### PR TITLE
rgw/logrotate.conf: Rename service name

### DIFF
--- a/src/rgw/logrotate.conf
+++ b/src/rgw/logrotate.conf
@@ -7,7 +7,7 @@
         if which invoke-rc.d > /dev/null 2>&1 && [ -x `which invoke-rc.d` ]; then
             invoke-rc.d radosgw reload >/dev/null
         elif which service > /dev/null 2>&1 && [ -x `which service` ]; then
-            service radosgw reload >/dev/null
+            service ceph-radosgw reload >/dev/null
         fi
         # Possibly reload twice, but depending on ceph.conf the reload above may be a no-op
         if which initctl > /dev/null 2>&1 && [ -x `which initctl` ]; then


### PR DESCRIPTION
In rhel 6, the service name for ceph rados gateway is "ceph-radosgw", 
the previously version of service name "radosgw" cause a failed reload, 
and finally make it impossible to create a new rados gateway log file. 

Signed-off-by: wuxingyi <wuxingyi@outlook.com>