### PR TITLE
ec : backend feature to read from all OSDs and silently discard EIO if possible

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -512,6 +512,7 @@ OPTION(osd_crush_chooseleaf_type, OPT_INT, 1) // 1 = host
 OPTION(osd_pool_default_crush_rule, OPT_INT, -1) // deprecated for osd_pool_default_crush_replicated_ruleset
 OPTION(osd_pool_default_crush_replicated_ruleset, OPT_INT, CEPH_DEFAULT_CRUSH_REPLICATED_RULESET)
 OPTION(osd_pool_erasure_code_stripe_width, OPT_U32, OSD_POOL_ERASURE_CODE_STRIPE_WIDTH) // in bytes
+OPTION(osd_pool_erasure_code_subread_all, OPT_BOOL, false)       // dispatch all OSD for sub-read op
 OPTION(osd_pool_default_size, OPT_INT, 3)
 OPTION(osd_pool_default_min_size, OPT_INT, 0)  // 0 means no specific default; ceph will use size-size/2
 OPTION(osd_pool_default_pg_num, OPT_INT, 8) // number of PGs for new pools. Configure in global or mon section of ceph.conf

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -284,6 +284,7 @@ public:
     int priority;
     ceph_tid_t tid;
     OpRequestRef op; // may be null if not on behalf of a client
+    bool is_recovery; // true if the op is for recovery, false otherwise
 
     map<hobject_t, read_request_t> to_read;
     map<hobject_t, read_result_t> complete;
@@ -306,7 +307,8 @@ public:
   void start_read_op(
     int priority,
     map<hobject_t, read_request_t> &to_read,
-    OpRequestRef op);
+    OpRequestRef op,
+    bool is_recovery);
 
 
   /**
@@ -431,6 +433,9 @@ public:
 
 
   const ECUtil::stripe_info_t sinfo;
+  // This flag indicates whether we issue subread requests to all replicas (
+  // data and parity), this can improve performance with some I/O overhead
+  bool subread_all;
   /// If modified, ensure that the ref is held until the update is applied
   SharedPtrRegistry<hobject_t, ECUtil::HashInfo> unstable_hashinfo_registry;
   ECUtil::HashInfoRef get_hash_info(const hobject_t &hoid);


### PR DESCRIPTION
Add osd setting osd_pool_erasure_code_subread_all. Default is false. If set it to true.
Will send sub-read op to all OSD and choose the first success read result.

Fixes: 9943
Signed-off-by: Wei Luo <luowei@yahoo-inc.com>
Signed-off-by: Guang Yang <yguang@yahoo-inc.com>