### PR TITLE
Fix race condition in ceph-disk unmount()

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -902,6 +902,8 @@ def unmount(
     """
     try:
         LOG.debug('Unmounting %s', path)
+        # Issue sync to avoid race condition 
+        command_check_call( [ 'sync' ] )
         command_check_call(
             [
                 '/bin/umount',


### PR DESCRIPTION
A race condition exists when using 'ceph-disk prepare' where changes to the disk are not flushed from the kernel by the time the unmount() function is called. Issuing a 'sync' command before 'umount' has fixed the issue in testing.

Signed-off-by: Brandon Blaine Gardner blaine.gardner@hp.com
