### PR TITLE
RFC ceph-fuse: check for failures on system() invocation

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -164,6 +164,7 @@ Client::Client(Messenger *m, MonClient *mc)
     ino_invalidate_cb(NULL),
     dentry_invalidate_cb(NULL),
     getgroups_cb(NULL),
+    can_invalidate_dentries(false),
     require_remount(false),
     async_ino_invalidator(m->cct),
     async_dentry_invalidator(m->cct),
@@ -3459,10 +3460,18 @@ public:
 
 void Client::_invalidate_kernel_dcache()
 {
-  // Hacky:
-  // when remounting a file system, linux kernel trims all unused dentries in the file system
-  if (remount_cb)
+  if (can_invalidate_dentries && dentry_invalidate_cb && root->dir) {
+    for (ceph::unordered_map<string, Dentry*>::iterator p = root->dir->dentries.begin();
+	 p != root->dir->dentries.end();
+	 ++p) {
+      if (p->second->inode)
+	_schedule_invalidate_dentry_callback(p->second, false);
+    }
+  } else if (remount_cb) {
+    // Hacky:
+    // when remounting a file system, linux kernel trims all unused dentries in the fs
     remount_finisher.queue(new C_Client_Remount(this));
+  }
 }
 
 void Client::trim_caps(MetaSession *s, int max)
