### PR TITLE
debian: move /var/lib/ceph/mds to ceph-mds package

### DIFF
--- a/debian/ceph-mds.dirs
+++ b/debian/ceph-mds.dirs
@@ -1,0 +1,1 @@
+var/lib/ceph/mds

--- a/debian/ceph.dirs
+++ b/debian/ceph.dirs
@@ -1,6 +1,5 @@
 var/lib/ceph/tmp
 var/lib/ceph/mon
 var/lib/ceph/osd
-var/lib/ceph/mds
 var/lib/ceph/bootstrap-osd
 var/lib/ceph/bootstrap-mds

--- a/debian/control
+++ b/debian/control
@@ -101,8 +101,8 @@ Package: ceph-mds
 Architecture: linux-any
 Depends: ceph, ${misc:Depends}, ${shlibs:Depends}
 Recommends: ceph-fs-common, ceph-fuse, libcephfs1
-Replaces: ceph (<< 0.58-1)
-Breaks: ceph (<< 0.58-1)
+Replaces: ceph (<< 0.93-417)
+Breaks: ceph (<< 0.93-417)
 Description: metadata server for the ceph distributed file system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,


### PR DESCRIPTION
On Debian, ceph-mds was split out into its own package in 9d6013e0db47b258cbcde4c692554a2764812099, but the `/var/lib/ceph/mds` directory was not moved along with the rest of the mds pieces.

The `/var/lib/ceph/mds` directory is only necessary if a user has installed ceph-mds. Move it to the ceph-mds subpackage.

This is a prerequisite to completing http://tracker.ceph.com/issues/10587 , which tracks the broader effort to split out all the server daemons into individual packages. 
