### PR TITLE
osd/ReplicatePG: correctly checking if an object is in hit set

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1607,8 +1607,13 @@ void ReplicatedPG::do_op(OpRequestRef& op)
 
   bool in_hit_set = false;
   if (hit_set) {
-    if (missing_oid != hobject_t() && hit_set->contains(missing_oid))
-      in_hit_set = true;
+    if (obc.get()) {
+      if (obc->obs.oi.soid != hobject_t() && hit_set->contains(obc->obs.oi.soid))
+	in_hit_set = true;
+    } else {
+      if (missing_oid != hobject_t() && hit_set->contains(missing_oid))
+        in_hit_set = true;
+    }
     hit_set->insert(oid);
     if (hit_set->is_full() ||
 	hit_set_start_stamp + pool.info.hit_set_period <= m->get_recv_stamp()) {


### PR DESCRIPTION
For the write case when the oid.snap is CEPH_NOSNAP, the obc is created
in find_object_context, and missing_oid is setting to a NULL object.
Checking if the missing_oid is in the hit set is not the correct way
since it's NULL. Instead, we should check the obc->obs.oi.soid.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>