### PR TITLE
osd: filestore sync by force when sync_and_flush

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -3710,6 +3710,7 @@ void FileStore::sync_and_flush()
     if (journal)
       journal->flush();
     _flush_op_queue();
+    sync();
   } else {
     // includes m_filestore_journal_parallel
     _flush_op_queue();


### PR DESCRIPTION
I think filestore should do sync by force when sync_and_flush.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>