### PR TITLE
Specify the actual struct used in protocol handshake

### DIFF
--- a/doc/dev/network-protocol.rst
+++ b/doc/dev/network-protocol.rst
@@ -17,7 +17,7 @@ Banner
 
 The first action is the server sending banner to the client.  The banner is
 defined in ``CEPH_BANNER`` from ``src/include/msgr.h``.  This is followed by
-the server's then client's address each encoded as a ``sockaddr_storage``.
+the server's then client's address each encoded as a ``entity_addr_t``.
 
 Once the client verifies that the servers banner matches its own it replies with
 its banner and its address.


### PR DESCRIPTION
Maybe it was sockaddr_storage in an older version, but it is
definitely entity_addr_t in "ceph v027".

Signed-off-by: Pete Zaitcev <zaitcev@redhat.com>