### PR TITLE
do_autogen.sh: --disable-static

### DIFF
--- a/do_autogen.sh
+++ b/do_autogen.sh
@@ -29,7 +29,7 @@ die() {
 debug_level=0
 verbose=0
 profile=0
-CONFIGURE_FLAGS=""
+CONFIGURE_FLAGS="--disable-static"
 while getopts  "d:e:hHTPjpnvO:" flag
 do
     case $flag in


### PR DESCRIPTION
This will make builds go ~2x as fast when developing.

Reported-by: Luis Pabon lpabon@redhat.com Signed-off-by: Sage Weil
sage@inktank.com
