### PR TITLE
ceph-disk: mount xfs with inode64 by default

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -89,7 +89,7 @@ MOUNT_OPTIONS = dict(
     # issues with ext4 before the xatts-in-leveldb work, and it seemed
     # that user_xattr helped
     ext4='noatime,user_xattr',
-    xfs='noatime',
+    xfs='noatime,inode64',
     )
 
 MKFS_ARGS = dict(


### PR DESCRIPTION
We did this forever ago with mkcephfs, but ceph-disk didn't.  Note that for 
modern XFS this option is obsolete, but for older kernels it was not the 
default.

Backport: firefly Signed-off-by: Sage Weil sage@redhat.com
