### PR TITLE
CollectionIndex: Collection name is added to the access_lock name

### DIFF
--- a/src/os/CollectionIndex.h
+++ b/src/os/CollectionIndex.h
@@ -73,6 +73,7 @@ protected:
   };
  public:
 
+  string access_lock_name;
   RWLock access_lock;
   /// Type of returned paths
   typedef ceph::shared_ptr<Path> IndexedPath;
@@ -180,7 +181,9 @@ protected:
   /// Call prior to removing directory
   virtual int prep_delete() { return 0; }
 
-  CollectionIndex():access_lock("CollectionIndex::access_lock"){}
+  CollectionIndex(coll_t collection):
+    access_lock_name ("CollectionIndex::access_lock::" + collection.to_str()), 
+    access_lock(access_lock_name.c_str()) {}
 
   /// Virtual destructor
   virtual ~CollectionIndex() {}

--- a/src/os/FlatIndex.h
+++ b/src/os/FlatIndex.h
@@ -32,8 +32,10 @@ class FlatIndex : public CollectionIndex {
   string base_path;
   coll_t collection;
 public:
-  FlatIndex(coll_t collection, string base_path) : base_path(base_path),
-						   collection(collection) {}
+  FlatIndex(coll_t collection, string base_path) : 
+              CollectionIndex(collection),
+              base_path(base_path),
+	      collection(collection) {}
 
   /// @see CollectionIndex
   uint32_t collection_version() { return FLAT_INDEX_TAG; }

--- a/src/os/LFNIndex.h
+++ b/src/os/LFNIndex.h
@@ -131,7 +131,8 @@ public:
     const char *base_path, ///< [in] path to Index root
     uint32_t index_version,
     double _error_injection_probability=0)
-    : base_path(base_path),
+    : CollectionIndex(collection), 
+      base_path(base_path),
       index_version(index_version),
       error_injection_enabled(false),
       error_injection_on(_error_injection_probability != 0),


### PR DESCRIPTION
The CollectionIndex constructor is changed to accept the coll_t
so that the collection name can be used to form access_lock(RWLock)
name.This is needed otherwise lockdep will report a recursive lock error
and assert. lockdep needs unique lock names for each Index object.

Fixes: #9145

Signed-off-by: Somnath Roy somnath.roy@sandisk.com
