### PR TITLE
rgw: fix doc, wrong HTTP header name

### DIFF
--- a/doc/radosgw/swift/objectops.rst
+++ b/doc/radosgw/swift/objectops.rst
@@ -263,7 +263,7 @@ Syntax
 Request Headers
 ~~~~~~~~~~~~~~~
 
-``X-Container-Meta-{key}``
+``X-Object-Meta-{key}``
 
 :Description:  A user-defined meta data key that takes an arbitrary string value.
 :Type: String


### PR DESCRIPTION
According to http://docs.openstack.org/api/openstack-object-storage/1.0/content/POST_updateObjectMeta__v1__account___container___object__storage_object_services.html#POST_updateObjectMeta__v1__account___container___object__storage_object_services-Request setting metadata to an object  needs X-Object-Meta-{key}  rather than X-Container-Meta-{key}.

Signed-off-by: Dmytro Iurchenko <diurchenko@mirantis.com>