### PR TITLE
TrackedOp: Removed redundant lock in OpTracker::_mark_event()

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -169,7 +169,7 @@ bool OpTracker::check_ops_in_flight(std::vector<string> &warning_vector)
       stringstream ss;
       ss << "slow request " << age << " seconds old, received at "
          << (*i)->get_initiated() << ": ";
-      (*i)->_dump_op_descriptor(ss);
+      (*i)->_dump_op_descriptor_unlocked(ss);
       ss << " currently "
 	 << ((*i)->current.size() ? (*i)->current : (*i)->state_string());
       warning_vector.push_back(ss.str());
@@ -232,7 +232,7 @@ void OpTracker::_mark_event(TrackedOp *op, const string &evt,
 			    utime_t time)
 {
   stringstream ss;
-  op->_dump_op_descriptor(ss);
+  op->_dump_op_descriptor_unlocked(ss);
   dout(5) << //"reqid: " << op->get_reqid() <<
 	     ", seq: " << op->seq
 	  << ", time: " << time << ", event: " << evt
@@ -267,7 +267,7 @@ void TrackedOp::mark_event(const string &event)
 void TrackedOp::dump(utime_t now, Formatter *f) const
 {
   stringstream name;
-  _dump_op_descriptor(name);
+  _dump_op_descriptor_unlocked(name);
   f->dump_string("description", name.str().c_str()); // this TrackedOp
   f->dump_stream("initiated_at") << get_initiated();
   f->dump_float("age", now - get_initiated());

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -149,7 +149,7 @@ protected:
   /// if you want something else to happen when events are marked, implement
   virtual void _event_marked() {}
   /// return a unique descriptor of the Op; eg the message it's attached to
-  virtual void _dump_op_descriptor(ostream& stream) const = 0;
+  virtual void _dump_op_descriptor_unlocked(ostream& stream) const = 0;
   /// called when the last non-OpTracker reference is dropped
   virtual void _unregistered() {};
 

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -343,7 +343,7 @@ void MDRequestImpl::_dump(utime_t now, Formatter *f) const
   }
 }
 
-void MDRequestImpl::_dump_op_descriptor(ostream& stream) const
+void MDRequestImpl::_dump_op_descriptor_unlocked(ostream& stream) const
 {
   if (client_request) {
     client_request->print(stream);

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -324,7 +324,7 @@ struct MDRequestImpl : public MutationImpl, public TrackedOp {
   typedef ceph::shared_ptr<MDRequestImpl> Ref;
 protected:
   void _dump(utime_t now, Formatter *f) const;
-  void _dump_op_descriptor(ostream& stream) const;
+  void _dump_op_descriptor_unlocked(ostream& stream) const;
 };
 
 typedef ceph::shared_ptr<MDRequestImpl> MDRequestRef;

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -60,7 +60,7 @@ void OpRequest::_dump(utime_t now, Formatter *f) const
   }
 }
 
-void OpRequest::_dump_op_descriptor(ostream& stream) const
+void OpRequest::_dump_op_descriptor_unlocked(ostream& stream) const
 {
   get_req()->print(stream);
 }

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -94,7 +94,7 @@ private:
   OpRequest(Message *req, OpTracker *tracker);
 
 protected:
-  void _dump_op_descriptor(ostream& stream) const;
+  void _dump_op_descriptor_unlocked(ostream& stream) const;
   void _unregistered();
 
 public:


### PR DESCRIPTION
ops_in_flight_lock seems redundant in OpTracker::_mark_event()
and this lock is highly contended for. Removing the same
is giving a significant performance boost.

Signed-off-by: Pavan Rallabhandi pavan.rallabhandi@sandisk.com
