### PR TITLE
test: Use non-default out/ dev/ paths in vstart

### DIFF
--- a/src/test/vstart_wrapper.sh
+++ b/src/test/vstart_wrapper.sh
@@ -14,6 +14,12 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Library Public License for more details.
 #
+
+
+export CEPH_DIR="$PWD/"
+export CEPH_DEV_DIR="$CEPH_DIR/test_dev"
+export CEPH_OUT_DIR="$CEPH_DIR/test_out"
+
 function vstart_teardown()
 {
     ./stop.sh
@@ -21,8 +27,8 @@ function vstart_teardown()
 
 function vstart_setup()
 {
-    rm -fr dev out
-    mkdir -p dev
+    rm -fr $CEPH_DEV_DIR $CEPH_OUT_DIR
+    mkdir -p $CEPH_DEV_DIR
     trap "vstart_teardown ; rm -f $TMPFILE" EXIT
     export LC_ALL=C # some tests are vulnerable to i18n
     MON=1 OSD=3 ./vstart.sh \

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -261,9 +261,9 @@ if [ "$start_all" -eq 1 ]; then
 fi
 $SUDO rm -f core*
 
-test -d out || mkdir out
-test -d dev || mkdir dev
-$SUDO rm -rf out/*
+test -d $CEPH_OUT_DIR || mkdir $CEPH_OUT_DIR
+test -d $CEPH_DEV_DIR || mkdir $CEPH_DEV_DIR
+$SUDO rm -rf $CEPH_OUT_DIR/*
 test -d gmon && $SUDO rm -rf gmon/*
 
 [ "$cephx" -eq 1 ] && [ "$new" -eq 1 ] && test -e $keyring_fn && rm $keyring_fn


### PR DESCRIPTION
Currently, running "make check" nukes any existing vstart
setup in the tree.  This change makes it use test_dev/ and test_out/
so that it can peacefully coexist.

Signed-off-by: John Spray john.spray@inktank.com
