### PR TITLE
OSD: add a get_latest_osdmap command to the admin socket

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1085,6 +1085,7 @@ private:
   bool paused_recovery;
 
   void set_disk_tp_priority();
+  void get_latest_osdmap();
 
   // -- sessions --
 public:


### PR DESCRIPTION
The command blocks and ensures we have the latest map from the
mon. This is useful in testing and to "unstick" clusters in some
odd situations.

Fixes: #9483, #9484 (maybe)
Signed-off-by: Mykola Golub <mgolub@mirantis.com>