### PR TITLE
librbd: protect list_children from invalid child pool IoCtxs

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -419,7 +419,12 @@ namespace librbd {
     for (std::list<string>::const_iterator it = pools.begin();
 	 it != pools.end(); ++it) {
       IoCtx ioctx;
-      rados.ioctx_create(it->c_str(), ioctx);
+      r = rados.ioctx_create(it->c_str(), ioctx);
+      if (r < 0) {
+        lderr(cct) << "Error accessing child image pool " << *it << dendl;
+        return r;
+      }
+
       set<string> image_ids;
       int r = cls_client::get_children(&ioctx, RBD_CHILDREN,
 				       parent_spec, image_ids);


### PR DESCRIPTION
While listing child images, don't ignore error codes returned
from librados when creating an IoCtx. This will prevent seg
faults from occurring when an invalid IoCtx is used.

Fixes: #10123
Backport: giant, firefly, dumpling
Signed-off-by: Jason Dillaman dillaman@redhat.com
(cherry picked from commit 0d350b6817d7905908a4e432cd359ca1d36bab50)
