### PR TITLE
doc: rm reference to old Ubuntu release

### DIFF
--- a/doc/rados/deployment/preflight-checklist.rst
+++ b/doc/rados/deployment/preflight-checklist.rst
@@ -16,9 +16,9 @@ daemons.
 Install an Operating System
 ===========================
 
-Install a recent release of Debian or Ubuntu (e.g., 12.04, 12.10) on your
-nodes. For additional details on operating systems or to use other operating
-systems other than Debian or Ubuntu, see `OS Recommendations`_.
+Install a recent release of Debian or Ubuntu (e.g., 12.04 LTS, 14.04 LTS) on
+your nodes. For additional details on operating systems or to use other
+operating systems other than Debian or Ubuntu, see `OS Recommendations`_.
 
 
 Install an SSH Server


### PR DESCRIPTION
Remove the reference to "Ubuntu 12.10" since this is EOL.

Clarify that we only recommend Ubuntu LTS releases.

(Since this information has a tendancy to become stale, perhaps this whole paragraph should be removed here and we should simply point at the main "OS Recommendations" page.)