### PR TITLE
Include types.h after stdint.h to accommodate for older distributions. 

### DIFF
--- a/src/include/int_types.h
+++ b/src/include/int_types.h
@@ -3,10 +3,6 @@
 
 #include "acconfig.h"
 
-#ifdef HAVE_LINUX_TYPES_H
-#include <linux/types.h>
-#endif
-
 /*
  * Get 64b integers either from inttypes.h or glib.h
  */
@@ -24,6 +20,14 @@
  */
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
+#endif
+
+/*
+ * Include types.h after stdint.h to accomodate for older distributions
+ *
+ */
+#ifdef HAVE_LINUX_TYPES_H
+#include <linux/types.h>
 #endif
 
 /*


### PR DESCRIPTION
This fixes compilation on CentOS 5.

This is similar to the fix in b2515b9e0b1e5e709716308a515026b3e6ff23b5
