### PR TITLE
avoid memcopy from librados to caller buffer

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -982,7 +982,7 @@ int librados::IoCtxImpl::getxattr(const object_t& oid,
   ::ObjectOperation rd;
   prepare_assert_ops(&rd);
   rd.getxattr(name, &bl, NULL);
-  int r = operate_read(oid, &rd, NULL);
+  int r = operate_read(oid, &rd, &bl);
   if (r < 0)
     return r;
 

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -3167,13 +3167,15 @@ extern "C" int rados_getxattr(rados_ioctx_t io, const char *o, const char *name,
   int ret;
   object_t oid(o);
   bufferlist bl;
+  bl.push_back(buffer::create_static(len, buf));
   ret = ctx->getxattr(oid, name, bl);
   if (ret >= 0) {
     if (bl.length() > len) {
       tracepoint(librados, rados_getxattr_exit, -ERANGE, buf, 0);
       return -ERANGE;
     }
-    bl.copy(0, bl.length(), buf);
+    if (bl.c_str() !=  buf)
+      bl.copy(0, bl.length(), buf);
     ret = bl.length();
   }
 

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1980,6 +1980,8 @@ public:
     o->priority = op.priority;
     o->snapid = snapid;
     o->outbl = pbl;
+    if (!o->outbl && op.size() == 1 && op.out_bl[0]->length())
+	o->outbl = op.out_bl[0];
     o->out_bl.swap(op.out_bl);
     o->out_handler.swap(op.out_handler);
     o->out_rval.swap(op.out_rval);


### PR DESCRIPTION
Avoid memcopy  from librados to caller buffer.