### PR TITLE
install-deps.sh: get lsb_release if needed

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -18,6 +18,11 @@ if test $(id -u) != 0 ; then
     SUDO=sudo
 fi
 export LC_ALL=C # the following is vulnerable to i18n
+
+if test -f /etc/redhat-release ; then
+    $SUDO yum install -y redhat-lsb-core
+fi
+
 case $(lsb_release -si) in
 Ubuntu|Debian|Devuan)
         $SUDO apt-get install -y dpkg-dev


### PR DESCRIPTION
Fedora does not have lsb_release by default. Since all supported Debian
based distributions already have it, assume yum is the way to install it

http://tracker.ceph.com/issues/10729 Fixes: #10729

Signed-off-by: Loic Dachary <ldachary@redhat.com>