### PR TITLE
Wip doc openstack

### DIFF
--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -156,7 +156,7 @@ default, edit ``/etc/glance/glance-api.conf`` and add::
     rbd_store_user=images
     rbd_store_pool=images
 
-If you’re using Folsom and want to enable copy-on-write cloning of images into
+If want to enable copy-on-write cloning of images into
 volumes, also add::
 
 	show_image_direct_url=True


### PR DESCRIPTION
The OpenStack document was updated for Havana. This should fix #5006.
