### PR TITLE
ceph-disk: fix list for encrypted or corrupt volume

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -791,6 +791,12 @@ def mount(
     Mounts a device with given filessystem type and
     mount options to a tempfile path under /var/lib/ceph/tmp.
     """
+    # sanity check: none of the arguments are None
+    if dev is None:
+        raise ValueError('dev may not be None')
+    if fstype is None:
+        raise ValueError('fstype may not be None')
+
     # pick best-of-breed mount options based on fs type
     if options is None:
         options = MOUNT_OPTIONS.get(fstype, '')
@@ -2193,16 +2199,17 @@ def main_list(args):
             ptype = get_partition_type(dev)
             if ptype == 'ceph data':
                 fs_type = get_dev_fs(dev)
-                try:
-                    tpath = mount(dev=dev, fstype=fs_type, options='')
+                if fs_type is not None:
                     try:
-                        journal_uuid = get_oneliner(tpath, 'journal_uuid')
-                        if journal_uuid:
-                            journal_map[journal_uuid.lower()] = dev
-                    finally:
-                        unmount(tpath)
-                except MountError:
-                    pass
+                        tpath = mount(dev=dev, fstype=fs_type, options='')
+                        try:
+                            journal_uuid = get_oneliner(tpath, 'journal_uuid')
+                            if journal_uuid:
+                                journal_map[journal_uuid.lower()] = dev
+                        finally:
+                            unmount(tpath)
+                    except MountError:
+                        pass
 
     for base, parts in sorted(partmap.iteritems()):
         if parts:


### PR DESCRIPTION
Continue gracefully if an fs type is not detected, either because it is 
encrypted or because it is corrupted.

Signed-off-by: Sage Weil sage@inktank.com
