### PR TITLE
Fix ceph pg dump_stuck with multiple options

### DIFF
--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -183,14 +183,12 @@ public:
   set<pg_t> creating_pgs;   // lru: front = new additions, back = recently pinged
   map<int,set<pg_t> > creating_pgs_by_osd;
 
-  enum StuckPG {
-    STUCK_INACTIVE,
-    STUCK_UNCLEAN,
-    STUCK_UNDERSIZED,
-    STUCK_DEGRADED,
-    STUCK_STALE,
-    STUCK_NONE
-  };
+  // Bits that use to be enum StuckPG
+  static const int STUCK_INACTIVE = (1<<0);
+  static const int STUCK_UNCLEAN = (1<<1);
+  static const int STUCK_UNDERSIZED = (1<<2);
+  static const int STUCK_DEGRADED = (1<<3);
+  static const int STUCK_STALE = (1<<4);
   
   PGMap()
     : version(0),
@@ -272,10 +270,10 @@ public:
   void dump_pg_stats_plain(ostream& ss,
 			   const ceph::unordered_map<pg_t, pg_stat_t>& pg_stats,
 			   bool brief) const;
-  void get_stuck_stats(StuckPG type, utime_t cutoff,
+  void get_stuck_stats(int types, utime_t cutoff,
 		       ceph::unordered_map<pg_t, pg_stat_t>& stuck_pgs) const;
-  void dump_stuck(Formatter *f, StuckPG type, utime_t cutoff) const;
-  void dump_stuck_plain(ostream& ss, StuckPG type, utime_t cutoff) const;
+  void dump_stuck(Formatter *f, int types, utime_t cutoff) const;
+  void dump_stuck_plain(ostream& ss, int types, utime_t cutoff) const;
 
   void dump(ostream& ss) const;
   void dump_basic(ostream& ss) const;

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1867,7 +1867,8 @@ bool PGMonitor::prepare_command(MMonCommand *m)
   return true;
 }
 
-static void note_stuck_detail(enum PGMap::StuckPG what,
+// Only called with a single bit set in "what"
+static void note_stuck_detail(int what,
 			      ceph::unordered_map<pg_t,pg_stat_t>& stuck_pgs,
 			      list<pair<health_status_t,string> > *detail)
 {
@@ -2240,31 +2241,32 @@ int PGMonitor::dump_stuck_pg_stats(stringstream &ds,
 				   int threshold,
 				   vector<string>& args) const
 {
-  PGMap::StuckPG stuck_type;
-  string type = args[0];
+  int stuck_types = 0;
 
-  if (type == "inactive")
-    stuck_type = PGMap::STUCK_INACTIVE;
-  else if (type == "unclean")
-    stuck_type = PGMap::STUCK_UNCLEAN;
-  else if (type == "undersized")
-    stuck_type = PGMap::STUCK_UNDERSIZED;
-  else if (type == "degraded")
-    stuck_type = PGMap::STUCK_DEGRADED;
-  else if (type == "stale")
-    stuck_type = PGMap::STUCK_STALE;
-  else {
-    ds << "Unknown type: " << type << std::endl;
-    return 0;
+  for (vector<string>::iterator i = args.begin() ; i != args.end(); ++i) {
+    if (*i == "inactive")
+      stuck_types |= PGMap::STUCK_INACTIVE;
+    else if (*i == "unclean")
+      stuck_types |= PGMap::STUCK_UNCLEAN;
+    else if (*i == "undersized")
+      stuck_types |= PGMap::STUCK_UNDERSIZED;
+    else if (*i == "degraded")
+      stuck_types |= PGMap::STUCK_DEGRADED;
+    else if (*i == "stale")
+      stuck_types |= PGMap::STUCK_STALE;
+    else {
+      ds << "Unknown type: " << *i << std::endl;
+      return 0;
+    }
   }
 
   utime_t now(ceph_clock_now(g_ceph_context));
   utime_t cutoff = now - utime_t(threshold, 0);
 
   if (!f) {
-    pg_map.dump_stuck_plain(ds, stuck_type, cutoff);
+    pg_map.dump_stuck_plain(ds, stuck_types, cutoff);
   } else {
-    pg_map.dump_stuck(f, stuck_type, cutoff);
+    pg_map.dump_stuck(f, stuck_types, cutoff);
     f->flush(ds);
   }
 

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -897,7 +897,7 @@ def validate(args, signature, partial=False):
                 if not desc.req:
                     # if not required, just push back; it might match
                     # the next arg
-                    print >> sys.stderr, myarg, 'not valid: ', str(e)
+                    save_exception = [ myarg, e ]
                     myargs.insert(0, myarg)
                     break
                 else:
@@ -909,12 +909,16 @@ def validate(args, signature, partial=False):
             # Whew, valid arg acquired.  Store in dict
             matchcnt += 1
             store_arg(desc, d)
+            # Clear prior exception
+            save_exception = None
 
     # Done with entire list of argdescs
     if matchcnt < reqsiglen:
         raise ArgumentTooFew("not enough arguments given")
 
     if myargs and not partial:
+        if save_exception:
+            print >> sys.stderr, save_exception[0], 'not valid: ', str(save_exception[1])
         raise ArgumentError("unused arguments: " + str(myargs))
 
     # Finally, success


### PR DESCRIPTION
Fix OSD to handle "ceph pg dump_stuck" with multiple options supplied.
Fixes: #11092

Eliminate a warning message that just confuses users.
Fixes: #11093
