### PR TITLE
add '\n' to 'ceph osd find [0-]' output

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2110,7 +2110,10 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
       f->dump_string(p->first.c_str(), p->second);
     f->close_section();
     f->close_section();
-    f->flush(rdata);
+    ostringstream rs;
+    f->flush(rs);
+    rs << "\n";
+    rdata.append(rs.str());
   } else if (prefix == "osd map") {
     string poolstr, objstr, namespacestr;
     cmd_getval(g_ceph_context, cmdmap, "pool", poolstr);


### PR DESCRIPTION
after execute the 'ceph osd find [0-]' the terminal like below:
root@hj:~# ceph osd find 0
{ "osd": 0,
  "ip": "192.168.2.10:6800\/3953",
  "crush_location": { "host": "hj",
      "root": "default"}}root@hj:~#
