### PR TITLE
rgw: reverse logic to identify next part

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -681,7 +681,7 @@ void RGWObjManifest::obj_iterator::operator++()
       stripe_ofs = part_ofs;
 
       /* move to the next rule? */
-      if (next_rule_iter->second.start_ofs >= stripe_ofs) {
+      if (stripe_ofs >= next_rule_iter->second.start_ofs) {
         rule_iter = next_rule_iter;
         bool last_rule = (next_rule_iter == manifest->rules.end());
         if (!last_rule) {


### PR DESCRIPTION
Fixes: #7935
The check that identifies whether we need to move to the next part when
iterating over an object was reversed.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
