### PR TITLE
client: cast m->get_client_tid() to compare to 16-bit Inode::flushing_cap_tid

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3860,9 +3860,10 @@ void Client::handle_cap_flush_ack(MetaSession *session, Inode *in, Cap *cap, MCl
   mds_rank_t mds = session->mds_num;
   int dirty = m->get_dirty();
   int cleaned = 0;
+  uint16_t flush_ack_tid = static_cast<uint16_t>(m->get_client_tid());
   for (int i = 0; i < CEPH_CAP_BITS; ++i) {
     if ((dirty & (1 << i)) &&
-	(m->get_client_tid() == in->flushing_cap_tid[i]))
+	(flush_ack_tid == in->flushing_cap_tid[i]))
       cleaned |= 1 << i;
   }
 


### PR DESCRIPTION
m->get_client_tid() is 64 bits (as it should be), but Inode::flushing_cap_tid
is only 16 bits. 16 bits should be plenty to let the cap flush updates
pipeline appropriately, but we need to cast in the proper direction when
comparing these differently-sized versions. So downcast the 64-bit one
to 16 bits.

Fixes: #9869

I tested this manually by bumping up the initial last_flush_tid value to 65535 on master and then turning on the client. There were immediate issues with cap flushing visible on new file creates in the log. Doing the same with this patch applied made everything work fine.
