### PR TITLE
mon/MonCommands: 'invalidate+forward' -> 'forward'

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -553,7 +553,7 @@ COMMAND("osd tier remove " \
 	"remove the tier <tierpool> from base pool <pool>", "osd", "rw", "cli,rest")
 COMMAND("osd tier cache-mode " \
 	"name=pool,type=CephPoolname " \
-	"name=mode,type=CephChoices,strings=none|writeback|invalidate+forward|readonly", \
+	"name=mode,type=CephChoices,strings=none|writeback|forward|readonly", \
 	"specify the caching mode for cache tier <pool>", "osd", "rw", "cli,rest")
 COMMAND("osd tier set-overlay " \
 	"name=pool,type=CephPoolname " \

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -1004,7 +1004,7 @@ class TestOSD(TestArgparse):
                                                         'toomany']))
 
     def test_tier_cache_mode(self):
-        for mode in ('none', 'writeback', 'invalidate+forward', 'readonly'):
+        for mode in ('none', 'writeback', 'forward', 'readonly'):
             self.assert_valid_command(['osd', 'tier', 'cache-mode',
                                        'poolname', mode])
         assert_equal({}, validate_command(sigdict, ['osd', 'tier',


### PR DESCRIPTION
Commit 4e439857a694 introduced invalidate+forward cache mode, commit
81279e3bb6e0 renamed it to forward, but missed the CLI.  Fix it.

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
