### PR TITLE
common: bufferlist::get_contiguous return 0 when param len == 0

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1367,6 +1367,10 @@ void buffer::list::rebuild_page_aligned()
     if (orig_off + len > length())
       throw end_of_buffer();
 
+    if (len == 0) {
+      return 0;
+    }
+
     unsigned off = orig_off;
     std::list<ptr>::iterator curbuf = _buffers.begin();
     while (off > 0 && off >= curbuf->length()) {

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1081,6 +1081,8 @@ TEST(BufferList, get_contiguous) {
   bufferptr b("123456789", 9);
   bufferptr c("ABCDEFGHI", 9);
   bufferlist bl;
+  ASSERT_EQ(0, bl.get_contiguous(0, 0));
+
   bl.append(a);
   bl.append(b);
   bl.append(c);


### PR DESCRIPTION
The new transaction depends on this semantic.

Or maybe we should have another determinate semantic.

Change-Id: I3eaee45b12c634687cd1b294b3c264aed8cab03a
Signed-off-by: Dong Yuan yuandong1222@gmail.com
