### PR TITLE
osd/ReplicatedPG: agent_stop on_shutdown

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8917,6 +8917,8 @@ void ReplicatedPG::on_shutdown()
   osd->remote_reserver.cancel_reservation(info.pgid);
   osd->local_reserver.cancel_reservation(info.pgid);
 
+  agent_stop();
+
   clear_primary_state(false);  // Not staying primary
   osd->remove_want_pg_temp(info.pgid.pgid);
   cancel_recovery();


### PR DESCRIPTION
It looks like this was never handled quite properly.

Fixes: #7637 Signed-off-by: Sage Weil sage@inktank.com
