### PR TITLE
mon/MDSMonitor: make 'mds fail' idempotent for IDs

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -874,8 +874,9 @@ int MDSMonitor::fail_mds(std::ostream &ss, const std::string &arg)
     // Try to interpret the arg as an MDS name
     const MDSMap::mds_info_t *mds_info = mdsmap.find_by_name(arg);
     if (!mds_info) {
-      ss << "Can't find any MDS named '" << arg << "'";
-      return -ENOENT;
+      ss << "MDS named '" << arg
+         << "' does not exist, or is not up";
+      return 0;
     }
     if (mds_info->rank >= 0) {
       dout(10) << __func__ << ": resolved MDS name '" << arg << "' to rank " << rank_or_gid << dendl;


### PR DESCRIPTION
Was returning ENOENT, should succeed for 'fail' on
a non-existent name, as the fail operation makes
it cease to exist.

Signed-off-by: John Spray <john.spray@redhat.com>