### PR TITLE
Fix read performance regression in ObjectCacher

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -950,14 +950,14 @@ void ObjectCacher::flush(loff_t amount)
 }
 
 
-void ObjectCacher::trim()
+void ObjectCacher::trim(uint64_t extra_space)
 {
   assert(lock.is_locked());
   ldout(cct, 10) << "trim  start: bytes: max " << max_size << "  clean " << get_stat_clean()
 		 << ", objects: max " << max_objects << " current " << ob_lru.lru_get_size()
 		 << dendl;
 
-  while (get_stat_clean() > 0 && (uint64_t) get_stat_clean() > max_size) {
+  while (get_stat_clean() > 0 && (uint64_t) (get_stat_clean() + get_stat_rx() + extra_space) > max_size) {
     BufferHead *bh = static_cast<BufferHead*>(bh_lru_rest.lru_expire());
     if (!bh)
       break;
@@ -1115,6 +1115,10 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
            ++bh_it) {
         loff_t clean = get_stat_clean() + get_stat_rx() +
                        bh_it->second->length();
+	if (get_stat_rx() > 0 && static_cast<uint64_t>(clean) > max_size) {
+	  trim(bh_it->second->length());
+	}
+	clean = get_stat_clean() + get_stat_rx() + bh_it->second->length();
         if (get_stat_rx() > 0 && static_cast<uint64_t>(clean) > max_size) {
           // cache is full -- wait for rx's to complete
           ldout(cct, 10) << "readx missed, waiting on cache to free "

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -435,7 +435,7 @@ class ObjectCacher {
   void bh_read(BufferHead *bh);
   void bh_write(BufferHead *bh);
 
-  void trim();
+  void trim(uint64_t extra_space = 0);
   void flush(loff_t amount=0);
 
   /**


### PR DESCRIPTION
The regression was introduced in commit 4fc9fffc494abedac0a9b1ce44706343f18466f1.  The problem is that the cache thinks it's full (when it's not), so it defers the read.  This change frees up cache space if necessary and only defers the read if enough space cannot be freed.

Fixes: 9513
Signed-off-by: Adam Crume adamcrume@gmail.com
