### PR TITLE
debian: remove lttng checking from rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -33,12 +33,6 @@ ifeq ($(DEB_HOST_ARCH), armel)
   extraopts += --without-libatomic-ops
 endif
 
-ifeq ($(shell lsb_release -sc | egrep -q '(precise|quantal|raring|saucy|wheezy|squeeze)' && echo yes),yes)
-  extraopts += --without-lttng --without-babeltrace
-else
-  extraopts += --with-lttng --with-babeltrace
-endif
-
 configure: configure-stamp
 configure-stamp:
 	dh_testdir


### PR DESCRIPTION
This can be done better in a separate script, which puts these in 
CEPH_EXTRA_CONFIGURE_ARGS. In particular, this lets us enable lttng for
gitbuilder builds, but not release builds.

Fixes: #11333 Signed-off-by: Josh Durgin <jdurgin@redhat.com>