### PR TITLE
librbd: flush cache when set_snap() is called

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1898,6 +1898,12 @@ reprotect_and_return_err:
     // ignore return value, since we may be set to a non-existent
     // snapshot and the user is trying to fix that
     ictx_check(ictx);
+    if (ictx->object_cacher) {
+      // complete pending writes before we're set to a snapshot and
+      // get -EROFS for writes
+      RWLock::WLocker l(ictx->md_lock);
+      ictx->flush_cache();
+    }
     return _snap_set(ictx, snap_name);
   }
 


### PR DESCRIPTION
If there are writes pending, they should be sent while the image
is still writeable. If the image becomes read-only, flushing the
cache will just mark everything dirty again due to -EROFS.

Fixes: #4525
Backport: bobtail
Signed-off-by: Josh Durgin josh.durgin@inktank.com
