### PR TITLE
LTTng based code profiling; focused on the path in ceph-osd for a write request to an object.

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -160,6 +160,8 @@ LIBOSD_TP = tracing/libosd_tp.la
 LIBRADOS_TP = tracing/librados_tp.la
 LIBRBD_TP = tracing/librbd_tp.la
 LIBOS_TP = tracing/libos_tp.la
+LIBPIPE_TP = tracing/libpipe_tp.la
+LIBASYNCMSGR_TP = tracing/libasyncmsgr_tp.la
 
 if WITH_LIBAIO
 LIBOS += -laio

--- a/src/msg/Makefile.am
+++ b/src/msg/Makefile.am
@@ -83,4 +83,8 @@ noinst_HEADERS += \
 	msg/xio/XioSubmit.h
 endif
 
+if WITH_LTTNG
+libmsg_la_LIBADD = $(LIBPIPE_TP) $(LIBASYNCMSGR_TP)
+endif
+
 noinst_LTLIBRARIES += libmsg.la

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -245,6 +245,7 @@ class AsyncConnection : public Connection {
   // Tis section are temp variables used by state transition
 
   // Open state
+  uint64_t tp_stamps[11];
   utime_t recv_stamp;
   utime_t throttle_stamp;
   uint64_t msg_left;

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1667,13 +1667,13 @@ void Pipe::reader()
       } else {
         if (in_q->can_fast_dispatch(m)) {
 	  reader_dispatching = true;
-	  // set_tp_stamp(tp_stamps[TP_READER_PIPE_UNLOCK], ceph_clock_now(msgr->cct).to_nsec()/1000); 
-          // pipe_lock.Unlock();
+	  set_tp_stamp(tp_stamps[TP_READER_PIPE_UNLOCK], ceph_clock_now(msgr->cct).to_nsec()/1000); 
+          pipe_lock.Unlock();
 	  set_tp_stamp(tp_stamps[TP_READER_DISPATCH], ceph_clock_now(msgr->cct).to_nsec()/1000); 
           in_q->fast_dispatch(m);
 	  set_tp_stamp(tp_stamps[TP_READER_DISPATCH_DONE], ceph_clock_now(msgr->cct).to_nsec()/1000); 
-          // pipe_lock.Lock();
-	  // set_tp_stamp(tp_stamps[TP_READER_PIPE_LOCK2], ceph_clock_now(msgr->cct).to_nsec()/1000); 
+          pipe_lock.Lock();
+	  set_tp_stamp(tp_stamps[TP_READER_PIPE_LOCK2], ceph_clock_now(msgr->cct).to_nsec()/1000); 
 	  reader_dispatching = false;
 	  if (state == STATE_CLOSED ||
 	      notify_on_dispatch_done) { // there might be somebody waiting

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -2343,7 +2343,7 @@ unsigned FileStore::_do_transaction(
 
     _inject_failure();
 
-    if (op != Transaction::OP_WRITE) {
+    if (op->op != Transaction::OP_WRITE) {
       set_tp_stamp(tp_stamps[TP_FSTORE_DO_TA_OTHER_OP_START], ceph_clock_now(g_ceph_context).to_nsec()/1000);
     }
 
@@ -2364,13 +2364,13 @@ unsigned FileStore::_do_transaction(
     case Transaction::OP_WRITE:
       {
         set_tp_stamp(tp_stamps[TP_FSTORE_DO_TA_WRITE_START], ceph_clock_now(g_ceph_context).to_nsec()/1000);
-	coll_t cid = i.decode_cid();
-	ghobject_t oid = i.decode_oid();
-	uint64_t off = i.decode_length();
-	uint64_t len = i.decode_length();
-	bool replica = i.get_replica();
-	bufferlist bl;
-	i.decode_bl(bl);
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        uint64_t off = op->off;
+        uint64_t len = op->len;
+        uint32_t fadvise_flags = i.get_fadvise_flags();
+        bufferlist bl;
+        i.decode_bl(bl);
         set_tp_stamp(tp_stamps[TP_FSTORE_DO_TA_WRITE_DECODE_END], ceph_clock_now(g_ceph_context).to_nsec()/1000);
         tracepoint(objectstore, write_enter, osr_name, off, len);
         if (_check_replay_guard(cid, oid, spos) > 0)

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -2745,9 +2745,9 @@ unsigned FileStore::_do_transaction(
       derr << "bad op " << op->op << dendl;
       assert(0);
     }
-    if (op != Transaction::OP_WRITE) {
+    if (op->op != Transaction::OP_WRITE) {
       set_tp_stamp(tp_stamps[TP_FSTORE_DO_TA_OTHER_OP_END], ceph_clock_now(g_ceph_context).to_nsec()/1000);
-      tracepoint(filestore, do_transaction, pthread_self(), op_seq, trans_num, "unknown", "", 0, 0,  op, tp_nops, tp_stamps);
+      tracepoint(filestore, do_transaction, pthread_self(), op_seq, trans_num, "unknown", "", 0, 0,  op->op, tp_nops, tp_stamps);
     }
 
     if (r < 0) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1765,8 +1765,8 @@ void PG::queue_op(OpRequestRef& op)
 #ifdef WITH_LTTNG
     osd_reqid_t reqid = op->get_reqid();
 #endif
-    tracepoint(pg, queue_op, reqid.name._type,
-        reqid.name._num, reqid.tid, reqid.inc, op->rmw_flags);
+    tracepoint(pg, queue_op, reqid.tid, reqid.name._type,
+        reqid.name._num, reqid.inc, op->rmw_flags, ceph_clock_now(cct).usec());
   }
 }
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -63,11 +63,10 @@
 
 #ifdef WITH_LTTNG
 #include "tracing/osd.h" // ??
-#else
-#define tracepoint(...)
 #define set_tp_stamp(stamp, val) { (stamp) = (val); }
 #define set_tp_stamp_if(cond, stamp, val) { if ((cond)) {(stamp) = (val); } }
 #else
+#define tracepoint(...)
 #define set_tp_stamp(stamp, val)
 #define set_tp_stamp_if(cond, stamp, val)
 #endif
@@ -7692,7 +7691,16 @@ Message * ReplicatedBackend::generate_subop(
     wr->pg_stats = pinfo.stats;  // reflects backfill progress
   else
     wr->pg_stats = get_info().stats;
-    
+
+  wr->pg_trim_to = pg_trim_to;
+  wr->pg_trim_rollback_to = pg_trim_rollback_to;
+
+  wr->new_temp_oid = new_temp_oid;
+  wr->discard_temp_oid = discard_temp_oid;
+  wr->updated_hit_set_history = hset_hist;
+  return wr;
+}
+
 #define TP_ISSUE_OP_START              0
 #define TP_ISSUE_OP_OSD_SUBOP_CREATED  1
 #define TP_ISSUE_OP_SEND_TO_OSD        2

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -65,6 +65,11 @@
 #include "tracing/osd.h" // ??
 #else
 #define tracepoint(...)
+#define set_tp_stamp(stamp, val) { (stamp) = (val); }
+#define set_tp_stamp_if(cond, stamp, val) { if ((cond)) {(stamp) = (val); } }
+#else
+#define set_tp_stamp(stamp, val)
+#define set_tp_stamp_if(cond, stamp, val)
 #endif
 
 #define dout_subsys ceph_subsys_osd
@@ -1368,6 +1373,14 @@ bool ReplicatedPG::check_src_targ(const hobject_t& soid, const hobject_t& toid) 
   return false;
 }
 
+#define TP_DO_OP_START              0
+#define TP_DO_OP_GOT_OP             1
+#define TP_DO_OP_FIND_CONTEXT       2
+#define TP_DO_OP_FIND_CONTEXT_DONE  3
+#define TP_DO_OP_EXECUTE_CTX        4
+#define TP_DO_OP_EXECUTE_CTX_DONE   5
+#define TP_DO_OP_DONE               6
+
 /** do_op - do an op
  * pg lock will be held (if multithreaded)
  * osd_lock NOT held.
@@ -1375,13 +1388,24 @@ bool ReplicatedPG::check_src_targ(const hobject_t& soid, const hobject_t& toid) 
 void ReplicatedPG::do_op(OpRequestRef& op)
 {
   MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+
+  uint64_t tp_stamps[7] = {0,0,0,0,0,0,0};
+
+  tp_stamps[TP_DO_OP_START] = ceph_clock_now(cct).to_nsec()/1000;
+
   assert(m->get_type() == CEPH_MSG_OSD_OP);
   if (op->includes_pg_op()) {
     if (pg_op_must_wait(m)) {
       wait_for_all_missing(op);
       return;
     }
-    return do_pg_op(op);
+    do_pg_op(op);
+    set_tp_stamp(tp_stamps[TP_DO_OP_DONE], ceph_clock_now(cct).to_nsec()/1000);
+    osd_reqid_t reqid = op->get_reqid();
+    tracepoint(osd, rpg_do_op, pthread_self(), m->get_tid(), m->get_seq(), m->get_type(),
+        reqid.tid, reqid.name._num, reqid.inc, tp_stamps);
+
+    return;
   }
 
   if (get_osdmap()->is_blacklisted(m->get_source_addr())) {
@@ -1390,6 +1414,8 @@ void ReplicatedPG::do_op(OpRequestRef& op)
     return;
   }
 
+  set_tp_stamp(tp_stamps[TP_DO_OP_GOT_OP], ceph_clock_now(cct).to_nsec()/1000);
+  
   // order this op as a write?
   bool write_ordered =
     op->may_write() ||
@@ -1499,6 +1525,7 @@ void ReplicatedPG::do_op(OpRequestRef& op)
     return;
   }
 
+  set_tp_stamp(tp_stamps[TP_DO_OP_FIND_CONTEXT], ceph_clock_now(cct).to_nsec()/1000);
   int r = find_object_context(
     oid, &obc, can_create,
     m->get_flags() & CEPH_OSD_FLAG_MAP_SNAP_CLONE,
@@ -1534,6 +1561,8 @@ void ReplicatedPG::do_op(OpRequestRef& op)
       return;
     }
   }
+
+  set_tp_stamp(tp_stamps[TP_DO_OP_FIND_CONTEXT_DONE], ceph_clock_now(cct).to_nsec()/1000);
 
   bool in_hit_set = false;
   if (hit_set) {
@@ -1740,7 +1769,16 @@ void ReplicatedPG::do_op(OpRequestRef& op)
   op->mark_started();
   ctx->src_obc = src_obc;
 
+  set_tp_stamp(tp_stamps[TP_DO_OP_EXECUTE_CTX], ceph_clock_now(cct).to_nsec()/1000);
   execute_ctx(ctx);
+  set_tp_stamp(tp_stamps[TP_DO_OP_EXECUTE_CTX_DONE], ceph_clock_now(cct).to_nsec()/1000);
+  set_tp_stamp(tp_stamps[TP_DO_OP_DONE], ceph_clock_now(cct).to_nsec()/1000);
+
+  {
+    osd_reqid_t reqid = op->get_reqid();
+    tracepoint(osd, rpg_do_op, pthread_self(), m->get_tid(), m->get_seq(), m->get_type(),
+       reqid.tid, reqid.name._num, reqid.inc, tp_stamps);
+  }
 }
 
 bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
@@ -2133,8 +2171,21 @@ void ReplicatedPG::promote_object(ObjectContextRef obc,
     wait_for_blocked_object(obc->obs.oi.soid, op);
 }
 
+#define TP_EXECUTE_START              0
+#define TP_EXECUTE_PREPARE            1
+#define TP_EXECUTE_PREPARE_DONE       2
+#define TP_EXECUTE_REPLY_ALLOCATED    3
+#define TP_EXECUTE_NEW_REPOP          4
+#define TP_EXECUTE_ISSUE_REPOP        5
+#define TP_EXECUTE_EVAL_REPOP         6
+#define TP_EXECUTE_DONE               7
+
 void ReplicatedPG::execute_ctx(OpContext *ctx)
 {
+  uint64_t tp_stamps[8] = {0,0,0,0,0,0,0,0};
+
+  tp_stamps[TP_EXECUTE_START] = ceph_clock_now(cct).usec();
+
   dout(10) << __func__ << " " << ctx << dendl;
   ctx->reset_obs(ctx->obc);
   OpRequestRef op = ctx->op;
@@ -2201,6 +2252,7 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
     p->second->ondisk_read_lock();
   }
 
+#if 0
   {
 #ifdef WITH_LTTNG
     osd_reqid_t reqid = ctx->op->get_reqid();
@@ -2208,9 +2260,15 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
     tracepoint(osd, prepare_tx_enter, reqid.name._type,
         reqid.name._num, reqid.tid, reqid.inc);
   }
+#endif
+
+  set_tp_stamp(tp_stamps[TP_EXECUTE_PREPARE], ceph_clock_now(cct).to_nsec()/1000);
 
   int result = prepare_transaction(ctx);
 
+  set_tp_stamp(tp_stamps[TP_EXECUTE_PREPARE_DONE], ceph_clock_now(cct).to_nsec()/1000);
+
+#if 0
   {
 #ifdef WITH_LTTNG
     osd_reqid_t reqid = ctx->op->get_reqid();
@@ -2218,6 +2276,7 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
     tracepoint(osd, prepare_tx_exit, reqid.name._type,
         reqid.name._num, reqid.tid, reqid.inc);
   }
+#endif
 
   if (op->may_read()) {
     dout(10) << " dropping ondisk_read_lock" << dendl;
@@ -2250,6 +2309,8 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
   // prepare the reply
   ctx->reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(), 0,
 			       successful_write);
+  set_tp_stamp(tp_stamps[TP_EXECUTE_REPLY_ALLOCATED], ceph_clock_now(cct).to_nsec()/1000);
+
 
   // Write operations aren't allowed to return a data payload because
   // we can't do so reliably. If the client has to resend the request
@@ -2310,14 +2371,25 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
 
   // issue replica writes
   ceph_tid_t rep_tid = osd->get_tid();
+
+  set_tp_stamp(tp_stamps[TP_EXECUTE_NEW_REPOP], ceph_clock_now(cct).to_nsec()/1000);
+
   RepGather *repop = new_repop(ctx, obc, rep_tid);  // new repop claims our obc, src_obc refs
   // note: repop now owns ctx AND ctx->op
 
   repop->src_obc.swap(src_obc); // and src_obc.
 
+  set_tp_stamp(tp_stamps[TP_EXECUTE_ISSUE_REPOP], ceph_clock_now(cct).to_nsec()/1000);
+
   issue_repop(repop, now);
 
+  set_tp_stamp(tp_stamps[TP_EXECUTE_EVAL_REPOP], ceph_clock_now(cct).to_nsec()/1000);
+
   eval_repop(repop);
+
+  set_tp_stamp(tp_stamps[TP_EXECUTE_DONE], ceph_clock_now(cct).to_nsec()/1000);
+  tracepoint(osd, rpg_execute_ctx, pthread_self(), m->get_tid(), m->get_seq(), m->get_type(), ctx->reply->get_tid(), rep_tid, tp_stamps);
+
   repop->put();
 }
 
@@ -7344,9 +7416,17 @@ void ReplicatedPG::op_applied(const eversion_t &applied_version)
   }
 }
 
+#define TP_EVAL_REPOP_START              0
+#define TP_EVAL_REPOP_ALL_COMMITTED      1
+#define TP_EVAL_REPOP_ALL_APPLIED1       2
+#define TP_EVAL_REPOP_ALL_APPLIED2       3
+#define TP_EVAL_REPOP_DONE               4
+
 void ReplicatedPG::eval_repop(RepGather *repop)
 {
   MOSDOp *m = NULL;
+  uint64_t tp_stamps[5] = {0,0,0,0,0};
+  
   if (repop->ctx->op)
     m = static_cast<MOSDOp *>(repop->ctx->op->get_req());
 
@@ -7364,6 +7444,7 @@ void ReplicatedPG::eval_repop(RepGather *repop)
     return;
 
   if (m) {
+    set_tp_stamp(tp_stamps[TP_EVAL_REPOP_START], ceph_clock_now(cct).to_nsec()/1000);
 
     // an 'ondisk' reply implies 'ack'. so, prefer to send just one
     // ondisk instead of ack followed by ondisk.
@@ -7407,6 +7488,7 @@ void ReplicatedPG::eval_repop(RepGather *repop)
 	}
 	reply->add_flags(CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK);
 	dout(10) << " sending commit on " << *repop << " " << reply << dendl;
+        set_tp_stamp(tp_stamps[TP_EVAL_REPOP_ALL_COMMITTED], ceph_clock_now(cct).to_nsec()/1000);
 	osd->send_message_osd_client(reply, m->get_connection());
 	repop->sent_disk = true;
 	repop->ctx->op->mark_commit_sent();
@@ -7427,6 +7509,7 @@ void ReplicatedPG::eval_repop(RepGather *repop)
 	  reply->set_reply_versions(repop->ctx->at_version,
 	                            repop->ctx->user_at_version);
 	  reply->add_flags(CEPH_OSD_FLAG_ACK);
+          set_tp_stamp(tp_stamps[TP_EVAL_REPOP_ALL_APPLIED1], ceph_clock_now(cct).to_nsec()/1000);
 	  osd->send_message_osd_client(reply, m->get_connection());
 	}
 	waiting_for_ack.erase(repop->v);
@@ -7445,6 +7528,7 @@ void ReplicatedPG::eval_repop(RepGather *repop)
 	reply->add_flags(CEPH_OSD_FLAG_ACK);
 	dout(10) << " sending ack on " << *repop << " " << reply << dendl;
         assert(entity_name_t::TYPE_OSD != m->get_connection()->peer_type);
+        set_tp_stamp(tp_stamps[TP_EVAL_REPOP_ALL_APPLIED2], ceph_clock_now(cct).to_nsec()/1000);
 	osd->send_message_osd_client(reply, m->get_connection());
 	repop->sent_ack = true;
       }
@@ -7456,6 +7540,8 @@ void ReplicatedPG::eval_repop(RepGather *repop)
       if (repop->ctx->readable_stamp == utime_t())
 	repop->ctx->readable_stamp = ceph_clock_now(cct);
     }
+    set_tp_stamp(tp_stamps[TP_EVAL_REPOP_DONE], ceph_clock_now(cct).to_nsec()/1000);
+    tracepoint(osd, eval_repop, pthread_self(), m->get_tid(), m->get_seq(), m->get_type(), tp_stamps);
   }
 
   // done.
@@ -7607,14 +7693,10 @@ Message * ReplicatedBackend::generate_subop(
   else
     wr->pg_stats = get_info().stats;
     
-  wr->pg_trim_to = pg_trim_to;
-  wr->pg_trim_rollback_to = pg_trim_rollback_to;
-
-  wr->new_temp_oid = new_temp_oid;
-  wr->discard_temp_oid = discard_temp_oid;
-  wr->updated_hit_set_history = hset_hist;
-  return wr;
-}
+#define TP_ISSUE_OP_START              0
+#define TP_ISSUE_OP_OSD_SUBOP_CREATED  1
+#define TP_ISSUE_OP_SEND_TO_OSD        2
+#define TP_ISSUE_OP_SEND_TO_OSD_DONE   3
 
 void ReplicatedBackend::issue_op(
   const hobject_t &soid,
@@ -7630,6 +7712,9 @@ void ReplicatedBackend::issue_op(
   InProgressOp *op,
   ObjectStore::Transaction *op_t)
 {
+  uint64_t tp_stamps[3] = {0,0,0};
+  int tp_iterations = 0;
+
 
   if (parent->get_actingbackfill_shards().size() > 1) {
     ostringstream ss;
@@ -7647,6 +7732,7 @@ void ReplicatedBackend::issue_op(
     pg_shard_t peer = *i;
     const pg_info_t &pinfo = parent->get_shard_info().find(peer)->second;
 
+    set_tp_stamp(tp_stamps[TP_ISSUE_OP_START], ceph_clock_now(cct).to_nsec()/1000);
     Message *wr;
     uint64_t min_features = parent->min_peer_features();
     if (!(min_features & CEPH_FEATURE_OSD_REPOP)) {
@@ -7684,8 +7770,13 @@ void ReplicatedBackend::issue_op(
 	    pinfo);
     }
 
+    // set_tp_stamp(tp_stamps[TP_ISSUE_OP_OSD_SUBOP_CREATED], ceph_clock_now(cct).to_nsec()/1000);
+    set_tp_stamp(tp_stamps[TP_ISSUE_OP_SEND_TO_OSD], ceph_clock_now(cct).to_nsec()/1000);
     get_parent()->send_message_osd_cluster(
       peer.osd, wr, get_osdmap()->get_epoch());
+    set_tp_stamp(tp_stamps[TP_ISSUE_OP_SEND_TO_OSD_DONE], ceph_clock_now(cct).to_nsec()/1000);
+    tp_iterations++;
+    tracepoint(osd, rbe_issue_op, pthread_self(), tid, 0, 0, reqid.tid, tp_iterations, tp_stamps);
   }
 }
 
@@ -8405,6 +8496,15 @@ void ReplicatedBackend::sub_op_modify(OpRequestRef op) {
   }
 }
 
+#define TP_SUB_OP_MODIFY_START              0
+#define TP_SUB_OP_MODIFY_MARK_STARTED       1
+#define TP_SUB_OP_MODIFY_UPDATE_STATS       2
+#define TP_SUB_OP_MODIFY_PARENT_LOG         3
+#define TP_SUB_OP_MODIFY_PARENT_LOG_DONE    4
+#define TP_SUB_OP_MODIFY_MARK_STARTED2      5
+#define TP_SUB_OP_MODIFY_QUEUE_TRANSACTION  6
+#define TP_SUB_OP_MODIFY_END                7
+
 template<typename T, int MSGTYPE>
 void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
 {
@@ -8412,9 +8512,11 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
   int msg_type = m->get_type();
   assert(MSGTYPE == msg_type);
   assert(msg_type == MSG_OSD_SUBOP || msg_type == MSG_OSD_REPOP);
+  uint64_t tp_stamps[8] = {0,0,0,0,0,0,0,0};
 
   const hobject_t& soid = m->poid;
 
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_START], ceph_clock_now(cct).to_nsec()/1000);
   dout(10) << "sub_op_modify trans"
            << " " << soid 
            << " v " << m->version
@@ -8431,6 +8533,7 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
   int ackerosd = m->get_source().num();
   
   op->mark_started();
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_MARK_STARTED], ceph_clock_now(cct).to_nsec()/1000);
 
   RepModifyRef rm(new RepModify);
   rm->op = op;
@@ -8473,7 +8576,9 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
     // collections now.  Otherwise, we do it later on push.
     update_snaps = true;
   }
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_UPDATE_STATS], ceph_clock_now(cct).to_nsec()/1000);
   parent->update_stats(m->pg_stats);
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_PARENT_LOG], ceph_clock_now(cct).to_nsec()/1000);
   parent->log_operation(
     log,
     m->updated_hit_set_history,
@@ -8481,10 +8586,11 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
     m->pg_trim_rollback_to,
     update_snaps,
     &(rm->localt));
-
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_PARENT_LOG_DONE], ceph_clock_now(cct).to_nsec()/1000);
   rm->bytes_written = rm->opt.get_encoded_bytes();
   
   op->mark_started();
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_MARK_STARTED2], ceph_clock_now(cct).to_nsec()/1000);
 
   rm->localt.append(rm->opt);
   rm->localt.register_on_commit(
@@ -8493,12 +8599,25 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
   rm->localt.register_on_applied(
     parent->bless_context(
       new C_OSD_RepModifyApply(this, rm)));
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_QUEUE_TRANSACTION], ceph_clock_now(cct).to_nsec()/1000);
   parent->queue_transaction(&(rm->localt), op);
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_END], ceph_clock_now(cct).to_nsec()/1000);
+  tracepoint(osd, rbe_sub_op_modify, pthread_self(), m->reqid.tid, tp_stamps);
   // op is cleaned up by oncommit/onapply when both are executed
 }
 
+#define TP_SUB_OP_MODIFY_APPLIED_START              0
+#define TP_SUB_OP_MODIFY_APPLIED_SEND_START         1
+#define TP_SUB_OP_MODIFY_APPLIED_SEND_DONE          2
+#define TP_SUB_OP_MODIFY_APPLIED_CALL_PARENT        3
+#define TP_SUB_OP_MODIFY_APPLIED_END                4
+
 void ReplicatedBackend::sub_op_modify_applied(RepModifyRef rm)
 {
+  uint64_t tp_stamps[5] = {0,0,0,0,0};
+  ceph_tid_t tp_ack_tid = 0;
+  
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_APPLIED_START], ceph_clock_now(cct).to_nsec()/1000);
   rm->op->mark_event("sub_op_applied");
   rm->applied = true;
 
@@ -8531,15 +8650,29 @@ void ReplicatedBackend::sub_op_modify_applied(RepModifyRef rm)
   // send ack to acker only if we haven't sent a commit already
   if (ack) {
     ack->set_priority(CEPH_MSG_PRIO_HIGH); // this better match commit priority!
+    set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_APPLIED_SEND_START], ceph_clock_now(cct).to_nsec()/1000);
     get_parent()->send_message_osd_cluster(
       rm->ackerosd, ack, get_osdmap()->get_epoch());
+    set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_APPLIED_SEND_DONE], ceph_clock_now(cct).to_nsec()/1000);
+    tp_ack_tid = ack->reqid.tid;
   }
   
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_APPLIED_CALL_PARENT], ceph_clock_now(cct).to_nsec()/1000);
   parent->op_applied(version);
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_APPLIED_END], ceph_clock_now(cct).to_nsec()/1000);
+  tracepoint(osd, rbe_sub_op_modify_applied, pthread_self(), m->reqid.tid, tp_ack_tid, tp_stamps);
 }
+
+#define TP_SUB_OP_MODIFY_COMMIT_START              0
+#define TP_SUB_OP_MODIFY_COMMIT_SEND_START         1
+#define TP_SUB_OP_MODIFY_COMMIT_SEND_DONE          2
+#define TP_SUB_OP_MODIFY_COMMIT_END                3
 
 void ReplicatedBackend::sub_op_modify_commit(RepModifyRef rm)
 {
+  uint64_t tp_stamps[4] = {0,0,0,0};
+  
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_COMMIT_START], ceph_clock_now(cct).to_nsec()/1000);
   rm->op->mark_commit_sent();
   rm->committed = true;
 
@@ -8574,10 +8707,14 @@ void ReplicatedBackend::sub_op_modify_commit(RepModifyRef rm)
   }
 
   commit->set_priority(CEPH_MSG_PRIO_HIGH); // this better match ack priority!
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_COMMIT_SEND_START], ceph_clock_now(cct).to_nsec()/1000);
   get_parent()->send_message_osd_cluster(
     rm->ackerosd, commit, get_osdmap()->get_epoch());
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_COMMIT_SEND_DONE], ceph_clock_now(cct).to_nsec()/1000);
   
   log_subop_stats(get_parent()->get_logger(), rm->op, l_osd_sop_w);
+  set_tp_stamp(tp_stamps[TP_SUB_OP_MODIFY_COMMIT_END], ceph_clock_now(cct).to_nsec()/1000);
+  tracepoint(osd, rbe_sub_op_modify_commit, pthread_self(), rm->op->get_reqid().tid, commit->reqid.tid, tp_stamps);
 }
 
 

--- a/src/tracing/Makefile.am
+++ b/src/tracing/Makefile.am
@@ -11,7 +11,11 @@ dist_noinst_DATA = \
 	oprequest.tp \
 	osd.tp \
 	pg.tp \
-	objectstore.tp
+	objectstore.tp \
+	filejournal.tp \
+	filestore.tp \
+	pipe.tp \
+	asyncmsgr.tp
 
 if WITH_LTTNG
 nodist_libosd_tp_la_SOURCES = \
@@ -20,11 +24,31 @@ nodist_libosd_tp_la_SOURCES = \
 	osd.c \
 	osd.h \
 	pg.h \
-	pg.c
+	pg.c \
+	filejournal.h \
+	filejournal.c
 endif
 libosd_tp_la_LIBADD = -llttng-ust -ldl
 libosd_tp_la_CPPFLAGS = -DTRACEPOINT_PROBE_DYNAMIC_LINKAGE
 libosd_tp_la_LDFLAGS =
+
+if WITH_LTTNG
+nodist_libpipe_tp_la_SOURCES = \
+	pipe.c \
+	pipe.h
+endif
+libpipe_tp_la_LIBADD = -llttng-ust -ldl
+libpipe_tp_la_CPPFLAGS = -DTRACEPOINT_PROBE_DYNAMIC_LINKAGE
+libpipe_tp_la_LDFLAGS =
+
+if WITH_LTTNG
+nodist_libasyncmsgr_tp_la_SOURCES = \
+	asyncmsgr.c \
+	asyncmsgr.h
+endif
+libasyncmsgr_tp_la_LIBADD = -llttng-ust -ldl
+libasyncmsgr_tp_la_CPPFLAGS = -DTRACEPOINT_PROBE_DYNAMIC_LINKAGE
+libasyncmsgr_tp_la_LDFLAGS =
 
 if WITH_LTTNG
 nodist_librados_tp_la_SOURCES = \
@@ -48,6 +72,10 @@ librbd_tp_la_LDFLAGS =
 
 if WITH_LTTNG
 nodist_libos_tp_la_SOURCES = \
+	filejournal.c \
+	filejournal.h \
+	filestore.c \
+	filestore.h \
 	objectstore.c \
 	objectstore.h
 endif
@@ -61,7 +89,9 @@ noinst_LTLIBRARIES = \
 	libosd_tp.la \
 	librados_tp.la \
 	librbd_tp.la \
-	libos_tp.la
+	libos_tp.la \
+	libpipe_tp.la \
+	libasyncmsgr_tp.la
 
 BUILT_SOURCES = \
 	librados.h \
@@ -69,11 +99,17 @@ BUILT_SOURCES = \
 	oprequest.h \
 	osd.h \
 	pg.h \
-	objectstore.h
+	objectstore.h \
+	filejournal.h \
+	filestore.h \
+	pipe.h \
+	asyncmsgr.h
 endif
 
 CLEANFILES = \
 	$(nodist_libosd_tp_la_SOURCES) \
 	$(nodist_librados_tp_la_SOURCES) \
 	$(nodist_librbd_tp_la_SOURCES) \
-	$(nodist_libos_tp_la_SOURCES)
+	$(nodist_libos_tp_la_SOURCES) \
+	$(nodist_libpipe_tp_la_SOURCES) \
+	$(nodist_libaysncmsgr_tp_la_SOURCES)

--- a/src/tracing/asyncmsgr.tp
+++ b/src/tracing/asyncmsgr.tp
@@ -1,0 +1,33 @@
+TRACEPOINT_EVENT(asyncmsgr, process,
+    TP_ARGS(
+        uint64_t,  threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_array(uint64_t, stamps, stamps, 11)
+    )
+)
+
+TRACEPOINT_EVENT(asyncmsgr, handle_write,
+    TP_ARGS(
+        uint64_t,  threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        uint64_t,  data_len,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_integer(uint64_t, data_len, data_len)
+        ctf_array(uint64_t, stamps, stamps, 4)
+    )
+)

--- a/src/tracing/filejournal.tp
+++ b/src/tracing/filejournal.tp
@@ -1,0 +1,14 @@
+TRACEPOINT_EVENT(filejournal, prep_single_write,
+    TP_ARGS(
+        uint64_t,  threadid,
+        uint64_t,  tid,
+        int32_t,  qlen,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer_hex(int32_t, journalq_len, qlen)
+        ctf_array(uint64_t, stamps, stamps, 3)
+    )
+)
+

--- a/src/tracing/filestore.tp
+++ b/src/tracing/filestore.tp
@@ -1,0 +1,64 @@
+
+TRACEPOINT_EVENT(filestore, queue_transactions,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t,  tid,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_array(uint64_t, stamps, stamps, 3)
+    )
+)
+
+TRACEPOINT_EVENT(filestore, do_op,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t, op_seq,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer(uint64_t, op_seq, op_seq)
+        ctf_array(uint64_t, stamps, stamps, 4)
+    )
+)
+
+TRACEPOINT_EVENT(filestore, do_transactions,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t, op_seq,
+        int32_t, trans_num,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer(uint64_t, op_seq, op_seq)
+        ctf_integer(int32_t, trans_num, trans_num)
+        ctf_array(uint64_t, stamps, stamps, 4)
+    )
+)
+
+TRACEPOINT_EVENT(filestore, do_transaction,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t, op_seq,
+        int32_t, trans_num,
+        const char*,  oid,
+        const char*,  cid,
+        uint64_t, off,
+        uint64_t, len,
+	int32_t, tp_op,
+        int32_t, tp_nops,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer(uint64_t, op_seq, op_seq)
+        ctf_integer(int32_t, trans_num, trans_num)
+        ctf_string(oid, oid)
+        ctf_string(cid, cid)
+        ctf_integer(uint64_t, off, off)
+        ctf_integer(uint64_t, len, len)
+        ctf_integer(int32_t, tp_op, tp_op)
+        ctf_integer(int32_t, tp_nops, tp_nops)
+        ctf_array(uint64_t, stamps, stamps, 8)
+    )
+)

--- a/src/tracing/osd.tp
+++ b/src/tracing/osd.tp
@@ -30,21 +30,6 @@ TRACEPOINT_EVENT(osd, prepare_tx_exit,
     )
 )
 
-TRACEPOINT_EVENT(osd, ms_fast_dispatch,
-    TP_ARGS(
-        // osd_reqid_t
-        uint8_t,  type,
-        int64_t,  num,
-        uint64_t, tid,
-        int32_t,  inc),
-    TP_FIELDS(
-        ctf_integer(uint8_t, type, type)
-        ctf_integer(int64_t, num, num)
-        ctf_integer(uint64_t, tid, tid)
-        ctf_integer(int32_t, inc, inc)
-    )
-)
-
 TRACEPOINT_EVENT(osd, opwq_process_start,
     TP_ARGS(
         // osd_reqid_t
@@ -756,3 +741,236 @@ TRACEPOINT_EVENT(osd, do_osd_op_post,
         ctf_integer_hex(int, result, result)
     )
 )
+
+TRACEPOINT_EVENT(osd, ms_fast_dispatch,
+    TP_ARGS(
+        uint64_t,  threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        int64_t,  data_len,
+        uint64_t,  reqtid,
+        int64_t,  reqnum,
+        int32_t,  reqinc,
+        int64_t,  pg_qlen,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_integer(int64_t, data_len, data_len)
+        ctf_integer_hex(uint64_t, reqtid, reqtid)
+        ctf_integer(int64_t, reqnum, reqnum)
+        ctf_integer(int32_t, reqinc, reqinc)
+        ctf_integer(int64_t, pg_qlen, pg_qlen)
+        ctf_array(uint64_t, stamps, stamps, 2)
+    )
+)
+
+TRACEPOINT_EVENT(osd, opwq_process,
+    TP_ARGS(
+        uint64_t, threadid,
+        // osd_reqid_t
+        uint64_t, tid,
+        int,      reqtype,
+        int64_t,  reqnum,
+        int32_t,  reqinc,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint8_t, reqtype, reqtype)
+        ctf_integer(int64_t, reqnum, reqnum)
+        ctf_integer(int32_t, reqinc, reqinc)
+        ctf_array(uint64_t, stamps, stamps, 4)
+    )
+)
+
+
+TRACEPOINT_EVENT(osd, rpg_do_op,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        uint64_t, reqtid,
+        int64_t,  reqnum,
+        int32_t,  reqinc,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_integer_hex(uint64_t, reqtid, reqtid)
+        ctf_integer(int64_t, reqnum, reqnum)
+        ctf_integer(int32_t, reqinc, reqinc)
+        ctf_array(uint64_t, stamps, stamps, 7)
+    )
+)
+
+TRACEPOINT_EVENT(osd, rpg_execute_ctx,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        uint64_t, replytid,
+        uint64_t, repoptid,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_integer_hex(uint64_t, replytid, replytid)
+        ctf_integer_hex(uint64_t, repoptid, repoptid)
+        ctf_array(uint64_t, stamps, stamps, 8)
+    )
+)
+
+TRACEPOINT_EVENT(osd, handle_op,
+    TP_ARGS(
+        uint64_t,  threadid,
+        uint64_t,  tid,
+        uint32_t,  seq,
+        int,       type,
+        uint64_t,  data_len,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint8_t, seq, seq)
+        ctf_integer(int64_t, type, type)
+        ctf_integer(uint64_t, data_len, data_len)
+        ctf_array(uint64_t, stamps, stamps, 5)
+    )
+)
+
+TRACEPOINT_EVENT(osd, handle_replica_op,
+    TP_ARGS(
+        uint64_t,  threadid,
+        uint64_t,  tid,
+        uint32_t,  seq,
+        int,       type,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint8_t, seq, seq)
+        ctf_integer(int64_t, type, type)
+        ctf_array(uint64_t, stamps, stamps, 4)
+    )
+)
+
+TRACEPOINT_EVENT(osd, rbe_submit_transaction,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        uint64_t, origtid,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_integer_hex(uint64_t, origtid, origtid)
+        ctf_array(uint64_t, stamps, stamps, 8)
+    )
+)
+
+TRACEPOINT_EVENT(osd, rbe_issue_op,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        uint64_t, origtid,
+        int32_t,  iteration,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_integer_hex(uint64_t, origtid, origtid)
+        ctf_integer(int32_t, iteration, iteration)
+        ctf_array(uint64_t, stamps, stamps, 4)
+    )
+)
+
+TRACEPOINT_EVENT(osd, rbe_sub_op_modify,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t,  tid,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_array(uint64_t, stamps, stamps, 8)
+    )
+)
+
+TRACEPOINT_EVENT(osd, rbe_sub_op_modify_reply,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t,  tid,
+        uint32_t,  seq,
+        uint64_t,  origtid,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer_hex(uint64_t, origtid, origtid)
+        ctf_array(uint64_t, stamps, stamps, 4)
+    )
+)
+
+TRACEPOINT_EVENT(osd, rbe_sub_op_modify_applied,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t,  tid,
+        uint64_t,  acktid,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer_hex(uint64_t, acktid, acktid)
+        ctf_array(uint64_t, stamps, stamps, 5)
+    )
+)
+
+TRACEPOINT_EVENT(osd, rbe_sub_op_modify_commit,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t,  tid,
+        uint64_t,  committid,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer_hex(uint64_t, committid, committid)
+        ctf_array(uint64_t, stamps, stamps, 4)
+    )
+)
+
+TRACEPOINT_EVENT(osd, eval_repop,
+    TP_ARGS(
+        uint64_t, threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_array(uint64_t, stamps, stamps, 5)
+    )
+)
+

--- a/src/tracing/pg.tp
+++ b/src/tracing/pg.tp
@@ -3,16 +3,18 @@
 TRACEPOINT_EVENT(pg, queue_op,
     TP_ARGS(
         // osd_reqid_t
-        uint8_t,  type,
-        int64_t,  num,
         uint64_t, tid,
+        uint8_t,  type,
+        int64_t,  reqnum,
         int32_t,  inc,
-        int,      rmw_flags),
+        int,      rmw_flags,
+        int32_t,  stamp),
     TP_FIELDS(
+        ctf_integer_hex(uint64_t, tid, tid)
         ctf_integer(uint8_t, type, type)
-        ctf_integer(int64_t, num, num)
-        ctf_integer(uint64_t, tid, tid)
+        ctf_integer(int64_t, reqnum, reqnum)
         ctf_integer(int32_t, inc, inc)
-        ctf_integer(int, rmw_flags, rmw_flags)
+        ctf_integer_hex(int, rmw_flags, rmw_flags)
+        ctf_integer(int, stamp, stamp)
     )
 )

--- a/src/tracing/pipe.tp
+++ b/src/tracing/pipe.tp
@@ -1,0 +1,71 @@
+TRACEPOINT_EVENT(pipe, reader,
+    TP_ARGS(
+        uint64_t,  threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        uint64_t,  data_len,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_integer(uint64_t, data_len, data_len)
+        ctf_array(uint64_t, stamps, stamps, 9)
+    )
+)
+
+TRACEPOINT_EVENT(pipe, writer,
+    TP_ARGS(
+        uint64_t,  threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        uint64_t,  data_len,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_integer(uint64_t, data_len, data_len)
+        ctf_array(uint64_t, stamps, stamps, 6)
+    )
+)
+
+TRACEPOINT_EVENT(pipe, read_message,
+    TP_ARGS(
+        uint64_t,  threadid,
+        uint64_t,  tid,
+        uint32_t, seq,
+        int,  type,
+        uint32_t, data_len,
+        int32_t, loops,
+        uint64_t *, stamps),
+    TP_FIELDS(
+        ctf_integer(uint64_t, threadid, threadid)
+        ctf_integer_hex(uint64_t, tid, tid)
+        ctf_integer(uint32_t, seq, seq)
+        ctf_integer(int32_t, type, type)
+        ctf_integer(uint32_t, data_len, data_len)
+        ctf_integer(int32_t, loops, loops)
+        ctf_array(uint64_t, stamps, stamps, 11)
+    )
+)
+
+TRACEPOINT_EVENT(pipe, do_sendmsg,
+    TP_ARGS(
+        uint32_t,  addr,
+        uint16_t,  port,
+        int32_t, len,
+        int32_t, loops,
+        uint64_t *, tp_stamps),
+    TP_FIELDS(
+        ctf_integer_network(uint32_t, addr, addr)
+        ctf_integer(int16_t, port, port)
+        ctf_integer(int32_t, len, len)
+        ctf_integer(int32_t, loops, loops)
+        ctf_array(uint64_t, tp_stamps, tp_stamps, 2)
+    )
+)


### PR DESCRIPTION
Added 13 tracepoints for ceph-osd daemon to provide timing analysis of functions in the path for primary and secondary write operations. These tracepoints collect timestamps within each of the instrumented functions and allow to track a complete transaction, i.e. the contributions to the overall latency for a write request.
A primary write starts when it arrives at the socket of ceph-osd and ends when the acknowledgement is sent back to the client.
At the layer of the Messenger, only the "simple" Messenger is instrumented; corresponding tracepoints for the "async" Messenger are pending.
