### PR TITLE
osd: fix some compile warning

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -212,7 +212,7 @@ OPTION(mon_cache_target_full_warn_ratio, OPT_FLOAT, .66) // position between poo
 OPTION(mon_osd_full_ratio, OPT_FLOAT, .95) // what % full makes an OSD "full"
 OPTION(mon_osd_nearfull_ratio, OPT_FLOAT, .85) // what % full makes an OSD near full
 OPTION(mon_allow_pool_delete, OPT_BOOL, true) // allow pool deletion
-OPTION(mon_globalid_prealloc, OPT_INT, 10000)   // how many globalids to prealloc
+OPTION(mon_globalid_prealloc, OPT_U32, 10000)   // how many globalids to prealloc
 OPTION(mon_osd_report_timeout, OPT_INT, 900)    // grace period before declaring unresponsive OSDs dead
 OPTION(mon_force_standby_active, OPT_BOOL, true) // should mons force standby-replay mds to be active
 OPTION(mon_warn_on_old_mons, OPT_BOOL, true) // should mons set health to WARN if part of quorum is old?

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1875,7 +1875,7 @@ int Pipe::read_message(Message **pm, AuthSessionHandler* auth_handler)
   
   ceph_msg_header header; 
   ceph_msg_footer footer;
-  __u32 header_crc;
+  __u32 header_crc = 0;
 
   if (connection_state->has_feature(CEPH_FEATURE_NOSRCADDR)) {
     if (tcp_read((char*)&header, sizeof(header)) < 0)


### PR DESCRIPTION
warning: comparison between signed and unsigned integer expressions
warning: ‘header_crc ’ is used uninitialized in this function

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>