### PR TITLE
mon/OSDMonitor: do not trust small values in osd epoch cache

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1688,10 +1688,17 @@ void OSDMonitor::send_incremental(PaxosServiceMessage *req, epoch_t first)
     osd = req->get_source().num();
     map<int,epoch_t>::iterator p = osd_epoch.find(osd);
     if (p != osd_epoch.end()) {
-      dout(10) << " osd." << osd << " should have epoch " << p->second << dendl;
-      first = p->second + 1;
-      if (first > osdmap.get_epoch())
-	return;
+      if (first <= p->second) {
+	dout(10) << __func__ << " osd." << osd << " should already have epoch "
+		 << p->second << dendl;
+	first = p->second + 1;
+	if (first > osdmap.get_epoch())
+	  return;
+      } else {
+	dout(10) << __func__ << " osd." << osd << " osd_epoch says " << p->second
+		 << " but first is " << first << dendl;
+	osd = -1;  // do not update cache below
+      }
     }
   }
 


### PR DESCRIPTION
If the epoch cache says the osd has epoch 100 and the osd is asking for
epoch 200+, do not send it 100+.

Fixes: #10787
Backport: giant, firefly
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit fad38421ca1ba7456206a66cbf73f0a179be648e)