### PR TITLE
Keep osd opwq worker wake for following op

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -499,6 +499,7 @@ OPTION(osd_recovery_threads, OPT_INT, 1)
 OPTION(osd_recover_clone_overlap, OPT_BOOL, true)   // preserve clone_overlap during recovery/migration
 OPTION(osd_op_num_threads_per_shard, OPT_INT, 2)
 OPTION(osd_op_num_shards, OPT_INT, 5)
+OPTION(osd_op_worker_wake_time, OPT_INT, 10 * 1000) //us, zero for sleep at once
 
 // Only use clone_overlap for recovery if there are fewer than
 // osd_recover_clone_overlap_limit entries in the overlap set

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -499,7 +499,7 @@ OPTION(osd_recovery_threads, OPT_INT, 1)
 OPTION(osd_recover_clone_overlap, OPT_BOOL, true)   // preserve clone_overlap during recovery/migration
 OPTION(osd_op_num_threads_per_shard, OPT_INT, 2)
 OPTION(osd_op_num_shards, OPT_INT, 5)
-OPTION(osd_op_worker_wake_time, OPT_INT, 10 * 1000) //us, zero for sleep at once
+OPTION(osd_op_worker_wake_time, OPT_INT, 0) //us, zero for sleep at once
 
 // Only use clone_overlap for recovery if there are fewer than
 // osd_recover_clone_overlap_limit entries in the overlap set

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8363,11 +8363,15 @@ void OSD::ShardedOpWQ::_enqueue(pair<PGRef, OpRequestRef> item) {
   else
     sdata->pqueue.enqueue(item.second->get_req()->get_source_inst(),
       priority, cost, item);
-  sdata->sdata_op_ordering_lock.Unlock();
-
-  sdata->sdata_lock.Lock();
-  sdata->sdata_cond.SignalOne();
-  sdata->sdata_lock.Unlock();
+      
+  if (sdata->has_waiting_thread) {
+    sdata->sdata_op_ordering_lock.Unlock();
+  } else {
+    sdata->sdata_op_ordering_lock.Unlock();
+    sdata->sdata_lock.Lock();
+    sdata->sdata_cond.SignalOne();
+    sdata->sdata_lock.Unlock();
+  }
 
 }
 
@@ -8392,11 +8396,14 @@ void OSD::ShardedOpWQ::_enqueue_front(pair<PGRef, OpRequestRef> item) {
     sdata->pqueue.enqueue_front(item.second->get_req()->get_source_inst(),
       priority, cost, item);
 
-  sdata->sdata_op_ordering_lock.Unlock();
-  sdata->sdata_lock.Lock();
-  sdata->sdata_cond.SignalOne();
-  sdata->sdata_lock.Unlock();
-
+  if (sdata->has_waiting_thread) {
+    sdata->sdata_op_ordering_lock.Unlock();
+  } else {
+    sdata->sdata_op_ordering_lock.Unlock();
+    sdata->sdata_lock.Lock();
+    sdata->sdata_cond.SignalOne();
+    sdata->sdata_lock.Unlock();
+  }
 }
 
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1444,7 +1444,7 @@ private:
           sdata_lock(lock_name.c_str()),
           sdata_op_ordering_lock(ordering_lock.c_str()),
           pqueue(max_tok_per_prio, min_cost),
-	  has_waiting_thread(false) {}
+          has_waiting_thread(false) {}
     };
 
     vector<ShardData*> shard_list;
@@ -1456,7 +1456,7 @@ private:
       ShardedOpWQ(uint32_t pnum_shards, OSD *o, time_t ti, ShardedThreadPool* tp):
         ShardedThreadPool::ShardedWQ < pair <PGRef, OpRequestRef> >(ti, ti*10, tp),
         osd(o), num_shards(pnum_shards),
-	worker_thread_wake_time(0, osd->cct->_conf->osd_op_worker_wake_time * 1000) {
+        worker_thread_wake_time(0, osd->cct->_conf->osd_op_worker_wake_time * 1000) {
         for(uint32_t i = 0; i < num_shards; i++) {
           char lock_name[32] = {0};
           snprintf(lock_name, sizeof(lock_name), "%s.%d", "OSD:ShardedOpWQ:", i);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1439,20 +1439,24 @@ private:
       Mutex sdata_op_ordering_lock;
       map<PG*, list<OpRequestRef> > pg_for_processing;
       PrioritizedQueue< pair<PGRef, OpRequestRef>, entity_inst_t> pqueue;
+      bool has_waiting_thread;
       ShardData(string lock_name, string ordering_lock, uint64_t max_tok_per_prio, uint64_t min_cost):
           sdata_lock(lock_name.c_str()),
           sdata_op_ordering_lock(ordering_lock.c_str()),
-          pqueue(max_tok_per_prio, min_cost) {}
+          pqueue(max_tok_per_prio, min_cost),
+	  has_waiting_thread(false) {}
     };
 
     vector<ShardData*> shard_list;
     OSD *osd;
     uint32_t num_shards;
+    utime_t worker_thread_wake_time;
 
     public:
       ShardedOpWQ(uint32_t pnum_shards, OSD *o, time_t ti, ShardedThreadPool* tp):
         ShardedThreadPool::ShardedWQ < pair <PGRef, OpRequestRef> >(ti, ti*10, tp),
-        osd(o), num_shards(pnum_shards) {
+        osd(o), num_shards(pnum_shards),
+	worker_thread_wake_time(0, osd->cct->_conf->osd_op_worker_wake_time * 1000) {
         for(uint32_t i = 0; i < num_shards; i++) {
           char lock_name[32] = {0};
           snprintf(lock_name, sizeof(lock_name), "%s.%d", "OSD:ShardedOpWQ:", i);


### PR DESCRIPTION
OSD OpWQ worker thread sleep immediately if no op in pgqueue, so the next op must wake up one thread to process. The context switch between threads cost about 100us per IO.

This patch keep one worker process wake for some time (10ms by default) after it finished all the work, so if the following op comes soon enough, there will be no context switch and it will reduce the time cost by OpWQ from 100us to less than 50us.

Here is test result for 4K Object WriteFull, each case tested 3 times and average 10000 operations:

TimeCost(shard_num = 5, thread_per_shard = 2)
*master: 21.2s, 20.5s, 19.4s
*patched: 19.4s, 16.9s, 17.3s
OpWQ latency(shard_num = 5, thread_per_shard = 2)
*master: 97.3us, 99.7us, 106.7us
*patched: 45.8us, 43.8us, 42.2us

I also tested only one shard for all PGs with more threads,so the hot thread can do work better. And the result is better for OpWQ latency too:

TimeCost(shard_num = 1, thread_per_shard = 8)
*master: 23.7s, 20.6s, 20.4s
*patched: 19.8s, 18.2s, 18.5s
OpWQ latency(shard_num = 1, thread_per_shard =8)
*master: 97.3us, 99.7us, 106.7us
*patched: 25.7us, 26.5us, 18.5us