### PR TITLE
tests: centos7 needs nc to run make check

### DIFF
--- a/src/test/centos/Dockerfile.in
+++ b/src/test/centos/Dockerfile.in
@@ -29,5 +29,6 @@ RUN rpm -ivh epel-release-7-5.noarch.rpm
 # build dependencies
 RUN cd /root ; ./install-deps.sh
 # development tools
-RUN yum install -y ccache valgrind gdb git python-virtualenv gdisk kpartx hdparm jq sudo xmlstarlet parted
+# nc is required to run make check on firefly only (giant+ do not use nc)
+RUN yum install -y ccache valgrind gdb git python-virtualenv gdisk kpartx hdparm jq sudo xmlstarlet parted nc
 RUN useradd -M --uid %%user_id%% %%USER%% && echo '%%USER%% ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
It is not added to ceph.spec.in because the requirement disapeared after
firefly.

Signed-off-by: Loic Dachary <ldachary@redhat.com>