### PR TITLE
KeyValueStore: move buffers from strip_header to BufferTransaction

### DIFF
--- a/src/os/KeyValueStore.h
+++ b/src/os/KeyValueStore.h
@@ -68,7 +68,6 @@ class StripObjectMap: public GenericObjectMap {
     ghobject_t oid;
     bool updated;
     bool deleted;
-    map<pair<string, string>, bufferlist> buffers;  // pair(prefix, key)
 
     StripObjectHeader(): strip_size(default_strip_size), max_size(0), updated(false), deleted(false) {}
 
@@ -249,6 +248,8 @@ class KeyValueStore : public ObjectStore,
 
     //Dirty records
     StripHeaderMap strip_headers;
+    map< uniq_id, map<pair<string, string>, bufferlist> > buffers;  // pair(prefix, key),to buffer updated data in one transaction
+
     list<Context*> finishes;
 
     KeyValueStore *store;


### PR DESCRIPTION
This patch is related to the patch https://github.com/ceph/ceph/pull/2875
This patch is another way to get rid of the 'osd crash' problem during KeyValueStore test

'strip_header' in KeyValueStore is used to cache all updated headers, 'buffers' is used to ensure all io in one transaction use buffers to access the lastest update.
Move buffers from strip_header to BufferTransaction can ensure 'buffers' being destructed after the transaction being submitted, which prevent growing 'strip_header->buffers' causing OOM problem.
Also, for all 'meta collection' will be cached in strip_header, and there lacks of lock of parallel io accessing meta collection, multi-thread accesing the 'meta collection' strip_header->buffers causes segmentation fault, when moving 'buffers' from strip_header to BufferTransaction can prevent such scenario.

Signed-off-by: Chendi.Xue chendi.xue@intel.com
