### PR TITLE
osd: PG:: fix, update info_struct_v when _wirte_info

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2602,7 +2602,7 @@ int PG::_write_info(ObjectStore::Transaction& t, epoch_t epoch,
     map<epoch_t,pg_interval_t> &past_intervals,
     interval_set<snapid_t> &snap_collections,
     hobject_t &infos_oid,
-    __u8 info_struct_v, bool dirty_big_info, bool force_ver)
+    __u8 &info_struct_v, bool dirty_big_info, bool force_ver)
 {
   // pg state
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2096,7 +2096,7 @@ public:
     map<epoch_t,pg_interval_t> &past_intervals,
     interval_set<snapid_t> &snap_collections,
     hobject_t &infos_oid,
-    __u8 info_struct_v, bool dirty_big_info, bool force_ver = false);
+    __u8 &info_struct_v, bool dirty_big_info, bool force_ver = false);
   void write_if_dirty(ObjectStore::Transaction& t);
 
   eversion_t get_next_version() const {


### PR DESCRIPTION
when _write_info, info_struct_v is passed by value, therefore, it just updates local value of info_struct_v. Since info_struct_v in pg is not updated and always be zero,  which will lead to unneccessary update for pg_biginfo before the next time osd daemon restarts.  Fix is passed info_struct_v by reference

Signed-off-by: Ning Yao zay11022@gmail.com
