### PR TITLE
Fix ceph_test_async_driver failed

### DIFF
--- a/src/test/msgr/test_async_driver.cc
+++ b/src/test/msgr/test_async_driver.cc
@@ -250,7 +250,7 @@ TEST(EventCenterTest, FileEventExpansion) {
   EventCenter center(g_ceph_context);
   center.init(100);
   EventCallbackRef e(new FakeEvent());
-  for (int i = 0; i < 10000; i++) {
+  for (int i = 0; i < 300; i++) {
     int sd = ::socket(AF_INET, SOCK_STREAM, 0);
     center.create_file_event(sd, EVENT_READABLE, e);
     sds.push_back(sd);


### PR DESCRIPTION
This test will create 10000 sockets which will failed because of limited system fd. Actually we only need to create several hundreds sockets and it's enough to get the test's goal.

Fix bug #11198