### PR TITLE
FileStore: detect XFS properly

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -850,12 +850,12 @@ int FileStore::_detect_fs()
     m_fs_type = FS_TYPE_BTRFS;
   } else if (st.f_type == XFS_SUPER_MAGIC) {
     dout(1) << "mount detected xfs" << dendl;
+    m_fs_type = FS_TYPE_XFS;
     if (m_filestore_replica_fadvise) {
       dout(1) << " disabling 'filestore replica fadvise' due to known issues with fadvise(DONTNEED) on xfs" << dendl;
       g_conf->set_val("filestore_replica_fadvise", "false");
       g_conf->apply_changes(NULL);
       assert(m_filestore_replica_fadvise == false);
-      m_fs_type = FS_TYPE_XFS;
     }
   }
 #endif


### PR DESCRIPTION
We were only setting m_fs_type = FS_TYPE_XFS if
m_filestore_replica_fadvise was also set -- presumably
the bug fix accidentally blocked off too much of the code type. This
resulted in our xattr counts always being set too low: the store
is mounted (and thus does _detectfs) twice; once in as part of the
not-as-conditional-as-it-looks convertfs in ceph_osd.cc, and once
as part of OSD::init().

Reported-by: Sushma Gurram Sushma.Gurram@sandisk.com
Signed-off-by: Greg Farnum greg@inktank.com
