### PR TITLE
client: fix use-after-free bug in unmount()

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4637,9 +4637,8 @@ void Client::unmount()
   while (!fd_map.empty()) {
     Fh *fh = fd_map.begin()->second;
     fd_map.erase(fd_map.begin());
-    int release_err = _release_fh(fh);
-    ldout(cct, 0) << " destroyed lost open file " << fh << " on " << *fh->inode << "(async_err = " << release_err << ")" << dendl;
-
+    ldout(cct, 0) << " destroyed lost open file " << fh << " on " << *fh->inode << dendl;
+    _release_fh(fh);
   }
 
   _ll_drop_pins();


### PR DESCRIPTION
If there is error, _release_fh() already outputs error message.
No need to print extra error message

Fixes: #10412
Signed-off-by: Yan, Zheng <zyan@redhat.com>