### PR TITLE
ceph.spec.in: add new Requires from ceph-disk-prepare

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -25,6 +25,10 @@ Requires:	librbd1 = %{version}-%{release}
 Requires:	librados2 = %{version}-%{release}
 Requires:	libcephfs1 = %{version}-%{release}
 Requires:	python
+Requires:	cryptsetup
+Requires:	gptfdisk
+Requires:	parted
+Requires:	util-linux
 Requires(post):	binutils
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:	gcc-c++


### PR DESCRIPTION
Added new Requires from ceph-disk-prepare: cryptsetup, gptfdisk,
parted and util-linux.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
