### PR TITLE
rados.py: fix typo in Ioctx::read() docstring

### DIFF
--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -1238,7 +1238,7 @@ written." % (self.name, ret, length))
 
     def read(self, key, length=8192, offset=0):
         """
-        Write data to an object synchronously
+        Read data from an object synchronously
 
         :param key: name of the object
         :type key: str


### PR DESCRIPTION
Fix docstring, which states write instead of read
