### PR TITLE
Do not make directories by mistake.

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1333,9 +1333,10 @@ def main_prepare(args):
         prepare_lock.acquire()
         if not os.path.exists(args.data):
             if args.data_dev:
-                raise Error('data path does not exist', args.data)
-            else:
-                os.mkdir(args.data)
+                raise Error('data path for device does not exist', args.data)
+            if args.data_dir:
+                raise Error('data path for directory does not exist', args.data)
+            raise Error('data path does not exist', args.data)
 
         # in use?
         dmode = os.stat(args.data).st_mode


### PR DESCRIPTION
Rational: I found I had created a series of OSD directories under "/dev/" when disks I thought existed did not exist.

Warning: This change will be noticed by end users and may effect deployment infrastructures.

Note: Please note this patch resolves this issue for ceph-deploy.
https://github.com/ceph/ceph-deploy/pull/224
