### PR TITLE
librbd: pending AIO operations are now flushed asynchronously

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -3103,9 +3103,16 @@ reprotect_and_return_err:
     ictx->user_flushed();
 
     c->get();
-    c->add_request();
     c->init_time(ictx, AIO_TYPE_FLUSH);
+
+    if (ictx->image_watcher != NULL) {
+      C_AioWrite *flush_ctx = new C_AioWrite(cct, c);
+      c->add_request();
+      ictx->image_watcher->flush_aio_operations(flush_ctx);
+    }
+
     C_AioWrite *req_comp = new C_AioWrite(cct, c);
+    c->add_request();
     if (ictx->object_cacher) {
       ictx->flush_cache_aio(req_comp);
     } else {


### PR DESCRIPTION
If exclusive locking was enabled, the librbd aio_flush command
would block waiting for queued AIO operations to proceed once
the exclusive lock was obtained.  Now librbd will no longer
block when aio_flush is invoked and AIO operations are waiting
on the exclusive lock.

Fixes: #10714
Signed-off-by: Jason Dillaman <dillaman@redhat.com>