### PR TITLE
Fix rhbz#1157938

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -14,9 +14,9 @@
 
 . /lib/lsb/init-functions
 
-# detect systemd
-SYSTEMD=0
-grep -qs systemd /proc/1/comm && SYSTEMD=1
+# detect systemd, also check whether the systemd-run binary exists
+SYSTEMD_RUN=$(which systemd-run 2>/dev/null)
+grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
 
 # if we start up as ./init-ceph, assume everything else is in the
 # current directory too.
@@ -25,7 +25,7 @@ if [ `dirname $0` = "." ] && [ $PWD != "/etc/init.d" ]; then
     SBINDIR=.
     LIBDIR=.
     ETCDIR=.
-    SYSTEMD=0
+    SYSTEMD_RUN=""
 else
     BINDIR=@bindir@
     SBINDIR=@prefix@/sbin
@@ -300,8 +300,8 @@ for name in $what; do
 	    [ -n "$wrap" ] && runmode="-f &" && runarg="-f"
 	    [ -n "$max_open_files" ] && files="ulimit -n $max_open_files;"
 
-	    if [ $SYSTEMD -eq 1 ]; then
-		cmd="systemd-run -r bash -c '$files $cmd --cluster $cluster -f'"
+	    if [ -n "$SYSTEMD_RUN" ]; then
+		cmd="$SYSTEMD_RUN -r bash -c '$files $cmd --cluster $cluster -f'"
 	    else
 		cmd="$files $wrap $cmd --cluster $cluster $runmode"
 	    fi

--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -45,9 +45,9 @@ if [ ! -x "$RADOSGW" ]; then
     exit 1
 fi
 
-# detect systemd
-SYSTEMD=0
-grep -qs systemd /proc/1/comm && SYSTEMD=1
+# detect systemd, also check whether the systemd-run binary exists
+SYSTEMD_RUN=$(which systemd-run 2>/dev/null)
+grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
 
 case "$1" in
     start)
@@ -84,8 +84,8 @@ case "$1" in
                 chown $user $log_file
             fi
 
-            if [ $SYSTEMD -eq 1 ]; then
-                systemd-run -r bash -c "ulimit -n 32768; $RADOSGW -n $name"
+            if [ -n "$SYSTEMD_RUN" ]; then
+                $SYSTEMD_RUN -r bash -c "ulimit -n 32768; $RADOSGW -n $name"
             else
                 #start-stop-daemon --start -u $user -x $RADOSGW -- -n $name
                 daemon --user="$user" "ulimit -n 32768; $RADOSGW -n $name"


### PR DESCRIPTION
The patch fixes rhbz#1157938 -- the init scripts fail to run the binaries because there is no systemd-run in fedora 19.
