### PR TITLE
ceph.spec.in: Fedora > 20 has junit instead of junit4

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -282,8 +282,13 @@ License:	LGPL-2.0
 Requires:	java
 Requires:	libcephfs_jni1 = %{epoch}:%{version}-%{release}
 BuildRequires:	java-devel
+%if 0%{?el6}
 Requires:	junit4
 BuildRequires:	junit4
+%else
+Requires:       junit
+BuildRequires:  junit
+%endif
 %description -n cephfs-java
 This package contains the Java libraries for the Ceph File System.
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/10728 Fixes: #10728

Signed-off-by: Loic Dachary <ldachary@redhat.com>