### PR TITLE
os: rename get_*() -> decode_*()

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -2166,7 +2166,7 @@ unsigned FileStore::_do_transaction(
     if (handle)
       handle->reset_tp_timeout();
 
-    int op = i.get_op();
+    int op = i.decode_op();
     int r = 0;
 
     _inject_failure();
@@ -2176,8 +2176,8 @@ unsigned FileStore::_do_transaction(
       break;
     case Transaction::OP_TOUCH:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	if (_check_replay_guard(cid, oid, spos) > 0)
 	  r = _touch(cid, oid);
       }
@@ -2185,13 +2185,13 @@ unsigned FileStore::_do_transaction(
       
     case Transaction::OP_WRITE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	uint64_t off = i.get_length();
-	uint64_t len = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	uint64_t off = i.decode_length();
+	uint64_t len = i.decode_length();
 	bool replica = i.get_replica();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	if (_check_replay_guard(cid, oid, spos) > 0)
 	  r = _write(cid, oid, off, len, bl, replica);
       }
@@ -2199,10 +2199,10 @@ unsigned FileStore::_do_transaction(
       
     case Transaction::OP_ZERO:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	uint64_t off = i.get_length();
-	uint64_t len = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	uint64_t off = i.decode_length();
+	uint64_t len = i.decode_length();
 	if (_check_replay_guard(cid, oid, spos) > 0)
 	  r = _zero(cid, oid, off, len);
       }
@@ -2210,19 +2210,19 @@ unsigned FileStore::_do_transaction(
       
     case Transaction::OP_TRIMCACHE:
       {
-	i.get_cid();
-	i.get_oid();
-	i.get_length();
-	i.get_length();
+	i.decode_cid();
+	i.decode_oid();
+	i.decode_length();
+	i.decode_length();
 	// deprecated, no-op
       }
       break;
       
     case Transaction::OP_TRUNCATE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	uint64_t off = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	uint64_t off = i.decode_length();
 	if (_check_replay_guard(cid, oid, spos) > 0)
 	  r = _truncate(cid, oid, off);
       }
@@ -2230,8 +2230,8 @@ unsigned FileStore::_do_transaction(
       
     case Transaction::OP_REMOVE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	if (_check_replay_guard(cid, oid, spos) > 0)
 	  r = _remove(cid, oid, spos);
       }
@@ -2239,11 +2239,11 @@ unsigned FileStore::_do_transaction(
       
     case Transaction::OP_SETATTR:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	string name = i.decode_attrname();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	if (_check_replay_guard(cid, oid, spos) > 0) {
 	  map<string, bufferptr> to_set;
 	  to_set[name] = bufferptr(bl.c_str(), bl.length());
@@ -2257,10 +2257,10 @@ unsigned FileStore::_do_transaction(
       
     case Transaction::OP_SETATTRS:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	map<string, bufferptr> aset;
-	i.get_attrset(aset);
+	i.decode_attrset(aset);
 	if (_check_replay_guard(cid, oid, spos) > 0)
 	  r = _setattrs(cid, oid, aset, spos);
   	if (r == -ENOSPC)
@@ -2270,9 +2270,9 @@ unsigned FileStore::_do_transaction(
 
     case Transaction::OP_RMATTR:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	string name = i.decode_attrname();
 	if (_check_replay_guard(cid, oid, spos) > 0)
 	  r = _rmattr(cid, oid, name.c_str(), spos);
       }
@@ -2280,8 +2280,8 @@ unsigned FileStore::_do_transaction(
 
     case Transaction::OP_RMATTRS:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	if (_check_replay_guard(cid, oid, spos) > 0)
 	  r = _rmattrs(cid, oid, spos);
       }
@@ -2289,39 +2289,39 @@ unsigned FileStore::_do_transaction(
       
     case Transaction::OP_CLONE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	ghobject_t noid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	ghobject_t noid = i.decode_oid();
 	r = _clone(cid, oid, noid, spos);
       }
       break;
 
     case Transaction::OP_CLONERANGE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	ghobject_t noid = i.get_oid();
- 	uint64_t off = i.get_length();
-	uint64_t len = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	ghobject_t noid = i.decode_oid();
+	uint64_t off = i.decode_length();
+	uint64_t len = i.decode_length();
 	r = _clone_range(cid, oid, noid, off, len, off, spos);
       }
       break;
 
     case Transaction::OP_CLONERANGE2:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	ghobject_t noid = i.get_oid();
- 	uint64_t srcoff = i.get_length();
-	uint64_t len = i.get_length();
- 	uint64_t dstoff = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	ghobject_t noid = i.decode_oid();
+	uint64_t srcoff = i.decode_length();
+	uint64_t len = i.decode_length();
+	uint64_t dstoff = i.decode_length();
 	r = _clone_range(cid, oid, noid, srcoff, len, dstoff, spos);
       }
       break;
 
     case Transaction::OP_MKCOLL:
       {
-	coll_t cid = i.get_cid();
+	coll_t cid = i.decode_cid();
 	if (_check_replay_guard(cid, spos) > 0)
 	  r = _create_collection(cid, spos);
       }
@@ -2329,7 +2329,7 @@ unsigned FileStore::_do_transaction(
 
     case Transaction::OP_RMCOLL:
       {
-	coll_t cid = i.get_cid();
+	coll_t cid = i.decode_cid();
 	if (_check_replay_guard(cid, spos) > 0)
 	  r = _destroy_collection(cid);
       }
@@ -2337,17 +2337,17 @@ unsigned FileStore::_do_transaction(
 
     case Transaction::OP_COLL_ADD:
       {
-	coll_t ncid = i.get_cid();
-	coll_t ocid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t ncid = i.decode_cid();
+	coll_t ocid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	r = _collection_add(ncid, ocid, oid, spos);
       }
       break;
 
     case Transaction::OP_COLL_REMOVE:
        {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	if (_check_replay_guard(cid, oid, spos) > 0)
 	  r = _remove(cid, oid, spos);
        }
@@ -2356,9 +2356,9 @@ unsigned FileStore::_do_transaction(
     case Transaction::OP_COLL_MOVE:
       {
 	// WARNING: this is deprecated and buggy; only here to replay old journals.
-	coll_t ocid = i.get_cid();
-	coll_t ncid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t ocid = i.decode_cid();
+	coll_t ncid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	r = _collection_add(ocid, ncid, oid, spos);
 	if (r == 0 &&
 	    (_check_replay_guard(ocid, oid, spos) > 0))
@@ -2368,20 +2368,20 @@ unsigned FileStore::_do_transaction(
 
     case Transaction::OP_COLL_MOVE_RENAME:
       {
-	coll_t oldcid = i.get_cid();
-	ghobject_t oldoid = i.get_oid();
-	coll_t newcid = i.get_cid();
-	ghobject_t newoid = i.get_oid();
+	coll_t oldcid = i.decode_cid();
+	ghobject_t oldoid = i.decode_oid();
+	coll_t newcid = i.decode_cid();
+	ghobject_t newoid = i.decode_oid();
 	r = _collection_move_rename(oldcid, oldoid, newcid, newoid, spos);
       }
       break;
 
     case Transaction::OP_COLL_SETATTR:
       {
-	coll_t cid = i.get_cid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	string name = i.decode_attrname();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	if (_check_replay_guard(cid, spos) > 0)
 	  r = _collection_setattr(cid, name.c_str(), bl.c_str(), bl.length());
       }
@@ -2389,8 +2389,8 @@ unsigned FileStore::_do_transaction(
 
     case Transaction::OP_COLL_RMATTR:
       {
-	coll_t cid = i.get_cid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	string name = i.decode_attrname();
 	if (_check_replay_guard(cid, spos) > 0)
 	  r = _collection_rmattr(cid, name.c_str());
       }
@@ -2402,81 +2402,81 @@ unsigned FileStore::_do_transaction(
 
     case Transaction::OP_COLL_RENAME:
       {
-	coll_t cid(i.get_cid());
-	coll_t ncid(i.get_cid());
+	coll_t cid(i.decode_cid());
+	coll_t ncid(i.decode_cid());
 	r = _collection_rename(cid, ncid, spos);
       }
       break;
 
     case Transaction::OP_OMAP_CLEAR:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	r = _omap_clear(cid, oid, spos);
       }
       break;
     case Transaction::OP_OMAP_SETKEYS:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	map<string, bufferlist> aset;
-	i.get_attrset(aset);
+	i.decode_attrset(aset);
 	r = _omap_setkeys(cid, oid, aset, spos);
       }
       break;
     case Transaction::OP_OMAP_RMKEYS:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	set<string> keys;
-	i.get_keyset(keys);
+	i.decode_keyset(keys);
 	r = _omap_rmkeys(cid, oid, keys, spos);
       }
       break;
     case Transaction::OP_OMAP_RMKEYRANGE:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	string first, last;
-	first = i.get_key();
-	last = i.get_key();
+	first = i.decode_key();
+	last = i.decode_key();
 	r = _omap_rmkeyrange(cid, oid, first, last, spos);
       }
       break;
     case Transaction::OP_OMAP_SETHEADER:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	r = _omap_setheader(cid, oid, bl, spos);
       }
       break;
     case Transaction::OP_SPLIT_COLLECTION:
       {
-	coll_t cid(i.get_cid());
-	uint32_t bits(i.get_u32());
-	uint32_t rem(i.get_u32());
-	coll_t dest(i.get_cid());
+	coll_t cid(i.decode_cid());
+	uint32_t bits(i.decode_u32());
+	uint32_t rem(i.decode_u32());
+	coll_t dest(i.decode_cid());
 	r = _split_collection_create(cid, bits, rem, dest, spos);
       }
       break;
     case Transaction::OP_SPLIT_COLLECTION2:
       {
-	coll_t cid(i.get_cid());
-	uint32_t bits(i.get_u32());
-	uint32_t rem(i.get_u32());
-	coll_t dest(i.get_cid());
+	coll_t cid(i.decode_cid());
+	uint32_t bits(i.decode_u32());
+	uint32_t rem(i.decode_u32());
+	coll_t dest(i.decode_cid());
 	r = _split_collection(cid, bits, rem, dest, spos);
       }
       break;
 
     case Transaction::OP_SETALLOCHINT:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
-        uint64_t expected_object_size = i.get_length();
-        uint64_t expected_write_size = i.get_length();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
+        uint64_t expected_object_size = i.decode_length();
+        uint64_t expected_write_size = i.decode_length();
         if (_check_replay_guard(cid, oid, spos) > 0)
           r = _set_alloc_hint(cid, oid, expected_object_size,
                               expected_write_size);

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -1158,7 +1158,7 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
     if (handle)
       handle->reset_tp_timeout();
 
-    int op = i.get_op();
+    int op = i.decode_op();
     int r = 0;
 
     switch (op) {
@@ -1167,69 +1167,69 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
 
     case Transaction::OP_TOUCH:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
         r = _touch(cid, oid, t);
       }
       break;
 
     case Transaction::OP_WRITE:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
-        uint64_t off = i.get_length();
-        uint64_t len = i.get_length();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
+        uint64_t off = i.decode_length();
+        uint64_t len = i.decode_length();
         bool replica = i.get_replica();
         bufferlist bl;
-        i.get_bl(bl);
+        i.decode_bl(bl);
         r = _write(cid, oid, off, len, bl, t, replica);
       }
       break;
 
     case Transaction::OP_ZERO:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
-        uint64_t off = i.get_length();
-        uint64_t len = i.get_length();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
+        uint64_t off = i.decode_length();
+        uint64_t len = i.decode_length();
         r = _zero(cid, oid, off, len, t);
       }
       break;
 
     case Transaction::OP_TRIMCACHE:
       {
-        i.get_cid();
-        i.get_oid();
-        i.get_length();
-        i.get_length();
+        i.decode_cid();
+        i.decode_oid();
+        i.decode_length();
+        i.decode_length();
         // deprecated, no-op
       }
       break;
 
     case Transaction::OP_TRUNCATE:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
-        uint64_t off = i.get_length();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
+        uint64_t off = i.decode_length();
         r = _truncate(cid, oid, off, t);
       }
       break;
 
     case Transaction::OP_REMOVE:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
         r = _remove(cid, oid, t);
       }
       break;
 
     case Transaction::OP_SETATTR:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
