### PR TITLE
Fix error message when stripping with format 1

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -421,7 +421,7 @@ static int do_create(librbd::RBD &rbd, librados::IoCtx& io_ctx,
     // weird striping not allowed with format 1!
     if ((stripe_unit || stripe_count) &&
 	(stripe_unit != (1ull << *order) && stripe_count != 1)) {
-      cerr << "non-default striping not allowed with format 1; use --format 2"
+      cerr << "non-default striping not allowed with format 1; use --image-format 2"
 	   << std::endl;
       return -EINVAL;
     }


### PR DESCRIPTION
Since the option '--format' for specifying the rbd image format is
deprecated, we should recommend '--image-format' instead.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
