### PR TITLE
qa: make rbd-fuse exit cleanly with lttng

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,8 +1,10 @@
-v0.87.1 Giant (Pending)
+v0.94
 -----
-* Due to a change in the Linux kernel version 3.18 and the limits of the FUSE
-  interface, ceph-fuse needs be mounted as root on at least some systems. See
-  issues #9997, #10277, and #10542 for details.
 
-v0.93
------
+* librbd and librados include lttng tracepoints on distros with
+  liblttng 2.4 or later (only Ubuntu Trusty for the ceph.com
+  packages). When running a daemon that uses these libraries, i.e. an
+  application that calls fork(2) or clone(2) without exec(3), you must
+  set LD_PRELOAD=liblttng-ust-fork.so.0 to prevent a crash in the
+  lttng atexit handler when the process exits. The only ceph tool that
+  requires this is rbd-fuse.

--- a/qa/workunits/rbd/merge_diff.sh
+++ b/qa/workunits/rbd/merge_diff.sh
@@ -33,7 +33,8 @@ function rebuild()
   rbd create $gen --size 100 --order $1 --stripe_unit $2 --stripe_count $3 --image-format $4
   rbd create $out --size 1 --order 19
   mkdir -p mnt diffs
-  rbd-fuse -p $pool mnt
+  # lttng has atexit handlers that need to be fork/clone aware
+  LD_PRELOAD=liblttng-ust-fork.so.0 rbd-fuse -p $pool mnt
 }
 
 function write()


### PR DESCRIPTION
lttng requires daemons (things that call fork, clone, or daemon without
exec, like fuse) to use a LD_PRELOAD library. Without this, the lttng
atexit() handler crashes.

Also add a release note about this LD_PRELOAD requirement.