### PR TITLE
RFC client: Hold on to exclusive caps on directories we "own"

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2850,6 +2850,13 @@ void Client::check_caps(Inode *in, bool is_delayed)
   unsigned used = get_caps_used(in);
   unsigned cap_used;
 
+  if (in->is_dir() && (in->flags & I_COMPLETE)) {
+    // we do this here because we don't want to drop to Fs (and then
+    // drop the Fs if we do a create!) if that alone makes us send lookups
+    // to the MDS. Doing it in in->caps_wanted() has knock-on effects elsewhere
+    wanted |= CEPH_CAP_FILE_EXCL;
+  }
+
   int retain = wanted | used | CEPH_CAP_PIN;
   if (!unmounting) {
     if (wanted)


### PR DESCRIPTION
If a directory is complete, we *really* want to keep the exclusive cap
so that we don't end up needing to do MDS lookup requests on every cache
miss.

Fixes: #11226

Does this look like a good heuristic? I'll test it to make sure nothing goes disastrously wrong, but we don't have much good test coverage of multi-client systems yet, much less running out of cache space. :/