### PR TITLE
ceph-debugpack: fix bashism of {1..10}

### DIFF
--- a/src/ceph-debugpack.in
+++ b/src/ceph-debugpack.in
@@ -22,7 +22,7 @@ usage_exit() {
 wait_pid_exit() {
 	pid=$1
 
-	for i in {1..10}; do
+	for i in $(seq 10); do
 		[ -e /proc/$pid ] || return
 		sleep 1
 	done


### PR DESCRIPTION
* replaces {1..10} with $(seq 10)
* fixes 772220@bugs.debian.org

Signed-off-by: Kefu Chai <tchaikov@gmail.com>