### PR TITLE
librados test driver and librbd unit test

### DIFF
--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -17,12 +17,13 @@
 #define CEPH_CONTEXT_H
 
 #include "common/dout.h"
-#include "include/assert.h"
 
+#include <boost/function.hpp>
 #include <list>
 #include <set>
 
 #include <iostream>
+#include "include/assert.h"
 #include "include/memory.h"
 
 #define mydout(cct, v) lgeneric_subdout(cct, context, v)
@@ -448,6 +449,20 @@ private:
 
 typedef C_GatherBase<Context, Context> C_Gather;
 typedef C_GatherBuilderBase<Context, C_Gather > C_GatherBuilder;
+
+class FunctionContext : public Context {
+public:
+  FunctionContext(const boost::function<void()> &callback)
+    : m_callback(callback)
+  {
+  }
+
+  virtual void finish(int r) {
+    m_callback();
+  }
+private:
+  boost::function<void()> m_callback;
+};
 
 #undef mydout
 

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -33,21 +33,6 @@ enum {
   NOTIFY_OP_HEADER_UPDATE = 3
 };
 
-class FunctionContext : public Context {
-public:
-  FunctionContext(const boost::function<void()> &callback)
-    : m_callback(callback)
-  {
-  }
-
-  virtual void finish(int r) {
-    m_callback();
-  }
-private:
-  boost::function<void()> m_callback;
-};
-
-
 ImageWatcher::ImageWatcher(ImageCtx &image_ctx)
   : m_image_ctx(image_ctx), m_watch_ctx(*this), m_handle(0),
     m_lock_owner_state(LOCK_OWNER_STATE_NOT_LOCKED),

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -730,6 +730,23 @@ ceph_multi_stress_watch_SOURCES = test/multi_stress_watch.cc
 ceph_multi_stress_watch_LDADD = $(LIBRADOS) $(CEPH_GLOBAL) $(RADOS_TEST_LDADD)
 bin_DEBUGPROGRAMS += ceph_multi_stress_watch
 
+librados_test_stub_la_SOURCES = \
+	test/librados_test_stub/LibradosTestStub.cc \
+	test/librados_test_stub/TestClassHandler.cc \
+	test/librados_test_stub/TestIoCtxImpl.cc \
+	test/librados_test_stub/TestMemIoCtxImpl.cc \
+	test/librados_test_stub/TestMemRadosClient.cc \
+	test/librados_test_stub/TestRadosClient.cc \
+	test/librados_test_stub/TestWatchNotify.cc
+noinst_HEADERS += \
+	test/librados_test_stub/TestClassHandler.h \
+	test/librados_test_stub/TestRadosClient.h \
+	test/librados_test_stub/TestMemRadosClient.h \
+	test/librados_test_stub/TestWatchNotify.h \
+	test/librados_test_stub/TestMemIoCtxImpl.h \
+	test/librados_test_stub/TestIoCtxImpl.h
+noinst_LTLIBRARIES += librados_test_stub.la
+
 ceph_test_librbd_SOURCES = \
 	test/librbd/test_fixture.cc \
 	test/librbd/test_librbd.cc \

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -747,20 +747,37 @@ noinst_HEADERS += \
 	test/librados_test_stub/TestIoCtxImpl.h
 noinst_LTLIBRARIES += librados_test_stub.la
 
-ceph_test_librbd_SOURCES = \
+librbd_test_la_SOURCES = \
 	test/librbd/test_fixture.cc \
 	test/librbd/test_librbd.cc \
 	test/librbd/test_ImageWatcher.cc \
-	test/librbd/test_internal.cc
-ceph_test_librbd_LDADD = \
-	librbd_api.la librbd_internal.la \
+	test/librbd/test_internal.cc \
+	test/librbd/test_main.cc
+librbd_test_la_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+noinst_LTLIBRARIES += librbd_test.la
+
+unittest_librbd_SOURCES =
+nodist_EXTRA_unittest_librbd_SOURCES = dummy.cc
+unittest_librbd_LDADD = \
+	librbd_test.la librbd_api.la librbd_internal.la \
 	libcls_rbd_client.la libcls_lock_client.la \
+	librados_test_stub.la librados_internal.la \
+	$(LIBOSDC) $(UNITTEST_LDADD) \
+	$(CEPH_GLOBAL) $(RADOS_TEST_LDADD)
+check_PROGRAMS += unittest_librbd
+
+ceph_test_librbd_SOURCES =
+nodist_EXTRA_ceph_test_librbd_SOURCES = dummy.cc
+ceph_test_librbd_LDADD = \
+	librbd_test.la librbd_api.la librbd_internal.la \
+        libcls_rbd_client.la libcls_lock_client.la \
 	librados_api.la $(LIBRADOS_DEPS) $(UNITTEST_LDADD) \
 	$(CEPH_GLOBAL) $(RADOS_TEST_LDADD)
 ceph_test_librbd_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_librbd
 
 if WITH_LTTNG
