### PR TITLE
mds: remove verify-mds-journal.sh script

### DIFF
--- a/src/verify-mds-journal.sh
+++ b/src/verify-mds-journal.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-while [ 1 ]
-do
-  ./ceph-mds -f --debug_mds 20 --debug_ms 1 --standby_replay_for 0 || exit 1
-  echo replay ok, sleeping
-  sleep 30
-done


### PR DESCRIPTION
This invokes the MDS in a way that it no longer understands,
and is unused.

Signed-off-by: John Spray <john.spray@redhat.com>