### PR TITLE
common, global: use lttng ust functions for handling fork-like calls

### DIFF
--- a/src/common/Preforker.h
+++ b/src/common/Preforker.h
@@ -8,6 +8,9 @@
 #include <sys/wait.h>
 #include <errno.h>
 #include <unistd.h>
+#ifdef WITH_LTTNG
+#include <lttng/ust.h>
+#endif
 #include "common/safe_io.h"
 #include "common/errno.h"
 
@@ -24,6 +27,9 @@ class Preforker {
   pid_t childpid;
   bool forked;
   int fd[2];  // parent's, child's
+#ifdef WITH_LTTNG
+    sigset_t sigset;
+#endif
 
 public:
   Preforker()
@@ -39,13 +45,17 @@ public:
       exit(errno);
     }
 
+#ifdef WITH_LTTNG
+    ust_before_fork(&sigset);
+#endif
+
     forked = true;
 
     childpid = fork();
     if (childpid == 0) {
-      ::close(fd[0]);
+      child_after_fork();
     } else {
-      ::close(fd[1]);
+      parent_after_fork();
     }
   }
 
@@ -99,6 +109,20 @@ public:
     r += r2;  // make the compiler shut up about the unused return code from ::write(2).
   }
   
+private:
+  void child_after_fork() {
+#ifdef WITH_LTTNG
+    ust_after_fork_child(&sigset);
+#endif
+    ::close(fd[0]);
+  }
+
+  void parent_after_fork() {
+#ifdef WITH_LTTNG
+    ust_after_fork_parent(&sigset);
+#endif
+    ::close(fd[1]);
+  }
 };
 
 #endif

--- a/src/global/Makefile.am
+++ b/src/global/Makefile.am
@@ -4,6 +4,9 @@ libglobal_la_SOURCES = \
 	global/pidfile.cc \
 	global/signal_handler.cc
 libglobal_la_LIBADD = $(LIBCOMMON)
+if WITH_LTTNG
+libglobal_la_LIBADD += -llttng-ust -ldl
+endif
 noinst_LTLIBRARIES += libglobal.la
 
 noinst_HEADERS += \

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -31,6 +31,10 @@
 
 #include <errno.h>
 #include <deque>
+#ifdef WITH_LTTNG
+#include <lttng/ust.h>
+#endif
+
 
 #define dout_subsys ceph_subsys_
 
@@ -188,6 +192,11 @@ void global_init_daemonize(CephContext *cct, int flags)
   if (global_init_prefork(cct, flags) < 0)
     return;
 
+#ifdef WITH_LTTNG
+  sigset_t sigset;
+  ust_before_fork(&sigset);
+#endif
+
   int ret = daemon(1, 1);
   if (ret) {
     ret = errno;
@@ -196,6 +205,9 @@ void global_init_daemonize(CephContext *cct, int flags)
     exit(1);
   }
 
+#ifdef WITH_LTTNG
+  ust_after_fork_child(&sigset);
+#endif
   global_init_postfork_start(cct);
   global_init_postfork_finish(cct, flags);
 }


### PR DESCRIPTION
This allows lttng to work across fork(2) and related calls, including 
daemon(3). Without these calls, LD_PRELOAD would need to include 
liblttng-ust-fork.so, which wraps fork and daemon.

If these calls or the liblttng-ust-fork wrappers are not used, the atexit(3)
handlers registered by lttng may cause a crash when the process exits. This
does not happen with upstart, since it runs ceph-osd and other daemons in the
foreground.

Backport: hammer
Signed-off-by: Josh Durgin <jdurgin@redhat.com>