### PR TITLE
Fix memstore free space caculation

### DIFF
--- a/src/os/MemStore.cc
+++ b/src/os/MemStore.cc
@@ -241,7 +241,7 @@ int MemStore::statfs(struct statfs *st)
   st->f_blocks = g_conf->memstore_device_bytes / st->f_bsize;
 
   dout(10) << __func__ << ": used_bytes: " << used_bytes << "/" << g_conf->memstore_device_bytes << dendl;
-  st->f_bfree = st->f_bavail = MAX((st->f_blocks - used_bytes / st->f_bsize), 0);
+  st->f_bfree = st->f_bavail = MAX((long(st->f_blocks) - long(used_bytes / st->f_bsize)), 0);
 
   return 0;
 }


### PR DESCRIPTION
Originally if memstore run out of space, it will report a very
large positive number as free space. For example:

root@bigmem:~# rados df
pool name                 KB      objects       clones     degraded      unfound           rd        rd KB           wr        wr KB
rbd                 12366704        92240            0            0           0            0            0        92240     12366704
  total used        12375877        92240
  total avail   36028797009199167
  total space        2611076

st->f_bavail = st->f_blocks - used_bytes / st->f_bsize

This is due to used_bytes is an unsigned value, so compiler make the whole statement unsigned.

Fix it by adding explicit type cast,

st->f_bavail = long(st->f_blocks) - long(used_bytes / st->f_bsize)

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>