### PR TITLE
ceph_test_rados_api_tier: fix [EC] HitSet{Read,Write,Trim} tests

### DIFF
--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -1944,21 +1944,28 @@ string set_pool_str(string pool, string var, int val)
     + stringify(val) + string("\"}");
 }
 
-TEST_F(LibRadosTierPP, HitSetRead) {
-  // enable hitset tracking for this pool
+TEST_F(LibRadosTwoPoolsPP, HitSetRead) {
+  // make it a tier
   bufferlist inbl;
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_count", 2),
+  ASSERT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
+    "\", \"tierpool\": \"" + cache_pool_name +
+    "\", \"force_nonempty\": \"--force-nonempty\" }",
+    inbl, NULL, NULL));
+
+  // enable hitset tracking for this pool
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_count", 2),
 						inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_period", 600),
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_period", 600),
 						inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_type",
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_type",
 						"explicit_object"),
 				   inbl, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
 
-  ioctx.set_namespace("");
+  cache_ioctx.set_namespace("");
 
   // keep reading until we see our object appear in the HitSet
   utime_t start = ceph_clock_now(NULL);
@@ -1969,16 +1976,16 @@ TEST_F(LibRadosTierPP, HitSetRead) {
     ASSERT_TRUE(now < hard_stop);
 
     string name = "foo";
-    uint32_t hash = ioctx.get_object_hash_position(name);
+    uint32_t hash = cache_ioctx.get_object_hash_position(name);
     hobject_t oid(sobject_t(name, CEPH_NOSNAP), "", hash,
-		  cluster.pool_lookup(pool_name.c_str()), "");
+		  cluster.pool_lookup(cache_pool_name.c_str()), "");
 
     bufferlist bl;
-    ASSERT_EQ(-ENOENT, ioctx.read("foo", bl, 1, 0));
+    ASSERT_EQ(-ENOENT, cache_ioctx.read("foo", bl, 1, 0));
 
     bufferlist hbl;
     AioCompletion *c = librados::Rados::aio_create_completion();
-    ASSERT_EQ(0, ioctx.hit_set_get(hash, c, now.sec(), &hbl));
+    ASSERT_EQ(0, cache_ioctx.hit_set_get(hash, c, now.sec(), &hbl));
     c->wait_for_complete();
     c->release();
 
@@ -1997,6 +2004,11 @@ TEST_F(LibRadosTierPP, HitSetRead) {
 
     sleep(1);
   }
+
+  ASSERT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
+    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    inbl, NULL, NULL));
 }
 
 static int _get_pg_num(Rados& cluster, string pool_name)
@@ -2028,30 +2040,37 @@ static int _get_pg_num(Rados& cluster, string pool_name)
 }
 
 
-TEST_F(LibRadosTierPP, HitSetWrite) {
+TEST_F(LibRadosTwoPoolsPP, HitSetWrite) {
   int num_pg = _get_pg_num(cluster, pool_name);
   assert(num_pg > 0);
 
-  // enable hitset tracking for this pool
+  // make it a tier
   bufferlist inbl;
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_count", 8),
+  ASSERT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
+    "\", \"tierpool\": \"" + cache_pool_name +
+    "\", \"force_nonempty\": \"--force-nonempty\" }",
+    inbl, NULL, NULL));
+
+  // enable hitset tracking for this pool
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_count", 8),
 						inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_period", 600),
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_period", 600),
 						inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_type",
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_type",
 						"explicit_hash"),
 				   inbl, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
 
-  ioctx.set_namespace("");
+  cache_ioctx.set_namespace("");
 
   // do a bunch of writes
   for (int i=0; i<1000; ++i) {
     bufferlist bl;
     bl.append("a");
-    ASSERT_EQ(0, ioctx.write(stringify(i), bl, 1, 0));
+    ASSERT_EQ(0, cache_ioctx.write(stringify(i), bl, 1, 0));
   }
 
   // get HitSets
