### PR TITLE
mds: Delay session close if in clientreplay

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -103,7 +103,10 @@ void Server::dispatch(Message *m)
       mds->enqueue_replay(new C_MDS_RetryMessage(mds, m));
       return;
     } else if (mds->is_clientreplay() &&
-	       (m->get_type() == CEPH_MSG_CLIENT_SESSION ||
+	       // session open requests need to be handled during replay,
+	       // close requests need to be delayed
+	       ((m->get_type() == CEPH_MSG_CLIENT_SESSION &&
+		 (static_cast<MClientSession*>(m))->get_op() != CEPH_SESSION_REQUEST_CLOSE) ||
 		(m->get_type() == CEPH_MSG_CLIENT_REQUEST &&
 		 (static_cast<MClientRequest*>(m))->is_replay()))) {
       // replaying!


### PR DESCRIPTION
If the mds is in clientreplay, a session close
request needs to be delayed until it reaches
active.  Otherwise, the session state gets set to
'closing', and the replay requests get dropped on the
floor.

Fixes #4564.
Signed-off-by: Sam Lang sam.lang@inktank.com
