### PR TITLE
mon: fix JSON `fs ls` output

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -791,6 +791,7 @@ bool MDSMonitor::preprocess_command(MMonCommand *m)
                 f->dump_int("data_pool_id", *dpi);
               }
             }
+            f->close_section();
 
             f->open_array_section("data_pools");
             {


### PR DESCRIPTION
A missing list terminator was causing unparseable output.

Signed-off-by: John Spray john.spray@redhat.com
