### PR TITLE
rgw: fix swift range response

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -536,7 +536,7 @@ int RGWGetObj_ObjStore_SWIFT::send_response_data(bufferlist& bl, off_t bl_ofs, o
     goto send_data;
 
   if (range_str)
-    dump_range(s, ofs, start, s->obj_size);
+    dump_range(s, ofs, end, s->obj_size);
 
   dump_content_length(s, total_len);
   dump_last_modified(s, lastmod);


### PR DESCRIPTION
Fixes: #7099
Backport: dumpling
The range response header was broken in swift.

Reported-by: Julien Calvet julien.calvet@neurea.com
Signed-off-by: Yehuda Sadeh yehuda@inktank.com
