### PR TITLE
mds/journal.cc: fix assert in replay()

### DIFF
--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1743,7 +1743,7 @@ void EUpdate::replay(MDS *mds)
       mds->server->prepare_force_open_sessions(cm, seqm);
       mds->server->finish_force_open_sessions(cm, seqm);
 
-      assert(mds->sessionmap.version = cmapv);
+      assert(mds->sessionmap.version == cmapv);
       mds->sessionmap.projected = mds->sessionmap.version;
     }
   }


### PR DESCRIPTION
Fix assert in replay(), check if mds->sessionmap.version is cmapv
instead of assign cmapv to  mds->sessionmap.version. Add missing
second '='.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
