### PR TITLE
mon: improve paxos proposals

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4144,11 +4144,9 @@ void Monitor::tick()
 
   if (is_leader() && paxos->is_active() && fingerprint.is_zero()) {
     // this is only necessary on upgraded clusters.
-    MonitorDBStore::TransactionRef t(new MonitorDBStore::Transaction);
+    MonitorDBStore::TransactionRef t = paxos->get_pending_transaction();
     prepare_new_fingerprint(t);
-    bufferlist tbl;
-    t->encode(tbl);
-    paxos->propose_new_value(tbl, new C_NoopContext);
+    paxos->trigger_propose();
   }
 
   new_tick();

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -572,6 +572,8 @@ void Paxos::handle_last(MMonPaxos *last)
 	  finish_contexts(g_ceph_context, waiting_for_active);
 	  finish_contexts(g_ceph_context, waiting_for_readable);
 	  finish_contexts(g_ceph_context, waiting_for_writeable);
+
+          queue_next();
 	}
       }
     }
@@ -920,6 +922,8 @@ void Paxos::commit_finish()
     finish_contexts(g_ceph_context, waiting_for_active);
     finish_contexts(g_ceph_context, waiting_for_readable);
     finish_contexts(g_ceph_context, waiting_for_writeable);
+
+    queue_next();
   }
 }
 
@@ -1053,11 +1057,15 @@ void Paxos::commit_proposal()
 
 void Paxos::finish_round()
 {
+  dout(10) << __func__ << dendl;
   assert(mon->is_leader());
 
   // ok, now go active!
   state = STATE_ACTIVE;
+}
 
+void Paxos::queue_next()
+{
   dout(10) << __func__ << " state " << state
 	   << " proposals left " << proposals.size() << dendl;
 
@@ -1069,6 +1077,7 @@ void Paxos::finish_round()
     propose_queued();
   }
 }
+
 
 // peon
 void Paxos::handle_lease(MMonPaxos *lease)

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -1038,21 +1038,13 @@ void Paxos::commit_proposal()
   dout(10) << __func__ << dendl;
   assert(mon->is_leader());
   assert(is_refresh());
-
-  if (proposals.empty()) {
+  if (!pending_proposal) {
     return;  // must have been updating previous
   }
 
-  C_Proposal *proposal = static_cast<C_Proposal*>(proposals.front());
-  if (proposal->proposed) {
-    dout(10) << __func__ << " proposal " << proposal << " took "
-	     << (ceph_clock_now(NULL) - proposal->proposal_time)
-	     << " to finish" << dendl;
-    proposals.pop_front();
-    proposal->complete(0);
-  } else {
-    // must have been updating previous.
-  }
+  list<Context*> ls;
+  ls.swap(committing_finishers);
+  finish_contexts(g_ceph_context, ls);
 }
 
 void Paxos::finish_round()
