### PR TITLE
Increase nofile ulimit for radosgw in upstart

### DIFF
--- a/src/upstart/radosgw.conf
+++ b/src/upstart/radosgw.conf
@@ -21,4 +21,5 @@ export id
 # this breaks oneiric
 #usage "cluster = name of cluster (defaults to 'ceph'); id = mds instance id"
 
+limit nofile 8096 65536
 exec /usr/bin/radosgw --cluster="${cluster:-ceph}" --id "$id" -f


### PR DESCRIPTION
The default ulimit for open file descriptors per process is 1024,
far too few for radosgw if you have lots of OSDs and configure
radosgw for decent number of threads.
