### PR TITLE
mon/OSDMonitor: share latest map with osd on dup boot message

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1210,6 +1210,7 @@ bool OSDMonitor::preprocess_boot(MOSDBoot *m)
   if (osdmap.exists(from) &&
       osdmap.get_info(from).up_from > m->version) {
     dout(7) << "prepare_boot msg from before last up_from, ignoring" << dendl;
+    send_latest(m, m->sb.current_epoch+1);
     goto ignore;
   }
 


### PR DESCRIPTION
If we get a dup boot message, share the newer maps with the osd so that they
know they are living in the past.

Fixes: #8279 Signed-off-by: Sage Weil sage@inktank.com
