### PR TITLE
eat up the level from logging output when not using the `-v` flag

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -2598,7 +2598,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    loglevel = logging.INFO
+    loglevel = logging.WARNING
     if args.verbose:
         loglevel = logging.DEBUG
 


### PR DESCRIPTION
Without verbose flag:

```
vagrant@node1:~$ sudo ceph-disk prepare --fs-type xfs --cluster ceph -- /dev/sdb /dev/sdb2
Running command: /usr/bin/ceph-osd --cluster=ceph --show-config-value=fsid
Running command: /usr/bin/ceph-conf --cluster=ceph --name=osd. --lookup osd_mkfs_options_xfs
Running command: /usr/bin/ceph-conf --cluster=ceph --name=osd. --lookup osd_fs_mkfs_options_xfs
Running command: /usr/bin/ceph-conf --cluster=ceph --name=osd. --lookup osd_mount_options_xfs
Running command: /usr/bin/ceph-conf --cluster=ceph --name=osd. --lookup osd_fs_mount_options_xfs
Running command: /usr/bin/ceph-osd --cluster=ceph --show-config-value=osd_journal_size
OSD will not be hot-swappable if journal is not the same device as the osd data
Running command: /sbin/sgdisk --largest-new=1 --change-name=1:ceph data --partition-guid=1:8a6634e1-dc71-400a-aa59-8d823107c7c3 --typecode=1:89c57f98-2fe5-4dc0-89c1-f3ad0ceff2be -- /dev/sdb
Could not create partition 1 from 34 to 2047
Error encountered; not saving changes.
ceph-disk: Error: Command '['/sbin/sgdisk', '--largest-new=1', '--change-name=1:ceph data', '--partition-guid=1:8a6634e1-dc71-400a-aa59-8d823107c7c3', '--typecode=1:89c57f98-2fe5-4dc0-89c1-f3ad0ceff2be', '--', '/dev/sdb']' returned non-zero exit status 4
```

With verbose flag:

```
vagrant@node1:~$ sudo ceph-disk -v prepare --fs-type xfs --cluster ceph -- /dev/sdb /dev/sdb2
[INFO  ] Running command: /usr/bin/ceph-osd --cluster=ceph --show-config-value=fsid
[INFO  ] Running command: /usr/bin/ceph-conf --cluster=ceph --name=osd. --lookup osd_mkfs_options_xfs
[INFO  ] Running command: /usr/bin/ceph-conf --cluster=ceph --name=osd. --lookup osd_fs_mkfs_options_xfs
[INFO  ] Running command: /usr/bin/ceph-conf --cluster=ceph --name=osd. --lookup osd_mount_options_xfs
[INFO  ] Running command: /usr/bin/ceph-conf --cluster=ceph --name=osd. --lookup osd_fs_mount_options_xfs
[INFO  ] Running command: /usr/bin/ceph-osd --cluster=ceph --show-config-value=osd_journal_size
[DEBUG ] Journal is file /dev/sdb2
[WARNING] OSD will not be hot-swappable if journal is not the same device as the osd data
[DEBUG ] Creating osd partition on /dev/sdb
[INFO  ] Running command: /sbin/sgdisk --largest-new=1 --change-name=1:ceph data --partition-guid=1:2d56cd00-222a-43ad-8a5f-e2ef9a5f3a88 --typecode=1:89c57f98-2fe5-4dc0-89c1-f3ad0ceff2be -- /dev/sdb
Could not create partition 1 from 34 to 2047
Error encountered; not saving changes.
ceph-disk: Error: Command '['/sbin/sgdisk', '--largest-new=1', '--change-name=1:ceph data', '--partition-guid=1:2d56cd00-222a-43ad-8a5f-e2ef9a5f3a88', '--typecode=1:89c57f98-2fe5-4dc0-89c1-f3ad0ceff2be', '--', '/dev/sdb']' returned non-zero exit status 4
```
