### PR TITLE
osd: make filestore_blackhole works

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -1836,10 +1836,10 @@ int FileStore::queue_transactions(Sequencer *posr, list<Transaction*> &tls,
   ObjectStore::Transaction::collect_contexts(
     tls, &onreadable, &ondisk, &onreadable_sync);
   if (g_conf->filestore_blackhole) {
-    dout(0) << "queue_transactions filestore_blackhole = TRUE, dropping transaction" << dendl;
-    delete ondisk;
-    delete onreadable;
-    delete onreadable_sync;
+    dout(1) << "queue_transactions filestore_blackhole = TRUE, dropping transaction" << dendl;
+    finisher.queue(ondisk);
+    finisher.queue(onreadable);
+    finisher.queue(onreadable_sync);
     return 0;
   }
 


### PR DESCRIPTION
filestore_blackhole is useful for performance test, but we should make
it works for client, so the patch queue ondisk/onreadable/
onreadable_sync directly into finisher.

The patch also set the dout level of filestore_blackhole to 1, so it
will not hurt the performance.

Signed-off-by: Dong Yuan yuandong1222@gmail.com
