### PR TITLE
DNM: Wip rados whereis

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -59,35 +59,31 @@ FormatterAttrs::FormatterAttrs(const char *attr, ...)
   va_end(ap);
 }
 
-Formatter::Formatter()
-{
-}
+Formatter::Formatter() { }
 
-Formatter::~Formatter()
-{
-}
+Formatter::~Formatter() { }
 
 Formatter *
 new_formatter(const std::string &type)
 {
-    std::string mytype = type;
-    if (mytype == "")
-      mytype = "json-pretty";
+  std::string mytype = type;
+  if (mytype == "")
+    mytype = "json-pretty";
 
-    if (mytype == "json")
-      return new JSONFormatter(false);
-    else if (mytype == "json-pretty")
-      return new JSONFormatter(true);
-    else if (mytype == "xml")
-      return new XMLFormatter(false);
-    else if (mytype == "xml-pretty")
-      return new XMLFormatter(true);
-    else if (mytype == "table")
-      return new TableFormatter();
-    else if (mytype == "table-kv")
-      return new TableFormatter(true);
-    else
-      return (Formatter *)NULL;
+  if (mytype == "json")
+    return new JSONFormatter(false);
+  else if (mytype == "json-pretty")
+    return new JSONFormatter(true);
+  else if (mytype == "xml")
+    return new XMLFormatter(false);
+  else if (mytype == "xml-pretty")
+    return new XMLFormatter(true);
+  else if (mytype == "table")
+    return new TableFormatter();
+  else if (mytype == "table-kv")
+    return new TableFormatter(true);
+  else
+    return (Formatter *) NULL;
 }
 
 void Formatter::dump_format(const char *name, const char *fmt, ...)
@@ -98,7 +94,7 @@ void Formatter::dump_format(const char *name, const char *fmt, ...)
   va_end(ap);
 }
 
