### PR TITLE
mon/OSDMonitor: fix 'osd pool set ...' int/float parsing

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2750,18 +2750,16 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
   if (pending_inc.new_pools.count(pool))
     p = pending_inc.new_pools[pool];
 
-  // accept val as a json string or int, and parse out int or float
-  // values from the string as needed
+  // accept val as a json string, but try to parse int or float values
+  // out in case we need them below.
   string val;
-  cmd_getval(g_ceph_context, cmdmap, "val", val);
+  if (!cmd_getval(g_ceph_context, cmdmap, "val", val)) {
+    return -EINVAL;
+  }
   string interr;
-  int64_t n = 0;
-  if (!cmd_getval(g_ceph_context, cmdmap, "val", n))
-    n = strict_strtoll(val.c_str(), 10, &interr);
+  int64_t n = strict_strtoll(val.c_str(), 10, &interr);
   string floaterr;
-  float f;
-  if (!cmd_getval(g_ceph_context, cmdmap, "val", f))
-    f = strict_strtod(val.c_str(), &floaterr);
+  float f = strict_strtod(val.c_str(), &floaterr);
 
   if (var == "size") {
     if (interr.length()) {


### PR DESCRIPTION
In 2fe0d0d97af95c22db80800f5b9da51f672d9407 I assumed that the command may
come with a range of JSON formats (string, int, float), but in reality the
client gets the schema via get_command_descriptions regardless of what
version it is running.  That means we only need to handle the string case. 
This fixes warnings like

2013-10-29 09:04:23.911996 7f38df7fe700 -1 bad boost::get: key val is not
type long 2013-10-29 09:04:23.934971 7f38df7fe700 -1 0x7f38df7f9578 
2013-10-29 09:04:23.935014 7f38df7fe700 -1 bad boost::get: key val is not
type float 2013-10-29 09:04:23.946177 7f38df7fe700 -1 0x7f38df7f9578

which are noted in #6673.

Signed-off-by: Sage Weil sage@inktank.com
