### PR TITLE
Fix the PG listing issue which could miss objects for EC pool

### DIFF
--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -610,7 +610,11 @@ int ObjectStore::collection_list_range(coll_t c, hobject_t start, hobject_t end,
 			    snapid_t seq, vector<hobject_t> *ls)
 {
   vector<ghobject_t> go;
-  ghobject_t gstart(start), gend(end);
+  // Starts with the smallest shard id and generation to
+  // make sure the result list has the marker object
+  ghobject_t gstart(start, 0, shard_id_t(0));
+  // Exclusive end, choose the smallest end ghobject
+  ghobject_t gend(end, 0, shard_id_t(0));
   int ret = collection_list_range(c, gstart, gend, seq, &go);
   if (ret == 0) {
     ls->reserve(go.size());

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -116,7 +116,11 @@ int PGBackend::objects_list_partial(
   hobject_t *next)
 {
   assert(ls);
-  ghobject_t _next(begin);
+  // Starts with the smallest shard id and generation to
+  // make sure the result list has the marker object (
+  // it might have multiple generations though, which would
+  // be filtered).
+  ghobject_t _next(begin, 0, shard_id_t(0));
   ls->reserve(max);
   int r = 0;
   while (!_next.is_max() && ls->size() < (unsigned)min) {


### PR DESCRIPTION
When doing a PG listing, the caller passed hobject_t as the marker (starting object), and for the collection listing (ObjectStore), it accepts a ghobject_t as the marker. The original implementation use the default generation (uint64_t max) and shard (uint8_t max) to compose a ghobject_t with a given hobject_t instance, however, this could break as the real shard ID is less than the default and thus it is skipped wrongly.

To fix this issue, we use the smallest generation and shard id.

Signed-off-by: Guang Yang (yguang@yahoo-inc.com)
