### PR TITLE
init, upstart: prevent daemons being started by both

### DIFF
--- a/src/ceph_common.sh
+++ b/src/ceph_common.sh
@@ -50,6 +50,10 @@ check_host() {
 
     #echo host for $name is $host, i am $hostname
 
+    if [ -e "/var/lib/ceph/$type/ceph-$id/upstart" ]; then
+	return 1
+    fi
+
     # sysvinit managed instance in standard location?
     if [ -e "/var/lib/ceph/$type/ceph-$id/sysvinit" ]; then
 	host="$hostname"

--- a/src/upstart/ceph-mds-all-starter.conf
+++ b/src/upstart/ceph-mds-all-starter.conf
@@ -9,7 +9,7 @@ script
   # TODO what's the valid charset for cluster names and mds ids?
   find -L /var/lib/ceph/mds/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
   | while read f; do
-    if [ -e "/var/lib/ceph/mds/$f/done" ] && [ -e "/var/lib/ceph/mds/$f/upstart" ]; then
+    if [ -e "/var/lib/ceph/mds/$f/done" ] && [ -e "/var/lib/ceph/mds/$f/upstart" ] && [ ! -e "/var/lib/ceph/mds/$f/sysvinit" ]; then
         cluster="${f%%-*}"
         id="${f#*-}"
         initctl emit ceph-mds cluster="$cluster" id="$id"

--- a/src/upstart/ceph-mon-all-starter.conf
+++ b/src/upstart/ceph-mon-all-starter.conf
@@ -9,7 +9,7 @@ script
   # TODO what's the valid charset for cluster names and mon ids?
   find -L /var/lib/ceph/mon/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
   | while read f; do
-    if [ -e "/var/lib/ceph/mon/$f/done" ] && [ -e "/var/lib/ceph/mon/$f/upstart" ]; then
+    if [ -e "/var/lib/ceph/mon/$f/done" ] && [ -e "/var/lib/ceph/mon/$f/upstart" ] && [ ! -e "/var/lib/ceph/mon/$f/sysvinit" ]; then
         cluster="${f%%-*}"
         id="${f#*-}"
 

--- a/src/upstart/ceph-osd-all-starter.conf
+++ b/src/upstart/ceph-osd-all-starter.conf
@@ -13,7 +13,7 @@ script
   # TODO what's the valid charset for cluster names and osd ids?
   find -L /var/lib/ceph/osd/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
   | while read f; do
-    if [ -e "/var/lib/ceph/osd/$f/ready" ] && [ -e "/var/lib/ceph/osd/$f/upstart" ]; then
+    if [ -e "/var/lib/ceph/osd/$f/ready" ] && [ -e "/var/lib/ceph/osd/$f/upstart" ] && [ ! -e "/var/lib/ceph/osd/$f/sysvinit" ]; then
         cluster="${f%%-*}"
         id="${f#*-}"
 	initctl emit ceph-osd cluster="$cluster" id="$id"


### PR DESCRIPTION
There can be only one init system starting a daemon. If there is a host entry
in ceph.conf for a daemon, sysvinit would try to start it even if the
daemon's directory did not include a sysvinit file. This preserves backwards
compatibility with older installs using sysvinit, but if an upstart file is
present in the daemon's directory, upstart will try to start them, regardless
of host entries in ceph.conf.

If there's an upstart file in a daemon's directory and a host entry for that
daemon in ceph.conf, both sysvinit and upstart would attempt to manage it.

Fix this by only starting daemons if the marker file for the other init
system is not present. This maintains backwards compatibility with older
installs using neither sysvinit or upstart marker files, and does not break
any valid configurations. The only configuration that would break is one with
both sysvinit and upstart files present for the same daemon.

Backport: emperor, dumpling
Reported-by: Tim Spriggs tims@uahirise.org 
Signed-off-by: Josh Durgin josh.durgin@inktank.com
