### PR TITLE
FileJournal: fix posix_fallocate error handling

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -299,11 +299,10 @@ int FileJournal::_open_file(int64_t oldsize, blksize_t blksize,
       return -err;
     }
     ret = ::posix_fallocate(fd, 0, newsize);
-    if (ret < 0) {
-      int err = errno;
+    if (ret) {
       derr << "FileJournal::_open_file : unable to preallocation journal to "
-	   << newsize << " bytes: " << cpp_strerror(err) << dendl;
-      return -err;
+	   << newsize << " bytes: " << cpp_strerror(ret) << dendl;
+      return -ret;
     }
     max_size = newsize;
   }


### PR DESCRIPTION
From the man page for posix_fallocate:

```
posix_fallocate() returns zero on success, or an error
number on failure.  Note that errno is not set.
```

Signed-off-by: Noah Watkins noahwatkins@gmail.com
