### PR TITLE
rgw: pass civetweb configurables to civetweb

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -148,6 +148,8 @@ public:
   bool get_val(const string& key, const string& def_val, string *out);
   bool get_val(const string& key, int def_val, int *out);
 
+  map<string, string>& get_config_map() { return config_map; }
+
   string get_framework() { return framework; }
 };
 
@@ -945,6 +947,12 @@ class RGWMongooseFrontend : public RGWFrontend {
   struct mg_context *ctx;
   RGWProcessEnv env;
 
+  void set_conf_default(map<string, string>& m, const string& key, const string& def_val) {
+    if (m.find(key) == m.end()) {
+      m[key] = def_val;
+    }
+  }
+
 public:
   RGWMongooseFrontend(RGWProcessEnv& pe, RGWFrontendConfig *_conf) : conf(_conf), ctx(NULL), env(pe) {
   }
@@ -957,9 +965,23 @@ public:
     char thread_pool_buf[32];
     snprintf(thread_pool_buf, sizeof(thread_pool_buf), "%d", (int)g_conf->rgw_thread_pool_size);
     string port_str;
+    map<string, string> conf_map = conf->get_config_map();
     conf->get_val("port", "80", &port_str);
-    const char *options[] = {"listening_ports", port_str.c_str(), "enable_keep_alive", "yes", "num_threads", thread_pool_buf,
-                             "decode_url", "no", NULL};
+    conf_map.erase("port");
+    conf_map["listening_ports"] = port_str;
+    set_conf_default(conf_map, "enable_keep_alive", "yes");
+    set_conf_default(conf_map, "num_threads", thread_pool_buf);
+    set_conf_default(conf_map, "decode_url", "no");
+
+    const char *options[conf_map.size() * 2 + 1];
+    int i = 0;
+    for (map<string, string>::iterator iter = conf_map.begin(); iter != conf_map.end(); ++iter) {
+      options[i] = iter->first.c_str();
+      options[i + 1] = iter->second.c_str();
+      dout(20)<< "civetweb config: " << options[i] << ": " << (options[i + 1] ? options[i + 1] : "<null>") << dendl;
+      i += 2;
+    }
+    options[i] = NULL;
 
     struct mg_callbacks cb;
     memset((void *)&cb, 0, sizeof(cb));


### PR DESCRIPTION
Fixes: #10907
Backport: firefly

Pass any configurables in the rgw frontends config line to civetweb.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>