### PR TITLE
mds/LogEvent.h: change print() signature to const

### DIFF
--- a/src/mds/LogEvent.h
+++ b/src/mds/LogEvent.h
@@ -92,7 +92,7 @@ protected:
     ENCODE_FINISH(bl);
   }
 
-  virtual void print(ostream& out) { 
+  virtual void print(ostream& out) const { 
     out << "event(" << _type << ")";
   }
 

--- a/src/mds/events/ECommitted.h
+++ b/src/mds/events/ECommitted.h
@@ -26,7 +26,7 @@ public:
   ECommitted(metareqid_t r) : 
     LogEvent(EVENT_COMMITTED), reqid(r) { }
 
-  void print(ostream& out) {
+  void print(ostream& out) const {
     out << "ECommitted " << reqid;
   }
 

--- a/src/mds/events/EExport.h
+++ b/src/mds/events/EExport.h
@@ -38,7 +38,7 @@ public:
   
   set<dirfrag_t> &get_bounds() { return bounds; }
   
-  void print(ostream& out) {
+  void print(ostream& out) const {
     out << "EExport " << base << " " << metablob;
   }
 

--- a/src/mds/events/EFragment.h
+++ b/src/mds/events/EFragment.h
@@ -30,7 +30,8 @@ public:
   EFragment(MDLog *mdlog, int o, inodeno_t i, frag_t bf, int b) : 
     LogEvent(EVENT_FRAGMENT), metablob(mdlog), 
     op(o), ino(i), basefrag(bf), bits(b) { }
-  void print(ostream& out) {
+
+  void print(ostream& out) const {
     out << "EFragment " << op_name(op) << " " << ino << " " << basefrag << " by " << bits << " " << metablob;
   }
 

--- a/src/mds/events/EOpen.h
+++ b/src/mds/events/EOpen.h
@@ -27,7 +27,7 @@ public:
   EOpen(MDLog *mdlog) : 
     LogEvent(EVENT_OPEN), metablob(mdlog) { }
 
-  void print(ostream& out) {
+  void print(ostream& out) const {
     out << "EOpen " << metablob << ", " << inos.size() << " open files";
   }
 

--- a/src/mds/events/EResetJournal.h
+++ b/src/mds/events/EResetJournal.h
@@ -28,7 +28,7 @@ class EResetJournal : public LogEvent {
   void decode(bufferlist::iterator& bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<EResetJournal*>& ls);
-  void print(ostream& out) {
+  void print(ostream& out) const {
     out << "EResetJournal";
   }
 

--- a/src/mds/events/ESession.h
+++ b/src/mds/events/ESession.h
@@ -51,7 +51,7 @@ class ESession : public LogEvent {
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ESession*>& ls);
 
-  void print(ostream& out) {
+  void print(ostream& out) const {
     if (open)
       out << "ESession " << client_inst << " open cmapv " << cmapv;
     else

--- a/src/mds/events/ESessions.h
+++ b/src/mds/events/ESessions.h
@@ -48,7 +48,7 @@ public:
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ESessions*>& ls);
 
-  void print(ostream& out) {
+  void print(ostream& out) const {
     out << "ESessions " << client_map.size() << " opens cmapv " << cmapv;
   }
   

--- a/src/mds/events/ESlaveUpdate.h
+++ b/src/mds/events/ESlaveUpdate.h
@@ -123,7 +123,7 @@ public:
     master(mastermds),
     op(o), origop(oo) { }
   
-  void print(ostream& out) {
+  void print(ostream& out) const {
     if (type.length())
       out << type << " ";
     out << " " << (int)op;

--- a/src/mds/events/ESubtreeMap.h
+++ b/src/mds/events/ESubtreeMap.h
@@ -27,7 +27,7 @@ public:
 
   ESubtreeMap() : LogEvent(EVENT_SUBTREEMAP), expire_pos(0) { }
   
-  void print(ostream& out) {
+  void print(ostream& out) const {
     out << "ESubtreeMap " << subtrees.size() << " subtrees " 
 	<< ", " << ambiguous_subtrees.size() << " ambiguous "
 	<< metablob;

--- a/src/mds/events/ETableClient.h
+++ b/src/mds/events/ETableClient.h
@@ -36,7 +36,7 @@ struct ETableClient : public LogEvent {
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ETableClient*>& ls);
 
-  void print(ostream& out) {
+  void print(ostream& out) const {
     out << "ETableClient " << get_mdstable_name(table) << " " << get_mdstableserver_opname(op);
     if (tid) out << " tid " << tid;
   }  

--- a/src/mds/events/ETableServer.h
+++ b/src/mds/events/ETableServer.h
@@ -41,7 +41,7 @@ struct ETableServer : public LogEvent {
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ETableServer*>& ls);
 
-  void print(ostream& out) {
+  void print(ostream& out) const {
     out << "ETableServer " << get_mdstable_name(table) 
 	<< " " << get_mdstableserver_opname(op);
     if (reqid) out << " reqid " << reqid;

--- a/src/mds/events/EUpdate.h
+++ b/src/mds/events/EUpdate.h
@@ -32,7 +32,7 @@ public:
     LogEvent(EVENT_UPDATE), metablob(mdlog),
     type(s), cmapv(0), had_slaves(false) { }
   
-  void print(ostream& out) {
+  void print(ostream& out) const {
     if (type.length())
       out << "EUpdate " << type << " ";
     out << metablob;


### PR DESCRIPTION
Fix print() function of src/mds/LogEvent.h, declare as

virtual void print(ostream& out) const {...}

Adapt functions of derived classes. This should fix a problem
with print function of derived classes EImportStart and
EImportFinish, which had a const signature, hiding virtual
function of the base class LogEvent (which wasn't const).

Fix -Woverloaded-virtual warning from clang was:

mds/events/EImportStart.h:43:8: warning: 'EImportStart::print'
 hides overloaded virtual function [-Woverloaded-virtual]
  void print(ostream& out) const {
       ^
mds/events/../LogEvent.h:95:16: note: hidden overloaded virtual
 function 'LogEvent::print' declared here
  virtual void print(ostream& out) {
               ^
In file included from mds/journal.cc:31:
mds/events/EImportFinish.h:35:8: warning: 'EImportFinish::print'
 hides overloaded virtual function [-Woverloaded-virtual]
  void print(ostream& out) const {
       ^
mds/events/../LogEvent.h:95:16: note: hidden overloaded
 virtual function 'LogEvent::print' declared here
  virtual void print(ostream& out) {

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