-void Formatter:: dump_format_ns(const char *name, const char *ns, const char *fmt, ...)
+void Formatter::dump_format_ns(const char *name, const char *ns, const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
@@ -106,7 +102,6 @@ void Formatter:: dump_format_ns(const char *name, const char *ns, const char *fm
   va_end(ap);
 
 }
-
 
 void Formatter::dump_format_unquoted(const char *name, const char *fmt, ...)
 {
@@ -117,8 +112,9 @@ void Formatter::dump_format_unquoted(const char *name, const char *fmt, ...)
 }
 
 // -----------------------
+
 JSONFormatter::JSONFormatter(bool p)
-  : m_pretty(p), m_is_pending_string(false)
+: m_pretty(p), m_is_pending_string(false)
 {
   reset();
 }
@@ -145,14 +141,14 @@ void JSONFormatter::print_comma(json_formatter_stack_entry_d& entry)
   if (entry.size) {
     if (m_pretty) {
       m_ss << ",\n";
-      for (unsigned i=1; i < m_stack.size(); i++)
-	m_ss << "    ";
+      for (unsigned i = 1; i < m_stack.size(); i++)
+        m_ss << "    ";
     } else {
       m_ss << ",";
     }
   } else if (entry.is_array && m_pretty) {
     m_ss << "\n";
-    for (unsigned i=1; i < m_stack.size(); i++)
+    for (unsigned i = 1; i < m_stack.size(); i++)
       m_ss << "    ";
   }
   if (m_pretty && entry.is_array)
@@ -178,9 +174,9 @@ void JSONFormatter::print_name(const char *name)
   if (!entry.is_array) {
     if (m_pretty) {
       if (entry.size)
-	m_ss << "  ";
+        m_ss << "  ";
       else
-	m_ss << " ";
+        m_ss << " ";
     }
     m_ss << "\"" << name << "\"";
     if (m_pretty)
@@ -307,7 +303,7 @@ const char *XMLFormatter::XML_1_DTD =
   "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
 
 XMLFormatter::XMLFormatter(bool pretty)
-  : m_pretty(pretty)
+: m_pretty(pretty)
 {
   reset();
 }
@@ -436,7 +432,7 @@ void XMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted,
   std::string e(name);
   print_spaces();
   if (ns) {
-    m_ss << "<" << e  << " xmlns=\"" << ns << "\">" << buf << "</" << e << ">";
+    m_ss << "<" << e << " xmlns=\"" << ns << "\">" << buf << "</" << e << ">";
   } else {
     m_ss << "<" << e << ">" << escape_xml_str(buf) << "</" << e << ">";
   }
@@ -479,8 +475,7 @@ void XMLFormatter::open_section_in_ns(const char *name, const char *ns, const Fo
 
   if (ns) {
     m_ss << "<" << name << attrs_str << " xmlns=\"" << ns << "\">";
-  }
-  else {
+  } else {
     m_ss << "<" << name << attrs_str << ">";
   }
   if (m_pretty)
@@ -492,7 +487,7 @@ void XMLFormatter::finish_pending_string()
 {
   if (!m_pending_string_name.empty()) {
     m_ss << escape_xml_str(m_pending_string.str().c_str())
-         << "</" << m_pending_string_name << ">";
+      << "</" << m_pending_string_name << ">";
     m_pending_string_name.clear();
     m_pending_string.str(std::string());
     if (m_pretty) {
@@ -532,110 +527,110 @@ void TableFormatter::flush(std::ostream& os)
   std::set<int> need_header_set;
 
   // auto-sizing columns
-  for (size_t i=0; i< m_vec.size(); i++) {
-    for (size_t j=0; j< m_vec[i].size(); j++) {
+  for (size_t i = 0; i < m_vec.size(); i++) {
+    for (size_t j = 0; j < m_vec[i].size(); j++) {
       column_size.resize(m_vec[i].size());
       column_name.resize(m_vec[i].size());
-      if (i>0) {
-	if (m_vec[i-1][j] != m_vec[i][j]) {
-	  // changing row labels require to show the header
-	  need_header_set.insert(i);
-	  column_name[i] = m_vec[i][j].first;
-	}
+      if (i > 0) {
+        if (m_vec[i - 1][j] != m_vec[i][j]) {
+          // changing row labels require to show the header
+          need_header_set.insert(i);
+          column_name[i] = m_vec[i][j].first;
+        }
       } else {
-	column_name[i] = m_vec[i][j].first;
+        column_name[i] = m_vec[i][j].first;
       }
 
-      if (m_vec[i][j].second.length()> column_size[j])
-	column_size[j]=m_vec[i][j].second.length();
-      if (m_vec[i][j].first.length()> column_size[j])
-	column_size[j]=m_vec[i][j].first.length();
+      if (m_vec[i][j].second.length() > column_size[j])
+        column_size[j] = m_vec[i][j].second.length();
+      if (m_vec[i][j].first.length() > column_size[j])
+        column_size[j] = m_vec[i][j].first.length();
     }
   }
-  
-  bool need_header=false;
-  if ( (column_size.size() == m_column_size.size() ) ) {
-    for (size_t i=0; i<column_size.size(); i++) {
+
+  bool need_header = false;
+  if ((column_size.size() == m_column_size.size())) {
+    for (size_t i = 0; i < column_size.size(); i++) {
       if (column_size[i] != m_column_size[i]) {
-	need_header = true;
-	break;
+        need_header = true;
+        break;
       }
     }
   } else {
     need_header = true;
   }
-  
+
   if (need_header) {
     // first row always needs a header if there wasn't one before
     need_header_set.insert(0);
   }
-  
+
   m_column_size = column_size;
-  for (size_t i=0; i< m_vec.size(); i++) {
-    if (i==0) {
+  for (size_t i = 0; i < m_vec.size(); i++) {
+    if (i == 0) {
       if (need_header_set.count(i)) {
-	// print the header
-	if (!m_keyval) {
-	  os << "+";
-	  for (size_t j=0; j< m_vec[i].size(); j++) {
-	    for (size_t v=0; v< m_column_size[j]+3; v++)
-	      os << "-";
-	    os << "+";
-	  }
-	  os << "\n";
-	  os << "|";
-	  
-	  for (size_t j=0; j< m_vec[i].size(); j++) {
-	    os << " ";
-	    std::stringstream fs;
-	    fs << boost::format ("%%-%is") % (m_column_size[j]+2);
-	    os << boost::format (fs.str()) % m_vec[i][j].first;
-	    os << "|";
-	  }
-	  os << "\n";
-	  os << "+";
-	  for (size_t j=0; j< m_vec[i].size(); j++) {
-	    for (size_t v=0; v< m_column_size[j]+3;v++)
-	      os << "-";
-	    os << "+";
-	  }
-	  os << "\n";
-	}
+        // print the header
+        if (!m_keyval) {
+          os << "+";
+          for (size_t j = 0; j < m_vec[i].size(); j++) {
+            for (size_t v = 0; v < m_column_size[j] + 3; v++)
+              os << "-";
+            os << "+";
+          }
+          os << "\n";
+          os << "|";
+
+          for (size_t j = 0; j < m_vec[i].size(); j++) {
+            os << " ";
+            std::stringstream fs;
+            fs << boost::format("%%-%is") % (m_column_size[j] + 2);
+            os << boost::format(fs.str()) % m_vec[i][j].first;
+            os << "|";
+          }
+          os << "\n";
+          os << "+";
+          for (size_t j = 0; j < m_vec[i].size(); j++) {
+            for (size_t v = 0; v < m_column_size[j] + 3; v++)
+              os << "-";
+            os << "+";
+          }
+          os << "\n";
+        }
       }
     }
     // print body
     if (!m_keyval)
       os << "|";
-    for (size_t j=0; j< m_vec[i].size(); j++) {
+    for (size_t j = 0; j < m_vec[i].size(); j++) {
       if (!m_keyval)
-	os << " ";
+        os << " ";
       std::stringstream fs;
-      
+
       if (m_keyval) {
-	os << "key::";
-	os << m_vec[i][j].first;
-	os << "=";
-	os << "\"";
-	os << m_vec[i][j].second;
-	os << "\" ";
+        os << "key::";
+        os << m_vec[i][j].first;
+        os << "=";
+        os << "\"";
+        os << m_vec[i][j].second;
+        os << "\" ";
       } else {
-	fs << boost::format ("%%-%is") % (m_column_size[j]+2);
-	os << boost::format (fs.str()) % m_vec[i][j].second;
-	os << "|";
+        fs << boost::format("%%-%is") % (m_column_size[j] + 2);
+        os << boost::format(fs.str()) % m_vec[i][j].second;
+        os << "|";
       }
     }
-      
+
     os << "\n";
     if (!m_keyval) {
-      if ( i == (m_vec.size()-1) ) {
-	// print trailer
-	os << "+";
-	for (size_t j=0; j< m_vec[i].size(); j++) {
-	  for (size_t v=0; v< m_column_size[j]+3;v++)
-	    os << "-";
-	  os << "+";
-	  }
-	os << "\n";
+      if (i == (m_vec.size() - 1)) {
+        // print trailer
+        os << "+";
+        for (size_t j = 0; j < m_vec[i].size(); j++) {
+          for (size_t v = 0; v < m_column_size[j] + 3; v++)
+            os << "-";
+          os << "+";
+        }
+        os << "\n";
       }
     }
     m_vec[i].clear();
@@ -693,7 +688,7 @@ void TableFormatter::close_section()
   //
   m_section_open--;
   if (m_section.size()) {
-    m_section_cnt[m_section.back()]=0;
+    m_section_cnt[m_section.back()] = 0;
     m_section.pop_back();
   }
 }
@@ -713,23 +708,22 @@ size_t TableFormatter::m_vec_index(const char *name)
   if (m_vec.size()) {
     if (m_vec[i].size()) {
       if (m_vec[i][0].first == key) {
-	// start a new column if a key is repeated
-	m_vec.resize(m_vec.size()+1);
-	i++;
+        // start a new column if a key is repeated
+        m_vec.resize(m_vec.size() + 1);
+        i++;
       }
     }
   }
-  
+
   return i;
 }
 
 std::string TableFormatter::get_section_name(const char* name)
 {
-  std::string t_name=name;
-  for (size_t i=0; i< m_section.size(); i++)
-  {
-    t_name.insert(0,":");
-    t_name.insert(0,m_section[i]);
+  std::string t_name = name;
+  for (size_t i = 0; i < m_section.size(); i++) {
+    t_name.insert(0, ":");
+    t_name.insert(0, m_section[i]);
   }
   if (m_section_open) {
     std::stringstream lss;
@@ -748,7 +742,7 @@ void TableFormatter::dump_unsigned(const char *name, uint64_t u)
   finish_pending_string();
   size_t i = m_vec_index(name);
   m_ss << u;
-  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_vec[i].push_back(std::make_pair(get_section_name(name), m_ss.str()));
   m_ss.clear();
   m_ss.str("");
 }
@@ -758,7 +752,7 @@ void TableFormatter::dump_int(const char *name, int64_t u)
   finish_pending_string();
   size_t i = m_vec_index(name);
   m_ss << u;
-  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_vec[i].push_back(std::make_pair(get_section_name(name), m_ss.str()));
   m_ss.clear();
   m_ss.str("");
 }
@@ -769,7 +763,7 @@ void TableFormatter::dump_float(const char *name, double d)
   size_t i = m_vec_index(name);
   m_ss << d;
 
-  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_vec[i].push_back(std::make_pair(get_section_name(name), m_ss.str()));
   m_ss.clear();
   m_ss.str("");
 }
@@ -780,7 +774,7 @@ void TableFormatter::dump_string(const char *name, std::string s)
   size_t i = m_vec_index(name);
   m_ss << s;
 
-  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_vec[i].push_back(std::make_pair(get_section_name(name), m_ss.str()));
   m_ss.clear();
   m_ss.str("");
 }
@@ -794,11 +788,10 @@ void TableFormatter::dump_string_with_attrs(const char *name, std::string s, con
   get_attrs_str(&attrs, attrs_str);
   m_ss << attrs_str << s;
 
-  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_vec[i].push_back(std::make_pair(get_section_name(name), m_ss.str()));
   m_ss.clear();
   m_ss.str("");
 }
-
 
 void TableFormatter::dump_format_va(const char* name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
@@ -809,10 +802,10 @@ void TableFormatter::dump_format_va(const char* name, const char *ns, bool quote
   size_t i = m_vec_index(name);
   if (ns) {
     m_ss << ns << "." << buf;
-  } else 
+  } else
     m_ss << buf;
 
-  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_vec[i].push_back(std::make_pair(get_section_name(name), m_ss.str()));
   m_ss.clear();
   m_ss.str("");
 }
@@ -821,7 +814,7 @@ std::ostream& TableFormatter::dump_stream(const char *name)
 {
   finish_pending_string();
   // we don't support this
-  m_pending_name=name;
+  m_pending_name = name;
   return m_ss;
 }
 
@@ -831,8 +824,7 @@ int TableFormatter::get_len() const
   return 0;
 }
 
-void TableFormatter::write_raw_data(const char *data)
-{
+void TableFormatter::write_raw_data(const char *data) {
   // not supported
 }
 
@@ -855,9 +847,9 @@ void TableFormatter::finish_pending_string()
     std::string ss = m_ss.str();
     m_ss.clear();
     m_ss.str("");
-    std::string pending_name=m_pending_name;
-    m_pending_name="";
-    dump_string(pending_name.c_str(),ss);
+    std::string pending_name = m_pending_name;
+    m_pending_name = "";
+    dump_string(pending_name.c_str(), ss);
   }
 }
 }

--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -26,6 +26,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
+#include <string>
+#include <set>
+#include <boost/format.hpp>
+
+
 
 // -----------------------
 namespace ceph {
@@ -77,6 +82,10 @@ new_formatter(const std::string &type)
       return new XMLFormatter(false);
     else if (mytype == "xml-pretty")
       return new XMLFormatter(true);
+    else if (mytype == "table")
+      return new TableFormatter();
+    else if (mytype == "table-kv")
+      return new TableFormatter(true);
     else
       return (Formatter *)NULL;
 }
@@ -294,7 +303,7 @@ void JSONFormatter::write_raw_data(const char *data)
   m_ss << data;
 }
 
-const char *XMLFormatter::XML_1_DTD = 
+const char *XMLFormatter::XML_1_DTD =
   "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
 
 XMLFormatter::XMLFormatter(bool pretty)
@@ -509,4 +518,347 @@ std::string XMLFormatter::escape_xml_str(const char *str)
   return std::string(&escaped[0]);
 }
 
+TableFormatter::TableFormatter(bool keyval) : m_keyval(keyval)
+{
+  reset();
 }
+
+void TableFormatter::flush(std::ostream& os)
+{
+  finish_pending_string();
+  std::vector<size_t> column_size = m_column_size;
+  std::vector<std::string> column_name = m_column_name;
+
+  std::set<int> need_header_set;
+
+  // auto-sizing columns
+  for (size_t i=0; i< m_vec.size(); i++) {
+    for (size_t j=0; j< m_vec[i].size(); j++) {
+      column_size.resize(m_vec[i].size());
+      column_name.resize(m_vec[i].size());
+      if (i>0) {
+	if (m_vec[i-1][j] != m_vec[i][j]) {
+	  // changing row labels require to show the header
+	  need_header_set.insert(i);
+	  column_name[i] = m_vec[i][j].first;
+	}
+      } else {
+	column_name[i] = m_vec[i][j].first;
+      }
+
+      if (m_vec[i][j].second.length()> column_size[j])
+	column_size[j]=m_vec[i][j].second.length();
+      if (m_vec[i][j].first.length()> column_size[j])
+	column_size[j]=m_vec[i][j].first.length();
+    }
+  }
+  
+  bool need_header=false;
+  if ( (column_size.size() == m_column_size.size() ) ) {
+    for (size_t i=0; i<column_size.size(); i++) {
+      if (column_size[i] != m_column_size[i]) {
+	need_header = true;
+	break;
+      }
+    }
+  } else {
+    need_header = true;
+  }
+  
+  if (need_header) {
+    // first row always needs a header if there wasn't one before
+    need_header_set.insert(0);
+  }
+  
+  m_column_size = column_size;
+  for (size_t i=0; i< m_vec.size(); i++) {
+    if (i==0) {
+      if (need_header_set.count(i)) {
+	// print the header
+	if (!m_keyval) {
+	  os << "+";
+	  for (size_t j=0; j< m_vec[i].size(); j++) {
+	    for (size_t v=0; v< m_column_size[j]+3; v++)
+	      os << "-";
+	    os << "+";
+	  }
+	  os << "\n";
+	  os << "|";
+	  
+	  for (size_t j=0; j< m_vec[i].size(); j++) {
+	    os << " ";
+	    std::stringstream fs;
+	    fs << boost::format ("%%-%is") % (m_column_size[j]+2);
+	    os << boost::format (fs.str()) % m_vec[i][j].first;
+	    os << "|";
+	  }
+	  os << "\n";
+	  os << "+";
+	  for (size_t j=0; j< m_vec[i].size(); j++) {
+	    for (size_t v=0; v< m_column_size[j]+3;v++)
+	      os << "-";
+	    os << "+";
+	  }
+	  os << "\n";
+	}
+      }
+    }
+    // print body
+    if (!m_keyval)
+      os << "|";
+    for (size_t j=0; j< m_vec[i].size(); j++) {
+      if (!m_keyval)
+	os << " ";
+      std::stringstream fs;
+      
+      if (m_keyval) {
+	os << "key::";
+	os << m_vec[i][j].first;
+	os << "=";
+	os << "\"";
+	os << m_vec[i][j].second;
+	os << "\" ";
+      } else {
+	fs << boost::format ("%%-%is") % (m_column_size[j]+2);
+	os << boost::format (fs.str()) % m_vec[i][j].second;
+	os << "|";
+      }
+    }
+      
+    os << "\n";
+    if (!m_keyval) {
+      if ( i == (m_vec.size()-1) ) {
+	// print trailer
+	os << "+";
+	for (size_t j=0; j< m_vec[i].size(); j++) {
+	  for (size_t v=0; v< m_column_size[j]+3;v++)
+	    os << "-";
+	  os << "+";
+	  }
+	os << "\n";
+      }
+    }
+    m_vec[i].clear();
+  }
+  m_vec.clear();
+}
+
+void TableFormatter::reset()
+{
+  m_ss.clear();
+  m_ss.str("");
+  m_section_cnt.clear();
+  m_column_size.clear();
+  m_section_open = 0;
+}
+
+void TableFormatter::open_object_section(const char *name)
+{
+  open_section_in_ns(name, NULL, NULL);
+}
+
+void TableFormatter::open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs)
+{
+  open_section_in_ns(name, NULL, NULL);
+}
+
+void TableFormatter::open_object_section_in_ns(const char *name, const char *ns)
+{
+  open_section_in_ns(name, NULL, NULL);
+}
+
+void TableFormatter::open_array_section(const char *name)
+{
+  open_section_in_ns(name, NULL, NULL);
+}
+
+void TableFormatter::open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs)
+{
+  open_section_in_ns(name, NULL, NULL);
+}
+
+void TableFormatter::open_array_section_in_ns(const char *name, const char *ns)
+{
+  open_section_in_ns(name, NULL, NULL);
+}
+
+void TableFormatter::open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs)
+{
+  m_section.push_back(name);
+  m_section_open++;
+}
+
+void TableFormatter::close_section()
+{
+  //
+  m_section_open--;
+  if (m_section.size()) {
+    m_section_cnt[m_section.back()]=0;
+    m_section.pop_back();
+  }
+}
+
+size_t TableFormatter::m_vec_index(const char *name)
+{
+  std::string key(name);
+
+  size_t i = m_vec.size();
+  if (i)
+    i--;
+
+  // make sure there are vectors to push back key/val pairs
+  if (!m_vec.size())
+    m_vec.resize(1);
+
+  if (m_vec.size()) {
+    if (m_vec[i].size()) {
+      if (m_vec[i][0].first == key) {
+	// start a new column if a key is repeated
+	m_vec.resize(m_vec.size()+1);
+	i++;
+      }
+    }
+  }
+  
+  return i;
+}
+
+std::string TableFormatter::get_section_name(const char* name)
+{
+  std::string t_name=name;
+  for (size_t i=0; i< m_section.size(); i++)
+  {
+    t_name.insert(0,":");
+    t_name.insert(0,m_section[i]);
+  }
+  if (m_section_open) {
+    std::stringstream lss;
+    lss << t_name;
+    lss << "[";
+    lss << m_section_cnt[t_name]++;
+    lss << "]";
+    return lss.str();
+  } else {
+    return t_name;
+  }
+}
+
+void TableFormatter::dump_unsigned(const char *name, uint64_t u)
+{
+  finish_pending_string();
+  size_t i = m_vec_index(name);
+  m_ss << u;
+  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_ss.clear();
+  m_ss.str("");
+}
+
+void TableFormatter::dump_int(const char *name, int64_t u)
+{
+  finish_pending_string();
+  size_t i = m_vec_index(name);
+  m_ss << u;
+  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_ss.clear();
+  m_ss.str("");
+}
+
+void TableFormatter::dump_float(const char *name, double d)
+{
+  finish_pending_string();
+  size_t i = m_vec_index(name);
+  m_ss << d;
+
+  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_ss.clear();
+  m_ss.str("");
+}
+
+void TableFormatter::dump_string(const char *name, std::string s)
+{
+  finish_pending_string();
+  size_t i = m_vec_index(name);
+  m_ss << s;
+
+  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_ss.clear();
+  m_ss.str("");
+}
+
+void TableFormatter::dump_string_with_attrs(const char *name, std::string s, const FormatterAttrs& attrs)
+{
+  finish_pending_string();
+  size_t i = m_vec_index(name);
+
+  std::string attrs_str;
+  get_attrs_str(&attrs, attrs_str);
+  m_ss << attrs_str << s;
+
+  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_ss.clear();
+  m_ss.str("");
+}
+
+
+void TableFormatter::dump_format_va(const char* name, const char *ns, bool quoted, const char *fmt, va_list ap)
+{
+  finish_pending_string();
+  char buf[LARGE_SIZE];
+  vsnprintf(buf, LARGE_SIZE, fmt, ap);
+
+  size_t i = m_vec_index(name);
+  if (ns) {
+    m_ss << ns << "." << buf;
+  } else 
+    m_ss << buf;
+
+  m_vec[i].push_back(std::make_pair(get_section_name(name),m_ss.str()));
+  m_ss.clear();
+  m_ss.str("");
+}
+
+std::ostream& TableFormatter::dump_stream(const char *name)
+{
+  finish_pending_string();
+  // we don't support this
+  m_pending_name=name;
+  return m_ss;
+}
+
+int TableFormatter::get_len() const
+{
+  // we don't know the size until flush is called
+  return 0;
+}
+
+void TableFormatter::write_raw_data(const char *data)
+{
+  // not supported
+}
+
+void TableFormatter::get_attrs_str(const FormatterAttrs *attrs, std::string& attrs_str)
+{
+  std::stringstream attrs_ss;
+
+  for (std::list<std::pair<std::string, std::string> >::const_iterator iter = attrs->attrs.begin();
+       iter != attrs->attrs.end(); ++iter) {
+    std::pair<std::string, std::string> p = *iter;
+    attrs_ss << " " << p.first << "=" << "\"" << p.second << "\"";
+  }
+
+  attrs_str = attrs_ss.str();
+}
+
+void TableFormatter::finish_pending_string()
+{
+  if (m_pending_name.length()) {
+    std::string ss = m_ss.str();
+    m_ss.clear();
+    m_ss.str("");
+    std::string pending_name=m_pending_name;
+    m_pending_name="";
+    dump_string(pending_name.c_str(),ss);
+  }
+}
+}
+

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -17,180 +17,184 @@
 
 namespace ceph {
 
+  struct FormatterAttrs {
+    std::list< std::pair<std::string, std::string> > attrs;
 
-struct FormatterAttrs {
-  std::list< std::pair<std::string, std::string> > attrs;
-
-  FormatterAttrs(const char *attr, ...);
-};
-
-class Formatter {
- public:
-  Formatter();
-  virtual ~Formatter();
-
-  virtual void flush(std::ostream& os) = 0;
-  void flush(bufferlist &bl) {
-    std::stringstream os;
-    flush(os);
-    bl.append(os.str());
-  }
-  virtual void reset() = 0;
-
-  virtual void open_array_section(const char *name) = 0;
-  virtual void open_array_section_in_ns(const char *name, const char *ns) = 0;
-  virtual void open_object_section(const char *name) = 0;
-  virtual void open_object_section_in_ns(const char *name, const char *ns) = 0;
-  virtual void close_section() = 0;
-  virtual void dump_unsigned(const char *name, uint64_t u) = 0;
-  virtual void dump_int(const char *name, int64_t s) = 0;
-  virtual void dump_float(const char *name, double d) = 0;
-  virtual void dump_string(const char *name, std::string s) = 0;
-  virtual void dump_bool(const char *name, bool b) {
-    dump_format_unquoted(name, "%s", (b ? "true" : "false"));
-  }
-  virtual std::ostream& dump_stream(const char *name) = 0;
-  virtual void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) = 0;
-  virtual void dump_format(const char *name, const char *fmt, ...);
-  virtual void dump_format_ns(const char *name, const char *ns, const char *fmt, ...);
-  virtual void dump_format_unquoted(const char *name, const char *fmt, ...);
-  virtual int get_len() const = 0;
-  virtual void write_raw_data(const char *data) = 0;
-
-  /* with attrs */
-  virtual void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs) {
-    open_array_section(name);
-  }
-  virtual void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs) {
-    open_object_section(name);
-  }
-  virtual void dump_string_with_attrs(const char *name, std::string s, const FormatterAttrs& attrs) {
-    dump_string(name, s);
-  }
-};
-
-Formatter *new_formatter(const std::string &type);
-
-class JSONFormatter : public Formatter {
- public:
-  JSONFormatter(bool p=false);
-
-  void flush(std::ostream& os);
-  void reset();
-  virtual void open_array_section(const char *name);
-  void open_array_section_in_ns(const char *name, const char *ns);
-  void open_object_section(const char *name);
-  void open_object_section_in_ns(const char *name, const char *ns);
-  void close_section();
-  void dump_unsigned(const char *name, uint64_t u);
-  void dump_int(const char *name, int64_t u);
-  void dump_float(const char *name, double d);
-  void dump_string(const char *name, std::string s);
-  std::ostream& dump_stream(const char *name);
-  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap);
-  int get_len() const;
-  void write_raw_data(const char *data);
-
- private:
-  struct json_formatter_stack_entry_d {
-    int size;
-    bool is_array;
-    json_formatter_stack_entry_d() : size(0), is_array(false) {}
+    FormatterAttrs(const char *attr, ...);
   };
 
-  bool m_pretty;
-  void open_section(const char *name, bool is_array);
-  void print_quoted_string(const char *s);
-  void print_name(const char *name);
-  void print_comma(json_formatter_stack_entry_d& entry);
-  void finish_pending_string();
+  class Formatter {
+  public:
+    Formatter();
+    virtual ~Formatter();
 
-  std::stringstream m_ss, m_pending_string;
-  std::list<json_formatter_stack_entry_d> m_stack;
-  bool m_is_pending_string;
-};
+    virtual void flush(std::ostream& os) = 0;
+    void flush(bufferlist &bl)
+    {
+      std::stringstream os;
+      flush(os);
+      bl.append(os.str());
+    }
+    virtual void reset() = 0;
 
-class XMLFormatter : public Formatter {
- public:
-  static const char *XML_1_DTD;
-  XMLFormatter(bool pretty = false);
+    virtual void open_array_section(const char *name) = 0;
+    virtual void open_array_section_in_ns(const char *name, const char *ns) = 0;
+    virtual void open_object_section(const char *name) = 0;
+    virtual void open_object_section_in_ns(const char *name, const char *ns) = 0;
+    virtual void close_section() = 0;
+    virtual void dump_unsigned(const char *name, uint64_t u) = 0;
+    virtual void dump_int(const char *name, int64_t s) = 0;
+    virtual void dump_float(const char *name, double d) = 0;
+    virtual void dump_string(const char *name, std::string s) = 0;
+    virtual void dump_bool(const char *name, bool b)
+    {
+      dump_format_unquoted(name, "%s", (b ? "true" : "false"));
+    }
+    virtual std::ostream& dump_stream(const char *name) = 0;
+    virtual void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) = 0;
+    virtual void dump_format(const char *name, const char *fmt, ...);
+    virtual void dump_format_ns(const char *name, const char *ns, const char *fmt, ...);
+    virtual void dump_format_unquoted(const char *name, const char *fmt, ...);
+    virtual int get_len() const = 0;
+    virtual void write_raw_data(const char *data) = 0;
+    /* with attrs */
+    virtual void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs)
+    {
+      open_array_section(name);
+    }
+    virtual void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs)
+    {
+      open_object_section(name);
+    }
+    virtual void dump_string_with_attrs(const char *name, std::string s, const FormatterAttrs& attrs)
+    {
+      dump_string(name, s);
+    }
+  };
 
