### PR TITLE
tests: keep intermediate docker build layers

### DIFF
--- a/src/test/docker-test-helper.sh
+++ b/src/test/docker-test-helper.sh
@@ -48,7 +48,7 @@ function setup_container() {
         os_version=$os_version user_id=$(id -u) \
             perl -p -e 's/%%(\w+)%%/$ENV{$1}/g' \
             dockerfile/Dockerfile.in > dockerfile/Dockerfile
-        docker $opts build --rm=true --tag=$image dockerfile
+        docker $opts build --tag=$image dockerfile
         rm -fr dockerfile
     fi
 }


### PR DESCRIPTION
Because the docker devmapper backend has an intermittent bug

   https://github.com/docker/docker/issues/4036

the build of the image will sometime fail. It will eventually succeed if
the command is repeated enough times. Not removing the intermediate
layers helps speed up the operation: when repeating the command, only
the layer that failed because of the above bug is rebuilt.

Signed-off-by: Loic Dachary <ldachary@redhat.com>