### PR TITLE
Bucket index sharding for radosgw:

### DIFF
--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -15,7 +15,20 @@ public:
 /* bucket index */
 void cls_rgw_bucket_init(librados::ObjectWriteOperation& o);
 
-void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& o, uint64_t tag_timeout);
+/**
+ * Init bucket index objects.
+ *
+ * io_ctx      - IO context for rados.
+ * bucket_objs - a lit of bucket index objects.
+ * max_io      - the maximum number of AIO (for throttling).
+ *
+ * Reutrn 0 on success, a failure code otherwise.
+ */
+int cls_rgw_bucket_index_init_op(librados::IoCtx &io_ctx,
+        const vector<string>& bucket_objs, uint32_t max_io);
+
+int cls_rgw_bucket_set_tag_timeout(librados::IoCtx& io_ctx,
+        const vector<string>& bucket_objs, uint64_t tag_timeout, uint32_t max_io);
 
 void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, string& tag,
                                string& name, string& locator, bool log_op);
@@ -24,16 +37,76 @@ void cls_rgw_bucket_complete_op(librados::ObjectWriteOperation& o, RGWModifyOp o
                                 rgw_bucket_entry_ver& ver, string& name, rgw_bucket_dir_entry_meta& dir_meta,
 				list<string> *remove_objs, bool log_op);
 
-int cls_rgw_list_op(librados::IoCtx& io_ctx, string& oid, string& start_obj,
-                    string& filter_prefix, uint32_t num_entries,
-                    rgw_bucket_dir *dir, bool *is_truncated);
+/**
+ * List the bucket with the starting object and filter prefix.
+ * NOTE: this method do listing requests for each bucket index shards identified by
+ *       the keys of the *list_results* map, which means the map should be popludated
+ *       by the caller to fill with each bucket index object id.
+ *
+ * io_ctx        - IO context for rados.
+ * start_obj     - marker for the listing.
+ * filter_prefix - filer prefix.
+ * num_entries   - number of entries to request for each object (note the total
+ *                 amount of entries returned depends on the number of shardings).
+ * list_results  - the list results keyed by bucket index object id.
+ * max_aio       - the maximum number of AIO (for throttling).
+ *
+ * Return 0 on success, a failure code otherwise.
+*/
+int cls_rgw_list_op(librados::IoCtx& io_ctx, const string & start_obj,
+                    const string& filter_prefix, uint32_t num_entries,
+                    map<string, struct rgw_cls_list_ret>& list_results,
+                    uint32_t max_aio);
 
-int cls_rgw_bucket_check_index_op(librados::IoCtx& io_ctx, string& oid,
-				  rgw_bucket_dir_header *existing_header,
-				  rgw_bucket_dir_header *calculated_header);
-int cls_rgw_bucket_rebuild_index_op(librados::IoCtx& io_ctx, string& oid);
+/**
+ * Check the bucket index.
+ *
+ * io_ctx  - IO context for rados.
+ * results - the results keyed by the bubcket index object id (shard).
+ * max_io  - the maximum number of AIO (for throttling).
+ *
+ * Return 0 on success, a failure code otherwise.
+ */
+int cls_rgw_bucket_check_index_op(librados::IoCtx& io_ctx,
+        map<string, struct rgw_cls_check_index_ret>& results, uint32_t max_io);
+
+/**
+ * Rebuild the bucket index.
+ *
+ * io_ctx      - IO context for rados.
+ * bucket_objs - a list of bucket objects (shard) to operate.
+ * max_io      - the maximum number of AIO (for throttling).
+ *
+ * Return 0 on success, a failure code otherwise.
+ */
+int cls_rgw_bucket_rebuild_index_op(librados::IoCtx& io_ctx, const vector<string>& bucket_objs,
+        uint32_t max_io);
   
-int cls_rgw_get_dir_header(librados::IoCtx& io_ctx, string& oid, rgw_bucket_dir_header *header);
+/**
+ * Remove objects from bucket index entry.
+ *
+ * io_ctx   - IO context for rados.
+ * updates  - a list of updates to perform. Key is the bucket index object id (shard),
+ *            value is a list of entries to remove.
+ * max_io   - the maximum number of AIO (for throttling).
+ *
+ * Return 0 on success, a failure code otherwise.
+ */
+int cls_rgw_bucket_remove_objs_op(librados::IoCtx& io_ctx,
+        const map<string, vector<rgw_bucket_dir_entry> >& updates, uint32_t max_io);
+
+/**
+ * Get dir headers with a bucket.
+ *
+ * io_ctx       - IO context for rados.
+ * list_results - list results for headers, keyed by the object index object id (shard).
+ * max_io       - maximum number of AIO (for throttling).
+ *
+ * Return 0 on success, a failure code otherwise.
+ */
+int cls_rgw_get_dir_header(librados::IoCtx& io_ctx,
+        map<string, rgw_cls_list_ret>& headers, uint32_t max_io);
+
 int cls_rgw_get_dir_header_async(librados::IoCtx& io_ctx, string& oid, RGWGetDirHeader_CB *ctx);
 
 void cls_rgw_encode_suggestion(char op, rgw_bucket_dir_entry& dirent, bufferlist& updates);
