### PR TITLE
QuorumService.h: use enum instead of static const int

### DIFF
--- a/src/mon/QuorumService.h
+++ b/src/mon/QuorumService.h
@@ -45,8 +45,10 @@ class QuorumService : public RefCountedObject
   };
 
 public:
-  static const int SERVICE_HEALTH                   = 0x01;
-  static const int SERVICE_TIMECHECK                = 0x02;
+  enum {
+    SERVICE_HEALTH                   = 0x01,
+    SERVICE_TIMECHECK                = 0x02
+  };
 
 protected:
   Monitor *mon;


### PR DESCRIPTION
Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
