### PR TITLE
Use dh_installinit to install upstart job files

### DIFF
--- a/debian/ceph-mds.ceph-mds-all-starter.upstart
+++ b/debian/ceph-mds.ceph-mds-all-starter.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-mds-all-starter.conf

--- a/debian/ceph-mds.ceph-mds-all.upstart
+++ b/debian/ceph-mds.ceph-mds-all.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-mds-all.conf

--- a/debian/ceph-mds.ceph-mds.upstart
+++ b/debian/ceph-mds.ceph-mds.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-mds.conf

--- a/debian/ceph.ceph-all.upstart
+++ b/debian/ceph.ceph-all.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-all.conf

--- a/debian/ceph.ceph-create-keys.upstart
+++ b/debian/ceph.ceph-create-keys.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-create-keys.conf

--- a/debian/ceph.ceph-mon-all-starter.upstart
+++ b/debian/ceph.ceph-mon-all-starter.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-mon-all-starter.conf

--- a/debian/ceph.ceph-mon-all.upstart
+++ b/debian/ceph.ceph-mon-all.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-mon-all.conf

--- a/debian/ceph.ceph-mon.upstart
+++ b/debian/ceph.ceph-mon.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-mon.conf

--- a/debian/ceph.ceph-osd-all-starter.upstart
+++ b/debian/ceph.ceph-osd-all-starter.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-osd-all-starter.conf

--- a/debian/ceph.ceph-osd-all.upstart
+++ b/debian/ceph.ceph-osd-all.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-osd-all.conf

--- a/debian/ceph.ceph-osd.upstart
+++ b/debian/ceph.ceph-osd.upstart
@@ -1,0 +1,1 @@
+../src/upstart/ceph-osd.conf

--- a/debian/radosgw.radowgw-all-starter.upstart
+++ b/debian/radosgw.radowgw-all-starter.upstart
@@ -1,0 +1,1 @@
+../src/upstart/radosgw-all-starter.conf

--- a/debian/radosgw.radowgw-all.upstart
+++ b/debian/radosgw.radowgw-all.upstart
@@ -1,0 +1,1 @@
+../src/upstart/radosgw-all.conf

--- a/debian/radosgw.radowgw.upstart
+++ b/debian/radosgw.radowgw.upstart
@@ -1,0 +1,1 @@
+../src/upstart/radosgw.conf

--- a/debian/rules
+++ b/debian/rules
@@ -114,15 +114,25 @@ binary-arch: build install
 	dh_installexamples -a
 	dh_install -a --sourcedir=$(DESTDIR) --list-missing
 	dh_installlogrotate -a
-	dh_installinit -a --no-start
-	# dh_installinit is only set up to handle one upstart script
-	# per package, so do this ourselves
-	install -d -m0755 debian/ceph/etc/init
-	install -m0644 src/upstart/ceph*.conf debian/ceph/etc/init
-	install -d -m0755 debian/ceph-mds/etc/init
-	mv debian/ceph/etc/init/ceph-mds* debian/ceph-mds/etc/init
-	install -d -m0755 debian/radosgw/etc/init
-	install -m0644 src/upstart/radosgw*.conf debian/radosgw/etc/init
+	#upstart job files for binary package ceph
+	dh_installinit --no-start --name=ceph-all
+	dh_installinit --no-start --name=ceph-create-keys
+	dh_installinit --no-start --name=ceph-mon-all-starter
+	dh_installinit --no-start --name=ceph-mon-all
+	dh_installinit --no-start --name=ceph-mon
+	dh_installinit --no-start --name=ceph-osd-all-starter
+	dh_installinit --no-start --name=ceph-osd-all
+	dh_installinit --no-start --name=ceph-osd
+	#upstart job files for binary package ceph-mds
+	dh_installinit --no-start --name=ceph-mds-all
+	dh_installinit --no-start --name=ceph-mds-all-starter
+	dh_installinit --no-start --name=ceph-mds
+	#upstart job files for binary package radowgw
+	dh_installinit --no-start --name=radosgw-all-starter
+	dh_installinit --no-start --name=radosgw-all
+	dh_installinit --no-start --name=radosgw
+	#all other initscripts
+	dh_installinit --no-start
 	dh_installman -a
 	dh_lintian -a
 	dh_link -a


### PR DESCRIPTION
I decided to create symlinks so the files in src/upstart/\* can still be distributed with the tar.xz releases and then used by other (non-debian-based) distributions. Another possibility would be the move of the files to the debian/ dir instead of the symlinks.
