### PR TITLE
Split ceph-devel and python-ceph packages

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -131,20 +131,6 @@ BuildRequires:	fuse-devel
 %description -n rbd-fuse
 FUSE based client to map Ceph rbd images to files
 
-%package devel
-Summary:	Ceph headers
-Group:		Development/Libraries
-License:	LGPL-2.0
-Requires:	%{name} = %{epoch}:%{version}-%{release}
-Requires:	librados2 = %{epoch}:%{version}-%{release}
-Requires:	libradosstriper1 = %{epoch}:%{version}-%{release}
-Requires:	librbd1 = %{epoch}:%{version}-%{release}
-Requires:	libcephfs1 = %{epoch}:%{version}-%{release}
-Requires:	libcephfs_jni1 = %{epoch}:%{version}-%{release}
-%description devel
-This package contains libraries and headers needed to develop programs
-that use Ceph.
-
 %package radosgw
 Summary:	Rados REST gateway
 Group:		Development/Libraries
@@ -189,6 +175,16 @@ developed as part of the Ceph distributed storage system. This is a
 shared library allowing applications to access the distributed object
 store using a simple file-like interface.
 
+%package -n librados2-devel
+Summary:	RADOS headers
+Group:		Development/Libraries
+License:	LGPL-2.0
+Requires:	librados2 = %{epoch}:%{version}-%{release}
+Obsoletes:	ceph-devel
+%description -n librados2-devel
+This package contains libraries and headers needed to develop programs
+that use RADOS object store.
+
 %package -n libradosstriper1
 Summary:	RADOS striping interface
 Group:		System Environment/Libraries
@@ -198,6 +194,16 @@ Requires:	librados2 = %{epoch}:%{version}
 Striping interface built on top of the rados library, allowing
 to stripe bigger objects onto several standard rados objects using
 an interface very similar to the rados one.
+
+%package -n libradosstriper1-devel
+Summary:	RADOS striping interface headers
+Group:		Development/Libraries
+License:	LGPL-2.0
+Requires:	libradosstriper1 = %{epoch}:%{version}-%{release}
+Requires:	librados2-devel = %{epoch}:%{version}-%{release}
+%description -n libradosstriper1-devel
+This package contains libraries and headers needed to develop programs
+that use RADOS striping interface.
 
 %package -n librbd1
 Summary:	RADOS block device client library
@@ -213,6 +219,17 @@ RADOS, a reliable, autonomic distributed object storage cluster
 developed as part of the Ceph distributed storage system. This is a
 shared library allowing applications to manage these block devices.
 
+%package -n librbd1-devel
+Summary:	RADOS block device headers
+Group:		Development/Libraries
+License:	LGPL-2.0
+Requires:	librbd1 = %{epoch}:%{version}-%{release}
+Requires:	librados2-devel = %{epoch}:%{version}-%{release}
+Obsoletes:	ceph-devel
+%description -n librbd1-devel
+This package contains libraries and headers needed to develop programs
+that use RADOS block device.
+
 %package -n libcephfs1
 Summary:	Ceph distributed file system client library
 Group:		System Environment/Libraries
@@ -226,6 +243,17 @@ Ceph is a distributed network file system designed to provide excellent
 performance, reliability, and scalability. This is a shared library
 allowing applications to access a Ceph distributed file system via a
 POSIX-like interface.
+
+%package -n libcephfs1-devel
+Summary:	Ceph distributed file system headers
+Group:		Development/Libraries
+License:	LGPL-2.0
+Requires:	libcephfs1 = %{epoch}:%{version}-%{release}
+Requires:	librados2-devel = %{epoch}:%{version}-%{release}
+Obsoletes:	ceph-devel
+%description -n libcephfs1-devel
+This package contains libraries and headers needed to develop programs
+that use Cephs distributed file system.
 
 %package -n python-ceph
 Summary:	Python libraries for the Ceph distributed filesystem
@@ -273,6 +301,16 @@ BuildRequires:	java-devel
 This package contains the Java Native Interface library for CephFS Java
 bindings.
 
+%package -n libcephfs_jni1-devel
+Summary:	Development files for CephFS Java Native Interface library.
+Group:		System Environment/Libraries
+License:	LGPL-2.0
+Requires:	java
+Requires:	libcephfs_jni1 = %{epoch}:%{version}-%{release}
+%description -n libcephfs_jni1-devel
+This package contains the development files for CephFS Java Native Interface
+library.
+
 %package -n cephfs-java
 Summary:	Java libraries for the Ceph File System.
 Group:		System Environment/Libraries
