### PR TITLE
ReplicatedPG: ensure clones are readable after find_object_context

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1251,6 +1251,11 @@ void ReplicatedPG::do_op(OpRequestRef op)
       wait_for_unreadable_object(missing_oid, op);
       return;
     }
+  } else if (r == 0 && is_unreadable_object(obc->obs.oi.soid)) {
+    dout(10) << __func__ << ": clone " << obc->obs.oi.soid
+	     << " is unreadable, waiting" << dendl;
+    wait_for_unreadable_object(obc->obs.oi.soid, op);
+    return;
   }
 
   if (hit_set) {


### PR DESCRIPTION
We only get EAGAIN if the object is missing.  We also need the
clone to be readable if we are reading it.

The other find_object_context callers already require !degraded.

Fixes: #7624
Signed-off-by: Samuel Just sam.just@inktank.com
