### PR TITLE
mds: Locker: fix a NULL deref in _update_cap_fields

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2689,6 +2689,9 @@ static uint64_t calc_bounding(uint64_t t)
   return t + 1;
 }
 
+/**
+ * m and ack might be NULL, so don't dereference them unless dirty != 0
+ */
 void Locker::_do_snap_update(CInode *in, snapid_t snap, int dirty, snapid_t follows, client_t client, MClientCaps *m, MClientCaps *ack)
 {
   dout(10) << "_do_snap_update dirty " << ccap_string(dirty)
@@ -2766,15 +2769,17 @@ void Locker::_do_snap_update(CInode *in, snapid_t snap, int dirty, snapid_t foll
 							   client, NULL, ack));
 }
 
-
+/**
+ * m might be NULL, so don't dereference it unless dirty != 0.
+ */
 void Locker::_update_cap_fields(CInode *in, int dirty, MClientCaps *m, inode_t *pi)
 {
 
   utime_t ctime = m->get_ctime();
-  if (dirty && ctime > pi->ctime) {
-    dout(7) << "  ctime " << pi->ctime << " -> " << ctime
+  if (dirty && m->get_ctime() > pi->ctime) {
+    dout(7) << "  ctime " << pi->ctime << " -> " << m->get_ctime()
 	    << " for " << *in << dendl;
-    pi->ctime = ctime;
+    pi->ctime = m->get_ctime();
   }
 
   // file


### PR DESCRIPTION
The MClientCaps\* is allowed to be NULL, so we can't deref it unless
the dirty param is non-zero. So don't do the ahead-of-time lookup;
just call it explicitly in the if block.

Signed-off-by: Greg Farnum greg@inktank.com
(cherry picked from commit 3cd8a7fb9683577a7d6e934f18c29b7e84415be6)
