### PR TITLE
Add more CLI options to ceph-rest-api

### DIFF
--- a/src/ceph-rest-api
+++ b/src/ceph-rest-api
@@ -34,6 +34,11 @@ def parse_args():
     parser.add_argument('--cluster', help='Ceph cluster name')
     parser.add_argument('-n', '--name', help='Ceph client name')
     parser.add_argument('-i', '--id', help='Ceph client id')
+    parser.add_argument('--addr', help='Ceph public address and port separated by ":"')
+    parser.add_argument('--keyring', help='Ceph keyring')
+    parser.add_argument('--log-file', help='Ceph log file path')
+    parser.add_argument('--base-url', help='Ceph REST API base URL')
+    parser.add_argument('--log-level', help='Ceph log Level')
 
     return parser.parse_known_args()
 
@@ -51,11 +56,20 @@ except EnvironmentError as e:
 
 # let other exceptions generate traceback
 
+options = {
+    'addr': parsed_args.addr,
+    'log_file': parsed_args.log_file,
+    'key_ring': parsed_args.log_file,
+    'base_url': parsed_args.base_url,
+    'log_level': parsed_args.log_level,
+}
+
 app = ceph_rest_api.generate_app(
     parsed_args.conf,
     parsed_args.cluster,
     parsed_args.name,
     parsed_args.id,
+    options,
     rest,
 )
 

--- a/src/pybind/ceph_rest_api.py
+++ b/src/pybind/ceph_rest_api.py
@@ -64,7 +64,7 @@ def find_up_osd(app):
 METHOD_DICT = {'r': ['GET'], 'w': ['PUT', 'DELETE']}
 
 
-def api_setup(app, conf, cluster, clientname, clientid, args):
+def api_setup(app, conf, cluster, clientname, clientid, options, args):
     '''
     This is done globally, and cluster connection kept open for
     the lifetime of the daemon.  librados should assure that even
@@ -105,11 +105,14 @@ def api_setup(app, conf, cluster, clientname, clientid, args):
     app.ceph_cluster.conf_parse_argv(args)
     app.ceph_cluster.connect()
 
-    app.ceph_baseurl = app.ceph_cluster.conf_get('restapi_base_url') \
+    app.ceph_baseurl = options.get(
+        'base_url', app.ceph_cluster.conf_get('restapi_base_url')) \
         or DEFAULT_BASEURL
     if app.ceph_baseurl.endswith('/'):
         app.ceph_baseurl = app.ceph_baseurl[:-1]
-    addr = app.ceph_cluster.conf_get('public_addr') or DEFAULT_ADDR
+
+    addr = options.get('addr', app.ceph_cluster.conf_get('public_addr')) \
+           or DEFAULT_ADDR
 
     # remove any nonce from the conf value
     addr = addr.split('/')[0]
@@ -118,11 +121,12 @@ def api_setup(app, conf, cluster, clientname, clientid, args):
     port = port or DEFAULT_PORT
     port = int(port)
 
-    loglevel = app.ceph_cluster.conf_get('restapi_log_level') \
+    loglevel = options.get('log_level',
+                           app.ceph_cluster.conf_get('restapi_log_level')) \
         or DEFAULT_LOG_LEVEL
     # ceph has a default log file for daemons only; clients (like this)
     # default to "".  Override that for this particular client.
-    logfile = app.ceph_cluster.conf_get('log_file')
+    logfile = options.get('log_file', app.ceph_cluster.conf_get('log_file'))
     if not logfile:
         logfile = os.path.join(
             DEFAULT_LOGDIR,
@@ -500,8 +504,9 @@ def handler(catchall_path=None, fmt=None, target=None):
 # Main entry point from wrapper/WSGI server: call with cmdline args,
 # get back the WSGI app entry point
 #
-def generate_app(conf, cluster, clientname, clientid, args):
-    addr, port = api_setup(app, conf, cluster, clientname, clientid, args)
+def generate_app(conf, cluster, clientname, clientid, options, args):
+    addr, port = api_setup(app, conf, cluster, clientname, clientid,
+                           options, args)
     app.ceph_addr = addr
     app.ceph_port = port
     return app


### PR DESCRIPTION
In order to containerized ceph-rest-api we need to expose some options
on the CLI directly. We don't want to rely on reading the ceph.conf. In
this commit, we expose all the configuration options as CLI extra
parameters.
Now you can run the API like this:

ceph-rest-api --addr 192.168.0.24:5001 --log-file /dev/null --base-url
/api/1.0/ --log-level debug

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>