### PR TITLE
os/Newstore: add newstore_db_path option

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -781,6 +781,7 @@ OPTION(newstore_open_by_handle, OPT_BOOL, true)
 OPTION(newstore_o_direct, OPT_BOOL, true)
 OPTION(newstore_aio, OPT_BOOL, true)
 OPTION(newstore_aio_poll_ms, OPT_INT, 250)  // milliseconds
+OPTION(newstore_db_path, OPT_STR, "")
 
 OPTION(filestore_omap_backend, OPT_STR, "leveldb")
 

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -569,6 +569,7 @@ NewStore::NewStore(CephContext *cct, const string& path)
     cct(cct),
     db(NULL),
     fs(NULL),
+    db_path(cct->_conf->newstore_db_path),
     path_fd(-1),
     fsid_fd(-1),
     frag_fd(-1),
@@ -889,6 +890,11 @@ int NewStore::mkfs()
   if (r < 0)
     goto out_close_fsid;
 
+  if (db_path != "") {
+    r = symlinkat(db_path.c_str(), path_fd, "db");
+    if (r < 0)
+      goto out_close_frag;
+  }
   r = _open_db();
   if (r < 0)
     goto out_close_frag;

--- a/src/os/newstore/NewStore.h
+++ b/src/os/newstore/NewStore.h
@@ -372,6 +372,7 @@ private:
   KeyValueDB *db;
   FS *fs;
   uuid_d fsid;
+  string db_path;
   int path_fd;  ///< open handle to $path
   int fsid_fd;  ///< open handle (locked) to $path/fsid
   int frag_fd;  ///< open handle to $path/fragments


### PR DESCRIPTION
The load of Keyvalue DB is heavy, allow user to put
DB to a seperate(fast) device.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>