### PR TITLE
ReplicatedPG::_scrub: don't record digests for snapdirs

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -12803,6 +12803,8 @@ void ReplicatedPG::_scrub(ScrubMap& scrubmap)
 	   scrubber.missing_digest.begin();
 	 p != scrubber.missing_digest.end();
 	 ++p) {
+      if (p->first.is_snapdir())
+	continue;
       dout(10) << __func__ << " recording digests for " << p->first << dendl;
       ObjectContextRef obc = get_object_context(p->first, false);
       assert(obc);


### PR DESCRIPTION
They are always empty, and the finish_ctx machinery doesn't really
work for snapdirs anyway.

Fixes: #10536
Signed-off-by: Samuel Just <sjust@redhat.com>