### PR TITLE
osd: consider last scrub timestamp globally when determining if the PG should schedule to scrub

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -897,12 +897,13 @@ void OSDService::share_map_peer(int peer, Connection *con, OSDMapRef map)
 }
 
 
-bool OSDService::inc_scrubs_pending()
+bool OSDService::inc_scrubs_pending(utime_t last_scrub_stamp)
 {
   bool result = false;
 
   sched_scrub_lock.Lock();
-  if (scrubs_pending + scrubs_active < cct->_conf->osd_max_scrubs) {
+  if (scrubs_pending + scrubs_active < cct->_conf->osd_max_scrubs &&
+      cmp_scrub_stamp(last_scrub_stamp)) {
     dout(20) << "inc_scrubs_pending " << scrubs_pending << " -> " << (scrubs_pending+1)
 	     << " (max " << cct->_conf->osd_max_scrubs << ", active " << scrubs_active << ")" << dendl;
     result = true;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -540,7 +540,13 @@ public:
     return true;
   }
 
-  bool inc_scrubs_pending();
+  bool cmp_scrub_stamp(utime_t last_scrub_stamp) {
+    assert(sched_scrub_lock.is_locked());
+    return last_scrub_pg.empty() ||
+      (last_scrub_stamp <= last_scrub_pg.begin()->first);
+  }
+
+  bool inc_scrubs_pending(utime_t last_scrub_stamp = utime_t());
   void inc_scrubs_active(bool reserved);
   void dec_scrubs_pending();
   void dec_scrubs_active();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3375,7 +3375,7 @@ void PG::sub_op_scrub_reserve(OpRequestRef op)
 
   op->mark_started();
 
-  scrubber.reserved = osd->inc_scrubs_pending();
+  scrubber.reserved = osd->inc_scrubs_pending(m->pg_last_scrub_stamp);
 
   MOSDSubOpReply *reply = new MOSDSubOpReply(
     m, pg_whoami, 0, get_osdmap()->get_epoch(), CEPH_OSD_FLAG_ACK);
@@ -3492,6 +3492,7 @@ void PG::scrub_reserve_replicas()
       reqid, pg_whoami, spg_t(info.pgid.pgid, i->shard), poid, 0,
       get_osdmap()->get_epoch(), osd->get_tid(), v);
     subop->ops = scrub;
+    subop->pg_last_scrub_stamp = scrubber.scrub_reg_stamp;
     osd->send_message_osd_cluster(
       i->osd, subop, get_osdmap()->get_epoch());
   }


### PR DESCRIPTION
Currently the scheduling of scrub is optimized locally at each OSD, that is, for each PG this OSD acts as the primary, it selects the one which hasn't been scheduled to scrubbing longest, put it as the candidate and request scrub reserver from all replicas. Since each OSD can only have 1 active scrubbing, that active slot could potentially always occupied by a replica, as a result, the PG whose primary is this OSD, fail to schedule and left behind.

For scrub reservation request, we can add the last scrub timestamp, so that for the replica OSD, it can use that timestamp to compare with its local scrub scheduling (primary) and make call to allow or deny the request.

Fixes: 10796

Signed-off-by: Guang Yang <yguang@yahoo-inc.com>