### PR TITLE
Fix FTBFS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Vcs-Git: git://github.com/ceph/ceph.git
 Vcs-Browser: https://github.com/ceph/ceph
 Maintainer: Laszlo Boszormenyi (GCS) <gcs@debian.hu>
 Uploaders: Sage Weil <sage@newdream.net>
-Build-Depends: debhelper (>= 6.0.7~), autotools-dev, autoconf, automake, libfuse-dev, libboost-dev (>= 1.34), libboost-thread-dev, libedit-dev, libnss3-dev, libtool, libexpat1-dev, libfcgi-dev, libatomic-ops-dev, libgoogle-perftools-dev [i386 amd64], pkg-config, libcurl4-gnutls-dev, libkeyutils-dev, uuid-dev, libaio-dev, python (>= 2.6.6-3~), libxml2-dev, javahelper, default-jdk, junit4, libboost-program-options-dev, libleveldb-dev, libsnappy-dev
+Build-Depends: debhelper (>= 6.0.7~), autotools-dev, autoconf, automake, libfuse-dev, libboost-dev (>= 1.42), libboost-thread-dev, libedit-dev, libnss3-dev, libtool, libexpat1-dev, libfcgi-dev, libatomic-ops-dev, libgoogle-perftools-dev [i386 amd64], pkg-config, libcurl4-gnutls-dev, libkeyutils-dev, uuid-dev, libaio-dev, python (>= 2.6.6-3~), libxml2-dev, javahelper, default-jdk, junit4, libboost-program-options-dev, libleveldb-dev, libsnappy-dev
 Standards-Version: 3.9.3
 
 Package: ceph


### PR DESCRIPTION
I got this build error with libboost from ubuntu lucid (1.40.0.1):

```
  CXX    libosd_a-OSDCap.o
osd/OSDCap.cc: In constructor 'OSDCapParser<Iterator>::OSDCapParser()':
osd/OSDCap.cc:139: error: 'qi::char_' has not been declared
osd/OSDCap.cc:140: error: 'qi::int_' has not been declared
osd/OSDCap.cc:141: error: 'qi::lexeme' has not been declared
osd/OSDCap.cc:142: error: 'qi::alnum' has not been declared
osd/OSDCap.cc:143: error: 'qi::_val' has not been declared
osd/OSDCap.cc:144: error: 'qi::_1' has not been declared
osd/OSDCap.cc:145: error: 'qi::_2' has not been declared
osd/OSDCap.cc:146: error: 'qi::_3' has not been declared
osd/OSDCap.cc:147: error: 'qi::eps' has not been declared
osd/OSDCap.cc:148: error: 'qi::lit' has not been declared
osd/OSDCap.cc:151: error: 'lexeme' was not declared in this scope
osd/OSDCap.cc:151: error: 'char_' was not declared in this scope
osd/OSDCap.cc:153: error: 'alnum' was not declared in this scope
...
```

The build is successful with libboost from debian squeeze (1.42.0.1) and ubuntu oneiric (1.46.1.1) and precise (1.48.0.2).
This commit is fix the depends.

Signed-off-by: Andras Elso elso.andras@gmail.com
