### PR TITLE
Handle empty CONTENT_LENGTH environment variable.

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1164,8 +1164,9 @@ int RGWREST::preprocess(struct req_state *s, RGWClientIO *cio)
   s->length = s->env->get("CONTENT_LENGTH");
   if (s->length) {
     if (*s->length == '\0')
-      return -EINVAL;
-    s->content_length = atoll(s->length);
+      s->content_length = 0;
+    else
+      s->content_length = atoll(s->length);
   }
 
   map<string, string>::iterator giter;


### PR DESCRIPTION
nginx seems to be providing a CONTENT_LENGTH environment variable with no data
when the request body is empty.

Signed-off-by: Jan Harkes jaharkes@cs.cmu.edu
