### PR TITLE
ReplicatedPG::do_op: delay if snapdir is unreadable

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1216,7 +1216,7 @@ void ReplicatedPG::do_op(OpRequestRef op)
   hobject_t snapdir(m->get_oid(), m->get_object_locator().key,
 		    CEPH_SNAPDIR, m->get_pg().ps(), info.pgid.pool(),
 		    m->get_object_locator().nspace);
-  if (is_missing_object(snapdir)) {
+  if (is_unreadable_object(snapdir)) {
     wait_for_unreadable_object(snapdir, op);
     return;
   }


### PR DESCRIPTION
Since all we really need on a snapdir is the context, we really only
need it to be !missing.  However, it might become !missing before it
becomes !unreadable.  That allows ops to end up in the
waiting_for_degraded queue before one in waiting_for_unreadable is
woken, which allows the ops to be reordered.  Rather than reintroduce an
extra waiting_for_missing queue, simply require !unreadable for snapdir
(which implies !misssing).

Fixes: #7777
Signed-off-by: Samuel Just sam.just@inktank.com
