### PR TITLE
qa/workunits/suites/fsx.sh: don't use zero range

### DIFF
--- a/qa/workunits/suites/fsx.sh
+++ b/qa/workunits/suites/fsx.sh
@@ -6,6 +6,8 @@ git clone git://ceph.newdream.net/git/xfstests.git
 make -C xfstests
 cp xfstests/ltp/fsx .
 
-./fsx   1MB -N 50000 -p 10000 -l 1048576
-./fsx  10MB -N 50000 -p 10000 -l 10485760
-./fsx 100MB -N 50000 -p 10000 -l 104857600
+OPTIONS="-z"  # don't use zero range calls; not supported by cephfs
+
+./fsx $OPTIONS  1MB -N 50000 -p 10000 -l 1048576
+./fsx $OPTIONS  10MB -N 50000 -p 10000 -l 10485760
+./fsx $OPTIONS 100MB -N 50000 -p 10000 -l 104857600


### PR DESCRIPTION
Zero range is not supported by cephfs.

Fixes: #8542 Signed-off-by: Sage Weil sage@inktank.com
