### PR TITLE
rbd: merge diff files

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -190,6 +190,14 @@ Commands
   metadata about image size changes, and the start and end snapshots.  It efficiently represents
   discarded or 'zero' regions of the image.
 
+:command:`merge-diff` [*first-diff-path*] [*second-diff-path*] [*merged-diff-path*]
+  Merge two continuous incremental diffs of an image into one single diff. The
+  first diff's end snapshot must be equal with the second diff's start snapshot.
+  The first diff could be - for stdin, and merged diff could be - for stdout, which
+  enables multiple diff files to be merged using something like
+  'rbd merge-diff first second - | rbd merge-diff - third result'. Note this command
+  currently only support the source incremental diff with stripe_count == 1
+
 :command:`import-diff` [*src-path*] [*image-name*]
   Imports an incremental diff of an image and applies it to the current image.  If the diff
   was generated relative to a start snapshot, we verify that snapshot already exists before

--- a/qa/workunits/rbd/merge_diff.sh
+++ b/qa/workunits/rbd/merge_diff.sh
@@ -1,0 +1,475 @@
+#!/bin/bash
+
+pool=rbd
+gen=$pool/gen
+out=$pool/out
+
+set -x
+
+mkdir -p merge_diff_test
+pushd merge_diff_test
+
+function expect_false()
+{
+  if "$@"; then return 1; else return 0; fi
+}
+
+function clear_all()
+{
+  umount mnt || true
+  while [ 1 ];
+  do
+    rbd snap purge $gen 2>/dev/null >/dev/null
+    rbd rm $gen 2>/dev/null >/dev/null
+    rbd snap purge $out 2>/dev/null >/dev/null
+    rbd rm $out 2>/dev/null >/dev/null
+
+    sleep 5
+
+    rbd info $gen 2>/dev/null >/dev/null && continue
+    rbd info $out 2>/dev/null >/dev/null && continue
+
+    break
+  done
+  rm -rf diffs
+}
+
+function rebuild()
+{
+  clear_all
+  rbd create $gen --size 100 --order $1 --stripe_unit $2 --stripe_count $3 --image-format $4
+  rbd create $out --size 1 --order 19
+  mkdir -p mnt diffs
+  rbd-fuse -p $pool mnt
+}
+
+function write()
+{
+  dd if=/dev/urandom of=mnt/gen bs=1M conv=notrunc seek=$1 count=$2
+}
+
+function snap()
+{
+  rbd snap create $gen@$1
+}
+
+function resize()
+{
+  rbd resize $gen --size $1 --allow-shrink
+}
+
+function export_diff()
+{
+  if [ $2 == "head" ]; then
+    target="$gen"
+  else
+    target="$gen@$2"
+  fi
+  if [ $1 == "null" ]; then
+    rbd export-diff $target diffs/$1.$2
+  else
+    rbd export-diff $target --from-snap $1 diffs/$1.$2
+  fi
+}
+
+function merge_diff()
+{
+  rbd merge-diff diffs/$1.$2 diffs/$2.$3 diffs/$1.$3
+}
+
+function check()
+{
+  rbd import-diff diffs/$1.$2 $out || return -1
+  if [ "$2" == "head" ]; then
+    sum1=`rbd export $gen - | md5sum`
+  else
+    sum1=`rbd export $gen@$2 - | md5sum`
+  fi
+  sum2=`rbd export $out - | md5sum`
+  if [ "$sum1" != "$sum2" ]; then
+    exit -1
+  fi
+  if [ "$2" != "head" ]; then
+    rbd snap ls $out | awk '{print $2}' | grep "^$2\$" || return -1
+  fi
+}
+
+#test f/t header
+rebuild 22 4194304 1 2
+write 0 1
+snap a
+write 1 1
+export_diff null a
+export_diff a head
+merge_diff null a head
+check null head
+
+rebuild 22 4194304 1 2
+write 0 1
+snap a
+write 1 1
+snap b
+write 2 1
+export_diff null a
+export_diff a b
+export_diff b head
+merge_diff null a b
+check null b
+
+rebuild 22 4194304 1 2
+write 0 1
+snap a
+write 1 1
+snap b
+write 2 1
+export_diff null a
+export_diff a b
+export_diff b head
+merge_diff a b head
+check null a
+check a head
+
+rebuild 22 4194304 1 2
+write 0 1
+snap a
+write 1 1
+snap b
+write 2 1
+export_diff null a
+export_diff a b
+export_diff b head
+rbd merge-diff diffs/null.a diffs/a.b - | rbd merge-diff - diffs/b.head - > diffs/null.head
+check null head
+
+#data test
+rebuild 22 4194304 1 2
+write 4 2
+snap s101
+write 0 3
+write 8 2
+snap s102
+export_diff null s101
+export_diff s101 s102
+merge_diff null s101 s102
+check null s102
+
+rebuild 22 4194304 1 2
+write 0 3
+write 2 5
+write 8 2
+snap s201
+write 0 2
+write 6 3
+snap s202
+export_diff null s201
+export_diff s201 s202
+merge_diff null s201 s202
+check null s202
+
+rebuild 22 4194304 1 2
+write 0 4
+write 12 6
+snap s301
+write 0 6
+write 10 5
+write 16 4
+snap s302
+export_diff null s301
+export_diff s301 s302
+merge_diff null s301 s302
+check null s302
+
+rebuild 22 4194304 1 2
+write 0 12
+write 14 2
+write 18 2
+snap s401
+write 1 2
+write 5 6
+write 13 3
+write 18 2
+snap s402
+export_diff null s401
+export_diff s401 s402
+merge_diff null s401 s402
+check null s402
+
+rebuild 22 4194304 1 2
+write 2 4
+write 10 12
+write 27 6
+write 36 4
+snap s501
+write 0 24
+write 28 4
+write 36 4
+snap s502
+export_diff null s501
+export_diff s501 s502
+merge_diff null s501 s502
+check null s502
+
+rebuild 22 4194304 1 2
+write 0 8
+resize 5
+snap r1
+resize 20
+write 12 8
+snap r2
+resize 8
+write 4 4
+snap r3
+export_diff null r1
+export_diff r1 r2
+export_diff r2 r3
+merge_diff null r1 r2
+merge_diff null r2 r3
+check null r3
+
+rebuild 22 4194304 1 2
+write 0 8
+resize 5
+snap r1
+resize 20
+write 12 8
+snap r2
+resize 8
+write 4 4
+snap r3
+resize 10
+snap r4
+export_diff null r1
+export_diff r1 r2
+export_diff r2 r3
+export_diff r3 r4
+merge_diff null r1 r2
+merge_diff null r2 r3
+merge_diff null r3 r4
+check null r4
+
+rebuild 22 65536 8 2
+write 0 32
+snap r1
+write 16 32
+snap r2
+export_diff null r1
+export_diff r1 r2
+expect_false merge_diff null r1 r2
+
+rebuild 22 4194304 1 2
+write 0 1
+write 2 1
+write 4 1
+write 6 1
+snap s1
+write 1 1
+write 3 1
+write 5 1
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 1 1
+write 3 1
+write 5 1
+snap s1
+write 0 1
+write 2 1
+write 4 1
+write 6 1
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 0 3
+write 6 3
+write 12 3
+snap s1
+write 1 1
+write 7 1
+write 13 1
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 0 3
+write 6 3
+write 12 3
+snap s1
+write 0 1
+write 6 1
+write 12 1
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 0 3
+write 6 3
+write 12 3
+snap s1
+write 2 1
+write 8 1
+write 14 1
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 1 1
+write 7 1
+write 13 1
+snap s1
+write 0 3
+write 6 3
+write 12 3
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 0 1
+write 6 1
+write 12 1
+snap s1
+write 0 3
+write 6 3
+write 12 3
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 2 1
+write 8 1
+write 14 1
+snap s1
+write 0 3
+write 6 3
+write 12 3
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 0 3
+write 6 3
+write 12 3
+snap s1
+write 0 3
+write 6 3
+write 12 3
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 2 4
+write 8 4
+write 14 4
+snap s1
+write 0 3
+write 6 3
+write 12 3
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 0 4
+write 6 4
+write 12 4
+snap s1
+write 0 3
+write 6 3
+write 12 3
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 0 6
+write 6 6
+write 12 6
+snap s1
+write 0 3
+write 6 3
+write 12 3
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 3 6
+write 9 6
+write 15 6
+snap s1
+write 0 3
+write 6 3
+write 12 3
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 0 8
+snap s1
+resize 2
+resize 100
+snap s2
+export_diff null s1
+export_diff s1 s2
+merge_diff null s1 s2
+check null s2
+
+rebuild 22 4194304 1 2
+write 0 8
+snap s1
+resize 2
+resize 100
+snap s2
+write 20 2
+snap s3
+export_diff null s1
+export_diff s1 s2
+export_diff s2 s3
+merge_diff s1 s2 s3
+check null s1
+check s1 s3
+
+#addme
+
+clear_all
+popd
+rm -rf merge_diff_test
+
+exit 0

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -2101,7 +2101,8 @@ int main(int argc, const char **argv)
     *dest_poolname = NULL, *dest_snapname = NULL, *path = NULL,
     *devpath = NULL, *lock_cookie = NULL, *lock_client = NULL,
     *lock_tag = NULL, *output_format = "plain",
