### PR TITLE
rdb: update init-rbdmap to fix duplicate mount point

### DIFF
--- a/src/init-rbdmap
+++ b/src/init-rbdmap
@@ -67,7 +67,7 @@ do_map() {
 			## Mount new rbd
 			MNT_RV=""
 			mount --fake /dev/rbd/$DEV >>/dev/null 2>&1 \
-			&& MNT_RV=$(mount -v /dev/rbd/$DEV 2>&1)
+			&& MNT_RV=$(mount -vn /dev/rbd/$DEV 2>&1)
 			[ -n "${MNT_RV}" ] && log_action_msg "mount: ${MNT_RV}"
 
 			## post-mapping


### PR DESCRIPTION
According to the manual 'mount -f' adds an entry in /etc/mtab.
Therefore the 'mount -v' command needs the flag -n to avoid
duplicate entries in /etc/mtab.

Signed-off-by: Karel Striegel <karel@striegel.be>