### PR TITLE
#11383: packaging: ship systemd/ceph.tmpfiles.d in tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,7 @@ EXTRA_DIST += \
 	src/test/run-cli-tests-maybe-unset-ccache \
 	src/test/cli \
 	src/test/downloads \
+	systemd/ceph.tmpfiles.d \
 	udev/50-rbd.rules \
 	udev/60-ceph-partuuid-workaround.rules \
 	udev/95-ceph-osd.rules \


### PR DESCRIPTION
Prior to this commit, the tarballs did not contain any files under the top-level "`systemd`" directory. This caused problems with RPM builds on Fedora and RHEL 7, because as of commit aa88364f30e2d2f254ade185a83ba263b48e2a73, those RPMs depend on the systemd/ceph.tmpfiles.d file.

(Longer-term we might want to improve the tarball generation code to be less complex/manual.)

Reported-by: Greg Farnum <gfarnum@redhat.com>