### PR TITLE
rbdmap: lazy umount on shutdown and reboot (runlevel 0 and 6)

### DIFF
--- a/src/init-rbdmap
+++ b/src/init-rbdmap
@@ -87,7 +87,18 @@ do_unmap() {
 			MNT=$(findmnt --mtab --source ${DEV} --noheadings | awk '{print $1'})
 			if [ -n "${MNT}" ]; then
 			    log_action_cont_msg "un-mounting '${MNT}'"
-			    UMNT_RV=$(umount "${MNT}" 2>&1)
+			    local ULAZY=""
+			    local RUNLEVEL=$(runlevel | awk '{print $2}')
+			    if [ $? -eq 0 ]; then
+			        if [ "${RUNLEVEL}" -eq 0 ] \
+			        || [ "${RUNLEVEL}" -eq 6 ] ; then
+			            ULAZY="-l"
+			            if [ -x "$(which fuser)" ]; then
+			                fuser -M -m "${MNT}" --kill -TERM
+			            fi
+			        fi
+			    fi
+			    UMNT_RV=$(umount ${ULAZY} "${MNT}" 2>&1)
 			fi
 			if mountpoint -q "${MNT}"; then
 			    ## Un-mounting failed.


### PR DESCRIPTION
Do lazy unmount in runlevel 0 and 6. This is necessary to avoid unclean
shutdown due to "umount" hangs on reboot.

"rbdmap" fail to umount and unmap RBD device when some applications are
still using file system on RBD. If RBD device not released on
shutdown/reboot system deconfigures network interfaces, terminates
remaining processes then tries to umount remaining file systems where it
hangs forever in endless libceph attempt to reach MONs. This scenario was
observed when /home is located on RBD device (users start processes in
screen/tmux etc.). Even worse, `umount` stuck on RBD mount point so
remaining local file systems are never un-mounted making unclean shutdown
almost inevitable.

Lazy umount is effective because it allows to release RBD device and
unmount file system when applications are terminated.

Signed-off-by: Dmitry Smirnov onlyjob@member.fsf.org
