### PR TITLE
kv_flat_btree_async.cc: fix AioCompletion resource leak

### DIFF
--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -2065,6 +2065,7 @@ bool KvFlatBtreeAsync::is_consistent() {
 	  err = aioc->get_return_value();
 	  if (ceph_clock_now(g_ceph_context) - idata.ts > timeout) {
 	    if (err < 0) {
+	      aioc->release();
 	      if (err == -ENOENT) {
 		continue;
 	      } else {
@@ -2083,6 +2084,7 @@ bool KvFlatBtreeAsync::is_consistent() {
 	    }
 	  }
 	  special_names.insert(dit->obj);
+	  aioc->release();
 	}
 	for(vector<create_data >::iterator cit = idata.to_create.begin();
 	    cit != idata.to_create.end(); ++cit) {


### PR DESCRIPTION
Call AioCompletion::release() if the completion is no longer
needed.

CID 727980 (#1-4 of 4): Resource leak (RESOURCE_LEAK)
  leaked_storage: Variable "aioc" going out of scope leaks
  the storage it points to.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
