### PR TITLE
arch/intel: use intel probe instructions for x86_64 only

### DIFF
--- a/src/arch/intel.c
+++ b/src/arch/intel.c
@@ -5,7 +5,7 @@ int ceph_arch_intel_sse42 = 0;
 
 
 /* this probably isn't specific enough for x86_64?  fix me someday */
-#ifdef __LP64__
+#ifdef __x86_64__
 
 /* intel cpu? */
 static void do_cpuid(unsigned int *eax, unsigned int *ebx, unsigned int *ecx,
@@ -35,7 +35,7 @@ int ceph_arch_intel_probe(void)
 	return 0;
 }
 
-#else // __LP64__
+#else // __x86_64__
 
 int ceph_arch_intel_probe(void)
 {
@@ -43,4 +43,4 @@ int ceph_arch_intel_probe(void)
 	return 0;
 }
 
-#endif // __LP64__
+#endif // __x86_64__

--- a/src/common/crc32c_intel_fast.h
+++ b/src/common/crc32c_intel_fast.h
@@ -8,7 +8,7 @@ extern "C" {
 /* is the fast version compiled in */
 extern int ceph_crc32c_intel_fast_exists(void);
 
-#ifdef __LP64__
+#ifdef __x86_64__
 
 extern uint32_t ceph_crc32c_intel_fast(uint32_t crc, unsigned char const *buffer, unsigned len);
 


### PR DESCRIPTION
Not LP64, which includes ppc64 and clearly does not build.

Signed-off-by: Sage Weil sage@inktank.com
