### PR TITLE
log the command that is being run with subprocess

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -280,7 +280,7 @@ def command(arguments, **kwargs):
     process in a tuple: (output, returncode).
     """
     arguments = _get_command_executable(arguments)
-
+    LOG.info('Running command: %s' % ' '.join(arguments))
     process = subprocess.Popen(
         arguments,
         stdout=subprocess.PIPE,
@@ -300,6 +300,7 @@ def command_check_call(arguments):
     otherwise.
     """
     arguments = _get_command_executable(arguments)
+    LOG.info('Running command: %s' % ' '.join(arguments))
     return subprocess.check_call(arguments)
 
 


### PR DESCRIPTION
Exposes the commands at `INFO` level so that it is clear what is going on when ceph-disk is called.

Below is output (stderr coming from ceph-disk is interpreted as yellow `warning` level by ceph-deploy) from calling ceph-disk with ceph-deploy to create an OSD:
![screen shot 2014-06-20 at 11 38 09 am](https://cloud.githubusercontent.com/assets/317847/3342327/3d83159c-f891-11e3-8f0e-f37e97d3ac7a.png)
