### PR TITLE
osd: fix bench block size

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4069,7 +4069,7 @@ void OSD::do_command(Connection *con, tid_t tid, vector<string>& cmd, bufferlist
     int64_t bsize;
     // default count 1G, size 4MB
     cmd_getval(cct, cmdmap, "count", count, (int64_t)1 << 30);
-    cmd_getval(cct, cmdmap, "bsize", bsize, (int64_t)4 << 20);
+    cmd_getval(cct, cmdmap, "size", bsize, (int64_t)4 << 20);
 
     bufferlist bl;
     bufferptr bp(bsize);

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -319,7 +319,7 @@ class TestObject(object):
         eq(self.object.read(3), 'bar')
         eq(self.object.read(3), 'baz')
 
-class TestMonCommand(object):
+class TestCommand(object):
 
     def setUp(self):
         self.rados = Rados(conffile='')
@@ -373,3 +373,12 @@ class TestMonCommand(object):
         d = json.loads(buf)
         assert('epoch' in d)
 
+    def test_osd_bench(self):
+        cmd = dict(prefix='bench', size=4096, count=8192)
+        ret, buf, err = self.rados.osd_command(0, json.dumps(cmd), '',
+                                               timeout=30)
+        eq(ret, 0)
+        assert len(err) > 0
+        out = json.loads(err)
+        eq(out['blocksize'], cmd['size'])
+        eq(out['bytes_written'], cmd['count'])


### PR DESCRIPTION
The command was declared to take 'size' in dumpling, but was trying to
read 'bsize' instead, so it always used the default of 4MiB. Change
the bench command to read 'size', so it matches what existing clients
are sending.

Fixes: #6795
Backport: emperor, dumpling
Signed-off-by: Josh Durgin josh.durgin@inktank.com
