### PR TITLE
rgw: admin ops create user API can not determine existing user

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -60,6 +60,7 @@ void RGWOp_User_Create::execute()
   bool gen_key;
   bool suspended;
   bool system;
+  bool exclusive;
 
   uint32_t max_buckets;
   int32_t key_type = KEY_TYPE_UNDEFINED;
@@ -77,6 +78,7 @@ void RGWOp_User_Create::execute()
   RESTArgs::get_bool(s, "suspended", false, &suspended);
   RESTArgs::get_uint32(s, "max-buckets", RGW_DEFAULT_MAX_BUCKETS, &max_buckets);
   RESTArgs::get_bool(s, "system", false, &system);
+  RESTArgs::get_bool(s, "exclusive", false, &exclusive);
 
   if (!s->user.system && system) {
     ldout(s->cct, 0) << "cannot set system flag by non-system user" << dendl;
@@ -120,6 +122,9 @@ void RGWOp_User_Create::execute()
 
   if (s->info.args.exists("system"))
     op_state.set_system(system);
+
+  if (s->info.args.exists("exclusive"))
+    op_state.set_exclusive(exclusive);
 
   if (gen_key)
     op_state.set_generate_key();

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1639,7 +1639,8 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
 
   // fail if the user exists already
   if (op_state.has_existing_user()) {
-    if ((user_email.empty() || old_info.user_email == user_email) &&
+    if (!op_state.exclusive &&
+        (user_email.empty() || old_info.user_email == user_email) &&
         old_info.display_name == display_name) {
       return execute_modify(op_state, err_msg);
     }

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -128,6 +128,7 @@ struct RGWUserAdminOpState {
   uint32_t max_buckets;
   __u8 suspended;
   __u8 system;
+  __u8 exclusive;
   std::string caps;
   RGWObjVersionTracker objv;
   uint32_t op_mask;
@@ -263,6 +264,9 @@ struct RGWUserAdminOpState {
     system = is_system;
     system_specified = true;
   }
+  void set_exclusive(__u8 is_exclusive) {
+    exclusive = is_exclusive;
+  }
   void set_user_info(RGWUserInfo& user_info) {
     user_id = user_info.user_id;
     info = user_info;
@@ -394,6 +398,7 @@ struct RGWUserAdminOpState {
     perm_mask = 0;
     suspended = 0;
     system = 0;
+    exclusive = 0;
     op_mask = 0;
 
     existing_user = false;


### PR DESCRIPTION
Fixes: #8583

Signed-off-by: Ray Lv raylv@yahoo-inc.com
