### PR TITLE
mds: clear objects' dirty flags after log segment is expired

### DIFF
--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -566,6 +566,7 @@ public:
   void send_expire_messages(map<int, MCacheExpire*>& expiremap);
   void trim_non_auth();      // trim out trimmable non-auth items
   bool trim_non_auth_subtree(CDir *directory);
+  void standby_trim_segment(LogSegment *ls);
   void try_trim_non_auth_subtree(CDir *dir);
   bool can_trim_non_auth_dirfrag(CDir *dir) {
     return my_ambiguous_imports.count((dir)->dirfrag()) == 0 &&

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -1114,15 +1114,7 @@ void MDLog::standby_trim_segments()
     if (seg->end > expire_pos)
       break;
     dout(10) << " removing segment " << seg->seq << "/" << seg->offset << dendl;
-    seg->dirty_dirfrags.clear_list();
-    seg->new_dirfrags.clear_list();
-    seg->dirty_inodes.clear_list();
-    seg->dirty_dentries.clear_list();
-    seg->open_files.clear_list();
-    seg->dirty_parent_inodes.clear_list();
-    seg->dirty_dirfrag_dir.clear_list();
-    seg->dirty_dirfrag_nest.clear_list();
-    seg->dirty_dirfrag_dirfragtree.clear_list();
+    mds->mdcache->standby_trim_segment(seg);
     remove_oldest_segment();
     removed_segment = true;
   }


### PR DESCRIPTION
When standby-replay MDS detects a log segment is expired, it should check
the expired segment's dirty lists and clear corresponding objects' dirty
bits. Otherwise these objects will be pinned in the standby-replay MDS's
cache forever.

Fixes: #8648
Signed-off-by: Yan, Zheng zyan@redhat.com
