### PR TITLE
mon/PGMap: use const ref, not pass-by-value

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -787,7 +787,7 @@ void PGMap::print_osd_perf_stats(std::ostream *ss) const
 }
 
 void PGMap::recovery_summary(Formatter *f, ostream *out,
-                             pool_stat_t delta_sum) const
+                             const pool_stat_t& delta_sum) const
 {
   bool first = true;
   if (delta_sum.stats.sum.num_objects_degraded) {
@@ -825,7 +825,7 @@ void PGMap::recovery_summary(Formatter *f, ostream *out,
 }
 
 void PGMap::recovery_rate_summary(Formatter *f, ostream *out,
-                                  pool_stat_t delta_sum,
+                                  const pool_stat_t& delta_sum,
                                   utime_t delta_stamp) const
 {
   // make non-negative; we can get negative values if osds send
@@ -886,7 +886,7 @@ void PGMap::pool_recovery_summary(Formatter *f, ostream *out,
 }
 
 void PGMap::client_io_rate_summary(Formatter *f, ostream *out,
-                                   pool_stat_t delta_sum,
+                                   const pool_stat_t& delta_sum,
                                    utime_t delta_stamp) const
 {
   pool_stat_t pos_delta = delta_sum;

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -244,12 +244,12 @@ public:
   void print_osd_perf_stats(std::ostream *ss) const;
 
   void recovery_summary(Formatter *f, ostream *out,
-                        pool_stat_t delta_sum) const;
+                        const pool_stat_t& delta_sum) const;
   void overall_recovery_summary(Formatter *f, ostream *out) const;
   void pool_recovery_summary(Formatter *f, ostream *out,
                              uint64_t poolid) const;
   void recovery_rate_summary(Formatter *f, ostream *out,
-                             pool_stat_t delta_sum,
+                             const pool_stat_t& delta_sum,
                              utime_t delta_stamp) const;
   void overall_recovery_rate_summary(Formatter *f, ostream *out) const;
   void pool_recovery_rate_summary(Formatter *f, ostream *out,
@@ -259,7 +259,7 @@ public:
    * given @p delta_sum pool over a given @p delta_stamp period of time.
    */
   void client_io_rate_summary(Formatter *f, ostream *out,
-                              pool_stat_t delta_sum,
+                              const pool_stat_t& delta_sum,
                               utime_t delta_stamp) const;
   /**
    * Obtain a formatted/plain output for the overall client I/O, which is


### PR DESCRIPTION
Signed-off-by: Sage Weil sage@inktank.com
