### PR TITLE
Changes related to command line parsing, fix for Bug # 2862

### DIFF
--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -26,26 +26,33 @@ using std::ostringstream;
 long long strict_strtoll(const char *str, int base, std::string *err)
 {
   char *endptr;
+  std::string errStr;
   errno = 0; /* To distinguish success/failure after call (see man page) */
   long long ret = strtoll(str, &endptr, base);
 
   if ((errno == ERANGE && (ret == LLONG_MAX || ret == LLONG_MIN))
       || (errno != 0 && ret == 0)) {
-    ostringstream oss;
-    oss << "strict_strtoll: integer underflow or overflow parsing '" << str << "'";
-    *err = oss.str();
+    errStr = "The option value '";
+    errStr.append(str);
+    errStr.append("'");
+    errStr.append(" seems to be invalid");
+    *err = errStr;
     return 0;
   }
   if (endptr == str) {
-    ostringstream oss;
-    oss << "strict_strtoll: expected integer, got: '" << str << "'";
-    *err = oss.str();
+    errStr = "The option value '";
+    errStr.append(str);
+    errStr.append("'");
+    errStr.append(" seems to be invalid");
+    *err =  errStr;
     return 0;
   }
   if (*endptr != '\0') {
-    ostringstream oss;
-    oss << "strict_strtoll: garbage at end of string. got: '" << str << "'";
-    *err = oss.str();
+    errStr = "The option value '";
+    errStr.append(str);
+    errStr.append("'");
+    errStr.append(" seems to be invalid");
+    *err =  errStr;
     return 0;
   }
   *err = "";
@@ -54,19 +61,16 @@ long long strict_strtoll(const char *str, int base, std::string *err)
 
 int strict_strtol(const char *str, int base, std::string *err)
 {
+  std::string errStr;
   long long ret = strict_strtoll(str, base, err);
   if (!err->empty())
     return 0;
-  if (ret <= INT_MIN) {
-    ostringstream oss;
-    oss << "strict_strtol: integer underflow parsing '" << str << "'";
-    *err = oss.str();
-    return 0;
-  }
-  if (ret >= INT_MAX) {
-    ostringstream oss;
-    oss << "strict_strtol: integer overflow parsing '" << str << "'";
-    *err = oss.str();
+  if ((ret <= INT_MIN) || (ret >= INT_MAX)) {
+    errStr = "The option value '";
+    errStr.append(str);
+    errStr.append("'");
+    errStr.append(" seems to be invalid");
+    *err = errStr;
     return 0;
   }
   return static_cast<int>(ret);

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -2741,6 +2741,10 @@ int main(int argc, const char **argv)
 	cerr << "rbd: " << err.str() << std::endl;
 	return EXIT_FAILURE;
       }
+      if ((order <= 0) || (order < 12) || (order > 25)) {
+	cerr << "rbd: order must be between 12 (4 KB) and 25 (32 MB)" << std::endl;
+	return EXIT_FAILURE;
+      }
     } else if (ceph_argparse_withlonglong(args, i, &bench_io_size, &err, "--io-size", (char*)NULL)) {
       if (!err.str().empty()) {
 	cerr << "rbd: " << err.str() << std::endl;
@@ -3202,11 +3206,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
   }
 
   if (opt_cmd == OPT_CREATE || opt_cmd == OPT_CLONE || opt_cmd == OPT_IMPORT) {
-    if (order && (order < 12 || order > 25)) {
-      cerr << "rbd: order must be between 12 (4 KB) and 25 (32 MB)"
-	   << std::endl;
-      return EINVAL;
-    }
     if ((stripe_unit && !stripe_count) || (!stripe_unit && stripe_count)) {
       cerr << "must specify both (or neither) of stripe-unit and stripe-count"
 	   << std::endl;

--- a/src/test/cli/osdmaptool/pool.t
+++ b/src/test/cli/osdmaptool/pool.t
@@ -10,7 +10,7 @@
   [1]
 
   $ osdmaptool myosdmap --test-map-object foo --pool bar
-  strict_strtoll: expected integer, got: 'bar'
+  The option value 'bar' is invalid
   [1]
 
   $ osdmaptool myosdmap --test-map-object foo --pool 123
@@ -35,7 +35,7 @@
   [1]
 
   $ osdmaptool myosdmap --test-map-pgs --pool baz
-  strict_strtoll: expected integer, got: 'baz'
+  The option value 'baz' is invalid
   [1]
 
   $ osdmaptool myosdmap --test-map-pgs --pool 123


### PR DESCRIPTION
The changes are to fix Bug # 2862
-- It will identify any missing option values and will also give better user friendly error messages
-- Did some other optimization for logging cli errors

Output of some wrong arguments with these changes
===========================================
ubuntu@Host-CephAdmin:~/myrepo/ceph/src/.libs$ ./rbd create rbd/rbd_img3 --size 10 --order 0
rbd: order must be between 12 (4 KB) and 25 (32 MB)

ubuntu@Host-CephAdmin:~/myrepo/ceph/src/.libs$ ./rbd create --size --image rbd_10
rbd: Missing option value

ubuntu@Host-CephAdmin:~/myrepo/ceph/src/.libs$ ./rbd create --image rbd_img4 --size
Option --size requires an argument.

ubuntu@Host-CephAdmin:~/myrepo/ceph/src/.libs$ ./rbd create rbd/img_abc --size 10g
rbd: The option value '10g' is invalid

ubuntu@Host-CephAdmin:~/myrepo/ceph/src/.libs$ ./rbd create rbd/img_abc --size 10.12
rbd: The option value '10.12' is invalid

ubuntu@Host-CephAdmin:~/myrepo/ceph/src/.libs$ ./rbd create rbd/img_abc --size 10#@#
rbd: The option value '10#@#' is invalid

ubuntu@Host-CephAdmin:~/myrepo/ceph/src/.libs$ ./rbd create rbd/rbd_img2 --size 10240000000000000000
rbd: The option value '10240000000000000000' seems to be invalid