-        string name = i.get_attrname();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
+        string name = i.decode_attrname();
         bufferlist bl;
-        i.get_bl(bl);
+        i.decode_bl(bl);
         map<string, bufferptr> to_set;
         to_set[name] = bufferptr(bl.c_str(), bl.length());
         r = _setattrs(cid, oid, to_set, t);
@@ -1241,10 +1241,10 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
 
     case Transaction::OP_SETATTRS:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
         map<string, bufferptr> aset;
-        i.get_attrset(aset);
+        i.decode_attrset(aset);
         r = _setattrs(cid, oid, aset, t);
         if (r == -ENOSPC)
           dout(0) << " ENOSPC on setxattrs on " << cid << "/" << oid << dendl;
@@ -1253,80 +1253,80 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
 
     case Transaction::OP_RMATTR:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
-        string name = i.get_attrname();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
+        string name = i.decode_attrname();
         r = _rmattr(cid, oid, name.c_str(), t);
       }
       break;
 
     case Transaction::OP_RMATTRS:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
         r = _rmattrs(cid, oid, t);
       }
       break;
 
     case Transaction::OP_CLONE:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
-        ghobject_t noid = i.get_oid();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
+        ghobject_t noid = i.decode_oid();
         r = _clone(cid, oid, noid, t);
       }
       break;
 
     case Transaction::OP_CLONERANGE:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
