### PR TITLE
mds: restart on -EBLACKLISTED

### DIFF
--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -42,7 +42,12 @@ void MDSIOContextBase::complete(int r) {
   dout(10) << "MDSIOContextBase::complete: " << typeid(*this).name() << dendl;
   assert(mds != NULL);
   Mutex::Locker l(mds->mds_lock);
-  MDSContext::complete(r);
+  if (r == -EBLACKLISTED) {
+    derr << "MDSIOContextBase: blacklisted!  Restarting..." << dendl;
+    mds->respawn();
+  } else {
+    MDSContext::complete(r);
+  }
 }
 
 MDS *MDSIOContext::get_mds() {


### PR DESCRIPTION
Previously these cases would (hopefully) hit an
assert(r==0) in the various completion contexts,
and the MDS would "crash" from the user's point of view.

With the introduction of MDSIOContext, we have a single
place to filter all RADOS op responses, which also has
a handle to the global MDS instance.  Check result values
for -EBLACKLISTED and call MDS::respawn() in response.

Signed-off-by: John Spray john.spray@redhat.com
