### PR TITLE
doc,tests: force checkout of submodules

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -29,7 +29,8 @@ else
 fi
 
 if test -d ".git" ; then
-  if ! git submodule update --init; then
+  force=$(if git submodule usage 2>&1 | grep --quiet 'update.*--force'; then echo --force ; fi)
+  if ! git submodule sync || ! git submodule update $force --init --recursive; then
     echo "Error: could not initialize submodule projects"
     echo "  Network connectivity might be required."
     exit 1


### PR DESCRIPTION
When updating submodules, always checkout even if the HEAD is the
desired commit hash (update --force) to avoid the following:

    * a directory gmock exists in hammer
    * a submodule gmock replaces the directory gmock in master
    * checkout master + submodule update : gmock/.git is created
    * checkout hammer : the gmock directory still contains the .git from
      master because it did not exist at the time and checkout won't
      remove untracked directories
    * checkout master + submodule update : git rev-parse HEAD is
      at the desired commit although the content of the gmock directory
      is from hammer

Signed-off-by: Loic Dachary <ldachary@redhat.com>