### PR TITLE
encoding: ignore uninitialized instantiation in boost::optional decode

### DIFF
--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -306,6 +306,8 @@ inline void encode(const boost::optional<T> &p, bufferlist &bl)
     encode(p.get(), bl);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
 template<typename T>
 inline void decode(boost::optional<T> &p, bufferlist::iterator &bp)
 {
@@ -317,6 +319,7 @@ inline void decode(boost::optional<T> &p, bufferlist::iterator &bp)
     decode(p.get(), bp);
   }
 }
+#pragma GCC diagnostic pop
 
 //triple tuple
 template<class A, class B, class C>


### PR DESCRIPTION
POD types won't be initialized until the decode writes to them.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>