### PR TITLE
tests: install parted in centos Dockerfile

### DIFF
--- a/src/test/centos/Dockerfile.in
+++ b/src/test/centos/Dockerfile.in
@@ -29,5 +29,5 @@ RUN rpm -ivh epel-release-7-5.noarch.rpm
 # build dependencies
 RUN cd /root ; ./install-deps.sh
 # development tools
-RUN yum install -y ccache valgrind gdb git python-virtualenv gdisk kpartx hdparm jq sudo xmlstarlet
+RUN yum install -y ccache valgrind gdb git python-virtualenv gdisk kpartx hdparm jq sudo xmlstarlet parted
 RUN useradd -M --uid %%user_id%% %%USER%% && echo '%%USER%% ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
It is needed to run root ceph-disk tests.

http://tracker.ceph.com/issues/10505 Fixes: #10505

Signed-off-by: Loic Dachary <ldachary@redhat.com>