### PR TITLE
tests: bring back useful test 'ceph tell osd.foo'

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1087,6 +1087,7 @@ function test_mon_pg()
   #
   ceph tell osd.0 version
   expect_false ceph tell osd.9999 version 
+  expect_false ceph tell osd.foo version
 
   # back to pg stuff
 


### PR DESCRIPTION
The test was removed in 1189138 (mon: make ceph tell mon.* version
work) as it began to fail due to #10439. After it fixed in c4548f6
(pybind: ceph_argparse: validate incorrectly formed targets), the test
can be restored.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>