### PR TITLE
blkdev: using strncpy instead of strcpy.

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -29,9 +29,11 @@ bool block_device_support_discard(const char *devname)
 {
   bool can_trim = false;
   char *p = strstr((char *)devname, "sd");
-  char name[32] = {0};
+  char name[32];
 
-  strcpy(name, p);
+  strncpy(name, p, sizeof(name) - 1);
+  name[sizeof(name) - 1] = '\0';
+
   for (unsigned int i = 0; i < strlen(name); i++) {
     if(isdigit(name[i])) {
       name[i] = 0;


### PR DESCRIPTION
Coverity Scan reported this bug:

> New defect(s) Reported-by: Coverity Scan Showing 1 of 1 defect(s)
> **\* CID 1255369:  Copy into fixed size buffer  (STRING_OVERFLOW)
> /common/blkdev.cc: 34 in block_device_support_discard(const char *)()
> 28     bool block_device_support_discard(const char *devname)
> 29     {
> 30       bool can_trim = false;
> 31       char *p = strstr((char *)devname, "sd");
> 32       char name[32] = {0};
> 33
> 
> > > > ```
> > > > CID 1255369:  Copy into fixed size buffer  (STRING_OVERFLOW)
> > > > You might overrun the 32 byte fixed-size string "name" by
> > > > copying "p" without checking the length.
> > > > ```
> > > > 
> > > > 34       strcpy(name, p);
> > > > 35       for (unsigned int i = 0; i < strlen(name); i++) {
> > > > 36         if(isdigit(name[i])) {
> > > > 37           name[i] = 0;
> > > > 38           break;
> > > > 39         }

Signed-off-by: Jianpeng Ma jianpeng.ma@intel.com
