### PR TITLE
mds: assertion on object mutation error

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1751,6 +1751,7 @@ class C_Dir_Committed : public Context {
 public:
   C_Dir_Committed(CDir *d, version_t v) : dir(d), version(v) { }
   void finish(int r) {
+    assert(r == 0);
     dir->_committed(version);
   }
 };

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -873,6 +873,7 @@ struct C_Inode_Stored : public Context {
   Context *fin;
   C_Inode_Stored(CInode *i, version_t v, Context *f) : in(i), version(v), fin(f) {}
   void finish(int r) {
+    assert(r == 0);
     in->_stored(version, fin);
   }
 };
@@ -1002,6 +1003,7 @@ struct C_Inode_StoredBacktrace : public Context {
   Context *fin;
   C_Inode_StoredBacktrace(CInode *i, version_t v, Context *f) : in(i), version(v), fin(f) {}
   void finish(int r) {
+    assert(r == 0);
     in->_stored_backtrace(version, fin);
   }
 };


### PR DESCRIPTION
I encountered weird MDS issues after the OSDs failed to handle object
mutations (caused by too many open files)

Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
