### PR TITLE
Make KeyValueStore not use expected_write_size

### DIFF
--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -3001,8 +3001,8 @@ int KeyValueStore::_set_alloc_hint(coll_t cid, const ghobject_t& oid,
   // Now only consider to change "strip_size" when the object is blank,
   // because set_alloc_hint is expected to be very lightweight<O(1)>
   if (blank) {
-    header->strip_size = MIN(expected_write_size, m_keyvaluestore_max_expected_write_size);
-    dout(20) << __func__ << " hint " << header->strip_size << " success" << dendl;
+    // header->strip_size = MIN(expected_write_size, m_keyvaluestore_max_expected_write_size);
+    // dout(20) << __func__ << " hint " << header->strip_size << " success" << dendl;
   }
 
   dout(10) << __func__ << "" << cid << "/" << oid << " object_size "


### PR DESCRIPTION
expected_write_size in set_alloc_hint isn't the mean of name, now it's just the
size of object. It's not suitable for KeyValueStore to set strip size.

Signed-off-by: Haomai Wang haomaiwang@gmail.com
