### PR TITLE
Invoke python with /usr/bin/env python instead of directly

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1466,7 +1466,7 @@ test/encoding/ceph_dencoder.cc: ./ceph_ver.h
 
 ceph: ceph.in ./ceph_ver.h Makefile
 	rm -f $@ $@.tmp
-	echo "#!/usr/bin/python" >$@.tmp
+	echo "#!/usr/bin/env python" >$@.tmp
 	grep "#define CEPH_GIT_NICE_VER" ./ceph_ver.h | \
 		sed -e 's/#define \(.*VER\) /\1=/' >>$@.tmp
 	grep "#define CEPH_GIT_VER" ./ceph_ver.h | \

--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse
 import errno
 import json

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse
 import errno

--- a/src/ceph-rest-api
+++ b/src/ceph-rest-api
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim: ts=4 sw=4 smarttab expandtab
 
 import argparse

--- a/src/objsync/boto_del.py
+++ b/src/objsync/boto_del.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #
 # Ceph - scalable distributed file system

--- a/src/pybind/ceph_rest_api.py
+++ b/src/pybind/ceph_rest_api.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim: ts=4 sw=4 smarttab expandtab
 
 import errno

--- a/src/script/perf-watch.py
+++ b/src/script/perf-watch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import json
 import argparse


### PR DESCRIPTION
Fixes: #6311
Signed-off-by: Dan Mick dan.mick@inktank.com
