### PR TITLE
automake: add dummy.cc to fix 'make tags'

### DIFF
--- a/src/common/dummy.cc
+++ b/src/common/dummy.cc
@@ -1,0 +1,20 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 Inktank, Inc
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+/*
+ * A dummy file with a .cc extension to make autotools link
+ * ceph_test_librbd_fsx with a C++ linker.  An approach w/o a physical
+ * dummy.cc recommended in 8.3.5 Libtool Convenience Libraries works,
+ * but breaks 'make tags' and friends.
+ */

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -639,8 +639,8 @@ ceph_test_librbd_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_librbd
 
 if LINUX
-ceph_test_librbd_fsx_SOURCES = test/librbd/fsx.c
-nodist_EXTRA_ceph_test_librbd_fsx_SOURCES = dummy.cc # force c++ linking
+# Force use of C++ linker with dummy.cc - LIBKRBD is a C++ library
+ceph_test_librbd_fsx_SOURCES = test/librbd/fsx.c common/dummy.cc
 ceph_test_librbd_fsx_LDADD = $(LIBKRBD) $(LIBRBD) $(LIBRADOS)
 ceph_test_librbd_fsx_CFLAGS = ${AM_CFLAGS} -Wno-format
 bin_DEBUGPROGRAMS += ceph_test_librbd_fsx


### PR DESCRIPTION
Commit 421e6c561704 ("test_librbd_fsx: add krbd mode support") added
a requirement for ceph_test_librbd_fsx to be linked with a C++ linker.
Implement it in a way that doesn't break 'make tags'.

Fixes: #8530
Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
