### PR TITLE
replace sgdisk subprocess calls with a helper

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -273,7 +273,7 @@ def command_check_call(arguments):
     of making sure that executables *will* be found and will error nicely
     otherwise.
     """
-    _check_command_executable(arguments)
+    arguments = _get_command_executable(arguments)
     return subprocess.check_call(arguments)
 
 


### PR DESCRIPTION
This fixes issue 6979, but most importantly adds a couple of things to `ceph-disk` that should get used a bit more and hopefully used in the other `ceph-*` scripts.
- There was too much repetition for `subprocess.*` calls that were the same. By introducing a helper the repetition gets reduced and we now can handle errors for `subprocess` calls in one place.
- Adds 2 Exceptions, because having custom messaging in the error was needed (something that the existing ones did not provide)
- The `try/except` block at the end now just raises `SystemExit` vs. printing to `stderr` and then calling `sys.exit(1)`. Raising that exception achieves the _same_ functionality and it is just one call and easier to read.

This is how the error looks before these changes:

```
vagrant@node1:~$ ceph-disk list
Traceback (most recent call last):
  File "/usr/sbin/ceph-disk", line 2342, in <module>
    main()
  File "/usr/sbin/ceph-disk", line 2331, in main
    args.func(args)
  File "/usr/sbin/ceph-disk", line 2008, in main_list
    part_uuid = get_partition_uuid(dev)
  File "/usr/sbin/ceph-disk", line 1918, in get_partition_uuid
    stderr = subprocess.PIPE).stdout.read()
  File "/usr/lib/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1249, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

This is how it looks now:

```
vagrant@node1:~$ ceph-disk list
ceph-disk ExecutableNotFound: sgdisk not in path. Could not run command: sgdisk -i 1 /dev/sda
```
