### PR TITLE
[rgw][s3] Allow colon ':' in access key

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2120,7 +2120,7 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
     if (strncmp(s->http_auth, "AWS ", 4))
       return -EINVAL;
     string auth_str(s->http_auth + 4);
-    int pos = auth_str.find(':');
+    int pos = auth_str.rfind(':');
     if (pos < 0)
       return -EINVAL;
 


### PR DESCRIPTION
Not sure about AWS, but Swift allows ':' in S3 access key:
[swift/tempauth.py](https://github.com/openstack/swift/blob/fa023eb2d66291e05703bdefa960ab0ad440d5a9/swift/common/middleware/tempauth.py#L278)
[swift3/request.py](https://github.com/stackforge/swift3/blob/4ca802310c4bb063cdcc4b9e78b9876d57c9b579/swift3/request.py#L132)
[keystonemiddleware/s3_token.py](https://github.com/openstack/keystonemiddleware/blob/5556599b5750d1839aee39c5e39e22ef93d9ca3a/keystonemiddleware/s3_token.py#L193)
