### PR TITLE
rgw: use correct objv_tracker for bucket instance

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2417,6 +2417,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     ret = put_linked_bucket_info(info, exclusive, 0, pep_objv, &attrs, true);
     if (ret == -EEXIST) {
        /* we need to reread the info and return it, caller will have a use for it */
+      RGWObjVersionTracker instance_ver = info.objv_tracker;
       info.objv_tracker.clear();
       r = get_bucket_info(NULL, bucket.name, info, NULL, NULL);
       if (r < 0) {
@@ -2432,7 +2433,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
         /* remove bucket meta instance */
         string entry;
         get_bucket_instance_entry(bucket, entry);
-        r = rgw_bucket_instance_remove_entry(this, entry, &info.objv_tracker);
+        r = rgw_bucket_instance_remove_entry(this, entry, &instance_ver);
         if (r < 0)
           return r;
 


### PR DESCRIPTION
When trying to create a bucket that already existed, use the
objv_tracker of the newly created instance, and not of the original
bucket.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
(cherry picked from commit fe158ecc25feefcea8aea4133118e4a84900a8ec)