### PR TITLE
Backport of pull request 3633 to hammer : libradosstriper: fixed write_full when ENOENT

### DIFF
--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -316,7 +316,7 @@ int libradosstriper::RadosStriperImpl::write_full(const std::string& soid,
 						  const bufferlist& bl) 
 {
   int rc = trunc(soid, 0);
-  if (rc) return rc;
+  if (rc && rc != -ENOENT) return rc; // ENOENT is obviously ok
   return write(soid, bl, bl.length(), 0);
 }
 

--- a/src/test/libradosstriper/io.cc
+++ b/src/test/libradosstriper/io.cc
@@ -27,6 +27,20 @@ TEST_F(StriperTestPP, SimpleWritePP) {
   ASSERT_EQ(0, striper.write("SimpleWritePP", bl, sizeof(buf), 0));
 }
 
+TEST_F(StriperTest, SimpleWriteFull) {
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+  ASSERT_EQ(0, rados_striper_write_full(striper, "SimpleWrite", buf, sizeof(buf)));
+}
+
+TEST_F(StriperTestPP, SimpleWriteFullPP) {
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+  ASSERT_EQ(0, striper.write_full("SimpleWritePP", bl));
+}
+
 TEST_F(StriperTest, Stat) {
   uint64_t psize;
   time_t pmtime;


### PR DESCRIPTION
Fixes: #10758
write_full was returning ENOENT when the file did not exists, while it should just have created it without complaining.

Signed-off-by: Sebastien Ponce <sebastien.ponce@cern.ch>
(cherry picked from commit 6a91f2bb82035b3c8021a7dc7b23548ce3d61eb6)