### PR TITLE
osdc: Fix compiler warning

### DIFF
--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -166,8 +166,10 @@ class ObjectCacher {
 
     //! Returns the size of the overlap between the BufferHead's range and the given range.
     uint64_t overlap_size(uint64_t start, uint64_t end) {
-      uint64_t overlap_start = MAX(start, ex.start);
-      uint64_t overlap_end = MIN(end, ex.start + ex.length);
+      assert(ex.start >= 0);
+      assert(ex.length >= 0);
+      uint64_t overlap_start = MAX(start, (uint64_t)ex.start);
+      uint64_t overlap_end = MIN(end, (uint64_t)(ex.start + ex.length));
       return overlap_end - overlap_start;
     }
   };


### PR DESCRIPTION
Was getting:

./osdc/ObjectCacher.h:169:51: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       uint64_t overlap_start = MAX(start, ex.start);
                                                   ^
./osdc/ObjectCacher.h:170:59: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       uint64_t overlap_end = MIN(end, ex.start + ex.length);
                                                           ^

Signed-off-by: Adam Crume adamcrume@gmail.com
