### PR TITLE
rgw: check appropriate entity permission on put_metadata

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1889,8 +1889,13 @@ done:
 
 int RGWPutMetadata::verify_permission()
 {
-  if (!verify_object_permission(s, RGW_PERM_WRITE))
-    return -EACCES;
+  if (s->object) {
+    if (!verify_object_permission(s, RGW_PERM_WRITE))
+      return -EACCES;
+  } else {
+    if (!verify_bucket_permission(s, RGW_PERM_WRITE))
+      return -EACCES;
+  }
 
   return 0;
 }


### PR DESCRIPTION
Fixes: #8428
Backport: firefly

Cannot use verify_object_permission() to test acls, as the operation
here might either be on object or on bucket.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
