### PR TITLE
mon/Monitor.h: return string instead of 'char *' from get_state_name()

### DIFF
--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -165,11 +165,11 @@ public:
     default: return "???";
     }
   }
-  const char *get_state_name() const {
+  const string get_state_name() const {
     string sn(get_state_name(state));
     string sync_name(get_sync_state_name());
     sn.append(sync_name);
-    return sn.c_str();
+    return sn;
   }
 
   bool is_probing() const { return state == STATE_PROBING; }


### PR DESCRIPTION
Return a string instead of 'char *' to avoid usage of std::string:c_str()
to return a 'char *' from get_state_name().

Returning result of c_str() from a function is dangerous since the
result gets (may) invalid after the related string object gets
destroyed or out of scope (which is the case with return). So you may
end up with garbage in this case.

Related warning from cppcheck:
 [src/mon/Monitor.h:172]: (error) Dangerous usage of c_str(). The value
 returned by c_str() is invalid after this call.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
