### PR TITLE
msg/Pipe: fix seq handshake on reconnect

### DIFF
--- a/src/msg/Pipe.h
+++ b/src/msg/Pipe.h
@@ -268,9 +268,10 @@ class DispatchQueue;
       return m;
     }
 
-    /* Remove all messages from the sent queue. Add those with seq > max_acked
-     * to the highest priority outgoing queue. */
-    void requeue_sent(uint64_t max_acked=0);
+    /// move all messages in the sent list back into the queue at the highest priority.
+    void requeue_sent();
+    /// discard messages requeued by requeued_sent() up to a given seq
+    void discard_requeued_up_to(uint64_t seq);
     void discard_out_queue();
 
     void shutdown_socket() {


### PR DESCRIPTION
We go to the trouble to exchange our seq numbers during the handshake, but
the bit that then avoids resending old messages was broken because we
already requeue_sent() before we get to this point.  Fix it by discarding
queued items (in the high prio slot) that we don't need to resend, and
adjust out_seq as needed.

Drop the optional arg to requeue_sent() now that it is unused.

Signed-off-by: Sage Weil sage@inktank.com
