### PR TITLE
Removed extra semicolons

### DIFF
--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -164,7 +164,7 @@ struct ExpiringCryptoKey {
     ::decode(expiration, bl);
   }
 };
-WRITE_CLASS_ENCODER(ExpiringCryptoKey);
+WRITE_CLASS_ENCODER(ExpiringCryptoKey)
 
 static inline ostream& operator<<(ostream& out, const ExpiringCryptoKey& c)
 {
@@ -226,7 +226,7 @@ struct RotatingSecrets {
 
   void dump();
 };
-WRITE_CLASS_ENCODER(RotatingSecrets);
+WRITE_CLASS_ENCODER(RotatingSecrets)
 
 
 

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -99,7 +99,7 @@ public:
 
   void to_str(std::string& s) const;
 };
-WRITE_CLASS_ENCODER(CryptoKey);
+WRITE_CLASS_ENCODER(CryptoKey)
 
 static inline ostream& operator<<(ostream& out, const CryptoKey& k)
 {

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -180,8 +180,8 @@ struct KeyServerData {
   }
 
 };
-WRITE_CLASS_ENCODER(KeyServerData);
-WRITE_CLASS_ENCODER(KeyServerData::Incremental);
+WRITE_CLASS_ENCODER(KeyServerData)
+WRITE_CLASS_ENCODER(KeyServerData::Incremental)
 
 
 
@@ -302,7 +302,7 @@ public:
   map<EntityName, EntityAuth>::iterator secrets_end()
   { return data.secrets_end(); }
 };
-WRITE_CLASS_ENCODER(KeyServer);
+WRITE_CLASS_ENCODER(KeyServer)
 
 
 #endif

--- a/src/auth/cephx/CephxProtocol.h
+++ b/src/auth/cephx/CephxProtocol.h
@@ -111,7 +111,7 @@ struct CephXServerChallenge {
     ::decode(server_challenge, bl);
   }
 };
-WRITE_CLASS_ENCODER(CephXServerChallenge);
+WRITE_CLASS_ENCODER(CephXServerChallenge)
 
 
 // request/reply headers, for subsequent exchanges.
@@ -126,7 +126,7 @@ struct CephXRequestHeader {
     ::decode(request_type, bl);
   }
 };
-WRITE_CLASS_ENCODER(CephXRequestHeader);
+WRITE_CLASS_ENCODER(CephXRequestHeader)
 
 struct CephXResponseHeader {
   uint16_t request_type;
@@ -141,7 +141,7 @@ struct CephXResponseHeader {
     ::decode(status, bl);
   }
 };
-WRITE_CLASS_ENCODER(CephXResponseHeader);
+WRITE_CLASS_ENCODER(CephXResponseHeader)
 
 struct CephXTicketBlob {
   uint64_t secret_id;
@@ -163,7 +163,7 @@ struct CephXTicketBlob {
     ::decode(blob, bl);
   }
 };
-WRITE_CLASS_ENCODER(CephXTicketBlob);
+WRITE_CLASS_ENCODER(CephXTicketBlob)
 
 // client -> server response to challenge
 struct CephXAuthenticate {
@@ -248,7 +248,7 @@ struct CephXServiceTicketRequest {
     ::decode(keys, bl);
   }
 };
-WRITE_CLASS_ENCODER(CephXServiceTicketRequest);
+WRITE_CLASS_ENCODER(CephXServiceTicketRequest)
 
 
 /*
@@ -268,7 +268,7 @@ struct CephXAuthorizeReply {
     ::decode(nonce_plus_one, bl);
   }
 };
-WRITE_CLASS_ENCODER(CephXAuthorizeReply);
+WRITE_CLASS_ENCODER(CephXAuthorizeReply)
 
 
 struct CephXAuthorizer : public AuthAuthorizer {
@@ -365,7 +365,7 @@ struct CephXServiceTicket {
     ::decode(validity, bl);
   }
 };
-WRITE_CLASS_ENCODER(CephXServiceTicket);
+WRITE_CLASS_ENCODER(CephXServiceTicket)
 
 /* B */
 struct CephXServiceTicketInfo {
@@ -385,7 +385,7 @@ struct CephXServiceTicketInfo {
     ::decode(session_key, bl);
   }
 };
-WRITE_CLASS_ENCODER(CephXServiceTicketInfo);
+WRITE_CLASS_ENCODER(CephXServiceTicketInfo)
 
 struct CephXAuthorize {
   uint64_t nonce;
@@ -400,7 +400,7 @@ struct CephXAuthorize {
     ::decode(nonce, bl);
   }
 };
