### PR TITLE
Fix ceph dencoder build

### DIFF
--- a/src/mds/Makefile-client.am
+++ b/src/mds/Makefile-client.am
@@ -1,0 +1,4 @@
+# There are no libmds_types so use the full mds library for dencoder for now
+DENCODER_SOURCES += $(LIBMDS_SOURCES)
+
+DENCODER_DEPS += $(LIBMDS_DEPS)

--- a/src/mds/Makefile-server.am
+++ b/src/mds/Makefile-server.am
@@ -1,0 +1,68 @@
+if WITH_MDS
+
+libmds_la_SOURCES = $(LIBMDS_SOURCES)
+libmds_la_LIBADD = $(LIBMDS_DEPS)
+noinst_LTLIBRARIES += libmds.la
+
+noinst_HEADERS += \
+	mds/inode_backtrace.h \
+	mds/flock.h \
+	mds/locks.c \
+	mds/locks.h \
+	mds/CDentry.h \
+	mds/CDir.h \
+	mds/CInode.h \
+	mds/Capability.h \
+	mds/InoTable.h \
+	mds/JournalPointer.h \
+	mds/LocalLock.h \
+	mds/Locker.h \
+	mds/LogEvent.h \
+	mds/LogSegment.h \
+	mds/MDBalancer.h \
+	mds/MDCache.h \
+	mds/RecoveryQueue.h \
+	mds/StrayManager.h \
+	mds/MDLog.h \
+	mds/MDS.h \
+	mds/Beacon.h \
+	mds/MDSContext.h \
+	mds/MDSAuthCaps.h \
+	mds/MDSMap.h \
+	mds/MDSTable.h \
+	mds/MDSTableServer.h \
+	mds/MDSTableClient.h \
+	mds/Mutation.h \
+	mds/Migrator.h \
+	mds/ScatterLock.h \
+	mds/Server.h \
+	mds/SessionMap.h \
+	mds/SimpleLock.h \
+	mds/SnapClient.h \
+	mds/SnapRealm.h \
+	mds/SnapServer.h \
+	mds/inode_backtrace.h \
+	mds/mds_table_types.h \
+	mds/mdstypes.h \
+	mds/snap.h \
+	mds/MDSContinuation.h
+
+noinst_HEADERS += \
+	mds/events/ECommitted.h \
+	mds/events/EExport.h \
+	mds/events/EFragment.h \
+	mds/events/EImportFinish.h \
+	mds/events/EImportStart.h \
+	mds/events/EMetaBlob.h \
+	mds/events/ENoOp.h \
+	mds/events/EOpen.h \
+	mds/events/EResetJournal.h \
+	mds/events/ESession.h \
+	mds/events/ESessions.h \
+	mds/events/ESlaveUpdate.h \
+	mds/events/ESubtreeMap.h \
+	mds/events/ETableClient.h \
+	mds/events/ETableServer.h \
+	mds/events/EUpdate.h
+
+endif # WITH_MDS

--- a/src/mds/Makefile.am
+++ b/src/mds/Makefile.am
@@ -1,7 +1,4 @@
-if ENABLE_SERVER
-if WITH_MDS
-
-libmds_la_SOURCES = \
+LIBMDS_SOURCES = \
 	mds/Capability.cc \
 	mds/MDS.cc \
 	mds/Beacon.cc \
@@ -33,69 +30,12 @@ libmds_la_SOURCES = \
 	mds/MDSAuthCaps.cc \
 	mds/MDLog.cc \
 	common/TrackedOp.cc
-libmds_la_LIBADD = $(LIBOSDC)
-noinst_LTLIBRARIES += libmds.la
+LIBMDS_DEPS = $(LIBOSDC)
 
-noinst_HEADERS += \
-	mds/inode_backtrace.h \
-	mds/flock.h \
-	mds/locks.c \
-	mds/locks.h \
-	mds/CDentry.h \
-	mds/CDir.h \
-	mds/CInode.h \
-	mds/Capability.h \
-	mds/InoTable.h \
-	mds/JournalPointer.h \
-	mds/LocalLock.h \
-	mds/Locker.h \
-	mds/LogEvent.h \
-	mds/LogSegment.h \
-	mds/MDBalancer.h \
-	mds/MDCache.h \
-	mds/RecoveryQueue.h \
-	mds/StrayManager.h \
-	mds/MDLog.h \
-	mds/MDS.h \
-	mds/Beacon.h \
-	mds/MDSContext.h \
-	mds/MDSAuthCaps.h \
-	mds/MDSMap.h \
-	mds/MDSTable.h \
-	mds/MDSTableServer.h \
-	mds/MDSTableClient.h \
-	mds/Mutation.h \
-	mds/Migrator.h \
-	mds/ScatterLock.h \
-	mds/Server.h \
-	mds/SessionMap.h \
-	mds/SimpleLock.h \
-	mds/SnapClient.h \
-	mds/SnapRealm.h \
-	mds/SnapServer.h \
-	mds/inode_backtrace.h \
-	mds/mds_table_types.h \
-	mds/mdstypes.h \
-	mds/snap.h \
-	mds/MDSContinuation.h
+if ENABLE_CLIENT
+include mds/Makefile-client.am
+endif
 
