### PR TITLE
osdc: Don't allow empty pool names when creating a pool

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3460,6 +3460,9 @@ int Objecter::create_pool(string& name, Context *onfinish, uint64_t auid,
   RWLock::WLocker wl(rwlock);
   ldout(cct, 10) << "create_pool name=" << name << dendl;
 
+  if (name.length() == 0)
+    return -EINVAL;
+
   if (osdmap->lookup_pg_pool_name(name.c_str()) >= 0)
     return -EEXIST;
 


### PR DESCRIPTION
Fixes: #10555

Signed-off-by: Wido den Hollander <wido@42on.com>