### PR TITLE
qa: set -e explicitly in quota test

### DIFF
--- a/qa/workunits/fs/misc/quota.sh
+++ b/qa/workunits/fs/misc/quota.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -ex
+#!/bin/bash
+
+set -e
+set -x
 
 function expect_false()
 {


### PR DESCRIPTION
Previously was set in hashbang, which meant
that "./quota.sh" was OK, but "sh ./quota.sh" would
just run through ignoring errors.

Signed-off-by: John Spray <john.spray@redhat.com>