### PR TITLE
rbd.py: increase parent name size limit

### DIFF
--- a/src/pybind/rbd.py
+++ b/src/pybind/rbd.py
@@ -432,7 +432,7 @@ class Image(object):
     def parent_info(self):
         ret = -errno.ERANGE
         size = 8
-        while ret == -errno.ERANGE and size < 128:
+        while ret == -errno.ERANGE and size <= 4096:
             pool = create_string_buffer(size)
             name = create_string_buffer(size)
             snapname = create_string_buffer(size)


### PR DESCRIPTION
64 characters isn't all that long. 4096 ought to be enough for anyone.

Fixes: #6072
Backport: dumpling, cuttlefish
Signed-off-by: Josh Durgin josh.durgin@inktank.com
