### PR TITLE
fix osd crash

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5934,6 +5934,13 @@ PG::RecoveryState::RepRecovering::react(const BackfillTooFull &)
   return transit<RepNotRecovering>();
 }
 
+boost::statechart::result 
+PG::RecoveryState::RepRecovering::react(const RequestBackfillPrio &evt)
+{
+  post_event( evt );
+  return transit<RepNotRecovering>();
+}
+
 void PG::RecoveryState::RepRecovering::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1751,10 +1751,12 @@ public:
       typedef boost::mpl::list<
 	boost::statechart::transition< RecoveryDone, RepNotRecovering >,
 	boost::statechart::transition< RemoteReservationRejected, RepNotRecovering >,
-	boost::statechart::custom_reaction< BackfillTooFull >
+	boost::statechart::custom_reaction< BackfillTooFull >,
+	boost::statechart::custom_reaction< RequestBackfillPrio >
 	> reactions;
       RepRecovering(my_context ctx);
       boost::statechart::result react(const BackfillTooFull &evt);
+	  boost::statechart::result react(const RequestBackfillPrio &evt);
       void exit();
     };
 


### PR DESCRIPTION
the primary do backfill that some replica's disk is full so it reply reject when do scan,
in this case primary transit to NotBackfilling from Backfilling and
add timer to trigger backfill in next internal.
time out trigger the primary do next backill and will send MBackfillReserve message to replica again,
but some replica still in RepRecovering state that it can't react RequestBackfillPrio event,
finally osd crash.

state change:
primary: Backfilling -> NotBackfilling -> WaitLocalBackfillReserved -> WaitRemoteBackfillReserved
replica: RepRecovering -> Crashed

in other case can trigger this crash etc.

Signed-off-by: zhenbiao chen altnti@126.com
