### PR TITLE
rgw: initialize variable before call

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -51,7 +51,7 @@ int rgw_read_user_buckets(RGWRados *store, string user_id, RGWUserBuckets& bucke
   bufferlist header;
   list<cls_user_bucket_entry> entries;
 
-  bool truncated;
+  bool truncated = false;
   string m = marker;
 
   do {


### PR DESCRIPTION
Need to initialize the truncated variable, as we sometimes ignore error
response (e.g., with ENOENT), and in such cases we can't expect it to be
set.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
