### PR TITLE
cleanup: changed order of #includes, global_context.h, debug.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1683,7 +1683,7 @@ noinst_HEADERS = \
 	mds/events/ETableServer.h\
         mds/events/EUpdate.h\
         mds/mds_table_types.h\
-        mds/mdstypes.h\
+        mds/mds_types.h\
         mds/snap.h\
         messages/MAuth.h\
         messages/MAuthReply.h\

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -15,11 +15,13 @@
 #ifndef CEPH_AUTHTYPES_H
 #define CEPH_AUTHTYPES_H
 
-#include "Crypto.h"
+#include "include/types.h"
 #include "msg/msg_types.h"
 
 #include "common/config.h"
 #include "common/entity_name.h"
+
+#include "Crypto.h"
 
 class Cond;
 

--- a/src/auth/AuthAuthorizeHandler.cc
+++ b/src/auth/AuthAuthorizeHandler.cc
@@ -13,12 +13,12 @@
  */
 
 #include "common/debug.h"
-#include "Auth.h"
-#include "AuthAuthorizeHandler.h"
+#include "common/Mutex.h"
+
 #include "cephx/CephxAuthorizeHandler.h"
 #include "none/AuthNoneAuthorizeHandler.h"
-#include "AuthMethodList.h"
-#include "common/Mutex.h"
+
+#include "AuthAuthorizeHandler.h"
 
 #define dout_subsys ceph_subsys_auth
 

--- a/src/auth/AuthAuthorizeHandler.h
+++ b/src/auth/AuthAuthorizeHandler.h
@@ -17,7 +17,6 @@
 
 #include "Auth.h"
 #include "AuthMethodList.h"
-#include "include/types.h"
 
 // Different classes of session crypto handling
 

--- a/src/auth/AuthClientHandler.cc
+++ b/src/auth/AuthClientHandler.cc
@@ -15,14 +15,14 @@
 
 #include <errno.h>
 
-#include "AuthClientHandler.h"
-#include "KeyRing.h"
-
 #include "messages/MAuth.h"
 #include "messages/MAuthReply.h"
 
 #include "cephx/CephxClientHandler.h"
 #include "none/AuthNoneClientHandler.h"
+#include "KeyRing.h"
+
+#include "AuthClientHandler.h"
 
 AuthClientHandler *get_auth_client_handler(CephContext *cct, int proto,
 					   RotatingKeyRing *rkeys)

--- a/src/auth/AuthClientHandler.h
+++ b/src/auth/AuthClientHandler.h
@@ -15,13 +15,11 @@
 #ifndef CEPH_AUTHCLIENTHANDLER_H
 #define CEPH_AUTHCLIENTHANDLER_H
 
-
-#include "auth/Auth.h"
-
 #include "common/Mutex.h"
 #include "common/Cond.h"
-
 #include "common/Timer.h"
+
+#include "Auth.h"
 
 class CephContext;
 class MAuthReply;

--- a/src/auth/AuthMethodList.cc
+++ b/src/auth/AuthMethodList.cc
@@ -12,15 +12,14 @@
  * 
  */
 
+#include "include/str_list.h"
 #include "common/Mutex.h"
 #include "common/config.h"
 #include "common/debug.h"
-#include "include/str_list.h"
 
 #include "AuthMethodList.h"
 
 const static int dout_subsys = ceph_subsys_auth;
