### PR TITLE
mon: informative message when erasure-code-profile set fails

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5143,7 +5143,11 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
       }
       if (!force) {
 	err = -EPERM;
-	ss << "will not override erasure code profile " << name;
+	ss << "will not override erasure code profile " << name
+	   << " because the existing profile "
+	   << osdmap.get_erasure_code_profile(name)
+	   << " is different from the proposed profile "
+	   << profile_map;
 	goto reply;
       }
     }


### PR DESCRIPTION
When erasure-code-profile set refuses to override an existing profile,
it may be non trivial to figure out why. For instance:

   ceph osd set default ruleset-failure-domain=host

fails with:

   Error EPERM: will not override erasure code profile default

although ruleset-failure-domain=host is documented to be the
default. The error message now includes the two profiles that have been
compared to not be equal so that the user can verify the difference.

   Error EPERM: will not override erasure code profile default
   because the existing profile
   {directory=.libs,k=2,m=1,plugin=jerasure,technique=reed_sol_van}
   is different from the proposed profile
   {directory=.libs,k=2,m=1,plugin=jerasure,ruleset-failure-domain=host,technique=reed_sol_van}

http://tracker.ceph.com/issues/10488 Fixes: #10488

Signed-off-by: Loic Dachary <ldachary@redhat.com>