### PR TITLE
mon: Monitor: tolerate GV duplicates during conversion

### DIFF
--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -1450,6 +1450,8 @@ public:
     boost::scoped_ptr<MonitorStore> store;
 
     set<version_t> gvs;
+    map<version_t, set<pair<string,version_t> > > gv_map;
+
     version_t highest_last_pn;
     version_t highest_accepted_pn;
 


### PR DESCRIPTION
It fixes Via's store, but haven't dumped the transactions yet to make sure the correct ordering is being maintained -- although, logic-wise, it should (but would love to make sure before merging this).
