### PR TITLE
#10688: support Boost 1.57.0

### DIFF
--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -16,7 +16,7 @@
 #define MAPCACHER_H
 
 #include <boost/scoped_ptr.hpp>
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include "include/memory.h"
 #include <set>
 #include <map>

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -286,7 +286,7 @@ inline void decode(T &o, bufferlist& bl)
 #include <deque>
 #include <vector>
 #include <string>
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <boost/tuple/tuple.hpp>
 
 #ifndef _BACKWARD_BACKWARD_WARNING_H

--- a/src/os/DBObjectMap.h
+++ b/src/os/DBObjectMap.h
@@ -17,7 +17,7 @@
 #include "common/Mutex.h"
 #include "common/Cond.h"
 #include "common/simple_cache.hpp"
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 
 /**
  * DBObjectMap: Implements ObjectMap in terms of KeyValueDB

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -13,7 +13,7 @@
  */
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <iostream>
 #include <sstream>
 

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -18,7 +18,7 @@
 #include "OSD.h"
 #include "PGBackend.h"
 #include "osd_types.h"
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include "erasure-code/ErasureCodeInterface.h"
 #include "ECTransaction.h"
 #include "ECMsgTypes.h"

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -13,7 +13,7 @@
  */
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <iostream>
 #include <vector>
 #include <sstream>

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -19,7 +19,7 @@
 #include "PGBackend.h"
 #include "osd_types.h"
 #include "ECUtil.h"
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include "erasure-code/ErasureCodeInterface.h"
 
 class ECTransaction : public PGBackend::PGTransaction {

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -17,7 +17,7 @@
 #ifndef CEPH_REPLICATEDPG_H
 #define CEPH_REPLICATEDPG_H
 
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <boost/tuple/tuple.hpp>
 
 #include "include/assert.h" 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <memory>
 #include <boost/scoped_ptr.hpp>
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 
 #include "include/rados/rados_types.hpp"
 


### PR DESCRIPTION
This patch comes from http://tracker.ceph.com/issues/10688 , and I've rebased @pmachata's patch for v0.87 onto the tip of master.

Note: With Ceph's v0.87, the patch cast `rhs.attrs` to a `bool`, but since this code has changed slightly in master (a53ead14c113047567177630b4906136a2109b65 changed the code to `rhs.attrs.get()` instead), I am not sure if that `bool` cast is appropriate any more? Can someone confirm?
