### PR TITLE
FAILED assert(soid < scrubber.start || soid >= scrubber.end)

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1697,6 +1697,19 @@ void ReplicatedPG::promote_object(OpRequestRef op, ObjectContextRef obc,
     obc = get_object_context(missing_oid, true);
   }
   dout(10) << __func__ << " " << obc->obs.oi.soid << dendl;
+  if (scrubber.write_blocked_by_scrub(obc->obs.oi.soid)) {
+    dout(10) << __func__ << " " << obc->obs.oi.soid
+	     << " blocked by scrub" << dendl;
+    if (op) {
+      waiting_for_active.push_back(op);
+      dout(10) << __func__ << " " << obc->obs.oi.soid
+	       << " placing op in waiting_for_active" << dendl;
+    } else {
+      dout(10) << __func__ << " " << obc->obs.oi.soid
+	       << " no op, dropping on the floor" << dendl;
+    }
+    return;
+  }
 
   PromoteCallback *cb = new PromoteCallback(op, obc, this);
   object_locator_t oloc(m->get_object_locator());

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1060,7 +1060,10 @@ protected:
    */
   void do_cache_redirect(OpRequestRef op, ObjectContextRef obc);
   /**
-   * This function starts up a copy from
+   * This function attempts to start a promote.  Either it succeeds,
+   * or places op on a wait list.  If op is null, failure means that
+   * this is a noop.  If a future user wants to be able to distinguish
+   * these cases, a return value should be added.
    */
   void promote_object(OpRequestRef op, ObjectContextRef obc,
 		      const hobject_t& missing_object);


### PR DESCRIPTION
http://tracker.ceph.com/issues/11156