### PR TITLE
RFC Client: do not require successful remount when unmounting

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3453,7 +3453,7 @@ public:
       client_t whoami = client->get_nodeid();
       lderr(client->cct) << "tried to remount (to trim kernel dentries) and got error "
 			 << r << dendl;
-      if (client->require_remount) {
+      if (client->require_remount && !client->unmounting) {
 	assert(0 == "failed to remount for kernel dentry trimming");
       }
     }

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -421,6 +421,7 @@ protected:
   friend class C_C_Tick; // Asserts on client_lock
   friend class C_Client_SyncCommit; // Asserts on client_lock
   friend class C_Client_RequestInterrupt;
+  friend class C_Client_Remount;
 
   //int get_cache_size() { return lru.lru_get_size(); }
   //void set_cache_size(int m) { lru.lru_set_max(m); }


### PR DESCRIPTION
This preserves the behavior we had before checking the return status of the system call: we try and remount while unmounting, get a failure, and ignore it (with a message, now).

We could also try to avoid the remount call to begin with, but I'm not sure about the race conditions that are present there, so I default to preserving existing behavior.