### PR TITLE
rgw: copy object data if target bucket is in a different pool

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3313,7 +3313,7 @@ set_err_state:
     return ret;
   }
 
-  bool copy_data = !astate->has_manifest;
+  bool copy_data = !astate->has_manifest || (src_obj.bucket.data_pool != dest_obj.bucket.data_pool);
   bool copy_first = false;
   if (astate->has_manifest) {
     if (!astate->manifest.has_tail()) {


### PR DESCRIPTION
Fixes: #9039
Backport: firefly

The new manifest does not provide a way to put the head and the tail in
separate pools. In any case, if an object is copied between buckets in
different pools, we may really just want the object to be copied, rather
than reference counted.

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
(cherry picked from commit 5d3a7e595f47455896304bf358e5251915d0f16f)