-WRITE_CLASS_ENCODER(CephXAuthorize);
+WRITE_CLASS_ENCODER(CephXAuthorize)
 
 /*
  * Decode an extract ticket

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -1423,7 +1423,7 @@ int get_id(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 
   ::encode(id, *out);
   return 0;
-};
+}
 
 /**
  * Set the id of an image. The object must already exist.

--- a/src/cls/replica_log/cls_replica_log_types.h
+++ b/src/cls/replica_log/cls_replica_log_types.h
@@ -189,6 +189,6 @@ public:
   void decode_json(JSONObj *obj);
   static void generate_test_instances(std::list<cls_replica_log_bound*>& ls);
 };
-WRITE_CLASS_ENCODER(cls_replica_log_bound);
+WRITE_CLASS_ENCODER(cls_replica_log_bound)
 
 #endif /* CLS_REPLICA_LOG_TYPES_H_ */

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -175,7 +175,7 @@ public:
     }
 
     ret_ctx->handle_response(r, ret.dir.header);
-  };
+  }
 };
 
 int cls_rgw_get_dir_header_async(IoCtx& io_ctx, string& oid, RGWGetDirHeader_CB *ctx)

--- a/src/common/BackTrace.cc
+++ b/src/common/BackTrace.cc
@@ -64,6 +64,6 @@ void BackTrace::print(std::ostream& out)
     }
     free(function);
   }
-};
+}
 
 }

--- a/src/common/TextTable.h
+++ b/src/common/TextTable.h
@@ -42,7 +42,7 @@ private:
     Align hd_align;
     Align col_align;
 
-    TextTableColumn() {};
+    TextTableColumn() {}
     TextTableColumn(std::string h, int w, Align ha, Align ca) :
 		    heading(h), width(w), hd_align(ha), col_align(ca) { }
     ~TextTableColumn() {}

--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -400,7 +400,7 @@ public:
   
   void _enqueue(GenContext<ThreadPool::TPHandle&> *c) {
     _queue.push_back(c);
-  };
+  }
   void _enqueue_front(GenContext<ThreadPool::TPHandle&> *c) {
     _queue.push_front(c);
   }

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -32,7 +32,7 @@ class AdminSocketHook {
 public:
   virtual bool call(std::string command, cmdmap_t &cmdmap, std::string format,
 		    bufferlist& out) = 0;
-  virtual ~AdminSocketHook() {};
+  virtual ~AdminSocketHook() {}
 };
 
 class AdminSocket : public Thread

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -134,7 +134,7 @@ static uint32_t simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZE
       : data(c), len(l), nref(0),
 	crc_lock("buffer::raw::crc_lock", false, false)
     { }
-    virtual ~raw() {};
+    virtual ~raw() {}
 
     // no copying.
     raw(const raw &other);
@@ -1433,7 +1433,7 @@ void buffer::list::rebuild_page_aligned()
     // splice in *replace (implement me later?)
     
     last_p = begin();  // just in case we were in the removed region.
-  };
+  }
 
   void buffer::list::write(int off, int len, std::ostream& out) const
   {

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -247,7 +247,7 @@ void CephContext::do_command(std::string command, cmdmap_t& cmdmap,
   delete f;
   lgeneric_dout(this, 1) << "do_command '" << command << "' '" << ss.str()
 		         << "result is " << out->length() << " bytes" << dendl;
-};
+}
 
 
 CephContext::CephContext(uint32_t module_type_)

--- a/src/common/ceph_json.cc
+++ b/src/common/ceph_json.cc
@@ -32,12 +32,12 @@ void JSONObjIter::operator++()
 {
   if (cur != last)
     ++cur;
-};
+}
 
 JSONObj *JSONObjIter::operator*()
 {
   return cur->second;
-};
+}
 
 // does not work, FIXME
 ostream& operator<<(ostream& out, JSONObj& obj) {

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -45,7 +45,7 @@ protected:
 
 public:
 
-  JSONObj() : parent(NULL){};
+  JSONObj() : parent(NULL){}
 
   virtual ~JSONObj();
 

--- a/src/common/entity_name.h
+++ b/src/common/entity_name.h
@@ -81,7 +81,7 @@ private:
 
 uint32_t str_to_ceph_entity_type(const char * str);
 
-WRITE_CLASS_ENCODER(EntityName);
+WRITE_CLASS_ENCODER(EntityName)
 
 WRITE_EQ_OPERATORS_2(EntityName, type, id)
 

--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -195,6 +195,6 @@ public:
     return 0;
   } ///< @return error value, 0 on success
 };
