### PR TITLE
mds: remove superfluous warning of releasing lease

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2518,13 +2518,16 @@ void Locker::process_request_cap_release(MDRequest *mdr, client_t client, const 
       if (dn) {
 	ClientLease *l = dn->get_client_lease(client);
 	if (l) {
-	  dout(10) << " removing lease on " << *dn << dendl;
+	  dout(10) << "process_cap_release removing lease on " << *dn << dendl;
 	  dn->remove_client_lease(l, this);
+	} else {
+	  dout(7) << "process_cap_release client." << client
+		  << " doesn't have lease on " << *dn << dendl;
 	}
       } else {
-	mds->clog.warn() << "client." << client << " released lease on dn "
-	    << dir->dirfrag() << "/" << dname << " which dne\n";
-     }
+	dout(7) << "process_cap_release client." << client << " released lease on dn "
+		<< dir->dirfrag() << "/" << dname << " which dne" << dendl;
+      }
     }
   }
 
@@ -2532,7 +2535,7 @@ void Locker::process_request_cap_release(MDRequest *mdr, client_t client, const 
   if (!cap)
     return;
 
-  dout(10) << "process_cap_update client." << client << " " << ccap_string(caps) << " on " << *in
+  dout(10) << "process_cap_release client." << client << " " << ccap_string(caps) << " on " << *in
 	   << (mdr ? "" : " (DEFERRED, no mdr)")
 	   << dendl;
     


### PR DESCRIPTION
When receiving the lease release message, it's possible that the lease
has already expired and the corresponding dentry has been trimmed from
the cache.

Fixes #5871

Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
