### PR TITLE
osdc: pass fadvise op flags to WritebackHandler read requests

### DIFF
--- a/src/client/ObjecterWriteback.h
+++ b/src/client/ObjecterWriteback.h
@@ -17,7 +17,7 @@ class ObjecterWriteback : public WritebackHandler {
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, Context *onfinish) {
+		    __u32 trunc_seq, int op_flags, Context *onfinish) {
     m_objecter->read_trunc(oid, oloc, off, len, snapid, pbl, 0,
 			   trunc_size, trunc_seq,
 			   new C_OnFinisher(new C_Lock(m_lock, onfinish),

--- a/src/librbd/AioCompletion.h
+++ b/src/librbd/AioCompletion.h
@@ -146,9 +146,6 @@ namespace librbd {
     void set_req(AioRead *req) {
       m_req = req;
     }
-    AioRead *get_req() {
-      return m_req;
-    }
   private:
     CephContext *m_cct;
     AioCompletion *m_completion;

--- a/src/librbd/AioRequest.h
+++ b/src/librbd/AioRequest.h
@@ -77,10 +77,6 @@ namespace librbd {
       return m_read_data;
     }
 
-    int get_op_flags() {
-      return m_op_flags;
-    }
-
     std::map<uint64_t, uint64_t> m_ext_map;
 
     friend class C_AioRead;

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -102,7 +102,7 @@ namespace librbd {
 			     const object_locator_t& oloc,
 			     uint64_t off, uint64_t len, snapid_t snapid,
 			     bufferlist *pbl, uint64_t trunc_size,
-			     __u32 trunc_seq, Context *onfinish)
+			     __u32 trunc_seq, int op_flags, Context *onfinish)
   {
     // on completion, take the mutex and then call onfinish.
     Context *req = new C_Request(m_ictx->cct, onfinish, &m_lock);
@@ -120,10 +120,7 @@ namespace librbd {
       librados::Rados::aio_create_completion(req, context_cb, NULL);
     librados::ObjectReadOperation op;
     op.read(off, len, pbl, NULL);
-    {
-      AioRead *req = (static_cast<C_AioRead *>(onfinish))->get_req();
-      op.set_op_flags2((uint32_t)req->get_op_flags());
-    }
+    op.set_op_flags2(op_flags);
     int flags = m_ictx->get_read_flags(snapid);
     int r = m_ictx->data_ctx.aio_operate(oid.name, rados_completion, &op,
 					 flags, NULL);

--- a/src/librbd/LibrbdWriteback.h
+++ b/src/librbd/LibrbdWriteback.h
@@ -27,7 +27,7 @@ namespace librbd {
     virtual void read(const object_t& oid, uint64_t object_no,
 		      const object_locator_t& oloc, uint64_t off, uint64_t len,
 		      snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		      __u32 trunc_seq, Context *onfinish);
+		      __u32 trunc_seq, int op_flags, Context *onfinish);
 
     // Determine whether a read to this extent could be affected by a write-triggered copy-on-write
     virtual bool may_copy_on_write(const object_t& oid, uint64_t read_off, uint64_t read_len, snapid_t snapid);

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -631,7 +631,7 @@ void ObjectCacher::close_object(Object *ob)
 
 
 
-void ObjectCacher::bh_read(BufferHead *bh)
+void ObjectCacher::bh_read(BufferHead *bh, int op_flags)
 {
   assert(lock.is_locked());
   ldout(cct, 7) << "bh_read on " << *bh << " outstanding reads "
@@ -647,7 +647,8 @@ void ObjectCacher::bh_read(BufferHead *bh)
   writeback_handler.read(bh->ob->get_oid(), bh->ob->get_object_number(),
 			 bh->ob->get_oloc(), bh->start(), bh->length(),
 			 bh->ob->get_snap(), &onfinish->bl,
-			 bh->ob->truncate_size, bh->ob->truncate_seq, onfinish);
+			 bh->ob->truncate_size, bh->ob->truncate_seq,
+			 op_flags, onfinish);
 
   ++reads_outstanding;
 }
@@ -1157,7 +1158,7 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 	  bh_remove(o, bh_it->second);
 	  delete bh_it->second;
 	} else {
-	  bh_read(bh_it->second);
+	  bh_read(bh_it->second, rd->fadvise_flags);
 	  if (success && onfinish) {
 	    ldout(cct, 10) << "readx missed, waiting on " << *bh_it->second
 			   << " off " << bh_it->first << dendl;

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -453,7 +453,7 @@ class ObjectCacher {
   void bh_remove(Object *ob, BufferHead *bh);
 
   // io
-  void bh_read(BufferHead *bh);
+  void bh_read(BufferHead *bh, int op_flags);
   void bh_write(BufferHead *bh);
 
   void trim();

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -15,7 +15,7 @@ class WritebackHandler {
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, Context *onfinish) = 0;
+		    __u32 trunc_seq, int op_flags, Context *onfinish) = 0;
   /**
    * check if a given extent read result may change due to a write
    *

--- a/src/test/osdc/FakeWriteback.cc
+++ b/src/test/osdc/FakeWriteback.cc
@@ -62,7 +62,7 @@ void FakeWriteback::read(const object_t& oid, uint64_t object_no,
 			 const object_locator_t& oloc,
 			 uint64_t off, uint64_t len, snapid_t snapid,
 			 bufferlist *pbl, uint64_t trunc_size,
-			 __u32 trunc_seq, Context *onfinish)
+			 __u32 trunc_seq, int op_flags, Context *onfinish)
 {
   C_Delay *wrapper = new C_Delay(m_cct, onfinish, m_lock, off, pbl, m_delay_ns);
   m_finisher->queue(wrapper, len);

--- a/src/test/osdc/FakeWriteback.h
+++ b/src/test/osdc/FakeWriteback.h
@@ -20,7 +20,7 @@ public:
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, Context *onfinish);
+		    __u32 trunc_seq, int op_flags, Context *onfinish);
 
   virtual ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
 		           uint64_t off, uint64_t len,


### PR DESCRIPTION
librbd was previously attempting to cast the provided Context to
retrieve the fadvise flags.  To eliminate the unsafe cast, now
the fadvise flags are directly passed to the WritebackHandler::read
callback.

Fixes: #10914
Signed-off-by: Jason Dillaman <dillaman@redhat.com>