### PR TITLE
remove duplicate DBObjectMap::cache_lock

### DIFF
--- a/src/os/DBObjectMap.h
+++ b/src/os/DBObjectMap.h
@@ -114,7 +114,6 @@ public:
   };
 
   DBObjectMap(KeyValueDB *db) : db(db), header_lock("DBOBjectMap"),
-                                cache_lock("DBObjectMap::CacheLock"),
                                 caches(g_conf->filestore_omap_header_cache_size)
     {}
 
@@ -327,7 +326,6 @@ public:
 private:
   /// Implicit lock on Header->seq
   typedef ceph::shared_ptr<_Header> Header;
-  Mutex cache_lock;
   SimpleLRU<ghobject_t, _Header> caches;
 
   string map_header_key(const ghobject_t &oid);


### PR DESCRIPTION
DBObjectMap::caches has an internal lock to prevent concurrency ops

Signed-off-by: xinxin shu xinxin.shu@intel.com
