### PR TITLE
osd: add l_osd_op_cache_hit perf counter for cache pool

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2149,6 +2149,8 @@ void OSD::create_logger()
   osd_plb.add_u64_counter(l_osd_object_ctx_cache_hit, "object_ctx_cache_hit");
   osd_plb.add_u64_counter(l_osd_object_ctx_cache_total, "object_ctx_cache_total");
 
+  osd_plb.add_u64_counter(l_osd_op_cache_hit, "op_cache_hit");
+
   logger = osd_plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
 }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -144,6 +144,8 @@ enum {
   l_osd_object_ctx_cache_hit,
   l_osd_object_ctx_cache_total,
 
+  l_osd_op_cache_hit,
+
   l_osd_last,
 };
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1866,6 +1866,7 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
   }
 
   if (obc.get() && obc->obs.exists) {
+    osd->logger->inc(l_osd_op_cache_hit);
     return false;
   }
 


### PR DESCRIPTION
l_osd_op_cache_hit counter which is useful for
showing the hit rate in cache pool when combined with l_osd_op counter.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>