### PR TITLE
mon: set MMonGetVersionReply tid

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3576,10 +3576,13 @@ void Monitor::handle_get_version(MMonGetVersion *m)
       svc->wait_for_readable(new C_RetryMessage(this, m));
       goto out;
     }
+
     MMonGetVersionReply *reply = new MMonGetVersionReply();
     reply->handle = m->handle;
     reply->version = svc->get_last_committed();
     reply->oldest_version = svc->get_first_committed();
+    reply->set_tid(m->get_tid());
+
     messenger->send_message(reply, m->get_source_inst());
   }
 


### PR DESCRIPTION
Currently we don't set MMonGetVersionReply tid even if the original
MMonGetVersion message had a non-zero tid.  This is bad for the kernel
client, which has the infrastructure in place that relies on tids to
lookup message buffers and contexts.  To kick off transitioning away
from the workaround, set MMonGetVersionReply tid to the tid of the
original MMonGetVersion message.

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
