### PR TITLE
Do not use some compilation flag invalid for clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,8 @@ if test "$CXX" = no || test "$CXX:$GXX" = "g++:"; then
   AC_MSG_ERROR([no C++ compiler found])
 fi
 
+AM_CONDITIONAL(CLANG, test x"$CXX" = x"clang++")
+
 #AC_PROG_CC
 AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL

--- a/do_autogen.sh
+++ b/do_autogen.sh
@@ -82,7 +82,11 @@ if [ "${debug_level}" -ge 3 ]; then
 -Wno-missing-field-initializers -Wno-missing-declarations"
 fi
 if [ "${debug_level}" -ge 4 ]; then
-    CXXFLAGS="${CXXFLAGS} -Wstrict-null-sentinel -Woverloaded-virtual"
+    if [ "${CXX}" -ne "clang++" ]; then
+        CXXFLAGS="${CXXFLAGS} -Wstrict-null-sentinel -Woverloaded-virtual"
+    else
+        CXXFLAGS="${CXXFLAGS} -Woverloaded-virtual"
+    fi
     CFLAGS="${CFLAGS} \
 -Wuninitialized -Winit-self \
 -Wformat=2 -Wunused -Wfloat-equal \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1318,7 +1318,6 @@ AM_COMMON_FLAGS = \
 	-D_THREAD_SAFE \
 	-D__STDC_FORMAT_MACROS \
 	-D_GNU_SOURCE \
-	-rdynamic \
 	-Wall \
 	${WARN_TYPE_LIMITS} \
 	${WARN_IGNORED_QUALIFIERS} \
@@ -1327,6 +1326,9 @@ AM_COMMON_FLAGS = \
 	-Werror=format-security \
 	-fno-strict-aliasing \
 	-fsigned-char
+if !CLANG
+    AM_COMMON_FLAGS += -rdynamic
+endif
 
 AM_CFLAGS = $(AM_COMMON_FLAGS)
 AM_CXXFLAGS = \
@@ -1334,8 +1336,11 @@ AM_CXXFLAGS = \
 	$(AM_COMMON_FLAGS) \
 	-DCEPH_LIBDIR=\"${libdir}\" \
 	-Wnon-virtual-dtor \
-	-Wno-invalid-offsetof \
-	-Wstrict-null-sentinel
+	-Wno-invalid-offsetof
+
+if !CLANG
+    AM_CXXFLAGS += -Wstrict-null-sentinel
+endif
 # note: this is position dependant, it affects the -l options that
 # come after it on the command line. when you use ${AM_LDFLAGS} in
 # later rules, take care where you place it. for more information, see


### PR DESCRIPTION
-Wstrict-null-sentinel and -rdynamic are invalid flags
for clang compiler.

Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com
