### PR TITLE
OSD: don't assume we have the pool in handle_pg_create

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5947,6 +5947,10 @@ void OSD::handle_pg_create(OpRequestRef op)
       dout(20) << "ignoring localized pg " << pgid << dendl;
       continue;
     }
+    if (!osdmap->have_pg_pool(pgid.pool())) {
+      dout(20) << "ignoring pg on deleted pool " << pgid << dendl;
+      continue;
+    }
 
     dout(20) << "mkpg " << pgid << " e" << created << dendl;
    


### PR DESCRIPTION
The pool may have been removed since the creation message
was sent.  Previously, role would end up as -1 and this
path would be avoided.

Fixes: 7190
Introduced in 268ae82ac3fe7b541c450aae168dcf9fa7294508
Signed-off-by: Samuel Just sam.just@inktank.com
