### PR TITLE
Event: Avoid illegal multiplication for memset

### DIFF
--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -120,7 +120,7 @@ int EventCenter::create_file_event(int fd, int mask, EventCallbackRef ctxt)
       lderr(cct) << __func__ << " failed to realloc file_events" << cpp_strerror(errno) << dendl;
       return -errno;
     }
-    memset(file_events+sizeof(FileEvent)*nevent, 0, sizeof(FileEvent)*(new_size-nevent));
+    memset(file_events+nevent, 0, sizeof(FileEvent)*(new_size-nevent));
     file_events = new_events;
     nevent = new_size;
   }


### PR DESCRIPTION
Because "file_events" is "FileEvent" type and adding an integral value to
this pointer automatically scales that value by the size.

Signed-off-by: Haomai Wang haomaiwang@gmail.com
