### PR TITLE
osd: OSDMap: have osdmap json dump print valid boolean instead of string

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,7 @@
 
 v0.80
 -----
+
+* OSDMap's json-formatted dump changed for keys 'full' and 'nearfull'.
+  What was previously being outputted as 'true' or 'false' strings are
+  now being outputted 'true' and 'false' booleans according to json syntax.

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2426,9 +2426,8 @@ void OSDMap::print_summary(Formatter *f, ostream& out) const
     f->dump_int("num_osds", get_num_osds());
     f->dump_int("num_up_osds", get_num_up_osds());
     f->dump_int("num_in_osds", get_num_in_osds());
-    f->dump_string("full", test_flag(CEPH_OSDMAP_FULL) ? "true" : "false");
-    f->dump_string("nearfull", test_flag(CEPH_OSDMAP_NEARFULL) ?
-		   "true" : "false");
+    f->dump_bool("full", test_flag(CEPH_OSDMAP_FULL) ? true : false);
+    f->dump_bool("nearfull", test_flag(CEPH_OSDMAP_NEARFULL) ? true : false);
     f->close_section();
   } else {
     out << "     osdmap e" << get_epoch() << ": "


### PR DESCRIPTION
Fixes: 8108

No tests/workunits check for these flags, so nothing else should need to be adjusted for this format change.
Users relying on this output for their tools should however adjust accordingly.

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
