### PR TITLE
osd: ignore num_objects_dirty for old pools

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -10024,12 +10024,14 @@ void ReplicatedPG::_scrub_finish()
   dout(10) << mode << " got "
 	   << scrub_cstat.sum.num_objects << "/" << info.stats.stats.sum.num_objects << " objects, "
 	   << scrub_cstat.sum.num_object_clones << "/" << info.stats.stats.sum.num_object_clones << " clones, "
+	   << scrub_cstat.sum.num_objects_dirty << "/" << info.stats.stats.sum.num_objects_dirty << " dirty, "
 	   << scrub_cstat.sum.num_bytes << "/" << info.stats.stats.sum.num_bytes << " bytes."
 	   << dendl;
 
   if (scrub_cstat.sum.num_objects != info.stats.stats.sum.num_objects ||
       scrub_cstat.sum.num_object_clones != info.stats.stats.sum.num_object_clones ||
-      scrub_cstat.sum.num_objects_dirty != info.stats.stats.sum.num_objects_dirty ||
+      (scrub_cstat.sum.num_objects_dirty != info.stats.stats.sum.num_objects_dirty &&
+       !info.stats.dirty_stats_invalid) ||
       scrub_cstat.sum.num_whiteouts != info.stats.stats.sum.num_whiteouts ||
       scrub_cstat.sum.num_bytes != info.stats.stats.sum.num_bytes) {
     osd->clog.error() << info.pgid << " " << mode
@@ -10044,6 +10046,7 @@ void ReplicatedPG::_scrub_finish()
     if (repair) {
       ++scrubber.fixed;
       info.stats.stats = scrub_cstat;
+      info.stats.dirty_stats_invalid = false;
       publish_stats_to_osd();
       share_pg_info();
     }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1450,7 +1450,7 @@ void pg_stat_t::dump_brief(Formatter *f) const
 
 void pg_stat_t::encode(bufferlist &bl) const
 {
-  ENCODE_START(13, 8, bl);
+  ENCODE_START(14, 8, bl);
   ::encode(version, bl);
   ::encode(reported_seq, bl);
   ::encode(reported_epoch, bl);
@@ -1479,12 +1479,13 @@ void pg_stat_t::encode(bufferlist &bl) const
   ::encode(stats_invalid, bl);
   ::encode(last_clean_scrub_stamp, bl);
   ::encode(last_became_active, bl);
+  ::encode(dirty_stats_invalid, bl);
   ENCODE_FINISH(bl);
 }
 
 void pg_stat_t::decode(bufferlist::iterator &bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(13, 8, 8, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(14, 8, 8, bl);
   ::decode(version, bl);
   ::decode(reported_seq, bl);
   ::decode(reported_epoch, bl);
@@ -1563,6 +1564,13 @@ void pg_stat_t::decode(bufferlist::iterator &bl)
     ::decode(last_became_active, bl);
   } else {
     last_became_active = last_active;
+  }
+  if (struct_v >= 14) {
+    ::decode(dirty_stats_invalid, bl);
+  } else {
+    // if we are decoding an old encoding of this object, then the
+    // encoder may not have supported num_objects_dirty accounting.
+    dirty_stats_invalid = true;
   }
   DECODE_FINISH(bl);
 }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1151,6 +1151,10 @@ struct pg_stat_t {
 
   utime_t last_became_active;
 
+  /// true if num_objects_dirty is not accurate (because it was not
+  /// maintained starting from pool creation)
+  bool dirty_stats_invalid;
+
   pg_stat_t()
     : reported_seq(0),
       reported_epoch(0),
@@ -1159,7 +1163,8 @@ struct pg_stat_t {
       parent_split_bits(0),
       stats_invalid(false),
       log_size(0), ondisk_log_size(0),
-      mapping_epoch(0)
+      mapping_epoch(0),
+      dirty_stats_invalid(false)
   { }
 
   epoch_t get_effective_last_epoch_clean() const {


### PR DESCRIPTION
Way back in a0ed9c20048750fd4b2c7ce0339fa8b20ef08ca3 we introduced the dirty
flag, but we did not track it in the stats until much later in 
c561d5ea22c335e4c05fdc16ca8fb41f75f89d81.  Unfortunately this interval spans
the emperor release.  To avoid making scrub error out and require repair on
_any_ of those old pools, flag stats that were encoded before now such that
the dirty stats are ignored.  Clear the flag if we _do_ do a repair so that
it will be tracked properly thereafter.

Signed-off-by: Sage Weil sage@inktank.com
