### PR TITLE
Fixed missing initializers issues

### DIFF
--- a/src/common/ceph_crypto_cms.cc
+++ b/src/common/ceph_crypto_cms.cc
@@ -313,7 +313,7 @@ loser:
 int ceph_decode_cms(CephContext *cct, bufferlist& cms_bl, bufferlist& decoded_bl)
 {
     NSSCMSMessage *cmsg = NULL;
-    struct decodeOptionsStr decodeOptions = { 0 };
+    struct decodeOptionsStr decodeOptions = { };
     struct optionsStr options;
     SECItem input;
 

--- a/src/rbd_fuse/rbd-fuse.c
+++ b/src/rbd_fuse/rbd-fuse.c
@@ -565,7 +565,7 @@ struct rbdfuse_attr {
 	{ "user.rbdfuse.imagesize", &imagesize },
 	{ "user.rbdfuse.imageorder", &imageorder },
 	{ "user.rbdfuse.imagefeatures", &imagefeatures },
-	{ NULL }
+	{ NULL, NULL }
 };
 
 int


### PR DESCRIPTION
Removes all the missing initializers warnings from clang-3.4's -Weverything diagnostics.
