### PR TITLE
galois.c: fix compiler warning

### DIFF
--- a/src/osd/ErasureCodePluginJerasure/galois.c
+++ b/src/osd/ErasureCodePluginJerasure/galois.c
@@ -693,7 +693,7 @@ void galois_w32_region_multiply(char *region,      /* Region to multiply */
   nbytes /= sizeof(int);
 
   if (galois_split_w8[0]== NULL) {
-    if (galois_create_split_w8_tables(8) < 0) {
+    if (galois_create_split_w8_tables() < 0) {
       fprintf(stderr, "galois_32_region_multiply -- couldn't make split multiplication tables\n");
       exit(1);
     }


### PR DESCRIPTION
galois_create_split_w8_tables() takes no parameter, remove '8' passed
to the function in one case.

osd/ErasureCodePluginJerasure/galois.c: In function 'galois_w32_region_multiply':
osd/ErasureCodePluginJerasure/galois.c:696:5: warning: call to function 'galois_create_split_w8_tables' without a real prototype [-Wunprototyped-calls]
In file included from osd/ErasureCodePluginJerasure/galois.c:53:0:
osd/ErasureCodePluginJerasure/galois.h:71:12: note: 'galois_create_split_w8_tables' was declared here

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
