### PR TITLE
Convert static libcommon library to dynamic libceph_common library

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -130,7 +130,7 @@ EXTRALIBS += -lprofiler
 endif # PROFILER
 
 LIBGLOBAL = libglobal.la
-LIBCOMMON = libcommon.la
+LIBCOMMON = libceph_common.la
 LIBSECRET = libsecret.la
 LIBARCH = libarch.la
 LIBPERFGLUE = libperfglue.la

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,4 +1,4 @@
-libcommon_la_SOURCES = \
+libceph_common_la_SOURCES = \
 	ceph_ver.c \
 	common/DecayCounter.cc \
 	common/LogClient.cc \
@@ -75,7 +75,7 @@ libcommon_la_SOURCES = \
 	common/module.c
 
 # these should go out of libcommon
-libcommon_la_SOURCES += \
+libceph_common_la_SOURCES += \
 	mon/MonCap.cc \
 	mon/MonClient.cc \
 	mon/MonMap.cc \
@@ -112,13 +112,14 @@ noinst_HEADERS += \
 LIBCOMMON_DEPS += \
 	$(LIBERASURE_CODE) \
 	$(LIBMSG) $(LIBAUTH) \
-	$(LIBCRUSH) $(LIBJSON_SPIRIT) $(LIBLOG) $(LIBARCH)
+	$(LIBCRUSH) $(LIBJSON_SPIRIT) $(LIBLOG) $(LIBARCH) \
+	$(CRYPTO_LIBS) -luuid
 
 if LINUX
 LIBCOMMON_DEPS += -lrt
 endif # LINUX
 
-libcommon_la_LIBADD = $(LIBCOMMON_DEPS)
+libceph_common_la_LIBADD = $(LIBCOMMON_DEPS)
 
 noinst_HEADERS += \
 	common/BackTrace.h \
@@ -205,7 +206,7 @@ noinst_HEADERS += \
 	common/linux_version.h \
 	common/module.h
 
-noinst_LTLIBRARIES += libcommon.la
+lib_LTLIBRARIES += libceph_common.la
 
 
 libsecret_la_SOURCES = common/secret.c

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -47,6 +47,9 @@
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
+
+static coll_t META_COLL("meta");
+
 template <class T>
 static ostream& _prefix(std::ostream *_dout, T *t)
 {
@@ -2533,7 +2536,7 @@ int PG::_write_info(ObjectStore::Transaction& t, epoch_t epoch,
     //dout(20) << "write_info bigbl " << bigbl.length() << dendl;
   }
 
-  t.omap_setkeys(coll_t::META_COLL, infos_oid, v);
+  t.omap_setkeys(META_COLL, infos_oid, v);
 
   return 0;
 }
