### PR TITLE
HashIndex: in cleanup, interpret missing dir as completed merge

### DIFF
--- a/src/os/HashIndex.cc
+++ b/src/os/HashIndex.cc
@@ -36,8 +36,12 @@ int HashIndex::cleanup() {
   InProgressOp in_progress(i);
   subdir_info_s info;
   r = get_info(in_progress.path, &info);
-  if (r < 0)
+  if (r == -ENOENT) {
+    return end_split_or_merge(in_progress.path);
+  } else if (r < 0) {
     return r;
+  }
+
   if (in_progress.is_split())
     return complete_split(in_progress.path, info);
   else if (in_progress.is_merge())


### PR DESCRIPTION
If we stop between unlinking the empty subdir and removing the root
merge marker, we get ENOENT on the get_info.  That's actually fine.

Backport: firefly
Fixes: 8332
Signed-off-by: Samuel Just sam.just@inktank.com
