### PR TITLE
deb: add zlib1g-dev to Build-Depends for Debian/jessie

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,7 +53,8 @@ Build-Depends: autoconf,
                xfslibs-dev,
                xfsprogs,
                xmlstarlet,
-               yasm [amd64]
+               yasm [amd64],
+               zlib1g-dev
 Standards-Version: 3.9.3
 
 Package: ceph


### PR DESCRIPTION
The zlib1g-dev is installed indirectly for Ubuntu 12.04 or Ubuntu 14.04
but it is only suggested in Debian/jessie. Adding it to the
Build-depends is redundant and harmless for Ubuntu and resolves the
missing dependency for Debian.

Signed-off-by: Loic Dachary <ldachary@redhat.com>