@@ -1066,15 +1058,14 @@ void Paxos::finish_round()
 
 void Paxos::queue_next()
 {
-  dout(10) << __func__ << " state " << state
-	   << " proposals left " << proposals.size() << dendl;
+  dout(10) << __func__ << " state " << state << dendl;
 
   if (should_trim()) {
     trim();
   }
 
-  if (is_active() && !proposals.empty()) {
-    propose_queued();
+  if (is_active() && pending_proposal) {
+    propose_pending();
   }
 }
 
@@ -1212,7 +1203,7 @@ void Paxos::trim()
 
   dout(10) << "trim to " << end << " (was " << first_committed << ")" << dendl;
 
-  MonitorDBStore::TransactionRef t(new MonitorDBStore::Transaction);
+  MonitorDBStore::TransactionRef t = get_pending_transaction();
 
   for (version_t v = first_committed; v < end; ++v) {
     dout(10) << "trim " << v << dendl;
@@ -1224,17 +1215,8 @@ void Paxos::trim()
     t->compact_range(get_name(), stringify(first_committed - 1), stringify(end));
   }
 
-  dout(30) << __func__ << " transaction dump:\n";
-  JSONFormatter f(true);
-  t->dump(&f);
-  f.flush(*_dout);
-  *_dout << dendl;
-
-  bufferlist bl;
-  t->encode(bl);
-
   trimming = true;
-  queue_proposal(bl, new C_Trimmed(this));
+  queue_pending_finisher(new C_Trimmed(this));
 }
 
 /*
@@ -1304,7 +1286,8 @@ void Paxos::shutdown() {
   finish_contexts(g_ceph_context, waiting_for_commit, -ECANCELED);
   finish_contexts(g_ceph_context, waiting_for_readable, -ECANCELED);
   finish_contexts(g_ceph_context, waiting_for_active, -ECANCELED);
-  finish_contexts(g_ceph_context, proposals, -ECANCELED);
+  finish_contexts(g_ceph_context, pending_finishers, -ECANCELED);
+  finish_contexts(g_ceph_context, committing_finishers, -ECANCELED);
   if (logger)
     g_ceph_context->get_perfcounters_collection()->remove(logger);
   delete logger;
@@ -1315,7 +1298,8 @@ void Paxos::leader_init()
   cancel_events();
   new_value.clear();
 
-  finish_contexts(g_ceph_context, proposals, -EAGAIN);
+  finish_contexts(g_ceph_context, pending_finishers, -EAGAIN);
+  finish_contexts(g_ceph_context, committing_finishers, -EAGAIN);
 
   logger->inc(l_paxos_start_leader);
 
@@ -1345,7 +1329,8 @@ void Paxos::peon_init()
   // no chance to write now!
   finish_contexts(g_ceph_context, waiting_for_writeable, -EAGAIN);
   finish_contexts(g_ceph_context, waiting_for_commit, -EAGAIN);
-  finish_contexts(g_ceph_context, proposals, -EAGAIN);
+  finish_contexts(g_ceph_context, pending_finishers, -EAGAIN);
+  finish_contexts(g_ceph_context, committing_finishers, -EAGAIN);
 
   logger->inc(l_paxos_start_peon);
 }
@@ -1365,7 +1350,8 @@ void Paxos::restart()
   }
   state = STATE_RECOVERING;
 
-  finish_contexts(g_ceph_context, proposals, -EAGAIN);
+  finish_contexts(g_ceph_context, committing_finishers, -EAGAIN);
+  finish_contexts(g_ceph_context, pending_finishers, -EAGAIN);
   finish_contexts(g_ceph_context, waiting_for_commit, -EAGAIN);
   finish_contexts(g_ceph_context, waiting_for_active, -EAGAIN);
 
@@ -1484,60 +1470,60 @@ bool Paxos::is_writeable()
     is_lease_valid();
 }
 
-void Paxos::list_proposals(ostream& out)
-{
-  out << __func__ << " " << proposals.size() << " in queue:\n";
-  list<Context*>::iterator p_it = proposals.begin();
-  for (int i = 0; p_it != proposals.end(); ++p_it, ++i) {
-    C_Proposal *p = (C_Proposal*) *p_it;
-    out << "-- entry #" << i << "\n";
-    out << *p << "\n";
-  }
-}
-
-void Paxos::propose_queued()
+void Paxos::propose_pending()
 {
   assert(is_active());
-  assert(!proposals.empty());
-
-  C_Proposal *proposal = static_cast<C_Proposal*>(proposals.front());
-  assert(!proposal->proposed);
+  assert(pending_proposal);
 
   cancel_events();
-  dout(10) << __func__ << " " << (last_committed + 1)
-	  << " " << proposal->bl.length() << " bytes" << dendl;
-  proposal->proposed = true;
 
-  dout(30) << __func__ << " ";
-  list_proposals(*_dout);
+  bufferlist bl;
+  pending_proposal->encode(bl);
+
+  dout(10) << __func__ << " " << (last_committed + 1)
+	   << " " << bl.length() << " bytes" << dendl;
+
+  dout(30) << __func__ << " transaction dump:\n";
+  JSONFormatter f(true);
+  pending_proposal->dump(&f);
+  f.flush(*_dout);
   *_dout << dendl;
 
+  pending_proposal.reset();
+
+  committing_finishers.swap(pending_finishers);
+
   state = STATE_UPDATING;
-  begin(proposal->bl);
+  begin(bl);
 }
 
-void Paxos::queue_proposal(bufferlist& bl, Context *onfinished)
+void Paxos::queue_pending_finisher(Context *onfinished)
 {
-  dout(5) << __func__ << " bl " << bl.length() << " bytes;"
-	  << " ctx = " << onfinished << dendl;
-
-  proposals.push_back(new C_Proposal(onfinished, bl));
+  dout(5) << __func__ << " " << onfinished << dendl;
+  assert(onfinished);
+  pending_finishers.push_back(onfinished);
 }
 
-bool Paxos::propose_new_value(bufferlist& bl, Context *onfinished)
+MonitorDBStore::TransactionRef Paxos::get_pending_transaction()
 {
   assert(mon->is_leader());
-
-  queue_proposal(bl, onfinished);
-
-  if (!is_active()) {
-    dout(5) << __func__ << " not active; proposal queued" << dendl; 
-    return true;
+  if (!pending_proposal) {
+    pending_proposal.reset(new MonitorDBStore::Transaction);
+    assert(pending_finishers.empty());
   }
+  return pending_proposal;
+}
 
-  propose_queued();
-  
-  return true;
+bool Paxos::trigger_propose()
+{
+  if (is_active()) {
+    dout(10) << __func__ << " active, proposing now" << dendl;
+    propose_pending();
+    return true;
+  } else {
+    dout(10) << __func__ << " not active, will propose later" << dendl;
+    return false;
+  }
 }
 
 bool Paxos::is_consistent()

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -1070,6 +1070,7 @@ private:
 
   void commit_proposal();
   void finish_round();
+  void queue_next();
 
 public:
   /**

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -578,10 +578,10 @@ private:
   /**
    *
    */
