### PR TITLE
crush: Avoid ruleset overflow.

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -805,12 +805,14 @@ int CrushWrapper::add_simple_ruleset(string name, string root_name,
     return -EINVAL;
   }
 
-  int ruleset = 0;
-  for (int i = 0; i < get_max_rules(); i++) {
-    if (rule_exists(i) &&
-	get_rule_mask_ruleset(i) >= ruleset) {
-      ruleset = get_rule_mask_ruleset(i) + 1;
-    }
+  int ruleset;
+  for (ruleset = 0; ruleset < CRUSH_MAX_RULESET; ruleset++) {
+      if (!ruleset_exists(ruleset))
+	break;
+  }
+  if (ruleset == CRUSH_MAX_RULESET) {
+    *err << "too many rulesets (max  " << CRUSH_MAX_RULESET << ")";
+    return -ENOSPC;
   }
 
   int steps = 3;

--- a/src/crush/builder.c
+++ b/src/crush/builder.c
@@ -95,6 +95,7 @@ struct crush_rule *crush_make_rule(int len, int ruleset, int type, int minsize, 
                 return NULL;
 	rule->len = len;
 	rule->mask.ruleset = ruleset;
+	assert(rule->mask.ruleset == ruleset);
 	rule->mask.type = type;
 	rule->mask.min_size = minsize;
 	rule->mask.max_size = maxsize;

--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -26,6 +26,7 @@
 #define CRUSH_MAGIC 0x00010000ul   /* for detecting algorithm revisions */
 
 #define CRUSH_MAX_DEPTH 10  /* max crush hierarchy depth */
+#define CRUSH_MAX_RULESET (1<<8)
 
 #define CRUSH_MAX_DEVICE_WEIGHT (100u * 0x10000u)
 #define CRUSH_MAX_BUCKET_WEIGHT (65535u * 0x10000u)


### PR DESCRIPTION
Add check to avoid ruleset of struct crush_rule_mask overflow.

Signed-off-by: Ma Jianpeng jianpeng.ma@intel.com