@@ -301,6 +339,24 @@ is included for backwards compatibility with distributions that depend on the
 former ceph-libs package, which is now split up into these three subpackages.
 Packages still depending on ceph-libs should be fixed to depend on librados2,
 librbd1 or libcephfs1 instead.
+
+%package devel-compat
+Summary:	Compatibility package for Ceph headers
+Group:		Development/Libraries
+License:	LGPL-2.0
+Obsoletes:	ceph-devel
+Requires:	%{name} = %{epoch}:%{version}-%{release}
+Requires:	librados2-devel = %{epoch}:%{version}-%{release}
+Requires:	libradosstriper1-devel = %{epoch}:%{version}-%{release}
+Requires:	librbd1-devel = %{epoch}:%{version}-%{release}
+Requires:	libcephfs1-devel = %{epoch}:%{version}-%{release}
+Requires:	libcephfs_jni1-devel = %{epoch}:%{version}-%{release}
+Provides:	ceph-devel
+%description devel-compat
+This is a compatibility package to accommodate ceph-devel split into
+librados2-devel, librbd1-devel and libcephfs1-devel. Packages still depending
+on ceph-devel should be fixed to depend on librados2-devel, librbd1-devel,
+libcephfs1-devel or libradosstriper1-devel instead.
 
 %if 0%{?opensuse} || 0%{?suse_version}
 %debug_package
@@ -581,33 +637,6 @@ fi
 %{_mandir}/man8/rbd-fuse.8*
 
 #################################################################################
-%files devel
-%defattr(-,root,root,-)
-%dir %{_includedir}/cephfs
-%{_includedir}/cephfs/libcephfs.h
-%dir %{_includedir}/rados
-%{_includedir}/rados/librados.h
-%{_includedir}/rados/librados.hpp
-%{_includedir}/rados/buffer.h
-%{_includedir}/rados/page.h
-%{_includedir}/rados/crc32c.h
-%{_includedir}/rados/rados_types.h
-%{_includedir}/rados/rados_types.hpp
-%{_includedir}/rados/memory.h
-%dir %{_includedir}/radosstriper
-%{_includedir}/radosstriper/libradosstriper.h
-%{_includedir}/radosstriper/libradosstriper.hpp
-%dir %{_includedir}/rbd
-%{_includedir}/rbd/librbd.h
-%{_includedir}/rbd/librbd.hpp
-%{_includedir}/rbd/features.h
-%{_libdir}/libcephfs.so
-%{_libdir}/librbd.so
-%{_libdir}/librados.so
-%{_libdir}/libradosstriper.so
-%{_libdir}/libcephfs_jni.so
-
-#################################################################################
 %files radosgw
 %defattr(-,root,root,-)
 %{_initrddir}/ceph-radosgw
@@ -664,6 +693,20 @@ fi
 /sbin/ldconfig
 
 #################################################################################
+%files -n librados2-devel
+%defattr(-,root,root,-)
+%dir %{_includedir}/rados
+%{_includedir}/rados/librados.h
+%{_includedir}/rados/librados.hpp
+%{_includedir}/rados/buffer.h
+%{_includedir}/rados/page.h
+%{_includedir}/rados/crc32c.h
+%{_includedir}/rados/rados_types.h
+%{_includedir}/rados/rados_types.hpp
+%{_includedir}/rados/memory.h
+%{_libdir}/librados.so
+
+#################################################################################
 %files -n libradosstriper1
 %defattr(-,root,root,-)
 %{_libdir}/libradosstriper.so.*
@@ -673,6 +716,14 @@ fi
 
 %postun -n libradosstriper1
 /sbin/ldconfig
+
+#################################################################################
+%files -n libradosstriper1-devel
+%defattr(-,root,root,-)
+%dir %{_includedir}/radosstriper
+%{_includedir}/radosstriper/libradosstriper.h
+%{_includedir}/radosstriper/libradosstriper.hpp
+%{_libdir}/libradosstriper.so
 
 #################################################################################
 %files -n librbd1
@@ -693,6 +744,15 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 /sbin/ldconfig
 
 #################################################################################
