### PR TITLE
rados: fix 'rados df --format=json' field names

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -23,3 +23,7 @@ v0.83
 
 * The 'rados df --format=json' output 'read_bytes' and 'write_bytes'
   fields were incorrectly reporting ops; this is now fixed.
+
+* The 'rados df --format=json' output previously included 'read_kb' and
+  'write_kb' fields; these have been removed.  Please use 'read_bytes' and
+  'write_bytes' instead (and divide by 1024 if appropriate).

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1488,8 +1488,6 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
           formatter->dump_format("num_objects_degraded", "%lld", s.num_objects_degraded);
           formatter->dump_format("read_ops", "%lld", s.num_rd);
           formatter->dump_format("read_bytes", "%lld", s.num_rd_kb * 1024ull);
-          formatter->dump_format("read_kb", "%lld", s.num_rd_kb);
-          formatter->dump_format("write_kb", "%lld", s.num_wr_kb);
           formatter->dump_format("write_ops", "%lld", s.num_wr);
           formatter->dump_format("write_bytes", "%lld", s.num_wr_kb * 1024ull);
           formatter->flush(cout);


### PR DESCRIPTION
read_bytes -> read_ops
read_kb -> read_bytes (and \* 1024)

Same for writes.

Remove the _kb fields entirely; they are redundant.

Backport: firefly, dumpling
Signed-off-by: Sage Weil sage@redhat.com
