### PR TITLE
Correcting sub module URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,9 @@
-[submodule "ceph-object-corpus"]
-	path = ceph-object-corpus
-	url = git://ceph.com/git/ceph-object-corpus.git
 [submodule "src/libs3"]
 	path = src/libs3
-	url = git://github.com/ceph/libs3.git
+	url = https://github.com/ceph/libs3.git
 [submodule "src/civetweb"]
 	path = src/civetweb
-	url = git://github.com/ceph/civetweb
+	url = https://github.com/ceph/civetweb
 [submodule "src/erasure-code/jerasure/jerasure"]
 	path = src/erasure-code/jerasure/jerasure
 	url = https://github.com/ceph/jerasure.git
@@ -17,4 +14,4 @@
 	branch = v1-ceph
 [submodule "src/rocksdb"]
 	path = src/rocksdb
-	url = git://github.com/ceph/rocksdb
+	url = https://github.com/ceph/rocksdb.git


### PR DESCRIPTION
Fixed the following:-
1. Removed the unused ceph-object-corpus sub module.
2. Updated the CivetWeb sub module URL, it was using incorrect git URL, changed it to use Https URL.
3. Updated the libs3 sub module URL, it was using incorrect git URL, changed it to use Https URL.
4. Updated the rockdb sub module URL, it was using incorrect git URL, changed it to use Https URL. 

This was causing the 'git module update --init' to fail which in fact was called in autogen.sh script. So the documented way of creating development environment was failing.
