### PR TITLE
rbd should use write-back when caching is enabled

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -2192,6 +2192,8 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     }
   }
 
+  g_conf->set_val_or_die("rbd_cache_writethrough_until_flush", "false");
+
   /* get defaults from rbd_default_* options to keep behavior consistent with
      manual short-form options */
   if (!format_specified)


### PR DESCRIPTION
librbd now defaults to write-through until the first flush
is received.  For rbd, force the use of write-through.

Signed-off-by: Jason Dillaman dillaman@redhat.com