@@ -2059,7 +2078,7 @@ TEST_F(LibRadosTierPP, HitSetWrite) {
   for (int i=0; i<num_pg; ++i) {
     list< pair<time_t,time_t> > ls;
     AioCompletion *c = librados::Rados::aio_create_completion();
-    ASSERT_EQ(0, ioctx.hit_set_list(i, c, &ls));
+    ASSERT_EQ(0, cache_ioctx.hit_set_list(i, c, &ls));
     c->wait_for_complete();
     c->release();
     std::cout << "pg " << i << " ls " << ls << std::endl;
@@ -2068,7 +2087,7 @@ TEST_F(LibRadosTierPP, HitSetWrite) {
     // get the latest
     c = librados::Rados::aio_create_completion();
     bufferlist bl;
-    ASSERT_EQ(0, ioctx.hit_set_get(i, c, ls.back().first, &bl));
+    ASSERT_EQ(0, cache_ioctx.hit_set_get(i, c, ls.back().first, &bl));
     c->wait_for_complete();
     c->release();
 
@@ -2081,14 +2100,14 @@ TEST_F(LibRadosTierPP, HitSetWrite) {
 
     // cope with racing splits by refreshing pg_num
     if (i == num_pg - 1)
-      num_pg = _get_pg_num(cluster, pool_name);
+      num_pg = _get_pg_num(cluster, cache_pool_name);
   }
 
   for (int i=0; i<1000; ++i) {
     string n = stringify(i);
-    uint32_t hash = ioctx.get_object_hash_position(n);
+    uint32_t hash = cache_ioctx.get_object_hash_position(n);
     hobject_t oid(sobject_t(n, CEPH_NOSNAP), "", hash,
-		  cluster.pool_lookup(pool_name.c_str()), "");
+		  cluster.pool_lookup(cache_pool_name.c_str()), "");
     std::cout << "checking for " << oid << std::endl;
     bool found = false;
     for (int p=0; p<num_pg; ++p) {
@@ -2099,27 +2118,39 @@ TEST_F(LibRadosTierPP, HitSetWrite) {
     }
     ASSERT_TRUE(found);
   }
+
+  ASSERT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
+    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    inbl, NULL, NULL));
 }
 
-TEST_F(LibRadosTierPP, HitSetTrim) {
+TEST_F(LibRadosTwoPoolsPP, HitSetTrim) {
   unsigned count = 3;
   unsigned period = 3;
 
-  // enable hitset tracking for this pool
+  // make it a tier
   bufferlist inbl;
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_count", count),
+  ASSERT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
+    "\", \"tierpool\": \"" + cache_pool_name +
+    "\", \"force_nonempty\": \"--force-nonempty\" }",
+    inbl, NULL, NULL));
+
+  // enable hitset tracking for this pool
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_count", count),
 						inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_period", period),
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_period", period),
 						inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_type", "bloom"),
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_type", "bloom"),
 				   inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_fpp", ".01"),
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_fpp", ".01"),
 				   inbl, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
 
-  ioctx.set_namespace("");
+  cache_ioctx.set_namespace("");
 
   // do a bunch of writes and make sure the hitsets rotate
   utime_t start = ceph_clock_now(NULL);
@@ -2128,16 +2159,16 @@ TEST_F(LibRadosTierPP, HitSetTrim) {
   time_t first = 0;
   while (true) {
     string name = "foo";
-    uint32_t hash = ioctx.get_object_hash_position(name);
+    uint32_t hash = cache_ioctx.get_object_hash_position(name);
     hobject_t oid(sobject_t(name, CEPH_NOSNAP), "", hash, -1, "");
 
     bufferlist bl;
     bl.append("f");
-    ASSERT_EQ(0, ioctx.write("foo", bl, 1, 0));
+    ASSERT_EQ(0, cache_ioctx.write("foo", bl, 1, 0));
 
     list<pair<time_t, time_t> > ls;
     AioCompletion *c = librados::Rados::aio_create_completion();
-    ASSERT_EQ(0, ioctx.hit_set_list(hash, c, &ls));
+    ASSERT_EQ(0, cache_ioctx.hit_set_list(hash, c, &ls));
     c->wait_for_complete();
     c->release();
 
@@ -2160,6 +2191,11 @@ TEST_F(LibRadosTierPP, HitSetTrim) {
 
     sleep(1);
   }
+
+  ASSERT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
+    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    inbl, NULL, NULL));
 }
 
 class LibRadosTwoPoolsECPP : public RadosTestECPP
@@ -3938,21 +3974,28 @@ TEST_F(LibRadosTierECPP, HitSetNone) {
   }
 }
 
-TEST_F(LibRadosTierECPP, HitSetRead) {
-  // enable hitset tracking for this pool
+TEST_F(LibRadosTwoPoolsECPP, HitSetRead) {
+  // make it a tier
   bufferlist inbl;
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_count", 2),
+  ASSERT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
+    "\", \"tierpool\": \"" + cache_pool_name +
+    "\", \"force_nonempty\": \"--force-nonempty\" }",
+    inbl, NULL, NULL));
+
+  // enable hitset tracking for this pool
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_count", 2),
 						inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_period", 600),
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_period", 600),
 						inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_type",
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_type",
 						"explicit_object"),
 				   inbl, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
 
