### PR TITLE
Fix Issue #6992: stop the accepter and mark all pipes down before rebind

### DIFF
--- a/src/msg/Accepter.cc
+++ b/src/msg/Accepter.cc
@@ -155,8 +155,6 @@ int Accepter::rebind(const set<int>& avoid_ports)
 {
   ldout(msgr->cct,1) << "accepter.rebind avoid " << avoid_ports << dendl;
   
-  stop();
-
   // invalidate our previously learned address.
   msgr->unlearn_addr();
 

--- a/src/msg/SimpleMessenger.cc
+++ b/src/msg/SimpleMessenger.cc
@@ -277,9 +277,9 @@ int SimpleMessenger::rebind(const set<int>& avoid_ports)
 {
   ldout(cct,1) << "rebind avoid " << avoid_ports << dendl;
   assert(did_bind);
-  int r = accepter.rebind(avoid_ports);
+  accepter.stop();
   mark_down_all();
-  return r;
+  return accepter.rebind(avoid_ports);
 }
 
 int SimpleMessenger::start()


### PR DESCRIPTION
msgr: fix rebind() race
stop the accepter and mark all pipes down before rebind to avoid race

Fixes: #6992

Signed-off-by: Xihui He xihuihe@gmail.com
