### PR TITLE
Makefile-env.am: add prefix to certain sbin targets

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -27,7 +27,7 @@ bin_DEBUGPROGRAMS =
 ceph_sbindir = $(sbindir)
 
 # certain things go straight into /sbin, though!
-su_sbindir = /sbin
+su_sbindir = $(prefix)/sbin
 
 # C/C++ tests to build will be appended to this
 check_PROGRAMS =


### PR DESCRIPTION
Fixes: #6744
Add missing prefix to rules.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
