### PR TITLE
ceph: Remove unavailable option with clang

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -52,7 +52,6 @@ AM_COMMON_CPPFLAGS = \
 	-DCEPH_LIBDIR=\"${libdir}\"
 
 AM_COMMON_CFLAGS = \
-	-rdynamic \
 	-Wall \
 	${WARN_TYPE_LIMITS} \
 	${WARN_IGNORED_QUALIFIERS} \
@@ -61,6 +60,9 @@ AM_COMMON_CFLAGS = \
 	-Werror=format-security \
 	-fno-strict-aliasing \
 	-fsigned-char
+if !CLANG
+	AM_COMMON_FLAGS += -rdynamic
+endif
 
 AM_CFLAGS = $(AM_COMMON_CFLAGS)
 AM_CPPFLAGS = $(AM_COMMON_CPPFLAGS)
@@ -68,8 +70,10 @@ AM_CXXFLAGS = \
 	@AM_CXXFLAGS@ \
 	$(AM_COMMON_CFLAGS) \
 	-Wnon-virtual-dtor \
-	-Wno-invalid-offsetof \
-	-Wstrict-null-sentinel
+	-Wno-invalid-offsetof
+if !CLANG
+	AM_CXXFLAGS += -Wstrict-null-sentinel
+endif
 
 # note: this is position dependant, it affects the -l options that
 # come after it on the command line. when you use ${AM_LDFLAGS} in


### PR DESCRIPTION
Some options are unavailable in clang. (-Wstrict-null-sentinel,
-rdynamic)

They were reintroduced by this commit
https://github.com/ceph/ceph/commit/6949d221ada12e6be4b5ebf94b58edd17288fb16

This patch fixes it.

Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com
