### PR TITLE
Added a note on keyring location

### DIFF
--- a/doc/start/quick-rbd.rst
+++ b/doc/start/quick-rbd.rst
@@ -43,6 +43,7 @@ Install Ceph
 
 	ceph-deploy admin ceph-client
 
+.. note:: The keyring will likely be copied over to ``/etc/ceph/ceph.client.admin.keyring`` 
 
 Configure a Block Device
 ========================


### PR DESCRIPTION
This quick start says that ceph-deploy will copy over the keyring. It neglects to mention the location. This makes it really confusing when 'Configure a Block Device' uses a dummy keyring directory: '/path/to/keyring'.

The note added to the end of the 'Install Ceph' section will hopefully clear this up.
