### PR TITLE
mon/MonClient: release pending outgoing messages on shutdown

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -328,6 +328,12 @@ void MonClient::shutdown()
     version_requests.erase(version_requests.begin());
   }
 
+  while (!waiting_for_session.empty()) {
+    ldout(cct, 20) << __func__ << " discarding pending message " << *waiting_for_session.front() << dendl;
+    waiting_for_session.front()->put();
+    waiting_for_session.pop_front();
+  }
+
   monc_lock.Unlock();
 
   if (initialized) {


### PR DESCRIPTION
This fixes a small memory leak when we have messages queued for the mon when
we shut down.  It is harmless except for the valgrind leak check noise that
obscures real leaks.

Backport: dumpling Signed-off-by: Sage Weil sage@inktank.com
