### PR TITLE
#10989 ceph.spec.in: loosen ceph-test's dependencies

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -315,9 +315,7 @@ RESTful bencher that can be used to benchmark radosgw performance.
 Summary:	Ceph benchmarks and test tools
 Group:		System Environment/Libraries
 License:	LGPL-2.0
-Requires:	librados2 = %{epoch}:%{version}-%{release}
-Requires:	librbd1 = %{epoch}:%{version}-%{release}
-Requires:	libcephfs1 = %{epoch}:%{version}-%{release}
+Requires:	ceph-common
 %if (0%{?fedora} >= 20 || 0%{?rhel} == 6)
 BuildRequires:	lttng-ust-devel
 BuildRequires:	libbabeltrace-devel


### PR DESCRIPTION
In Debian, the ceph-test package can be installed along with any version of ceph-common.

Prior to this pull request, in RHEL, we're much more strict about which version of the dependencies we require in ceph-test. We depend directly on librados2/librbd1 instead of ceph-common, and we also require the specific versions of these libraries to match the version of ceph-test.

For testing Ceph, it is nice to have the ability to upgrade the librados2/librbd1 libraries on a host without having to also upgrade the ceph-test package as well.

This should fix http://tracker.ceph.com/issues/10989