### PR TITLE
Clock: Using clock_gettime instead of gettimeofday in linux os.

### DIFF
--- a/src/common/Clock.cc
+++ b/src/common/Clock.cc
@@ -22,9 +22,15 @@
 
 utime_t ceph_clock_now(CephContext *cct)
 {
+#if defined(__linux__)
+  struct timespec tp;
+  clock_gettime(CLOCK_REALTIME, &tp);
+  utime_t n(tp);
+#else
   struct timeval tv;
   gettimeofday(&tv, NULL);
   utime_t n(&tv);
+#endif
   if (cct)
     n += cct->_conf->clock_offset;
   return n;

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -50,6 +50,11 @@ public:
   utime_t(const struct ceph_timespec &v) {
     decode_timeval(&v);
   }
+  utime_t(const struct timespec v)
+  {
+    tv.tv_sec = v.tv_sec;
+    tv.tv_nsec = v.tv_nsec;
+  }
   utime_t(const struct timeval &v) {
     set_from_timeval(&v);
   }


### PR DESCRIPTION
The precision of utime_t is nsec. In func ceph_clock_now, it use
gettimeofday to set utime_t. But the precision of gettimeofday is
microseconds. In linux, the precision of clock_gettime is nsec.
So using clock_gettime install gettimeofday in order to get higer
precision.

Signed-off-by: Jianpeng Ma jianpeng.ma@intel.com
