### PR TITLE
osd: only complain about stored vs actual digest if all peers support it

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -12901,7 +12901,8 @@ void ReplicatedPG::_scrub(
 
     dout(20) << mode << "  " << soid << " " << oi << dendl;
 
-    if (pool.info.is_replicated()) {
+    if (pool.info.is_replicated() &&
+	(get_min_peer_features() & CEPH_FEATURE_OSD_OBJECT_DIGEST)) {
       if (oi.is_data_digest() && p->second.digest_present &&
 	  oi.data_digest != p->second.digest) {
 	osd->clog->error() << mode << " " << info.pgid << " " << soid


### PR DESCRIPTION
If we have a mixed cluster of hammer and pre-hammer OSDs, we will fall back
to using 0 as the initial crc32c value.  However, if the primary has a
stored digest, it currently compares its value to the reported value (w/
the wrong initial value) and complains.

There are two possible fixes:
 - avoid storing a digest if all peers don't support it, or
 - avoid complaining on scrub if all peers don't support it.

The latter is easier, and this fix also has the benefit of fixing the bug
even for clusters where this has already happened.

Fixes: #11102
Signed-off-by: Sage Weil <sage@redhat.com>