### PR TITLE
code_env: use feature test for PR_GET_NAME support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -536,6 +536,9 @@ AC_CHECK_FUNC([fallocate],
 	[])
 
 
+AC_CHECK_HEADERS([sys/prctl.h])
+AC_CHECK_FUNCS([prctl])
+
 # Checks for typedefs, structures, and compiler characteristics.
 #AC_HEADER_STDBOOL
 #AC_C_CONST


### PR DESCRIPTION
Function `get_process_name` has platform specific dependencies. Check
for Linux prctl function and correct command flag.

Signed-off-by: Noah Watkins noahwatkins@gmail.com
