### PR TITLE
doc: Add a contributing file at the root of repo

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,10 @@
+For the general process of submitting patches to ceph, read the below
+
+`Submitting Patches`_
+
+For documentation patches the the following guide will help you get started
+
+`Documenting Ceph`_
+
+.. _Submitting Patches: SubmittingPatches
+.. _Documenting Ceph:  doc/start/documenting-ceph.rst


### PR DESCRIPTION
Github shows up a `guidelines for contributing` while opening a new pull
request for any repository with a CONTRIBUTING file at the repo
root, which allows for a quick overview to contribute to the
repository.

Currently this file just links to the Submitting Patches and the
documentation start guide.

Signed-off-by: Abhishek Lekshmanan abhishek.lekshmanan@gmail.com
