### PR TITLE
rgw-admin: Fix bucket list with no --uid

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -900,12 +900,8 @@ static int bucket_stats(RGWRados *store, std::string&  bucket_name, Formatter *f
 int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher)
 {
-  RGWBucket bucket;
-  int ret = bucket.init(store, op_state);
-  if (ret < 0)
-    return ret;
+  int ret;
   string bucket_name = op_state.get_bucket_name();
-
   Formatter *formatter = flusher.get_formatter();
   flusher.start(0);
 
@@ -949,12 +945,13 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
   } else {
     RGWAccessHandle handle;
 
-    if (store->list_buckets_init(&handle) > 0) {
+    if (store->list_buckets_init(&handle) == 0) {
       RGWObjEnt obj;
       while (store->list_buckets_next(obj, &handle) >= 0) {
-	formatter->dump_string("bucket", obj.name);
         if (show_stats)
           bucket_stats(store, obj.name, formatter);
+        else
+          formatter->dump_string("bucket", obj.name);
       }
     }
   }

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -15,6 +15,7 @@
 #include "common/Formatter.h"
 #include "common/lru_map.h"
 #include "rgw_formats.h"
+#include "rgw/rgw_user.h"
 
 
 using namespace std;
@@ -159,7 +160,7 @@ struct RGWBucketAdminOpState {
   bool will_fix_index() { return fix_index; };
   bool will_delete_children() { return delete_child_objects; };
   bool will_check_objects() { return check_objects; };
-  bool is_user_op() { return !uid.empty(); };
+  bool is_user_op() { return !uid.empty() && uid.compare(rgw_get_anon_uid()) != 0; };
   bool is_system_op() { return uid.empty(); }; 
   bool has_bucket_stored() { return bucket_stored; };
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -25,6 +25,13 @@ using namespace std;
 
 static RGWMetadataHandler *user_meta_handler = NULL;
 
+/**
+ * Get the anonymous (ie, unauthenticated) user id
+ */
+std::string rgw_get_anon_uid()
+{
+  return RGW_USER_ANON_ID;
+}
 
 /**
  * Get the anonymous (ie, unauthenticated) user info.

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -39,6 +39,11 @@ struct RGWUID
 WRITE_CLASS_ENCODER(RGWUID)
 
 /**
+ * Get the anonymous (ie, unauthenticated) user id.
+ */
+extern std::string rgw_get_anon_uid();
+
+/**
  * Get the anonymous (ie, unauthenticated) user info.
  */
 extern void rgw_get_anon_user(RGWUserInfo& info);


### PR DESCRIPTION
http://tracker.ceph.com/issues/5228 fixes #5228

The command bucket list with no uid specified was no displaying
the right output. Instead of listing all buckets, it was outputing
nothing.

The is_user_op was returning true if the user was anonymous,
and the list_bucket_init function call was not checking for the
right return value.

Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com
