### PR TITLE
osd: new transcation if needed

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1721,7 +1721,6 @@ void ReplicatedPG::do_op(OpRequestRef& op)
   }
 
   OpContext *ctx = new OpContext(op, m->get_reqid(), m->ops, obc, this);
-  ctx->op_t = pgbackend->get_transaction();
 
   if (!obc->obs.exists)
     ctx->snapset_obc = get_object_context(obc->obs.oi.soid.get_snapdir(), false);


### PR DESCRIPTION
1. ctx->op_t is not used in do_op, get_transaction has been called in execute_ctx

2. call get_transaction if needed in make_writeable 

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>