### PR TITLE
ReplicatedPG: avoid undefined behavior in xattr cmp

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2348,7 +2348,7 @@ int ReplicatedPG::do_xattr_cmp_u64(int op, __u64 v1, bufferlist& xattr)
 int ReplicatedPG::do_xattr_cmp_str(int op, string& v1s, bufferlist& xattr)
 {
   const char *v1, *v2;
-  v1 = v1s.data();
+  v1 = v1s.c_str();
   string v2s;
   if (xattr.length()) {
     v2s = string(xattr.c_str(), xattr.length());


### PR DESCRIPTION
Reading past the end of a pointer returned by string.data() in c++98 is
undefined. This value is passed to strcmp later, so simply use the 
NUL-terminated c_str() instead.

Fixes: #7250 Backport: dumpling Signed-off-by: Josh Durgin
josh.durgin@inktank.com
