### PR TITLE
mon: caps validation should rely on EntityName instead of entity_name_t

### DIFF
--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -114,7 +114,7 @@ BOOST_FUSION_ADAPT_STRUCT(StringConstraint,
 
 // </magic>
 
-void MonCapGrant::expand_profile(entity_name_t name) const
+void MonCapGrant::expand_profile(EntityName name) const
 {
   // only generate this list once
   if (!profile_grants.empty())
@@ -196,7 +196,7 @@ void MonCapGrant::expand_profile(entity_name_t name) const
 }
 
 mon_rwxa_t MonCapGrant::get_allowed(CephContext *cct,
-				    entity_name_t name,
+				    EntityName name,
 				    const std::string& s, const std::string& c,
 				    const map<string,string>& c_args) const
 {
@@ -262,7 +262,7 @@ void MonCap::set_allow_all()
 }
 
 bool MonCap::is_capable(CephContext *cct,
-			entity_name_t name,
+			EntityName name,
 			const string& service,
 			const string& command, const map<string,string>& command_args,
 			bool op_may_read, bool op_may_write, bool op_may_exec) const

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -8,7 +8,7 @@
 using std::ostream;
 
 #include "include/types.h"
-#include "msg/msg_types.h"
+#include "common/entity_name.h"
 
 class CephContext;
 
@@ -76,7 +76,7 @@ struct MonCapGrant {
   // needed by expand_profile() (via is_match()) and cached here.
   mutable list<MonCapGrant> profile_grants;
 
-  void expand_profile(entity_name_t name) const;
+  void expand_profile(EntityName name) const;
 
   MonCapGrant() : allow(0) {}
   MonCapGrant(mon_rwxa_t a) : allow(a) {}
@@ -97,7 +97,7 @@ struct MonCapGrant {
    * @return bits we allow
    */
   mon_rwxa_t get_allowed(CephContext *cct,
-			 entity_name_t name,
+			 EntityName name,
 			 const std::string& service,
 			 const std::string& command,
 			 const map<string,string>& command_args) const;
@@ -143,7 +143,7 @@ struct MonCap {
    * @return true if the operation is allowed, false otherwise
    */
   bool is_capable(CephContext *cct,
-		  entity_name_t name,
+		  EntityName name,
 		  const string& service,
 		  const string& command, const map<string,string>& command_args,
 		  bool op_may_read, bool op_may_write, bool op_may_exec) const;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2317,7 +2317,7 @@ bool Monitor::_allowed_command(MonSession *s, string &module, string &prefix,
   bool cmd_w = this_cmd->requires_perm('w');
   bool cmd_x = this_cmd->requires_perm('x');
 
-  bool capable = s->caps.is_capable(g_ceph_context, s->inst.name,
+  bool capable = s->caps.is_capable(g_ceph_context, s->entity_name,
                                     module, prefix, param_str_map,
                                     cmd_r, cmd_w, cmd_x);
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3088,7 +3088,6 @@ void Monitor::_ms_dispatch(Message *m)
   ConnectionRef connection = m->get_connection();
   MonSession *s = NULL;
   MonCap caps;
-  EntityName entity_name;
   bool src_is_mon;
 
   // regardless of who we are or who the sender is, the message must
@@ -3159,7 +3158,7 @@ void Monitor::_ms_dispatch(Message *m)
 
   if (s) {
     if (s->auth_handler) {
-      entity_name = s->auth_handler->get_entity_name();
+      s->entity_name = s->auth_handler->get_entity_name();
     }
     dout(20) << " caps " << s->caps.get_str() << dendl;
   }

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -75,7 +75,7 @@ struct MonSession : public RefCountedObject {
   bool is_capable(string service, int mask) {
     map<string,string> args;
     return caps.is_capable(g_ceph_context,
-			   inst.name,
+			   entity_name,
 			   service, "", args,
 			   mask & MON_CAP_R, mask & MON_CAP_W, mask & MON_CAP_X);
   }

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -52,6 +52,7 @@ struct MonSession : public RefCountedObject {
   map<string, Subscription*> sub_map;
 
   AuthServiceHandler *auth_handler;
+  EntityName entity_name;
 
   ConnectionRef proxy_con;
   uint64_t proxy_tid;

--- a/src/test/mon/moncap.cc
+++ b/src/test/mon/moncap.cc
@@ -177,7 +177,7 @@ TEST(MonCap, AllowAll) {
 
   ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.is_allow_all());
-  ASSERT_TRUE(cap.is_capable(NULL, entity_name_t::CLIENT(0),
+  ASSERT_TRUE(cap.is_capable(NULL, EntityName(),
 			     "foo", "asdf", map<string,string>(), true, true, true));
 
   MonCap cap2;
@@ -191,7 +191,8 @@ TEST(MonCap, ProfileOSD) {
   bool r = cap.parse("allow profile osd", NULL);
   ASSERT_TRUE(r);
 
-  entity_name_t name = entity_name_t::OSD(123);
+  EntityName name;
+  name.from_str("osd.123");
   map<string,string> ca;
 
   ASSERT_TRUE(cap.is_capable(NULL, name, "osd", "", ca, true, false, false));


### PR DESCRIPTION
http://tracker.ceph.com/issues/10844