### PR TITLE
EC-ISA: add intelligent table cache

### DIFF
--- a/src/erasure-code/isa/ErasureCodeIsaTableCache.h
+++ b/src/erasure-code/isa/ErasureCodeIsaTableCache.h
@@ -1,0 +1,173 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 CERN (Switzerland)
+ *
+ * Author: Andreas-Joachim Peters <Andreas.Joachim.Peters@cern.ch>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+/**
+ * @file   ErasureCodeIsaTableCache.h
+ *
+ * @brief  Erasure Code Isa CODEC Table Cache
+ *
+ * The INTEL ISA-L library supports two pre-defined encoding matrices (cauchy = default, reed_sol_van = default)
+ * The default CODEC implementation using these two matrices is implemented in class ErasureCodeIsaDefault.
+ * ISA-L allows to use custom matrices which might be added later as implementations deriving from the base class ErasoreCodeIsa.
+ */
+
+#ifndef CEPH_ERASURE_CODE_ISA_TABLE_CACHE_H
+#define CEPH_ERASURE_CODE_ISA_TABLE_CACHE_H
+
+// -----------------------------------------------------------------------------
+#include "common/Mutex.h"
+#include "erasure-code/ErasureCodeInterface.h"
+// -----------------------------------------------------------------------------
+#include <list>
+// -----------------------------------------------------------------------------
+
+class ErasureCodeIsaTableCache  {
+  // ---------------------------------------------------------------------------
+  // This class implements a table caches for encoding and decoding matrixes.
+  // Encoding matrixes are shared for the same (k,m) combination. It supplies
+  // a decoding matrix lru cache which is shared for identical
+  // matrix types e.g. there is one cache (lru-list + lru-map) for Cauchy and 
+  // one for Vandermonde matrices!
+  // ---------------------------------------------------------------------------
+
+public:
+  
+  // the cache size is sufficient up to (12,4) decoding's
+
+  static const int decoding_tables_lru_length=2516;  
+
+  typedef std::pair<std::list<std::string>::iterator, bufferptr> lru_entry_t;
+  typedef std::map< int, unsigned char** > codec_table_t; 
+  typedef std::map< int , codec_table_t > codec_tables_t; 
+  typedef std::map< int, codec_tables_t > codec_technique_tables_t; 
+
+  typedef std::map< std::string, lru_entry_t > lru_map_t;
+  typedef std::list< std::string > lru_list_t;
+
+
+ ErasureCodeIsaTableCache() :
+  codec_tables_guard("isa-lru-cache") {}
+
+  virtual ~ErasureCodeIsaTableCache() {
+    Mutex::Locker lock(codec_tables_guard);
+
+    codec_technique_tables_t::const_iterator ttables_it;
+    codec_tables_t::const_iterator tables_it;
+    codec_table_t::const_iterator table_it;
+
+    std::map<int, lru_map_t*>::const_iterator lru_map_it;
+    std::map<int, lru_list_t*>::const_iterator lru_list_it;
+
+    // clean-up all allocated tables
+    for (ttables_it = encoding_coefficient.begin(); ttables_it != encoding_coefficient.end(); ++ttables_it) {
+      for (tables_it = ttables_it->second.begin(); tables_it != ttables_it->second.end(); ++tables_it) {
+	for (table_it = tables_it->second.begin(); table_it != tables_it->second.end(); ++table_it) {
+	  if (table_it->second) {
+	    if (*(table_it->second)) {
+	      delete *(table_it->second);
+	    }
+	    delete table_it->second;
+	  }
+	}
+      }
+    }
+
+    for (ttables_it = encoding_table.begin(); ttables_it != encoding_table.end(); ++ttables_it) {
+      for (tables_it = ttables_it->second.begin(); tables_it != ttables_it->second.end(); ++tables_it) {
+	for (table_it = tables_it->second.begin(); table_it != tables_it->second.end(); ++table_it) {
+	  if (table_it->second) {
+	    if (*(table_it->second)) {
+	      delete *(table_it->second);
+	    }
+	    delete table_it->second;
+	  }
+	}
+      }
+    }
+    
+    for (lru_map_it = decoding_tables.begin(); lru_map_it != decoding_tables.end(); ++lru_map_it) {
+      if (lru_map_it->second) {
+	delete lru_map_it->second;
+      }
+    }
+    
+    for (lru_list_it = decoding_tables_lru.begin(); lru_list_it != decoding_tables_lru.end(); ++lru_list_it) {
+      if (lru_list_it->second) {
+	delete lru_list_it->second;
+      }
+    }
+  }
+
+  int getDecodingCacheSize( int matrixtype )
+  {
+    Mutex::Locker lock(codec_tables_guard);
+    if (decoding_tables[matrixtype])
+      return decoding_tables[matrixtype]->size();
+    else
+      return -1;
+  }
+
+  lru_map_t* getDecodingTables( int matrix_type ) {
+    Mutex::Locker lock(codec_tables_guard);
+    // create an lru_map if not yet allocated
+    if (!decoding_tables[matrix_type]) {
+      decoding_tables[matrix_type] = new lru_map_t;
+    }
+    return decoding_tables[matrix_type];
+  }
+  
+  lru_list_t* getDecodingTablesLru( int matrix_type ) {
+    Mutex::Locker lock(codec_tables_guard);
+    // create an lru_list if not yet allocated
+    if (!decoding_tables_lru[matrix_type]) {
+      decoding_tables_lru[matrix_type] = new lru_list_t;
+    }
+    return decoding_tables_lru[matrix_type];
+  }
+
+  unsigned char** getEncodingTable(int matrix, int k, int m)
+  {
+    Mutex::Locker lock(codec_tables_guard);
+    // create a pointer to store an encoding table address
+    if (! encoding_table[matrix][k][m] ) { 
+      encoding_table[matrix][k][m] = new (unsigned char*);
+      *encoding_table[matrix][k][m] = 0;
+    }
+    return encoding_table[matrix][k][m];
+  }
+
+  unsigned char** getEncodingCoefficient(int matrix, int k, int m)
+  {
+    Mutex::Locker lock(codec_tables_guard);
+    // create a pointer to store an encoding coefficients adddress
+    if (! encoding_coefficient[matrix][k][m] ) {
+      encoding_coefficient[matrix][k][m] = new (unsigned char*);
+      *encoding_coefficient[matrix][k][m] = 0;
+    }
+    return encoding_coefficient[matrix][k][m];
+  }
+
+  Mutex* getLock() {return &codec_tables_guard;}
+
+ private:
+  Mutex codec_tables_guard; // mutex used to protect modifications in decoding table maps
+
+  codec_technique_tables_t encoding_coefficient;  // encoding coefficients accessed via table[matrix][k][m]
+  codec_technique_tables_t encoding_table;        // encoding coefficeints accessed via table[matrix][k][m]
+
+  std::map<int, lru_map_t*>  decoding_tables;          // decoding table cache accessed via map[matrixtype]
+  std::map<int, lru_list_t*> decoding_tables_lru;      // decoding table lru list accessed via list[matrixtype]
+};
+
+#endif

