### PR TITLE
osd: Make RPGTransaction::get_bytes_written return the correct size.

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -274,6 +274,7 @@ class RPGTransaction : public PGBackend::PGTransaction {
   set<hobject_t> temp_added;
   set<hobject_t> temp_cleared;
   ObjectStore::Transaction *t;
+  uint64_t written;
   const coll_t &get_coll_ct(const hobject_t &hoid) {
     if (hoid.is_temp()) {
       temp_cleared.erase(hoid);
@@ -296,7 +297,7 @@ class RPGTransaction : public PGBackend::PGTransaction {
   }
 public:
   RPGTransaction(coll_t coll, coll_t temp_coll)
-    : coll(coll), temp_coll(temp_coll), t(new ObjectStore::Transaction)
+    : coll(coll), temp_coll(temp_coll), t(new ObjectStore::Transaction), written(0)
     {}
 
   /// Yields ownership of contained transaction
@@ -318,6 +319,7 @@ public:
     uint64_t len,
     bufferlist &bl
     ) {
+    written += len;
     t->write(get_coll_ct(hoid), hoid, off, len, bl);
   }
   void remove(
@@ -355,6 +357,8 @@ public:
     const hobject_t &hoid,
     map<string, bufferlist> &keys
     ) {
+    for (map<string, bufferlist>::iterator p = keys.begin(); p != keys.end(); p++)
+      written += p->first.length() + p->second.length();
     return t->omap_setkeys(get_coll(hoid), hoid, keys);
   }
   void omap_rmkeys(
@@ -372,6 +376,7 @@ public:
     const hobject_t &hoid,
     bufferlist &header
     ) {
+    written += header.length();
     t->omap_setheader(get_coll(hoid), hoid, header);
   }
   void clone_range(
@@ -436,6 +441,8 @@ public:
     ) {
     RPGTransaction *to_append = dynamic_cast<RPGTransaction*>(_to_append);
     assert(to_append);
+    written += to_append->written;
+    to_append->written = 0;
     t->append(*(to_append->t));
     for (set<hobject_t>::iterator i = to_append->temp_added.begin();
 	 i != to_append->temp_added.end();
@@ -457,7 +464,7 @@ public:
     return t->empty();
   }
   uint64_t get_bytes_written() const {
-    return t->get_encoded_bytes();
+    return written;
   }
   ~RPGTransaction() { delete t; }
 };


### PR DESCRIPTION
It record size larger than clien wrote. It should like
ECTransaction::get_bytes_written only return the size which clien wrote.

Fixes: #9342
Signed-off-by: Ma Jianpeng jianpeng.ma@intel.com
