### PR TITLE
erasure-code: relax cauchy w restrictions (giant)

### DIFF
--- a/src/erasure-code/jerasure/ErasureCodeJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.cc
@@ -298,13 +298,6 @@ int ErasureCodeJerasureCauchy::parse(const map<std::string,std::string> &paramet
 				     ostream *ss)
 {
   int err = ErasureCodeJerasure::parse(parameters, ss);
-  if (w != 8 && w != 16 && w != 32) {
-    *ss << "Cauchy: w=" << w
-	<< " must be one of {8, 16, 32} : revert to " 
-        << DEFAULT_W << std::endl;
-    w = DEFAULT_W;
-    err = -EINVAL;
-  }
   err |= to_int("packetsize", parameters, &packetsize, DEFAULT_PACKETSIZE, ss);
   err |= to_bool("jerasure-per-chunk-alignment", parameters,
 		 &per_chunk_alignment, false, ss);


### PR DESCRIPTION
A restriction that the w parameter of the cauchy technique is limited to
8, 16 or 32 was added incorrectly while refactoring parameter parsing in
the jerasure plugin and must be relaxed.

http://tracker.ceph.com/issues/10325 Fixes: #10325

Signed-off-by: Loic Dachary <ldachary@redhat.com>
(cherry picked from commit bb80437f247345502203ad87a7e7bbb5b5602b9a)