### PR TITLE
doc: typo s/loose/lose

### DIFF
--- a/doc/dev/erasure-coded-pool.rst
+++ b/doc/dev/erasure-coded-pool.rst
@@ -103,7 +103,7 @@ Display the default erasure code profile::
   plugin=jerasure
   technique=reed_sol_van
 
-Create a profile to set the data to be distributed on six OSDs (k+m=6) and sustain the loss of three OSDs (m=3) without loosing data::
+Create a profile to set the data to be distributed on six OSDs (k+m=6) and sustain the loss of three OSDs (m=3) without losing data::
 
   $ ceph osd erasure-code-profile set myprofile k=3 m=3
   $ ceph osd erasure-code-profile get myprofile

--- a/doc/dev/osd_internals/erasure_coding.rst
+++ b/doc/dev/osd_internals/erasure_coding.rst
@@ -37,7 +37,7 @@ Glossary
 *M* 
    the number of coding *chunks*, i.e. the number of additional *chunks*
    computed by the encoding functions. If there are 2 coding *chunks*, 
-   it means 2 OSDs can be out without loosing data.
+   it means 2 OSDs can be out without losing data.
 
 *N*
    the number of data *chunks* plus the number of coding *chunks*, 

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -5,7 +5,7 @@
 When you first deploy a cluster without creating a pool, Ceph uses the default
 pools for storing data. A pool provides you with:
 
-- **Resilience**: You can set how many OSD are allowed to fail without loosing data.
+- **Resilience**: You can set how many OSD are allowed to fail without losing data.
   For replicated pools, it is the desired number of copies/replicas of an object. 
   A typical configuration stores an object and one additional copy
   (i.e., ``size = 2``), but you can determine the number of copies/replicas.


### PR DESCRIPTION
Minor typo replace loose with lose 

Signed-off-by: Abhishek Lekshmanan abhishek.lekshmanan@gmail.com
