### PR TITLE
MOSDOp: dump_ops to track state of message when clear_buffer

### DIFF
--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -19,6 +19,7 @@
 #include "msg/Message.h"
 #include "osd/osd_types.h"
 #include "include/ceph_features.h"
+#include <sstream>
 
 /*
  * OSD op
@@ -55,6 +56,8 @@ private:
   vector<snapid_t> snaps;
 
   uint64_t features;
+  
+  string dump_ops;
 
 public:
   friend class MOSDOpReply;
@@ -354,6 +357,9 @@ struct ceph_osd_request_head {
   }
 
   void clear_buffers() {
+    std::ostringstream os;
+    os << ops;
+    dump_ops = os.str();
     ops.clear();
   }
 
@@ -378,7 +384,10 @@ struct ceph_osd_request_head {
     if (oloc.key.size())
       out << " " << oloc;
 
-    out << " " << ops;
+    if (dump_ops.empty())
+      out << " " << ops;
+    else
+      out << " " << dump_ops;
     out << " " << pgid;
     if (is_retry_attempt())
       out << " RETRY=" << get_retry_attempt();


### PR DESCRIPTION
In ceph-0.72 version, dump_historic_ops could show ops, such as:
"description": "osd_op(client.14122.1:8259 rb.0.1013.6b8b4567.000000000163
[write 2097152~524288] 0.a052cb27 ondisk+write e24)"

But after ceph-0.80, ops is disappear when dump_historic_ops.
"description": "osd_op(client.14122.1:8259 rb.0.1013.6b8b4567.000000000163
[] 0.a052cb27 ondisk+write e24)"

I think this is useful of debugging.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>