### PR TITLE
qa: ignore duplicates in rados ls

### DIFF
--- a/qa/workunits/rbd/import_export.sh
+++ b/qa/workunits/rbd/import_export.sh
@@ -9,7 +9,7 @@ objects () {
    # it doesn't necessarily make sense as they're hex, at least it makes
    # the list repeatable and comparable
    objects=$(rados ls -p rbd | grep $prefix | \
-       sed -e 's/'$prefix'\.//' -e 's/^0*\([0-9a-f]\)/\1/' | sort)
+       sed -e 's/'$prefix'\.//' -e 's/^0*\([0-9a-f]\)/\1/' | sort -u)
    echo $objects
 }
 


### PR DESCRIPTION
These can happen with split or with state changes due to reordering results
within the hash range requested. It's easy enough to filter them out at this
stage.

Backport: giant, firefly
Signed-off-by: Josh Durgin <jdurgin@redhat.com>