@@ -42,9 +115,10 @@ void cls_rgw_suggest_changes(librados::ObjectWriteOperation& o, bufferlist& upda
 
 /* bucket index log */
 
-int cls_rgw_bi_log_list(librados::IoCtx& io_ctx, string& oid, string& marker, uint32_t max,
-                    list<rgw_bi_log_entry>& entries, bool *truncated);
-int cls_rgw_bi_log_trim(librados::IoCtx& io_ctx, string& oid, string& start_marker, string& end_marker);
+int cls_rgw_bi_log_list(librados::IoCtx& io_ctx, map<string, struct cls_rgw_bi_log_list_ret>& list_results,
+        string& marker, uint32_t max, uint32_t max_io);
+int cls_rgw_bi_log_trim(librados::IoCtx& io_ctx, vector<string>& bucket_objs, string& start_marker,
+        string& end_marker, uint32_t max_io);
 
 /* usage logging */
 int cls_rgw_usage_log_read(librados::IoCtx& io_ctx, string& oid, string& user,
@@ -65,5 +139,35 @@ int cls_rgw_gc_list(librados::IoCtx& io_ctx, string& oid, string& marker, uint32
                     list<cls_rgw_gc_obj_info>& entries, bool *truncated);
 
 void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const list<string>& tags);
+
+/**
+ * This helper method iterates the given AIO completion list and wait for completion
+ * of all of them.
+ *
+ * completions - a list of AIO completions.
+ *
+ * Return 0 on success, otherwise a failure code.
+ */
+int cls_rgw_util_wait_for_complete(const vector<librados::AioCompletion*>& completions);
+
+/**
+ * This helper method iterates the given AIO completion list and wait for the completion
+ * and callbacks of all of them.
+ *
+ * completions - a list of AIO completions.
+ *
+ * Return 0 on success, a failure code otherwise.
+ */
+int cls_rgw_util_wait_for_complete_and_cb(const vector<librados::AioCompletion*>& completions);
+
+/**
+ * Parse markers (key as object id, value as marker for the object) from the given marker string.
+ *
+ * marker   - the original marker string, with schema: {oid}#{marker},{oid}#{marker}...
+ * markers  - the output markers map with oid as key and marker as value.
+ *
+ * Return 0 on succes, a failure code otherwise.
+ */
+int cls_rgw_util_parse_markers(const string& marker, map<string, string>& markers);
 
 #endif

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -749,6 +749,20 @@ OPTION(nss_db_path, OPT_STR, "") // path to nss db
 
 OPTION(rgw_max_chunk_size, OPT_INT, 512 * 1024)
 
+/**
+ * Represents the number of shards for the bucket index object, a value of zero
+ * indicates there is no sharding. By default (no sharding, the name of the object
+ * is '.dir.{marker}', with sharding, the name is '.dir.{markder}.{sharding_id}',
+ * sharding_id is zero-based value. It is not recommended to set a too large value
+ * (e.g. thousand) as it increases the cost for bucket listing.
+ */
+OPTION(rgw_bucket_index_max_shards, OPT_U32, 0)
+
+/**
+ * Represents the maximum AIO operations for the bucket index object shards.
+ */
+OPTION(rgw_bucket_index_max_aio, OPT_U32, 8)
+
 OPTION(rgw_data, OPT_STR, "/var/lib/ceph/radosgw/$cluster-$id")
 OPTION(rgw_enable_apis, OPT_STR, "s3, swift, swift_auth, admin")
 OPTION(rgw_cache_enabled, OPT_BOOL, true)   // rgw cache enabled

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -516,9 +516,9 @@ int bucket_stats(rgw_bucket& bucket, Formatter *formatter)
     return r;
 
   map<RGWObjCategory, RGWStorageStats> stats;
-  uint64_t bucket_ver, master_ver;
+  string bucket_ver, master_ver;
   string max_marker;
-  int ret = store->get_bucket_stats(bucket, &bucket_ver, &master_ver, stats, &max_marker);
+  int ret = store->get_bucket_stats(bucket, bucket_ver, master_ver, stats, &max_marker);
   if (ret < 0) {
     cerr << "error getting bucket stats ret=" << ret << std::endl;
     return ret;
@@ -532,8 +532,8 @@ int bucket_stats(rgw_bucket& bucket, Formatter *formatter)
   formatter->dump_string("marker", bucket.marker);
   formatter->dump_string("owner", bucket_info.owner);
   formatter->dump_int("mtime", mtime);
-  formatter->dump_int("ver", bucket_ver);
-  formatter->dump_int("master_ver", master_ver);
+  formatter->dump_string("ver", bucket_ver);
+  formatter->dump_string("master_ver", master_ver);
   formatter->dump_string("max_marker", max_marker);
   dump_bucket_usage(stats, formatter);
   formatter->close_section();
@@ -1903,8 +1903,7 @@ next:
     while (is_truncated) {
       map<string, RGWObjEnt> result;
       int r = store->cls_bucket_list(bucket, marker, prefix, 1000, 
-                                     result, &is_truncated, &marker,
-                                     bucket_object_check_filter);
+                                     result, &is_truncated, bucket_object_check_filter);
 
       if (r < 0 && r != -ENOENT) {
         cerr << "ERROR: failed operation r=" << r << std::endl;
@@ -1941,6 +1940,10 @@ next:
 
         formatter->close_section();
         formatter->flush(cout);
+      }
+      // Refresh marker
+      if (!result.empty()) {
+        marker = result.rbegin()->first;
       }
     }
     formatter->close_section();
@@ -2274,8 +2277,6 @@ next:
       for (list<rgw_bi_log_entry>::iterator iter = entries.begin(); iter != entries.end(); ++iter) {
         rgw_bi_log_entry& entry = *iter;
         encode_json("entry", entry, formatter);
-
-        marker = entry.id;
       }
       formatter->flush(cout);
     } while (truncated && count < max_entries);

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -355,9 +355,9 @@ int rgw_remove_bucket(RGWRados *store, const string& bucket_owner, rgw_bucket& b
   RGWBucketInfo info;
   bufferlist bl;
 
-  uint64_t bucket_ver, master_ver;
+  string bucket_ver, master_ver;
 
-  ret = store->get_bucket_stats(bucket, &bucket_ver, &master_ver, stats, NULL);
+  ret = store->get_bucket_stats(bucket, bucket_ver, master_ver, stats, NULL);
   if (ret < 0)
     return ret;
 
@@ -727,13 +727,16 @@ int RGWBucket::check_object_index(RGWBucketAdminOpState& op_state,
     map<string, RGWObjEnt> result;
 
     int r = store->cls_bucket_list(bucket, marker, prefix, 1000, result,
-             &is_truncated, &marker,
-             bucket_object_check_filter);
+             &is_truncated, bucket_object_check_filter);
 
     if (r == -ENOENT) {
       break;
     } else if (r < 0 && r != -ENOENT) {
       set_err_msg(err_msg, "ERROR: failed operation r=" + cpp_strerror(-r));
+    }
+    // Refresh marker
+    if (!result.empty()) {
+      marker = result.rbegin()->first;
     }
   }
 
