### PR TITLE
mon: Monitor: MMonGetMap doesn't require caps

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3179,6 +3179,17 @@ void Monitor::dispatch(MonSession *s, Message *m, const bool src_is_mon)
       handle_ping(static_cast<MPing*>(m));
       break;
 
+    /* MMonGetMap may be used by clients to obtain a monmap *before*
+     * authenticating with the monitor.  We need to handle these without
+     * checking caps because, even on a cluster without cephx, we only set
+     * session caps *after* the auth handshake.  A good example of this
+     * is when a client calls MonClient::get_monmap_privately(), which does
+     * not authenticate when obtaining a monmap.
+     */
+    case CEPH_MSG_MON_GET_MAP:
+      handle_mon_get_map(static_cast<MMonGetMap*>(m));
+      break;
+
     default:
       dealt_with = false;
       break;
@@ -3249,10 +3260,6 @@ void Monitor::dispatch(MonSession *s, Message *m, const bool src_is_mon)
   switch (m->get_type()) {
 
     // misc
-    case CEPH_MSG_MON_GET_MAP:
-      handle_mon_get_map(static_cast<MMonGetMap*>(m));
-      break;
-
     case CEPH_MSG_MON_GET_VERSION:
       handle_get_version(static_cast<MMonGetVersion*>(m));
       break;


### PR DESCRIPTION
We are dropping the requirement for MON_CAP_R for MMonGetMap.

Reason is simple enough: clients may need to contact the monitors and
obtain the latest monmap before authenticating.  This happens, for
instance, when a client calls MonClient::get_monmap_privately().  The
osd uses this function during mkfs, prior to initializing a keyring or
even so much as existing.

Fixes: #9859

Signed-off-by: Joao Eduardo Luis joao@redhat.com
