### PR TITLE
rgw: add compatibility for MultipartUpload

### DIFF
--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -48,7 +48,8 @@ bool RGWMultiCompleteUpload::xml_end(const char *el) {
 
 XMLObj *RGWMultiXMLParser::alloc_obj(const char *el) {
   XMLObj *obj = NULL;
-  if (strcmp(el, "CompleteMultipartUpload") == 0) {
+  if (strcmp(el, "CompleteMultipartUpload") == 0 ||
+      strcmp(el, "MultipartUpload") == 0) {
     obj = new RGWMultiCompleteUpload();
   } else if (strcmp(el, "Part") == 0) {
     obj = new RGWMultiPart();


### PR DESCRIPTION
Fixes: #6677
It seems that there's some external library that uses MultipartUpload
instead of CompleteMultipartUpload, even though it's not part of the
documented api. Support it.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
