### PR TITLE
librados: drop #include of int_types.h from installed headers

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -14,8 +14,6 @@
 #ifndef CEPH_BUFFER_H
 #define CEPH_BUFFER_H
 
-#include "include/int_types.h"
-
 #if defined(__linux__)
 #include <stdlib.h>
 #include <linux/types.h>
@@ -46,6 +44,7 @@ void	*valloc(size_t);
 #include <malloc.h>
 #endif
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -420,7 +419,7 @@ public:
     ssize_t read_fd(int fd, size_t len);
     int write_file(const char *fn, int mode=0644);
     int write_fd(int fd) const;
-    __u32 crc32c(__u32 crc) const;
+    uint32_t crc32c(uint32_t crc) const;
   };
 
   /*
@@ -428,7 +427,7 @@ public:
    */
 
   class hash {
-    __u32 crc;
+    uint32_t crc;
 
   public:
     hash() : crc(0) { }
@@ -437,7 +436,7 @@ public:
       crc = bl.crc32c(crc);
     }
 
-    __u32 digest() {
+    uint32_t digest() {
       return crc;
     }
   };

--- a/src/include/crc32c.h
+++ b/src/include/crc32c.h
@@ -1,8 +1,7 @@
 #ifndef CEPH_CRC32C_H
 #define CEPH_CRC32C_H
 
-#include "include/int_types.h"
-
+#include <inttypes.h>
 #include <string.h>
 
 typedef uint32_t (*ceph_crc32c_func_t)(uint32_t crc, unsigned char const *data, unsigned length);

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1,8 +1,6 @@
 #ifndef CEPH_LIBRADOS_H
 #define CEPH_LIBRADOS_H
 
-#include "include/int_types.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -566,7 +564,7 @@ int rados_pool_create_with_auid(rados_t cluster, const char *pool_name, uint64_t
  * @returns 0 on success, negative error code on failure
  */
 int rados_pool_create_with_crush_rule(rados_t cluster, const char *pool_name,
-				      __u8 crush_rule_num);
+				      uint8_t crush_rule_num);
 
 /**
  * Create a pool with a specific CRUSH rule and auid
@@ -581,7 +579,7 @@ int rados_pool_create_with_crush_rule(rados_t cluster, const char *pool_name,
  * @returns 0 on success, negative error code on failure
  */
 int rados_pool_create_with_all(rados_t cluster, const char *pool_name, uint64_t auid,
-			       __u8 crush_rule_num);
+			       uint8_t crush_rule_num);
 
 /**
  * Delete a pool and all data inside it


### PR DESCRIPTION
These are unnecessary, and breaks compilation for outside users.

Signed-off-by: Sage Weil sage@inktank.com
