### PR TITLE
ceph-osd: don't close stderr if not daemonizing

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -506,9 +506,6 @@ int main(int argc, const char **argv)
     return 1;
   }
 
-  // Now close the standard file descriptors
-  global_init_shutdown_stderr(g_ceph_context);
-
   ms_public->start();
   ms_hbclient->start();
   ms_hb_front_server->start();


### PR DESCRIPTION
Otherwise, one loses log messages when running with -f or -d

Fixes: #10010, #10113, #9810

Signed-off-by: Dan Mick dan.mick@redhat.com
