### PR TITLE
erasure-code: fix compilation warnings

### DIFF
--- a/src/erasure-code/isa/xor_op.h
+++ b/src/erasure-code/isa/xor_op.h
@@ -26,8 +26,8 @@
 // -------------------------------------------------------------------------
 // -------------------------------------------------------------------------
 
-#define EC_ISA_ADDRESS_ALIGNMENT 32
-#define EC_ISA_VECTOR_SSE2_WORDSIZE 64
+#define EC_ISA_ADDRESS_ALIGNMENT 32u
+#define EC_ISA_VECTOR_SSE2_WORDSIZE 64u
 
 #if __GNUC__ > 4 || \
   ( (__GNUC__ == 4) && (__GNUC_MINOR__ >= 4) ) ||\

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -595,10 +595,10 @@ TEST(CRUSH, straw2_reweight) {
   for (int i=0; i<total; ++i) {
     vector<int> out0, out1;
     c->do_rule(ruleset0, i, out0, 1, reweight);
-    ASSERT_EQ(1, out0.size());
+    ASSERT_EQ(1u, out0.size());
 
     c->do_rule(ruleset1, i, out1, 1, reweight);
-    ASSERT_EQ(1, out1.size());
+    ASSERT_EQ(1u, out1.size());
 
     sum[out1[0]]++;
     //sum[rand()%n]++;

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -308,11 +308,11 @@ TEST_F(IsaErasureCodeTest, chunk_size)
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT, Isa.get_chunk_size(1));
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT, Isa.get_chunk_size(EC_ISA_ADDRESS_ALIGNMENT * k - 1));
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT * 2, Isa.get_chunk_size(EC_ISA_ADDRESS_ALIGNMENT * k + 1));
-    int object_size = EC_ISA_ADDRESS_ALIGNMENT * k * 1024 + 1;
-    ASSERT_NE(0, object_size % k);
-    ASSERT_NE(0, object_size % EC_ISA_ADDRESS_ALIGNMENT);
-    int chunk_size = Isa.get_chunk_size(object_size);
-    ASSERT_EQ(0, chunk_size % EC_ISA_ADDRESS_ALIGNMENT);
+    unsigned object_size = EC_ISA_ADDRESS_ALIGNMENT * k * 1024 + 1;
+    ASSERT_NE(0u, object_size % k);
+    ASSERT_NE(0u, object_size % EC_ISA_ADDRESS_ALIGNMENT);
+    unsigned chunk_size = Isa.get_chunk_size(object_size);
+    ASSERT_EQ(0u, chunk_size % EC_ISA_ADDRESS_ALIGNMENT);
     ASSERT_GT(chunk_size, (chunk_size * k) - object_size);
   }
 }

--- a/src/test/erasure-code/TestErasureCodeShec_all.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_all.cc
@@ -63,7 +63,7 @@ TEST_P(ParameterTest, parameter_all)
   char* k = GetParam().k;
   char* m = GetParam().m;
   char* c = GetParam().c;
-  int c_size = GetParam().ch_size;
+  unsigned c_size = GetParam().ch_size;
   int i_k = atoi(k);
   int i_m = atoi(m);
   int i_c = atoi(c);
@@ -89,7 +89,7 @@ TEST_P(ParameterTest, parameter_all)
   EXPECT_EQ(i_k, shec->k);
   EXPECT_EQ(i_m, shec->m);
   EXPECT_EQ(i_c, shec->c);
-  EXPECT_EQ(8u, shec->w);
+  EXPECT_EQ(8, shec->w);
   EXPECT_EQ(ErasureCodeShec::MULTIPLE, shec->technique);
   EXPECT_STREQ("default", shec->ruleset_root.c_str());
   EXPECT_STREQ("osd", shec->ruleset_failure_domain.c_str());
@@ -132,7 +132,7 @@ TEST_P(ParameterTest, parameter_all)
 	g_recover++;
       } else {
 	EXPECT_EQ(-EIO, result);
-	EXPECT_EQ(0, minimum_chunks.size());
+	EXPECT_EQ(0u, minimum_chunks.size());
 	g_cannot_recover++;
 	comb.k = shec->k;
 	comb.m = shec->m;


### PR DESCRIPTION
this change helps to cleanup the compilation warnings while we `make check`.