### PR TITLE
global: call observers (and start logging) in global_init

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -125,6 +125,10 @@ void global_init(std::vector < const char * > *alt_def_args, std::vector < const
   }
   register_assert_context(cct);
 
+  // call all observers now.  this has the side-effect of configuring
+  // and opening the log file immediately.
+  conf->call_all_observers();
+
   if (code_env == CODE_ENVIRONMENT_DAEMON)
     output_ceph_version();
 }


### PR DESCRIPTION
Call observers so that the logging infrastructure gets initailized and we
start logging.  Otherwise, unless a default log setting has been modified,
we won't start logging until we daemonize, and we won't get the nice
version banner in the log file.

Unlike the previous attempt to fix this (a3091774), we do this after all
of the lockdep initialization has completed.

Signed-off-by: Sage Weil sage@inktank.com
