### PR TITLE
mon/OSDMonitor: make 'osd crush rm ...' slightly more idempotent

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2720,10 +2720,17 @@ bool OSDMonitor::prepare_command(MMonCommand *m)
       string name;
       cmd_getval(g_ceph_context, cmdmap, "name", name);
 
-      if (!newcrush.name_exists(name)) {
+      if (!osdmap.crush->name_exists(name)) {
 	err = 0;
 	ss << "device '" << name << "' does not appear in the crush map";
 	break;
+      }
+      if (!newcrush.name_exists(name)) {
+	err = 0;
+	ss << "device '" << name << "' does not appear in the crush map";
+	getline(ss, rs);
+	wait_for_finished_proposal(new Monitor::C_Command(mon, m, 0, rs, get_last_committed()));
+	return true;
       }
       int id = newcrush.get_item_id(name);
       bool unlink_only = prefix == "osd crush unlink";


### PR DESCRIPTION
This particular failure is easily triggered by the crush_ops.sh
workunit.  Make it a bit less likely to fail.

Signed-off-by: Sage Weil sage@inktank.com
