### PR TITLE
WIP-8797: fix python thread hanging bug

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -841,4 +841,10 @@ def main():
     return 0
 
 if __name__ == '__main__':
-    sys.exit(main())
+    result = main()
+
+    # sys.exit doesn't necessarily trigger threads to garbage collect
+    # clean up the class and shutdown the thread
+    del cluster_handle
+
+    sys.exit(result)


### PR DESCRIPTION
sys.exit does not guarantee garbage collection in threads, possibly
preventing Rados.shutdown() from being called causing python to hang due
to http://bugs.python.org/issue21963 .

Signed-off-by: Joe Julian me@joejulian.name
