### PR TITLE
librbd: add fast diff feature

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -135,6 +135,7 @@ Parameters
    striping: striping v2 support
    exclusive-lock: exclusive locking support
    object-map: object map support (requires exclusive-lock)
+   fast-diff: fast diff calculations (requires object-map)
 
 .. option:: --image-shared
 

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -142,6 +142,15 @@ Parameters
    This will disable features that are dependent upon exclusive ownership
    of the image.
 
+.. option:: --object-extents
+
+   Specifies that the diff should be limited to the extents of a full object
+   instead of showing intra-object deltas. When the object map feature is
+   enabled on an image, limiting the diff to the object extents will
+   dramatically improve performance since the differences can be computed
+   by examining the in-memory object map instead of querying RADOS for each
+   object within the image.
+
 Commands
 ========
 
@@ -204,7 +213,7 @@ Commands
   The --stripe-unit and --stripe-count arguments are optional, but must be
   used together.
 
-:command:`export-diff` [*image-name*] [*dest-path*] [--from-snap *snapname*]
+:command:`export-diff` [*image-name*] [*dest-path*] [--from-snap *snapname*] [--object-extents]
   Exports an incremental diff for an image to dest path (use - for stdout).  If
   an initial snapshot is specified, only changes since that snapshot are included; otherwise,
   any regions of the image that contain data are included.  The end snapshot is specified
@@ -226,7 +235,7 @@ Commands
   continuing.  If there was an end snapshot we verify it does not already exist before
   applying the changes, and create the snapshot when we are done.
 
-:command:`diff` [*image-name*] [--from-snap *snapname*]
+:command:`diff` [*image-name*] [--from-snap *snapname*] [--object-extents]
   Dump a list of byte extents in the image that have changed since the specified start
   snapshot, or since the image was created.  Each output line includes the starting offset
   (in bytes), the length of the region (in bytes), and either 'zero' or 'data' to indicate

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -41,6 +41,7 @@
 #include "common/errno.h"
 #include "objclass/objclass.h"
 #include "include/rbd_types.h"
+#include "include/rbd/object_map_types.h"
 
 #include "cls/rbd/cls_rbd.h"
 
@@ -98,6 +99,8 @@ cls_method_handle_t h_object_map_load;
 cls_method_handle_t h_object_map_save;
 cls_method_handle_t h_object_map_resize;
 cls_method_handle_t h_object_map_update;
+cls_method_handle_t h_object_map_snap_add;
+cls_method_handle_t h_object_map_snap_remove;
 cls_method_handle_t h_metadata_set;
 cls_method_handle_t h_metadata_remove;
 cls_method_handle_t h_metadata_list;
@@ -2219,6 +2222,84 @@ int object_map_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out
   return r;
 }
 
+/**
+ * Mark all _EXISTS objects as _EXISTS_CLEAN so future writes to the
+ * image HEAD can be tracked.
+ *
+ * Input:
+ * none
+ *
+ * Output:
+ * @returns 0 on success, negative error code on failure
+ */
+int object_map_snap_add(cls_method_context_t hctx, bufferlist *in,
+                        bufferlist *out)
+{
+  BitVector<2> object_map;
+  int r = object_map_read(hctx, object_map);
+  if (r < 0) {
+    return r;
+  }
+
+  bool updated = false;
+  for (uint64_t i = 0; i < object_map.size(); ++i) {
+    if (object_map[i] == OBJECT_EXISTS) {
+      object_map[i] = OBJECT_EXISTS_CLEAN;
+      updated = true;
+    }
+  }
+
+  if (updated) {
+    bufferlist bl;
+    ::encode(object_map, bl);
+    r = cls_cxx_write_full(hctx, &bl);
+  }
+  return r;
+}
+
+/**
+ * Mark all _EXISTS_CLEAN objects as _EXISTS in the current object map
+ * if the provided snapshot object map object is marked as _EXISTS.
+ *
+ * Input:
+ * @param snapshot object map bit vector
+ *
+ * Output:
+ * @returns 0 on success, negative error code on failure
+ */
+int object_map_snap_remove(cls_method_context_t hctx, bufferlist *in,
+                           bufferlist *out)
+{
+  BitVector<2> src_object_map;
+  try {
+    bufferlist::iterator iter = in->begin();
+    ::decode(src_object_map, iter);
+  } catch (const buffer::error &err) {
+    return -EINVAL;
+  }
+
+  BitVector<2> dst_object_map;
+  int r = object_map_read(hctx, dst_object_map);
+  if (r < 0) {
+    return r;
+  }
+
+  bool updated = false;
+  for (uint64_t i = 0; i < dst_object_map.size(); ++i) {
+    if (dst_object_map[i] == OBJECT_EXISTS_CLEAN &&
+        (i >= src_object_map.size() || src_object_map[i] == OBJECT_EXISTS)) {
+      dst_object_map[i] = OBJECT_EXISTS;
+      updated = true;
+    }
+  }
+
+  if (updated) {
+    bufferlist bl;
+    ::encode(dst_object_map, bl);
+    r = cls_cxx_write_full(hctx, &bl);
+  }
+  return r;
+}
 
 static const string metadata_key_for_name(const string &name)
 {
@@ -2708,6 +2789,12 @@ void __cls_init()
   cls_register_cxx_method(h_class, "object_map_update",
                           CLS_METHOD_RD | CLS_METHOD_WR,
 			  object_map_update, &h_object_map_update);
+  cls_register_cxx_method(h_class, "object_map_snap_add",
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+			  object_map_snap_add, &h_object_map_snap_add);
+  cls_register_cxx_method(h_class, "object_map_snap_remove",
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+			  object_map_snap_remove, &h_object_map_snap_remove);
 
  /* methods for the old format */
   cls_register_cxx_method(h_class, "snap_list",

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -764,6 +764,23 @@ namespace librbd {
       rados_op->exec("rbd", "object_map_update", in);
     }
 
+    void object_map_snap_add(librados::ObjectWriteOperation *rados_op)
+    {
+      bufferlist in;
+      rados_op->exec("rbd", "object_map_snap_add", in);
+    }
+
+    void object_map_snap_remove(librados::ObjectWriteOperation *rados_op,
+                                const ceph::BitVector<2> &object_map)
+    {
+      ceph::BitVector<2> object_map_copy(object_map);
+      object_map_copy.set_crc_enabled(false);
+
+      bufferlist in;
+      ::encode(object_map_copy, in);
+      rados_op->exec("rbd", "object_map_snap_remove", in);
+    }
+
     int metadata_set(librados::IoCtx *ioctx, const std::string &oid,
                      const map<string, bufferlist> &data)
     {

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -130,6 +130,9 @@ namespace librbd {
 			   uint64_t start_object_no, uint64_t end_object_no,
 			   uint8_t new_object_state,
 			   const boost::optional<uint8_t> &current_object_state);
+    void object_map_snap_add(librados::ObjectWriteOperation *rados_op);
+    void object_map_snap_remove(librados::ObjectWriteOperation *rados_op,
+                                const ceph::BitVector<2> &object_map);
 
     // class operations on the old format, kept for
     // backwards compatability

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -105,6 +105,7 @@ noinst_HEADERS += \
 	include/rbd/features.h \
 	include/rbd/librbd.h \
 	include/rbd/librbd.hpp\
+	include/rbd/object_map_types.h \
 	include/util.h\
 	include/stat.h \
 	include/on_exit.h \

--- a/src/include/rbd/features.h
+++ b/src/include/rbd/features.h
@@ -5,20 +5,24 @@
 #define RBD_FEATURE_STRIPINGV2		(1<<1)
 #define RBD_FEATURE_EXCLUSIVE_LOCK	(1<<2)
 #define RBD_FEATURE_OBJECT_MAP		(1<<3)
+#define RBD_FEATURE_FAST_DIFF           (1<<4)
 
 #define RBD_FEATURES_INCOMPATIBLE 	(RBD_FEATURE_LAYERING |       \
 					 RBD_FEATURE_STRIPINGV2)
 
 #define RBD_FEATURES_RW_INCOMPATIBLE	(RBD_FEATURES_INCOMPATIBLE |  \
 					 RBD_FEATURE_EXCLUSIVE_LOCK | \
-					 RBD_FEATURE_OBJECT_MAP)
+					 RBD_FEATURE_OBJECT_MAP | \
+                                         RBD_FEATURE_FAST_DIFF)
 
 #define RBD_FEATURES_ALL          	(RBD_FEATURE_LAYERING |       \
 					 RBD_FEATURE_STRIPINGV2 |     \
                                    	 RBD_FEATURE_EXCLUSIVE_LOCK | \
