### PR TITLE
osd: flush/evict op fixes

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8667,6 +8667,16 @@ int OSD::init_op_flags(OpRequestRef& op)
         break;
       }
 
+    case CEPH_OSD_OP_DELETE:
+      // if we get a delete with FAILOK we can skip promote.  without
+      // FAILOK we still need to promote (or do something smarter) to
+      // determine whether to return ENOENT or 0.
+      if (iter == m->ops.begin() &&
+	  iter->op.flags == CEPH_OSD_OP_FLAG_FAILOK) {
+	op->set_skip_promote();
+      }
+      break;
+
     default:
       break;
     }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8677,6 +8677,14 @@ int OSD::init_op_flags(OpRequestRef& op)
       }
       break;
 
+    case CEPH_OSD_OP_CACHE_TRY_FLUSH:
+    case CEPH_OSD_OP_CACHE_FLUSH:
+    case CEPH_OSD_OP_CACHE_EVICT:
+      // If try_flush/flush/evict is the only op, no need to promote.
+      if (m->ops.size() == 1) {
+	op->set_skip_promote();
+      }
+
     default:
       break;
     }

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -98,7 +98,10 @@ bool OpRequest::need_class_write_cap() {
   return check_rmw(CEPH_OSD_RMW_FLAG_CLASS_WRITE);
 }
 bool OpRequest::need_promote() {
-  return check_rmw(CEPH_OSD_RMW_FLAG_PROMOTE);
+  return check_rmw(CEPH_OSD_RMW_FLAG_FORCE_PROMOTE);
+}
+bool OpRequest::need_skip_promote() {
+  return check_rmw(CEPH_OSD_RMW_FLAG_SKIP_PROMOTE);
 }
 
 void OpRequest::set_rmw_flags(int flags) {
@@ -117,7 +120,8 @@ void OpRequest::set_class_read() { set_rmw_flags(CEPH_OSD_RMW_FLAG_CLASS_READ); 
 void OpRequest::set_class_write() { set_rmw_flags(CEPH_OSD_RMW_FLAG_CLASS_WRITE); }
 void OpRequest::set_pg_op() { set_rmw_flags(CEPH_OSD_RMW_FLAG_PGOP); }
 void OpRequest::set_cache() { set_rmw_flags(CEPH_OSD_RMW_FLAG_CACHE); }
-void OpRequest::set_promote() { set_rmw_flags(CEPH_OSD_RMW_FLAG_PROMOTE); }
+void OpRequest::set_promote() { set_rmw_flags(CEPH_OSD_RMW_FLAG_FORCE_PROMOTE); }
+void OpRequest::set_skip_promote() { set_rmw_flags(CEPH_OSD_RMW_FLAG_SKIP_PROMOTE); }
 
 void OpRequest::mark_flag_point(uint8_t flag, const string& s) {
 #ifdef WITH_LTTNG

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -66,6 +66,7 @@ struct OpRequest : public TrackedOp {
   bool need_class_read_cap();
   bool need_class_write_cap();
   bool need_promote();
+  bool need_skip_promote();
   void set_read();
   void set_write();
   void set_cache();
@@ -73,6 +74,7 @@ struct OpRequest : public TrackedOp {
   void set_class_write();
   void set_pg_op();
   void set_promote();
+  void set_skip_promote();
 
   void _dump(utime_t now, Formatter *f) const;
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3750,6 +3750,10 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  result = -EINVAL;
 	  break;
 	}
+	if (!obs.exists) {
+	  result = 0;
+	  break;
+	}
 	if (oi.is_dirty()) {
 	  result = -EBUSY;
 	  break;

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1156,11 +1156,6 @@ protected:
 		      const object_locator_t& oloc,    ///< locator for obc|oid
 		      OpRequestRef op);                ///< [optional] client op
 
-  /**
-   * Check if the op is such that we can skip promote (e.g., DELETE)
-   */
-  bool can_skip_promote(OpRequestRef op);
-
   int prepare_transaction(OpContext *ctx);
   list<pair<OpRequestRef, OpContext*> > in_progress_async_reads;
   void complete_read_ctx(int result, OpContext *ctx);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -241,7 +241,8 @@ enum {
   CEPH_OSD_RMW_FLAG_CLASS_WRITE = (1 << 4),
   CEPH_OSD_RMW_FLAG_PGOP        = (1 << 5),
   CEPH_OSD_RMW_FLAG_CACHE       = (1 << 6),
-  CEPH_OSD_RMW_FLAG_PROMOTE     = (1 << 7),
+  CEPH_OSD_RMW_FLAG_FORCE_PROMOTE   = (1 << 7),
+  CEPH_OSD_RMW_FLAG_SKIP_PROMOTE    = (1 << 8),
 };
 
 

--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -786,10 +786,10 @@ TEST_F(LibRadosTwoPoolsPP, Evict) {
     op.cache_evict();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate(
-      "fooberdoodle", completion, &op,
+      "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
     completion->wait_for_safe();
-    ASSERT_EQ(-ENOENT, completion->get_return_value());
+    ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
   {
@@ -2988,10 +2988,10 @@ TEST_F(LibRadosTwoPoolsECPP, Evict) {
     op.cache_evict();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate(
-      "fooberdoodle", completion, &op,
+      "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
     completion->wait_for_safe();
-    ASSERT_EQ(-ENOENT, completion->get_return_value());
+    ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
   {


### PR DESCRIPTION
1) Move the skip promotion detection logic into init_op_flags
2) Skip promotion for flush/evict op
3) Correctly handle the evict op when obs doesn't exist