### PR TITLE
6748: rgw: Optionally return the bucket name in a response header.

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -732,6 +732,7 @@ OPTION(rgw_replica_log_obj_prefix, OPT_STR, "replica_log") //
 OPTION(rgw_bucket_quota_ttl, OPT_INT, 600) // time for cached bucket stats to be cached within rgw instance
 OPTION(rgw_bucket_quota_soft_threshold, OPT_DOUBLE, 0.95) // threshold from which we don't rely on cached info for quota decisions
 OPTION(rgw_bucket_quota_cache_size, OPT_INT, 10000) // number of entries in bucket quota cache
+OPTION(rgw_expose_bucket, OPT_BOOL, false) // Return the bucket name in the 'Bucket' response header
 
 OPTION(mutex_perf_counter, OPT_BOOL, false) // enable/disable mutex perf counter
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -389,10 +389,8 @@ void RGWProcess::handle_request(RGWRequest *req)
     goto done;
   }
 
-  if (s->expect_cont)
-    dump_continue(s);
-
   req->log(s, "executing");
+  op->pre_exec();
   op->execute();
   op->complete();
 done:

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -395,6 +395,14 @@ static int rgw_build_policies(RGWRados *store, struct req_state *s, bool only_bu
   return ret;
 }
 
+static void rgw_bucket_object_pre_exec(struct req_state *s)
+{
+  if (s->expect_cont)
+    dump_continue(s);
+
+  dump_bucket_from_state(s);  
+}
+
 int RGWGetObj::verify_permission()
 {
   obj.init(s->bucket, s->object_str);
@@ -790,6 +798,11 @@ int RGWGetObj::get_data_cb(bufferlist& bl, off_t bl_ofs, off_t bl_len)
   return send_response_data(bl, bl_ofs, bl_len);
 }
 
+void RGWGetObj::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
+}
+
 void RGWGetObj::execute()
 {
   void *handle = NULL;
@@ -983,6 +996,11 @@ int RGWStatBucket::verify_permission()
   return 0;
 }
 
+void RGWStatBucket::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
+}
+
 void RGWStatBucket::execute()
 {
   RGWUserBuckets buckets;
@@ -1028,6 +1046,11 @@ int RGWListBucket::parse_max_keys()
   }
 
   return 0;
+}
+
+void RGWListBucket::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
 }
 
 void RGWListBucket::execute()
@@ -1092,6 +1115,11 @@ static int forward_request_to_master(struct req_state *s, obj_version *objv, RGW
   }
 
   return 0;
+}
+
+void RGWCreateBucket::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
 }
 
 void RGWCreateBucket::execute()
@@ -1215,6 +1243,11 @@ int RGWDeleteBucket::verify_permission()
     return -EACCES;
 
   return 0;
+}
+
+void RGWDeleteBucket::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
 }
 
 void RGWDeleteBucket::execute()
@@ -1375,6 +1408,11 @@ void RGWPutObj::dispose_processor(RGWPutObjProcessor *processor)
   delete processor;
 }
 
+void RGWPutObj::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
+}
+
 void RGWPutObj::execute()
 {
   RGWPutObjProcessor *processor = NULL;
@@ -1531,6 +1569,11 @@ void RGWPostObj::dispose_processor(RGWPutObjProcessor *processor)
   delete processor;
 }
 
+void RGWPostObj::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
+}
+
 void RGWPostObj::execute()
 {
   RGWPutObjProcessor *processor = NULL;
@@ -1631,6 +1674,11 @@ int RGWPutMetadata::verify_permission()
   return 0;
 }
 
+void RGWPutMetadata::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
+}
+
 void RGWPutMetadata::execute()
 {
   const char *meta_prefix = RGW_ATTR_META_PREFIX;
@@ -1695,6 +1743,11 @@ int RGWDeleteObj::verify_permission()
     return -EACCES;
 
   return 0;
+}
+
+void RGWDeleteObj::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
 }
 
 void RGWDeleteObj::execute()
@@ -1849,6 +1902,11 @@ void RGWCopyObj::progress_cb(off_t ofs)
   last_ofs = ofs;
 }
 
+void RGWCopyObj::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
+}
+
 void RGWCopyObj::execute()
 {
   rgw_obj src_obj, dst_obj;
@@ -1899,6 +1957,11 @@ int RGWGetACLs::verify_permission()
   return 0;
 }
 
+void RGWGetACLs::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
+}
+
 void RGWGetACLs::execute()
 {
   stringstream ss;
@@ -1922,6 +1985,11 @@ int RGWPutACLs::verify_permission()
     return -EACCES;
 
   return 0;
+}
+
+void RGWPutACLs::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
 }
 
 void RGWPutACLs::execute()
@@ -2159,6 +2227,11 @@ int RGWInitMultipart::verify_permission()
   return 0;
 }
 
+void RGWInitMultipart::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
+}
+
 void RGWInitMultipart::execute()
 {
   bufferlist aclbl;
@@ -2254,6 +2327,11 @@ int RGWCompleteMultipart::verify_permission()
     return -EACCES;
 
   return 0;
+}
+
+void RGWCompleteMultipart::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
 }
 
 void RGWCompleteMultipart::execute()
@@ -2405,6 +2483,11 @@ int RGWAbortMultipart::verify_permission()
   return 0;
 }
 
+void RGWAbortMultipart::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
+}
+
 void RGWAbortMultipart::execute()
 {
   ret = -EINVAL;
@@ -2465,6 +2548,11 @@ int RGWListMultipart::verify_permission()
   return 0;
 }
 
