### PR TITLE
osd: prevent old clients from using tiered pools

### DIFF
--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -74,6 +74,10 @@ struct OpRequest : public TrackedOp {
 
   void _dump(utime_t now, Formatter *f) const;
 
+  bool has_feature(uint64_t f) const {
+    return request->get_connection()->has_feature(f);
+  }
+
 private:
   Message *request; /// the logical request we are tracking
   osd_reqid_t reqid;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1116,6 +1116,12 @@ void ReplicatedPG::do_request(
       waiting_for_active.push_back(op);
       return;
     }
+    // verify client features
+    if ((pool.info.has_tiers() || pool.info.is_tier()) &&
+	!op->has_feature(CEPH_FEATURE_OSD_CACHEPOOL)) {
+      osd->reply_op_error(op, -EOPNOTSUPP);
+      return;
+    }
     do_op(op); // do it now
     break;
 


### PR DESCRIPTION
If the client is old and doesn't understand tiering, don't let them use a 
tiered pool.  Reply with EOPNOTSUPP.

Fixes: #8714 Backport: firefly Signed-off-by: Sage Weil sage@redhat.com
