### PR TITLE
rgw: quiet down ECANCELED on put_obj_meta()

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2301,6 +2301,11 @@ done_cancel:
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: complete_update_index_cancel() returned ret=" << ret << dendl;
   }
+  /* we lost in a race, object was already overwritten, we
+   * should treat it as a success
+   */
+  if (r == -ECANCELED)
+    r = 0;
   return r;
 }
 


### PR DESCRIPTION
Fixes: #5439

ECANCELED there means that we lost in a race to write the object. We
should treat it as a successful write. This is reviving an old behavior
that was changed inadvertently.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
