### PR TITLE
OSDMonitor: be a little nicer about letting users do pg splitting

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2796,10 +2796,15 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
     }
     if (n <= (int)p.get_pg_num()) {
       ss << "specified pg_num " << n << " <= current " << p.get_pg_num();
-    } else if (!mon->pgmon()->pg_map.creating_pgs.empty()) {
-      ss << "currently creating pgs, wait";
-      return -EAGAIN;
     } else {
+      for(set<pg_t>::iterator i = mon->pgmon()->pg_map.creating_pgs.begin();
+	  i != mon->pgmon()->pg_map.creating_pgs.end();
+	  ++i) {
+	if (i->m_pool == static_cast<uint64_t>(pool)) {
+	  ss << "currently creating pgs, wait";
+	  return -EAGAIN;
+	}
+      }
       p.set_pg_num(n);
       ss << "set pool " << pool << " pg_num to " << n;
     }
@@ -2812,10 +2817,15 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
       ss << "specified pgp_num must > 0, but you set to " << n;
     } else if (n > (int)p.get_pg_num()) {
       ss << "specified pgp_num " << n << " > pg_num " << p.get_pg_num();
-    } else if (!mon->pgmon()->pg_map.creating_pgs.empty()) {
-      ss << "still creating pgs, wait";
-      return -EAGAIN;
     } else {
+      for(set<pg_t>::iterator i = mon->pgmon()->pg_map.creating_pgs.begin();
+	  i != mon->pgmon()->pg_map.creating_pgs.end();
+	  ++i) {
+	if (i->m_pool == static_cast<uint64_t>(pool)) {
+	  ss << "currently creating pgs, wait";
+	  return -EAGAIN;
+	}
+      }
       p.set_pgp_num(n);
       ss << "set pool " << pool << " pgp_num to " << n;
     }


### PR DESCRIPTION
I tested this by running vstart with two OSDs. Doing split on a pool while a different pool was creating succeeded; trying to split a still-creating pool did not.

gregf@kai:~/ceph/src [next]$ ./ceph osd pool create foo 100 && ./ceph osd pool set data pg_num 50
**\* DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
pool 'foo' created
**\* DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
set pool 0 pg_num to 50
gregf@kai:~/ceph/src [next]$ ./ceph osd pool set data pg_num 100
**\* DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
Error EAGAIN: currently creating pgs, wait
