### PR TITLE
avoid re-running configure after initial 'make' invocation

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -27,6 +27,7 @@ rm -f config.cache
 aclocal -I m4 --install
 check_for_pkg_config
 $LIBTOOLIZE --force --copy
+aclocal -I m4 --install
 autoconf
 autoheader
 automake -a --add-missing -Wall


### PR DESCRIPTION
This seems to prevent configure from re-running after the first
invocation of 'make' following ./autogen.sh. The autoreconf script also
does this.

Signed-off-by: Noah Watkins noahwatkins@gmail.com
