### PR TITLE
vstart.sh: pull default CEPH_PORT from .ceph_port

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -82,3 +82,4 @@ Makefile
 # old dir, may in use by older branches
 /leveldb
 /mkcephfs
+/.ceph_port

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -261,7 +261,10 @@ fi
 # export CEPH_ARGS="--lockdep 1"
 
 [ -z "$CEPH_BIN" ] && CEPH_BIN=.
-[ -z "$CEPH_PORT" ] && CEPH_PORT=6789
+if [ -z "$CEPH_PORT" ]; then
+    CEPH_PORT=6789
+    [ -e ".ceph.port" ] && CEPH_PORT=`cat .ceph_port`
+fi
 
 
 # sudo if btrfs
@@ -294,6 +297,7 @@ else
     echo ip $IP
 fi
 echo "ip $IP"
+echo "port $PORT"
 
 
 


### PR DESCRIPTION
This lets you put a unique port in .ceph_port in your working dir and
vstart.sh instances will avoid each other without having to pass
CEPH_PORT=... to each one each time.

Signed-off-by: Sage Weil <sage@redhat.com>