### PR TITLE
Makefile: fix ceph_sbindir

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,7 +28,7 @@ bin_PROGRAMS =
 bin_DEBUGPROGRAMS =
 sbin_PROGRAMS =
 # like sbin_SCRIPTS but can be used to install to e.g. /usr/sbin
-ceph_sbindir = $(prefix)$(sbindir)
+ceph_sbindir = $(sbindir)
 ceph_sbin_SCRIPTS = \
 	ceph-disk \
 	ceph-disk-prepare \


### PR DESCRIPTION
From Denis Kaganovich mahatma@eu.by:

At least in some cases, scripts (ceph-disk*, ceph-create-keys)
installing into /usr/usr/sbin. This happened while
"ceph_sbindir = $(prefix)$(sbindir)" in src/Makefile.am and "
./configure --prefix=/usr ..." (Gentoo's default configure call).
I don't dig too deep, but IMHO it can be result of "prefix=" &
"exec_prefix=" disorder. Fixed for me by "ceph_sbindir = $(sbindir)"
(I don't try other configure behaviors, but looks universal).

Reported-by: Denis Kaganovich mahatma@eu.by
Fixes: #5492
Signed-off-by: Sage Weil sage@inktank.com
