### PR TITLE
init-rbdmap: fix error on stop rbdmap

### DIFF
--- a/src/init-rbdmap
+++ b/src/init-rbdmap
@@ -68,7 +68,7 @@ do_unmap() {
 		umount $MNT
 	done 
 	# Unmap all rbd device
-	if [ -b /dev/rbd[0-9]* ]; then
+	if ls /dev/rbd[0-9]* >/dev/null 2>&1; then
 		for DEV in /dev/rbd[0-9]*; do
 			log_progress_msg $DEV
 			rbd unmap $DEV


### PR DESCRIPTION
Avoid an error on stop service if many /dev/rbd\* exist.

Signed-off-by: Laurent Barbe laurent@ksperis.com
