### PR TITLE
libcephfs/test.cc: close fd before umount

### DIFF
--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -1096,6 +1096,7 @@ TEST(LibCephFS, GetOsdCrushLocation) {
     }
   }
 
+  ceph_close(cmount, fd);
   ceph_shutdown(cmount);
 }
 


### PR DESCRIPTION
Fixes: #10415
Signed-off-by: Yan, Zheng zyan@redhat.com
(cherry picked from commit d3fb563cee4c4cf08ff4ee01782e52a100462429)
