### PR TITLE
rgw: S3 object copy content type fix

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1284,7 +1284,7 @@ void RGWCopyObj_ObjStore_S3::send_partial_response(off_t ofs)
     set_req_state_err(s, ret);
     dump_errno(s);
 
-    end_header(s, this, "binary/octet-stream");
+    end_header(s, this, "application/xml");
     if (ret == 0) {
       s->formatter->open_object_section("CopyObjectResult");
     }


### PR DESCRIPTION
Fixes: #9478
Backport: firefly, giant
Content type for S3 object copy response should be set to
application/xml.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
(cherry picked from commit 31963459a0a869c4d32f55baa629f36df33eaa90)