### PR TITLE
Use invoke-rc.d in maintainer scripts

### DIFF
--- a/debian/ceph-mds.postinst
+++ b/debian/ceph-mds.postinst
@@ -1,4 +1,5 @@
 #!/bin/sh
+# vim: set noet ts=8:
 # postinst script for ceph-mds
 #
 # see: dh_installdeb(1)
@@ -20,7 +21,14 @@ set -e
 
 case "$1" in
     configure)
-	[ -x /sbin/start ] && start ceph-mds-all || :
+	invoke-rc.d ceph-mds-all start || {
+		RESULT=$?
+		# Ignore if ceph-mds-all upstart config does not
+		# exist or upstart is not in use
+		if [ $RESULT != 100 ]; then
+			exit $RESULT
+		fi
+	}
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
 	:

--- a/debian/ceph-mds.prerm
+++ b/debian/ceph-mds.prerm
@@ -1,5 +1,17 @@
 #!/bin/sh
+# vim: set noet ts=8:
 
-[ -x /sbin/stop ] && stop ceph-mds-all || :
+set -e
+
+invoke-rc.d ceph-mds-all stop || {
+	RESULT=$?
+	# Ignore if ceph-all upstart config does not
+	# exist or upstart is not in use
+	if [ $RESULT != 100 ]; then
+		exit $RESULT
+	fi
+}
+
+#DEBHELPER#
 
 exit 0

--- a/debian/ceph.postinst
+++ b/debian/ceph.postinst
@@ -1,4 +1,5 @@
 #!/bin/sh
+# vim: set noet ts=8:
 # postinst script for ceph
 #
 # see: dh_installdeb(1)
@@ -27,7 +28,14 @@ set -e
 case "$1" in
     configure)
 	rm -f /etc/init/ceph.conf
-	[ -x /sbin/start ] && start ceph-all || :
+	invoke-rc.d ceph-all start || {
+		RESULT=$?
+		# Ignore if ceph-all upstart config does not
+		# exist or upstart is not in use
+		if [ $RESULT != 100 ]; then
+			exit $RESULT
+		fi
+	}
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
 	:

--- a/debian/ceph.prerm
+++ b/debian/ceph.prerm
@@ -1,5 +1,17 @@
 #!/bin/sh
+# vim: set noet ts=8:
 
-[ -x /sbin/stop ] && stop ceph-all || :
+set -e
+
+invoke-rc.d ceph-all stop || {
+	RESULT=$?
+	# Ignore if ceph-all upstart config does not
+	# exist or upstart is not in use
+	if [ $RESULT != 100 ]; then
+		exit $RESULT
+	fi
+}
+
+#DEBHELPER#
 
 exit 0


### PR DESCRIPTION
Upstart configurations and sysv init scripts should be started and stopped
using invoke-rc.d in maintainer scripts.

This ensures the correct behaviour across both Debian (sysv) and Ubuntu (upstart)
and in restricted environments such as schroot where start/stop of services from
maintainer scripts is normally disabled.

Signed-off-by: James Page james.page@ubuntu.com
