### PR TITLE
msg: remove comparison operators for sockaddr_storage

### DIFF
--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -26,13 +26,6 @@ namespace ceph {
   class Formatter;
 }
 
-inline bool operator==(const sockaddr_in& a, const sockaddr_in& b) {
-  return memcmp((const char*)&a, (const char*)&b, sizeof(a)) == 0;
-}
-inline bool operator!=(const sockaddr_in& a, const sockaddr_in& b) {
-  return memcmp((const char*)&a, (const char*)&b, sizeof(a)) != 0;
-}
-
 extern ostream& operator<<(ostream& out, const sockaddr_storage &ss);
 
 class entity_name_t {


### PR DESCRIPTION
We don't need these at all, it turns out.

Signed-off-by: Sage Weil sage@inktank.com
