### PR TITLE
osd: do not bind ms_objecter messenger

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -453,8 +453,6 @@ int main(int argc, const char **argv)
   if (r < 0)
     exit(1);
 
-  ms_objecter->bind(g_conf->public_addr);
-
   // Set up crypto, daemonize, etc.
   global_init_daemonize(g_ceph_context, 0);
   common_init_finish(g_ceph_context);


### PR DESCRIPTION
The objecter messenger is only used as a client to initiate client-side 
connections to other OSDs.  It doesn't need to bind to a port.

This was added in 558d9fc956204b7a18001b148e171b893cb63d85 to push client 
traffic to the cluster interface.  This doesn't actually help/work because we
are still connecting to our peers' client-facing addresses.

Signed-off-by: Sage Weil sage@redhat.com
