### PR TITLE
config_opts: add two ceph-rest-api-only variables for convenience

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -30,6 +30,8 @@ OPTION(daemonize, OPT_BOOL, false) // default changed by common_preinit()
 OPTION(pid_file, OPT_STR, "") // default changed by common_preinit()
 OPTION(chdir, OPT_STR, "/")
 OPTION(max_open_files, OPT_LONGLONG, 0)
+OPTION(restapi_log_level, OPT_STR, "") 	// default set by Python code
+OPTION(restapi_base_url, OPT_STR, "")	// "
 OPTION(fatal_signal_handlers, OPT_BOOL, true)
 
 OPTION(log_file, OPT_STR, "/var/log/ceph/$cluster-$name.log") // default changed by common_preinit()


### PR DESCRIPTION
These aren't used by the C++ code at all, but in order for
rados_conf_get to find them, they need to be listed.  They're
consumed by ceph_rest_api.

Signed-off-by: Dan Mick dan.mick@inktank.com
