### PR TITLE
doc: Some files still use http://ceph.newdream.net

### DIFF
--- a/qa/workunits/kernel_untar_build.sh
+++ b/qa/workunits/kernel_untar_build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-#wget -q http://ceph.newdream.net/qa/linux-2.6.33.tar.bz2
+#wget -q http://ceph.com/qa/linux-2.6.33.tar.bz2
 wget -q http://ceph.com/qa/linux-3.2.9.tar.bz2
 
 mkdir t

--- a/qa/workunits/suites/fsx.sh
+++ b/qa/workunits/suites/fsx.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-git clone git://ceph.newdream.net/git/xfstests.git
+git clone git://ceph.com/git/xfstests.git
 make -C xfstests
 cp xfstests/ltp/fsx .
 

--- a/src/include/addr_parsing.h
+++ b/src/include/addr_parsing.h
@@ -4,7 +4,7 @@
  *  Created on: Sep 14, 2010
  *      Author: gregf
  *      contains functions used by Ceph to convert named addresses
- *      (eg ceph.newdream.net) into IP addresses (ie 127.0.0.1).
+ *      (eg ceph.com) into IP addresses (ie 127.0.0.1).
  */
 
 #ifndef ADDR_PARSING_H_

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -287,7 +287,7 @@ int Pipe::accept()
   int removed; // single-use down below
 
   // this should roughly mirror pseudocode at
-  //  http://ceph.newdream.net/wiki/Messaging_protocol
+  //  http://ceph.com/wiki/Messaging_protocol
   int reply_tag = 0;
   uint64_t existing_seq = -1;
 


### PR DESCRIPTION
This probably redirects to http://ceph.com but ceph.newdream.net still appears in some places

http://tracker.ceph.com/issues/10615 Fixes: #10615

Related: #9922

Signed-off-by: Armando Segnini <armando.segnini@telecom-bretagne.eu>