### PR TITLE
os: IndexManager:: optimize map<coll_t, CollectionIndex* > col_indices to unordered_map

### DIFF
--- a/src/os/IndexManager.cc
+++ b/src/os/IndexManager.cc
@@ -13,7 +13,7 @@
  */
 
 #include "include/memory.h"
-#include <map>
+#include "include/unordered_map.h"
 
 #if defined(__FreeBSD__)
 #include <sys/param.h>
@@ -63,7 +63,7 @@ static int get_version(const char *path, uint32_t *version) {
 
 IndexManager::~IndexManager() {
 
-  for (map<coll_t, CollectionIndex* > ::iterator it = col_indices.begin(); 
+  for (ceph::unordered_map<coll_t, CollectionIndex* > ::iterator it = col_indices.begin(); 
        it != col_indices.end(); ++it) {
 
     delete it->second;
@@ -123,7 +123,7 @@ int IndexManager::build_index(coll_t c, const char *path, CollectionIndex **inde
 int IndexManager::get_index(coll_t c, const string& baseDir, Index *index) {
 
   Mutex::Locker l(lock);
-  map<coll_t, CollectionIndex* > ::iterator it = col_indices.find(c);
+  ceph::unordered_map<coll_t, CollectionIndex* > ::iterator it = col_indices.find(c);
   if (it == col_indices.end()) {
     char path[PATH_MAX];
     snprintf(path, sizeof(path), "%s/current/%s", baseDir.c_str(), c.to_str().c_str());

--- a/src/os/IndexManager.h
+++ b/src/os/IndexManager.h
@@ -15,7 +15,7 @@
 #define OS_INDEXMANAGER_H
 
 #include "include/memory.h"
-#include <map>
+#include "include/unordered_map.h"
 
 #include "common/Mutex.h"
 #include "common/Cond.h"
@@ -52,7 +52,7 @@ struct Index {
 class IndexManager {
   Mutex lock; ///< Lock for Index Manager
   bool upgrade;
-  map<coll_t, CollectionIndex* > col_indices;
+  ceph::unordered_map<coll_t, CollectionIndex* > col_indices;
 
   /**
    * Index factory


### PR DESCRIPTION
col_indices is just used to cache CollectionIndex, and use col_indices.find() to get its corresponding index. Without any using of up_bound() and low_bound(), we can use unordered_map to make it fast. Based on perf, when I chanage map to unordered_map, the cpu cost for get_index(coll_t c, const string& baseDir, Index *index) is much lower.

Signed-off-by: Ning Yao zay11022@gmail.com
