### PR TITLE
mds: persist completed_requests reliably

### DIFF
--- a/src/mds/LogSegment.h
+++ b/src/mds/LogSegment.h
@@ -63,6 +63,9 @@ class LogSegment {
   // client request ids
   map<int, ceph_tid_t> last_client_tids;
 
+  // potentially dirty sessions
+  std::set<entity_name_t> touched_sessions;
+
   // table version
   version_t inotablev;
   version_t sessionmapv;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1081,6 +1081,7 @@ void Server::reply_client_request(MDRequestRef& mdr, MClientReply *reply)
   if (req->may_write() && mdr->session && reply->get_result() == 0) {
     inodeno_t created = mdr->alloc_ino ? mdr->alloc_ino : mdr->used_prealloc_ino;
     mdr->session->add_completed_request(mdr->reqid.tid, created);
+    mdr->ls->touched_sessions.insert(mdr->session->info.inst.name);
   }
 
   // give any preallocated inos to the session
@@ -1349,7 +1350,11 @@ void Server::handle_client_request(MClientRequest *req)
   if (req->get_oldest_client_tid() > 0) {
     dout(15) << " oldest_client_tid=" << req->get_oldest_client_tid() << dendl;
     assert(session);
-    session->trim_completed_requests(req->get_oldest_client_tid());
+    if (session->trim_completed_requests(req->get_oldest_client_tid())) {
+      // Sessions 'completed_requests' was dirtied, mark it to be
+      // potentially flushed at segment expiry.
+      mdlog->get_current_segment()->touched_sessions.insert(session->info.inst.name);
+    }
   }
 
   // register + dispatch

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1081,7 +1081,9 @@ void Server::reply_client_request(MDRequestRef& mdr, MClientReply *reply)
   if (req->may_write() && mdr->session && reply->get_result() == 0) {
     inodeno_t created = mdr->alloc_ino ? mdr->alloc_ino : mdr->used_prealloc_ino;
     mdr->session->add_completed_request(mdr->reqid.tid, created);
-    mdr->ls->touched_sessions.insert(mdr->session->info.inst.name);
+    if (mdr->ls) {
+      mdr->ls->touched_sessions.insert(mdr->session->info.inst.name);
+    }
   }
 
   // give any preallocated inos to the session

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -747,61 +747,85 @@ public:
 };
 
 
