### PR TITLE
mon: Monitor: clearer output on error during attempt to convert store

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -224,8 +224,14 @@ int main(int argc, const char **argv)
 
   {
     Monitor::StoreConverter converter(g_conf->mon_data);
-    if (converter.needs_conversion())
+    int ret = converter.needs_conversion();
+    if (ret > 0) {
       assert(!converter.convert());
+    } else if (ret < 0) {
+      derr << "found errors while attempting to convert the monitor store: "
+           << cpp_strerror(ret) << dendl;
+      exit(1);
+    }
   }
 
   MonitorDBStore store(g_conf->mon_data);
@@ -233,7 +239,6 @@ int main(int argc, const char **argv)
   if (err < 0) {
     cerr << argv[0] << ": error opening mon data store at '"
          << g_conf->mon_data << "': " << cpp_strerror(err) << std::endl;
-    cerr << "Have you run '--mkfs'?" << std::endl;
     exit(1);
   }
   assert(err == 0);

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -1451,7 +1451,13 @@ public:
 	highest_last_pn(0), highest_accepted_pn(0)
     { }
 
-    bool needs_conversion();
+    /**
+     * Check if store needs to be converted from old format to a
+     * k/v store.
+     *
+     * @returns 0 if store doesn't need conversion; 1 if it does; <0 if error
+     */
+    int needs_conversion();
     int convert();
 
    private:


### PR DESCRIPTION
This makes the most obvious cases, that shouldn't do any harm, to output clearer messages.

However, we kept a whole bunch of asserts all over the store convert procedure.  We want to be strict with this, and let the user know something terrible happened during the process so they come running to us, telling us what happened.

Also, this also adds a new check that won't let the monitor start if there are remnants of a failed conversion.

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
