### PR TITLE
tools: skip up to expire_pos in journal-tool

### DIFF
--- a/src/tools/cephfs/JournalScanner.cc
+++ b/src/tools/cephfs/JournalScanner.cc
@@ -152,10 +152,17 @@ int JournalScanner::scan_events()
   bool gap = false;
   uint64_t gap_start = -1;
   for (uint64_t obj_offset = (read_offset / object_size); ; obj_offset++) {
+    uint64_t offset_in_obj = 0;
+    if (obj_offset * object_size < header->expire_pos) {
+      // Skip up to expire_pos from start of the object
+      // (happens for the first object we read)
+      offset_in_obj = header->expire_pos - obj_offset * object_size;
+    }
+
     // Read this journal segment
     bufferlist this_object;
     std::string const oid = obj_name(obj_offset);
-    int r = io.read(oid, this_object, INT_MAX, 0);
+    int r = io.read(oid, this_object, INT_MAX, offset_in_obj);
 
     // Handle absent journal segments
     if (r < 0) {


### PR DESCRIPTION
Previously worked for journals starting from an
object boundary (i.e. freshly created filesystems)

Fixes: #9977
Signed-off-by: John Spray john.spray@redhat.com
