### PR TITLE
FileStore: return error if get_index fails in lfn_open

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -242,6 +242,10 @@ int FileStore::lfn_open(coll_t cid,
   }
   if (!((*index).index)) {
     r = get_index(cid, index);
+    if (r < 0) {
+      dout(10) << __func__ << " could not get index r = " << r << dendl;
+      return r;
+    }
   } else {
     need_lock = false;
   }


### PR DESCRIPTION
(*index).index is NULL if get_index fails, need to return error in this case.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>