### PR TITLE
os/FileJournal: return errors on make_writeable() if reopen fails

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -75,8 +75,8 @@ int FileJournal::_open(bool forwrite, bool create)
   fd = TEMP_FAILURE_RETRY(::open(fn.c_str(), flags, 0644));
   if (fd < 0) {
     int err = errno;
-    dout(2) << "FileJournal::_open: unable to open journal: open() failed: "
-	    << cpp_strerror(err) << dendl;
+    dout(2) << "FileJournal::_open unable to open journal "
+	    << fn << ": " << cpp_strerror(err) << dendl;
     return -err;
   }
 
@@ -1576,9 +1576,12 @@ void FileJournal::put_throttle(uint64_t ops, uint64_t bytes)
   }
 }
 
-void FileJournal::make_writeable()
+int FileJournal::make_writeable()
 {
-  _open(true);
+  dout(10) << __func__ << dendl;
+  int r = _open(true);
+  if (r < 0)
+    return r;
 
   if (read_pos > 0)
     write_pos = read_pos;
@@ -1588,6 +1591,7 @@ void FileJournal::make_writeable()
 
   must_write_header = true;
   start_writer();
+  return 0;
 }
 
 void FileJournal::wrap_read_bl(

--- a/src/os/FileJournal.h
+++ b/src/os/FileJournal.h
@@ -400,7 +400,7 @@ private:
   bool is_writeable() {
     return read_pos == 0;
   }
-  void make_writeable();
+  int make_writeable();
 
   // writes
   void commit_start(uint64_t seq);

--- a/src/os/Journal.h
+++ b/src/os/Journal.h
@@ -56,7 +56,7 @@ public:
 
   // writes
   virtual bool is_writeable() = 0;
-  virtual void make_writeable() = 0;
+  virtual int make_writeable() = 0;
   virtual void submit_entry(uint64_t seq, bufferlist& e, int alignment,
 			    Context *oncommit,
 			    TrackedOpRef osd_op = TrackedOpRef()) = 0;

--- a/src/os/JournalingObjectStore.cc
+++ b/src/os/JournalingObjectStore.cc
@@ -98,7 +98,9 @@ int JournalingObjectStore::journal_replay(uint64_t fs_op_seq)
   submit_manager.set_op_seq(op_seq);
 
   // done reading, make writeable.
-  journal->make_writeable();
+  err = journal->make_writeable();
+  if (err < 0)
+    return err;
 
   return count;
 }


### PR DESCRIPTION
This is why #7738 is resulting in a crash instead of an error.

Signed-off-by: Sage Weil sage@inktank.com
