### PR TITLE
Support 'expected_num_objects' parameter when creating pool for pg folder splitting

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -538,7 +538,8 @@ COMMAND("osd pool create " \
 	"name=pgp_num,type=CephInt,range=0,req=false " \
         "name=pool_type,type=CephChoices,strings=replicated|erasure,req=false " \
 	"name=erasure_code_profile,type=CephString,req=false,goodchars=[A-Za-z0-9-_.=] " \
-	"name=ruleset,type=CephString,req=false,goodchars=[A-Za-z0-9-_.=]", \
+	"name=ruleset,type=CephString,req=false,goodchars=[A-Za-z0-9-_.=] " \
+	"name=expected_num_objects,type=CephInt,req=false", \
 	"create pool", "osd", "rw", "cli,rest")
 COMMAND("osd pool delete " \
 	"name=pool,type=CephPoolname " \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2919,12 +2919,12 @@ int OSDMonitor::prepare_new_pool(MPoolOp *m)
     return prepare_new_pool(m->name, m->auid, m->crush_rule, ruleset_name,
 			    0, 0,
                             erasure_code_profile,
-			    pg_pool_t::TYPE_REPLICATED, ss);
+			    pg_pool_t::TYPE_REPLICATED, 0, ss);
   else
     return prepare_new_pool(m->name, session->auid, m->crush_rule, ruleset_name,
 			    0, 0,
                             erasure_code_profile,
-			    pg_pool_t::TYPE_REPLICATED, ss);
+			    pg_pool_t::TYPE_REPLICATED, 0, ss);
 }
 
 int OSDMonitor::crush_ruleset_create_erasure(const string &name,
@@ -3201,6 +3201,7 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
                                  unsigned pg_num, unsigned pgp_num,
 				 const string &erasure_code_profile,
                                  const unsigned pool_type,
+                                 const uint64_t expected_num_objects,
 				 stringstream &ss)
 {
   int r;
@@ -3236,6 +3237,7 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
 
   pi->size = size;
   pi->min_size = min_size;
+  pi->expected_num_objects = expected_num_objects;
   pi->crush_ruleset = crush_ruleset;
   pi->object_hash = CEPH_STR_HASH_RJENKINS;
   pi->set_pg_num(pg_num ? pg_num : g_conf->osd_pool_default_pg_num);
@@ -4835,11 +4837,20 @@ done:
       }
     }
 
