### PR TITLE
rgw: fix rgw_read_user_buckets() use of max param

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -54,8 +54,10 @@ int rgw_read_user_buckets(RGWRados *store, string user_id, RGWUserBuckets& bucke
   bool truncated;
   string m = marker;
 
+  uint64_t total = 0;
+
   do {
-    ret = store->cls_user_list_buckets(obj, m, max, entries, &m, &truncated);
+    ret = store->cls_user_list_buckets(obj, m, max - total, entries, &m, &truncated);
     if (ret == -ENOENT)
       ret = 0;
 
@@ -65,8 +67,10 @@ int rgw_read_user_buckets(RGWRados *store, string user_id, RGWUserBuckets& bucke
     for (list<cls_user_bucket_entry>::iterator q = entries.begin(); q != entries.end(); ++q) {
       RGWBucketEnt e(*q);
       buckets.add(e);
+      total++;
     }
-  } while (truncated);
+
+  } while (truncated && total < max);
 
   if (need_stats) {
     map<string, RGWBucketEnt>& m = buckets.get_buckets();


### PR DESCRIPTION
Fixes: #7336

The rgw_read_user_buckets() treated the max param as the max number of
entries to request in a single op, but always fetched the entire list
of buckets. This is wrong, as it should have treated it as the total
number of entries requested. All the callers assume the latter.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
