### PR TITLE
EC-ISA: provide a 10% faster simple parity operation for (k, m=1)

### DIFF
--- a/src/erasure-code/isa/ErasureCodeIsa.h
+++ b/src/erasure-code/isa/ErasureCodeIsa.h
@@ -137,7 +137,7 @@ public:
     return g_decode_tbls_lru.size();
   }
 
-  // we implement an LRU cache for coding matrix - the cache size is sufficient up to (10,4) decodings
+  // we implement an LRU cache for coding matrix - the cache size is sufficient up to (12,4) decodings
   typedef std::pair<std::list<std::string>::iterator, bufferptr> lru_entry_t;
 
   std::map<std::string, lru_entry_t> g_decode_tbls_map;


### PR DESCRIPTION
The ISA EC plugin implements a fast region XOR function giving slightly better performance than computing simple parity via GF multiplication. This might be useful for LRC computations.

```
#ISA 
./ceph_erasure_code_benchmark -p isa -P technique=reed_sol_van -i 10000 -s 1000000 -P k=4 -P m=1
#JERAUSRE
./ceph_erasure_code_benchmark -p jerasure -P technique=reed_sol_van -i 10000 -s 1000000 -P k=4 -P 

ISA encoding (4,1) : 3.8 s
JERASURE (4,1): 3.5s
ISA optimized (4,1): 3.15s
```

For 4K en-/decoding the measured effect is smaller:

```
# ./ceph_erasure_code_benchmark -p isa -P technique=reed_sol_van -i 1 -s 4096 -P k=4 -P m=1 
0.000020    4
# ./ceph_erasure_code_benchmark -p jerasure -P technique=reed_sol_van -i 1 -s 4096 -P k=4 -P m=1 
0.000029    4
```
