### PR TITLE
os/FileStore: verify kernel is new enough before using extsize ioctl

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -746,10 +746,11 @@ OPTION(filestore_fsync_flushes_journal_data, OPT_BOOL, false)
 OPTION(filestore_fiemap, OPT_BOOL, false)     // (try to) use fiemap
 OPTION(filestore_fadvise, OPT_BOOL, true)
 
-// (try to) use extsize for alloc hint
-// WARNING: extsize seems to trigger data corruption in xfs -- that is why it is
-// off by default, see bug #8830
-OPTION(filestore_xfs_extsize, OPT_BOOL, false)
+// (try to) use extsize for alloc hint NOTE: extsize seems to trigger
+// data corruption in xfs prior to kernel 3.5.  filestore will
+// implicity disable this if it cannot confirm the kernel is newer
+// than that.
+OPTION(filestore_xfs_extsize, OPT_BOOL, true)
 
 OPTION(filestore_journal_parallel, OPT_BOOL, false)
 OPTION(filestore_journal_writeahead, OPT_BOOL, false)


### PR DESCRIPTION
Old kernels have an XFS bug that exposes uninitialized data when the
extsize hint is set and only partially written.  This is fixed by Linux
commit aff3a9edb7080f69f07fe76a8bd089b3dfa4cb5d, documented in XFS bug
http://oss.sgi.com/bugzilla/show_bug.cgi?id=874, and tested by XFS
test xfs/229 to prevent regressions.

Notably the original bug affects kernel 3.2, which is widely deployed with
ubuntu precise 12.04.

Reenable this option.  It will be automagically used only on new kernels
that are unaffected by the bug.

This partially reverts 01cd3cdc726a3e838bce05b355a021778b4e5db1.

Fixes: #9956
Signed-off-by: Sage Weil <sage@redhat.com>