### PR TITLE
osd: move on to next pg when scrub reservation is rejected

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -209,6 +209,7 @@ OSDService::OSDService(OSD *osd) :
   peer_map_epoch_lock("OSDService::peer_map_epoch_lock"),
   sched_scrub_lock("OSDService::sched_scrub_lock"), scrubs_pending(0),
   scrubs_active(0),
+  reject_scrub_pg(boost::none),
   agent_lock("OSD::agent_lock"),
   agent_valid_iterator(false),
   agent_ops(0),

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3294,6 +3294,7 @@ bool PG::sched_scrub()
       dout(20) << "sched_scrub: failed, a peer declined" << dendl;
       clear_scrub_reserved();
       scrub_unreserve_replicas();
+      osd->next_pg_scrub(info.pgid);
       ret = false;
     } else if (scrubber.reserved_peers.size() == acting.size()) {
       dout(20) << "sched_scrub: success, reserved self and replicas" << dendl;


### PR DESCRIPTION
If remote peer reject the currrent scurb request for pg A, ceph should continue
to check whether next pg B is permitted for scurb. Currently, ceph would check
pg A again in next schedule round, so it would been rejected again.

Fixes: #11017
Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>