### PR TITLE
src/Makefile.am: use exec_prefix instead of prefix for ceph_sbindir

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,7 +28,7 @@ bin_PROGRAMS =
 bin_DEBUGPROGRAMS =
 sbin_PROGRAMS =
 # like sbin_SCRIPTS but can be used to install to e.g. /usr/sbin
-ceph_sbindir = $(prefix)$(sbindir)
+ceph_sbindir = $(exec_prefix)$(sbindir)
 ceph_sbin_SCRIPTS = \
 	ceph-disk \
 	ceph-disk-prepare \


### PR DESCRIPTION
Fixes: #5492

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
