### PR TITLE
osd/OSDMap: respect temp primary without temp acting

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1557,7 +1557,9 @@ void OSDMap::_pg_to_up_acting_osds(pg_t pg, vector<int> *up, int *up_primary,
   _get_temp_osds(*pool, pg, &_acting, &_acting_primary);
   if (_acting.empty()) {
     _acting = _up;
-    _acting_primary = _up_primary;
+    if (_acting_primary == -1) {
+      _acting_primary = _up_primary;
+    }
   }
   if (up)
     up->swap(_up);


### PR DESCRIPTION
be2748c6d540891f2e1a62e7034cb44f7d04bf18 ensured that
if the temp acting mapping contains only CRUSH_ITEM_NONE,
that the acting_primary is left at -1.  However, even if
acting.empty(), we need to respect a temp_primary mapping.
Thus, use _acting_primary unless acting.empty() &&
acting_primary == -1.

Bug introduced in be2748c6d540891f2e1a62e7034cb44f7d04bf18.
Signed-off-by: Samuel Just sam.just@inktank.com
