### PR TITLE
ceph-disk: fix various dmcrypt bugs

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -119,6 +119,9 @@ STATEDIR = '/var/lib/ceph'
 
 SYSCONFDIR = '/etc/ceph'
 
+# only warn once about some things
+warned_about = {}
+
 # Nuke the TERM variable to avoid confusing any subprocesses we call.
 # For example, libreadline will print weird control sequences for some
 # TERM values.
@@ -2193,6 +2196,9 @@ def get_partition_type(part):
         return None    # GPT, and blkid appears to be new, so we're done.
 
     # bah, fall back to sgdisk.
+    if 'blkid' not in warned_about:
+        LOG.warning('Old blkid does not support ID_PART_ENTRY_* fields, trying sgdisk; may not correctly identify ceph volumes with dmcrypt')
+        warned_about['blkid'] = True
     (base, partnum) = re.match('(\D+)(\d+)', part).group(1, 2)
     sgdisk, _ = command(
         [
@@ -2741,3 +2747,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+    warned_about = {}


### PR DESCRIPTION
Two sets of patches here: the first few just make ceph-disk work with
dmcrypt.

The second set make 'ceph-disk list' print out useful information when they
are dmcrypted volumes.  This isn't quite as clean as I would like as there
is some duplicate logic in the partiion_map code and in the list code, but
it seems to work and isn't worse than before.  In an ideal work, we would
probably have a single method that makes a full 'map' of the devices,
partitions, and file systems on them, and then print it out without mounting
things (again).  But, if the fs is already mounted, this is fast, so
whatever.

It doesn't map a dmcrypt volume if it isn't already mapped, so that could
be improved as well.
