### PR TITLE
support Boost 1.57.0

### DIFF
--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -16,7 +16,7 @@
 #define MAPCACHER_H
 
 #include <boost/scoped_ptr.hpp>
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include "include/memory.h"
 #include <set>
 #include <map>

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -286,7 +286,7 @@ inline void decode(T &o, bufferlist& bl)
 #include <deque>
 #include <vector>
 #include <string>
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 
 #ifndef _BACKWARD_BACKWARD_WARNING_H
 #define _BACKWARD_BACKWARD_WARNING_H   // make gcc 4.3 shut up about hash_*

--- a/src/os/DBObjectMap.h
+++ b/src/os/DBObjectMap.h
@@ -17,7 +17,7 @@
 #include "common/Mutex.h"
 #include "common/Cond.h"
 #include "common/simple_cache.hpp"
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 
 /**
  * DBObjectMap: Implements ObjectMap in terms of KeyValueDB

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -13,7 +13,7 @@
  */
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <iostream>
 #include <sstream>
 

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -81,7 +81,7 @@ ostream &operator<<(ostream &lhs, const ECBackend::read_result_t &rhs)
   lhs << "read_result_t(r=" << rhs.r
       << ", errors=" << rhs.errors;
   if (rhs.attrs) {
-    lhs << ", attrs=" << rhs.attrs;
+    lhs << ", attrs=" << rhs.attrs.get();
   } else {
     lhs << ", noattrs";
   }

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -18,7 +18,7 @@
 #include "OSD.h"
 #include "PGBackend.h"
 #include "osd_types.h"
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include "erasure-code/ErasureCodeInterface.h"
 #include "ECTransaction.h"
 #include "ECMsgTypes.h"

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -13,7 +13,7 @@
  */
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <iostream>
 #include <vector>
 #include <sstream>

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -19,7 +19,7 @@
 #include "PGBackend.h"
 #include "osd_types.h"
 #include "ECUtil.h"
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include "erasure-code/ErasureCodeInterface.h"
 
 class ECTransaction : public PGBackend::PGTransaction {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -5271,7 +5271,10 @@ void ReplicatedPG::do_osd_op_effects(OpContext *ctx)
   for (list<OpContext::NotifyAck>::iterator p = ctx->notify_acks.begin();
        p != ctx->notify_acks.end();
        ++p) {
-    dout(10) << "notify_ack " << make_pair(p->watch_cookie, p->notify_id) << dendl;
+    if (p->watch_cookie)
+      dout(10) << "notify_ack " << make_pair(p->watch_cookie.get(), p->notify_id) << dendl;
+    else
+      dout(10) << "notify_ack " << make_pair("NULL", p->notify_id) << dendl;
     for (map<pair<uint64_t, entity_name_t>, WatchRef>::iterator i =
 	   ctx->obc->watchers.begin();
 	 i != ctx->obc->watchers.end();

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -17,7 +17,7 @@
 #ifndef CEPH_REPLICATEDPG_H
 #define CEPH_REPLICATEDPG_H
 
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <boost/tuple/tuple.hpp>
 
 #include "include/assert.h" 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <memory>
 #include <boost/scoped_ptr.hpp>
-#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 
 #include "include/rados/rados_types.hpp"
 


### PR DESCRIPTION
Sometime after 1.55, boost introduced a forward declaration of
operator<< in optional.hpp. In 1.55 and earlier, when << was used
without the _io having been included, what got dumped was an implicit
bool conversion.

http://tracker.ceph.com/issues/10688 Refs: #10688
Signed-off-by: Ken Dreyer <kdreyer@redhat.com>
(cherry picked from commit 85717394c33137eb703a7b88608ec9cf3287f67a)

Conflicts:
	src/include/encoding.h
        trivial conflict