### PR TITLE
osd: fix journal header.committed_up_to

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -509,6 +509,8 @@ int FileJournal::open(uint64_t fs_op_seq)
   // looks like a valid header.
   write_pos = 0;  // not writeable yet
 
+  journaled_seq = header.committed_up_to;
+
   // find next entry
   read_pos = header.start;
   uint64_t seq = header.start_seq;
@@ -1723,6 +1725,8 @@ bool FileJournal::read_entry(
     } else {
       read_pos = next_pos;
       next_seq = seq;
+      if (seq > journaled_seq)
+        journaled_seq = seq;
       return true;
     }
   }


### PR DESCRIPTION
Journal  header.committed_up_to may reset to 0 sometimes. 
Such as, we set g_conf->journal_write_header_frequency 1. When osd restart and recevied first op,  call do_write(or do_aio_write)
then call prepare_header(), and then header.committed_up_to reset to 0 now,  because journaled_seq is 0 when osd restart.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>