### PR TITLE
PG::find_best_info: let history.last_epoch_started provide a lower bound

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -867,6 +867,10 @@ map<pg_shard_t, pg_info_t>::const_iterator PG::find_best_info(
   for (map<pg_shard_t, pg_info_t>::const_iterator i = infos.begin();
        i != infos.end();
        ++i) {
+    if (max_last_epoch_started_found < i->second.history.last_epoch_started) {
+      min_last_update_acceptable = eversion_t::max();
+      max_last_epoch_started_found = i->second.history.last_epoch_started;
+    }
     if (max_last_epoch_started_found < i->second.last_epoch_started) {
       min_last_update_acceptable = eversion_t::max();
       max_last_epoch_started_found = i->second.last_epoch_started;
@@ -876,7 +880,8 @@ map<pg_shard_t, pg_info_t>::const_iterator PG::find_best_info(
 	min_last_update_acceptable = i->second.last_update;
     }
   }
-  assert(min_last_update_acceptable != eversion_t::max());
+  if (min_last_update_acceptable == eversion_t::max())
+    return infos.end();
 
   map<pg_shard_t, pg_info_t>::const_iterator best = infos.end();
   // find osd with newest last_update (oldest for ec_pool).


### PR DESCRIPTION
If we find a info.history.last_epoch_started above any
info.last_epoch_started, we must be missing updates and
min_last_update_acceptable should provisionally be max().

Fixes: #9482
Backport: firefly
Signed-off-by: Samuel Just sam.just@inktank.com
