### PR TITLE
osd/ReplicatedPG: initialize new_backfill in ctor

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1232,6 +1232,7 @@ ReplicatedPG::ReplicatedPG(OSDService *o, OSDMapRef curmap,
     PGBackend::build_pg_backend(
       _pool.info, curmap, this, coll_t(p), coll_t::make_temp_coll(p), o->store, cct)),
   snapset_contexts_lock("ReplicatedPG::snapset_contexts"),
+  new_backfill(false),
   temp_seq(0),
   snap_trimmer_machine(this)
 { 


### PR DESCRIPTION
**\* CID 1260213:  Uninitialized scalar field  (UNINIT_CTOR)
/osd/ReplicatedPG.cc: 1242 in ReplicatedPG::ReplicatedPG(OSDService *,
std::tr1::shared_ptr<const OSDMap>, const PGPool &, spg_t)()
1236       snap_trimmer_machine(this)
1237     {
1238       missing_loc.set_backend_predicates(
1239         pgbackend->get_is_readable_predicate(),
1240         pgbackend->get_is_recoverable_predicate());
1241       snap_trimmer_machine.initiate();

> > > ```
> > > CID 1260213:  Uninitialized scalar field  (UNINIT_CTOR)
> > > Non-static class member "new_backfill" is not initialized in this
> > > ```
> > > 
> > > constructor nor in any functions that it calls.
> > > 1242     }
> > > 1243
> > > 1244     void ReplicatedPG::get_src_oloc(const object_t& oid, const
> > > object_locator_t& oloc, object_locator_t& src_oloc)
> > > 1245     {
> > > 1246       src_oloc = oloc;
> > > 1247       if (oloc.key.empty())

Signed-off-by: Sage Weil sage@redhat.com
