### PR TITLE
Enable rocksdb log level

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -598,6 +598,7 @@ OPTION(rocksdb_disableDataSync, OPT_BOOL, true) // if true, data files are not s
 OPTION(rocksdb_disableWAL, OPT_BOOL, false)  // diable write ahead log
 OPTION(rocksdb_num_levels, OPT_INT, 0) // number of levels for this database
 OPTION(rocksdb_wal_dir, OPT_STR, "")  //  rocksdb write ahead log file
+OPTION(rocksdb_info_log_level, OPT_STR, "info")  // info log level : debug , info , warn, error, fatal
 
 /**
  * osd_client_op_priority and osd_recovery_op_priority adjust the relative

--- a/src/os/RocksDBStore.h
+++ b/src/os/RocksDBStore.h
@@ -96,6 +96,7 @@ public:
   void compact_range_async(const string& prefix, const string& start, const string& end) {
     compact_range_async(combine_strings(prefix, start), combine_strings(prefix, end));
   }
+  int get_info_log_level(string info_log_level);
 
   /**
    * options_t: Holds options which are minimally interpreted
@@ -132,6 +133,7 @@ public:
 
     string log_file;
     string wal_dir;
+    string info_log_level;
 
     options_t() :
       write_buffer_size(0), //< 0 means default
@@ -148,7 +150,8 @@ public:
       level0_stop_writes_trigger(0),
       disableDataSync(false),
       disableWAL(false),
-      num_levels(0)
+      num_levels(0),
+      info_log_level("info")
     {}
   } options;
 


### PR DESCRIPTION
currently ,  if you redirect rocksdb info log to another file , the log file get created but empty , this is due to the default log level (ERROR_LEVEL), this patch will enable log level config option for rocksdb.
