### PR TITLE
LDADD PTHREAD_LIBS to fix librados-config linking

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -145,7 +145,7 @@ cephfs_LDADD = libcommon.la
 bin_PROGRAMS += cephfs
 
 librados_config_SOURCES = librados-config.cc
-librados_config_LDADD = libglobal.la librados.la $(EXTRALIBS) $(CRYPTO_LIBS)
+librados_config_LDADD = libglobal.la librados.la $(PTHREAD_LIBS) $(EXTRALIBS) $(CRYPTO_LIBS)
 bin_PROGRAMS += librados-config
 
 # synthetic client


### PR DESCRIPTION
librados-config depends on libglobal which in turn
reference symbols in pthread; this caused issues
when linking due to the indirect dependency via
libglobal.

Signed-off-by: James Page james.page@ubuntu.com
