### PR TITLE
lockdep: increase max locks (1000 -> 2000)

### DIFF
--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -37,7 +37,7 @@ CEPH_HASH_NAMESPACE_END
 #undef DOUT_COND
 #define DOUT_COND(cct, l) cct && l <= XDOUT_CONDVAR(cct, dout_subsys)
 #define lockdep_dout(v) lsubdout(g_lockdep_ceph_ctx, lockdep, v)
-#define MAX_LOCKS  1000   // increase me as needed
+#define MAX_LOCKS  2000   // increase me as needed
 #define BACKTRACE_SKIP 2
 
 /******* Globals **********/


### PR DESCRIPTION
We hit the 1000 lock limit on

 ubuntu@teuthology:/a/teuthology-2014-08-31_02:30:01-rados-next-testing-basic-multi/463411

Fixes: #9309
Signed-off-by: Sage Weil sage@redhat.com
