### PR TITLE
rgw: don't try to authenticate a CORS preflight request

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2050,6 +2050,12 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(const string& auth_id, 
   return 0;
 }
 
+static void init_anon_user(struct req_state *s)
+{
+  rgw_get_anon_user(s->user);
+  s->perm_mask = RGW_PERM_FULL_CONTROL;
+}
+
 /*
  * verify that a signed request comes from the keyholder
  * by checking the signature against our locally-computed version
@@ -2070,6 +2076,11 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
     return -EPERM;
   }
 
+  if (s->op == OP_OPTIONS) {
+    init_anon_user(s);
+    return 0;
+  }
+
   if (!s->http_auth || !(*s->http_auth)) {
     auth_id = s->info.args.get("AWSAccessKeyId");
     if (auth_id.size()) {
@@ -2083,8 +2094,7 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
       qsr = true;
     } else {
       /* anonymous access */
-      rgw_get_anon_user(s->user);
-      s->perm_mask = RGW_PERM_FULL_CONTROL;
+      init_anon_user(s);
       return 0;
     }
   } else {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -778,7 +778,8 @@ RGWOp *RGWHandler_ObjStore_Obj_SWIFT::op_options()
 
 int RGWHandler_ObjStore_SWIFT::authorize()
 {
-  if (!s->os_auth_token && s->info.args.get("temp_url_sig").empty()) {
+  if ((!s->os_auth_token && s->info.args.get("temp_url_sig").empty()) ||
+      (s->op == OP_OPTIONS)) {
     /* anonymous access */
     rgw_get_anon_user(s->user);
     s->perm_mask = RGW_PERM_FULL_CONTROL;


### PR DESCRIPTION
Fixes: #8718
Backport: firefly

CORS preflight requests don't need to be authenticated. Treat them as
coming from anonymous user.

Reported-by: Robert Hubbard bobby.hubbard@garmin.com
Signed-off-by: Yehuda Sadeh yehuda@redhat.com
