### PR TITLE
librbd: moved snap_create header update notification to initiator

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -387,11 +387,6 @@ void ImageWatcher::release_lock()
   unlock();
 }
 
-void ImageWatcher::finalize_header_update() {
-  librbd::notify_change(m_image_ctx.md_ctx, m_image_ctx.header_oid,
-			&m_image_ctx);
-}
-
 void ImageWatcher::assert_header_locked(librados::ObjectWriteOperation *op) {
   rados::cls::lock::assert_locked(op, RBD_LOCK_NAME, LOCK_EXCLUSIVE,
                                   encode_lock_cookie(), WATCHER_LOCK_TAG);
@@ -896,16 +891,6 @@ void ImageWatcher::handle_payload(const SnapCreatePayload &payload,
     int r = librbd::snap_create(&m_image_ctx, payload.snap_name.c_str(), false);
 
     ::encode(ResponseMessage(r), *out);
-    if (r == 0) {
-      // increment now to avoid race due to the delayed notification
-      Mutex::Locker lictx(m_image_ctx.refresh_lock);
-      ++m_image_ctx.refresh_seq;
-
-      // cannot notify within a notificiation
-      FunctionContext *ctx = new FunctionContext(
-	boost::bind(&ImageWatcher::finalize_header_update, this));
-      m_task_finisher->queue(TASK_CODE_HEADER_UPDATE, ctx);
-    }
   }
 }
 

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -74,7 +74,6 @@ namespace librbd {
       TASK_CODE_RELEASED_LOCK,
       TASK_CODE_RETRY_AIO_REQUESTS,
       TASK_CODE_CANCEL_ASYNC_REQUESTS,
-      TASK_CODE_HEADER_UPDATE,
       TASK_CODE_REREGISTER_WATCH,
       TASK_CODE_ASYNC_REQUEST,
       TASK_CODE_ASYNC_PROGRESS
@@ -212,7 +211,6 @@ namespace librbd {
     int lock();
     void release_lock();
     bool try_request_lock();
-    void finalize_header_update();
 
     void schedule_retry_aio_requests(bool use_timer);
     void retry_aio_requests();

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -531,7 +531,8 @@ int remove_object_map(ImageCtx *ictx) {
       }
 
       r = ictx->image_watcher->notify_snap_create(snap_name);
-      if (r == -EEXIST) {
+      if (r == 0 || r == -EEXIST) {
+        notify_change(ictx->md_ctx, ictx->header_oid, ictx);
         return 0;
       } else if (r != -ETIMEDOUT) {
 	return r;


### PR DESCRIPTION
When handling a proxied snap_create operation, the client which
invoked the snap_create should send the header update notification
to avoid a possible race condition where snap_create completes but
the client doesn't see the new snapshot (since it didn't yet receive
the notification).

Fixes: #11342
Signed-off-by: Jason Dillaman <dillaman@redhat.com>