### PR TITLE
init: try to start all OSDs, don't give up on failures

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -327,7 +327,7 @@ for name in $what; do
 		    get_conf osd_weight "" "osd crush initial weight"
 		    defaultweight="$(df -P -k $osd_data/. | tail -1 | awk '{ print sprintf("%.2f",$2/1073741824) }')"
 		    get_conf osd_keyring "$osd_data/keyring" "keyring"
-		    do_cmd "timeout 30 $BINDIR/ceph -c $conf --name=osd.$id --keyring=$osd_keyring osd crush create-or-move -- $id ${osd_weight:-${defaultweight:-1}} $osd_location"
+		    do_cmd_okfail "timeout 30 $BINDIR/ceph -c $conf --name=osd.$id --keyring=$osd_keyring osd crush create-or-move -- $id ${osd_weight:-${defaultweight:-1}} $osd_location"
 		fi
 	    fi
 


### PR DESCRIPTION
 With multiple OSDs we shall try to start all of them instead of giving up
 when one OSD did not start.

 This fixes the problem when no OSD started if OSD.1 is unable to start
 because its file system is not mounted (which is expected when HDD is
 dead). Since HDDs fail from time to time we should tolerate error(s) and
 try to bring other OSDs up.

Signed-off-by: Dmitry Smirnov onlyjob@member.fsf.org
