### PR TITLE
osdc: fix Journaler write error handling

### DIFF
--- a/src/osdc/Journaler.h
+++ b/src/osdc/Journaler.h
@@ -319,6 +319,7 @@ private:
   // for wait_for_readable()
   C_OnFinisher    *on_readable;
   C_OnFinisher    *on_write_error;
+  bool             called_write_error;
 
   void _finish_read(int r, uint64_t offset, bufferlist &bl); // read completion callback
   void _finish_retry_read(int r);
@@ -383,7 +384,7 @@ public:
     waiting_for_zero(false),
     read_pos(0), requested_pos(0), received_pos(0),
     fetch_len(0), temp_fetch_len(0),
-    on_readable(0), on_write_error(NULL),
+    on_readable(0), on_write_error(NULL), called_write_error(false),
     expire_pos(0), trimming_pos(0), trimmed_pos(0)
   {
     memset(&layout, 0, sizeof(layout));


### PR DESCRIPTION
Since we started wrapping the write error
handler in a finisher, multiple calls to
handle_write_error would hit the assert()
on the second call before the actual
handler had been called (at the other end
of the finisher) from the first call.

The symptom was that the MDS was intermittently
failing to respawn on blacklist, seen in #10011.

Signed-off-by: John Spray john.spray@redhat.com
