### PR TITLE
#10864 ceph.spec.in: move ceph-rbdnamer to librbd1 RPM

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -466,7 +466,6 @@ fi
 %{_bindir}/ceph-mon
 %{_bindir}/ceph-mds
 %{_bindir}/ceph-osd
-%{_bindir}/ceph-rbdnamer
 %{_bindir}/librados-config
 %{_bindir}/ceph-client-debug
 %{_bindir}/cephfs-journal-tool
@@ -523,7 +522,6 @@ fi
 %{_mandir}/man8/monmaptool.8*
 %{_mandir}/man8/cephfs.8*
 %{_mandir}/man8/mount.ceph.8*
-%{_mandir}/man8/ceph-rbdnamer.8*
 %{_mandir}/man8/ceph-debugpack.8*
 %{_mandir}/man8/ceph-clsinfo.8*
 %{_mandir}/man8/librados-config.8*
@@ -696,6 +694,8 @@ fi
 %else
 /lib/udev/rules.d/50-rbd.rules
 %endif
+%{_bindir}/ceph-rbdnamer
+%{_mandir}/man8/ceph-rbdnamer.8*
 
 %post -n librbd1
 /sbin/ldconfig


### PR DESCRIPTION
Prior to this commit, the RPMs and DEBs were slightly mis-aligned regarding ceph-rbdnamer. The `/usr/bin/ceph-rbdnamer` utilitiy shipped in the main "ceph" RPM, whereas in the Debian packages, the `ceph-rbdnamer` utility shipped in the "librbd1" subpackage instead.

Given that:

1. the 50-rbd.rules file already ships in the librbd1 RPM, and
2. 50-rbd.rules requires /usr/bin/ceph-rbdnamer in order to function,

it makes sense to follow the Debian packages here and put `/usr/bin/ceph-rbdnamer` and the ceph-rbdnamer(8) man page into the librbd1 RPM as well.

This resolves http://tracker.ceph.com/issues/10864 for the hammer branch.