### PR TITLE
Transaction Id added for swift response

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1057,6 +1057,8 @@ struct req_state {
 
    string req_id;
 
+   char trans_id[100];
+
    req_info info;
 
    req_state(CephContext *_cct, class RGWEnv *e);

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -90,6 +90,7 @@ static void signal_shutdown();
 struct RGWRequest
 {
   uint64_t id;
+  uuid_t theID;
   struct req_state *s;
   string req_str;
   RGWOp *op;
@@ -102,6 +103,10 @@ struct RGWRequest
 
   void init_state(req_state *_s) {
     s = _s;
+  }
+
+  void init_uuid() {
+	  uuid_generate(theID);
   }
 
   void log_format(struct req_state *s, const char *fmt, ...)
@@ -552,6 +557,8 @@ static int process_request(RGWRados *store, RGWREST *rest, RGWRequest *req, RGWC
   s->obj_ctx = &rados_ctx;
 
   s->req_id = store->unique_id(req->id);
+  req->init_uuid();
+  uuid_unparse(req->theID,s->trans_id);
 
   req->log(s, "initializing");
 


### PR DESCRIPTION
OpenStack Swift response has Transaction Id in headers which is concatenation of uuid and timestamp.
uuid field has been added in RGWRequest from which we generate trans_id filed added in req_state
While sending Swift response, X-Trans_Id header is dumped formed by joining trans_id and milliseconds

Signed-off-by: Abhishek Dixit <dixitabhi@gmail.com>