### PR TITLE
Wip 10063 zafman only

### DIFF
--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -529,7 +529,16 @@ def main():
         for basename in db[nspace].keys():
             file = os.path.join(DATADIR, nspace + "-" + basename)
             JSON = db[nspace][basename]['json']
-            for pg in OBJREPPGS:
+            jsondict = json.loads(JSON)
+
+            for pg in ALLPGS:
+                # Make sure rep obj with rep pg or ec obj with ec pg
+                if ('shard_id' in jsondict) != (pg.find('s') > 0):
+                    continue
+                if 'shard_id' in jsondict:
+                    # Fix shard_id since we only have one json instance for each object
+                    jsondict['shard_id'] = int(string.split(pg, 's')[1])
+                    JSON = json.dumps(jsondict)
                 OSDS = get_osds(pg, OSDDIR)
                 for osd in OSDS:
                     DIR = os.path.join(OSDDIR, os.path.join(osd, os.path.join("current", "{pg}_head".format(pg=pg))))
@@ -549,11 +558,11 @@ def main():
                     keys = get_lines(ATTRFILE)
                     values = dict(db[nspace][basename]["xattr"])
                     for key in keys:
-                        if key == "_" or key == "snapset":
+                        if key == "_" or key == "snapset" or key == "hinfo_key":
                             continue
                         key = key.strip("_")
                         if key not in values:
-                            logging.error("The key {key} should be present".format(key=key))
+                            logging.error("Unexpected key {key} present".format(key=key))
                             ERRORS += 1
                             continue
                         exp = values.pop(key)


### PR DESCRIPTION
This branch fixes 3 things.  

The ATTR_OBJS setting was doing 1 less attribute which is important if you want to do a quick run with only 2 objects per namespace.  The reason is that the no attribute case is always one of the attribute tests.

The check for malformed JSON actually detects the problem in bug 10063.  

The list-attr code wasn't even trying to test erasure coded objects.
