### PR TITLE
Fixed trivial locking issue in the trunc method of libradosstriper - Giant branch

### DIFF
--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -600,20 +600,20 @@ int libradosstriper::RadosStriperImpl::trunc(const std::string& soid, uint64_t s
   std::string firstObjOid = getObjectId(soid, 0);
   try {
     RadosExclusiveLock lock(&m_ioCtx, firstObjOid);
+    // load layout and size
+    ceph_file_layout layout;
+    uint64_t original_size;
+    int rc = internal_get_layout_and_size(firstObjOid, &layout, &original_size);
+    if (rc) return rc;
+    if (size < original_size) {
+      rc = truncate(soid, original_size, size, layout);
+    } else if (size > original_size) {
+      rc = grow(soid, original_size, size, layout);
+    }
+    return rc;
   } catch (ErrorCode &e) {
     return e.m_code;
   }
-  // load layout and size
-  ceph_file_layout layout;
-  uint64_t original_size;
-  int rc = internal_get_layout_and_size(firstObjOid, &layout, &original_size);
-  if (rc) return rc;
-  if (size < original_size) {
-    rc = truncate(soid, original_size, size, layout);
-  } else if (size > original_size) {
-    rc = grow(soid, original_size, size, layout);
-  }
-  return rc;
 }
 
 ///////////////////////// private helpers /////////////////////////////


### PR DESCRIPTION
Trivial mistake leading to absence of file locking in case of truncation.
This pull request fixes it in giant. It is the backport of pull request #2951