### PR TITLE
upstart: handle upper case for cluster name and id

### DIFF
--- a/src/upstart/ceph-mds-all-starter.conf
+++ b/src/upstart/ceph-mds-all-starter.conf
@@ -8,7 +8,7 @@ task
 script
   set -e
   # TODO what's the valid charset for cluster names and mds ids?
-  find /var/lib/ceph/mds/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[a-z0-9]+-[a-z0-9._-]+' -printf '%P\n' \
+  find /var/lib/ceph/mds/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
   | while read f; do
     if [ -e "/var/lib/ceph/mds/$f/done" ] && [ -e "/var/lib/ceph/mds/$f/upstart" ]; then
         cluster="${f%%-*}"

--- a/src/upstart/ceph-mon-all-starter.conf
+++ b/src/upstart/ceph-mon-all-starter.conf
@@ -8,7 +8,7 @@ task
 script
   set -e
   # TODO what's the valid charset for cluster names and mon ids?
-  find /var/lib/ceph/mon/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[a-z0-9]+-[a-z0-9._-]+' -printf '%P\n' \
+  find /var/lib/ceph/mon/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
   | while read f; do
     if [ -e "/var/lib/ceph/mon/$f/done" ] && [ -e "/var/lib/ceph/mon/$f/upstart" ]; then
         cluster="${f%%-*}"

--- a/src/upstart/ceph-osd-all-starter.conf
+++ b/src/upstart/ceph-osd-all-starter.conf
@@ -8,7 +8,7 @@ task
 script
   set -e
   # TODO what's the valid charset for cluster names and osd ids?
-  find /var/lib/ceph/osd/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[a-z0-9]+-[a-z0-9._-]+' -printf '%P\n' \
+  find /var/lib/ceph/osd/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
   | while read f; do
     if [ -e "/var/lib/ceph/osd/$f/ready" ] && [ -e "/var/lib/ceph/osd/$f/upstart" ]; then
         cluster="${f%%-*}"

--- a/src/upstart/radosgw-all-starter.conf
+++ b/src/upstart/radosgw-all-starter.conf
@@ -8,7 +8,7 @@ task
 script
   set -e
   # TODO what's the valid charset for cluster names and daemon ids?
-  find /var/lib/ceph/radosgw/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[a-z0-9]+-[a-z0-9._-]+' -printf '%P\n' \
+  find /var/lib/ceph/radosgw/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
   | while read f; do
     if [ -e "/var/lib/ceph/radosgw/$f/done" ]; then
         cluster="${f%%-*}"


### PR DESCRIPTION
Some people have hostnames in uppercase. When using upstart, the current regex does not handle that.
This impact monitor, radosgw and mds.

This patch also allows for a capitalized cluster name, i'll be happy to scratch that if needed.

Not sure why the OSD id need that, but for consistency (it already has [a-z]), I added upper case support too.
