### PR TITLE
kv_flat_btree_async.cc: fix AioCompletion resource leak

### DIFF
--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -669,11 +669,13 @@ int KvFlatBtreeAsync::read_object(const string &obj, object_data * odata) {
   err = obj_aioc->get_return_value();
   if (err < 0){
     //possibly -ENOENT, meaning someone else deleted it.
+    obj_aioc->release();
     return err;
   }
   odata->unwritable = string(unw_bl.c_str(), unw_bl.length()) == "1";
   odata->version = obj_aioc->get_version();
   odata->size = odata->omap.size();
+  obj_aioc->release();
   return 0;
 }
 


### PR DESCRIPTION
Call AioCompletion::release() if the completion is no longer needed.

CID 727978 (#1-2 of 2): Resource leak (RESOURCE_LEAK)
  leaked_storage: Variable "obj_aioc" going out of scope leaks the
  storage it points to.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
