### PR TITLE
test: catch a straggler still using 'data' pool

### DIFF
--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -33,7 +33,7 @@ def test_rados_init():
 
 def test_ioctx_context_manager():
     with Rados(conffile='', rados_id='admin') as conn:
-        with conn.open_ioctx('data') as ioctx:
+        with conn.open_ioctx('rbd') as ioctx:
             pass
 
 class TestRados(object):


### PR DESCRIPTION
Used rbd pool instead, which is still created by default.

Signed-off-by: John Spray john.spray@redhat.com
