### PR TITLE
init-radosgw*: don't require rgw_socket_path to be defined

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -52,12 +52,6 @@ case "$1" in
                 continue
             fi
 
-            # is the socket defined?  if it's not, this instance shouldn't run as a daemon.
-            rgw_socket=`$RADOSGW -n $name --show-config-value rgw_socket_path`
-            if [ -z "$rgw_socket" ]; then
-                continue
-            fi
-
             # mapped to this host?
             host=`ceph-conf -n $name host`
             hostname=`hostname -s`

--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -59,12 +59,6 @@ case "$1" in
                 continue
             fi
 
-            # is the socket defined?  if it's not, this instance shouldn't run as a daemon.
-            rgw_socket=`$RADOSGW -n $name --show-config-value rgw_socket_path`
-            if [ -z "$rgw_socket" ]; then
-                continue
-            fi
-
             # mapped to this host?
             host=`ceph-conf -n $name host`
             hostname=`hostname -s`


### PR DESCRIPTION
Fixes: #11159
Backport: hammer, firefly

Scripts required rgw_socket_path to exist in order to start radosgw.
This is not needed.

Reported-by: Dan Mick <dmick@redhat.com>
Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>