### PR TITLE
mon: ceph osd setcrushmap: test_with_crushtool improvements

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -229,7 +229,8 @@ noinst_HEADERS += \
 	common/Cycles.h \
 	common/Initialize.h \
 	common/ContextCompletion.h \
-	common/bit_vector.hpp
+	common/bit_vector.hpp \
+	common/SubProcess.h
 
 if ENABLE_XIO
 noinst_HEADERS += \

--- a/src/common/SubProcess.h
+++ b/src/common/SubProcess.h
@@ -1,0 +1,329 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph distributed storage system
+ *
+ * Copyright (C) 2015 Mirantis Inc
+ *
+ * Author: Mykola Golub <mgolub@mirantis.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#ifndef SUB_PROCESS_H
+#define SUB_PROCESS_H
+
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sstream>
+#include <vector>
+
+#include <include/assert.h>
+#include <common/errno.h>
+
+/**
+ * SubProcess:
+ * A helper class to spawn a subprocess.
+ *
+ * Example:
+ *
+ *   SubProcess cat("cat", true, true);
+ *   if (cat.spawn() != 0) {
+ *     std::cerr << "cat failed: " << cat.err() << std::endl;
+ *     return false;
+ *   }
+ *   write_to_fd(cat.stdout(), "hello world!\n");
+ *   cat.close_stdout();
+ *   read_from_fd(cat.stdin(), buf);
+ *   if (cat.join() != 0) {
+ *     std::cerr << cat.err() << std::endl;
+ *     return false;
+ *   }
+ */
+
+class SubProcess {
+public:
+  SubProcess(const char *cmd, bool pipe_stdin = false, bool pipe_stdout = false,
+	     bool pipe_stderr = false);
+  virtual ~SubProcess();
+
+  void add_cmd_args(const char *arg, ...);
+  void add_cmd_arg(const char *arg);
+
+  virtual int spawn(); // Returns 0 on success or -errno on failure.
+  virtual int join();  // Returns exit code (0 on success).
+
+  bool is_spawned() const { return pid > 0; }
+
+  int stdin() const;
+  int stdout() const;
+  int stderr() const;
+
+  void close_stdin();
+  void close_stdout();
+  void close_stderr();
+
+  void kill(int signo = SIGTERM) const;
+
+  const char* err() const;
+
+protected:
+  bool is_child() const { return pid == 0; }
+  virtual void exec();
+
+private:
+  void close(int &fd);
+
+protected:
+  std::string cmd;
+  std::vector<std::string> cmd_args;
+  bool pipe_stdin;
+  bool pipe_stdout;
+  bool pipe_stderr;
+  int stdin_pipe_out_fd;
+  int stdout_pipe_in_fd;
+  int stderr_pipe_in_fd;
+  int pid;
+  std::ostringstream errstr;
+};
+
+SubProcess::SubProcess(const char *cmd_, bool stdin, bool stdout, bool stderr) :
+  cmd(cmd_),
+  cmd_args(),
+  pipe_stdin(stdin),
+  pipe_stdout(stdout),
+  pipe_stderr(stderr),
+  stdin_pipe_out_fd(-1),
+  stdout_pipe_in_fd(-1),
+  stderr_pipe_in_fd(-1),
+  pid(-1),
+  errstr() {
+}
+
+SubProcess::~SubProcess() {
+  assert(!is_spawned());
+  assert(stdin_pipe_out_fd == -1);
+  assert(stdout_pipe_in_fd == -1);
+  assert(stderr_pipe_in_fd == -1);
+}
+
+void SubProcess::add_cmd_args(const char *arg, ...) {
+  assert(!is_spawned());
+
+  va_list ap;
+  va_start(ap, arg);
+  const char *p = arg;
+  do {
+    add_cmd_arg(p);
+    p = va_arg(ap, const char*);
+  } while (p != NULL);
+  va_end(ap);
+}
+
+void SubProcess::add_cmd_arg(const char *arg) {
+  assert(!is_spawned());
+
+  cmd_args.push_back(arg);
+}
+
+int SubProcess::stdin() const {
+  assert(is_spawned());
+  assert(pipe_stdin);
+
+  return stdin_pipe_out_fd;
+}
+
+int SubProcess::stdout() const {
+  assert(is_spawned());
+  assert(pipe_stdout);
+
+  return stdout_pipe_in_fd;
+}
+
+int SubProcess::stderr() const {
+  assert(is_spawned());
+  assert(pipe_stderr);
+
+  return stderr_pipe_in_fd;
+}
+
+void SubProcess::close(int &fd) {
+  if (fd == -1)
+    return;
+
+  ::close(fd);
+  fd = -1;
+}
+
+void SubProcess::close_stdin() {
+  assert(is_spawned());
+  assert(pipe_stdin);
+
+  close(stdin_pipe_out_fd);
+}
+
+void SubProcess::close_stdout() {
+  assert(is_spawned());
+  assert(pipe_stdout);
+
+  close(stdout_pipe_in_fd);
+}
+
+void SubProcess::close_stderr() {
+  assert(is_spawned());
+  assert(pipe_stderr);
+
+  close(stderr_pipe_in_fd);
+}
+
+void SubProcess::kill(int signo) const {
+  assert(is_spawned());
+
+  int ret = ::kill(pid, signo);
+  assert(ret == 0);
+}
+
+const char* SubProcess::err() const {
+  return errstr.str().c_str();
+}
+
+int SubProcess::spawn() {
+  assert(!is_spawned());
+  assert(stdin_pipe_out_fd == -1);
+  assert(stdout_pipe_in_fd == -1);
+  assert(stderr_pipe_in_fd == -1);
+
+  enum { IN = 0, OUT = 1 };
+
+  int ipipe[2], opipe[2], epipe[2];
+
+  ipipe[0] = ipipe[1] = opipe[0] = opipe[1] = epipe[0] = epipe[1] = -1;
+
+  int ret = 0;
+
+  if ((pipe_stdin  && ::pipe(ipipe) == -1) ||
+      (pipe_stdout && ::pipe(opipe) == -1) ||
+      (pipe_stderr && ::pipe(epipe) == -1)) {
+    ret = -errno;
+    errstr << "pipe failed: " << cpp_strerror(errno);
+    goto fail;
+  }
+
+  pid = fork();
+
+  if (pid > 0) { // Parent
+    stdin_pipe_out_fd = ipipe[OUT]; close(ipipe[IN ]);
+    stdout_pipe_in_fd = opipe[IN ]; close(opipe[OUT]);
+    stderr_pipe_in_fd = epipe[IN ]; close(epipe[OUT]);
+    return 0;
+  }
+
+  if (pid == 0) { // Child
+    close(ipipe[OUT]);
+    close(opipe[IN ]);
+    close(epipe[IN ]);
+
+    if (ipipe[IN] != -1 && ipipe[IN] != STDIN_FILENO) {
+      ::dup2(ipipe[IN], STDIN_FILENO);
+      close(ipipe[IN]);
+    }
+    if (opipe[OUT] != -1 && opipe[OUT] != STDOUT_FILENO) {
+      ::dup2(opipe[OUT], STDOUT_FILENO);
+      close(opipe[OUT]);
+    }
+    if (epipe[OUT] != -1 && epipe[OUT] != STDERR_FILENO) {
+      ::dup2(epipe[OUT], STDERR_FILENO);
+      close(epipe[OUT]);
+    }
+
+    int maxfd = sysconf(_SC_OPEN_MAX);
+    if (maxfd == -1)
+      maxfd = 16384;
+    for (int fd = 0; fd <= maxfd; fd++) {
+      if (fd == STDIN_FILENO && pipe_stdin)
+	continue;
+      if (fd == STDOUT_FILENO && pipe_stdout)
+	continue;
+      if (fd == STDERR_FILENO && pipe_stderr)
+	continue;
+      ::close(fd);
+    }
+
+    exec();
+    assert(0); // Never reached
+  }
+
+  ret = -errno;
+  errstr << "fork failed: " << cpp_strerror(errno);
+
+fail:
+  close(ipipe[0]);
+  close(ipipe[1]);
+  close(opipe[0]);
+  close(opipe[1]);
+  close(epipe[0]);
+  close(epipe[1]);
+
+  return ret;
+}
+
+void SubProcess::exec() {
+  assert(is_child());
+
+  std::vector<const char *> args;
+  args.push_back(cmd.c_str());
+  for (std::vector<std::string>::iterator i = cmd_args.begin();
+       i != cmd_args.end();
+       i++) {
+    args.push_back(i->c_str());
+  }
+  args.push_back(NULL);
+
+  int ret = execvp(cmd.c_str(), (char * const *)&args[0]);
+  assert(ret == -1);
+
+  std::ostringstream err;
+  err << cmd << ": exec failed: " << cpp_strerror(errno) << "\n";
+  write(STDERR_FILENO, err.str().c_str(), err.str().size());
+  _exit(EXIT_FAILURE);
+}
+
+int SubProcess::join() {
+  assert(is_spawned());
+
+  close(stdin_pipe_out_fd);
+  close(stdout_pipe_in_fd);
+  close(stderr_pipe_in_fd);
+
+  int status;
+
+  while (waitpid(pid, &status, 0) == -1)
+    assert(errno == EINTR);
+
+  pid = -1;
+
+  if (WIFEXITED(status)) {
+    if (WEXITSTATUS(status) != EXIT_SUCCESS)
+      errstr << cmd << ": exit status: " << WEXITSTATUS(status);
+    return WEXITSTATUS(status);
+  }
+  if (WIFSIGNALED(status)) {
+    errstr << cmd << ": got signal: " << WTERMSIG(status);
+    return 128 + WTERMSIG(status);
+  }
+  errstr << cmd << ": waitpid: unknown status returned\n";
+  return EXIT_FAILURE;
+}
+
+#endif

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -25,6 +25,7 @@ OPTION(mon_host, OPT_STR, "")
 OPTION(lockdep, OPT_BOOL, false)
 OPTION(run_dir, OPT_STR, "/var/run/ceph")       // the "/var/run/ceph" dir, created on daemon startup
 OPTION(admin_socket, OPT_STR, "$run_dir/$cluster-$name.asok") // default changed by common_preinit()
