### PR TITLE
rbd: Only allow shrinking an image when --allow-shrink flag is passed

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -71,12 +71,13 @@ static string dir_oid = RBD_DIRECTORY;
 static string dir_info_oid = RBD_INFO;
 
 bool udevadm_settle = true;
+bool resize_allow_shrink = false;
 
 #define dout_subsys ceph_subsys_rbd
 
 void usage()
 {
-  cout << 
+  cout <<
 "usage: rbd [-n <auth user>] [OPTIONS] <cmd> ...\n"
 "where 'pool' is a rados pool name (default is 'rbd') and 'cmd' is one of:\n"
 "  (ls | list) [-l | --long ] [pool-name] list rbd images\n"
@@ -152,7 +153,8 @@ void usage()
 "  --shared <tag>                     take a shared (rather than exclusive) lock\n"
 "  --format <output-format>           output format (default: plain, json, xml)\n"
 "  --pretty-format                    make json or xml output more readable\n"
-"  --no-settle                        do not wait for udevadm to settle on map/unmap\n";
+"  --no-settle                        do not wait for udevadm to settle on map/unmap\n"
+"  --allow-shrink                     allow shrinking of an image when resizing\n";
 }
 
 static string feature_str(uint64_t feature)
@@ -1354,7 +1356,7 @@ static int do_import(librbd::RBD &rbd, librados::IoCtx& io_ctx,
 	goto done;
       }
     }
-    // done with whole block, whether written or not 
+    // done with whole block, whether written or not
     image_pos += blklen;
     // if read had returned 0, we're at EOF and should quit
     if (readlen == 0)
@@ -2188,6 +2190,8 @@ int main(int argc, const char **argv)
       lock_tag = strdup(val.c_str());
     } else if (ceph_argparse_flag(args, i, "--no-settle", (char *)NULL)) {
       udevadm_settle = false;
+    } else if (ceph_argparse_flag(args, i , "--allow-shrink", (char *)NULL)) {
+      resize_allow_shrink = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--format", (char *) NULL)) {
       std::string err;
       long long ret = strict_strtoll(val.c_str(), 10, &err);
@@ -2627,6 +2631,18 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     break;
 
   case OPT_RESIZE:
+    librbd::image_info_t info;
+    r = image.stat(info, sizeof(info));
+    if (r < 0) {
+       cerr << "rbd: resize error: " << cpp_strerror(-r) << std::endl;
+       return EXIT_FAILURE;
+    }
+
+    if (info.size > size && !resize_allow_shrink) {
+        cerr << "rbd: shrinking an image is only allowed with the --allow-shrink flag" << std::endl;
+        return EXIT_FAILURE;
+    }
+
     r = do_resize(image, size);
     if (r < 0) {
       cerr << "rbd: resize error: " << cpp_strerror(-r) << std::endl;


### PR DESCRIPTION
When resizing you can currently destroy an image (happened to me...), so I wrote a patch for the "rbd" tool which only allows shrinking with the "--allow-shrink" flag.

wido@wido-desktop:~$ rbd create wido --size 2048
wido@wido-desktop:~$ rbd resize wido --size 1024
rbd: shrinking an image is only allowed with the --allow-shrink flag
wido@wido-desktop:~$ rbd resize wido --size 1024 --allow-shrink
Resizing image: 100% complete...done.
wido@wido-desktop:~$
