### PR TITLE
osd_types: s/stashed/rollback_info_completed and set on create

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2548,7 +2548,7 @@ void ObjectModDesc::dump(Formatter *f) const
 {
   f->open_object_section("object_mod_desc");
   f->dump_bool("can_local_rollback", can_local_rollback);
-  f->dump_bool("stashed", stashed);
+  f->dump_bool("rollback_info_completed", rollback_info_completed);
   {
     f->open_array_section("ops");
     DumpVisitor vis(f);
@@ -2583,7 +2583,7 @@ void ObjectModDesc::encode(bufferlist &_bl) const
 {
   ENCODE_START(1, 1, _bl);
   ::encode(can_local_rollback, _bl);
-  ::encode(stashed, _bl);
+  ::encode(rollback_info_completed, _bl);
   ::encode(bl, _bl);
   ENCODE_FINISH(_bl);
 }
@@ -2591,7 +2591,7 @@ void ObjectModDesc::decode(bufferlist::iterator &_bl)
 {
   DECODE_START(1, _bl);
   ::decode(can_local_rollback, _bl);
-  ::decode(stashed, _bl);
+  ::decode(rollback_info_completed, _bl);
   ::decode(bl, _bl);
   DECODE_FINISH(_bl);
 }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1874,7 +1874,7 @@ inline ostream& operator<<(ostream& out, const pg_query_t& q) {
 class PGBackend;
 class ObjectModDesc {
   bool can_local_rollback;
-  bool stashed;
+  bool rollback_info_completed;
 public:
   class Visitor {
   public:
@@ -1894,22 +1894,22 @@ public:
     CREATE = 4,
     UPDATE_SNAPS = 5
   };
-  ObjectModDesc() : can_local_rollback(true), stashed(false) {}
+  ObjectModDesc() : can_local_rollback(true), rollback_info_completed(false) {}
   void claim(ObjectModDesc &other) {
     bl.clear();
     bl.claim(other.bl);
     can_local_rollback = other.can_local_rollback;
-    stashed = other.stashed;
+    rollback_info_completed = other.rollback_info_completed;
   }
   void claim_append(ObjectModDesc &other) {
-    if (!can_local_rollback || stashed)
+    if (!can_local_rollback || rollback_info_completed)
       return;
     if (!other.can_local_rollback) {
       mark_unrollbackable();
       return;
     }
     bl.claim_append(other.bl);
-    stashed = other.stashed;
+    rollback_info_completed = other.rollback_info_completed;
   }
   void swap(ObjectModDesc &other) {
     bl.swap(other.bl);
@@ -1918,16 +1918,16 @@ public:
     other.can_local_rollback = can_local_rollback;
     can_local_rollback = temp;
 
-    temp = other.stashed;
-    other.stashed = stashed;
-    stashed = temp;
+    temp = other.rollback_info_completed;
+    other.rollback_info_completed = rollback_info_completed;
+    rollback_info_completed = temp;
   }
   void append_id(ModID id) {
     uint8_t _id(id);
     ::encode(_id, bl);
   }
   void append(uint64_t old_size) {
-    if (!can_local_rollback || stashed)
+    if (!can_local_rollback || rollback_info_completed)
       return;
     ENCODE_START(1, 1, bl);
     append_id(APPEND);
@@ -1935,7 +1935,7 @@ public:
     ENCODE_FINISH(bl);
   }
   void setattrs(map<string, boost::optional<bufferlist> > &old_attrs) {
-    if (!can_local_rollback || stashed)
+    if (!can_local_rollback || rollback_info_completed)
       return;
     ENCODE_START(1, 1, bl);
     append_id(SETATTRS);
@@ -1943,24 +1943,25 @@ public:
     ENCODE_FINISH(bl);
   }
   bool rmobject(version_t deletion_version) {
-    if (!can_local_rollback || stashed)
+    if (!can_local_rollback || rollback_info_completed)
       return false;
     ENCODE_START(1, 1, bl);
     append_id(DELETE);
     ::encode(deletion_version, bl);
     ENCODE_FINISH(bl);
-    stashed = true;
+    rollback_info_completed = true;
     return true;
   }
   void create() {
-    if (!can_local_rollback || stashed)
+    if (!can_local_rollback || rollback_info_completed)
       return;
+    rollback_info_completed = true;
     ENCODE_START(1, 1, bl);
     append_id(CREATE);
     ENCODE_FINISH(bl);
   }
   void update_snaps(set<snapid_t> &old_snaps) {
-    if (!can_local_rollback || stashed)
+    if (!can_local_rollback || rollback_info_completed)
       return;
     ENCODE_START(1, 1, bl);
     append_id(UPDATE_SNAPS);


### PR DESCRIPTION
Originally, this flag indicated that the object had already been stashed and
that therefore recording subsequent changes is unecessary.  We want to set it
on create() as well since operations like [create, writefull] should not need
to stash the object.

Fixes: #8625
Signed-off-by: Samuel Just sam.just@inktank.com
