### PR TITLE
doc: rhel6.5 is rhel6

### DIFF
--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -63,7 +63,7 @@ following steps:
    Paste the following example code. Replace ``{ceph-release}`` with
    the recent major release of Ceph (e.g., ``firefly``). Replace ``{distro}``
    with your Linux distribution (e.g., ``el6`` for CentOS 6, 
-   ``el7`` for CentOS 7, ``rhel6.5`` for
+   ``el7`` for CentOS 7, ``rhel6`` for
    Red Hat 6.5, ``rhel7`` for Red Hat 7, and ``fc19`` or ``fc20`` for Fedora 19
    or Fedora 20. Finally, save the contents to the 
    ``/etc/yum.repos.d/ceph.repo`` file. ::


### PR DESCRIPTION
RHEL 6.5 is actually  http://ceph.com/rpm-giant/rhel6/

Signed-off-by: Loic Dachary <ldachary@redhat.com>