### PR TITLE
radosgw: increase nofiles ulimit on sysvinit machines

### DIFF
--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -80,7 +80,7 @@ case "$1" in
             fi
 
             #start-stop-daemon --start -u $user -x $RADOSGW -- -n $name
-            daemon --user="$user" "$RADOSGW -n $name"
+            daemon --user="$user" "ulimit -n 32768; $RADOSGW -n $name"
             echo "Starting $name..."
         done
         daemon_is_running $RADOSGW


### PR DESCRIPTION
Clusters with many OSDs require a higher nofiles ulimit than the RHEL default. Increase it.

Tested-by: Dan van der Ster daniel.vanderster@cern.ch
Signed-off-by: Dan van der Ster daniel.vanderster@cern.ch