-void SessionMap::save_if_dirty(entity_name_t session_id,
+void SessionMap::save_if_dirty(const std::set<entity_name_t> &tgt_sessions,
                                MDSGatherBuilder *gather_bld)
 {
   assert(gather_bld != NULL);
 
-  if (session_map.count(session_id) == 0) {
-    // Session isn't around any more, never mind.
-    return;
+  std::vector<entity_name_t> write_sessions;
+
+  // Decide which sessions require a write
+  for (std::set<entity_name_t>::iterator i = tgt_sessions.begin();
+       i != tgt_sessions.end(); ++i) {
+    const entity_name_t &session_id = *i;
+
+    if (session_map.count(session_id) == 0) {
+      // Session isn't around any more, never mind.
+      continue;
+    }
+
+    Session *session = session_map[session_id];
+    if (!session->has_dirty_completed_requests()) {
+      // Session hasn't had completed_requests
+      // modified since last write, no need to
+      // write it now.
+      continue;
+    }
+
+    if (dirty_sessions.count(session_id) > 0) {
+      // Session is already dirtied, will be written, no
+      // need to pre-empt that.
+      continue;
+    }
+    // Okay, passed all our checks, now we write
+    // this session out.  The version we write
+    // into the OMAP may now be higher-versioned
+    // than the version in the header, but that's
+    // okay because it's never a problem to have
+    // an overly-fresh copy of a session.
+    write_sessions.push_back(*i);
   }
 
-  Session *session = session_map[session_id];
-  if (!session->has_dirty_completed_requests()) {
-    // Session hasn't had completed_requests
-    // modified since last write, no need to
-    // write it now.
-    return;
-  }
+  dout(4) << __func__ << ": writing " << write_sessions.size() << dendl;
 
-  if (dirty_sessions.count(session_id) > 0) {
-    // Session is already dirtied, will be written, no
-    // need to pre-empt that.
-    return;
-  }
-
-  // Okay, passed all our checks, now we write
-  // this session out.  The version we write
-  // into the OMAP may now be higher-versioned
-  // than the version in the header, but that's
-  // okay because it's never a problem to have
-  // an overly-fresh copy of a session.
-  session->clear_dirty_completed_requests();
-
-  MDSInternalContextBase *on_safe = gather_bld->new_sub();
-
+  // Batch writes into mds_sessionmap_keys_per_op
+  const uint32_t kpo = g_conf->mds_sessionmap_keys_per_op;
   map<string, bufferlist> to_set;
+  for (uint32_t i = 0; i < write_sessions.size(); ++i) {
+    // Start a new write transaction?
+    if (i % g_conf->mds_sessionmap_keys_per_op == 0) {
+      to_set.clear();
+    }
 
-  // Serialize K
-  std::ostringstream k;
-  k << session_id;
+    const entity_name_t &session_id = write_sessions[i];
+    Session *session = session_map[session_id];
+    session->clear_dirty_completed_requests();
 
-  // Serialize V
-  bufferlist bl;
-  session->info.encode(bl);
+    // Serialize K
+    std::ostringstream k;
+    k << session_id;
 
-  // Add to RADOS op
-  to_set[k.str()] = bl;
+    // Serialize V
+    bufferlist bl;
+    session->info.encode(bl);
 
-  ObjectOperation op;
-  op.omap_set(to_set);
+    // Add to RADOS op
+    to_set[k.str()] = bl;
 
-  SnapContext snapc;
-  object_t oid = get_object_name();
-  object_locator_t oloc(mds->mdsmap->get_metadata_pool());
-  mds->objecter->mutate(oid, oloc, op, snapc, ceph_clock_now(g_ceph_context),
-      0, NULL, new C_OnFinisher(new C_IO_SM_Save_One(this, on_safe), &mds->finisher));
+    // Complete this write transaction?
+    if (i == write_sessions.size() - 1
+        || i % kpo == kpo - 1) {
+      ObjectOperation op;
+      op.omap_set(to_set);
+
+      SnapContext snapc;
+      object_t oid = get_object_name();
+      object_locator_t oloc(mds->mdsmap->get_metadata_pool());
+      MDSInternalContextBase *on_safe = gather_bld->new_sub();
+      mds->objecter->mutate(oid, oloc, op, snapc, ceph_clock_now(g_ceph_context),
+          0, NULL, new C_OnFinisher(new C_IO_SM_Save_One(this, on_safe), &mds->finisher));
+    }
+  }
 }
 
 

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -560,12 +560,13 @@ public:
   void replay_advance_version();
 
   /**
-   * If a session exists with this ID, and it has
+   * For these session IDs, if a session exists with this ID, and it has
    * dirty completed_requests, then persist it immediately
    * (ahead of usual project/dirty versioned writes
    *  of the map).
    */
-  void save_if_dirty(entity_name_t, MDSGatherBuilder *gather_bld);
+  void save_if_dirty(const std::set<entity_name_t> &tgt_sessions,
+                     MDSGatherBuilder *gather_bld);
 };
 
 

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -193,6 +193,10 @@ public:
 private:
   version_t cap_push_seq;        // cap push seq #
   map<version_t, list<MDSInternalContextBase*> > waitfor_flush; // flush session messages
+
+  // Has completed_requests been modified since the last time we
+  // wrote this session out?
+  bool completed_requests_dirty;
 public:
   xlist<Capability*> caps;     // inodes with caps; front=most recently used
   xlist<ClientLease*> leases;  // metadata leases to clients
@@ -232,12 +236,21 @@ private:
 public:
   void add_completed_request(ceph_tid_t t, inodeno_t created) {
     info.completed_requests[t] = created;
+    completed_requests_dirty = true;
   }
-  void trim_completed_requests(ceph_tid_t mintid) {
+  bool trim_completed_requests(ceph_tid_t mintid) {
     // trim
+    bool erased_any = false;
     while (!info.completed_requests.empty() && 
-	   (mintid == 0 || info.completed_requests.begin()->first < mintid))
+	   (mintid == 0 || info.completed_requests.begin()->first < mintid)) {
       info.completed_requests.erase(info.completed_requests.begin());
+      erased_any = true;
+    }
+
+    if (erased_any) {
+      completed_requests_dirty = true;
+    }
+    return erased_any;
   }
   bool have_completed_request(ceph_tid_t tid, inodeno_t *pcreated) const {
     map<ceph_tid_t,inodeno_t>::const_iterator p = info.completed_requests.find(tid);
@@ -248,6 +261,16 @@ public:
     return true;
   }
 
+  bool has_dirty_completed_requests() const
+  {
+    return completed_requests_dirty;
+  }
+
+  void clear_dirty_completed_requests()
+  {
+    completed_requests_dirty = false;
+  }
+
 
   Session() : 
     state(STATE_CLOSED), state_seq(0), importing_count(0),
@@ -255,6 +278,7 @@ public:
     connection(NULL), item_session_list(this),
     requests(0),  // member_offset passed to front() manually
     cap_push_seq(0),
+    completed_requests_dirty(false),
     lease_seq(0) { }
   ~Session() {
     assert(!item_session_list.is_on_list());
@@ -534,6 +558,14 @@ public:
    * and `projected` to account for that.
    */
   void replay_advance_version();
+
+  /**
+   * If a session exists with this ID, and it has
+   * dirty completed_requests, then persist it immediately
+   * (ahead of usual project/dirty versioned writes
+   *  of the map).
+   */
+  void save_if_dirty(entity_name_t, MDSGatherBuilder *gather_bld);
 };
 
 

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -237,6 +237,13 @@ void LogSegment::try_to_expire(MDS *mds, MDSGatherBuilder &gather_bld, int op_pr
     mds->sessionmap.save(gather_bld.new_sub(), sessionmapv);
   }
 
+  // updates to sessions for completed_requests
+  for (std::set<entity_name_t>::iterator i = touched_sessions.begin();
+       i != touched_sessions.end(); ++i) {
+    mds->sessionmap.save_if_dirty(*i, &gather_bld);
+  }
+  touched_sessions.clear();
+
   // pending commit atids
   for (map<int, ceph::unordered_set<version_t> >::iterator p = pending_commit_tids.begin();
        p != pending_commit_tids.end();

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -238,10 +238,7 @@ void LogSegment::try_to_expire(MDS *mds, MDSGatherBuilder &gather_bld, int op_pr
   }
 
   // updates to sessions for completed_requests
-  for (std::set<entity_name_t>::iterator i = touched_sessions.begin();
-       i != touched_sessions.end(); ++i) {
-    mds->sessionmap.save_if_dirty(*i, &gather_bld);
-  }
+  mds->sessionmap.save_if_dirty(touched_sessions, &gather_bld);
   touched_sessions.clear();
 
   // pending commit atids


### PR DESCRIPTION
Ensure that if this was modified during
a segment, and the session is not
persisted for some other reason, we
go ahead and persist it at the end
of the segment.

Fixes: #11048
Signed-off-by: John Spray <john.spray@redhat.com>