### PR TITLE
client: ceph-fuse use fuse_session_loop_mt to allow multithreaded operat...

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -769,7 +769,11 @@ done:
 
 int CephFuse::Handle::loop()
 {
-  return fuse_session_loop(se);
+  if (client->cct->_conf->fuse_multithreaded) {
+    return fuse_session_loop_mt(se);
+  } else {
+    return fuse_session_loop(se);
+  }
 }
 
 uint64_t CephFuse::Handle::fino_snap(uint64_t fino)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -269,6 +269,7 @@ OPTION(fuse_default_permissions, OPT_BOOL, true)
 OPTION(fuse_big_writes, OPT_BOOL, true)
 OPTION(fuse_atomic_o_trunc, OPT_BOOL, true)
 OPTION(fuse_debug, OPT_BOOL, false)
+OPTION(fuse_multithreaded, OPT_BOOL, false)
 
 OPTION(crush_location, OPT_STR, "")       // whitespace-separated list of key=value pairs describing crush location
 


### PR DESCRIPTION
client: ceph-fuse use fuse_session_loop_mt to allow multithreaded operation if "fuse multithreaded = 1".
Signed-off-by: Moritz Moeller mm@mxs.de
