### PR TITLE
doc: clarify that mons must have qurorum during deploy

### DIFF
--- a/doc/rados/deployment/ceph-deploy-keys.rst
+++ b/doc/rados/deployment/ceph-deploy-keys.rst
@@ -13,9 +13,13 @@ following::
 	ceph-deploy gatherkeys {monitor-host}
 
 
-.. note:: To retreive the keys, you specify a host that has a
+.. note:: To retrieve the keys, you specify a host that has a
    Ceph monitor. 
 
+.. note:: If you have specified multiple monitors in the setup of the cluster,
+   make sure, that all monitors are up and running. If the monitors haven't
+   formed quorum, ``ceph-create-keys`` will not finish and the keys aren't 
+   generated.
 
 Forget Keys
 ===========

--- a/doc/rados/deployment/ceph-deploy-mon.rst
+++ b/doc/rados/deployment/ceph-deploy-mon.rst
@@ -31,7 +31,8 @@ the tool enforces a single monitor per host. ::
 
 
 .. note:: Ensure that you add monitors such that they may arrive at a consensus
-   among a majority of monitors.
+   among a majority of monitors, otherwise other steps (like ``ceph-deploy gatherkeys``)
+   will fail.
 
 .. note::  When adding a monitor on a host that was not in hosts intially defined
    with the ``ceph-deploy new`` command, a ``public network`` statement needs


### PR DESCRIPTION
If multiple mons are specified in 'ceph-deploy new', but less than
those necessary for quorum are started with 'ceph-deploy mon create',
later steps (like 'ceph-deploy gatherkeys') will fail.
