### PR TITLE
Follow-up fix for 9614

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1895,7 +1895,7 @@ void PG::mark_clean()
 {
   // only mark CLEAN if we have the desired number of replicas AND we
   // are not remapped.
-  if (acting.size() == get_osdmap()->get_pg_size(info.pgid.pgid) &&
+  if (actingset.size() == get_osdmap()->get_pg_size(info.pgid.pgid) &&
       up == acting)
     state_set(PG_STATE_CLEAN);
 


### PR DESCRIPTION
The fix for issue 9614 was not completed, as a result, for those erasure coded PGs with one OSD down, the state was wrongly marked as active+clean+degraded. This patch makes sure the clean flag is not set for such PG.

Fixes: 9614

Signed-off-by: Guang Yang yguang@yahoo-inc.com
