### PR TITLE
doc: explain that ceph tell osd.N bench is non-destructive

### DIFF
--- a/doc/rados/operations/control.rst
+++ b/doc/rados/operations/control.rst
@@ -286,7 +286,10 @@ Sends a repair command to OSD.N. To send the command to all OSDs, use ``*``. ::
 
 Runs a simple throughput benchmark against OSD.N, writing ``NUMBER_OF_OBJECTS``
 in write requests of ``BYTES_PER_WRITE`` each. By default, the test
-writes 1 GB in total in 4-MB increments. ::
+writes 1 GB in total in 4-MB increments.
+The benchmark is non-destructive and will not overwrite existing live
+OSD data, but might temporarily affect the performance of clients
+concurrently accessing the OSD. ::
 
 	ceph tell osd.N bench [NUMER_OF_OBJECTS] [BYTES_PER_WRITE]
 


### PR DESCRIPTION
It seems that it's not explicitly documented anywhere whether or not `ceph tell osd.N bench` is destructive. Explain that it is not, but that it may have a temporary adverse effect on the OSD's performance.