### PR TITLE
Revert "osd: detect (some) misordered ondisk tmaps"

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3019,18 +3019,10 @@ int ReplicatedPG::do_tmapup(OpContext *ctx, bufferlist::iterator& bp, OSDOp& osd
     string nextkey, last_in_key;
     bufferlist nextval;
     bool have_next = false;
-    string last_disk_key;
     if (!ip.end()) {
       have_next = true;
       ::decode(nextkey, ip);
       ::decode(nextval, ip);
-      if (nextkey < last_disk_key) {
-	dout(5) << "tmapup warning: key '" << nextkey << "' < previous key '" << last_disk_key
-		<< "', falling back to an inefficient (unsorted) update" << dendl;
-	bp = orig_bp;
-	return do_tmapup_slow(ctx, bp, osd_op, newop.outdata);
-      }
-      last_disk_key = nextkey;
     }
     result = 0;
     while (!bp.end() && !result) {


### PR DESCRIPTION
This reverts commit 10b68b2e1a1479c478843fab8232537675053c9b.

The check for 'nextkey < last_disk_key' makes not much sense since
last_disk_key is an empty string and not set before. Comparing a
decoded string to be less than an empty string will be never true.

Since this if() isn't part of a loop last_disk_key is only set
once and there is no other consumer: revert this dead code.

Conflicts:
    src/osd/ReplicatedPG.cc
