### PR TITLE
heap_profiler: support new gperftools header locations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -290,7 +290,13 @@ AC_ARG_WITH([profiler],
             [with_profiler=no])
 AS_IF([test "x$with_profiler" = xyes],
 	    [AC_CHECK_LIB([profiler], [ProfilerFlush], [],
-	        	  [AC_MSG_FAILURE([--with-profiler was given but libprofiler (libgoogle-perftools-dev on debian) not found])])],
+	        	  [AC_MSG_FAILURE([--with-profiler was given but libprofiler (libgoogle-perftools-dev on debian) not found])]),
+             AC_LANG_PUSH([C++]),
+             AC_CHECK_HEADERS([gperftools/heap-profiler.h \
+               gperftools/malloc_extension.h \
+               gperftools/profiler.h]),
+             AC_LANG_POP([C++])
+            ],
 	    [])
 AM_CONDITIONAL(WITH_PROFILER, test "$with_profiler" = "yes")
 AS_IF([test "$with_profiler" = "yes"],

--- a/src/perfglue/cpu_profiler.cc
+++ b/src/perfglue/cpu_profiler.cc
@@ -12,10 +12,19 @@
  *
  */
 
+#include "acconfig.h"
+
+// Use the newer gperftools header locations if available.
+// If not, fall back to the old (gperftools < 2.0) locations.
+
+#ifdef HAVE_GPERFTOOLS_PROFILER_H
+  #include <gperftools/profiler.h>
+#else
+  #include <google/profiler.h>
+#endif
+
 #include "common/LogClient.h"
 #include "perfglue/cpu_profiler.h"
-
-#include <google/profiler.h>
 
 void cpu_profiler_handle_command(const std::vector<std::string> &cmd,
 				 ostream& out)

--- a/src/perfglue/heap_profiler.cc
+++ b/src/perfglue/heap_profiler.cc
@@ -12,8 +12,23 @@
  * 
  */
 
-#include <google/heap-profiler.h>
-#include <google/malloc_extension.h>
+#include "acconfig.h"
+
+// Use the newer gperftools header locations if available.
+// If not, fall back to the old (gperftools < 2.0) locations.
+
+#ifdef HAVE_GPERFTOOLS_HEAP_PROFILER_H
+  #include <gperftools/heap-profiler.h>
+#else
+  #include <google/heap-profiler.h>
+#endif
+
+#ifdef HAVE_GPERFTOOLS_MALLOC_EXTENSION_H
+  #include <gperftools/malloc_extension.h>
+#else
+  #include <google/malloc_extension.h>
+#endif
+
 #include "heap_profiler.h"
 #include "common/environment.h"
 #include "common/LogClient.h"


### PR DESCRIPTION
This is tracked in Redmine at http://tracker.ceph.com/issues/10231

The `google/` headers location has been deprecated as of gperftools 2.0. As of gperftools 2.2rc, the `google/` headers will now give deprecation warnings, and they will probably disappear in a future gperftools update.

An original fix for this was proposed at https://github.com/ceph/ceph/pull/2267 , but that was not backwards-compatible with older gperftools releases (eg. Ubuntu 12.04 Precise). The fix in this pull request should be fully forwards- and backwards-compatible.

CC'ing @branto1 in case he wants to review.
