### PR TITLE
Define AO_REQUIRE_CAS (fixes FTBFS on 'hppa')

### DIFF
--- a/src/include/atomic.h
+++ b/src/include/atomic.h
@@ -25,6 +25,7 @@
 #ifndef NO_ATOMIC_OPS
 
 // libatomic_ops implementation
+#define AO_REQUIRE_CAS
 #include <atomic_ops.h>
 
 // reinclude our assert to clobber the system one


### PR DESCRIPTION
 to fix FTBFS due to undeclared atomic functions.

As reported

```
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=748571
```

by John David Anglin dave.anglin@bell.net

```
./include/atomic.h: In member function 'size_t ceph::atomic_t::inc()':
./include/atomic.h:42:36: error: 'AO_fetch_and_add1' was not declared in this scope
       return AO_fetch_and_add1(&val) + 1;
                                    ^
./include/atomic.h: In member function 'size_t ceph::atomic_t::dec()':
./include/atomic.h:45:42: error: 'AO_fetch_and_sub1_write' was not declared in this scope
       return AO_fetch_and_sub1_write(&val) - 1;
                                          ^
./include/atomic.h: In member function 'void ceph::atomic_t::add(size_t)':
./include/atomic.h:48:36: error: 'AO_fetch_and_add' was not declared in this scope
       AO_fetch_and_add(&val, add_me);
                                    ^
./include/atomic.h: In member function 'void ceph::atomic_t::sub(int)':
./include/atomic.h:52:48: error: 'AO_fetch_and_add_write' was not declared in this scope
       AO_fetch_and_add_write(&val, (AO_t)negsub);
                                                ^
./include/atomic.h: In member function 'size_t ceph::atomic_t::dec()':
./include/atomic.h:46:5: warning: control reaches end of non-void function [-Wreturn-type]
     }
     ^
make[5]: *** [cls/user/cls_user_client.o] Error 1
```
