### PR TITLE
mon: MonCommands.h: have 'auth' read-only operations require 'x' cap

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -12,5 +12,15 @@ v0.78 firefly
 
   to your ceph.conf to get back the (leveldb) defaults.
 
+* monitor 'auth' read-only commands now expect the user to have 'rx' caps.
+  the affected commands are::
+
+    ceph auth export
+    ceph auth get
+    ceph auth get-key
+    ceph auth print-key
+    ceph auth list
+
+
 v0.79
 -----

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -152,16 +152,16 @@ COMMAND("pg set_nearfull_ratio name=ratio,type=CephFloat,range=0.0|1.0", \
 
 COMMAND("auth export name=entity,type=CephString,req=false", \
        	"write keyring for requested entity, or master keyring if none given", \
-	"auth", "r", "cli,rest")
+	"auth", "rx", "cli,rest")
 COMMAND("auth get name=entity,type=CephString", \
-	"write keyring file with requested key", "auth", "r", "cli,rest")
+	"write keyring file with requested key", "auth", "rx", "cli,rest")
 COMMAND("auth get-key name=entity,type=CephString", "display requested key", \
-	"auth", "r", "cli,rest")
+	"auth", "rx", "cli,rest")
 COMMAND("auth print-key name=entity,type=CephString", "display requested key", \
-	"auth", "r", "cli,rest")
+	"auth", "rx", "cli,rest")
 COMMAND("auth print_key name=entity,type=CephString", "display requested key", \
-	"auth", "r", "cli,rest")
-COMMAND("auth list", "list authentication state", "auth", "r", "cli,rest")
+	"auth", "rx", "cli,rest")
+COMMAND("auth list", "list authentication state", "auth", "rx", "cli,rest")
 COMMAND("auth import", "auth import: read keyring file from -i <file>", \
 	"auth", "rw", "cli,rest")
 COMMAND("auth add " \


### PR DESCRIPTION
This reintroduces the same semantics that were in place in dumpling prior
to the refactoring of the cap/command matching code.

We haven't added this requirement to auth read-write operations as that
would have the potential to break a lot of well-configured keyrings once
the users upgraded, without any significant gain -- we assume that if
they have set 'rw' caps on a given entity, they are indeed expecting said
entity to be sort-of-privileged entities with regard to monitor access.

Fixes: 7919

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
