### PR TITLE
tests: allow multiple users of docker-tests.sh

### DIFF
--- a/src/test/docker-test-helper.sh
+++ b/src/test/docker-test-helper.sh
@@ -18,7 +18,7 @@ function get_image_name() {
     local os_type=$1
     local os_version=$2
 
-    echo ceph-$os_type-$os_version
+    echo ceph-$os_type-$os_version-$USER
 }
 
 function setup_container() {

--- a/src/test/docker-test-helper.sh
+++ b/src/test/docker-test-helper.sh
@@ -147,17 +147,6 @@ function run_in_docker() {
     return $status
 }
 
-declare -A OS_TYPE2VERSIONS=([ubuntu]="12.04 14.04" [centos]="6 7")
-
-function self_in_docker() {
-    local script=$1
-    shift
-
-    if test $# -gt 0 ; then
-        eval OS_TYPE2VERSIONS="$@"
-    fi
-}
-
 function remove_all() {
     local os_type=$1
     local os_version=$2


### PR DESCRIPTION
The docker image created by docker-tests.sh for a given operating system
is parameterized with the user name. If two users on the same machine
try to use the same image, they will compete and fail with an error
like:

... user get supplementary groups Unable to find user ...

Add the $USER to the image name to reflect the fact that they contain an
account for this user.

Signed-off-by: Loic Dachary <ldachary@redhat.com>