### PR TITLE
osd: get more reasonable scrub_reg_stamp

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3298,7 +3298,11 @@ void PG::reg_next_scrub()
       (info.stats.stats_invalid && g_conf->osd_scrub_invalid_stats)) {
     scrubber.scrub_reg_stamp = utime_t();
   } else {
-    scrubber.scrub_reg_stamp = info.history.last_scrub_stamp;
+    if (info.history.last_scrub_stamp + cct->_conf->osd_scrub_min_interval <
+        info.history.last_deep_scrub_stamp + cct->_conf->osd_deep_scrub_interval)
+      scrubber.scrub_reg_stamp = info.history.last_scrub_stamp;
+    else
+      scrubber.scrub_reg_stamp = info.history.last_deep_scrub_stamp;
   }
   if (is_primary())
     osd->reg_last_pg_scrub(info.pgid, scrubber.scrub_reg_stamp);


### PR DESCRIPTION
If we execute the command "ceph osd set nodeep-scrub", the last_scrub_stamp
would be osd_deep_scrub_interval largger than last_deep_scrub. E.g.,
```
pg_stat last_scrub      scrub_stamp last_deep_scrub deep_scrub_stamp
2.d8    35845'2779955   2015-04-10 16:49:32.340098      35666'2695089   2015-04-01 21:39:13.234161
```
And then, If we set nodeep-scrub sometime of the day, case below would be possible.

```
PG  scrub_stamp deep_scrub_stamp
A       8              2
B       9              1
```

If the osd_deep_scrub_interval is 7 and osd_scrub_min_interval is 1. I think we should
schedule PG B first instead of PG A, because PG B is time for deep scrub.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>