### PR TITLE
os/Newstore: Allow gap in _do_write append mode

### DIFF
--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -3137,7 +3137,7 @@ int NewStore::_do_write(TransContext *txc,
     goto out;
   }
 
-  if (o->onode.size == offset ||
+  if (o->onode.size <= offset ||
       o->onode.size == 0 ||
       o->onode.data_map.empty()) {
     _do_overlay_clear(txc, o);


### PR DESCRIPTION
We can allow some gap so we only need to ensure
onode.size <= offset.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>