### PR TITLE
mon/PaxosService: trim periodically instead of via propose_pending

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4139,6 +4139,7 @@ void Monitor::tick()
   
   for (vector<PaxosService*>::iterator p = paxos_service.begin(); p != paxos_service.end(); ++p) {
     (*p)->tick();
+    (*p)->maybe_trim();
   }
   
   // trim sessions

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -469,6 +469,11 @@ public:
   virtual void tick() {}
 
   /**
+   * called at same interval as tick.  consider a trim.
+   */
+  void maybe_trim();
+
+  /**
    * Get health information
    *
    * @param summary list of summary strings and associated severity


### PR DESCRIPTION
We want to trim old states even if there is no update activity.  For
example, if a long-running rebalance finishes all osdmap updates will
stop and we won't trim out old maps to free space.

Instead, trim at the same time as tick().  Remove the trim during
propose_pending() to force all trims through this path and avoid
introducing a new and rarely-exercised behavior.

Signed-off-by: Sage Weil sage@inktank.com
