### PR TITLE
osdc/Objecter: mark all ops as known-if-redirected

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -377,6 +377,7 @@ enum {
 	CEPH_OSD_FLAG_ENFORCE_SNAPC    =0x100000,  /* use snapc provided even if
 						      pool uses pool snaps */
 	CEPH_OSD_FLAG_REDIRECTED   = 0x200000,  /* op has been redirected */
+	CEPH_OSD_FLAG_KNOWN_REDIR = 0x400000,  /* redirect bit is authoritative */
 };
 
 enum {

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -49,6 +49,7 @@ const char *ceph_osd_flag_name(unsigned flag)
   case CEPH_OSD_FLAG_MAP_SNAP_CLONE: return "map_snap_clone";
   case CEPH_OSD_FLAG_ENFORCE_SNAPC: return "enforce_snapc";
   case CEPH_OSD_FLAG_REDIRECTED: return "redirected";
+  case CEPH_OSD_FLAG_KNOWN_REDIR: return "known_if_redirected";
   default: return "???";
   }
 }

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1625,6 +1625,7 @@ void Objecter::send_op(Op *op)
   ldout(cct, 15) << "send_op " << op->tid << " to osd." << op->session->osd << dendl;
 
   int flags = op->target.flags;
+  flags |= CEPH_OSD_FLAG_KNOWN_REDIR;
   if (op->oncommit)
     flags |= CEPH_OSD_FLAG_ONDISK;
   if (op->onack)


### PR DESCRIPTION
This is 100% untested, but if we're going to mark redirected flags, we need to know if the lack of that flag is definitive. Add such a flag now, so that we can use redirect flags authoritatively in the future without requiring a new client.

(The kernel client will require a similar flag, but it doesn't have the redirect marker at all yet.)
