### PR TITLE
objecter: waive OSDMAP_FULL check for MDS

### DIFF
--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1463,6 +1463,7 @@ public:
     RECALC_OP_TARGET_OSD_DNE,
     RECALC_OP_TARGET_OSD_DOWN,
   };
+  bool osdmap_full_flag() const;
   bool op_should_be_paused(Op *op);
   int recalc_op_target(Op *op);
   bool recalc_linger_op_target(LingerOp *op);


### PR DESCRIPTION
The MDS expects to be able to perform writes to OSDs even
if the full ratio has been reached, in order to journal
file deletions to free space.

Fixes: #7780

Signed-off-by: John Spray john.spray@inktank.com
