### PR TITLE
rgw: Adding stats in the header of GET response on account

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1005,6 +1005,16 @@ void RGWListBuckets::execute()
       break;
     }
     map<string, RGWBucketEnt>& m = buckets.get_buckets();
+    map<string, RGWBucketEnt>::iterator iter;
+    for (iter = m.begin(); iter != m.end(); ++iter) {
+      RGWBucketEnt& bucket = iter->second;
+      buckets_size += bucket.size;
+      buckets_size_rounded += bucket.size_rounded;
+      buckets_objcount += bucket.count;
+
+      marker = iter->first;
+    }
+    buckets_count += m.size();
 
     total_count += m.size();
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -186,10 +186,18 @@ protected:
   string marker;
   uint64_t limit;
   uint64_t limit_max;
+  uint32_t buckets_count;
+  uint64_t buckets_objcount;
+  uint64_t buckets_size;
+  uint64_t buckets_size_rounded;
 
 public:
   RGWListBuckets() : ret(0), sent_data(false) {
     limit = limit_max = RGW_LIST_BUCKETS_LIMIT_MAX;
+    buckets_count = 0;
+    buckets_objcount = 0;
+    buckets_size = 0;
+    buckets_size_rounded = 0;
   }
 
   int verify_permission();

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -45,6 +45,24 @@ int RGWListBuckets_ObjStore_SWIFT::get_params()
   return 0;
 }
 
+static void dump_account_metadata(struct req_state *s, uint32_t buckets_count,
+                                  uint64_t buckets_object_count, uint64_t buckets_size, uint64_t buckets_size_rounded)
+{
+  char buf[32];
+  utime_t now = ceph_clock_now(g_ceph_context);
+  snprintf(buf, sizeof(buf), "%0.5f", (double)now);
+  /* Adding X-Timestamp to keep align with Swift API */
+  s->cio->print("X-Timestamp: %s\r\n", buf);
+  snprintf(buf, sizeof(buf), "%lld", (long long)buckets_count);
+  s->cio->print("X-Account-Container-Count: %s\r\n", buf);
+  snprintf(buf, sizeof(buf), "%lld", (long long)buckets_object_count);
+  s->cio->print("X-Account-Object-Count: %s\r\n", buf);
+  snprintf(buf, sizeof(buf), "%lld", (long long)buckets_size);
+  s->cio->print("X-Account-Bytes-Used: %s\r\n", buf);
+  snprintf(buf, sizeof(buf), "%lld", (long long)buckets_size_rounded);
+  s->cio->print("X-Account-Bytes-Used-Actual: %s\r\n", buf);
+}
+
 void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
 {
   if (ret) {
@@ -53,6 +71,8 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
     ret = STATUS_NO_CONTENT;
     set_req_state_err(s, ret);
   }
+  /* Adding account stats in the header to keep align with Swift API */
+  dump_account_metadata(s, buckets_count, buckets_objcount, buckets_size, buckets_size_rounded);
   dump_errno(s);
   end_header(s, NULL);
 
@@ -246,20 +266,6 @@ static void dump_container_metadata(struct req_state *s, RGWBucketEnt& bucket)
       s->cio->print("X-Storage-Policy: %s\r\n", s->bucket_info.placement_rule.c_str());
     }
   }
-}
-
-static void dump_account_metadata(struct req_state *s, uint32_t buckets_count,
-                                  uint64_t buckets_object_count, uint64_t buckets_size, uint64_t buckets_size_rounded)
-{
-  char buf[32];
-  snprintf(buf, sizeof(buf), "%lld", (long long)buckets_count);
-  s->cio->print("X-Account-Container-Count: %s\r\n", buf);
-  snprintf(buf, sizeof(buf), "%lld", (long long)buckets_object_count);
-  s->cio->print("X-Account-Object-Count: %s\r\n", buf);
-  snprintf(buf, sizeof(buf), "%lld", (long long)buckets_size);
-  s->cio->print("X-Account-Bytes-Used: %s\r\n", buf);
-  snprintf(buf, sizeof(buf), "%lld", (long long)buckets_size_rounded);
-  s->cio->print("X-Account-Bytes-Used-Actual: %s\r\n", buf);
 }
 
 void RGWStatAccount_ObjStore_SWIFT::send_response()


### PR DESCRIPTION
In Swift the GET request on account returns the stats header also.
This patch adds the missing header in the response content to algin
with Swift API:

X-Timestamp
X-Account-Bytes-Used
X-Account-Container-Count
X-Account-Object-Count
X-Account-Bytes-Used-Actual

Fixes #10684
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>