### PR TITLE
Raise the default value of filestore_queue_max_ops to 500

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -730,7 +730,7 @@ OPTION(filestore_xfs_extsize, OPT_BOOL, false)
 OPTION(filestore_journal_parallel, OPT_BOOL, false)
 OPTION(filestore_journal_writeahead, OPT_BOOL, false)
 OPTION(filestore_journal_trailing, OPT_BOOL, false)
-OPTION(filestore_queue_max_ops, OPT_INT, 50)
+OPTION(filestore_queue_max_ops, OPT_INT, 500)
 OPTION(filestore_queue_max_bytes, OPT_INT, 100 << 20)
 OPTION(filestore_queue_committing_max_ops, OPT_INT, 500)        // this is ON TOP of filestore_queue_max_*
 OPTION(filestore_queue_committing_max_bytes, OPT_INT, 100 << 20) //  "


### PR DESCRIPTION
http://ceph.com/docs/master/rados/configuration/filestore-config-ref/ shows the default value for 'filestore queue max ops' is 500, however, the default value in code is 50. Our testing shows that this default value of 50 could become limiting factor, especially during peering and thus the filestore ops are throttled.

Raise the default value to 500.

Signed-off-by: Guang Yang yguang@yahoo-inc.com
