### PR TITLE
osd/ReplicatedPG: fix iterator corruption in cancel_copy_ops()

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -4583,10 +4583,9 @@ void ReplicatedPG::cancel_copy(CopyOpRef cop)
 void ReplicatedPG::cancel_copy_ops()
 {
   dout(10) << __func__ << dendl;
-  for (map<hobject_t,CopyOpRef>::iterator p = copy_ops.begin();
-       p != copy_ops.end();
-       copy_ops.erase(p++)) {
-    cancel_copy(p->second);
+  map<hobject_t,CopyOpRef>::iterator p = copy_ops.begin();
+  while (p != copy_ops.end()) {
+    cancel_copy((p++)->second);
   }
 }
 


### PR DESCRIPTION
The cancel_copy() method removes the entry from copy_ops.  Move the iterator
forward before calling.

Fixes segfault when thrashing osds with a copy-from workload.

Signed-off-by: Sage Weil sage@inktank.com
