### PR TITLE
buffer: Judge bufferlist whether need  rebuild

### DIFF
--- a/src/os/LevelDBStore.cc
+++ b/src/os/LevelDBStore.cc
@@ -154,7 +154,6 @@ void LevelDBStore::LevelDBTransactionImpl::set(
   const bufferlist &to_set_bl)
 {
   buffers.push_back(to_set_bl);
-  buffers.rbegin()->rebuild();
   bufferlist &bl = *(buffers.rbegin());
   string key = combine_strings(prefix, k);
   keys.push_back(key);

--- a/src/os/RocksDBStore.cc
+++ b/src/os/RocksDBStore.cc
@@ -226,7 +226,6 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const bufferlist &to_set_bl)
 {
   buffers.push_back(to_set_bl);
-  buffers.rbegin()->rebuild();
   bufferlist &bl = *(buffers.rbegin());
   string key = combine_strings(prefix, k);
   keys.push_back(key);


### PR DESCRIPTION
The function of rebuild() are:
a: return a contiguous ptr
b: if len % CEPH_PAGE_SIZE == 0, the return ptr must page aligned.

Before doing, it should check whether bufferlist alreay ok.

Signed-off-by: Jianpeng Ma jianpeng.ma@intel.com
