### PR TITLE
radosgw-admin: don't generate access key if user exists

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1356,7 +1356,9 @@ int main(int argc, char **argv)
   case OPT_USER_INFO:
     break;
   case OPT_USER_CREATE:
-    user_op.set_generate_key(); // generate a new key by default
+    if (!user_op.has_existing_user()) {
+      user_op.set_generate_key(); // generate a new key by default
+    }
     ret = user.add(user_op, &err_msg);
     if (ret < 0) {
       cerr << "could not create user: " << err_msg << std::endl;


### PR DESCRIPTION
Fixes: #6936
We want the user creation operation to be idempotent, so if user already
exists don't generate a new access key.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
