### PR TITLE
librados: handle failed watch registration better

### DIFF
--- a/qa/workunits/rbd/test_lock_fence.sh
+++ b/qa/workunits/rbd/test_lock_fence.sh
@@ -42,8 +42,5 @@ fi
 set -e
 ceph osd blacklist rm $clientaddr
 rbd lock remove $IMAGE $LOCKID "$clientid"
-# rbdrw will have exited with an existing watch, so, until #3527 is fixed,
-# hang out until the watch expires
-sleep 30
 rbd rm $IMAGE
 echo OK


### PR DESCRIPTION
If watch() failed, the LingerOp would be deleted, but a pointer to it
would live on in the handle passed by the caller. An unwatch() called
on that handle would cause a segfault.

Set handle only after the watch osd op has returned, and set it to 0
on failure. Make unwatch() return 0 early if passed a handle of 0, to
get back the earlier behavior of not segfaulting if a non-registered
cookie is passed to unwatch(). This aspect of the interface changed
when the new watch2/notify2 functions were introduced.