### PR TITLE
AsyncMessenger: Bind thread to core, use buffer read and fix some bugs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -842,6 +842,24 @@ AC_DEFINE([HAVE_FDATASYNC], 1, [Define to 1 if you have fdatasync.])
 AC_MSG_RESULT([no])
 ])
 
+AC_MSG_CHECKING([for sched.h])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#define _GNU_SOURCE
+#include <sched.h>
+]], [[
+cpu_set_t cpuset;
+CPU_ZERO(&cpuset);
+CPU_SET(sched_getcpu(), &cpuset);
+sched_setaffinity(0, sizeof(cpuset), &cpuset);
+sched_yield();
+return 0;
+]])], [
+AC_MSG_RESULT([yes])
+AC_DEFINE([HAVE_SCHED], 1, [Define to 1 if you have sched.h.])
+], [
+AC_MSG_RESULT([no])
+])
+
 #
 # Check for pthread spinlock (depends on ACX_PTHREAD)
 #

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -145,6 +145,13 @@ OPTION(ms_inject_internal_delays, OPT_DOUBLE, 0)   // seconds
 OPTION(ms_dump_on_send, OPT_BOOL, false)           // hexdump msg to log on send
 OPTION(ms_dump_corrupt_message_level, OPT_INT, 1)  // debug level to hexdump undecodeable messages at
 OPTION(ms_async_op_threads, OPT_INT, 2)
+OPTION(ms_async_set_affinity, OPT_BOOL, true)
+// example: ms_async_affinity_cores = 0,1
+// The number of coreset is expected to equal to ms_async_op_threads, otherwise
+// extra op threads will loop ms_async_affinity_cores again.
+// If ms_async_affinity_cores is empty, all threads will be bind to current running
+// core
+OPTION(ms_async_affinity_cores, OPT_STR, "")
 
 OPTION(inject_early_sigterm, OPT_BOOL, false)
 

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1623,7 +1623,7 @@ int AsyncConnection::handle_connect_msg(ceph_msg_connect &connect, bufferlist &a
                          << " > " << existing->connect_seq << dendl;
     goto replace;
   } // existing
-  else if (!replacing && policy.resetcheck && connect.connect_seq > 0) {
+  else if (!replacing && connect.connect_seq > 0) {
     // we reset, and they are opening a new session
     ldout(async_msgr->cct, 0) << __func__ << "accept we reset (peer sent cseq "
                         << connect.connect_seq << "), sending RESETSESSION" << dendl;

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2111,7 +2111,6 @@ void AsyncConnection::mark_down()
   stopping.set(1);
   Mutex::Locker l(lock);
   _stop();
-  center->dispatch_event_external(reset_handler);
 }
 
 void AsyncConnection::_send_keepalive_or_ack(bool ack, utime_t *tp)

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2111,6 +2111,7 @@ void AsyncConnection::mark_down()
   stopping.set(1);
   Mutex::Locker l(lock);
   _stop();
+  center->dispatch_event_external(reset_handler);
 }
 
 void AsyncConnection::_send_keepalive_or_ack(bool ack, utime_t *tp)

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1925,7 +1925,7 @@ void AsyncConnection::fault()
 
   // woke up again;
   register_time_events.insert(center->create_time_event(
-          backoff, EventCallbackRef(new C_time_wakeup(this))));
+          backoff.to_nsec()/1000, EventCallbackRef(new C_time_wakeup(this))));
 }
 
 void AsyncConnection::was_session_reset()

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1581,7 +1581,7 @@ int AsyncConnection::handle_connect_msg(ceph_msg_connect &connect, bufferlist &a
                             << " == " << connect.connect_seq << ", sending WAIT" << dendl;
         assert(peer_addr > async_msgr->get_myaddr());
         // make sure our outgoing connection will follow through
-        existing->_send_keepalive_or_ack();
+        existing->send_keepalive();
         return _reply_accept(CEPH_MSGR_TAG_WAIT, connect, reply, authorizer_reply);
       }
     }

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -842,6 +842,12 @@ void AsyncConnection::process()
           break;
         }
 
+      case STATE_WAIT:
+        {
+          ldout(async_msgr->cct, 20) << __func__ << " enter wait state" << dendl;
+          break;
+        }
+
       default:
         {
           if (_process_connection() < 0)
@@ -1369,7 +1375,7 @@ int AsyncConnection::_process_connection()
 
     default:
       {
-        lderr(async_msgr->cct) << __func__ << " bad state" << get_state_name(state) << dendl;
+        lderr(async_msgr->cct) << __func__ << " bad state: " << get_state_name(state) << dendl;
         assert(0);
       }
   }

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1998,7 +1998,7 @@ void AsyncConnection::fault()
     return;
   }
 
