### PR TITLE
mon: set leader commands prior to first election

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -198,6 +198,15 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   assert(r);
 
   exited_quorum = ceph_clock_now(g_ceph_context);
+
+  // assume our commands until we have an election.  this only means
+  // we won't reply with EINVAL before the election; any command that
+  // actually matters will wait until we have quorum etc and then
+  // retry (and revalidate).
+  const MonCommand *cmds;
+  int cmdsize;
+  get_locally_supported_monitor_commands(&cmds, &cmdsize);
+  set_leader_supported_commands(cmds, cmdsize);
 }
 
 PaxosService *Monitor::get_paxos_service_by_name(const string& name)


### PR DESCRIPTION
If we have just started and receive a command, we currently will reply with 
EINVAL because the leader commands are empty.  Note that this race is very 
difficult to reach because the (old) peon needs to forward a command to the
mon while it still thinks it has quorum, and the message needs to get sent
after the leader mon has restarted and reset its connection but before it has
declared a new election.

To fix this, we should assume at startup time that our commands are valid. 
If it is an internal command that does not require quorum, that is fine.  If
it does require quorum, we will retry the command after the election
completes and we will revalidate the command then.

Fixes: #8132 Signed-off-by: Sage Weil sage@inktank.com
