### PR TITLE
mds: fix asok on rank 0

### DIFF
--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -238,7 +238,7 @@ bool MDS::asok_command(string command, cmdmap_t& cmdmap, string format,
     f->dump_unsigned("osdmap_epoch_barrier", get_osd_epoch_barrier());
     f->close_section(); // status
   } else {
-    if (whoami <= 0) {
+    if (whoami < 0) {
       dout(1) << "Can't run that command on an inactive MDS!" << dendl;
       f->dump_string("error", "mds_not_active");
     } else if (command == "dump_ops_in_flight") {


### PR DESCRIPTION
Broken by:
1b2b34431 (MDS: do not allow invocation of most commands on an inactive MDS)

MDS::whoami is a rank, so check for inactive is <0, not <=0

Signed-off-by: John Spray john.spray@redhat.com
