### PR TITLE
msg: fixup for 2ffacbe (crc configuration in messenger)

### DIFF
--- a/src/include/msgr.h
+++ b/src/include/msgr.h
@@ -185,9 +185,10 @@ struct ceph_msg_footer {
 	__u8 flags;
 } __attribute__ ((packed));
 
-#define CEPH_MSG_FOOTER_COMPLETE  (1<<0)   /* msg wasn't aborted */
-#define CEPH_MSG_FOOTER_NOCRC     (1<<1)   /* no data crc */
-#define CEPH_MSG_FOOTER_SIGNED	  (1<<2)   /* msg was signed */
+#define CEPH_MSG_FOOTER_COMPLETE    (1<<0)   /* msg wasn't aborted */
+#define CEPH_MSG_FOOTER_NODATACRC   (1<<1)   /* no data crc */
+#define CEPH_MSG_FOOTER_SIGNED      (1<<2)   /* msg was signed */
+#define CEPH_MSG_FOOTER_NOHEADERCRC (1<<3)   /* no header crc */
 
 
 #endif

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -277,7 +277,8 @@ Message *decode_message(CephContext *cct, int crcflags,
       }
       return 0;
     }
-
+  }
+  if (crcflags & MSG_CRC_DATA) {
     if ((footer.flags & CEPH_MSG_FOOTER_NOCRC) == 0) {
       __u32 data_crc = data.crc32c(0);
       if (data_crc != footer.data_crc) {
@@ -290,7 +291,7 @@ Message *decode_message(CephContext *cct, int crcflags,
 	return 0;
       }
     }
-  } 
+  }
 
   // make message
   Message *m = 0;
@@ -775,7 +776,7 @@ void encode_message(Message *msg, uint64_t features, bufferlist& payload)
   bufferlist front, middle, data;
   ceph_msg_footer_old old_footer;
   ceph_msg_footer footer;
-  msg->encode(features, true);
+  msg->encode(features, MSG_CRC_ALL);
   ::encode(msg->get_header(), payload);
 
   // Here's where we switch to the old footer format.  PLR

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -170,8 +170,9 @@
 #define MSG_MON_HEALTH            0x601
 
 // *** Message::encode() crcflags bits ***
-#define MSG_CRC_DATA           1
-#define MSG_CRC_HEADER         2
+#define MSG_CRC_DATA           (1 << 0)
+#define MSG_CRC_HEADER         (1 << 1)
+#define MSG_CRC_ALL            (MSG_CRC_DATA | MSG_CRC_HEADER)
 
 // Xio Testing
 #define MSG_DATA_PING		  0x602

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -616,7 +616,7 @@ void AsyncMessenger::submit_message(Message *m, AsyncConnectionRef con,
                                     const entity_addr_t& dest_addr, int dest_type)
 {
   if (cct->_conf->ms_dump_on_send) {
-    m->encode(-1, true);
+    m->encode(-1, MSG_CRC_ALL);
     ldout(cct, 0) << __func__ << "submit_message " << *m << "\n";
     m->get_payload().hexdump(*_dout);
     if (m->get_data().length() > 0) {


### PR DESCRIPTION
* Update the remaining Message::encode() calls, which now expect crc
  flags to be passed as a flags parameter instead of a bool (this e.g.
  fixes the issue with routing messages forwarded from an older client).

* In Message::encode() data crc is calculated when MSG_CRC_DATA is
  set, but in decode_message(), Pipe::read/write_message() data crc is
  calculated when MSG_CRC_HEADER is set. Fix this.

Note, 2ffacbe changed the behavior of Pipe::read_message/write_message():
previously the method always calculated crc, now they calculate it
only if crc is enabled in the config. This means crc can not be disabled
if there are monitors of older version in the cluster.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>