### PR TITLE
mon/AuthMonitor: make initial auth include rotating keys

### DIFF
--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -160,6 +160,7 @@ bool KeyServer::_check_rotating_secrets()
   added += _rotate_secret(CEPH_ENTITY_TYPE_MDS);
 
   if (added) {
+    ldout(cct, 10) << __func__ << " added " << added << dendl;
     data.rotating_ver++;
     //data.next_rotating_time = ceph_clock_now(cct);
     //data.next_rotating_time += MIN(g_conf->auth_mon_ticket_ttl, g_conf->auth_service_ticket_ttl);

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -50,15 +50,15 @@ ostream& operator<<(ostream& out, AuthMonitor& pm)
   return out << "auth";
 }
 
-void AuthMonitor::check_rotate()
+bool AuthMonitor::check_rotate()
 {
   KeyServerData::Incremental rot_inc;
   rot_inc.op = KeyServerData::AUTH_INC_SET_ROTATING;
   if (!mon->key_server.updated_rotating(rot_inc.rotating_bl, last_rotating_ver))
-    return;
-  dout(10) << "AuthMonitor::tick() updated rotating, now calling propose_pending" << dendl;
+    return false;
+  dout(10) << __func__ << " updated rotating" << dendl;
   push_cephx_inc(rot_inc);
-  propose_pending();
+  return true;
 }
 
 /*
@@ -74,7 +74,8 @@ void AuthMonitor::tick()
 
   if (!mon->is_leader()) return; 
 
-  check_rotate();
+  if (check_rotate())
+    propose_pending();
 }
 
 void AuthMonitor::on_active()
@@ -110,6 +111,9 @@ void AuthMonitor::create_initial()
   inc.inc_type = GLOBAL_ID;
   inc.max_global_id = max_global_id;
   pending_auth.push_back(inc);
+
+  // initalize rotating keys, too
+  check_rotate();
 }
 
 void AuthMonitor::update_from_paxos()

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -148,7 +148,7 @@ private:
   bool preprocess_command(MMonCommand *m);
   bool prepare_command(MMonCommand *m);
 
-  void check_rotate();
+  bool check_rotate();
  public:
   AuthMonitor(Monitor *mn, Paxos *p, const string& service_name)
     : PaxosService(mn, p, service_name), last_rotating_ver(0),


### PR DESCRIPTION
This closes a very narrow race during mon creation where there are no
service keys.

Fixes: #5427
Signed-off-by: Sage Weil sage@inktank.com
