### PR TITLE
osdc/Objecter: linger_register now acquires rwlock

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -658,7 +658,7 @@ Objecter::LingerOp *Objecter::linger_register(const object_t& oid,
   info->target.flags = flags;
   info->watch_valid_thru = ceph_clock_now(NULL);
 
-  RWLock::Context lc(rwlock, RWLock::Context::TakenForWrite);
+  RWLock::WLocker l(rwlock);
 
   // Acquire linger ID
   info->linger_id = ++max_linger_id;


### PR DESCRIPTION
Previously linger_register just created a RWLock::Context
which does not result in the lock being acquired.

Fixes: #10827
Signed-off-by: Jason Dillaman <dillaman@redhat.com>