### PR TITLE
ReplicatedPG::fill_in_copy_get: fix early return bug

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -5274,9 +5274,6 @@ int ReplicatedPG::fill_in_copy_get(
 	result = pgbackend->objects_read_sync(
 	  oi.soid, cursor.data_offset, left, &bl);
 	if (result < 0)
-	  if (cb) {
-	    delete cb;
-	  }
 	  return result;
       }
       assert(result <= left);


### PR DESCRIPTION
This is not a leak: we are in an else block where cb must
be NULL.  The fix as introduced did not include braces on
the if causing the method to return unconditionally.

Fixes: #7604
Introduced in: 500206d809f0cd85cd99e4f0ec164bbf74f92c28
Signed-off-by: Samuel Just sam.just@inktank.com
