### PR TITLE
Fix formatting of header

### DIFF
--- a/doc/dev/rbd-diff.rst
+++ b/doc/dev/rbd-diff.rst
@@ -7,7 +7,7 @@ two snapshots (or a snapshot and the head) of an RBD image.
 Header
 ~~~~~~
 
-"rbd diff v1\n"
+"rbd diff v1\\n"
 
 Metadata records
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The header was displaying the newline as a simple "n" due to quoting in the doc.
