### PR TITLE
PG::can_discard_op: do discard old subopreplies

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5039,7 +5039,7 @@ bool PG::can_discard_request(OpRequestRef op)
   case MSG_OSD_PG_PUSH_REPLY:
     return can_discard_replica_op<MOSDPGPushReply, MSG_OSD_PG_PUSH_REPLY>(op);
   case MSG_OSD_SUBOPREPLY:
-    return false;
+    return can_discard_replica_op<MOSDSubOpReply, MSG_OSD_SUBOPREPLY>(op);
 
   case MSG_OSD_EC_WRITE:
     return can_discard_replica_op<MOSDECSubOpWrite, MSG_OSD_EC_WRITE>(op);


### PR DESCRIPTION
Otherwise, a sub_op_reply from a previous interval can stick around
until we either one day go active again and get rid of it or delete the
pg which is holding it on its waiting_for_active list.  While it sticks
around futily waiting for the pg to once more go active, it will cause
harmless slow request warnings.

Fixes: #9259
Backport: firefly
Signed-off-by: Samuel Just sam.just@inktank.com
