### PR TITLE
better systemd support

### DIFF
--- a/systemd/ceph
+++ b/systemd/ceph
@@ -1,0 +1,66 @@
+#! /bin/bash
+
+### BEGIN INIT INFO
+# Provides:       ceph ceph-mon ceph-osd
+# Required-Start: $network $remote_fs
+# Required-Stop:  $network $remote_fs
+# Should-Start: network-remotefs
+# Should-Stop: network-remotefs
+# Default-Start:  3 5
+# Default-Stop:   0 1 2 6
+# Short-Description: Ceph is a distributed object, and block, storage platform
+# Description:    Ceph is a distributed object, block, and file storage platform
+### END INIT INFO
+
+SYSTEMD_NO_WRAP=1 . /etc/rc.status
+rc_reset
+
+action=$1 ; shift
+cluster="ceph"
+config=$1 ; shift
+
+# Shared variables by many actions
+dir_mon="/var/lib/ceph/mon/"
+dir_osd="/var/lib/ceph/osd/"
+if test -d ${dir_mon} ; then
+lmon=`ls ${dir_mon} | grep ${cluster}`
+fi
+if test -d ${dir_osd} ; then
+losd=`ls ${dir_osd} | grep ${cluster}`
+fi
+prefix="${cluster}-"
+
+if test -n "$config" ; then
+	systemctl "${action}" "ceph-mon@${config}.service"
+else
+	case $action in
+    start | stop | status | enable | disable | restart | is-active | is-failed | show | kill | reset-failed  )
+        n=0
+        if test -n ${lmon} ; then
+            for s in ${lmon#=${prefix}} ; do
+                systemctl "${action}" ceph-mon@${s#$prefix}.service
+                rc_check
+                ((++n))
+            done
+        fi
+        if test -n ${lmon} ; then
+            for s in ${losd#=${prefix}} ; do
+                systemctl "${action}" ceph-osd@${s#$prefix}.service
+                rc_check
+                ((++n))
+            done
+        fi
+        if test $n -gt 0 ; then
+			rc_status
+		else
+			rc_status -u
+		fi
+    ;;
+	*)
+		echo "Invalid paramter : $action"
+        echo "Valid paramters  : start | stop | status | enable | disable | restart | is-active | is-failed | show | kill | reset-failed"
+	;;
+	esac
+fi
+rc_exit
+

--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Ceph metadata server daemon
-After=network-online.target
-Wants=network-online.target
+After=network-online.target local-fs.target
+Wants=network-online.target local-fs.target
+PartOf=ceph.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph
@@ -9,4 +10,4 @@ Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=ceph.target

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -7,8 +7,9 @@ Wants=network-online.target
 #   http://www.freedesktop.org/wiki/Software/systemd/NetworkTarget
 # these can be removed once ceph-mon will dynamically change network
 # configuration.
-After=network-online.target
-Wants=network-online.target
+After=network-online.target local-fs.target
+Wants=network-online.target local-fs.target
+PartOf=ceph.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph
@@ -16,4 +17,4 @@ Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=ceph.target

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Ceph object storage daemon
-After=network-online.target
-Wants=network-online.target
+After=network-online.target local-fs.target
+Wants=network-online.target local-fs.target
+PartOf=ceph.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph
@@ -10,4 +11,4 @@ ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i
 ExecStartPre=/usr/libexec/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=ceph.target

--- a/systemd/ceph.target
+++ b/systemd/ceph.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph*@.service instances at once
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Added ceph.target
Made ceph-mds, ceph-mon, ceph-osd services part of ceph.target
Made ceph-mds, ceph-mon, ceph-osd services require partitions to be available.
Added ceph init script with sysV like behaviour.

Provided by Tim Serong tserong@suse.com and Owen Synge osynge@suse.com

Signed-off-by: Owen Synge osynge@suse.com
