### PR TITLE
Fix the lock contention issue during scrubbing

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1775,7 +1775,8 @@ void OSD::add_newly_split_pg(PG *pg, PG::RecoveryCtx *rctx)
   pg->get_osdmap()->pg_to_up_acting_osds(pg->info.pgid, up, acting);
   int role = pg->get_osdmap()->calc_pg_role(service.whoami, acting);
   pg->set_role(role);
-  pg->reg_next_scrub();
+  if (pg->is_primary())
+    pg->reg_next_scrub();
   pg->handle_loaded(rctx);
   pg->write_if_dirty(*(rctx->transaction));
   pg->queue_null(e, e);
@@ -2023,12 +2024,13 @@ void OSD::load_pgs()
 
     service.init_splits_between(pg->info.pgid, pg->get_osdmap(), osdmap);
 
-    pg->reg_next_scrub();
-
     // generate state for PG's current mapping
     pg->get_osdmap()->pg_to_up_acting_osds(pgid, pg->up, pg->acting);
     int role = pg->get_osdmap()->calc_pg_role(whoami, pg->acting);
     pg->set_role(role);
+
+    if (pg->is_primary())
+      pg->reg_next_scrub();
 
     PG::RecoveryCtx rctx(0, 0, 0, 0, 0, 0);
     pg->handle_loaded(&rctx);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2038,7 +2038,8 @@ void PG::init(int role, vector<int>& newup, vector<int>& newacting,
     info.last_complete = info.last_update;
   }
 
-  reg_next_scrub();
+  if (is_primary())
+    reg_next_scrub();
 
   dirty_info = true;
   dirty_big_info = true;
@@ -2670,12 +2671,15 @@ bool PG::sched_scrub()
 
 void PG::reg_next_scrub()
 {
-  if (scrubber.must_scrub) {
-    scrubber.scrub_reg_stamp = utime_t();
-  } else {
-    scrubber.scrub_reg_stamp = info.history.last_scrub_stamp;
+  // It is expected that only primary PGs coordinate scrubbing
+  if (is_primary()) {
+    if (scrubber.must_scrub) {
+      scrubber.scrub_reg_stamp = utime_t();
+    } else {
+      scrubber.scrub_reg_stamp = info.history.last_scrub_stamp;
+    }
+    osd->reg_last_pg_scrub(info.pgid, scrubber.scrub_reg_stamp);
   }
-  osd->reg_last_pg_scrub(info.pgid, scrubber.scrub_reg_stamp);
 }
 
 void PG::unreg_next_scrub()
@@ -4205,7 +4209,8 @@ void PG::scrub_finish()
   }
 
   // finish up
-  unreg_next_scrub();
+  if (is_primary())
+    unreg_next_scrub();
   utime_t now = ceph_clock_now(g_ceph_context);
   info.history.last_scrub = info.last_update;
   info.history.last_scrub_stamp = now;
@@ -4239,7 +4244,9 @@ void PG::scrub_finish()
   info.stats.stats.sum.num_scrub_errors = 
     info.stats.stats.sum.num_shallow_scrub_errors +
     info.stats.stats.sum.num_deep_scrub_errors;
-  reg_next_scrub();
+
+  if (is_primary())
+    reg_next_scrub();
 
   {
     ObjectStore::Transaction *t = new ObjectStore::Transaction;
@@ -4324,9 +4331,11 @@ void PG::share_pg_log()
 
 void PG::update_history_from_master(pg_history_t new_history)
 {
-  unreg_next_scrub();
+  if (is_primary())
+    unreg_next_scrub();
   info.history.merge(new_history);
-  reg_next_scrub();
+  if (is_primary())
+    reg_next_scrub();
 }
 
 void PG::fulfill_info(int from, const pg_query_t &query, 
@@ -4553,8 +4562,17 @@ void PG::start_peering_interval(const OSDMapRef lastmap,
   else
     state_clear(PG_STATE_REMAPPED);
 
+  // it is up to primary PGs to coordinate scrubbing, so that we do
+  // unreg / reg before and after the role change as the primary role
+  // could change
+  if (is_primary()) 
+    unreg_next_scrub();
+
   int role = osdmap->calc_pg_role(osd->whoami, acting, acting.size());
   set_role(role);
+
+  if (is_primary())
+    reg_next_scrub();
 
   // did acting, up, primary|acker change?
   if (!lastmap) {
@@ -4676,10 +4694,8 @@ void PG::proc_primary_info(ObjectStore::Transaction &t, const pg_info_t &oinfo)
 {
   assert(!is_primary());
 
-  unreg_next_scrub();
   if (info.history.merge(oinfo.history))
     dirty_info = true;
-  reg_next_scrub();
 
   if (last_complete_ondisk.epoch >= info.history.last_epoch_started) {
     // DEBUG: verify that the snaps are empty in snap_mapper


### PR DESCRIPTION
Fix the lock contention issue during scrubbing by:  
1. Only make primary PG register itself to the scrub list
   1. When role changes, explicitly refresh the list

Signed-off-by: Guang Yang (yguang@yahoo-inc.com)
