### PR TITLE
Coverity and SCA fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,35 +87,38 @@ AC_SUBST(AM_CXXFLAGS)
 AM_CXXFLAGS="${AM_CXXFLAGS}"
 
 # Check for yasm
-if yasm -f elf64 src/common/crc32c_intel_fast_asm.S -o /dev/null; then
-   echo 'we have a modern and working yasm'
-   if test `arch` = "x86_64" ; then
-      echo 'we are x86_64'
-      arch_x32=0
-      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
-        #if defined(__x86_64__) && defined(__ILP32__)
-        #error x32
-        #endif]])], [], [arch_x32=1])
-      if test $arch_x32 -eq 0 ; then
-         echo 'we are not x32'
-         AC_DEFINE([HAVE_GOOD_YASM_ELF64], [1], [we have a recent yasm and are x86_64])
-         with_good_yasm=yes
-
-         if yasm -f elf64 -i src/ceph/src/ceph/src/erasure-code/isa/isa-l/include/ src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm.s -o /dev/null 2> /dev/null ; then
-            echo 'yasm can also build the isa-l stuff'
-            AC_DEFINE([HAVE_BETTER_YASM_ELF64], [1], [yasm can also build the isa-l])
-	    with_better_yasm=yes
-         else
-            echo "yasm doesn't build the isa-l stuff"
-	 fi
-      else
-         echo 'we are x32; no yasm for you'
-      fi
-   else
-      echo 'we are not x86_64 && !x32'
-   fi
-else
-   echo 'we do not have a modern/working yasm'
+AC_CHECK_PROG(YASM_CHECK, yasm, yes)
+if test x"$YASM_CHECK" = x"yes"; then
+  if yasm -f elf64 src/common/crc32c_intel_fast_asm.S -o /dev/null; then
+     echo 'we have a modern and working yasm'
+     if test `arch` = "x86_64" ; then
+        echo 'we are x86_64'
+        arch_x32=0
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+          #if defined(__x86_64__) && defined(__ILP32__)
+          #error x32
+          #endif]])], [], [arch_x32=1])
+        if test $arch_x32 -eq 0 ; then
+           echo 'we are not x32'
+           AC_DEFINE([HAVE_GOOD_YASM_ELF64], [1], [we have a recent yasm and are x86_64])
+           with_good_yasm=yes
+  
+           if yasm -f elf64 -i src/ceph/src/ceph/src/erasure-code/isa/isa-l/include/ src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm.s -o /dev/null 2> /dev/null ; then
+              echo 'yasm can also build the isa-l stuff'
+              AC_DEFINE([HAVE_BETTER_YASM_ELF64], [1], [yasm can also build the isa-l])
+  	    with_better_yasm=yes
+           else
+              echo "yasm doesn't build the isa-l stuff"
+  	 fi
+        else
+           echo 'we are x32; no yasm for you'
+        fi
+     else
+        echo 'we are not x86_64 && !x32'
+     fi
+  else
+     echo 'we do not have a modern/working yasm'
+  fi
 fi
 AM_CONDITIONAL(WITH_GOOD_YASM_ELF64, test "$with_good_yasm" = "yes")
 AM_CONDITIONAL(WITH_BETTER_YASM_ELF64, test "$with_better_yasm" = "yes")
