### PR TITLE
ceph_argparse: kill _daemon versions of argparse calls

### DIFF
--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -249,8 +249,7 @@ bool ceph_argparse_binary_flag(std::vector<const char*> &args,
 }
 
 static bool va_ceph_argparse_witharg(std::vector<const char*> &args,
-	std::vector<const char*>::iterator &i, std::string *ret, bool cli,
-	va_list ap)
+	std::vector<const char*>::iterator &i, std::string *ret, va_list ap)
 {
   const char *first = *i;
   char tmp[strlen(first)+1];
@@ -274,12 +273,8 @@ static bool va_ceph_argparse_witharg(std::vector<const char*> &args,
       else if (first[strlen_a] == '\0') {
 	// find second part (or not)
 	if (i+1 == args.end()) {
-	  if (cli) {
-	    cerr << "Option " << *i << " requires an argument." << std::endl;
-	    _exit(1);
-	  } else {
-	    return false;
-	  }
+	  cerr << "Option " << *i << " requires an argument." << std::endl;
+	  _exit(1);
 	}
 	i = args.erase(i);
 	*ret = *i;
@@ -296,21 +291,11 @@ bool ceph_argparse_witharg(std::vector<const char*> &args,
   bool r;
   va_list ap;
   va_start(ap, ret);
-  r = va_ceph_argparse_witharg(args, i, ret, false, ap);
+  r = va_ceph_argparse_witharg(args, i, ret, ap);
   va_end(ap);
   return r;
 }
 
-bool ceph_argparse_witharg_daemon(std::vector<const char*> &args,
-	std::vector<const char*>::iterator &i, std::string *ret, ...)
-{
-  bool r;
-  va_list ap;
-  va_start(ap, ret);
-  r = va_ceph_argparse_witharg(args, i, ret, false, ap);
-  va_end(ap);
-  return r;
-}
 bool ceph_argparse_withint(std::vector<const char*> &args,
 	std::vector<const char*>::iterator &i, int *ret,
 	std::ostream *oss, ...)
@@ -319,30 +304,7 @@ bool ceph_argparse_withint(std::vector<const char*> &args,
   va_list ap;
   std::string str;
   va_start(ap, oss);
-  r = va_ceph_argparse_witharg(args, i, &str, true, ap);
-  va_end(ap);
-  if (!r) {
-    return false;
-  }
-
-  std::string err;
-  int myret = strict_strtol(str.c_str(), 10, &err);
-  *ret = myret;
-  if (!err.empty()) {
-    *oss << err;
-  }
-  return true;
-}
-
-bool ceph_argparse_withint_daemon(std::vector<const char*> &args,
-	std::vector<const char*>::iterator &i, int *ret,
-	std::ostream *oss, ...)
-{
-  bool r;
-  va_list ap;
-  std::string str;
-  va_start(ap, oss);
-  r = va_ceph_argparse_witharg(args, i, &str, false, ap);
+  r = va_ceph_argparse_witharg(args, i, &str, ap);
   va_end(ap);
   if (!r) {
     return false;
@@ -365,7 +327,7 @@ bool ceph_argparse_withlonglong(std::vector<const char*> &args,
   va_list ap;
   std::string str;
   va_start(ap, oss);
-  r = va_ceph_argparse_witharg(args, i, &str, false, ap);
+  r = va_ceph_argparse_witharg(args, i, &str, ap);
   va_end(ap);
   if (!r) {
     return false;
@@ -388,7 +350,7 @@ bool ceph_argparse_withfloat(std::vector<const char*> &args,
   va_list ap;
   std::string str;
   va_start(ap, oss);
-  r = va_ceph_argparse_witharg(args, i, &str, false, ap);
+  r = va_ceph_argparse_witharg(args, i, &str, ap);
   va_end(ap);
   if (!r) {
     return false;

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -57,8 +57,6 @@ bool ceph_argparse_flag(std::vector<const char*> &args,
 	std::vector<const char*>::iterator &i, ...);
 bool ceph_argparse_witharg(std::vector<const char*> &args,
 	std::vector<const char*>::iterator &i, std::string *ret, ...);
-bool ceph_argparse_witharg_daemon(std::vector<const char*> &args,
-	std::vector<const char*>::iterator &i, std::string *ret, ...);
 bool ceph_argparse_binary_flag(std::vector<const char*> &args,
 	std::vector<const char*>::iterator &i, int *ret,
 	std::ostream *oss, ...);
@@ -66,9 +64,6 @@ extern CephInitParameters ceph_argparse_early_args
 	    (std::vector<const char*>& args, uint32_t module_type, int flags,
 	     std::string *cluster, std::string *conf_file_list);
 extern bool ceph_argparse_withint(std::vector<const char*> &args,
-	std::vector<const char*>::iterator &i, int *ret,
-	std::ostream *oss, ...);
-extern bool ceph_argparse_withint_daemon(std::vector<const char*> &args,
 	std::vector<const char*>::iterator &i, int *ret,
 	std::ostream *oss, ...);
 extern bool ceph_argparse_withfloat(std::vector<const char*> &args,


### PR DESCRIPTION
Commit c76bbc2e6df1, which introduced _daemon versions of some of the
argparse calls, also changed the behaviour of non-_daemon versions.
The change resulted in incorrect error messages, e.g.

  $ ./rbd create b0 --size
  rbd: extraneous parameter --size

instead of what should have been

  $ ./rbd create b0 --size
  Option --size requires an argument.

The users of _daemon versions were added in commit be801f6c506d and
removed in commit f26bd55e57f1, so just kill the _daemon versions and
restore the old behaviour.  (This effectively reverts commit
c76bbc2e6df1.)

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
