### PR TITLE
rm old ceph-deploy reference

### DIFF
--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -166,10 +166,9 @@ Enable Password-less SSH
 ------------------------
 
 Since ``ceph-deploy`` will not prompt for a password, you must generate
-SSH keys on the admin node and distribute the public key to each Ceph node.
-
-.. note:: ``ceph-deploy`` v1.1.3 and later releases will attempt to generate
-   the SSH keys for initial monitors. 
+SSH keys on the admin node and distribute the public key to each Ceph
+node. ``ceph-deploy`` will attempt to generate the SSH keys for initial
+monitors.
 
 #. Generate the SSH keys, but do not use ``sudo`` or the
    ``root`` user. Leave the passphrase empty::


### PR DESCRIPTION
There's no need to refer to this old version of ceph-deploy. v1.1.3 is circa June 2013, and since that time, we have shipped much newer version of ceph-deploy (1.5.22 at the time of this writing). We should simply state the behavior of modern ceph-deploys here.

(CC'ing @trhoden / @johnwilkins for review.)