### PR TITLE
ceph.spec.in: remove BuildRoot

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -30,7 +30,6 @@ Requires:	util-linux
 Requires:	hdparm
 Requires:       redhat-lsb-core
 Requires(post):	binutils
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:	make
 BuildRequires:	gcc-c++
 BuildRequires:	libtool


### PR DESCRIPTION
Deprecated

Fixes: #8143 Signed-off-by: Sage Weil sage@inktank.com
