### PR TITLE
osd: tiering: proxy instead of redirect read in writeback mode when the cache pool is full

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1800,6 +1800,11 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
     // Always proxy
     do_proxy_read(op);
 
+    // Avoid duplicate promotion
+    if (obc.get() && obc->is_blocked()) {
+      return true;
+    }
+
     // Promote too?
     switch (pool.info.min_read_recency_for_promote) {
     case 0:


### PR DESCRIPTION
To preserve read op order

Signed-off-by: Zhiqiang Wang zhiqiang.wang@intel.com
