### PR TITLE
ECBackend: when removing the temp obj, use the right shard

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -807,7 +807,12 @@ void ECBackend::handle_sub_write(
 	 ++i) {
       dout(10) << __func__ << ": removing object " << *i
 	       << " since we won't get the transaction" << dendl;
-      localt->remove(temp_coll, *i);
+      localt->remove(
+	temp_coll,
+	ghobject_t(
+	  *i,
+	  ghobject_t::NO_GEN,
+	  get_parent()->whoami_shard().shard));
     }
   }
   clear_temp_objs(op.temp_removed);


### PR DESCRIPTION
Introduced in d0b1094ff7b98ef9262ecb45ee8324853003a77c
Fixes: #7681
Signed-off-by: Samuel Just sam.just@inktank.com
