### PR TITLE
rbd: omit 'rw' option during map

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -1643,12 +1643,12 @@ static int do_kernel_add(const char *poolname, const char *imgname,
   }
 
   if (read_only)
-    oss << " ro";
+    oss << " ro,";
   else
-    oss << " rw";
+    oss << " ";
 
   const char *user = g_conf->name.get_id().c_str();
-  oss << ",name=" << user;
+  oss << "name=" << user;
 
   char key_name[strlen(user) + strlen("client.") + 1];
   snprintf(key_name, sizeof(key_name), "client.%s", user);


### PR DESCRIPTION
The ro and rw options were added in linux 3.7. To be compatible with older
kernels, don't specify rw. The default will probably always be rw, so this
should not present any problems in the future.

Reported-by: nicolasc nicolas.canceill@surfsara.nl
Signed-off-by: Josh Durgin josh.durgin@inktank.com
