### PR TITLE
ObjectStore: Don't use largest_data_off to calc data_align.

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -511,7 +511,7 @@ public:
     int get_data_alignment() {
       if (!largest_data_len)
 	return -1;
-      return (largest_data_off - get_data_offset()) & ~CEPH_PAGE_MASK;
+      return (0 - get_data_offset()) & ~CEPH_PAGE_MASK;
     }
     /// Is the Transaction empty (no operations)
     bool empty() {


### PR DESCRIPTION
If largest_data_off % CEPH_PAGE_SIZE != 0, the get_data_aligment return
a erro value. This make the FileJouranl::align_bl to memcopy much data.

Tested-by: Sage Weil <sage@redhat.com>
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>
(cherry picked from commit a1aa70f2f21339feabfe9c1b3c9c9f97fbd53c9d)