### PR TITLE
mon: make reweight-by-* sanity limits configurable

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -190,6 +190,8 @@ OPTION(mon_slurp_bytes, OPT_INT, 256*1024)    // limit size of slurp messages
 OPTION(mon_client_bytes, OPT_U64, 100ul << 20)  // client msg data allowed in memory (in bytes)
 OPTION(mon_daemon_bytes, OPT_U64, 400ul << 20)  // mds, osd message memory cap (in bytes)
 OPTION(mon_max_log_entries_per_event, OPT_INT, 4096)
+OPTION(mon_reweight_min_pgs_per_osd, OPT_U64, 10)   // min pgs per osd for reweight-by-pg command
+OPTION(mon_reweight_min_bytes_per_osd, OPT_U64, 100*1024*1024)   // min bytes per osd for reweight-by-utilization command
 OPTION(mon_health_data_update_interval, OPT_FLOAT, 60.0)
 OPTION(mon_data_avail_crit, OPT_INT, 5)
 OPTION(mon_data_avail_warn, OPT_INT, 30)

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -394,6 +394,7 @@ $extra_conf
 [mon]
         mon pg warn min per osd = 10
         mon osd allow primary affinity = true
+        mon reweight min pgs per osd = 4
 $DAEMONOPTS
 $CMONDEBUG
 $extra_conf


### PR DESCRIPTION
Also drop the somewhat redundant osd_sum.kb check; the main thing we care 
about here is

Signed-off-by: Sage Weil sage@redhat.com
