### PR TITLE
erasure-code isa-l: remove duplicated lines (fix warning)

### DIFF
--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx.asm.s
@@ -198,5 +198,3 @@ global %1_slver
 slversion gf_vect_dot_prod_avx, 02,  03,  0061
 ; inform linker that this doesn't require executable stack
 section .note.GNU-stack noalloc noexec nowrite progbits
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits


### PR DESCRIPTION
06a245a added a section def to assembly files; I added it twice to
this file.  There's no damage, but a compiler warning (on machines with
yasm installed)

Signed-off-by: Dan Mick dan.mick@redhat.com