-  ioctx.set_namespace("");
+  cache_ioctx.set_namespace("");
 
   // keep reading until we see our object appear in the HitSet
   utime_t start = ceph_clock_now(NULL);
@@ -3963,16 +4006,16 @@ TEST_F(LibRadosTierECPP, HitSetRead) {
     ASSERT_TRUE(now < hard_stop);
 
     string name = "foo";
-    uint32_t hash = ioctx.get_object_hash_position(name);
+    uint32_t hash = cache_ioctx.get_object_hash_position(name);
     hobject_t oid(sobject_t(name, CEPH_NOSNAP), "", hash,
-		  cluster.pool_lookup(pool_name.c_str()), "");
+		  cluster.pool_lookup(cache_pool_name.c_str()), "");
 
     bufferlist bl;
-    ASSERT_EQ(-ENOENT, ioctx.read("foo", bl, 1, 0));
+    ASSERT_EQ(-ENOENT, cache_ioctx.read("foo", bl, 1, 0));
 
     bufferlist hbl;
     AioCompletion *c = librados::Rados::aio_create_completion();
-    ASSERT_EQ(0, ioctx.hit_set_get(hash, c, now.sec(), &hbl));
+    ASSERT_EQ(0, cache_ioctx.hit_set_get(hash, c, now.sec(), &hbl));
     c->wait_for_complete();
     c->release();
 
@@ -3991,6 +4034,11 @@ TEST_F(LibRadosTierECPP, HitSetRead) {
 
     sleep(1);
   }
+
+  ASSERT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
+    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    inbl, NULL, NULL));
 }
 
 // disable this test until hitset-get reliably works on EC pools
@@ -4069,25 +4117,32 @@ TEST_F(LibRadosTierECPP, HitSetWrite) {
 }
 #endif
 
-TEST_F(LibRadosTierECPP, HitSetTrim) {
+TEST_F(LibRadosTwoPoolsECPP, HitSetTrim) {
   unsigned count = 3;
   unsigned period = 3;
 
-  // enable hitset tracking for this pool
+  // make it a tier
   bufferlist inbl;
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_count", count),
+  ASSERT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
+    "\", \"tierpool\": \"" + cache_pool_name +
+    "\", \"force_nonempty\": \"--force-nonempty\" }",
+    inbl, NULL, NULL));
+
+  // enable hitset tracking for this pool
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_count", count),
 						inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_period", period),
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_period", period),
 						inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_type", "bloom"),
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_type", "bloom"),
 				   inbl, NULL, NULL));
-  ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_fpp", ".01"),
+  ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_fpp", ".01"),
 				   inbl, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
 
-  ioctx.set_namespace("");
+  cache_ioctx.set_namespace("");
 
   // do a bunch of writes and make sure the hitsets rotate
   utime_t start = ceph_clock_now(NULL);
@@ -4100,16 +4155,16 @@ TEST_F(LibRadosTierECPP, HitSetTrim) {
 
   while (true) {
     string name = "foo";
-    uint32_t hash = ioctx.get_object_hash_position(name);
+    uint32_t hash = cache_ioctx.get_object_hash_position(name);
     hobject_t oid(sobject_t(name, CEPH_NOSNAP), "", hash, -1, "");
 
     bufferlist bl;
     bl.append(buf, bsize);
-    ASSERT_EQ(0, ioctx.append("foo", bl, bsize));
+    ASSERT_EQ(0, cache_ioctx.append("foo", bl, bsize));
 
     list<pair<time_t, time_t> > ls;
     AioCompletion *c = librados::Rados::aio_create_completion();
-    ASSERT_EQ(0, ioctx.hit_set_list(hash, c, &ls));
+    ASSERT_EQ(0, cache_ioctx.hit_set_list(hash, c, &ls));
     c->wait_for_complete();
     c->release();
 
@@ -4133,6 +4188,11 @@ TEST_F(LibRadosTierECPP, HitSetTrim) {
     sleep(1);
   }
   delete[] buf;
+
+  ASSERT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
+    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    inbl, NULL, NULL));
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The hit_set_ fields can only be set on tier pools as of 
f131dfbaedf6f451572e7aa3a83f653912122953.

Fixes: #8823 Signed-off-by: Sage Weil sage@inktank.com
