### PR TITLE
OSD: adjust share_map() to handle the case that the osd is down

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4820,8 +4820,10 @@ void OSDService::share_map(
 	   << name << " " << con->get_peer_addr()
 	   << " " << epoch << dendl;
 
-  assert(osd->is_active() ||
-	 osd->is_stopping());
+  if ((!osd->is_active()) && (!osd->is_stopping())) {
+    /*It is safe not to proceed as OSD is not in healthy state*/
+    return;
+  }
 
   bool want_shared = should_share_map(name, con, epoch,
                                       osdmap, sent_epoch_p);


### PR DESCRIPTION
The assert was hitting while OSd is waiting for becoming healthy
in handle_osd_map(). This can happen while io is going on and
OSDs are made down forcefully by say osd thrash command.
So, the fix could be instead of asserting just return from here.

Fixes: http://tracker.ceph.com/issues/8646

Signed-off-by: Somnath Roy somnath.roy@sandisk.com
