### PR TITLE
Correct syntax for generate swift key

### DIFF
--- a/doc/radosgw/config.rst
+++ b/doc/radosgw/config.rst
@@ -333,7 +333,7 @@ subuser and a Swift access key.
 
 ::
 
-  sudo radosgw-admin key create --subuser=johndoe:swift --key-type=swift
+  sudo radosgw-admin key create --subuser=johndoe:swift --key-type=swift --gen-secret
 
 .. code-block:: javascript
 

--- a/doc/start/quick-rgw.rst
+++ b/doc/start/quick-rgw.rst
@@ -306,7 +306,7 @@ Next, create a subuser for the Swift-compatible interface. ::
 
 ::
 
-  sudo radosgw-admin key create --subuser=johndoe:swift --key-type=swift
+  sudo radosgw-admin key create --subuser=johndoe:swift --key-type=swift --gen-secret
 
 .. code-block:: javascript
 


### PR DESCRIPTION
Missing "--gen-secret" when documentation explain how to generate swift secret key.

Signed-off-by: Lukasz Jagiello jagiello.lukasz@gmail.com
