### PR TITLE
EC: Allow LRC to use different EC backends

### DIFF
--- a/doc/rados/operations/erasure-code-lrc.rst
+++ b/doc/rados/operations/erasure-code-lrc.rst
@@ -59,6 +59,7 @@ To create a new lrc erasure code profile::
              [ruleset-locality={bucket-type}] \
              [ruleset-failure-domain={bucket-type}] \
              [directory={directory}] \
+             [subplugin={jerasure, isa}] \
              [--force]
 
 Where:
@@ -135,6 +136,14 @@ Where:
 :Type: String
 :Required: No.
 :Default: /usr/lib/ceph/erasure-code
+
+``directory={directory}``
+
+:Description: Set the erasure code **plugin** name which is loaded.
+
+:Type: String
+:Required: No.
+:Default: jerasure
 
 ``--force``
 

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -220,8 +220,9 @@ int ErasureCodeLrc::layers_init()
       layer.parameters["k"] = stringify(layer.data.size());
     if (layer.parameters.find("m") == layer.parameters.end())
       layer.parameters["m"] = stringify(layer.coding.size());
-    if (layer.parameters.find("plugin") == layer.parameters.end())
-      layer.parameters["plugin"] = "jerasure";
+    if (layer.parameters.find("plugin") == layer.parameters.end()) {
+      layer.parameters["plugin"] = subplugin;
+    }
     if (layer.parameters.find("technique") == layer.parameters.end())
       layer.parameters["technique"] = "reed_sol_van";
     if (layer.parameters.find("directory") == layer.parameters.end())
@@ -277,6 +278,9 @@ int ErasureCodeLrc::parse(const map<string,string> &parameters,
 
   if (parameters.count("directory") != 0)
     directory = parameters.find("directory")->second;
+
+  if (parameters.count("subplugin") != 0)
+    subplugin = parameters.find("subplugin")->second;
 
   return parse_ruleset(parameters, ss);
 }

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -58,6 +58,7 @@ public:
   };
   vector<Layer> layers;
   string directory;
+  string subplugin;
   unsigned int chunk_count;
   unsigned int data_chunk_count;
   string ruleset_root;
@@ -73,7 +74,7 @@ public:
   vector<Step> ruleset_steps;
 
   ErasureCodeLrc() :
-    chunk_count(0), data_chunk_count(0), ruleset_root("default")
+    chunk_count(0), data_chunk_count(0), ruleset_root("default"), subplugin("jerasure")
   {
     ruleset_steps.push_back(Step("chooseleaf", "host", 0));
   }


### PR DESCRIPTION
LRC now uses jerasure as the EC backend by default. This commit adds
one option("subplugin") in erasure-code-profile that allow to choose
different Erasure Code backends like isa.

Signed-off-by: Yuan Zhou yuan.zhou@intel.com
