### PR TITLE
msg: Make SimpleMessenger shutdown safer

### DIFF
--- a/src/msg/Accepter.cc
+++ b/src/msg/Accepter.cc
@@ -247,7 +247,9 @@ void Accepter::stop()
 
   // wait for thread to stop before closing the socket, to avoid
   // racing against fd re-use.
-  join();
+  if (is_started()) {
+    join();
+  }
 
   if (listen_sd >= 0) {
     ::close(listen_sd);

--- a/src/msg/DispatchQueue.h
+++ b/src/msg/DispatchQueue.h
@@ -168,6 +168,7 @@ class DispatchQueue {
   void entry();
   void wait();
   void shutdown();
+  bool is_started() {return dispatch_thread.is_started();}
 
   DispatchQueue(CephContext *cct, SimpleMessenger *msgr)
     : cct(cct), msgr(msgr),

--- a/src/msg/SimpleMessenger.cc
+++ b/src/msg/SimpleMessenger.cc
@@ -509,10 +509,12 @@ void SimpleMessenger::wait()
   }
   lock.Unlock();
 
-  ldout(cct,10) << "wait: waiting for dispatch queue" << dendl;
-  dispatch_queue.wait();
-  ldout(cct,10) << "wait: dispatch queue is stopped" << dendl;
-  
+  if(dispatch_queue.is_started()) {
+    ldout(cct,10) << "wait: waiting for dispatch queue" << dendl;
+    dispatch_queue.wait();
+    ldout(cct,10) << "wait: dispatch queue is stopped" << dendl;
+  }
+
   // done!  clean up.
   if (did_bind) {
     ldout(cct,20) << "wait: stopping accepter thread" << dendl;


### PR DESCRIPTION
In the case where no dispatchers were ever added, previously
we would throw an assertion in wait().

This was a path that could come up in cases where other init things were failing and someone was tearing down their messenger early.
