### PR TITLE
osdc/Objecter: drop bad session nref assert

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1317,7 +1317,6 @@ void Objecter::close_session(OSDSession *s)
 
   osd_sessions.erase(s->osd);
   s->lock.unlock();
-  assert(s->get_nref() == 1);  // We reassigned any/all ops, so should be last ref
   put_session(s);
 
   // Assign any leftover ops to the homeless session


### PR DESCRIPTION
This is a bad assert.  Specifically, handle_osd_op_reply may still be holding
the session ref while it is calling the completion for a previous request. 
This is safe: it is only holding the session ref after it dropped the global
map rwlock because of the per-session completion locks.  The request in
question was already marked completed by the time our thread took the session
lock.

Fixes: #9241 Signed-off-by: Sage Weil sage@redhat.com
