### PR TITLE
OSD: verify that client ops are targeted correctly in the current epoch

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7857,6 +7857,13 @@ void OSD::handle_op(OpRequestRef op, OSDMapRef osdmap)
     return;
   }
 
+  // check against current map too
+  if (!osdmap->have_pg_pool(pgid.pool()) ||
+      osdmap->get_pg_acting_role(pgid.pgid, whoami) < 0) {
+    dout(7) << "dropping; no longer have PG (or pool); client will retarget" << dendl;
+    return;
+  }
+
   PG *pg = get_pg_or_queue_for_pg(pgid, op);
   if (pg) {
     op->send_map_update = share_map.should_send;


### PR DESCRIPTION
We were previously only looking at the epoch the op was sent in, which meant
that if we had dropped responsibility somewhere between send_epoch and our
current epoch, we would queue up the op until a new osdmap came along. If it
never did, we could block all client IO against us...
