### PR TITLE
make: add tmalloc lib dep in tcmalloc guard

### DIFF
--- a/src/perfglue/Makefile.am
+++ b/src/perfglue/Makefile.am
@@ -2,6 +2,7 @@ libperfglue_la_SOURCES =
 
 if WITH_TCMALLOC
 libperfglue_la_SOURCES += perfglue/heap_profiler.cc
+libperfglue_la_LIBADD = -ltcmalloc
 AM_CFLAGS += -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
 AM_CXXFLAGS += -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
 else
@@ -14,7 +15,6 @@ else
 libperfglue_la_SOURCES += perfglue/disabled_stubs.cc
 endif # WITH_PROFILER
 
-libperfglue_la_LIBADD = -ltcmalloc
 noinst_LTLIBRARIES += libperfglue.la
 
 noinst_HEADERS += \


### PR DESCRIPTION
Fixes --without-tcmalloc on boxes without libtcmalloc.

Signed-off-by: Noah Watkins noahwatkins@gmail.com
Reported-by: Adam Manzanares nmtadam@gmail.com
