### PR TITLE
ceph_test_rados: notice read error; do not race rollback with snap_delete

### DIFF
--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -143,6 +143,7 @@ public:
   map<int, map<string,ObjectDesc> > pool_obj_cont;
   set<string> oid_in_use;
   set<string> oid_not_in_use;
+  set<int> snaps_in_use;
   int current_snap;
   string pool_name;
   librados::IoCtx io_ctx;
@@ -1315,6 +1316,8 @@ public:
     }
     context->oid_in_use.insert(oid);
     context->oid_not_in_use.erase(oid);
+    context->snaps_in_use.insert(roll_back_to);
+
     context->roll_back(oid, roll_back_to);
     uint64_t snap = context->snaps[roll_back_to];
 
@@ -1342,6 +1345,7 @@ public:
     context->update_object_version(oid, comp->get_version64());
     context->oid_in_use.erase(oid);
     context->oid_not_in_use.insert(oid);
+    context->snaps_in_use.erase(roll_back_to);
     context->kick();
   }
 

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -120,13 +120,16 @@ private:
       }
 
     case TEST_OP_ROLLBACK:
-      if (context.snaps.empty()) {
+      if (context.snaps.size() <= context.snaps_in_use.size()) {
 	return NULL;
-      } else {
+      }
+      while (true) {
 	int snap = rand_choose(context.snaps)->first;
+	if (context.snaps_in_use.count(snap))
+	  continue;  // in use; try again!
 	string oid = *(rand_choose(context.oid_not_in_use));
 	cout << "rollback oid " << oid << " to " << snap << std::endl;
-        return new RollbackOp(m_op, &context, oid, snap);
+	return new RollbackOp(m_op, &context, oid, snap);
       }
 
     case TEST_OP_SETATTR:


### PR DESCRIPTION
fixes model half of #6254
