### PR TITLE
RFC: buffer: implement list::get_contiguous

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -433,6 +433,11 @@ public:
     char *c_str();
     void substr_of(const list& other, unsigned off, unsigned len);
 
+    /// return a pointer to a contiguous extent of the buffer,
+    /// reallocating as needed
+    char *get_contiguous(unsigned off,  ///< offset
+			 unsigned len); ///< length
+
     // funky modifer
     void splice(unsigned off, unsigned len, list *claim_by=0 /*, bufferlist& replace_with */);
     void write(int off, int len, std::ostream& out) const;

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1076,6 +1076,23 @@ TEST(BufferList, buffers) {
   ASSERT_EQ((unsigned)1, bl.buffers().size());
 }
 
+TEST(BufferList, get_contiguous) {
+  bufferptr a("foobarbaz", 9);
+  bufferptr b("123456789", 9);
+  bufferptr c("ABCDEFGHI", 9);
+  bufferlist bl;
+  bl.append(a);
+  bl.append(b);
+  bl.append(c);
+  ASSERT_EQ(3, bl.buffers().size());
+  ASSERT_EQ(0, memcmp("bar", bl.get_contiguous(3, 3), 3));
+  ASSERT_EQ(0, memcmp("456", bl.get_contiguous(12, 3), 3));
+  ASSERT_EQ(0, memcmp("ABC", bl.get_contiguous(18, 3), 3));
+  ASSERT_EQ(3, bl.buffers().size());
+  ASSERT_EQ(0, memcmp("789ABC", bl.get_contiguous(15, 6), 6));
+  ASSERT_LT(bl.buffers().size(), 3);
+}
+
 TEST(BufferList, swap) {
   bufferlist b1;
   b1.append('A');


### PR DESCRIPTION
Return a pointer to a contiguous range of the bufferlist, rebuilding
into a contiguous region as needed.  For now, if we need to rebuild,
we just do the whole thing.  We can obviously optimize this later to
rebuild on the necessary region, but this is good enough for the
(presumably) common case where the needed region is already in fact
contiguous.

Signed-off-by: Sage Weil sage@redhat.com
