### PR TITLE
librbd: verify image's object map validity

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -1973,8 +1973,9 @@ int object_map_resize(cls_method_context_t hctx, bufferlist *in, bufferlist *out
 
   size_t orig_object_map_size = object_map.size();
   if (object_count < orig_object_map_size) {
-    for (uint64_t i = object_count; i < orig_object_map_size; ++i) {
+    for (uint64_t i = object_count + 1; i < orig_object_map_size; ++i) {
       if (object_map[i] != default_state) {
+	CLS_ERR("object map indicates object still exists: %" PRIu64, i);
 	return -ESTALE;
       }
     }

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -48,7 +48,8 @@ namespace librbd {
     int set_parent(librados::IoCtx *ioctx, const std::string &oid,
 		   parent_spec pspec, uint64_t parent_overlap);
     int get_flags(librados::IoCtx *ioctx, const std::string &oid,
-                  snapid_t snap_id, uint64_t *flags);
+		  uint64_t *flags, const std::vector<snapid_t> &snap_ids,
+		  vector<uint64_t> *snap_flags);
     void set_flags(librados::ObjectWriteOperation *op,
                    uint64_t flags, uint64_t mask);
     int remove_parent(librados::IoCtx *ioctx, const std::string &oid);

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -157,6 +157,7 @@ CEPH_RBD_API int rbd_get_parent_info(rbd_image_t image,
 			             char *parent_name, size_t pnamelen,
 			             char *parent_snapname,
                                      size_t psnapnamelen);
+CEPH_RBD_API int rbd_get_flags(rbd_image_t image, uint64_t *flags);
 
 /* exclusive lock feature */
 CEPH_RBD_API int rbd_is_exclusive_lock_owner(rbd_image_t image, int *is_owner);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -117,6 +117,7 @@ public:
   int size(uint64_t *size);
   int features(uint64_t *features);
   int overlap(uint64_t *overlap);
+  int get_flags(uint64_t *flags);
 
   /* exclusive lock feature */
   int is_exclusive_lock_owner(bool *is_owner);

--- a/src/librbd/AioRequest.h
+++ b/src/librbd/AioRequest.h
@@ -249,15 +249,18 @@ namespace librbd {
   protected:
     virtual void add_write_ops(librados::ObjectWriteOperation *wr) {
       if (has_parent()) {
-	m_object_state = OBJECT_EXISTS;
 	wr->truncate(0);
       } else {
-	m_object_state = OBJECT_PENDING;
 	wr->remove();
       }
     }
 
     virtual void pre_object_map_update(uint8_t *new_state) {
+      if (has_parent()) {
+	m_object_state = OBJECT_EXISTS;
+      } else {
+	m_object_state = OBJECT_PENDING;
+      }
       *new_state = m_object_state;
     }
 

--- a/src/librbd/AsyncResizeRequest.h
+++ b/src/librbd/AsyncResizeRequest.h
@@ -19,7 +19,8 @@ public:
 		     ProgressContext &prog_ctx)
     : AsyncRequest(image_ctx, on_finish),
       m_original_size(original_size), m_new_size(new_size),
-      m_prog_ctx(prog_ctx)
+      m_prog_ctx(prog_ctx), m_original_parent_overlap(0),
+      m_new_parent_overlap(0)
   {
   }
 
@@ -60,6 +61,8 @@ protected:
   uint64_t m_original_size;
   uint64_t m_new_size;
   ProgressContext &m_prog_ctx;
+  uint64_t m_original_parent_overlap;
+  uint64_t m_new_parent_overlap;
 
   virtual bool should_complete(int r);
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -415,12 +415,12 @@ namespace librbd {
   }
 
   void ImageCtx::add_snap(string in_snap_name, snap_t id, uint64_t in_size,
-			  uint64_t features,
-			  parent_info parent,
-			  uint8_t protection_status)
+			  uint64_t features, parent_info parent,
+			  uint8_t protection_status, uint64_t flags)
   {
     snaps.push_back(id);
-    SnapInfo info(in_snap_name, in_size, features, parent, protection_status);
+    SnapInfo info(in_snap_name, in_size, features, parent, protection_status,
+		  flags);
     snap_info.insert(pair<snap_t, SnapInfo>(id, info));
     snap_ids.insert(pair<string, snap_t>(in_snap_name, id));
   }
@@ -447,6 +447,20 @@ namespace librbd {
     const SnapInfo *info = get_snap_info(in_snap_id);
     if (info) {
       *out_features = info->features;
+      return 0;
+    }
+    return -ENOENT;
+  }
+
+  int ImageCtx::get_flags(librados::snap_t _snap_id, uint64_t *_flags) const
+  {
+    if (_snap_id == CEPH_NOSNAP) {
+      *_flags = flags;
+      return 0;
+    }
+    const SnapInfo *info = get_snap_info(_snap_id);
+    if (info) {
+      *_flags = info->flags;
       return 0;
     }
     return -ENOENT;

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -151,10 +151,12 @@ namespace librbd {
 
     void add_snap(std::string in_snap_name, librados::snap_t id,
 		  uint64_t in_size, uint64_t features,
-		  parent_info parent, uint8_t protection_status);
+		  parent_info parent, uint8_t protection_status,
+		  uint64_t flags);
     uint64_t get_image_size(librados::snap_t in_snap_id) const;
     int get_features(librados::snap_t in_snap_id,
 		     uint64_t *out_features) const;
+    int get_flags(librados::snap_t in_snap_id, uint64_t *flags) const;
     const parent_info* get_parent_info(librados::snap_t in_snap_id) const;
     int64_t get_parent_pool_id(librados::snap_t in_snap_id) const;
     std::string get_parent_image_id(librados::snap_t in_snap_id) const;

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -187,6 +187,9 @@ bool ObjectMap::aio_update(uint64_t start_object_no, uint64_t end_object_no,
   assert(start_object_no < end_object_no);
   
   CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << &m_image_ctx << " aio_update: start=" << start_object_no
+		 << ", end=" << end_object_no << ", new_state="
+		 << static_cast<uint32_t>(new_state) << dendl;
   if (end_object_no > object_map.size()) {
     ldout(cct, 20) << "skipping update of invalid object map" << dendl;
     return false;
@@ -319,7 +322,8 @@ void ObjectMap::UpdateRequest::send() {
 
   ldout(cct, 20) << &m_image_ctx << " updating on-disk object map: ["
 		 << m_start_object_no << "," << m_end_object_no << ") = "
-		 << (m_current_state ? stringify(*m_current_state) : "")
+		 << (m_current_state ?
+		       stringify(static_cast<uint32_t>(*m_current_state)) : "")
 		 << "->" << static_cast<uint32_t>(m_new_state)
 		 << dendl;
   

--- a/src/librbd/SnapInfo.h
+++ b/src/librbd/SnapInfo.h
@@ -18,10 +18,11 @@ namespace librbd {
     uint64_t features;
     parent_info parent;
     uint8_t protection_status;
+    uint64_t flags;
     SnapInfo(std::string _name, uint64_t _size, uint64_t _features,
-	     parent_info _parent, uint8_t _protection_status) :
-      name(_name), size(_size), features(_features), parent(_parent),
-      protection_status(_protection_status) {}
+	     parent_info _parent, uint8_t _protection_status, uint64_t _flags)
+      : name(_name), size(_size), features(_features), parent(_parent),
+	protection_status(_protection_status), flags(_flags) {}
   };
 }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1452,6 +1452,18 @@ reprotect_and_return_err:
     return 0;
   }
 
+  int get_flags(ImageCtx *ictx, uint64_t *flags)
+  {
+    int r = ictx_check(ictx);
+    if (r < 0) {
+      return r;
+    }
+
+    RWLock::RLocker l(ictx->md_lock);
+    RWLock::RLocker l2(ictx->snap_lock);
+    return ictx->get_flags(ictx->snap_id, flags);
+  }
+
   int is_exclusive_lock_owner(ImageCtx *ictx, bool *is_owner)
   {
     RWLock::RLocker l(ictx->owner_lock);
@@ -1851,6 +1863,7 @@ reprotect_and_return_err:
     vector<uint64_t> snap_features;
     vector<parent_info> snap_parents;
     vector<uint8_t> snap_protection;
+    vector<uint64_t> snap_flags;
     {
       int r;
       RWLock::WLocker l(ictx->snap_lock);
@@ -1918,31 +1931,33 @@ reprotect_and_return_err:
 	      return -ENOSYS;
 	    }
 
-            r = cls_client::get_flags(&ictx->md_ctx, ictx->header_oid,
-                                      ictx->snap_id, &ictx->flags);
+	    r = cls_client::get_flags(&ictx->md_ctx, ictx->header_oid,
+				      &ictx->flags, new_snapc.snaps,
+				      &snap_flags);
             if (r == -EOPNOTSUPP || r == -EIO) {
               // Older OSD doesn't support RBD flags, need to assume the worst
               ldout(ictx->cct, 10) << "OSD does not support RBD flags" << dendl;
-            } else if (r == -ENOENT) {
-              ldout(ictx->cct, 10) << "Image at invalid snapshot" << dendl;
-            } else if (r < 0 && r != -ENOENT) {
-              lderr(cct) << "Error reading flags: " << cpp_strerror(r) << dendl;
-              return r;
-            }
-            if (r < 0) {
               ictx->flags = 0;
               if ((ictx->features & RBD_FEATURE_OBJECT_MAP) != 0) {
                 ldout(ictx->cct, 10) << "disabling object map optimizations"
                                      << dendl;
                 ictx->flags |= RBD_FLAG_OBJECT_MAP_INVALID;
               }
+
+	      vector<uint64_t> default_flags(new_snapc.snaps.size(), ictx->flags);
+	      snap_flags.swap(default_flags);
+            } else if (r == -ENOENT) {
+              ldout(ictx->cct, 10) << "Image at invalid snapshot" << dendl;
+	      continue;
+            } else if (r < 0) {
+              lderr(cct) << "Error reading flags: " << cpp_strerror(r) << dendl;
+              return r;
             }
 
 	    r = cls_client::snapshot_list(&(ictx->md_ctx), ictx->header_oid,
 					  new_snapc.snaps, &snap_names,
 					  &snap_sizes, &snap_features,
-					  &snap_parents,
-					  &snap_protection);
+					  &snap_parents, &snap_protection);
 	    // -ENOENT here means we raced with snapshot deletion
 	    if (r < 0 && r != -ENOENT) {
 	      lderr(ictx->cct) << "snapc = " << new_snapc << dendl;
@@ -1975,13 +1990,14 @@ reprotect_and_return_err:
 	ictx->snap_ids.clear();
 	for (size_t i = 0; i < new_snapc.snaps.size(); ++i) {
 	  uint64_t features = ictx->old_format ? 0 : snap_features[i];
+	  uint64_t flags = ictx->old_format ? 0 : snap_flags[i];
 	  uint8_t protection_status = ictx->old_format ?
 	    (uint8_t)RBD_PROTECTION_STATUS_UNPROTECTED : snap_protection[i];
 	  parent_info parent;
 	  if (!ictx->old_format)
 	    parent = snap_parents[i];
-	  ictx->add_snap(snap_names[i], new_snapc.snaps[i].val,
-			 snap_sizes[i], features, parent, protection_status);
+	  ictx->add_snap(snap_names[i], new_snapc.snaps[i].val, snap_sizes[i],
+			 features, parent, protection_status, flags);
 	}
 
 	r = refresh_parent(ictx);

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -104,6 +104,7 @@ namespace librbd {
   int get_overlap(ImageCtx *ictx, uint64_t *overlap);
   int get_parent_info(ImageCtx *ictx, std::string *parent_pool_name,
 		      std::string *parent_name, std::string *parent_snap_name);
+  int get_flags(ImageCtx *ictx, uint64_t *flags);
   int is_exclusive_lock_owner(ImageCtx *ictx, bool *is_owner);
 
   int remove(librados::IoCtx& io_ctx, const char *imgname,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -360,6 +360,15 @@ namespace librbd {
     return r;
   }
 
+  int Image::get_flags(uint64_t *flags)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    tracepoint(librbd, get_flags_enter, ictx);
+    int r = librbd::get_flags(ictx, flags);
+    tracepoint(librbd, get_flags_exit, ictx, r, *flags);
+    return r;
+  }
+
   int Image::is_exclusive_lock_owner(bool *is_owner)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
@@ -1173,6 +1182,15 @@ extern "C" int rbd_get_parent_info(rbd_image_t image,
 
   tracepoint(librbd, get_parent_info_exit, 0, parent_pool_name, parent_name, parent_snap_name);
   return 0;
+}
+
+extern "C" int rbd_get_flags(rbd_image_t image, uint64_t *flags)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  tracepoint(librbd, get_flags_enter, ictx);
+  int r = librbd::get_flags(ictx, flags);
+  tracepoint(librbd, get_flags_exit, ictx, r, *flags);
+  return r;
 }
 
 extern "C" int rbd_is_exclusive_lock_owner(rbd_image_t image, int *is_owner)

--- a/src/pybind/rbd.py
+++ b/src/pybind/rbd.py
@@ -29,6 +29,8 @@ RBD_FEATURE_LAYERING = 1
 RBD_FEATURE_STRIPINGV2 = 2
 RBD_FEATURE_EXCLUSIVE_LOCK = 4
 
+RBD_FLAG_OBJECT_MAP_INVALID = 1
+
 class Error(Exception):
     pass
 
@@ -525,7 +527,24 @@ class Image(object):
             raise make_ex(ret, 'error getting overlap for image' % (self.name))
         return overlap.value
 
+    def flags(self):
+        """
+        Gets the flags bitmask of the image.
+
+        :returns: int - the flags bitmask of the image
+        """
+        flags = c_uint64()
+        reg = self.librbd.rbd_get_flags(self.image, byref(flags))
+        if (ret != 0):
+            raise make_ex(ret, 'error getting flags for image' % (self.name))
+        return flags.value
+
     def is_exclusive_lock_owner(self):
+        """
+        Gets the status of the image exclusive lock.
+
+        :returns: bool - true if the image is exclusively locked
+        """
         owner = c_int()
         ret = self.librbd.rbd_is_exclusive_lock_owner(self.image, byref(owner))
         if (ret != 0):

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -292,6 +292,10 @@ class TestImage(object):
         info = self.image.stat()
         check_stat(info, IMG_SIZE, IMG_ORDER)
 
+    def test_flags(self):
+        flags = self.image.flags()
+        eq(0, flags)
+
     def test_write(self):
         data = rand_data(256)
         self.image.write(data, 0)

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -1393,6 +1393,26 @@ TRACEPOINT_EVENT(librbd, get_old_format_exit,
     )
 )
 
+TRACEPOINT_EVENT(librbd, get_flags_enter,
+    TP_ARGS(
+        void*, imagectx),
+    TP_FIELDS(
+      ctf_integer_hex(void*, imagectx, imagectx)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, get_flags_exit,
+    TP_ARGS(
+        void*, imagectx,
+        int, retval,
+        uint64_t, flags),
+    TP_FIELDS(
+      ctf_integer_hex(void*, imagectx, imagectx)
+      ctf_integer(int, retval, retval)
+      ctf_integer(uint64_t, flags, flags)
+    )
+)
+
 TRACEPOINT_EVENT(librbd, is_exclusive_lock_owner_enter,
     TP_ARGS(
         void*, imagectx),


### PR DESCRIPTION
Exposed RBD image flags via a new API method. Updated RBD integration tests to verify whether or not the object map was invalidated during the test case.  Fixed two object map issues that were discovered with the new object map validity checks.