### PR TITLE
doc: update doc with latest code

### DIFF
--- a/doc/dev/osd_internals/map_message_handling.rst
+++ b/doc/dev/osd_internals/map_message_handling.rst
@@ -66,7 +66,7 @@ MOSDPGOps follow the following process:
   1. OSD::handle_op: validates permissions and crush mapping.
      discard the request if they are not connected and the client cannot get the reply ( See OSD::op_is_discardable )
      See OSDService::handle_misdirected_op
-     See OSD::op_has_sufficient_caps
+     See PG::op_has_sufficient_caps
      See OSD::require_same_or_newer_map
   2. OSD::enqueue_op
 
@@ -118,7 +118,7 @@ Peering messages are tagged with two epochs:
 
 These are the same in cases where there was no triggering message.  We discard
 a peering message if the message's query_epoch if the PG in question has entered
-a new epoch (See PG::old_peering_event, PG::queue_peering_event).  Notifies,
+a new epoch (See PG::old_peering_evt, PG::queue_peering_event).  Notifies,
 infos, notifies, and logs are all handled as PG::RecoveryMachine events and
 are wrapped by PG::queue_* by PG::CephPeeringEvts, which include the created
 state machine event along with epoch_sent and query_epoch in order to

--- a/doc/dev/osd_internals/snaps.rst
+++ b/doc/dev/osd_internals/snaps.rst
@@ -58,7 +58,7 @@ Snap Removal
 To remove a snapshot, a request is made to the *Monitor* cluster to
 add the snapshot id to the list of purged snaps (or to remove it from
 the set of pool snaps in the case of *pool snaps*).  In either case,
-the *PG* adds the snap to its *snaptrimq* for trimming.
+the *PG* adds the snap to its *snap_trimq* for trimming.
 
 A clone can be removed when all of its snaps have been removed.  In
 order to determine which clones might need to be removed upon snap
@@ -70,7 +70,7 @@ See ReplicatedPG::SnapTrimmer, SnapMapper
 This trimming is performed asynchronously by the snap_trim_wq while the
 pg is clean and not scrubbing.
 
