### PR TITLE
debian/control: depends cryptsetup or cryptsetup-bin

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,6 +32,7 @@ Build-Depends: autoconf,
                libsnappy-dev,
                libtool,
                libxml2-dev,
+               lsb-release,
                pkg-config,
                python (>= 2.6.6-3~),
                uuid-dev
@@ -41,7 +42,7 @@ Package: ceph
 Architecture: linux-any
 Depends: binutils,
          ceph-common,
-         cryptsetup-bin | cryptsetup,
+         ${dist:Depends},
          gdisk,
          parted,
          python,

--- a/debian/rules
+++ b/debian/rules
@@ -37,6 +37,13 @@ ifneq ($(DEB_HOST_ARCH), amd64)
 endif
 endif
 
+DEBIAN_DIST_NAME := $(shell lsb_release -sc)
+ifneq ($(filter $(DEBIAN_DIST_NAME), lucid squeeze),)
+ SUBSTVARS = -Vdist:Depends="cryptsetup"
+else
+ SUBSTVARS = -Vdist:Depends="cryptsetup-bin"
+endif
+
 configure: configure-stamp
 configure-stamp:
 	dh_testdir
@@ -104,7 +111,7 @@ binary-indep: build install
 	dh_fixperms -i
 	dh_python2 -i
 	dh_installdeb -i
-	dh_gencontrol -i
+	dh_gencontrol -i -- $(SUBSTVARS)
 	dh_md5sums -i
 	dh_builddeb -i
 
@@ -150,7 +157,7 @@ binary-arch: build install
 	dh_python2 -a
 	dh_installdeb -a
 	dh_shlibdeps -a
-	dh_gencontrol -a
+	dh_gencontrol -a -- $(SUBSTVARS)
 	dh_md5sums -a
 	dh_builddeb -a
 


### PR DESCRIPTION
We can query the distribution name with lsb-release. and we pass the right crypsetup name to gencontrol based on that value.
