### PR TITLE
make sure we use a version of sphinx that we can handle

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,3 +1,3 @@
-Sphinx >=1.1.2
+Sphinx == 1.1.3
 -e git+https://github.com/ceph/sphinx-ditaa.git#egg=sphinx-ditaa
 -e git+https://github.com/ceph/asphyxiate.git#egg=asphyxiate


### PR DESCRIPTION
this fixed the build where the Index now shows up nicely

See: http://ceph.com/docs/wip-doc-warn-fix/
