### PR TITLE
mds: fix not journaling client metadata

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -236,7 +236,7 @@ void Server::handle_client_session(MClientSession *m)
     sseq = mds->sessionmap.set_state(session, Session::STATE_OPENING);
     mds->sessionmap.touch_session(session);
     pv = ++mds->sessionmap.projected;
-    mdlog->start_submit_entry(new ESession(m->get_source_inst(), true, pv),
+    mdlog->start_submit_entry(new ESession(m->get_source_inst(), true, pv, m->client_meta),
 			      new C_MDS_session_finish(mds, session, sseq, true, pv));
     mdlog->flush();
     break;

--- a/src/mds/events/ESession.h
+++ b/src/mds/events/ESession.h
@@ -29,14 +29,19 @@ class ESession : public LogEvent {
   interval_set<inodeno_t> inos;
   version_t inotablev;
 
+  // Client metadata stored during open
+  std::map<std::string, std::string> client_metadata;
+
  public:
   ESession() : LogEvent(EVENT_SESSION), open(false) { }
-  ESession(const entity_inst_t& inst, bool o, version_t v) :
+  ESession(const entity_inst_t& inst, bool o, version_t v,
+      const std::map<std::string, std::string> &cm) :
     LogEvent(EVENT_SESSION),
     client_inst(inst),
     open(o),
     cmapv(v),
-    inotablev(0) {
+    inotablev(0),
+    client_metadata(cm) {
   }
   ESession(const entity_inst_t& inst, bool o, version_t v,
 	   const interval_set<inodeno_t>& i, version_t iv) :

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -620,6 +620,11 @@ void session_info_t::dump(Formatter *f) const
     f->close_section();
   }
   f->close_section();
+
+  for (map<string, string>::const_iterator i = client_metadata.begin();
+      i != client_metadata.end(); ++i) {
+    f->dump_string(i->first.c_str(), i->second);
+  }
 }
 
 void session_info_t::generate_test_instances(list<session_info_t*>& ls)


### PR DESCRIPTION
Previously the code was there for storing in
the SessionMap table, but not for the ESession
logevent.

Fixes: #9518

Signed-off-by: John Spray john.spray@redhat.com
