### PR TITLE
ceph-conf: do not log

### DIFF
--- a/src/tools/ceph_conf.cc
+++ b/src/tools/ceph_conf.cc
@@ -162,6 +162,8 @@ int main(int argc, const char **argv)
   args.push_back("");
   args.push_back("--no-log-to-stderr");
   args.push_back("--no-log-to-syslog");
+  args.push_back("--admin-socket");
+  args.push_back("");
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_DAEMON,
 	      CINIT_FLAG_NO_DAEMON_ACTIONS);


### PR DESCRIPTION
If you are querying the conf for an osd and it has a log configured, we 
should not generate any log activity.

This isn't super pretty, but it is much less intrusive that wiring a 'do not
log' flag down into CephContext and a zillion other places.

Fixes: #7849 Signed-off-by: Sage Weil sage@inktank.com
