### PR TITLE
PG: set/clear CREATING in Primary state entry/exit

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4719,12 +4719,6 @@ void PG::start_peering_interval(
 
   reg_next_scrub();
 
-  // set CREATING bit until we have peered for the first time.
-  if (is_primary() && info.history.last_epoch_started == 0)
-    state_set(PG_STATE_CREATING);
-  else
-    state_clear(PG_STATE_CREATING);
-
   // did acting, up, primary|acker change?
   if (!lastmap) {
     dout(10) << " no lastmap" << dendl;
@@ -5572,6 +5566,10 @@ PG::RecoveryState::Primary::Primary(my_context ctx)
   context< RecoveryMachine >().log_enter(state_name);
   PG *pg = context< RecoveryMachine >().pg;
   assert(pg->want_acting.empty());
+
+  // set CREATING bit until we have peered for the first time.
+  if (pg->info.history.last_epoch_started == 0)
+    pg->state_set(PG_STATE_CREATING);
 }
 
 boost::statechart::result PG::RecoveryState::Primary::react(const MNotifyRec& notevt)
@@ -5605,6 +5603,7 @@ void PG::RecoveryState::Primary::exit()
   utime_t dur = ceph_clock_now(pg->cct) - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_primary_latency, dur);
   pg->clear_primary_state();
+  pg->state_clear(PG_STATE_CREATING);
 }
 
 /*---------Peering--------*/


### PR DESCRIPTION
Previously, we did not actually set it when we got a pg creation message from
the mon.  It would actually get set on the first start_peering_interval after
that point.  If we don't get that far, but do send a stat update to the mon, we
can end up with 11197.  Instead, let's just set it and clear it upon entry into
and exit from the Primary state.

Fixes: 11197
Signed-off-by: Samuel Just <sjust@redhat.com>