### PR TITLE
librados: expose rados_{read|write}_op_assert_version() in C

### DIFF
--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -4125,6 +4125,13 @@ extern "C" void rados_write_op_set_flags(rados_write_op_t write_op, int flags)
   tracepoint(librados, rados_write_op_set_flags_exit);
 }
 
+extern "C" void rados_write_op_assert_version(rados_write_op_t write_op, uint64_t ver)
+{
+  tracepoint(librados, rados_write_op_assert_version_enter, write_op);
+  ((::ObjectOperation *)write_op)->assert_version(ver);
+  tracepoint(librados, rados_write_op_assert_version_exit);
+}
+
 extern "C" void rados_write_op_assert_exists(rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_assert_exists_enter, write_op);
@@ -4378,6 +4385,13 @@ extern "C" void rados_read_op_set_flags(rados_read_op_t read_op, int flags)
   tracepoint(librados, rados_read_op_set_flags_enter, read_op, flags);
   set_op_flags((::ObjectOperation *)read_op, flags);
   tracepoint(librados, rados_read_op_set_flags_exit);
+}
+
+extern "C" void rados_read_op_assert_version(rados_read_op_t read_op, uint64_t ver)
+{
+  tracepoint(librados, rados_read_op_assert_version_enter, read_op);
+  ((::ObjectOperation *)read_op)->assert_version(ver);
+  tracepoint(librados, rados_read_op_assert_version_exit);
 }
 
 extern "C" void rados_read_op_assert_exists(rados_read_op_t read_op)

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -4127,7 +4127,7 @@ extern "C" void rados_write_op_set_flags(rados_write_op_t write_op, int flags)
 
 extern "C" void rados_write_op_assert_version(rados_write_op_t write_op, uint64_t ver)
 {
-  tracepoint(librados, rados_write_op_assert_version_enter, write_op);
+  tracepoint(librados, rados_write_op_assert_version_enter, write_op, ver);
   ((::ObjectOperation *)write_op)->assert_version(ver);
   tracepoint(librados, rados_write_op_assert_version_exit);
 }
@@ -4389,7 +4389,7 @@ extern "C" void rados_read_op_set_flags(rados_read_op_t read_op, int flags)
 
 extern "C" void rados_read_op_assert_version(rados_read_op_t read_op, uint64_t ver)
 {
-  tracepoint(librados, rados_read_op_assert_version_enter, read_op);
+  tracepoint(librados, rados_read_op_assert_version_enter, read_op, ver);
   ((::ObjectOperation *)read_op)->assert_version(ver);
   tracepoint(librados, rados_read_op_assert_version_exit);
 }

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -510,6 +510,34 @@ TEST_F(LibRadosMiscPP, AssertExistsPP) {
   ASSERT_EQ(-EEXIST, ioctx.create("asdffoo", true));
 }
 
+TEST_F(LibRadosMiscPP, AssertVersionPP) {
+  char buf[64];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+
+  // Create test object...
+  ASSERT_EQ(0, ioctx.create("asdfbar", true));
+  // ...then write it again to guarantee that the
+  // (unsigned) version must be at least 1 (not 0)
+  // since we want to decrement it by 1 later.
+  ASSERT_EQ(0, ioctx.write_full("asdfbar", bl));
+
+  uint64_t v = ioctx.get_last_version();
+  ObjectWriteOperation op1;
+  op1.assert_version(v+1);
+  op1.write(0, bl);
+  ASSERT_EQ(-EOVERFLOW, ioctx.operate("asdfbar", &op1));
+  ObjectWriteOperation op2;
+  op2.assert_version(v-1);
+  op2.write(0, bl);
+  ASSERT_EQ(-ERANGE, ioctx.operate("asdfbar", &op2));
+  ObjectWriteOperation op3;
+  op3.assert_version(v);
+  op3.write(0, bl);
+  ASSERT_EQ(0, ioctx.operate("asdfbar", &op3));
+}
+
 TEST_F(LibRadosMiscPP, BigAttrPP) {
   char buf[64];
   memset(buf, 0xcc, sizeof(buf));

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -2599,6 +2599,21 @@ TRACEPOINT_EVENT(librados, rados_write_op_set_flags_exit,
     TP_FIELDS()
 )
 
+TRACEPOINT_EVENT(librados, rados_write_op_assert_version_enter,
+    TP_ARGS(
+        rados_write_op_t, op,
+	uint64_t, ver),
+    TP_FIELDS(
+        ctf_integer_hex(rados_write_op_t, op, op)
+	ctf_integer(uint64_t, ver, ver)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_write_op_assert_version_exit,
+    TP_ARGS(),
+    TP_FIELDS()
+)
+
 TRACEPOINT_EVENT(librados, rados_write_op_assert_exists_enter,
     TP_ARGS(
         rados_write_op_t, op),
@@ -2985,6 +3000,21 @@ TRACEPOINT_EVENT(librados, rados_read_op_set_flags_enter,
 )
 
 TRACEPOINT_EVENT(librados, rados_read_op_set_flags_exit,
+    TP_ARGS(),
+    TP_FIELDS()
+)
+
+TRACEPOINT_EVENT(librados, rados_read_op_assert_version_enter,
+    TP_ARGS(
+        rados_read_op_t, read_op,
+	uint64_t, ver),
+    TP_FIELDS(
+        ctf_integer_hex(rados_read_op_t, read_op, read_op)
+        ctf_integer(uint64_t, ver, ver)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_read_op_assert_version_exit,
     TP_ARGS(),
     TP_FIELDS()
 )


### PR DESCRIPTION
Previously, assert_version was only available in the C++ interface.

Signed-off-by: Kim Vandry <vandry@TZoNE.ORG>