### PR TITLE
rados.py: keep reference to python callbacks

### DIFF
--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -909,11 +909,14 @@ class Snap(object):
 
 class Completion(object):
     """completion object"""
-    def __init__(self, ioctx, rados_comp, oncomplete, onsafe):
+    def __init__(self, ioctx, rados_comp, oncomplete, onsafe,
+                 complete_cb, safe_cb):
         self.rados_comp = rados_comp
         self.oncomplete = oncomplete
         self.onsafe = onsafe
         self.ioctx = ioctx
+        self.complete_cb = complete_cb
+        self.safe_cb = safe_cb
 
     def is_safe(self):
         """
@@ -1071,7 +1074,8 @@ class Ioctx(object):
         if ret < 0:
             raise make_ex(ret, "error getting a completion")
         with self.lock:
-            completion_obj = Completion(self, completion, oncomplete, onsafe)
+            completion_obj = Completion(self, completion, oncomplete, onsafe,
+                                        complete_cb, safe_cb)
             if oncomplete:
                 self.complete_cbs[completion.value] = completion_obj
             if onsafe:


### PR DESCRIPTION
If we don't keep a reference to these, the librados aio calls will segfault
since the python-level callbacks will have been garbage collected. Passing
them to aio_create_completion() does not take a reference to them. Keep a
reference in the python Completion object associated with the request, since
they need the same lifetime.

This fixes a regression from 60b019f69aa0e39d276c669698c92fc890599f50.

Fixes: #10775 Backport: dumpling, firefly, giant Signed-off-by: Josh Durgin
<jdurgin@redhat.com>