@@ -3494,6 +3503,13 @@ void Client::trim_caps(MetaSession *s, int max)
       while (q != in->dn_set.end()) {
 	Dentry *dn = *q++;
 	if (dn->lru_is_expireable()) {
+	  if (can_invalidate_dentries &&
+	      dn->dir->parent_inode->ino == MDS_INO_ROOT) {
+	    // Only issue one of these per DN for inodes in root: handle
+	    // others more efficiently by calling for root-child DNs at
+	    // the end of this function.
+	    _schedule_invalidate_dentry_callback(dn, true);
+	  }
 	  trim_dentry(dn);
         } else {
           ldout(cct, 20) << "  not expirable: " << dn->name << dendl;
@@ -7995,11 +8011,17 @@ void Client::ll_register_callbacks(struct client_callback_args *args)
   getgroups_cb = args->getgroups_cb;
 }
 
-int Client::test_remount()
+int Client::test_dentry_handling(bool can_invalidate)
 {
   int r = 0;
 
-  if (remount_cb) {
+  can_invalidate_dentries = can_invalidate;
+
+  if (can_invalidate_dentries) {
+    assert(dentry_invalidate_cb);
+    ldout(cct, 1) << "using dentry_invalidate_cb" << dendl;
+  } else if (remount_cb) {
+    ldout(cct, 1) << "using remount_cb" << dendl;
     int s = remount_cb(callback_handle);
     if (s) {
       lderr(cct) << "Failed to invoke remount, needed to ensure kernel dcache consistency"
@@ -8009,6 +8031,10 @@ int Client::test_remount()
       require_remount = true;
       r = s;
     }
+  } else {
+    lderr(cct) << "no method to invalidate kernel dentry cache; expect issues!" << dendl;
+    if (cct->_conf->client_die_on_failed_remount)
+      assert(0);
   }
   return r;
 }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3443,7 +3443,16 @@ private:
 public:
   C_Client_Remount(Client *c) : client(c) {}
   void finish(int r) {
-    client->remount_cb(client->callback_handle);
+    assert (r == 0);
+    r = client->remount_cb(client->callback_handle);
+    if (r != 0) {
+      client_t whoami = client->get_nodeid();
+      lderr(client->cct) << "tried to remount (to trim kernel dentries) and got error "
+			 << r << dendl;
+      if (client->cct->_conf->client_die_on_failed_remount) {
+	assert(0 == "failed to remount for kernel dentry trimming");
+      }
+    }
   }
 };
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -242,6 +242,7 @@ class Client : public Dispatcher {
   client_ino_callback_t ino_invalidate_cb;
   client_dentry_callback_t dentry_invalidate_cb;
   client_getgroups_callback_t getgroups_cb;
+  bool require_remount;
 
   Finisher async_ino_invalidator;
   Finisher async_dentry_invalidator;
@@ -954,6 +955,7 @@ public:
   int ll_osdaddr(int osd, char* buf, size_t size);
 
   void ll_register_callbacks(struct client_callback_args *args);
+  int test_remount();
 };
 
 #endif

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -136,7 +136,7 @@ typedef void (*client_ino_callback_t)(void *handle, vinodeno_t ino, int64_t off,
 
 typedef void (*client_dentry_callback_t)(void *handle, vinodeno_t dirino,
 					 vinodeno_t ino, string& name);
-typedef void (*client_remount_callback_t)(void *handle);
+typedef int (*client_remount_callback_t)(void *handle);
 
 typedef int (*client_getgroups_callback_t)(void *handle, uid_t uid, gid_t **sgids);
 typedef void(*client_switch_interrupt_callback_t)(void *req, void *data);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -242,6 +242,7 @@ class Client : public Dispatcher {
   client_ino_callback_t ino_invalidate_cb;
   client_dentry_callback_t dentry_invalidate_cb;
   client_getgroups_callback_t getgroups_cb;
+  bool can_invalidate_dentries;
   bool require_remount;
 
   Finisher async_ino_invalidator;
@@ -955,7 +956,7 @@ public:
   int ll_osdaddr(int osd, char* buf, size_t size);
 
   void ll_register_callbacks(struct client_callback_args *args);
-  int test_remount();
+  int test_dentry_handling(bool can_invalidate);
 };
 
 #endif

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -864,8 +864,6 @@ CephFuse::Handle::~Handle()
 
 void CephFuse::Handle::finalize()
 {
-  client->ll_register_callbacks(NULL);
-
   if (se)
     fuse_remove_signal_handlers(se);
   if (ch)

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -757,14 +757,19 @@ static void dentry_invalidate_cb(void *handle, vinodeno_t dirino,
 #endif
 }
 
-static void remount_cb(void *handle)
+static int remount_cb(void *handle)
 {
   // used for trimming kernel dcache. when remounting a file system, linux kernel
   // trims all unused dentries in the file system
   char cmd[1024];
   CephFuse::Handle *cfuse = (CephFuse::Handle *)handle;
   snprintf(cmd, sizeof(cmd), "mount -i -o remount %s", cfuse->mountpoint);
-  system(cmd);
+  int r = system(cmd);
+  if (r != 0 && r != -1) {
+    r = WEXITSTATUS(r);
+  }
+
+  return r;
 }
 
 static void do_init(void *data, fuse_conn_info *bar)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -326,6 +326,7 @@ OPTION(fuse_big_writes, OPT_BOOL, true)
 OPTION(fuse_atomic_o_trunc, OPT_BOOL, true)
 OPTION(fuse_debug, OPT_BOOL, false)
 OPTION(fuse_multithreaded, OPT_BOOL, true)
+OPTION(client_try_dentry_invalidate, OPT_BOOL, true) // the client should try to use dentry invaldation instead of remounting, on kernels it believes that will work for
 OPTION(client_die_on_failed_remount, OPT_BOOL, true)
 
 OPTION(crush_location, OPT_STR, "")       // whitespace-separated list of key=value pairs describing crush location

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -326,6 +326,7 @@ OPTION(fuse_big_writes, OPT_BOOL, true)
 OPTION(fuse_atomic_o_trunc, OPT_BOOL, true)
 OPTION(fuse_debug, OPT_BOOL, false)
 OPTION(fuse_multithreaded, OPT_BOOL, true)
+OPTION(client_die_on_failed_remount, OPT_BOOL, true)
 
 OPTION(crush_location, OPT_STR, "")       // whitespace-separated list of key=value pairs describing crush location
 


### PR DESCRIPTION
I've tested that this doesn't break anything when it works, but I'm having difficulty testing it under a failure condition because I can't induce a failure.

http://tracker.ceph.com/issues/10542 suggests it ought to be possible to check...