### PR TITLE
MOSDMap: reencode maps if target doesn't have OSDMAP_ENC

### DIFF
--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -86,11 +86,12 @@ public:
     ::encode(fsid, payload);
     if ((features & CEPH_FEATURE_PGID64) == 0 ||
 	(features & CEPH_FEATURE_PGPOOL3) == 0 ||
-	(features & CEPH_FEATURE_OSDENC) == 0) {
+	(features & CEPH_FEATURE_OSDENC) == 0 ||
+        (features & CEPH_FEATURE_OSDMAP_ENC) == 0) {
       if ((features & CEPH_FEATURE_PGID64) == 0 ||
 	  (features & CEPH_FEATURE_PGPOOL3) == 0)
 	header.version = 1;  // old old_client version
-      else
+      else if ((features & CEPH_FEATURE_OSDENC) == 0)
 	header.version = 2;  // old pg_pool_t
 
       // reencode maps using old format


### PR DESCRIPTION
Reencode both full and incremental maps if target doesn't know how to
decode OSDMAP_ENC maps (CEPH_FEATURE_OSDMAP_ENC bit is not set).  This
fixes a compatibility bug that was introduced in 3d7c69fb0986 ("OSDMap:
add a CEPH_FEATURE_OSDMAP_ENC feature, and use new encoding").

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
