### PR TITLE
#10025/giant -- tools: fix MDS journal import

### DIFF
--- a/src/tools/cephfs/Dumper.cc
+++ b/src/tools/cephfs/Dumper.cc
@@ -159,7 +159,7 @@ void Dumper::undump(const char *dump_file)
   cout << "start " << start << " len " << len << std::endl;
   
   Journaler::Header h;
-  h.trimmed_pos = start;
+  h.trimmed_pos = start - (start % g_default_file_layout.fl_object_size);
   h.expire_pos = start;
   h.write_pos = write_pos;
   h.stream_format = format;


### PR DESCRIPTION
Previously it only worked on fresh filesystems which
hadn't been trimmed yet, and resulted in an invalid
trimmed_pos when expire_pos wasn't on an object
boundary.

Fixes: #10025

Signed-off-by: John Spray john.spray@redhat.com
(cherry picked from commit fb29e71f9a97c12354045ad2e128156e503be696)
