### PR TITLE
rbd: return 0 and an empty list when pool is entirely empty

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,12 @@
+v0.75
+~~~~~
+
+- 'rbd ls' on a pool which never held rbd images now exits with code
+  0. It outputs nothing in plain format, or an empty list in
+  non-plain format. This is consistent with the behavior for a pool
+  which used to hold images, but contains none. Scripts relying on
+  this behavior should be updated.
+
 v0.74
 ~~~~~
 

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -251,6 +251,8 @@ static int do_list(librbd::RBD &rbd, librados::IoCtx& io_ctx, bool lflag,
 {
   std::vector<string> names;
   int r = rbd.list(io_ctx, names);
+  if (r == -ENOENT)
+    r = 0;
   if (r < 0)
     return r;
 
@@ -2777,14 +2779,7 @@ if (!set_conf_param(v, p1, p2, p3)) { \
   case OPT_LIST:
     r = do_list(rbd, io_ctx, lflag, formatter.get());
     if (r < 0) {
-      switch (r) {
-      case -ENOENT:
-        cerr << "rbd: pool " << poolname << " doesn't contain rbd images"
-	     << std::endl;
-        break;
-      default:
-        cerr << "rbd: list: " << cpp_strerror(-r) << std::endl;
-      }
+      cerr << "rbd: list: " << cpp_strerror(-r) << std::endl;
       return -r;
     }
     break;

--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -1,3 +1,12 @@
+ls on empty pool never containing images
+========================================
+  $ rados -p rbd rm rbd_directory || true
+  $ rbd ls
+  $ rbd ls --format json
+  [] (no-eol)
+  $ rbd ls --format xml
+  <images></images> (no-eol)
+
 create
 =======
   $ rbd create -s 1024 foo


### PR DESCRIPTION
rbd_list will return -ENOENT when no rbd_directory object exists. Handle this
in the cli tool and interpret it as success with an empty list.

Add this to the release notes since it changes command line behavior.

Fixes: #6693 Signed-off-by: Josh Durgin josh.durgin@inktank.com
