### PR TITLE
SimpleMessenger: adjust some debug log level for SimpleMessenger

### DIFF
--- a/src/msg/simple/SimpleMessenger.cc
+++ b/src/msg/simple/SimpleMessenger.cc
@@ -98,7 +98,7 @@ int SimpleMessenger::_send_message(Message *m, const entity_inst_t& dest)
 
   if (!m->get_priority()) m->set_priority(get_default_send_priority());
  
-  ldout(cct,1) <<"--> " << dest.name << " "
+  ldout(cct,20) <<"--> " << dest.name << " "
           << dest.addr << " -- " << *m
     	  << " -- ?+" << m->get_data().length()
 	  << " " << m 
@@ -126,7 +126,7 @@ int SimpleMessenger::_send_message(Message *m, Connection *con)
 
   if (!m->get_priority()) m->set_priority(get_default_send_priority());
 
-  ldout(cct,1) << "--> " << con->get_peer_addr()
+  ldout(cct,20) << "--> " << con->get_peer_addr()
       << " -- " << *m
       << " -- ?+" << m->get_data().length()
       << " " << m << " con " << con


### PR DESCRIPTION
I think level 1 is too high for _send_message in SimpleMessenger.
Signed-off-by: Xinze Chi xmdxcxz@gmail.com
