### PR TITLE
ceph.spec.in: use %{_sbindir} macro again

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -290,9 +290,9 @@ find $RPM_BUILD_ROOT -type f -name "*.la" -exec rm -f {} ';'
 find $RPM_BUILD_ROOT -type f -name "*.a" -exec rm -f {} ';'
 install -D src/init-ceph $RPM_BUILD_ROOT%{_initrddir}/ceph
 install -D src/init-radosgw.sysv $RPM_BUILD_ROOT%{_initrddir}/ceph-radosgw
-mkdir -p $RPM_BUILD_ROOT/usr/sbin
-ln -sf ../../etc/init.d/ceph %{buildroot}/usr/sbin/rcceph
-ln -sf ../../etc/init.d/ceph-radosgw %{buildroot}/usr/sbin/rcceph-radosgw
+mkdir -p $RPM_BUILD_ROOT%{_sbindir}
+ln -sf ../../etc/init.d/ceph %{buildroot}/%{_sbindir}/rcceph
+ln -sf ../../etc/init.d/ceph-radosgw %{buildroot}/%{_sbindir}/rcceph-radosgw
 install -m 0644 -D src/logrotate.conf $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/ceph
 install -m 0644 -D src/rgw/logrotate.conf $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/radosgw
 chmod 0644 $RPM_BUILD_ROOT%{_docdir}/ceph/sample.ceph.conf


### PR DESCRIPTION
Commit ae71b576a7396bf44f052845af7561cc0436486a change some paths
again to absolute path to /usr/sbin. Use the correct macro %{_sbindir}
again as done in 4b90a958d11059bf470897cbedf460cd9c159dd6.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
