### PR TITLE
osd/PG: fix crash from second backfill reservation rejection

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5792,6 +5792,18 @@ PG::RecoveryState::NotBackfilling::NotBackfilling(my_context ctx)
   context< RecoveryMachine >().log_enter(state_name);
 }
 
+boost::statechart::result
+PG::RecoveryState::NotBackfilling::react(const RemoteBackfillReserved &evt)
+{
+  return discard_event();
+}
+
+boost::statechart::result
+PG::RecoveryState::NotBackfilling::react(const RemoteReservationRejected &evt)
+{
+  return discard_event();
+}
+
 void PG::RecoveryState::NotBackfilling::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1717,10 +1717,14 @@ public:
 
     struct NotBackfilling : boost::statechart::state< NotBackfilling, Active>, NamedState {
       typedef boost::mpl::list<
-	boost::statechart::transition< RequestBackfill, WaitLocalBackfillReserved>
+	boost::statechart::transition< RequestBackfill, WaitLocalBackfillReserved>,
+	boost::statechart::custom_reaction< RemoteBackfillReserved >,
+	boost::statechart::custom_reaction< RemoteReservationRejected >
 	> reactions;
       NotBackfilling(my_context ctx);
       void exit();
+      boost::statechart::result react(const RemoteBackfillReserved& evt);
+      boost::statechart::result react(const RemoteReservationRejected& evt);
     };
 
     struct RepNotRecovering;


### PR DESCRIPTION
If we get more than one reservation rejection we should ignore them; when
we got the first we already sent out cancellations.  More importantly, we
should not crash.

Fixes: #8863
Backport: firefly, dumpling
Signed-off-by: Sage Weil sage@redhat.com
