### PR TITLE
librados: remove unneeded callback in librados::IoCtxImpl::aio_operate

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -556,8 +556,13 @@ int librados::IoCtxImpl::aio_operate(const object_t& oid,
   if (snap_seq != CEPH_NOSNAP)
     return -EROFS;
 
-  Context *onack = new C_aio_Ack(c);
-  Context *oncommit = new C_aio_Safe(c);
+  Context *onack = 0;
+  Context *oncommit = 0;
+
+  if(c->callback_complete)
+    onack = new C_aio_Ack(c);
+  if(c->callback_safe)
+    oncommit = new C_aio_Safe(c);
 
   c->io = this;
   queue_aio_write(c);


### PR DESCRIPTION
There is no need to call the on_ack callback if the request does not requir for it.
In our practice, after this patch applied the rbd_write latency descreased avg 4us.

Signed-off-by: Ketor Meng d.ketor@gmail.com
