### PR TITLE
utime: Because class Clock didn't exist,so remove the declaration in class utime_t

### DIFF
--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -33,8 +33,6 @@ public:
     __u32 tv_sec, tv_nsec;
   } tv;
 
-  friend class Clock;
- 
  public:
   bool is_zero() const {
     return (tv.tv_sec == 0) && (tv.tv_nsec == 0);


### PR DESCRIPTION
Signed-off-by: Ma Jianpeng jianpeng.ma@intel.com
