### PR TITLE
osdc: watch error callback invoked on cancelled context

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -491,7 +491,14 @@ struct C_DoWatchError : public Context {
     info->_queued_async();
   }
   void finish(int r) {
-    info->watch_context->handle_error(info->get_cookie(), err);
+    objecter->rwlock.get_read();
+    bool canceled = info->canceled;
+    objecter->rwlock.put_read();
+
+    if (!canceled) {
+      info->watch_context->handle_error(info->get_cookie(), err);
+    }
+
     info->finished_async();
     info->put();
     objecter->_linger_callback_finish();


### PR DESCRIPTION
The C_DoWatchError context did not verify whether or not the
watch was cancelled prior to invoking the callback.  This
resulted in sporadic crashes when reconnect errors bubbled
up to destroyed objects.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>