### PR TITLE
SimpleMessenger: allow RESETSESSION whenever we forget an endpoint

### DIFF
--- a/src/msg/Pipe.cc
+++ b/src/msg/Pipe.cc
@@ -549,7 +549,7 @@ int Pipe::accept()
 	       << " > " << existing->connect_seq << dendl;
       goto replace;
     } // existing
-    else if (policy.resetcheck && connect.connect_seq > 0) {
+    else if (connect.connect_seq > 0) {
       // we reset, and they are opening a new session
       ldout(msgr->cct,0) << "accept we reset (peer sent cseq " << connect.connect_seq << "), sending RESETSESSION" << dendl;
       msgr->lock.Unlock();


### PR DESCRIPTION
In the past (e229f8451d37913225c49481b2ce2896ca6788a2) we decided to disable
reset of lossless Pipes, because lossless peers resetting caused trouble and
they can't forget about each other. But they actually can: if mark_down()
is called.

I can't figure out how else we could forget about a remote endpoint, so I think
it's okay if we tell them we reset in order to clean up state. That's desirable
so that we don't get into strange situations with out-of-whack counters.

Fixes: #10080
Backport: giant, firefly, dumpling

Signed-off-by: Greg Farnum <gfarnum@redhat.com>
(cherry picked from commit 8cd1fdd7a778eb84cb4d7161f73bc621cc394261)