### PR TITLE
PGLog: fix clear() to avoid the IndexLog::zero() asserts

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -136,7 +136,7 @@ void PGLog::reset_backfill()
 void PGLog::clear() {
   divergent_priors.clear();
   missing.clear();
-  log.zero();
+  log.clear();
   log_keys_debug.clear();
   undirty();
 }

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -109,6 +109,11 @@ struct PGLog {
       rollback_info_trimmed_to_riter = log.rbegin();
       reset_recovery_pointers();
     }
+    void clear() {
+      rollback_info_trimmed_to = head;
+      rollback_info_trimmed_to_riter = log.rbegin();
+      zero();
+    }
     void reset_recovery_pointers() {
       complete_to = log.end();
       last_requested = 0;


### PR DESCRIPTION
Introduced in:
  c5b8d8105d965da852c79add607b69d5ae79a4d4
  ac11ca40b4f4525cbe9b1778b1c5d9472ecb9efa
Signed-off-by: Samuel Just sam.just@inktank.com
