### PR TITLE
kv_flat_btree_async.cc: fix AioCompletion resource leak

### DIFF
--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -690,12 +690,14 @@ int KvFlatBtreeAsync::read_object(const string &obj, rebalance_args * args) {
     if (verbose) cout << "\t\t" << client_name
 	<< "-read_object: reading failed with "
 	<< err << std::endl;
+    a->release();
     return err;
   }
   bufferlist::iterator it = outbl.begin();
   args->decode(it);
   args->odata.name = obj;
   args->odata.version = a->get_version();
+  a->release();
   return err;
 }
 


### PR DESCRIPTION
Call AioCompletion::release() if the completion is no longer needed.

CID 727979 (#1-2 of 2): Resource leak (RESOURCE_LEAK)
  leaked_storage: Variable "a" going out of scope leaks the storage
  it points to.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
