### PR TITLE
Ensure autogen.sh to be executed at the top-level

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+test -f src/ceph.in || {
+    echo "You must run this script in the top-level ceph directory"
+    exit 1
+}
+
 check_for_pkg_config() {
     which pkg-config >/dev/null && return
 


### PR DESCRIPTION
This first contribution adds a test to ensure that user
executes 'autogen.sh' at the top-level of the directory.

Signed-off-by: Sahid Orentino Ferdjaoui sahid.ferdjaoui@cloudwatt.com
