### PR TITLE
qa: Add ceph_multi_stress_watch for rep and ec

### DIFF
--- a/qa/workunits/rados/stress_watch.sh
+++ b/qa/workunits/rados/stress_watch.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
 ceph_test_stress_watch
+ceph_multi_stress_watch rep reppool repobj
+ceph_multi_stress_watch ec ecpool ecobj
 
 exit 0


### PR DESCRIPTION
This is going into master because the change to the test case is based on the new way to configure EC pools.
