### PR TITLE
objecter: clean up linger op locking

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -551,8 +551,6 @@ void Objecter::_send_linger_ping(LingerOp *info)
   utime_t now = ceph_clock_now(NULL);
   ldout(cct, 10) << __func__ << " " << info->linger_id << " now " << now << dendl;
 
-  RWLock::Context lc(rwlock, RWLock::Context::TakenForRead);
-
   vector<OSDOp> opv(1);
   opv[0].op.op = CEPH_OSD_OP_WATCH;
   opv[0].op.watch.cookie = info->get_cookie();

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2642,11 +2642,6 @@ int Objecter::_get_osd_session(int osd, RWLock::Context& lc, OSDSession **psessi
   return 0;
 }
 
-int Objecter::_get_op_target_session(Op *op, RWLock::Context& lc, OSDSession **psession)
-{
-  return _get_osd_session(op->target.osd, lc, psession);
-}
-
 bool Objecter::_promote_lock_check_race(RWLock::Context& lc)
 {
   epoch_t epoch = osdmap->get_epoch();

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1771,7 +1771,7 @@ void Objecter::kick_requests(OSDSession *session)
 
 void Objecter::_kick_requests(OSDSession *session, map<uint64_t, LingerOp *>& lresend)
 {
-  assert(rwlock.is_locked());
+  assert(rwlock.is_wlocked());
 
   // resend ops
   map<ceph_tid_t,Op*> resend;  // resend in tid order
@@ -1815,7 +1815,7 @@ void Objecter::_kick_requests(OSDSession *session, map<uint64_t, LingerOp *>& lr
 
 void Objecter::_linger_ops_resend(map<uint64_t, LingerOp *>& lresend)
 {
-  assert(rwlock.is_locked());
+  assert(rwlock.is_wlocked());
 
   while (!lresend.empty()) {
     LingerOp *op = lresend.begin()->second;
@@ -2578,7 +2578,7 @@ void Objecter::_session_linger_op_assign(OSDSession *to, LingerOp *op)
 void Objecter::_session_linger_op_remove(OSDSession *from, LingerOp *op)
 {
   assert(from == op->session);
-  assert(from->lock.is_locked());
+  assert(from->lock.is_wlocked());
 
   if (from->is_homeless()) {
     num_homeless_ops.dec();

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1741,7 +1741,6 @@ public:
   void _session_command_op_assign(OSDSession *to, CommandOp *op);
   void _session_command_op_remove(OSDSession *from, CommandOp *op);
 
-  int _get_osd_session(int osd, RWLock::Context& lc, OSDSession **psession);
   int _assign_op_target_session(Op *op, RWLock::Context& lc, bool src_session_locked, bool dst_session_locked);
   int _recalc_linger_op_target(LingerOp *op, RWLock::Context& lc);
 
@@ -1929,7 +1928,6 @@ private:
   int pool_snap_get_info(int64_t poolid, snapid_t snap, pool_snap_info_t *info);
   int pool_snap_list(int64_t poolid, vector<uint64_t> *snaps);
 private:
-  bool _promote_lock_check_race(RWLock::Context& lc);
 
   // low-level
   ceph_tid_t _op_submit(Op *op, RWLock::Context& lc);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1743,7 +1743,6 @@ public:
 
   int _get_osd_session(int osd, RWLock::Context& lc, OSDSession **psession);
   int _assign_op_target_session(Op *op, RWLock::Context& lc, bool src_session_locked, bool dst_session_locked);
-  int _get_op_target_session(Op *op, RWLock::Context& lc, OSDSession **psession);
   int _recalc_linger_op_target(LingerOp *op, RWLock::Context& lc);
 
   void _linger_submit(LingerOp *info);


### PR DESCRIPTION
Remove a bunch of dead/confusing code, and correct locking for
a couple fields.