### PR TITLE
ceph-objectstore-tool: Output only unsupported features when incomatible

### DIFF
--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2557,8 +2557,9 @@ int main(int argc, char **argv)
     cerr << "On-disk features: " << superblock.compat_features << std::endl;
   }
   if (supported.compare(superblock.compat_features) == -1) {
+    CompatSet unsupported = supported.unsupported(superblock.compat_features);
     cerr << "On-disk OSD incompatible features set "
-      << superblock.compat_features << std::endl;
+      << unsupported << std::endl;
     ret = EINVAL;
     goto out;
   }


### PR DESCRIPTION
Fixes: #11176
Backport: firefly, giant

Signed-off-by: David Zafman <dzafman@redhat.com>