### PR TITLE
ceph-disk: Handle custom mount options for non-default-named clusters

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1657,33 +1657,32 @@ def mount_activate(
             e,
             )
 
-    # TODO always using mount options from cluster=ceph for
-    # now; see http://tracker.newdream.net/issues/3253
-    mount_options = get_conf(
-        cluster='ceph',
-        variable='osd_mount_options_{fstype}'.format(
-            fstype=fstype,
-            ),
-        )
-
-    if mount_options is None:
-        mount_options = get_conf(
-            cluster='ceph',
-            variable='osd_fs_mount_options_{fstype}'.format(
-                fstype=fstype,
-                ),
-            )
-
-    #remove whitespaces from mount_options
-    if mount_options is not None:
-        mount_options = "".join(mount_options.split())
-
+    mount_options = None
     path = mount(dev=dev, fstype=fstype, options=mount_options)
 
     osd_id = None
     cluster = None
     try:
         (osd_id, cluster) = activate(path, activate_key_template, init)
+
+        mount_options = get_conf(
+            cluster=cluster,
+            variable='osd_mount_options_{fstype}'.format(
+                fstype=fstype,
+                ),
+            )
+    
+        if mount_options is None:
+            mount_options = get_conf(
+                cluster=cluster,
+                variable='osd_fs_mount_options_{fstype}'.format(
+                    fstype=fstype,
+                    ),
+                )
+    
+        #remove whitespaces from mount_options
+        if mount_options is not None:
+            mount_options = "".join(mount_options.split())
 
         # check if the disk is already active, or if something else is already
         # mounted there


### PR DESCRIPTION
Mount the disk temporally and read the cluster uuid, then load the right config file. 
Unmount and pass the custom options to move_mount.

Signed-off-by: Kai Zhang zakir.exe@gmail.com
