### PR TITLE
obj_bencher: status_printer waits before the first calculation

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -109,7 +109,7 @@ void *ObjBencher::status_printer(void *_bencher) {
     else
       bandwidth = 0;
 
-    if (!isnan(bandwidth)) {
+    if (!isnan(bandwidth) && bandwidth > 0) {
       if (bandwidth > data.idata.max_bandwidth)
         data.idata.max_bandwidth = bandwidth;
       if (bandwidth < data.idata.min_bandwidth)


### PR DESCRIPTION
Fix for issue http://tracker.ceph.com/issues/7401
Cause of the issue: ObjBencher::status_printer calculates first step metrics before a bench test run.
Now, ObjBencher::status_printer waits one measurement period before starting calculating metrics.

Note: the ideal mechanism for such situation is: main thread notify the status thread when a test is started -> after that the status thread waits a measurement period and calculates first values. But this is redundantly here.