### PR TITLE
lockdep: do not use $CEPH_LOCKDEP for g_lockdep

### DIFF
--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -34,14 +34,12 @@ CEPH_HASH_NAMESPACE_END
 #endif
 
 /******* Constants **********/
-#undef DOUT_COND
-#define DOUT_COND(cct, l) cct && l <= XDOUT_CONDVAR(cct, dout_subsys)
 #define lockdep_dout(v) lsubdout(g_lockdep_ceph_ctx, lockdep, v)
 #define MAX_LOCKS  2000   // increase me as needed
 #define BACKTRACE_SKIP 2
 
 /******* Globals **********/
-int g_lockdep = get_env_int("CEPH_LOCKDEP");
+int g_lockdep = 0;
 struct lockdep_stopper_t {
   // disable lockdep when this module destructs.
   ~lockdep_stopper_t() {
@@ -140,7 +138,7 @@ int lockdep_register(const char *name)
 }
 
 
-// does a follow b?
+// does b follow a?
 static bool does_follow(int a, int b)
 {
   if (follows[a][b]) {


### PR DESCRIPTION
if i start ceph-mon with "CEPH_LOCKDEP=2" environment variable. it crashes.

```
(gdb) bt
#0  lockdep_register (name=0x129a17e "md_config_t") at common/lockdep.cc:131
#1  0x0000000001057615 in Mutex::_register (this=0x3dd9108) at ./common/Mutex.h:53
#2  0x00000000010571ec in Mutex::Mutex (this=0x3dd9108, n=0x129a17e "md_config_t",
    r=true, ld=true, bt=false, cct=0x0) at common/Mutex.cc:46
#3  0x00000000010c203c in md_config_t::md_config_t (this=0x3dd8000)
    at common/config.cc:151
#4  0x00000000010ad620 in CephContext::CephContext (this=0x3db0cb0, module_type_=1)
    at common/ceph_context.cc:297
#5  0x00000000010bdd38 in common_preinit (iparams=...,
    code_env=CODE_ENVIRONMENT_DAEMON, flags=8) at common/common_init.cc:42
#6  0x000000000124a87a in global_pre_init (alt_def_args=0x7fffffffd3f0, args=...,
    module_type=1, code_env=CODE_ENVIRONMENT_DAEMON, flags=8)
    at global/global_init.cc:70
#7  0x000000000124acc3 in global_init (alt_def_args=0x7fffffffd3f0, args=...,
    module_type=1, code_env=CODE_ENVIRONMENT_DAEMON, flags=8)
    at global/global_init.cc:117
#8  0x0000000000d6c316 in main (argc=8, argv=0x7fffffffe4b8) at ceph_mon.cc:261
```

`g_lockdep_ceph_ctx` is not set until it is fully constructed, and the `dout_impl()` always tries to check the log level in `context->_conf`. but in this case, the context is still being constructed when lockdep tries print the logging messages. so `dout_impl()` failed to dereference `g_lockdep_ceph_ctx`.

so i disable the feature of looking env var `CEPH_LOCKDEP` for `g_lockdep`.
