### PR TITLE
os/FileJournal: Update the journal header when closing journal

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -544,6 +544,7 @@ void FileJournal::close()
 
   // close
   assert(writeq_empty());
+  assert(!must_write_header);
   assert(fd >= 0);
   VOID_TEMP_FAILURE_RETRY(::close(fd));
   fd = -1;
@@ -1102,7 +1103,7 @@ void FileJournal::write_thread_entry()
   while (1) {
     {
       Mutex::Locker locker(writeq_lock);
-      if (writeq.empty()) {
+      if (writeq.empty() && !must_write_header) {
 	if (write_stop)
 	  break;
 	dout(20) << "write_thread_entry going to sleep" << dendl;


### PR DESCRIPTION
When closing journal, it should check must_write_header and update
journal header if must_write_header alreay set.
It can reduce the nosense journal-replay after restarting osd.

Signed-off-by: Ma Jianpeng jianpeng.ma@intel.com
Reviewed-by: Sage Weil sage@redhat.com
