### PR TITLE
ReplicatedPG: For async-read, set the real result after completing read.

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -5354,6 +5354,7 @@ void ReplicatedPG::complete_read_ctx(int result, OpContext *ctx)
     reply->set_enoent_reply_versions(info.last_update, info.last_user_version);
   }
 
+  reply->set_result(result);
   reply->add_flags(CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK);
   osd->send_message_osd_client(reply, m->get_connection());
   close_op_ctx(ctx, 0);


### PR DESCRIPTION
When reading an object from replicated pool, ceph uses sync mode,
so it can set the results in execute_ctx correctly.
However, For the async-read in EC Pool, current code didn't set the
real results after read in complete_read_ctx.
