### PR TITLE
Mark libcls_kvs as a module

### DIFF
--- a/src/key_value_store/Makefile.am
+++ b/src/key_value_store/Makefile.am
@@ -1,6 +1,6 @@
 libcls_kvs_la_SOURCES = key_value_store/cls_kvs.cc
 libcls_kvs_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libcls_kvs_la_LDFLAGS = ${AM_LDFLAGS} -version-info 1:0:0 -export-symbols-regex '.*__cls_.*'
+libcls_kvs_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -export-symbols-regex '.*__cls_.*'
 radoslib_LTLIBRARIES += libcls_kvs.la
 
 noinst_HEADERS += \


### PR DESCRIPTION
Sorry - I missed this module in my last pull request (it got missed when I rebased the patch from 0.64 -> 0.72); I've tested in the Debian/Ubuntu packaging.
