### PR TITLE
Add backward comptible acting set until all OSDs updated

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -528,6 +528,9 @@ OPTION(osd_max_object_size, OPT_U64, 100*1024L*1024L*1024L) // OSD's maximum obj
 OPTION(osd_max_attr_size, OPT_U64, 0)
 
 OPTION(osd_objectstore, OPT_STR, "filestore")  // ObjectStore backend type
+// Override maintaining compatibility with older OSDs
+// Set to true for testing.  Users should NOT set this.
+OPTION(osd_debug_override_acting_compat, OPT_BOOL, false)
 
 /// filestore wb throttle limits
 OPTION(filestore_wbthrottle_enable, OPT_BOOL, true)


### PR DESCRIPTION
Add configuration variable to use compatible acting set until
we can also check in osdmap that all OSDs are updated.

Fixes: #6990

Signed-off-by: David Zafman david.zafman@inktank.com
