### PR TITLE
osd/PG: fix choose_acting revert to up case

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1163,12 +1163,13 @@ bool PG::choose_acting(pg_shard_t &auth_log_shard_id)
       dout(10) << "choose_acting no suitable info found (incomplete backfills?),"
 	       << " reverting to up" << dendl;
       want_acting = up;
-      return true;
+      vector<int> empty;
+      osd->queue_want_pg_temp(info.pgid.pgid, empty);
     } else {
       dout(10) << "choose_acting failed" << dendl;
       assert(want_acting.empty());
-      return false;
     }
+    return false;
   }
 
   if ((up.size() &&


### PR DESCRIPTION
If we decide to revert back to up, we need to

1- return false, so that we go into the NeedActingChange state, and 2-
actually ask for that change.

It's too fugly to try to jump down to the existing queue_want_pg_temp call
100+ lines down in this function, so just do it here.  We already know that
we are requesting to clear the pg_temp.

Fixes: #7902 Backport: emperor, dumpling Signed-off-by: Sage Weil
sage@inktank.com
