### PR TITLE
10132: osd: tries to set ioprio when the config option is blank

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8498,6 +8498,9 @@ void OSD::set_disk_tp_priority()
 	   << " class " << cct->_conf->osd_disk_thread_ioprio_class
 	   << " priority " << cct->_conf->osd_disk_thread_ioprio_priority
 	   << dendl;
+  if (cct->_conf->osd_disk_thread_ioprio_class.empty() ||
+      cct->_conf->osd_disk_thread_ioprio_priority < 0)
+    return;
   int cls =
     ceph_ioprio_string_to_class(cct->_conf->osd_disk_thread_ioprio_class);
   if (cls < 0)


### PR DESCRIPTION
According to documentation, ioprio params will only be used if both
osd disk thread ioprio class and osd disk thread ioprio priority are
set to a non default value.

So, add a proper check and do not generate "set_disk_tp_priority(22)
Invalid argument" warning for the default settings.

http://tracker.ceph.com/issues/10132

Signed-off-by: Mykola Golub mgolub@mirantis.com
