### PR TITLE
osd: limit deep scrub rate

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -597,6 +597,7 @@ OPTION(osd_scrub_max_interval, OPT_FLOAT, 7*60*60*24)  // regardless of load
 OPTION(osd_scrub_chunk_min, OPT_INT, 5)
 OPTION(osd_scrub_chunk_max, OPT_INT, 25)
 OPTION(osd_scrub_sleep, OPT_FLOAT, 0)   // sleep between [deep]scrub ops
+OPTION(osd_deep_scrub_rate_max, OPT_U64, 0) // 0 unlimited, 100 << 20 means deep scrub rate 100MB/s
 OPTION(osd_deep_scrub_interval, OPT_FLOAT, 60*60*24*7) // once a week
 OPTION(osd_deep_scrub_stride, OPT_INT, 524288)
 OPTION(osd_deep_scrub_update_digest_min_age, OPT_INT, 2*60*60)   // objects must be this old (seconds) before we update the whole-object digest on scrub

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -217,6 +217,8 @@ OSDService::OSDService(OSD *osd) :
   agent_stop_flag(false),
   agent_timer_lock("OSD::agent_timer_lock"),
   agent_timer(osd->client_messenger->cct, agent_timer_lock),
+  scrub_timer_lock("OSD::scrub_timer_lock"),
+  scrub_timer(cct, scrub_timer_lock),
   objecter(new Objecter(osd->client_messenger->cct, osd->objecter_messenger, osd->monc, NULL, 0, 0)),
   objecter_finisher(osd->client_messenger->cct),
   watch_lock("OSD::watch_lock"),
@@ -441,6 +443,13 @@ void OSDService::start_shutdown()
     agent_timer.cancel_all_events();
     agent_timer.shutdown();
   }
+
+  {
+    Mutex::Locker l(scrub_timer_lock);
+    scrub_timer.cancel_all_events();
+    scrub_timer.shutdown();
+  }
+
 }
 
 void OSDService::shutdown()
@@ -470,6 +479,7 @@ void OSDService::init()
   objecter->start();
   watch_timer.init();
   agent_timer.init();
+  scrub_timer.init();
 
   agent_thread.create();
 }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -569,6 +569,9 @@ public:
   Mutex agent_timer_lock;
   SafeTimer agent_timer;
 
+  Mutex scrub_timer_lock;
+  SafeTimer scrub_timer;    // safe timer (scrub_timer_lock)
+
   void agent_entry();
   void agent_stop();
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3744,6 +3744,17 @@ void PG::scrub(ThreadPool::TPHandle &handle)
   unlock();
 }
 
+struct C_Scrub_Tick : public Context {
+    OSDService *osd;
+    PG *pg;
+  public:
+    C_Scrub_Tick(OSDService *o, PG *p) : osd(o), pg(p) {}
+    void finish(int r) {
+      osd->scrub_wq.queue(pg);
+    }
+  };
+
+
 /*
  * Chunky scrub scrubs objects one chunk at a time with writes blocked for that
  * chunk.
@@ -3889,6 +3900,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 
           bool boundary_found = false;
           hobject_t start = scrubber.start;
+          uint32_t scrub_objects = 0;
           while (!boundary_found) {
             vector<hobject_t> objects;
             ret = get_pgbackend()->objects_list_partial(
@@ -3918,6 +3930,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
                 candidate_end = end;
                 boundary_found = true;
               }
+              scrub_objects = objects.size();
             }
           }
 
@@ -3930,6 +3943,15 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	    break;
 	  }
 	  scrubber.end = candidate_end;
+
+          scrubber.last_scrub_stamp = ceph_clock_now(cct);
+          if (info.stats.stats.sum.num_objects) {
+            scrubber.last_scrub_num_bytes = info.stats.stats.sum.num_bytes *
+                             scrub_objects / info.stats.stats.sum.num_objects;
+          } else {
+            scrubber.last_scrub_num_bytes = 0;
+          }
+
         }
         scrubber.block_writes = true;
 
@@ -4041,8 +4063,24 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
           scrubber.start = scrubber.end;
 
           scrubber.state = PG::Scrubber::NEW_CHUNK;
-          osd->scrub_wq.queue(this);
           done = true;
+          if (scrubber.deep && cct->_conf->osd_deep_scrub_rate_max) {
+            double interval = 1.0 * (ceph_clock_now(cct).to_nsec() - scrubber.last_scrub_stamp.to_nsec()) / 1000000000;
+            double ratio = 1.0 * scrubber.last_scrub_num_bytes / (cct->_conf->osd_deep_scrub_rate_max * cct->_conf->osd_max_scrubs);
+            dout(20) << __func__ << " last_scrub_num_bytes " << scrubber.last_scrub_num_bytes << " osd_deep_scrub_rate_max "
+                     << cct->_conf->osd_deep_scrub_rate_max << " ratio " << ratio << " interval " << interval << dendl;
+            double wait_secs = ratio - interval;
+            if (wait_secs > 0) {
+              dout(20) << __func__ << " should wait " << wait_secs << " secs" << dendl;
+              osd->scrub_timer_lock.Lock();
+              osd->scrub_timer.add_event_after(wait_secs, new C_Scrub_Tick(osd, this));
+              osd->scrub_timer_lock.Unlock();
+            } else {
+              osd->scrub_wq.queue(this);
+            }
+          } else {
+            osd->scrub_wq.queue(this);
+          }
         } else {
           scrubber.state = PG::Scrubber::FINISH;
         }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1032,7 +1032,8 @@ public:
       num_digest_updates_pending(0),
       state(INACTIVE),
       deep(false),
-      seed(0)
+      seed(0),
+      last_scrub_num_bytes(0), last_scrub_stamp(utime_t())
     {
     }
 
@@ -1089,6 +1090,9 @@ public:
     // deep scrub
     bool deep;
     uint32_t seed;
+
+    uint32_t last_scrub_num_bytes;
+    utime_t last_scrub_stamp;
 
     list<Context*> callbacks;
     void add_callback(Context *context) {
@@ -1167,6 +1171,9 @@ public:
       authoritative.clear();
       missing_digest.clear();
       num_digest_updates_pending = 0;
+
+      last_scrub_num_bytes = 0;
+      last_scrub_stamp = utime_t();
     }
 
   } scrubber;


### PR DESCRIPTION
When ceph does deep scrub, it may run out of disk bandwidth.
Thus, it severely affecting normal io request.
Maybe limiting the rate is meaningful. The added config will limit the max object sizes in one second.
Default is unlimited.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>