### PR TITLE
osdc/Objecter: flag ops that have been redirected

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -376,6 +376,7 @@ enum {
 						 */
 	CEPH_OSD_FLAG_ENFORCE_SNAPC    =0x100000,  /* use snapc provided even if
 						      pool uses pool snaps */
+	CEPH_OSD_FLAG_REDIRECTED   = 0x200000,  /* op has been redirected */
 };
 
 enum {

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -48,6 +48,7 @@ const char *ceph_osd_flag_name(unsigned flag)
   case CEPH_OSD_FLAG_FLUSH: return "flush";
   case CEPH_OSD_FLAG_MAP_SNAP_CLONE: return "map_snap_clone";
   case CEPH_OSD_FLAG_ENFORCE_SNAPC: return "enforce_snapc";
+  case CEPH_OSD_FLAG_REDIRECTED: return "redirected";
   default: return "???";
   }
 }

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1768,6 +1768,7 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     unregister_op(op);
     m->get_redirect().combine_with_locator(op->target.target_oloc,
 					   op->target.target_oid.name);
+    op->target.flags |= CEPH_OSD_FLAG_REDIRECTED;
     _op_submit(op);
     m->put();
     return;


### PR DESCRIPTION
In the future it may be helpful to know whether an op has been redirected by
the OSD.

We don't need it bad enough now to spend a feature bit to know whether this 
flag is reliably set.

Signed-off-by: Sage Weil sage@inktank.com
