### PR TITLE
Document unstable nature of CephFS

### DIFF
--- a/doc/cephfs/index.rst
+++ b/doc/cephfs/index.rst
@@ -7,6 +7,7 @@ a Ceph Storage Cluster to store its data. The Ceph filesystem uses the same Ceph
 Storage Cluster system as Ceph Block Devices, Ceph Object Storage with its S3
 and Swift APIs, or native bindings (librados).
 
+.. important:: Ceph FS is currently not recommended for production data.
 
 .. ditaa::
             +-----------------------+  +------------------------+

--- a/doc/rados/deployment/ceph-deploy-mds.rst
+++ b/doc/rados/deployment/ceph-deploy-mds.rst
@@ -6,8 +6,9 @@ With ``ceph-deploy``, adding and removing metadata servers is a simple task. You
 just add or remove one or more metadata servers on the command line with one
 command.
 
-.. note:: CephFS is in production using 1 metadata server per cluster. You
-   **MUST** deploy at least one metadata server to use CephFS.
+.. important:: You must deploy at least one metadata server to use CephFS.
+    There is experimental support for running multiple metadata servers.
+    Do not run multiple metadata servers in production.
 
 See `MDS Config Reference`_ for details on configuring metadata servers.
 


### PR DESCRIPTION
- Add note to docs indicating that CephFS is not recommended for
  production datasets.
- Add note to docs indicating that running CephFS with multiple MDS
  servers is not currently recommended.

This fixes issue #5797 http://tracker.ceph.com/issues/5797
