### PR TITLE
Add ceph-client-debug and jerasure shared objects to RPM spec file.

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -406,6 +406,7 @@ fi
 %{_bindir}/librados-config
 %{_bindir}/rados
 %{_bindir}/rbd
+%{_bindir}/ceph-client-debug
 %{_bindir}/ceph-debugpack
 %{_bindir}/ceph-coverage
 %{_bindir}/ceph_mon_store_converter
@@ -437,7 +438,8 @@ fi
 %{_libdir}/ceph/erasure-code/libec_fail_to_initialize.so*
 %{_libdir}/ceph/erasure-code/libec_fail_to_register.so*
 %{_libdir}/ceph/erasure-code/libec_hangs.so*
-%{_libdir}/ceph/erasure-code/libec_jerasure.so*
+%{_libdir}/ceph/erasure-code/libec_jerasure*.so*
+%{_libdir}/ceph/erasure-code/libec_test_jerasure*.so*
 %{_libdir}/ceph/erasure-code/libec_missing_entry_point.so*
 /lib/udev/rules.d/50-rbd.rules
 /lib/udev/rules.d/60-ceph-partuuid-workaround.rules


### PR DESCRIPTION
ceph-client-debug and jerasure shared objects were recently added to the build output, but not to rpm.spec.in.

The packages on gitbuilder (firefly branch) simply don't include these files, causing errors when using EC pools. When I ran rpmbuild, it failed because they were unaccounted for in the spec file.
