### PR TITLE
Fix bug: When run Test_filejournal  testcase with gtest argument, all of testcases is failed.

### DIFF
--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -56,6 +56,8 @@ public:
 };
 
 unsigned size_mb = 200;
+//Gtest argument prefix
+const char GTEST_PRFIX[] = "--gtest_";
 
 int main(int argc, char **argv) {
   vector<const char*> args;
@@ -70,9 +72,23 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf->apply_changes(NULL);
 
   finisher = new Finisher(g_ceph_context);
-  srand(getpid()+time(0));
-  snprintf(path, sizeof(path), "/tmp/ceph_test_filejournal.tmp.%d", rand());
   
+  path[0] = '\0';
+  if (!args.empty()) {
+    for ( unsigned int i = 0; i < args.size(); ++i) {
+      if (strncmp(args[i], GTEST_PRFIX, sizeof(GTEST_PRFIX) - 1)) {
+      	//Non gtest argument, set to path.
+        size_t copy_len = std::min(sizeof(path) - 1, strlen(args[i]));
+        strncpy(path, args[i], copy_len);
+        path[copy_len] = '\0';
+        break;
+      }
+    }
+  }
+  if ( path[0] == '\0') {
+    srand(getpid() + time(0));
+    snprintf(path, sizeof(path), "/var/tmp/ceph_test_filejournal.tmp.%d", rand());
+  }
   cout << "path " << path << std::endl;
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -70,15 +70,9 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf->apply_changes(NULL);
 
   finisher = new Finisher(g_ceph_context);
+  srand(getpid()+time(0));
+  snprintf(path, sizeof(path), "/tmp/ceph_test_filejournal.tmp.%d", rand());
   
-  if (!args.empty()) {
-    size_t copy_len = std::min(sizeof(path)-1, strlen(args[0]));
-    strncpy(path, args[0], copy_len);
-    path[copy_len] = '\0';
-  } else {
-    srand(getpid()+time(0));
-    snprintf(path, sizeof(path), "/tmp/ceph_test_filejournal.tmp.%d", rand());
-  }
   cout << "path " << path << std::endl;
 
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
when run testcase with gtest argument, for example, with argument --gtest_output=xml:/root/reports/ceph_test_cls_version.xml,
then the test result is failed, because of the test program use the first argument as the journal file name.
Signed-off-by: qiushanggao, qiushanggao@qq.com