### PR TITLE
Make better error reporting for client's call to rados.Rados

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -620,7 +620,7 @@ def main():
         retargs = cluster_handle.conf_parse_argv(childargs)
     except rados.Error as e:
         print >> sys.stderr, 'Error initializing cluster client: {0}'.\
-            format(e.__class__.__name__)
+            format(repr(e))
         return 1
 
     #tmp = childargs


### PR DESCRIPTION
This is a quick fix to improve the error reporting when starting the Ceph client. Currently, when there's a problem, it prints out this

``` text
Error initializing cluster client: Error
```

This makes it difficult to figure out the actual problem. The advice to use repr comes from http://stackoverflow.com/questions/4308182/getting-the-exception-value-in-python

Signed-off-by: Derrick Schneider derrick.schneider@gmail.com
