### PR TITLE
osd: fix bad is_active() assert in share_map()

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4770,7 +4770,8 @@ void OSDService::share_map(
 	   << name << " " << con->get_peer_addr()
 	   << " " << epoch << dendl;
 
-  assert(osd->is_active());
+  assert(osd->is_active() ||
+	 osd->is_stopping());
 
   bool want_shared = should_share_map(name, con, epoch,
                                       osdmap, sent_epoch_p);


### PR DESCRIPTION
We may be is_stopping() here if we are racing with shutdown().

Fixes: #8465 Backport: firefly, dumpling Signed-off-by: Sage Weil
sage@inktank.com
