### PR TITLE
mon: Do not allow empty pool names when creating

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3660,6 +3660,8 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
                                  const uint64_t expected_num_objects,
 				 stringstream &ss)
 {
+  if (name.length() == 0)
+    return -EINVAL;
   int r;
   r = prepare_pool_crush_ruleset(pool_type, erasure_code_profile,
 				 crush_ruleset_name, &crush_ruleset, ss);


### PR DESCRIPTION
Fixes: #10555

Signed-off-by: Wido den Hollander <wido@42on.com>