### PR TITLE
librbd: fix coverity false-positives for tests

### DIFF
--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -44,7 +44,7 @@ public:
 
   class WatchCtx : public librados::WatchCtx2 {
   public:
-    WatchCtx(TestImageWatcher &parent) : m_parent(parent) {}
+    WatchCtx(TestImageWatcher &parent) : m_parent(parent), m_handle(0) {}
 
     int watch(const librbd::ImageCtx &ictx) {
       m_header_oid = ictx.header_oid;

--- a/src/test/librbd/test_fixture.cc
+++ b/src/test/librbd/test_fixture.cc
@@ -40,7 +40,7 @@ std::string TestFixture::_pool_name;
 librados::Rados TestFixture::_rados;
 uint64_t TestFixture::_image_number = 0;
 
-TestFixture::TestFixture() {
+TestFixture::TestFixture() : m_image_size(0) {
 }
 
 void TestFixture::SetUpTestCase() {


### PR DESCRIPTION
Coverity flagged two variables as uninitialized prior to use.
Explicitly initialize the variables in the constructors to remove
the false-positives.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>