### PR TITLE
qa/workunits/rest/test.py: do not test 'osd thrash'

### DIFF
--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -431,5 +431,4 @@ if __name__ == '__main__':
     r = expect('osd/pool/get.json?pool=rbd&var=crush_ruleset', 'GET', 200, 'json')
     assert(r.myjson['output']['crush_ruleset'] == 0)
 
-    expect('osd/thrash?num_epochs=10', 'PUT', 200, '')
     print 'OK'


### PR DESCRIPTION
This wreaks havoc on our QA because it marks osds up and down and then 
immediately after that we try to scrub and some osds are still down.  I think
it is not worth futzing with here since this is a debug/dev operation and is
covered by the CLI test.

Signed-off-by: Sage Weil sage@inktank.com
