### PR TITLE
crush: backport newer get_full_location

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -241,6 +241,8 @@ map<string, string> CrushWrapper::get_full_location(int id)
 
 int CrushWrapper::get_full_location_ordered(int id, vector<pair<string, string> >& path)
 {
+  if (!item_exists(id))
+    return -ENOENT;
   int cur = id;
   int ret;
   while (true) {


### PR DESCRIPTION
The old implematnion could get stuck in a loop in some cases; see
bug #7648
