### PR TITLE
rgw, radosgw-admin: bucket link uses bucket instance id now

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1525,9 +1525,11 @@ int main(int argc, char **argv)
   }
 
   if (opt_cmd == OPT_BUCKET_LINK) {
-    int r = RGWBucketAdminOp::link(store, bucket_op);
+    bucket_op.set_bucket_id(bucket_id);
+    string err;
+    int r = RGWBucketAdminOp::link(store, bucket_op, &err);
     if (r < 0) {
-      cerr << "failure: " << cpp_strerror(-r) << std::endl;
+      cerr << "failure: " << cpp_strerror(-r) << ": " << err << std::endl;
       return -r;
     }
   }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -461,6 +461,12 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
     return -EINVAL;
   }
 
+  string bucket_id = op_state.get_bucket_id();
+  if (bucket_id.empty()) {
+    set_err_msg(err_msg, "empty bucket instance id");
+    return -EINVAL;
+  }
+
   std::string no_oid;
 
   std::string display_name = op_state.get_user_display_name();
@@ -472,7 +478,8 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
   map<string, bufferlist> attrs;
   RGWBucketInfo bucket_info;
 
-  int r = store->get_bucket_info(NULL, bucket.name, bucket_info, NULL, &attrs);
+  string key = bucket.name + ":" + bucket_id;
+  int r = store->get_bucket_instance_info(NULL, key, bucket_info, NULL, &attrs);
   if (r < 0) {
     return r;
   }
@@ -857,7 +864,7 @@ int RGWBucketAdminOp::unlink(RGWRados *store, RGWBucketAdminOpState& op_state)
   return bucket.unlink(op_state);
 }
 
-int RGWBucketAdminOp::link(RGWRados *store, RGWBucketAdminOpState& op_state)
+int RGWBucketAdminOp::link(RGWRados *store, RGWBucketAdminOpState& op_state, string *err)
 {
   RGWBucket bucket;
 
@@ -865,7 +872,7 @@ int RGWBucketAdminOp::link(RGWRados *store, RGWBucketAdminOpState& op_state)
   if (ret < 0)
     return ret;
 
-  return bucket.link(op_state);
+  return bucket.link(op_state, err);
 
 }
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -158,6 +158,11 @@ struct RGWBucketAdminOpState {
     bucket_stored = true;
   }
 
+  void set_bucket_id(const string& bi) {
+    bucket_id = bi;
+  }
+  const string& get_bucket_id() { return bucket_id; };
+
   bool will_fetch_stats() { return stat_buckets; };
   bool will_fix_index() { return fix_index; };
   bool will_delete_children() { return delete_child_objects; };
@@ -226,7 +231,7 @@ public:
 
 
   static int unlink(RGWRados *store, RGWBucketAdminOpState& op_state);
-  static int link(RGWRados *store, RGWBucketAdminOpState& op_state);
+  static int link(RGWRados *store, RGWBucketAdminOpState& op_state, string *err_msg = NULL);
 
   static int check_index(RGWRados *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher);

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -123,14 +123,17 @@ void RGWOp_Bucket_Link::execute()
 {
   std::string uid;
   std::string bucket;
+  std::string bucket_id;
 
   RGWBucketAdminOpState op_state;
 
   RESTArgs::get_string(s, "uid", uid, &uid);
   RESTArgs::get_string(s, "bucket", bucket, &bucket);
+  RESTArgs::get_string(s, "bucket-id", bucket_id, &bucket_id);
 
   op_state.set_user_id(uid);
   op_state.set_bucket_name(bucket);
+  op_state.set_bucket_id(bucket_id);
 
   http_ret = RGWBucketAdminOp::link(store, op_state);
 }


### PR DESCRIPTION
Fixes: 7499
We need to link user to a specific bucket instance. This updates both
the radosgw-admin link command, and the RESTful admin api.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
