### PR TITLE
rgw: Add explicit messages in radosgw init script

### DIFF
--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -35,6 +35,7 @@ fi
 
 case "$1" in
     start)
+        echo "Starting radosgw instance(s)..."
         for name in `ceph-conf --list-sections $PREFIX`;
         do
             auto_start=`ceph-conf -n $name 'auto start'`
@@ -73,7 +74,7 @@ case "$1" in
     reload)
         #start-stop-daemon --signal HUP -x $RADOSGW --oknodo
         killproc $RADOSGW -SIGHUP
-        echo "Reloading radosgw..."
+        echo "Reloading radosgw instance(s)..."
         ;;
     restart|force-reload)
         $0 stop
@@ -82,7 +83,7 @@ case "$1" in
     stop)
         #start-stop-daemon --stop -x $RADOSGW --oknodo
         killproc $RADOSGW
-        echo "Stopping radosgw..."
+        echo "Stopping radosgw instance(s)..."
         ;;
     status)
         if pidof $RADOSGW >/dev/null; then


### PR DESCRIPTION
http://tracker.ceph.com/issues/5478 fixes #5478

As mentionned in this issue, there should be a bit more consistency.
What is reported in this issue is a correct behaviour to me, but it might miss some more messages, to tell user we are going to start or stop instance(s).

As in the start, we have the instances name, the behaviour was to display a message with the name of the instance.
But when stopping all instances, as we are killing all processes, we can't display a message for each instances.

This commit should make the init script messages more explanatory.

Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com
