### PR TITLE
osd/ReplicatedPG: For CEPH_OSD_OP_ASSERT_VER, it should use

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -4106,7 +4106,7 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
     case CEPH_OSD_OP_ASSERT_VER:
       ++ctx->num_read;
       {
-	uint64_t ver = op.watch.ver;
+	uint64_t ver = op.assert_ver.ver;
 	tracepoint(osd, do_osd_op_pre_assert_ver, soid.oid.name.c_str(), soid.snap.val, ver);
 	if (!ver)
 	  result = -EINVAL;


### PR DESCRIPTION
op.assert_ver rather than op.watch.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>