### PR TITLE
:doc Ceph OSD is standard name

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -77,14 +77,17 @@ reflect either technical terms or legacy ways of referring to Ceph systems.
 
 	Object Storage Device
 	OSD
-		A physical or logical storage unit (*e.g.*, LUN). Ceph users often 
-		conflate the term OSD with "Ceph OSD Daemon."
+		A physical or logical storage unit (*e.g.*, LUN).
+		Sometimes, Ceph users use the
+		term "OSD" to refer to :term:`Ceph OSD Daemon`, though the
+		proper term is "Ceph OSD".
 		
 	Ceph OSD Daemon
-	OSD
 	Ceph OSD
-		The Ceph OSD software, which interacts with a logical disk (OSD). Ceph 
-		users often frequently conflate the term OSD with "Ceph OSD Daemon."
+		The Ceph OSD software, which interacts with a logical
+		disk (:term:`OSD`). Sometimes, Ceph users use the
+		term "OSD" to refer to "Ceph OSD Daemon", though the
+		proper term is "Ceph OSD".
 		
 	Ceph Monitor
 	MON

--- a/doc/start/intro.rst
+++ b/doc/start/intro.rst
@@ -14,7 +14,7 @@ Filesystem clients.
             |      OSDs     | |    Monitor    | |      MDS      |
             +---------------+ +---------------+ +---------------+
 
-- **OSDs**: A :term:`Ceph OSD Daemon` (OSD) stores data, handles data 
+- **Ceph OSDs**: A :term:`Ceph OSD Daemon` (Ceph OSD) stores data, handles data
   replication, recovery, backfilling, rebalancing, and provides some monitoring
   information to Ceph Monitors by checking other Ceph OSD Daemons for a 
   heartbeat. A Ceph Storage Cluster requires at least two Ceph OSD Daemons to 


### PR DESCRIPTION
This is a method of standardizing the usage of OSD so that "Ceph OSD"
is the daemon, and OSD maintains its industry standard usage of Object
Storage Device.

Signed-off-by: Kevin Dalley kevin@kelphead.org
