### PR TITLE
Really use the hostname, otherwise ambiguous

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -40,7 +40,7 @@ case "$1" in
 
             # mapped to this host?
             host=`ceph-conf -n $name host`
-            if [ "$host" != `hostname` ]; then
+            if [ "$host" != `hostname -s` ]; then
                 continue
             fi
 

--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -43,7 +43,7 @@ case "$1" in
 
             # mapped to this host?
             host=`ceph-conf -n $name host`
-            if [ "$host" != `hostname` ]; then
+            if [ "$host" != `hostname -s` ]; then
                 continue
             fi
 


### PR DESCRIPTION
"hostname" can return either the hostname or the fqdn depending on
configuration.
This refers to the issue http://tracker.ceph.com/issues/6706
