### PR TITLE
ceph.in : show the target daemon of cli

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -192,13 +192,13 @@ function test_mon_injectargs()
   check_response "osd_debug_op_order = 'false'"
   ! grep "the.dump" $TMPFILE || return 1
   ceph tell osd.0 injectargs '--osd_debug_op_order --osd_failsafe_full_ratio .99' >& $TMPFILE || return 1
-  check_response "osd_debug_op_order = 'true' osd_failsafe_full_ratio = '0.99'"
+  check_response "osd.0: osd_debug_op_order = 'true' osd_failsafe_full_ratio = '0.99'"
   ceph tell osd.0 injectargs --no-osd_debug_op_order >& $TMPFILE || return 1
-  check_response "osd_debug_op_order = 'false'"
+  check_response "osd.0: osd_debug_op_order = 'false'"
   ceph tell osd.0 injectargs -- --osd_debug_op_order >& $TMPFILE || return 1
-  check_response "osd_debug_op_order = 'true'"
+  check_response "osd.0: osd_debug_op_order = 'true'"
   ceph tell osd.0 injectargs -- '--osd_debug_op_order --osd_failsafe_full_ratio .98' >& $TMPFILE || return 1
-  check_response "osd_debug_op_order = 'true' osd_failsafe_full_ratio = '0.98'" 
+  check_response "osd.0: osd_debug_op_order = 'true' osd_failsafe_full_ratio = '0.98'" 
 }
 
 function test_mon_injectargs_SI()

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -673,6 +673,7 @@ def allocate_osd_id(
     except subprocess.CalledProcessError as e:
         raise Error('ceph osd create failed', e, e.output)
     osd_id = must_be_one_line(osd_id)
+    osd_id = osd_id.replace('mon: ','')
     check_osd_id(osd_id)
     return osd_id
 

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -799,9 +799,13 @@ def main():
         # prettify?  prefix output with target, if there was a wildcard used
         prefix = ''
         suffix = ''
-        if not parsed_args.output_file and len(targets) > 1:
-            prefix = '{0}.{1}: '.format(*target)
-            suffix = '\n'
+        if not parsed_args.output_file and len(targets) >= 1:
+            if len(str(target[1])) >= 1 :
+                prefix = '{0}.{1}: '.format(*target)
+            else :
+                prefix = '{0}: '.format(target[0])
+            if len(targets) > 1:
+                suffix = '\n'
 
         ret, outbuf, outs = json_command(cluster_handle, target=target,
                                          prefix='get_command_descriptions')

--- a/src/ceph.in.cmake
+++ b/src/ceph.in.cmake
@@ -727,9 +727,13 @@ def main():
         # prettify?  prefix output with target, if there was a wildcard used
         prefix = ''
         suffix = ''
-        if not parsed_args.output_file and len(targets) > 1:
-            prefix = '{0}.{1}: '.format(*target)
-            suffix = '\n'
+        if not parsed_args.output_file and len(targets) >= 1:
+            if len(str(target[1])) >= 1 :
+                prefix = '{0}.{1}: '.format(*target)
+            else :
+                prefix = '{0}: '.format(target[0])
+            if len(targets) > 1:
+                suffix = '\n'
 
         ret, outbuf, outs = json_command(cluster_handle, target=target,
                                          prefix='get_command_descriptions')

--- a/src/test/mon/misc.sh
+++ b/src/test/mon/misc.sh
@@ -62,8 +62,9 @@ function TEST_osd_pool_get_set() {
 	./ceph osd pool set $TEST_POOL $flag 0 || return 1
     done
 
-    local size=$(./ceph osd pool get $TEST_POOL size|awk '{print $2}')
-    local min_size=$(./ceph osd pool get $TEST_POOL min_size|awk '{print $2}')
+    # output of ceph osd pool would be: mon: min_size: 1
+    local size=$(./ceph osd pool get $TEST_POOL size|awk '{print $NF}')
+    local min_size=$(./ceph osd pool get $TEST_POOL min_size|awk '{print $NF}')
     #replicated pool size restrict in 1 and 10
     ! ./ceph osd pool set $TEST_POOL 11 || return 1
     #replicated pool min_size must be between in 1 and size
@@ -73,8 +74,9 @@ function TEST_osd_pool_get_set() {
     local ecpool=erasepool
     ./ceph osd pool create $ecpool 12 12 erasure default || return 1
     #erasue pool size=k+m, min_size=k
-    local size=$(./ceph osd pool get $ecpool size|awk '{print $2}')
-    local k=$(./ceph osd pool get $ecpool min_size|awk '{print $2}')
+    # output of ceph osd pool would be: mon: min_size: 1
+    local size=$(./ceph osd pool get $ecpool size|awk '{print $NF}')
+    local k=$(./ceph osd pool get $ecpool min_size|awk '{print $NF}')
     #erasure pool size can't change
     ! ./ceph osd pool set $ecpool size  $(expr $size + 1) || return 1
     #erasure pool min_size must be between in k and size


### PR DESCRIPTION
I think the result of /usr/bin/ceph should also show the target even if the number of targets is 1.
[root@ceph~]# ceph osd pool get rbd min_size 
mon: min_size: 1

This result would tell user that the result is return by monitor.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>