-  void flush(std::ostream& os);
-  void reset();
-  void open_array_section(const char *name);
-  void open_array_section_in_ns(const char *name, const char *ns);
-  void open_object_section(const char *name);
-  void open_object_section_in_ns(const char *name, const char *ns);
-  void close_section();
-  void dump_unsigned(const char *name, uint64_t u);
-  void dump_int(const char *name, int64_t u);
-  void dump_float(const char *name, double d);
-  void dump_string(const char *name, std::string s);
-  std::ostream& dump_stream(const char *name);
-  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap);
-  int get_len() const;
-  void write_raw_data(const char *data);
+  Formatter *new_formatter(const std::string &type);
 
-  /* with attrs */
-  void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs);
-  void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs);
-  void dump_string_with_attrs(const char *name, std::string s, const FormatterAttrs& attrs);
- private:
-  void open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs);
-  void finish_pending_string();
-  void print_spaces();
-  static std::string escape_xml_str(const char *str);
-  void get_attrs_str(const FormatterAttrs *attrs, std::string& attrs_str);
+  class JSONFormatter : public Formatter {
+  public:
+    JSONFormatter(bool p = false);
 
-  std::stringstream m_ss, m_pending_string;
-  std::deque<std::string> m_sections;
-  bool m_pretty;
-  std::string m_pending_string_name;
-};
+    void flush(std::ostream& os);
+    void reset();
+    virtual void open_array_section(const char *name);
+    void open_array_section_in_ns(const char *name, const char *ns);
+    void open_object_section(const char *name);
+    void open_object_section_in_ns(const char *name, const char *ns);
+    void close_section();
+    void dump_unsigned(const char *name, uint64_t u);
+    void dump_int(const char *name, int64_t u);
+    void dump_float(const char *name, double d);
+    void dump_string(const char *name, std::string s);
+    std::ostream& dump_stream(const char *name);
+    void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap);
+    int get_len() const;
+    void write_raw_data(const char *data);
 
