### PR TITLE
#9883 tools/cephfs: add recover_dentries to journaltool

### DIFF
--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -99,6 +99,8 @@ void InoTable::apply_release_ids(interval_set<inodeno_t>& ids)
 
 void InoTable::replay_alloc_id(inodeno_t id) 
 {
+  assert(mds);  // Only usable in online mode
+
   dout(10) << "replay_alloc_id " << id << dendl;
   if (free.contains(id)) {
     free.erase(id);
@@ -111,6 +113,8 @@ void InoTable::replay_alloc_id(inodeno_t id)
 }
 void InoTable::replay_alloc_ids(interval_set<inodeno_t>& ids) 
 {
+  assert(mds);  // Only usable in online mode
+
   dout(10) << "replay_alloc_ids " << ids << dendl;
   interval_set<inodeno_t> is;
   is.intersection_of(free, ids);

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -67,6 +67,22 @@ class InoTable : public MDSTable {
   static void generate_test_instances(list<InoTable*>& ls);
 
   void skip_inos(inodeno_t i);
+
+  /**
+   * If the specified inode is marked as free, mark it as used.
+   * For use in tools, not normal operations.
+   *
+   * @returns true if the inode was previously marked as free
+   */
+  bool force_consume(inodeno_t ino)
+  {
+    if (free.contains(ino)) {
+      free.erase(ino);
+      return true;
+    } else {
+      return false;
+    }
+  }
 };
 
 #endif

--- a/src/tools/cephfs/EventOutput.cc
+++ b/src/tools/cephfs/EventOutput.cc
@@ -120,4 +120,14 @@ void EventOutput::summary() const
   for (std::map<std::string, int>::iterator i = type_count.begin(); i != type_count.end(); ++i) {
       std::cout << "  " << i->first << ": " << i->second << std::endl;
   }
+
+  std::cout << "Errors: " << scan.errors.size() << std::endl;
+  if (scan.errors.size()) {
+    for (JournalScanner::ErrorMap::const_iterator i = scan.errors.begin();
+         i != scan.errors.end(); ++i) {
+      std::cout << "  0x" << std::hex << i->first << std::dec
+                << ": " << i->second.r << " "
+                << i->second.description << std::endl;
+    }
+  }
 }

--- a/src/tools/cephfs/JournalScanner.h
+++ b/src/tools/cephfs/JournalScanner.h
@@ -85,7 +85,17 @@ class JournalScanner
     LogEvent *log_event;
     uint32_t raw_size;  //< Size from start offset including all encoding overhead
   };
+
+  class EventError {
+    public:
+    int r;
+    std::string description;
+    EventError(int r_, const std::string &desc_)
+      : r(r_), description(desc_) {}
+  };
+
   typedef std::map<uint64_t, EventRecord> EventMap;
+  typedef std::map<uint64_t, EventError> ErrorMap;
   typedef std::pair<uint64_t, uint64_t> Range;
   bool pointer_present;
   bool pointer_valid;
@@ -100,6 +110,11 @@ class JournalScanner
   std::vector<Range> ranges_invalid;
   std::vector<uint64_t> events_valid;
   EventMap events;
