### PR TITLE
osd: Update object state after removing watch from object info

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -7091,6 +7091,9 @@ void ReplicatedPG::handle_watch_timeout(WatchRef watch)
   issue_repop(repop, repop->ctx->mtime);
   eval_repop(repop);
   repop->put();
+
+  // apply new object state.
+  ctx->obc->obs = ctx->new_obs;
 }
 
 ObjectContextRef ReplicatedPG::create_object_context(const object_info_t& oi,


### PR DESCRIPTION
Fixes: #10784

Signed-off-by: David Zafman <dzafman@redhat.com>
(cherry picked from commit 418ca0c3a5aa8aa64c1aa78f45ce4925e7d2ac6f)

Conflicts:
	src/osd/ReplicatedPG.cc
        the conflict comes from three lines being encapsultated
        into the simple_repop_submit method but otherwise the same