### PR TITLE
osd: include osd_objectstore in metadata reported to mon

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3839,6 +3839,7 @@ void OSD::_collect_metadata(map<string,string> *pm)
   // config info
   (*pm)["osd_data"] = dev_path;
   (*pm)["osd_journal"] = journal_path;
+  (*pm)["osd_objectstore"] = g_conf->osd_objectstore;
   (*pm)["front_addr"] = stringify(client_messenger->get_myaddr());
   (*pm)["back_addr"] = stringify(cluster_messenger->get_myaddr());
   (*pm)["hb_front_addr"] = stringify(hb_front_server_messenger->get_myaddr());


### PR DESCRIPTION
Provide visibility into the OSD backend.

Signed-off-by: Sage Weil sage@inktank.com
