### PR TITLE
Variable length array of std::strings (not legal in C++) changed to std::vector<std::string>

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -360,7 +360,7 @@ void RGWLoadGenProcess::run()
   int num_buckets;
   conf->get_val("num_buckets", 1, &num_buckets);
 
-  string buckets[num_buckets];
+  vector<string> buckets(num_buckets);
 
   atomic_t failed;
 


### PR DESCRIPTION
Variable-length arrays (VLAs) are not permitted in standard C++.

Some compiler support them as extension:
e.g. Clang supports VLAs in a limited way (only with POD datatypes).

Here is a great summary of the issue and how to solve it:
http://clang.llvm.org/compatibility.html#vla

This pull request does exactly this: make standard conforming compilers happy.

(Specifically clang-3.4 is now able to compile the project)
