### PR TITLE
wip-9219: subscribe to the newest osdmap when reconnecting to a monitor

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4335,6 +4335,7 @@ void OSD::ms_handle_connect(Connection *con)
       send_pg_stats(ceph_clock_now(cct));
 
       monc->sub_want("osd_pg_creates", 0, CEPH_SUBSCRIBE_ONETIME);
+      monc->sub_want("osdmap", osdmap->get_epoch(), CEPH_SUBSCRIBE_ONETIME);
       monc->renew_subs();
     }
   }


### PR DESCRIPTION
This is mostly relevant in testing clusters, but it ensures that an OSD
disconnecting from the monitor at the wrong time will still see any recent
map updates and prevent accidental loss of map injection into the OSD cluster.
Fixes: #9219

Signed-off-by: Greg Farnum greg@inktank.com

This patch is only compile-tested, but should be suitable for merge.
