### PR TITLE
librbd: better handling for async maintenance requests

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -870,6 +870,7 @@ OPTION(rbd_readahead_disable_after_bytes, OPT_LONGLONG, 50 * 1024 * 1024) // how
 OPTION(rbd_clone_copy_on_read, OPT_BOOL, false)
 OPTION(rbd_blacklist_on_break_lock, OPT_BOOL, true) // whether to blacklist clients whose lock was broken
 OPTION(rbd_blacklist_expire_seconds, OPT_INT, 0) // number of seconds to blacklist - set to 0 for OSD default
+OPTION(rbd_request_timed_out_seconds, OPT_INT, 30) // number of seconds before maint request times out
 
 /*
  * The following options change the behavior for librbd's image creation methods that

--- a/src/librbd/AsyncFlattenRequest.cc
+++ b/src/librbd/AsyncFlattenRequest.cc
@@ -119,7 +119,7 @@ void AsyncFlattenRequest::send() {
       boost::lambda::_1, &m_image_ctx, m_object_size, m_snapc,
       boost::lambda::_2));
   AsyncObjectThrottle *throttle = new AsyncObjectThrottle(
-    context_factory, create_callback_context(), m_prog_ctx, 0,
+    *this, context_factory, create_callback_context(), m_prog_ctx, 0,
     m_overlap_objects);
   throttle->start_ops(cct->_conf->rbd_concurrent_management_ops);
 }

--- a/src/librbd/AsyncObjectThrottle.h
+++ b/src/librbd/AsyncObjectThrottle.h
@@ -11,6 +11,7 @@
 
 namespace librbd
 {
+class AsyncRequest;
 class ProgressContext;
 
 class AsyncObjectThrottleFinisher {
@@ -42,7 +43,8 @@ public:
   typedef boost::function<C_AsyncObjectThrottle*(AsyncObjectThrottle&,
       					   uint64_t)> ContextFactory;
 
-  AsyncObjectThrottle(const ContextFactory& context_factory, Context *ctx,
+  AsyncObjectThrottle(const AsyncRequest &async_request,
+                      const ContextFactory& context_factory, Context *ctx,
 		      ProgressContext &prog_ctx, uint64_t object_no,
 		      uint64_t end_object_no);
 
@@ -51,6 +53,7 @@ public:
 
 private:
   Mutex m_lock;
+  const AsyncRequest &m_async_request;
   ContextFactory m_context_factory;
   Context *m_ctx;
   ProgressContext &m_prog_ctx;

--- a/src/librbd/AsyncOperation.cc
+++ b/src/librbd/AsyncOperation.cc
@@ -17,14 +17,26 @@ void AsyncOperation::start_op(ImageCtx &image_ctx) {
 
   ldout(m_image_ctx->cct, 20) << this << " " << __func__ << dendl; 
   Mutex::Locker l(m_image_ctx->async_ops_lock);
-  m_image_ctx->async_ops.push_back(&m_xlist_item);
+  m_image_ctx->async_ops.push_front(&m_xlist_item);
 }
 
 void AsyncOperation::finish_op() {
   ldout(m_image_ctx->cct, 20) << this << " " << __func__ << dendl;
   {
     Mutex::Locker l(m_image_ctx->async_ops_lock);
+    xlist<AsyncOperation *>::iterator iter(&m_xlist_item);
+    ++iter;
     assert(m_xlist_item.remove_myself());
+
+    // linked list stored newest -> oldest ops
+    if (!iter.end()) {
+      ldout(m_image_ctx->cct, 20) << "moving flush contexts to previous op: "
+                                  << *iter << dendl;
+      (*iter)->m_flush_contexts.insert((*iter)->m_flush_contexts.end(),
+                                       m_flush_contexts.begin(),
+                                       m_flush_contexts.end());
+      return;
+    }
   }
 
   while (!m_flush_contexts.empty()) {

--- a/src/librbd/AsyncRequest.cc
+++ b/src/librbd/AsyncRequest.cc
@@ -1,11 +1,25 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 #include "librbd/AsyncRequest.h"
+#include "librbd/ImageCtx.h"
 #include "librbd/internal.h"
 #include <boost/bind.hpp>
 
 namespace librbd
 {
+
+AsyncRequest::AsyncRequest(ImageCtx &image_ctx, Context *on_finish)
+  : m_image_ctx(image_ctx), m_on_finish(on_finish), m_canceled(false),
+    m_xlist_item(this) {
+  Mutex::Locker l(m_image_ctx.async_ops_lock);
+  m_image_ctx.async_requests.push_back(&m_xlist_item);
+}
+
+AsyncRequest::~AsyncRequest() {
+  Mutex::Locker l(m_image_ctx.async_ops_lock);
+  assert(m_xlist_item.remove_myself());
+  m_image_ctx.async_requests_cond.Signal();
+}
 
 librados::AioCompletion *AsyncRequest::create_callback_completion() {
   return librados::Rados::aio_create_completion(create_callback_context(),

--- a/src/librbd/AsyncTrimRequest.cc
+++ b/src/librbd/AsyncTrimRequest.cc
@@ -154,7 +154,7 @@ void AsyncTrimRequest::send_remove_objects() {
     boost::lambda::bind(boost::lambda::new_ptr<AsyncTrimObjectContext>(),
       boost::lambda::_1, &m_image_ctx, boost::lambda::_2));
   AsyncObjectThrottle *throttle = new AsyncObjectThrottle(
-    context_factory, ctx, m_prog_ctx, m_delete_start, m_num_objects);
+    *this, context_factory, ctx, m_prog_ctx, m_delete_start, m_num_objects);
   throttle->start_ops(cct->_conf->rbd_concurrent_management_ops);
 }
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -708,6 +708,6 @@ namespace librbd {
 
     ldout(cct, 20) << "flush async operations: " << on_finish << " "
                    << "count=" << async_ops.size() << dendl;
-    async_ops.back()->add_flush_context(on_finish);
+    async_ops.front()->add_flush_context(on_finish);
   }
 }

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -8,6 +8,7 @@
 #include "common/perf_counters.h"
 
 #include "librbd/AsyncOperation.h"
+#include "librbd/AsyncRequest.h"
 #include "librbd/internal.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageWatcher.h"
@@ -709,5 +710,21 @@ namespace librbd {
     ldout(cct, 20) << "flush async operations: " << on_finish << " "
                    << "count=" << async_ops.size() << dendl;
     async_ops.front()->add_flush_context(on_finish);
+  }
+
+  void ImageCtx::cancel_async_requests() {
+    Mutex::Locker l(async_ops_lock);
+    ldout(cct, 10) << "canceling async requests: count="
+                   << async_requests.size() << dendl;
+
+    for (xlist<AsyncRequest*>::iterator it = async_requests.begin();
+         !it.end(); ++it) {
+      ldout(cct, 10) << "canceling async request: " << *it << dendl;
+      (*it)->cancel();
+    }
+
+    while (!async_requests.empty()) {
+      async_requests_cond.Wait(async_ops_lock);
+    }
   }
 }

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -36,6 +36,7 @@ class PerfCounters;
 namespace librbd {
 
   class AsyncOperation;
+  class AsyncRequest;
   class CopyupRequest;
   class ImageWatcher;
   class ObjectMap;
@@ -112,6 +113,8 @@ namespace librbd {
     std::map<uint64_t, CopyupRequest*> copyup_list;
 
     xlist<AsyncOperation*> async_ops;
+    xlist<AsyncRequest*> async_requests;
+    Cond async_requests_cond;
 
     ObjectMap *object_map;
 
@@ -187,6 +190,8 @@ namespace librbd {
 
     void flush_async_operations();
     void flush_async_operations(Context *on_finish);
+
+    void cancel_async_requests();
   };
 }
 

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -161,7 +161,7 @@ namespace librbd {
     struct HandlePayloadVisitor : public boost::static_visitor<void> {
       ImageWatcher *image_watcher;
       uint64_t notify_id;
-      uint64_t handle; 
+      uint64_t handle;
 
       HandlePayloadVisitor(ImageWatcher *image_watcher_, uint64_t notify_id_,
 			   uint64_t handle_)
@@ -226,6 +226,8 @@ namespace librbd {
     void notify_request_lock();
     int notify_lock_owner(bufferlist &bl);
 
+    void schedule_async_request_timed_out(const WatchNotify::AsyncRequestId &id);
+    void async_request_timed_out(const WatchNotify::AsyncRequestId &id);
     int notify_async_request(const WatchNotify::AsyncRequestId &id,
 			     bufferlist &in, ProgressContext& prog_ctx);
     void notify_request_leadership();

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -40,6 +40,8 @@ namespace librbd {
     int try_lock();
     int request_lock(const boost::function<int(AioCompletion*)>& restart_op,
 		     AioCompletion* c);
+    void prepare_unlock();
+    void cancel_unlock();
     int unlock();
 
     void assert_header_locked(librados::ObjectWriteOperation *op);
@@ -56,7 +58,8 @@ namespace librbd {
 
     enum LockOwnerState {
       LOCK_OWNER_STATE_NOT_LOCKED,
-      LOCK_OWNER_STATE_LOCKED
+      LOCK_OWNER_STATE_LOCKED,
+      LOCK_OWNER_STATE_RELEASING
     };
 
     enum WatchState {

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -61,4 +61,5 @@ noinst_HEADERS += \
 	librbd/ObjectMap.h \
 	librbd/parent_types.h \
 	librbd/SnapInfo.h \
+	librbd/TaskFinisher.h \
 	librbd/WatchNotifyTypes.h

--- a/src/librbd/TaskFinisher.h
+++ b/src/librbd/TaskFinisher.h
@@ -1,0 +1,141 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef LIBRBD_TASK_FINISHER_H
+#define LIBRBD_TASK_FINISHER_H
+
+#include "include/int_types.h"
+#include "include/Context.h"
+#include "common/Finisher.h"
+#include "common/Mutex.h"
+#include "common/Timer.h"
+#include <map>
+#include <utility>
+
+class CephContext;
+class Context;
+
+namespace librbd {
+
+template <typename Task>
+class TaskFinisher {
+public:
+  TaskFinisher(CephContext &cct)
+    : m_cct(cct), m_lock("librbd::TaskFinisher::m_lock"),
+      m_finisher(new Finisher(&cct)),
+      m_safe_timer(new SafeTimer(&cct, m_lock, false))
+  {
+    m_finisher->start();
+    m_safe_timer->init();
+  }
+
+  ~TaskFinisher() {
+    {
+      Mutex::Locker l(m_lock);
+      m_safe_timer->shutdown();
+      delete m_safe_timer;
+    }
+
+    m_finisher->stop();
+    delete m_finisher;
+  }
+
+  void cancel(const Task& task) {
+    Mutex::Locker l(m_lock);
+    typename TaskContexts::iterator it = m_task_contexts.find(task);
+    if (it != m_task_contexts.end()) {
+      delete it->second.first;
+      m_task_contexts.erase(it);
+    }
+  }
+
+  void cancel_all() {
+    Mutex::Locker l(m_lock);
+    for (typename TaskContexts::iterator it = m_task_contexts.begin();
+         it != m_task_contexts.end(); ++it) {
+      delete it->second.first;
+    }
+    m_task_contexts.clear();
+  }
+
+  bool add_event_after(const Task& task, double seconds, Context *ctx) {
+    Mutex::Locker l(m_lock);
+    if (m_task_contexts.count(task) != 0) {
+      // task already scheduled on finisher or timer
+      delete ctx;
+      return false;
+    }
+    C_Task *timer_ctx = new C_Task(this, task);
+    m_task_contexts[task] = std::make_pair(ctx, timer_ctx);
+
+    m_safe_timer->add_event_after(seconds, timer_ctx);
+    return true;
+  }
+
+  void queue(Context *ctx) {
+    m_finisher->queue(ctx);
+  }
+
+  bool queue(const Task& task, Context *ctx) {
+    Mutex::Locker l(m_lock);
+    typename TaskContexts::iterator it = m_task_contexts.find(task);
+    if (it != m_task_contexts.end()) {
+      if (it->second.second != NULL) {
+        assert(m_safe_timer->cancel_event(it->second.second));
+        delete it->second.first;
+      } else {
+        // task already scheduled on the finisher
+        delete ctx;
+        return false;
+      }
+    }
+    m_task_contexts[task] = std::make_pair(ctx, reinterpret_cast<Context *>(NULL));
+
+    m_finisher->queue(new C_Task(this, task));
+    return true;
+  }
+
+private:
+  class C_Task : public Context {
+  public:
+    C_Task(TaskFinisher *task_finisher, const Task& task)
+      : m_task_finisher(task_finisher), m_task(task)
+    {
+    }
+  protected:
+    virtual void finish(int r) {
+      m_task_finisher->complete(m_task);
+    }
+  private:
+    TaskFinisher *m_task_finisher;
+    Task m_task;
+  };
+
+  CephContext &m_cct;
+
+  Mutex m_lock;
+  Finisher *m_finisher;
+  SafeTimer *m_safe_timer;
+
+  typedef std::map<Task, std::pair<Context *, Context *> > TaskContexts;
+  TaskContexts m_task_contexts;
+
+  void complete(const Task& task) {
+    Context *ctx = NULL;
+    {
+      Mutex::Locker l(m_lock);
+      typename TaskContexts::iterator it = m_task_contexts.find(task);
+      if (it != m_task_contexts.end()) {
+        ctx = it->second.first;
+        m_task_contexts.erase(it);
+      }
+    }
+
+    if (ctx != NULL) {
+      ctx->complete(0);
+    }
+  }
+};
+
+} // namespace librbd
+
+#endif // LIBRBD_TASK_FINISHER

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -67,6 +67,9 @@ struct AsyncRequestId {
       return request_id < rhs.request_id;
     }
   }
+  inline bool operator!=(const AsyncRequestId &rhs) const {
+    return (client_id != rhs.client_id || request_id != rhs.request_id);
+  }
 };
 
 enum NotifyOp {

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2345,6 +2345,19 @@ reprotect_and_return_err:
     // ignore return value, since we may be set to a non-existent
     // snapshot and the user is trying to fix that
     ictx_check(ictx);
+
+    bool unlocking = false;
+    {
+      RWLock::WLocker l(ictx->owner_lock);
+      if (ictx->image_watcher != NULL && ictx->image_watcher->is_lock_owner() &&
+          snap_name != NULL && strlen(snap_name) != 0) {
+        // stop incoming requests since we will release the lock
+        ictx->image_watcher->prepare_unlock();
+        unlocking = true;
+      }
+    }
+
+    ictx->cancel_async_requests();
     ictx->flush_async_operations();
     if (ictx->object_cacher) {
       // complete pending writes before we're set to a snapshot and
@@ -2354,13 +2367,16 @@ reprotect_and_return_err:
     }
     int r = _snap_set(ictx, snap_name);
     if (r < 0) {
+      RWLock::WLocker l(ictx->owner_lock);
+      if (unlocking) {
+        ictx->image_watcher->cancel_unlock();
+      }
       return r;
     }
 
     RWLock::WLocker l(ictx->owner_lock);
     if (ictx->image_watcher != NULL) {
-      if (!ictx->image_watcher->is_lock_supported() &&
-	  ictx->image_watcher->is_lock_owner()) {
+      if (unlocking) {
 	r = ictx->image_watcher->unlock();
 	if (r < 0) {
 	  lderr(ictx->cct) << "error unlocking image: " << cpp_strerror(r)
@@ -2411,6 +2427,15 @@ reprotect_and_return_err:
   {
     ldout(ictx->cct, 20) << "close_image " << ictx << dendl;
 
+    {
+      RWLock::WLocker l(ictx->owner_lock);
+      if (ictx->image_watcher != NULL && ictx->image_watcher->is_lock_owner()) {
+        // stop incoming requests
+        ictx->image_watcher->prepare_unlock();
+      }
+    }
+
+    ictx->cancel_async_requests();
     ictx->readahead.wait_for_pending();
     if (ictx->object_cacher) {
       ictx->shutdown_cache(); // implicitly flushes


### PR DESCRIPTION
Lock owners will now cancel in-progress async requests before they release the lock.  Clients will now time out if the lock owner doesn't report progress within 30 seconds.