### PR TITLE
rgw: RGWRados::get_obj() returns wrong len if len == 0

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4689,7 +4689,7 @@ int RGWRados::get_obj(void *ctx, RGWObjVersionTracker *objv_tracker, void **hand
     bl.append(read_bl);
 
 done:
-  if (bl.length() > 0) {
+  if (r >= 0) {
     r = bl.length();
   }
   if (r < 0 || !len || ((off_t)(ofs + len - 1) == end)) {


### PR DESCRIPTION
Fixes: #9877
We only updated if len was > 0, should update it if r >= 0. This was the
culprit for issue #9877.
Backport: giant, firefly

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
