### PR TITLE
qa/workunits/cephtool/test.sh: make set pg_num test non-racy

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -60,10 +60,15 @@ ceph osd tier add data cache2
 expect_false ceph osd tier add metadata cache
 ceph osd tier cache-mode cache writeback
 ceph osd tier cache-mode cache readonly
-expect_false ceph osd pool set cache pg_num 3
-set +e
-ceph osd pool set cache pg_num 3 --yes-i-really-mean-it 2>$TMPFILE ; check_response 'currently creating pgs' $? 16
-set -e
+TRIES=0
+while ! ceph osd pool set cache pg_num 3 --yes-i-really-mean-it 2>$TMPFILE
+do
+    grep 'currently creating pgs' $TMPFILE
+    TRIES=$(( $TRIES + 1 ))
+    test $TRIES -ne 60
+    sleep 3
+done
+expect_false ceph osd pool set cache pg_num 4
 ceph osd tier cache-mode cache none
 ceph osd tier set-overlay data cache
 expect_false ceph osd tier set-overlay data cache2


### PR DESCRIPTION
Loop while the pool is creating.

Signed-off-by: Sage Weil sage@inktank.com
