### PR TITLE
ReplicatedPG: writeout hit_set object with correct prior_version

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -11185,7 +11185,7 @@ void ReplicatedPG::hit_set_persist()
       pg_log_entry_t::MODIFY,
       oid,
       ctx->at_version,
-      ctx->obs->oi.version,
+      eversion_t(),
       0,
       osd_reqid_t(),
       ctx->mtime)


### PR DESCRIPTION
Fixes: #9875
Backport: giant, firefly
Signed-off-by: Samuel Just sam.just@inktank.com
