### PR TITLE
OSDMonitor: Do not allow OSD removal using setmaxosd

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4505,6 +4505,23 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
       goto reply;
     }
 
+    // Don't allow shrinking OSD number as this will cause data loss
+    // and may cause kernel crashes.
+    // Note: setmaxosd sets the maximum OSD number and not the number of OSDs
+    if (newmax < osdmap.get_max_osd()) {
+      // Check if the OSDs exist between current max and new value.
+      // If there are any OSDs exist, then don't allow shrinking number
+      // of OSDs.
+      for (int i = newmax; i <= osdmap.get_max_osd(); i++) {
+        if (osdmap.exists(i)) {
+          err = -EINVAL;
+          ss << "cannot shrink max_osd to " << newmax 
+             << " which is < curent max osd number" ;
+          goto reply;
+        }
+      }
+    }
+
     pending_inc.new_max_osd = newmax;
     ss << "set new max_osd = " << pending_inc.new_max_osd;
     getline(ss, rs);


### PR DESCRIPTION
Description: Currently setmaxosd command allows removal of OSDs by providing
a number less than current max OSD number. This causes abrupt removal of
OSDs causing data loss as well as kernel panic when kernel RBDs are involved.
Fix is to avoid removal of OSDs using setmaxosd command.

Fixes: #8865

Signed-off-by: Anand Bhat anand.bhat@sandisk.com
