### PR TITLE
mon: OSDMonitor: allow (un)setting 'hashpspool' flag via 'osd pool set'

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -294,6 +294,9 @@ ceph osd pool set data size 3
 ceph osd pool get data size | grep 'size: 3'
 ceph osd pool set data size 2
 
+ceph osd pool set data hashpspool 1
+ceph osd pool set data hashpspool 0
+
 ceph osd pool get rbd crush_ruleset | grep 'crush_ruleset: 2'
 
 ceph osd thrash 10

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -497,7 +497,7 @@ COMMAND("osd pool get " \
 	"get pool parameter <var>", "osd", "r", "cli,rest")
 COMMAND("osd pool set " \
 	"name=pool,type=CephPoolname " \
-	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset " \
+	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset|hashpspool " \
 	"name=val,type=CephInt", \
 	"set pool parameter <var> to <val>", "osd", "rw", "cli,rest")
 // 'val' is a CephString because it can include a unit.  Perhaps

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3635,7 +3635,24 @@ done:
 	  ss << "crush ruleset " << n << " does not exist";
 	  err = -ENOENT;
 	}
-      } 
+      } else if (var == "hashpspool") {
+	pg_pool_t new_pool = *p;
+	if (pending_inc.new_pools.count(pool))
+	  new_pool = pending_inc.new_pools[pool];
+	if (n == 1) {
+	  new_pool.flags |= pg_pool_t::FLAG_HASHPSPOOL;
+	  ss << "set";
+	} else if (n == 0) {
+	  new_pool.flags &= ~pg_pool_t::FLAG_HASHPSPOOL;
+	  ss << "unset";
+	} else {
+	  ss << "expecting value 1 or 0";
+	  err = -EINVAL;
+	}
+	pending_inc.new_pools[pool] = new_pool;
+	ss << " pool " << pool << " flag hashpspool";
+      }
+
       pending_inc.new_pools[pool].last_change = pending_inc.epoch;
       getline(ss, rs);
       wait_for_finished_proposal(new Monitor::C_Command(mon, m, 0, rs, get_last_committed()));


### PR DESCRIPTION
This PR backports to Dumpling the monitor command for setting and unsetting "hashpspool" on a per-pool basis. This is necessary:
1) We already have hashpspool functionality
1b) for some portion of time it was enabled by default (now it is disabled by default).
2) Because hashpspool is controlled via a flag in the osdmap, there is no way to manipulate it without a monitor command
3) The hashpspool functionality is useful for clusters which are running Dumpling.

So backport the relevant patches to change it. Unfortunately they had to go through quite a bit of change: Dumpling did not have all the generic "pool set" infrastructure we do in current master, so I had to special-case it. Dumpling uses integers rather than strings for the parameters, so backporting required changing that syntax. I'm not sure if there's documentation we want to provide on that.
