### PR TITLE
librados: rectify the pool name caching in IoCtxImpl.

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -623,7 +623,7 @@ namespace librados
 
     uint64_t get_instance_id() const;
 
-    std::string get_pool_name();
+    std::string get_pool_name() const;
 
     bool pool_requires_alignment();
     uint64_t pool_required_alignment();
@@ -1018,8 +1018,6 @@ namespace librados
     // assert version for next sync operations
     void set_assert_version(uint64_t ver);
     void set_assert_src_version(const std::string& o, uint64_t ver);
-
-    const std::string& get_pool_name() const;
 
     void locator_set_key(const std::string& key);
     void set_namespace(const std::string& nspace);

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -33,9 +33,8 @@ librados::IoCtxImpl::IoCtxImpl() :
 }
 
 librados::IoCtxImpl::IoCtxImpl(RadosClient *c, Objecter *objecter,
-			       int64_t poolid,
-			       const char *pool_name, snapid_t s)
-  : ref_cnt(0), client(c), poolid(poolid), pool_name(pool_name), snap_seq(s),
+			       int64_t poolid, snapid_t s)
+  : ref_cnt(0), client(c), poolid(poolid), snap_seq(s),
     assert_ver(0), last_objver(0),
     notify_timeout(c->cct->_conf->client_notify_timeout),
     oloc(poolid),

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -32,7 +32,6 @@ struct librados::IoCtxImpl {
   atomic_t ref_cnt;
   RadosClient *client;
   int64_t poolid;
-  string pool_name;
   snapid_t snap_seq;
   ::SnapContext snapc;
   uint64_t assert_ver;
@@ -51,13 +50,12 @@ struct librados::IoCtxImpl {
 
   IoCtxImpl();
   IoCtxImpl(RadosClient *c, Objecter *objecter,
-	    int64_t poolid, const char *pool_name, snapid_t s);
+	    int64_t poolid, snapid_t s);
 
   void dup(const IoCtxImpl& rhs) {
     // Copy everything except the ref count
     client = rhs.client;
     poolid = rhs.poolid;
-    pool_name = rhs.pool_name;
     snap_seq = rhs.snap_seq;
     snapc = rhs.snapc;
     assert_ver = rhs.assert_ver;

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -348,20 +348,13 @@ int librados::RadosClient::create_ioctx(const char *name, IoCtxImpl **io)
     }
   }
 
-  *io = new librados::IoCtxImpl(this, objecter, poolid, name, CEPH_NOSNAP);
+  *io = new librados::IoCtxImpl(this, objecter, poolid, CEPH_NOSNAP);
   return 0;
 }
 
 int librados::RadosClient::create_ioctx(int64_t pool_id, IoCtxImpl **io)
 {
-  std::string pool_name;
-  int r = pool_get_name(pool_id, &pool_name);
-  if (r < 0) {
-    return r;
-  }
-
-  *io = new librados::IoCtxImpl(this, objecter, pool_id, pool_name.c_str(),
-                                CEPH_NOSNAP);
+  *io = new librados::IoCtxImpl(this, objecter, pool_id, CEPH_NOSNAP);
   return 0;
 }
 

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -394,7 +394,7 @@ uint64_t IoCtx::get_last_version() {
   return ctx->get_last_version();
 }
 
-std::string IoCtx::get_pool_name() {
+std::string IoCtx::get_pool_name() const {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->get_pool_name();
 }


### PR DESCRIPTION
Fixes: #10458 Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>