### PR TITLE
DNM: mon: whitelist the plugins

### DIFF
--- a/src/messages/MMonElection.h
+++ b/src/messages/MMonElection.h
@@ -21,7 +21,7 @@
 
 class MMonElection : public Message {
 
-  static const int HEAD_VERSION = 5;
+  static const int HEAD_VERSION = 6;
   static const int COMPAT_VERSION = 2;
 
 public:
@@ -45,6 +45,7 @@ public:
   bufferlist monmap_bl;
   set<int32_t> quorum;
   uint64_t quorum_features;
+  map<string,string> quorum_plugins;
   bufferlist sharing_bl;
   /* the following were both used in the next branch for a while
    * on user cluster, so we've left them in for compatibility. */
@@ -92,6 +93,7 @@ public:
     ::encode(defunct_one, payload);
     ::encode(defunct_two, payload);
     ::encode(sharing_bl, payload);
+    ::encode(quorum_plugins, payload);
   }
   void decode_payload() {
     bufferlist::iterator p = payload.begin();
@@ -113,6 +115,8 @@ public:
     }
     if (header.version >= 5)
       ::decode(sharing_bl, p);
+    if (header.version >= 6)
+      ::decode(quorum_plugins, p);
   }
   
 };

--- a/src/messages/MMonProbe.h
+++ b/src/messages/MMonProbe.h
@@ -22,7 +22,7 @@
 
 class MMonProbe : public Message {
 public:
-  static const int HEAD_VERSION = 6;
+  static const int HEAD_VERSION = 7;
   static const int COMPAT_VERSION = 5;
 
   enum {
@@ -55,6 +55,7 @@ public:
   version_t paxos_last_version;
   bool has_ever_joined;
   uint64_t required_features;
+  map<string,string> required_plugins;
 
   MMonProbe()
     : Message(MSG_MON_PROBE, HEAD_VERSION, COMPAT_VERSION) {}
@@ -86,6 +87,8 @@ public:
       out << " new";
     if (required_features)
       out << " required_features " << required_features;
+    if (required_plugins)
+      out << " required_plugins " << required_plugins;
     out << ")";
   }
   
@@ -107,6 +110,7 @@ public:
     ::encode(paxos_first_version, payload);
     ::encode(paxos_last_version, payload);
     ::encode(required_features, payload);
+    ::encode(required_plugins, payload);
   }
   void decode_payload() {
     bufferlist::iterator p = payload.begin();
@@ -122,6 +126,8 @@ public:
       ::decode(required_features, p);
     else
       required_features = 0;
+    if (header.version >= 7)
+      ::decode(required_plugins, p);
   }
 };
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -433,6 +433,84 @@ void Monitor::write_features(MonitorDBStore::TransactionRef t)
   t->put(MONITOR_NAME, COMPAT_SET_LOC, bl);
 }
 
