### PR TITLE
ReplicatedPG: block write on degraded object if there are waiters

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1487,6 +1487,7 @@ void ReplicatedPG::do_op(OpRequestRef& op)
   if (write_ordered &&
       is_degraded_object(head, &valid_copies) &&
       (valid_copies < pool.info.min_size ||
+       waiting_for_degraded_object.count(head) ||
        pool.info.ec_pool() ||
        !cct->_conf->osd_enable_degraded_writes ||
        !(get_min_peer_features() & CEPH_FEATURE_OSD_DEGRADED_WRITES))) {


### PR DESCRIPTION
Suppose we have min_size of 2 and size of 3, foo exists only on the
primary.
- block op 1 on foo due to < min_size
- start recovery on foo for replicas 1 and 2
- complete push to replica 1 (2 copies now)
- allow op 2 on foo through since we have 2 copies
- complete recovery on foo, requeue op 1

Fixes: 11057
Signed-off-by: Samuel Just <sjust@redhat.com>