### PR TITLE
ceph-disk: rhel 7 and up can use partprobe

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1023,7 +1023,10 @@ def update_partition(action, dev, description):
      # On RHEL and CentOS distros, calling partprobe forces a reboot of the
      # server. Since we are not resizing partitons so we rely on calling
      # partx
-     if platform_distro().startswith(('centos', 'red', 'scientific')):
+
+     # This was fixed in rhel 7.x, checking for it.
+     rel = platform_information()[1]
+     if float(rel) < 7.0 and platform_distro().startswith(('centos', 'red', 'scientific')):
          LOG.info('calling partx on %s device %s', description, dev)
          LOG.info('re-reading known partitions will display errors')
          command(

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1023,20 +1023,20 @@ def update_partition(action, dev, description):
      # On RHEL and CentOS distros, calling partprobe forces a reboot of the
      # server. Since we are not resizing partitons so we rely on calling
      # partx
-
-     # This was fixed in rhel 7.x, checking for it.
-     rel = platform_information()[1]
-     if float(rel) < 7.0 and platform_distro().startswith(('centos', 'red', 'scientific')):
-         LOG.info('calling partx on %s device %s', description, dev)
-         LOG.info('re-reading known partitions will display errors')
-         command(
-             [
-                 'partx',
-                 action,
-                 dev,
-             ],
-         )
-
+     if platform_distro().startswith('red'):
+          # This was fixed in rhel 7.x, checking for it.
+          _, version, _ = platform_information()
+          if not version.startswith('7'):
+               if platform_distro().startswith(('centos', 'red', 'scientific')):
+                    LOG.info('calling partx on %s device %s', description, dev)
+                    LOG.info('re-reading known partitions will display errors')
+                    command(
+                        [
+                            'partx',
+                            action,
+                            dev,
+                        ],
+                    )
      else:
          LOG.debug('Calling partprobe on %s device %s', description, dev)
          command(


### PR DESCRIPTION
Previous rhedaht based versions needed to use partx when creating new partitions.
This is no longer an issue with rhel 7 and up. this breaks ceph-disk for
rhel 7 due to the fact partx no longer supports the parameters used. I have added
a check to make all versions of redhat from 7 and up to use partprobe instead.

Signed-off-by: Itamar Landsman itamar@itamar.org