### PR TITLE
Bump memstore_device_bytes from U32 to U64

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -687,7 +687,7 @@ OPTION(osd_bench_large_size_max_throughput, OPT_U64, 100 << 20) // 100 MB/s
 OPTION(osd_bench_max_block_size, OPT_U64, 64 << 20) // cap the block size at 64MB
 OPTION(osd_bench_duration, OPT_U32, 30) // duration of 'osd bench', capped at 30s to avoid triggering timeouts
 
-OPTION(memstore_device_bytes, OPT_U32, 1024*1024*1024)
+OPTION(memstore_device_bytes, OPT_U64, 1024*1024*1024)
 
 OPTION(filestore_omap_backend, OPT_STR, "leveldb")
 


### PR DESCRIPTION
U32 limit the max size of memstore to a few GB, which
block our test on memstore performance(as a phototype).

Bump it to U64 will suit for more widely usage

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>