### PR TITLE
os/FileStore: For getxattr, enlarge the value size avoid try again.

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -3745,7 +3745,7 @@ int FileStore::snapshot(const string& name)
 
 int FileStore::_fgetattr(int fd, const char *name, bufferptr& bp)
 {
-  char val[100];
+  char val[CHAIN_XATTR_MAX_BLOCK_LEN];
   int l = chain_fgetxattr(fd, name, val, sizeof(val));
   if (l >= 0) {
     bp = buffer::create(l);


### PR DESCRIPTION
Even the size of content of user.ceph._ is larger than 100. It will try
again. Avoid this, enlarge the buffer size which use
CHAIN_XATTR_MAX_BLOCK_LEN.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>