### PR TITLE
PG::init: clear rollback info for backfill as well

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2418,6 +2418,11 @@ void PG::init(
     dout(10) << __func__ << ": Setting backfill" << dendl;
     info.last_backfill = hobject_t();
     info.last_complete = info.last_update;
+
+    PGLogEntryHandler rollbacker;
+    pg_log_t empty;
+    pg_log.claim_log_and_clear_rollback_info(empty, &rollbacker);
+    rollbacker.apply(this, t);
     pg_log.mark_log_for_rewrite();
   }
 


### PR DESCRIPTION
Otherwise, we won't remove the old rollback objects from a resurrected pg.  In
rare cases, this can cause us to get an EEXIST if we happen to reuse the same
rename id on the same object in a subsequent interval.

Fixes: #9293
Related to: 8346e10755027e982f26bab4642334fd91cc31aa
Backport: firefly
Signed-off-by: Samuel Just sam.just@inktank.com
