### PR TITLE
osdc/Objecter: cancel timeout before clearing op->session

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3875,14 +3875,15 @@ void Objecter::_finish_command(CommandOp *c, int r, string rs)
   if (c->onfinish)
     c->onfinish->complete(r);
 
+  if (c->ontimeout) {
+    timer.cancel_event(c->ontimeout);
+  }
+
   OSDSession *s = c->session;
   s->lock.get_write();
   _session_command_op_remove(c->session, c);
   s->lock.unlock();
 
-  if (c->ontimeout) {
-    timer.cancel_event(c->ontimeout);
-  }
   c->put();
 
   logger->dec(l_osdc_command_active);


### PR DESCRIPTION
The C_CancelOp path assumes op->session != NULL.  Cancel that op before we
clear it.  This fixes a crash like

../nptl/sysdeps/unix/sysv/linux/x86_64/pthread_rwlock_wrlock.S:39
out>) at ./common/RWLock.h:88
r=-110) at osdc/Objecter.cc:1850
out>) at ./include/Context.h:64
common/Timer.cc:268
common/Timer.cc:200
pthread_create.c:308

Signed-off-by: Sage Weil sage@redhat.com