@@ -2577,7 +2580,7 @@ epoch_t PG::peek_map_epoch(ObjectStore *store, coll_t coll, hobject_t &infos_oid
     set<string> keys;
     keys.insert(get_epoch_key(pgid));
     map<string,bufferlist> values;
-    store->omap_get_values(coll_t::META_COLL, infos_oid, keys, &values);
+    store->omap_get_values(META_COLL, infos_oid, keys, &values);
     assert(values.size() == 1);
     tmpbl = values[ek];
     bufferlist::iterator p = tmpbl.begin();
@@ -2683,7 +2686,7 @@ void PG::append_log(
   }
 
   dout(10) << "append_log  adding " << keys.size() << " keys" << dendl;
-  t.omap_setkeys(coll_t::META_COLL, log_oid, keys);
+  t.omap_setkeys(META_COLL, log_oid, keys);
 
   pg_log.trim(&handler, trim_to, info);
 
@@ -2742,7 +2745,7 @@ int PG::read_info(
     ::decode(struct_v, p);
   } else {
     if (struct_v < 6) {
-      int r = store->read(coll_t::META_COLL, biginfo_oid, 0, 0, lbl);
+      int r = store->read(META_COLL, biginfo_oid, 0, 0, lbl);
       if (r < 0)
         return r;
       p = lbl.begin();
@@ -2755,7 +2758,7 @@ int PG::read_info(
       keys.insert(k);
       keys.insert(bk);
       map<string,bufferlist> values;
-      store->omap_get_values(coll_t::META_COLL, infos_oid, keys, &values);
+      store->omap_get_values(META_COLL, infos_oid, keys, &values);
       assert(values.size() == 2);
       lbl = values[k];
       p = lbl.begin();

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -500,8 +500,6 @@ ostream& operator<<(ostream& out, const pg_t &pg)
 
 // -- coll_t --
 
-const coll_t coll_t::META_COLL("meta");
-
 bool coll_t::is_temp(spg_t& pgid) const
 {
   const char *cstr(str.c_str());

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -467,8 +467,6 @@ ostream& operator<<(ostream& out, const spg_t &pg);
 
 class coll_t {
 public:
-  const static coll_t META_COLL;
-
   coll_t()
     : str("meta")
   { }

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -82,7 +82,7 @@ noinst_PROGRAMS += get_command_descriptions
 if WITH_BUILD_TESTS
 test_build_libcommon_SOURCES = \
 	test/buildtest_skeleton.cc \
-	$(libcommon_la_SOURCES)
+	$(libceph_common_la_SOURCES)
 test_build_libcommon_LDADD = \
 	$(LIBCOMMON_DEPS) \
 	$(PTHREAD_LIBS) $(CRYPTO_LIBS) $(EXTRALIBS)
@@ -264,7 +264,7 @@ UNITTEST_LDADD = \
 	$(PTHREAD_LIBS)
 
 unittest_encoding_SOURCES = test/encoding.cc
-unittest_encoding_LDADD = $(LIBCEPHFS) $(LIBRADOS) -lm $(UNITTEST_LDADD)
+unittest_encoding_LDADD = $(LIBCEPHFS) $(LIBRADOS) -lm $(UNITTEST_LDADD) $(LIBCOMMON)
 unittest_encoding_CXXFLAGS = $(UNITTEST_CXXFLAGS) -fno-strict-aliasing
 check_PROGRAMS += unittest_encoding
 
@@ -349,7 +349,7 @@ unittest_crush_wrapper_CXXFLAGS = $(UNITTEST_CXXFLAGS) -O2
 check_PROGRAMS += unittest_crush_wrapper
 
 unittest_base64_SOURCES = test/base64.cc
-unittest_base64_LDADD = $(LIBCEPHFS) -lm $(UNITTEST_LDADD)
+unittest_base64_LDADD = $(LIBCEPHFS) -lm $(UNITTEST_LDADD) $(LIBCOMMON)
 unittest_base64_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_PROGRAMS += unittest_base64
 
@@ -398,7 +398,7 @@ unittest_gather_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_PROGRAMS += unittest_gather
 
 unittest_run_cmd_SOURCES = test/run_cmd.cc
-unittest_run_cmd_LDADD = $(LIBCEPHFS) $(UNITTEST_LDADD)
+unittest_run_cmd_LDADD = $(LIBCEPHFS) $(UNITTEST_LDADD) $(LIBCOMMON)
 unittest_run_cmd_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_PROGRAMS += unittest_run_cmd
 
@@ -408,7 +408,7 @@ unittest_signals_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_PROGRAMS += unittest_signals
 
 unittest_simple_spin_SOURCES = test/simple_spin.cc
-unittest_simple_spin_LDADD = $(LIBCEPHFS) $(UNITTEST_LDADD)
+unittest_simple_spin_LDADD = $(LIBCEPHFS) $(UNITTEST_LDADD) $(LIBCOMMON)
 unittest_simple_spin_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_PROGRAMS += unittest_simple_spin
 

--- a/src/test/cli/ceph-authtool/manpage.t
+++ b/src/test/cli/ceph-authtool/manpage.t
@@ -1,5 +1,5 @@
   $ ceph-authtool
-  ceph-authtool: must specify filename
+  *ceph-authtool: must specify filename (glob)
   usage: ceph-authtool keyringfile [OPTIONS]...
   where the options are:
     -l, --list                    will list all keys and capabilities present in

--- a/src/test/cli/ceph-authtool/simple.t
+++ b/src/test/cli/ceph-authtool/simple.t
@@ -1,5 +1,5 @@
   $ ceph-authtool
-  ceph-authtool: must specify filename
+  *ceph-authtool: must specify filename (glob)
   usage: ceph-authtool keyringfile [OPTIONS]...
   where the options are:
     -l, --list                    will list all keys and capabilities present in

--- a/src/test/cli/crushtool/reweight_multiple.t
+++ b/src/test/cli/crushtool/reweight_multiple.t
@@ -1,5 +1,5 @@
   $ crushtool -c "$TESTDIR/simple.template.multitree" -o mt
   $ crushtool -i mt --reweight-item osd1 2.5 -o mt
-  crushtool reweighting item osd1 to 2.5
+  *crushtool reweighting item osd1 to 2.5 (glob)
   $ crushtool -d mt -o mt.txt
   $ diff mt.txt "$TESTDIR/simple.template.multitree.reweighted"

--- a/src/test/cli/crushtool/test-map-bobtail-tunables.t
+++ b/src/test/cli/crushtool/test-map-bobtail-tunables.t
@@ -1,5 +1,5 @@
   $ crushtool -i "$TESTDIR/test-map-a.crushmap" --test --show-statistics --rule 0 --set-choose-local-tries 0 --set-choose-local-fallback-tries 0 --set-choose-total-tries 50 --set-chooseleaf-descend-once 1
-  crushtool successfully built or modified map.  Use '-o <file>' to write it out.
+  *crushtool successfully built or modified map.  Use '-o <file>' to write it out. (glob)
   rule 0 (data), x = 0..1023, numrep = 1..10
   CRUSH rule 0 x 0 [36]
   CRUSH rule 0 x 1 [876]

--- a/src/test/cli/crushtool/test-map-firefly-tunables.t
+++ b/src/test/cli/crushtool/test-map-firefly-tunables.t
@@ -1,5 +1,5 @@
   $ crushtool -i "$TESTDIR/test-map-vary-r.crushmap" --test --show-statistics --rule 0 --set-choose-local-tries 0 --set-choose-local-fallback-tries 0 --set-choose-total-tries 50 --set-chooseleaf-descend-once 1 --set-chooseleaf-vary-r 1 --weight 12 0 --weight 20 0 --weight 30 0
-  crushtool successfully built or modified map.  Use '-o <file>' to write it out.
+  *crushtool successfully built or modified map.  Use '-o <file>' to write it out. (glob)
   rule 0 (data), x = 0..1023, numrep = 1..10
   CRUSH rule 0 x 0 [101]
   CRUSH rule 0 x 1 [80]

--- a/src/test/cli/crushtool/test-map-indep.t
+++ b/src/test/cli/crushtool/test-map-indep.t
@@ -1,5 +1,5 @@
   $ crushtool -i "$TESTDIR/test-map-indep.crushmap" --test --show-statistics --rule 1 --set-choose-local-tries 0 --set-choose-local-fallback-tries 0 --set-choose-total-tries 50 --set-chooseleaf-descend-once 2
-  crushtool successfully built or modified map.  Use '-o <file>' to write it out.
+  *crushtool successfully built or modified map.  Use '-o <file>' to write it out. (glob)
   rule 1 (metadata), x = 0..1023, numrep = 1..10
   CRUSH rule 1 x 0 [36]
   CRUSH rule 1 x 1 [876]

--- a/src/test/cli/crushtool/test-map-vary-r-0.t
+++ b/src/test/cli/crushtool/test-map-vary-r-0.t
@@ -1,5 +1,5 @@
   $ crushtool -i "$TESTDIR/test-map-vary-r.crushmap" --test --show-statistics --rule 3 --set-chooseleaf-vary-r 0 --weight 0 0 --weight 4 0 --weight 9 0
-  crushtool successfully built or modified map.  Use '-o <file>' to write it out.
+  *crushtool successfully built or modified map.  Use '-o <file>' to write it out. (glob)
   rule 3 (delltestrule), x = 0..1023, numrep = 2..4
   CRUSH rule 3 x 0 [94,85]
   CRUSH rule 3 x 1 [73,78]

--- a/src/test/cli/crushtool/test-map-vary-r-1.t
+++ b/src/test/cli/crushtool/test-map-vary-r-1.t
@@ -1,5 +1,5 @@
   $ crushtool -i "$TESTDIR/test-map-vary-r.crushmap" --test --show-statistics --rule 3 --set-chooseleaf-vary-r 1 --weight 0 0 --weight 4 0 --weight 9 0
-  crushtool successfully built or modified map.  Use '-o <file>' to write it out.
+  *crushtool successfully built or modified map.  Use '-o <file>' to write it out. (glob)
   rule 3 (delltestrule), x = 0..1023, numrep = 2..4
   CRUSH rule 3 x 0 [94,6]
   CRUSH rule 3 x 1 [73,52]

--- a/src/test/cli/crushtool/test-map-vary-r-2.t
+++ b/src/test/cli/crushtool/test-map-vary-r-2.t
@@ -1,5 +1,5 @@
   $ crushtool -i "$TESTDIR/test-map-vary-r.crushmap" --test --show-statistics --rule 3 --set-chooseleaf-vary-r 2 --weight 0 0 --weight 4 0 --weight 9 0
-  crushtool successfully built or modified map.  Use '-o <file>' to write it out.
+  *crushtool successfully built or modified map.  Use '-o <file>' to write it out. (glob)
   rule 3 (delltestrule), x = 0..1023, numrep = 2..4
   CRUSH rule 3 x 0 [94,45]
   CRUSH rule 3 x 1 [73,78]

--- a/src/test/cli/crushtool/test-map-vary-r-3.t
+++ b/src/test/cli/crushtool/test-map-vary-r-3.t
@@ -1,5 +1,5 @@
   $ crushtool -i "$TESTDIR/test-map-vary-r.crushmap" --test --show-statistics --rule 3 --set-chooseleaf-vary-r 3 --weight 0 0 --weight 4 0 --weight 9 0
-  crushtool successfully built or modified map.  Use '-o <file>' to write it out.
+  *crushtool successfully built or modified map.  Use '-o <file>' to write it out. (glob)
   rule 3 (delltestrule), x = 0..1023, numrep = 2..4
   CRUSH rule 3 x 0 [94,85]
   CRUSH rule 3 x 1 [73,78]

--- a/src/test/cli/crushtool/test-map-vary-r-4.t
+++ b/src/test/cli/crushtool/test-map-vary-r-4.t
@@ -1,5 +1,5 @@
   $ crushtool -i "$TESTDIR/test-map-vary-r.crushmap" --test --show-statistics --rule 3 --set-chooseleaf-vary-r 4 --weight 0 0 --weight 4 0 --weight 9 0
-  crushtool successfully built or modified map.  Use '-o <file>' to write it out.
+  *crushtool successfully built or modified map.  Use '-o <file>' to write it out. (glob)
   rule 3 (delltestrule), x = 0..1023, numrep = 2..4
   CRUSH rule 3 x 0 [94,85]
   CRUSH rule 3 x 1 [73,78]

--- a/src/test/cli/monmaptool/add-exists.t
+++ b/src/test/cli/monmaptool/add-exists.t
@@ -1,21 +1,21 @@
   $ monmaptool --create mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
-  monmaptool: writing epoch 0 to mymonmap (0 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  .*monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
+  *monmaptool: writing epoch 0 to mymonmap (0 monitors) (glob)
 
   $ ORIG_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
 
   $ monmaptool --add foo 2.3.4.5:6789 mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: writing epoch 0 to mymonmap (1 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  *monmaptool: writing epoch 0 to mymonmap (1 monitors) (glob)
   $ monmaptool --add foo 3.4.5.6:7890 mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: map already contains mon.foo
+  *monmaptool: monmap file mymonmap (glob)
+  *monmaptool: map already contains mon.foo (glob)
    usage: [--print] [--create [--clobber][--fsid uuid]] [--generate] [--set-initial-members] [--add name 1.2.3.4:567] [--rm name] <mapfilename>
   [1]
 
   $ monmaptool --print mymonmap
-  monmaptool: monmap file mymonmap
+  *monmaptool: monmap file mymonmap (glob)
   epoch 0
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)

--- a/src/test/cli/monmaptool/add-many.t
+++ b/src/test/cli/monmaptool/add-many.t
@@ -1,22 +1,22 @@
   $ monmaptool --create mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
-  monmaptool: writing epoch 0 to mymonmap (0 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  .*monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
+  *monmaptool: writing epoch 0 to mymonmap (0 monitors) (glob)
 
   $ ORIG_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
 
   $ monmaptool --add foo 2.3.4.5:6789 mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: writing epoch 0 to mymonmap (1 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  *monmaptool: writing epoch 0 to mymonmap (1 monitors) (glob)
   $ monmaptool --add bar 3.4.5.6:7890 mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: writing epoch 0 to mymonmap (2 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  *monmaptool: writing epoch 0 to mymonmap (2 monitors) (glob)
   $ monmaptool --add baz 4.5.6.7:8901 mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: writing epoch 0 to mymonmap (3 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  *monmaptool: writing epoch 0 to mymonmap (3 monitors) (glob)
 
   $ monmaptool --print mymonmap
-  monmaptool: monmap file mymonmap
+  *monmaptool: monmap file mymonmap (glob)
   epoch 0
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)

--- a/src/test/cli/monmaptool/clobber.t
+++ b/src/test/cli/monmaptool/clobber.t
@@ -1,18 +1,18 @@
   $ monmaptool --create --add foo 2.3.4.5:6789 mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
-  monmaptool: writing epoch 0 to mymonmap (1 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  .*monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
+  *monmaptool: writing epoch 0 to mymonmap (1 monitors) (glob)
 
   $ ORIG_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
 
   $ monmaptool --create mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: mymonmap exists, --clobber to overwrite
+  *monmaptool: monmap file mymonmap (glob)
+  *monmaptool: mymonmap exists, --clobber to overwrite (glob)
   [255]
 
 # hasn't changed yet
   $ monmaptool --print mymonmap
-  monmaptool: monmap file mymonmap
+  *monmaptool: monmap file mymonmap (glob)
   epoch 0
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
@@ -23,15 +23,15 @@
   $ [ "$ORIG_FSID" = "$NEW_FSID" ]
 
   $ monmaptool --create --clobber mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
-  monmaptool: writing epoch 0 to mymonmap (0 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  .*monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
+  *monmaptool: writing epoch 0 to mymonmap (0 monitors) (glob)
 
   $ NEW_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
   $ [ "$ORIG_FSID" != "$NEW_FSID" ]
 
   $ monmaptool --print mymonmap
-  monmaptool: monmap file mymonmap
+  *monmaptool: monmap file mymonmap (glob)
   epoch 0
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)

--- a/src/test/cli/monmaptool/create-print.t
+++ b/src/test/cli/monmaptool/create-print.t
@@ -1,17 +1,17 @@
   $ monmaptool --create mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
-  monmaptool: writing epoch 0 to mymonmap (0 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  .*monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
+  *monmaptool: writing epoch 0 to mymonmap (0 monitors) (glob)
 
   $ monmaptool --print mymonmap
-  monmaptool: monmap file mymonmap
+  *monmaptool: monmap file mymonmap (glob)
   epoch 0
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
 
   $ monmaptool --print -- mymonmap
-  monmaptool: monmap file mymonmap
+  *monmaptool: monmap file mymonmap (glob)
   epoch 0
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)

--- a/src/test/cli/monmaptool/create-with-add.t
+++ b/src/test/cli/monmaptool/create-with-add.t
@@ -1,10 +1,10 @@
   $ monmaptool --create --add foo 2.3.4.5:6789 mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
-  monmaptool: writing epoch 0 to mymonmap (1 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  .*monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
+  *monmaptool: writing epoch 0 to mymonmap (1 monitors) (glob)
 
   $ monmaptool --print mymonmap
-  monmaptool: monmap file mymonmap
+  *monmaptool: monmap file mymonmap (glob)
   epoch 0
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)

--- a/src/test/cli/monmaptool/print-empty.t
+++ b/src/test/cli/monmaptool/print-empty.t
@@ -1,5 +1,5 @@
   $ touch empty
   $ monmaptool --print empty
-  monmaptool: monmap file empty
-  monmaptool: unable to read monmap file
+  *monmaptool: monmap file empty (glob)
+  *monmaptool: unable to read monmap file (glob)
   [255]

--- a/src/test/cli/monmaptool/print-nonexistent.t
+++ b/src/test/cli/monmaptool/print-nonexistent.t
@@ -1,4 +1,4 @@
   $ monmaptool --print nonexistent
-  monmaptool: monmap file nonexistent
-  monmaptool: couldn't open nonexistent: (2) No such file or directory
+  *monmaptool: monmap file nonexistent (glob)
+  *monmaptool: couldn't open nonexistent: (2) No such file or directory (glob)
   [255]

--- a/src/test/cli/monmaptool/rm-nonexistent.t
+++ b/src/test/cli/monmaptool/rm-nonexistent.t
@@ -1,19 +1,19 @@
   $ monmaptool --create --add foo 2.3.4.5:6789 mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
-  monmaptool: writing epoch 0 to mymonmap (1 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  .*monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
+  *monmaptool: writing epoch 0 to mymonmap (1 monitors) (glob)
 
   $ ORIG_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
 
   $ monmaptool --rm doesnotexist mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: removing doesnotexist
-  monmaptool: map does not contain doesnotexist
+  *monmaptool: monmap file mymonmap (glob)
+  *monmaptool: removing doesnotexist (glob)
+  *monmaptool: map does not contain doesnotexist (glob)
    usage: [--print] [--create [--clobber][--fsid uuid]] [--generate] [--set-initial-members] [--add name 1.2.3.4:567] [--rm name] <mapfilename>
   [1]
 
   $ monmaptool --print mymonmap
-  monmaptool: monmap file mymonmap
+  *monmaptool: monmap file mymonmap (glob)
   epoch 0
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)

--- a/src/test/cli/monmaptool/rm.t
+++ b/src/test/cli/monmaptool/rm.t
@@ -1,17 +1,17 @@
   $ monmaptool --create --add foo 2.3.4.5:6789 mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
-  monmaptool: writing epoch 0 to mymonmap (1 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  .*monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
+  *monmaptool: writing epoch 0 to mymonmap (1 monitors) (glob)
 
   $ ORIG_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
 
   $ monmaptool --rm foo mymonmap
-  monmaptool: monmap file mymonmap
-  monmaptool: removing foo
-  monmaptool: writing epoch 0 to mymonmap (0 monitors)
+  *monmaptool: monmap file mymonmap (glob)
+  *monmaptool: removing foo (glob)
+  *monmaptool: writing epoch 0 to mymonmap (0 monitors) (glob)
 
   $ monmaptool --print mymonmap
-  monmaptool: monmap file mymonmap
+  *monmaptool: monmap file mymonmap (glob)
   epoch 0
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)

--- a/src/test/cli/monmaptool/simple.t
+++ b/src/test/cli/monmaptool/simple.t
@@ -1,4 +1,4 @@
   $ monmaptool
-  monmaptool: must specify monmap filename
+  *monmaptool: must specify monmap filename (glob)
    usage: [--print] [--create [--clobber][--fsid uuid]] [--generate] [--set-initial-members] [--add name 1.2.3.4:567] [--rm name] <mapfilename>
   [1]

--- a/src/test/cli/osdmaptool/clobber.t
+++ b/src/test/cli/osdmaptool/clobber.t
@@ -1,19 +1,19 @@
   $ osdmaptool --createsimple 3 myosdmap
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: writing epoch 1 to myosdmap
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: writing epoch 1 to myosdmap (glob)
 
   $ ORIG_FSID="$(osdmaptool --print myosdmap|grep ^fsid)"
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
 
   $ osdmaptool --createsimple 3 myosdmap
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: myosdmap exists, --clobber to overwrite
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: myosdmap exists, --clobber to overwrite (glob)
   [255]
 
 # hasn't changed yet
 #TODO typo
   $ osdmaptool --print myosdmap
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   epoch 1
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
@@ -26,15 +26,15 @@
   
 
   $ NEW_FSID="$(osdmaptool --print myosdmap|grep ^fsid)"
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   $ [ "$ORIG_FSID" = "$NEW_FSID" ]
 
   $ osdmaptool --createsimple 1 --clobber myosdmap
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: writing epoch 1 to myosdmap
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: writing epoch 1 to myosdmap (glob)
 
   $ osdmaptool --print myosdmap
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   epoch 1
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
@@ -47,7 +47,7 @@
   
 
   $ NEW_FSID="$(osdmaptool --print myosdmap|grep ^fsid)"
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
 #TODO --clobber should probably set new fsid, remove the [1]
   $ [ "$ORIG_FSID" != "$NEW_FSID" ]
   [1]

--- a/src/test/cli/osdmaptool/create-print.t
+++ b/src/test/cli/osdmaptool/create-print.t
@@ -1,10 +1,10 @@
   $ osdmaptool --createsimple 3 myosdmap
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: writing epoch 1 to myosdmap
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: writing epoch 1 to myosdmap (glob)
 
   $ osdmaptool --export-crush oc myosdmap
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: exported crush map to oc
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: exported crush map to oc (glob)
   $ crushtool --decompile oc
   # begin crush map
   tunable choose_local_tries 0
@@ -68,7 +68,7 @@
   
   # end crush map
   $ osdmaptool --print myosdmap
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   epoch 1
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
@@ -80,23 +80,23 @@
   max_osd 3
   
   $ osdmaptool --clobber --createsimple 3 --osd_pool_default_crush_replicated_ruleset 66 myosdmap
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: writing epoch 1 to myosdmap
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: writing epoch 1 to myosdmap (glob)
   $ osdmaptool --print myosdmap | grep 'pool 0'
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 66 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0
   $ osdmaptool --clobber --createsimple 3 --osd_pool_default_crush_rule 55 myosdmap 2>&1 >/dev/null | sed -e 's/^.* 0 osd_pool_//'
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   default_crush_rule is deprecated use osd_pool_default_crush_replicated_ruleset instead
   default_crush_rule = 55 overrides osd_pool_default_crush_replicated_ruleset = 0
   $ osdmaptool --print myosdmap | grep 'pool 0'
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0
   $ osdmaptool --clobber --createsimple 3 --osd_pool_default_crush_replicated_ruleset 66 --osd_pool_default_crush_rule 55 myosdmap 2>&1 >/dev/null | sed -e 's/^.* 0 osd_pool_//'
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   default_crush_rule is deprecated use osd_pool_default_crush_replicated_ruleset instead
   default_crush_rule = 55 overrides osd_pool_default_crush_replicated_ruleset = 66
   $ osdmaptool --print myosdmap | grep 'pool 0'
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0
   $ rm -f myosdmap

--- a/src/test/cli/osdmaptool/create-racks.t
+++ b/src/test/cli/osdmaptool/create-racks.t
@@ -1,9 +1,9 @@
   $ osdmaptool --create-from-conf om -c $TESTDIR/ceph.conf.withracks
-  osdmaptool: osdmap file 'om'
-  osdmaptool: writing epoch 1 to om
+  *osdmaptool: osdmap file 'om' (glob)
+  *osdmaptool: writing epoch 1 to om (glob)
   $ osdmaptool --export-crush oc om
-  osdmaptool: osdmap file 'om'
-  osdmaptool: exported crush map to oc
+  *osdmaptool: osdmap file 'om' (glob)
+  *osdmaptool: exported crush map to oc (glob)
   $ crushtool --decompile oc
   # begin crush map
   tunable choose_local_tries 0
@@ -777,11 +777,11 @@
   # end crush map
   $ rm oc
   $ osdmaptool --test-map-pg 0.0 om
-  osdmaptool: osdmap file 'om'
+  *osdmaptool: osdmap file 'om' (glob)
    parsed '0.0' -> 0.0
   0.0 raw ([], p-1) up ([], p-1) acting ([], p-1)
   $ osdmaptool --print om
-  osdmaptool: osdmap file 'om'
+  *osdmaptool: osdmap file 'om' (glob)
   epoch 1
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
@@ -794,23 +794,23 @@
   
 
   $ osdmaptool --clobber --create-from-conf --osd_pool_default_crush_replicated_ruleset 55 om -c $TESTDIR/ceph.conf.withracks  
-  osdmaptool: osdmap file 'om'
-  osdmaptool: writing epoch 1 to om
+  *osdmaptool: osdmap file 'om' (glob)
+  *osdmaptool: writing epoch 1 to om (glob)
   $ osdmaptool --print om | grep 'pool 0'
-  osdmaptool: osdmap file 'om'
+  *osdmaptool: osdmap file 'om' (glob)
   pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0
   $ osdmaptool --clobber --create-from-conf --osd_pool_default_crush_rule 55 om -c $TESTDIR/ceph.conf.withracks 2>&1 >/dev/null | sed -e 's/^.* 0 osd_pool_//'
-  osdmaptool: osdmap file 'om'
+  *osdmaptool: osdmap file 'om' (glob)
   default_crush_rule is deprecated use osd_pool_default_crush_replicated_ruleset instead
   default_crush_rule = 55 overrides osd_pool_default_crush_replicated_ruleset = 0
   $ osdmaptool --print om | grep 'pool 0'
-  osdmaptool: osdmap file 'om'
+  *osdmaptool: osdmap file 'om' (glob)
   pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0
   $ osdmaptool --clobber --create-from-conf --osd_pool_default_crush_replicated_ruleset 66 --osd_pool_default_crush_rule 55 om -c $TESTDIR/ceph.conf.withracks 2>&1 >/dev/null | sed -e 's/^.* 0 osd_pool_//'
-  osdmaptool: osdmap file 'om'
+  *osdmaptool: osdmap file 'om' (glob)
   default_crush_rule is deprecated use osd_pool_default_crush_replicated_ruleset instead
   default_crush_rule = 55 overrides osd_pool_default_crush_replicated_ruleset = 66
   $ osdmaptool --print om | grep 'pool 0'
-  osdmaptool: osdmap file 'om'
+  *osdmaptool: osdmap file 'om' (glob)
   pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0
   $ rm -f om

--- a/src/test/cli/osdmaptool/crush.t
+++ b/src/test/cli/osdmaptool/crush.t
@@ -1,10 +1,10 @@
   $ osdmaptool --createsimple 3 myosdmap
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: writing epoch 1 to myosdmap
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: writing epoch 1 to myosdmap (glob)
   $ osdmaptool --export-crush oc myosdmap
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: exported crush map to oc
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: exported crush map to oc (glob)
   $ osdmaptool --import-crush oc myosdmap
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: imported 486 byte crush map from oc
-  osdmaptool: writing epoch 3 to myosdmap
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: imported 486 byte crush map from oc (glob)
+  *osdmaptool: writing epoch 3 to myosdmap (glob)

--- a/src/test/cli/osdmaptool/missing-argument.t
+++ b/src/test/cli/osdmaptool/missing-argument.t
@@ -1,5 +1,5 @@
   $ osdmaptool
-  osdmaptool: must specify osdmap filename
+  *osdmaptool: must specify osdmap filename (glob)
    usage: [--print] [--createsimple <numosd> [--clobber] [--pg_bits <bitsperosd>]] <mapfilename>
      --export-crush <file>   write osdmap's crush map to <file>
      --import-crush <file>   replace osdmap's crush map with <file>

--- a/src/test/cli/osdmaptool/pool.t
+++ b/src/test/cli/osdmaptool/pool.t
@@ -1,6 +1,6 @@
   $ osdmaptool --createsimple 3 myosdmap
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: writing epoch 1 to myosdmap
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: writing epoch 1 to myosdmap (glob)
 
 #
 # --test-map-object / --pool
@@ -14,17 +14,17 @@
   [1]
 
   $ osdmaptool myosdmap --test-map-object foo --pool 123
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   There is no pool 123
   [1]
 
   $ osdmaptool myosdmap --test-map-object foo --pool 0
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
    object 'foo' \-\> 0\..* (re)
 
   $ osdmaptool myosdmap --test-map-object foo
-  osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: assuming pool 0 (use --pool to override)
+  *osdmaptool: osdmap file 'myosdmap' (glob)
+  *osdmaptool: assuming pool 0 (use --pool to override) (glob)
    object 'foo' \-\> 0\..* (re)
 
 #
@@ -39,14 +39,14 @@
   [1]
 
   $ osdmaptool myosdmap --test-map-pgs --pool 123
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   There is no pool 123
   [1]
 
   $ osdmaptool myosdmap --mark-up-in --test-map-pgs --pool 0 | grep pool
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   pool 0 pg_num .* (re)
 
   $ osdmaptool myosdmap --mark-up-in --test-map-pgs | grep pool
-  osdmaptool: osdmap file 'myosdmap'
+  *osdmaptool: osdmap file 'myosdmap' (glob)
   pool 0 pg_num .* (re)

--- a/src/test/cli/osdmaptool/print-empty.t
+++ b/src/test/cli/osdmaptool/print-empty.t
@@ -1,5 +1,5 @@
   $ touch empty
   $ osdmaptool --print empty
-  osdmaptool: osdmap file 'empty'
-  osdmaptool: error decoding osdmap 'empty'
+  *osdmaptool: osdmap file 'empty' (glob)
+  *osdmaptool: error decoding osdmap 'empty' (glob)
   [255]

--- a/src/test/cli/osdmaptool/print-nonexistent.t
+++ b/src/test/cli/osdmaptool/print-nonexistent.t
@@ -1,4 +1,4 @@
   $ osdmaptool --print nonexistent
-  osdmaptool: osdmap file 'nonexistent'
-  osdmaptool: couldn't open nonexistent: can't open nonexistent: (2) No such file or directory
+  *osdmaptool: osdmap file 'nonexistent' (glob)
+  *osdmaptool: couldn't open nonexistent: can't open nonexistent: (2) No such file or directory (glob)
   [255]

--- a/src/test/cli/osdmaptool/test-map-pgs.t
+++ b/src/test/cli/osdmaptool/test-map-pgs.t
@@ -7,17 +7,17 @@
 #
   $ OSD_MAP="osdmap"
   $ osdmaptool --osd_pool_default_size $SIZE --pg_bits $PG_BITS --createsimple $NUM_OSDS "$OSD_MAP" > /dev/null
-  osdmaptool: osdmap file 'osdmap'
+  *osdmaptool: osdmap file 'osdmap' (glob)
   $ CRUSH_MAP="crushmap"
   $ CEPH_ARGS="--debug-crush 0" crushtool --outfn "$CRUSH_MAP" --build --num_osds $NUM_OSDS node straw 10 rack straw 10 root straw 0
   $ osdmaptool --import-crush "$CRUSH_MAP" "$OSD_MAP" > /dev/null
-  osdmaptool: osdmap file 'osdmap'
+  *osdmaptool: osdmap file 'osdmap' (glob)
   $ OUT="$TESTDIR/out"
 # 
 # --test-map-pgs
 #
   $ osdmaptool --mark-up-in --test-map-pgs "$OSD_MAP" > "$OUT"
-  osdmaptool: osdmap file 'osdmap'
+  *osdmaptool: osdmap file 'osdmap' (glob)
   $ PG_NUM=$(($NUM_OSDS << $PG_BITS))
   $ grep "pg_num $PG_NUM" "$OUT" || cat $OUT
   pool 0 pg_num 8000
@@ -29,7 +29,7 @@
 # --test-map-pgs --test-random is expected to change nothing regarding the totals
 #
   $ osdmaptool --mark-up-in --test-random --test-map-pgs "$OSD_MAP" > "$OUT"
-  osdmaptool: osdmap file 'osdmap'
+  *osdmaptool: osdmap file 'osdmap' (glob)
   $ PG_NUM=$(($NUM_OSDS << $PG_BITS))
   $ grep "pg_num $PG_NUM" "$OUT" || cat $OUT
   pool 0 pg_num 8000

--- a/src/tools/ceph_filestore_dump.cc
+++ b/src/tools/ceph_filestore_dump.cc
@@ -31,6 +31,8 @@
 namespace po = boost::program_options;
 using namespace std;
 
+static coll_t META_COLL("meta");
+
 enum {
     TYPE_NONE = 0,
     TYPE_PG_BEGIN,
@@ -491,10 +493,10 @@ int initiate_new_remove_pg(ObjectStore *store, spg_t r_pgid,
     return ENOENT;
   }
 
-  cout << "remove " << coll_t::META_COLL << " " << log_oid.oid << std::endl;
-  rmt->remove(coll_t::META_COLL, log_oid);
-  cout << "remove " << coll_t::META_COLL << " " << biginfo_oid.oid << std::endl;
-  rmt->remove(coll_t::META_COLL, biginfo_oid);
+  cout << "remove " << META_COLL << " " << log_oid.oid << std::endl;
+  rmt->remove(META_COLL, log_oid);
+  cout << "remove " << META_COLL << " " << biginfo_oid.oid << std::endl;
+  rmt->remove(META_COLL, biginfo_oid);
 
   store->apply_transaction(*rmt);
 
@@ -1250,7 +1252,7 @@ int main(int argc, char **argv)
   bufferlist bl;
   OSDSuperblock superblock;
   bufferlist::iterator p;
-  r = fs->read(coll_t::META_COLL, OSD_SUPERBLOCK_POBJECT, 0, 0, bl);
+  r = fs->read(META_COLL, OSD_SUPERBLOCK_POBJECT, 0, 0, bl);
   if (r < 0) {
     cout << "Failure to read OSD superblock error= " << r << std::endl;
     goto out;


### PR DESCRIPTION
libcommon as a static library causes issues with LTTng, because it ends
up linked statically into both executables and dynamic libraries.
When the executables load the dynamic libraries, the same tracepoints
get loaded twice, and LTTng aborts the process.  This is why libcommon
was changed to a dynamic library.

libcommon was renamed to libceph_common because it will now be an
installed library, and the name libcommon is too generic and prone to
clashes.  The new installed library will probably require packaging
changes in the future.

Many test outputs (_.t) were modified to change "toolname: <msg>" to
"_toolname: <msg> (glob)".  Now that libcommon is a dynamic library,
many tools which previously did not rely on any Ceph dynamic libraries
changed from being invoked directly in tests to being invoked through a
libtool-generated script, which changed argv[0] in the program, which
changed the program's output.

The global variable coll_t::META_COLL was removed because its destructor
was called twice when it was linked into an executable as well as
libcommon, causing a segfault.

Signed-off-by: Adam Crume adamcrume@gmail.com
