### PR TITLE
Objecter: failed assert(tick_event==NULL) at osdc/Objecter.cc

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1548,8 +1548,6 @@ void Objecter::tick()
   RWLock::RLocker rl(rwlock);
 
   ldout(cct, 10) << "tick" << dendl;
-  if (!initialized.read())
-    return;
 
   // we are only called by C_Tick
   assert(tick_event);


### PR DESCRIPTION
When the Objecter timer erases the tick_event from its events queue and
calls tick() to dispatch it, if the Objecter::rwlock is held by shutdown(),
it waits there to get the rwlock. However, inside the shutdown function,
it checks the tick_event and tries to cancel it. The cancel_event function
returns false since tick_event is already removed from the events queue. Thus
tick_event is not set to NULL in shutdown(). Later the tick function return
ealier and doesn't set tick_event to NULL as well. This leads to the assertion
failure.

Fixes #11183.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>