+%files -n librbd1-devel
+%defattr(-,root,root,-)
+%dir %{_includedir}/rbd
+%{_includedir}/rbd/librbd.h
+%{_includedir}/rbd/librbd.hpp
+%{_includedir}/rbd/features.h
+%{_libdir}/librbd.so
+
+#################################################################################
 %files -n libcephfs1
 %defattr(-,root,root,-)
 %{_libdir}/libcephfs.so.*
@@ -702,6 +762,13 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 
 %postun -n libcephfs1
 /sbin/ldconfig
+
+#################################################################################
+%files -n libcephfs1-devel
+%defattr(-,root,root,-)
+%dir %{_includedir}/cephfs
+%{_includedir}/cephfs/libcephfs.h
+%{_libdir}/libcephfs.so
 
 #################################################################################
 %files -n python-ceph
@@ -752,17 +819,30 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_bindir}/rbd-replay-prep
 %endif
 
+#################################################################################
 %files -n libcephfs_jni1
 %defattr(-,root,root,-)
 %{_libdir}/libcephfs_jni.so.*
 
+#################################################################################
+%files -n libcephfs_jni1-devel
+%defattr(-,root,root,-)
+%{_libdir}/libcephfs_jni.so
+
+#################################################################################
 %files -n cephfs-java
 %defattr(-,root,root,-)
 %{_javadir}/libcephfs.jar
 %{_javadir}/libcephfs-test.jar
 
+#################################################################################
 %files libs-compat
 # We need an empty %%files list for ceph-libs-compat, to tell rpmbuild to actually
 # build this meta package.
+
+#################################################################################
+%files devel-compat
+# We need an empty %%files list for ceph-devel-compat, to tell rpmbuild to
+# actually build this meta package.
 
 %changelog

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -24,7 +24,9 @@ Requires:	librbd1 = %{epoch}:%{version}-%{release}
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 Requires:	libcephfs1 = %{epoch}:%{version}-%{release}
 Requires:	ceph-common = %{epoch}:%{version}-%{release}
-Requires:	python-ceph = %{epoch}:%{version}-%{release}
+Requires:	python-rados = %{epoch}:%{version}-%{release}
+Requires:	python-rbd = %{epoch}:%{version}-%{release}
+Requires:	python-cephfs = %{epoch}:%{version}-%{release}
 Requires:	python
 Requires:	python-argparse
 Requires:	python-requests
@@ -107,7 +109,9 @@ Summary:	Ceph Common
 Group:		System Environment/Base
 Requires:	librbd1 = %{epoch}:%{version}-%{release}
 Requires:	librados2 = %{epoch}:%{version}-%{release}
-Requires:	python-ceph = %{epoch}:%{version}-%{release}
+Requires:	python-rados = %{epoch}:%{version}-%{release}
+Requires:	python-rbd = %{epoch}:%{version}-%{release}
+Requires:	python-cephfs = %{epoch}:%{version}-%{release}
 Requires:	python-requests
 Requires:	redhat-lsb-core
 %description -n ceph-common
@@ -185,6 +189,19 @@ Obsoletes:	ceph-devel
 This package contains libraries and headers needed to develop programs
 that use RADOS object store.
 
+%package -n python-rados
+Summary:	Python libraries for the RADOS object store
+Group:		System Environment/Libraries
+License:	LGPL-2.0
+Requires:	librados2 = %{epoch}:%{version}-%{release}
+Obsoletes:	python-ceph
+%if 0%{defined suse_version}
+%py_requires
+%endif
+%description -n python-rados
+This package contains Python libraries for interacting with Cephs RADOS
+object store.
+
 %package -n libradosstriper1
 Summary:	RADOS striping interface
 Group:		System Environment/Libraries
@@ -230,6 +247,17 @@ Obsoletes:	ceph-devel
 This package contains libraries and headers needed to develop programs
 that use RADOS block device.
 
+%package -n python-rbd
+Summary:	Python libraries for the RADOS block device
+Group:		System Environment/Libraries
+License:	LGPL-2.0
+Requires:	librbd1 = %{epoch}:%{version}-%{release}
+Requires:	python-rados = %{epoch}:%{version}-%{release}
+Obsoletes:	python-ceph
+%description -n python-rbd
+This package contains Python libraries for interacting with Cephs RADOS
+block device.
+
 %package -n libcephfs1
 Summary:	Ceph distributed file system client library
 Group:		System Environment/Libraries
