### PR TITLE
prio-q: initialize cur iterator

### DIFF
--- a/src/common/PrioritizedQueue.h
+++ b/src/common/PrioritizedQueue.h
@@ -92,7 +92,7 @@ class PrioritizedQueue {
     SubQueue()
       : tokens(0),
 	max_tokens(0),
-	size(0) {}
+	size(0), cur(q.begin()) {}
     void set_max_tokens(unsigned mt) {
       max_tokens = mt;
     }


### PR DESCRIPTION
For new SubQueues `cur` is not intialized, so front/pop_front will freak
out. I honestly I have no idea how this hasn't been seen, but it was
being triggered frequently on OSX.

Fixes: #6686

Signed-off-by: Noah Watkins noahwatkins@gmail.com
