### PR TITLE
mds: update backtrace when old format inode is touched

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2900,6 +2900,10 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
 
     wrlock_force(&in->xattrlock, mut);
   }
+
+  // update backtrace for old format inode. (see inode_t::decode)
+  if (pi->backtrace_version == 0)
+    pi->update_backtrace();
   
   mut->auth_pin(in);
   mdcache->predirty_journal_parents(mut, &le->metablob, in, 0, PREDIRTY_PRIMARY, 0, follows);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3206,6 +3206,11 @@ void Server::handle_client_setattr(MDRequest *mdr)
 
   // log + wait
   le->metablob.add_client_req(req->get_reqid(), req->get_oldest_client_tid());
+
+  // update backtrace for old format inode. (see inode_t::decode)
+  if (pi->backtrace_version == 0)
+    pi->update_backtrace();
+
   mdcache->predirty_journal_parents(mdr, &le->metablob, cur, 0, PREDIRTY_PRIMARY, false);
   mdcache->journal_dirty_inode(mdr, &le->metablob, cur);
   

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -295,6 +295,8 @@ void inode_t::decode(bufferlist::iterator &p)
     ::decode(backtrace_version, p);
   if (struct_v >= 7)
     ::decode(old_pools, p);
+  else
+    backtrace_version = 0; // note inode which has no backtrace
   if (struct_v >= 8)
     ::decode(max_size_ever, p);
 


### PR DESCRIPTION
We updated inode format version to 7 when introducing inode backtrace.
If we found a inode's format version < 7 when fetching the inode, set
the inode's backtrace_version to 0, to indicate the inode's backtrace
is out of data. When touching a inode with backtrace_version == 0, we
also update its backtrace.

Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
