### PR TITLE
ceph-disk: partprobe before settle when preparing dev

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1199,6 +1199,12 @@ def prepare_dev(
             )
             command(
                 [
+                    'partprobe',
+                    data,
+                    ],
+                )
+            command(
+                [
                     # wait for udev event queue to clear
                     'udevadm',
                     'settle',


### PR DESCRIPTION
Two users have reported this fixes a problem with using --dmcrypt.

Fixes: #6966 Signed-off-by: Sage Weil sage@inktank.com
