### PR TITLE
librbd: add CRC validation to object map

### DIFF
--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -68,7 +68,7 @@ private:
 
     State m_state;
 
-    void invalidate();
+    bool invalidate();
   }; 
 
   class ResizeRequest : public Request {


### PR DESCRIPTION
The on-disk object map now includes a CRC to help protect against data rot.