### PR TITLE
rgw: fix url escaping

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -731,7 +731,7 @@ bool url_decode(string& src_str, string& dest_str)
 static void escape_char(char c, string& dst)
 {
   char buf[16];
-  snprintf(buf, sizeof(buf), "%%%.2X", (unsigned int)c);
+  snprintf(buf, sizeof(buf), "%%%.2X", (int)(unsigned char)c);
   dst.append(buf);
 }
 


### PR DESCRIPTION
Fixes: #8202
This fixes the radosgw side of issue #8202. Needed to cast value
to unsigned char, otherwise it'd get padded.

Backport: dumpling

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
