### PR TITLE
DNM: osd: bump the priority of PG from OSD with most work

### DIFF
--- a/src/messages/MBackfillReserve.h
+++ b/src/messages/MBackfillReserve.h
@@ -33,10 +33,10 @@ public:
 
   MBackfillReserve()
     : Message(MSG_OSD_BACKFILL_RESERVE, HEAD_VERSION, COMPAT_VERSION),
-      query_epoch(0), type(-1), priority(-1) {}
+      query_epoch(0), type(-1), priority(OSD_PRIORITY_NONE) {}
   MBackfillReserve(int type,
 		   spg_t pgid,
-		   epoch_t query_epoch, unsigned prio = -1)
+		   epoch_t query_epoch, unsigned prio = OSD_PRIORITY_NONE)
     : Message(MSG_OSD_BACKFILL_RESERVE, HEAD_VERSION, COMPAT_VERSION),
       pgid(pgid), query_epoch(query_epoch),
       type(type), priority(prio) {}

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1719,6 +1719,9 @@ bool OSD::asok_command(string command, cmdmap_t& cmdmap, string format,
     f->open_object_section("remote_reservations");
     service.remote_reserver.dump(f);
     f->close_section();
+    f->open_object_section("backfill_reservations_stats");
+    service.backfill_reservations_stats.dump(f);
+    f->close_section();
     f->close_section();
   } else {
     assert(0 == "broken asok registration");

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -203,6 +203,73 @@ struct C_CompleteSplits;
 
 typedef ceph::shared_ptr<ObjectStore::Sequencer> SequencerRef;
 
+struct OSDBackfillReservationsStats {
+  mutable Mutex lock;
+
+  uint64_t reserved;
+  uint64_t local_waiting;
+  uint64_t remote_waiting;
+
+  OSDBackfillReservationsStats() :
+    lock("OSDBackfillReservationsStats::lock"),
+    reserved(0),
+    local_waiting(0),
+    remote_waiting(0)
+  { }
+
+  void dump(Formatter *f) {
+    Mutex::Locker l(lock);
+
+    f->dump_unsigned("reserved", reserved);
+    f->dump_unsigned("local_waiting", local_waiting);
+    f->dump_unsigned("remote_waiting", remote_waiting);
+  }
+
+  void reserved_inc() {
+    Mutex::Locker l(lock);
+    ++reserved;
+  }
+  void reserved_dec() {
+    Mutex::Locker l(lock);
+    --reserved;
+  }
+  uint64_t get_reserved() const {
+    Mutex::Locker l(lock);
+    return reserved;
+  }
+
+  void local_waiting_inc() {
+    Mutex::Locker l(lock);
+    ++local_waiting;
+  }
+  void local_waiting_dec() {
+    Mutex::Locker l(lock);
+    --local_waiting;
+  }
+  uint64_t get_local_waiting() const {
+    Mutex::Locker l(lock);
+    return local_waiting;
+  }
+
+  void remote_waiting_inc() {
+    Mutex::Locker l(lock);
+    ++remote_waiting;
+  }
+  void remote_waiting_dec() {
+    Mutex::Locker l(lock);
+    --remote_waiting;
+  }
+  uint64_t get_remote_waiting() const {
+    Mutex::Locker l(lock);
+    return remote_waiting;
+  }
+
+  uint64_t get_sum() const {
+    Mutex::Locker l(lock);
+    return remote_waiting + local_waiting + reserved;
+  }
+};
+
 class DeletingState {
   Mutex lock;
   Cond cond;
@@ -683,6 +750,9 @@ public:
   Finisher reserver_finisher;
   AsyncReserver<spg_t> local_reserver;
   AsyncReserver<spg_t> remote_reserver;
+
+  // -- backfill_reservations_stats --
+  OSDBackfillReservationsStats backfill_reservations_stats;
 
   // -- pg_temp --
   Mutex pg_temp_lock;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -12,6 +12,8 @@
  * 
  */
 
+#include <math.h>
+
 #include "PG.h"
 #include "common/errno.h"
 #include "common/config.h"
@@ -1920,20 +1922,22 @@ unsigned PG::get_recovery_priority()
 unsigned PG::get_backfill_priority()
 {
   // a higher value -> a higher priority
-
-  // undersized: 200 + num missing replicas
+  // the most important factor
+  uint32_t high = 0;
   if (is_undersized()) {
     assert(pool.info.size > actingset.size());
-    return 200 + (pool.info.size - actingset.size());
+    high += MIN(64, 1 + (pool.info.size - actingset.size()));
+  } else if (is_degraded()) {
+    high += 1;
   }
 
-  // degraded: baseline degraded
-  if (is_degraded()) {
-    return 200;
-  }
+  // the less important factor
+  double low = ::log((double)osd->backfill_reservations_stats.get_sum());
 
-  // baseline
-  return 1;
+  uint32_t priority = high * 64 + MIN(64, (int)low);
+
+  // fit it in [1,255]
+  return MIN(255, MAX(1, priority));
 }
 
 void PG::finish_recovery(list<Context*>& tfin)
@@ -5648,6 +5652,7 @@ PG::RecoveryState::Backfilling::Backfilling(my_context ctx)
   pg->state_clear(PG_STATE_BACKFILL_TOOFULL);
   pg->state_clear(PG_STATE_BACKFILL_WAIT);
   pg->state_set(PG_STATE_BACKFILL);
+  pg->osd->backfill_reservations_stats.reserved_inc();
 }
 
 boost::statechart::result
@@ -5693,6 +5698,7 @@ void PG::RecoveryState::Backfilling::exit()
   pg->state_clear(PG_STATE_BACKFILL);
   utime_t dur = ceph_clock_now(pg->cct) - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_backfilling_latency, dur);
