### PR TITLE
mon: OSDMonitor: tolerate catastrophically bad crush maps

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -917,6 +917,7 @@ function test_mon_osd()
   f=$TMPDIR/map.$$
   ceph osd getcrushmap -o $f
   [ -s $f ]
+  ceph osd setcrushmap -i $f
   rm $f
   ceph osd getmap -o $f
   [ -s $f ]

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -3,7 +3,12 @@
 
 #include <algorithm>
 #include <stdlib.h>
-
+/* fork */
+#include <unistd.h>
+/* waitpid */
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <common/errno.h>
 
 void CrushTester::set_device_weight(int dev, float f)
 {
@@ -348,6 +353,76 @@ void CrushTester::write_integer_indexed_scalar_data_string(vector<string> &dst, 
 
   // write the data buffer to the destination
   dst.push_back( data_buffer.str() );
+}
+
+int CrushTester::test_with_crushtool()
+{
+  vector<const char *> cmd_args;
+  cmd_args.push_back("crushtool");
+  cmd_args.push_back("-i");
+  cmd_args.push_back("-");
+  cmd_args.push_back("--test");
+  cmd_args.push_back("--output-csv");
+  cmd_args.push_back(NULL);
+
+  int pipefds[2];
+  if (::pipe(pipefds) == -1) {
+    int r = errno;
+    err << "error creating pipe: " << cpp_strerror(r) << "\n";
+    return -r;
+  }
+
+  int fpid = fork();
+  if (fpid < 0) {
+    int r = errno;
+    err << "unable to fork(): " << cpp_strerror(r);
+    ::close(pipefds[0]);
+    ::close(pipefds[1]);
+    return -r;
+  } else if (fpid == 0) {
+    ::close(pipefds[1]);
+    ::dup2(pipefds[0], STDIN_FILENO);
+    ::close(pipefds[0]);
+    ::close(1);
+    ::close(2);
+    int r = execvp(cmd_args[0], (char * const *)&cmd_args[0]);
+    if (r < 0)
+      exit(errno);
+    // we should never reach this
+    exit(EINVAL);
+  }
+  ::close(pipefds[0]);
+
+  bufferlist bl;
+  ::encode(crush, bl);
+  bl.write_fd(pipefds[1]);
+  ::close(pipefds[1]);
+
+  int status;
+  int r = waitpid(fpid, &status, 0);
+  assert(r == fpid);
+
+  if (!WIFEXITED(status)) {
+    assert(WIFSIGNALED(status));
+    err << "error testing crush map\n";
+    return -EINVAL;
+  }
+
+  r = WEXITSTATUS(status);
+  if (r == 0) {
+    // major success!
+    return 0;
+  }
+
+  if (r == ENOENT) {
+    err << "unable to find 'crushtool' to test the map";
+    return -ENOENT;
+  }
+
+  // something else entirely happened
+  // log it and consider an invalid crush map
+  err << "error running crushmap through crushtool: " << cpp_strerror(r);
+  return -r;
 }
 
 int CrushTester::test()

--- a/src/crush/CrushTester.h
+++ b/src/crush/CrushTester.h
@@ -334,6 +334,7 @@ public:
   }
 
   int test();
+  int test_with_crushtool();
 };
 
 #endif

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -26,11 +26,13 @@ if [ `dirname $0` = "." ] && [ $PWD != "/etc/init.d" ]; then
     LIBDIR=.
     ETCDIR=.
     SYSTEMD_RUN=""
+    ASSUME_DEV=1
 else
     BINDIR=@bindir@
     SBINDIR=@prefix@/sbin
     LIBDIR=@libdir@/ceph
     ETCDIR=@sysconfdir@/ceph
+    ASSUME_DEV=0
 fi
 
 usage_exit() {
@@ -219,6 +221,9 @@ for name in $what; do
 
     binary="$BINDIR/ceph-$type"
     cmd="$binary -i $id"
+    if [ $ASSUME_DEV -eq 1 ]; then
+      cmd="PATH=$PWD:$PATH $cmd"
+    fi
 
     get_conf run_dir "/var/run/ceph" "run dir"
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4486,7 +4486,14 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
     dout(10) << " testing map" << dendl;
     stringstream ess;
     CrushTester tester(crush, ess);
-    tester.test();
+    int r = tester.test_with_crushtool();
+    if (r < 0) {
+      derr << "error on crush map: " << ess.str() << dendl;
+      ss << "Failed to parse crushmap: " << ess.str();
+      err = r;
+      goto reply;
+    }
+
     dout(10) << " result " << ess.str() << dendl;
 
     pending_inc.crush = data;

--- a/src/test/vstart_wrapper.sh
+++ b/src/test/vstart_wrapper.sh
@@ -27,10 +27,10 @@ function vstart_setup()
     mkdir -p $CEPH_DEV_DIR
     trap "teardown $CEPH_DIR" EXIT
     export LC_ALL=C # some tests are vulnerable to i18n
+    export PATH=.:$PATH
     ./vstart.sh \
         -o 'paxos propose interval = 0.01' \
         -n -l $CEPH_START || return 1
-    export PATH=.:$PATH
     export CEPH_CONF=$CEPH_DIR/ceph.conf
 
     crit=$(expr 100 - $(ceph-conf --show-config-value mon_data_avail_crit))


### PR DESCRIPTION
This set of patches do not fix any bugs in crush map testing or
encoding.  Instead, we sandbox crush map testing thus avoiding a
monitor crash in case of a particularly malformed crush map that
ends up leading to a segfault.

``Signed-off-by: Joao Eduardo Luis <joao@redhat.com>``