### PR TITLE
librbd: resize takes the ictx->owner_lock twice in some cases

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -844,7 +844,6 @@ void ImageWatcher::handle_payload(const FlattenPayload &payload,
 
 void ImageWatcher::handle_payload(const ResizePayload &payload,
 				  bufferlist *out) {
-  RWLock::RLocker l(m_image_ctx.owner_lock);
   if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
     int r = 0;
     bool new_request = false;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1782,11 +1782,11 @@ reprotect_and_return_err:
 	  ldout(ictx->cct, 5) << "resize timed out notifying lock owner"
                               << dendl;
 	}
+      }
 
-	r = async_resize(ictx, &ctx, size, prog_ctx);
-	if (r < 0) {
-	  return r;
-	}
+      r = async_resize(ictx, &ctx, size, prog_ctx);
+      if (r < 0) {
+        return r;
       }
 
       r = ctx.wait();
@@ -1804,10 +1804,6 @@ reprotect_and_return_err:
   int async_resize(ImageCtx *ictx, Context *ctx, uint64_t size,
 		   ProgressContext &prog_ctx)
   {
-    assert(ictx->owner_lock.is_locked());
-    assert(!ictx->image_watcher->is_lock_supported() ||
-	   ictx->image_watcher->is_lock_owner());
-
     CephContext *cct = ictx->cct;
     ictx->snap_lock.get_read();
     ldout(cct, 20) << "async_resize " << ictx << " " << ictx->size << " -> "
@@ -1833,7 +1829,6 @@ reprotect_and_return_err:
   void async_resize_helper(ImageCtx *ictx, Context *ctx, uint64_t new_size,
                            ProgressContext& prog_ctx)
   {
-    assert(ictx->owner_lock.is_locked());
     AsyncResizeRequest *req = new AsyncResizeRequest(*ictx, ctx, new_size,
                                                      prog_ctx);
     req->send();


### PR DESCRIPTION
ictx->owner_lock is taken for read before calling async_resize function.
And in the resize state machine, this lock is re-taken in some functions
like send_grow_object_map, send_update_header, etc. This will lead to
the lock being taken twice in some cases. Actually, since the resize
state machine can handle the cases when losting exclusive lock and takes
the ictx->owner_locker as needed, there is no need to take this lock
before calling async_resize.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>