### PR TITLE
kv_flat_btree_async.cc: fix AioCompletion resource leak

### DIFF
--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -2168,6 +2168,7 @@ string KvFlatBtreeAsync::str() {
   io_ctx.aio_operate(index_name, top_aioc, &oro, NULL);
   top_aioc->wait_for_safe();
   err = top_aioc->get_return_value();
+  top_aioc->release();
   if (err < 0 && err != -5){
     if (verbose) cout << "getting keys failed with error " << err << std::endl;
     return ret.str();


### PR DESCRIPTION
Call AioCompletion::release() if the completion is no longer
needed to free the resources.

CID 727981 (#3 of 3): Resource leak (RESOURCE_LEAK)
  leaked_storage: Variable "top_aioc" going out of scope leaks the
  storage it points to.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
