### PR TITLE
PG:: append_log: duplicated PGLog transaction inserted in append_log

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2785,7 +2785,7 @@ void PG::append_log(
   }
 
   dout(10) << "append_log  adding " << keys.size() << " keys" << dendl;
-  t.omap_setkeys(META_COLL, log_oid, keys);
+  // t.omap_setkeys(META_COLL, log_oid, keys);  extra pg_log transaction here
 
   pg_log.trim(&handler, trim_to, info);
 

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -774,6 +774,7 @@ void PGLog::_write_log(
     keys[p->get_key_name()].claim(bl);
   }
 
+  //pg_log transaction will be correctly inserted here.
   for (list<pg_log_entry_t>::reverse_iterator p = log.log.rbegin();
        p != log.log.rend() &&
 	 (p->version >= dirty_from || p->version >= writeout_from) &&


### PR DESCRIPTION
Since append_log will call write_if_dirty any way, it always call the _write_log() in PGLog. While writeout_from will always updateto the first modified eversion of the pg_log, p->version >= writeout_from must be true so that it will be inserted all non-submitted pg_log to transaction in _write_log (where I mark in the code). Thus, there is no need to submit two exactly same transaction to the FileStore. it seems to be reasonable to remove the first one to improve the performance
In the dump of transaction information below,
    { "offset": 1215090688,
      "seq": 2040475,
      "transactions": [
            { "trans_num": 0,
              "ops": [
                    { "op_num": 0,
                      "op_name": "omap_setkeys",
                      "collection": "meta",
                      "oid": "5172fe8b\/pglog_0.76\/0\/\/-1",
                      "attr_lens": { "0000000198.00000000000000017999": 171}},
                    { "op_num": 1,
                      "op_name": "omap_setkeys",
                      "collection": "meta",
                      "oid": "16ef7597\/infos\/head\/\/-1",
                      "attr_lens": { "0.76_epoch": 4,
                          "0.76_info": 729}},
                    { "op_num": 2,
                      "op_name": "omap_rmkeys",
                      "collection": "meta",
                      "oid": "5172fe8b\/pglog_0.76\/0\/\/-1"},
                    { "op_num": 3,
                      "op_name": "omap_setkeys",
                      "collection": "meta",
                      "oid": "5172fe8b\/pglog_0.76\/0\/\/-1",
                      "attr_lens": { "0000000198.00000000000000017999": 171,
                          "can_rollback_to": 12}},
                    { "op_num": 4,
                      "op_name": "write",
                      "collection": "0.76_head",
                      "oid": "bd96de76\/rb.0.105c.6b8b4567.0000000013fa\/head\/\/0",
                      "length": 4096,
                      "offset": 4100096,
                      "bufferlist length": 4096},
                    { "op_num": 5,
                      "op_name": "setattr",
                      "collection": "0.76_head",
                      "oid": "bd96de76\/rb.0.105c.6b8b4567.0000000013fa\/head\/\/0",
                      "name": "_",
                      "length": 258},
                    { "op_num": 6,
                      "op_name": "setattr",
                      "collection": "0.76_head",
                      "oid": "bd96de76\/rb.0.105c.6b8b4567.0000000013fa\/head\/\/0",
                      "name": "snapset",
                      "length": 31}]}]},
Here is one of the write transaction, it also says that op_num: 0 is actually the same with op_num: 3.

so is it safe to do that? Maybe I will miss something.

Signed-off-by: Ning Yao zay11022@gmail.com
