### PR TITLE
bugfix rbdmap upstart script

### DIFF
--- a/src/upstart/rbdmap.conf
+++ b/src/upstart/rbdmap.conf
@@ -27,7 +27,7 @@ pre-start script
             DEV=rbd/$DEV
             ;;
         esac
-        for PARAM in $(echo $PARAM | tr ',' '\n'); do
+        for PARAM in $(echo $PARAMS | tr ',' '\n'); do
             CMDPARAMS="$CMDPARAMS --$(echo $PARAM | tr '=' ' ')"
         done
         if [ ! -b /dev/rbd/$DEV ]; then


### PR DESCRIPTION
It seems like the upstart script is lacking a little behind [the initscript](https://github.com/ceph/ceph/blob/master/src/init-rbdmap#L44-L49); however, this bugfix makes it actually do what it should do.

Before, the bug made the job just ignore all parameters, with the following error in /var/log/upstart/rbdmap.log:

```
rbd map volumes/volume-one
rbd: add failed: (22) Invalid argument
```
