### PR TITLE
(Do Not Merge) BSD-Linux network interoperability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,23 @@ if test x"$linux" = x"yes"; then
 fi
 AC_CHECK_FUNCS([syncfs], AC_DEFINE([HAVE_SYS_SYNCFS], [1], [we have syncfs]), [])
 
+# Checks related to struct sockaddr_storage
+AC_CACHE_CHECK([for ss_len field in struct sockaddr_storage],
+		ac_cv_have_ss_len_in_struct_ss, [
+	AC_TRY_COMPILE(
+		[
+#include <sys/types.h>
+#include <sys/socket.h>
+		],
+		[ struct sockaddr_storage s; s.ss_len = 1; ],
+		[ ac_cv_have_ss_len_in_struct_ss="yes" ],
+		[ ac_cv_have_ss_len_in_struct_ss="no" ],
+	)
+])
+if test "x$ac_cv_have_ss_len_in_struct_ss" = "xyes" ; then
+	AC_DEFINE(HAVE_SS_LEN_IN_SOCKADDR_STORAGE, 1, [Does struct sockaddr_storage have ss_len?])
+fi
+
 # Find some crypto library for us to use, while letting user to decide which one to use.
 AC_ARG_WITH([cryptopp],
 	[AS_HELP_STRING([--with-cryptopp], [Use cryptographic functions from cryptopp])],

--- a/src/include/msgr.h
+++ b/src/include/msgr.h
@@ -58,13 +58,26 @@ struct ceph_entity_name {
 
 extern const char *ceph_entity_type_name(int type);
 
+
+/*
+ * A portable version of sockaddr_storage.  For backwards compatibility, it is
+ * defined binary compatibly with Linux 3.2.0 amd64.
+ * On Linux amd64 this must be castable to a struct sockaddr_storage.  On
+ * other platforms, it must be translated.
+ */
+struct ceph_sockaddr_storage {
+	__be16 ss_family;            /* Big endian */
+	__u8   __ss_padding[126];
+} __attribute__ ((__packed__));
+
+
 /*
  * entity_addr -- network address
  */
 struct ceph_entity_addr {
 	__le32 type;
 	__le32 nonce;  /* unique id for process (e.g. pid) */
-	struct sockaddr_storage in_addr;
+	struct ceph_sockaddr_storage in_addr;
 } __attribute__ ((packed));
 
 struct ceph_entity_inst {

--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -97,6 +97,9 @@ bool entity_addr_t::parse(const char *s, const char **end)
   } else {
     return false;
   }
+#if HAVE_SS_LEN_IN_SOCKADDR_STORAGE
+  addr.ss_len = addr_size();
+#endif
 
   if (brackets) {
     if (*p != ']')

--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -1,8 +1,14 @@
 #include "common/config.h"
 #include "include/buffer.h"
 #include "include/encoding.h"
+#include "msg/msg_types.h"
 
 #include "gtest/gtest.h"
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 
 template < typename T >
 static void test_encode_and_decode(const T& src)
@@ -195,4 +201,197 @@ TEST(EncodingRoundTrip, MultimapConstructorCounter) {
   EXPECT_EQ(my_val_t::get_one_arg_ctor(), 0);
   EXPECT_EQ(my_val_t::get_copy_ctor(), 10);
   EXPECT_EQ(my_val_t::get_assigns(), 0);
+}
+
+inline bool operator==(struct sockaddr_storage l, struct sockaddr_storage r) {
+  return (0 == memcmp(&l, &r, sizeof(l)));
+}
+
+inline bool operator==(struct sockaddr_storage& l, struct sockaddr_storage& r) {
+  return (0 == memcmp(&l, &r, sizeof(l)));
+}
+
+
+TEST(EncodingRoundTrip, struct_sockaddr_in) {
+  struct sockaddr_storage ss;
+  struct sockaddr_in &sin = reinterpret_cast<struct sockaddr_in&>(ss);
+
+  // encode may skip don't care fields.  For testing purposes, we zero them.
+  bzero(&ss, sizeof(ss));
+#ifdef HAVE_SS_LEN_IN_SOCKADDR_STORAGE
+  sin.sin_len = sizeof(sin);
+#endif
+  sin.sin_family = AF_INET;
+  sin.sin_port = htons(0x9abc);
+  EXPECT_EQ(1, inet_pton(AF_INET, "18.52.86.120", &sin.sin_addr));
+
+  test_encode_and_decode < struct sockaddr_storage >(ss);
+}
+
+TEST(EncodingRoundTrip, struct_sockaddr_in6) {
+  struct sockaddr_storage ss;
+  struct sockaddr_in6 &sin6 = reinterpret_cast<struct sockaddr_in6&>(ss);
+
+  // encode may skip don't care fields.  For testing purposes, we zero them.
+  bzero(&ss, sizeof(ss));
+#ifdef HAVE_SS_LEN_IN_SOCKADDR_STORAGE
+  sin6.sin6_len = sizeof(sin6);
+#endif
+  sin6.sin6_family = AF_INET6;
+  sin6.sin6_port = htons(0x9abc);
+  sin6.sin6_scope_id = 0xe;    //Global scope
+  sin6.sin6_flowinfo = 0xfedcb;
+  EXPECT_EQ(1, inet_pton(AF_INET6, "2001:1234:5678:9abc:def0:cba9:8765:4321",
+      &sin6.sin6_addr));
+  test_encode_and_decode < struct sockaddr_storage >(ss);
+}
+
+// Test that we can encode a struct ceph_sockaddr_storage and get the same
+// binary layout that Linux amd64 produces when casting a sockaddr_in to
+// sockaddr_storage
+TEST(SockaddrStoragePortability, encode_in) {
+  bufferlist bl;
+  struct sockaddr_storage ss;
+  struct sockaddr_in &sin = reinterpret_cast<struct sockaddr_in&>(ss);
+  uint8_t encoded[128];
+  uint8_t expected[128] = {
+    0,                                              //Upper byte of sin_family
+    AF_INET,                                        //Lower byte of sin_family
+    0x9a, 0xbc,                                     //sin_port in big endian
+    0x12, 0x34, 0x56, 0x78,                         //sin_addr in big endian
+    0, 0, 0, 0,                                     //sin_zero
+    0, 0, 0, 0, 0, 0, 0, 0,                         //__ss_padding[8:16]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[16:32]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[32:64]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[64:80]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[80:96]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[96:112]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[112:128]
+  };
+
+  // encode may skip don't care fields.  For testing purposes, we zero them.
+  bzero(&ss, sizeof(ss));
+#ifdef HAVE_SS_LEN_IN_SOCKADDR_STORAGE
+  sin.sin_len = sizeof(sin);
+#endif
+  sin.sin_family = AF_INET;
+  sin.sin_port = htons(0x9abc);
+  EXPECT_EQ(1, inet_pton(AF_INET, "18.52.86.120", &sin.sin_addr));
+  encode(ss, bl);
+  EXPECT_EQ(sizeof(expected), bl.length());
+  bl.copy(0, 128, (char*)encoded);
+  EXPECT_EQ(0, memcmp(expected, encoded, 128));
+}
+
+// Test that we can encode a struct ceph_sockaddr_storage and get the same
+// binary layout that Linux amd64 produces when casting a sockaddr_in6 to
+// sockaddr_storage
+TEST(SockaddrStoragePortability, encode_in6) {
+  bufferlist bl;
+  struct sockaddr_storage ss;
+  struct sockaddr_in6 &sin6 = reinterpret_cast<struct sockaddr_in6&>(ss);
+  uint8_t encoded[128];
+  uint8_t expected[128] = {
+    0,                                              //Upper byte of sin6_family
+    AF_INET6,                                       //Lower byte of sin6_family
+    0x9a, 0xbc,                                     //sin6_port in big endian
+    0xcb, 0xed, 0x0f, 0x00,                         //sin6_flowinfo in LE
+    0x20, 0x01, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, //sin6_addr[0:8]
+    0xde, 0xf0, 0xcb, 0xa9, 0x87, 0x65, 0x43, 0x21, //sin6_addr[8:16]
+    0x0e, 0x00, 0x00, 0x00,                         //sin6_scope_id in LE
+    0, 0, 0, 0,                                     //__ss_padding[12:16]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[16:32]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[32:64]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[64:80]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[80:96]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[96:112]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[112:128]
+  };
+
+  // encode may skip don't care fields.  For testing purposes, we zero them.
+  bzero(&ss, sizeof(ss));
+#ifdef HAVE_SS_LEN_IN_SOCKADDR_STORAGE
+  sin6.sin6_len = sizeof(sin6);
+#endif
+  sin6.sin6_family = AF_INET6;
+  sin6.sin6_port = htons(0x9abc);
+  sin6.sin6_scope_id = 0xe;    //Global scope
+  sin6.sin6_flowinfo = 0xfedcb;
+  EXPECT_EQ(1, inet_pton(AF_INET6, "2001:1234:5678:9abc:def0:cba9:8765:4321",
+      &sin6.sin6_addr));
+
+  encode(ss, bl);
+  EXPECT_EQ(sizeof(expected), bl.length());
+  bl.copy(0, 128, (char*)encoded);
+  EXPECT_EQ(0, memcmp(expected, encoded, 128));
+}
+
+// Test that we can decode a struct ceph_sockaddr_storage using the binary
+// layout of Linux amd64 and get the correct sockaddr_in
+TEST(SockaddrStoragePortability, decode_in) {
+  bufferlist bl;
+  struct sockaddr_storage ss;
+  struct sockaddr_in &sin = reinterpret_cast<struct sockaddr_in&>(ss);
+  struct in_addr expected_addr;
+  uint8_t encoded[128] = {
+    0,                                              //Upper byte of sin_family
+    AF_INET,                                        //Lower byte of sin_family
+    0x9a, 0xbc,                                     //sin_port in big endian
+    0x12, 0x34, 0x56, 0x78,                         //sin_addr in big endian
+    0, 0, 0, 0,                                     //sin_zero
+    0, 0, 0, 0, 0, 0, 0, 0,                         //__ss_padding[8:16]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[16:32]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[32:64]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[64:80]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[80:96]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[96:112]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[112:128]
+  };
+  bl.append((char*)encoded, 128);
+
+  decode(ss, bl);
+#ifdef HAVE_SS_LEN_IN_SOCKADDR_STORAGE
+  EXPECT_EQ(sizeof(sin), sin.sin_len);
+#endif
+  EXPECT_EQ(AF_INET, sin.sin_family);
+  EXPECT_EQ(0x9abc, ntohs(sin.sin_port));
+  EXPECT_EQ(1, inet_pton(AF_INET, "18.52.86.120", &expected_addr));
+  EXPECT_EQ(expected_addr.s_addr, sin.sin_addr.s_addr);
+}
+
+// Test that we can decode a struct ceph_sockaddr_storage using the binary
+// layout of Linux amd64 and get the correct sockaddr_in6
+TEST(SockaddrStoragePortability, decode_in6) {
+  bufferlist bl;
+  struct sockaddr_storage ss;
+  struct sockaddr_in6 &sin6 = reinterpret_cast<struct sockaddr_in6&>(ss);
+  struct in6_addr expected_addr;
+  uint8_t encoded[128] = {
+    0,                                              //Upper byte of sin6_family
+    AF_INET6,                                       //Lower byte of sin6_family
+    0x9a, 0xbc,                                     //sin6_port in big endian
+    0xcb, 0xed, 0x0f, 0x00,                         //sin6_flowinfo in LE
+    0x20, 0x01, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, //sin6_addr[0:8]
+    0xde, 0xf0, 0xcb, 0xa9, 0x87, 0x65, 0x43, 0x21, //sin6_addr[8:16]
+    0x0e, 0x00, 0x00, 0x00,                         //sin6_scope_id in LE
+    0, 0, 0, 0,                                     //__ss_padding[12:16]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[16:32]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[32:64]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[64:80]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[80:96]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[96:112]
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //__ss_padding[112:128]
+  };
+  bl.append((char*)encoded, 128);
+
+  decode(ss, bl);
+#ifdef HAVE_SS_LEN_IN_SOCKADDR_STORAGE
+  EXPECT_EQ(sizeof(sin6), sin6.sin6_len);
+#endif
+  EXPECT_EQ(AF_INET6, sin6.sin6_family);
+  EXPECT_EQ(0x9abc, ntohs(sin6.sin6_port));
+  EXPECT_EQ(0xeu, sin6.sin6_scope_id);
+  EXPECT_EQ(0xfedcbu, sin6.sin6_flowinfo);
+  EXPECT_EQ(1, inet_pton(AF_INET6, "2001:1234:5678:9abc:def0:cba9:8765:4321", &expected_addr));
+  EXPECT_EQ(0, memcmp(&expected_addr, &sin6.sin6_addr, sizeof(expected_addr)));
 }


### PR DESCRIPTION
Ceph's networking protocol passes the in-memory representation of struct
sockaddr_storage over the wire, even though that structure is
operating-system and architecture specific.  This commit creates a
portably-defined struct ceph_sockaddr_storage which is identical to struct
sockaddr_storage on Linux amd64, along with appropriate encode and decode
functions.  This allows FreeBSD and Linux machines to coexist on the same
Ceph cluster.

Signed-off-by: Alan Somers asomers@gmail.com
