### PR TITLE
KeyValueStore: Some bug fixing in KeyValueStore prevent osd runtime crash

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -764,6 +764,7 @@ OPTION(keyvaluestore_op_thread_timeout, OPT_INT, 60)
 OPTION(keyvaluestore_op_thread_suicide_timeout, OPT_INT, 180)
 OPTION(keyvaluestore_default_strip_size, OPT_INT, 4096) // Only affect new object
 OPTION(keyvaluestore_max_expected_write_size, OPT_U64, 1ULL << 24) // bytes
+OPTION(keyvaluestore_header_cache, OPT_BOOL, false)    // Header cache off by default
 OPTION(keyvaluestore_header_cache_size, OPT_INT, 4096)    // Header cache size
 OPTION(keyvaluestore_backend, OPT_STR, "leveldb")
 

--- a/src/os/KeyValueStore.h
+++ b/src/os/KeyValueStore.h
@@ -69,8 +69,10 @@ class StripObjectMap: public GenericObjectMap {
     bool updated;
     bool deleted;
     map<pair<string, string>, bufferlist> buffers;  // pair(prefix, key)
+    Mutex buffers_mutex;
+    bool enable_buffers;
 
-    StripObjectHeader(): strip_size(default_strip_size), max_size(0), updated(false), deleted(false) {}
+    StripObjectHeader(): strip_size(default_strip_size), max_size(0), updated(false), deleted(false), buffers_mutex("StripObjectHeader::buffers_mutex"), enable_buffers(g_conf->keyvaluestore_header_cache){}
 
     void encode(bufferlist &bl) const {
       ENCODE_START(1, 1, bl);


### PR DESCRIPTION
KeyValueStore: 
    Add mutex when update strip_header->buffers to avoid segmentation fault
    Add option in config_opts.h to turn on/off strip_header->buffers to prevent OOM

When run random write 4k test on rbd with KeyValueStore backend, random osd crashes, and ceph-osd.log shows a segmentation fault which caused by multi threads updating the strip_header->buffers, so add mutex here

Another problem is after running pretty long time, osd being killed by os due to OOM, which is also caused by there is no eviction mechanism in strip_header->buffers, so add a option in config_opts.h to turn strip_header->buffers off by default

Signed-off-by Chendi.Xue chendi.xue@intel.com
