### PR TITLE
mon/PGMap: restructure 'pg stat' formatted output

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -44,3 +44,8 @@ v0.90
   a bogus value (for example, when rados_watch() returns an error and
   handle is not defined).
 
+* The structure of the formatted 'pg stat' command is changed for the
+  portion that counts states by name to avoid using the '+' character
+  (which appears in state names) as part of the XML token (it is not
+  legal).
+

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1272,12 +1272,16 @@ void PGMap::print_oneline_summary(Formatter *f, ostream *out) const
   std::stringstream ss;
 
   if (f)
-    f->open_object_section("num_pg_by_state");
+    f->open_array_section("num_pg_by_state");
   for (ceph::unordered_map<int,int>::const_iterator p = num_pg_by_state.begin();
        p != num_pg_by_state.end();
        ++p) {
-    if (f)
-      f->dump_unsigned(pg_state_string(p->first).c_str(), p->second);
+    if (f) {
+      f->open_object_section("state");
+      f->dump_string("name", pg_state_string(p->first));
+      f->dump_unsigned("num", p->second);
+      f->close_section();
+    }
     if (p != num_pg_by_state.begin())
       ss << ", ";
     ss << p->second << " " << pg_state_string(p->first);


### PR DESCRIPTION
The + character, which appears in state names, is not a valid XML token.

Signed-off-by: Sage Weil sage@redhat.com
