### PR TITLE
fix error: 'snprintf' was not declared in this scope

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -22,6 +22,8 @@
 #endif
 
 #include <stdlib.h>
+#include <stdio.h>
+
 #ifdef DARWIN
 
 #ifndef MAP_ANON


### PR DESCRIPTION
Signed-off-by: Alexey Lapitsky lex@realisticgroup.com
