### PR TITLE
Makefile: fix /sbin vs /usr/sbin behavior

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -269,7 +269,6 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 
 %{configure}	CPPFLAGS="$java_inc" \
 		--prefix=/usr \
-		--sbindir=/sbin \
 		--localstatedir=/var \
 		--sysconfdir=/etc \
 		--docdir=%{_docdir}/ceph \

--- a/debian/rules
+++ b/debian/rules
@@ -34,7 +34,7 @@ configure: configure-stamp
 configure-stamp:
 	dh_testdir
 	./autogen.sh
-	./configure --prefix=/usr --sbindir=/sbin --localstatedir=/var \
+	./configure --prefix=/usr --localstatedir=/var \
 	  --sysconfdir=/etc $(extraopts) $(confflags) \
 	  $(CEPH_EXTRA_CONFIGURE_ARGS)
 	touch $@

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -12,6 +12,8 @@ noinst_PROGRAMS =
 bin_SCRIPTS =
 sbin_PROGRAMS =
 sbin_SCRIPTS =
+su_sbin_PROGRAMS =
+su_sbin_SCRIPTS =
 dist_bin_SCRIPTS =
 lib_LTLIBRARIES = 
 noinst_LTLIBRARIES = 
@@ -22,7 +24,10 @@ radoslib_LTLIBRARIES =
 bin_DEBUGPROGRAMS =
 
 # like sbin_SCRIPTS but can be used to install to e.g. /usr/sbin
-ceph_sbindir = $(exec_prefix)$(sbindir)
+ceph_sbindir = $(sbindir)
+
+# certain things go straight into /sbin, though!
+su_sbindir = /sbin
 
 # C/C++ tests to build will be appended to this
 check_PROGRAMS =

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,9 +58,9 @@ bin_PROGRAMS += ceph-mds
 mount_ceph_SOURCES = mount/mount.ceph.c
 mount_ceph_LDADD = $(LIBCOMMON)
 if LINUX
-sbin_PROGRAMS += mount.ceph
+su_sbin_PROGRAMS += mount.ceph
 endif # LINUX
-sbin_SCRIPTS += mount.fuse.ceph
+su_sbin_SCRIPTS += mount.fuse.ceph
 
 cephfs_SOURCES = cephfs.cc
 cephfs_LDADD = $(LIBCOMMON)
@@ -239,7 +239,7 @@ bin_SCRIPTS += \
 	ceph-post-file
 
 BUILT_SOURCES += init-ceph
-sbin_SCRIPTS += mkcephfs
+su_sbin_SCRIPTS += mkcephfs
 
 shell_scripts += init-ceph mkcephfs
 


### PR DESCRIPTION
Instead of telling configure to put things in /sbin, explicitly put the two
important items (mkcephfs and mount.fuse.ceph) in /sbin via an automake rule.
 This unbreaks FreeBSD 9.1 and probably others.

Based on patches originally from Alan Somers asomers@gmail.com, modified 
for the current Makefile structure and applied to the specfile too.

Fixes: #6456 Signed-off-by: Sage Weil sage@inktank.com