+unittest_librbd_LDADD += $(LIBRBD_TP)
 ceph_test_librbd_LDADD += $(LIBRBD_TP)
 endif
 

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -1,0 +1,906 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "include/rados/librados.hpp"
+#include "common/ceph_argparse.h"
+#include "common/common_init.h"
+#include "common/config.h"
+#include "common/snap_types.h"
+#include "global/global_context.h"
+#include "librados/AioCompletionImpl.h"
+#include "test/librados_test_stub/TestClassHandler.h"
+#include "test/librados_test_stub/TestIoCtxImpl.h"
+#include "test/librados_test_stub/TestRadosClient.h"
+#include "test/librados_test_stub/TestMemRadosClient.h"
+#include "objclass/objclass.h"
+#include <boost/bind.hpp>
+#include <deque>
+#include <vector>
+
+static librados::TestClassHandler *get_class_handler() {
+  static librados::TestClassHandler *s_class_handler = NULL;
+  if (s_class_handler == NULL) {
+    s_class_handler = new librados::TestClassHandler();
+    s_class_handler->open_all_classes();
+  }
+  return s_class_handler;
+}
+
+static librados::TestRadosClient *get_rados_client() {
+  // TODO: use factory to allow tests to swap out impl
+  static librados::TestRadosClient *s_rados_client = NULL;
+  if (s_rados_client == NULL) {
+    CephInitParameters iparams(CEPH_ENTITY_TYPE_CLIENT);
+    CephContext *cct = common_preinit(iparams, CODE_ENVIRONMENT_LIBRARY, 0);
+    cct->_conf->parse_env();
+    cct->_conf->apply_changes(NULL);
+    g_ceph_context = cct;
+    s_rados_client = new librados::TestMemRadosClient(cct);
+    cct->put();
+  }
+  s_rados_client->get();
+  return s_rados_client;
+}
+
+static void do_out_buffer(bufferlist& outbl, char **outbuf, size_t *outbuflen) {
+  if (outbuf) {
+    if (outbl.length() > 0) {
+      *outbuf = (char *)malloc(outbl.length());
+      memcpy(*outbuf, outbl.c_str(), outbl.length());
+    } else {
+      *outbuf = NULL;
+    }
+  }
+  if (outbuflen) {
+    *outbuflen = outbl.length();
+  }
+}
+
+static void do_out_buffer(string& outbl, char **outbuf, size_t *outbuflen) {
+  if (outbuf) {
+    if (outbl.length() > 0) {
+      *outbuf = (char *)malloc(outbl.length());
+      memcpy(*outbuf, outbl.c_str(), outbl.length());
+    } else {
+      *outbuf = NULL;
+    }
+  }
+  if (outbuflen) {
+    *outbuflen = outbl.length();
+  }
+}
+
+extern "C" int rados_aio_create_completion(void *cb_arg,
+                                           rados_callback_t cb_complete,
+                                           rados_callback_t cb_safe,
+                                           rados_completion_t *pc)
+{
+  librados::AioCompletionImpl *c = new librados::AioCompletionImpl;
+  if (cb_complete) {
+    c->set_complete_callback(cb_arg, cb_complete);
+  }
+  if (cb_safe) {
+    c->set_safe_callback(cb_arg, cb_safe);
+  }
+  *pc = c;
+  return 0;
+}
+
+extern "C" int rados_aio_get_return_value(rados_completion_t c) {
+  return reinterpret_cast<librados::AioCompletionImpl*>(c)->get_return_value();
+}
+
+extern "C" rados_config_t rados_cct(rados_t cluster)
+{
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+  return reinterpret_cast<rados_config_t>(client->cct());
+}
+
+extern "C" int rados_conf_parse_env(rados_t cluster, const char *var) {
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+  md_config_t *conf = client->cct()->_conf;
+  std::vector<const char*> args;
+  env_to_vec(args, var);
+  int ret = conf->parse_argv(args);
+  if (ret == 0) {
+    conf->apply_changes(NULL);
+  }
+  return ret;
+}
+
+extern "C" int rados_conf_read_file(rados_t cluster, const char *path) {
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+  md_config_t *conf = client->cct()->_conf;
+  std::deque<std::string> parse_errors;
+  int ret = conf->parse_config_files(path, &parse_errors, NULL, 0);
+  if (ret == 0) {
+    conf->parse_env();
+    conf->apply_changes(NULL);
+    complain_about_parse_errors(client->cct(), &parse_errors);
+  } else if (ret == -EINVAL) {
+    // ignore missing client config
+    return 0;
+  }
+  return ret;
+}
+
+extern "C" int rados_connect(rados_t cluster) {
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+  return client->connect();
+}
+
+extern "C" int rados_create(rados_t *cluster, const char * const id) {
+  *cluster = get_rados_client();
+  return 0;
+}
+
+extern "C" int rados_ioctx_create(rados_t cluster, const char *pool_name,
+                                  rados_ioctx_t *ioctx) {
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+
+  int64_t pool_id = client->pool_lookup(pool_name);
+  if (pool_id < 0) {
+    return static_cast<int>(pool_id);
+  }
+
+  *ioctx = reinterpret_cast<rados_ioctx_t>(
+      client->create_ioctx(pool_id, pool_name));
+  return 0;
+}
+
+extern "C" int rados_ioctx_create2(rados_t cluster, int64_t pool_id,
+                                   rados_ioctx_t *ioctx)
+{
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+
+  std::list<std::pair<int64_t, std::string> > pools;
+  int r = client->pool_list(pools);
+  if (r < 0) {
+    return r;
+  }
+
+  for (std::list<std::pair<int64_t, std::string> >::iterator it =
+       pools.begin(); it != pools.end(); ++it) {
+    if (it->first == pool_id) {
+      *ioctx = reinterpret_cast<rados_ioctx_t>(
+	client->create_ioctx(pool_id, it->second));
+      return 0;
+    }
+  }
+  return -ENOENT;
+}
+
+extern "C" void rados_ioctx_destroy(rados_ioctx_t io) {
+  librados::TestIoCtxImpl *ctx =
+    reinterpret_cast<librados::TestIoCtxImpl*>(io);
+  ctx->put();
+}
+
+extern "C" int rados_mon_command(rados_t cluster, const char **cmd,
+                                 size_t cmdlen, const char *inbuf,
+                                 size_t inbuflen, char **outbuf,
+                                 size_t *outbuflen, char **outs,
+                                 size_t *outslen) {
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+
+  vector<string> cmdvec;
+  for (size_t i = 0; i < cmdlen; i++) {
+    cmdvec.push_back(cmd[i]);
+  }
+
+  bufferlist inbl;
+  inbl.append(inbuf, inbuflen);
+
+  bufferlist outbl;
+  string outstring;
+  int ret = client->mon_command(cmdvec, inbl, &outbl, &outstring);
+
+  do_out_buffer(outbl, outbuf, outbuflen);
+  do_out_buffer(outstring, outs, outslen);
+  return ret;
+}
+
+extern "C" int rados_pool_create(rados_t cluster, const char *pool_name) {
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+  return client->pool_create(pool_name);
+}
+
+extern "C" int rados_pool_delete(rados_t cluster, const char *pool_name) {
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+  return client->pool_delete(pool_name);
+}
+
+extern "C" void rados_shutdown(rados_t cluster) {
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+  client->put();
+}
+
+extern "C" int rados_wait_for_latest_osdmap(rados_t cluster) {
+  librados::TestRadosClient *client =
+    reinterpret_cast<librados::TestRadosClient*>(cluster);
+  return client->wait_for_latest_osdmap();
+}
+
+namespace librados {
+
+void AioCompletion::release() {
+  AioCompletionImpl *c = reinterpret_cast<AioCompletionImpl *>(pc);
+  c->release();
+  delete this;
+}
+
+IoCtx::IoCtx() : io_ctx_impl(NULL) {
+}
+
+IoCtx::~IoCtx() {
+  close();
+}
+
+int IoCtx::aio_flush() {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  ctx->aio_flush();
+  return 0;
+}
+
+int IoCtx::aio_flush_async(AioCompletion *c) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  ctx->aio_flush_async(c->pc);
+  return 0;
+}
+
+int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
+                       ObjectReadOperation *op, int flags,
+                       bufferlist *pbl) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
+  return ctx->aio_operate_read(oid, *ops, c->pc, flags, pbl);
+}
+
+int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
+                       ObjectWriteOperation *op) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
+  return ctx->aio_operate(oid, *ops, c->pc, NULL, 0);
+}
+
+int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
+                       ObjectWriteOperation *op, snap_t seq,
+                       std::vector<snap_t>& snaps) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
+
+  std::vector<snapid_t> snv;
+  snv.resize(snaps.size());
+  for (size_t i = 0; i < snaps.size(); ++i)
+    snv[i] = snaps[i];
+  SnapContext snapc(seq, snv);
+
+  return ctx->aio_operate(oid, *ops, c->pc, &snapc, 0);
+}
+
+int IoCtx::aio_remove(const std::string& oid, AioCompletion *c) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->aio_remove(oid, c->pc);
+}
+
+config_t IoCtx::cct() {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return reinterpret_cast<config_t>(ctx->get_rados_client()->cct());
+}
+
+void IoCtx::close() {
+  if (io_ctx_impl) {
+    TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+    ctx->put();
+  }
+  io_ctx_impl = NULL;
+}
+
+int IoCtx::create(const std::string& oid, bool exclusive) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->create(oid, exclusive);
+}
+
+void IoCtx::dup(const IoCtx& rhs) {
+  close();
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(rhs.io_ctx_impl);
+  io_ctx_impl = reinterpret_cast<IoCtxImpl*>(ctx->clone());
+}
+
+int IoCtx::exec(const std::string& oid, const char *cls, const char *method,
+                bufferlist& inbl, bufferlist& outbl) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->exec(oid, *get_class_handler(), cls, method, inbl, &outbl);
+}
+
+void IoCtx::from_rados_ioctx_t(rados_ioctx_t p, IoCtx &io) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(p);
+  ctx->get();
+
+  io.close();
+  io.io_ctx_impl = reinterpret_cast<IoCtxImpl*>(ctx);
+}
+
+int64_t IoCtx::get_id() {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->get_id();
+}
+
+uint64_t IoCtx::get_last_version() {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->get_last_version();
+}
+
+std::string IoCtx::get_pool_name() {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->get_pool_name();
+}
+
+int IoCtx::list_snaps(const std::string& o, snap_set_t *out_snaps) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->list_snaps(o, out_snaps);
+}
+
+int IoCtx::list_watchers(const std::string& o,
+                         std::list<obj_watch_t> *out_watchers) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->list_watchers(o, out_watchers);
+}
+
+int IoCtx::notify(const std::string& o, uint64_t ver, bufferlist& bl) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->notify(o, bl, 0, NULL);
+}
+
+int IoCtx::notify2(const std::string& o, bufferlist& bl,
+                   uint64_t timeout_ms, bufferlist *pbl) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->notify(o, bl, timeout_ms, pbl);
+}
+
+void IoCtx::notify_ack(const std::string& o, uint64_t notify_id,
+                       uint64_t handle, bufferlist& bl) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  ctx->notify_ack(o, notify_id, handle, bl);
+}
+
+int IoCtx::omap_get_vals(const std::string& oid,
+                         const std::string& start_after,
+                         uint64_t max_return,
+                         std::map<std::string, bufferlist> *out_vals) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->omap_get_vals(oid, start_after, "", max_return, out_vals);
+}
+
+int IoCtx::operate(const std::string& oid, ObjectWriteOperation *op) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
+  return ctx->operate(oid, *ops);
+}
+
+int IoCtx::operate(const std::string& oid, ObjectReadOperation *op,
+                   bufferlist *pbl) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
+  return ctx->operate_read(oid, *ops, pbl);
+}
+
+int IoCtx::read(const std::string& oid, bufferlist& bl, size_t len,
+                uint64_t off) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->read(oid, len, off, &bl);
+}
+
+int IoCtx::remove(const std::string& oid) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->remove(oid);
+}
+
+int IoCtx::selfmanaged_snap_create(uint64_t *snapid) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->selfmanaged_snap_create(snapid);
+}
+
+int IoCtx::selfmanaged_snap_remove(uint64_t snapid) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->selfmanaged_snap_remove(snapid);
+}
+
+int IoCtx::selfmanaged_snap_rollback(const std::string& oid,
+                                     uint64_t snapid) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->selfmanaged_snap_rollback(oid, snapid);
+}
+
+int IoCtx::selfmanaged_snap_set_write_ctx(snap_t seq,
+                                          std::vector<snap_t>& snaps) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->selfmanaged_snap_set_write_ctx(seq, snaps);
+}
+
+void IoCtx::snap_set_read(snap_t seq) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  ctx->set_snap_read(seq);
+}
+
+int IoCtx::stat(const std::string& oid, uint64_t *psize, time_t *pmtime) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->stat(oid, psize, pmtime);;
+}
+
+int IoCtx::tmap_update(const std::string& oid, bufferlist& cmdbl) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->tmap_update(oid, cmdbl);
+}
+
+int IoCtx::unwatch2(uint64_t handle) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->unwatch(handle);
+}
+
+int IoCtx::unwatch(const std::string& o, uint64_t handle) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->unwatch(handle);
+}
+
+int IoCtx::watch(const std::string& o, uint64_t ver, uint64_t *handle,
+                 librados::WatchCtx *wctx) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->watch(o, handle, wctx, NULL);
+}
+
+int IoCtx::watch2(const std::string& o, uint64_t *handle,
+                  librados::WatchCtx2 *wctx) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->watch(o, handle, NULL, wctx);
+}
+
+int IoCtx::write(const std::string& oid, bufferlist& bl, size_t len,
+                 uint64_t off) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->write(oid, bl, len, off);
+}
+
+static int save_operation_result(int result, int *pval) {
+  if (pval != NULL) {
+    *pval = result;
+  }
+  return result;
+}
+
+ObjectOperation::ObjectOperation() {
+  TestObjectOperationImpl *o = new TestObjectOperationImpl();
+  o->get();
+  impl = reinterpret_cast<ObjectOperationImpl*>(o);
+}
+
+ObjectOperation::~ObjectOperation() {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  if (o) {
+    o->put();
+    o = NULL;
+  }
+}
+
+void ObjectOperation::assert_exists() {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::assert_exists, _1, _2));
+}
+
+void ObjectOperation::exec(const char *cls, const char *method,
+                           bufferlist& inbl) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::exec, _1, _2,
+			       boost::ref(*get_class_handler()),
+			       cls, method, inbl, _3));
+}
+
+void ObjectOperation::set_op_flags2(int flags) {
+}
+
+size_t ObjectOperation::size() {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  return o->ops.size();
+}
+
+void ObjectReadOperation::read(size_t off, uint64_t len, bufferlist *pbl,
+                               int *prval) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+
+  ObjectOperationTestImpl op;
+  if (pbl != NULL) {
+    op = boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, pbl);
+  } else {
+    op = boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, _3);
+  }
+
+  if (prval != NULL) {
+    op = boost::bind(save_operation_result,
+                     boost::bind(op, _1, _2, _3), prval);
+  }
+  o->ops.push_back(op);
+}
+
+void ObjectReadOperation::sparse_read(uint64_t off, uint64_t len,
+                                      std::map<uint64_t,uint64_t> *m,
+                                      bufferlist *pbl, int *prval) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+
+  ObjectOperationTestImpl op;
+  if (pbl != NULL) {
+    op = boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, m, pbl);
+  } else {
+    op = boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, m, _3);
+  }
+
+  if (prval != NULL) {
+    op = boost::bind(save_operation_result,
+                     boost::bind(op, _1, _2, _3), prval);
+  }
+  o->ops.push_back(op);
+}
+
+void ObjectWriteOperation::create(bool exclusive) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::create, _1, _2, exclusive));
+}
+
+void ObjectWriteOperation::omap_set(const std::map<std::string, bufferlist> &map) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::omap_set, _1, _2, boost::ref(map)));
+}
+
+void ObjectWriteOperation::remove() {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::remove, _1, _2));
+}
+
+void ObjectWriteOperation::selfmanaged_snap_rollback(uint64_t snapid) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::selfmanaged_snap_rollback,
+			       _1, _2, snapid));
+}
+
+void ObjectWriteOperation::set_alloc_hint(uint64_t expected_object_size,
+                                          uint64_t expected_write_size) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::set_alloc_hint, _1, _2,
+			       expected_object_size, expected_write_size));
+}
+
+void ObjectWriteOperation::truncate(uint64_t off) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::truncate, _1, _2, off));
+}
+
+void ObjectWriteOperation::write(uint64_t off, const bufferlist& bl) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::write, _1, _2, bl, bl.length(),
+			       off));
+}
+
+void ObjectWriteOperation::write_full(const bufferlist& bl) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::write_full, _1, _2, bl));
+}
+
+void ObjectWriteOperation::zero(uint64_t off, uint64_t len) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::zero, _1, _2, off, len));
+}
+
+Rados::Rados() : client(NULL) {
+}
+
+Rados::Rados(IoCtx& ioctx) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(ioctx.io_ctx_impl);
+  TestRadosClient *impl = ctx->get_rados_client();
+  impl->get();
+
+  client = reinterpret_cast<RadosClient*>(impl);
+  assert(client != NULL);
+}
+
+Rados::~Rados() {
+  shutdown();
+}
+
+AioCompletion *Rados::aio_create_completion(void *cb_arg,
+                                            callback_t cb_complete,
+                                            callback_t cb_safe) {
+  AioCompletionImpl *c;
+  int r = rados_aio_create_completion(cb_arg, cb_complete, cb_safe,
+      reinterpret_cast<void**>(&c));
+  assert(r == 0);
+  return new AioCompletion(c);
+}
+
+int Rados::conf_parse_env(const char *env) const {
+  return rados_conf_parse_env(reinterpret_cast<rados_t>(client), env);
+}
+
+int Rados::conf_read_file(const char * const path) const {
+  return rados_conf_read_file(reinterpret_cast<rados_t>(client), path);
+}
+
+int Rados::connect() {
+  return rados_connect(reinterpret_cast<rados_t>(client));
+}
+
+uint64_t Rados::get_instance_id() {
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+  return impl->get_instance_id();
+}
+
+int Rados::init(const char * const id) {
+  return rados_create(reinterpret_cast<rados_t *>(&client), id);
+}
+
+int Rados::ioctx_create(const char *name, IoCtx &io) {
+  rados_ioctx_t p;
+  int ret = rados_ioctx_create(reinterpret_cast<rados_t>(client), name, &p);
+  if (ret) {
+    return ret;
+  }
+  io.io_ctx_impl = reinterpret_cast<IoCtxImpl*>(p);
+  return 0;
+}
+
+int Rados::ioctx_create2(int64_t pool_id, IoCtx &io)
+{
+  rados_ioctx_t p;
+  int ret = rados_ioctx_create2(reinterpret_cast<rados_t>(client), pool_id, &p);
+  if (ret) {
+    return ret;
+  }
+  io.io_ctx_impl = reinterpret_cast<IoCtxImpl*>(p);
+  return 0;
+}
+
+int Rados::mon_command(std::string cmd, const bufferlist& inbl,
+                       bufferlist *outbl, std::string *outs) {
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+
+  std::vector<std::string> cmds;
+  cmds.push_back(cmd);
+  return impl->mon_command(cmds, inbl, outbl, outs);
+}
+
+int Rados::pool_create(const char *name) {
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+  return impl->pool_create(name);
+}
+
+int Rados::pool_delete(const char *name) {
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+  return impl->pool_delete(name);
+}
+
+int Rados::pool_get_base_tier(int64_t pool, int64_t* base_tier) {
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+  return impl->pool_get_base_tier(pool, base_tier);
+}
+
+int Rados::pool_list(std::list<std::string>& v) {
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+  std::list<std::pair<int64_t, std::string> > pools;
+  int r = impl->pool_list(pools);
+  if (r < 0) {
+    return r;
+  }
+
+  v.clear();
+  for (std::list<std::pair<int64_t, std::string> >::iterator it = pools.begin();
+       it != pools.end(); ++it) {
+    v.push_back(it->second);
+  }
+  return 0;
+}
+
+int librados::Rados::pool_list2(std::list<std::pair<int64_t, std::string> >& v)
+{
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+  return impl->pool_list(v);
+}
+
+int64_t Rados::pool_lookup(const char *name) {
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+  return impl->pool_lookup(name);
+}
+
+int Rados::pool_reverse_lookup(int64_t id, std::string *name) {
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+  return impl->pool_reverse_lookup(id, name);
+}
+
+void Rados::shutdown() {
+  if (client == NULL) {
+    return;
+  }
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+  impl->put();
+  client = NULL;
+}
+
+int Rados::wait_for_latest_osdmap() {
+  TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
+  return impl->wait_for_latest_osdmap();
+}
+
+WatchCtx::~WatchCtx() {
+}
+
+WatchCtx2::~WatchCtx2() {
+}
+
+} // namespace librados
+
+int cls_cxx_create(cls_method_context_t hctx, bool exclusive) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  return ctx->io_ctx_impl->create(ctx->oid, exclusive);
+}
+
+int cls_get_request_origin(cls_method_context_t hctx, entity_inst_t *origin) {
+  //TODO
+  return 0;
+}
+
+int cls_cxx_getxattr(cls_method_context_t hctx, const char *name,
+                     bufferlist *outbl) {
+  std::map<string, bufferlist> attrs;
+  int r = cls_cxx_getxattrs(hctx, &attrs);
+  if (r < 0) {
+    return r;
+  }
+
+  std::map<string, bufferlist>::iterator it = attrs.find(name);
+  if (it == attrs.end()) {
+    return -ENODATA;
+  }
+  *outbl = it->second;
+  return 0;
+}
+
+int cls_cxx_getxattrs(cls_method_context_t hctx, std::map<string, bufferlist> *attrset) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  return ctx->io_ctx_impl->xattr_get(ctx->oid, attrset);
+}
+
+int cls_cxx_map_get_keys(cls_method_context_t hctx, const string &start_obj,
+                         uint64_t max_to_get, std::set<string> *keys) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+
+  keys->clear();
+  std::map<string, bufferlist> vals;
+  std::string last_key = start_obj;
+  do {
+    vals.clear();
+    int r = ctx->io_ctx_impl->omap_get_vals(ctx->oid, last_key, "", 1024,
+                                            &vals);
+    if (r < 0) {
+      return r;
+    }
+
+    for (std::map<string, bufferlist>::iterator it = vals.begin();
+        it != vals.end(); ++it) {
+      last_key = it->first;
+      keys->insert(last_key);
+    }
+  } while (!vals.empty());
+  return 0;
+}
+
+int cls_cxx_map_get_val(cls_method_context_t hctx, const string &key,
+                        bufferlist *outbl) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+
+  std::map<string, bufferlist> vals;
+  int r = ctx->io_ctx_impl->omap_get_vals(ctx->oid, "", key, 1024, &vals);
+  if (r < 0) {
+    return r;
+  }
+
+  std::map<string, bufferlist>::iterator it = vals.find(key);
+  if (it == vals.end()) {
+    return -ENOENT;
+  }
+
+  *outbl = it->second;
+  return 0;
+}
+
+int cls_cxx_map_get_vals(cls_method_context_t hctx, const string &start_obj,
+                         const string &filter_prefix, uint64_t max_to_get,
+                         std::map<string, bufferlist> *vals) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  return ctx->io_ctx_impl->omap_get_vals(ctx->oid, start_obj, filter_prefix,
+      max_to_get, vals);
+}
+
+int cls_cxx_map_remove_key(cls_method_context_t hctx, const string &key) {
+  std::set<std::string> keys;
+  keys.insert(key);
+
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  return ctx->io_ctx_impl->omap_rm_keys(ctx->oid, keys);
+}
+
+int cls_cxx_map_set_val(cls_method_context_t hctx, const string &key,
+                        bufferlist *inbl) {
+  std::map<std::string, bufferlist> m;
+  m[key] = *inbl;
+  return cls_cxx_map_set_vals(hctx, &m);
+}
+
+int cls_cxx_map_set_vals(cls_method_context_t hctx,
+                         const std::map<string, bufferlist> *map) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  return ctx->io_ctx_impl->omap_set(ctx->oid, *map);
+}
+
+int cls_cxx_read(cls_method_context_t hctx, int ofs, int len,
+                 bufferlist *outbl) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  return ctx->io_ctx_impl->read(ctx->oid, len, ofs, outbl);
+}
+
+int cls_cxx_setxattr(cls_method_context_t hctx, const char *name,
+                     bufferlist *inbl) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  return ctx->io_ctx_impl->xattr_set(ctx->oid, name, *inbl);
+}
+
+int cls_cxx_stat(cls_method_context_t hctx, uint64_t *size, time_t *mtime) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  return ctx->io_ctx_impl->stat(ctx->oid, size, mtime);
+}
+
+int cls_cxx_write(cls_method_context_t hctx, int ofs, int len,
+                  bufferlist *inbl) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  return ctx->io_ctx_impl->write(ctx->oid, *inbl, len, ofs);
+}
+
+int cls_cxx_write_full(cls_method_context_t hctx, bufferlist *inbl) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  return ctx->io_ctx_impl->write_full(ctx->oid, *inbl);
+}
+
+int cls_log(int level, const char *format, ...) {
+  return 0;
+}
+
+int cls_register(const char *name, cls_handle_t *handle) {
+  librados::TestClassHandler *cls = get_class_handler();
+  return cls->create(name, handle);
+}
+
+int cls_register_cxx_method(cls_handle_t hclass, const char *method,
+    int flags,
+    cls_method_cxx_call_t class_call,
+    cls_method_handle_t *handle) {
+  librados::TestClassHandler *cls = get_class_handler();
+  return cls->create_method(hclass, method, class_call, handle);
+}

