### PR TITLE
osd/OSD.h: fix try_stop_deletion

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -216,7 +216,7 @@ public:
      * state, because this might block the caller behind entire pg
      * removals.
      */
-    while (status == DELETING_DIR || status == DELETING_DIR)
+    while (status == DELETING_DIR || status == DELETED_DIR)
       cond.Wait(lock);
     return status != DELETED_DIR;
   } ///< @return true if we don't need to recreate the collection


### PR DESCRIPTION
Fix try_stop_deletion(): The comment above the while loop says "If we are
in DELETING_DIR or DELETED_DIR", but the while loop checks for DELETING_DIR
twice. Change one check to DELETED_DIR otherwise on state get missed.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
