### PR TITLE
[NewStore]Clear removed_collections after reap

### DIFF
--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -1043,9 +1043,14 @@ void NewStore::_queue_reap_collection(CollectionRef& c)
 
 void NewStore::_reap_collections()
 {
-  Mutex::Locker l(reap_lock);
-  for (list<CollectionRef>::iterator p = removed_collections.begin();
-       p != removed_collections.end();
+  reap_lock.Lock();
+
+  list<CollectionRef> removed_colls;
+  removed_colls.swap(removed_collections);
+  reap_lock.Unlock();
+
+  for (list<CollectionRef>::iterator p = removed_colls.begin();
+       p != removed_colls.end();
        ++p) {
     CollectionRef c = *p;
     dout(10) << __func__ << " " << c->cid << dendl;


### PR DESCRIPTION
Previous code forgot to clear the removed_collections queues
after reaped the collections in _reap_collection.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>