### PR TITLE
spec.in: sphinx -b man needs sphinx > 1.0 (part 2)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -75,10 +75,10 @@ BuildRequires:	python
 BuildRequires:	python-argparse
 BuildRequires:	python-nose
 BuildRequires:	python-requests
-%if 0%{?rhel} >= 7 || 0%{?fedora}
-BuildRequires:	python-sphinx
-%else
+%if ( 0%{?rhel} > 0 && 0%{?rhel} < 7 ) || ( 0%{?centos} > 0 && 0%{?centos} < 7 )
 BuildRequires:	python-sphinx10
+%else
+BuildRequires:	python-sphinx
 %endif
 BuildRequires:	python-virtualenv
 BuildRequires:	util-linux


### PR DESCRIPTION
Instead of listing the operating system versions that do not require the
python-sphinx10 package, switch to listing the operating system versions that
require the python-sphinx10 package. It's easier to maintain because
there only are a few.

Signed-off-by: Loic Dachary <ldachary@rehdat.com>