### PR TITLE
In OP thread, test the ondisk_read_lock as early as possible to avoid stuck the thread later

### DIFF
--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3293,6 +3293,10 @@ public:
     readers++;
     lock.Unlock();
   }
+  bool test_ondisk_read_lock() {
+    Mutex::Locker l(lock);
+    return unstable_writes == 0;
+  }
   void ondisk_read_unlock() {
     lock.Lock();
     assert(readers > 0);


### PR DESCRIPTION
In our production cluster (with rgw), we came across a problem that all rgw process are stuck (all worker threads stuck waiting for response from OSD, start giving 500 response to clients). Dump objecter_requests (on rgw) shows the slow in flight ops were caused by one OSD, that OSD has 2 PGs doing backfilling and it has 2 bucket index objects.

At the OSD side, we have 8 op threads, it turns out at the time when this problem occurred, several (if not all of them) op threads took seconds (even tens of seconds) handling the bucket index op (stuck at acquiring the ondisk_read_lock), as a result, the throughput of the op threads dropped, cascade to the entire cluster.

Similar to the object context's r/w lock, this patch try to test the ondisk_read_lock at a early stage and re-queue the op back if the testing failed (so as to avoid stuck op thread).

Testing:
Performance not tested.

Fixes: 10739
Signed-off-by: Guang Yang <yguang@yahoo-inc.com>