### PR TITLE
fix command 'ceph pg dump_stuck degraded'

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -954,7 +954,7 @@ Subcommand ``dump_stuck`` shows information about stuck pgs.
 
 Usage::
 
-	ceph pg dump_stuck {inactive|unclean|stale[inactive|unclean|stale...]}
+	ceph pg dump_stuck {inactive|unclean|stale[inactive|unclean|stale|undersized|degraded...]}
 	{<int>}
 
 Subcommand ``force_create_pg`` forces creation of pg <pgid>.

--- a/doc/rados/operations/control.rst
+++ b/doc/rados/operations/control.rst
@@ -65,7 +65,7 @@ The valid formats are ``plain`` (default) and ``json``.
 To display the statistics for all placement groups stuck in a specified state, 
 execute the following:: 
 
-	ceph pg dump_stuck inactive|unclean|stale [--format {format}] [-t|--threshold {seconds}]
+	ceph pg dump_stuck inactive|unclean|stale|undersized|degraded [--format {format}] [-t|--threshold {seconds}]
 
 
 ``--format`` may be ``plain`` (default) or ``json``

--- a/doc/rados/operations/monitoring-osd-pg.rst
+++ b/doc/rados/operations/monitoring-osd-pg.rst
@@ -552,7 +552,7 @@ include:
 
 To identify stuck placement groups, execute the following:: 
 
-	ceph pg dump_stuck [unclean|inactive|stale]
+	ceph pg dump_stuck [unclean|inactive|stale|undersized|degraded]
 
 See `Placement Group Subsystem`_ for additional details. To troubleshoot
 stuck placement groups, see `Troubleshooting PG Errors`_.

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -342,7 +342,7 @@ Get Statistics for Stuck PGs
 To get the statistics for all placement groups stuck in a specified state,
 execute the following::
 
-        ceph pg dump_stuck inactive|unclean|stale [--format <format>] [-t|--threshold <seconds>]
+        ceph pg dump_stuck inactive|unclean|stale|undersized|degraded [--format <format>] [-t|--threshold <seconds>]
 
 **Inactive** Placement groups cannot process reads or writes because they are waiting for an OSD
 with the most up-to-date data to come up and in.

--- a/man/ceph.8
+++ b/man/ceph.8
@@ -2020,7 +2020,7 @@ Usage:
 .sp
 .nf
 .ft C
-ceph pg dump_stuck {inactive|unclean|stale[inactive|unclean|stale...]}
+ceph pg dump_stuck {inactive|unclean|stale|undersized|degraded[inactive|unclean|stale|undersized|degraded...]}
 {<int>}
 .ft P
 .fi

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1056,6 +1056,8 @@ function test_mon_pg()
   ceph pg dump_stuck inactive
   ceph pg dump_stuck unclean
   ceph pg dump_stuck stale
+  ceph pg dump_stuck undersized
+  ceph pg dump_stuck degraded
   # can't test this...
   # ceph pg force_create_pg
   ceph pg getmap -o $TMPDIR/map.$$

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -123,7 +123,7 @@ COMMAND("pg dump_json " \
 COMMAND("pg dump_pools_json", "show pg pools info in json only",\
 	"pg", "r", "cli,rest")
 COMMAND("pg dump_stuck " \
-	"name=stuckops,type=CephChoices,strings=inactive|unclean|stale,n=N,req=false " \
+	"name=stuckops,type=CephChoices,strings=inactive|unclean|stale|undersized|degraded,n=N,req=false " \
 	"name=threshold,type=CephInt,req=false",
 	"show information about stuck pgs",\
 	"pg", "r", "cli,rest")


### PR DESCRIPTION
undersized not valid:  undersized not in inactive|unclean|stale
undersized not valid:  undersized doesn't represent an int
Invalid command:  unused arguments: ['undersized']
pg dump_stuck {inactive|unclean|stale [inactive|unclean|stale...]} {<int>} :  show information about stuck pgs

Signed-off-by: xinxin shu <xinxin.shu@intel.com>