### PR TITLE
osd/ECBackend: clean up assert(r==0) in continue_recovery_op.

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -481,7 +481,6 @@ void ECBackend::continue_recovery_op(
 	recovery_ops.erase(op.hoid);
 	return;
       }
-      assert(r == 0);
       m->read(
 	this,
 	op.hoid,


### PR DESCRIPTION
After the commit(d9106ce5e4437ab02), the assert(r==0) is no longer
necessary.
