### PR TITLE
decrement WBThrottle perfcounters in clear_object

### DIFF
--- a/src/os/WBThrottle.cc
+++ b/src/os/WBThrottle.cc
@@ -242,7 +242,10 @@ void WBThrottle::clear_object(const ghobject_t &hoid)
     return;
 
   cur_ios -= i->second.first.ios;
+  logger->dec(l_wbthrottle_ios_dirtied, i->second.first.ios);
   cur_size -= i->second.first.size;
+  logger->dec(l_wbthrottle_bytes_dirtied, i->second.first.size);
+  logger->dec(l_wbthrottle_inodes_dirtied);
 
   pending_wbs.erase(i);
   remove_object(hoid);


### PR DESCRIPTION
We observed that the WBThrottle perfcounters are leaking upwards
at a rate of around 50-100 ios_dirtied per day. The counters are
currently not decremented in clear_object, so that's the likely
explanation. Decrement them like elsewhere in WBThrottle.

Signed-off-by: Dan van der Ster daniel.vanderster@cern.ch
