### PR TITLE
mon: MDSMonitor: missing backports for giant 

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1091,7 +1091,8 @@ bool MDSMonitor::management_command(
         // Ensure fs name is not empty so that we can implement
         // commmands that refer to FS by name in future.
         ss << "Filesystem name may not be empty";
-        return -EINVAL;
+        r = -EINVAL;
+        return true;
     }
 
     if (pending_mdsmap.get_enabled()

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1108,6 +1108,7 @@ bool MDSMonitor::management_command(
       /* We currently only support one filesystem, so cannot create a second */
       ss << "A filesystem already exists, use `ceph fs rm` if you wish to delete it";
       r = -EINVAL;
+      return true;
     }
 
     pg_pool_t const *data_pool = mon->osdmon()->osdmap.get_pg_pool(data);

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1116,14 +1116,11 @@ bool MDSMonitor::management_command(
     pg_pool_t const *metadata_pool = mon->osdmon()->osdmap.get_pg_pool(metadata);
     assert(metadata_pool != NULL);  // Checked it existed above
 
-    // Automatically set crash_replay_interval on data pool if it
-    // isn't already set.
-    if (data_pool->get_crash_replay_interval() == 0) {
-      r = mon->osdmon()->set_crash_replay_interval(data, g_conf->osd_default_data_pool_replay_window);
-      assert(r == 0);  // We just did get_pg_pool so it must exist and be settable
-      request_proposal(mon->osdmon());
-    }
-
+    // we must make these checks before we even allow ourselves to *think*
+    // about requesting a proposal to the osdmonitor and bail out now if
+    // we believe we must.  bailing out *after* we request the proposal is
+    // bad business as we could have changed the osdmon's state and ending up
+    // returning an error to the user.
     r = _check_pool(data, &ss);
     if (r) {
       return true;
@@ -1132,6 +1129,14 @@ bool MDSMonitor::management_command(
     r = _check_pool(metadata, &ss);
     if (r) {
       return true;
+    }
+
+    // Automatically set crash_replay_interval on data pool if it
+    // isn't already set.
+    if (data_pool->get_crash_replay_interval() == 0) {
+      r = mon->osdmon()->set_crash_replay_interval(data, g_conf->osd_default_data_pool_replay_window);
+      assert(r == 0);  // We just did get_pg_pool so it must exist and be settable
+      request_proposal(mon->osdmon());
     }
 
     // All checks passed, go ahead and create.


### PR DESCRIPTION
Specifically, missing backport of 1d1ae41 results in issue #10643.

The other two backports are just for good measure and because they were part of the original patch series.

Fixes: #10643
``Signed-off-by: Joao Eduardo Luis <joao@redhat.com>``