### PR TITLE
fix build and warnings on older gcc

### DIFF
--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -306,6 +306,7 @@ inline void encode(const boost::optional<T> &p, bufferlist &bl)
     encode(p.get(), bl);
 }
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -321,6 +322,7 @@ inline void decode(boost::optional<T> &p, bufferlist::iterator &bp)
   }
 }
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"
 
 //triple tuple
 template<class A, class B, class C>

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -850,13 +850,15 @@ void Pipe::set_socket_options()
 
   int prio = msgr->get_socket_priority();
   if (prio >= 0) {
+    int r;
+#ifdef IPTOS_CLASS_CS6
     int iptos = IPTOS_CLASS_CS6;
-    int r = ::setsockopt(sd, IPPROTO_IP, IP_TOS, &iptos, sizeof(iptos));
+    r = ::setsockopt(sd, IPPROTO_IP, IP_TOS, &iptos, sizeof(iptos));
     if (r < 0) {
       ldout(msgr->cct,0) << "couldn't set IP_TOS to " << iptos
                          << ": " << cpp_strerror(errno) << dendl;
     }
-
+#endif
     // setsockopt(IPTOS_CLASS_CS6) sets the priority of the socket as 0.
     // See http://goo.gl/QWhvsD and http://goo.gl/laTbjT
     // We need to call setsockopt(SO_PRIORITY) after it.

--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -4,6 +4,7 @@
 #include "ObjectStore.h"
 #include "common/Formatter.h"
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -504,6 +505,7 @@ void ObjectStore::Transaction::_build_actions_from_tbl()
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"
 
 void ObjectStore::Transaction::dump(ceph::Formatter *f)
 {
@@ -932,6 +934,7 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
   f->close_section();
 }
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -981,3 +984,4 @@ void ObjectStore::Transaction::generate_test_instances(list<ObjectStore::Transac
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2515,6 +2515,7 @@ void PG::init(
   write_if_dirty(*t);
 }
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -2555,6 +2556,7 @@ void PG::upgrade(ObjectStore *store, const interval_set<snapid_t> &snapcolls)
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"
 
 void PG::_upgrade_v7(ObjectStore *store, const interval_set<snapid_t> &snapcolls)
 {
@@ -2753,6 +2755,7 @@ void PG::write_info(ObjectStore::Transaction& t)
   dirty_big_info = false;
 }
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -2843,6 +2846,7 @@ epoch_t PG::peek_map_epoch(ObjectStore *store,
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"
 
 void PG::write_if_dirty(ObjectStore::Transaction& t)
 {

--- a/src/test/librados/list.cc
+++ b/src/test/librados/list.cc
@@ -34,6 +34,7 @@ TEST_F(LibRadosList, ListObjects) {
   rados_objects_list_close(ctx);
 }
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -154,6 +155,7 @@ static void check_list(std::set<std::string>& myset, rados_list_ctx_t& ctx)
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"
 
 TEST_F(LibRadosList, ListObjectsNS) {
   char buf[128];
@@ -207,6 +209,7 @@ TEST_F(LibRadosList, ListObjectsNS) {
   ASSERT_EQ(-EINVAL, rados_objects_list_open(ioctx, &ctx));
 }
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -474,6 +477,7 @@ TEST_F(LibRadosListECPP, ListObjectsEndIter) {
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"
 
 TEST_F(LibRadosListEC, ListObjectsNS) {
   char buf[128];
@@ -570,6 +574,7 @@ TEST_F(LibRadosListECPP, ListObjectsPPNS) {
   EXPECT_THROW(check_listpp(def, ioctx), std::runtime_error);
 }
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -661,3 +666,4 @@ TEST_F(LibRadosListECPP, ListObjectsStartPP) {
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"

--- a/src/test/librados/watch_notify.cc
+++ b/src/test/librados/watch_notify.cc
@@ -98,6 +98,7 @@ public:
 
 // --
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -215,6 +216,7 @@ TEST_F(LibRadosWatchNotifyECPP, WatchNotifyTimeout) {
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"
 
 
 // --

--- a/src/test/multi_stress_watch.cc
+++ b/src/test/multi_stress_watch.cc
@@ -29,6 +29,7 @@ public:
     }
 };
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -67,6 +68,7 @@ test_loop(Rados &cluster, std::string pool_name, std::string obj_name)
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"
 
 void
 test_replicated(Rados &cluster, std::string pool_name, std::string obj_name)

--- a/src/test/system/st_rados_notify.cc
+++ b/src/test/system/st_rados_notify.cc
@@ -38,6 +38,7 @@ StRadosNotify::~StRadosNotify()
 {
 }
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -77,3 +78,4 @@ int StRadosNotify::run()
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"

--- a/src/test/system/st_rados_watch.cc
+++ b/src/test/system/st_rados_watch.cc
@@ -47,6 +47,7 @@ StRadosWatch::
 {
 }
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -100,3 +101,4 @@ run()
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"

--- a/src/test/test_stress_watch.cc
+++ b/src/test/test_stress_watch.cc
@@ -35,6 +35,7 @@ public:
     }
 };
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -122,3 +123,4 @@ TEST_P(WatchStress, Stress1) {
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -727,6 +727,7 @@ int finish_remove_pgs(ObjectStore *store)
   return 0;
 }
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -766,6 +767,7 @@ int mark_pg_for_removal(ObjectStore *fs, spg_t pgid, ObjectStore::Transaction *t
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"
 
 int initiate_new_remove_pg(ObjectStore *store, spg_t r_pgid)
 {

--- a/src/tools/scratchtoolpp.cc
+++ b/src/tools/scratchtoolpp.cc
@@ -23,6 +23,7 @@ using namespace librados;
 #include <stdlib.h>
 #include <time.h>
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -317,3 +318,4 @@ int main(int argc, const char **argv)
 }
 
 #pragma GCC diagnostic pop
+#pragma GCC diagnostic warning "-Wpragmas"


### PR DESCRIPTION
This makes things compile again on squeeze,
and fixes a bunch of warnings on precise and
other distros with gcc < 4.6