### PR TITLE
Add header cache to DBObjectMap

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -631,6 +631,7 @@ OPTION(filestore_index_retry_probability, OPT_DOUBLE, 0)
 OPTION(filestore_debug_inject_read_err, OPT_BOOL, false)
 
 OPTION(filestore_debug_omap_check, OPT_BOOL, 0) // Expensive debugging check on sync
+OPTION(filestore_omap_header_cache_size, OPT_INT, 1024) 
 
 // Use omap for xattrs for attrs over
 // filestore_max_inline_xattr_size or

--- a/src/common/simple_cache.hpp
+++ b/src/common/simple_cache.hpp
@@ -62,6 +62,16 @@ public:
     }
   }
 
+  void clear(K key) {
+    Mutex::Locker l(lock);
+    typename map<K, typename list<pair<K, V> >::iterator>::iterator i =
+      contents.find(key);
+    if (i == contents.end())
+      return;
+    lru.erase(i->second);
+    contents.erase(i);
+  }
+
   void set_size(size_t new_size) {
     Mutex::Locker l(lock);
     max_size = new_size;

--- a/src/os/DBObjectMap.cc
+++ b/src/os/DBObjectMap.cc
@@ -1114,18 +1114,31 @@ DBObjectMap::Header DBObjectMap::_lookup_map_header(const ghobject_t &oid)
   while (map_header_in_use.count(oid))
     header_cond.Wait(header_lock);
 
+  _Header *header = new _Header();
+  {
+    Mutex::Locker l(cache_lock);
+    if (caches.lookup(oid, header)) {
+      return Header(header, RemoveMapHeaderOnDelete(this, oid));
+    }
+  }
+
   map<string, bufferlist> out;
   set<string> to_get;
   to_get.insert(map_header_key(oid));
   int r = db->get(HOBJECT_TO_SEQ, to_get, &out);
-  if (r < 0)
+  if (r < 0 || out.empty()) {
+    delete header;
     return Header();
-  if (out.empty())
-    return Header();
-  
-  Header ret(new _Header(), RemoveMapHeaderOnDelete(this, oid));
+  }
+
+  Header ret(header, RemoveMapHeaderOnDelete(this, oid));
   bufferlist::iterator iter = out.begin()->second.begin();
   ret->decode(iter);
+  {
+    Mutex::Locker l(cache_lock);
+    caches.add(oid, *ret);
+  }
+
   return ret;
 }
 
@@ -1220,6 +1233,10 @@ void DBObjectMap::remove_map_header(const ghobject_t &oid,
   set<string> to_remove;
   to_remove.insert(map_header_key(oid));
   t->rmkeys(HOBJECT_TO_SEQ, to_remove);
+  {
+    Mutex::Locker l(cache_lock);
+    caches.clear(oid);
+  }
 }
 
 void DBObjectMap::set_map_header(const ghobject_t &oid, _Header header,
@@ -1231,6 +1248,10 @@ void DBObjectMap::set_map_header(const ghobject_t &oid, _Header header,
   map<string, bufferlist> to_set;
   header.encode(to_set[map_header_key(oid)]);
   t->set(HOBJECT_TO_SEQ, to_set);
+  {
+    Mutex::Locker l(cache_lock);
+    caches.add(oid, header);
+  }
 }
 
 bool DBObjectMap::check_spos(const ghobject_t &oid,


### PR DESCRIPTION
OMap is used by PG to store PGLog, so it's called by each write operations.
Because leveldb don't play well in random read and "header_lock" limit the
concurrence. Add a LRU cache to avoid too much overload on seeking header.

Signed-off-by: Haomai Wang haomaiwang@gmail.com

In private cluster: we make two osd(replicate size 2) each backend with SSD make full use of. The io util can get 90%. Two OSD can get nearly 10k IOPS(4k). Before this patch, we only can get 35-45% of io util.

If something I missed or wrong, plz correct me.
