### PR TITLE
client: fix possible null dereference in create

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8138,7 +8138,8 @@ out:
 
   // passing an Inode in outp requires an additional ref
   if (outp) {
-    _ll_get(in);
+    if (in)
+      _ll_get(in);
     *outp = in;
   }
 


### PR DESCRIPTION
There are two paths that jump to the out label for which 'in' can be NULL and
outp can be non-NULL.  For those cases we want to fill in the caller's pointer
value (they asked for it) but we clearly cannot take a reference.

Backport: emperor, dumpling Signed-off-by: Sage Weil sage@inktank.com
