### PR TITLE
osd: read into correct variable for magic string

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -731,7 +731,7 @@ int OSD::peek_meta(ObjectStore *store, std::string& magic,
 {
   string val;
 
-  int r = store->read_meta("magic", &magic);
+  int r = store->read_meta("magic", &val);
   if (r < 0)
     return r;
   magic = val;


### PR DESCRIPTION
4d140a71a1a48081b449b7d8dde808eb6e74c6b2 refactored this and introduced a
bug. peek_meta() was accidentally reading into magic, then replacing magic
with val, which was always the empty string, resulting in the osd always
failing to start due to 'mismatched' magic values.

Signed-off-by: Josh Durgin josh.durgin@inktank.com
