### PR TITLE
JounralingObjectStore: journal->committed_thru after replay

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -451,7 +451,6 @@ int FileJournal::open(uint64_t fs_op_seq)
 {
   dout(2) << "open " << fn << " fsid " << fsid << " fs_op_seq " << fs_op_seq << dendl;
 
-  last_committed_seq = fs_op_seq;
   uint64_t next_seq = fs_op_seq + 1;
 
   int err = _open(false);
@@ -510,6 +509,16 @@ int FileJournal::open(uint64_t fs_op_seq)
   // find next entry
   read_pos = header.start;
   uint64_t seq = header.start_seq;
+
+  // last_committed_seq is 1 before the start of the journal or
+  // 0 if the start is 0
+  last_committed_seq = seq > 0 ? seq - 1 : seq;
+  if (last_committed_seq < fs_op_seq) {
+    dout(2) << "open advancing committed_seq " << last_committed_seq
+	    << " to fs op_seq " << fs_op_seq << dendl;
+    last_committed_seq = fs_op_seq;
+  }
+
   while (1) {
     bufferlist bl;
     off64_t old_pos = read_pos;


### PR DESCRIPTION
It's possible that the osd stopped between when the filestore op_seq file was
updated and when the journal was trimmed.  In that case, it's possible that
on boot the journal might be full, and yet not be trimmed because
commit_start assumes there is no work to do.  Calling committed_thru on the
journal ensures that the journal matches committed_seq.

Backport: giant firefly emperor dumpling Fixes: #6756 Signed-off-by: Samuel
Just sam.just@inktank.com Reviewed-by: Josh Durgin
josh.durgin@inktank.com Reviewed-by: David Zafman
david.zafman@inktank.com
