### PR TITLE
mon: fix 'pg dump' JSON output

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1541,9 +1541,9 @@ void pg_stat_t::dump(Formatter *f) const
   f->open_array_section("acting");
   for (vector<int>::const_iterator p = acting.begin(); p != acting.end(); ++p)
     f->dump_int("osd", *p);
+  f->close_section();
   f->dump_int("up_primary", up_primary);
   f->dump_int("acting_primary", acting_primary);
-  f->close_section();
 }
 
 void pg_stat_t::dump_brief(Formatter *f) const
@@ -1556,9 +1556,9 @@ void pg_stat_t::dump_brief(Formatter *f) const
   f->open_array_section("acting");
   for (vector<int>::const_iterator p = acting.begin(); p != acting.end(); ++p)
     f->dump_int("osd", *p);
+  f->close_section();
   f->dump_int("up_primary", up_primary);
   f->dump_int("acting_primary", acting_primary);
-  f->close_section();
 }
 
 void pg_stat_t::encode(bufferlist &bl) const


### PR DESCRIPTION
This was broken by 40bdcb88.  The 'acting' array had
the up_primary and acting_primary appended.

Fixes: #7572

Signed-off-by: John Spray john.spray@inktank.com
