### PR TITLE
upstart: add rbdmap script

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -119,6 +119,7 @@ binary-arch: build install
 	# per package, so do this ourselves
 	install -d -m0755 debian/ceph/etc/init
 	install -m0644 src/upstart/ceph*.conf debian/ceph/etc/init
+	install -m0644 src/upstart/rbdmap.conf debian/ceph/etc/init
 	install -d -m0755 debian/ceph-mds/etc/init
 	mv debian/ceph/etc/init/ceph-mds* debian/ceph-mds/etc/init
 	install -d -m0755 debian/radosgw/etc/init

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -173,6 +173,7 @@ EXTRA_DIST += \
 	$(srcdir)/upstart/radosgw.conf \
 	$(srcdir)/upstart/radosgw-all.conf \
 	$(srcdir)/upstart/radosgw-all-starter.conf \
+	$(srcdir)/upstart/rbdmap.conf \
 	ceph.in \
 	ceph-disk \
 	ceph-disk-prepare \

--- a/src/upstart/rbdmap.conf
+++ b/src/upstart/rbdmap.conf
@@ -1,0 +1,48 @@
+# rbdmap - Ceph RBD Mapping
+#
+# This script does not manage mount and unmount fs which depends on rbd device.
+# You should use _netdev option in fstab to mount and umount in the correct order.
+
+description "ceph rbd mapping"
+
+start on (started networking
+    and remote-filesystems)
+stop on unmounted-remote-filesystems
+
+env RBDMAPFILE="/etc/ceph/rbdmap"
+
+pre-start script
+    if [ ! -f "$RBDMAPFILE" ]; then
+        exit 0
+    fi
+
+    while read DEV PARAMS; do
+        case "$DEV" in
+          ""|\#*)
+            continue
+            ;;
+          */*)
+            ;;
+          *)
+            DEV=rbd/$DEV
+            ;;
+        esac
+        for PARAM in $(echo $PARAM | tr ',' '\n'); do
+            CMDPARAMS="$CMDPARAMS --$(echo $PARAM | tr '=' ' ')"
+        done
+        if [ ! -b /dev/rbd/$DEV ]; then
+            echo "rbd map $DEV"
+            rbd map $DEV $CMDPARAMS
+        fi
+    done < $RBDMAPFILE
+end script
+
+post-stop script
+    if ls /dev/rbd[0-9]* >/dev/null 2>&1; then
+        for DEV in /dev/rbd[0-9]*; do
+            echo "rbd unmap $DEV"
+            rbd unmap $DEV
+        done
+    fi
+end script
+


### PR DESCRIPTION
Upstart script for mapping / unmapping rbd device based on /etc/ceph/rbdmap file.
It does not mount or unmount filesystem, this part should be performed by _netdev option in fstab.

Signed-off-by: Laurent Barbe laurent@ksperis.com
