### PR TITLE
osd/ReplicatedPG: mark_unrollbackable when _rollback_to head

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -5096,6 +5096,9 @@ void ReplicatedPG::finish_ctx(OpContext *ctx, int log_op_type)
 	changing.insert(OI_ATTR);
 	changing.insert(SS_ATTR);
 	ctx->obc->fill_in_setattrs(changing, &(ctx->mod_desc));
+      } else {
+	// replicated pools are never rollbackable in this case
+	ctx->mod_desc.mark_unrollbackable();
       }
     } else {
       dout(10) << " no snapset (this is a clone)" << dendl;


### PR DESCRIPTION
We fell into the case in _rollback_to where we just set ctx->modify = true 
and don't explicitly mark the ctx and unrollbackable.  Later, we screw up in
proc_replica_log as a result because we think we can rollback this update to
the head when in reality we cannot.

Fixes: #7907 Signed-off-by: Sage Weil sage@inktank.com
