### PR TITLE
osd: number of degraded objects in EC pool is wrong when there is OSD down(in).

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2300,8 +2300,8 @@ void PG::_update_calc_stats()
     uint64_t degraded = 0;
 
     // if acting is smaller than desired, add in those missing replicas
-    if (acting.size() < target)
-      degraded += (target - acting.size()) * num_objects;
+    if (actingset.size() < target)
+      degraded += (target - actingset.size()) * num_objects;
 
     // missing on primary
     info.stats.stats.sum.num_objects_missing_on_primary =


### PR DESCRIPTION
With EC pool (crush rule choose indep), when there is an OSD down, the size of the 'acting' list does not change (CRUSH_ITEM_NONE is used to replace the down OSD), in this case, 'actingset' should be used to calculate the degraded objects.

Fixes: 4254

Signed-off-by: Guang Yang <yguang@yahoo-inc.com>