### PR TITLE
Fix kv compact on mount

### DIFF
--- a/src/os/LevelDBStore.cc
+++ b/src/os/LevelDBStore.cc
@@ -74,12 +74,6 @@ int LevelDBStore::do_open(ostream &out, bool create_if_missing)
     return -EINVAL;
   }
 
-  if (g_conf->leveldb_compact_on_mount) {
-    derr << "Compacting leveldb store..." << dendl;
-    compact();
-    derr << "Finished compacting leveldb store" << dendl;
-  }
-
   PerfCountersBuilder plb(g_ceph_context, "leveldb", l_leveldb_first, l_leveldb_last);
   plb.add_u64_counter(l_leveldb_gets, "leveldb_get", "Gets");
   plb.add_u64_counter(l_leveldb_txns, "leveldb_transaction", "Transactions");
@@ -89,6 +83,12 @@ int LevelDBStore::do_open(ostream &out, bool create_if_missing)
   plb.add_u64(l_leveldb_compact_queue_len, "leveldb_compact_queue_len", "Length of compaction queue");
   logger = plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
+
+  if (g_conf->leveldb_compact_on_mount) {
+    derr << "Compacting leveldb store..." << dendl;
+    compact();
+    derr << "Finished compacting leveldb store" << dendl;
+  }
   return 0;
 }
 

--- a/src/os/RocksDBStore.cc
+++ b/src/os/RocksDBStore.cc
@@ -131,20 +131,11 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
 
   //apply env setting
   ldoptions.env = env;
-  //rocksdb::DB *_db;
   rocksdb::Status status = rocksdb::DB::Open(ldoptions, path, &db);
   if (!status.ok()) {
     out << status.ToString() << std::endl;
     return -EINVAL;
   }
-  //db.reset(_db);
-
-  if (g_conf->rocksdb_compact_on_mount) {
-    derr << "Compacting rocksdb store..." << dendl;
-    compact();
-    derr << "Finished compacting rocksdb store" << dendl;
-  }
-
 
   PerfCountersBuilder plb(g_ceph_context, "rocksdb", l_rocksdb_first, l_rocksdb_last);
   plb.add_u64_counter(l_rocksdb_gets, "rocksdb_get", "Gets");
@@ -155,6 +146,12 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
   plb.add_u64(l_rocksdb_compact_queue_len, "rocksdb_compact_queue_len", "Length of compaction queue");
   logger = plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
+
+  if (g_conf->rocksdb_compact_on_mount) {
+    derr << "Compacting rocksdb store..." << dendl;
+    compact();
+    derr << "Finished compacting rocksdb store" << dendl;
+  }
   return 0;
 }
 


### PR DESCRIPTION
In both LevelDBStore::do_open and RocksDBStore::do_open, if compact_on_mount = true, that will cause a segmentation fault due to use uninitialized perf counter in compact().

This PR fix the bug.