### PR TITLE
Cleanup some requirements of spec file

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -144,7 +144,6 @@ store using a simple file-like interface.
 Summary:	RADOS block device client library
 Group:		System Environment/Libraries
 License:	LGPL-2.0
-Requires:	librados2 = %{version}-%{release}
 %description -n librbd1
 RBD is a block device striped across multiple distributed objects in
 RADOS, a reliable, autonomic distributed object storage cluster


### PR DESCRIPTION
Merge some changes from the current ceph.spec file of the opensuse build service (where we currently build for the following RPM based distros: RHEL/CentOS6, Fedora 16-18, openSUSE 11.4-12.3/Factory and SLE11SP2 (all on x86 and x86_64)) back to git.

Should also fix tcc#4027
