### PR TITLE
msg: allow calling dtor immediately after ctor

### DIFF
--- a/src/msg/SimpleMessenger.cc
+++ b/src/msg/SimpleMessenger.cc
@@ -65,7 +65,7 @@ SimpleMessenger::~SimpleMessenger()
 {
   assert(!did_bind); // either we didn't bind or we shut down the Accepter
   assert(rank_pipe.empty()); // we don't have any running Pipes.
-  assert(reaper_stop && !reaper_started); // the reaper thread is stopped
+  assert(!reaper_started); // the reaper thread is stopped
 }
 
 void SimpleMessenger::ready()


### PR DESCRIPTION
Asserting on reaper_stop only made sense if the
messenger had ever been started: as it stood,
one couldn't create and destroy a messenger
without also starting and stopping it.

Signed-off-by: John Spray john.spray@redhat.com
