### PR TITLE
mds: CInode::build_backtrace() always incr iter

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1018,8 +1018,10 @@ void CInode::build_backtrace(int64_t location, inode_backtrace_t* bt)
   vector<int64_t>::iterator i = inode.old_pools.begin();
   while(i != inode.old_pools.end()) {
     // don't add our own pool id to old_pools to avoid looping (e.g. setlayout 0, 1, 0)
-    if (*i == location)
+    if (*i == location) {
+      ++i;
       continue;
+    }
     bt->old_pools.insert(*i);
     ++i;
   }


### PR DESCRIPTION
Always increment the iterator when adding old pools
to the backtrace.  This fixes a bug on files where
the layout had been set to a different pool and then
back to the same pool, causing continuous looping in
the build_backtrace() function.

Fixes #4537.
Signed-off-by: Sam Lang sam.lang@inktank.com
