### PR TITLE
rgw: don't turn 404 into 400 for the replicalog api

### DIFF
--- a/src/rgw/rgw_rest_replica_log.cc
+++ b/src/rgw/rgw_rest_replica_log.cc
@@ -171,7 +171,9 @@ static int bucket_instance_to_bucket(RGWRados *store, string& bucket_instance, r
   
   int r = store->get_bucket_instance_info(NULL, bucket_instance, bucket_info, &mtime, NULL);
   if (r < 0) {
-    dout(5) << "could not get bucket instance info for bucket=" << bucket_instance << dendl;
+    dout(5) << "could not get bucket instance info for bucket=" << bucket_instance << ": " << cpp_strerror(r) << dendl;
+    if (r == -ENOENT)
+      return r;
     return -EINVAL;
   }
 


### PR DESCRIPTION
404 is not actually a problem to clients like radosgw-agent, but 400
implies something about the request was incorrect.

Backport: dumpling
Signed-off-by: Josh Durgin josh.durgin@inktank.com
