### PR TITLE
rgw: send user manifest header field

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -36,6 +36,7 @@ static struct rgw_http_attr rgw_to_http_attr_list[] = {
   { RGW_ATTR_CACHE_CONTROL, "Cache-Control"},
   { RGW_ATTR_CONTENT_DISP, "Content-Disposition"},
   { RGW_ATTR_CONTENT_ENC, "Content-Encoding"},
+  { RGW_ATTR_USER_MANIFEST, "X-Object-Manifest"},
   { NULL, NULL},
 };
 


### PR DESCRIPTION
Fixes: #8170
Backport: firefly
If user manifest header exists (swift) send it as part of the object
header data.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
