### PR TITLE
librbd: fixed object map issues discovered via fsx

### DIFF
--- a/src/librbd/AioRequest.cc
+++ b/src/librbd/AioRequest.cc
@@ -440,8 +440,11 @@ namespace librbd {
         m_state = LIBRBD_AIO_WRITE_PRE; 
         FunctionContext *ctx = new FunctionContext(
           boost::bind(&AioRequest::complete, this, _1));
-        m_ictx->object_map->aio_update(m_object_no, new_state,
-				       current_state, ctx);
+        if (!m_ictx->object_map->aio_update(m_object_no, new_state,
+					    current_state, ctx)) {
+	  // no object map update required
+	  return false;
+	}
       }
     }
     
@@ -471,8 +474,11 @@ namespace librbd {
     m_state = LIBRBD_AIO_WRITE_POST;
     FunctionContext *ctx = new FunctionContext(
       boost::bind(&AioRequest::complete, this, _1));
-    m_ictx->object_map->aio_update(m_object_no, OBJECT_NONEXISTENT,
-                                   OBJECT_PENDING, ctx);
+    if (!m_ictx->object_map->aio_update(m_object_no, OBJECT_NONEXISTENT,
+					OBJECT_PENDING, ctx)) {
+      // no object map update required
+      return true;
+    }
     return false;  
   } 
 

--- a/src/librbd/AsyncResizeRequest.cc
+++ b/src/librbd/AsyncResizeRequest.cc
@@ -33,7 +33,7 @@ bool AsyncResizeRequest::should_complete(int r)
   switch (m_state) {
   case STATE_TRIM_IMAGE:
     ldout(cct, 5) << "TRIM_IMAGE" << dendl;
-    send_grow_object_map();
+    send_update_header();
     break;
 
   case STATE_GROW_OBJECT_MAP:
@@ -127,10 +127,10 @@ void AsyncResizeRequest::send_grow_object_map() {
     }
   }
 
+  // avoid possible recursive lock attempts
   if (!object_map_enabled) {
     send_update_header();
   } else if (lost_exclusive_lock) {
-    // only complete when not holding locks
     complete(-ERESTART);
   }
 }
@@ -160,8 +160,8 @@ bool AsyncResizeRequest::send_shrink_object_map() {
     }
   }
 
+  // avoid possible recursive lock attempts
   if (lost_exclusive_lock) {
-    // only complete when not holding locks
     complete(-ERESTART);
   }
   return false;
@@ -207,8 +207,8 @@ void AsyncResizeRequest::send_update_header() {
     }
   }
 
+  // avoid possible recursive lock attempts
   if (lost_exclusive_lock) {
-    // only complete when not holding locks
     complete(-ERESTART);
   }
 }

--- a/src/librbd/CopyupRequest.cc
+++ b/src/librbd/CopyupRequest.cc
@@ -171,28 +171,32 @@ namespace librbd {
   }
 
   bool CopyupRequest::send_object_map() {
-    bool object_map_enabled = true;
+    bool copyup = false;
     {
       RWLock::RLocker l(m_ictx->owner_lock);
       RWLock::RLocker l2(m_ictx->md_lock);
       if (m_ictx->object_map == NULL) {
-	object_map_enabled = false;
+	copyup = true;
       } else if (!m_ictx->image_watcher->is_lock_owner()) {
 	ldout(m_ictx->cct, 20) << "exclusive lock not held for copy-on-read"
 			       << dendl;
 	return true; 
       } else {
 	m_state = STATE_OBJECT_MAP;
-        m_ictx->object_map->aio_update(m_object_no, OBJECT_EXISTS,
-				       boost::optional<uint8_t>(),
-				       create_callback_context());
+        if (!m_ictx->object_map->aio_update(m_object_no, OBJECT_EXISTS,
+					    boost::optional<uint8_t>(),
+					    create_callback_context())) {
+	  copyup = true;
+	}
       }
     }
 
-    if (!object_map_enabled) {
+    // avoid possible recursive lock attempts
+    if (copyup) {
+      // no object map update required
       send_copyup();
       return true;
-    }        
+    }
     return false;
   }
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -298,6 +298,10 @@ namespace librbd {
       snap_name = in_snap_name;
       snap_exists = true;
       data_ctx.snap_set_read(snap_id);
+
+      if (object_map != NULL) {
+        object_map->refresh();
+      }
       return 0;
     }
     return -ENOENT;
@@ -309,6 +313,10 @@ namespace librbd {
     snap_name = "";
     snap_exists = true;
     data_ctx.snap_set_read(snap_id);
+
+    if (object_map != NULL) {
+      object_map->refresh();
+    }
   }
 
   snap_t ImageCtx::get_snap_id(string in_snap_name) const

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -31,10 +31,10 @@ public:
 
   void aio_resize(uint64_t new_size, uint8_t default_object_state,
 		  Context *on_finish);
-  void aio_update(uint64_t object_no, uint8_t new_state,
-		 const boost::optional<uint8_t> &current_state,
-		 Context *on_finish);
-  void aio_update(uint64_t start_object_no, uint64_t end_object_no,
+  bool aio_update(uint64_t object_no, uint8_t new_state,
+		  const boost::optional<uint8_t> &current_state,
+		  Context *on_finish);
+  bool aio_update(uint64_t start_object_no, uint64_t end_object_no,
 		  uint8_t new_state,
 		  const boost::optional<uint8_t> &current_state,
 		  Context *on_finish);

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2281,10 +2281,6 @@ reprotect_and_return_err:
     if (r < 0) {
       return r;
     }
-
-    if (ictx->object_map != NULL) {
-      ictx->object_map->refresh();
-    }
     refresh_parent(ictx);
     return 0;
   }

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -741,6 +741,7 @@ class TestClone(object):
 
     def test_resize_io(self):
         parent_data = self.image.read(IMG_SIZE / 2, 256)
+        self.image.resize(0)
         self.clone.resize(IMG_SIZE / 2 + 128)
         child_data = self.clone.read(IMG_SIZE / 2, 128)
         eq(child_data, parent_data[:128])


### PR DESCRIPTION
The object map wasn't being properly refreshed after setting
the snapshot context on the parent image. Additionally fixed
a potential deadlock that could have occurred if no object
map update was required when trimming an image.

Fixes: #10706
Signed-off-by: Jason Dillaman <dillaman@redhat.com>