### PR TITLE
Add "config get <var>" to the admin socket

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -170,7 +170,7 @@ void CephContext::do_command(std::string command, std::string args, bufferlist *
     _perf_counters_collection->write_json_to_buf(*out, false);
   }
   else if (command == "perfcounters_schema" || command == "2" ||
-	   command == "perf schema") {
+    command == "perf schema") {
     _perf_counters_collection->write_json_to_buf(*out, true);
   }
   else {
@@ -183,18 +183,18 @@ void CephContext::do_command(std::string command, std::string args, bufferlist *
       std::string var = args;
       size_t pos = var.find(' ');
       if (pos == string::npos) {
-	jf.dump_string("error", "syntax error: 'config set <var> <value>'");
+        jf.dump_string("error", "syntax error: 'config set <var> <value>'");
       } else {
-	std::string val = var.substr(pos+1);
-	var.resize(pos);
-	int r = _conf->set_val(var.c_str(), val.c_str());
-	if (r < 0) {
-	  jf.dump_stream("error") << "error setting '" << var << "' to '" << val << "': " << cpp_strerror(r);
-	} else {
-	  ostringstream ss;
-	  _conf->apply_changes(&ss);
-	  jf.dump_string("success", ss.str());
-	}
+        std::string val = var.substr(pos+1);
+        var.resize(pos);
+        int r = _conf->set_val(var.c_str(), val.c_str());
+        if (r < 0) {
+          jf.dump_stream("error") << "error setting '" << var << "' to '" << val << "': " << cpp_strerror(r);
+        } else {
+          ostringstream ss;
+          _conf->apply_changes(&ss);
+          jf.dump_string("success", ss.str());
+        }
       }
     } else if (command == "config get") {
         char buf[128];


### PR DESCRIPTION
This adds the possibility to get the value of one specific configuration setting instead of dumping them all.

This prevents you from parsing the JSON first in search of your config value.

For admins it's also easier, they don't have to pipe through grep first.

$ ceph --admin-socket /path/to/socket config get debug_osd

The second patch fixes some whitespace issues in the same file, although the whole file seems to need a whitespace / indentation fixup.
