### PR TITLE
Update rgw_common.h

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -898,7 +898,7 @@ struct req_info {
 
   req_info(CephContext *cct, RGWEnv *_env);
   void rebuild_from(req_info& src);
-  void init_meta_info(bool *found_nad_meta);
+  void init_meta_info(bool *found_bad_meta);
 };
 
 /** Store all the state necessary to complete and respond to an HTTP request*/


### PR DESCRIPTION
Fixed a small typo: found_nad_meta argument supposed to be named found_bad_meta. Method implementation in rgw_common.cc uses correct name.

Signed-off-by: Dmytro Iurchenko <diurchenko@mirantis.com>