### PR TITLE
use `partx` for CentOS/RHEL instead of `partprobe`

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -995,7 +995,8 @@ def prepare_journal_dev(
         # server. Since we are not resizing partitons so we rely on calling
         # partx
         if platform_distro().startswith(('centos', 'red')):
-            LOG.debug('Calling partx on prepared device %s', journal)
+            LOG.info('calling partx on prepared device %s', journal)
+            LOG.info('re-reading known partitions will display errors')
             command(
                 [
                     'partx',
@@ -1419,7 +1420,9 @@ def main_prepare(args):
             # the server. Since we are not resizing partitons so we rely on
             # calling partx
             if platform_distro().startswith(('centos', 'red')):
-                LOG.debug('Calling partx on prepared device %s', args.data)
+                LOG.info('calling partx on prepared device %s', args.data)
+                LOG.info('re-reading known partitions will display errors')
+
                 command(
                     [
                         'partx',


### PR DESCRIPTION
Those distros will force a user to reboot in order to get the kernel to re-read the partition that was created in the process of creating an OSD.

For a full/detailed description of the issue, see: http://tracker.ceph.com/issues/7334
Fix was verified on CentOS by adding two OSDs and seeing the partitions correctly listed:

```
[ubuntu@apama002 ~]$ sudo parted /dev/sdc print
Model: HP LOGICAL VOLUME (scsi)
Disk /dev/sdc: 3001GB
Sector size (logical/physical): 512B/512B
Partition Table: gpt

Number  Start   End     Size    File system  Name          Flags
 1      1049kB  5370MB  5369MB               ceph journal
 2      5370MB  10.7GB  5369MB               ceph journal
```
