### PR TITLE
rgw: rgw-admin throw an error when invalid flag is passed

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -853,6 +853,9 @@ int main(int argc, char **argv)
         cerr << "ERROR: invalid replica log type" << std::endl;
         return EINVAL;
       }
+    } else if (strncmp(*i, "-", 1) == 0) {
+      cerr << "ERROR: invalid flag " << *i << std::endl;
+      return EINVAL;
     } else {
       ++i;
     }


### PR DESCRIPTION
fix #5820 http://tracker.ceph.com/issues/5820

Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com
