### PR TITLE
tests: speed up Python RBD random data generation

### DIFF
--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -1,6 +1,5 @@
 # vim: expandtab smarttab shiftwidth=4 softtabstop=4
 import functools
-import random
 import socket
 import struct
 import os
@@ -264,8 +263,7 @@ def test_rename():
     eq([image_name], rbd.list(ioctx))
 
 def rand_data(size):
-    l = [random.Random().getrandbits(64) for _ in xrange(size/8)]
-    return struct.pack((size/8)*'Q', *l)
+    return os.urandom(size)
 
 def check_stat(info, size, order):
     assert 'block_name_prefix' in info


### PR DESCRIPTION
The RBD large_write test cases was taking multiple minutes to
run under a Fedora 21 VM.  Replaced the million+ random number
generator calls with a single call to os.urandom. The test
now completes within seconds.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>