### PR TITLE
doc: Fixed Typo in pools documentation - replaced '-' with '_' in eg

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -135,11 +135,11 @@ Set Pool Quotas
 You can set pool quotas for the maximum number of bytes and/or the maximum 
 number of objects per pool. ::
 
-	ceph osd pool set-quota {pool-name} [max-objects {obj-count}] [max_bytes {bytes}] 
+	ceph osd pool set-quota {pool-name} [max_objects {obj-count}] [max_bytes {bytes}] 
 
 For example:: 
 
-	ceph osd pool set-quota data max-objects 10000
+	ceph osd pool set-quota data max_objects 10000
 
 To remove a quota, set its value to ``0``.
 


### PR DESCRIPTION
Examples incorrectly had 'max-objects' where they should have had 'max_objects'