-}; // namespace
+} // namespace
 
 #endif

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -443,7 +443,7 @@ inline ostream& operator<<(ostream &oss, health_status_t status) {
       break;
   }
   return oss;
-};
+}
 #endif
 
 #endif

--- a/src/key_value_store/key_value_structure.h
+++ b/src/key_value_store/key_value_structure.h
@@ -57,7 +57,7 @@ public:
   virtual int suicide() = 0;
 
   ////////////////DESTRUCTOR/////////////////
-  virtual ~KeyValueStructure() {};
+  virtual ~KeyValueStructure() {}
 
   ////////////////UPDATERS///////////////////
 

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -88,7 +88,7 @@ public:
     case PIN_PURGING: return "purging";
     default: return generic_pin_name(p);
     }
-  };
+  }
 
   // -- wait --
   //static const int WAIT_LOCK_OFFSET = 8;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -452,7 +452,7 @@ public:
     g_num_inoa++;
     state = 0;  
     if (auth) state_set(STATE_AUTH);
-  };
+  }
   ~CInode() {
     g_num_ino--;
     g_num_inos++;

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -285,7 +285,7 @@ public:
     //check_rdcaps_list();
   }
 
-  void inc_last_seq() { last_sent++; };
+  void inc_last_seq() { last_sent++; }
   ceph_seq_t get_last_seq() { return last_sent; }
   ceph_seq_t get_last_issue() { return last_issue; }
 

--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -2222,7 +2222,7 @@ bool MDS::ms_verify_authorizer(Connection *con, int peer_type,
   }
 
   return true;  // we made a decision (see is_valid)
-};
+}
 
 
 void MDS::ms_handle_accept(Connection *con)

--- a/src/mds/mds_table_types.h
+++ b/src/mds/mds_table_types.h
@@ -55,7 +55,7 @@ inline const char *get_mdstableserver_opname(int op) {
   case TABLESERVER_OP_SERVER_READY: return "server_ready";
   default: assert(0); return 0;
   }
-};
+}
 
 enum {
   TABLE_OP_CREATE,
@@ -70,6 +70,6 @@ inline const char *get_mdstable_opname(int op) {
   case TABLE_OP_DESTROY: return "destroy";
   default: assert(0); return 0;
   }
-};
+}
 
 #endif

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -480,7 +480,7 @@ struct fnode_t {
   void decode(bufferlist::iterator& bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<fnode_t*>& ls);
-  fnode_t() : version(0) {};
+  fnode_t() : version(0) {}
 };
 WRITE_CLASS_ENCODER(fnode_t)
 

--- a/src/mds/snap.h
+++ b/src/mds/snap.h
@@ -89,6 +89,6 @@ struct sr_t {
   void dump(Formatter *f) const;
   static void generate_test_instances(list<sr_t*>& ls);
 };
-WRITE_CLASS_ENCODER(sr_t);
+WRITE_CLASS_ENCODER(sr_t)
 
 #endif

--- a/src/messages/MPGStats.h
+++ b/src/messages/MPGStats.h
@@ -35,7 +35,7 @@ public:
   {}
 
 private:
-  ~MPGStats() {};
+  ~MPGStats() {}
 
 public:
   const char *get_type_name() const { return "pg_stats"; }

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -162,6 +162,6 @@ private:
 };
 
 
-WRITE_CLASS_ENCODER_FEATURES(AuthMonitor::Incremental);
+WRITE_CLASS_ENCODER_FEATURES(AuthMonitor::Incremental)
 
 #endif

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4128,7 +4128,7 @@ bool Monitor::ms_verify_authorizer(Connection *con, int peer_type,
     isvalid = true;
   }
   return true;
-};
+}
 
 #undef dout_prefix
 #define dout_prefix *_dout

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -957,6 +957,6 @@ struct MonCommand {
     DECODE_FINISH(bl);
   }
 };
-WRITE_CLASS_ENCODER(MonCommand);
+WRITE_CLASS_ENCODER(MonCommand)
 
 #endif

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -315,7 +315,7 @@ class MonitorDBStore
     }
     pair<string,string> get_last_key() {
       return last_key;
-    };
+    }
     virtual bool has_next_chunk() {
       return !done && _is_valid();
     }
@@ -571,7 +571,7 @@ class MonitorDBStore
 
 };
 
