### PR TITLE
mon: add 'pg dump delta' to get just the rate info

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -111,7 +111,7 @@ COMMAND("pg getmap", "get binary pg map to -o/stdout", "pg", "r", "cli,rest")
 COMMAND("pg send_pg_creates", "trigger pg creates to be issued",\
 	"pg", "rw", "cli,rest")
 COMMAND("pg dump " \
-	"name=dumpcontents,type=CephChoices,strings=all|summary|sum|pools|osds|pgs|pgs_brief,n=N,req=false", \
+	"name=dumpcontents,type=CephChoices,strings=all|summary|sum|delta|pools|osds|pgs|pgs_brief,n=N,req=false", \
 	"show human-readable versions of pg map", "pg", "r", "cli,rest")
 COMMAND("pg dump_json " \
 	"name=dumpcontents,type=CephChoices,strings=all|summary|sum|pools|osds|pgs,n=N,req=false", \

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -513,12 +513,17 @@ void PGMap::dump_basic(Formatter *f) const
   pg_sum.dump(f);
   f->close_section();
 
-  f->open_object_section("pg_stats_delta");
-  pg_sum_delta.dump(f);
-  f->close_section();
-  
   f->open_object_section("osd_stats_sum");
   osd_sum.dump(f);
+  f->close_section();
+
+  dump_delta(f);
+}
+
+void PGMap::dump_delta(Formatter *f) const
+{
+  f->open_object_section("pg_stats_delta");
+  pg_sum_delta.dump(f);
   f->close_section();
 }
 

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -158,6 +158,7 @@ public:
   void dump_pg_stats(Formatter *f, bool brief) const;
   void dump_pool_stats(Formatter *f) const;
   void dump_osd_stats(Formatter *f) const;
+  void dump_delta(Formatter *f) const;
 
   void dump_pg_stats_plain(ostream& ss,
 			   const hash_map<pg_t, pg_stat_t>& pg_stats) const;

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1406,6 +1406,11 @@ bool PGMonitor::preprocess_command(MMonCommand *m)
 	if (what.count("pgs_brief")) {
 	  pg_map.dump_pg_stats(f.get(), true);
 	}
+	if (what.count("delta")) {
+	  f->open_object_section("delta");
+	  pg_map.dump_delta(f.get());
+	  f->close_section();
+	}
       }
       f->flush(ds);
     } else {


### PR DESCRIPTION
Still include it in the basic 'pg dump summary' info.

Signed-off-by: Sage Weil sage@inktank.com
