### PR TITLE
packages: add python-virtualenv and xmlstarlet

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -47,6 +47,7 @@ BuildRequires:	pkgconfig
 BuildRequires:	python
 BuildRequires:	python-nose
 BuildRequires:	python-argparse
+BuildRequires:	python-virtualenv
 BuildRequires:	libaio-devel
 BuildRequires:	libcurl-devel
 BuildRequires:	libxml2-devel
@@ -55,6 +56,7 @@ BuildRequires:	libblkid-devel >= 2.17
 BuildRequires:	libudev-devel
 BuildRequires:	leveldb-devel > 1.2
 BuildRequires:	xfsprogs-devel
+BuildRequires:	xmlstarlet
 BuildRequires:	yasm
 %if 0%{?rhel} || 0%{?centos} || 0%{?fedora}
 BuildRequires:	snappy-devel

--- a/debian/control
+++ b/debian/control
@@ -43,9 +43,11 @@ Build-Depends: autoconf,
                python (>= 2.6.6-3~),
                python-argparse,
                python-nose,
+               python-virtualenv,
                uuid-dev,
                uuid-runtime,
                xfslibs-dev,
+               xmlstarlet,
                yasm [amd64]
 Standards-Version: 3.9.3
 


### PR DESCRIPTION
python-virtualenv is required to run make check and xmlstarlet is useful
to develop shell base tests using ceph --format xml osd dump.

Signed-off-by: Loic Dachary <ldachary@redhat.com>