### PR TITLE
mon: mon_cluster_log_file_level

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -51,6 +51,7 @@ OPTION(mon_cluster_log_to_syslog, OPT_BOOL, false)
 OPTION(mon_cluster_log_to_syslog_level, OPT_STR, "info")   // this level and above
 OPTION(mon_cluster_log_to_syslog_facility, OPT_STR, "daemon")
 OPTION(mon_cluster_log_file, OPT_STR, "/var/log/ceph/$cluster.log")
+OPTION(mon_cluster_log_file_level, OPT_STR, "info")
 
 DEFAULT_SUBSYS(0, 5)
 SUBSYS(lockdep, 0, 1)

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -129,16 +129,18 @@ void LogMonitor::update_from_paxos(bool *need_bootstrap)
       le.decode(p);
       dout(7) << "update_from_paxos applying incremental log " << summary.version+1 <<  " " << le << dendl;
 
-      stringstream ss;
-      ss << le;
-      string s = ss.str();
-
       if (g_conf->mon_cluster_log_to_syslog) {
 	le.log_to_syslog(g_conf->mon_cluster_log_to_syslog_level,
 			 g_conf->mon_cluster_log_to_syslog_facility);
       }
       if (g_conf->mon_cluster_log_file.length()) {
-	blog.append(s + "\n");
+	int min = string_to_syslog_level(g_conf->mon_cluster_log_file_level);
+	int l = clog_type_to_syslog_level(le.type);
+	if (l <= min) {
+	  stringstream ss;
+	  ss << le << "\n";
+	  blog.append(ss.str());
+	}
       }
 
       summary.add(le);


### PR DESCRIPTION
By popular demand, control the min level of logging that goes to
/var/lib/ceph/ceph.log.

Signed-off-by: Sage Weil sage@inktank.com
