### PR TITLE
doc: osd_backfill_scan_(min|max) are object counts

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -399,16 +399,15 @@ priority than requests to read or write data.
 
 ``osd backfill scan min`` 
 
-:Description: The scan interval in seconds for backfill operations when cluster 
-              load is low.
+:Description: The minimum number of objects per backfill scan.
+
 :Type: 32-bit Integer
 :Default: ``64`` 
 
 
 ``osd backfill scan max`` 
 
-:Description: The maximum scan interval in seconds for backfill operations 
-              irrespective of cluster load.
+:Description: The maximum number of objects per backfill scan.
 
 :Type: 32-bit Integer
 :Default: ``512`` 


### PR DESCRIPTION
Current doc is either very wrong or I am very confused.
