### PR TITLE
rgw: reduce calls to rgw_obj.set_obj()

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1083,10 +1083,13 @@ public:
   }
 
   void set_obj(const string& o) {
+    object.reserve(128);
+
     orig_obj = o;
     if (ns.empty()) {
-      if (o.empty())
+      if (o.empty()) {
         return;
+      }
       if (o.size() < 1 || o[0] != '_') {
         object = o;
         return;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -393,11 +393,15 @@ public:
     }
     obj_iterator(RGWObjManifest *_m) : manifest(_m) {
       init();
-      seek(0);
+      if (!manifest->empty()) {
+        seek(0);
+      }
     }
     obj_iterator(RGWObjManifest *_m, uint64_t _ofs) : manifest(_m) {
       init();
-      seek(_ofs);
+      if (!manifest->empty()) {
+        seek(_ofs);
+      }
     }
     void seek(uint64_t ofs);
 
@@ -675,6 +679,31 @@ struct RGWObjState {
   RGWObjState() : is_atomic(false), has_attrs(0), exists(false),
                   size(0), mtime(0), epoch(0), fake_tag(false), has_manifest(false),
                   has_data(false), prefetch_data(false), keep_tail(false) {}
+  RGWObjState(const RGWObjState& rhs) {
+    is_atomic = rhs.is_atomic;
+    has_attrs = rhs.has_attrs;
+    exists = rhs.exists;
+    size = rhs.size;
+    mtime = rhs.mtime;
+    epoch = rhs.epoch;
+    if (rhs.obj_tag.length()) {
+      obj_tag = rhs.obj_tag;
+    }
+    write_tag = rhs.write_tag;
+    fake_tag = rhs.fake_tag;
+    if (rhs.has_manifest) {
+      manifest = rhs.manifest;
+    }
+    has_manifest = rhs.has_manifest;
+    shadow_obj = rhs.shadow_obj;
+    has_data = rhs.has_data;
+    if (rhs.data.length()) {
+      data = rhs.data;
+    }
+    prefetch_data = rhs.prefetch_data;
+    keep_tail = rhs.keep_tail;
+    objv_tracker = rhs.objv_tracker;
+  }
 
   bool get_attr(string name, bufferlist& dest) {
     map<string, bufferlist>::iterator iter = attrset.find(name);


### PR DESCRIPTION
This commit is part of the performance work that we're doing.

default manifest iterator construction did unneeded init of rgw_obj.
Also add a smarter copy constructor to RGWObjState that does not copy
manifest if not needed.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
