### PR TITLE
ceph-objectstore-tool: Fix pgid scan to skip snapdirs

### DIFF
--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2836,8 +2836,9 @@ int main(int argc, char **argv)
     if (op != "list-pgs" && tmppgid != pgid) {
       continue;
     }
-    if (snap != CEPH_NOSNAP && debug) {
-      cout << "skipping snapped dir " << *it
+    if (snap != CEPH_NOSNAP) {
+      if (debug)
+        cerr << "skipping snapped dir " << *it
 	       << " (pg " << pgid << " snap " << snap << ")" << std::endl;
       continue;
     }


### PR DESCRIPTION
Long standing bug where it wasn't skipping snapdirs if !debug
For debug output use stderr like all other cases

Signed-off-by: David Zafman <dzafman@redhat.com>