### PR TITLE
Unconditionally chown rados log file.

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -72,8 +72,10 @@ case "$1" in
             fi
 
             log_file=`$RADOSGW -n $name --show-config-value log_file`
-            if [ -n "$log_file" ] && [ ! -e "$log_file" ]; then
-                touch "$log_file"
+            if [ -n "$log_file" ]; then
+                if [ ! -e "$log_file" ]; then
+                    touch "$log_file"
+                fi
                 chown $user $log_file
             fi
 

--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -79,8 +79,10 @@ case "$1" in
             fi
 
             log_file=`$RADOSGW -n $name --show-config-value log_file`
-            if [ -n "$log_file" ] && [ ! -e "$log_file" ]; then
-                touch "$log_file"
+            if [ -n "$log_file" ]; then
+                if [ ! -e "$log_file" ]; then
+                    touch "$log_file"
+                fi
                 chown $user $log_file
             fi
 


### PR DESCRIPTION
This fixes bnc#905047 (in a somewhat ad-hoc way). Sadly the log
file gets created from several places, so its existence does not
mean init-radosgw had actually run.

(bug link is https://bugzilla.novell.com/show_bug.cgi?id=905047)