### PR TITLE
PG:: filter_snapc: Return immediately if no snapc need to trim

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2999,6 +2999,10 @@ void PG::update_snap_map(
  */
 void PG::filter_snapc(vector<snapid_t> &snaps)
 {
+  //nothing needs to trim, we can return immediately
+  if(snap_trimq.empty() && info.purged_snaps.empty())
+    return;
+
   bool filtering = false;
   vector<snapid_t> newsnaps;
   for (vector<snapid_t>::iterator p = snaps.begin();


### PR DESCRIPTION
we can return immediately if no snapc need to trim. Do not iterater snapc vector and do extra judgement and ops.

Signed-off-by: Ning Yao zay11022@gmail.com
