### PR TITLE
do_autogen.sh: default configure with nss instead of cryptopp

### DIFF
--- a/do_autogen.sh
+++ b/do_autogen.sh
@@ -15,7 +15,7 @@ do_autogen.sh: make a ceph build by running autogen, etc.
 -P                               profiling build
 -p                               google profiler
 -O <level>                       optimize
--n                               use libnss
+-c                               use cryptopp
 -j                               with java
 -r                               with rocksdb
 
@@ -31,14 +31,14 @@ debug_level=0
 verbose=0
 profile=0
 CONFIGURE_FLAGS="--disable-static"
-while getopts  "d:e:hHrTPjpnvO:" flag
+while getopts  "d:e:hHrTPjpcvO:" flag
 do
     case $flag in
     d) debug_level=$OPTARG;;
 
     O) CFLAGS="${CFLAGS} -O$OPTARG";;
 
-    n) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-nss --without-cryptopp";;
+    c) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-cryptopp --without-nss";;
 
     P) profile=1;;
     p) with_profiler="--with-profiler" ;;
@@ -126,6 +126,6 @@ export CXXFLAGS
 
 ./configure \
 --prefix=/usr --sbindir=/sbin --localstatedir=/var --sysconfdir=/etc \
---with-debug $with_profiler --with-cryptopp --with-radosgw \
+--with-debug $with_profiler --with-nss --with-radosgw \
 $CONFIGURE_FLAGS \
 || die "configure failed"


### PR DESCRIPTION
The -n option for nss has been changed to -c to give the
chance to pass the cryptopp flag to configure

Signed-off-by: Federico Gimenez fgimenez@coit.es
