### PR TITLE
os/newstore: cap fid_max below newstore_max_dir_size

### DIFF
--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -1939,8 +1939,8 @@ int NewStore::_create_fid(TransContext *txc, fid_t *fid)
 	fid_last.fno < g_conf->newstore_max_dir_size) {
       ++fid_last.fno;
       if (fid_last.fno >= fid_max.fno) {
-	// raise fid_max, same fset
-	fid_max.fno += g_conf->newstore_fid_prealloc;
+	// raise fid_max, same fset, capping to max_dir_size
+	fid_max.fno = min(fid_max.fno + g_conf->newstore_fid_prealloc, g_conf->newstore_max_dir_size);
 	assert(fid_max.fno >= fid_last.fno);
 	bufferlist bl;
 	::encode(fid_max, bl);


### PR DESCRIPTION
Prevent fid_max over the max_dir_size when preallocation.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>