### PR TITLE
mds: fixed the ceph get mdsmap assertion.

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -777,7 +777,7 @@ bool MDSMonitor::preprocess_command(MMonCommand *m)
       if (err == -ENOENT) {
 	r = -ENOENT;
       } else {
-	assert(r == 0);
+	assert(err == 0);
 	assert(b.length());
 	MDSMap mm;
 	mm.decode(b);


### PR DESCRIPTION
When we want to get mdsmap, we try to get_version()
and the return value err = 0 means success.

The assert verified r == 0. r would not change in this flow.
It always meet assert and lead mon failure.

I think this verify should be:
    assert(err == 0)
It will help to check return value of get_version().

If you have any questions, feel free to let me know.
Thanks!

Signed-off-by: Vicente Cheng <freeze.bilsted@gmail.com>