### PR TITLE
WBThrottle: Call posix_fadvise to free page cache if nocache set in clear()

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -722,6 +722,7 @@ OPTION(filestore_btrfs_clone_range, OPT_BOOL, true)
 OPTION(filestore_zfs_snap, OPT_BOOL, false) // zfsonlinux is still unstable
 OPTION(filestore_fsync_flushes_journal_data, OPT_BOOL, false)
 OPTION(filestore_fiemap, OPT_BOOL, false)     // (try to) use fiemap
+OPTION(filestore_fadvise, OPT_BOOL, true)
 
 // (try to) use extsize for alloc hint
 // WARNING: extsize seems to trigger data corruption in xfs -- that is why it is

--- a/src/os/WBThrottle.cc
+++ b/src/os/WBThrottle.cc
@@ -166,7 +166,7 @@ void *WBThrottle::entry()
     ::fsync(**wb.get<1>());
 #endif
 #ifdef HAVE_POSIX_FADVISE
-    if (wb.get<2>().nocache) {
+    if (g_conf->filestore_fadvise && wb.get<2>().nocache) {
       int fa_r = posix_fadvise(**wb.get<1>(), 0, 0, POSIX_FADV_DONTNEED);
       assert(fa_r == 0);
     }
@@ -220,7 +220,7 @@ void WBThrottle::clear()
        i != pending_wbs.end();
        ++i) {
 #ifdef HAVE_POSIX_FADVISE
-    if (i->second.first.nocache) {
+    if (g_conf->filestore_fadvise && i->second.first.nocache) {
       int fa_r = posix_fadvise(**i->second.second, 0, 0, POSIX_FADV_DONTNEED);
       assert(fa_r == 0);
     }


### PR DESCRIPTION
Because FileStore will sync fs and call clear() to clear all pending
ghobjct. So in clear(), the pending object can free the page cache if
nocache is set.
Signed-off-by: Jianpeng Ma jianpeng.ma@intel.com
