### PR TITLE
osd: don't assert if get_omap_iterator() returns NULL

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2922,7 +2922,10 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  ObjectMap::ObjectMapIterator iter = osd->store->get_omap_iterator(
 	    coll, soid
 	    );
-	  assert(iter);
+          if (!iter) {
+            result = -ENOENT;
+            goto fail;
+          }
 	  iter->upper_bound(start_after);
 	  if (filter_prefix >= start_after) iter->lower_bound(filter_prefix);
 	  for (uint64_t i = 0;


### PR DESCRIPTION
Fixes: #4949
This can happen if the object does not exist and it's
a write operation. Just return -ENOENT.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
