### PR TITLE
Clarify journal size based on filestore max sync

### DIFF
--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -386,10 +386,10 @@ journal data (e.g., a solid state drive delivers high performance journaling).
 
 Ceph's default ``osd journal size`` is 0, so you will need to set this in your 
 ``ceph.conf`` file. A journal size should find the product of the ``filestore
-min sync interval`` and the expected throughput, and multiple the product by 
+max sync interval`` and the expected throughput, and multiply the product by 
 two (2)::  
 	  
-	osd journal size = {2 * (expected throughput * filestore min sync interval)}
+	osd journal size = {2 * (expected throughput * filestore max sync interval)}
 
 The expected throughput number should include the expected disk throughput
 (i.e., sustained data transfer rate), and network throughput. For example, 

--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -30,7 +30,7 @@
 :Description: The size of the journal in megabytes. If this is 0, and the journal is a block device, the entire block device is used. Since v0.54, this is ignored if the journal is a block device, and the entire block device is used.
 :Type: 32-bit Integer
 :Default: ``1024``
-:Recommended: Begin with 1GB. Should at least twice the product of the expected speed multiplied by ``filestore min sync interval``.
+:Recommended: Begin with 1GB. Should be at least twice the product of the expected speed multiplied by ``filestore max sync interval``.
 
 
 ``osd max write size`` 


### PR DESCRIPTION
The docs had the recommended journal size based on the option
"filestore min sync interval" when it should have been
"filestore max sync interval".

While in there, fix a couple of typos -- multiple when it should
be multiply, and a missing word.  Change "Should at least twice"
to "Should be at least twice..."

Signed-off-by: Travis Rhoden trhoden@gmail.com
