### PR TITLE
rgw: shouldn't return content-type: application/xml if content length is 0

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -500,7 +500,9 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type)
     dump_access_control(s, op);
   }
 
-  if (!content_type || s->err.is_err()) {
+  /* do not send content type if content length is zero
+     and the content type was not set by the user */
+  if ((s->formatter->get_len()  != 0 && !content_type) || s->err.is_err()){
     switch (s->format) {
     case RGW_FORMAT_XML:
       ctype = "application/xml";
@@ -526,9 +528,13 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type)
     s->formatter->close_section();
     dump_content_length(s, s->formatter->get_len());
   }
-  int r = s->cio->print("Content-type: %s\r\n", content_type);
-  if (r < 0) {
-    ldout(s->cct, 0) << "ERROR: s->cio->print() returned err=" << r << dendl;
+
+  int r;
+  if (content_type) {
+      r = s->cio->print("Content-type: %s\r\n", content_type);
+      if (r < 0) {
+	ldout(s->cct, 0) << "ERROR: s->cio->print() returned err=" << r << dendl;
+      }
   }
   r = s->cio->complete_header();
   if (r < 0) {


### PR DESCRIPTION

Fixed: #11091

Signed-off-by: Orit Wasserman <owasserm@redhat.com>