### PR TITLE
ceph-disk: do not reuse partition if encryption required

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1051,6 +1051,9 @@ def prepare_journal_dev(
     reusing_partition = False
 
     if is_partition(journal):
+        if journal_dm_keypath:
+            raise Error(journal + ' partition already exists'
+                        ' and --dmcrypt specified')
         LOG.debug('Journal %s is a partition', journal)
         LOG.warning('OSD will not be hot-swappable if journal is not the same device as the osd data')
         if get_partition_type(journal) == JOURNAL_UUID:


### PR DESCRIPTION
If encryption is required, an existing journal partition must not be
reused. If an existing partition that was not prepared with ceph-disk is
found and reused, the caller will assume it is encrypted although it is
not.

Signed-off-by: Loic Dachary <ldachary@redhat.com>