### PR TITLE
mon: make 'log ...' command wait for commit before reply

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2632,6 +2632,10 @@ void Monitor::handle_command(MMonCommand *m)
     authmon()->dispatch(m);
     return;
   }
+  if (module == "log") {
+    logmon()->dispatch(m);
+    return;
+  }
 
   if (module == "config-key") {
     if (!access_all) {
@@ -2647,21 +2651,6 @@ void Monitor::handle_command(MMonCommand *m)
     ds << monmap->fsid;
     rdata.append(ds);
     reply_command(m, 0, "", rdata, 0);
-    return;
-  }
-  if (prefix == "log") {
-    if (!access_r) {
-      r = -EACCES;
-      rs = "access denied";
-      goto out;
-    }
-    vector<string> logtext;
-    cmd_getval(g_ceph_context, cmdmap, "logtext", logtext);
-    std::copy(logtext.begin(), logtext.end(),
-	      ostream_iterator<string>(ds, " "));
-    clog.info(ds);
-    rs = "ok";
-    reply_command(m, 0, rs, 0);
     return;
   }
 


### PR DESCRIPTION
Previously we should just dump the command argument to our local log client
and reply immediately, which could lose the message if we then restarted.
Instead, commit directly and wait before replying.

Also, log as the actual client, not as the monitor processing the message.

Fixes: #5409
Signed-off-by: Sage Weil sage@inktank.com
