### PR TITLE
DBObjectMap::clear_keys_header: use generate_new_header, not _generate_n...

### DIFF
--- a/src/os/DBObjectMap.cc
+++ b/src/os/DBObjectMap.cc
@@ -798,7 +798,7 @@ int DBObjectMap::clear_keys_header(const ghobject_t &oid,
     return r;
 
   // create new header
-  Header newheader = _generate_new_header(oid, Header());
+  Header newheader = generate_new_header(oid, Header());
   set_map_header(oid, *newheader, t);
   if (attrs.size())
     t->set(xattr_prefix(newheader), attrs);


### PR DESCRIPTION
...ew_header

We aren't holding the header_lock here, so we need the locked version.

Signed-off-by: Samuel Just sam.just@inktank.com
