### PR TITLE
test/librbd/fsx.c: disable RBD object map for krbd

### DIFF
--- a/src/test/librbd/fsx.c
+++ b/src/test/librbd/fsx.c
@@ -480,7 +480,8 @@ __librbd_clone(struct rbd_ctx *ctx, const char *src_snapname,
 
 	uint64_t features = RBD_FEATURES_ALL;
 	if (krbd) {
-		features &= ~RBD_FEATURE_EXCLUSIVE_LOCK;
+		features &= ~(RBD_FEATURE_EXCLUSIVE_LOCK |
+		              RBD_FEATURE_OBJECT_MAP);
 	}
 	ret = rbd_clone2(ioctx, ctx->name, src_snapname, ioctx,
 			 dst_imagename, features, order,


### PR DESCRIPTION
RBD object map requires exclusive lock support, which is not
yet available in the kernel client.

Fixes: #10900
Signed-off-by: Jason Dillaman <dillaman@redhat.com>