### PR TITLE
rpm: unconditionally package rbd-replay-prep(8)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -743,10 +743,10 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_bindir}/ceph-kvstore-tool
 %{_mandir}/man8/rbd-replay.8*
 %{_mandir}/man8/rbd-replay-many.8*
+%{_mandir}/man8/rbd-replay-prep.8*
 %{_bindir}/rbd-replay
 %{_bindir}/rbd-replay-many
 %if (0%{?fedora} >= 20 || 0%{?rhel} == 6)
-%{_mandir}/man8/rbd-replay-prep.8*
 %{_bindir}/rbd-replay-prep
 %endif
 


### PR DESCRIPTION
The build system will conditionally build and install the `rbd-replay-prep` utility based on the presence of lttng.

Commit 230c5b8e7f58e2e8be32c3f31c6abcc5bdabc5ca adjusted the RPM packaging so that we only package and ship the `rbd-replay-prep` utility and its man page when we're on a platform that has lttng.

The problem is that this is only half-correct. The build system unconditionally installs the man page for `rbd-replay-prep`, regardless of whether lttng was present or absent, and (by extension,) without regard for whether we've built and installed the `rbd-replay-prep` binary or not.

We have two options: either the build system should be adjusted to conditionally skip installing `rbd-replay-prep(8)`, or else we should just adjust the RPM packaging to always ship the man page. This commit does the latter.

(cc'ing @adamcrume in case he wants to review, since he's worked on this area of the packaging recently)
