### PR TITLE
ceph.spec.in: quote %files macro in comment

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -761,7 +761,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_javadir}/libcephfs-test.jar
 
 %files libs-compat
-# We need an empty %files list for ceph-libs-compat, to tell rpmbuild to actually
+# We need an empty %%files list for ceph-libs-compat, to tell rpmbuild to actually
 # build this meta package.
 
 %changelog


### PR DESCRIPTION
Prior to this commit, RPM would expand the `%files` macro that was present in the comment.

Use a double percent sign to quote the macro so that RPM will not expand it.

This fixes an rpmlint warning, "`W: macro-in-comment %files`"

More information from rpmlint's "`-I`" (help) command:

```
  $ rpmlint -I macro-in-comment
  macro-in-comment:
  There is a unescaped macro after a shell style comment in the
  specfile.  Macros are expanded everywhere, so check if it can cause a
  problem in this case and escape the macro with another leading % if
  appropriate.
```
