### PR TITLE
Update quick-ceph-deploy.rst

### DIFF
--- a/doc/start/quick-ceph-deploy.rst
+++ b/doc/start/quick-ceph-deploy.rst
@@ -102,8 +102,7 @@ configuration details, perform the following steps using ``ceph-deploy``.
    - ``{cluster-name}.bootstrap-mds.keyring``
    - ``{cluster-name}.bootstrap-rgw.keyring``
 
-.. note:: The bootstrap-rgw keyring is only created during installation of clusters
-   running Hammer or newer
+   .. note:: The bootstrap-rgw keyring is only created during installation of clusters running Hammer or newer
 
 
 #. Add two OSDs. For fast setup, this quick start uses a directory rather


### PR DESCRIPTION
The steps 6 to 9 of the 'Create a cluster' section should no longer be erroneously numbered 1 to 4.