### PR TITLE
PG::choose_acting: in mixed cluster case, acting may include backfill

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1293,7 +1293,6 @@ bool PG::choose_acting(pg_shard_t &auth_log_shard_id)
     if (*i != CRUSH_ITEM_NONE)
       ++num_want_acting;
   }
-  assert(want_acting_backfill.size() - want_backfill.size() == num_want_acting);
 
   // This is a bit of a problem, if we allow the pg to go active with
   // want.size() < min_size, we won't consider the pg to have been


### PR DESCRIPTION
Fixes: 9696
Backport: firefly, giant
Introduced: 92cfd370395385ca5537b5bc72220934c9f09026
Signed-off-by: Samuel Just sam.just@inktank.com
