### PR TITLE
Fix Issue #6992

### DIFF
--- a/src/msg/Pipe.cc
+++ b/src/msg/Pipe.cc
@@ -1342,10 +1342,8 @@ void Pipe::stop()
 {
   ldout(msgr->cct,10) << "stop" << dendl;
   assert(pipe_lock.is_locked());
-  state = STATE_CLOSED;
-  state_closed.set(1);
+  state = STATE_CLOSING;
   cond.Signal();
-  shutdown_socket();
 }
 
 


### PR DESCRIPTION
In Pipe::stop, set the state = STATE_CLOSING rather than STATE_CLOSED, so the remote Pipe could also be stopped. http://tracker.ceph.com/issues/6992
