### PR TITLE
FileJournal: Refactor function align_bl().

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -927,14 +927,11 @@ int FileJournal::prepare_single_write(bufferlist& bl, off64_t& queue_pos, uint64
 void FileJournal::align_bl(off64_t pos, bufferlist& bl)
 {
   // make sure list segments are page aligned
-  if (directio && (!bl.is_page_aligned() ||
-		   !bl.is_n_page_sized())) {
-    bl.rebuild_page_aligned();
-    if ((bl.length() & ~CEPH_PAGE_MASK) != 0 ||
-	(pos & ~CEPH_PAGE_MASK) != 0)
-      dout(0) << "rebuild_page_aligned failed, " << bl << dendl;
+  if (directio) {
     assert((bl.length() & ~CEPH_PAGE_MASK) == 0);
     assert((pos & ~CEPH_PAGE_MASK) == 0);
+    if (!bl.is_page_aligned() || !bl.is_n_page_sized())
+      bl.rebuild_page_aligned();
   }
 }
 


### PR DESCRIPTION
rebuild_page_aligned() dont' change the size of bufferlist.
We first check the pos and length. Then only for bufferlist don't page
aliged, we call rebuild_page_aligned.

Signed-off-by: Ma Jianpeng jianpeng.ma@intel.com