@@ -954,9 +957,9 @@ static int bucket_stats(RGWRados *store, std::string&  bucket_name, Formatter *f
 
   bucket = bucket_info.bucket;
 
-  uint64_t bucket_ver, master_ver;
+  string bucket_ver, master_ver;
   string max_marker;
-  int ret = store->get_bucket_stats(bucket, &bucket_ver, &master_ver, stats, &max_marker);
+  int ret = store->get_bucket_stats(bucket, bucket_ver, master_ver, stats, &max_marker);
   if (ret < 0) {
     cerr << "error getting bucket stats ret=" << ret << std::endl;
     return ret;
@@ -969,8 +972,8 @@ static int bucket_stats(RGWRados *store, std::string&  bucket_name, Formatter *f
   formatter->dump_string("id", bucket.bucket_id);
   formatter->dump_string("marker", bucket.marker);
   formatter->dump_string("owner", bucket_info.owner);
-  formatter->dump_int("ver", bucket_ver);
-  formatter->dump_int("master_ver", master_ver);
+  formatter->dump_string("ver", bucket_ver);
+  formatter->dump_string("master_ver", master_ver);
   formatter->dump_int("mtime", mtime);
   formatter->dump_string("max_marker", max_marker);
   dump_bucket_usage(stats, formatter);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -729,9 +729,12 @@ struct RGWBucketInfo
   RGWObjVersionTracker objv_tracker; /* we don't need to serialize this, for runtime tracking */
   obj_version ep_objv; /* entry point object version, for runtime tracking only */
   RGWQuotaInfo quota;
+  // Represents the number of bucket index object shards, a value of zero indicates there
+  // is no sharding of the bucket index object
+  uint32_t num_shards;
 
   void encode(bufferlist& bl) const {
-     ENCODE_START(9, 4, bl);
+     ENCODE_START(10, 4, bl);
      ::encode(bucket, bl);
      ::encode(owner, bl);
      ::encode(flags, bl);
@@ -741,6 +744,7 @@ struct RGWBucketInfo
      ::encode(placement_rule, bl);
      ::encode(has_instance_obj, bl);
      ::encode(quota, bl);
+     ::encode(num_shards, bl);
      ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
@@ -763,6 +767,8 @@ struct RGWBucketInfo
        ::decode(has_instance_obj, bl);
      if (struct_v >= 9)
        ::decode(quota, bl);
+     if (struct_v >= 10)
+       ::decode(num_shards, bl);
      DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -318,11 +318,11 @@ int RGWBucketStatsCache::fetch_stats_from_storage(const string& user, rgw_bucket
 {
   RGWBucketInfo bucket_info;
 
-  uint64_t bucket_ver;
-  uint64_t master_ver;
+  string bucket_ver;
+  string master_ver;
 
   map<RGWObjCategory, RGWStorageStats> bucket_stats;
-  int r = store->get_bucket_stats(bucket, &bucket_ver, &master_ver, bucket_stats, NULL);
+  int r = store->get_bucket_stats(bucket, bucket_ver, master_ver, bucket_stats, NULL);
   if (r < 0) {
     ldout(store->ctx(), 0) << "could not get bucket info for bucket=" << bucket.name << dendl;
     return r;

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -317,7 +317,7 @@ void RGWOp_BILog_List::execute() {
 
     count += entries.size();
 
-    send_response(entries, marker);
+    send_response(entries);
   } while (truncated && count < max_entries);
 
   send_response_end();
@@ -339,13 +339,12 @@ void RGWOp_BILog_List::send_response() {
   s->formatter->open_array_section("entries");
 }
 
-void RGWOp_BILog_List::send_response(list<rgw_bi_log_entry>& entries, string& marker)
+void RGWOp_BILog_List::send_response(list<rgw_bi_log_entry>& entries)
 {
   for (list<rgw_bi_log_entry>::iterator iter = entries.begin(); iter != entries.end(); ++iter) {
     rgw_bi_log_entry& entry = *iter;
     encode_json("entry", entry, s->formatter);
 
-    marker = entry.id;
     flusher.flush();
   }
 }
@@ -380,7 +379,7 @@ void RGWOp_BILog_Info::execute() {
     }
   }
   map<RGWObjCategory, RGWStorageStats> stats;
-  int ret =  store->get_bucket_stats(bucket_info.bucket, &bucket_ver, &master_ver, stats, &max_marker);
+  int ret =  store->get_bucket_stats(bucket_info.bucket, bucket_ver, master_ver, stats, &max_marker);
   if (ret < 0 && ret != -ENOENT) {
     http_ret = ret;
     return;

--- a/src/rgw/rgw_rest_log.h
+++ b/src/rgw/rgw_rest_log.h
@@ -29,7 +29,7 @@ public:
     return check_caps(s->user.caps);
   }
   virtual void send_response();
-  virtual void send_response(list<rgw_bi_log_entry>& entries, string& marker);
+  virtual void send_response(list<rgw_bi_log_entry>& entries);
   virtual void send_response_end();
   void execute();
   virtual const string name() {
@@ -38,11 +38,11 @@ public:
 };
 
 class RGWOp_BILog_Info : public RGWRESTOp {
-  uint64_t bucket_ver;
-  uint64_t master_ver;
+  string bucket_ver;
+  string master_ver;
   string max_marker;
 public:
-  RGWOp_BILog_Info() : bucket_ver(0), master_ver(0) {}
+  RGWOp_BILog_Info() : bucket_ver(), master_ver() {}
   ~RGWOp_BILog_Info() {}
 
   int check_caps(RGWUserCaps& caps) {


### PR DESCRIPTION
This patch implements the bucket index object sharding for radosgw, it adds a configuration to let user specify the number of shards for each bucket index object, and changes all related operations to make it work with multiple shards.

Testing:
1. Covered object PUT/DELETE, bucket CREATE/LISTING/REMOVAL.
2. Keep radosgw run a couple of hours making sure background thread works.
3. Test BI logs to make sure shard object id is part of the listing result so that we can do pre-fix listing.

Todo:
Make radosgw-agent to work with the new schema change for marker for bi log, this should be an easy change after we agree on the schema change brought by this patch.

Signed-off-by: Guang Yang (yguang@yahoo-inc.com)
