### PR TITLE
librbd: add read_iterate2 call with fixed argument type

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -311,8 +311,27 @@ int rbd_break_lock(rbd_image_t image, const char *client, const char *cookie);
 typedef void *rbd_completion_t;
 typedef void (*rbd_callback_t)(rbd_completion_t cb, void *arg);
 ssize_t rbd_read(rbd_image_t image, uint64_t ofs, size_t len, char *buf);
+
+/* DEPRECATED; use rbd_read_iterate2 */
 int64_t rbd_read_iterate(rbd_image_t image, uint64_t ofs, size_t len,
 			 int (*cb)(uint64_t, size_t, const char *, void *), void *arg);
+
+/**
+ * iterate read over an image
+ *
+ * Reads each region of the image and calls the callback.  If the
+ * buffer pointer passed to the callback is NULL, the given extent is
+ * defined to be zeros (a hole).  Normally the granularity for the
+ * callback is the image stripe size.
+ *
+ * @param image image to read
+ * @param ofs offset to start from
+ * @param len bytes of source image to cover
+ * @param cb callback for each region
+ * @returns 0 success, error otherwise
+ */
+int rbd_read_iterate2(rbd_image_t image, uint64_t ofs, uint64_t len,
+		      int (*cb)(uint64_t, size_t, const char *, void *), void *arg);
 /**
  * get difference between two versions of an image
  *

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -156,6 +156,8 @@ public:
   ssize_t read(uint64_t ofs, size_t len, ceph::bufferlist& bl);
   int64_t read_iterate(uint64_t ofs, size_t len,
 		       int (*cb)(uint64_t, size_t, const char *, void *), void *arg);
+  int read_iterate2(uint64_t ofs, uint64_t len,
+		    int (*cb)(uint64_t, size_t, const char *, void *), void *arg);
   /**
    * get difference between two versions of an image
    *

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1883,7 +1883,7 @@ reprotect_and_return_err:
       r = 0;
       prog_ctx.update_progress(cp.src_size, cp.src_size);
     }
-    return r;
+    return (int)r;
   }
 
   // common snap_set functionality for snap_set and open_image
@@ -2201,7 +2201,7 @@ reprotect_and_return_err:
     ctx->complete(comp->get_return_value());
   }
 
-  int64_t read_iterate(ImageCtx *ictx, uint64_t off, size_t len,
+  int64_t read_iterate(ImageCtx *ictx, uint64_t off, uint64_t len,
 		       int (*cb)(uint64_t, size_t, const char *, void *),
 		       void *arg)
   {

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -442,6 +442,17 @@ namespace librbd {
     return librbd::read_iterate(ictx, ofs, len, cb, arg);
   }
 
+  int Image::read_iterate2(uint64_t ofs, uint64_t len,
+			      int (*cb)(uint64_t, size_t, const char *, void *),
+			      void *arg)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    int64_t r = librbd::read_iterate(ictx, ofs, len, cb, arg);
+    if (r > 0)
+      r = 0;
+    return (int)r;
+  }
+
   int Image::diff_iterate(const char *fromsnapname,
 			  uint64_t ofs, uint64_t len,
 			  int (*cb)(uint64_t, size_t, int, void *),
@@ -1030,6 +1041,17 @@ extern "C" int64_t rbd_read_iterate(rbd_image_t image, uint64_t ofs, size_t len,
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   return librbd::read_iterate(ictx, ofs, len, cb, arg);
+}
+
+extern "C" int rbd_read_iterate2(rbd_image_t image, uint64_t ofs, uint64_t len,
+				 int (*cb)(uint64_t, size_t, const char *, void *),
+				 void *arg)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  int64_t r = librbd::read_iterate(ictx, ofs, len, cb, arg);
+  if (r > 0)
+    r = 0;
+  return (int)r;
 }
 
 extern "C" int rbd_diff_iterate(rbd_image_t image,

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -1033,7 +1033,7 @@ static int do_export(librbd::Image& image, const char *path)
     return -errno;
 
   ExportContext ec(&image, fd, info.size);
-  r = image.read_iterate(0, info.size, export_read_cb, (void *)&ec);
+  r = image.read_iterate2(0, info.size, export_read_cb, (void *)&ec);
   if (r < 0)
     goto out;
 


### PR DESCRIPTION
The existing read_iterate takes a size_t for the length, which is only 4GB
on 32-bit machines.  Instead, take a uint64_t length for the new
read_iterate2().

Fixes: #4665
Signed-off-by: Sage Weil sage@inktank.com
