### PR TITLE
tools: use cout instead of cerr in journal tool

### DIFF
--- a/qa/workunits/suites/cephfs_journal_tool_smoke.sh
+++ b/qa/workunits/suites/cephfs_journal_tool_smoke.sh
@@ -17,11 +17,11 @@ fi
 # following checks.
 echo "Testing that export/import cycle preserves state"
 HEADER_STATE=`$BIN header get`
-EVENT_LIST=`$BIN event get list 2>&1`
+EVENT_LIST=`$BIN event get list`
 $BIN journal export $JOURNAL_FILE
 $BIN journal import $JOURNAL_FILE
 NEW_HEADER_STATE=`$BIN header get`
-NEW_EVENT_LIST=`$BIN event get list 2>&1`
+NEW_EVENT_LIST=`$BIN event get list`
 
 if [ ! "$HEADER_STATE" = "$NEW_HEADER_STATE" ] ; then
     echo "Import failed to preserve header state"

--- a/src/tools/cephfs/EventOutput.cc
+++ b/src/tools/cephfs/EventOutput.cc
@@ -95,12 +95,12 @@ void EventOutput::list() const
       detail = eu->type;
     }
 
-    std::cerr << "0x"
+    std::cout << "0x"
       << std::hex << i->first << std::dec << " "
       << i->second.log_event->get_type_str() << ": "
       << " (" << detail << ")" << std::endl;
     for (std::vector<std::string>::iterator i = ev_paths.begin(); i != ev_paths.end(); ++i) {
-        std::cerr << "  " << *i << std::endl;
+        std::cout << "  " << *i << std::endl;
     }
   }
 }
@@ -116,8 +116,8 @@ void EventOutput::summary() const
     type_count[type] += 1;
   }
 
-  std::cerr << "Events by type:" << std::endl;
+  std::cout << "Events by type:" << std::endl;
   for (std::map<std::string, int>::iterator i = type_count.begin(); i != type_count.end(); ++i) {
-      std::cerr << "  " << i->first << ": " << i->second << std::endl;
+      std::cout << "  " << i->first << ": " << i->second << std::endl;
   }
 }


### PR DESCRIPTION
Aside from being a bit odd to begin with, using stderr
was causing tests to fail because the output was polluted
by log output which is also on stderr.

Fixes: 9281

Signed-off-by: John Spray john.spray@redhat.com
