### PR TITLE
Wip dz scrub fixes

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4293,7 +4293,7 @@ void PG::scrub_finish()
   // when every one has been fixed.
   if (repair) {
     if (scrubber.fixed == scrubber.shallow_errors + scrubber.deep_errors) {
-      assert(deep_scrub || scrubber.deep_errors == 0);
+      assert(deep_scrub);
       scrubber.shallow_errors = scrubber.deep_errors = 0;
     } else {
       // Deep scrub in order to get corrected error counts


### PR DESCRIPTION
That actual fix went in for bug  7517.  Reverting assert change and improving log output.
