### PR TITLE
cls_rbd: do not make noise in osd log on rbd removal

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -1525,7 +1525,8 @@ static int dir_remove_image_helper(cls_method_context_t hctx,
   string id_key = dir_key_for_id(id);
   int r = read_key(hctx, name_key, &stored_id);
   if (r < 0) {
-    CLS_ERR("error reading name to id mapping: %d", r);
+    if (r != -ENOENT)
+      CLS_ERR("error reading name to id mapping: %d", r);
     return r;
   }
   r = read_key(hctx, id_key, &stored_name);
@@ -1619,7 +1620,8 @@ int dir_get_id(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   string id;
   int r = read_key(hctx, dir_key_for_name(name), &id);
   if (r < 0) {
-    CLS_ERR("error reading id for name '%s': %d", name.c_str(), r);
+    if (r != -ENOENT)
+      CLS_ERR("error reading id for name '%s': %d", name.c_str(), r);
     return r;
   }
   ::encode(id, *out);


### PR DESCRIPTION
ubuntu@burnupi06:~$ tail -f /var/log/ceph/ceph-osd.1.log 2013-02-07
17:00:30.565749 7fdb09e6b700 0 <cls> cls/rbd/cls_rbd.cc:1615: error reading
id for name 'sds': -2 2013-02-07 17:00:30.566301 7fdb0a66c700 0 <cls>
cls/rbd/cls_rbd.cc:1521: error reading name to id mapping: -2 2013-02-07
17:03:54.085700 7fdb0a66c700 0 <cls> cls/rbd/cls_rbd.cc:1615: error reading
id for name 'sdfsd': -2 2013-02-07 17:03:54.086143 7fdb09e6b700 0 <cls>
cls/rbd/cls_rbd.cc:1521: error reading name to id mapping: -2

Fixes: #4047 Signed-off-by: Sage Weil sage@inktank.com
