### PR TITLE
cherry-pick fix for #4122 from bobtail back to master

### DIFF
--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -150,7 +150,7 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
     quoted_string %=
       lexeme['"' >> +(char_ - '"') >> '"'] | 
       lexeme['\'' >> +(char_ - '\'') >> '\''];
-    unquoted_word %= +(alnum | '_' | '-');
+    unquoted_word %= +char_("a-zA-Z0-9_-");
     str %= quoted_string | unquoted_word;
 
     spaces = +lit(' ');


### PR DESCRIPTION
Newer versions of spirit (1.49.0-3.1ubuntu1.1 in quantal, in particular)
dislike the construct with alnum and replace the - and _ with '\0' in the
resulting string.

Fixes: #4122
Backport: bobtail
Signed-off-by: Sage Weil sage@inktank.com
Reviewed-by: Josh Durgin josh.durgin@inktank.com
(cherry picked from commit 6c504d96c1e4fbb67578fba0666ca453b939c218)
