### PR TITLE
formatter: clean up dump_format()

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -80,6 +80,33 @@ new_formatter(const std::string &type)
     else
       return (Formatter *)NULL;
 }
+
+void Formatter::dump_format(const char *name, const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  dump_format_va(name, NULL, true, fmt, ap);
+  va_end(ap);
+}
+
+void Formatter:: dump_format_ns(const char *name, const char *ns, const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  dump_format_va(name, ns, true, fmt, ap);
+  va_end(ap);
+
+}
+
+
+void Formatter::dump_format_unquoted(const char *name, const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  dump_format_va(name, NULL, false, fmt, ap);
+  va_end(ap);
+}
+
 // -----------------------
 JSONFormatter::JSONFormatter(bool p)
   : m_pretty(p), m_is_pending_string(false)
@@ -243,43 +270,17 @@ std::ostream& JSONFormatter::dump_stream(const char *name)
   return m_pending_string;
 }
 
-void JSONFormatter::dump_format(const char *name, const char *fmt, ...)
+void JSONFormatter::dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
-  va_list ap;
-  va_start(ap, fmt);
   vsnprintf(buf, LARGE_SIZE, fmt, ap);
-  va_end(ap);
 
   print_name(name);
-  print_quoted_string(buf);
-}
-
-void JSONFormatter:: dump_format_ns(const char *name, const char *ns, const char *fmt, ...)
-{
-  // ignore the namespace for now
-  char buf[LARGE_SIZE];
-  va_list ap;
-  va_start(ap, fmt);
-  vsnprintf(buf, LARGE_SIZE, fmt, ap);
-  va_end(ap);
-
-  print_name(name);
-  print_quoted_string(buf);
-
-}
-
-
-void JSONFormatter::dump_format_unquoted(const char *name, const char *fmt, ...)
-{
-  char buf[LARGE_SIZE];
-  va_list ap;
-  va_start(ap, fmt);
-  vsnprintf(buf, LARGE_SIZE, fmt, ap);
-  va_end(ap);
-
-  print_name(name);
-  m_ss << buf;
+  if (quoted) {
+    print_quoted_string(buf);
+  } else {
+    m_ss << buf;
+  }
 }
 
 int JSONFormatter::get_len() const
@@ -417,52 +418,19 @@ std::ostream& XMLFormatter::dump_stream(const char *name)
   return m_pending_string;
 }
 
-void XMLFormatter::dump_format(const char *name, const char *fmt, ...)
+void XMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
-  va_list ap;
-  va_start(ap, fmt);
   vsnprintf(buf, LARGE_SIZE, fmt, ap);
-  va_end(ap);
-
-  std::string e(name);
-  print_spaces();
-  m_ss << "<" << e << ">" << escape_xml_str(buf) << "</" << e << ">";
-  if (m_pretty)
-    m_ss << "\n";
-}
-
-void XMLFormatter::dump_format_ns(const char* name, const char *ns, const char *fmt, ...)
-{
-  char buf[LARGE_SIZE];
-  va_list ap;
-  va_start(ap, fmt);
-  vsnprintf(buf, LARGE_SIZE, fmt, ap);
-  va_end(ap);
 
   std::string e(name);
   print_spaces();
   if (ns) {
     m_ss << "<" << e  << " xmlns=\"" << ns << "\">" << buf << "</" << e << ">";
   } else {
-    m_ss << "<" << e << ">" << buf << "</" << e << ">";
+    m_ss << "<" << e << ">" << escape_xml_str(buf) << "</" << e << ">";
   }
 
-  if (m_pretty)
-    m_ss << "\n";
-}
-
-void XMLFormatter::dump_format_unquoted(const char *name, const char *fmt, ...)
-{
-  char buf[LARGE_SIZE];
-  va_list ap;
-  va_start(ap, fmt);
-  vsnprintf(buf, LARGE_SIZE, fmt, ap);
-  va_end(ap);
-
-  std::string e(name);
-  print_spaces();
-  m_ss << "<" << e << ">" << buf << "</" << e << ">";
   if (m_pretty)
     m_ss << "\n";
 }

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -48,9 +48,10 @@ class Formatter {
     dump_format_unquoted(name, "%s", (b ? "true" : "false"));
   }
   virtual std::ostream& dump_stream(const char *name) = 0;
