### PR TITLE
mailmap updates

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -28,6 +28,7 @@ Carlos Maltzahn <carlosm@cs.ucsc.edu> carlosm <carlosm@29311d96-e01e-0410-9327-a
 Chendi Xue <chendi.xue@intel.com> Chendi Xue <xuechendi@gmail.com>
 Chendi Xue <chendi.xue@intel.com> Chendi.Xue <chendi.xue@intel.com>
 Cheng Cheng <ccheng.leo@gmail.com> cchengleo <ccheng.leo@gmail.com>
+Chris Holcombe <chris.holcombe@nebula.com> cholcombe973 <xfactor973@gmail.com>
 Christian Brunner <christian@brunner-muc.de> <chb@muc.de> 
 Christian Marie <pingu@anchor.net.au> <christian@ponies.io>
 Christophe Courtaut <christophe.courtaut@gmail.com> Kri5 <christophe.courtaut@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -222,6 +222,7 @@ Unaffiliated <no@organization.net> Cheng Cheng <ccheng.leo@gmail.com>
 Unaffiliated <no@organization.net> Daniel Schepler <dschepler@gmail.com>
 Unaffiliated <no@organization.net> Colin Mattson <colinmattson@gmail.com>
 Unaffiliated <no@organization.net> Dan Chai <tengweicai@gmail.com>
+Unaffiliated <no@organization.net> David Anderson <dave@natulte.net>
 Unaffiliated <no@organization.net> Ding Dinghua <dingdinghua85@gmail.com>
 Unaffiliated <no@organization.net> Dominik Hannen <cantares1+github@gmail.com>
 Unaffiliated <no@organization.net> Dongmao Zhang <deanraccoon@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -220,6 +220,7 @@ Unaffiliated <no@organization.net> Accela Zhao <accelazh@gmail.com>
 Unaffiliated <no@organization.net> Ailing Zhang <zhangal1992@gmail.com> 
 Unaffiliated <no@organization.net> BJ Lougee <almightybeeij@gmail.com>
 Unaffiliated <no@organization.net> Cheng Cheng <ccheng.leo@gmail.com>
+Unaffiliated <no@organization.net> Christos Stavrakakis <stavr.chris@gmail.com>
 Unaffiliated <no@organization.net> Daniel Schepler <dschepler@gmail.com>
 Unaffiliated <no@organization.net> Colin Mattson <colinmattson@gmail.com>
 Unaffiliated <no@organization.net> Dan Chai <tengweicai@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -136,6 +136,7 @@ Lebanon Evangelical School <contact@lesbg.com> Jonathan Dieter <jdieter@lesbg.co
 Los Alamos National Laboratory <contact@lanl.gov> Esteban Molina-Estolano <eestolan@lanl.gov>
 Mirantis <contact@mirantis.com> Andrew Woodward <awoodward@mirantis.com>
 MIT Computer Science and Artificial Intelligence Laboratory <webmaster@csail.mit.edu> Stephen Jahl <stephenjahl@gmail.com>
+Nebula <info@nebula.com> Chris Holcombe <chris.holcombe@nebula.com>
 Opower <contact@opower.com> Derrick Schneider <derrick.schneider@opower.com>
 Pacific Northwest National Laboratory <contact@pnl.gov> Brown, David M JR <david.brown@pnl.gov>
 Pacific Northwest National Laboratory <contact@pnl.gov> Erwin, Brock A <Brock.Erwin@pnl.gov>

--- a/.organizationmap
+++ b/.organizationmap
@@ -212,6 +212,7 @@ The Linux Box <contact@linuxbox.com> Casey Bodley <casey@linuxbox.com>
 The Linux Box <contact@linuxbox.com> Matt Benjamin <matt@linuxbox.com>
 The University of Arizona <contact@arizona.edu> James Ryan Cresawn <jrcresawn@gmail.com>
 Ubuntu Kylin <contact@ubuntukylin.com> Li Wang <liwang@ubuntukylin.com>
+Ubuntu Kylin <contact@ubuntukylin.com> Yunchuan Wen <yunchuanwen@ubuntukylin.com>
 Unaffiliated <no@organization.net> Yongyue Sun <abioy.sun@gmail.com>
 Unaffiliated <no@organization.net> Accela Zhao <accelazh@gmail.com>
 Unaffiliated <no@organization.net> Ailing Zhang <zhangal1992@gmail.com> 

