### PR TITLE
rgw: Swift API. Include metadata in a response to "show container details" request

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1183,11 +1183,19 @@ void RGWListBucket::pre_exec()
 
 void RGWListBucket::execute()
 {
-  string no_ns;
-
   ret = get_params();
   if (ret < 0)
     return;
+
+  if (need_container_stats()) {
+    map<string, RGWBucketEnt> m;
+    m[s->bucket.name] = RGWBucketEnt();
+    m.begin()->second.bucket = s->bucket;
+    ret = store->update_containers_stats(m);
+    if (ret > 0) {
+      bucket = m.begin()->second;
+    } 
+  }
 
   RGWRados::Bucket target(store, s->bucket);
   RGWRados::Bucket::List list_op(&target);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -237,6 +237,7 @@ public:
 
 class RGWListBucket : public RGWOp {
 protected:
+  RGWBucketEnt bucket;
   string prefix;
   rgw_obj_key marker; 
   rgw_obj_key next_marker; 
@@ -265,6 +266,7 @@ public:
   virtual const string name() { return "list_bucket"; }
   virtual RGWOpType get_type() { return RGW_OP_LIST_BUCKET; }
   virtual uint32_t op_mask() { return RGW_OP_TYPE_READ; }
+  virtual bool need_container_stats() { return false; }
 };
 
 class RGWGetBucketLogging : public RGWOp {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -131,12 +131,15 @@ int RGWListBucket_ObjStore_SWIFT::get_params()
   return 0;
 }
 
+static void dump_container_metadata(struct req_state *, RGWBucketEnt&);
+
 void RGWListBucket_ObjStore_SWIFT::send_response()
 {
   vector<RGWObjEnt>::iterator iter = objs.begin();
   map<string, bool>::iterator pref_iter = common_prefixes.begin();
 
   dump_start(s);
+  dump_container_metadata(s, bucket);
 
   s->formatter->open_array_section_with_attrs("container", FormatterAttrs("name", s->bucket.name.c_str(), NULL));
 

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -40,6 +40,7 @@ public:
 
   int get_params();
   void send_response();
+  bool need_container_stats() { return true; }
 };
 
 class RGWStatAccount_ObjStore_SWIFT : public RGWStatAccount_ObjStore {


### PR DESCRIPTION
OpenStack Object Storage API v1 states that X-Container-Object-Count, X-Container-Bytes-Used and user-defined metadata headers should be included in a response.

Fixes: #10666
Reported-by: Ahmad Faheem <ahmad.faheem@ril.com>
Signed-off-by: Dmytro Iurchenko <diurchenko@mirantis.com>