### PR TITLE
librbd: notify_resize doesn't notify change to all clients

### DIFF
--- a/src/librbd/AsyncResizeRequest.h
+++ b/src/librbd/AsyncResizeRequest.h
@@ -75,6 +75,7 @@ private:
     STATE_GROW_OBJECT_MAP,
     STATE_UPDATE_HEADER,
     STATE_SHRINK_OBJECT_MAP,
+    STATE_UPDATE_SIZE_OVERLAP,
     STATE_FINISHED
   };
 
@@ -97,8 +98,8 @@ private:
   void send_update_header();
 
   void compute_parent_overlap();
-  void increment_refresh_seq();
   void update_size_and_overlap();
+  void send_notify_change();
 
 };
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1796,7 +1796,6 @@ reprotect_and_return_err:
     } while (r == -ERESTART);
 
     ictx->perfcounter->inc(l_librbd_resize);
-    notify_change(ictx->md_ctx, ictx->header_oid, ictx);
     ldout(cct, 2) << "resize finished" << dendl;
     return r;
   }


### PR DESCRIPTION
When a resize request is sending to a non lock owner client, it calls
notify_resize to send a resize request to the lock owner. However, the
lock owner doesn't notify all the clients about this change after
completing the request. Should send notify change at the end of the
async resize request.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>