### PR TITLE
rgw: optionally call FCGX_Free() on the fcgi connection

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -770,6 +770,7 @@ OPTION(rgw_cache_lru_size, OPT_INT, 10000)   // num of entries in rgw cache
 OPTION(rgw_socket_path, OPT_STR, "")   // path to unix domain socket, if not specified, rgw will not run as external fcgi
 OPTION(rgw_host, OPT_STR, "")  // host for radosgw, can be an IP, default is 0.0.0.0
 OPTION(rgw_port, OPT_STR, "")  // port to listen, format as "8080" "5000", if not specified, rgw will not run external fcgi
+OPTION(rgw_fcgi_explicit_free, OPT_BOOL, true) // whether to call FCGX_Free explicitly on every complete request
 OPTION(rgw_dns_name, OPT_STR, "")
 OPTION(rgw_script_uri, OPT_STR, "") // alternative value for SCRIPT_URI if not set in request
 OPTION(rgw_request_uri, OPT_STR,  "") // alternative value for REQUEST_URI if not set in request

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -639,6 +639,10 @@ void RGWFCGXProcess::handle_request(RGWRequest *r)
 
   FCGX_Finish_r(fcgx);
 
+  if (store->ctx()->_conf->rgw_fcgi_explicit_free) {
+    FCGX_Free(fcgx, 1);
+  }
+
   delete req;
 }
 


### PR DESCRIPTION
Fixes: #10194

A new configurable controls this behavior. This forces disconnection of
the fcgi connection when done with the request.

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
