### PR TITLE
mds: fix decoding of InodeStore::oldest_snap

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1283,7 +1283,7 @@ void InodeStore::decode_bare(bufferlist::iterator &bl, __u8 struct_v)
       ::decode(inode.layout, bl); // but we only care about the layout portion
     }
   }
-  if (struct_v >= 5)
+  if (struct_v >= 5 && !bl.end())
     ::decode(oldest_snap, bl);
 }
 

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -95,7 +95,7 @@ public:
 
   /* Serialization without ENCODE_START/FINISH blocks for use embedded in dentry */
   void encode_bare(bufferlist &bl) const;
-  void decode_bare(bufferlist::iterator &bl, __u8 struct_v=4);
+  void decode_bare(bufferlist::iterator &bl, __u8 struct_v=5);
 
   /* For use in debug and ceph-dencoder */
   void dump(Formatter *f) const;


### PR DESCRIPTION
There is no ENCODE_START/FINISH block when encoding inode that
embedded in dentry. So we can't use encoding version to check
if the buffer contains InodeStore::oldest_snap. Instead, we check
if the buffer iterator reaches end of buffer.

Signed-off-by: Yan, Zheng <zyan@redhat.com>