### PR TITLE
mds: force update backtraces for previously created FS

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -809,6 +809,12 @@ version_t CInode::pre_dirty()
     assert(is_base());
     pv = get_projected_version() + 1;
   }
+  // force update backtrace for old format inode (see inode_t::decode)
+  if (inode.backtrace_version == 0 && !projected_nodes.empty()) {
+    inode_t *pi = projected_nodes.back()->inode;
+    if (pi->backtrace_version == 0)
+      pi->update_backtrace(pv);
+  }
   return pv;
 }
 

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2941,10 +2941,6 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
 
     wrlock_force(&in->xattrlock, mut);
   }
-
-  // update backtrace for old format inode. (see inode_t::decode)
-  if (pi->backtrace_version == 0)
-    pi->update_backtrace();
   
   mut->auth_pin(in);
   mdcache->predirty_journal_parents(mut, &le->metablob, in, 0, PREDIRTY_PRIMARY, 0, follows);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3264,11 +3264,6 @@ void Server::handle_client_setattr(MDRequest *mdr)
 
   // log + wait
   le->metablob.add_client_req(req->get_reqid(), req->get_oldest_client_tid());
-
-  // update backtrace for old format inode. (see inode_t::decode)
-  if (pi->backtrace_version == 0)
-    pi->update_backtrace();
-
   mdcache->predirty_journal_parents(mdr, &le->metablob, cur, 0, PREDIRTY_PRIMARY, false);
   mdcache->journal_dirty_inode(mdr, &le->metablob, cur);
   

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -448,6 +448,9 @@ private:
     //cout << "journaling " << in->inode.ino << " at " << my_offset << std::endl;
 
     inode_t *pi = in->get_projected_inode();
+    if ((state & fullbit::STATE_DIRTY) && pi->is_backtrace_updated())
+      state |= fullbit::STATE_DIRTYPARENT;
+
     bufferlist snapbl;
     sr_t *sr = in->get_projected_srnode();
     if (sr)

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -204,7 +204,7 @@ ostream& operator<<(ostream& out, const client_writeable_range_t& r)
  */
 void inode_t::encode(bufferlist &bl) const
 {
-  ENCODE_START(9, 6, bl);
+  ENCODE_START(10, 6, bl);
 
   ::encode(ino, bl);
   ::encode(rdev, bl);
@@ -247,7 +247,7 @@ void inode_t::encode(bufferlist &bl) const
 
 void inode_t::decode(bufferlist::iterator &p)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(9, 6, 6, p);
+  DECODE_START_LEGACY_COMPAT_LEN(10, 6, 6, p);
 
   ::decode(ino, p);
   ::decode(rdev, p);
@@ -297,8 +297,6 @@ void inode_t::decode(bufferlist::iterator &p)
     ::decode(backtrace_version, p);
   if (struct_v >= 7)
     ::decode(old_pools, p);
-  else
-    backtrace_version = 0; // note inode which has no backtrace
   if (struct_v >= 8)
     ::decode(max_size_ever, p);
   if (struct_v >= 9) {
@@ -307,6 +305,8 @@ void inode_t::decode(bufferlist::iterator &p)
   } else {
     inline_version = CEPH_INLINE_NONE;
   }
+  if (struct_v < 10)
+    backtrace_version = 0; // force update backtrace
 
   DECODE_FINISH(p);
 }

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -440,8 +440,8 @@ struct inode_t {
   bool is_backtrace_updated() {
     return backtrace_version == version;
   }
-  void update_backtrace() {
-    backtrace_version = version;
+  void update_backtrace(version_t pv=0) {
+    backtrace_version = pv ? pv : version;
   }
 
   void add_old_pool(int64_t l) {


### PR DESCRIPTION
Update inode format version to 10, treat any previously created
inode as no backtrace. When inode with no backtrace is modified,
force update its backtrace.

Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
