### PR TITLE
Fix build of `--with-debug --enable-xio`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,6 +109,7 @@ endif # WITH_FUSE
 libcephfs_la_SOURCES = libcephfs.cc
 libcephfs_la_LIBADD = $(LIBCLIENT) $(LIBCOMMON) $(PTHREAD_LIBS) $(CRYPTO_LIBS) $(EXTRALIBS)
 libcephfs_la_LDFLAGS = ${AM_LDFLAGS} -version-info 1:0:0 -export-symbols-regex '^ceph_.*'
+libcephfs_la_LDFLAGS += -Xcompiler -Xlinker -Xcompiler '--exclude-libs=libcommon.a'
 lib_LTLIBRARIES += libcephfs.la
 
 # jni library (java source is in src/java)

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -97,13 +97,6 @@ libcommon_internal_la_SOURCES += \
 LIBCOMMON_DEPS += libcommon_internal.la
 noinst_LTLIBRARIES += libcommon_internal.la
 
-libcommon_api_la_SOURCES = \
-	common/buffer.cc
-if LINUX
-libcommon_api_la_CXXFLAGS = -fvisibility=hidden -fvisibility-inlines-hidden
-endif # LINUX
-noinst_LTLIBRARIES += libcommon_api.la
-
 # inject crc in common
 libcommon_crc_la_SOURCES = \
 	common/sctp_crc32.c \
@@ -135,8 +128,8 @@ if LINUX
 LIBCOMMON_DEPS += -lrt
 endif # LINUX
 
-libcommon_la_SOURCES =
-libcommon_la_LIBADD = $(LIBCOMMON_DEPS) libcommon_api.la
+libcommon_la_SOURCES = common/buffer.cc
+libcommon_la_LIBADD = $(LIBCOMMON_DEPS)
 noinst_LTLIBRARIES += libcommon.la
 
 noinst_HEADERS += \

--- a/src/libradosstriper/Makefile.am
+++ b/src/libradosstriper/Makefile.am
@@ -6,7 +6,7 @@ libradosstriper_la_SOURCES = \
 # We need this to avoid basename conflicts with the libradosstriper build tests in test/Makefile.am
 libradosstriper_la_CXXFLAGS = ${AM_CXXFLAGS}
 
-LIBRADOSSTRIPER_DEPS = $(LIBRADOS_DEPS)
+LIBRADOSSTRIPER_DEPS = $(LIBRADOS_DEPS) librados_api.la
 libradosstriper_la_LIBADD = $(LIBRADOSSTRIPER_DEPS)
 libradosstriper_la_LDFLAGS = ${AM_LDFLAGS} -version-info 1:0:0
 if LINUX

--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -211,7 +211,7 @@ int XioConnection::on_msg_req(struct xio_session *session,
 
   if (! in_seq.p()) {
     if (!treq->in.header.iov_len) {
-	derr << __func__ << " empty header: packet out of sequence?" << dendl;
+	ldout(msgr->cct,0) << __func__ << " empty header: packet out of sequence?" << dendl;
 	xio_release_msg(req);
 	return 0;
     }
@@ -657,9 +657,8 @@ int XioConnection::CState::state_discon()
   return 0;
 }
 
-int XioConnection::CState::state_flow_controlled(uint32_t flags) {
-  dout(11) << __func__ << " ENTER " << dendl;
-
+int XioConnection::CState::state_flow_controlled(uint32_t flags)
+{
   if (! (flags & OP_FLAG_LOCKED))
     pthread_spin_lock(&xcon->sp);
 

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -644,26 +644,26 @@ int XioMessenger::bind(const entity_addr_t& addr)
   if (a->is_blank_ip()) {
     a = &_addr;
     std::vector <std::string> my_sections;
-    g_conf->get_my_sections(my_sections);
+    cct->_conf->get_my_sections(my_sections);
     std::string rdma_local_str;
-    if (g_conf->get_val_from_conf_file(my_sections, "rdma local",
+    if (cct->_conf->get_val_from_conf_file(my_sections, "rdma local",
 				      rdma_local_str, true) == 0) {
       struct entity_addr_t local_rdma_addr;
       local_rdma_addr = *a;
       const char *ep;
       if (!local_rdma_addr.parse(rdma_local_str.c_str(), &ep)) {
-	derr << "ERROR:  Cannot parse rdma local: " << rdma_local_str << dendl;
+	ldout(cct,0) << "ERROR:  Cannot parse rdma local: " << rdma_local_str << dendl;
 	return -EINVAL;
       }
       if (*ep) {
-	derr << "WARNING: 'rdma local trailing garbage ignored: '" << ep << dendl;
+	ldout(cct,0) << "WARNING: 'rdma local trailing garbage ignored: '" << ep << dendl;
       }
       int p = _addr.get_port();
       _addr.set_sockaddr(reinterpret_cast<struct sockaddr *>(
 			  &local_rdma_addr.ss_addr()));
       _addr.set_port(p);
     } else {
-      derr << "WARNING: need 'rdma local' config for remote use!" <<dendl;
+      ldout(cct,0) << "WARNING: need 'rdma local' config for remote use!" <<dendl;
     }
   }
 

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -731,7 +731,8 @@ ceph_test_cls_rgw_opstate_LDADD = \
 	-lcurl -luuid -lexpat \
 	libcls_version_client.a libcls_log_client.a \
 	libcls_statelog_client.a libcls_refcount_client.la \
-	libcls_rgw_client.la libcls_user_client.a libcls_lock_client.la
+	libcls_rgw_client.la libcls_user_client.a libcls_lock_client.la \
+	$(LIBRADOS)
 ceph_test_cls_rgw_opstate_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_cls_rgw_opstate
 endif # WITH_RADOSGW


### PR DESCRIPTION
* fix the build with `--enable-xio --with-debug`
* do not hide the symbols in buffer.cc if ENABLE_XIO, as XioMessenger.cc
  is referencing it.

Fixes: #10735
Co-authored-by: Danny Al-Gaaf <danny.al-gaaf@bisect.de>
Signed-off-by: Kefu Chai <kchai@redhat.com>

see #3734 