### PR TITLE
rgw: manifest hold the actual bucket used for tail objects

### DIFF
--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -65,6 +65,7 @@ void RGWObjManifest::dump(Formatter *f) const
   ::encode_json("head_size", head_size, f);
   ::encode_json("max_head_size", max_head_size, f);
   ::encode_json("prefix", prefix, f);
+  ::encode_json("tail_bucket", tail_bucket, f);
   ::encode_json("rules", rules, f);
 }
 


### PR DESCRIPTION
Fixes: 7703
Object can be copied between different buckets, so we need to keep track
of which bucket is used for naming the tail parts. The new manifest
requires that because older manifest just held all the tail objects
(each containing the appropriate bucket internally).

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
