### PR TITLE
Use clearer "local monitor storage" in log messages

### DIFF
--- a/src/mon/DataHealthService.cc
+++ b/src/mon/DataHealthService.cc
@@ -205,7 +205,7 @@ void DataHealthService::service_tick()
   DataStats &ours = stats[mon->messenger->get_myinst()];
 
   if (ours.latest_avail_percent <= g_conf->mon_data_avail_crit) {
-    derr << "reached critical levels of available space on data store"
+    derr << "reached critical levels of available space on local monitor storage"
          << " -- shutdown!" << dendl;
     force_shutdown();
     return;
@@ -218,7 +218,7 @@ void DataHealthService::service_tick()
   if (ours.latest_avail_percent <= g_conf->mon_data_avail_warn) {
     if (ours.latest_avail_percent != last_warned_percent)
       mon->clog.warn()
-	<< "reached concerning levels of available space on data store"
+	<< "reached concerning levels of available space on local monitor storage"
 	<< " (" << ours.latest_avail_percent << "\% free)\n";
     last_warned_percent = ours.latest_avail_percent;
   } else {


### PR DESCRIPTION
Signed-off-by: David Zafman david.zafman@inktank.com
