### PR TITLE
mds: Add encode/decode/dump for use with dencoder

### DIFF
--- a/doc/man/8/ceph-dencoder.rst
+++ b/doc/man/8/ceph-dencoder.rst
@@ -45,6 +45,11 @@ Commands
 
    Select the given type for future ``encode`` or ``decode`` operations.
 
+.. option:: skip <bytes>
+
+   Seek <bytes> into the imported file before reading data structure, use
+   this with objects that have a preamble/header before the object of interest.
+
 .. option:: decode
 
    Decode the contents of the in-memory buffer into an instance of the
@@ -84,7 +89,9 @@ Commands
 Example
 =======
 
-Say you want to examine an attribute on an object stored by ``ceph-osd``.  You can do::
+Say you want to examine an attribute on an object stored by ``ceph-osd``.  You can do this:
+
+::
 
     $ cd /mnt/osd.12/current/2.b_head
     $ attr -l foo_bar_head_EFE6384B
@@ -112,6 +119,21 @@ Say you want to examine an attribute on an object stored by ``ceph-osd``.  You c
       "truncate_seq": 0,
       "truncate_size": 0,
       "watchers": {}}
+
+Alternatively, perhaps you wish to dump an internal CephFS metadata object, you might
+do that like this:
+
+::
+
+   $ rados -p metadata get mds_snaptable mds_snaptable.bin
+   $ ceph-dencoder type SnapServer skip 8 import mds_snaptable.bin decode dump_json
+   { "snapserver": { "last_snap": 1,
+      "pending_noop": [],
+      "snaps": [],
+      "need_to_purge": {},
+      "pending_create": [],
+      "pending_destroy": []}} 
+
 
 Availability
 ============

