### PR TITLE
rgw: swift GET / HEAD object returns X-Timestamp field

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -566,6 +566,7 @@ int RGWGetObj_ObjStore_SWIFT::send_response_data(bufferlist& bl, off_t bl_ofs, o
 
   dump_content_length(s, total_len);
   dump_last_modified(s, lastmod);
+  s->cio->print("X-Timestamp: %lld\r\n", (long long)lastmod);
 
   if (!ret) {
     map<string, bufferlist>::iterator iter = attrs.find(RGW_ATTR_ETAG);


### PR DESCRIPTION
Fixes: #8911
Backport: giant, firefly, dumpling
Swift clients expect X-Timestamp header, dump it.

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
