### PR TITLE
mds/Locker: fix null deref on cap import

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -1799,8 +1799,10 @@ bool Locker::issue_caps(CInode *in, Capability *only_cap)
     // add in any xlocker-only caps (for locks this client is the xlocker for)
     allowed |= xlocker_allowed & in->get_xlocker_mask(it->first);
 
+    Session *session = mds->get_session(it->first);
     if (in->inode.inline_version != CEPH_INLINE_NONE &&
-        !mds->get_session(it->first)->connection->has_feature(CEPH_FEATURE_MDS_INLINE_DATA))
+	!(session && session->connection &&
+	  session->connection->has_feature(CEPH_FEATURE_MDS_INLINE_DATA)))
       allowed &= ~(CEPH_CAP_FILE_RD | CEPH_CAP_FILE_WR);
 
     int pending = cap->pending();


### PR DESCRIPTION
The session Connection\* may be NULL.

Fixes: #7708 Signed-off-by: Sage Weil sage@inktank.com