-        ghobject_t noid = i.get_oid();
-        uint64_t off = i.get_length();
-        uint64_t len = i.get_length();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
+        ghobject_t noid = i.decode_oid();
+        uint64_t off = i.decode_length();
+        uint64_t len = i.decode_length();
         r = _clone_range(cid, oid, noid, off, len, off, t);
       }
       break;
 
     case Transaction::OP_CLONERANGE2:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
-        ghobject_t noid = i.get_oid();
-        uint64_t srcoff = i.get_length();
-        uint64_t len = i.get_length();
-        uint64_t dstoff = i.get_length();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
+        ghobject_t noid = i.decode_oid();
+        uint64_t srcoff = i.decode_length();
+        uint64_t len = i.decode_length();
+        uint64_t dstoff = i.decode_length();
         r = _clone_range(cid, oid, noid, srcoff, len, dstoff, t);
       }
       break;
 
     case Transaction::OP_MKCOLL:
       {
-        coll_t cid = i.get_cid();
+        coll_t cid = i.decode_cid();
         r = _create_collection(cid, t);
       }
       break;
 
     case Transaction::OP_RMCOLL:
       {
-        coll_t cid = i.get_cid();
+        coll_t cid = i.decode_cid();
         r = _destroy_collection(cid, t);
       }
       break;
 
     case Transaction::OP_COLL_ADD:
       {
-        coll_t ncid = i.get_cid();
-        coll_t ocid = i.get_cid();
-        ghobject_t oid = i.get_oid();
+        coll_t ncid = i.decode_cid();
+        coll_t ocid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
         r = _collection_add(ncid, ocid, oid, t);
       }
       break;
 
     case Transaction::OP_COLL_REMOVE:
        {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
         r = _remove(cid, oid, t);
        }
       break;
