### PR TITLE
man: add conf.py to the list of distributed files

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,5 +1,7 @@
 AUTOMAKE_OPTIONS = gnu
 
+EXTRA_DIST = conf.py
+
 dist_man_MANS = 
 
 if ENABLE_CLIENT


### PR DESCRIPTION
Otherwise packages won't build as it's not included in the tarbal.

Signed-off-by: Loic Dachary <ldachary@redhat.com>