### PR TITLE
Fix python-requests package dependencies.

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -22,6 +22,7 @@ Requires:	libcephfs1 = %{version}-%{release}
 Requires:	python
 Requires:	python-argparse
 Requires:	python-ceph
+Requires:	python-requests
 Requires:       xfsprogs
 Requires:	cryptsetup
 Requires:	parted
@@ -196,7 +197,6 @@ Requires:	librados2 = %{version}-%{release}
 Requires:	librbd1 = %{version}-%{release}
 Requires:	libcephfs1 = %{version}-%{release}
 Requires:	python-flask
-Requires:	python-requests
 %if 0%{defined suse_version}
 %py_requires
 %endif

--- a/debian/control
+++ b/debian/control
@@ -157,7 +157,7 @@ Description: debugging symbols for rbd-fuse
 Package: ceph-common
 Architecture: linux-any
 Depends: librbd1 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends},
-         python-ceph (= ${binary:Version})
+         python-ceph (= ${binary:Version}), python-requests
 Conflicts: ceph-client-tools
 Replaces: ceph-client-tools
 Suggests: ceph, ceph-mds
@@ -394,7 +394,7 @@ Description: Ceph test and benchmarking tools.
 Package: python-ceph
 Architecture: linux-any
 Section: python
-Depends: librados2, librbd1, python-flask, ${misc:Depends}, ${python:Depends}, python-requests
+Depends: librados2, librbd1, python-flask, ${misc:Depends}, ${python:Depends}
 X-Python-Version: >= 2.6
 Description: Python libraries for the Ceph distributed filesystem
  Ceph is a distributed storage and network file system designed to provide


### PR DESCRIPTION
python-ceph does not require requests, but ceph-common does (for ceph-brag).

Signed-off-by: Dan Mick dan.mick@inktank.com
