### PR TITLE
mon: Monitor: change 'status' function names for clarity's sake

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -260,7 +260,7 @@ void Monitor::do_admin_command(string command, cmdmap_t& cmdmap, string format,
   boost::scoped_ptr<Formatter> f(new_formatter(format));
 
   if (command == "mon_status") {
-    _mon_status(f.get(), ss);
+    get_mon_status(f.get(), ss);
     if (f)
       f->flush(ss);
   } else if (command == "quorum_status")
@@ -1740,7 +1740,7 @@ void Monitor::_quorum_status(Formatter *f, ostream& ss)
     delete f;
 }
 
-void Monitor::_mon_status(Formatter *f, ostream& ss)
+void Monitor::get_mon_status(Formatter *f, ostream& ss)
 {
   bool free_formatter = false;
 
@@ -2375,7 +2375,7 @@ void Monitor::handle_command(MMonCommand *m)
     rs = "";
     r = 0;
   } else if (prefix == "mon_status") {
-    _mon_status(f.get(), ds);
+    get_mon_status(f.get(), ds);
     if (f)
       f->flush(ds);
     rdata.append(ds);
@@ -3042,7 +3042,7 @@ void Monitor::handle_ping(MPing *m)
   get_health(health_str, NULL, f);
   {
     stringstream ss;
-    _mon_status(f, ss);
+    get_mon_status(f, ss);
   }
 
   f->close_section();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -618,7 +618,7 @@ public:
                         const map<string,cmd_vartype>& cmdmap,
                         const map<string,string>& param_str_map,
                         const MonCommand *this_cmd);
-  void _mon_status(Formatter *f, ostream& ss);
+  void get_mon_status(Formatter *f, ostream& ss);
   void _quorum_status(Formatter *f, ostream& ss);
   void _osdmonitor_prepare_command(cmdmap_t& cmdmap, ostream& ss);
   void _add_bootstrap_peer_hint(string cmd, cmdmap_t& cmdmap, ostream& ss);


### PR DESCRIPTION
I found myself going through status functions this morning and realizing
just how annoyingly confusing the names are.  We have a '_mon_status()'
function and a 'get_status()' function.  Just by looking at them we figure out
just what each one's intended purpose is, but it's annoying to have to check
them out.  So I just changed them to something that is reasonable and clear.

'_mon_status()' thus becomes 'get_mon_status()', as it obtains mon-specific
status about the mon we are poking.

'get_status()' becomes 'get_cluster_status()', as it reports on cluster status
instead of 'just-monitor-specific status'.

This is not in any way a critical fix.  Just function renaming.  For the sake of
humanity.

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
