### PR TITLE
os: WBThrottle: optimize the map to unordered_map

### DIFF
--- a/src/os/WBThrottle.cc
+++ b/src/os/WBThrottle.cc
@@ -145,7 +145,7 @@ bool WBThrottle::get_next_should_flush(
   assert(!pending_wbs.empty());
   ghobject_t obj(pop_object());
   
-  map<ghobject_t, pair<PendingWB, FDRef> >::iterator i =
+  ceph::unordered_map<ghobject_t, pair<PendingWB, FDRef> >::iterator i =
     pending_wbs.find(obj);
   *next = boost::make_tuple(obj, i->second.second, i->second.first);
   pending_wbs.erase(i);
@@ -189,7 +189,7 @@ void WBThrottle::queue_wb(
   bool nocache)
 {
   Mutex::Locker l(lock);
-  map<ghobject_t, pair<PendingWB, FDRef> >::iterator wbiter =
+  ceph::unordered_map<ghobject_t, pair<PendingWB, FDRef> >::iterator wbiter =
     pending_wbs.find(hoid);
   if (wbiter == pending_wbs.end()) {
     wbiter = pending_wbs.insert(
@@ -215,7 +215,7 @@ void WBThrottle::queue_wb(
 void WBThrottle::clear()
 {
   Mutex::Locker l(lock);
-  for (map<ghobject_t, pair<PendingWB, FDRef> >::iterator i =
+  for (ceph::unordered_map<ghobject_t, pair<PendingWB, FDRef> >::iterator i =
 	 pending_wbs.begin();
        i != pending_wbs.end();
        ++i) {
@@ -236,7 +236,7 @@ void WBThrottle::clear_object(const ghobject_t &hoid)
   Mutex::Locker l(lock);
   while (clearing == hoid)
     cond.Wait(lock);
-  map<ghobject_t, pair<PendingWB, FDRef> >::iterator i =
+  ceph::unordered_map<ghobject_t, pair<PendingWB, FDRef> >::iterator i =
     pending_wbs.find(hoid);
   if (i == pending_wbs.end())
     return;

--- a/src/os/WBThrottle.h
+++ b/src/os/WBThrottle.h
@@ -15,7 +15,7 @@
 #ifndef WBTHROTTLE_H
 #define WBTHROTTLE_H
 
-#include <map>
+#include "include/unordered_map.h"
 #include <boost/tuple/tuple.hpp>
 #include "include/memory.h"
 #include "include/buffer.h"
@@ -45,7 +45,6 @@ enum {
  */
 class WBThrottle : Thread, public md_config_obs_t {
   ghobject_t clearing;
-
   /* *_limits.first is the start_flusher limit and
    * *_limits.second is the hard limit
    */
@@ -90,10 +89,10 @@ class WBThrottle : Thread, public md_config_obs_t {
    * Flush objects in lru order
    */
   list<ghobject_t> lru;
-  map<ghobject_t, list<ghobject_t>::iterator> rev_lru;
+  ceph::unordered_map<ghobject_t, list<ghobject_t>::iterator> rev_lru;
   void remove_object(const ghobject_t &oid) {
     assert(lock.is_locked());
-    map<ghobject_t, list<ghobject_t>::iterator>::iterator iter =
+    ceph::unordered_map<ghobject_t, list<ghobject_t>::iterator>::iterator iter =
       rev_lru.find(oid);
     if (iter == rev_lru.end())
       return;
@@ -114,7 +113,7 @@ class WBThrottle : Thread, public md_config_obs_t {
     rev_lru.insert(make_pair(oid, --lru.end()));
   }
 
-  map<ghobject_t, pair<PendingWB, FDRef> > pending_wbs;
+  ceph::unordered_map<ghobject_t, pair<PendingWB, FDRef> > pending_wbs;
 
   /// get next flush to perform
   bool get_next_should_flush(


### PR DESCRIPTION
Using unordered_map to save the cpu cost and acceralate map::find() operation. Also, do not call Signal() at all time when we queue_wb(), just call Signal when it really cond.wait() on lock. When use SSD as Journal, backend dirty_io is always greater than the writeback limitation we set, therefore, the thread will be always working and no need to Signal(). So it would be meaningful

Signed-off-by: Ning Yao <zay11022@gmail.com>