### PR TITLE
librbd: fixed snap create race conditions

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -895,6 +895,10 @@ void ImageWatcher::handle_payload(const SnapCreatePayload &payload,
 
     ::encode(ResponseMessage(r), *out);
     if (r == 0) {
+      // increment now to avoid race due to the delayed notification
+      Mutex::Locker lictx(m_image_ctx.refresh_lock);
+      ++m_image_ctx.refresh_seq;
+
       // cannot notify within a notificiation
       FunctionContext *ctx = new FunctionContext(
 	boost::bind(&ImageWatcher::finalize_header_update, this));


### PR DESCRIPTION
Since the post-snap create header update runs asynchrously
in a finalizer callback, it's possible that the snapshot
is not immediately visible.  Also, if a proxied snap create
message is replayed, it's possible for the client to receive
a EEXISTS error.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>