### PR TITLE
osd/PG: fix assert when deep repair finds no errors

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4291,7 +4291,7 @@ void PG::scrub_finish()
   // when every one has been fixed.
   if (repair) {
     if (scrubber.fixed == scrubber.shallow_errors + scrubber.deep_errors) {
-      assert(deep_scrub);
+      assert(deep_scrub || scrubber.deep_errors == 0);
       scrubber.shallow_errors = scrubber.deep_errors = 0;
     } else {
       // Deep scrub in order to get corrected error counts


### PR DESCRIPTION
If there are no deep repairs, we don't want to assert. Fixes:

```
-1> 2014-02-21 21:13:56.393087 7f0258ff9700  0 log [INF] : 0.0 repair ok,
```

0 fixed
    0> 2014-02-21 21:13:56.428703 7f0258ff9700 -1 osd/PG.cc: In function
'void PG::scrub_finish()' thread 7f0258ff9700 time 2014-02-21 21:13:56.393127 
osd/PG.cc: 4294: FAILED assert(deep_scrub)

Signed-off-by: David Zafman david.zafman@inktank.com Signed-off-by: Sage
Weil sage@inktank.com
