### PR TITLE
Added a new command line parameter (-i or --image=) that allows rbd-fuse...

### DIFF
--- a/src/rbd_fuse/rbd-fuse.c
+++ b/src/rbd_fuse/rbd-fuse.c
@@ -670,7 +670,7 @@ static struct fuse_opt rbdfs_opts[] = {
 	{"-p %s", offsetof(struct rbd_options, pool_name), KEY_RADOS_POOLNAME},
 	{"--poolname=%s", offsetof(struct rbd_options, pool_name),
 	 KEY_RADOS_POOLNAME_LONG},
-    {"-i %s", offsetof(struct rbd_options, image_name), KEY_RBD_IMAGENAME},
+    {"-r %s", offsetof(struct rbd_options, image_name), KEY_RBD_IMAGENAME},
     {"--image=%s", offsetof(struct rbd_options, image_name),
     KEY_RBD_IMAGENAME_LONG},
 };
@@ -685,7 +685,7 @@ static void usage(const char *progname)
 "    -V   --version         print version\n"
 "    -c   --configfile      ceph configuration file [/etc/ceph/ceph.conf]\n"
 "    -p   --poolname        rados pool name [rbd]\n"
-"    -i   --image           RBD image name\n"
+"    -r   --image           RBD image name\n"
 "\n", progname);
 }
 


### PR DESCRIPTION
Added a new command line parameter (-i or --image=) that allows rbd-fuse to specify a single image to be made available within the mount directory. The purpose of this is to allow a single RBD to be "mounted" in user space without opening (and locking) the other images in the pool.

This is accomplished by performing a case-sensitive string compare in enumerate_images() when an image name is specified on the command line. If no image name is specified, all images appear in the mount directory. If a non-existent image name is specified, the mount directory is empty.

Signed-off-by: Stephen F Taylor steveftaylor@gmail.com
