### PR TITLE
cleanup: state_name in NamedState init list

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5118,9 +5118,9 @@ std::ostream& operator<<(std::ostream& oss,
 
 /*------Crashed-------*/
 PG::RecoveryState::Crashed::Crashed(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Crashed")
 {
-  state_name = "Crashed";
   context< RecoveryMachine >().log_enter(state_name);
   assert(0 == "we got a bad state machine event");
 }
@@ -5128,9 +5128,9 @@ PG::RecoveryState::Crashed::Crashed(my_context ctx)
 
 /*------Initial-------*/
 PG::RecoveryState::Initial::Initial(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Initial")
 {
-  state_name = "Initial";
   context< RecoveryMachine >().log_enter(state_name);
 }
 
@@ -5179,9 +5179,9 @@ void PG::RecoveryState::Initial::exit()
 
 /*------Started-------*/
 PG::RecoveryState::Started::Started(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started")
 {
-  state_name = "Started";
   context< RecoveryMachine >().log_enter(state_name);
 }
 
@@ -5228,9 +5228,9 @@ void PG::RecoveryState::Started::exit()
 
 /*--------Reset---------*/
 PG::RecoveryState::Reset::Reset(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Reset")
 {
-  state_name = "Reset";
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
   pg->flushed = false;
@@ -5303,9 +5303,9 @@ void PG::RecoveryState::Reset::exit()
 
 /*-------Start---------*/
 PG::RecoveryState::Start::Start(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Start")
 {
-  state_name = "Start";
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -5328,9 +5328,9 @@ void PG::RecoveryState::Start::exit()
 
 /*---------Primary--------*/
 PG::RecoveryState::Primary::Primary(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary")
 {
-  state_name = "Started/Primary";
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
   assert(pg->want_acting.empty());
@@ -5377,9 +5377,10 @@ void PG::RecoveryState::Primary::exit()
 
 /*---------Peering--------*/
 PG::RecoveryState::Peering::Peering(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct), flushed(false)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Peering"),
+    flushed(false)
 {
-  state_name = "Started/Primary/Peering";
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -5466,9 +5467,9 @@ void PG::RecoveryState::Peering::exit()
 
 /*------Backfilling-------*/
 PG::RecoveryState::Backfilling::Backfilling(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active/Backfilling")
 {
-  state_name = "Started/Primary/Active/Backfilling";
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
   pg->backfill_reserved = true;
@@ -5504,9 +5505,9 @@ void PG::RecoveryState::Backfilling::exit()
 /*--WaitRemoteBackfillReserved--*/
 
 PG::RecoveryState::WaitRemoteBackfillReserved::WaitRemoteBackfillReserved(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active/WaitRemoteBackfillReserved")
 {
-  state_name = "Started/Primary/Active/WaitRemoteBackfillReserved";
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
   pg->state_set(PG_STATE_BACKFILL_WAIT);
@@ -5559,9 +5560,9 @@ PG::RecoveryState::WaitRemoteBackfillReserved::react(const RemoteReservationReje
 
 /*--WaitLocalBackfillReserved--*/
 PG::RecoveryState::WaitLocalBackfillReserved::WaitLocalBackfillReserved(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active/WaitLocalBackfillReserved")
 {
-  state_name = "Started/Primary/Active/WaitLocalBackfillReserved";
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
   pg->state_set(PG_STATE_BACKFILL_WAIT);
@@ -5583,9 +5584,9 @@ void PG::RecoveryState::WaitLocalBackfillReserved::exit()
 
 /*----NotBackfilling------*/
 PG::RecoveryState::NotBackfilling::NotBackfilling(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active/NotBackfilling")
 {
-  state_name = "Started/Primary/Active/NotBackfilling";
   context< RecoveryMachine >().log_enter(state_name);
 }
 
@@ -5599,9 +5600,9 @@ void PG::RecoveryState::NotBackfilling::exit()
 
 /*---RepNotRecovering----*/
 PG::RecoveryState::RepNotRecovering::RepNotRecovering(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/ReplicaActive/RepNotRecovering")
 {
-  state_name = "Started/ReplicaActive/RepNotRecovering";
   context< RecoveryMachine >().log_enter(state_name);
 }
 
@@ -5615,9 +5616,9 @@ void PG::RecoveryState::RepNotRecovering::exit()
 
 /*---RepWaitRecoveryReserved--*/
 PG::RecoveryState::RepWaitRecoveryReserved::RepWaitRecoveryReserved(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/ReplicaActive/RepWaitRecoveryReserved")
 {
-  state_name = "Started/ReplicaActive/RepWaitRecoveryReserved";
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
 
@@ -5652,9 +5653,9 @@ void PG::RecoveryState::RepWaitRecoveryReserved::exit()
 
 /*-RepWaitBackfillReserved*/
 PG::RecoveryState::RepWaitBackfillReserved::RepWaitBackfillReserved(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/ReplicaActive/RepWaitBackfillReserved")
 {
-  state_name = "Started/ReplicaActive/RepWaitBackfillReserved";
   context< RecoveryMachine >().log_enter(state_name);
 }
 
@@ -5712,9 +5713,9 @@ PG::RecoveryState::RepWaitBackfillReserved::react(const RemoteReservationRejecte
 
 /*---RepRecovering-------*/
 PG::RecoveryState::RepRecovering::RepRecovering(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/ReplicaActive/RepRecovering")
 {
-  state_name = "Started/ReplicaActive/RepRecovering";
   context< RecoveryMachine >().log_enter(state_name);
 }
 
@@ -5737,9 +5738,9 @@ void PG::RecoveryState::RepRecovering::exit()
 
 /*------Activating--------*/
 PG::RecoveryState::Activating::Activating(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active/Activating")
 {
-  state_name = "Started/Primary/Active/Activating";
   context< RecoveryMachine >().log_enter(state_name);
 }
 
@@ -5752,9 +5753,9 @@ void PG::RecoveryState::Activating::exit()
 }
 
 PG::RecoveryState::WaitLocalRecoveryReserved::WaitLocalRecoveryReserved(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active/WaitLocalRecoveryReserved")
 {
-  state_name = "Started/Primary/Active/WaitLocalRecoveryReserved";
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
   pg->state_set(PG_STATE_RECOVERY_WAIT);
@@ -5775,10 +5776,9 @@ void PG::RecoveryState::WaitLocalRecoveryReserved::exit()
 
 PG::RecoveryState::WaitRemoteRecoveryReserved::WaitRemoteRecoveryReserved(my_context ctx)
   : my_base(ctx),
-    NamedState(context< RecoveryMachine >().pg->cct),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active/WaitRemoteRecoveryReserved"),
     acting_osd_it(context< Active >().sorted_acting_set.begin())
 {
-  state_name = "Started/Primary/Active/WaitRemoteRecoveryReserved";
   context< RecoveryMachine >().log_enter(state_name);
   post_event(RemoteRecoveryReserved());
 }
@@ -5822,9 +5822,9 @@ void PG::RecoveryState::WaitRemoteRecoveryReserved::exit()
 }
 
 PG::RecoveryState::Recovering::Recovering(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active/Recovering")
 {
-  state_name = "Started/Primary/Active/Recovering";
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -5885,11 +5885,11 @@ void PG::RecoveryState::Recovering::exit()
 }
 
 PG::RecoveryState::Recovered::Recovered(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active/Recovered")
 {
   int newest_update_osd;
 
-  state_name = "Started/Primary/Active/Recovered";
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -5919,9 +5919,9 @@ void PG::RecoveryState::Recovered::exit()
 }
 
 PG::RecoveryState::Clean::Clean(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active/Clean")
 {
-  state_name = "Started/Primary/Active/Clean";
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -5949,12 +5949,11 @@ void PG::RecoveryState::Clean::exit()
 /*---------Active---------*/
 PG::RecoveryState::Active::Active(my_context ctx)
   : my_base(ctx),
-    NamedState(context< RecoveryMachine >().pg->cct),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Active"),
     sorted_acting_set(context< RecoveryMachine >().pg->acting.begin(),
                       context< RecoveryMachine >().pg->acting.end()),
     all_replicas_activated(false)
 {
-  state_name = "Started/Primary/Active";
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -6200,10 +6199,9 @@ void PG::RecoveryState::Active::exit()
 
 /*------ReplicaActive-----*/
 PG::RecoveryState::ReplicaActive::ReplicaActive(my_context ctx) 
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/ReplicaActive")
 {
-  state_name = "Started/ReplicaActive";
-
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -6293,8 +6291,9 @@ void PG::RecoveryState::ReplicaActive::exit()
 
 /*-------Stray---*/
 PG::RecoveryState::Stray::Stray(my_context ctx) 
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct) {
-  state_name = "Started/Stray";
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Stray")
+{
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -6395,9 +6394,9 @@ void PG::RecoveryState::Stray::exit()
 
 /*--------GetInfo---------*/
 PG::RecoveryState::GetInfo::GetInfo(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Peering/GetInfo")
 {
-  state_name = "Started/Primary/Peering/GetInfo";
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -6569,10 +6568,11 @@ void PG::RecoveryState::GetInfo::exit()
 }
 
 /*------GetLog------------*/
-PG::RecoveryState::GetLog::GetLog(my_context ctx) : 
-  my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct), newest_update_osd(-1), msg(0)
+PG::RecoveryState::GetLog::GetLog(my_context ctx)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Peering/GetLog"),
+    newest_update_osd(-1), msg(0)
 {
-  state_name = "Started/Primary/Peering/GetLog";
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -6685,9 +6685,9 @@ void PG::RecoveryState::GetLog::exit()
 
 /*------WaitActingChange--------*/
 PG::RecoveryState::WaitActingChange::WaitActingChange(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Peering/WaitActingChange")
 {
-  state_name = "Started/Primary/Peering/WaitActingChange";
   context< RecoveryMachine >().log_enter(state_name);
 }
 
@@ -6745,9 +6745,9 @@ void PG::RecoveryState::WaitActingChange::exit()
 
 /*------Incomplete--------*/
 PG::RecoveryState::Incomplete::Incomplete(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Peering/Incomplete")
 {
-  state_name = "Started/Primary/Peering/Incomplete";
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
 
@@ -6782,9 +6782,9 @@ void PG::RecoveryState::Incomplete::exit()
 
 /*------GetMissing--------*/
 PG::RecoveryState::GetMissing::GetMissing(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Peering/GetMissing")
 {
-  state_name = "Started/Primary/Peering/GetMissing";
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
@@ -6907,9 +6907,9 @@ void PG::RecoveryState::GetMissing::exit()
 
 /*---WaitFlushedPeering---*/
 PG::RecoveryState::WaitFlushedPeering::WaitFlushedPeering(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Peering/WaitFlushedPeering")
 {
-  state_name = "Started/Primary/Peering/WaitFlushedPeering";
   PG *pg = context< RecoveryMachine >().pg;
   context< RecoveryMachine >().log_enter(state_name);
   if (context< RecoveryMachine >().pg->flushed)
@@ -6937,9 +6937,9 @@ PG::RecoveryState::WaitFlushedPeering::react(const QueryState &q)
 
 /*------WaitUpThru--------*/
 PG::RecoveryState::WaitUpThru::WaitUpThru(my_context ctx)
-  : my_base(ctx), NamedState(context< RecoveryMachine >().pg->cct)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Peering/WaitUpThru")
 {
-  state_name = "Started/Primary/Peering/WaitUpThru";
   context< RecoveryMachine >().log_enter(state_name);
 }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -385,7 +385,9 @@ public:
     const char *state_name;
     utime_t enter_time;
     const char *get_state_name() { return state_name; }
-    NamedState(CephContext *cct_) : state_name(0), enter_time(ceph_clock_now(cct_)) {};
+    NamedState(CephContext *cct_, const char *state_name_)
+      : state_name(state_name_),
+        enter_time(ceph_clock_now(cct_)) {};
     virtual ~NamedState() {}
   };
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8068,9 +8068,8 @@ void ReplicatedPG::SnapTrimmer::log_exit(const char *state_name, utime_t enter_t
 /* NotTrimming */
 ReplicatedPG::NotTrimming::NotTrimming(my_context ctx)
   : my_base(ctx), 
-    NamedState(context< SnapTrimmer >().pg->cct)
+    NamedState(context< SnapTrimmer >().pg->cct, "NotTrimming")
 {
-  state_name = "NotTrimming";
   context< SnapTrimmer >().requeue = false;
   context< SnapTrimmer >().log_enter(state_name);
 }
@@ -8111,9 +8110,8 @@ boost::statechart::result ReplicatedPG::NotTrimming::react(const SnapTrim&)
 /* TrimmingObjects */
 ReplicatedPG::TrimmingObjects::TrimmingObjects(my_context ctx)
   : my_base(ctx),
-    NamedState(context< SnapTrimmer >().pg->cct)
+    NamedState(context< SnapTrimmer >().pg->cct, "Trimming/TrimmingObjects")
 {
-  state_name = "Trimming/TrimmingObjects";
   context< SnapTrimmer >().log_enter(state_name);
 }
 
@@ -8163,9 +8161,8 @@ boost::statechart::result ReplicatedPG::TrimmingObjects::react(const SnapTrim&)
 /* WaitingOnReplicasObjects */
 ReplicatedPG::WaitingOnReplicas::WaitingOnReplicas(my_context ctx)
   : my_base(ctx),
-    NamedState(context< SnapTrimmer >().pg->cct)
+    NamedState(context< SnapTrimmer >().pg->cct, "Trimming/WaitingOnReplicas")
 {
-  state_name = "Trimming/WaitingOnReplicas";
   context< SnapTrimmer >().log_enter(state_name);
   context< SnapTrimmer >().requeue = false;
 }


### PR DESCRIPTION
Small additional patch to address what was discussed in #568. If it was merely a compile-time issue, this does the trick.
