### PR TITLE
doc: drop mention of MDS capabilities from radosgw man page

### DIFF
--- a/doc/man/8/radosgw.rst
+++ b/doc/man/8/radosgw.rst
@@ -86,7 +86,7 @@ You will also have to generate a key for the radosgw to use for
 authentication with the cluster::
 
         ceph-authtool -C -n client.radosgw.gateway --gen-key /etc/ceph/keyring.radosgw.gateway
-        ceph-authtool -n client.radosgw.gateway --cap mon 'allow r' --cap osd 'allow rwx' --cap mds 'allow' /etc/ceph/keyring.radosgw.gateway
+        ceph-authtool -n client.radosgw.gateway --cap mon 'allow r' --cap osd 'allow rwx' /etc/ceph/keyring.radosgw.gateway
 
 And add the key to the auth entries::
 


### PR DESCRIPTION
rgw doesn't need to talk to an MDS, let's not confuse people by mentioning a capability that's not needed.
