### PR TITLE
rgw: generate the "Date" HTTP header.

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -147,6 +147,20 @@ int RGWMongoose::send_100_continue()
   return mg_write(conn, buf, sizeof(buf) - 1);
 }
 
+static void dump_date_header(bufferlist &out)
+{
+  char timestr[TIME_BUF_SIZE];
+  const time_t gtime = time(NULL);
+  struct tm result;
+  struct tm const * const tmp = gmtime_r(&gtime, &result);
+
+  if (tmp == NULL)
+    return;
+
+  if (strftime(timestr, sizeof(timestr), "Date: %a, %d %b %Y %H:%M:%S %Z\r\n", tmp))
+    out.append(timestr);
+}
+
 int RGWMongoose::complete_header()
 {
   header_done = true;
@@ -154,6 +168,8 @@ int RGWMongoose::complete_header()
   if (!has_content_length) {
     return 0;
   }
+
+  dump_date_header(header_data);
 
   if (explicit_keepalive)
     header_data.append("Connection: Keep-Alive\r\n");

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -3,6 +3,7 @@
 
 #ifndef CEPH_RGW_MONGOOSE_H
 #define CEPH_RGW_MONGOOSE_H
+#define TIME_BUF_SIZE 128
 
 #include "rgw_client_io.h"
 


### PR DESCRIPTION
I would like to propose initial version of the patch adding support for generation of mandatory HTTP "Date" header to radosgw. Currently, the radosgw lacks support for it. In many cases the problem is hidden because some HTTP servers rectifying it. However, not all of them (eg. civetweb) do that.