### PR TITLE
doc: mon should be listed before osd

### DIFF
--- a/doc/rados/configuration/index.rst
+++ b/doc/rados/configuration/index.rst
@@ -11,8 +11,8 @@ configuration using command-line utilities.
 
 When Ceph starts, it activates three daemons:
 
-- ``ceph-osd`` (mandatory)
 - ``ceph-mon`` (mandatory)
+- ``ceph-osd`` (mandatory)
 - ``ceph-mds`` (mandatory for cephfs only)
 
 Each process, daemon or utility loads the host's configuration file. A process


### PR DESCRIPTION
When deploying a Ceph cluster, the mon must be run first.
In the list shown at http://ceph.com/docs/master/rados/configuration/
it would therefore be better to have mon listed before osd.

http://tracker.ceph.com/issues/10204 Fixes: #10204

Signed-off-by: Hazem <hazem.amara@telecom-bretagne.eu>