### PR TITLE
unit/tox tests structure for ceph-disk

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -32,7 +32,6 @@ import tempfile
 import uuid
 import time
 import shlex
-import stat
 
 """
 Prepare:

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -88,6 +88,12 @@ check_SCRIPTS += test/ceph-disk.sh
 endif
 
 EXTRA_DIST += \
+	$(srcdir)/test/python/ceph-disk/setup.py \
+	$(srcdir)/test/python/ceph-disk/tox.ini \
+	$(srcdir)/test/python/ceph-disk/tests/test_ceph_disk.py \
+	$(srcdir)/test/python/brag-client/setup.py \
+	$(srcdir)/test/python/brag-client/tox.ini \
+	$(srcdir)/test/python/brag-client/tests/test_ceph_brag.py \
 	$(srcdir)/test/debian-jessie/Dockerfile.in \
 	$(srcdir)/test/debian-jessie/install-deps.sh \
 	$(srcdir)/test/debian-jessie/debian \
@@ -202,12 +208,12 @@ unittest_workqueue_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_workqueue_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 check_PROGRAMS += unittest_workqueue
 
-unittest_striper_SOURCES = test/test_striper.cc 
+unittest_striper_SOURCES = test/test_striper.cc
 unittest_striper_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_striper_LDADD = $(LIBOSDC) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 check_PROGRAMS += unittest_striper
 
-unittest_prebufferedstreambuf_SOURCES = test/test_prebufferedstreambuf.cc 
+unittest_prebufferedstreambuf_SOURCES = test/test_prebufferedstreambuf.cc
 unittest_prebufferedstreambuf_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_prebufferedstreambuf_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD) $(EXTRALIBS)
 check_PROGRAMS += unittest_prebufferedstreambuf
@@ -244,7 +250,7 @@ check_PROGRAMS += unittest_mds_types
 
 unittest_osd_types_SOURCES = test/osd/types.cc
 unittest_osd_types_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-unittest_osd_types_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL) 
+unittest_osd_types_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 check_PROGRAMS += unittest_osd_types
 
 unittest_lru_SOURCES = test/common/test_lru.cc
@@ -268,7 +274,7 @@ unittest_signals_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_PROGRAMS += unittest_signals
 
 unittest_bufferlist_SOURCES = test/bufferlist.cc
-unittest_bufferlist_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL) 
+unittest_bufferlist_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_bufferlist_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_PROGRAMS += unittest_bufferlist
 

--- a/src/test/python/ceph-disk/setup.py
+++ b/src/test/python/ceph-disk/setup.py
@@ -1,0 +1,27 @@
+import os
+from setuptools import setup, find_packages
+
+# link ceph-disk script here so we can "install" it
+current_dir = os.path.abspath(os.path.dirname(__file__))
+src_dir = os.path.dirname(os.path.dirname(os.path.dirname(current_dir)))
+script_path = os.path.join(src_dir, 'ceph-disk')
+
+
+def link_target(source, destination):
+    if not os.path.exists(destination):
+        try:
+            os.symlink(source, destination)
+        except (IOError, OSError) as error:
+            print 'Ignoring linking of target: %s' % str(error)
+
+link_target(script_path, 'ceph_disk.py')
+
+setup(
+    name='ceph_disk',
+    version='0.1',
+    description='',
+    author='',
+    author_email='',
+    zip_safe=False,
+    packages=find_packages(),
+)

--- a/src/test/python/ceph-disk/tests/test_ceph_disk.py
+++ b/src/test/python/ceph-disk/tests/test_ceph_disk.py
@@ -1,0 +1,10 @@
+import ceph_disk
+
+# This file tests nothing (yet) except for being able to import ceph_disk
+# correctly and thus ensuring somewhat that it will work under different Python
+# versions. You must write unittests here so that code has adequate coverage.
+
+class TestCephDisk(object):
+
+    def test_basic(self):
+        assert True

--- a/src/test/python/ceph-disk/tox.ini
+++ b/src/test/python/ceph-disk/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py26, py27, flake8
+skipsdist=True
+
+[testenv]
+deps=
+  pytest
+
+commands=
+  python setup.py develop
+  py.test -v
+
+[testenv:flake8]
+deps=
+  flake8
+commands=flake8 --select=F ceph_disk.py


### PR DESCRIPTION
No actual tests added, just a bare structure so that tests can be provided.

Will need to be called from somewhere (make check?) to see if all passes. So far (just like ceph-brag)
it will make sure it can import the module in both Python 2.6 and 2.7 plus check egregious issues with
a linter.

Reference issue: http://tracker.ceph.com/issues/11065