### PR TITLE
msg/Accepter: do not unlearn_addr on bind()

### DIFF
--- a/src/msg/Accepter.cc
+++ b/src/msg/Accepter.cc
@@ -152,9 +152,6 @@ int Accepter::rebind(const set<int>& avoid_ports)
 {
   ldout(msgr->cct,1) << "accepter.rebind avoid " << avoid_ports << dendl;
   
-  // invalidate our previously learned address.
-  msgr->unlearn_addr();
-
   entity_addr_t addr = msgr->get_myaddr();
   set<int> new_avoid = avoid_ports;
   new_avoid.insert(addr.get_port());

--- a/src/msg/SimpleMessenger.cc
+++ b/src/msg/SimpleMessenger.cc
@@ -694,13 +694,6 @@ void SimpleMessenger::learned_addr(const entity_addr_t &peer_addr_for_me)
   lock.Unlock();
 }
 
-void SimpleMessenger::unlearn_addr()
-{
-  lock.Lock();
-  need_addr = true;
-  lock.Unlock();
-}
-
 void SimpleMessenger::init_local_connection()
 {
   local_connection->peer_addr = my_inst.addr;

--- a/src/msg/SimpleMessenger.h
+++ b/src/msg/SimpleMessenger.h
@@ -386,13 +386,6 @@ public:
   void learned_addr(const entity_addr_t& peer_addr_for_me);
 
   /**
-   * Tell the SimpleMessenger its address is no longer known
-   *
-   * This happens when we rebind to a new port.
-   */
-  void unlearn_addr();
-
-  /**
    * Release memory accounting back to the dispatch throttler.
    *
    * @param msize The amount of memory to release.


### PR DESCRIPTION
It is dangerous to set need_addr = false as it means someone may set the addr
to something else (specifically the port) in a racing thread.

However, it is not necessary: the only reason we added it way back in 
5d5045d31a9e10d21b44eb1bd137db9ae53128ff was so that 
local_connection->peer_addr would get updated, and bind() now calls that 
unconditionally.

Fixes: #9079 Backport: firefly Signed-off-by: Sage Weil sage@redhat.com
