### PR TITLE
crush: optimized crush algorithm for balanced pg distribution among osds

### DIFF
--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -78,6 +78,7 @@ int CrushCompiler::decompile_bucket_impl(int i, ostream &out)
   bool dopos = false;
   switch (alg) {
   case CRUSH_BUCKET_UNIFORM:
+  case CRUSH_BUCKET_LINEAR:
     out << "\t# do not change bucket size (" << n << ") unnecessarily";
     dopos = true;
     break;
@@ -435,6 +436,8 @@ int CrushCompiler::parse_bucket(iter_t const& i)
 	alg = CRUSH_BUCKET_TREE;
       else if (a == "straw")
 	alg = CRUSH_BUCKET_STRAW;
+      else if (a == "linear")
+	alg = CRUSH_BUCKET_LINEAR;
       else {
 	err << "unknown bucket alg '" << a << "'" << std::endl << std::endl;
 	return -EINVAL;
@@ -512,7 +515,7 @@ int CrushCompiler::parse_bucket(iter_t const& i)
 	  assert(0);
 
       }
-      if (alg == CRUSH_BUCKET_UNIFORM) {
+      if (alg == CRUSH_BUCKET_UNIFORM || alg == CRUSH_BUCKET_LINEAR) {
 	if (!have_uniform_weight) {
 	  have_uniform_weight = true;
 	  uniform_weight = weight;

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -964,6 +964,10 @@ void CrushWrapper::encode(bufferlist& bl, bool lean) const
       }
       break;
 
+    case CRUSH_BUCKET_LINEAR:
+      ::encode(((crush_bucket_linear*)crush->buckets[i])->item_weight, bl);
+      break;
+
     default:
       assert(0);
       break;
@@ -1108,6 +1112,9 @@ void CrushWrapper::decode_crush_bucket(crush_bucket** bptr, bufferlist::iterator
   case CRUSH_BUCKET_STRAW:
     size = sizeof(crush_bucket_straw);
     break;
+  case CRUSH_BUCKET_LINEAR:
+    size = sizeof(crush_bucket_linear);
+    break;
   default:
     {
       char str[128];
@@ -1170,6 +1177,10 @@ void CrushWrapper::decode_crush_bucket(crush_bucket** bptr, bufferlist::iterator
     }
     break;
   }
+
+  case CRUSH_BUCKET_LINEAR:
+    ::decode(((crush_bucket_linear*)bucket)->item_weight, blp);
+    break;
 
   default:
     // We should have handled this case in the first switch statement

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -925,6 +925,20 @@ public:
       out[i] = rawout[i];
   }
 
+  void do_rule(int rule, int x, vector<int>& out, int maxout,
+	       const vector<__u32>& weight, float balance_param) const {
+    Mutex::Locker l(mapper_lock);
+    int rawout[maxout];
+    int scratch[maxout * 3];
+    int numrep = crush_do_rule_wrapper(crush, rule, x, rawout, maxout,
+					&weight[0], weight.size(), scratch, balance_param);
+    if (numrep < 0)
+      numrep = 0;
+    out.resize(numrep);
+    for (int i=0; i<numrep; i++)
+      out[i] = rawout[i];
+  }
+
   int read_from_file(const char *fn) {
     bufferlist bl;
     std::string error;

--- a/src/crush/builder.h
+++ b/src/crush/builder.h
@@ -39,5 +39,9 @@ struct crush_bucket_straw *
 crush_make_straw_bucket(int hash, int type, int size,
 			int *items,
 			int *weights);
+struct crush_bucket_linear *
+crush_make_linear_bucket(int hash, int type, int size,
+			  int *items,
+			  int item_weight);
 
 #endif

--- a/src/crush/crush.c
+++ b/src/crush/crush.c
@@ -18,6 +18,7 @@ const char *crush_bucket_alg_name(int alg)
 	case CRUSH_BUCKET_LIST: return "list";
 	case CRUSH_BUCKET_TREE: return "tree";
 	case CRUSH_BUCKET_STRAW: return "straw";
+	case CRUSH_BUCKET_LINEAR: return "linear";
 	default: return "unknown";
 	}
 }
@@ -41,6 +42,8 @@ int crush_get_bucket_item_weight(const struct crush_bucket *b, int p)
 		return ((struct crush_bucket_tree *)b)->node_weights[crush_calc_tree_node(p)];
 	case CRUSH_BUCKET_STRAW:
 		return ((struct crush_bucket_straw *)b)->item_weights[p];
+	case CRUSH_BUCKET_LINEAR:
+		return ((struct crush_bucket_linear *)b)->item_weight;
 	}
 	return 0;
 }
