### PR TITLE
rgw: send http status reason explicitly in fastcgi

### DIFF
--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -33,7 +33,7 @@ void RGWFCGX::init_env(CephContext *cct)
 
 int RGWFCGX::send_status(const char *status, const char *status_name)
 {
-  return print("Status: %s\n", status);
+  return print("Status: %s %s\n", status, status_name);
 }
 
 int RGWFCGX::send_100_continue()


### PR DESCRIPTION
There are issues in certain versions of apache 2.4, where the reason is
not sent back. Instead, just provide the reason explicitly.

Backport: firefly, giant

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
