### PR TITLE
build-doc: fix checks for required commands for non-debian

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 cd "$(dirname "$0")"
 cd ..
 TOPDIR=`pwd`
@@ -19,10 +18,12 @@ if command -v dpkg >/dev/null; then
 	exit 1
     fi
 else
-    for command in virtualenv doxygen ditaa ant; do
-	if ! command -v "$command" >/dev/null; then
+    for command in virtualenv doxygen ant ditaa; do
+	command -v "$command" > /dev/null;
+	ret_code=$?
+	if [ $ret_code -ne 0 ]; then
             # add a space after old values
-	    missing="${missing:+$missing }$package"
+	    missing="${missing:+$missing }$command"
 	fi
     done
     if [ -n "$missing" ]; then


### PR DESCRIPTION
Fixes: 7695

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
