### PR TITLE
osd: fix PG::all_unfound_are_queried_or_lost for non-existent osds

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -792,6 +792,8 @@ bool PG::all_unfound_are_queried_or_lost(const OSDMapRef osdmap) const
     if (iter != peer_info.end() &&
         (iter->second.is_empty() || iter->second.dne()))
       continue;
+    if (!osdmap->exists(peer->osd))
+      continue;
     const osd_info_t &osd_info(osdmap->get_info(peer->osd));
     if (osd_info.lost_at <= osd_info.up_from) {
       // If there is even one OSD in might_have_unfound that isn't lost, we

--- a/src/test/test_common.sh
+++ b/src/test/test_common.sh
@@ -150,7 +150,7 @@ start_recovery() {
         CEPH_NUM_OSD=$1
         osd=0
         while [ $osd -lt $CEPH_NUM_OSD ]; do
-                ./ceph -c ./ceph.conf osd tell $osd debug kick_recovery_wq 0
+                ./ceph -c ./ceph.conf tell osd.$osd debug kick_recovery_wq 0
                 osd=$((osd+1))
         done
 }

--- a/src/test/test_common.sh
+++ b/src/test/test_common.sh
@@ -43,7 +43,13 @@ stop_osd() {
         osd_index=$1
         pidfile="out/osd.$osd_index.pid"
         if [ -e $pidfile ]; then
-                kill `cat $pidfile` && return 0
+                if kill `cat $pidfile` ; then
+                        poll_cmd "eval test -e $pidfile ; echo \$?" "1" 1 30
+                        [ $? -eq 1 ] && return 0
+                        echo "ceph-osd process did not terminate correctly"
+                else
+                        echo "kill `cat $pidfile` failed"
+                fi
         else
                 echo "ceph-osd process $osd_index is not running"
         fi

--- a/src/test/test_common.sh
+++ b/src/test/test_common.sh
@@ -38,6 +38,21 @@ die() {
         exit 1
 }
 
+# Test that flag is set (the element is found in the list)
+is_set()
+{
+	local flag=$1; shift
+	local flags="$@"
+	local i
+
+	for i in ${flags}; do
+		if [ "${flag}" = "${i}" ]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
 # Stop an OSD started by vstart
 stop_osd() {
         osd_index=$1


### PR DESCRIPTION
This is #3858 rebased on master.

This is a fix for http://tracker.ceph.com/issues/10976

I'd like to have this in hammer, firefly and giant.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>
