### PR TITLE
Skipping '_netdev' Debian fstab option

### DIFF
--- a/src/mount.fuse.ceph
+++ b/src/mount.fuse.ceph
@@ -22,5 +22,8 @@ cephargs='--'`echo $1 | sed 's/,/ --/g'`
 # strip out 'noauto' option; libfuse doesn't like it
 opts=`echo $4 | sed 's/,noauto//' | sed 's/noauto,//'`
 
+# strip out '_netdev' option; libfuse doesn't like it
+opts=`echo $opts | sed 's/,_netdev//' | sed 's/_netdev,//'`
+
 # go
 exec ceph-fuse $cephargs $2 $3 $opts


### PR DESCRIPTION
Signed-off-by: Florent Bautista florent@coppint.com
