### PR TITLE
Update Python hashbang to respect environment

### DIFF
--- a/doc/scripts/gen_state_diagram.py
+++ b/doc/scripts/gen_state_diagram.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import re
 import sys
 


### PR DESCRIPTION
The /usr/bin/python hashbang causes doc builds to fail when Python3 is
the default Python and Python2 is being used from within a virtualenv or
Pythonbrew environment.

Signed-off-by: Sharif Olorin sio@tesser.org
