### PR TITLE
ReplicatedPG::maybe_handle_cache: do not skip promote for write_ordered

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1605,7 +1605,7 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
     if (!must_promote && can_skip_promote(op, obc)) {
       return false;
     }
-    if (op->may_write() || must_promote || !hit_set) {
+    if (op->may_write() || write_ordered || must_promote || !hit_set) {
       promote_object(op, obc, missing_oid);
     } else {
       switch (pool.info.min_read_recency_for_promote) {


### PR DESCRIPTION
We cannot redirect a RW ordered read.

Fixes: #9064
Introduced: 0ed3adc1e0a74bf9548d1d956aece11f019afee0
Signed-off-by: Samuel Just sam.just@inktank.com