@@ -78,6 +81,13 @@ void crush_destroy_bucket_straw(struct crush_bucket_straw *b)
 	kfree(b);
 }
 
+void crush_destroy_bucket_linear(struct crush_bucket_linear *b)
+{
+	kfree(b->h.perm);
+	kfree(b->h.items);
+	kfree(b);
+}
+
 void crush_destroy_bucket(struct crush_bucket *b)
 {
 	switch (b->alg) {
@@ -92,6 +102,9 @@ void crush_destroy_bucket(struct crush_bucket *b)
 		break;
 	case CRUSH_BUCKET_STRAW:
 		crush_destroy_bucket_straw((struct crush_bucket_straw *)b);
+		break;
+	case CRUSH_BUCKET_LINEAR:
+		crush_destroy_bucket_linear((struct crush_bucket_linear *)b);
 		break;
 	}
 }

--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -112,7 +112,8 @@ enum {
 	CRUSH_BUCKET_UNIFORM = 1,
 	CRUSH_BUCKET_LIST = 2,
 	CRUSH_BUCKET_TREE = 3,
-	CRUSH_BUCKET_STRAW = 4
+	CRUSH_BUCKET_STRAW = 4,
+	CRUSH_BUCKET_LINEAR = 5
 };
 extern const char *crush_bucket_alg_name(int alg);
 
@@ -159,7 +160,10 @@ struct crush_bucket_straw {
 	__u32 *straws;         /* 16-bit fixed point */
 };
 
