### PR TITLE
osd/ReplicatedPG: fix trim of in-flight hit_sets

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -10924,15 +10924,11 @@ void ReplicatedPG::hit_set_trim(RepGather *repop, unsigned max)
       agent_state->remove_oldest_hit_set();
     updated_hit_set_hist.history.pop_front();
 
-    struct stat st;
-    int r = osd->store->stat(
-      coll,
-      ghobject_t(oid, ghobject_t::NO_GEN, pg_whoami.shard),
-      &st);
-    assert(r == 0);
+    ObjectContextRef obc = get_object_context(oid, false);
+    assert(obc);
     --repop->ctx->delta_stats.num_objects;
     --repop->ctx->delta_stats.num_objects_hit_set_archive;
-    repop->ctx->delta_stats.num_bytes -= st.st_size;
+    repop->ctx->delta_stats.num_bytes -= obc->obs.oi.size;
   }
 }
 


### PR DESCRIPTION
We normally need to stat the hit_set to know how many bytes to adjust the 
stats by.  If the hit_set was just written, we will get ENOENT.  Augment the
hit_set_flushing map<> with a size map so that we can skip the stat entirely
for recent hit_sets.

Fixes: #8283 Backport: firefly Signed-off-by: Sage Weil sage@inktank.com
