### PR TITLE
mds: update segment references during journal rewrite

### DIFF
--- a/src/mds/LogSegment.h
+++ b/src/mds/LogSegment.h
@@ -33,9 +33,11 @@ class CDentry;
 class MDS;
 struct MDSlaveUpdate;
 
+typedef uint64_t log_segment_seq_t;
+
 class LogSegment {
  public:
-  const uint64_t seq;
+  const log_segment_seq_t seq;
   uint64_t offset, end;
   int num_events;
 

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -220,7 +220,7 @@ public:
     return segments.rbegin()->second;
   }
 
-  LogSegment *get_segment(uint64_t seq) {
+  LogSegment *get_segment(log_segment_seq_t seq) {
     if (segments.count(seq))
       return segments[seq];
     return NULL;

--- a/src/mds/MDS.h
+++ b/src/mds/MDS.h
@@ -345,7 +345,7 @@ private:
   void handle_signal(int signum);
 
   // who am i etc
-  int get_nodeid() { return whoami; }
+  int get_nodeid() const { return whoami; }
   uint64_t get_metadata_pool() { return mdsmap->get_metadata_pool(); }
   MDSMap *get_mds_map() { return mdsmap; }
 

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -20,6 +20,7 @@
 #include "../CInode.h"
 #include "../CDir.h"
 #include "../CDentry.h"
+#include "../LogSegment.h"
 
 #include "include/triple.h"
 #include "include/interval_set.h"
@@ -305,7 +306,7 @@ private:
 
   // inodes i've truncated
   list<inodeno_t> truncate_start;        // start truncate 
-  map<inodeno_t,uint64_t> truncate_finish;  // finished truncate (started in segment blah)
+  map<inodeno_t, log_segment_seq_t> truncate_finish;  // finished truncate (started in segment blah)
 
 public:
   vector<inodeno_t> destroyed_inodes;
@@ -374,6 +375,8 @@ private:
   void add_truncate_finish(inodeno_t ino, uint64_t segoff) {
     truncate_finish[ino] = segoff;
   }
+  
+  bool rewrite_truncate_finish(MDS const *mds, std::map<uint64_t, uint64_t> const &old_to_new);
 
   void add_destroyed_inode(inodeno_t ino) {
     destroyed_inodes.push_back(ino);


### PR DESCRIPTION
... to avoid leaving log events that reference log
segments by offsets which no longer exist.

Signed-off-by: John Spray john.spray@redhat.com
