### PR TITLE
mon: limit warnings about low mon disk space

### DIFF
--- a/src/mon/DataHealthService.cc
+++ b/src/mon/DataHealthService.cc
@@ -51,6 +51,7 @@ void DataHealthService::start_epoch()
   // to hold the cluster back, even confusing the user, due to some possibly
   // outdated stats.
   stats.clear();
+  last_warned_percent = 0;
 }
 
 void DataHealthService::get_health(Formatter *f,
@@ -177,9 +178,13 @@ void DataHealthService::service_tick()
   // otherwise we may very well contribute to the consumption of the
   // already low available disk space.
   if (ours.latest_avail_percent <= g_conf->mon_data_avail_warn) {
-    mon->clog.warn()
-      << "reached concerning levels of available space on data store"
-      << " (" << ours.latest_avail_percent << "\% free)\n";
+    if (ours.latest_avail_percent != last_warned_percent)
+      mon->clog.warn()
+	<< "reached concerning levels of available space on data store"
+	<< " (" << ours.latest_avail_percent << "\% free)\n";
+    last_warned_percent = ours.latest_avail_percent;
+  } else {
+    last_warned_percent = 0;
   }
 }
 

--- a/src/mon/DataHealthService.h
+++ b/src/mon/DataHealthService.h
@@ -34,6 +34,8 @@ class DataHealthService :
   public HealthService
 {
   map<entity_inst_t,DataStats> stats;
+  int last_warned_percent;
+
   void handle_tell(MMonHealth *m);
   int update_stats();
   void share_stats();
@@ -58,7 +60,8 @@ protected:
 
 public:
   DataHealthService(Monitor *m) :
-    HealthService(m)
+    HealthService(m),
+    last_warned_percent(0)
   {
     set_update_period(g_conf->mon_health_data_update_interval);
   }


### PR DESCRIPTION
Only warn once per percentage point per epoch.

Signed-off-by: Sage Weil sage@inktank.com
