### PR TITLE
OSD::session_notify_pg_create: requeue at the start of the queue

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5489,7 +5489,7 @@ void OSD::session_notify_pg_create(
     session->waiting_for_pg.find(pgid);
   if (i != session->waiting_for_pg.end()) {
     session->waiting_on_map.splice(
-      session->waiting_on_map.end(),
+      session->waiting_on_map.begin(),
       i->second);
     session->waiting_for_pg.erase(i);
   }


### PR DESCRIPTION
Introduced: 2120f4bb6c5ba0f066d4541a51ce1d43c8ab6881
Fixes: #9205
Signed-off-by: Samuel Just sam.just@inktank.com