-class TableFormatter : public Formatter {
- public:
-  TableFormatter(bool keyval=false);
+  private:
 
-  void flush(std::ostream& os);
-  void reset();
-  virtual void open_array_section(const char *name);
-  void open_array_section_in_ns(const char *name, const char *ns);
-  void open_object_section(const char *name);
-  void open_object_section_in_ns(const char *name, const char *ns);
+    struct json_formatter_stack_entry_d {
+      int size;
+      bool is_array;
+      json_formatter_stack_entry_d() : size(0), is_array(false) { }
+    };
 
-  void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs);
-  void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs);
+    bool m_pretty;
+    void open_section(const char *name, bool is_array);
+    void print_quoted_string(const char *s);
+    void print_name(const char *name);
+    void print_comma(json_formatter_stack_entry_d& entry);
+    void finish_pending_string();
 
-  void close_section();
-  void dump_unsigned(const char *name, uint64_t u);
-  void dump_int(const char *name, int64_t u);
-  void dump_float(const char *name, double d);
-  void dump_string(const char *name, std::string s);
-  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap);
-  void dump_string_with_attrs(const char *name, std::string s, const FormatterAttrs& attrs);
-  std::ostream& dump_stream(const char *name);
+    std::stringstream m_ss, m_pending_string;
+    std::list<json_formatter_stack_entry_d> m_stack;
+    bool m_is_pending_string;
+  };
 
