### PR TITLE
osd: compress data in recovery process

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -126,7 +126,7 @@ LIBCOMMON_DEPS += \
 	$(LIBCRUSH) $(LIBJSON_SPIRIT) $(LIBLOG) $(LIBARCH)
 
 if LINUX
-LIBCOMMON_DEPS += -lrt
+LIBCOMMON_DEPS += -lrt -llz4
 endif # LINUX
 
 libcommon_la_SOURCES =

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -31,6 +31,8 @@
 #include <sys/uio.h>
 #include <limits.h>
 
+#include "lz4.h"
+
 namespace ceph {
 
 #ifdef BUFFER_DEBUG
@@ -1808,6 +1810,28 @@ void buffer::list::write_stream(std::ostream &out) const
   }
 }
 
+void buffer::list::compress(compression_type alg, list& dest)
+{
+  const char* pch_src = c_str();
+  uint32_t input_size = length();
+  if (alg == ALG_LZ4) {
+    uint32_t max_compressed_size = LZ4_compressBound(input_size);
+    bufferptr bp = buffer::create_page_aligned(max_compressed_size);
+    uint32_t actual = LZ4_compress(pch_src, bp.c_str(), input_size);
+    bp.set_length(actual);
+    dest.append(bp);
+  }
+}
+
+void buffer::list::decompress(compression_type alg, list& dest, uint32_t len)
+{
+  const char* pch_src = c_str();
+  if (alg == ALG_LZ4) {
+    bufferptr bp = buffer::create_page_aligned(len);
+    LZ4_decompress_fast(pch_src, bp.c_str(), len);
+    dest.append(bp);
+  }
+}
 
 void buffer::list::hexdump(std::ostream &out) const
 {

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -511,6 +511,7 @@ OPTION(osd_disk_threads, OPT_INT, 1)
 OPTION(osd_disk_thread_ioprio_class, OPT_STR, "") // rt realtime be best effort idle
 OPTION(osd_disk_thread_ioprio_priority, OPT_INT, -1) // 0-7
 OPTION(osd_recovery_threads, OPT_INT, 1)
+OPTION(osd_recovery_data_compression, OPT_BOOL, true)
 OPTION(osd_recover_clone_overlap, OPT_BOOL, true)   // preserve clone_overlap during recovery/migration
 OPTION(osd_op_num_threads_per_shard, OPT_INT, 2)
 OPTION(osd_op_num_shards, OPT_INT, 5)

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -100,6 +100,9 @@ public:
     int code;
   };
 
+  enum compression_type {
+    ALG_LZ4,
+  };
 
   /// total bytes allocated
   static int get_total_alloc();
@@ -494,6 +497,8 @@ public:
     int write_fd(int fd) const;
     int write_fd_zero_copy(int fd) const;
     uint32_t crc32c(uint32_t crc) const;
