### PR TITLE
qa/run_xfstests.sh: use old xfstests until we adapt to new org

### DIFF
--- a/qa/run_xfstests.sh
+++ b/qa/run_xfstests.sh
@@ -276,6 +276,9 @@ function install_xfstests() {
 
 	cd xfstests
 
+	# FIXME: use an older version before the tests were rearranged!
+	git reset --hard e5f1a13792f20cfac097fef98007610b422f2cac
+
 	ncpu=$(getconf _NPROCESSORS_ONLN 2>&1)
 	[ -n "${ncpu}" -a "${ncpu}" -gt 1 ] && multiple="-j ${ncpu}"
 


### PR DESCRIPTION
Tests were rearranged upstream; use an old version for the time being until
we can refactor run_xfstests.sh to cope.  See #6385

Signed-off-by: Sage Weil sage@inktank.com
