### PR TITLE
rgw: use s->bucket_attrs instead of trying to read obj attrs

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1945,10 +1945,14 @@ void RGWPutMetadata::execute()
   /* no need to track object versioning, need it for bucket's data only */
   RGWObjVersionTracker *ptracker = (s->object ? NULL : &s->bucket_info.objv_tracker);
 
-  /* check if obj exists, read orig attrs */
-  ret = get_obj_attrs(store, s, obj, orig_attrs, NULL, ptracker);
-  if (ret < 0)
-    return;
+  if (s->object) {
+    /* check if obj exists, read orig attrs */
+    ret = get_obj_attrs(store, s, obj, orig_attrs, NULL, ptracker);
+    if (ret < 0)
+      return;
+  } else {
+    orig_attrs = s->bucket_attrs;
+  }
 
   /* only remove meta attrs */
   for (iter = orig_attrs.begin(); iter != orig_attrs.end(); ++iter) {


### PR DESCRIPTION
Fixes: #10307
Backport: firefly, giant

This is needed, since we can't really read the bucket attrs by trying to
read the bucket entry point attrs. We already have the bucket attrs
anyway, use these.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
(cherry picked from commit 5cf193c8686196d5235889e68cb5ea8f1fc8e556)