### PR TITLE
rgw: if extra data pool name is empty, use data pool name instead

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1688,7 +1688,8 @@ int RGWRados::open_bucket_data_ctx(rgw_bucket& bucket, librados::IoCtx& data_ctx
 
 int RGWRados::open_bucket_data_extra_ctx(rgw_bucket& bucket, librados::IoCtx& data_ctx)
 {
-  int r = open_bucket_pool_ctx(bucket.name, bucket.data_extra_pool, data_ctx);
+  string& pool = (!bucket.data_extra_pool.empty() ? bucket.data_extra_pool : bucket.data_pool);
+  int r = open_bucket_pool_ctx(bucket.name, pool, data_ctx);
   if (r < 0)
     return r;
 


### PR DESCRIPTION
Fixes: #8311
An empty pool name could be used as the extra data pool.

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
