### PR TITLE
osd: do not include logbl in scrub map

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3630,10 +3630,7 @@ int PG::build_scrub_map_chunk(
 
   // pg attrs
   osd->store->collection_getattrs(coll, map.attrs);
-
-  // log
-  osd->store->read(coll_t(), log_oid, 0, 0, map.logbl);
-  dout(10) << " done.  pg log is " << map.logbl.length() << " bytes" << dendl;
+  dout(10) << __func__ << " done." << dendl;
 
   return 0;
 }
@@ -3674,9 +3671,7 @@ void PG::build_scrub_map(ScrubMap &map, ThreadPool::TPHandle &handle)
   // pg attrs
   osd->store->collection_getattrs(coll, map.attrs);
 
-  // log
-  osd->store->read(coll_t(), log_oid, 0, 0, map.logbl);
-  dout(10) << " done.  pg log is " << map.logbl.length() << " bytes" << dendl;
+  dout(10) << __func__ << " done." << dendl;
 }
 
 
@@ -3713,9 +3708,6 @@ void PG::build_inc_scrub_map(
   _scan_list(map, ls, false, handle);
   // pg attrs
   osd->store->collection_getattrs(coll, map.attrs);
-
-  // log
-  osd->store->read(coll_t(), log_oid, 0, 0, map.logbl);
 }
 
 void PG::repair_object(const hobject_t& soid, ScrubMap::object *po, int bad_peer, int ok_peer)

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2842,7 +2842,6 @@ void ScrubMap::merge_incr(const ScrubMap &l)
 {
   assert(valid_through == l.incr_since);
   attrs = l.attrs;
-  logbl = l.logbl;
   valid_through = l.valid_through;
 
   for (map<hobject_t,object>::const_iterator p = l.objects.begin();
@@ -2864,7 +2863,8 @@ void ScrubMap::encode(bufferlist& bl) const
   ENCODE_START(3, 2, bl);
   ::encode(objects, bl);
   ::encode(attrs, bl);
-  ::encode(logbl, bl);
+  bufferlist old_logbl;  // not used
+  ::encode(old_logbl, bl);
   ::encode(valid_through, bl);
   ::encode(incr_since, bl);
   ENCODE_FINISH(bl);
@@ -2875,7 +2875,8 @@ void ScrubMap::decode(bufferlist::iterator& bl, int64_t pool)
   DECODE_START_LEGACY_COMPAT_LEN(3, 2, 2, bl);
   ::decode(objects, bl);
   ::decode(attrs, bl);
-  ::decode(logbl, bl);
+  bufferlist old_logbl;   // not used
+  ::decode(old_logbl, bl);
   ::decode(valid_through, bl);
   ::decode(incr_since, bl);
   DECODE_FINISH(bl);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1993,7 +1993,6 @@ struct ScrubMap {
 
   map<hobject_t,object> objects;
   map<string,bufferptr> attrs;
-  bufferlist logbl;
   eversion_t valid_through;
   eversion_t incr_since;
 


### PR DESCRIPTION
This is a potentially use object/file, usually prefixed by a zeroed region
on disk, that is not used by scrub at all.  It dates back to
f51348dc8bdd5071b7baaf3f0e4d2e0496618f08 (2008) and the original version of
scrub.

This _might_ fix #4179.  It is not a leak per se, but I observed 1GB
scrub messages going over the write.  Maybe the allocations are causing
fragmentation, or the sub_op queues are growing.

Signed-off-by: Sage Weil sage@inktank.com
