### PR TITLE
OSDMonitor: enable getting hit set parameters

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -399,12 +399,18 @@ expect_false ceph osd pool set data hashpspool asdf
 expect_false ceph osd pool set data hashpspool 2
 
 ceph osd pool set rbd hit_set_type explicit_hash
+ceph osd pool get rbd hit_set_type | grep "hit_set_type: explicit_hash"
 ceph osd pool set rbd hit_set_type explicit_object
+ceph osd pool get rbd hit_set_type | grep "hit_set_type: explicit_object"
 ceph osd pool set rbd hit_set_type bloom
+ceph osd pool get rbd hit_set_type | grep "hit_set_type: bloom"
 expect_false ceph osd pool set rbd hit_set_type i_dont_exist
 ceph osd pool set rbd hit_set_period 123
+ceph osd pool get rbd hit_set_period | grep "hit_set_period: 123"
 ceph osd pool set rbd hit_set_count 12
+ceph osd pool get rbd hit_set_count | grep "hit_set_count: 12"
 ceph osd pool set rbd hit_set_fpp .01
+ceph osd pool get rbd hit_set_fpp | grep "hit_set_fpp: 0.01"
 
 ceph osd pool set rbd target_max_objects 123
 ceph osd pool set rbd target_max_bytes 123456

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -522,11 +522,11 @@ COMMAND("osd pool rename " \
 	"rename <srcpool> to <destpool>", "osd", "rw", "cli,rest")
 COMMAND("osd pool get " \
 	"name=pool,type=CephPoolname " \
-	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset", \
+	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp", \
 	"get pool parameter <var>", "osd", "r", "cli,rest")
 COMMAND("osd pool set " \
 	"name=pool,type=CephPoolname " \
-	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset|hashpspool|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp|debug_fake_ec_pool||target_max_bytes|target_max_objects|cache_target_dirty_ratio|cache_target_full_ratio|cache_min_flush_age|cache_min_evict_age " \
+	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset|hashpspool|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp|debug_fake_ec_pool|target_max_bytes|target_max_objects|cache_target_dirty_ratio|cache_target_full_ratio|cache_min_flush_age|cache_min_evict_age " \
 	"name=val,type=CephString", \
 	"set pool parameter <var> to <val>", "osd", "rw", "cli,rest")
 // 'val' is a CephString because it can include a unit.  Perhaps

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2392,6 +2392,22 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
         f->dump_int("crash_replay_interval", p->get_crash_replay_interval());
       } else if (var == "crush_ruleset") {
         f->dump_int("crush_ruleset", p->get_crush_ruleset());
+      } else if (var == "hit_set_period") {
+	f->dump_int("hit_set_period", p->hit_set_period);
+      } else if (var == "hit_set_count") {
+	f->dump_int("hit_set_count", p->hit_set_count);
+      } else if (var == "hit_set_type") {
+	f->dump_string("hit_set_type", HitSet::get_type_name(p->hit_set_params.get_type()));
+      } else if (var == "hit_set_fpp") {
+	if (p->hit_set_params.get_type() != HitSet::TYPE_BLOOM) {
+	  f->close_section();
+	  ss << "hit set is no of type Bloom; invalid to get a false positive rate!";
+	  r = -EINVAL;
+	  goto reply;
+	} else {
+	  BloomHitSet::Params *bloomp = static_cast<BloomHitSet::Params*>(p->hit_set_params.impl.get());
+	  f->dump_float("hit_set_fpp", bloomp->get_fpp());
+	}
       }
 
       f->close_section();
@@ -2409,6 +2425,20 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
         ss << "crash_replay_interval: " << p->get_crash_replay_interval();
       } else if (var == "crush_ruleset") {
         ss << "crush_ruleset: " << p->get_crush_ruleset();
+      } else if (var == "hit_set_period") {
+	ss << "hit_set_period: " << p->hit_set_period;
+      } else if (var == "hit_set_count") {
+	ss << "hit_set_count: " << p->hit_set_count;
+      } else if (var == "hit_set_type") {
+	ss << "hit_set_type: " <<  HitSet::get_type_name(p->hit_set_params.get_type());
+      } else if (var == "hit_set_fpp") {
+	if (p->hit_set_params.get_type() != HitSet::TYPE_BLOOM) {
+	  ss << "hit set is no of type Bloom; invalid to get a false positive rate!";
+	  r = -EINVAL;
+	  goto reply;
+	}
+	BloomHitSet::Params *bloomp = static_cast<BloomHitSet::Params*>(p->hit_set_params.impl.get());
+	ss << "hit_set_fpp: " << bloomp->get_fpp();
       }
       rdata.append(ss);
       ss.str("");


### PR DESCRIPTION
We would like to get the hit set parameters: hit_set_type |
hit_set_period | hit_set_count | hit_set_fpp via OSDMonitor

Signed-off-by: Kai Zhang zakir.exe@gmail.com
