### PR TITLE
mon/PGMonitor: set tid on no-op PGStatsAck

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -762,6 +762,7 @@ bool PGMonitor::prepare_pg_stats(MPGStats *stats)
   if (!pg_stats_have_changed(from, stats)) {
     dout(10) << " message contains no new osd|pg stats" << dendl;
     MPGStatsAck *ack = new MPGStatsAck;
+    ack->set_tid(stats->get_tid());
     for (map<pg_t,pg_stat_t>::const_iterator p = stats->pg_stat.begin();
 	 p != stats->pg_stat.end();
 	 ++p) {


### PR DESCRIPTION
The OSD needs to know the tid.  Both generally, and specifically because the
flush_pg_stats may be blocking on it.

Fixes: #8280 Backport: firefly, dumpling Signed-off-by: Sage Weil
sage@inktank.com
