### PR TITLE
Make ceph_erasure_code_benchmark more robust.

### DIFF
--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -130,6 +130,15 @@ int ErasureCodeBench::encode()
   int k = atoi(parameters["k"].c_str());
   int m = atoi(parameters["m"].c_str());
 
+  if (erasure_code->get_data_chunk_count() != (unsigned int)k ||
+      (erasure_code->get_chunk_count() - erasure_code->get_data_chunk_count()
+       != (unsigned int)m)) {
+    cout << "paramter k is " << k << "/m is " << m << ". But data chunk count is "
+      << erasure_code->get_data_chunk_count() <<"/parity chunk count is "
+      << erasure_code->get_chunk_count() - erasure_code->get_data_chunk_count() << endl;
+    return -EINVAL;
+  }
+
   bufferlist in;
   in.append(string(in_size, 'X'));
   set<int> want_to_encode;
@@ -158,6 +167,14 @@ int ErasureCodeBench::decode()
   int k = atoi(parameters["k"].c_str());
   int m = atoi(parameters["m"].c_str());
 
+  if (erasure_code->get_data_chunk_count() != (unsigned int)k ||
+      (erasure_code->get_chunk_count() - erasure_code->get_data_chunk_count()
+       != (unsigned int)m)) {
+    cout << "paramter k is " << k << "/m is " << m << ". But data chunk count is "
+      << erasure_code->get_data_chunk_count() <<"/parity chunk count is "
+      << erasure_code->get_chunk_count() - erasure_code->get_data_chunk_count() << endl;
+    return -EINVAL;
+  }
   bufferlist in;
   in.append(string(in_size, 'X'));
 


### PR DESCRIPTION
@dachary
If we use incorrect parameter for k/m. The ceph_erasure_code_benchmark don't end up rather than do some test. But we don't know the result whether we want.
