### PR TITLE
init-radosgw.sysv: set ulimit -n before starting daemon

### DIFF
--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -87,8 +87,8 @@ case "$1" in
             if [ $SYSTEMD -eq 1 ]; then
                 systemd-run -r bash -c "ulimit -n 32768; $RADOSGW -n $name"
             else
-                #start-stop-daemon --start -u $user -x $RADOSGW -- -n $name
-                daemon --user="$user" "ulimit -n 32768; $RADOSGW -n $name"
+		ulimit -n 32768
+                daemon --user="$user" "$RADOSGW -n $name"
             fi
             echo "Starting $name..."
         done


### PR DESCRIPTION
If we do the ulimit inside the daemon command we will have already
dropped privs and will fail.

Fixes: #9587
Signed-off-by: Sage Weil sage@redhat.com
