### PR TITLE
Backport "client: cast m->get_client_tid() to compare to 16-bit Inode::flushing_cap_tid"

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3513,9 +3513,10 @@ void Client::handle_cap_flush_ack(MetaSession *session, Inode *in, Cap *cap, MCl
   int mds = session->mds_num;
   int dirty = m->get_dirty();
   int cleaned = 0;
+  uint16_t flush_ack_tid = (uint16_t)m->get_client_tid();
   for (int i = 0; i < CEPH_CAP_BITS; ++i) {
     if ((dirty & (1 << i)) &&
-	(m->get_client_tid() == in->flushing_cap_tid[i]))
+	(flush_ack_tid == in->flushing_cap_tid[i]))
       cleaned |= 1 << i;
   }
 


### PR DESCRIPTION
m->get_client_tid() is 64 bits (as it should be), but Inode::flushing_cap_tid
is only 16 bits. 16 bits should be plenty to let the cap flush updates
pipeline appropriately, but we need to cast in the proper direction when
comparing these differently-sized versions. So downcast the 64-bit one
to 16 bits.

Fixes: #9869

Signed-off-by: Greg Farnum greg@inktank.com
(cherry picked from commit 7cda0e52924787f4be6f80cf7c3edcef1c995728)
