### PR TITLE
librados: bump rados version number

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -40,7 +40,7 @@ extern "C" {
 
 #define LIBRADOS_VER_MAJOR 0
 #define LIBRADOS_VER_MINOR 69
-#define LIBRADOS_VER_EXTRA 0
+#define LIBRADOS_VER_EXTRA 1
 
 #define LIBRADOS_VERSION(maj, min, extra) ((maj << 16) + (min << 8) + extra)
 


### PR DESCRIPTION
As a follow-on to 49d114f1fff90e5c0f206725a5eb82c0ba329376,
increment the "extra" version field so clients can easily
determine if they have a version of librados that properly
translates C API operation flags.

Signed-off-by: Matthew Richards <mattjrichards@gmail.com>