### PR TITLE
specify the filetype when mounting

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -671,6 +671,7 @@ def mount(
         subprocess.check_call(
             args=[
                 'mount',
+                '-t', fstype,
                 '-o', options,
                 '--',
                 dev,


### PR DESCRIPTION
specifically with XFS filesystems we may find that when not specifying the filetype `mount` gives up and does not want to mount anything.

Fixes issue 6085: http://tracker.ceph.com/issues/6085
