### PR TITLE
Use the right exit statuses in radosgw init script, provide minimum verbosity.

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -20,8 +20,20 @@ DEFAULT_USER='www-data'
 
 RADOSGW=`which radosgw`
 if [ ! -x "$RADOSGW" ]; then
-    exit 0
+    echo "$RADOSGW could not start, it is not executable."
+    exit 1
 fi
+
+daemon_is_running() {
+    daemon=$1
+    if pidof $daemon >/dev/null; then
+        echo "$daemon is running."
+        exit 0
+    else
+        echo "$daemon is not running."
+        exit 1
+    fi
+}
 
 case "$1" in
     start)
@@ -40,8 +52,10 @@ case "$1" in
 
             # mapped to this host?
             host=`ceph-conf -n $name host`
-            if [ "$host" != `hostname -s` ]; then
-                continue
+            hostname=`hostname -s`
+            if [ "$host" != "$hostname" ]; then
+                echo "$hostname could not be found in ceph.conf, not starting."
+                exit 1
             fi
 
             user=`ceph-conf -n $name user`
@@ -57,6 +71,7 @@ case "$1" in
 
             echo "Starting $name..."
             start-stop-daemon --start -u $user -x $RADOSGW -- -n $name
+            daemon_is_running $RADOSGW
         done
         ;;
     reload)
@@ -71,16 +86,10 @@ case "$1" in
         start-stop-daemon --stop -x $RADOSGW --oknodo
         ;;
     status)
-        if pidof $RADOSGW >/dev/null; then
-            echo "$RADOSGW is running."
-        else
-            echo "$RADOSGW is not running."
-            exit 1
-        fi
+        daemon_is_running $RADOSGW
         ;;
     *)
         echo "Usage: $0 start|stop|restart|force-reload|reload|status" >&2
         exit 3
         ;;
 esac
-

--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -22,7 +22,8 @@ DEFAULT_USER='apache'
 
 RADOSGW=`which radosgw`
 if [ ! -x "$RADOSGW" ]; then
-    exit 0
+    echo "$RADOSGW could not start, it is not executable."
+    exit 1
 fi
 
 case "$1" in
@@ -43,8 +44,10 @@ case "$1" in
 
             # mapped to this host?
             host=`ceph-conf -n $name host`
-            if [ "$host" != `hostname -s` ]; then
-                continue
+            hostname=`hostname -s`
+            if [ "$host" != "$hostname" ]; then
+                echo "$hostname could not be found in ceph.conf, not starting."
+                exit 1
             fi
 
             user=`ceph-conf -n $name user`
@@ -61,6 +64,7 @@ case "$1" in
             #start-stop-daemon --start -u $user -x $RADOSGW -- -n $name
             daemon --user="$user" "$RADOSGW -n $name"
             echo "Starting $name..."
+            daemon_is_running $RADOSGW
         done
         ;;
     reload)
@@ -78,12 +82,7 @@ case "$1" in
         echo "Stopping radosgw instance(s)..."
         ;;
     status)
-        if pidof $RADOSGW >/dev/null; then
-            echo "$RADOSGW is running."
-        else
-            echo "$RADOSGW is not running."
-            exit 1
-        fi
+        daemon_is_running $RADOSGW
         ;;
     *)
         echo "Usage: $0 start|stop|restart|force-reload|reload|status" >&2


### PR DESCRIPTION
Ref: http://tracker.ceph.com/issues/6710
Before, we would exit 0 where we should exit 1 or use "continue".
This means we were not returning exit 1 if there was an error and
radosgw did not start.
This commit aims to handle theses cases better.
We also now verify that radosgw started successfully.

Signed-off-by: David Moreau Simard dmsimard@iweb.com
