### PR TITLE
Remove mon socket in post-stop

### DIFF
--- a/src/upstart/ceph-mon.conf
+++ b/src/upstart/ceph-mon.conf
@@ -24,3 +24,8 @@ export id
 #usage "cluster = name of cluster (defaults to 'ceph'); id = monitor instance id"
 
 exec /usr/bin/ceph-mon --cluster="${cluster:-ceph}" -i "$id" -f
+
+post-stop script
+    # Cleanup socket in case of segfault
+    rm -f "/var/run/ceph/ceph-mon.$id.asok"
+end script


### PR DESCRIPTION
If ceph-mon segfault, socket file isn't removed.

By adding a remove in post-stop, upstart clean run directory properly.
