### PR TITLE
osd: fix PG leak in SnapTrimWQ._clear()

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1501,7 +1501,9 @@ protected:
       pg->put("SnapTrimWQ");
     }
     void _clear() {
-      osd->snap_trim_queue.clear();
+      while (PG *pg = _dequeue()) {
+	pg->put("SnapTrimWQ");
+      }
     }
   } snap_trim_wq;
 


### PR DESCRIPTION
Fixes: #10421
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 01e154d592d6cdbf3f859cf1b4357e803536a6b4)