### PR TITLE
librbd: better error when unprotect fails on unprotected snap

### DIFF
--- a/qa/qa_scripts/RbdLib.pm
+++ b/qa/qa_scripts/RbdLib.pm
@@ -81,8 +81,7 @@ our $SNAP_PROTECT_ERR = "Device or resource busy";
 our $SNAP_PROTECT_RM_ERR = "protected from removal";
 our $SNAP_PROTECT_ERR1 = "No such file or directory";
 our $SNAP_UNPROT_ERR   = "snap_unprotect: image must support layering";
-our $SNAP_UNPROT_ERR1   = "snap_unprotect: can't unprotect";
-#our $SNAP_UNPROTECT_ERR - bug # 4045  
+our $SNAP_UNPROT_ERR1   = "snap_unprotect: snapshot is already unprotected";
 our $SNAP_PROT_ERR     = "snap_protect: image must support layering";
 our $CLONE_UNPROTECT_ERR = "parent snapshot must be protected";
 our $CLONE_ARG_ERR     = "destination image name was not specified";

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -616,8 +616,11 @@ namespace librbd {
     if (r < 0)
       return r;
 
-    if (is_unprotected)
+    if (is_unprotected) {
+      lderr(ictx->cct) << "snap_unprotect: snapshot is already unprotected"
+		       << dendl;
       return -EINVAL;
+    }
 
     r = cls_client::set_protection_status(&ictx->md_ctx,
 					  ictx->header_oid,


### PR DESCRIPTION
This will show up on the command line and logs, making it more clear than
EINVAL.

Fixes #6851 and #4045 Signed-off-by: Josh Durgin josh.durgin@inktank.com
