### PR TITLE
rgw: use s->content_length instead of s->length

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -784,7 +784,7 @@ void RGWOp_Quota_Set::execute()
 
   bool use_http_params;
 
-  if (s->length > 0) {
+  if (s->content_length > 0) {
     use_http_params = false;
   } else {
     const char *encoding = s->info.env->get("HTTP_TRANSFER_ENCODING");


### PR DESCRIPTION
Fixes: #7876
Need to use the actual content length, not the pointer to the string.
This was probably working because there's correlation to when
content_length > 0 to whether s->length is not null.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