-WRITE_CLASS_ENCODER(MonitorDBStore::Op);
-WRITE_CLASS_ENCODER(MonitorDBStore::Transaction);
+WRITE_CLASS_ENCODER(MonitorDBStore::Op)
+WRITE_CLASS_ENCODER(MonitorDBStore::Transaction)
 
 #endif /* CEPH_MONITOR_DB_STORE_H */

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -34,7 +34,7 @@ struct Subscription {
   bool incremental_onetime;  // has CEPH_FEATURE_INCSUBOSDMAP
   
   Subscription(MonSession *s, const string& t) : session(s), type(t), type_item(this),
-						 next(0), onetime(false), incremental_onetime(false) {};
+						 next(0), onetime(false), incremental_onetime(false) {}
 };
 
 struct MonSession : public RefCountedObject {

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -84,7 +84,7 @@ struct LevelDBStoreStats {
     DECODE_FINISH(p);
   }
 };
-WRITE_CLASS_ENCODER(LevelDBStoreStats);
+WRITE_CLASS_ENCODER(LevelDBStoreStats)
 
 // data stats
 
@@ -134,7 +134,7 @@ struct DataStats {
     DECODE_FINISH(p);
   }
 };
-WRITE_CLASS_ENCODER(DataStats);
+WRITE_CLASS_ENCODER(DataStats)
 
 struct ScrubResult {
   map<string,uint32_t> prefix_crc;  ///< prefix -> crc
@@ -173,7 +173,7 @@ struct ScrubResult {
     ls.back()->prefix_keys["bar"] = 456;
   }
 };
-WRITE_CLASS_ENCODER(ScrubResult);
+WRITE_CLASS_ENCODER(ScrubResult)
 
 static inline ostream& operator<<(ostream& out, const ScrubResult& r) {
   return out << "ScrubResult(keys " << r.prefix_keys << " crc " << r.prefix_crc << ")";

--- a/src/os/BtrfsFileStoreBackend.h
+++ b/src/os/BtrfsFileStoreBackend.h
@@ -30,7 +30,7 @@ private:
   bool m_filestore_btrfs_snap;
 public:
   BtrfsFileStoreBackend(FileStore *fs);
-  ~BtrfsFileStoreBackend() {};
+  ~BtrfsFileStoreBackend() {}
   int detect_features();
   bool can_checkpoint();
   int create_current();

--- a/src/os/FileStore.h
+++ b/src/os/FileStore.h
@@ -682,7 +682,7 @@ protected:
   }
 public:
   FileStoreBackend(FileStore *fs) : filestore(fs) {}
-  virtual ~FileStoreBackend() {};
+  virtual ~FileStoreBackend() {}
   virtual int detect_features() = 0;
   virtual int create_current() = 0;
   virtual bool can_checkpoint() = 0;

--- a/src/os/GenericFileStoreBackend.h
+++ b/src/os/GenericFileStoreBackend.h
@@ -26,11 +26,11 @@ private:
   bool m_filestore_fsync_flushes_journal_data;
 public:
   GenericFileStoreBackend(FileStore *fs);
-  virtual ~GenericFileStoreBackend() {};
+  virtual ~GenericFileStoreBackend() {}
 
   virtual int detect_features();
   virtual int create_current();
-  virtual bool can_checkpoint() { return false; };
+  virtual bool can_checkpoint() { return false; }
   virtual int list_checkpoints(list<string>& ls) { return 0; }
   virtual int create_checkpoint(const string& name, uint64_t *cid) { return -EOPNOTSUPP; }
   virtual int sync_checkpoint(uint64_t id) { return -EOPNOTSUPP; }

--- a/src/os/KeyValueDB.h
+++ b/src/os/KeyValueDB.h
@@ -60,7 +60,7 @@ public:
       const string &prefix ///< [in] Prefix by which to remove keys
       ) = 0;
 
-    virtual ~TransactionImpl() {};
+    virtual ~TransactionImpl() {}
   };
   typedef ceph::shared_ptr< TransactionImpl > Transaction;
 

--- a/src/os/XfsFileStoreBackend.h
+++ b/src/os/XfsFileStoreBackend.h
@@ -25,7 +25,7 @@ private:
   int set_extsize(int fd, unsigned int val);
 public:
   XfsFileStoreBackend(FileStore *fs);
-  ~XfsFileStoreBackend() {};
+  ~XfsFileStoreBackend() {}
   int detect_features();
   int set_alloc_hint(int fd, uint64_t hint);
 };

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1095,7 +1095,7 @@ void ECBackend::filter_read_op(
       get_parent()->bless_gencontext(
 	new FinishReadOp(this, op.tid)));
   }
