### PR TITLE
mon: PaxosService: can be readable even if proposing

### DIFF
--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -566,7 +566,6 @@ public:
    */
   bool is_readable(version_t ver = 0) {
     if (ver > get_last_committed() ||
-	is_proposing() ||
 	!paxos->is_readable(0) ||
 	get_last_committed() == 0)
       return false;


### PR DESCRIPTION
As long as we have a stable version in memory that is lower or equal to
the version we want.

Fixes: #9321
Fixes: #9322

Signed-off-by: Joao Eduardo Luis joao@redhat.com