--- a/src/erasure-code/isa/ErasureCodePluginIsa.cc
+++ b/src/erasure-code/isa/ErasureCodePluginIsa.cc
@@ -25,9 +25,11 @@
 // -----------------------------------------------------------------------------
 #include "common/debug.h"
 #include "erasure-code/ErasureCodePlugin.h"
+#include "ErasureCodePluginIsa.h"
+#include "ErasureCodeIsaTableCache.h"
 #include "ErasureCodeIsa.h"
 // -----------------------------------------------------------------------------
-
+ErasureCodeIsaTableCache ErasureCodePluginIsa::tcache; // singleton table cache
 
 // -----------------------------------------------------------------------------
 #define dout_subsys ceph_subsys_osd
@@ -41,41 +43,11 @@ static ostream& _prefix(std::ostream* _dout)
 }
 
 // -----------------------------------------------------------------------------
-
-class ErasureCodePluginIsa : public ErasureCodePlugin {
-public:
-
-  virtual int factory(const map<std::string, std::string> &parameters,
-                      ErasureCodeInterfaceRef *erasure_code)
-  {
-    ErasureCodeIsa *interface;
-    std::string t = "reed_sol_van";
-    if (parameters.find("technique") != parameters.end())
-      t = parameters.find("technique")->second;
-    if ((t == "reed_sol_van")) {
-      interface = new ErasureCodeIsaDefault(ErasureCodeIsaDefault::kVandermonde);
-    } else {
-      if ((t == "cauchy")) {
-        interface = new ErasureCodeIsaDefault(ErasureCodeIsaDefault::kCauchy);
-      } else {
-        derr << "technique=" << t << " is not a valid coding technique. "
-          << " Choose one of the following: "
-          << "reed_sol_van,"
-          << "cauchy" << dendl;
-        return -ENOENT;
-      }
-    }
-
-    interface->init(parameters);
-    *erasure_code = ErasureCodeInterfaceRef(interface);
-    return 0;
-  }
-};
-
-// -----------------------------------------------------------------------------
-
 int __erasure_code_init(char *plugin_name)
 {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
+
   return instance.add(plugin_name, new ErasureCodePluginIsa());
 }