+map<string,string> Monitor::get_initial_supported_plugins()
+{
+  map<string,string> plugins;
+  plugins["jerasure"] = "1.0.0";
+  plugins["isa"] = "1.0.0";
+  plugins["lrc"] = "1.0.0";
+  return plugins;
+}
+
+map<string,string> Monitor::get_supported_features()
+{
+  map<string,string> plugins;
+  // walk the plugins dirs
+  return plugins;
+}
+
+map<string,string> Monitor::get_legacy_features()
+{
+  map<string,string> plugins;
+  plugins["jerasure"] = "1.0.0";
+  plugins["isa"] = "1.0.0";
+  plugins["lrc"] = "1.0.0";
+  return plugins;
+}
+
+int Monitor::check_plugins(MonitorDBStore *store)
+{
+  map<string,string> required = get_supported_features();
+  map<string,string> ondisk;
+
+  read_plugins_off_disk(store, &ondisk);
+
+  if (!required.compatible_with(ondisk) {
+      stringstream ss;
+      required.unsupported(ondisk, &ss);
+      generic_derr << "ERROR: on disk plugins is incompatible with plugins that can be dynamically loaded : " << ss.str() << dendl;
+      return -EPERM;
+  }
+
+  return 0;
+}
+
+void Monitor::read_plugins_off_disk(MonitorDBStore *store, map<stirng,string> *plugins)
+{
+  bufferlist pluginsbl;
+  store->get(MONITOR_NAME, PLUGINS_LOC, pluginsbl);
+  if (pluginsbl.length() == 0) {
+    generic_dout(0) << "WARNING: mon fs missing plugins list.\n"
+            << "Assuming it is old-style and introducing one." << dendl;
+    *plugins = get_legacy_plugins();
+
+    bufferlist bl;
+    plugins->encode(bl);
+    MonitorDBStore::TransactionRef t(new MonitorDBStore::Transaction);
+    t->put(MONITOR_NAME, PLUGINS_LOC, bl);
+    store->apply_transaction(t);
+  } else {
+    bufferlist::iterator it = pluginsbl.begin();
+    plugins->decode(it);
+  }
+}
+
+void Monitor::read_plugins()
+{
+  read_plugins_off_disk(store, &plugins);
+  dout(10) << "plugins " << plugins << dendl;
+
+  apply_plugins_to_quorum_requirements();
+  dout(10) << "required_plugins " << required_plugins << dendl;
+}
+
+void Monitor::write_plugins(MonitorDBStore::TransactionRef t)
+{
+  bufferlist bl;
+  plugins.encode(bl);
+  t->put(MONITOR_NAME, PLUGINS_LOC, bl);
+}
+
 const char** Monitor::get_tracked_conf_keys() const
 {
   static const char* KEYS[] = {
@@ -1825,6 +1903,7 @@ void Monitor::win_election(epoch_t epoch, set<int>& active, uint64_t features,
   leader = rank;
   quorum = active;
   quorum_features = features;
+  quorum_plugins = plugins;
   outside_quorum.clear();
 
   clog->info() << "mon." << name << "@" << rank
@@ -1859,7 +1938,7 @@ void Monitor::win_election(epoch_t epoch, set<int>& active, uint64_t features,
   }
 }
 
-void Monitor::lose_election(epoch_t epoch, set<int> &q, int l, uint64_t features) 
+void Monitor::lose_election(epoch_t epoch, set<int> &q, int l, uint64_t features, map<string,string> plugins) 
 {
   state = STATE_PEON;
   leader_since = utime_t();
@@ -1867,8 +1946,12 @@ void Monitor::lose_election(epoch_t epoch, set<int> &q, int l, uint64_t features
   quorum = q;
   outside_quorum.clear();
   quorum_features = features;
+  quorum_plugins = plugins;
   dout(10) << "lose_election, epoch " << epoch << " leader is mon" << leader
-	   << " quorum is " << quorum << " features are " << quorum_features << dendl;
+	   << " quorum is " << quorum
+	   << " features are " << quorum_features
+	   << " plugins are " << quorum_plugins
+	   << dendl;
 
   paxos->peon_init();
   for (vector<PaxosService*>::iterator p = paxos_service.begin(); p != paxos_service.end(); ++p)
@@ -1897,6 +1980,17 @@ void Monitor::finish_election()
     dout(10) << " renaming myself from " << cur_name << " -> " << name << dendl;
     messenger->send_message(new MMonJoin(monmap->fsid, name, messenger->get_myaddr()),
 			    monmap->get_inst(*quorum.begin()));
+  }
+}
+
+void Monitor::apply_quorum_plugins()
+{
+  if (compare quorum_plugins to plugins)
+    MonitorDBStore::TransactionRef t(new MonitorDBStore::Transaction);
+    write_plugins(t);
+    store->apply_transaction(t);
+
+    // apply_plugins_to_quorum_requirements();
   }
 }
 

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -119,6 +119,7 @@ struct MMonHealth;
 struct MonCommand;
 
 #define COMPAT_SET_LOC "feature_set"
+#define PLUGINS_LOC "plugins"
 
 class Monitor : public Dispatcher,
                 public md_config_obs_t {
@@ -218,12 +219,14 @@ private:
 
   /// features we require of peers (based on on-disk compatset)
   uint64_t required_features;
+  map<string,string> required_plugins;
   
   int leader;            // current leader (to best of knowledge)
   set<int> quorum;       // current active set of monitors (if !starting)
   utime_t leader_since;  // when this monitor became the leader, if it is the leader
   utime_t exited_quorum; // time detected as not in quorum; 0 if in
   uint64_t quorum_features;  ///< intersection of quorum member feature bits
+  map<string,string> quorum_plugins;
   bufferlist supported_commands_bl; // encoded MonCommands we support
   bufferlist classic_commands_bl; // encoded MonCommands supported by Dumpling
   set<int> classic_mons; // set of "classic" monitors; only valid on leader
@@ -548,8 +551,14 @@ public:
   uint64_t get_quorum_features() const {
     return quorum_features;
   }
+  const map<string,string>& get_quorum_plugins() const {
+    return quorum_plugins;
+  }
   uint64_t get_required_features() const {
     return required_features;
+  }
+  const map<string,string> get_required_plugins() const {
+    return required_plugins;
   }
   void apply_quorum_to_compatset_features();
   void apply_compatset_features_to_quorum_requirements();


### PR DESCRIPTION
So that adding a plugin does not consume a feature bit and third party
plugins can be added without crashing a monitor simply because one of
them did not install it.

http://tracker.ceph.com/issues/7291 Fixes: #7291

Signed-off-by: Loic Dachary <ldachary@redhat.com>