### PR TITLE
Fix radosgw init/upstart scripts to set user & ownership correctly

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -73,11 +73,12 @@ case "$1" in
             log_file=`$RADOSGW -n $name --show-config-value log_file`
             if [ -n "$log_file" ] && [ ! -e "$log_file" ]; then
                 touch "$log_file"
-                chown $user $log_file
             fi
+            chown $user $log_file
+            chown $user /var/run/ceph
 
             echo "Starting $name..."
-            start-stop-daemon --start -u $user -x $RADOSGW -- -n $name
+            start-stop-daemon --start -c $user -x $RADOSGW -- -n $name
         done
         daemon_is_running $RADOSGW
         ;;

--- a/src/upstart/radosgw-all-starter.conf
+++ b/src/upstart/radosgw-all-starter.conf
@@ -6,13 +6,20 @@ task
 
 script
   set -e
+  DEFAULT_USER='www-data'
   # TODO what's the valid charset for cluster names and daemon ids?
   find -L /var/lib/ceph/radosgw/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
   | while read f; do
     if [ -e "/var/lib/ceph/radosgw/$f/done" ]; then
         cluster="${f%%-*}"
         id="${f#*-}"
-        initctl emit radosgw cluster="$cluster" id="$id"
+        cephconf=`which ceph-conf`
+        radosgw=`which radosgw`
+        log_file=`$radosgw -n client.$id --show-config-value log_file`
+        user=`$cephconf -n client.$id user` || true
+        if [ -z "$user" ]; then
+           user="$DEFAULT_USER"
+        fi emit radosgw cluster="$cluster" id="$id" user="$user" log_file="$log_file"
     fi
   done
 end script

--- a/src/upstart/radosgw.conf
+++ b/src/upstart/radosgw.conf
@@ -12,15 +12,19 @@ pre-start script
     set -e
     test -x /usr/bin/radosgw || { stop; exit 0; }
     test -d "/var/lib/ceph/radosgw/${cluster:-ceph}-$id" || { stop; exit 0; }
-
-    install -d -m0755 /var/run/ceph
+    install -d -m0755 $user /var/run/ceph
+    if [ -n "$log_file" ] && [ ! -e "$log_file" ]; then
+        touch "$log_file"
+    fi
+    chown $user $log_file
 end script
 
 instance ${cluster:-ceph}/$id
 export cluster
 export id
+export user
 
 # this breaks oneiric
 #usage "cluster = name of cluster (defaults to 'ceph'); id = mds instance id"
 
-exec /usr/bin/radosgw --cluster="${cluster:-ceph}" --id "$id" -f
+exec su -s /bin/sh -c 'exec /usr/bin/radosgw --cluster="${cluster:-ceph}" --id "$id" -f' $user


### PR DESCRIPTION
This sets it so radosgw doesn't run as root by default on ubuntu.
Set ownership on /var/run/ceph and ceph log file to allow it to startup
appropriately
