### PR TITLE
rgw: change default log level

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -461,7 +461,7 @@ int main(int argc, const char **argv)
 
   /* alternative default for module */
   vector<const char *> def_args;
-  def_args.push_back("--debug-rgw=20");
+  def_args.push_back("--debug-rgw=1/5");
   def_args.push_back("--keyring=$rgw_data/keyring");
   def_args.push_back("--log-file=/var/log/radosgw/$cluster-$name");
 


### PR DESCRIPTION
Fixes: #6554
Backport: cuttlefish, dumpling
Default log level was just too high, bring it down a bit.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
