### PR TITLE
assert: fix the compilation with C compiler

### DIFF
--- a/src/include/assert.h
+++ b/src/include/assert.h
@@ -12,7 +12,7 @@
 # include "acconfig.h"
 #endif
 
-class CephContext;
+struct CephContext;
 
 #ifdef __cplusplus
 namespace ceph {
@@ -65,7 +65,7 @@ struct FailedAssertion {
 # define __CEPH_ASSERT_FUNCTION ((__const char *) 0)
 #endif
 
-extern void register_assert_context(CephContext *cct);
+extern void register_assert_context(struct CephContext *cct);
 extern void __ceph_assert_fail(const char *assertion, const char *file, int line, const char *function)
   __attribute__ ((__noreturn__));
 extern void __ceph_assertf_fail(const char *assertion, const char *file, int line, const char *function, const char* msg, ...)


### PR DESCRIPTION
* gcc 4.9.2 chokes at `class CephContext` if the language is C.

Fixes: #10999
Signed-off-by: Kefu Chai <kchai@redhat.com>