### PR TITLE
doc: Add RGW quick start info

### DIFF
--- a/doc/start/quick-ceph-deploy.rst
+++ b/doc/start/quick-ceph-deploy.rst
@@ -100,6 +100,10 @@ configuration details, perform the following steps using ``ceph-deploy``.
    - ``{cluster-name}.client.admin.keyring``
    - ``{cluster-name}.bootstrap-osd.keyring``
    - ``{cluster-name}.bootstrap-mds.keyring``
+   - ``{cluster-name}.bootstrap-rgw.keyring``
+
+.. note:: The bootstrap-rgw keyring is only created during installation of clusters
+   running Hammer or newer
 
 
 #. Add two OSDs. For fast setup, this quick start uses a directory rather
@@ -268,6 +272,38 @@ For example::
 .. note:: Currently Ceph runs in production with one metadata server only. You
    may use more, but there is currently no commercial support for a cluster
    with multiple metadata servers.
+
+
+Add an RGW Instance
+-------------------
+
+To use the :term:`Ceph Object Gateway` component of Ceph, you must deploy an
+instance of :term:`RGW`.  Execute the following to create an new instance of
+RGW::
+
+    ceph-deploy rgw create {gateway-node}
+
+For example::
+
+    ceph-deploy rgw create node1
+
+.. note:: This functionality is new with the **Hammer** release, and also with
+   ``ceph-deploy`` v1.5.23.
+
+By default, the :term:`RGW` instance will listen on port 7480. This can be
+changed by editing ceph.conf on the node running the :term:`RGW` as follows:
+
+.. code-block:: ini
+
+    [client]
+    rgw frontends = civetweb port=80
+
+To use an IPv6 address, use:
+
+.. code-block:: ini
+
+    [client]
+    rgw frontends = civetweb port=[::]:80
 
 
 Adding Monitors

--- a/doc/start/quick-rgw.rst
+++ b/doc/start/quick-rgw.rst
@@ -2,10 +2,27 @@
  Quick Ceph Object Storage
 ===========================
 
-At this time, ``ceph-deploy`` does not provide a rapid installation for 
-:term:`Ceph Object Storage`. To install a :term:`Ceph Object Gateway`, 
-see `Install Ceph Object Gateway`_. To configure a Ceph Object Gateway, 
-see `Configuring Ceph Object Gateway`_.
+To use the :term:`Ceph Object Storage` Quick Start guide, you must have executed the
+procedures in the `Storage Cluster Quick Start`_ guide first. Make sure that you
+have at least one :term:`RGW` instance running.
 
-.. _Install Ceph Object Gateway: ../../install/install-ceph-gateway
+Configure new RGW instance
+==========================
+
+The :term:`RGW` instance created by the `Storage Cluster Quick Start`_ will run using
+the embedded CivetWeb webserver. ``ceph-deploy`` will create the instance and start
+it automatically with default parameters.
+
+To administer the :term:`RGW` instance, see details in the the
+`RGW Admin Guide`_.
+
+Additional details may be found in the `Configuring Ceph Object Gateway`_ guide, but
+the steps specific to Apache are no longer needed.
+
+.. note:: Deploying RGW using ``ceph-deploy`` and using the CivetWeb webserver instead
+   of Apache is new functionality as of **Hammer** release.
+
+
+.. _Storage Cluster Quick Start: ../quick-ceph-deploy
+.. _RGW Admin Guide: ../../radosgw/admin
 .. _Configuring Ceph Object Gateway: ../../radosgw/config


### PR DESCRIPTION
Add details of how to use ceph-deploy to deploy the CivetWeb-based
RGW present in Hammer.

Signed-off-by: Travis Rhoden <trhoden@redhat.com>