-  if (state != STATE_CONNECTING) {
+  if (!(state >= STATE_CONNECTING && state < STATE_CONNECTING_READY)) {
     // policy maybe empty when state is in accept
     if (policy.server || (state >= STATE_ACCEPTING && state < STATE_ACCEPTING_WAIT_SEQ)) {
       ldout(async_msgr->cct, 0) << __func__ << " server, going to standby" << dendl;
@@ -2017,6 +2017,7 @@ void AsyncConnection::fault()
       if (backoff > async_msgr->cct->_conf->ms_max_backoff)
         backoff.set_from_double(async_msgr->cct->_conf->ms_max_backoff);
     }
+    state = STATE_CONNECTING;
     ldout(async_msgr->cct, 10) << __func__ << " waiting " << backoff << dendl;
   }
 

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1118,6 +1118,7 @@ int AsyncConnection::_process_connection()
         bufferlist authorizer_reply;
         if (connect_reply.authorizer_len) {
           ldout(async_msgr->cct, 10) << __func__ << " reply.authorizer_len=" << connect_reply.authorizer_len << dendl;
+          assert(connect_reply.authorizer_len < 4096);
           r = read_until(connect_reply.authorizer_len, state_buffer);
           if (r < 0) {
             ldout(async_msgr->cct, 1) << __func__ << " read connect reply authorizer failed" << dendl;
@@ -1966,6 +1967,7 @@ void AsyncConnection::_stop()
   shutdown_socket();
   discard_out_queue();
   open_write = false;
+  state_offset = 0;
   state = STATE_CLOSED;
   if (sd > 0)
     ::close(sd);

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -53,7 +53,7 @@ class AsyncConnection : public Connection {
   int read_until(uint64_t needed, char *p);
   int _process_connection();
   void _connect();
-  void _stop();
+  void _stop(bool discard=true);
   int handle_connect_reply(ceph_msg_connect &connect, ceph_msg_connect_reply &r);
   int handle_connect_msg(ceph_msg_connect &m, bufferlist &aubl, bufferlist &bl);
   void was_session_reset();

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -286,6 +286,10 @@ class AsyncConnection : public Connection {
   void process();
   void wakeup_from(uint64_t id);
   void local_deliver();
+  void stop() {
+    mark_down();
+    center->dispatch_event_external(reset_handler);
+  }
 }; /* AsyncConnection */
 
 typedef boost::intrusive_ptr<AsyncConnection> AsyncConnectionRef;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -285,8 +285,17 @@ class AsyncConnection : public Connection {
   void wakeup_from(uint64_t id);
   void local_deliver();
   void stop() {
-    mark_down();
     center->dispatch_event_external(reset_handler);
+    mark_down();
+  }
+  void cleanup_handler() {
+    read_handler.reset();
+    write_handler.reset();
+    reset_handler.reset();
+    remote_reset_handler.reset();
+    connect_handler.reset();
+    accept_handler.reset();
+    local_deliver_handler.reset();
   }
 }; /* AsyncConnection */
 

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -53,7 +53,7 @@ class AsyncConnection : public Connection {
   int read_until(uint64_t needed, char *p);
   int _process_connection();
   void _connect();
-  void _stop(bool discard=true);
+  void _stop();
   int handle_connect_reply(ceph_msg_connect &connect, ceph_msg_connect_reply &r);
   int handle_connect_msg(ceph_msg_connect &m, bufferlist &aubl, bufferlist &bl);
   void was_session_reset();

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -266,6 +266,7 @@ class AsyncConnection : public Connection {
                      // there won't exists conflicting connection so we use
                      // "replacing" to skip RESETSESSION to avoid detect wrong
                      // presentation
+  bool once_session_reset;
   atomic_t stopping;
 
   // used only for local state, it will be overwrite when state transition

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -157,7 +157,6 @@ class AsyncConnection : public Connection {
     STATE_CONNECTING_WAIT_ACK_SEQ,
     STATE_CONNECTING_READY,
     STATE_ACCEPTING,
-    STATE_ACCEPTING_HANDLE_CONNECT,
     STATE_ACCEPTING_WAIT_BANNER_ADDR,
     STATE_ACCEPTING_WAIT_CONNECT_MSG,
     STATE_ACCEPTING_WAIT_CONNECT_MSG_AUTH,
@@ -194,7 +193,6 @@ class AsyncConnection : public Connection {
                                         "STATE_CONNECTING_WAIT_ACK_SEQ",
                                         "STATE_CONNECTING_READY",
                                         "STATE_ACCEPTING",
-                                        "STATE_ACCEPTING_HANDLE_CONNECT",
                                         "STATE_ACCEPTING_WAIT_BANNER_ADDR",
                                         "STATE_ACCEPTING_WAIT_CONNECT_MSG",
                                         "STATE_ACCEPTING_WAIT_CONNECT_MSG_AUTH",
@@ -202,8 +200,7 @@ class AsyncConnection : public Connection {
                                         "STATE_ACCEPTING_READY",
                                         "STATE_STANDBY",
                                         "STATE_CLOSED",
-                                        "STATE_WAIT",
-                                        "STATE_FAULT"};
+                                        "STATE_WAIT"};
       return statenames[state];
   }
 

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -430,6 +430,7 @@ AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
 AsyncMessenger::~AsyncMessenger()
 {
   assert(!did_bind); // either we didn't bind or we shut down the Processor
+  local_connection->mark_down();
 }
 
 void AsyncMessenger::ready()
@@ -700,7 +701,6 @@ void AsyncMessenger::mark_down_all()
       set<AsyncConnectionRef>::iterator it = deleted_conns.begin();
       AsyncConnectionRef p = *it;
       ldout(cct, 5) << __func__ << " delete " << p << dendl;
-      p->put();
       deleted_conns.erase(it);
     }
   }

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -66,15 +66,10 @@ class Processor {
   Worker *worker;
   int listen_sd;
   uint64_t nonce;
-  Mutex stop_lock;
-  Cond stop_cond;
 
  public:
-  Processor(AsyncMessenger *r, uint64_t n)
-    : msgr(r), worker(NULL), listen_sd(-1), nonce(n),
-      stop_lock("AsyncMessenger::Processor::stop_lock") {}
+  Processor(AsyncMessenger *r, uint64_t n): msgr(r), worker(NULL), listen_sd(-1), nonce(n) {}
 
-  void stop_cb();
   void stop();
   int bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports);
   int rebind(const set<int>& avoid_port);

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -351,7 +351,6 @@ private:
     Mutex::Locker l(deleted_lock);
     if (deleted_conns.count(p->second)) {
       deleted_conns.erase(p->second);
-      p->second->put();
       conns.erase(p);
       return NULL;
     }
@@ -393,7 +392,6 @@ public:
       Mutex::Locker l(deleted_lock);
       if (deleted_conns.count(existing)) {
         deleted_conns.erase(existing);
-        existing->put();
       } else if (conn != existing) {
         return -1;
       }

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -63,12 +63,13 @@ class Worker : public Thread {
  */
 class Processor {
   AsyncMessenger *msgr;
+  NetHandler net;
   Worker *worker;
   int listen_sd;
   uint64_t nonce;
 
  public:
-  Processor(AsyncMessenger *r, uint64_t n): msgr(r), worker(NULL), listen_sd(-1), nonce(n) {}
+  Processor(AsyncMessenger *r, CephContext *c, uint64_t n): msgr(r), net(c), worker(NULL), listen_sd(-1), nonce(n) {}
 
   void stop();
   int bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports);

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -389,6 +389,7 @@ public:
       AsyncConnectionRef existing = conns[conn->peer_addr];
 
       // lazy delete, see "deleted_conns"
+      // If conn already in, we will return 0
       Mutex::Locker l(deleted_lock);
       if (deleted_conns.count(existing)) {
         deleted_conns.erase(existing);

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -315,7 +315,7 @@ int EventCenter::process_events(int timeout_microseconds)
       shortest = it->first;
       trigger_time = true;
       if (shortest > now) {
-        period = now - shortest;
+        period = shortest - now;
         period.copy_to_timeval(&tv);
       } else {
         tv.tv_sec = 0;

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -121,8 +121,8 @@ int EventCenter::create_file_event(int fd, int mask, EventCallbackRef ctxt)
       lderr(cct) << __func__ << " failed to realloc file_events" << cpp_strerror(errno) << dendl;
       return -errno;
     }
-    memset(file_events+nevent, 0, sizeof(FileEvent)*(new_size-nevent));
     file_events = new_events;
+    memset(file_events+nevent, 0, sizeof(FileEvent)*(new_size-nevent));
     nevent = new_size;
   }
 

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -134,6 +134,8 @@ class EventCenter {
     last_time = time(NULL);
   }
   ~EventCenter();
+  ostream& _event_prefix(std::ostream *_dout);
+
   int init(int nevent);
   void set_owner(pthread_t p) { owner = p; }
   pthread_t get_owner() { return owner; }

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -82,9 +82,6 @@ class EventDriver {
 
 /*
  * EventCenter maintain a set of file descriptor and handle registered events.
- *
- * EventCenter is aimed to used by one thread, other threads access EventCenter
- * only can use dispatch_event_external method which is protected by lock.
  */
 class EventCenter {
   struct FileEvent {
@@ -104,13 +101,14 @@ class EventCenter {
   CephContext *cct;
   int nevent;
   // Used only to external event
-  Mutex lock;
+  Mutex external_lock, file_lock, time_lock;
   deque<EventCallbackRef> external_events;
   FileEvent *file_events;
   EventDriver *driver;
   map<utime_t, list<TimeEvent> > time_events;
   uint64_t time_event_next_id;
   time_t last_time; // last time process time event
+  utime_t next_time; // next wake up time
   int notify_receive_fd;
   int notify_send_fd;
   NetHandler net;
@@ -127,7 +125,9 @@ class EventCenter {
  public:
   EventCenter(CephContext *c):
     cct(c), nevent(0),
-    lock("AsyncMessenger::lock"),
+    external_lock("AsyncMessenger::external_lock"),
+    file_lock("AsyncMessenger::file_lock"),
+    time_lock("AsyncMessenger::time_lock"),
     file_events(NULL),
     driver(NULL), time_event_next_id(0),
     notify_receive_fd(-1), notify_send_fd(-1), net(c), owner(0) {

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -116,6 +116,7 @@ class EventCenter {
 
   int process_time_events();
   FileEvent *_get_file_event(int fd) {
+    assert(fd < nevent);
     FileEvent *p = &file_events[fd];
     if (!p->mask)
       new(p) FileEvent();

--- a/src/msg/async/EventEpoll.cc
+++ b/src/msg/async/EventEpoll.cc
@@ -47,7 +47,7 @@ int EpollDriver::init(int nevent)
 int EpollDriver::add_event(int fd, int cur_mask, int add_mask)
 {
   ldout(cct, 20) << __func__ << " add event fd=" << fd << " cur_mask=" << cur_mask
-                 << " add_mask=" << add_mask << dendl;
+                 << " add_mask=" << add_mask << " to " << epfd << dendl;
   struct epoll_event ee;
   /* If the fd was already monitored for some event, we need a MOD
    * operation. Otherwise we need an ADD operation. */
@@ -63,8 +63,8 @@ int EpollDriver::add_event(int fd, int cur_mask, int add_mask)
   ee.data.u64 = 0; /* avoid valgrind warning */
   ee.data.fd = fd;
   if (epoll_ctl(epfd, op, fd, &ee) == -1) {
-    lderr(cct) << __func__ << " unable to add event: "
-                       << cpp_strerror(errno) << dendl;
+    lderr(cct) << __func__ << " epoll_ctl: add fd=" << fd << " failed. "
+               << cpp_strerror(errno) << dendl;
     return -errno;
   }
 
@@ -74,7 +74,7 @@ int EpollDriver::add_event(int fd, int cur_mask, int add_mask)
 void EpollDriver::del_event(int fd, int cur_mask, int delmask)
 {
   ldout(cct, 20) << __func__ << " del event fd=" << fd << " cur_mask=" << cur_mask
-                 << " delmask=" << delmask << dendl;
+                 << " delmask=" << delmask << " to " << epfd << dendl;
   struct epoll_event ee;
   int mask = cur_mask & (~delmask);
 

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -25,7 +25,7 @@
 
 #define dout_subsys ceph_subsys_ms
 #undef dout_prefix
-#define dout_prefix *_dout << "net_handler: "
+#define dout_prefix *_dout << "NetHandler "
 
 namespace ceph{
 
@@ -42,7 +42,7 @@ int NetHandler::create_socket(int domain, bool reuse_addr)
    * will be able to close/open sockets a zillion of times */
   if (reuse_addr) {
     if (::setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1) {
-      lderr(cct) << __func__ << " setsockopt SO_REUSEADDR failed: %s"
+      lderr(cct) << __func__ << " setsockopt SO_REUSEADDR failed: "
                  << strerror(errno) << dendl;
       close(s);
       return -errno;
@@ -60,11 +60,11 @@ int NetHandler::set_nonblock(int sd)
    * Note that fcntl(2) for F_GETFL and F_SETFL can't be
    * interrupted by a signal. */
   if ((flags = fcntl(sd, F_GETFL)) < 0 ) {
-    lderr(cct) << __func__ << " fcntl(F_GETFL) failed: %s" << strerror(errno) << dendl;
+    lderr(cct) << __func__ << " fcntl(F_GETFL) failed: " << strerror(errno) << dendl;
     return -errno;
   }
   if (fcntl(sd, F_SETFL, flags | O_NONBLOCK) < 0) {
-    lderr(cct) << __func__ << " fcntl(F_SETFL,O_NONBLOCK): %s" << strerror(errno) << dendl;
+    lderr(cct) << __func__ << " fcntl(F_SETFL,O_NONBLOCK): " << strerror(errno) << dendl;
     return -errno;
   }
 
@@ -121,7 +121,7 @@ int NetHandler::generic_connect(const entity_addr_t& addr, bool nonblock)
     if (errno == EINPROGRESS && nonblock)
       return s;
 
-    lderr(cct) << __func__ << " connect: %s " << strerror(errno) << dendl;
+    lderr(cct) << __func__ << " connect: " << strerror(errno) << dendl;
     close(s);
     return -errno;
   }

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -30,7 +30,12 @@
 #include "messages/MPing.h"
 #include "messages/MCommand.h"
 
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/binomial_distribution.hpp>
 #include <gtest/gtest.h>
+
+typedef boost::mt11213b gen_type;
 
 #if GTEST_HAS_PARAM_TEST
 
@@ -73,7 +78,7 @@ class FakeDispatcher : public Dispatcher {
 
     Session(ConnectionRef c): RefCountedObject(g_ceph_context), lock("FakeDispatcher::Session::lock"), count(0), con(c) {
     }
-    uint64_t get_count() {return count;}
+    uint64_t get_count() { return count; }
   };
 
   Mutex lock;
@@ -97,6 +102,7 @@ class FakeDispatcher : public Dispatcher {
   }
 
   void ms_handle_fast_connect(Connection *con) {
+    lock.Lock();
     cerr << __func__ << con << std::endl;
     Session *s = static_cast<Session*>(con->get_priv());
     if (!s) {
@@ -105,12 +111,12 @@ class FakeDispatcher : public Dispatcher {
       cerr << __func__ << " con: " << con << " count: " << s->count << std::endl;
     }
     s->put();
-    lock.Lock();
     got_connect = true;
     cond.Signal();
     lock.Unlock();
   }
   void ms_handle_fast_accept(Connection *con) {
+    Mutex::Locker l(lock);
     Session *s = static_cast<Session*>(con->get_priv());
     if (!s) {
       s = new Session(con);
@@ -119,24 +125,25 @@ class FakeDispatcher : public Dispatcher {
     s->put();
   }
   bool ms_dispatch(Message *m) {
+    Mutex::Locker l(lock);
     Session *s = static_cast<Session*>(m->get_connection()->get_priv());
     if (!s) {
       s = new Session(m->get_connection());
       m->get_connection()->set_priv(s->get());
     }
     s->put();
-    Mutex::Locker l(s->lock);
+    Mutex::Locker l1(s->lock);
     s->count++;
     cerr << __func__ << " conn: " << m->get_connection() << " session " << s << " count: " << s->count << std::endl;
-    if (is_server)
+    if (is_server) {
       reply_message(m);
-    lock.Lock();
+    }
     got_new = true;
     cond.Signal();
-    lock.Unlock();
     return true;
   }
   bool ms_handle_reset(Connection *con) {
+    Mutex::Locker l(lock);
     cerr << __func__ << con << std::endl;
     Session *s = static_cast<Session*>(con->get_priv());
     if (s) {
@@ -147,6 +154,7 @@ class FakeDispatcher : public Dispatcher {
     return true;
   }
   void ms_handle_remote_reset(Connection *con) {
+    Mutex::Locker l(lock);
     cerr << __func__ << con << std::endl;
     Session *s = static_cast<Session*>(con->get_priv());
     if (s) {
@@ -157,29 +165,29 @@ class FakeDispatcher : public Dispatcher {
     got_remote_reset = true;
   }
   void ms_fast_dispatch(Message *m) {
+    Mutex::Locker l(lock);
     Session *s = static_cast<Session*>(m->get_connection()->get_priv());
     if (!s) {
       s = new Session(m->get_connection());
       m->get_connection()->set_priv(s->get());
     }
     s->put();
-    Mutex::Locker (s->lock);
+    Mutex::Locker l1(s->lock);
     s->count++;
     cerr << __func__ << " conn: " << m->get_connection() << " session " << s << " count: " << s->count << std::endl;
-    if (is_server)
+    if (is_server) {
       reply_message(m);
-    lock.Lock();
+    }
     got_new = true;
     cond.Signal();
-    lock.Unlock();
   }
+
   bool ms_verify_authorizer(Connection *con, int peer_type, int protocol,
                             bufferlist& authorizer, bufferlist& authorizer_reply,
                             bool& isvalid, CryptoKey& session_key) {
     isvalid = true;
     return true;
   }
-
 
   void reply_message(Message *m) {
     MPing *rm = new MPing();
@@ -555,8 +563,119 @@ TEST_P(MessengerTest, ClientStandbyTest) {
   client_msgr->wait();
 }
 
+class SyntheticDispatcher : public Dispatcher {
+ public:
+  Mutex lock;
+  Cond cond;
+  bool is_server;
+  bool got_new;
+  bool got_remote_reset;
+  bool got_connect;
+  map<ConnectionRef, list<uint64_t> > conn_sent;
+  map<uint64_t, bufferlist> sent;
+  atomic_t index;
+
+  SyntheticDispatcher(bool s): Dispatcher(g_ceph_context), lock("SyntheticDispatcher::lock"),
+                          is_server(s), got_new(false), got_remote_reset(false),
+                          got_connect(false), index(0) {}
+  bool ms_can_fast_dispatch_any() const { return true; }
+  bool ms_can_fast_dispatch(Message *m) const {
+    switch (m->get_type()) {
+    case CEPH_MSG_PING:
+    case MSG_COMMAND:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  void ms_handle_fast_connect(Connection *con) {
+    lock.Lock();
+    got_connect = true;
+    cond.Signal();
+    lock.Unlock();
+  }
+  void ms_handle_fast_accept(Connection *con) { }
+  bool ms_dispatch(Message *m) {
+    assert(0);
+  }
+  bool ms_handle_reset(Connection *con) {
+    return true;
+  }
+  void ms_handle_remote_reset(Connection *con) {
+    Mutex::Locker l(lock);
+    got_remote_reset = true;
+  }
+  void ms_fast_dispatch(Message *m) {
+    Mutex::Locker l(lock);
+    if (is_server) {
+      reply_message(m);
+    } else if (m->get_middle().length()) {
+      bufferlist middle = m->get_middle();
+      uint64_t i;
+      ASSERT_EQ(sizeof(uint64_t), middle.length());
+      memcpy(&i, middle.c_str(), middle.length());
+      if (sent.count(i)) {
+        ASSERT_EQ(conn_sent[m->get_connection()].front(), i);
+        ASSERT_TRUE(m->get_data().contents_equal(sent[i]));
+        conn_sent[m->get_connection()].pop_front();
+        sent.erase(i);
+      }
+    }
+    got_new = true;
+    cond.Signal();
+  }
+
+  bool ms_verify_authorizer(Connection *con, int peer_type, int protocol,
+                            bufferlist& authorizer, bufferlist& authorizer_reply,
+                            bool& isvalid, CryptoKey& session_key) {
+    isvalid = true;
+    return true;
+  }
+
+  void reply_message(Message *m) {
+    MPing *rm = new MPing();
+    if (m->get_data_len())
+      rm->set_data(m->get_data());
+    if (m->get_middle().length())
+      rm->set_middle(m->get_middle());
+    m->get_connection()->send_message(rm);
+  }
+
+  void send_message_wrap(ConnectionRef con, Message *m) {
+    {
+      Mutex::Locker l(lock);
+      bufferlist bl;
+      uint64_t i = index.read();
+      index.inc();
+      bufferptr bp(sizeof(i));
+      memcpy(bp.c_str(), (char*)&i, sizeof(i));
+      bl.push_back(bp);
+      m->set_middle(bl);
+      sent[i] = m->get_data();
+      conn_sent[con].push_back(i);
+    }
+    ASSERT_EQ(con->send_message(m), 0);
+  }
+
+  uint64_t get_pending() {
+    Mutex::Locker l(lock);
+    return sent.size();
+  }
+
+  void clear_pending(ConnectionRef con) {
+    Mutex::Locker l(lock);
+
+    for (list<uint64_t>::iterator it = conn_sent[con].begin();
+         it != conn_sent[con].end(); ++it)
+      sent.erase(*it);
+    conn_sent.erase(con);
+  }
+};
+
+
 TEST_P(MessengerTest, MessageTest) {
-  FakeDispatcher cli_dispatcher(false), srv_dispatcher(true);
+  SyntheticDispatcher cli_dispatcher(false), srv_dispatcher(true);
   entity_addr_t bind_addr;
   bind_addr.parse("127.0.0.1");
   Messenger::Policy p = Messenger::Policy::stateful_server(0, 0);
@@ -594,11 +713,210 @@ TEST_P(MessengerTest, MessageTest) {
     cli_dispatcher.got_new = false;
   }
 
+  // 2. A very large "data"
+  {
+    bufferlist bl;
+    string s("abcdefghijklmnopqrstuvwxyz");
+    for (int i = 0; i < 1024*30; i++)
+      bl.append(s);
+    MPing *m = new MPing();
+    m->set_data(bl);
+    cli_dispatcher.send_message_wrap(conn, m);
+    utime_t t;
+    t += 1000*1000*500;
+    Mutex::Locker l(cli_dispatcher.lock);
+    while (!cli_dispatcher.got_new)
+      cli_dispatcher.cond.WaitInterval(g_ceph_context, cli_dispatcher.lock, t);
+    ASSERT_TRUE(cli_dispatcher.got_new);
+    cli_dispatcher.got_new = false;
+  }
   server_msgr->shutdown();
   client_msgr->shutdown();
   server_msgr->wait();
   client_msgr->wait();
 }
+
+
+class SyntheticWorkload {
+  Mutex lock;
+  Cond cond;
+  set<Messenger*> available_servers;
+  set<Messenger*> available_clients;
+  map<pair<Messenger*, Messenger*>, ConnectionRef> available_connections;
+  SyntheticDispatcher cli_dispatcher, srv_dispatcher;
+  gen_type rng;
+  vector<bufferlist> rand_data;
+
+ public:
+  static const unsigned max_in_flight = 512;
+  static const unsigned max_connections = 128;
+  static const unsigned max_messege_len = 1024 * 1024 * 4;
+
+  SyntheticWorkload(int servers, int clients, string type, int random_num):
+      lock("SyntheticWorkload::lock"), cli_dispatcher(false), srv_dispatcher(true),
+      rng(time(NULL)) {
+    Messenger *msgr;
+    int base_port = 16800;
+    for (int i = 0; i < servers; ++i) {
+      entity_addr_t bind_addr;
+      char addr[64];
+      snprintf(addr, sizeof(addr), "127.0.0.1:%d", base_port+i);
+      msgr = Messenger::create(g_ceph_context, type, entity_name_t::OSD(0),
+                               "server", getpid()+i);
+      bind_addr.parse(addr);
+      msgr->bind(bind_addr);
+      msgr->add_dispatcher_head(&srv_dispatcher);
+
+      assert(msgr);
+      msgr->set_default_policy(Messenger::Policy::stateless_server(0, 0));
+      available_servers.insert(msgr);
+      msgr->start();
+    }
+
+    for (int i = 0; i < clients; ++i) {
+      msgr = Messenger::create(g_ceph_context, type, entity_name_t::CLIENT(-1),
+                               "client", getpid()+i+servers);
+      assert(msgr);
+      msgr->set_default_policy(Messenger::Policy::lossless_client(0, 0));
+      msgr->add_dispatcher_head(&cli_dispatcher);
+      available_clients.insert(msgr);
+      msgr->start();
+    }
+
+    static const char alphanum[] = "0123456789"
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "abcdefghijklmnopqrstuvwxyz";
+
+    for (int i = 0; i < random_num; i++) {
+      bufferlist bl;
+      boost::uniform_int<> u(1, max_messege_len);
+      uint64_t value_len = u(rng);
+      bufferptr bp(value_len);
+      for (uint64_t j = 0; j < value_len; j++)
+        bp[j] = alphanum[rand() % (sizeof(alphanum) - 1)];
+
+      bp[value_len - 1] = '\0';
+      bl.append(bp);
+      rand_data.push_back(bl);
+    }
+  }
+
+  ConnectionRef _get_random_connection(pair<Messenger*, Messenger*> *p) {
+    while (cli_dispatcher.get_pending() > max_in_flight)
+      usleep(500);
+    assert(lock.is_locked());
+    boost::uniform_int<> choose(0, available_connections.size() - 1);
+    int index = choose(rng);
+    map<pair<Messenger*, Messenger*>, ConnectionRef>::iterator i = available_connections.begin();
+    for (; index > 0; --index, ++i) ;
+    if (p)
+      *p = i->first;
+    return i->second;
+  }
+
+  bool can_create_connection() {
+    return available_connections.size() < max_connections;
+  }
+
+  void generate_connection() {
+    Mutex::Locker l(lock);
+    if (!can_create_connection())
+      return ;
+
+    Messenger *server, *client;
+    {
+      boost::uniform_int<> choose(0, available_servers.size() - 1);
+      int index = choose(rng);
+      set<Messenger*>::iterator i = available_servers.begin();
+      for (; index > 0; --index, ++i) ;
+      server = *i;
+    }
+    {
+      boost::uniform_int<> choose(0, available_clients.size() - 1);
+      int index = choose(rng);
+      set<Messenger*>::iterator i = available_clients.begin();
+      for (; index > 0; --index, ++i) ;
+      client = *i;
+    }
+
+    if (!available_connections.count(make_pair(client, server))) {
+      ConnectionRef conn = client->get_connection(server->get_myinst());
+      available_connections[make_pair(client, server)] = conn;
+    }
+  }
+
+  void send_message() {
+    Message *m = new MPing();
+    bufferlist bl;
+    boost::uniform_int<> u(0, rand_data.size()-1);
+    uint64_t index = u(rng);
+    bl = rand_data[index];
+    m->set_data(bl);
+    Mutex::Locker l(lock);
+    ConnectionRef conn = _get_random_connection(NULL);
+    cli_dispatcher.send_message_wrap(conn, m);
+  }
+
+  void drop_connection() {
+    pair<Messenger*, Messenger*> p;
+    Mutex::Locker l(lock);
+    if (available_connections.size() < 10)
+      return;
+    ConnectionRef conn = _get_random_connection(&p);
+    cli_dispatcher.clear_pending(conn);
+    conn->mark_down();
+    ASSERT_EQ(available_connections.erase(p), 1U);
+  }
+
+  void print_internal_state() {
+    Mutex::Locker l(lock);
+    cerr << "available_connections: " << available_connections.size()
+         << " inflight messages: " << cli_dispatcher.get_pending() << std::endl;
+  }
+
+  void wait_for_done() {
+    while (cli_dispatcher.get_pending())
+      usleep(500);
+    for (set<Messenger*>::iterator it = available_servers.begin();
+         it != available_servers.end(); ++it) {
+      (*it)->shutdown();
+      (*it)->wait();
+    }
+    for (set<Messenger*>::iterator it = available_clients.begin();
+         it != available_clients.end(); ++it) {
+      (*it)->shutdown();
+      (*it)->wait();
+    }
+  }
+};
+
+TEST_P(MessengerTest, SyntheticTest) {
+  SyntheticWorkload test_msg(32, 128, GetParam(), 100);
+  for (int i = 0; i < 100; ++i) {
+    if (!(i % 10)) cerr << "seeding connection " << i << std::endl;
+    test_msg.generate_connection();
+  }
+  gen_type rng(time(NULL));
+  for (int i = 0; i < 10000; ++i) {
+    if (!(i % 10)) {
+      cerr << "Op " << i << ": ";
+      test_msg.print_internal_state();
+    }
+    boost::uniform_int<> true_false(0, 99);
+    int val = true_false(rng);
+    if (val > 85) {
+      test_msg.generate_connection();
+    } else if (val > 70) {
+      test_msg.drop_connection();
+    } else if (val > 10) {
+      test_msg.send_message();
+    } else {
+      usleep(rand() % 500 + 100);
+    }
+  }
+  test_msg.wait_for_done();
+}
+
 
 class MarkdownDispatcher : public Dispatcher {
   Mutex lock;

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -16,6 +16,7 @@
 
 #include <iostream>
 #include <unistd.h>
+#include <stdlib.h>
 #include <time.h>
 #include "common/Mutex.h"
 #include "common/Cond.h"
@@ -574,9 +575,11 @@ class MarkdownDispatcher : public Dispatcher {
 
   void ms_handle_fast_connect(Connection *con) {
     cerr << __func__ << con << std::endl;
+    Mutex::Locker l(lock);
     conns.insert(con);
   }
   void ms_handle_fast_accept(Connection *con) {
+    Mutex::Locker l(lock);
     conns.insert(con);
   }
   bool ms_dispatch(Message *m) {
@@ -588,6 +591,7 @@ class MarkdownDispatcher : public Dispatcher {
       return true;
 
     last_mark = true;
+    usleep(rand() % 500);
     for (set<Connection*>::iterator it = conns.begin(); it != conns.end(); ++it) {
       if ((*it) != m->get_connection().get()) {
         (*it)->mark_down();
@@ -601,10 +605,13 @@ class MarkdownDispatcher : public Dispatcher {
   }
   bool ms_handle_reset(Connection *con) {
     cerr << __func__ << con << std::endl;
+    Mutex::Locker l(lock);
     conns.erase(con);
+    usleep(rand() % 500);
     return true;
   }
   void ms_handle_remote_reset(Connection *con) {
+    Mutex::Locker l(lock);
     conns.erase(con);
     cerr << __func__ << con << std::endl;
   }

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -149,7 +149,6 @@ class FakeDispatcher : public Dispatcher {
     cerr << __func__ << con << std::endl;
     Session *s = static_cast<Session*>(con->get_priv());
     if (s) {
-      Mutex::Locker l(s->lock);
       s->con.reset(NULL);  // break con <-> session ref cycle
       con->set_priv(NULL);   // break ref <-> session cycle, if any
       s->put();

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -748,7 +748,7 @@ class SyntheticWorkload {
   vector<bufferlist> rand_data;
 
  public:
-  static const unsigned max_in_flight = 512;
+  static const unsigned max_in_flight = 64;
   static const unsigned max_connections = 128;
   static const unsigned max_message_len = 1024 * 1024 * 4;
 
@@ -905,14 +905,14 @@ TEST_P(MessengerTest, SyntheticStressTest) {
     }
     boost::uniform_int<> true_false(0, 99);
     int val = true_false(rng);
-    if (val > 85) {
+    if (val > 90) {
       test_msg.generate_connection();
-    } else if (val > 70) {
+    } else if (val > 80) {
       test_msg.drop_connection();
     } else if (val > 10) {
       test_msg.send_message();
     } else {
-      usleep(rand() % 500 + 100);
+      usleep(rand() % 1000 + 500);
     }
   }
   test_msg.wait_for_done();
@@ -920,7 +920,7 @@ TEST_P(MessengerTest, SyntheticStressTest) {
 
 
 TEST_P(MessengerTest, SyntheticInjectTest) {
-  g_ceph_context->_conf->set_val("ms_inject_socket_failures", "10");
+  g_ceph_context->_conf->set_val("ms_inject_socket_failures", "30");
   g_ceph_context->_conf->set_val("ms_inject_internal_delays", "0.1");
   SyntheticWorkload test_msg(4, 16, GetParam(), 100);
   for (int i = 0; i < 100; ++i) {
@@ -935,9 +935,9 @@ TEST_P(MessengerTest, SyntheticInjectTest) {
     }
     boost::uniform_int<> true_false(0, 99);
     int val = true_false(rng);
-    if (val > 85) {
+    if (val > 90) {
       test_msg.generate_connection();
-    } else if (val > 70) {
+    } else if (val > 80) {
       test_msg.drop_connection();
     } else if (val > 10) {
       test_msg.send_message();
@@ -1106,6 +1106,7 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf->set_val("auth_client_required", "none");
   g_ceph_context->_conf->set_val("enable_experimental_unrecoverable_data_corrupting_features", "ms-type-async");
   g_ceph_context->_conf->set_val("ms_die_on_bad_msg", "true");
+  g_ceph_context->_conf->set_val("ms_max_backoff", "1");
   common_init_finish(g_ceph_context);
 
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
1. Bind limited threads to specified cores
2. Using buffer read like what pipe done
3. discard poll call
4. add ms_inject_* to async
5. fix replace process
6. fix memory leak
7. lots of small bug fixed

impl feature #10172 #10396 