### PR TITLE
client: clean-up objecter on failed client init

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -364,6 +364,7 @@ int Client::init()
   int r = monclient->init();
   if (r < 0) {
     // need to do cleanup because we're in an intermediate init state
+    objecter->shutdown();
     timer.shutdown();
     client_lock.Unlock();
     objectcacher->stop();


### PR DESCRIPTION
During mount() the objecter isn't shutdown if the mon client fails to
initialize. Objecter asserts in destructor expect it to have been
shutdown but this skipped.

hadoop@plana85:~$ ./hadoop/bin/hadoop fs -ls /
14/10/05 12:35:50 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
osdc/Objecter.cc: In function 'virtual Objecter::~Objecter()' thread 7ff422705700 time 2014-10-05 12:35:51.090776
osdc/Objecter.cc: 3927: FAILED assert(!m_request_state_hook)
 ceph version 0.85-981-g25bcc39 (25bcc39bb809e2d13beea1529e4ab92d1b61fa5b)
 1: (ceph::__ceph_assert_fail(char const_, char const_, int, char const*)+0x7f) [0x7ff3f5c28f7f]
 2: (Objecter::~Objecter()+0x397) [0x7ff3f5bca707]
 3: (Objecter::~Objecter()+0x9) [0x7ff3f5bca8b9]
 4: (Client::~Client()+0x7d) [0x7ff3f5b6770d]
 5: (Client::~Client()+0x9) [0x7ff3f5b680a9]
 6: (ceph_mount_info::mount(std::string const&)+0x149) [0x7ff3f5b1fa49]
 7: (ceph_mount()+0x4e) [0x7ff3f5b1dcbe]
 8: (Java_com_ceph_fs_CephMount_native_1ceph_1mount()+0xb7) [0x7ff4158b1c97]
 9: [0x7ff41839dd68]
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is needed to interpret this.
terminate called after throwing an instance of 'ceph::FailedAssertion'
Aborted

fixes: #9663

Signed-off-by: Noah Watkins noahwatkins@gmail.com
