### PR TITLE
ceph.spec.in: use hardening flags

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -5,6 +5,8 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 %endif
 
+%global _hardened_build 1
+
 #################################################################################
 # common
 #################################################################################


### PR DESCRIPTION
Quoting from https://fedoraproject.org/wiki/Packaging:Guidelines#PIE

> This adds `-fPIC` (if `-fPIE` is not already present) to the compiler flags, and adds `-z now` to the linker flags.

This change was originally done downstream in Fedora at https://bugzilla.redhat.com/955174 , but it never made its way upstream.

The Fedora Project intends to set this flag by default in Fedora 23: https://fedoraproject.org/wiki/Changes/Harden_all_packages_with_position-independent_code If that happens, we will still need this flag here for RHEL 6 and RHEL 7.