### PR TITLE
doc: fix link to FAQ

### DIFF
--- a/doc/start/quick-rbd.rst
+++ b/doc/start/quick-rbd.rst
@@ -73,5 +73,5 @@ See `block devices`_ for additional details.
 
 .. _Storage Cluster Quick Start: ../quick-ceph-deploy
 .. _block devices: ../../rbd/rbd
-.. _FAQ: http://wiki.ceph.com/03FAQs/01General_FAQ#How_Can_I_Give_Ceph_a_Try.3F
+.. _FAQ: http://wiki.ceph.com/FAQs/How_Can_I_Give_Ceph_a_Try%3F
 .. _OS Recommendations: ../os-recommendations


### PR DESCRIPTION
The location of the ceph wiki FAQ has changed.
Now, the link from ceph documentation matches the current FAQ location

Signed-off-by: Kevin Dalley kevin@kelphead.org
