### PR TITLE
install-deps: fix LC_ALL setting

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -17,7 +17,7 @@ mkdir -p $DIR
 if test $(id -u) != 0 ; then
     SUDO=sudo
 fi
-export LC_ALL=C# the following is vulnerable to i18n
+export LC_ALL=C # the following is vulnerable to i18n
 case $(lsb_release -si) in
 Ubuntu|Debian|Devuan)
         $SUDO apt-get install -y dpkg-dev


### PR DESCRIPTION
On my box LC_ALL=C# includes the '#' in the value without
a space between C and '#' and things go completely bonkers.

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>