### PR TITLE
client/Client.cc: fix/silence "logically dead code" CID-Error

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2720,18 +2720,17 @@ void Client::_flush_range(Inode *in, int64_t offset, uint64_t size)
   Cond cond;
   bool safe = false;
   Context *onflush = new C_SafeCond(&flock, &cond, &safe);
-  safe = objectcacher->file_flush(&in->oset, &in->layout, in->snaprealm->get_snap_context(),
-				  offset, size, onflush);
-  if (safe)
-    return;
-
-  // wait for flush
-  client_lock.Unlock();
-  flock.Lock();
-  while (!safe)
-    cond.Wait(flock);
-  flock.Unlock();
-  client_lock.Lock();
+  bool ret = objectcacher->file_flush(&in->oset, &in->layout, in->snaprealm->get_snap_context(),
+				      offset, size, onflush);
+  if (!ret) {
+    // wait for flush
+    client_lock.Unlock();
+    flock.Lock();
+    while (!safe)
+      cond.Wait(flock);
+    flock.Unlock();
+    client_lock.Lock();
+  }
 }
 
 void Client::flush_set_callback(ObjectCacher::ObjectSet *oset)


### PR DESCRIPTION
Fix handling of 'safe' and the conditions after calling file_flush().

CID 1019548 (#1 of 1): Logically dead code (DEADCODE)
  dead_error_begin: Execution cannot reach this statement "flock.Unlock();"

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
## 

v2 of pull request #288 (use bool instead of int)
