### PR TITLE
Lack of "start" member function declare in WBThrottle.h

### DIFF
--- a/src/os/WBThrottle.h
+++ b/src/os/WBThrottle.h
@@ -134,6 +134,7 @@ public:
   WBThrottle(CephContext *cct);
   ~WBThrottle();
 
+  void start();
   void stop();
   /// Set fs as XFS or BTRFS
   void set_fs(FS new_fs) {


### PR DESCRIPTION
Fix urgent mistake.
see http://gitbuilder.sepia.ceph.com/gitbuilder-ceph-deb-precise-amd64-gcov/log.cgi?log=b8fb366eab2c7fff27732087f250b0eb1ab7dd79

Signed-off-by: Haomai Wang haomaiwang@gmail.com
