### PR TITLE
Avoid sending a success response when an error occurs.

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -71,7 +71,6 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs, off_
 {
   const char *content_type = NULL;
   string content_type_str;
-  int req_state = ret;
   map<string, string> response_attrs;
   map<string, string>::iterator riter;
 
@@ -131,10 +130,8 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs, off_
     }
   }
 
-  if (partial_content && !ret)
-    req_state = STATUS_PARTIAL_CONTENT;
 done:
-  set_req_state_err(s, req_state);
+  set_req_state_err(s, (partial_content && !ret) ? STATUS_PARTIAL_CONTENT : ret);
 
   dump_errno(s);
 


### PR DESCRIPTION
Functions called from RGWGetObj_ObjStore_S3::send_response_data may
change the value of the non-local variable 'ret'. But the response
relies on a local 'req_state' which copies ret at the start of the
function.

Right now none of the called functions actually changes ret so the
problem doesn't trigger, but to avoid future breakage it is safer
to not rely on the (early) copy of the ret variable.

Signed-off-by: Jan Harkes jaharkes@cs.cmu.edu
