### PR TITLE
rgw_users: Generate an id(access_key) during SWIFT key creation

### DIFF
--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1040,6 +1040,15 @@ int RGWAccessKeyPool::add(RGWUserAdminOpState& op_state, std::string *err_msg, b
   int ret; 
   std::string subprocess_msg;
 
+  if (op_state.get_key_type() == KEY_TYPE_SWIFT && !op_state.will_gen_access()) {
+    if (op_state.get_access_key().empty()) {
+      op_state.set_gen_access();
+    } else {
+      set_err_msg(err_msg, "access key was specified during SWIFT key creation");
+      return -EINVAL;
+    }
+  }
+
   ret = check_op(op_state, &subprocess_msg);
   if (ret < 0) {
     set_err_msg(err_msg, "unable to parse request, " + subprocess_msg);


### PR DESCRIPTION
Description: An blank/empty id(access_key) is generated during SWIFT key creation
and is entered into the .users.swift pool; instead of the specified
subuser(user:subuser). "radosgw-admin user info" will show the correct
information; but the same subuser will not be listed under .users.swift
pool. This caused rgw to return with an 403 Forbidden error for the
subuser.

Fixes: #9155

Signed-off-by: Dhiraj Kamble dhiraj.kamble@sandisk.com
