### PR TITLE
README: rm references to old Ubuntu distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ The list of debian packages dependencies can be installed with:
 	./install-deps.sh
 
 Note: libsnappy-dev and libleveldb-dev are not available upstream for
-natty, oneiric, and squeeze.  Backports for Ceph can be found at
-ceph.com/debian-leveldb.
+Debian Squeeze.  Backports for Ceph can be found at ceph.com/debian-leveldb.
 
 rpm-based
 ---------


### PR DESCRIPTION
Support for Ubuntu 11.04 officially ended on 28 October 2012.

Support for Ubuntu Oneiric Ocelot was officially ended on 9 May 2013.

This pull request removes the references to these EOL distro versions.