### PR TITLE
KeyValueStore:: do_transactions: clean up code which is never used

### DIFF
--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -1159,15 +1159,6 @@ int KeyValueStore::_do_transactions(list<Transaction*> &tls, uint64_t op_seq,
   ThreadPool::TPHandle *handle)
 {
   int r = 0;
-
-  uint64_t bytes = 0, ops = 0;
-  for (list<Transaction*>::iterator p = tls.begin();
-       p != tls.end();
-       ++p) {
-    bytes += (*p)->get_num_bytes();
-    ops += (*p)->get_num_ops();
-  }
-
   int trans_num = 0;
   BufferTransaction bt(this);
 


### PR DESCRIPTION
clean up ops and bytes which is never used in do_transactions()

Signed-off-by: Ning Yao zay11022@gmail.com
