### PR TITLE
DNM: osdc/Objecter: use SafeTimer; make callbacks race-tolerant

### DIFF
--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1035,7 +1035,8 @@ private:
   version_t last_seen_pgmap_version;
 
   RWLock rwlock;
-  RWTimer timer;
+  Mutex timer_lock;
+  SafeTimer timer;
 
   PerfCounters *logger;
   
@@ -1602,7 +1603,8 @@ public:
     last_seen_osdmap_version(0),
     last_seen_pgmap_version(0),
     rwlock("Objecter::rwlock"),
-    timer(cct, rwlock),
+    timer_lock("Objecter::timer_lock"),
+    timer(cct, timer_lock, false),
     logger(NULL), tick_event(NULL),
     m_request_state_hook(NULL),
     num_homeless_ops(0),


### PR DESCRIPTION
The RWTimer event cancellation is racy.  Instead, just make all of our 
callbacks tolerate cancellation races.  This is already true of most of them
(in fact, they are probably broken because they try to take a write lock
while holding a read lock).  Fix C_CancelOp so that it calls the other
op_cancel (that takes a tid).

Then switch the RWTimer back to a SafeTimer.  Put it in unsafe callbacks mode
because we don't want to introduce lock cycles with timer_lock.

Fixes: #9582 See also: #9650 Signed-off-by: Sage Weil sage@redhat.com