@@ -1334,37 +1334,37 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
     case Transaction::OP_COLL_MOVE:
       {
         // WARNING: this is deprecated and buggy; only here to replay old journals.
-        coll_t ocid = i.get_cid();
-        coll_t ncid = i.get_cid();
-        ghobject_t oid = i.get_oid();
+        coll_t ocid = i.decode_cid();
+        coll_t ncid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
         r = _collection_move_rename(ocid, oid, ncid, oid, t);
       }
       break;
 
     case Transaction::OP_COLL_MOVE_RENAME:
       {
-        coll_t oldcid = i.get_cid();
-        ghobject_t oldoid = i.get_oid();
-        coll_t newcid = i.get_cid();
-        ghobject_t newoid = i.get_oid();
+        coll_t oldcid = i.decode_cid();
+        ghobject_t oldoid = i.decode_oid();
+        coll_t newcid = i.decode_cid();
+        ghobject_t newoid = i.decode_oid();
         r = _collection_move_rename(oldcid, oldoid, newcid, newoid, t);
       }
       break;
 
     case Transaction::OP_COLL_SETATTR:
       {
-        coll_t cid = i.get_cid();
-        string name = i.get_attrname();
+        coll_t cid = i.decode_cid();
+        string name = i.decode_attrname();
         bufferlist bl;
-        i.get_bl(bl);
+        i.decode_bl(bl);
         r = _collection_setattr(cid, name.c_str(), bl.c_str(), bl.length(), t);
       }
       break;
 
     case Transaction::OP_COLL_RMATTR:
       {
-        coll_t cid = i.get_cid();
-        string name = i.get_attrname();
+        coll_t cid = i.decode_cid();
+        string name = i.decode_attrname();
         r = _collection_rmattr(cid, name.c_str(), t);
       }
       break;
@@ -1377,71 +1377,71 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
 
     case Transaction::OP_COLL_RENAME:
       {
-        coll_t cid(i.get_cid());
-        coll_t ncid(i.get_cid());
+        coll_t cid(i.decode_cid());
+        coll_t ncid(i.decode_cid());
         r = _collection_rename(cid, ncid, t);
       }
       break;
 
     case Transaction::OP_OMAP_CLEAR:
       {
-        coll_t cid(i.get_cid());
-        ghobject_t oid = i.get_oid();
+        coll_t cid(i.decode_cid());
+        ghobject_t oid = i.decode_oid();
         r = _omap_clear(cid, oid, t);
       }
       break;
     case Transaction::OP_OMAP_SETKEYS:
       {
-        coll_t cid(i.get_cid());
-        ghobject_t oid = i.get_oid();
+        coll_t cid(i.decode_cid());
+        ghobject_t oid = i.decode_oid();
         map<string, bufferlist> aset;
-        i.get_attrset(aset);
+        i.decode_attrset(aset);
         r = _omap_setkeys(cid, oid, aset, t);
       }
       break;
     case Transaction::OP_OMAP_RMKEYS:
       {
-        coll_t cid(i.get_cid());
-        ghobject_t oid = i.get_oid();
+        coll_t cid(i.decode_cid());
+        ghobject_t oid = i.decode_oid();
         set<string> keys;
-        i.get_keyset(keys);
+        i.decode_keyset(keys);
         r = _omap_rmkeys(cid, oid, keys, t);
       }
       break;
     case Transaction::OP_OMAP_RMKEYRANGE:
       {
-        coll_t cid(i.get_cid());
-        ghobject_t oid = i.get_oid();
+        coll_t cid(i.decode_cid());
+        ghobject_t oid = i.decode_oid();
         string first, last;
-        first = i.get_key();
-        last = i.get_key();
+        first = i.decode_key();
+        last = i.decode_key();
         r = _omap_rmkeyrange(cid, oid, first, last, t);
       }
       break;
     case Transaction::OP_OMAP_SETHEADER:
       {
-        coll_t cid(i.get_cid());
-        ghobject_t oid = i.get_oid();
+        coll_t cid(i.decode_cid());
+        ghobject_t oid = i.decode_oid();
         bufferlist bl;
-        i.get_bl(bl);
+        i.decode_bl(bl);
         r = _omap_setheader(cid, oid, bl, t);
       }
       break;
     case Transaction::OP_SPLIT_COLLECTION:
       {
-        coll_t cid(i.get_cid());
-        uint32_t bits(i.get_u32());
-        uint32_t rem(i.get_u32());
-        coll_t dest(i.get_cid());
+        coll_t cid(i.decode_cid());
+        uint32_t bits(i.decode_u32());
+        uint32_t rem(i.decode_u32());
+        coll_t dest(i.decode_cid());
         r = _split_collection_create(cid, bits, rem, dest, t);
       }
       break;
     case Transaction::OP_SPLIT_COLLECTION2:
       {
-        coll_t cid(i.get_cid());
-        uint32_t bits(i.get_u32());
-        uint32_t rem(i.get_u32());
-        coll_t dest(i.get_cid());
+        coll_t cid(i.decode_cid());
+        uint32_t bits(i.decode_u32());
+        uint32_t rem(i.decode_u32());
+        coll_t dest(i.decode_cid());
         r = _split_collection(cid, bits, rem, dest, t);
       }
       break;