+    int64_t expected_num_objects;
+    cmd_getval(g_ceph_context, cmdmap, "expected_num_objects", expected_num_objects, int64_t(0));
+    if (expected_num_objects < 0) {
+      ss << "'expected_num_objects' must be non-negative";
+      err = -EINVAL;
+      goto reply;
+    }
+
     err = prepare_new_pool(poolstr, 0, // auid=0 for admin created pool
 			   -1, // default crush rule
 			   ruleset_name,
 			   pg_num, pgp_num,
 			   erasure_code_profile, pool_type,
+                           (uint64_t)expected_num_objects,
 			   ss);
     if (err < 0) {
       switch(err) {

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -275,6 +275,7 @@ private:
                        unsigned pg_num, unsigned pgp_num,
 		       const string &erasure_code_profile,
                        const unsigned pool_type,
+                       const uint64_t expected_num_objects,
 		       stringstream &ss);
   int prepare_new_pool(MPoolOp *m);
 

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -4462,7 +4462,10 @@ int FileStore::_create_collection(
 {
   char fn[PATH_MAX];
   get_cdir(c, fn, sizeof(fn));
-  dout(15) << "create_collection " << fn << dendl;
+  dout(15) << "create_collection " << fn
+    << ", expected number of objects in this collection: "
+    << c.get_coll_expected_num_objects()
+    << " pg number of this collection: " << c.get_coll_pg_num() << dendl;
   int r = ::mkdir(fn, 0755);
   if (r < 0)
     r = -errno;

--- a/src/os/HashIndex.h
+++ b/src/os/HashIndex.h
@@ -267,6 +267,14 @@ private:
     vector<string> *path   ///< [out] Path components for hoid.
     );
 
+  /// Pre-hash and split folders to avoid runtime splitting,
+  /// based on the number of objects estimation given by user.
+  int pre_split_folder();
+
+  /// Initialize the folder (dir info) with the given hash level and number
+  /// of its subdirs.
+  int init_split_folder(vector<string> &paths, uint32_t hash_level);
+
   /// do collection split for path
   static int col_split_level(
     HashIndex &from,            ///< [in] from index
@@ -316,6 +324,25 @@ private:
       *bits = path.size() * 4;
   }
 
+  /// Calculate the number of bits.
+  static int calc_bits(uint64_t n) {
+    int ret = 0;
+    while (n > 0) {
+      n = n >> 1;
+      ret++;
+    }
+    return ret;
+  }
+  
+  /// Convert a number to hex string (upper case).
+  static string to_hex(int n) {
+    assert(n >= 0 && n < 16);
+    char c = (n <= 9 ? ('0' + n) : ('A' + n - 10));
+    string str;
+    str.append(1, c);
+    return str;
+  }
+
   /// Get path contents by hash
   int get_path_contents_by_hash(
     const vector<string> &path,            /// [in] Path to list
@@ -335,6 +362,11 @@ private:
     ghobject_t *next,            /// [in,out] List objects >= *next
     vector<ghobject_t> *out      /// [out] Listed objects
     ); ///< @return Error Code, 0 on success
+
+  /// Create the given levels of sub directories from the given root.
+  /// The contents of *path* is not changed after calling this function.
+  int create_path_recursive(
+      vector<string> &path, int level);
 };
 
 #endif

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -586,7 +586,7 @@ class TestOSD(TestArgparse):
         self.assert_valid_command(['osd', 'crush', 'dump'])
         assert_equal({}, validate_command(sigdict, ['osd', 'crush']))
         assert_equal({}, validate_command(sigdict, ['osd', 'crush',
-                                                    'dump', 
+                                                    'dump',
                                                     'toomany']))
 
     def test_setcrushmap(self):
@@ -948,6 +948,9 @@ class TestOSD(TestArgparse):
         self.assert_valid_command(['osd', 'pool', 'create',
                                    'poolname', '128', '128',
                                    'erasure', 'profile', 'ruleset'])
+        self.assert_valid_command(['osd', 'pool', 'create',
+                                   'poolname', '128', '128',
+                                   'erasure', 'profile', 'ruleset', '123456'])
         assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create']))
         assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
                                                     'poolname']))
@@ -967,6 +970,11 @@ class TestOSD(TestArgparse):
                                                     '128', '128',
                                                     'INVALID', 'profile',
                                                     'ruleset']))
+        assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
+                                                    'poolname',
+                                                    '128', '128',
+                                                    'erasure', 'profile',
+                                                    'ruleset', '-123456']))
 
     def test_pool_delete(self):
         self.assert_valid_command(['osd', 'pool', 'delete',
@@ -1123,7 +1131,7 @@ class TestConfigKey(TestArgparse):
     def test_list(self):
         self.check_no_arg('config-key', 'list')
 # Local Variables:
-# compile-command: "cd ../.. ; make -j4 && 
+# compile-command: "cd ../.. ; make -j4 &&
 #  PYTHONPATH=pybind nosetests --stop \
 #  test/pybind/test_ceph_argparse.py # test_ceph_argparse.py:TestOSD.test_rm"
 # End:


### PR DESCRIPTION
This patch adds a new parameter for pool creation named 'expected_num_objects', to give user a choice to specify the number of objects he/she would like to put into the pool. This information is used to pre-hash PG's namespace by creating a certain number of folders, so as to avoid run-time folder splitting which could saturate disk I/O.

Testing - test against various combinations of PG number and splittings.

Issue - as we add two new fields to coll_t struct, and given its encode/decode logic, when we bump up the version number, it could break old version software. This would request to upgrade all nodes before creating new pool.

Todo - doc the behavior.

Signed-off-by: Guang Yang (yguang@yahoo-inc.com)
