### PR TITLE
osd: check that source OSD is valid for MOSDRepScrub

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6175,17 +6175,18 @@ bool OSD::require_mon_peer(Message *m)
   return true;
 }
 
-bool OSD::require_osd_peer(OpRequestRef& op)
+bool OSD::require_osd_peer(Message *m)
 {
-  if (!op->get_req()->get_connection()->peer_is_osd()) {
-    dout(0) << "require_osd_peer received from non-osd " << op->get_req()->get_connection()->get_peer_addr()
-	    << " " << *op->get_req() << dendl;
+  if (!m->get_connection()->peer_is_osd()) {
+    dout(0) << "require_osd_peer received from non-osd "
+	    << m->get_connection()->get_peer_addr()
+	    << " " << *m << dendl;
     return false;
   }
   return true;
 }
 
-bool OSD::require_self_aliveness(OpRequestRef& op, epoch_t epoch)
+bool OSD::require_self_aliveness(Message *m, epoch_t epoch)
 {
   if (epoch < up_epoch) {
     dout(7) << "from pre-up epoch " << epoch << " < " << up_epoch << dendl;
@@ -6193,16 +6194,15 @@ bool OSD::require_self_aliveness(OpRequestRef& op, epoch_t epoch)
   }
 
   if (!is_active()) {
-    dout(7) << "still in boot state, dropping message " << *op->get_req() << dendl;
+    dout(7) << "still in boot state, dropping message " << *m << dendl;
     return false;
   }
 
   return true;
 }
 
-bool OSD::require_same_peer_instance(OpRequestRef& op, OSDMapRef& map)
+bool OSD::require_same_peer_instance(Message *m, OSDMapRef& map)
 {
-  Message *m = op->get_req();
   int from = m->get_source().num();
 
   if (!map->have_inst(from) ||
@@ -6224,15 +6224,15 @@ bool OSD::require_same_peer_instance(OpRequestRef& op, OSDMapRef& map)
   return true;
 }
 
-bool OSD::require_up_osd_peer(OpRequestRef& op, OSDMapRef& map,
+bool OSD::require_up_osd_peer(Message *m, OSDMapRef& map,
                               epoch_t their_epoch)
 {
-  if (!require_self_aliveness(op, their_epoch)) {
+  if (!require_self_aliveness(m, their_epoch)) {
     return false;
-  } else if (!require_osd_peer(op)) {
+  } else if (!require_osd_peer(m)) {
     return false;
   } else if (map->get_epoch() >= their_epoch &&
-	     !require_same_peer_instance(op, map)) {
+	     !require_same_peer_instance(m, map)) {
     return false;
   }
   return true;
@@ -6256,13 +6256,13 @@ bool OSD::require_same_or_newer_map(OpRequestRef& op, epoch_t epoch)
     return false;
   }
 
-  if (!require_self_aliveness(op, epoch)) {
+  if (!require_self_aliveness(op->get_req(), epoch)) {
     return false;
   }
 
   // ok, our map is same or newer.. do they still exist?
   if (m->get_connection()->get_messenger() == cluster_messenger &&
-      !require_same_peer_instance(op, osdmap)) {
+      !require_same_peer_instance(op->get_req(), osdmap)) {
     return false;
   }
 
@@ -6731,7 +6731,7 @@ void OSD::handle_pg_notify(OpRequestRef op)
   dout(7) << "handle_pg_notify from " << m->get_source() << dendl;
   int from = m->get_source().num();
 
-  if (!require_osd_peer(op))
+  if (!require_osd_peer(op->get_req()))
     return;
 
   if (!require_same_or_newer_map(op, m->get_epoch())) return;
@@ -6766,7 +6766,7 @@ void OSD::handle_pg_log(OpRequestRef op)
   assert(m->get_header().type == MSG_OSD_PG_LOG);
   dout(7) << "handle_pg_log " << *m << " from " << m->get_source() << dendl;
 
-  if (!require_osd_peer(op))
+  if (!require_osd_peer(op->get_req()))
     return;
 
   int from = m->get_source().num();
@@ -6795,7 +6795,7 @@ void OSD::handle_pg_info(OpRequestRef op)
   assert(m->get_header().type == MSG_OSD_PG_INFO);
   dout(7) << "handle_pg_info " << *m << " from " << m->get_source() << dendl;
 
-  if (!require_osd_peer(op))
+  if (!require_osd_peer(op->get_req()))
     return;
 
   int from = m->get_source().num();
@@ -6832,7 +6832,7 @@ void OSD::handle_pg_trim(OpRequestRef op)
 
   dout(7) << "handle_pg_trim " << *m << " from " << m->get_source() << dendl;
 
-  if (!require_osd_peer(op))
+  if (!require_osd_peer(op->get_req()))
     return;
 
   int from = m->get_source().num();
@@ -6888,7 +6888,7 @@ void OSD::handle_pg_scan(OpRequestRef op)
   assert(m->get_header().type == MSG_OSD_PG_SCAN);
   dout(10) << "handle_pg_scan " << *m << " from " << m->get_source() << dendl;
   
-  if (!require_osd_peer(op))
+  if (!require_osd_peer(op->get_req()))
     return;
   if (!require_same_or_newer_map(op, m->query_epoch))
     return;
@@ -6916,7 +6916,7 @@ void OSD::handle_pg_backfill(OpRequestRef op)
   assert(m->get_header().type == MSG_OSD_PG_BACKFILL);
   dout(10) << "handle_pg_backfill " << *m << " from " << m->get_source() << dendl;
   
-  if (!require_osd_peer(op))
+  if (!require_osd_peer(op->get_req()))
     return;
   if (!require_same_or_newer_map(op, m->query_epoch))
     return;
@@ -6943,7 +6943,7 @@ void OSD::handle_pg_backfill_reserve(OpRequestRef op)
   MBackfillReserve *m = static_cast<MBackfillReserve*>(op->get_req());
   assert(m->get_header().type == MSG_OSD_BACKFILL_RESERVE);
 
-  if (!require_osd_peer(op))
+  if (!require_osd_peer(op->get_req()))
     return;
   if (!require_same_or_newer_map(op, m->query_epoch))
     return;
@@ -6992,7 +6992,7 @@ void OSD::handle_pg_recovery_reserve(OpRequestRef op)
   MRecoveryReserve *m = static_cast<MRecoveryReserve*>(op->get_req());
   assert(m->get_header().type == MSG_OSD_RECOVERY_RESERVE);
 
-  if (!require_osd_peer(op))
+  if (!require_osd_peer(op->get_req()))
     return;
   if (!require_same_or_newer_map(op, m->query_epoch))
     return;
@@ -7048,7 +7048,7 @@ void OSD::handle_pg_query(OpRequestRef op)
   MOSDPGQuery *m = (MOSDPGQuery*)op->get_req();
   assert(m->get_header().type == MSG_OSD_PG_QUERY);
 
-  if (!require_osd_peer(op))
+  if (!require_osd_peer(op->get_req()))
     return;
 
   dout(7) << "handle_pg_query from " << m->get_source() << " epoch " << m->get_epoch() << dendl;
@@ -7152,7 +7152,7 @@ void OSD::handle_pg_remove(OpRequestRef op)
   assert(m->get_header().type == MSG_OSD_PG_REMOVE);
   assert(osd_lock.is_locked());
 
-  if (!require_osd_peer(op))
+  if (!require_osd_peer(op->get_req()))
     return;
 
   dout(7) << "handle_pg_remove from " << m->get_source() << " on "
@@ -7642,7 +7642,7 @@ void OSD::handle_replica_op(OpRequestRef op)
     return;
   }
 
-  if (!require_up_osd_peer(op, osdmap, m->map_epoch))
+  if (!require_up_osd_peer(op->get_req(), osdmap, m->map_epoch))
     return;
 
   // must be a rep op.

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1554,19 +1554,19 @@ protected:
   void repeer(PG *pg, map< int, map<spg_t,pg_query_t> >& query_map);
 
   bool require_mon_peer(Message *m);
-  bool require_osd_peer(OpRequestRef& op);
+  bool require_osd_peer(Message *m);
   /***
    * Verifies that we were alive in the given epoch, and that
    * still are.
    */
-  bool require_self_aliveness(OpRequestRef& op, epoch_t alive_since);
+  bool require_self_aliveness(Message *m, epoch_t alive_since);
   /**
    * Verifies that the OSD who sent the given op has the same
    * address as in the given map.
    * @pre op was sent by an OSD using the cluster messenger
    */
-  bool require_same_peer_instance(OpRequestRef& op, OSDMapRef& map);
-  bool require_up_osd_peer(OpRequestRef& Op, OSDMapRef& map,
+  bool require_same_peer_instance(Message *m, OSDMapRef& map);
+  bool require_up_osd_peer(Message *m, OSDMapRef& map,
                            epoch_t their_epoch);
 
   bool require_same_or_newer_map(OpRequestRef& op, epoch_t e);


### PR DESCRIPTION
Make sure the message we got from the peer OSD is valid.  Specifically,
this avoids a race like this:

- A marks down B
- B sends MOSDRepScrub
- A accepts connection from B as new
- A replies to scrub
- B crashes because msgr seq 1 < expected seq 1000+

See #8880 for the most recent fix for requests.

Fixes: #9555
Backport: giant, firefly
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 847e5e102522d651aa9687a54aaafcebf3afc596)