### PR TITLE
pybind: fix error hiding and inconsistency on librados load.

### DIFF
--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -203,17 +203,10 @@ Rados object in state %s." % self.state)
 
     def __init__(self, rados_id=None, name=None, clustername=None,
                  conf_defaults=None, conffile=None, conf=None, flags=0):
-        librados_path = find_library('rados')
-        if not librados_path:
-            #maybe find_library can not find it correctly on all platforms.
-            try:
-                self.librados = CDLL('librados.so.2')
-            except OSError as e:
-                    raise EnvironmentError("Unable to load librados: %s" % e)
-            except:
-                raise Error("Unexpected error")
-        else:
-            self.librados = CDLL(librados_path)
+        library_path  = find_library('rados')
+        # maybe find_library can not find it correctly on all platforms,
+        # so fall back to librados.so.2 in such case.
+        self.librados = CDLL(library_path if library_path is not None else 'librados.so.2')
 
         self.parsed_args = []
         self.conf_defaults = conf_defaults


### PR DESCRIPTION
When loading of librados failed, the real cause was hidden in some
circumstances due to exception rewriting. Additionally, the error
reporting was inconsistent -- two paths with different exceptions
and messages existed.