### PR TITLE
Fix #7187: Include all summary items in JSON health output

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1758,17 +1758,17 @@ void Monitor::get_health(string& status, bufferlist *detailbl, Formatter *f)
   stringstream ss;
   health_status_t overall = HEALTH_OK;
   if (!summary.empty()) {
-    if (f) {
-      f->open_object_section("item");
-      f->dump_stream("severity") <<  summary.front().first;
-      f->dump_string("summary", summary.front().second);
-      f->close_section();
-    }
     ss << ' ';
     while (!summary.empty()) {
       if (overall > summary.front().first)
 	overall = summary.front().first;
       ss << summary.front().second;
+      if (f) {
+        f->open_object_section("item");
+        f->dump_stream("severity") <<  summary.front().first;
+        f->dump_string("summary", summary.front().second);
+        f->close_section();
+      }
       summary.pop_front();
       if (!summary.empty())
 	ss << "; ";


### PR DESCRIPTION
Signed-off-by: John Spray john.spray@inktank.com
