### PR TITLE
osd: more useful message to find out potential unhealth osd

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -680,12 +680,18 @@ void ReplicatedBackend::sub_op_modify_reply(OpRequestRef op)
     if (r->ack_type & CEPH_OSD_FLAG_ONDISK) {
       assert(ip_op.waiting_for_commit.count(from));
       ip_op.waiting_for_commit.erase(from);
-      if (ip_op.op)
-	ip_op.op->mark_event("sub_op_commit_rec");
+      if (ip_op.op) {
+        ostringstream ss;
+        ss << "sub_op_commit_rec from " << from;
+	ip_op.op->mark_event(ss.str());
+      }
     } else {
       assert(ip_op.waiting_for_applied.count(from));
-      if (ip_op.op)
-	ip_op.op->mark_event("sub_op_applied_rec");
+      if (ip_op.op) {
+        ostringstream ss;
+        ss << "sub_op_applied_rec from " << from;
+	ip_op.op->mark_event(ss.str());
+      }
     }
     ip_op.waiting_for_applied.erase(from);
 


### PR DESCRIPTION
Currently, the command ”ceph --admin-daemon /var/run/ceph/ceph-osd.0.asok dump_historic_ops“ may return as below:
```
        { "description": "osd_op(client.4436.1:11617 rb.0.1153.6b8b4567.000000000192 [] 2.8eb4757c ondisk+write e92)",
          "received_at": "2015-03-25 19:41:47.146145",
          "age": "2.186521",
          "duration": "1.237882",
          "type_data": [
                "commit sent; apply or cleanup",
                { "client": "client.4436",
                  "tid": 11617},
                [
                    { "time": "2015-03-25 19:41:47.150803",
                      "event": "waiting_for_osdmap"},
                    { "time": "2015-03-25 19:41:47.150873",
                      "event": "reached_pg"},
                    { "time": "2015-03-25 19:41:47.150895",
                      "event": "started"},
                    { "time": "2015-03-25 19:41:47.150930",
                      "event": "waiting for subops from 1,2"},
                    { "time": "2015-03-25 19:41:47.150972",
                      "event": "commit_queued_for_journal_write"},
                    { "time": "2015-03-25 19:41:47.151062",
                      "event": "write_thread_in_journal_buffer"},
                    { "time": "2015-03-25 19:41:47.152156",
                      "event": "journaled_completion_queued"},
                    { "time": "2015-03-25 19:41:47.152179",
                      "event": "op_commit"},
                    { "time": "2015-03-25 19:41:47.152399",
                      "event": "op_applied"},
                    { "time": "2015-03-25 19:41:47.380073",
                      "event": "sub_op_commit_rec"},
                    { "time": "2015-03-25 19:41:48.384009",
                      "event": "sub_op_commit_rec"},
                    { "time": "2015-03-25 19:41:48.384020",
                      "event": "commit_sent"},
                    { "time": "2015-03-25 19:41:48.384027",
                      "event": "done"}]]}
```
Request send to osd.1 and osd.2 from primary osd.0, when it receive reply from osd.1 or osd.2
But, it is hard to find out which osd reply is received first. 
For example, if osd.2's disk have some problem, so it reply to primary is later than osd.1.
But from the dump_historic_ops we do not know which osd have problem.

My patch would print more message, such as:
```
                    { "time": "2015-03-25 19:41:47.392397",
                      "event": "sub_op_commit_rec from 2"},
                    { "time": "2015-03-25 19:41:48.420867",
                      "event": "sub_op_commit_rec from 1"},
```
Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>