### PR TITLE
cephfs-java: build against older jni headers

### DIFF
--- a/src/java/native/libcephfs_jni.cc
+++ b/src/java/native/libcephfs_jni.cc
@@ -2875,7 +2875,7 @@ jobject sockaddrToInetAddress(JNIEnv* env, const sockaddr_storage& ss, jint* por
         return NULL;
     }
     env->SetByteArrayRegion(byteArray.get(), 0, addressLength,
-            reinterpret_cast<const jbyte*>(rawAddress));
+			    reinterpret_cast<jbyte*>(const_cast<void*>(rawAddress)));
 
     if (ss.ss_family == AF_UNIX) {
         // Note that we get here for AF_UNIX sockets on accept(2). The unix(7) man page claims


### PR DESCRIPTION
Older versions of the JNI interface expected non-const parameters
to their memory move functions. It's unpleasant, but won't actually
change the memory in question, to do a cast_const in order to satisfy
those older headers. (And even if it _did_ modify the memory, that
would be okay given our single user.)

Signed-off-by: Greg Farnum greg@inktank.com