--- a/.organizationmap
+++ b/.organizationmap
@@ -44,6 +44,7 @@ Cloudwatt <libre.licensing@cloudwatt.com> Christophe Courtaut <christophe.courta
 Cloudwatt <libre.licensing@cloudwatt.com> Florent Flament <florent.flament@cloudwatt.com>
 Cloudwatt <libre.licensing@cloudwatt.com> Loic Dachary <loic@dachary.org>
 Cloudwatt <libre.licensing@cloudwatt.com> Sahid Orentino Ferdjaoui <sahid.ferdjaoui@cloudwatt.com>
+CohortFS, LLC <contact@cohortfs.com> Matt Benjamin <matt@cohortfs.com>
 Commerce Guys <contact@commerceguys.com> Nikola Kotur <kotnick@gmail.com>
 Corvisa LLC <contact@corvisa.com> Walter Huf <hufman@gmail.com>
 Credit Mutuel Arkea <contact@arkea.com> Eric Mourgaya <eric.mourgaya@arkea.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -192,6 +192,7 @@ SanDisk <contact@sandisk.com> Anand Bhat <anand.bhat@sandisk.com>
 SanDisk <contact@sandisk.com> Pavan Rallabhandi <pavan.rallabhandi@sandisk.com>
 SanDisk <contact@sandisk.com> Somnath Roy <somnath.roy@sandisk.com>
 SanDisk <contact@sandisk.com> Sushma Gurram <sushma.gurram@sandisk.com>
+SanDisk	<contact@sandisk.com> Shishir Gowda <shishir.gowda@sandisk.com>
 Science & Technology Facilities Council <contact@stfc.ac.uk> George Ryall <george.ryall@stfc.ac.uk>
 SendFaster <contact@sendfaster.com> Christopher O'Connell <jwriteclub@gmail.com>
 Spectra Logic <contact@spectralogic.com> Alan Somers <asomers@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -243,6 +243,7 @@ Unaffiliated <no@organization.net> Mehdi Abaakouk <sileht@sileht.net>
 Unaffiliated <no@organization.net> Michal Jarzabek <stiopa@gmail.com>
 Unaffiliated <no@organization.net> Michael Nelson <mikenel@tnld.net>
 Unaffiliated <no@organization.net> Michael Riederer <michael@riederer.org>
+Unaffiliated <no@organization.net> Ning Yao <zay11022@gmail.com>
 Unaffiliated <no@organization.net> (no author) <(no author)@29311d96-e01e-0410-9327-a35deaab8ce9>
 Unaffiliated <no@organization.net> Roman Haritonov <reclosedev@gmail.com>
 Unaffiliated <no@organization.net> Shawn Edwards <lesser.evil@gmail.com>

--- a/.peoplemap
+++ b/.peoplemap
@@ -16,7 +16,7 @@
 # git log --pretty='%aN <%aE>' $range | git -c mailmap.file=.peoplemap check-mailmap --stdin | sort | uniq | sed -e 's/\(.*\) \(<.*\)/\2 \1/' | uniq --skip-field=1 --all-repeated | sed -e 's/\(.*>\) \(.*\)/\2 \1/'
 #
 Alexandre Marangone <amarango@redhat.com> Alexandre Marangone <alexandre.marangone@inktank.com>
-Alfredo Deza <adeza@redhat.com> Alfreda Deza <alfredo.deza@inktank.com>
+Alfredo Deza <adeza@redhat.com> Alfredo Deza <alfredo.deza@inktank.com>
 Dan Mick <dmick@redhat.com> Dan Mick <dan.mick@inktank.com>
 David Zafman <dzafman@redhat.com> David Zafman <david.zafman@inktank.com>
 Greg Farnum <gfarnum@redhat.com> Greg Farnum <greg@inktank.com>


### PR DESCRIPTION
cf:
http://wiki.ceph.com/Community/Ceph_contributors_list_maintenance_guide

Was preparing for V0.90 Ceph contributors list, using origin/next. As far as I can see, seems strictly not necessary for v0.90, but still , job is already done.
