### PR TITLE
mon: OSDMonitor: only allow an osd to boot iff it has the fsid on record

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4365,7 +4365,7 @@ int OSDMonitor::_prepare_rename_pool(uint64_t pool, string newname)
   for (map<int64_t,string>::iterator p = pending_inc.new_pool_names.begin();
        p != pending_inc.new_pool_names.end();
        ++p) {
-    if (p->second == newname && p->first != pool) {
+    if (p->second == newname && (uint64_t)p->first != pool) {
       return -EEXIST;
     }
   }


### PR DESCRIPTION
Fixes: #6605

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
