### PR TITLE
Fix size of network protocol intergers.

### DIFF
--- a/src/messages/MOSDPGTemp.h
+++ b/src/messages/MOSDPGTemp.h
@@ -22,7 +22,7 @@
 class MOSDPGTemp : public PaxosServiceMessage {
  public:
   epoch_t map_epoch;
-  map<pg_t, vector<int> > pg_temp;
+  map<pg_t, vector<int32_t> > pg_temp;
 
   MOSDPGTemp(epoch_t e) : PaxosServiceMessage(MSG_OSD_PGTEMP, e), map_epoch(e) { }
   MOSDPGTemp() : PaxosServiceMessage(MSG_OSD_PGTEMP, 0) {}

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1465,7 +1465,7 @@ bool OSDMonitor::preprocess_pgtemp(MOSDPGTemp *m)
     goto ignore;
   }
 
-  for (map<pg_t,vector<int> >::iterator p = m->pg_temp.begin(); p != m->pg_temp.end(); ++p) {
+  for (map<pg_t,vector<int32_t> >::iterator p = m->pg_temp.begin(); p != m->pg_temp.end(); ++p) {
     dout(20) << " " << p->first
 	     << (osdmap.pg_temp->count(p->first) ? (*osdmap.pg_temp)[p->first] : empty)
              << " -> " << p->second << dendl;
@@ -1517,7 +1517,7 @@ bool OSDMonitor::prepare_pgtemp(MOSDPGTemp *m)
 {
   int from = m->get_orig_source().num();
   dout(7) << "prepare_pgtemp e" << m->map_epoch << " from " << m->get_orig_source_inst() << dendl;
-  for (map<pg_t,vector<int> >::iterator p = m->pg_temp.begin(); p != m->pg_temp.end(); ++p) {
+  for (map<pg_t,vector<int32_t> >::iterator p = m->pg_temp.begin(); p != m->pg_temp.end(); ++p) {
     uint64_t pool = p->first.pool();
     if (pending_inc.old_pools.count(pool)) {
       dout(10) << __func__ << " ignore " << p->first << " -> " << p->second
@@ -5925,7 +5925,7 @@ int OSDMonitor::_prepare_remove_pool(int64_t pool, ostream *ss)
       pending_inc.new_pg_temp[p->first].clear();
     }
   }
-  for (map<pg_t,int>::iterator p = osdmap.primary_temp->begin();
+  for (map<pg_t,int32_t>::iterator p = osdmap.primary_temp->begin();
       p != osdmap.primary_temp->end();
       ++p) {
     if (p->first.pool() == (uint64_t)pool) {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -698,7 +698,7 @@ void OSDMap::Incremental::dump(Formatter *f) const
   f->close_section();
 
   f->open_array_section("new_pg_temp");
-  for (map<pg_t,vector<int> >::const_iterator p = new_pg_temp.begin();
+  for (map<pg_t,vector<int32_t> >::const_iterator p = new_pg_temp.begin();
        p != new_pg_temp.end();
        ++p) {
     f->open_object_section("pg");
@@ -712,7 +712,7 @@ void OSDMap::Incremental::dump(Formatter *f) const
   f->close_section();
 
   f->open_array_section("primary_temp");
-  for (map<pg_t, int>::const_iterator p = new_primary_temp.begin();
+  for (map<pg_t, int32_t>::const_iterator p = new_primary_temp.begin();
       p != new_primary_temp.end();
       ++p) {
     f->dump_stream("pgid") << p->first;
@@ -1092,7 +1092,7 @@ void OSDMap::remove_redundant_temporaries(CephContext *cct, const OSDMap& osdmap
 {
   ldout(cct, 10) << "remove_redundant_temporaries" << dendl;
 
-  for (map<pg_t,vector<int> >::iterator p = osdmap.pg_temp->begin();
+  for (map<pg_t,vector<int32_t> >::iterator p = osdmap.pg_temp->begin();
        p != osdmap.pg_temp->end();
        ++p) {
     if (pending_inc->new_pg_temp.count(p->first) == 0) {
@@ -1109,7 +1109,7 @@ void OSDMap::remove_redundant_temporaries(CephContext *cct, const OSDMap& osdmap
     OSDMap templess;
     templess.deepish_copy_from(osdmap);
     templess.primary_temp->clear();
-    for (map<pg_t,int>::iterator p = osdmap.primary_temp->begin();
+    for (map<pg_t,int32_t>::iterator p = osdmap.primary_temp->begin();
         p != osdmap.primary_temp->end();
         ++p) {
       if (pending_inc->new_primary_temp.count(p->first) == 0) {
@@ -1135,11 +1135,11 @@ void OSDMap::remove_down_temps(CephContext *cct,
   tmpmap.deepish_copy_from(osdmap);
   tmpmap.apply_incremental(*pending_inc);
 
-  for (map<pg_t,vector<int> >::iterator p = tmpmap.pg_temp->begin();
+  for (map<pg_t,vector<int32_t> >::iterator p = tmpmap.pg_temp->begin();
        p != tmpmap.pg_temp->end();
        ++p) {
     unsigned num_up = 0;
-    for (vector<int>::iterator i = p->second.begin();
+    for (vector<int32_t>::iterator i = p->second.begin();
 	 i != p->second.end();
 	 ++i) {
       if (!tmpmap.is_down(*i))
@@ -1148,7 +1148,7 @@ void OSDMap::remove_down_temps(CephContext *cct,
     if (num_up == 0)
       pending_inc->new_pg_temp[p->first].clear();
   }
-  for (map<pg_t,int>::iterator p = tmpmap.primary_temp->begin();
+  for (map<pg_t,int32_t>::iterator p = tmpmap.primary_temp->begin();
       p != tmpmap.primary_temp->end();
       ++p) {
     if (tmpmap.is_down(p->second))
@@ -1307,7 +1307,7 @@ int OSDMap::apply_incremental(const Incremental &inc)
       (*pg_temp)[p->first] = p->second;
   }
 
-  for (map<pg_t,int>::const_iterator p = inc.new_primary_temp.begin();
+  for (map<pg_t,int32_t>::const_iterator p = inc.new_primary_temp.begin();
       p != inc.new_primary_temp.end();
       ++p) {
     if (p->second == -1)
@@ -1521,7 +1521,7 @@ void OSDMap::_get_temp_osds(const pg_pool_t& pool, pg_t pg,
                             vector<int> *temp_pg, int *temp_primary) const
 {
   pg = pool.raw_pg_to_pg(pg);
-  map<pg_t,vector<int> >::const_iterator p = pg_temp->find(pg);
+  map<pg_t,vector<int32_t> >::const_iterator p = pg_temp->find(pg);
   temp_pg->clear();
   if (p != pg_temp->end()) {
     for (unsigned i=0; i<p->second.size(); i++) {
@@ -1536,7 +1536,7 @@ void OSDMap::_get_temp_osds(const pg_pool_t& pool, pg_t pg,
       }
     }
   }
-  map<pg_t,int>::const_iterator pp = primary_temp->find(pg);
+  map<pg_t,int32_t>::const_iterator pp = primary_temp->find(pg);
   *temp_primary = -1;
   if (pp != primary_temp->end()) {
     *temp_primary = pp->second;
@@ -2126,7 +2126,7 @@ void OSDMap::dump(Formatter *f) const
   f->close_section();
 
   f->open_array_section("pg_temp");
-  for (map<pg_t,vector<int> >::const_iterator p = pg_temp->begin();
+  for (map<pg_t,vector<int32_t> >::const_iterator p = pg_temp->begin();
        p != pg_temp->end();
        ++p) {
     f->open_object_section("osds");
@@ -2140,7 +2140,7 @@ void OSDMap::dump(Formatter *f) const
   f->close_section();
 
   f->open_array_section("primary_temp");
-  for (map<pg_t, int>::const_iterator p = primary_temp->begin();
+  for (map<pg_t, int32_t>::const_iterator p = primary_temp->begin();
       p != primary_temp->end();
       ++p) {
     f->dump_stream("pgid") << p->first;
@@ -2274,12 +2274,12 @@ void OSDMap::print(ostream& out) const
   }
   out << std::endl;
 
-  for (map<pg_t,vector<int> >::const_iterator p = pg_temp->begin();
+  for (map<pg_t,vector<int32_t> >::const_iterator p = pg_temp->begin();
        p != pg_temp->end();
        ++p)
     out << "pg_temp " << p->first << " " << p->second << "\n";
 
-  for (map<pg_t,int>::const_iterator p = primary_temp->begin();
+  for (map<pg_t,int32_t>::const_iterator p = primary_temp->begin();
       p != primary_temp->end();
       ++p)
     out << "primary_temp " << p->first << " " << p->second << "\n";

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -140,7 +140,7 @@ public:
     map<int32_t,uint8_t> new_state;             // XORed onto previous state.
     map<int32_t,uint32_t> new_weight;
     map<pg_t,vector<int32_t> > new_pg_temp;     // [] to remove
-    map<pg_t, int> new_primary_temp;            // [-1] to remove
+    map<pg_t, int32_t> new_primary_temp;            // [-1] to remove
     map<int32_t,uint32_t> new_primary_affinity;
     map<int32_t,epoch_t> new_up_thru;
     map<int32_t,pair<epoch_t,epoch_t> > new_last_clean_interval;
@@ -222,8 +222,8 @@ private:
 
   vector<__u32>   osd_weight;   // 16.16 fixed point, 0x10000 = "in", 0 = "out"
   vector<osd_info_t> osd_info;
-  ceph::shared_ptr< map<pg_t,vector<int> > > pg_temp;  // temp pg mapping (e.g. while we rebuild)
-  ceph::shared_ptr< map<pg_t,int > > primary_temp;  // temp primary mapping (e.g. while we rebuild)
+  ceph::shared_ptr< map<pg_t,vector<int32_t> > > pg_temp;  // temp pg mapping (e.g. while we rebuild)
+  ceph::shared_ptr< map<pg_t,int32_t > > primary_temp;  // temp primary mapping (e.g. while we rebuild)
   ceph::shared_ptr< vector<__u32> > osd_primary_affinity; ///< 16.16 fixed point, 0x10000 = baseline
 
   map<int64_t,pg_pool_t> pools;
@@ -253,8 +253,8 @@ private:
 	     flags(0),
 	     num_osd(0), max_osd(0),
 	     osd_addrs(new addrs_s),
-	     pg_temp(new map<pg_t,vector<int> >),
-	     primary_temp(new map<pg_t,int>),
+	     pg_temp(new map<pg_t,vector<int32_t> >),
+	     primary_temp(new map<pg_t,int32_t>),
 	     osd_uuid(new vector<uuid_d>),
 	     cluster_snapshot_epoch(0),
 	     new_blacklist_entries(false),
@@ -272,8 +272,8 @@ public:
 
   void deepish_copy_from(const OSDMap& o) {
     *this = o;
-    primary_temp.reset(new map<pg_t,int>(*o.primary_temp));
-    pg_temp.reset(new map<pg_t,vector<int> >(*o.pg_temp));
+    primary_temp.reset(new map<pg_t,int32_t>(*o.primary_temp));
+    pg_temp.reset(new map<pg_t,vector<int32_t> >(*o.pg_temp));
     osd_uuid.reset(new vector<uuid_d>(*o.osd_uuid));
 
     // NOTE: this still references shared entity_addr_t's.

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -190,7 +190,8 @@ TEST_F(OSDMapTest, PrimaryTempRespected) {
 
   pg_t rawpg(0, 0, -1);
   pg_t pgid = osdmap.raw_pg_to_pg(rawpg);
-  vector<int> up_osds, acting_osds;
+  vector<int> up_osds
+  vector<uint32_t> acting_osds;
   int up_primary, acting_primary;
 
   osdmap.pg_to_up_acting_osds(pgid, &up_osds, &up_primary,
@@ -212,7 +213,7 @@ TEST_F(OSDMapTest, RemovesRedundantTemps) {
   pg_t rawpg(0, 0, -1);
   pg_t pgid = osdmap.raw_pg_to_pg(rawpg);
   vector<int> up_osds, acting_osds;
-  int up_primary, acting_primary;
+  int32_t up_primary, acting_primary;
 
   osdmap.pg_to_up_acting_osds(pgid, &up_osds, &up_primary,
                               &acting_osds, &acting_primary);


### PR DESCRIPTION
This fixes the size of some integers that are visible in the network
protocol.  There should be no change for machines where sizeof(int) ==
4.

I tried to change all related values but I might have missed some.  This **will** change the network protocol of machines with non-32bit int types.
