### PR TITLE
ceph-osd-prestart.sh: check OSD exists.

### DIFF
--- a/src/ceph-osd-prestart.sh
+++ b/src/ceph-osd-prestart.sh
@@ -17,6 +17,12 @@ if [ -z "$id"  ]; then
     exit 1;
 fi
 
+# Check OSD exists
+if [ ! -d ${dir_osd-/var/lib/ceph/osd/}/${cluster:-ceph}-${id} ]; then
+    echo "ceph cluster '${cluster:-ceph}' does not have OSD '${id}' on this host"
+    exit 1;
+fi
+
 update="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_update_on_start || :)"
 
 if [ "${update:-1}" = "1" -o "${update:-1}" = "true" ]; then


### PR DESCRIPTION
if the directory ${dir_osd-/var/lib/ceph/osd/}/${cluster:-ceph}-${id}
does not exist fail with a clear error message.

https://bugzilla.suse.com/show_bug.cgi?id=895759 fixes # 895759

Signed-off-by: Owen Synge <osynge@suse.com>
(cherry picked from commit 8c8b9a0a6ca1b3600184f5072488e22be5865a96)
(cherry picked from commit 460ef1c25014060c14b9217224355ef3e1ca7284)