### PR TITLE
ceph.spec.in: add missing %{_libdir}/rados-classes/libcls_* files

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -398,6 +398,10 @@ fi
 %{_libdir}/rados-classes/libcls_lock.so*
 %{_libdir}/rados-classes/libcls_kvs.so*
 %{_libdir}/rados-classes/libcls_refcount.so*
+%{_libdir}/rados-classes/libcls_log.so*
+%{_libdir}/rados-classes/libcls_replica_log.so*
+%{_libdir}/rados-classes/libcls_statelog.so*
+%{_libdir}/rados-classes/libcls_version.so*
 %{_libdir}/ceph
 /lib/udev/rules.d/50-rbd.rules
 /lib/udev/rules.d/60-ceph-partuuid-workaround.rules


### PR DESCRIPTION
Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