@@ -1449,10 +1449,10 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
     case Transaction::OP_SETALLOCHINT:
       {
         // TODO: can kvstore make use of the hint?
-        coll_t cid(i.get_cid());
-        ghobject_t oid = i.get_oid();
-        i.get_length(); // uint64_t expected_object_size
-        i.get_length(); // uint64_t expected_write_size
+        coll_t cid(i.decode_cid());
+        ghobject_t oid = i.decode_oid();
+        i.decode_length(); // uint64_t expected_object_size
+        i.decode_length(); // uint64_t expected_write_size
       }
       break;
 

--- a/src/os/MemStore.cc
+++ b/src/os/MemStore.cc
@@ -685,7 +685,7 @@ void MemStore::_do_transaction(Transaction& t)
   int pos = 0;
 
   while (i.have_op()) {
-    int op = i.get_op();
+    int op = i.decode_op();
     int r = 0;
 
     switch (op) {
@@ -693,69 +693,69 @@ void MemStore::_do_transaction(Transaction& t)
       break;
     case Transaction::OP_TOUCH:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	r = _touch(cid, oid);
       }
       break;
       
     case Transaction::OP_WRITE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	uint64_t off = i.get_length();
-	uint64_t len = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	uint64_t off = i.decode_length();
+	uint64_t len = i.decode_length();
 	bool replica = i.get_replica();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	r = _write(cid, oid, off, len, bl, replica);
       }
       break;
       
     case Transaction::OP_ZERO:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	uint64_t off = i.get_length();
-	uint64_t len = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	uint64_t off = i.decode_length();
+	uint64_t len = i.decode_length();
 	r = _zero(cid, oid, off, len);
       }
       break;
       
     case Transaction::OP_TRIMCACHE:
       {
-	i.get_cid();
-	i.get_oid();
-	i.get_length();
-	i.get_length();
+	i.decode_cid();
+	i.decode_oid();
+	i.decode_length();
+	i.decode_length();
 	// deprecated, no-op
       }
       break;
       
     case Transaction::OP_TRUNCATE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	uint64_t off = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	uint64_t off = i.decode_length();
 	r = _truncate(cid, oid, off);
       }
       break;
       
     case Transaction::OP_REMOVE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	r = _remove(cid, oid);
       }
       break;
       
     case Transaction::OP_SETATTR:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	string name = i.decode_attrname();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	map<string, bufferptr> to_set;
 	to_set[name] = bufferptr(bl.c_str(), bl.length());
 	r = _setattrs(cid, oid, to_set);
@@ -764,90 +764,90 @@ void MemStore::_do_transaction(Transaction& t)
       
     case Transaction::OP_SETATTRS:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	map<string, bufferptr> aset;
-	i.get_attrset(aset);
+	i.decode_attrset(aset);
 	r = _setattrs(cid, oid, aset);
       }
       break;
 
     case Transaction::OP_RMATTR:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	string name = i.decode_attrname();
 	r = _rmattr(cid, oid, name.c_str());
       }
       break;
 
     case Transaction::OP_RMATTRS:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	r = _rmattrs(cid, oid);
       }
       break;
       
     case Transaction::OP_CLONE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	ghobject_t noid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	ghobject_t noid = i.decode_oid();
 	r = _clone(cid, oid, noid);
       }
       break;
 
     case Transaction::OP_CLONERANGE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	ghobject_t noid = i.get_oid();
- 	uint64_t off = i.get_length();
-	uint64_t len = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	ghobject_t noid = i.decode_oid();
+	uint64_t off = i.decode_length();
+	uint64_t len = i.decode_length();
 	r = _clone_range(cid, oid, noid, off, len, off);
       }
       break;
 
     case Transaction::OP_CLONERANGE2:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	ghobject_t noid = i.get_oid();
- 	uint64_t srcoff = i.get_length();
-	uint64_t len = i.get_length();
- 	uint64_t dstoff = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	ghobject_t noid = i.decode_oid();
+	uint64_t srcoff = i.decode_length();
+	uint64_t len = i.decode_length();
+	uint64_t dstoff = i.decode_length();
 	r = _clone_range(cid, oid, noid, srcoff, len, dstoff);
       }
       break;
 
     case Transaction::OP_MKCOLL:
       {
-	coll_t cid = i.get_cid();
+	coll_t cid = i.decode_cid();
 	r = _create_collection(cid);
       }
       break;
 
     case Transaction::OP_RMCOLL:
       {
-	coll_t cid = i.get_cid();
+	coll_t cid = i.decode_cid();
 	r = _destroy_collection(cid);
       }
       break;
 
     case Transaction::OP_COLL_ADD:
       {
-	coll_t ncid = i.get_cid();
-	coll_t ocid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t ncid = i.decode_cid();
+	coll_t ocid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	r = _collection_add(ncid, ocid, oid);
       }
       break;
 
     case Transaction::OP_COLL_REMOVE:
        {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	r = _remove(cid, oid);
        }
       break;
