### PR TITLE
ceph-disk: Enable creating multiple osds per dev

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -953,8 +953,8 @@ def prepare_journal_dev(
     if journal == data:
         # we're sharing the disk between osd data and journal;
         # make journal be partition number 2, so it's pretty
-        num = 2
-        journal_part = '{num}:0:{size}M'.format(
+        num = get_free_partition_index(dev=journal)
+        journal_part = '{num}:+0:+{size}M'.format(
             num=num,
             size=journal_size,
             )
@@ -1157,6 +1157,7 @@ def prepare_dir(
 
 def prepare_dev(
     data,
+    data_size,
     journal,
     fstype,
     mkfs_args,
@@ -1190,19 +1191,41 @@ def prepare_dev(
     else:
         LOG.debug('Creating osd partition on %s', data)
         try:
-            command_check_call(
-                [
-                    'sgdisk',
-                    '--largest-new=1',
-                    '--change-name=1:ceph data',
-                    '--partition-guid=1:{osd_uuid}'.format(
-                        osd_uuid=osd_uuid,
-                        ),
-                    '--typecode=1:%s' % ptype_tobe,
-                    '--',
-                    data,
-                ],
-            )
+            if data_size is None:
+                num = 1
+                command_check_call(
+                    [
+                        'sgdisk',
+                        '--largest-new=1',
+                        '--change-name=1:ceph data',
+                        '--partition-guid=1:{osd_uuid}'.format(
+                            osd_uuid=osd_uuid,
+                            ),
+                        '--typecode=1:%s' % ptype_tobe,
+                        '--',
+                        data,
+                    ],
+                )
+            else:
+                num = get_free_partition_index(dev=data)
+                part = '{num}:+0:+{size}M'.format(
+                    num=num,
+                    size=data_size)
+                command_check_call(
+                    [
+                        'sgdisk',
+                        '--new={part}'.format(part=part),
+                        '--change-name={num}:ceph data'.format(num=num),
+                        '--partition-guid={num}:{osd_uuid}'.format(
+                            num=num,
+                            osd_uuid=osd_uuid,
+                            ),
+                        '--typecode={num}:{ptype}'.format(num=num, ptype=ptype_tobe),
+                        '--',
+                        data,
+                    ],
+                )
+
             command(
                 [
                     'partprobe',
@@ -1219,7 +1242,7 @@ def prepare_dev(
         except subprocess.CalledProcessError as e:
             raise Error(e)
 
-        rawdev = get_partition_dev(data, 1)
+        rawdev = get_partition_dev(data, num)
 
     dev = None
     if osd_dm_keypath:
@@ -1275,7 +1298,7 @@ def prepare_dev(
             command_check_call(
                 [
                     'sgdisk',
-                    '--typecode=1:%s' % ptype_osd,
+                    '--typecode={num}:{ptype}'.format(num=num, ptype=ptype_osd),
                     '--',
                     data,
                 ],
@@ -1366,6 +1389,11 @@ def main_prepare(args):
             )
         journal_size = int(journal_size)
 
+        if args.data_size is not None:
+            data_size = int(args.data_size)
+        else:
+            data_size = None
+
         # colocate journal with data?
         if stat.S_ISBLK(dmode) and not is_partition(args.data) and args.journal is None and args.journal_file is None:
             LOG.info('Will colocate journal with data on %s', args.data)
@@ -1409,6 +1437,7 @@ def main_prepare(args):
                 raise Error('data path is not a directory', args.data)
             prepare_dev(
                 data=args.data,
+                data_size=data_size,
                 journal=journal_symlink,
                 fstype=args.fs_type,
                 mkfs_args=mkfs_args,
@@ -2416,6 +2445,11 @@ def parse_args():
         metavar='KEYDIR',
         default='/etc/ceph/dmcrypt-keys',
         help='directory where dm-crypt keys are stored',
+        )
+    prepare_parser.add_argument(
+        '--data-size',
+        default=None,
+        help='size of data partition'
         )
     prepare_parser.add_argument(
         'data',


### PR DESCRIPTION
This is useful for demos and testing.  Enables
creation of lots of OSDs on a single block device
by simply running ceph-disk prepare more than once,
with a --data-size argument set.

Signed-off-by: John Spray john.spray@inktank.com
