### PR TITLE
librados: init last_objver

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -36,7 +36,8 @@ librados::IoCtxImpl::IoCtxImpl(RadosClient *c, Objecter *objecter,
 			       int poolid,
 			       const char *pool_name, snapid_t s)
   : ref_cnt(0), client(c), poolid(poolid), pool_name(pool_name), snap_seq(s),
-    assert_ver(0), notify_timeout(c->cct->_conf->client_notify_timeout),
+    assert_ver(0), last_objver(0),
+    notify_timeout(c->cct->_conf->client_notify_timeout),
     oloc(poolid),
     aio_write_list_lock("librados::IoCtxImpl::aio_write_list_lock"),
     aio_write_seq(0), objecter(objecter)


### PR DESCRIPTION
**\* CID 1258788:  Uninitialized scalar field  (UNINIT_CTOR)
/librados/IoCtxImpl.cc: 44 in
librados::IoCtxImpl::IoCtxImpl(librados::RadosClient *, Objecter *, int, const
char *, snapid_t)()
38       : ref_cnt(0), client(c), poolid(poolid), pool_name(pool_name),
snap_seq(s),
39         assert_ver(0), notify_timeout(c->cct->_conf->client_notify_timeout),
40         oloc(poolid),
41         aio_write_list_lock("librados::IoCtxImpl::aio_write_list_lock"),
42         aio_write_seq(0), objecter(objecter)
43     {

> > > ```
> > > CID 1258788:  Uninitialized scalar field  (UNINIT_CTOR)
> > > Non-static class member "last_objver" is not initialized in this
> > > ```
> > > 
> > > constructor nor in any functions that it calls.
> > > 44     }
> > > 45
> > > 46     void librados::IoCtxImpl::set_snap_read(snapid_t s)
> > > 47     {
> > > 48       if (!s)
> > > 49         s = CEPH_NOSNAP;

Signed-off-by: Sage Weil sage@redhat.com
