### PR TITLE
pybind: improve EnvironmentError output

### DIFF
--- a/src/pybind/cephfs.py
+++ b/src/pybind/cephfs.py
@@ -127,8 +127,8 @@ def load_libcephfs():
     # in addition, it doesn't seem work on centos 6.4 (see e46d2ca067b5)
     try:
         return CDLL('libcephfs.so.1')
-    except OSError:
-        raise EnvironmentError("Unable to find libcephfs")
+    except OSError as e:
+        raise EnvironmentError("Unable to load libcephfs: %s" % e)
 
 class LibCephFS(object):
     """libcephfs python wrapper"""

--- a/src/pybind/rbd.py
+++ b/src/pybind/rbd.py
@@ -129,8 +129,8 @@ def load_librbd():
     # in addition, it doesn't seem work on centos 6.4 (see e46d2ca067b5)
     try:
         return CDLL('librbd.so.1')
-    except OSError:
-        raise EnvironmentError("Unable to find librbd")
+    except OSError as e:
+        raise EnvironmentError("Unable to load librbd: %s" % e)
 
 class RBD(object):
     """


### PR DESCRIPTION
Follow 70c7c9e600c5 ("pybind/rados.py: improve error output") and
improve EnvironmentError output for librbd and libcephfs too.

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
