### PR TITLE
OSDCap.cc: fix unquote '-' and '_' in pool names

### DIFF
--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -150,8 +150,8 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
     quoted_string %=
       lexeme['"' >> +(char_ - '"') >> '"'] | 
       lexeme['\'' >> +(char_ - '\'') >> '\''];
-    unquoted_word %= +(alnum | '_' | '-');
-    str %= quoted_string | unquoted_word;
+    unquoted_word %= +(qi::alnum | char_('_') | char_('-'));
+    str %= (quoted_string | unquoted_word);
 
     spaces = +lit(' ');
 


### PR DESCRIPTION
Fix pool names to not replace '-' and '_' by '\0'. Use char_(''_) instead of '_'.

Fixes: #4122

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
