### PR TITLE
Add a metadata object parameter for rados bench

### DIFF
--- a/src/common/obj_bencher.h
+++ b/src/common/obj_bencher.h
@@ -63,7 +63,7 @@ protected:
 
   int fetch_bench_metadata(const std::string& metadata_file, int* object_size, int* num_objects, int* prevPid);
 
-  int write_bench(int secondsToRun, int maxObjects, int concurrentios);
+  int write_bench(int secondsToRun, int maxObjects, int concurrentios, const char *meta_obj);
   int seq_read_bench(int secondsToRun, int concurrentios, int num_objects, int writePid);
   int rand_read_bench(int secondsToRun, int num_objects, int concurrentios, int writePid);
 
@@ -97,8 +97,8 @@ public:
   virtual ~ObjBencher() {}
   int aio_bench(
     int operation, int secondsToRun, int maxObjectsToCreate,
-    int concurrentios, int op_size, bool cleanup);
-  int clean_up(const std::string& prefix, int concurrentios);
+    int concurrentios, int op_size, bool cleanup, const char *meta_obj);
+  int clean_up(const std::string& prefix, const char *meta_obj, int concurrentios);
 
   void set_show_time(bool dt) {
     show_time = dt;


### PR DESCRIPTION
rados bench is useful to benchmark the cluster, however, there is one user case it does not support: read after write if there are multiple write instance, this is because the current implementation hard code the metadata object which will make the last update win, as a result, the metadata of the previous run is lost and user is unable to run a read (seq) based on that round of write.

This fix make things backward compatible, and if user has a request like us (run read after multiple write), user can specify a new meta-object to record the metadata.

Signed-off-by:  Guang Yang (yguang@yahoo-inc.com)
