### PR TITLE
client: drop inode when rmdir request finishes

### DIFF
--- a/src/client/MetaRequest.h
+++ b/src/client/MetaRequest.h
@@ -54,6 +54,7 @@ public:
   MClientReply *reply;         // the reply
   bool kick;
   bool aborted;
+  bool success;
   
   // readdir result
   frag_t readdir_frag;
@@ -91,7 +92,7 @@ public:
     mds(-1), resend_mds(-1), send_to_auth(false), sent_on_mseq(0),
     num_fwd(0), retry_attempt(0),
     ref(1), reply(0), 
-    kick(false), aborted(false),
+    kick(false), aborted(false), success(false),
     readdir_offset(0), readdir_end(false), readdir_num(0),
     got_unsafe(false), item(this), unsafe_item(this),
     lock("MetaRequest lock"),


### PR DESCRIPTION
Current client code relies on cap message to trim unlinked inode
from cache. This method is too sensitive to message ordering. If
client receives the cap message while directory inode still contains
dentries that are referenced by unsafe requests, the inode can't
get trimmed.

The fix is, when rmdir/rename request finishes, try trimming the
unlinked inode again.

Fixes: #11339
Signed-off-by: Yan, Zheng <zyan@redhat.com>