### PR TITLE
RBD Documentation and Example fixes for --image-format

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -143,7 +143,7 @@ Commands
   specified. Size will be the same as the parent snapshot.
 
   The parent snapshot must be protected (see `rbd snap protect`).
-  This requires format 2.
+  This requires image format 2.
 
 :command:`flatten` [*image-name*]
   If image is a clone, copy all shared blocks from the parent snapshot and
@@ -151,13 +151,13 @@ Commands
   parent snap and child.  The parent snapshot can be unprotected and
   deleted if it has no further dependent clones.
 
-  This requires format 2.
+  This requires image format 2.
 
 :command:`children` [*image-name*]
   List the clones of the image at the given snapshot. This checks
   every pool, and outputs the resulting poolname/imagename.
 
-  This requires format 2.
+  This requires image format 2.
 
 :command:`resize` [*image-name*] [--allow-shrink]
   Resizes rbd image. The size parameter also needs to be specified.
@@ -198,7 +198,7 @@ Commands
 
 :command:`cp` [*src-image*] [*dest-image*]
   Copies the content of a src-image into the newly created dest-image.
-  dest-image will have the same size, order, and format as src-image.
+  dest-image will have the same size, order, and image format as src-image.
 
 :command:`mv` [*src-image*] [*dest-image*]
   Renames an image.  Note: rename across pools is not supported.
@@ -226,14 +226,14 @@ Commands
   refer to this snapshot.  `rbd clone` will fail on a nonprotected
   snapshot.
 
-  This requires format 2.
+  This requires image format 2.
 
 :command:`snap` unprotect [*image-name*]
   Unprotect a snapshot from deletion (undo `snap protect`).  If cloned
   children remain, `snap unprotect` fails.  (Note that clones may exist
   in different pools than the parent snapshot.)
 
-  This requires format 2.
+  This requires image format 2.
 
 :command:`map` [*image-name*]
   Maps the specified image to a block device via the rbd kernel module.
@@ -351,7 +351,7 @@ To unmap an image::
 
 To create an image and a clone from it::
 
-       rbd import --format 2 image mypool/parent
+       rbd import --image-format 2 image mypool/parent
        rbd snap create --snap snapname mypool/parent
        rbd snap protect mypool/parent@snap
        rbd clone mypool/parent@snap otherpool/child
@@ -360,11 +360,11 @@ To create an image with a smaller stripe_unit (to better distribute small writes
 
        rbd -p mypool create myimage --size 102400 --stripe-unit 65536 --stripe-count 16
 
-To change an image from one format to another, export it and then
-import it as the desired format::
+To change an image from one image format to another, export it and then
+import it as the desired image format::
 
        rbd export mypool/myimage@snap /tmp/img
-       rbd import --format 2 /tmp/img mypool/myimage2
+       rbd import --image-format 2 /tmp/img mypool/myimage2
 
 To lock an image for exclusive use::
 

--- a/doc/rbd/rbd-snapshot.rst
+++ b/doc/rbd/rbd-snapshot.rst
@@ -177,7 +177,7 @@ a snapshot refers to the snapshot, so you **MUST** protect the snapshot before
 you clone it. The following diagram depicts the process.
 
 .. note:: Ceph only supports cloning for ``format 2`` images (i.e., created with 
-  ``rbd create --format 2``), and is not yet supported by the kernel ``rbd`` module. 
+  ``rbd create --image-format 2``), and is not yet supported by the kernel ``rbd`` module. 
   So you MUST use QEMU/KVM or ``librbd`` directly to access clones in the current
   release.
 


### PR DESCRIPTION
- RBD Documentation, --image-format wrongly specified as --format in examples
- RBD Documentation, better describe image format, to differentiate from --format
