### PR TITLE
tests: don't depend on 'data' pool in rbd test

### DIFF
--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -1,5 +1,7 @@
 ls on empty pool never containing images
 ========================================
+  $ ceph osd pool create rbd_other 8
+  pool 'rbd_other' created
   $ rados -p rbd rm rbd_directory >/dev/null 2>&1 || true
   $ rbd ls
   $ rbd ls --format json
@@ -26,9 +28,9 @@ snapshot
 clone
 =====
   $ rbd snap protect bar@snap
-  $ rbd clone bar@snap data/child
-  $ rbd snap create data/child@snap
-  $ rbd flatten data/child 2> /dev/null
+  $ rbd clone bar@snap rbd_other/child
+  $ rbd snap create rbd_other/child@snap
+  $ rbd flatten rbd_other/child 2> /dev/null
 
 lock
 ====
@@ -41,7 +43,7 @@ test formatting
 ===============
   $ rbd children foo@snap
   $ rbd children bar@snap
-  data/child
+  rbd_other/child
   $ rbd children bar@snap2
 TODO: figure out why .* does not match the block_name_prefix line in rbd info.
 For now, use a more inclusive regex.
@@ -274,14 +276,14 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
     <block_name_prefix>rb.0.*</block_name_prefix> (glob)
     <format>1</format>
   </image>
-  $ rbd info data/child
+  $ rbd info rbd_other/child
   rbd image 'child':
   \tsize 512 MB in 128 objects (esc)
   \torder 22 (4096 kB objects) (esc)
   [^^]+ (re)
   \tformat: 2 (esc)
   \tfeatures: layering (esc)
-  $ rbd info data/child --format json | python -mjson.tool
+  $ rbd info rbd_other/child --format json | python -mjson.tool
   {
       "block_name_prefix": "rbd_data.*",  (glob)
       "features": [
@@ -295,7 +297,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
       "order": 22, 
       "size": 536870912
   }
-  $ rbd info data/child --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
+  $ rbd info rbd_other/child --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
   <image>
     <name>child</name>
     <size>536870912</size>
@@ -309,7 +311,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
       <feature>striping</feature>
     </features>
   </image>
-  $ rbd info data/child@snap
+  $ rbd info rbd_other/child@snap
   rbd image 'child':
   \tsize 512 MB in 128 objects (esc)
   \torder 22 (4096 kB objects) (esc)
@@ -319,7 +321,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   \tprotected: False (esc)
   \tparent: rbd/bar@snap (esc)
   \toverlap: 512 MB (esc)
-  $ rbd info data/child@snap --format json | python -mjson.tool
+  $ rbd info rbd_other/child@snap --format json | python -mjson.tool
   {
       "block_name_prefix": "rbd_data.*",  (glob)
       "features": [
@@ -340,7 +342,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
       "protected": "false", 
       "size": 536870912
   }
-  $ rbd info data/child@snap --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
+  $ rbd info rbd_other/child@snap --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
   <image>
     <name>child</name>
     <size>536870912</size>
@@ -481,21 +483,21 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
       <lock_type>shared</lock_type>
     </image>
   </images>
-  $ rbd list data
+  $ rbd list rbd_other
   child
-  $ rbd list data --format json | python -mjson.tool
+  $ rbd list rbd_other --format json | python -mjson.tool
   [
       "child"
   ]
-  $ rbd list data --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
+  $ rbd list rbd_other --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
   <images>
     <name>child</name>
   </images>
-  $ rbd list data -l
+  $ rbd list rbd_other -l
   NAME       SIZE PARENT       FMT PROT LOCK 
   child      512M                2           
   child@snap 512M rbd/bar@snap   2           
-  $ rbd list data -l --format json | python -mjson.tool
+  $ rbd list rbd_other -l --format json | python -mjson.tool
   [
       {
           "format": 2, 
@@ -515,7 +517,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
           "snapshot": "snap"
       }
   ]
-  $ rbd list data -l --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
+  $ rbd list rbd_other -l --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
   <images>
     <image>
       <image>child</image>
@@ -649,10 +651,10 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   []
   $ rbd snap list baz --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
   <snapshots></snapshots>
-  $ rbd snap list data/child
+  $ rbd snap list rbd_other/child
   SNAPID NAME   SIZE 
       *snap*512*MB* (glob)
-  $ rbd snap list data/child --format json | python -mjson.tool
+  $ rbd snap list rbd_other/child --format json | python -mjson.tool
   [
       {
           "id": *,  (glob)
@@ -660,7 +662,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
           "size": 536870912
       }
   ]
-  $ rbd snap list data/child --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
+  $ rbd snap list rbd_other/child --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
   <snapshots>
     <snapshot>
       <id>*</id> (glob)
@@ -670,12 +672,14 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </snapshots>
 
 # cleanup
-  $ rbd snap remove data/child@snap
+  $ rbd snap remove rbd_other/child@snap
   $ rbd snap unprotect bar@snap
   $ rbd snap purge bar 2> /dev/null
   $ rbd snap purge foo 2> /dev/null
-  $ rbd rm data/child 2> /dev/null
+  $ rbd rm rbd_other/child 2> /dev/null
   $ rbd rm foo 2> /dev/null
   $ rbd rm bar 2> /dev/null
   $ rbd rm quux 2> /dev/null
   $ rbd rm baz 2> /dev/null
+  $ ceph osd pool delete rbd_other rbd_other --yes-i-really-really-mean-it
+  pool 'rbd_other' removed


### PR DESCRIPTION
Since we removed the default 'data' and 'metadata' pools,
tests which need a pool should create it themselves.

Signed-off-by: John Spray john.spray@redhat.com
