### PR TITLE
Messenger: Fix bad crc when different header crc config set

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -553,7 +553,7 @@ void AsyncConnection::process()
           ldout(async_msgr->cct, 20) << __func__ << " begin MSG" << dendl;
           ceph_msg_header header;
           ceph_msg_header_old oldheader;
-          __u32 header_crc;
+          __u32 header_crc = 0;
           int len;
           if (has_feature(CEPH_FEATURE_NOSRCADDR))
             len = sizeof(header);
@@ -572,7 +572,7 @@ void AsyncConnection::process()
 
           if (has_feature(CEPH_FEATURE_NOSRCADDR)) {
             header = *((ceph_msg_header*)state_buffer);
-            if (msgr->crcflags & MSG_CRC_HEADER)
+            if (msgr->crcflags & MSG_CRC_HEADER && header.crc)
               header_crc = ceph_crc32c(0, (unsigned char *)&header,
                                        sizeof(header) - sizeof(header.crc));
           } else {
@@ -581,7 +581,7 @@ void AsyncConnection::process()
             memcpy(&header, &oldheader, sizeof(header));
             header.src = oldheader.src.name;
             header.reserved = oldheader.reserved;
-            if (msgr->crcflags & MSG_CRC_HEADER) {
+            if (msgr->crcflags & MSG_CRC_HEADER && oldheader.crc) {
               header.crc = oldheader.crc;
               header_crc = ceph_crc32c(0, (unsigned char *)&oldheader, sizeof(oldheader) - sizeof(oldheader.crc));
             }

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1900,7 +1900,7 @@ int Pipe::read_message(Message **pm, AuthSessionHandler* auth_handler)
   if (connection_state->has_feature(CEPH_FEATURE_NOSRCADDR)) {
     if (tcp_read((char*)&header, sizeof(header)) < 0)
       return -1;
-    if (msgr->crcflags & MSG_CRC_HEADER) {
+    if (msgr->crcflags & MSG_CRC_HEADER && header.crc) {
       header_crc = ceph_crc32c(0, (unsigned char *)&header, sizeof(header) - sizeof(header.crc));
     }
   } else {
@@ -1911,7 +1911,7 @@ int Pipe::read_message(Message **pm, AuthSessionHandler* auth_handler)
     memcpy(&header, &oldheader, sizeof(header));
     header.src = oldheader.src.name;
     header.reserved = oldheader.reserved;
-    if (msgr->crcflags & MSG_CRC_HEADER) {
+    if (msgr->crcflags & MSG_CRC_HEADER && oldheader.crc) {
       header.crc = oldheader.crc;
       header_crc = ceph_crc32c(0, (unsigned char *)&oldheader, sizeof(oldheader) - sizeof(oldheader.crc));
     }


### PR DESCRIPTION
If initiator disable header crc and receiver enable header crc, we need to check message whether header' crc is trusted(!= 0);