### PR TITLE
ceph-conf: flush log on exit

### DIFF
--- a/src/tools/ceph_conf.cc
+++ b/src/tools/ceph_conf.cc
@@ -206,6 +206,7 @@ int main(int argc, const char **argv)
     }
   }
 
+  g_ceph_context->_log->flush();
   if (action == "help") {
     usage();
     exit(0);


### PR DESCRIPTION
This makes it deterministic whether we output

2014-08-03 20:59:45.482614 4036c80 -1 did not load config file, using default
settings.

or not, and will make the unit tests stop intermittently failing.

Signed-off-by: Sage Weil sage@redhat.com
