### PR TITLE
wip-store-tool: Few patches to ceph_test_store_tool

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1269,7 +1269,7 @@ ceph_test_keyvaluedb_iterators_CXXFLAGS = ${AM_CXXFLAGS} ${UNITTEST_CXXFLAGS} ${
 bin_DEBUGPROGRAMS += ceph_test_keyvaluedb_iterators
 
 ceph_test_store_tool_SOURCES = test/ObjectMap/test_store_tool/test_store_tool.cc \
-			  os/LevelDBStore.cc
+			  os/LevelDBStore.cc common/strtol.cc
 ceph_test_store_tool_LDFLAGS = ${AM_LDFLAGS}
 ceph_test_store_tool_LDADD =  $(LIBOS_LDA) $(LIBGLOBAL_LDA)
 ceph_test_store_tool_CXXFLAGS = ${AM_CXXFLAGS} ${UNITTEST_CXXFLAGS}

--- a/src/test/ObjectMap/test_store_tool/test_store_tool.cc
+++ b/src/test/ObjectMap/test_store_tool/test_store_tool.cc
@@ -24,6 +24,7 @@
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "common/config.h"
+#include "common/strtol.h"
 
 using namespace std;
 
@@ -83,7 +84,7 @@ class StoreTool
     assert(!prefix.empty() && !key.empty());
 
     map<string,bufferlist> result;
-    set<string> keys;
+    std::set<std::string> keys;
     keys.insert(key);
     db->get(prefix, keys, &result);
 
@@ -105,6 +106,18 @@ class StoreTool
     std::cout << "total: " << s << std::endl;
     return s;
   }
+
+  bool set(const string &prefix, const string &key, bufferlist &val) {
+    assert(!prefix.empty());
+    assert(!key.empty());
+    assert(val.length() > 0);
+
+    KeyValueDB::Transaction tx = db->get_transaction();
+    tx->set(prefix, key, val);
+    int ret = db->submit_transaction_sync(tx);
+
+    return (ret == 0);
+  }
 };
 
 void usage(const char *pname)
@@ -118,6 +131,7 @@ void usage(const char *pname)
     << "  get <prefix> <key>\n"
     << "  crc <prefix> <key>\n"
     << "  get-size\n"
+    << "  set <prefix> <key> [ver <N>|in <file>]\n"
     << std::endl;
 }
 
@@ -209,6 +223,44 @@ int main(int argc, const char *argv[])
 
   } else if (cmd == "get-size") {
     std::cout << "estimated store size: " << st.get_size() << std::endl;
+
+  } else if (cmd == "set") {
+    if (argc < 7) {
+      usage(argv[0]);
+      return 1;
+    }
+    string prefix(argv[3]);
+    string key(argv[4]);
+    string subcmd(argv[5]);
+
+    bufferlist val;
+    string errstr;
+    if (subcmd == "ver") {
+      version_t v = (version_t) strict_strtoll(argv[6], 10, &errstr);
+      if (!errstr.empty()) {
+        std::cerr << "error reading version: " << errstr << std::endl;
+        return 1;
+      }
+      ::encode(v, val);
+    } else if (subcmd == "in") {
+      int ret = val.read_file(argv[6], &errstr);
+      if (ret < 0 || !errstr.empty()) {
+        std::cerr << "error reading file: " << errstr << std::endl;
+        return 1;
+      }
+    } else {
+      std::cerr << "unrecognized subcommand '" << subcmd << "'" << std::endl;
+      usage(argv[0]);
+      return 1;
+    }
+
+    bool ret = st.set(prefix, key, val);
+    if (!ret) {
+      std::cerr << "error setting ("
+                << prefix << "," << key << ")" << std::endl;
+      return 1;
+    }
+
   } else {
     std::cerr << "Unrecognized command: " << cmd << std::endl;
     return 1;


### PR DESCRIPTION
Adds the following features:
- obtain prefix:key's value's crc
- list all keys (store-wide or for a given prefix) while outputting the value's crc
- allow setting a prefix:key to a specified value
