### PR TITLE
Makefile.am: fix build of ceph_test_cors

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -883,7 +883,7 @@ check_PROGRAMS += unittest_texttable
 if WITH_RADOSGW
 ceph_test_cors_SOURCES = test/test_cors.cc
 ceph_test_cors_LDFLAGS = libglobal.la
-ceph_test_cors_LDADD = librados.la librgw.a ${UNITTEST_LDADD} ${UNITTEST_STATIC_LDADD} -lcryptopp -lcurl -luuid -lexpat
+ceph_test_cors_LDADD = librados.la librgw.a ${UNITTEST_LDADD} ${UNITTEST_STATIC_LDADD} $(CRYPTO_LIBS) -lcurl -luuid -lexpat
 ceph_test_cors_CXXFLAGS = ${AM_CXXFLAGS} ${UNITTEST_CXXFLAGS}
 bin_DEBUGPROGRAMS += ceph_test_cors
 endif


### PR DESCRIPTION
Fix build of ceph_test_cors: use $(CRYPTO_LIBS) instead of -lcryptopp.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
