### PR TITLE
sample.ceph.conf: minor update

### DIFF
--- a/src/sample.ceph.conf
+++ b/src/sample.ceph.conf
@@ -210,6 +210,12 @@
     # (Default: 300)
     ;mon osd down out interval  = 300
 
+    # The grace period in seconds before declaring unresponsive Ceph OSD
+    # Daemons "down".
+    # Type: 32-bit Integer
+    # (Default: 900)
+    ;mon osd report timeout          = 300
+
 ### http://ceph.com/docs/master/rados/troubleshooting/log-and-debug/
 
     # logging, for debugging monitor crashes, in order of
@@ -293,6 +299,10 @@
     # (Default: 5)
     ;osd recovery max active      = 3
 
+    # The maximum number of simultaneous scrub operations for a Ceph OSD Daemon.
+    # Type: 32-bit Int
+    # (Default: 1)
+    ;osd max scrubs               = 2
 
     # You may add settings for ceph-deploy so that it will create and mount
     # the correct type of file system. Remove the comment `#` character for
@@ -350,20 +360,6 @@
     ;debug filestore              = 20
     ;debug journal                = 20
 
-
-
-;[osd.0]
-;    host                         = delta
-
-;[osd.1]
-;    host                         = epsilon
-
-;[osd.2]
-;    host                         = zeta
-
-;[osd.3]
-;    host                         = eta
-
 ### http://ceph.com/docs/master/rados/configuration/filestore-config-ref/
 
     # The maximum interval in seconds for synchronizing the filestore.
@@ -382,6 +378,26 @@
     # Required: No
     # (Default: false)
     ;filestore flusher            = true
+
+    # Defines the maximum number of in progress operations the file store
+    # accepts before blocking on queuing new operations.
+    # Type: Integer
+    # Required: No. Minimal impact on performance.
+    # (Default: 500)
+    ;filestore queue max ops      = 500
+
+;[osd.0]
+;    host                         = delta
+
+;[osd.1]
+;    host                         = epsilon
+
+;[osd.2]
+;    host                         = zeta
+
+;[osd.3]
+;    host                         = eta
+
 
 ##################
 ## client settings


### PR DESCRIPTION
- Moved filestore settings above [osd.*] declarations otherwise
  (if uncommented) those settings might be applied only to last
  OSD which is not very obvious.
- Few options added.
