### PR TITLE
osd: clear extra mark_started

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8618,8 +8618,6 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
 
   rm->bytes_written = rm->opt.get_encoded_bytes();
   
-  op->mark_started();
-
   rm->localt.append(rm->opt);
   rm->localt.register_on_commit(
     parent->bless_context(

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1823,7 +1823,7 @@ void ReplicatedPG::do_op(OpRequestRef& op)
   }
 
   op->mark_started();
-  ctx->src_obc = src_obc;
+  ctx->src_obc.swap(src_obc);
 
   execute_ctx(ctx);
 }


### PR DESCRIPTION
1. use swap to reassign src_obc in do_op
2. Mark_started call twice in sub_op_modify_impl.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>