### PR TITLE
OSD: FileJournal: call writeq_cond.Signal if necessary in submit_entry

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -1456,8 +1456,9 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, int alignment,
     completions.push_back(
       completion_item(
 	seq, oncommit, ceph_clock_now(g_ceph_context), osd_op));
+    if (writeq.empty())
+      writeq_cond.Signal();
     writeq.push_back(write_item(seq, e, alignment, osd_op));
-    writeq_cond.Signal();
   }
 }
 


### PR DESCRIPTION
For now, every write op should call writeq_cond.Signal() in FileJournal::submit_entry.
We can call signal if neceesary.

Signed-off-by: Xinze Chi xmdxcxz@gmail.com
