### PR TITLE
Objecter::_op_submit: only replace the tid if it's 0

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1243,9 +1243,11 @@ ceph_tid_t Objecter::op_submit(Op *op)
 
 ceph_tid_t Objecter::_op_submit(Op *op)
 {
-  // pick tid
-  ceph_tid_t mytid = ++last_tid;
-  op->tid = mytid;
+  // pick tid if we haven't got one yet
+  if (op->tid == ceph_tid_t(0)) {
+    ceph_tid_t mytid = ++last_tid;
+    op->tid = mytid;
+  }
   assert(client_inc >= 0);
 
   // pick target


### PR DESCRIPTION
Otherwise, redirected ops will suddenly have a different tid
and will become uncancelable.

Fixes: #7588
Signed-off-by: Samuel Just sam.just@inktank.com
