### PR TITLE
erasure-code: fix uninitialized data members on SHEC

### DIFF
--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -51,9 +51,13 @@ public:
   ErasureCodeShec(const int _technique,
 		  ErasureCodeShecTableCache &_tcache) :
     tcache(_tcache),
+    k(0),
     DEFAULT_K(2),
+    m(0),
     DEFAULT_M(1),
+    c(0),
     DEFAULT_C(1),
+    w(0),
     DEFAULT_W(8),
     technique(_technique),
     ruleset_root("default"),

--- a/src/test/erasure-code/TestErasureCodeShec.cc
+++ b/src/test/erasure-code/TestErasureCodeShec.cc
@@ -3215,30 +3215,6 @@ TEST(ErasureCodeShec, get_chunk_count_1)
   delete parameters;
 }
 
-TEST(ErasureCodeShec, get_chunk_count_2)
-{
-  //init
-  ErasureCodeShecTableCache tcache;
-  ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
-				  tcache,
-				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  //init is not executed
-
-  //get_chunk_count
-  EXPECT_EQ(10u, shec->get_chunk_count());
-
-  delete shec;
-  delete parameters;
-}
-
 TEST(ErasureCodeShec, get_data_chunk_count_1)
 {
   //init
@@ -3263,7 +3239,7 @@ TEST(ErasureCodeShec, get_data_chunk_count_1)
   delete parameters;
 }
 
-TEST(ErasureCodeShec, get_data_chunk_count_2)
+TEST(ErasureCodeShec, get_chunk_count_no_init)
 {
   //init
   ErasureCodeShecTableCache tcache;
@@ -3281,7 +3257,8 @@ TEST(ErasureCodeShec, get_data_chunk_count_2)
   //init is not executed
 
   //get_data_chunk_count
-  EXPECT_EQ(6u, shec->get_data_chunk_count());
+  EXPECT_EQ(0u, shec->get_data_chunk_count());
+  EXPECT_EQ(0u, shec->get_chunk_count());
 
   delete shec;
   delete parameters;


### PR DESCRIPTION
Also fix the tests that verify the result when init is not called and
factorize the two tests that were almost identical for simplicity.

http://tracker.ceph.com/issues/10839 Fixes: #10839

Backport: hammer
Signed-off-by: Loic Dachary <ldachary@redhat.com>