### PR TITLE
vstart: Update apache conf to run against apache 2.4

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -536,10 +536,21 @@ $DAEMONOPTS
 EOF
 		    mkdir -p $CEPH_OUT_DIR/htdocs
 		    mkdir -p $CEPH_OUT_DIR/fastcgi_sock
+		    APACHE2_MODULE_PATH="/usr/lib/apache2/modules"
+		    APACHE2_EXTRA_MODULES_NAME="mpm_prefork authz_core"
+		    for module in $APACHE2_EXTRA_MODULES_NAME
+		    do
+			    if [ -f "${APACHE2_MODULE_PATH}/mod_${module}.so" ]; then
+				    APACHE2_EXTRA_MODULES="${APACHE2_EXTRA_MODULES}LoadModule ${module}_module ${APACHE2_MODULE_PATH}/mod_${module}.so
+"
+			    fi 
+		    done
+		    echo $APACHE2_EXTRA_MODULES
 		    cat <<EOF > $CEPH_OUT_DIR/apache.conf
 LoadModule env_module /usr/lib/apache2/modules/mod_env.so
 LoadModule rewrite_module /usr/lib/apache2/modules/mod_rewrite.so
 LoadModule fastcgi_module /usr/lib/apache2/modules/mod_fastcgi.so
+$APACHE2_EXTRA_MODULES
 
 Listen $rgwport
 ServerName rgwtest.example.com


### PR DESCRIPTION
Tested with ./vstart.sh -r -l -n -x was not working anymore on ubuntu 13.10 as it uses apache 2.4, which one introduces changes in configuration and default options requierement.

Might need testing on previous versions of apache.

Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com
