### PR TITLE
Fix Issue #5140 , ceph init script failed to determine correct hostname for remote osd

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -310,7 +310,7 @@ for name in $what; do
                     # command line, ceph.conf can override what it wants
 		    get_conf osd_location "" "osd crush location"
 		    get_conf osd_weight "" "osd crush initial weight"
-		    defaultweight=`df $osd_data/. | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }'`
+		    defaultweight="$(do_cmd "df $osd_data/. | tail -1 | awk '{ d= \$2/1073741824 ; r = sprintf(\"%.2f\", d); print r }'")"
 		    get_conf osd_keyring "$osd_data/keyring" "keyring"
 		    $BINDIR/ceph \
 			--name="osd.$id" \
@@ -320,7 +320,7 @@ for name in $what; do
 			"$id" \
 			"${osd_weight:-${defaultweight:-1}}" \
 			root=default \
-			host="$(hostname -s)" \
+			host=$host \
 			$osd_location \
 			|| :
 		fi


### PR DESCRIPTION
When using /etc/init.d/ceph -a start, and if you have osds spread across multi hosts. The init script failed to run correctly.It will put all osds to the first host,and failed to calculate the default weight according to available space for remote osds.

This patch fixed this issue
