### PR TITLE
Cache ObjectContexts across OSDOps

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -604,6 +604,8 @@ OPTION(osd_target_transaction_size, OPT_INT, 30)     // to adjust various transa
 OPTION(osd_failsafe_full_ratio, OPT_FLOAT, .97) // what % full makes an OSD "full" (failsafe)
 OPTION(osd_failsafe_nearfull_ratio, OPT_FLOAT, .90) // what % full makes an OSD near full (failsafe)
 
+OPTION(osd_pg_object_context_cache_count, OPT_INT, 64)
+
 // determines whether PGLog::check() compares written out log to stored log
 OPTION(osd_debug_pg_log_writeout, OPT_BOOL, false)
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2142,6 +2142,9 @@ void OSD::create_logger()
   osd_plb.add_u64_counter(l_osd_agent_flush, "agent_flush");
   osd_plb.add_u64_counter(l_osd_agent_evict, "agent_evict");
 
+  osd_plb.add_u64_counter(l_osd_object_ctx_cache_hit, "object_ctx_cache_hit");
+  osd_plb.add_u64_counter(l_osd_object_ctx_cache_total, "object_ctx_cache_total");
+
   logger = osd_plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
 }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -141,6 +141,9 @@ enum {
   l_osd_agent_flush,
   l_osd_agent_evict,
 
+  l_osd_object_ctx_cache_hit,
+  l_osd_object_ctx_cache_total,
+
   l_osd_last,
 };
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -9865,9 +9865,11 @@ void ReplicatedPG::on_change(ObjectStore::Transaction *t)
     hit_set_clear();
   }
 
+  // we don't trust the object_contexts cache anymore
+  object_contexts.clear();
+
   // requeue everything in the reverse order they should be
   // reexamined.
-
   clear_scrub_reserved();
   scrub_clear_state();
 
@@ -9955,9 +9957,6 @@ void ReplicatedPG::on_pool_change()
   }
   hit_set_setup();
   agent_setup();
-  if (get_role() !=0) {
-    object_contexts.clear();
-  }
 }
 
 // clear state.  called on recovery completion AND cancellation.

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1232,6 +1232,7 @@ ReplicatedPG::ReplicatedPG(OSDService *o, OSDMapRef curmap,
   pgbackend(
     PGBackend::build_pg_backend(
       _pool.info, curmap, this, coll_t(p), coll_t::make_temp_coll(p), o->store, cct)),
+  object_contexts(o->cct, g_conf->osd_pg_object_context_cache_count),
   snapset_contexts_lock("ReplicatedPG::snapset_contexts"),
   temp_seq(0),
   snap_trimmer_machine(this)
@@ -9951,6 +9952,9 @@ void ReplicatedPG::on_pool_change()
   }
   hit_set_setup();
   agent_setup();
+  if (get_role() !=0) {
+    object_contexts.clear();
+  }
 }
 
 // clear state.  called on recovery completion AND cancellation.

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -7533,10 +7533,13 @@ ObjectContextRef ReplicatedPG::get_object_context(const hobject_t& soid,
       pg_log.get_log().objects.find(soid)->second->op ==
       pg_log_entry_t::LOST_REVERT));
   ObjectContextRef obc = object_contexts.lookup(soid);
