### PR TITLE
osd: make scrub chunk size tunable

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -426,6 +426,8 @@ OPTION(osd_max_scrubs, OPT_INT, 1)
 OPTION(osd_scrub_load_threshold, OPT_FLOAT, 0.5)
 OPTION(osd_scrub_min_interval, OPT_FLOAT, 60*60*24)    // if load is low
 OPTION(osd_scrub_max_interval, OPT_FLOAT, 7*60*60*24)  // regardless of load
+OPTION(osd_scrub_chunk_min, OPT_INT, 5)
+OPTION(osd_scrub_chunk_max, OPT_INT, 25)
 OPTION(osd_deep_scrub_interval, OPT_FLOAT, 60*60*24*7) // once a week
 OPTION(osd_deep_scrub_stride, OPT_INT, 524288)
 OPTION(osd_scan_list_ping_tp_interval, OPT_U64, 100)

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3658,7 +3658,9 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
           while (!boundary_found) {
             vector<hobject_t> objects;
             ret = osd->store->collection_list_partial(coll, start,
-                                                      5, 5, 0,
+                                                      g_conf->osd_scrub_chunk_min,
+						      g_conf->osd_scrub_chunk_max,
+						      0,
                                                       &objects, &scrubber.end);
             assert(ret >= 0);
 


### PR DESCRIPTION
It was hard-coded at 5.  Make it range from 5-15 by default, for now.

We should still keep this smallish since this range is locked for the
duration of the scrub on this chunk.

Signed-off-by: Sage Weil sage@inktank.com
