### PR TITLE
Wip async fix 4

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1752,7 +1752,9 @@ int AsyncConnection::handle_connect_msg(ceph_msg_connect &connect, bufferlist &a
     existing->replacing = true;
     existing->state_offset = 0;
     existing->state = STATE_ACCEPTING_WAIT_CONNECT_MSG;
-    // there should exist any buffer
+    // Discard existing prefetch buffer in `recv_buf`
+    existing->recv_start = existing->recv_end = 0;
+    // there shouldn't exist any buffer
     assert(recv_start == recv_end);
 
     if (existing->_reply_accept(CEPH_MSGR_TAG_RETRY_GLOBAL, connect, reply, authorizer_reply) < 0) {

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -373,9 +373,9 @@ int EventCenter::process_events(int timeout_microseconds)
     external_lock.Unlock();
     while (!cur_process.empty()) {
       EventCallbackRef e = cur_process.front();
-      cur_process.pop_front();
       if (e)
         e->do_request(0);
+      cur_process.pop_front();
     }
   }
   return numevents;


### PR DESCRIPTION
Fix osd crash problem:

1. osd A,B connected and lots of messages inflight
2. the connection failed and each side try to reconnect
3. assume osd.a successfully send ceph_connect_msg to osd.b
4. osd.b accept and reply to osd.a with CEPH_MSGR_TAG_RETRY_GLOBAL
5. osd.a will try to send ceph_connect_msg again
6. there still exists some prefetch buffer in osd.b side, so osd.b got a wrong ceph_connect_msg
7. so osd.b got a default policy according to wrong host_type, so lossy will be true
8. then osd.b verify connect_msg and found wrong protocol version, so go to fail
9. osd.b will discard all states because of lossy=true!

So now we just avoid use incoming policy directly.