### PR TITLE
config.cc: add debug_ prefix to subsys logging levels

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -334,9 +334,11 @@ void md_config_t::_show_config(std::ostream *out, Formatter *f)
 	   << "/" << subsys.get_gather_level(o) << std::endl;
     if (f) {
       ostringstream ss;
+      std::string debug_name = "debug_";
+      debug_name += subsys.get_name(o);
       ss << subsys.get_log_level(o)
 	 << "/" << subsys.get_gather_level(o);
-      f->dump_string(subsys.get_name(o).c_str(), ss.str());
+      f->dump_string(debug_name.c_str(), ss.str());
     }
   }
   for (int i = 0; i < NUM_CONFIG_OPTIONS; i++) {


### PR DESCRIPTION
Add debug_ prefix also for 'ceph --admin-daemon *.asok config show'
as already done e.g. by 'ceph-osd --show-config'.

Fixes: #7602

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
