### PR TITLE
Support ceph cluster names with systemd

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1861,18 +1861,23 @@ def start_daemon(
                     ],
                 )
         elif os.path.exists(os.path.join(path, 'systemd')):
+            cname = ""
+            if cluster != "ceph":
+                cname = "%s-" % (cluster)
             command_check_call(
                 [
                     'systemctl',
                     'enable',
-                    'ceph-osd@{osd_id}'.format(osd_id=osd_id),
+                    'ceph-{cname}osd@{osd_id}'.format(osd_id=osd_id,
+                        cname=cname),
                     ],
                 )
             command_check_call(
                 [
                     'systemctl',
                     'start',
-                    'ceph-osd@{osd_id}'.format(osd_id=osd_id),
+                    'ceph-{cname}osd@{osd_id}'.format(osd_id=osd_id,
+                        cname=cname),
                     ],
                 )
         else:


### PR DESCRIPTION
Systemd unit files could only ever support one cluster name due
to not supporting dynamically gathered variables. For this reason
we support multiple systemd units for different cluster names.

Signed-off-by: Owen Synge <osynge@suse.com>