### PR TITLE
fuse: fix fuse_getgroups detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -250,7 +250,10 @@ AS_IF([test "x$with_fuse" != xno],
                          [Define if you have fuse])
                HAVE_LIBFUSE=1
 	       # look for fuse_getgroups and define FUSE_GETGROUPS if found
+           LIBS_saved="$LIBS"
+           LIBS="$LIBS -lfuse"
 	       AC_CHECK_FUNCS([fuse_getgroups])
+           LIBS="$LIBS_saved"
               ],
              [AC_MSG_FAILURE(
                    [no FUSE found (use --without-fuse to disable)])])])

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -14,6 +14,7 @@
 
 #define FUSE_USE_VERSION 26
 
+#include <fuse/fuse.h>
 #include <fuse/fuse_lowlevel.h>
 #include <signal.h>
 #include <stdio.h>
@@ -520,7 +521,7 @@ static int getgroups_cb(void *handle, uid_t uid, gid_t **sgids)
     return 0;
   }
 
-  *sgids = malloc(c*sizeof(**sgids));
+  *sgids = (gid_t*)malloc(c*sizeof(**sgids));
   if (!*sgids) {
     return -ENOMEM;
   }


### PR DESCRIPTION
The ac_check_func fails because -lfuse is not in LIBS. This also enables
code that wasn't being compiled, and fixes compiler errors that
resulted.

Signed-off-by: Noah Watkins noahwatkins@gmail.com
