### PR TITLE
rgw: don't error out on empty owner when setting acls

### DIFF
--- a/src/rgw/rgw_acl_s3.cc
+++ b/src/rgw/rgw_acl_s3.cc
@@ -454,8 +454,10 @@ int RGWAccessControlPolicy_S3::rebuild(RGWRados *store, ACLOwner *owner, RGWAcce
     return -EINVAL;
 
   ACLOwner *requested_owner = static_cast<ACLOwner_S3 *>(find_first("Owner"));
-  if (requested_owner && requested_owner->get_id().compare(owner->get_id()) != 0) {
-    return -EPERM;
+  if (requested_owner) {
+    const string& requested_id = requested_owner->get_id();
+    if (!requested_id.empty() && requested_id.compare(owner->get_id()) != 0)
+      return -EPERM;
   }
 
   RGWUserInfo owner_info;


### PR DESCRIPTION
Fixes: #6892
Backport: dumpling, emperor
s3cmd specifies empty owner field when trying to set acls on object
/ bucket. We errored out as it didn't match the current owner name, but
with this change we ignore it.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
