### PR TITLE
Fix ceph_test_librbd_fsx link failed

### DIFF
--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -814,7 +814,7 @@ if LINUX
 ceph_test_librbd_fsx_SOURCES = test/librbd/fsx.c common/dummy.cc
 ceph_test_librbd_fsx_LDADD = \
 	$(LIBKRBD) $(LIBRBD) $(LIBRADOS) \
-	$(CRYPTO_LIBS) $(PTHREAD_LIBS) -luuid
+	$(CRYPTO_LIBS) $(PTHREAD_LIBS) $(CEPH_GLOBAL) -luuid
 ceph_test_librbd_fsx_CFLAGS = ${AM_CFLAGS}
 bin_DEBUGPROGRAMS += ceph_test_librbd_fsx
 endif


### PR DESCRIPTION
  CXXLD  ceph_test_librbd_fsx
./.libs/librbd.so: undefined reference to `g_ceph_context'
collect2: ld returned 1 exit status