### PR TITLE
Fix for Swift key command

### DIFF
--- a/doc/start/quick-rgw.rst
+++ b/doc/start/quick-rgw.rst
@@ -306,7 +306,7 @@ Next, create a subuser for the Swift-compatible interface. ::
 
 ::
 
-  sudo radosgw-admin key create --subuser=johndoe:swift --key-type=swift
+  sudo radosgw-admin key create --subuser=johndoe:swift --key-type=swift --gen-secret
 
 .. code-block:: javascript
 


### PR DESCRIPTION
When creating a secret key for the Swift user, the command without the --gen-secret option generates an empty key.
