### PR TITLE
client: wake up umount waiter if receiving session open message

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1610,9 +1610,10 @@ void Client::handle_client_session(MClientSession *m)
   case CEPH_SESSION_OPEN:
     renew_caps(session);
     session->state = MetaSession::STATE_OPEN;
-    if (!unmounting) {
+    if (unmounting)
+      mount_cond.Signal();
+    else
       connect_mds_targets(from);
-    }
     signal_context_list(session->waiting_for_open);
     break;
 


### PR DESCRIPTION
Wake up umount waiter if receiving session open message while
umounting. The umount waiter will re-close the session.

Fixes: #8004
Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
