### PR TITLE
reverse the order of the mons in the init script when stopping

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -174,7 +174,7 @@ get_name_list "$@"
 
 # Reverse the order if we are stopping
 if [ "$command" = "stop" ]; then
-    for f in "$what"; do
+    for f in $what; do
        new_order="$f $new_order"
     done
     what="$new_order"


### PR DESCRIPTION
Fixes a (possible) issue when stopping monitors by reversing the actual order (last ones will be stopped first).
