### PR TITLE
rbd: ObjectCacher reads can hang when reading sparse files

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -709,6 +709,9 @@ void ObjectCacher::bh_read_finish(int64_t poolid, sobject_t oid, ceph_tid_t tid,
       }
     }
 
+    ls.splice(ls.end(), waitfor_read);
+    waitfor_read.clear();
+
     // apply to bh's!
     loff_t opos = start;
     while (true) {
@@ -762,9 +765,6 @@ void ObjectCacher::bh_read_finish(int64_t poolid, sobject_t oid, ceph_tid_t tid,
 
       loff_t oldpos = opos;
       opos = bh->end();
-
-      ls.splice(ls.end(), waitfor_read);
-      waitfor_read.clear();
 
       if (r == -ENOENT) {
 	if (trust_enoent) {


### PR DESCRIPTION
The pending read list was not properly flushed when empty objects
were read from a space file.

Signed-off-by: Jason Dillaman dillaman@redhat.com
(cherry picked from commit cdb7675a21c9107e3596c90c2b1598def3c6899f)
