### PR TITLE
memstore: fix touch double-allocation

### DIFF
--- a/src/os/MemStore.cc
+++ b/src/os/MemStore.cc
@@ -1012,8 +1012,9 @@ int MemStore::_touch(coll_t cid, const ghobject_t& oid)
 
   ObjectRef o = c->get_object(oid);
   if (!o) {
-    c->object_map[oid].reset(new Object);
-    c->object_hash[oid].reset(new Object);
+    o.reset(new Object);
+    c->object_map[oid] = o;
+    c->object_hash[oid] = o;
   }
   return 0;
 }


### PR DESCRIPTION
Reported-by: Allen Samuels allen.samuels@sandisk.com Signed-off-by: Sage
Weil sage@inktank.com
