### PR TITLE
osd: fix PG leak in SnapTrimWQ._clear()

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2084,7 +2084,9 @@ protected:
       pg->put("SnapTrimWQ");
     }
     void _clear() {
-      osd->snap_trim_queue.clear();
+      while (PG *pg = _dequeue()) {
+	pg->put("SnapTrimWQ");
+      }
     }
   } snap_trim_wq;
 


### PR DESCRIPTION
i am not 100% sure that this change fixes http://tracker.ceph.com/issues/10421, but it's very likely that the leak in SnapTrimWQ contributed to the 5 floating ref count of pg 88.1 in that ticket .
