### PR TITLE
rgw: use strict_strtoll() for content length

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1240,7 +1240,7 @@ int RGWREST::preprocess(struct req_state *s, RGWClientIO *cio)
       s->content_length = 0;
     } else {
       string err;
-      s->content_length = strict_strtol(s->length, 10, &err);
+      s->content_length = strict_strtoll(s->length, 10, &err);
       if (!err.empty()) {
         ldout(s->cct, 10) << "bad content length, aborting" << dendl;
         return -EINVAL;


### PR DESCRIPTION
instead of strict_strtol().

Backport: giant, firefly
Fixes: #10701

Reported-by: Axel Dunkel <ad@dunkel.de>
Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>