### PR TITLE
Doc: Incomplete example in erasure-coded-pool.rst

### DIFF
--- a/doc/dev/erasure-coded-pool.rst
+++ b/doc/dev/erasure-coded-pool.rst
@@ -90,7 +90,7 @@ Choose an alternate erasure code plugin::
  m=1
  plugin=example
  technique=xor
- $ ceph osd create ecpool 12 12 erasure \
+ $ ceph osd pool create ecpool 12 12 erasure \
      myprofile
 
 Display the default erasure code profile::


### PR DESCRIPTION
The example lacked the parameter "pool".