### PR TITLE
add redhat settings to rbdmap init script

### DIFF
--- a/src/init-rbdmap
+++ b/src/init-rbdmap
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# rbdmap Ceph RBD Mapping
+#
+# chkconfig: 2345 20 80
+# description: Ceph RBD Mapping
 
 ### BEGIN INIT INFO
 # Provides:          rbdmap


### PR DESCRIPTION
Add a chkconfig line for RHEL based distros to make chkconfig start rbdmap earlier on boot and stop later on shutdown.  This will help prevent shutdown/reboot from hanging your system forever in the event that some daemon has a file held open on an rbd mounted filesystem.

Signed-off-by: Adam Twardowski adam.twardowski@gmail.com
