### PR TITLE
Fix journal partition creation

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -704,11 +704,9 @@ def prepare_journal_dev(
     num = None
     if journal == data:
         # we're sharing the disk between osd data and journal;
-        # make journal be partition number 2, so it's pretty; put
-        # journal at end of free space so partitioning tools don't
-        # reorder them suddenly
+        # make journal be partition number 2, so it's pretty
         num = 2
-        journal_part = '{num}:-{size}M:0'.format(
+        journal_part = '{num}:0:{size}M'.format(
             num=num,
             size=journal_size,
             )


### PR DESCRIPTION
With OSD sharing data and journal, the previous code created the
journal partiton from the end of the device. A uint32_t is
used in sgdisk to get the last sector, with large HD, uint32_t
is too small.
The journal partition will be created backwards from the
a sector in the midlle of the disk leaving space before
and after it. The data partition will use whichever of
these spaces is greater. The remaining will not be used.

This patch creates the journal partition from the start as a workaround.

Signed-off-by: Alexandre Marangone alexandre.marangone@inktank.com
