### PR TITLE
ceph_test_rados_api_misc: do not assert rbd feature match

### DIFF
--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -321,7 +321,8 @@ TEST_F(LibRadosMisc, Exec) {
   bufferlist::iterator iter = bl.begin();
   uint64_t all_features;
   ::decode(all_features, iter);
-  ASSERT_EQ(all_features, (uint64_t)RBD_FEATURES_ALL);
+  // make sure *some* features are specified; don't care which ones
+  ASSERT_NE(all_features, 0);
 }
 
 TEST_F(LibRadosMiscPP, ExecPP) {
@@ -333,7 +334,8 @@ TEST_F(LibRadosMiscPP, ExecPP) {
   bufferlist::iterator iter = out.begin();
   uint64_t all_features;
   ::decode(all_features, iter);
-  ASSERT_EQ(all_features, (uint64_t)RBD_FEATURES_ALL);
+  // make sure *some* features are specified; don't care which ones
+  ASSERT_NE(all_features, 0);
 }
 
 TEST_F(LibRadosMiscPP, Operate1PP) {


### PR DESCRIPTION
This test fails on upgrades when we (or the server) have new
features.  Make it less fragile.

Fixes: #10576
Signed-off-by: Sage Weil <sage@redhat.com>