### PR TITLE
PG: clear want_pg_temp in clear_primary_state only if primary

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -830,6 +830,8 @@ void PG::clear_primary_state(bool staying_primary)
 
   if (!staying_primary)
     agent_clear();
+
+  osd->remove_want_pg_temp(info.pgid.pgid);
 }
 
 /**
@@ -4772,8 +4774,6 @@ void PG::start_peering_interval(
       }
     }
   }
-  // make sure we clear out any pg_temp change requests
-  osd->remove_want_pg_temp(info.pgid.pgid);
   cancel_recovery();
 
   if (acting.empty() && !up.empty() && up_primary == pg_whoami) {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8920,8 +8920,8 @@ void ReplicatedPG::on_shutdown()
   osd->remote_reserver.cancel_reservation(info.pgid);
   osd->local_reserver.cancel_reservation(info.pgid);
 
-  clear_primary_state(false);  // Not staying primary
-  osd->remove_want_pg_temp(info.pgid.pgid);
+  if (is_primary())
+    clear_primary_state(false);  // Not staying primary
   cancel_recovery();
 }
 


### PR DESCRIPTION
Clearing it in that way in on_shutdown() can cause a stray
shard to clobber the want_pg_temp value created by the primary
shard on the same osd.  Thus, instead only clear it if we are
the primary.

Fixes: #7719
Signed-off-by: Samuel Just sam.just@inktank.com
