### PR TITLE
qa: fail_all_mds between fs reset and fs rm

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -719,6 +719,8 @@ function test_mon_mds()
   # Check that 'fs reset' runs
   ceph fs reset cephfs --yes-i-really-mean-it
 
+  fail_all_mds
+
   # Clean up to enable subsequent newfs tests
   ceph fs rm cephfs --yes-i-really-mean-it
 


### PR DESCRIPTION
Because fs reset opens a brief window for the previously
failed MDSs to spring back into life.

Fixes: #10539

Signed-off-by: John Spray <john.spray@redhat.com>