### PR TITLE
osd: add sanity check/warning on a few key configs

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -911,6 +911,7 @@ public:
   virtual const char** get_tracked_conf_keys() const;
   virtual void handle_conf_change(const struct md_config_t *conf,
 				  const std::set <std::string> &changed);
+  void check_config();
 
 protected:
   Mutex osd_lock;			// global lock


### PR DESCRIPTION
Warn when certain config values are set to bad values.

Backport: firefly, dumpling Signed-off-by: Sage Weil sage@inktank.com
