### PR TITLE
librados: simplify/fix rados_pool_list bounds checks

### DIFF
--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2058,10 +2058,10 @@ extern "C" int rados_pool_list(rados_t cluster, char *buf, size_t len)
   std::list<std::string>::const_iterator i = pools.begin();
   std::list<std::string>::const_iterator p_end = pools.end();
   for (; i != p_end; ++i) {
-    if (len == 0)
-      break;
     int rl = i->length() + 1;
-    strncat(b, i->c_str(), len - 2); // leave space for two NULLs
+    if (len < (unsigned)rl)
+      break;
+    strncat(b, i->c_str(), rl);
     needed += rl;
     len -= rl;
     b += rl;


### PR DESCRIPTION
We were not breaking out of the loop when we filled up the buffer unless we
happened to do so on a pool name boundary.  This means that len would roll
over (it was unsigned).  In my case, I was not able to reproduce anything
particularly bad since (I think) the strncpy was interpreting the large
unsigned value as signed, but in any case this fixes it, simplifies the
arithmetic, and adds a simple test.
- use a single 'rl' value for the amount of buffer space we want to
  consume
- use this to check that there is room and also as the strncat length
- rely on the initial memset to ensure that the trailing 0 is in place.

Fixes: #8447 Signed-off-by: Sage Weil sage@inktank.com
