### PR TITLE
correct error of repeatedly adding io_size to off in do_bench_write

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -924,7 +924,7 @@ static int do_bench_write(librbd::Image& image, uint64_t io_size,
 
   printf("  SEC       OPS   OPS/SEC   BYTES/SEC\n");
   uint64_t off;
-  for (off = 0; off < io_bytes; off += io_size) {
+  for (off = 0; off < io_bytes; ) {
     b.wait_for(io_threads - 1);
     i = 0;
     while (i < io_threads && off < io_bytes &&


### PR DESCRIPTION
In do_bench_write(), when we successfully start an io("b.start_write"), we already add io_size to off, so there's no need to add io_size to off again before next loop starts.
Signed-off-by: jiangheng jiangheng0511@gmail.com
