### PR TITLE
doc/install/manual-deployment: fix osd install doc

### DIFF
--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -445,11 +445,12 @@ OSDs with the long form procedure, execute the following on ``node2`` and
    In this case, to allow the start of the daemon at each reboot you
    must create an empty file like this::
 
-	sudo touch /var/lib/ceph/osd/{cluster-name}-{hostname}/sysvinit
+	sudo touch /var/lib/ceph/osd/{cluster-name}-{osd-num}/sysvinit
 
    For example::
 
-	sudo touch /var/lib/ceph/osd/ceph-node1/sysvinit
+	sudo touch /var/lib/ceph/osd/ceph-0/sysvinit
+	sudo touch /var/lib/ceph/osd/ceph-1/sysvinit
 
    Once you start your OSD, it is ``up`` and ``in``.
 


### PR DESCRIPTION
* should be using /var/lib/ceph/osd/{cluster-name}-{osd-num}/sysvinit
  instead of var/lib/ceph/osd/{cluster-name}-{hostname}/sysvinit, thanks
  to Kyle Hutson <kylehutson@ksu.edu>

Fixes: #10957
Signed-off-by: Kefu Chai <kchai@redhat.com>