### PR TITLE
doc: fix spelling in corpus page

### DIFF
--- a/doc/dev/corpus.rst
+++ b/doc/dev/corpus.rst
@@ -7,7 +7,7 @@ ceph.git/ceph-object-corpus is a submodule.::
  bin/   # misc scripts
  archive/$version/objects/$type/$hash  # a sample of encoded objects from a specific version
 
-You can also mark known or deliber incompatibilities between versions with::
+You can also mark known or deliberate incompatibilities between versions with::
 
  archive/$version/forward_incompat/$type
 
@@ -37,7 +37,7 @@ We can generate an object corpus for a particular version of ceph like so.
 	cd src
 	MON=3 OSD=3 MDS=3 RGW=1 ./vstart.sh -n -x
 
-#. Use a much functionality of the cluster as you can, to exercise as many object encoder methods as possible::
+#. Use as much functionality of the cluster as you can, to exercise as many object encoder methods as possible::
 
 	./rados -p rbd bench 10 write -b 123
 	./ceph osd out 0


### PR DESCRIPTION
This pull request fixes two spelling errors in the corpus documentation page.
