### PR TITLE
rgw: fix uninit ofs in RGWObjManifect::obj_iterator

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -374,6 +374,7 @@ public:
     void init() {
       part_ofs = 0;
       stripe_ofs = 0;
+      ofs = 0;
       stripe_size = 0;
       cur_part_id = 0;
       cur_stripe = 0;


### PR DESCRIPTION
Valgrind picked this up:

  <kind>UninitCondition</kind>
 <what>Conditional jump or move depends on uninitialised value(s)</what>
 <stack>
   <frame>
     <ip>0x5145B8</ip>
     <obj>/usr/bin/radosgw</obj>
     <fn>RGWObjManifest::obj_iterator::seek(unsigned long)</fn>

<dir>/srv/autobuild-ceph/gitbuilder.git/build/out~/ceph-0.82-354-g62027ec/src/rgw</dir>
     <file>rgw_rados.cc</file>
     <line>562</line>
   </frame>
   <frame>
     <ip>0x5672A4</ip>
     <obj>/usr/bin/radosgw</obj>
     <fn>list_multipart_parts(RGWRados_, req_state_, std::string const&amp;,
std::string&amp;, int, int, std::map&lt;unsigned int, RGWUploadPartInfo,
std::less&lt;unsigned int&gt;, std::allocator&lt;std::pair&lt;unsigned int
const, RGWUploadPartInfo&gt; &gt; &gt;&amp;, int_, bool_, bool)</fn>

<dir>/srv/autobuild-ceph/gitbuilder.git/build/out~/ceph-0.82-354-g62027ec/src/rgw</dir>
     <file>rgw_rados.h</file>
     <line>217</line>
   </frame>
   <frame>
     <ip>0x5688EE</ip>
     <obj>/usr/bin/radosgw</obj>
     <fn>RGWListMultipart::execute()</fn>

<dir>/srv/autobuild-ceph/gitbuilder.git/build/out~/ceph-0.82-354-g62027ec/src/rgw</dir>
     <file>rgw_op.cc</file>
     <line>2956</line>
   </frame>
...

Fixes: #8699 Backport: firefly Signed-off-by: Sage Weil sage@inktank.com
