### PR TITLE
Fix set_alloc_hint op cause KeyValueStore crash problem

### DIFF
--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -1448,7 +1448,13 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
       break;
 
     case Transaction::OP_SETALLOCHINT:
-      // TODO: can kvstore make use of the hint?
+      {
+        // TODO: can kvstore make use of the hint?
+        coll_t cid(i.get_cid());
+        ghobject_t oid = i.get_oid();
+        uint64_t expected_object_size = i.get_length();
+        uint64_t expected_write_size = i.get_length();
+      }
       break;
 
     default:

--- a/src/os/MemStore.cc
+++ b/src/os/MemStore.cc
@@ -950,7 +950,12 @@ void MemStore::_do_transaction(Transaction& t)
       break;
 
     case Transaction::OP_SETALLOCHINT:
-      // nop
+      {
+        coll_t cid(i.get_cid());
+        ghobject_t oid = i.get_oid();
+        uint64_t expected_object_size = i.get_length();
+        uint64_t expected_write_size = i.get_length();
+      }
       break;
 
     default:


### PR DESCRIPTION
Now KeyValueStore doesn't support set_alloc_hit op, the implementation of
_do_transaction need to consider decoding the arguments. Otherwise, the
arguments will be regarded as the next op.

Fix the same problem for MemStore.

Fix #8381

Reported-by: Xinxin Shu xinxin.shu5040@gmail.com
Signed-off-by: Haomai Wang haomaiwang@gmail.com
