### PR TITLE
doc: include 'fs new' stuff in cephfs quickstart

### DIFF
--- a/doc/start/quick-cephfs.rst
+++ b/doc/start/quick-cephfs.rst
@@ -28,6 +28,19 @@ Prerequisites
 	ceph -s [-m {monitor-ip-address}] [-k {path/to/ceph.client.admin.keyring}]
 
 
+Create a Filesystem
+===================
+
+You have already created an MDS (`Storage Cluster Quick Start`_) but it will not
+become active until you create some pools and a filesystem.  See :doc:`/cephfs/createfs`.
+
+::
+
+    ceph osd pool create cephfs_data <pg_num>
+    ceph osd pool create cephfs_metadata <pg_num>
+    ceph fs new <fs_name> cephfs_metadata cephfs_data
+
+
 Create a Secret File
 ====================
 


### PR DESCRIPTION
Not sure how 'quick' this really is now compared with
the full filesystem instructions, but let's not leave
it incomplete.

Signed-off-by: John Spray john.spray@redhat.com
