### PR TITLE
test_rbd.py: ignore children in cache pools

### DIFF
--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -699,11 +699,18 @@ class TestClone(object):
         parent_data = self.image.read(IMG_SIZE / 2 + 256, 256)
         eq(parent_data, '\0' * 256)
 
+    def check_children(self, expected):
+        actual = self.image.list_children()
+        # dedup for cache pools until
+        # http://tracker.ceph.com/issues/8187 is fixed
+        deduped = set([('rbd', image[1]) for image in actual])
+        eq(deduped, set(expected))
+
     def test_list_children(self):
         global ioctx
         global features
         self.image.set_snap('snap1')
-        eq(self.image.list_children(), [('rbd', 'clone')])
+        self.check_children([('rbd', 'clone')])
         self.clone.close()
         self.rbd.remove(ioctx, 'clone')
         eq(self.image.list_children(), [])
@@ -712,16 +719,16 @@ class TestClone(object):
         for i in xrange(10):
             self.rbd.clone(ioctx, IMG_NAME, 'snap1', ioctx, 'clone%d' % i, features)
             expected_children.append(('rbd', 'clone%d' % i))
-            eq(self.image.list_children(), expected_children)
+            self.check_children(expected_children)
 
         for i in xrange(10):
             self.rbd.remove(ioctx, 'clone%d' % i)
             expected_children.pop(0)
-            eq(self.image.list_children(), expected_children)
+            self.check_children(expected_children)
 
         eq(self.image.list_children(), [])
         self.rbd.clone(ioctx, IMG_NAME, 'snap1', ioctx, 'clone', features)
-        eq(self.image.list_children(), [('rbd', 'clone')])
+        self.check_children([('rbd', 'clone')])
         self.clone = Image(ioctx, 'clone')
 
     def test_flatten_errors(self):


### PR DESCRIPTION
This is necessary until http://tracker.ceph.com/issues/8187 is fixed.

Signed-off-by: Josh Durgin josh.durgin@inktank.com
