### PR TITLE
xio: Enable xio option to call fork init

### DIFF
--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -284,6 +284,10 @@ XioMessenger::XioMessenger(CephContext *cct, entity_name_t name,
       xio_set_opt(NULL, XIO_OPTLEVEL_ACCELIO, XIO_OPTNAME_DISABLE_HUGETBL,
 		  &xopt, sizeof(xopt));
 
+      xopt = 1;
+      xio_set_opt(NULL, XIO_OPTLEVEL_RDMA, XIO_OPTNAME_ENABLE_FORK_INIT,
+		  &xopt, sizeof(xopt));
+
       xopt = XIO_MSGR_IOVLEN;
       xio_set_opt(NULL, XIO_OPTLEVEL_ACCELIO, XIO_OPTNAME_MAX_IN_IOVLEN,
 		  &xopt, sizeof(xopt));


### PR DESCRIPTION
Ceph uses fork. This fix call xio option to enforce Accelio to
explicitly call ibv_fork_init() to avoid cq overrun issue.

Signed-off-by: Vu Pham <vu@mellanox.com>