### PR TITLE
mon/OSDMonitor: validate crush features for osd (not just mon)

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3691,12 +3691,13 @@ bool OSDMonitor::validate_crush_against_features(const CrushWrapper *newcrush,
   OSDMap newmap;
   newmap.deepish_copy_from(osdmap);
   newmap.apply_incremental(new_pending);
-  uint64_t features = newmap.get_features(CEPH_ENTITY_TYPE_MON, NULL);
+
+  uint64_t features =
+    newmap.get_features(CEPH_ENTITY_TYPE_MON, NULL) |
+    newmap.get_features(CEPH_ENTITY_TYPE_OSD, NULL);
 
   stringstream features_ss;
-
   int r = check_cluster_features(features, features_ss);
-
   if (!r)
     return true;
 


### PR DESCRIPTION
We need to check that the OSD features are met as well.

Backport: giant, firefly
Signed-off-by: Sage Weil <sage@redhat.com>