### PR TITLE
rgw: fix get cors, delete cors

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1994,7 +1994,6 @@ int RGWDeleteCORS::verify_permission()
 
 void RGWDeleteCORS::execute()
 {
-  RGWCORSConfiguration bucket_cors;
   ret = read_bucket_cors();
   if (ret < 0)
     return;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -531,7 +531,6 @@ public:
 class RGWGetCORS : public RGWOp {
 protected:
   int ret;
-  RGWCORSConfiguration bucket_cors;
 
 public:
   RGWGetCORS() : ret(0) {}


### PR DESCRIPTION
Remove a couple of variables that overrode class member. Not
really clear how it was working before, might have been a bad
merge / rebase.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
