### PR TITLE
messages/MClientCaps: init peer.flags

### DIFF
--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -113,21 +113,21 @@ class MClientCaps : public Message {
     head.wanted = wanted;
     head.dirty = dirty;
     head.migrate_seq = mseq;
-    peer.cap_id = 0;
+    memset(&peer, 0, sizeof(peer));
     inline_version = 0;
   }
   MClientCaps(int op,
 	      inodeno_t ino, inodeno_t realm,
 	      uint64_t id, int mseq, epoch_t oeb)
     : Message(CEPH_MSG_CLIENT_CAPS, HEAD_VERSION, COMPAT_VERSION),
-      osd_epoch_barrier(oeb){
+      osd_epoch_barrier(oeb) {
     memset(&head, 0, sizeof(head));
     head.op = op;
     head.ino = ino;
     head.realm = realm;
     head.cap_id = id;
     head.migrate_seq = mseq;
-    peer.cap_id = 0;
+    memset(&peer, 0, sizeof(peer));
     inline_version = 0;
   }
 private:


### PR DESCRIPTION
**\* CID 1258789:  Uninitialized scalar field  (UNINIT_CTOR)
/messages/MClientCaps.h: 132 in MClientCaps::MClientCaps(int, inodeno_t,
inodeno_t, unsigned long, int, unsigned int)()
126         head.ino = ino;
127         head.realm = realm;
128         head.cap_id = id;
129         head.migrate_seq = mseq;
130         peer.cap_id = 0;
131         inline_version = 0;

> > > ```
> > > CID 1258789:  Uninitialized scalar field  (UNINIT_CTOR)
> > > Non-static class member field "peer.flags" is not initialized in this
> > > ```
> > > 
> > > constructor nor in any functions that it calls.
> > > 132       }
> > > 133     private:
> > > 134       ~MClientCaps() {}
> > > 135
> > > 136     public:
> > > 137       const char *get_type_name() const { return "Cfcap";}

Signed-off-by: Sage Weil sage@redhat.com