+
+  // For events present in ::events (i.e. scanned successfully),
+  // any subsequent errors handling them (e.g. replaying)
+  ErrorMap errors;
+
 
   private:
   // Forbid copy construction because I have ptr members

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -605,7 +605,7 @@ int JournalTool::scavenge_dentries(
         << frag_oid.name << " " << cpp_strerror(r) << dendl;
       write_fnode = true;
       // Note: creating the dirfrag *without* a backtrace, relying on
-      // MDS to regenerate backtraces in FSCK
+      // MDS to regenerate backtraces on read or in FSCK
     } else if (r == 0) {
       // Conditionally update existing omap header
       fnode_t old_fnode;

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -356,7 +356,8 @@ int JournalTool::main_event(std::vector<const char*> &argv)
      * Iterate over log entries, attempting to scavenge from each one
      */
     std::set<inodeno_t> consumed_inos;
-    for (JournalScanner::EventMap::iterator i = js.events.begin(); i != js.events.end(); ++i) {
+    for (JournalScanner::EventMap::iterator i = js.events.begin();
+         i != js.events.end(); ++i) {
       LogEvent *le = i->second.log_event;
       EMetaBlob const *mb = le->get_metablob();
       if (mb) {
@@ -583,13 +584,15 @@ int JournalTool::scavenge_dentries(
     time_t pmtime;
     r = io.stat(frag_oid.name, &psize, &pmtime);
     if (r == -ENOENT) {
-      dout(4) << ": Frag object " << frag_oid.name << " did not exist, will create" << dendl;
+      dout(4) << ": Frag object " << frag_oid.name
+              << " did not exist, will create" << dendl;
     } else if (r != 0) {
       derr << "Unexpected error stat'ing frag " << frag_oid.name
            << ": " << cpp_strerror(r) << dendl;
       return r;
     } else {
-      dout(4) << "Frag object " << frag_oid.name << " exists, will modify" << dendl;
+      dout(4) << "Frag object " << frag_oid.name
+              << " exists, will modify" << dendl;
     }
 
     // Update fnode in omap header of dirfrag object
@@ -613,7 +616,8 @@ int JournalTool::scavenge_dentries(
           old_fnode.version << " vs new v" << lump.fnode.version << dendl;
         write_fnode = old_fnode.version < lump.fnode.version;
       } catch (const buffer::error &err) {
-        dout(1) << "frag " << frag_oid.name << " is corrupt, overwriting" << dendl;
+        dout(1) << "frag " << frag_oid.name
+                << " is corrupt, overwriting" << dendl;
         write_fnode = true;
       }
     } else {
@@ -629,14 +633,17 @@ int JournalTool::scavenge_dentries(
       lump.fnode.encode(fnode_bl);
       r = io.omap_set_header(frag_oid.name, fnode_bl);
       if (r != 0) {
-        derr << "Failed to write fnode for frag object " << frag_oid.name << dendl;
+        derr << "Failed to write fnode for frag object "
+             << frag_oid.name << dendl;
         return r;
       }
     }
 
     // Try to get the existing dentry
-    list<ceph::shared_ptr<EMetaBlob::fullbit> > const &fb_list = lump.get_dfull();
-    for (list<ceph::shared_ptr<EMetaBlob::fullbit> >::const_iterator fbi = fb_list.begin(); fbi != fb_list.end(); ++fbi) {
+    list<ceph::shared_ptr<EMetaBlob::fullbit> > const &fb_list =
+      lump.get_dfull();
+    for (list<ceph::shared_ptr<EMetaBlob::fullbit> >::const_iterator fbi =
+        fb_list.begin(); fbi != fb_list.end(); ++fbi) {
       EMetaBlob::fullbit const &fb = *(*fbi);
 
       // Get a key like "foobar_head"
@@ -655,7 +662,8 @@ int JournalTool::scavenge_dentries(
         return r;
       }
     
-      dout(4) << "inspecting fullbit " << frag_oid.name << "/" << fb.dn << dendl;
+      dout(4) << "inspecting fullbit " << frag_oid.name << "/" << fb.dn
+        << dendl;
       bool write_dentry = false;
       if (vals.find(key) == vals.end()) {
         dout(4) << "dentry did not already exist, will create" << dendl;
@@ -689,13 +697,15 @@ int JournalTool::scavenge_dentries(
             write_dentry = true;
           }
         } else {
-          dout(4) << "corrupt dentry in backing store, overwriting from journal" << dendl;
+          dout(4) << "corrupt dentry in backing store, overwriting from "
+            "journal" << dendl;
           write_dentry = true;
         }
       }
 
       if (write_dentry && !dry_run) {
-        dout(4) << "writing dentry " << key << " into frag " << frag_oid.name << dendl;
+        dout(4) << "writing dentry " << key << " into frag "
+          << frag_oid.name << dendl;
 
         // Compose: Dentry format is dnfirst, [I|L], InodeStore(bare=true)
         bufferlist dentry_bl;
@@ -723,7 +733,8 @@ int JournalTool::scavenge_dentries(
    * important because clients use them to infer completeness
    * of directories
    */
-  for (list<ceph::shared_ptr<EMetaBlob::fullbit> >::const_iterator p = metablob.roots.begin(); p != metablob.roots.end(); ++p) {
+  for (list<ceph::shared_ptr<EMetaBlob::fullbit> >::const_iterator p =
+       metablob.roots.begin(); p != metablob.roots.end(); ++p) {
     EMetaBlob::fullbit const &fb = *(*p);
     inodeno_t ino = fb.inode.ino;
     dout(4) << "updating root 0x" << std::hex << ino << std::dec << dendl;
@@ -740,7 +751,8 @@ int JournalTool::scavenge_dentries(
     } else if (r >= 0) {
       r = 0;
       InodeStore old_inode;
-      dout(4) << "root exists, will modify (" << old_root_ino_bl.length() << ")" << dendl;
+      dout(4) << "root exists, will modify (" << old_root_ino_bl.length()
+        << ")" << dendl;
       bufferlist::iterator inode_bl_iter = old_root_ino_bl.begin(); 
       std::string magic;
       ::decode(magic, inode_bl_iter);

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -738,6 +738,7 @@ int JournalTool::scavenge_dentries(
       dout(4) << "root does not exist, will create" << dendl;
       write_root_ino = true;
     } else if (r >= 0) {
+      r = 0;
       InodeStore old_inode;
       dout(4) << "root exists, will modify (" << old_root_ino_bl.length() << ")" << dendl;
       bufferlist::iterator inode_bl_iter = old_root_ino_bl.begin(); 
@@ -1106,12 +1107,6 @@ int JournalTool::consume_inos(const std::set<inodeno_t> &inos)
     ::decode(inotable_ver, q);
     InoTable ino_table(NULL);
     ino_table.decode(q);
-    interval_set<inodeno_t> projected_free;
-    /*
-    DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, q);
-    ::decode(projected_free, q);
-    DECODE_FINISH(q);
-    */
     
     // Update InoTable in memory
     bool inotable_modified = false;
@@ -1133,11 +1128,6 @@ int JournalTool::consume_inos(const std::set<inodeno_t> &inos)
       bufferlist inotable_new_bl;
       ::encode(inotable_ver, inotable_new_bl);
       ino_table.encode_state(inotable_new_bl);
-      /*
-      ENCODE_START(2, 2, inotable_new_bl);
-      ::encode(projected_free, inotable_new_bl);
-      ENCODE_FINISH(inotable_new_bl);
-      */
       int write_r = io.write_full(inotable_oid.name, inotable_new_bl);
       if (write_r != 0) {
         derr << "error writing modified inotable " << inotable_oid.name

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -368,7 +368,10 @@ int JournalTool::main_event(std::vector<const char*> &argv)
           if (r == 0) {
             r = scav_r;
           }
-          // Our goal is to read all we can, so don't stop on errors
+          // Our goal is to read all we can, so don't stop on errors, but
+          // do record them for possible later output
+          js.errors.insert(std::make_pair(i->first,
+                JournalScanner::EventError(scav_r, cpp_strerror(r))));
         }
       }
     }

--- a/src/tools/cephfs/JournalTool.h
+++ b/src/tools/cephfs/JournalTool.h
@@ -16,12 +16,12 @@
 
 #include "mds/mdstypes.h"
 #include "mds/LogEvent.h"
+#include "mds/events/EMetaBlob.h"
 
 #include "include/rados/librados.hpp"
 
 #include "JournalFilter.h"
 
-class EMetaBlob;
 class JournalScanner;
 
 
@@ -55,10 +55,21 @@ class JournalTool : public MDSUtility
     librados::IoCtx io;
 
     // Metadata backing store manipulation
+    int scavenge_dentries(
+        EMetaBlob const &metablob,
+        bool const dry_run,
+        std::set<inodeno_t> *consumed_inos);
     int replay_offline(EMetaBlob const &metablob, bool const dry_run);
 
     // Splicing
     int erase_region(JournalScanner const &jp, uint64_t const pos, uint64_t const length);
+
+    // Backing store helpers
+    void encode_fullbit_as_inode(
+        const EMetaBlob::fullbit &fb,
+        const bool bare,
+        bufferlist *out_bl);
+    int consume_inos(const std::set<inodeno_t> &inos);
 
   public:
     void usage();


### PR DESCRIPTION
This is intended as a comparatively safe recovery
operation, where we compare the versions
of journalled dentries with backing store dentries,
and write into the backing store only when the
existing contents are older than the journal
or invalid.

Fixes: #9883

Signed-off-by: John Spray <john.spray@redhat.com>