### PR TITLE
md_config_t: change from class to struct as the name indicates

### DIFF
--- a/src/auth/KeyRing.h
+++ b/src/auth/KeyRing.h
@@ -20,7 +20,6 @@
 #include "auth/Crypto.h"
 #include "auth/Auth.h"
 
-class md_config_t;
 
 class KeyRing : public KeyStore {
   map<EntityName, EntityAuth> keys;

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -25,7 +25,7 @@ class AdminSocket;
 class CephContextServiceThread;
 class PerfCountersCollection;
 class md_config_obs_t;
-class md_config_t;
+struct md_config_t;
 class CephContextHook;
 class CryptoNone;
 class CryptoAES;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -67,7 +67,7 @@ extern const char *CEPH_CONF_FILE_DEFAULT;
  * FIXME: really we shouldn't allow changing integer or floating point values
  * while another thread is reading them, either.
  */
-class md_config_t {
+struct md_config_t {
 public:
   /* Maps configuration options to the observer listening for them. */
   typedef std::multimap <std::string, md_config_obs_t*> obs_map_t;

--- a/src/common/config_obs.h
+++ b/src/common/config_obs.h
@@ -18,7 +18,7 @@
 #include <set>
 #include <string>
 
-class md_config_t;
+struct md_config_t;
 
 class md_config_obs_t {
 public:

--- a/src/global/global_context.h
+++ b/src/global/global_context.h
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <stdint.h>
 
-class md_config_t;
+struct md_config_t;
 
 extern CephContext *g_ceph_context;
 extern md_config_t *g_conf;

--- a/src/global/pidfile.h
+++ b/src/global/pidfile.h
@@ -15,7 +15,7 @@
 #ifndef CEPH_COMMON_PIDFILE_H
 #define CEPH_COMMON_PIDFILE_H
 
-class md_config_t;
+struct md_config_t;
 
 // Write a pidfile with the current pid, using the configuration in the
 // provided conf structure.

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -56,7 +56,6 @@ using namespace std;
 
 */
 
-class md_config_t;
 class CephContext;
 
 extern CompatSet get_mdsmap_compat_set();


### PR DESCRIPTION
Change md_config_t from class to struct to fix some issues
from clang. The name indicates it's a struct so change it to
struct and unify the used type in some places.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
