### PR TITLE
check to_remove before setting transaction

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -799,7 +799,8 @@ void PGLog::_write_log(
   }
   ::encode(log.can_rollback_to, keys["can_rollback_to"]);
 
-  t.omap_rmkeys(META_COLL, log_oid, to_remove);
+  if (to_remove.size())
+    t.omap_rmkeys(META_COLL, log_oid, to_remove);
   t.omap_setkeys(META_COLL, log_oid, keys);
 }
 


### PR DESCRIPTION
currently if you dump transaction for a single rbd write, a transaction
of OMAP_RMKEYS will be listed even if to_remove is empty.

Signed-off-by: xinxin shu xinxin.shu@intel.com
