### PR TITLE
ceph.in: Better error on bad arg to 'tell'

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1061,9 +1061,14 @@ def send_command(cluster, target=('mon', ''), cmd=None, inbuf='', timeout=0,
                 ret, outbuf, outs = cluster.mon_command(cmd, inbuf, timeout)
             else:
                 ret, outbuf, outs = cluster.mon_command(cmd, inbuf, timeout, target[1])
+        else:
+            raise ArgumentValid("Bad target type '{0}'".format(target[0]))
 
     except Exception as e:
-        raise RuntimeError('"{0}": exception {1}'.format(cmd, e))
+        if not isinstance(e, ArgumentError):
+            raise RuntimeError('"{0}": exception {1}'.format(cmd, e))
+        else:
+            raise
 
     return ret, outbuf, outs
 
@@ -1103,7 +1108,10 @@ def json_command(cluster, target=('mon', ''), prefix=None, argdict=None,
                                          inbuf, timeout, verbose)
 
     except Exception as e:
-        raise RuntimeError('"{0}": exception {1}'.format(prefix, e))
+        if not isinstance(e, ArgumentError):
+            raise RuntimeError('"{0}": exception {1}'.format(cmd, e))
+        else:
+            raise
 
     return ret, outbuf, outs
 


### PR DESCRIPTION
Previously would get a rather enigmatic error:
  UnboundLocalError: local variable 'ret' referenced before assignment

Now give something sensible:
  ceph_argparse.ArgumentValid: Bad target type 'mds'

Also update a couple of the other catch-all exception handlers
so that they will let the (nicer) ArgumentError exception through
for humans to see instead of munging them into RuntimeErrors.

Signed-off-by: John Spray john.spray@inktank.com
