### PR TITLE
os/FileStore: do not loop in sync_entry on shutdown

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -3533,7 +3533,7 @@ void FileStore::sync_entry()
       dout(10) << "sync_entry more waiters, committing again" << dendl;
       goto again;
     }
-    if (journal && journal->should_commit_now()) {
+    if (!stop && journal && journal->should_commit_now()) {
       dout(10) << "sync_entry journal says we should commit again (probably is/was full)" << dendl;
       goto again;
     }


### PR DESCRIPTION
Normally we repeat a sync if the journal is full and asks for it or if we 
have pending sync waiters.  This isn't for correctness: it's to move things 
along quickly.

If we are shutting down _and_ the journal is full, however, we currently can
get stuck in a loop where we repeatedly sync.  However, the journal never
gets unfull because we aren't expiring anything.

We tried to fix this in 682b9daacb1960eb60b5f0e9b40d4a3a3e9afd5b but that 
didn't work because we don't tell the journal to stop before we shut down the
filestore sync thread.

I'm pretty sure there is another issue in the journal code as

 full_state == FULL_FULL
submit_manager.op_seq = 14761
apply_manager.committing_seq = 14761
apply_manager.committed_seq = 14761

which seems odd.  But I have no longs.  Meanwhile, this fixes the hang.

Fixes: #9545 Signed-off-by: Sage Weil sage@redhat.com
