### PR TITLE
install-deps.sh: Debian GNU/Linux wheezy needs backports

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -48,10 +48,11 @@ Ubuntu|Debian|Devuan)
         case $(lsb_release -sc) in
             squeeze|wheezy)
                 packages=$(echo $packages | perl -pe 's/[-\w]*babeltrace[-\w]*//g')
+                backports="-t $(lsb_release -sc)-backports"
                 ;;
         esac
         packages=$(echo $packages) # change newlines into spaces
-        $SUDO bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y $packages"
+        $SUDO bash -c "DEBIAN_FRONTEND=noninteractive apt-get install $backports -y $packages"
         ;;
 CentOS|Fedora|RedHatEnterpriseServer)
         case $(lsb_release -si) in


### PR DESCRIPTION
It is not enough for the backports to be available, they also need to be
explicitly allowed to take precedence whenever a package is installed
indirectly. This is causing problems with libp11-kit-dev pulled by
libcurl4-gnutls-dev.

Signed-off-by: Loic Dachary <ldachary@redhat.com>