### PR TITLE
Be more verbose in radosgw init script issues, return the right exit codes

### DIFF
--- a/doc/radosgw/troubleshooting.rst
+++ b/doc/radosgw/troubleshooting.rst
@@ -17,6 +17,14 @@ the startup script is trying to start the process as a
 ``www-data`` or ``apache`` user and an existing ``.asok`` is 
 preventing the script from starting the daemon.
 
+The radosgw init script (/etc/init.d/radosgw) also has a verbose argument that
+can provide some insight as to what could be the issue:
+
+  /etc/init.d/radosgw start -v
+
+or
+
+  /etc/init.d radosgw start --verbose
 
 HTTP Request Errors
 ===================

--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -23,6 +23,13 @@ daemon_is_running() {
     fi
 }
 
+VERBOSE=0
+for opt in $*; do
+    if [ "$opt" = "-v" ] || [ "$opt" = "--verbose" ]; then
+       VERBOSE=1
+    fi
+done
+
 # prefix for radosgw instances in ceph.conf
 PREFIX='client.radosgw.'
 
@@ -31,6 +38,7 @@ DEFAULT_USER='www-data'
 
 RADOSGW=`which radosgw`
 if [ ! -x "$RADOSGW" ]; then
+    [ $VERBOSE -eq 1 ] && echo "$RADOSGW could not start, it is not executable."
     exit 1
 fi
 
@@ -51,7 +59,9 @@ case "$1" in
 
             # mapped to this host?
             host=`ceph-conf -n $name host`
-            if [ "$host" != `hostname -s` ]; then
+            hostname=`hostname -s`
+            if [ "$host" != "$hostname" ]; then
+                [ $VERBOSE -eq 1 ] && echo "hostname $hostname could not be found in ceph.conf:[$name], not starting."
                 continue
             fi
 
@@ -86,7 +96,7 @@ case "$1" in
         daemon_is_running $RADOSGW
         ;;
     *)
-        echo "Usage: $0 start|stop|restart|force-reload|reload|status" >&2
+        echo "Usage: $0 {start|stop|restart|force-reload|reload|status} [-v|--verbose]" >&2
         exit 3
         ;;
 esac

--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -24,6 +24,13 @@ daemon_is_running() {
     fi
 }
 
+VERBOSE=0
+for opt in $*; do
+    if [ "$opt" = "-v" ] || [ "$opt" = "--verbose" ]; then
+       VERBOSE=1
+    fi
+done
+
 # prefix for radosgw instances in ceph.conf
 PREFIX='client.radosgw.'
 
@@ -33,6 +40,7 @@ DEFAULT_USER='apache'
 
 RADOSGW=`which radosgw`
 if [ ! -x "$RADOSGW" ]; then
+    [ $VERBOSE -eq 1 ] && echo "$RADOSGW could not start, it is not executable."
     exit 1
 fi
 
@@ -54,7 +62,9 @@ case "$1" in
 
             # mapped to this host?
             host=`ceph-conf -n $name host`
-            if [ "$host" != `hostname -s` ]; then
+            hostname=`hostname -s`
+            if [ "$host" != "$hostname" ]; then
+                [ $VERBOSE -eq 1 ] && echo "hostname $hostname could not be found in ceph.conf:[$name], not starting."
                 continue
             fi
 
@@ -93,7 +103,7 @@ case "$1" in
         daemon_is_running $RADOSGW
         ;;
     *)
-        echo "Usage: $0 start|stop|restart|force-reload|reload|status" >&2
+        echo "Usage: $0 {start|stop|restart|force-reload|reload|status} [-v|--verbose]" >&2
         exit 3
         ;;
 esac


### PR DESCRIPTION
Ref: http://tracker.ceph.com/issues/6710
Before, we would exit 0 where we should exit 1 or use "continue".
This means we were not returning exit 1 if there was an error and
radosgw did not start.
This commit aims to handle theses cases better.
We also now verify that radosgw started successfully.
