### PR TITLE
qa: disable automatic locking for manual locking test

### DIFF
--- a/qa/workunits/rbd/test_lock_fence.sh
+++ b/qa/workunits/rbd/test_lock_fence.sh
@@ -8,7 +8,7 @@ CEPH_REF=${CEPH_REF:-master}
 
 wget -O $RBDRW "https://ceph.com/git/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/librbd/rbdrw.py"
 
-rbd create $IMAGE --size 10 --image-format 2 || exit 1
+rbd create $IMAGE --size 10 --image-format 2 --image-shared || exit 1
 
 # rbdrw loops doing I/O to $IMAGE after locking with lockid $LOCKID
 python $RBDRW $IMAGE $LOCKID &


### PR DESCRIPTION
Automatic locking hides the ESHUTDOWN from the caller, which is how this test
detects that blacklisting works.

Fixes: #10592 Signed-off-by: Josh Durgin <jdurgin@redhat.com>