### PR TITLE
ceph: respect the PYTHON environment variable for dev mode.

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -40,16 +40,17 @@ if MYDIR.endswith('src') and \
     else:
         lib_path_var = "LD_LIBRARY_PATH"
 
+    py_binary = os.environ.get("PYTHON", "python")
     MYLIBPATH = os.path.join(MYDIR, '.libs')
     if lib_path_var in os.environ:
         if MYLIBPATH not in os.environ[lib_path_var]:
             os.environ[lib_path_var] += ':' + MYLIBPATH
             print >> sys.stderr, DEVMODEMSG
-            os.execvp('python', ['python'] + sys.argv)
+            os.execvp(py_binary, ['python'] + sys.argv)
     else:
         os.environ[lib_path_var] = MYLIBPATH
         print >> sys.stderr, DEVMODEMSG
-        os.execvp('python', ['python'] + sys.argv)
+        os.execvp(py_binary, ['python'] + sys.argv)
     sys.path.insert(0, os.path.join(MYDIR, 'pybind'))
     if os.environ.has_key('PATH') and MYDIR not in os.environ['PATH']:
         os.environ['PATH'] += ':' + MYDIR


### PR DESCRIPTION
On OSes where `python` is python3, dev mode's re-exec makes the
ceph tool fail. The standard way to fix this is by exporting
the PYTHON envvar pointing to the python2 interpreter.
