### PR TITLE
packaging: package ceph-disk(8)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -499,6 +499,7 @@ fi
 %config %{_sysconfdir}/bash_completion.d/ceph
 %config(noreplace) %{_sysconfdir}/logrotate.d/ceph
 %config(noreplace) %{_sysconfdir}/logrotate.d/radosgw
+%{_mandir}/man8/ceph-disk.8*
 %{_mandir}/man8/ceph-mon.8*
 %{_mandir}/man8/ceph-mds.8*
 %{_mandir}/man8/ceph-osd.8*

--- a/debian/ceph.install
+++ b/debian/ceph.install
@@ -24,6 +24,7 @@ usr/share/doc/ceph/sample.ceph.conf
 usr/share/doc/ceph/sample.fetch_config
 usr/share/man/man8/ceph-clsinfo.8
 usr/share/man/man8/ceph-debugpack.8
+usr/share/man/man8/ceph-disk.8
 usr/share/man/man8/ceph-mon.8
 usr/share/man/man8/ceph-osd.8
 usr/share/man/man8/ceph-run.8


### PR DESCRIPTION
The `ceph-disk` man page was added in a450cab2b8148cb8a9b043d629feccf89e5aabac, but this was not added to the RPM or DEB packaging. This pull request adds it.

CC'ing @nilamdyuti in case he wants to review.
