### PR TITLE
ceph_test_rados_api_tier: do fewer writes in HitSetWrite

### DIFF
--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -2047,8 +2047,10 @@ TEST_F(LibRadosTierPP, HitSetWrite) {
 
   ioctx.set_namespace("");
 
+  int num = 200;
+
   // do a bunch of writes
-  for (int i=0; i<1000; ++i) {
+  for (int i=0; i<num; ++i) {
     bufferlist bl;
     bl.append("a");
     ASSERT_EQ(0, ioctx.write(stringify(i), bl, 1, 0));
@@ -2084,7 +2086,7 @@ TEST_F(LibRadosTierPP, HitSetWrite) {
       num_pg = _get_pg_num(cluster, pool_name);
   }
 
-  for (int i=0; i<1000; ++i) {
+  for (int i=0; i<num; ++i) {
     string n = stringify(i);
     uint32_t hash = ioctx.get_object_hash_position(n);
     hobject_t oid(sobject_t(n, CEPH_NOSNAP), "", hash,


### PR DESCRIPTION
We don't need to do quite so many writes.  It can be slow when we are 
thrashing and aren't doing anything in parallel.

Fixes: #8932 Signed-off-by: Sage Weil sage@redhat.com
