### PR TITLE
osdc/ObjectCacher: back off less during flush

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1457,6 +1457,12 @@ void ObjectCacher::flusher_entry()
 	ldout(cct, 10) << "flusher flushing aged dirty bh " << *bh << dendl;
 	bh_write(bh);
       }
+      if (!max) {
+	// back off the lock to avoid starving other threads
+	lock.Unlock();
+	lock.Lock();
+	continue;
+      }
     }
     if (flusher_stop)
       break;


### PR DESCRIPTION
In cce990efc8f2a58c8d0fa11c234ddf2242b1b856 we added a limit to avoid holding
the lock for too long.  However, if we back off, we currently wait for a full
second, which is probably a bit much--we really just want to give other
threads a chance.

Backport: emperor Signed-off-by: Sage Weil sage@inktank.com
