### PR TITLE
Conditional-compile against minimal tcmalloc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -406,6 +406,26 @@ AS_IF([test "x$with_jemalloc" = xyes],
 		  [no jemalloc found (do not use --with-jemalloc)])])])
 AM_CONDITIONAL(WITH_JEMALLOC, [test "$HAVE_LIBJEMALLOC" = "1"])
 
+# tcmalloc-minimal?
+AC_ARG_WITH([tcmalloc-minimal],
+	    [AS_HELP_STRING([--with-tcmalloc-minimal], [enable minimal tcmalloc support for memory allocations])],
+	    [],
+	    [with_tcmalloc_minimal=no])
+
+AS_IF([test "x$with_jemalloc" = "xyes"],[with_tcmalloc_minimal=no],[])
+
+TCMALLOC_MINIMAL=
+AS_IF([test "x$with_tcmalloc_minimal" != xno],
+        [AC_CHECK_LIB([tcmalloc_minimal], [malloc],
+         [AC_SUBST([LIBTCMALLOC], ["-ltcmalloc_minimal"])
+	       AC_DEFINE([HAVE_LIBTCMALLOC_MINIMAL], [1],
+	       		 [Define if you have tcmalloc])
+	       HAVE_LIBTCMALLOC_MINIMAL=1
+	     ],
+	    [AC_MSG_FAILURE(
+		  [no tcmalloc found (do not use --with-tcmalloc-minimal)])])])
+AM_CONDITIONAL(WITH_TCMALLOC_MINIMAL, [test "$HAVE_LIBTCMALLOC_MINIMAL" = "1"])
+
 # tcmalloc?
 AC_ARG_WITH([tcmalloc],
 	    [AS_HELP_STRING([--without-tcmalloc], [disable tcmalloc for memory allocations])],
@@ -413,6 +433,7 @@ AC_ARG_WITH([tcmalloc],
 	    [with_tcmalloc=yes])
 
 AS_IF([test "x$with_jemalloc" = "xyes"],[with_tcmalloc=no],[])
+AS_IF([test "x$with_tcmalloc_minimal" = "xyes"],[with_tcmalloc=no],[])
 
 TCMALLOC=
 AS_IF([test "x$with_tcmalloc" != xno],

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -175,6 +175,10 @@ if WITH_LIBROCKSDB
 LIBOS += libos_rocksdb.la
 endif # WITH_LIBROCKSDB
 
+if WITH_TCMALLOC_MINIMAL
+LIBPERFGLUE += -ltcmalloc_minimal
+endif # WITH_TCMALLOC_MINIMAL
+
 if WITH_TCMALLOC
 LIBPERFGLUE += -ltcmalloc
 endif # WITH_TCMALLOC

--- a/src/perfglue/Makefile.am
+++ b/src/perfglue/Makefile.am
@@ -6,7 +6,14 @@ libperfglue_la_LIBADD = -ltcmalloc
 AM_CFLAGS += -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
 AM_CXXFLAGS += -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
 else
+if WITH_TCMALLOC_MINIMAL
+libperfglue_la_SOURCES += perfglue/heap_profiler.cc
+libperfglue_la_LIBADD = -ltcmalloc_minimal
+AM_CFLAGS += -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
+AM_CXXFLAGS += -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
+else
 libperfglue_la_SOURCES += perfglue/disabled_heap_profiler.cc
+endif # WITH_TCMALLOC_MINIMAL
 endif # WITH_TCMALLOC
 
 if WITH_PROFILER


### PR DESCRIPTION
Certain older systems (SLE11 in this case) do not provide the full
tcmalloc functionality, due to e.g. incomplete libunwind
functionality. Use --with-tcmalloc-minimal to enable the cut-down
version. Fixes bnc#882430.

Signed-off-by: Thorsten Behrens <tbehrens@suse.com>