### PR TITLE
osd: fix leaked OSDMap

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6111,6 +6111,7 @@ void OSD::handle_osd_map(MOSDMap *m)
 		<< " but failed to encode full with correct crc; requesting"
 		<< dendl;
 	clog->warn() << "failed to encode map e" << e << " with expected crc\n";
+	delete o;
 	MMonGetOSDMap *req = new MMonGetOSDMap;
 	req->request_full(e, last);
 	monc->send_mon_message(req);


### PR DESCRIPTION
**\* CID 1258787:  Resource leak  (RESOURCE_LEAK)
/osd/OSD.cc: 6118 in OSD::handle_osd_map(MOSDMap *)()
6112                    << dendl;
6113            clog->warn() << "failed to encode map e" << e << " with expecte
crc\n";
6114            MMonGetOSDMap *req = new MMonGetOSDMap;
6115            req->request_full(e, last);
6116            monc->send_mon_message(req);
6117            last = e - 1;

> > > ```
> > > CID 1258787:  Resource leak  (RESOURCE_LEAK)
> > > Variable "o" going out of scope leaks the storage it points to.
> > > ```
> > > 
> > > 6118            break;
> > > 6119           }
> > > 6120
> > > 6121
> > > 6122           hobject_t fulloid = get_osdmap_pobject_name(e);
> > > 6123           t.write(META_COLL, fulloid, 0, fbl.length(), fbl);

Signed-off-by: Sage Weil sage@redhat.com
