### PR TITLE
Cleanup boost optionals for boost 1.56

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -81,7 +81,7 @@ ostream &operator<<(ostream &lhs, const ECBackend::read_result_t &rhs)
   lhs << "read_result_t(r=" << rhs.r
       << ", errors=" << rhs.errors;
   if (rhs.attrs) {
-    lhs << ", attrs=" << rhs.attrs;
+    lhs << ", attrs=" << rhs.attrs.get();
   } else {
     lhs << ", noattrs";
   }

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -5259,7 +5259,10 @@ void ReplicatedPG::do_osd_op_effects(OpContext *ctx)
   for (list<OpContext::NotifyAck>::iterator p = ctx->notify_acks.begin();
        p != ctx->notify_acks.end();
        ++p) {
-    dout(10) << "notify_ack " << make_pair(p->watch_cookie, p->notify_id) << dendl;
+    if (p->watch_cookie)
+      dout(10) << "notify_ack " << make_pair(p->watch_cookie.get(), p->notify_id) << dendl;
+    else
+      dout(10) << "notify_ack " << make_pair("NULL", p->notify_id) << dendl;
     for (map<pair<uint64_t, entity_name_t>, WatchRef>::iterator i =
 	   ctx->obc->watchers.begin();
 	 i != ctx->obc->watchers.end();


### PR DESCRIPTION
Cleans up errors with boost 1.56 such as

```
building ceph_filestore_dump
  CXXLD  ceph_filestore_dump
./.libs/libosd.a(libosd_la-ReplicatedPG.o): In function `operator<< <boost::optional<long unsigned int>, long unsigned int>':
/tmp/nix-build-ceph-0.85.drv-0/ceph-0.85/src/./include/types.h:91: undefined reference to `std::basic_ostream<char, std::char_traits<char> >& boost::operator<< <char, std::char_traits<char>, unsigned long>(std::basic_ostream<char, std::char_traits<char> >&, boost::optional<unsigned long> const&)'
./.libs/libosd.a(libosd_la-ECBackend.o): In function `operator<<(std::ostream&, ECBackend::read_result_t const&)':
/tmp/nix-build-ceph-0.85.drv-0/ceph-0.85/src/osd/ECBackend.cc:84: undefined reference to `std::basic_ostream<char, std::char_traits<char> >& boost::operator<< <char, std::char_traits<char>, std::map<std::string, ceph::buffer::list, std::less<std::string>, std::allocator<std::pair<std::string const, ceph::buffer::list> > > >(std::basic_ostream<char, std::char_traits<char> >&, boost::optional<std::map<std::string, ceph::buffer::list, std::less<std::string>, std::allocator<std::pair<std::string const, ceph::buffer::list> > > > const&)'
collect2: error: ld returned 1 exit status
make[3]: *** [ceph_filestore_dump] Error 1
make[3]: Leaving directory `/tmp/nix-build-ceph-0.85.drv-0/ceph-0.85/src'
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory `/tmp/nix-build-ceph-0.85.drv-0/ceph-0.85/src'
make[1]: *** [all] Error 2
```

This builds fine for me with ceph 0.85 and boost 1.56