-
 
 AuthMethodList::AuthMethodList(CephContext *cct, string str)
 {

--- a/src/auth/AuthMethodList.h
+++ b/src/auth/AuthMethodList.h
@@ -16,6 +16,7 @@
 #define CEPH_AUTHMETHODLIST_H
 
 #include "include/inttypes.h"
+
 #include <list>
 #include <set>
 #include <string>

--- a/src/auth/AuthServiceHandler.cc
+++ b/src/auth/AuthServiceHandler.cc
@@ -12,11 +12,11 @@
  * 
  */
 
-#include "AuthServiceHandler.h"
 #include "cephx/CephxServiceHandler.h"
 #include "none/AuthNoneServiceHandler.h"
 #include "AuthMethodList.h"
-#include "common/config.h"
+
+#include "AuthServiceHandler.h"
 
 #define dout_subsys ceph_subsys_auth
 

--- a/src/auth/AuthServiceHandler.h
+++ b/src/auth/AuthServiceHandler.h
@@ -15,8 +15,6 @@
 #ifndef CEPH_AUTHSERVICEHANDLER_H
 #define CEPH_AUTHSERVICEHANDLER_H
 
-#include "include/types.h"
-#include "common/config.h"
 #include "Auth.h"
 
 class CephContext;

--- a/src/auth/AuthSessionHandler.cc
+++ b/src/auth/AuthSessionHandler.cc
@@ -13,11 +13,11 @@
  */
 
 #include "common/debug.h"
-#include "AuthSessionHandler.h"
 #include "cephx/CephxSessionHandler.h"
 #include "none/AuthNoneSessionHandler.h"
 #include "unknown/AuthUnknownSessionHandler.h"
-#include "common/config.h"
+
+#include "AuthSessionHandler.h"
 
 #define dout_subsys ceph_subsys_auth
 

--- a/src/auth/AuthSessionHandler.h
+++ b/src/auth/AuthSessionHandler.h
@@ -16,9 +16,8 @@
 #ifndef CEPH_AUTHSESSIONHANDLER_H
 #define CEPH_AUTHSESSIONHANDLER_H
 
-#include "include/types.h"
-#include "common/config.h"
 #include "msg/Message.h"
+
 #include "Auth.h"
 
 #define SESSION_SIGNATURE_FAILURE -1

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -10,9 +10,11 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "include/types.h"
 
 #include <sstream>
-#include "Crypto.h"
+#include <errno.h>
+
 #ifdef USE_CRYPTOPP
 # include <cryptopp/modes.h>
 # include <cryptopp/aes.h>
@@ -24,6 +26,8 @@
 #endif
 
 #include "include/assert.h"
+#include "include/ceph_fs.h"
+#include "include/compat.h"
 #include "common/Clock.h"
 #include "common/armor.h"
 #include "common/ceph_crypto.h"
@@ -31,10 +35,8 @@
 #include "common/debug.h"
 #include "common/hex.h"
 #include "common/safe_io.h"
-#include "include/ceph_fs.h"
-#include "include/compat.h"
 
-#include <errno.h>
+#include "Crypto.h"
 
 int get_random_bytes(char *buf, int len)
 {

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -16,9 +16,10 @@
 #define CEPH_AUTH_CRYPTO_H
 
 #include "include/types.h"
-#include "include/utime.h"
 
 #include <string>
+
+#include "include/utime.h"
 
 class CephContext;
 class CryptoHandler;

--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -17,14 +17,16 @@
 #include <memory>
 #include <sstream>
 
-#include "auth/AuthMethodList.h"
-#include "auth/Crypto.h"
-#include "auth/KeyRing.h"
+#include "include/str_list.h"
 #include "common/ConfUtils.h"
 #include "common/config.h"
 #include "common/debug.h"
 #include "common/errno.h"
-#include "include/str_list.h"
+
+#include "AuthMethodList.h"
+#include "Crypto.h"
+
+#include "KeyRing.h"
 
 #define dout_subsys ceph_subsys_auth
 

--- a/src/auth/KeyRing.h
+++ b/src/auth/KeyRing.h
@@ -15,10 +15,8 @@
 #ifndef CEPH_KEYRING_H
 #define CEPH_KEYRING_H
 
-#include "common/config.h"
-
-#include "auth/Crypto.h"
-#include "auth/Auth.h"
+#include "Crypto.h"
+#include "Auth.h"
 
 class md_config_t;
 

--- a/src/auth/RotatingKeyRing.cc
+++ b/src/auth/RotatingKeyRing.cc
@@ -1,13 +1,13 @@
 #include <errno.h>
 #include <map>
 
-#include "common/config.h"
-#include "common/debug.h"
 #include "include/str_list.h"
+#include "common/debug.h"
 
 #include "Crypto.h"
-#include "auth/RotatingKeyRing.h"
-#include "auth/KeyRing.h"
+#include "KeyRing.h"
+
+#include "RotatingKeyRing.h"
 
 #define dout_subsys ceph_subsys_auth
 #undef dout_prefix

--- a/src/auth/RotatingKeyRing.h
+++ b/src/auth/RotatingKeyRing.h
@@ -15,11 +15,10 @@
 #ifndef CEPH_ROTATINGKEYRING_H
 #define CEPH_ROTATINGKEYRING_H
 
-#include "common/config.h"
 #include "common/Mutex.h"
 
-#include "auth/Crypto.h"
-#include "auth/Auth.h"
+#include "Crypto.h"
+#include "Auth.h"
 
 /*
  * mediate access to a service's keyring and rotating secrets

--- a/src/auth/cephx/CephxAuthorizeHandler.cc
+++ b/src/auth/cephx/CephxAuthorizeHandler.cc
@@ -1,7 +1,7 @@
 
 #include "../KeyRing.h"
-
 #include "CephxProtocol.h"
+
 #include "CephxAuthorizeHandler.h"
 
 #define dout_subsys ceph_subsys_auth

--- a/src/auth/cephx/CephxClientHandler.cc
+++ b/src/auth/cephx/CephxClientHandler.cc
@@ -15,12 +15,11 @@
 
 #include <errno.h>
 
-#include "CephxClientHandler.h"
-#include "CephxProtocol.h"
+#include "common/config.h"
 
 #include "../KeyRing.h"
 
-#include "common/config.h"
+#include "CephxClientHandler.h"
 
 #define dout_subsys ceph_subsys_auth
 #undef dout_prefix

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -12,14 +12,13 @@
  * 
  */
 
+#include <sstream>
+
 #include "common/config.h"
-
-#include "CephxKeyServer.h"
 #include "common/Timer.h"
-
 #include "global/global_context.h"
 
-#include <sstream>
+#include "CephxKeyServer.h"
 
 #define dout_subsys ceph_subsys_auth
 #undef dout_prefix

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -16,11 +16,11 @@
 #define CEPH_KEYSSERVER_H
 
 #include "common/config.h"
-
-#include "auth/KeyRing.h"
-#include "CephxProtocol.h"
-
 #include "common/Timer.h"
+
+#include "../KeyRing.h"
+
+#include "CephxProtocol.h"
 
 class CephContext;
 

--- a/src/auth/cephx/CephxProtocol.cc
+++ b/src/auth/cephx/CephxProtocol.cc
@@ -12,17 +12,16 @@
  *
  */
 
-#include "CephxProtocol.h"
+#include "include/buffer.h"
 #include "common/Clock.h"
 #include "common/config.h"
 #include "common/debug.h"
-#include "include/buffer.h"
+
+#include "CephxProtocol.h"
 
 #define dout_subsys ceph_subsys_auth
 #undef dout_prefix
 #define dout_prefix *_dout << "cephx: "
-
-
 
 void cephx_calc_client_server_challenge(CephContext *cct, CryptoKey& secret, uint64_t server_challenge, 
 		  uint64_t client_challenge, uint64_t *key, std::string &ret)

--- a/src/auth/cephx/CephxServiceHandler.cc
+++ b/src/auth/cephx/CephxServiceHandler.cc
@@ -12,19 +12,16 @@
  * 
  */
 
-
-#include "CephxServiceHandler.h"
-#include "CephxProtocol.h"
-
-#include "../Auth.h"
-
-#include "mon/Monitor.h"
-
 #include <errno.h>
 #include <sstream>
 
-#include "common/config.h"
 #include "include/assert.h"
+#include "common/config.h"
+#include "mon/Monitor.h"
+
+#include "CephxProtocol.h"
+
+#include "CephxServiceHandler.h"
 
 #define dout_subsys ceph_subsys_auth
 #undef dout_prefix

--- a/src/auth/cephx/CephxSessionHandler.cc
+++ b/src/auth/cephx/CephxSessionHandler.cc
@@ -12,15 +12,16 @@
  * 
  */
 
-#include "CephxSessionHandler.h"
-#include "CephxProtocol.h"
-
 #include <errno.h>
 #include <sstream>
 
-#include "common/config.h"
 #include "include/assert.h"
 #include "include/ceph_features.h"
+#include "common/config.h"
+
+#include "CephxProtocol.h"
+
+#include "CephxSessionHandler.h"
 
 #define dout_subsys ceph_subsys_auth
 

--- a/src/auth/none/AuthNoneAuthorizeHandler.cc
+++ b/src/auth/none/AuthNoneAuthorizeHandler.cc
@@ -12,8 +12,9 @@
  *
  */
 
-#include "AuthNoneAuthorizeHandler.h"
 #include "common/debug.h"
+
+#include "AuthNoneAuthorizeHandler.h"
 
 #define dout_subsys ceph_subsys_auth
 

--- a/src/auth/unknown/AuthUnknownAuthorizeHandler.cc
+++ b/src/auth/unknown/AuthUnknownAuthorizeHandler.cc
@@ -12,8 +12,9 @@
  *
  */
 
-#include "AuthUnknownAuthorizeHandler.h"
 #include "common/debug.h"
+
+#include "AuthUnknownAuthorizeHandler.h"
 
 #define dout_subsys ceph_subsys_auth
 

--- a/src/ceph_authtool.cc
+++ b/src/ceph_authtool.cc
@@ -12,20 +12,19 @@
  * 
  */
 
-using namespace std;
+#include <sstream>
 
 #include "common/config.h"
 #include "common/strtol.h"
-
 #include "common/ConfUtils.h"
 #include "common/ceph_argparse.h"
-#include "global/global_context.h"
-#include "global/global_init.h"
 #include "auth/Crypto.h"
 #include "auth/Auth.h"
 #include "auth/KeyRing.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
 
-#include <sstream>
+using namespace std;
 
 void usage()
 {

--- a/src/ceph_conf.cc
+++ b/src/ceph_conf.cc
@@ -18,13 +18,13 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include "mon/AuthMonitor.h"
+#include "include/str_list.h"
 #include "common/ConfUtils.h"
-#include "global/global_init.h"
 #include "common/entity_name.h"
 #include "common/ceph_argparse.h"
 #include "common/config.h"
-#include "include/str_list.h"
+#include "mon/AuthMonitor.h"
+#include "global/global_init.h"
 
 using std::deque;
 using std::string;

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -15,29 +15,26 @@
 #include <sys/stat.h>
 #include <iostream>
 #include <string>
-using namespace std;
+#include <sys/types.h>
+#include <fcntl.h>
 
-#include "common/config.h"
-#include "common/errno.h"
-
-#include "client/Client.h"
-#include "client/fuse_ll.h"
-
-#include "msg/Messenger.h"
-
-#include "mon/MonClient.h"
-
-#include "common/Timer.h"
-#include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "common/safe_io.h"
-       
 #ifndef DARWIN
 #include <envz.h>
 #endif // DARWIN
 
-#include <sys/types.h>
-#include <fcntl.h>
+#include "common/config.h"
+#include "common/errno.h"
+#include "common/Timer.h"
+#include "common/safe_io.h"
+#include "common/ceph_argparse.h"
+#include "client/Client.h"
+#include "client/fuse_ll.h"
+#include "msg/Messenger.h"
+#include "mon/MonClient.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+
+using namespace std;
 
 void usage()
 {

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -15,36 +15,30 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-
 #include <iostream>
 #include <string>
-using namespace std;
 
 #include "include/ceph_features.h"
-
-#include "common/config.h"
-#include "common/strtol.h"
-
-#include "mon/MonMap.h"
-#include "mds/MDS.h"
-#include "mds/Dumper.h"
-#include "mds/Resetter.h"
-
-#include "msg/Messenger.h"
-
+#include "include/assert.h"
 #include "common/Timer.h"
 #include "common/ceph_argparse.h"
 #include "common/pick_address.h"
-
+#include "common/config.h"
+#include "common/strtol.h"
+#include "auth/KeyRing.h"
+#include "mon/MonMap.h"
+#include "mon/MonClient.h"
+#include "msg/Messenger.h"
+#include "mds/MDS.h"
+#include "mds/Dumper.h"
+#include "mds/Resetter.h"
 #include "global/global_init.h"
+#include "global/global_context.h"
 #include "global/signal_handler.h"
+#include "global/debug.h"
 #include "global/pidfile.h"
 
-#include "mon/MonClient.h"
-
-#include "auth/KeyRing.h"
-
-#include "include/assert.h"
+using namespace std;
 
 #define dout_subsys ceph_subsys_mds
 

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -15,33 +15,28 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-
 #include <iostream>
 #include <string>
-using namespace std;
-
-#include "common/config.h"
-#include "include/ceph_features.h"
-
-#include "mon/MonMap.h"
-#include "mon/Monitor.h"
-#include "mon/MonitorStore.h"
-#include "mon/MonClient.h"
-
-#include "msg/Messenger.h"
 
 #include "include/CompatSet.h"
-
+#include "include/assert.h"
+#include "include/ceph_features.h"
+#include "common/config.h"
 #include "common/ceph_argparse.h"
 #include "common/pick_address.h"
 #include "common/Timer.h"
 #include "common/errno.h"
-
+#include "mon/MonMap.h"
+#include "mon/Monitor.h"
+#include "mon/MonitorStore.h"
+#include "mon/MonClient.h"
+#include "msg/Messenger.h"
 #include "global/global_init.h"
+#include "global/global_context.h"
 #include "global/signal_handler.h"
 #include "global/debug.h"
 
-#include "include/assert.h"
+using namespace std;
 
 #define dout_subsys ceph_subsys_mon
 

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -16,37 +16,28 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <uuid/uuid.h>
-
 #include <iostream>
 #include <string>
-using namespace std;
 
-#include "osd/OSD.h"
-#include "os/FileStore.h"
-#include "mon/MonClient.h"
 #include "include/ceph_features.h"
-
-#include "common/config.h"
-
-#include "mon/MonMap.h"
-
-
-#include "msg/Messenger.h"
-
+#include "include/color.h"
+#include "include/assert.h"
+#include "common/errno.h"
+#include "common/pick_address.h"
 #include "common/Timer.h"
 #include "common/ceph_argparse.h"
-
+#include "common/config.h"
+#include "mon/MonMap.h"
+#include "mon/MonClient.h"
+#include "msg/Messenger.h"
+#include "os/FileStore.h"
+#include "osd/OSD.h"
+#include "perfglue/heap_profiler.h"
 #include "global/global_init.h"
 #include "global/signal_handler.h"
 #include "global/debug.h"
 
-#include "include/color.h"
-#include "common/errno.h"
-#include "common/pick_address.h"
-
-#include "perfglue/heap_profiler.h"
-
-#include "include/assert.h"
+using namespace std;
 
 #define dout_subsys ceph_subsys_osd
 

--- a/src/ceph_syn.cc
+++ b/src/ceph_syn.cc
@@ -15,28 +15,24 @@
 #include <sys/stat.h>
 #include <iostream>
 #include <string>
-using namespace std;
-
-#include "common/config.h"
-
-#include "client/SyntheticClient.h"
-#include "client/Client.h"
-
-#include "msg/Messenger.h"
-
-#include "mon/MonClient.h"
-
-#include "common/Timer.h"
-#include "global/global_init.h"
-#include "common/ceph_argparse.h"
-#include "common/pick_address.h"
+#include <sys/types.h>
+#include <fcntl.h>
 
 #if !defined(DARWIN) && !defined(__FreeBSD__)
 #include <envz.h>
 #endif // DARWIN || __FreeBSD__
 
-#include <sys/types.h>
-#include <fcntl.h>
+#include "common/config.h"
+#include "common/Timer.h"
+#include "common/ceph_argparse.h"
+#include "common/pick_address.h"
+#include "client/SyntheticClient.h"
+#include "msg/Messenger.h"
+#include "mon/MonClient.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+
+using namespace std;
 
 extern int syn_filer_flags;
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12,9 +12,6 @@
  * 
  */
 
-
-
-// unix-ey fs stuff
 #include <unistd.h>
 #include <sys/types.h>
 #include <time.h>
@@ -22,18 +19,24 @@
 #include <sys/stat.h>
 #include <sys/param.h>
 #include <fcntl.h>
-
 #include <sys/statvfs.h>
-
 #include <iostream>
-using namespace std;
 
+#include "include/assert.h"
+#include "include/compat.h"
+#include "common/Cond.h"
+#include "common/perf_counters.h"
 #include "common/config.h"
-
-// ceph stuff
+#include "common/admin_socket.h"
+#include "common/errno.h"
+#include "mon/MonClient.h"
+#include "mon/MonMap.h"
+#include "mds/MDSMap.h"
+#include "osd/OSDMap.h"
+#include "osdc/Filer.h"
+#include "osdc/WritebackHandler.h"
 
 #include "messages/MMonMap.h"
-
 #include "messages/MClientSession.h"
 #include "messages/MClientReconnect.h"
 #include "messages/MClientRequest.h"
@@ -43,33 +46,9 @@ using namespace std;
 #include "messages/MClientCapRelease.h"
 #include "messages/MClientLease.h"
 #include "messages/MClientSnap.h"
-
 #include "messages/MGenericMessage.h"
-
 #include "messages/MMDSMap.h"
 
-#include "mon/MonClient.h"
-
-#include "mds/MDSMap.h"
-#include "osd/OSDMap.h"
-#include "mon/MonMap.h"
-
-#include "osdc/Filer.h"
-#include "osdc/WritebackHandler.h"
-
-#include "common/Cond.h"
-#include "common/Mutex.h"
-#include "common/perf_counters.h"
-#include "common/admin_socket.h"
-#include "common/errno.h"
-
-#define dout_subsys ceph_subsys_client
-
-#include "include/lru.h"
-
-#include "include/compat.h"
-
-#include "Client.h"
 #include "Inode.h"
 #include "Dentry.h"
 #include "Dir.h"
@@ -79,8 +58,11 @@ using namespace std;
 #include "MetaRequest.h"
 #include "ObjecterWriteback.h"
 
-#include "include/assert.h"
+#include "Client.h"
 
+using namespace std;
+
+#define dout_subsys ceph_subsys_client
 #undef dout_prefix
 #define dout_prefix *_dout << "client." << whoami << " "
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -17,36 +17,28 @@
 #define CEPH_CLIENT_H
 
 #include "include/types.h"
+#include "mds/mds_types.h"
 
-// stl
 #include <string>
 #include <set>
 #include <map>
 #include <fstream>
-using std::set;
-using std::map;
-using std::fstream;
-
 #include <ext/hash_map>
-using namespace __gnu_cxx;
 
 #include "include/filepath.h"
 #include "include/interval_set.h"
 #include "include/lru.h"
-
-#include "mds/mdstypes.h"
-
-#include "msg/Message.h"
-#include "msg/Dispatcher.h"
-#include "msg/Messenger.h"
-
 #include "common/Mutex.h"
 #include "common/Timer.h"
 #include "common/Finisher.h"
-
 #include "common/compiler_extensions.h"
-
 #include "osdc/ObjectCacher.h"
+#include "msg/Messenger.h"
+
+using std::set;
+using std::map;
+using std::fstream;
+using namespace __gnu_cxx;
 
 class MDSMap;
 class OSDMap;

--- a/src/client/Dentry.cc
+++ b/src/client/Dentry.cc
@@ -3,12 +3,12 @@
 
 #include "include/types.h"
 #include "include/utime.h"
+#include "common/Formatter.h"
 
-#include "Dentry.h"
 #include "Dir.h"
 #include "Inode.h"
 
-#include "common/Formatter.h"
+#include "Dentry.h"
 
 void Dentry::dump(Formatter *f) const
 {

--- a/src/client/Dir.h
+++ b/src/client/Dir.h
@@ -2,6 +2,7 @@
 #define CEPH_CLIENT_DIR_H
 
 class Inode;
+class Dentry;
 
 class Dir {
  public:

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -2,10 +2,11 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "MetaSession.h"
-#include "Inode.h"
 #include "Dentry.h"
 #include "Dir.h"
 #include "SnapRealm.h"
+
+#include "Inode.h"
 
 ostream& operator<<(ostream &out, Inode &in)
 {

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -5,13 +5,12 @@
 #define CEPH_CLIENT_INODE_H
 
 #include "include/types.h"
+#include "mds/mds_types.h" // hrm
+
+#include "include/assert.h"
 #include "include/xlist.h"
 #include "include/filepath.h"
-
-#include "mds/mdstypes.h" // hrm
-
 #include "osdc/ObjectCacher.h"
-#include "include/assert.h"
 
 class MetaSession;
 class Dentry;

--- a/src/client/MetaRequest.cc
+++ b/src/client/MetaRequest.cc
@@ -2,11 +2,14 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "include/types.h"
-#include "client/MetaRequest.h"
-#include "client/Dentry.h"
-#include "client/Inode.h"
-#include "messages/MClientReply.h"
 #include "common/Formatter.h"
+
+#include "messages/MClientReply.h"
+
+#include "Dentry.h"
+#include "Inode.h"
+
+#include "MetaRequest.h"
 
 void MetaRequest::dump(Formatter *f) const
 {

--- a/src/client/MetaRequest.h
+++ b/src/client/MetaRequest.h
@@ -7,10 +7,10 @@
 
 #include "include/types.h"
 #include "msg/msg_types.h"
+#include "mds/mds_types.h"
+
 #include "include/xlist.h"
 #include "include/filepath.h"
-#include "mds/mdstypes.h"
-
 #include "common/Mutex.h"
 
 #include "messages/MClientRequest.h"

--- a/src/client/MetaSession.cc
+++ b/src/client/MetaSession.cc
@@ -3,9 +3,9 @@
 
 #include "include/types.h"
 
-#include "MetaSession.h"
-
 #include "common/Formatter.h"
+
+#include "MetaSession.h"
 
 void MetaSession::dump(Formatter *f) const
 {

--- a/src/client/MetaSession.h
+++ b/src/client/MetaSession.h
@@ -5,8 +5,9 @@
 #define CEPH_CLIENT_METASESSION_H
 
 #include "include/types.h"
-#include "include/utime.h"
 #include "msg/msg_types.h"
+
+#include "include/utime.h"
 #include "include/xlist.h"
 
 #include "messages/MClientCapRelease.h"

--- a/src/client/SnapRealm.cc
+++ b/src/client/SnapRealm.cc
@@ -1,8 +1,9 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "SnapRealm.h"
 #include "common/Formatter.h"
+
+#include "SnapRealm.h"
 
 void SnapRealm::dump(Formatter *f) const
 {

--- a/src/client/SnapRealm.h
+++ b/src/client/SnapRealm.h
@@ -5,8 +5,8 @@
 #define CEPH_CLIENT_SNAPREALM_H
 
 #include "include/types.h"
-#include "common/snap_types.h"
 #include "include/xlist.h"
+#include "common/snap_types.h"
 
 class Inode;
 

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -14,18 +14,6 @@
 
 #include <iostream>
 #include <sstream>
-using namespace std;
-
-
-#include "common/config.h"
-#include "SyntheticClient.h"
-#include "osdc/Objecter.h"
-#include "osdc/Filer.h"
-
-
-#include "include/filepath.h"
-#include "common/perf_counters.h"
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -33,8 +21,17 @@ using namespace std;
 #include <math.h>
 #include <sys/statvfs.h>
 
+
 #include "include/assert.h"
+#include "common/config.h"
+#include "common/perf_counters.h"
+#include "osdc/Objecter.h"
+#include "osdc/Filer.h"
 #include "global/debug.h"
+
+#include "SyntheticClient.h"
+
+using namespace std;
 
 #define dout_subsys ceph_subsys_client
 #undef dout_prefix

--- a/src/client/SyntheticClient.h
+++ b/src/client/SyntheticClient.h
@@ -18,9 +18,10 @@
 
 #include <pthread.h>
 
-#include "Client.h"
 #include "include/Distribution.h"
+#include "global/global_context.h"
 
+#include "Client.h"
 #include "Trace.h"
 
 #define SYNCLIENT_MODE_RANDOMWALK  1

--- a/src/client/Trace.cc
+++ b/src/client/Trace.cc
@@ -12,27 +12,20 @@
  * 
  */
 
-
-
-#include "Trace.h"
-#include "common/debug.h"
-
 #include <iostream>
 #include <map>
 #include <ext/rope>
-using namespace __gnu_cxx;
-
-#include "common/Mutex.h"
-
-#include "common/config.h"
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include "common/Mutex.h"
+#include "common/config.h"
+#include "common/debug.h"
 
+#include "Trace.h"
 
-
+using namespace __gnu_cxx;
 
 void Trace::start()
 {

--- a/src/client/Trace.h
+++ b/src/client/Trace.h
@@ -17,10 +17,10 @@
 #define CEPH_CLIENT_TRACE_H
 
 #include <stdlib.h>
-
 #include <list>
 #include <string>
 #include <fstream>
+
 using std::list;
 using std::string;
 using std::ifstream;

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -23,13 +23,14 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-// ceph
+#include "include/types.h"
+#include "include/assert.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
-#include "include/types.h"
-#include "Client.h"
 #include "common/config.h"
-#include "include/assert.h"
+#include "global/debug.h"
+
+#include "Client.h"
 
 static Client *client;
 

--- a/src/client/test_ioctls.c
+++ b/src/client/test_ioctls.c
@@ -1,4 +1,3 @@
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -6,7 +5,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <limits.h>
-
 #include <sys/ioctl.h>
 #include <netinet/in.h>
 #include <sys/socket.h>

--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -8,6 +8,8 @@
  *
  */
 
+#include "include/types.h"
+
 #include <algorithm>
 #include <cstring>
 #include <cstdlib>
@@ -17,20 +19,15 @@
 #include <sstream>
 #include <vector>
 
-#include "include/types.h"
 #include "include/utime.h"
-#include "objclass/objclass.h"
-
 #include "common/Clock.h"
-
-#include "cls/lock/cls_lock_types.h"
-#include "cls/lock/cls_lock_ops.h"
-
+#include "objclass/objclass.h"
 #include "global/global_context.h"
 
+#include "cls_lock_types.h"
+#include "cls_lock_ops.h"
 
 using namespace rados::cls::lock;
-
 
 CLS_VER(1,0)
 CLS_NAME(lock)

--- a/src/cls/lock/cls_lock_client.cc
+++ b/src/cls/lock/cls_lock_client.cc
@@ -14,19 +14,17 @@
 
 #include "include/types.h"
 #include "msg/msg_types.h"
-#include "include/rados/librados.hpp"
-
-using namespace librados;
 
 #include <iostream>
-
 #include <errno.h>
 #include <stdlib.h>
 #include <time.h>
 
-#include "cls/lock/cls_lock_types.h"
-#include "cls/lock/cls_lock_ops.h"
-#include "cls/lock/cls_lock_client.h"
+#include "cls_lock_ops.h"
+
+#include "cls_lock_client.h"
+
+using namespace librados;
 
 namespace rados {
   namespace cls {

--- a/src/cls/lock/cls_lock_client.h
+++ b/src/cls/lock/cls_lock_client.h
@@ -4,12 +4,10 @@
 #ifndef CEPH_CLS_LOCK_CLIENT_H
 #define CEPH_CLS_LOCK_CLIENT_H
 
-
 #include "include/types.h"
 #include "include/rados/librados.hpp"
 
-#include "cls/lock/cls_lock_types.h"
-
+#include "cls_lock_types.h"
 
 namespace rados {
   namespace cls {

--- a/src/cls/lock/cls_lock_ops.cc
+++ b/src/cls/lock/cls_lock_ops.cc
@@ -14,10 +14,10 @@
 
 #include "include/types.h"
 #include "msg/msg_types.h"
+
 #include "common/Formatter.h"
 
-#include "cls/lock/cls_lock_types.h"
-#include "cls/lock/cls_lock_ops.h"
+#include "cls_lock_ops.h"
 
 using namespace rados::cls::lock;
 

--- a/src/cls/lock/cls_lock_ops.h
+++ b/src/cls/lock/cls_lock_ops.h
@@ -3,7 +3,8 @@
 
 #include "include/types.h"
 #include "include/utime.h"
-#include "cls/lock/cls_lock_types.h"
+
+#include "cls_lock_types.h"
 
 struct cls_lock_lock_op
 {

--- a/src/cls/lock/cls_lock_types.cc
+++ b/src/cls/lock/cls_lock_types.cc
@@ -14,9 +14,10 @@
 
 #include "include/types.h"
 #include "msg/msg_types.h"
+
 #include "common/Formatter.h"
 
-#include "cls/lock/cls_lock_types.h"
+#include "cls_lock_types.h"
 
 using namespace rados::cls::lock;
 

--- a/src/cls/lock/cls_lock_types.h
+++ b/src/cls/lock/cls_lock_types.h
@@ -1,10 +1,11 @@
 #ifndef CEPH_CLS_LOCK_TYPES_H
 #define CEPH_CLS_LOCK_TYPES_H
 
+#include "msg/msg_types.h"
+
 #include "include/encoding.h"
 #include "include/types.h"
 #include "include/utime.h"
-#include "msg/msg_types.h"
 
 /* lock flags */
 #define LOCK_FLAG_RENEW 0x1        /* idempotent lock acquire */

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -26,6 +26,8 @@
  * in each one that they take an input and an output bufferlist.
  */
 
+#include "include/types.h"
+
 #include <algorithm>
 #include <cstring>
 #include <cstdlib>
@@ -35,11 +37,10 @@
 #include <sstream>
 #include <vector>
 
-#include "include/types.h"
-#include "objclass/objclass.h"
 #include "include/rbd_types.h"
+#include "objclass/objclass.h"
 
-#include "cls/rbd/cls_rbd.h"
+#include "cls_rbd.h"
 
 
 /*

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -1,14 +1,16 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "cls/lock/cls_lock_client.h"
-#include "include/buffer.h"
-#include "include/encoding.h"
 #include "include/rbd_types.h"
 
-#include "cls_rbd_client.h"
-
 #include <errno.h>
+
+#include "include/buffer.h"
+#include "include/encoding.h"
+
+#include "../lock/cls_lock_client.h"
+
+#include "cls_rbd_client.h"
 
 namespace librbd {
   namespace cls_client {

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -4,15 +4,16 @@
 #ifndef CEPH_LIBRBD_CLS_RBD_CLIENT_H
 #define CEPH_LIBRBD_CLS_RBD_CLIENT_H
 
-#include "cls/lock/cls_lock_types.h"
-#include "common/snap_types.h"
+#include <string>
+#include <vector>
+
 #include "include/rados.h"
 #include "include/rados/librados.hpp"
 #include "include/types.h"
 #include "librbd/parent_types.h"
+#include "common/snap_types.h"
 
-#include <string>
-#include <vector>
+#include "../lock/cls_lock_types.h"
 
 namespace librbd {
   namespace cls_client {

--- a/src/cls/refcount/cls_refcount_client.cc
+++ b/src/cls/refcount/cls_refcount_client.cc
@@ -1,11 +1,12 @@
+#include "include/types.h"
+
 #include <errno.h>
 
-#include "include/types.h"
-#include "cls/refcount/cls_refcount_ops.h"
 #include "include/rados/librados.hpp"
 
-using namespace librados;
+#include "cls_refcount_ops.h"
 
+using namespace librados;
 
 void cls_refcount_get(librados::ObjectWriteOperation& op, const string& tag, bool implicit_ref)
 {

--- a/src/cls/refcount/cls_refcount_ops.h
+++ b/src/cls/refcount/cls_refcount_ops.h
@@ -4,9 +4,9 @@
 #ifndef CEPH_CLS_REFCOUNT_OPS_H
 #define CEPH_CLS_REFCOUNT_OPS_H
 
-#include <map>
-
 #include "include/types.h"
+
+#include <map>
 
 struct cls_refcount_get_op {
   string tag;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1,19 +1,19 @@
 // -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <iostream>
+#include "include/types.h"
 
+#include <iostream>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
 
-#include "include/types.h"
 #include "include/utime.h"
-#include "objclass/objclass.h"
-#include "cls/rgw/cls_rgw_ops.h"
 #include "common/Clock.h"
-
+#include "objclass/objclass.h"
 #include "global/global_context.h"
+
+#include "cls_rgw_ops.h"
 
 CLS_VER(1,0)
 CLS_NAME(rgw)

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -1,8 +1,10 @@
+#include "include/types.h"
+
 #include <errno.h>
 
-#include "include/types.h"
-#include "cls/rgw/cls_rgw_ops.h"
 #include "include/rados/librados.hpp"
+
+#include "cls_rgw_ops.h"
 
 using namespace librados;
 

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -3,6 +3,7 @@
 
 #include "include/types.h"
 #include "include/rados/librados.hpp"
+
 #include "cls_rgw_types.h"
 
 /* bucket index */

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -1,8 +1,6 @@
-
-#include "cls/rgw/cls_rgw_ops.h"
-
 #include "common/Formatter.h"
 
+#include "cls_rgw_ops.h"
 
 void rgw_cls_obj_prepare_op::generate_test_instances(list<rgw_cls_obj_prepare_op*>& o)
 {

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1,10 +1,11 @@
 #ifndef CEPH_CLS_RGW_OPS_H
 #define CEPH_CLS_RGW_OPS_H
 
+#include "include/types.h"
+
 #include <map>
 
-#include "include/types.h"
-#include "cls/rgw/cls_rgw_types.h"
+#include "cls_rgw_types.h"
 
 struct rgw_cls_tag_timeout_op
 {

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -1,7 +1,6 @@
-
-#include "cls/rgw/cls_rgw_types.h"
 #include "common/Formatter.h"
 
+#include "cls_rgw_types.h"
 
 void rgw_bucket_pending_info::generate_test_instances(list<rgw_bucket_pending_info*>& o)
 {

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1,9 +1,10 @@
 #ifndef CEPH_CLS_RGW_TYPES_H
 #define CEPH_CLS_RGW_TYPES_H
 
+#include "include/types.h"
+
 #include <map>
 
-#include "include/types.h"
 #include "include/utime.h"
 
 #define CEPH_RGW_REMOVE 'r'

--- a/src/cls_acl.cc
+++ b/src/cls_acl.cc
@@ -1,17 +1,14 @@
-
+#include "include/types.h"
 
 
 #include <iostream>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
-
 #include <openssl/md5.h>
 #include <openssl/sha.h>
 
-#include "include/types.h"
 #include "objclass/objclass.h"
-
 
 CLS_VER(1,0)
 CLS_NAME(acl)

--- a/src/cls_crypto.cc
+++ b/src/cls_crypto.cc
@@ -1,17 +1,13 @@
-
-
+#include "include/types.h"
 
 #include <iostream>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
-
 #include <openssl/md5.h>
 #include <openssl/sha.h>
 
-#include "include/types.h"
 #include "objclass/objclass.h"
-
 
 CLS_VER(1,0)
 CLS_NAME(crypto)

--- a/src/common/BackTrace.cc
+++ b/src/common/BackTrace.cc
@@ -1,13 +1,13 @@
+#include "acconfig.h"
 
 #include <ostream>
 #include <cxxabi.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "BackTrace.h"
-
 #include "common/version.h"
-#include "acconfig.h"
+
+#include "BackTrace.h"
 
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)

--- a/src/common/Clock.cc
+++ b/src/common/Clock.cc
@@ -12,13 +12,10 @@
  * 
  */
 
-
-#include "common/Clock.h"
 #include "common/ceph_context.h"
 #include "common/config.h"
-#include "include/utime.h"
 
-#include <time.h>
+#include "Clock.h"
 
 utime_t ceph_clock_now(CephContext *cct)
 {

--- a/src/common/Clock.h
+++ b/src/common/Clock.h
@@ -15,9 +15,9 @@
 #ifndef CEPH_CLOCK_H
 #define CEPH_CLOCK_H
 
-#include "include/utime.h"
-
 #include <time.h>
+
+#include "include/utime.h"
 
 class CephContext;
 

--- a/src/common/Cond.h
+++ b/src/common/Cond.h
@@ -16,14 +16,12 @@
 #ifndef CEPH_COND_H
 #define CEPH_COND_H
 
+#include <pthread.h>
 #include <time.h>
 
-#include "Mutex.h"
-#include "Clock.h"
-
 #include "include/Context.h"
-
-#include <pthread.h>
+#include "common/Mutex.h"
+#include "common/Clock.h"
 
 class Cond {
   // my bits

--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <errno.h>
 #include <list>
-#include <map>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
@@ -25,10 +24,10 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "include/buffer.h"
 #include "common/errno.h"
 #include "common/utf8.h"
-#include "common/ConfUtils.h"
+
+#include "ConfUtils.h"
 
 using std::cerr;
 using std::ostringstream;

--- a/src/common/DecayCounter.h
+++ b/src/common/DecayCounter.h
@@ -15,9 +15,9 @@
 #ifndef CEPH_DECAYCOUNTER_H
 #define CEPH_DECAYCOUNTER_H
 
-#include "include/utime.h"
-
 #include <math.h>
+
+#include "include/utime.h"
 
 /**
  *

--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -2,9 +2,10 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "common/config.h"
+#include "common/debug.h"
+
 #include "Finisher.h"
 
-#include "common/debug.h"
 #define dout_subsys ceph_subsys_finisher
 #undef dout_prefix
 #define dout_prefix *_dout << "finisher(" << this << ") "

--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -14,17 +14,14 @@
 
 #define LARGE_SIZE 1024
 
-#include "assert.h"
-#include "Formatter.h"
-#include "common/escape.h"
-
-#include <inttypes.h>
-#include <iostream>
-#include <sstream>
-#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
+
+#include "include/assert.h"
+#include "common/escape.h"
+
+#include "Formatter.h"
 
 // -----------------------
 namespace ceph {

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -1,8 +1,8 @@
 #ifndef CEPH_FORMATTER_H
 #define CEPH_FORMATTER_H
 
-#include <deque>
 #include <inttypes.h>
+#include <deque>
 #include <iostream>
 #include <list>
 #include <ostream>

--- a/src/common/HeartbeatMap.cc
+++ b/src/common/HeartbeatMap.cc
@@ -18,11 +18,12 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#include "HeartbeatMap.h"
-#include "ceph_context.h"
+#include "common/ceph_context.h"
 #include "common/errno.h"
+#include "common/debug.h"
 
-#include "debug.h"
+#include "HeartbeatMap.h"
+
 #define dout_subsys ceph_subsys_heartbeatmap
 #undef dout_prefix
 #define dout_prefix *_dout << "heartbeat_map "

--- a/src/common/HeartbeatMap.h
+++ b/src/common/HeartbeatMap.h
@@ -16,13 +16,12 @@
 #define CEPH_HEARTBEATMAP_H
 
 #include <pthread.h>
-
 #include <string>
 #include <list>
 
 #include "include/atomic.h"
 
-#include "RWLock.h"
+#include "common/RWLock.h"
 
 class CephContext;
 

--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -12,16 +12,7 @@
  * 
  */
 
-
-
 #include "include/types.h"
-
-#include "msg/Messenger.h"
-#include "msg/Message.h"
-
-#include "messages/MLog.h"
-#include "messages/MLogAck.h"
-#include "mon/MonMap.h"
 
 #include <iostream>
 #include <errno.h>
@@ -33,9 +24,14 @@
 #include <sys/mount.h>
 #endif // DARWIN
 
-#include "common/LogClient.h"
-
 #include "common/config.h"
+#include "msg/Messenger.h"
+#include "mon/MonMap.h"
+
+#include "messages/MLog.h"
+#include "messages/MLogAck.h"
+
+#include "LogClient.h"
 
 #define dout_subsys ceph_subsys_monc
 

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -15,11 +15,11 @@
 #ifndef CEPH_LOGCLIENT_H
 #define CEPH_LOGCLIENT_H
 
-#include "common/LogEntry.h"
-#include "common/Mutex.h"
-
 #include <iosfwd>
 #include <sstream>
+
+#include "common/LogEntry.h"
+#include "common/Mutex.h"
 
 class LogClient;
 class MLog;

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -1,9 +1,9 @@
 
 #include <syslog.h>
 
-#include "LogEntry.h"
-#include "Formatter.h"
+#include "common/Formatter.h"
 
+#include "LogEntry.h"
 
 int clog_type_to_syslog_prio(clog_type t)
 {

--- a/src/common/LogEntry.h
+++ b/src/common/LogEntry.h
@@ -16,9 +16,10 @@
 #define CEPH_LOGENTRY_H
 
 #include "include/types.h"
+#include "msg/msg_types.h" // for entity_inst_t
+
 #include "include/utime.h"
 #include "include/encoding.h"
-#include "msg/msg_types.h" // for entity_inst_t
 
 namespace ceph {
   class Formatter;

--- a/src/common/MemoryModel.cc
+++ b/src/common/MemoryModel.cc
@@ -1,10 +1,11 @@
-
 #include "include/types.h"
-#include "MemoryModel.h"
-#include "common/config.h"
-#include "debug.h"
 
 #include <fstream>
+
+#include "common/config.h"
+#include "common/debug.h"
+
+#include "MemoryModel.h"
 
 #define dout_subsys ceph_subsys_
 

--- a/src/common/Mutex.cc
+++ b/src/common/Mutex.cc
@@ -11,15 +11,16 @@
  * Foundation.  See file COPYING.
  *
  */
-using namespace std;
 #include <string>
 
-#include "common/Mutex.h"
-#include "common/perf_counters.h"
-#include "common/ceph_context.h"
-#include "common/config.h"
 #include "include/utime.h"
+#include "common/perf_counters.h"
+#include "common/config.h"
 #include "common/Clock.h"
+
+#include "Mutex.h"
+
+using namespace std;
 
 Mutex::Mutex(const char *n, bool r, bool ld,
 	     bool bt,

--- a/src/common/Mutex.h
+++ b/src/common/Mutex.h
@@ -15,11 +15,11 @@
 #ifndef CEPH_MUTEX_H
 #define CEPH_MUTEX_H
 
-#include "include/assert.h"
-#include "lockdep.h"
-#include "common/ceph_context.h"
-
 #include <pthread.h>
+
+#include "include/assert.h"
+#include "common/lockdep.h"
+#include "common/ceph_context.h"
 
 using namespace ceph;
 

--- a/src/common/OutputDataSocket.cc
+++ b/src/common/OutputDataSocket.cc
@@ -11,9 +11,20 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include <inttypes.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <set>
+#include <sstream>
+#include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
 
-#include "common/Thread.h"
-#include "common/OutputDataSocket.h"
+#include "include/compat.h"
 #include "common/config.h"
 #include "common/debug.h"
 #include "common/errno.h"
@@ -23,22 +34,7 @@
 #include "common/version.h"
 #include "common/Formatter.h"
 
-#include <errno.h>
-#include <fcntl.h>
-#include <inttypes.h>
-#include <map>
-#include <poll.h>
-#include <set>
-#include <sstream>
-#include <stdint.h>
-#include <string.h>
-#include <string>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/un.h>
-#include <unistd.h>
-
-#include "include/compat.h"
+#include "OutputDataSocket.h"
 
 #define dout_subsys ceph_subsys_asok
 #undef dout_prefix

--- a/src/common/OutputDataSocket.h
+++ b/src/common/OutputDataSocket.h
@@ -15,14 +15,14 @@
 #ifndef CEPH_COMMON_OUTPUTDATASOCKET_H
 #define CEPH_COMMON_OUTPUTDATASOCKET_H
 
-#include "common/Thread.h"
-#include "common/Mutex.h"
-#include "common/Cond.h"
-
 #include <string>
 #include <map>
 #include <list>
+
 #include "include/buffer.h"
+#include "common/Thread.h"
+#include "common/Mutex.h"
+#include "common/Cond.h"
 
 class CephContext;
 

--- a/src/common/PrebufferedStreambuf.cc
+++ b/src/common/PrebufferedStreambuf.cc
@@ -1,5 +1,5 @@
 
-#include "common/PrebufferedStreambuf.h"
+#include "PrebufferedStreambuf.h"
 
 PrebufferedStreambuf::PrebufferedStreambuf(char *buf, size_t len)
   : m_buf(buf), m_buf_len(len)

--- a/src/common/RWLock.h
+++ b/src/common/RWLock.h
@@ -18,7 +18,8 @@
 #define CEPH_RWLock_Posix__H
 
 #include <pthread.h>
-#include "lockdep.h"
+
+#include "common/lockdep.h"
 
 class RWLock
 {

--- a/src/common/RefCountedObj.cc
+++ b/src/common/RefCountedObj.cc
@@ -12,7 +12,7 @@
  * 
  */
 
-#include "common/RefCountedObj.h"
+#include "RefCountedObj.h"
 
 void intrusive_ptr_add_ref(RefCountedObject *p) {
   p->get();

--- a/src/common/RefCountedObj.h
+++ b/src/common/RefCountedObj.h
@@ -15,10 +15,9 @@
 #ifndef CEPH_REFCOUNTEDOBJ_H
 #define CEPH_REFCOUNTEDOBJ_H
  
+#include "include/atomic.h"
 #include "common/Mutex.h"
 #include "common/Cond.h"
-#include "include/atomic.h"
-
 
 struct RefCountedObject {
   atomic_t nref;

--- a/src/common/TextTable.h
+++ b/src/common/TextTable.h
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <iomanip>
 #include <string>
+
 #include "include/assert.h"
 
 /**

--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -12,21 +12,20 @@
  *
  */
 
-#include "common/Thread.h"
-#include "common/code_environment.h"
-#include "common/debug.h"
-#include "common/signal.h"
-
 #include <dirent.h>
 #include <errno.h>
 #include <iostream>
-#include <pthread.h>
 #include <signal.h>
 #include <sstream>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 
+#include "common/code_environment.h"
+#include "common/debug.h"
+#include "common/signal.h"
+
+#include "Thread.h"
 
 Thread::Thread()
   : thread_id(0)

--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -1,8 +1,8 @@
-
-#include "common/Throttle.h"
 #include "common/debug.h"
 #include "common/ceph_context.h"
 #include "common/perf_counters.h"
+
+#include "Throttle.h"
 
 #define dout_subsys ceph_subsys_throttle
 

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -1,10 +1,11 @@
 #ifndef CEPH_THROTTLE_H
 #define CEPH_THROTTLE_H
 
-#include "Mutex.h"
-#include "Cond.h"
 #include <list>
+
 #include "include/atomic.h"
+#include "common/Mutex.h"
+#include "common/Cond.h"
 
 class CephContext;
 class PerfCounters;

--- a/src/common/Timer.cc
+++ b/src/common/Timer.cc
@@ -12,23 +12,20 @@
  *
  */
 
-#include "Cond.h"
-#include "Mutex.h"
-#include "Thread.h"
-#include "Timer.h"
-
-#include "common/config.h"
-#include "include/Context.h"
-
-#define dout_subsys ceph_subsys_timer
-#undef dout_prefix
-#define dout_prefix *_dout << "timer(" << this << ")."
-
 #include <sstream>
 #include <signal.h>
 #include <sys/time.h>
 #include <math.h>
 
+#include "include/Context.h"
+#include "common/config.h"
+#include "common/Thread.h"
+
+#include "Timer.h"
+
+#define dout_subsys ceph_subsys_timer
+#undef dout_prefix
+#define dout_prefix *_dout << "timer(" << this << ")."
 
 class SafeTimerThread : public Thread {
   SafeTimer *parent;

--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -15,10 +15,10 @@
 #ifndef CEPH_TIMER_H
 #define CEPH_TIMER_H
 
-#include "Cond.h"
-#include "Mutex.h"
-
 #include <map>
+
+#include "common/Cond.h"
+#include "common/Mutex.h"
 
 class CephContext;
 class Context;

--- a/src/common/WorkQueue.cc
+++ b/src/common/WorkQueue.cc
@@ -11,15 +11,15 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "include/types.h"
 
 #include <sstream>
 
-#include "include/types.h"
 #include "include/utime.h"
-#include "WorkQueue.h"
-
 #include "common/config.h"
 #include "common/HeartbeatMap.h"
+
+#include "WorkQueue.h"
 
 #define dout_subsys ceph_subsys_tp
 #undef dout_prefix

--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -15,9 +15,9 @@
 #ifndef CEPH_WORKQUEUE_H
 #define CEPH_WORKQUEUE_H
 
-#include "Mutex.h"
-#include "Cond.h"
-#include "Thread.h"
+#include "common/Mutex.h"
+#include "common/Cond.h"
+#include "common/Thread.h"
 #include "common/config_obs.h"
 
 class CephContext;

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -12,8 +12,21 @@
  * 
  */
 
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <poll.h>
+#include <set>
+#include <sstream>
+#include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "include/compat.h"
 #include "common/Thread.h"
-#include "common/admin_socket.h"
 #include "common/config.h"
 #include "common/debug.h"
 #include "common/errno.h"
@@ -23,22 +36,7 @@
 #include "common/version.h"
 #include "common/Formatter.h"
 
-#include <errno.h>
-#include <fcntl.h>
-#include <inttypes.h>
-#include <map>
-#include <poll.h>
-#include <set>
-#include <sstream>
-#include <stdint.h>
-#include <string.h>
-#include <string>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/un.h>
-#include <unistd.h>
-
-#include "include/compat.h"
+#include "admin_socket.h"
 
 #define dout_subsys ceph_subsys_asok
 #undef dout_prefix

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -15,12 +15,12 @@
 #ifndef CEPH_COMMON_ADMIN_SOCKET_H
 #define CEPH_COMMON_ADMIN_SOCKET_H
 
-#include "common/Thread.h"
-#include "common/Mutex.h"
-
 #include <string>
 #include <map>
+
 #include "include/buffer.h"
+#include "common/Thread.h"
+#include "common/Mutex.h"
 
 class AdminSocket;
 class CephContext;

--- a/src/common/admin_socket_client.cc
+++ b/src/common/admin_socket_client.cc
@@ -12,12 +12,6 @@
  *
  */
 
-#include "common/admin_socket.h"
-#include "common/ceph_context.h"
-#include "common/errno.h"
-#include "common/safe_io.h"
-#include "common/admin_socket_client.h"
-
 #include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -25,17 +19,22 @@
 #include <map>
 #include <poll.h>
 #include <sstream>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <string>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <time.h>
 #include <unistd.h>
 #include <vector>
+
+#include "common/admin_socket.h"
+#include "common/ceph_context.h"
+#include "common/errno.h"
+#include "common/safe_io.h"
+
+#include "common/admin_socket_client.h"
 
 using std::ostringstream;
 

--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -11,19 +11,18 @@
  * Foundation.  See file COPYING.
  *
  */
-
-#include "BackTrace.h"
-#include "common/ceph_context.h"
-#include "common/config.h"
-#include "common/debug.h"
-#include "common/Clock.h"
-#include "include/assert.h"
-
 #include <errno.h>
 #include <iostream>
 #include <pthread.h>
 #include <sstream>
 #include <time.h>
+
+#include "include/assert.h"
+#include "common/ceph_context.h"
+#include "common/config.h"
+#include "common/debug.h"
+#include "common/Clock.h"
+#include "common/BackTrace.h"
 
 namespace ceph {
   static CephContext *g_assert_context = NULL;

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -1,19 +1,19 @@
+#include "acconfig.h"
+
 #include <inttypes.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <errno.h>
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mount.h>
 #include <iostream>
 
-#include "acconfig.h"
-#include "include/compat.h"
-
 #if defined(__FreeBSD__)
 #include <sys/disk.h>
 #endif
+
+#include "include/compat.h"
 
 int get_block_device_size(int fd, int64_t *psize)
 {

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -11,22 +11,21 @@
  * Foundation.  See file COPYING.
  * 
  */
-
-
-#include "armor.h"
-#include "common/environment.h"
-#include "common/errno.h"
-#include "common/safe_io.h"
-#include "common/simple_spin.h"
-#include "include/atomic.h"
 #include "include/types.h"
-#include "include/compat.h"
 
 #include <errno.h>
 #include <fstream>
 #include <sstream>
 #include <sys/uio.h>
 #include <limits.h>
+
+#include "include/atomic.h"
+#include "include/compat.h"
+#include "common/environment.h"
+#include "common/errno.h"
+#include "common/safe_io.h"
+#include "common/simple_spin.h"
+#include "common/armor.h"
 
 namespace ceph {
 

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -11,16 +11,6 @@
  * Foundation.  See file COPYING.
  *
  */
-
-#include "auth/Auth.h"
-#include "common/ConfUtils.h"
-#include "common/ceph_argparse.h"
-#include "common/common_init.h"
-#include "common/config.h"
-#include "common/strtol.h"
-#include "common/version.h"
-#include "include/intarith.h"
-#include "include/str_list.h"
 #include "msg/msg_types.h"
 
 #include <errno.h>
@@ -30,6 +20,17 @@
 #include <string.h>
 #include <sstream>
 #include <vector>
+
+#include "include/intarith.h"
+#include "include/str_list.h"
+#include "common/ConfUtils.h"
+#include "common/common_init.h"
+#include "common/config.h"
+#include "common/strtol.h"
+#include "common/version.h"
+#include "auth/Auth.h"
+
+#include "ceph_argparse.h"
 
 /*
  * Ceph argument parsing library

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -22,6 +22,7 @@
  * Until we do that, though, this file is the place for argv parsing
  * stuff to live.
  */
+#include "msg/msg_types.h"
 
 #include <deque>
 #include <stdint.h>
@@ -29,7 +30,6 @@
 #include <vector>
 
 #include "common/entity_name.h"
-#include "msg/msg_types.h"
 
 /////////////////////// Types ///////////////////////
 class CephInitParameters

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -13,23 +13,22 @@
  */
 
 #include <time.h>
+#include <pthread.h>
+#include <semaphore.h>
 
 #include "common/admin_socket.h"
 #include "common/perf_counters.h"
 #include "common/Thread.h"
-#include "common/ceph_context.h"
 #include "common/config.h"
 #include "common/debug.h"
 #include "common/HeartbeatMap.h"
 #include "common/errno.h"
 #include "common/lockdep.h"
 #include "common/Formatter.h"
-#include "log/Log.h"
 #include "auth/Crypto.h"
+#include "log/Log.h"
 
-#include <iostream>
-#include <pthread.h>
-#include <semaphore.h>
+#include "ceph_context.h"
 
 using ceph::HeartbeatMap;
 

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -12,13 +12,14 @@
  *
  */
 
-#include "common/config.h"
-#include "common/ceph_context.h"
-#include "ceph_crypto.h"
-#include "auth/Crypto.h"
-
 #include <pthread.h>
 #include <stdlib.h>
+
+#include "common/config.h"
+#include "common/ceph_context.h"
+#include "auth/Crypto.h"
+
+#include "ceph_crypto.h"
 
 void ceph::crypto::shutdown();
 

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -10,7 +10,7 @@
 
 #ifdef USE_CRYPTOPP
 # define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
-#include <string.h>
+# include <string.h>
 # include <cryptopp/md5.h>
 # include <cryptopp/sha.h>
 # include <cryptopp/hmac.h>

--- a/src/common/ceph_crypto_cms.cc
+++ b/src/common/ceph_crypto_cms.cc
@@ -34,30 +34,22 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
-
-#include "common/config.h"
+#include <string.h>
+#include <errno.h>
 
 #ifdef USE_NSS
-
 #include <nspr.h>
 #include <cert.h>
 #include <nss.h>
 #include <smime.h>
-
 #endif
 
-#include <string.h>
-#include <errno.h>
-
-
-#include "include/buffer.h"
-
+#include "common/config.h"
 #include "common/debug.h"
 
 #include "ceph_crypto_cms.h"
 
 #define dout_subsys ceph_subsys_crypto
-
 
 #ifndef USE_NSS
 

--- a/src/common/code_environment.cc
+++ b/src/common/code_environment.cc
@@ -12,16 +12,17 @@
  *
  */
 
-#include "common/code_environment.h"
-
 #include <errno.h>
 #include <iostream>
 #include <stdlib.h>
 #include <string.h>
 #include <string>
+
 #if defined(__linux__)
 #include <sys/prctl.h>
 #endif
+
+#include "code_environment.h"
 
 code_environment_t g_code_env = CODE_ENVIRONMENT_UTILITY;
 

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -11,21 +11,19 @@
  * Foundation.  See file COPYING.
  *
  */
+#include <errno.h>
 
+#include "include/color.h"
 #include "common/ceph_argparse.h"
 #include "common/ceph_context.h"
 #include "common/ceph_crypto.h"
-#include "common/code_environment.h"
-#include "common/common_init.h"
 #include "common/config.h"
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "common/version.h"
-#include "include/color.h"
 
-#include <errno.h>
-#include <deque>
+#include "common_init.h"
 
 #define dout_subsys ceph_subsys_
 

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -11,22 +11,7 @@
  * Foundation.  See file COPYING.
  *
  */
-
-#include "auth/Auth.h"
-#include "common/ConfUtils.h"
-#include "common/ceph_argparse.h"
-#include "common/common_init.h"
-#include "common/config.h"
-#include "common/static_assert.h"
-#include "common/strtol.h"
-#include "common/version.h"
-#include "include/str_list.h"
 #include "include/types.h"
-#include "include/stringify.h"
-#include "msg/msg_types.h"
-#include "osd/osd_types.h"
-
-#include "include/assert.h"
 
 #include <errno.h>
 #include <sstream>
@@ -34,6 +19,20 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include "include/str_list.h"
+#include "include/stringify.h"
+#include "include/assert.h"
+#include "common/ceph_argparse.h"
+#include "common/common_init.h"
+#include "common/static_assert.h"
+#include "common/strtol.h"
+#include "common/version.h"
+#include "auth/Auth.h"
+#include "msg/msg_types.h"
+#include "osd/osd_types.h"
+
+#include "config.h"
 
 /* Don't use standard Ceph logging in this file.
  * We can't use logging until it's initialized, and a lot of the necessary

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -17,6 +17,8 @@
 
 extern struct ceph_file_layout g_default_file_layout;
 
+#include "msg/msg_types.h"
+
 #include <iosfwd>
 #include <vector>
 #include <map>
@@ -25,9 +27,8 @@ extern struct ceph_file_layout g_default_file_layout;
 #include "common/ConfUtils.h"
 #include "common/entity_name.h"
 #include "common/Mutex.h"
-#include "log/SubsystemMap.h"
 #include "common/config_obs.h"
-#include "msg/msg_types.h"
+#include "log/SubsystemMap.h"
 
 #define OSD_REP_PRIMARY 0
 #define OSD_REP_SPLAY   1

--- a/src/common/debug.cc
+++ b/src/common/debug.cc
@@ -1,4 +1,3 @@
-
 #include <iostream>
 
 void dout_emergency(const char * const str)

--- a/src/common/debug.h
+++ b/src/common/debug.h
@@ -16,16 +16,16 @@
 #ifndef CEPH_DOUT_H
 #define CEPH_DOUT_H
 
-#include "common/config.h"
-#include "common/likely.h"
-#include "common/Clock.h"
-#include "log/Log.h"
-#include "include/assert.h"
-
 #include <iostream>
 #include <pthread.h>
 #include <streambuf>
 #include <sstream>
+
+#include "include/assert.h"
+#include "common/config.h"
+#include "common/likely.h"
+#include "common/Clock.h"
+#include "log/Log.h"
 
 extern void dout_emergency(const char * const str);
 extern void dout_emergency(const std::string &str);

--- a/src/common/entity_name.cc
+++ b/src/common/entity_name.cc
@@ -11,13 +11,14 @@
  * Foundation.  See file COPYING.
  *
  */
-
-#include "common/entity_name.h"
-#include "include/msgr.h"
+#include "include/types.h"
 
 #include <errno.h>
 #include <sstream>
-#include <string>
+
+#include "include/msgr.h"
+
+#include "entity_name.h"
 
 using std::string;
 

--- a/src/common/entity_name.h
+++ b/src/common/entity_name.h
@@ -15,13 +15,14 @@
 #ifndef CEPH_COMMON_ENTITY_NAME_H
 #define CEPH_COMMON_ENTITY_NAME_H
 
+#include "msg/msg_types.h"
+
 #include <iosfwd>
 #include <stdint.h>
 #include <string>
 
 #include "include/encoding.h"
 #include "include/buffer.h"
-#include "msg/msg_types.h"
 
 /* Represents a Ceph entity name.
  *

--- a/src/common/environment.cc
+++ b/src/common/environment.cc
@@ -12,10 +12,10 @@
  *
  */
 
-#include "common/environment.h"
-
 #include <stdlib.h>
 #include <strings.h>
+
+#include "environment.h"
 
 bool get_env_bool(const char *key)
 {

--- a/src/common/errno.cc
+++ b/src/common/errno.cc
@@ -1,8 +1,7 @@
-#include "common/errno.h"
-
 #include <sstream>
-#include <string>
 #include <string.h>
+
+#include "errno.h"
 
 std::string cpp_strerror(int err)
 {

--- a/src/common/escape.c
+++ b/src/common/escape.c
@@ -12,10 +12,10 @@
  *
  */
 
-#include "common/escape.h"
-
 #include <stdio.h>
 #include <string.h>
+
+#include "escape.h"
 
 /*
  * Some functions for escaping RGW responses

--- a/src/common/fd.cc
+++ b/src/common/fd.cc
@@ -12,15 +12,15 @@
  *
  */
 
-#include "fd.h"
-
 #include <sys/types.h>
 #include <unistd.h>
 #include <dirent.h>
 #include <errno.h>
 
-#include "debug.h"
-#include "errno.h"
+#include "common/debug.h"
+#include "common/errno.h"
+
+#include "fd.h"
 
 void dump_open_fds(CephContext *cct)
 {

--- a/src/common/fiemap.cc
+++ b/src/common/fiemap.cc
@@ -34,6 +34,7 @@
 #if defined(__linux__)
 #include <linux/fs.h>
 #endif
+
 #include "include/inttypes.h"
 #include "include/fiemap.h"
 

--- a/src/common/hex.cc
+++ b/src/common/hex.cc
@@ -12,11 +12,11 @@
  *
  */
 
-#include "common/debug.h"
-#include "common/hex.h"
-
 #include <stdio.h>
-#include <string>
+
+#include "common/debug.h"
+
+#include "hex.h"
 
 void hex2str(const char *s, int len, char *buf, int dest_len)
 {

--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -1,9 +1,9 @@
-#include "include/ipaddr.h"
 
 #include <arpa/inet.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "include/ipaddr.h"
 
 static void netmask_ipv4(const struct in_addr *addr,
 			 unsigned int prefix_len,

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -11,14 +11,17 @@
  * Foundation.  See file COPYING.
  *
  */
-#include "BackTrace.h"
-#include "Clock.h"
-#include "common/debug.h"
-#include "common/environment.h"
 #include "include/types.h"
-#include "lockdep.h"
 
 #include <ext/hash_map>
+
+#include "common/BackTrace.h"
+#include "common/Clock.h"
+#include "common/debug.h"
+#include "common/environment.h"
+
+#include "lockdep.h"
+
 
 #if defined(__FreeBSD__) && defined(__LP64__)	// On FreeBSD pthread_t is a pointer.
 namespace __gnu_cxx {

--- a/src/common/mime.c
+++ b/src/common/mime.c
@@ -11,11 +11,11 @@
  * Foundation.  See file COPYING.
  *
  */
-#include "common/utf8.h"
-
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "common/utf8.h"
 
 int mime_encode_as_qp(const char *input, char *output, int outlen)
 {

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -14,19 +14,16 @@
  * try and bench on a pool you don't have permission to access
  * it will just loop forever.
  */
-#include "common/Cond.h"
-#include "global/global_context.h"
-#include "obj_bencher.h"
-
 #include <iostream>
 #include <fstream>
-
 #include <cerrno>
-
 #include <stdlib.h>
 #include <time.h>
 #include <sstream>
 
+#include "global/global_context.h"
+
+#include "obj_bencher.h"
 
 const std::string BENCH_LASTRUN_METADATA = "benchmark_last_metadata";
 const std::string BENCH_PREFIX = "benchmark_data";

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -11,18 +11,16 @@
  * Foundation.  See file COPYING.
  *
  */
+#include <inttypes.h>
+#include <errno.h>
+#include <map>
+#include <sstream>
+#include <string.h>
 
-#include "common/perf_counters.h"
 #include "common/debug.h"
 #include "common/errno.h"
 
-#include <errno.h>
-#include <inttypes.h>
-#include <map>
-#include <sstream>
-#include <stdint.h>
-#include <string.h>
-#include <string>
+#include "perf_counters.h"
 
 using std::ostringstream;
 

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -16,14 +16,14 @@
 #ifndef CEPH_COMMON_PERF_COUNTERS_H
 #define CEPH_COMMON_PERF_COUNTERS_H
 
-#include "common/config_obs.h"
-#include "common/Mutex.h"
-#include "include/buffer.h"
-#include "include/utime.h"
-
 #include <stdint.h>
 #include <string>
 #include <vector>
+
+#include "include/buffer.h"
+#include "include/utime.h"
+#include "common/config_obs.h"
+#include "common/Mutex.h"
 
 class CephContext;
 class PerfCountersBuilder;

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -12,8 +12,6 @@
  *
  */
 
-#include "common/pick_address.h"
-
 #include <netdb.h>
 #include <errno.h>
 
@@ -21,6 +19,8 @@
 #include "include/str_list.h"
 #include "common/debug.h"
 #include "common/errno.h"
+
+#include "pick_address.h"
 
 #define dout_subsys ceph_subsys_
 

--- a/src/common/pipe.c
+++ b/src/common/pipe.c
@@ -12,11 +12,11 @@
  *
  */
 
-#include "common/pipe.h"
-
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
+
+#include "pipe.h"
 
 int pipe_cloexec(int pipefd[2])
 {

--- a/src/common/run_cmd.cc
+++ b/src/common/run_cmd.cc
@@ -12,8 +12,6 @@
  *
  */
 
-#include "common/errno.h"
-
 #include <errno.h>
 #include <sstream>
 #include <stdarg.h>
@@ -22,6 +20,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
+
+#include "common/errno.h"
 
 using std::ostringstream;
 

--- a/src/common/safe_io.c
+++ b/src/common/safe_io.c
@@ -17,7 +17,7 @@
 #include <unistd.h>
 #include <errno.h>
 
-#include "common/safe_io.h"
+#include "safe_io.h"
 
 ssize_t safe_read(int fd, void *buf, size_t count)
 {

--- a/src/common/shared_cache.hpp
+++ b/src/common/shared_cache.hpp
@@ -19,6 +19,7 @@
 #include <list>
 #include <memory>
 #include <utility>
+
 #include "common/Mutex.h"
 #include "common/Cond.h"
 

--- a/src/common/sharedptr_registry.hpp
+++ b/src/common/sharedptr_registry.hpp
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <memory>
+
 #include "common/Mutex.h"
 #include "common/Cond.h"
 

--- a/src/common/signal.cc
+++ b/src/common/signal.cc
@@ -12,18 +12,18 @@
  *
  */
 
-#include "common/BackTrace.h"
-#include "common/perf_counters.h"
-#include "global/pidfile.h"
-#include "common/debug.h"
-#include "common/signal.h"
-#include "common/config.h"
-
-#include <signal.h>
 #include <sstream>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include "common/BackTrace.h"
+#include "common/perf_counters.h"
+#include "common/debug.h"
+#include "common/config.h"
+#include "global/pidfile.h"
+
+#include "signal.h"
 
 std::string signal_mask_to_str()
 {

--- a/src/common/simple_cache.hpp
+++ b/src/common/simple_cache.hpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <list>
 #include <memory>
+
 #include "common/Mutex.h"
 #include "common/Cond.h"
 

--- a/src/common/simple_spin.cc
+++ b/src/common/simple_spin.cc
@@ -12,11 +12,10 @@
  *
  */
 
-#include "common/simple_spin.h"
-
 #include <stdio.h>
-#include <stdint.h>
 #include <pthread.h>
+
+#include "simple_spin.h"
 
 static uint32_t bar = 13;
 static uint32_t *foo = &bar;

--- a/src/common/snap_types.cc
+++ b/src/common/snap_types.cc
@@ -1,6 +1,6 @@
+#include "common/Formatter.h"
 
 #include "snap_types.h"
-#include "common/Formatter.h"
 
 void SnapRealmInfo::encode(bufferlist& bl) const
 {

--- a/src/common/utf8.c
+++ b/src/common/utf8.c
@@ -11,10 +11,10 @@
  * Foundation.  See file COPYING.
  *
  */
-#include "common/utf8.h"
-
 #include <stdio.h>
 #include <string.h>
+
+#include "utf8.h"
 
 #define MAX_UTF8_SZ 6
 #define INVALID_UTF8_CHAR 0xfffffffful

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -13,11 +13,12 @@
  */
 
 #include "acconfig.h"
-#include "ceph_ver.h"
-#include "common/version.h"
 
 #include <sstream>
-#include <string>
+
+#include "ceph_ver.h"
+
+#include "version.h"
 
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)

--- a/src/common/xattr.c
+++ b/src/common/xattr.c
@@ -25,7 +25,7 @@
 #error "Your system is not supported!"
 #endif
 
-#include "common/xattr.h"
+#include "xattr.h"
 
 /*
  * Sets extended attribute on a file.

--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -1,19 +1,15 @@
+#include <iostream>
+#include <stack>
+#include <string>
+#include <stdexcept>
+#include <map>
+#include <typeinfo>
 
 #include "CrushCompiler.h"
 
 #ifndef EBADE
 #define EBADE EFTYPE
 #endif
-
-#include <iostream>
-#include <stack>
-#include <functional>
-#include <string>
-#include <stdexcept>
-#include <map>
-
-
-#include <typeinfo>
 
 // -------------
 

--- a/src/crush/CrushCompiler.h
+++ b/src/crush/CrushCompiler.h
@@ -4,12 +4,12 @@
 #ifndef CEPH_CRUSH_COMPILER_H
 #define CEPH_CRUSH_COMPILER_H
 
-#include "crush/CrushWrapper.h"
-#include "crush/grammar.h"
-
 #include <map>
 #include <ostream>
 #include <functional>
+
+#include "CrushWrapper.h"
+#include "grammar.h"
 
 class CrushCompiler {
   CrushWrapper& crush;

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -1,8 +1,6 @@
-
-#include "CrushTester.h"
-
 #include <stdlib.h>
 
+#include "CrushTester.h"
 
 void CrushTester::set_device_weight(int dev, float f)
 {

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -4,14 +4,18 @@
 #ifndef CEPH_CRUSH_WRAPPER_H
 #define CEPH_CRUSH_WRAPPER_H
 
+#include "include/types.h"
+
 #include <stdlib.h>
 #include <map>
 #include <set>
 #include <string>
-
 #include <iostream> //for testing, remove
 
-#include "include/types.h"
+#include "include/assert.h"
+#include "include/err.h"
+#include "include/encoding.h"
+#include "common/Mutex.h"
 
 extern "C" {
 #include "crush.h"
@@ -20,13 +24,6 @@ extern "C" {
 #include "builder.h"
 }
 
-#include "include/err.h"
-#include "include/encoding.h"
-
-
-#include "common/Mutex.h"
-
-#include "include/assert.h"
 #define BUG_ON(x) assert(!(x))
 
 namespace ceph {

--- a/src/crush/builder.c
+++ b/src/crush/builder.c
@@ -6,8 +6,9 @@
 #include <assert.h>
 #include <errno.h>
 
-#include "builder.h"
 #include "hash.h"
+
+#include "builder.h"
 
 #define BUG_ON(x) assert(!(x))
 

--- a/src/crush/grammar.h
+++ b/src/crush/grammar.h
@@ -27,6 +27,7 @@
 #include <boost/spirit/include/classic_ast.hpp>
 #include <boost/spirit/include/classic_tree_to_xml.hpp>
 #endif
+
 using namespace boost::spirit;
 
 struct crush_grammar : public grammar<crush_grammar>

--- a/src/crush/hash.c
+++ b/src/crush/hash.c
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include "include/inttypes.h"
 #endif
+
 #include "hash.h"
 
 /*

--- a/src/crush/hash.h
+++ b/src/crush/hash.h
@@ -1,6 +1,13 @@
 #ifndef CEPH_CRUSH_HASH_H
 #define CEPH_CRUSH_HASH_H
 
+#if defined(__linux__)
+#include <linux/types.h>
+#elif defined(__FreeBSD__)
+#include <sys/types.h>
+#include "include/inttypes.h"
+#endif
+
 #define CRUSH_HASH_RJENKINS1   0
 
 #define CRUSH_HASH_DEFAULT CRUSH_HASH_RJENKINS1

--- a/src/crushtool.cc
+++ b/src/crushtool.cc
@@ -16,31 +16,27 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
-
 #include <fstream>
 
+#include "include/assert.h"
 #include "common/errno.h"
 #include "common/config.h"
-
 #include "common/ceph_argparse.h"
-#include "global/global_context.h"
-#include "global/global_init.h"
-#include "global/debug.h"
 #include "crush/CrushWrapper.h"
 #include "crush/CrushCompiler.h"
 #include "crush/CrushTester.h"
-#include "include/assert.h"
-
-#define dout_subsys ceph_subsys_crush
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "global/debug.h"
 
 using namespace std;
+
+#define dout_subsys ceph_subsys_crush
 
 void usage();
 void data_analysis();
 
-
 const char *infn = "stdin";
-
 
 ////////////////////////////////////////////////////////////////////////////
 

--- a/src/dupstore.cc
+++ b/src/dupstore.cc
@@ -13,12 +13,13 @@
  */
 
 #include <iostream>
-#include "os/FileStore.h"
+#include <ext/hash_map>
+
 #include "common/ceph_argparse.h"
+#include "os/FileStore.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
 
-#include <ext/hash_map>
 using __gnu_cxx::hash_map;
 
 int dupstore(ObjectStore* src, ObjectStore* dst)

--- a/src/fooclass.cc
+++ b/src/fooclass.cc
@@ -1,6 +1,3 @@
-
-
-
 #include <iostream>
 #include <string.h>
 #include <stdlib.h>

--- a/src/global/global_context.cc
+++ b/src/global/global_context.cc
@@ -13,7 +13,8 @@
  */
 
 #include "common/ceph_context.h"
-#include "global/global_context.h"
+
+#include "global_context.h"
 
 /*
  * Global variables for use from process context.

--- a/src/global/global_context.h
+++ b/src/global/global_context.h
@@ -15,10 +15,10 @@
 #ifndef CEPH_GLOBAL_CONTEXT_H
 #define CEPH_GLOBAL_CONTEXT_H
 
-#include "common/ceph_context.h"
-
 #include <iostream>
 #include <stdint.h>
+
+#include "common/ceph_context.h"
 
 class md_config_t;
 

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -12,6 +12,10 @@
  *
  */
 
+#include <errno.h>
+
+#include "include/compat.h"
+#include "include/color.h"
 #include "common/Thread.h"
 #include "common/ceph_argparse.h"
 #include "common/code_environment.h"
@@ -22,15 +26,11 @@
 #include "common/signal.h"
 #include "common/version.h"
 #include "global/global_context.h"
-#include "global/global_init.h"
 #include "global/pidfile.h"
 #include "global/signal_handler.h"
 #include "global/debug.h"
-#include "include/compat.h"
-#include "include/color.h"
 
-#include <errno.h>
-#include <deque>
+#include "global_init.h"
 
 #define dout_subsys ceph_subsys_
 

--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -11,12 +11,6 @@
  * Foundation.  See file COPYING.
  *
  */
-
-#include "common/errno.h"
-#include "common/safe_io.h"
-#include "global/debug.h"
-#include "global/pidfile.h"
-
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -28,6 +22,11 @@
 #endif
 
 #include "include/compat.h"
+#include "common/errno.h"
+#include "common/safe_io.h"
+#include "global/debug.h"
+
+#include "pidfile.h"
 
 #define dout_prefix *_dout
 

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -12,18 +12,19 @@
  *
  */
 
-#include "common/BackTrace.h"
-#include "common/perf_counters.h"
-#include "common/config.h"
-#include "global/pidfile.h"
-#include "global/debug.h"
-#include "global/signal_handler.h"
-
-#include <signal.h>
 #include <sstream>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include "common/BackTrace.h"
+#include "common/perf_counters.h"
+#include "common/config.h"
+#include "global/global_context.h"
+#include "global/pidfile.h"
+#include "global/debug.h"
+
+#include "signal_handler.h"
 
 void install_sighandler(int signum, signal_handler_t handler, int flags)
 {

--- a/src/include/CompatSet.h
+++ b/src/include/CompatSet.h
@@ -14,9 +14,12 @@
 
 #ifndef CEPH_COMPATSET_H
 #define CEPH_COMPATSET_H
-#include "include/buffer.h"
+
+#include "types.h"
+
 #include <vector>
 
+#include "include/buffer.h"
 #include "common/Formatter.h"
 
 struct CompatSet {

--- a/src/key_value_store/cls_kvs.cc
+++ b/src/key_value_store/cls_kvs.cc
@@ -5,14 +5,16 @@
  *      Author: Eleanor Cawthon
  */
 
-#include "objclass/objclass.h"
-#include "/usr/include/asm-generic/errno-base.h"
-#include "/usr/include/asm-generic/errno.h"
-#include "key_value_store/kvs_arg_types.h"
 #include "include/types.h"
+
 #include <iostream>
 #include <climits>
+#include <asm-generic/errno-base.h>
+#include <asm-generic/errno.h>
 
+#include "objclass/objclass.h"
+
+#include "kvs_arg_types.h"
 
 cls_handle_t h_class;
 cls_method_handle_t h_get_idata_from_key;

--- a/src/key_value_store/key_value_structure.h
+++ b/src/key_value_store/key_value_structure.h
@@ -14,9 +14,10 @@
 #ifndef KEY_VALUE_STRUCTURE_HPP_
 #define KEY_VALUE_STRUCTURE_HPP_
 
+#include <vector>
+
 #include "include/rados/librados.hpp"
 #include "include/utime.h"
-#include <vector>
 
 using std::string;
 using std::map;

--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -11,27 +11,21 @@
  * Foundation.  See file COPYING.
  */
 
-#include "key_value_store/key_value_structure.h"
-#include "key_value_store/kv_flat_btree_async.h"
-#include "key_value_store/kvs_arg_types.h"
-#include "include/rados/librados.hpp"
-#include "/usr/include/asm-generic/errno.h"
-#include "/usr/include/asm-generic/errno-base.h"
-#include "common/ceph_context.h"
-#include "global/global_context.h"
-#include "common/Clock.h"
-#include "include/rados.h"
 #include "include/types.h"
-
 
 #include <string>
 #include <iostream>
 #include <cassert>
 #include <climits>
 #include <cmath>
-#include <sstream>
 #include <stdlib.h>
 #include <iterator>
+#include <asm-generic/errno.h>
+#include <asm-generic/errno-base.h>
+
+#include "kvs_arg_types.h"
+
+#include "kv_flat_btree_async.h"
 
 using namespace std;
 using ceph::bufferlist;

--- a/src/key_value_store/kv_flat_btree_async.h
+++ b/src/key_value_store/kv_flat_btree_async.h
@@ -18,19 +18,19 @@
 #define EPREFIX 136
 #define EFIRSTOBJ 138
 
-#include "key_value_store/key_value_structure.h"
-#include "include/utime.h"
+#include <cfloat>
+#include <queue>
+#include <sstream>
+#include <stdarg.h>
+
 #include "include/rados.h"
 #include "include/encoding.h"
 #include "common/Mutex.h"
 #include "common/Clock.h"
 #include "common/Formatter.h"
 #include "global/global_context.h"
-#include "include/rados/librados.hpp"
-#include <cfloat>
-#include <queue>
-#include <sstream>
-#include <stdarg.h>
+
+#include "key_value_structure.h"
 
 using namespace std;
 using ceph::bufferlist;

--- a/src/key_value_store/kvs_arg_types.h
+++ b/src/key_value_store/kvs_arg_types.h
@@ -10,8 +10,7 @@
 
 #define EBALANCE 137
 
-#include "include/encoding.h"
-#include "key_value_store/kv_flat_btree_async.h"
+#include "kv_flat_btree_async.h"
 
 using namespace std;
 using ceph::bufferlist;

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -17,18 +17,19 @@
 #include <string.h>
 #include <string>
 
-#include "client/Client.h"
 #include "include/cephfs/libcephfs.h"
+#include "include/str_list.h"
+#include "include/assert.h"
 #include "common/Mutex.h"
 #include "common/ceph_argparse.h"
 #include "common/common_init.h"
 #include "common/config.h"
 #include "common/version.h"
+#include "client/Client.h"
 #include "mon/MonClient.h"
-#include "include/str_list.h"
-#include "messages/MMonMap.h"
 #include "msg/Messenger.h"
-#include "include/assert.h"
+
+#include "messages/MMonMap.h"
 
 class ceph_mount_info
 {

--- a/src/librados-config.cc
+++ b/src/librados-config.cc
@@ -12,12 +12,11 @@
  *
  */
 
+#include "include/rados/librados.h"
 #include "common/config.h"
-
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
 #include "global/global_context.h"
-#include "include/rados/librados.h"
 
 void usage()
 {

--- a/src/librados/AioCompletionImpl.h
+++ b/src/librados/AioCompletionImpl.h
@@ -15,14 +15,14 @@
 #ifndef CEPH_LIBRADOS_AIOCOMPLETIONIMPL_H
 #define CEPH_LIBRADOS_AIOCOMPLETIONIMPL_H
 
-#include "common/Cond.h"
-#include "common/Mutex.h"
+#include "osd/osd_types.h"
 
 #include "include/buffer.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
 #include "include/xlist.h"
-#include "osd/osd_types.h"
+#include "common/Cond.h"
+#include "common/Mutex.h"
 
 class IoCtxImpl;
 

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -14,12 +14,13 @@
 
 #include <limits.h>
 
-#include "IoCtxImpl.h"
-
-#include "librados/AioCompletionImpl.h"
-#include "librados/PoolAsyncCompletionImpl.h"
-#include "librados/RadosClient.h"
 #include "include/assert.h"
+
+#include "AioCompletionImpl.h"
+#include "PoolAsyncCompletionImpl.h"
+#include "RadosClient.h"
+
+#include "IoCtxImpl.h"
 
 #define dout_subsys ceph_subsys_rados
 #undef dout_prefix

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -15,6 +15,9 @@
 #ifndef CEPH_LIBRADOS_IOCTXIMPL_H
 #define CEPH_LIBRADOS_IOCTXIMPL_H
 
+#include "include/types.h"
+#include "osd/osd_types.h"
+
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/snap_types.h"
@@ -22,9 +25,7 @@
 #include "include/rados.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
-#include "include/types.h"
 #include "include/xlist.h"
-#include "osd/osd_types.h"
 #include "osdc/Objecter.h"
 
 class RadosClient;

--- a/src/librados/PoolAsyncCompletionImpl.h
+++ b/src/librados/PoolAsyncCompletionImpl.h
@@ -15,11 +15,11 @@
 #ifndef CEPH_LIBRADOS_POOLASYNCCOMPLETIONIMPL_H
 #define CEPH_LIBRADOS_POOLASYNCCOMPLETIONIMPL_H
 
-#include "common/Cond.h"
-#include "common/Mutex.h"
 #include "include/Context.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
+#include "common/Cond.h"
+#include "common/Mutex.h"
 
 namespace librados {
   struct PoolAsyncCompletionImpl {

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -15,27 +15,25 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-
 #include <iostream>
 #include <string>
 #include <pthread.h>
 #include <errno.h>
 
+#include "include/assert.h"
+#include "include/buffer.h"
 #include "common/ceph_context.h"
 #include "common/config.h"
 #include "common/common_init.h"
 #include "common/errno.h"
-#include "include/buffer.h"
-
-#include "messages/MWatchNotify.h"
 #include "msg/SimpleMessenger.h"
 
-#include "AioCompletionImpl.h"
-#include "IoCtxImpl.h"
-#include "PoolAsyncCompletionImpl.h"
-#include "RadosClient.h"
+#include "messages/MWatchNotify.h"
 
-#include "include/assert.h"
+#include "AioCompletionImpl.h"
+#include "PoolAsyncCompletionImpl.h"
+
+#include "RadosClient.h"
 
 #define dout_subsys ceph_subsys_rados
 #undef dout_prefix

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -14,11 +14,11 @@
 #ifndef CEPH_LIBRADOS_RADOSCLIENT_H
 #define CEPH_LIBRADOS_RADOSCLIENT_H
 
+#include "include/rados/librados.h"
+#include "include/rados/librados.hpp"
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/Timer.h"
-#include "include/rados/librados.h"
-#include "include/rados/librados.hpp"
 #include "mon/MonClient.h"
 #include "msg/Dispatcher.h"
 #include "osd/OSDMap.h"

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -12,20 +12,21 @@
  *
  */
 
-using namespace std;
+#include "include/types.h"
 
+#include "include/rados/librados.h"
+#include "include/rados/librados.hpp"
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/ceph_argparse.h"
 #include "common/common_init.h"
-#include "include/rados/librados.h"
-#include "include/rados/librados.hpp"
-#include "include/types.h"
 
-#include "librados/AioCompletionImpl.h"
-#include "librados/IoCtxImpl.h"
-#include "librados/PoolAsyncCompletionImpl.h"
-#include "librados/RadosClient.h"
+#include "AioCompletionImpl.h"
+#include "IoCtxImpl.h"
+#include "PoolAsyncCompletionImpl.h"
+#include "RadosClient.h"
+
+using namespace std;
 
 #define dout_subsys ceph_subsys_rados
 #undef dout_prefix

--- a/src/librbd/AioCompletion.cc
+++ b/src/librbd/AioCompletion.cc
@@ -6,10 +6,10 @@
 #include "common/ceph_context.h"
 #include "common/debug.h"
 
-#include "librbd/AioRequest.h"
-#include "librbd/internal.h"
+#include "AioRequest.h"
+#include "internal.h"
 
-#include "librbd/AioCompletion.h"
+#include "AioCompletion.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix

--- a/src/librbd/AioCompletion.h
+++ b/src/librbd/AioCompletion.h
@@ -3,18 +3,16 @@
 #ifndef CEPH_LIBRBD_AIOCOMPLETION_H
 #define CEPH_LIBRBD_AIOCOMPLETION_H
 
+#include "include/Context.h"
+#include "include/utime.h"
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/ceph_context.h"
 #include "common/perf_counters.h"
-#include "include/Context.h"
-#include "include/utime.h"
-#include "include/rbd/librbd.hpp"
-
-#include "librbd/ImageCtx.h"
-#include "librbd/internal.h"
-
 #include "osdc/Striper.h"
+
+#include "ImageCtx.h"
+#include "internal.h"
 
 namespace librbd {
 

--- a/src/librbd/AioRequest.cc
+++ b/src/librbd/AioRequest.cc
@@ -5,11 +5,11 @@
 #include "common/debug.h"
 #include "common/Mutex.h"
 
-#include "librbd/AioCompletion.h"
-#include "librbd/ImageCtx.h"
-#include "librbd/internal.h"
+#include "AioCompletion.h"
+#include "ImageCtx.h"
+#include "internal.h"
 
-#include "librbd/AioRequest.h"
+#include "AioRequest.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix

--- a/src/librbd/AioRequest.h
+++ b/src/librbd/AioRequest.h
@@ -3,14 +3,13 @@
 #ifndef CEPH_LIBRBD_AIOREQUEST_H
 #define CEPH_LIBRBD_AIOREQUEST_H
 
+#include "inttypes.h"
 #include <map>
 
-#include "inttypes.h"
-
-#include "common/snap_types.h"
 #include "include/buffer.h"
 #include "include/Context.h"
 #include "include/rados/librados.hpp"
+#include "common/snap_types.h"
 
 namespace librbd {
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -3,25 +3,25 @@
 #ifndef CEPH_LIBRBD_IMAGECTX_H
 #define CEPH_LIBRBD_IMAGECTX_H
 
-#include <inttypes.h>
+#include "include/types.h"
+#include "include/rbd_types.h"
 
+#include <inttypes.h>
 #include <map>
 #include <set>
 #include <string>
 #include <vector>
 
-#include "common/Mutex.h"
-#include "common/snap_types.h"
 #include "include/buffer.h"
 #include "include/rbd/librbd.hpp"
-#include "include/rbd_types.h"
-#include "include/types.h"
+#include "common/Mutex.h"
+#include "common/snap_types.h"
 #include "osdc/ObjectCacher.h"
-
 #include "cls/rbd/cls_rbd_client.h"
-#include "librbd/LibrbdWriteback.h"
-#include "librbd/SnapInfo.h"
-#include "librbd/parent_types.h"
+
+#include "LibrbdWriteback.h"
+#include "SnapInfo.h"
+#include "parent_types.h"
 
 class CephContext;
 class PerfCounters;

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -3,19 +3,17 @@
 
 #include <errno.h>
 
+#include "include/assert.h"
+#include "include/rbd/librbd.hpp"
 #include "common/ceph_context.h"
 #include "common/debug.h"
 #include "common/Mutex.h"
-#include "include/Context.h"
-#include "include/rados/librados.hpp"
-#include "include/rbd/librbd.hpp"
 
-#include "librbd/AioRequest.h"
-#include "librbd/ImageCtx.h"
-#include "librbd/internal.h"
-#include "librbd/LibrbdWriteback.h"
+#include "AioRequest.h"
+#include "ImageCtx.h"
+#include "internal.h"
 
-#include "include/assert.h"
+#include "LibrbdWriteback.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix

--- a/src/librbd/LibrbdWriteback.h
+++ b/src/librbd/LibrbdWriteback.h
@@ -3,10 +3,11 @@
 #ifndef CEPH_LIBRBD_LIBRBDWRITEBACKHANDLER_H
 #define CEPH_LIBRBD_LIBRBDWRITEBACKHANDLER_H
 
-#include "include/Context.h"
 #include "include/types.h"
-#include "include/rados/librados.hpp"
 #include "osd/osd_types.h"
+
+#include "include/Context.h"
+#include "include/rados/librados.hpp"
 #include "osdc/WritebackHandler.h"
 
 class Mutex;

--- a/src/librbd/SnapInfo.h
+++ b/src/librbd/SnapInfo.h
@@ -8,7 +8,7 @@
 #include "include/rados/librados.hpp"
 
 #include "cls/rbd/cls_rbd_client.h"
-#include "librbd/parent_types.h"
+#include "parent_types.h"
 
 namespace librbd {
 

--- a/src/librbd/WatchCtx.cc
+++ b/src/librbd/WatchCtx.cc
@@ -5,10 +5,10 @@
 #include "common/debug.h"
 #include "common/perf_counters.h"
 
-#include "librbd/ImageCtx.h"
-#include "librbd/internal.h"
+#include "ImageCtx.h"
+#include "internal.h"
 
-#include "librbd/WatchCtx.h"
+#include "WatchCtx.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix

--- a/src/librbd/WatchCtx.h
+++ b/src/librbd/WatchCtx.h
@@ -5,9 +5,9 @@
 
 #include <inttypes.h>
 
-#include "common/Mutex.h"
 #include "include/buffer.h"
 #include "include/rados/librados.hpp"
+#include "common/Mutex.h"
 
 class ImageCtx;
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1,23 +1,23 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
+#include "include/inttypes.h"
+
 #include <errno.h>
 #include <limits.h>
 
+#include "include/stringify.h"
 #include "common/ceph_context.h"
 #include "common/debug.h"
 #include "common/errno.h"
 #include "cls/lock/cls_lock_client.h"
-#include "include/inttypes.h"
-#include "include/stringify.h"
-
 #include "cls/rbd/cls_rbd.h"
 
-#include "librbd/AioCompletion.h"
-#include "librbd/AioRequest.h"
-#include "librbd/ImageCtx.h"
+#include "AioCompletion.h"
+#include "AioRequest.h"
+#include "ImageCtx.h"
+#include "parent_types.h"
 
-#include "librbd/internal.h"
-#include "librbd/parent_types.h"
+#include "internal.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -3,8 +3,9 @@
 #ifndef CEPH_LIBRBD_INTERNAL_H
 #define CEPH_LIBRBD_INTERNAL_H
 
-#include <inttypes.h>
+#include "include/rbd_types.h"
 
+#include <inttypes.h>
 #include <map>
 #include <set>
 #include <string>
@@ -12,7 +13,6 @@
 
 #include "include/buffer.h"
 #include "include/rbd/librbd.hpp"
-#include "include/rbd_types.h"
 
 enum {
   l_librbd_first = 26000,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -11,28 +11,26 @@
  * Foundation.	See file COPYING.
  *
  */
-
-#include <errno.h>
 #include <inttypes.h>
+#include <errno.h>
+#include <algorithm>
+#include <string>
+#include <vector>
 
+#include "include/Context.h"
+#include "include/rbd/librbd.hpp"
 #include "common/Cond.h"
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/snap_types.h"
 #include "common/perf_counters.h"
-#include "include/Context.h"
-#include "include/rbd/librbd.hpp"
 #include "osdc/ObjectCacher.h"
-
-#include "librbd/AioCompletion.h"
 #include "cls/rbd/cls_rbd_client.h"
-#include "librbd/ImageCtx.h"
-#include "librbd/internal.h"
-#include "librbd/LibrbdWriteback.h"
 
-#include <algorithm>
-#include <string>
-#include <vector>
+#include "AioCompletion.h"
+#include "ImageCtx.h"
+#include "internal.h"
+#include "LibrbdWriteback.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix

--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -4,10 +4,11 @@
 #ifndef __CEPH_LOG_ENTRY_H
 #define __CEPH_LOG_ENTRY_H
 
-#include "include/utime.h"
-#include "common/PrebufferedStreambuf.h"
 #include <pthread.h>
 #include <string>
+
+#include "include/utime.h"
+#include "common/PrebufferedStreambuf.h"
 
 #define CEPH_LOG_ENTRY_PREALLOC 80
 

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -1,18 +1,17 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "Log.h"
-
 #include <errno.h>
 #include <syslog.h>
-
 #include <iostream>
 #include <sstream>
 
+#include "include/assert.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "common/Clock.h"
-#include "include/assert.h"
+
+#include "Log.h"
 
 #define DEFAULT_MAX_NEW    100
 #define DEFAULT_MAX_RECENT 10000

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -4,9 +4,9 @@
 #ifndef __CEPH_LOG_LOG_H
 #define __CEPH_LOG_LOG_H
 
-#include "common/Thread.h"
-
 #include <pthread.h>
+
+#include "common/Thread.h"
 
 #include "Entry.h"
 #include "EntryQueue.h"

--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -1,8 +1,9 @@
 #include <gtest/gtest.h>
 
-#include "log/Log.h"
 #include "common/Clock.h"
 #include "common/PrebufferedStreambuf.h"
+
+#include "Log.h"
 
 using namespace ceph::log;
 

--- a/src/mds/Anchor.h
+++ b/src/mds/Anchor.h
@@ -15,13 +15,13 @@
 #ifndef CEPH_ANCHOR_H
 #define CEPH_ANCHOR_H
 
-#include <string>
-using std::string;
+#include "mds_types.h"
 
-#include "include/types.h"
-#include "mdstypes.h"
+#include <string>
+
 #include "include/buffer.h"
 
+using std::string;
 
 // identifies a anchor table mutation
 

--- a/src/mds/AnchorClient.cc
+++ b/src/mds/AnchorClient.cc
@@ -12,22 +12,20 @@
  * 
  */
 
-#include "AnchorClient.h"
-#include "MDSMap.h"
-#include "LogSegment.h"
-#include "MDS.h"
+#include "common/config.h"
 #include "msg/Messenger.h"
+#include "global/debug.h"
 
 #include "messages/MMDSTableRequest.h"
 
-#include "common/config.h"
+#include "LogSegment.h"
+#include "MDS.h"
 
-#include "global/debug.h"
+#include "AnchorClient.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << ".anchorclient "
-
 
 
 // LOOKUPS

--- a/src/mds/AnchorServer.cc
+++ b/src/mds/AnchorServer.cc
@@ -12,12 +12,14 @@
  * 
  */
 
-#include "AnchorServer.h"
-#include "MDS.h"
 #include "msg/Messenger.h"
+#include "global/debug.h"
+
 #include "messages/MMDSTableRequest.h"
 
-#include "global/debug.h"
+#include "MDS.h"
+
+#include "AnchorServer.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -11,22 +11,20 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "global/global_context.h"
+#include "global/debug.h"
 
+#include "messages/MLock.h"
 
-
-#include "CDentry.h"
 #include "CInode.h"
 #include "CDir.h"
 #include "Anchor.h"
-
 #include "MDS.h"
 #include "MDCache.h"
 #include "Locker.h"
 #include "LogSegment.h"
 
-#include "messages/MLock.h"
-
-#include "global/debug.h"
+#include "CDentry.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -11,25 +11,24 @@
  * Foundation.  See file COPYING.
  * 
  */
-
-
-
 #ifndef CEPH_CDENTRY_H
 #define CEPH_CDENTRY_H
 
+#include "mds_types.h"
+
 #include <string>
 #include <set>
-using namespace std;
 
 #include "include/types.h"
 #include "include/buffer.h"
 #include "include/lru.h"
 #include "include/elist.h"
 #include "include/filepath.h"
-#include "mdstypes.h"
 
 #include "SimpleLock.h"
 #include "LocalLock.h"
+
+using namespace std;
 
 class CInode;
 class CDir;
@@ -42,8 +41,6 @@ class CDentry;
 class LogSegment;
 
 class Session;
-
-
 
 // define an ordering
 bool operator<(const CDentry& l, const CDentry& r);

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -15,33 +15,27 @@
 
 #include "include/types.h"
 
-#include "CDir.h"
-#include "CDentry.h"
-#include "CInode.h"
-#include "Mutation.h"
+#include "include/bloom_filter.hpp"
+#include "include/Context.h"
+#include "include/assert.h"
+#include "common/Clock.h"
+#include "common/config.h"
+#include "osdc/Objecter.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
-#include "MDSMap.h"
+#include "CDentry.h"
+#include "Mutation.h"
 #include "MDS.h"
 #include "MDCache.h"
 #include "Locker.h"
 #include "MDLog.h"
-#include "LogSegment.h"
 
-#include "include/bloom_filter.hpp"
-#include "include/Context.h"
-#include "common/Clock.h"
-
-#include "osdc/Objecter.h"
-
-#include "common/config.h"
-#include "include/assert.h"
-#include "global/debug.h"
+#include "CDir.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << cache->mds->get_nodeid() << ".cache.dir(" << this->dirfrag() << ") "
-
-
 
 // PINS
 //int cdir_pins[CDIR_NUM_PINS] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0 };

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -18,21 +18,21 @@
 #define CEPH_CDIR_H
 
 #include "include/types.h"
-#include "include/buffer.h"
-#include "mdstypes.h"
-#include "common/config.h"
-#include "common/DecayCounter.h"
+#include "mds_types.h"
 
 #include <iostream>
-
 #include <list>
 #include <set>
 #include <map>
 #include <string>
-using namespace std;
 
+#include "include/buffer.h"
+#include "common/config.h"
+#include "common/DecayCounter.h"
 
 #include "CInode.h"
+
+using namespace std;
 
 class CDentry;
 class MDCache;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -16,32 +16,24 @@
 #include <string>
 #include <stdio.h>
 
-#include "CInode.h"
-#include "CDir.h"
-#include "CDentry.h"
+#include "include/assert.h"
+#include "common/Clock.h"
+#include "osdc/Objecter.h"
+#include "global/global_context.h"
 
+#include "messages/MLock.h"
+#include "messages/MClientCaps.h"
+
+#include "events/EUpdate.h"
+
+#include "CDir.h"
 #include "MDS.h"
 #include "MDCache.h"
 #include "MDLog.h"
 #include "Locker.h"
 #include "Mutation.h"
 
-#include "events/EUpdate.h"
-
-#include "osdc/Objecter.h"
-
-#include "snap.h"
-
-#include "LogSegment.h"
-
-#include "common/Clock.h"
-
-#include "messages/MLock.h"
-#include "messages/MClientCaps.h"
-
-#include "common/config.h"
-#include "global/global_context.h"
-#include "include/assert.h"
+#include "CInode.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -17,17 +17,22 @@
 #ifndef CEPH_CINODE_H
 #define CEPH_CINODE_H
 
-#include "common/config.h"
+#include "include/types.h"
+#include "mds_types.h"
+
+#include <list>
+#include <vector>
+#include <set>
+#include <map>
+#include <iostream>
+
 #include "include/dlist.h"
 #include "include/elist.h"
-#include "include/types.h"
 #include "include/lru.h"
-
+#include "common/config.h"
 #include "global/debug.h"
 
-#include "mdstypes.h"
 #include "flock.h"
-
 #include "CDentry.h"
 #include "SimpleLock.h"
 #include "ScatterLock.h"
@@ -35,11 +40,6 @@
 #include "Capability.h"
 #include "snap.h"
 
-#include <list>
-#include <vector>
-#include <set>
-#include <map>
-#include <iostream>
 using namespace std;
 
 class Context;

--- a/src/mds/Dumper.cc
+++ b/src/mds/Dumper.cc
@@ -16,14 +16,16 @@
 #define _BACKWARD_BACKWARD_WARNING_H   // make gcc 4.3 shut up about hash_*
 #endif
 
+#include "mds_types.h"
+
 #include "include/compat.h"
 #include "common/entity_name.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
-#include "mds/Dumper.h"
-#include "mds/mdstypes.h"
 #include "mon/MonClient.h"
-#include "osdc/Journaler.h"
+#include "global/debug.h"
+
+#include "Dumper.h"
 
 Dumper::~Dumper()
 {

--- a/src/mds/Dumper.h
+++ b/src/mds/Dumper.h
@@ -17,7 +17,6 @@
 #include "osd/OSDMap.h"
 #include "osdc/Objecter.h"
 #include "osdc/Journaler.h"
-#include "msg/Dispatcher.h"
 #include "msg/Messenger.h"
 #include "auth/Auth.h"
 #include "global/global_context.h"

--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -12,13 +12,14 @@
  * 
  */
 
-#include "InoTable.h"
-#include "MDS.h"
-
 #include "include/types.h"
 
 #include "common/config.h"
 #include "global/debug.h"
+
+#include "MDS.h"
+
+#include "InoTable.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -16,8 +16,9 @@
 #ifndef CEPH_INOTABLE_H
 #define CEPH_INOTABLE_H
 
-#include "MDSTable.h"
 #include "include/interval_set.h"
+
+#include "MDSTable.h"
 
 class MDS;
 

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -12,50 +12,43 @@
  * 
  */
 
+#include "include/types.h"
 
-#include "MDS.h"
-#include "MDCache.h"
-#include "Locker.h"
-#include "CInode.h"
-#include "CDir.h"
-#include "CDentry.h"
-#include "Mutation.h"
-
-#include "MDLog.h"
-#include "MDSMap.h"
+#include <errno.h>
 
 #include "include/filepath.h"
+#include "common/config.h"
+#include "msg/Messenger.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
 #include "events/EString.h"
 #include "events/EUpdate.h"
 #include "events/EOpen.h"
 
-#include "msg/Messenger.h"
-
 #include "messages/MGenericMessage.h"
 #include "messages/MDiscover.h"
 #include "messages/MDiscoverReply.h"
-
 #include "messages/MDirUpdate.h"
-
 #include "messages/MInodeFileCaps.h"
-
 #include "messages/MLock.h"
 #include "messages/MClientLease.h"
 #include "messages/MDentryUnlink.h"
-
 #include "messages/MClientRequest.h"
 #include "messages/MClientReply.h"
 #include "messages/MClientCaps.h"
 #include "messages/MClientCapRelease.h"
-
 #include "messages/MMDSSlaveRequest.h"
 
-#include <errno.h>
+#include "MDS.h"
+#include "MDCache.h"
+#include "CInode.h"
+#include "CDir.h"
+#include "CDentry.h"
+#include "Mutation.h"
+#include "MDLog.h"
 
-#include "common/config.h"
-#include "global/debug.h"
-
+#include "Locker.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -20,6 +20,9 @@
 #include <map>
 #include <list>
 #include <set>
+
+#include "SimpleLock.h"
+
 using std::map;
 using std::list;
 using std::set;
@@ -53,8 +56,6 @@ class SimpleLock;
 class ScatterLock;
 class LocalLock;
 class MDCache;
-
-#include "SimpleLock.h"
 
 class Locker {
 private:

--- a/src/mds/LogEvent.cc
+++ b/src/mds/LogEvent.cc
@@ -13,10 +13,6 @@
  */
 
 #include "common/config.h"
-#include "LogEvent.h"
-
-#include "MDS.h"
-
 #include "global/debug.h"
 
 // events i know of
@@ -40,6 +36,9 @@
 #include "events/ETableClient.h"
 #include "events/ETableServer.h"
 
+#include "MDS.h"
+
+#include "LogEvent.h"
 
 LogEvent *LogEvent::decode(bufferlist& bl)
 {

--- a/src/mds/LogEvent.h
+++ b/src/mds/LogEvent.h
@@ -15,6 +15,14 @@
 #ifndef CEPH_LOGEVENT_H
 #define CEPH_LOGEVENT_H
 
+#include <string>
+
+#include "include/buffer.h"
+#include "include/Context.h"
+#include "include/utime.h"
+
+using namespace std;
+
 #define EVENT_STRING       1
 
 #define EVENT_SUBTREEMAP   2
@@ -37,14 +45,6 @@
 #define EVENT_TABLESERVER  43
 
 #define EVENT_SUBTREEMAP_TEST   50
-
-
-#include <string>
-using namespace std;
-
-#include "include/buffer.h"
-#include "include/Context.h"
-#include "include/utime.h"
 
 class MDS;
 class LogSegment;

--- a/src/mds/LogSegment.h
+++ b/src/mds/LogSegment.h
@@ -15,16 +15,19 @@
 #ifndef CEPH_LOGSEGMENT_H
 #define CEPH_LOGSEGMENT_H
 
+#include "mds_types.h"
+
+#include <ext/hash_set>
+
 #include "include/dlist.h"
 #include "include/elist.h"
 #include "include/interval_set.h"
 #include "include/Context.h"
-#include "mdstypes.h"
+
 #include "CInode.h"
 #include "CDentry.h"
 #include "CDir.h"
 
-#include <ext/hash_set>
 using __gnu_cxx::hash_set;
 
 class CDir;

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -12,31 +12,31 @@
  *
  */
 
-#include "mdstypes.h"
-
-#include "MDBalancer.h"
-#include "MDS.h"
-#include "mon/MonClient.h"
-#include "MDSMap.h"
-#include "CInode.h"
-#include "CDir.h"
-#include "MDCache.h"
-#include "Migrator.h"
-
-#include "include/Context.h"
-#include "msg/Messenger.h"
-#include "messages/MHeartbeat.h"
-#include "messages/MMDSLoadTargets.h"
+#include "mds_types.h"
 
 #include <fstream>
 #include <iostream>
 #include <vector>
-#include <map>
+
+#include "include/Context.h"
+#include "common/config.h"
+#include "msg/Messenger.h"
+#include "global/global_context.h"
+#include "global/debug.h"
+
+#include "messages/MHeartbeat.h"
+#include "messages/MMDSLoadTargets.h"
+
+#include "MDS.h"
+#include "mon/MonClient.h"
+#include "CDir.h"
+#include "MDCache.h"
+#include "Migrator.h"
+
+#include "MDBalancer.h"
+
 using std::map;
 using std::vector;
-
-#include "common/config.h"
-#include "global/debug.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef DOUT_COND

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -17,15 +17,16 @@
 #ifndef CEPH_MDBALANCER_H
 #define CEPH_MDBALANCER_H
 
+#include "include/types.h"
+
 #include <list>
 #include <map>
-using std::list;
-using std::map;
 
-#include "include/types.h"
 #include "common/Clock.h"
 #include "CInode.h"
 
+using std::list;
+using std::map;
 
 class MDS;
 class Message;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12,6 +12,10 @@
  * 
  */
 
+extern struct ceph_file_layout g_default_file_layout;
+
+#include "mds_types.h"
+
 #include <errno.h>
 #include <fstream>
 #include <iostream>
@@ -19,34 +23,18 @@
 #include <string>
 #include <map>
 
-#include "MDCache.h"
-#include "MDS.h"
-#include "Server.h"
-#include "Locker.h"
-#include "MDLog.h"
-#include "MDBalancer.h"
-#include "Migrator.h"
-
-#include "AnchorClient.h"
-#include "SnapClient.h"
-
-#include "MDSMap.h"
-
-#include "CInode.h"
-#include "CDir.h"
-
-#include "Mutation.h"
-
 #include "include/ceph_fs.h"
-#include "include/filepath.h"
-
-#include "msg/Message.h"
-#include "msg/Messenger.h"
-
+#include "include/assert.h"
+#include "common/Timer.h"
 #include "common/perf_counters.h"
 #include "common/MemoryModel.h"
+#include "common/config.h"
+#include "msg/Message.h"
+#include "msg/Messenger.h"
 #include "osdc/Journaler.h"
 #include "osdc/Filer.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
 #include "events/ESubtreeMap.h"
 #include "events/EUpdate.h"
@@ -86,18 +74,22 @@
 
 #include "messages/MMDSFragmentNotify.h"
 
+#include "MDS.h"
+#include "Server.h"
+#include "Locker.h"
+#include "MDLog.h"
+#include "MDBalancer.h"
+#include "Migrator.h"
+#include "Mutation.h"
+
+#include "AnchorClient.h"
+#include "SnapClient.h"
 
 #include "InoTable.h"
 
-#include "common/Timer.h"
+#include "MDCache.h"
 
 using namespace std;
-
-extern struct ceph_file_layout g_default_file_layout;
-
-#include "common/config.h"
-#include "include/assert.h"
-#include "global/debug.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -18,6 +18,7 @@
 #define CEPH_MDCACHE_H
 
 #include "include/types.h"
+
 #include "include/filepath.h"
 
 #include "CInode.h"

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -12,22 +12,21 @@
  * 
  */
 
-#include "MDLog.h"
+#include "include/assert.h"
+#include "common/entity_name.h"
+#include "common/perf_counters.h"
+#include "common/config.h"
+#include "common/errno.h"
+#include "osdc/Journaler.h"
+#include "events/ESubtreeMap.h"
+#include "global/global_context.h"
+#include "global/debug.h"
+
 #include "MDS.h"
 #include "MDCache.h"
 #include "LogEvent.h"
 
-#include "osdc/Journaler.h"
-
-#include "common/entity_name.h"
-#include "common/perf_counters.h"
-
-#include "events/ESubtreeMap.h"
-
-#include "common/config.h"
-#include "common/errno.h"
-#include "include/assert.h"
-#include "global/debug.h"
+#include "MDLog.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef DOUT_COND

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -16,6 +16,19 @@
 #ifndef CEPH_MDLOG_H
 #define CEPH_MDLOG_H
 
+#include "include/types.h"
+
+#include <list>
+#include <map>
+
+#include "include/Context.h"
+#include "common/Thread.h"
+#include "common/Cond.h"
+
+#include "LogSegment.h"
+
+using std::map;
+
 enum {
   l_mdl_first = 5000,
   l_mdl_evadd,
@@ -37,27 +50,12 @@ enum {
   l_mdl_last,
 };
 
-#include "include/types.h"
-#include "include/Context.h"
-
-#include "common/Thread.h"
-#include "common/Cond.h"
-
-#include "LogSegment.h"
-
-#include <list>
-
 class Journaler;
 class LogEvent;
 class MDS;
 class LogSegment;
 class ESubtreeMap;
-
 class PerfCounters;
-
-#include <map>
-using std::map;
-
 
 class MDLog {
 public:

--- a/src/mds/MDS.h
+++ b/src/mds/MDS.h
@@ -17,11 +17,10 @@
 #ifndef CEPH_MDS_H
 #define CEPH_MDS_H
 
-#include "mdstypes.h"
-
-#include "msg/Dispatcher.h"
-#include "include/CompatSet.h"
 #include "include/types.h"
+#include "mds_types.h"
+
+#include "include/CompatSet.h"
 #include "include/Context.h"
 #include "common/DecayCounter.h"
 #include "common/perf_counters.h"
@@ -29,14 +28,12 @@
 #include "common/Cond.h"
 #include "common/Timer.h"
 #include "common/LogClient.h"
+#include "msg/Dispatcher.h"
 
 #include "MDSMap.h"
-
 #include "SessionMap.h"
 
-
 #define CEPH_MDS_PROTOCOL    14 /* cluster internal */
-
 
 enum {
   l_mds_first = 2000,

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -11,13 +11,11 @@
  * Foundation.  See file COPYING.
  * 
  */
-
+#include <sstream>
 
 #include "MDSMap.h"
 
-#include <sstream>
 using std::stringstream;
-
 
 // features
 CompatSet get_mdsmap_compat_set() {

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -16,23 +16,21 @@
 #ifndef CEPH_MDSMAP_H
 #define CEPH_MDSMAP_H
 
-#include <errno.h>
-
 #include "include/types.h"
-#include "common/Clock.h"
-#include "msg/Message.h"
 
+#include <errno.h>
 #include <set>
 #include <map>
 #include <string>
-using namespace std;
-
-#include "common/config.h"
 
 #include "include/CompatSet.h"
+#include "common/config.h"
 #include "common/Formatter.h"
-
+#include "common/Clock.h"
+#include "msg/Message.h"
 #include "global/global_context.h"
+
+using namespace std;
 
 /*
 

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -12,24 +12,22 @@
  * 
  */
 
-#include "MDSTable.h"
+#include "mds_types.h"
+
+#include "include/assert.h"
+#include "common/config.h"
+#include "osdc/Filer.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
 #include "MDS.h"
 #include "MDLog.h"
 
-#include "osdc/Filer.h"
-
-#include "include/types.h"
-
-#include "common/config.h"
-#include "include/assert.h"
-#include "global/debug.h"
-
+#include "MDSTable.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << "." << table_name << ": "
-
 
 class C_MT_Save : public Context {
   MDSTable *ida;

--- a/src/mds/MDSTable.h
+++ b/src/mds/MDSTable.h
@@ -15,8 +15,9 @@
 #ifndef CEPH_MDSTABLE_H
 #define CEPH_MDSTABLE_H
 
-#include "mdstypes.h"
+#include "mds_types.h"
 #include "mds_table_types.h"
+
 #include "include/buffer.h"
 #include "include/Context.h"
 

--- a/src/mds/MDSTableClient.cc
+++ b/src/mds/MDSTableClient.cc
@@ -12,24 +12,22 @@
  * 
  */
 
+#include "mds_types.h"
+
 #include <iostream>
 
-#include "MDSMap.h"
-
-#include "include/Context.h"
+#include "common/config.h"
 #include "msg/Messenger.h"
+#include "global/debug.h"
 
-#include "MDS.h"
-#include "MDLog.h"
-#include "LogSegment.h"
-
-#include "MDSTableClient.h"
 #include "events/ETableClient.h"
 
 #include "messages/MMDSTableRequest.h"
 
-#include "common/config.h"
-#include "global/debug.h"
+#include "MDS.h"
+#include "MDLog.h"
+
+#include "MDSTableClient.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix

--- a/src/mds/MDSTableServer.cc
+++ b/src/mds/MDSTableServer.cc
@@ -11,16 +11,18 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "mds_types.h"
 
-#include "MDSTableServer.h"
-#include "MDS.h"
-#include "MDLog.h"
 #include "msg/Messenger.h"
+#include "global/debug.h"
 
 #include "messages/MMDSTableRequest.h"
 #include "events/ETableServer.h"
 
-#include "global/debug.h"
+#include "MDS.h"
+#include "MDLog.h"
+
+#include "MDSTableServer.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -11,21 +11,12 @@
  * Foundation.  See file COPYING.
  * 
  */
-
-#include "MDS.h"
-#include "MDCache.h"
-#include "CInode.h"
-#include "CDir.h"
-#include "CDentry.h"
-#include "Migrator.h"
-#include "Locker.h"
-#include "Server.h"
-
-#include "MDBalancer.h"
-#include "MDLog.h"
-#include "MDSMap.h"
+#include "mds_types.h"
 
 #include "include/filepath.h"
+#include "common/config.h"
+#include "msg/Messenger.h"
+#include "global/debug.h"
 
 #include "events/EString.h"
 #include "events/EExport.h"
@@ -33,10 +24,7 @@
 #include "events/EImportFinish.h"
 #include "events/ESessions.h"
 
-#include "msg/Messenger.h"
-
 #include "messages/MClientCaps.h"
-
 #include "messages/MExportDirDiscover.h"
 #include "messages/MExportDirDiscoverAck.h"
 #include "messages/MExportDirCancel.h"
@@ -47,10 +35,20 @@
 #include "messages/MExportDirNotify.h"
 #include "messages/MExportDirNotifyAck.h"
 #include "messages/MExportDirFinish.h"
-
 #include "messages/MExportCaps.h"
 #include "messages/MExportCapsAck.h"
 
+#include "MDS.h"
+#include "MDCache.h"
+#include "CInode.h"
+#include "CDir.h"
+#include "CDentry.h"
+#include "Locker.h"
+#include "Server.h"
+#include "MDBalancer.h"
+#include "MDLog.h"
+
+#include "Migrator.h"
 
 /*
  * this is what the dir->dir_auth values look like
@@ -71,9 +69,6 @@
  * which implies:
  *  - auth bit is set if i am listed as first _or_ second dir_auth.
  */
-
-#include "common/config.h"
-#include "global/debug.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef DOUT_COND

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -22,10 +22,10 @@
 #include <map>
 #include <list>
 #include <set>
+
 using std::map;
 using std::list;
 using std::set;
-
 
 class MDS;
 class CDir;
@@ -47,7 +47,6 @@ class MExportCaps;
 class MExportCapsAck;
 
 class EImportStart;
-
 
 class Migrator {
 private:

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -11,14 +11,13 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "messages/MMDSSlaveRequest.h"
+#include "messages/MClientRequest.h"
 
-#include "Mutation.h"
 #include "ScatterLock.h"
 #include "CDir.h"
 
-#include "messages/MClientRequest.h"
-#include "messages/MMDSSlaveRequest.h"
-
+#include "Mutation.h"
 
 // Mutation
 

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -15,10 +15,10 @@
 #ifndef CEPH_MDS_MUTATION_H
 #define CEPH_MDS_MUTATION_H
 
+#include "mds_types.h"
+
 #include "include/interval_set.h"
 #include "include/elist.h"
-
-#include "mdstypes.h"
 
 #include "SimpleLock.h"
 #include "Capability.h"

--- a/src/mds/Resetter.cc
+++ b/src/mds/Resetter.cc
@@ -12,11 +12,13 @@
  * 
  */
 
-#include "mds/Resetter.h"
-#include "osdc/Journaler.h"
-#include "mds/mdstypes.h"
+#include "mds_types.h"
+
 #include "mon/MonClient.h"
-#include "mds/events/EResetJournal.h"
+
+#include "events/EResetJournal.h"
+
+#include "Resetter.h"
 
 Resetter::~Resetter()
 {

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -12,8 +12,40 @@
  * 
  */
 
+#include "mds_types.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <list>
+#include <iostream>
+
+#include "include/filepath.h"
+#include "include/compat.h"
+#include "common/Timer.h"
+#include "common/perf_counters.h"
+#include "common/config.h"
+#include "msg/Messenger.h"
+#include "osd/OSDMap.h"
+#include "global/debug.h"
+
+#include "messages/MClientSession.h"
+#include "messages/MClientRequest.h"
+#include "messages/MClientReply.h"
+#include "messages/MClientReconnect.h"
+#include "messages/MClientCaps.h"
+#include "messages/MClientSnap.h"
+#include "messages/MMDSSlaveRequest.h"
+#include "messages/MLock.h"
+#include "messages/MDentryUnlink.h"
+
+#include "events/EString.h"
+#include "events/EUpdate.h"
+#include "events/ESlaveUpdate.h"
+#include "events/ESession.h"
+#include "events/EOpen.h"
+#include "events/ECommitted.h"
+
 #include "MDS.h"
-#include "Server.h"
 #include "Locker.h"
 #include "MDCache.h"
 #include "MDLog.h"
@@ -24,42 +56,9 @@
 #include "SnapClient.h"
 #include "Mutation.h"
 
-#include "msg/Messenger.h"
+#include "Server.h"
 
-#include "messages/MClientSession.h"
-#include "messages/MClientRequest.h"
-#include "messages/MClientReply.h"
-#include "messages/MClientReconnect.h"
-#include "messages/MClientCaps.h"
-#include "messages/MClientSnap.h"
-
-#include "messages/MMDSSlaveRequest.h"
-
-#include "messages/MLock.h"
-
-#include "messages/MDentryUnlink.h"
-
-#include "events/EString.h"
-#include "events/EUpdate.h"
-#include "events/ESlaveUpdate.h"
-#include "events/ESession.h"
-#include "events/EOpen.h"
-#include "events/ECommitted.h"
-
-#include "include/filepath.h"
-#include "common/Timer.h"
-#include "common/perf_counters.h"
-#include "include/compat.h"
-
-#include <errno.h>
-#include <fcntl.h>
-
-#include <list>
-#include <iostream>
 using namespace std;
-
-#include "common/config.h"
-#include "global/debug.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -12,19 +12,19 @@
  * 
  */
 
+#include "include/assert.h"
+#include "common/config.h"
+#include "osdc/Filer.h"
+#include "global/debug.h"
+
 #include "MDS.h"
 #include "MDCache.h"
-#include "SessionMap.h"
-#include "osdc/Filer.h"
 
-#include "common/config.h"
-#include "include/assert.h"
-#include "global/debug.h"
+#include "SessionMap.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << ".sessionmap "
-
 
 void SessionMap::dump()
 {

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -11,29 +11,26 @@
  * Foundation.  See file COPYING.
  * 
  */
-
 #ifndef CEPH_MDS_SESSIONMAP_H
 #define CEPH_MDS_SESSIONMAP_H
 
-#include <set>
-using std::set;
+#include "mds_types.h"
 
+#include <set>
 #include <ext/hash_map>
-using __gnu_cxx::hash_map;
 
 #include "include/Context.h"
 #include "include/xlist.h"
 #include "include/elist.h"
 #include "include/interval_set.h"
-#include "mdstypes.h"
-
-class CInode;
-class MDRequest;
+#include "msg/Message.h"
+#include "global/global_context.h"
 
 #include "CInode.h"
 #include "Capability.h"
-#include "msg/Message.h"
 
+using std::set;
+using __gnu_cxx::hash_map;
 
 /* 
  * session

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -16,6 +16,8 @@
 #ifndef CEPH_SIMPLELOCK_H
 #define CEPH_SIMPLELOCK_H
 
+#include "mds_types.h"
+
 // -- lock types --
 // see CEPH_LOCK_*
 

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -11,21 +11,21 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "mds_types.h"
 
-#include "SnapServer.h"
-#include "MDS.h"
-#include "osd/OSDMap.h"
+#include "include/assert.h"
+#include "common/config.h"
+#include "msg/Messenger.h"
 #include "mon/MonClient.h"
+#include "osd/OSDMap.h"
+#include "global/debug.h"
 
-#include "include/types.h"
 #include "messages/MMDSTableRequest.h"
 #include "messages/MRemoveSnaps.h"
 
-#include "msg/Messenger.h"
+#include "MDS.h"
 
-#include "common/config.h"
-#include "include/assert.h"
-#include "global/debug.h"
+#include "SnapServer.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix

--- a/src/mds/flock.cc
+++ b/src/mds/flock.cc
@@ -1,10 +1,10 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
-#include <errno.h>
+#include "mds_types.h"
 
 #include "global/debug.h"
-#include "mdstypes.h"
-#include "mds/flock.h"
+
+#include "flock.h"
 
 #define dout_subsys ceph_subsys_mds
 

--- a/src/mds/flock.h
+++ b/src/mds/flock.h
@@ -3,11 +3,11 @@
 #ifndef CEPH_MDS_FLOCK_H
 #define CEPH_MDS_FLOCK_H
 
+#include "mds_types.h"
+
 #include <errno.h>
 
 #include "common/debug.h"
-#include "mdstypes.h"
-
 
 inline ostream& operator<<(ostream& out, ceph_filelock& l) {
   out << "start: " << l.start << ", length: " << l.length

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -14,6 +14,8 @@
 
 #include "common/config.h"
 #include "osdc/Journaler.h"
+#include "global/debug.h"
+
 #include "events/EString.h"
 #include "events/ESubtreeMap.h"
 #include "events/ESession.h"
@@ -35,9 +37,6 @@
 #include "events/ETableClient.h"
 #include "events/ETableServer.h"
 
-
-#include "LogSegment.h"
-
 #include "MDS.h"
 #include "MDLog.h"
 #include "MDCache.h"
@@ -51,7 +50,6 @@
 
 #include "Locker.h"
 
-#include "global/debug.h"
 
 #define dout_subsys ceph_subsys_mds
 #undef DOUT_COND

--- a/src/mds/locks.c
+++ b/src/mds/locks.c
@@ -15,6 +15,7 @@ typedef char bool;
 #include <fcntl.h>
 
 #include "include/ceph_fs.h"
+
 #include "locks.h"
 
 static const struct sm_state_t simplelock[LOCK_MAX] = {

--- a/src/mds/mds_types.h
+++ b/src/mds/mds_types.h
@@ -3,25 +3,27 @@
 #ifndef CEPH_MDSTYPES_H
 #define CEPH_MDSTYPES_H
 
+#include "include/types.h"
+
+#include <boost/pool/pool.hpp>
 #include <inttypes.h>
 #include <math.h>
 #include <ostream>
 #include <set>
 #include <map>
-using namespace std;
 
+#include "include/Context.h"
+#include "include/assert.h"
+#include "include/frag.h"
+#include "include/xlist.h"
 #include "common/config.h"
 #include "common/Clock.h"
 #include "common/DecayCounter.h"
-#include "include/Context.h"
-
-#include "include/frag.h"
-#include "include/xlist.h"
+#include "global/global_context.h"
 
 #include "inode_backtrace.h"
 
-#include <boost/pool/pool.hpp>
-#include "include/assert.h"
+using namespace std;
 
 #define CEPH_FS_ONDISK_MAGIC "ceph fs volume v011"
 

--- a/src/mds/snap.cc
+++ b/src/mds/snap.cc
@@ -11,13 +11,15 @@
  * Foundation.  See file COPYING.
  * 
  */
-
-#include "snap.h"
-#include "MDCache.h"
-#include "MDS.h"
+#include "mds_types.h"
 
 #include "messages/MClientSnap.h"
 #include "global/debug.h"
+
+#include "MDS.h"
+#include "MDCache.h"
+
+#include "snap.h"
 
 /*
  * SnapRealm

--- a/src/mds/snap.h
+++ b/src/mds/snap.h
@@ -15,7 +15,8 @@
 #ifndef CEPH_MDS_SNAP_H
 #define CEPH_MDS_SNAP_H
 
-#include "mdstypes.h"
+#include "mds_types.h"
+
 #include "include/xlist.h"
 #include "include/elist.h"
 #include "common/snap_types.h"

--- a/src/messages/MCacheExpire.h
+++ b/src/messages/MCacheExpire.h
@@ -15,7 +15,7 @@
 #ifndef CEPH_MCACHEEXPIRE_H
 #define CEPH_MCACHEEXPIRE_H
 
-#include "mds/mdstypes.h"
+#include "mds/mds_types.h"
 
 class MCacheExpire : public Message {
   __s32 from;

--- a/src/messages/MClientReconnect.h
+++ b/src/messages/MClientReconnect.h
@@ -15,10 +15,10 @@
 #ifndef CEPH_MCLIENTRECONNECT_H
 #define CEPH_MCLIENTRECONNECT_H
 
-#include "msg/Message.h"
-#include "mds/mdstypes.h"
-#include "include/ceph_features.h"
+#include "mds/mds_types.h"
 
+#include "include/ceph_features.h"
+#include "msg/Message.h"
 
 class MClientReconnect : public Message {
 

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -33,15 +33,15 @@
  *  
  */
 
-#include "msg/Message.h"
-#include "include/filepath.h"
-#include "mds/mdstypes.h"
+#include "mds/mds_types.h"
 
 #include <sys/types.h>
 #include <utime.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include "include/filepath.h"
+#include "msg/Message.h"
 
 // metadata ops.
 

--- a/src/messages/MMDSSlaveRequest.h
+++ b/src/messages/MMDSSlaveRequest.h
@@ -16,8 +16,11 @@
 #ifndef CEPH_MMDSSLAVEREQUEST_H
 #define CEPH_MMDSSLAVEREQUEST_H
 
+#include "mds/mds_types.h"
+
+#include "include/filepath.h"
+
 #include "msg/Message.h"
-#include "mds/mdstypes.h"
 
 class MMDSSlaveRequest : public Message {
  public:

--- a/src/messages/MMonElection.h
+++ b/src/messages/MMonElection.h
@@ -16,6 +16,7 @@
 #ifndef CEPH_MMONELECTION_H
 #define CEPH_MMONELECTION_H
 
+#include "include/ceph_features.h"
 #include "msg/Message.h"
 #include "mon/MonMap.h"
 

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -12,33 +12,34 @@
  * 
  */
 
+#include "mon_types.h"
+#include "osd/osd_types.h"
+
 #include <sstream>
 
-#include "AuthMonitor.h"
-#include "Monitor.h"
-#include "MonitorStore.h"
+#include "include/str_list.h"
+#include "include/assert.h"
+#include "common/config.h"
+#include "common/Timer.h"
+#include "auth/AuthServiceHandler.h"
+#include "auth/KeyRing.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
 #include "messages/MMonCommand.h"
 #include "messages/MAuth.h"
 #include "messages/MAuthReply.h"
 #include "messages/MMonGlobalID.h"
 
-#include "include/str_list.h"
-#include "common/Timer.h"
+#include "Monitor.h"
+#include "MonitorStore.h"
 
-#include "auth/AuthServiceHandler.h"
-#include "auth/KeyRing.h"
-
-#include "osd/osd_types.h"
-
-#include "common/config.h"
-#include "include/assert.h"
-
-#include "global/debug.h"
+#include "AuthMonitor.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, paxos->get_version())
+
 static ostream& _prefix(std::ostream *_dout, Monitor *mon, version_t v) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
 		<< "(" << mon->get_state_name()

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -15,15 +15,18 @@
 #ifndef CEPH_AUTHMONITOR_H
 #define CEPH_AUTHMONITOR_H
 
+#include "mon_types.h"
+
 #include <map>
 #include <set>
-using namespace std;
 
 #include "include/ceph_features.h"
-#include "include/types.h"
 #include "msg/Messenger.h"
+
 #include "PaxosService.h"
-#include "mon/Monitor.h"
+#include "Monitor.h"
+
+using namespace std;
 
 class MMonCommand;
 class MAuth;

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -11,19 +11,20 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "mon_types.h"
 
-#include "Elector.h"
-#include "Monitor.h"
+#include "include/assert.h"
+#include "common/config.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
-#include "common/Timer.h"
-#include "MonitorStore.h"
-#include "MonmapMonitor.h"
 #include "messages/MMonElection.h"
 
-#include "common/config.h"
-#include "include/assert.h"
+#include "Monitor.h"
+#include "MonitorStore.h"
+#include "MonmapMonitor.h"
 
-#include "global/debug.h"
+#include "Elector.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -16,15 +16,15 @@
 #ifndef CEPH_MON_ELECTOR_H
 #define CEPH_MON_ELECTOR_H
 
-#include <map>
-using namespace std;
+#include "mon_types.h"
 
-#include "include/types.h"
-#include "msg/Message.h"
+#include <map>
 
 #include "include/Context.h"
-
 #include "common/Timer.h"
+#include "msg/Message.h"
+
+using namespace std;
 
 class Monitor;
 

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -11,26 +11,26 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "mon_types.h"
+#include "osd/osd_types.h"
 
 #include <sstream>
 #include <syslog.h>
 
-#include "LogMonitor.h"
+#include "include/assert.h"
+#include "common/Timer.h"
+#include "common/errno.h"
+#include "common/config.h"
+#include "global/global_context.h"
+#include "global/debug.h"
+
+#include "messages/MMonCommand.h"
+#include "messages/MLogAck.h"
+
 #include "Monitor.h"
 #include "MonitorStore.h"
 
-#include "messages/MMonCommand.h"
-#include "messages/MLog.h"
-#include "messages/MLogAck.h"
-
-#include "common/Timer.h"
-
-#include "osd/osd_types.h"
-#include "common/errno.h"
-#include "common/config.h"
-#include "include/assert.h"
-
-#include "global/debug.h"
+#include "LogMonitor.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -15,16 +15,18 @@
 #ifndef CEPH_LOGMONITOR_H
 #define CEPH_LOGMONITOR_H
 
+#include "mon_types.h"
+
 #include <map>
 #include <set>
-using namespace std;
-
-#include "include/types.h"
-#include "msg/Messenger.h"
-#include "PaxosService.h"
 
 #include "common/LogEntry.h"
+#include "msg/Messenger.h"
 #include "messages/MLog.h"
+
+#include "PaxosService.h"
+
+using namespace std;
 
 class MMonCommand;
 

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -11,31 +11,30 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "mon_types.h"
 
+#include <sstream>
 
-#include "MDSMonitor.h"
-#include "Monitor.h"
-#include "MonitorStore.h"
-#include "OSDMonitor.h"
-
+#include "include/assert.h"
+#include "common/config.h"
 #include "common/strtol.h"
 #include "common/ceph_argparse.h"
+#include "common/perf_counters.h"
+#include "common/Timer.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
 #include "messages/MMDSMap.h"
 #include "messages/MMDSBeacon.h"
 #include "messages/MMDSLoadTargets.h"
 #include "messages/MMonCommand.h"
-
 #include "messages/MGenericMessage.h"
 
-#include "common/perf_counters.h"
-#include "common/Timer.h"
+#include "Monitor.h"
+#include "MonitorStore.h"
+#include "OSDMonitor.h"
 
-#include <sstream>
-
-#include "common/config.h"
-#include "include/assert.h"
-#include "global/debug.h"
+#include "MDSMonitor.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -18,19 +18,20 @@
 #ifndef CEPH_MDSMONITOR_H
 #define CEPH_MDSMONITOR_H
 
+#include "mon_types.h"
+
 #include <map>
 #include <set>
-using namespace std;
 
-#include "include/types.h"
 #include "msg/Messenger.h"
-
 #include "mds/MDSMap.h"
+
+#include "messages/MMDSBeacon.h"
 
 #include "PaxosService.h"
 #include "Session.h"
 
-#include "messages/MMDSBeacon.h"
+using namespace std;
 
 class MMDSGetMap;
 class MMonCommand;

--- a/src/mon/MonCaps.cc
+++ b/src/mon/MonCaps.cc
@@ -11,14 +11,16 @@
  * Foundation.  See file COPYING.
  *
  */
+#include "mon_types.h"
 
 #include <errno.h>
+
+#include "include/ceph_features.h"
 #include "common/config.h"
 #include "common/debug.h"
 #include "common/Formatter.h"
+
 #include "MonCaps.h"
-#include "mon_types.h"
-#include "include/ceph_features.h"
 
 #define dout_subsys ceph_subsys_auth
 

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -12,7 +12,18 @@
  * 
  */
 
+#include "include/str_list.h"
+#include "include/addr_parsing.h"
+#include "common/ConfUtils.h"
+#include "common/ceph_argparse.h"
+#include "common/errno.h"
+#include "common/LogClient.h"
+#include "common/config.h"
+#include "auth/Auth.h"
+#include "auth/KeyRing.h"
+#include "auth/AuthMethodList.h"
 #include "msg/SimpleMessenger.h"
+
 #include "messages/MMonGetMap.h"
 #include "messages/MMonGetVersion.h"
 #include "messages/MMonGetVersionReply.h"
@@ -22,23 +33,8 @@
 
 #include "messages/MMonSubscribe.h"
 #include "messages/MMonSubscribeAck.h"
-#include "common/ConfUtils.h"
-#include "common/ceph_argparse.h"
-#include "common/errno.h"
-#include "common/LogClient.h"
 
 #include "MonClient.h"
-#include "MonMap.h"
-
-#include "auth/Auth.h"
-#include "auth/KeyRing.h"
-#include "auth/AuthMethodList.h"
-
-#include "include/str_list.h"
-#include "include/addr_parsing.h"
-
-#include "common/config.h"
-
 
 #define dout_subsys ceph_subsys_monc
 #undef dout_prefix

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -15,22 +15,19 @@
 #ifndef CEPH_MONCLIENT_H
 #define CEPH_MONCLIENT_H
 
-#include "msg/Dispatcher.h"
-#include "msg/Messenger.h"
-
-#include "MonMap.h"
+#include <memory>
 
 #include "common/Timer.h"
 #include "common/Finisher.h"
-
+#include "common/SimpleRNG.h"
+#include "msg/Dispatcher.h"
+#include "msg/Messenger.h"
 #include "auth/AuthClientHandler.h"
 #include "auth/RotatingKeyRing.h"
 
 #include "messages/MMonSubscribe.h"
 
-#include "common/SimpleRNG.h"
-
-#include <memory>
+#include "MonMap.h"
 
 class MonMap;
 class MMonMap;

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -1,18 +1,16 @@
 
-#include "MonMap.h"
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 
-#include "common/Formatter.h"
-
 #include "include/ceph_features.h"
 #include "include/addr_parsing.h"
+#include "common/Formatter.h"
 #include "common/ceph_argparse.h"
 #include "common/errno.h"
-
 #include "common/debug.h"
+
+#include "MonMap.h"
 
 using ceph::Formatter;
 

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -15,11 +15,10 @@
 #ifndef CEPH_MONMAP_H
 #define CEPH_MONMAP_H
 
-#include "include/err.h"
-
-#include "msg/Message.h"
 #include "include/types.h"
-//#include "common/config.h"
+
+#include "include/err.h"
+#include "msg/Message.h"
 
 namespace ceph {
   class Formatter;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -11,21 +11,27 @@
  * Foundation.  See file COPYING.
  * 
  */
-
+#include "mon_types.h"
 
 #include <sstream>
 #include <stdlib.h>
 #include <signal.h>
 #include <limits.h>
 
-#include "Monitor.h"
+#include "include/color.h"
+#include "include/ceph_fs.h"
+#include "include/str_list.h"
+#include "include/assert.h"
+#include "common/config.h"
 #include "common/version.h"
-
-#include "osd/OSDMap.h"
-
-#include "MonitorStore.h"
-
-#include "msg/Messenger.h"
+#include "common/strtol.h"
+#include "common/ceph_argparse.h"
+#include "common/Clock.h"
+#include "common/errno.h"
+#include "common/perf_counters.h"
+#include "common/admin_socket.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
 #include "messages/PaxosServiceMessage.h"
 #include "messages/MMonMap.h"
@@ -33,30 +39,15 @@
 #include "messages/MMonGetVersion.h"
 #include "messages/MMonGetVersionReply.h"
 #include "messages/MGenericMessage.h"
-#include "messages/MMonCommand.h"
 #include "messages/MMonCommandAck.h"
 #include "messages/MMonProbe.h"
 #include "messages/MMonJoin.h"
 #include "messages/MMonPaxos.h"
 #include "messages/MRoute.h"
 #include "messages/MForward.h"
-
 #include "messages/MMonSubscribe.h"
 #include "messages/MMonSubscribeAck.h"
-
 #include "messages/MAuthReply.h"
-
-#include "common/strtol.h"
-#include "common/ceph_argparse.h"
-#include "common/Timer.h"
-#include "common/Clock.h"
-#include "common/errno.h"
-#include "common/perf_counters.h"
-#include "common/admin_socket.h"
-
-#include "include/color.h"
-#include "include/ceph_fs.h"
-#include "include/str_list.h"
 
 #include "OSDMonitor.h"
 #include "MDSMonitor.h"
@@ -64,14 +55,9 @@
 #include "PGMonitor.h"
 #include "LogMonitor.h"
 #include "AuthMonitor.h"
+#include "MonitorStore.h"
 
-#include "auth/AuthMethodList.h"
-#include "auth/KeyRing.h"
-
-#include "common/config.h"
-#include "include/assert.h"
-
-#include "global/debug.h"
+#include "Monitor.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -23,31 +23,26 @@
 #ifndef CEPH_MONITOR_H
 #define CEPH_MONITOR_H
 
-#include "include/types.h"
-#include "msg/Messenger.h"
+#include "mon_types.h"
+
+#include <memory>
+#include <errno.h>
 
 #include "common/Timer.h"
+#include "common/LogClient.h"
+#include "auth/cephx/CephxKeyServer.h"
+#include "auth/AuthMethodList.h"
+#include "auth/KeyRing.h"
+#include "msg/Messenger.h"
+#include "osd/OSDMap.h"
+#include "perfglue/heap_profiler.h"
+
+#include "messages/MMonCommand.h"
 
 #include "MonMap.h"
 #include "Elector.h"
 #include "Paxos.h"
 #include "Session.h"
-
-#include "osd/OSDMap.h"
-
-#include "common/LogClient.h"
-
-#include "auth/cephx/CephxKeyServer.h"
-#include "auth/AuthMethodList.h"
-#include "auth/KeyRing.h"
-
-#include "perfglue/heap_profiler.h"
-
-#include "messages/MMonCommand.h"
-
-#include <memory>
-#include <errno.h>
-
 
 #define CEPH_MON_PROTOCOL     9 /* cluster internal */
 

--- a/src/mon/MonitorStore.cc
+++ b/src/mon/MonitorStore.cc
@@ -11,29 +11,7 @@
  * Foundation.  See file COPYING.
  * 
  */
-
-#include "MonitorStore.h"
-#include "common/Clock.h"
-#include "common/entity_name.h"
-#include "common/errno.h"
-#include "common/run_cmd.h"
-#include "common/safe_io.h"
-#include "common/config.h"
-#include "common/sync_filesystem.h"
-#include "global/debug.h"
-
-#if defined(__FreeBSD__)
-#include <sys/param.h>
-#endif
-
-#include "include/compat.h"
-
-#define dout_subsys ceph_subsys_mon
-#undef dout_prefix
-#define dout_prefix _prefix(_dout, dir)
-static ostream& _prefix(std::ostream *_dout, const string& dir) {
-  return *_dout << "store(" << dir << ") ";
-}
+#include "mon_types.h"
 
 #include <stdio.h>
 #include <sys/types.h>
@@ -43,6 +21,29 @@ static ostream& _prefix(std::ostream *_dout, const string& dir) {
 #include <unistd.h>
 #include <sstream>
 #include <sys/file.h>
+
+#if defined(__FreeBSD__)
+#include <sys/param.h>
+#endif
+
+#include "include/compat.h"
+#include "common/Clock.h"
+#include "common/entity_name.h"
+#include "common/errno.h"
+#include "common/run_cmd.h"
+#include "common/safe_io.h"
+#include "common/config.h"
+#include "common/sync_filesystem.h"
+#include "global/debug.h"
+
+#include "MonitorStore.h"
+
+#define dout_subsys ceph_subsys_mon
+#undef dout_prefix
+#define dout_prefix _prefix(_dout, dir)
+static ostream& _prefix(std::ostream *_dout, const string& dir) {
+  return *_dout << "store(" << dir << ") ";
+}
 
 int MonitorStore::mount()
 {

--- a/src/mon/MonitorStore.h
+++ b/src/mon/MonitorStore.h
@@ -15,14 +15,14 @@
 #ifndef CEPH_MON_MONITORSTORE_H
 #define CEPH_MON_MONITORSTORE_H
 
-#include "include/types.h"
-#include "include/buffer.h"
-
-#include "common/compiler_extensions.h"
+#include "mon_types.h"
 
 #include <iosfwd>
 #include <string.h>
 #include <errno.h>
+
+#include "include/buffer.h"
+#include "common/compiler_extensions.h"
 
 class MonitorStore {
   string dir;

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -11,25 +11,27 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "mon_types.h"
 
-#include "MonmapMonitor.h"
-#include "Monitor.h"
-#include "MonitorStore.h"
+#include <sstream>
+
+#include "include/assert.h"
+#include "common/config.h"
+#include "common/Timer.h"
+#include "common/ceph_argparse.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
 #include "messages/MMonCommand.h"
 #include "messages/MMonJoin.h"
 
-#include "common/Timer.h"
-#include "common/ceph_argparse.h"
-#include "mon/MDSMonitor.h"
-#include "mon/OSDMonitor.h"
-#include "mon/PGMonitor.h"
+#include "MDSMonitor.h"
+#include "OSDMonitor.h"
+#include "PGMonitor.h"
+#include "MonitorStore.h"
+#include "Monitor.h"
 
-#include <sstream>
-#include "common/config.h"
-#include "include/assert.h"
-
-#include "global/debug.h"
+#include "MonmapMonitor.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix

--- a/src/mon/MonmapMonitor.h
+++ b/src/mon/MonmapMonitor.h
@@ -19,16 +19,17 @@
 #ifndef CEPH_MONMAPMONITOR_H
 #define CEPH_MONMAPMONITOR_H
 
+#include "mon_types.h"
+
 #include <map>
 #include <set>
 
-using namespace std;
-
-#include "include/types.h"
 #include "msg/Messenger.h"
 
 #include "PaxosService.h"
 #include "MonMap.h"
+
+using namespace std;
 
 class MMonGetMap;
 class MMonMap;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -11,18 +11,23 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "mon_types.h"
 
 #include <sstream>
 
-#include "OSDMonitor.h"
-#include "Monitor.h"
-#include "MDSMonitor.h"
-#include "PGMonitor.h"
-
-#include "MonitorStore.h"
-
+#include "include/compat.h"
+#include "include/assert.h"
+#include "include/stringify.h"
+#include "common/Timer.h"
+#include "common/ceph_argparse.h"
+#include "common/perf_counters.h"
+#include "common/strtol.h"
+#include "common/config.h"
+#include "common/errno.h"
 #include "crush/CrushWrapper.h"
 #include "crush/CrushTester.h"
+#include "global/debug.h"
+#include "global/global_context.h"
 
 #include "messages/MOSDFailure.h"
 #include "messages/MOSDMap.h"
@@ -35,19 +40,12 @@
 #include "messages/MRemoveSnaps.h"
 #include "messages/MOSDScrub.h"
 
-#include "common/Timer.h"
-#include "common/ceph_argparse.h"
-#include "common/perf_counters.h"
-#include "common/strtol.h"
+#include "Monitor.h"
+#include "MDSMonitor.h"
+#include "PGMonitor.h"
+#include "MonitorStore.h"
 
-#include "common/config.h"
-#include "common/errno.h"
-
-#include "include/compat.h"
-#include "include/assert.h"
-#include "include/stringify.h"
-
-#include "global/debug.h"
+#include "OSDMonitor.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -18,24 +18,26 @@
 #ifndef CEPH_OSDMONITOR_H
 #define CEPH_OSDMONITOR_H
 
+#include "mon_types.h"
+
 #include <map>
 #include <set>
-using namespace std;
 
-#include "include/types.h"
 #include "msg/Messenger.h"
-
 #include "osd/OSDMap.h"
 
-#include "PaxosService.h"
-#include "Session.h"
-
-class Monitor;
 #include "messages/MOSDBoot.h"
 #include "messages/MMonCommand.h"
 #include "messages/MOSDMap.h"
 #include "messages/MOSDFailure.h"
 #include "messages/MPoolOp.h"
+
+#include "PaxosService.h"
+#include "Session.h"
+
+using namespace std;
+
+class Monitor;
 
 /// information about a particular peer's failure reports for one osd
 struct failure_reporter_t {

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1,14 +1,12 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "include/ceph_features.h"
+#include "common/Formatter.h"
+
 #include "PGMap.h"
 
 #define dout_subsys ceph_subsys_mon
-#include "common/debug.h"
-
-#include "common/Formatter.h"
-#include "include/ceph_features.h"
-
 // --
 
 void PGMap::Incremental::encode(bufferlist &bl, uint64_t features) const

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -21,10 +21,12 @@
 #ifndef CEPH_PGMAP_H
 #define CEPH_PGMAP_H
 
-#include "common/debug.h"
 #include "osd/osd_types.h"
-#include "common/config.h"
+
 #include <sstream>
+
+#include "common/debug.h"
+#include "common/config.h"
 
 namespace ceph { class Formatter; }
 

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -11,42 +11,38 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "mon_types.h"
 
+#include <sstream>
 
-#include "PGMonitor.h"
-#include "Monitor.h"
-#include "MDSMonitor.h"
-#include "OSDMonitor.h"
-#include "MonitorStore.h"
+#include "common/Timer.h"
+#include "common/Formatter.h"
+#include "common/ceph_argparse.h"
+#include "common/perf_counters.h"
+#include "common/errno.h"
+#include "osd/osd_types.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
-#include "messages/MPGStats.h"
-#include "messages/MPGStatsAck.h"
 #include "messages/MGetPoolStats.h"
 #include "messages/MGetPoolStatsReply.h"
-
 #include "messages/MStatfs.h"
 #include "messages/MStatfsReply.h"
 #include "messages/MOSDPGCreate.h"
 #include "messages/MMonCommand.h"
 #include "messages/MOSDScrub.h"
 
-#include "common/Timer.h"
-#include "common/Formatter.h"
-#include "common/ceph_argparse.h"
-#include "common/perf_counters.h"
+#include "Monitor.h"
+#include "MDSMonitor.h"
+#include "OSDMonitor.h"
+#include "MonitorStore.h"
 
-#include "osd/osd_types.h"
-
-#include "common/config.h"
-#include "common/errno.h"
-
-#include "global/debug.h"
-
-#include <sstream>
+#include "PGMonitor.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, pg_map)
+
 static ostream& _prefix(std::ostream *_dout, const Monitor *mon, const PGMap& pg_map) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
 		<< "(" << mon->get_state_name()

--- a/src/mon/PGMonitor.h
+++ b/src/mon/PGMonitor.h
@@ -20,19 +20,23 @@
 #ifndef CEPH_PGMONITOR_H
 #define CEPH_PGMONITOR_H
 
+#include "mon_types.h"
+
 #include <map>
 #include <set>
-using namespace std;
 
-#include "PGMap.h"
-#include "PaxosService.h"
-#include "include/types.h"
 #include "include/utime.h"
-#include "msg/Messenger.h"
 #include "common/config.h"
+#include "msg/Messenger.h"
 
 #include "messages/MPGStats.h"
 #include "messages/MPGStatsAck.h"
+
+#include "PGMap.h"
+#include "PaxosService.h"
+
+using namespace std;
+
 class MStatfs;
 class MMonCommand;
 class MGetPoolStats;

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -11,20 +11,24 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "mon_types.h"
 
-#include "Paxos.h"
-#include "Monitor.h"
-#include "MonitorStore.h"
+#include "include/assert.h"
+#include "common/config.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
 #include "messages/MMonPaxos.h"
 
-#include "common/config.h"
-#include "include/assert.h"
-#include "global/debug.h"
+#include "Monitor.h"
+#include "MonitorStore.h"
+
+#include "Paxos.h"
 
 #define dout_subsys ceph_subsys_paxos
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, mon->name, mon->rank, machine_name, state, first_committed, last_committed)
+
 static ostream& _prefix(std::ostream *_dout, Monitor *mon, const string& name,
 		        int rank, const char *machine_name, int state,
 			version_t first_committed, version_t last_committed)

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -38,16 +38,16 @@ e 12v
 #ifndef CEPH_MON_PAXOS_H
 #define CEPH_MON_PAXOS_H
 
-#include "include/types.h"
 #include "mon_types.h"
+
+#include <errno.h>
+
 #include "include/buffer.h"
-#include "messages/PaxosServiceMessage.h"
+#include "include/Context.h"
+#include "common/Timer.h"
 #include "msg/msg_types.h"
 
-#include "include/Context.h"
-
-#include "common/Timer.h"
-#include <errno.h>
+#include "messages/PaxosServiceMessage.h"
 
 class Monitor;
 class MMonPaxos;

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -12,17 +12,20 @@
  * 
  */
 
-#include "PaxosService.h"
+#include "include/assert.h"
+#include "common/config.h"
 #include "common/Clock.h"
+#include "global/global_context.h"
+#include "global/debug.h"
+
 #include "Monitor.h"
 
-#include "common/config.h"
-#include "include/assert.h"
-#include "global/debug.h"
+#include "PaxosService.h"
 
 #define dout_subsys ceph_subsys_paxos
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, paxos, paxos->machine_id)
+
 static ostream& _prefix(std::ostream *_dout, Monitor *mon, Paxos *paxos, int machine_id) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
 		<< "(" << mon->get_state_name()

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -15,9 +15,11 @@
 #ifndef CEPH_PAXOSSERVICE_H
 #define CEPH_PAXOSSERVICE_H
 
-#include "messages/PaxosServiceMessage.h"
-#include "include/Context.h"
 #include <errno.h>
+
+#include "include/Context.h"
+
+#include "messages/PaxosServiceMessage.h"
 
 class Monitor;
 class Paxos;

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -15,14 +15,14 @@
 #ifndef CEPH_MON_SESSION_H
 #define CEPH_MON_SESSION_H
 
-#include "include/xlist.h"
+#include "mon_types.h"
 #include "msg/msg_types.h"
 
+#include "include/xlist.h"
 #include "auth/AuthServiceHandler.h"
+#include "global/global_context.h"
 
 #include "MonCaps.h"
-
-#include "global/global_context.h"
 
 struct MonSession;
 

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -15,6 +15,8 @@
 #ifndef CEPH_MON_TYPES_H
 #define CEPH_MON_TYPES_H
 
+#include "include/types.h"
+
 #define PAXOS_PGMAP      0  // before osd, for pg kick to behave
 #define PAXOS_MDSMAP     1
 #define PAXOS_OSDMAP     2

--- a/src/monmaptool.cc
+++ b/src/monmaptool.cc
@@ -16,17 +16,17 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
-
 #include <iostream>
 #include <string>
-using namespace std;
 
+#include "include/str_list.h"
 #include "common/config.h"
 #include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "global/debug.h"
 #include "mon/MonMap.h"
-#include "include/str_list.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+
+using namespace std;
 
 void usage()
 {

--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -6,8 +6,8 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#include "common/secret.h"
 #include "include/addr_parsing.h"
+#include "common/secret.h"
 
 #ifndef MS_RELATIME
 # define MS_RELATIME (1<<21)

--- a/src/mount/mtab.c
+++ b/src/mount/mtab.c
@@ -24,7 +24,6 @@
 
 #include "mount/canonicalize.c"
 
-
 /* Updating mtab ----------------------------------------------*/
 
 /* Flag for already existing lock file. */

--- a/src/msg/Accepter.cc
+++ b/src/msg/Accepter.cc
@@ -18,17 +18,16 @@
 #include <limits.h>
 #include <poll.h>
 
-#include "Accepter.h"
-#include "SimpleMessenger.h"
-
-#include "Message.h"
-#include "Pipe.h"
-
 #include "common/debug.h"
 #include "common/errno.h"
 
-#define dout_subsys ceph_subsys_ms
+#include "SimpleMessenger.h"
+#include "Message.h"
+#include "Pipe.h"
 
+#include "Accepter.h"
+
+#define dout_subsys ceph_subsys_ms
 #undef dout_prefix
 #define dout_prefix *_dout << "accepter."
 

--- a/src/msg/Accepter.h
+++ b/src/msg/Accepter.h
@@ -15,7 +15,8 @@
 #ifndef CEPH_MSG_ACCEPTER_H
 #define CEPH_MSG_ACCEPTER_H
 
-#include "msg/msg_types.h"
+#include "msg_types.h"
+
 #include "common/Thread.h"
 
 class SimpleMessenger;

--- a/src/msg/DispatchQueue.cc
+++ b/src/msg/DispatchQueue.cc
@@ -12,19 +12,19 @@
  * 
  */
 
-#include "msg/Message.h"
-#include "DispatchQueue.h"
-#include "SimpleMessenger.h"
 #include "common/ceph_context.h"
-
-#define dout_subsys ceph_subsys_ms
 #include "common/debug.h"
 
+#include "Message.h"
+#include "SimpleMessenger.h"
+
+#include "DispatchQueue.h"
 
 /*******************
  * DispatchQueue
  */
 
+#define dout_subsys ceph_subsys_ms
 #undef dout_prefix
 #define dout_prefix *_dout << "-- " << msgr->get_myaddr() << " "
 

--- a/src/msg/DispatchQueue.h
+++ b/src/msg/DispatchQueue.h
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <boost/intrusive_ptr.hpp>
+
 #include "include/assert.h"
 #include "include/xlist.h"
 #include "include/atomic.h"

--- a/src/msg/Dispatcher.h
+++ b/src/msg/Dispatcher.h
@@ -16,9 +16,10 @@
 #ifndef CEPH_DISPATCHER_H
 #define CEPH_DISPATCHER_H
 
-#include "Message.h"
 #include "common/config.h"
 #include "auth/Auth.h"
+
+#include "Message.h"
 
 class Messenger;
 

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -1,20 +1,18 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
 // vim: ts=8 sw=2 smarttab
 
+#include "include/types.h"
+
 #ifdef ENCODE_DUMP
 # include <typeinfo>
 # include <cxxabi.h>
 #endif
 
 #include <iostream>
-using namespace std;
 
-#include "include/types.h"
-
+#include "common/config.h"
 #include "global/global_context.h"
 
-#include "Message.h"
-#include "Pipe.h"
 #include "messages/MPGStats.h"
 
 #include "messages/MGenericMessage.h"
@@ -146,7 +144,11 @@ using namespace std;
 
 #include "messages/MWatchNotify.h"
 
-#include "common/config.h"
+#include "Pipe.h"
+
+#include "Message.h"
+
+using namespace std;
 
 #define DEBUGLVL  10    // debug level of output
 

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -14,21 +14,18 @@
 
 #ifndef CEPH_MESSAGE_H
 #define CEPH_MESSAGE_H
+
+#include "msg_types.h"
+#include "include/types.h"
  
 #include <stdlib.h>
 #include <ostream>
-
 #include <boost/intrusive_ptr.hpp>
-// Because intusive_ptr clobbers our assert...
-#include "include/assert.h"
 
-#include "include/types.h"
+#include "include/assert.h" // intusive_ptr clobbers it
 #include "include/buffer.h"
 #include "common/Throttle.h"
-#include "msg_types.h"
-
 #include "common/RefCountedObj.h"
-
 #include "common/debug.h"
 #include "common/config.h"
 

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -12,29 +12,28 @@
  * 
  */
 
-
-
 #ifndef CEPH_MESSENGER_H
 #define CEPH_MESSENGER_H
 
-#include <map>
-using namespace std;
-
-#include "Message.h"
-#include "Dispatcher.h"
-#include "common/Mutex.h"
-#include "common/Cond.h"
-#include "include/Context.h"
 #include "include/types.h"
-#include "include/ceph_features.h"
-#include "auth/Crypto.h"
 
+#include <map>
 #include <errno.h>
 #include <sstream>
 
+#include "common/Mutex.h"
+#include "common/Cond.h"
+#include "include/Context.h"
+#include "include/ceph_features.h"
+#include "auth/Crypto.h"
+
+#include "Message.h"
+#include "Dispatcher.h"
+
+using namespace std;
+
 class MDS;
 class Timer;
-
 
 class Messenger {
 private:

--- a/src/msg/Pipe.cc
+++ b/src/msg/Pipe.cc
@@ -18,18 +18,17 @@
 #include <limits.h>
 #include <poll.h>
 
-#include "Message.h"
-#include "Pipe.h"
-#include "SimpleMessenger.h"
-
 #include "common/debug.h"
 #include "common/errno.h"
-
 // Below included to get encode_encrypt(); That probably should be in Crypto.h, instead
-
 #include "auth/Crypto.h"
 #include "auth/cephx/CephxProtocol.h"
 #include "auth/AuthSessionHandler.h"
+
+#include "Message.h"
+#include "SimpleMessenger.h"
+
+#include "Pipe.h"
 
 // Constant to limit starting sequence number to 2^31.  Nothing special about it, just a big number.  PLR
 #define SEQ_MASK  0x7fffffff 

--- a/src/msg/Pipe.h
+++ b/src/msg/Pipe.h
@@ -16,9 +16,10 @@
 #define CEPH_MSGR_PIPE_H
 
 #include "msg_types.h"
-#include "Messenger.h"
+
 #include "auth/AuthSessionHandler.h"
 
+#include "Messenger.h"
 
 class SimpleMessenger;
 class IncomingQueue;

--- a/src/msg/SimpleMessenger.h
+++ b/src/msg/SimpleMessenger.h
@@ -16,28 +16,28 @@
 #define CEPH_SIMPLEMESSENGER_H
 
 #include "include/types.h"
-#include "include/xlist.h"
 
 #include <list>
 #include <map>
-using namespace std;
 #include <ext/hash_map>
 #include <ext/hash_set>
-using namespace __gnu_cxx;
 
-#include "common/Mutex.h"
 #include "include/atomic.h"
+#include "include/assert.h"
+#include "include/xlist.h"
+#include "common/Mutex.h"
 #include "common/Cond.h"
 #include "common/Thread.h"
 #include "common/Throttle.h"
 
 #include "Messenger.h"
 #include "Message.h"
-#include "include/assert.h"
 #include "DispatchQueue.h"
-
 #include "Pipe.h"
 #include "Accepter.h"
+
+using namespace std;
+using namespace __gnu_cxx;
 
 /*
  * This class handles transmission and reception of messages. Generally

--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -1,12 +1,12 @@
 
-#include "msg_types.h"
-
 #include <arpa/inet.h>
 #include <stdlib.h>
 #include <string.h>
 #include <netdb.h>
 
 #include "common/Formatter.h"
+
+#include "msg_types.h"
 
 void entity_name_t::dump(Formatter *f) const
 {

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -15,9 +15,10 @@
 #ifndef CEPH_MSG_TYPES_H
 #define CEPH_MSG_TYPES_H
 
+#include "include/types.h"
+
 #include <netinet/in.h>
 
-#include "include/types.h"
 #include "include/blobhash.h"
 #include "include/encoding.h"
 

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -2,11 +2,10 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "common/config.h"
-
-#include "objclass/objclass.h"
 #include "osd/ReplicatedPG.h"
-
 #include "osd/ClassHandler.h"
+
+#include "objclass.h"
 
 static ClassHandler *ch;
 

--- a/src/objclass/class_debug.cc
+++ b/src/objclass/class_debug.cc
@@ -1,16 +1,15 @@
 // -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "common/config.h"
-
-#include "global/debug.h"
-#include "objclass/objclass.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
-
 #include <iostream>
+
+#include "common/config.h"
+#include "global/debug.h"
+
+#include "objclass.h"
 
 #define dout_subsys ceph_subsys_objclass
 

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -6,7 +6,7 @@
 
 #ifdef __cplusplus
 
-#include "../include/types.h"
+#include "include/types.h"
 #include "msg/msg_types.h"
 
 extern "C" {

--- a/src/os/CollectionIndex.h
+++ b/src/os/CollectionIndex.h
@@ -19,8 +19,8 @@
 #include <vector>
 #include <tr1/memory>
 
-#include "osd/osd_types.h"
 #include "include/object.h"
+#include "osd/osd_types.h"
 
 /**
  * CollectionIndex provides an interface for manipulating indexed colelctions

--- a/src/os/DBObjectMap.cc
+++ b/src/os/DBObjectMap.cc
@@ -2,22 +2,13 @@
 
 #include <iostream>
 #include <inttypes.h>
-#include "include/buffer.h"
-#include <set>
-#include <map>
-#include <string>
-#include <tr1/memory>
-
-#include <vector>
-
-#include "ObjectMap.h"
-#include "KeyValueDB.h"
-#include "DBObjectMap.h"
 #include <errno.h>
 
-#include "global/debug.h"
-#include "common/config.h"
 #include "include/assert.h"
+#include "common/config.h"
+#include "global/debug.h"
+
+#include "DBObjectMap.h"
 
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix

--- a/src/os/DBObjectMap.h
+++ b/src/os/DBObjectMap.h
@@ -2,20 +2,21 @@
 #ifndef DBOBJECTMAP_DB_H
 #define DBOBJECTMAP_DB_H
 
-#include "include/buffer.h"
+#include "osd/osd_types.h"
+
+#include <boost/scoped_ptr.hpp>
+#include <tr1/memory>
 #include <set>
 #include <map>
 #include <string>
-
 #include <vector>
-#include <tr1/memory>
-#include <boost/scoped_ptr.hpp>
+
+#include "include/buffer.h"
+#include "common/Mutex.h"
+#include "common/Cond.h"
 
 #include "ObjectMap.h"
 #include "KeyValueDB.h"
-#include "osd/osd_types.h"
-#include "common/Mutex.h"
-#include "common/Cond.h"
 
 /**
  * DBObjectMap: Implements ObjectMap in terms of KeyValueDB

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -12,15 +12,6 @@
  * 
  */
 
-#include "common/errno.h"
-#include "common/safe_io.h"
-#include "FileJournal.h"
-#include "include/color.h"
-#include "common/perf_counters.h"
-#include "os/ObjectStore.h"
-
-#include "include/compat.h"
-
 #include <fcntl.h>
 #include <sstream>
 #include <stdio.h>
@@ -28,9 +19,16 @@
 #include <sys/stat.h>
 #include <sys/mount.h>
 
+#include "include/compat.h"
+#include "include/color.h"
+#include "common/errno.h"
+#include "common/safe_io.h"
+#include "common/perf_counters.h"
 #include "common/blkdev.h"
+#include "os/ObjectStore.h"
 #include "global/debug.h"
 
+#include "FileJournal.h"
 
 #define dout_subsys ceph_subsys_journal
 #undef dout_prefix

--- a/src/os/FileJournal.h
+++ b/src/os/FileJournal.h
@@ -17,18 +17,20 @@
 #define CEPH_FILEJOURNAL_H
 
 #include <deque>
-using std::deque;
 
-#include "Journal.h"
+#ifdef HAVE_LIBAIO
+# include <libaio.h>
+#endif
+
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/Thread.h"
 #include "common/Throttle.h"
 #include "global/global_context.h"
 
-#ifdef HAVE_LIBAIO
-# include <libaio.h>
-#endif
+#include "Journal.h"
+
+using std::deque;
 
 /**
  * Implements journaling on top of block device or file.

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -12,6 +12,9 @@
  * 
  */
 
+#include "include/types.h"
+#include "osd/osd_types.h"
+
 #include <inttypes.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -22,65 +25,51 @@
 #include <errno.h>
 #include <dirent.h>
 #include <sys/ioctl.h>
+#include <sstream>
+#include <iostream>
 
 #if defined(__linux__)
 #include <linux/fs.h>
 #include <syscall.h>
 #endif
 
-#include <iostream>
-#include <map>
-
 #if defined(__FreeBSD__)
 #include "include/inttypes.h"
 #endif
-
-#include "include/compat.h"
-#include "include/fiemap.h"
-
-#include "common/xattr.h"
-#include "chain_xattr.h"
 
 #if defined(DARWIN) || defined(__FreeBSD__)
 #include <sys/param.h>
 #include <sys/mount.h>
 #endif // DARWIN
 
-
-#include <fstream>
-#include <sstream>
-
-#include "FileStore.h"
-#include "common/BackTrace.h"
-#include "include/types.h"
-#include "FileJournal.h"
-
-#include "osd/osd_types.h"
+#include "include/compat.h"
+#include "include/fiemap.h"
 #include "include/color.h"
 #include "include/buffer.h"
-
-#include "common/Timer.h"
+#include "common/xattr.h"
+#include "common/BackTrace.h"
+#include "common/config.h"
 #include "common/errno.h"
 #include "common/run_cmd.h"
 #include "common/safe_io.h"
 #include "common/perf_counters.h"
 #include "common/sync_filesystem.h"
 #include "common/fd.h"
-#include "HashIndex.h"
+#include "common/ceph_crypto.h"
+#include "global/debug.h"
+
+#include "chain_xattr.h"
+#include "FileJournal.h"
 #include "DBObjectMap.h"
 #include "LevelDBStore.h"
-
-#include "common/ceph_crypto.h"
-using ceph::crypto::SHA1;
 
 #ifndef __CYGWIN__
 #  include "btrfs_ioctl.h"
 #endif
 
-#include "include/assert.h"
+#include "FileStore.h"
 
-#include "common/config.h"
-#include "global/debug.h"
+using ceph::crypto::SHA1;
 
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix

--- a/src/os/FileStore.h
+++ b/src/os/FileStore.h
@@ -22,28 +22,24 @@
 #include <deque>
 #include <boost/scoped_ptr.hpp>
 #include <fstream>
-using namespace std;
-
 #include <ext/hash_map>
-using namespace __gnu_cxx;
 
 #include "include/assert.h"
+#include "include/uuid.h"
+#include "common/Timer.h"
+#include "common/WorkQueue.h"
+#include "common/Mutex.h"
+#include "global/global_context.h"
 
 #include "ObjectStore.h"
 #include "JournalingObjectStore.h"
-
-#include "common/Timer.h"
-#include "common/WorkQueue.h"
-
-#include "common/Mutex.h"
 #include "HashIndex.h"
 #include "IndexManager.h"
 #include "ObjectMap.h"
 #include "SequencerPosition.h"
 
-#include "include/uuid.h"
-
-#include "global/global_context.h"
+using namespace std;
+using namespace __gnu_cxx;
 
 // from include/linux/falloc.h:
 #ifndef FALLOC_FL_PUNCH_HOLE

--- a/src/os/FlatIndex.cc
+++ b/src/os/FlatIndex.cc
@@ -11,19 +11,20 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "osd/osd_types.h"
+
+#include <errno.h>
 
 #if defined(__FreeBSD__)
 #include <sys/cdefs.h>
 #include <sys/param.h>
 #endif
 
-#include "FlatIndex.h"
-#include "CollectionIndex.h"
 #include "common/ceph_crypto.h"
-#include "osd/osd_types.h"
-#include <errno.h>
 
 #include "chain_xattr.h"
+
+#include "FlatIndex.h"
 
 using ceph::crypto::SHA1;
 

--- a/src/os/HashIndex.cc
+++ b/src/os/HashIndex.cc
@@ -11,15 +11,14 @@
  * Foundation.  See file COPYING.
  * 
  */
-
 #include "include/types.h"
-#include "include/buffer.h"
 #include "osd/osd_types.h"
+
 #include <errno.h>
 
-#include "HashIndex.h"
-
 #include "global/debug.h"
+
+#include "HashIndex.h"
 
 #define dout_subsys ceph_subsys_filestore
 

--- a/src/os/HashIndex.h
+++ b/src/os/HashIndex.h
@@ -17,8 +17,8 @@
 
 #include "include/buffer.h"
 #include "include/encoding.h"
-#include "LFNIndex.h"
 
+#include "LFNIndex.h"
 
 /**
  * Implements collection prehashing.

--- a/src/os/IndexManager.cc
+++ b/src/os/IndexManager.cc
@@ -12,28 +12,19 @@
  * 
  */
 
-#include <tr1/memory>
-#include <map>
+#include <errno.h>
 
 #if defined(__FreeBSD__)
 #include <sys/param.h>
 #endif
 
-#include <errno.h>
-
-#include "common/Mutex.h"
-#include "common/Cond.h"
-#include "common/config.h"
 #include "include/buffer.h"
-
-#include "IndexManager.h"
-#include "FlatIndex.h"
-#include "HashIndex.h"
-#include "CollectionIndex.h"
-
-#include "chain_xattr.h"
 #include "global/global_context.h"
 #include "global/debug.h"
+
+#include "chain_xattr.h"
+
+#include "IndexManager.h"
 
 static int set_version(const char *path, uint32_t version) {
   bufferlist bl;

--- a/src/os/JournalingObjectStore.cc
+++ b/src/os/JournalingObjectStore.cc
@@ -1,14 +1,12 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 
-#include "JournalingObjectStore.h"
-
 #include "global/debug.h"
+
+#include "JournalingObjectStore.h"
 
 #define dout_subsys ceph_subsys_journal
 #undef dout_prefix
 #define dout_prefix *_dout << "journal "
-
-
 
 void JournalingObjectStore::journal_start()
 {

--- a/src/os/JournalingObjectStore.h
+++ b/src/os/JournalingObjectStore.h
@@ -15,10 +15,11 @@
 #ifndef CEPH_JOURNALINGOBJECTSTORE_H
 #define CEPH_JOURNALINGOBJECTSTORE_H
 
-#include "ObjectStore.h"
-#include "Journal.h"
-#include "global/global_context.h"
 #include "common/RWLock.h"
+#include "global/global_context.h"
+
+#include "Journal.h"
+#include "ObjectStore.h"
 
 class JournalingObjectStore : public ObjectStore {
 protected:

--- a/src/os/KeyValueDB.h
+++ b/src/os/KeyValueDB.h
@@ -3,12 +3,14 @@
 #ifndef KEY_VALUE_DB_H
 #define KEY_VALUE_DB_H
 
-#include "include/buffer.h"
 #include <set>
 #include <map>
 #include <string>
 #include <tr1/memory>
 #include <boost/scoped_ptr.hpp>
+
+#include "include/buffer.h"
+
 #include "ObjectMap.h"
 
 using std::string;

--- a/src/os/LFNIndex.cc
+++ b/src/os/LFNIndex.cc
@@ -11,11 +11,8 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "osd/osd_types.h"
 
-#include <string>
-#include <map>
-#include <set>
-#include <vector>
 #include <errno.h>
 #include <string.h>
 
@@ -23,22 +20,19 @@
 #include <sys/param.h>
 #endif
 
-#include "osd/osd_types.h"
-#include "include/object.h"
+#include "include/buffer.h"
+#include "include/compat.h"
 #include "common/config.h"
 #include "common/debug.h"
-#include "include/buffer.h"
-#include "common/ceph_crypto.h"
-#include "include/compat.h"
 #include "chain_xattr.h"
 
 #include "LFNIndex.h"
+
 using ceph::crypto::SHA1;
 
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "LFNIndex(" << get_base_path() << ") "
-
 
 const string LFNIndex::LFN_ATTR = "user.cephos.lfn";
 const string LFNIndex::PHASH_ATTR_PREFIX = "user.cephos.phash.";

--- a/src/os/LFNIndex.h
+++ b/src/os/LFNIndex.h
@@ -12,9 +12,10 @@
  * 
  */
 
-
 #ifndef OS_LFNINDEX_H
 #define OS_LFNINDEX_H
+
+#include "osd/osd_types.h"
 
 #include <string>
 #include <map>
@@ -23,7 +24,6 @@
 #include <tr1/memory>
 #include <exception>
 
-#include "osd/osd_types.h"
 #include "include/object.h"
 #include "common/ceph_crypto.h"
 

--- a/src/os/LevelDBStore.cc
+++ b/src/os/LevelDBStore.cc
@@ -1,15 +1,18 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
-#include "LevelDBStore.h"
 
 #include <set>
 #include <map>
 #include <string>
 #include <tr1/memory>
+#include <errno.h>
+
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 #include "leveldb/slice.h"
-#include <errno.h>
+
+#include "LevelDBStore.h"
+
 using std::string;
 
 int LevelDBStore::init(ostream &out)

--- a/src/os/LevelDBStore.h
+++ b/src/os/LevelDBStore.h
@@ -4,16 +4,15 @@
 #define LEVEL_DB_STORE_H
 
 #include "include/types.h"
-#include "include/buffer.h"
-#include "KeyValueDB.h"
-#include <set>
-#include <map>
-#include <string>
-#include <tr1/memory>
+
 #include <boost/scoped_ptr.hpp>
+
+#include "include/buffer.h"
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 #include "leveldb/slice.h"
+
+#include "KeyValueDB.h"
 
 /**
  * Uses LevelDB to implement the KeyValueDB interface

--- a/src/os/ObjectMap.h
+++ b/src/os/ObjectMap.h
@@ -15,11 +15,12 @@
 #ifndef OS_KEYVALUESTORE_H
 #define OS_KEYVALUESTORE_H
 
-#include "IndexManager.h"
-#include "SequencerPosition.h"
 #include <string>
 #include <vector>
 #include <tr1/memory>
+
+#include "IndexManager.h"
+#include "SequencerPosition.h"
 
 /**
  * Encapsulates the FileStore key value store

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -12,8 +12,10 @@
  * 
  */
 #include <sstream>
-#include "ObjectStore.h"
+
 #include "common/Formatter.h"
+
+#include "ObjectStore.h"
 
 ostream& operator<<(ostream& out, const ObjectStore::Sequencer& s)
 {

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -14,12 +14,8 @@
 #ifndef CEPH_OBJECTSTORE_H
 #define CEPH_OBJECTSTORE_H
 
-#include "include/Context.h"
-#include "include/buffer.h"
 #include "include/types.h"
 #include "osd/osd_types.h"
-#include "common/TrackedOp.h"
-#include "ObjectMap.h"
 
 #include <errno.h>
 #include <sys/stat.h>
@@ -30,6 +26,12 @@
 #else
 #include <sys/vfs.h>    /* or <sys/statfs.h> */
 #endif /* DARWIN */
+
+#include "include/Context.h"
+#include "include/buffer.h"
+#include "common/TrackedOp.h"
+
+#include "ObjectMap.h"
 
 using std::vector;
 using std::string;

--- a/src/os/SequencerPosition.h
+++ b/src/os/SequencerPosition.h
@@ -5,11 +5,13 @@
 #define __CEPH_OS_SEQUENCERPOSITION_H
 
 #include "include/types.h"
+
+#include <ostream>
+
 #include "include/cmp.h"
 #include "include/encoding.h"
 #include "common/Formatter.h"
 
-#include <ostream>
 
 /**
  * transaction and op offset

--- a/src/os/chain_xattr.cc
+++ b/src/os/chain_xattr.cc
@@ -1,8 +1,6 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "chain_xattr.h"
-
 #include <inttypes.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -10,12 +8,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/file.h>
-#include <errno.h>
 #include <dirent.h>
 #include <sys/ioctl.h>
 #include <string.h>
 #include <stdio.h>
-#include "include/assert.h"
 
 #if defined(__linux__)
 #include <linux/fs.h>
@@ -25,7 +21,9 @@
 #include "include/inttypes.h"
 #endif
 
-#include "common/xattr.h"
+#include "include/assert.h"
+
+#include "chain_xattr.h"
 
 /*
  * chaining xattrs

--- a/src/os/chain_xattr.h
+++ b/src/os/chain_xattr.h
@@ -4,9 +4,9 @@
 #ifndef __CEPH_OSD_CHAIN_XATTR_H
 #define __CEPH_OSD_CHAIN_XATTR_H
 
-#include "common/xattr.h"
-
 #include <errno.h>
+
+#include "common/xattr.h"
 
 #define CHAIN_XATTR_MAX_NAME_LEN  128
 #define CHAIN_XATTR_MAX_BLOCK_LEN 2048

--- a/src/os/hobject.cc
+++ b/src/os/hobject.cc
@@ -1,7 +1,8 @@
-
 #include "include/types.h"
-#include "hobject.h"
+
 #include "common/Formatter.h"
+
+#include "hobject.h"
 
 void hobject_t::encode(bufferlist& bl) const
 {

--- a/src/os/hobject.h
+++ b/src/os/hobject.h
@@ -17,9 +17,8 @@
 
 #include "include/object.h"
 #include "include/cmp.h"
-
 #include "json_spirit/json_spirit_value.h"
-#include "include/assert.h"   // spirit clobbers it!
+#include "include/assert.h" // spirit clobbers it!
 
 typedef uint64_t filestore_hobject_key_t;
 

--- a/src/osd/Ager.cc
+++ b/src/osd/Ager.cc
@@ -3,13 +3,6 @@
 
 #include "include/types.h"
 
-#include "Ager.h"
-#include "os/ObjectStore.h"
-
-#include "common/Clock.h"
-#include "global/global_context.h"
-#include "global/debug.h"
-
 // ick
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -20,6 +13,10 @@
 #include <sys/mount.h>
 #endif // DARWIN || __FreeBSD__
 
+#include "global/global_context.h"
+#include "global/debug.h"
+
+#include "Ager.h"
 
 int myrand() 
 {

--- a/src/osd/Ager.h
+++ b/src/osd/Ager.h
@@ -4,12 +4,14 @@
 #define CEPH_AGER_H
 
 #include "include/types.h"
-#include "include/Distribution.h"
-#include "os/ObjectStore.h"
-#include "common/Clock.h"
 
 #include <list>
 #include <vector>
+
+#include "include/Distribution.h"
+#include "common/Clock.h"
+#include "os/ObjectStore.h"
+
 using namespace std;
 
 class Ager {

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -1,11 +1,7 @@
 
 #include "include/types.h"
-#include "msg/Message.h"
-#include "osd/OSD.h"
-#include "ClassHandler.h"
 
 #include <dlfcn.h>
-
 #include <map>
 
 #if defined(__FreeBSD__)
@@ -13,7 +9,12 @@
 #endif
 
 #include "common/config.h"
+#include "msg/Message.h"
 #include "global/debug.h"
+
+#include "OSD.h"
+
+#include "ClassHandler.h"
 
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix

--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -3,11 +3,9 @@
 
 #include "include/types.h"
 
-#include "objclass/objclass.h"
-
 #include "common/Cond.h"
 #include "common/Mutex.h"
-
+#include "objclass/objclass.h"
 
 class ClassHandler
 {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -15,44 +15,39 @@
 #ifndef CEPH_OSD_H
 #define CEPH_OSD_H
 
-#include "boost/tuple/tuple.hpp"
+#include <boost/tuple/tuple.hpp>
+#include <map>
+#include <memory>
+#include <tr1/memory>
+#include <ext/hash_map>
+#include <ext/hash_set>
 
-#include "PG.h"
-
-#include "msg/Dispatcher.h"
-
+#include "include/CompatSet.h"
 #include "common/Mutex.h"
 #include "common/RWLock.h"
 #include "common/Timer.h"
 #include "common/WorkQueue.h"
 #include "common/LogClient.h"
 #include "common/AsyncReserver.h"
-
-#include "os/ObjectStore.h"
-#include "OSDCap.h"
-
-#include "common/DecayCounter.h"
-#include "osd/ClassHandler.h"
-
-#include "include/CompatSet.h"
-
-#include "auth/KeyRing.h"
-#include "messages/MOSDRepScrub.h"
-#include "OpRequest.h"
-
-#include <map>
-#include <memory>
-#include <tr1/memory>
-using namespace std;
-
-#include <ext/hash_map>
-#include <ext/hash_set>
-using namespace __gnu_cxx;
-
 #include "common/shared_cache.hpp"
 #include "common/simple_cache.hpp"
 #include "common/sharedptr_registry.hpp"
 #include "common/PrioritizedQueue.h"
+#include "common/DecayCounter.h"
+#include "auth/KeyRing.h"
+#include "msg/Dispatcher.h"
+#include "os/ObjectStore.h"
+#include "global/global_context.h"
+
+#include "messages/MOSDRepScrub.h"
+
+#include "OSDCap.h"
+#include "ClassHandler.h"
+#include "OpRequest.h"
+#include "PG.h"
+
+using namespace std;
+using namespace __gnu_cxx;
 
 #define CEPH_OSD_PROTOCOL    10 /* cluster internal */
 

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -17,9 +17,10 @@
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix.hpp>
 
-#include "OSDCap.h"
 #include "common/config.h"
 #include "common/debug.h"
+
+#include "OSDCap.h"
 
 using std::ostream;
 using std::vector;

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -27,10 +27,11 @@
 #ifndef CEPH_OSDCAP_H
 #define CEPH_OSDCAP_H
 
-#include <ostream>
-using std::ostream;
-
 #include "include/types.h"
+
+#include <ostream>
+
+using std::ostream;
 
 static const __u8 OSD_CAP_R     = (1 << 1);      // read
 static const __u8 OSD_CAP_W     = (1 << 2);      // write

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -12,13 +12,10 @@
  *
  */
 
-#include "OSDMap.h"
-
-#include "common/config.h"
-#include "common/Formatter.h"
-#include "include/ceph_features.h"
-
 #include "common/code_environment.h"
+#include "common/Formatter.h"
+
+#include "OSDMap.h"
 
 #define dout_subsys ceph_subsys_osd
 

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -21,27 +21,26 @@
  *   disks, disk groups, total # osds,
  *
  */
-#include "common/config.h"
+
 #include "include/types.h"
 #include "osd_types.h"
-#include "msg/Message.h"
-#include "common/Mutex.h"
-#include "common/Clock.h"
-
-#include "include/ceph_features.h"
-
-#include "crush/CrushWrapper.h"
-
-#include "include/interval_set.h"
 
 #include <vector>
 #include <list>
 #include <set>
 #include <map>
 #include <tr1/memory>
-using namespace std;
-
 #include <ext/hash_set>
+
+#include "include/ceph_features.h"
+#include "include/interval_set.h"
+#include "common/config.h"
+#include "common/Mutex.h"
+#include "common/Clock.h"
+#include "crush/CrushWrapper.h"
+#include "msg/Message.h"
+
+using namespace std;
 using __gnu_cxx::hash_set;
 
 /*

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -1,16 +1,17 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
 
-#include "OpRequest.h"
-#include "common/Formatter.h"
 #include <iostream>
 #include <vector>
+
+#include "include/assert.h"
+#include "common/Formatter.h"
 #include "common/config.h"
-#include "msg/Message.h"
 #include "messages/MOSDOp.h"
 #include "messages/MOSDSubOp.h"
-#include "include/assert.h"
 #include "global/global_context.h"
 #include "global/debug.h"
+
+#include "OpRequest.h"
 
 #define dout_subsys ceph_subsys_optracker
 #undef dout_prefix

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -13,17 +13,18 @@
 
 #ifndef OPREQUEST_H_
 #define OPREQUEST_H_
+
+#include "osd_types.h"
+
 #include <sstream>
 #include <stdint.h>
-#include <vector>
-
 #include <include/utime.h>
-#include "common/Mutex.h"
-#include "include/xlist.h"
-#include "msg/Message.h"
 #include <tr1/memory>
+
+#include "include/xlist.h"
+#include "common/Mutex.h"
 #include "common/TrackedOp.h"
-#include "osd/osd_types.h"
+#include "msg/Message.h"
 
 class OpRequest;
 class OpHistory {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -12,12 +12,11 @@
  * 
  */
 
-#include "PG.h"
-#include "common/config.h"
-#include "OSD.h"
-#include "OpRequest.h"
+#include <sstream>
 
 #include "common/Timer.h"
+#include "common/config.h"
+#include "global/debug.h"
 
 #include "messages/MOSDOp.h"
 #include "messages/MOSDPGNotify.h"
@@ -29,13 +28,12 @@
 #include "messages/MOSDPGBackfill.h"
 #include "messages/MBackfillReserve.h"
 #include "messages/MRecoveryReserve.h"
-
 #include "messages/MOSDSubOp.h"
 #include "messages/MOSDSubOpReply.h"
 
-#include "global/debug.h"
+#include "OSD.h"
 
-#include <sstream>
+#include "PG.h"
 
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -15,6 +15,9 @@
 #ifndef CEPH_PG_H
 #define CEPH_PG_H
 
+#include "include/types.h"
+#include "osd_types.h"
+
 #include <boost/statechart/custom_reaction.hpp>
 #include <boost/statechart/event.hpp>
 #include <boost/statechart/simple_state.hpp>
@@ -23,38 +26,32 @@
 #include <boost/statechart/transition.hpp>
 #include <boost/statechart/event_base.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <tr1/memory>
-
-// re-include our assert to clobber boost's
-#include "include/assert.h" 
-
-#include "include/types.h"
-#include "include/stringify.h"
-#include "osd_types.h"
-#include "include/buffer.h"
-#include "include/xlist.h"
-#include "include/atomic.h"
-
-#include "OpRequest.h"
-#include "OSDMap.h"
-#include "os/ObjectStore.h"
-#include "msg/Messenger.h"
-#include "messages/MOSDRepScrub.h"
-#include "messages/MOSDPGLog.h"
-
-#include "common/DecayCounter.h"
-
-#include "global/global_context.h"
-
 #include <list>
 #include <memory>
 #include <string>
-using namespace std;
-
+#include <tr1/memory>
 #include <ext/hash_map>
 #include <ext/hash_set>
-using namespace __gnu_cxx;
 
+
+#include "include/assert.h" // boost clobbers it
+#include "include/stringify.h"
+#include "include/buffer.h"
+#include "include/xlist.h"
+#include "include/atomic.h"
+#include "common/DecayCounter.h"
+#include "os/ObjectStore.h"
+#include "msg/Messenger.h"
+#include "global/global_context.h"
+
+#include "messages/MOSDRepScrub.h"
+#include "messages/MOSDPGLog.h"
+
+#include "OpRequest.h"
+#include "OSDMap.h"
+
+using namespace std;
+using namespace __gnu_cxx;
 
 //#define DEBUG_RECOVERY_OIDS   // track set of recovering oids explicitly, to find counting bugs
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -11,40 +11,30 @@
  * 
  */
 
-#include "PG.h"
-#include "ReplicatedPG.h"
-#include "OSD.h"
-#include "OpRequest.h"
-
+#include "include/compat.h"
+#include "common/config.h"
 #include "common/errno.h"
 #include "common/perf_counters.h"
+#include "mds/inode_backtrace.h" // Ugh
+#include "global/global_context.h"
+#include "json_spirit/json_spirit_value.h"
+#include "json_spirit/json_spirit_reader.h"
+#include "include/assert.h"  // json_spirit clobbers it
 
 #include "messages/MOSDOp.h"
 #include "messages/MOSDOpReply.h"
 #include "messages/MOSDSubOp.h"
 #include "messages/MOSDSubOpReply.h"
-
 #include "messages/MOSDPGNotify.h"
 #include "messages/MOSDPGInfo.h"
 #include "messages/MOSDPGRemove.h"
 #include "messages/MOSDPGTrim.h"
 #include "messages/MOSDPGScan.h"
 #include "messages/MOSDPGBackfill.h"
-
 #include "messages/MOSDPing.h"
 #include "messages/MWatchNotify.h"
 
-#include "Watch.h"
-
-#include "mds/inode_backtrace.h" // Ugh
-
-#include "common/config.h"
-#include "include/compat.h"
-#include "global/debug.h"
-
-#include "json_spirit/json_spirit_value.h"
-#include "json_spirit/json_spirit_reader.h"
-#include "include/assert.h"  // json_spirit clobbers it
+#include "ReplicatedPG.h"
 
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this, osd->whoami, get_osdmap()

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -14,17 +14,16 @@
 #ifndef CEPH_REPLICATEDPG_H
 #define CEPH_REPLICATEDPG_H
 
-
-#include "PG.h"
-#include "OSD.h"
-#include "Watch.h"
-#include "OpRequest.h"
+#include "global/debug.h"
 
 #include "messages/MOSDOp.h"
 #include "messages/MOSDOpReply.h"
 #include "messages/MOSDSubOp.h"
 
-#include "global/debug.h"
+#include "PG.h"
+#include "OSD.h"
+#include "Watch.h"
+#include "OpRequest.h"
 
 class MOSDSubOpReply;
 

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -1,15 +1,9 @@
-
-#include "PG.h"
-
 #include "include/types.h"
 
-#include <map>
-
-#include "OSD.h"
+#include "PG.h"
 #include "ReplicatedPG.h"
-#include "Watch.h"
 
-#include "common/config.h"
+#include "Watch.h"
 
 bool Watch::ack_notification(entity_name_t& watcher, Notification *notif)
 {

--- a/src/osd/Watch.h
+++ b/src/osd/Watch.h
@@ -18,8 +18,9 @@
 
 #include <map>
 
-#include "OSD.h"
 #include "common/config.h"
+
+#include "OSD.h"
 
 class MWatchNotify;
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -13,7 +13,9 @@
  */
 
 #include "osd_types.h"
+
 #include "include/ceph_features.h"
+
 #include "PG.h"
 #include "OSDMap.h"
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -15,19 +15,19 @@
 #ifndef CEPH_OSD_TYPES_H
 #define CEPH_OSD_TYPES_H
 
+#include "include/types.h"
+#include "msg/msg_types.h"
+
 #include <sstream>
 #include <stdio.h>
 #include <memory>
 
-#include "msg/msg_types.h"
-#include "include/types.h"
 #include "include/utime.h"
 #include "include/CompatSet.h"
 #include "include/interval_set.h"
 #include "common/snap_types.h"
 #include "common/Formatter.h"
 #include "os/hobject.h"
-
 
 #define CEPH_OSD_ONDISK_MAGIC "ceph osd volume v026"
 

--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -13,19 +13,15 @@
  */
 
 
-#include "Filer.h"
-#include "osd/OSDMap.h"
-#include "Striper.h"
+#include "include/Context.h"
+#include "common/config.h"
+#include "msg/Messenger.h"
 
 #include "messages/MOSDOp.h"
 #include "messages/MOSDOpReply.h"
 #include "messages/MOSDMap.h"
 
-#include "msg/Messenger.h"
-
-#include "include/Context.h"
-
-#include "common/config.h"
+#include "Filer.h"
 
 #define dout_subsys ceph_subsys_filer
 #undef dout_prefix

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -27,8 +27,8 @@
  */
 
 #include "include/types.h"
-
 #include "osd/OSDMap.h"
+
 #include "Objecter.h"
 #include "Striper.h"
 

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -12,18 +12,18 @@
  * 
  */
 
+#include "include/Context.h"
+#include "include/assert.h"
 #include "common/perf_counters.h"
 #include "common/debug.h"
-#include "include/Context.h"
-#include "msg/Messenger.h"
-#include "osdc/Journaler.h"
 #include "common/errno.h"
-#include "include/assert.h"
+#include "msg/Messenger.h"
+
+#include "Journaler.h"
 
 #define dout_subsys ceph_subsys_journaler
 #undef dout_prefix
 #define dout_prefix *_dout << objecter->messenger->get_myname() << ".journaler" << (readonly ? "(ro) ":"(rw) ")
-
 
 void Journaler::set_readonly()
 {

--- a/src/osdc/Journaler.h
+++ b/src/osdc/Journaler.h
@@ -50,11 +50,11 @@
 #ifndef CEPH_JOURNALER_H
 #define CEPH_JOURNALER_H
 
-#include "Objecter.h"
-#include "Filer.h"
-
 #include <list>
 #include <map>
+
+#include "Objecter.h"
+#include "Filer.h"
 
 class CephContext;
 class Context;

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -3,13 +3,14 @@
 
 #include <limits.h>
 
-#include "msg/Messenger.h"
-#include "ObjectCacher.h"
-#include "WritebackHandler.h"
+#include "include/assert.h"
 #include "common/errno.h"
 #include "common/perf_counters.h"
+#include "msg/Messenger.h"
 
-#include "include/assert.h"
+#include "WritebackHandler.h"
+
+#include "ObjectCacher.h"
 
 /*** ObjectCacher::BufferHead ***/
 

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -4,6 +4,7 @@
 #define CEPH_OBJECTCACHER_H
 
 #include "include/types.h"
+
 #include "include/lru.h"
 #include "include/Context.h"
 #include "include/xlist.h"

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -12,35 +12,28 @@
  * 
  */
 
-#include "Objecter.h"
-#include "osd/OSDMap.h"
-#include "Filer.h"
-
-#include "mon/MonClient.h"
-
-#include "msg/Messenger.h"
-#include "msg/Message.h"
-
-#include "messages/MPing.h"
-#include "messages/MOSDOp.h"
-#include "messages/MOSDOpReply.h"
-#include "messages/MOSDMap.h"
-
-#include "messages/MPoolOp.h"
-#include "messages/MPoolOpReply.h"
-
-#include "messages/MGetPoolStats.h"
-#include "messages/MGetPoolStatsReply.h"
-#include "messages/MStatfs.h"
-#include "messages/MStatfsReply.h"
-
-#include "messages/MOSDFailure.h"
-
 #include <errno.h>
 
 #include "common/config.h"
 #include "common/perf_counters.h"
+#include "mon/MonClient.h"
+#include "msg/Messenger.h"
+#include "msg/Message.h"
 
+#include "messages/MPing.h"
+#include "messages/MOSDOpReply.h"
+#include "messages/MOSDMap.h"
+#include "messages/MPoolOp.h"
+#include "messages/MPoolOpReply.h"
+#include "messages/MGetPoolStats.h"
+#include "messages/MGetPoolStatsReply.h"
+#include "messages/MStatfs.h"
+#include "messages/MStatfsReply.h"
+#include "messages/MOSDFailure.h"
+
+#include "Filer.h"
+
+#include "Objecter.h"
 
 #define dout_subsys ceph_subsys_objecter
 #undef dout_prefix

--- a/src/osdc/Striper.cc
+++ b/src/osdc/Striper.cc
@@ -12,19 +12,18 @@
  * 
  */
 
-#include "Striper.h"
-
 #include "include/types.h"
-#include "include/buffer.h"
-#include "osd/OSDMap.h"
 
+#include "include/buffer.h"
 #include "common/config.h"
 #include "common/debug.h"
+#include "osd/OSDMap.h"
+
+#include "Striper.h"
 
 #define dout_subsys ceph_subsys_striper
 #undef dout_prefix
 #define dout_prefix *_dout << "striper "
-
 
 void Striper::file_to_extents(CephContext *cct, const char *object_format,
 			    ceph_file_layout *layout,

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -3,9 +3,10 @@
 #ifndef CEPH_OSDC_WRITEBACKHANDLER_H
 #define CEPH_OSDC_WRITEBACKHANDLER_H
 
-#include "include/Context.h"
-#include "include/types.h"
 #include "osd/osd_types.h"
+#include "include/types.h"
+
+#include "include/Context.h"
 
 class WritebackHandler {
  public:

--- a/src/osdmaptool.cc
+++ b/src/osdmaptool.cc
@@ -16,19 +16,18 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
-
 #include <iostream>
 #include <string>
-using namespace std;
 
 #include "common/config.h"
-
 #include "common/errno.h"
+#include "common/ceph_argparse.h"
 #include "osd/OSDMap.h"
 #include "mon/MonMap.h"
-#include "common/ceph_argparse.h"
 #include "global/global_init.h"
-#include "global/debug.h"
+#include "global/global_context.h"
+
+using namespace std;
 
 void usage()
 {

--- a/src/perfglue/cpu_profiler.cc
+++ b/src/perfglue/cpu_profiler.cc
@@ -12,10 +12,11 @@
  *
  */
 
-#include "common/LogClient.h"
-#include "perfglue/cpu_profiler.h"
-
 #include <google/profiler.h>
+
+#include "common/LogClient.h"
+
+#include "cpu_profiler.h"
 
 void cpu_profiler_handle_command(const std::vector<std::string> &cmd,
 				 ostream& out)

--- a/src/perfglue/disabled_stubs.cc
+++ b/src/perfglue/disabled_stubs.cc
@@ -12,11 +12,12 @@
  *
  */
 
-#include "common/LogClient.h"
-#include "perfglue/cpu_profiler.h"
-
 #include <vector>
 #include <string>
+
+#include "common/LogClient.h"
+
+#include "cpu_profiler.h"
 
 void cpu_profiler_handle_command(const std::vector<std::string> &cmd,
 				 ostream& out)

--- a/src/perfglue/heap_profiler.cc
+++ b/src/perfglue/heap_profiler.cc
@@ -14,11 +14,13 @@
 
 #include <google/heap-profiler.h>
 #include <google/malloc_extension.h>
-#include "heap_profiler.h"
+
 #include "common/environment.h"
 #include "common/LogClient.h"
 #include "global/global_context.h"
 #include "global/debug.h"
+
+#include "heap_profiler.h"
 
 bool ceph_using_tcmalloc()
 {

--- a/src/perfglue/heap_profiler.h
+++ b/src/perfglue/heap_profiler.h
@@ -15,6 +15,7 @@
 
 #include <string>
 #include <vector>
+
 #include "common/config.h"
 
 class LogClient;

--- a/src/psim.cc
+++ b/src/psim.cc
@@ -1,10 +1,9 @@
-
 #include <iostream>
 
+#include "include/buffer.h"
+#include "common/config.h"
 #include "crush/CrushWrapper.h"
 #include "osd/OSDMap.h"
-#include "common/config.h"
-#include "include/buffer.h"
 
 int main(int argc, char **argv)
 {

--- a/src/rados.cc
+++ b/src/rados.cc
@@ -14,23 +14,6 @@
 
 #include "include/types.h"
 
-#include "include/rados/librados.hpp"
-#include "rados_sync.h"
-using namespace librados;
-
-#include "common/config.h"
-#include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "global/debug.h"
-#include "common/Cond.h"
-#include "common/errno.h"
-#include "common/Formatter.h"
-#include "common/obj_bencher.h"
-#include "mds/inode_backtrace.h"
-#include "auth/Crypto.h"
-#include <iostream>
-#include <fstream>
-
 #include <stdlib.h>
 #include <time.h>
 #include <sstream>
@@ -39,8 +22,27 @@ using namespace librados;
 #include <stdexcept>
 #include <climits>
 #include <locale>
+#include <iostream>
+#include <fstream>
+
+#include "include/rados/librados.hpp"
+#include "common/config.h"
+#include "common/ceph_argparse.h"
+#include "common/Cond.h"
+#include "common/errno.h"
+#include "common/Formatter.h"
+#include "common/obj_bencher.h"
+#include "auth/Crypto.h"
+#include "mds/inode_backtrace.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
 #include "cls/lock/cls_lock_client.h"
+
+#include "rados_sync.h"
+
+using namespace librados;
 
 int rados_tool_sync(const std::map < std::string, std::string > &opts,
                              std::vector<const char*> &args);

--- a/src/rados_export.cc
+++ b/src/rados_export.cc
@@ -12,11 +12,6 @@
  *
  */
 
-#include "rados_sync.h"
-#include "common/errno.h"
-#include "common/strtol.h"
-#include "include/rados/librados.hpp"
-
 #include <dirent.h>
 #include <errno.h>
 #include <fstream>
@@ -26,12 +21,16 @@
 #include <stdlib.h>
 #include <string>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 
+#include "include/rados/librados.hpp"
 #include "include/compat.h"
+#include "common/errno.h"
+#include "common/strtol.h"
 #include "common/xattr.h"
+
+#include "rados_sync.h"
 
 using namespace librados;
 

--- a/src/rados_import.cc
+++ b/src/rados_import.cc
@@ -20,14 +20,14 @@
 #include <sstream>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 
-#include "rados_sync.h"
+#include "include/rados/librados.hpp"
 #include "common/errno.h"
 #include "common/strtol.h"
-#include "include/rados/librados.hpp"
+
+#include "rados_sync.h"
 
 using namespace librados;
 using std::auto_ptr;

--- a/src/rados_sync.cc
+++ b/src/rados_sync.cc
@@ -12,18 +12,6 @@
  *
  */
 
-#include "common/ceph_argparse.h"
-#include "common/config.h"
-#include "common/errno.h"
-#include "common/strtol.h"
-#include "global/global_context.h"
-#include "global/global_init.h"
-#include "include/rados/librados.hpp"
-#include "rados_sync.h"
-#include "include/compat.h"
-
-#include "common/xattr.h"
-
 #include <dirent.h>
 #include <errno.h>
 #include <fstream>
@@ -32,11 +20,21 @@
 #include <memory>
 #include <sstream>
 #include <stdlib.h>
-#include <string>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+
+#include "include/rados/librados.hpp"
+#include "include/compat.h"
+#include "common/ceph_argparse.h"
+#include "common/config.h"
+#include "common/errno.h"
+#include "common/strtol.h"
+#include "common/xattr.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+
+#include "rados_sync.h"
 
 using namespace librados;
 using std::auto_ptr;

--- a/src/rados_sync.h
+++ b/src/rados_sync.h
@@ -16,11 +16,11 @@
 #define CEPH_RADOS_SYNC_H
 
 #include <stddef.h>
-#include "include/atomic.h"
-#include "common/WorkQueue.h"
-
 #include <string>
 #include <sys/types.h>
+
+#include "include/atomic.h"
+#include "common/WorkQueue.h"
 
 namespace librados {
   class IoCtx;

--- a/src/radosacl.cc
+++ b/src/radosacl.cc
@@ -11,16 +11,16 @@
  * Foundation.  See file COPYING.
  * 
  */
-
 #include "include/types.h"
-#include "include/rados/librados.hpp"
-using namespace librados;
 
 #include <iostream>
-
 #include <stdlib.h>
 #include <time.h>
 #include <errno.h>
+
+#include "include/rados/librados.hpp"
+
+using namespace librados;
 
 void buf_to_hex(const unsigned char *buf, int len, char *str)
 {

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -12,26 +12,7 @@
  *
  */
 
-#include "mon/MonClient.h"
-#include "mon/MonMap.h"
-#include "common/config.h"
-
-#include "auth/KeyRing.h"
-#include "common/errno.h"
-#include "common/ceph_argparse.h"
-#include "global/global_context.h"
-#include "global/global_init.h"
-#include "common/safe_io.h"
-#include "common/secret.h"
-#include "include/stringify.h"
-#include "include/rados/librados.hpp"
-#include "include/rbd/librbd.hpp"
-#include "include/byteorder.h"
-
-#include "include/intarith.h"
-
-#include "include/compat.h"
-#include "common/blkdev.h"
+#include "include/rbd_types.h"
 
 #include <dirent.h>
 #include <errno.h>
@@ -45,9 +26,6 @@
 #include <tr1/memory>
 #include <sys/ioctl.h>
 
-#include "include/rbd_types.h"
-#include "common/TextTable.h"
-
 #if defined(__linux__)
 #include <linux/fs.h>
 #endif
@@ -56,7 +34,25 @@
 #include <sys/param.h>
 #endif
 
+#include "include/stringify.h"
+#include "include/rados/librados.hpp"
+#include "include/rbd/librbd.hpp"
+#include "include/byteorder.h"
+#include "include/intarith.h"
+#include "include/compat.h"
 #include "include/fiemap.h"
+#include "common/config.h"
+#include "common/errno.h"
+#include "common/ceph_argparse.h"
+#include "common/safe_io.h"
+#include "common/secret.h"
+#include "common/blkdev.h"
+#include "common/TextTable.h"
+#include "auth/KeyRing.h"
+#include "mon/MonClient.h"
+#include "mon/MonMap.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
 
 #define MAX_SECRET_LEN 1000
 #define MAX_POOL_NAME_SIZE 128

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -13,17 +13,19 @@
  */
 
 #include "include/types.h"
+
+#include <errno.h>
+#include <sstream>
+#include <string.h>
+
 #include "include/rados/librgw.h"
-#include "rgw/rgw_acl_s3.h"
-#include "rgw_acl.h"
 #include "common/ceph_argparse.h"
 #include "common/ceph_context.h"
 #include "common/common_init.h"
 #include "common/debug.h"
 
-#include <errno.h>
-#include <sstream>
-#include <string.h>
+#include "rgw_acl.h"
+#include "rgw_acl_s3.h"
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -1,20 +1,16 @@
-#include <string.h>
-
-#include <iostream>
-#include <map>
-
 #include "include/types.h"
 
 #include "common/Formatter.h"
+#include "common/debug.h"
 
-#include "rgw_acl.h"
 #include "rgw_user.h"
-
 #include "rgw_acl_s3.h" // required for backward compatibility
 
-#define dout_subsys ceph_subsys_rgw
+#include "rgw_acl.h"
 
 using namespace std;
+
+#define dout_subsys ceph_subsys_rgw
 
 void RGWAccessControlList::_add_grant(ACLGrant *grant)
 {

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -1,15 +1,13 @@
 #ifndef CEPH_RGW_ACL_H
 #define CEPH_RGW_ACL_H
 
+#include <include/types.h>
+
 #include <map>
 #include <string>
 #include <iostream>
-#include <include/types.h>
-
-#include "common/debug.h"
 
 using namespace std;
-
 
 #define RGW_PERM_READ            0x01
 #define RGW_PERM_WRITE           0x02

--- a/src/rgw/rgw_acl_s3.cc
+++ b/src/rgw/rgw_acl_s3.cc
@@ -1,17 +1,16 @@
-#include <string.h>
-
-#include <iostream>
-#include <map>
-
 #include "include/types.h"
 
-#include "rgw_acl_s3.h"
+#include <string.h>
+
+#include "common/debug.h"
+
 #include "rgw_user.h"
 
-#define dout_subsys ceph_subsys_rgw
+#include "rgw_acl_s3.h"
 
 using namespace std;
 
+#define dout_subsys ceph_subsys_rgw
 
 #define RGW_URI_ALL_USERS	"http://acs.amazonaws.com/groups/global/AllUsers"
 #define RGW_URI_AUTH_USERS	"http://acs.amazonaws.com/groups/global/AuthenticatedUsers"

--- a/src/rgw/rgw_acl_s3.h
+++ b/src/rgw/rgw_acl_s3.h
@@ -1,9 +1,6 @@
 #ifndef CEPH_RGW_ACL_S3_H
 #define CEPH_RGW_ACL_S3_H
 
-#include <map>
-#include <string>
-#include <iostream>
 #include <include/types.h>
 
 #include <expat.h>

--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -1,15 +1,13 @@
-
-#include <string.h>
-
-#include <vector>
+#include "common/debug.h"
 
 #include "rgw_common.h"
 #include "rgw_user.h"
+
 #include "rgw_acl_swift.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 using namespace std;
+
+#define dout_subsys ceph_subsys_rgw
 
 #define SWIFT_PERM_READ  RGW_PERM_READ_OBJS
 #define SWIFT_PERM_WRITE RGW_PERM_WRITE_OBJS

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -1,11 +1,9 @@
 #ifndef CEPH_RGW_ACL_SWIFT_H
 #define CEPH_RGW_ACL_SWIFT3_H
 
-#include <map>
-#include <string>
-#include <iostream>
-#include <vector>
 #include <include/types.h>
+
+#include <vector>
 
 #include "rgw_acl.h"
 

--- a/src/rgw/rgw_aclparser.cc
+++ b/src/rgw/rgw_aclparser.cc
@@ -1,12 +1,9 @@
-#include <string.h>
-
-#include "common/ceph_context.h"
 #include "include/types.h"
-#include "rgw/rgw_acl.h"
+
+#include "global/global_context.h"
 #include "global/debug.h"
 
-#include <iostream>
-#include <map>
+#include "rgw_acl.h"
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1,21 +1,20 @@
 #include <errno.h>
-
 #include <iostream>
 #include <sstream>
 #include <string>
 
-using namespace std;
-
+#include "include/utime.h"
+#include "include/str_list.h"
 #include "common/config.h"
 #include "common/ceph_argparse.h"
 #include "common/Formatter.h"
-#include "global/global_init.h"
-#include "global/debug.h"
 #include "common/errno.h"
-#include "include/utime.h"
-#include "include/str_list.h"
-
 #include "common/armor.h"
+#include "auth/Crypto.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "global/debug.h"
+
 #include "rgw_user.h"
 #include "rgw_rados.h"
 #include "rgw_acl.h"
@@ -23,7 +22,8 @@ using namespace std;
 #include "rgw_log.h"
 #include "rgw_formats.h"
 #include "rgw_usage.h"
-#include "auth/Crypto.h"
+
+using namespace std;
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -1,11 +1,12 @@
-#include "rgw_cache.h"
-#include "common/debug.h"
-
 #include <errno.h>
 
-#define dout_subsys ceph_subsys_rgw
+#include "common/debug.h"
+
+#include "rgw_cache.h"
 
 using namespace std;
+
+#define dout_subsys ceph_subsys_rgw
 
 int ObjectCache::get(string& name, ObjectCacheInfo& info, uint32_t mask)
 {

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -1,12 +1,14 @@
 #ifndef CEPH_RGWCACHE_H
 #define CEPH_RGWCACHE_H
 
-#include "rgw_rados.h"
 #include <string>
 #include <map>
+
 #include "include/types.h"
 #include "include/utime.h"
 #include "include/assert.h"
+
+#include "rgw_rados.h"
 
 enum {
   UPDATE_OBJ,

--- a/src/rgw/rgw_client_io.cc
+++ b/src/rgw/rgw_client_io.cc
@@ -1,10 +1,7 @@
-
 #include <stdio.h>
-#include <stdlib.h>
 #include <stdarg.h>
 
 #include "rgw_client_io.h"
-
 
 int RGWClientIO::print(const char *format, ...)
 {

--- a/src/rgw/rgw_client_io.h
+++ b/src/rgw/rgw_client_io.h
@@ -1,9 +1,9 @@
 #ifndef CEPH_RGW_CLIENT_IO_H
 #define CEPH_RGW_CLIENT_IO_H
 
-#include <stdlib.h>
-
 #include "include/types.h"
+
+#include <stdlib.h>
 
 class RGWClientIO {
   bool account;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1,20 +1,17 @@
-#include <errno.h>
+#include <sstream>
 
-#include "rgw_common.h"
-#include "rgw_acl.h"
-#include "rgw_string.h"
-
-#include "common/ceph_crypto.h"
+#include "include/str_list.h"
 #include "common/armor.h"
 #include "common/errno.h"
 #include "common/Clock.h"
 #include "common/Formatter.h"
-#include "common/perf_counters.h"
-#include "include/str_list.h"
 #include "auth/Crypto.h"
 #include "global/debug.h"
 
-#include <sstream>
+#include "rgw_acl.h"
+#include "rgw_string.h"
+
+#include "rgw_common.h"
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -15,17 +15,17 @@
 #ifndef CEPH_RGW_COMMON_H
 #define CEPH_RGW_COMMON_H
 
-#include "common/ceph_crypto.h"
-#include "common/perf_counters.h"
-
 #include "acconfig.h"
+#include "include/types.h"
 
 #include <errno.h>
 #include <string.h>
 #include <string>
 #include <map>
-#include "include/types.h"
+
 #include "include/utime.h"
+#include "common/ceph_crypto.h"
+#include "common/perf_counters.h"
 
 using namespace std;
 

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -1,3 +1,4 @@
+#include "common/Formatter.h"
 
 #include "rgw_common.h"
 #include "rgw_rados.h"
@@ -5,8 +6,6 @@
 #include "rgw_acl.h"
 #include "rgw_acl_s3.h"
 #include "rgw_cache.h"
-
-#include "common/Formatter.h"
 
 void RGWObjManifestPart::generate_test_instances(std::list<RGWObjManifestPart*>& o)
 {

--- a/src/rgw/rgw_env.cc
+++ b/src/rgw/rgw_env.cc
@@ -1,9 +1,6 @@
 #include "rgw_common.h"
 #include "rgw_log.h"
 
-#include <string>
-#include <map>
-
 #define dout_subsys ceph_subsys_rgw
 
 RGWEnv::RGWEnv()

--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -1,14 +1,12 @@
-
-
-#include "rgw_fcgi.h"
-
 #include "acconfig.h"
+
 #ifdef FASTCGI_INCLUDE_DIR
 # include "fastcgi/fcgiapp.h"
 #else
 # include "fcgiapp.h"
 #endif
 
+#include "rgw_fcgi.h"
 
 int RGWFCGX::write_data(const char *buf, int len)
 {

--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -3,9 +3,7 @@
 
 #include "rgw_client_io.h"
 
-
 struct FCGX_Request;
-
 
 class RGWFCGX : public RGWClientIO
 {

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -14,8 +14,10 @@
 
 #include "common/escape.h"
 #include "common/Formatter.h"
-#include "rgw/rgw_common.h"
-#include "rgw/rgw_formats.h"
+
+#include "rgw_common.h"
+
+#include "rgw_formats.h"
 
 #define LARGE_SIZE 8192
 

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -1,11 +1,11 @@
 #ifndef CEPH_RGW_FORMATS_H
 #define CEPH_RGW_FORMATS_H
 
-#include "common/Formatter.h"
-
 #include <list>
 #include <stdint.h>
 #include <string>
+
+#include "common/Formatter.h"
 
 struct plain_stack_entry {
   int size;

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -1,18 +1,19 @@
-#include "rgw_gc.h"
+#include <list>
+
 #include "include/rados/librados.hpp"
+#include "auth/Crypto.h"
 #include "cls/rgw/cls_rgw_client.h"
 #include "cls/refcount/cls_refcount_client.h"
 #include "cls/lock/cls_lock_client.h"
-#include "auth/Crypto.h"
-
+#include "global/global_context.h"
 #include "global/debug.h"
 
-#include <list>
-
-#define dout_subsys ceph_subsys_rgw
+#include "rgw_gc.h"
 
 using namespace std;
 using namespace librados;
+
+#define dout_subsys ceph_subsys_rgw
 
 static string gc_oid_prefix = "gc";
 static string gc_index_lock_name = "gc_process";

--- a/src/rgw/rgw_gc.h
+++ b/src/rgw/rgw_gc.h
@@ -1,16 +1,16 @@
 #ifndef CEPH_RGW_GC_H
 #define CEPH_RGW_GC_H
 
-
 #include "include/types.h"
+
 #include "include/atomic.h"
-#include "include/rados/librados.hpp"
 #include "common/Mutex.h"
 #include "common/Cond.h"
 #include "common/Thread.h"
+#include "cls/rgw/cls_rgw_types.h"
+
 #include "rgw_common.h"
 #include "rgw_rados.h"
-#include "cls/rgw/cls_rgw_types.h"
 
 class RGWGC {
   CephContext *cct;

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -2,7 +2,7 @@
 #include <curl/easy.h>
 
 #include "global/debug.h"
-#include "rgw_common.h"
+
 #include "rgw_http_client.h"
 
 #define dout_subsys ceph_subsys_rgw

--- a/src/rgw/rgw_json.cc
+++ b/src/rgw/rgw_json.cc
@@ -1,11 +1,9 @@
 #include <iostream>
 #include <include/types.h>
+#include <fstream> // for testing DELETE ME
 
 #include "rgw_json.h"
 #include "rgw_common.h"
-
-// for testing DELETE ME
-#include <fstream>
 
 using namespace std;
 using namespace json_spirit;

--- a/src/rgw/rgw_json.h
+++ b/src/rgw/rgw_json.h
@@ -1,18 +1,15 @@
 #ifndef RGW_JSON_H
 #define RGW_JSON_H
 
-#include <iostream>
 #include <include/types.h>
 
-// for testing DELETE ME
-#include <fstream>
+#include <iostream>
+#include <fstream> // for testing DELETE ME
 
 #include "json_spirit/json_spirit.h"
 
-
 using namespace std;
 using namespace json_spirit;
-
 
 class JSONObj;
 

--- a/src/rgw/rgw_jsonparser.cc
+++ b/src/rgw/rgw_jsonparser.cc
@@ -1,15 +1,13 @@
-#include <string.h>
-
-#include <iostream>
-#include <map>
-
 #include "include/types.h"
+
+#include <string.h>
+#include <map>
 
 #include "rgw_json.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 using namespace std;
+
+#define dout_subsys ceph_subsys_rgw
 
 void dump_array(JSONObj *obj)
 {

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -1,13 +1,12 @@
 #include "common/Clock.h"
 #include "common/Timer.h"
 #include "common/utf8.h"
-#include "common/OutputDataSocket.h"
-#include "common/Formatter.h"
 
-#include "rgw_log.h"
 #include "rgw_acl.h"
 #include "rgw_rados.h"
 #include "rgw_client_io.h"
+
+#include "rgw_log.h"
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -1,10 +1,10 @@
 #ifndef CEPH_RGW_LOG_H
 #define CEPH_RGW_LOG_H
 
-#include "rgw_common.h"
-#include "include/utime.h"
 #include "common/Formatter.h"
 #include "common/OutputDataSocket.h"
+
+#include "rgw_common.h"
 
 class RGWRados;
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -1,35 +1,37 @@
+#include "acconfig.h"
+#include "include/types.h"
+
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdarg.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <signal.h>
-
+#include <vector>
+#include <iostream>
+#include <sstream>
 #include <curl/curl.h>
 
-#include "acconfig.h"
 #ifdef FASTCGI_INCLUDE_DIR
 # include "fastcgi/fcgiapp.h"
 #else
 # include "fcgiapp.h"
 #endif
 
-#include "rgw_fcgi.h"
-
+#include "include/str_list.h"
 #include "common/ceph_argparse.h"
-#include "global/global_context.h"
-#include "global/global_init.h"
-#include "global/signal_handler.h"
-#include "global/debug.h"
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/WorkQueue.h"
 #include "common/Timer.h"
 #include "common/Throttle.h"
-#include "include/str_list.h"
+#include "common/BackTrace.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "global/signal_handler.h"
+#include "global/debug.h"
+
 #include "rgw_common.h"
 #include "rgw_rados.h"
 #include "rgw_acl.h"
@@ -45,19 +47,11 @@
 #include "rgw_log.h"
 #include "rgw_tools.h"
 #include "rgw_resolve.h"
-
-#include <map>
-#include <string>
-#include <vector>
-#include <iostream>
-#include <sstream>
-
-#include "include/types.h"
-#include "common/BackTrace.h"
-
-#define dout_subsys ceph_subsys_rgw
+#include "rgw_fcgi.h"
 
 using namespace std;
+
+#define dout_subsys ceph_subsys_rgw
 
 static sighandler_t sighandler_usr1;
 static sighandler_t sighandler_alrm;

--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -1,17 +1,13 @@
-#include <string.h>
-
-#include <iostream>
-#include <map>
-
 #include "include/types.h"
 
-#include "rgw_xml.h"
-#include "rgw_multi.h"
+#include <string.h>
+#include <iostream>
 
-#define dout_subsys ceph_subsys_rgw
+#include "rgw_multi.h"
 
 using namespace std;
 
+#define dout_subsys ceph_subsys_rgw
 
 bool RGWMultiPart::xml_end(const char *el)
 {

--- a/src/rgw/rgw_multi_del.cc
+++ b/src/rgw/rgw_multi_del.cc
@@ -1,15 +1,13 @@
-#include <string.h>
-
-#include <iostream>
-
 #include "include/types.h"
 
-#include "rgw_xml.h"
+#include <string.h>
+#include <iostream>
+
 #include "rgw_multi_del.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 using namespace std;
+
+#define dout_subsys ceph_subsys_rgw
 
 
 bool RGWMultiDelObject::xml_end(const char *el)

--- a/src/rgw/rgw_multiparser.cc
+++ b/src/rgw/rgw_multiparser.cc
@@ -1,15 +1,13 @@
-#include <string.h>
-
-#include <iostream>
-#include <map>
-
 #include "include/types.h"
+
+#include <string.h>
+#include <iostream>
 
 #include "rgw_multi.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 using namespace std;
+
+#define dout_subsys ceph_subsys_rgw
                                   
 int main(int argc, char **argv) {
   RGWMultiXMLParser parser;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1,7 +1,5 @@
-
 #include <errno.h>
 #include <stdlib.h>
-
 #include <sstream>
 
 #include "common/Clock.h"
@@ -10,22 +8,19 @@
 #include "common/utf8.h"
 #include "global/debug.h"
 
-#include "rgw_rados.h"
-#include "rgw_op.h"
 #include "rgw_rest.h"
-#include "rgw_acl.h"
 #include "rgw_acl_s3.h"
-#include "rgw_user.h"
 #include "rgw_log.h"
 #include "rgw_multi.h"
 #include "rgw_multi_del.h"
-
 #include "rgw_client_io.h"
 
-#define dout_subsys ceph_subsys_rgw
+#include "rgw_op.h"
 
 using namespace std;
 using ceph::crypto::MD5;
+
+#define dout_subsys ceph_subsys_rgw
 
 static string mp_ns = RGW_OBJ_NS_MULTIPART;
 static string shadow_ns = RGW_OBJ_NS_SHADOW;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -11,9 +11,6 @@
 
 #include <limits.h>
 
-#include <string>
-#include <map>
-
 #include "rgw_common.h"
 #include "rgw_rados.h"
 #include "rgw_user.h"

--- a/src/rgw/rgw_policy_s3.cc
+++ b/src/rgw/rgw_policy_s3.cc
@@ -1,11 +1,9 @@
-
-#include <errno.h>
-
 #include "global/debug.h"
 
-#include "rgw_policy_s3.h"
 #include "rgw_json.h"
 #include "rgw_common.h"
+
+#include "rgw_policy_s3.h"
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_policy_s3.h
+++ b/src/rgw/rgw_policy_s3.h
@@ -1,8 +1,6 @@
 #ifndef CEPH_RGW_POLICY_H
 #define CEPH_RGW_POLICY_H
 
-#include <limits.h>
-
 #include <map>
 #include <list>
 #include <string>
@@ -10,7 +8,6 @@
 #include "include/utime.h"
 
 #include "rgw_string.h"
-
 
 class RGWPolicyEnv {
   std::map<std::string, std::string, ltstr_nocase> vars;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1,36 +1,28 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/types.h>
-
-#include "common/errno.h"
-#include "common/Formatter.h"
-
-#include "rgw_rados.h"
-#include "rgw_cache.h"
-#include "rgw_acl.h"
-
-#include "cls/rgw/cls_rgw_types.h"
-#include "cls/rgw/cls_rgw_client.h"
-#include "cls/refcount/cls_refcount_client.h"
-
-#include "rgw_tools.h"
-
-#include "common/Clock.h"
-#include "global/debug.h"
-
-#include "include/rados/librados.hpp"
-using namespace librados;
-
 #include <string>
 #include <iostream>
 #include <vector>
 #include <list>
 #include <map>
+
+#include "common/errno.h"
+#include "common/Formatter.h"
+#include "common/Clock.h"
 #include "auth/Crypto.h" // get_random_bytes()
+#include "cls/rgw/cls_rgw_client.h"
+#include "cls/refcount/cls_refcount_client.h"
+#include "global/debug.h"
 
-#include "rgw_log.h"
-
+#include "rgw_cache.h"
+#include "rgw_acl.h"
+#include "rgw_tools.h"
 #include "rgw_gc.h"
+
+#include "rgw_rados.h"
+
+using namespace librados;
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3,8 +3,9 @@
 
 #include "include/rados/librados.hpp"
 #include "include/Context.h"
-#include "rgw_common.h"
 #include "cls/rgw/cls_rgw_types.h"
+
+#include "rgw_common.h"
 #include "rgw_log.h"
 
 class RGWWatcher;

--- a/src/rgw/rgw_resolve.cc
+++ b/src/rgw/rgw_resolve.cc
@@ -4,7 +4,7 @@
 #include <resolv.h>
 
 #include "global/debug.h"
-#include "rgw_common.h"
+
 #include "rgw_resolve.h"
 
 #define dout_subsys ceph_subsys_rgw

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1,24 +1,21 @@
-#include <errno.h>
 #include <limits.h>
 
+#include "include/str_list.h"
 #include "common/Formatter.h"
 #include "common/utf8.h"
-#include "include/str_list.h"
 #include "global/debug.h"
+
 #include "rgw_common.h"
 #include "rgw_rados.h"
-#include "rgw_formats.h"
-#include "rgw_op.h"
-#include "rgw_rest.h"
 #include "rgw_rest_swift.h"
 #include "rgw_rest_s3.h"
 #include "rgw_swift_auth.h"
-
 #include "rgw_client_io.h"
 #include "rgw_resolve.h"
 
-#define dout_subsys ceph_subsys_rgw
+#include "rgw_rest.h"
 
+#define dout_subsys ceph_subsys_rgw
 
 struct rgw_http_attr {
   const char *rgw_attr;

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -5,7 +5,6 @@
 #include "rgw_op.h"
 #include "rgw_formats.h"
 
-
 extern std::map<std::string, std::string> rgw_to_http_attrs;
 
 extern void rgw_rest_init(CephContext *cct);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4,20 +4,18 @@
 #include "common/ceph_crypto.h"
 #include "common/Formatter.h"
 #include "common/utf8.h"
+#include "common/armor.h"
 #include "global/debug.h"
 
 #include "rgw_rest.h"
-#include "rgw_rest_s3.h"
 #include "rgw_acl.h"
-#include "rgw_policy_s3.h"
-
-#include "common/armor.h"
-
 #include "rgw_client_io.h"
 
-#define dout_subsys ceph_subsys_rgw
+#include "rgw_rest_s3.h"
 
 using namespace ceph::crypto;
+
+#define dout_subsys ceph_subsys_rgw
 
 void dump_common_s3_headers(struct req_state *s, const char *etag,
                             size_t content_len, const char *conn_status)

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1,14 +1,15 @@
+#include <sstream>
 
 #include "common/Formatter.h"
 #include "common/utf8.h"
 #include "global/debug.h"
+
 #include "rgw_swift.h"
-#include "rgw_rest_swift.h"
 #include "rgw_acl_swift.h"
 #include "rgw_formats.h"
 #include "rgw_client_io.h"
 
-#include <sstream>
+#include "rgw_rest_swift.h"
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_rest_usage.cc
+++ b/src/rgw/rgw_rest_usage.cc
@@ -1,8 +1,9 @@
+#include "include/str_list.h"
+
 #include "rgw_op.h"
 #include "rgw_usage.h"
-#include "rgw_rest_usage.h"
 
-#include "include/str_list.h"
+#include "rgw_rest_usage.h"
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_rest_usage.h
+++ b/src/rgw/rgw_rest_usage.h
@@ -4,7 +4,6 @@
 #include "rgw_rest.h"
 #include "rgw_rest_s3.h"
 
-
 class RGWHandler_Usage : public RGWHandler_Auth_S3 {
 protected:
   RGWOp *op_get();

--- a/src/rgw/rgw_string.h
+++ b/src/rgw/rgw_string.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <limits.h>
+#include <errno.h>
 
 struct ltstr_nocase
 {

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -2,19 +2,18 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "include/str_list.h"
+#include "common/ceph_crypto_cms.h"
+#include "common/armor.h"
+#include "global/global_context.h"
+#include "global/debug.h"
+
 #include "rgw_json.h"
-#include "rgw_common.h"
-#include "rgw_swift.h"
 #include "rgw_swift_auth.h"
 #include "rgw_user.h"
 #include "rgw_http_client.h"
 
-#include "include/str_list.h"
-
-#include "global/global_context.h"
-#include "global/debug.h"
-#include "common/ceph_crypto_cms.h"
-#include "common/armor.h"
+#include "rgw_swift.h"
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -1,9 +1,9 @@
-
 #ifndef CEPH_RGW_SWIFT_H
 #define CEPH_RGW_SWIFT_H
 
-#include "rgw_common.h"
 #include "common/Cond.h"
+
+#include "rgw_common.h"
 
 class RGWRados;
 

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -1,19 +1,17 @@
-#include "rgw_swift_auth.h"
-#include "rgw_rest.h"
-
-#include "global/debug.h"
 #include "common/ceph_crypto.h"
 #include "common/Clock.h"
-
 #include "auth/Crypto.h"
+#include "global/debug.h"
 
 #include "rgw_client_io.h"
+
+#include "rgw_swift_auth.h"
+
+using namespace ceph::crypto;
 
 #define dout_subsys ceph_subsys_rgw
 
 #define DEFAULT_SWIFT_PREFIX "swift"
-
-using namespace ceph::crypto;
 
 static int build_token(string& swift_user, string& key, uint64_t nonce, utime_t& expiration, bufferlist& bl)
 {

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -1,11 +1,9 @@
-#include <errno.h>
+#include "include/types.h"
 
 #include "common/errno.h"
 
-#include "include/types.h"
-
-#include "rgw_common.h"
 #include "rgw_rados.h"
+
 #include "rgw_tools.h"
 
 #define dout_subsys ceph_subsys_rgw

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -1,9 +1,8 @@
 #ifndef CEPH_RGW_TOOLS_H
 #define CEPH_RGW_TOOLS_H
 
-#include <string>
-
 #include "include/types.h"
+
 #include "rgw_common.h"
 
 class RGWRados;

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -1,13 +1,9 @@
 
-#include <string>
-#include <map>
-
 #include "rgw_rados.h"
+
 #include "rgw_usage.h"
-#include "rgw_formats.h"
 
 using namespace std;
-
 
 static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log_entry& entry, map<string, bool> *categories)
 {

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1,19 +1,15 @@
-#include <errno.h>
-
-#include <string>
-#include <map>
+#include "include/types.h"
 
 #include "common/errno.h"
+
 #include "rgw_rados.h"
 #include "rgw_acl.h"
 
-#include "include/types.h"
 #include "rgw_user.h"
-
-#define dout_subsys ceph_subsys_rgw
 
 using namespace std;
 
+#define dout_subsys ceph_subsys_rgw
 
 /**
  * Get the anonymous (ie, unauthenticated) user info.

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -1,9 +1,8 @@
 #ifndef CEPH_RGW_USER_H
 #define CEPH_RGW_USER_H
 
-#include <string>
-
 #include "include/types.h"
+
 #include "rgw_common.h"
 #include "rgw_tools.h"
 

--- a/src/rgw/rgw_xml.cc
+++ b/src/rgw/rgw_xml.cc
@@ -1,11 +1,7 @@
-#include <string.h>
-
-#include <iostream>
-#include <map>
-
 #include "include/types.h"
 
 #include "rgw_common.h"
+
 #include "rgw_xml.h"
 
 #define dout_subsys ceph_subsys_rgw

--- a/src/scratchtoolpp.cc
+++ b/src/scratchtoolpp.cc
@@ -11,17 +11,16 @@
  * Foundation.  See file COPYING.
  * 
  */
-
 #include "include/types.h"
-#include "include/rados/librados.hpp"
-
-using namespace librados;
 
 #include <iostream>
-
 #include <errno.h>
 #include <stdlib.h>
 #include <time.h>
+
+#include "include/rados/librados.hpp"
+
+using namespace librados;
 
 void buf_to_hex(const unsigned char *buf, int len, char *str)
 {

--- a/src/streamtest.cc
+++ b/src/streamtest.cc
@@ -13,11 +13,12 @@
  */
 
 #include <iostream>
+
+#include "common/ceph_argparse.h"
+#include "common/debug.h"
 #include "os/FileStore.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
-#include "common/ceph_argparse.h"
-#include "common/debug.h"
 
 #undef dout_prefix
 #define dout_prefix *_dout

--- a/src/test/ObjectMap/KeyValueDBMemory.h
+++ b/src/test/ObjectMap/KeyValueDBMemory.h
@@ -5,9 +5,9 @@
 #include <string>
 #include <tr1/memory>
 
-#include "os/KeyValueDB.h"
 #include "include/buffer.h"
 #include "include/Context.h"
+#include "os/KeyValueDB.h"
 
 using std::string;
 

--- a/src/test/ObjectMap/test_keyvaluedb_iterators.cc
+++ b/src/test/ObjectMap/test_keyvaluedb_iterators.cc
@@ -10,20 +10,17 @@
 * License version 2.1, as published by the Free Software
 * Foundation. See file COPYING.
 */
-#include <tr1/memory>
-#include <map>
-#include <set>
 #include <deque>
-#include <boost/scoped_ptr.hpp>
-
-#include "test/ObjectMap/KeyValueDBMemory.h"
-#include "os/KeyValueDB.h"
-#include "os/LevelDBStore.h"
 #include <sys/types.h>
+#include <boost/scoped_ptr.hpp>
+#include "gtest/gtest.h"
+
+#include "common/ceph_argparse.h"
+#include "os/LevelDBStore.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
-#include "common/ceph_argparse.h"
-#include "gtest/gtest.h"
+
+#include "KeyValueDBMemory.h"
 
 using namespace std;
 

--- a/src/test/ObjectMap/test_object_map.cc
+++ b/src/test/ObjectMap/test_object_map.cc
@@ -1,23 +1,18 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-#include <tr1/memory>
-#include <map>
-#include <set>
+#include <sys/types.h>
 #include <boost/scoped_ptr.hpp>
+#include "stdlib.h"
+#include <dirent.h>
+#include "gtest/gtest.h"
 
-#include "include/buffer.h"
-#include "test/ObjectMap/KeyValueDBMemory.h"
-#include "os/KeyValueDB.h"
+#include "common/ceph_argparse.h"
 #include "os/DBObjectMap.h"
 #include "os/HashIndex.h"
 #include "os/LevelDBStore.h"
-#include <sys/types.h>
 #include "global/global_context.h"
 #include "global/global_init.h"
-#include "common/ceph_argparse.h"
-#include <dirent.h>
 
-#include "gtest/gtest.h"
-#include "stdlib.h"
+#include "KeyValueDBMemory.h"
 
 using namespace std;
 

--- a/src/test/TestSignalHandlers.cc
+++ b/src/test/TestSignalHandlers.cc
@@ -17,16 +17,17 @@
  *
  * Test the Ceph signal handlers
  */
-#include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "global/debug.h"
-#include "common/errno.h"
-#include "common/config.h"
-
 #include <errno.h>
 #include <iostream>
 #include <sstream>
 #include <string>
+
+#include "common/ceph_argparse.h"
+#include "common/errno.h"
+#include "common/config.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "global/debug.h"
 
 using std::string;
 

--- a/src/test/TestTimers.cc
+++ b/src/test/TestTimers.cc
@@ -1,10 +1,10 @@
+#include <iostream>
+
 #include "common/ceph_argparse.h"
 #include "common/Mutex.h"
 #include "common/Timer.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
-
-#include <iostream>
 
 /*
  * TestTimers

--- a/src/test/admin_socket.cc
+++ b/src/test/admin_socket.cc
@@ -11,17 +11,16 @@
  * Foundation.  See file COPYING.
  *
  */
-
-#include "common/Mutex.h"
-#include "common/admin_socket.h"
-#include "common/admin_socket_client.h"
-#include "common/ceph_context.h"
-#include "test/unit.h"
-
 #include <stdint.h>
 #include <string.h>
 #include <string>
 #include <sys/un.h>
+
+#include "common/Mutex.h"
+#include "common/admin_socket.h"
+#include "common/admin_socket_client.h"
+
+#include "unit.h"
 
 class AdminSocketTest
 {

--- a/src/test/bench/bencher.h
+++ b/src/test/bench/bencher.h
@@ -4,13 +4,15 @@
 #define BENCHERH
 
 #include <utility>
-#include "distribution.h"
-#include "stat_collector.h"
-#include "backend.h"
 #include <boost/scoped_ptr.hpp>
+
 #include "common/Mutex.h"
 #include "common/Cond.h"
 #include "common/Thread.h"
+
+#include "distribution.h"
+#include "stat_collector.h"
+#include "backend.h"
 
 class OnWriteApplied;
 class OnWriteCommit;

--- a/src/test/bench/detailed_stat_collector.h
+++ b/src/test/bench/detailed_stat_collector.h
@@ -3,16 +3,18 @@
 #ifndef DETAILEDSTATCOLLECTERH
 #define DETAILEDSTATCOLLECTERH
 
-#include "stat_collector.h"
-#include "common/Formatter.h"
-#include <boost/scoped_ptr.hpp>
-#include "common/Mutex.h"
-#include "common/Cond.h"
-#include "include/utime.h"
 #include <list>
 #include <map>
 #include <boost/tuple/tuple.hpp>
 #include <ostream>
+#include <boost/scoped_ptr.hpp>
+
+#include "include/utime.h"
+#include "common/Formatter.h"
+#include "common/Mutex.h"
+#include "common/Cond.h"
+
+#include "stat_collector.h"
 
 class DetailedStatCollector : public StatCollector {
 public:

--- a/src/test/bench/dumb_backend.h
+++ b/src/test/bench/dumb_backend.h
@@ -3,13 +3,13 @@
 #ifndef DUMBBACKEND
 #define DUMBBACKEND
 
-#include "backend.h"
-#include "include/Context.h"
-#include "os/ObjectStore.h"
+#include <deque>
+
 #include "common/WorkQueue.h"
 #include "common/Semaphore.h"
+#include "os/ObjectStore.h"
 
-#include <deque>
+#include "backend.h"
 
 class DumbBackend : public Backend {
 	const string path;

--- a/src/test/bench/filestore_backend.cc
+++ b/src/test/bench/filestore_backend.cc
@@ -1,9 +1,9 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 
-#include "filestore_backend.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
-#include "os/ObjectStore.h"
+
+#include "filestore_backend.h"
 
 struct C_DeleteTransWrapper : public Context {
   Context *c;

--- a/src/test/bench/filestore_backend.h
+++ b/src/test/bench/filestore_backend.h
@@ -4,9 +4,9 @@
 #define FILESTOREBACKENDH
 
 #include "common/Finisher.h"
-#include "backend.h"
-#include "include/Context.h"
 #include "os/ObjectStore.h"
+
+#include "backend.h"
 
 class FileStoreBackend : public Backend {
   ObjectStore *os;

--- a/src/test/bench/rados_backend.h
+++ b/src/test/bench/rados_backend.h
@@ -3,9 +3,9 @@
 #ifndef RADOSBACKENDH
 #define RADOSBACKENDH
 
-#include "backend.h"
-#include "include/Context.h"
 #include "include/rados/librados.hpp"
+
+#include "backend.h"
 
 class RadosBackend : public Backend {
   librados::IoCtx *ioctx;

--- a/src/test/bench/small_io_bench_dumb.cc
+++ b/src/test/bench/small_io_bench_dumb.cc
@@ -15,14 +15,14 @@
 #include <iostream>
 
 #include "common/Formatter.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
 
+#include "dumb_backend.h"
 #include "bencher.h"
 #include "rados_backend.h"
 #include "detailed_stat_collector.h"
 #include "distribution.h"
-#include "global/global_init.h"
-#include "os/FileStore.h"
-#include "dumb_backend.h"
 
 namespace po = boost::program_options;
 using namespace std;

--- a/src/test/bench/small_io_bench_fs.cc
+++ b/src/test/bench/small_io_bench_fs.cc
@@ -15,15 +15,16 @@
 #include <iostream>
 
 #include "common/Formatter.h"
+#include "common/perf_counters.h"
+#include "os/FileStore.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
 
-#include "bencher.h"
 #include "rados_backend.h"
+#include "filestore_backend.h"
+#include "bencher.h"
 #include "detailed_stat_collector.h"
 #include "distribution.h"
-#include "global/global_init.h"
-#include "os/FileStore.h"
-#include "filestore_backend.h"
-#include "common/perf_counters.h"
 
 namespace po = boost::program_options;
 using namespace std;

--- a/src/test/bench/tp_bench.cc
+++ b/src/test/bench/tp_bench.cc
@@ -15,16 +15,16 @@
 #include <iostream>
 
 #include "common/Formatter.h"
+#include "common/WorkQueue.h"
+#include "common/Semaphore.h"
+#include "common/Finisher.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
 
 #include "bencher.h"
 #include "rados_backend.h"
 #include "detailed_stat_collector.h"
 #include "distribution.h"
-#include "global/global_context.h"
-#include "global/global_init.h"
-#include "common/WorkQueue.h"
-#include "common/Semaphore.h"
-#include "common/Finisher.h"
 
 namespace po = boost::program_options;
 using namespace std;

--- a/src/test/bench_log.cc
+++ b/src/test/bench_log.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "include/types.h"
+
 #include "common/Thread.h"
 #include "common/Clock.h"
 #include "common/config.h"

--- a/src/test/ceph_crypto.cc
+++ b/src/test/ceph_crypto.cc
@@ -1,6 +1,6 @@
 #include "common/ceph_crypto.h"
 
-#include "test/unit.h"
+#include "unit.h"
 
 class CryptoEnvironment: public ::testing::Environment {
 public:

--- a/src/test/common/ObjectContents.h
+++ b/src/test/common/ObjectContents.h
@@ -1,7 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+#include <map>
+
 #include "include/interval_set.h"
 #include "include/buffer.h"
-#include <map>
 
 #ifndef COMMON_OBJECT_H
 #define COMMON_OBJECT_H

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -1,11 +1,12 @@
+#include "include/types.h"
+
 #include <errno.h>
 #include <time.h>
 
-#include "include/types.h"
-#include "auth/Crypto.h"
 #include "common/ceph_crypto.h"
+#include "auth/Crypto.h"
 
-#include "test/unit.h"
+#include "unit.h"
 
 class CryptoEnvironment: public ::testing::Environment {
 public:

--- a/src/test/daemon_config.cc
+++ b/src/test/daemon_config.cc
@@ -12,16 +12,17 @@
  *
  */
 
-#include "common/ceph_argparse.h"
-#include "common/config.h"
-#include "include/cephfs/libcephfs.h"
-#include "include/rados/librados.h"
-#include "test/unit.h"
-
 #include <errno.h>
 #include <sstream>
 #include <string>
 #include <string.h>
+
+#include "include/cephfs/libcephfs.h"
+#include "include/rados/librados.h"
+#include "common/ceph_argparse.h"
+#include "common/config.h"
+
+#include "unit.h"
 
 using std::string;
 

--- a/src/test/encoding/ceph_dencoder.cc
+++ b/src/test/encoding/ceph_dencoder.cc
@@ -1,13 +1,16 @@
-#include <errno.h>
 #include "include/types.h"
 #include "ceph_ver.h"
+
+#include <errno.h>
+
 #include "include/encoding.h"
 #include "include/ceph_features.h"
+#include "include/assert.h"
 #include "common/ceph_argparse.h"
 #include "common/Formatter.h"
 #include "common/errno.h"
 #include "msg/Message.h"
-#include "include/assert.h"
+#include "global/global_context.h"
 
 #define TYPE(t)
 #define TYPEWITHSTRAYDATA(t)

--- a/src/test/filestore/DeterministicOpSequence.cc
+++ b/src/test/filestore/DeterministicOpSequence.cc
@@ -12,23 +12,20 @@
 */
 #include <stdio.h>
 #include <string.h>
-#include <iostream>
-#include <fstream>
 #include <time.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <sstream>
-#include "os/FileStore.h"
-#include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "global/debug.h"
 #include <boost/scoped_ptr.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include "DeterministicOpSequence.h"
-
-#include "common/config.h"
 #include "include/assert.h"
+#include "common/ceph_argparse.h"
+#include "common/config.h"
+#include "global/global_init.h"
+#include "global/debug.h"
+
+#include "DeterministicOpSequence.h"
 
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix

--- a/src/test/filestore/DeterministicOpSequence.h
+++ b/src/test/filestore/DeterministicOpSequence.h
@@ -16,10 +16,11 @@
 #include <iostream>
 #include <fstream>
 #include <set>
-#include "os/FileStore.h"
 #include <boost/scoped_ptr.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
+
+#include "os/FileStore.h"
 
 #include "TestFileStoreState.h"
 

--- a/src/test/filestore/FileStoreDiff.cc
+++ b/src/test/filestore/FileStoreDiff.cc
@@ -12,11 +12,10 @@
 */
 #include <stdio.h>
 #include <stdlib.h>
-#include <map>
-#include <boost/scoped_ptr.hpp>
-#include "global/debug.h"
-#include "os/FileStore.h"
+
 #include "common/config.h"
+#include "os/FileStore.h"
+#include "global/debug.h"
 
 #include "FileStoreDiff.h"
 

--- a/src/test/filestore/FileStoreDiff.h
+++ b/src/test/filestore/FileStoreDiff.h
@@ -17,9 +17,8 @@
 #include <stdlib.h>
 #include <map>
 #include <boost/scoped_ptr.hpp>
-#include "common/debug.h"
+
 #include "os/FileStore.h"
-#include "common/config.h"
 
 class FileStoreDiff {
 

--- a/src/test/filestore/FileStoreTracker.h
+++ b/src/test/filestore/FileStoreTracker.h
@@ -2,13 +2,16 @@
 
 #ifndef FILESTORE_TRACKER_H
 #define FILESTORE_TRACKER_H
-#include "test/common/ObjectContents.h"
-#include "os/FileStore.h"
-#include "os/KeyValueDB.h"
+
 #include <boost/scoped_ptr.hpp>
 #include <list>
 #include <map>
+
 #include "common/Mutex.h"
+#include "os/FileStore.h"
+#include "os/KeyValueDB.h"
+
+#include "../common/ObjectContents.h"
 
 class FileStoreTracker {
   const static uint64_t SIZE = 4 * 1024;

--- a/src/test/filestore/TestFileStoreState.cc
+++ b/src/test/filestore/TestFileStoreState.cc
@@ -16,14 +16,14 @@
 #include <time.h>
 #include <stdlib.h>
 #include <signal.h>
-#include "os/FileStore.h"
+#include <boost/lexical_cast.hpp>
+
+#include "include/assert.h"
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
 #include "global/debug.h"
-#include <boost/scoped_ptr.hpp>
-#include <boost/lexical_cast.hpp>
+
 #include "TestFileStoreState.h"
-#include "include/assert.h"
 
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix

--- a/src/test/filestore/TestFileStoreState.h
+++ b/src/test/filestore/TestFileStoreState.h
@@ -13,12 +13,13 @@
 #ifndef TEST_FILESTORE_STATE_H_
 #define TEST_FILESTORE_STATE_H_
 
-#include "os/FileStore.h"
 #include <boost/scoped_ptr.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <map>
 #include <vector>
+
+#include "os/FileStore.h"
 
 class TestFileStoreState {
 public:

--- a/src/test/filestore/store_test.cc
+++ b/src/test/filestore/store_test.cc
@@ -16,20 +16,23 @@
 #include <string.h>
 #include <iostream>
 #include <time.h>
-#include "os/FileStore.h"
-#include "include/Context.h"
-#include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "common/Mutex.h"
-#include "common/Cond.h"
 #include <boost/scoped_ptr.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/binomial_distribution.hpp>
 #include <gtest/gtest.h>
-
 #include <ext/hash_map>
+
+#include "include/Context.h"
+#include "common/ceph_argparse.h"
+#include "common/Mutex.h"
+#include "common/Cond.h"
+#include "os/FileStore.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+
 using __gnu_cxx::hash_map;
+
 typedef boost::mt11213b gen_type;
 
 class StoreTest : public ::testing::Test {

--- a/src/test/filestore/test_idempotent.cc
+++ b/src/test/filestore/test_idempotent.cc
@@ -15,16 +15,19 @@
 #include <iostream>
 #include <sstream>
 #include <boost/scoped_ptr.hpp>
-#include "os/FileStore.h"
-#include "global/global_init.h"
-#include "global/debug.h"
+
 #include "common/ceph_argparse.h"
-#include "test/common/ObjectContents.h"
-#include "FileStoreTracker.h"
+#include "os/FileStore.h"
 #include "os/LevelDBStore.h"
 #include "os/KeyValueDB.h"
 #include "os/ObjectStore.h"
 #include "os/FileStore.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "global/debug.h"
+
+#include "../common/ObjectContents.h"
+#include "FileStoreTracker.h"
 
 void usage(const string &name) {
   std::cerr << "Usage: " << name << " [new|continue] store_path store_journal db_path"

--- a/src/test/filestore/test_idempotent_sequence.cc
+++ b/src/test/filestore/test_idempotent_sequence.cc
@@ -16,16 +16,18 @@
 #include <sstream>
 #include <time.h>
 #include <stdlib.h>
+
 #include "common/ceph_argparse.h"
+#include "common/config.h"
+#include "os/FileStore.h"
+#include "global/global_context.h"
 #include "global/global_init.h"
 #include "global/debug.h"
-#include "os/FileStore.h"
 
 #include "DeterministicOpSequence.h"
 #include "FileStoreDiff.h"
 
-#include "common/config.h"
-#include "include/assert.h"
+#include "include/assert.h" // boost in DeterministicOpSequence.h clobbers it
 
 #define dout_subsys ceph_subsys_
 #undef dout_prefix

--- a/src/test/filestore/workload_generator.cc
+++ b/src/test/filestore/workload_generator.cc
@@ -19,17 +19,14 @@
 #include <signal.h>
 #include <cctype>
 #include <errno.h>
-#include <sys/time.h>
-#include "os/FileStore.h"
+#include <boost/lexical_cast.hpp>
+
+#include "include/assert.h"
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
 #include "global/debug.h"
-#include <boost/scoped_ptr.hpp>
-#include <boost/lexical_cast.hpp>
-#include "workload_generator.h"
-#include "include/assert.h"
 
-#include "TestFileStoreState.h"
+#include "workload_generator.h"
 
 static const char *our_name = NULL;
 void usage();

--- a/src/test/filestore/workload_generator.h
+++ b/src/test/filestore/workload_generator.h
@@ -13,7 +13,6 @@
 #ifndef WORKLOAD_GENERATOR_H_
 #define WORKLOAD_GENERATOR_H_
 
-#include "os/FileStore.h"
 #include <boost/scoped_ptr.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>

--- a/src/test/gather.cc
+++ b/src/test/gather.cc
@@ -12,7 +12,8 @@
  * 
  */
 #include "include/Context.h"
-#include "test/unit.h"
+
+#include "unit.h"
 
 class C_Checker : public Context {
 public:

--- a/src/test/heartbeat_map.cc
+++ b/src/test/heartbeat_map.cc
@@ -15,8 +15,9 @@
 #include "common/Mutex.h"
 #include "common/HeartbeatMap.h"
 #include "common/ceph_context.h"
-#include "test/unit.h"
 #include "common/config.h"
+
+#include "unit.h"
 
 using namespace ceph;
 

--- a/src/test/kv_store_bench.cc
+++ b/src/test/kv_store_bench.cc
@@ -5,19 +5,14 @@
  *      Author: eleanor
  */
 
-#include "test/kv_store_bench.h"
-#include "key_value_store/key_value_structure.h"
-#include "key_value_store/kv_flat_btree_async.h"
-#include "include/rados/librados.hpp"
-#include "test/omap_bench.h"
-#include "common/ceph_argparse.h"
-
-
-#include <string>
-#include <climits>
-#include <iostream>
 #include <sstream>
 #include <cmath>
+
+#include "common/ceph_argparse.h"
+
+#include "omap_bench.h"
+
+#include "kv_store_bench.h"
 
 KvStoreBench::KvStoreBench()
 : entries(30),

--- a/src/test/kv_store_bench.h
+++ b/src/test/kv_store_bench.h
@@ -14,17 +14,17 @@
 #ifndef KVSTOREBENCH_H_
 #define KVSTOREBENCH_H_
 
-#include "key_value_store/key_value_structure.h"
-#include "key_value_store/kv_flat_btree_async.h"
-#include "common/Clock.h"
-#include "global/global_context.h"
-#include "common/Mutex.h"
-#include "common/Cond.h"
-
 #include <string>
 #include <climits>
 #include <cfloat>
 #include <iostream>
+
+#include "common/Clock.h"
+#include "common/Mutex.h"
+#include "common/Cond.h"
+#include "key_value_store/key_value_structure.h"
+#include "key_value_store/kv_flat_btree_async.h"
+#include "global/global_context.h"
 
 using namespace std;
 using ceph::bufferlist;

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -1,15 +1,17 @@
-#include "mds/mdstypes.h"
-#include "include/buffer.h"
-#include "include/rbd_types.h"
-#include "include/rados/librados.h"
-#include "include/rados/librados.hpp"
-#include "test/librados/test.h"
+#include "mds/mds_types.h"
 
-#include "gtest/gtest.h"
 #include <errno.h>
 #include <map>
 #include <sstream>
 #include <string>
+#include <gtest/gtest.h>
+
+#include "include/buffer.h"
+#include "include/rbd_types.h"
+#include "include/rados/librados.h"
+#include "include/rados/librados.hpp"
+
+#include "test.h"
 
 using namespace librados;
 using ceph::buffer;

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -11,27 +11,19 @@
  * Foundation.  See file COPYING.
  * 
  */
+#include "osd/osd_types.h"
+
 #include <iostream>
 #include <string>
 #include <map>
-
 #include <boost/scoped_ptr.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
 
-
-#include "osd/osd_types.h"
-#include "osd/OSD.h"
-#include "osd/OSDMap.h"
-#include "osdc/Objecter.h"
-#include "mon/MonClient.h"
-#include "msg/Dispatcher.h"
-#include "msg/Messenger.h"
+#include "include/uuid.h"
+#include "include/assert.h"
 #include "common/Timer.h"
 #include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "global/signal_handler.h"
-#include "global/debug.h"
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/Cond.h"
@@ -40,8 +32,15 @@
 #include "common/LogEntry.h"
 #include "auth/KeyRing.h"
 #include "auth/AuthAuthorizeHandler.h"
-#include "include/uuid.h"
-#include "include/assert.h"
+#include "osd/OSD.h"
+#include "osd/OSDMap.h"
+#include "osdc/Objecter.h"
+#include "mon/MonClient.h"
+#include "msg/Messenger.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "global/signal_handler.h"
+#include "global/debug.h"
 
 #include "messages/MOSDBoot.h"
 #include "messages/MOSDAlive.h"

--- a/src/test/old/test_disk_bw.cc
+++ b/src/test/old/test_disk_bw.cc
@@ -1,4 +1,3 @@
-
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -9,11 +8,12 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/uio.h>
+#include <iostream>
 
 #include "common/Clock.h"
 #include "common/safe_io.h"
+#include "global/global_context.h"
 
-#include <iostream>
 using namespace std;
 
 int main(int argc, char **argv)

--- a/src/test/old/testcounter.cc
+++ b/src/test/old/testcounter.cc
@@ -1,7 +1,8 @@
+#include <list>
 
 #include "common/DecayCounter.h"
+#include "global/global_context.h"
 
-#include <list>
 using namespace std;
 
 struct RealCounter {

--- a/src/test/omap_bench.cc
+++ b/src/test/omap_bench.cc
@@ -11,21 +11,18 @@
  * Foundation.  See file COPYING.
  */
 
-#include "include/rados/librados.hpp"
-#include "include/Context.h"
-#include "common/ceph_context.h"
-#include "common/Mutex.h"
-#include "common/Cond.h"
-#include "include/utime.h"
-#include "global/global_context.h"
-#include "common/ceph_argparse.h"
-#include "test/omap_bench.h"
-
-#include <string>
 #include <iostream>
 #include <cassert>
 #include <climits>
 #include <cmath>
+
+#include "include/Context.h"
+#include "include/utime.h"
+#include "common/ceph_context.h"
+#include "common/ceph_argparse.h"
+#include "global/global_context.h"
+
+#include "omap_bench.h"
 
 using namespace std;
 using ceph::bufferlist;

--- a/src/test/omap_bench.h
+++ b/src/test/omap_bench.h
@@ -14,12 +14,13 @@
 #ifndef OMAP_BENCH_HPP_
 #define OMAP_BENCH_HPP_
 
-#include "common/Mutex.h"
-#include "common/Cond.h"
-#include "include/rados/librados.hpp"
 #include <string>
 #include <map>
 #include <cfloat>
+
+#include "include/rados/librados.hpp"
+#include "common/Mutex.h"
+#include "common/Cond.h"
 
 using ceph::bufferlist;
 

--- a/src/test/osdc/FakeWriteback.h
+++ b/src/test/osdc/FakeWriteback.h
@@ -3,10 +3,11 @@
 #ifndef CEPH_TEST_OSDC_FAKEWRITEBACK_H
 #define CEPH_TEST_OSDC_FAKEWRITEBACK_H
 
-#include "include/atomic.h"
-#include "include/Context.h"
 #include "include/types.h"
 #include "osd/osd_types.h"
+
+#include "include/atomic.h"
+#include "include/Context.h"
 #include "osdc/WritebackHandler.h"
 
 class Finisher;

--- a/src/test/osdc/object_cacher_stress.cc
+++ b/src/test/osdc/object_cacher_stress.cc
@@ -8,18 +8,18 @@
 #include <vector>
 #include <boost/scoped_ptr.hpp>
 
+#include "include/atomic.h"
+#include "include/buffer.h"
+#include "include/Context.h"
+#include "include/stringify.h"
 #include "common/ceph_argparse.h"
 #include "common/common_init.h"
 #include "common/config.h"
 #include "common/Mutex.h"
 #include "common/snap_types.h"
+#include "osdc/ObjectCacher.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
-#include "include/atomic.h"
-#include "include/buffer.h"
-#include "include/Context.h"
-#include "include/stringify.h"
-#include "osdc/ObjectCacher.h"
 
 #include "FakeWriteback.h"
 

--- a/src/test/perf_counters.cc
+++ b/src/test/perf_counters.cc
@@ -43,9 +43,9 @@
 #include <time.h>
 #include <unistd.h>
 
-#include "global/global_init.h"
 #include "common/common_init.h"
-#include "common/ceph_context.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
 
 int main(int argc, char **argv) {
   std::vector<const char *> preargs;

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -1,16 +1,16 @@
-#include <gtest/gtest.h>
 #include <stdlib.h>
+#include <gtest/gtest.h>
 
+#include "include/Context.h"
 #include "common/ceph_argparse.h"
 #include "common/common_init.h"
-#include "global/global_context.h"
-#include "global/global_init.h"
 #include "common/config.h"
 #include "common/Finisher.h"
-#include "os/FileJournal.h"
-#include "include/Context.h"
 #include "common/Mutex.h"
 #include "common/safe_io.h"
+#include "os/FileJournal.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
 
 Finisher *finisher;
 Cond sync_cond;

--- a/src/test/test_mutate.cc
+++ b/src/test/test_mutate.cc
@@ -15,18 +15,18 @@
 /*
  * Test Ioctx::operate
  */
-
-#include "common/ceph_argparse.h"
-#include "common/debug.h"
-#include "common/config.h"
-#include "global/global_context.h"
-#include "global/global_init.h"
-#include "include/rados/librados.hpp"
 #include "include/types.h"
 
 #include <errno.h>
 #include <iostream>
 #include <string>
+
+#include "include/rados/librados.hpp"
+#include "common/ceph_argparse.h"
+#include "common/debug.h"
+#include "common/config.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
 
 using std::cerr;
 using std::string;

--- a/src/test/test_striper.cc
+++ b/src/test/test_striper.cc
@@ -1,10 +1,10 @@
 #include "gtest/gtest.h"
-#include "global/global_context.h"
-#include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "common/common_init.h"
 
+#include "common/ceph_argparse.h"
+#include "common/common_init.h"
 #include "osdc/Striper.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
 
 TEST(Striper, Stripe1)
 {

--- a/src/test/test_workqueue.cc
+++ b/src/test/test_workqueue.cc
@@ -1,10 +1,10 @@
 #include "gtest/gtest.h"
 
 #include "common/WorkQueue.h"
-#include "global/global_context.h"
 #include "common/ceph_argparse.h"
-#include "global/global_init.h"
 #include "common/common_init.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
 
 TEST(WorkQueue, StartStop)
 {

--- a/src/test/unit.h
+++ b/src/test/unit.h
@@ -18,13 +18,13 @@
 #include "include/types.h" // FIXME: ordering shouldn't be important, but right 
                            // now, this include has to come before the others.
 
+#include <vector>
+#include <gtest/gtest.h>
+
+#include "include/msgr.h" // for CEPH_ENTITY_TYPE_CLIENT
 #include "common/code_environment.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
-#include "include/msgr.h" // for CEPH_ENTITY_TYPE_CLIENT
-#include "gtest/gtest.h"
-
-#include <vector>
 
 /*
  * You only need to include this file if you are testing Ceph internal code. If

--- a/src/test/xattr_bench.cc
+++ b/src/test/xattr_bench.cc
@@ -18,19 +18,20 @@
 #include <iostream>
 #include <sstream>
 #include <time.h>
-#include "os/FileStore.h"
-#include "include/Context.h"
-#include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "common/Mutex.h"
-#include "common/Cond.h"
 #include <boost/scoped_ptr.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/binomial_distribution.hpp>
 #include <gtest/gtest.h>
-
 #include <ext/hash_map>
+
+#include "include/Context.h"
+#include "common/ceph_argparse.h"
+#include "common/Mutex.h"
+#include "common/Cond.h"
+#include "os/FileStore.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
 
 void usage(const string &name) {
   std::cerr << "Usage: " << name << " [xattr|omap] store_path store_journal"

--- a/src/test_trans.cc
+++ b/src/test_trans.cc
@@ -13,11 +13,13 @@
  */
 
 #include <iostream>
+
+#include "include/assert.h"
 #include "common/ceph_argparse.h"
 #include "os/FileStore.h"
 #include "global/global_init.h"
+#include "global/global_context.h"
 #include "global/debug.h"
-#include "include/assert.h"
 
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix

--- a/src/testclass.cc
+++ b/src/testclass.cc
@@ -1,6 +1,4 @@
 
-
-
 #include <iostream>
 #include <string.h>
 #include <stdlib.h>

--- a/src/testcrypto.cc
+++ b/src/testcrypto.cc
@@ -1,8 +1,6 @@
-#include "auth/Crypto.h"
 #include "common/Clock.h"
-
 #include "common/config.h"
-
+#include "auth/Crypto.h"
 #include "global/global_context.h"
 #include "global/debug.h"
 

--- a/src/testkeys.cc
+++ b/src/testkeys.cc
@@ -1,9 +1,9 @@
-#include "auth/cephx/CephxKeyServer.h"
 #include "common/ceph_argparse.h"
+#include "common/config.h"
+#include "auth/cephx/CephxKeyServer.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
 #include "global/debug.h"
-#include "common/config.h"
 
 #define AES_KEY_LEN	16
 

--- a/src/testmsgr.cc
+++ b/src/testmsgr.cc
@@ -15,28 +15,27 @@
 #include <sys/stat.h>
 #include <iostream>
 #include <string>
-using namespace std;
-
-#include "common/config.h"
-
-#include "mon/MonMap.h"
-#include "mon/MonClient.h"
-#include "msg/Messenger.h"
-#include "messages/MPing.h"
-
-#include "common/Timer.h"
-#include "global/global_context.h"
-#include "global/global_init.h"
-#include "global/debug.h"
-#include "common/ceph_argparse.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #ifndef DARWIN
 #include <envz.h>
 #endif // DARWIN
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include "common/config.h"
+#include "common/Timer.h"
+#include "common/ceph_argparse.h"
+#include "mon/MonMap.h"
+#include "mon/MonClient.h"
+#include "msg/Messenger.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "global/debug.h"
+
+#include "messages/MPing.h"
+
+using namespace std;
 
 #define dout_subsys ceph_subsys_ms
 

--- a/src/tools/ceph.cc
+++ b/src/tools/ceph.cc
@@ -27,16 +27,16 @@
 #include <unistd.h>
 #include <string.h>
 
+#include "include/compat.h"
+#include "include/assert.h"
 #include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "global/debug.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "common/config.h"
-#include "tools/common.h"
+#include "global/global_init.h"
+#include "global/debug.h"
 
-#include "include/compat.h"
-#include "include/assert.h"
+#include "common.h"
 
 using std::vector;
 

--- a/src/tools/common.cc
+++ b/src/tools/common.cc
@@ -12,41 +12,35 @@
  * 
  */
 
+#include "acconfig.h"
+
 #include <sys/stat.h>
 #include <iostream>
 #include <string>
-using namespace std;
+#include <memory>
+#include <sys/types.h>
+#include <fcntl.h>
 
 #if !defined(DARWIN) && !defined(__FreeBSD__)
 #include <envz.h>
 #endif // DARWIN
 
-#include <memory>
-#include <sys/types.h>
-#include <fcntl.h>
-
 extern "C" {
 #include <histedit.h>
 }
 
-#include "acconfig.h"
-#include "messages/MMonCommand.h"
-#include "messages/MMonCommandAck.h"
-#include "messages/MLog.h"
-#include "mon/MonClient.h"
-#include "mon/MonMap.h"
-#include "osd/OSDMap.h"
-#include "msg/SimpleMessenger.h"
-#include "tools/common.h"
-
+#include "include/assert.h"
 #include "common/errno.h"
-#include "common/Cond.h"
-#include "common/Mutex.h"
-#include "common/Timer.h"
+#include "mon/MonMap.h"
+#include "msg/SimpleMessenger.h"
 #include "global/global_init.h"
 #include "global/debug.h"
 
-#include "include/assert.h"
+#include "messages/MMonCommand.h"
+
+#include "common.h"
+
+using namespace std;
 
 #define dout_subsys ceph_subsys_
 

--- a/src/tools/common.h
+++ b/src/tools/common.h
@@ -3,27 +3,27 @@
 #ifndef CEPH_TOOLS_COMMON_DOT_H
 #define CEPH_TOOLS_COMMON_DOT_H
 
+#include "mon/mon_types.h"
+
 #include <iosfwd>
 #include <stdint.h>
 #include <map>
 
 #include "common/Cond.h"
 #include "common/Mutex.h"
+#include "common/Timer.h"
+#include "common/LogEntry.h"
 #include "mon/MonClient.h"
 #include "mon/PGMap.h"
 #include "mds/MDSMap.h"
 #include "osd/OSDMap.h"
-#include "common/Timer.h"
+#include "global/global_context.h"
 
-
-#include "common/LogEntry.h"
-#include "mon/mon_types.h"
 #include "messages/MOSDMap.h"
 #include "messages/MLog.h"
 #include "messages/MCommand.h"
 #include "messages/MCommandReply.h"
 #include "messages/MMonCommandAck.h"
-
 
 #define OSD_MON_UPDATE	    (1<<0)
 #define MDS_MON_UPDATE	    (1<<1)

--- a/src/tools/rest_bench.cc
+++ b/src/tools/rest_bench.cc
@@ -13,21 +13,21 @@
  */
 
 #include "include/types.h"
-#include "include/atomic.h"
 
+#include <deque>
+#include <errno.h>
+
+#include "include/atomic.h"
 #include "common/obj_bencher.h"
 #include "common/config.h"
 #include "common/ceph_argparse.h"
 #include "common/WorkQueue.h"
 #include "msg/Message.h"
 #include "global/global_init.h"
+#include "global/global_context.h"
 #include "global/debug.h"
 
 #include "libs3.h"
-
-#include <deque>
-
-#include <errno.h>
 
 #define DEFAULT_USER_AGENT "rest-bench"
 #define DEFAULT_BUCKET "rest-bench-bucket"


### PR DESCRIPTION
- lots of rewriting of #include ordering (see below)
- renamed mdstypes.h to mds_types.h, same as {osd,mon}_types.h
- included global/global_context.h and global/debug.h where used
- fixed lots of duplicate includes

The order of #includes is now;
1. types include (include/types.h, mds/mds_types.h, etc)
2. system includes (like stl, boost, etc)
3. ceph includes (include/..)
4. ceph common (common/..)
5. ceph other (auth/.., os/.., global/.., etc)
6. list of messages/.., if used
7. local includes (headers from same module)
8. own header (<basename>.h)

"using namespace" stuff is always directly below #include, not intermixed with them

(WIP notice: almost all files have this new ordering implemented, but some not yet)

Signed-off-by: Roald J. van Loon roaldvanloon@gmail.com
