### PR TITLE
ObjectStore: Make every write-op in ObjectStore::Transaction has their own fadvise-flags.

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -2302,7 +2302,7 @@ unsigned FileStore::_do_transaction(
         ghobject_t oid = i.get_oid(op->oid);
         uint64_t off = op->off;
         uint64_t len = op->len;
-        uint32_t fadvise_flags = i.get_fadvise_flags();
+        uint32_t fadvise_flags =  i.get_fadvise_flags(op);
         bufferlist bl;
         i.decode_bl(bl);
         tracepoint(objectstore, write_enter, osr_name, off, len);

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -1215,7 +1215,7 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
         ghobject_t oid = i.get_oid(op->oid);
         uint64_t off = op->off;
         uint64_t len = op->len;
-	uint32_t fadvise_flags = i.get_fadvise_flags();
+        uint32_t fadvise_flags = i.get_fadvise_flags(op);
         bufferlist bl;
         i.decode_bl(bl);
         r = _write(cid, oid, off, len, bl, t, fadvise_flags);

--- a/src/os/MemStore.cc
+++ b/src/os/MemStore.cc
@@ -668,7 +668,7 @@ void MemStore::_do_transaction(Transaction& t)
         ghobject_t oid = i.get_oid(op->oid);
         uint64_t off = op->off;
         uint64_t len = op->len;
-	uint32_t fadvise_flags = i.get_fadvise_flags();
+        uint32_t fadvise_flags = i.get_fadvise_flags(op);
         bufferlist bl;
         i.decode_bl(bl);
 	r = _write(cid, oid, off, len, bl, fadvise_flags);

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -518,10 +518,6 @@ public:
 	return true;
     }
 
-    void set_fadvise_flags(uint32_t flags) {
-      data.fadvise_flags = flags;
-    }
-
     void set_fadvise_flags_all(uint32_t flag) {
       if (per_op_fadvise_flags) {
 	int ops = data.ops;

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -810,6 +810,8 @@ void ECBackend::handle_sub_write(
     get_parent()->update_stats(op.stats);
   ObjectStore::Transaction *localt = new ObjectStore::Transaction;
   localt->set_use_tbl(op.t.get_use_tbl());
+  localt->set_per_op_fadvise_flags(op.t.get_per_op_fadvise_flags());
+
   if (!op.temp_added.empty()) {
     get_temp_coll(localt);
     add_temp_objs(op.temp_added);
@@ -839,7 +841,7 @@ void ECBackend::handle_sub_write(
 
   if (!(dynamic_cast<ReplicatedPG *>(get_parent())->is_undersized()) &&
       get_parent()->whoami_shard().shard >= ec_impl->get_data_chunk_count())
-    op.t.set_fadvise_flag(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    op.t.set_fadvise_flags_all(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
 
   localt->append(op.t);
   if (on_local_applied_sync) {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8426,7 +8426,7 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
 
   p = m->logbl.begin();
   ::decode(log, p);
-  rm->opt.set_fadvise_flag(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+  rm->opt.set_fadvise_flags_all(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
 
   bool update_snaps = false;
   if (!rm->opt.empty()) {


### PR DESCRIPTION
@liewegas . Now ObjectStore fast encode/decode merged into master. I  make the write-op in ObjectStore::Transaction has their own fadvise-flags like read-op.  To be simple, i don't remove the fadvise_flags of Transaction.  I think in the future, we don't need fadvise_flags of Transaction, we can make this as unused_field(maybe for other purpose).