### PR TITLE
Avoid extra check for clean object

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1618,6 +1618,9 @@ bool ObjectCacher::flush_set(ObjectSet *oset, Context *onfinish)
        !i.end(); ++i) {
     Object *ob = *i;
 
+    if (ob->dirty_or_tx == 0)
+      continue;
+
     if (!flush(ob, 0, 0)) {
       // we'll need to gather...
       ldout(cct, 10) << "flush_set " << oset << " will wait for ack tid " 


### PR DESCRIPTION
We needn't to check clean object via buffer state, skip the clean object.

Signed-off-by: Haomai Wang haomaiwang@gmail.com
