### PR TITLE
libcephfs: fix ceph_get_osd_crush_location

### DIFF
--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -822,7 +822,7 @@ extern "C" int ceph_get_osd_crush_location(struct ceph_mount_info *cmount,
   if (!cmount->is_mounted())
     return -ENOTCONN;
 
-  if (!path)
+  if (!path && len)
     return -EINVAL;
 
   vector<pair<string, string> > loc;
@@ -837,7 +837,7 @@ extern "C" int ceph_get_osd_crush_location(struct ceph_mount_info *cmount,
     string& type = it->first;
     string& name = it->second;
     needed += type.size() + name.size() + 2;
-    if (needed < len) {
+    if (needed <= len) {
       strcpy(path + cur, type.c_str());
       cur += type.size() + 1;
       strcpy(path + cur, name.c_str());

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -990,7 +990,7 @@ TEST(LibCephFS, GetOsdCrushLocation) {
   ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
   ASSERT_EQ(ceph_mount(cmount, NULL), 0);
 
-  ASSERT_EQ(ceph_get_osd_crush_location(cmount, 0, NULL, 0), -EINVAL);
+  ASSERT_EQ(ceph_get_osd_crush_location(cmount, 0, NULL, 1), -EINVAL);
 
   char path[256];
   ASSERT_EQ(ceph_get_osd_crush_location(cmount, 9999999, path, 0), -ENOENT);


### PR DESCRIPTION
(a) Allow NULL buffer when length is zero to get the target buffer
length. (b) fix edge case where buffer length is the exact size
required.

Signed-off-by: Noah Watkins noahwatkins@gmail.com
