### PR TITLE
osd: set min_read_recency_for_promote to default 1 when doing upgrade

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1263,8 +1263,7 @@ void pg_pool_t::decode(bufferlist::iterator& bl)
   if (struct_v >= 16) {
     ::decode(min_read_recency_for_promote, bl);
   } else {
-    pg_pool_t def;
-    min_read_recency_for_promote = def.min_read_recency_for_promote;
+    min_read_recency_for_promote = 1;
   }
   if (struct_v >= 17) {
     ::decode(expected_num_objects, bl);


### PR DESCRIPTION
When upgrading from a build without the promotion on 2nd read feature,
should set min_read_recency_for_promote to the default value 1, instead
of 0.

Signed-off-by: Zhiqiang Wang wonzhq@hotmail.com
