### PR TITLE
doc: add cases where ceph-extras is not needed

### DIFF
--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -124,6 +124,10 @@ Add our Ceph Extras package repository to your system's list of APT sources. ::
 RPM Packages
 ------------
 
+.. note:: ceph-extras on RPM-based systems is only needed on EL6-based
+   distributions (RHEL 6, CentOS 6, Scientific Linux 6). It is not needed
+   for Fedora or RHEL 7+.
+
 For RPM packages, add our package repository to your ``/etc/yum.repos.d`` repos (e.g.,
 ``ceph-extras.repo``). Some Ceph packages (e.g., QEMU) must take priority over standard 
 packages, so you must ensure that you set ``priority=2``. ::

--- a/doc/install/install-vm-cloud.rst
+++ b/doc/install/install-vm-cloud.rst
@@ -57,6 +57,10 @@ To install QEMU, execute the following:
 	[main]
 	enabled = 1
 
+.. note:: ceph-extras on RPM-based systems is only needed on EL6-based
+   distributions (RHEL 6, CentOS 6, Scientific Linux 6). It is not needed
+   for Fedora or RHEL 7+.
+
 #. Create a ``/etc/yum.repos.d/ceph-extras.repo`` file with the following 
    contents, and replace ``{distro}`` with your Linux distribution. Follow
    the ``baseurl`` path below to see which distributions Ceph supports:: 


### PR DESCRIPTION
The Ceph Extras repo is not needed on EL7 distributions or
Fedora

http://tracker.ceph.com/issues/9793 Refs: #9793

Signed-off-by: Travis Rhoden <trhoden@redhat.com>