### PR TITLE
osd: avoid transaction append much of the time

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -655,7 +655,7 @@ bool ECBackend::handle_message(
   switch (_op->get_req()->get_type()) {
   case MSG_OSD_EC_WRITE: {
     MOSDECSubOpWrite *op = static_cast<MOSDECSubOpWrite*>(_op->get_req());
-    handle_sub_write(op->op.from, _op, op->op);
+    handle_sub_write(op->op->from, _op, *op->op);
     return true;
   }
   case MSG_OSD_EC_WRITE_REPLY: {
@@ -809,12 +809,12 @@ void ECBackend::handle_sub_write(
   if (!get_parent()->pgb_is_primary())
     get_parent()->update_stats(op.stats);
   ObjectStore::Transaction *localt = new ObjectStore::Transaction;
-  localt->set_use_tbl(op.t.get_use_tbl());
+  localt->set_use_tbl(op.t->get_use_tbl());
   if (!op.temp_added.empty()) {
     get_temp_coll(localt);
     add_temp_objs(op.temp_added);
   }
-  if (op.t.empty()) {
+  if (op.t->empty()) {
     for (set<hobject_t>::iterator i = op.temp_removed.begin();
 	 i != op.temp_removed.end();
 	 ++i) {
@@ -834,14 +834,13 @@ void ECBackend::handle_sub_write(
     op.updated_hit_set_history,
     op.trim_to,
     op.trim_rollback_to,
-    !(op.t.empty()),
+    !(op.t->empty()),
     localt);
 
   if (!(dynamic_cast<ReplicatedPG *>(get_parent())->is_undersized()) &&
       get_parent()->whoami_shard().shard >= ec_impl->get_data_chunk_count())
-    op.t.set_fadvise_flag(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    op.t->set_fadvise_flag(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
 
-  localt->append(op.t);
   if (on_local_applied_sync) {
     dout(10) << "Queueing onreadable_sync: " << on_local_applied_sync << dendl;
     localt->register_on_applied_sync(on_local_applied_sync);
@@ -857,7 +856,13 @@ void ECBackend::handle_sub_write(
       new SubWriteApplied(this, msg, op.tid, op.at_version)));
   localt->register_on_applied(
     new ObjectStore::C_DeleteTransaction(localt));
-  get_parent()->queue_transaction(localt, msg);
+  localt->register_on_applied(
+    new ObjectStore::C_DeleteTransaction(op.t));
+  list<ObjectStore::Transaction*> tls;
+  tls.push_back(localt);
+  tls.push_back(op.t);
+  op.t = NULL;  // NOTE: we steal the txn from the caller's ECSubWrite
+  get_parent()->queue_transactions(tls, msg);
 }
 
 void ECBackend::handle_sub_read(
@@ -1511,13 +1516,13 @@ void ECBackend::check_op(Op *op)
 }
 
 void ECBackend::start_write(Op *op) {
-  map<shard_id_t, ObjectStore::Transaction> trans;
+  map<shard_id_t, ObjectStore::Transaction*> trans;
   for (set<pg_shard_t>::const_iterator i =
 	 get_parent()->get_actingbackfill_shards().begin();
        i != get_parent()->get_actingbackfill_shards().end();
        ++i) {
-    trans[i->shard];
-    trans[i->shard].set_use_tbl(parent->transaction_use_tbl());
+    trans[i->shard] = new ObjectStore::Transaction;
+    trans[i->shard]->set_use_tbl(parent->transaction_use_tbl());
   }
   op->t->generate_transactions(
     op->unstable_hash_infos,
@@ -1536,7 +1541,7 @@ void ECBackend::start_write(Op *op) {
        ++i) {
     op->pending_apply.insert(*i);
     op->pending_commit.insert(*i);
-    map<shard_id_t, ObjectStore::Transaction>::iterator iter =
+    map<shard_id_t, ObjectStore::Transaction*>::iterator iter =
       trans.find(i->shard);
     assert(iter != trans.end());
     bool should_send = get_parent()->should_send_op(*i, op->hoid);
@@ -1544,14 +1549,18 @@ void ECBackend::start_write(Op *op) {
       should_send ?
       get_info().stats :
       parent->get_shard_info().find(*i)->second.stats;
+    ObjectStore::Transaction *t = iter->second;
+    if (!should_send)
+      delete t;
+    trans.erase(iter);
 
-    ECSubWrite sop(
+    ECSubWrite *sop = new ECSubWrite(
       get_parent()->whoami_shard(),
       op->tid,
       op->reqid,
       op->hoid,
       stats,
-      should_send ? iter->second : ObjectStore::Transaction(),
+      t,
       op->version,
       op->trim_to,
       op->trim_rollback_to,
@@ -1563,9 +1572,10 @@ void ECBackend::start_write(Op *op) {
       handle_sub_write(
 	get_parent()->whoami_shard(),
 	op->client_op,
-	sop,
+	*sop,
 	op->on_local_applied_sync);
       op->on_local_applied_sync = 0;
+      delete sop;
     } else {
       MOSDECSubOpWrite *r = new MOSDECSubOpWrite(sop);
       r->set_priority(cct->_conf->osd_client_op_priority);
@@ -1574,6 +1584,11 @@ void ECBackend::start_write(Op *op) {
       get_parent()->send_message_osd_cluster(
 	i->osd, r, get_parent()->get_epoch());
     }
+  }
+  // release unused Transactions
+  while (!trans.empty()) {
+    delete trans.begin()->second;
+    trans.erase(trans.begin());
   }
 }
 

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -35,13 +35,15 @@ void ECSubWrite::encode(bufferlist &bl) const
 
 void ECSubWrite::decode(bufferlist::iterator &bl)
 {
+  delete t;
+  t = new ObjectStore::Transaction;
   DECODE_START(3, bl);
   ::decode(from, bl);
   ::decode(tid, bl);
   ::decode(reqid, bl);
   ::decode(soid, bl);
   ::decode(stats, bl);
-  ::decode(t, bl);
+  ::decode(*t, bl);
   ::decode(at_version, bl);
   ::decode(trim_to, bl);
   ::decode(log_entries, bl);

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -26,7 +26,7 @@ struct ECSubWrite {
   osd_reqid_t reqid;
   hobject_t soid;
   pg_stat_t stats;
-  ObjectStore::Transaction t;
+  ObjectStore::Transaction *t;
   eversion_t at_version;
   eversion_t trim_to;
   eversion_t trim_rollback_to;
@@ -34,14 +34,14 @@ struct ECSubWrite {
   set<hobject_t> temp_added;
   set<hobject_t> temp_removed;
   boost::optional<pg_hit_set_history_t> updated_hit_set_history;
-  ECSubWrite() {}
+  ECSubWrite() : t(NULL) {}
   ECSubWrite(
     pg_shard_t from,
     ceph_tid_t tid,
     osd_reqid_t reqid,
     hobject_t soid,
     const pg_stat_t &stats,
-    const ObjectStore::Transaction &t,
+    ObjectStore::Transaction *t,
     eversion_t at_version,
     eversion_t trim_to,
     eversion_t trim_rollback_to,
@@ -57,6 +57,14 @@ struct ECSubWrite {
       temp_added(temp_added),
       temp_removed(temp_removed),
       updated_hit_set_history(updated_hit_set_history) {}
+  ~ECSubWrite() {
+    delete t;
+  }
+private:
+  // no outside copying
+  ECSubWrite(ECSubWrite& other);
+  const ECSubWrite& operator=(const ECSubWrite& other);
+public:
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &bl);
   void dump(Formatter *f) const;

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -200,7 +200,7 @@ public:
     ErasureCodeInterfaceRef &ecimpl,
     pg_t pgid,
     const ECUtil::stripe_info_t &sinfo,
-    map<shard_id_t, ObjectStore::Transaction> *transactions,
+    map<shard_id_t, ObjectStore::Transaction*> *transactions,
     set<hobject_t> *temp_added,
     set<hobject_t> *temp_removed,
     stringstream *out = 0) const;

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -109,6 +109,10 @@
        ObjectStore::Transaction *t,
        OpRequestRef op = OpRequestRef()
        ) = 0;
+     virtual void queue_transactions(
+       list<ObjectStore::Transaction*>& tls,
+       OpRequestRef op = OpRequestRef()
+       ) = 0;
      virtual epoch_t get_epoch() const = 0;
 
      virtual const set<pg_shard_t> &get_actingbackfill_shards() const = 0;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -571,10 +571,10 @@ void ReplicatedBackend::submit_transaction(
     &op,
     op_t);
 
-  ObjectStore::Transaction local_t;
-  local_t.set_use_tbl(op_t->get_use_tbl());
+  ObjectStore::Transaction *local_t = new ObjectStore::Transaction;
+  local_t->set_use_tbl(op_t->get_use_tbl());
   if (!(t->get_temp_added().empty())) {
-    get_temp_coll(&local_t);
+    get_temp_coll(local_t);
     add_temp_objs(t->get_temp_added());
   }
   clear_temp_objs(t->get_temp_cleared());
@@ -585,10 +585,7 @@ void ReplicatedBackend::submit_transaction(
     trim_to,
     trim_rollback_to,
     true,
-    &local_t);
-
-  local_t.append(*op_t);
-  local_t.swap(*op_t);
+    local_t);
   
   op_t->register_on_applied_sync(on_local_applied_sync);
   op_t->register_on_applied(
@@ -596,11 +593,16 @@ void ReplicatedBackend::submit_transaction(
       new C_OSD_OnOpApplied(this, &op)));
   op_t->register_on_applied(
     new ObjectStore::C_DeleteTransaction(op_t));
+  op_t->register_on_applied(
+    new ObjectStore::C_DeleteTransaction(local_t));
   op_t->register_on_commit(
     parent->bless_context(
       new C_OSD_OnOpCommit(this, &op)));
-      
-  parent->queue_transaction(op_t, op.op);
+
+  list<ObjectStore::Transaction*> tls;
+  tls.push_back(local_t);
+  tls.push_back(op_t);
+  parent->queue_transactions(tls, op.op);
   delete t;
 }
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8459,14 +8459,16 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
   
   op->mark_started();
 
-  rm->localt.append(rm->opt);
-  rm->localt.register_on_commit(
+  rm->opt.register_on_commit(
     parent->bless_context(
       new C_OSD_RepModifyCommit(this, rm)));
   rm->localt.register_on_applied(
     parent->bless_context(
       new C_OSD_RepModifyApply(this, rm)));
-  parent->queue_transaction(&(rm->localt), op);
+  list<ObjectStore::Transaction*> tls;
+  tls.push_back(&(rm->localt));
+  tls.push_back(&(rm->opt));
+  parent->queue_transactions(tls, op);
   // op is cleaned up by oncommit/onapply when both are executed
 }
 

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -322,9 +322,10 @@ public:
     osd->send_message_osd_cluster(to_osd, m, get_osdmap()->get_epoch());
   }
   void queue_transaction(ObjectStore::Transaction *t, OpRequestRef op) {
-    list<ObjectStore::Transaction *> tls;
-    tls.push_back(t);
     osd->store->queue_transaction(osr.get(), t, 0, 0, 0, op);
+  }
+  void queue_transactions(list<ObjectStore::Transaction*>& tls, OpRequestRef op) {
+    osd->store->queue_transactions(osr.get(), tls, 0, 0, 0, op);
   }
   epoch_t get_epoch() const {
     return get_osdmap()->get_epoch();

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -87,7 +87,7 @@ TYPE(PushReplyOp)
 TYPE(ECUtil::HashInfo)
 
 #include "osd/ECMsgTypes.h"
-TYPE(ECSubWrite)
+TYPE_NOCOPY(ECSubWrite)
 TYPE(ECSubWriteReply)
 TYPE_FEATUREFUL(ECSubRead)
 TYPE(ECSubReadReply)


### PR DESCRIPTION
I think this will reclaim most of the hit we took for copying the ops in Transaction::append()