### PR TITLE
osd: add 'osd heartbeat min healthy ratio' tunable

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -425,6 +425,11 @@ OPTION(osd_heartbeat_addr, OPT_ADDR, entity_addr_t())
 OPTION(osd_heartbeat_interval, OPT_INT, 6)       // (seconds) how often we ping peers
 OPTION(osd_heartbeat_grace, OPT_INT, 20)         // (seconds) how long before we decide a peer has failed
 OPTION(osd_heartbeat_min_peers, OPT_INT, 10)     // minimum number of peers
+
+// minimum number of peers tha tmust be reachable to mark ourselves
+// back up after being wrongly marked down.
+OPTION(osd_heartbeat_min_healthy_ratio, OPT_FLOAT, .33)
+
 OPTION(osd_mon_heartbeat_interval, OPT_INT, 30)  // (seconds) how often to ping monitor if no peers
 OPTION(osd_mon_report_interval_max, OPT_INT, 120)
 OPTION(osd_mon_report_interval_min, OPT_INT, 5)  // pg stats, failures, up_thru, boot.

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3513,7 +3513,7 @@ bool OSD::_is_healthy()
 	++up;
       ++num;
     }
-    if (up < num / 3) {
+    if ((float)up < (float)num * g_conf->osd_heartbeat_min_healthy_ratio) {
       dout(1) << "is_healthy false -- only " << up << "/" << num << " up peers (less than 1/3)" << dendl;
       return false;
     }


### PR DESCRIPTION
This was hard-coded to 1/3; make it tunable.

Signed-off-by: Sage Weil sage@inktank.com
