### PR TITLE
Add perf counter for cache_tier hit rate and cache_tier total

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2153,6 +2153,8 @@ void OSD::create_logger()
 
   osd_plb.add_u64_counter(l_osd_copyfrom, "copyfrom", "Rados \"copy-from\" operations");
 
+  osd_plb.add_u64_counter(l_osd_tier_total, "tier_total", "Tier total ops");
+  osd_plb.add_u64_counter(l_osd_tier_hit, "tier_hit", "Tier hits");
   osd_plb.add_u64_counter(l_osd_tier_promote, "tier_promote", "Tier promotions");
   osd_plb.add_u64_counter(l_osd_tier_flush, "tier_flush", "Tier flushes");
   osd_plb.add_u64_counter(l_osd_tier_flush_fail, "tier_flush_fail", "Failed tier flushes");
@@ -2164,6 +2166,9 @@ void OSD::create_logger()
   osd_plb.add_u64_counter(l_osd_tier_clean, "tier_clean", "Dirty tier flag cleaned");
   osd_plb.add_u64_counter(l_osd_tier_delay, "tier_delay", "Tier delays (agent waiting)");
   osd_plb.add_u64_counter(l_osd_tier_proxy_read, "tier_proxy_read", "Tier proxy reads");
+  osd_plb.add_time_avg(l_osd_tier_flush_lat, "osd_tier_flush_lat", "Object flush latency");
+  osd_plb.add_time_avg(l_osd_tier_promote_lat, "osd_tier_promote_lat", "Object promote latency");
+  osd_plb.add_time_avg(l_osd_tier_r_lat, "osd_tier_r_lat", "Object proxy read latency");
 
   osd_plb.add_u64_counter(l_osd_agent_wake, "agent_wake", "Tiering agent wake up");
   osd_plb.add_u64_counter(l_osd_agent_skip, "agent_skip", "Objects skipped by agent");
@@ -2172,11 +2177,6 @@ void OSD::create_logger()
 
   osd_plb.add_u64_counter(l_osd_object_ctx_cache_hit, "object_ctx_cache_hit", "Object context cache hits");
   osd_plb.add_u64_counter(l_osd_object_ctx_cache_total, "object_ctx_cache_total", "Object context cache lookups");
-
-  osd_plb.add_u64_counter(l_osd_op_cache_hit, "op_cache_hit");
-  osd_plb.add_time_avg(l_osd_tier_flush_lat, "osd_tier_flush_lat", "Object flush latency");
-  osd_plb.add_time_avg(l_osd_tier_promote_lat, "osd_tier_promote_lat", "Object promote latency");
-  osd_plb.add_time_avg(l_osd_tier_r_lat, "osd_tier_r_lat", "Object proxy read latency");
 
   logger = osd_plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -124,6 +124,8 @@ enum {
 
   l_osd_copyfrom,
 
+  l_osd_tier_total,
+  l_osd_tier_hit,
   l_osd_tier_promote,
   l_osd_tier_flush,
   l_osd_tier_flush_fail,
@@ -135,6 +137,9 @@ enum {
   l_osd_tier_clean,
   l_osd_tier_delay,
   l_osd_tier_proxy_read,
+  l_osd_tier_flush_lat,
+  l_osd_tier_promote_lat,
+  l_osd_tier_r_lat,
 
   l_osd_agent_wake,
   l_osd_agent_skip,
@@ -143,11 +148,6 @@ enum {
 
   l_osd_object_ctx_cache_hit,
   l_osd_object_ctx_cache_total,
-
-  l_osd_op_cache_hit,
-  l_osd_tier_flush_lat,
-  l_osd_tier_promote_lat,
-  l_osd_tier_r_lat,
 
   l_osd_last,
 };

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1787,6 +1787,7 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
 	     << " in_hit_set " << (int)in_hit_set
 	     << dendl;
 
+  osd->logger->inc(l_osd_tier_total);
   // if it is write-ordered and blocked, stop now
   if (obc.get() && obc->is_blocked() && write_ordered) {
     // we're already doing something with this object
@@ -1800,7 +1801,7 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
   }
 
   if (obc.get() && obc->obs.exists) {
-    osd->logger->inc(l_osd_op_cache_hit);
+    osd->logger->inc(l_osd_tier_hit);
     return false;
   }
   


### PR DESCRIPTION
Just count hit may not be enough in #3889 , osd Ops may aggregate all ops for all pools, not just cache pool. We need to count total Ops from cache pools.
Secondly, some Ops may redirect or proxy read without promotion. Those kind of Ops will not take too much disk resource. So we may keep trace on the number of promotion. 

Signed-off-by: Ning Yao <yaoning@ruijie.com.cn>