### PR TITLE
CrushWrapper: pick a ruleset same as rule_id

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -763,9 +763,9 @@ public:
 
   bool ruleset_exists(int ruleset) const {
     for (size_t i = 0; i < crush->max_rules; ++i) {
-     if (crush->rules[i]->mask.ruleset == ruleset) {
-       return true;
-     }
+      if (rule_exists(i) && crush->rules[i]->mask.ruleset == ruleset) {
+	return true;
+      }
     }
 
     return false;


### PR DESCRIPTION
Originally in the add_simple_ruleset funtion, the ruleset_id
is not reused but rule_id is reused. So after some add/remove
against rules, the newly created rule likely to have
ruleset!=rule_id.

We dont want this happen because we are trying to hold the constraint
that ruleset == rule_id.

Signed-off-by: Xiaoxi Chen xiaoxi.chen@intel.com
(cherry picked from commit 78e84f34da83abf5a62ae97bb84ab70774b164a6)

Conflicts:
    src/crush/CrushWrapper.cc
    src/crush/crush.h
    src/test/erasure-code/TestErasureCodeIsa.cc
    src/test/erasure-code/TestErasureCodeJerasure.cc
    src/test/mon/osd-crush.sh

Fixes: #9675
