### PR TITLE
osd: a few things to fix pg ref tracking

### DIFF
--- a/src/common/tracked_int_ptr.hpp
+++ b/src/common/tracked_int_ptr.hpp
@@ -50,11 +50,20 @@ public:
     TrackedIntPtr o(rhs.ptr);
     swap(o);
   }
+  const T &operator*() const {
+    return *ptr;
+  }
   T &operator*() {
     return *ptr;
   }
+  const T *operator->() const {
+    return ptr;
+  }
   T *operator->() {
     return ptr;
+  }
+  operator bool() const {
+    return ptr != NULL;
   }
   bool operator<(const TrackedIntPtr &lhs) const {
     return ptr < lhs.ptr;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2365,6 +2365,9 @@ int OSD::shutdown()
       if (p->second->ref.read() != 1) {
         derr << "pgid " << p->first << " has ref count of "
             << p->second->ref.read() << dendl;
+#ifdef PG_DEBUG_REFS
+	p->second->dump_live_ids();
+#endif
         assert(0);
       }
       p->second->unlock();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -236,7 +236,7 @@ void PG::lock_suspend_timeout(ThreadPool::TPHandle &handle)
   handle.reset_tp_timeout();
 }
 
-void PG::lock(bool no_lockdep)
+void PG::lock(bool no_lockdep) const
 {
   _lock.Lock(no_lockdep);
   // if we have unrecorded dirty state with the lock dropped, there is a bug

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -233,7 +233,7 @@ protected:
    * put() should be called on destruction of some previously copied pointer.
    * put_unlock() when done with the current pointer (_most common_).
    */  
-  Mutex _lock;
+  mutable Mutex _lock;
   atomic_t ref;
 
 #ifdef PG_DEBUG_REFS
@@ -248,8 +248,8 @@ public:
 
 
   void lock_suspend_timeout(ThreadPool::TPHandle &handle);
-  void lock(bool no_lockdep = false);
-  void unlock() {
+  void lock(bool no_lockdep = false) const;
+  void unlock() const {
     //generic_dout(0) << this << " " << info.pgid << " unlock" << dendl;
     assert(!dirty_info);
     assert(!dirty_big_info);


### PR DESCRIPTION
This only really matters when PG_DEBUG_REFS is defined for debugging,
but it's annoying to go chase these down every time you need to use it.

Slightly worried that making ock/unlock const might be a bit dangerous,
but only slightly.  :)