### PR TITLE
ReplicatedPG::promote_object: do not create obc if not promoting

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2145,23 +2145,24 @@ void ReplicatedPG::promote_object(ObjectContextRef obc,
 				  const object_locator_t& oloc,
 				  OpRequestRef op)
 {
-  if (!obc) { // we need to create an ObjectContext
-    assert(missing_oid != hobject_t());
-    obc = get_object_context(missing_oid, true);
-  }
-  dout(10) << __func__ << " " << obc->obs.oi.soid << dendl;
-  if (scrubber.write_blocked_by_scrub(obc->obs.oi.soid)) {
-    dout(10) << __func__ << " " << obc->obs.oi.soid
+  hobject_t hoid = obc ? obc->obs.oi.soid : missing_oid;
+  assert(hoid != hobject_t());
+  if (scrubber.write_blocked_by_scrub(hoid)) {
+    dout(10) << __func__ << " " << hoid
 	     << " blocked by scrub" << dendl;
     if (op) {
       waiting_for_active.push_back(op);
-      dout(10) << __func__ << " " << obc->obs.oi.soid
+      dout(10) << __func__ << " " << hoid
 	       << " placing op in waiting_for_active" << dendl;
     } else {
-      dout(10) << __func__ << " " << obc->obs.oi.soid
+      dout(10) << __func__ << " " << hoid
 	       << " no op, dropping on the floor" << dendl;
     }
     return;
+  }
+  if (!obc) { // we need to create an ObjectContext
+    assert(missing_oid != hobject_t());
+    obc = get_object_context(missing_oid, true);
   }
 
   PromoteCallback *cb = new PromoteCallback(obc, this);


### PR DESCRIPTION
Otherwise, we can leave an incorrect cached obc around.

Introduced: 65bb4df599541cd2e0f195b905f24f529e255c00
Fixes: 11284
Signed-off-by: Samuel Just <sjust@redhat.com>