### PR TITLE
mon, osd: Clean up "flush(stringstream); bl.append(stringstream.str())

### DIFF
--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -157,8 +157,7 @@ void KeyRing::encode_formatted(string label, Formatter *f, bufferlist& bl)
     f->close_section();	/* auth_entities */
   }
   f->close_section();	/* auth_dump */
-  f->flush(os);
-  bl.append(os.str());
+  f->flush(bl);
 }
 
 void KeyRing::decode_plaintext(bufferlist::iterator& bli)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -117,8 +117,7 @@ bool Client::CommandHook::call(std::string command, cmdmap_t& cmdmap,
   else
     assert(0 == "bad command registered");
   m_client->client_lock.Unlock();
-  f->flush(ss);
-  out.append(ss);
+  f->flush(out);
   delete f;
   return true;
 }

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -626,7 +626,6 @@ bool AuthMonitor::preprocess_command(MMonCommand *m)
   } else if (prefix == "auth list") {
     if (f) {
       mon->key_server.encode_formatted("auth", f.get(), rdata);
-      f->flush(rdata);
     } else {
       mon->key_server.encode_plaintext(rdata);
       if (rdata.length() > 0)

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1952,9 +1952,8 @@ void Monitor::handle_command(MMonCommand *m)
     f->close_section();	// command_descriptions
 
     bufferlist rdata;
-    f->flush(ds);
+    f->flush(rdata);
     delete f;
-    rdata.append(ds);
     reply_command(m, 0, "", rdata, 0);
     return;
   }
@@ -2016,13 +2015,13 @@ void Monitor::handle_command(MMonCommand *m)
   }
 
   if (prefix == "fsid") {
-    ds << monmap->fsid;
     if (f) {
       f->open_object_section("fsid");
       f->dump_stream("fsid") << monmap->fsid;
       f->close_section();
       f->flush(rdata);
     } else {
+      ds << monmap->fsid;
       rdata.append(ds);
     }
     reply_command(m, 0, "", rdata, 0);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1966,8 +1966,9 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
   if (prefix == "osd stat") {
     osdmap.print_summary(f.get(), ds);
     if (f)
-      f->flush(ds);
-    rdata.append(ds);
+      f->flush(rdata);
+    else
+      rdata.append(ds);
   }
   else if (prefix == "osd dump" ||
 	   prefix == "osd tree" ||
@@ -2080,9 +2081,7 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
       f->dump_string(p->first.c_str(), p->second);
     f->close_section();
     f->close_section();
-    f->flush(ds);
-    ds << "\n";
-    rdata.append(ds);
+    f->flush(rdata);
   } else if (prefix == "osd map") {
     string poolstr, objstr, namespacestr;
     cmd_getval(g_ceph_context, cmdmap, "pool", poolstr);

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1358,7 +1358,6 @@ bool PGMonitor::preprocess_command(MMonCommand *m)
     } else {
       ds << pg_map;
     }
-    rdata.append(ds);
     r = 0;
   } else if (prefix == "pg getmap") {
     pg_map.encode(rdata);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3935,7 +3935,6 @@ void OSD::do_command(Connection *con, tid_t tid, vector<string>& cmd, bufferlist
     f->close_section();	// command_descriptions
 
     f->flush(ds);
-    odata.append(ds);
     delete f;
     goto out;
   }

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2348,9 +2348,8 @@ bool Objecter::RequestStateHook::call(std::string command, cmdmap_t& cmdmap,
   m_objecter->client_lock.Lock();
   m_objecter->dump_requests(f);
   m_objecter->client_lock.Unlock();
-  f->flush(ss);
+  f->flush(out);
   delete f;
-  out.append(ss);
   return true;
 }
 


### PR DESCRIPTION
Also: One redundant flush in AuthMonitor, two in PGMonitor, and
a ds << that should have been conditional in Monitor.

Signed-off-by: Dan Mick dan.mick@inktank.com
