### PR TITLE
OSDMap: Populate primary_temp values a little more carefully

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1376,8 +1376,8 @@ void OSDMap::_get_temp_osds(const pg_pool_t& pool, pg_t pg,
   *temp_primary = -1;
   if (pp != primary_temp->end())
     *temp_primary = pp->second;
-  else if (p != pg_temp->end()) // apply pg_temp's primary
-    *temp_primary = p->second.front();
+  else if (!temp_pg->empty()) // apply pg_temp's primary
+    *temp_primary = temp_pg->front();
 }
 
 int OSDMap::pg_to_osds(pg_t pg, vector<int> *raw, int *primary) const


### PR DESCRIPTION
In _get_temp_osds(), we populate temp_pg from the list in the OSDMap,
but we also skip anybody in the list who's down. We need to account
for those skips when setting the primary. It's easy enough to do -- just
look at the output pg_temp list instead of the OSDMap's starting one.

Fixes: #7177

Signed-off-by: Greg Farnum greg@inktank.com
