### PR TITLE
librados: Add config observer for Objecter instance.

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -271,6 +271,8 @@ int librados::RadosClient::connect()
 
   lock.Unlock();
 
+  cct->_conf->call_all_observers();
+
   ldout(cct, 1) << "init done" << dendl;
   err = 0;
 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -288,6 +288,8 @@ void Objecter::init()
   timer.init();
   timer_lock.Unlock();
 
+  cct->_conf->add_observer(this);
+
   initialized.set(1);
 }
 


### PR DESCRIPTION
The Objecter instance used by librados does not currently have
add_observer() called on it. This means that the Objecter instance
it creates does not receive any notification of changes to the
'crush_location' parameter.

This can cause performance problems if commands using librados
(e.g. 'rbd') are run with localized reads on arbitrary (non-
cluster) hosts, as the client instance cannot self-determine
its locality, causing it to randomly select osds.

Change the Objecter instance to instead register its own observer
(as the other classes inheriting md_config_obs_t do) and ensure
that the configuration change propagates through to the librados
Objecter instance by calling call_all_observers() at the end of
init.

The 'crush location' setting can now be specified in either the
[global] or [client] sections of ceph.conf and will be respected.

Signed-off-by: Alistair Strachan <alistair.strachan@imgtec.com>