### PR TITLE
mon: clear osd request queue latency info on down or up

### DIFF
--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -84,6 +84,20 @@ public:
       // 0 the stats for the osd
       osd_stat_updates[osd] = osd_stat_t();
     }
+    void stat_osd_down_up(int32_t osd, PGMap& pg_map) {
+      // 0 the op_queue_age_hist for this osd
+      map<int32_t,osd_stat_t>::iterator p = osd_stat_updates.find(osd);
+      if (p != osd_stat_updates.end()) {
+	p->second.op_queue_age_hist.clear();
+	return;
+      }
+      ceph::unordered_map<int32_t,osd_stat_t>::iterator q =
+	pg_map.osd_stat.find(osd);
+      if (q != pg_map.osd_stat.end()) {
+	osd_stat_t& t = osd_stat_updates[osd] = q->second;
+	t.op_queue_age_hist.clear();
+      }
+    }
     void rm_stat(int32_t osd) {
       osd_stat_rm.insert(osd);
       osd_epochs.erase(osd);

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -910,6 +910,11 @@ void PGMonitor::check_osd_map(epoch_t epoch)
         if (report != last_osd_report.end()) {
           last_osd_report.erase(report);
         }
+
+	// clear out osd_stat slow request histogram
+	dout(20) << __func__ << " clearing osd." << p->first
+		 << " request histogram" << dendl;
+	pending_inc.stat_osd_down_up(p->first, pg_map);
       }
 
       if (p->second & CEPH_OSD_EXISTS) {


### PR DESCRIPTION
It doesn't make sense to warn about slow requests on OSDs that are down; 
clear those stats in the monitor when we see an OSD go down (or up).

Fixes: #8692 Signed-off-by: Sage Weil sage@inktank.com
