### PR TITLE
OSD: _share_map_outgoing whenever sending a message to a peer

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3852,7 +3852,10 @@ void OSDService::send_message_osd_cluster(int peer, Message *m, epoch_t from_epo
     m->put();
     return;
   }
-  osd->cluster_messenger->send_message(m, next_osdmap->get_cluster_inst(peer));
+  const entity_inst_t& peer_inst = next_osdmap->get_cluster_inst(peer);
+  Connection *peer_con = osd->cluster_messenger->get_connection(peer_inst).get();
+  osd->_share_map_outgoing(peer, peer_con, next_osdmap);
+  osd->cluster_messenger->send_message(m, peer_inst);
 }
 
 ConnectionRef OSDService::get_con_osd_cluster(int peer, epoch_t from_epoch)

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -334,7 +334,7 @@ public:
   void dequeue_pg(PG *pg, list<OpRequestRef> *dequeued);
 
   // -- superblock --
-  Mutex publish_lock, pre_publish_lock;
+  Mutex publish_lock, pre_publish_lock; // pre-publish orders before publish
   OSDSuperblock superblock;
   OSDSuperblock get_superblock() {
     Mutex::Locker l(publish_lock);


### PR DESCRIPTION
This ensures that they get new maps before an op which requires them (that
they would then request from the monitor).

I ran it through a full RADOS suite:
"5 failed, 3 hung, 510 passed in gregf-2014-04-04_22:05:49-rados-wip-7994-testing-basic-plana".
Sage confirmed that all the failures/hangs were known issues.