@@ -858,81 +858,81 @@ void MemStore::_do_transaction(Transaction& t)
 
     case Transaction::OP_COLL_MOVE_RENAME:
       {
-	coll_t oldcid = i.get_cid();
-	ghobject_t oldoid = i.get_oid();
-	coll_t newcid = i.get_cid();
-	ghobject_t newoid = i.get_oid();
+	coll_t oldcid = i.decode_cid();
+	ghobject_t oldoid = i.decode_oid();
+	coll_t newcid = i.decode_cid();
+	ghobject_t newoid = i.decode_oid();
 	r = _collection_move_rename(oldcid, oldoid, newcid, newoid);
       }
       break;
 
     case Transaction::OP_COLL_SETATTR:
       {
-	coll_t cid = i.get_cid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	string name = i.decode_attrname();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	r = _collection_setattr(cid, name.c_str(), bl.c_str(), bl.length());
       }
       break;
 
     case Transaction::OP_COLL_RMATTR:
       {
-	coll_t cid = i.get_cid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	string name = i.decode_attrname();
 	r = _collection_rmattr(cid, name.c_str());
       }
       break;
 
     case Transaction::OP_COLL_RENAME:
       {
-	coll_t cid(i.get_cid());
-	coll_t ncid(i.get_cid());
+	coll_t cid(i.decode_cid());
+	coll_t ncid(i.decode_cid());
 	r = _collection_rename(cid, ncid);
       }
       break;
 
     case Transaction::OP_OMAP_CLEAR:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	r = _omap_clear(cid, oid);
       }
       break;
     case Transaction::OP_OMAP_SETKEYS:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	map<string, bufferlist> aset;
-	i.get_attrset(aset);
+	i.decode_attrset(aset);
 	r = _omap_setkeys(cid, oid, aset);
       }
       break;
     case Transaction::OP_OMAP_RMKEYS:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	set<string> keys;
-	i.get_keyset(keys);
+	i.decode_keyset(keys);
 	r = _omap_rmkeys(cid, oid, keys);
       }
       break;
     case Transaction::OP_OMAP_RMKEYRANGE:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	string first, last;
-	first = i.get_key();
-	last = i.get_key();
+	first = i.decode_key();
+	last = i.decode_key();
 	r = _omap_rmkeyrange(cid, oid, first, last);
       }
       break;
     case Transaction::OP_OMAP_SETHEADER:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	r = _omap_setheader(cid, oid, bl);
       }
       break;
