### PR TITLE
rados.py: fix create_pool()

### DIFF
--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -209,15 +209,16 @@ Rados object in state %s." % (self.state))
                 ret = self.librados.rados_pool_create(
                             self.cluster, c_char_p(pool_name))
             else:
-                ret = self.librados.rados_pool_create_with_all(
-                            self.cluster, c_char_p(pool_name), c_uint64(auid),
-                            c_ubyte(crush_rule))
+                ret = self.librados.rados_pool_create_with_crush_rule(
+                            self.cluster, c_char_p(pool_name), c_ubyte(crush_rule))
+
         elif (crush_rule == None):
             ret = self.librados.rados_pool_create_with_auid(
                         self.cluster, c_char_p(pool_name), c_uint64(auid))
         else:
-            ret = self.librados.rados_pool_create_with_crush_rule(
-                        self.cluster, c_char_p(pool_name), c_ubyte(crush_rule))
+            ret = self.librados.rados_pool_create_with_all(
+                        self.cluster, c_char_p(pool_name), c_uint64(auid),
+                        c_ubyte(crush_rule))
         if ret < 0:
             raise make_ex(ret, "error creating pool '%s'" % pool_name)
 


### PR DESCRIPTION
Call rados_pool_create_with_all() only if auid and crush_rule
are set properly. In case only crush_rule is set call
rados_pool_create_with_crush_rule() on librados, not the other
way around.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
(cherry picked from commit 94a1f25e7230a700f06a2699c9c2b99ec1bf7144)
