### PR TITLE
doc: highlight that "raw" is the only useful RBD format for QEMU

### DIFF
--- a/doc/rbd/qemu-rbd.rst
+++ b/doc/rbd/qemu-rbd.rst
@@ -40,11 +40,18 @@ You can create a block device image from QEMU. You must specify ``rbd``,  the
 pool name, and the name of the image you wish to create. You must also specify
 the size of the image. ::
 
-	qemu-img create -f rbd rbd:{pool-name}/{image-name} {size}
+	qemu-img create -f raw rbd:{pool-name}/{image-name} {size}
 
 For example::
 
-	qemu-img create -f rbd rbd:data/foo 10G
+	qemu-img create -f raw rbd:data/foo 10G
+
+.. important:: The ``raw`` data format is really the only sensible
+   ``format`` option to use with RBD. Technically, you could use other
+   QEMU-supported formats (such as ``qcow2`` or ``vmdk``), but doing
+   so would add additional overhead, and would also render the volume
+   unsafe for virtual machine live migration when caching (see below)
+   is enabled.
 
 
 Resizing Images with QEMU
@@ -54,11 +61,11 @@ You can resize a block device image from QEMU. You must specify ``rbd``,
 the pool name, and the name of the image you wish to resize. You must also
 specify the size of the image. ::
 
-	qemu-img resize -f rbd rbd:{pool-name}/{image-name} {size}
+	qemu-img resize rbd:{pool-name}/{image-name} {size}
 
 For example::
 
-	qemu-img resize -f rbd rbd:data/foo 10G
+	qemu-img resize rbd:data/foo 10G
 
 
 Retrieving Image Info with QEMU
@@ -67,11 +74,11 @@ Retrieving Image Info with QEMU
 You can retrieve block device image information from QEMU. You must 
 specify ``rbd``, the pool name, and the name of the image. ::
 
-	qemu-img info -f rbd rbd:{pool-name}/{image-name}
+	qemu-img info rbd:{pool-name}/{image-name}
 
 For example::
 
-	qemu-img info -f rbd rbd:data/foo
+	qemu-img info rbd:data/foo
 
 
 Running QEMU with RBD
@@ -86,7 +93,7 @@ an additional context switch, and can take advantage of `RBD caching`_.
 You can use ``qemu-img`` to convert existing virtual machine images to Ceph
 block device images. For example, if you have a qcow2 image, you could run::
 
-    qemu-img convert -f qcow2 -O rbd debian_squeeze.qcow2 rbd:data/squeeze
+    qemu-img convert -f qcow2 -O raw debian_squeeze.qcow2 rbd:data/squeeze
 
 To run a virtual machine booting from that image, you could run::
 


### PR DESCRIPTION
Small doc patch making clear that people should really be only using "raw" as their QEMU rbd format. This was previously briefly alluded to in the RBD/OpenStack doc, but not really explained.

Brief IRC discussion with @jdurgin on the subject:

(11:46:34 PM) fghaas: joshd, gregsfortytwo: could it be that the recommendation against using the qcow2 image format on rbd, and the fact that only raw images are supported for Qemu, aren't documented anywhere? Or is that no longer true and my knowledge is outdated?
(11:48:53 PM) joshd: fghaas: technically you can use qcow2, but it just adds overhead and makes live-migration with caching unsafe
(11:49:18 PM) joshd: fghaas: the docs could be more explicit about it though - it's just mentioned at the end of the qemu and openstack instructions iirc
(11:49:49 PM) fghaas: joshd, yes, plus the qemu examples all explicitly specify format=raw, but they don't really explain why
(11:51:46 PM) fghaas: also, if by "at the end of the qemu instructions" you refer to http://ceph.com/docs/next/rbd/qemu-rbd/, then that actually doesn't mention anything specific
(11:53:40 PM) joshd: yeah, I was thinking of http://ceph.com/docs/next/rbd/qemu-rbd/#running-qemu-with-rbd and http://ceph.com/docs/master/rbd/rbd-openstack/#booting-from-a-block-device
(02/11/2014 12:00:45 AM) fghaas: joshd: would you like a doc patch? :)
(12:01:05 AM) joshd: fghaas: of course!
(12:25:39 AM) fghaas: joshd: re the doc patch -- "qemu-img create -f rbd rbd:{pool-name}/{image-name} {size}" ... is that intentional? shouldn't that be "-f raw", because the driver is only concerned about the rbd: path prefix?
(12:26:52 AM) joshd: fghaas: yes, that should just be raw for clarity
(12:27:02 AM) fghaas: ok
