### PR TITLE
mon/PGMonitor: always send pg creations after mapping

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -306,6 +306,7 @@ void PGMonitor::post_paxos_update()
 {
   if (mon->osdmon()->osdmap.get_epoch()) {
     map_pg_creates();
+    send_pg_creates();
   }
 }
 


### PR DESCRIPTION
At some point in the dumpling cycle I separated the map stage from the send
stage, but it is not clear to me now why that is useful.  In particular, in
this particular we can send the creates any time we have a non-zero osdmap
epoch, and are in good shape as long as we do the map step after the osdmap
is loaded (hence the post_paxos_update).

This particular path is responsible for the stalled test referenced in bug

Backport: dumpling Signed-off-by: Sage Weil sage@inktank.com
