### PR TITLE
rgw: update swift subuser perm masks when authenticating

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -785,8 +785,6 @@ int RGWHandler_ObjStore_SWIFT::authorize()
   if (!authorized)
     return -EPERM;
 
-  s->perm_mask = RGW_PERM_FULL_CONTROL;
-
   return 0;
 }
 

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -614,13 +614,41 @@ int authenticate_temp_url(RGWRados *store, req_state *s)
 
 bool RGWSwift::verify_swift_token(RGWRados *store, req_state *s)
 {
+  if (!do_verify_swift_token(store, s)) {
+    return false;
+  }
+
+  if (!s->swift_user.empty()) {
+    string subuser;
+    ssize_t pos = s->swift_user.find(':');
+    if (pos < 0) {
+      subuser = s->swift_user;
+    } else {
+      subuser = s->swift_user.substr(pos + 1);
+    }
+    s->perm_mask = 0;
+    map<string, RGWSubUser>::iterator iter = s->user.subusers.find(subuser);
+    if (iter != s->user.subusers.end()) {
+      RGWSubUser& subuser = iter->second;
+      s->perm_mask = subuser.perm_mask;
+    }
+  } else {
+    s->perm_mask = RGW_PERM_FULL_CONTROL;
+  }
+
+  return true;
+
+}
+
+bool RGWSwift::do_verify_swift_token(RGWRados *store, req_state *s)
+{
   if (!s->os_auth_token) {
     int ret = authenticate_temp_url(store, s);
     return (ret >= 0);
   }
 
   if (strncmp(s->os_auth_token, "AUTH_rgwtk", 10) == 0) {
-    int ret = rgw_swift_verify_signed_token(s->cct, store, s->os_auth_token, s->user);
+    int ret = rgw_swift_verify_signed_token(s->cct, store, s->os_auth_token, s->user, &s->swift_user);
     if (ret < 0)
       return false;
 

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -56,6 +56,7 @@ class RGWSwift {
   bool supports_keystone() {
     return !cct->_conf->rgw_keystone_url.empty();
   }
+  bool do_verify_swift_token(RGWRados *store, req_state *s);
 protected:
   int check_revoked();
 public:

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -59,7 +59,7 @@ static int encode_token(CephContext *cct, string& swift_user, string& key, buffe
   return ret;
 }
 
-int rgw_swift_verify_signed_token(CephContext *cct, RGWRados *store, const char *token, RGWUserInfo& info)
+int rgw_swift_verify_signed_token(CephContext *cct, RGWRados *store, const char *token, RGWUserInfo& info, string *pswift_user)
 {
   if (strncmp(token, "AUTH_rgwtk", 10) != 0)
     return -EINVAL;
@@ -126,6 +126,7 @@ int rgw_swift_verify_signed_token(CephContext *cct, RGWRados *store, const char 
     dout(0) << "NOTICE: tokens mismatch tok=" << buf << dendl;
     return -EPERM;
   }
+  *pswift_user = swift_user;
 
   return 0;
 }

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -9,7 +9,7 @@
 
 #define RGW_SWIFT_TOKEN_EXPIRATION (15 * 60)
 
-extern int rgw_swift_verify_signed_token(CephContext *cct, RGWRados *store, const char *token, RGWUserInfo& info);
+extern int rgw_swift_verify_signed_token(CephContext *cct, RGWRados *store, const char *token, RGWUserInfo& info, string *pswift_user);
 
 class RGW_SWIFT_Auth_Get : public RGWOp {
 public:


### PR DESCRIPTION
Fixes: #9918
Backport: firefly, giant
It seems that we weren't setting the swift perm mask correctly.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
(cherry picked from commit 5d9f36f757a7272c24d2c9adc31db1ed5e712992)