### PR TITLE
upstart: fix ceph-crush-location default

### DIFF
--- a/src/upstart/ceph-osd.conf
+++ b/src/upstart/ceph-osd.conf
@@ -19,6 +19,9 @@ pre-start script
     if [ "${update:-1}" = "1" -o "{$update:-1}" = "true" ]; then
         # update location in crush
 	hook="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_location_hook || :)"
+	if [ -z "$hook" ]; then
+	    hook="/usr/bin/ceph-crush-location"
+	fi
 	location="$($hook --cluster ${cluster:-ceph} --id $id --type osd)"
 	weight="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_initial_weight || :)"
 	defaultweight=`df /var/lib/ceph/osd/${cluster:-ceph}-$id/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }'`


### PR DESCRIPTION
Behave if it is not specified on ceph.conf.  (init-ceph also falls back to
the default.)

Fixes: #6698 Signed-off-by: Sage Weil sage@inktank.com
