### PR TITLE
ceph-disk: test activate on the second journal

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -964,6 +964,9 @@ def unmount(
 
 ###########################################
 
+def extract_parted_partition_numbers(partitions):
+    numbers_as_strings = re.findall('^\d+', partitions, re.MULTILINE)
+    return map(int, numbers_as_strings)
 
 def get_free_partition_index(dev):
     """
@@ -988,31 +991,19 @@ def get_free_partition_index(dev):
 
     if not lines:
         raise Error('parted failed to output anything')
-    lines = str(lines).splitlines(True)
-
-    # work around buggy libreadline(?) library in rhel/centos.
-    idiot_prefix = '\x1b\x5b\x3f\x31\x30\x33\x34\x68'
-    if lines[0].startswith(idiot_prefix):
-        lines[0] = lines[0][8:]
-
-    if lines[0] not in ['CHS;\n', 'CYL;\n', 'BYT;\n']:
-        raise Error('weird parted units', lines[0])
-    del lines[0]
-
-    if not lines[0].startswith('/dev/'):
-        raise Error('weird parted disk entry', lines[0])
-    del lines[0]
-
-    seen = set()
-    for line in lines:
-        idx, _ = line.split(':', 1)
-        idx = int(idx)
-        seen.add(idx)
-
-    num = 1
-    while num in seen:
-        num += 1
-    return num
+    if ('CHS;' not in lines and
+        'CYL;' not in lines and
+        'BYT;' not in lines):
+        raise Error('parted output expected to contain one of ' +
+                    'CHH; CYL; or BYT; : ' + lines)
+    if dev not in lines:
+        raise Error('parted output expected to contain ' + dev + ': ' + lines)
+    _, partitions = lines.split(dev)
+    partition_numbers = extract_parted_partition_numbers(partitions)
+    if partition_numbers:
+        return max(partition_numbers) + 1
+    else:
+        return 1
 
 
 def update_partition(action, dev, description):

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -51,6 +51,7 @@ timeout=$(which timeout)
 diff=$(which diff)
 mkdir=$(which mkdir)
 rm=$(which rm)
+uuidgen=$(which uuidgen)
 
 function setup() {
     teardown
@@ -170,7 +171,7 @@ function test_no_path() {
 # ceph-disk prepare returns immediately on success if the magic file
 # exists in the --osd-data directory.
 function test_activate_dir_magic() {
-    local uuid=$(uuidgen)
+    local uuid=$($uuidgen)
     local osd_data=$DIR/osd
 
     echo a failure to create the fsid file implies the magic file is not created
@@ -192,7 +193,7 @@ function test_activate_dir_magic() {
 
     echo will not override an existing OSD
 
-    CEPH_ARGS="--fsid $(uuidgen)" \
+    CEPH_ARGS="--fsid $($uuidgen)" \
      ./ceph-disk $CEPH_DISK_ARGS prepare $osd_data 2>&1 | tee $DIR/out
     grep --quiet 'ceph-disk:Data dir .* already exists' $DIR/out || return 1
     grep --quiet $uuid $osd_data/ceph_fsid || return 1
@@ -202,7 +203,7 @@ function test_activate() {
     local to_prepare=$1
     local to_activate=$2
     local journal=$3
-    local osd_uuid=$(uuidgen)
+    local osd_uuid=$($uuidgen)
 
     $mkdir -p $OSD_DATA
 
@@ -378,8 +379,8 @@ function activate_dmcrypt_dev_body() {
     local disk=$1
     local journal=$2
     local newdisk=$3
-    local uuid=$(uuidgen)
-    local juuid=$(uuidgen)
+    local uuid=$($uuidgen)
+    local juuid=$($uuidgen)
 
     setup
     run_mon
@@ -414,8 +415,8 @@ function activate_dmcrypt_plain_dev_body() {
     local disk=$1
     local journal=$2
     local newdisk=$3
-    local uuid=$(uuidgen)
-    local juuid=$(uuidgen)
+    local uuid=$($uuidgen)
+    local juuid=$($uuidgen)
 
     setup
     run_mon

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -303,21 +303,28 @@ function create_dev() {
     local name=$1
 
     dd if=/dev/zero of=$name bs=1024k count=200
+    set -x
+    echo create_dev $name >&2
     losetup --find $name
     local dev=$(losetup --associated $name | cut -f1 -d:)
     ceph-disk zap $dev > /dev/null 2>&1
     echo $dev
+    set +x
 }
 
 function destroy_dev() {
     local name=$1
     local dev=$2
 
+    set -x
+    echo destroy_dev $name $dev >&2
     for partition in 1 2 3 4 ; do
-        umount ${dev}p${partition} || true
+        umount ${dev}p${partition} > /dev/null 2>&1 || true
     done
+    ceph-disk zap $dev > /dev/null 2>&1
     losetup --detach $dev
     rm $name
+    set +x
 }
 
 function activate_dev_body() {

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -31,6 +31,7 @@ FSID=$(uuidgen)
 export CEPH_CONF=$DIR/ceph.conf
 export CEPH_ARGS="--fsid $FSID"
 CEPH_ARGS+=" --chdir="
+CEPH_ARGS+=" --journal-dio=false"
 CEPH_ARGS+=" --run-dir=$DIR"
 CEPH_ARGS+=" --osd-failsafe-full-ratio=.99"
 CEPH_ARGS+=" --mon-host=$MONA"

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -202,11 +202,12 @@ function test_activate() {
     local to_prepare=$1
     local to_activate=$2
     local journal=$3
+    local osd_uuid=$(uuidgen)
 
     $mkdir -p $OSD_DATA
 
     ./ceph-disk $CEPH_DISK_ARGS \
-        prepare $to_prepare $journal || return 1
+        prepare --osd-uuid $osd_uuid $to_prepare $journal || return 1
 
     $timeout $TIMEOUT ./ceph-disk $CEPH_DISK_ARGS \
         activate \
@@ -214,7 +215,7 @@ function test_activate() {
         $to_activate || return 1
     $timeout $TIMEOUT ./ceph osd pool set $TEST_POOL size 1 || return 1
 
-    local id=$($cat $OSD_DATA/ceph-?/whoami || $cat $to_activate/whoami)
+    local id=$(ceph osd create $osd_uuid)
     local weight=1
     ./ceph osd crush add osd.$id $weight root=default host=localhost || return 1
     echo FOO > $DIR/BAR

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -357,9 +357,22 @@ function activate_dev_body() {
 
     setup
     run_mon
+    #
+    # Create an OSD and reuse an existing journal partition
+    #
     test_activate $newdisk ${newdisk}p1 ${journal}p1 || return 1
+    #
+    # Create an OSD and get a journal partition from a disk that
+    # already contains a journal partition which is in use. Updates of
+    # the kernel partition table may behave differently when a
+    # partition is in use. See http://tracker.ceph.com/issues/7334 for
+    # more information.
+    #
+    ceph-disk zap $disk || return 1
+    test_activate $disk ${disk}p1 $journal || return 1
     kill_daemons
     umount ${newdisk}p1 || return 1
+    umount ${disk}p1 || return 1
     teardown
 }
 

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Copyright (C) 2014 Cloudwatt <libre.licensing@cloudwatt.com>
-# Copyright (C) 2014 Red Hat <contact@redhat.com>
+# Copyright (C) 2014, 2015 Red Hat <contact@redhat.com>
 #
 # Author: Loic Dachary <loic@dachary.org>
 #
@@ -350,6 +350,7 @@ function test_activate_dev() {
 
     activate_dev_body $disk $journal $newdisk
     status=$?
+    test $status != 0 && teardown
 
     destroy_dev vdf.disk $disk
     destroy_dev vdg.disk $journal
@@ -399,6 +400,7 @@ function test_activate_dmcrypt_dev() {
 
     activate_dmcrypt_dev_body $disk $journal $newdisk
     status=$?
+    test $status != 0 && teardown
 
     destroy_dmcrypt_dev vdf.disk $disk
     destroy_dmcrypt_dev vdg.disk $journal


### PR DESCRIPTION
This series has been manually tested on Ubuntu 14.04, CentOS 7, RHEL 7, CentOS 6.5 and RHEL 6.5 on virtual machines and a native distribution installed, with a compilation from sources and the following command:
<pre>
sudo env PATH=:$PATH test/ceph-disk.sh test_activate_dev
</pre>
run from the src directory. In the case of CentOS 6.5 and RHEL 6.5 an additional reboot was necessary to add loop.max_part=16 to the kernel cmdline.