### PR TITLE
mds: wait for mydir replicas to go away in stopping

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7191,6 +7191,14 @@ bool MDCache::shutdown_pass()
   }
   assert(subtrees.empty());
 
+  // Still replicas of mydir?
+  if (mydir->inode->is_replicated()) {
+    // We do this because otherwise acks to locks could come in after
+    // we cap the log.
+    dout(7) << "waiting for mydir replicas to release: " << *mydir << dendl;
+    return false;
+  }
+
   // (only do this once!)
   if (!mds->mdlog->is_capped()) {
     dout(7) << "capping the log" << dendl;


### PR DESCRIPTION
Previously, while we were waiting for locks related
to mydir to be acknowledged by other ranks, we could
advance to the point of capping the log.  When the
locks were acked, we would try to write to the log
and assert out.  Avoid this by waiting for mydir
to not be replicated before capping the log.

Fixes: #10743
Signed-off-by: John Spray <john.spray@redhat.com>