### PR TITLE
rbdmap: per-device mount (Closes: #8538)

### DIFF
--- a/src/init-rbdmap
+++ b/src/init-rbdmap
@@ -18,7 +18,7 @@
 # Description:       Ceph RBD Mapping
 ### END INIT INFO
 
-DESC="RBD Mapping"
+DESC="RBD Mapping:"
 RBDMAPFILE="/etc/ceph/rbdmap"
 
 . /lib/lsb/init-functions
@@ -29,9 +29,7 @@ do_map() {
 		exit 0
 	fi
 
-	log_daemon_msg "Starting $DESC"
 	# Read /etc/rbdtab to create non-existant mapping
-	newrbd=
 	RET=0
 	while read DEV PARAMS; do
 		case "$DEV" in
@@ -44,6 +42,10 @@ do_map() {
 			DEV=rbd/$DEV
 			;;
 		esac
+		log_action_begin_msg "${DESC} '${DEV}'"
+		newrbd=""
+		MAP_RV=""
+		RET_OP=0
 		OIFS=$IFS
 		IFS=','
 		for PARAM in ${PARAMS[@]}; do
@@ -51,39 +53,59 @@ do_map() {
 		done
 		IFS=$OIFS
 		if [ ! -b /dev/rbd/$DEV ]; then
-			log_progress_msg $DEV
-			rbd map $DEV $CMDPARAMS
-			[ $? -ne "0" ] && RET=1
-			newrbd="yes"
+			MAP_RV=$(rbd map $DEV $CMDPARAMS 2>&1)
+			if [ $? -eq 0 ]; then
+			    newrbd="yes"
+			else
+			    RET=$((${RET}+$?))
+			    RET_OP=1
+			fi
+		fi
+		log_action_end_msg ${RET_OP} "${MAP_RV}"
+
+		if [ "$newrbd" ]; then
+                        ## Mount new rbd
+			MNT_RV=""
+			mount --fake /dev/rbd/$DEV >>/dev/null 2>&1 \
+			&& MNT_RV=$(mount -v /dev/rbd/$DEV 2>&1)
+			[ -n "${MNT_RV}" ] && log_action_msg "mount: ${MNT_RV}"
 		fi
 	done < $RBDMAPFILE
-	log_end_msg $RET
+	exit ${RET}
 
-	# Mount new rbd
-	if [ "$newrbd" ]; then
-                log_action_begin_msg "Mounting all filesystems"
-		mount -a
-		log_action_end_msg $?
-	fi
 }
 
 do_unmap() {
-	log_daemon_msg "Stopping $DESC"
 	RET=0
-	# Recursive umount that depends /dev/rbd*
-	MNTDEP=$(findmnt --mtab | awk '$2 ~ /^\/dev\/rbd[0-9]*$/ {print $1}' | sort -r)
-	for MNT in $MNTDEP; do
-		umount $MNT
-	done 
-	# Unmap all rbd device
+	## Unmount and unmap all rbd devices
 	if ls /dev/rbd[0-9]* >/dev/null 2>&1; then
 		for DEV in /dev/rbd[0-9]*; do
-			log_progress_msg $DEV
-			rbd unmap $DEV
-			[ $? -ne "0" ] && RET=1
+			log_action_begin_msg "RBD un-mapping: '${DEV}'"
+			UMNT_RV=""
+			UMAP_RV=""
+			RET_OP=0
+			MNT=$(findmnt --mtab --source ${DEV} --noheadings | awk '{print $1'})
+			if [ -n "${MNT}" ]; then
+			    log_action_cont_msg "un-mounting '${MNT}'"
+			    UMNT_RV=$(umount "${MNT}" 2>&1)
+			fi
+			if mountpoint -q "${MNT}"; then
+			    ## Un-mounting failed.
+			    RET_OP=1
+			    RET=$((${RET}+1))
+			else
+			    ## Un-mapping.
+			    UMAP_RV=$(rbd unmap $DEV 2>&1)
+			    if [ $? -ne 0 ]; then
+			        RET=$((${RET}+$?))
+			        RET_OP=1
+			    fi
+			fi
+			log_action_end_msg ${RET_OP} "${UMAP_RV}"
+			[ -n "${UMNT_RV}" ] && log_action_msg "${UMNT_RV}"
 		done
 	fi
-	log_end_msg $RET
+	exit ${RET}
 }
 
 
@@ -114,5 +136,3 @@ case "$1" in
 	exit 1
 	;;
 esac
-
-exit 0


### PR DESCRIPTION
`/etc/init.d/rbdmap start` was doing `mount -a`. Although (arguably)
`mount -a -O _netdev` could be less disruptive, it's not RBD mapping job to
mount unrelated devices and potentially do it at the wrong time.

Solution is to call `mount {device}` which works as expected and mounts
device even if it given in form `mount /dev/rbd/pool/imagename` while
`/etc/fstab` uses UUID or LABEL notation.

Furthermore this commit
- fixes global exit code (it was always 0): now it is 0 only when
  all devices were (un)mounted successfully; otherwise non-zero.
- replaces `mount -a` with per-device post-mapping `mount {dev}`
- show mapping progress using LSB functions per device instead of for
  {start|stop} invocation.
- capture output of `(u)mount` (if any) and report it as "info".

Signed-off-by: Dmitry Smirnov onlyjob@member.fsf.org
