### PR TITLE
erasure-code: Remove the unnecessary code.

### DIFF
--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -66,10 +66,9 @@ int ErasureCode::encode_prepare(const bufferlist &raw,
     pad.zero();
     prepared->push_back(pad);
   }
-  unsigned coding_length = blocksize * m;
-  bufferptr coding(buffer::create_page_aligned(coding_length));
+
+  bufferptr coding(blocksize * m);
   prepared->push_back(coding);
-  prepared->rebuild_page_aligned();
   return 0;
 }
 


### PR DESCRIPTION
Although do erasure-encode need align memory, the rebuild_page_aligned
and create_page_aligned  don't this function. Really in func encode_chunks,
it make the encode data memory address aligned.

Signed-off-by: Ma Jianpeng jianpeng.ma@intel.com
