### PR TITLE
Fix #10080 - OSD crashes during msgr reconnection

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1260,8 +1260,17 @@ void Pipe::discard_requeued_up_to(uint64_t seq)
     rq.pop_front();
     out_seq++;
   }
-  if (rq.empty())
+
+  if (rq.empty()) {
+    // Bump up the out_seq to match its peer's in_seq, for example, if the connection with
+    // the peer was marked down, and there is a re-connection from peer, we need to make
+    // sure the in/out seq are synced to prevent message (wrongly) ignoring from peer or even
+    // crash if we need to a do reconnect (for whatever reasons)
+    if (seq > out_seq) {
+      out_seq = seq;
+    }
     out_q.erase(CEPH_MSG_PRIO_HIGHEST);
+  }
 }
 
 /*


### PR DESCRIPTION
Event flow analysis:
Let us say OSD A and B are peers with each other, at certain point, B is marked down by monitor (and thus kicked off osd map), but the daemon is still there, A would mark the connection with B down and clean everything. When B is in again, it will try to connect with A and negotiate the message in/out sequence. At A side, it will receive B's in_seq and drop messages whose sequence is equal to or less than B's in_seq. In this case, A's out_seq might be inconsistent to B's in_seq.

Solution:
At A side, after receiving B's in_seq, if after locally clean-up, if its out_seq is still less than B's in_seq, bump up its out_seq to make two sides consistent with each other.

Fixes: #10080

Signed-off-by: Guang Yang yguang@yahoo-inc.com