-                                         RBD_FEATURE_OBJECT_MAP)
+                                         RBD_FEATURE_OBJECT_MAP |     \
+                                         RBD_FEATURE_FAST_DIFF)
 
 #define RBD_FEATURES_MUTABLE            (RBD_FEATURE_EXCLUSIVE_LOCK | \
-                                         RBD_FEATURE_OBJECT_MAP)
+                                         RBD_FEATURE_OBJECT_MAP | \
+                                         RBD_FEATURE_FAST_DIFF)
 
 #endif

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -389,6 +389,8 @@ CEPH_RBD_API int rbd_read_iterate2(rbd_image_t image, uint64_t ofs, uint64_t len
  * @param fromsnapname start snapshot name, or NULL
  * @param ofs start offset
  * @param len len in bytes of region to report on
+ * @param include_parent 1 if full history diff should include parent
+ * @param whole_object 1 if diff extents should cover whole object
  * @param cb callback to call for each allocated region
  * @param arg argument to pass to the callback
  * @returns 0 on success, or negative error code on error
@@ -398,6 +400,12 @@ CEPH_RBD_API int rbd_diff_iterate(rbd_image_t image,
 		                  uint64_t ofs, uint64_t len,
 		                  int (*cb)(uint64_t, size_t, int, void *),
                                   void *arg);
+CEPH_RBD_API int rbd_diff_iterate2(rbd_image_t image,
+		                   const char *fromsnapname,
+		                   uint64_t ofs, uint64_t len,
+                                   uint8_t include_parent, uint8_t whole_object,
+		                   int (*cb)(uint64_t, size_t, int, void *),
+                                   void *arg);
 CEPH_RBD_API ssize_t rbd_write(rbd_image_t image, uint64_t ofs, size_t len,
                                const char *buf);
 /*

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -48,6 +48,7 @@ extern "C" {
 #endif
 
 #define RBD_FLAG_OBJECT_MAP_INVALID   (1<<0)
+#define RBD_FLAG_FAST_DIFF_INVALID    (1<<1)
 
 typedef void *rbd_snap_t;
 typedef void *rbd_image_t;

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -187,6 +187,8 @@ public:
    * @param fromsnapname start snapshot name, or NULL
    * @param ofs start offset
    * @param len len in bytes of region to report on
+   * @param include_parent true if full history diff should include parent
+   * @param whole_object 1 if diff extents should cover whole object
    * @param cb callback to call for each allocated region
    * @param arg argument to pass to the callback
    * @returns 0 on success, or negative error code on error
@@ -194,6 +196,11 @@ public:
   int diff_iterate(const char *fromsnapname,
 		   uint64_t ofs, uint64_t len,
 		   int (*cb)(uint64_t, size_t, int, void *), void *arg);
+  int diff_iterate2(const char *fromsnapname,
+		    uint64_t ofs, uint64_t len,
+                    bool include_parent, bool whole_object,
+		    int (*cb)(uint64_t, size_t, int, void *), void *arg);
+
   ssize_t write(uint64_t ofs, size_t len, ceph::bufferlist& bl);
   /* @parmam op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   ssize_t write2(uint64_t ofs, size_t len, ceph::bufferlist& bl, int op_flags);

--- a/src/include/rbd/object_map_types.h
+++ b/src/include/rbd/object_map_types.h
@@ -1,0 +1,13 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef CEPH_RBD_OBJECT_MAP_TYPES_H
+#define CEPH_RBD_OBJECT_MAP_TYPES_H
+
+#include "include/int_types.h"
+
+static const uint8_t OBJECT_NONEXISTENT  = 0;
+static const uint8_t OBJECT_EXISTS       = 1;
+static const uint8_t OBJECT_PENDING      = 2;
+static const uint8_t OBJECT_EXISTS_CLEAN = 3;
+
+#endif // CEPH_RBD_OBJECT_MAP_TYPES_H

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -436,6 +436,14 @@ namespace librbd {
     snap_ids.insert(pair<string, snap_t>(in_snap_name, id));
   }
 
+  void ImageCtx::rm_snap(string in_snap_name, snap_t id)
+  {
+    assert(snap_lock.is_wlocked());
+    snaps.erase(std::remove(snaps.begin(), snaps.end(), id), snaps.end());
+    snap_info.erase(id);
+    snap_ids.erase(in_snap_name);
+  }
+
   uint64_t ImageCtx::get_image_size(snap_t in_snap_id) const
   {
     assert(snap_lock.is_locked());

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -192,6 +192,7 @@ namespace librbd {
     void add_snap(std::string in_snap_name, librados::snap_t id,
 		  uint64_t in_size, parent_info parent,
                   uint8_t protection_status, uint64_t flags);
+    void rm_snap(std::string in_snap_name, librados::snap_t id);
     uint64_t get_image_size(librados::snap_t in_snap_id) const;
     bool test_features(uint64_t test_features) const;
     int get_flags(librados::snap_t in_snap_id, uint64_t *flags) const;

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -49,6 +49,7 @@ namespace librbd {
     int notify_resize(uint64_t request_id, uint64_t size,
 		      ProgressContext &prog_ctx);
     int notify_snap_create(const std::string &snap_name);
+    int notify_snap_remove(const std::string &snap_name);
     int notify_rebuild_object_map(uint64_t request_id,
                                   ProgressContext &prog_ctx);
 
@@ -265,6 +266,8 @@ namespace librbd {
     void handle_payload(const WatchNotify::ResizePayload& payload,
 		        bufferlist *out);
     void handle_payload(const WatchNotify::SnapCreatePayload& payload,
+		        bufferlist *out);
+    void handle_payload(const WatchNotify::SnapRemovePayload& payload,
 		        bufferlist *out);
     void handle_payload(const WatchNotify::RebuildObjectMapPayload& payload,
                         bufferlist *out);

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -278,7 +278,7 @@ void ObjectMap::rollback(uint64_t snap_id) {
   }
 }
 
-void ObjectMap::snapshot(uint64_t snap_id) {
+void ObjectMap::snapshot_add(uint64_t snap_id) {
   assert(m_image_ctx.snap_lock.is_wlocked());
   if ((m_image_ctx.features & RBD_FEATURE_OBJECT_MAP) == 0) {
     return;
@@ -308,6 +308,15 @@ void ObjectMap::snapshot(uint64_t snap_id) {
 	       << cpp_strerror(r) << dendl;
     invalidate(snap_id);
   }
+}
+
+int ObjectMap::snapshot_remove(uint64_t snap_id) {
+  std::string oid(object_map_name(m_image_ctx.id, snap_id));
+  int r = m_image_ctx.md_ctx.remove(oid);
+  if (r < 0 && r != -ENOENT) {
+    return r;
+  }
+  return 0;
 }
 
 void ObjectMap::aio_save(Context *on_finish)

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -5,6 +5,7 @@
 
 #include "include/int_types.h"
 #include "include/rados/librados.hpp"
+#include "include/rbd/object_map_types.h"
 #include "common/bit_vector.hpp"
 #include "librbd/AsyncRequest.h"
 #include <boost/optional.hpp>
@@ -12,10 +13,6 @@
 class Context;
 
 namespace librbd {
-
-static const uint8_t OBJECT_NONEXISTENT = 0;
-static const uint8_t OBJECT_EXISTS = 1;
-static const uint8_t OBJECT_PENDING = 2;
 
 class ImageCtx;
 

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -48,7 +48,8 @@ public:
 
   void refresh(uint64_t snap_id);
   void rollback(uint64_t snap_id);
-  void snapshot(uint64_t snap_id);
+  void snapshot_add(uint64_t snap_id);
+  int snapshot_remove(uint64_t snap_id);
 
   bool enabled() const;
 

--- a/src/librbd/RebuildObjectMapRequest.cc
+++ b/src/librbd/RebuildObjectMapRequest.cc
@@ -312,20 +312,20 @@ bool RebuildObjectMapRequest::send_update_header() {
     } else {
       ldout(cct, 5) << this << " send_update_header" << dendl;
 
+      uint64_t flags = RBD_FLAG_OBJECT_MAP_INVALID | RBD_FLAG_FAST_DIFF_INVALID;
+
       librados::ObjectWriteOperation op;
       if (m_image_ctx.image_watcher->is_lock_supported()) {
         m_image_ctx.image_watcher->assert_header_locked(&op);
       }
-      cls_client::set_flags(&op, m_image_ctx.snap_id, 0,
-                            RBD_FLAG_OBJECT_MAP_INVALID);
+      cls_client::set_flags(&op, m_image_ctx.snap_id, 0, flags);
 
       int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid,
                                              create_callback_completion(), &op);
       assert(r == 0);
 
       RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
-      m_image_ctx.update_flags(m_image_ctx.snap_id, RBD_FLAG_OBJECT_MAP_INVALID,
-                               false);
+      m_image_ctx.update_flags(m_image_ctx.snap_id, flags, false);
       return false;
     }
   }

--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -241,6 +241,20 @@ void SnapCreatePayload::dump(Formatter *f) const {
   f->dump_string("snap_name", snap_name);
 }
 
+void SnapRemovePayload::encode(bufferlist &bl) const {
+  ::encode(static_cast<uint32_t>(NOTIFY_OP_SNAP_REMOVE), bl);
+  ::encode(snap_name, bl);
+}
+
+void SnapRemovePayload::decode(__u8 version, bufferlist::iterator &iter) {
+  ::decode(snap_name, iter);
+}
+
+void SnapRemovePayload::dump(Formatter *f) const {
+  f->dump_string("notify_op", stringify(NOTIFY_OP_SNAP_REMOVE));
+  f->dump_string("snap_name", snap_name);
+}
+
 void RebuildObjectMapPayload::encode(bufferlist &bl) const {
   ::encode(static_cast<uint32_t>(NOTIFY_OP_REBUILD_OBJECT_MAP), bl);
   ::encode(async_request_id, bl);
@@ -308,6 +322,9 @@ void NotifyMessage::decode(bufferlist::iterator& iter) {
   case NOTIFY_OP_SNAP_CREATE:
     payload = SnapCreatePayload();
     break;
+  case NOTIFY_OP_SNAP_REMOVE:
+    payload = SnapRemovePayload();
+    break;
   case NOTIFY_OP_REBUILD_OBJECT_MAP:
     payload = RebuildObjectMapPayload();
     break;
@@ -334,6 +351,7 @@ void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
   o.push_back(new NotifyMessage(FlattenPayload(AsyncRequestId(ClientId(0, 1), 2))));
   o.push_back(new NotifyMessage(ResizePayload(123, AsyncRequestId(ClientId(0, 1), 2))));
   o.push_back(new NotifyMessage(SnapCreatePayload("foo")));
+  o.push_back(new NotifyMessage(SnapRemovePayload("foo")));
   o.push_back(new NotifyMessage(RebuildObjectMapPayload(AsyncRequestId(ClientId(0, 1), 2))));
 }
 
@@ -391,6 +409,9 @@ std::ostream &operator<<(std::ostream &out,
     break;
   case NOTIFY_OP_SNAP_CREATE:
     out << "SnapCreate";
+    break;
+  case NOTIFY_OP_SNAP_REMOVE:
+    out << "SnapRemove";
     break;
   case NOTIFY_OP_REBUILD_OBJECT_MAP:
     out << "RebuildObjectMap";

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -82,7 +82,8 @@ enum NotifyOp {
   NOTIFY_OP_FLATTEN            = 6,
   NOTIFY_OP_RESIZE             = 7,
   NOTIFY_OP_SNAP_CREATE        = 8,
-  NOTIFY_OP_REBUILD_OBJECT_MAP = 9
+  NOTIFY_OP_SNAP_REMOVE        = 9,
+  NOTIFY_OP_REBUILD_OBJECT_MAP = 10
 };
 
 struct AcquiredLockPayload {
@@ -186,6 +187,17 @@ struct SnapCreatePayload {
   void dump(Formatter *f) const;
 };
 
+struct SnapRemovePayload {
+  SnapRemovePayload() {}
+  SnapRemovePayload(const std::string &name) : snap_name(name) {}
+
+  std::string snap_name;
+
+  void encode(bufferlist &bl) const;
+  void decode(__u8 version, bufferlist::iterator &iter);
+  void dump(Formatter *f) const;
+};
+
 struct RebuildObjectMapPayload {
   RebuildObjectMapPayload() {}
   RebuildObjectMapPayload(const AsyncRequestId &id) : async_request_id(id) {}
@@ -212,6 +224,7 @@ typedef boost::variant<AcquiredLockPayload,
                  FlattenPayload,
                  ResizePayload,
                  SnapCreatePayload,
+                 SnapRemovePayload,
                  RebuildObjectMapPayload,
                  UnknownPayload> Payload;
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -643,18 +643,53 @@ int invoke_async_request(ImageCtx *ictx, const std::string& request_type,
     if (r < 0)
       return r;
 
-    RWLock::RLocker l(ictx->md_lock);
-    snap_t snap_id;
-
     {
-      // block for purposes of auto-destruction of l2 on early return
-      RWLock::RLocker l2(ictx->snap_lock);
+      RWLock::RLocker snap_locker(ictx->snap_lock);
+      if (ictx->get_snap_id(snap_name) == CEPH_NOSNAP) {
+        return -ENOENT;
+      }
+    }
+
+    r = invoke_async_request(ictx, "snap_remove",
+                             boost::bind(&snap_remove_helper, ictx, _1,
+                                         snap_name),
+                             boost::bind(&ImageWatcher::notify_snap_remove,
+                                         ictx->image_watcher, snap_name));
+    if (r < 0 && r != -EEXIST) {
+      return r;
+    }
+
+    notify_change(ictx->md_ctx, ictx->header_oid, ictx);
+
+    ictx->perfcounter->inc(l_librbd_snap_remove);
+    return 0;
+  }
+
+  int snap_remove_helper(ImageCtx *ictx, Context *ctx, const char *snap_name)
+  {
+    assert(ictx->owner_lock.is_locked());
+    assert(!ictx->image_watcher->is_lock_supported() ||
+           ictx->image_watcher->is_lock_owner());
+
+    ldout(ictx->cct, 20) << "snap_remove_helper " << ictx << " " << snap_name
+                         << dendl;
+
+    int r = ictx_check(ictx);
+    if (r < 0) {
+      return r;
+    }
+
+    RWLock::RLocker md_locker(ictx->md_lock);
+    snap_t snap_id;
+    {
+      // block for purposes of auto-destruction of snap_locker on early return
+      RWLock::RLocker snap_locker(ictx->snap_lock);
       snap_id = ictx->get_snap_id(snap_name);
       if (snap_id == CEPH_NOSNAP)
 	return -ENOENT;
 
       parent_spec our_pspec;
-      RWLock::RLocker l3(ictx->parent_lock);
+      RWLock::RLocker parent_locker(ictx->parent_lock);
       r = ictx->get_parent_spec(snap_id, &our_pspec);
       if (r < 0) {
 	lderr(ictx->cct) << "snap_remove: can't get parent spec" << dendl;
@@ -663,13 +698,13 @@ int invoke_async_request(ImageCtx *ictx, const std::string& request_type,
 
       if (ictx->parent_md.spec != our_pspec &&
 	  (scan_for_parents(ictx, our_pspec, snap_id) == -ENOENT)) {
-	  r = cls_client::remove_child(&ictx->md_ctx, RBD_CHILDREN,
-				       our_pspec, ictx->id);
-	  if (r < 0 && r != -ENOENT) {
-            lderr(ictx->cct) << "snap_remove: failed to deregister from parent "
-                                "image" << dendl;
-	    return r;
-          }
+        r = cls_client::remove_child(&ictx->md_ctx, RBD_CHILDREN,
+				     our_pspec, ictx->id);
+	if (r < 0 && r != -ENOENT) {
+          lderr(ictx->cct) << "snap_remove: failed to deregister from parent "
+                           << "image" << dendl;
+	  return r;
+        }
       }
     }
 
@@ -681,16 +716,18 @@ int invoke_async_request(ImageCtx *ictx, const std::string& request_type,
     }
 
     r = rm_snap(ictx, snap_name);
-    if (r < 0)
+    if (r < 0) {
       return r;
+    }
 
     r = ictx->data_ctx.selfmanaged_snap_remove(snap_id);
-    if (r < 0)
+    if (r < 0) {
       return r;
+    }
 
-    notify_change(ictx->md_ctx, ictx->header_oid, ictx);
-
-    ictx->perfcounter->inc(l_librbd_snap_remove);
+    if (ctx != NULL) {
+      ctx->complete(0);
+    }
     return 0;
   }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -708,8 +708,8 @@ int invoke_async_request(ImageCtx *ictx, const std::string& request_type,
       }
     }
 
-    r = ictx->md_ctx.remove(ObjectMap::object_map_name(ictx->id, snap_id));
-    if (r < 0 && r != -ENOENT) {
+    r = ictx->object_map.snapshot_remove(snap_id);
+    if (r < 0) {
       lderr(ictx->cct) << "snap_remove: failed to remove snapshot object map"
 		       << dendl;
       return 0;
@@ -1971,7 +1971,7 @@ reprotect_and_return_err:
 
     RWLock::WLocker l(ictx->snap_lock);
     if (!ictx->old_format) {
-      ictx->object_map.snapshot(snap_id);
+      ictx->object_map.snapshot_add(snap_id);
       if (lock_owner) {
 	// immediately start using the new snap context if we
 	// own the exclusive lock

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -104,7 +104,7 @@ int diff_object_map(ImageCtx* ictx, uint64_t from_snap_id, uint64_t to_snap_id,
       lderr(cct) << "diff_object_map: failed to retrieve image flags" << dendl;
       return r;
     }
-    if ((flags & RBD_FLAG_OBJECT_MAP_INVALID) != 0) {
+    if ((flags & RBD_FLAG_FAST_DIFF_INVALID) != 0) {
       ldout(cct, 1) << "diff_object_map: cannot perform fast diff on invalid "
                     << "object map" << dendl;
       return -EINVAL;
@@ -2303,6 +2303,9 @@ reprotect_and_return_err:
 				   << "disabling object map optimizations"
 				   << dendl;
 	      ictx->flags = RBD_FLAG_OBJECT_MAP_INVALID;
+              if ((ictx->features & RBD_FEATURE_FAST_DIFF) != 0) {
+                ictx->flags |= RBD_FLAG_FAST_DIFF_INVALID;
+              }
 
 	      vector<uint64_t> default_flags(new_snapc.snaps.size(), ictx->flags);
 	      snap_flags.swap(default_flags);

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -117,6 +117,7 @@ namespace librbd {
   int snap_rollback(ImageCtx *ictx, const char *snap_name,
 		    ProgressContext& prog_ctx);
   int snap_remove(ImageCtx *ictx, const char *snap_name);
+  int snap_remove_helper(ImageCtx *ictx, Context* ctx, const char *snap_name);
   int snap_protect(ImageCtx *ictx, const char *snap_name);
   int snap_unprotect(ImageCtx *ictx, const char *snap_name);
   int snap_is_protected(ImageCtx *ictx, const char *snap_name,

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -184,8 +184,8 @@ namespace librbd {
   int64_t read_iterate(ImageCtx *ictx, uint64_t off, uint64_t len,
 		       int (*cb)(uint64_t, size_t, const char *, void *),
 		       void *arg);
-  int diff_iterate(ImageCtx *ictx, const char *fromsnapname,
-		   uint64_t off, uint64_t len,
+  int diff_iterate(ImageCtx *ictx, const char *fromsnapname, uint64_t off,
+                   uint64_t len, bool include_parent, bool whole_object,
 		   int (*cb)(uint64_t, size_t, int, void *),
 		   void *arg);
   ssize_t read(ImageCtx *ictx, uint64_t off, size_t len, char *buf, int op_flags);

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -123,7 +123,7 @@ namespace librbd {
   int snap_is_protected(ImageCtx *ictx, const char *snap_name,
 			bool *is_protected);
   int add_snap(ImageCtx *ictx, const char *snap_name);
-  int rm_snap(ImageCtx *ictx, const char *snap_name);
+  int rm_snap(ImageCtx *ictx, const char *snap_name, uint64_t snap_id);
   int refresh_parent(ImageCtx *ictx);
   int ictx_check(ImageCtx *ictx);
   int ictx_refresh(ImageCtx *ictx);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -673,8 +673,25 @@ namespace librbd {
 			  void *arg)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
-    tracepoint(librbd, diff_iterate_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, fromsnapname, ofs, len);
-    int r = librbd::diff_iterate(ictx, fromsnapname, ofs, len, cb, arg);
+    tracepoint(librbd, diff_iterate_enter, ictx, ictx->name.c_str(),
+               ictx->snap_name.c_str(), ictx->read_only, fromsnapname, ofs, len,
+               true, true);
+    int r = librbd::diff_iterate(ictx, fromsnapname, ofs, len, true, false, cb,
+                                 arg);
+    tracepoint(librbd, diff_iterate_exit, r);
+    return r;
+  }
+
+  int Image::diff_iterate2(const char *fromsnapname, uint64_t ofs, uint64_t len,
+                           bool include_parent, bool whole_object,
+                           int (*cb)(uint64_t, size_t, int, void *), void *arg)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    tracepoint(librbd, diff_iterate_enter, ictx, ictx->name.c_str(),
+              ictx->snap_name.c_str(), ictx->read_only, fromsnapname, ofs, len,
+              include_parent, whole_object);
+    int r = librbd::diff_iterate(ictx, fromsnapname, ofs, len, include_parent,
+                                whole_object, cb, arg);
     tracepoint(librbd, diff_iterate_exit, r);
     return r;
   }
@@ -1638,8 +1655,27 @@ extern "C" int rbd_diff_iterate(rbd_image_t image,
 				void *arg)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
-  tracepoint(librbd, diff_iterate_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, fromsnapname, ofs, len);
-  int r = librbd::diff_iterate(ictx, fromsnapname, ofs, len, cb, arg);
+  tracepoint(librbd, diff_iterate_enter, ictx, ictx->name.c_str(),
+             ictx->snap_name.c_str(), ictx->read_only, fromsnapname, ofs, len,
+             true, true);
+  int r = librbd::diff_iterate(ictx, fromsnapname, ofs, len, true, false, cb,
+                               arg);
+  tracepoint(librbd, diff_iterate_exit, r);
+  return r;
+}
+
+extern "C" int rbd_diff_iterate2(rbd_image_t image, const char *fromsnapname,
+                                uint64_t ofs, uint64_t len,
+                                uint8_t include_parent, uint8_t whole_object,
+                                int (*cb)(uint64_t, size_t, int, void *),
+                                void *arg)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  tracepoint(librbd, diff_iterate_enter, ictx, ictx->name.c_str(),
+            ictx->snap_name.c_str(), ictx->read_only, fromsnapname, ofs, len,
+            include_parent != 0, whole_object != 0);
+  int r = librbd::diff_iterate(ictx, fromsnapname, ofs, len, include_parent,
+                              whole_object, cb, arg);
   tracepoint(librbd, diff_iterate_exit, r);
   return r;
 }

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -249,7 +249,8 @@ static void format_features(Formatter *f, uint64_t features)
 static void format_flags(Formatter *f, uint64_t flags)
 {
   std::map<uint64_t, std::string> mapping = boost::assign::map_list_of(
-    RBD_FLAG_OBJECT_MAP_INVALID, "object map invalid");
+    RBD_FLAG_OBJECT_MAP_INVALID, "object map invalid")(
+    RBD_FLAG_FAST_DIFF_INVALID, "fast diff invalid");
   format_bitmask(f, "flag", mapping, flags);
 }
 

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -81,7 +81,8 @@ static std::map<uint64_t, std::string> feature_mapping =
     RBD_FEATURE_LAYERING, "layering")(
     RBD_FEATURE_STRIPINGV2, "striping")(
     RBD_FEATURE_EXCLUSIVE_LOCK, "exclusive-lock")(
-    RBD_FEATURE_OBJECT_MAP, "object-map");
+    RBD_FEATURE_OBJECT_MAP, "object-map")(
+    RBD_FEATURE_FAST_DIFF, "fast-diff");
 
 void usage()
 {

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -21,9 +21,10 @@
            <path> <image-name>                  import image from file (dest
                                                 defaults as the filename part
                                                 of file). "-" for stdin
-    diff <image-name> [--from-snap <snap-name>] print extents that differ since
+    diff [--from-snap <snap-name>] [--object-extents] <image-name>
+                                                print extents that differ since
                                                 a previous snap, or image creation
-    export-diff <image-name> [--from-snap <snap-name>] <path>
+    export-diff [--from-snap <snap-name>] [--object-extents] <image-name> <path>
                                                 export an incremental diff to
                                                 path, or "-" for stdout
     merge-diff <diff1> <diff2> <path>           merge <diff1> and <diff2> into

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -100,7 +100,7 @@
     --allow-shrink                     allow shrinking of an image when resizing
   
   Supported image features:
-    layering (+), striping (+), exclusive-lock (*), object-map (*)
+    layering (+), striping (+), exclusive-lock (*), object-map (*), fast-diff (*)
   
     (*) supports enabling/disabling on existing images
     (+) enabled by default for new images if features are not specified

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -5,6 +5,7 @@
 #include "include/encoding.h"
 #include "include/types.h"
 #include "include/rados/librados.h"
+#include "include/rbd/object_map_types.h"
 #include "include/stringify.h"
 #include "cls/rbd/cls_rbd.h"
 #include "cls/rbd/cls_rbd_client.h"
@@ -54,6 +55,8 @@ using ::librbd::cls_client::object_map_load;
 using ::librbd::cls_client::object_map_save;
 using ::librbd::cls_client::object_map_resize;
 using ::librbd::cls_client::object_map_update;
+using ::librbd::cls_client::object_map_snap_add;
+using ::librbd::cls_client::object_map_snap_remove;
 using ::librbd::cls_client::get_flags;
 using ::librbd::cls_client::set_flags;
 using ::librbd::cls_client::metadata_set;
@@ -1032,6 +1035,98 @@ TEST_F(TestClsRbd, object_map_load_enoent)
   ASSERT_EQ(-ENOENT, object_map_load(&ioctx, oid, &osd_bit_vector));
 
   ioctx.close();
+}
+
+TEST_F(TestClsRbd, object_map_snap_add)
+{
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  string oid = get_temp_image_name();
+  BitVector<2> ref_bit_vector;
+  ref_bit_vector.resize(16);
+  for (uint64_t i = 0; i < ref_bit_vector.size(); ++i) {
+    if (i < 4) {
+      ref_bit_vector[i] = OBJECT_NONEXISTENT;
+    } else {
+      ref_bit_vector[i] = OBJECT_EXISTS;
+    }
+  }
+
+  BitVector<2> osd_bit_vector;
+
+  librados::ObjectWriteOperation op1;
+  object_map_resize(&op1, ref_bit_vector.size(), OBJECT_EXISTS);
+  ASSERT_EQ(0, ioctx.operate(oid, &op1));
+
+  librados::ObjectWriteOperation op2;
+  object_map_update(&op2, 0, 4, OBJECT_NONEXISTENT, boost::optional<uint8_t>());
+  ASSERT_EQ(0, ioctx.operate(oid, &op2));
+
+  ASSERT_EQ(0, object_map_load(&ioctx, oid, &osd_bit_vector));
+  ASSERT_EQ(ref_bit_vector, osd_bit_vector);
+
+  librados::ObjectWriteOperation op3;
+  object_map_snap_add(&op3);
+  ASSERT_EQ(0, ioctx.operate(oid, &op3));
+
+  for (uint64_t i = 0; i < ref_bit_vector.size(); ++i) {
+    if (ref_bit_vector[i] == OBJECT_EXISTS) {
+      ref_bit_vector[i] = OBJECT_EXISTS_CLEAN;
+    }
+  }
+
+  ASSERT_EQ(0, object_map_load(&ioctx, oid, &osd_bit_vector));
+  ASSERT_EQ(ref_bit_vector, osd_bit_vector);
+}
+
+TEST_F(TestClsRbd, object_map_snap_remove)
+{
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  string oid = get_temp_image_name();
+  BitVector<2> ref_bit_vector;
+  ref_bit_vector.resize(16);
+  for (uint64_t i = 0; i < ref_bit_vector.size(); ++i) {
+    if (i < 4) {
+      ref_bit_vector[i] = OBJECT_EXISTS_CLEAN;
+    } else {
+      ref_bit_vector[i] = OBJECT_EXISTS;
+    }
+  }
+
+  BitVector<2> osd_bit_vector;
+
+  librados::ObjectWriteOperation op1;
+  object_map_resize(&op1, ref_bit_vector.size(), OBJECT_EXISTS);
+  ASSERT_EQ(0, ioctx.operate(oid, &op1));
+
+  librados::ObjectWriteOperation op2;
+  object_map_update(&op2, 0, 4, OBJECT_EXISTS_CLEAN, boost::optional<uint8_t>());
+  ASSERT_EQ(0, ioctx.operate(oid, &op2));
+
+  ASSERT_EQ(0, object_map_load(&ioctx, oid, &osd_bit_vector));
+  ASSERT_EQ(ref_bit_vector, osd_bit_vector);
+
+  BitVector<2> snap_bit_vector;
+  snap_bit_vector.resize(4);
+  for (uint64_t i = 0; i < snap_bit_vector.size(); ++i) {
+    if (i == 1 || i == 2) {
+      snap_bit_vector[i] = OBJECT_EXISTS;
+    } else {
+      snap_bit_vector[i] = OBJECT_NONEXISTENT;
+    }
+  }
+
+  librados::ObjectWriteOperation op3;
+  object_map_snap_remove(&op3, snap_bit_vector);
+  ASSERT_EQ(0, ioctx.operate(oid, &op3));
+
+  ref_bit_vector[1] = OBJECT_EXISTS;
+  ref_bit_vector[2] = OBJECT_EXISTS;
+  ASSERT_EQ(0, object_map_load(&ioctx, oid, &osd_bit_vector));
+  ASSERT_EQ(ref_bit_vector, osd_bit_vector);
 }
 
 TEST_F(TestClsRbd, flags)

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -587,6 +587,18 @@ size_t ObjectOperation::size() {
   return o->ops.size();
 }
 
+void ObjectReadOperation::list_snaps(snap_set_t *out_snaps, int *prval) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+
+  ObjectOperationTestImpl op = boost::bind(&TestIoCtxImpl::list_snaps, _1, _2,
+                                           out_snaps);
+  if (prval != NULL) {
+    op = boost::bind(save_operation_result,
+                     boost::bind(op, _1, _2, _3), prval);
+  }
+  o->ops.push_back(op);
+}
+
 void ObjectReadOperation::read(size_t off, uint64_t len, bufferlist *pbl,
                                int *prval) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -880,6 +880,27 @@ TEST_F(TestImageWatcher, NotifySnapCreateError) {
   ASSERT_EQ(expected_notify_ops, m_notifies);
 }
 
+TEST_F(TestImageWatcher, NotifySnapRemove) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  ASSERT_EQ(0, register_image_watch(*ictx));
+  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+        "auto " + stringify(m_watch_ctx->get_handle())));
+
+  m_notify_acks = boost::assign::list_of(
+    std::make_pair(NOTIFY_OP_SNAP_REMOVE, create_response_message(0)));
+
+  RWLock::RLocker l(ictx->owner_lock);
+  ASSERT_EQ(0, ictx->image_watcher->notify_snap_remove("snap"));
+
+  NotifyOps expected_notify_ops;
+  expected_notify_ops += NOTIFY_OP_SNAP_REMOVE;
+  ASSERT_EQ(expected_notify_ops, m_notifies);
+}
+
 TEST_F(TestImageWatcher, NotifyAsyncTimedOut) {
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -20,6 +20,7 @@ public:
   typedef std::vector<std::pair<std::string, bool> > Snaps;
 
   virtual void TearDown() {
+    unlock_image();
     for (Snaps::iterator iter = m_snaps.begin(); iter != m_snaps.end(); ++iter) {
       librbd::ImageCtx *ictx;
       EXPECT_EQ(0, open_image(m_image_name, &ictx));

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2870,16 +2870,26 @@ TEST_F(TestLibRBD, UpdateFeatures)
   ASSERT_EQ(-EINVAL, image.update_features(0, true));
 
   ASSERT_EQ(0, image.update_features(RBD_FEATURE_EXCLUSIVE_LOCK |
-                                       RBD_FEATURE_OBJECT_MAP, false));
+                                       RBD_FEATURE_OBJECT_MAP |
+                                       RBD_FEATURE_FAST_DIFF, false));
 
   // cannot enable object map w/o exclusive lock
   ASSERT_EQ(-EINVAL, image.update_features(RBD_FEATURE_OBJECT_MAP, true));
-
   ASSERT_EQ(0, image.update_features(RBD_FEATURE_EXCLUSIVE_LOCK, true));
-  ASSERT_EQ(0, image.update_features(RBD_FEATURE_OBJECT_MAP, true));
+
+  // cannot enable fast diff w/o object map
+  ASSERT_EQ(-EINVAL, image.update_features(RBD_FEATURE_FAST_DIFF, true));
+  ASSERT_EQ(0, image.update_features(RBD_FEATURE_OBJECT_MAP |
+                                       RBD_FEATURE_FAST_DIFF, true));
+
+  // cannot disable object map w/ fast diff
+  ASSERT_EQ(-EINVAL, image.update_features(RBD_FEATURE_OBJECT_MAP, false));
+  ASSERT_EQ(0, image.update_features(RBD_FEATURE_FAST_DIFF, false));
 
   // cannot disable exclusive lock w/ object map
   ASSERT_EQ(-EINVAL, image.update_features(RBD_FEATURE_EXCLUSIVE_LOCK, false));
+  ASSERT_EQ(0, image.update_features(RBD_FEATURE_OBJECT_MAP, false));
+  ASSERT_EQ(0, image.update_features(RBD_FEATURE_EXCLUSIVE_LOCK, false));
 }
 
 TEST_F(TestLibRBD, RebuildObjectMap)

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2939,6 +2939,9 @@ TEST_F(TestLibRBD, RebuildObjectMap)
 
     ASSERT_EQ(bl.length(), image.write(0, bl.length(), bl));
 
+    ASSERT_EQ(0, image.snap_create("snap1"));
+    ASSERT_EQ(bl.length(), image.write(1<<order, bl.length(), bl));
+
     librbd::image_info_t info;
     ASSERT_EQ(0, image.stat(info, sizeof(info)));
 
@@ -2967,6 +2970,10 @@ TEST_F(TestLibRBD, RebuildObjectMap)
 
   bufferlist read_bl;
   ASSERT_EQ(bl.length(), image2.read(0, bl.length(), read_bl));
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+
+  read_bl.clear();
+  ASSERT_EQ(bl.length(), image2.read(1<<order, bl.length(), read_bl));
   ASSERT_TRUE(bl.contents_equal(read_bl));
 
   ASSERT_PASSED(validate_object_map, image1);

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2185,7 +2185,7 @@ TYPED_TEST(DiffIterateTest, DiffIterateDiscard)
   ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
 
   int obj_ofs = 256;
-  ASSERT_EQ(obj_ofs, image.discard(0, obj_ofs));
+  ASSERT_EQ(1 << order, image.discard(0, 1 << order));
 
   extents.clear();
   ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2887,13 +2887,27 @@ TEST_F(TestLibRBD, UpdateFeatures)
   ASSERT_EQ(0, image.update_features(RBD_FEATURE_OBJECT_MAP |
                                        RBD_FEATURE_FAST_DIFF, true));
 
+  uint64_t expected_flags = RBD_FLAG_OBJECT_MAP_INVALID |
+                            RBD_FLAG_FAST_DIFF_INVALID;
+  uint64_t flags;
+  ASSERT_EQ(0, image.get_flags(&flags));
+  ASSERT_EQ(expected_flags, flags);
+
   // cannot disable object map w/ fast diff
   ASSERT_EQ(-EINVAL, image.update_features(RBD_FEATURE_OBJECT_MAP, false));
   ASSERT_EQ(0, image.update_features(RBD_FEATURE_FAST_DIFF, false));
 
+  expected_flags = RBD_FLAG_OBJECT_MAP_INVALID;
+  ASSERT_EQ(0, image.get_flags(&flags));
+  ASSERT_EQ(expected_flags, flags);
+
   // cannot disable exclusive lock w/ object map
   ASSERT_EQ(-EINVAL, image.update_features(RBD_FEATURE_EXCLUSIVE_LOCK, false));
   ASSERT_EQ(0, image.update_features(RBD_FEATURE_OBJECT_MAP, false));
+
+  ASSERT_EQ(0, image.get_flags(&flags));
+  ASSERT_EQ(0U, flags);
+
   ASSERT_EQ(0, image.update_features(RBD_FEATURE_EXCLUSIVE_LOCK, false));
 }
 

--- a/src/test/run-rbd-tests
+++ b/src/test/run-rbd-tests
@@ -35,7 +35,7 @@ run_cli_tests
 export RBD_CREATE_ARGS="--format 2"
 run_cli_tests
 
-for i in 0 1 5 13
+for i in 0 1 5 13 29
 do
     export RBD_FEATURES=$i
     run_api_tests

--- a/src/test/run-rbd-unit-tests.sh
+++ b/src/test/run-rbd-unit-tests.sh
@@ -7,7 +7,7 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CEPH_SRC/.libs"
 PATH="$CEPH_SRC:$PATH"
 
 unittest_librbd
-for i in 0 1 5 13
+for i in 0 1 5 13 29
 do
     RBD_FEATURES=$i unittest_librbd
 done

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -1287,7 +1287,9 @@ TRACEPOINT_EVENT(librbd, diff_iterate_enter,
         char, read_only,
         const char*, from_snap_name,
         uint64_t, offset,
-        uint64_t, length),
+        uint64_t, length,
+        char, include_parent,
+        char, whole_object),
     TP_FIELDS(
         ctf_integer_hex(void*, imagectx, imagectx)
         ctf_string(name, name)
@@ -1296,6 +1298,8 @@ TRACEPOINT_EVENT(librbd, diff_iterate_enter,
         ctf_string(from_snap_name, from_snap_name)
         ctf_integer(uint64_t, offset, offset)
         ctf_integer(uint64_t, length, length)
+        ctf_integer(char, include_parent, include_parent)
+        ctf_integer(char, whole_object, whole_object)
     )
 )
 


### PR DESCRIPTION
The fast diff feature uses the object map to track when objects are updated/deleted between snapshots. This eliminates all per-object RADOS operations in favor of object map loads and in-memory comparisons.