### PR TITLE
kv_flat_btree_async.cc: fix resource leak

### DIFF
--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -1815,6 +1815,7 @@ int KvFlatBtreeAsync::set_many(const map<string, bufferlist> &in_map) {
   io_ctx.aio_exec(index_name, aioc,  "kvs", "read_many", inbl, &outbl);
   aioc->wait_for_safe();
   err = aioc->get_return_value();
+  aioc->release();
   if (err < 0) {
     cerr << "getting index failed with " << err << std::endl;
     return err;


### PR DESCRIPTION
Call AioCompletion::release() if the completion is no longer
needed to free the resources.

CID 727983 : Resource leak (RESOURCE_LEAK)
  leaked_storage: Variable "aioc" going out of scope leaks the
  storage it points to.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
