### PR TITLE
packaging: move rbd udev rules to ceph-common

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -565,7 +565,6 @@ fi
 %{_bindir}/ceph-mon
 %{_bindir}/ceph-mds
 %{_bindir}/ceph-osd
-%{_bindir}/ceph-rbdnamer
 %{_bindir}/librados-config
 %{_bindir}/ceph-client-debug
 %{_bindir}/cephfs-journal-tool
@@ -622,7 +621,6 @@ fi
 %{_mandir}/man8/monmaptool.8*
 %{_mandir}/man8/cephfs.8*
 %{_mandir}/man8/mount.ceph.8*
-%{_mandir}/man8/ceph-rbdnamer.8*
 %{_mandir}/man8/ceph-debugpack.8*
 %{_mandir}/man8/ceph-clsinfo.8*
 %{_mandir}/man8/librados-config.8*
@@ -643,6 +641,7 @@ fi
 %{_bindir}/ceph-authtool
 %{_bindir}/ceph-conf
 %{_bindir}/ceph-dencoder
+%{_bindir}/ceph-rbdnamer
 %{_bindir}/ceph-syn
 %{_bindir}/ceph-crush-location
 %{_bindir}/rados
@@ -652,6 +651,7 @@ fi
 %{_mandir}/man8/ceph-authtool.8*
 %{_mandir}/man8/ceph-conf.8*
 %{_mandir}/man8/ceph-dencoder.8*
+%{_mandir}/man8/ceph-rbdnamer.8*
 %{_mandir}/man8/ceph-syn.8*
 %{_mandir}/man8/ceph-post-file.8*
 %{_mandir}/man8/ceph.8*
@@ -667,6 +667,11 @@ fi
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap
 %{_initrddir}/rbdmap
 %{python_sitelib}/ceph_argparse.py*
+%if 0%{?rhel} >= 7 || 0%{?fedora}
+/usr/lib/udev/rules.d/50-rbd.rules
+%else
+/lib/udev/rules.d/50-rbd.rules
+%endif
 
 %postun -n ceph-common
 # Package removal cleanup
@@ -791,11 +796,6 @@ fi
 %files -n librbd1
 %defattr(-,root,root,-)
 %{_libdir}/librbd.so.*
-%if 0%{?rhel} >= 7 || 0%{?fedora}
-/usr/lib/udev/rules.d/50-rbd.rules
-%else
-/lib/udev/rules.d/50-rbd.rules
-%endif
 
 %post -n librbd1
 /sbin/ldconfig

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -4,6 +4,7 @@ usr/bin/ceph
 usr/bin/ceph-authtool
 usr/bin/ceph-conf
 usr/bin/ceph-dencoder
+usr/bin/ceph-rbdnamer
 usr/bin/ceph-syn
 usr/bin/ceph-crush-location
 usr/bin/rados
@@ -13,6 +14,7 @@ usr/bin/ceph-brag
 usr/share/man/man8/ceph-authtool.8
 usr/share/man/man8/ceph-conf.8
 usr/share/man/man8/ceph-dencoder.8
+usr/share/man/man8/ceph-rbdnamer.8
 usr/share/man/man8/ceph-syn.8
 usr/share/man/man8/ceph-post-file.8
 usr/share/man/man8/ceph.8
@@ -23,3 +25,4 @@ usr/share/ceph/id_dsa_drop.ceph.com
 usr/share/ceph/id_dsa_drop.ceph.com.pub
 etc/ceph/rbdmap
 etc/init.d/rbdmap
+lib/udev/rules.d/50-rbd.rules

--- a/debian/control
+++ b/debian/control
@@ -188,9 +188,11 @@ Depends: librbd1 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends},
 Conflicts: ceph-client-tools
 Replaces: ceph-client-tools,
 	  ceph (<< 0.78-500),
-	  python-ceph (<< 0.92-1223)
+	  python-ceph (<< 0.92-1223),
+	  librbd1 (<< 0.92-1238)
 Breaks: ceph (<< 0.78-500),
-	python-ceph (<< 0.92-1223)
+	python-ceph (<< 0.92-1223),
+	librbd1 (<< 0.92-1238)
 Suggests: ceph, ceph-mds
 Description: common utilities to mount and interact with a ceph storage cluster
  Ceph is a massively scalable, open-source, distributed

--- a/debian/librbd1.install
+++ b/debian/librbd1.install
@@ -1,4 +1,1 @@
-lib/udev/rules.d/50-rbd.rules
-usr/bin/ceph-rbdnamer
 usr/lib/librbd.so.*
-usr/share/man/man8/ceph-rbdnamer.8


### PR DESCRIPTION
We should ship the RBD udev rules in the same package that ships `/usr/bin/rbd`.  This package happens to be ceph-common, so move the udev rules there.

The udev rules rely on the `ceph-rbdnamer` utility, so move that utility and its man page as well.

This pull request resolves http://tracker.ceph.com/issues/10864