### PR TITLE
tests: exercise all RBD features during unit testing

### DIFF
--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -291,7 +291,8 @@ unittest_librbd_LDADD = \
 	librados_test_stub.la librados_internal.la \
 	$(LIBOSDC) $(UNITTEST_LDADD) \
 	$(CEPH_GLOBAL) $(RADOS_TEST_LDADD)
-check_PROGRAMS += unittest_librbd
+noinst_PROGRAMS += unittest_librbd
+check_SCRIPTS += test/run-rbd-unit-tests.sh
 
 ceph_test_librbd_SOURCES =
 nodist_EXTRA_ceph_test_librbd_SOURCES = dummy.cc

--- a/src/test/run-rbd-unit-tests.sh
+++ b/src/test/run-rbd-unit-tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ex
+
+# this should be run from the src directory in the ceph.git
+
+CEPH_SRC=$(pwd)
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CEPH_SRC/.libs"
+PATH="$CEPH_SRC:$PATH"
+
+unittest_librbd
+for i in 0 1 5 13
+do
+    RBD_FEATURES=$i unittest_librbd
+done
+
+echo OK


### PR DESCRIPTION
The librbd unit tests currently only test the old image format. Ensure
the new format and its possible features are also tested.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>