### PR TITLE
debian: make ceph depend on ceph-common >= 0.67

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,7 @@ Standards-Version: 3.9.3
 Package: ceph
 Architecture: linux-any
 Depends: binutils,
-         ceph-common,
+         ceph-common (>= 0.67),
          cryptsetup-bin | cryptsetup,
          gdisk,
          parted,


### PR DESCRIPTION
The older versions of ceph-common (ceph CLI, in particular) can't talk to 
newer clusters.  The primary change happened with dumpling when the new CLI
and rest-api changes were made.  Although in reality ceph doesn't care what
version of ceph-common is installed, in practice this forces ceph-common to
get upgraded along with ceph and avoids some user pain.

Fixes: #7641 Signed-off-by: Sage Weil sage@inktank.com
