### PR TITLE
Fix #7180 in ceph_rest_api

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -282,11 +282,11 @@ COMMAND("mds set " \
         "name=key,type=CephChoices,strings=allow_new_snaps " \
         "name=sure,type=CephString,req=false", \
         "set <key>", \
-        "mds", "w", "cli,rest")
+        "mds", "rw", "cli,rest")
 COMMAND("mds unset " \
         "name=key,type=CephChoices,strings=allow_new_snaps " \
         "name=sure,type=CephString,req=false", \
-        "unset <key>", "mds", "w", "cli,rest")
+        "unset <key>", "mds", "rw", "cli,rest")
 COMMAND("mds add_data_pool " \
 	"name=pool,type=CephString", \
 	"add data pool <pool>", "mds", "rw", "cli,rest")


### PR DESCRIPTION
Missing a key for perm 'w' in permmap (src/pybin/ceph_rest_api.py:277) ,which leads to a 500 error when getting mds help info via rest api.
Changed perm with "w" to "rw" in src/mon/MonCommands.h
