### PR TITLE
PG: don't query unfound on empty pgs

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -441,6 +441,13 @@ void PG::discover_all_missing(map< int, map<pg_t,pg_query_t> > &query_map)
       continue;
     }
 
+    map<int, pg_info_t>::const_iterator iter = peer_info.find(peer);
+    if (iter != peer_info.end() &&
+        (iter->second.is_empty() || iter->second.dne())) {
+      // ignore empty peers
+      continue;
+    }
+
     // If we've requested any of this stuff, the pg_missing_t information
     // should be on its way.
     // TODO: coalsce requested_* into a single data structure
@@ -672,6 +679,10 @@ bool PG::all_unfound_are_queried_or_lost(const OSDMapRef osdmap) const
   set<int>::const_iterator mend = might_have_unfound.end();
   for (; peer != mend; ++peer) {
     if (peer_missing.count(*peer))
+      continue;
+    map<int, pg_info_t>::const_iterator iter = peer_info.find(*peer);
+    if (iter != peer_info.end() &&
+        (iter->second.is_empty() || iter->second.dne()))
       continue;
     const osd_info_t &osd_info(osdmap->get_info(*peer));
     if (osd_info.lost_at <= osd_info.up_from) {


### PR DESCRIPTION
When the replica responds, it responds with a notify
rather than a log, which the primary then ignores since
it is already in the peer_info map.  Rather than fix that
we'll simply not send queries to peers we already know to
have no unfound objects.

Fixes: #6910
Signed-off-by: Samuel Just sam.just@inktank.com
Reviewed-by: Sage Weil sage@inktank.com
Reviewed-by: David Zafman david.zafman@inktank.com
(cherry picked from commit 838b6c8387087543ce50837277f7f6b52ae87d00)
