### PR TITLE
librbd: Python unit tests now use unique pools and images

### DIFF
--- a/src/test/run-rbd-tests
+++ b/src/test/run-rbd-tests
@@ -22,7 +22,6 @@ run_cli_tests() {
 }
 
 run_api_tests() {
-    recreate_pool rbd
     # skip many_snaps since it takes several minutes
     nosetests -v test_rbd -e '.*many_snaps'
     # ceph_test_librbd creates its own pools


### PR DESCRIPTION
RBD python unit tests no longer utilize the 'rbd' pool for
test cases.  Instead, a new temporary pool is created and
deleted. Additionally, each unit test now uses a unique
image name to reduce the possibility of test case failures
affecting subsequent tests.

Signed-off-by: Jason Dillaman dillaman@redhat.com