-  virtual void dump_format(const char *name, const char *fmt, ...) = 0;
-  virtual void dump_format_ns(const char *name, const char *ns, const char *fmt, ...) = 0;
-  virtual void dump_format_unquoted(const char *name, const char *fmt, ...) = 0;
+  virtual void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) = 0;
+  virtual void dump_format(const char *name, const char *fmt, ...);
+  virtual void dump_format_ns(const char *name, const char *ns, const char *fmt, ...);
+  virtual void dump_format_unquoted(const char *name, const char *fmt, ...);
   virtual int get_len() const = 0;
   virtual void write_raw_data(const char *data) = 0;
 
@@ -84,9 +85,7 @@ class JSONFormatter : public Formatter {
   void dump_float(const char *name, double d);
   void dump_string(const char *name, std::string s);
   std::ostream& dump_stream(const char *name);
-  void dump_format(const char *name, const char *fmt, ...);
-  void dump_format_unquoted(const char *name, const char *fmt, ...);
-  void dump_format_ns(const char*name, const char *ns, const char *fmt, ...);
+  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap);
   int get_len() const;
   void write_raw_data(const char *data);
 
@@ -126,9 +125,7 @@ class XMLFormatter : public Formatter {
   void dump_float(const char *name, double d);
   void dump_string(const char *name, std::string s);
   std::ostream& dump_stream(const char *name);
-  void dump_format(const char *name, const char *fmt, ...);
-  void dump_format_ns(const char *name, const char *ns, const char *fmt, ...);
-  void dump_format_unquoted(const char *name, const char *fmt, ...);
+  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap);
   int get_len() const;
   void write_raw_data(const char *data);
 

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -121,10 +121,9 @@ std::ostream& RGWFormatter_Plain::dump_stream(const char *name)
   assert(0);
 }
 
-void RGWFormatter_Plain::dump_format(const char *name, const char *fmt, ...)
+void RGWFormatter_Plain::dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
-  va_list ap;
   const char *format;
 
   struct plain_stack_entry& entry = stack.back();
@@ -139,39 +138,7 @@ void RGWFormatter_Plain::dump_format(const char *name, const char *fmt, ...)
   if (!should_print)
     return;
 
-  va_start(ap, fmt);
   vsnprintf(buf, LARGE_SIZE, fmt, ap);
-  va_end(ap);
-  if (len)
-    format = "\n%s";
-  else
-    format = "%s";
-
-  write_data(format, buf);
-}
-
-void RGWFormatter_Plain::dump_format_ns(const char *name, const char *fmt, const char *ns, ...)
-{
-  // ignore the namespace for now
-  char buf[LARGE_SIZE];
-  va_list ap;
-  const char *format;
-
-  struct plain_stack_entry& entry = stack.back();
-
-  if (!min_stack_level)
-    min_stack_level = stack.size();
-
-  bool should_print = (stack.size() == min_stack_level && !entry.size);
-
-  entry.size++;
-
-  if (!should_print)
-    return;
-
-  va_start(ap, fmt);
-  vsnprintf(buf, LARGE_SIZE, fmt, ap);
-  va_end(ap);
   if (len)
     format = "\n%s";
   else

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -38,11 +38,7 @@ public:
   virtual void dump_float(const char *name, double d);
   virtual void dump_string(const char *name, std::string s);
   virtual std::ostream& dump_stream(const char *name);
-  virtual void dump_format(const char *name, const char *fmt, ...);
-  virtual void dump_format_unquoted(const char *name, const char *fmt, ...) {
-    assert(0 == "not implemented");
-  }
-  virtual void dump_format_ns(const char *name, const char *ns, const char *fmt, ...);
+  virtual void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap);
   virtual int get_len() const;
   virtual void write_raw_data(const char *data);
 


### PR DESCRIPTION
Create a common dump_format_va() function, and make all the different
variants call it.

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