+void RGWListMultipart::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
+}
+
 void RGWListMultipart::execute()
 {
   map<string, bufferlist> xattrs;
@@ -2487,6 +2575,11 @@ int RGWListBucketMultiparts::verify_permission()
     return -EACCES;
 
   return 0;
+}
+
+void RGWListBucketMultiparts::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
 }
 
 void RGWListBucketMultiparts::execute()
@@ -2533,6 +2626,11 @@ int RGWDeleteMultiObj::verify_permission()
     return -EACCES;
 
   return 0;
+}
+
+void RGWDeleteMultiObj::pre_exec()
+{
+    rgw_bucket_object_pre_exec(s);
 }
 
 void RGWDeleteMultiObj::execute()

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -64,6 +64,7 @@ public:
   virtual bool prefetch_data() { return false; }
   virtual int verify_permission() = 0;
   virtual int verify_op_mask();
+  virtual void pre_exec() {}
   virtual void execute() = 0;
   virtual void send_response() {}
   virtual void complete() { send_response(); }
@@ -123,6 +124,7 @@ public:
     this->get_data = get_data;
   }
   int verify_permission();
+  void pre_exec();
   void execute();
   int read_user_manifest_part(rgw_bucket& bucket, RGWObjEnt& ent, RGWAccessControlPolicy *bucket_policy, off_t start_ofs, off_t end_ofs);
   int iterate_user_manifest_parts(rgw_bucket& bucket, string& obj_prefix, RGWAccessControlPolicy *bucket_policy,
@@ -217,6 +219,7 @@ public:
     is_truncated = false;
   }
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual int get_params() = 0;
@@ -246,6 +249,7 @@ public:
   ~RGWStatBucket() {}
 
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual void send_response() = 0;
@@ -268,6 +272,7 @@ public:
   RGWCreateBucket() : ret(0) {}
 
   int verify_permission();
+  void pre_exec();
   void execute();
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *h) {
     RGWOp::init(store, s, h);
@@ -289,6 +294,7 @@ public:
   RGWDeleteBucket() : ret(0) {}
 
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual void send_response() = 0;
@@ -331,6 +337,7 @@ public:
   void dispose_processor(RGWPutObjProcessor *processor);
 
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual int get_params() = 0;
@@ -370,6 +377,7 @@ public:
   }
 
   int verify_permission();
+  void pre_exec();
   void execute();
 
   RGWPutObjProcessor *select_processor();
@@ -402,6 +410,7 @@ public:
     policy.set_ctx(s->cct);
   }
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual int get_params() = 0;
@@ -418,6 +427,7 @@ public:
   RGWDeleteObj() : ret(0) {}
 
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual void send_response() = 0;
@@ -486,6 +496,7 @@ public:
     dest_policy.set_ctx(s->cct);
   }
   int verify_permission();
+  void pre_exec();
   void execute();
   void progress_cb(off_t ofs);
 
@@ -506,6 +517,7 @@ public:
   RGWGetACLs() : ret(0) {}
 
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual void send_response() = 0;
@@ -530,6 +542,7 @@ public:
   }
 
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual int get_policy_from_state(RGWRados *store, struct req_state *s, stringstream& ss) { return 0; }
@@ -625,6 +638,7 @@ public:
     policy.set_ctx(s->cct);
   }
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual int get_params() = 0;
@@ -654,6 +668,7 @@ public:
   }
 
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual int get_params() = 0;
@@ -670,6 +685,7 @@ public:
   RGWAbortMultipart() : ret(0) {}
 
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual void send_response() = 0;
@@ -698,6 +714,7 @@ public:
     policy = RGWAccessControlPolicy(s->cct);
   }
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual int get_params() = 0;
@@ -801,6 +818,7 @@ public:
   }
 
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual int get_params() = 0;
@@ -831,6 +849,7 @@ public:
     status_dumped = false;
   }
   int verify_permission();
+  void pre_exec();
   void execute();
 
   virtual int get_params() = 0;

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -262,8 +262,11 @@ void dump_pair(struct req_state *s, const char *key, const char *value)
 
 void dump_bucket_from_state(struct req_state *s)
 {
-  if (!s->bucket_name_str.empty())
-    s->cio->print("Bucket: \"%s\"\n", s->bucket_name_str.c_str());
+  int expose_bucket = g_conf->rgw_expose_bucket;
+  if (expose_bucket) {
+    if (!s->bucket_name_str.empty())
+      s->cio->print("Bucket: \"%s\"\n", s->bucket_name_str.c_str());
+  }
 }
 
 void dump_object_from_state(struct req_state *s)
@@ -450,6 +453,7 @@ void abort_early(struct req_state *s, RGWOp *op, int err_no)
   }
   set_req_state_err(s, err_no);
   dump_errno(s);
+  dump_bucket_from_state(s);
   end_header(s, op);
   rgw_flush_formatter_and_reset(s, s->formatter);
   perfcounter->inc(l_rgw_failed_req);


### PR DESCRIPTION
This can be useful in situations where accounting of traffic is done externally
when for example HTTP traffic is cached by a reverse proxy like Varnish.

Since not all traffic reaches the RGW daemon it can't fully account all traffic
and this the caching proxy needs to be aware of which bucket the request came for.

Signed-off-by: Wido den Hollander wido@42on.com
