### PR TITLE
tests: docker-test must bind mount .ccache

### DIFF
--- a/src/test/docker-test-helper.sh
+++ b/src/test/docker-test-helper.sh
@@ -121,9 +121,8 @@ function run_in_docker() {
     local image=$(get_image_name $os_type $os_version)
     local upstream=$(get_upstream)
     local ccache
-    if test -d $HOME/.ccache ; then
-        ccache="--volume $HOME/.ccache:$HOME/.ccache"
-    fi
+    mkdir -p $HOME/.ccache
+    ccache="--volume $HOME/.ccache:$HOME/.ccache"
     if $dev ; then
         dev="--volume /dev:/dev"
     else


### PR DESCRIPTION
run-make-check.sh relies on ccache. If ~/.ccache is not bind mounted and
$HOME is not bind mounted either, ./configure will fail with an obscure
error because it cannot create the directory. Create the directory if it
does not exist already and avoid this problem. The worst that can happen
is that an empty .ccache directory is created and never used which
should not be a major inconvenience.

Signed-off-by: Loic Dachary <ldachary@redhat.com>