### PR TITLE
adds a navigational menu for docs

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,5 +1,5 @@
 {% extends "!layout.html" %}
 
 {%- block extrahead %}
-  <script type="text/javascript" src="http://ayni.ceph.com/public/js/ceph-deploy.js"</script>
+    <script type="text/javascript" src="http://ayni.ceph.com/public/js/ceph.js"></script>
 {% endblock %}


### PR DESCRIPTION
Which is basically pulling JS+CSS from the HTTP service shown in the src to the `<head>` tag.

Links to browsershots showing compatibility in almost every browser (lol Konkeror) 

http://browsershots.org/http://ceph.com/docs/wip-8366/radosgw/

![09-04-2014-13-09-33](https://cloud.githubusercontent.com/assets/317847/4153287/f8424c94-3456-11e4-86d9-d41b584d39e4.png)
