### PR TITLE
doc: Common graph used in 2 quick start files

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@ release = 'dev'
 templates_path = ['_templates']
 source_suffix = '.rst'
 master_doc = 'index'
-exclude_patterns = ['**/.#*', '**/*~']
+exclude_patterns = ['**/.#*', '**/*~', 'start/quick-common.rst']
 pygments_style = 'sphinx'
 
 html_theme = 'ceph'

--- a/doc/start/quick-ceph-deploy.rst
+++ b/doc/start/quick-ceph-deploy.rst
@@ -7,34 +7,7 @@ If you haven't completed your `Preflight Checklist`_, do that first. This
 on your admin node. Create a three Ceph Node cluster so you can 
 explore Ceph functionality. 
 
-.. ditaa:: 
-           /------------------\         /----------------\
-           |    Admin Node    |         |      node1     |
-           |                  +-------->+ cCCC           |
-           |    ceph–deploy   |         |    mon.node1   |
-           \---------+--------/         \----------------/
-                     |
-                     |                  /----------------\
-                     |                  |      node2     |
-                     +----------------->+ cCCC           |
-                     |                  |     osd.0      |
-                     |                  \----------------/
-                     |
-                     |                  /----------------\
-                     |                  |      node3     |
-                     +----------------->| cCCC           |
-                                        |     osd.1      |
-                                        \----------------/
-
-For best results, create a directory on your admin node node for maintaining the
-configuration that ``ceph-deploy`` generates for your cluster. ::
-
-	mkdir my-cluster
-	cd my-cluster
-
-.. tip:: The ``ceph-deploy`` utility will output files to the 
-   current directory. Ensure you are in this directory when executing
-   ``ceph-deploy``.
+.. include:: quick-common.rst
 
 As a first exercise, create a Ceph Storage Cluster with one Ceph Monitor and two
 Ceph OSD Daemons. Once the cluster reaches a ``active + clean`` state, expand it 

--- a/doc/start/quick-common.rst
+++ b/doc/start/quick-common.rst
@@ -1,0 +1,28 @@
+.. ditaa:: 
+           /------------------\         /----------------\
+           |    Admin Node    |         |      node1     |
+           |                  +-------->+ cCCC           |
+           |    ceph–deploy   |         |    mon.node1   |
+           \---------+--------/         \----------------/
+                     |
+                     |                  /----------------\
+                     |                  |      node2     |
+                     +----------------->+ cCCC           |
+                     |                  |     osd.0      |
+                     |                  \----------------/
+                     |
+                     |                  /----------------\
+                     |                  |      node3     |
+                     +----------------->| cCCC           |
+                                        |     osd.1      |
+                                        \----------------/
+
+For best results, create a directory on your admin node node for maintaining the
+configuration that ``ceph-deploy`` generates for your cluster. ::
+
+	mkdir my-cluster
+	cd my-cluster
+
+.. tip:: The ``ceph-deploy`` utility will output files to the 
+   current directory. Ensure you are in this directory when executing
+   ``ceph-deploy``.

--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -11,25 +11,10 @@ three Ceph Nodes (or virtual machines) that will host your Ceph Storage Cluster.
 Before proceeding any further, see `OS Recommendations`_ to verify that you have
 a supported distribution and version of Linux.
 
+In the descriptions below, :term:`Node` refers to a single machine.
 
-.. ditaa:: 
-           /------------------\         /----------------\
-           |    Admin Node    |         |     node1      |
-           |                  +-------->+                |
-           |    ceph–deploy   |         | cCCC           |
-           \---------+--------/         \----------------/
-                     |
-                     |                  /----------------\
-                     |                  |     node2      |
-                     +----------------->+                |
-                     |                  | cCCC           |
-                     |                  \----------------/
-                     |
-                     |                  /----------------\
-                     |                  |     node3      |
-                     +----------------->|                |
-                                        | cCCC           |
-                                        \----------------/
+.. include:: quick-common.rst
+
 
 
 Ceph Deploy Setup


### PR DESCRIPTION
The graph in quick-ceph-deploy.rst applies to
quick-start-preflight.rst.
The graph in deploy seems more complete, so I put the common
documentation in quick-common.rst and had it included.
doc/conf.py has 'start/quick-common.rst' in exclude patterns so that
sphinx does not complain about this file not being in toc.

Signed-off-by: Kevin Dalley kevin@kelphead.org
