### PR TITLE
doc: update instructions for RPM distros

### DIFF
--- a/doc/install/build-ceph.rst
+++ b/doc/install/build-ceph.rst
@@ -96,6 +96,14 @@ host. ::
 
 	zypper install boost-devel gcc-c++ libedit-devel libopenssl-devel fuse-devel
 
+Fedora 20
+---------
+
+As root, run:
+
+::
+
+    yum install make automake autoconf  boost-devel fuse-devel gcc-c++ libtool libuuid-devel libblkid-devel keyutils-libs-devel cryptopp-devel fcgi-devel libcurl-devel expat-devel gperftools-devel libedit-devel libatomic_ops-devel snappy-devel leveldb-devel libaio-devel xfsprogs-devel git libudev-devel
 
 
 Build Ceph
@@ -160,15 +168,19 @@ Once you have installed the tools, setup an RPM compilation environment::
 
 Fetch the source tarball for the RPM compilation environment::
 
-	wget -P ~/rpmbuild/SOURCES/ http://ceph.com/download/ceph-<version>.tar.gz
+	wget -P ~/rpmbuild/SOURCES/ http://ceph.com/download/ceph-<version>.tar.bz2
 
 Or from the EU mirror::
 
-	wget -P ~/rpmbuild/SOURCES/ http://eu.ceph.com/download/ceph-<version>.tar.gz
+	wget -P ~/rpmbuild/SOURCES/ http://eu.ceph.com/download/ceph-<version>.tar.bz2
+
+Extract the specfile::
+
+    tar --strip-components=1 --no-anchored -xvf ~/rpmbuild/SOURCES/ceph-<version>.tar.gz "ceph.spec" -C ~/rpmbuild/SPECS/
 
 Build the RPM packages::
 
-	rpmbuild -tb ~/rpmbuild/SOURCES/ceph-<version>.tar.gz
+	rpmbuild -ba ~/rpmbuild/SPECS/ceph.spec
 
 For multi-processor CPUs use the ``-j`` option to accelerate the build.
 


### PR DESCRIPTION
Fix RPM building instructions: this has been broken since
libs3 was included inline in the ceph repo as a submodule.
"rpmbuild -tb" was concatenating the ceph.spec and
libs3.spec files, resulting in something that didn't work.

Also, the instructions suggested downloading a .tar.gz file
whereas the specfile requires a .tar.bz2 file.

Also, add a convenient yum command line for getting the compile
dependencies on Fedora 20.

Signed-off-by: John Spray john.spray@inktank.com
