### PR TITLE
ReplicatedPG::trim_object: use old_snaps for rollback

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2356,7 +2356,7 @@ ReplicatedPG::RepGather *ReplicatedPG::trim_object(const hobject_t &coid)
       set<snapid_t> snaps(
 	ctx->obc->obs.oi.snaps.begin(),
 	ctx->obc->obs.oi.snaps.end());
-      ctx->log.back().mod_desc.update_snaps(snaps);
+      ctx->log.back().mod_desc.update_snaps(old_snaps);
     } else {
       ctx->log.back().mod_desc.mark_unrollbackable();
     }


### PR DESCRIPTION
We need to rollback the old value of snaps, not the
new one.

Fixes: #7638
Signed-off-by: Samuel Just sam.just@inktank.com
