### PR TITLE
ReplicatedPG::wait_for_degraded_object: only recover if found

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -459,6 +459,11 @@ void ReplicatedPG::wait_for_degraded_object(const hobject_t& soid, OpRequestRef 
 	    << soid 
 	    << ", already recovering"
 	    << dendl;
+  } else if (missing_loc.is_unfound(soid)) {
+    dout(7) << "degraded "
+	    << soid
+	    << ", still unfound, waiting"
+	    << dendl;
   } else {
     dout(7) << "degraded " 
 	    << soid 


### PR DESCRIPTION
Fixes: #7618
Signed-off-by: Samuel Just sam.just@inktank.com