--- a/src/test/librados_test_stub/TestClassHandler.cc
+++ b/src/test/librados_test_stub/TestClassHandler.cc
@@ -1,0 +1,110 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librados_test_stub/TestClassHandler.h"
+#include <boost/algorithm/string/predicate.hpp>
+#include <dlfcn.h>
+#include <errno.h>
+
+namespace librados {
+
+TestClassHandler::TestClassHandler() {
+}
+
+TestClassHandler::~TestClassHandler() {
+  for (ClassHandles::iterator it = m_class_handles.begin();
+      it != m_class_handles.end(); ++it) {
+    dlclose(*it);
+  }
+}
+
+void TestClassHandler::open_class(const std::string& name,
+                                  const std::string& path) {
+  void *handle = dlopen(path.c_str(), RTLD_NOW);
+  if (handle == NULL) {
+    std::cerr << "Failed to load class: " << dlerror() << std::endl;
+    return;
+  }
+  m_class_handles.push_back(handle);
+
+  // initialize
+  void (*cls_init)() = reinterpret_cast<void (*)()>(
+      dlsym(handle, "__cls_init"));
+  if (cls_init) {
+    cls_init();
+  }
+}
+
+void TestClassHandler::open_all_classes() {
+  assert(m_class_handles.empty());
+
+  DIR *dir = ::opendir(".libs");
+  if (dir == NULL) {
+    assert(false);;
+  }
+
+  char buf[offsetof(struct dirent, d_name) + PATH_MAX + 1];
+  struct dirent *pde;
+  int r = 0;
+  while ((r = ::readdir_r(dir, (dirent *)&buf, &pde)) == 0 && pde) {
+    std::string name(pde->d_name);
+    if (!boost::algorithm::starts_with(name, "libcls_") ||
+        !boost::algorithm::ends_with(name, ".so")) {
+      continue;
+    }
+    std::string class_name = name.substr(7, name.size() - 10);
+    open_class(class_name, ".libs/" + name);
+  }
+  closedir(dir);
+}
+
+int TestClassHandler::create(const std::string &name, cls_handle_t *handle) {
+  if (m_classes.find(name) != m_classes.end()) {
+    return -EEXIST;
+  }
+
+  SharedClass cls(new Class());
+  m_classes[name] = cls;
+  *handle = reinterpret_cast<cls_handle_t>(cls.get());
+  return 0;
+}
+
+int TestClassHandler::create_method(cls_handle_t hclass,
+                                    const char *name,
+                                    cls_method_cxx_call_t class_call,
+                                    cls_method_handle_t *handle) {
+  Class *cls = reinterpret_cast<Class*>(hclass);
+  if (cls->methods.find(name) != cls->methods.end()) {
+    return -EEXIST;
+  }
+
+  SharedMethod method(new Method());
+  method->class_call = class_call;
+  cls->methods[name] = method;
+  return 0;
+}
+
+cls_method_cxx_call_t TestClassHandler::get_method(const std::string &cls,
+                                                   const std::string &method) {
+  Classes::iterator c_it = m_classes.find(cls);
+  if (c_it == m_classes.end()) {
+    return NULL;
+  }
+
+  SharedClass scls = c_it->second;
+  Methods::iterator m_it = scls->methods.find(method);
+  if (m_it == scls->methods.end()) {
+    return NULL;
+  }
+  return m_it->second->class_call;
+}
+
+TestClassHandler::SharedMethodContext TestClassHandler::get_method_context(
+    TestIoCtxImpl *io_ctx_impl, const std::string &oid) {
+  SharedMethodContext ctx(new MethodContext());
+  ctx->io_ctx_impl = io_ctx_impl;
+  ctx->oid = oid;
+  return ctx;
+}
+
+} // namespace librados

--- a/src/test/librados_test_stub/TestClassHandler.h
+++ b/src/test/librados_test_stub/TestClassHandler.h
@@ -1,0 +1,66 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_CLASS_HANDLER_H
+#define CEPH_TEST_CLASS_HANDLER_H
+
+#include "objclass/objclass.h"
+#include <boost/shared_ptr.hpp>
+#include <list>
+#include <map>
+#include <string>
+
+namespace librados
+{
+
+class TestIoCtxImpl;
+
+class TestClassHandler {
+public:
+
+  TestClassHandler();
+  ~TestClassHandler();
+
+  struct MethodContext {
+    TestIoCtxImpl *io_ctx_impl;
+    std::string oid;
+  };
+  typedef boost::shared_ptr<MethodContext> SharedMethodContext;
+
+  struct Method {
+    cls_method_cxx_call_t class_call;
+  };
+  typedef boost::shared_ptr<Method> SharedMethod;
+  typedef std::map<std::string, SharedMethod> Methods;
+
+  struct Class {
+    Methods methods;
+  };
+  typedef boost::shared_ptr<Class> SharedClass;
+
+  void open_all_classes();
+
+  int create(const std::string &name, cls_handle_t *handle);
+  int create_method(cls_handle_t hclass, const char *method,
+                    cls_method_cxx_call_t class_call,
+                    cls_method_handle_t *handle);
+  cls_method_cxx_call_t get_method(const std::string &cls,
+                                   const std::string &method);
+  SharedMethodContext get_method_context(TestIoCtxImpl *io_ctx_impl,
+                                         const std::string &oid);
+
+private:
+
+  typedef std::map<std::string, SharedClass> Classes;
+  typedef std::list<void*> ClassHandles;
+
+  Classes m_classes;
+  ClassHandles m_class_handles;
+
+  void open_class(const std::string& name, const std::string& path);
+
+};
+
+} // namespace librados
+
+#endif // CEPH_TEST_CLASS_HANDLER_H

