### PR TITLE
rgw: deny writes to a secondary zone by non-system users

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -418,6 +418,11 @@ int RGWOp::verify_op_mask()
     return -EPERM;
   }
 
+  if (!s->system_request && (required_mask & RGW_OP_TYPE_MODIFY) && !store->zone.is_master)  {
+    ldout(s->cct, 5) << "NOTICE: modify request to a non-master zone by a non-system user, permission denied"  << dendl;
+    return -EPERM;
+  }
+
   return 0;
 }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -362,6 +362,10 @@ int RGWZoneParams::init(CephContext *cct, RGWRados *store, RGWRegion& region)
     return -EIO;
   }
 
+  is_master = (name == region.master_zone) || (region.master_zone.empty() && name == "default");
+
+  ldout(cct, 2) << "zone " << name << " is " << (is_master ? "" : "NOT ") << "master" << dendl;
+
   return 0;
 }
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -428,10 +428,13 @@ struct RGWZoneParams {
   rgw_bucket user_uid_pool;
 
   string name;
+  bool is_master;
 
   RGWAccessKey system_key;
 
   map<string, RGWZonePlacementInfo> placement_pools;
+
+  RGWZoneParams() : is_master(false) {}
 
   static int get_pool_name(CephContext *cct, string *pool_name);
   void init_name(CephContext *cct, RGWRegion& region);


### PR DESCRIPTION
Fixes: #6678
We don't want to allow regular users to write to secondary zones,
otherwise we'd end up with data inconsistencies.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
