### PR TITLE
librbd: schedule header refresh after watch error

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -611,6 +611,7 @@ void ImageWatcher::reregister_watch() {
         return;
       }
     }
+    handle_header_update();
 
     if (lock_owner) {
       r = try_lock();


### PR DESCRIPTION
If a librados watch error occurs, it is possible that one
or more events were missed.  Therefore, flag the header as
dirty so that it will be reloaded after the next operation.

Fixes: #4092
Signed-off-by: Jason Dillaman <dillaman@redhat.com>