### PR TITLE
jemalloc-support: Added --with-jemalloc configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -403,6 +403,30 @@ AS_IF([test "x$with_tcmalloc" != xno],
 		  [no tcmalloc found (use --without-tcmalloc to disable)])])])
 AM_CONDITIONAL(WITH_TCMALLOC, [test "$HAVE_LIBTCMALLOC" = "1"])
 
+# jemalloc?
+AC_ARG_WITH([jemalloc],
+	    [AS_HELP_STRING([--with-jemalloc], [enable jemalloc for memory allocations])],
+	    [],
+	    [with_jemalloc=no])
+JEMALLOC=
+AS_IF([test "x$with_jemalloc" = xyes],
+	    [AC_CHECK_LIB([jemalloc], [malloc],
+	     [AC_SUBST([LIBJEMALLOC], ["-ljemalloc"])
+	       AC_DEFINE([HAVE_LIBJEMALLOC], [1],
+                         [Define if you have jemalloc])
+	       HAVE_LIBJEMALLOC=1
+	     ],
+	    [AC_MSG_FAILURE(
+		  [no jemalloc found (do not use --with-jemalloc)])])])
+AM_CONDITIONAL(WITH_JEMALLOC, [test "$HAVE_LIBJEMALLOC" = "1"])
+
+# error out if --with-jemalloc and ! --without-tcmalloc
+if test "x$with_jemalloc" = "xyes"; then
+	if test "x$with_tcmalloc" != "xno"; then
+		AC_MSG_FAILURE([--with-jemalloc called without --without-tcmalloc])
+	fi
+fi
+
 #set pg ref debugging?
 AC_ARG_ENABLE([pgrefdebugging],
 	    [AS_HELP_STRING([--enable-pgrefdebugging], [enable pg ref debugging])],
@@ -595,6 +619,14 @@ AS_IF([test "x$with_librocksdb_static" = "xyes"],
             [AC_DEFINE([HAVE_LIBROCKSDB], [1], [Defined if you have librocksdb enabled])])
 AM_CONDITIONAL(WITH_SLIBROCKSDB, [ test "x$with_librocksdb_static" = "xyes" ])
 AM_CONDITIONAL(WITH_LIBROCKSDB, [ test "x$with_librocksdb_static" = "xyes" -o "x$with_librocksdb" = "xyes" ])
+
+# error out if --with-jemalloc and --with-librocksdb_static as rocksdb uses tcmalloc
+if test "x$with_jemalloc" = "xyes"; then
+	if test "x$with_librocksdb_static" != "xno"; then
+		AC_MSG_FAILURE([--with-jemalloc called with --with-librocksdb_static, turn off
+			        --with-librocksdb-static or --with-jemalloc])
+	fi
+fi
 
 # use system libs3?
 AC_ARG_WITH([system-libs3],

--- a/do_autogen.sh
+++ b/do_autogen.sh
@@ -18,6 +18,7 @@ do_autogen.sh: make a ceph build by running autogen, etc.
 -c                               use cryptopp
 -j                               with java
 -r                               with rocksdb
+-J				 --with-jemalloc
 
 EOF
 }
@@ -31,7 +32,7 @@ debug_level=0
 verbose=0
 profile=0
 CONFIGURE_FLAGS="--disable-static"
-while getopts  "d:e:hHrTPjpcvO:" flag
+while getopts  "d:e:hHrTPJjpcvO:" flag
 do
     case $flag in
     d) debug_level=$OPTARG;;
@@ -55,6 +56,8 @@ do
     v) verbose=1;;
 
     e) encode_dump=$OPTARG;;
+
+    J) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-jemalloc";;
 
     *)
         echo

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -177,6 +177,13 @@ if WITH_TCMALLOC
 LIBPERFGLUE += -ltcmalloc
 endif # WITH_TCMALLOC
 
+if WITH_JEMALLOC
+LIBMON += -ljemalloc
+LIBOSD += -ljemalloc
+LIBMDS += -ljemalloc
+LIBRGW += -ljemalloc
+endif # WITH_JEMALLOC
+
 if ENABLE_COVERAGE
 EXTRALIBS += -lgcov
 endif # ENABLE_COVERAGE


### PR DESCRIPTION
If --with-jemalloc option is not specified, then it defaults to tcmalloc.

If --with-jemalloc is specified, then --without-tcmalloc is required.
Also if a rocksdb static linking is desired --with-librocksdb-static,
do not use --with-jemalloc, as rocksdb uses tcmalloc for builds.

Support for jemalloc in package build and perf stats/heap profiler is
underway

Signed-off-by: shishir gowda shishir.gowda@sandisk.com
