### PR TITLE
rgw: normal PUT object requests got 405 sometimes

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -659,13 +659,12 @@ bool verify_object_permission(struct req_state *s, int perm)
   return verify_object_permission(s, s->bucket_acl, s->object_acl, perm);
 }
 
-static char hex_to_num(char c)
+class HexTable
 {
-  static char table[256];
-  static bool initialized = false;
+  char table[256];
 
-
-  if (!initialized) {
+public:
+  HexTable() {
     memset(table, -1, sizeof(table));
     int i;
     for (i = '0'; i<='9'; i++)
@@ -674,10 +673,17 @@ static char hex_to_num(char c)
       table[i] = i - 'A' + 0xa;
     for (i = 'a'; i<='f'; i++)
       table[i] = i - 'a' + 0xa;
-
-    initialized = true;
   }
-  return table[(int)c];
+
+  char to_num(char c) {
+    return table[(int)c];
+  }
+};
+
+static char hex_to_num(char c)
+{
+  static HexTable hex_table;
+  return hex_table.to_num(c);
 }
 
 bool url_decode(string& src_str, string& dest_str)


### PR DESCRIPTION
Under load testing, normal PUT object requests got 405 sometimes. Bug #6672 (http://tracker.ceph.com/issues/6672) has been filed to track this issue. The root cause is that there is a defect in hex_to_num() to decode url in multi-threading context.

A quick fix is to set initialized to true after populating table in hex_to_num(). But it's safer to make sure the hex table is initialized before first use. The easiest approach is wrapping the table as a class and defining as a static local variable in hex_to_num() as commit 5032ca2b4abf701a22f9a71a57d48c221a8d935e.
