### PR TITLE
compat: avoid unused warn with TEMP_FAILURE_RETRY

### DIFF
--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -42,7 +42,7 @@ int get_random_bytes(char *buf, int len)
   if (fd < 0)
     return -errno;
   int ret = safe_read_exact(fd, buf, len);
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   return ret;
 }
 

--- a/src/common/OutputDataSocket.cc
+++ b/src/common/OutputDataSocket.cc
@@ -62,7 +62,7 @@ static bool cleanup_atexit = false;
 static void remove_cleanup_file(const char *file)
 {
   pthread_mutex_lock(&cleanup_lock);
-  TEMP_FAILURE_RETRY(unlink(file));
+  VOID_TEMP_FAILURE_RETRY(unlink(file));
   for (std::vector <const char*>::iterator i = cleanup_files.begin();
        i != cleanup_files.end(); ++i) {
     if (strcmp(file, *i) == 0) {
@@ -79,7 +79,7 @@ static void remove_all_cleanup_files()
   pthread_mutex_lock(&cleanup_lock);
   for (std::vector <const char*>::iterator i = cleanup_files.begin();
        i != cleanup_files.end(); ++i) {
-    TEMP_FAILURE_RETRY(unlink(*i));
+    VOID_TEMP_FAILURE_RETRY(unlink(*i));
     free((void*)*i);
   }
   cleanup_files.clear();
@@ -170,7 +170,7 @@ std::string OutputDataSocket::bind_and_listen(const std::string &sock_path, int 
   int r = fcntl(sock_fd, F_SETFD, FD_CLOEXEC);
   if (r < 0) {
     r = errno;
-    TEMP_FAILURE_RETRY(::close(sock_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(sock_fd));
     ostringstream oss;
     oss << "OutputDataSocket::bind_and_listen: failed to fcntl on socket: " << cpp_strerror(r);
     return oss.str();
@@ -185,7 +185,7 @@ std::string OutputDataSocket::bind_and_listen(const std::string &sock_path, int 
     if (err == EADDRINUSE) {
       // The old UNIX domain socket must still be there.
       // Let's unlink it and try again.
-      TEMP_FAILURE_RETRY(unlink(sock_path.c_str()));
+      VOID_TEMP_FAILURE_RETRY(unlink(sock_path.c_str()));
       if (bind(sock_fd, (struct sockaddr*)&address,
 	       sizeof(struct sockaddr_un)) == 0) {
 	err = 0;
@@ -209,7 +209,7 @@ std::string OutputDataSocket::bind_and_listen(const std::string &sock_path, int 
     oss << "OutputDataSocket::bind_and_listen: "
 	  << "failed to listen to socket: " << cpp_strerror(err);
     close(sock_fd);
-    TEMP_FAILURE_RETRY(unlink(sock_path.c_str()));
+    VOID_TEMP_FAILURE_RETRY(unlink(sock_path.c_str()));
     return oss.str();
   }
   *fd = sock_fd;
@@ -342,7 +342,7 @@ int OutputDataSocket::dump_data(int fd)
 
 void OutputDataSocket::close_connection(int fd)
 {
-  TEMP_FAILURE_RETRY(close(fd));
+  VOID_TEMP_FAILURE_RETRY(close(fd));
 }
 
 bool OutputDataSocket::init(const std::string &path)
@@ -391,7 +391,7 @@ void OutputDataSocket::shutdown()
   // Send a byte to the shutdown pipe that the thread is listening to
   char buf[1] = { 0x0 };
   int ret = safe_write(m_shutdown_wr_fd, buf, sizeof(buf));
-  TEMP_FAILURE_RETRY(close(m_shutdown_wr_fd));
+  VOID_TEMP_FAILURE_RETRY(close(m_shutdown_wr_fd));
   m_shutdown_wr_fd = -1;
 
   if (ret == 0) {

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -65,7 +65,7 @@ static bool cleanup_atexit = false;
 static void remove_cleanup_file(const char *file)
 {
   pthread_mutex_lock(&cleanup_lock);
-  TEMP_FAILURE_RETRY(unlink(file));
+  VOID_TEMP_FAILURE_RETRY(unlink(file));
   for (std::vector <const char*>::iterator i = cleanup_files.begin();
        i != cleanup_files.end(); ++i) {
     if (strcmp(file, *i) == 0) {
@@ -82,7 +82,7 @@ static void remove_all_cleanup_files()
   pthread_mutex_lock(&cleanup_lock);
   for (std::vector <const char*>::iterator i = cleanup_files.begin();
        i != cleanup_files.end(); ++i) {
-    TEMP_FAILURE_RETRY(unlink(*i));
+    VOID_TEMP_FAILURE_RETRY(unlink(*i));
     free((void*)*i);
   }
   cleanup_files.clear();
@@ -172,7 +172,7 @@ std::string AdminSocket::bind_and_listen(const std::string &sock_path, int *fd)
   int r = fcntl(sock_fd, F_SETFD, FD_CLOEXEC);
   if (r < 0) {
     r = errno;
-    TEMP_FAILURE_RETRY(::close(sock_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(sock_fd));
     ostringstream oss;
     oss << "AdminSocket::bind_and_listen: failed to fcntl on socket: " << cpp_strerror(r);
     return oss.str();
@@ -193,7 +193,7 @@ std::string AdminSocket::bind_and_listen(const std::string &sock_path, int *fd)
 	err = EEXIST;
       } else {
 	ldout(m_cct, 20) << "unlink stale file " << sock_path << dendl;
-	TEMP_FAILURE_RETRY(unlink(sock_path.c_str()));
+	VOID_TEMP_FAILURE_RETRY(unlink(sock_path.c_str()));
 	if (bind(sock_fd, (struct sockaddr*)&address,
 		 sizeof(struct sockaddr_un)) == 0) {
 	  err = 0;
@@ -217,7 +217,7 @@ std::string AdminSocket::bind_and_listen(const std::string &sock_path, int *fd)
     oss << "AdminSocket::bind_and_listen: "
 	  << "failed to listen to socket: " << cpp_strerror(err);
     close(sock_fd);
-    TEMP_FAILURE_RETRY(unlink(sock_path.c_str()));
+    VOID_TEMP_FAILURE_RETRY(unlink(sock_path.c_str()));
     return oss.str();
   }
   *fd = sock_fd;
@@ -386,7 +386,7 @@ bool AdminSocket::do_accept()
   }
   m_lock.Unlock();
 
-  TEMP_FAILURE_RETRY(close(connection_fd));
+  VOID_TEMP_FAILURE_RETRY(close(connection_fd));
   return rval;
 }
 
@@ -551,7 +551,7 @@ void AdminSocket::shutdown()
   // Send a byte to the shutdown pipe that the thread is listening to
   char buf[1] = { 0x0 };
   int ret = safe_write(m_shutdown_wr_fd, buf, sizeof(buf));
-  TEMP_FAILURE_RETRY(close(m_shutdown_wr_fd));
+  VOID_TEMP_FAILURE_RETRY(close(m_shutdown_wr_fd));
   m_shutdown_wr_fd = -1;
 
   if (ret == 0) {

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -399,9 +399,9 @@ static uint32_t simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZE
 
     void close_pipe(int *fds) {
       if (fds[0] >= 0)
-	TEMP_FAILURE_RETRY(::close(fds[0]));
+	VOID_TEMP_FAILURE_RETRY(::close(fds[0]));
       if (fds[1] >= 0)
-	TEMP_FAILURE_RETRY(::close(fds[1]));
+	VOID_TEMP_FAILURE_RETRY(::close(fds[1]));
     }
     char *copy_pipe(int *fds) {
       /* preserve original pipe contents by copying into a temporary
@@ -1496,7 +1496,7 @@ int buffer::list::read_file(const char *fn, std::string *error)
     oss << "bufferlist::read_file(" << fn << "): read error:"
 	<< cpp_strerror(ret);
     *error = oss.str();
-    TEMP_FAILURE_RETRY(::close(fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
     return ret;
   }
   else if (ret != st.st_size) {
@@ -1507,7 +1507,7 @@ int buffer::list::read_file(const char *fn, std::string *error)
     *error = oss.str();
     // not actually an error, but weird
   }
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   return 0;
 }
 
@@ -1559,7 +1559,7 @@ int buffer::list::write_file(const char *fn, int mode)
   if (ret) {
     cerr << "bufferlist::write_fd(" << fn << "): write_fd error: "
 	 << cpp_strerror(ret) << std::endl;
-    TEMP_FAILURE_RETRY(::close(fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
     return ret;
   }
   if (TEMP_FAILURE_RETRY(::close(fd))) {

--- a/src/common/pipe.c
+++ b/src/common/pipe.c
@@ -53,8 +53,8 @@ int pipe_cloexec(int pipefd[2])
 	return 0;
 
 out:
-	TEMP_FAILURE_RETRY(close(pipefd[0]));
-	TEMP_FAILURE_RETRY(close(pipefd[1]));
+	VOID_TEMP_FAILURE_RETRY(close(pipefd[0]));
+	VOID_TEMP_FAILURE_RETRY(close(pipefd[1]));
 
 	return ret;
 #endif

--- a/src/common/safe_io.c
+++ b/src/common/safe_io.c
@@ -175,13 +175,13 @@ int safe_write_file(const char *base, const char *file,
   }
   ret = safe_write(fd, val, vallen);
   if (ret) {
-    TEMP_FAILURE_RETRY(close(fd));
+    VOID_TEMP_FAILURE_RETRY(close(fd));
     return ret;
   }
 
   ret = fsync(fd);
   if (ret < 0) ret = -errno;
-  TEMP_FAILURE_RETRY(close(fd));
+  VOID_TEMP_FAILURE_RETRY(close(fd));
   if (ret < 0) {
     unlink(tmp);
     return ret;
@@ -200,7 +200,7 @@ int safe_write_file(const char *base, const char *file,
   }
   ret = fsync(fd);
   if (ret < 0) ret = -errno;
-  TEMP_FAILURE_RETRY(close(fd));
+  VOID_TEMP_FAILURE_RETRY(close(fd));
 
   return ret;
 }
@@ -218,11 +218,11 @@ int safe_read_file(const char *base, const char *file,
   }
   len = safe_read(fd, val, vallen - 1);
   if (len < 0) {
-    TEMP_FAILURE_RETRY(close(fd));
+    VOID_TEMP_FAILURE_RETRY(close(fd));
     return len;
   }
   // close sometimes returns errors, but only after write()
-  TEMP_FAILURE_RETRY(close(fd));
+  VOID_TEMP_FAILURE_RETRY(close(fd));
 
   val[len] = 0;
   return len;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -201,14 +201,14 @@ void global_init_postfork(CephContext *cct, int flags)
    * guarantee that nobody ever writes to stdout, even though they're not
    * supposed to.
    */
-  TEMP_FAILURE_RETRY(close(STDIN_FILENO));
+  VOID_TEMP_FAILURE_RETRY(close(STDIN_FILENO));
   if (open("/dev/null", O_RDONLY) < 0) {
     int err = errno;
     derr << "global_init_daemonize: open(/dev/null) failed: error "
 	 << err << dendl;
     exit(1);
   }
-  TEMP_FAILURE_RETRY(close(STDOUT_FILENO));
+  VOID_TEMP_FAILURE_RETRY(close(STDOUT_FILENO));
   if (open("/dev/null", O_RDONLY) < 0) {
     int err = errno;
     derr << "global_init_daemonize: open(/dev/null) failed: error "
@@ -245,7 +245,7 @@ void global_init_chdir(const CephContext *cct)
  */
 int global_init_shutdown_stderr(CephContext *cct)
 {
-  TEMP_FAILURE_RETRY(close(STDERR_FILENO));
+  VOID_TEMP_FAILURE_RETRY(close(STDERR_FILENO));
   if (open("/dev/null", O_RDONLY) < 0) {
     int err = errno;
     derr << "global_init_shutdown_stderr: open(/dev/null) failed: error "

--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -57,7 +57,7 @@ int pidfile_write(const md_config_t *conf)
   if (ret < 0) {
     derr << "write_pid_file: failed to write to pid file '"
 	 << pid_file << "': " << cpp_strerror(ret) << dendl;
-    TEMP_FAILURE_RETRY(::close(fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
     return ret;
   }
   if (TEMP_FAILURE_RETRY(::close(fd))) {
@@ -82,7 +82,7 @@ int pidfile_remove(void)
   char buf[32];
   memset(buf, 0, sizeof(buf));
   ssize_t res = safe_read(fd, buf, sizeof(buf));
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   if (res < 0)
     return res;
   int a = atoi(buf);

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -26,6 +26,14 @@
   __result; })
 #endif
 
+#ifdef __cplusplus
+# define VOID_TEMP_FAILURE_RETRY(expression) \
+   static_cast<void>(TEMP_FAILURE_RETRY(expression))
+#else
+# define VOID_TEMP_FAILURE_RETRY(expression) \
+   do { (void)TEMP_FAILURE_RETRY(expression); } while (0)
+#endif
+
 #if defined(__FreeBSD__) || defined(__APPLE__)
 #define lseek64(fd, offset, whence) lseek(fd, offset, whence)
 #endif

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -72,7 +72,7 @@ Log::~Log()
 
   assert(!is_started());
   if (m_fd >= 0)
-    TEMP_FAILURE_RETRY(::close(m_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(m_fd));
 
   pthread_mutex_destroy(&m_queue_mutex);
   pthread_mutex_destroy(&m_flush_mutex);
@@ -113,7 +113,7 @@ void Log::set_log_file(string fn)
 void Log::reopen_log_file()
 {
   if (m_fd >= 0)
-    TEMP_FAILURE_RETRY(::close(m_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(m_fd));
   if (m_log_file.length()) {
     m_fd = ::open(m_log_file.c_str(), O_CREAT|O_WRONLY|O_APPEND, 0644);
   } else {

--- a/src/mds/Dumper.cc
+++ b/src/mds/Dumper.cc
@@ -184,7 +184,7 @@ void Dumper::undump(const char *dump_file)
   char buf[200];
   int r = safe_read(fd, buf, sizeof(buf));
   if (r < 0) {
-    TEMP_FAILURE_RETRY(::close(fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
     return;
   }
 
@@ -247,7 +247,7 @@ void Dumper::undump(const char *dump_file)
     left -= l;
   }
 
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   cout << "done." << std::endl;
 }
 

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -163,7 +163,7 @@ void LogMonitor::update_from_paxos(bool *need_bootstrap)
 	dout(1) << "error writing to " << g_conf->mon_cluster_log_file
 		<< ": " << cpp_strerror(err) << dendl;
       }
-      TEMP_FAILURE_RETRY(::close(fd));
+      VOID_TEMP_FAILURE_RETRY(::close(fd));
     }
   }
 

--- a/src/os/FDCache.h
+++ b/src/os/FDCache.h
@@ -44,7 +44,7 @@ public:
       return fd;
     }
     ~FD() {
-      TEMP_FAILURE_RETRY(::close(fd));
+      VOID_TEMP_FAILURE_RETRY(::close(fd));
     }
   };
 

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -124,7 +124,7 @@ int FileJournal::_open(bool forwrite, bool create)
   return 0;
 
  out_fd:
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   return ret;
 }
 
@@ -344,7 +344,7 @@ int FileJournal::check()
   ret = 0;
 
  done:
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   fd = -1;
   return ret;
 }
@@ -545,7 +545,7 @@ void FileJournal::close()
   // close
   assert(writeq_empty());
   assert(fd >= 0);
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   fd = -1;
 }
 

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -269,7 +269,7 @@ int FileStore::lfn_open(coll_t cid,
     if (create && (!exist)) {
       r = (*index)->created(oid, (*path)->path());
       if (r < 0) {
-	TEMP_FAILURE_RETRY(::close(fd));
+	VOID_TEMP_FAILURE_RETRY(::close(fd));
 	derr << "error creating " << oid << " (" << (*path)->path()
 	     << ") in index: " << cpp_strerror(-r) << dendl;
 	goto fail;
@@ -281,7 +281,7 @@ int FileStore::lfn_open(coll_t cid,
     Mutex::Locker l(fdcache_lock);
     *outfd = fdcache.lookup(oid);
     if (*outfd) {
-      TEMP_FAILURE_RETRY(::close(fd));
+      VOID_TEMP_FAILURE_RETRY(::close(fd));
       return 0;
     } else {
       *outfd = fdcache.add(oid, fd);
@@ -703,7 +703,7 @@ int FileStore::mkfs()
     if (initial_seq == 0) {
       int err = write_op_seq(fd, 1);
       if (err < 0) {
-	TEMP_FAILURE_RETRY(::close(fd));
+	VOID_TEMP_FAILURE_RETRY(::close(fd));
 	derr << "mkfs: failed to write to " << current_op_seq_fn << ": "
 	     << cpp_strerror(err) << dendl;
 	goto close_fsid_fd;
@@ -716,15 +716,15 @@ int FileStore::mkfs()
 	char s[NAME_MAX];
 	snprintf(s, sizeof(s), COMMIT_SNAP_ITEM, 1ull);
 	ret = backend->create_checkpoint(s, NULL);
-	TEMP_FAILURE_RETRY(::close(current_fd));
+	VOID_TEMP_FAILURE_RETRY(::close(current_fd));
 	if (ret < 0 && ret != -EEXIST) {
-	  TEMP_FAILURE_RETRY(::close(fd));  
+	  VOID_TEMP_FAILURE_RETRY(::close(fd));  
 	  derr << "mkfs: failed to create snap_1: " << cpp_strerror(ret) << dendl;
 	  goto close_fsid_fd;
 	}
       }
     }
-    TEMP_FAILURE_RETRY(::close(fd));  
+    VOID_TEMP_FAILURE_RETRY(::close(fd));  
   }
 
   {
@@ -751,10 +751,10 @@ int FileStore::mkfs()
   ret = 0;
 
  close_fsid_fd:
-  TEMP_FAILURE_RETRY(::close(fsid_fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
   fsid_fd = -1;
  close_basedir_fd:
-  TEMP_FAILURE_RETRY(::close(basedir_fd));
+  VOID_TEMP_FAILURE_RETRY(::close(basedir_fd));
   if (backend != generic_backend) {
     delete backend;
     backend = generic_backend;
@@ -777,10 +777,10 @@ int FileStore::mkjournal()
   ret = read_fsid(fd, &fsid);
   if (ret < 0) {
     derr << "FileStore::mkjournal: read error: " << cpp_strerror(ret) << dendl;
-    TEMP_FAILURE_RETRY(::close(fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
     return ret;
   }
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
 
   ret = 0;
 
@@ -851,7 +851,7 @@ bool FileStore::test_mount_in_use()
   if (fsid_fd < 0)
     return 0;   // no fsid, ok.
   bool inuse = lock_fsid() < 0;
-  TEMP_FAILURE_RETRY(::close(fsid_fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
   fsid_fd = -1;
   return inuse;
 }
@@ -921,7 +921,7 @@ int FileStore::_detect_fs()
     *_dout << "If you are using ext3 or ext4, be sure to mount the underlying "
 	   << "file system with the 'user_xattr' option." << dendl;
     ::unlink(fn);
-    TEMP_FAILURE_RETRY(::close(tmpfd));
+    VOID_TEMP_FAILURE_RETRY(::close(tmpfd));
     return -ENOTSUP;
   }
 
@@ -942,7 +942,7 @@ int FileStore::_detect_fs()
   chain_fremovexattr(tmpfd, "user.test5");
 
   ::unlink(fn);
-  TEMP_FAILURE_RETRY(::close(tmpfd));
+  VOID_TEMP_FAILURE_RETRY(::close(tmpfd));
 
   return 0;
 }
@@ -1081,7 +1081,7 @@ int FileStore::read_op_seq(uint64_t *seq)
   int ret = safe_read(op_fd, s, sizeof(s) - 1);
   if (ret < 0) {
     derr << "error reading " << current_op_seq_fn << ": " << cpp_strerror(ret) << dendl;
-    TEMP_FAILURE_RETRY(::close(op_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(op_fd));
     assert(!m_filestore_fail_eio || ret != -EIO);
     return ret;
   }
@@ -1248,7 +1248,7 @@ int FileStore::mount()
 	{
 	  int fd = read_op_seq(&curr_seq);
 	  if (fd >= 0) {
-	    TEMP_FAILURE_RETRY(::close(fd));
+	    VOID_TEMP_FAILURE_RETRY(::close(fd));
 	  }
 	}
 	if (curr_seq)
@@ -1323,7 +1323,7 @@ int FileStore::mount()
       derr << "FileStore::mount: failed to create current/nosnap" << dendl;
       goto close_current_fd;
     }
-    TEMP_FAILURE_RETRY(::close(r));
+    VOID_TEMP_FAILURE_RETRY(::close(r));
   } else {
     // clear nosnap marker, if present.
     ::unlink(nosnapfn);
@@ -1482,13 +1482,13 @@ int FileStore::mount()
   return 0;
 
 close_current_fd:
-  TEMP_FAILURE_RETRY(::close(current_fd));
+  VOID_TEMP_FAILURE_RETRY(::close(current_fd));
   current_fd = -1;
 close_basedir_fd:
-  TEMP_FAILURE_RETRY(::close(basedir_fd));
+  VOID_TEMP_FAILURE_RETRY(::close(basedir_fd));
   basedir_fd = -1;
 close_fsid_fd:
-  TEMP_FAILURE_RETRY(::close(fsid_fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
   fsid_fd = -1;
 done:
   assert(!m_filestore_fail_eio || ret != -EIO);
@@ -1516,19 +1516,19 @@ int FileStore::umount()
   ondisk_finisher.stop();
 
   if (fsid_fd >= 0) {
-    TEMP_FAILURE_RETRY(::close(fsid_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
     fsid_fd = -1;
   }
   if (op_fd >= 0) {
-    TEMP_FAILURE_RETRY(::close(op_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(op_fd));
     op_fd = -1;
   }
   if (current_fd >= 0) {
-    TEMP_FAILURE_RETRY(::close(current_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(current_fd));
     current_fd = -1;
   }
   if (basedir_fd >= 0) {
-    TEMP_FAILURE_RETRY(::close(basedir_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(basedir_fd));
     basedir_fd = -1;
   }
 
@@ -1894,7 +1894,7 @@ void FileStore::_set_global_replay_guard(coll_t cid,
 
   _inject_failure();
 
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   dout(10) << __func__ << ": " << spos << " done" << dendl;
 }
 
@@ -1917,7 +1917,7 @@ int FileStore::_check_global_replay_guard(coll_t cid,
   if (r < 0) {
     dout(20) << __func__ << " no xattr" << dendl;
     assert(!m_filestore_fail_eio || r != -EIO);
-    TEMP_FAILURE_RETRY(::close(fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
     return 1;  // no xattr
   }
   bufferlist bl;
@@ -1927,7 +1927,7 @@ int FileStore::_check_global_replay_guard(coll_t cid,
   bufferlist::iterator p = bl.begin();
   ::decode(opos, p);
 
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   return spos >= opos ? 1 : -1;
 }
 
@@ -2065,7 +2065,7 @@ int FileStore::_check_replay_guard(coll_t cid, const SequencerPosition& spos)
     return 1;  // if collection does not exist, there is no guard, and we can replay.
   }
   int ret = _check_replay_guard(fd, spos);
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   return ret;
 }
 
@@ -3799,7 +3799,7 @@ int FileStore::collection_getattr(coll_t c, const char *name,
   char n[PATH_MAX];
   get_attrname(name, n, PATH_MAX);
   r = chain_fgetxattr(fd, n, value, size);
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
  out:
   dout(10) << "collection_getattr " << fn << " '" << name << "' len " << size << " = " << r << dendl;
   assert(!m_filestore_fail_eio || r != -EIO);
@@ -3822,7 +3822,7 @@ int FileStore::collection_getattr(coll_t c, const char *name, bufferlist& bl)
   }
   r = _fgetattr(fd, n, bp);
   bl.push_back(bp);
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
  out:
   dout(10) << "collection_getattr " << fn << " '" << name << "' = " << r << dendl;
   assert(!m_filestore_fail_eio || r != -EIO);
@@ -3841,7 +3841,7 @@ int FileStore::collection_getattrs(coll_t cid, map<string,bufferptr>& aset)
     goto out;
   }
   r = _fgetattrs(fd, aset, true);
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
  out:
   dout(10) << "collection_getattrs " << fn << " = " << r << dendl;
   assert(!m_filestore_fail_eio || r != -EIO);
@@ -3864,7 +3864,7 @@ int FileStore::_collection_setattr(coll_t c, const char *name,
   }
   get_attrname(name, n, PATH_MAX);
   r = chain_fsetxattr(fd, n, value, size);
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
  out:
   dout(10) << "collection_setattr " << fn << " '" << name << "' len " << size << " = " << r << dendl;
   return r;
@@ -3884,7 +3884,7 @@ int FileStore::_collection_rmattr(coll_t c, const char *name)
     goto out;
   }
   r = chain_fremovexattr(fd, n);
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
  out:
   dout(10) << "collection_rmattr " << fn << " = " << r << dendl;
   return r;
@@ -3911,7 +3911,7 @@ int FileStore::_collection_setattrs(coll_t cid, map<string,bufferptr>& aset)
     if (r < 0)
       break;
   }
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
  out:
   dout(10) << "collection_setattrs " << fn << " = " << r << dendl;
   return r;
@@ -3989,7 +3989,7 @@ int FileStore::_collection_rename(const coll_t &cid, const coll_t &ncid,
     int fd = ::open(new_coll, O_RDONLY);
     assert(fd >= 0);
     _set_replay_guard(fd, spos);
-    TEMP_FAILURE_RETRY(::close(fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
   }
 
   dout(10) << "collection_rename '" << cid << "' to '" << ncid << "'"

--- a/src/os/GenericFileStoreBackend.cc
+++ b/src/os/GenericFileStoreBackend.cc
@@ -98,13 +98,13 @@ int GenericFileStoreBackend::detect_features()
     if (r < 0) {
       r = -errno;
       derr << "detect_features: failed to lseek " << fn << ": " << cpp_strerror(r) << dendl;
-      TEMP_FAILURE_RETRY(::close(fd));
+      VOID_TEMP_FAILURE_RETRY(::close(fd));
       return r;
     }
     r = write(fd, buf, sizeof(buf));
     if (r < 0) {
       derr << "detect_features: failed to write to " << fn << ": " << cpp_strerror(r) << dendl;
-      TEMP_FAILURE_RETRY(::close(fd));
+      VOID_TEMP_FAILURE_RETRY(::close(fd));
       return r;
     }
   }
@@ -132,7 +132,7 @@ int GenericFileStoreBackend::detect_features()
   }
 
   ::unlink(fn);
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
 
 
   bool have_syncfs = false;

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -662,7 +662,7 @@ int KeyValueStore::mkfs()
   ret = 0;
 
  close_fsid_fd:
-  TEMP_FAILURE_RETRY(::close(fsid_fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
   fsid_fd = -1;
   return ret;
 }
@@ -718,7 +718,7 @@ bool KeyValueStore::test_mount_in_use()
   if (fsid_fd < 0)
     return 0;   // no fsid, ok.
   bool inuse = lock_fsid() < 0;
-  TEMP_FAILURE_RETRY(::close(fsid_fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
   fsid_fd = -1;
   return inuse;
 }
@@ -882,10 +882,10 @@ int KeyValueStore::mount()
   return 0;
 
 close_current_fd:
-  TEMP_FAILURE_RETRY(::close(current_fd));
+  VOID_TEMP_FAILURE_RETRY(::close(current_fd));
   current_fd = -1;
 close_fsid_fd:
-  TEMP_FAILURE_RETRY(::close(fsid_fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
   fsid_fd = -1;
 done:
   return ret;
@@ -900,15 +900,15 @@ int KeyValueStore::umount()
   ondisk_finisher.stop();
 
   if (fsid_fd >= 0) {
-    TEMP_FAILURE_RETRY(::close(fsid_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
     fsid_fd = -1;
   }
   if (op_fd >= 0) {
-    TEMP_FAILURE_RETRY(::close(op_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(op_fd));
     op_fd = -1;
   }
   if (current_fd >= 0) {
-    TEMP_FAILURE_RETRY(::close(current_fd));
+    VOID_TEMP_FAILURE_RETRY(::close(current_fd));
     current_fd = -1;
   }
 

--- a/src/os/LFNIndex.cc
+++ b/src/os/LFNIndex.cc
@@ -162,7 +162,7 @@ int LFNIndex::fsync_dir(const vector<string> &path)
     return -errno;
   maybe_inject_failure();
   int r = ::fsync(fd);
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   maybe_inject_failure();
   if (r < 0)
     return -errno;

--- a/src/tools/ceph.cc
+++ b/src/tools/ceph.cc
@@ -183,7 +183,7 @@ static void parse_cmd_args(vector<const char*> &args,
 
 static int get_indata(const char *in_file, bufferlist &indata)
 {
-  int fd = TEMP_FAILURE_RETRY(::open(in_file, O_RDONLY));
+  int fd = VOID_TEMP_FAILURE_RETRY(::open(in_file, O_RDONLY));
   if (fd < 0) {
     int err = errno;
     derr << "error opening in_file '" << in_file << "': "
@@ -195,7 +195,7 @@ static int get_indata(const char *in_file, bufferlist &indata)
     int err = errno;
     derr << "error getting size of in_file '" << in_file << "': "
 	 << cpp_strerror(err) << dendl;
-    TEMP_FAILURE_RETRY(::close(fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
     return 1;
   }
 
@@ -205,11 +205,11 @@ static int get_indata(const char *in_file, bufferlist &indata)
   if (ret) {
     derr << "error reading in_file '" << in_file << "': "
 	 << cpp_strerror(ret) << dendl;
-    TEMP_FAILURE_RETRY(::close(fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
     return 1;
   }
 
-  TEMP_FAILURE_RETRY(::close(fd));
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
   derr << "read " << st.st_size << " bytes from " << in_file << dendl;
   return 0;
 }
@@ -378,7 +378,7 @@ int main(int argc, const char **argv)
     if (out_file.empty() || out_file == "-") {
       err = outbl.write_fd(STDOUT_FILENO);
     } else {
-      int out_fd = TEMP_FAILURE_RETRY(::open(out_file.c_str(), O_WRONLY|O_CREAT|O_TRUNC, 0644));
+      int out_fd = VOID_TEMP_FAILURE_RETRY(::open(out_file.c_str(), O_WRONLY|O_CREAT|O_TRUNC, 0644));
       if (out_fd < 0) {
 	int ret = errno;
 	derr << " failed to create file '" << out_file << "': "

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -224,7 +224,7 @@ static int do_get(IoCtx& io_ctx, const char *objname, const char *outfile, unsig
 
  out:
   if (fd != 1)
-    TEMP_FAILURE_RETRY(::close(fd));
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
   return ret;
 }
 
@@ -426,7 +426,7 @@ static int do_put(IoCtx& io_ctx, const char *objname, const char *infile, int op
   }
   ret = 0;
  out:
-  TEMP_FAILURE_RETRY(close(fd));
+  VOID_TEMP_FAILURE_RETRY(close(fd));
   delete[] buf;
   return ret;
 }


### PR DESCRIPTION
The version of TEMP_FAILURE_RETRY found on Linux has a GNU extension
that squashes the unused return value warning where applicable. This
adds a VOID_TEMP_FAILURE_RETRY to make the case explicit, casting the
expression value to void to avoid the warning.

Signed-off-by: Noah Watkins noahwatkins@gmail.com
