### PR TITLE
mds: fix FP error in ROUND_UP_TO

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2119,7 +2119,13 @@ public:
 void Locker::calc_new_client_ranges(CInode *in, uint64_t size, map<client_t,client_writeable_range_t>& new_ranges)
 {
   inode_t *latest = in->get_projected_inode();
-  uint64_t ms = ROUND_UP_TO((size+1)<<1, latest->get_layout_size_increment());
+  uint64_t ms;
+  if(latest->has_layout()) {
+    ms = ROUND_UP_TO((size+1)<<1, latest->get_layout_size_increment());
+  } else {
+    // Layout-less directories like ~mds0/, have zero size
+    ms = 0;
+  }
 
   // increase ranges as appropriate.
   // shrink to 0 if no WR|BUFFER caps issued.


### PR DESCRIPTION
Explicitly handle case where denominator is 0, instead of
passing into ROUND_UP_TO.

Regression from 9449520b121fc6ce0c64948386d4ff77f46f4f5f

Signed-off-by: John Spray john.spray@redhat.com
