### PR TITLE
common: seq_read_bench argument order changed

### DIFF
--- a/src/common/obj_bencher.h
+++ b/src/common/obj_bencher.h
@@ -64,7 +64,7 @@ protected:
   int fetch_bench_metadata(const std::string& metadata_file, int* object_size, int* num_objects, int* prevPid);
 
   int write_bench(int secondsToRun, int maxObjects, int concurrentios, const string& run_name_meta);
-  int seq_read_bench(int secondsToRun, int concurrentios, int num_objects, int writePid);
+  int seq_read_bench(int secondsToRun, int num_objects, int concurrentios, int writePid);
   int rand_read_bench(int secondsToRun, int num_objects, int concurrentios, int writePid);
 
   int clean_up(int num_objects, int prevPid, int concurrentios);


### PR DESCRIPTION
The argument order for seq_read_bench in src/common/obj_bencher.h has
been changed to match the argument order in obj_bencher.cc

Calls to seq_read_bench already use the correct order.
seq_read_bench also matches the order of rand_read_bench and
write_bench

Signed-off-by: Kevin Dalley kevin@kelphead.org
