### PR TITLE
librados: fix ObjectIterator::operator= for the end iterator

### DIFF
--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -489,6 +489,10 @@ librados::ObjectIterator& librados::ObjectIterator::operator=(const librados::Ob
 {
   if (&rhs == this)
     return *this;
+  if (rhs.ctx.get() == NULL) {
+    ctx.reset();
+    return *this;
+  }
   Objecter::ListContext *list_ctx = new Objecter::ListContext(*rhs.ctx->lc);
   ctx.reset(new ObjListCtx(rhs.ctx->ctx, list_ctx));
   cur_obj = rhs.cur_obj;

--- a/src/test/librados/list.cc
+++ b/src/test/librados/list.cc
@@ -105,6 +105,31 @@ TEST_F(LibRadosListPP, ListObjectsCopyIterPP) {
   ASSERT_TRUE(iter3 == ioctx.objects_end());
 }
 
+TEST_F(LibRadosListPP, ListObjectsEndIter) {
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl1;
+  bl1.append(buf, sizeof(buf));
+  ASSERT_EQ((int)sizeof(buf), ioctx.write("foo", bl1, sizeof(buf), 0));
+
+  ObjectIterator iter(ioctx.objects_begin());
+  ObjectIterator iter_end(ioctx.objects_end());
+  ObjectIterator iter_end2 = ioctx.objects_end();
+  ASSERT_TRUE(iter_end == iter_end2);
+  ASSERT_TRUE(iter_end == ioctx.objects_end());
+  ASSERT_TRUE(iter_end2 == ioctx.objects_end());
+
+  ASSERT_EQ(iter->first, "foo");
+  ++iter;
+  ASSERT_TRUE(iter == ioctx.objects_end());
+  ASSERT_TRUE(iter == iter_end);
+  ASSERT_TRUE(iter == iter_end2);
+  ObjectIterator iter2 = iter;
+  ASSERT_TRUE(iter2 == ioctx.objects_end());
+  ASSERT_TRUE(iter2 == iter_end);
+  ASSERT_TRUE(iter2 == iter_end2);
+}
+
 static void check_list(std::set<std::string>& myset, rados_list_ctx_t& ctx)
 {
   const char *entry;


### PR DESCRIPTION
We can't set a shared_ptr to NULL, we need to reset it instead. Add another
test for various permutations of this.

Fixes: #7538
Signed-off-by: Josh Durgin josh.durgin@inktank.com
