### PR TITLE
ceph-authtool: exit(1) when printing a non-existing key

### DIFF
--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -264,6 +264,7 @@ int main(int argc, const char **argv)
         cout << key << std::endl;
       } else {
         cerr << "entity " << ename << " not found" << std::endl;
+        exit(1);
       }
     }
   
@@ -274,6 +275,7 @@ int main(int argc, const char **argv)
       r = bl.write_file(fn.c_str(), 0600);
       if (r < 0) {
         cerr << "could not write " << fn << std::endl;
+        exit(1);
       }
       //cout << "wrote " << bl.length() << " bytes to " << fn << std::endl;
     }


### PR DESCRIPTION
When printing a non-existing key, ceph-authtool exits with a success
value:

[root@ip-172-31-3-178 ~]# ceph-authtool /etc/ceph/ceph.mon.keyring -p -n
client.doesntexist ; echo $?
entity client.doesntexist not found
0

Expected result: 1