### PR TITLE
ceph.in: do not allow using 'tell' with interactive mode

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -705,8 +705,15 @@ def main():
     # Repulsive hack to handle tell: lop off 'tell' and target
     # and validate the rest of the command.  'target' is already
     # determined in our callers, so it's ok to remove it here.
+    is_tell = False
     if len(childargs) and childargs[0] == 'tell':
         childargs = childargs[2:]
+        is_tell = True
+
+    if is_tell and not len(childargs):
+        print >> sys.stderr, \
+                'Cannot use \'tell\' with interactive mode'
+        return errno.EINVAL
 
     # fetch JSON sigs from command
     # each line contains one command signature (a placeholder name


### PR DESCRIPTION
This avoids a lot of hassle when dealing with to whom tell each command
on interactive mode, and even more so if multiple targets are specified.

As so, 'tell' commands should be used while on interactive mode instead.

Backport: dumpling,emperor

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
