### PR TITLE
doc: mention kernel support for rbd format 2

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -55,7 +55,7 @@ Parameters
      does not support newer features like cloning.
 
    * format 2 - Use the second rbd format, which is supported by
-     librbd (but not the kernel rbd module) at this time. This adds
+     librbd and kernel since version 3.11 (except for striping). This adds
      support for cloning and is more easily extensible to allow more
      features in the future.
 

--- a/man/rbd.8
+++ b/man/rbd.8
@@ -105,7 +105,7 @@ understood by all versions of librbd and the kernel rbd module, but
 does not support newer features like cloning.
 .IP \(bu 2
 format 2 \- Use the second rbd format, which is supported by
-librbd (but not the kernel rbd module) at this time. This adds
+librbd and kernel since version 3.11 (except for striping). This adds
 support for cloning and is more easily extensible to allow more
 features in the future.
 .UNINDENT


### PR DESCRIPTION
Correct rbd(8) claim that kernel do not support format 2 images. Please review.
