### PR TITLE
erasure code: backend feature to read from all OSDs and silently discard...

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -461,6 +461,7 @@ OPTION(osd_crush_chooseleaf_type, OPT_INT, 1) // 1 = host
 OPTION(osd_pool_default_crush_rule, OPT_INT, -1) // deprecated for osd_pool_default_crush_replicated_ruleset
 OPTION(osd_pool_default_crush_replicated_ruleset, OPT_INT, CEPH_DEFAULT_CRUSH_REPLICATED_RULESET)
 OPTION(osd_pool_erasure_code_stripe_width, OPT_U32, OSD_POOL_ERASURE_CODE_STRIPE_WIDTH) // in bytes
+OPTION(osd_pool_erasure_code_subread_all, OPT_BOOL, false)       // dispatch all OSD for sub-read op
 OPTION(osd_pool_default_size, OPT_INT, 3)
 OPTION(osd_pool_default_min_size, OPT_INT, 0)  // 0 means no specific default; ceph will use size-size/2
 OPTION(osd_pool_default_pg_num, OPT_INT, 8) // number of PGs for new pools. Configure in global or mon section of ceph.conf

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -178,7 +178,8 @@ ECBackend::ECBackend(
   : PGBackend(pg, store, coll, temp_coll),
     cct(cct),
     ec_impl(ec_impl),
-    sinfo(ec_impl->get_data_chunk_count(), stripe_width) {
+    sinfo(ec_impl->get_data_chunk_count(), stripe_width),
+    subread_all(g_conf->osd_pool_erasure_code_subread_all) {
   assert((ec_impl->get_data_chunk_count() *
 	  ec_impl->get_chunk_size(stripe_width)) == stripe_width);
 }
@@ -882,7 +883,6 @@ void ECBackend::handle_sub_read(
 	bl, j->get<2>(),
 	false);
       if (r < 0) {
-	assert(0);
 	reply->buffers_read.erase(i->first);
 	reply->errors[i->first] = r;
 	break;
@@ -1007,7 +1007,23 @@ shard_to_read_map.find(from);
   assert(rop.in_progress.count(from));
   rop.in_progress.erase(from);
   if (!rop.in_progress.empty()) {
-    dout(10) << __func__ << " readop not complete: " << rop << dendl;
+    if (subread_all) {
+      int k = ec_impl->get_data_chunk_count();
+      for (map<hobject_t, read_result_t>::iterator i =
+             rop.complete.begin();
+           i != rop.complete.end();
+           ++i) {
+        if ( i->second.returned.front().get<2>().size() < k ) {
+          dout(10) << __func__ << " readop not complete: " << rop << dendl;
+          return;
+        }
+      }
+      dout(10) << __func__ << " readop complete: " << rop << dendl;
+      rop.in_progress.clear();
+      complete_read_op(rop, m);
+    } else {
+      dout(10) << __func__ << " readop not complete: " << rop << dendl;
+    }
   } else {
     dout(10) << __func__ << " readop complete: " << rop << dendl;
     complete_read_op(rop, m);
@@ -1357,9 +1373,16 @@ int ECBackend::get_min_avail_to_read_shards(
   }
 
   set<int> need;
-  int r = ec_impl->minimum_to_decode(want, have, &need);
-  if (r < 0)
-    return r;
+  if (subread_all && !for_recovery) {
+    if (have.size() < ec_impl->get_data_chunk_count()) {
+      return -EIO;
+    }
+    need = have;
+  } else {
+    int r = ec_impl->minimum_to_decode(want, have, &need);
+    if (r < 0)
+      return r;
+  }
 
   if (!to_read)
     return 0;
@@ -1602,8 +1625,10 @@ struct CallClientContexts :
   void finish(pair<RecoveryMessages *, ECBackend::read_result_t &> &in) {
     ECBackend::read_result_t &res = in.second;
     assert(res.returned.size() == to_read.size());
-    assert(res.r == 0);
-    assert(res.errors.empty());
+    if (!ec->subread_all) {
+      assert(res.r == 0);
+      assert(res.errors.empty());
+    }
     for (list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
 		   pair<bufferlist*, Context*> > >::iterator i = to_read.begin();
 	 i != to_read.end();
@@ -1614,11 +1639,17 @@ struct CallClientContexts :
 	     res.returned.front().get<1>() == adjusted.second);
       map<int, bufferlist> to_decode;
       bufferlist bl;
+      int jj = 0;
+      int k = ec->ec_impl->get_data_chunk_count();
       for (map<pg_shard_t, bufferlist>::iterator j =
 	     res.returned.front().get<2>().begin();
-	   j != res.returned.front().get<2>().end();
+	   j != res.returned.front().get<2>().end() && jj < k;
 	   ++j) {
-	to_decode[j->first.shard].claim(j->second);
+        uint64_t data_len = j->second.length();
+        if ((data_len > 0) && ( data_len % ec->sinfo.get_chunk_size() == 0)) {
+	  to_decode[j->first.shard].claim(j->second);
+          jj++;
+        }
       }
       ECUtil::decode(
 	ec->sinfo,

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -431,6 +431,7 @@ public:
 
 
   const ECUtil::stripe_info_t sinfo;
+  bool subread_all;
   /// If modified, ensure that the ref is held until the update is applied
   SharedPtrRegistry<hobject_t, ECUtil::HashInfo> unstable_hashinfo_registry;
   ECUtil::HashInfoRef get_hash_info(const hobject_t &hoid);

--- a/src/test/erasure-code/test-erasure-code.sh
+++ b/src/test/erasure-code/test-erasure-code.sh
@@ -97,6 +97,30 @@ function rados_put_get() {
     rm $dir/ORIGINAL
 }
 
+function rados_put_error_get() {
+    local dir=$1
+    local poolname=$2
+
+    for marker in AAA BBB CCCC DDDD ; do
+        printf "%*s" 1024 $marker
+    done > $dir/ORIGINAL
+
+    #
+    # get and put an object, compare they are equal
+    #
+    ./rados --pool $poolname put SOMETHINGERR $dir/ORIGINAL || return 1
+    # need to wait for file flush to disk
+    sleep 3
+    file=`find test-erasure-code -name "*SOMETHINGERR*" | grep "ffffffffffffffff_0"`
+    # Change the file contents
+    echo "test" > $file
+    ./rados --pool $poolname get SOMETHINGERR $dir/COPY || return 1
+    diff $dir/ORIGINAL $dir/COPY || return 1
+
+    rm $dir/COPY
+    rm $dir/ORIGINAL
+}
+
 function plugin_exists() {
     local plugin=$1
 
@@ -270,6 +294,34 @@ function TEST_chunk_mapping() {
 
     delete_pool remap-pool
     ./ceph osd erasure-code-profile rm remap-profile
+}
+
+function TEST_read_all_flag() {
+    local dir=$1
+
+    # Set flag
+    ./ceph tell osd.* injectargs "--osd-pool-erasure-code-subread-all=true"
+
+    local poolname=pool-jerasure
+    local profile=profile-jerasure
+
+    ./ceph osd erasure-code-profile set $profile \
+        plugin=jerasure \
+        k=4 m=2 \
+        ruleset-failure-domain=osd || return 1
+    ./ceph osd pool create $poolname 12 12 erasure $profile \
+        || return 1
+
+    rados_put_get $dir $poolname || return 1
+
+    rados_put_error_get $dir $poolname || return 1
+
+    delete_pool $poolname
+    ./ceph osd erasure-code-profile rm $profile
+
+    # Unset flag
+    ./ceph tell osd.* injectargs "--osd-pool-erasure-code-subread-all=false"
+
 }
 
 main test-erasure-code


### PR DESCRIPTION
... EIO if possible

Bug: http://tracker.ceph.com/issues/9943

Brief: Add osd setting osd_pool_erasure_code_subread_all. Default is false. If set it to true. Will send sub-read op to all OSD and choose the first success read result.

Signed-off-by: Wei Luo <luowei@yahoo-inc.com>