### PR TITLE
mon: implement `fs reset`

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -715,6 +715,11 @@ function test_mon_mds()
   metadata_poolnum=$(ceph osd dump | grep "pool.* 'fs_metadata" | awk '{print $2;}')
 
   fail_all_mds
+
+  # Check that 'fs reset' runs
+  ceph fs reset cephfs --yes-i-really-mean-it
+
+  # Clean up to enable subsequent newfs tests
   ceph fs rm cephfs --yes-i-really-mean-it
 
   set +e

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1228,6 +1228,15 @@ int MDSMonitor::management_command(
       return -EINVAL;
     }
 
+    // Check for confirmation flag
+    string sure;
+    cmd_getval(g_ceph_context, cmdmap, "sure", sure);
+    if (sure != "--yes-i-really-mean-it") {
+      ss << "this is a potentially destructive operation, only for use by experts in disaster recovery.  "
+        "Add --yes-i-really-mean-it if you are sure you wish to continue.";
+      return -EPERM;
+    }
+
     MDSMap newmap;
 
     // Populate rank 0 as existing (so don't go into CREATING)

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -307,6 +307,11 @@ COMMAND("fs rm " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"disable the named filesystem", \
 	"fs", "rw", "cli,rest")
+COMMAND("fs reset " \
+	"name=fs_name,type=CephString " \
+	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"disaster recovery only: reset to a single-MDS map", \
+	"fs", "rw", "cli,rest")
 COMMAND("fs ls ", \
 	"list filesystems", \
 	"fs", "r", "cli,rest")


### PR DESCRIPTION
This is for use in CephFS disaster recovery.  When
the metadata pool has been forcibly reset to a single-MDS
metadata tree, we would like to reset the MDSMap to match.

Signed-off-by: John Spray <john.spray@redhat.com>