### PR TITLE
tests: clone ceph-erasure-code-corpus from ceph

### DIFF
--- a/qa/workunits/erasure-code/encode-decode-non-regression.sh
+++ b/qa/workunits/erasure-code/encode-decode-non-regression.sh
@@ -14,7 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Library Public License for more details.
 #
-: ${CORPUS:=https://github.com/dachary/ceph-erasure-code-corpus.git}
+: ${CORPUS:=https://github.com/ceph/ceph-erasure-code-corpus.git}
 : ${DIRECTORY:=../ceph-erasure-code-corpus}
 
 # when running from sources, the current directory must have precedence


### PR DESCRIPTION
Instead of the http://github.com/dachary namespace. It is not an issue
in the common case because it should be cloned because it is in the
.gitmodules file with the proper namespace.

http://tracker.ceph.com/issues/10836 Fixes: #10836

Signed-off-by: Loic Dachary <ldachary@redhat.com>