### PR TITLE
PGLog::IndexedLog::trim(): rollback_info_trimmed_to_riter may be log.ren...

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -101,7 +101,8 @@ void PGLog::IndexedLog::trim(
 
     unindex(e);         // remove from index,
 
-    if (e.version == rollback_info_trimmed_to_riter->version) {
+    if (rollback_info_trimmed_to_riter == log.rend() ||
+	e.version == rollback_info_trimmed_to_riter->version) {
       log.pop_front();
       rollback_info_trimmed_to_riter = log.rend();
     } else {


### PR DESCRIPTION
...d()

Fixes: #9731
Backport: giant, firefly
Signed-off-by: Samuel Just sam.just@inktank.com
