### PR TITLE
udev rules now explicitly specify init system

### DIFF
--- a/systemd/udev-rules.d-95-ceph-osd.rules
+++ b/systemd/udev-rules.d-95-ceph-osd.rules
@@ -1,0 +1,27 @@
+# activate ceph-tagged partitions
+ACTION=="add", SUBSYSTEM=="block", \
+  ENV{DEVTYPE}=="partition", \
+  ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-062c0ceff05d", \
+  RUN+="/usr/sbin/ceph-disk-activate --mark-init systemd /dev/$name"
+
+# activate ceph-tagged partitions
+ACTION=="add", SUBSYSTEM=="block", \
+  ENV{DEVTYPE}=="partition", \
+  ENV{ID_PART_ENTRY_TYPE}=="45b0969e-9b03-4f30-b4c6-b4b80ceff106", \
+  RUN+="/usr/sbin/ceph-disk activate-journal --mark-init systemd  /dev/$name"
+
+# Map journal if using dm-crypt
+ACTION=="add" SUBSYSTEM=="block", \
+  ENV{DEVTYPE}=="partition", \
+  ENV{ID_PART_ENTRY_TYPE}=="45b0969e-9b03-4f30-b4c6-5ec00ceff106", \
+  RUN+="/sbin/cryptsetup --key-file /etc/ceph/dmcrypt-keys/$env{ID_PART_ENTRY_UUID} --key-size 256 create $env{ID_PART_ENTRY_UUID} /dev/$name"
+
+# Map data device and
+# activate ceph-tagged partitions
+# for dm-crypted data devices
+ACTION=="add" SUBSYSTEM=="block", \
+  ENV{DEVTYPE}=="partition", \
+  ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-5ec00ceff05d", \
+  RUN+="/sbin/cryptsetup --key-file /etc/ceph/dmcrypt-keys/$env{ID_PART_ENTRY_UUID} --key-size 256 create $env{ID_PART_ENTRY_UUID} /dev/$name", \
+  RUN+="/bin/bash -c 'while [ ! -e /dev/mapper/$env{ID_PART_ENTRY_UUID} ];do sleep 1; done'", \
+  RUN+="/usr/sbin/ceph-disk-activate  --mark-init systemd /dev/mapper/$env{ID_PART_ENTRY_UUID}"


### PR DESCRIPTION
ceph-disk detects OS and Version and from this decides
to use sysV systemd or upstart. This code needs a bigger
rewrite so for now just explicitly tell ceph-disk the
init system.

Signed-off-by: Owen Synge <osynge@suse.com>
Signed-off-by: Thorsten Behrens <tbehrens@suse.com>
(cherry picked from commit 283a37cf2344e52a76d08ae3b075dc99fe18f175)