### PR TITLE
PG:: recovery optimazation: recovery what is really modified

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -350,6 +350,15 @@ void PG::remove_snap_mapped_object(
   clear_object_snap_mapping(&t, soid);
 }
 
+void PG::truncate_stale_object(
+  ObjectStore::Transaction &t, const hobject_t &soid, uint64_t offset)
+{
+  t.truncate(
+    coll,
+    ghobject_t(soid, ghobject_t::NO_GEN, pg_whoami.shard),
+    offset);
+}
+
 void PG::clear_object_snap_mapping(
   ObjectStore::Transaction *t, const hobject_t &soid)
 {

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -255,6 +255,9 @@ public:
   void on_local_recover_start(
     const hobject_t &oid,
     ObjectStore::Transaction *t);
+  void on_local_recover_start_partial(
+    const hobject_t &oid,
+    ObjectStore::Transaction *t);
   void on_local_recover(
     const hobject_t &oid,
     const object_stat_sum_t &stat_diff,
@@ -522,6 +525,8 @@ public:
     ObjectContextRef snapset_obc;  // if we created/deleted a snapdir
 
     int data_off;        // FIXME: we may want to kill this msgr hint off at some point!
+    bool has_truncate;   // whether modify op has truncation
+    uint64_t truncate_offset;  // truncate truncate offset if there is a truncation included 
 
     MOSDOpReply *reply;
 
@@ -595,9 +600,8 @@ public:
       ignore_cache(false),
       bytes_written(0), bytes_read(0), user_at_version(0),
       current_osd_subop_num(0),
-      op_t(NULL),
-      obc(obc),
-      data_off(0), reply(NULL), pg(_pg),
+      op_t(NULL), obc(obc),
+      data_off(0), has_truncate(false), truncate_offset(0), reply(NULL), pg(_pg),
       num_read(0),
       num_write(0),
       copy_cb(NULL),


### PR DESCRIPTION
Now, recover always pull or push the whole object when recovering. We want to record modified_range into pg_log and recover the partial content of the object that is really modified. Don't delete and copy a whole object when running pg_log based recovery. Since it is related to the data integrity, so the code just shows a purpose or idea to do that, and still cannot use safely. Still lots of compact issue should be completed. Maybe it is possible, or it may not. Can any one give more ideas or suggestions? 

Signed-off-by: Ning Yao <zay11022@ruijie.com.cn>