### PR TITLE
Pipe: avoid redundancy new/delete for struct iovec

### DIFF
--- a/src/msg/Pipe.cc
+++ b/src/msg/Pipe.cc
@@ -2192,7 +2192,6 @@ int Pipe::write_message(ceph_msg_header& header, ceph_msg_footer& footer, buffer
   // set up msghdr and iovecs
   struct msghdr msg;
   memset(&msg, 0, sizeof(msg));
-  struct iovec *msgvec = new iovec[3 + blist.buffers().size()];  // conservative upper bound
   msg.msg_iov = msgvec;
   int msglen = 0;
   
@@ -2297,7 +2296,6 @@ int Pipe::write_message(ceph_msg_header& header, ceph_msg_footer& footer, buffer
   ret = 0;
 
  out:
-  delete[] msgvec;
   return ret;
 
  fail:

--- a/src/msg/Pipe.h
+++ b/src/msg/Pipe.h
@@ -173,6 +173,8 @@ class DispatchQueue;
 
   private:
     int sd;
+    struct iovec msgvec[IOV_MAX];
+
   public:
     int port;
     int peer_type;


### PR DESCRIPTION
Signed-off-by: Haomai Wang haomaiwang@gmail.com
