### PR TITLE
Typo: pool should be root in rados/operations/crush-map.rst

### DIFF
--- a/doc/rados/operations/crush-map.rst
+++ b/doc/rados/operations/crush-map.rst
@@ -669,7 +669,7 @@ To add or move an OSD in the CRUSH map of a running cluster, execute the
 	
 For Bobtail (v 0.56), execute the following:: 
 
-	ceph osd crush set {id-or-name} {weight} pool={pool-name}  [{bucket-type}={bucket-name} ...]
+	ceph osd crush set {id-or-name} {weight} root={pool-name}  [{bucket-type}={bucket-name} ...]
 
 Where:
 


### PR DESCRIPTION
Signed-off-by: Alexandre Marangone alexandre.marangone@inktank.com
