### PR TITLE
qa: test_alloc_hint: set ec ruleset-failure-domain to osd

### DIFF
--- a/qa/workunits/rados/test_alloc_hint.sh
+++ b/qa/workunits/rados/test_alloc_hint.sh
@@ -108,7 +108,7 @@ setup_osd_data
 
 POOL="alloc_hint-rep"
 ceph osd pool create "${POOL}" "${NUM_PG}"
-ceph osd pool set "${POOL}" size "${NUM_OSDS}" # just in case
+ceph osd pool set "${POOL}" size "${NUM_OSDS}"
 
 OBJ="foo"
 setup_pgid "${POOL}" "${OBJ}"
@@ -151,10 +151,11 @@ ceph osd pool delete "${POOL}" "${POOL}" --yes-i-really-really-mean-it
 # ECBackend tests
 #
 
+PROFILE="alloc_hint-ecprofile"
 POOL="alloc_hint-ec"
-RULE="ecruleset"
-ceph osd crush rule create-erasure "${RULE}" default
-ceph osd pool create "${POOL}" "${NUM_PG}" "${NUM_PGP}" erasure default "${RULE}"
+ceph osd erasure-code-profile set "${PROFILE}" k=2 m=1 ruleset-failure-domain=osd
+ceph osd erasure-code-profile get "${PROFILE}" # just so it's logged
+ceph osd pool create "${POOL}" "${NUM_PG}" "${NUM_PGP}" erasure "${PROFILE}"
 
 OBJ="baz"
 setup_pgid "${POOL}" "${OBJ}"


### PR DESCRIPTION
Create a custom profile with ruleset-failure-domain=osd.  (The default
ruleset-failure-domain=host won't do because this script assumes and
works only if all osds are on the same host.)  While at it, set k and m
explicitly to avoid troubles in the future.

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
