### PR TITLE
document adding dev key for custom Apache/FCGI install

### DIFF
--- a/doc/install/install-ceph-gateway.rst
+++ b/doc/install/install-ceph-gateway.rst
@@ -58,6 +58,9 @@ builds of Apache and FastCGI packages modified for Ceph at `gitbuilder.ceph.com`
 Debian Packages
 ---------------
 
+#. Add the development key:
+        wget -q -O- https://raw.github.com/ceph/ceph/master/keys/autobuild.asc | sudo apt-key add -
+
 #. Add a ``ceph-apache.list`` file to your APT sources. :: 
 
 	echo deb http://gitbuilder.ceph.com/apache2-deb-$(lsb_release -sc)-x86_64-basic/ref/master $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph-apache.list


### PR DESCRIPTION
following the docs will only get you the release key and the install of custom Apache/FCGI fails w/ key error
