### PR TITLE
Change crush_ln to provide 32 more digits.

### DIFF
--- a/src/crush/crush_ln_table.h
+++ b/src/crush/crush_ln_table.h
@@ -24,6 +24,9 @@
 #define CEPH_CRUSH_LN_H
 
 
+// RH_LH_tbl[2*k] = 2^48/(1.0+k/128.0)
+// RH_LH_tbl[2*k+1] = 2^48*log2(1.0+k/128.0)
+
 static int64_t __RH_LH_tbl[128*2+2] = {
   0x0001000000000000ll, 0x0000000000000000ll, 0x0000fe03f80fe040ll, 0x000002dfca16dde1ll, 
   0x0000fc0fc0fc0fc1ll, 0x000005b9e5a170b4ll, 0x0000fa232cf25214ll, 0x0000088e68ea899all, 


### PR DESCRIPTION
32 more digits(more precision) were given by crush_ln, so we dont
 need to do left shift in bucket_straw2_choose now.

This change will slightly improve the quality of distribution.

expect                  169.664
osd     weight  count   adjusted
0       1       179     179
1       1.75    291     166
2       3.062   507     165
3       5.359   937     174
4       9.379   1581    168
5       16.41   2771    168
6       28.72   4847    168
7       50.27   8690    172
8       87.96   14924   169
9       153.9   26069   169
10      269.4   45706   169
11      471.4   79754   169
12      825     139847  169
13      1444    245707  170
14      2527    428190  169
std dev 12.4895
     vs 12.6005 (expected)

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>