### PR TITLE
Jmacarthur/baserock support

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -711,7 +711,7 @@ def get_conf(cluster, variable):
                 'ceph-conf',
                 '--cluster={cluster}'.format(
                     cluster=cluster,
-                    ),
+                    ) if cluster != None else '',
                 '--name=osd.',
                 '--lookup',
                 variable,

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1981,6 +1981,8 @@ def activate(
                 (distro, release, codename) = platform.dist()
                 if distro == 'Ubuntu':
                     init = 'upstart'
+                elif distro == 'Baserock':
+                    init = 'systemd'
                 else:
                     init = 'sysvinit'
 


### PR DESCRIPTION
This adds a mapping from Baserock (http://wiki.baserock.org/) to systemd since the vast majority of Ceph-capable Baserock Linux systems will use systemd.

There is also a fix for ceph-disk when --cluster is not supplied; the default argument for --cluster does not appear to be inherited by the 'prepare' subparser, so args.cluster can be None. Currently /etc/ceph/ceph.conf will not be read in this case, which can be fixed by removing the --cluster argument to ceph-conf.

Signed-off-by: Jim MacArthur <jim.macarthur@codethink.co.uk>