### PR TITLE
init-ceph: continue after failure doing osd data mount

### DIFF
--- a/src/ceph_common.sh
+++ b/src/ceph_common.sh
@@ -137,6 +137,24 @@ do_root_cmd() {
     fi
 }
 
+do_root_cmd_okfail() {
+    ERR=0
+    if [ -z "$ssh" ]; then
+	[ $verbose -eq 1 ] && echo "--- $host# $1"
+	ulimit -c unlimited
+	whoami=`whoami`
+	if [ "$whoami" = "root" ]; then
+	    bash -c "$1" || { [ -z "$3" ] && echo "failed: '$1'" && ERR=1 && return 1; }
+	else
+	    sudo bash -c "$1" || { [ -z "$3" ] && echo "failed: '$1'" && ERR=1 && return 1; }
+	fi
+    else
+	[ $verbose -eq 1 ] && echo "--- $rootssh $2 \"if [ ! -d $sshdir ]; then mkdir -p $sshdir; fi; cd $sshdir ; ulimit -c unlimited ; $1\""
+	$rootssh $2 "if [ ! -d $sshdir ]; then mkdir -p $sshdir; fi; cd $sshdir ; ulimit -c unlimited ; $1" || { [ -z "$3" ] && echo "failed: '$rootssh $1'" && ERR=1 && return 1; }
+    fi
+    return 0
+}
+
 get_local_daemon_list() {
     type=$1
     if [ -d "/var/lib/ceph/$type" ]; then

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -311,10 +311,14 @@ for name in $what; do
 
 		if [ "$fs_type" = "btrfs" ]; then
 		    echo Mounting Btrfs on $host:$fs_path
-		    do_root_cmd "modprobe btrfs ; btrfs device scan || btrfsctl -a ; egrep -q '^[^ ]+ $fs_path' /proc/mounts || mount -t btrfs $fs_opt $first_dev $fs_path"
+		    do_root_cmd_okfail "modprobe btrfs ; btrfs device scan || btrfsctl -a ; egrep -q '^[^ ]+ $fs_path' /proc/mounts || mount -t btrfs $fs_opt $first_dev $fs_path"
 		else
 		    echo Mounting $fs_type on $host:$fs_path
-		    do_root_cmd "modprobe $fs_type ; egrep -q '^[^ ]+ $fs_path' /proc/mounts || mount -t $fs_type $fs_opt $first_dev $fs_path"
+		    do_root_cmd_okfail "modprobe $fs_type ; egrep -q '^[^ ]+ $fs_path' /proc/mounts || mount -t $fs_type $fs_opt $first_dev $fs_path"
+		fi
+		if [ "$ERR" != "0" ]; then
+		    EXIT_STATUS=$ERR
+		    continue
 		fi
 	    fi
 


### PR DESCRIPTION
If we are starting many daemons and hit an error, we normally note it and 
move on.  Do the same when doing the pre-mount step.

Fixes: #8554 Signed-off-by: Sage Weil sage@inktank.com