+OPTION(crushtool, OPT_STR, "crushtool") // crushtool utility path
 
 OPTION(daemonize, OPT_BOOL, false) // default changed by common_preinit()
 OPTION(pid_file, OPT_STR, "") // default changed by common_preinit()

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -353,9 +353,9 @@ void CrushTester::write_integer_indexed_scalar_data_string(vector<string> &dst, 
   dst.push_back( data_buffer.str() );
 }
 
-int CrushTester::test_with_crushtool(const char *crushtool_cmd)
+int CrushTester::test_with_crushtool(const char *crushtool_cmd, int timeout)
 {
-  SubProcess crushtool(crushtool_cmd, true, false, true);
+  SubProcessTimed crushtool(crushtool_cmd, true, false, true, timeout);
   crushtool.add_cmd_args("-i", "-", "--test", "--output-csv", NULL);
   int ret = crushtool.spawn();
   if (ret != 0) {

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -353,9 +353,9 @@ void CrushTester::write_integer_indexed_scalar_data_string(vector<string> &dst, 
   dst.push_back( data_buffer.str() );
 }
 
-int CrushTester::test_with_crushtool()
+int CrushTester::test_with_crushtool(const char *crushtool_cmd)
 {
-  SubProcess crushtool("crushtool", true, false, true);
+  SubProcess crushtool(crushtool_cmd, true, false, true);
   crushtool.add_cmd_args("-i", "-", "--test", "--output-csv", NULL);
   int ret = crushtool.spawn();
   if (ret != 0) {

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -1,14 +1,12 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
 #include "CrushTester.h"
 
 #include <algorithm>
 #include <stdlib.h>
-/* fork */
-#include <unistd.h>
-/* waitpid */
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <common/errno.h>
+
+#include <common/SubProcess.h>
 
 void CrushTester::set_device_weight(int dev, float f)
 {
@@ -357,72 +355,31 @@ void CrushTester::write_integer_indexed_scalar_data_string(vector<string> &dst, 
 
 int CrushTester::test_with_crushtool()
 {
-  vector<const char *> cmd_args;
-  cmd_args.push_back("crushtool");
-  cmd_args.push_back("-i");
-  cmd_args.push_back("-");
-  cmd_args.push_back("--test");
-  cmd_args.push_back("--output-csv");
-  cmd_args.push_back(NULL);
-
-  int pipefds[2];
-  if (::pipe(pipefds) == -1) {
-    int r = errno;
-    err << "error creating pipe: " << cpp_strerror(r) << "\n";
-    return -r;
+  SubProcess crushtool("crushtool", true, false, true);
+  crushtool.add_cmd_args("-i", "-", "--test", "--output-csv", NULL);
+  int ret = crushtool.spawn();
+  if (ret != 0) {
+    err << "failed run crushtool: " << crushtool.err();
+    return ret;
   }
-
-  int fpid = fork();
-  if (fpid < 0) {
-    int r = errno;
-    err << "unable to fork(): " << cpp_strerror(r);
-    ::close(pipefds[0]);
-    ::close(pipefds[1]);
-    return -r;
-  } else if (fpid == 0) {
-    ::close(pipefds[1]);
-    ::dup2(pipefds[0], STDIN_FILENO);
-    ::close(pipefds[0]);
-    ::close(1);
-    ::close(2);
-    int r = execvp(cmd_args[0], (char * const *)&cmd_args[0]);
-    if (r < 0)
-      exit(errno);
-    // we should never reach this
-    exit(EINVAL);
-  }
-  ::close(pipefds[0]);
 
   bufferlist bl;
   ::encode(crush, bl);
-  bl.write_fd(pipefds[1]);
-  ::close(pipefds[1]);
-
-  int status;
-  int r = waitpid(fpid, &status, 0);
-  assert(r == fpid);
-
-  if (!WIFEXITED(status)) {
-    assert(WIFSIGNALED(status));
-    err << "error testing crush map\n";
+  bl.write_fd(crushtool.stdin());
+  crushtool.close_stdin();
+  bl.clear();
+  ret = bl.read_fd(crushtool.stderr(), 100 * 1024);
+  if (ret < 0) {
+    err << "failed read from crushtool: " << cpp_strerror(-ret);
+    return ret;
+  }
+  bl.write_stream(err);
+  if (crushtool.join() != 0) {
+    err << crushtool.err();
     return -EINVAL;
   }
 
-  r = WEXITSTATUS(status);
-  if (r == 0) {
-    // major success!
-    return 0;
-  }
-
-  if (r == ENOENT) {
-    err << "unable to find 'crushtool' to test the map";
-    return -ENOENT;
-  }
-
-  // something else entirely happened
-  // log it and consider an invalid crush map
-  err << "error running crushmap through crushtool: " << cpp_strerror(r);
-  return -r;
+  return 0;
 }
 
 int CrushTester::test()

--- a/src/crush/CrushTester.h
+++ b/src/crush/CrushTester.h
@@ -334,7 +334,7 @@ public:
   }
 
   int test();
-  int test_with_crushtool();
+  int test_with_crushtool(const char *crushtool_cmd = "crushtool");
 };
 
 #endif

--- a/src/crush/CrushTester.h
+++ b/src/crush/CrushTester.h
@@ -334,7 +334,8 @@ public:
   }
 
   int test();
-  int test_with_crushtool(const char *crushtool_cmd = "crushtool");
+  int test_with_crushtool(const char *crushtool_cmd = "crushtool",
+			  int timeout = 0);
 };
 
 #endif

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4526,7 +4526,7 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
     dout(10) << " testing map" << dendl;
     stringstream ess;
     CrushTester tester(crush, ess);
-    int r = tester.test_with_crushtool();
+    int r = tester.test_with_crushtool(g_conf->crushtool.c_str());
     if (r < 0) {
       derr << "error on crush map: " << ess.str() << dendl;
       ss << "Failed to parse crushmap: " << ess.str();

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4526,7 +4526,11 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
     dout(10) << " testing map" << dendl;
     stringstream ess;
     CrushTester tester(crush, ess);
-    int r = tester.test_with_crushtool(g_conf->crushtool.c_str());
+    // XXX: Use mon_lease as a timeout value for crushtool.
+    // If crushtool takes longer than mon_lease and blocks the mon, an election
+    // will happen and the command will run again, indefinitely.
+    int r = tester.test_with_crushtool(g_conf->crushtool.c_str(),
+				       g_conf->mon_lease);
     if (r < 0) {
       derr << "error on crush map: " << ess.str() << dendl;
       ss << "Failed to parse crushmap: " << ess.str();

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -940,6 +940,20 @@ target_link_libraries(unittest_on_exit
 set_target_properties(unittest_on_exit PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 
+# unittest_subprocess
+set(unittest_subprocess_srcs test_subprocess.cc)
+add_executable(unittest_subprocess
+  ${unittest_subprocess_srcs}
+  $<TARGET_OBJECTS:heap_profiler_objs>
+  )
+target_link_libraries(unittest_subprocess
+  global
+  ${CMAKE_DL_LIBS}
+  ${TCMALLOC_LIBS}
+  ${UNITTEST_LIBS})
+set_target_properties(unittest_subprocess PROPERTIES COMPILE_FLAGS
+  ${UNITTEST_CXX_FLAGS})
+
 if(${WITH_RADOSGW})
   # test_cors
   set(test_cors_srcs test_cors.cc)

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -682,6 +682,11 @@ unittest_bit_vector_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_bit_vector_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 check_PROGRAMS += unittest_bit_vector
 
+unittest_subprocess_SOURCES = test/test_subprocess.cc
+unittest_subprocess_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD)
+unittest_subprocess_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+check_PROGRAMS += unittest_subprocess
+
 check_SCRIPTS += test/pybind/test_ceph_argparse.py
 
 if WITH_RADOSGW

--- a/src/test/test_subprocess.cc
+++ b/src/test/test_subprocess.cc
@@ -166,3 +166,103 @@ TEST(SubProcess, Subshell)
   std::cerr << "err: " << sh.err() << std::endl;
   ASSERT_FALSE(sh.err()[0] == '\0');
 }
+
+TEST(SubProcessTimed, True)
+{
+  SubProcessTimed p("true", false, false, false, 10);
+  ASSERT_EQ(p.spawn(), 0);
+  ASSERT_EQ(p.join(), 0);
+  ASSERT_TRUE(p.err()[0] == '\0');
+}
+
+TEST(SubProcessTimed, SleepNoTimeout)
+{
+  SubProcessTimed sleep("sleep", false, false, false, 0);
+  sleep.add_cmd_arg("1");
+
+  ASSERT_EQ(sleep.spawn(), 0);
+  ASSERT_EQ(sleep.join(), 0);
+  ASSERT_TRUE(sleep.err()[0] == '\0');
+}
+
+TEST(SubProcessTimed, Killed)
+{
+  SubProcessTimed cat("cat", true, true, true, 5);
+
+  ASSERT_EQ(cat.spawn(), 0);
+  cat.kill();
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(cat.stdout(), buf));
+  ASSERT_TRUE(buf.empty());
+  ASSERT_TRUE(read_from_fd(cat.stderr(), buf));
+  ASSERT_TRUE(buf.empty());
+  ASSERT_EQ(cat.join(), 128 + SIGTERM);
+  std::cerr << "err: " << cat.err() << std::endl;
+  ASSERT_FALSE(cat.err()[0] == '\0');
+}
+
+TEST(SubProcessTimed, SleepTimedout)
+{
+  SubProcessTimed sleep("sleep", false, false, true, 1);
+  sleep.add_cmd_arg("10");
+
+  ASSERT_EQ(sleep.spawn(), 0);
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(sleep.stderr(), buf));
+  std::cerr << "stderr: " << buf;
+  ASSERT_FALSE(buf.empty());
+  ASSERT_EQ(sleep.join(), 128 + SIGKILL);
+  std::cerr << "err: " << sleep.err() << std::endl;
+  ASSERT_FALSE(sleep.err()[0] == '\0');
+}
+
+TEST(SubProcessTimed, SubshellNoTimeout)
+{
+  SubProcessTimed sh("/bin/sh", true, true, true, 0);
+  sh.add_cmd_args("-c", "cat >&2", NULL);
+  ASSERT_EQ(sh.spawn(), 0);
+  std::string msg("the quick brown fox jumps over the lazy dog");
+  int n = write(sh.stdin(), msg.c_str(), msg.size());
+  ASSERT_EQ(n, (int)msg.size());
+  sh.close_stdin();
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(sh.stdout(), buf));
+  std::cerr << "stdout: " << buf << std::endl;
+  ASSERT_TRUE(buf.empty());
+  ASSERT_TRUE(read_from_fd(sh.stderr(), buf));
+  std::cerr << "stderr: " << buf << std::endl;
+  ASSERT_EQ(buf, msg);
+  ASSERT_EQ(sh.join(), 0);
+  ASSERT_TRUE(sh.err()[0] == '\0');
+}
+
+TEST(SubProcessTimed, SubshellKilled)
+{
+  SubProcessTimed sh("/bin/sh", true, true, true, 10);
+  sh.add_cmd_args("-c", "sh -c cat", NULL);
+  ASSERT_EQ(sh.spawn(), 0);
+  std::string msg("etaoin shrdlu");
+  int n = write(sh.stdin(), msg.c_str(), msg.size());
+  ASSERT_EQ(n, (int)msg.size());
+  sh.kill();
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(sh.stderr(), buf));
+  ASSERT_TRUE(buf.empty());
+  ASSERT_EQ(sh.join(), 128 + SIGTERM);
+  std::cerr << "err: " << sh.err() << std::endl;
+  ASSERT_FALSE(sh.err()[0] == '\0');
+}
+
+TEST(SubProcessTimed, SubshellTimedout)
+{
+  SubProcessTimed sh("/bin/sh", true, true, true, 1, SIGTERM);
+  sh.add_cmd_args("-c", "sleep 1000& cat; NEVER REACHED", NULL);
+  ASSERT_EQ(sh.spawn(), 0);
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(sh.stderr(), buf));
+  std::cerr << "stderr: " << buf;
+  ASSERT_FALSE(buf.empty());
+  ASSERT_EQ(sh.join(), 128 + SIGTERM);
+  std::cerr << "err: " << sh.err() << std::endl;
+  ASSERT_FALSE(sh.err()[0] == '\0');
+}

--- a/src/test/test_subprocess.cc
+++ b/src/test/test_subprocess.cc
@@ -1,0 +1,168 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph distributed storage system
+ *
+ * Copyright (C) 2015 Mirantis Inc
+ *
+ * Author: Mykola Golub <mgolub@mirantis.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#include <unistd.h>
+
+#include <iostream>
+
+#include "common/SubProcess.h"
+#include "common/safe_io.h"
+#include "gtest/gtest.h"
+
+bool read_from_fd(int fd, std::string &out) {
+  out.clear();
+  char buf[1024];
+  ssize_t n = safe_read(fd, buf, sizeof(buf) - 1);
+  if (n < 0)
+    return false;
+  buf[n] = '\0';
+  out = buf;
+  return true;
+}
+
+TEST(SubProcess, True)
+{
+  SubProcess p("true");
+  ASSERT_EQ(p.spawn(), 0);
+  ASSERT_EQ(p.join(), 0);
+  ASSERT_TRUE(p.err()[0] == '\0');
+}
+
+TEST(SubProcess, False)
+{
+  SubProcess p("false");
+  ASSERT_EQ(p.spawn(), 0);
+  ASSERT_EQ(p.join(), 1);
+  ASSERT_FALSE(p.err()[0] == '\0');
+}
+
+TEST(SubProcess, NotFound)
+{
+  SubProcess p("NOTEXISTENTBINARY", false, false, true);
+  ASSERT_EQ(p.spawn(), 0);
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(p.stderr(), buf));
+  std::cerr << "stderr: " << buf;
+  ASSERT_EQ(p.join(), 1);
+  std::cerr << "err: " << p.err() << std::endl;
+  ASSERT_FALSE(p.err()[0] == '\0');
+}
+
+TEST(SubProcess, Echo)
+{
+  SubProcess echo("echo", false, true);
+  echo.add_cmd_args("1", "2", "3", NULL);
+
+  ASSERT_EQ(echo.spawn(), 0);
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(echo.stdout(), buf));
+  std::cerr << "stdout: " << buf;
+  ASSERT_EQ(buf, "1 2 3\n");
+  ASSERT_EQ(echo.join(), 0);
+  ASSERT_TRUE(echo.err()[0] == '\0');
+}
+
+TEST(SubProcess, Cat)
+{
+  SubProcess cat("cat", true, true, true);
+
+  ASSERT_EQ(cat.spawn(), 0);
+  std::string msg("to my, trociny!");
+  int n = write(cat.stdin(), msg.c_str(), msg.size());
+  ASSERT_EQ(n, (int)msg.size());
+  cat.close_stdin();
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(cat.stdout(), buf));
+  std::cerr << "stdout: " << buf << std::endl;
+  ASSERT_EQ(buf, msg);
+  ASSERT_TRUE(read_from_fd(cat.stderr(), buf));
+  ASSERT_EQ(buf, "");
+  ASSERT_EQ(cat.join(), 0);
+  ASSERT_TRUE(cat.err()[0] == '\0');
+}
+
+TEST(SubProcess, CatDevNull)
+{
+  SubProcess cat("cat", true, true, true);
+  cat.add_cmd_arg("/dev/null");
+
+  ASSERT_EQ(cat.spawn(), 0);
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(cat.stdout(), buf));
+  ASSERT_EQ(buf, "");
+  ASSERT_TRUE(read_from_fd(cat.stderr(), buf));
+  ASSERT_EQ(buf, "");
+  ASSERT_EQ(cat.join(), 0);
+  ASSERT_TRUE(cat.err()[0] == '\0');
+}
+
+TEST(SubProcess, Killed)
+{
+  SubProcessTimed cat("cat", true, true);
+
+  ASSERT_EQ(cat.spawn(), 0);
+  cat.kill();
+  ASSERT_EQ(cat.join(), 128 + SIGTERM);
+  std::cerr << "err: " << cat.err() << std::endl;
+  ASSERT_FALSE(cat.err()[0] == '\0');
+}
+
+TEST(SubProcess, CatWithArgs)
+{
+  SubProcess cat("cat", true, true, true);
+  cat.add_cmd_args("/dev/stdin", "/dev/null", "/NOTEXIST", NULL);
+
+  ASSERT_EQ(cat.spawn(), 0);
+  std::string msg("Hello, Word!");
+  int n = write(cat.stdin(), msg.c_str(), msg.size());
+  ASSERT_EQ(n, (int)msg.size());
+  cat.close_stdin();
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(cat.stdout(), buf));
+  std::cerr << "stdout: " << buf << std::endl;
+  ASSERT_EQ(buf, msg);
+  ASSERT_TRUE(read_from_fd(cat.stderr(), buf));
+  std::cerr << "stderr: " << buf;
+  ASSERT_FALSE(buf.empty());
+  ASSERT_EQ(cat.join(), 1);
+  std::cerr << "err: " << cat.err() << std::endl;
+  ASSERT_FALSE(cat.err()[0] == '\0');
+}
+
+TEST(SubProcess, Subshell)
+{
+  SubProcess sh("/bin/sh", true, true, true);
+  sh.add_cmd_args("-c",
+      "sleep 0; "
+      "cat; "
+      "echo 'error from subshell' >&2; "
+      "/bin/sh -c 'exit 13'", NULL);
+  ASSERT_EQ(sh.spawn(), 0);
+  std::string msg("hello via subshell");
+  int n = write(sh.stdin(), msg.c_str(), msg.size());
+  ASSERT_EQ(n, (int)msg.size());
+  sh.close_stdin();
+  std::string buf;
+  ASSERT_TRUE(read_from_fd(sh.stdout(), buf));
+  std::cerr << "stdout: " << buf << std::endl;
+  ASSERT_EQ(buf, msg);
+  ASSERT_TRUE(read_from_fd(sh.stderr(), buf));
+  std::cerr << "stderr: " << buf;
+  ASSERT_EQ(buf, "error from subshell\n");
+  ASSERT_EQ(sh.join(), 13);
+  std::cerr << "err: " << sh.err() << std::endl;
+  ASSERT_FALSE(sh.err()[0] == '\0');
+}

