### PR TITLE
rgw: Fix return value for swift user not found

### DIFF
--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -181,7 +181,10 @@ void RGW_SWIFT_Auth_Get::execute()
   user_str = user;
 
   if ((ret = rgw_get_user_info_by_swift(store, user_str, info)) < 0)
+  {
+    ret = -EACCES;
     goto done;
+  }
 
   siter = info.swift_keys.find(user_str);
   if (siter == info.swift_keys.end()) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/1779 fixes #1779

Adjust the return value from rgw_get_user_info_by_swift call
in RGW_SWIFT_Auth_Get::execute() to have the correct
return code in response.
