### PR TITLE
Make it possible for FileStore to be in a state which never do merge and keep it backward compatible

### DIFF
--- a/src/os/HashIndex.cc
+++ b/src/os/HashIndex.cc
@@ -418,13 +418,14 @@ int HashIndex::set_info(const vector<string> &path, const subdir_info_s &info) {
 
 bool HashIndex::must_merge(const subdir_info_s &info) {
   return (info.hash_level > 0 &&
+          merge_threshold > 0 &&
 	  info.objs < (unsigned)merge_threshold &&
 	  info.subdirs == 0);
 }
 
 bool HashIndex::must_split(const subdir_info_s &info) {
   return (info.hash_level < (unsigned)MAX_HASH_LEVEL &&
-	  info.objs > ((unsigned)merge_threshold * 16 * split_multiplier));
+	  info.objs > ((unsigned)(abs(merge_threshold)) * 16 * split_multiplier));
 			    
 }
 

--- a/src/os/HashIndex.h
+++ b/src/os/HashIndex.h
@@ -43,7 +43,7 @@
  * would be located in (root)/2/D/0/
  * 
  * Subdirectories are created when the number of objects in a directory
- * exceed 32*merge_threshhold.  The number of objects in a directory 
+ * exceed (abs(merge_threshhold)) * 16 * split_multiplier.  The number of objects in a directory 
  * is encoded as subdir_info_s in an xattr on the directory.
  */
 class HashIndex : public LFNIndex {
@@ -60,7 +60,8 @@ private:
   /**
    * Merges occur when the number of object drops below
    * merge_threshold and splits occur when the number of objects
-   * exceeds 16 * merge_threshold * split_multiplier.
+   * exceeds 16 * abs(merge_threshold) * split_multiplier.
+   * Please note if merge_threshold is less than zero, it will never do merging
    */
   int merge_threshold;
   int split_multiplier;


### PR DESCRIPTION
Make the configuration "filestore merge threshold" can be negative which prevent it from merging, this could help:
1. We are trying to create the PG folder up to several levels with a standalone tool to prevent it from runtime splitting, we need a configuration which prevent it from merging even there is no file within the folder.
2. As runtime split / merge could bring latency issues, customer can use a negative merge threshold to prevent merging but only splitting.
   This change is backward compatible.
   Signed-off-by: Guang Yang (yguang@yahoo-inc.com)
