### PR TITLE
librbd/AsyncResize: avoid dup incrementing refresh seq

### DIFF
--- a/src/librbd/AsyncResizeRequest.cc
+++ b/src/librbd/AsyncResizeRequest.cc
@@ -98,7 +98,6 @@ bool AsyncResizeRequest::should_complete(int r) {
     ldout(cct, 5) << "UPDATE_HEADER" << dendl;
     if (send_shrink_object_map()) {
       update_size_and_overlap();
-      increment_refresh_seq();
       return true;
     }
     break;
@@ -106,7 +105,6 @@ bool AsyncResizeRequest::should_complete(int r) {
   case STATE_SHRINK_OBJECT_MAP:
     ldout(cct, 5) << "SHRINK_OBJECT_MAP" << dendl;
     update_size_and_overlap();
-    increment_refresh_seq();
     return true;
 
   case STATE_FINISHED:
@@ -299,12 +297,6 @@ void AsyncResizeRequest::compute_parent_overlap() {
   } else {
     m_new_parent_overlap = MIN(m_new_size, m_image_ctx.parent_md.overlap);
   }
-}
-
-void AsyncResizeRequest::increment_refresh_seq() {
-  m_image_ctx.refresh_lock.Lock();
-  ++m_image_ctx.refresh_seq;
-  m_image_ctx.refresh_lock.Unlock();
 }
 
 void AsyncResizeRequest::update_size_and_overlap() {

--- a/src/librbd/AsyncResizeRequest.h
+++ b/src/librbd/AsyncResizeRequest.h
@@ -97,7 +97,6 @@ private:
   void send_update_header();
 
   void compute_parent_overlap();
-  void increment_refresh_seq();
   void update_size_and_overlap();
 
 };


### PR DESCRIPTION
The refresh_seq is incremented in notify_change when calling
notify_async_complete after the locker owner completes the resize
request.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>