### PR TITLE
WBThrottle: make bytes/ios/inode_wb's perf counter effective

### DIFF
--- a/src/os/WBThrottle.cc
+++ b/src/os/WBThrottle.cc
@@ -175,9 +175,12 @@ void *WBThrottle::entry()
     clearing = ghobject_t();
     cur_ios -= wb.get<2>().ios;
     logger->dec(l_wbthrottle_ios_dirtied, wb.get<2>().ios);
+    logger->inc(l_wbthrottle_ios_wb, wb.get<2>().ios);
     cur_size -= wb.get<2>().size;
     logger->dec(l_wbthrottle_bytes_dirtied, wb.get<2>().size);
+    logger->inc(l_wbthrottle_bytes_wb, wb.get<2>().size);
     logger->dec(l_wbthrottle_inodes_dirtied);
+    logger->inc(l_wbthrottle_inodes_wb);
     cond.Signal();
     wb = boost::tuple<ghobject_t, FDRef, PendingWB>();
   }


### PR DESCRIPTION
Since sync thread will cause unstable iops and latency performance curve, we
may want make WBThread do more(or moderate?) writeback and avoid sync thread
flush too much which will cause journal io long tail.

Via these counters, we can view how much object or bytes are write backed by
WBThread and how much bytes are flushed . Then we can have a great tuning for
"_bytes_start_flusher", "_ios_start_flusher" and "*inodes_start_flusher".
What we want to see is that in-memory data can writeback into disk with a
moderate rate.

Signed-off-by: Haomai Wang haomaiwang@gmail.com
