### PR TITLE
Fixes for RadosGW init script

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -64,7 +64,7 @@ case "$1" in
 	    fi
 
             echo "Starting $name..."
-	    start-stop-daemon --start -u $user -x $RADOSGW -- -n $name
+	    start-stop-daemon --start -u $user --chuid $user -x $RADOSGW -- -n $name
 	done
         ;;
     reload)


### PR DESCRIPTION
The --signal argument to Debian's start-stop-daemon doesn't make it send a signal, but defines which signal should be send when --stop is specified.

Also pass --chuid to make setuid to www-data work.

And finally, made sure the Signed-off-by line is in the commit messages.
