### PR TITLE
common: restore format fallback semantic

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -64,7 +64,8 @@ Formatter::Formatter() { }
 Formatter::~Formatter() { }
 
 Formatter *Formatter::create(const std::string &type,
-			     const std::string& default_type)
+			     const std::string& default_type,
+			     const std::string& fallback)
 {
   std::string mytype = type;
   if (mytype == "")
@@ -82,6 +83,8 @@ Formatter *Formatter::create(const std::string &type,
     return new TableFormatter();
   else if (mytype == "table-kv")
     return new TableFormatter(true);
+  else if (fallback != "")
+    return create(fallback, "", "");
   else
     return (Formatter *) NULL;
 }

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -28,9 +28,14 @@ namespace ceph {
   class Formatter {
   public:
     static Formatter *create(const std::string& type,
-			     const std::string& default_type);
+			     const std::string& default_type,
+			     const std::string& fallback);
+    static Formatter *create(const std::string& type,
+			     const std::string& default_type) {
+      return create(type, default_type, "");
+    }
     static Formatter *create(const std::string& type) {
-      return create(type, "json-pretty");
+      return create(type, "json-pretty", "");
     }
 
     Formatter();

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -448,7 +448,7 @@ class HelpHook : public AdminSocketHook {
 public:
   HelpHook(AdminSocket *as) : m_as(as) {}
   bool call(string command, cmdmap_t &cmdmap, string format, bufferlist& out) {
-    Formatter *f = Formatter::create(format);
+    Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
     f->open_object_section("help");
     for (map<string,string>::iterator p = m_as->m_help.begin();
 	 p != m_as->m_help.end();

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -225,7 +225,7 @@ public:
 void CephContext::do_command(std::string command, cmdmap_t& cmdmap,
 			     std::string format, bufferlist *out)
 {
-  Formatter *f = Formatter::create(format);
+  Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
   stringstream ss;
   for (cmdmap_t::iterator it = cmdmap.begin(); it != cmdmap.end(); ++it) {
     if (it->first != "prefix") {

--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -221,7 +221,7 @@ bool MDS::asok_command(string command, cmdmap_t& cmdmap, string format,
 {
   dout(1) << "asok_command: " << command << " (starting...)" << dendl;
 
-  Formatter *f = Formatter::create(format);
+  Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
   if (command == "status") {
 
     const OSDMap *osdmap = objecter->get_osdmap_read();

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2478,8 +2478,8 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
       goto reply;
     }
     string format;
-    cmd_getval(g_ceph_context, cmdmap, "format", format, string("json-pretty"));
-    boost::scoped_ptr<Formatter> f(Formatter::create(format));
+    cmd_getval(g_ceph_context, cmdmap, "format", format);
+    boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
     f->open_object_section("osd_location");
     f->dump_int("osd", osd);
     f->dump_stream("ip") << osdmap.get_addr(osd);
@@ -2504,8 +2504,8 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
       goto reply;
     }
     string format;
-    cmd_getval(g_ceph_context, cmdmap, "format", format, string("json-pretty"));
-    boost::scoped_ptr<Formatter> f(Formatter::create(format));
+    cmd_getval(g_ceph_context, cmdmap, "format", format);
+    boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
     f->open_object_section("osd_metadata");
     r = dump_osd_metadata(osd, f.get(), &ss);
     if (r < 0)
@@ -3001,8 +3001,8 @@ stats_out:
   } else if (prefix == "osd crush rule list" ||
 	     prefix == "osd crush rule ls") {
     string format;
-    cmd_getval(g_ceph_context, cmdmap, "format", format, string("json-pretty"));
-    boost::scoped_ptr<Formatter> f(Formatter::create(format));
+    cmd_getval(g_ceph_context, cmdmap, "format", format);
+    boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
     f->open_array_section("rules");
     osdmap.crush->list_rules(f.get());
     f->close_section();
@@ -3014,8 +3014,8 @@ stats_out:
     string name;
     cmd_getval(g_ceph_context, cmdmap, "name", name);
     string format;
-    cmd_getval(g_ceph_context, cmdmap, "format", format, string("json-pretty"));
-    boost::scoped_ptr<Formatter> f(Formatter::create(format));
+    cmd_getval(g_ceph_context, cmdmap, "format", format);
+    boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
     if (name == "") {
       f->open_array_section("rules");
       osdmap.crush->dump_rules(f.get());
@@ -3035,8 +3035,8 @@ stats_out:
     rdata.append(rs.str());
   } else if (prefix == "osd crush dump") {
     string format;
-    cmd_getval(g_ceph_context, cmdmap, "format", format, string("json-pretty"));
-    boost::scoped_ptr<Formatter> f(Formatter::create(format));
+    cmd_getval(g_ceph_context, cmdmap, "format", format);
+    boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
     f->open_object_section("crush_map");
     osdmap.crush->dump(f.get());
     f->close_section();
@@ -3046,8 +3046,8 @@ stats_out:
     rdata.append(rs.str());
   } else if (prefix == "osd crush show-tunables") {
     string format;
-    cmd_getval(g_ceph_context, cmdmap, "format", format, string("json-pretty"));
-    boost::scoped_ptr<Formatter> f(Formatter::create(format));
+    cmd_getval(g_ceph_context, cmdmap, "format", format);
+    boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
     f->open_object_section("crush_map_tunables");
     osdmap.crush->dump_tunables(f.get());
     f->close_section();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1626,7 +1626,7 @@ public:
 bool OSD::asok_command(string command, cmdmap_t& cmdmap, string format,
 		       ostream& ss)
 {
-  Formatter *f = Formatter::create(format);
+  Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
   if (command == "status") {
     f->open_object_section("status");
     f->dump_stream("cluster_fsid") << superblock.cluster_fsid;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -603,7 +603,7 @@ int ReplicatedPG::do_command(cmdmap_t cmdmap, ostream& ss,
   string format;
 
   cmd_getval(cct, cmdmap, "format", format);
-  boost::scoped_ptr<Formatter> f(Formatter::create(format, "json"));
+  boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json"));
 
   string command;
   cmd_getval(cct, cmdmap, "cmd", command);

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -4225,7 +4225,7 @@ Objecter::RequestStateHook::RequestStateHook(Objecter *objecter) :
 bool Objecter::RequestStateHook::call(std::string command, cmdmap_t& cmdmap,
 				      std::string format, bufferlist& out)
 {
-  Formatter *f = Formatter::create(format);
+  Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
   RWLock::RLocker rl(m_objecter->rwlock);
   m_objecter->dump_requests(f);
   f->flush(out);

--- a/src/test/ceph-helpers.sh
+++ b/src/test/ceph-helpers.sh
@@ -273,9 +273,9 @@ function test_run_mon() {
     setup $dir || return 1
 
     run_mon $dir a || return 1
-    local size=$(CEPH_ARGS='' ceph daemon $dir/ceph-mon.a.asok \
+    local size=$(CEPH_ARGS='' ceph --format=json daemon $dir/ceph-mon.a.asok \
         config get osd_pool_default_size)
-    test "$size" = '{ "osd_pool_default_size": "3"}' || return 1
+    test "$size" = '{"osd_pool_default_size":"3"}' || return 1
 
     ! CEPH_ARGS='' ceph status || return 1
     CEPH_ARGS='' ceph --conf $dir/ceph.conf status || return 1
@@ -283,16 +283,16 @@ function test_run_mon() {
     kill_daemons $dir
 
     run_mon $dir a --osd_pool_default_size=1 || return 1
-    local size=$(CEPH_ARGS='' ceph daemon $dir/ceph-mon.a.asok \
+    local size=$(CEPH_ARGS='' ceph --format=json daemon $dir/ceph-mon.a.asok \
         config get osd_pool_default_size)
-    test "$size" = '{ "osd_pool_default_size": "1"}' || return 1
+    test "$size" = '{"osd_pool_default_size":"1"}' || return 1
     kill_daemons $dir
 
     CEPH_ARGS="$CEPH_ARGS --osd_pool_default_size=2" \
         run_mon $dir a || return 1
-    local size=$(CEPH_ARGS='' ceph daemon $dir/ceph-mon.a.asok \
+    local size=$(CEPH_ARGS='' ceph --format=json daemon $dir/ceph-mon.a.asok \
         config get osd_pool_default_size)
-    test "$size" = '{ "osd_pool_default_size": "2"}' || return 1
+    test "$size" = '{"osd_pool_default_size":"2"}' || return 1
     kill_daemons $dir
 
     teardown $dir || return 1
@@ -359,19 +359,19 @@ function test_run_osd() {
     run_mon $dir a || return 1
 
     run_osd $dir 0 || return 1
-    local backfills=$(CEPH_ARGS='' ceph daemon $dir//ceph-osd.0.asok \
+    local backfills=$(CEPH_ARGS='' ceph --format=json daemon $dir//ceph-osd.0.asok \
         config get osd_max_backfills)
-    test "$backfills" = '{ "osd_max_backfills": "10"}' || return 1
+    test "$backfills" = '{"osd_max_backfills":"10"}' || return 1
 
     run_osd $dir 1 --osd-max-backfills 20 || return 1
-    local backfills=$(CEPH_ARGS='' ceph daemon $dir//ceph-osd.1.asok \
+    local backfills=$(CEPH_ARGS='' ceph --format=json daemon $dir//ceph-osd.1.asok \
         config get osd_max_backfills)
-    test "$backfills" = '{ "osd_max_backfills": "20"}' || return 1
+    test "$backfills" = '{"osd_max_backfills":"20"}' || return 1
 
     CEPH_ARGS="$CEPH_ARGS --osd-max-backfills 30" run_osd $dir 2 || return 1
-    local backfills=$(CEPH_ARGS='' ceph daemon $dir//ceph-osd.2.asok \
+    local backfills=$(CEPH_ARGS='' ceph --format=json daemon $dir//ceph-osd.2.asok \
         config get osd_max_backfills)
-    test "$backfills" = '{ "osd_max_backfills": "30"}' || return 1
+    test "$backfills" = '{"osd_max_backfills":"30"}' || return 1
 
     teardown $dir || return 1
 }
@@ -471,16 +471,16 @@ function test_activate_osd() {
     run_mon $dir a || return 1
 
     run_osd $dir 0 || return 1
-    local backfills=$(CEPH_ARGS='' ceph daemon $dir//ceph-osd.0.asok \
+    local backfills=$(CEPH_ARGS='' ceph --format=json daemon $dir//ceph-osd.0.asok \
         config get osd_max_backfills)
-    test "$backfills" = '{ "osd_max_backfills": "10"}' || return 1
+    test "$backfills" = '{"osd_max_backfills":"10"}' || return 1
 
     kill_daemons $dir TERM osd
 
     activate_osd $dir 0 --osd-max-backfills 20 || return 1
-    local backfills=$(CEPH_ARGS='' ceph daemon $dir//ceph-osd.0.asok \
+    local backfills=$(CEPH_ARGS='' ceph --format=json daemon $dir//ceph-osd.0.asok \
         config get osd_max_backfills)
-    test "$backfills" = '{ "osd_max_backfills": "20"}' || return 1
+    test "$backfills" = '{"osd_max_backfills":"20"}' || return 1
 
     teardown $dir || return 1
 }

--- a/src/test/ceph-helpers.sh
+++ b/src/test/ceph-helpers.sh
@@ -463,7 +463,7 @@ function activate_osd() {
     return $status
 }
 
-function test_run_osd() {
+function test_activate_osd() {
     local dir=$1
 
     setup $dir || return 1

--- a/src/test/common/test_context.cc
+++ b/src/test/common/test_context.cc
@@ -47,7 +47,7 @@ TEST(CephContext, do_command)
     bufferlist out;
     cct->do_command("config get", cmdmap, "UNSUPPORTED", &out);
     string s(out.c_str(), out.length());
-    EXPECT_EQ("{ \"key\": \"value\"}", s);
+    EXPECT_EQ("{\n    \"key\": \"value\"\n}\n", s);
   }
 
   cct->put();

--- a/src/test/crush/TestCrushWrapper.cc
+++ b/src/test/crush/TestCrushWrapper.cc
@@ -850,7 +850,7 @@ TEST(CrushWrapper, dump_rules) {
     stringstream ss;
     f->flush(ss);
     delete f;
-    EXPECT_EQ("", ss.str());
+    EXPECT_EQ("\n", ss.str());
   }
 
   string name("NAME");

--- a/src/test/perf_counters.cc
+++ b/src/test/perf_counters.cc
@@ -61,7 +61,7 @@ TEST(PerfCounters, SimpleTest) {
   AdminSocketClient client(get_rand_socket_path());
   std::string message;
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\" }", &message));
-  ASSERT_EQ("{}", message);
+  ASSERT_EQ("{}\n", message);
 }
 
 enum {


### PR DESCRIPTION
When Formatter::create replaced new_formatter, the handling of an
invalid format was also incorrectly changed. When an invalid format (for
instance "plain") was specified, new_formatter returned a NULL pointer
which was sometime handled by creating a json-pretty formatter and
sometimes differently.

A new Formatter::create prototype with a fallback argument is added and
is used if it is not the empty string and that the format is not
known. This prototype is used where new_formatter returning NULL was
replaced by a json-pretty formatter.

Signed-off-by: Loic Dachary <ldachary@redhat.com>