### PR TITLE
osd: expose bytes used/avail via perf / asok

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -115,6 +115,10 @@ enum {
 
   l_osd_waiting_for_map,
 
+  l_osd_stat_bytes,
+  l_osd_stat_bytes_used,
+  l_osd_stat_bytes_avail,
+
   l_osd_last,
 };
 


### PR DESCRIPTION
This values are already sent to the monitor.  Expose them via the admin 
socket too so collectd/diamond/whatever can pick them up.

Signed-off-by: Sage Weil sage@inktank.com
