### PR TITLE
librbd: trim would not complete if exclusive lock is lost

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1814,7 +1814,7 @@ reprotect_and_return_err:
       RWLock::RLocker l(m_ictx->owner_lock);
       if (m_ictx->image_watcher->is_lock_supported() &&
           !m_ictx->image_watcher->is_lock_owner()) {
-	r = -ERESTART;
+	m_ctx->complete(-ERESTART);
 	return;
       }
 


### PR DESCRIPTION
The trim completion context was not properly invoked if the
image's exclusive lock was lost between issuing a librados call
and receiving its completion.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>