### PR TITLE
librbd/internal.cc: fix resource leak

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -345,6 +345,7 @@ namespace librbd {
       ictx->data_ctx.aio_operate(oid, rados_completion, &op);
       ldout(cct, 10) << "scheduling selfmanaged_snap_rollback on "
 		     << oid << " to " << snap_id << dendl;
+      rados_completion->release();
       prog_ctx.update_progress(i * bsize, numseg * bsize);
     }
 


### PR DESCRIPTION
## NOTE: not 100% sure this is the correct fix, so please review carefully.

Call release() on librados::AioCompletion to free storage before
leave the loop or call new again.

CID 1021213 (#1 of 1): Resource leak (RESOURCE_LEAK)
  leaked_storage: Variable "rados_completion" going out of scope leaks
  the storage it points to.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
