### PR TITLE
CrushWrapper: pick a ruleset same as rule_id

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -885,9 +885,9 @@ public:
 
   bool ruleset_exists(int const ruleset) const {
     for (size_t i = 0; i < crush->max_rules; ++i) {
-     if (crush->rules[i]->mask.ruleset == ruleset) {
-       return true;
-     }
+      if (rule_exists(i) && crush->rules[i]->mask.ruleset == ruleset) {
+	return true;
+      }
     }
 
     return false;

--- a/src/crush/builder.c
+++ b/src/crush/builder.c
@@ -63,7 +63,7 @@ int crush_add_rule(struct crush_map *map, struct crush_rule *rule, int ruleno)
 		for (r=0; r < map->max_rules; r++)
 			if (map->rules[r] == 0)
 				break;
-		assert(r <= INT_MAX);
+		assert(r < CRUSH_MAX_RULES);
 	}
 	else
 		r = ruleno;
@@ -72,6 +72,8 @@ int crush_add_rule(struct crush_map *map, struct crush_rule *rule, int ruleno)
 		/* expand array */
 		int oldsize;
 		void *_realloc = NULL;
+		if (map->max_rules +1 > CRUSH_MAX_RULES)
+			return -ENOSPC;
 		oldsize = map->max_rules;
 		map->max_rules = r+1;
 		if ((_realloc = realloc(map->rules, map->max_rules * sizeof(map->rules[0]))) == NULL) {

--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -26,6 +26,8 @@
 #define CRUSH_MAGIC 0x00010000ul   /* for detecting algorithm revisions */
 
 #define CRUSH_MAX_DEPTH 10  /* max crush hierarchy depth */
+#define CRUSH_MAX_RULESET (1<<8) /*max crush ruleset number*/
+#define CRUSH_MAX_RULES	CRUSH_MAX_RULESET /*max crush rules, shold be the same as max rulesets*/
 
 #define CRUSH_MAX_DEVICE_WEIGHT (100u * 0x10000u)
 #define CRUSH_MAX_BUCKET_WEIGHT (65535u * 0x10000u)

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -734,36 +734,6 @@ TEST(IsaErasureCodeTest, create_ruleset)
     }
   }
 
-  //
-  // The ruleid may be different from the ruleset when a crush rule is
-  // removed because the removed ruleid will be reused but the removed
-  // ruleset will not be reused. 
-  //
-  // This also asserts that the create_ruleset() method returns a
-  // ruleset and not a ruleid http://tracker.ceph.com/issues/9044
-  //
-  {
-    stringstream ss;
-    ErasureCodeIsaDefault isa;
-    map<std::string,std::string> parameters;
-    parameters["k"] = "2";
-    parameters["m"] = "2";
-    parameters["w"] = "8";
-    isa.init(parameters);
-    int FIRST = isa.create_ruleset("FIRST", *c, &ss);
-    int SECOND = isa.create_ruleset("SECOND", *c, &ss);
-    int FIRST_ruleid = c->get_rule_id("FIRST");
-    EXPECT_EQ(0, c->remove_rule(FIRST_ruleid));
-    int ruleset = isa.create_ruleset("myrule", *c, &ss);
-    EXPECT_NE(FIRST, ruleset);
-    EXPECT_NE(SECOND, ruleset);
-    EXPECT_NE(ruleset, c->get_rule_id("myrule"));
-    int SECOND_ruleid = c->get_rule_id("SECOND");
-    EXPECT_EQ(0, c->remove_rule(SECOND_ruleid));
-    int myrule_ruleid = c->get_rule_id("myrule");
-    EXPECT_EQ(0, c->remove_rule(myrule_ruleid));
-  }
-
   {
     stringstream ss;
     ErasureCodeIsaDefault isa;

--- a/src/test/erasure-code/TestErasureCodeJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodeJerasure.cc
@@ -293,36 +293,6 @@ TEST(ErasureCodeTest, create_ruleset)
     }
   }
 
-  //
-  // The ruleid may be different from the ruleset when a crush rule is
-  // removed because the removed ruleid will be reused but the removed
-  // ruleset will not be reused. 
-  //
-  // This also asserts that the create_ruleset() method returns a
-  // ruleset and not a ruleid http://tracker.ceph.com/issues/9044
-  //
-  {
-    stringstream ss;
-    ErasureCodeJerasureReedSolomonVandermonde jerasure;
-    map<std::string,std::string> parameters;
-    parameters["k"] = "2";
-    parameters["m"] = "2";
-    parameters["w"] = "8";
-    jerasure.init(parameters);
-    int FIRST = jerasure.create_ruleset("FIRST", *c, &ss);
-    int SECOND = jerasure.create_ruleset("SECOND", *c, &ss);
-    int FIRST_ruleid = c->get_rule_id("FIRST");
-    EXPECT_EQ(0, c->remove_rule(FIRST_ruleid));
-    int ruleset = jerasure.create_ruleset("myrule", *c, &ss);
-    EXPECT_NE(FIRST, ruleset);
-    EXPECT_NE(SECOND, ruleset);
-    EXPECT_NE(ruleset, c->get_rule_id("myrule"));
-    int SECOND_ruleid = c->get_rule_id("SECOND");
-    EXPECT_EQ(0, c->remove_rule(SECOND_ruleid));
-    int myrule_ruleid = c->get_rule_id("myrule");
-    EXPECT_EQ(0, c->remove_rule(myrule_ruleid));
-  }
-
   {
     stringstream ss;
     ErasureCodeJerasureReedSolomonVandermonde jerasure;


### PR DESCRIPTION
Originally in the add_simple_ruleset funtion, the ruleset_id
is not reused but rule_id is reused. So after some add/remove
against rules, the newly created rule likely to have
ruleset!=rule_id.

We dont want this happen because we are trying to hold the constraint
that ruleset == rule_id.

This patch allow ruleset_id be reused. After having this patch,
add/remove rules will not break the constraint.

Signed-off-by: Xiaoxi Chen xiaoxi.chen@intel.com
