### PR TITLE
Call --mbrtogpt on journal run of sgdisk should the drive require a GPT ...

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -850,6 +850,7 @@ def prepare_journal_dev(
                     num=num,
                     uuid=ptype,
                     ),
+                '--mbrtogpt',
                 '--',
                 journal,
                 ],


### PR DESCRIPTION
Call --mbrtogpt on journal run of sgdisk should the drive require a GPT-based table.
