### PR TITLE
Sharded object listing in librados

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -56,8 +56,7 @@ AM_COMMON_CPPFLAGS = \
 	-D__STDC_FORMAT_MACROS \
 	-D_GNU_SOURCE \
 	-DCEPH_LIBDIR=\"${libdir}\" \
-	-DCEPH_PKGLIBDIR=\"${pkglibdir}\" \
-	-DGTEST_HAS_TR1_TUPLE=0
+	-DCEPH_PKGLIBDIR=\"${pkglibdir}\"
 
 AM_COMMON_CFLAGS = \
 	-Wall \

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -883,6 +883,25 @@ CEPH_RADOS_API int rados_nobjects_list_open(rados_ioctx_t io,
                                             rados_list_ctx_t *ctx);
 
 /**
+ * Start listing objects in a pool, within a particular subset.
+ *
+ * The subset is defined by dividing the object location hashes into m
+ * bins, where the `n` parameter defines which bin we will iterate over.
+ * This is intended for use by pools of `m` workers, who would all pass
+ * in their unique `n` to get a share of the objects.
+ *
+ * @param io the pool to list from
+ * @param n which object range we will iterate over
+ * @param m how many object ranges to divide the overall space into
+ * @param ctx the handle to store list context in
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_nobjects_list_open_range(rados_ioctx_t io,
+                                                  uint32_t n,
+                                                  uint32_t m,
+                                                  rados_list_ctx_t *ctx);
+
+/**
  * Return hash position of iterator, rounded to the current PG
  *
  * @param ctx iterator marking where you are in the listing

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -767,6 +767,8 @@ namespace librados
     NObjectIterator nobjects_begin();
     /// Start enumerating objects for a pool starting from a hash position
     NObjectIterator nobjects_begin(uint32_t start_hash_position);
+    /// Start enumerating objects for a pool within a subset
+    NObjectIterator nobjects_begin(uint32_t n, uint32_t m);
     /// Iterator indicating the end of a pool
     const NObjectIterator& nobjects_end() const;
 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3120,9 +3120,10 @@ uint32_t Objecter::list_nobjects_seek(NListContext *list_context,
   return list_context->current_pg;
 }
 
+
 void Objecter::list_nobjects(NListContext *list_context, Context *onfinish)
 {
-  ldout(cct, 10) << "list_objects" << dendl;
+  ldout(cct, 10) << __func__ << dendl;
   ldout(cct, 20) << " pool_id " << list_context->pool_id
 	   << " pool_snap_seq " << list_context->pool_snap_seq
 	   << " max_entries " << list_context->max_entries
@@ -3131,12 +3132,59 @@ void Objecter::list_nobjects(NListContext *list_context, Context *onfinish)
 	   << " list_context->current_pg " << list_context->current_pg
 	   << " list_context->cookie " << list_context->cookie << dendl;
 
+  // Read out pg_num
+  rwlock.get_read();
+  const pg_pool_t *pool = osdmap->get_pg_pool(list_context->pool_id);
+  uint32_t pg_num = pool->get_pg_num();
+  rwlock.unlock();
+
+  // Record starting_pg_num on first call
+  if (list_context->starting_pg_num == 0) {     // there can't be zero pgs!
+    list_context->starting_pg_num = pg_num;
+    ldout(cct, 20) << pg_num << " placement groups" << dendl;
+  }
+
+  // Range of PGs to list over
+  uint32_t pg_min = 0;  // (inclusive)
+  uint32_t pg_max = list_context->starting_pg_num;  // (exclusive)
+  if (list_context->is_sharded()) {
+    // Work out PG range addressed by this worker
+    // (divide hash space into pg_num*worker_m chunks, and assign pg_num
+    // of them to each worker)
+    pg_min = (list_context->worker_n * pg_num) / list_context->worker_m;
+    if (list_context->worker_n == list_context->worker_m - 1) {
+      // Extend PG max to encompass any remainder
+      pg_max = list_context->starting_pg_num;
+    } else {
+      pg_max = (list_context->worker_n * pg_num + pg_num) / list_context->worker_m;
+    }
+
+
+
+    // No PGs assigned to this worker?
+    if (pg_min == pg_max) {
+      ldout(cct, 10) << "Worker " << list_context->worker_n << " of "
+                     << list_context->worker_m << " assigned no PGs" << dendl;
+      put_nlist_context_budget(list_context);
+      onfinish->complete(0);
+      return;
+    }
+  }
+
+  // Initialize current_pg
+  if (list_context->current_pg == 0xffffffff) {
+    list_context->current_pg = pg_min;
+  }
+
+  // Advance to next PG if necessary
   if (list_context->at_end_of_pg) {
     list_context->at_end_of_pg = false;
     ++list_context->current_pg;
     list_context->current_pg_epoch = 0;
     list_context->cookie = collection_list_handle_t();
-    if (list_context->current_pg >= list_context->starting_pg_num) {
+    
+    // Always list from upper
+    if (list_context->current_pg >= pg_max) {
       list_context->at_end_of_pool = true;
       ldout(cct, 20) << " no more pgs; reached end of pool" << dendl;
     } else {
@@ -3152,19 +3200,10 @@ void Objecter::list_nobjects(NListContext *list_context, Context *onfinish)
     return;
   }
 
-  rwlock.get_read();
-  const pg_pool_t *pool = osdmap->get_pg_pool(list_context->pool_id);
-  int pg_num = pool->get_pg_num();
-  rwlock.unlock();
-
-  if (list_context->starting_pg_num == 0) {     // there can't be zero pgs!
-    list_context->starting_pg_num = pg_num;
-    ldout(cct, 20) << pg_num << " placement groups" << dendl;
-  }
   if (list_context->starting_pg_num != pg_num) {
     // start reading from the beginning; the pgs have changed
     ldout(cct, 10) << " pg_num changed; restarting with " << pg_num << dendl;
-    list_context->current_pg = 0;
+    list_context->current_pg = pg_min;
     list_context->cookie = collection_list_handle_t();
     list_context->current_pg_epoch = 0;
     list_context->starting_pg_num = pg_num;
@@ -3185,7 +3224,7 @@ void Objecter::list_nobjects(NListContext *list_context, Context *onfinish)
 void Objecter::_nlist_reply(NListContext *list_context, int r,
 			   Context *final_finish, epoch_t reply_epoch)
 {
-  ldout(cct, 10) << "_list_reply" << dendl;
+  ldout(cct, 10) << __func__ << dendl;
 
   bufferlist::iterator iter = list_context->bl.begin();
   pg_nls_response_t response;
@@ -3195,6 +3234,8 @@ void Objecter::_nlist_reply(NListContext *list_context, int r,
     ::decode(extra_info, iter);
   }
   list_context->cookie = response.handle;
+
+
   if (!list_context->current_pg_epoch) {
     // first pgls result, set epoch marker
     ldout(cct, 20) << " first pgls piece, reply_epoch is "

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1307,10 +1307,10 @@ public:
 
   // Pools and statistics 
   struct NListContext {
-    int current_pg;
+    uint32_t current_pg;
     collection_list_handle_t cookie;
     epoch_t current_pg_epoch;
-    int starting_pg_num;
+    uint32_t starting_pg_num;
     bool at_end_of_pool;
     bool at_end_of_pg;
 
@@ -1318,6 +1318,11 @@ public:
     int pool_snap_seq;
     int max_entries;
     string nspace;
+
+    // Worker n (from zero) of ...
+    uint32_t worker_n;
+    // ...total m workers.  Or m=0 if not using multiple workers.
+    uint32_t worker_m;
 
     bufferlist bl;   // raw data read to here
     std::list<librados::ListObjectImpl> list;
@@ -1332,13 +1337,15 @@ public:
     // the last op reply.
     int ctx_budget;
 
-    NListContext() : current_pg(0), current_pg_epoch(0), starting_pg_num(0),
+    NListContext() : current_pg(0xffffffff), current_pg_epoch(0), starting_pg_num(0),
 		    at_end_of_pool(false),
 		    at_end_of_pg(false),
 		    pool_id(0),
 		    pool_snap_seq(0),
                     max_entries(0),
                     nspace(),
+                    worker_n(0),
+                    worker_m(0),
                     bl(),
                     list(),
                     filter(),
@@ -1351,6 +1358,14 @@ public:
 
     uint32_t get_pg_hash_position() const {
       return current_pg;
+    }
+
+    /**
+     * True if this context is iterating over a hash range,
+     * false if it is iterating over all objects
+     */
+    bool is_sharded() const {
+      return worker_m > 0;
     }
   };
 


### PR DESCRIPTION
This is #9963

Dividing up the object hash space between workers is simple, but then to get a defined fraction of the hash space within a particular PG we have to do some contortions to generate a contiguous range in the nibble-twiddled HashIndex ordering, and make sure that the ranges shared out will get each worker a fair share of objects (as the objects within a given PG are not equally distributed across the hash space).

I originally played with a different approach that would stripe accesses from many workers across the PGs, but it relied on bitwise masks to assign a PG subset to a worker, and got too awkward when the number of PGs wasn't a power of two.  I ended up with something simpler by assigning each worker a simple range of PGs.

RFC because I'm still writing the proper tests, and some of the calculation bits are overly verbose with redundant variables for the benefit of my puny meat brain.