### PR TITLE
rgw: only look at next placement rule if we're not at the last rule

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -680,10 +680,11 @@ void RGWObjManifest::obj_iterator::operator++()
       part_ofs += rule->part_size;
       stripe_ofs = part_ofs;
 
+      bool last_rule = (next_rule_iter == manifest->rules.end());
       /* move to the next rule? */
-      if (stripe_ofs >= next_rule_iter->second.start_ofs) {
+      if (!last_rule && stripe_ofs >= next_rule_iter->second.start_ofs) {
         rule_iter = next_rule_iter;
-        bool last_rule = (next_rule_iter == manifest->rules.end());
+        last_rule = (next_rule_iter == manifest->rules.end());
         if (!last_rule) {
           ++next_rule_iter;
         }


### PR DESCRIPTION
Fixes: #7978
We tried to move to the next placement rule, but we were already at the
last one, so we ended up looping forever.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
