### PR TITLE
librbd: remove unused 'flush' counter

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -210,7 +210,6 @@ namespace librbd {
     plb.add_u64_counter(l_librbd_discard, "discard");
     plb.add_u64_counter(l_librbd_discard_bytes, "discard_bytes");
     plb.add_time_avg(l_librbd_discard_latency, "discard_latency");
-    plb.add_u64_counter(l_librbd_flush, "flush");
     plb.add_u64_counter(l_librbd_aio_rd, "aio_rd");
     plb.add_u64_counter(l_librbd_aio_rd_bytes, "aio_rd_bytes");
     plb.add_time_avg(l_librbd_aio_rd_latency, "aio_rd_latency");

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -26,7 +26,6 @@ enum {
   l_librbd_discard,
   l_librbd_discard_bytes,
   l_librbd_discard_latency,
-  l_librbd_flush,
 
   l_librbd_aio_rd,               // read ops
   l_librbd_aio_rd_bytes,         // bytes read


### PR DESCRIPTION
It all goes through aio.

Fixes: #5668 Signed-off-by: Sage Weil sage@inktank.com
