### PR TITLE
doc: mention admin-node in common documentation

### DIFF
--- a/doc/start/quick-ceph-deploy.rst
+++ b/doc/start/quick-ceph-deploy.rst
@@ -154,10 +154,6 @@ configuration file, perform the following steps using ``ceph-deploy``.
 
 	ceph-deploy admin node1 node2 node3 admin-node
 
-   **Note:** Since you are using ``ceph-deploy`` to talk to the
-   local host (admin-node), your host must be reachable by its hostname 
-   (e.g., you can modify ``/etc/hosts`` if necessary). 
-   
 #. Ensure that you have the correct permissions for the 
    ``ceph.client.admin.keyring``. ::
 

--- a/doc/start/quick-common.rst
+++ b/doc/start/quick-common.rst
@@ -1,6 +1,6 @@
 .. ditaa:: 
            /------------------\         /----------------\
-           |    Admin Node    |         |      node1     |
+           |    admin-node    |         |      node1     |
            |                  +-------->+ cCCC           |
            |    ceph–deploy   |         |    mon.node1   |
            \---------+--------/         \----------------/
@@ -26,3 +26,8 @@ configuration that ``ceph-deploy`` generates for your cluster. ::
 .. tip:: The ``ceph-deploy`` utility will output files to the 
    current directory. Ensure you are in this directory when executing
    ``ceph-deploy``.
+
+.. tip:: ``ceph-deploy`` is talking to the
+   local admin host (``admin-node``). This host must be reachable by
+   its hostname. If necessary, modify ``/etc/hosts`` to add the name
+   of the admin host.


### PR DESCRIPTION
This change uses admin-node in the quick-common.rst file, including
the graph. This name is already used in
quick-ceph-deploy.rst.

Signed-off-by: Kevin Dalley kevin@kelphead.org
