### PR TITLE
mds: avoid spurious TMAP2OMAP warning

### DIFF
--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -494,7 +494,11 @@ int MDS::init(int wanted_state)
     uint64_t osd_features = objecter->osdmap->get_up_osd_features();
     if (osd_features & CEPH_FEATURE_OSD_TMAP2OMAP)
       break;
-    derr << "*** one or more OSDs do not support TMAP2OMAP; upgrade OSDs before starting MDS (or downgrade MDS) ***" << dendl;
+    if (objecter->osdmap->get_num_up_osds() > 0) {
+        derr << "*** one or more OSDs do not support TMAP2OMAP; upgrade OSDs before starting MDS (or downgrade MDS) ***" << dendl;
+    } else {
+        derr << "*** no OSDs are up as of epoch " << objecter->osdmap->get_epoch() << ", waiting" << dendl;
+    }
     sleep(10);
   }
 


### PR DESCRIPTION
The message "one or more OSDs do not support TMAP2OMAP" was printed
incorrectly when zero OSDs were up (and therefore the feature was
absent).  Don't issue this prompt until at least one OSD is up.

Signed-off-by: John Spray john.spray@inktank.com