-
+struct crush_bucket_linear {
+	struct crush_bucket h;
+	__u32 item_weight;  /* 16-bit fixed point; all items equally weighted */
+};
 
 /*
  * CRUSH map includes all buckets, rules, etc.
@@ -203,6 +207,7 @@ extern void crush_destroy_bucket_uniform(struct crush_bucket_uniform *b);
 extern void crush_destroy_bucket_list(struct crush_bucket_list *b);
 extern void crush_destroy_bucket_tree(struct crush_bucket_tree *b);
 extern void crush_destroy_bucket_straw(struct crush_bucket_straw *b);
+extern void crush_destroy_bucket_linear(struct crush_bucket_linear *b);
 extern void crush_destroy_bucket(struct crush_bucket *b);
 extern void crush_destroy_rule(struct crush_rule *r);
 extern void crush_destroy(struct crush_map *map);

--- a/src/crush/grammar.h
+++ b/src/crush/grammar.h
@@ -116,7 +116,8 @@ struct crush_grammar : public grammar<crush_grammar>
       bucket_alg = str_p("alg") >> ( str_p("uniform") |
 				     str_p("list") |
 				     str_p("tree") |
-				     str_p("straw") );
+				     str_p("straw")|
+				     str_p("linear"));
       bucket_hash = str_p("hash") >> ( integer |
 				       str_p("rjenkins1") );
       bucket_item = str_p("item") >> name

--- a/src/crush/mapper.h
+++ b/src/crush/mapper.h
@@ -16,5 +16,10 @@ extern int crush_do_rule(const struct crush_map *map,
 			 int x, int *result, int result_max,
 			 const __u32 *weights, int weight_max,
 			 int *scratch);
-
+extern int crush_do_rule_wrapper(const struct crush_map *map,
+			 int ruleno,
+			 int x, int *result, int result_max,
+			 const __u32 *weights, int weight_max,
+			 int *scratch,
+			 float balance_param);
 #endif

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -66,6 +66,27 @@ static ostream& _prefix(std::ostream *_dout, Monitor *mon, OSDMap& osdmap) {
 		<< ").osd e" << osdmap.get_epoch() << " ";
 }
 
+float cal_average(vector<int> dataset, int length) {
+  float avg = 0;
+  float sum = 0;
+  for(int i = 0; i < length; i++){
+    sum += dataset[i];
+  }
+  avg = sum/length;
+  return avg;
+}
+
+float cal_stdev(vector<int> dataset, int length) {
+  float avg = cal_average(dataset, length);
+  float sum = 0;
+  float stdev;
+  for(int i = 0; i < length; i++){
+    sum += pow(dataset[i] - avg, 2);
+  }
+  stdev = pow(sum/length, 0.5);
+  return stdev;
+}
+
 bool OSDMonitor::_have_pending_crush()
 {
   return pending_inc.crush.length();
@@ -3149,6 +3170,43 @@ int OSDMonitor::prepare_new_pool(MPoolOp *m)
 			    pg_pool_t::TYPE_REPLICATED, 0, ss);
 }
 
+void OSDMonitor::prepare_adaptive_balance_param(pg_pool_t *pi, int64_t pool)
+{
+  float min_stdev = 999999;
+  float balance_param = 1;
+
+  for (int k = 1; k < 5; k++) {
+    map<int, int> osd_total_pgs;
+    pi->set_balance_param((float)k);
+    for (int i = 0; i < (int)pi->get_pg_num(); i++) {
+      pg_t pg(i, pool);
+      pg.set_pool(pool);
+      vector<int> acting;
+      int nrep = osdmap.pg_to_up_osds_adaptive(*pi, pg, acting);
+      if (nrep) {
+        for (int j = 0; j < nrep; j++) {
+          osd_total_pgs[acting[j]]++;
+        }
+      }
+    }
+
+    vector<int> pg_num;
+    for (map<int, int>::iterator ptr = osd_total_pgs.begin();
+	   ptr != osd_total_pgs.end();
+	   ++ptr) {
+      pg_num.push_back(ptr->second);
+    }
+
+    float stdev = cal_stdev(pg_num, pg_num.size());
+    if (stdev < min_stdev) {
+      min_stdev = stdev;
+      balance_param = k;
+    }
+  }
+
+  pi->set_balance_param(balance_param);
+}
+
 int OSDMonitor::crush_ruleset_create_erasure(const string &name,
 					     const string &profile,
 					     int *ruleset,
@@ -3535,6 +3593,7 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
     g_conf->osd_pool_default_cache_target_full_ratio * 1000000;
   pi->cache_min_flush_age = g_conf->osd_pool_default_cache_min_flush_age;
   pi->cache_min_evict_age = g_conf->osd_pool_default_cache_min_evict_age;
+  prepare_adaptive_balance_param(pi, pool);
   pending_inc.new_pool_names[pool] = name;
   return 0;
 }

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -253,6 +253,7 @@ private:
   bool prepare_pool_op (MPoolOp *m);
   bool prepare_pool_op_create (MPoolOp *m);
   bool prepare_pool_op_delete(MPoolOp *m);
+  void prepare_adaptive_balance_param(pg_pool_t *pi, int64_t pool);
   int crush_ruleset_create_erasure(const string &name,
 				   const string &profile,
 				   int *ruleset,

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1419,13 +1419,13 @@ int OSDMap::_pg_to_osds(const pg_pool_t& pool, pg_t pg,
 			ps_t *ppps) const
 {
   // map to osds[]
-  ps_t pps = pool.raw_pg_to_pps(pg);  // placement ps
+  ps_t pps = pool.raw_pg_to_congruential_pps(pg);  // placement ps
   unsigned size = pool.get_size();
 
   // what crush rule?
   int ruleno = crush->find_rule(pool.get_crush_ruleset(), pool.get_type(), size);
   if (ruleno >= 0)
-    crush->do_rule(ruleno, pps, *osds, size, osd_weight);
+    crush->do_rule(ruleno, pps, *osds, size, osd_weight, pool.get_balance_param());
 
   _remove_nonexistent_osds(pool, *osds);
 
@@ -1582,6 +1582,15 @@ void OSDMap::pg_to_raw_up(pg_t pg, vector<int> *up, int *primary) const
   _pg_to_osds(*pool, pg, &raw, primary, &pps);
   _raw_to_up_osds(*pool, raw, up, primary);
   _apply_primary_affinity(pps, *pool, up, primary);
+}
+
+int OSDMap::pg_to_up_osds_adaptive(const pg_pool_t& pool, pg_t pg, vector<int>& up) const
+{
+  int primary;
+  vector<int> raw;
+  _pg_to_osds(pool, pg, &raw, &primary, NULL);
+  _raw_to_up_osds(pool, raw, &up, &primary);
+  return up.size();
 }
   
 void OSDMap::_pg_to_up_acting_osds(const pg_t& pg, vector<int> *up, int *up_primary,

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -642,6 +642,7 @@ public:
     int r = pg_to_acting_osds(pg, &acting, &primary);
     return r;
   }
+  int pg_to_up_osds_adaptive(const pg_pool_t& pool, pg_t pg, vector<int>& up) const;
   /**
    * This does not apply temp overrides and should not be used
    * by anybody for data mapping purposes. Specify both pointers.

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -768,6 +768,7 @@ void pg_pool_t::dump(Formatter *f) const
   f->dump_int("min_size", get_min_size());
   f->dump_int("crush_ruleset", get_crush_ruleset());
   f->dump_int("object_hash", get_object_hash());
+  f->dump_float("balance_param", get_balance_param());
   f->dump_int("pg_num", get_pg_num());
   f->dump_int("pg_placement_num", get_pgp_num());
   f->dump_unsigned("crash_replay_interval", get_crash_replay_interval());
@@ -991,6 +992,23 @@ ps_t pg_pool_t::raw_pg_to_pps(pg_t pg) const
   }
 }
 
+ps_t pg_pool_t::raw_pg_to_congruential_pps(pg_t pg) const
+{
+  if (flags & FLAG_HASHPSPOOL) {
+    // Shuffles the original pgid sequence, with poolid being the seed
+    ps_t stable = ceph_stable_mod(pg.ps(), pgp_num, pgp_num_mask);
+    ps_t pps = (1033*stable + 2*pg.pool() + 1) % pgp_num_mask + pg.pool();
+    return pps;
+  } else {
+    // Legacy behavior; add ps and pool together.  This is not a great
+    // idea because the PGs from each pool will essentially overlap on
+    // top of each other: 0.5 == 1.4 == 2.3 == ...
+    return
+      ceph_stable_mod(pg.ps(), pgp_num, pgp_num_mask) +
+      pg.pool();
+  }
+}
+
 uint32_t pg_pool_t::get_random_pg_position(pg_t pg, uint32_t seed) const
 {
   uint32_t r = crush_hash32_2(CRUSH_HASH_RJENKINS1, seed, 123);
@@ -1018,6 +1036,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     ::encode(size, bl);
     ::encode(crush_ruleset, bl);
     ::encode(object_hash, bl);
+    ::encode(balance_param, bl);
     ::encode(pg_num, bl);
     ::encode(pgp_num, bl);
     __u32 lpg_num = 0, lpgp_num = 0;  // tell old code that there are no localized pgs.
@@ -1046,6 +1065,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     ::encode(size, bl);
     ::encode(crush_ruleset, bl);
     ::encode(object_hash, bl);
+    ::encode(balance_param, bl);
     ::encode(pg_num, bl);
     ::encode(pgp_num, bl);
     __u32 lpg_num = 0, lpgp_num = 0;  // tell old code that there are no localized pgs.
@@ -1073,6 +1093,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     ::encode(size, bl);
     ::encode(crush_ruleset, bl);
     ::encode(object_hash, bl);
+    ::encode(balance_param, bl);
     ::encode(pg_num, bl);
     ::encode(pgp_num, bl);
     __u32 lpg_num = 0, lpgp_num = 0;  // tell old code that there are no localized pgs.
@@ -1116,6 +1137,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
   ::encode(size, bl);
   ::encode(crush_ruleset, bl);
   ::encode(object_hash, bl);
+  ::encode(balance_param, bl);
   ::encode(pg_num, bl);
   ::encode(pgp_num, bl);
   __u32 lpg_num = 0, lpgp_num = 0;  // tell old code that there are no localized pgs.
@@ -1163,6 +1185,7 @@ void pg_pool_t::decode(bufferlist::iterator& bl)
   ::decode(size, bl);
   ::decode(crush_ruleset, bl);
   ::decode(object_hash, bl);
+  ::decode(balance_param, bl);
   ::decode(pg_num, bl);
   ::decode(pgp_num, bl);
   {
@@ -1284,6 +1307,7 @@ void pg_pool_t::generate_test_instances(list<pg_pool_t*>& o)
   a.size = 2;
   a.crush_ruleset = 3;
   a.object_hash = 4;
+  a.balance_param = 1.0;
   a.pg_num = 6;
   a.pgp_num = 5;
   a.last_change = 9;
@@ -1336,6 +1360,7 @@ ostream& operator<<(ostream& out, const pg_pool_t& p)
       << " min_size " << p.get_min_size()
       << " crush_ruleset " << p.get_crush_ruleset()
       << " object_hash " << p.get_object_hash_name()
+      << " balance_param " << p.get_balance_param()
       << " pg_num " << p.get_pg_num()
       << " pgp_num " << p.get_pgp_num()
       << " last_change " << p.get_last_change();

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -895,6 +895,7 @@ struct pg_pool_t {
   __u8 size, min_size;      ///< number of osds in each pg
   __u8 crush_ruleset;       ///< crush placement rule set
   __u8 object_hash;         ///< hash mapping object name to ps
+  float balance_param;
 private:
   __u32 pg_num, pgp_num;    ///< number of pgs
 
@@ -982,7 +983,7 @@ public:
 
   pg_pool_t()
     : flags(0), type(0), size(0), min_size(0),
-      crush_ruleset(0), object_hash(0),
+      crush_ruleset(0), object_hash(0), balance_param(1),
       pg_num(0), pgp_num(0),
       last_change(0),
       last_force_op_resend(0),
@@ -1029,6 +1030,7 @@ public:
   unsigned get_min_size() const { return min_size; }
   int get_crush_ruleset() const { return crush_ruleset; }
   int get_object_hash() const { return object_hash; }
+  float get_balance_param() const { return balance_param; }
   const char *get_object_hash_name() const {
     return ceph_str_hash_name(get_object_hash());
   }
@@ -1067,6 +1069,8 @@ public:
 
   unsigned get_pg_num_mask() const { return pg_num_mask; }
   unsigned get_pgp_num_mask() const { return pgp_num_mask; }
+
+  void set_balance_param(float b) { balance_param = b; }
 
   // if pg_num is not a multiple of two, pgs are not equally sized.
   // return, for a given pg, the fraction (denominator) of the total
@@ -1143,6 +1147,7 @@ public:
    * seeds.
    */
   ps_t raw_pg_to_pps(pg_t pg) const;
