### PR TITLE
os/FileJournal: avoid OSD::mkfs infinite wait when journal using aio mode

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -1384,10 +1384,13 @@ void FileJournal::check_aio_completion()
   while (p != aio_queue.end() && p->done) {
     dout(20) << "check_aio_completion completed seq " << p->seq << " "
 	     << p->off << "~" << p->len << dendl;
-    if (p->seq) {
-      new_journaled_seq = p->seq;
-      completed_something = true;
-    }
+    /*
+     *Now we can only update journal header w/o other data.
+     *The seq of for write journal header is 0.So we don't check the p->seq
+     */
+    new_journaled_seq = p->seq;
+    completed_something = true;
+
     aio_num--;
     aio_bytes -= p->len;
     aio_queue.erase(p++);


### PR DESCRIPTION
The aim of commit(4eb18dd487da) is want to update journal-header when
closing journal.But when mkfs, there are some case to update
journal-header. If journal us aio mode(block as journal), the process of
mkfs will infinite wait.

This becasue in aio mode, in func check_aio_completion:

> >  if (p->seq) {
> >      new_journaled_seq = p->seq;
> >      completed_something = true;
> >    }
> >   .....
> > if (completed_something) {
> >    ....
> >   aio_cond.Signal();

only the seq not zero, it can wake the aio_cond.wait().

But for updateing jouranl-header, in func do_aio_write:

> > } else {
> >    // header too?
> >    if (hbp.length()) {
> >      .....
> >      if (write_aio_bl(pos, hbl, 0)) {
> > The seq is zero.

In write_thread_entry, it consider the aio_num and
throttle_bytes.get_current().But journal-header don't add to
throttle_bytes.

The debug messages are following:
2014-07-31 23:46:45.059655 7f460423b700 10 journal write_thread_entry start
2014-07-31 23:46:45.059682 7f4609054800 10 journal journal_start
2014-07-31 23:46:45.059688 7f460423b700 20 journal prepare_multi_write queue_pos now 4096
2014-07-31 23:46:45.059736 7f460423b700 15 journal do_aio_write writing 4096~0 + header
2014-07-31 23:46:45.059740 7f460423b700 20 journal write_aio_bl 0~4096 seq 0
2014-07-31 23:46:45.059725 7f4603239700 10 journal write_finish_thread_entry enter
2014-07-31 23:46:45.059791 7f460423b700 20 journal write_aio_bl ..0~4096 in 1
2014-07-31 23:46:45.060288 7f4609054800 10 journal op_journal_transactions 2 0x7fffb94caa00
2014-07-31 23:46:45.060292 7f4609054800  5 journal submit_entry seq 2 len 505 (0x2f75d20)
2014-07-31 23:46:45.060297 7f4609054800 10 journal op_submit_finish 2
2014-07-31 23:46:45.061618 7f460423b700 20 journal write_aio_bl 4096~0 seq 0
2014-07-31 23:46:45.061630 7f460423b700  5 journal put_throttle finished
0 ops and 0 bytes, now 0 ops and 0 bytes
2014-07-31 23:46:45.061632 7f460423b700 20 journal write_thread_entry
aio throttle: aio num 1 bytes 4096 ... exp 2 min_new 4 ... pending 0
2014-07-31 23:46:45.061637 7f460423b700 20 journal write_thread_entry
deferring until more aios complete: 1 aios with 4096 bytes needs 4 bytes
to start a new aio (currently 0 pending)

Signed-off-by: Ma Jianpeng jianpeng.ma@intel.com
