### PR TITLE
Cache tiering: adjust avg_size calculation in agent_choose_mode

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -11565,9 +11565,8 @@ void ReplicatedPG::agent_choose_mode(bool restart)
   // get dirty, full ratios
   uint64_t dirty_micro = 0;
   uint64_t full_micro = 0;
-  if (pool.info.target_max_bytes && info.stats.stats.sum.num_objects > 0) {
-    uint64_t avg_size = info.stats.stats.sum.num_bytes /
-      info.stats.stats.sum.num_objects;
+  if (pool.info.target_max_bytes && num_user_objects > 0) {
+    uint64_t avg_size = info.stats.stats.sum.num_bytes / num_user_objects;
     dirty_micro =
       num_dirty * avg_size * 1000000 /
       MAX(pool.info.target_max_bytes / divisor, 1);


### PR DESCRIPTION
Two things to correct in agent_choose_mode:
1) When info.stats.stats.sum.num_objects is greater than 0, but num_user_objects is not greater than 0, there is no need to calculate dirty_micro and full_micro.
2) Usually, the size of a hit set object is relative small comparing to a data object. So it would be better to exclude the hit set objects when calculating avg_size. When the number of hit sets are not that small, it makes differences.
Signed-off-by: Zhiqiang Wang wonzhq@hotmail.com
