### PR TITLE
client: re-send requsets before composing the cap reconnect message

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -312,7 +312,8 @@ public:
 			     mds_rank_t mds, int drop, int unless);
   mds_rank_t choose_target_mds(MetaRequest *req);
   void connect_mds_targets(mds_rank_t mds);
-  void send_request(MetaRequest *request, MetaSession *session);
+  void send_request(MetaRequest *request, MetaSession *session,
+		    bool drop_cap_releases=false);
   MClientRequest *build_client_request(MetaRequest *request);
   void kick_requests(MetaSession *session);
   void kick_requests_closed(MetaSession *session);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -130,6 +130,9 @@ void Server::dispatch(Message *m)
 	  dout(3) << "queuing completed op" << dendl;
 	  queue_replay = true;
 	}
+	// this request was created before the cap reconnect message, drop any embedded
+	// cap releases.
+	req->releases.clear();
       }
       if (queue_replay) {
 	mds->enqueue_replay(new C_MDS_RetryMessage(mds, m));


### PR DESCRIPTION
After commit 419800fe (client: re-send request when MDS enters reconnecting
stage), cephfs client can send both unsafe requests and normal requests when
MDS is in reconnecting stage. Normal requests can have embedded cap releases,
the client code encodes these embedded cap releases after composing the cap
reconnect message. This causes the client sliently drop some caps. The fix
is re-send requsets (which add embedded cap releases) before composing the
cap reconnect message

Fixes: #10912
Signed-off-by: Yan, Zheng <zyan@redhat.com>