### PR TITLE
update hadoop-wordcount test to be able to run on hadoop 2.x. 

### DIFF
--- a/qa/workunits/hadoop-wordcount/test.sh
+++ b/qa/workunits/hadoop-wordcount/test.sh
@@ -46,7 +46,7 @@ $command5
 $command6
 $command7
 $command8
-#$command9
+$command9
 
 echo "completed hadoop-wordcount test"
 exit 0


### PR DESCRIPTION
The hadoop and mapreduce library are no longer hard coded so they can be specified to point to the right path. The relative paths hdfs are changed to absolute paths.

A sample command to run the test on hadoop 2.x is
TESTDIR=/home/test HADOOP_HOME=/usr/lib/hadoop HADOOP_MR_HOME=/usr/lib/hadoop-mapreduce sh workunits/hadoop-wordcount/test.sh starting hadoop-wordcount test