-noinst_HEADERS += \
-	mds/events/ECommitted.h \
-	mds/events/EExport.h \
-	mds/events/EFragment.h \
-	mds/events/EImportFinish.h \
-	mds/events/EImportStart.h \
-	mds/events/EMetaBlob.h \
-	mds/events/ENoOp.h \
-	mds/events/EOpen.h \
-	mds/events/EResetJournal.h \
-	mds/events/ESession.h \
-	mds/events/ESessions.h \
-	mds/events/ESlaveUpdate.h \
-	mds/events/ESubtreeMap.h \
-	mds/events/ETableClient.h \
-	mds/events/ETableServer.h \
-	mds/events/EUpdate.h
-
-endif # WITH_MDS
-endif # ENABLE_SERVER
+if ENABLE_SERVER
+include mds/Makefile-server.am
+endif

--- a/src/perfglue/Makefile.am
+++ b/src/perfglue/Makefile.am
@@ -17,6 +17,11 @@ endif # WITH_PROFILER
 
 noinst_LTLIBRARIES += libperfglue.la
 
+# Do not use TCMALLOC with dencoder
+DENCODER_SOURCES += \
+	perfglue/disabled_heap_profiler.cc \
+	perfglue/disabled_stubs.cc
+
 noinst_HEADERS += \
 	perfglue/cpu_profiler.h \
 	perfglue/heap_profiler.h

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -1,4 +1,13 @@
 if ENABLE_CLIENT
+
+# inject rgw stuff in the decoder testcase
+DENCODER_SOURCES += \
+	rgw/rgw_dencoder.cc \
+	rgw/rgw_acl.cc \
+	rgw/rgw_common.cc \
+	rgw/rgw_env.cc \
+	rgw/rgw_json_enc.cc
+
 if WITH_RADOS
 if WITH_RADOSGW
 
@@ -106,14 +115,6 @@ ceph_rgw_jsonparser_SOURCES = \
 	rgw/rgw_json_enc.cc
 ceph_rgw_jsonparser_LDADD = $(LIBRGW) $(LIBRGW_DEPS) $(CEPH_GLOBAL)
 bin_DEBUGPROGRAMS += ceph_rgw_jsonparser
-
-# inject rgw stuff in the decoder testcase
-DENCODER_SOURCES += \
-	rgw/rgw_dencoder.cc \
-	rgw/rgw_acl.cc \
-	rgw/rgw_common.cc \
-	rgw/rgw_env.cc \
-	rgw/rgw_json_enc.cc
 
 
 noinst_HEADERS += \

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -1,3 +1,27 @@
+# This should use LIBMDS_TYPES once it exists
+ceph_dencoder_SOURCES = \
+	test/encoding/ceph_dencoder.cc \
+	$(DENCODER_SOURCES)
+ceph_dencoder_LDADD = \
+	$(LIBRBD_TYPES) \
+	$(LIBOSD_TYPES) \
+	$(LIBOS_TYPES) \
+	$(LIBMON_TYPES) \
+	$(DENCODER_DEPS) \
+	$(CEPH_GLOBAL)
+
+# These should always use explicit _CFLAGS/_CXXFLAGS so avoid basename conflicts
+ceph_dencoder_CFLAGS = ${AM_CFLAGS}
+ceph_dencoder_CXXFLAGS = ${AM_CXXFLAGS}
+
+if COMPILER_HAS_VTA
+ceph_dencoder_CFLAGS += -fno-var-tracking-assignments
+ceph_dencoder_CXXFLAGS += -fno-var-tracking-assignments
+endif
+
+bin_PROGRAMS += ceph-dencoder
+
+
 if WITH_RADOS
 
 libradostest_la_SOURCES = \

--- a/src/test/Makefile-server.am
+++ b/src/test/Makefile-server.am
@@ -202,30 +202,6 @@ check_PROGRAMS += unittest_lfnindex
 
 if WITH_MDS
 
-# This should go to client once LIBMDS_TYPES exists
-ceph_dencoder_SOURCES = \
-	test/encoding/ceph_dencoder.cc \
-	$(DENCODER_SOURCES)
-ceph_dencoder_LDADD = \
-	$(LIBRBD_TYPES) \
-	$(LIBOSD_TYPES) \
-	$(LIBOS_TYPES) \
-	$(LIBMDS) \
-	$(LIBMON_TYPES) \
-	$(DENCODER_DEPS) \
-	$(CEPH_GLOBAL)
-
-# These should always use explicit _CFLAGS/_CXXFLAGS so avoid basename conflicts
-ceph_dencoder_CFLAGS = ${AM_CFLAGS}
-ceph_dencoder_CXXFLAGS = ${AM_CXXFLAGS}
-
-if COMPILER_HAS_VTA
-ceph_dencoder_CFLAGS += -fno-var-tracking-assignments
-ceph_dencoder_CXXFLAGS += -fno-var-tracking-assignments
-endif
-
-bin_PROGRAMS += ceph-dencoder
-
 unittest_mds_authcap_SOURCES = test/mds/TestMDSAuthCaps.cc 
 unittest_mds_authcap_LDADD = $(LIBMDS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_mds_authcap_CXXFLAGS = $(UNITTEST_CXXFLAGS)


### PR DESCRIPTION
This patchset tries to fix few issues we've been having with ceph-dencoder build:

ceph-dencoder should not be linked against tcmalloc
it shoulbe be built as a client binary, not server binary
broken build with --without-radosgw configure flag

To fix this, ceph-dencoder is always compiled with all the libmds sources and perfglue sources with disabled tcmalloc calls. The infrastructure that allowed me to do this ~nicely was pretty much already in place (DENCODER_SOURCES and DENCODER_DEPS variables).