### PR TITLE
mon: remove bad assert about monmap version

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1389,7 +1389,6 @@ void Monitor::sync_obtain_latest_monmap(bufferlist &bl)
   if (monmap->epoch > latest_monmap.epoch)
     latest_monmap = *monmap;
 
-  assert(latest_monmap.epoch > 0);
   dout(1) << __func__ << " obtained monmap e" << latest_monmap.epoch << dendl;
 
   latest_monmap.encode(bl, CEPH_FEATURES_ALL);


### PR DESCRIPTION
It is possible to start a sync when our newest monmap is 0.  Usually we see
e0 from probe, but that isn't always published as part of the very first
paxos transaction due to the way PaxosService::_active generates it's
first initial commit.

In any case, having e0 here is harmless.

Fixes: #5509
Signed-off-by: Sage Weil sage@inktank.com
