### PR TITLE
Remove stop on from upstart tasks

### DIFF
--- a/src/upstart/ceph-create-keys.conf
+++ b/src/upstart/ceph-create-keys.conf
@@ -1,7 +1,6 @@
 description "Create Ceph client.admin key when possible"
 
 start on started ceph-mon
-stop on runlevel [!2345]
 
 task
 

--- a/src/upstart/ceph-mds-all-starter.conf
+++ b/src/upstart/ceph-mds-all-starter.conf
@@ -1,7 +1,6 @@
 description "Ceph MDS (start all instances)"
 
 start on starting ceph-mds-all
-stop on runlevel [!2345] or stopping ceph-mds-all
 
 task
 

--- a/src/upstart/ceph-mon-all-starter.conf
+++ b/src/upstart/ceph-mon-all-starter.conf
@@ -1,7 +1,6 @@
 description "Ceph MON (start all instances)"
 
 start on starting ceph-mon-all
-stop on runlevel [!2345] or stopping ceph-mon-all
 
 task
 

--- a/src/upstart/ceph-osd-all-starter.conf
+++ b/src/upstart/ceph-osd-all-starter.conf
@@ -1,7 +1,6 @@
 description "Ceph OSD (start all instances)"
 
 start on starting ceph-osd-all
-stop on runlevel [!2345] or stopping ceph-osd-all
 
 task
 

--- a/src/upstart/radosgw-all-starter.conf
+++ b/src/upstart/radosgw-all-starter.conf
@@ -1,7 +1,6 @@
 description "Ceph radosgw (task to start all instances)"
 
 start on starting radosgw-all
-stop on runlevel [!2345] or stopping radosgw-all
 
 task
 


### PR DESCRIPTION
Upstart tasks don't have to concept of 'stop on' as they are not long running.
