### PR TITLE
Update vstart to setup users for s3-tests

### DIFF
--- a/doc/dev/quick_guide.rst
+++ b/doc/dev/quick_guide.rst
@@ -108,9 +108,9 @@ You can now use the swift python client to communicate with the RadosGW.
 
 .. code::
 
-    $ swift -A http://localhost:8080/auth -U tester:testing -K asdf list
-    $ swift -A http://localhost:8080/auth -U tester:testing -K asdf upload mycontainer ceph
-    $ swift -A http://localhost:8080/auth -U tester:testing -K asdf list
+    $ swift -A http://localhost:8000/auth -U tester:testing -K asdf list
+    $ swift -A http://localhost:8000/auth -U tester:testing -K asdf upload mycontainer ceph
+    $ swift -A http://localhost:8000/auth -U tester:testing -K asdf list
 
 
 Run unit tests

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -625,6 +625,22 @@ do_rgw()
     echo "setting up user testid"
     $CEPH_BIN/radosgw-admin user create --uid testid --access-key $akey --secret $skey --display-name 'M. Tester' --email tester@ceph.com -c $conf_fn > /dev/null
 
+    # Create S3-test users
+    # See: https://github.com/ceph/s3-tests
+    echo "setting up s3-test users"
+    $CEPH_BIN/radosgw-admin user create \
+        --uid 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+        --access-key ABCDEFGHIJKLMNOPQRST \
+        --secret abcdefghijklmnopqrstuvwxyzabcdefghijklmn \
+        --display-name youruseridhere \
+        --email s3@example.com -c $conf_fn > /dev/null
+    $CEPH_BIN/radosgw-admin user create \
+        --uid 56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234 \
+        --access-key NOPQRSTUVWXYZABCDEFG \
+        --secret nopqrstuvwxyzabcdefghijklmnabcdefghijklm \
+        --display-name john.doe \
+        --email john.doe@example.com -c $conf_fn > /dev/null
+
     # Create Swift user
     echo "setting up user tester"
     $CEPH_BIN/radosgw-admin user create --subuser=tester:testing --display-name=Tester-Subuser --key-type=swift --secret=asdf > /dev/null


### PR DESCRIPTION
vstart.sh now creates the users for the default configuration
for the s3-tests, available on https://github.com/ceph/s3-tests.

Also updated the documentation to show the correct RadosGW port.

Signed-off-by: Luis Pabón lpabon@redhat.com
