### PR TITLE
rgw: fix can not disable max_size quota

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -688,7 +688,11 @@ void set_quota_info(RGWQuotaInfo& quota, int opt_cmd, int64_t max_size, int64_t 
         quota.max_objects = max_objects;
       }
       if (have_max_size) {
-        quota.max_size_kb = rgw_rounded_kb(max_size);
+        if (max_size < 0) {
+          quota.max_size_kb = -1;
+        } else {
+          quota.max_size_kb = rgw_rounded_kb(max_size);
+        }
       }
       break;
     case OPT_QUOTA_DISABLE:


### PR DESCRIPTION
Currently if we enable quota and set max_size = -1 trying to disable max size quota, it turns out to be max_size_kb = 0 and it will cause we can not write any object. The root cause is rgw_rounded_kb returns 0 for -1. We should not convert negative value to uint64_t. 

Sign off by: Dong Lei leidong@yahoo-inc.com
