### PR TITLE
PG,ReplicatedPG: make missing_digests local to scrub_compare_maps

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4152,6 +4152,7 @@ void PG::scrub_compare_maps()
 
   // construct authoritative scrub map for type specific scrubbing
   ScrubMap authmap(scrubber.primary_scrubmap);
+  map<hobject_t, pair<uint32_t, uint32_t> > missing_digest;
 
   if (acting.size() > 1) {
     dout(10) << __func__ << "  comparing replica scrub maps" << dendl;
@@ -4182,7 +4183,7 @@ void PG::scrub_compare_maps()
       scrubber.missing,
       scrubber.inconsistent,
       authoritative,
-      scrubber.missing_digest,
+      missing_digest,
       scrubber.shallow_errors,
       scrubber.deep_errors,
       info.pgid, acting,
@@ -4217,7 +4218,7 @@ void PG::scrub_compare_maps()
   }
 
   // ok, do the pg-type specific scrubbing
-  _scrub(authmap);
+  _scrub(authmap, missing_digest);
 }
 
 void PG::scrub_process_inconsistent()

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1106,8 +1106,7 @@ public:
     // Map from object with errors to good peers
     map<hobject_t, list<pair<ScrubMap::object, pg_shard_t> > > authoritative;
 
-    // Objects who need digest updates
-    map<hobject_t, pair<uint32_t,uint32_t> > missing_digest;
+    // digest updates which we are waiting on
     int num_digest_updates_pending;
 
     // chunky scrub
@@ -1202,7 +1201,6 @@ public:
       inconsistent.clear();
       missing.clear();
       authoritative.clear();
-      missing_digest.clear();
       num_digest_updates_pending = 0;
     }
 
@@ -1240,7 +1238,9 @@ public:
    */
   virtual bool _range_available_for_scrub(
     const hobject_t &begin, const hobject_t &end) = 0;
-  virtual void _scrub(ScrubMap &map) { }
+  virtual void _scrub(
+    ScrubMap &map,
+    const std::map<hobject_t, pair<uint32_t, uint32_t> > &missing_digest) { }
   virtual void _scrub_clear_state() { }
   virtual void _scrub_finish() { }
   virtual void get_colls(list<coll_t> *out) = 0;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -12765,7 +12765,9 @@ void ReplicatedPG::_scrub_digest_updated()
   }
 }
 
-void ReplicatedPG::_scrub(ScrubMap& scrubmap)
+void ReplicatedPG::_scrub(
+  ScrubMap &scrubmap,
+  const map<hobject_t, pair<uint32_t, uint32_t> > &missing_digest)
 {
   dout(10) << "_scrub" << dendl;
 
@@ -12980,9 +12982,9 @@ void ReplicatedPG::_scrub(ScrubMap& scrubmap)
   }
 
   if (scrubber.shallow_errors == 0) {
-    for (map<hobject_t,pair<uint32_t,uint32_t> >::iterator p =
-	   scrubber.missing_digest.begin();
-	 p != scrubber.missing_digest.end();
+    for (map<hobject_t,pair<uint32_t,uint32_t> >::const_iterator p =
+	   missing_digest.begin();
+	 p != missing_digest.end();
 	 ++p) {
       if (p->first.is_snapdir())
 	continue;

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1359,7 +1359,9 @@ protected:
   // -- scrub --
   virtual bool _range_available_for_scrub(
     const hobject_t &begin, const hobject_t &end);
-  virtual void _scrub(ScrubMap& map);
+  virtual void _scrub(
+    ScrubMap &map,
+    const std::map<hobject_t, pair<uint32_t, uint32_t> > &missing_digest);
   void _scrub_digest_updated();
   virtual void _scrub_clear_state();
   virtual void _scrub_finish();


### PR DESCRIPTION
We don't want/need to carry this state between scrub stages, so lets
remove the tempation by simply making it a local to scrub_compare_maps.

This caused a bug where we would attempt to write out the
missing_digests from the previous chunk during all future chunks, which
caused trouble.

Fixes: 10840
Signed-off-by: Samuel Just <sjust@redhat.com>