### PR TITLE
client: fix dispatcher ordering (broken fuse)

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -354,8 +354,8 @@ int Client::init()
   objecter->init();
 
   // ok!
-  messenger->add_dispatcher_head(objecter);
-  messenger->add_dispatcher_head(this);
+  messenger->add_dispatcher_tail(objecter);
+  messenger->add_dispatcher_tail(this);
 
   int r = monclient->init();
   if (r < 0) {
@@ -370,7 +370,6 @@ int Client::init()
 
   monclient->set_want_keys(CEPH_ENTITY_TYPE_MDS | CEPH_ENTITY_TYPE_OSD);
   monclient->sub_want("mdsmap", 0, 0);
-  monclient->sub_want("osdmap", 0, CEPH_SUBSCRIBE_ONETIME);
   monclient->renew_subs();
 
   // logger


### PR DESCRIPTION
Objecter never saw any OSD maps because of 1e1ee480 and
the dispatchers being in the wrong order -- ignoring map
in Client was hiding it from Objecter.

Fixes: #9266

Signed-off-by: John Spray john.spray@redhat.com
