### PR TITLE
crush: add a new flag HASHPSPOOL2 for the congruential pps algorithm

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1139,8 +1139,9 @@ function test_mon_osd_pool_set()
   ceph osd pool set $TEST_POOL_GETSET hashpspool false
   ceph osd pool set $TEST_POOL_GETSET hashpspool 0
   ceph osd pool set $TEST_POOL_GETSET hashpspool 1
+  ceph osd pool set $TEST_POOL_GETSET hashpspool 2
   expect_false ceph osd pool set $TEST_POOL_GETSET hashpspool asdf
-  expect_false ceph osd pool set $TEST_POOL_GETSET hashpspool 2
+  expect_false ceph osd pool set $TEST_POOL_GETSET hashpspool 3
 
   ceph osd pool delete $TEST_POOL_GETSET $TEST_POOL_GETSET --yes-i-really-really-mean-it
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -481,7 +481,7 @@ OPTION(osd_erasure_code_plugins, OPT_STR,
 #endif
        ) // list of erasure code plugins
 OPTION(osd_pool_default_flags, OPT_INT, 0)   // default flags for new pools
-OPTION(osd_pool_default_flag_hashpspool, OPT_BOOL, true)   // use new pg hashing to prevent pool/pg overlap
+OPTION(osd_pool_default_flag_hashpspool, OPT_INT, 1)   // use new pg hashing to prevent pool/pg overlap
 OPTION(osd_pool_default_hit_set_bloom_fpp, OPT_FLOAT, .05)
 OPTION(osd_pool_default_cache_target_dirty_ratio, OPT_FLOAT, .4)
 OPTION(osd_pool_default_cache_target_full_ratio, OPT_FLOAT, .8)

