### PR TITLE
Properly format Content-Length: header on 32-bit systems.

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -227,10 +227,10 @@ void dump_errno(struct req_state *s, int err)
   dump_status(s, buf);
 }
 
-void dump_content_length(struct req_state *s, size_t len)
+void dump_content_length(struct req_state *s, uint64_t len)
 {
-  char buf[16];
-  snprintf(buf, sizeof(buf), "%lu", (long unsigned int)len);
+  char buf[21];
+  snprintf(buf, sizeof(buf), "%"PRIu64, len);
   int r = s->cio->print("Content-Length: %s\n", buf);
   if (r < 0) {
     ldout(s->cct, 0) << "ERROR: s->cio->print() returned err=" << r << dendl;

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -281,7 +281,7 @@ extern void end_header(struct req_state *s, const char *content_type = NULL);
 extern void dump_start(struct req_state *s);
 extern void list_all_buckets_start(struct req_state *s);
 extern void dump_owner(struct req_state *s, string& id, string& name, const char *section = NULL);
-extern void dump_content_length(struct req_state *s, size_t len);
+extern void dump_content_length(struct req_state *s, uint64_t len);
 extern void dump_etag(struct req_state *s, const char *etag);
 extern void dump_last_modified(struct req_state *s, time_t t);
 extern void abort_early(struct req_state *s, int err);


### PR DESCRIPTION
Use proper 64-bit unsigned formatting instead of a cast to 32-bit
unsigned.

Signed-off-by: Jan Harkes jaharkes@cs.cmu.edu
