### PR TITLE
mon/OSDMonitor: ignore boot message from before last up_from

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1207,6 +1207,12 @@ bool OSDMonitor::preprocess_boot(MOSDBoot *m)
     goto ignore;
   }
 
+  if (osdmap.exists(from) &&
+      osdmap.get_info(from).up_from > m->boot_epoch) {
+    dout(7) << "prepare_boot msg from before last up_from, ignoring" << dendl;
+    goto ignore;
+  }
+
   // noup?
   if (!can_mark_up(from)) {
     dout(7) << "preprocess_boot ignoring boot from " << m->get_orig_source_inst() << dendl;


### PR DESCRIPTION
It is possible we will have a dup OSDBoot message queued up in the mon and
will process it again after that osd was marked up and then down.  If that
happens, we should ignore this message, not mark the osd back in with the
same address.

Fixes: #8062 Signed-off-by: Sage Weil sage@inktank.com
