### PR TITLE
rgw: reset objv tracker on bucket recreation

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -688,6 +688,11 @@ struct RGWObjVersionTracker {
     write_version = obj_version();
   }
 
+  void clear() {
+    read_version = obj_version();
+    write_version = obj_version();
+  }
+
   void generate_new_write_ver(CephContext *cct);
 };
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2357,6 +2357,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     ret = put_linked_bucket_info(info, exclusive, 0, pep_objv, &attrs, true);
     if (ret == -EEXIST) {
        /* we need to reread the info and return it, caller will have a use for it */
+      info.objv_tracker.clear();
       r = get_bucket_info(NULL, bucket.name, info, NULL, NULL);
       if (r < 0) {
         if (r == -ENOENT) {


### PR DESCRIPTION
Fixes: #6951
If we cannot create a new bucket (as it already existed), we need to
read the old bucket's info. However, this was failing as we were holding
the objv tracker that we created for the bucket creation. We need to
clear it, as subsequent read using it will fail.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
