### PR TITLE
osd_types: add missing osd op flags

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -30,6 +30,9 @@ const char *ceph_osd_flag_name(unsigned flag)
   case CEPH_OSD_FLAG_READ: return "read";
   case CEPH_OSD_FLAG_WRITE: return "write";
   case CEPH_OSD_FLAG_ORDERSNAP: return "ordersnap";
+  case CEPH_OSD_FLAG_PEERSTAT_OLD: return "peerstat_old";
+  case CEPH_OSD_FLAG_BALANCE_READS: return "balance_reads";
+  case CEPH_OSD_FLAG_PARALLELEXEC: return "parallelexec";
   case CEPH_OSD_FLAG_PGOP: return "pgop";
   case CEPH_OSD_FLAG_EXEC: return "exec";
   case CEPH_OSD_FLAG_EXEC_PUBLIC: return "exec_public";


### PR DESCRIPTION
These were accidentally removed in: 85282319ee3e0d535d1ffc0a6ae8f763a41628b7

Fixes: #7067 Signed-off-by: Josh Durgin josh.durgin@inktank.com
