### PR TITLE
Cleanup:  call ceph_clock_now added clock_offset defined in ceph.conf

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -243,7 +243,7 @@ void OpTracker::get_age_ms_histogram(pow2_hist_t *h)
 {
   h->clear();
 
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now(g_ceph_context);
   unsigned bin = 30;
   uint32_t lb = 1 << (bin-1);  // lower bound for this bin
   int count = 0;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6986,7 +6986,7 @@ void OSD::handle_pg_create(OpRequestRef op)
     if (ci->second == utime_t()) {
       // Older OSD doesn't send ctime, so just do what we did before
       // The repair_test.py can fail in a mixed cluster
-      utime_t now = ceph_clock_now(NULL);
+      utime_t now = ceph_clock_now(cct);
       history.last_scrub_stamp = now;
       history.last_deep_scrub_stamp = now;
     } else {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -4591,7 +4591,7 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	    break;
 	  }
 	  dout(10) << " found existing watch " << w << " by " << entity << dendl;
-	  p->second->got_ping(ceph_clock_now(NULL));
+	  p->second->got_ping(ceph_clock_now(cct));
 	  result = 0;
         } else if (op.watch.op == CEPH_OSD_WATCH_OP_UNWATCH) {
 	  map<pair<uint64_t, entity_name_t>, watch_info_t>::iterator oi_iter =
@@ -11727,7 +11727,7 @@ void ReplicatedPG::hit_set_setup()
 
 void ReplicatedPG::hit_set_create()
 {
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now(cct);
   // make a copy of the params to modify
   HitSet::Params params(pool.info.hit_set_params);
 
@@ -12316,7 +12316,7 @@ bool ReplicatedPG::agent_maybe_flush(ObjectContextRef& obc)
     return false;
   }
 
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now(cct);
   utime_t ob_local_mtime;
   if (obc->obs.oi.local_mtime != utime_t()) {
     ob_local_mtime = obc->obs.oi.local_mtime;
@@ -12393,9 +12393,9 @@ bool ReplicatedPG::agent_maybe_evict(ObjectContextRef& obc)
     uint64_t atime_upper = 0, atime_lower = 0;
     if (atime < 0 && obc->obs.oi.mtime != utime_t()) {
       if (obc->obs.oi.local_mtime != utime_t()) {
-        atime = ceph_clock_now(NULL).sec() - obc->obs.oi.local_mtime;
+        atime = ceph_clock_now(cct).sec() - obc->obs.oi.local_mtime;
       } else {
-        atime = ceph_clock_now(NULL).sec() - obc->obs.oi.mtime;
+        atime = ceph_clock_now(cct).sec() - obc->obs.oi.mtime;
       }
     }
     if (atime < 0) {
@@ -12691,7 +12691,7 @@ void ReplicatedPG::agent_estimate_atime_temp(const hobject_t& oid,
     else
       return;
   }
-  time_t now = ceph_clock_now(NULL).sec();
+  time_t now = ceph_clock_now(cct).sec();
   for (map<time_t,HitSetRef>::reverse_iterator p =
 	 agent_state->hit_set_map.rbegin();
        p != agent_state->hit_set_map.rend();


### PR DESCRIPTION
@yuyuyu101 , @dachary, Do you think it is a bug? we should add the clock_offset in ceph.conf.

I grep all the ceph code, there are so many place use ceph_clock_now(NULL).

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>