### PR TITLE
Wip 10194 master

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -180,6 +180,7 @@ noinst_HEADERS += \
 	common/map_cacher.hpp \
 	common/MemoryModel.h \
 	common/Mutex.h \
+	common/QueueRing.h \
 	common/PrebufferedStreambuf.h \
 	common/RWLock.h \
 	common/Semaphore.h \

--- a/src/common/QueueRing.h
+++ b/src/common/QueueRing.h
@@ -1,0 +1,61 @@
+#ifndef QUEUE_RING_H
+#define QUEUE_RING_H
+
+#include <list>
+#include <vector>
+#include "common/Mutex.h"
+#include "common/Cond.h"
+
+
+
+template <class T>
+class QueueRing {
+  struct QueueBucket {
+    Mutex lock;
+    Cond cond;
+    typename std::list<T> entries;
+
+    QueueBucket() : lock("QueueRing::QueueBucket::lock") {}
+    QueueBucket(const QueueBucket& rhs) : lock("QueueRing::QueueBucket::lock") {
+      entries = rhs.entries;
+    }
+
+    void enqueue(const T& entry) {
+      lock.Lock();
+      if (entries.empty()) {
+        cond.Signal();
+      }
+      entries.push_back(entry);
+      lock.Unlock();
+    }
+
+    void dequeue(T *entry) {
+      lock.Lock();
+      if (entries.empty()) {
+        cond.Wait(lock);
+      };
+      assert(!entries.empty());
+      *entry = entries.front();
+      entries.pop_front();
+      lock.Unlock();
+    };
+  };
+
+  std::vector<QueueBucket> buckets;
+  int num_buckets;
+  atomic_t cur_read_bucket;
+  atomic_t cur_write_bucket;
+public:
+  QueueRing(int n) : buckets(n), num_buckets(n) {
+  }
+
+  void enqueue(const T& entry) {
+    buckets[cur_write_bucket.inc() % num_buckets].enqueue(entry);
+  };
+
+  void dequeue(T *entry) {
+    buckets[cur_read_bucket.inc() % num_buckets].dequeue(entry);
+  }
+};
+
+#endif


### PR DESCRIPTION
A more intrusive fix to 10194. This will reuse connection structure between requests.