--- a/src/test/librados_test_stub/TestIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestIoCtxImpl.cc
@@ -1,0 +1,250 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librados_test_stub/TestIoCtxImpl.h"
+#include "test/librados_test_stub/TestClassHandler.h"
+#include "test/librados_test_stub/TestRadosClient.h"
+#include "test/librados_test_stub/TestWatchNotify.h"
+#include "librados/AioCompletionImpl.h"
+#include "include/assert.h"
+#include "objclass/objclass.h"
+#include <boost/bind.hpp>
+#include <errno.h>
+
+namespace librados {
+
+TestIoCtxImpl::TestIoCtxImpl() : m_client(NULL) {
+  get();
+}
+
+TestIoCtxImpl::TestIoCtxImpl(TestRadosClient &client, int64_t pool_id,
+                             const std::string& pool_name)
+  : m_client(&client), m_pool_id(pool_id), m_pool_name(pool_name),
+    m_snap_seq(CEPH_NOSNAP)
+{
+  m_client->get();
+  get();
+}
+
+TestIoCtxImpl::TestIoCtxImpl(const TestIoCtxImpl& rhs)
+  : m_client(rhs.m_client),
+    m_pool_id(rhs.m_pool_id),
+    m_pool_name(rhs.m_pool_name),
+    m_snap_seq(rhs.m_snap_seq)
+{
+  m_client->get();
+  get();
+}
+
+TestIoCtxImpl::~TestIoCtxImpl() {
+}
+
+void TestObjectOperationImpl::get() {
+  m_refcount.inc();
+}
+
+void TestObjectOperationImpl::put() {
+  if (m_refcount.dec() == 0) {
+    delete this;
+  }
+}
+
+void TestIoCtxImpl::get() {
+  m_refcount.inc();
+}
+
+void TestIoCtxImpl::put() {
+  if (m_refcount.dec() == 0) {
+    m_client->put();
+    delete this;
+  }
+}
+
+int64_t TestIoCtxImpl::get_id() {
+  return m_pool_id;
+}
+
+uint64_t TestIoCtxImpl::get_last_version() {
+  return 0;
+}
+
+std::string TestIoCtxImpl::get_pool_name() {
+  return m_pool_name;
+}
+
+int TestIoCtxImpl::aio_flush() {
+  m_client->flush_aio_operations();
+  return 0;
+}
+
+void TestIoCtxImpl::aio_flush_async(AioCompletionImpl *c) {
+  m_client->flush_aio_operations(c);
+}
+
+int TestIoCtxImpl::aio_operate(const std::string& oid, TestObjectOperationImpl &ops,
+                               AioCompletionImpl *c, SnapContext *snap_context,
+                               int flags) {
+  // TODO ignoring snap_context and flags for now
+  ops.get();
+  m_client->add_aio_operation(oid, boost::bind(
+    &TestIoCtxImpl::execute_aio_operations, this, oid, &ops,
+    reinterpret_cast<bufferlist*>(NULL)), c);
+  return 0;
+}
+
+int TestIoCtxImpl::aio_operate_read(const std::string& oid,
+                                    TestObjectOperationImpl &ops,
+                                    AioCompletionImpl *c, int flags,
+                                    bufferlist *pbl) {
+  // TODO ignoring flags for now
+  ops.get();
+  m_client->add_aio_operation(oid, boost::bind(
+    &TestIoCtxImpl::execute_aio_operations, this, oid, &ops, pbl), c);
+  return 0;
+}
+
+int TestIoCtxImpl::exec(const std::string& oid, TestClassHandler &handler,
+                        const char *cls, const char *method,
+                        bufferlist& inbl, bufferlist* outbl) {
+  cls_method_cxx_call_t call = handler.get_method(cls, method);
+  if (call == NULL) {
+    return -ENOSYS;
+  }
+
+  return (*call)(reinterpret_cast<cls_method_context_t>(
+    handler.get_method_context(this, oid).get()), &inbl, outbl);
+}
+
+int TestIoCtxImpl::list_watchers(const std::string& o,
+                                 std::list<obj_watch_t> *out_watchers) {
+  return m_client->get_watch_notify().list_watchers(o, out_watchers);
+}
+
+int TestIoCtxImpl::notify(const std::string& o, bufferlist& bl,
+                          uint64_t timeout_ms, bufferlist *pbl) {
+  return m_client->get_watch_notify().notify(o, bl, timeout_ms, pbl);
+}
+
+void TestIoCtxImpl::notify_ack(const std::string& o, uint64_t notify_id,
+                               uint64_t handle, bufferlist& bl) {
+  m_client->get_watch_notify().notify_ack(o, notify_id, handle,
+                                          m_client->get_instance_id(), bl);
+}
+
+int TestIoCtxImpl::operate(const std::string& oid, TestObjectOperationImpl &ops) {
+  AioCompletionImpl *comp = new AioCompletionImpl();
+  int ret = aio_operate(oid, ops, comp, NULL, 0);
+  if (ret == 0) {
+    comp->wait_for_safe();
+    ret = comp->get_return_value();
+  }
+  comp->put();
+  return ret;
+}
+
+int TestIoCtxImpl::operate_read(const std::string& oid, TestObjectOperationImpl &ops,
+                                bufferlist *pbl) {
+  AioCompletionImpl *comp = new AioCompletionImpl();
+  int ret = aio_operate_read(oid, ops, comp, 0, pbl);
+  if (ret == 0) {
+    comp->wait_for_complete();
+    ret = comp->get_return_value();
+  }
+  comp->put();
+  return ret;
+}
+
+int TestIoCtxImpl::selfmanaged_snap_set_write_ctx(snap_t seq,
+                                                  std::vector<snap_t>& snaps) {
+  std::vector<snapid_t> snap_ids(snaps.begin(), snaps.end());
+  m_snapc = SnapContext(seq, snap_ids);
+  return 0;
+}
+
+int TestIoCtxImpl::set_alloc_hint(const std::string& oid,
+                                  uint64_t expected_object_size,
+                                  uint64_t expected_write_size) {
+  return 0;
+}
+
+void TestIoCtxImpl::set_snap_read(snap_t seq) {
+  if (seq == 0) {
+    seq = CEPH_NOSNAP;
+  }
+  m_snap_seq = seq;
+}
+
+int TestIoCtxImpl::tmap_update(const std::string& oid, bufferlist& cmdbl) {
+  // TODO: protect against concurrent tmap updates
+  bufferlist tmap_header;
+  std::map<string,bufferlist> tmap;
+  uint64_t size = 0;
+  int r = stat(oid, &size, NULL);
+  if (r == -ENOENT) {
+    r = create(oid, false);
+  }
+  if (r < 0) {
+    return r;
+  }
+
+  if (size > 0) {
+    bufferlist inbl;
+    r = read(oid, size, 0, &inbl);
+    if (r < 0) {
+      return r;
+    }
+    bufferlist::iterator iter = inbl.begin();
+    ::decode(tmap_header, iter);
+    ::decode(tmap, iter);
+  }
+
+  __u8 c;
+  std::string key;
+  bufferlist value;
+  bufferlist::iterator iter = cmdbl.begin();
+  ::decode(c, iter);
+  ::decode(key, iter);
+
+  switch (c) {
+    case CEPH_OSD_TMAP_SET:
+      ::decode(value, iter);
+      tmap[key] = value;
+      break;
+    case CEPH_OSD_TMAP_RM:
+      tmap.erase(key);
+      break;
+    default:
+      return -EINVAL;
+  }
+
+  bufferlist out;
+  ::encode(tmap_header, out);
+  ::encode(tmap, out);
+  r = write_full(oid, out);
+  return r;
+}
+
+int TestIoCtxImpl::unwatch(uint64_t handle) {
+  return m_client->get_watch_notify().unwatch(handle);
+}
+
+int TestIoCtxImpl::watch(const std::string& o, uint64_t *handle,
+                         librados::WatchCtx *ctx, librados::WatchCtx2 *ctx2) {
+  return m_client->get_watch_notify().watch(o, handle, ctx, ctx2);
+}
+
+int TestIoCtxImpl::execute_aio_operations(const std::string& oid,
+                                          TestObjectOperationImpl *ops,
+                                          bufferlist *pbl) {
+  int ret = 0;
+  for (ObjectOperations::iterator it = ops->ops.begin(); it != ops->ops.end(); ++it) {
+    ret = (*it)(this, oid, pbl);
+    if (ret < 0) {
+      break;
+    }
+  }
+  ops->put();
+  return ret;
+}
+
+} // namespace librados

