### PR TITLE
mds: fix shared_ptr MDRequest bugs

### DIFF
--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -240,7 +240,7 @@ protected:
 
   // -- requests --
 protected:
-  ceph::unordered_map<metareqid_t,ceph::weak_ptr<MDRequestImpl> > active_requests;
+  ceph::unordered_map<metareqid_t, MDRequestRef> active_requests;
 
 public:
   int get_num_client_requests();

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -2618,7 +2618,7 @@ void Migrator::import_finish(CDir *dir, bool notify, bool last)
   it->second.peer_exports.swap(peer_exports);
 
   // clear import state (we're done!)
-  MutationRef& mut = it->second.mut;
+  MutationRef mut = it->second.mut;
   import_state.erase(it);
 
   mds->mdlog->start_submit_entry(new EImportFinish(dir, true));

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -34,7 +34,6 @@ class MClientRequest;
 class MMDSSlaveRequest;
 
 struct MutationImpl {
-  ceph::weak_ptr<MutationImpl> self_ref;
   metareqid_t reqid;
   __u32 attempt;      // which attempt for this request
   LogSegment *ls;  // the log segment i'm committing to
@@ -80,16 +79,14 @@ struct MutationImpl {
   list<pair<CDentry*,version_t> > dirty_cow_dentries;
 
   MutationImpl()
-    : self_ref(),
-      attempt(0),
+    : attempt(0),
       ls(0),
       slave_to_mds(-1),
       locking(NULL),
       locking_target_mds(-1),
       done_locking(false), committing(false), aborted(false), killed(false) { }
   MutationImpl(metareqid_t ri, __u32 att=0, int slave_to=-1)
-    : self_ref(),
-      reqid(ri), attempt(att),
+    : reqid(ri), attempt(att),
       ls(0),
       slave_to_mds(slave_to), 
       locking(NULL),
@@ -140,10 +137,6 @@ struct MutationImpl {
 
   virtual void print(ostream &out) {
     out << "mutation(" << this << ")";
-  }
-
-  void set_self_ref(ceph::shared_ptr<MutationImpl>& ref) {
-    self_ref = ref;
   }
 };
 
@@ -314,9 +307,6 @@ struct MDRequestImpl : public MutationImpl {
   void clear_ambiguous_auth();
 
   void print(ostream &out);
-  void set_self_ref(ceph::shared_ptr<MDRequestImpl>& ref) {
-    self_ref = ceph::static_pointer_cast<MutationImpl,MDRequestImpl>(ref);
-  }
 };
 
 typedef ceph::shared_ptr<MDRequestImpl> MDRequestRef;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -548,8 +548,7 @@ void Server::journal_close_session(Session *session, int state)
     session->requests.begin(member_offset(MDRequestImpl,
 					  item_session_request));
   while (!p.end()) {
-    MDRequestRef mdr = ceph::static_pointer_cast<MDRequestImpl,MutationImpl>((*p)->self_ref.lock());
-    assert(mdr);
+    MDRequestRef mdr = mdcache->request_get((*p)->reqid);
     ++p;
     mdcache->request_kill(mdr);
   }


### PR DESCRIPTION
The main change is use shared_ptr instead of weak_ptr to define
active request map. The reason is that slave request needs to be
preserved until master explicitly finish it.

Fixes: #8026
Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
