### PR TITLE
Add annotation to all assembly files to turn off stack-execute bit

### DIFF
--- a/src/common/crc32c_intel_fast_asm.S
+++ b/src/common/crc32c_intel_fast_asm.S
@@ -662,3 +662,5 @@ global %1_slver
 %endmacro
 ;;;       func            core, ver, snum
 slversion crc32_iscsi_00, 00,   02,  0014
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/common/crc32c_intel_fast_zero_asm.S
+++ b/src/common/crc32c_intel_fast_zero_asm.S
@@ -644,3 +644,5 @@ global %1_slver
 %endmacro
 ;;;       func            core, ver, snum
 slversion crc32_iscsi_zero_00, 00,   02,  0014
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/ec_multibinary.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/ec_multibinary.asm.s
@@ -264,3 +264,5 @@ global %1_slver
 slversion ec_encode_data,	00,   02,  0133
 slversion gf_vect_mul,		00,   02,  0134
 slversion gf_vect_dot_prod,	00,   01,  0138
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx.asm.s
@@ -232,3 +232,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_2vect_dot_prod_avx, 02,  03,  0191
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx2.asm.s
@@ -244,3 +244,5 @@ global %1_slver
 %endmacro
 ;;;       func                   core, ver, snum
 slversion gf_2vect_dot_prod_avx2, 04,  03,  0196
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_sse.asm.s
@@ -234,3 +234,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_2vect_dot_prod_sse, 00,  02,  0062
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx.asm.s
@@ -255,4 +255,6 @@ global %1_slver
 	db 0x%3, 0x%2
 %endmacro
 ;;;       func                  core, ver, snum
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits
 slversion gf_3vect_dot_prod_avx, 02,  03,  0192

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx2.asm.s
@@ -269,3 +269,5 @@ global %1_slver
 %endmacro
 ;;;       func                   core, ver, snum
 slversion gf_3vect_dot_prod_avx2, 04,  03,  0197
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_sse.asm.s
@@ -257,3 +257,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_3vect_dot_prod_sse, 00,  03,  0063
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx.asm.s
@@ -294,3 +294,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_4vect_dot_prod_avx, 00,  02,  0064
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx2.asm.s
@@ -303,3 +303,5 @@ global %1_slver
 %endmacro
 ;;;       func                   core, ver, snum
 slversion gf_4vect_dot_prod_avx2, 04,  03,  0064
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_sse.asm.s
@@ -294,3 +294,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_4vect_dot_prod_sse, 00,  03,  0064
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx.asm.s
@@ -309,3 +309,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_5vect_dot_prod_avx, 02,  03,  0194
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx2.asm.s
@@ -321,3 +321,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_5vect_dot_prod_avx2, 04,  03,  0199
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_sse.asm.s
@@ -309,4 +309,6 @@ global %1_slver
 	db 0x%3, 0x%2
 %endmacro
 ;;;       func                  core, ver, snum
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits
 slversion gf_5vect_dot_prod_sse, 00,  03,  0065

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx.asm.s
@@ -321,3 +321,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_6vect_dot_prod_avx, 02,  03,  0195
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx2.asm.s
@@ -332,3 +332,5 @@ global %1_slver
 %endmacro
 ;;;       func                   core, ver, snum
 slversion gf_6vect_dot_prod_avx2, 04,  03,  019a
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_sse.asm.s
@@ -321,3 +321,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_6vect_dot_prod_sse, 00,  03,  0066
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx.asm.s
@@ -196,3 +196,7 @@ global %1_slver
 %endmacro
 ;;;       func                 core, ver, snum
 slversion gf_vect_dot_prod_avx, 02,  03,  0061
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm.s
@@ -201,3 +201,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_vect_dot_prod_avx2, 04,  03,  0190
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_sse.asm.s
@@ -193,3 +193,5 @@ global %1_slver
 %endmacro
 ;;;       func                 core, ver, snum
 slversion gf_vect_dot_prod_sse, 00,  03,  0060
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_avx.asm.s
@@ -170,3 +170,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_vect_mul_avx, 01,   02,  0036
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_sse.asm.s
@@ -176,3 +176,5 @@ global %1_slver
 %endmacro
 ;;;       func        core, ver, snum
 slversion gf_vect_mul_sse, 00,   02,  0034
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits


### PR DESCRIPTION
See discussion in http://tracker.ceph.com/issues/10114

Building with these changes allows output from readelf like this:

 $ readelf -lW src/.libs/librados.so.2 | grep GNU_STACK
  GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000
0x000000 RW  0x8

(note the absence of 'X' in 'RW')

Fixes: #10114
Signed-off-by: Dan Mick dan.mick@redhat.com
