### PR TITLE
pybind: ceph_argparse: validate incorrectly formed targets

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -425,7 +425,12 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
                 if interactive_input in ['q', 'quit', 'Q']:
                     return 0, '', ''
                 cmdargs = parse_cmdargs(interactive_input.split())[2]
-                target = find_cmd_target(cmdargs)
+                try:
+                    target = find_cmd_target(cmdargs)
+                except Exception as e:
+                    print >> sys.stderr, \
+                            'error handling command target: {0}'.format(e)
+                    return 1
                 valid_dict = validate_command(sigdict, cmdargs, verbose)
                 if valid_dict:
                     if parsed_args.output_format:
@@ -753,7 +758,12 @@ def main():
     if parsed_args.status:
         childargs.insert(0, 'status')
 
-    target = find_cmd_target(childargs)
+    try:
+        target = find_cmd_target(childargs)
+    except Exception as e:
+        print >> sys.stderr, \
+                'error handling command target: {0}'.format(e)
+        return 1
 
     # Repulsive hack to handle tell: lop off 'tell' and target
     # and validate the rest of the command.  'target' is already

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -42,15 +42,18 @@ if MYDIR.endswith('src') and \
 
     py_binary = os.environ.get("PYTHON", "python")
     MYLIBPATH = os.path.join(MYDIR, '.libs')
+    execv_cmd = ['python']
+    if 'CEPH_DBG' in os.environ:
+        execv_cmd += ['-mpdb']
     if lib_path_var in os.environ:
         if MYLIBPATH not in os.environ[lib_path_var]:
             os.environ[lib_path_var] += ':' + MYLIBPATH
             print >> sys.stderr, DEVMODEMSG
-            os.execvp(py_binary, ['python'] + sys.argv)
+            os.execvp(py_binary, execv_cmd + sys.argv)
     else:
         os.environ[lib_path_var] = MYLIBPATH
         print >> sys.stderr, DEVMODEMSG
-        os.execvp(py_binary, ['python'] + sys.argv)
+        os.execvp(py_binary, execv_cmd + sys.argv)
     sys.path.insert(0, os.path.join(MYDIR, 'pybind'))
     if os.environ.has_key('PATH') and MYDIR not in os.environ['PATH']:
         os.environ['PATH'] += ':' + MYDIR


### PR DESCRIPTION
Prior to this patch find_cmd_target() would perform the following
parsing for any given command:

- check if it's a "tell" to a parseable CephName
  (i.e., ceph tell <type.id> ...)
  - if so, return <type>, <id>

- check if it's a "tell" to a parseable PG id
  (e.g., ceph tell 0.4a)
  - if so, return 'pg', <pgid>

- check if it's a "pg" command to a parseable PG id
  (e.g., ceph pg 0.4a)
  - if so, return 'pg', <pgid>

- otherwise return 'mon', ''

However, parsing of CephName and CephPgid is performed in a relaxed
fashion, and tightening those checks requirements end up having
nefarious effects on properly formed commands, whereas keeping them
relaxed ends up having us returning 'mon','' in the end for a clearly
malformed target (e.g., 'ceph tell foo ...').

This patch fixes this behavior by adding a new check:

- if command is a "tell" and we were not able to parse either a CephName
  nor a PG id, then explicitely validate the target as a CephName (given
  we would be sending to a monitor anyway, we can just as well validate
  a 'tell' as a CephName).
  - if validation fails, we will propagate exceptions referring to the
    cause of the validation failure.

Fixes: #10439

Signed-off-by: Joao Eduardo Luis <joao@redhat.com>