+  pg->osd->backfill_reservations_stats.reserved_dec();
 }
 
 /*--WaitRemoteBackfillReserved--*/
@@ -5705,6 +5711,7 @@ PG::RecoveryState::WaitRemoteBackfillReserved::WaitRemoteBackfillReserved(my_con
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
   pg->state_set(PG_STATE_BACKFILL_WAIT);
+  pg->osd->backfill_reservations_stats.remote_waiting_inc();
   post_event(RemoteBackfillReserved());
 }
 
@@ -5743,6 +5750,7 @@ void PG::RecoveryState::WaitRemoteBackfillReserved::exit()
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
   utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  pg->osd->backfill_reservations_stats.remote_waiting_dec();
   pg->osd->recoverystate_perf->tinc(rs_waitremotebackfillreserved_latency, dur);
 }
 
@@ -5790,6 +5798,7 @@ PG::RecoveryState::WaitLocalBackfillReserved::WaitLocalBackfillReserved(my_conte
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
   pg->state_set(PG_STATE_BACKFILL_WAIT);
+  pg->osd->backfill_reservations_stats.local_waiting_inc();
   pg->osd->local_reserver.request_reservation(
     pg->info.pgid,
     new QueuePeeringEvt<LocalBackfillReserved>(
@@ -5803,6 +5812,7 @@ void PG::RecoveryState::WaitLocalBackfillReserved::exit()
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
   utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  pg->osd->backfill_reservations_stats.local_waiting_dec();
   pg->osd->recoverystate_perf->tinc(rs_waitlocalbackfillreserved_latency, dur);
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -59,7 +59,10 @@
 
 
 /// max recovery priority for MBackfillReserve
+#define OSD_PRIORITY_NONE UINT_MAX
+// Keep it low because AsyncReserver creates one queue for each value
 #define OSD_RECOVERY_PRIORITY_MAX 255u
+#define OSD_BACKFILL_PRIORITY_MAX 254u
 
 
 typedef hobject_t collection_list_handle_t;


### PR DESCRIPTION
Based on the number of pending backfill reservations and current
backfills in the primary OSD, increase the priority of the backfill
reservation requests. This will increase the chances of reservations
from the busiest OSDs to succeed and probably shorten the tail of the
recovery process.

http://tracker.ceph.com/issues/9566 Fixes: #9566

Signed-off-by: Loic Dachary <loic-201408@dachary.org>