### PR TITLE
msg/Pipe: discard delay queue before incoming queue

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1331,9 +1331,9 @@ void Pipe::fault(bool onread)
     unregister_pipe();
     msgr->lock.Unlock();
 
-    in_q->discard_queue(conn_id);
     if (delay_thread)
       delay_thread->discard();
+    in_q->discard_queue(conn_id);
     discard_out_queue();
 
     // disconnect from Connection, and mark it failed.  future messages


### PR DESCRIPTION
Shutdown the delayed delivery before the incoming queue in case a racing
thread is busy queueing messages.

Signed-off-by: Sage Weil sage@redhat.com