+
+

--- a/src/erasure-code/isa/ErasureCodePluginIsa.h
+++ b/src/erasure-code/isa/ErasureCodePluginIsa.h
@@ -1,0 +1,62 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 CERN (Switzerland)
+ *
+ * Author: Andreas-Joachim Peters <Andreas.Joachim.Peters@cern.ch>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+
+/**
+ * @file   ErasureCodePluginIsa.h
+ *
+ * @brief  Erasure Code Plug-in class wrapping the INTEL ISA-L library
+ *
+ * The factory plug-in class allows to call individual encoding techniques.
+ * The INTEL ISA-L library provides two pre-defined encoding matrices (cauchy, reed_sol_van = default).
+ */
+
+// -----------------------------------------------------------------------------
+#include "common/debug.h"
+#include "erasure-code/ErasureCodePlugin.h"
+#include "ErasureCodeIsaTableCache.h"
+#include "ErasureCodeIsa.h"
+// -----------------------------------------------------------------------------
+
+class ErasureCodePluginIsa : public ErasureCodePlugin {
+
+public:
+  static ErasureCodeIsaTableCache tcache;
+
+  virtual int factory(const map<std::string, std::string> &parameters,
+                      ErasureCodeInterfaceRef *erasure_code)
+  {
+    ErasureCodeIsa *interface;
+    std::string t = "reed_sol_van";
+    if (parameters.find("technique") != parameters.end())
+      t = parameters.find("technique")->second;
+    if ((t == "reed_sol_van")) {
+      interface = new ErasureCodeIsaDefault(ErasureCodeIsaDefault::kVandermonde);
+    } else {
+      if ((t == "cauchy")) {
+        interface = new ErasureCodeIsaDefault(ErasureCodeIsaDefault::kCauchy);
+      } else {
+        derr << "technique=" << t << " is not a valid coding technique. "
+          << " Choose one of the following: "
+          << "reed_sol_van,"
+          << "cauchy" << dendl;
+        return -ENOENT;
+      }
+    }
+
+    interface->init(parameters);
+    *erasure_code = ErasureCodeInterfaceRef(interface);
+    return 0;
+  }
+};

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -477,7 +477,7 @@ TYPED_TEST(IsaErasureCodeTest, isa_vandermonde_exhaustive)
     want_to_decode.erase(l1);
   }
   EXPECT_EQ(2516, cnt_cf);
-  EXPECT_EQ(2503, Isa.get_tbls_lru_size());
+  EXPECT_EQ(2506, Isa.get_tbls_lru_size()); // 3 are from 2+2 test
 }
 
 TYPED_TEST(IsaErasureCodeTest, isa_cauchy_exhaustive)

--- a/src/test/erasure-code/TestErasureCodePluginIsa.cc
+++ b/src/test/erasure-code/TestErasureCodePluginIsa.cc
@@ -17,6 +17,7 @@
 #include "arch/intel.h"
 #include "global/global_init.h"
 #include "erasure-code/ErasureCodePlugin.h"
+#include "erasure-code/isa/ErasureCodeIsaTableCache.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
 #include "gtest/gtest.h"
@@ -35,6 +36,7 @@ TEST(ErasureCodePlugin, factory)
   }
   const char *techniques[] = {
     "reed_sol_van",
+    "cauchy",
     0
   };
   for(const char **technique = techniques; *technique; technique++) {
@@ -45,6 +47,99 @@ TEST(ErasureCodePlugin, factory)
                                   &erasure_code, cerr));
     EXPECT_TRUE(erasure_code);
   }
