### PR TITLE
make: build common/secret only on linux

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -59,13 +59,16 @@ libcommon_la_SOURCES = \
 	common/pick_address.cc \
 	common/util.cc \
 	common/TextTable.cc \
-	common/secret.c \
 	common/ceph_fs.cc \
 	common/ceph_hash.cc \
 	common/ceph_strings.cc \
 	common/ceph_frag.cc \
 	common/addr_parsing.c \
 	common/hobject.cc
+
+if LINUX
+libcommon_la_SOURCES += common/secret.c
+endif
 
 # these should go out of libcommon
 libcommon_la_SOURCES += \


### PR DESCRIPTION
libkeyutils is only available on linux. before the automake refactoring
secret.c was compiled into rbd and ceph_mount targets which are linux
only targets. secret.c was moved to libcommon during the refactoring,
but the conditional compilation was lost.

Signed-off-by: Noah Watkins noahwatkins@gmail.com
