### PR TITLE
Use a rolling average to compute RBD write throughput

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -29,6 +29,9 @@
 #include "include/compat.h"
 #include "common/blkdev.h"
 
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/rolling_sum.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <errno.h>
 #include <iostream>
@@ -922,6 +925,20 @@ static int do_bench_write(librbd::Image& image, uint64_t io_size,
     thread_offset.push_back(start_pos);
   }
 
+  const int WINDOW_SIZE = 5;
+  typedef boost::accumulators::accumulator_set<
+    double, boost::accumulators::stats<
+      boost::accumulators::tag::rolling_sum> > RollingSum;
+
+  RollingSum time_acc(
+    boost::accumulators::tag::rolling_window::window_size = WINDOW_SIZE);
+  RollingSum ios_acc(
+    boost::accumulators::tag::rolling_window::window_size = WINDOW_SIZE);
+  RollingSum off_acc(
+    boost::accumulators::tag::rolling_window::window_size = WINDOW_SIZE);
+  uint64_t cur_ios = 0;
+  uint64_t cur_off = 0;
+
   printf("  SEC       OPS   OPS/SEC   BYTES/SEC\n");
   uint64_t off;
   for (off = 0; off < io_bytes; ) {
@@ -932,6 +949,9 @@ static int do_bench_write(librbd::Image& image, uint64_t io_size,
       ++i;
       ++ios;
       off += io_size;
+
+      ++cur_ios;
+      cur_off += io_size;
 
       if (pattern == "rand") {
         thread_offset[i] = (rand() % (size / io_size)) * io_size;
@@ -944,12 +964,21 @@ static int do_bench_write(librbd::Image& image, uint64_t io_size,
 
     utime_t now = ceph_clock_now(NULL);
     utime_t elapsed = now - start;
-    if (elapsed.sec() != last.sec()) {
+    if (last.is_zero()) {
+      last = elapsed;
+    } else if (elapsed.sec() != last.sec()) {
+      time_acc(elapsed - last);
+      ios_acc(static_cast<double>(cur_ios));
+      off_acc(static_cast<double>(cur_off));
+      cur_ios = 0;
+      cur_off = 0;
+
+      double time_sum = boost::accumulators::rolling_sum(time_acc);
       printf("%5d  %8d  %8.2lf  %8.2lf\n",
-	     (int)elapsed,
-	     (int)(ios - io_threads),
-	     (double)(ios - io_threads) / elapsed,
-	     (double)(off - io_threads * io_size) / elapsed);
+             (int)elapsed,
+             (int)(ios - io_threads),
+             boost::accumulators::rolling_sum(ios_acc) / time_sum,
+             boost::accumulators::rolling_sum(off_acc) / time_sum);
       last = elapsed;
     }
   }


### PR DESCRIPTION
Replace the cumulative average with a rolling average
to better expose variations within IOS/sec and bytes/sec.

Signed-off-by: Jason Dillaman dillaman@redhat.com
