### PR TITLE
mds: make strncpy in ::respawn safer

### DIFF
--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -1711,7 +1711,7 @@ void MDS::respawn()
     dout(1) << " cwd " << cwd << dendl;
 
     /* Fall back to a best-effort: just running in our CWD */
-    strncpy(exe_path, orig_argv[0], sizeof(exe_path));
+    strncpy(exe_path, orig_argv[0], sizeof(exe_path) - 1);
   }
 
   dout(1) << " exe_path " << exe_path << dendl;


### PR DESCRIPTION
Previous code assumed null terminated argv[0]
was not longer than PATH_MAX and the resulting
strncpy was not strictly safe.

Modify the bounds to ensure that copy will not
result in an unterminated string if argv[0]
is oversized.

Signed-off-by: John Spray john.spray@inktank.com
