### PR TITLE
osd/ReplicatedPG: correct the checking if the promoting object is in other hit sets

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1945,10 +1945,17 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
 	map<time_t,HitSetRef>::iterator itor;
 	bool in_other_hit_sets = false;
 	for (itor = agent_state->hit_set_map.begin(); itor != agent_state->hit_set_map.end(); ++itor) {
-	  if (itor->second->contains(missing_oid)) {
-	    in_other_hit_sets = true;
-	    break;
-	  }
+          if (obc.get()) {
+            if (obc->obs.oi.soid != hobject_t() && itor->second->contains(obc->obs.oi.soid)) {
+              in_other_hit_sets = true;
+              break;
+            }
+          } else {
+            if (missing_oid != hobject_t() && itor->second->contains(missing_oid)) {
+              in_other_hit_sets = true;
+              break;
+            }
+          }
 	}
 	if (in_other_hit_sets) {
 	  promote_object(obc, missing_oid, oloc, promote_op);


### PR DESCRIPTION
missing_oid could be a NULL object while obc is not. Should check
obc->obs.oi.soid first, and then missing_oid.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>