### PR TITLE
osdc: fix a memory leak in C_TwoContexts

### DIFF
--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -89,6 +89,13 @@ struct ObjectOperation {
     void finish(int r) {
       first->complete(r);
       second->complete(r);
+      first = NULL;
+      second = NULL;
+    }
+
+    virtual ~C_TwoContexts() {
+        delete first;
+        delete second;
     }
   };
 


### PR DESCRIPTION
If an ObjectOperation op is cancelled, its destructor is
called and each Context object in out_handler is deleted.
A C_TwoContexts object can be one of these handlers. The
two contexts wrapped in C_TwoContexts must be deleted
as well.

Signed-off-by: Xiong Yiliang <xiongyiliang@xunlei.com>
(cherry picked from commit f33cdbe485d0e4b78a46657bfcb8d5c02d24be69)