### PR TITLE
rgw: finalize perfcounters after shutting down storage

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -1198,8 +1198,6 @@ int main(int argc, const char **argv)
 
   delete olog;
 
-  rgw_perf_stop(g_ceph_context);
-
   RGWStoreManager::close_storage(store);
 
   rgw_tools_cleanup();
@@ -1210,6 +1208,8 @@ int main(int argc, const char **argv)
   g_ceph_context->put();
 
   ceph::crypto::shutdown();
+
+  rgw_perf_stop(g_ceph_context);
 
   signal_fd_finalize();
 


### PR DESCRIPTION
Fixes: #10572
Backport: giant, firefly
First disable the storage subsystem, then disable perfcounters.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>