### PR TITLE
osd: fix pg epoch floor tracking

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -351,7 +351,7 @@ public:
     Mutex::Locker l(pg_epoch_lock);
     map<spg_t,epoch_t>::iterator t = pg_epoch.find(pgid);
     assert(t != pg_epoch.end());
-    pg_epochs.erase(t->second);
+    pg_epochs.erase(pg_epochs.find(t->second));
     t->second = epoch;
     pg_epochs.insert(epoch);
   }
@@ -359,7 +359,7 @@ public:
     Mutex::Locker l(pg_epoch_lock);
     map<spg_t,epoch_t>::iterator t = pg_epoch.find(pgid);
     if (t != pg_epoch.end()) {
-      pg_epochs.erase(t->second);
+      pg_epochs.erase(pg_epochs.find(t->second));
       pg_epoch.erase(t);
     }
   }


### PR DESCRIPTION
If you call erase() on a multiset it will delete all instances of a value;
we only want to delete one of them.  Fix this by passing an iterator.

Backport: firefly
Signed-off-by: Sage Weil sage@redhat.com
