### PR TITLE
mon: AuthMonitor: delete auth_handler while increasing max_global_id

### DIFF
--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -440,14 +440,16 @@ bool AuthMonitor::prep_auth(MAuth *m, bool paxos_writable)
   if (!s->global_id) {
     s->global_id = assign_global_id(m, paxos_writable);
     if (!s->global_id) {
+
+      delete s->auth_handler;
+      s->auth_handler = NULL;
+
       if (mon->is_leader() && paxos_writable) {
         dout(10) << "increasing global id, waitlisting message" << dendl;
         wait_for_active(new C_RetryMessage(this, m));
         goto done;
       }
 
-      delete s->auth_handler;
-      s->auth_handler = NULL;
       s->put();
 
       if (!mon->is_leader()) {


### PR DESCRIPTION
By not deleting and setting NULL the session's auth_handler, we could
hit a scenario in which we'd end up dispatching a previously-wait-listed
auth message and we wouldn't start its auth session.

This only happened when increasing max_global_id via Paxos (in which case
we would wait-list the message) and would only be noticeable when running
with cephx disabled.

Fixes: #4519

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
