### PR TITLE
test: Only build death tests on platforms that support them

### DIFF
--- a/src/test/ceph_crypto.cc
+++ b/src/test/ceph_crypto.cc
@@ -135,6 +135,8 @@ void do_simple_crypto() {
   exit(0);
 }
 
+#if GTEST_HAS_DEATH_TEST
 TEST_F(ForkDeathTest, MD5) {
   ASSERT_EXIT(do_simple_crypto(), ::testing::ExitedWithCode(0), "^$");
 }
+#endif //GTEST_HAS_DEATH_TEST

--- a/src/test/os/TestFlatIndex.cc
+++ b/src/test/os/TestFlatIndex.cc
@@ -41,6 +41,7 @@ TEST(FlatIndex, FlatIndex) {
   EXPECT_EQ(0, index.cleanup());
 }
 
+#ifdef GTEST_HAS_DEATH_TEST
 TEST(FlatIndex, collection) {
   coll_t collection("ABC");
   const std::string base_path("PATH");
@@ -53,6 +54,7 @@ TEST(FlatIndex, collection) {
   vector<ghobject_t> ls;
   ASSERT_DEATH(index.collection_list_partial(hoid, 0, 0, 0, &ls, &hoid), "0");
 }
+#endif //GTEST_HAS_DEATH_TEST
 
 TEST(FlatIndex, created_unlink) {
   coll_t collection("ABC");


### PR DESCRIPTION
googletest does not support death tests on FreeBSD.  I've submitted a
patch upstream that trivially enables support, but in the meantime we
can't compile death tests for Ceph on FreeBSD.

https://groups.google.com/forum/#!topic/googletestframework/tjY6UjWgNOw

Signed-off-by: Alan Somers asomers@gmail.com