--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -1,0 +1,147 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_IO_CTX_IMPL_H
+#define CEPH_TEST_IO_CTX_IMPL_H
+
+#include "include/rados/librados.hpp"
+#include "include/atomic.h"
+#include "common/snap_types.h"
+#include <boost/function.hpp>
+#include <list>
+
+namespace librados {
+
+class TestClassHandler;
+class TestIoCtxImpl;
+class TestRadosClient;
+
+typedef boost::function<int(TestIoCtxImpl*,
+			    const std::string&,
+			    bufferlist *)> ObjectOperationTestImpl;
+typedef std::list<ObjectOperationTestImpl> ObjectOperations;
+
+struct TestObjectOperationImpl {
+public:
+  void get();
+  void put();
+
+  ObjectOperations ops;
+private:
+  atomic_t m_refcount;
+};
+
+class TestIoCtxImpl {
+public:
+
+  TestIoCtxImpl();
+  explicit TestIoCtxImpl(TestRadosClient &client, int64_t m_pool_id,
+                         const std::string& pool_name);
+
+  TestRadosClient *get_rados_client() {
+    return m_client;
+  }
+
+  void get();
+  void put();
+
+  virtual TestIoCtxImpl *clone() = 0;
+
+  virtual int64_t get_id();
+  virtual uint64_t get_last_version();
+  virtual std::string get_pool_name();
+  snap_t get_snap_read() const {
+    return m_snap_seq;
+  }
+
+  const SnapContext &get_snap_context() const {
+    return m_snapc;
+  }
+
+  virtual int aio_flush();
+  virtual void aio_flush_async(AioCompletionImpl *c);
+  virtual int aio_operate(const std::string& oid, TestObjectOperationImpl &ops,
+                          AioCompletionImpl *c, SnapContext *snap_context,
+                          int flags);
+  virtual int aio_operate_read(const std::string& oid, TestObjectOperationImpl &ops,
+                               AioCompletionImpl *c, int flags,
+                               bufferlist *pbl);
+  virtual int aio_remove(const std::string& oid, AioCompletionImpl *c) = 0;
+
+  virtual int assert_exists(const std::string &oid) = 0;
+
+  virtual int create(const std::string& oid, bool exclusive) = 0;
+  virtual int exec(const std::string& oid, TestClassHandler &handler,
+                   const char *cls, const char *method,
+                   bufferlist& inbl, bufferlist* outbl);
+  virtual int list_snaps(const std::string& o, snap_set_t *out_snaps) = 0;
+  virtual int list_watchers(const std::string& o,
+                            std::list<obj_watch_t> *out_watchers);
+  virtual int notify(const std::string& o, bufferlist& bl,
+                     uint64_t timeout_ms, bufferlist *pbl);
+  virtual void notify_ack(const std::string& o, uint64_t notify_id,
+                          uint64_t handle, bufferlist& bl);
+  virtual int omap_get_vals(const std::string& oid,
+                            const std::string& start_after,
+                            const std::string &filter_prefix,
+                            uint64_t max_return,
+                            std::map<std::string, bufferlist> *out_vals) = 0;
+  virtual int omap_rm_keys(const std::string& oid,
+                           const std::set<std::string>& keys) = 0;
+  virtual int omap_set(const std::string& oid,
+                       const std::map<std::string, bufferlist> &map) = 0;
+  virtual int operate(const std::string& oid, TestObjectOperationImpl &ops);
+  virtual int operate_read(const std::string& oid, TestObjectOperationImpl &ops,
+                           bufferlist *pbl);
+  virtual int read(const std::string& oid, size_t len, uint64_t off,
+                   bufferlist *bl) = 0;
+  virtual int remove(const std::string& oid) = 0;
+  virtual int selfmanaged_snap_create(uint64_t *snapid) = 0;
+  virtual int selfmanaged_snap_remove(uint64_t snapid) = 0;
+  virtual int selfmanaged_snap_rollback(const std::string& oid,
+                                        uint64_t snapid) = 0;
+  virtual int selfmanaged_snap_set_write_ctx(snap_t seq,
+                                             std::vector<snap_t>& snaps);
+  virtual int set_alloc_hint(const std::string& oid,
+                             uint64_t expected_object_size,
+                             uint64_t expected_write_size);
+  virtual void set_snap_read(snap_t seq);
+  virtual int sparse_read(const std::string& oid, uint64_t off, uint64_t len,
+                          std::map<uint64_t,uint64_t> *m,
+                          bufferlist *data_bl) = 0;
+  virtual int stat(const std::string& oid, uint64_t *psize, time_t *pmtime) = 0;
+  virtual int truncate(const std::string& oid, uint64_t size) = 0;
+  virtual int tmap_update(const std::string& oid, bufferlist& cmdbl);
+  virtual int unwatch(uint64_t handle);
+  virtual int watch(const std::string& o, uint64_t *handle,
+                    librados::WatchCtx *ctx, librados::WatchCtx2 *ctx2);
+  virtual int write(const std::string& oid, bufferlist& bl, size_t len,
+                    uint64_t off) = 0;
+  virtual int write_full(const std::string& oid, bufferlist& bl) = 0;
+  virtual int xattr_get(const std::string& oid,
+                        std::map<std::string, bufferlist>* attrset) = 0;
+  virtual int xattr_set(const std::string& oid, const std::string &name,
+                        bufferlist& bl) = 0;
+  virtual int zero(const std::string& oid, uint64_t off, uint64_t len) = 0;
+
+protected:
+  TestIoCtxImpl(const TestIoCtxImpl& rhs);
+  virtual ~TestIoCtxImpl();
+
+  int execute_aio_operations(const std::string& oid, TestObjectOperationImpl *ops,
+                             bufferlist *pbl);
+
+private:
+
+  TestRadosClient *m_client;
+  int64_t m_pool_id;
+  std::string m_pool_name;
+  snap_t m_snap_seq;
+  SnapContext m_snapc;
+  atomic_t m_refcount;
+
+};
+
+} // namespace librados
+
+#endif // CEPH_TEST_IO_CTX_IMPL_H

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -1,0 +1,600 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librados_test_stub/TestMemIoCtxImpl.h"
+#include "test/librados_test_stub/TestMemRadosClient.h"
+#include "common/Clock.h"
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind.hpp>
+#include <errno.h>
+
+static void to_vector(const interval_set<uint64_t> &set,
+                      std::vector<std::pair<uint64_t, uint64_t> > *vec) {
+  vec->clear();
+  for (interval_set<uint64_t>::const_iterator it = set.begin();
+      it != set.end(); ++it) {
+    vec->push_back(*it);
+  }
+}
+
+namespace librados {
+
+TestMemIoCtxImpl::TestMemIoCtxImpl() {
+}
+
+TestMemIoCtxImpl::TestMemIoCtxImpl(const TestMemIoCtxImpl& rhs)
+  : TestIoCtxImpl(rhs), m_client(rhs.m_client), m_pool(rhs.m_pool) {
+  }
+
+TestMemIoCtxImpl::TestMemIoCtxImpl(TestMemRadosClient &client, int64_t pool_id,
+                                   const std::string& pool_name,
+                                   TestMemRadosClient::Pool *pool)
+  : TestIoCtxImpl(client, pool_id, pool_name), m_client(&client), m_pool(pool) {
+  }
+
+TestIoCtxImpl *TestMemIoCtxImpl::clone() {
+  return new TestMemIoCtxImpl(*this);
+}
+
+int TestMemIoCtxImpl::aio_remove(const std::string& oid, AioCompletionImpl *c) {
+  m_client->add_aio_operation(oid, boost::bind(&TestMemIoCtxImpl::remove, this, oid),
+                              c);
+  return 0;
+}
+
+int TestMemIoCtxImpl::assert_exists(const std::string &oid) {
+  RWLock::RLocker l(m_pool->file_lock);
+  TestMemRadosClient::SharedFile file = get_file(oid, false);
+  if (file == NULL) {
+    return -ENOENT;
+  }
+  return 0;
+}
+
+int TestMemIoCtxImpl::create(const std::string& oid, bool exclusive) {
+  if (get_snap_read() != CEPH_NOSNAP) {
+    return -EROFS;
+  }
+
+  RWLock::WLocker l(m_pool->file_lock);
+  get_file(oid, true);
+  return 0;
+}
+
+int TestMemIoCtxImpl::list_snaps(const std::string& oid, snap_set_t *out_snaps) {
+  out_snaps->seq = 0;
+  out_snaps->clones.clear();
+
+  RWLock::RLocker l(m_pool->file_lock);
+  TestMemRadosClient::Files::iterator it = m_pool->files.find(oid);
+  if (it == m_pool->files.end()) {
+    return -ENOENT;
+  }
+
+  bool include_head = false;
+  TestMemRadosClient::FileSnapshots &file_snaps = it->second;
+  for (TestMemRadosClient::FileSnapshots::iterator s_it = file_snaps.begin();
+       s_it != file_snaps.end(); ++s_it) {
+    TestMemRadosClient::File &file = *s_it->get();
+
+    if (file_snaps.size() > 1) {
+      out_snaps->seq = file.snap_id;
+      TestMemRadosClient::FileSnapshots::iterator next_it(s_it);
+      ++next_it;
+      if (next_it == file_snaps.end()) {
+        include_head = true;
+        break;
+      }
+
+      ++out_snaps->seq;
+      if (!file.exists) {
+        continue;
+      }
+
+      // update the overlap with the next version's overlap metadata
+      TestMemRadosClient::File &next_file = *next_it->get();
+      interval_set<uint64_t> overlap;
+      if (next_file.exists) {
+        overlap = next_file.snap_overlap;
+      }
+
+      clone_info_t clone;
+      clone.cloneid = file.snap_id;
+      clone.snaps = file.snaps;
+      to_vector(overlap, &clone.overlap);
+      clone.size = file.data.length();
+      out_snaps->clones.push_back(clone);
+    }
+  }
+
+  if ((file_snaps.size() == 1 && file_snaps.back()->data.length() > 0) ||
+      include_head)
+  {
+    // Include the SNAP_HEAD
+    TestMemRadosClient::File &file = *file_snaps.back();
+    if (file.exists) {
+      RWLock::RLocker l2(file.lock);
+      if (out_snaps->seq == 0 && !include_head) {
+        out_snaps->seq = file.snap_id;
+      }
+      clone_info_t head_clone;
+      head_clone.cloneid = librados::SNAP_HEAD;
+      head_clone.size = file.data.length();
+      out_snaps->clones.push_back(head_clone);
+    }
+  }
+  return 0;
+
+}
+
+int TestMemIoCtxImpl::omap_get_vals(const std::string& oid,
+                                    const std::string& start_after,
+                                    const std::string &filter_prefix,
+                                    uint64_t max_return,
+                                    std::map<std::string, bufferlist> *out_vals) {
+  if (out_vals == NULL) {
+    return -EINVAL;
+  }
+
+  TestMemRadosClient::SharedFile file;
+  {
+    RWLock::RLocker l(m_pool->file_lock);
+    file = get_file(oid, false);
+    if (file == NULL) {
+      return -ENOENT;
+    }
+  }
+
+  out_vals->clear();
+
+  RWLock::RLocker l(file->lock);
+  TestMemRadosClient::FileOMaps::iterator o_it = m_pool->file_omaps.find(oid);
+  if (o_it == m_pool->file_omaps.end()) {
+    return 0;
+  }
+
+  TestMemRadosClient::OMap &omap = o_it->second;
+  TestMemRadosClient::OMap::iterator it = omap.begin();
+  if (!start_after.empty()) {
+    it = omap.upper_bound(start_after);
+  }
+
+  while (it != omap.end() && max_return > 0) {
+    if (filter_prefix.empty() ||
+        boost::algorithm::starts_with(it->first, filter_prefix)) {
+      (*out_vals)[it->first] = it->second;
+      --max_return;
+    }
+    ++it;
+  }
+  return 0;
+}
+
+int TestMemIoCtxImpl::omap_rm_keys(const std::string& oid,
+                                   const std::set<std::string>& keys) {
+  if (get_snap_read() != CEPH_NOSNAP) {
+    return -EROFS;
+  }
+
+  TestMemRadosClient::SharedFile file;
+  {
+    RWLock::WLocker l(m_pool->file_lock);
+    file = get_file(oid, true);
+    if (file == NULL) {
+      return -ENOENT;
+    }
+  }
+
+  RWLock::WLocker l(file->lock);
+  for (std::set<std::string>::iterator it = keys.begin();
+       it != keys.end(); ++it) {
+    m_pool->file_omaps[oid].erase(*it);
+  }
+  return 0;
+}
+
+int TestMemIoCtxImpl::omap_set(const std::string& oid,
+                               const std::map<std::string, bufferlist> &map) {
+  if (get_snap_read() != CEPH_NOSNAP) {
+    return -EROFS;
+  }
+
+  TestMemRadosClient::SharedFile file;
+  {
+    RWLock::WLocker l(m_pool->file_lock);
+    file = get_file(oid, true);
+    if (file == NULL) {
+      return -ENOENT;
+    }
+  }
+
+  RWLock::WLocker l(file->lock);
+  for (std::map<std::string, bufferlist>::const_iterator it = map.begin();
+      it != map.end(); ++it) {
+    bufferlist bl;
+    bl.append(it->second);
+    m_pool->file_omaps[oid][it->first] = bl;
+  }
+
+  return 0;
+}
+
+int TestMemIoCtxImpl::read(const std::string& oid, size_t len, uint64_t off,
+                           bufferlist *bl) {
+  TestMemRadosClient::SharedFile file;
+  {
+    RWLock::RLocker l(m_pool->file_lock);
+    file = get_file(oid, false);
+    if (file == NULL) {
+      return -ENOENT;
+    }
+  }
+
+  RWLock::RLocker l(file->lock);
+  if (len == 0) {
+    len = file->data.length();
+  }
+  len = clip_io(off, len, file->data.length());
+  if (bl != NULL && len > 0) {
+    bl->substr_of(file->data, off, len);
+  }
+  return 0;
+}
+
+int TestMemIoCtxImpl::remove(const std::string& oid) {
+  if (get_snap_read() != CEPH_NOSNAP) {
+    return -EROFS;
+  }
+
+  RWLock::WLocker l(m_pool->file_lock);
+  TestMemRadosClient::SharedFile file = get_file(oid, false);
+  if (file == NULL) {
+    return -ENOENT;
+  }
+  file = get_file(oid, true);
+
+  RWLock::WLocker l2(file->lock);
+  file->exists = false;
+
+  TestMemRadosClient::Files::iterator it = m_pool->files.find(oid);
+  assert(it != m_pool->files.end());
+  if (it->second.size() == 1) {
+    m_pool->files.erase(it);
+    m_pool->file_omaps.erase(oid);
+  }
+  return 0;
+}
+
+int TestMemIoCtxImpl::selfmanaged_snap_create(uint64_t *snapid) {
+  RWLock::WLocker l(m_pool->file_lock);
+  *snapid = ++m_pool->snap_id;
+  m_pool->snap_seqs.insert(*snapid);
+  return 0;
+}
+
+int TestMemIoCtxImpl::selfmanaged_snap_remove(uint64_t snapid) {
+  RWLock::WLocker l(m_pool->file_lock);
+  TestMemRadosClient::SnapSeqs::iterator it =
+    m_pool->snap_seqs.find(snapid);
+  if (it == m_pool->snap_seqs.end()) {
+    return -ENOENT;
+  }
+
+  // TODO clean up all file snapshots
+  m_pool->snap_seqs.erase(it);
+  return 0;
+}
+
+int TestMemIoCtxImpl::selfmanaged_snap_rollback(const std::string& oid,
+                                                uint64_t snapid) {
+  RWLock::WLocker l(m_pool->file_lock);
+
+  TestMemRadosClient::SharedFile file;
+  TestMemRadosClient::Files::iterator f_it = m_pool->files.find(oid);
+  if (f_it == m_pool->files.end()) {
+    return 0;
+  }
+
+  TestMemRadosClient::FileSnapshots &snaps = f_it->second;
+  file = snaps.back();
+
+  size_t versions = 0;
+  for (TestMemRadosClient::FileSnapshots::reverse_iterator it = snaps.rbegin();
+      it != snaps.rend(); ++it) {
+    TestMemRadosClient::SharedFile file = *it;
+    if (file->snap_id < get_snap_read()) {
+      if (versions == 0) {
+        // already at the snapshot version
+        return 0;
+      } else if (file->snap_id == CEPH_NOSNAP) {
+        if (versions == 1) {
+          // delete it current HEAD, next one is correct version
+          snaps.erase(it.base());
+        } else {
+          // overwrite contents of current HEAD
+          file = TestMemRadosClient::SharedFile (new TestMemRadosClient::File(**it));
+          file->snap_id = CEPH_NOSNAP;
+          *it = file;
+        }
+      } else {
+        // create new head version
+        file = TestMemRadosClient::SharedFile (new TestMemRadosClient::File(**it));
+        file->snap_id = m_pool->snap_id;
+        snaps.push_back(file);
+      }
+      return 0;
+    }
+    ++versions;
+  }
+  return 0;
+}
+
+int TestMemIoCtxImpl::sparse_read(const std::string& oid, uint64_t off,
+                                  uint64_t len,
+                                  std::map<uint64_t,uint64_t> *m,
+                                  bufferlist *data_bl) {
+  // TODO verify correctness
+  TestMemRadosClient::SharedFile file;
+  {
+    RWLock::RLocker l(m_pool->file_lock);
+    file = get_file(oid, false);
+    if (file == NULL) {
+      return -ENOENT;
+    }
+  }
+
+  RWLock::RLocker l(file->lock);
+  len = clip_io(off, len, file->data.length());
+  if (m != NULL) {
+    m->clear();
+    if (len > 0) {
+      (*m)[off] = len;
+    }
+  }
+  if (data_bl != NULL && len > 0) {
+    data_bl->substr_of(file->data, off, len);
+  }
+  return 0;
+}
+
+int TestMemIoCtxImpl::stat(const std::string& oid, uint64_t *psize,
+                           time_t *pmtime) {
+  TestMemRadosClient::SharedFile file;
+  {
+    RWLock::RLocker l(m_pool->file_lock);
+    file = get_file(oid, false);
+    if (file == NULL) {
+      return -ENOENT;
+    }
+  }
+
+  RWLock::RLocker l(file->lock);
+  if (psize != NULL) {
+    *psize = file->data.length();
+  }
+  if (pmtime != NULL) {
+    *pmtime = file->mtime;
+  }
+  return 0;
+}
+
+int TestMemIoCtxImpl::truncate(const std::string& oid, uint64_t size) {
+  if (get_snap_read() != CEPH_NOSNAP) {
+    return -EROFS;
+  }
+
+  TestMemRadosClient::SharedFile file;
+  {
+    RWLock::WLocker l(m_pool->file_lock);
+    file = get_file(oid, true);
+  }
+
+  RWLock::WLocker l(file->lock);
+  bufferlist bl(size);
+
+  interval_set<uint64_t> is;
+  if (file->data.length() > size) {
+    is.insert(size, file->data.length() - size);
+
+    bl.substr_of(file->data, 0, size);
+    file->data.swap(bl);
+  } else if (file->data.length() != size) {
+    if (size == 0) {
+      bl.clear();
+    } else {
+      is.insert(0, size);
+
+      bl.append_zero(size - file->data.length());
+      file->data.append(bl);
+    }
+  }
+  is.intersection_of(file->snap_overlap);
+  file->snap_overlap.subtract(is);
+  return 0;
+}
+
+int TestMemIoCtxImpl::write(const std::string& oid, bufferlist& bl, size_t len,
+                            uint64_t off) {
+  if (get_snap_read() != CEPH_NOSNAP) {
+    return -EROFS;
+  }
+
+  TestMemRadosClient::SharedFile file;
+  {
+    RWLock::WLocker l(m_pool->file_lock);
+    file = get_file(oid, true);
+  }
+
+  RWLock::WLocker l(file->lock);
+  if (len > 0) {
+    interval_set<uint64_t> is;
+    is.insert(off, len);
+    is.intersection_of(file->snap_overlap);
+    file->snap_overlap.subtract(is);
+  }
+
+  ensure_minimum_length(off + len, &file->data);
+  file->data.copy_in(off, len, bl);
+  return 0;
+}
+
+int TestMemIoCtxImpl::write_full(const std::string& oid, bufferlist& bl) {
+  if (get_snap_read() != CEPH_NOSNAP) {
+    return -EROFS;
+  }
+
+  TestMemRadosClient::SharedFile file;
+  {
+    RWLock::WLocker l(m_pool->file_lock);
+    file = get_file(oid, true);
+    if (file == NULL) {
+      return -ENOENT;
+    }
+  }
+
+  RWLock::WLocker l(file->lock);
+  if (bl.length() > 0) {
+    interval_set<uint64_t> is;
+    is.insert(0, bl.length());
+    is.intersection_of(file->snap_overlap);
+    file->snap_overlap.subtract(is);
+  }
+
+  file->data.clear();
+  file->data.append(bl);
+  return 0;
+}
+
+int TestMemIoCtxImpl::xattr_get(const std::string& oid,
+                                std::map<std::string, bufferlist>* attrset) {
+  TestMemRadosClient::SharedFile file;
+  RWLock::RLocker l(m_pool->file_lock);
+  TestMemRadosClient::FileXAttrs::iterator it = m_pool->file_xattrs.find(oid);
+  if (it == m_pool->file_xattrs.end()) {
+    return -ENODATA;
+  }
+  *attrset = it->second;
+  return 0;
+}
+
+int TestMemIoCtxImpl::xattr_set(const std::string& oid, const std::string &name,
+                                bufferlist& bl) {
+  RWLock::WLocker l(m_pool->file_lock);
+  m_pool->file_xattrs[oid][name] = bl;
+  return 0;
+}
+
+int TestMemIoCtxImpl::zero(const std::string& oid, uint64_t off, uint64_t len) {
+  bool truncate_redirect = false;
+  TestMemRadosClient::SharedFile file;
+  {
+    RWLock::WLocker l(m_pool->file_lock);
+    file = get_file(oid, false);
+    if (!file) {
+      return 0;
+    }
+    file = get_file(oid, true);
+
+    RWLock::RLocker l2(file->lock);
+    if (len > 0 && off + len >= file->data.length()) {
+      // Zero -> Truncate logic embedded in OSD
+      truncate_redirect = true;
+    }
+  }
+  if (truncate_redirect) {
+    return truncate(oid, off);
+  }
+
+  bufferlist bl;
+  bl.append_zero(len);
+  return write(oid, bl, len, off);
+}
+
+size_t TestMemIoCtxImpl::clip_io(size_t off, size_t len, size_t bl_len) {
+  if (off >= bl_len) {
+    len = 0;
+  } else if (off + len > bl_len) {
+    len = bl_len - off;
+  }
+  return len;
+}
+
+void TestMemIoCtxImpl::ensure_minimum_length(size_t len, bufferlist *bl) {
+  if (len > bl->length()) {
+    bufferptr ptr(buffer::create(len - bl->length()));
+    ptr.zero();
+    bl->append(ptr);
+  }
+}
+
+TestMemRadosClient::SharedFile TestMemIoCtxImpl::get_file(
+    const std::string &oid, bool write) {
+  assert(m_pool->file_lock.is_locked() || m_pool->file_lock.is_wlocked());
+  assert(!write || m_pool->file_lock.is_wlocked());
+
+  TestMemRadosClient::SharedFile file;
+  TestMemRadosClient::Files::iterator it = m_pool->files.find(oid);
+  if (it != m_pool->files.end()) {
+    file = it->second.back();
+  } else if (!write) {
+    return TestMemRadosClient::SharedFile();
+  }
+
+  if (write) {
+    const SnapContext &snapc = get_snap_context();
+    bool new_version = false;
+    if (!file || !file->exists) {
+      file = TestMemRadosClient::SharedFile(new TestMemRadosClient::File());
+      new_version = true;
+    } else {
+      if (!snapc.snaps.empty() && file->snap_id < snapc.seq) {
+        for (std::vector<snapid_t>::const_reverse_iterator seq_it =
+            snapc.snaps.rbegin();
+            seq_it != snapc.snaps.rend(); ++seq_it) {
+          if (*seq_it > file->snap_id && *seq_it <= snapc.seq) {
+            file->snaps.push_back(*seq_it);
+          }
+        }
+        file->snap_id = file->snaps.back();
+
+        uint64_t prev_size = file->data.length();
+        file = TestMemRadosClient::SharedFile(
+          new TestMemRadosClient::File(*file));
+        if (prev_size > 0) {
+          file->snap_overlap.insert(0, prev_size);
+        }
+        new_version = true;
+      }
+    }
+
+    if (new_version) {
+      file->snap_id = snapc.seq;
+      file->mtime = ceph_clock_now(m_client->cct()).sec();
+      m_pool->files[oid].push_back(file);
+    }
+    return file;
+  }
+
+  if (get_snap_read() == CEPH_NOSNAP) {
+    if (!file->exists) {
+      assert(it->second.size() > 1);
+      return TestMemRadosClient::SharedFile();
+    }
+    return file;
+  }
+
+  TestMemRadosClient::FileSnapshots &snaps = it->second;
+  for (TestMemRadosClient::FileSnapshots::reverse_iterator it = snaps.rbegin();
+      it != snaps.rend(); ++it) {
+    TestMemRadosClient::SharedFile file = *it;
+    if (file->snap_id < get_snap_read()) {
+      if (!file->exists) {
+        return TestMemRadosClient::SharedFile();
+      }
+      return file;
+    }
+  }
+  return TestMemRadosClient::SharedFile();
+}
+
+} // namespace librados

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.h
@@ -1,0 +1,71 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_MEM_IO_CTX_IMPL_H
+#define CEPH_TEST_MEM_IO_CTX_IMPL_H
+
+#include "test/librados_test_stub/TestIoCtxImpl.h"
+#include "test/librados_test_stub/TestMemRadosClient.h"
+
+namespace librados {
+
+class TestMemIoCtxImpl : public TestIoCtxImpl {
+public:
+  TestMemIoCtxImpl();
+  explicit TestMemIoCtxImpl(TestMemRadosClient &client, int64_t m_pool_id,
+                            const std::string& pool_name,
+                            TestMemRadosClient::Pool *pool);
+
+  virtual TestIoCtxImpl *clone();
+
+  virtual int aio_remove(const std::string& oid, AioCompletionImpl *c);
+
+  virtual int assert_exists(const std::string &oid);
+
+  virtual int create(const std::string& oid, bool exclusive);
+  virtual int list_snaps(const std::string& o, snap_set_t *out_snaps);
+  virtual int omap_get_vals(const std::string& oid,
+                            const std::string& start_after,
+                            const std::string &filter_prefix,
+                            uint64_t max_return,
+                            std::map<std::string, bufferlist> *out_vals);
+  virtual int omap_rm_keys(const std::string& oid,
+                           const std::set<std::string>& keys);
+  virtual int omap_set(const std::string& oid, const std::map<std::string,
+                       bufferlist> &map);
+  virtual int read(const std::string& oid, size_t len, uint64_t off,
+                   bufferlist *bl);
+  virtual int remove(const std::string& oid);
+  virtual int selfmanaged_snap_create(uint64_t *snapid);
+  virtual int selfmanaged_snap_remove(uint64_t snapid);
+  virtual int selfmanaged_snap_rollback(const std::string& oid,
+                                        uint64_t snapid);
+  virtual int sparse_read(const std::string& oid, uint64_t off, uint64_t len,
+                          std::map<uint64_t,uint64_t> *m, bufferlist *data_bl);
+  virtual int stat(const std::string& oid, uint64_t *psize, time_t *pmtime);
+  virtual int truncate(const std::string& oid, uint64_t size);
+  virtual int write(const std::string& oid, bufferlist& bl, size_t len,
+                    uint64_t off);
+  virtual int write_full(const std::string& oid, bufferlist& bl);
+  virtual int xattr_get(const std::string& oid,
+                        std::map<std::string, bufferlist>* attrset);
+  virtual int xattr_set(const std::string& oid, const std::string &name,
+                        bufferlist& bl);
+  virtual int zero(const std::string& oid, uint64_t off, uint64_t len);
+
+private:
+  TestMemIoCtxImpl(const TestMemIoCtxImpl&);
+
+  TestMemRadosClient *m_client;
+  TestMemRadosClient::Pool *m_pool;
+
+  size_t clip_io(size_t off, size_t len, size_t bl_len);
+  void ensure_minimum_length(size_t len, bufferlist *bl);
+
+  TestMemRadosClient::SharedFile get_file(const std::string &oid, bool write);
+
+};
+
+} // namespace librados
+
+#endif // CEPH_TEST_MEM_IO_CTX_IMPL_H

