### PR TITLE
mds: Clear backtrace updates on standby_trim_seg

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -622,6 +622,7 @@ void MDLog::standby_trim_segments()
     seg->dirty_dirfrag_dir.clear_list();
     seg->dirty_dirfrag_nest.clear_list();
     seg->dirty_dirfrag_dirfragtree.clear_list();
+    seg->update_backtraces.clear_list();
     remove_oldest_segment();
     removed_segment = true;
   }


### PR DESCRIPTION
If the mds is standby, when a segment is trimmed, we need
to clear the backtrace updates list to avoid the following
assertion when the segment is deleted.

./include/elist.h: 92: FAILED assert(_head.empty())
ceph version 0.59-478-g8befbca (8befbca77aa50a1188969892aabedaf11d8f8ce7)
(MDLog::standby_trim_segments()+0xce5) [0x6ccec5](MDS::C_MDS_StandbyReplayRestartFinish::finish%28int%29+0x39) [0x4e86b9](Journaler::_finish_reprobe%28int, unsigned long, Context*%29+0x190)
[0x6d3210](Filer::_probed%28Filer::Probe*, object_t const&, unsigned long,
utime_t%29+0x558) [0x704a88](Objecter::C_Stat::finish%28int%29+0xc0) [0x705900](Objecter::handle_osd_op_reply%28MOSDOpReply*%29+0xe38) [0x6f1df8](MDS::handle_core_message%28Message*%29+0xae8) [0x4dc318](MDS::_dispatch%28Message*%29+0x2f) [0x4dc4df](MDS::ms_dispatch%28Message*%29+0x1db) [0x4ddf7b](DispatchQueue::entry%28%29+0x341) [0x81f561](DispatchQueue::DispatchThread::entry%28%29+0xd) [0x79c6ad](%28%29+0x7e9a) [0x7f346bb9ee9a](clone%28%29+0x6d) [0x7f346a3574bd]

Fixes #4539.
Signed-off-by: Sam Lang sam.lang@inktank.com
