### PR TITLE
rgw: move perf cleanup before context cleanup

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -1204,12 +1204,12 @@ int main(int argc, const char **argv)
   rgw_shutdown_resolver();
   curl_global_cleanup();
 
+  rgw_perf_stop(g_ceph_context);
+
   dout(1) << "final shutdown" << dendl;
   g_ceph_context->put();
 
   ceph::crypto::shutdown();
-
-  rgw_perf_stop(g_ceph_context);
 
   signal_fd_finalize();
 


### PR DESCRIPTION
Fixes: #10722
Fixes: #10572

This fixes a regression introduced in commit
de2e5fa048639de6c9ee004a93ab295625fa3b94.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>