-  list<Context*> proposals;
-  /**
-   * @}
-   */
+
+  MonitorDBStore::TransactionRef pending_proposal;
+  list<Context*> pending_finishers;
+  list<Context*> committing_finishers;
 
   /**
    * @defgroup Paxos_h_sync_warns Synchronization warnings
@@ -1046,17 +1046,9 @@ private:
   void warn_on_future_time(utime_t t, entity_name_t from);
 
   /**
-   * Queue a new proposal by pushing it at the back of the queue; do not
-   * propose it.
-   *
-   * @param bl The bufferlist to be proposed
-   * @param onfinished The callback to be called once the proposal finishes
-   */
-  void queue_proposal(bufferlist& bl, Context *onfinished);
-  /**
    * Begin proposing the Proposal at the front of the proposals queue.
    */
-  void propose_queued();
+  void propose_pending();
 
   /**
    * refresh state from store
@@ -1335,13 +1327,6 @@ public:
   }
 
   /**
-   * List all queued proposals
-   *
-   * @param out[out] Output Stream onto which we will output the list
-   *		     of queued proposals.
-   */
-  void list_proposals(ostream& out);
-  /**
    * Propose a new value to the Leader.
    *
    * This function enables the submission of a new value to the Leader, which
@@ -1350,7 +1335,11 @@ public:
    * @param bl A bufferlist holding the value to be proposed
    * @param onfinish A callback to be fired up once we finish the proposal
    */
-  bool propose_new_value(bufferlist& bl, Context *onfinished=0);
+  MonitorDBStore::TransactionRef get_pending_transaction();
+  void queue_pending_finisher(Context *onfinished);
+
+  bool trigger_propose();
+
   /**
    * Add oncommit to the back of the list of callbacks waiting for us to
    * finish committing.


### PR DESCRIPTION
- do callbacks before queuing next proposal
- propose everything in a single round insetad of queueing multiple smaller
  transactions

This helped immensely with congress under load.