### PR TITLE
ceph-disk: add Scientific Linux as a Redhat clone

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1075,7 +1075,7 @@ def prepare_journal_dev(
         # On RHEL and CentOS distros, calling partprobe forces a reboot of the
         # server. Since we are not resizing partitons so we rely on calling
         # partx
-        if platform_distro().startswith(('centos', 'red')):
+        if platform_distro().startswith(('centos', 'red', 'scientific')):
             LOG.info('calling partx on prepared device %s', journal)
             LOG.info('re-reading known partitions will display errors')
             command(
@@ -1508,7 +1508,7 @@ def main_prepare(args):
             # On RHEL and CentOS distros, calling partprobe forces a reboot of
             # the server. Since we are not resizing partitons so we rely on
             # calling partx
-            if platform_distro().startswith(('centos', 'red')):
+            if platform_distro().startswith(('centos', 'red', 'scientific')):
                 LOG.info('calling partx on prepared device %s', args.data)
                 LOG.info('re-reading known partitions will display errors')
 


### PR DESCRIPTION
Scientific Linux is a RHEL clone and needs to use partx.

Would appreciate a backport to dumpling, firefly, and giant.

FYI, facter lists many more RHEL variants:

https://github.com/puppetlabs/facter/blob/master/lib/facter/operatingsystem/linux.rb
