### PR TITLE
test/libcephfs/test.cc: free cmount structure before return

### DIFF
--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -110,6 +110,7 @@ TEST(LibCephFS, UnmountUnmounted) {
   ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
   ASSERT_EQ(0, ceph_conf_read_file(cmount, NULL));
   ASSERT_EQ(-ENOTCONN, ceph_unmount(cmount));
+  ceph_shutdown(cmount);
 }
 
 TEST(LibCephFS, ReleaseUnmounted) {


### PR DESCRIPTION
call ceph_shutdown to free cmount structure before return

Signed-off-by: Xing Lin xinglin@cs.utah.edu
