### PR TITLE
ceph, config, auth: better messages on failure to open keyring/ceph.conf

### DIFF
--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -42,11 +42,15 @@ int KeyRing::from_ceph_context(CephContext *cct)
   int ret = -ENOENT;
   string filename;
 
-  if (ceph_resolve_file_search(conf->keyring, filename)) {
+  ret = ceph_resolve_file_search(conf->keyring, filename);
+  if (ret == 0) {
     ret = load(cct, filename);
     if (ret < 0)
       lderr(cct) << "failed to load " << filename
 		 << ": " << cpp_strerror(ret) << dendl;
+  } else {
+    lderr(cct) << "error opening keyring: " << cpp_strerror(errno) << dendl;
+    return -errno;
   }
 
   if (!conf->key.empty()) {

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -543,8 +543,13 @@ def main():
     if parsed_args.cluster:
         clustername = parsed_args.cluster
 
-    cluster_handle = rados.Rados(name=name, clustername=clustername,
-                                 conf_defaults=conf_defaults, conffile=conffile)
+    try:
+        cluster_handle = rados.Rados(name=name, clustername=clustername,
+                                     conf_defaults=conf_defaults,
+                                     conffile=conffile)
+    except Exception as e:
+        print >> sys.stderr, "Error opening cluster: ", str(e)
+        return 1
 
     retargs = cluster_handle.conf_parse_argv(childargs)
     #tmp = childargs
@@ -570,8 +575,8 @@ def main():
         print >> sys.stderr, 'Cluster connection aborted'
         return 1
     except Exception as e:
-        print >> sys.stderr, 'Error connecting to cluster: {0}'.\
-            format(e.__class__.__name__)
+        print >> sys.stderr, 'Error connecting to cluster: {0}({1})'.\
+            format(e.__class__.__name__, str(e))
         return 1
 
     if parsed_args.help or parsed_args.help_all:

--- a/src/ceph_conf.cc
+++ b/src/ceph_conf.cc
@@ -129,7 +129,7 @@ static int lookup(const std::deque<std::string> &sections,
   else if (ret == 0) {
     if (resolve_search) {
       string result;
-      if (ceph_resolve_file_search(val, result))
+      if (ceph_resolve_file_search(val, result) >= 0)
 	puts(result.c_str());
     }
     else {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -235,8 +235,8 @@ typedef enum {
 	OPT_ADDR, OPT_U32, OPT_U64, OPT_UUID
 } opt_type_t;
 
-bool ceph_resolve_file_search(const std::string& filename_list,
-			      std::string& result);
+int ceph_resolve_file_search(const std::string& filename_list,
+			     std::string& result);
 
 struct config_option {
   const char *name;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -93,7 +93,9 @@ void global_init(std::vector < const char * > *alt_def_args, std::vector < const
     }
   }
   else if (ret) {
-    dout_emergency("global_init: error reading config file.\n");
+    dout_emergency("global_init: error reading config file: ");
+    dout_emergency(cpp_strerror(ret));
+    dout_emergency("\n");
     _exit(1);
   }
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3594,7 +3594,7 @@ int Monitor::mkfs(bufferlist& osdmapbl)
 
   KeyRing keyring;
   string keyring_filename;
-  if (!ceph_resolve_file_search(g_conf->keyring, keyring_filename)) {
+  if (ceph_resolve_file_search(g_conf->keyring, keyring_filename) != 0) {
     derr << "unable to find a keyring file on " << g_conf->keyring << dendl;
     return -ENOENT;
   }


### PR DESCRIPTION
If something as simple as file ownership is wrong, Ceph commands
and daemons can fail to run, and the diagnostics are not great.
Improve that for at least the specific cases of unopenable keyring and
ceph.conf files.
