### PR TITLE
FileStore: support compiling without libxfs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -529,6 +529,31 @@ AS_IF([test "$with_libaio" = "yes"],
 	    [AC_DEFINE([HAVE_LIBAIO], [1], [Defined if you don't have atomic_ops])])
 AM_CONDITIONAL(WITH_LIBAIO, [ test "$with_libaio" = "yes" ])
 
+# use libxfs?
+AC_ARG_WITH([libxfs],
+  [AS_HELP_STRING([--without-libxfs], [disable libxfs use by FileStore])],
+  [],
+  [with_libxfs=yes])
+AS_IF([test "x$with_libxfs" != "xno"], [
+  # xfs/xfs.h presence and XFS_XFLAG_EXTSIZE define
+  AC_CHECK_HEADER([xfs/xfs.h], [], AC_MSG_ERROR(
+    [xfs/xfs.h not found (--without-libxfs to disable)]))
+  AC_MSG_CHECKING([for XFS_XFLAG_EXTSIZE in xfs/xfs.h])
+  AC_EGREP_CPP([yes_have_xfs_xflag_extsize], [
+    #include <xfs/xfs.h>
+    #ifdef XFS_XFLAG_EXTSIZE
+    yes_have_xfs_xflag_extsize
+    #endif
+  ], [
+    AC_MSG_RESULT([yes])
+    AC_DEFINE([HAVE_LIBXFS], [1], [Define to 1 if you have libxfs])
+  ], [
+    AC_MSG_RESULT([no])
+    AC_MSG_ERROR([XFS_XFLAG_EXTSIZE not found (--without-libxfs to disable)])
+  ])
+])
+AM_CONDITIONAL(WITH_LIBXFS, [test "x$with_libxfs" != "xno"])
+
 # use libzfs
 AC_ARG_WITH([libzfs],
 	    [AS_HELP_STRING([--with-libzfs], [build ZFS support])],
@@ -654,21 +679,6 @@ AC_EGREP_CPP([yes_have_f_setpipe_sz], [
 ], [
   AC_MSG_RESULT([no])
   AC_MSG_NOTICE([F_SETPIPE_SZ not found, zero-copy may be less efficent])
-])
-
-# XFS_XFLAG_EXTSIZE in xfs/xfs.h on Linux
-AS_IF([test "x$linux" = "xyes"], [
-  AC_CHECK_HEADER([xfs/xfs.h], [], AC_MSG_ERROR([xfs/xfs.h not found]))
-  AC_MSG_CHECKING([for XFS_XFLAG_EXTSIZE in xfs/xfs.h])
-  AC_EGREP_CPP([yes_have_xfs_xflag_extsize], [
-     #include <xfs/xfs.h>
-     #ifdef XFS_XFLAG_EXTSIZE
-     yes_have_xfs_xflag_extsize
-     #endif
-  ], AC_MSG_RESULT([yes]), [
-     AC_MSG_RESULT([no])
-     AC_MSG_ERROR([XFS_XFLAG_EXTSIZE not found])
-  ])
 ])
 
 AC_CHECK_FUNCS([posix_fallocate])

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -682,7 +682,7 @@ int FileStore::mkfs()
     backend = new BtrfsFileStoreBackend(this);
 #endif
   } else if (basefs.f_type == XFS_SUPER_MAGIC) {
-#if defined(__linux__)
+#ifdef HAVE_LIBXFS
     backend = new XfsFileStoreBackend(this);
 #endif
   } else if (basefs.f_type == ZFS_SUPER_MAGIC) {
@@ -881,9 +881,12 @@ int FileStore::_detect_fs()
     wbthrottle.set_fs(WBThrottle::BTRFS);
 #endif
   } else if (st.f_type == XFS_SUPER_MAGIC) {
-#if defined(__linux__)
+#ifdef HAVE_LIBXFS
     dout(0) << "mount detected xfs (libxfs)" << dendl;
     backend = new XfsFileStoreBackend(this);
+#else
+    dout(0) << "mount detected xfs" << dendl;
+#endif
     m_fs_type = FS_TYPE_XFS;
 
     // wbthrottle is constructed with fs(WBThrottle::XFS)
@@ -893,7 +896,6 @@ int FileStore::_detect_fs()
       g_conf->apply_changes(NULL);
       assert(m_filestore_replica_fadvise == false);
     }
-#endif
   } else if (st.f_type == ZFS_SUPER_MAGIC) {
 #ifdef HAVE_LIBZFS
     dout(0) << "mount detected zfs (libzfs)" << dendl;

--- a/src/os/Makefile.am
+++ b/src/os/Makefile.am
@@ -19,6 +19,9 @@ libos_la_SOURCES = \
 
 if LINUX
 libos_la_SOURCES += os/BtrfsFileStoreBackend.cc
+endif
+
+if WITH_LIBXFS
 libos_la_SOURCES += os/XfsFileStoreBackend.cc
 endif
 


### PR DESCRIPTION
When configured with --without-libxfs, use GenericFileStoreBackend
instead of XfsFileStoreBackend for XFS.  At this point this would only
impact the allocation hint op.  The default is to compile with
--with-libxfs.  (Previously it was unconditionally enabled on linux and
disabled for non-linux arches.)

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
