### PR TITLE
pybind: aio_read not escaping \0, binary-unsafe

### DIFF
--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -1085,8 +1085,11 @@ class Ioctx(object):
         :returns: completion object
         """
         buf = create_string_buffer(length)
-        def oncomplete_(completion):
-            return oncomplete(completion, buf.value)
+        def oncomplete_(completion_v):
+            return_value = completion_v.get_return_value()
+            return oncomplete(completion_v,
+                              ctypes.string_at(buf, return_value) if return_value >= 0 else None)
+
         completion = self.__get_completion(oncomplete_, None)
         ret = run_in_thread(self.librados.rados_aio_read,
                             (self.io, c_char_p(object_name),


### PR DESCRIPTION
Ioctx.aio_read() discards any part of a read chunk after a NUL.

This patch exists (existed?) on a [refactoring](http://tracker.ceph.com/projects/ceph/repository/revisions/31b6c4d061c5534428bbe7842aedea114fe7a2d9) [branch](https://github.com/ceph/ceph/commit/31b6c4d061c5534428bbe7842aedea114fe7a2d9) `wip-pybind-fixes`, but I consider
this a **serious** bug, which may eat your data if faultily read data is trusted; and thus would propose it's singular inclusion, not wating on a refactoring to happen or not.
(Luckily my use-case was compressed files and I caught on real quick when they couldn't be decompressed.)

I would propose this patch to be merged by itself, and possibly backported to older python-rados versions.
