### PR TITLE
EC-ISA: add intelligent table cache

### DIFF
--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -46,8 +46,13 @@ ErasureCodeIsa::create_ruleset(const string &name,
                                CrushWrapper &crush,
                                ostream *ss) const
 {
-  int ruleid = crush.add_simple_ruleset(name, ruleset_root, ruleset_failure_domain,
-                                        "indep", pg_pool_t::TYPE_ERASURE, ss);
+  int ruleid = crush.add_simple_ruleset(name,
+                                        ruleset_root,
+                                        ruleset_failure_domain,
+                                        "indep",
+                                        pg_pool_t::TYPE_ERASURE,
+                                        ss);
+
   if (ruleid < 0)
     return ruleid;
   else
@@ -106,7 +111,7 @@ int ErasureCodeIsa::decode_chunks(const set<int> &want_to_read,
   int erasures_count = 0;
   char *data[k];
   char *coding[m];
-  for (int i =  0; i < k + m; i++) {
+  for (int i = 0; i < k + m; i++) {
     if (chunks.find(i) == chunks.end()) {
       erasures[erasures_count] = i;
       erasures_count++;
@@ -128,13 +133,13 @@ ErasureCodeIsaDefault::isa_encode(char **data,
                                   char **coding,
                                   int blocksize)
 {
-  
-  if (m==1)
+
+  if (m == 1)
     // single parity stripe
-    region_xor( (unsigned char**) data, (unsigned char*) coding[0], k, blocksize );
+    region_xor((unsigned char**) data, (unsigned char*) coding[0], k, blocksize);
   else
-    ec_encode_data(blocksize, k, m, g_encode_tbls,
-		   (unsigned char**) data, (unsigned char**) coding);
+    ec_encode_data(blocksize, k, m, encode_tbls,
+                   (unsigned char**) data, (unsigned char**) coding);
 }
 
 // -----------------------------------------------------------------------------
@@ -151,74 +156,7 @@ ErasureCodeIsaDefault::erasure_contains(int *erasures, int i)
 
 // -----------------------------------------------------------------------------
 
-bool
-ErasureCodeIsaDefault::get_decoding_table_from_cache(std::string &signature, unsigned char* &table)
-{
-  // --------------------------------------------------------------------------
-  // LRU decoding matrix cache
-  // --------------------------------------------------------------------------
 
-  dout(12) << "[ get table    ] = " << signature << dendl;
-
-  // we try to fetch a decoding table from an LRU cache
-  bool found = false;
-
-  Mutex::Locker lock(g_decode_tbls_guard);
-  if (g_decode_tbls_map.count(signature)) {
-    dout(12) << "[ cached table ] = " << signature << dendl;
-    // copy the table out of the cache
-    memcpy(table, g_decode_tbls_map[signature].second.c_str(), k * (m + k)*32);
-    // find item in LRU queue and push back
-    dout(12) << "[ cache size   ] = " << g_decode_tbls_lru.size() << dendl;
-    g_decode_tbls_lru.splice(g_decode_tbls_map[signature].first, g_decode_tbls_lru, g_decode_tbls_lru.end());
-    found = true;
-  }
-
-  return found;
-}
-
-// -----------------------------------------------------------------------------
-
-void
-ErasureCodeIsaDefault::put_decoding_table_to_cache(std::string &signature, unsigned char* &table)
-{
-  // --------------------------------------------------------------------------
-  // LRU decoding matrix cache
-  // --------------------------------------------------------------------------
-
-  dout(12) << "[ put table    ] = " << signature << dendl;
-
-  // we store a new table to the cache
-
-  bufferptr cachetable;
-
-  Mutex::Locker lock(g_decode_tbls_guard);
-
-  // evt. shrink the LRU queue/map
-  if ((int)g_decode_tbls_lru.size() >= g_decode_tbls_lru_length) {
-    dout(12) << "[ shrink lru   ] = " << signature << dendl;
-    // reuse old buffer
-    cachetable = g_decode_tbls_map[g_decode_tbls_lru.front()].second;
-    // remove from map
-    g_decode_tbls_map.erase(g_decode_tbls_lru.front());
-    // remove from lru
-    g_decode_tbls_lru.pop_front();
-    // add the new to the map
-    g_decode_tbls_map[signature] = std::make_pair(g_decode_tbls_lru.begin(), cachetable);
-    // add to the end of lru
-    g_decode_tbls_lru.push_back(signature);
-  } else {
-    dout(12) << "[ store table  ] = " << signature << dendl;
-    // allocate a new buffer
-    cachetable = buffer::create(k * (m + k)*32);
-    g_decode_tbls_lru.push_back(signature);
-    g_decode_tbls_map[signature] = std::make_pair(g_decode_tbls_lru.begin(), cachetable);
-    dout(12) << "[ cache size   ] = " << g_decode_tbls_lru.size() << dendl;
-  }
-
-  // copy-in the new table
-  memcpy(cachetable.c_str(), table, k * (m + k)*32);
-}
 
 // -----------------------------------------------------------------------------
 
@@ -267,10 +205,11 @@ ErasureCodeIsaDefault::isa_decode(int *erasures,
     }
   }
 
-  if (m==1) {
+  if (m == 1) {
     // single parity decoding
-    assert (1 == nerrs);
-    dout(20) << "isa_decode: reconstruct using region xor [" << erasures[0] << "]" << dendl;
+    assert(1 == nerrs);
+    dout(20) << "isa_decode: reconstruct using region xor [" << 
+      erasures[0] << "]" << dendl;
     region_xor(recover_source, recover_target[0], k, blocksize);
     return 0;
   }
@@ -280,7 +219,8 @@ ErasureCodeIsaDefault::isa_decode(int *erasures,
       (nerrs == 1) &&
       (erasures[0] < (k + 1))) {
     // use xor decoding if a data chunk is missing or the first coding chunk
-    dout(20) << "isa_decode: reconstruct using region xor [" << erasures[0] << "]" << dendl;
+    dout(20) << "isa_decode: reconstruct using region xor [" << 
+      erasures[0] << "]" << dendl;
     assert(1 == s);
     assert(k == r);
     region_xor(recover_source, recover_target[0], k, blocksize);
@@ -290,8 +230,8 @@ ErasureCodeIsaDefault::isa_decode(int *erasures,
   unsigned char b[k * (m + k)];
   unsigned char c[k * (m + k)];
   unsigned char d[k * (m + k)];
-  unsigned char g_decode_tbls[k * (m + k)*32];
-  unsigned char *p_tbls = g_decode_tbls;
+  unsigned char decode_tbls[k * (m + k)*32];
+  unsigned char *p_tbls = decode_tbls;
 
   int decode_index[k];
 
@@ -324,11 +264,11 @@ ErasureCodeIsaDefault::isa_decode(int *erasures,
   // ---------------------------------------------
   // Try to get an already computed matrix
   // ---------------------------------------------
-  if (!get_decoding_table_from_cache(erasure_signature, p_tbls)) {
+  if (!tcache.getDecodingTableFromCache(erasure_signature, p_tbls, matrixtype, k, m)) {
     for (i = 0; i < k; i++) {
       r = decode_index[i];
       for (j = 0; j < k; j++)
-        b[k * i + j] = a[k * r + j];
+        b[k * i + j] = encode_coeff[k * r + j];
     }
     // ---------------------------------------------
     // Compute inverted matrix
@@ -360,7 +300,7 @@ ErasureCodeIsaDefault::isa_decode(int *erasures,
           s = 0;
           for (j = 0; j < k; j++)
             s ^= gf_mul(d[j * k + i],
-                        a[k * erasures[p] + j]);
+                        encode_coeff[k * erasures[p] + j]);
 
           c[k * p + i] = s;
         }
@@ -370,12 +310,12 @@ ErasureCodeIsaDefault::isa_decode(int *erasures,
     // ---------------------------------------------
     // Initialize Decoding Table
     // ---------------------------------------------
-    ec_init_tables(k, nerrs, c, g_decode_tbls);
-    put_decoding_table_to_cache(erasure_signature, p_tbls);
+    ec_init_tables(k, nerrs, c, decode_tbls);
+    tcache.putDecodingTableToCache(erasure_signature, p_tbls, matrixtype, k, m);
   }
   // Recover data sources
   ec_encode_data(blocksize,
-                 k, nerrs, g_decode_tbls, recover_source, recover_target);
+                 k, nerrs, decode_tbls, recover_source, recover_target);
 
 
   return 0;
@@ -405,15 +345,15 @@ int ErasureCodeIsaDefault::parse(const map<std::string,
     // full erasures
     if (k > 32) {
       *ss << "Vandermonde: m=" << m
-          << " should be less/equal than 32 : revert to k=32" << std::endl;
+        << " should be less/equal than 32 : revert to k=32" << std::endl;
       k = 32;
       err = -EINVAL;
     }
 
     if (m > 4) {
       *ss << "Vandermonde: m=" << m
-          << " should be less than 5 to guarantee an MDS codec:"
-          << " revert to m=4" << std::endl;
+        << " should be less than 5 to guarantee an MDS codec:"
+        << " revert to m=4" << std::endl;
       m = 4;
       err = -EINVAL;
     }
@@ -421,8 +361,8 @@ int ErasureCodeIsaDefault::parse(const map<std::string,
     case 4:
       if (k > 21) {
         *ss << "Vandermonde: k=" << k
-            << " should be less than 22 to guarantee an MDS"
-            << " codec with m=4: revert to k=21" << std::endl;
+          << " should be less than 22 to guarantee an MDS"
+          << " codec with m=4: revert to k=21" << std::endl;
         k = 21;
         err = -EINVAL;
       }
@@ -439,18 +379,49 @@ int ErasureCodeIsaDefault::parse(const map<std::string,
 void
 ErasureCodeIsaDefault::prepare()
 {
-  a = (unsigned char*) malloc(k * (m + k));
-  g_encode_tbls = (unsigned char*) malloc(k * (m + k)*32);
+  Mutex::Locker lock(tcache.codec_tables_guard);
 
-  unsigned memory_lru_cache = k * (m + k) * 32 * g_decode_tbls_lru_length;
-  dout(10) << "[ cache memory ] = " << memory_lru_cache << " bytes" << dendl;
-  // build encoding table which needs to be computed once for a configure (k,m)
+  // setup shared encoding table and coefficients
+  unsigned char** p_enc_table = 
+  tcache.getEncodingTable(matrixtype, k, m);
+  
+  unsigned char** p_enc_coeff = 
+  tcache.getEncodingCoefficient(matrixtype, k, m);
+
+  if (!*p_enc_coeff) {
+    dout(10) << "[ cache tables ] creating coeff for k=" << 
+      k << " m=" << m << dendl;
+    // build encoding coefficients which need to be computed once for each (k,m)
+    *p_enc_coeff = (unsigned char*) malloc(k * (m + k));
+    encode_coeff = *p_enc_coeff;
+
+    if (matrixtype == kVandermonde)
+      gf_gen_rs_matrix(encode_coeff, k + m, k);
+    if (matrixtype == kCauchy)
+      gf_gen_cauchy1_matrix(encode_coeff, k + m, k);
+  } else {
+    encode_coeff = *p_enc_coeff;
+  }
+
+  if (!*p_enc_table) {
+    dout(10) << "[ cache tables ] creating tables for k=" << 
+      k << " m=" << m << dendl;
+    // build encoding table which needs to be computed once for each (k,m)
+    *p_enc_table = (unsigned char*) malloc(k * (m + k)*32);
+    encode_tbls = *p_enc_table;
+    ec_init_tables(k, m, &encode_coeff[k * k], encode_tbls);
+  } else {
+    encode_tbls = *p_enc_table;
+  }
+
+  unsigned memory_lru_cache =
+    k * (m + k) * 32 * tcache.decoding_tables_lru_length;
+
+  dout(10) << "[ cache memory ] = " << memory_lru_cache << " bytes" << 
+    " [ matrix ] = " << 
+    ((matrixtype == kVandermonde) ? "Vandermonde" : "Cauchy") << dendl;
+
   assert((matrixtype == kVandermonde) || (matrixtype == kCauchy));
-  if (matrixtype == kVandermonde)
-    gf_gen_rs_matrix(a, k + m, k);
-  if (matrixtype == kCauchy)
-    gf_gen_cauchy1_matrix(a, k + m, k);
 
-  ec_init_tables(k, m, &a[k * k], g_encode_tbls);
 }
 // -----------------------------------------------------------------------------

--- a/src/erasure-code/isa/ErasureCodeIsa.h
+++ b/src/erasure-code/isa/ErasureCodeIsa.h
@@ -28,22 +28,32 @@
 // -----------------------------------------------------------------------------
 #include "common/Mutex.h"
 #include "erasure-code/ErasureCode.h"
+#include "ErasureCodeIsaTableCache.h"
 // -----------------------------------------------------------------------------
 #include <list>
 // -----------------------------------------------------------------------------
 
 class ErasureCodeIsa : public ErasureCode {
 public:
-  enum eMatrix {kVandermonde=0, kCauchy=1};
+
+  enum eMatrix {
+    kVandermonde = 0, kCauchy = 1
+  };
 
   int k;
   int m;
   int w;
+
+  ErasureCodeIsaTableCache &tcache;
   const char *technique;
   string ruleset_root;
   string ruleset_failure_domain;
 
-  ErasureCodeIsa(const char *_technique) :
+
+
+  ErasureCodeIsa(const char *_technique,
+                 ErasureCodeIsaTableCache &_tcache) :
+  tcache(_tcache),
   technique(_technique),
   ruleset_root("default"),
   ruleset_failure_domain("host")
@@ -74,11 +84,11 @@ public:
   virtual unsigned int get_chunk_size(unsigned int object_size) const;
 
   virtual int encode_chunks(const set<int> &want_to_encode,
-			    map<int, bufferlist> *encoded);
+                            map<int, bufferlist> *encoded);
 
   virtual int decode_chunks(const set<int> &want_to_read,
-			    const map<int, bufferlist> &chunks,
-			    map<int, bufferlist> *decoded);
+                            const map<int, bufferlist> &chunks,
+                            map<int, bufferlist> *decoded);
 
   void init(const map<std::string, std::string> &parameters);
 
@@ -105,37 +115,22 @@ public:
 // -----------------------------------------------------------------------------
 
 class ErasureCodeIsaDefault : public ErasureCodeIsa {
-
+private:
   int matrixtype;
 
 public:
 
   static const int DEFAULT_K = 7;
   static const int DEFAULT_M = 3;
-  static const int g_decode_tbls_lru_length=2516; // caches up to 12+4 completely
 
-  unsigned char* a; // encoding coefficient
-  unsigned char* g_encode_tbls; // encoding table
+  unsigned char* encode_coeff; // encoding coefficient
+  unsigned char* encode_tbls; // encoding table
 
-
-  // we create a cache for decoding tables
-  Mutex g_decode_tbls_guard;
-
-  int get_tbls_lru_size()
-  {
-    Mutex::Locker lock(g_decode_tbls_guard);
-    return g_decode_tbls_lru.size();
-  }
-
-  // we implement an LRU cache for coding matrix - the cache size is
-  // sufficient up to (12,4) decodings
-  typedef std::pair<std::list<std::string>::iterator, bufferptr> lru_entry_t;
-
-  std::map<std::string, lru_entry_t> g_decode_tbls_map;
-  std::list<std::string> g_decode_tbls_lru;
-
-  ErasureCodeIsaDefault(int matrix = kVandermonde) : ErasureCodeIsa("default"),
-    a(0), g_encode_tbls(0), g_decode_tbls_guard("isa-lru-cache")
+  ErasureCodeIsaDefault(ErasureCodeIsaTableCache &_tcache,
+                        int matrix = kVandermonde ) :
+                       
+  ErasureCodeIsa("default", _tcache),
+  encode_coeff(0), encode_tbls(0)
   {
     matrixtype = matrix;
   }
@@ -143,12 +138,7 @@ public:
   virtual
   ~ErasureCodeIsaDefault()
   {
-    if (a) {
-      free(a);
-    }
-    if (g_encode_tbls) {
-      free(g_encode_tbls);
-    }
+
   }
 
   virtual void isa_encode(char **data,
@@ -170,8 +160,7 @@ public:
 
   virtual void prepare();
 
-  bool get_decoding_table_from_cache(std::string &signature, unsigned char* &table);
-  void put_decoding_table_to_cache(std::string&, unsigned char*&);
+
 };
 
 #endif

--- a/src/erasure-code/isa/ErasureCodePluginIsa.cc
+++ b/src/erasure-code/isa/ErasureCodePluginIsa.cc
@@ -2,10 +2,8 @@
  * Ceph - scalable distributed file system
  *
  * Copyright (C) 2014 CERN (Switzerland)
- * Copyright (C) 2014 Red Hat <contact@redhat.com>
  *
  * Author: Andreas-Joachim Peters <Andreas.Joachim.Peters@cern.ch>
- * Author: Loic Dachary <loic@dachary.org>
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -21,32 +19,22 @@
  * @brief  Erasure Code Plug-in class wrapping the INTEL ISA-L library
  *
  * The factory plug-in class allows to call individual encoding techniques.
- * The INTEL ISA-L library provides two pre-defined encoding matrices (cauchy, reed_sol_van = default).
+ * The INTEL ISA-L library provides two pre-defined encoding matrices 
+ * (cauchy, reed_sol_van = default).
  */
 
 // -----------------------------------------------------------------------------
 #include "ceph_ver.h"
 #include "common/debug.h"
 #include "erasure-code/ErasureCodePlugin.h"
+#include "ErasureCodeIsaTableCache.h"
 #include "ErasureCodeIsa.h"
 // -----------------------------------------------------------------------------
 
-
-// -----------------------------------------------------------------------------
-#define dout_subsys ceph_subsys_osd
-#undef dout_prefix
-#define dout_prefix _prefix(_dout)
-// -----------------------------------------------------------------------------
-
-static ostream& _prefix(std::ostream* _dout)
-{
-  return *_dout << "ErasureCodePluginIsa: ";
-}
-
-// -----------------------------------------------------------------------------
-
 class ErasureCodePluginIsa : public ErasureCodePlugin {
+
 public:
+  ErasureCodeIsaTableCache tcache;
 
   virtual int factory(const map<std::string, std::string> &parameters,
                       ErasureCodeInterfaceRef *erasure_code)
@@ -56,10 +44,12 @@ public:
     if (parameters.find("technique") != parameters.end())
       t = parameters.find("technique")->second;
     if ((t == "reed_sol_van")) {
-      interface = new ErasureCodeIsaDefault(ErasureCodeIsaDefault::kVandermonde);
+      interface = new ErasureCodeIsaDefault(tcache,
+					    ErasureCodeIsaDefault::kVandermonde);
     } else {
       if ((t == "cauchy")) {
-        interface = new ErasureCodeIsaDefault(ErasureCodeIsaDefault::kCauchy);
+        interface = new ErasureCodeIsaDefault(tcache,
+					      ErasureCodeIsaDefault::kCauchy);
       } else {
         derr << "technique=" << t << " is not a valid coding technique. "
           << " Choose one of the following: "
@@ -75,12 +65,13 @@ public:
   }
 };
 
-// -----------------------------------------------------------------------------
-
+// -----------------------------------------------------------------------------                                                                                                                           
 const char *__erasure_code_version() { return CEPH_GIT_NICE_VER; }
 
+// -----------------------------------------------------------------------------                                                                                                                           
 int __erasure_code_init(char *plugin_name, char *directory)
 {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
+
   return instance.add(plugin_name, new ErasureCodePluginIsa());
 }

--- a/src/erasure-code/isa/Makefile.am
+++ b/src/erasure-code/isa/Makefile.am
@@ -1,6 +1,7 @@
 # ISA
 noinst_HEADERS += \
 	erasure-code/isa/ErasureCodeIsa.h \
+	erasure-code/isa/ErasureCodeIsaTableCache.h \
 	erasure-code/isa/xor_op.h \
 	erasure-code/isa/isa-l/erasure_code/ec_base.h \
 	erasure-code/isa/isa-l/include/erasure_code.h \
@@ -35,6 +36,7 @@ isa_sources = \
 	erasure-code/isa/isa-l/erasure_code/gf_vect_mul_avx.asm.s \
 	erasure-code/isa/isa-l/erasure_code/gf_vect_mul_sse.asm.s \
 	erasure-code/isa/ErasureCodeIsa.cc \
+	erasure-code/isa/ErasureCodeIsaTableCache.cc \
 	erasure-code/isa/ErasureCodePluginIsa.cc \
 	erasure-code/isa/xor_op.cc
 


### PR DESCRIPTION
Add persistent caching and sharing of encoding and decoding tables stored in a singleton object which are used/fillled by Isa CODEC instances. 

Refactored to split caching from codec functionality.
