### PR TITLE
mds: fix check for merging/spliting dirfrag

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -325,6 +325,7 @@ protected:
     return num_dirty;
   }
 
+  int64_t get_frag_size() { return get_projected_fnode()->fragstat.size(); }
 
   // -- dentries and inodes --
  public:
@@ -371,10 +372,10 @@ public:
   void merge(list<CDir*>& subs, list<Context*>& waiters, bool replay);
 
   bool should_split() {
-    return (int)get_num_head_items() > g_conf->mds_bal_split_size;
+    return (int)get_frag_size() > g_conf->mds_bal_split_size;
   }
   bool should_merge() {
-    return (int)get_num_head_items() < g_conf->mds_bal_merge_size;
+    return (int)get_frag_size() < g_conf->mds_bal_merge_size;
   }
 
 private:

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -1000,11 +1000,11 @@ void MDBalancer::hit_dir(utime_t now, CDir *dir, int type, int who, double amoun
       dir->is_auth()) {
 
     dout(20) << "hit_dir " << type << " pop is " << v << ", frag " << dir->get_frag()
-	     << " size " << dir->get_num_head_items() << dendl;
+	     << " size " << dir->get_frag_size() << dendl;
 
     // split
     if (g_conf->mds_bal_split_size > 0 &&
-	((dir->get_num_head_items() > (unsigned)g_conf->mds_bal_split_size) ||
+	(dir->should_split() ||
 	 (v > g_conf->mds_bal_split_rd && type == META_POP_IRD) ||
 	 (v > g_conf->mds_bal_split_wr && type == META_POP_IWR)) &&
 	split_queue.count(dir->dirfrag()) == 0) {
@@ -1013,8 +1013,7 @@ void MDBalancer::hit_dir(utime_t now, CDir *dir, int type, int who, double amoun
     }
 
     // merge?
-    if (dir->get_frag() != frag_t() &&
-	(dir->get_num_head_items() < (unsigned)g_conf->mds_bal_merge_size) &&
+    if (dir->get_frag() != frag_t() && dir->should_merge() &&
 	merge_queue.count(dir->dirfrag()) == 0) {
       dout(10) << "hit_dir " << type << " pop is " << v << ", putting in merge_queue: " << *dir << dendl;
       merge_queue.insert(dir->dirfrag());


### PR DESCRIPTION
check actual number of items instead of number of cached items

Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
