### PR TITLE
upstart/ceph-osd.conf: bump nofile limit up by 10x

### DIFF
--- a/src/upstart/ceph-osd.conf
+++ b/src/upstart/ceph-osd.conf
@@ -6,7 +6,7 @@ stop on runlevel [!2345] or stopping ceph-osd-all
 respawn
 respawn limit 5 30
 
-limit nofile 32768 32768
+limit nofile 327680 327680
 
 pre-start script
     set -e


### PR DESCRIPTION
This should ensure that we don't hit this limit on all but the very biggest 
clusters.  We seen it hit on a ~500 OSD dumpling cluster.

Backport: firefly, dumpling Signed-off-by: Sage Weil sage@redhat.com
