### PR TITLE
erasure code: backend feature to read from all OSDs and silently discard...

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -461,6 +461,7 @@ OPTION(osd_crush_chooseleaf_type, OPT_INT, 1) // 1 = host
 OPTION(osd_pool_default_crush_rule, OPT_INT, -1) // deprecated for osd_pool_default_crush_replicated_ruleset
 OPTION(osd_pool_default_crush_replicated_ruleset, OPT_INT, CEPH_DEFAULT_CRUSH_REPLICATED_RULESET)
 OPTION(osd_pool_erasure_code_stripe_width, OPT_U32, OSD_POOL_ERASURE_CODE_STRIPE_WIDTH) // in bytes
+OPTION(osd_pool_erasure_code_subread_all, OPT_BOOL, false)       // dispatch all OSD for sub-read op
 OPTION(osd_pool_default_size, OPT_INT, 3)
 OPTION(osd_pool_default_min_size, OPT_INT, 0)  // 0 means no specific default; ceph will use size-size/2
 OPTION(osd_pool_default_pg_num, OPT_INT, 8) // number of PGs for new pools. Configure in global or mon section of ceph.conf

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -431,6 +431,7 @@ public:
 
 
   const ECUtil::stripe_info_t sinfo;
+  bool subread_all;
   /// If modified, ensure that the ref is held until the update is applied
   SharedPtrRegistry<hobject_t, ECUtil::HashInfo> unstable_hashinfo_registry;
   ECUtil::HashInfoRef get_hash_info(const hobject_t &hoid);

--- a/src/test/erasure-code/test-erasure-code.sh
+++ b/src/test/erasure-code/test-erasure-code.sh
@@ -97,6 +97,30 @@ function rados_put_get() {
     rm $dir/ORIGINAL
 }
 
+function rados_put_error_get() {
+    local dir=$1
+    local poolname=$2
+
+    for marker in AAA BBB CCCC DDDD ; do
+        printf "%*s" 1024 $marker
+    done > $dir/ORIGINAL
+
+    #
+    # get and put an object, compare they are equal
+    #
+    ./rados --pool $poolname put SOMETHINGERR $dir/ORIGINAL || return 1
+    # need to wait for file flush to disk
+    sleep 3
+    file=`find test-erasure-code -name "*SOMETHINGERR*" | grep "ffffffffffffffff_0"`
+    # Change the file contents
+    echo "test" > $file
+    ./rados --pool $poolname get SOMETHINGERR $dir/COPY || return 1
+    diff $dir/ORIGINAL $dir/COPY || return 1
+
+    rm $dir/COPY
+    rm $dir/ORIGINAL
+}
+
 function plugin_exists() {
     local plugin=$1
 
@@ -270,6 +294,34 @@ function TEST_chunk_mapping() {
 
     delete_pool remap-pool
     ./ceph osd erasure-code-profile rm remap-profile
+}
+
+function TEST_read_all_flag() {
+    local dir=$1
+
+    # Set flag
+    ./ceph tell osd.* injectargs "--osd-pool-erasure-code-subread-all=true"
+
+    local poolname=pool-jerasure
+    local profile=profile-jerasure
+
+    ./ceph osd erasure-code-profile set $profile \
+        plugin=jerasure \
+        k=4 m=2 \
+        ruleset-failure-domain=osd || return 1
+    ./ceph osd pool create $poolname 12 12 erasure $profile \
+        || return 1
+
+    rados_put_get $dir $poolname || return 1
+
+    rados_put_error_get $dir $poolname || return 1
+
+    delete_pool $poolname
+    ./ceph osd erasure-code-profile rm $profile
+
+    # Unset flag
+    ./ceph tell osd.* injectargs "--osd-pool-erasure-code-subread-all=false"
+
 }
 
 main test-erasure-code


### PR DESCRIPTION
... EIO if possible

Bug: http://tracker.ceph.com/issues/9943

Brief: Add osd setting osd_pool_erasure_code_subread_all. Default is false. If set it to true. Will send sub-read op to all OSD and choose the first success read result.

Signed-off-by: Wei Luo <luowei@yahoo-inc.com>