### PR TITLE
tests: ensure RBD integration tests exercise all features

### DIFF
--- a/src/test/run-rbd-tests
+++ b/src/test/run-rbd-tests
@@ -32,12 +32,12 @@ ceph_test_cls_rbd
 run_api_tests
 run_cli_tests
 
-RBD_CREATE_ARGS="--format 2"
+export RBD_CREATE_ARGS="--format 2"
 run_cli_tests
 
 for i in 0 1 5
 do
-    RBD_FEATURES=$i
+    export RBD_FEATURES=$i
     run_api_tests
 done
 


### PR DESCRIPTION
The RBD_FEATURES environment variables was not being exported to
the Python and C++ integration tests.  This resulted in the same
test cases being run multiple times instead of testing different
RBD features.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>