### PR TITLE
libcephfs.h libcephfs.cc : Defined error codes for the mount function

### DIFF
--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -107,6 +107,11 @@ struct CephContext;
 # define CEPH_SETATTR_CTIME 64
 #endif
 
+/* define error codes for the mount function*/
+# define CEPHFS_ERROR_MON_MAP_BUILD 1000
+# define CEPHFS_ERROR_NEW_CLIENT 1002
+# define CEPHFS_ERROR_MESSENGER_START 1003
+
 /**
  * @defgroup libcephfs_h_init Setup and Teardown
  * These are the first and last functions that should be called

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -72,7 +72,7 @@ public:
 
     //monmap
     monclient = new MonClient(cct);
-    ret = -1000;
+    ret = -CEPHFS_ERROR_MON_MAP_BUILD; //defined in libcephfs.h;
     if (monclient->build_initial_monmap() < 0)
       goto fail;
 
@@ -80,12 +80,12 @@ public:
     messenger = Messenger::create(cct, entity_name_t::CLIENT(), "client", msgr_nonce);
 
     //at last the client
-    ret = -1002;
+    ret = -CEPHFS_ERROR_NEW_CLIENT; //defined in libcephfs.h;
     client = new Client(messenger, monclient);
     if (!client)
       goto fail;
 
-    ret = -1003;
+    ret = -CEPHFS_ERROR_MESSENGER_START; //defined in libcephfs.h;
     if (messenger->start() != 0)
       goto fail;
 


### PR DESCRIPTION
Used new error codes from libcephfs.h to replace the magic numbers in the mount functon found in libcephfs.cc.

Signed-off-by: BJ Lougee almightybeeij@gmail.com
