### PR TITLE
fuse: implement 'access' low level function

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -591,6 +591,11 @@ static void fuse_ll_releasedir(fuse_req_t req, fuse_ino_t ino,
   fuse_reply_err(req, 0);
 }
 
+static void fuse_ll_access(fuse_req_t req, fuse_ino_t ino, int mask)
+{
+  fuse_reply_err(req, 0);
+}
+
 static void fuse_ll_create(fuse_req_t req, fuse_ino_t parent, const char *name,
 			   mode_t mode, struct fuse_file_info *fi)
 {
@@ -733,7 +738,7 @@ const static struct fuse_lowlevel_ops fuse_ll_oper = {
  getxattr: fuse_ll_getxattr,
  listxattr: fuse_ll_listxattr,
  removexattr: fuse_ll_removexattr,
- access: 0,
+ access: fuse_ll_access,
  create: fuse_ll_create,
  getlk: 0,
  setlk: 0,


### PR DESCRIPTION
Add an empty 'access' function to fuse low level functions. This
allow us to use ceph-fuse with fuse_default_permissions = false.
'fuse_default_permissions = false' can significantly improve the
speed of create/removing files.

When fuse_default_permissions is true, the fuse kernel module sends
a getattr request whenever the kernel needs to check a directory's
permission. getattr (STAT_CAP_INODE_ALL) can be very slow if the
directory was just modified.

Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
