### PR TITLE
Minor fix: bootstrap-mds in user-management.rst

### DIFF
--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -189,7 +189,7 @@ The following entries describe each capability.
               bootstrapping an OSD.
 
 
-``profile bootstrap-osd``
+``profile bootstrap-mds``
 
 :Description: Gives a user permissions to bootstrap a metadata server. 
               Conferred on deployment tools such as ``ceph-deploy``, etc.


### PR DESCRIPTION
Documentation referred to bootstrap-osd instead of bootstrap-mds, which may cause confusion for some users.