### PR TITLE
XfsFileStoreBackend: default to disabling extsize on xfs

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -651,6 +651,12 @@ OPTION(filestore_btrfs_clone_range, OPT_BOOL, true)
 OPTION(filestore_zfs_snap, OPT_BOOL, false) // zfsonlinux is still unstable
 OPTION(filestore_fsync_flushes_journal_data, OPT_BOOL, false)
 OPTION(filestore_fiemap, OPT_BOOL, false)     // (try to) use fiemap
+
+// (try to) use extsize for alloc hint
+// WARNING: extsize seems to trigger data corruption in xfs -- that is why it is
+// off by default, see bug #8830
+OPTION(filestore_xfs_extsize, OPT_BOOL, false)
+
 OPTION(filestore_journal_parallel, OPT_BOOL, false)
 OPTION(filestore_journal_writeahead, OPT_BOOL, false)
 OPTION(filestore_journal_trailing, OPT_BOOL, false)

--- a/src/os/XfsFileStoreBackend.cc
+++ b/src/os/XfsFileStoreBackend.cc
@@ -103,15 +103,20 @@ int XfsFileStoreBackend::detect_features()
     goto out_close;
   }
 
-  ret = set_extsize(fd, 1U << 15); // a few pages
-  if (ret) {
-    ret = 0;
-    dout(0) << "detect_feature: failed to set test file extsize, assuming extsize is NOT supported" << dendl;
-    goto out_close;
+  if (g_conf->filestore_xfs_extsize) {
+    ret = set_extsize(fd, 1U << 15); // a few pages
+    if (ret) {
+      ret = 0;
+      dout(0) << "detect_feature: failed to set test file extsize, assuming extsize is NOT supported" << dendl;
+      goto out_close;
+    } else {
+      dout(0) << "detect_feature: extsize is supported" << dendl;
+      m_has_extsize = true;
+    }
+  } else {
+    dout(0) << "detect_feature: extsize is disabled by conf" << dendl;
   }
 
-  dout(0) << "detect_feature: extsize is supported" << dendl;
-  m_has_extsize = true;
 
 out_close:
   TEMP_FAILURE_RETRY(::close(fd));


### PR DESCRIPTION
This appears to be responsible for the deep scrub mismatches on some rbd
workloads.

Fixes: 8830
Signed-off-by: Samuel Just sam.just@inktank.com
