### PR TITLE
librbd: clear LAYERING feature bit when removing the parent

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -869,6 +869,16 @@ int remove_parent(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     return r;
   }
 
+  // remove LAYERING feature, since we are not (now) layered
+  uint64_t features;
+  r = read_key(hctx, "features", &features);
+  features &= ~RBD_FEATURE_LAYERING;
+  bufferlist featuresbl;
+  ::encode(features, featuresbl);
+  r = cls_cxx_map_set_val(hctx, "features", &featuresbl);
+  if (r < 0)
+    return r;
+
   return 0;
 }
 


### PR DESCRIPTION
Once we remove the parent, clients no longer need to support layering to
use the image.  Remove the feature bit.

This also makes it simpler for clients to detect whether a parent is
present in that the get_parent ENOENT needn't be handled (although it
probably should be given that the old behavior did not clear this bit).

Signed-off-by: Sage Weil sage@inktank.com
