### PR TITLE
ceph-disk: set '--cluster=ceph' in 'prepare' subcommand

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -2773,7 +2773,6 @@ def parse_args():
     parser.set_defaults(
         # we want to hold on to this, for later
         prog=parser.prog,
-        cluster='ceph',
         )
 
     subparsers = parser.add_subparsers(
@@ -2786,6 +2785,7 @@ def parse_args():
     prepare_parser.add_argument(
         '--cluster',
         metavar='NAME',
+        default='ceph',
         help='cluster name to assign this disk to',
         )
     prepare_parser.add_argument(


### PR DESCRIPTION
otherwise the 'ceph' default value won't be catched by "main_prepare()",
this breaks TEST_corrupt_and_repair_replicated. seems the behaviour
was changed in python 2.7.9, so we move the default value to where
the '--cluster' argument is added instead of setting it in the
main argument parser.

Signed-off-by: Kefu Chai <kchai@redhat.com>