### PR TITLE
osd/ReplicatedPG: Fix a memory leak in do_pg_op.

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1008,6 +1008,8 @@ void ReplicatedPG::do_pg_op(OpRequestRef op)
 	dout(10) << " pgnls result=" << result << " outdata.length()="
 		 << osd_op.outdata.length() << dendl;
       }
+      delete filter;
+      filter = NULL;
       break;
 
     case CEPH_OSD_OP_PGLS_FILTER:
@@ -1156,6 +1158,8 @@ void ReplicatedPG::do_pg_op(OpRequestRef op)
 	dout(10) << " pgls result=" << result << " outdata.length()="
 		 << osd_op.outdata.length() << dendl;
       }
+      delete filter;
+      filter = NULL;
       break;
 
     case CEPH_OSD_OP_PG_HITSET_LS:
@@ -1209,7 +1213,6 @@ void ReplicatedPG::do_pg_op(OpRequestRef op)
 	  }
 	  if (is_unreadable_object(oid)) {
 	    wait_for_unreadable_object(oid, op);
-	    delete filter;
 	    return;
 	  }
 	  result = osd->store->read(coll, oid, 0, 0, osd_op.outdata);


### PR DESCRIPTION
If op have pgls_filter & pgnls_filter at the same time, it don't free
the first filter.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>