@@ -293,11 +296,11 @@ AC_ARG_WITH([profiler],
             [with_profiler=no])
 AS_IF([test "x$with_profiler" = xyes],
 	    [AC_CHECK_LIB([profiler], [ProfilerFlush], [],
-	        	  [AC_MSG_FAILURE([--with-profiler was given but libprofiler (libgoogle-perftools-dev on debian) not found])]),
-             AC_LANG_PUSH([C++]),
+	        	  [AC_MSG_FAILURE([--with-profiler was given but libprofiler (libgoogle-perftools-dev on debian) not found])])
+             AC_LANG_PUSH([C++])
              AC_CHECK_HEADERS([gperftools/heap-profiler.h \
                gperftools/malloc_extension.h \
-               gperftools/profiler.h]),
+               gperftools/profiler.h])
              AC_LANG_POP([C++])
             ],
 	    [])

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2070,7 +2070,7 @@ void Client::handle_osd_map(MOSDMap *m)
     // (i.e. we only need to know which inodes had outstanding ops, not the exact
     // op-to-inode relation)
     for (unordered_map<vinodeno_t,Inode*>::iterator i = inode_map.begin();
-         i != inode_map.end(); i++)
+         i != inode_map.end(); ++i)
     {
       Inode *inode = i->second;
       if (inode->oset.dirty_or_tx) {

--- a/src/common/Cycles.cc
+++ b/src/common/Cycles.cc
@@ -57,7 +57,7 @@ void Cycles::init()
   // After 10ms have elapsed, take the ratio between these readings.
 
   struct timeval start_time, stop_time;
-  uint64_t start_cycles, stop_cycles, micros;
+  uint64_t start_cycles, micros;
   double old_cycles;
 
   // There is one tricky aspect, which is that we could get interrupted
@@ -75,7 +75,7 @@ void Cycles::init()
       if (gettimeofday(&stop_time, NULL) != 0) {
         assert(0 == "couldn't read clock");
       }
-      stop_cycles = rdtsc();
+      uint64_t stop_cycles = rdtsc();
       micros = (stop_time.tv_usec - start_time.tv_usec) +
           (stop_time.tv_sec - start_time.tv_sec)*1000000;
       if (micros > 10000) {

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -405,7 +405,7 @@ CephContext::~CephContext()
   join_service_thread();
 
   for (map<string, AssociatedSingletonObject*>::iterator it = _associated_objs.begin();
-       it != _associated_objs.end(); it++)
+       it != _associated_objs.end(); ++it)
     delete it->second;
 
   if (_conf->lockdep) {

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -1,4 +1,5 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
  *
@@ -154,6 +155,10 @@ int ObjBencher::aio_bench(
   int operation, int secondsToRun,
   int maxObjectsToCreate,
   int concurrentios, int op_size, bool cleanup, const char* run_name) {
+
+  if (concurrentios <= 0) 
+    return -EINVAL;
+
   int object_size = op_size;
   int num_objects = 0;
   int r = 0;
@@ -286,6 +291,9 @@ int ObjBencher::fetch_bench_metadata(const std::string& metadata_file, int* obje
 
 int ObjBencher::write_bench(int secondsToRun, int maxObjectsToCreate,
 			    int concurrentios, const string& run_name_meta) {
+  if (concurrentios <= 0) 
+    return -EINVAL;
+
   if (maxObjectsToCreate > 0 && concurrentios > maxObjectsToCreate)
     concurrentios = maxObjectsToCreate;
   out(cout) << "Maintaining " << concurrentios << " concurrent writes of "
@@ -484,6 +492,10 @@ int ObjBencher::write_bench(int secondsToRun, int maxObjectsToCreate,
 
 int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurrentios, int pid) {
   lock_cond lc(&lock);
+
+  if (concurrentios <= 0) 
+    return -EINVAL;
+
   std::vector<string> name(concurrentios);
   std::string newName;
   bufferlist* contents[concurrentios];
@@ -668,6 +680,10 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
 int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurrentios, int pid)
 {
   lock_cond lc(&lock);
+
+  if (concurrentios <= 0) 
+    return -EINVAL;
+ 
   std::vector<string> name(concurrentios);
   std::string newName;
   bufferlist* contents[concurrentios];
@@ -883,6 +899,10 @@ int ObjBencher::clean_up(const char* prefix, int concurrentios, const char* run_
 
 int ObjBencher::clean_up(int num_objects, int prevPid, int concurrentios) {
   lock_cond lc(&lock);
+  
+  if (concurrentios <= 0) 
+    return -EINVAL;
+
   std::vector<string> name(concurrentios);
   std::string newName;
   int r = 0;
@@ -1043,6 +1063,10 @@ bool ObjBencher::more_objects_matching_prefix(const std::string& prefix, std::li
 
 int ObjBencher::clean_up_slow(const std::string& prefix, int concurrentios) {
   lock_cond lc(&lock);
+
+  if (concurrentios <= 0) 
+    return -EINVAL;
+
   std::vector<string> name(concurrentios);
   std::string newName;
   int r = 0;

--- a/src/common/obj_bencher.h
+++ b/src/common/obj_bencher.h
@@ -1,4 +1,5 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
  *

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -84,7 +84,7 @@ bool PerfCountersCollection::reset(const std::string &name)
   if (!strcmp(name.c_str(), "all"))  {
     while (i != i_end) {
       (*i)->reset();
-      i++;
+      ++i;
     }
     result = true;
   } else {
@@ -94,7 +94,7 @@ bool PerfCountersCollection::reset(const std::string &name)
 	result = true;
 	break;
       }
-      i++;
+      ++i;
     }
   }
 
@@ -260,7 +260,7 @@ void PerfCounters::reset()
 
   while (d != d_end) {
     d->reset();
-    d++;
+    ++d;
   }
 }
 

--- a/src/crush/crush.c
+++ b/src/crush/crush.c
@@ -141,6 +141,9 @@ int crush_addition_is_unsafe(__u32 a, __u32 b)
 
 int crush_multiplication_is_unsafe(__u32  a, __u32 b)
 {
+  // prevent division by zero 
+  if (!b)
+    return 1;
   if ((((__u32)(-1)) / b) < a)
     return 1;
   else

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -668,7 +668,6 @@ librados::NObjectIterator::~NObjectIterator()
 librados::NObjectIterator::NObjectIterator(const NObjectIterator &rhs)
 {
   if (rhs.impl == NULL) {
-    delete impl;
     impl = NULL;
     return;
   }
@@ -4707,7 +4706,6 @@ librados::ListObject::ListObject(librados::ListObjectImpl *i): impl(i)
 librados::ListObject::ListObject(const ListObject& rhs)
 {
   if (rhs.impl == NULL) {
-    delete impl;
     impl = NULL;
     return;
   }

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -240,7 +240,7 @@ public:
   Capability(CInode *i = NULL, uint64_t id = 0, client_t c = 0) : 
     inode(i), client(c),
     cap_id(id),
-    _wanted(0),
+    _wanted(0), num_revoke_warnings(0),
     _pending(0), _issued(0),
     last_sent(0),
     last_issue(0),

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -184,7 +184,7 @@ class C_ReopenComplete : public MDSInternalContext {
   MDLog *mdlog;
   MDSInternalContextBase *on_complete;
 public:
-  C_ReopenComplete(MDLog *mdlog_, MDSInternalContextBase *on_complete_) : MDSInternalContext(mdlog->mds), mdlog(mdlog_), on_complete(on_complete_) {}
+  C_ReopenComplete(MDLog *mdlog_, MDSInternalContextBase *on_complete_) : MDSInternalContext(mdlog_->mds), mdlog(mdlog_), on_complete(on_complete_) {}
   void finish(int r) {
     mdlog->append();
     on_complete->complete(r);

--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -432,7 +432,6 @@ int MDS::_command_flush_journal(std::stringstream *ss)
   // Attach contexts to wait for all expiring segments to expire
   MDSGatherBuilder expiry_gather(g_ceph_context);
 
-  std::list<C_SaferCond*> expired_ctxs;
   const std::set<LogSegment*> &expiring_segments = mdlog->get_expiring_segments();
   for (std::set<LogSegment*>::const_iterator i = expiring_segments.begin();
        i != expiring_segments.end(); ++i) {

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3955,7 +3955,8 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur,
       pi->add_old_pool(old_pool);
       pi->layout = layout;
       pi->ctime = mdr->get_op_stamp();
-    } else if (name.find("ceph.quota") == 0) {
+    } else {
+      // expect this to be "ceph.quota"
       if (!cur->is_dir() || cur->is_root()) {
         respond_to_request(mdr, -EINVAL);
         return;

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -301,7 +301,6 @@ int AsyncConnection::_try_send(bufferlist send_bl, bool send)
     return -EINTR;
   }
 
-  int r = 0;
   uint64_t sent = 0;
   list<bufferptr>::const_iterator pb = outcoming_bl.buffers().begin();
   uint64_t left_pbrs = outcoming_bl.buffers().size();
@@ -322,7 +321,7 @@ int AsyncConnection::_try_send(bufferlist send_bl, bool send)
       size--;
     }
 
-    r = do_sendmsg(msg, msglen, false);
+    int r = do_sendmsg(msg, msglen, false);
     if (r < 0)
       return r;
 

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -291,13 +291,12 @@ void Worker::stop()
 void *Worker::entry()
 {
   ldout(cct, 10) << __func__ << " starting" << dendl;
-  int r;
 
   center.set_owner(pthread_self());
   while (!done) {
     ldout(cct, 20) << __func__ << " calling event process" << dendl;
 
-    r = center.process_events(30000000);
+    int r = center.process_events(30000000);
     if (r < 0) {
       ldout(cct, 20) << __func__ << " process events failed: "
                           << cpp_strerror(errno) << dendl;

--- a/src/msg/async/EventSelect.cc
+++ b/src/msg/async/EventSelect.cc
@@ -66,14 +66,14 @@ int SelectDriver::resize_events(int newsize)
 
 int SelectDriver::event_wait(vector<FiredFileEvent> &fired_events, struct timeval *tvp)
 {
-  int retval, j, numevents = 0;
+  int retval, numevents = 0;
 
   memcpy(&_rfds, &rfds, sizeof(fd_set));
   memcpy(&_wfds, &wfds, sizeof(fd_set));
 
   retval = select(max_fd+1, &_rfds, &_wfds, NULL, tvp);
   if (retval > 0) {
-    for (j = 0; j <= max_fd; j++) {
+    for (int j = 0; j <= max_fd; j++) {
       int mask = 0;
       struct FiredFileEvent fe;
       if (FD_ISSET(j, &_rfds))

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -2257,7 +2257,7 @@ int KeyValueStore::collection_getattr(coll_t c, const char *name,
     r = -EINVAL;
   }
 
-  if (out.size()) {
+  if (!out.empty()) {
     bl.swap(out.begin()->second);
     r = bl.length();
   } else {

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
 
 #include "include/types.h"
 #include "msg/Message.h"
@@ -106,21 +108,21 @@ int ClassHandler::_load_class(ClassData *cls)
 	     cls->name.c_str());
     dout(10) << "_load_class " << cls->name << " from " << fname << dendl;
 
-    struct stat st;
-    int r = ::stat(fname, &st);
-    if (r < 0) {
-      r = -errno;
-      dout(0) << __func__ << " could not stat class " << fname
-	      << ": " << cpp_strerror(r) << dendl;
-      return r;
-    }
-
     cls->handle = dlopen(fname, RTLD_NOW);
     if (!cls->handle) {
-      dout(0) << "_load_class could not open class " << fname
-	      << " (dlopen failed): " << dlerror() << dendl;
+      struct stat st;
+      int r = ::stat(fname, &st);
+      if (r < 0) {
+        r = -errno;
+        dout(0) << __func__ << " could not stat class " << fname
+                << ": " << cpp_strerror(r) << dendl;
+      } else {
+	dout(0) << "_load_class could not open class " << fname
+      	        << " (dlopen failed): " << dlerror() << dendl;
+      	r = -EIO;
+      }
       cls->status = ClassData::CLASS_MISSING;
-      return -EIO;
+      return r;
     }
 
     cls_deps_t *(*cls_deps)();

--- a/src/test/bench/tp_bench.cc
+++ b/src/test/bench/tp_bench.cc
@@ -99,8 +99,8 @@ class PassAlong : public ThreadPool::WorkQueue<unsigned> {
   void _clear() { q.clear(); }
   bool _empty() { return q.empty(); }
 public:
-  PassAlong(ThreadPool *tp, Queueable *next) :
-    ThreadPool::WorkQueue<unsigned>("TestQueue", 100, 100, tp), next(next) {}
+  PassAlong(ThreadPool *tp, Queueable *_next) :
+    ThreadPool::WorkQueue<unsigned>("TestQueue", 100, 100, tp), next(_next) {}
 };
 
 int main(int argc, char **argv)

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -175,6 +175,7 @@ TEST(LibRadosAio, TooBig) {
                                          my_completion, buf, UINT_MAX));
   ASSERT_EQ(-E2BIG, rados_aio_append(test_data.m_ioctx, "foo",
                                      my_completion, buf, UINT_MAX));
+  rados_aio_release(my_completion);
 }
 
 TEST(LibRadosAio, TooBigPP) {

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -187,6 +187,7 @@ TEST(LibRadosAio, TooBigPP) {
   ASSERT_EQ(-E2BIG, test_data.m_ioctx.aio_write("foo", aio_completion, bl, UINT_MAX, 0));
   ASSERT_EQ(-E2BIG, test_data.m_ioctx.aio_append("foo", aio_completion, bl, UINT_MAX));
   // ioctx.aio_write_full no way to overflow bl.length()
+  delete aio_completion;
 }
 
 TEST(LibRadosAio, SimpleWrite) {

--- a/src/test/librados/snapshots.cc
+++ b/src/test/librados/snapshots.cc
@@ -161,6 +161,8 @@ TEST_F(LibRadosSnapshotsPP, SnapCreateRemovePP) {
 
   EXPECT_EQ(0, ioctx.snap_remove("snapfoo"));
   EXPECT_EQ(0, ioctx.snap_remove("snapbar"));
+
+  delete op;
 }
 
 TEST_F(LibRadosSnapshotsSelfManaged, Snap) {

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -342,14 +342,14 @@ class OSDStub : public TestStub
   };
 
 
-  OSDStub(int whoami, CephContext *cct)
+  OSDStub(int _whoami, CephContext *cct)
     : TestStub(cct, "osd"),
       auth_handler_registry(new AuthAuthorizeHandlerRegistry(
 				  cct,
 				  cct->_conf->auth_cluster_required.length() ?
 				  cct->_conf->auth_cluster_required :
 				  cct->_conf->auth_supported)),
-      whoami(whoami),
+      whoami(_whoami),
       gen(whoami),
       mon_osd_rng(STUB_MON_OSD_FIRST, STUB_MON_OSD_LAST)
   {

--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -55,15 +55,9 @@ int main(int argc, const char **argv)
   argv_to_vec(argc, argv, args);
   env_to_vec(args);
 
-  bool gen_key = false;
-  bool gen_print_key = false;
   std::string add_key;
-  bool list = false;
-  bool print_key = false;
-  bool create_keyring = false;
   std::string caps_fn;
   std::string import_keyring;
-  bool set_auid = false;
   uint64_t auid = CEPH_AUTH_UID_DEFAULT;
   map<string,bufferlist> caps;
   std::string fn;
@@ -71,7 +65,15 @@ int main(int argc, const char **argv)
   try {
     global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
   	      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+
+    bool gen_key = false;
+    bool gen_print_key = false;
+    bool list = false;
+    bool print_key = false;
+    bool create_keyring = false;
+    bool set_auid = false;
     std::vector<const char*>::iterator i;
+
     for (i = args.begin(); i != args.end(); ) {
       std::string val;
       if (ceph_argparse_double_dash(args, i)) {

--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -365,7 +365,7 @@ int main(int argc, char **argv) {
       goto done;
     }
 
-    if (v <= 0) {
+    if (v == 0) {
       v = st.get(map_type, "last_committed");
     }
 

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -467,7 +467,7 @@ struct pgid_object_list {
       f->open_array_section("pgid_objects");
     for (list<pair<coll_t, ghobject_t> >::const_iterator i = _objects.begin();
 	 i != _objects.end();
-	 i++) {
+	 ++i) {
       if (i != _objects.begin() && human_readable) {
         f->flush(cout);
         cout << std::endl;
@@ -2415,7 +2415,7 @@ int main(int argc, char **argv)
 	    pgidstr = object_pgidstr;
 	    pgid = object_pgid;
 	  }
-	  i++;
+	  ++i;
 	  v = *i;
 	}
 	try {

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -358,11 +358,10 @@ struct action_on_object_t {
 int _action_on_all_objects_in_pg(ObjectStore *store, coll_t coll, action_on_object_t &action, bool debug)
 {
   unsigned LIST_AT_A_TIME = 100;
-  int r;
   ghobject_t next;
   while (!next.is_max()) {
     vector<ghobject_t> list;
-    r = store->collection_list_partial(
+    int r = store->collection_list_partial(
 				       coll,
 				       next,
 				       LIST_AT_A_TIME,


### PR DESCRIPTION
Coverity:
- CID 1242020
- CID 1242018
- CID 1260395
- CID 1256099
- CID 1256100
- CID 1238902
- CID 1128404/1128405/1219644-1219646
- CID 1219471
- CID 743419

SCA fixes like:
- unsigned can't be less than zero
- remove unused variable
- reduce scope of variables
- init variables in constructor
- fix error about self init
- prefer ++operator for non-primitive iterators
- prefer !empty() over size() for emptiness check

Misc:
- fix -Wsign-compare
- fix -Wmaybe-uninitialized
- small fixes for configure.ac to solve unknown commands warnings.
