### PR TITLE
rgw: init script in stop action waits until the radosgw stops

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -93,7 +93,15 @@ case "$1" in
         $0 start
         ;;
     stop)
-        start-stop-daemon --stop -x $RADOSGW --oknodo
+        timeout=0
+        for name in `ceph-conf --list-sections $PREFIX`;
+        do
+          t=`$RADOSGW -n $name --show-config-value rgw_exit_timeout_secs`
+          if [ $t -gt $timeout ]; then timeout=$t; fi
+        done
+
+        if [ $timeout -gt 0 ]; then TIMEOUT="-R $timeout"; fi
+        start-stop-daemon --stop -x $RADOSGW --oknodo $TIMEOUT
         ;;
     status)
         daemon_is_running $RADOSGW

--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -107,8 +107,19 @@ case "$1" in
         ;;
     stop)
         #start-stop-daemon --stop -x $RADOSGW --oknodo
+        timeout=0
+        for name in `ceph-conf --list-sections $PREFIX`;
+        do
+          t=`$RADOSGW -n $name --show-config-value rgw_exit_timeout_secs`
+          if [ $t -gt $timeout ]; then timeout=$t; fi
+        done
+
         killproc $RADOSGW
         echo "Stopping radosgw instance(s)..."
+        while pidof $RADOSGW >/dev/null && [ $timeout -gt 0 ] ; do
+          sleep 1
+          timeout=$(($timeout - 1))
+        done
         ;;
     status)
         daemon_is_running $RADOSGW


### PR DESCRIPTION
I would like to propose the fix for  http://tracker.ceph.com/issues/11140 