### PR TITLE
FileStore: report l_os_j_lat as commit latency

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -130,7 +130,7 @@ void FileStore::FSPerfTracker::update_from_perfcounters(
 {
   os_commit_latency.consume_next(
     logger.get_tavg_ms(
-      l_os_commit_lat));
+      l_os_j_lat));
   os_apply_latency.consume_next(
     logger.get_tavg_ms(
       l_os_apply_lat));


### PR DESCRIPTION
l_os_commit_lat is actually the commit cycle latency.

Fixes: #9269
Backport: firefly
Signed-off-by: Samuel Just sam.just@inktank.com
