### PR TITLE
osd/ReplicatedPG: avoid dereferencing iterator at end()

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -6441,7 +6441,7 @@ int ReplicatedPG::start_flush(
     vector<snapid_t>::iterator dnewest = p;
 
     // we may need to send a delete first
-    if (prev_snapc + 1 < *dnewest) {
+    if (dnewest != snapset.snaps.end() && prev_snapc + 1 < *dnewest) {
       while (p != snapset.snaps.end() && *p > prev_snapc)
 	++p;
       dsnapc.snaps = vector<snapid_t>(p, snapset.snaps.end());


### PR DESCRIPTION
The preceding loop could terminate with p == snapset.clones.end(), which we
assign to dnewest.  We can't dereference the iterator in that case.

For example:

 start_flush ffe627f3/foo/a/test-rados-api-plana05-22080-18/83 v430'42 uv130
blocking
 snapset b=[b,a]:[a,b]+head
start_flush no older clones

prev_snapc will be 0, oi.snaps will be [a], p will end up at end(), get 
assigned to dnewest, and we'll dereference.  It's only sometime harmful 
though because we may still take the right (else) branch...

Fixes: #9294 Signed-off-by: Sage Weil sage@redhat.com
