### PR TITLE
osd: fix agent thread shutdown

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -487,7 +487,7 @@ public:
     if (p == agent_queue_pos)
       ++agent_queue_pos;
     oq.erase(p);
-    if (oq.empty() && agent_queue.size() > 1) {
+    if (oq.empty()) {
       if (agent_queue.rbegin()->first == old_priority)
 	agent_valid_iterator = false;
       agent_queue.erase(old_priority);


### PR DESCRIPTION
We had an old invariant that agent_queue would have at least 1 entry in it to
simplify some other code paths, but it turns out that it is simpler not to do
that.

In particular, this was triggering a failed assertion on shutdown when we 
assert that the queue is empty.

Dump offending items on shutdown if they are there, tho, to catch any future
bugs.

Fixes: #7637 Signed-off-by: Sage Weil sage@inktank.com
