### PR TITLE
rbd: Fix the rbd export when image size more than 2G

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -1027,8 +1027,8 @@ public:
         return;
       }
 
-      r = lseek64(m_fd, m_offset, SEEK_SET);
-      if (static_cast<uint64_t>(r) != m_offset) {
+      uint64_t chkret = lseek64(m_fd, m_offset, SEEK_SET);
+      if (chkret != m_offset) {
         cerr << "rbd: error seeking destination image to offset "
              << m_offset << std::endl;
         r = -errno;


### PR DESCRIPTION
When using export <image-name> <path> and the size of image is more
than 2G, the previous version about finish() could not handle in
seeking the offset in image and return error.

This is caused by the incorrect variable type. Try to use the correct
variable type to fixed it.

I use another variable which type is uint64_t for confirming seeking
and still use the previous r for return error.

uint64_t is more better than type int for handle lseek64().

Signed-off-by: Vicente Cheng freeze.bilsted@gmail.com
(cherry picked from commit 4b87a81c86db06f6fe2bee440c65fc05cd4c23ce)
