### PR TITLE
librbd: fix error path cleanup for opening an image

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2080,7 +2080,7 @@ reprotect_and_return_err:
 			 << ictx->snap_name << "'" << dendl;
     int r = ictx->init();
     if (r < 0)
-      return r;
+      goto err_close;
 
     if (!ictx->read_only) {
       r = ictx->register_watch();

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -189,6 +189,16 @@ def test_open_read_only():
             RBD().remove(ioctx, IMG_NAME)
             eq(data, read)
 
+def test_open_dne():
+    for i in xrange(100):
+        assert_raises(ImageNotFound, Image, ioctx, IMG_NAME + 'dne')
+        assert_raises(ImageNotFound, Image, ioctx, IMG_NAME, 'snap')
+
+def test_open_readonly_dne():
+    for i in xrange(100):
+        assert_raises(ImageNotFound, Image, ioctx, IMG_NAME + 'dne', read_only=True)
+        assert_raises(ImageNotFound, Image, ioctx, IMG_NAME, 'snap', read_only=True)
+
 def test_remove_dne():
     assert_raises(ImageNotFound, remove_image)
 


### PR DESCRIPTION
If the image doesn't exist and caching is enabled, the ObjectCacher was not
being shutdown, and the ImageCtx was leaked. The IoCtx could later be closed
while the ObjectCacher was still running, resulting in a segfault. Simply use
the usual cleanup path in open_image(), which works fine here.

Fixes: #8912
Backport: dumpling, firefly
Signed-off-by: Josh Durgin josh.durgin@inktank.com
