### PR TITLE
client: add ceph version to metadata

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -34,6 +34,8 @@ using namespace std;
 
 #include "common/config.h"
 
+#include "common/version.h"
+
 // ceph stuff
 
 #include "messages/MMonMap.h"
@@ -1732,6 +1734,10 @@ void Client::populate_metadata()
 
   // Ceph entity id (the '0' in "client.0")
   metadata["entity_id"] = cct->_conf->name.get_id();
+
+  // Ceph version
+  metadata["ceph_version"] = pretty_version_to_str();
+  metadata["ceph_sha1"] = git_version_to_str();
 }
 
 /**


### PR DESCRIPTION
looks like this now:

2015-01-09 14:48:18.657237 7ffd01ffb700 20 mds.0.server handle_client_session CEPH_SESSION_REQUEST_OPEN 4 metadata entries:
2015-01-09 14:48:18.657243 7ffd01ffb700 20 mds.0.server   ceph_sha1: e6a4ab1391846be1fb98e2cb9fe52893b922b073
2015-01-09 14:48:18.657246 7ffd01ffb700 20 mds.0.server   ceph_version: ceph version 0.90-826-ge6a4ab1 (e6a4ab1391846be1fb98e2cb9fe52893b922b073)
2015-01-09 14:48:18.657250 7ffd01ffb700 20 mds.0.server   entity_id: admin
2015-01-09 14:48:18.657252 7ffd01ffb700 20 mds.0.server   hostname: rex002