### PR TITLE
client, librados, osdc: do not shadow Dispatcher::cct

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -152,7 +152,6 @@ dir_result_t::dir_result_t(Inode *in)
 
 Client::Client(Messenger *m, MonClient *mc)
   : Dispatcher(m->cct),
-    cct(m->cct),
     logger(NULL),
     m_command_hook(this),
     timer(m->cct, client_lock),

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -208,7 +208,7 @@ struct dir_result_t {
 
 class Client : public Dispatcher {
  public:
-  CephContext *cct;
+  using Dispatcher::cct;
 
   PerfCounters *logger;
 

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -65,8 +65,7 @@ bool librados::RadosClient::ms_get_authorizer(int dest_type,
 }
 
 librados::RadosClient::RadosClient(CephContext *cct_)
-  : Dispatcher(cct_),
-    cct(cct_->get()),
+  : Dispatcher(cct_->get()),
     conf(cct_->_conf),
     state(DISCONNECTED),
     monclient(cct_),

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -36,7 +36,7 @@ class Messenger;
 class librados::RadosClient : public Dispatcher
 {
 public:
-  CephContext *cct;
+  using Dispatcher::cct;
   md_config_t *conf;
 private:
   enum {

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1007,7 +1007,7 @@ public:
 private:
   OSDMap    *osdmap;
 public:
-  CephContext *cct;
+  using Dispatcher::cct;
   std::multimap<string,string> crush_location;
 
   atomic_t initialized;
@@ -1778,10 +1778,9 @@ public:
 	   Finisher *fin,
 	   double mon_timeout,
 	   double osd_timeout) :
-    Dispatcher(cct),
+    Dispatcher(cct_),
     messenger(m), monc(mc), finisher(fin),
     osdmap(new OSDMap),
-    cct(cct_),
     initialized(0),
     last_tid(0), client_inc(-1), max_linger_id(0),
     num_unacked(0), num_uncommitted(0),


### PR DESCRIPTION
there is no need to have another `cct` as `Dispatch` has one already. and in `Objecter`, the ctor is initiating its parent class using the uninitialized member variable `cct`. it does not hurt since the `Dispatch::cct` in this case is never referenced. but the less uncertainty the better.