### PR TITLE
ReplicatedPG: Removed the redundant register_snapset_context call

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -7111,7 +7111,6 @@ ObjectContextRef ReplicatedPG::get_object_context(const hobject_t& soid,
     obc->ssc = get_snapset_context(
       soid, true,
       soid.has_snapset() ? attrs : 0);
-    register_snapset_context(obc->ssc);
 
     populate_obc_watchers(obc);
 


### PR DESCRIPTION
In the get_object_context(), the get_snapset_context is been called
and the register_snapset_context is already been invoked from there.
This call seems to be redundant.

Signed-off-by: Somnath Roy somnath.roy@sandisk.com
