### PR TITLE
mon: fix preforker exit behavior behavior

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -544,6 +544,7 @@ int main(int argc, const char **argv)
     dout(0) << "ceph-mon: gmon.out should be in " << s << dendl;
   }
 
-  return prefork.exit(0);
+  prefork.signal_exit(0);
+  return 0;
 }
 

--- a/src/common/Preforker.h
+++ b/src/common/Preforker.h
@@ -76,12 +76,16 @@ public:
     return r;
   }
 
-  int exit(int r) {
+  int signal_exit(int r) {
     if (forked) {
       // tell parent
       (void)::write(fd[1], &r, sizeof(r));
     }
     return r;
+  }
+  void exit(int r) {
+    signal_exit(r);
+    exit(r);
   }
 
   void daemonize() {


### PR DESCRIPTION
In 3c5706163b72245768958155d767abf561e6d96d we made exit() not actually
exit so that the leak checking would behave for a non-forking case.
That is only needed for the normal exit case; every other case expects
exit() to actually terminate and not continue execution.

Instead, make a signal_exit() method that signals the parent (if any)
and then lets you return.  exit() goes back to it's usual behavior,
fixing the many other calls in main().

Signed-off-by: Sage Weil sage@inktank.com
