### PR TITLE
os: LevelDBStore: ignore ENOENT files when estimating store size

### DIFF
--- a/src/os/LevelDBStore.h
+++ b/src/os/LevelDBStore.h
@@ -329,7 +329,11 @@ public:
       string fpath = path + '/' + n;
       struct stat s;
       int err = stat(fpath.c_str(), &s);
-      if (err < 0) {
+      // we may race against leveldb while reading files; this should only
+      // happen when those files are being updated, data is being shuffled
+      // and files get removed, in which case there's not much of a problem
+      // as we'll get to them next time around.
+      if ((err < 0) && (err != -ENOENT)) {
         lderr(cct) << __func__ << " error obtaining stats for " << fpath
                    << ": " << cpp_strerror(errno) << dendl;
         goto err;


### PR DESCRIPTION
While iterating over the store files we race against leveldb, which may
be shuffling data around thus removing some files.

By ignoring missing files on stat, we'll get to not account those files
but that's okay -- this is just an estimate.

Fixes: #6178

Signed-off-by: Joao Eduardo Luis jecluis@gmail.com
