### PR TITLE
librados: fix message dropping and race condition in RadosClient::monitor_log()

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -2864,7 +2864,8 @@ CEPH_RADOS_API int rados_pg_command(rados_t cluster, const char *pgstr,
  *
  * @param cluster cluster handle
  * @param level minimum log level (debug, info, warn|warning, err|error)
- * @param cb callback to run for each log message
+ * @param cb callback to run for each log message. It MUST NOT block
+ * nor call back into librados.
  * @param arg void argument to pass to cb
  *
  * @returns 0 on success, negative code on error

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -827,15 +827,9 @@ void librados::RadosClient::handle_log(MLog *m)
 	       stamp.tv_sec, stamp.tv_nsec,
 	       e.seq, level.c_str(), e.msg.c_str());
       }
-
-      /*
-	this was present in the old cephtool code, but does not appear to be necessary. :/
-
-	version_t v = log_last_version + 1;
-	ldout(cct, 10) << __func__ << " wanting " << log_watch << " ver " << v << dendl;
-	monclient.sub_want(log_watch, v, 0);
-      */
     }
+
+    monclient.sub_got(log_watch, log_last_version);
   }
 
   m->put();

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -764,6 +764,8 @@ int librados::RadosClient::pg_command(pg_t pgid, vector<string>& cmd,
 
 int librados::RadosClient::monitor_log(const string& level, rados_log_callback_t cb, void *arg)
 {
+  Mutex::Locker l(lock);
+
   if (cb == NULL) {
     // stop watch
     ldout(cct, 10) << __func__ << " removing cb " << (void*)log_cb << dendl;

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -815,19 +815,19 @@ void librados::RadosClient::handle_log(MLog *m)
 
     if (log_cb) {
       for (std::deque<LogEntry>::iterator it = m->entries.begin(); it != m->entries.end(); ++it) {
-	LogEntry e = *it;
-	ostringstream ss;
-	ss << e.stamp << " " << e.who.name << " " << e.prio << " " << e.msg;
-	string line = ss.str();
-	string who = stringify(e.who);
-	string level = stringify(e.prio);
-	struct timespec stamp;
-	e.stamp.to_timespec(&stamp);
+        LogEntry e = *it;
+        ostringstream ss;
+        ss << e.stamp << " " << e.who.name << " " << e.prio << " " << e.msg;
+        string line = ss.str();
+        string who = stringify(e.who);
+        string level = stringify(e.prio);
+        struct timespec stamp;
+        e.stamp.to_timespec(&stamp);
 
-	ldout(cct, 20) << __func__ << " delivering " << ss.str() << dendl;
-	log_cb(log_cb_arg, line.c_str(), who.c_str(),
-	       stamp.tv_sec, stamp.tv_nsec,
-	       e.seq, level.c_str(), e.msg.c_str());
+        ldout(cct, 20) << __func__ << " delivering " << ss.str() << dendl;
+        log_cb(log_cb_arg, line.c_str(), who.c_str(),
+               stamp.tv_sec, stamp.tv_nsec,
+               e.seq, level.c_str(), e.msg.c_str());
       }
     }
 


### PR DESCRIPTION
I would like to propose two changes:

1) Fix for the problem described in the issue [#5639](http://tracker.ceph.com/issues/5639).
2) Introducing synchronization between _librados::RadosClient::monitor_log()_ and _librados::RadosClient::handle_log()_ because there could be race condition while updating the pair of pointer to user callback and its argument. I'm afraid the operation in not atomic.