### PR TITLE
osd: the async read callback doesn't take pg lock

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -143,10 +143,12 @@ void ReplicatedPG::OpContext::finish_read(ReplicatedPG *pg)
   assert(inflightreads > 0);
   --inflightreads;
   if (async_reads_complete()) {
+    pg->lock();
     assert(pg->in_progress_async_reads.size());
     assert(pg->in_progress_async_reads.front().second == this);
     pg->in_progress_async_reads.pop_front();
     pg->complete_read_ctx(async_read_result, this);
+    pg->unlock();
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Zhiqiang Wang zhiqiang.wang@intel.com
