### PR TITLE
msg_types.h: Don't use strncmp for comparing sockaddr_in.

### DIFF
--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -27,10 +27,10 @@ namespace ceph {
 }
 
 inline bool operator==(const sockaddr_in& a, const sockaddr_in& b) {
-  return strncmp((const char*)&a, (const char*)&b, sizeof(a)) == 0;
+  return memcmp((const char*)&a, (const char*)&b, sizeof(a)) == 0;
 }
 inline bool operator!=(const sockaddr_in& a, const sockaddr_in& b) {
-  return strncmp((const char*)&a, (const char*)&b, sizeof(a)) != 0;
+  return memcmp((const char*)&a, (const char*)&b, sizeof(a)) != 0;
 }
 
 extern ostream& operator<<(ostream& out, const sockaddr_storage &ss);


### PR DESCRIPTION
Fixes: #8472
Signed-off-by: Dan Mick dan.mick@inktank.com
