### PR TITLE
ensure others can read the admin keyring

### DIFF
--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -101,6 +101,7 @@ def get_key(cluster, mon_id):
                     continue
 
             os.rename(tmp, path)
+            os.chmod(path, 0644)
             break
         finally:
             try:


### PR DESCRIPTION
![screen shot 2014-07-08 at 3 35 26 pm](https://cloud.githubusercontent.com/assets/317847/3515564/0dc73b0e-06d7-11e4-8ce3-2c27865434de.png)
Makes sure that others can at least read the admin keyring file

The attached image shows how the keyring is now readable after starting the mon daemon
