### PR TITLE
mon/PGMonitor: fix primary osd check on deep-scrub

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1539,7 +1539,7 @@ bool PGMonitor::preprocess_command(MMonCommand *m)
       r = -ENOENT;
       goto reply;
     }
-    if (pg_map.pg_stat[pgid].acting_primary != -1) {
+    if (pg_map.pg_stat[pgid].acting_primary == -1) {
       ss << "pg " << pgid << " has no primary osd";
       r = -EAGAIN;
       goto reply;


### PR DESCRIPTION
s/!=/==/.  Logic was reversed.

Broken in 40bdcb88504aea6288d461d29d24d5b0bf7aeebc.

Signed-off-by: Sage Weil sage@inktank.com
