### PR TITLE
osd: check pending or active scrub before sched_scrub

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -564,6 +564,7 @@ public:
     return true;
   }
 
+  bool can_inc_scrubs_pending();
   bool inc_scrubs_pending();
   void inc_scrubs_active(bool reserved);
   void dec_scrubs_pending();


### PR DESCRIPTION
osd would contiue to get next pg for scrub even if it is rejected
because current pending + active scrub large than osd_max_scrubs.
This would be rejected in the next round at most time. So check
pending or active scrub before sched_scrub.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>