### PR TITLE
osdc: Constrain max number of in-flight read requests

### DIFF
--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -341,6 +341,8 @@ class ObjectCacher {
 
   vector<ceph::unordered_map<sobject_t, Object*> > objects; // indexed by pool_id
 
+  list<Context*> waitfor_read;
+
   ceph_tid_t last_read_tid;
 
   set<BufferHead*>    dirty_or_tx_bh;
@@ -457,6 +459,7 @@ class ObjectCacher {
 
   int _readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 	     bool external_call);
+  void retry_waiting_reads();
 
  public:
   void bh_read_finish(int64_t poolid, sobject_t oid, ceph_tid_t tid,


### PR DESCRIPTION
The ObjectCacher now keeps track of the number of in-flight
read-request bytes.  If the number of in-flight read-request
bytes surpasses the cache size, the read request will be
delayed until previous read requests finish.  This prevents
the cache usage from ballooning in size during read-heavy ops
such as copy-up from a cloned image parent.

Fixes: #9854
Backport: giant, firefly, dumpling
Signed-off-by: Jason Dillaman dillaman@redhat.com
