### PR TITLE
mds: remove mdsdir in the final step of shutdown MDS

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7289,17 +7289,12 @@ bool MDCache::shutdown_pass()
     return false;
   }
 
-  // make mydir subtree go away
-  if (myin) {
-    CDir *mydir = myin->get_dirfrag(frag_t());
-    if (mydir && mydir->is_subtree_root()) {
-      adjust_subtree_auth(mydir, CDIR_AUTH_UNKNOWN);
-      remove_subtree(mydir);
-    }
-  }
-  
+  CDir *mydir = myin ? myin->get_dirfrag(frag_t()) : NULL;
+  if (mydir && !mydir->is_subtree_root())
+    mydir = NULL;
+
   // subtrees map not empty yet?
-  if (!subtrees.empty()) {
+  if (subtrees.size() > (mydir ? 1 : 0)) {
     dout(7) << "still have " << num_subtrees() << " subtrees" << dendl;
     show_subtrees();
     migrator->show_importing();
@@ -7308,9 +7303,15 @@ bool MDCache::shutdown_pass()
       show_cache();
     return false;
   }
-  assert(subtrees.empty());
   assert(!migrator->is_exporting());
   assert(!migrator->is_importing());
+
+  // make mydir subtree go away
+  if (mydir) {
+    adjust_subtree_auth(mydir, CDIR_AUTH_UNKNOWN);
+    remove_subtree(mydir);
+  }
+  assert(subtrees.empty());
 
   // (only do this once!)
   if (!mds->mdlog->is_capped()) {


### PR DESCRIPTION
Otherwise we may get bad subtree map if we restart the MDS before
the shutdown process finishes.

Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
