### PR TITLE
Fix output of command 'ceph osd tree --format=json'

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1598,13 +1598,11 @@ void OSDMap::print_tree(ostream *out, Formatter *f) const
 	if (out)
 	  *out << "\n";
 	if (f) {
+	  f->dump_float("crush_weight", weight);
+	  f->dump_unsigned("depth", depth);
 	  f->close_section();
 	}
 	touched.insert(cur);
-      }
-      if (f) {
-	f->dump_float("crush_weight", weight);
-	f->dump_unsigned("depth", depth);
       }
       if (cur >= 0) {
 	continue;


### PR DESCRIPTION
Two values which were suppose to be part of the osd array were being printed after the osd section was closed which resulted in output like this,

```
{ "id": 19,
  "name": "osd.19",
  "exists": 1,
  "type": "osd",
  "type_id": 0,
  "status": "up",
  "reweight": "1.000000"},
"1.000000",
3,
```

New output now looks like this,

```
{ "id": 19,
  "name": "osd.19",
  "exists": 1,
  "type": "osd",
  "type_id": 0,
  "status": "up",
  "reweight": "1.000000",
  "crush_weight": "1.000000",
  "depth": 3},
```
