### PR TITLE
msg/Pipe: discard delay queue before incoming queue

### DIFF
--- a/src/msg/Pipe.cc
+++ b/src/msg/Pipe.cc
@@ -1337,9 +1337,9 @@ void Pipe::fault(bool onread)
     unregister_pipe();
     msgr->lock.Unlock();
 
-    in_q->discard_queue(conn_id);
     if (delay_thread)
       delay_thread->discard();
+    in_q->discard_queue(conn_id);
     discard_out_queue();
 
     // disconnect from Connection, and mark it failed.  future messages


### PR DESCRIPTION
Shutdown the delayed delivery before the incoming queue in case the
DelayedDelivery thread is busy queuing messages.

Fixes: #9910
Signed-off-by: Sage Weil <sage@redhat.com>
Reviewed-by: Greg Farnum <greg@inktank.com>
(cherry picked from commit f7431cc3c25878057482007beb874c9d4473883e)