### PR TITLE
For CRUSH rule using indep algorithm, it should also check if the acting set contains CRUSH_ITEM_NONE or not to determine PG state.

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1665,7 +1665,7 @@ void PG::activate(ObjectStore::Transaction& t,
     }
 
     // degraded?
-    if (get_osdmap()->get_pg_size(info.pgid.pgid) > acting.size()) {
+    if (get_osdmap()->get_pg_size(info.pgid.pgid) > actingset.size()) {
       state_set(PG_STATE_DEGRADED);
       state_set(PG_STATE_UNDERSIZED);
     }
@@ -1915,8 +1915,8 @@ unsigned PG::get_backfill_priority()
 
   // undersized: 200 + num missing replicas
   if (is_undersized()) {
-    assert(pool.info.size > acting.size());
-    return 200 + (pool.info.size - acting.size());
+    assert(pool.info.size > actingset.size());
+    return 200 + (pool.info.size - actingset.size());
   }
 
   // degraded: baseline degraded
@@ -6107,8 +6107,10 @@ PG::RecoveryState::Recovered::Recovered(my_context ctx)
   // DEGRADED | UNDERSIZED is appropriate.
   assert(!pg->actingbackfill.empty());
   if (pg->get_osdmap()->get_pg_size(pg->info.pgid.pgid) <=
-      pg->actingbackfill.size())
+      pg->actingbackfill.size()) {
     pg->state_clear(PG_STATE_DEGRADED);
+    pg->state_clear(PG_STATE_UNDERSIZED);
+  }
 
   // adjust acting set?  (e.g. because backfill completed...)
   if (pg->acting != pg->up && !pg->choose_acting(auth_log_shard))
@@ -6219,8 +6221,7 @@ boost::statechart::result PG::RecoveryState::Active::react(const AdvMap& advmap)
   for (vector<int>::iterator p = pg->want_acting.begin();
        p != pg->want_acting.end(); ++p) {
     if (!advmap.osdmap->is_up(*p)) {
-      assert((std::find(pg->acting.begin(), pg->acting.end(), *p) !=
-	      pg->acting.end()) ||
+      assert(pg->is_acting(*p) ||
 	     (std::find(pg->up.begin(), pg->up.end(), *p) !=
 	      pg->up.end()));
     }
@@ -6230,7 +6231,7 @@ boost::statechart::result PG::RecoveryState::Active::react(const AdvMap& advmap)
    * this does not matter) */
   if (advmap.lastmap->get_pg_size(pg->info.pgid.pgid) !=
       pg->get_osdmap()->get_pg_size(pg->info.pgid.pgid)) {
-    if (pg->get_osdmap()->get_pg_size(pg->info.pgid.pgid) <= pg->acting.size()) {
+    if (pg->get_osdmap()->get_pg_size(pg->info.pgid.pgid) <= pg->actingset.size()) {
       pg->state_clear(PG_STATE_UNDERSIZED);
       if (pg->needs_recovery()) {
 	pg->state_set(PG_STATE_DEGRADED);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -766,6 +766,16 @@ public:
       return std::find(acting.begin(), acting.end(), osd.osd) != acting.end();
     }
   }
+  bool is_acting(int osd) {
+    for (set<pg_shard_t>::const_iterator it = actingset.begin();
+        it != actingset.end();
+        ++it) {
+      if (it->osd == osd) {
+        return true;
+      }
+    }
+    return false;
+  }
   bool is_up(pg_shard_t osd) const {
     if (pool.info.ec_pool()) {
       return up.size() > osd.shard && up[osd.shard] == osd.osd;


### PR DESCRIPTION
Fixes: 9614

Signed-off-by: Guang Yang (yguang@yahoo-inc.com)
