### PR TITLE
osd: OSD failed to start with osd_leveldb_cache_size > 0

### DIFF
--- a/src/os/LevelDBStore.cc
+++ b/src/os/LevelDBStore.cc
@@ -75,6 +75,9 @@ LevelDBStore::~LevelDBStore()
 {
   close();
   delete logger;
+
+  // Ensure db is destroyed before dependent db_cache and filterpolicy
+  db.reset();
 }
 
 void LevelDBStore::close()

--- a/src/os/LevelDBStore.h
+++ b/src/os/LevelDBStore.h
@@ -48,11 +48,11 @@ class LevelDBStore : public KeyValueDB {
   CephContext *cct;
   PerfCounters *logger;
   string path;
-  boost::scoped_ptr<leveldb::DB> db;
   boost::scoped_ptr<leveldb::Cache> db_cache;
 #ifdef HAVE_LEVELDB_FILTER_POLICY
   boost::scoped_ptr<const leveldb::FilterPolicy> filterpolicy;
 #endif
+  boost::scoped_ptr<leveldb::DB> db;
 
   int init(ostream &out, bool create_if_missing);
 


### PR DESCRIPTION
Fix: http://tracker.ceph.com/issues/7172

To ensure LevelDBStore::db is destroyed before dependent LevelDBStore::db_cache and LevelDBStore::filterpolicy.
