### PR TITLE
rgw: need to pass need_to_wait for throttle_data()

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1583,7 +1583,7 @@ static int put_data_and_throttle(RGWPutObjProcessor *processor, bufferlist& data
       hash = NULL; /* only calculate hash once */
     }
 
-    ret = processor->throttle_data(handle, false);
+    ret = processor->throttle_data(handle, need_to_wait);
     if (ret < 0)
       return ret;
 


### PR DESCRIPTION
need_to_wait wasn't passed into processor->throttle_data()

CID 1229541:    (PW.PARAM_SET_BUT_NOT_USED)

Backport: firefly

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
