### PR TITLE
mon: PGMonitor: populate scrub timestamps with 'now' on pg creation

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -983,6 +983,11 @@ void PGMonitor::register_pg(pg_pool_t& pool, pg_t pgid, epoch_t epoch, bool new_
   stats.parent = parent;
   stats.parent_split_bits = split_bits;
 
+  utime_t now = ceph_clock_now(g_ceph_context);
+  stats.last_scrub_stamp = now;
+  stats.last_deep_scrub_stamp = now;
+  stats.last_clean_scrub_stamp = now;
+
   if (split_bits == 0) {
     dout(10) << "register_new_pgs  will create " << pgid << dendl;
   } else {


### PR DESCRIPTION
Fixes: #9496
