### PR TITLE
librbd: don't close an already closed parent image upon failure

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1260,7 +1260,6 @@ reprotect_and_return_err:
     if (r < 0) {
       lderr(ictx->cct) << "error opening parent image: " << cpp_strerror(r)
 		       << dendl;
-      close_image(ictx->parent);
       ictx->parent = NULL;
       return r;
     }


### PR DESCRIPTION
If librbd is not able to open a child's parent image, it will
incorrectly close the parent image twice, resulting in a crash.

Fixes: #10030
Backport: firefly, giant
Signed-off-by: Jason Dillaman dillaman@redhat.com
(cherry picked from commit 61ebfebd59b61ffdc203dfeca01ee1a02315133e)
