### PR TITLE
cls_rgw: fix object name of objects removed on object creation

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -670,7 +670,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     unaccount_entry(header, remove_entry);
 
     if (op.log_op) {
-      rc = log_index_operation(hctx, op.name, CLS_RGW_OP_DEL, op.tag, remove_entry.meta.mtime,
+      rc = log_index_operation(hctx, remove_oid_name, CLS_RGW_OP_DEL, op.tag, remove_entry.meta.mtime,
                                remove_entry.ver, CLS_RGW_STATE_COMPLETE, header.ver, header.max_marker);
       if (rc < 0)
         continue;


### PR DESCRIPTION
Fixes: #8972
Backport: firefly, dumpling

Reported-by: Patrycja Szabłowska szablowska.patrycja@gmail.com
Signed-off-by: Yehuda Sadeh yehuda@redhat.com
