### PR TITLE
sample.ceph.conf: some updates

### DIFF
--- a/src/sample.ceph.conf
+++ b/src/sample.ceph.conf
@@ -95,7 +95,7 @@
 
     ## Replication level, number of data copies.
     # Type: 32-bit Integer
-    # (Default: 2)
+    # (Default: 3)
     ;osd pool default size      = 3
 
     ## Replication level in degraded state, less than 'osd pool default size' value.
@@ -299,6 +299,11 @@
     # (Default: 5)
     ;osd recovery max active      = 3
 
+    # The maximum number of backfills allowed to or from a single OSD.
+    # Type: 64-bit Integer
+    # (Default: 10)
+    ;osd max backfills            = 5
+
     # The maximum number of simultaneous scrub operations for a Ceph OSD Daemon.
     # Type: 32-bit Int
     # (Default: 1)
@@ -386,6 +391,41 @@
     # (Default: 500)
     ;filestore queue max ops      = 500
 
+    ## Filestore and OSD settings can be tweak to achieve better performance
+
+### http://ceph.com/docs/master/rados/configuration/filestore-config-ref/#misc
+
+    # Min number of files in a subdir before merging into parent NOTE: A negative value means to disable subdir merging
+    # Type: Integer
+    # Required: No
+    # Default:  10
+    ;filestore merge threshold    = 10
+
+    # filestore_split_multiple * abs(filestore_merge_threshold) * 16 is the maximum number of files in a subdirectory before splitting into child directories.
+    # Type: Integer
+    # Required: No
+    # Default:  2
+    ;filestore split multiple     = 2
+
+    # The number of filesystem operation threads that execute in parallel.
+    # Type: Integer
+    # Required: No
+    # Default:  2
+    ;filestore op threads         = 4
+
+    # The number of threads to service Ceph OSD Daemon operations. Set to 0 to disable it. Increasing the number may increase the request processing rate.
+    # Type: 32-bit Integer
+    # Default:  2
+    ;osd op threads               = 2
+
+    ## CRUSH
+
+    # By default OSDs update their details (location, weight and root) on the CRUSH map during startup
+    # Type: Boolean
+    # Required: No;
+    # (Default: true)
+    ;osd crush update on start    = false
+
 ;[osd.0]
 ;    host                         = delta
 
@@ -447,3 +487,45 @@
     # Required: No
     # (Default: false)
     ;rbd cache writethrough until flush = false
+
+##################
+## radosgw client settings
+[client.radosgw.gateway]
+
+### http://ceph.com/docs/master/radosgw/config-ref/
+
+    # Sets the location of the data files for Ceph Object Gateway.
+    # You must create the directory when deploying Ceph.
+    # We do not recommend changing the default.
+    # Type: String
+    # Default: /var/lib/ceph/radosgw/$cluster-$id
+    ;rgw data                     = /var/lib/ceph/radosgw/$name
+
+    # Client's hostname
+    ;host                         =  ceph-radosgw
+
+    # where the radosgw keeps it's secret encryption keys
+    ;keyring                      = /etc/ceph/ceph.client.radosgw.keyring
+
+    # FastCgiExternalServer uses this socket.
+    # If you do not specify a socket path, Ceph Object Gateway will not run as an external server.
+    # The path you specify here must be the same as the path specified in the rgw.conf file.
+    # Type: String
+    # Default: None
+    ;rgw socket path              = /var/run/ceph/ceph.radosgw.gateway.fastcgi.sock
+
+    # The location of the logging file for your radosgw.
+    # Type: String
+    # Required: No
+    # Default: /var/log/ceph/$cluster-$name.log
+    ;log file                     = /var/log/ceph/client.radosgw.gateway.log
+
+    # Enable 100-continue if it is operational.
+    # Type: Boolean
+    # Default:  true
+    ;rgw print continue           = false
+
+    # The DNS name of the served domain.
+    # Type: String
+    # Default:  None
+    ;rgw dns name                 = radosgw.ceph.internal


### PR DESCRIPTION
This commit adds:
- a section for radosgw
- fix the replica count value (default is 3 since firefly)
- more OSDs options for performance and CRUSH

Signed-off-by: Sébastien Han sebastien.han@enovance.com
