### PR TITLE
logrotate.conf: fix osd log rotation

### DIFF
--- a/src/logrotate.conf
+++ b/src/logrotate.conf
@@ -14,7 +14,7 @@
             for daemon in osd mon mds ; do
               find -L /var/lib/ceph/$daemon/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
                 | while read f; do
-                    if [ -e "/var/lib/ceph/$daemon/$f/done" ] && [ -e "/var/lib/ceph/$daemon/$f/upstart" ] && [ ! -e "/var/lib/ceph/$daemon/$f/sysvinit" ]; then
+                    if [ -e "/var/lib/ceph/$daemon/$f/done" -o -e "/var/lib/ceph/$daemon/$f/ready" ] && [ -e "/var/lib/ceph/$daemon/$f/upstart" ] && [ ! -e "/var/lib/ceph/$daemon/$f/sysvinit" ]; then
                       cluster="${f%%-*}"
                       id="${f#*-}"
 


### PR DESCRIPTION
In commit 7411c3c6a42bef5987bdd76b1812b01686303502 we generalized this 
enumeration code by copying what was in the upstart scripts.  However, while
the mon and mds directories get a 'done' file, the OSDs get a 'ready' file. 
Bah!  Trigger off of either one.

Backport: firefly Signed-off-by: Sage Weil sage@redhat.com