@@ -255,18 +283,16 @@ Obsoletes:	ceph-devel
 This package contains libraries and headers needed to develop programs
 that use Cephs distributed file system.
 
-%package -n python-ceph
-Summary:	Python libraries for the Ceph distributed filesystem
+%package -n python-cephfs
+Summary:	Python libraries for Ceph distributed file system
 Group:		System Environment/Libraries
 License:	LGPL-2.0
-Requires:	librados2 = %{epoch}:%{version}-%{release}
-Requires:	librbd1 = %{epoch}:%{version}-%{release}
-%if 0%{defined suse_version}
-%py_requires
-%endif
-%description -n python-ceph
-This package contains Python libraries for interacting with Cephs RADOS
-object storage.
+Requires:	libcephfs1 = %{epoch}:%{version}-%{release}
+Requires:	python-rados = %{epoch}:%{version}-%{release}
+Obsoletes:	python-ceph
+%description -n python-cephfs
+This package contains Python libraries for interacting with Cephs distributed
+file system.
 
 %package -n rest-bench
 Summary:	RESTful benchmark
@@ -357,6 +383,21 @@ This is a compatibility package to accommodate ceph-devel split into
 librados2-devel, librbd1-devel and libcephfs1-devel. Packages still depending
 on ceph-devel should be fixed to depend on librados2-devel, librbd1-devel,
 libcephfs1-devel or libradosstriper1-devel instead.
+
+%package -n python-ceph-compat
+Summary:	Compatibility package for Cephs python libraries
+Group:		System Environment/Libraries
+License:	LGPL-2.0
+Obsoletes:	python-ceph
+Requires:	python-rados = %{epoch}:%{version}-%{release}
+Requires:	python-rbd = %{epoch}:%{version}-%{release}
+Requires:	python-cephfs = %{epoch}:%{version}-%{release}
+Provides:	python-ceph
+%description -n python-ceph-compat
+This is a compatibility package to accommodate python-ceph split into
+python-rados, python-rbd and python-cephfs. Packages still depending on
+python-ceph should be fixed to depend on python-rados, python-rbd or
+python-cephfs instead.
 
 %if 0%{?opensuse} || 0%{?suse_version}
 %debug_package
@@ -611,6 +652,7 @@ fi
 %config %{_sysconfdir}/bash_completion.d/rbd
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap
 %{_initrddir}/rbdmap
+%{python_sitelib}/ceph_argparse.py*
 
 %postun -n ceph-common
 # Package removal cleanup
@@ -707,6 +749,11 @@ fi
 %{_libdir}/librados.so
 
 #################################################################################
+%files -n python-rados
+%defattr(-,root,root,-)
+%{python_sitelib}/rados.py*
+
+#################################################################################
 %files -n libradosstriper1
 %defattr(-,root,root,-)
 %{_libdir}/libradosstriper.so.*
@@ -753,6 +800,11 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_libdir}/librbd.so
 
 #################################################################################
+%files -n python-rbd
+%defattr(-,root,root,-)
+%{python_sitelib}/rbd.py*
+
+#################################################################################
 %files -n libcephfs1
 %defattr(-,root,root,-)
 %{_libdir}/libcephfs.so.*
@@ -771,12 +823,9 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_libdir}/libcephfs.so
 
 #################################################################################
-%files -n python-ceph
+%files -n python-cephfs
 %defattr(-,root,root,-)
-%{python_sitelib}/rados.py*
-%{python_sitelib}/rbd.py*
 %{python_sitelib}/cephfs.py*
-%{python_sitelib}/ceph_argparse.py*
 
 #################################################################################
 %files -n rest-bench
@@ -843,6 +892,11 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 #################################################################################
 %files devel-compat
 # We need an empty %%files list for ceph-devel-compat, to tell rpmbuild to
+# actually build this meta package.
+
+#################################################################################
+%files -n python-ceph-compat
+# We need an empty %%files list for python-ceph-compat, to tell rpmbuild to
 # actually build this meta package.
 
 %changelog


### PR DESCRIPTION
This is a request to split the ceph-devel and python-ceph packages in upstream spec file (we already do this for fedora and rhel). This is a newer version for the request that does the split in two patches and was rebased on top of latest master. See https://github.com/ceph/ceph/pull/2900 for the previous pull request.