### PR TITLE
Change CrushWrapper::crush to private

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -52,16 +52,15 @@ using namespace std;
 class CrushWrapper {
   mutable Mutex mapper_lock;
 public:
-  struct crush_map *crush;
   std::map<int32_t, string> type_map; /* bucket/device type names */
   std::map<int32_t, string> name_map; /* bucket/device names */
   std::map<int32_t, string> rule_name_map;
 
+private:
+  struct crush_map *crush;
   /* reverse maps */
   bool have_rmaps;
   std::map<string, int> type_rmap, name_rmap, rule_name_rmap;
-
-private:
   void build_rmaps() {
     if (have_rmaps) return;
     build_rmap(type_map, type_rmap);

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -581,10 +581,8 @@ int main(int argc, const char **argv)
 	  dout(2) << "  item " << items[j] << " weight " << weights[j] << dendl;
 	}
 
-	crush_bucket *b = crush_make_bucket(buckettype, CRUSH_HASH_DEFAULT, type, j, items, weights);
-	assert(b);
 	int id;
-	int r = crush_add_bucket(crush.crush, 0, b, &id);
+	int r = crush.add_bucket(0, buckettype, CRUSH_HASH_DEFAULT, type, j, items, weights, &id);
 	if (r < 0) {
 	  dout(2) << "Couldn't add bucket: " << cpp_strerror(r) << dendl;
 	}


### PR DESCRIPTION
Currently in CrushWrapper, the member "struct crush_map *crush"  is a public member,
so people can break the encapsulation and manipulate directly to the crush structure.

This is not a good practice for encapsulation and will lead to inconsistent if code
mix use the CrushWrapper API and crush C API.A simple example could be:
1.some code use crush_add_rule(C-API) to add a rule, which will not set the have_rmap flag to false in CrushWrapper
2.another code using CrushWrapper trying to look up the newly added rule by name will get a -ENOENT.

This patch move CrushWrapper::crush to private, together with three reverse map(type_rmap, name_rmap, rule_name_rmap)
and also change codes accessing the CrushWrapper::crush to make it compile.

Signed-off-by: Xiaoxi Chen xiaoxi.chen@intel.com
