### PR TITLE
osd_types::object_stat_sum_t: fix add/sub for num_objects_omap

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1439,6 +1439,7 @@ void object_stat_sum_t::add(const object_stat_sum_t& o)
   num_keys_recovered += o.num_keys_recovered;
   num_objects_dirty += o.num_objects_dirty;
   num_whiteouts += o.num_whiteouts;
+  num_objects_omap += o.num_objects_omap;
 }
 
 void object_stat_sum_t::sub(const object_stat_sum_t& o)
@@ -1462,6 +1463,7 @@ void object_stat_sum_t::sub(const object_stat_sum_t& o)
   num_keys_recovered -= o.num_keys_recovered;
   num_objects_dirty -= o.num_objects_dirty;
   num_whiteouts -= o.num_whiteouts;
+  num_objects_omap -= o.num_objects_omap;
 }
 
 


### PR DESCRIPTION
Introduced in a130a4452e4fb159dc62fb417077d98dc9ebd621
Signed-off-by: Samuel Just sam.just@inktank.com
