### PR TITLE
packaging: include ceph_perf_objectstore

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -855,6 +855,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_bindir}/ceph_erasure_code
 %{_bindir}/ceph_erasure_code_benchmark
 %{_bindir}/ceph_omapbench
+%{_bindir}/ceph_perf_objectstore
 %{_bindir}/ceph_psim
 %{_bindir}/ceph_radosacl
 %{_bindir}/ceph_rgw_jsonparser

--- a/debian/ceph-test.install
+++ b/debian/ceph-test.install
@@ -6,6 +6,7 @@ usr/bin/ceph_multi_stress_watch
 usr/bin/ceph_erasure_code
 usr/bin/ceph_erasure_code_benchmark
 usr/bin/ceph_omapbench
+usr/bin/ceph_perf_objectstore
 usr/bin/ceph_psim
 usr/bin/ceph_radosacl
 usr/bin/ceph_rgw_jsonparser


### PR DESCRIPTION
The `/usr/bin/ceph_perf_objectstore` file is installed by default (see https://github.com/ceph/ceph/pull/3043). The problem is that the file was missing from the packaging. This caused the RPM to fail to build in mock.

This pull request adds `ceph_perf_objectstore` to the "ceph-test" RPM and Debian package.

If we end up developing further `ceph_perf_*` utilities, it would make sense to glob them all with a wildcard, similar to what we are doing with all the `ceph_test_*` utilities in ceph-test.