### PR TITLE
ceph-objectstore-test: fix warning in collect_metadata test

### DIFF
--- a/src/include/atomic.h
+++ b/src/include/atomic.h
@@ -122,7 +122,7 @@ namespace ceph {
 #if SIZEOF_AO_T == 8
   typedef atomic_t atomic64_t;
 #else
-  typedef atomic_spinlock_t<long long> atomic64_t;
+  typedef atomic_spinlock_t<unsigned long long> atomic64_t;
 #endif
 
 }


### PR DESCRIPTION
In file included from test/objectstore/store_test.cc:33:0:
../src/gtest/include/gtest/gtest.h: In function ‘testing::AssertionResult
testing::internal::CmpHelperNE(const char_, const char_, const T1&, const
T2&) [with T1 = long unsigned int, T2 = int]’: 
test/objectstore/store_test.cc:82:5: instantiated from here warning:
../src/gtest/include/gtest/gtest.h:1379:1: comparison between signed and
unsigned integer expressions [-Wsign-compare]

Signed-off-by: Sage Weil sage@inktank.com
