### PR TITLE
tests: increase the delay waiting for a cluster event

### DIFF
--- a/src/test/ceph-helpers.sh
+++ b/src/test/ceph-helpers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Copyright (C) 2013,2014 Cloudwatt <libre.licensing@cloudwatt.com>
-# Copyright (C) 2014 Red Hat <contact@redhat.com>
+# Copyright (C) 2014,2015 Red Hat <contact@redhat.com>
 # Copyright (C) 2014 Federico Gimenez <fgimenez@coit.es>
 #
 # Author: Loic Dachary <loic@dachary.org>
@@ -18,7 +18,7 @@
 # GNU Library Public License for more details.
 #
 CEPH_HELPER_VERBOSE=false
-TIMEOUT=60
+TIMEOUT=120
 PG_NUM=4
 
 if type xmlstarlet > /dev/null 2>&1; then


### PR DESCRIPTION
In some cases the machine running tests may be slow enough that it takes
more than a minute for an OSD to come up. It only happens rarely and
changing the wait period from 60 seconds to 120 seconds. Is so slow
that it takes more than 2 minutes to bring an OSD up, chances are a lot
more will go wrong anyway.

Signed-off-by: Loic Dachary <ldachary@redhat.com>