### PR TITLE
Fix decoding + characters in URL

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -700,13 +700,15 @@ bool url_decode(string& src_str, string& dest_str)
   int pos = 0;
   char c;
 
+  bool in_query = false;
   while (*src) {
     if (*src != '%') {
-      if (*src != '+') {
-	dest[pos++] = *src++;
+      if (!in_query || *src != '+') {
+        if (*src == '?') in_query = true;
+        dest[pos++] = *src++;
       } else {
-	dest[pos++] = ' ';
-	++src;
+        dest[pos++] = ' ';
+        ++src;
       }
     } else {
       src++;


### PR DESCRIPTION
Only decode + characters to spaces if we're in a query argument.  The + => ' ' translation is not correct for file/directory names.

Resolves http://tracker.ceph.com/issues/8702