--- a/src/test/librados_test_stub/TestMemRadosClient.cc
+++ b/src/test/librados_test_stub/TestMemRadosClient.cc
@@ -1,0 +1,99 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librados_test_stub/TestMemRadosClient.h"
+#include "test/librados_test_stub/TestMemIoCtxImpl.h"
+#include <errno.h>
+
+namespace librados {
+
+TestMemRadosClient::TestMemRadosClient(CephContext *cct)
+  : TestRadosClient(cct), m_pool_id() {
+}
+
+TestMemRadosClient::~TestMemRadosClient() {
+  for (Pools::iterator iter = m_pools.begin(); iter != m_pools.end(); ++iter) {
+    delete iter->second;
+  }
+}
+
+TestMemRadosClient::File::File()
+  : snap_id(), exists(true), lock("TestMemRadosClient::File::lock")
+{
+}
+
+TestMemRadosClient::File::File(const File &rhs)
+  : data(rhs.data),
+    mtime(rhs.mtime),
+    snap_id(rhs.snap_id),
+    exists(rhs.exists),
+    lock("TestMemRadosClient::File::lock")
+{
+}
+
+TestMemRadosClient::Pool::Pool()
+  : pool_id(), snap_id(1), file_lock("TestMemRadosClient::Pool::file_lock")
+{
+}
+
+TestIoCtxImpl *TestMemRadosClient::create_ioctx(int64_t pool_id,
+						const std::string &pool_name) {
+  Pools::iterator iter = m_pools.find(pool_name);
+  assert(iter != m_pools.end());
+
+  return new TestMemIoCtxImpl(*this, pool_id, pool_name, iter->second);
+}
+
+int TestMemRadosClient::pool_create(const std::string &pool_name) {
+  if (m_pools.find(pool_name) != m_pools.end()) {
+    return -EEXIST;
+  }
+  Pool *pool = new Pool();
+  pool->pool_id = ++m_pool_id;
+  m_pools[pool_name] = pool;
+  return 0;
+}
+
+int TestMemRadosClient::pool_delete(const std::string &pool_name) {
+  Pools::iterator iter = m_pools.find(pool_name);
+  if (iter == m_pools.end()) {
+    return -ENOENT;
+  }
+  delete iter->second;
+  m_pools.erase(iter);
+  return 0;
+}
+
+int TestMemRadosClient::pool_get_base_tier(int64_t pool_id, int64_t* base_tier) {
+  // TODO
+  *base_tier = pool_id;
+  return 0;
+}
+
+int TestMemRadosClient::pool_list(std::list<std::pair<int64_t, std::string> >& v) {
+  v.clear();
+  for (Pools::iterator iter = m_pools.begin(); iter != m_pools.end(); ++iter) {
+    v.push_back(std::make_pair(iter->second->pool_id, iter->first));
+  }
+  return 0;
+}
+
+int64_t TestMemRadosClient::pool_lookup(const std::string &pool_name) {
+  Pools::iterator iter = m_pools.find(pool_name);
+  if (iter == m_pools.end()) {
+    return -ENOENT;
+  }
+  return iter->second->pool_id;
+}
+
+int TestMemRadosClient::pool_reverse_lookup(int64_t id, std::string *name) {
+  for (Pools::iterator iter = m_pools.begin(); iter != m_pools.end(); ++iter) {
+    if (iter->second->pool_id == id) {
+      *name = iter->first;
+      return 0;
+    }
+  }
+  return -ENOENT;
+}
+
+} // namespace librados

