### PR TITLE
msg/PipeConnection: make methods behave on 'anon' connection

### DIFF
--- a/src/msg/PipeConnection.cc
+++ b/src/msg/PipeConnection.cc
@@ -69,6 +69,7 @@ void PipeConnection::reset_pipe(Pipe *p)
 
 int PipeConnection::send_message(Message *m)
 {
+  assert(msgr);
   return static_cast<SimpleMessenger*>(msgr)->send_message(m, this);
 }
 
@@ -79,10 +80,12 @@ void PipeConnection::send_keepalive()
 
 void PipeConnection::mark_down()
 {
-  static_cast<SimpleMessenger*>(msgr)->mark_down(this);
+  if (msgr)
+    static_cast<SimpleMessenger*>(msgr)->mark_down(this);
 }
 
 void PipeConnection::mark_disposable()
 {
-  static_cast<SimpleMessenger*>(msgr)->mark_disposable(this);
+  if (msgr)
+    static_cast<SimpleMessenger*>(msgr)->mark_disposable(this);
 }


### PR DESCRIPTION
The monitor does a create_anon_connection() to create a pseudo Connection
object for forwarded messages.  If we try to call mark_down or similar
on one of these we should silently ignore the operation, not crash.

If we try to send a message, still crash (explicitly assert); the caller
should probably know better.

Fixes: #9062
Signed-off-by: Sage Weil sage@redhat.com
