### PR TITLE
osd: erasure-code-profile incremental rm before set

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1222,17 +1222,17 @@ int OSDMap::apply_incremental(const Incremental &inc)
   }
 
   // erasure_code_profiles
+  for (vector<string>::const_iterator i = inc.old_erasure_code_profiles.begin();
+       i != inc.old_erasure_code_profiles.end();
+       ++i)
+    erasure_code_profiles.erase(*i);
+  
   for (map<string,map<string,string> >::const_iterator i =
 	 inc.new_erasure_code_profiles.begin();
        i != inc.new_erasure_code_profiles.end();
        i++) {
     set_erasure_code_profile(i->first, i->second);
   }
-  
-  for (vector<string>::const_iterator i = inc.old_erasure_code_profiles.begin();
-       i != inc.old_erasure_code_profiles.end();
-       i++)
-    erasure_code_profiles.erase(*i);
   
   // up/down
   for (map<int32_t,uint8_t>::const_iterator i = inc.new_state.begin();


### PR DESCRIPTION
It is possible for an incremental change to have both a rm and a set for
a given erasure code profile. It only happens when a rm is followed by a
set. When a set is followed by a rm, the rm will remove the pending set
in the incremental change.

The logic is the same for pool create and pool delete.

We must apply the incremental erasure-code-profile removal before the
creation otherwise rm and set in the same proposal will ignore the set.

This fix is minimal. A better change would be that erasure-code-profile
set checks if there is a pending removal and wait_for_finished_proposal
before creating.

http://tracker.ceph.com/issues/11144 Fixes: #11144

Signed-off-by: Loic Dachary <ldachary@redhat.com>
(cherry picked from commit 0d52aca0d0c302983d03b0f5213ffed187e4ed63)

Conflicts:
	src/osd/OSDMap.cc