### PR TITLE
mds: Make min/max UID configurable for who is allowed to create a snapsh...

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -383,8 +383,8 @@ OPTION(mds_op_history_size, OPT_U32, 20)    // Max number of completed ops to tr
 OPTION(mds_op_history_duration, OPT_U32, 600) // Oldest completed op to track
 OPTION(mds_op_complaint_time, OPT_FLOAT, 30) // how many seconds old makes an op complaint-worthy
 OPTION(mds_op_log_threshold, OPT_INT, 5) // how many op log messages to show in one go
-OPTION(mds_mksnap_min_uid, OPT_U32, 0) // The minimum UID required to create a snapshot
-OPTION(mds_mksnap_max_uid, OPT_U32, 65536) // The maximum UID allowed to create a snapshot
+OPTION(mds_snap_min_uid, OPT_U32, 0) // The minimum UID required to create a snapshot
+OPTION(mds_snap_max_uid, OPT_U32, 65536) // The maximum UID allowed to create a snapshot
 
 // If true, compact leveldb store on mount
 OPTION(osd_compact_leveldb_on_mount, OPT_BOOL, false)

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7373,7 +7373,7 @@ void Server::handle_client_mksnap(MDRequestRef& mdr)
   
   const string &snapname = req->get_filepath().last_dentry();
 
-  if (mdr->client_request->get_caller_uid() < g_conf->mds_mksnap_min_uid || mdr->client_request->get_caller_uid() > g_conf->mds_mksnap_max_uid) {
+  if (mdr->client_request->get_caller_uid() < g_conf->mds_snap_min_uid || mdr->client_request->get_caller_uid() > g_conf->mds_snap_max_uid) {
     dout(20) << "mksnap " << snapname << " on " << *diri << " denied to uid " << mdr->client_request->get_caller_uid() << dendl;
     reply_request(mdr, -EPERM);
     return;
@@ -7512,7 +7512,7 @@ void Server::handle_client_rmsnap(MDRequestRef& mdr)
 
   const string &snapname = req->get_filepath().last_dentry();
 
-  if (mdr->client_request->get_caller_uid() < g_conf->mds_mksnap_min_uid || mdr->client_request->get_caller_uid() > g_conf->mds_mksnap_max_uid) {
+  if (mdr->client_request->get_caller_uid() < g_conf->mds_snap_min_uid || mdr->client_request->get_caller_uid() > g_conf->mds_snap_max_uid) {
     dout(20) << "rmsnap " << snapname << " on " << *diri << " denied to uid " << mdr->client_request->get_caller_uid() << dendl;
     reply_request(mdr, -EPERM);
     return;


### PR DESCRIPTION
...ot

This way administrators can configure which UIDs are allowed to create
snapshots on CephFS.

In certain situations it might be desirable that regular users are not allowed
to create snapshots. For example on shared hosting environments.

Fixes: #9029
