### PR TITLE
erasure-code: initialize all data members

### DIFF
--- a/src/erasure-code/isa/ErasureCodeIsa.h
+++ b/src/erasure-code/isa/ErasureCodeIsa.h
@@ -51,6 +51,9 @@ public:
 
   ErasureCodeIsa(const char *_technique,
                  ErasureCodeIsaTableCache &_tcache) :
+  k(0),
+  m(0),
+  w(0),
   tcache(_tcache),
   technique(_technique),
   ruleset_root("default"),

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -34,8 +34,11 @@ public:
   bool per_chunk_alignment;
 
   ErasureCodeJerasure(const char *_technique) :
+    k(0),
     DEFAULT_K(2),
+    m(0),
     DEFAULT_M(1),
+    w(0),
     DEFAULT_W(8),
     technique(_technique),
     ruleset_root("default"),


### PR DESCRIPTION
As a safeguard against unitialized memory in isa and jerasure
plugins. Since the init method is supposed to be called before the
plugin is used, it is mostly not relevant. However it can lead to
problems that are non trivial to figure out.

Signed-off-by: Loic Dachary <ldachary@redhat.com>