+}
+
+TEST(ErasureCodePlugin, cache)
+{
+  ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
+  map<std::string,std::string> parameters;
+  parameters["directory"] = ".libs";
+
+  const char *techniques[] = {
+    "reed_sol_van",
+    "cauchy",
+    0
+  };
+  for(const char **technique = techniques; *technique; technique++) {
+    ErasureCodeInterfaceRef erasure_code;
+    parameters["technique"] = *technique;
+    EXPECT_FALSE(erasure_code);
+    EXPECT_EQ(0, instance.factory("isa", parameters,
+                                  &erasure_code, cerr));
+    EXPECT_TRUE(erasure_code);
+  }
+
+  ErasureCodeIsaTableCache table_cache;
+  
+  // there should be no cache yet - size -1
+  for (int i=0; i<=1; i++) {
+    EXPECT_EQ(-1,table_cache.getDecodingCacheSize(i));
+  }
+
+  // don't share the decoding table cache map between matrix types
+  ErasureCodeIsaTableCache::lru_map_t* a[2];
+  ErasureCodeIsaTableCache::lru_list_t* b[2];
+  ErasureCodeIsaTableCache::lru_map_t* c[2];
+  ErasureCodeIsaTableCache::lru_list_t* d[2];
+  for (int i=0; i<=1; i++) {
+    a[i] = table_cache.getDecodingTables(i);
+    b[i] = table_cache.getDecodingTablesLru(i);
+    c[i] = table_cache.getDecodingTables(i);
+    d[i] = table_cache.getDecodingTablesLru(i);
+  }
+
+  EXPECT_TRUE(a[0] != a[1]);
+  EXPECT_TRUE(b[0] != b[1]);
+  EXPECT_TRUE(a[0] == c[0]);
+  EXPECT_TRUE(b[0] == d[0]);
+
+  // there should be a decoding cache with size 0
+  for (int i=0; i<=1; i++) {
+    EXPECT_EQ(0,table_cache.getDecodingCacheSize(i));
+  }
+
+  {
+    // share encoding tables for same (k,m), but not for different matrices
+    unsigned char** t1 = table_cache.getEncodingTable(0,10,3);
+    unsigned char** t2 = table_cache.getEncodingTable(1,10,3);
+    unsigned char** t3 = table_cache.getEncodingTable(0,10,4);
+    unsigned char** t4 = table_cache.getEncodingTable(1,11,3);
+    unsigned char** t5 = table_cache.getEncodingTable(0,10,3);
+    unsigned char** t6 = table_cache.getEncodingTable(1,10,3);
+    
+    EXPECT_TRUE(t1==t5);
+    EXPECT_TRUE(t2==t6);
+    EXPECT_FALSE(t1==t2);
+    EXPECT_FALSE(t3==t4);
+    EXPECT_FALSE(t1==t3);
+    EXPECT_FALSE(t2==t4);
+
+    // attach some memory to one encoding table to see if it get's freed on exit
+    *t1 = (unsigned char*) malloc(1024*1024);
+  }
+
+  {
+    // share encoding coefficients for same (k,m), but not for different matrices
+    unsigned char** t1 = table_cache.getEncodingCoefficient(0,10,3);
+    unsigned char** t2 = table_cache.getEncodingCoefficient(1,10,3);
+    unsigned char** t3 = table_cache.getEncodingCoefficient(0,10,4);
+    unsigned char** t4 = table_cache.getEncodingCoefficient(1,11,3);
+    unsigned char** t5 = table_cache.getEncodingCoefficient(0,10,3);
+    unsigned char** t6 = table_cache.getEncodingCoefficient(1,10,3);
+    
+    EXPECT_TRUE(t1==t5);
+    EXPECT_TRUE(t2==t6);
+    EXPECT_FALSE(t1==t2);
+    EXPECT_FALSE(t3==t4);
+    EXPECT_FALSE(t1==t3);
+    EXPECT_FALSE(t2==t4);
+
+    // attach some memory to one encoding coefficient table to see if it get's freed on exit
+    *t1 = (unsigned char*) malloc(1024*1024);
+  }
+
+  EXPECT_TRUE(table_cache.getLock()!=0);
+  Mutex::Locker lock(*table_cache.getLock());
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Add persistent caching and sharing of encoding and decoding tables stored in a singleton object which are used/fillled by Isa CODEC instances. 
