### PR TITLE
osd/OSDMap: do not create erasure rule by default

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2081,10 +2081,7 @@ int OSDMap::build_simple_crush_rulesets(CephContext *cct,
 			       "firstn", pg_pool_t::TYPE_REPLICATED, ss);
   if (r < 0)
     return r;
-  r = crush.add_simple_ruleset("erasure_ruleset", root, failure_domain,
-				  "indep", pg_pool_t::TYPE_ERASURE, ss);
-  if (r < 0)
-    return r;
-  else
-    return 0;
+  // do not add an erasure rule by default or else we will implicitly
+  // require the crush_v2 feature of clients
+  return 0;
 }

--- a/src/test/cli/crushtool/build.t
+++ b/src/test/cli/crushtool/build.t
@@ -87,16 +87,6 @@
   \tstep chooseleaf firstn 0 type root (esc)
   \tstep emit (esc)
   }
-  rule erasure_ruleset {
-  \truleset 1 (esc)
-  \ttype erasure (esc)
-  \tmin_size 3 (esc)
-  \tmax_size 20 (esc)
-  \tstep set_chooseleaf_tries 5 (esc)
-  \tstep take root (esc)
-  \tstep chooseleaf indep 0 type root (esc)
-  \tstep emit (esc)
-  }
   
   # end crush map
   $ rm "$map" "$map.txt"

--- a/src/test/cli/osdmaptool/create-print.t
+++ b/src/test/cli/osdmaptool/create-print.t
@@ -65,16 +65,6 @@
   \tstep chooseleaf firstn 0 type host (esc)
   \tstep emit (esc)
   }
-  rule erasure_ruleset {
-  \truleset 1 (esc)
-  \ttype erasure (esc)
-  \tmin_size 3 (esc)
-  \tmax_size 20 (esc)
-  \tstep set_chooseleaf_tries 5 (esc)
-  \tstep take default (esc)
-  \tstep chooseleaf indep 0 type host (esc)
-  \tstep emit (esc)
-  }
   
   # end crush map
   $ osdmaptool --print myosdmap

--- a/src/test/cli/osdmaptool/create-racks.t
+++ b/src/test/cli/osdmaptool/create-racks.t
@@ -773,16 +773,6 @@
   \tstep chooseleaf firstn 0 type host (esc)
   \tstep emit (esc)
   }
-  rule erasure_ruleset {
-  \truleset 1 (esc)
-  \ttype erasure (esc)
-  \tmin_size 3 (esc)
-  \tmax_size 20 (esc)
-  \tstep set_chooseleaf_tries 5 (esc)
-  \tstep take default (esc)
-  \tstep chooseleaf indep 0 type host (esc)
-  \tstep emit (esc)
-  }
   
   # end crush map
   $ rm oc


### PR DESCRIPTION
If we do, we will require the v2 feature bit from clients.

We could only include feature bits for rules that are actually referenced by
pools, but for now making the user create the rule is simpler.  There is no
need to create this rule ahead of time.

Signed-off-by: Sage Weil sage@inktank.com
