### PR TITLE
Wip 8306 rebase

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -592,6 +592,7 @@ fi
 %{_mandir}/man8/radosgw.8*
 %{_mandir}/man8/radosgw-admin.8*
 %{_sbindir}/rcceph-radosgw
+%config %{_sysconfdir}/bash_completion.d/radosgw-admin
 %dir %{_localstatedir}/log/radosgw/
 
 %post radosgw


### PR DESCRIPTION
This is a rebase of Sandon's work to split off ceph-common, along with a bunch of cleanup
recommended by other RPM packagers.
