### PR TITLE
Number of degraded objects in EC pool is wrong when there is OSD down(in)

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2300,8 +2300,8 @@ void PG::_update_calc_stats()
     uint64_t degraded = 0;
 
     // if acting is smaller than desired, add in those missing replicas
-    if (acting.size() < target)
-      degraded += (target - acting.size()) * num_objects;
+    if (actingset.size() < target)
+      degraded += (target - actingset.size()) * num_objects;
 
     // missing on primary
     info.stats.stats.sum.num_objects_missing_on_primary =


### PR DESCRIPTION
For EC pool, actingset should be used instead of acting to calculate the number of degraded objects.

Signed-off-by: Guang Yang <yguang@yahoo-inc.com>