### PR TITLE
Skip rule resolution when ruleid matches ruleset_id

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -773,6 +773,16 @@ void CrushWrapper::reweight(CephContext *cct)
   }
 }
 
+bool CrushWrapper::check_rule_id_matches_ruleset_id() const
+{
+  for (int rno = 0; rno < get_max_rules(); rno++) {
+    if (rule_exists(rno)
+	&& get_rule_mask_ruleset(rno)!=rno)
+       return false;
+  }
+  return true;
+}
+
 int CrushWrapper::add_simple_ruleset(string name, string root_name,
                                      string failure_domain_name,
                                      string mode,

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -94,6 +94,7 @@ public:
     crush = crush_create();
     assert(crush);
     have_rmaps = false;
+    is_rule_id_matches_ruleset_id = false;
 
     set_tunables_default();
   }
@@ -851,6 +852,7 @@ public:
   void finalize() {
     assert(crush);
     crush_finalize(crush);
+    is_rule_id_matches_ruleset_id = check_rule_id_matches_ruleset_id();
   }
 
   void start_choose_profile() {
@@ -877,8 +879,21 @@ public:
     crush->max_devices = m;
   }
 
-  int find_rule(int ruleset, int type, int size) const {
+  int find_rule(int ruleset, int type, int size) {
     if (!crush) return -1;
+    if (is_rule_id_matches_ruleset_id) {
+      if (rule_exists(ruleset) &&
+	  get_rule_mask_ruleset(ruleset) == ruleset &&
+	  get_rule_mask_type(ruleset) == type &&
+	  get_rule_mask_min_size(ruleset) <= size &&
+	  get_rule_mask_max_size(ruleset) >= size) {
+
+	return ruleset;
+      }	else {
+	is_rule_id_matches_ruleset_id = false;
+	return -1;
+      }
+    }
     return crush_find_rule(crush, ruleset, type, size);
   }
 
@@ -891,6 +906,9 @@ public:
 
     return false;
   }
+
+  bool is_rule_id_matches_ruleset_id;
+  bool check_rule_id_matches_ruleset_id() const;
 
   /**
    * Return the lowest numbered ruleset of type `type`

--- a/src/test/crush/TestCrushWrapper.cc
+++ b/src/test/crush/TestCrushWrapper.cc
@@ -473,6 +473,52 @@ TEST(CrushWrapper, is_valid_crush_loc) {
   }
 }
 
+TEST(CrushWrapper, rule_id_match_ruleset_id) {
+  CrushWrapper *c = new CrushWrapper;
+
+  const int ROOT_TYPE = 1;
+  c->set_type_name(ROOT_TYPE, "root");
+  const int OSD_TYPE = 0;
+  c->set_type_name(OSD_TYPE, "osd");
+
+  string failure_domain_type("osd");
+  string root_name("default");
+  int rootno;
+  c->add_bucket(0, CRUSH_BUCKET_STRAW, CRUSH_HASH_RJENKINS1,
+		ROOT_TYPE, 0, NULL, NULL, &rootno);
+  c->set_item_name(rootno, root_name);
+
+  int item = 0;
+
+  pair <string,string> loc;
+  int ret;
+  loc = c->get_immediate_parent(item, &ret);
+  EXPECT_EQ(-ENOENT, ret);
+
+  {
+    map<string,string> loc;
+    loc["root"] = root_name;
+
+    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+				"osd.0", loc));
+  }
+
+  string name("NAME");
+  int rule_id = c->add_simple_ruleset(name, root_name, failure_domain_type,
+				      "firstn", pg_pool_t::TYPE_ERASURE);
+  EXPECT_EQ(0, rule_id);
+
+  CrushWrapper newcrush;
+  bufferlist bl;
+  bufferlist::iterator p = bl.begin();
+  {
+    EXPECT_EQ(rule_id, c->get_rule_mask_ruleset(rule_id));
+    c->encode(bl);
+    newcrush.decode(p);
+    EXPECT_EQ(true, newcrush.is_rule_id_matches_ruleset_id);
+  }
+}
+
 TEST(CrushWrapper, dump_rules) {
   CrushWrapper *c = new CrushWrapper;
 


### PR DESCRIPTION
Add a checking funtion into CrushWrapper::finalize(), this funtion
will check if current crush rules hoding the constraint that one rule
per ruleset and rule_id=ruleset_id.

If such a constraint holds, we set a flag(is_rule_id_matches_ruleset_id)
to true and then skip the rule resolution (which searches all rules for
a rule with the right ruleset and size).

Signed-off-by: Xiaoxi Chen xiaoxi.chen@intel.com
