### PR TITLE
mon/OSDMonitor: require force argument to split a cache pool

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -60,6 +60,8 @@ ceph osd tier add data cache2
 expect_false ceph osd tier add metadata cache
 ceph osd tier cache-mode cache writeback
 ceph osd tier cache-mode cache readonly
+expect_false ceph osd pool set cache pg_num 3
+ceph osd pool set cache pg_num 3 --yes-i-really-mean-it
 ceph osd tier cache-mode cache none
 ceph osd tier set-overlay data cache
 expect_false ceph osd tier set-overlay data cache2

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -557,7 +557,8 @@ COMMAND("osd pool get " \
 COMMAND("osd pool set " \
 	"name=pool,type=CephPoolname " \
 	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset|hashpspool|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp|debug_fake_ec_pool|target_max_bytes|target_max_objects|cache_target_dirty_ratio|cache_target_full_ratio|cache_min_flush_age|cache_min_evict_age " \
-	"name=val,type=CephString", \
+	"name=val,type=CephString " \
+	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"set pool parameter <var> to <val>", "osd", "rw", "cli,rest")
 // 'val' is a CephString because it can include a unit.  Perhaps
 // there should be a Python type for validation/conversion of strings

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3324,6 +3324,13 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
 	return -EEXIST;
       return 0;
     }
+    string force;
+    cmd_getval(g_ceph_context,cmdmap, "force", force);
+    if (p.cache_mode != pg_pool_t::CACHEMODE_NONE &&
+	force != "--yes-i-really-mean-it") {
+      ss << "splits in cache pools must be followed by scrubs and leave sufficient free space to avoid overfilling.  use --yes-i-really-mean-it to force.";
+      return -EPERM;
+    }
     int expected_osds = MIN(p.get_pg_num(), osdmap.get_num_osds());
     int64_t new_pgs = n - p.get_pg_num();
     int64_t pgs_per_osd = new_pgs / expected_osds;


### PR DESCRIPTION
There are several perils when splitting a cache pool:
- split invalidstes pg stats, which disables the agent
  - a scrub must be manually triggered post-split to rebuild stats
  - the pool may fill the OSDs during that period.
  - or, the pool may end up beyond the 'full' mark and once scrub does
    complete and the agent activate we may block IO for a long time while
    we catch up with flush/evict

Make it a bit harder for users to shoot themselves in the foot.

Fixes: #8043 Signed-off-by: Sage Weil sage@inktank.com
