### PR TITLE
wbthrottle: use posix_fadvise if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -539,6 +539,7 @@ AC_CHECK_FUNC([fallocate],
 AC_CHECK_HEADERS([sys/prctl.h])
 AC_CHECK_FUNCS([prctl])
 AC_CHECK_FUNCS([pipe2])
+AC_CHECK_FUNCS([posix_fadvise])
 
 # Checks for typedefs, structures, and compiler characteristics.
 #AC_HEADER_STDBOOL

--- a/src/os/WBThrottle.cc
+++ b/src/os/WBThrottle.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "acconfig.h"
+
 #include "os/WBThrottle.h"
 #include "common/perf_counters.h"
 
@@ -146,8 +148,10 @@ void *WBThrottle::entry()
     clearing = wb.get<0>();
     lock.Unlock();
     ::fdatasync(**wb.get<1>());
+#ifdef HAVE_POSIX_FADVISE
     if (wb.get<2>().nocache)
       posix_fadvise(**wb.get<1>(), 0, 0, POSIX_FADV_DONTNEED);
+#endif
     lock.Lock();
     clearing = ghobject_t();
     cur_ios -= wb.get<2>().ios;


### PR DESCRIPTION
Only adding information about data usage. This won't effect correctness.

Signed-off-by: Noah Watkins noahwatkins@gmail.com
