### PR TITLE
Fix clone problem

### DIFF
--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -204,11 +204,14 @@ void StripObjectMap::clone_wrap(StripObjectHeader &old_header,
 
   if (target_header)
     *target_header = old_header;
+  if (origin_header)
+    *origin_header = old_header;
 
   clone(old_header.header, cid, oid, t, &new_origin_header,
         &target_header->header);
 
-  old_header.header = new_origin_header;
+  if(origin_header)
+    origin_header->header = new_origin_header;
 
   if (target_header) {
     target_header->oid = oid;


### PR DESCRIPTION
When clone happened, the origin header also will be updated in GenericObjectMap,
so the new header wraper(StripObjectHeader) should be updated too.

Fix #8282
Signed-off-by: Haomai Wang haomaiwang@gmail.com
