### PR TITLE
tests: resolve ceph-helpers races

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -88,8 +88,7 @@ stop_daemon() {
     action=$5
     [ -z "$action" ] && action="Stopping"
     echo -n "$action Ceph $name on $host..."
-    do_cmd "while [ 1 ]; do
-	[ -e $pidfile ] || break
+    do_cmd "if [ -e $pidfile ] ; then 
 	pid=\`cat $pidfile\`
 	while [ -e /proc/\$pid ] && grep -q $daemon /proc/\$pid/cmdline ; do
 	    cmd=\"kill $signal \$pid\"
@@ -98,8 +97,7 @@ stop_daemon() {
 	    sleep 1
 	    continue
 	done
-	break
-    done"
+    fi"
     echo done
 }
 


### PR DESCRIPTION
Some tests were racing against the monitor. On a fast machine it worked
but slower machines (or sometime when running in parallel), the monitor
is lagging behind. Use wait_for_clean to make sure the monitor is in the
desired state for the test to succeed.

http://tracker.ceph.com/issues/10384 Fixes: #10384

Signed-off-by: Loic Dachary <ldachary@redhat.com>