### PR TITLE
osd: disable agent when stats_invalid (post-split)

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -10579,6 +10579,10 @@ void ReplicatedPG::agent_setup()
     dout(10) << __func__ << " keeping existing state" << dendl;
   }
 
+  if (info.stats.stats_invalid) {
+    osd->clog.warn() << "pg " << info.pgid << " has invalid (post-split) stats; must scrub before tier agent can activate";
+  }
+
   agent_choose_mode();
 }
 


### PR DESCRIPTION
After a split the pg stats are approximate but not precisely correct.  Any 
inaccuracy can be problematic for the agent because it determines the level of
effort and potentially full/blocking behavior based on that.

We could concievably do some estimation here that is "safe" in that we don't
commit to too much effort (or back off later if it isn't paying off) and never
block, but that is error-prone.

Instead, just disable the agent until a scrub makes the stats reliable again.

We should document that a scrub after split is recommended (in any case) and
especially important on cache tiers, but there are currently _no_ user docs
about PG splitting.

Fixes: #7975 Signed-off-by: Sage Weil sage@inktank.com
