### PR TITLE
librados: only call watch_flush if necessary

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -282,9 +282,6 @@ int librados::RadosClient::connect()
 
 void librados::RadosClient::shutdown()
 {
-  // make sure watch callbacks are flushed
-  watch_flush();
-
   lock.Lock();
   if (state == DISCONNECTED) {
     lock.Unlock();
@@ -301,8 +298,11 @@ void librados::RadosClient::shutdown()
   instance_id = 0;
   timer.shutdown();   // will drop+retake lock
   lock.Unlock();
-  if (need_objecter)
+  if (need_objecter) {
+    // make sure watch callbacks are flushed
+    watch_flush();
     objecter->shutdown();
+  }
   monclient.shutdown();
   if (messenger) {
     messenger->shutdown();


### PR DESCRIPTION
Fix bug #10424
Signed-off-by: Haomai Wang haomaiwang@gmail.com
