### PR TITLE
Fix CID 1058791

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2551,7 +2551,7 @@ int RGWRados::copy_obj(void *ctx,
         conn = rest_master_conn;
       } else {
         map<string, RGWRESTConn *>::iterator iter = region_conn_map.find(src_bucket_info.region);
-        if (iter == zone_conn_map.end()) {
+        if (iter == region_conn_map.end()) {
           ldout(cct, 0) << "could not find region connection to region: " << source_zone << dendl;
           return -ENOENT;
         }


### PR DESCRIPTION
rgw_rados.cc: fix invalid iterator comparison 
The iterator should be compared against the end() function of
the same iter() from region_conn_map.

CID 1058791 (#1 of 1): Invalid iterator comparison (MISMATCHED_ITERATOR)
  mismatched_comparison: Comparing "iter" from "this->region_conn_map" to
  "this->zone_conn_map.end()" from "this->zone_conn_map".
