### PR TITLE
osd: cache pool: delete dead code in ReplicatedPG::agent_choose_mode

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -11829,11 +11829,7 @@ void ReplicatedPG::agent_choose_mode(bool restart)
     // set effort in [0..1] range based on where we are between
     evict_mode = TierAgentState::EVICT_MODE_SOME;
     uint64_t over = full_micro - evict_target;
-    uint64_t span;
-    if (evict_target >= 1000000)
-      span = 1;
-    else
-      span = 1000000 - evict_target;
+    uint64_t span  = 1000000 - evict_target;
     evict_effort = MAX(over * 1000000 / span,
 		       (unsigned)(1000000.0 * g_conf->osd_agent_min_evict_effort));
 


### PR DESCRIPTION
Because in this case full_micro <= 1000000, full_micro > evict_target, so evict_target must be less than 1000000.
Signed-off-by: Xinze Chi xmdxcxz@gmail.com
