### PR TITLE
[DNM] #10691: build: remove LIBPERFGLUE from LIBMDS

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -194,7 +194,6 @@ LIBOSD += $(LIBOSDC) $(LIBOS)
 # These have references to syms like ceph_using_tcmalloc(), glue libperfglue to them
 LIBMON += $(LIBPERFGLUE)
 LIBOSD += $(LIBPERFGLUE)
-LIBMDS += $(LIBPERFGLUE)
 
 # Always use system leveldb
 LIBOS += -lleveldb -lsnappy

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,7 +48,7 @@ ceph_osd_LDADD = $(LIBOSD) $(CEPH_GLOBAL) $(LIBCOMMON)
 bin_PROGRAMS += ceph-osd
 
 ceph_mds_SOURCES = ceph_mds.cc
-ceph_mds_LDADD = $(LIBMDS) $(LIBOSDC) $(CEPH_GLOBAL) $(LIBCOMMON)
+ceph_mds_LDADD = $(LIBMDS) $(LIBOSDC) $(CEPH_GLOBAL) $(LIBCOMMON) $(LIBPERFGLUE)
 bin_PROGRAMS += ceph-mds
 
 

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -68,14 +68,14 @@ cephfs_journal_tool_SOURCES = \
 	tools/cephfs/Dumper.cc \
 	tools/cephfs/Resetter.cc \
 	tools/cephfs/MDSUtility.cc
-cephfs_journal_tool_LDADD = $(LIBMDS) $(LIBRADOS) $(CEPH_GLOBAL)
+cephfs_journal_tool_LDADD = $(LIBMDS) $(LIBRADOS) $(CEPH_GLOBAL) $(LIBPERFGLUE)
 bin_PROGRAMS += cephfs-journal-tool
 
 cephfs_table_tool_SOURCES = \
 	tools/cephfs/cephfs-table-tool.cc \
 	tools/cephfs/TableTool.cc \
 	tools/cephfs/MDSUtility.cc
-cephfs_table_tool_LDADD = $(LIBMDS) $(LIBRADOS) $(CEPH_GLOBAL)
+cephfs_table_tool_LDADD = $(LIBMDS) $(LIBRADOS) $(CEPH_GLOBAL) $(LIBPERFGLUE)
 bin_PROGRAMS += cephfs-table-tool
 
 if WITH_REST_BENCH


### PR DESCRIPTION
The `ceph-dencoder` tool links to `LIBMDS`. Prior to this commit, `LIBMDS` included `LIBPERFGLUE`, which may contain `-ltcmalloc`. This meant that `ceph-dencoder` could end up linking to tcmalloc when it did not need to do so.

Drop `LIBPERFGLUE` from `LIBMDS` and include it directly in the individual binaries that need it (`mds`, `cephfs_journal_tool`, `cephfs_table_tool`)

Thanks to Dan Mick and Gregory Farnum for help with this.

http://tracker.ceph.com/issues/10691