### PR TITLE
mon: refuse "mon remove" if only one mon left

### DIFF
--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -404,6 +404,11 @@ bool MonmapMonitor::prepare_command(MMonCommand *m)
         goto out;
       }
 
+      if (pending_map.size() == 1) {
+	err = -EINVAL;
+	ss << "error: refusing removal of last monitor " << name;
+	goto out;
+      }
       entity_addr_t addr = pending_map.get_addr(name);
       pending_map.remove(name);
       pending_map.last_changed = ceph_clock_now(g_ceph_context);


### PR DESCRIPTION
Fixes: #4439
Signed-off-by: Dan Mick dan.mick@inktank.com
