### PR TITLE
osd_types: op_queue_age_hist and fs_perf_stat should be in osd_stat_t::o...

### DIFF
--- a/src/common/histogram.h
+++ b/src/common/histogram.h
@@ -74,6 +74,10 @@ public:
     return b;
   }
 
+  bool operator==(const pow2_hist_t &r) const {
+    return h == r.h;
+  }
+
   /// get a value's position in the histogram.
   ///
   /// positions are represented as values in the range [0..1000000]

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -654,6 +654,11 @@ struct objectstore_perf_stat_t {
   objectstore_perf_stat_t() :
     filestore_commit_latency(0), filestore_apply_latency(0) {}
 
+  bool operator==(const objectstore_perf_stat_t &r) const {
+    return filestore_commit_latency == r.filestore_commit_latency &&
+      filestore_apply_latency == r.filestore_apply_latency;
+  }
+
   void add(const objectstore_perf_stat_t &o) {
     filestore_commit_latency += o.filestore_commit_latency;
     filestore_apply_latency += o.filestore_apply_latency;
@@ -717,7 +722,9 @@ inline bool operator==(const osd_stat_t& l, const osd_stat_t& r) {
     l.snap_trim_queue_len == r.snap_trim_queue_len &&
     l.num_snap_trimming == r.num_snap_trimming &&
     l.hb_in == r.hb_in &&
-    l.hb_out == r.hb_out;
+    l.hb_out == r.hb_out &&
+    l.op_queue_age_hist == r.op_queue_age_hist &&
+    l.fs_perf_stat == r.fs_perf_stat;
 }
 inline bool operator!=(const osd_stat_t& l, const osd_stat_t& r) {
   return !(l == r);


### PR DESCRIPTION
...perator==

Fixes: 10259
Backport: giant, firefly, dumpling
Signed-off-by: Samuel Just <sjust@redhat.com>
(cherry picked from commit 1ac17c0a662e6079c2c57edde2b4dc947f547f57)