--- a/src/mds/AnchorServer.h
+++ b/src/mds/AnchorServer.h
@@ -33,7 +33,7 @@ class AnchorServer : public MDSTableServer {
   map<inodeno_t, list<pair<version_t, Context*> > > pending_ops;
 
   void reset_state();
-  void encode_server_state(bufferlist& bl) {
+  void encode_server_state(bufferlist& bl) const {
     ENCODE_START(2, 2, bl);
     ::encode(anchor_map, bl);
     ::encode(pending_create, bl);
@@ -70,10 +70,11 @@ class AnchorServer : public MDSTableServer {
   // for the dencoder
   AnchorServer() : MDSTableServer(NULL, TABLE_ANCHOR) {}
   void encode(bufferlist& bl) const {
-    AnchorServer *me = const_cast<AnchorServer*>(this);
-    me->encode_server_state(bl);
+    encode_server_state(bl);
   }
-  void decode(bufferlist::iterator& bl) { decode_server_state(bl); }
+  void decode(bufferlist::iterator& bl) {
+    decode_server_state(bl);
+  }
 
   // server bits
   void _prepare(bufferlist &bl, uint64_t reqid, int bymds);

--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -156,3 +156,34 @@ void InoTable::skip_inos(inodeno_t i)
   projected_version = ++version;
   dout(10) << "skip_inos now " << free << dendl;
 }
+
+void InoTable::dump(Formatter *f) const
+{
+  f->open_object_section("inotable");
+
+  f->open_array_section("projected_free");
+  for (interval_set<inodeno_t>::const_iterator i = projected_free.begin(); i != projected_free.end(); ++i) {
+    f->open_object_section("range");
+    f->dump_int("start", (*i).first);
+    f->dump_int("len", (*i).second);
+    f->close_section();
+  }
+  f->close_section();
+
+  f->open_array_section("free");
+  for (interval_set<inodeno_t>::const_iterator i = free.begin(); i != free.end(); ++i) {
+    f->open_object_section("range");
+    f->dump_int("start", (*i).first);
+    f->dump_int("len", (*i).second);
+    f->close_section();
+  }
+  f->close_section();
+
+  f->close_section();
+}
+
+
+void InoTable::generate_test_instances(list<InoTable*>& ls)
+{
+  ls.push_back(new InoTable());
+}

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -43,7 +43,7 @@ class InoTable : public MDSTable {
   void replay_reset();
 
   void reset_state();
-  void encode_state(bufferlist& bl) {
+  void encode_state(bufferlist& bl) const {
     ENCODE_START(2, 2, bl);
     ::encode(free, bl);
     ENCODE_FINISH(bl);
@@ -54,6 +54,17 @@ class InoTable : public MDSTable {
     projected_free = free;
     DECODE_FINISH(bl);
   }
+
+  // To permit enc/decoding in isolation in dencoder
+  InoTable() : MDSTable(NULL, "inotable", true) {}
+  void encode(bufferlist& bl) const {
+    encode_state(bl);
+  }
+  void decode(bufferlist::iterator& bl) {
+    decode_state(bl);
+  }
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<InoTable*>& ls);
 
   void skip_inos(inodeno_t i);
 };

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -27,7 +27,7 @@
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
-#define dout_prefix *_dout << "mds." << mds->get_nodeid() << "." << table_name << ": "
+#define dout_prefix *_dout << "mds." << (mds ? mds->get_nodeid() : -1) << "." << table_name << ": "
 
 
 class C_MT_Save : public Context {

--- a/src/mds/MDSTable.h
+++ b/src/mds/MDSTable.h
@@ -79,7 +79,7 @@ public:
   // child must overload these
   virtual void reset_state() = 0;
   virtual void decode_state(bufferlist::iterator& p) = 0;
-  virtual void encode_state(bufferlist& bl) = 0;
+  virtual void encode_state(bufferlist& bl) const = 0;
 };
 
 #endif

--- a/src/mds/MDSTableServer.h
+++ b/src/mds/MDSTableServer.h
@@ -77,10 +77,10 @@ private:
   void handle_request(MMDSTableRequest *m);
   void do_server_update(bufferlist& bl);
 
-  virtual void encode_server_state(bufferlist& bl) = 0;
+  virtual void encode_server_state(bufferlist& bl) const = 0;
   virtual void decode_server_state(bufferlist::iterator& bl) = 0;
 
-  void encode_state(bufferlist& bl) {
+  void encode_state(bufferlist& bl) const {
     encode_server_state(bl);
     ::encode(pending_for_mds, bl);
   }

--- a/src/mds/SnapServer.h
+++ b/src/mds/SnapServer.h
@@ -39,7 +39,7 @@ public:
 		       last_checked_osdmap(0) { }
     
   void reset_state();
-  void encode_server_state(bufferlist& bl) {
+  void encode_server_state(bufferlist& bl) const {
     ENCODE_START(3, 3, bl);
     ::encode(last_snap, bl);
     ::encode(snaps, bl);
@@ -66,6 +66,17 @@ public:
     ::decode(pending_noop, bl);
     DECODE_FINISH(bl);
   }
+
+  // To permit enc/decoding in isolation in dencoder
+  SnapServer() : MDSTableServer(NULL, TABLE_SNAP), last_checked_osdmap(0) {}
+  void encode(bufferlist& bl) const {
+    encode_server_state(bl);
+  }
+  void decode(bufferlist::iterator& bl) {
+    decode_server_state(bl);
+  }
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<SnapServer*>& ls);
 
   // server bits
   void _prepare(bufferlist &bl, uint64_t reqid, int bymds);

--- a/src/osdc/Journaler.h
+++ b/src/osdc/Journaler.h
@@ -98,6 +98,38 @@ public:
       ::decode(write_pos, bl);
       ::decode(layout, bl);
     }
+
+    void dump(Formatter *f) const {
+      f->open_object_section("journal_header");
+      {
+	f->dump_string("magic", magic);
+	f->dump_unsigned("write_pos", write_pos);
+	f->dump_unsigned("expire_pos", expire_pos);
+	f->dump_unsigned("trimmed_pos", trimmed_pos);
+	f->open_object_section("layout");
+	{
+	  f->dump_unsigned("stripe_unit", layout.fl_stripe_unit);
+	  f->dump_unsigned("stripe_count", layout.fl_stripe_unit);
+	  f->dump_unsigned("object_size", layout.fl_stripe_unit);
+	  f->dump_unsigned("cas_hash", layout.fl_stripe_unit);
+	  f->dump_unsigned("object_stripe_unit", layout.fl_stripe_unit);
+	  f->dump_unsigned("pg_pool", layout.fl_stripe_unit);
+	}
+	f->close_section(); // layout
+      }
+      f->close_section(); // journal_header
+    }
+
+    static void generate_test_instances(list<Header*> &ls)
+    {
+      ls.push_back(new Header());
+      ls.push_back(new Header());
+      ls.back()->trimmed_pos = 1;
+      ls.back()->expire_pos = 2;
+      ls.back()->unused_field = 3;
+      ls.back()->write_pos = 4;
+      ls.back()->magic = "magique";
+    }
   } last_written, last_committed;
   WRITE_CLASS_ENCODER(Header)
 

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -129,6 +129,9 @@ TYPE(MonCap)
 TYPE(DBObjectMap::_Header)
 TYPE(DBObjectMap::State)
 
+#include "osdc/Journaler.h"
+TYPE(Journaler::Header)
+
 #include "mds/Anchor.h"
 TYPE(Anchor)
 
@@ -164,7 +167,13 @@ TYPE_FEATUREFUL(MDSMap::mds_info_t)
 TYPE_NOCOPY(Capability)
 
 #include "mds/AnchorServer.h"
-TYPE(AnchorServer)
+TYPEWITHSTRAYDATA(AnchorServer)
+
+#include "mds/InoTable.h"
+TYPE(InoTable)
+
+#include "mds/SnapServer.h"
+TYPEWITHSTRAYDATA(SnapServer)
 
 #include "mds/SessionMap.h"
 TYPE(SessionMap)


### PR DESCRIPTION
This is for the MDSTable subclasses, and adding 'skip' to dencoder to deal with version preambles on the objects containing them.

Signed-off-by: John Spray john.spray@inktank.com
