### PR TITLE
osd: fix negative degraded objects during backfilling

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2297,7 +2297,7 @@ void PG::_update_calc_stats()
 
     // a degraded objects has fewer replicas or EC shards than the
     // pool specifies
-    uint64_t degraded = 0;
+    int64_t degraded = 0;
 
     // if acting is smaller than desired, add in those missing replicas
     if (acting.size() < target)
@@ -2319,7 +2319,9 @@ void PG::_update_calc_stats()
       degraded += peer_missing[*i].num_missing();
 
       // not yet backfilled
-      degraded += num_objects - peer_info[*i].stats.stats.sum.num_objects;
+      int64_t diff = num_objects - peer_info[*i].stats.stats.sum.num_objects;
+      if (diff > 0)
+        degraded += diff;
     }
     info.stats.stats.sum.num_objects_degraded = degraded;
     info.stats.stats.sum.num_objects_unfound = get_num_unfound();


### PR DESCRIPTION
When there is deleting requests during backfilling, the reported number of degraded
objects could be negative, as the primary's num_objects is the latest (locally) but
the number for replicas might not reflect the deletings. A simple fix is to ignore
the negative subtracted value.

Fixes: 7737

Signed-off-by: Guang Yang <yguang@yahoo-inc.com>