### PR TITLE
Make fsid comparison case-insensitive

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -570,7 +570,7 @@ def get_fsid(cluster):
     fsid = get_conf(cluster=cluster, variable='fsid')
     if fsid is None:
         raise Error('getting cluster uuid from configuration failed')
-    return fsid
+    return fsid.lower()
 
 
 def get_or_create_dmcrypt_key(
@@ -1601,6 +1601,7 @@ def find_cluster_by_uuid(_uuid):
     Find a cluster name by searching /etc/ceph/*.conf for a conf file
     with the right uuid.
     """
+    _uuid = _uuid.lower()
     no_fsid = []
     if not os.path.exists('/etc/ceph'):
         return None
@@ -1608,11 +1609,15 @@ def find_cluster_by_uuid(_uuid):
         if not conf_file.endswith('.conf'):
             continue
         cluster = conf_file[:-5]
-        fsid = get_conf(cluster, 'fsid')
-        if fsid is None:
+        try:
+            fsid = get_fsid(cluster)
+        except Error as e: 
+            if e.message != 'getting cluster uuid from configuration failed':
+                raise e
             no_fsid.append(cluster)
-        elif fsid == _uuid:
-            return cluster
+        else:
+            if fsid == _uuid:
+                return cluster
     # be tolerant of /etc/ceph/ceph.conf without an fsid defined.
     if len(no_fsid) == 1 and no_fsid[0] == 'ceph':
         LOG.warning('No fsid defined in /etc/ceph/ceph.conf; using anyway')


### PR DESCRIPTION
get_fsid and find_cluster_by_uuid are modified so ceph-disk activate and
ceph-disk activate-all will work if the fsid uses uppercase characters.

Signed-off-by: Harry Harrington git-harry@live.co.uk
