### PR TITLE
mds: Avoid assertions in shutdown

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -496,6 +496,11 @@ void MDLog::_replay_thread()
 	   !journaler->get_error()) {
       journaler->wait_for_readable(new C_MDL_Replay(this));
       replay_cond.Wait(mds->mds_lock);
+      if (mds->get_want_state() == CEPH_MDS_STATE_DNE) {
+        dout(0) << "_replay_thread aborting due to DNE state" << dendl;
+        mds->mds_lock.Unlock();
+        return;
+      }
     }
     if (journaler->get_error()) {
       r = journaler->get_error();
@@ -529,9 +534,21 @@ void MDLog::_replay_thread()
           if (err) { // well, crap
             dout(0) << "got error while reading head: " << cpp_strerror(err)
                     << dendl;
-            mds->suicide();
+            mds->mds_lock.Lock();
+            if (mds->get_want_state() != CEPH_MDS_STATE_DNE) {
+              mds->suicide();
+            }
+            mds->mds_lock.Unlock();
+            // Now that we've suicided, it's time to return so that we
+            // don't try to read/do anything after the loop.
+            return;
           }
           mds->mds_lock.Lock();
+          if (mds->get_want_state() == CEPH_MDS_STATE_DNE) {
+            dout(0) << "_replay_thread aborting due to DNE state" << dendl;
+            mds->mds_lock.Unlock();
+            return;
+          }
 	  standby_trim_segments();
           if (journaler->get_read_pos() < journaler->get_expire_pos()) {
             dout(0) << "expire_pos is higher than read_pos, returning EAGAIN" << dendl;
@@ -598,6 +615,11 @@ void MDLog::_replay_thread()
     // drop lock for a second, so other events/messages (e.g. beacon timer!) can go off
     mds->mds_lock.Unlock();
     mds->mds_lock.Lock();
+    if (mds->get_want_state() == CEPH_MDS_STATE_DNE) {
+      dout(0) << "_replay_thread aborting due to DNE state" << dendl;
+      mds->mds_lock.Unlock();
+      return;
+    }
   }
 
   // done!


### PR DESCRIPTION
"MDS::suicide() was tearing down the objecter, but it was possible
for a _dispatch call to still be in process (#5382) while that happened
if called from a signal handler.  Fix this by checking for DNE state
every time mds_lock is taken, including in the various places it's
dropped during _dispatch.

Fixes: #5382"

Here, we can do a proper review for you, @jcsp. :)
