### PR TITLE
mon/PGMap: return empty stats if pool is not in sum

### DIFF
--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -205,10 +205,11 @@ public:
     stamp = s;
   }
 
-  const pool_stat_t& get_pg_pool_sum_stat(int64_t pool) {
+  pool_stat_t get_pg_pool_sum_stat(int64_t pool) {
     ceph::unordered_map<int,pool_stat_t>::iterator p = pg_pool_sum.find(pool);
-    assert(p != pg_pool_sum.end());
-    return p->second;
+    if (p != pg_pool_sum.end())
+      return p->second;
+    return pool_stat_t();
   }
 
   void update_pg(pg_t pgid, bufferlist& bl);


### PR DESCRIPTION
Greg was right!

When a pool is created, the PGs are not added to the PGMap until the _next_ 
proposal.  Weaken the assert here and return empty stats for non-existent
(new) pools so that a pool create + tier add sequence does not crash.

Signed-off-by: Sage Weil sage@inktank.com
