### PR TITLE
mds: flush immediately in do_open_truncate

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3618,6 +3618,10 @@ void Server::do_open_truncate(MDRequestRef& mdr, int cmode)
 
   journal_and_reply(mdr, in, dn, le, new C_MDS_inode_update_finish(mds, mdr, in, old_size > 0,
 								   changed_ranges));
+  // Although the `open` part can give an early reply, the truncation won't
+  // happen until our EUpdate is persistent, to give the client a prompt
+  // response we must also flush that event.
+  mdlog->flush();
 }
 
 


### PR DESCRIPTION
Previously truncating opens were horribly laggy
for clients when the system was otherwise idle,
as they would wait for the next tick() before
proceeding.

Fixes: #11011
Signed-off-by: John Spray <john.spray@redhat.com>