### PR TITLE
doc: Remove redundant command for quick start preflight

### DIFF
--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -100,9 +100,6 @@ For Debian and Ubuntu distributions, perform the following steps:
 #. Add the release key::
 
 	wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | sudo apt-key add -
-	echo deb http://ceph.com/debian-dumpling/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
-	sudo apt-get update
-	sudo apt-get install ceph-deploy
 
 #. Add the Ceph packages to your repository. Replace ``{ceph-stable-release}``
    with a stable Ceph release (e.g., ``cuttlefish``, ``dumpling``, etc.). 


### PR DESCRIPTION
Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com

This patch removes a few commands, which are redundant with following
commands.

Btw, they are also unrelated with the subtitle of the section, which is
"Add the release key".
