### PR TITLE
ceph.spec.in: use wildcards to capture man pages

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -515,8 +515,8 @@ fi
 %{_mandir}/man8/mount.ceph.8*
 %{_mandir}/man8/ceph-rbdnamer.8*
 %{_mandir}/man8/ceph-debugpack.8*
-%{_mandir}/man8/ceph-clsinfo.8.gz
-%{_mandir}/man8/librados-config.8.gz
+%{_mandir}/man8/ceph-clsinfo.8*
+%{_mandir}/man8/librados-config.8*
 #set up placeholder directories
 %dir %{_localstatedir}/lib/ceph/
 %dir %{_localstatedir}/lib/ceph/tmp


### PR DESCRIPTION
Use wildcard to capture gzipped man pages for `ceph-clsinfo(8)` and `librados-config(8)`. In addition to future-proofing us against possible compression type changes down the road, this also aligns us with the existing convention that's used to capture the rest of the man page files.