### PR TITLE
doc: Replace cloudfiles with swiftclient in Python Swift example

### DIFF
--- a/doc/radosgw/swift/python.rst
+++ b/doc/radosgw/swift/python.rst
@@ -11,13 +11,13 @@ This creates a connection so that you can interact with the server:
 
 .. code-block:: python
 
-	import cloudfiles
-	username = 'account_name:username'
-	api_key = 'your_api_key'
+	import swiftclient
+	user = 'account_name:username'
+	key = 'your_api_key'
 
-	conn = cloudfiles.get_connection(
-		username=username,
-		api_key=api_key,
+	conn = swiftclient.Connection(
+		user=user,
+		key=key,
 		authurl='https://objects.dreamhost.com/auth',
 	)
 
@@ -29,8 +29,9 @@ This creates a new container called ``my-new-container``:
 
 .. code-block:: python
 
-	container = conn.create_container('my-new-container')
-	
+	container_name = 'my-new-container'
+	conn.put_container(container_name)
+
 
 Create an Object
 ================
@@ -39,10 +40,11 @@ This creates a file ``hello.txt`` from the file named ``my_hello.txt``:
 
 .. code-block:: python
 
-	obj = container.create_object('hello.txt')
-	obj.content_type = 'text/plain'
-	obj.load_from_filename('./my_hello.txt')
-	
+	with open('hello.txt', 'r') as hello_file:
+		conn.put_object(container_name, 'hello.txt',
+						contents= hello_file.read(),
+						content_type='text/plain')
+
 
 List Owned Containers
 =====================
@@ -51,8 +53,8 @@ This gets a list of containers that you own, and prints out the container name:
 
 .. code-block:: python
 
-	for container in conn.get_all_containers():
-		print container.name
+	for container in conn.get_account()[1]:
+		print container['name']
 
 The output will look something like this::
 
@@ -63,13 +65,13 @@ The output will look something like this::
 List a Container's Content
 ==========================
 
-This gets a list of objects in the container, and prints out each 
+This gets a list of objects in the container, and prints out each
 object's name, the file size, and last modified date:
 
 .. code-block:: python
 
-	for obj in container.get_objects():
-		print "{0}\t{1}\t{2}".format(obj.name, obj.size, obj.last_modified)
+	for data in conn.get_container(container_name)[1]:
+		print '{0}\t{1}\t{2}'.format(data['name'], data['bytes'], data['last_modified'])
 
 The output will look something like this::
 
@@ -85,8 +87,9 @@ This downloads the object ``hello.txt`` and saves it in
 
 .. code-block:: python
 
-	obj = container.get_object('hello.txt')
-	obj.save_to_filename('./my_hello.txt')
+	obj_tuple = conn.get_object(container_name, 'hello.txt')
+	with open('my_hello.txt', 'w') as my_hello:
+		my_hello.write(obj_tuple[1])
 
 
 Delete an Object
@@ -96,8 +99,8 @@ This deletes the object ``goodbye.txt``:
 
 .. code-block:: python
 
-	container.delete_object('goodbye.txt')
-	
+	conn.delete_object(container_name, 'hello.txt')
+
 Delete a Container
 ==================
 
@@ -107,5 +110,5 @@ Delete a Container
 
 .. code-block:: python
 
-	conn.delete_container(container.name)
+	conn.delete_container(container_name)
 


### PR DESCRIPTION
The Cloud Files client library is no longer supported by Rackspace.
Users installing the package receive the following warning:

DeprecationWarning: python-cloudfiles has been deprecated as of August
1, 2013. Please see https://github.com/openstack/python-swiftclient.

This commit updates the documentation to use the python-swiftclient
package.

Signed-off-by: Tim Freund <tim@freunds.net>