### PR TITLE
mon/OSDMonitor: fix osdmap encode feature logic

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -203,9 +203,17 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
     if (t == NULL)
       t = new MonitorDBStore::Transaction;
 
-    // write out the full map for all past epochs
+    // Write out the full map for all past epochs.  Encode the full
+    // map with the same features as the incremental.  If we don't
+    // know, use the quorum features.  If we don't know those either,
+    // encode with all features.
+    uint64_t f = inc.encode_features;
+    if (!f)
+      f = mon->quorum_features;
+    if (!f)
+      f = -1;
     bufferlist full_bl;
-    osdmap.encode(full_bl, inc.encode_features);
+    osdmap.encode(full_bl, f);
     tx_size += full_bl.length();
 
     put_version_full(t, osdmap.epoch, full_bl);


### PR DESCRIPTION
If we are encoding a full map based on an old Incremental that does not encode
the features, fall back to the quorum features or (barring that) all features.
 Do _not_ do no features or else we will end up with encode_client_old which
does not even include the extended info and will cause the mon to crash when
decoding.

This was observed when upgading a 0.76 cluster to 0.77 (all mons stopped, 
upgraded, and then started)

Reported-by: Aaron Ten Clay aarontc@aarontc.com Signed-off-by: Sage Weil
sage@inktank.com
