### PR TITLE
os/FileJournal: do not request sync while shutting down

### DIFF
--- a/src/os/FileJournal.h
+++ b/src/os/FileJournal.h
@@ -405,7 +405,7 @@ private:
   void commit_start(uint64_t seq);
   void committed_thru(uint64_t seq);
   bool should_commit_now() {
-    return full_state != FULL_NOTFULL;
+    return full_state != FULL_NOTFULL && !write_stop;
   }
 
   void set_wait_on_full(bool b) { wait_on_full = b; }


### PR DESCRIPTION
FileStore calls should_commit_now() to determine whether it should
loop and do a second sync (among other things).  During shutdown, this
can force us into a livelock: the journal is shutting down, but the
sync_entry loop never completes and repeatedly syncs because the
journal is full.  Since the journal is otherwise stopped, no expire
happens and we never become unfull, and we're stuck.

This seems to be triggered semi-reliably by the ceph_objectstore_tool
import function.

Fix by not requesting a sync while shutting down.

Fixes: #9545
Signed-off-by: Sage Weil sage@redhat.com