-  int get_len() const;
-  void write_raw_data(const char *data);
-  void get_attrs_str(const FormatterAttrs *attrs, std::string& attrs_str);
+  class XMLFormatter : public Formatter {
+  public:
+    static const char *XML_1_DTD;
+    XMLFormatter(bool pretty = false);
 
- private:
-  void open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs);
-  std::vector< std::vector<std::pair<std::string,std::string> > > m_vec;
-  std::stringstream m_ss;
-  size_t m_vec_index(const char* name);
-  std::string get_section_name(const char* name);
-  void finish_pending_string();
-  std::string m_pending_name;
-  bool m_keyval;
+    void flush(std::ostream& os);
+    void reset();
+    void open_array_section(const char *name);
+    void open_array_section_in_ns(const char *name, const char *ns);
+    void open_object_section(const char *name);
+    void open_object_section_in_ns(const char *name, const char *ns);
+    void close_section();
+    void dump_unsigned(const char *name, uint64_t u);
+    void dump_int(const char *name, int64_t u);
+    void dump_float(const char *name, double d);
+    void dump_string(const char *name, std::string s);
+    std::ostream& dump_stream(const char *name);
+    void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap);
+    int get_len() const;
+    void write_raw_data(const char *data);
 
-  int m_section_open;
-  std::vector< std::string > m_section;
-  std::map<std::string,int> m_section_cnt;
-  std::vector<size_t> m_column_size;
-  std::vector< std::string > m_column_name;
-};
+    /* with attrs */
+    void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs);
+    void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs);
+    void dump_string_with_attrs(const char *name, std::string s, const FormatterAttrs& attrs);
+  private:
+    void open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs);
+    void finish_pending_string();
+    void print_spaces();
+    static std::string escape_xml_str(const char *str);
+    void get_attrs_str(const FormatterAttrs *attrs, std::string& attrs_str);
+
+    std::stringstream m_ss, m_pending_string;
+    std::deque<std::string> m_sections;
+    bool m_pretty;
+    std::string m_pending_string_name;
+  };
+
+  class TableFormatter : public Formatter {
+  public:
+    TableFormatter(bool keyval = false);
+
+    void flush(std::ostream& os);
+    void reset();
+    virtual void open_array_section(const char *name);
+    void open_array_section_in_ns(const char *name, const char *ns);
+    void open_object_section(const char *name);
+    void open_object_section_in_ns(const char *name, const char *ns);
+
+    void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs);
+    void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs);
+
+    void close_section();
+    void dump_unsigned(const char *name, uint64_t u);
+    void dump_int(const char *name, int64_t u);
+    void dump_float(const char *name, double d);
+    void dump_string(const char *name, std::string s);
+    void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap);
+    void dump_string_with_attrs(const char *name, std::string s, const FormatterAttrs& attrs);
+    std::ostream& dump_stream(const char *name);
+
+    int get_len() const;
+    void write_raw_data(const char *data);
+    void get_attrs_str(const FormatterAttrs *attrs, std::string& attrs_str);
+
+  private:
+    void open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs);
+    std::vector< std::vector<std::pair<std::string, std::string> > > m_vec;
+    std::stringstream m_ss;
+    size_t m_vec_index(const char* name);
+    std::string get_section_name(const char* name);
+    void finish_pending_string();
+    std::string m_pending_name;
+    bool m_keyval;
+
+    int m_section_open;
+    std::vector< std::string > m_section;
+    std::map<std::string, int> m_section_cnt;
+    std::vector<size_t> m_column_size;
+    std::vector< std::string > m_column_name;
+  };
 
 
 }

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -6,10 +6,12 @@
 #include <deque>
 #include <iostream>
 #include <list>
+#include <vector>
 #include <ostream>
 #include <sstream>
 #include <stdarg.h>
 #include <string>
+#include <map>
 
 #include "include/buffer.h"
 
@@ -95,7 +97,7 @@ class JSONFormatter : public Formatter {
     bool is_array;
     json_formatter_stack_entry_d() : size(0), is_array(false) {}
   };
-  
+
   bool m_pretty;
   void open_section(const char *name, bool is_array);
   void print_quoted_string(const char *s);
@@ -145,6 +147,51 @@ class XMLFormatter : public Formatter {
   bool m_pretty;
   std::string m_pending_string_name;
 };
+
+class TableFormatter : public Formatter {
+ public:
+  TableFormatter(bool keyval=false);
+
+  void flush(std::ostream& os);
+  void reset();
+  virtual void open_array_section(const char *name);
+  void open_array_section_in_ns(const char *name, const char *ns);
+  void open_object_section(const char *name);
+  void open_object_section_in_ns(const char *name, const char *ns);
+
+  void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs);
+  void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs);
+
+  void close_section();
+  void dump_unsigned(const char *name, uint64_t u);
+  void dump_int(const char *name, int64_t u);
+  void dump_float(const char *name, double d);
+  void dump_string(const char *name, std::string s);
+  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap);
+  void dump_string_with_attrs(const char *name, std::string s, const FormatterAttrs& attrs);
+  std::ostream& dump_stream(const char *name);
+
+  int get_len() const;
+  void write_raw_data(const char *data);
+  void get_attrs_str(const FormatterAttrs *attrs, std::string& attrs_str);
+
+ private:
+  void open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs);
+  std::vector< std::vector<std::pair<std::string,std::string> > > m_vec;
+  std::stringstream m_ss;
+  size_t m_vec_index(const char* name);
+  std::string get_section_name(const char* name);
+  void finish_pending_string();
+  std::string m_pending_name;
+  bool m_keyval;
+
+  int m_section_open;
+  std::vector< std::string > m_section;
+  std::map<std::string,int> m_section_cnt;
+  std::vector<size_t> m_column_size;
+  std::vector< std::string > m_column_name;
+};
+
 
 }
 #endif

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -32,6 +32,7 @@ namespace librados
   class RadosClient;
   class ListObjectImpl;
   struct NObjectIteratorImpl;
+  class RadosWhereis; 
 
   typedef void *list_ctx_t;
   typedef uint64_t auid_t;
@@ -116,6 +117,16 @@ namespace librados
   };
 
   // DEPRECATED; Use NObjectIterator
+  typedef struct whereis {
+    int64_t osd_id;                              //< ID of the OSD hosting this object
+    std::string osd_state;                       //< state of the OSD - either 'active' or 'inactive'
+    int64_t pg_seed;                             //< Seed of the PG hosting this object
+    std::string ip_string;                       //< Ip as string
+    std::vector<std::string> host_names;         //< optional reverse DNS HostNames 
+    std::map<std::string, std::string> user_map; //< optional user KV map
+    void resolve();                              //< reverse DNS OSD IPs and store in HostNames
+  } whereis_t;
+
   class ObjectIterator : public std::iterator <std::forward_iterator_tag, std::pair<std::string, std::string> > {
   public:
     static const ObjectIterator __EndObjectIterator;
@@ -934,6 +945,7 @@ namespace librados
 
     friend class Rados; // Only Rados can use our private constructor to create IoCtxes.
     friend class libradosstriper::RadosStriper; // Striper needs to see our IoCtxImpl
+    friend class librados::RadosWhereis; // Whereis class needs to see our IoCtxImpl
     friend class ObjectWriteOperation;  // copy_from needs to see our IoCtxImpl
 
     IoCtxImpl *io_ctx_impl;
@@ -994,6 +1006,9 @@ namespace librados
 		       std::map<std::string, stats_map>& stats);
     int cluster_stat(cluster_stat_t& result);
     int cluster_fsid(std::string *fsid);
+
+    //  'whereis' of objects
+    static int whereis(IoCtx &ioctx, const std::string &oid, std::vector<whereis_t> &locations);
 
     /// get/wait for the most recent osdmap
     int wait_for_latest_osdmap();

--- a/src/librados/Makefile.am
+++ b/src/librados/Makefile.am
@@ -3,6 +3,7 @@ librados_la_SOURCES = \
 	librados/RadosClient.cc \
 	librados/IoCtxImpl.cc \
 	librados/snap_set_diff.cc \
+	librados/RadosWhereis.cc \
 	librados/RadosXattrIter.cc
 
 # We need this to avoid basename conflicts with the librados build tests in test/Makefile.am