-};
+}
 
 void ECBackend::check_recovery_sources(const OSDMapRef osdmap)
 {

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -149,6 +149,6 @@ typedef ceph::shared_ptr<HashInfo> HashInfoRef;
 bool is_hinfo_key_string(const string &key);
 const string &get_hinfo_key();
 
-};
+}
 WRITE_CLASS_ENCODER(ECUtil::HashInfo)
 #endif

--- a/src/osd/HitSet.h
+++ b/src/osd/HitSet.h
@@ -167,8 +167,8 @@ public:
 private:
   void reset_to_type(impl_type_t type);
 };
-WRITE_CLASS_ENCODER(HitSet);
-WRITE_CLASS_ENCODER(HitSet::Params);
+WRITE_CLASS_ENCODER(HitSet)
+WRITE_CLASS_ENCODER(HitSet::Params)
 
 typedef boost::shared_ptr<HitSet> HitSetRef;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5032,7 +5032,7 @@ bool OSD::ms_verify_authorizer(Connection *con, int peer_type,
     s->put();
   }
   return true;
-};
+}
 
 void OSD::do_waiters()
 {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1236,7 +1236,7 @@ public:
     HeartbeatDispatcher(OSD *o) : Dispatcher(cct), osd(o) {}
     bool ms_dispatch(Message *m) {
       return osd->heartbeat_dispatch(m);
-    };
+    }
     bool ms_handle_reset(Connection *con) {
       return osd->heartbeat_reset(con);
     }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7182,7 +7182,7 @@ boost::statechart::result PG::RecoveryState::GetMissing::react(const MLogRec& lo
     }
   }
   return discard_event();
-};
+}
 
 boost::statechart::result PG::RecoveryState::GetMissing::react(const QueryState& q)
 {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -516,7 +516,7 @@ public:
     const char *get_state_name() { return state_name; }
     NamedState(CephContext *cct_, const char *state_name_)
       : state_name(state_name_),
-        enter_time(ceph_clock_now(cct_)) {};
+        enter_time(ceph_clock_now(cct_)) {}
     virtual ~NamedState() {}
   };
 
@@ -1138,7 +1138,7 @@ public:
     const hobject_t &hoid,
     const map<string, bufferptr> &attrs,
     pg_shard_t osd,
-    ostream &out) { return false; };
+    ostream &out) { return false; }
   void clear_scrub_reserved();
   void scrub_reserve_replicas();
   void scrub_unreserve_replicas();

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -191,7 +191,7 @@ public:
 
   public:
     /// Provide the final size of the copied object to the CopyCallback
-    virtual ~CopyCallback() {};
+    virtual ~CopyCallback() {}
   };
 
   friend class CopyFromCallback;

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -69,7 +69,7 @@ struct Mapping {
     DECODE_FINISH(bl);
   }
 };
-WRITE_CLASS_ENCODER(Mapping);
+WRITE_CLASS_ENCODER(Mapping)
 
 string SnapMapper::get_prefix(snapid_t snap)
 {

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -415,17 +415,17 @@ class ObjectCacher {
     bh_set_state(bh2, bh1->get_state());
   }
   
-  void mark_missing(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_MISSING); };
-  void mark_clean(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_CLEAN); };
-  void mark_zero(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_ZERO); };
-  void mark_rx(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_RX); };
-  void mark_tx(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_TX); };
-  void mark_error(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_ERROR); };
+  void mark_missing(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_MISSING); }
+  void mark_clean(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_CLEAN); }
+  void mark_zero(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_ZERO); }
+  void mark_rx(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_RX); }
+  void mark_tx(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_TX); }
+  void mark_error(BufferHead *bh) { bh_set_state(bh, BufferHead::STATE_ERROR); }
   void mark_dirty(BufferHead *bh) { 
     bh_set_state(bh, BufferHead::STATE_DIRTY); 
     bh_lru_dirty.lru_touch(bh);
     //bh->set_dirty_stamp(ceph_clock_now(g_ceph_context));
-  };
+  }
 
   void bh_add(Object *ob, BufferHead *bh);
   void bh_remove(Object *ob, BufferHead *bh);

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -147,12 +147,12 @@ struct RGWBucketAdminOpState {
     object_name = object_str;
   }
 
-  std::string& get_user_id() { return uid; };
-  std::string& get_user_display_name() { return display_name; };
-  std::string& get_bucket_name() { return bucket_name; };
-  std::string& get_object_name() { return object_name; };
+  std::string& get_user_id() { return uid; }
+  std::string& get_user_display_name() { return display_name; }
+  std::string& get_bucket_name() { return bucket_name; }
+  std::string& get_object_name() { return object_name; }
 
