### PR TITLE
osd: fix negative degraded objects during backfilling

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2226,7 +2226,7 @@ void PG::_update_calc_stats()
     // the summation, not individual stat categories.
     uint64_t num_objects = info.stats.stats.sum.num_objects;
 
-    uint64_t degraded = 0;
+    int64_t degraded = 0;
 
     // if the actingbackfill set is smaller than we want, add in those missing replicas
     if (actingbackfill.size() < target)
@@ -2248,7 +2248,9 @@ void PG::_update_calc_stats()
       degraded += peer_missing[*i].num_missing();
 
       // not yet backfilled
-      degraded += num_objects - peer_info[*i].stats.stats.sum.num_objects;
+      int64_t diff = num_objects - peer_info[*i].stats.stats.sum.num_objects;
+      if (diff > 0)
+        degraded += diff;
     }
     info.stats.stats.sum.num_objects_degraded = degraded;
     info.stats.stats.sum.num_objects_unfound = get_num_unfound();


### PR DESCRIPTION
When there is deleting requests during backfilling, the reported number of degraded
objects could be negative, as the primary's num_objects is the latest (locally) but
the number for replicas might not reflect the deletings. A simple fix is to ignore
the negative subtracted value.

Signed-off-by: Guang Yang <yguang@yahoo-inc.com>
(cherry picked from commit 14d7e36d3c978844da73d0e1c8a3a1ec863bac15)

Conflicts:
	src/osd/PG.cc