### PR TITLE
tests: fixes to run make check on fedora 20

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1472,6 +1472,8 @@ protected:
   void _maybe_boot(epoch_t oldest, epoch_t newest);
   void _send_boot();
   void _collect_metadata(map<string,string> *pmeta);
+  bool _lsb_release_set(char *buf, const char *str, map<string,string> *pm, const char *key);
+  void _lsb_release_parse (map<string,string> *pm);
 
   void start_waiting_for_healthy();
   bool _is_healthy();

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -185,6 +185,7 @@ function test_activate_dir() {
 
     local osd_data=$DIR/osd
 
+    /bin/mkdir -p $osd_data
     ./ceph-disk $CEPH_DISK_ARGS \
         prepare $osd_data || return 1
 

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -73,8 +73,9 @@ function run_mon() {
 
 function kill_daemons() {
     for pidfile in $(find $DIR | grep pidfile) ; do
+        pid=$(cat $pidfile)
         for try in 0 1 1 1 2 3 ; do
-            kill $(cat $pidfile) || break
+            kill $pid || break
             sleep $try
         done
     done

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -84,7 +84,7 @@ function kill_daemons() {
 function command_fixture() {
     local command=$1
 
-    [ $(which $command) = ./$command ] || return 1
+    [ $(which $command) = ./$command ] || [ $(which $command) = $(pwd)/$command ] || return 1
 
     cat > $DIR/$command <<EOF
 #!/bin/bash

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -84,7 +84,7 @@ function kill_daemons() {
 function command_fixture() {
     local command=$1
 
-    [ $(which $command) = ./$command ] || [ $(which $command) = $(pwd)/$command ] || return 1
+    [ $(which $command) = ./$command ] || [ $(which $command) = `readlink -f $(pwd)/$command` ] || return 1
 
     cat > $DIR/$command <<EOF
 #!/bin/bash

--- a/src/test/cli/osdmaptool/test-map-pgs.t
+++ b/src/test/cli/osdmaptool/test-map-pgs.t
@@ -24,7 +24,7 @@
   pool 1 pg_num 8000
   pool 2 pg_num 8000
   $ TOTAL=$((POOL_COUNT * $PG_NUM))
-  $ PATTERN=$(echo "size $SIZE\t$TOTAL")
+  $ PATTERN=$(echo "size $SIZE.$TOTAL")
   $ grep "$PATTERN" $OUT || cat "$OUT"
   size 3\t24000 (esc)
   $ STATS_CRUSH=$(grep '^ avg ' "$OUT")
@@ -39,7 +39,7 @@
   pool 1 pg_num 8000
   pool 2 pg_num 8000
   $ TOTAL=$((POOL_COUNT * $PG_NUM))
-  $ PATTERN=$(echo "size $SIZE\t$TOTAL")
+  $ PATTERN=$(echo "size $SIZE.$TOTAL")
   $ grep "$PATTERN" $OUT || cat "$OUT"
   size 3\t24000 (esc)
   $ STATS_RANDOM=$(grep '^ avg ' "$OUT")

--- a/src/test/common/histogram.cc
+++ b/src/test/common/histogram.cc
@@ -47,63 +47,64 @@ TEST(Histogram, Set) {
 }
 
 TEST(Histogram, Position) {
-  {
-    pow2_hist_t h;
-    uint64_t lb, ub;
-    h.add(0);
-    ASSERT_EQ(-1, h.get_position_micro(-20, &lb, &ub));
-  }
-  {
-    pow2_hist_t h;
-    h.add(0);
-    uint64_t lb, ub;
-    h.get_position_micro(0, &lb, &ub);
-    ASSERT_EQ(0u, lb);
-    ASSERT_EQ(1000000u, ub);
-    h.add(0);
-    h.add(0);
-    h.add(0);
-    h.get_position_micro(0, &lb, &ub);
-    ASSERT_EQ(0u, lb);
-    ASSERT_EQ(1000000u, ub);
-  }
-  {
-    pow2_hist_t h;
-    h.add(1);
-    h.add(1);
-    uint64_t lb, ub;
-    h.get_position_micro(0, &lb, &ub);
-    ASSERT_EQ(0u, lb);
-    ASSERT_EQ(0u, ub);
-    h.add(0);
-    h.get_position_micro(0, &lb, &ub);
-    ASSERT_EQ(0u, lb);
-    ASSERT_EQ(333333u, ub);
-    h.get_position_micro(1, &lb, &ub);
-    ASSERT_EQ(333333u, lb);
-    ASSERT_EQ(1000000u, ub);
-  }
-  {
-    pow2_hist_t h;
-    h.h.resize(10, 0);
-    h.h[0] = 1;
-    h.h[5] = 1;
-    uint64_t lb, ub;
-    h.get_position_micro(4, &lb, &ub);
-    ASSERT_EQ(500000u, lb);
-    ASSERT_EQ(500000u, ub);
-  }
+  pow2_hist_t h;
+  uint64_t lb, ub;
+  h.add(0);
+  ASSERT_EQ(-1, h.get_position_micro(-20, &lb, &ub));
+}
+
+TEST(Histogram, Position1) {
+  pow2_hist_t h;
+  h.add(0);
+  uint64_t lb, ub;
+  h.get_position_micro(0, &lb, &ub);
+  ASSERT_EQ(0u, lb);
+  ASSERT_EQ(1000000u, ub);
+  h.add(0);
+  h.add(0);
+  h.add(0);
+  h.get_position_micro(0, &lb, &ub);
+  ASSERT_EQ(0u, lb);
+  ASSERT_EQ(1000000u, ub);
 }
 
 TEST(Histogram, Position2) {
+  pow2_hist_t h;
+  h.add(1);
+  h.add(1);
+  uint64_t lb, ub;
+  h.get_position_micro(0, &lb, &ub);
+  ASSERT_EQ(0u, lb);
+  ASSERT_EQ(0u, ub);
+  h.add(0);
+  h.get_position_micro(0, &lb, &ub);
+  ASSERT_EQ(0u, lb);
+  ASSERT_EQ(333333u, ub);
+  h.get_position_micro(1, &lb, &ub);
+  ASSERT_EQ(333333u, lb);
+  ASSERT_EQ(1000000u, ub);
+}
+
+TEST(Histogram, Position3) {
+  pow2_hist_t h;
+  h.h.resize(10, 0);
+  h.h[0] = 1;
+  h.h[5] = 1;
+  uint64_t lb, ub;
+  h.get_position_micro(4, &lb, &ub);
+  ASSERT_EQ(500000u, lb);
+  ASSERT_EQ(500000u, ub);
+}
+
+TEST(Histogram, Position4) {
   pow2_hist_t h;
   h.h.resize(10, 0);
   h.h[0] = UINT_MAX;
   h.h[5] = UINT_MAX;
   uint64_t lb, ub;
   h.get_position_micro(4, &lb, &ub);
-  ASSERT_EQ(500000u, lb);
-  ASSERT_EQ(500000u, ub);
+  ASSERT_EQ(0u, lb);
+  ASSERT_EQ(0u, ub);
 }
 
 TEST(Histogram, Decay) {

--- a/src/test/common/histogram.cc
+++ b/src/test/common/histogram.cc
@@ -93,15 +93,17 @@ TEST(Histogram, Position) {
     ASSERT_EQ(500000u, lb);
     ASSERT_EQ(500000u, ub);
   }
-  {
-    pow2_hist_t h;
-    h.h.resize(10, 0);
-    h.h[0] = UINT_MAX;
-    h.h[5] = UINT_MAX;
-    uint64_t lb, ub;
-    ASSERT_EQ(500000u, lb);
-    ASSERT_EQ(500000u, ub);
-  }
+}
+
+TEST(Histogram, Position2) {
+  pow2_hist_t h;
+  h.h.resize(10, 0);
+  h.h[0] = UINT_MAX;
+  h.h[5] = UINT_MAX;
+  uint64_t lb, ub;
+  h.get_position_micro(4, &lb, &ub);
+  ASSERT_EQ(500000u, lb);
+  ASSERT_EQ(500000u, ub);
 }
 
 TEST(Histogram, Decay) {

--- a/src/test/mon/mkfs.sh
+++ b/src/test/mon/mkfs.sh
@@ -66,8 +66,9 @@ function mon_run() {
 
 function kill_daemons() {
     for pidfile in $(find $DIR -name pidfile) ; do
+        pid=$(cat $pidfile)
         for try in 0 1 1 1 2 3 ; do
-            kill $(cat $pidfile) || break
+            kill $pid || break
             sleep $try
         done
     done

--- a/src/test/mon/mon-test-helpers.sh
+++ b/src/test/mon/mon-test-helpers.sh
@@ -59,8 +59,9 @@ function run_mon() {
 function kill_daemons() {
     local dir=$1
     for pidfile in $(find $dir | grep pidfile) ; do
+        pid=$(cat $pidfile)
         for try in 0 1 1 1 2 3 ; do
-            kill -9 $(cat $pidfile 2> /dev/null) 2> /dev/null || break
+            kill -9 $pid 2> /dev/null || break
             sleep $try
         done
     done


### PR DESCRIPTION
Use . instead of tab in echo to avoid variations in how escape sequences
are interpreted by the shell.

http://tracker.ceph.com/issues/10281 Fixes: #10281

Signed-off-by: Loic Dachary <ldachary@redhat.com>