### PR TITLE
librbd: snap_remove should ignore -ENOENT errors

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -584,8 +584,11 @@ namespace librbd {
 	  (scan_for_parents(ictx, our_pspec, snap_id) == -ENOENT)) {
 	  r = cls_client::remove_child(&ictx->md_ctx, RBD_CHILDREN,
 				       our_pspec, ictx->id);
-	  if (r < 0)
+	  if (r < 0 && r != -ENOENT) {
+            lderr(ictx->cct) << "snap_remove: failed to deregister from parent "
+                                "image" << dendl;
 	    return r;
+          }
       }
     }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1426,6 +1426,9 @@ reprotect_and_return_err:
 
     RWLock::RLocker l(ictx->snap_lock);
     RWLock::RLocker l2(ictx->parent_lock);
+    if (ictx->parent == NULL) {
+      return -ENOENT;
+    }
 
     parent_spec parent_spec;
 


### PR DESCRIPTION
If the attempt to deregister the snapshot from the parent
image fails with -ENOENT, ignore the error as it is safe
to assume that the child is not associated with the parent.

Fixes: #11113
Signed-off-by: Jason Dillaman <dillaman@redhat.com>
(cherry picked from commit cf8094942ccdba831e03e5a79451cfa5d78a135f)