### PR TITLE
rgw: flush xml header on get acl request

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1300,6 +1300,7 @@ void RGWGetACLs_ObjStore_S3::send_response()
   dump_errno(s);
   end_header(s, this, "application/xml");
   dump_start(s);
+  rgw_flush_formatter(s, s->formatter);
   s->cio->write(acls.c_str(), acls.size());
 }
 


### PR DESCRIPTION
Fixes: #10106
Backport: firefly, giant

dump_start() updates the formatter with the appropriate prefix, however,
we never flushed the formatter.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
(cherry picked from commit eb45f861343162e018968b8c56693a8c6f5b2cab)