-  rgw_bucket& get_bucket() { return bucket; };
+  rgw_bucket& get_bucket() { return bucket; }
   void set_bucket(rgw_bucket& _bucket) {
     bucket = _bucket; 
     bucket_stored = true;
@@ -161,15 +161,15 @@ struct RGWBucketAdminOpState {
   void set_bucket_id(const string& bi) {
     bucket_id = bi;
   }
-  const string& get_bucket_id() { return bucket_id; };
+  const string& get_bucket_id() { return bucket_id; }
 
-  bool will_fetch_stats() { return stat_buckets; };
-  bool will_fix_index() { return fix_index; };
-  bool will_delete_children() { return delete_child_objects; };
-  bool will_check_objects() { return check_objects; };
-  bool is_user_op() { return !uid.empty(); };
-  bool is_system_op() { return uid.empty(); }; 
-  bool has_bucket_stored() { return bucket_stored; };
+  bool will_fetch_stats() { return stat_buckets; }
+  bool will_fix_index() { return fix_index; }
+  bool will_delete_children() { return delete_child_objects; }
+  bool will_check_objects() { return check_objects; }
+  bool is_user_op() { return !uid.empty(); }
+  bool is_system_op() { return uid.empty(); }
+  bool has_bucket_stored() { return bucket_stored; }
 
   RGWBucketAdminOpState() : list_buckets(false), stat_buckets(false), check_objects(false), 
                             fix_index(false), delete_child_objects(false),
@@ -218,7 +218,7 @@ public:
   int policy_bl_to_stream(bufferlist& bl, ostream& o);
   int get_policy(RGWBucketAdminOpState& op_state, ostream& o);
 
-  void clear_failure() { failure = false; };
+  void clear_failure() { failure = false; }
 };
 
 class RGWBucketAdminOp

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -354,7 +354,7 @@ struct RGWAccessKey {
   void decode_json(JSONObj *obj);
   void decode_json(JSONObj *obj, bool swift);
 };
-WRITE_CLASS_ENCODER(RGWAccessKey);
+WRITE_CLASS_ENCODER(RGWAccessKey)
 
 struct RGWSubUser {
   string name;
@@ -380,7 +380,7 @@ struct RGWSubUser {
 
   void decode_json(JSONObj *obj);
 };
-WRITE_CLASS_ENCODER(RGWSubUser);
+WRITE_CLASS_ENCODER(RGWSubUser)
 
 class RGWUserCaps
 {
@@ -410,7 +410,7 @@ public:
 
   void decode_json(JSONObj *obj);
 };
-WRITE_CLASS_ENCODER(RGWUserCaps);
+WRITE_CLASS_ENCODER(RGWUserCaps)
 
 void encode_json(const char *name, const obj_version& v, Formatter *f);
 void encode_json(const char *name, const RGWUserCaps& val, Formatter *f);

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -7,7 +7,7 @@ class KeystoneToken {
 public:
   class Metadata {
   public:
-    Metadata() : is_admin(false) { };
+    Metadata() : is_admin(false) { }
     bool is_admin;
     void decode_json(JSONObj *obj);
   };
@@ -31,10 +31,10 @@ public:
 
   class Token {
   public:
-    Token() : expires(0) { };
+    Token() : expires(0) { }
     class Tenant {
     public:
-      Tenant() : enabled(false) { };
+      Tenant() : enabled(false) { }
       string id;
       string name;
       string description;

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -821,7 +821,7 @@ public:
   void *entry() {
     pprocess->run();
     return NULL;
-  };
+  }
 };
 
 class RGWProcessFrontend : public RGWFrontend {

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -69,9 +69,9 @@ struct RGWMetadataLogData {
     encode_json("read_version", read_version, f);
     encode_json("write_version", write_version, f);
     encode_json("status", LogStatusDump(status), f);
-  };
+  }
 };
-WRITE_CLASS_ENCODER(RGWMetadataLogData);
+WRITE_CLASS_ENCODER(RGWMetadataLogData)
 
 
 int RGWMetadataLog::add_entry(RGWRados *store, RGWMetadataHandler *handler, const string& section, const string& key, bufferlist& bl) {

--- a/src/rgw/rgw_multi_del.h
+++ b/src/rgw/rgw_multi_del.h
@@ -13,7 +13,7 @@ public:
 
   std::vector<string> objects;
   bool quiet;
-  bool is_quiet() { return quiet; };
+  bool is_quiet() { return quiet; }
 };
 
 class RGWMultiDelQuiet : public XMLObj

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -736,14 +736,14 @@ public:
   virtual void update_stats(const string& user, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) {
     bucket_stats_cache.adjust_stats(user, bucket, obj_delta, added_bytes, removed_bytes);
     user_stats_cache.adjust_stats(user, bucket, obj_delta, added_bytes, removed_bytes);
-  };
+  }
 };
 
 
 RGWQuotaHandler *RGWQuotaHandler::generate_handler(RGWRados *store, bool quota_threads)
 {
   return new RGWQuotaHandlerImpl(store, quota_threads);
-};
+}
 
 void RGWQuotaHandler::free_handler(RGWQuotaHandler *handler)
 {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1013,7 +1013,7 @@ int RGWPutObjProcessor_Plain::prepare(RGWRados *store, void *obj_ctx)
   obj.init(bucket, obj_str);
 
   return 0;
-};
+}
 
 int RGWPutObjProcessor_Plain::handle_data(bufferlist& bl, off_t _ofs, void **phandle)
 {
@@ -1202,7 +1202,7 @@ int RGWPutObjProcessor_Atomic::prepare_next_part(off_t ofs) {
   add_obj(cur_obj);
 
   return 0;
-};
+}
 
 int RGWPutObjProcessor_Atomic::complete_parts()
 {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -116,7 +116,7 @@ struct RGWObjManifestPart {
   void dump(Formatter *f) const;
   static void generate_test_instances(list<RGWObjManifestPart*>& o);
 };
-WRITE_CLASS_ENCODER(RGWObjManifestPart);
+WRITE_CLASS_ENCODER(RGWObjManifestPart)
 
 /*
  The manifest defines a set of rules for structuring the object parts.
@@ -163,7 +163,7 @@ struct RGWObjManifestRule {
   }
   void dump(Formatter *f) const;
 };
-WRITE_CLASS_ENCODER(RGWObjManifestRule);
+WRITE_CLASS_ENCODER(RGWObjManifestRule)
 
 class RGWObjManifest {
 protected:
@@ -484,7 +484,7 @@ public:
     }
   };
 };
-WRITE_CLASS_ENCODER(RGWObjManifest);
+WRITE_CLASS_ENCODER(RGWObjManifest)
 
 struct RGWUploadPartInfo {
   uint32_t num;
@@ -541,7 +541,7 @@ public:
     store = _store;
     obj_ctx = _o;
     return 0;
-  };
+  }
   virtual int handle_data(bufferlist& bl, off_t ofs, void **phandle) = 0;
   virtual int throttle_data(void *handle) = 0;
   virtual int complete(string& etag, time_t *mtime, time_t set_mtime, map<string, bufferlist>& attrs);
@@ -767,7 +767,7 @@ struct RGWZonePlacementInfo {
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
-WRITE_CLASS_ENCODER(RGWZonePlacementInfo);
+WRITE_CLASS_ENCODER(RGWZonePlacementInfo)
 
 struct RGWZoneParams {
   rgw_bucket domain_root;
@@ -838,7 +838,7 @@ struct RGWZoneParams {
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
-WRITE_CLASS_ENCODER(RGWZoneParams);
+WRITE_CLASS_ENCODER(RGWZoneParams)
 
 struct RGWZone {
   string name;
@@ -870,7 +870,7 @@ struct RGWZone {
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
-WRITE_CLASS_ENCODER(RGWZone);
+WRITE_CLASS_ENCODER(RGWZone)
 
 struct RGWDefaultRegionInfo {
   string default_region;
@@ -889,7 +889,7 @@ struct RGWDefaultRegionInfo {
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
-WRITE_CLASS_ENCODER(RGWDefaultRegionInfo);
+WRITE_CLASS_ENCODER(RGWDefaultRegionInfo)
 
 struct RGWRegionPlacementTarget {
   string name;
@@ -926,7 +926,7 @@ struct RGWRegionPlacementTarget {
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
-WRITE_CLASS_ENCODER(RGWRegionPlacementTarget);
+WRITE_CLASS_ENCODER(RGWRegionPlacementTarget)
 
 
 struct RGWRegion {
@@ -985,7 +985,7 @@ struct RGWRegion {
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
-WRITE_CLASS_ENCODER(RGWRegion);
+WRITE_CLASS_ENCODER(RGWRegion)
 
 struct RGWRegionMap {
   Mutex lock;
@@ -1011,7 +1011,7 @@ struct RGWRegionMap {
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
-WRITE_CLASS_ENCODER(RGWRegionMap);
+WRITE_CLASS_ENCODER(RGWRegionMap)
 
 class RGWDataChangesLog;
 class RGWReplicaLogger;

--- a/src/rgw/rgw_resolve.cc
+++ b/src/rgw/rgw_resolve.cc
@@ -167,7 +167,7 @@ RGWResolver::RGWResolver() {
 
 int RGWResolver::resolve_cname(const string& hostname, string& cname, bool *found) {
   return resolver->resolve_cname(hostname, cname, found);
-};
+}
 
 RGWResolver *rgw_resolver;
 

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -238,17 +238,17 @@ RGWOp *RGWHandler_Bucket::op_get()
     return new RGWOp_Check_Bucket_Index;
 
   return new RGWOp_Bucket_Info;
-};
+}
 
 RGWOp *RGWHandler_Bucket::op_put()
 {
   return new RGWOp_Bucket_Link;
-};
+}
 
 RGWOp *RGWHandler_Bucket::op_post()
 {
   return new RGWOp_Bucket_Unlink;
-};
+}
 
 RGWOp *RGWHandler_Bucket::op_delete()
 {
@@ -256,5 +256,5 @@ RGWOp *RGWHandler_Bucket::op_delete()
     return new RGWOp_Object_Remove;
 
   return new RGWOp_Bucket_Remove;
-};
+}
 

--- a/src/rgw/rgw_rest_usage.cc
+++ b/src/rgw/rgw_rest_usage.cc
@@ -86,11 +86,11 @@ void RGWOp_Usage_Delete::execute() {
 RGWOp *RGWHandler_Usage::op_get()
 {
   return new RGWOp_Usage_Get;
-};
+}
 
 RGWOp *RGWHandler_Usage::op_delete()
 {
   return new RGWOp_Usage_Delete;
-};
+}
 
 

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -874,7 +874,7 @@ RGWOp *RGWHandler_User::op_get()
     return new RGWOp_Quota_Info;
 
   return new RGWOp_User_Info;
-};
+}
 
 RGWOp *RGWHandler_User::op_put()
 {
@@ -891,7 +891,7 @@ RGWOp *RGWHandler_User::op_put()
     return new RGWOp_Quota_Set;
 
   return new RGWOp_User_Create;
-};
+}
 
 RGWOp *RGWHandler_User::op_post()
 {
@@ -899,7 +899,7 @@ RGWOp *RGWHandler_User::op_post()
     return new RGWOp_Subuser_Modify;
 
   return new RGWOp_User_Modify;
-};
+}
 
 RGWOp *RGWHandler_User::op_delete()
 {
@@ -913,5 +913,5 @@ RGWOp *RGWHandler_User::op_delete()
     return new RGWOp_Caps_Remove;
 
   return new RGWOp_User_Remove;
-};
+}
 

--- a/src/rgw/rgw_xml.cc
+++ b/src/rgw/rgw_xml.cc
@@ -38,7 +38,7 @@ get_next()
     ++cur;
   }
   return obj;
-};
+}
 
 ostream& operator<<(ostream& out, XMLObj& obj) {
    out << obj.obj_type << ": " << obj.data;

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -214,8 +214,8 @@ TYPE(EUpdate)
 #ifdef WITH_RADOSGW
 
 #include "rgw/rgw_rados.h"
-TYPE(RGWObjManifestPart);
-TYPE(RGWObjManifest);
+TYPE(RGWObjManifestPart)
+TYPE(RGWObjManifest)
 
 #include "rgw/rgw_acl.h"
 TYPE(ACLPermission)
@@ -276,8 +276,8 @@ TYPE(cls_user_get_header_ret)
 TYPE(cls_user_complete_stats_sync_op)
 
 #include "rgw/rgw_common.h"
-TYPE(RGWAccessKey);
-TYPE(RGWSubUser);
+TYPE(RGWAccessKey)
+TYPE(RGWSubUser)
 TYPE(RGWUserInfo)
 TYPE(rgw_bucket)
 TYPE(RGWBucketInfo)

--- a/src/test/librados/TestCase.h
+++ b/src/test/librados/TestCase.h
@@ -92,8 +92,8 @@ protected:
 
 class RadosTestECPP : public ::testing::Test {
 public:
-  RadosTestECPP() : cluster(s_cluster) {};
-  virtual ~RadosTestECPP() {};
+  RadosTestECPP() : cluster(s_cluster) {}
+  virtual ~RadosTestECPP() {}
 protected:
   static void SetUpTestCase();
   static void TearDownTestCase();


### PR DESCRIPTION
Removes all the extra semicolon warnings from clang-3.4's -Weverything diagnostics.
