### PR TITLE
restrict xattr length to inline for xfs

### DIFF
--- a/src/os/chain_xattr.h
+++ b/src/os/chain_xattr.h
@@ -9,7 +9,7 @@
 #include <errno.h>
 
 #define CHAIN_XATTR_MAX_NAME_LEN  128
-#define CHAIN_XATTR_MAX_BLOCK_LEN 2048
+#define CHAIN_XATTR_MAX_BLOCK_LEN 250
 
 
 // wrappers to hide annoying errno handling.


### PR DESCRIPTION
Not inline xattr will casue performance penalty. Now object_info_t
becomes 259 bytes, which cannot be inline for xfs. For inline xattr, the
value should be smaller than 254 bytes.
Under is the performance boost if we change it.
before                                           after
find_object_context() _setattrs()   find_object_context() _setattrs()
185138                      4694190     165751                       3319890
improve                                         10.47%                      29.28%

Signed-off-by: Ning Yao <yaoning@ruijie.com.cn>