### PR TITLE
osd/ReplicatedPG: do not evict blocked objects

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -11581,6 +11581,10 @@ bool ReplicatedPG::agent_maybe_evict(ObjectContextRef& obc)
     dout(20) << __func__ << " skip (watchers) " << obc->obs.oi << dendl;
     return false;
   }
+  if (obc->is_blocked()) {
+    dout(20) << __func__ << " skip (blocked) " << obc->obs.oi << dendl;
+    return false;
+  }
 
   if (soid.snap == CEPH_NOSNAP) {
     int result = _verify_no_head_clones(soid, obc->ssc->snapset);


### PR DESCRIPTION
If the object is blocked, that means we are either still promoting it, or we
are in the process of doing a blocking flush.  In both cases, do not evict it
just yet.  For the promotion case in particular this can cause a very long op
delay because we'll have to restart the promotion, and this can potentially
loop indefinitely.

For the flush case, flushes are generally only blocking when the user 
explicitly requests it.  In that case, we are not particularly concerned that
we may delay the objects eventual eviction as the user is probably 
controlling that anyway (and even if they aren't, the agent will still try
this object again later).

Fixes: #9285 Reported-by: Wang, Zhiqiang zhiqiang.wang@intel.com 
Signed-off-by: Sage Weil sage@redhat.com
