### PR TITLE
OSDMap: clarify is_{down,in}() definitions

### DIFF
--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -370,7 +370,7 @@ public:
   }
 
   bool is_down(int osd) const {
-    return !exists(osd) || !is_up(osd);
+    return !is_up(osd);
   }
 
   bool is_out(int osd) const {
@@ -378,7 +378,7 @@ public:
   }
 
   bool is_in(int osd) const {
-    return exists(osd) && !is_out(osd);
+    return !is_out(osd);
   }
 
   /**


### PR DESCRIPTION
Make it clear that is_down() == !is_up() and is_in() == !is_out().
This is not a functional change.

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
