### PR TITLE
Makefile: don't use srcdir in TESTS

### DIFF
--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -233,8 +233,8 @@ bin_DEBUGPROGRAMS += ceph_bench_log
 ## Unit tests
 
 check_SCRIPTS += \
-	$(srcdir)/unittest_bufferlist.sh \
-	$(srcdir)/test/encoding/check-generated.sh
+	unittest_bufferlist.sh \
+	test/encoding/check-generated.sh
 
 # target to build but not run the unit tests
 unittests:: $(check_PROGRAMS)


### PR DESCRIPTION
src/Makefile-env.am:31: error: using '$(srcdir)' in TESTS is currently broken:
'$(srcdir)/unittest_bufferlist.sh' src/Makefile.am:1:   'src/Makefile-env.am'
included from here src/Makefile-env.am:31: error: using '$(srcdir)' in TESTS
is currently broken: '$(srcdir)/test/encoding/check-generated.sh' 
src/Makefile.am:1:   'src/Makefile-env.am' included from here

on my (raring) laptop.

Signed-off-by: Sage Weil sage@inktank.com
