### PR TITLE
pybind/rados: Fix timeouts for small t

### DIFF
--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -159,7 +159,7 @@ def run_in_thread(target, args, timeout=0):
         # poll for thread exit
         while t.is_alive():
             t.join(POLL_TIME_INCR)
-            if timeout:
+            if timeout and t.is_alive():
                 countdown = countdown - POLL_TIME_INCR
                 if countdown <= 0:
                     raise KeyboardInterrupt


### PR DESCRIPTION
Previously, if passing a number less than 0.5 for
the timeout, operations would always return
a failure status code.

The same problem would also generate premature timeouts
for operations which completed within 0.5s of
their timeout deadline.

Fix the logic so that we only decrement `countdown`
if the thread has not completed when returning from join().

Signed-off-by: John Spray john.spray@inktank.com
