### PR TITLE
tests: group clusters in a single directory

### DIFF
--- a/src/test/ceph-helpers.sh
+++ b/src/test/ceph-helpers.sh
@@ -82,7 +82,7 @@ TIMEOUT=60
 function setup() {
     local dir=$1
     teardown $dir || return 1
-    mkdir $dir
+    mkdir -p $dir
 }
 
 function test_setup() {
@@ -929,7 +929,7 @@ function test_repair() {
 # @return 0 on success, 1 on error
 #
 function main() {
-    local dir=$1
+    local dir=testdir/$1
     shift
 
     set -x
@@ -966,7 +966,7 @@ function run_tests() {
     export CEPH_CONF=/dev/null
 
     local funcs=${@:-$(set | sed -n -e 's/^\(test_[0-9a-z_]*\) .*/\1/p')}
-    local dir=ceph-helpers
+    local dir=testdir/ceph-helpers
 
     for func in $funcs ; do
         $func $dir || return 1

--- a/src/test/mon/mon-test-helpers.sh
+++ b/src/test/mon/mon-test-helpers.sh
@@ -20,7 +20,7 @@ source test/test_btrfs_common.sh
 function setup() {
     local dir=$1
     teardown $dir
-    mkdir $dir
+    mkdir -p $dir
 }
 
 function teardown() {
@@ -103,7 +103,7 @@ function call_TEST_functions() {
 }
 
 function main() {
-    local dir=$1
+    local dir=testdir/$1
 
     export PATH=:$PATH # make sure program from sources are prefered
 

--- a/src/test/vstart_wrapper.sh
+++ b/src/test/vstart_wrapper.sh
@@ -17,7 +17,7 @@
 
 source test/mon/mon-test-helpers.sh
 
-export CEPH_DIR="$PWD/test-$CEPH_PORT"
+export CEPH_DIR="$PWD/testdir/test-$CEPH_PORT"
 export CEPH_DEV_DIR="$CEPH_DIR/dev"
 export CEPH_OUT_DIR="$CEPH_DIR/out"
 


### PR DESCRIPTION
Group all test directories used for mini clusters into a single
sub-directory (testdir). This is easier to cleanup manually and less
error prone.

http://tracker.ceph.com/issues/10426 Fixes: #10426

Signed-off-by: Loic Dachary <ldachary@redhat.com>