### PR TITLE
ceph_objectstore_tool: fix check_output on python2.6

### DIFF
--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -1,7 +1,25 @@
 #!/usr/bin/env python
 
 from subprocess import call
-from subprocess import check_output
+try:
+    from subprocess import check_output
+except ImportError:
+    def check_output(*popenargs, **kwargs):
+        import subprocess
+        # backported from python 2.7 stdlib
+        process = subprocess.Popen(
+           stdout=subprocess.PIPE, *popenargs, **kwargs)
+        output, unused_err = process.communicate()
+        retcode = process.poll()
+        if retcode:
+            cmd = kwargs.get("args")
+            if cmd is None:
+                cmd = popenargs[0]
+            error = subprocess.CalledProcessError(retcode, cmd)
+            error.output = output
+            raise error
+        return output
+
 import subprocess
 import os
 import time


### PR DESCRIPTION
* backported the subprocess.check_output from python2.7

Fixes: 10756

Signed-off-by: Kefu Chai <kchai@redhat.com>