### PR TITLE
doc: fix some typos in ObjectStore.h

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -204,7 +204,7 @@ public:
    *
    * The data portion of an object is conceptually equivalent to a
    * file in a file system. Random and Partial access for both read
-   * and operations is required. The ability to have a sparse
+   * and write operations is required. The ability to have a sparse
    * implementation of the data portion of an object is beneficial for
    * some workloads, but not required. There is a system-wide limit on
    * the maximum size of an object, which is typically around 100 MB.
@@ -269,7 +269,7 @@ public:
    * execute quickly and must not acquire any locks of the calling
    * environment. Conversely, "on_applied" is called from the separate
    * Finisher thread, meaning that it can contend for calling
-   * environment locks. NB, on_applied and on_applied sync are
+   * environment locks. NB, on_applied and on_applied_sync are
    * sometimes called on_readable and on_readable_sync.
    *
    * The "on_commit" callback is also called from the Finisher thread
@@ -320,7 +320,7 @@ public:
    * Enumeration operations may violate transaction isolation as
    * described above when a storage element is being created or
    * deleted as part of a transaction. In this case, ObjectStore is
-   * allowed to consider the enumeration operation to either preceed
+   * allowed to consider the enumeration operation to either precede
    * or follow the violating transaction element. In other words, the
    * presence/absence of the mutated element in the enumeration is
    * entirely at the discretion of ObjectStore. The arbitrary ordering
@@ -328,7 +328,7 @@ public:
    * if a transaction contains two mutating elements "create A" and
    * "delete B". And an enumeration operation is performed while this
    * transaction is pending. It is permissable for ObjectStore to
-   * report any of the four possible combinations of the existance of
+   * report any of the four possible combinations of the existence of
    * A and B.
    *
    */
@@ -808,7 +808,7 @@ public:
      * object are cloned (data, xattrs, omap header, omap
      * entries).
      *
-     * The destination named object may already exist in
+     * The destination named object may already exist, in
      * which case its previous contents are discarded.
      */
     void clone(coll_t cid, const ghobject_t& oid, ghobject_t noid) {
@@ -1340,7 +1340,7 @@ public:
    * Returns an encoded map of the extents of an object's data portion
    * (map<offset,size>).
    *
-   * A non-enlightend implementation is free to return the extent (offset, len)
+   * A non-enlightened implementation is free to return the extent (offset, len)
    * as the sole extent.
    *
    * @param cid collection for object


### PR DESCRIPTION
just fix some trivial typos in comment.
