### PR TITLE
osd: Translate fadvise flag NOCACHE into DONTNEED if first access object.

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -679,6 +679,9 @@ OPTION(osd_pg_object_context_cache_count, OPT_INT, 64)
 // determines whether PGLog::check() compares written out log to stored log
 OPTION(osd_debug_pg_log_writeout, OPT_BOOL, false)
 
+// when first access object it can transform fadvise flag NOCACHE into DONTNEED.
+OPTION(osd_munge_nocache_wontneed_on_first_access, OPT_BOOL, true)
+
 // default timeout while caling WaitInterval on an empty queue
 OPTION(threadpool_default_timeout, OPT_INT, 60)
 // default wait time for an empty queue before pinging the hb timeout

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -682,6 +682,10 @@ OPTION(osd_debug_pg_log_writeout, OPT_BOOL, false)
 // when first access object it can transform fadvise flag NOCACHE into DONTNEED.
 OPTION(osd_munge_nocache_wontneed_on_first_access, OPT_BOOL, true)
 
+// peering will effect obc(ObjectContext) cache. After peering+this time,
+// the obc cache is in normal state.
+OPTION(osd_warmup_obc_time, OPT_DOUBLE, 1200.0)  //second
+
 // default timeout while caling WaitInterval on an empty queue
 OPTION(threadpool_default_timeout, OPT_INT, 60)
 // default wait time for an empty queue before pinging the hb timeout

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1924,6 +1924,10 @@ void PG::all_activated_and_committed()
         get_osdmap()->get_epoch(),
         get_osdmap()->get_epoch(),
         AllReplicasActivated())));
+
+  //For pg create/load/recover/backfill, at the end it be there.
+  last_peer_endtime = ceph_clock_now(cct);
+
 }
 
 void PG::queue_snap_trim()
@@ -5476,6 +5480,7 @@ PG::RecoveryState::Reset::Reset(my_context ctx)
   PG *pg = context< RecoveryMachine >().pg;
 
   pg->flushes_in_progress = 0;
+  pg->last_peer_endtime = utime_t();
   pg->set_last_peering_reset();
 }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -245,7 +245,7 @@ protected:
 
 public:
   bool deleting;  // true while in removing or OSD is shutting down
-
+  utime_t last_peer_endtime;
 
   void lock_suspend_timeout(ThreadPool::TPHandle &handle);
   void lock(bool no_lockdep = false) const;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3432,7 +3432,8 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
      * In this case, we transform NOCACHE into DONTNEED.
      * Although this method isn't exactly. But at some case it can work and don't affect others.
      */
-    if (!(ctx->obc->found_in_cache) && (op.flags & CEPH_OSD_OP_FLAG_FADVISE_NOCACHE))
+    if (!(ctx->obc->found_in_cache) && (op.flags & CEPH_OSD_OP_FLAG_FADVISE_NOCACHE) &&
+	g_conf->osd_munge_nocache_wontneed_on_first_access)
       op.flags = op.flags | CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
 
     switch (op.op) {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3423,6 +3423,18 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
       op.op = CEPH_OSD_OP_TRUNCATE;
     }
 
+    /*
+     * The mean of LIBRADOS_OP_FLAG_FADVISE_NOCACHE is this client(only for this client) don't
+     * need data in the future. For filestore, it hope if no data found in page
+     * cache it should use directio. But at present, filesystem don't handle this.
+     * So we use a tricky method that if can't find object in cache of
+     * ObjectContext which mean in the past shorttime none access this object.
+     * In this case, we transform NOCACHE into DONTNEED.
+     * Although this method isn't exactly. But at some case it can work and don't affect others.
+     */
+    if (!(ctx->obc->found_in_cache) && (op.flags & CEPH_OSD_OP_FLAG_FADVISE_NOCACHE))
+      op.flags = op.flags | CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
+
     switch (op.op) {
       
       // --- READS ---
@@ -7745,6 +7757,7 @@ ObjectContextRef ReplicatedPG::get_object_context(const hobject_t& soid,
   osd->logger->inc(l_osd_object_ctx_cache_total);
   if (obc) {
     osd->logger->inc(l_osd_object_ctx_cache_hit);
+    obc->found_in_cache = true;
     dout(10) << __func__ << ": found obc in cache: " << obc
 	     << dendl;
   } else {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3431,9 +3431,13 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
      * ObjectContext which mean in the past shorttime none access this object.
      * In this case, we transform NOCACHE into DONTNEED.
      * Although this method isn't exactly. But at some case it can work and don't affect others.
+     * Avoid DONTNEED on a freshly peered PG where we may not have a warm obc cache and may get false positives.
+     * We record the end-time of last peer event.
      */
     if (!(ctx->obc->found_in_cache) && (op.flags & CEPH_OSD_OP_FLAG_FADVISE_NOCACHE) &&
-	g_conf->osd_munge_nocache_wontneed_on_first_access)
+	g_conf->osd_munge_nocache_wontneed_on_first_access &&
+	(last_peer_endtime != utime_t() &&
+	 (last_peer_endtime < ceph_clock_now(NULL) + cct->_conf->osd_warmup_obc_time)))
       op.flags = op.flags | CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
 
     switch (op.op) {
@@ -8921,6 +8925,7 @@ void ReplicatedPG::on_change(ObjectStore::Transaction *t)
   // NOTE: we actually assert that all currently live references are dead
   // by the time the flush for the next interval completes.
   object_contexts.clear();
+  last_peer_endtime = utime_t();
 }
 
 void ReplicatedPG::on_role_change()

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3005,6 +3005,9 @@ public:
   /// in-progress copyfrom ops for this object
   bool blocked;
 
+  //means this obc was found in a cache and not just created
+  bool found_in_cache;
+
   // set if writes for this object are blocked on another objects recovery
   ObjectContextRef blocked_by;      // object blocking our writes
   set<ObjectContextRef> blocking;   // objects whose writes we block
@@ -3254,7 +3257,7 @@ public:
       destructor_callback(0),
       lock("ReplicatedPG::ObjectContext::lock"),
       unstable_writes(0), readers(0), writers_waiting(0), readers_waiting(0),
-      blocked(false), requeue_scrub_on_unblock(false) {}
+      blocked(false), found_in_cache(false), requeue_scrub_on_unblock(false) {}
 
   ~ObjectContext() {
     assert(rwstate.empty());


### PR DESCRIPTION
The mean of LIBRADOS_OP_FLAG_FADVISE_NOCACHE is only this client don't
need data in the future. For filestore, it hope if no data found in page
cache it should use directio. But at present, filesystem don't handle
this.
So we use a tricky method that if can't find object in cache of
ObjectContext which mean in the shorttime no one access this object.
In that case we add DONTNEED flag if op has NOCACHE.
Although this method isn't exactly. But at some case it can work and
don't affect others.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>