### PR TITLE
rgw: support swift storage policy api

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1908,6 +1908,13 @@ void RGWPutMetadata::execute()
   if (ret < 0)
     return;
 
+  if (!s->object && !placement_rule.empty()) {
+    if (placement_rule != s->bucket_info.placement_rule) {
+      ret = -EEXIST;
+      return;
+    }
+  }
+
   /* only remove meta attrs */
   for (iter = orig_attrs.begin(); iter != orig_attrs.end(); ++iter) {
     const string& name = iter->first;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -419,6 +419,7 @@ protected:
   bool has_policy, has_cors;
   RGWAccessControlPolicy policy;
   RGWCORSConfiguration cors_config;
+  string placement_rule;
 
 public:
   RGWPutMetadata() {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -441,6 +441,7 @@ int RGWPutMetadata_ObjStore_SWIFT::get_params()
       return r;
     }
   }
+  placement_rule = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
 
   return 0;
 }


### PR DESCRIPTION
Fixes: #9932

When creating a bucket, set the placement rule according to the
provided X-Storage-Policy http header.

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
