### PR TITLE
Fix radosgw upstart job

### DIFF
--- a/src/upstart/radosgw.conf
+++ b/src/upstart/radosgw.conf
@@ -1,6 +1,6 @@
 description "Ceph radosgw"
 
-start on radosgw-all
+start on radosgw
 stop on runlevel [!2345] or stopping radosgw-all
 
 respawn


### PR DESCRIPTION
As discussed with Sage, 'start on radosgw-all' should be 'start on radosgw'

Signed-off-by: Alexandre Marangone alexandre.marangone@inktank.com
