### PR TITLE
Makefiles: remove libkeyutils from every binary except two

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -116,7 +116,7 @@ AM_CCASFLAGS = -f elf64
 #####################
 ## library definitions and dependencies
 
-EXTRALIBS = -luuid -lm $(KEYUTILS_LIB)
+EXTRALIBS = -luuid -lm
 if FREEBSD
 EXTRALIBS += -lexecinfo
 endif # FREEBSD

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,8 +54,8 @@ bin_PROGRAMS += ceph-mds
 
 # user tools
 
-mount_ceph_SOURCES = mount/mount.ceph.c
-mount_ceph_LDADD = $(LIBCOMMON)
+mount_ceph_SOURCES = mount/mount.ceph.c common/secret.c
+mount_ceph_LDADD = $(LIBCOMMON) $(KEYUTILS_LIB)
 if LINUX
 su_sbin_PROGRAMS += mount.ceph
 endif # LINUX
@@ -74,8 +74,8 @@ ceph_syn_SOURCES += client/SyntheticClient.cc # uses g_conf.. needs cleanup
 ceph_syn_LDADD = $(LIBCLIENT) $(CEPH_GLOBAL)
 bin_PROGRAMS += ceph-syn
 
-rbd_SOURCES = rbd.cc
-rbd_LDADD = $(LIBRBD) $(LIBRADOS) $(CEPH_GLOBAL) -lblkid
+rbd_SOURCES = rbd.cc common/secret.c
+rbd_LDADD = $(LIBRBD) $(LIBRADOS) $(CEPH_GLOBAL) -lblkid $(KEYUTILS_LIB)
 if LINUX
 bin_PROGRAMS += rbd
 endif #LINUX

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -71,11 +71,6 @@ libcommon_la_SOURCES = \
 	common/bloom_filter.cc \
 	common/linux_version.c
 
-if LINUX
-libcommon_la_SOURCES += \
-	common/secret.c
-endif
-
 # these should go out of libcommon
 libcommon_la_SOURCES += \
 	mon/MonCap.cc \
@@ -114,8 +109,7 @@ noinst_HEADERS += \
 LIBCOMMON_DEPS += \
 	$(LIBERASURE_CODE) \
 	$(LIBMSG) $(LIBAUTH) \
-	$(LIBCRUSH) $(LIBJSON_SPIRIT) $(LIBLOG) $(LIBARCH) \
-	$(KEYUTILS_LIB) 
+	$(LIBCRUSH) $(LIBJSON_SPIRIT) $(LIBLOG) $(LIBARCH)
 
 if LINUX
 LIBCOMMON_DEPS += -lrt


### PR DESCRIPTION
Only rbd and mount_ceph need secret.c, and only secret.c needs libkeyutils;
remove it from LIBCOMMON_DEPS so it's not a dependency for everything,
remove secret.c from libcommon.a, and add it to mount.ceph/rbd's sources;
add LIBKEYID_LIB to mount.ceph/rbd's LDADD.

Signed-off-by: Dan Mick dan.mick@inktank.com
