### PR TITLE
RocksDBStore: filterpolicy is not deleted when RocksDBStore destructs

### DIFF
--- a/src/os/RocksDBStore.cc
+++ b/src/os/RocksDBStore.cc
@@ -153,6 +153,7 @@ RocksDBStore::~RocksDBStore()
 
   // Ensure db is destroyed before dependent db_cache and filterpolicy
   delete db;
+  delete filterpolicy;
 }
 
 void RocksDBStore::close()


### PR DESCRIPTION
Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>