--- a/src/test/vstart_wrapper.sh
+++ b/src/test/vstart_wrapper.sh
@@ -17,6 +17,7 @@
 
 source test/mon/mon-test-helpers.sh
 
+export CEPH_VSTART_WRAPPER=1
 export CEPH_DIR="$PWD/testdir/test-$CEPH_PORT"
 export CEPH_DEV_DIR="$CEPH_DIR/dev"
 export CEPH_OUT_DIR="$CEPH_DIR/out"
@@ -27,7 +28,7 @@ function vstart_setup()
     mkdir -p $CEPH_DEV_DIR
     trap "teardown $CEPH_DIR" EXIT
     export LC_ALL=C # some tests are vulnerable to i18n
-    export PATH=.:$PATH
+    export PATH="${CEPH_DIR}:$(pwd):${PATH}"
     ./vstart.sh \
         -o 'paxos propose interval = 0.01' \
         -n -l $CEPH_START || return 1

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -12,10 +12,13 @@ else
         [ -z $OBJCLASS_PATH ] && OBJCLASS_PATH=$CEPH_LIB/rados-classes
 fi
 
+if [ -z "${CEPH_VSTART_WRAPPER}" ]; then
+    PATH=$(pwd):$PATH
+fi
+
 export PYTHONPATH=./pybind
 export LD_LIBRARY_PATH=$CEPH_LIB
 export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
-
 
 # abort on failure
 set -e


### PR DESCRIPTION
This set of patches improves current implementation of sandboxing crush map testing when 'ceph osd setcrushmap' is run:

* Use _exit(2) instead of exit(2) if exec(3) failed (does not call the atexit functions, removing asock and pid files in the child process).
* Close all parent descriptors before exec(3).
* Log crushtool stderr.
* Allow to specify crushtool path in config.
* Add safeguard timeout for running crushtool.
* Better test coverage.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>