### PR TITLE
rgw: initialize RGWUserAdminOpState::system_specified

### DIFF
--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -409,6 +409,7 @@ struct RGWUserAdminOpState {
     perm_specified = false;
     op_mask_specified = false;
     suspension_op = false;
+    system_specified = false;
     key_op = false;
     populated = false;
     initialized = false;


### PR DESCRIPTION
Fixes: #6829
We didn't init this member variable, which might cause that when
modifying user info that has this flag set the 'system' flag might
inadvertently reset.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
