### PR TITLE
osd/OSDMap: populate *primary when pool dne

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1390,6 +1390,7 @@ void OSDMap::_get_temp_osds(const pg_pool_t& pool, pg_t pg,
 int OSDMap::pg_to_osds(pg_t pg, vector<int> *raw, int *primary) const
 {
   *primary = -1;
+  raw->clear();
   const pg_pool_t *pool = get_pg_pool(pg.pool());
   if (!pool)
     return 0;
@@ -1400,8 +1401,13 @@ int OSDMap::pg_to_osds(pg_t pg, vector<int> *raw, int *primary) const
 void OSDMap::pg_to_raw_up(pg_t pg, vector<int> *up, int *primary) const
 {
   const pg_pool_t *pool = get_pg_pool(pg.pool());
-  if (!pool)
+  if (!pool) {
+    if (primary)
+      *primary = -1;
+    if (up)
+      up->clear();
     return;
+  }
   vector<int> raw;
   _pg_to_osds(*pool, pg, &raw, primary);
   _raw_to_up_osds(pg, raw, up, primary);
@@ -1411,8 +1417,17 @@ void OSDMap::_pg_to_up_acting_osds(pg_t pg, vector<int> *up, int *up_primary,
                                    vector<int> *acting, int *acting_primary) const
 {
   const pg_pool_t *pool = get_pg_pool(pg.pool());
-  if (!pool)
+  if (!pool) {
+    if (up)
+      up->clear();
+    if (up_primary)
+      *up_primary = -1;
+    if (acting)
+      acting->clear();
+    if (acting_primary)
+      *acting_primary = -1;
     return;
+  }
   vector<int> raw;
   vector<int> _up;
   vector<int> _acting;


### PR DESCRIPTION
This fixes a valgrind error from OSD::handle_osd_map where primary is not 
initialized and is compared after the call to pg_to_acting_osds().

Signed-off-by: Sage Weil sage@inktank.com
