### PR TITLE
rgw: add civetweb as a default frontend

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -901,7 +901,7 @@ OPTION(rgw_bucket_quota_cache_size, OPT_INT, 10000) // number of entries in buck
 
 OPTION(rgw_expose_bucket, OPT_BOOL, false) // Return the bucket name in the 'Bucket' response header
 
-OPTION(rgw_frontends, OPT_STR, "") // alternative front ends
+OPTION(rgw_frontends, OPT_STR, "fastcgi, civetweb port=7480") // rgw front ends
 
 OPTION(rgw_user_quota_bucket_sync_interval, OPT_INT, 180) // time period for accumulating modified buckets before syncing stats
 OPTION(rgw_user_quota_sync_interval, OPT_INT, 3600 * 24) // time period for accumulating modified buckets before syncing entire user stats


### PR DESCRIPTION
Fixes: #9013
Originally the configurable was empty, now setting explicitly both
fastcgi and civetweb (on port 8080).

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
