### PR TITLE
tests: centos 7 docker does not need systemd

### DIFF
--- a/src/test/centos-7/Dockerfile.in
+++ b/src/test/centos-7/Dockerfile.in
@@ -23,8 +23,7 @@ FROM centos:%%os_version%%
 COPY install-deps.sh /root/
 COPY ceph.spec.in /root/
 # http://jperrin.github.io/centos/2014/09/25/centos-docker-and-systemd/
-RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs && (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done) && rm -f /lib/systemd/system/multi-user.target.wants/* && rm -f /etc/systemd/system/*.wants/* && rm -f /lib/systemd/system/local-fs.target.wants/* && rm -f /lib/systemd/system/sockets.target.wants/*udev* && rm -f /lib/systemd/system/sockets.target.wants/*initctl* && rm -f /lib/systemd/system/basic.target.wants/* && rm -f /lib/systemd/system/anaconda.target.wants/* && yum install -y redhat-lsb-core
-RUN yum install -y yum-utils && yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/7/x86_64/ && yum install --nogpgcheck -y epel-release && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7 && rm /etc/yum.repos.d/dl.fedoraproject.org*
+RUN yum install -y redhat-lsb-core && yum install -y yum-utils && yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/7/x86_64/ && yum install --nogpgcheck -y epel-release && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7 && rm /etc/yum.repos.d/dl.fedoraproject.org*
 # build dependencies
 RUN cd /root ; ./install-deps.sh
 # development tools


### PR DESCRIPTION
The line

   yum -y swap -- remove fakesystemd -- ...

can be reduced to

   yum install -y redhat-lsb-core

because lsb_release is all we need. In addition an AUFS bug makes it
fail with https://github.com/docker/docker/issues/6980 when docker is
used with the AUFS storage backed (default on Ubuntu).

Signed-off-by: Loic Dachary <ldachary@redhat.com>