### PR TITLE
MDSMonitor: do not allow MDS to transition from STATE_STOPPING

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -493,6 +493,14 @@ bool MDSMonitor::prepare_beacon(MMDSBeacon *m)
     // state change
     MDSMap::mds_info_t& info = pending_mdsmap.get_info_gid(gid);
 
+    if (info.state == MDSMap::STATE_STOPPING && state != MDSMap::STATE_STOPPED ) {
+      // we can't transition to any other states from STOPPING
+      dout(0) << "got beacon for MDS in STATE_STOPPING, ignoring requested state change"
+	       << dendl;
+      _note_beacon(m);
+      return true;
+    }
+
     if (info.laggy()) {
       dout(10) << "prepare_beacon clearing laggy flag on " << addr << dendl;
       info.clear_laggy();


### PR DESCRIPTION
They can only go into STATE_STOPPED. I was a little concerned
that some of the rejoin code might inadvertently allow a stopping
MDS to end up active, but after a little auditing it looks like
that all behaves properly and this is an invariant we maintain.