### PR TITLE
OSD: wake_pg_waiters after dropping pg lock

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1648,6 +1648,11 @@ protected:
   };
   res_result _try_resurrect_pg(
     OSDMapRef curmap, spg_t pgid, spg_t *resurrected, PGRef *old_pg_state);
+
+  /**
+   * After unlocking the pg, the user must ensure that wake_pg_waiters
+   * is called.
+   */
   PG   *_create_lock_pg(
     OSDMapRef createmap,
     spg_t pgid,


### PR DESCRIPTION
Otherwise, we dispatch_session_waiting while still holding the pg lock,
which is obviously wrong.  Unfortunately, this places an additional
burden on any user of _create_lock_pg, but I think it's unavoidable
since that method must atomically add the pg to the map and lock it.

Fixes: #8961
Introduced in:
  25466839589813047c975e44e67e14f34e32139e
  ecda2fef8ce982df3581a3b47ba74ae581d82479
Signed-off-by: Samuel Just sam.just@inktank.com
