### PR TITLE
qa/workunits/snaps: New allow_new_snaps syntax

### DIFF
--- a/qa/workunits/snaps/snap-rm-diff.sh
+++ b/qa/workunits/snaps/snap-rm-diff.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 wget -q http://ceph.com/qa/linux-2.6.33.tar.bz2
 mkdir foo
 cp linux* foo

--- a/qa/workunits/snaps/snaptest-0.sh
+++ b/qa/workunits/snaps/snaptest-0.sh
@@ -9,7 +9,7 @@ expect_failure() {
 set -e
 
 expect_failure mkdir .snap/foo
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 echo asdf > foo
 mkdir .snap/foo
@@ -23,7 +23,7 @@ grep asdf .snap/bar/bar
 rmdir .snap/bar
 rm foo
 
-ceph mds unset allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps false
 expect_failure mkdir .snap/baz
 
 echo OK

--- a/qa/workunits/snaps/snaptest-1.sh
+++ b/qa/workunits/snaps/snaptest-1.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 echo 1 > file1
 echo 2 > file2

--- a/qa/workunits/snaps/snaptest-2.sh
+++ b/qa/workunits/snaps/snaptest-2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 echo "Create dir 100 to 199 ..."
 for i in $(seq 100 199); do

--- a/qa/workunits/snaps/snaptest-authwb.sh
+++ b/qa/workunits/snaps/snaptest-authwb.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 touch foo
 chmod +x foo

--- a/qa/workunits/snaps/snaptest-capwb.sh
+++ b/qa/workunits/snaps/snaptest-capwb.sh
@@ -4,7 +4,7 @@ set -e
 
 mkdir foo
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 # make sure mds handles it when the client does not send flushsnap
 echo x > foo/x

--- a/qa/workunits/snaps/snaptest-dir-rename.sh
+++ b/qa/workunits/snaps/snaptest-dir-rename.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 #
 # make sure we keep an existing dn's seq

--- a/qa/workunits/snaps/snaptest-double-null.sh
+++ b/qa/workunits/snaps/snaptest-double-null.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 # multiple intervening snapshots with no modifications, and thus no
 # snapflush client_caps messages.  make sure the mds can handle this.

--- a/qa/workunits/snaps/snaptest-estale.sh
+++ b/qa/workunits/snaps/snaptest-estale.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 mkdir .snap/foo
 

--- a/qa/workunits/snaps/snaptest-git-ceph.sh
+++ b/qa/workunits/snaps/snaptest-git-ceph.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 git clone git://ceph.com/git/ceph.git
 cd ceph

--- a/qa/workunits/snaps/snaptest-intodir.sh
+++ b/qa/workunits/snaps/snaptest-intodir.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 # this tests fix for #1399
 mkdir foo

--- a/qa/workunits/snaps/snaptest-multiple-capsnaps.sh
+++ b/qa/workunits/snaps/snaptest-multiple-capsnaps.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 echo asdf > a
 mkdir .snap/1

--- a/qa/workunits/snaps/snaptest-parents.sh
+++ b/qa/workunits/snaps/snaptest-parents.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 echo "making directory tree and files"
 mkdir -p 1/a/b/c/

--- a/qa/workunits/snaps/snaptest-snap-rm-cmp.sh
+++ b/qa/workunits/snaps/snaptest-snap-rm-cmp.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 file=linux-2.6.33.tar.bz2
 wget -q http://ceph.com/qa/$file

--- a/qa/workunits/snaps/snaptest-upchildrealms.sh
+++ b/qa/workunits/snaps/snaptest-upchildrealms.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 #
 # verify that a snap update on a parent realm will induce

--- a/qa/workunits/snaps/snaptest-xattrwb.sh
+++ b/qa/workunits/snaps/snaptest-xattrwb.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 echo "testing simple xattr wb"
 touch x

--- a/qa/workunits/snaps/untar_snap_rm.sh
+++ b/qa/workunits/snaps/untar_snap_rm.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ceph mds set allow_new_snaps --yes-i-really-mean-it
+ceph mds set allow_new_snaps true --yes-i-really-mean-it
 
 do_tarball() {
     wget http://ceph.com/qa/$1


### PR DESCRIPTION
These were probably just obscuring other failures.

Ran tasks/snaptests.yaml by hand and got a pass.
