### PR TITLE
librbd: Only public API symbols from the shared library

### DIFF
--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -47,14 +47,14 @@ namespace librbd {
 
   typedef rbd_image_info_t image_info_t;
 
-  class ProgressContext
+  class CEPH_RBD_API ProgressContext
   {
   public:
     virtual ~ProgressContext();
     virtual int update_progress(uint64_t offset, uint64_t total) = 0;
   };
 
-class RBD
+class CEPH_RBD_API RBD
 {
 public:
   RBD();
@@ -102,7 +102,7 @@ private:
   const RBD& operator=(const RBD& rhs);
 };
 
-class Image
+class CEPH_RBD_API Image
 {
 public:
   Image();

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -17,7 +17,8 @@ endif
 
 librbd_la_LDFLAGS = ${AM_LDFLAGS} -version-info 1:0:0
 if LINUX
-librbd_la_LDFLAGS += -export-symbols-regex '^rbd_.*'
+librbd_la_CXXFLAGS = -fvisibility=hidden -fvisibility-inlines-hidden
+librbd_la_LDFLAGS += -Xcompiler -Xlinker -Xcompiler '--exclude-libs=ALL'
 endif
 lib_LTLIBRARIES += librbd.la
 


### PR DESCRIPTION
The librbd shared library was previously exporting all
symbols.  librbd public API methods are now explicitly
exported and all other symbols are hidden.

Signed-off-by: Jason Dillaman dillaman@redhat.com
