### PR TITLE
ceph.spec.in: set _with_systemd on RHEL 7 and Fedora

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -10,7 +10,7 @@
 # the _with_systemd variable only implies that we'll install
 # /etc/tmpfiles.d/ceph.conf in order to set up the socket directory in
 # /var/run/ceph.
-%if 0%{?rhel} > 7
+%if 0%{?fedora} || 0%{?rhel} >= 7
   %global _with_systemd 1
 %endif
 


### PR DESCRIPTION
Commit 71a5090bca049a43e30a7f0cf99141950ef9c5dd added a `_with_systemd` conditional to the RPMs, but I erred with the version comparison operator, so this only applied to RHEL 8+, not RHEL 7+.

Adjust the conditional so that it will really apply to RHEL 7+. While we're here, add Fedora as well.

Reported by @branto1 - thanks for catching this.