### PR TITLE
rgw: only keep track for cleanup of rados objects that were written

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1454,7 +1454,6 @@ int RGWPutObjProcessor_Multipart::prepare(RGWRados *store, void *obj_ctx, string
 
   head_obj = manifest_gen.get_cur_obj();
   cur_obj = head_obj;
-  add_obj(cur_obj);
 
   return 0;
 }


### PR DESCRIPTION
Fixes: #10311

We're keeping track of rados objects that we've written so that we could
clean them up if needed. Earlier we weren't too accurate about it and
were also setting the head object that is yet to be written. This now
only applies to the tail data, and a bit clearer.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>