### PR TITLE
Rbd: add listwatchers command

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -263,6 +263,9 @@ Commands
 :command:`showmapped`
   Show the rbd images that are mapped via the rbd kernel module.
 
+:command:`status` [*image-name*]
+  Show the status of the image, including which clients have the open.
+
 :command:`lock` list [*image-name*]
   Show locks held on the image. The first column is the locker
   to use with the `lock remove` command.

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -42,6 +42,7 @@
     snap protect <snap-name>                    prevent a snapshot from being deleted
     snap unprotect <snap-name>                  allow a snapshot to be deleted
     watch <image-name>                          watch events on image
+    status <image-name>                         show the status of this image
     map <image-name>                            map image to a block device
                                                 using the kernel
     unmap <device>                              unmap a rbd device that was


### PR DESCRIPTION
Currently, RBD does not provide an easy way to consult who opened a specied image, this complicates
the cloud maintenance, sometimes the administrator found that a RBD image could not be deleted with an error 'image has watchers', but no further information available. The RADOS has a command to show the watchers of an object, but the commands at RADOS level are not supposed to be exposed to a cloud administrator, and it is not clear for a non-expert administrator to how to associate an opened RBD with a corresponding watched object. This motivates us to add an RBD command to list the information
of the clients who opened a RBD image to facilitate the cloud maintenance.