### PR TITLE
client: remove O_LAZY

### DIFF
--- a/src/client/Fh.h
+++ b/src/client/Fh.h
@@ -14,8 +14,6 @@ struct Fh {
   int       mds;        // have to talk to mds we opened with (for now)
   int       mode;       // the mode i opened the file with
 
-  bool is_lazy() { return mode & O_LAZY; }
-
   int flags;
   bool pos_locked;           // pos is currently in use
   list<Cond*> pos_waiters;   // waiters for pos

--- a/src/doc/lazy_posix.txt
+++ b/src/doc/lazy_posix.txt
@@ -25,7 +25,7 @@ http://www.usenix.org/events/fast05/wips/slides/welch.pdf
 
 -- lazy i/o integrity
 
-  O_LAZY to open(2)
+  FIXME: currently missing call to flag an Fd/file has lazy.  used to be O_LAZY on open, but no more.
 
   * relax data coherency
   * writes may not be visible until lazyio_propagate, fsync, close

--- a/src/include/ceph_fs.cc
+++ b/src/include/ceph_fs.cc
@@ -56,10 +56,6 @@ int ceph_flags_to_mode(int flags)
 		mode = CEPH_FILE_MODE_RDWR;
 		break;
 	}
-#ifdef O_LAZY
-	if (flags & O_LAZY)
-		mode |= CEPH_FILE_MODE_LAZY;
-#endif
 
 	return mode;
 }

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -271,8 +271,6 @@ typedef uint64_t tid_t;         // transaction id
 typedef uint64_t version_t;
 typedef __u32 epoch_t;       // map epoch  (32bits -> 13 epochs/second for 10 years)
 
-#define O_LAZY 01000000
-
 // --------------------------------------
 // identify individual mount clients by 64bit value
 


### PR DESCRIPTION
The once-upon-a-time unique O_LAZY value I chose forever ago is not
O_NOATIME, which means that some clients were choosing relaxed
consistency without meaning to.

It is highly unlikely that a real O_LAZY will ever exist, and we can
select it in the ceph case with the ioctl or libcephfs call, so drop
any support for doing this via open(2) flags.

Remove the outdated doc/lazy_posix.txt file.

Backport: cuttlefish
Signed-off-by: Sage Weil sage@inktank.com
