### PR TITLE
rgw: don't log system requests in usage log

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -166,6 +166,9 @@ void rgw_log_usage_finalize()
 
 static void log_usage(struct req_state *s, const string& op_name)
 {
+  if (s->system_request) /* don't log system user operations */
+    return;
+
   if (!usage_logger)
     return;
 


### PR DESCRIPTION
Fixes: 6889
System requets should not be logged in the usage log.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
