### PR TITLE
osd/PG: check scrub state when handle CEPH_OSD_OP_SCRUB_MAP.

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3322,6 +3322,11 @@ void PG::sub_op_scrub_map(OpRequestRef op)
     return;
   }
 
+  if (!scrubber.is_chunky_scrub_active()) {
+    dout(10) << "sub_op_scrub_map scrub isn't active" << dendl;
+    return;
+  }
+
   op->mark_started();
 
   dout(10) << " got " << m->from << " scrub map" << dendl;


### PR DESCRIPTION
There is chance which cause scrub stop before replica-node send
scrub-map.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>