### PR TITLE
PGLog: initialize writeout_from in PGLog constructor

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -237,6 +237,7 @@ public:
   PGLog(CephContext *cct = 0) :
     pg_log_debug(!(cct && !(cct->_conf->osd_debug_pg_log_writeout))),
     touched_log(false), dirty_from(eversion_t::max()),
+    writeout_from(eversion_t::max()),
     dirty_divergent_priors(false), cct(cct) {}
 
 


### PR DESCRIPTION
Fixes: 6151
Backport: dumpling
Signed-off-by: Samuel Just sam.just@inktank.com
Introduced: f808c205c503f7d32518c91619f249466f84c4cf
