### PR TITLE
Fix XioLoopbackConnection Lifecycle.

### DIFF
--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -352,6 +352,6 @@ public:
   }
 };
 
-typedef boost::intrusive_ptr<XioLoopbackConnection> LoopbackConnectionRef;
+typedef boost::intrusive_ptr<XioLoopbackConnection> XioLoopbackConnectionRef;
 
 #endif /* XIO_CONNECTION_H */

--- a/src/msg/xio/XioMessenger.h
+++ b/src/msg/xio/XioMessenger.h
@@ -39,7 +39,7 @@ private:
   XioConnection::EntitySet conns_entity_map;
   XioPortals portals;
   DispatchStrategy* dispatch_strategy;
-  XioLoopbackConnection loop_con;
+  XioLoopbackConnectionRef loop_con;
   uint32_t special_handling;
   Mutex sh_mtx;
   Cond sh_cond;
@@ -57,7 +57,7 @@ public:
 
   virtual void set_myaddr(const entity_addr_t& a) {
     Messenger::set_myaddr(a);
-    loop_con.set_peer_addr(a);
+    loop_con->set_peer_addr(a);
   }
 
   int _send_message(Message *m, const entity_inst_t &dest);


### PR DESCRIPTION
Since XioLoopbackConnection is a RefCountedObject, it can't be
an expanded member of XioMessenger.

Fixes cleanup/shutdown errors.

Signed-off-by: Matt Benjamin <matt@cohortfs.com>
(cherry picked from commit f5735b28d154612b339cf5d3b558e4dc5eaa2884)