### PR TITLE
ReplicatedPG::already_(complete|ack) should skip temp object ops

### DIFF
--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -774,6 +774,9 @@ protected:
     for (xlist<RepGather*>::iterator i = repop_queue.begin();
 	 !i.end();
 	 ++i) {
+      // skip copy from temp object ops
+      if ((*i)->v == eversion_t())
+	continue;
       if ((*i)->v > v)
         break;
       if (!(*i)->all_committed)
@@ -786,6 +789,9 @@ protected:
     for (xlist<RepGather*>::iterator i = repop_queue.begin();
 	 !i.end();
 	 ++i) {
+      // skip copy from temp object ops
+      if ((*i)->v == eversion_t())
+	continue;
       if ((*i)->v > v)
         break;
       if (!(*i)->all_applied)


### PR DESCRIPTION
We clearly won't get dup ops on these repops, and they don't
have meaningful versions since they don't carry log
entries.

Fixes: #7682
Signed-off-by: Samuel Just sam.just@inktank.com
