### PR TITLE
ceph.in: Re-enable ceph interactive mode (missing its output).

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -396,10 +396,15 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
                                                      target=target,
                                                      argdict=valid_dict)
                     if ret:
-                        sys.stderr.write('Error {0}: {1}'.format(ret, outs))
-                        return ret, '', outs
+                        ret = abs(ret)
+                        print >> sys.stderr, \
+                            'Error: {0} {1}'.format(ret, errno.errorcode[ret])
+                    if outbuf:
+                        print outbuf
+                    if outs:
+                        print >> sys.stderr, 'Status:\n', outs
                 else:
-                    print "invalid command"
+                    print >> sys.stderr, "Invalid command"
 
     if verbose:
         print >> sys.stderr, "Submitting command ", valid_dict


### PR DESCRIPTION
Also, loop on error.  There's no reason to exit the interpreter loop on
an error, and it's probably less annoying if we don't.  Print the error,
and any output, and continue.

Fixes: #5746
Signed-off-by: Dan Mick dan.mick@inktank.com