+  ps_t raw_pg_to_congruential_pps(pg_t pg) const;
 
   /// choose a random hash position within a pg
   uint32_t get_random_pg_position(pg_t pgid, uint32_t seed) const;

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -91,7 +91,7 @@ void usage()
   cout << "                         specify output for for (de)compilation\n";
   cout << "   --build --num_osds N layer1 ...\n";
   cout << "                         build a new map, where each 'layer' is\n";
-  cout << "                           'name (uniform|straw|list|tree) size'\n";
+  cout << "                           'name (uniform|straw|list|tree|linear) size'\n";
   cout << "   -i mapfn --test       test a range of inputs on the map\n";
   cout << "      [--min-x x] [--max-x x] [--x x]\n";
   cout << "      [--min-rule r] [--max-rule r] [--rule r]\n";
@@ -148,6 +148,7 @@ struct bucket_types_t {
   { "list", CRUSH_BUCKET_LIST },
   { "straw", CRUSH_BUCKET_STRAW },
   { "tree", CRUSH_BUCKET_TREE },
+  { "linear", CRUSH_BUCKET_LINEAR },
   { 0, 0 },
 };
 


### PR DESCRIPTION
We met an issue of read performance issues (17% degradation) when working on ceph object storage performance evaluation, and found the root cause is unbalanced pg distribution among all osd disks, due to current CRUSH algorithm. We decided to do some optimization on it.

At first, we add a new pps hash algorithm based on the "congruential pseudo-random number generator", which hashes the original raw pgid sequence to some permutation of it. It can produce a uniform pps key space as input for CRUSH.
Then we introduce a new bucket type called "linear", and apply a new modulo based hash algorithm to it, with a balance parameter to adjust for the best distribution uniformity.
At last, we make it an adaptive procedure by adjusting the balance parameter automatically during the preparation for creating a new pool, according to different cluster topology, PG# and replica#, in order to gain a most uniform distribution.

Signed-off-by: yujiehe yujie.he@intel.com
