### PR TITLE
osd/OSDMap: encode blacklist in deterministic order

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1760,7 +1760,15 @@ void OSDMap::encode_classic(bufferlist& bl, uint64_t features) const
   ::encode(ev, bl);
   ::encode(osd_addrs->hb_back_addr, bl);
   ::encode(osd_info, bl);
-  ::encode(blacklist, bl);
+  {
+    // put this in a sorted, ordered map<> so that we encode in a
+    // deterministic order.
+    map<entity_addr_t,utime_t> blacklist_map;
+    for (ceph::unordered_map<entity_addr_t,utime_t>::const_iterator p =
+	   blacklist.begin(); p != blacklist.end(); ++p)
+      blacklist_map.insert(make_pair(p->first, p->second));
+    ::encode(blacklist_map, bl);
+  }
   ::encode(osd_addrs->cluster_addr, bl);
   ::encode(cluster_snapshot_epoch, bl);
   ::encode(cluster_snapshot, bl);
@@ -2176,6 +2184,7 @@ void OSDMap::generate_test_instances(list<OSDMap*>& o)
   uuid_d fsid;
   o.back()->build_simple(cct, 1, fsid, 16, 7, 8);
   o.back()->created = o.back()->modified = utime_t(1, 2);  // fix timestamp
+  o.back()->blacklist[entity_addr_t()] = utime_t(5, 6);
   cct->put();
 }
 


### PR DESCRIPTION
When we use an unordered_map the encoding order is non-deterministic,
which is problematic for OSDMap.  Construct an ordered map<> on encode
and use that.  This lets us keep the hash table for lookups in the general
case.

Fixes: #9211
Backport: firefly
Signed-off-by: Sage Weil sage@redhat.com
