### PR TITLE
librbd: potential deadlock on close_image

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2291,13 +2291,15 @@ reprotect_and_return_err:
     }
 
     if (ictx->image_watcher) {
-      RWLock::WLocker l(ictx->owner_lock);
-      if (ictx->image_watcher->is_lock_owner()) {
-        int r = ictx->image_watcher->unlock();
-        if (r < 0) {
-	  lderr(ictx->cct) << "error unlocking object map: " << cpp_strerror(r)
-			   << dendl;
-        }
+      {
+	RWLock::WLocker l(ictx->owner_lock);
+	if (ictx->image_watcher->is_lock_owner()) {
+	  int r = ictx->image_watcher->unlock();
+	  if (r < 0) {
+	    lderr(ictx->cct) << "error unlocking image: " << cpp_strerror(r)
+			     << dendl;
+	  }
+	}
       }
       ictx->unregister_watch();
     }


### PR DESCRIPTION
The owner_lock was incorrectly held when unregistering the image
watcher.  It was possible for the ImageWatcher finisher to be
running code that was then deadlocked waiting to acquire the
owner_lock while the close_image thread was attempting to shutdown
the deadlocked finisher.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>