### PR TITLE
librbd: protect list_children from invalid child pool IoCtxs

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -429,7 +429,12 @@ namespace librbd {
 	continue;
       }
       IoCtx ioctx;
-      rados.ioctx_create(it->c_str(), ioctx);
+      r = rados.ioctx_create(it->c_str(), ioctx);
+      if (r < 0) {
+        lderr(cct) << "Error accessing child image pool " << *it << dendl;
+        return r;
+      }
+
       set<string> image_ids;
       r = cls_client::get_children(&ioctx, RBD_CHILDREN,
 				       parent_spec, image_ids);


### PR DESCRIPTION
While listing child images, don't ignore error codes returned
from librados when creating an IoCtx. This will prevent seg
faults from occurring when an invalid IoCtx is used.

Fixes: #10123
Backport: giant, firefly, dumpling
Signed-off-by: Jason Dillaman dillaman@redhat.com
