### PR TITLE
ceph-mon: check fs stats just before preforking

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -305,27 +305,6 @@ int main(int argc, const char **argv)
     usage();
   }
 
-  {
-    // check fs stats. don't start if it's critically close to full.
-    ceph_data_stats_t stats;
-    int err = get_fs_stats(stats, g_conf->mon_data.c_str());
-    if (err < 0) {
-      cerr << "error checking monitor data's fs stats: " << cpp_strerror(err)
-           << std::endl;
-      exit(-err);
-    }
-    if (stats.avail_percent <= g_conf->mon_data_avail_crit) {
-      cerr << "error: monitor data filesystem reached concerning levels of"
-           << " available storage space (available: "
-           << stats.avail_percent << "% " << prettybyte_t(stats.byte_avail)
-           << ")\nyou may adjust 'mon data avail crit' to a lower value"
-           << " to make this go away (default: " << g_conf->mon_data_avail_crit
-           << "%)\n" << std::endl;
-      exit(ENOSPC);
-    }
-  }
-
-
   // -- mkfs --
   if (mkfs) {
 
@@ -488,6 +467,26 @@ int main(int argc, const char **argv)
     cerr << "error accessing '" << g_conf->mon_data << "': "
          << cpp_strerror(-err) << std::endl;
     exit(1);
+  }
+
+  {
+    // check fs stats. don't start if it's critically close to full.
+    ceph_data_stats_t stats;
+    int err = get_fs_stats(stats, g_conf->mon_data.c_str());
+    if (err < 0) {
+      cerr << "error checking monitor data's fs stats: " << cpp_strerror(err)
+           << std::endl;
+      exit(-err);
+    }
+    if (stats.avail_percent <= g_conf->mon_data_avail_crit) {
+      cerr << "error: monitor data filesystem reached concerning levels of"
+           << " available storage space (available: "
+           << stats.avail_percent << "% " << prettybyte_t(stats.byte_avail)
+           << ")\nyou may adjust 'mon data avail crit' to a lower value"
+           << " to make this go away (default: " << g_conf->mon_data_avail_crit
+           << "%)\n" << std::endl;
+      exit(ENOSPC);
+    }
   }
 
   // we fork early to prevent leveldb's environment static state from


### PR DESCRIPTION
Otherwise statfs may fail if mkfs hasn't been run yet or if the monitor
data directory does not exist.  There are checks to account for the mon
data dir not existing and we should wait for them to clear before we go
ahead and check the fs stats.

Signed-off-by: Joao Eduardo Luis joao@redhat.com
