### PR TITLE
rgw: do not pre-fetch data for HEAD requests

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -448,7 +448,8 @@ int RGWGetObj::verify_permission()
 {
   obj = rgw_obj(s->bucket, s->object);
   store->set_atomic(s->obj_ctx, obj);
-  store->set_prefetch_data(s->obj_ctx, obj);
+  if (get_data)
+    store->set_prefetch_data(s->obj_ctx, obj);
 
   if (!verify_object_permission(s, RGW_PERM_READ))
     return -EACCES;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -157,7 +157,7 @@ public:
     ret = 0;
  }
 
-  virtual bool prefetch_data() { return true; }
+  virtual bool prefetch_data() { return get_data; }
 
   void set_get_data(bool get_data) {
     this->get_data = get_data;


### PR DESCRIPTION
For HEAD request, as only the meta-data are concerned, it is unnecessary to read the content of the chunk. This could improve the performance for GET, and save resource of the cluster.

Tested locally for HEAD request.

Fixes: 11001

Signed-off-by: Guang Yang <yguang@yahoo-inc.com>