### PR TITLE
SimpleMessenger: allow RESETSESSION whenever we forget an endpoint

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -597,7 +597,7 @@ int Pipe::accept()
 	       << " > " << existing->connect_seq << dendl;
       goto replace;
     } // existing
-    else if (policy.resetcheck && connect.connect_seq > 0) {
+    else if (connect.connect_seq > 0) {
       // we reset, and they are opening a new session
       ldout(msgr->cct,0) << "accept we reset (peer sent cseq " << connect.connect_seq << "), sending RESETSESSION" << dendl;
       msgr->lock.Unlock();


### PR DESCRIPTION
Allow session reset if we see an incoming connection from somebody we don't recognize but who thinks they know us.

This has already been reviewed by Sage.
