### PR TITLE
test/ceph-disk.sh: resolve symlinks before check

### DIFF
--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -85,7 +85,7 @@ function kill_daemons() {
 function command_fixture() {
     local command=$1
 
-    [ $(which $command) = ./$command ] || return 1
+    [ $(which $command) = ./$command ] || [ $(which $command) = `readlink -f $(pwd)/$command` ] || return 1
 
     cat > $DIR/$command <<EOF
 #!/bin/bash


### PR DESCRIPTION
Make sure symlinks are resolved in command_fixture()
before compare result of which command and the current
path.

Signed-off-by: Danny Al-Gaaf <danny.al-gaaf@bisect.de>
(cherry picked from commit 8ea86dfa7c4a3d7e089cf9d4e49586657875f851)

Conflicts:
	src/test/ceph-disk.sh