### PR TITLE
#11376: packaging: mv ceph-objectstore-tool to main ceph pkg

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -587,6 +587,7 @@ fi
 %{_bindir}/ceph-run
 %{_bindir}/ceph-mon
 %{_bindir}/ceph-mds
+%{_bindir}/ceph-objectstore-tool
 %{_bindir}/ceph-osd
 %{_bindir}/librados-config
 %{_bindir}/ceph-client-debug
@@ -894,7 +895,6 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_bindir}/ceph_smalliobenchdumb
 %{_bindir}/ceph_smalliobenchfs
 %{_bindir}/ceph_smalliobenchrbd
-%{_bindir}/ceph-objectstore-tool
 %{_bindir}/ceph_streamtest
 %{_bindir}/ceph_test_*
 %{_bindir}/ceph_tpbench

--- a/debian/ceph-test.install
+++ b/debian/ceph-test.install
@@ -1,6 +1,5 @@
 usr/bin/ceph-coverage
 usr/bin/ceph_bench_log
-usr/bin/ceph-objectstore-tool
 usr/bin/ceph_kvstorebench
 usr/bin/ceph_multi_stress_watch
 usr/bin/ceph_erasure_code

--- a/debian/ceph.install
+++ b/debian/ceph.install
@@ -8,6 +8,7 @@ usr/sbin/ceph-disk-prepare
 usr/bin/ceph-clsinfo
 usr/bin/ceph-debugpack
 usr/bin/ceph-mon
+usr/bin/ceph-objectstore-tool
 usr/bin/ceph-osd
 usr/bin/ceph-run
 usr/bin/ceph-rest-api

--- a/debian/control
+++ b/debian/control
@@ -74,8 +74,9 @@ Depends: binutils,
          ${misc:Depends},
          ${shlibs:Depends}
 Recommends: btrfs-tools, ceph-mds, librados2, libradosstriper1, librbd1
-Replaces: ceph-common (<< 0.78-500), python-ceph (<< 0.92-1223)
-Breaks: python-ceph (<< 0.92-1223)
+Replaces: ceph-common (<< 0.78-500), python-ceph (<< 0.92-1223),
+	  ceph-test (<< 0.94-1322)
+Breaks: python-ceph (<< 0.92-1223), ceph-test (<< 0.94-1322)
 X-Python-Version: >= 2.6
 Description: distributed storage and file system
  Ceph is a massively scalable, open-source, distributed


### PR DESCRIPTION
This change ensures that the ceph-objectstore-tool utility is present on all OSDs.  This makes it easier for users to run this tool to do manual debugging/recovery in some scenarios.

This fixes http://tracker.ceph.com/issues/11376