### PR TITLE
kv_flat_btree_async.cc: release AioCompletion before leave the loop

### DIFF
--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -2230,6 +2230,7 @@ string KvFlatBtreeAsync::str() {
     all_sizes[indexer] = all_maps[indexer].size();
     all_versions[indexer] = aioc->get_version();
     indexer++;
+    aioc->release();
   }
 
   ret << "///////////////////OBJECT NAMES////////////////" << std::endl;


### PR DESCRIPTION
## NOTE: not 100% sure this is the correct fix, so please review carefully.

CID 727982 (#1 of 1): Resource leak (RESOURCE_LEAK)
  leaked_storage: Variable "aioc" going out of scope leaks the storage
  it points to.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
