### PR TITLE
crush: invalidate rmap on create (and thus decode)

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -855,7 +855,6 @@ void CrushWrapper::decode(bufferlist::iterator& blp)
     decode_32_or_64_string_map(type_map, blp);
     decode_32_or_64_string_map(name_map, blp);
     decode_32_or_64_string_map(rule_name_map, blp);
-    build_rmaps();
 
     // tunables
     if (!blp.end()) {

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -94,6 +94,7 @@ public:
       crush_destroy(crush);
     crush = crush_create();
     assert(crush);
+    have_rmaps = false;
   }
 
   // tunables


### PR DESCRIPTION
If we have an existing CrushWrapper object and decode from a bufferlist, 
reset build_rmaps so that they get rebuilt.

Remove the build_rmaps() all in decode that was useless on a redecode
(because have_rmaps == true in that case and it did nothing).

Fixes: #6442 Backport: dumpling Signed-off-by: Sage Weil sage@inktank.com
