### PR TITLE
sysvinit, upstart: use df -P when weighting new OSDs

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -322,7 +322,7 @@ for name in $what; do
 		    get_conf osd_location_hook "$BINDIR/ceph-crush-location" "osd crush location hook"
 		    osd_location=`$osd_location_hook --cluster ceph --id $id --type osd`
 		    get_conf osd_weight "" "osd crush initial weight"
-		    defaultweight="$(do_cmd "df $osd_data/. | tail -1 | awk '{ d= \$2/1073741824 ; r = sprintf(\"%.2f\", d); print r }'")"
+		    defaultweight="$(do_cmd "df -P -k $osd_data/. | tail -1 | awk '{ d= \$2/1073741824 ; r = sprintf(\"%.2f\", d); print r }'")"
 		    get_conf osd_keyring "$osd_data/keyring" "keyring"
 		    do_cmd "timeout 10 $BINDIR/ceph \
 			--name=osd.$id \

--- a/src/upstart/ceph-osd.conf
+++ b/src/upstart/ceph-osd.conf
@@ -24,7 +24,7 @@ pre-start script
 	fi
 	location="$($hook --cluster ${cluster:-ceph} --id $id --type osd)"
 	weight="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_initial_weight || :)"
-	defaultweight=`df /var/lib/ceph/osd/${cluster:-ceph}-$id/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }'`
+	defaultweight=`df -P -k /var/lib/ceph/osd/${cluster:-ceph}-$id/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }'`
 	ceph \
             --cluster="${cluster:-ceph}" \
             --name="osd.$id" \


### PR DESCRIPTION
This avoids parsing out the wrong value when a long device name makes df wrap
over two lines.

Fixes: #6699 Reported-by: Jan Harkes jaharkes@cs.cmu.edu Reviewed-by: Noah
Watkins noah.watkins@inktank.com Signed-off-by: Sage Weil
sage@inktank.com
