### PR TITLE
configure: show package name when libkeyutils is missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,7 @@ dnl check for libkeyutils on linux
 KEYUTILS_LIB=""
 AS_IF([test x"$linux" = x"yes"], [
   AC_CHECK_LIB([keyutils], [add_key], [KEYUTILS_LIB="-lkeyutils"], [
-    AC_MSG_FAILURE([libkeyutils not found])])])
+    AC_MSG_FAILURE([libkeyutils not found (libkeyutils-dev, keyutils-libs-devel)])])])
 AC_SUBST(KEYUTILS_LIB)
 
 AC_CHECK_LIB([m], [pow], [true], AC_MSG_FAILURE([libm not found]))


### PR DESCRIPTION
Prior to this commit, when `./configure` can't find libkeyutils, it would bail out with a terse error message.
    
Some of the other library checks helpfully print the DEB and RPM package names in parentheses. Add the DEB and RPM package names to the libkeyutils check.

Reported-by: Pankaj Garg <Pankaj.Garg@caviumnetworks.com>