### PR TITLE
mon/MDSMonitor: don't reset incarnation when creating newfs

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -947,6 +947,7 @@ bool MDSMonitor::prepare_command(MMonCommand *m)
       ss << "this is DANGEROUS and will wipe out the mdsmap's fs, and may clobber data in the new pools you specify.  add --yes-i-really-mean-it if you do.";
       r = -EPERM;
     } else {
+      newmap.inc = pending_mdsmap.inc;
       pending_mdsmap = newmap;
       pending_mdsmap.epoch = mdsmap.epoch + 1;
       create_new_fs(pending_mdsmap, metadata, data);


### PR DESCRIPTION
Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
