### PR TITLE
README: update a list of build deps for rpm-based systems

### DIFF
--- a/README
+++ b/README
@@ -99,7 +99,6 @@ To build the documentation, ensure that you are in the top-level `/ceph director
 Build Prerequisites
 ===================
 
-
 debian-based
 ------------
 To build the source code, you must install the following:
@@ -144,12 +143,18 @@ These are the rpm packages needed to install in an rpm-based OS:
     autoconf
     automake
     gcc
+    gcc-c++
     make
     libtool
     python-argparse
     python-flask
     libuuid-devel
+    keyutils-libs-devel
+    cryptopp-devel
     nss-devel
+    fcgi-devel
+    expat-devel
+    libcurl-devel
     fuse-devel
     gperftools-devel
     libedit-devel
@@ -161,5 +166,5 @@ These are the rpm packages needed to install in an rpm-based OS:
 
 For example:
 
-      $ yum install autoconf automake gcc make libtool python-argparse python-flask libuuid-devel nss-devel fuse-devel gperftools-devel libedit-devel libatomic_ops-devel snappy-devel leveldb-devel libaio-devel boost-devel
+	$ yum install autoconf automake gcc gcc-c++ make libtool python-argparse python-flask libuuid-devel keyutils-libs-devel cryptopp-devel nss-devel fcgi-devel expat-devel libcurl-devel fuse-devel gperftools-devel libedit-devel libatomic_ops-devel snappy-devel leveldb-devel libaio-devel boost-devel
 


### PR DESCRIPTION
A list of build dependencies for rpm-based OSes is missing a few items.
This fills in the gaps.

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
