### PR TITLE
ceph.spec.in: Always depend on junit4 (fixes bug #6216)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -239,14 +239,8 @@ License:	LGPL-2.0
 Requires:	java
 Requires:	libcephfs_jni1 = %{version}-%{release}
 BuildRequires:  java-devel
-%if 0%{?suse_version} > 1220
 Requires:       junit4
 BuildRequires:  junit4
-%else
-Requires:       junit
-BuildRequires:  junit
-%endif
-BuildRequires:  junit
 %description -n cephfs-java
 This package contains the Java libraries for the Ceph File System.
 


### PR DESCRIPTION
The RPM spec file currently lists `junit` as a dependency on all platforms except recent versions of OpenSUSE. This is problematic because `junit` refers to version 3.x, which doesn't satisfy the check in the configure script:

```
configure: Cannot find junit4.jar (apt-get install junit4)
```

As a result, rpmbuild doesn't build `libcephfs-test.jar` and fails:

```
http://tracker.ceph.com/issues/6216
```

So let's depend on `junit4` in all cases. This package is provided by all supported platforms (el6, fc17, fc18, fc19, opensuse12.2, opensuse12, sles11), and my testing on CentOS 6 shows that rpmbuild now succeeds and produces the expected `libcephfs_jni1` RPM.
