### PR TITLE
osdmaptool: don't put progress on stdout

### DIFF
--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -156,7 +156,7 @@ int main(int argc, const char **argv)
   OSDMap osdmap;
   bufferlist bl;
 
-  cout << me << ": osdmap file '" << fn << "'" << std::endl;
+  cerr << me << ": osdmap file '" << fn << "'" << std::endl;
   
   int r = 0;
   struct stat st;


### PR DESCRIPTION
If one requests JSON output, the progress message pollutes the output;
don't do that, send it to stderr instead

Signed-off-by: Dan Mick dan.mick@inktank.com
