### PR TITLE
osd: do not update mtime when recording digest

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2233,9 +2233,6 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
     ctx->user_at_version = obc->obs.oi.user_version;
   dout(30) << __func__ << " user_at_version " << ctx->user_at_version << dendl;
 
-  // note my stats
-  utime_t now = ceph_clock_now(cct);
-
   if (op->may_read()) {
     dout(10) << " taking ondisk_read_lock" << dendl;
     obc->ondisk_read_lock();
@@ -2359,7 +2356,7 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
 
   repop->src_obc.swap(src_obc); // and src_obc.
 
-  issue_repop(repop, now);
+  issue_repop(repop);
 
   eval_repop(repop);
   repop->put();
@@ -7362,7 +7359,7 @@ void ReplicatedPG::eval_repop(RepGather *repop)
   }
 }
 
-void ReplicatedPG::issue_repop(RepGather *repop, utime_t now)
+void ReplicatedPG::issue_repop(RepGather *repop)
 {
   OpContext *ctx = repop->ctx;
   const hobject_t& soid = ctx->obs->oi.soid;
@@ -7489,7 +7486,7 @@ ReplicatedPG::RepGather *ReplicatedPG::simple_repop_create(ObjectContextRef obc)
 void ReplicatedPG::simple_repop_submit(RepGather *repop)
 {
   dout(20) << __func__ << " " << repop << dendl;
-  issue_repop(repop, repop->ctx->mtime);
+  issue_repop(repop);
   eval_repop(repop);
   repop->put();
 }

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -11343,6 +11343,7 @@ void ReplicatedPG::_scrub(
       RepGather *repop = simple_repop_create(obc);
       OpContext *ctx = repop->ctx;
       ctx->at_version = get_next_version();
+      ctx->mtime = utime_t();      // do not update mtime
       ctx->new_obs.oi.set_data_digest(p->second.first);
       ctx->new_obs.oi.set_omap_digest(p->second.second);
       finish_ctx(ctx, pg_log_entry_t::MODIFY, true, true);

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -865,7 +865,7 @@ protected:
   void repop_all_applied(RepGather *repop);
   void repop_all_committed(RepGather *repop);
   void eval_repop(RepGather*);
-  void issue_repop(RepGather *repop, utime_t now);
+  void issue_repop(RepGather *repop);
   RepGather *new_repop(OpContext *ctx, ObjectContextRef obc, ceph_tid_t rep_tid);
   void remove_repop(RepGather *repop);
 


### PR DESCRIPTION
The user mtime and local_mtime are normally set in finish_ctx based on the
value of ctx->mtime; clear that to avoid this update.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>
[Sage: simplified]
Signed-off-by: Sage Weil <sage@redhat.com>