### PR TITLE
Normalization of HTTP-X headers should be optional

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -183,8 +183,7 @@ struct str_len meta_prefixes[] = { STR_LEN_ENTRY("HTTP_X_AMZ"),
                                    STR_LEN_ENTRY("HTTP_X_CONTAINER"),
                                    {NULL, 0} };
 
-
-void req_info::init_meta_info(bool *found_bad_meta)
+void req_info::init_meta_info(bool *found_bad_meta, bool normalize_prefix)
 {
   x_meta_map.clear();
 
@@ -201,12 +200,13 @@ void req_info::init_meta_info(bool *found_bad_meta)
         dout(10) << "meta>> " << p << dendl;
         const char *name = p+len; /* skip the prefix */
         int name_len = header_name.size() - len;
+        int normalize_prefix_idx = normalize_prefix ? 0 : prefix_num;
 
         if (found_bad_meta && strncmp(name, "_META_", name_len) == 0)
           *found_bad_meta = true;
 
-        char name_low[meta_prefixes[0].len + name_len + 1];
-        snprintf(name_low, meta_prefixes[0].len - 5 + name_len + 1, "%s%s", meta_prefixes[0].str + 5 /* skip HTTP_ */, name); // normalize meta prefix
+        char name_low[meta_prefixes[normalize_prefix_idx].len + name_len + 1];
+        snprintf(name_low, meta_prefixes[normalize_prefix_idx].len - 5 + name_len + 1, "%s%s", meta_prefixes[normalize_prefix_idx].str + 5 /* skip HTTP_ */, name); // normalize meta prefix
         int j;
         for (j = 0; name_low[j]; j++) {
           if (name_low[j] != '_')

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -776,7 +776,7 @@ struct req_info {
 
   req_info(CephContext *cct, RGWEnv *_env);
   void rebuild_from(req_info& src);
-  void init_meta_info(bool *found_nad_meta);
+  void init_meta_info(bool *found_bad_meta, bool normalize_prefix);
 };
 
 /** Store all the state necessary to complete and respond to an HTTP request*/

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1204,7 +1204,7 @@ int RGWREST::preprocess(struct req_state *s, RGWClientIO *cio)
   }
   s->op = op_from_method(info.method);
 
-  info.init_meta_info(&s->has_bad_meta);
+  info.init_meta_info(&s->has_bad_meta, true);
 
   return 0;
 }

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -571,7 +571,7 @@ int RGWRESTStreamReadRequest::get_obj(RGWAccessKey& key, map<string, string>& ex
   new_info.request_uri = new_info.script_uri;
   new_info.effective_uri = new_info.effective_uri;
 
-  new_info.init_meta_info(NULL);
+  new_info.init_meta_info(NULL, true);
 
   int ret = sign_request(key, new_env, new_info);
   if (ret < 0) {


### PR DESCRIPTION
I'm working on a Google Storage API, and while doing that I discovered that all HTTP_X_GOOG_\* headers are normalized to x-amz-\* entries in the x_meta_map. This breaks the signature checking when authorizing because GS always sends the X-Goog-Api-Version header, which gets normalized to x-amz-api-version and hence become wrongly part of the canonical headers in the authorization signature.

Adding a boolean to the init_meta_info allows to override this default behaviour. It normalizes HTTP_X_GOOG_\* header to x-goog-\* entries in the x_meta_map.

Signed-off-by: Roald J. van Loon roaldvanloon@gmail.com