@@ -27,4 +28,5 @@ noinst_HEADERS += \
 	librados/PoolAsyncCompletionImpl.h \
 	librados/RadosClient.h \
 	librados/RadosXattrIter.h \
-	librados/ListObjectImpl.h
+	librados/ListObjectImpl.h \
+	librados/RadosWhereis.h 

--- a/src/librados/RadosWhereis.cc
+++ b/src/librados/RadosWhereis.cc
@@ -1,0 +1,144 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 CERN (Switzerland)
+ *
+ * Author: Andreas-Joachim Peters <Andreas.Joachim.Peters@cern.ch>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+// -----------------------------------------------------------------------------
+#include "librados/IoCtxImpl.h"
+#include "include/rados/librados.hpp"
+#include "common/Formatter.h"
+#include "RadosWhereis.h"
+#include <string>
+#include <iostream>
+#include <boost/asio.hpp>
+
+// -----------------------------------------------------------------------------
+
+/**
+ * @file RadosWhereis.cc
+ *
+ * @brief Class providing a function to retrieve a vector of locations
+ *
+ * The 'whereis' function fills a vector storing the IP, OSD- & PG-Seeds for
+ * a given object in a given IO context (pool).
+ */
+
+
+
+// -----------------------------------------------------------------------------
+
+void
+librados::whereis::resolve()
+{
+  // translate ip's using boost asio
+  boost::asio::ip::address ipa = boost::asio::ip::address::from_string(ip_string);
+  boost::asio::ip::tcp::endpoint ep;
+  ep.address(ipa);
+
+  boost::asio::io_service io_service;
+  boost::asio::ip::tcp::resolver resolver(io_service);
+
+  boost::asio::ip::tcp::resolver::iterator itr = resolver.resolve(ep);
+  boost::asio::ip::tcp::resolver::iterator end;
+
+  for (int i = 1; itr != end; itr++, i++) {
+    host_names.push_back(itr->host_name());
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+int
+librados::Rados::whereis(IoCtx &ioctx, const std::string &oid, std::vector<whereis_t> &locations)
+{
+  RadosWhereis locator(ioctx);
+  return locator.whereis(oid, locations);
+}
+
+// -----------------------------------------------------------------------------
+
+int
+librados::RadosWhereis::whereis(const std::string &oname,
+                                std::vector<librados::whereis_t> &locations
+                                )
+{
+  librados::IoCtxImpl *ctx = io.io_ctx_impl;
+  object_t oid(oname.c_str());
+
+  // retrieve OSD map
+  const OSDMap* osdmap = ctx->objecter->get_osdmap_read();
+  // check if given pool is defined in the OSD map
+  int64_t pool = ctx->poolid;
+  if (!osdmap->have_pg_pool(pool)) {
+    if (osdmap)
+      ctx->objecter->put_osdmap_read();
+    return ENOENT;
+  }
+
+  object_locator_t loc(pool);
+  pg_t raw_pgid = osdmap->object_locator_to_pg(oid, loc);
+  pg_t pgid = osdmap->raw_pg_to_pg(raw_pgid);
+
+  vector<int> acting;
+  osdmap->pg_to_acting_osds(pgid, acting);
+
+  // fill and translate all given locations into a location vector
+  for (size_t i = 0; i < acting.size(); i++) {
+    std::stringstream hostaddr;
+    entity_addr_t addr = osdmap->get_addr(acting[i]);
+    hostaddr << addr.ss_addr();
+    std::string host = hostaddr.str().c_str();
+    host.erase(host.rfind(":"));
+
+    whereis_t new_location;
+    new_location.ip_string = host;
+    new_location.osd_id = acting[i];
+    new_location.pg_seed = pgid.ps();
+
+    if ((osdmap->get_state(acting[i]) & CEPH_OSD_UP) &&
+        (osdmap->get_weight(acting[i])))
+      new_location.osd_state = "active";
+    else
+      new_location.osd_state = "inactive";
+
+    locations.push_back(new_location);
+  }
+
+  ctx->objecter->put_osdmap_read();
+  return 0;
+}
+
+void
+librados::RadosWhereis::dump(librados::whereis_t &location, bool reversedns, Formatter* formatter)
+{
+  if (reversedns)
+    location.resolve();
+
+  if (!formatter)
+    return;
+
+  formatter->dump_int("osd-id", location.osd_id);
+  formatter->dump_int("pg-seed", location.pg_seed);
+  formatter->dump_string("ip", location.ip_string);
+  formatter->dump_string("state", location.osd_state);
+
+  if (reversedns) {
+    std::vector<std::string>::const_iterator it;
+    for (it = location.host_names.begin(); it != location.host_names.end(); ++it) {
+      formatter->open_array_section("host");
+      formatter->dump_string("name", it->c_str());
+      formatter->close_section();
+    }
+  }
+}
+
+

--- a/src/librados/RadosWhereis.h
+++ b/src/librados/RadosWhereis.h
@@ -1,0 +1,50 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 CERN (Switzerland)
+ *
+ * Author: Andreas-Joachim Peters <Andreas.Joachim.Peters@cern.ch>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#ifndef CEPH_LIBRADOS_RADOSWHEREIS_H
+#define CEPH_LIBRADOS_RADOSWHEREIS_H
+
+#include <stdio.h>
+
+/**
+ * @file RadosWhereis.h
+ *
+ * @brief Class providing a function to retrieve a vector of locations
+ *
+ * The 'whereis' function fills a vector storing the IP, OSD- & PG-Seeds for
+ * a given object in a given IO context (pool).
+ */
+
+
+namespace librados {
+  class IoCtx;
+
+  class RadosWhereis {
+  public:
+    RadosWhereis(IoCtx &_io) : io(_io) { };
+    virtual
+    ~RadosWhereis() { };
+
+    int
+    whereis(const std::string &oio,
+            std::vector<librados::whereis_t> &locations
+            );
+
+    static void dump(librados::whereis_t &location, bool reversedns, Formatter* formatter);
+
+  private:
+    IoCtx &io;
+  };
+}
+#endif

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -625,6 +625,10 @@ unittest_readahead_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_readahead_CXXFLAGS = $(UNITTEST_CXXFLAGS) -O2
 check_PROGRAMS += unittest_readahead
 
+unittest_tableformatter_SOURCES = test/common/test_tableformatter.cc
+unittest_tableformatter_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+unittest_tableformatter_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
+check_PROGRAMS += unittest_tableformatter
 
 check_SCRIPTS += test/pybind/test_ceph_argparse.py
 

--- a/src/test/common/test_tableformatter.cc
+++ b/src/test/common/test_tableformatter.cc
@@ -5,12 +5,13 @@
 #include <sstream>
 #include <string>
 
-TEST(tableformatter, singleline) {
+TEST(tableformatter, singleline)
+{
   std::stringstream sout;
   TableFormatter formatter;
-  formatter.dump_int("integer",10);
-  formatter.dump_float("float",10.0);
-  formatter.dump_string("string","string");
+  formatter.dump_int("integer", 10);
+  formatter.dump_float("float", 10.0);
+  formatter.dump_string("string", "string");
   formatter.flush(sout);
 
   std::string cmp = ""
@@ -19,40 +20,42 @@ TEST(tableformatter, singleline) {
     "+----------+--------+---------+\n"
     "| 10       | 10     | string  |\n"
     "+----------+--------+---------+\n";
-  EXPECT_EQ(cmp,sout.str());
+  EXPECT_EQ(cmp, sout.str());
 }
 
-TEST(tableformatter, multiline) {
+TEST(tableformatter, multiline)
+{
   std::stringstream sout;
   TableFormatter formatter;
-  formatter.dump_int("integer",10);
-  formatter.dump_float("float",10.0);
-  formatter.dump_string("string","string");
-  formatter.dump_int("integer",20);
-  formatter.dump_float("float",20.0);
-  formatter.dump_string("string","string");
+  formatter.dump_int("integer", 10);
+  formatter.dump_float("float", 10.0);
+  formatter.dump_string("string", "string");
+  formatter.dump_int("integer", 20);
+  formatter.dump_float("float", 20.0);
+  formatter.dump_string("string", "string");
 
   std::string cmp = ""
-     "+----------+--------+---------+\n"
-     "| integer  | float  | string  |\n"
-     "+----------+--------+---------+\n"
-     "| 10       | 10     | string  |\n"
-     "| 20       | 20     | string  |\n"
-     "+----------+--------+---------+\n";
+    "+----------+--------+---------+\n"
+    "| integer  | float  | string  |\n"
+    "+----------+--------+---------+\n"
+    "| 10       | 10     | string  |\n"
+    "| 20       | 20     | string  |\n"
+    "+----------+--------+---------+\n";
 
   formatter.flush(sout);
-  EXPECT_EQ(cmp,sout.str());
+  EXPECT_EQ(cmp, sout.str());
 }
 
-TEST(tableformatter, multiflush) {
+TEST(tableformatter, multiflush)
+{
   std::stringstream sout1;
   std::stringstream sout2;
   TableFormatter formatter;
-  formatter.dump_int("integer",10);
-  formatter.dump_float("float",10.0);
-  formatter.dump_string("string","string");
+  formatter.dump_int("integer", 10);
+  formatter.dump_float("float", 10.0);
+  formatter.dump_string("string", "string");
   formatter.flush(sout1);
-  
+
   std::string cmp = ""
     "+----------+--------+---------+\n"
     "| integer  | float  | string  |\n"
@@ -60,32 +63,33 @@ TEST(tableformatter, multiflush) {
     "| 10       | 10     | string  |\n"
     "+----------+--------+---------+\n";
 
-  EXPECT_EQ(cmp,sout1.str());
+  EXPECT_EQ(cmp, sout1.str());
 
-  formatter.dump_int("integer",20);
-  formatter.dump_float("float",20.0);
-  formatter.dump_string("string","string");
+  formatter.dump_int("integer", 20);
+  formatter.dump_float("float", 20.0);
+  formatter.dump_string("string", "string");
   formatter.flush(sout2);
 
   cmp = ""
     "| 20       | 20     | string  |\n"
     "+----------+--------+---------+\n";
 
-  EXPECT_EQ(cmp,sout2.str());
+  EXPECT_EQ(cmp, sout2.str());
 
 }
 
-TEST(tableformatter, multireset) {
+TEST(tableformatter, multireset)
+{
   std::stringstream sout;
   TableFormatter formatter;
-  formatter.dump_int("integer",10);
-  formatter.dump_float("float",10.0);
-  formatter.dump_string("string","string");
+  formatter.dump_int("integer", 10);
+  formatter.dump_float("float", 10.0);
+  formatter.dump_string("string", "string");
   formatter.flush(sout);
   formatter.reset();
-  formatter.dump_int("integer",20);
-  formatter.dump_float("float",20.0);
-  formatter.dump_string("string","string");
+  formatter.dump_int("integer", 20);
+  formatter.dump_float("float", 20.0);
+  formatter.dump_string("string", "string");
   formatter.flush(sout);
 
   std::string cmp = ""
@@ -100,19 +104,20 @@ TEST(tableformatter, multireset) {
     "| 20       | 20     | string  |\n"
     "+----------+--------+---------+\n";
 
-  EXPECT_EQ(cmp,sout.str());
+  EXPECT_EQ(cmp, sout.str());
 }
 
-TEST(tableformatter, changingheaderlength) {
+TEST(tableformatter, changingheaderlength)
+{
   std::stringstream sout;
   TableFormatter formatter;
-  formatter.dump_int("integer",10);
-  formatter.dump_float("float",10.0);
-  formatter.dump_string("string","string");
+  formatter.dump_int("integer", 10);
+  formatter.dump_float("float", 10.0);
+  formatter.dump_string("string", "string");
   formatter.flush(sout);
-  formatter.dump_int("integer",20);
-  formatter.dump_float("float",20.0);
-  formatter.dump_string("string","stringstring");
+  formatter.dump_int("integer", 20);
+  formatter.dump_float("float", 20.0);
+  formatter.dump_string("string", "stringstring");
   formatter.flush(sout);
 
   std::string cmp = ""
@@ -127,19 +132,20 @@ TEST(tableformatter, changingheaderlength) {
     "| 20       | 20     | stringstring  |\n"
     "+----------+--------+---------------+\n";
 
-  EXPECT_EQ(cmp,sout.str());  
+  EXPECT_EQ(cmp, sout.str());
 }
 
-TEST(tableformatter, changingheader) {
+TEST(tableformatter, changingheader)
+{
   std::stringstream sout;
   TableFormatter formatter;
-  formatter.dump_int("integer",10);
-  formatter.dump_float("float",10.0);
-  formatter.dump_string("string","string");
+  formatter.dump_int("integer", 10);
+  formatter.dump_float("float", 10.0);
+  formatter.dump_string("string", "string");
   formatter.flush(sout);
-  formatter.dump_int("longinteger",20);
-  formatter.dump_float("double",20.0);
-  formatter.dump_string("char*","stringstring");
+  formatter.dump_int("longinteger", 20);
+  formatter.dump_float("double", 20.0);
+  formatter.dump_string("char*", "stringstring");
   formatter.flush(sout);
 
   std::string cmp = ""
@@ -154,20 +160,21 @@ TEST(tableformatter, changingheader) {
     "| 20           | 20      | stringstring  |\n"
     "+--------------+---------+---------------+\n";
 
-  EXPECT_EQ(cmp,sout.str());
+  EXPECT_EQ(cmp, sout.str());
 }
 
-TEST(tableformatter, extendingheader) {
+TEST(tableformatter, extendingheader)
+{
   std::stringstream sout;
   TableFormatter formatter;
-  formatter.dump_int("integer",10);
-  formatter.dump_float("float",10.0);
-  formatter.dump_string("string","string");
+  formatter.dump_int("integer", 10);
+  formatter.dump_float("float", 10.0);
+  formatter.dump_string("string", "string");
   formatter.flush(sout);
-  formatter.dump_int("integer",20);
-  formatter.dump_float("float",20.0);
-  formatter.dump_string("string","string");
-  formatter.dump_string("char*","abcde");
+  formatter.dump_int("integer", 20);
+  formatter.dump_float("float", 20.0);
+  formatter.dump_string("string", "string");
+  formatter.dump_string("char*", "abcde");
   formatter.flush(sout);
 
   std::string cmp = ""
@@ -182,10 +189,11 @@ TEST(tableformatter, extendingheader) {
     "| 20       | 20     | string  | abcde  |\n"
     "+----------+--------+---------+--------+\n";
 
-  EXPECT_EQ(cmp,sout.str());  
+  EXPECT_EQ(cmp, sout.str());
 }
 
-TEST(tableformatter, stream) {
+TEST(tableformatter, stream)
+{
   std::stringstream sout;
   TableFormatter* formatter = (TableFormatter*) new_formatter("table");
   formatter->dump_stream("integer") << 10;
@@ -201,29 +209,30 @@ TEST(tableformatter, stream) {
     "| 10       | 10     | string  |\n"
     "+----------+--------+---------+\n";
 
-  EXPECT_EQ(cmp,sout.str());  
+  EXPECT_EQ(cmp, sout.str());
 }
 
-TEST(tableformatter, multiline_keyval) {
+TEST(tableformatter, multiline_keyval)
+{
   std::stringstream sout;
   TableFormatter* formatter = (TableFormatter*) new_formatter("table-kv");
-  formatter->dump_int("integer",10);
-  formatter->dump_float("float",10.0);
-  formatter->dump_string("string","string");
-  formatter->dump_int("integer",20);
-  formatter->dump_float("float",20.0);
-  formatter->dump_string("string","string");
+  formatter->dump_int("integer", 10);
+  formatter->dump_float("float", 10.0);
+  formatter->dump_string("string", "string");
+  formatter->dump_int("integer", 20);
+  formatter->dump_float("float", 20.0);
+  formatter->dump_string("string", "string");
   formatter->flush(sout);
   delete formatter;
 
   std::string cmp = ""
-    "key::integer=\"10\" key::float=\"10\" key::string=\"string\" \n" 
-    "key::integer=\"20\" key::float=\"20\" key::string=\"string\" \n"; 
-  
-  EXPECT_EQ(cmp,sout.str());
+    "key::integer=\"10\" key::float=\"10\" key::string=\"string\" \n"
+    "key::integer=\"20\" key::float=\"20\" key::string=\"string\" \n";
+
+  EXPECT_EQ(cmp, sout.str());
 }
 
-/*                                                                                                                                                                                                    
+/*
  * Local Variables:
  * compile-command: "cd ../.. ; make -j4 &&
  *   make unittest_tableformatter &&

--- a/src/test/common/test_tableformatter.cc
+++ b/src/test/common/test_tableformatter.cc
@@ -1,0 +1,236 @@
+#include "gtest/gtest.h"
+
+#include "common/Formatter.h"
+#include <iostream>
+#include <sstream>
+#include <string>
+
+TEST(tableformatter, singleline) {
+  std::stringstream sout;
+  TableFormatter formatter;
+  formatter.dump_int("integer",10);
+  formatter.dump_float("float",10.0);
+  formatter.dump_string("string","string");
+  formatter.flush(sout);
+
+  std::string cmp = ""
+    "+----------+--------+---------+\n"
+    "| integer  | float  | string  |\n"
+    "+----------+--------+---------+\n"
+    "| 10       | 10     | string  |\n"
+    "+----------+--------+---------+\n";
+  EXPECT_EQ(cmp,sout.str());
+}
+
+TEST(tableformatter, multiline) {
+  std::stringstream sout;
+  TableFormatter formatter;
+  formatter.dump_int("integer",10);
+  formatter.dump_float("float",10.0);
+  formatter.dump_string("string","string");
+  formatter.dump_int("integer",20);
+  formatter.dump_float("float",20.0);
+  formatter.dump_string("string","string");
+
+  std::string cmp = ""
+     "+----------+--------+---------+\n"
+     "| integer  | float  | string  |\n"
+     "+----------+--------+---------+\n"
+     "| 10       | 10     | string  |\n"
+     "| 20       | 20     | string  |\n"
+     "+----------+--------+---------+\n";
+
+  formatter.flush(sout);
+  EXPECT_EQ(cmp,sout.str());
+}
+
+TEST(tableformatter, multiflush) {
+  std::stringstream sout1;
+  std::stringstream sout2;
+  TableFormatter formatter;
+  formatter.dump_int("integer",10);
+  formatter.dump_float("float",10.0);
+  formatter.dump_string("string","string");
+  formatter.flush(sout1);
+  
+  std::string cmp = ""
+    "+----------+--------+---------+\n"
+    "| integer  | float  | string  |\n"
+    "+----------+--------+---------+\n"
+    "| 10       | 10     | string  |\n"
+    "+----------+--------+---------+\n";
+
+  EXPECT_EQ(cmp,sout1.str());
+
+  formatter.dump_int("integer",20);
+  formatter.dump_float("float",20.0);
+  formatter.dump_string("string","string");
+  formatter.flush(sout2);
+
+  cmp = ""
+    "| 20       | 20     | string  |\n"
+    "+----------+--------+---------+\n";
+
+  EXPECT_EQ(cmp,sout2.str());
+
+}
+
+TEST(tableformatter, multireset) {
+  std::stringstream sout;
+  TableFormatter formatter;
+  formatter.dump_int("integer",10);
+  formatter.dump_float("float",10.0);
+  formatter.dump_string("string","string");
+  formatter.flush(sout);
+  formatter.reset();
+  formatter.dump_int("integer",20);
+  formatter.dump_float("float",20.0);
+  formatter.dump_string("string","string");
+  formatter.flush(sout);
+
+  std::string cmp = ""
+    "+----------+--------+---------+\n"
+    "| integer  | float  | string  |\n"
+    "+----------+--------+---------+\n"
+    "| 10       | 10     | string  |\n"
+    "+----------+--------+---------+\n"
+    "+----------+--------+---------+\n"
+    "| integer  | float  | string  |\n"
+    "+----------+--------+---------+\n"
+    "| 20       | 20     | string  |\n"
+    "+----------+--------+---------+\n";
+
+  EXPECT_EQ(cmp,sout.str());
+}
+
+TEST(tableformatter, changingheaderlength) {
+  std::stringstream sout;
+  TableFormatter formatter;
+  formatter.dump_int("integer",10);
+  formatter.dump_float("float",10.0);
+  formatter.dump_string("string","string");
+  formatter.flush(sout);
+  formatter.dump_int("integer",20);
+  formatter.dump_float("float",20.0);
+  formatter.dump_string("string","stringstring");
+  formatter.flush(sout);
+
+  std::string cmp = ""
+    "+----------+--------+---------+\n"
+    "| integer  | float  | string  |\n"
+    "+----------+--------+---------+\n"
+    "| 10       | 10     | string  |\n"
+    "+----------+--------+---------+\n"
+    "+----------+--------+---------------+\n"
+    "| integer  | float  | string        |\n"
+    "+----------+--------+---------------+\n"
+    "| 20       | 20     | stringstring  |\n"
+    "+----------+--------+---------------+\n";
+
+  EXPECT_EQ(cmp,sout.str());  
+}
+
+TEST(tableformatter, changingheader) {
+  std::stringstream sout;
+  TableFormatter formatter;
+  formatter.dump_int("integer",10);
+  formatter.dump_float("float",10.0);
+  formatter.dump_string("string","string");
+  formatter.flush(sout);
+  formatter.dump_int("longinteger",20);
+  formatter.dump_float("double",20.0);
+  formatter.dump_string("char*","stringstring");
+  formatter.flush(sout);
+
+  std::string cmp = ""
+    "+----------+--------+---------+\n"
+    "| integer  | float  | string  |\n"
+    "+----------+--------+---------+\n"
+    "| 10       | 10     | string  |\n"
+    "+----------+--------+---------+\n"
+    "+--------------+---------+---------------+\n"
+    "| longinteger  | double  | char*         |\n"
+    "+--------------+---------+---------------+\n"
+    "| 20           | 20      | stringstring  |\n"
+    "+--------------+---------+---------------+\n";
+
+  EXPECT_EQ(cmp,sout.str());
+}
+
+TEST(tableformatter, extendingheader) {
+  std::stringstream sout;
+  TableFormatter formatter;
+  formatter.dump_int("integer",10);
+  formatter.dump_float("float",10.0);
+  formatter.dump_string("string","string");
+  formatter.flush(sout);
+  formatter.dump_int("integer",20);
+  formatter.dump_float("float",20.0);
+  formatter.dump_string("string","string");
+  formatter.dump_string("char*","abcde");
+  formatter.flush(sout);
+
+  std::string cmp = ""
+    "+----------+--------+---------+\n"
+    "| integer  | float  | string  |\n"
+    "+----------+--------+---------+\n"
+    "| 10       | 10     | string  |\n"
+    "+----------+--------+---------+\n"
+    "+----------+--------+---------+--------+\n"
+    "| integer  | float  | string  | char*  |\n"
+    "+----------+--------+---------+--------+\n"
+    "| 20       | 20     | string  | abcde  |\n"
+    "+----------+--------+---------+--------+\n";
+
+  EXPECT_EQ(cmp,sout.str());  
+}
+
+TEST(tableformatter, stream) {
+  std::stringstream sout;
+  TableFormatter* formatter = (TableFormatter*) new_formatter("table");
+  formatter->dump_stream("integer") << 10;
+  formatter->dump_stream("float") << 10.0;
+  formatter->dump_stream("string") << "string";
+  formatter->flush(sout);
+  delete formatter;
+
+  std::string cmp = ""
+    "+----------+--------+---------+\n"
+    "| integer  | float  | string  |\n"
+    "+----------+--------+---------+\n"
+    "| 10       | 10     | string  |\n"
+    "+----------+--------+---------+\n";
+
+  EXPECT_EQ(cmp,sout.str());  
+}
+
+TEST(tableformatter, multiline_keyval) {
+  std::stringstream sout;
+  TableFormatter* formatter = (TableFormatter*) new_formatter("table-kv");
+  formatter->dump_int("integer",10);
+  formatter->dump_float("float",10.0);
+  formatter->dump_string("string","string");
+  formatter->dump_int("integer",20);
+  formatter->dump_float("float",20.0);
+  formatter->dump_string("string","string");
+  formatter->flush(sout);
+  delete formatter;
+
+  std::string cmp = ""
+    "key::integer=\"10\" key::float=\"10\" key::string=\"string\" \n" 
+    "key::integer=\"20\" key::float=\"20\" key::string=\"string\" \n"; 
+  
+  EXPECT_EQ(cmp,sout.str());
+}
+
+/*                                                                                                                                                                                                    
+ * Local Variables:
+ * compile-command: "cd ../.. ; make -j4 &&
+ *   make unittest_tableformatter &&
+ *      ./unittest_tableformatter
+ *   '
+ * End:
+ */
+
+
+


### PR DESCRIPTION
This includes/is based on wip-table-formatter https://github.com/ceph/ceph/pull/2728#

It adds a RadosWhereis class to get access to the location information of objects and the on/off state of the hosting osd. It supports hostname reverse dns using the boost library.

Usage:
```
std::vector<librados::whereis_t> locations;
int retc;
if ((retc = librados::Rados::whereis(io_ctx, oid, locations))) {
   cerr << "failed to locate " << pool_name << "/" << oid << ": " << cpp_strerror(ret) << std::endl;
}
```
Since I don't know which output to expect I didn't add a unit test for this. 
