### PR TITLE
mon: Monitor: backup monmap using all ceph features instead of quorum's

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1351,7 +1351,7 @@ void Monitor::sync_store_init()
       return; // this is moot
     } else {
       dout(10) << __func__ << " backup current monmap" << dendl;
-      monmap->encode(latest_monmap, get_quorum_features());
+      monmap->encode(latest_monmap, CEPH_FEATURES_ALL);
     }
   }
 


### PR DESCRIPTION
When a monitor is freshly created and for some reason its initial sync is
aborted, it will end up with an incorrect backup monmap.  This monmap is
incorrect in the sense that it will not contain the monitor's names as
it will expect on the next run.

This results from us being using the quorum features to encode the monmap
when backing it up, instead of CEPH_FEATURES_ALL.

Fixes: #5203

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
