### PR TITLE
ceph.spec.in: remove reference to EOL Fedoras

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1,6 +1,6 @@
 %bcond_with ocf
 
-%if ! (0%{?fedora} > 12 || 0%{?rhel} > 5)
+%if (0%{?el5} || (0%{?rhel_version} >= 500 && 0%{?rhel_version} <= 600))
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 %endif


### PR DESCRIPTION
Fedora 12 has been EOL for a long time. Remove the reference in the RPM .spec file.

This means that we only check and conditionally define `python_sitelib` and `python_sitearch` on RHEL 5 now.

My preference would be to just delete this whole `%if`... `%endif` condition entirely since we only build Ceph for RHEL 6 and above. Doing so would remove RHEL 5 support, since RHEL 5 does not have those `python_` macros. I think there may have been effort to port Ceph to RHEL 5 at some point long ago, and I'm unsure of the status, so I'll keep the main stuff for now.