### PR TITLE
osdc/ObjectCacher: limit writeback IOs generated while holding lock

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -11,6 +11,8 @@
 
 #include "include/assert.h"
 
+#define MAX_FLUSH_UNDER_LOCK 20  ///< max bh's we start writeback on while holding the lock
+
 /*** ObjectCacher::BufferHead ***/
 
 
@@ -1448,8 +1450,10 @@ void ObjectCacher::flusher_entry()
       utime_t cutoff = ceph_clock_now(cct);
       cutoff -= max_dirty_age;
       BufferHead *bh = 0;
+      int max = MAX_FLUSH_UNDER_LOCK;
       while ((bh = static_cast<BufferHead*>(bh_lru_dirty.lru_get_next_expire())) != 0 &&
-	     bh->last_write < cutoff) {
+	     bh->last_write < cutoff &&
+	     --max > 0) {
 	ldout(cct, 10) << "flusher flushing aged dirty bh " << *bh << dendl;
 	bh_write(bh);
       }


### PR DESCRIPTION
While analyzing a log from Mike Dawson I saw a long stall while librbd's 
objectcacher was starting lots (many hundreds) of IOs.  Limit the amount of 
time we spend doing this at a time to allow IO replies to be processed so 
that the cache remains responsive.

Signed-off-by: Sage Weil sage@inktank.com
