### PR TITLE
librbd: clarify license header

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -6,7 +6,7 @@
  * Copyright (C) 2011 New Dream Network
  *
  * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public
+ * modify it under the terms of the GNU Lesser General Public
  * License version 2.1, as published by the Free Software
  * Foundation.	See file COPYING.
  *

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -6,7 +6,7 @@
  * Copyright (C) 2011 New Dream Network
  *
  * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public
+ * modify it under the terms of the GNU Lesser General Public
  * License version 2.1, as published by the Free Software
  * Foundation.	See file COPYING.
  *

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -6,7 +6,7 @@
  * Copyright (C) 2011 New Dream Network
  *
  * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public
+ * modify it under the terms of the GNU Lesser General Public
  * License version 2.1, as published by the Free Software
  * Foundation.	See file COPYING.
  *


### PR DESCRIPTION
These were meant to say LGPL, but a typo was propagated and it referred to
the non-existent GPL2.1, and also to COPYING which correctly indicated these
files were LGPL2.1.

Signed-off-by: Josh Durgin josh.durgin@inktank.com
