### PR TITLE
Phase I - implement bucket index sharding for radosgw

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -1,5 +1,7 @@
 #include <errno.h>
 
+#include <boost/algorithm/string.hpp>
+
 #include "include/types.h"
 #include "cls/rgw/cls_rgw_ops.h"
 #include "cls/rgw/cls_rgw_client.h"
@@ -15,13 +17,35 @@ void cls_rgw_bucket_init(ObjectWriteOperation& o)
   o.exec("rgw", "bucket_init_index", in);
 }
 
-void cls_rgw_bucket_set_tag_timeout(ObjectWriteOperation& o, uint64_t tag_timeout)
+int cls_rgw_bucket_set_tag_timeout(librados::IoCtx& io_ctx, const vector<string>& bucket_objs,
+        uint64_t tag_timeout, uint32_t max_io)
 {
-  bufferlist in;
-  struct rgw_cls_tag_timeout_op call;
-  call.tag_timeout = tag_timeout;
-  ::encode(call, in);
-  o.exec("rgw", "bucket_set_tag_timeout", in);
+  int ret = 0;
+  vector<librados::AioCompletion*> completions;
+  vector<string>::const_iterator iter = bucket_objs.begin();
+  while (iter != bucket_objs.end()) {
+    completions.clear();
+    uint32_t max_aio_requests = max_io;
+    for (; iter != bucket_objs.end() && max_aio_requests-- > 0; ++iter) {
+      bufferlist in;
+      struct rgw_cls_tag_timeout_op call;
+      call.tag_timeout = tag_timeout;
+      ::encode(call, in);
+      ObjectWriteOperation op;
+      op.exec("rgw", "bucket_set_tag_timeout", in);
+      AioCompletion* c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+      completions.push_back(c);
+
+      // Do AIO operation
+      ret = io_ctx.aio_operate(*iter, c, &op, NULL);
+      if (ret < 0)
+        return ret;
+    }
+    ret = cls_rgw_util_wait_for_complete(completions);
+    if (ret < 0)
+      return ret;
+  }
+  return 0;
 }
 
 void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, string& tag,
@@ -57,69 +81,195 @@ void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, string&
   o.exec("rgw", "bucket_complete_op", in);
 }
 
