### PR TITLE
tools: rados put /dev/null should write() and not create()

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -431,10 +431,9 @@ static int do_put(IoCtx& io_ctx, const char *objname, const char *infile, int op
       goto out;
     }
     if (count == 0) {
-      if (!offset) {
-	ret = io_ctx.create(oid, true);
+      if (!offset) { // in case we have to create an empty object
+	ret = io_ctx.write_full(oid, indata); // indata is empty
 	if (ret < 0) {
-	  cerr << "WARNING: could not create object: " << oid << std::endl;
 	  goto out;
 	}
       }


### PR DESCRIPTION
In the rados.cc special case to handle put an empty objects, use
write_full() instead of create().

A special case was introduced 6843a0b81f10125842c90bc63eccc4fd873b58f2
to create() an object if the rados put file is empty. Prior to this fix
an attempt to rados put an empty file was a noop. The problem with this
fix is that it is not idempotent. rados put an empty file twice would
fail the second time and rados put a file with one byte would succeed as
expected.

Signed-off-by: Loic Dachary loic-201408@dachary.org
(cherry picked from commit 50e80407f3c2f74d77ba876d01e7313c3544ea4d)
