### PR TITLE
rados.py: fix Object.write() method

### DIFF
--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -2007,7 +2007,8 @@ class Object(object):
     def write(self, string_to_write):
         self.require_object_exists()
         ret = self.ioctx.write(self.key, string_to_write, self.offset)
-        self.offset += ret
+        if ret == 0:
+            self.offset += len(string_to_write)
         return ret
 
     @set_object_locator


### PR DESCRIPTION
the file position should advance by the number of bytes written,
but the `ioctx.write()` function returns 0 on success