### PR TITLE
doc: Fixes a broken link on the rados deploy osd page.

### DIFF
--- a/doc/rados/deployment/ceph-deploy-osd.rst
+++ b/doc/rados/deployment/ceph-deploy-osd.rst
@@ -109,5 +109,5 @@ Destroy OSDs
 
 .. Destroying an OSD will take it ``down`` and ``out`` of the cluster.
 
-.. _Data Storage: ../../../install/hardware-recommendations#data-storage
+.. _Data Storage: ../../../start/hardware-recommendations#data-storage
 .. _Remove OSDs: ../../operations/add-or-rm-osds#removing-osds-manual


### PR DESCRIPTION
Looks like the /install/ namespace changed to /start/ at some point. Found a broken link.

Signed-off-by: Stephen Jahl stephenjahl@gmail.com
