### PR TITLE
mon/OSDMonitor: fix 'ceph osd crush reweight ...'

### DIFF
--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -68,4 +68,13 @@ ceph osd crush add-bucket foo host
 ceph osd crush move foo root=default rack=localrack
 ceph osd crush rm foo
 
+# test reweight
+o3=`ceph osd create`
+ceph osd crush add $o3 123 root=foo
+ceph osd tree | grep osd.$o3 | grep 123
+ceph osd crush reweight osd.$o3 113
+ceph osd tree | grep osd.$o3 | grep 113
+ceph osd crush rm osd.$o3
+ceph osd rm osd.$o3
+
 echo OK

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2997,7 +2997,7 @@ bool OSDMonitor::prepare_command(MMonCommand *m)
       cmd_getval(g_ceph_context, cmdmap, "weight", w);
 
       err = newcrush.adjust_item_weightf(g_ceph_context, id, w);
-      if (err == 0) {
+      if (err >= 0) {
 	pending_inc.crush.clear();
 	newcrush.encode(pending_inc.crush);
 	ss << "reweighted item id " << id << " name '" << name << "' to " << w


### PR DESCRIPTION
The adjust method returns a count of adjusted items.

Add a test.

Fixes: #6382 Backport: dumpling Signed-off-by: Sage Weil sage@inktank.com
