### PR TITLE
ReplicatedPG: don't bless C_OSD_SendMessageOnConn

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1602,9 +1602,8 @@ void ReplicatedBackend::_do_push(OpRequestRef op)
   reply->compute_cost(cct);
 
   t->register_on_complete(
-    get_parent()->bless_context(
-      new C_OSD_SendMessageOnConn(
-	osd, reply, m->get_connection())));
+    new C_OSD_SendMessageOnConn(
+      osd, reply, m->get_connection()));
 
   get_parent()->queue_transaction(t);
 }
@@ -1670,9 +1669,8 @@ void ReplicatedBackend::_do_pull_response(OpRequestRef op)
     reply->compute_cost(cct);
 
     t->register_on_complete(
-      get_parent()->bless_context(
-	new C_OSD_SendMessageOnConn(
-	  osd, reply, m->get_connection())));
+      new C_OSD_SendMessageOnConn(
+	osd, reply, m->get_connection()));
   }
 
   get_parent()->queue_transaction(t);


### PR DESCRIPTION
C_OSD_SendMessageOnConn doesn't need to lock the pg.
Canceling it resulted in a leaked message.

Fixes: 6443
Signed-off-by: Samuel Just sam.just@inktank.com
