### PR TITLE
qa: fix rbd cli tests checking size

### DIFF
--- a/qa/workunits/rbd/copy.sh
+++ b/qa/workunits/rbd/copy.sh
@@ -109,8 +109,8 @@ test_ls() {
     rbd ls | grep test2
     rbd ls | wc -l | grep 2
     # look for fields in output of ls -l without worrying about space
-    rbd ls -l | grep 'test1.*1024K.*1'
-    rbd ls -l | grep 'test2.*1024K.*1'
+    rbd ls -l | grep 'test1.*1024k.*1'
+    rbd ls -l | grep 'test2.*1024k.*1'
 
     rbd rm test1
     rbd rm test2
@@ -120,8 +120,8 @@ test_ls() {
     rbd ls | grep test1
     rbd ls | grep test2
     rbd ls | wc -l | grep 2
-    rbd ls -l | grep 'test1.*1024K.*2'
-    rbd ls -l | grep 'test2.*1024K.*2'
+    rbd ls -l | grep 'test1.*1024k.*2'
+    rbd ls -l | grep 'test2.*1024k.*2'
 
     rbd rm test1
     rbd rm test2
@@ -131,8 +131,8 @@ test_ls() {
     rbd ls | grep test1
     rbd ls | grep test2
     rbd ls | wc -l | grep 2
-    rbd ls -l | grep 'test1.*1024K.*2'
-    rbd ls -l | grep 'test2.*1024K.*1'
+    rbd ls -l | grep 'test1.*1024k.*2'
+    rbd ls -l | grep 'test2.*1024k.*1'
     remove_images
 	
     # test that many images can be shown by ls

--- a/qa/workunits/rbd/import_export.sh
+++ b/qa/workunits/rbd/import_export.sh
@@ -66,7 +66,7 @@ dd if=/dev/urandom bs=1M count=1 of=/tmp/sparse2; truncate /tmp/sparse2 -s 2M
 
 # 1M sparse, 1M data
 rbd import $RBD_CREATE_ARGS --order 20 /tmp/sparse1
-rbd ls -l | grep sparse1 | grep '2048K'
+rbd ls -l | grep sparse1 | grep '2048k'
 [ "$(objects sparse1)" = '1' ]
 
 # export, compare contents and on-disk size
@@ -77,7 +77,7 @@ rbd rm sparse1
 
 # 1M data, 1M sparse
 rbd import $RBD_CREATE_ARGS --order 20 /tmp/sparse2
-rbd ls -l | grep sparse2 | grep '2048K'
+rbd ls -l | grep sparse2 | grep '2048k'
 [ "$(objects sparse2)" = '0' ]
 rbd export sparse2 /tmp/sparse2.out
 compare_files_and_ondisk_sizes /tmp/sparse2 /tmp/sparse2.out
@@ -88,7 +88,7 @@ rbd rm sparse2
 truncate /tmp/sparse1 -s 10M
 # import from stdin just for fun, verify still sparse
 rbd import $RBD_CREATE_ARGS --order 20 - sparse1 < /tmp/sparse1
-rbd ls -l | grep sparse1 | grep '10240K'
+rbd ls -l | grep sparse1 | grep '10240k'
 [ "$(objects sparse1)" = '1' ]
 rbd export sparse1 /tmp/sparse1.out
 compare_files_and_ondisk_sizes /tmp/sparse1 /tmp/sparse1.out
@@ -99,7 +99,7 @@ rbd rm sparse1
 dd if=/dev/urandom bs=2M count=1 of=/tmp/sparse2 oflag=append conv=notrunc
 # again from stding
 rbd import $RBD_CREATE_ARGS --order 20 - sparse2 < /tmp/sparse2
-rbd ls -l | grep sparse2 | grep '4096K'
+rbd ls -l | grep sparse2 | grep '4096k'
 [ "$(objects sparse2)" = '0 2 3' ]
 rbd export sparse2 /tmp/sparse2.out
 compare_files_and_ondisk_sizes /tmp/sparse2 /tmp/sparse2.out

--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -39,7 +39,7 @@ For now, use a more inclusive regex.
   $ rbd info foo
   rbd image 'foo':
   \tsize 1024 MB in 256 objects (esc)
-  \torder 22 (4096 KB objects) (esc)
+  \torder 22 (4096 kB objects) (esc)
   [^^]+ (re)
   \tformat: 1 (esc)
   $ rbd info foo --format json | python -mjson.tool
@@ -67,7 +67,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   $ rbd info foo@snap
   rbd image 'foo':
   \tsize 1024 MB in 256 objects (esc)
-  \torder 22 (4096 KB objects) (esc)
+  \torder 22 (4096 kB objects) (esc)
   [^^]+ (re)
   \tformat: 1 (esc)
   \tprotected: False (esc)
@@ -96,7 +96,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   $ rbd info bar
   rbd image 'bar':
   \tsize 1024 MB in 256 objects (esc)
-  \torder 22 (4096 KB objects) (esc)
+  \torder 22 (4096 kB objects) (esc)
   [^^]+ (re)
   \tformat: 2 (esc)
   \tfeatures: layering (esc)
@@ -131,7 +131,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   $ rbd info bar@snap
   rbd image 'bar':
   \tsize 512 MB in 128 objects (esc)
-  \torder 22 (4096 KB objects) (esc)
+  \torder 22 (4096 kB objects) (esc)
   [^^]+ (re)
   \tformat: 2 (esc)
   \tfeatures: layering (esc)
@@ -169,7 +169,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   $ rbd info bar@snap2
   rbd image 'bar':
   \tsize 1024 MB in 256 objects (esc)
-  \torder 22 (4096 KB objects) (esc)
+  \torder 22 (4096 kB objects) (esc)
   [^^]+ (re)
   \tformat: 2 (esc)
   \tfeatures: layering (esc)
@@ -207,7 +207,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   $ rbd info baz
   rbd image 'baz':
   \tsize 2048 MB in 512 objects (esc)
-  \torder 22 (4096 KB objects) (esc)
+  \torder 22 (4096 kB objects) (esc)
   [^^]+ (re)
   \tformat: 2 (esc)
   \tfeatures: layering (esc)
@@ -241,8 +241,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info quux
   rbd image 'quux':
-  \tsize 1024 KB in 1 objects (esc)
-  \torder 22 (4096 KB objects) (esc)
+  \tsize 1024 kB in 1 objects (esc)
+  \torder 22 (4096 kB objects) (esc)
   [^^]+ (re)
   \tformat: 1 (esc)
   $ rbd info quux --format json | python -mjson.tool
@@ -268,7 +268,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   $ rbd info data/child
   rbd image 'child':
   \tsize 512 MB in 128 objects (esc)
-  \torder 22 (4096 KB objects) (esc)
+  \torder 22 (4096 kB objects) (esc)
   [^^]+ (re)
   \tformat: 2 (esc)
   \tfeatures: layering (esc)
@@ -303,7 +303,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   $ rbd info data/child@snap
   rbd image 'child':
   \tsize 512 MB in 128 objects (esc)
-  \torder 22 (4096 KB objects) (esc)
+  \torder 22 (4096 kB objects) (esc)
   [^^]+ (re)
   \tformat: 2 (esc)
   \tfeatures: layering (esc)
@@ -375,7 +375,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   NAME       SIZE PARENT FMT PROT LOCK 
   foo       1024M          1           
   foo@snap  1024M          1           
-  quux      1024K          1      excl 
+  quux      1024k          1      excl 
   bar       1024M          2           
   bar@snap   512M          2 yes       
   bar@snap2 1024M          2           


### PR DESCRIPTION
b43bc1a0b0692818d789f9f489b9aba5dd40522f changed the kilo prefix
from K to k in a few places.

Signed-off-by: Josh Durgin josh.durgin@inktank.com
