### PR TITLE
ceph-fuse: add ioctl support

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7462,6 +7462,18 @@ int Client::ll_link(vinodeno_t vino, vinodeno_t newparent, const char *newname, 
   return r;
 }
 
+int Client::ll_describe_layout(Fh *fh, ceph_file_layout* lp)
+{
+  Mutex::Locker lock(client_lock);
+  ldout(cct, 3) << "ll_describe_layout " << fh << " " << fh->inode->ino << dendl;
+  tout(cct) << "ll_describe_layout" << std::endl;
+
+  Inode *in = fh->inode;
+  *lp = in->layout;
+
+  return 0;
+}
+
 int Client::ll_opendir(vinodeno_t vino, void **dirpp, int uid, int gid)
 {
   Mutex::Locker lock(client_lock);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -713,6 +713,7 @@ public:
   int ll_rmdir(vinodeno_t vino, const char *name, int uid = -1, int gid = -1);
   int ll_rename(vinodeno_t parent, const char *name, vinodeno_t newparent, const char *newname, int uid = -1, int gid = -1);
   int ll_link(vinodeno_t vino, vinodeno_t newparent, const char *newname, struct stat *attr, int uid = -1, int gid = -1);
+  int ll_describe_layout(Fh *fh, ceph_file_layout* layout);
   int ll_open(vinodeno_t vino, int flags, Fh **fh, int uid = -1, int gid = -1);
   int ll_create(vinodeno_t parent, const char *name, mode_t mode, int flags, struct stat *attr, Fh **fh, int uid = -1, int gid = -1);
   int ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl);

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -28,6 +28,7 @@
 #include "common/safe_io.h"
 #include "include/types.h"
 #include "Client.h"
+#include "ioctl.h"
 #include "common/config.h"
 #include "include/assert.h"
 
@@ -368,6 +369,34 @@ static void fuse_ll_flush(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info 
   fuse_reply_err(req, 0);
 }
 
+static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino, int cmd, void *arg, struct fuse_file_info *fi,
+                          unsigned flags, const void *in_buf, size_t in_bufsz, size_t out_bufsz)
+{
+  CephFuse::Handle *cfuse = (CephFuse::Handle *)fuse_req_userdata(req);
+
+  if (flags & FUSE_IOCTL_COMPAT) {
+    fuse_reply_err(req, ENOSYS);
+    return;
+  }
+
+  switch(cmd) {
+    case CEPH_IOC_GET_LAYOUT: {
+      struct ceph_file_layout layout;
+      struct ceph_ioctl_layout l;
+      Fh *fh = (Fh*)fi->fh;
+      cfuse->client->ll_describe_layout(fh, &layout);
+      l.stripe_unit = layout.fl_stripe_unit;
+      l.stripe_count = layout.fl_stripe_count;
+      l.object_size = layout.fl_object_size;
+      l.data_pool = layout.fl_pg_pool;
+      fuse_reply_ioctl(req, 0, &l, sizeof(struct ceph_ioctl_layout));
+    }
+    break;
+    default:
+      fuse_reply_err(req, EINVAL);
+  }
+}
+
 static void fuse_ll_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 {
   CephFuse::Handle *cfuse = (CephFuse::Handle *)fuse_req_userdata(req);
@@ -567,7 +596,8 @@ const static struct fuse_lowlevel_ops fuse_ll_oper = {
  create: fuse_ll_create,
  getlk: 0,
  setlk: 0,
- bmap: 0
+ bmap: 0,
+ ioctl: fuse_ll_ioctl
 };
 
 


### PR DESCRIPTION
this commit add the ioctl support to fuse client. So cephfs commands can use on fuse mount. Currently get_layout is implemeted.

Signed-off-by: Andras Elso elso.andras@gmail.com
