### PR TITLE
Test: fixing a compile warning in ceph_objectstore_tool.cc

### DIFF
--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2151,7 +2151,7 @@ int main(int argc, char **argv)
   if (op == "list-lost" || op == "fix-lost") {
     unsigned LIST_AT_A_TIME = 100;
     unsigned scanned = 0;
-    int r;
+    int r = 0;
     vector<coll_t> colls_to_check;
     if (pgidstr.length()) {
       colls_to_check.push_back(coll_t(pgid));


### PR DESCRIPTION
For the compiler's sake:
tools/ceph_objectstore_tool.cc:2547:15: warning: ‘r’ may be used uninitialized in this function [-Wmaybe-uninitialized]

Signed-off-by: Zhiqiang Wang wonzhq@hotmail.com
