### PR TITLE
During the Pipe::accept, we should set the policy flag as server so that we don't do reconnect from server side.

### DIFF
--- a/src/msg/Pipe.cc
+++ b/src/msg/Pipe.cc
@@ -359,7 +359,11 @@ int Pipe::accept()
 
     // note peer's type, flags
     set_peer_type(connect.host_type);
+
     policy = msgr->get_policy(connect.host_type);
+    // the connection should not be re-established from our end
+    policy.server = true;
+
     ldout(msgr->cct,10) << "accept of host_type " << connect.host_type
 			<< ", policy.lossy=" << policy.lossy
 			<< " policy.server=" << policy.server


### PR DESCRIPTION
During the Pipe::accept, we should set the policy flag as server so that we don't try to do re-connect at our end when there is issue with the connection.

Signed-off-by: Guang Yang (yguang@yahoo-inc.com)
