### PR TITLE
Fix FTBFS on alpha due to incorrect check on BLKGETSIZE

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -10,7 +10,7 @@ int get_block_device_size(int fd, int64_t *psize)
 {
 #ifdef BLKGETSIZE64
   int ret = ::ioctl(fd, BLKGETSIZE64, psize);
-#elif BLKGETSIZE
+#elif defined(BLKGETSIZE)
   unsigned long sectors = 0;
   int ret = ::ioctl(fd, BLKGETSIZE, &sectors);
   *psize = sectors * 512ULL;


### PR DESCRIPTION
Ceph FTBFS on Alpha with:

```
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -D__CEPH__ -D_FILE_OFFSET_BITS=64 -D_REENTRANT -D_THREAD_SAFE -D__STDC_FORMAT_MACROS -D_GNU_SOURCE -DCEPH_LIBDIR=\"/usr/lib/alpha-linux-gnu\" -DCEPH_PKGLIBDIR=\"/usr/lib/alpha-linux-gnu/ceph\" -DGTEST_HAS_TR1_TUPLE=0 -D_FORTIFY_SOURCE=2 -I/usr/include/nss -I/usr/include/nspr -Wall -Wtype-limits -Wignored-qualifiers -Winit-self -Wpointer-arith -Werror=format-security -fno-strict-aliasing -fsigned-char -rdynamic -ftemplate-depth-1024 -Wnon-virtual-dtor -Wno-invalid-offsetof -Wstrict-null-sentinel -g -O2 -Wformat -Werror=format-security -c common/blkdev.cc  -fPIC -DPIC -o common/.libs/blkdev.o
In file included from /usr/include/alpha-linux-gnu/asm/ioctls.h:4:0,
                 from /usr/include/alpha-linux-gnu/bits/ioctls.h:23,
                 from /usr/include/alpha-linux-gnu/sys/ioctl.h:26,
                 from common/blkdev.cc:3:
common/blkdev.cc:13:7: error: missing binary operator before token "int"
 #elif BLKGETSIZE
       ^
```

This error occurs because the value of BLKGETSIZE is tested in a
c-preprocessor conditional compilation test whereas the test should
be for existence.

From: Michael Cree mcree@orcon.net.nz
Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=756892
Signed-off-by: Dmitry Smirnov onlyjob@member.fsf.org
