### PR TITLE
ceph needs gmock/gtest to be statically linked

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,4 @@
 [submodule "src/gmock"]
 	path = src/gmock
 	url = https://github.com/ceph/gmock.git
+        branch = ceph-release-1.7.0


### PR DESCRIPTION
The ceph-test package depends on gmock and gtest and needs to statically
link them because packages are not configured to distribute the
corresponding shared library files.

Update the gmock submodule to the version that is configured with
noinst libraries that will be statically linked.

The gmock submodule is modified to reference the branch in which the
ceph specific changes have been done.

http://tracker.ceph.com/issues/11040 Fixes: #11040

Signed-off-by: Loic Dachary <loic@dachary.org>