### PR TITLE
osd: OSDMap: build reverse name->pool map upon decoding

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1721,12 +1721,7 @@ void OSDMap::decode_classic(bufferlist::iterator& p)
   else
     osd_addrs->hb_front_addr.resize(osd_addrs->hb_back_addr.size());
 
-  // index pool names
-  name_pool.clear();
-  for (map<int64_t,string>::iterator i = pool_name.begin(); i != pool_name.end(); ++i)
-    name_pool[i->second] = i->first;
-
-  calc_num_osds();
+  post_decode();
 }
 
 void OSDMap::decode(bufferlist::iterator& bl)
@@ -1793,6 +1788,20 @@ void OSDMap::decode(bufferlist::iterator& bl)
   }
 
   DECODE_FINISH(bl); // wrapper
+
+  post_decode();
+}
+
+void OSDMap::post_decode()
+{
+  // index pool names
+  name_pool.clear();
+  for (map<int64_t,string>::iterator i = pool_name.begin();
+       i != pool_name.end(); ++i) {
+    name_pool[i->second] = i->first;
+  }
+
+  calc_num_osds();
 }
 
 void OSDMap::dump_json(ostream& out) const

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -475,6 +475,7 @@ private:
   void encode_client_old(bufferlist& bl) const;
   void encode_classic(bufferlist& bl, uint64_t features) const;
   void decode_classic(bufferlist::iterator& p);
+  void post_decode();
 public:
   void encode(bufferlist& bl, uint64_t features=CEPH_FEATURES_ALL) const;
   void decode(bufferlist& bl);


### PR DESCRIPTION
Commit 3d7c69fb09 introduced a new OSDMap encoding/decoding scheme.
However, while the classic decoding function still kept building the
reverse name->pool map, the new decoding function did not, causing the
monitor to be unable to map pool names to pool ids.

This patch fixes this, by factoring out the loop responsible for
populating the 'name_pool' map, as well as calling 'calc_num_osds()', to
OSDMap::post_decode() and having this function called from both the
classic and the new decode functions.

Fixes: 7166

Signed-off-by: Joao Eduardo Luis jecluis@gmail.com
