### PR TITLE
rgw: multi object delete should be idempotent

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2878,6 +2878,9 @@ void RGWDeleteMultiObj::execute()
     rgw_obj obj(bucket,(*iter));
     store->set_atomic(s->obj_ctx, obj);
     ret = store->delete_obj(s->obj_ctx, s->bucket_owner.get_id(), obj);
+    if (ret == -ENOENT) {
+      ret = 0;
+    }
     result = make_pair(*iter, ret);
 
     send_partial_response(result);


### PR DESCRIPTION
Fixes: #7346
When doing a multi object delete, if an object does not exist then we
should return a success code for that object.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