@@ -941,20 +941,20 @@ void MemStore::_do_transaction(Transaction& t)
       break;
     case Transaction::OP_SPLIT_COLLECTION2:
       {
-	coll_t cid(i.get_cid());
-	uint32_t bits(i.get_u32());
-	uint32_t rem(i.get_u32());
-	coll_t dest(i.get_cid());
+	coll_t cid(i.decode_cid());
+	uint32_t bits(i.decode_u32());
+	uint32_t rem(i.decode_u32());
+	coll_t dest(i.decode_cid());
 	r = _split_collection(cid, bits, rem, dest);
       }
       break;
 
     case Transaction::OP_SETALLOCHINT:
       {
-        coll_t cid(i.get_cid());
-        ghobject_t oid = i.get_oid();
-        i.get_length(); // uint64_t expected_object_size
-        i.get_length(); // uint64_t expected_write_size
+        coll_t cid(i.decode_cid());
+        ghobject_t oid = i.decode_oid();
+        i.decode_length(); // uint64_t expected_object_size
+        i.decode_length(); // uint64_t expected_write_size
       }
       break;
 

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -119,7 +119,7 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
   int op_num = 0;
   bool stop_looping = false;
   while (i.have_op() && !stop_looping) {
-    int op = i.get_op();
+    int op = i.decode_op();
     f->open_object_section("op");
     f->dump_int("op_num", op_num);
 
@@ -129,8 +129,8 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
       break;
     case Transaction::OP_TOUCH:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	f->dump_string("op_name", "touch");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -139,12 +139,12 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
       
     case Transaction::OP_WRITE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	uint64_t off = i.get_length();
-	uint64_t len = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	uint64_t off = i.decode_length();
+	uint64_t len = i.decode_length();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	f->dump_string("op_name", "write");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -156,10 +156,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
       
     case Transaction::OP_ZERO:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	uint64_t off = i.get_length();
-	uint64_t len = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	uint64_t off = i.decode_length();
+	uint64_t len = i.decode_length();
 	f->dump_string("op_name", "zero");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -170,10 +170,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
       
     case Transaction::OP_TRIMCACHE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	uint64_t off = i.get_length();
-	uint64_t len = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	uint64_t off = i.decode_length();
+	uint64_t len = i.decode_length();
 	f->dump_string("op_name", "trim_cache");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -184,9 +184,9 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
       
     case Transaction::OP_TRUNCATE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	uint64_t off = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	uint64_t off = i.decode_length();
 	f->dump_string("op_name", "truncate");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -196,8 +196,8 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
       
     case Transaction::OP_REMOVE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	f->dump_string("op_name", "remove");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -206,11 +206,11 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
       
     case Transaction::OP_SETATTR:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	string name = i.decode_attrname();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	f->dump_string("op_name", "setattr");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -221,10 +221,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
       
     case Transaction::OP_SETATTRS:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	map<string, bufferptr> aset;
-	i.get_attrset(aset);
+	i.decode_attrset(aset);
 	f->dump_string("op_name", "setattrs");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -239,9 +239,9 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_RMATTR:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	string name = i.decode_attrname();
 	f->dump_string("op_name", "rmattr");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -251,8 +251,8 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_RMATTRS:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	f->dump_string("op_name", "rmattrs");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -261,9 +261,9 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
       
     case Transaction::OP_CLONE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	ghobject_t noid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	ghobject_t noid = i.decode_oid();
 	f->dump_string("op_name", "clone");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("src_oid") << oid;
@@ -273,11 +273,11 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_CLONERANGE:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	ghobject_t noid = i.get_oid();
- 	uint64_t off = i.get_length();
-	uint64_t len = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	ghobject_t noid = i.decode_oid();
+	uint64_t off = i.decode_length();
+	uint64_t len = i.decode_length();
 	f->dump_string("op_name", "clonerange");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("src_oid") << oid;
@@ -289,12 +289,12 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_CLONERANGE2:
       {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
-	ghobject_t noid = i.get_oid();
- 	uint64_t srcoff = i.get_length();
-	uint64_t len = i.get_length();
- 	uint64_t dstoff = i.get_length();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
+	ghobject_t noid = i.decode_oid();
+	uint64_t srcoff = i.decode_length();
+	uint64_t len = i.decode_length();
+	uint64_t dstoff = i.decode_length();
 	f->dump_string("op_name", "clonerange2");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("src_oid") << oid;
@@ -307,7 +307,7 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_MKCOLL:
       {
-	coll_t cid = i.get_cid();
+	coll_t cid = i.decode_cid();
 	f->dump_string("op_name", "mkcoll");
 	f->dump_stream("collection") << cid;
       }
@@ -315,7 +315,7 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_RMCOLL:
       {
-	coll_t cid = i.get_cid();
+	coll_t cid = i.decode_cid();
 	f->dump_string("op_name", "rmcoll");
 	f->dump_stream("collection") << cid;
       }
@@ -323,9 +323,9 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_COLL_ADD:
       {
-	coll_t ncid = i.get_cid();
-	coll_t ocid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t ncid = i.decode_cid();
+	coll_t ocid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	f->dump_string("op_name", "collection_add");
 	f->dump_stream("src_collection") << ocid;
 	f->dump_stream("dst_collection") << ncid;
@@ -335,8 +335,8 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_COLL_REMOVE:
        {
-	coll_t cid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t cid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	f->dump_string("op_name", "collection_remove");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -345,9 +345,9 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_COLL_MOVE:
        {
-	coll_t ocid = i.get_cid();
-	coll_t ncid = i.get_cid();
-	ghobject_t oid = i.get_oid();
+	coll_t ocid = i.decode_cid();
+	coll_t ncid = i.decode_cid();
+	ghobject_t oid = i.decode_oid();
 	f->open_object_section("collection_move");
 	f->dump_stream("src_collection") << ocid;
 	f->dump_stream("dst_collection") << ncid;
@@ -359,10 +359,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_COLL_SETATTR:
       {
-	coll_t cid = i.get_cid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	string name = i.decode_attrname();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	f->dump_string("op_name", "collection_setattr");
 	f->dump_stream("collection") << cid;
 	f->dump_string("name", name);
@@ -372,8 +372,8 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_COLL_RMATTR:
       {
-	coll_t cid = i.get_cid();
-	string name = i.get_attrname();
+	coll_t cid = i.decode_cid();
+	string name = i.decode_attrname();
 	f->dump_string("op_name", "collection_rmattr");
 	f->dump_stream("collection") << cid;
 	f->dump_string("name", name);
@@ -386,8 +386,8 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_COLL_RENAME:
       {
-	coll_t cid(i.get_cid());
-	coll_t ncid(i.get_cid());
+	coll_t cid(i.decode_cid());
+	coll_t ncid(i.decode_cid());
 	f->dump_string("op_name", "collection_rename");
 	f->dump_stream("src_collection") << cid;
 	f->dump_stream("dst_collection") << ncid;
@@ -396,8 +396,8 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_OMAP_CLEAR:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	f->dump_string("op_name", "omap_clear");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -406,10 +406,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_OMAP_SETKEYS:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	map<string, bufferlist> aset;
-	i.get_attrset(aset);
+	i.decode_attrset(aset);
 	f->dump_string("op_name", "omap_setkeys");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -424,10 +424,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_OMAP_RMKEYS:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	set<string> keys;
-	i.get_keyset(keys);
+	i.decode_keyset(keys);
 	f->dump_string("op_name", "omap_rmkeys");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -436,10 +436,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_OMAP_SETHEADER:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	bufferlist bl;
-	i.get_bl(bl);
+	i.decode_bl(bl);
 	f->dump_string("op_name", "omap_setheader");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -449,10 +449,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_SPLIT_COLLECTION:
       {
-	coll_t cid(i.get_cid());
-	uint32_t bits(i.get_u32());
-	uint32_t rem(i.get_u32());
-	coll_t dest(i.get_cid());
+	coll_t cid(i.decode_cid());
+	uint32_t bits(i.decode_u32());
+	uint32_t rem(i.decode_u32());
+	coll_t dest(i.decode_cid());
 	f->dump_string("op_name", "op_split_collection_create");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("bits") << bits;
@@ -463,10 +463,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_SPLIT_COLLECTION2:
       {
-	coll_t cid(i.get_cid());
-	uint32_t bits(i.get_u32());
-	uint32_t rem(i.get_u32());
-	coll_t dest(i.get_cid());
+	coll_t cid(i.decode_cid());
+	uint32_t bits(i.decode_u32());
+	uint32_t rem(i.decode_u32());
+	coll_t dest(i.decode_cid());
 	f->dump_string("op_name", "op_split_collection");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("bits") << bits;
@@ -477,11 +477,11 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_OMAP_RMKEYRANGE:
       {
-	coll_t cid(i.get_cid());
-	ghobject_t oid = i.get_oid();
+	coll_t cid(i.decode_cid());
+	ghobject_t oid = i.decode_oid();
 	string first, last;
-	first = i.get_key();
-	last = i.get_key();
+	first = i.decode_key();
+	last = i.decode_key();
 	f->dump_string("op_name", "op_omap_rmkeyrange");
 	f->dump_stream("collection") << cid;
 	f->dump_stream("oid") << oid;
@@ -492,10 +492,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_COLL_MOVE_RENAME:
       {
-	coll_t old_cid(i.get_cid());
-	ghobject_t old_oid = i.get_oid();
-	coll_t new_cid(i.get_cid());
-	ghobject_t new_oid = i.get_oid();
+	coll_t old_cid(i.decode_cid());
+	ghobject_t old_oid = i.decode_oid();
+	coll_t new_cid(i.decode_cid());
+	ghobject_t new_oid = i.decode_oid();
 	f->dump_string("op_name", "op_coll_move_rename");
 	f->dump_stream("old_collection") << old_cid;
 	f->dump_stream("old_oid") << old_oid;
@@ -506,10 +506,10 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
 
     case Transaction::OP_SETALLOCHINT:
       {
-        coll_t cid = i.get_cid();
-        ghobject_t oid = i.get_oid();
-        uint64_t expected_object_size = i.get_length();
-        uint64_t expected_write_size = i.get_length();
+        coll_t cid = i.decode_cid();
+        ghobject_t oid = i.decode_oid();
+        uint64_t expected_object_size = i.decode_length();
+        uint64_t expected_write_size = i.decode_length();
         f->dump_string("op_name", "op_setallochint");
         f->dump_stream("collection") << cid;
         f->dump_stream("oid") << oid;

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -537,16 +537,16 @@ public:
        * stream. There is no checking that the encoded data is of the
        * correct type.
        */
-      int get_op() {
+      int decode_op() {
 	__u32 op;
 	::decode(op, p);
 	return op;
       }
-      void get_bl(bufferlist& bl) {
+      void decode_bl(bufferlist& bl) {
 	::decode(bl, p);
       }
       /// Get an oid, recognize various legacy forms and update them.
-      ghobject_t get_oid() {
+      ghobject_t decode_oid() {
 	ghobject_t oid;
 	if (sobject_encoding) {
 	  sobject_t soid;
@@ -564,36 +564,36 @@ public:
 	}
 	return oid;
       }
-      coll_t get_cid() {
+      coll_t decode_cid() {
 	coll_t c;
 	::decode(c, p);
 	return c;
       }
-      uint64_t get_length() {
+      uint64_t decode_length() {
 	uint64_t len;
 	::decode(len, p);
 	return len;
       }
-      string get_attrname() {
+      string decode_attrname() {
 	string s;
 	::decode(s, p);
 	return s;
       }
-      string get_key() {
+      string decode_key() {
 	string s;
 	::decode(s, p);
 	return s;
       }
-      void get_attrset(map<string,bufferptr>& aset) {
+      void decode_attrset(map<string,bufferptr>& aset) {
 	::decode(aset, p);
       }
-      void get_attrset(map<string,bufferlist>& aset) {
+      void decode_attrset(map<string,bufferlist>& aset) {
 	::decode(aset, p);
       }
-      void get_keyset(set<string> &keys) {
+      void decode_keyset(set<string> &keys) {
 	::decode(keys, p);
       }
-      uint32_t get_u32() {
+      uint32_t decode_u32() {
 	uint32_t bits;
 	::decode(bits, p);
 	return bits;


### PR DESCRIPTION
These methods have side-effects: they move the decode iterator _and_ return a
value.  Rename them to avoid confusion with typical get_\* accessors.

Signed-off-by: Sage Weil sage@inktank.com
