### PR TITLE
mon: MonCommands: expect a CephString as 1st arg for 'osd crush move'

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -384,7 +384,7 @@ COMMAND("osd crush create-or-move " \
 	"create entry or move existing entry for <name> <weight> at/to location <args>", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd crush move " \
-	"name=id,type=CephOsdName " \
+	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=]", \
 	"move existing entry for <name> to location <args>", \
 	"osd", "rw", "cli,rest")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2825,6 +2825,7 @@ bool OSDMonitor::prepare_command(MMonCommand *m)
 
       string args;
       vector<string> argvec;
+      cmd_getval(g_ceph_context, cmdmap, "name", name);
       cmd_getval(g_ceph_context, cmdmap, "args", argvec);
       map<string,string> loc;
       parse_loc_map(argvec, &loc);


### PR DESCRIPTION
Fixes: #6230

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
