### PR TITLE
osd: fix FileStore::_do_transaction assert bug

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -2474,7 +2474,7 @@ unsigned FileStore::_do_transaction(
         Transaction::Op *op2 = i.decode_op();
         coll_t ocid2 = i.get_cid(op2->cid);
         ghobject_t oid2 = i.get_oid(op2->oid);
-        assert(op->op == Transaction::OP_COLL_REMOVE);
+        assert(op2->op == Transaction::OP_COLL_REMOVE);
         assert(ocid2 == ocid);
         assert(oid2 == oid);
 


### PR DESCRIPTION
When process OP_COLL_ADD the assert should be applied to op2 not op.

Change-Id: I3ff7463a81583225be1288befdcd275148a9fbfe
Signed-off-by: Dong Yuan yuandong1222@gmail.com
