### PR TITLE
client: fix invalid iterator dereference in Client::trim_caps()

### DIFF
--- a/src/client/MetaSession.h
+++ b/src/client/MetaSession.h
@@ -43,12 +43,14 @@ struct MetaSession {
   xlist<MetaRequest*> requests;
   xlist<MetaRequest*> unsafe_requests;
 
+  Cap *s_cap_iterator;
+
   MClientCapRelease *release;
   
   MetaSession()
     : mds_num(-1), con(NULL),
       seq(0), cap_gen(0), cap_renew_seq(0), num_caps(0),
-      state(STATE_NEW),
+      state(STATE_NEW), s_cap_iterator(NULL),
       release(NULL)
   {}
   ~MetaSession();


### PR DESCRIPTION
trimming inode drops a reference to the inode's parent, it may cause
the inode's parent also be trimmed. If the cap iterator 'p' happens to
point to the inode's parent and the inode's parent is trimmed, the cap
iterator 'p' become invalid.

Fix the issue by delaying removing cap from the seesion cap list.
(similar to what the kclient does)

Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