-  #. The next snap in PG::snaptrimq is selected for trimming
+  #. The next snap in PG::snap_trimq is selected for trimming
   #. We determine the next object for trimming out of PG::snap_mapper.
      For each object, we create a log entry and repop updating the
      object info and the snap set (including adjusting the overlaps).

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -1032,9 +1032,8 @@ int ObjBencher::clean_up(int num_objects, int prevPid, int concurrentios) {
  * prefix. The list is guaranteed to have at least one item when the
  * function returns true.
  *
- * @in
  * @param prefix the prefix to match against
- * @param objects return list of objects
+ * @param objects [out] return list of objects
  * @returns true if there are any objects in the store which match
  * the prefix, false if there are no more
  */

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -127,7 +127,7 @@ struct CephContext;
  *
  * @param major where to store the major version number
  * @param minor where to store the minor version number
- * @param extra where to store the extra version number
+ * @param patch where to store the extra version number
  */
 const char *ceph_version(int *major, int *minor, int *patch);
 
@@ -363,7 +363,7 @@ const char* ceph_getcwd(struct ceph_mount_info *cmount);
  * @param path the path to the working directory to change into.
  * @returns 0 on success, negative error code otherwise.
  */
-int ceph_chdir(struct ceph_mount_info *cmount, const char *s);
+int ceph_chdir(struct ceph_mount_info *cmount, const char *path);
 
 /** @} fsops */
 
@@ -655,7 +655,7 @@ int ceph_chown(struct ceph_mount_info *cmount, const char *path, int uid, int gi
  * Change the ownership of a file from an open file descriptor.
  *
  * @param cmount the ceph mount handle to use for performing the chown.
- * @param path the path of the file/directory to change the ownership of.
+ * @param fd the fd of the open file/directory to change the ownership of.
  * @param uid the user id to set on the file/directory.
  * @param gid the group id to set on the file/directory.
  * @returns 0 on success or negative error code on failure.
@@ -757,8 +757,8 @@ int ceph_close(struct ceph_mount_info *cmount, int fd);
  * @param offset the offset to set the stream to
  * @param whence the flag to indicate what type of seeking to perform:
  *	SEEK_SET: the offset is set to the given offset in the file.
- *      SEEK_CUR: the offset is set to the current location plus @ref offset bytes.
- *      SEEK_END: the offset is set to the end of the file plus @ref offset bytes.
+ *      SEEK_CUR: the offset is set to the current location plus @e offset bytes.
+ *      SEEK_END: the offset is set to the end of the file plus @e offset bytes.
  * @returns 0 on success or a negative error code on failure.
  */
 int64_t ceph_lseek(struct ceph_mount_info *cmount, int fd, int64_t offset, int whence);
@@ -768,7 +768,7 @@ int64_t ceph_lseek(struct ceph_mount_info *cmount, int fd, int64_t offset, int w
  * @param cmount the ceph mount handle to use for performing the read.
  * @param fd the file descriptor of the open file to read from.
  * @param buf the buffer to read data into
- * @param the initial size of the buffer
+ * @param size the initial size of the buffer
  * @param offset the offset in the file to read from.  If this value is negative, the
  *        function reads from the current offset of the file descriptor.
  * @returns the number of bytes read into buf, or a negative error code on failure.
@@ -1144,7 +1144,7 @@ int ceph_get_pool_replication(struct ceph_mount_info *cmount, int pool_id);
  *	anywhere within the stripe unit.
  * @param addr the address of the OSD holding that stripe
  * @param naddr the capacity of the address passed in.
- * @returns the size of the addressed filled into the @ref addr parameter, or a negative
+ * @returns the size of the addressed filled into the @e addr parameter, or a negative
  *	error code on failure.
  */
 int ceph_get_file_stripe_address(struct ceph_mount_info *cmount, int fd, int64_t offset,
@@ -1163,7 +1163,7 @@ int ceph_get_file_stripe_address(struct ceph_mount_info *cmount, int fd, int64_t
  * @returns the number of items stored in the output array, or -ERANGE if the
  * array is not large enough.
  */
-int ceph_get_file_extent_osds(struct ceph_mount_info *cmount, int fh,
+int ceph_get_file_extent_osds(struct ceph_mount_info *cmount, int fd,
                               int64_t offset, int64_t *length, int *osds, int nosds);
 
 /**
@@ -1248,7 +1248,7 @@ int ceph_debug_get_fd_caps(struct ceph_mount_info *cmount, int fd);
  * Get the capabilities currently issued to the client.
  *
  * @param cmount the ceph mount handle to use.
- * @param the path to the file
+ * @param path the path to the file
  * @returns the current capabilities issued to this client
  *       for the file
  */

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -109,7 +109,7 @@ enum {
 /** @} */
 
 /**
- * @defgroup librados_h_operation_flags
+ * @defgroup librados_h_operation_flags Operation Flags
  * Flags for rados_read_op_opeprate(), rados_write_op_operate(),
  * rados_aio_read_op_operate(), and rados_aio_write_op_operate().
  * See librados.hpp for details.
@@ -349,7 +349,7 @@ CEPH_RADOS_API int rados_create2(rados_t *pcluster,
  * Share configuration state with another rados_t instance.
  *
  * @param cluster where to store the handle
- * @param cct_ the existing configuration to use
+ * @param cct the existing configuration to use
  * @returns 0 on success, negative error code on failure
  */
 CEPH_RADOS_API int rados_create_with_context(rados_t *cluster,
@@ -1985,7 +1985,7 @@ CEPH_RADOS_API int rados_watch(rados_ioctx_t io, const char *o, uint64_t ver,
  * @param io the pool the object is in
  * @param o the object to watch
  * @param cookie where to store the internal id assigned to this watch
- * @param watchcb2 what to do when a notify is received on this object
+ * @param watchcb what to do when a notify is received on this object
  * @param watcherrcb what to do when the watch session encounters an error
  * @param arg opaque value to pass to the callback
  * @returns 0 on success, negative error code on failure
@@ -2331,7 +2331,7 @@ CEPH_RADOS_API void rados_write_op_remove(rados_write_op_t write_op);
 /**
  * Truncate an object
  * @param write_op operation to add this action to
- * @offset Offset to truncate to
+ * @param offset Offset to truncate to
  */
 CEPH_RADOS_API void rados_write_op_truncate(rados_write_op_t write_op,
                                             uint64_t offset);
@@ -2339,8 +2339,8 @@ CEPH_RADOS_API void rados_write_op_truncate(rados_write_op_t write_op,
 /**
  * Zero part of an object
  * @param write_op operation to add this action to
- * @offset Offset to zero
- * @len length to zero
+ * @param offset Offset to zero
+ * @param len length to zero
  */
 CEPH_RADOS_API void rados_write_op_zero(rados_write_op_t write_op,
 			                uint64_t offset,
@@ -2479,7 +2479,7 @@ CEPH_RADOS_API void rados_read_op_assert_exists(rados_read_op_t read_op);
  * @param read_op operation to add this action to
  * @param ver object version number
  */
-CEPH_RADOS_API void rados_read_op_assert_version(rados_read_op_t write_op, uint64_t ver);
+CEPH_RADOS_API void rados_read_op_assert_version(rados_read_op_t read_op, uint64_t ver);
 
 /**
  * Ensure that the an xattr satisfies a comparison
@@ -2550,15 +2550,15 @@ CEPH_RADOS_API void rados_read_op_stat(rados_read_op_t read_op,
  *
  * @param read_op operation to add this action to
  * @param offset offset to read from
- * @param buffer where to put the data
  * @param len length of buffer
- * @param prval where to store the return value of this action
+ * @param buffer where to put the data
  * @param bytes_read where to store the number of bytes read by this action
+ * @param prval where to store the return value of this action
  */
 CEPH_RADOS_API void rados_read_op_read(rados_read_op_t read_op,
 			               uint64_t offset,
 			               size_t len,
-			               char *buf,
+			               char *buffer,
 			               size_t *bytes_read,
 			               int *prval);
 
@@ -2624,7 +2624,7 @@ CEPH_RADOS_API void rados_read_op_exec_user_buf(rados_read_op_t read_op,
  * @param read_op operation to add this action to
  * @param start_after list keys starting after start_after
  * @param filter_prefix list only keys beginning with filter_prefix
- * @parem max_return list no more than max_return key/value pairs
+ * @param max_return list no more than max_return key/value pairs
  * @param iter where to store the iterator
  * @param prval where to store the return value from this action
  */
@@ -2643,7 +2643,7 @@ CEPH_RADOS_API void rados_read_op_omap_get_vals(rados_read_op_t read_op,
  *
  * @param read_op operation to add this action to
  * @param start_after list keys starting after start_after
- * @parem max_return list no more than max_return keys
+ * @param max_return list no more than max_return keys
  * @param iter where to store the iterator
  * @param prval where to store the return value from this action
  */
@@ -2673,9 +2673,9 @@ CEPH_RADOS_API void rados_read_op_omap_get_vals_by_keys(rados_read_op_t read_op,
 /**
  * Perform a read operation synchronously
  * @param read_op operation to perform
- * @io the ioctx that the object is in
- * @oid the object id
- * @flags flags to apply to the entire operation (LIBRADOS_OPERATION_*)
+ * @param io the ioctx that the object is in
+ * @param oid the object id
+ * @param flags flags to apply to the entire operation (LIBRADOS_OPERATION_*)
  */
 CEPH_RADOS_API int rados_read_op_operate(rados_read_op_t read_op,
 			                 rados_ioctx_t io,
@@ -2685,10 +2685,10 @@ CEPH_RADOS_API int rados_read_op_operate(rados_read_op_t read_op,
 /**
  * Perform a read operation asynchronously
  * @param read_op operation to perform
- * @io the ioctx that the object is in
+ * @param io the ioctx that the object is in
  * @param completion what to do when operation has been attempted
- * @oid the object id
- * @flags flags to apply to the entire operation (LIBRADOS_OPERATION_*)
+ * @param oid the object id
+ * @param flags flags to apply to the entire operation (LIBRADOS_OPERATION_*)
  */
 CEPH_RADOS_API int rados_aio_read_op_operate(rados_read_op_t read_op,
 			                     rados_ioctx_t io,
@@ -2712,7 +2712,7 @@ CEPH_RADOS_API int rados_aio_read_op_operate(rados_read_op_t read_op,
  * @returns -EBUSY if the lock is already held by another (client, cookie) pair
  * @returns -EEXIST if the lock is already held by the same (client, cookie) pair
  */
-CEPH_RADOS_API int rados_lock_exclusive(rados_ioctx_t io, const char * o,
+CEPH_RADOS_API int rados_lock_exclusive(rados_ioctx_t io, const char * oid,
                                         const char * name, const char * cookie,
                                         const char * desc,
                                         struct timeval * duration,

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -460,7 +460,7 @@ namespace librados
      * Get up to max_return keys and values beginning after start_after
      *
      * @param start_after [in] list no keys smaller than start_after
-     * @parem max_return [in] list no more than max_return key/value pairs
+     * @param max_return [in] list no more than max_return key/value pairs
      * @param out_vals [out] place returned values in out_vals on completion
      * @param prval [out] place error code in prval upon completion
      */
@@ -477,7 +477,7 @@ namespace librados
      *
      * @param start_after [in] list keys starting after start_after
      * @param filter_prefix [in] list only keys beginning with filter_prefix
-     * @parem max_return [in] list no more than max_return key/value pairs
+     * @param max_return [in] list no more than max_return key/value pairs
      * @param out_vals [out] place returned values in out_vals on completion
      * @param prval [out] place error code in prval upon completion
      */
@@ -495,7 +495,7 @@ namespace librados
      * Get up to max_return keys beginning after start_after
      *
      * @param start_after [in] list keys starting after start_after
-     * @parem max_return [in] list no more than max_return keys
+     * @param max_return [in] list no more than max_return keys
      * @param out_keys [out] place returned values in out_keys on completion
      * @param prval [out] place error code in prval upon completion
      */
@@ -515,8 +515,8 @@ namespace librados
     /**
      * get key/value pairs for specified keys
      *
-     * @param to_get [in] keys to get
-     * @param out_vals [out] place key/value pairs found here on completion
+     * @param keys [in] keys to get
+     * @param map [out] place key/value pairs found here on completion
      * @param prval [out] place error code in prval upon completion
      */
     void omap_get_vals_by_keys(const std::set<std::string> &keys,
@@ -550,7 +550,7 @@ namespace librados
     /**
      * query dirty state of an object
      *
-     * @param out_dirty [out] pointer to resulting bool
+     * @param isdirty [out] pointer to resulting bool
      * @param prval [out] place error code in prval upon completion
      */
     void is_dirty(bool *isdirty, int *prval);
@@ -864,9 +864,8 @@ namespace librados
      * The return value of the completion will be 0 on success, negative
      * error code on failure.
      *
-     * @param io the context to operate in
      * @param oid the name of the object
-     * @param completion what to do when the remove is safe and complete
+     * @param c what to do when the remove is safe and complete
      * @returns 0 on success, -EROFS if the io context specifies a snap_seq
      * other than SNAP_HEAD
      */

--- a/src/include/radosstriper/libradosstriper.h
+++ b/src/include/radosstriper/libradosstriper.h
@@ -57,7 +57,7 @@ void rados_striper_destroy(rados_striper_t striper);
  * Already existing objects will be opened with their own layout.
  *
  * @param striper the targetted striper
- * @param stiper_unit the stripe_unit value of the new object layout
+ * @param stripe_unit the stripe_unit value of the new object layout
  * @returns 0 on success, negative error code on failure
  */
 int rados_striper_set_object_layout_stripe_unit(rados_striper_t striper,
@@ -202,7 +202,7 @@ int rados_striper_remove(rados_striper_t striper,
  * @note the truncation can not happen if any I/O is ongoing (it
  * will return EBUSY). Identically, no I/O will be able to start
  * during truncation (same EBUSY return code)
- * @param striper the striper in which the truncation will occur
+ * @param io the rados context to use
  * @param soid the name of the striped object
  * @param size the new size of the object in bytes
  * @returns 0 on success, negative error code on failure
@@ -225,7 +225,7 @@ int rados_striper_trunc(rados_ioctx_t io, const char *soid, uint64_t size);
  * Get the value of an extended attribute on a striped object.
  *
  * @param striper the striper in which the getxattr will occur
- * @param o name of the striped object
+ * @param oid name of the striped object
  * @param name which extended attribute to read
  * @param buf where to store the result
  * @param len size of buf in bytes
@@ -241,7 +241,7 @@ int rados_striper_getxattr(rados_striper_t striper,
  * Set an extended attribute on a striped object.
  *
  * @param striper the striper in which the setxattr will occur
- * @param o name of the object
+ * @param oid name of the object
  * @param name which extended attribute to set
  * @param buf what to store in the xattr
  * @param len the number of bytes in buf

--- a/src/include/str_map.h
+++ b/src/include/str_map.h
@@ -83,8 +83,8 @@ extern int get_json_str_map(
  * Always returns 0, as there is no condition for failure.
  *
  * @param [in] str plain text key/value pairs
+ * @param [in] delims field delimiters to be used for parsing str
  * @param [out] str_map key/value pairs parsed from str
- * @param [in] delim field delimiters to be used for parsing str
  * @return **0**
  */
 extern int get_str_map(

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -952,8 +952,8 @@ public:
    *
    * @param results A freshly-created validated_data struct, with values set
    * as described in the struct documentation.
-   * @param Context The callback to activate once the validation has
-   * been completed.
+   * @param mdr The request to be responeded upon the completion of the
+   * validation.
    */
   void validate_disk_state(validated_data *results,
                            MDRequestRef& mdr);

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -56,7 +56,7 @@ class Elector {
    *
    * @remarks This function assumes as a default firing value the duration of
    *	      the monitor's lease interval, and adds to it the value specified
-   *	      in @plus
+   *	      in @e plus
    *
    * @post expire_event is set
    *

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -232,7 +232,7 @@ private:
   set<string> outside_quorum;
 
   /**
-   * @defgroup scrub
+   * @defgroup Monitor_h_scrub
    * @{
    */
   version_t scrub_version;            ///< paxos version we are scrubbing
@@ -250,7 +250,7 @@ private:
   void scrub_reset();
 
   /**
-   * @defgroup Synchronization
+   * @defgroup Monitor_h_sync Synchronization
    * @{
    */
   /**

--- a/src/mon/MonitorStore.h
+++ b/src/mon/MonitorStore.h
@@ -82,7 +82,8 @@ public:
    * Put a whole set of values efficiently and safely.
    *
    * @param a - prefix/directory
-   * @param vals - map of int name -> values
+   * @param start
+   * @param end defines a range of map from int -> values
    * @return 0 for success or negative error code
    */
   void put_bl_sn_map(const char *a,

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1154,6 +1154,7 @@ void PGMap::pool_client_io_rate_summary(Formatter *f, ostream *out,
  * @param old_pool_sum      Previous stats sum
  * @param last_ts           Last timestamp for pool
  * @param result_pool_sum   Resulting stats
+ * @param result_pool_delta Resulting pool delta
  * @param result_ts_delta   Resulting timestamp delta
  * @param delta_avg_list    List of last N computed deltas, used to average
  */

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -987,7 +987,7 @@ private:
    *
    * @invariant The received message is an operation of type OP_LEASE
    *
-   * @param The message sent by the Leader to the Peon during the
+   * @param lease The message sent by the Leader to the Peon during the
    *	    Paxos::extend_lease function
    */
   void handle_lease(MMonPaxos *lease);
@@ -1084,7 +1084,8 @@ private:
 public:
   /**
    * @param m A monitor
-   * @param mid A machine id
+   * @param name A name for the paxos service. It serves as the naming space
+   * of the underlying persistent storage for this service.
    */
   Paxos(Monitor *m, const string &name) 
 		 : mon(m),
@@ -1272,7 +1273,7 @@ public:
    * Check if a given version is readable.
    *
    * A version may not be readable for a myriad of reasons:
-   *  @li the version @v is higher that the last committed version
+   *  @li the version @e v is higher that the last committed version
    *  @li we are not the Leader nor a Peon (election may be on-going)
    *  @li we do not have a committed value yet
    *  @li we do not have a valid lease
@@ -1282,7 +1283,7 @@ public:
    */
   bool is_readable(version_t seen=0);
   /**
-   * Read version @v and store its value in @bl
+   * Read version @e v and store its value in @e bl
    *
    * @param[in] v The version we want to read
    * @param[out] bl The version's value

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -188,7 +188,7 @@ public:
   /**
    * @param mn A Monitor instance
    * @param p A Paxos instance
-   * @parem name Our service's name.
+   * @param name Our service's name.
    */
   PaxosService(Monitor *mn, Paxos *p, string name) 
     : mon(mn), paxos(p), service_name(name),
@@ -661,7 +661,7 @@ public:
   }
 
   /**
-   * @defgroup PaxosService_h_Trim
+   * @defgroup PaxosService_h_Trim Functions for trimming states
    * @{
    */
   /**
@@ -672,8 +672,8 @@ public:
   void maybe_trim();
 
   /**
-   * Auxiliary function to trim our state from version @from to version @to,
-   * not including; i.e., the interval [from, to[
+   * Auxiliary function to trim our state from version @p from to version
+   * @p to, not including; i.e., the interval [from, to[
    *
    * @param t The transaction to which we will add the trim operations.
    * @param from the lower limit of the interval to be trimmed

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -287,16 +287,16 @@ public:
    */
   virtual Policy get_default_policy() = 0;
   /**
-   * Set a Throttler which is applied to all Messages from the given
-   * type of peer.
+   * Set Throttlers applied to all Messages from the given type of peer
    *
    * This is an init-time function and cannot be called after calling
    * start() or bind().
    *
-   * @param type The peer type this Throttler will apply to.
-   * @param t The Throttler to apply. The Messenger does not take
-   * ownership of this pointer, but you must not destroy it before
-   * you destroy the Messenger.
+   * @param type The peer type the Throttlers will apply to.
+   * @param bytes The Throttle for the number of bytes carried by the message
+   * @param msgs The Throttle for the number of messages for this @p type
+   * @note The Messenger does not take ownership of the Throttle pointers, but
+   * you must not destroy them before you destroy the Messenger.
    */
   virtual void set_policy_throttlers(int type, Throttle *bytes, Throttle *msgs=NULL) = 0;
   /**

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -249,9 +249,6 @@ private:
    *
    * @param addr The address of the entity to connect to.
    * @param type The peer type of the entity at the address.
-   * @param con An existing Connection to associate with the new connection. If
-   * NULL, it creates a new Connection.
-   * @param msg an initial message to queue on the new connection
    *
    * @return a pointer to the newly-created connection. Caller does not own a
    * reference; take one if you need it.
@@ -266,7 +263,7 @@ private:
    *
    * @param m The Message to queue up. This function eats a reference.
    * @param con The existing Connection to use, or NULL if you don't know of one.
-   * @param addr The address to send the Message to.
+   * @param dest_addr The address to send the Message to.
    * @param dest_type The peer type of the address we're sending to
    * just drop silently under failure.
    */

--- a/src/msg/simple/SimpleMessenger.h
+++ b/src/msg/simple/SimpleMessenger.h
@@ -215,7 +215,7 @@ private:
    * @param type The peer type of the entity at the address.
    * @param con An existing Connection to associate with the new Pipe. If
    * NULL, it creates a new Connection.
-   * @param msg an initial message to queue on the new pipe
+   * @param first an initial message to queue on the new pipe
    *
    * @return a pointer to the newly-created Pipe. Caller does not own a
    * reference; take one if you need it.

--- a/src/os/CollectionIndex.h
+++ b/src/os/CollectionIndex.h
@@ -150,7 +150,7 @@ protected:
     ) = 0;
 
   /**
-   * Moves objects matching <match> in the lsb <bits>
+   * Moves objects matching @e match in the lsb @e bits
    *
    * dest and this must be the same subclass
    *

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -108,7 +108,7 @@ public:
 			     const string& type,
 			     const string& data,
 			     const string& journal,
-			     osflagbits_t flag = 0);
+			     osflagbits_t flags = 0);
 
   Logger *logger;
 
@@ -2016,7 +2016,7 @@ public:
    * collection_getattrs - get all xattrs of a collection
    *
    * @param cid collection name
-   * @param asert map of keys and buffers that contain the values
+   * @param aset map of keys and buffers that contain the values
    * @returns 0 on success, negative error code on failure
    */
   virtual int collection_getattrs(coll_t cid, map<string,bufferptr> &aset)
@@ -2063,7 +2063,7 @@ public:
    * @param c collection
    * @param start list object that sort >= this value
    * @param end list objects that sort < this value
-   * @param snapid return no objects with snap < snapid
+   * @param seq return no objects with snap < seq
    * @param ls [out] result
    * @return zero on success, or negative error
    */

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -91,7 +91,6 @@ struct OSDCapMatch {
   /**
    * check if given request parameters match our constraints
    *
-   * @param auid requesting user's auid
    * @param pool_name pool name
    * @param nspace_name namespace name
    * @param pool_auid pool's auid

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2300,14 +2300,14 @@ struct pg_log_t {
    *
    * @param other pg_log_t to copy from
    * @param from copy entries after this version
-   * @parem to up to and including this version
+   * @param to up to and including this version
    */
   void copy_range(const pg_log_t &other, eversion_t from, eversion_t to);
 
   /**
    * copy up to N entries
    *
-   * @param o source log
+   * @param other source log
    * @param max max number of entreis to copy
    */
   void copy_up_to(const pg_log_t &other, int max);
@@ -3525,7 +3525,7 @@ struct OSDOp {
    * buffer, including the sobject_t soid.
    *
    * @param ops [in] vector of OSDOps
-   * @param in  [out] combined data buffer
+   * @param out [out] combined data buffer
    */
   static void merge_osd_op_vector_in_data(vector<OSDOp>& ops, bufferlist& out);
 
@@ -3541,7 +3541,7 @@ struct OSDOp {
    * merge outdata members of a vector of OSDOps into a single bufferlist
    *
    * @param ops [in] vector of OSDOps
-   * @param in  [out] combined data buffer
+   * @param out [out] combined data buffer
    */
   static void merge_osd_op_vector_out_data(vector<OSDOp>& ops, bufferlist& out);
 };

--- a/src/test/messenger/xio_dispatcher.h
+++ b/src/test/messenger/xio_dispatcher.h
@@ -76,7 +76,7 @@ public:
   virtual void ms_handle_remote_reset(Connection *con);
 
   /**
-   * @defgroup Authentication
+   * @defgroup test_xio_dispatcher_h_auth Authentication
    * @{
    */
   /**


### PR DESCRIPTION
this change tries to fix some of the trivial error/warnings in the doxygen comments. some of them simply hide the markup'ed text in the generated document. while the other are showing us doc out of sync with the code.