### PR TITLE
osd: write journal header by force when journal write close

### DIFF
--- a/src/os/FileJournal.h
+++ b/src/os/FileJournal.h
@@ -414,6 +414,8 @@ private:
     return full_state != FULL_NOTFULL && !write_stop;
   }
 
+  void write_header();
+
   void set_wait_on_full(bool b) { wait_on_full = b; }
 
   // reads


### PR DESCRIPTION
osd update the journal header when ceph call FileStore::sync_entry(
ApplyManager::commit_finish -> FileJournal::committed_thru).
But, it doesnot write the journal head until the next transaction
(calling do_write or do_aio_write).
So write journal header when journal write close, so that
committed_up_to in journal header is new enough. ceph may
not replay some transaction which has been writen to filestore.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>