### PR TITLE
osd/ReplicatedPG: adjust avg_size calculation in agent_choose_mode

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -11575,9 +11575,8 @@ void ReplicatedPG::agent_choose_mode(bool restart)
   // get dirty, full ratios
   uint64_t dirty_micro = 0;
   uint64_t full_micro = 0;
-  if (pool.info.target_max_bytes && info.stats.stats.sum.num_objects > 0) {
-    uint64_t avg_size = info.stats.stats.sum.num_bytes /
-      info.stats.stats.sum.num_objects;
+  if (pool.info.target_max_bytes && num_user_objects > 0) {
+    uint64_t avg_size = num_user_bytes / num_user_objects;
     dirty_micro =
       num_dirty * avg_size * 1000000 /
       MAX(pool.info.target_max_bytes / divisor, 1);

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1511,7 +1511,6 @@ void object_stat_sum_t::decode(bufferlist::iterator& bl)
 void object_stat_sum_t::generate_test_instances(list<object_stat_sum_t*>& o)
 {
   object_stat_sum_t a;
-  o.push_back(new object_stat_sum_t(a));
 
   a.num_bytes = 1;
   a.num_objects = 3;
@@ -1531,8 +1530,8 @@ void object_stat_sum_t::generate_test_instances(list<object_stat_sum_t*>& o)
   a.num_objects_dirty = 21;
   a.num_whiteouts = 22;
   a.num_objects_misplaced = 1232;
-  o.num_objects_hit_set_archive = 2;
-  o.num_bytes_hit_set_archive = 27;
+  a.num_objects_hit_set_archive = 2;
+  a.num_bytes_hit_set_archive = 27;
   o.push_back(new object_stat_sum_t(a));
 }
 


### PR DESCRIPTION
Refined the avg_size patch based on the change of adding num_bytes_hit_set_archive, and fixed a minor bug.

Signed-off-by: Zhiqiang Wang wonzhq@hotmail.com
