### PR TITLE
doc: Fix OpenStack Glance configuration

### DIFF
--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -200,6 +200,10 @@ Juno
 
 Edit ``/etc/glance/glance-api.conf`` and add under the ``[glance_store]`` section::
 
+    [DEFAULT]
+    ...
+    default_store = rbd
+    ...
     [glance_store]
     stores = rbd
     rbd_store_pool = images
@@ -210,6 +214,8 @@ Edit ``/etc/glance/glance-api.conf`` and add under the ``[glance_store]`` sectio
 
 For more information about the configuration options available in Glance please see: http://docs.openstack.org/trunk/config-reference/content/section_glance-api.conf.html.
 
+.. important:: Glance has not completely moved to 'store' yet.
+    So we still need to configure the store in the DEFAULT section.
 
 Any OpenStack version
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Glance has not completely moved to 'store' yet so we need to configure
the store in the DEFAULT section as well.

Fixes: #10478

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>