+/**
+ * This class represents the bucket index object callback context.
+ */
+template<typename T>
+class ClsBucketIndexOpCtx : public ObjectOperationCompletion {
+private:
+  T* data;
+  // Return code of the operation
+  int* ret_code;
+public:
+  ClsBucketIndexOpCtx(T* _data, int *_ret_code) : data(_data), ret_code(_ret_code) {}
+  ~ClsBucketIndexOpCtx() {}
 
-int cls_rgw_list_op(IoCtx& io_ctx, string& oid, string& start_obj,
-                    string& filter_prefix, uint32_t num_entries,
-                    rgw_bucket_dir *dir, bool *is_truncated)
-{
-  bufferlist in, out;
-  struct rgw_cls_list_op call;
-  call.start_obj = start_obj;
-  call.filter_prefix = filter_prefix;
-  call.num_entries = num_entries;
-  ::encode(call, in);
-  int r = io_ctx.exec(oid, "rgw", "bucket_list", in, out);
-  if (r < 0)
-    return r;
-
-  struct rgw_cls_list_ret ret;
-  try {
-    bufferlist::iterator iter = out.begin();
-    ::decode(ret, iter);
-  } catch (buffer::error& err) {
-    return -EIO;
+  // The completion callback, fill the response data
+  void handle_completion(int r, bufferlist& outbl) {
+    if (r >= 0) {
+      try {
+        bufferlist::iterator iter = outbl.begin();
+        ::decode((*data), iter);
+      } catch (buffer::error& err) {
+        r = -EIO;
+      }
+    }
+    if (ret_code) {
+      *ret_code = r;
+    }
   }
+};
 
-  if (dir)
-    *dir = ret.dir;
-  if (is_truncated)
-    *is_truncated = ret.is_truncated;
-
- return r;
-}
-
-int cls_rgw_bucket_check_index_op(IoCtx& io_ctx, string& oid,
-				  rgw_bucket_dir_header *existing_header,
-				  rgw_bucket_dir_header *calculated_header)
+int cls_rgw_list_op(IoCtx& io_ctx, const string& start_obj,
+        const string& filter_prefix, uint32_t num_entries,
+        map<string, struct rgw_cls_list_ret>& list_results, uint32_t max_aio)
 {
-  bufferlist in, out;
-  int r = io_ctx.exec(oid, "rgw", "bucket_check_index", in, out);
-  if (r < 0)
-    return r;
+  int ret;
+  vector<librados::AioCompletion*> completions;
 
-  struct rgw_cls_check_index_ret ret;
-  try {
-    bufferlist::iterator iter = out.begin();
-    ::decode(ret, iter);
-  } catch (buffer::error& err) {
-    return -EIO;
+  map<string, struct rgw_cls_list_ret>::iterator liter = list_results.begin();
+  while (liter != list_results.end()) {
+    uint32_t max_aio_requests = max_aio;
+    completions.clear();
+    for (; liter != list_results.end() && max_aio_requests-- > 0; ++liter) {
+      bufferlist in;
+      struct rgw_cls_list_op call;
+      call.start_obj = start_obj;
+      call.filter_prefix = filter_prefix;
+      call.num_entries = num_entries;
+      ::encode(call, in);
+
+      librados::ObjectReadOperation op;
+      op.exec("rgw", "bucket_list", in, new ClsBucketIndexOpCtx<struct rgw_cls_list_ret>(
+            &liter->second, NULL));
+      AioCompletion* c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+      completions.push_back(c);
+
+      // Do AIO operate
+      io_ctx.aio_operate(liter->first, c, &op, NULL);
+    }
+    ret = cls_rgw_util_wait_for_complete_and_cb(completions);
+    if (ret < 0)
+      return ret;
   }
-
-  if (existing_header)
-    *existing_header = ret.existing_header;
-  if (calculated_header)
-    *calculated_header = ret.calculated_header;
 
   return 0;
 }
 
-int cls_rgw_bucket_rebuild_index_op(IoCtx& io_ctx, string& oid)
+int cls_rgw_bucket_check_index_op(IoCtx& io_ctx,
+        map<string, struct rgw_cls_check_index_ret>& results, uint32_t max_io)
 {
+  int ret;
+  vector<librados::AioCompletion*> completions;
   bufferlist in, out;
-  int r = io_ctx.exec(oid, "rgw", "bucket_rebuild_index", in, out);
-  if (r < 0)
-    return r;
+  map<string, struct rgw_cls_check_index_ret>::iterator iter = results.begin();
+  while (iter != results.end()) {
+    completions.clear();
+    uint32_t max_aio_requests = max_io;
+    for (; iter != results.end() && max_aio_requests-- > 0; ++iter) {
+      librados::ObjectReadOperation op;
+      op.exec("rgw", "bucket_check_index", in, new ClsBucketIndexOpCtx<struct rgw_cls_check_index_ret>(
+                  &iter->second, NULL));
+      AioCompletion* c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+      completions.push_back(c);
 
+      // Do AIO operation
+      io_ctx.aio_operate(iter->first, c, &op, NULL);
+    }
+    ret = cls_rgw_util_wait_for_complete_and_cb(completions);
+    if (ret < 0)
+      return ret;
+  }
+  return 0;
+}
+
+int cls_rgw_bucket_remove_objs_op(librados::IoCtx& io_ctx,
+        const map<string, vector<rgw_bucket_dir_entry> >& updates, uint32_t max_io)
+{
+  vector<librados::AioCompletion*> completions;
+  map<string, vector<rgw_bucket_dir_entry> >::const_iterator iter = updates.begin();
+  while (iter != updates.end()) {
+      completions.clear();
+      uint32_t max_aio_requests = max_io;
+      for (; iter != updates.end() && max_aio_requests-- > 0; ++iter) {
+        bufferlist update;
+        vector<rgw_bucket_dir_entry>::const_iterator viter;
+        for (viter = (iter->second).begin(); viter != (iter->second).end(); ++viter) {
+          update.append(CEPH_RGW_REMOVE);
+          ::encode(*viter, update);
+        }
+        librados::ObjectWriteOperation op;
+        op.exec("rgw", "dir_suggest_changes", update);
+        AioCompletion* c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+        completions.push_back(c);
+
+        // Do AIO operation
+        io_ctx.aio_operate(iter->first, c, &op, NULL);
+      }
+      int r = cls_rgw_util_wait_for_complete(completions);
+      if (r < 0)
+        return r;
+  }
+  return 0;
+}
+
+int cls_rgw_bucket_index_init_op(librados::IoCtx &io_ctx,
+        const vector<string>& bucket_objs, uint32_t max_io)
+{
+  int ret = 0;
+  vector<librados::AioCompletion*> completions;
+  vector<string> created_objs;
+  vector<string>::const_iterator iter = bucket_objs.begin();
+  bufferlist in;
+  while (iter != bucket_objs.end()) {
+    int max_aio_requests = max_io;
+    completions.clear();
+    for (; iter != bucket_objs.end() && max_aio_requests-- > 0; ++iter) {
+      librados::ObjectWriteOperation op;
+      op.create(true);
+      op.exec("rgw", "bucket_init_index", in);
+      AioCompletion* c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+      completions.push_back(c);
+
+      // Do AIO operation
+      io_ctx.aio_operate(*iter, c, &op);
+    }
+
+    for (size_t i = 0; i < completions.size(); ++i) {
+      completions[i]->wait_for_safe();
+      int aio_ret = completions[i]->get_return_value();
+      if (aio_ret < 0 && aio_ret != -EEXIST) {
+        ret = aio_ret;
+      }
+      completions[i]->release();
+      created_objs.push_back(bucket_objs[i]);
+    }
+    if (ret < 0) {
+      // Do best effort removal
+      for (iter = created_objs.begin(); iter != created_objs.end(); ++iter) {
+        io_ctx.remove(*iter);
+      }
+      break;
+    }
+  }
+
+  return ret;
+}
+
+int cls_rgw_bucket_rebuild_index_op(IoCtx& io_ctx, const vector<string>& bucket_objs,
+        uint32_t max_io)
+{
+  int ret;
+  vector<librados::AioCompletion*> completions;
+  bufferlist in;
+
+  vector<string>::const_iterator iter = bucket_objs.begin();
+  while (iter != bucket_objs.end()) {
+    completions.clear();
+    uint32_t max_aio_requests = max_io;
+    for (; iter != bucket_objs.end() && max_aio_requests-- > 0; ++iter) {
+      librados::ObjectWriteOperation op;
+      op.exec("rgw", "bucket_rebuild_index", in);
+      AioCompletion* c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+      completions.push_back(c);
+
+      // Do AIO operation
+      io_ctx.aio_operate(*iter, c, &op, NULL);
+  }
+  ret = cls_rgw_util_wait_for_complete(completions);
+  if (ret < 0)
+    return ret;
+  }
   return 0;
 }
 
@@ -134,28 +284,35 @@ void cls_rgw_suggest_changes(ObjectWriteOperation& o, bufferlist& updates)
   o.exec("rgw", "dir_suggest_changes", updates);
 }
 
-int cls_rgw_get_dir_header(IoCtx& io_ctx, string& oid, rgw_bucket_dir_header *header)
+int cls_rgw_get_dir_header(IoCtx& io_ctx, map<string, rgw_cls_list_ret>& list_results,
+        uint32_t max_io)
 {
-  bufferlist in, out;
-  struct rgw_cls_list_op call;
-  call.num_entries = 0;
-  ::encode(call, in);
-  int r = io_ctx.exec(oid, "rgw", "bucket_list", in, out);
-  if (r < 0)
-    return r;
+  int ret;
+  vector<librados::AioCompletion*> completions;
+  map<string, rgw_cls_list_ret>::iterator iter = list_results.begin();
+  while (iter != list_results.end()) {
+    completions.clear();
+    uint32_t max_aio_requests = max_io;
+    for (; iter != list_results.end() && max_aio_requests-- > 0; ++iter) {
+      bufferlist in;
+      struct rgw_cls_list_op call;
+      call.num_entries = 0;
+      ::encode(call, in);
 
-  struct rgw_cls_list_ret ret;
-  try {
-    bufferlist::iterator iter = out.begin();
-    ::decode(ret, iter);
-  } catch (buffer::error& err) {
-    return -EIO;
+      librados::ObjectReadOperation op;
+      op.exec("rgw", "bucket_list", in, new ClsBucketIndexOpCtx<struct rgw_cls_list_ret>(
+                  &iter->second, NULL));
+      AioCompletion* c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+      completions.push_back(c);
+
+      // Do AIO operate
+      io_ctx.aio_operate(iter->first, c, &op, NULL);
+    }
+    ret = cls_rgw_util_wait_for_complete_and_cb(completions);
+    if (ret < 0)
+      return ret;
   }
-
-  if (header)
-    *header = ret.dir.header;
-
- return r;
+  return 0;
 }
 
 class GetDirHeaderCompletion : public ObjectOperationCompletion {
@@ -196,54 +353,124 @@ int cls_rgw_get_dir_header_async(IoCtx& io_ctx, string& oid, RGWGetDirHeader_CB 
   return 0;
 }
 
-int cls_rgw_bi_log_list(IoCtx& io_ctx, string& oid, string& marker, uint32_t max,
-                    list<rgw_bi_log_entry>& entries, bool *truncated)
+int cls_rgw_bi_log_list(IoCtx& io_ctx, map<string, cls_rgw_bi_log_list_ret>& list_results,
+        string& marker, uint32_t max, uint32_t max_io)
 {
-  bufferlist in, out;
-  cls_rgw_bi_log_list_op call;
-  call.marker = marker;
-  call.max = max;
-  ::encode(call, in);
-  int r = io_ctx.exec(oid, "rgw", "bi_log_list", in, out);
-  if (r < 0)
-    return r;
-
-  cls_rgw_bi_log_list_ret ret;
-  try {
-    bufferlist::iterator iter = out.begin();
-    ::decode(ret, iter);
-  } catch (buffer::error& err) {
-    return -EIO;
+  int ret;
+  // If it is a composed marker (for each bucket index shard), let us get marker
+  // for each shard first
+  map<string, string> markers;
+  if (marker.find('#') != string::npos) {
+    ret = cls_rgw_util_parse_markers(marker, markers);
+    if (ret < 0)
+      return ret;
   }
 
-  entries = ret.entries;
+  uint32_t num = max / (list_results.size());
+  vector<librados::AioCompletion*> completions;
+  map<string, cls_rgw_bi_log_list_ret>::iterator iter = list_results.begin();
+  while (iter != list_results.end()) {
+    completions.clear();
+    uint32_t max_aio_requests = max_io;
+    for (; iter != list_results.end() && max_aio_requests-- > 0; ++iter) {
+      bufferlist in, out;
+      cls_rgw_bi_log_list_op call;
+      if (!markers.empty()) {
+        // It requires a marker for each shard
+        if (!markers.count(iter->first))
+          return -EINVAL;
+        call.marker = markers[iter->first];
+      } else {
+        call.marker = marker;
+      }
+      if (iter == list_results.begin()) {
+        call.max = num + (max % (list_results.size()));
+      } else {
+        call.max = num;
+      }
+      ::encode(call, in);
 
-  if (truncated)
-    *truncated = ret.truncated;
+      librados::ObjectReadOperation op;
+      op.exec("rgw", "bi_log_list", in, new ClsBucketIndexOpCtx<cls_rgw_bi_log_list_ret>(
+                  &iter->second, NULL));
+      AioCompletion* c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+      completions.push_back(c);
 
- return r;
+      // Do AIO operation
+      io_ctx.aio_operate(iter->first, c, &op, NULL);
+    }
+    ret = cls_rgw_util_wait_for_complete_and_cb(completions);
+    if (ret < 0)
+      return ret;
+  }
+  return 0;
 }
 
-int cls_rgw_bi_log_trim(IoCtx& io_ctx, string& oid, string& start_marker, string& end_marker)
+int cls_rgw_bi_log_trim(IoCtx& io_ctx, vector<string>& bucket_objs, string& start_marker, string& end_marker, uint32_t max_io)
 {
+  int ret = 0;
+  map<string, string> start_markers;
+  map<string, string> end_markers;
+  if (start_marker.find('#') != string::npos) {
+    ret = cls_rgw_util_parse_markers(start_marker, start_markers);
+    if (ret < 0)
+      return ret;
+    ret = cls_rgw_util_parse_markers(end_marker, end_markers);
+    if (ret < 0)
+      return ret;
+    // Validation
+    vector<string>::iterator viter;
+    for (viter = bucket_objs.begin(); viter != bucket_objs.end(); ++viter) {
+       if (start_markers.count(*viter) == 0)
+         return -EINVAL;
+       if (end_markers.count(*viter) == 0)
+         return -EINVAL;
+    }
+  }
+
+  map<librados::AioCompletion*, string> completions;
+  map<librados::AioCompletion*, string>::iterator miter;
+  vector<string>::iterator iter;
   do {
-    int r;
-    bufferlist in, out;
-    cls_rgw_bi_log_trim_op call;
-    call.start_marker = start_marker;
-    call.end_marker = end_marker;
-    ::encode(call, in);
-    r = io_ctx.exec(oid, "rgw", "bi_log_trim", in, out);
+    completions.clear();
+    uint32_t max_aio_requests = max_io;
+    for (iter = bucket_objs.begin(); iter != bucket_objs.end() && max_aio_requests-- > 0; ++iter)
+    {
+      bufferlist in, out;
+      cls_rgw_bi_log_trim_op call;
+      if (!start_markers.empty()) {
+        call.start_marker = start_markers[*iter];
+        call.end_marker = end_markers[*iter];
+      } else {
+        call.start_marker = start_marker;
+        call.end_marker = end_marker;
+      }
+      ::encode(call, in);
+      ObjectWriteOperation op;
+      op.exec("rgw", "bi_log_trim", in);
+      AioCompletion* c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+      completions[c] = *iter;
 
-    if (r == -ENODATA)
-      break;
+      // Do AIO request
+      ret = io_ctx.aio_operate(*iter, c, &op, NULL);
+      if (ret < 0)
+        return ret;
+    }
 
-    if (r < 0)
-      return r;
+    // Wait for completions
+    for (miter = completions.begin(); miter != completions.end(); ++miter) {
+      miter->first->wait_for_complete();
+      int r = miter->first->get_return_value();
+      if (r == -ENODATA) {
+        bucket_objs.erase(std::remove(bucket_objs.begin(), bucket_objs.end(), miter->second), bucket_objs.end());
+      } else if (ret < 0) {
+        ret = r;
+      }
+      miter->first->release();
+    }
+  } while (!bucket_objs.empty());
 
-  } while (1);
-
-  return 0;
+  return ret;
 }
 
 int cls_rgw_usage_log_read(IoCtx& io_ctx, string& oid, string& user,
@@ -360,4 +587,51 @@ void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const list<string>& t
   call.tags = tags;
   ::encode(call, in);
   op.exec("rgw", "gc_remove", in);
+}
+
+int cls_rgw_util_wait_for_complete_and_cb(const vector<librados::AioCompletion*>& completions)
+{
+  int ret = 0;
+  vector<librados::AioCompletion*>::const_iterator iter;
+  for (iter = completions.begin(); iter != completions.end(); ++iter) {
+    (*iter)->wait_for_complete_and_cb();
+    int r = (*iter)->get_return_value();
+    if (r != 0) {
+      ret = r;
+    }
+
+    (*iter)->release();
+  }
+
+  return ret;
+}
+
+int cls_rgw_util_wait_for_complete(const vector<librados::AioCompletion*>& completions)
+{
+  int ret = 0;
+  vector<librados::AioCompletion*>::const_iterator iter;
+  for (iter = completions.begin(); iter != completions.end(); ++iter) {
+    (*iter)->wait_for_complete();
+    int r = (*iter)->get_return_value();
+    if (r != 0) {
+      ret = r;
+    }
+
+    (*iter)->release();
+  }
+
+  return ret;
+}
+
+int cls_rgw_util_parse_markers(const string& marker, map<string, string>& markers)
+{
+  vector<string> parts;
+  boost::split(parts, marker, boost::is_any_of(",#"));
+  if (parts.size() % 2 != 0)
+    return -EINVAL;
+  for (size_t i = 0; i < parts.size(); ) {
+    markers[parts[i]] = parts[i + 1];
+    i += 2;
+  }
+  return 0;
 }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -15,7 +15,20 @@ public:
 /* bucket index */
 void cls_rgw_bucket_init(librados::ObjectWriteOperation& o);
 
-void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& o, uint64_t tag_timeout);
+/**
+ * Init bucket index objects.
+ *
+ * io_ctx      - IO context for rados.
+ * bucket_objs - a lit of bucket index objects.
+ * max_io      - the maximum number of AIO (for throttling).
+ *
+ * Reutrn 0 on success, a failure code otherwise.
+ */
+int cls_rgw_bucket_index_init_op(librados::IoCtx &io_ctx,
+        const vector<string>& bucket_objs, uint32_t max_io);
+
+int cls_rgw_bucket_set_tag_timeout(librados::IoCtx& io_ctx, const vector<string>& bucket_objs, uint64_t tag_timeout,
+        uint32_t max_io);
 
 void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, string& tag,
                                string& name, string& locator, bool log_op);
@@ -24,16 +37,76 @@ void cls_rgw_bucket_complete_op(librados::ObjectWriteOperation& o, RGWModifyOp o
                                 rgw_bucket_entry_ver& ver, string& name, rgw_bucket_dir_entry_meta& dir_meta,
 				list<string> *remove_objs, bool log_op);
 
-int cls_rgw_list_op(librados::IoCtx& io_ctx, string& oid, string& start_obj,
-                    string& filter_prefix, uint32_t num_entries,
-                    rgw_bucket_dir *dir, bool *is_truncated);
+/**
+ * List the bucket with the starting object and filter prefix.
+ * NOTE: this method do listing requests for each bucket index shards identified by
+ *       the keys of the *list_results* map, which means the map should be popludated
+ *       by the caller to fill with each bucket index object id.
+ *
+ * io_ctx        - IO context for rados.
+ * start_obj     - marker for the listing.
+ * filter_prefix - filer prefix.
+ * num_entries   - number of entries to request for each object (note the total 
+ *                 amount of entries returned depends on the number of shardings).
+ * list_results  - the list results keyed by bucket index object id.
+ * max_aio       - the maximum number of AIO (for throttling).
+ *
+ * Return 0 on success, a failure code otherwise.
+*/
+int cls_rgw_list_op(librados::IoCtx& io_ctx, const string & start_obj,
+                    const string& filter_prefix, uint32_t num_entries,
+                    map<string, struct rgw_cls_list_ret>& list_results,
+                    uint32_t max_aio);
 
-int cls_rgw_bucket_check_index_op(librados::IoCtx& io_ctx, string& oid,
-				  rgw_bucket_dir_header *existing_header,
-				  rgw_bucket_dir_header *calculated_header);
-int cls_rgw_bucket_rebuild_index_op(librados::IoCtx& io_ctx, string& oid);
+/**
+ * Check the bucket index.
+ *
+ * io_ctx  - IO context for rados.
+ * results - the results keyed by the bubcket index object id (shard).
+ * max_io  - the maximum number of AIO (for throttling).
+ *
+ * Return 0 on success, a failure code otherwise.
+ */
+int cls_rgw_bucket_check_index_op(librados::IoCtx& io_ctx,
+        map<string, struct rgw_cls_check_index_ret>& results, uint32_t max_io);
+
+/**
+ * Rebuild the bucket index.
+ *
+ * io_ctx      - IO context for rados.
+ * bucket_objs - a list of bucket objects (shard) to operate.
+ * max_io      - the maximum number of AIO (for throttling).
+ *
+ * Return 0 on success, a failure code otherwise.
+ */
+int cls_rgw_bucket_rebuild_index_op(librados::IoCtx& io_ctx, const vector<string>& bucket_objs,
+        uint32_t max_io);
   
-int cls_rgw_get_dir_header(librados::IoCtx& io_ctx, string& oid, rgw_bucket_dir_header *header);
+/**
+ * Remove objects from bucket index entry.
+ *
+ * io_ctx   - IO context for rados.
+ * updates  - a list of updates to perform. Key is the bucket index object id (shard),
+ *            value is a list of entries to remove.
+ * max_io   - the maximum number of AIO (for throttling).
+ *
+ * Return 0 on success, a failure code otherwise.
+ */ 
+int cls_rgw_bucket_remove_objs_op(librados::IoCtx& io_ctx,
+        const map<string, vector<rgw_bucket_dir_entry> >& updates, uint32_t max_io);
+
+/**
+ * Get dir headers with a bucket.
+ *
+ * io_ctx       - IO context for rados.
+ * list_results - list results for headers, keyed by the object index object id (shard).
+ * max_io       - maximum number of AIO (for throttling).
+ *
+ * Return 0 on success, a failure code otherwise.
+ */
+int cls_rgw_get_dir_header(librados::IoCtx& io_ctx,
+        map<string, rgw_cls_list_ret>& headers, uint32_t max_io);
+
 int cls_rgw_get_dir_header_async(librados::IoCtx& io_ctx, string& oid, RGWGetDirHeader_CB *ctx);
 
 void cls_rgw_encode_suggestion(char op, rgw_bucket_dir_entry& dirent, bufferlist& updates);
@@ -42,9 +115,9 @@ void cls_rgw_suggest_changes(librados::ObjectWriteOperation& o, bufferlist& upda
 
 /* bucket index log */
 
-int cls_rgw_bi_log_list(librados::IoCtx& io_ctx, string& oid, string& marker, uint32_t max,
-                    list<rgw_bi_log_entry>& entries, bool *truncated);
-int cls_rgw_bi_log_trim(librados::IoCtx& io_ctx, string& oid, string& start_marker, string& end_marker);
+int cls_rgw_bi_log_list(librados::IoCtx& io_ctx, map<string, struct cls_rgw_bi_log_list_ret>& list_results,
+        string& marker, uint32_t max, uint32_t max_io);
+int cls_rgw_bi_log_trim(librados::IoCtx& io_ctx, vector<string>& bucket_objs, string& start_marker, string& end_marker, uint32_t max_io);
 
 /* usage logging */
 int cls_rgw_usage_log_read(librados::IoCtx& io_ctx, string& oid, string& user,
@@ -65,5 +138,35 @@ int cls_rgw_gc_list(librados::IoCtx& io_ctx, string& oid, string& marker, uint32
                     list<cls_rgw_gc_obj_info>& entries, bool *truncated);
 
 void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const list<string>& tags);
+
+/**
+ * This helper method iterates the given AIO completion list and wait for completion
+ * of all of them.
+ *
+ * completions - a list of AIO completions.
+ *
+ * Return 0 on success, otherwise a failure code.
+ */
+int cls_rgw_util_wait_for_complete(const vector<librados::AioCompletion*>& completions);
+
+/**
+ * This helper method iterates the given AIO completion list and wait for the completion
+ * and callbacks of all of them.
+ *
+ * completions - a list of AIO completions.
+ *
+ * Return 0 on success, a failure code otherwise.
+ */
+int cls_rgw_util_wait_for_complete_and_cb(const vector<librados::AioCompletion*>& completions);
+
+/**
+ * Parse markers (key as object id, value as marker for the object) from the given marker string.
+ *
+ * marker   - the original marker string, with schema: {oid}#{marker},{oid}#{marker}...
+ * markers  - the output markers map with oid as key and marker as value.
+ *
+ * Return 0 on succes, a failure code otherwise.
+ */
+int cls_rgw_util_parse_markers(const string& marker, map<string, string>& markers);
 
 #endif

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -749,6 +749,20 @@ OPTION(nss_db_path, OPT_STR, "") // path to nss db
 
 OPTION(rgw_max_chunk_size, OPT_INT, 512 * 1024)
 
+/**
+ * Represents the number of shards for the bucket index object, a value of zero
+ * indicates there is no sharding. By default (no sharding, the name of the object
+ * is '.dir.{marker}', with sharding, the name is '.dir.{markder}.{sharding_id}',
+ * sharding_id is zero-based value. It is not recommended to set a too large value
+ * (e.g. thousand) as it increases the cost for bucket listing.
+ */
+OPTION(rgw_bucket_index_max_shards, OPT_U32, 0)
+
+/**
+ * Represents the maximum AIO operations for the bucket index object shards.
+ */
+OPTION(rgw_bucket_index_max_aio, OPT_U32, 8)
+
 OPTION(rgw_data, OPT_STR, "/var/lib/ceph/radosgw/$cluster-$id")
 OPTION(rgw_enable_apis, OPT_STR, "s3, swift, swift_auth, admin")
 OPTION(rgw_cache_enabled, OPT_BOOL, true)   // rgw cache enabled

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -355,9 +355,9 @@ int rgw_remove_bucket(RGWRados *store, const string& bucket_owner, rgw_bucket& b
   RGWBucketInfo info;
   bufferlist bl;
 
-  uint64_t bucket_ver, master_ver;
+  string bucket_ver, master_ver;
 
-  ret = store->get_bucket_stats(bucket, &bucket_ver, &master_ver, stats, NULL);
+  ret = store->get_bucket_stats(bucket, bucket_ver, master_ver, stats, NULL);
   if (ret < 0)
     return ret;
 
@@ -727,13 +727,16 @@ int RGWBucket::check_object_index(RGWBucketAdminOpState& op_state,
     map<string, RGWObjEnt> result;
 
     int r = store->cls_bucket_list(bucket, marker, prefix, 1000, result,
-             &is_truncated, &marker,
-             bucket_object_check_filter);
+             &is_truncated, bucket_object_check_filter);
 
     if (r == -ENOENT) {
       break;
     } else if (r < 0 && r != -ENOENT) {
       set_err_msg(err_msg, "ERROR: failed operation r=" + cpp_strerror(-r));
+    }
+    // Refresh marker
+    if (!result.empty()) {
+      marker = result.rbegin()->first;
     }
   }
 
@@ -954,9 +957,9 @@ static int bucket_stats(RGWRados *store, std::string&  bucket_name, Formatter *f
 
   bucket = bucket_info.bucket;
 
-  uint64_t bucket_ver, master_ver;
+  string bucket_ver, master_ver;
   string max_marker;
-  int ret = store->get_bucket_stats(bucket, &bucket_ver, &master_ver, stats, &max_marker);
+  int ret = store->get_bucket_stats(bucket, bucket_ver, master_ver, stats, &max_marker);
   if (ret < 0) {
     cerr << "error getting bucket stats ret=" << ret << std::endl;
     return ret;
@@ -969,8 +972,8 @@ static int bucket_stats(RGWRados *store, std::string&  bucket_name, Formatter *f
   formatter->dump_string("id", bucket.bucket_id);
   formatter->dump_string("marker", bucket.marker);
   formatter->dump_string("owner", bucket_info.owner);
-  formatter->dump_int("ver", bucket_ver);
-  formatter->dump_int("master_ver", master_ver);
+  formatter->dump_string("ver", bucket_ver);
+  formatter->dump_string("master_ver", master_ver);
   formatter->dump_int("mtime", mtime);
   formatter->dump_string("max_marker", max_marker);
   dump_bucket_usage(stats, formatter);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -729,9 +729,12 @@ struct RGWBucketInfo
   RGWObjVersionTracker objv_tracker; /* we don't need to serialize this, for runtime tracking */
   obj_version ep_objv; /* entry point object version, for runtime tracking only */
   RGWQuotaInfo quota;
+  // Represents the number of bucket index object shards, a value of zero indicates there
+  // is no sharding of the bucket index object
+  uint32_t num_shards;
 
   void encode(bufferlist& bl) const {
-     ENCODE_START(9, 4, bl);
+     ENCODE_START(10, 4, bl);
      ::encode(bucket, bl);
      ::encode(owner, bl);
      ::encode(flags, bl);
@@ -741,6 +744,7 @@ struct RGWBucketInfo
      ::encode(placement_rule, bl);
      ::encode(has_instance_obj, bl);
      ::encode(quota, bl);
+     ::encode(num_shards, bl);
      ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
@@ -763,6 +767,8 @@ struct RGWBucketInfo
        ::decode(has_instance_obj, bl);
      if (struct_v >= 9)
        ::decode(quota, bl);
+     if (struct_v >= 10)
+       ::decode(num_shards, bl);
      DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -318,11 +318,11 @@ int RGWBucketStatsCache::fetch_stats_from_storage(const string& user, rgw_bucket
 {
   RGWBucketInfo bucket_info;
 
-  uint64_t bucket_ver;
-  uint64_t master_ver;
+  string bucket_ver;
+  string master_ver;
 
   map<RGWObjCategory, RGWStorageStats> bucket_stats;
-  int r = store->get_bucket_stats(bucket, &bucket_ver, &master_ver, bucket_stats, NULL);
+  int r = store->get_bucket_stats(bucket, bucket_ver, master_ver, bucket_stats, NULL);
   if (r < 0) {
     ldout(store->ctx(), 0) << "could not get bucket info for bucket=" << bucket.name << dendl;
     return r;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -15,6 +15,7 @@
 #include "rgw_metadata.h"
 #include "rgw_bucket.h"
 
+#include "cls/rgw/cls_rgw_ops.h"
 #include "cls/rgw/cls_rgw_types.h"
 #include "cls/rgw/cls_rgw_client.h"
 #include "cls/refcount/cls_refcount_client.h"
@@ -1372,6 +1373,9 @@ int RGWRados::init_rados()
 
   max_chunk_size = cct->_conf->rgw_max_chunk_size;
 
+  max_bucket_index_shards = cct->_conf->rgw_bucket_index_max_shards;
+  ldout(cct, 20) << __func__ << " max bucket index shards is: " << max_bucket_index_shards << dendl;
+
   rados = new Rados();
   if (!rados)
     return -ENOMEM;
@@ -2224,6 +2228,7 @@ int RGWRados::list_objects(rgw_bucket& bucket, int max, string& prefix, string& 
 			   bool get_content_type, string& ns, bool enforce_ns,
                            bool *is_truncated, RGWAccessListFilter *filter)
 {
+  ldout(cct, 20) << __func__ << "shanghai" << dendl;
   int count = 0;
   bool truncated;
 
@@ -2244,12 +2249,12 @@ int RGWRados::list_objects(rgw_bucket& bucket, int max, string& prefix, string& 
   do {
     std::map<string, RGWObjEnt> ent_map;
     int r = cls_bucket_list(bucket, cur_marker, cur_prefix, max - count, ent_map,
-                            &truncated, &cur_marker);
+                            &truncated);
     if (r < 0)
       return r;
 
     std::map<string, RGWObjEnt>::iterator eiter;
-    for (eiter = ent_map.begin(); eiter != ent_map.end(); ++eiter) {
+    for (eiter = ent_map.begin(); count < max && eiter != ent_map.end(); ++eiter) {
       string obj = eiter->first;
       string key = obj;
 
@@ -2287,6 +2292,14 @@ int RGWRados::list_objects(rgw_bucket& bucket, int max, string& prefix, string& 
       result.push_back(ent);
       count++;
     }
+    // Refresh marker for next call
+    if (!ent_map.empty()) {
+      cur_marker = ent_map.rbegin()->first;
+    }
+
+    // Either the back-end telling us truncated, or we don't consume all
+    // items returned per the amount caller request
+    truncated = (truncated || eiter != ent_map.end());
   } while (truncated && count < max);
 
 done:
@@ -2334,13 +2347,10 @@ int RGWRados::init_bucket_index(rgw_bucket& bucket)
   string dir_oid =  dir_oid_prefix;
   dir_oid.append(bucket.marker);
 
-  librados::ObjectWriteOperation op;
-  op.create(true);
-  r = cls_rgw_init_index(index_ctx, op, dir_oid);
-  if (r < 0 && r != -EEXIST)
-    return r;
+  vector<string> bucket_objs;
+  get_bucket_index_objs(dir_oid, bucket_objs, max_bucket_index_shards);
 
-  return 0;
+  return cls_rgw_bucket_index_init_op(index_ctx, bucket_objs, cct->_conf->rgw_bucket_index_max_aio);
 }
 
 /**
@@ -2407,6 +2417,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     info.owner = owner.user_id;
     info.region = region_name;
     info.placement_rule = selected_placement_rule;
+    info.num_shards = max_bucket_index_shards;
     if (!creation_time)
       time(&info.creation_time);
     else
@@ -2435,11 +2446,16 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
 
         /* remove bucket index */
         librados::IoCtx index_ctx; // context for new bucket
-        int r = open_bucket_index_ctx(bucket, index_ctx);
+        vector<string> bucket_objs;
+        int r = open_bucket_index(bucket, index_ctx, bucket_objs);
         if (r < 0)
           return r;
 
-        index_ctx.remove(dir_oid);
+        vector<string>::const_iterator biter;
+        for (biter = bucket_objs.begin(); biter != bucket_objs.end(); ++biter) {
+          // Do best effort removal
+          index_ctx.remove(*biter);
+        }
       }
       /* ret == -ENOENT here */
     }
@@ -2789,7 +2805,7 @@ int RGWRados::put_obj_meta_impl(void *ctx, rgw_obj& obj,  uint64_t size,
                   map<string, bufferlist>* rmattrs,
                   const bufferlist *data,
                   RGWObjManifest *manifest,
-		  const string *ptag,
+                  const string *ptag,
                   list<string> *remove_objs,
                   bool modify_version,
                   RGWObjVersionTracker *objv_tracker,
@@ -3524,20 +3540,15 @@ done_err:
  */
 int RGWRados::delete_bucket(rgw_bucket& bucket, RGWObjVersionTracker& objv_tracker)
 {
-  librados::IoCtx index_ctx;
-  string oid;
-  int r = open_bucket_index(bucket, index_ctx, oid);
-  if (r < 0)
-    return r;
-
   std::map<string, RGWObjEnt> ent_map;
   string marker, prefix;
   bool is_truncated;
 
+  int r;
   do {
 #define NUM_ENTRIES 1000
     r = cls_bucket_list(bucket, marker, prefix, NUM_ENTRIES, ent_map,
-                        &is_truncated, &marker);
+                        &is_truncated);
     if (r < 0)
       return r;
 
@@ -3549,6 +3560,10 @@ int RGWRados::delete_bucket(rgw_bucket& bucket, RGWObjVersionTracker& objv_track
 
       if (rgw_obj::translate_raw_obj_to_obj_in_ns(obj, ns))
         return -ENOTEMPTY;
+    }
+    // Refresh marker
+    if (!ent_map.empty()) {
+      marker = ent_map.rbegin()->first;
     }
   } while (is_truncated);
 
@@ -3654,7 +3669,7 @@ int RGWRados::complete_atomic_overwrite(RGWRadosCtx *rctx, RGWObjState *state, r
   return ret;
 }
 
-int RGWRados::open_bucket_index(rgw_bucket& bucket, librados::IoCtx& index_ctx, string& bucket_oid)
+int RGWRados::open_bucket_index_base(rgw_bucket& bucket, librados::IoCtx& index_ctx, string& bucket_oid_base)
 {
   if (bucket_is_system(bucket))
     return -EINVAL;
@@ -3668,13 +3683,63 @@ int RGWRados::open_bucket_index(rgw_bucket& bucket, librados::IoCtx& index_ctx, 
     return -EIO;
   }
 
-  bucket_oid = dir_oid_prefix;
-  bucket_oid.append(bucket.marker);
+  bucket_oid_base = dir_oid_prefix;
+  bucket_oid_base.append(bucket.marker);
 
   return 0;
 }
 
-static void translate_raw_stats(rgw_bucket_dir_header& header, map<RGWObjCategory, RGWStorageStats>& stats)
+int RGWRados::open_bucket_index(rgw_bucket& bucket, librados::IoCtx& index_ctx,
+        const string& obj_key, string& bucket_oid)
+{
+  string bucket_oid_base;
+  int r = open_bucket_index_base(bucket, index_ctx, bucket_oid_base);
+
+  // Get the bucket info
+  RGWBucketInfo binfo;
+  r = get_bucket_info(NULL, bucket.name, binfo, NULL, NULL);
+  if (r < 0)
+    return r;
+
+  get_bucket_index_obj(bucket_oid_base, obj_key, bucket_oid, binfo.num_shards);
+  return 0;
+}
+
+template<typename T>
+int RGWRados::open_bucket_index(rgw_bucket& bucket, librados::IoCtx& index_ctx,
+        map<string, T>& bucket_objs)
+{
+    vector<string> oids;
+    int ret = open_bucket_index(bucket, index_ctx, oids);
+    if (ret < 0)
+      return ret;
+
+    vector<string>::const_iterator iter;
+    for (iter = oids.begin(); iter != oids.end(); ++iter) {
+      bucket_objs[*iter] = T();
+    }
+    return 0;
+}
+
+int RGWRados::open_bucket_index(rgw_bucket& bucket, librados::IoCtx& index_ctx,
+        vector<string>& bucket_objs)
+{
+  string bucket_oid_base;
+  open_bucket_index_base(bucket, index_ctx, bucket_oid_base);
+ 
+  // Get the bucket info
+  RGWBucketInfo binfo;
+  int ret = get_bucket_info(NULL, bucket.name, binfo, NULL, NULL);
+  if (ret < 0)
+    return ret;
+
+  get_bucket_index_objs(bucket_oid_base, bucket_objs, binfo.num_shards);
+
+  return 0;
+}
+
+
+static void accumulate_raw_stats(rgw_bucket_dir_header& header, map<RGWObjCategory, RGWStorageStats>& stats)
 {
   map<uint8_t, struct rgw_bucket_category_stats>::iterator iter = header.stats.begin();
   for (; iter != header.stats.end(); ++iter) {
@@ -3682,9 +3747,9 @@ static void translate_raw_stats(rgw_bucket_dir_header& header, map<RGWObjCategor
     RGWStorageStats& s = stats[category];
     struct rgw_bucket_category_stats& header_stats = iter->second;
     s.category = (RGWObjCategory)iter->first;
-    s.num_kb = ((header_stats.total_size + 1023) / 1024);
-    s.num_kb_rounded = ((header_stats.total_size_rounded + 1023) / 1024);
-    s.num_objects = header_stats.num_entries;
+    s.num_kb += ((header_stats.total_size + 1023) / 1024);
+    s.num_kb_rounded += ((header_stats.total_size_rounded + 1023) / 1024);
+    s.num_objects += header_stats.num_entries;
   }
 }
 
@@ -3693,21 +3758,22 @@ int RGWRados::bucket_check_index(rgw_bucket& bucket,
 				 map<RGWObjCategory, RGWStorageStats> *calculated_stats)
 {
   librados::IoCtx index_ctx;
-  string oid;
-
-  int ret = open_bucket_index(bucket, index_ctx, oid);
+  // key   - oid (for different shards if there is any)
+  // value - check result for the corresponding oid (shard), it is filled by the AIO callback
+  map<string, struct rgw_cls_check_index_ret> results;
+  int ret = open_bucket_index(bucket, index_ctx, results);
   if (ret < 0)
     return ret;
 
-  rgw_bucket_dir_header existing_header;
-  rgw_bucket_dir_header calculated_header;
-
-  ret = cls_rgw_bucket_check_index_op(index_ctx, oid, &existing_header, &calculated_header);
+  ret = cls_rgw_bucket_check_index_op(index_ctx, results, cct->_conf->rgw_bucket_index_max_aio);
   if (ret < 0)
     return ret;
 
-  translate_raw_stats(existing_header, *existing_stats);
-  translate_raw_stats(calculated_header, *calculated_stats);
+  map<string, struct rgw_cls_check_index_ret>::iterator iter;
+  for (iter = results.begin(); iter != results.end(); ++iter) {
+    accumulate_raw_stats(iter->second.existing_header, *existing_stats);
+    accumulate_raw_stats(iter->second.calculated_header, *calculated_stats);
+  }
 
   return 0;
 }
@@ -3715,13 +3781,12 @@ int RGWRados::bucket_check_index(rgw_bucket& bucket,
 int RGWRados::bucket_rebuild_index(rgw_bucket& bucket)
 {
   librados::IoCtx index_ctx;
-  string oid;
-
-  int ret = open_bucket_index(bucket, index_ctx, oid);
+  vector<string> bucket_objs;
+  int ret = open_bucket_index(bucket, index_ctx, bucket_objs);
   if (ret < 0)
     return ret;
 
-  return cls_rgw_bucket_rebuild_index_op(index_ctx, oid);
+  return cls_rgw_bucket_rebuild_index_op(index_ctx, bucket_objs, cct->_conf->rgw_bucket_index_max_aio);
 }
 
 
@@ -5213,53 +5278,98 @@ int RGWRados::obj_stat(void *ctx, rgw_obj& obj, uint64_t *psize, time_t *pmtime,
   return 0;
 }
 
-int RGWRados::get_bucket_stats(rgw_bucket& bucket, uint64_t *bucket_ver, uint64_t *master_ver, map<RGWObjCategory, RGWStorageStats>& stats,
+int RGWRados::get_bucket_stats(rgw_bucket& bucket, string& bucket_ver, string& master_ver, map<RGWObjCategory, RGWStorageStats>& stats,
                                string *max_marker)
 {
-  rgw_bucket_dir_header header;
-  int r = cls_bucket_head(bucket, header);
+  map<string, rgw_bucket_dir_header> headers;
+  int r = cls_bucket_head(bucket, headers);
   if (r < 0)
     return r;
 
   stats.clear();
+  map<string, rgw_bucket_dir_header>::iterator iter;
+  char buf[100];
+  for (iter = headers.begin(); iter != headers.end(); ++iter) {
+    accumulate_raw_stats(iter->second, stats);
+    if (bucket_ver.length()) {
+      bucket_ver.append(",");
+      master_ver.append(",");
+      if (max_marker) {
+        max_marker->append(",");
+      }
+    }
+    snprintf(buf, sizeof(buf), "%s#%lu", iter->first.c_str(), iter->second.ver);
+    bucket_ver.append(buf);
+    snprintf(buf, sizeof(buf), "%s#%lu", iter->first.c_str(), iter->second.master_ver);
+    master_ver.append(buf);
 
-  translate_raw_stats(header, stats);
-
-  *bucket_ver = header.ver;
-  *master_ver = header.master_ver;
-
-  if (max_marker)
-    *max_marker = header.max_marker;
+    if (max_marker) {
+      max_marker->append(iter->first.c_str());
+      max_marker->append("#");
+      max_marker->append(iter->second.max_marker);
+    }
+  }
 
   return 0;
 }
 
 class RGWGetBucketStatsContext : public RGWGetDirHeader_CB {
   RGWGetBucketStats_CB *cb;
+  uint32_t pendings;
+  map<RGWObjCategory, RGWStorageStats> stats;
+  uint64_t ver;
+  uint64_t master_ver;
+  string max_marker;
+  int ret_code;
+  bool should_cb;
+  Mutex lock;
 
 public:
-  RGWGetBucketStatsContext(RGWGetBucketStats_CB *_cb) : cb(_cb) {}
+  RGWGetBucketStatsContext(RGWGetBucketStats_CB *_cb, uint32_t _pendings) : cb(_cb),
+    pendings(_pendings), stats(), ver(0), master_ver(0), max_marker(),
+    ret_code(0), should_cb(true), lock("RGWGetBucketStatsContext") {}
   void handle_response(int r, rgw_bucket_dir_header& header) {
-    map<RGWObjCategory, RGWStorageStats> stats;
+    Mutex::Locker l(lock);
+    if (should_cb) {
+      if (r >= 0)
+        accumulate_raw_stats(header, stats);
+      else
+        ret_code = r;
 
-    if (r >= 0) {
-      translate_raw_stats(header, stats);
-      cb->set_response(header.ver, header.master_ver, &stats, header.max_marker);
+      // Are we all done?
+      if (--pendings == 0) {
+        if (ret_code == 0)
+          cb->set_response(ver, master_ver, &stats, max_marker);
+        cb->handle_response(r);
+        cb->put();
+      }
     }
+  }
 
-    cb->handle_response(r);
-
-    cb->put();
+  void unset_cb() {
+    Mutex::Locker l(lock);
+    should_cb = false;
   }
 };
 
 int RGWRados::get_bucket_stats_async(rgw_bucket& bucket, RGWGetBucketStats_CB *ctx)
 {
-  RGWGetBucketStatsContext *get_ctx = new RGWGetBucketStatsContext(ctx);
-  int r = cls_bucket_head_async(bucket, get_ctx);
+  RGWBucketInfo binfo;
+  int r = get_bucket_info(NULL, bucket.name, binfo, NULL, NULL);
+  if (r < 0)
+    return r;
+
+  int num_aio = 0;
+  RGWGetBucketStatsContext *get_ctx = new RGWGetBucketStatsContext(ctx, binfo.num_shards);
+  r = cls_bucket_head_async(bucket, static_cast<RGWGetDirHeader_CB*>(get_ctx->get()), &num_aio);
+  get_ctx->put();
   if (r < 0) {
     ctx->put();
-    delete get_ctx;
+    // If there is no request out (thus no callback), just release the object
+    if (num_aio == 0)
+      delete get_ctx;
+    else
+      get_ctx->unset_cb();
     return r;
   }
 
@@ -5632,21 +5742,24 @@ int RGWRados::update_containers_stats(map<string, RGWBucketEnt>& m)
     RGWBucketEnt& ent = iter->second;
     rgw_bucket& bucket = ent.bucket;
 
-    rgw_bucket_dir_header header;
-    int r = cls_bucket_head(bucket, header);
+    map<string, rgw_bucket_dir_header> headers;
+    int r = cls_bucket_head(bucket, headers);
     if (r < 0)
       return r;
 
     ent.count = 0;
     ent.size = 0;
 
-    RGWObjCategory category = main_category;
-    map<uint8_t, struct rgw_bucket_category_stats>::iterator iter = header.stats.find((uint8_t)category);
-    if (iter != header.stats.end()) {
-      struct rgw_bucket_category_stats& stats = iter->second;
-      ent.count = stats.num_entries;
-      ent.size = stats.total_size;
-      ent.size_rounded = stats.total_size_rounded;
+    map<string, rgw_bucket_dir_header>::iterator hiter;
+    for (hiter = headers.begin(); hiter != headers.end(); ++hiter) { 
+      RGWObjCategory category = main_category;
+      map<uint8_t, struct rgw_bucket_category_stats>::iterator iter = (hiter->second.stats).find((uint8_t)category);
+      if (iter != hiter->second.stats.end()) {
+        struct rgw_bucket_category_stats& stats = iter->second;
+        ent.count += stats.num_entries;
+        ent.size += stats.total_size;
+        ent.size_rounded += stats.total_size_rounded;
+      }
     }
   }
 
@@ -5772,23 +5885,47 @@ int RGWRados::list_raw_objects(rgw_bucket& pool, const string& prefix_filter,
 int RGWRados::list_bi_log_entries(rgw_bucket& bucket, string& marker, uint32_t max,
                                   std::list<rgw_bi_log_entry>& result, bool *truncated)
 {
+  ldout(cct, 20) << __func__ << bucket << " marker " << marker << " max " << max << dendl;
   result.clear();
 
   librados::IoCtx index_ctx;
-  string oid;
-  int r = open_bucket_index(bucket, index_ctx, oid);
+  map<string, cls_rgw_bi_log_list_ret> list_results;
+  int r = open_bucket_index(bucket, index_ctx, list_results);
   if (r < 0)
     return r;
 
-  std::list<rgw_bi_log_entry> entries;
-  int ret = cls_rgw_bi_log_list(index_ctx, oid, marker, max - result.size(), entries, truncated);
+  int ret = cls_rgw_bi_log_list(index_ctx, list_results, marker, max - result.size(), cct->_conf->rgw_bucket_index_max_aio);
   if (ret < 0)
     return ret;
 
-  std::list<rgw_bi_log_entry>::iterator iter;
-  for (iter = entries.begin(); iter != entries.end(); ++iter) {
-    result.push_back(*iter);
+  map<string, cls_rgw_bi_log_list_ret>::iterator miter;
+  string max_entry_id;
+  // We need to refresh marker
+  marker = "";
+  for (miter = list_results.begin(); miter != list_results.end(); ++miter) {
+    std::list<rgw_bi_log_entry>::iterator iter;
+    for (iter = miter->second.entries.begin(); iter != miter->second.entries.end(); ++iter) {
+      rgw_bi_log_entry& entry = *iter;
+      // If there are multiple shards, we compose the marker with the following schema:
+      //   {shard_id_0}#{largest_entity_id_for_this_shard},{shard_id_1}#{largest_entity_id_for_this_shard}...
+      if (list_results.size() > 1) {
+        string tmp_entry_id = miter->first;
+        tmp_entry_id.append("#");
+        tmp_entry_id.append(entry.id);
+        entry.id = tmp_entry_id; 
+      }
+      result.push_back(entry);
+      max_entry_id = entry.id;
+    }
+    if (marker.length()) {
+      marker.append(",");
+    }
+    marker.append(max_entry_id);
+    if (truncated) {
+      (*truncated) = (*truncated) || miter->second.truncated;
+    }
   }
+  ldout(cct, 20) << __func__ << " refreshed marker: " << marker << dendl;
 
   return 0;
 }
@@ -5796,12 +5933,12 @@ int RGWRados::list_bi_log_entries(rgw_bucket& bucket, string& marker, uint32_t m
 int RGWRados::trim_bi_log_entries(rgw_bucket& bucket, string& start_marker, string& end_marker)
 {
   librados::IoCtx index_ctx;
-  string oid;
-  int r = open_bucket_index(bucket, index_ctx, oid);
+  vector<string> bucket_objs;
+  int r = open_bucket_index(bucket, index_ctx, bucket_objs);
   if (r < 0)
     return r;
 
-  int ret = cls_rgw_bi_log_trim(index_ctx, oid, start_marker, end_marker);
+  int ret = cls_rgw_bi_log_trim(index_ctx, bucket_objs, start_marker, end_marker, cct->_conf->rgw_bucket_index_max_aio);
   if (ret < 0)
     return ret;
 
@@ -5848,15 +5985,15 @@ int RGWRados::cls_obj_prepare_op(rgw_bucket& bucket, RGWModifyOp op, string& tag
                                  string& name, string& locator)
 {
   librados::IoCtx index_ctx;
-  string oid;
-
-  int r = open_bucket_index(bucket, index_ctx, oid);
+  string bucket_obj;
+  int r = open_bucket_index(bucket, index_ctx, name, bucket_obj);
   if (r < 0)
     return r;
-
+  ldout(cct, 20) << " bucket index object: " << bucket_obj << dendl;
+ 
   ObjectWriteOperation o;
   cls_rgw_bucket_prepare_op(o, op, tag, name, locator, zone_public_config.log_data);
-  r = index_ctx.operate(oid, &o);
+  r = index_ctx.operate(bucket_obj, &o);
   return r;
 }
 
@@ -5866,11 +6003,11 @@ int RGWRados::cls_obj_complete_op(rgw_bucket& bucket, RGWModifyOp op, string& ta
 				  list<string> *remove_objs)
 {
   librados::IoCtx index_ctx;
-  string oid;
-
-  int r = open_bucket_index(bucket, index_ctx, oid);
+  string bucket_obj;
+  int r = open_bucket_index(bucket, index_ctx, ent.name, bucket_obj);
   if (r < 0)
     return r;
+  ldout(cct, 20) << " bucket index object: " << bucket_obj << dendl;
 
   ObjectWriteOperation o;
   rgw_bucket_dir_entry_meta dir_meta;
@@ -5888,7 +6025,7 @@ int RGWRados::cls_obj_complete_op(rgw_bucket& bucket, RGWModifyOp op, string& ta
   cls_rgw_bucket_complete_op(o, op, tag, ver, ent.name, dir_meta, remove_objs, zone_public_config.log_data);
 
   AioCompletion *c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
-  r = index_ctx.aio_operate(oid, c, &o);
+  r = index_ctx.aio_operate(bucket_obj, c, &o);
   c->release();
   return r;
 }
@@ -5920,92 +6057,90 @@ int RGWRados::cls_obj_complete_cancel(rgw_bucket& bucket, string& tag, string& n
 int RGWRados::cls_obj_set_bucket_tag_timeout(rgw_bucket& bucket, uint64_t timeout)
 {
   librados::IoCtx index_ctx;
-  string oid;
-
-  int r = open_bucket_index(bucket, index_ctx, oid);
+  vector<string> bucket_objs;
+  int r = open_bucket_index(bucket, index_ctx, bucket_objs);
   if (r < 0)
     return r;
 
-  ObjectWriteOperation o;
-  cls_rgw_bucket_set_tag_timeout(o, timeout);
-
-  r = index_ctx.operate(oid, &o);
-
-  return r;
+  return cls_rgw_bucket_set_tag_timeout(index_ctx, bucket_objs, timeout, cct->_conf->rgw_bucket_index_max_aio);
 }
 
-int RGWRados::cls_bucket_list(rgw_bucket& bucket, string start, string prefix,
-		              uint32_t num, map<string, RGWObjEnt>& m,
-			      bool *is_truncated, string *last_entry,
-			      bool (*force_check_filter)(const string&  name))
+int RGWRados::cls_bucket_list(rgw_bucket& bucket, const string& start, const string& prefix,
+		                      uint32_t suggest_num, map<string, RGWObjEnt>& m,
+			                  bool *is_truncated, bool (*force_check_filter)(const string&  name))
 {
-  ldout(cct, 10) << "cls_bucket_list " << bucket << " start " << start << " num " << num << dendl;
+  ldout(cct, 10) << "cls_bucket_list " << bucket << " start " << start << " suggested num " << suggest_num << dendl;
 
   librados::IoCtx index_ctx;
-  string oid;
-  int r = open_bucket_index(bucket, index_ctx, oid);
+  // key   - oid (for different shards if there is any)
+  // value - list result for the corresponding oid (shard), it is filled by the AIO callback
+  map<string, struct rgw_cls_list_ret> list_results;
+  int r = open_bucket_index(bucket, index_ctx, list_results);
   if (r < 0)
     return r;
 
-  struct rgw_bucket_dir dir;
-  r = cls_rgw_list_op(index_ctx, oid, start, prefix, num, &dir, is_truncated);
-  if (r < 0)
+  r = cls_rgw_list_op(index_ctx, start, prefix, suggest_num, list_results, cct->_conf->rgw_bucket_index_max_aio);
+  if (r < 0) {
     return r;
+  }
 
-  map<string, struct rgw_bucket_dir_entry>::iterator miter;
-  bufferlist updates;
-  for (miter = dir.m.begin(); miter != dir.m.end(); ++miter) {
-    RGWObjEnt e;
-    rgw_bucket_dir_entry& dirent = miter->second;
+  // Aggregate the listing results from different bucket index objects
+  map<string, struct rgw_cls_list_ret>::const_iterator liter;
+  *is_truncated = false;
+  for (liter = list_results.begin(); liter != list_results.end(); ++liter) {
+    bufferlist updates;
+    struct rgw_bucket_dir dir = liter->second.dir;
+    *is_truncated = (*is_truncated || liter->second.is_truncated);
+    map<string, struct rgw_bucket_dir_entry>::iterator miter;
+    for (miter = dir.m.begin(); miter != dir.m.end(); ++miter) {
+      rgw_bucket_dir_entry& dirent = miter->second;
+      /* oh, that shouldn't happen! */
+      if (dirent.name.empty()) {
+        ldout(cct, 0) << "WARNING: got empty dirent name, skipping" << dendl;
+        continue;
+      }
 
-    // fill it in with initial values; we may correct later
-    e.name = dirent.name;
-    e.size = dirent.meta.size;
-    e.mtime = dirent.meta.mtime;
-    e.etag = dirent.meta.etag;
-    e.owner = dirent.meta.owner;
-    e.owner_display_name = dirent.meta.owner_display_name;
-    e.content_type = dirent.meta.content_type;
-    e.tag = dirent.tag;
+      // fill it in with initial values; we may correct later
+      RGWObjEnt e;
+      e.name = dirent.name;
+      e.size = dirent.meta.size;
+      e.mtime = dirent.meta.mtime;
+      e.etag = dirent.meta.etag;
+      e.owner = dirent.meta.owner;
+      e.owner_display_name = dirent.meta.owner_display_name;
+      e.content_type = dirent.meta.content_type;
+      e.tag = dirent.tag;
 
-    /* oh, that shouldn't happen! */
-    if (e.name.empty()) {
-      ldout(cct, 0) << "WARNING: got empty dirent name, skipping" << dendl;
-      continue;
-    }
-
-    bool force_check = force_check_filter && force_check_filter(dirent.name);
-
-    if (!dirent.exists || !dirent.pending_map.empty() || force_check) {
-      /* there are uncommitted ops. We need to check the current state,
-       * and if the tags are old we need to do cleanup as well. */
-      librados::IoCtx sub_ctx;
-      sub_ctx.dup(index_ctx);
-      r = check_disk_state(sub_ctx, bucket, dirent, e, updates);
-      if (r < 0) {
-        if (r == -ENOENT)
-          continue;
-        else
-          return r;
+      bool force_check = force_check_filter && force_check_filter(dirent.name);
+      if (!dirent.exists || !dirent.pending_map.empty() || force_check) {
+        /* there are uncommitted ops. We need to check the current state,
+         * and if the tags are old we need to do cleanup as well. */
+        librados::IoCtx sub_ctx;
+        sub_ctx.dup(index_ctx);
+        r = check_disk_state(sub_ctx, bucket, dirent, e, updates);
+        if (r < 0) {
+          if (r == -ENOENT)
+            continue;
+          else
+            return r;
+        }
+      }
+      m[e.name] = e;
+      ldout(cct, 10) << "RGWRados::cls_bucket_list: got " << e.name << dendl;
+ 
+      // Suggest updates if there is any
+      if (updates.length()) {
+        ObjectWriteOperation o;
+        cls_rgw_suggest_changes(o, updates);
+        // we don't care if we lose suggested updates, send them off blindly
+        AioCompletion *c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+        index_ctx.aio_operate(liter->first, c, &o);
+        c->release();
       }
     }
-    m[e.name] = e;
-    ldout(cct, 10) << "RGWRados::cls_bucket_list: got " << e.name << dendl;
   }
 
-  if (dir.m.size()) {
-    *last_entry = dir.m.rbegin()->first;
-  }
-
-  if (updates.length()) {
-    ObjectWriteOperation o;
-    cls_rgw_suggest_changes(o, updates);
-    // we don't care if we lose suggested updates, send them off blindly
-    AioCompletion *c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
-    r = index_ctx.aio_operate(oid, c, &o);
-    c->release();
-  }
-  return m.size();
+  return 0;
 }
 
 int RGWRados::cls_obj_usage_log_add(const string& oid, rgw_usage_log_info& info)
@@ -6072,29 +6207,30 @@ int RGWRados::remove_objs_from_index(rgw_bucket& bucket, list<string>& oid_list)
   librados::IoCtx index_ctx;
   string dir_oid;
 
-  int r = open_bucket_index(bucket, index_ctx, dir_oid);
+  int r = open_bucket_index_base(bucket, index_ctx, dir_oid);
   if (r < 0)
     return r;
 
-  bufferlist updates;
+  // This should be directly served from cache
+  RGWBucketInfo binfo;
+  r = get_bucket_info(NULL, bucket.name, binfo, NULL, NULL);
+  if (r < 0)
+    return r;
 
+  map<string, vector<rgw_bucket_dir_entry> > updates;
   list<string>::iterator iter;
-
   for (iter = oid_list.begin(); iter != oid_list.end(); ++iter) {
     string& oid = *iter;
     dout(2) << "RGWRados::remove_objs_from_index bucket=" << bucket << " oid=" << oid << dendl;
     rgw_bucket_dir_entry entry;
     entry.ver.epoch = (uint64_t)-1; // ULLONG_MAX, needed to that objclass doesn't skip out request
     entry.name = oid;
-    updates.append(CEPH_RGW_REMOVE);
-    ::encode(entry, updates);
+    string bucket_obj;
+    get_bucket_index_obj(dir_oid, oid, bucket_obj, binfo.num_shards);
+    updates[bucket_obj].push_back(entry);
   }
 
-  bufferlist out;
-
-  r = index_ctx.exec(dir_oid, "rgw", "dir_suggest_changes", updates, out);
-
-  return r;
+  return cls_rgw_bucket_remove_objs_op(index_ctx, updates, cct->_conf->rgw_bucket_index_max_aio);
 }
 
 int RGWRados::check_disk_state(librados::IoCtx io_ctx,
@@ -6198,34 +6334,44 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
   return 0;
 }
 
-int RGWRados::cls_bucket_head(rgw_bucket& bucket, struct rgw_bucket_dir_header& header)
+int RGWRados::cls_bucket_head(rgw_bucket& bucket, map<string, struct rgw_bucket_dir_header>& headers)
 {
   librados::IoCtx index_ctx;
-  string oid;
-  int r = open_bucket_index(bucket, index_ctx, oid);
+  map<string, struct rgw_cls_list_ret> list_results;
+  int r = open_bucket_index(bucket, index_ctx, list_results);
   if (r < 0)
     return r;
 
-  r = cls_rgw_get_dir_header(index_ctx, oid, &header);
+  r = cls_rgw_get_dir_header(index_ctx, list_results, cct->_conf->rgw_bucket_index_max_aio);
   if (r < 0)
     return r;
+
+  map<string, struct rgw_cls_list_ret>::iterator iter;
+  for (iter = list_results.begin(); iter != list_results.end(); ++iter) {
+    headers[iter->first] = iter->second.dir.header;
+  }
 
   return 0;
 }
 
-int RGWRados::cls_bucket_head_async(rgw_bucket& bucket, RGWGetDirHeader_CB *ctx)
+int RGWRados::cls_bucket_head_async(rgw_bucket& bucket, RGWGetDirHeader_CB *ctx, int* num_aio)
 {
   librados::IoCtx index_ctx;
-  string oid;
-  int r = open_bucket_index(bucket, index_ctx, oid);
+  vector<string> bucket_objs;
+  int r = open_bucket_index(bucket, index_ctx, bucket_objs);
   if (r < 0)
     return r;
 
-  r = cls_rgw_get_dir_header_async(index_ctx, oid, ctx);
-  if (r < 0)
-    return r;
-
-  return 0;
+  int ret = 0;
+  vector<string>::iterator iter;
+  for (iter = bucket_objs.begin(); iter != bucket_objs.end(); ++iter) {
+    r = cls_rgw_get_dir_header_async(index_ctx, *iter, ctx);
+    if (r < 0)
+      return r;
+    else
+      (*num_aio)++;
+  }
+  return ret;
 }
 
 int RGWRados::cls_user_get_header(const string& user_id, cls_user_header *header)
@@ -6276,8 +6422,8 @@ int RGWRados::cls_user_get_header_async(const string& user_id, RGWGetUserHeader_
 
 int RGWRados::cls_user_sync_bucket_stats(rgw_obj& user_obj, rgw_bucket& bucket)
 {
-  rgw_bucket_dir_header header;
-  int r = cls_bucket_head(bucket, header);
+  map<string, struct rgw_bucket_dir_header> headers;
+  int r = cls_bucket_head(bucket, headers);
   if (r < 0) {
     ldout(cct, 20) << "cls_bucket_header() returned " << r << dendl;
     return r;
@@ -6287,12 +6433,15 @@ int RGWRados::cls_user_sync_bucket_stats(rgw_obj& user_obj, rgw_bucket& bucket)
 
   bucket.convert(&entry.bucket);
 
-  map<uint8_t, struct rgw_bucket_category_stats>::iterator iter = header.stats.begin();
-  for (; iter != header.stats.end(); ++iter) {
-    struct rgw_bucket_category_stats& header_stats = iter->second;
-    entry.size += header_stats.total_size;
-    entry.size_rounded += header_stats.total_size_rounded;
-    entry.count += header_stats.num_entries;
+  map<string, struct rgw_bucket_dir_header>::iterator hiter;
+  for (hiter = headers.begin(); hiter != headers.end(); ++hiter) {
+    map<uint8_t, struct rgw_bucket_category_stats>::iterator iter = hiter->second.stats.begin();
+    for (; iter != hiter->second.stats.end(); ++iter) {
+      struct rgw_bucket_category_stats& header_stats = iter->second;
+      entry.size += header_stats.total_size;
+      entry.size_rounded += header_stats.total_size_rounded;
+      entry.count += header_stats.num_entries;
+    }
   }
 
   list<cls_user_bucket_entry> entries;
@@ -6511,6 +6660,34 @@ int RGWRados::remove_temp_objects(string date, string time)
   return 0;
 }
 
+void RGWRados::get_bucket_index_objs(const string& bucket_oid_base,
+        vector<string>& bucket_objs, uint32_t num_shards)
+{
+  if (!num_shards) {
+    bucket_objs.push_back(bucket_oid_base);
+  } else {
+    char buf[100];
+    for (uint32_t i = 0; i < num_shards; ++i) {
+      snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), i);
+      bucket_objs.push_back(string(buf));
+    }
+  }
+}
+
+void RGWRados::get_bucket_index_obj(const string& bucket_oid_base, const string& obj_key,
+        string& bucket_obj, uint32_t num_shards)
+{
+  if (!num_shards) {
+    // By default with no sharding, we use the bucket oid as itself
+    bucket_obj = bucket_oid_base;
+  } else {
+    uint32_t sid = ceph_str_hash_linux(obj_key.c_str(), obj_key.size()) % num_shards;
+    char buf[100];
+    snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), sid);
+    bucket_obj = buf;
+  }
+}
+
 int RGWRados::process_intent_log(rgw_bucket& bucket, string& oid,
 				 time_t epoch, int flags, bool purge)
 {
@@ -6584,19 +6761,22 @@ int RGWRados::process_intent_log(rgw_bucket& bucket, string& oid,
         break;
       } else {
         librados::IoCtx index_ctx;
-        string oid;
-        int r = open_bucket_index(entry.obj.bucket, index_ctx, oid);
+        vector<string> oids;
+        int r = open_bucket_index(entry.obj.bucket, index_ctx, oids);
         if (r < 0)
           return r;
-        ObjectWriteOperation op;
-        op.remove();
-        oid.append(entry.obj.bucket.marker);
-        librados::AioCompletion *completion = rados->aio_create_completion(NULL, NULL, NULL);
-        r = index_ctx.aio_operate(oid, completion, &op);
-        completion->release();
-        if (r < 0 && r != -ENOENT) {
-          cerr << "failed to remove bucket: " << entry.obj.bucket << std::endl;
-          complete = false;
+        vector<string>::iterator oiter;
+        for (oiter = oids.begin(); oiter != oids.end(); ++oiter) {
+          ObjectWriteOperation op;
+          op.remove();
+          librados::AioCompletion *completion = rados->aio_create_completion(NULL, NULL, NULL);
+          r = index_ctx.aio_operate(*oiter, completion, &op);
+          completion->release();
+          if (r < 0 && r != -ENOENT) {
+            cerr << "failed to remove bucket: " << entry.obj.bucket << std::endl;
+            complete = false;
+            break;
+          }
         }
       }
       break;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1126,8 +1126,8 @@ public:
 class RGWGetBucketStats_CB : public RefCountedObject {
 protected:
   rgw_bucket bucket;
-  uint64_t bucket_ver;
-  uint64_t master_ver;
+  string bucket_ver;
+  string master_ver;
   map<RGWObjCategory, RGWStorageStats> *stats;
   string max_marker;
 public:
@@ -1181,9 +1181,21 @@ class RGWRados
   int open_bucket_index_ctx(rgw_bucket& bucket, librados::IoCtx&  index_ctx);
   int open_bucket_data_ctx(rgw_bucket& bucket, librados::IoCtx&  io_ctx);
   int open_bucket_data_extra_ctx(rgw_bucket& bucket, librados::IoCtx&  io_ctx);
-  int open_bucket_index(rgw_bucket& bucket, librados::IoCtx&  index_ctx, string& bucket_oid);
+  int open_bucket_index_base(rgw_bucket& bucket, librados::IoCtx&  index_ctx,
+          string& bucket_oid_base);
 
-  struct GetObjState {
+  /** open bucket index methods, open the bucket index IO context,
+   *  and populate the bucket index object(s)
+   */
+  template<typename T>
+  int open_bucket_index(rgw_bucket& bucket, librados::IoCtx& index_ctx,
+          map<string, T>& bucket_objs);
+  int open_bucket_index(rgw_bucket& bucket, librados::IoCtx& index_ctx,
+          vector<string>& bucket_objs);
+  int open_bucket_index(rgw_bucket& bucket, librados::IoCtx& index_ctx,
+          const string& obj_key, string& bucket_oid);
+
+   struct GetObjState {
     librados::IoCtx io_ctx;
     bool sent_data;
 
@@ -1220,6 +1232,10 @@ class RGWRados
   uint64_t max_bucket_id;
 
   uint64_t max_chunk_size;
+
+  // This field represents the number of bucket index object shards, it is initialized
+  // from the configuration
+  uint32_t max_bucket_index_shards;
 
   int get_obj_state(RGWRadosCtx *rctx, rgw_obj& obj, RGWObjState **state, RGWObjVersionTracker *objv_tracker);
   int append_atomic_test(RGWRadosCtx *rctx, rgw_obj& obj,
@@ -1286,6 +1302,7 @@ public:
                watch_initialized(false),
                bucket_id_lock("rados_bucket_id"), max_bucket_id(0),
                max_chunk_size(0),
+               max_bucket_index_shards(0),
                cct(NULL), rados(NULL),
                pools_initialized(false),
                quota_handler(NULL),
@@ -1719,7 +1736,7 @@ public:
   }
 
   int decode_policy(bufferlist& bl, ACLOwner *owner);
-  int get_bucket_stats(rgw_bucket& bucket, uint64_t *bucket_ver, uint64_t *master_ver, map<RGWObjCategory, RGWStorageStats>& stats,
+  int get_bucket_stats(rgw_bucket& bucket, string& bucket_ver, string& master_ver, map<RGWObjCategory, RGWStorageStats>& stats,
                        string *max_marker);
   int get_bucket_stats_async(rgw_bucket& bucket, RGWGetBucketStats_CB *cb);
   int get_user_stats(const string& user, RGWStorageStats& stats);
@@ -1752,11 +1769,21 @@ public:
   int cls_obj_complete_del(rgw_bucket& bucket, string& tag, int64_t pool, uint64_t epoch, string& name);
   int cls_obj_complete_cancel(rgw_bucket& bucket, string& tag, string& name);
   int cls_obj_set_bucket_tag_timeout(rgw_bucket& bucket, uint64_t timeout);
-  int cls_bucket_list(rgw_bucket& bucket, string start, string prefix, uint32_t num,
-                      map<string, RGWObjEnt>& m, bool *is_truncated,
-                      string *last_entry, bool (*force_check_filter)(const string&  name) = NULL);
-  int cls_bucket_head(rgw_bucket& bucket, struct rgw_bucket_dir_header& header);
-  int cls_bucket_head_async(rgw_bucket& bucket, RGWGetDirHeader_CB *ctx);
+  int cls_bucket_list(rgw_bucket& bucket, const string& start, const string& prefix,
+                      uint32_t suggest_num,  map<string, RGWObjEnt>& m, bool *is_truncated,
+                      bool (*force_check_filter)(const string&  name) = NULL);
+  int cls_bucket_head(rgw_bucket& bucket, map<string, struct rgw_bucket_dir_header>& headers);
+
+  /**
+   * Issue bucket head request async.
+   *
+   * bucket  - the bucket.
+   * ctx     - the callback to caller.
+   * num_aio - number of AIOs issued.
+   *
+   * Return 0 on success, a failure code otherwise.
+   */
+  int cls_bucket_head_async(rgw_bucket& bucket, RGWGetDirHeader_CB *ctx, int* num_aio);
   int prepare_update_index(RGWObjState *state, rgw_bucket& bucket,
                            RGWModifyOp op, rgw_obj& oid, string& tag);
   int complete_update_index(rgw_bucket& bucket, string& oid, string& tag, int64_t poolid, uint64_t epoch, uint64_t size,
@@ -1852,6 +1879,29 @@ public:
   }
 
  private:
+  /**
+   * This is a helper method, it generates a list of bucket index objects with the given
+   * bucket base oid and number of shards.
+   *
+   * bucket_oid_base - base name of the bucket index object;
+   * bucket_objs - filled by this method, a list of bucket index objects.
+   * num_shards - number of bucket index object shards.
+   */
+  void get_bucket_index_objs(const string& bucket_oid_base, vector<string>& bucket_objs,
+          uint32_t num_shards);
+
+  /**
+   * Get the bucket index object with the given base bucket index object and object key,
+   * and the number of bucket index shards.
+   *
+   * bucket_oid_base - bucket object base name.
+   * obj_key - object key.
+   * bucket_obj - the bucket index object for the given object.
+   * num_shards - number of bucket index shards.
+   */
+  void get_bucket_index_obj(const string& bucket_oid_base, const string& obj_key,
+          string& bucket_obj, uint32_t num_shards);
+
   int process_intent_log(rgw_bucket& bucket, string& oid,
 			 time_t epoch, int flags, bool purge);
   /**

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -317,7 +317,7 @@ void RGWOp_BILog_List::execute() {
 
     count += entries.size();
 
-    send_response(entries, marker);
+    send_response(entries);
   } while (truncated && count < max_entries);
 
   send_response_end();
@@ -339,13 +339,12 @@ void RGWOp_BILog_List::send_response() {
   s->formatter->open_array_section("entries");
 }
 
-void RGWOp_BILog_List::send_response(list<rgw_bi_log_entry>& entries, string& marker)
+void RGWOp_BILog_List::send_response(list<rgw_bi_log_entry>& entries)
 {
   for (list<rgw_bi_log_entry>::iterator iter = entries.begin(); iter != entries.end(); ++iter) {
     rgw_bi_log_entry& entry = *iter;
     encode_json("entry", entry, s->formatter);
 
-    marker = entry.id;
     flusher.flush();
   }
 }
@@ -380,7 +379,7 @@ void RGWOp_BILog_Info::execute() {
     }
   }
   map<RGWObjCategory, RGWStorageStats> stats;
-  int ret =  store->get_bucket_stats(bucket_info.bucket, &bucket_ver, &master_ver, stats, &max_marker);
+  int ret =  store->get_bucket_stats(bucket_info.bucket, bucket_ver, master_ver, stats, &max_marker);
   if (ret < 0 && ret != -ENOENT) {
     http_ret = ret;
     return;

--- a/src/rgw/rgw_rest_log.h
+++ b/src/rgw/rgw_rest_log.h
@@ -29,7 +29,7 @@ public:
     return check_caps(s->user.caps);
   }
   virtual void send_response();
-  virtual void send_response(list<rgw_bi_log_entry>& entries, string& marker);
+  virtual void send_response(list<rgw_bi_log_entry>& entries);
   virtual void send_response_end();
   void execute();
   virtual const string name() {
@@ -38,11 +38,11 @@ public:
 };
 
 class RGWOp_BILog_Info : public RGWRESTOp {
-  uint64_t bucket_ver;
-  uint64_t master_ver;
+  string bucket_ver;
+  string master_ver;
   string max_marker;
 public:
-  RGWOp_BILog_Info() : bucket_ver(0), master_ver(0) {}
+  RGWOp_BILog_Info() : bucket_ver(), master_ver() {}
   ~RGWOp_BILog_Info() {}
 
   int check_caps(RGWUserCaps& caps) {


### PR DESCRIPTION
This is the phase one implementation of the bucket index sharding strategy at radosgw, key changes include:
1. Static shard bucket index objects to a configured number of objects.
2. Listing / stats become more expensive due to the fact that it needs to talk to a couple of bucket index shards.

Everything should work as it did with the default configuration. 

Testing:
1. Covered object PUT/DELETE, bucket CREATE/LISTING/REMOVAL.
2. Keep radosgw run a couple of hours making sure background thread works.

Todo:
1. Make radosgw-agent to work with the new schema change for marker for bi log.

Signed-off-by: Guang Yang (yguang@yahoo-inc.com)
