### PR TITLE
PGLog::claim_log_and_clear_rollback_info: fix rollback_info_trimmed_to

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -88,8 +88,8 @@ struct PGLog {
       assert(rollback_info_trimmed_to_riter == log.rbegin());
 
       log = o.log;
-      rollback_info_trimmed_to = head;
       head = o.head;
+      rollback_info_trimmed_to = head;
       tail = o.tail;
       index();
     }


### PR DESCRIPTION
We have been setting it to the old head value.  This is usually
harmless since the new head will virtually always be ahead of the
old head for claim_log_and_clear_rollback_info, but can cause trouble
in some edge cases.

Fixes: #9481
Backport: firefly
Signed-off-by: Samuel Just sam.just@inktank.com
