### PR TITLE
Bug fix: Transaction::append SHOULD NOT modify other.op_bl

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -665,16 +665,23 @@ public:
            object_index_p != other.object_index.end();
            object_index_p++) {
         om[object_index_p->second] = _get_object_id(object_index_p->first);
-      }
+      }      
 
-      //update other.op_bl with cm & om
+      //the other.op_bl SHOULD NOT be changes during append operation,
+      //we use additional bufferlist to avoid this problem
+      bufferptr other_op_bl_ptr(other.op_bl.length());
+      other.op_bl.copy(0, other.op_bl.length(), other_op_bl_ptr.c_str());
+      bufferlist other_op_bl;
+      other_op_bl.append(other_op_bl_ptr);
+
+      //update other_op_bl with cm & om
       //When the other is appended to current transaction, all coll_index and
       //object_index in other.op_buffer should be updated by new index of the
       //combined transaction
-      _update_op_bl(other.op_bl, cm, om);
+      _update_op_bl(other_op_bl, cm, om);
 
       //append op_bl
-      op_bl.append(other.op_bl);
+      op_bl.append(other_op_bl);
       //append data_bl
       data_bl.append(other.data_bl);
     }

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -586,7 +586,9 @@ void ReplicatedBackend::submit_transaction(
     trim_rollback_to,
     true,
     &local_t);
-  (*op_t).append(local_t);
+
+  local_t.append(*op_t);
+  local_t.swap(*op_t);
   
   op_t->register_on_applied_sync(on_local_applied_sync);
   op_t->register_on_applied(

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8443,14 +8443,14 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
   
   op->mark_started();
 
-  rm->opt.append(rm->localt);
-  rm->opt.register_on_commit(
+  rm->localt.append(rm->opt);
+  rm->localt.register_on_commit(
     parent->bless_context(
       new C_OSD_RepModifyCommit(this, rm)));
-  rm->opt.register_on_applied(
+  rm->localt.register_on_applied(
     parent->bless_context(
       new C_OSD_RepModifyApply(this, rm)));
-  parent->queue_transaction(&(rm->opt), op);
+  parent->queue_transaction(&(rm->localt), op);
   // op is cleaned up by oncommit/onapply when both are executed
 }
 


### PR DESCRIPTION
Transaction::append SHOULD NOT modify other.op_bl since msg will use it at the same time when os do append.

That is the reason of http://tracker.ceph.com/issues/10517 and why commit d427ca3  reversed the order of localt and op_t.

This PR use an additional buffer to avoid modifying other.op_bl when append, so msg can works fine with the new transaction now. But an additional memcpy is needed which may hurt the performance.

This PR also partially revert the commit  d427ca3 to fix http://tracker.ceph.com/issues/10534.