### PR TITLE
Use new fuse package instead of fuse-utils

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -101,7 +101,7 @@ Description: debugging symbols for ceph-mds
 Package: ceph-fuse
 Architecture: linux-any
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Recommends: fuse-utils
+Recommends: fuse | fuse-utils
 Description: FUSE-based client for the Ceph distributed file system
  Ceph is a distributed network file system designed to provide
  excellent performance, reliability, and scalability.  This is a
@@ -130,7 +130,7 @@ Description: debugging symbols for ceph-fuse
 Package: rbd-fuse
 Architecture: linux-any
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Recommends: fuse-utils
+Recommends: fuse | fuse-utils
 Description: FUSE-based rbd client for the Ceph distributed file system
  Ceph is a distributed network file system designed to provide
  excellent performance, reliability, and scalability.  This is a


### PR DESCRIPTION
I've left the fuse-utils as a secondary dep option as Debian squeeze has the older style fuse-utils package.
