### PR TITLE
ceph_argparse_flag has no regular 3rd parameter.

### DIFF
--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -81,7 +81,7 @@ int main(int argc, const char **argv)
       gen_print_key = true;
     } else if (ceph_argparse_witharg(args, i, &val, "-a", "--add-key", (char*)NULL)) {
       add_key = val;
-    } else if (ceph_argparse_flag(args, i, &val, "-l", "--list", (char*)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "-l", "--list", (char*)NULL)) {
       list = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--caps", (char*)NULL)) {
       caps_fn = val;


### PR DESCRIPTION
With clang warning: 'va_start' has undefined behavior with reference
types, noticing copy-paste mistake on ceph_argparse_flag.

Signed-off-by: Thorsten Behrens tbehrens@suse.com
