### PR TITLE
mon: fix wrong arg to "instructed to" status message

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2154,7 +2154,7 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
 				osdmap.get_inst(i));
 	}
       r = 0;
-      ss << " instructed to " << whostr;
+      ss << " instructed to " << pvec.back();
     } else {
       long osd = parse_osd_id(whostr.c_str(), &ss);
       if (osd < 0) {


### PR DESCRIPTION
Fixes: #6293
Signed-off-by: Dan Mick dan.mick@inktank.com
