### PR TITLE
Populate AUTHORS and ChangeLog for a distributed package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,3 +66,8 @@ dist-hook:
 	  cd $(srcdir); \
 	  git log --format='%aN <%aE>' | sort -u >$(distdir)/AUTHORS; \
 	fi
+#	Generates ChangeLog from git
+	if test -d $(srcdir)/.git; then \
+	  cd $(srcdir); \
+	  git log --oneline --decorate --no-merges > $(distdir)/ChangeLog; \
+	fi


### PR DESCRIPTION
This set of commits add rule in the Makefile.am to use dist hook from automake to generate from the git history a list of contributors and the ChangeLog.

To test it:
   make dist