--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -78,6 +78,7 @@ int CrushCompiler::decompile_bucket_impl(int i, ostream &out)
   bool dopos = false;
   switch (alg) {
   case CRUSH_BUCKET_UNIFORM:
+  case CRUSH_BUCKET_LINEAR:
     out << "\t# do not change bucket size (" << n << ") unnecessarily";
     dopos = true;
     break;
@@ -439,6 +440,8 @@ int CrushCompiler::parse_bucket(iter_t const& i)
 	alg = CRUSH_BUCKET_TREE;
       else if (a == "straw")
 	alg = CRUSH_BUCKET_STRAW;
+      else if (a == "linear")
+        alg = CRUSH_BUCKET_LINEAR;
       else {
 	err << "unknown bucket alg '" << a << "'" << std::endl << std::endl;
 	return -EINVAL;
@@ -516,15 +519,16 @@ int CrushCompiler::parse_bucket(iter_t const& i)
 	  assert(0);
 
       }
-      if (alg == CRUSH_BUCKET_UNIFORM) {
+      if (alg == CRUSH_BUCKET_UNIFORM || alg == CRUSH_BUCKET_LINEAR) {
 	if (!have_uniform_weight) {
 	  have_uniform_weight = true;
 	  uniform_weight = weight;
 	} else {
 	  if (uniform_weight != weight) {
-	    err << "item '" << iname << "' in uniform bucket '" << name << "' has weight " << weight
+	    //string bucket_type = (alg == CRUSH_BUCKET_UNIFORM) ? "uniform" : "linear";
+	    err << "item '" << iname << "' in " << crush_bucket_alg_name(alg) << " bucket '" << name << "' has weight " << weight
 		<< " but previous item(s) have weight " << (float)uniform_weight/(float)0x10000
-		<< "; uniform bucket items must all have identical weights." << std::endl;
+		<< "; " << crush_bucket_alg_name(alg) << " bucket items must all have identical weights." << std::endl;
 	    return -1;
 	  }
 	}

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -489,7 +489,7 @@ int CrushTester::test()
           if (use_crush) {
             if (output_mappings)
 	      err << "CRUSH"; // prepend CRUSH to placement output
-            crush.do_rule(r, x, out, nr, weight);
+            crush.do_rule(r, x, out, nr, weight, 1);
           } else {
             if (output_mappings)
 	      err << "RNG"; // prepend RNG to placement output to denote simulation

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1075,6 +1075,10 @@ void CrushWrapper::encode(bufferlist& bl, bool lean) const
       }
       break;
 
+    case CRUSH_BUCKET_LINEAR:
+      ::encode((reinterpret_cast<crush_bucket_linear*>(crush->buckets[i]))->item_weight, bl);
+      break;
+
     default:
       assert(0);
       break;
@@ -1223,6 +1227,9 @@ void CrushWrapper::decode_crush_bucket(crush_bucket** bptr, bufferlist::iterator
   case CRUSH_BUCKET_STRAW:
     size = sizeof(crush_bucket_straw);
     break;
+  case CRUSH_BUCKET_LINEAR:
+    size = sizeof(crush_bucket_linear);
+    break;
   default:
     {
       char str[128];
@@ -1286,6 +1293,10 @@ void CrushWrapper::decode_crush_bucket(crush_bucket** bptr, bufferlist::iterator
     break;
   }
 
+  case CRUSH_BUCKET_LINEAR:
+    ::decode((reinterpret_cast<crush_bucket_linear*>(bucket))->item_weight, blp);
+    break;
+  
   default:
     // We should have handled this case in the first switch statement
     assert(0);

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -965,11 +965,11 @@ public:
   }
 
   void do_rule(int rule, int x, vector<int>& out, int maxout,
-	       const vector<__u32>& weight) const {
+	       const vector<__u32>& weight, int seed) const {
     Mutex::Locker l(mapper_lock);
     int rawout[maxout];
     int scratch[maxout * 3];
-    int numrep = crush_do_rule(crush, rule, x, rawout, maxout, &weight[0], weight.size(), scratch);
+    int numrep = crush_do_rule(crush, rule, x, rawout, maxout, &weight[0], weight.size(), scratch, seed);
     if (numrep < 0)
       numrep = 0;
     out.resize(numrep);

--- a/src/crush/builder.c
+++ b/src/crush/builder.c
@@ -605,6 +605,52 @@ err:
 
 
 
+/* linear bucket */
+
+struct crush_bucket_linear *
+crush_make_linear_bucket(int hash, int type, int size,
+			  int *items,
+			  int item_weight)
+{
+	int i;
+	struct crush_bucket_linear *bucket;
+
+	bucket = malloc(sizeof(*bucket));
+        if (!bucket)
+                return NULL;
+	memset(bucket, 0, sizeof(*bucket));
+	bucket->h.alg = CRUSH_BUCKET_LINEAR;
+	bucket->h.hash = hash;
+	bucket->h.type = type;
+	bucket->h.size = size;
+
+	if (crush_multiplication_is_unsafe(size, item_weight))
+                goto err;
+
+	bucket->h.weight = size * item_weight;
+	bucket->item_weight = item_weight;
+	bucket->h.items = malloc(sizeof(__s32)*size);
+
+        if (!bucket->h.items)
+                goto err;
+
+        bucket->h.perm = malloc(sizeof(__u32)*size);
+
+        if (!bucket->h.perm)
+                goto err;
+	for (i=0; i<size; i++)
+		bucket->h.items[i] = items[i];
+
+	return bucket;
+err:
+        free(bucket->h.perm);
+        free(bucket->h.items);
+        free(bucket);
+        return NULL;
+}
+
+
+
 struct crush_bucket*
 crush_make_bucket(struct crush_map *map,
 		  int alg, int hash, int type, int size,
@@ -629,6 +675,13 @@ crush_make_bucket(struct crush_map *map,
 
 	case CRUSH_BUCKET_STRAW:
 		return (struct crush_bucket *)crush_make_straw_bucket(map, hash, type, size, items, weights);
+
+	case CRUSH_BUCKET_LINEAR:
+		if (size && weights)
+			item_weight = weights[0];
+		else
+			item_weight = 0;
+		return (struct crush_bucket *)crush_make_linear_bucket(hash, type, size, items, item_weight);
 	}
 	return 0;
 }
@@ -808,6 +861,33 @@ int crush_add_straw_bucket_item(struct crush_map *map,
 	return crush_calc_straw(map, bucket);
 }
 
+int crush_add_linear_bucket_item(struct crush_bucket_linear *bucket, int item, int weight)
+{
+	int newsize = bucket->h.size + 1;
+	void *_realloc = NULL;
+
+	if ((_realloc = realloc(bucket->h.items, sizeof(__s32)*newsize)) == NULL) {
+		return -ENOMEM;
+	} else {
+		bucket->h.items = _realloc;
+	}
+	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
+		return -ENOMEM;
+	} else {
+		bucket->h.perm = _realloc;
+	}
+
+	bucket->h.items[newsize-1] = item;
+
+        if (crush_addition_is_unsafe(bucket->h.weight, weight))
+                return -ERANGE;
+
+        bucket->h.weight += weight;
+        bucket->h.size++;
+
+        return 0;
+}
+
 int crush_bucket_add_item(struct crush_map *map,
 			  struct crush_bucket *b, int item, int weight)
 {
@@ -823,6 +903,8 @@ int crush_bucket_add_item(struct crush_map *map,
 		return crush_add_tree_bucket_item((struct crush_bucket_tree *)b, item, weight);
 	case CRUSH_BUCKET_STRAW:
 		return crush_add_straw_bucket_item(map, (struct crush_bucket_straw *)b, item, weight);
+	case CRUSH_BUCKET_LINEAR:
+		return crush_add_linear_bucket_item((struct crush_bucket_linear *)b, item, weight);
 	default:
 		return -1;
 	}
@@ -1034,6 +1116,39 @@ int crush_remove_straw_bucket_item(struct crush_map *map,
 	return crush_calc_straw(map, bucket);
 }
 
+int crush_remove_linear_bucket_item(struct crush_bucket_linear *bucket, int item)
+{
+	unsigned i, j;
+	int newsize;
+	void *_realloc = NULL;
+
+	for (i = 0; i < bucket->h.size; i++)
+		if (bucket->h.items[i] == item)
+			break;
+	if (i == bucket->h.size)
+		return -ENOENT;
+
+	for (j = i; j < bucket->h.size; j++)
+		bucket->h.items[j] = bucket->h.items[j+1];
+	newsize = --bucket->h.size;
+	if (bucket->item_weight < bucket->h.weight)
+		bucket->h.weight -= bucket->item_weight;
+	else
+		bucket->h.weight = 0;
+
+	if ((_realloc = realloc(bucket->h.items, sizeof(__s32)*newsize)) == NULL) {
+		return -ENOMEM;
+	} else {
+		bucket->h.items = _realloc;
+	}
+	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
+		return -ENOMEM;
+	} else {
+		bucket->h.perm = _realloc;
+	}
+	return 0;
+}
+
 int crush_bucket_remove_item(struct crush_map *map, struct crush_bucket *b, int item)
 {
 	/* invalidate perm cache */
@@ -1048,6 +1163,8 @@ int crush_bucket_remove_item(struct crush_map *map, struct crush_bucket *b, int 
 		return crush_remove_tree_bucket_item((struct crush_bucket_tree *)b, item);
 	case CRUSH_BUCKET_STRAW:
 		return crush_remove_straw_bucket_item(map, (struct crush_bucket_straw *)b, item);
+	case CRUSH_BUCKET_LINEAR:
+		return crush_remove_linear_bucket_item((struct crush_bucket_linear *)b, item);
 	default:
 		return -1;
 	}
@@ -1140,6 +1257,16 @@ int crush_adjust_straw_bucket_item_weight(struct crush_map *map,
 	return diff;
 }
 
+int crush_adjust_linear_bucket_item_weight(struct crush_bucket_linear *bucket, int item, int weight)
+{
+	int diff = (weight - bucket->item_weight) * bucket->h.size;
+
+	bucket->item_weight = weight;
+	bucket->h.weight = bucket->item_weight * bucket->h.size;
+
+	return diff;
+}
+
 int crush_bucket_adjust_item_weight(struct crush_map *map,
 				    struct crush_bucket *b,
 				    int item, int weight)
@@ -1157,6 +1284,9 @@ int crush_bucket_adjust_item_weight(struct crush_map *map,
 	case CRUSH_BUCKET_STRAW:
 		return crush_adjust_straw_bucket_item_weight(map,
 							     (struct crush_bucket_straw *)b,
+							     item, weight);
+	case CRUSH_BUCKET_LINEAR:
+		return crush_adjust_linear_bucket_item_weight((struct crush_bucket_linear *)b,
 							     item, weight);
 	default:
 		return -1;
@@ -1263,6 +1393,34 @@ static int crush_reweight_straw_bucket(struct crush_map *crush, struct crush_buc
 	return 0;
 }
 
+static int crush_reweight_linear_bucket(struct crush_map *crush, struct crush_bucket_linear *bucket)
+{
+	unsigned i;
+	unsigned sum = 0, n = 0, leaves = 0;
+
+	for (i = 0; i < bucket->h.size; i++) {
+		int id = bucket->h.items[i];
+		if (id < 0) {
+			struct crush_bucket *c = crush->buckets[-1-id];
+			crush_reweight_bucket(crush, c);
+
+			if (crush_addition_is_unsafe(sum, c->weight))
+                                return -ERANGE;
+
+			sum += c->weight;
+			n++;
+		} else {
+			leaves++;
+		}
+	}
+
+	if (n > leaves)
+		bucket->item_weight = sum / n;  // more bucket children than leaves, average!
+	bucket->h.weight = bucket->item_weight * bucket->h.size;
+
+	return 0;
+}
+
 int crush_reweight_bucket(struct crush_map *crush, struct crush_bucket *b)
 {
 	switch (b->alg) {
@@ -1274,6 +1432,8 @@ int crush_reweight_bucket(struct crush_map *crush, struct crush_bucket *b)
 		return crush_reweight_tree_bucket(crush, (struct crush_bucket_tree *)b);
 	case CRUSH_BUCKET_STRAW:
 		return crush_reweight_straw_bucket(crush, (struct crush_bucket_straw *)b);
+	case CRUSH_BUCKET_LINEAR:
+		return crush_reweight_linear_bucket(crush, (struct crush_bucket_linear *)b);
 	default:
 		return -1;
 	}

--- a/src/crush/builder.h
+++ b/src/crush/builder.h
@@ -40,5 +40,9 @@ crush_make_straw_bucket(struct crush_map *map,
 			int hash, int type, int size,
 			int *items,
 			int *weights);
-
+struct crush_bucket_linear *
+crush_make_linear_bucket(int hash, int type, int size,
+			  int *items,
+			  int item_weight);
+			  
 #endif

--- a/src/crush/crush.c
+++ b/src/crush/crush.c
@@ -18,6 +18,7 @@ const char *crush_bucket_alg_name(int alg)
 	case CRUSH_BUCKET_LIST: return "list";
 	case CRUSH_BUCKET_TREE: return "tree";
 	case CRUSH_BUCKET_STRAW: return "straw";
+	case CRUSH_BUCKET_LINEAR: return "linear";
 	default: return "unknown";
 	}
 }
@@ -41,6 +42,8 @@ int crush_get_bucket_item_weight(const struct crush_bucket *b, int p)
 		return ((struct crush_bucket_tree *)b)->node_weights[crush_calc_tree_node(p)];
 	case CRUSH_BUCKET_STRAW:
 		return ((struct crush_bucket_straw *)b)->item_weights[p];
+	case CRUSH_BUCKET_LINEAR:
+		return ((struct crush_bucket_linear *)b)->item_weight;
 	}
 	return 0;
 }
@@ -78,6 +81,13 @@ void crush_destroy_bucket_straw(struct crush_bucket_straw *b)
 	kfree(b);
 }
 
+void crush_destroy_bucket_linear(struct crush_bucket_linear *b)
+{
+	kfree(b->h.perm);
+	kfree(b->h.items);
+	kfree(b);
+}
+
 void crush_destroy_bucket(struct crush_bucket *b)
 {
 	switch (b->alg) {
@@ -92,6 +102,9 @@ void crush_destroy_bucket(struct crush_bucket *b)
 		break;
 	case CRUSH_BUCKET_STRAW:
 		crush_destroy_bucket_straw((struct crush_bucket_straw *)b);
+		break;
+	case CRUSH_BUCKET_LINEAR:
+		crush_destroy_bucket_linear((struct crush_bucket_linear *)b);
 		break;
 	}
 }

--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -107,12 +107,14 @@ struct crush_rule {
  *  list            O(n)       optimal      poor
  *  tree            O(log n)   good         good
  *  straw           O(n)       optimal      optimal
+ *  linear          O(1)       poor         poor
  */
 enum {
 	CRUSH_BUCKET_UNIFORM = 1,
 	CRUSH_BUCKET_LIST = 2,
 	CRUSH_BUCKET_TREE = 3,
-	CRUSH_BUCKET_STRAW = 4
+	CRUSH_BUCKET_STRAW = 4,
+	CRUSH_BUCKET_LINEAR = 5
 };
 extern const char *crush_bucket_alg_name(int alg);
 
@@ -159,6 +161,10 @@ struct crush_bucket_straw {
 	__u32 *straws;         /* 16-bit fixed point */
 };
 
+struct crush_bucket_linear {
+	struct crush_bucket h;
+	__u32 item_weight;  /* 16-bit fixed point; all items equally weighted */
+};
 
 
 /*
@@ -209,6 +215,7 @@ extern void crush_destroy_bucket_uniform(struct crush_bucket_uniform *b);
 extern void crush_destroy_bucket_list(struct crush_bucket_list *b);
 extern void crush_destroy_bucket_tree(struct crush_bucket_tree *b);
 extern void crush_destroy_bucket_straw(struct crush_bucket_straw *b);
+extern void crush_destroy_bucket_linear(struct crush_bucket_linear *b);
 extern void crush_destroy_bucket(struct crush_bucket *b);
 extern void crush_destroy_rule(struct crush_rule *r);
 extern void crush_destroy(struct crush_map *map);

--- a/src/crush/grammar.h
+++ b/src/crush/grammar.h
@@ -116,7 +116,8 @@ struct crush_grammar : public grammar<crush_grammar>
       bucket_alg = str_p("alg") >> ( str_p("uniform") |
 				     str_p("list") |
 				     str_p("tree") |
-				     str_p("straw") );
+				     str_p("straw") |
+				     str_p("linear") );
       bucket_hash = str_p("hash") >> ( integer |
 				       str_p("rjenkins1") );
       bucket_item = str_p("item") >> name

--- a/src/crush/mapper.c
+++ b/src/crush/mapper.c
@@ -239,6 +239,16 @@ static int bucket_straw_choose(struct crush_bucket_straw *bucket,
 	return bucket->h.items[high];
 }
 
+/* linear */
+
+static int bucket_linear_choose(struct crush_bucket_linear *bucket,
+			       int x, int r)
+{
+	unsigned int item = x%bucket->h.size;
+	return bucket->h.items[item];
+}
+
+
 static int crush_bucket_choose(struct crush_bucket *in, int x, int r)
 {
 	dprintk(" crush_bucket_choose %d x=%d r=%d\n", in->id, x, r);
@@ -256,6 +266,10 @@ static int crush_bucket_choose(struct crush_bucket *in, int x, int r)
 	case CRUSH_BUCKET_STRAW:
 		return bucket_straw_choose((struct crush_bucket_straw *)in,
 					   x, r);
+	case CRUSH_BUCKET_LINEAR:
+		return bucket_linear_choose((struct crush_bucket_linear *)in,
+					  x, r);
+
 	default:
 		dprintk("unknown bucket %d alg %d\n", in->id, in->alg);
 		return in->items[0];

--- a/src/crush/mapper.h
+++ b/src/crush/mapper.h
@@ -15,6 +15,7 @@ extern int crush_do_rule(const struct crush_map *map,
 			 int ruleno,
 			 int x, int *result, int result_max,
 			 const __u32 *weights, int weight_max,
-			 int *scratch);
+			 int *scratch,
+			 int seed);
 
 #endif

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -59,6 +59,7 @@
 #define CEPH_FEATURE_OSD_OBJECT_DIGEST  (1ULL<<46)  /* overlap with fadvise */
 #define CEPH_FEATURE_OSD_TRANSACTION_MAY_LAYOUT (1ULL<<46) /* overlap w/ fadvise */
 #define CEPH_FEATURE_MDS_QUOTA      (1ULL<<47)
+#define CEPH_FEATURE_OSDHASHPSPOOL2  (1ULL<<48)
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */
@@ -142,6 +143,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_OSD_OBJECT_DIGEST	|    \
          CEPH_FEATURE_OSD_TRANSACTION_MAY_LAYOUT |   \
 	 CEPH_FEATURE_MDS_QUOTA | \
+	 CEPH_FEATURE_OSDHASHPSPOOL2 | \
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3687,8 +3687,10 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
   pg_pool_t *pi = pending_inc.get_new_pool(pool, &empty);
   pi->type = pool_type;
   pi->flags = g_conf->osd_pool_default_flags;
-  if (g_conf->osd_pool_default_flag_hashpspool)
+  if (g_conf->osd_pool_default_flag_hashpspool == 1)
     pi->flags |= pg_pool_t::FLAG_HASHPSPOOL;
+  else if (g_conf->osd_pool_default_flag_hashpspool == 2)
+    pi->flags |= pg_pool_t::FLAG_HASHPSPOOL2;
 
   pi->size = size;
   pi->min_size = min_size;
@@ -3941,10 +3943,13 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
     // make sure we only compare against 'n' if we didn't receive a string
     if (val == "true" || (interr.empty() && n == 1)) {
       p.flags |= pg_pool_t::FLAG_HASHPSPOOL;
+    } else if (interr.empty() && n == 2) {
+      p.flags |= pg_pool_t::FLAG_HASHPSPOOL2;
     } else if (val == "false" || (interr.empty() && n == 0)) {
       p.flags &= ~pg_pool_t::FLAG_HASHPSPOOL;
+      p.flags &= ~pg_pool_t::FLAG_HASHPSPOOL2;
     } else {
-      ss << "expecting value 'true', 'false', '0', or '1'";
+      ss << "expecting value 'true', 'false', '0', '1' or '2'";
       return -EINVAL;
     }
   } else if (var == "hit_set_type") {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -68,6 +68,27 @@ static ostream& _prefix(std::ostream *_dout, Monitor *mon, OSDMap& osdmap) {
 		<< ").osd e" << osdmap.get_epoch() << " ";
 }
 
+float cal_average(vector<int> dataset, int length) {
+  float avg = 0;
+  float sum = 0;
+  for(int i = 0; i < length; i++){
+    sum += dataset[i];
+  }
+  avg = sum/length;
+  return avg;
+}
+
+float cal_stdev(vector<int> dataset, int length) {
+  float avg = cal_average(dataset, length);
+  float sum = 0;
+  float stdev;
+  for(int i = 0; i < length; i++){
+    sum += pow(dataset[i] - avg, 2);
+  }
+  stdev = pow(sum/length, 0.5);
+  return stdev;
+}
+
 bool OSDMonitor::_have_pending_crush()
 {
   return pending_inc.crush.length();
@@ -3312,6 +3333,43 @@ int OSDMonitor::crush_rename_bucket(const string& srcname,
   return 0;
 }
 
+void OSDMonitor::prepare_adaptive_seed(pg_pool_t *pi, int64_t pool)
+{
+  float min_stdev = 999999;
+  int balance_param = 1;
+
+  for (int k = 1; k < 5; k++) {
+    map<int, int> osd_total_pgs;
+    pi->set_seed(k);
+    for (int i = 0; i < (int)pi->get_pg_num(); i++) {
+      pg_t pg(i, pool);
+      pg.set_pool(pool);
+      vector<int> acting;
+      int nrep = osdmap.pg_to_up_osds_adaptive(*pi, pg, acting);
+      if (nrep) {
+        for (int j = 0; j < nrep; j++) {
+          osd_total_pgs[acting[j]]++;
+        }
+      }
+    }
+
+    vector<int> pg_num;
+    for (map<int, int>::iterator ptr = osd_total_pgs.begin();
+	   ptr != osd_total_pgs.end();
+	   ++ptr) {
+      pg_num.push_back(ptr->second);
+    }
+
+    float stdev = cal_stdev(pg_num, pg_num.size());
+    if (stdev < min_stdev) {
+      min_stdev = stdev;
+      balance_param = k;
+    }
+  }
+
+  pi->set_seed(balance_param);
+}
+
 int OSDMonitor::crush_ruleset_create_erasure(const string &name,
 					     const string &profile,
 					     int *ruleset,
@@ -3709,6 +3767,8 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
     g_conf->osd_pool_default_cache_target_full_ratio * 1000000;
   pi->cache_min_flush_age = g_conf->osd_pool_default_cache_min_flush_age;
   pi->cache_min_evict_age = g_conf->osd_pool_default_cache_min_evict_age;
+  
+  prepare_adaptive_seed(pi, pool);
   pending_inc.new_pool_names[pool] = name;
   return 0;
 }

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -266,6 +266,7 @@ private:
   int crush_rename_bucket(const string& srcname,
 			  const string& dstname,
 			  ostream *ss);
+  void prepare_adaptive_seed(pg_pool_t *pi, int64_t pool);
   int crush_ruleset_create_erasure(const string &name,
 				   const string &profile,
 				   int *ruleset,

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1500,7 +1500,7 @@ int OSDMap::_pg_to_osds(const pg_pool_t& pool, pg_t pg,
   // what crush rule?
   int ruleno = crush->find_rule(pool.get_crush_ruleset(), pool.get_type(), size);
   if (ruleno >= 0)
-    crush->do_rule(ruleno, pps, *osds, size, osd_weight);
+    crush->do_rule(ruleno, pps, *osds, size, osd_weight, 0);
 
   _remove_nonexistent_osds(pool, *osds);
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1500,7 +1500,7 @@ int OSDMap::_pg_to_osds(const pg_pool_t& pool, pg_t pg,
   // what crush rule?
   int ruleno = crush->find_rule(pool.get_crush_ruleset(), pool.get_type(), size);
   if (ruleno >= 0)
-    crush->do_rule(ruleno, pps, *osds, size, osd_weight, 0);
+    crush->do_rule(ruleno, pps, *osds, size, osd_weight, pool.get_seed());
 
   _remove_nonexistent_osds(pool, *osds);
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1036,6 +1036,9 @@ uint64_t OSDMap::get_features(int entity_type, uint64_t *pmask) const
     if (p->second.flags & pg_pool_t::FLAG_HASHPSPOOL) {
       features |= CEPH_FEATURE_OSDHASHPSPOOL;
     }
+    if (p->second.flags & pg_pool_t::FLAG_HASHPSPOOL2) {
+      features |= CEPH_FEATURE_OSDHASHPSPOOL2;
+    }
     if (p->second.is_erasure() &&
 	entity_type != CEPH_ENTITY_TYPE_CLIENT) { // not for clients
       features |= CEPH_FEATURE_OSD_ERASURE_CODES;
@@ -1065,7 +1068,7 @@ uint64_t OSDMap::get_features(int entity_type, uint64_t *pmask) const
 	features |= CEPH_FEATURE_ERASURE_CODE_PLUGINS_V2;
     }
   }
-  mask |= CEPH_FEATURE_OSDHASHPSPOOL | CEPH_FEATURE_OSD_CACHEPOOL;
+  mask |= CEPH_FEATURE_OSDHASHPSPOOL | CEPH_FEATURE_OSDHASHPSPOOL2 |CEPH_FEATURE_OSD_CACHEPOOL;
   if (entity_type != CEPH_ENTITY_TYPE_CLIENT)
     mask |= CEPH_FEATURE_OSD_ERASURE_CODES;
 
@@ -2694,8 +2697,10 @@ int OSDMap::build_simple(CephContext *cct, epoch_t e, uuid_d &fsid,
     int64_t pool = ++pool_max;
     pools[pool].type = pg_pool_t::TYPE_REPLICATED;
     pools[pool].flags = cct->_conf->osd_pool_default_flags;
-    if (cct->_conf->osd_pool_default_flag_hashpspool)
+    if (cct->_conf->osd_pool_default_flag_hashpspool == 1)
       pools[pool].flags |= pg_pool_t::FLAG_HASHPSPOOL;
+    if (cct->_conf->osd_pool_default_flag_hashpspool == 2)
+      pools[pool].flags |= pg_pool_t::FLAG_HASHPSPOOL2;
     pools[pool].size = cct->_conf->osd_pool_default_size;
     pools[pool].min_size = cct->_conf->get_osd_pool_default_min_size();
     pools[pool].crush_ruleset = default_replicated_ruleset;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1659,6 +1659,15 @@ void OSDMap::pg_to_raw_up(pg_t pg, vector<int> *up, int *primary) const
   _apply_primary_affinity(pps, *pool, up, primary);
 }
   
+int OSDMap::pg_to_up_osds_adaptive(const pg_pool_t& pool, pg_t pg, vector<int>& up) const
+{
+  int primary;
+  vector<int> raw;
+  _pg_to_osds(pool, pg, &raw, &primary, NULL);
+  _raw_to_up_osds(pool, raw, &up, &primary);
+  return up.size();
+}
+
 void OSDMap::_pg_to_up_acting_osds(const pg_t& pg, vector<int> *up, int *up_primary,
                                    vector<int> *acting, int *acting_primary) const
 {

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -654,6 +654,7 @@ public:
     int r = pg_to_acting_osds(pg, &acting, &primary);
     return r;
   }
+  int pg_to_up_osds_adaptive(const pg_pool_t& pool, pg_t pg, vector<int>& up) const;
   /**
    * This does not apply temp overrides and should not be used
    * by anybody for data mapping purposes. Specify both pointers.

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1026,6 +1026,11 @@ ps_t pg_pool_t::raw_pg_to_pps(pg_t pg) const
       crush_hash32_2(CRUSH_HASH_RJENKINS1,
 		     ceph_stable_mod(pg.ps(), pgp_num, pgp_num_mask),
 		     pg.pool());
+  } else if (flags & FLAG_HASHPSPOOL2) {
+    // Hash pg seed with pool id using congruential generator
+    ps_t stable = ceph_stable_mod(pg.ps(), pgp_num, pgp_num_mask);
+    ps_t pps = (1033*stable + 2*pg.pool() + 1) % pgp_num_mask + crush_hash32(CRUSH_HASH_RJENKINS1, pg.pool());
+    return pps;
   } else {
     // Legacy behavior; add ps and pool together.  This is not a great
     // idea because the PGs from each pool will essentially overlap on

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -857,6 +857,7 @@ void pg_pool_t::dump(Formatter *f) const
   f->dump_unsigned("min_read_recency_for_promote", min_read_recency_for_promote);
   f->dump_unsigned("stripe_width", get_stripe_width());
   f->dump_unsigned("expected_num_objects", expected_num_objects);
+  f->dump_int("seed", get_seed());
 }
 
 
@@ -1161,7 +1162,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     return;
   }
 
-  ENCODE_START(17, 5, bl);
+  ENCODE_START(18, 5, bl);
   ::encode(type, bl);
   ::encode(size, bl);
   ::encode(crush_ruleset, bl);
@@ -1203,12 +1204,13 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
   ::encode(last_force_op_resend, bl);
   ::encode(min_read_recency_for_promote, bl);
   ::encode(expected_num_objects, bl);
+  ::encode(seed, bl);
   ENCODE_FINISH(bl);
 }
 
 void pg_pool_t::decode(bufferlist::iterator& bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(17, 5, 5, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(18, 5, 5, bl);
   ::decode(type, bl);
   ::decode(size, bl);
   ::decode(crush_ruleset, bl);
@@ -1320,6 +1322,11 @@ void pg_pool_t::decode(bufferlist::iterator& bl)
   } else {
     expected_num_objects = 0;
   }
+  if (struct_v >= 18) {
+    ::decode(seed, bl);
+  } else {
+    seed = 0;
+  }
   DECODE_FINISH(bl);
   calc_pg_masks();
 }
@@ -1375,6 +1382,7 @@ void pg_pool_t::generate_test_instances(list<pg_pool_t*>& o)
   a.cache_min_evict_age = 2321;
   a.erasure_code_profile = "profile in osdmap";
   a.expected_num_objects = 123456;
+  a.seed = 1;
   o.push_back(new pg_pool_t(a));
 }
 
@@ -1424,6 +1432,8 @@ ostream& operator<<(ostream& out, const pg_pool_t& p)
   out << " stripe_width " << p.get_stripe_width();
   if (p.expected_num_objects)
     out << " expected_num_objects " << p.expected_num_objects;
+  if (p.get_seed())
+    out << " seed " << p.get_seed();
   return out;
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -991,6 +991,8 @@ public:
   uint64_t expected_num_objects; ///< expected number of objects on this pool, a value of 0 indicates
                                  ///< user does not specify any expected value
 
+  __u8 seed; ///< seed for compressing size of pps number space
+
   pg_pool_t()
     : flags(0), type(0), size(0), min_size(0),
       crush_ruleset(0), object_hash(0),
@@ -1014,7 +1016,8 @@ public:
       hit_set_count(0),
       min_read_recency_for_promote(0),
       stripe_width(0),
-      expected_num_objects(0)
+      expected_num_objects(0),
+      seed(1)
   { }
 
   void dump(Formatter *f) const;
@@ -1106,6 +1109,8 @@ public:
   uint64_t get_quota_max_objects() {
     return quota_max_objects;
   }
+  void set_seed(int s) {seed = s; }
+  int get_seed() const { return seed; }
 
   static int calc_bits_of(int t);
   void calc_pg_masks();

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -821,6 +821,7 @@ struct pg_pool_t {
     FLAG_FULL       = 1<<1, // pool is full
     FLAG_DEBUG_FAKE_EC_POOL = 1<<2, // require ReplicatedPG to act like an EC pg
     FLAG_INCOMPLETE_CLONES = 1<<3, // may have incomplete clones (bc we are/were an overlay)
+    FLAG_HASHPSPOOL2 = 1<<4, // hash pg seed and pool using congruential pseudo-random number generator
   };
 
   static const char *get_flag_name(int f) {
@@ -829,6 +830,7 @@ struct pg_pool_t {
     case FLAG_FULL: return "full";
     case FLAG_DEBUG_FAKE_EC_POOL: return "require_local_rollback";
     case FLAG_INCOMPLETE_CLONES: return "incomplete_clones";
+    case FLAG_HASHPSPOOL2: return "hashpspool_congruential";
     default: return "???";
     }
   }

--- a/src/test/cli/crushtool/help.t
+++ b/src/test/cli/crushtool/help.t
@@ -6,7 +6,7 @@
                            specify output for for (de)compilation
      --build --num_osds N layer1 ...
                            build a new map, where each 'layer' is
-                             'name (uniform|straw|list|tree) size'
+                             'name (uniform|straw|list|tree|linear) size'
      -i mapfn --test       test a range of inputs on the map
         [--min-x x] [--max-x x] [--x x]
         [--min-rule r] [--max-rule r] [--rule r]

--- a/src/test/cli/osdmaptool/clobber.t
+++ b/src/test/cli/osdmaptool/clobber.t
@@ -20,7 +20,7 @@
   modified \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   flags 
   
-  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 0 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0
+  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 0 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0 seed 1
   
   max_osd 3
   
@@ -41,7 +41,7 @@
   modified \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   flags 
   
-  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 0 object_hash rjenkins pg_num 64 pgp_num 64 last_change 0 flags hashpspool stripe_width 0
+  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 0 object_hash rjenkins pg_num 64 pgp_num 64 last_change 0 flags hashpspool stripe_width 0 seed 1
   
   max_osd 1
   

--- a/src/test/cli/osdmaptool/create-print.t
+++ b/src/test/cli/osdmaptool/create-print.t
@@ -76,7 +76,7 @@
   modified \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   flags 
   
-  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 0 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0
+  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 0 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0 seed 1
   
   max_osd 3
   
@@ -85,19 +85,19 @@
   osdmaptool: writing epoch 1 to myosdmap
   $ osdmaptool --print myosdmap | grep 'pool 0'
   osdmaptool: osdmap file 'myosdmap'
-  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 66 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0
+  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 66 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0 seed 1
   $ osdmaptool --clobber --createsimple 3 --osd_pool_default_crush_rule 55 myosdmap 2>&1 >/dev/null | sed -e 's/^.* 0 osd_pool_//'
   osdmaptool: osdmap file 'myosdmap'
   default_crush_rule is deprecated use osd_pool_default_crush_replicated_ruleset instead
   default_crush_rule = 55 overrides osd_pool_default_crush_replicated_ruleset = 0
   $ osdmaptool --print myosdmap | grep 'pool 0'
   osdmaptool: osdmap file 'myosdmap'
-  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0
+  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0 seed 1
   $ osdmaptool --clobber --createsimple 3 --osd_pool_default_crush_replicated_ruleset 66 --osd_pool_default_crush_rule 55 myosdmap 2>&1 >/dev/null | sed -e 's/^.* 0 osd_pool_//'
   osdmaptool: osdmap file 'myosdmap'
   default_crush_rule is deprecated use osd_pool_default_crush_replicated_ruleset instead
   default_crush_rule = 55 overrides osd_pool_default_crush_replicated_ruleset = 66
   $ osdmaptool --print myosdmap | grep 'pool 0'
   osdmaptool: osdmap file 'myosdmap'
-  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0
+  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 192 pgp_num 192 last_change 0 flags hashpspool stripe_width 0 seed 1
   $ rm -f myosdmap

--- a/src/test/cli/osdmaptool/create-racks.t
+++ b/src/test/cli/osdmaptool/create-racks.t
@@ -789,7 +789,7 @@
   modified \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   flags 
   
-  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 0 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0
+  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 0 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0 seed 1
   
   max_osd 239
   
@@ -799,19 +799,19 @@
   osdmaptool: writing epoch 1 to om
   $ osdmaptool --print om | grep 'pool 0'
   osdmaptool: osdmap file 'om'
-  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0
+  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0 seed 1
   $ osdmaptool --clobber --create-from-conf --osd_pool_default_crush_rule 55 om -c $TESTDIR/ceph.conf.withracks 2>&1 >/dev/null | sed -e 's/^.* 0 osd_pool_//'
   osdmaptool: osdmap file 'om'
   default_crush_rule is deprecated use osd_pool_default_crush_replicated_ruleset instead
   default_crush_rule = 55 overrides osd_pool_default_crush_replicated_ruleset = 0
   $ osdmaptool --print om | grep 'pool 0'
   osdmaptool: osdmap file 'om'
-  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0
+  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0 seed 1
   $ osdmaptool --clobber --create-from-conf --osd_pool_default_crush_replicated_ruleset 66 --osd_pool_default_crush_rule 55 om -c $TESTDIR/ceph.conf.withracks 2>&1 >/dev/null | sed -e 's/^.* 0 osd_pool_//'
   osdmaptool: osdmap file 'om'
   default_crush_rule is deprecated use osd_pool_default_crush_replicated_ruleset instead
   default_crush_rule = 55 overrides osd_pool_default_crush_replicated_ruleset = 66
   $ osdmaptool --print om | grep 'pool 0'
   osdmaptool: osdmap file 'om'
-  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0
+  pool 0 'rbd' replicated size 3 min_size 2 crush_ruleset 55 object_hash rjenkins pg_num 15296 pgp_num 15296 last_change 0 flags hashpspool stripe_width 0 seed 1
   $ rm -f om

--- a/src/test/crush/TestCrushWrapper.cc
+++ b/src/test/crush/TestCrushWrapper.cc
@@ -111,9 +111,9 @@ TEST(CrushWrapper, straw_zero) {
   vector<unsigned> reweight(n, 0x10000);
   for (int i=0; i<10000; ++i) {
     vector<int> out0, out1;
-    c->do_rule(ruleset0, i, out0, 1, reweight);
+    c->do_rule(ruleset0, i, out0, 1, reweight, 1);
     ASSERT_EQ(1u, out0.size());
-    c->do_rule(ruleset1, i, out1, 1, reweight);
+    c->do_rule(ruleset1, i, out1, 1, reweight, 1);
     ASSERT_EQ(1u, out1.size());
     ASSERT_EQ(out0[0], out1[0]);
     //cout << i << "\t" << out0 << "\t" << out1 << std::endl;
@@ -205,9 +205,9 @@ TEST(CrushWrapper, straw_same) {
   int max = 100000;
   for (int i=0; i<max; ++i) {
     vector<int> out0, out1;
-    c->do_rule(ruleset0, i, out0, 1, reweight);
+    c->do_rule(ruleset0, i, out0, 1, reweight, 1);
     ASSERT_EQ(1u, out0.size());
-    c->do_rule(ruleset1, i, out1, 1, reweight);
+    c->do_rule(ruleset1, i, out1, 1, reweight, 1);
     ASSERT_EQ(1u, out1.size());
     sum0[out0[0]]++;
     sum1[out1[0]]++;

--- a/src/test/crush/indep.cc
+++ b/src/test/crush/indep.cc
@@ -99,7 +99,7 @@ TEST(CRUSH, indep_toosmall) {
 
   for (int x = 0; x < 100; ++x) {
     vector<int> out;
-    c->do_rule(0, x, out, 5, weight);
+    c->do_rule(0, x, out, 5, weight, 1);
     cout << x << " -> " << out << std::endl;
     int num_none = 0;
     for (unsigned i=0; i<out.size(); ++i) {
@@ -119,7 +119,7 @@ TEST(CRUSH, indep_basic) {
 
   for (int x = 0; x < 100; ++x) {
     vector<int> out;
-    c->do_rule(0, x, out, 5, weight);
+    c->do_rule(0, x, out, 5, weight, 1);
     cout << x << " -> " << out << std::endl;
     int num_none = 0;
     for (unsigned i=0; i<out.size(); ++i) {
@@ -146,7 +146,7 @@ TEST(CRUSH, indep_out_alt) {
   c->set_choose_total_tries(100);
   for (int x = 0; x < 100; ++x) {
     vector<int> out;
-    c->do_rule(0, x, out, 9, weight);
+    c->do_rule(0, x, out, 9, weight, 1);
     cout << x << " -> " << out << std::endl;
     int num_none = 0;
     for (unsigned i=0; i<out.size(); ++i) {
@@ -172,7 +172,7 @@ TEST(CRUSH, indep_out_contig) {
   c->set_choose_total_tries(100);
   for (int x = 0; x < 100; ++x) {
     vector<int> out;
-    c->do_rule(0, x, out, 7, weight);
+    c->do_rule(0, x, out, 7, weight, 1);
     cout << x << " -> " << out << std::endl;
     int num_none = 0;
     for (unsigned i=0; i<out.size(); ++i) {
@@ -200,7 +200,7 @@ TEST(CRUSH, indep_out_progressive) {
     vector<int> prev;
     for (unsigned i=0; i<weight.size(); ++i) {
       vector<int> out;
-      c->do_rule(0, x, out, 7, weight);
+      c->do_rule(0, x, out, 7, weight, 1);
       cout << "(" << i << "/" << weight.size() << " out) "
 	   << x << " -> " << out << std::endl;
       int num_none = 0;

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -911,7 +911,7 @@ TEST_F(IsaErasureCodeTest, create_ruleset)
     vector<__u32> weight(c->get_max_devices(), 0x10000);
     vector<int> out;
     int x = 0;
-    c->do_rule(ruleset, x, out, isa.get_chunk_count(), weight);
+    c->do_rule(ruleset, x, out, isa.get_chunk_count(), weight, 1);
     ASSERT_EQ(out.size(), isa.get_chunk_count());
     for (unsigned i=0; i<out.size(); ++i)
       ASSERT_NE(CRUSH_ITEM_NONE, out[i]);

--- a/src/test/erasure-code/TestErasureCodeJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodeJerasure.cc
@@ -312,7 +312,7 @@ TEST(ErasureCodeTest, create_ruleset)
     vector<__u32> weight(c->get_max_devices(), 0x10000);
     vector<int> out;
     int x = 0;
-    c->do_rule(ruleset, x, out, jerasure.get_chunk_count(), weight);
+    c->do_rule(ruleset, x, out, jerasure.get_chunk_count(), weight, 1);
     ASSERT_EQ(out.size(), jerasure.get_chunk_count());
     for (unsigned i=0; i<out.size(); ++i)
       ASSERT_NE(CRUSH_ITEM_NONE, out[i]);

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -149,7 +149,7 @@ TEST(ErasureCodeTest, create_ruleset)
   int rule = c->get_rule_id(rule_name);
   vector<int> out;
   unsigned int n = racks * hosts;
-  c->do_rule(rule, 1, out, n, weight);
+  c->do_rule(rule, 1, out, n, weight, 1);
   EXPECT_EQ(n, out.size());
   //
   // check that the first five are in the same rack and the next five

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -91,7 +91,7 @@ void usage()
   cout << "                         specify output for for (de)compilation\n";
   cout << "   --build --num_osds N layer1 ...\n";
   cout << "                         build a new map, where each 'layer' is\n";
-  cout << "                           'name (uniform|straw|list|tree) size'\n";
+  cout << "                           'name (uniform|straw|list|tree|linear) size'\n";
   cout << "   -i mapfn --test       test a range of inputs on the map\n";
   cout << "      [--min-x x] [--max-x x] [--x x]\n";
   cout << "      [--min-rule r] [--max-rule r] [--rule r]\n";
@@ -151,6 +151,7 @@ struct bucket_types_t {
   { "list", CRUSH_BUCKET_LIST },
   { "straw", CRUSH_BUCKET_STRAW },
   { "tree", CRUSH_BUCKET_TREE },
+  { "linear", CRUSH_BUCKET_LINEAR },
   { 0, 0 },
 };
 


### PR DESCRIPTION
We did some optimization for the issue of unbalanced pg distribution among osds in previous work. Please refer to <a href="https://github.com/ceph/ceph/pull/2402">#2402</a> for details.

In this commit, we updated codes for adding a new hashpspool flag HASHPSPOOL2 for the new congruential pps hash algorithm as per previous comments.