### PR TITLE
osd: ignore bad_peer when found in ok_peers

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3619,8 +3619,17 @@ void PG::repair_object(
     list<pair<ScrubMap::object, pg_shard_t> >::iterator i;
     for (i = ok_peers->begin();
 	 i != ok_peers->end();
-	 i++)
-      missing_loc.add_location(soid, i->second);
+	 i++) {
+      if (i->second == bad_peer) {
+	stringstream ss;
+	ss << __func__ << ": bad_peer osd." << bad_peer
+	   << " unexpectedly found in ok_peers osd." << *ok_peers
+	   << " (ignored) " << std::endl;
+	osd->clog->error(ss);
+      } else {
+	missing_loc.add_location(soid, i->second);
+      }
+    }
 
     pg_log.set_last_requested(0);
     dout(10) << __func__ << ": primary = " << primary << dendl;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3585,12 +3585,24 @@ int PG::build_scrub_map_chunk(
   return 0;
 }
 
+std::ostream& operator << (std::ostream& o, const list<pair<ScrubMap::object, pg_shard_t> > l)
+{
+  list<pair<ScrubMap::object, pg_shard_t> >::const_iterator i;
+  if (l.size() > 1)
+    o << '{';
+  for (i = l.begin(); i != l.end(); ++i)
+    o << i->second << ' ';
+  if (l.size() > 1)
+    o << '}';
+  return o;
+}
+
 void PG::repair_object(
   const hobject_t& soid, list<pair<ScrubMap::object, pg_shard_t> > *ok_peers,
   pg_shard_t bad_peer)
 {
   dout(10) << "repair_object " << soid << " bad_peer osd."
-	   << bad_peer << " ok_peers osd.{" << ok_peers << "}" << dendl;
+	   << bad_peer << " ok_peers osd." << *ok_peers << dendl;
   ScrubMap::object &po = ok_peers->back().first;
   eversion_t v;
   bufferlist bv;


### PR DESCRIPTION
When repairing an object, ignore bad_peer when it is found in the
ok_peers and issue an error message.

http://tracker.ceph.com/issues/10524 Refs: #10524

Signed-off-by: Loic Dachary <ldachary@redhat.com>