### PR TITLE
Support latest qemu iotest code

### DIFF
--- a/qa/workunits/rbd/qemu-iotests.sh
+++ b/qa/workunits/rbd/qemu-iotests.sh
@@ -6,17 +6,46 @@
 # to qemu-iotests currently.
 
 # This will only work with particular qemu versions, like 1.0. Later
-# versions of qemu includ qemu-iotests directly in the qemu
+# versions of qemu include qemu-iotests directly in the qemu
 # repository.
-git clone git://ceph.com/git/qemu-iotests.git
+codevers=`lsb_release -sc`
+iotests=qemu-iotests
+testlist='001 002 003 004 005 008 009 010 011 021 025'
 
-cd qemu-iotests
+# See if we need to use the iotests suites in qemu (newer version).
+# Right now, trusty is the only version that uses this.
+for chkcode in "trusty"
+do
+    if [ "$chkcode" = "$codevers" ]
+    then
+        iotests=qemu/tests/qemu-iotests
+    fi
+done
+
+if [ "$iotests" = "qemu/tests/qemu-iotests" ]
+then
+    git clone git://repo.or.cz/qemu.git
+    testlist=$testlist' 032 033 055 077'
+else
+    git clone git://ceph.com/git/qemu-iotests.git
+fi
+
+cd "$iotests"
+
 mkdir bin
 # qemu-iotests expects a binary called just 'qemu' to be available
 ln -s `which qemu-system-x86_64` bin/qemu
 
 # TEST_DIR is the pool for rbd
-TEST_DIR=rbd PATH="$PATH:$PWD/bin" ./check -rbd
+TEST_DIR=rbd PATH="$PATH:$PWD/bin" ./check -rbd $testlist
 
-cd ..
-rm -rf qemu-iotests
+if [ "$iotests" = "qemu/tests/qemu-iotests" ]
+then
+    cd ../../..
+else
+    cd ..
+fi
+
+dname=`echo $iotests | cut -d "/" -f1`
+rm -rf $dname
+


### PR DESCRIPTION
Modified qemu-iotests workunit script to check for versions
that use the latest qemu (currently only Trusty).  Limit the
tests to those that are applicable to rbd.

Fixes: 7882
Signed-off-by: Warren Usui warren.usui@inktank.com
