### PR TITLE
Add rbd_discard_skip_zeroing flag

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -892,6 +892,7 @@ OPTION(rbd_clone_copy_on_read, OPT_BOOL, false)
 OPTION(rbd_blacklist_on_break_lock, OPT_BOOL, true) // whether to blacklist clients whose lock was broken
 OPTION(rbd_blacklist_expire_seconds, OPT_INT, 0) // number of seconds to blacklist - set to 0 for OSD default
 OPTION(rbd_request_timed_out_seconds, OPT_INT, 30) // number of seconds before maint request times out
+OPTION(rbd_skip_partial_discard, OPT_BOOL, false) // when trying to discard a range inside an object, set to true to skip zeroing the range.
 
 /*
  * The following options change the behavior for librbd's image creation methods that

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -3576,9 +3576,13 @@ reprotect_and_return_err:
 	req = new AioTruncate(ictx, p->oid.name, p->objectno, p->offset, objectx, object_overlap,
 			      snapc, snap_id, req_comp);
       } else {
-	req = new AioZero(ictx, p->oid.name, p->objectno, p->offset, p->length,
-			  objectx, object_overlap,
-			  snapc, snap_id, req_comp);
+	if(ictx->cct->_conf->rbd_skip_partial_discard) {
+	  continue;
+	} else {
+	  req = new AioZero(ictx, p->oid.name, p->objectno, p->offset, p->length,
+			    objectx, object_overlap,
+			    snapc, snap_id, req_comp);
+	}
       }
 
       r = req->send();


### PR DESCRIPTION
If we want to discard a range of an object, we will zero the
range now. In general this is not what user expect(saving some
space) and introduce some overhead(extra writes).

If the filesystem ontop of RBD holding lots of small files, this
behavior will bring big performance penalty.

Adding a flag that allow user to control if they want to zero the
range, and default off( no zeroing).

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>