### PR TITLE
init: add systemd service files

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -447,6 +447,7 @@ fi
 %endif
 %dir %{_libdir}/ceph
 %{_libdir}/ceph/ceph_common.sh
+%{_libexecdir}/ceph/ceph-osd-prestart.sh
 %dir %{_libdir}/rados-classes
 %{_libdir}/rados-classes/libcls_rbd.so*
 %{_libdir}/rados-classes/libcls_hello.so*

--- a/debian/ceph.install
+++ b/debian/ceph.install
@@ -18,6 +18,7 @@ usr/bin/osdmaptool
 usr/lib/ceph/ceph_common.sh
 usr/lib/ceph/erasure-code/*
 usr/lib/rados-classes/*
+usr/libexec/ceph/ceph-osd-prestart.sh
 usr/share/doc/ceph/sample.ceph.conf
 usr/share/doc/ceph/sample.fetch_config
 usr/share/man/man8/ceph-clsinfo.8

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -154,6 +154,7 @@ EXTRA_DIST += \
 	$(srcdir)/vstart.sh \
 	$(srcdir)/stop.sh \
 	ceph-run \
+	$(srcdir)/ceph-osd-prestart.sh \
 	$(srcdir)/ceph_common.sh \
 	$(srcdir)/init-radosgw \
 	$(srcdir)/init-radosgw.sysv \
@@ -221,6 +222,9 @@ doc_DATA = $(srcdir)/sample.ceph.conf sample.fetch_config
 
 shell_commondir = $(libdir)/ceph
 shell_common_SCRIPTS = ceph_common.sh
+
+ceph_libexecdir = $(libexecdir)/ceph
+ceph_libexec_SCRIPTS = ceph-osd-prestart.sh
 
 bash_completiondir = $(sysconfdir)/bash_completion.d
 bash_completion_DATA = $(srcdir)/bash_completion/ceph \

--- a/src/ceph-osd-prestart.sh
+++ b/src/ceph-osd-prestart.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+eval set -- "$(getopt -o i: --long id:,cluster: -- $@)"
+
+while true ; do
+	case "$1" in
+		-i|--id) id=$2; shift 2 ;;
+		--cluster) cluster=$2; shift 2 ;;
+		--) shift ; break ;;
+	esac
+done
+
+if [ -z "$id"  ]; then
+    echo "Usage: $0 [OPTIONS]"
+    echo "--id/-i ID        set ID portion of my name"
+    echo "--cluster NAME    set cluster name (default: ceph)"
+    exit 1;
+fi
+
+update="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_update_on_start || :)"
+
+if [ "${update:-1}" = "1" -o "${update:-1}" = "true" ]; then
+    # update location in crush
+    hook="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_location_hook || :)"
+    if [ -z "$hook" ]; then
+        hook="/usr/bin/ceph-crush-location"
+    fi
+    location="$($hook --cluster ${cluster:-ceph} --id $id --type osd)"
+    weight="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_initial_weight || :)"
+    defaultweight=`df -P -k /var/lib/ceph/osd/${cluster:-ceph}-$id/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }'`
+    ceph \
+        --cluster="${cluster:-ceph}" \
+        --name="osd.$id" \
+        --keyring="/var/lib/ceph/osd/${cluster:-ceph}-$id/keyring" \
+        osd crush create-or-move \
+        -- \
+        "$id" \
+        "${weight:-${defaultweight:-1}}" \
+        $location
+fi
+
+journal="/var/lib/ceph/osd/${cluster:-ceph}-$id/journal"
+if [ -L "$journal" -a ! -e "$journal" ]; then
+    udevadm settle --timeout=5 || :
+    if [ -L "$journal" -a ! -e "$journal" ]; then
+        echo "ceph-osd($UPSTART_INSTANCE): journal not present, not starting yet." 1>&2
+        stop
+        exit 0
+    fi
+fi

--- a/src/upstart/ceph-osd.conf
+++ b/src/upstart/ceph-osd.conf
@@ -15,36 +15,7 @@ pre-start script
 
     install -d -m0755 /var/run/ceph
 
-    update="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_update_on_start || :)"
-    if [ "${update:-1}" = "1" -o "${update:-1}" = "true" ]; then
-        # update location in crush
-	hook="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_location_hook || :)"
-	if [ -z "$hook" ]; then
-	    hook="/usr/bin/ceph-crush-location"
-	fi
-	location="$($hook --cluster ${cluster:-ceph} --id $id --type osd)"
-	weight="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_initial_weight || :)"
-	defaultweight=`df -P -k /var/lib/ceph/osd/${cluster:-ceph}-$id/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }'`
-	ceph \
-            --cluster="${cluster:-ceph}" \
-            --name="osd.$id" \
-            --keyring="/var/lib/ceph/osd/${cluster:-ceph}-$id/keyring" \
-            osd crush create-or-move \
-	    -- \
-            "$id" \
-	    "${weight:-${defaultweight:-1}}" \
-	    $location
-    fi
-
-    journal="/var/lib/ceph/osd/${cluster:-ceph}-$id/journal"
-    if [ -L "$journal" -a ! -e "$journal" ]; then
-        udevadm settle --timeout=5 || :
-	if [ -L "$journal" -a ! -e "$journal" ]; then
-            echo "ceph-osd($UPSTART_INSTANCE): journal not present, not starting yet." 1>&2
-	    stop
-	    exit 0
-	fi
-    fi
+    /usr/libexec/ceph/ceph-osd-prestart.sh --cluster="${cluster:-ceph}" -i "$id"
 end script
 
 instance ${cluster:-ceph}/$id

--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Ceph metadata server daemon
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/ceph
+Environment=CLUSTER=ceph
+ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Ceph cluster monitor daemon
+
+# According to:
+#   http://www.freedesktop.org/wiki/Software/systemd/NetworkTarget
+# these can be removed once ceph-mon will dynamically change network
+# configuration.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/ceph
+Environment=CLUSTER=ceph
+ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Ceph object storage daemon
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/ceph
+Environment=CLUSTER=ceph
+ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i
+ExecStartPre=/usr/libexec/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This patch adds systemd service files. It is possible to start and
enable multiple instances (per monid, osdid, mds name), e.g.

 # systemctl start ceph-mon@node01
 # systemctl enable ceph-mon@node01

 # systemctl start ceph-osd@0
 # systemctl enable ceph-osd@0

The ceph cluster can be set in the system config file:

 /etc/sysconfig/ceph

adding or editing the CLUSTER environment variable.

Signed-off-by: Federico Simoncelli fsimonce@redhat.com
