### PR TITLE
mds: fix root and mdsdir inodes' rsubdirs

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -349,6 +349,7 @@ void MDCache::create_empty_hierarchy(C_Gather *gather)
 
   root->inode.dirstat = rootdir->fnode.fragstat;
   root->inode.rstat = rootdir->fnode.rstat;
+  ++root->inode.rstat.rsubdirs;
   root->inode.accounted_rstat = root->inode.rstat;
 
   rootdir->mark_complete();
@@ -399,6 +400,7 @@ void MDCache::create_mydir_hierarchy(C_Gather *gather)
 
   myin->inode.dirstat = mydir->fnode.fragstat;
   myin->inode.rstat = mydir->fnode.rstat;
+  ++myin->inode.rstat.rsubdirs;
   myin->inode.accounted_rstat = myin->inode.rstat;
 
 


### PR DESCRIPTION
inode rstat accounts inode itself.

Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
(cherry picked from commit da17394941386dab88ddbfed4af2c8cb6b5eb72f)
