### PR TITLE
init-ceph: fix (and simplify) pushing ceph.conf to remote unique name

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -217,11 +217,8 @@ for name in $what; do
 	cur_conf=$conf
     else
 	unique=`dd if=/dev/urandom bs=16 count=1 2>/dev/null | md5sum | awk '{print $1}'`
-	if echo $pushed_to | grep -v -q " $host "; then
-	    scp -q $conf $host:/tmp/ceph.conf.$unique
-	    trap "ssh $host rm /tmp/ceph.conf.$unique" EXIT
-	    pushed_to="$pushed_to $host "
-	fi
+	scp -q $conf $host:/tmp/ceph.conf.$unique
+	trap "ssh $host rm /tmp/ceph.conf.$unique" EXIT
 	cur_conf="/tmp/ceph.conf.$unique"
     fi
     cmd="$cmd -c $cur_conf"


### PR DESCRIPTION
The old code would only do the push once per remote node (due to the
list in $pushed_to) but would reset $unique on each attempt.  This would
break if a remote host was processed twice.

Fix by just skipping the $pushed_to optimization entirely.

Fixes: #4794
Reported-by: Andreas Friedrich andreas.friedrich@ts.fujitsu.com
Signed-off-by: Sage Weil sage@inktank.com
