### PR TITLE
osd: skip out of order op checks on tiered pools

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1834,7 +1834,8 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
   calc_trim_to();
 
   // verify that we are doing this in order?
-  if (cct->_conf->osd_debug_op_order && m->get_source().is_client()) {
+  if (cct->_conf->osd_debug_op_order && m->get_source().is_client() &&
+      !pool.info.is_tier() && !pool.info.has_tiers()) {
     map<client_t,ceph_tid_t>& cm = debug_op_order[obc->obs.oi.soid];
     ceph_tid_t t = m->get_tid();
     client_t n = m->get_source().num();

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -915,6 +915,7 @@ public:
   cache_mode_t cache_mode;  ///< cache pool mode
 
   bool is_tier() const { return tier_of >= 0; }
+  bool has_tiers() const { return !tiers.empty(); }
   void clear_tier() { tier_of = -1; }
   bool has_read_tier() const { return read_tier >= 0; }
   void clear_read_tier() { read_tier = -1; }


### PR DESCRIPTION
When we send redirected ops, we do not assign a new tid, which means that a
given client's ops for a pool may not have strictly ordered tids.  Skip this
check if the pool is tiered to avoid false positives.

Fixes: #8380 Signed-off-by: Sage Weil sage@inktank.com
