### PR TITLE
rgw : Issue AIO for next chunk first before flush the (cached) data.

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5677,10 +5677,6 @@ int RGWRados::get_obj_iterate_cb(RGWObjectCtx *ctx, RGWObjState *astate,
     }
   }
 
-  r = flush_read_list(d);
-  if (r < 0)
-    return r;
-
   get_obj_bucket_and_oid_loc(obj, bucket, oid, key);
 
   d->throttle.get(len);
@@ -5703,6 +5699,11 @@ int RGWRados::get_obj_iterate_cb(RGWObjectCtx *ctx, RGWObjState *astate,
   ldout(cct, 20) << "rados->aio_operate r=" << r << " bl.length=" << pbl->length() << dendl;
   if (r < 0)
     goto done_err;
+
+  // Flush data to client if there is any
+  r = flush_read_list(d);
+  if (r < 0)
+    return r;
 
   return 0;
 


### PR DESCRIPTION
When handling GET request for large object (with multiple chunks), currently it will first flush the
cached data, and then issue AIO request for next chunk, this has the potential issue to make the retriving
from OSD and sending to client serialized. This patch switch the two operations.

Fixes: 11322
Signed-off-by: Guang Yang <yguang@yahoo-inc.com>