### PR TITLE
librbd: fixed ImageWatcher recursive locking issues

### DIFF
--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -220,6 +220,8 @@ namespace librbd {
     void handle_error(uint64_t cookie, int err);
     void acknowledge_notify(uint64_t notify_id, uint64_t handle,
 			    bufferlist &out);
+
+    void schedule_reregister_watch();
     void reregister_watch();
   };
 


### PR DESCRIPTION
It was possible for ImageWatcher to attempt to re-acquire held locks
via context callbacks.  This issue affected resizing/flattening when
no work was required and rescheduling a watch upon two successive
failures.

Fixes: #10899
Signed-off-by: Jason Dillaman <dillaman@redhat.com>