### PR TITLE
rgw: move generic server usage after all options

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -727,11 +727,11 @@ int usage()
   cerr << "  --rgw-region=<region>     region in which radosgw runs\n";
   cerr << "  --rgw-zone=<zone>         zone in which radosgw runs\n";
   cerr << "  --rgw-socket-path=<path>  specify a unix domain socket path\n";
-  generic_server_usage();
   cerr << "  -m monaddress[:port]      connect to specified monitor\n";
   cerr << "  --keyring=<path>          path to radosgw keyring\n";
   cerr << "  --logfile=<logfile>       file to log debug output\n";
   cerr << "  --debug-rgw=<log-level>/<memory-level>  set radosgw debug level\n";
+  generic_server_usage();
 
   return 0;
 }


### PR DESCRIPTION
Since generic_server_usage() exits after printing the options, any other
help options should be printed before that. Now the help for radosgw
looks like the following:

```
usage: radosgw [options...]
options:
  --rgw-region=<region>     region in which radosgw runs
  --rgw-zone=<zone>         zone in which radosgw runs
  --rgw-socket-path=<path>  specify a unix domain socket path
  -m monaddress[:port]      connect to specified monitor
  --keyring=<path>          path to radosgw keyring
  --logfile=<logfile>       file to log debug output
  --debug-rgw=<log-level>/<memory-level>  set radosgw debug level
  --conf/-c FILE    read configuration from the given configuration file
  --id/-i ID        set ID portion of my name
  --name/-n TYPE.ID set name
  --cluster NAME    set cluster name (default: ceph)
  --version         show version and quit

  -d                run in foreground, log to stderr.
  -f                run in foreground, log to usual location.
  --debug_ms N      set message debug level (e.g. 1)

```

This should sync the help options displayed similar to man page options
in current master.  This should close documentation bugs #8112 & #8864

Signed-off-by: Abhishek Lekshmanan abhishek.lekshmanan@gmail.com
