### PR TITLE
os/LevelDBStore, RocksDBStore: fix race handling for get store size

### DIFF
--- a/src/os/LevelDBStore.h
+++ b/src/os/LevelDBStore.h
@@ -341,7 +341,10 @@ public:
       // happen when those files are being updated, data is being shuffled
       // and files get removed, in which case there's not much of a problem
       // as we'll get to them next time around.
-      if ((err < 0) && (err != -ENOENT)) {
+      if (err == -ENOENT) {
+	continue;
+      }
+      if (err < 0) {
         lderr(cct) << __func__ << " error obtaining stats for " << fpath
                    << ": " << cpp_strerror(err) << dendl;
         goto err;

--- a/src/os/RocksDBStore.h
+++ b/src/os/RocksDBStore.h
@@ -285,7 +285,10 @@ public:
       // happen when those files are being updated, data is being shuffled
       // and files get removed, in which case there's not much of a problem
       // as we'll get to them next time around.
-      if ((err < 0) && (err != -ENOENT)) {
+      if (err == -ENOENT) {
+	continue;
+      }
+      if (err < 0) {
         lderr(cct) << __func__ << " error obtaining stats for " << fpath
                    << ": " << cpp_strerror(err) << dendl;
         goto err;


### PR DESCRIPTION
If we get ENOENT, skip this file, instead of adding in undefined stat values.

Backport: firefly Signed-off-by: Sage Weil sage@redhat.com
