### PR TITLE
Fix "disk zap" sgdisk invocation

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1053,6 +1053,13 @@ def zap(dev):
             [
                 'sgdisk',
                 '--zap-all',
+                '--',
+                dev,
+            ],
+        )
+        command_check_call(
+            [
+                'sgdisk',
                 '--clear',
                 '--mbrtogpt',
                 '--',


### PR DESCRIPTION
If the metadata on the disk is truly invalid, sgdisk would fail to zero
it in one go, because --mbrtogpt apparently tried to operate on the
metadata it read before executing --zap-all.

Splitting this up into two separate invocations to first zap everything
and then clear it properly fixes this issue.

Based on patch by Lars Marowsky-Bree <lmb@suse.com> in ceph-deploy.
Created by Vincent Untz <vuntz@suse.com>

Signed-off-by: Owen Synge <osynge@suse.com>
Signed-off-by: Thorsten Behrens <tbehrens@suse.com>