### PR TITLE
Add "make check" dep python-virtualenv in deps.rpm.txt

### DIFF
--- a/deps.rpm.txt
+++ b/deps.rpm.txt
@@ -24,6 +24,7 @@ nss-devel
 python-argparse
 python-flask
 python-nose
+python-virtualenv
 snappy-devel
 systemd-devel
 xfsprogs-devel


### PR DESCRIPTION
In fedora20, When 'make  check' and met those error messages:
/src/test/run-cli-tests: virtualenv not installed, skipping python-using
tests.

Signed-off-by: Jianpeng Ma jianpeng.ma@intel.com
