### PR TITLE
SimpleThrottle: fix -ENOENT checking

### DIFF
--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -237,7 +237,7 @@ void SimpleThrottle::end_op(int r)
 {
   Mutex::Locker l(m_lock);
   --m_current;
-  if (r < 0 && !m_ret && (r != -ENOENT || m_ignore_enoent))
+  if (r < 0 && !m_ret && !(r == -ENOENT && m_ignore_enoent))
     m_ret = r;
   m_cond.Signal();
 }


### PR DESCRIPTION
The condition was reversed. Rewrite it so it's clear that we're
ignoring -ENOENT only when m_ignore_enoent is set.

Signed-off-by: Josh Durgin josh.durgin@inktank.com
