### PR TITLE
qa: allow small allocation diffs for exported rbds

### DIFF
--- a/qa/workunits/rbd/import_export.sh
+++ b/qa/workunits/rbd/import_export.sh
@@ -20,7 +20,9 @@ compare_files_and_ondisk_sizes () {
     cmp -l $1 $2 || return 1
     origsize=$(stat $1 --format %b)
     exportsize=$(stat $2 --format %b)
-    [ $origsize = $exportsize ]
+    difference=$(($exportsize - $origsize))
+    difference=${difference#-} # absolute value
+    test $difference -ge 0 -a $difference -lt 4096
 }
 
 # cannot import a dir


### PR DESCRIPTION
The local filesytem may behave slightly differently. This isn't foolproof,
but seems to be reliable enough on rhel7 rootfs, where exact comparison was
failing.

Fixes: #10002 Signed-off-by: Josh Durgin jdurgin@redhat.com
