### PR TITLE
mds: fix replay locking

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -1045,7 +1045,9 @@ void MDLog::_replay_thread()
       le->_segment->end = journaler->get_read_pos();
       num_events++;
 
+      mds->mds_lock.Lock();
       le->replay(mds);
+      mds->mds_lock.Unlock();
     }
     delete le;
 


### PR DESCRIPTION
When replaying EImportFinish/EFragment event, the replay thread may call
MDS::queue_waiters. MDS::queue_waiters() requires its caller to hold the
mds_lock. Otherwise assert(waiter_mutex == __null || waiter_mutex->is_locked())
in Cond::Signal() will be tiggered.

Signed-off-by: Yan, Zheng zyan@redhat.com
