### PR TITLE
fix mon crash when osdmap and pgmap aren't yet synced

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1865,6 +1865,8 @@ void PGMonitor::get_health(list<pair<health_status_t,string> >& summary,
 	 p != pg_map.pg_pool_sum.end();
 	 ++p) {
       const pg_pool_t *pi = mon->osdmon()->osdmap.get_pg_pool(p->first);
+      if (!pi)
+	continue;   // in case osdmap changes haven't propagated to PGMap yet
       if (pi->get_pg_num() > pi->get_pgp_num()) {
 	ostringstream ss;
 	ss << "pool " << mon->osdmon()->osdmap.get_pool_name(p->first) << " pg_num "


### PR DESCRIPTION
fixes this: 2013-09-25 15:06:23.307320 7fabf13a3700 -1 **\* Caught signal (Segmentation fault) **
 in thread 7fabf13a3700

 ceph version 0.69-280-g60d541d (60d541d36d3ebf3a6d8ef411a026ca31da99b95d)
 1: ceph-mon() [0x80fdea]
 2: (()+0xfcb0) [0x7fabf58b9cb0]
 3: (PGMonitor::get_health(std::list<std::pair<health_status_t, std::string>, std::allocator<std::pair<health_status_t, std::string> > >&, std::list<std::pair<health_status_t, std::string>, std::allocator<std::pair<health_status_t, std::string> > >_) const+0x1abe) [0x5fb20e]
 4: (Monitor::get_health(std::string&, ceph::buffer::list_, ceph::Formatter_)+0xcb) [0x55bb4b]
 5: (Monitor::get_status(std::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >&, ceph::Formatter_)+0x62) [0x55d102]
 6: (Monitor::handle_command(MMonCommand_)+0x19f4) [0x56d524]
 7: (Monitor::_ms_dispatch(Message_)+0xcbb) [0x574a6b]
 8: (Monitor::ms_dispatch(Message*)+0x32) [0x58c7d2]
 9: (DispatchQueue::entry()+0x549) [0x7e60b9]
 10: (DispatchQueue::DispatchThread::entry()+0xd) [0x71902d]
 11: (()+0x7e9a) [0x7fabf58b1e9a]
 12: (clone()+0x6d) [0x7fabf3eb5cbd]
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is needed to interpret this.
