### PR TITLE
Fix keyvaluestore fiemap bug

### DIFF
--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -1670,7 +1670,8 @@ int KeyValueStore::fiemap(coll_t cid, const ghobject_t& oid,
   map<uint64_t, uint64_t> m;
   for (vector<StripObjectMap::StripExtent>::iterator iter = extents.begin();
        iter != extents.end(); ++iter) {
-    m[iter->offset] = iter->len;
+    uint64_t off = iter->no * header.strip_size + iter->offset;
+    m[off] = iter->len;
   }
   ::encode(m, bl);
   return 0;


### PR DESCRIPTION
The result of fiemap is wrong and the offset get from
"StripObjectMap::file_to_extents" need to multiply by sequence number

Signed-off-by: Haomai Wang haomaiwang@gmail.com
