### PR TITLE
init-ceph: don't use bashism

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -182,7 +182,7 @@ done
 
 
 # if `--cluster` was not passed in, fallback to looking at the config name
-if ! [[ -n "$cluster" ]]; then
+if [ -z "$cluster" ]; then
     cluster=`echo $conf | awk -F'/' '{print $(NF)}' | cut -d'.' -f 1`
 else
     # if we were told to use a given cluster name then $conf needs to be updated


### PR DESCRIPTION
-z STRING
             the length of STRING is zero

Signed-off-by: Sage Weil sage@redhat.com
