### PR TITLE
use cpp_strerror() wherever possible, and make it be the POSIX one

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -108,7 +108,7 @@ int mon_data_exists(bool *r)
     if (errno == ENOENT) {
       *r = false;
     } else {
-      cerr << "stat(" << mon_data << ") " << strerror(errno) << std::endl;
+      cerr << "stat(" << mon_data << ") " << cpp_strerror(errno) << std::endl;
       return -errno;
     }
   } else {
@@ -123,7 +123,7 @@ int mon_data_empty(bool *r)
 
   DIR *dir = ::opendir(mon_data.c_str());
   if (!dir) {
-    cerr << "opendir(" << mon_data << ") " << strerror(errno) << std::endl;
+    cerr << "opendir(" << mon_data << ") " << cpp_strerror(errno) << std::endl;
     return -errno;
   }
   char buf[offsetof(struct dirent, d_name) + PATH_MAX + 1];
@@ -135,7 +135,7 @@ int mon_data_empty(bool *r)
   while (!::readdir_r(dir, reinterpret_cast<struct dirent*>(buf), &de)) {
     if (!de) {
       if (errno) {
-	cerr << "readdir(" << mon_data << ") " << strerror(errno) << std::endl;
+	cerr << "readdir(" << mon_data << ") " << cpp_strerror(errno) << std::endl;
 	code = -errno;
       }
       break;
@@ -285,7 +285,7 @@ int main(int argc, const char **argv)
     if (!exists) {
       if (::mkdir(g_conf->mon_data.c_str(), 0755)) {
 	cerr << "mkdir(" << g_conf->mon_data << ") : "
-	     << strerror(errno) << std::endl;
+	     << cpp_strerror(errno) << std::endl;
 	exit(1);
       }
     }

--- a/src/cephfs.cc
+++ b/src/cephfs.cc
@@ -65,8 +65,7 @@ int main (int argc, char **argv) {
     memset(&layout, 0, sizeof(layout));
     err = ioctl(fd, CEPH_IOC_GET_LAYOUT, (unsigned long)&layout);
     if (err) {
-      cerr << "Error getting layout: "
-	   << (err == -1 ? strerror(errno) : strerror(-err)) << endl;
+      cerr << "Error getting layout: " << cpp_strerror(errno) << endl;
       return 1;
     }
     if (layout.stripe_unit == 0) {
@@ -82,8 +81,7 @@ int main (int argc, char **argv) {
     location.file_offset = file_offset;
     err = ioctl(fd, CEPH_IOC_GET_DATALOC, (unsigned long)&location);
     if (err) {
-      cerr << "Error getting location: "
-	   << (err == -1 ? strerror(errno) : strerror(-err)) << endl;
+      cerr << "Error getting location: " << cpp_strerror(err) << endl;
       return 1;
     }
     cout << "location.file_offset:  " << location.file_offset << endl;
@@ -106,16 +104,14 @@ int main (int argc, char **argv) {
     layout.unused = -1;   /* used to be preferred_osd */
     err = ioctl(fd, ioctl_num, (unsigned long)&layout);
     if (err) {
-      cerr << "Error setting layout: " 
-	   << (err == -1 ? strerror(errno) : strerror(-err)) << endl;
+      cerr << "Error setting layout: " << cpp_strerror(errno) << endl;
       return 1;
     }
   } else if (CMD_MAP == cmd) {
     struct stat st;
     err = ::fstat(fd, &st);
     if (err < 0) {
-      cerr << "error statting file: "
-	   << (err == -1 ? strerror(errno) : strerror(-err)) << endl;
+      cerr << "error statting file: " << cpp_strerror(errno) << endl;
       return 1;
     }
 
@@ -123,8 +119,7 @@ int main (int argc, char **argv) {
     memset(&layout, 0, sizeof(layout));
     err = ioctl(fd, CEPH_IOC_GET_LAYOUT, (unsigned long)&layout);
     if (err) {
-      cerr << "Error getting layout: "
-	   << (err == -1 ? strerror(errno) : strerror(-err)) << endl;
+      cerr << "Error getting layout: " << cpp_strerror(errno) << endl;
       return 1;
     }
 
@@ -136,8 +131,7 @@ int main (int argc, char **argv) {
       location.file_offset = off;
       err = ioctl(fd, CEPH_IOC_GET_DATALOC, (unsigned long)&location);
       if (err) {
-	cerr << "Error getting location: "
-	     << (err == -1 ? strerror(errno) : strerror(-err)) << endl;
+	cerr << "Error getting location: " << cpp_strerror(errno) << endl;
 	return 1;
       }
       printf("%15lld  %24s  %12lld  %12lld  %d\n",
@@ -193,7 +187,7 @@ int init_options(int argc, char **argv, int *fd, char **path, int *cmd,
 
   *fd = open(argv[1], O_RDONLY);
   if (*fd < 0) {
-    cerr << "error opening path: " << strerror(*fd) << endl;
+    cerr << "error opening path: " << cpp_strerror(*fd) << endl;
     return 1;
   }
 

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -33,6 +33,7 @@ using namespace std;
 #include <math.h>
 #include <sys/statvfs.h>
 
+#include "common/errno.h"
 #include "include/assert.h"
 
 #define dout_subsys ceph_subsys_client
@@ -318,16 +319,14 @@ int SyntheticClient::run()
   dout(15) << "initing" << dendl;
   int err = client->init();
   if (err < 0) {
-    char buf[80];
-    dout(0) << "failed to initialize: " << strerror_r(-err, buf, sizeof(buf)) << dendl;
+    dout(0) << "failed to initialize: " << cpp_strerror(err) << dendl;
     return -1;
   }
 
   dout(15) << "mounting" << dendl;
   err = client->mount("");
   if (err < 0) {
-    char buf[80];
-    dout(0) << "failed to mount: " << strerror_r(-err, buf, sizeof(buf)) << dendl;
+    dout(0) << "failed to mount: " << cpp_strerror(err) << dendl;
     client->shutdown();
     return -1;
   }

--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -21,6 +21,7 @@
 #include "include/utime.h"
 #include "objclass/objclass.h"
 
+#include "common/errno.h"
 #include "common/Clock.h"
 
 #include "cls/lock/cls_lock_types.h"
@@ -175,7 +176,7 @@ static int lock_obj(cls_method_context_t hctx,
   // see if there's already a locker
   int r = read_lock(hctx, name, &linfo);
   if (r < 0 && r != -ENOENT) {
-    CLS_ERR("Could not read lock info: %s", strerror(r));
+    CLS_ERR("Could not read lock info: %s", cpp_strerror(r).c_str());
     return r;
   }
   map<locker_id_t, locker_info_t>& lockers = linfo.lockers;
@@ -282,7 +283,7 @@ static int remove_lock(cls_method_context_t hctx,
   lock_info_t linfo;
   int r = read_lock(hctx, name, &linfo);
   if (r < 0) {
-    CLS_ERR("Could not read list of current lockers off disk: %s", strerror(r));
+    CLS_ERR("Could not read list of current lockers off disk: %s", cpp_strerror(r).c_str());
     return r;
   }
 
@@ -381,7 +382,7 @@ static int get_info(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   lock_info_t linfo;
   int r = read_lock(hctx, op.name, &linfo);
   if (r < 0) {
-    CLS_ERR("Could not read lock info: %s", strerror(r));
+    CLS_ERR("Could not read lock info: %s", cpp_strerror(r).c_str());
     return r;
   }
 

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -37,6 +37,7 @@
 #include <sstream>
 #include <vector>
 
+#include "common/errno.h"
 #include "objclass/objclass.h"
 #include "include/rbd_types.h"
 
@@ -290,7 +291,7 @@ int get_features(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   if (snap_id == CEPH_NOSNAP) {
     int r = read_key(hctx, "features", &features);
     if (r < 0) {
-      CLS_ERR("failed to read features off disk: %s", strerror(r));
+      CLS_ERR("failed to read features off disk: %s", cpp_strerror(r).c_str());
       return r;
     }
   } else {
@@ -359,14 +360,14 @@ int get_size(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 
   int r = read_key(hctx, "order", &order);
   if (r < 0) {
-    CLS_ERR("failed to read the order off of disk: %s", strerror(r));
+    CLS_ERR("failed to read the order off of disk: %s", cpp_strerror(r).c_str());
     return r;
   }
 
   if (snap_id == CEPH_NOSNAP) {
     r = read_key(hctx, "size", &size);
     if (r < 0) {
-      CLS_ERR("failed to read the image's size off of disk: %s", strerror(r));
+      CLS_ERR("failed to read the image's size off of disk: %s", cpp_strerror(r).c_str());
       return r;
     }
   } else {
@@ -409,7 +410,7 @@ int set_size(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   uint64_t orig_size;
   int r = read_key(hctx, "size", &orig_size);
   if (r < 0) {
-    CLS_ERR("Could not read image's size off disk: %s", strerror(r));
+    CLS_ERR("Could not read image's size off disk: %s", cpp_strerror(r).c_str());
     return r;
   }
 
@@ -615,7 +616,7 @@ int get_stripe_unit_count(cls_method_context_t hctx, bufferlist *in, bufferlist 
     uint8_t order;
     r = read_key(hctx, "order", &order);
     if (r < 0) {
-      CLS_ERR("failed to read the order off of disk: %s", strerror(r));
+      CLS_ERR("failed to read the order off of disk: %s", cpp_strerror(r).c_str());
       return -EIO;
     }
     stripe_unit = 1ull << order;
@@ -674,7 +675,7 @@ int set_stripe_unit_count(cls_method_context_t hctx, bufferlist *in, bufferlist 
   uint8_t order;
   r = read_key(hctx, "order", &order);
   if (r < 0) {
-    CLS_ERR("failed to read the order off of disk: %s", strerror(r));
+    CLS_ERR("failed to read the order off of disk: %s", cpp_strerror(r).c_str());
     return r;
   }
   if ((1ull << order) % stripe_unit || stripe_unit > (1ull << order)) {
@@ -1121,7 +1122,7 @@ int get_snapcontext(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   uint64_t snap_seq;
   r = read_key(hctx, "snap_seq", &snap_seq);
   if (r < 0) {
-    CLS_ERR("could not read the image's snap_seq off disk: %s", strerror(r));
+    CLS_ERR("could not read the image's snap_seq off disk: %s", cpp_strerror(r).c_str());
     return r;
   }
 
@@ -1147,7 +1148,7 @@ int get_object_prefix(cls_method_context_t hctx, bufferlist *in, bufferlist *out
   int r = read_key(hctx, "object_prefix", &object_prefix);
   if (r < 0) {
     CLS_ERR("failed to read the image's object prefix off of disk: %s",
-            strerror(r));
+            cpp_strerror(r).c_str());
     return r;
   }
 
@@ -1218,7 +1219,7 @@ int snapshot_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   uint64_t cur_snap_seq;
   int r = read_key(hctx, "snap_seq", &cur_snap_seq);
   if (r < 0) {
-    CLS_ERR("Could not read image's snap_seq off disk: %s", strerror(r));
+    CLS_ERR("Could not read image's snap_seq off disk: %s", cpp_strerror(r).c_str());
     return r;
   }
 
@@ -1229,12 +1230,12 @@ int snapshot_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 
   r = read_key(hctx, "size", &snap_meta.image_size);
   if (r < 0) {
-    CLS_ERR("Could not read image's size off disk: %s", strerror(r));
+    CLS_ERR("Could not read image's size off disk: %s", cpp_strerror(r).c_str());
     return r;
   }
   r = read_key(hctx, "features", &snap_meta.features);
   if (r < 0) {
-    CLS_ERR("Could not read image's features off disk: %s", strerror(r));
+    CLS_ERR("Could not read image's features off disk: %s", cpp_strerror(r).c_str());
     return r;
   }
 

--- a/src/common/Preforker.h
+++ b/src/common/Preforker.h
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include "common/safe_io.h"
+#include "common/errno.h"
 
 /**
  * pre-fork fork/daemonize helper class
@@ -68,7 +69,7 @@ public:
       ::close(2);
       r = 0;
     } else if (err) {
-      cerr << "[" << getpid() << "]: " << cpp_strerror(-err) << std::endl;
+      cerr << "[" << getpid() << "]: " << cpp_strerror(err) << std::endl;
     } else {
       // wait for child to exit
       waitpid(childpid, NULL, 0);

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -25,6 +25,7 @@
 #include "include/stringify.h"
 #include "msg/msg_types.h"
 #include "osd/osd_types.h"
+#include "common/errno.h"
 
 #include "include/assert.h"
 
@@ -439,7 +440,7 @@ int md_config_t::parse_argv(std::vector<const char*>& args)
 	  show_config_value_arg << "': option not found" << std::endl;
       else
 	std::cerr << "failed to get config option '" <<
-	  show_config_value_arg << "': " << strerror(-r) << std::endl;
+	  show_config_value_arg << "': " << cpp_strerror(r) << std::endl;
       _exit(1);
     }
     string s = buf;

--- a/src/common/errno.cc
+++ b/src/common/errno.cc
@@ -1,8 +1,28 @@
+/*
+ * This must be first to ensure we get the non-Gnu version of strerror_r.
+ *
+ * There are two versions of strerror_r: POSIX and Gnu.  The difference
+ * is that the Gnu version returns the string for convenience and the 
+ * POSIX version returns success or failure (one wonders what the failure
+ * could possibly be, but there you go, it's POSIX).
+ *
+ * You might think we could just go ahead and use either version and
+ * just get the result out of buf.  However, you'd be wrong, because the
+ * Gnu version may or may not fill buf; it may just return a pointer to
+ * a static string inside libc.  Which it does.
+ *
+ * So we really want the POSIX version for portability.
+ */
+#undef _GNU_SOURCE
+
 #include "common/errno.h"
 
 #include <sstream>
 #include <string>
+#include <iostream>
+
 #include <string.h>
+#include <stdio.h>
 
 std::string cpp_strerror(int err)
 {
@@ -11,7 +31,9 @@ std::string cpp_strerror(int err)
   if (err < 0)
     err = -err;
   std::ostringstream oss;
-  oss << "(" << err << ") " << strerror_r(err, buf, sizeof(buf));
+  buf[0] = '\0';
+  ::strerror_r(err, buf, sizeof(buf));
+  oss << "(" << err << ") " << buf;
 
   return oss.str();
 }

--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -14,6 +14,7 @@
 #include <cctype>
 
 #include <typeinfo>
+#include "common/errno.h"
 
 // -------------
 
@@ -563,7 +564,7 @@ int CrushCompiler::parse_bucket(iter_t const& i)
     if (r == -EEXIST)
       err << "Duplicate bucket id " << id << std::endl;
     else
-      err << "add_bucket failed " << strerror(-r) << std::endl;
+      err << "add_bucket failed " << cpp_strerror(r) << std::endl;
     return r;
   }
   r = crush.set_item_name(id, name.c_str());

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1,6 +1,7 @@
 
 #include "common/debug.h"
 #include "common/Formatter.h"
+#include "common/errno.h"
 
 #include "CrushWrapper.h"
 
@@ -453,8 +454,7 @@ int CrushWrapper::insert_item(CephContext *cct, int item, float weight, string n
       int empty = 0, newid;
       int r = add_bucket(0, CRUSH_BUCKET_STRAW, CRUSH_HASH_DEFAULT, p->first, 1, &cur, &empty, &newid);
       if (r < 0) {
-        char buf[128]; 
-        ldout(cct, 1) << "add_bucket failure error: " << strerror_r(-r, buf, sizeof(buf)) << dendl;
+        ldout(cct, 1) << "add_bucket failure error: " << cpp_strerror(r) << dendl;
         return r;
       }
       set_item_name(newid, q->second);

--- a/src/erasure-code/ErasureCodePlugin.cc
+++ b/src/erasure-code/ErasureCodePlugin.cc
@@ -18,6 +18,7 @@
 #include <dlfcn.h>
 
 #include "ErasureCodePlugin.h"
+#include "common/errno.h"
 
 #define PLUGIN_PREFIX "libec_"
 #define PLUGIN_SUFFIX ".so"
@@ -107,7 +108,7 @@ int ErasureCodePluginRegistry::load(const std::string &plugin_name,
     int r = erasure_code_init(name.c_str());
     if (r != 0) {
       ss << "erasure_code_init(" << plugin_name
-	 << "): " << strerror(-r);
+	 << "): " << cpp_strerror(r);
       dlclose(library);
       return r;
     }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -53,6 +53,7 @@
 #include "events/ECommitted.h"
 
 #include "include/filepath.h"
+#include "common/errno.h"
 #include "common/Timer.h"
 #include "common/perf_counters.h"
 #include "include/compat.h"
@@ -857,9 +858,8 @@ void Server::early_reply(MDRequestRef& mdr, CInode *tracei, CDentry *tracedn)
   // that have projected linkages from getting new replica.
   mds->locker->set_xlocks_done(mdr.get(), mdr->client_request->get_op() == CEPH_MDS_OP_RENAME);
 
-  char buf[80];
   dout(10) << "early_reply " << reply->get_result() 
-	   << " (" << strerror_r(-reply->get_result(), buf, sizeof(buf))
+	   << " (" << cpp_strerror(reply->get_result())
 	   << ") " << *req << dendl;
 
   if (tracei || tracedn) {
@@ -894,9 +894,8 @@ void Server::reply_request(MDRequestRef& mdr, MClientReply *reply, CInode *trace
   assert(mdr.get());
   MClientRequest *req = mdr->client_request;
   
-  char buf[80];
   dout(10) << "reply_request " << reply->get_result() 
-	   << " (" << strerror_r(-reply->get_result(), buf, sizeof(buf))
+	   << " (" << cpp_strerror(reply->get_result())
 	   << ") " << *req << dendl;
 
   // note successful request in session map?

--- a/src/messages/MAuthReply.h
+++ b/src/messages/MAuthReply.h
@@ -16,6 +16,7 @@
 #define CEPH_MAUTHREPLY_H
 
 #include "msg/Message.h"
+#include "common/errno.h"
 
 struct MAuthReply : public Message {
   __u32 protocol;
@@ -38,8 +39,7 @@ private:
 public:
   const char *get_type_name() const { return "auth_reply"; }
   void print(ostream& o) const {
-    char buf[80];
-    o << "auth_reply(proto " << protocol << " " << result << " " << strerror_r(-result, buf, sizeof(buf));
+    o << "auth_reply(proto " << protocol << " " << result << " " << cpp_strerror(result);
     if (result_msg.length())
       o << ": " << result_msg;
     o << ")";

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -21,6 +21,7 @@
 
 #include "msg/Message.h"
 #include "include/ceph_features.h"
+#include "common/errno.h"
 
 #include <vector>
 using namespace std;
@@ -229,8 +230,7 @@ public:
     o << "client_reply(???:" << get_tid();
     o << " = " << get_result();
     if (get_result() <= 0) {
-      char buf[80];
-      o << " " << strerror_r(-get_result(), buf, sizeof(buf));
+      o << " " << cpp_strerror(get_result());
     }
     if (head.op & CEPH_MDS_OP_WRITE) {
       if (head.safe)

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -20,6 +20,7 @@
 
 #include "MOSDOp.h"
 #include "os/ObjectStore.h"
+#include "common/errno.h"
 
 /*
  * OSD op reply
@@ -262,8 +263,7 @@ public:
       out << " ack";
     out << " = " << get_result();
     if (get_result() < 0) {
-      char buf[80];
-      out << " (" << strerror_r(-get_result(), buf, sizeof(buf)) << ")";
+      out << " (" << cpp_strerror(get_result()) << ")";
     }
     if (is_redirect_reply()) {
       out << " redirect: { " << redirect << " }";

--- a/src/mon/ConfigKeyService.cc
+++ b/src/mon/ConfigKeyService.cc
@@ -23,6 +23,7 @@
 
 #include "common/config.h"
 #include "common/cmdparse.h"
+#include "common/errno.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix

--- a/src/mon/DataHealthService.cc
+++ b/src/mon/DataHealthService.cc
@@ -38,6 +38,7 @@
 #include "include/Context.h"
 #include "include/assert.h"
 #include "common/Formatter.h"
+#include "common/errno.h"
 
 #include "mon/Monitor.h"
 #include "mon/QuorumService.h"

--- a/src/mon/MonitorStore.cc
+++ b/src/mon/MonitorStore.cc
@@ -246,7 +246,7 @@ bool MonitorStore::exists_bl_ss(const char *a, const char *b)
   struct stat st;
   int r = ::stat(fn, &st);
   //char buf[80];
-  //dout(15) << "exists_bl stat " << fn << " r=" << r << " errno " << errno << " " << strerror_r(errno, buf, sizeof(buf)) << dendl;
+  //dout(15) << "exists_bl stat " << fn << " r=" << r << " " << cpp_strerror(errno) << dendl;
   if (r) {
     assert (errno == ENOENT);
   }
@@ -282,11 +282,10 @@ int MonitorStore::get_bl_ss(bufferlist& bl, const char *a, const char *b)
   
   int fd = ::open(fn, O_RDONLY);
   if (fd < 0) {
-    char buf[80];
     if (b) {
-      dout(15) << "get_bl " << a << "/" << b << " " << strerror_r(errno, buf, sizeof(buf)) << dendl;
+      dout(15) << "get_bl " << a << "/" << b << " " << cpp_strerror(errno) << dendl;
     } else {
-      dout(15) << "get_bl " << a << " " << strerror_r(errno, buf, sizeof(buf)) << dendl;
+      dout(15) << "get_bl " << a << " " << cpp_strerror(errno) << dendl;
     }
     return -errno;
   }
@@ -304,10 +303,8 @@ int MonitorStore::get_bl_ss(bufferlist& bl, const char *a, const char *b)
   while (off < len) {
     dout(20) << "reading at off " << off << " of " << len << dendl;
     int r = ::read(fd, bp.c_str()+off, len-off);
-    if (r < 0) {
-      char buf[80];
-      dout(0) << "errno on read " << strerror_r(errno, buf, sizeof(buf)) << dendl;
-    }
+    if (r < 0)
+      dout(0) << "errno on read " << cpp_strerror(errno) << dendl;
     assert(r>0);
     off += r;
   }

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -21,6 +21,7 @@
 
 #include "common/Timer.h"
 #include "common/ceph_argparse.h"
+#include "common/errno.h"
 #include "mon/MDSMonitor.h"
 #include "mon/OSDMonitor.h"
 #include "mon/PGMonitor.h"

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3614,8 +3614,7 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
 				       CRUSH_HASH_DEFAULT, type, 0, NULL,
 				       NULL, &bucketno);
     if (err < 0) {
-      char buf[128];
-      ss << "add_bucket error: '" << strerror_r(-err, buf, sizeof(buf)) << "'";
+      ss << "add_bucket error: '" << cpp_strerror(err) << "'";
       goto reply;
     }
     err = newcrush.set_item_name(bucketno, name);

--- a/src/msg/Accepter.cc
+++ b/src/msg/Accepter.cc
@@ -58,9 +58,8 @@ int Accepter::bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports)
   /* socket creation */
   listen_sd = ::socket(family, SOCK_STREAM, 0);
   if (listen_sd < 0) {
-    char buf[80];
     lderr(msgr->cct) << "accepter.bind unable to create socket: "
-		     << strerror_r(errno, buf, sizeof(buf)) << dendl;
+		     << cpp_strerror(errno) << dendl;
     return -errno;
   }
 
@@ -84,9 +83,8 @@ int Accepter::bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports)
 
     rc = ::bind(listen_sd, (struct sockaddr *) &listen_addr.ss_addr(), listen_addr.addr_size());
     if (rc < 0) {
-      char buf[80];
       lderr(msgr->cct) << "accepter.bind unable to bind to " << listen_addr.ss_addr()
-		       << ": " << strerror_r(errno, buf, sizeof(buf)) << dendl;
+		       << ": " << cpp_strerror(errno) << dendl;
       return -errno;
     }
   } else {
@@ -100,11 +98,10 @@ int Accepter::bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports)
 	break;
     }
     if (rc < 0) {
-      char buf[80];
       lderr(msgr->cct) << "accepter.bind unable to bind to " << listen_addr.ss_addr()
 		       << " on any port in range " << msgr->cct->_conf->ms_bind_port_min
 		       << "-" << msgr->cct->_conf->ms_bind_port_max
-		       << ": " << strerror_r(errno, buf, sizeof(buf))
+		       << ": " << cpp_strerror(errno)
 		       << dendl;
       return -errno;
     }
@@ -191,8 +188,6 @@ void *Accepter::entry()
   
   int errors = 0;
 
-  char buf[80];
-
   struct pollfd pfd;
   pfd.fd = listen_sd;
   pfd.events = POLLIN | POLLERR | POLLNVAL | POLLHUP;
@@ -220,7 +215,7 @@ void *Accepter::entry()
       msgr->add_accept_pipe(sd);
     } else {
       ldout(msgr->cct,0) << "accepter no incoming connection?  sd = " << sd
-	      << " errno " << errno << " " << strerror_r(errno, buf, sizeof(buf)) << dendl;
+	      << " errno " << errno << " " << cpp_strerror(errno) << dendl;
       if (++errors > 4)
 	break;
     }

--- a/src/os/JournalingObjectStore.cc
+++ b/src/os/JournalingObjectStore.cc
@@ -2,6 +2,7 @@
 
 #include "JournalingObjectStore.h"
 
+#include "common/errno.h"
 #include "common/debug.h"
 
 #define dout_subsys ceph_subsys_journal
@@ -47,9 +48,8 @@ int JournalingObjectStore::journal_replay(uint64_t fs_op_seq)
 
   int err = journal->open(op_seq);
   if (err < 0) {
-    char buf[80];
     dout(3) << "journal_replay open failed with " 
-	    << strerror_r(-err, buf, sizeof(buf)) << dendl;
+	    << cpp_strerror(err) << dendl;
     delete journal;
     journal = 0;
     return err;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -45,6 +45,7 @@
 #include "common/config.h"
 #include "common/perf_counters.h"
 #include "include/str_list.h"
+#include "common/errno.h"
 
 
 #define dout_subsys ceph_subsys_objecter
@@ -249,7 +250,7 @@ void Objecter::init_unlocked()
 					   "show in-progress osd requests");
   if (ret < 0) {
     lderr(cct) << "error registering admin socket command: "
-	       << cpp_strerror(-ret) << dendl;
+	       << cpp_strerror(ret) << dendl;
   }
 }
 

--- a/src/test/cli/monmaptool/print-nonexistent.t
+++ b/src/test/cli/monmaptool/print-nonexistent.t
@@ -1,4 +1,4 @@
   $ monmaptool --print nonexistent
   monmaptool: monmap file nonexistent
-  monmaptool: couldn't open nonexistent: No such file or directory
+  monmaptool: couldn't open nonexistent: (2) No such file or directory
   [255]

--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -34,6 +34,7 @@
 #include "mon/Paxos.h"
 #include "common/Formatter.h"
 #include "include/stringify.h"
+#include "common/errno.h"
 
 namespace po = boost::program_options;
 using namespace std;

--- a/src/tools/ceph_osdomap_tool.cc
+++ b/src/tools/ceph_osdomap_tool.cc
@@ -32,6 +32,7 @@
 #include "os/LevelDBStore.h"
 #include "mon/MonitorDBStore.h"
 #include "os/DBObjectMap.h"
+#include "common/errno.h"
 
 namespace po = boost::program_options;
 using namespace std;

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -586,7 +586,7 @@ int main(int argc, const char **argv)
 	int id;
 	int r = crush_add_bucket(crush.crush, 0, b, &id);
 	if (r < 0) {
-	  dout(2) << "Couldn't add bucket: " << strerror(-r) << dendl;
+	  dout(2) << "Couldn't add bucket: " << cpp_strerror(r) << dendl;
 	}
 
 	char format[20];
@@ -722,8 +722,7 @@ int main(int argc, const char **argv)
       crush.encode(bl);
       int r = bl.write_file(outfn.c_str());
       if (r < 0) {
-	char buf[80];
-	cerr << me << ": error writing '" << outfn << "': " << strerror_r(-r, buf, sizeof(buf)) << std::endl;
+	cerr << me << ": error writing '" << outfn << "': " << cpp_strerror(r) << std::endl;
 	exit(1);
       }
       if (verbose)

--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -23,6 +23,7 @@ using namespace std;
 
 #include "common/config.h"
 #include "common/ceph_argparse.h"
+#include "common/errno.h"
 #include "global/global_init.h"
 #include "mon/MonMap.h"
 #include "include/str_list.h"
@@ -115,9 +116,8 @@ int main(int argc, const char **argv)
     }
   }
 
-  char buf[80];
   if (!create && r < 0) {
-    cerr << me << ": couldn't open " << fn << ": " << strerror_r(-r, buf, sizeof(buf)) << std::endl;
+    cerr << me << ": couldn't open " << fn << ": " << cpp_strerror(r) << std::endl;
     return -1;
   }    
   else if (create && !clobber && r == 0) {
@@ -198,7 +198,7 @@ int main(int argc, const char **argv)
 	 << std::endl;
     int r = monmap.write(fn.c_str());
     if (r < 0) {
-      cerr << "monmaptool: error writing to '" << fn << "': " << strerror_r(-r, buf, sizeof(buf)) << std::endl;
+      cerr << "monmaptool: error writing to '" << fn << "': " << cpp_strerror(r) << std::endl;
       return 1;
     }
   }

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -391,8 +391,7 @@ static int do_copy_pool(Rados& rados, const char *src_pool, const char *target_p
     target_ctx.locator_set_key(locator);
     ret = do_copy(src_ctx, oid.c_str(), target_ctx, oid.c_str());
     if (ret < 0) {
-      char buf[64];
-      cerr << "error copying object: " << strerror_r(errno, buf, sizeof(buf)) << std::endl;
+      cerr << "error copying object: " << cpp_strerror(errno) << std::endl;
       return ret;
     }
   }
@@ -413,8 +412,7 @@ static int do_put(IoCtx& io_ctx, const char *objname, const char *infile, int op
   if (!stdio)
     fd = open(infile, O_RDONLY);
   if (fd < 0) {
-    char buf[80];
-    cerr << "error reading input file " << infile << ": " << strerror_r(errno, buf, sizeof(buf)) << std::endl;
+    cerr << "error reading input file " << infile << ": " << cpp_strerror(errno) << std::endl;
     return 1;
   }
   char *buf = new char[op_size];
@@ -479,7 +477,7 @@ int gen_rand_alphanumeric(char *dest, int size) /* size should be the required s
 {
   int ret = get_random_bytes(dest, size);
   if (ret < 0) {
-    cerr << "cannot get random bytes: " << cpp_strerror(-ret) << std::endl;
+    cerr << "cannot get random bytes: " << cpp_strerror(ret) << std::endl;
     return -1;
   }
 
@@ -633,7 +631,7 @@ int LoadGen::bootstrap(const char *pool)
 
   int ret = rados->ioctx_create(pool, io_ctx);
   if (ret < 0) {
-    cerr << "error opening pool " << pool << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+    cerr << "error opening pool " << pool << ": " << cpp_strerror(ret) << std::endl;
     return ret;
   }
 
@@ -923,8 +921,6 @@ static int do_lock_cmd(std::vector<const char*> &nargs,
                        IoCtx *ioctx,
 		       Formatter *formatter)
 {
-  char buf[128];
-
   if (nargs.size() < 3)
     usage_exit();
 
@@ -971,7 +967,7 @@ static int do_lock_cmd(std::vector<const char*> &nargs,
     list<string> locks;
     int ret = rados::cls::lock::list_locks(ioctx, oid, &locks);
     if (ret < 0) {
-      cerr << "ERROR: rados_list_locks(): " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "ERROR: rados_list_locks(): " << cpp_strerror(ret) << std::endl;
       return ret;
     }
 
@@ -1001,7 +997,7 @@ static int do_lock_cmd(std::vector<const char*> &nargs,
     string tag;
     int ret = rados::cls::lock::get_lock_info(ioctx, oid, lock_name, &lockers, &type, &tag);
     if (ret < 0) {
-      cerr << "ERROR: rados_lock_get_lock_info(): " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "ERROR: rados_lock_get_lock_info(): " << cpp_strerror(ret) << std::endl;
       return ret;
     }
 
@@ -1042,7 +1038,7 @@ static int do_lock_cmd(std::vector<const char*> &nargs,
       ret = l.lock_exclusive(ioctx, oid);
     }
     if (ret < 0) {
-      cerr << "ERROR: failed locking: " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "ERROR: failed locking: " << cpp_strerror(ret) << std::endl;
       return ret;
     }
 
@@ -1064,7 +1060,7 @@ static int do_lock_cmd(std::vector<const char*> &nargs,
     }
     int ret = l.break_lock(ioctx, oid, name);
     if (ret < 0) {
-      cerr << "ERROR: failed breaking lock: " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "ERROR: failed breaking lock: " << cpp_strerror(ret) << std::endl;
       return ret;
     }
   } else {
@@ -1326,7 +1322,6 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
      ret = -1;
      goto out;
   }
-  char buf[80];
 
   if (create_pool && !pool_name) {
     cerr << "--create-pool requested but pool_name was not specified!" << std::endl;
@@ -1337,7 +1332,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = rados.pool_create(pool_name, 0, 0);
     if (ret < 0) {
       cerr << "error creating pool " << pool_name << ": "
-	   << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+	   << cpp_strerror(ret) << std::endl;
       goto out;
     }
   }
@@ -1347,7 +1342,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = rados.ioctx_create(pool_name, io_ctx);
     if (ret < 0) {
       cerr << "error opening pool " << pool_name << ": "
-	   << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+	   << cpp_strerror(ret) << std::endl;
       goto out;
     }
   }
@@ -1356,7 +1351,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   if (snapname) {
     ret = io_ctx.snap_lookup(snapname, &snapid);
     if (ret < 0) {
-      cerr << "error looking up snap '" << snapname << "': " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error looking up snap '" << snapname << "': " << cpp_strerror(ret) << std::endl;
       goto out;
     }
   }
@@ -1550,7 +1545,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = io_ctx.set_auid(new_auid);
     if (ret < 0) {
       cerr << "error changing auid on pool " << io_ctx.get_pool_name() << ':'
-	   << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+	   << cpp_strerror(ret) << std::endl;
     } else cerr << "changed auid on pool " << io_ctx.get_pool_name()
 		<< " to " << new_auid << std::endl;
   }
@@ -1578,7 +1573,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = io_ctx.stat(oid, &size, &mtime);
     if (ret < 0) {
       cerr << " error stat-ing " << pool_name << "/" << oid << ": "
-           << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+           << cpp_strerror(ret) << std::endl;
       goto out;
     } else {
       cout << pool_name << "/" << oid
@@ -1590,7 +1585,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       usage_exit();
     ret = do_get(io_ctx, nargs[1], nargs[2], op_size);
     if (ret < 0) {
-      cerr << "error getting " << pool_name << "/" << nargs[1] << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error getting " << pool_name << "/" << nargs[1] << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
   }
@@ -1599,7 +1594,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       usage_exit();
     ret = do_put(io_ctx, nargs[1], nargs[2], op_size);
     if (ret < 0) {
-      cerr << "error putting " << pool_name << "/" << nargs[1] << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error putting " << pool_name << "/" << nargs[1] << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
   }
@@ -1617,7 +1612,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     if (ret < 0) {
       cerr << "error truncating oid "
 	   << oid << " to " << size << ": "
-	   << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+	   << cpp_strerror(ret) << std::endl;
     } else {
       ret = 0;
     }
@@ -1635,7 +1630,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
     ret = io_ctx.setxattr(oid, attr_name.c_str(), bl);
     if (ret < 0) {
-      cerr << "error setting xattr " << pool_name << "/" << oid << "/" << attr_name << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error setting xattr " << pool_name << "/" << oid << "/" << attr_name << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
     else
@@ -1651,7 +1646,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     bufferlist bl;
     ret = io_ctx.getxattr(oid, attr_name.c_str(), bl);
     if (ret < 0) {
-      cerr << "error getting xattr " << pool_name << "/" << oid << "/" << attr_name << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error getting xattr " << pool_name << "/" << oid << "/" << attr_name << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
     else
@@ -1667,7 +1662,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
     ret = io_ctx.rmxattr(oid, attr_name.c_str());
     if (ret < 0) {
-      cerr << "error removing xattr " << pool_name << "/" << oid << "/" << attr_name << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error removing xattr " << pool_name << "/" << oid << "/" << attr_name << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
   } else if (strcmp(nargs[0], "listxattr") == 0) {
@@ -1679,7 +1674,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     bufferlist bl;
     ret = io_ctx.getxattrs(oid, attrset);
     if (ret < 0) {
-      cerr << "error getting xattr set " << pool_name << "/" << oid << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error getting xattr set " << pool_name << "/" << oid << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
 
@@ -1875,7 +1870,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = rados.ioctx_create(target, target_ctx);
     if (ret < 0) {
       cerr << "error opening target pool " << target << ": "
-           << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+           << cpp_strerror(ret) << std::endl;
       goto out;
     }
     if (target_oloc.size()) {
@@ -1884,7 +1879,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
     ret = do_copy(io_ctx, nargs[1], target_ctx, target_obj);
     if (ret < 0) {
-      cerr << "error copying " << pool_name << "/" << nargs[1] << " => " << target << "/" << target_obj << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error copying " << pool_name << "/" << nargs[1] << " => " << target << "/" << target_obj << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
   }
@@ -1916,7 +1911,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = rados.ioctx_create(target, target_ctx);
     if (ret < 0) {
       cerr << "error opening target pool " << target << ": "
-           << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+           << cpp_strerror(ret) << std::endl;
       goto out;
     }
     if (oloc.size()) {
@@ -1929,7 +1924,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
     ret = do_clone_data(io_ctx, nargs[1], target_ctx, target_obj);
     if (ret < 0) {
-      cerr << "error cloning " << pool_name << "/" << nargs[1] << " => " << target << "/" << target_obj << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error cloning " << pool_name << "/" << nargs[1] << " => " << target << "/" << target_obj << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
   } else if (strcmp(nargs[0], "rm") == 0) {
@@ -1941,7 +1936,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       const string & oid = *iter;
       ret = io_ctx.remove(oid);
       if (ret < 0) {
-        cerr << "error removing " << pool_name << "/" << oid << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+        cerr << "error removing " << pool_name << "/" << oid << ": " << cpp_strerror(ret) << std::endl;
         goto out;
       }
     }
@@ -1957,7 +1952,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       ret = io_ctx.create(oid, true);
     }
     if (ret < 0) {
-      cerr << "error creating " << pool_name << "/" << oid << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error creating " << pool_name << "/" << oid << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
   }
@@ -1970,7 +1965,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       string oid(nargs[2]);
       ret = io_ctx.read(oid, outdata, 0, 0);
       if (ret < 0) {
-	cerr << "error reading " << pool_name << "/" << oid << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+	cerr << "error reading " << pool_name << "/" << oid << ": " << cpp_strerror(ret) << std::endl;
 	goto out;
       }
       bufferlist::iterator p = outdata.begin();
@@ -2071,7 +2066,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = rados.pool_create(nargs[1], auid, crush_rule);
     if (ret < 0) {
       cerr << "error creating pool " << nargs[1] << ": "
-	   << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+	   << cpp_strerror(ret) << std::endl;
       goto out;
     }
     cout << "successfully created pool " << nargs[1] << std::endl;
@@ -2091,7 +2086,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = do_copy_pool(rados, src_pool, target_pool);
     if (ret < 0) {
       cerr << "error copying pool " << src_pool << " => " << target_pool << ": "
-	   << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+	   << cpp_strerror(ret) << std::endl;
       goto out;
     }
     cout << "successfully copied pool " << nargs[1] << std::endl;
@@ -2157,7 +2152,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = io_ctx.snap_create(nargs[1]);
     if (ret < 0) {
       cerr << "error creating pool " << pool_name << " snapshot " << nargs[1]
-	   << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+	   << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
     cout << "created pool " << pool_name << " snap " << nargs[1] << std::endl;
@@ -2170,7 +2165,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = io_ctx.snap_remove(nargs[1]);
     if (ret < 0) {
       cerr << "error removing pool " << pool_name << " snapshot " << nargs[1]
-	   << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+	   << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
     cout << "removed pool " << pool_name << " snap " << nargs[1] << std::endl;
@@ -2183,7 +2178,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = io_ctx.rollback(nargs[1], nargs[2]);
     if (ret < 0) {
       cerr << "error rolling back pool " << pool_name << " to snapshot " << nargs[1]
-	   << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+	   << cpp_strerror(ret) << std::endl;
       goto out;
     }
     cout << "rolled back pool " << pool_name
@@ -2260,7 +2255,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = io_ctx.set_alloc_hint(oid, expected_object_size, expected_write_size);
     if (ret < 0) {
       cerr << "error setting alloc-hint " << pool_name << "/" << oid << ": "
-           << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+           << cpp_strerror(ret) << std::endl;
       goto out;
     }
   } else if (strcmp(nargs[0], "load-gen") == 0) {
@@ -2335,7 +2330,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
     ret = io_ctx.list_watchers(oid, &lw);
     if (ret < 0) {
-      cerr << "error listing watchers " << pool_name << "/" << oid << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error listing watchers " << pool_name << "/" << oid << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
     else
@@ -2354,7 +2349,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     io_ctx.snap_set_read(LIBRADOS_SNAP_DIR);
     ret = io_ctx.list_snaps(oid, &ls);
     if (ret < 0) {
-      cerr << "error listing snap shots " << pool_name << "/" << oid << ": " << strerror_r(-ret, buf, sizeof(buf)) << std::endl;
+      cerr << "error listing snap shots " << pool_name << "/" << oid << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
     else


### PR DESCRIPTION
Portability is enhanced by not relying on the Gnu behavior of strerror_r()
(namely, that it returns char \* rather than int), so select it with
an #undef; further, clean up the random calls to strerror and strerror_r
(along with all their private little one-use buffers) and regularize
the code to use cpp_strerror almost everywhere.  Where changed,
any negation of the error code is also removed, since cpp_strerror()
will do that.

Note: some tools were using their own calls to strerror/strerror_r, so
will now get a (%d) in their output that wasn't there before; hence
the change to test/cli/monmaptool/print-nonexistent.t

Fixes: #8041
Signed-off-by: Dan Mick dan.mick@inktank.com
