### PR TITLE
mds: support constness in MDSCacheObjects

### DIFF
--- a/src/include/frag.h
+++ b/src/include/frag.h
@@ -191,7 +191,7 @@ public:
 
   // -------------
   // accessors
-  bool empty() { 
+  bool empty() const { 
     return _splits.empty();
   }
   int get_split(const frag_t hb) const {

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -43,7 +43,7 @@ LockType CDentry::versionlock_type(CEPH_LOCK_DVERSION);
 
 // CDentry
 
-ostream& operator<<(ostream& out, CDentry& dn)
+ostream& operator<<(ostream& out, const CDentry& dn)
 {
   filepath path;
   dn.make_path(path);
@@ -137,7 +137,7 @@ inodeno_t CDentry::get_ino()
 }
 */
 
-mds_authority_t CDentry::authority()
+mds_authority_t CDentry::authority() const
 {
   return dir->authority();
 }
@@ -213,7 +213,7 @@ void CDentry::mark_new()
   state_set(STATE_NEW);
 }
 
-void CDentry::make_path_string(string& s)
+void CDentry::make_path_string(string& s) const
 {
   if (dir) {
     dir->inode->make_path_string(s);
@@ -224,7 +224,7 @@ void CDentry::make_path_string(string& s)
   s.append(name.data(), name.length());
 }
 
-void CDentry::make_path(filepath& fp)
+void CDentry::make_path(filepath& fp) const
 {
   assert(dir);
   if (dir->inode->is_base())
@@ -330,7 +330,7 @@ CDentry::linkage_t *CDentry::pop_projected_linkage()
 // ----------------------------
 // auth pins
 
-int CDentry::get_num_dir_auth_pins()
+int CDentry::get_num_dir_auth_pins() const
 {
   assert(!is_projected());
   if (get_linkage()->is_primary())
@@ -338,7 +338,7 @@ int CDentry::get_num_dir_auth_pins()
   return auth_pins;
 }
 
-bool CDentry::can_auth_pin()
+bool CDentry::can_auth_pin() const
 {
   assert(dir);
   return dir->can_auth_pin();
@@ -394,12 +394,12 @@ void CDentry::adjust_nested_auth_pins(int adjustment, int diradj, void *by)
   dir->adjust_nested_auth_pins(adjustment, diradj, by);
 }
 
-bool CDentry::is_frozen()
+bool CDentry::is_frozen() const
 {
   return dir->is_frozen();
 }
 
-bool CDentry::is_freezing()
+bool CDentry::is_freezing() const
 {
   return dir->is_freezing();
 }

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -79,7 +79,7 @@ public:
   static const int PIN_INODEPIN =     1;  // linked inode is pinned
   static const int PIN_FRAGMENTING = -2;  // containing dir is refragmenting
   static const int PIN_PURGING =      3;
-  const char *pin_name(int p) {
+  const char *pin_name(int p) const {
     switch (p) {
     case PIN_INODEPIN: return "inodepin";
     case PIN_FRAGMENTING: return "fragmenting";
@@ -118,13 +118,14 @@ public:
 
     // dentry type is primary || remote || null
     // inode ptr is required for primary, optional for remote, undefined for null
-    bool is_primary() { return remote_ino == 0 && inode != 0; }
-    bool is_remote() { return remote_ino > 0; }
-    bool is_null() { return remote_ino == 0 && inode == 0; }
+    bool is_primary() const { return remote_ino == 0 && inode != 0; }
+    bool is_remote() const { return remote_ino > 0; }
+    bool is_null() const { return remote_ino == 0 && inode == 0; }
 
     CInode *get_inode() { return inode; }
-    inodeno_t get_remote_ino() { return remote_ino; }
-    unsigned char get_remote_d_type() { return remote_d_type; }
+    const CInode *get_inode() const { return inode; }
+    inodeno_t get_remote_ino() const { return remote_ino; }
+    unsigned char get_remote_d_type() const { return remote_d_type; }
 
     void set_remote(inodeno_t ino, unsigned char d_type) { 
       remote_ino = ino;
@@ -202,12 +203,14 @@ public:
   }
 
 
-  CDir *get_dir() const { return dir; }
+  const CDir *get_dir() const { return dir; }
+  CDir *get_dir() { return dir; }
   const std::string& get_name() const { return name; }
 
   __u32 get_hash() const { return hash; }
 
   // linkage
+  const linkage_t *get_linkage() const { return &linkage; }
   linkage_t *get_linkage() { return &linkage; }
 
   linkage_t *_project_linkage() {
@@ -225,7 +228,7 @@ public:
   void push_projected_linkage(CInode *inode); 
   linkage_t *pop_projected_linkage();
 
-  bool is_projected() { return !projected.empty(); }
+  bool is_projected() const { return !projected.empty(); }
 
   linkage_t *get_projected_linkage() {
     if (!projected.empty())
@@ -254,16 +257,16 @@ public:
   void _put();
 
   // auth pins
-  bool can_auth_pin();
+  bool can_auth_pin() const;
   void auth_pin(void *by);
   void auth_unpin(void *by);
   void adjust_nested_auth_pins(int adjustment, int diradj, void *by);
-  bool is_frozen();
-  bool is_freezing();
-  bool is_auth_pinned() { return auth_pins || nested_auth_pins; }
-  int get_num_auth_pins() { return auth_pins; }
-  int get_num_dir_auth_pins();
-  int get_num_nested_auth_pins() { return nested_auth_pins; }
+  bool is_frozen() const;
+  bool is_freezing() const;
+  bool is_auth_pinned() const { return auth_pins || nested_auth_pins; }
+  int get_num_auth_pins() const { return auth_pins; }
+  int get_num_dir_auth_pins() const;
+  int get_num_nested_auth_pins() const { return nested_auth_pins; }
   
   // remote links
   void link_remote(linkage_t *dnl, CInode *in);
@@ -274,16 +277,16 @@ public:
   const CDentry& operator= (const CDentry& right);
 
   // misc
-  void make_path_string(std::string& s);
-  void make_path(filepath& fp);
+  void make_path_string(std::string& s) const;
+  void make_path(filepath& fp) const;
 
   // -- version --
-  version_t get_version() { return version; }
+  version_t get_version() const { return version; }
   void set_version(version_t v) { projected_version = version = v; }
-  version_t get_projected_version() { return projected_version; }
+  version_t get_projected_version() const { return projected_version; }
   void set_projected_version(version_t v) { projected_version = v; }
   
-  mds_authority_t authority();
+  mds_authority_t authority() const;
 
   version_t pre_dirty(version_t min=0);
   void _mark_dirty(LogSegment *ls);
@@ -291,7 +294,7 @@ public:
   void mark_clean();
 
   void mark_new();
-  bool is_new() { return state_test(STATE_NEW); }
+  bool is_new() const { return state_test(STATE_NEW); }
   void clear_new() { state_clear(STATE_NEW); }
   
   // -- replication
@@ -366,16 +369,21 @@ public:
  public:
   map<client_t,ClientLease*> client_lease_map;
 
-  bool is_any_leases() {
+  bool is_any_leases() const {
     return !client_lease_map.empty();
+  }
+  const ClientLease *get_client_lease(client_t c) const {
+    if (client_lease_map.count(c))
+      return client_lease_map.find(c)->second;
+    return 0;
   }
   ClientLease *get_client_lease(client_t c) {
     if (client_lease_map.count(c))
-      return client_lease_map[c];
+      return client_lease_map.find(c)->second;
     return 0;
   }
-  bool have_client_lease(client_t c) {
-    ClientLease *l = get_client_lease(c);
+  bool have_client_lease(client_t c) const {
+    const ClientLease *l = get_client_lease(c);
     if (l) 
       return true;
     else
@@ -393,7 +401,7 @@ public:
   friend class CDir;
 };
 
-ostream& operator<<(ostream& out, CDentry& dn);
+ostream& operator<<(ostream& out, const CDentry& dn);
 
 
 #endif

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -74,7 +74,7 @@ public:
 boost::pool<> CDir::pool(sizeof(CDir));
 
 
-ostream& operator<<(ostream& out, CDir& dir)
+ostream& operator<<(ostream& out, const CDir& dir)
 {
   string path;
   dir.get_inode()->make_path_string_projected(path);
@@ -128,7 +128,7 @@ ostream& operator<<(ostream& out, CDir& dir)
   if (!(dir.fnode.fragstat == dir.fnode.accounted_fragstat))
     out << "/" << dir.fnode.accounted_fragstat;
   if (g_conf->mds_debug_scatterstat && dir.is_projected()) {
-    fnode_t *pf = dir.get_projected_fnode();
+    const fnode_t *pf = dir.get_projected_fnode();
     out << "->" << pf->fragstat;
     if (!(pf->fragstat == pf->accounted_fragstat))
       out << "/" << pf->accounted_fragstat;
@@ -139,7 +139,7 @@ ostream& operator<<(ostream& out, CDir& dir)
   if (!(dir.fnode.rstat == dir.fnode.accounted_rstat))
     out << "/" << dir.fnode.accounted_rstat;
   if (g_conf->mds_debug_scatterstat && dir.is_projected()) {
-    fnode_t *pf = dir.get_projected_fnode();
+    const fnode_t *pf = dir.get_projected_fnode();
     out << "->" << pf->rstat;
     if (!(pf->rstat == pf->accounted_rstat))
       out << "/" << pf->accounted_rstat;
@@ -2242,7 +2242,7 @@ void CDir::decode_import(bufferlist::iterator& blp, utime_t now, LogSegment *ls)
  * if dir_auth.first == parent, auth is same as inode.
  * unless .second != unknown, in which case that sticks.
  */
-mds_authority_t CDir::authority() 
+mds_authority_t CDir::authority() const
 {
   if (is_subtree_root()) 
     return dir_auth;
@@ -2536,9 +2536,9 @@ void CDir::unfreeze_tree()
   }
 }
 
-bool CDir::is_freezing_tree()
+bool CDir::is_freezing_tree() const
 {
-  CDir *dir = this;
+  const CDir *dir = this;
   while (1) {
     if (dir->is_freezing_tree_root()) return true;
     if (dir->is_subtree_root()) return false;
@@ -2549,9 +2549,9 @@ bool CDir::is_freezing_tree()
   }
 }
 
-bool CDir::is_frozen_tree()
+bool CDir::is_frozen_tree() const
 {
-  CDir *dir = this;
+  const CDir *dir = this;
   while (1) {
     if (dir->is_frozen_tree_root()) return true;
     if (dir->is_subtree_root()) return false;

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -40,7 +40,7 @@ class bloom_filter;
 
 struct ObjectOperation;
 
-ostream& operator<<(ostream& out, class CDir& dir);
+ostream& operator<<(ostream& out, const class CDir& dir);
 class CDir : public MDSCacheObject {
   /*
    * This class uses a boost::pool to handle allocation. This is *not*
@@ -73,7 +73,7 @@ public:
   static const int PIN_EXPORTBOUND = 10;
   static const int PIN_STICKY =      11;
   static const int PIN_SUBTREETEMP = 12;  // used by MDCache::trim_non_auth()
-  const char *pin_name(int p) {
+  const char *pin_name(int p) const {
     switch (p) {
     case PIN_DNWAITER: return "dnwaiter";
     case PIN_INOWAITER: return "inowaiter";
@@ -189,12 +189,19 @@ public:
 
 
 public:
-  version_t get_version() { return fnode.version; }
+  version_t get_version() const { return fnode.version; }
   void set_version(version_t v) { 
     assert(projected_fnode.empty());
     projected_version = fnode.version = v; 
   }
-  version_t get_projected_version() { return projected_version; }
+  version_t get_projected_version() const { return projected_version; }
+
+  const fnode_t *get_projected_fnode() const {
+    if (projected_fnode.empty())
+      return &fnode;
+    else
+      return projected_fnode.back();
+  }
 
   fnode_t *get_projected_fnode() {
     if (projected_fnode.empty())
@@ -205,7 +212,7 @@ public:
   fnode_t *project_fnode();
 
   void pop_and_dirty_projected_fnode(LogSegment *ls);
-  bool is_projected() { return !projected_fnode.empty(); }
+  bool is_projected() const { return !projected_fnode.empty(); }
   version_t pre_dirty(version_t min=0);
   void _mark_dirty(LogSegment *ls);
   void _set_dirty_flag() {
@@ -302,16 +309,17 @@ protected:
   dirfrag_t dirfrag() const { return dirfrag_t(inode->ino(), frag); }
 
   CInode *get_inode()    { return inode; }
+  const CInode *get_inode() const { return inode; }
   CDir *get_parent_dir() { return inode->get_parent_dir(); }
 
   map_t::iterator begin() { return items.begin(); }
   map_t::iterator end() { return items.end(); }
 
-  unsigned get_num_head_items() { return num_head_items; }
-  unsigned get_num_head_null() { return num_head_null; }
-  unsigned get_num_snap_items() { return num_snap_items; }
-  unsigned get_num_snap_null() { return num_snap_null; }
-  unsigned get_num_any() { return num_head_items + num_head_null + num_snap_items + num_snap_null; }
+  unsigned get_num_head_items() const { return num_head_items; }
+  unsigned get_num_head_null() const { return num_head_null; }
+  unsigned get_num_snap_items() const { return num_snap_items; }
+  unsigned get_num_snap_null() const { return num_snap_null; }
+  unsigned get_num_any() const { return num_head_items + num_head_null + num_snap_items + num_snap_null; }
   
   bool check_rstats();
 
@@ -320,7 +328,7 @@ protected:
     assert(num_dirty > 0);
     num_dirty--; 
   }
-  int get_num_dirty() {
+  int get_num_dirty() const {
     return num_dirty;
   }
 
@@ -396,21 +404,21 @@ private:
   mds_authority_t dir_auth;
 
  public:
-  mds_authority_t authority();
-  mds_authority_t get_dir_auth() { return dir_auth; }
+  mds_authority_t authority() const;
+  mds_authority_t get_dir_auth() const { return dir_auth; }
   void set_dir_auth(mds_authority_t a);
   void set_dir_auth(mds_rank_t a) { set_dir_auth(mds_authority_t(a, CDIR_AUTH_UNKNOWN)); }
-  bool is_ambiguous_dir_auth() {
+  bool is_ambiguous_dir_auth() const {
     return dir_auth.second != CDIR_AUTH_UNKNOWN;
   }
-  bool is_full_dir_auth() {
+  bool is_full_dir_auth() const {
     return is_auth() && !is_ambiguous_dir_auth();
   }
-  bool is_full_dir_nonauth() {
+  bool is_full_dir_nonauth() const {
     return !is_auth() && !is_ambiguous_dir_auth();
   }
   
-  bool is_subtree_root() {
+  bool is_subtree_root() const {
     return dir_auth != CDIR_AUTH_DEFAULT;
   }
 
@@ -477,8 +485,8 @@ private:
   bool is_importing() { return state & STATE_IMPORTING; }
   bool is_dirty_dft() { return state & STATE_DIRTYDFT; }
 
-  int get_dir_rep() { return dir_rep; }
-  bool is_rep() { 
+  int get_dir_rep() const { return dir_rep; }
+  bool is_rep() const { 
     if (dir_rep == REP_NONE) return false;
     return true;
   }
@@ -511,8 +519,8 @@ public:
 	      bool ignore_authpinnability=false, int op_prio=-1);
 
   // -- dirtyness --
-  version_t get_committing_version() { return committing_version; }
-  version_t get_committed_version() { return committed_version; }
+  version_t get_committing_version() const { return committing_version; }
+  version_t get_committed_version() const { return committed_version; }
   void set_committed_version(version_t v) { committed_version = v; }
 
   void mark_complete();
@@ -559,11 +567,11 @@ public:
 
 
   // -- auth pins --
-  bool can_auth_pin() { return is_auth() && !(is_frozen() || is_freezing()); }
-  int get_cum_auth_pins() { return auth_pins + nested_auth_pins; }
-  int get_auth_pins() { return auth_pins; }
-  int get_nested_auth_pins() { return nested_auth_pins; }
-  int get_dir_auth_pins() { return dir_auth_pins; }
+  bool can_auth_pin() const { return is_auth() && !(is_frozen() || is_freezing()); }
+  int get_cum_auth_pins() const { return auth_pins + nested_auth_pins; }
+  int get_auth_pins() const { return auth_pins; }
+  int get_nested_auth_pins() const { return nested_auth_pins; }
+  int get_dir_auth_pins() const { return dir_auth_pins; }
   void auth_pin(void *who);
   void auth_unpin(void *who);
 
@@ -581,17 +589,17 @@ public:
 
   void maybe_finish_freeze();
 
-  bool is_freezing() { return is_freezing_tree() || is_freezing_dir(); }
-  bool is_freezing_tree();
-  bool is_freezing_tree_root() { return state & STATE_FREEZINGTREE; }
-  bool is_freezing_dir() { return state & STATE_FREEZINGDIR; }
+  bool is_freezing() const { return is_freezing_tree() || is_freezing_dir(); }
+  bool is_freezing_tree() const;
+  bool is_freezing_tree_root() const { return state & STATE_FREEZINGTREE; }
+  bool is_freezing_dir() const { return state & STATE_FREEZINGDIR; }
 
-  bool is_frozen() { return is_frozen_dir() || is_frozen_tree(); }
-  bool is_frozen_tree();
-  bool is_frozen_tree_root() { return state & STATE_FROZENTREE; }
-  bool is_frozen_dir() { return state & STATE_FROZENDIR; }
+  bool is_frozen() const { return is_frozen_dir() || is_frozen_tree(); }
+  bool is_frozen_tree() const;
+  bool is_frozen_tree_root() const { return state & STATE_FROZENTREE; }
+  bool is_frozen_dir() const { return state & STATE_FROZENDIR; }
   
-  bool is_freezeable(bool freezing=false) {
+  bool is_freezeable(bool freezing=false) const {
     // no nested auth pins.
     if ((auth_pins-freezing) > 0 || nested_auth_pins > 0) 
       return false;
@@ -602,7 +610,7 @@ public:
 
     return true;
   }
-  bool is_freezeable_dir(bool freezing=false) {
+  bool is_freezeable_dir(bool freezing=false) const {
     if ((auth_pins-freezing) > 0 || dir_auth_pins > 0) 
       return false;
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -97,7 +97,7 @@ int num_cinode_locks = 5;
 
 
 
-ostream& operator<<(ostream& out, CInode& in)
+ostream& operator<<(ostream& out, const CInode& in)
 {
   string path;
   in.make_path_string_projected(path);
@@ -147,14 +147,14 @@ ostream& operator<<(ostream& out, CInode& in)
   if (in.is_frozen_inode()) out << " FROZEN";
   if (in.is_frozen_auth_pin()) out << " FROZEN_AUTHPIN";
 
-  inode_t *pi = in.get_projected_inode();
+  const inode_t *pi = in.get_projected_inode();
   if (pi->is_truncating())
     out << " truncating(" << pi->truncate_from << " to " << pi->truncate_size << ")";
 
   if (in.inode.is_dir()) {
     out << " " << in.inode.dirstat;
     if (g_conf->mds_debug_scatterstat && in.is_projected()) {
-      inode_t *pi = in.get_projected_inode();
+      const inode_t *pi = in.get_projected_inode();
       out << "->" << pi->dirstat;
     }
   } else {
@@ -168,7 +168,7 @@ ostream& operator<<(ostream& out, CInode& in)
   if (!(in.inode.rstat == in.inode.accounted_rstat))
     out << "/" << in.inode.accounted_rstat;
   if (g_conf->mds_debug_scatterstat && in.is_projected()) {
-    inode_t *pi = in.get_projected_inode();
+    const inode_t *pi = in.get_projected_inode();
     out << "->" << pi->rstat;
     if (!(pi->rstat == pi->accounted_rstat))
       out << "/" << pi->accounted_rstat;
@@ -209,7 +209,7 @@ ostream& operator<<(ostream& out, CInode& in)
 
   if (!in.get_client_caps().empty()) {
     out << " caps={";
-    for (map<client_t,Capability*>::iterator it = in.get_client_caps().begin();
+    for (map<client_t,Capability*>::const_iterator it = in.get_client_caps().begin();
          it != in.get_client_caps().end();
          ++it) {
       if (it != in.get_client_caps().begin()) out << ",";
@@ -229,7 +229,7 @@ ostream& operator<<(ostream& out, CInode& in)
   }
   if (!in.get_mds_caps_wanted().empty()) {
     out << " mcw={";
-    for (map<int,int>::iterator p = in.get_mds_caps_wanted().begin();
+    for (map<int,int>::const_iterator p = in.get_mds_caps_wanted().begin();
 	 p != in.get_mds_caps_wanted().end(); ++p) {
       if (p != in.get_mds_caps_wanted().begin())
 	out << ',';
@@ -765,7 +765,7 @@ bool CInode::is_projected_ancestor_of(CInode *other)
   return false;
 }
 
-void CInode::make_path_string(string& s, bool force, CDentry *use_parent)
+void CInode::make_path_string(string& s, bool force, CDentry *use_parent) const
 {
   if (!force)
     use_parent = parent;
@@ -790,7 +790,7 @@ void CInode::make_path_string(string& s, bool force, CDentry *use_parent)
     s += n;
   }
 }
-void CInode::make_path_string_projected(string& s)
+void CInode::make_path_string_projected(string& s) const
 {
   make_path_string(s);
   
@@ -798,7 +798,7 @@ void CInode::make_path_string_projected(string& s)
     string q;
     q.swap(s);
     s = "{" + q;
-    for (list<CDentry*>::iterator p = projected_parent.begin();
+    for (list<CDentry*>::const_iterator p = projected_parent.begin();
 	 p != projected_parent.end();
 	 ++p) {
       string q;
@@ -810,7 +810,7 @@ void CInode::make_path_string_projected(string& s)
   }
 }
 
-void CInode::make_path(filepath& fp)
+void CInode::make_path(filepath& fp) const
 {
   if (parent) 
     parent->make_path(fp);
@@ -2101,20 +2101,20 @@ void CInode::finish_scatter_gather_update_accounted(int type, MutationRef& mut, 
 
 // waiting
 
-bool CInode::is_frozen()
+bool CInode::is_frozen() const
 {
   if (is_frozen_inode()) return true;
   if (parent && parent->dir->is_frozen()) return true;
   return false;
 }
 
-bool CInode::is_frozen_dir()
+bool CInode::is_frozen_dir() const
 {
   if (parent && parent->dir->is_frozen_dir()) return true;
   return false;
 }
 
-bool CInode::is_freezing()
+bool CInode::is_freezing() const
 {
   if (is_freezing_inode()) return true;
   if (parent && parent->dir->is_freezing()) return true;
@@ -2256,7 +2256,7 @@ void CInode::clear_ambiguous_auth()
 }
 
 // auth_pins
-bool CInode::can_auth_pin() {
+bool CInode::can_auth_pin() const {
   if (!is_auth() || is_freezing_inode() || is_frozen_inode() || is_frozen_auth_pin())
     return false;
   if (parent)
@@ -2343,7 +2343,7 @@ void CInode::adjust_nested_auth_pins(int a, void *by)
 
 // authority
 
-mds_authority_t CInode::authority() 
+mds_authority_t CInode::authority() const
 {
   if (inode_auth.first >= 0) 
     return inode_auth;
@@ -2738,7 +2738,7 @@ void CInode::export_client_caps(map<client_t,Capability::Export>& cl)
 }
 
   // caps allowed
-int CInode::get_caps_liked()
+int CInode::get_caps_liked() const
 {
   if (is_dir())
     return CEPH_CAP_PIN | CEPH_CAP_ANY_EXCL | CEPH_CAP_ANY_SHARED;  // but not, say, FILE_RD|WR|WRBUFFER
@@ -2746,7 +2746,7 @@ int CInode::get_caps_liked()
     return CEPH_CAP_ANY & ~CEPH_CAP_FILE_LAZYIO;
 }
 
-int CInode::get_caps_allowed_ever()
+int CInode::get_caps_allowed_ever() const
 {
   int allowed;
   if (is_dir())
@@ -2761,7 +2761,7 @@ int CInode::get_caps_allowed_ever()
      (linklock.gcaps_allowed_ever() << linklock.get_cap_shift()));
 }
 
-int CInode::get_caps_allowed_by_type(int type)
+int CInode::get_caps_allowed_by_type(int type) const
 {
   return 
     CEPH_CAP_PIN |
@@ -2771,7 +2771,7 @@ int CInode::get_caps_allowed_by_type(int type)
     (linklock.gcaps_allowed(type) << linklock.get_cap_shift());
 }
 
-int CInode::get_caps_careful()
+int CInode::get_caps_careful() const
 {
   return 
     (filelock.gcaps_careful() << filelock.get_cap_shift()) |
@@ -2780,7 +2780,7 @@ int CInode::get_caps_careful()
     (linklock.gcaps_careful() << linklock.get_cap_shift());
 }
 
-int CInode::get_xlocker_mask(client_t client)
+int CInode::get_xlocker_mask(client_t client) const
 {
   return 
     (filelock.gcaps_xlocker_mask(client) << filelock.get_cap_shift()) |
@@ -2789,7 +2789,7 @@ int CInode::get_xlocker_mask(client_t client)
     (linklock.gcaps_xlocker_mask(client) << linklock.get_cap_shift());
 }
 
-int CInode::get_caps_allowed_for_client(client_t client)
+int CInode::get_caps_allowed_for_client(client_t client) const
 {
   int allowed;
   if (client == get_loner()) {
@@ -2812,9 +2812,11 @@ int CInode::get_caps_issued(int *ploner, int *pother, int *pxlocker,
 {
   int c = 0;
   int loner = 0, other = 0, xlocker = 0;
-  if (!is_auth())
+  if (!is_auth()) {
     loner_cap = -1;
-  for (map<client_t,Capability*>::iterator it = client_caps.begin();
+  }
+
+  for (map<client_t,Capability*>::const_iterator it = client_caps.begin();
        it != client_caps.end();
        ++it) {
     int i = it->second->issued();
@@ -2831,9 +2833,9 @@ int CInode::get_caps_issued(int *ploner, int *pother, int *pxlocker,
   return (c >> shift) & mask;
 }
 
-bool CInode::is_any_caps_wanted()
+bool CInode::is_any_caps_wanted() const
 {
-  for (map<client_t,Capability*>::iterator it = client_caps.begin();
+  for (map<client_t,Capability*>::const_iterator it = client_caps.begin();
        it != client_caps.end();
        ++it)
     if (it->second->wanted())
@@ -2841,11 +2843,11 @@ bool CInode::is_any_caps_wanted()
   return false;
 }
 
-int CInode::get_caps_wanted(int *ploner, int *pother, int shift, int mask)
+int CInode::get_caps_wanted(int *ploner, int *pother, int shift, int mask) const
 {
   int w = 0;
   int loner = 0, other = 0;
-  for (map<client_t,Capability*>::iterator it = client_caps.begin();
+  for (map<client_t,Capability*>::const_iterator it = client_caps.begin();
        it != client_caps.end();
        ++it) {
     if (!it->second->is_stale()) {
@@ -2859,7 +2861,7 @@ int CInode::get_caps_wanted(int *ploner, int *pother, int shift, int mask)
     //cout << " get_caps_wanted client " << it->first << " " << cap_string(it->second.wanted()) << endl;
   }
   if (is_auth())
-    for (map<int,int>::iterator it = mds_caps_wanted.begin();
+    for (map<int,int>::const_iterator it = mds_caps_wanted.begin();
 	 it != mds_caps_wanted.end();
 	 ++it) {
       w |= it->second;

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -577,13 +577,13 @@ public:
 
 
   // caps
-  bool is_loner_mode() {
+  bool is_loner_mode() const {
     return get_sm()->states[state].loner;
   }
-  int gcaps_allowed_ever() {
+  int gcaps_allowed_ever() const {
     return parent->is_auth() ? get_sm()->allowed_ever_auth : get_sm()->allowed_ever_replica;
   }
-  int gcaps_allowed(int who, int s=-1) {
+  int gcaps_allowed(int who, int s=-1) const {
     if (s < 0) s = state;
     if (parent->is_auth()) {
       if (get_xlock_by_client() >= 0 && who == CAP_XLOCKER)
@@ -595,14 +595,14 @@ public:
     } else 
       return get_sm()->states[s].replica_caps;
   }
-  int gcaps_careful() {
+  int gcaps_careful() const {
     if (get_num_wrlocks())
       return get_sm()->careful;
     return 0;
   }
 
 
-  int gcaps_xlocker_mask(client_t client) {
+  int gcaps_xlocker_mask(client_t client) const {
     if (client == get_xlock_by_client())
       return type->type == CEPH_LOCK_IFILE ? 0xf : (CEPH_CAP_GSHARED|CEPH_CAP_GEXCL);
     return 0;

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -430,12 +430,12 @@ private:
     in->last_journaled = event_seq;
     //cout << "journaling " << in->inode.ino << " at " << my_offset << std::endl;
 
-    inode_t *pi = in->get_projected_inode();
+    const inode_t *pi = in->get_projected_inode();
     if ((state & fullbit::STATE_DIRTY) && pi->is_backtrace_updated())
       state |= fullbit::STATE_DIRTYPARENT;
 
     bufferlist snapbl;
-    sr_t *sr = in->get_projected_srnode();
+    const sr_t *sr = in->get_projected_srnode();
     if (sr)
       sr->encode(snapbl);
 
@@ -478,7 +478,7 @@ private:
     add_primary_dentry(dn, 0, dirty, dirty_parent, dirty_pool);
   }
 
-  void add_root(bool dirty, CInode *in, inode_t *pi=0, fragtree_t *pdft=0, bufferlist *psnapbl=0,
+  void add_root(bool dirty, CInode *in, const inode_t *pi=0, fragtree_t *pdft=0, bufferlist *psnapbl=0,
 		    map<string,bufferptr> *px=0) {
     in->last_journaled = event_seq;
     //cout << "journaling " << in->inode.ino << " at " << my_offset << std::endl;
@@ -524,7 +524,7 @@ private:
     return add_dir(dir->dirfrag(), dir->get_projected_fnode(), dir->get_projected_version(),
 		   dirty, false, false, false, dirtydft);
   }
-  dirlump& add_dir(dirfrag_t df, fnode_t *pf, version_t pv, bool dirty,
+  dirlump& add_dir(dirfrag_t df, const fnode_t *pf, version_t pv, bool dirty,
 		   bool complete=false, bool isnew=false,
 		   bool importing=false, bool dirty_dft=false) {
     if (lump_map.count(df) == 0)

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -492,7 +492,7 @@ struct inode_t {
     }
   }
 
-  bool is_backtrace_updated() {
+  bool is_backtrace_updated() const {
     return backtrace_version == version;
   }
   void update_backtrace(version_t pv=0) {
@@ -1198,7 +1198,7 @@ class MDSCacheObject {
   const static int PIN_TEMPEXPORTING = 1008;  // temp pin between encode_ and finish_export
   static const int PIN_CLIENTLEASE = 1009;
 
-  const char *generic_pin_name(int p) {
+  const char *generic_pin_name(int p) const {
     switch (p) {
     case PIN_REPLICATED: return "replicated";
     case PIN_DIRTY: return "dirty";
@@ -1261,8 +1261,8 @@ class MDSCacheObject {
 
   // --------------------------------------------
   // authority
-  virtual mds_authority_t authority() = 0;
-  bool is_ambiguous_auth() {
+  virtual mds_authority_t authority() const = 0;
+  bool is_ambiguous_auth() const {
     return authority().second != CDIR_AUTH_UNKNOWN;
   }
 
@@ -1275,12 +1275,14 @@ protected:
 #endif
 
  public:
-  int get_num_ref(int by = -1) {
+  int get_num_ref(int by = -1) const {
 #ifdef MDS_REF_SET
     if (by >= 0) {
-      if (ref_map.find(by) == ref_map.end())
+      if (ref_map.find(by) == ref_map.end()) {
 	return 0;
-      return ref_map[by];
+      } else {
+        return ref_map.find(by)->second;
+      }
     }
 #endif
     return ref;
@@ -1294,7 +1296,7 @@ protected:
     return total;
   }
 #endif
-  virtual const char *pin_name(int by) = 0;
+  virtual const char *pin_name(int by) const = 0;
   //bool is_pinned_by(int by) { return ref_set.count(by); }
   //multiset<int>& get_ref_set() { return ref_set; }
 
@@ -1345,9 +1347,9 @@ protected:
 #endif
   }
 
-  void print_pin_set(std::ostream& out) {
+  void print_pin_set(std::ostream& out) const {
 #ifdef MDS_REF_SET
-    std::map<int, int>::iterator it = ref_map.begin();
+    std::map<int, int>::const_iterator it = ref_map.begin();
     while (it != ref_map.end()) {
       out << " " << pin_name(it->first) << "=" << it->second;
       ++it;
@@ -1360,12 +1362,12 @@ protected:
 
   // --------------------------------------------
   // auth pins
-  virtual bool can_auth_pin() = 0;
+  virtual bool can_auth_pin() const = 0;
   virtual void auth_pin(void *who) = 0;
   virtual void auth_unpin(void *who) = 0;
-  virtual bool is_frozen() = 0;
-  virtual bool is_freezing() = 0;
-  virtual bool is_freezing_or_frozen() {
+  virtual bool is_frozen() const = 0;
+  virtual bool is_freezing() const = 0;
+  virtual bool is_freezing_or_frozen() const {
     return is_frozen() || is_freezing();
   }
 
@@ -1377,9 +1379,9 @@ protected:
   std::map<mds_rank_t,unsigned>	replica_map;   // [auth] mds -> nonce
 
  public:
-  bool is_replicated() { return !replica_map.empty(); }
-  bool is_replica(mds_rank_t mds) { return replica_map.count(mds); }
-  int num_replicas() { return replica_map.size(); }
+  bool is_replicated() const { return !replica_map.empty(); }
+  bool is_replica(mds_rank_t mds) const { return replica_map.count(mds); }
+  int num_replicas() const { return replica_map.size(); }
   unsigned add_replica(mds_rank_t mds) {
     if (replica_map.count(mds)) 
       return ++replica_map[mds];  // inc nonce
@@ -1409,15 +1411,15 @@ protected:
   }
   std::map<mds_rank_t,unsigned>::iterator replicas_begin() { return replica_map.begin(); }
   std::map<mds_rank_t,unsigned>::iterator replicas_end() { return replica_map.end(); }
-  const std::map<mds_rank_t,unsigned>& get_replicas() { return replica_map; }
-  void list_replicas(std::set<mds_rank_t>& ls) {
+  const std::map<mds_rank_t,unsigned>& get_replicas() const { return replica_map; }
+  void list_replicas(std::set<mds_rank_t>& ls) const {
     for (std::map<mds_rank_t,unsigned>::const_iterator p = replica_map.begin();
 	 p != replica_map.end();
 	 ++p) 
       ls.insert(p->first);
   }
 
-  unsigned get_replica_nonce() { return replica_nonce; }
+  unsigned get_replica_nonce() const { return replica_nonce; }
   void set_replica_nonce(unsigned n) { replica_nonce = n; }
 
 


### PR DESCRIPTION
So that one can have const CInode and CDir references
from time to time.

This is mostly just dumb adding 'const' to declarations
and iterators, but there is also an awkward case in CInode
where CINode::get_caps_issued was resetting loner_cap to -1
based on get_auth(), so that has changed functionally to
update loner_cap in state_set/state_clear/state_reset
instead so that the getter is just a getter.

Signed-off-by: John Spray <john.spray@redhat.com>