+  osd->logger->inc(l_osd_object_ctx_cache_total);
   if (obc) {
+    osd->logger->inc(l_osd_object_ctx_cache_hit);
     dout(10) << __func__ << ": found obc in cache: " << obc
 	     << dendl;
   } else {
+    dout(10) << __func__ << ": obc NOT found in cache: " << soid << dendl;
     // check disk
     bufferlist bv;
     if (attrs) {

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -886,7 +886,7 @@ protected:
   friend struct C_OnPushCommit;
 
   // projected object info
-  SharedPtrRegistry<hobject_t, ObjectContext> object_contexts;
+  SharedLRU<hobject_t, ObjectContext> object_contexts;
   // map from oid.snapdir() to SnapSetContext *
   map<hobject_t, SnapSetContext*> snapset_contexts;
   Mutex snapset_contexts_lock;

--- a/src/test/common/test_shared_cache.cc
+++ b/src/test/common/test_shared_cache.cc
@@ -118,6 +118,23 @@ TEST_F(SharedLRU_all, add) {
     ASSERT_TRUE(existed);
   }
 }
+TEST_F(SharedLRU_all, empty) {
+  SharedLRUTest cache;
+  unsigned int key = 1;
+  int value1 = 2;
+  bool existed = false;
+
+  ASSERT_TRUE(cache.empty());
+  {
+    shared_ptr<int> ptr = cache.add(key, new int(value1), &existed);
+    ASSERT_EQ(value1, *ptr);
+    ASSERT_FALSE(existed);
+  }
+  ASSERT_FALSE(cache.empty());
+
+  cache.clear(key);
+  ASSERT_TRUE(cache.empty());
+}
 
 TEST_F(SharedLRU_all, lookup) {
   SharedLRUTest cache;
@@ -129,6 +146,23 @@ TEST_F(SharedLRU_all, lookup) {
     ASSERT_EQ(value, *cache.lookup(key));
   }
   ASSERT_TRUE(cache.lookup(key));
+}
+TEST_F(SharedLRU_all, lookup_or_create) {
+  SharedLRUTest cache;
+  {
+    int value = 2;
+    unsigned int key = 1;
+    ASSERT_TRUE(cache.add(key, new int(value)));
+    ASSERT_TRUE(cache.lookup_or_create(key));
+    ASSERT_EQ(value, *cache.lookup(key));
+  }
+  {
+    unsigned int key = 2;
+    ASSERT_TRUE(cache.lookup_or_create(key));
+    ASSERT_EQ(0, *cache.lookup(key));
+  }
+  ASSERT_TRUE(cache.lookup(1));
+  ASSERT_TRUE(cache.lookup(2));
 }
 
 TEST_F(SharedLRU_all, wait_lookup) {
@@ -148,6 +182,32 @@ TEST_F(SharedLRU_all, wait_lookup) {
   EXPECT_EQ(value, *t.ptr);
   // waiting on a key does not block lookups on other keys
   EXPECT_FALSE(cache.lookup(key + 12345));
+  {
+    Mutex::Locker l(cache.get_lock());
+    cache.get_weak_refs().erase(key);
+    cache.get_cond().Signal();
+  }
+  ASSERT_TRUE(wait_for(cache, 0));
+  t.join();
+  EXPECT_FALSE(t.ptr);
+}
+TEST_F(SharedLRU_all, wait_lookup_or_create) {
+  SharedLRUTest cache;
+  unsigned int key = 1;
+  int value = 2;
+
+  {
+    shared_ptr<int> ptr(new int);
+    cache.get_weak_refs()[key] = make_pair(ptr, &*ptr);
+  }
+  EXPECT_FALSE(cache.get_weak_refs()[key].first.lock());
+
+  Thread_wait t(cache, key, value, Thread_wait::LOOKUP);
+  t.create();
+  ASSERT_TRUE(wait_for(cache, 1));
+  EXPECT_EQ(value, *t.ptr);
+  // waiting on a key does not block lookups on other keys
+  EXPECT_TRUE(cache.lookup_or_create(key + 12345));
   {
     Mutex::Locker l(cache.get_lock());
     cache.get_weak_refs().erase(key);
@@ -202,6 +262,57 @@ TEST_F(SharedLRU_all, wait_lower_bound) {
   t.join();
   EXPECT_TRUE(t.ptr);
 }
+TEST_F(SharedLRU_all, get_next) {
+
+  {
+    SharedLRUTest cache;
+    const unsigned int key = 0;
+    pair<unsigned int, int> i;
+    EXPECT_FALSE(cache.get_next(key, &i));
+  }
+  {
+    SharedLRUTest cache;
+
+    const unsigned int key2 = 333;
+    shared_ptr<int> ptr2 = cache.lookup_or_create(key2);
+    const int value2 = *ptr2 = 400;
+
+    // entries with expired pointers are silently ignored
+    const unsigned int key_gone = 222;
+    cache.get_weak_refs()[key_gone] = make_pair(shared_ptr<int>(), (int*)0);
+
+    const unsigned int key1 = 111;
+    shared_ptr<int> ptr1 = cache.lookup_or_create(key1);
+    const int value1 = *ptr1 = 800;
+
+    pair<unsigned int, int> i;
+    EXPECT_TRUE(cache.get_next(i.first, &i));
+    EXPECT_EQ(key1, i.first);
+    EXPECT_EQ(value1, i.second);
+
+    EXPECT_TRUE(cache.get_next(i.first, &i));
+    EXPECT_EQ(key2, i.first);
+    EXPECT_EQ(value2, i.second);
+
+    EXPECT_FALSE(cache.get_next(i.first, &i));
+
+    cache.get_weak_refs().clear();
+  }
+  {
+    SharedLRUTest cache;
+    const unsigned int key1 = 111;
+    shared_ptr<int> *ptr1 = new shared_ptr<int>(cache.lookup_or_create(key1));
+    const unsigned int key2 = 222;
+    shared_ptr<int> ptr2 = cache.lookup_or_create(key2);
+
+    pair<unsigned int, shared_ptr<int> > i;
+    EXPECT_TRUE(cache.get_next(i.first, &i));
+    EXPECT_EQ(key1, i.first);
+    delete ptr1;
+    EXPECT_TRUE(cache.get_next(i.first, &i));
+    EXPECT_EQ(key2, i.first);
+  }
+}
 
 TEST_F(SharedLRU_all, clear) {
   SharedLRUTest cache;
@@ -221,6 +332,24 @@ TEST_F(SharedLRU_all, clear) {
   ASSERT_TRUE(cache.lookup(key));
   cache.clear(key);
   ASSERT_FALSE(cache.lookup(key));
+}
+TEST_F(SharedLRU_all, clear_all) {
+  SharedLRUTest cache;
+  unsigned int key = 1;
+  int value = 2;
+  {
+    ceph::shared_ptr<int> ptr = cache.add(key, new int(value));
+    ASSERT_EQ(value, *cache.lookup(key));
+  }
+  ASSERT_TRUE(cache.lookup(key));
+  cache.clear();
+  ASSERT_FALSE(cache.lookup(key));
+
+  ceph::shared_ptr<int> ptr2 = cache.add(key, new int(value));
+  ASSERT_TRUE(cache.lookup(key));
+  cache.clear();
+  ASSERT_TRUE(cache.lookup(key));
+  ASSERT_FALSE(cache.empty());
 }
 
 TEST(SharedCache_all, add) {


### PR DESCRIPTION
ObjectContext is constructed when op begins and destroyed when op finished, it costs about 100us each op.

This patch will cache the ObjectContext in a RandomCache to keep it in memory, and trim the cache when its correspondent object is removed or the cache count reach the osd_object_context_caches_count whose default is 4096.

This patch will reduce nearly 100us for each IO if hit cache.

Signed-off-by: Dong Yuan <yuandong1222@gmail.com>