+    void compress(compression_type alg, list& dest);
+    void decompress(compression_type alg, list& dest, uint32_t len);
   };
 
   /*

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8944,7 +8944,15 @@ bool ReplicatedBackend::handle_pull_response(
 {
   interval_set<uint64_t> data_included = pop.data_included;
   bufferlist data;
-  data.claim(pop.data);
+  if (pop.compression) {
+    pop.data.decompress(buffer::ALG_LZ4, data, pop.src_len);
+    if (data.crc32c(0) != pop.src_data_crc) {
+      dout(10) << __func__ << pop << " crc error!" << dendl;
+      assert(0);
+    }
+  } else {
+    data.claim(pop.data);
+  }
   dout(10) << "handle_pull_response "
 	   << pop.recovery_info
 	   << pop.after_progress
@@ -9047,7 +9055,15 @@ void ReplicatedBackend::handle_push(
 	   << pop.after_progress
 	   << dendl;
   bufferlist data;
-  data.claim(pop.data);
+  if (pop.compression) {
+    pop.data.decompress(buffer::ALG_LZ4, data, pop.src_len);
+    if (data.crc32c(0) != pop.src_data_crc) {
+      dout(10) << __func__ << pop << " crc error!" << dendl;
+      assert(0);
+    }
+  } else {
+    data.claim(pop.data);
+  }
   bool first = pop.before_progress.first;
   bool complete = pop.after_progress.data_complete &&
     pop.after_progress.omap_complete;
@@ -9260,6 +9276,15 @@ int ReplicatedBackend::build_push_op(const ObjectRecoveryInfo &recovery_info,
       new_progress.data_complete = true;
     }
     out_op->data.claim_append(bit);
+  }
+
+  if (cct->_conf->osd_recovery_data_compression) {
+    out_op->compression = true;
+    bufferlist dest;
+    out_op->data.compress(buffer::ALG_LZ4, dest);
+    out_op->src_len = out_op->data.length();
+    out_op->src_data_crc = out_op->data.crc32c(0);
+    out_op->data.swap(dest);
   }
 
   if (new_progress.is_complete(recovery_info)) {

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4401,7 +4401,7 @@ void PushOp::generate_test_instances(list<PushOp*> &o)
 
 void PushOp::encode(bufferlist &bl) const
 {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   ::encode(soid, bl);
   ::encode(version, bl);
   ::encode(data, bl);
@@ -4412,12 +4412,15 @@ void PushOp::encode(bufferlist &bl) const
   ::encode(recovery_info, bl);
   ::encode(after_progress, bl);
   ::encode(before_progress, bl);
+  ::encode(compression, bl);
+  ::encode(src_len, bl);
+  ::encode(src_data_crc, bl);
   ENCODE_FINISH(bl);
 }
 
 void PushOp::decode(bufferlist::iterator &bl)
 {
-  DECODE_START(1, bl);
+  DECODE_START(2, bl);
   ::decode(soid, bl);
   ::decode(version, bl);
   ::decode(data, bl);
@@ -4428,6 +4431,13 @@ void PushOp::decode(bufferlist::iterator &bl)
   ::decode(recovery_info, bl);
   ::decode(after_progress, bl);
   ::decode(before_progress, bl);
+  if (struct_v >= 2) {
+    ::decode(compression, bl);
+    ::decode(src_len, bl);
+    ::decode(src_data_crc, bl);
+  } else {
+    compression = false;
+  }
   DECODE_FINISH(bl);
 }
 
@@ -4455,6 +4465,9 @@ void PushOp::dump(Formatter *f) const
     before_progress.dump(f);
     f->close_section();
   }
+  f->dump_bool("compression", compression);
+  f->dump_int("src_len", src_len);
+  f->dump_int("src_data_crc", src_data_crc);
 }
 
 ostream &PushOp::print(ostream &out) const
@@ -4470,6 +4483,9 @@ ostream &PushOp::print(ostream &out) const
     << ", recovery_info: " << recovery_info
     << ", after_progress: " << after_progress
     << ", before_progress: " << before_progress
+    << ", compression: " << compression
+    << ", src_len: " << src_len
+    << ", src_data_crc: " << src_data_crc
     << ")";
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3308,6 +3308,10 @@ struct PushOp {
   ObjectRecoveryProgress before_progress;
   ObjectRecoveryProgress after_progress;
 
+  bool compression;
+  uint32_t src_len;
+  uint32_t src_data_crc;
+
   static void generate_test_instances(list<PushOp*>& o);
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &bl);
@@ -3315,6 +3319,8 @@ struct PushOp {
   void dump(Formatter *f) const;
 
   uint64_t cost(CephContext *cct) const;
+
+  PushOp() : compression(false) {}
 };
 WRITE_CLASS_ENCODER(PushOp)
 ostream& operator<<(ostream& out, const PushOp &op);


### PR DESCRIPTION
Ceph may run out of network bandwith in recovery process, compress data if needed. 

By default, I will use lz4. Maybe we can shoose any compression algorithm by user as ec pools does.

To run of my patch, First of all, we should install lz4 from https://code.google.com/p/lz4/.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>