### PR TITLE
doc,tests: force checkout of submodules

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -11,6 +11,15 @@ check_for_pkg_config() {
     exit 1
 }
 
+if test -d ".git" ; then
+  force=$(if git submodule usage 2>&1 | grep --quiet 'update.*--force'; then echo --force ; fi)
+  if ! git submodule sync || ! git submodule update $force --init --recursive; then
+    echo "Error: could not initialize submodule projects"
+    echo "  Network connectivity might be required."
+    exit 1
+  fi
+fi
+
 rm -f config.cache
 aclocal -I m4 --install
 check_for_pkg_config


### PR DESCRIPTION
When updating submodules, always checkout even if the HEAD is the
desired commit hash (update --force) to avoid the following:

    * a directory gmock exists in hammer
    * a submodule gmock replaces the directory gmock in master
    * checkout master + submodule update : gmock/.git is created
    * checkout hammer : the gmock directory still contains the .git from
      master because it did not exist at the time and checkout won't
      remove untracked directories
    * checkout master + submodule update : git rev-parse HEAD is
      at the desired commit although the content of the gmock directory
      is from hammer

http://tracker.ceph.com/issues/11157 Fixes: #11157

Signed-off-by: Loic Dachary <ldachary@redhat.com>