### PR TITLE
rados.h,ReplicatedPG: add CEPH_OSD_FLAG_ENFORCE_SNAPC and use on flush

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -374,6 +374,8 @@ enum {
 	CEPH_OSD_FLAG_FLUSH =         0x40000,  /* this is part of flush */
 	CEPH_OSD_FLAG_MAP_SNAP_CLONE =0x80000,  /* map snap direct to clone id
 						 */
+	CEPH_OSD_FLAG_ENFORCE_SNAPC    =0x100000,  /* use snapc provided even if
+						      pool uses pool snaps */
 };
 
 enum {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1716,7 +1716,8 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
     op->mark_started();
 
     // snap
-    if (pool.info.is_pool_snaps_mode()) {
+    if (!(m->get_flags() & CEPH_OSD_FLAG_ENFORCE_SNAPC) &&
+	pool.info.is_pool_snaps_mode()) {
       // use pool's snapc
       ctx->snapc = pool.snapc;
     } else {
@@ -6202,7 +6203,9 @@ int ReplicatedPG::start_flush(OpContext *ctx, bool blocking, hobject_t *pmissing
       o,
       dsnapc,
       oi.mtime,
-      CEPH_OSD_FLAG_IGNORE_OVERLAY | CEPH_OSD_FLAG_ORDERSNAP,
+      (CEPH_OSD_FLAG_IGNORE_OVERLAY |
+       CEPH_OSD_FLAG_ORDERSNAP |
+       CEPH_OSD_FLAG_ENFORCE_SNAPC),
       NULL,
       NULL /* no callback, we'll rely on the ordering w.r.t the next op */);
     osd->objecter_lock.Unlock();
@@ -6228,11 +6231,12 @@ int ReplicatedPG::start_flush(OpContext *ctx, bool blocking, hobject_t *pmissing
   C_Flush *fin = new C_Flush(this, soid, get_last_peering_reset());
 
   osd->objecter_lock.Lock();
-  ceph_tid_t tid = osd->objecter->mutate(soid.oid, base_oloc, o, snapc, oi.mtime,
-				    CEPH_OSD_FLAG_IGNORE_OVERLAY,
-				    NULL,
-				    new C_OnFinisher(fin,
-						     &osd->objecter_finisher));
+  ceph_tid_t tid = osd->objecter->mutate(
+    soid.oid, base_oloc, o, snapc, oi.mtime,
+    CEPH_OSD_FLAG_IGNORE_OVERLAY | CEPH_OSD_FLAG_ENFORCE_SNAPC,
+    NULL,
+    new C_OnFinisher(fin,
+		     &osd->objecter_finisher));
   fin->tid = tid;
   fop->objecter_tid = tid;
   osd->objecter_lock.Unlock();

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -47,6 +47,7 @@ const char *ceph_osd_flag_name(unsigned flag)
   case CEPH_OSD_FLAG_IGNORE_OVERLAY: return "ignore_overlay";
   case CEPH_OSD_FLAG_FLUSH: return "flush";
   case CEPH_OSD_FLAG_MAP_SNAP_CLONE: return "map_snap_clone";
+  case CEPH_OSD_FLAG_ENFORCE_SNAPC: return "enforce_snapc";
   default: return "???";
   }
 }


### PR DESCRIPTION
We need to ensure that even with pool snaps, we use the snapc provided in order
to ensure that the clones are written back correctly.

Fixes: #7941
Signed-off-by: Samuel Just sam.just@inktank.com
