### PR TITLE
common/RefCountedObject: fix use-after-free in debug print

### DIFF
--- a/src/common/RefCountedObj.h
+++ b/src/common/RefCountedObj.h
@@ -39,13 +39,14 @@ public:
     return this;
   }
   void put() {
+    CephContext *local_cct = cct;
     int v = nref.dec();
-    if (cct)
-      lsubdout(cct, refs, 1) << "RefCountedObject::put " << this << " "
-			     << (v + 1) << " -> " << v
-			     << dendl;
     if (v == 0)
       delete this;
+    if (local_cct)
+      lsubdout(local_cct, refs, 1) << "RefCountedObject::put " << this << " "
+				   << (v + 1) << " -> " << v
+				   << dendl;
   }
   void set_cct(CephContext *c) {
     cct = c;


### PR DESCRIPTION
We could race with another thread that deletes this right after we call 
dec().  Our access of cct would then become a use-after-free.  Valgrind 
managed to turn this up.

Copy it into a local variable before the dec() to be safe!

Signed-off-by: Sage Weil sage@redhat.com
