### PR TITLE
mon/PGMap: clear pool sum when last pg is deleted

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -264,6 +264,7 @@ void PGMap::apply_incremental(CephContext *cct, const Incremental& inc)
     // adjust [near]full status
     register_nearfull_status(osd, new_stats);
   }
+  set<int64_t> deleted_pools;
   for (set<pg_t>::const_iterator p = inc.pg_remove.begin();
        p != inc.pg_remove.end();
        ++p) {
@@ -273,6 +274,14 @@ void PGMap::apply_incremental(CephContext *cct, const Incremental& inc)
       stat_pg_sub(removed_pg, s->second);
       pg_stat.erase(s);
     }
+    if (removed_pg.ps() == 0)
+      deleted_pools.insert(removed_pg.pool());
+  }
+  for (set<int64_t>::iterator p = deleted_pools.begin();
+       p != deleted_pools.end();
+       ++p) {
+    dout(20) << " deleted pool " << *p << dendl;
+    deleted_pool(*p);
   }
 
   for (set<int>::iterator p = inc.get_osd_stat_rm().begin();

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -139,6 +139,13 @@ public:
                           const ceph::unordered_map<uint64_t, pool_stat_t>& pg_pool_sum_old);
   void clear_delta();
 
+  void deleted_pool(int64_t pool) {
+    pg_pool_sum.erase(pool);
+    per_pool_sum_deltas.erase(pool);
+    per_pool_sum_deltas_stamps.erase(pool);
+    per_pool_sum_delta.erase(pool);
+  }
+
  private:
   void update_delta(CephContext *cct,
                     const utime_t ts,

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -430,6 +430,7 @@ void PGMonitor::apply_pgmap_delta(bufferlist& bl)
   ceph::unordered_map<uint64_t, pool_stat_t> pg_pool_sum_old;
 
   // pgs
+  set<int64_t> deleted_pools;
   bufferlist::iterator p = dirty_pgs.begin();
   while (!p.end()) {
     pg_t pgid;
@@ -446,6 +447,8 @@ void PGMonitor::apply_pgmap_delta(bufferlist& bl)
       pg_map.update_pg(pgid, bl);
     } else {
       pg_map.remove_pg(pgid);
+      if (pgid.ps() == 0)
+	deleted_pools.insert(pgid.pool());
     }
   }
 
@@ -466,6 +469,14 @@ void PGMonitor::apply_pgmap_delta(bufferlist& bl)
 
   pg_map.update_global_delta(g_ceph_context, inc_stamp, pg_sum_old);
   pg_map.update_pool_deltas(g_ceph_context, inc_stamp, pg_pool_sum_old);
+
+  // clean up deleted pools after updating the deltas
+  for (set<int64_t>::iterator p = deleted_pools.begin();
+       p != deleted_pools.end();
+       ++p) {
+    dout(20) << " deleted pool " << *p << dendl;
+    pg_map.deleted_pool(*p);
+  }
 
   // ok, we're now on the new version
   pg_map.version = v;


### PR DESCRIPTION
Use the x.0 pg as a sentinel for the existence of the pool.  Note that we 
have to clean in up two paths: apply_incrmenetal (which is actually 
deprecated) and the normal PGMonitor refresh.

Fixes: #7912 Signed-off-by: Sage Weil sage@inktank.com
