### PR TITLE
rgw: correct "If-Modified-Since" handle.

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4295,7 +4295,7 @@ int RGWRados::prepare_get_obj(void *ctx, rgw_obj& obj,
 
     if (mod_ptr) {
       ldout(cct, 10) << "If-Modified-Since: " << *mod_ptr << " Last-Modified: " << ctime << dendl;
-      if (ctime < *mod_ptr) {
+      if (ctime <= *mod_ptr) {
         r = -ERR_NOT_MODIFIED;
         goto done_err;
       }


### PR DESCRIPTION
Normally client will use `Last-Modified` of server returned, as the
value of `If-Modified-Since`. So the `ctime` is exactly equal to
`*mod_ptr`, and rgw should return `Not Modified`, otherwise the cache
will never worked.

Signed-off-by: VRan Liu gliuwr@gmail.com