--- a/src/test/librados_test_stub/TestMemRadosClient.h
+++ b/src/test/librados_test_stub/TestMemRadosClient.h
@@ -1,0 +1,92 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_MEM_RADOS_CLIENT_H
+#define CEPH_TEST_MEM_RADOS_CLIENT_H
+
+#include "test/librados_test_stub/TestRadosClient.h"
+#include "include/atomic.h"
+#include "include/buffer.h"
+#include "include/interval_set.h"
+#include "common/RWLock.h"
+#include <boost/shared_ptr.hpp>
+#include <list>
+#include <map>
+#include <set>
+#include <string>
+
+namespace librados {
+
+class AioCompletionImpl;
+
+class TestMemRadosClient : public TestRadosClient {
+public:
+
+  typedef std::map<std::string, bufferlist> OMap;
+  typedef std::map<std::string, OMap> FileOMaps;
+  typedef std::map<std::string, bufferlist> FileTMaps;
+  typedef std::map<std::string, bufferlist> XAttrs;
+  typedef std::map<std::string, XAttrs> FileXAttrs;
+
+  struct File {
+    File();
+    File(const File &rhs);
+
+    bufferlist data;
+    time_t mtime;
+
+    uint64_t snap_id;
+    std::vector<uint64_t> snaps;
+    interval_set<uint64_t> snap_overlap;
+
+    bool exists;
+    RWLock lock;
+  };
+  typedef boost::shared_ptr<File> SharedFile;
+
+  typedef std::list<SharedFile> FileSnapshots;
+  typedef std::map<std::string, FileSnapshots> Files;
+
+  typedef std::set<uint64_t> SnapSeqs;
+  struct Pool {
+    Pool();
+
+    int64_t pool_id;
+
+    SnapSeqs snap_seqs;
+    uint64_t snap_id;
+
+    RWLock file_lock;
+    Files files;
+    FileOMaps file_omaps;
+    FileTMaps file_tmaps;
+    FileXAttrs file_xattrs;
+  };
+
+  TestMemRadosClient(CephContext *cct);
+
+  virtual TestIoCtxImpl *create_ioctx(int64_t pool_id,
+                                      const std::string &pool_name);
+
+  virtual int pool_create(const std::string &pool_name);
+  virtual int pool_delete(const std::string &pool_name);
+  virtual int pool_get_base_tier(int64_t pool_id, int64_t* base_tier);
+  virtual int pool_list(std::list<std::pair<int64_t, std::string> >& v);
+  virtual int64_t pool_lookup(const std::string &name);
+  virtual int pool_reverse_lookup(int64_t id, std::string *name);
+
+protected:
+  ~TestMemRadosClient();
+
+private:
+
+  typedef std::map<std::string, Pool*>		Pools;
+
+  Pools	m_pools;
+  int64_t m_pool_id;
+
+};
+
+} // namespace librados
+
+#endif // CEPH_TEST_MEM_RADOS_CLIENT_H

--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -1,0 +1,205 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librados_test_stub/TestRadosClient.h"
+#include "test/librados_test_stub/TestIoCtxImpl.h"
+#include "librados/AioCompletionImpl.h"
+#include "include/assert.h"
+#include "common/ceph_json.h"
+#include "common/Finisher.h"
+#include <boost/bind.hpp>
+#include <boost/thread.hpp>
+#include <errno.h>
+
+static int get_concurrency() {
+  int concurrency = 0;
+  char *env = getenv("LIBRADOS_CONCURRENCY");
+  if (env != NULL) {
+    concurrency = atoi(env);
+  }
+  if (concurrency == 0) {
+    concurrency = boost::thread::thread::hardware_concurrency();
+  }
+  if (concurrency == 0) {
+    concurrency = 1;
+  }
+  return concurrency;
+}
+
+namespace librados {
+
+static void finish_aio_completion(AioCompletionImpl *c, int r) {
+  c->lock.Lock();
+  c->ack = true;
+  c->safe = true;
+  c->rval = r;
+  c->lock.Unlock();
+
+  rados_callback_t cb_complete = c->callback_complete;
+  void *cb_complete_arg = c->callback_complete_arg;
+  if (cb_complete) {
+    cb_complete(c, cb_complete_arg);
+  }
+
+  rados_callback_t cb_safe = c->callback_safe;
+  void *cb_safe_arg = c->callback_safe_arg;
+  if (cb_safe) {
+    cb_safe(c, cb_safe_arg);
+  }
+
+  c->lock.Lock();
+  c->callback_complete = NULL;
+  c->callback_safe = NULL;
+  c->cond.Signal();
+  c->put_unlock();
+}
+
+class AioFunctionContext : public Context {
+public:
+  AioFunctionContext(const TestRadosClient::AioFunction &callback,
+                     AioCompletionImpl *c)
+    : m_callback(callback), m_comp(c)
+  {
+    if (m_comp != NULL) {
+      m_comp->get();
+    }
+  }
+
+  virtual void finish(int r) {
+    int ret = m_callback();
+    if (m_comp != NULL) {
+      finish_aio_completion(m_comp, ret);
+    }
+  }
+private:
+  TestRadosClient::AioFunction m_callback;
+  AioCompletionImpl *m_comp;
+};
+
+TestRadosClient::TestRadosClient(CephContext *cct)
+  : m_cct(cct->get()),
+    m_watch_notify(m_cct)
+{
+  get();
+
+  int concurrency = get_concurrency();
+  for (int i = 0; i < concurrency; ++i) {
+    m_finishers.push_back(new Finisher(m_cct));
+    m_finishers.back()->start();
+  }
+}
+
+TestRadosClient::~TestRadosClient() {
+  flush_aio_operations();
+
+  for (size_t i = 0; i < m_finishers.size(); ++i) {
+    m_finishers[i]->stop();
+    delete m_finishers[i];
+  }
+
+  m_cct->put();
+  m_cct = NULL;
+}
+
+void TestRadosClient::get() {
+  m_refcount.inc();
+}
+
+void TestRadosClient::put() {
+  if (m_refcount.dec() == 0) {
+    shutdown();
+    delete this;
+  }
+}
+
+CephContext *TestRadosClient::cct() {
+  return m_cct;
+}
+
+uint64_t TestRadosClient::get_instance_id() {
+  return 0;
+}
+
+int TestRadosClient::connect() {
+  return 0;
+}
+
+void TestRadosClient::shutdown() {
+}
+
+int TestRadosClient::wait_for_latest_osdmap() {
+  return 0;
+}
+
+int TestRadosClient::mon_command(const std::vector<std::string>& cmd,
+                                 const bufferlist &inbl,
+                                 bufferlist *outbl, std::string *outs) {
+  for (std::vector<std::string>::const_iterator it = cmd.begin();
+       it != cmd.end(); ++it) {
+    JSONParser parser;
+    if (!parser.parse(it->c_str(), it->length())) {
+      return -EINVAL;
+    }
+
+    JSONObjIter j_it = parser.find("prefix");
+    if (j_it.end()) {
+      return -EINVAL;
+    }
+
+    if ((*j_it)->get_data() == "osd tier add") {
+      return 0;
+    } else if ((*j_it)->get_data() == "osd tier cache-mode") {
+      return 0;
+    } else if ((*j_it)->get_data() == "osd tier set-overlay") {
+      return 0;
+    } else if ((*j_it)->get_data() == "osd tier remove-overlay") {
+      return 0;
+    } else if ((*j_it)->get_data() == "osd tier remove") {
+      return 0;
+    }
+  }
+  return -ENOSYS;
+}
+
+void TestRadosClient::add_aio_operation(const std::string& oid,
+				        const AioFunction &aio_function,
+                                        AioCompletionImpl *c) {
+  AioFunctionContext *ctx = new AioFunctionContext(aio_function, c);
+  get_finisher(oid)->queue(ctx);
+}
+
+struct WaitForFlush {
+  int flushed() {
+    if (count.dec() == 0) {
+      if (c != NULL) {
+	finish_aio_completion(c, 0);
+      }
+      delete this;
+    }
+    return 0;
+  }
+
+  atomic_t count;
+  AioCompletionImpl *c;
+};
+
+void TestRadosClient::flush_aio_operations() {
+  AioCompletionImpl *comp = new AioCompletionImpl();
+  flush_aio_operations(comp);
+  comp->wait_for_safe();
+  comp->put();
+}
+
+void TestRadosClient::flush_aio_operations(AioCompletionImpl *c) {
+  WaitForFlush *wait_for_flush = new WaitForFlush();
+  wait_for_flush->count.set(m_finishers.size());
+  wait_for_flush->c = c;
+  add_aio_operation("", boost::bind(&WaitForFlush::flushed, wait_for_flush), NULL);
+}
+
+Finisher *TestRadosClient::get_finisher(const std::string &oid) {
+  std::size_t h = m_hash(oid);
+  return m_finishers[h % m_finishers.size()];
+}
+
+} // namespace librados

--- a/src/test/librados_test_stub/TestRadosClient.h
+++ b/src/test/librados_test_stub/TestRadosClient.h
@@ -1,0 +1,84 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_RADOS_CLIENT_H
+#define CEPH_TEST_RADOS_CLIENT_H
+
+#include "include/rados/librados.hpp"
+#include "common/config.h"
+#include "include/atomic.h"
+#include "include/buffer.h"
+#include "test/librados_test_stub/TestWatchNotify.h"
+#include <boost/function.hpp>
+#include <boost/functional/hash.hpp>
+#include <map>
+#include <string>
+#include <vector>
+
+class Finisher;
+
+namespace librados {
+
+class TestIoCtxImpl;
+
+class TestRadosClient {
+public:
+
+  typedef boost::function<int()> AioFunction;
+
+  TestRadosClient(CephContext *cct);
+
+  void get();
+  void put();
+
+  virtual CephContext *cct();
+
+  virtual uint64_t get_instance_id();
+
+  virtual int connect();
+  virtual void shutdown();
+  virtual int wait_for_latest_osdmap();
+
+  virtual TestIoCtxImpl *create_ioctx(int64_t pool_id,
+                                      const std::string &pool_name) = 0;
+
+  virtual int mon_command(const std::vector<std::string>& cmd,
+                          const bufferlist &inbl,
+                          bufferlist *outbl, std::string *outs);
+
+  virtual int pool_create(const std::string &pool_name) = 0;
+  virtual int pool_delete(const std::string &pool_name) = 0;
+  virtual int pool_get_base_tier(int64_t pool_id, int64_t* base_tier) = 0;
+  virtual int pool_list(std::list<std::pair<int64_t, std::string> >& v) = 0;
+  virtual int64_t pool_lookup(const std::string &name) = 0;
+  virtual int pool_reverse_lookup(int64_t id, std::string *name) = 0;
+
+  TestWatchNotify &get_watch_notify() {
+    return m_watch_notify;
+  }
+
+  void add_aio_operation(const std::string& oid,
+			 const AioFunction &aio_function, AioCompletionImpl *c);
+  void flush_aio_operations();
+  void flush_aio_operations(AioCompletionImpl *c);
+
+protected:
+  virtual ~TestRadosClient();
+
+private:
+
+  CephContext *m_cct;
+  atomic_t m_refcount;
+
+  Finisher *get_finisher(const std::string& oid);
+
+  std::vector<Finisher *> m_finishers;
+  boost::hash<std::string> m_hash;
+
+  TestWatchNotify m_watch_notify;
+
+};
+
+} // namespace librados
+
+#endif // CEPH_TEST_RADOS_CLIENT_H

