### PR TITLE
doc: Network Configuration Reference duplicate string #10206

### DIFF
--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -73,8 +73,7 @@ IP Tables
 
 By default, daemons `bind`_ to ports within the ``6800:7100`` range. You may
 configure this range at your discretion. Before configuring your IP tables,
-check the default ``iptables`` configuration. You may configure this range 
-at your discretion.
+check the default ``iptables`` configuration.
 
 	sudo iptables -L
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/10206 Fixes: #10206

Signed-off-by: Thomas Cantin <thomas.cantin@telecom-bretagne.eu>