### PR TITLE
osd: OSDMap: fix output from ceph status --format=json for num_in_osds

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2181,7 +2181,7 @@ void OSDMap::print_summary(Formatter *f, ostream& out) const
     f->dump_int("epoch", get_epoch());
     f->dump_int("num_osds", get_num_osds());
     f->dump_int("num_up_osds", get_num_up_osds());
-    f->dump_stream("num_in_osds") << get_num_in_osds();
+    f->dump_int("num_in_osds", get_num_in_osds());
     f->dump_string("full", test_flag(CEPH_OSDMAP_FULL) ? "true" : "false");
     f->dump_string("nearfull", test_flag(CEPH_OSDMAP_NEARFULL) ?
 		   "true" : "false");


### PR DESCRIPTION
num_up_osds returns as an int value, while num_in_osds returns as a string.
Since only an int can be returned from get_num_in_osds(), num_in_osds should
should also be an int to remain consistant with num_up_osds.

Fixes: 7159

Signed-off-by: Tyler Brekke tyler.brekke@inktank.com