--- a/src/test/librados_test_stub/TestWatchNotify.cc
+++ b/src/test/librados_test_stub/TestWatchNotify.cc
@@ -1,0 +1,206 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librados_test_stub/TestWatchNotify.h"
+#include "include/Context.h"
+#include "common/Finisher.h"
+#include <boost/bind.hpp>
+#include <boost/function.hpp>
+
+namespace librados {
+
+TestWatchNotify::TestWatchNotify(CephContext *cct)
+  : m_cct(cct), m_finisher(new Finisher(cct)), m_handle(), m_notify_id(),
+    m_file_watcher_lock("librados::TestWatchNotify::m_file_watcher_lock") {
+  m_finisher->start();
+}
+
+TestWatchNotify::~TestWatchNotify() {
+  m_finisher->stop();
+  delete m_finisher;
+}
+
+TestWatchNotify::NotifyHandle::NotifyHandle()
+  : pbl(NULL), pending_responses(),
+    lock("TestWatchNotify::NotifyHandle::lock") {
+}
+
+TestWatchNotify::Watcher::Watcher()
+  : lock("TestWatchNotify::Watcher::lock") {
+}
+
+int TestWatchNotify::list_watchers(const std::string& o,
+                                   std::list<obj_watch_t> *out_watchers) {
+  SharedWatcher watcher = get_watcher(o);
+  RWLock::RLocker l(watcher->lock);
+
+  out_watchers->clear();
+  for (TestWatchNotify::WatchHandles::iterator it =
+         watcher->watch_handles.begin();
+       it != watcher->watch_handles.end(); ++it) {
+    obj_watch_t obj;
+    strcpy(obj.addr, ":/0");
+    obj.watcher_id = static_cast<int64_t>(it->second.handle);
+    obj.cookie = it->second.handle;
+    obj.timeout_seconds = 30;
+    out_watchers->push_back(obj);
+  }
+  return 0;
+}
+
+int TestWatchNotify::notify(const std::string& oid, bufferlist& bl,
+                            uint64_t timeout_ms, bufferlist *pbl) {
+  Mutex lock("TestRadosClient::watcher_notify::lock");
+  Cond cond;
+  bool done = false;
+
+  {
+    SharedWatcher watcher = get_watcher(oid);
+    RWLock::WLocker l(watcher->lock);
+    {
+      Mutex::Locker l2(m_file_watcher_lock);
+      uint64_t notify_id = ++m_notify_id;
+
+      SharedNotifyHandle notify_handle(new NotifyHandle());
+      notify_handle->pbl = pbl;
+
+      watcher->notify_handles[notify_id] = notify_handle;
+
+      FunctionContext *ctx = new FunctionContext(
+          boost::bind(&TestWatchNotify::execute_notify, this,
+                      oid, bl, notify_id, &lock, &cond, &done));
+      m_finisher->queue(ctx);
+    }
+  }
+
+  lock.Lock();
+  while (!done) {
+    cond.Wait(lock);
+  }
+  lock.Unlock();
+  return 0;
+}
+
+void TestWatchNotify::notify_ack(const std::string& o, uint64_t notify_id,
+                                 uint64_t handle, uint64_t gid,
+                                 bufferlist& bl) {
+  SharedWatcher watcher = get_watcher(o);
+
+  RWLock::RLocker l(watcher->lock);
+  NotifyHandles::iterator it = watcher->notify_handles.find(notify_id);
+  if (it == watcher->notify_handles.end()) {
+    return;
+  }
+
+  bufferlist response;
+  response.append(bl);
+
+  SharedNotifyHandle notify_handle = it->second;
+  Mutex::Locker l2(notify_handle->lock);
+  --notify_handle->pending_responses;
+  notify_handle->notify_responses[std::make_pair(gid, handle)] = response;
+  notify_handle->cond.Signal();
+}
+
+int TestWatchNotify::watch(const std::string& o, uint64_t *handle,
+                           librados::WatchCtx *ctx, librados::WatchCtx2 *ctx2) {
+  SharedWatcher watcher = get_watcher(o);
+
+  RWLock::WLocker l(watcher->lock);
+  WatchHandle watch_handle;
+  watch_handle.handle = ++m_handle;
+  watch_handle.watch_ctx = ctx;
+  watch_handle.watch_ctx2 = ctx2;
+  watcher->watch_handles[watch_handle.handle] = watch_handle;
+
+  *handle = watch_handle.handle;
+  return 0;
+}
+
+int TestWatchNotify::unwatch(uint64_t handle) {
+
+  SharedWatcher watcher;
+  {
+    Mutex::Locker l(m_file_watcher_lock);
+    for (FileWatchers::iterator it = m_file_watchers.begin();
+         it != m_file_watchers.end(); ++it) {
+      if (it->second->watch_handles.find(handle) !=
+            it->second->watch_handles.end()) {
+        watcher = it->second;
+        break;
+      }
+    }
+  }
+
+  if (watcher) {
+    RWLock::WLocker l(watcher->lock);
+    watcher->watch_handles.erase(handle);
+  }
+  return 0;
+}
+
+TestWatchNotify::SharedWatcher TestWatchNotify::get_watcher(
+    const std::string& oid) {
+  Mutex::Locker l(m_file_watcher_lock);
+  return _get_watcher(oid);
+}
+
+TestWatchNotify::SharedWatcher TestWatchNotify::_get_watcher(
+    const std::string& oid) {
+  SharedWatcher &watcher = m_file_watchers[oid];
+  if (!watcher) {
+    watcher.reset(new Watcher());
+  }
+  return watcher;
+}
+
+void TestWatchNotify::execute_notify(const std::string &oid,
+                                     bufferlist &bl, uint64_t notify_id,
+                                     Mutex *lock, Cond *cond,
+                                     bool *done) {
+  SharedWatcher watcher = get_watcher(oid);
+  RWLock::RLocker l(watcher->lock);
+
+  utime_t timeout;
+  timeout.set_from_double(ceph_clock_now(m_cct) + 15);
+
+  NotifyHandles::iterator n_it = watcher->notify_handles.find(notify_id);
+  if (n_it == watcher->notify_handles.end()) {
+    return;
+  }
+  SharedNotifyHandle notify_handle = n_it->second;
+
+  for (WatchHandles::iterator w_it = watcher->watch_handles.begin();
+       w_it != watcher->watch_handles.end(); ++w_it) {
+    WatchHandle &watch_handle = w_it->second;
+
+    bufferlist notify_bl;
+    notify_bl.append(bl);
+    if (watch_handle.watch_ctx2 != NULL) {
+      {
+        Mutex::Locker l2(notify_handle->lock);
+        ++notify_handle->pending_responses;
+      }
+      watch_handle.watch_ctx2->handle_notify(notify_id, w_it->first, 0,
+                                             notify_bl);
+    } else if (watch_handle.watch_ctx != NULL) {
+      watch_handle.watch_ctx->notify(0, 0, notify_bl);
+    }
+  }
+
+  {
+    Mutex::Locker l2(notify_handle->lock);
+    while (notify_handle->pending_responses > 0) {
+      notify_handle->cond.WaitUntil(notify_handle->lock, timeout);
+    }
+    if (notify_handle->pbl != NULL) {
+      ::encode(notify_handle->notify_responses, *notify_handle->pbl);
+    }
+  }
+
+  Mutex::Locker l3(*lock);
+  *done = true;
+  cond->Signal();
+}
+
+} // namespace librados

--- a/src/test/librados_test_stub/TestWatchNotify.h
+++ b/src/test/librados_test_stub/TestWatchNotify.h
@@ -1,0 +1,88 @@
+
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_WATCH_NOTIFY_H
+#define CEPH_TEST_WATCH_NOTIFY_H
+
+#include "include/rados/librados.hpp"
+#include "common/Cond.h"
+#include "common/Mutex.h"
+#include "common/RWLock.h"
+#include <boost/noncopyable.hpp>
+#include <boost/shared_ptr.hpp>
+#include <list>
+#include <map>
+
+class CephContext;
+class Cond;
+class Finisher;
+
+namespace librados {
+
+class TestWatchNotify : boost::noncopyable {
+public:
+  typedef std::map<std::pair<uint64_t, uint64_t>, bufferlist> NotifyResponses;
+
+  struct NotifyHandle {
+    NotifyHandle();
+    NotifyResponses notify_responses;
+    bufferlist *pbl;
+    size_t pending_responses;
+    Mutex lock;
+    Cond cond;
+  };
+  typedef boost::shared_ptr<NotifyHandle> SharedNotifyHandle;
+  typedef std::map<uint64_t, SharedNotifyHandle> NotifyHandles;
+
+  struct WatchHandle {
+    uint64_t handle;
+    librados::WatchCtx* watch_ctx;
+    librados::WatchCtx2* watch_ctx2;
+  };
+
+  typedef std::map<uint64_t, WatchHandle> WatchHandles;
+
+  struct Watcher {
+    Watcher();
+    WatchHandles watch_handles;
+    NotifyHandles notify_handles;
+    RWLock lock;
+  };
+  typedef boost::shared_ptr<Watcher> SharedWatcher;
+
+  TestWatchNotify(CephContext *cct);
+  ~TestWatchNotify();
+
+  int list_watchers(const std::string& o,
+                    std::list<obj_watch_t> *out_watchers);
+  int notify(const std::string& o, bufferlist& bl,
+             uint64_t timeout_ms, bufferlist *pbl);
+  void notify_ack(const std::string& o, uint64_t notify_id,
+                  uint64_t handle, uint64_t gid, bufferlist& bl);
+  int watch(const std::string& o, uint64_t *handle,
+            librados::WatchCtx *ctx, librados::WatchCtx2 *ctx2);
+  int unwatch(uint64_t handle);
+
+private:
+
+  typedef std::map<std::string, SharedWatcher> FileWatchers;
+
+  CephContext *m_cct;
+  Finisher *m_finisher;
+
+  uint64_t m_handle;
+  uint64_t m_notify_id;
+
+  Mutex m_file_watcher_lock;
+  FileWatchers	m_file_watchers;
+
+  SharedWatcher get_watcher(const std::string& oid);
+  SharedWatcher _get_watcher(const std::string& oid);
+  void execute_notify(const std::string &oid, bufferlist &bl,
+                      uint64_t notify_id, Mutex *lock, Cond *cond, bool *done);
+
+};
+
+} // namespace librados
+
+#endif // CEPH_TEST_WATCH_NOTIFY_H

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -26,6 +26,9 @@
 
 using namespace ceph;
 
+void register_test_image_watcher() {
+}
+
 class TestImageWatcher : public TestFixture {
 public:
 
@@ -342,14 +345,17 @@ TEST_F(TestImageWatcher, UnlockNotifyReleaseLock) {
 
   ASSERT_EQ(0, register_image_watch(*ictx));
   m_notify_acks = boost::assign::list_of(
-    std::make_pair(NOTIFY_OP_ACQUIRED_LOCK, bufferlist()))(
-    std::make_pair(NOTIFY_OP_RELEASED_LOCK, bufferlist()));
+    std::make_pair(NOTIFY_OP_ACQUIRED_LOCK, bufferlist()));
 
   RWLock::WLocker l(ictx->owner_lock);
   ASSERT_EQ(0, ictx->image_watcher->try_lock());
-  ASSERT_EQ(0, ictx->image_watcher->unlock());
-
   ASSERT_TRUE(wait_for_notifies(*ictx));
+
+  m_notify_acks = boost::assign::list_of(
+    std::make_pair(NOTIFY_OP_RELEASED_LOCK, bufferlist()));
+  ASSERT_EQ(0, ictx->image_watcher->unlock());
+  ASSERT_TRUE(wait_for_notifies(*ictx));
+
   ASSERT_TRUE(m_notify_acks.empty());
   NotifyOpPayloads expected_notify_ops = boost::assign::list_of(
     std::make_pair(NOTIFY_OP_ACQUIRED_LOCK, bufferlist()))(

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -7,6 +7,9 @@
 #include <utility>
 #include <vector>
 
+void register_test_internal() {
+}
+
 class TestInternal : public TestFixture {
 public:
 

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -54,6 +54,9 @@ using namespace std;
     ASSERT_TRUE(passed);          \
   } while(0)
 
+void register_test_librbd() {
+}
+
 static int get_features(bool *old_format, uint64_t *features)
 {
   const char *c = getenv("RBD_FEATURES");
@@ -2242,17 +2245,4 @@ TEST_F(TestLibRBD, TestPendingAio)
   }
 
   rados_ioctx_destroy(ioctx);
-}
-
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
-  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
-  common_init_finish(g_ceph_context);
-
-  return RUN_ALL_TESTS();
 }

--- a/src/test/librbd/test_main.cc
+++ b/src/test/librbd/test_main.cc
@@ -1,0 +1,29 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "gtest/gtest.h"
+#include "common/ceph_argparse.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include <vector>
+
+extern void register_test_image_watcher();
+extern void register_test_internal();
+extern void register_test_librbd();
+
+int main(int argc, char **argv)
+{
+  register_test_image_watcher();
+  register_test_internal();
+  register_test_librbd();
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Created a in-memory test implementation of librados that can be used by unit tests to simulate interactions with the OSDs.  The existing librbd integration tests have been linked against the test driver to provide a librbd unit test which now runs during ```make check```.