### PR TITLE
Make <poolname> in "ceph osd tier --help" clearer (fix issue 8256).

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -585,11 +585,13 @@ COMMAND("osd tier add " \
 	"name=pool,type=CephPoolname " \
 	"name=tierpool,type=CephPoolname " \
 	"name=force_nonempty,type=CephChoices,strings=--force-nonempty,req=false",
-	"add the tier <tierpool> to base pool <pool>", "osd", "rw", "cli,rest")
+	"add the tier <tierpool> (the second one) to base pool <pool> (the first one)", \
+	"osd", "rw", "cli,rest")
 COMMAND("osd tier remove " \
 	"name=pool,type=CephPoolname " \
 	"name=tierpool,type=CephPoolname",
-	"remove the tier <tierpool> from base pool <pool>", "osd", "rw", "cli,rest")
+	"remove the tier <tierpool> (the second one) from base pool <pool> (the first one)", \
+	"osd", "rw", "cli,rest")
 COMMAND("osd tier cache-mode " \
 	"name=pool,type=CephPoolname " \
 	"name=mode,type=CephChoices,strings=none|writeback|forward|readonly", \
@@ -606,7 +608,7 @@ COMMAND("osd tier add-cache " \
 	"name=pool,type=CephPoolname " \
 	"name=tierpool,type=CephPoolname " \
 	"name=size,type=CephInt,range=0", \
-	"add a cache <tierpool> of size <size> to existing pool <pool>", \
+	"add a cache <tierpool> (the second one) of size <size> to existing pool <pool> (the first one)", \
 	"osd", "rw", "cli,rest")
 
 /*


### PR DESCRIPTION
Make &lt;poolname&gt; in "ceph osd tier --help" clearer.

The ceph osd tier --help info on the left always says &lt;poolname&gt;:

&quot;osd tier add &lt;poolname&gt; &lt;poolname&gt; force-nonempty}&quot;

Two &lt;poolname&gt; are the same. It is unclear which one to put &lt;tierpool&gt; according to descriptions the right:

&quot;add the tier &lt;tierpool&gt; to base pool &lt;pool&gt;&quot;

This patch modifies descriptions on the right to tell which &lt;poolname&gt;:

&quot;add the tier &lt;tierpool&gt; (the secondone) to base pool &lt;pool&gt; (the first one)&quot;

Fix: http://tracker.ceph.com/issues/8256

Signed-off-by: Yilong Zhao &lt;accelazh@gmail.com&gt;
