### PR TITLE
qa/workunits/fs/misc: fix permission denied error in acl.sh

### DIFF
--- a/qa/workunits/fs/misc/acl.sh
+++ b/qa/workunits/fs/misc/acl.sh
@@ -19,7 +19,7 @@ do
 	# inherited ACL from parent directory's default ACL
 	mkdir d1
 	c1=`getfacl d1 | grep -c "nobody:rw"`
-	sudo echo 3 > /proc/sys/vm/drop_caches
+	sudo bash -c 'echo 3 > /proc/sys/vm/drop_caches'
 	c2=`getfacl d1 | grep -c "nobody:rw"`
 	rmdir d1
 	if [ $c1 -ne 2 ] || [ $c2 -ne 2 ]


### PR DESCRIPTION
acl.sh: 22:
acl.sh: cannot create /proc/sys/vm/drop_caches: Permission denied

Signed-off-by: Yan, Zheng zyan@redhat.com
