### PR TITLE
rgw: Response 204 when post on containers

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -449,8 +449,13 @@ int RGWPutMetadata_ObjStore_SWIFT::get_params()
 
 void RGWPutMetadata_ObjStore_SWIFT::send_response()
 {
-  if (!ret)
-    ret = STATUS_ACCEPTED;
+  if (!ret) {
+    /* Return 204 when post metadata on a container */
+    if (s->object.empty())
+      ret = STATUS_NO_CONTENT;
+    else
+      ret = STATUS_ACCEPTED;
+  }
   set_req_state_err(s, ret);
   dump_errno(s);
   end_header(s, this);


### PR DESCRIPTION
Currently POST request on container returns 202 if success. But in Swift
the code is 204. Let's use 204 to keep align with the Swift API.

Fixes #10667
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>