### PR TITLE
mon: Paxos: handle all pending proposals before we bootstrap

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -711,6 +711,8 @@ void Monitor::reset()
   quorum.clear();
   outside_quorum.clear();
 
+  bootstrap_ready_services.clear();
+
   paxos->restart();
 
   for (vector<PaxosService*>::iterator p = paxos_service.begin(); p != paxos_service.end(); ++p)
@@ -3935,6 +3937,26 @@ void Monitor::tick()
   }
 
   new_tick();
+}
+
+void Monitor::prepare_bootstrap()
+{
+  dout(1) << __func__ << dendl;
+  for (vector<PaxosService*>::iterator p = paxos_service.begin();
+       p != paxos_service.end(); ++p) {
+    (*p)->prepare_bootstrap();
+  }
+}
+
+void Monitor::mark_bootstrap_ready(string name)
+{
+  dout(1) << __func__ << dendl;
+  bootstrap_ready_services.insert(name);
+
+  if (bootstrap_ready_services.size() == paxos_service.size()) {
+    dout(1) << __func__ << " preparing paxos to bootstrap" << dendl;
+    paxos->prepare_bootstrap();
+  }
 }
 
 int Monitor::check_fsid()

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -1444,7 +1444,12 @@ private:
   Monitor(const Monitor& rhs);
   Monitor& operator=(const Monitor &rhs);
 
+  set<string> bootstrap_ready_services;
+
 public:
+  void prepare_bootstrap();
+  void mark_bootstrap_ready(string name);
+
   class StoreConverter {
     const string path;
     boost::scoped_ptr<MonitorDBStore> db;

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -111,7 +111,7 @@ void MonmapMonitor::update_from_paxos()
   }
 
   if (need_restart) {
-    paxos->prepare_bootstrap();
+    mon->prepare_bootstrap();
   }
 }
 

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -42,6 +42,9 @@ void Paxos::prepare_bootstrap()
   dout(0) << __func__ << dendl;
 
   going_to_bootstrap = true;
+
+  if (is_active())
+    mon->bootstrap();
 }
 
 MonitorDBStore *Paxos::get_store()


### PR DESCRIPTION
We were already taking into account our need to propose any pending
proposals before we went ahead to bootstrap the monitor, while guaranteeing
that no other proposals would be proposed in the meantime by considering
the need to bootstrap in our 'is_active()' condition on PaxosService.

However, we were asserting on propose_pending() whenever it was called
from the proposal_timer, which could be scheduled in-between delaying a
proposal and finding out about our need to bootstrap.

The easy fix would be to bootstrap on propose_pending() if we were to
notice that we had been marked in such need.  However, this would mean
losing the pending value, and that is not acceptable.

This patch refactors the previous approach, forcing services to request
a bootstrap to the Monitor class instead of doing it to the Paxos class.
This allows the Monitor to force all PaxosServices to flush their proposals
as soon as possible, if there are any to be flushed.  Once all services
acknowledge they have successfully proposed their pending state, the
Monitor will let Paxos know it should bootstrap, allowing Paxos to
finish any proposal it may have going on (this should however only happen
during early stages of Paxos recovery), and then bootstrap once it's
active.

Peons will follow the same behavior.  However, a peon's Paxos instance
will never bootstrap.  This allows us to flush all the leader's proposals
before the leader indeed decides to bootstrap, at which point all peons
should follow suit.

Fixes: #5102

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
