### PR TITLE
mon: fix forwarded request features when requests are resent

### DIFF
--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -659,8 +659,10 @@ public:
     bufferlist request_bl;
     MonSession *session;
     ConnectionRef con;
+    uint64_t con_features;
     entity_inst_t client_inst;
 
+    RoutedRequest() : tid(0), session(NULL), con_features(0) {}
     ~RoutedRequest() {
       if (session)
 	session->put();


### PR DESCRIPTION
Pass the features in explicitly so that we can use messages we've just 
decoded in resend_routed_requests().

Keep the features in struct RoutedRequest.

Renamed conn_features -> con_features while we are here.

Signed-off-by: Sage Weil sage@inktank.com
