### PR TITLE
mds: properly propagate dirty dirstat to auth inode

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -1983,8 +1983,8 @@ void MDCache::predirty_journal_parents(Mutation *mut, EMetaBlob *blob,
     }
 
     bool stop = false;
-    if (!pin->can_auth_pin() || pin->is_ambiguous_auth()) {
-      dout(10) << "predirty_journal_parents can't auth pin or ambig on " << *pin << dendl;
+    if (!pin->is_auth() || (!mut->is_auth_pinned(pin) && !pin->can_auth_pin())) {
+      dout(10) << "predirty_journal_parents !auth or ambig or can't authpin on " << *pin << dendl;
       stop = true;
     }
 


### PR DESCRIPTION
Propagate dirty dirstat to freezing auth inode if the inode is
already auth pinned by the Mutation. Otherwiese the dirstat can
be propagated to inode after client changes inode's mtime.

Fixes: #7880
Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
