### PR TITLE
Ceph: Fix

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -750,9 +750,9 @@ void PGMap::dump_pg_stats_plain(ostream& ss,
 	 << "\t" << st.last_change
 	 << "\t" << st.version
 	 << "\t" << st.reported_epoch << ":" << st.reported_seq
-	 << "\t" << st.up
+	 << "\t" << pg_vector_string(st.up)
 	 << "\t" << st.up_primary
-	 << "\t" << st.acting
+	 << "\t" << pg_vector_string(st.acting)
 	 << "\t" << st.acting_primary
 	 << "\t" << st.last_scrub << "\t" << st.last_scrub_stamp
 	 << "\t" << st.last_deep_scrub << "\t" << st.last_deep_scrub_stamp

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -694,6 +694,22 @@ void coll_t::generate_test_instances(list<coll_t*>& o)
 
 // ---
 
+std::string pg_vector_string(const vector<int32_t> &a)
+{
+  ostringstream oss;
+  oss << "[";
+  for (vector<int32_t>::const_iterator i = a.begin(); i != a.end(); ++i) {
+    if (i != a.begin()) 
+      oss << ",";
+    if (*i != CRUSH_ITEM_NONE) 
+      oss << *i;
+    else 
+      oss << "NONE";
+  }
+  oss << "]";
+  return oss.str();
+}
+
 std::string pg_state_string(int state)
 {
   ostringstream oss;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -770,7 +770,7 @@ inline ostream& operator<<(ostream& out, const osd_stat_t& s) {
 #define PG_STATE_ACTIVATING   (1<<24) // pg is peered but not yet active
 
 std::string pg_state_string(int state);
-
+std::string pg_vector_string(const vector<int32_t> &a);
 
 /*
  * pool_snap_info_t


### PR DESCRIPTION
Replacing of numeric constant 0x7fffffff by string CRUSH_ITEM_NONE in ceph pg dump in pgmap output.
Fixes #10519
Signed-off-by: Kiseleva Alyona
<akiselyova@mirantis.com>