### PR TITLE
messages: MForward: fix compat version

### DIFF
--- a/src/messages/MForward.h
+++ b/src/messages/MForward.h
@@ -31,7 +31,7 @@ struct MForward : public Message {
   uint64_t con_features;
 
   static const int HEAD_VERSION = 2;
-  static const int COMPAT_VERSION = 0;
+  static const int COMPAT_VERSION = 1;
 
   MForward() : Message(MSG_FORWARD, HEAD_VERSION, COMPAT_VERSION),
                tid(0), msg(NULL), con_features(0) {}


### PR DESCRIPTION
A while ago we bumped the head version and reset the compat version to 0.
Doing this so happens to make the messenger assume that the message does
not support the compat versioning and sets the compat version to the head
version -- thus making compat = 2 when it should have been 1.

The nasty side-effect of this is that upgrading from emperor to firefly
will have emperor-leaders being unable to decode forwarded messages from
firefly-peons.

Fixes: #8727

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
