### PR TITLE
rgw: fix test to identify whether object has tail

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -306,6 +306,11 @@ public:
 
   bool has_tail() {
     if (explicit_objs) {
+      if (objs.size() == 1) {
+        map<uint64_t, RGWObjManifestPart>::iterator iter = objs.begin();
+        rgw_obj& obj = iter->second.loc;
+        return head_obj.object != obj.object;
+      }
       return (objs.size() >= 2);
     }
     return (obj_size > head_size);


### PR DESCRIPTION
Fixes: #9226
Reported-by: Sylvain Munaut s.munaut@whatever-company.com
Backport: firefly

We need to identify whether an object is just composed of a head, or
also has a tail. Test for pre-firefly objects ("explicit objs") was
broken as it was just looking at the number of explicit objs in the
manifest. However, this is insufficient, as we might have empty head,
and in this case it wouldn't appear, so we need to check whether the
sole object is actually pointing at the head.

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
