### PR TITLE
mon: get rid of the prepare_bootstrap() mechanism

### DIFF
--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -111,7 +111,7 @@ void MonmapMonitor::update_from_paxos()
   }
 
   if (need_restart) {
-    paxos->prepare_bootstrap();
+    mon->bootstrap();
   }
 }
 

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -530,7 +530,6 @@ private:
    * @}
    */
 
-  bool going_to_bootstrap;
   /**
    * Should be true if we have proposed to trim, or are in the middle of
    * trimming; false otherwise.
@@ -1017,16 +1016,12 @@ public:
 		   lease_timeout_event(0),
 		   accept_timeout_event(0),
 		   clock_drift_warned(0),
-		   going_to_bootstrap(false),
 		   going_to_trim(false),
 		   trim_disabled_version(0) { }
 
   const string get_name() const {
     return paxos_name;
   }
-
-  bool is_bootstrapping() { return going_to_bootstrap; }
-  void prepare_bootstrap();
 
   void dispatch(PaxosServiceMessage *m);
 

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -498,8 +498,7 @@ public:
    */
   bool is_active() {
     return (!is_proposing() && !paxos->is_recovering()
-        && !paxos->is_locked()
-	&& !paxos->is_bootstrapping());
+        && !paxos->is_locked());
   }
 
   /**
@@ -579,7 +578,7 @@ public:
    * @param c The callback to be awaken once we become active.
    */
   void wait_for_active(Context *c) {
-    if (paxos->is_bootstrapping() || !is_proposing()) {
+    if (!is_proposing()) {
       paxos->wait_for_active(c);
       return;
     }
@@ -612,7 +611,7 @@ public:
    * @param c The callback to be awaken once we become writeable.
    */
   void wait_for_writeable(Context *c) {
-    if (paxos->is_bootstrapping() || !is_proposing()) {
+    if (!is_proposing()) {
       paxos->wait_for_writeable(c);
       return;
     }


### PR DESCRIPTION
This pull request contains 3 patches:
- call finish_proposal() after finishing a recovery, allowing us to handle it as any other proposal including trimming if need be;
- call finish_contexts() on the queued proposals list, thus allowing the proposal's contexts to be correctly handled
- rip the prepare_bootstrap() stuff as it is not needed
