### PR TITLE
ceph.spec.in: standardize capitalization and punctuation

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -113,7 +113,7 @@ Requires:	python-ceph = %{epoch}:%{version}-%{release}
 Requires:	python-requests
 Requires:	redhat-lsb-core
 %description -n ceph-common
-common utilities to mount and interact with a ceph storage cluster
+Common utilities to mount and interact with a ceph storage cluster.
 
 %package fuse
 Summary:	Ceph fuse-based client
@@ -161,8 +161,8 @@ BuildRequires:	expat-devel
 BuildRequires:	fcgi-devel
 %endif
 %description radosgw
-radosgw is an S3 HTTP REST gateway for the RADOS object store. It is
-implemented as a FastCGI module using libfcgi, and can be used in
+This package is an S3 HTTP REST gateway for the RADOS object store. It
+is implemented as a FastCGI module using libfcgi, and can be used in
 conjunction with any FastCGI capable web server.
 
 %if %{with ocf}


### PR DESCRIPTION
Ensure that each sub-package's `%description` starts with a capital letter and ends with a dot.

rpmlint has a rule that checks the Summary field, but not `%description` (yet).