### PR TITLE
Properly detect `systemd` in Ubuntu

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -219,6 +219,28 @@ class ExecutableNotFound(CephDiskException):
 
 ####### utils
 
+def grep(term, file_path):
+    # A small grep-like function that will search for a word in a file and
+    # return True if it does and False if it does not.
+
+    # Implemented initially to have a similar behavior as the init system
+    # detection in Ceph's init scripts::
+
+    #     # detect systemd
+    #     # SYSTEMD=0
+    #     grep -qs systemd /proc/1/comm && SYSTEMD=1
+
+    # .. note:: Because we intent to be operating in silent mode, we explicitly
+    # return ``False`` if the file does not exist.
+    if not os.path.isfile(file_path):
+        return False
+
+    with open(file_path) as _file:
+        for line in _file.readlines():
+            if term in line:
+                return True
+        return False
+
 
 def maybe_mkdir(*a, **kw):
     """
@@ -353,6 +375,18 @@ def platform_information():
     )
 
 
+def is_systemd():
+    """
+    Attempt to detect if a remote system is a systemd one or not
+    by looking into ``/proc`` just like the ceph init script does::
+
+        # detect systemd
+        # SYSTEMD=0
+        grep -qs systemd /proc/1/comm && SYSTEMD=1
+    """
+    return grep('systemd', '/proc/1/comm')
+
+
 def get_dev_name(path):
     """
     get device name from path.  e.g.::
@@ -460,6 +494,7 @@ def list_partitions(basename):
             partitions.append(name)
     return partitions
 
+
 def get_partition_base(dev):
     """
     Get the base device for a partition
@@ -477,6 +512,7 @@ def get_partition_base(dev):
         if os.path.exists(os.path.join('/sys/block', basename, name)):
             return '/dev/' + basename
     raise Error('no parent device for partition', dev)
+
 
 def is_partition(dev):
     """

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1755,7 +1755,7 @@ def start_daemon(
                     'osd.{osd_id}'.format(osd_id=osd_id),
                     ],
                 )
-        elif os.path.exists(os.path.join(path, 'systemd')):
+        elif is_systemd():
             command_check_call(
                 [
                     'systemctl',
@@ -2013,6 +2013,8 @@ def activate(
                 )
             if conf_val is not None:
                 init = conf_val
+            elif is_systemd():
+                init = 'systemd'
             else:
                 (distro, release, codename) = platform.dist()
                 if distro == 'Ubuntu':

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -238,6 +238,7 @@ def grep(term, file_path):
     with open(file_path) as _file:
         for line in _file.readlines():
             if term in line:
+                LOG.info('detected init as systemd')
                 return True
         return False
 


### PR DESCRIPTION
Since Ubuntu is now changing to `systemd` this will no longer associate `upstart` with Ubuntu and it will try to detect it properly by adding a couple of helpers.

Reference issue: http://tracker.ceph.com/issues/11212