### PR TITLE
mon: fix issues with mixed-version monitors features

### DIFF
--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -283,6 +283,7 @@ void Elector::handle_ack(MMonElection *m)
       required_features) {
     dout(5) << " ignoring ack from mon" << from
 	    << " without required features" << dendl;
+    m->put();
     return;
   }
   

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -214,6 +214,9 @@ void Elector::handle_propose(MMonElection *m)
 
   assert(m->epoch % 2 == 1); // election
   uint64_t required_features = mon->get_required_features();
+  dout(10) << __func__ << " required features " << required_features
+           << ", peer features " << m->get_connection()->get_features()
+           << dendl;
   if ((required_features ^ m->get_connection()->get_features()) &
       required_features) {
     dout(5) << " ignoring propose from mon" << from

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -341,18 +341,24 @@ void Monitor::handle_signal(int signum)
   shutdown();
 }
 
-CompatSet Monitor::get_supported_features()
+CompatSet Monitor::get_initial_supported_features()
 {
   CompatSet::FeatureSet ceph_mon_feature_compat;
   CompatSet::FeatureSet ceph_mon_feature_ro_compat;
   CompatSet::FeatureSet ceph_mon_feature_incompat;
   ceph_mon_feature_incompat.insert(CEPH_MON_FEATURE_INCOMPAT_BASE);
   ceph_mon_feature_incompat.insert(CEPH_MON_FEATURE_INCOMPAT_SINGLE_PAXOS);
-  ceph_mon_feature_incompat.insert(CEPH_MON_FEATURE_INCOMPAT_OSD_ERASURE_CODES);
-  ceph_mon_feature_incompat.insert(CEPH_MON_FEATURE_INCOMPAT_OSDMAP_ENC);
-  ceph_mon_feature_incompat.insert(CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V2);
   return CompatSet(ceph_mon_feature_compat, ceph_mon_feature_ro_compat,
 		   ceph_mon_feature_incompat);
+}
+
+CompatSet Monitor::get_supported_features()
+{
+  CompatSet compat = get_initial_supported_features();
+  compat.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_OSD_ERASURE_CODES);
+  compat.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_OSDMAP_ENC);
+  compat.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V2);
+  return compat;
 }
 
 CompatSet Monitor::get_legacy_features()
@@ -4237,7 +4243,7 @@ int Monitor::mkfs(bufferlist& osdmapbl)
   t->put(MONITOR_NAME, "magic", magicbl);
 
 
-  features = get_supported_features();
+  features = get_initial_supported_features();
   write_features(t);
 
   // save monmap, osdmap, keyring.

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -550,7 +550,7 @@ public:
     return quorum_features;
   }
   uint64_t get_required_features() const {
-    return quorum_features;
+    return required_features;
   }
   void apply_quorum_to_compatset_features();
   void apply_compatset_features_to_quorum_requirements();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -796,6 +796,7 @@ public:
   void extract_save_mon_key(KeyRing& keyring);
 
   // features
+  static CompatSet get_initial_supported_features();
   static CompatSet get_supported_features();
   static CompatSet get_legacy_features();
   /// read the ondisk features into the CompatSet pointed to by read_features


### PR DESCRIPTION
Mainly, we were setting features in a manner that would have a freshly
mkfs'ed monitor to write all the features it supports to disk.  This would
make it impossible to form a quorum with an older monitor, even though
it should -- say, quorum does not support feature X but monitor, having
been mkfs'ed with feature X, would expect given feature to be available
in the quorum.

Also fixes a few other issues, including returning the proper features in
Monitor::get_required_features() -- we were returning 'quorum_features'
instead.