### PR TITLE
rbd: disable RBD exclusive locking by default

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -123,6 +123,17 @@ Parameters
 
    Map the image read-only.  Equivalent to -o ro.
 
+.. option:: --image-features features
+
+   Specifies which RBD format 2 features are to be enabled when creating
+   an image. The numbers from the desired features below should be added
+   to compute the parameter value:
+
+   +1: layering support
+   +2: striping v2 support
+   +4: exclusive locking support
+   +8: object map support
+
 .. option:: --image-shared
 
    Specifies that the image will be used concurrently by multiple clients.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -863,7 +863,6 @@ OPTION(rbd_readahead_trigger_requests, OPT_INT, 10) // number of sequential requ
 OPTION(rbd_readahead_max_bytes, OPT_LONGLONG, 512 * 1024) // set to 0 to disable readahead
 OPTION(rbd_readahead_disable_after_bytes, OPT_LONGLONG, 50 * 1024 * 1024) // how many bytes are read in total before readahead is disabled
 OPTION(rbd_clone_copy_on_read, OPT_BOOL, false)
-OPTION(rbd_object_map, OPT_BOOL, false) // whether to enable the RBD object map
 OPTION(rbd_blacklist_on_break_lock, OPT_BOOL, true) // whether to blacklist clients whose lock was broken
 OPTION(rbd_blacklist_expire_seconds, OPT_INT, 0) // number of seconds to blacklist - set to 0 for OSD default
 
@@ -887,7 +886,7 @@ OPTION(rbd_default_format, OPT_INT, 1)
 OPTION(rbd_default_order, OPT_INT, 22)
 OPTION(rbd_default_stripe_count, OPT_U64, 0) // changing requires stripingv2 feature
 OPTION(rbd_default_stripe_unit, OPT_U64, 0) // changing to non-object size requires stripingv2 feature
-OPTION(rbd_default_features, OPT_INT, 7) // only applies to format 2 images
+OPTION(rbd_default_features, OPT_INT, 3) // only applies to format 2 images
 					 // +1 for layering, +2 for stripingv2,
 					 // +4 for exclusive lock, +8 for object map
 

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -85,10 +85,10 @@ void usage()
 "                                              (-l includes snapshots/clones)\n"
 "  info <image-name>                           show information about image size,\n"
 "                                              striping, etc.\n"
-"  create [--order <bits>] [--image-shared] --size <MB> <name>\n"
-"                                              create an empty image\n"
-"  clone [--order <bits>] [--image-shared] <parentsnap> <clonename>\n"
-"                                              clone a snapshot into a COW\n"
+"  create [--order <bits>] [--image-features <features>] [--image-shared]\n"
+"         --size <MB> <name>                   create an empty image\n"
+"  clone [--order <bits>] [--image-features <features>] [--image-shared]\n"
+"        <parentsnap> <clonename>              clone a snapshot into a COW\n"
 "                                              child image\n"
 "  children <snap-name>                        display children of snapshot\n"
 "  flatten <image-name>                        fill clone with parent data\n"
@@ -97,10 +97,10 @@ void usage()
 "  rm <image-name>                             delete an image\n"
 "  export <image-name> <path>                  export image to file\n"
 "                                              \"-\" for stdout\n"
-"  import [--image-shared] <path> <image-name> import image from file\n"
-"                                              (dest defaults\n"
-"                                               as the filename part of file)\n"
-"                                              \"-\" for stdin\n"
+"  import [--image-features <features>] [--image-shared]\n"
+"         <path> <image-name>                  import image from file (dest\n"
+"                                              defaults as the filename part\n"
+"                                              of file). \"-\" for stdin\n"
 "  diff <image-name> [--from-snap <snap-name>] print extents that differ since\n"
 "                                              a previous snap, or image creation\n"
 "  export-diff <image-name> [--from-snap <snap-name>] <path>\n"
@@ -154,6 +154,9 @@ void usage()
 "  --image-format <format-number>     format to use when creating an image\n"
 "                                     format 1 is the original format (default)\n"
 "                                     format 2 supports cloning\n"
+"  --image-features <features>        optional format 2 features to enable\n"
+"                                     +1 layering support, +2 striping v2,\n"
+"                                     +4 exclusive lock, +8 object map\n"
 "  --image-shared                     image will be used concurrently (disables\n"
 "                                     RBD exclusive lock and dependent features)\n"
 "  --id <username>                    rados user (without 'client.'prefix) to\n"
