### PR TITLE
DNM: ceph-disk-active: Handle custom mount options for non-default-named clusters

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1589,10 +1589,16 @@ def mount_activate(
             e,
             )
 
-    # TODO always using mount options from cluster=ceph for
-    # now; see http://tracker.newdream.net/issues/3253
+    mount_options = None
+    path = mount(dev=dev, fstype=fstype, options=mount_options)
+
+    osd_id = None
+    cluster = None
+    try:
+        (osd_id, cluster) = activate(path, activate_key_template, init)
+
     mount_options = get_conf(
-        cluster='ceph',
+        cluster=cluster,
         variable='osd_mount_options_{fstype}'.format(
             fstype=fstype,
             ),
@@ -1600,7 +1606,7 @@ def mount_activate(
 
     if mount_options is None:
         mount_options = get_conf(
-            cluster='ceph',
+            cluster=cluster,
             variable='osd_fs_mount_options_{fstype}'.format(
                 fstype=fstype,
                 ),
@@ -1609,13 +1615,6 @@ def mount_activate(
     #remove whitespaces from mount_options
     if mount_options is not None:
         mount_options = "".join(mount_options.split())
-
-    path = mount(dev=dev, fstype=fstype, options=mount_options)
-
-    osd_id = None
-    cluster = None
-    try:
-        (osd_id, cluster) = activate(path, activate_key_template, init)
 
         # check if the disk is already active, or if something else is already
         # mounted there


### PR DESCRIPTION
Mount the disk temporally and read the cluster uuid, then load the
right config file. Unmount and pass the custom options to move_mount.

In my cluster, disk was activated immediately after ceph-disk-prepare for unknown reasons.
Signed-off-by: Kai Zhang zakir.exe@gmail.com
