### PR TITLE
RBD snapshot, created while flattening image, is unremovable

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -523,8 +523,11 @@ namespace librbd {
 	  (scan_for_parents(ictx, our_pspec, snap_id) == -ENOENT)) {
 	  r = cls_client::remove_child(&ictx->md_ctx, RBD_CHILDREN,
 				       our_pspec, ictx->id);
-	  if (r < 0)
+	  if (r < 0 && r != -ENOENT) {
+            lderr(ictx->cct) << "snap_remove: failed to deregister from parent "
+                                "image" << dendl;
 	    return r;
+          }
       }
     }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1302,6 +1302,9 @@ reprotect_and_return_err:
 
     RWLock::RLocker l(ictx->snap_lock);
     RWLock::RLocker l2(ictx->parent_lock);
+    if (ictx->parent == NULL) {
+      return -ENOENT;
+    }
 
     parent_spec parent_spec;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/11113