-    *fromsnapname = NULL;
+    *fromsnapname = NULL,
+    *first_diff = NULL, *second_diff = NULL;
   bool lflag = false;
   int pretty_format = 0;
   long long stripe_unit = 0, stripe_count = 0;
@@ -2288,6 +2289,9 @@ if (!set_conf_param(v, p1, p2, p3)) { \
       case OPT_EXPORT_DIFF:
 	SET_CONF_PARAM(v, &imgname, &path, NULL);
 	break;
+      case OPT_MERGE_DIFF:
+        SET_CONF_PARAM(v, &first_diff, &second_diff, &path);
+        break;
       case OPT_IMPORT:
       case OPT_IMPORT_DIFF:
 	SET_CONF_PARAM(v, &path, &imgname, NULL);
@@ -2392,7 +2396,8 @@ if (!set_conf_param(v, p1, p2, p3)) { \
       opt_cmd != OPT_IMPORT &&
       opt_cmd != OPT_IMPORT_DIFF &&
       opt_cmd != OPT_UNMAP &&
-      opt_cmd != OPT_SHOWMAPPED && !imgname) {
+      opt_cmd != OPT_SHOWMAPPED &&
+      opt_cmd != OPT_MERGE_DIFF && !imgname) {
     cerr << "rbd: image name was not specified" << std::endl;
     return EXIT_FAILURE;
   }
@@ -2446,6 +2451,20 @@ if (!set_conf_param(v, p1, p2, p3)) { \
   if (!dest_poolname)
     dest_poolname = "rbd";
 
+  if (opt_cmd == OPT_MERGE_DIFF) {
+    if (!first_diff) {
+      cerr << "rbd: first diff was not specified" << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (!second_diff) {
+      cerr << "rbd: second diff was not specified" << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (!path) {
+      cerr << "rbd: path was not specified" << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
   if (opt_cmd == OPT_EXPORT && !path)
     path = imgname;
 

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -103,6 +103,10 @@ void usage()
 "  export-diff <image-name> [--from-snap <snap-name>] <path>\n"
 "                                              export an incremental diff to\n"
 "                                              path, or \"-\" for stdout\n"
+"  merge-diff <diff1> <diff2> <path>           merge <diff1> and <diff2> into\n"
+"                                              <path>, <diff1> could be \"-\"\n"
+"                                              for stdin, and <path> could be \"-\"\n"
+"                                              for stdout\n"
 "  import-diff <path> <image-name>             import an incremental diff from\n"
 "                                              path or \"-\" for stdin\n"
 "  (cp | copy) <src> <dest>                    copy src image to dest\n"
@@ -1965,6 +1969,7 @@ enum {
   OPT_LOCK_ADD,
   OPT_LOCK_REMOVE,
   OPT_BENCH_WRITE,
+  OPT_MERGE_DIFF,
 };
 
 static int get_cmd(const char *cmd, bool snapcmd, bool lockcmd)
@@ -1991,6 +1996,8 @@ static int get_cmd(const char *cmd, bool snapcmd, bool lockcmd)
       return OPT_EXPORT;
     if (strcmp(cmd, "export-diff") == 0)
       return OPT_EXPORT_DIFF;
+    if (strcmp(cmd, "merge-diff") == 0)
+      return OPT_MERGE_DIFF;
     if (strcmp(cmd, "diff") == 0)
       return OPT_DIFF;
     if (strcmp(cmd, "import") == 0)

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -25,6 +25,10 @@
     export-diff <image-name> [--from-snap <snap-name>] <path>
                                                 export an incremental diff to
                                                 path, or "-" for stdout
+    merge-diff <diff1> <diff2> <path>           merge <diff1> and <diff2> into
+                                                <path>, <diff1> could be "-"
+                                                for stdin, and <path> could be "-"
+                                                for stdout
     import-diff <path> <image-name>             import an incremental diff from
                                                 path or "-" for stdin
     (cp | copy) <src> <dest>                    copy src image to dest


### PR DESCRIPTION
RBD supplies the 'export-diff' to export a diff file between two clones.
This is inconvinient for periodical backup, since a bunch of diff files 
wastes the disk space by keeping multiple copies of the data on the 
same location, and complicates and slows down the recovery process.
In this case, only one diff file is expected. This motivates us to develop 
a 'merge-diff' tool. The semantic is straightforward, it merges two diff 
files into one single diff  file. Multiple diff files could be easily merged 
by further using some simple shell tricks.