@@ -474,15 +477,11 @@ static int do_create(librbd::RBD &rbd, librados::IoCtx& io_ctx,
     }
     r = rbd.create(io_ctx, imgname, size, order);
   } else {
-    if (features == 0) {
-      features = RBD_FEATURE_LAYERING | RBD_FEATURE_EXCLUSIVE_LOCK;
-    }
-    if (g_conf->rbd_object_map) {
-      features |= RBD_FEATURE_OBJECT_MAP;
-    }
     if ((stripe_unit || stripe_count) &&
 	(stripe_unit != (1ull << *order) && stripe_count != 1)) {
       features |= RBD_FEATURE_STRIPINGV2;
+    } else {
+      features &= ~RBD_FEATURE_STRIPINGV2;
     }
     r = rbd.create3(io_ctx, imgname, size, features, order,
 		    stripe_unit, stripe_count);
@@ -497,14 +496,8 @@ static int do_clone(librbd::RBD &rbd, librados::IoCtx &p_ioctx,
 		    librados::IoCtx &c_ioctx, const char *c_name,
 		    uint64_t features, int *c_order)
 {
-  if (features == 0) {
-    features = (RBD_FEATURES_ALL & ~RBD_FEATURE_OBJECT_MAP);
-  }
-  else if ((features & RBD_FEATURE_LAYERING) != RBD_FEATURE_LAYERING) {
+  if ((features & RBD_FEATURE_LAYERING) != RBD_FEATURE_LAYERING) {
     return -EINVAL;
-  }
-  if (g_conf->rbd_object_map) {
-    features |= RBD_FEATURE_OBJECT_MAP;
   }
 
   return rbd.clone(p_ioctx, p_name, p_snapname, c_ioctx, c_name, features,
@@ -2620,7 +2613,10 @@ int main(int argc, const char **argv)
   bool format_specified = false,
     output_format_specified = false;
   int format = 1;
-  uint64_t features = RBD_FEATURE_LAYERING | RBD_FEATURE_EXCLUSIVE_LOCK;
+
+  uint64_t features = g_conf->rbd_default_features;
+  bool shared = false;
+
   const char *imgname = NULL, *snapname = NULL, *destname = NULL,
     *dest_poolname = NULL, *dest_snapname = NULL, *path = NULL,
     *devpath = NULL, *lock_cookie = NULL, *lock_client = NULL,
@@ -2723,8 +2719,15 @@ int main(int argc, const char **argv)
       progress = false;
     } else if (ceph_argparse_flag(args, i , "--allow-shrink", (char *)NULL)) {
       resize_allow_shrink = true;
+    } else if (ceph_argparse_flag(args, i, "--image-features", (char *)NULL)) {
+      features = strict_strtol(val.c_str(), 10, &parse_err);
+      if (!parse_err.empty()) {
+	cerr << "rbd: error parsing --image-features: " << parse_err
+             << std::endl;
+	return EXIT_FAILURE;
+      }
     } else if (ceph_argparse_flag(args, i, "--image-shared", (char *)NULL)) {
-      features &= ~(RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_OBJECT_MAP);
+      shared = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--format", (char *) NULL)) {
       long long ret = strict_strtoll(val.c_str(), 10, &parse_err);
       if (parse_err.empty()) {
@@ -2742,6 +2745,16 @@ int main(int argc, const char **argv)
     } else {
       ++i;
     }
+  }
+
+  if (shared) {
+    features &= ~(RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_OBJECT_MAP);
+  }
+  if (((features & RBD_FEATURE_EXCLUSIVE_LOCK) == 0) &&
+      ((features & RBD_FEATURE_OBJECT_MAP) != 0)) {
+    cerr << "rbd: exclusive lock image feature must be enabled to use "
+         << "the object map" << std::endl;
+    return EXIT_FAILURE;
   }
 
   common_init_finish(g_ceph_context);

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -5,10 +5,10 @@
                                                 (-l includes snapshots/clones)
     info <image-name>                           show information about image size,
                                                 striping, etc.
-    create [--order <bits>] [--image-shared] --size <MB> <name>
-                                                create an empty image
-    clone [--order <bits>] [--image-shared] <parentsnap> <clonename>
-                                                clone a snapshot into a COW
+    create [--order <bits>] [--image-features <features>] [--image-shared]
+           --size <MB> <name>                   create an empty image
+    clone [--order <bits>] [--image-features <features>] [--image-shared]
+          <parentsnap> <clonename>              clone a snapshot into a COW
                                                 child image
     children <snap-name>                        display children of snapshot
     flatten <image-name>                        fill clone with parent data
@@ -17,10 +17,10 @@
     rm <image-name>                             delete an image
     export <image-name> <path>                  export image to file
                                                 "-" for stdout
-    import [--image-shared] <path> <image-name> import image from file
-                                                (dest defaults
-                                                 as the filename part of file)
-                                                "-" for stdin
+    import [--image-features <features>] [--image-shared]
+           <path> <image-name>                  import image from file (dest
+                                                defaults as the filename part
+                                                of file). "-" for stdin
     diff <image-name> [--from-snap <snap-name>] print extents that differ since
                                                 a previous snap, or image creation
     export-diff <image-name> [--from-snap <snap-name>] <path>
@@ -74,6 +74,9 @@
     --image-format <format-number>     format to use when creating an image
                                        format 1 is the original format (default)
                                        format 2 supports cloning
+    --image-features <features>        optional format 2 features to enable
+                                       +1 layering support, +2 striping v2,
+                                       +4 exclusive lock, +8 object map
     --image-shared                     image will be used concurrently (disables
                                        RBD exclusive lock and dependent features)
     --id <username>                    rados user (without 'client.'prefix) to

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -138,7 +138,7 @@ def check_default_params(format, order=None, features=None, stripe_count=None,
 
                     expected_features = features
                     if expected_features is None or format == 1:
-                        expected_features = 0 if format == 1 else 7
+                        expected_features = 0 if format == 1 else 3
                     eq(expected_features, image.features())
 
                     expected_stripe_count = stripe_count


### PR DESCRIPTION
Added a new config option which will enable the new RBD
exclusive lock feature via the rbd CLI.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>