### PR TITLE
test: generalise default_pools in test_rados

### DIFF
--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -44,6 +44,9 @@ class TestRados(object):
         self.rados.conf_parse_env()
         self.rados.connect()
 
+        # Assume any pre-existing pools are the cluster's defaults
+        self.default_pools = self.rados.list_pools()
+
     def tearDown(self):
         self.rados.shutdown()
 
@@ -63,7 +66,8 @@ class TestRados(object):
 
     def list_non_default_pools(self):
         pools = self.rados.list_pools()
-        pools.remove('rbd')
+        for p in self.default_pools:
+            pools.remove(p)
         return set(pools)
 
     def test_list_pools(self):


### PR DESCRIPTION
Instead of fragile assumptions about what pools
do or do not exist by default, simply use what
exists at test setup time as a baseline.

Fixes: #8751

Signed-off-by: John Spray john.spray@redhat.com
