### PR TITLE
tests: display ceph report when stuck

### DIFF
--- a/src/test/ceph-helpers.sh
+++ b/src/test/ceph-helpers.sh
@@ -866,6 +866,8 @@ function wait_for_clean() {
         if get_is_making_recovery_progress ; then
             timer=0
         elif (( timer >= $TIMEOUT )) ; then
+            ceph pg dump
+            ceph health detail
             return 1
         fi
 


### PR DESCRIPTION
When the cluster is stuck (wait_for_clean times out), display ceph
report to stderr for debugging purposes.

Signed-off-by: Loic Dachary <ldachary@redhat.com>