### PR TITLE
Makefile.am: fix build, use $(CRYPTO_LIBS)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -989,21 +989,21 @@ bin_DEBUGPROGRAMS += ceph_test_cors
 
 cls_test_rgw_meta_SOURCES = test/test_rgw_admin_meta.cc
 cls_test_rgw_meta_LDFLAGS = libglobal.la 
-cls_test_rgw_meta_LDADD = librgw.a ${UNITTEST_LDADD} ${UNITTEST_STATIC_LDADD} -lcryptopp -lcurl -luuid -lexpat  librados.la libcls_version_client.a \
+cls_test_rgw_meta_LDADD = librgw.a ${UNITTEST_LDADD} ${UNITTEST_STATIC_LDADD} $(CRYPTO_LIBS) -lcurl -luuid -lexpat  librados.la libcls_version_client.a \
  libcls_log_client.a libcls_statelog_client.a libcls_refcount_client.a libcls_rgw_client.a libcls_lock_client.a
 cls_test_rgw_meta_CXXFLAGS = ${AM_CXXFLAGS} ${UNITTEST_CXXFLAGS}
 bin_DEBUGPROGRAMS += cls_test_rgw_meta
 
 cls_test_rgw_log_SOURCES = test/test_rgw_admin_log.cc
 cls_test_rgw_log_LDFLAGS = libglobal.la 
-cls_test_rgw_log_LDADD = librgw.a ${UNITTEST_LDADD} ${UNITTEST_STATIC_LDADD} -lcryptopp -lcurl -luuid -lexpat  librados.la libcls_version_client.a \
+cls_test_rgw_log_LDADD = librgw.a ${UNITTEST_LDADD} ${UNITTEST_STATIC_LDADD} $(CRYPTO_LIBS) -lcurl -luuid -lexpat  librados.la libcls_version_client.a \
  libcls_log_client.a libcls_statelog_client.a libcls_refcount_client.a libcls_rgw_client.a libcls_lock_client.a
 cls_test_rgw_log_CXXFLAGS = ${AM_CXXFLAGS} ${UNITTEST_CXXFLAGS}
 bin_DEBUGPROGRAMS += cls_test_rgw_log
 
 cls_test_rgw_opstate_SOURCES = test/test_rgw_admin_opstate.cc
 cls_test_rgw_opstate_LDFLAGS = libglobal.la 
-cls_test_rgw_opstate_LDADD = librgw.a ${UNITTEST_LDADD} ${UNITTEST_STATIC_LDADD} -lcryptopp -lcurl -luuid -lexpat  librados.la libcls_version_client.a \
+cls_test_rgw_opstate_LDADD = librgw.a ${UNITTEST_LDADD} ${UNITTEST_STATIC_LDADD} $(CRYPTO_LIBS) -lcurl -luuid -lexpat  librados.la libcls_version_client.a \
  libcls_log_client.a libcls_statelog_client.a libcls_refcount_client.a libcls_rgw_client.a libcls_lock_client.a
 cls_test_rgw_opstate_CXXFLAGS = ${AM_CXXFLAGS} ${UNITTEST_CXXFLAGS}
 bin_DEBUGPROGRAMS += cls_test_rgw_opstate


### PR DESCRIPTION
Use $(CRYPTO_LIBS) instead of -lcryptopp to work also with
nss crypto lib.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
