### PR TITLE
qa: skip xfstest 002 in qemu

### DIFF
--- a/qa/run_xfstests_qemu.sh
+++ b/qa/run_xfstests_qemu.sh
@@ -7,4 +7,4 @@ chmod +x run_xfstests.sh
 # tests excluded fail in the current testing vm regardless of whether
 # rbd is used
 
-./run_xfstests.sh -c 1 -f xfs -t /dev/vdb -s /dev/vdc 1-7 9-17 19-26 28-49 51-61 63 66-67 69-79 83 85-105 108-110 112-135 137-170 174-191 193-204 206-217 220-227 230-231 233 235-241 243-249 251-262 264-278 281-286 288-289
+./run_xfstests.sh -c 1 -f xfs -t /dev/vdb -s /dev/vdc 1 3-7 9-17 19-26 28-49 51-61 63 66-67 69-79 83 85-105 108-110 112-135 137-170 174-191 193-204 206-217 220-227 230-231 233 235-241 243-249 251-262 264-278 281-286 288-289


### PR DESCRIPTION
Different versions of userspace utilities have slightly different output that
breaks this test. It also doesn't test much, so just skip it.

Signed-off-by: Josh Durgin josh.durgin@inktank.com
