### PR TITLE
Objecter: failed assert(tick_event==NULL) at osdc/Objecter.cc

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -395,6 +395,10 @@ void Objecter::shutdown()
     if (timer.cancel_event(tick_event)) {
       ldout(cct, 10) <<  " successfully canceled tick" << dendl;
       tick_event = NULL;
+    } else {
+      ldout(cct, 10) << tick_event << " not found in the timer" << dendl;
+      delete tick_event;
+      tick_event = NULL;
     }
   }
 


### PR DESCRIPTION
The assert failure is caused by a locking issue. When the Objecter timer
erases the tick_event from its events queue and calls tick() to dispatch
it, if the Objecter::rwlock is held by shutdown(), it waits there to get
the rwlock. However, inside the shutdown function, it checks the
tick_event and tries to cancel it. The cancel_event function returns
false since tick_event is already removed from the events queue. Thus
tick_event is not set to NULL, and leads to this assertion failure.

Fix issue #11183.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>