### PR TITLE
Fix init-ceph error when firstly starting OSD

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -332,7 +332,8 @@ for name in $what; do
 			-- \
 			$id \
 			${osd_weight:-${defaultweight:-1}} \
-			$osd_location"
+			$osd_location \
+            || :"
 		fi
 	    fi
 


### PR DESCRIPTION
close bug #7222

Signed-off-by: Haomai Wang haomaiwang@gmail.com
