### PR TITLE
leveldb: increase leveldb defaults (filestore, keyvaluestore)

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -518,8 +518,8 @@ OPTION(osd_leveldb_log, OPT_STR, "")  // enable OSD leveldb log file
 // determines whether PGLog::check() compares written out log to stored log
 OPTION(osd_debug_pg_log_writeout, OPT_BOOL, false)
 
-OPTION(leveldb_write_buffer_size, OPT_U64, 0) // leveldb write buffer size
-OPTION(leveldb_cache_size, OPT_U64, 0) // leveldb cache size
+OPTION(leveldb_write_buffer_size, OPT_U64, 8*1024*1024) // leveldb write buffer size
+OPTION(leveldb_cache_size, OPT_U64, 256*1024*1024) // leveldb cache size
 OPTION(leveldb_block_size, OPT_U64, 0) // leveldb block size
 OPTION(leveldb_bloom_size, OPT_INT, 0) // leveldb bloom bits per entry
 OPTION(leveldb_max_open_files, OPT_INT, 0) // leveldb max open files


### PR DESCRIPTION
The FileStore's leveldb currently uses libleveldb's defaults for cache and 
write buffer size, which are both 4 MB.  Increase the cache size to 128MB and
the write buffer to 8MB.

Signed-off-by: Sage Weil sage@inktank.com
