### PR TITLE
Make symlink  of librbd to qemu's folder so it can detect it.

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -583,6 +583,8 @@ fi
 
 %post -n librbd1
 /sbin/ldconfig
+mkdir -p /usr/lib64/qemu/ 
+ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 
 %postun -n librbd1
 /sbin/ldconfig


### PR DESCRIPTION
Per issue #7293.

Signed-off-by: Sandon Van Ness sandon@inktank.com
