### PR TITLE
Fix warning: 'va_start' has undefined behavior with reference types.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -602,6 +602,9 @@ AC_CHECK_HEADER([boost/statechart/state.hpp], [],
 AC_CHECK_HEADER([boost/program_options/option.hpp], [],
     AC_MSG_FAILURE(["Can't find boost program_options headers"]))
 
+AC_CHECK_HEADER([boost/preprocessor/repetition/repeat.hpp], [],
+    AC_MSG_FAILURE(["Can't find boost preprocessor headers"]))
+
 # If we have the boost system library installed, then we may want to link
 # with it.
 AC_CHECK_LIB(boost_system-mt, main, [],

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -56,7 +56,7 @@ int main(int argc, const char **argv, const char *envp[]) {
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "--localize-reads", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--localize-reads")) {
       cerr << "setting CEPH_OSD_FLAG_LOCALIZE_READS" << std::endl;
       filer_flags |= CEPH_OSD_FLAG_LOCALIZE_READS;
     } else {

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -206,11 +206,11 @@ int main(int argc, const char **argv)
 	 i != args_copy.end(); ) {
       if (ceph_argparse_double_dash(args_copy, i)) {
 	break;
-      } else if (ceph_argparse_flag(args_copy, i, "--mkfs", (char*)NULL)) {
+      } else if (ceph_argparse_flag(args_copy, i, "--mkfs")) {
 	flags |= CINIT_FLAG_NO_DAEMON_ACTIONS;
-      } else if (ceph_argparse_witharg(args_copy, i, &val, "--inject_monmap", (char*)NULL)) {
+      } else if (ceph_argparse_witharg(args_copy, i, &val, "--inject-monmap", (char*)NULL)) {
 	flags |= CINIT_FLAG_NO_DAEMON_ACTIONS;
-      } else if (ceph_argparse_witharg(args_copy, i, &val, "--extract-monmap", (char*)NULL)) {
+      } else if (ceph_argparse_witharg(args_copy, i, &val, "--extract-monmap")) {
 	flags |= CINIT_FLAG_NO_DAEMON_ACTIONS;
       } else {
 	++i;
@@ -225,16 +225,16 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-h", "--help")) {
       usage();
       exit(0);
-    } else if (ceph_argparse_flag(args, i, "--mkfs", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--mkfs")) {
       mkfs = true;
-    } else if (ceph_argparse_flag(args, i, "--compact", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--compact")) {
       compact = true;
-    } else if (ceph_argparse_flag(args, i, "--force-sync", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--force-sync")) {
       force_sync = true;
-    } else if (ceph_argparse_flag(args, i, "--yes-i-really-mean-it", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--yes-i-really-mean-it")) {
       yes_really = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--osdmap", (char*)NULL)) {
       osdmapfn = val;

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -91,28 +91,28 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-h", "--help")) {
       usage();
       exit(0);
-    } else if (ceph_argparse_flag(args, i, "--mkfs", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--mkfs")) {
       mkfs = true;
-    } else if (ceph_argparse_flag(args, i, "--mkjournal", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--mkjournal")) {
       mkjournal = true;
-    } else if (ceph_argparse_flag(args, i, "--mkkey", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--mkkey")) {
       mkkey = true;
-    } else if (ceph_argparse_flag(args, i, "--flush-journal", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--flush-journal")) {
       flushjournal = true;
-    } else if (ceph_argparse_flag(args, i, "--convert-filestore", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--convert-filestore")) {
       convertfilestore = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--dump-pg-log", (char*)NULL)) {
       dump_pg_log = val;
-    } else if (ceph_argparse_flag(args, i, "--dump-journal", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--dump-journal")) {
       dump_journal = true;
-    } else if (ceph_argparse_flag(args, i, "--get-cluster-fsid", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--get-cluster-fsid")) {
       get_cluster_fsid = true;
-    } else if (ceph_argparse_flag(args, i, "--get-osd-fsid", "--get-osd-uuid", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--get-osd-fsid", "--get-osd-uuid")) {
       get_osd_fsid = true;
-    } else if (ceph_argparse_flag(args, i, "--get-journal-fsid", "--get-journal-uuid", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--get-journal-fsid", "--get-journal-uuid")) {
       get_journal_fsid = true;
     } else {
       ++i;

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -27,9 +27,16 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
 
 #include "common/entity_name.h"
 #include "msg/msg_types.h"
+
+/////////////////////// Macros ///////////////////////
+#ifndef CEPH_ARGPARSE_MAX_ARGS
+# define CEPH_ARGPARSE_MAX_ARGS 4
+#endif
 
 /////////////////////// Types ///////////////////////
 class CephInitParameters
@@ -53,8 +60,17 @@ extern void vec_to_argv(const char *argv0, std::vector<const char*>& args,
 extern bool parse_ip_port_vec(const char *s, std::vector<entity_addr_t>& vec);
 bool ceph_argparse_double_dash(std::vector<const char*> &args,
 	std::vector<const char*>::iterator &i);
-bool ceph_argparse_flag(std::vector<const char*> &args,
-	std::vector<const char*>::iterator &i, ...);
+
+#define CEPH_ARGPARSE_FLAG_protomake(z_, n_, unused_) \
+bool ceph_argparse_flag( \
+    std::vector<const char*> &args, \
+    std::vector<const char*>::iterator &i, \
+    BOOST_PP_ENUM_PARAMS(n_, const char* s) );
+BOOST_PP_REPEAT_FROM_TO(1, CEPH_ARGPARSE_MAX_ARGS,
+                        CEPH_ARGPARSE_FLAG_protomake, ~)
+
+#undef CEPH_ARGPARSE_FLAG_protomake
+
 bool ceph_argparse_witharg(std::vector<const char*> &args,
 	std::vector<const char*>::iterator &i, std::string *ret, ...);
 bool ceph_argparse_binary_flag(std::vector<const char*> &args,

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -376,22 +376,22 @@ int md_config_t::parse_argv(std::vector<const char*>& args)
        * argument parses will still need to see it. */
       break;
     }
-    else if (ceph_argparse_flag(args, i, "--show_conf", (char*)NULL)) {
+    else if (ceph_argparse_flag(args, i, "--show_conf")) {
       cerr << cf << std::endl;
       _exit(0);
     }
-    else if (ceph_argparse_flag(args, i, "--show_config", (char*)NULL)) {
+    else if (ceph_argparse_flag(args, i, "--show_config")) {
       show_config = true;
     }
     else if (ceph_argparse_witharg(args, i, &val, "--show_config_value", (char*)NULL)) {
       show_config_value = true;
       show_config_value_arg = val;
     }
-    else if (ceph_argparse_flag(args, i, "--foreground", "-f", (char*)NULL)) {
+    else if (ceph_argparse_flag(args, i, "--foreground", "-f")) {
       set_val_or_die("daemonize", "false");
       set_val_or_die("pid_file", "");
     }
-    else if (ceph_argparse_flag(args, i, "-d", (char*)NULL)) {
+    else if (ceph_argparse_flag(args, i, "-d")) {
       set_val_or_die("daemonize", "false");
       set_val_or_die("log_file", "");
       set_val_or_die("pid_file", "");
@@ -503,7 +503,7 @@ int md_config_t::parse_option(std::vector<const char*>& args,
       } else {
 	std::string no("--no-");
 	no += opt->name;
-	if (ceph_argparse_flag(args, i, no.c_str(), (char*)NULL)) {
+	if (ceph_argparse_flag(args, i, no.c_str())) {
 	  set_val_impl("false", opt);
 	  break;
 	}

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -1994,10 +1994,10 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--secret", (char*)NULL)) {
       int r = g_conf->set_val("keyfile", val.c_str());
       assert(r == 0);
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-h", "--help")) {
       usage();
       return 0;
-    } else if (ceph_argparse_flag(args, i, "--new-format", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--new-format")) {
       format = 2;
       format_specified = true;
     } else if (ceph_argparse_withint(args, i, &format, &err, "--image-format",
@@ -2028,7 +2028,7 @@ int main(int argc, const char **argv)
       }
       size = sizell << 20;   // bytes to MB
       size_set = true;
-    } else if (ceph_argparse_flag(args, i, "-l", "--long", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-l", "--long")) {
       lflag = true;
     } else if (ceph_argparse_withlonglong(args, i, &stripe_unit, &err, "--stripe-unit", (char*)NULL)) {
     } else if (ceph_argparse_withlonglong(args, i, &stripe_count, &err, "--stripe-count", (char*)NULL)) {
@@ -2050,7 +2050,7 @@ int main(int argc, const char **argv)
       imgname = strdup(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--shared", (char *)NULL)) {
       lock_tag = strdup(val.c_str());
-    } else if (ceph_argparse_flag(args, i, "--no-settle", (char *)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--no-settle")) {
       cerr << "rbd: --no-settle is deprecated" << std::endl;
     } else if (ceph_argparse_witharg(args, i, &val, "-o", "--options", (char*)NULL)) {
       char *map_options = strdup(val.c_str());
@@ -2058,12 +2058,12 @@ int main(int argc, const char **argv)
         cerr << "rbd: couldn't parse map options" << std::endl;
         return EXIT_FAILURE;
       }
-    } else if (ceph_argparse_flag(args, i, "--read-only", (char *)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--read-only")) {
       // --read-only is equivalent to -o ro
       put_map_option("rw", "ro");
-    } else if (ceph_argparse_flag(args, i, "--no-progress", (char *)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--no-progress")) {
       progress = false;
-    } else if (ceph_argparse_flag(args, i , "--allow-shrink", (char *)NULL)) {
+    } else if (ceph_argparse_flag(args, i , "--allow-shrink")) {
       resize_allow_shrink = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--format", (char *) NULL)) {
       std::string err;

--- a/src/tools/ceph.cc
+++ b/src/tools/ceph.cc
@@ -152,25 +152,25 @@ static void parse_cmd_args(vector<const char*> &args,
       if (i == args.end())
 	usage();
       *admin_socket_cmd = *i++;
-    } else if (ceph_argparse_flag(args, i, "-s", "--status", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-s", "--status")) {
       *mode = CEPH_TOOL_MODE_STATUS;
-    } else if (ceph_argparse_flag(args, i, "-w", "--watch", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-w", "--watch")) {
       *mode = CEPH_TOOL_MODE_WATCH;
-    } else if (ceph_argparse_flag(args, i, "--watch-debug", (char*) NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--watch-debug")) {
       *watch_level = "log-debug";
-    } else if (ceph_argparse_flag(args, i, "--watch-info", (char*) NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--watch-info")) {
       *watch_level = "log-info";
-    } else if (ceph_argparse_flag(args, i, "--watch-sec", (char*) NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--watch-sec")) {
       *watch_level = "log-sec";
-    } else if (ceph_argparse_flag(args, i, "--watch-warn", (char*) NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--watch-warn")) {
       *watch_level = "log-warn";
-    } else if (ceph_argparse_flag(args, i, "--watch-error", (char*) NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--watch-error")) {
       *watch_level = "log-error";
-    } else if (ceph_argparse_flag(args, i, "--concise", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--concise")) {
       *concise = true;
-    } else if (ceph_argparse_flag(args, i, "--verbose", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--verbose")) {
       *concise = false;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-h", "--help")) {
       usage();
     } else {
       if (admin_socket_cmd && admin_socket_cmd->length()) {

--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -75,13 +75,13 @@ int main(int argc, const char **argv)
     std::string val;
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-g", "--gen-key", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-g", "--gen-key")) {
       gen_key = true;
-    } else if (ceph_argparse_flag(args, i, "--gen-print-key", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--gen-print-key")) {
       gen_print_key = true;
     } else if (ceph_argparse_witharg(args, i, &val, "-a", "--add-key", (char*)NULL)) {
       add_key = val;
-    } else if (ceph_argparse_flag(args, i, &val, "-l", "--list", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-l", "--list")) {
       list = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--caps", (char*)NULL)) {
       caps_fn = val;
@@ -94,9 +94,9 @@ int main(int argc, const char **argv)
       std::string my_val = *i;
       ++i;
       ::encode(my_val, caps[my_key]);
-    } else if (ceph_argparse_flag(args, i, "-p", "--print-key", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-p", "--print-key")) {
       print_key = true;
-    } else if (ceph_argparse_flag(args, i, "-C", "--create-keyring", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-C", "--create-keyring")) {
       create_keyring = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--import-keyring", (char*)NULL)) {
       import_keyring = val;

--- a/src/tools/ceph_conf.cc
+++ b/src/tools/ceph_conf.cc
@@ -164,14 +164,14 @@ int main(int argc, const char **argv)
       break;
     } else if (ceph_argparse_witharg(args, i, &val, "-s", "--section", (char*)NULL)) {
       sections.push_back(val);
-    } else if (ceph_argparse_flag(args, i, "-r", "--resolve_search", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-r", "--resolve_search")) {
       resolve_search = true;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-h", "--help")) {
       action = "help";
     } else if (ceph_argparse_witharg(args, i, &val, "--lookup", (char*)NULL)) {
       action = "lookup";
       lookup_key = val;
-    } else if (ceph_argparse_flag(args, i, "-L", "--list_all_sections", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-L", "--list_all_sections")) {
       action = "list-sections";
       section_list_prefix = "";
     } else if (ceph_argparse_witharg(args, i, &val, "-l", "--list_sections", (char*)NULL)) {

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -212,7 +212,7 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-h", "--help")) {
       usage();
       exit(0);
     } else if (ceph_argparse_witharg(args, i, &val, "-d", "--decompile", (char*)NULL)) {
@@ -222,31 +222,31 @@ int main(int argc, const char **argv)
       infn = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-o", "--outfn", (char*)NULL)) {
       outfn = val;
-    } else if (ceph_argparse_flag(args, i, "-v", "--verbose", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-v", "--verbose")) {
       verbose += 1;
-    } else if (ceph_argparse_flag(args, i, "--show_utilization", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--show_utilization")) {
       display = true;
       tester.set_output_utilization(true);
-    } else if (ceph_argparse_flag(args, i, "--show_utilization_all", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--show_utilization_all")) {
       display = true;
       tester.set_output_utilization_all(true);
-    } else if (ceph_argparse_flag(args, i, "--show_statistics", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--show_statistics")) {
       display = true;
       tester.set_output_statistics(true);
-    } else if (ceph_argparse_flag(args, i, "--show_bad_mappings", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--show_bad_mappings")) {
       display = true;
       tester.set_output_bad_mappings(true);
-    } else if (ceph_argparse_flag(args, i, "--show_choose_tries", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--show_choose_tries")) {
       display = true;
       tester.set_output_choose_tries(true);
     } else if (ceph_argparse_witharg(args, i, &val, "-c", "--compile", (char*)NULL)) {
       srcfn = val;
       compile = true;
-    } else if (ceph_argparse_flag(args, i, "-t", "--test", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-t", "--test")) {
       test = true;
-    } else if (ceph_argparse_flag(args, i, "-s", "--simulate", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-s", "--simulate")) {
       tester.set_random_placement();
-    } else if (ceph_argparse_flag(args, i, "--enable-unsafe-tunables", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--enable-unsafe-tunables")) {
       unsafe_tunables = true;
     } else if (ceph_argparse_withint(args, i, &choose_local_tries, &err,
 				     "--set_choose_local_tries", (char*)NULL)) {
@@ -263,7 +263,7 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_withint(args, i, &chooseleaf_vary_r, &err,
 				     "--set_chooseleaf_vary_r", (char*)NULL)) {
       adjust = true;
-    } else if (ceph_argparse_flag(args, i, "--reweight", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--reweight")) {
       reweight = true;
     } else if (ceph_argparse_withint(args, i, &add_item, &err, "--add_item", (char*)NULL)) {
       if (!err.str().empty()) {
@@ -309,11 +309,11 @@ int main(int argc, const char **argv)
       std::string name(*i);
       i = args.erase(i);
       add_loc[type] = name;
-    } else if (ceph_argparse_flag(args, i, "--output-csv", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--output-csv")) {
       write_to_file = true;
       tester.set_output_data_file(true);
       tester.set_output_csv(true);
-    } else if (ceph_argparse_flag(args, i, "--help-output", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--help-output")) {
       data_analysis_usage();
       exit(0);
     } else if (ceph_argparse_witharg(args, i, &val, "--output-name", (char*)NULL)) {
@@ -335,7 +335,7 @@ int main(int argc, const char **argv)
       }
       reweight_weight = atof(*i);
       i = args.erase(i);
-    } else if (ceph_argparse_flag(args, i, "--build", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--build")) {
       build = true;
     } else if (ceph_argparse_withint(args, i, &num_osds, &err, "--num_osds", (char*)NULL)) {
       if (!err.str().empty()) {

--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -52,19 +52,19 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-h", "--help")) {
       usage();
-    } else if (ceph_argparse_flag(args, i, "-p", "--print", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-p", "--print")) {
       print = true;
-    } else if (ceph_argparse_flag(args, i, "--create", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--create")) {
       create = true;
-    } else if (ceph_argparse_flag(args, i, "--clobber", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--clobber")) {
       clobber = true;
-    } else if (ceph_argparse_flag(args, i, "--generate", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--generate")) {
       generate = true;
-    } else if (ceph_argparse_flag(args, i, "--set-initial-members", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--set-initial-members")) {
       filter = true;
-    } else if (ceph_argparse_flag(args, i, "--add", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--add")) {
       string name = *i;
       i = args.erase(i);
       if (i == args.end())

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -76,13 +76,13 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-h", "--help")) {
       usage();
-    } else if (ceph_argparse_flag(args, i, "-p", "--print", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-p", "--print")) {
       print = true;
-    } else if (ceph_argparse_flag(args, i, "--dump-json", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--dump-json")) {
       print_json = true;
-    } else if (ceph_argparse_flag(args, i, "--tree", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--tree")) {
       tree = true;
     } else if (ceph_argparse_withint(args, i, &num_osd, &err, "--createsimple", (char*)NULL)) {
       if (!err.str().empty()) {
@@ -90,17 +90,17 @@ int main(int argc, const char **argv)
 	exit(EXIT_FAILURE);
       }
       createsimple = true;
-    } else if (ceph_argparse_flag(args, i, "--create-from-conf", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--create-from-conf")) {
       create_from_conf = true;
-    } else if (ceph_argparse_flag(args, i, "--mark-up-in", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--mark-up-in")) {
       mark_up_in = true;
-    } else if (ceph_argparse_flag(args, i, "--clear-temp", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--clear-temp")) {
       clear_temp = true;
-    } else if (ceph_argparse_flag(args, i, "--test-map-pgs", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--test-map-pgs")) {
       test_map_pgs = true;
-    } else if (ceph_argparse_flag(args, i, "--test-random", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--test-random")) {
       test_random = true;
-    } else if (ceph_argparse_flag(args, i, "--clobber", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--clobber")) {
       clobber = true;
     } else if (ceph_argparse_withint(args, i, &pg_bits, &err, "--pg_bits", (char*)NULL)) {
       if (!err.str().empty()) {
@@ -120,7 +120,7 @@ int main(int argc, const char **argv)
       test_map_pg = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--test_map_object", (char*)NULL)) {
       test_map_object = val;
-    } else if (ceph_argparse_flag(args, i, "--test_crush", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--test_crush")) {
       test_crush = true;
     } else if (ceph_argparse_withint(args, i, &range_first, &err, "--range_first", (char*)NULL)) {
     } else if (ceph_argparse_withint(args, i, &range_last, &err, "--range_last", (char*)NULL)) {

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2554,21 +2554,20 @@ int main(int argc, const char **argv)
   for (i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-h", "--help")) {
       usage(cout);
       exit(0);
-    } else if (ceph_argparse_flag(args, i, "-f", "--force", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-f", "--force")) {
       opts["force"] = "true";
-    } else if (ceph_argparse_flag(args, i, "-d", "--delete-after", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-d", "--delete-after")) {
       opts["delete-after"] = "true";
-    } else if (ceph_argparse_flag(args, i, "-C", "--create", "--create-pool",
-				  (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-C", "--create", "--create-pool")) {
       opts["create"] = "true";
-    } else if (ceph_argparse_flag(args, i, "--pretty-format", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--pretty-format")) {
       opts["pretty-format"] = "true";
-    } else if (ceph_argparse_flag(args, i, "--show-time", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--show-time")) {
       opts["show-time"] = "true";
-    } else if (ceph_argparse_flag(args, i, "--no-cleanup", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--no-cleanup")) {
       opts["no-cleanup"] = "true";
     } else if (ceph_argparse_witharg(args, i, &val, "--run-name", (char*)NULL)) {
       opts["run-name"] = val;

--- a/src/tools/rest_bench.cc
+++ b/src/tools/rest_bench.cc
@@ -684,12 +684,12 @@ int main(int argc, const char **argv)
   for (i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-h", "--help")) {
       usage(cout);
       exit(0);
-    } else if (ceph_argparse_flag(args, i, "--show-time", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--show-time")) {
       show_time = true;
-    } else if (ceph_argparse_flag(args, i, "--no-cleanup", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--no-cleanup")) {
       cleanup = false;
     } else if (ceph_argparse_witharg(args, i, &user_agent, "--agent", (char*)NULL)) {
       /* nothing */


### PR DESCRIPTION
- fixing the clang-flagged varargs issue
  - quick'n'dirty via boost preprocessor, long-term, we should
    e.g. use boost program_options
    (ceph_erasure_code already uses it anyway)
- interesting bug found: ceph_authtool.cc:84 called
  ceph_argparse_flag with a std::string arg
- only converted one of the 6 varargs functions, pending
  feedback

Signed-off-by: Thorsten Behrens tbehrens@suse.com
