### PR TITLE
mds: Remove failed mds from resolve/rejoin

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2612,11 +2612,11 @@ void MDCache::handle_mds_failure(int who)
   recovery_set.erase(mds->get_nodeid());
   dout(1) << "handle_mds_failure mds." << who << " : recovery peers are " << recovery_set << dendl;
 
-  resolve_gather.insert(who);
+  resolve_gather.erase(who);
   discard_delayed_resolve(who);
   ambiguous_slave_updates.erase(who);
 
-  rejoin_gather.insert(who);
+  rejoin_gather.erase(who);
   rejoin_sent.erase(who);        // i need to send another
   rejoin_ack_gather.erase(who);  // i'll need/get another.
 


### PR DESCRIPTION
Instead of adding a failed mds to resolve_gather
and rejoin_gather sets, we need to remove it.

Fixes #4637.
Signed-off-by: Sam Lang sam.lang@inktank.com
