### PR TITLE
common/Readahead: use correct lock when waiting on the pending ops

### DIFF
--- a/src/common/Readahead.cc
+++ b/src/common/Readahead.cc
@@ -131,7 +131,7 @@ void Readahead::dec_pending(int count) {
 void Readahead::wait_for_pending() {
   m_pending_lock.Lock();
   while (m_pending > 0) {
-    m_pending_cond.Wait(m_lock);
+    m_pending_cond.Wait(m_pending_lock);
   }
   m_pending_lock.Unlock();
 }


### PR DESCRIPTION
Readahead was using the incorrect lock with the pending condition,
resulting in a failed assertion.  It now uses the lock associated
with pending ops.

Fixes: #10045
Signed-off-by: Jason Dillaman dillaman@redhat.com
