### PR TITLE
mon: move supported_commands fields, methods into Monitor, and fix leak

### DIFF
--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -180,10 +180,10 @@ void Elector::victory()
   const MonCommand *cmds;
   int cmdsize;
   if (use_classic_commands) {
-    get_classic_monitor_commands(&cmds, &cmdsize);
+    mon->get_classic_monitor_commands(&cmds, &cmdsize);
     cmds_bl = &mon->get_classic_commands_bl();
   } else {
-    get_locally_supported_monitor_commands(&cmds, &cmdsize);
+    mon->get_locally_supported_monitor_commands(&cmds, &cmdsize);
     cmds_bl = &mon->get_supported_commands_bl();
   }
   
@@ -324,12 +324,12 @@ void Elector::handle_victory(MMonElection *m)
     int cmdsize;
     bufferlist::iterator bi = m->commands.begin();
     MonCommand::decode_array(&new_cmds, &cmdsize, bi);
-    set_leader_supported_commands(new_cmds, cmdsize);
+    mon->set_leader_supported_commands(new_cmds, cmdsize);
   } else { // they are a legacy monitor; use known legacy command set
     const MonCommand *new_cmds;
     int cmdsize;
-    get_classic_monitor_commands(&new_cmds, &cmdsize);
-    set_leader_supported_commands(new_cmds, cmdsize);
+    mon->get_classic_monitor_commands(&new_cmds, &cmdsize);
+    mon->set_leader_supported_commands(new_cmds, cmdsize);
   }
 
   m->put();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -140,6 +140,9 @@ public:
 
   CompatSet features;
 
+  const MonCommand *leader_supported_mon_commands;
+  int leader_supported_mon_commands_size;
+
 private:
   void new_tick();
   friend class C_Mon_Tick;
@@ -866,6 +869,16 @@ public:
     void _convert_machines();
     void _convert_paxos();
   };
+
+  static void format_command_descriptions(const MonCommand *commands,
+					  unsigned commands_size,
+					  Formatter *f,
+					  bufferlist *rdata);
+  void get_locally_supported_monitor_commands(const MonCommand **cmds, int *count);
+  void get_classic_monitor_commands(const MonCommand **cmds, int *count);
+  void get_leader_supported_commands(const MonCommand **cmds, int *count);
+  /// the Monitor owns this pointer once you pass it in
+  void set_leader_supported_commands(const MonCommand *cmds, int size);
 };
 
 #define CEPH_MON_FEATURE_INCOMPAT_BASE CompatSet::Feature (1, "initial feature set (~v.18)")
@@ -928,16 +941,5 @@ struct MonCommand {
   }
 };
 WRITE_CLASS_ENCODER(MonCommand);
-
-void get_command_descriptions(const MonCommand *commands,
-			      unsigned commands_size,
-			      Formatter *f,
-			      bufferlist *rdata);
-void get_locally_supported_monitor_commands(const MonCommand **cmds, int *count);
-void get_classic_monitor_commands(const MonCommand **cmds, int *count);
-void get_leader_supported_commands(const MonCommand **cmds, int *count);
-/// the Monitor owns this pointer once you pass it in
-void set_leader_supported_commands(const MonCommand *cmds, int size);
-
 
 #endif

--- a/src/test/common/get_command_descriptions.cc
+++ b/src/test/common/get_command_descriptions.cc
@@ -45,7 +45,7 @@ static void json_print(const MonCommand *mon_commands, int size)
 {
   bufferlist rdata;
   Formatter *f = new_formatter("json");
-  get_command_descriptions(mon_commands, size, f, &rdata);
+  Monitor::format_command_descriptions(mon_commands, size, f, &rdata);
   delete f;
   string data(rdata.c_str(), rdata.length());
   cout << data << std::endl;


### PR DESCRIPTION
We were leaking the static leader_supported_mon_commands.  Move this into the
class so that we can clean up in the destructor.

Rename get_command_descriptions -> format_command_descriptions.

Fixes: #7009 Signed-off-by: Sage Weil sage@inktank.com
