### PR TITLE
Usage log and ops log are disabled by defaults since 0.56

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -163,14 +163,14 @@ set automatically.
 
 :Description: Enable logging for RGW operations.
 :Type: Boolean
-:Default: ``true``
+:Default: ``false``
 
 
 ``rgw enable usage log``
 
 :Description: Enable the usage log.
 :Type: Boolean
-:Default: ``true``
+:Default: ``false``
 
 
 ``rgw usage log flush threshold``


### PR DESCRIPTION
http://ceph.com/docs/next/release-notes/#v0-56-bobtail
