### PR TITLE
doc: RGW is "built on top of librgw" changed to "librados"

### DIFF
--- a/doc/radosgw/index.rst
+++ b/doc/radosgw/index.rst
@@ -3,7 +3,7 @@
 =====================
 
 :term:`Ceph Object Gateway` is an object storage interface built on top of
-``librgw`` to provide applications with a RESTful gateway to
+``libradosw`` to provide applications with a RESTful gateway to
 Ceph Storage Clusters. :term:`Ceph Object Storage` supports two interfaces:
 
 #. **S3-compatible:** Provides object storage functionality with an interface 


### PR DESCRIPTION
Signed-off-by: Neil Levine <levine@yoyo.org>