### PR TITLE
RADOS: add a 'locator' interface via a new class 'RadosLocator' 

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -30,7 +30,7 @@ namespace librados
   struct ObjListCtx;
   struct PoolAsyncCompletionImpl;
   class RadosClient;
-  class RadosLocator;
+  class RadosWhereis;
 
   typedef void *list_ctx_t;
   typedef uint64_t auid_t;
@@ -65,20 +65,23 @@ namespace librados
   typedef void (*callback_t)(completion_t cb, void *arg);
 
 
-  struct Location {
+  struct whereis {
     // -------------------------------------------------------------------------
     int64_t OsdID; //< ID of the OSD hosting this object
+    std::string OsdState; //< state of the OSD hosting this object - either 'active' or 'inactive'
     int64_t PgSeed; //< Seed of the PG hosting this object
     std::string IpString; //< Ip as string
-    std::string HostName; //< optional reverse DNS HostName for Ip
+    std::vector<std::string> HostNames; //< optional reverse DNS HostNames for Ip
+    std::map <std::string,std::string> UserMap; //< optional user KV map
     // -------------------------------------------------------------------------
-    void resolve(); //< try to reverse DNS an OSD IP and store in HostName
+    void resolve(); //< try to reverse DNS an OSD IP and store in HostNames
     // -------------------------------------------------------------------------
-    std::string dump(bool showhost=false) const;
+    void dump(bool reversedns=false, void* formatter=NULL) const;
   };
 
-  typedef struct Location location_t;
-  typedef std::vector<location_t>  location_vector_t;
+  typedef struct whereis whereis_t;
+
+  typedef std::vector<whereis_t>  whereis_vector_t;
 
 
   class ObjectIterator : public std::iterator <std::forward_iterator_tag, std::string> {
@@ -892,7 +895,7 @@ namespace librados
 
     friend class Rados; // Only Rados can use our private constructor to create IoCtxes.
     friend class libradosstriper::RadosStriper; // Striper needs to see our IoCtxImpl
-    friend class librados::RadosLocator; // Locator needs to see our IoCtxImpl
+    friend class librados::RadosWhereis; // Whereis class needs to see our IoCtxImpl
     friend class ObjectWriteOperation;  // copy_from needs to see our IoCtxImpl
 
     IoCtxImpl *io_ctx_impl;
@@ -953,9 +956,9 @@ namespace librados
     int cluster_stat(cluster_stat_t& result);
     int cluster_fsid(std::string *fsid);
 
-    /* locating objects */
-    static bool locate(IoCtx &ioctx, const std::string &oid, location_vector_t &locations);
-    static std::string dump_location(location_t &location, bool reversedns=false);
+    /* whereis of objects */
+    static bool whereis(IoCtx &ioctx, const std::string &oid, whereis_vector_t &locations);
+    static std::string dump_whereis(whereis_t &location, bool reversedns=false, void* formatter=NULL);
 
     /// get/wait for the most recent osdmap
     int wait_for_latest_osdmap();

--- a/src/librados/Makefile.am
+++ b/src/librados/Makefile.am
@@ -4,7 +4,7 @@ librados_la_SOURCES = \
 	librados/IoCtxImpl.cc \
 	librados/snap_set_diff.cc \
 	librados/RadosXattrIter.cc \
-        librados/RadosLocator.cc
+        librados/RadosWhereis.cc
 
 # We need this to avoid basename conflicts with the librados build tests in test/Makefile.am
 librados_la_CXXFLAGS = ${AM_CXXFLAGS}
@@ -28,5 +28,5 @@ noinst_HEADERS += \
 	librados/PoolAsyncCompletionImpl.h \
 	librados/RadosClient.h \
 	librados/RadosXattrIter.h \
-        librados/RadosLocator.h
+        librados/RadosWhereis.h
 

--- a/src/librados/RadosWhereis.h
+++ b/src/librados/RadosWhereis.h
@@ -11,13 +11,13 @@
  * Foundation.  See file COPYING.
  *
  */
-#ifndef CEPH_LIBRADOS_RADOSLOCATOR_H
-#define CEPH_LIBRADOS_RADOSLOCATOR_H
+#ifndef CEPH_LIBRADOS_RADOSWHEREIS_H
+#define CEPH_LIBRADOS_RADOSWHEREIS_H
 
 #include <stdio.h>
 
 /**
- * @file RadosLocator.h
+ * @file RadosWhereis.h
  *
  * @brief Class providing a function to retrieve a vector of locations
  *
@@ -28,21 +28,21 @@
 
 namespace librados {
 class IoCtx;
-class RadosLocator {
+class RadosWhereis {
 public:
 
-  RadosLocator(IoCtx &_io) : io(_io)
+  RadosWhereis(IoCtx &_io) : io(_io)
   {
   };
 
   virtual
-  ~RadosLocator()
+  ~RadosWhereis()
   {
   };
 
   bool
-  locate(const std::string &oio,
-         location_vector_t &locations
+  whereis(const std::string &oio,
+         whereis_vector_t &locations
          );
 
 private:


### PR DESCRIPTION
.... to lookup OSD IPs (optional Hostnames) storing a given object name. Requirement is to provide a public API to location information to deploy an authenticating overlay server network on top of OSDs with redirection to object primary locations.

The functionality is for convenience also exported as a RADOS shell command:

```
[root@XXX src]# ./rados -p mypool locate /123
osd-id=0050 pg-seed=0450 ip=111.142.21.46
osd-id=0079 pg-seed=0450 ip=111.142.21.44
osd-id=0148 pg-seed=0450 ip=111.142.21.81

[root@XXX src]# ./rados --dns -p mypool locate /123
osd-id=0050 pg-seed=0450 ip=111.142.21.46 hostname=p051.fake.ch
osd-id=0079 pg-seed=0450 ip=111.142.21.44 hostname=p052.fake.ch
osd-id=0148 pg-seed=0450 ip=111.142.21.81 hostname=p053.fake.ch
```

The API adds two functions to librados (the implementation is in librados::RadosLocator)

```
librados::Rados::locate(...)
librados::Rados::dump_location(...);
```

Currently these are not wrapped in the C api. Please give feedback if the structure is not good since the structure of librados  is not so straight forward either ...

Remark: the hostname translation is very rudimentary. It tries to use 'dig' if available, otherwise hostnames stay as unresolved. I wanted to avoid any third-party library dependency since the host names are only for convenience in the shell output if required.
