### PR TITLE
mon: Don't block on EAGAIN from `osd pool set`

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3346,7 +3346,7 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
 	++i) {
       if (i->m_pool == static_cast<uint64_t>(pool)) {
 	ss << "currently creating pgs, wait";
-	return -EAGAIN;
+	return -EBUSY;
       }
     }
     p.set_pg_num(n);
@@ -3368,7 +3368,7 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
 	++i) {
       if (i->m_pool == static_cast<uint64_t>(pool)) {
 	ss << "currently creating pgs, wait";
-	return -EAGAIN;
+	return -EBUSY;
       }
     }
     p.set_pgp_num(n);


### PR DESCRIPTION
This is a bit subjective, but thought it would be clearer to send a PR for discussion than to go straight to the mailing list. 

---

Behavior was changed in 69321bf5 to block instead of returning
when pg_num/pgp_num changes were prevented by PG creates in
progress.  That can be a long block, and there's no feedback
to user about why their command is stuck -- let's handle the
retry in the caller of the command instead.

Signed-off-by: John Spray john.spray@inktank.com
