### PR TITLE
common/LogClient: fix sending dup log items

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -125,6 +125,7 @@ bool LogClient::are_pending()
 
 Message *LogClient::_get_mon_log_message()
 {
+  assert(log_lock.is_locked());
    if (log_queue.empty())
      return NULL;
 
@@ -150,7 +151,7 @@ Message *LogClient::_get_mon_log_message()
   assert(num_unsent <= log_queue.size());
   std::deque<LogEntry>::iterator p = log_queue.begin();
   std::deque<LogEntry> o;
-  while (p->seq < last_log_sent) {
+  while (p->seq <= last_log_sent) {
     ++p;
     assert(p != log_queue.end());
   }


### PR DESCRIPTION
We need to skip even the most recently sent item in order to get to the ones
we haven't sent yet.

Backport: firefly, dumpling Signed-off-by: Sage Weil sage@redhat.com
