### PR TITLE
test: put unittest_librbd in the check_PROGRAMS, not noinst

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -29,8 +29,9 @@ ceph_sbindir = $(sbindir)
 # certain things go straight into /sbin, though!
 su_sbindir = /sbin
 
-# C/C++ tests to build will be appended to this
-check_PROGRAMS =
+# C/C++ tests to build and executed will be appended to this
+check_TESTPROGRAMS =
+check_PROGRAMS = $(check_TESTPROGRAMS)
 
 # tests scripts will be appended to this
 check_SCRIPTS =

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -148,7 +148,7 @@ ceph_libexec_SCRIPTS = ceph-osd-prestart.sh
 # target by target
 
 TESTS = \
-	$(check_PROGRAMS) \
+	$(check_TESTPROGRAMS) \
 	$(check_SCRIPTS)
 
 check-local:

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -112,12 +112,12 @@ endif # LINUX
 unittest_librados_SOURCES = test/librados/librados.cc
 unittest_librados_LDADD = $(LIBRADOS) $(CEPH_GLOBAL) $(UNITTEST_LDADD)
 unittest_librados_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_librados
+check_TESTPROGRAMS += unittest_librados
 
 unittest_librados_config_SOURCES = test/librados/librados_config.cc
 unittest_librados_config_LDADD = $(LIBRADOS) $(CEPH_GLOBAL) $(UNITTEST_LDADD)
 unittest_librados_config_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_librados_config
+check_TESTPROGRAMS += unittest_librados_config
 
 ceph_multi_stress_watch_SOURCES = test/multi_stress_watch.cc
 ceph_multi_stress_watch_LDADD = $(LIBRADOS) $(CEPH_GLOBAL) $(RADOS_TEST_LDADD)
@@ -296,7 +296,7 @@ unittest_rbd_replay_LDADD = $(LIBRBD) \
 	librbd_replay_ios.la \
 	$(UNITTEST_LDADD)
 unittest_rbd_replay_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_rbd_replay
+check_TESTPROGRAMS += unittest_rbd_replay
 
 librbd_test_la_SOURCES = \
 	test/librbd/test_fixture.cc \
@@ -315,7 +315,7 @@ unittest_librbd_LDADD = \
 	librados_test_stub.la librados_internal.la \
 	$(LIBOSDC) $(UNITTEST_LDADD) \
 	$(CEPH_GLOBAL) $(RADOS_TEST_LDADD)
-noinst_PROGRAMS += unittest_librbd
+check_PROGRAMS += unittest_librbd
 check_SCRIPTS += test/run-rbd-unit-tests.sh
 
 ceph_test_librbd_SOURCES =
@@ -390,27 +390,27 @@ endif # WITH_BUILD_TESTS
 
 unittest_encoding_LDADD = $(LIBCEPHFS) $(LIBRADOS) $(CEPH_GLOBAL) -lm $(UNITTEST_LDADD)
 unittest_encoding_CXXFLAGS = $(UNITTEST_CXXFLAGS) -fno-strict-aliasing
-check_PROGRAMS += unittest_encoding
+check_TESTPROGRAMS += unittest_encoding
 
 unittest_base64_SOURCES = test/base64.cc
 unittest_base64_LDADD = $(LIBCEPHFS) $(CEPH_GLOBAL) -lm $(UNITTEST_LDADD)
 unittest_base64_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_base64
+check_TESTPROGRAMS += unittest_base64
 
 unittest_run_cmd_SOURCES = test/run_cmd.cc
 unittest_run_cmd_LDADD = $(LIBCEPHFS) $(CEPH_GLOBAL) $(UNITTEST_LDADD)
 unittest_run_cmd_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_run_cmd
+check_TESTPROGRAMS += unittest_run_cmd
 
 unittest_simple_spin_SOURCES = test/simple_spin.cc
 unittest_simple_spin_LDADD = $(LIBCEPHFS) $(CEPH_GLOBAL) $(UNITTEST_LDADD)
 unittest_simple_spin_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_simple_spin
+check_TESTPROGRAMS += unittest_simple_spin
 
 unittest_libcephfs_config_SOURCES = test/libcephfs_config.cc
 unittest_libcephfs_config_LDADD = $(LIBCEPHFS) $(CEPH_GLOBAL) $(UNITTEST_LDADD)
 unittest_libcephfs_config_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_libcephfs_config
+check_TESTPROGRAMS += unittest_libcephfs_config
 
 ceph_test_libcephfs_SOURCES = \
 	test/libcephfs/test.cc \
@@ -470,13 +470,13 @@ endif # WITH_BUILD_TESTS
 #unittest_librgw_link_LDFLAGS = $(PTHREAD_CFLAGS) ${AM_LDFLAGS}
 #unittest_librgw_link_LDADD = $(LIBRGW) ${UNITTEST_LDADD}
 #unittest_librgw_link_CXXFLAGS = ${CRYPTO_CFLAGS} ${AM_CXXFLAGS} ${UNITTEST_CXXFLAGS}
-#check_PROGRAMS += unittest_librgw_link
+#check_TESTPROGRAMS += unittest_librgw_link
 
 #unittest_librgw_SOURCES = test/librgw.cc
 #unittest_librgw_LDFLAGS = -lrt $(PTHREAD_CFLAGS) -lcurl ${AM_LDFLAGS}
 #unittest_librgw_LDADD =  librgw.la $(LIBRADOS) ${UNITTEST_LDADD} -lexpat $(CEPH_GLOBAL)
 #unittest_librgw_CXXFLAGS = ${CRYPTO_CFLAGS} ${AM_CXXFLAGS} ${UNITTEST_CXXFLAGS}
-#check_PROGRAMS += unittest_librgw
+#check_TESTPROGRAMS += unittest_librgw
 
 ceph_test_cors_SOURCES = test/test_cors.cc
 ceph_test_cors_LDADD = \

--- a/src/test/Makefile-server.am
+++ b/src/test/Makefile-server.am
@@ -134,12 +134,12 @@ noinst_PROGRAMS += get_command_descriptions
 unittest_mon_moncap_SOURCES = test/mon/moncap.cc
 unittest_mon_moncap_LDADD = $(LIBMON) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_mon_moncap_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_mon_moncap
+check_TESTPROGRAMS += unittest_mon_moncap
 
 unittest_mon_pgmap_SOURCES = test/mon/PGMap.cc
 unittest_mon_pgmap_LDADD = $(LIBMON) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_mon_pgmap_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_mon_pgmap
+check_TESTPROGRAMS += unittest_mon_pgmap
 
 endif # WITH_MON
 
@@ -148,12 +148,12 @@ if WITH_OSD
 unittest_ecbackend_SOURCES = test/osd/TestECBackend.cc
 unittest_ecbackend_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_ecbackend_LDADD = $(LIBOSD) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_ecbackend
+check_TESTPROGRAMS += unittest_ecbackend
 
 unittest_osdscrub_SOURCES = test/osd/TestOSDScrub.cc
 unittest_osdscrub_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_osdscrub_LDADD = $(LIBOSD) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_osdscrub
+check_TESTPROGRAMS += unittest_osdscrub
 if LINUX
 unittest_osdscrub_LDADD += -ldl
 endif # LINUX
@@ -161,7 +161,7 @@ endif # LINUX
 unittest_pglog_SOURCES = test/osd/TestPGLog.cc
 unittest_pglog_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_pglog_LDADD = $(LIBOSD) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_pglog
+check_TESTPROGRAMS += unittest_pglog
 if LINUX
 unittest_pglog_LDADD += -ldl
 endif # LINUX
@@ -169,12 +169,12 @@ endif # LINUX
 unittest_hitset_SOURCES = test/osd/hitset.cc
 unittest_hitset_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_hitset_LDADD = $(LIBOSD) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_hitset
+check_TESTPROGRAMS += unittest_hitset
 
 unittest_osd_osdcap_SOURCES = test/osd/osdcap.cc 
 unittest_osd_osdcap_LDADD = $(LIBOSD) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_osd_osdcap_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_osd_osdcap
+check_TESTPROGRAMS += unittest_osd_osdcap
 
 ceph_test_snap_mapper_SOURCES = test/test_snap_mapper.cc
 ceph_test_snap_mapper_LDADD = $(LIBOSD) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
@@ -187,17 +187,17 @@ endif # WITH_OSD
 unittest_chain_xattr_SOURCES = test/objectstore/chain_xattr.cc
 unittest_chain_xattr_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_chain_xattr_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_chain_xattr
+check_TESTPROGRAMS += unittest_chain_xattr
 
 unittest_flatindex_SOURCES = test/os/TestFlatIndex.cc
 unittest_flatindex_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_flatindex_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_flatindex
+check_TESTPROGRAMS += unittest_flatindex
 
 unittest_lfnindex_SOURCES = test/os/TestLFNIndex.cc
 unittest_lfnindex_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_lfnindex_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_lfnindex
+check_TESTPROGRAMS += unittest_lfnindex
 
 
 if WITH_MDS
@@ -205,6 +205,6 @@ if WITH_MDS
 unittest_mds_authcap_SOURCES = test/mds/TestMDSAuthCaps.cc 
 unittest_mds_authcap_LDADD = $(LIBMDS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_mds_authcap_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_mds_authcap
+check_TESTPROGRAMS += unittest_mds_authcap
 
 endif # WITH_MDS

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -146,228 +146,228 @@ UNITTEST_LDADD = \
 unittest_addrs_SOURCES = test/test_addrs.cc
 unittest_addrs_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_addrs_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_addrs
+check_TESTPROGRAMS += unittest_addrs
 
 unittest_blkdev_SOURCES = test/common/test_blkdev.cc
 unittest_blkdev_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_blkdev_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_blkdev
+check_TESTPROGRAMS += unittest_blkdev
 
 unittest_bloom_filter_SOURCES = test/common/test_bloom_filter.cc
 unittest_bloom_filter_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_bloom_filter_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_bloom_filter
+check_TESTPROGRAMS += unittest_bloom_filter
 
 unittest_histogram_SOURCES = test/common/histogram.cc
 unittest_histogram_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_histogram_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_histogram
+check_TESTPROGRAMS += unittest_histogram
 
 unittest_prioritized_queue_SOURCES = test/common/test_prioritized_queue.cc
 unittest_prioritized_queue_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_prioritized_queue_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_prioritized_queue
+check_TESTPROGRAMS += unittest_prioritized_queue
 
 
 unittest_str_map_SOURCES = test/common/test_str_map.cc
 unittest_str_map_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_str_map_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_str_map
+check_TESTPROGRAMS += unittest_str_map
 
 unittest_sharedptr_registry_SOURCES = test/common/test_sharedptr_registry.cc
 unittest_sharedptr_registry_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_sharedptr_registry_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_sharedptr_registry
+check_TESTPROGRAMS += unittest_sharedptr_registry
 
 unittest_shared_cache_SOURCES = test/common/test_shared_cache.cc
 unittest_shared_cache_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_shared_cache_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_shared_cache
+check_TESTPROGRAMS += unittest_shared_cache
 
 unittest_sloppy_crc_map_SOURCES = test/common/test_sloppy_crc_map.cc
 unittest_sloppy_crc_map_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_sloppy_crc_map_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_sloppy_crc_map
+check_TESTPROGRAMS += unittest_sloppy_crc_map
 
 unittest_util_SOURCES = test/common/test_util.cc
 unittest_util_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_util_LDADD = $(LIBCOMMON) -lm $(UNITTEST_LDADD) $(CRYPTO_LIBS) $(EXTRALIBS)
-check_PROGRAMS += unittest_util
+check_TESTPROGRAMS += unittest_util
 
 unittest_crush_wrapper_SOURCES = test/crush/CrushWrapper.cc
 unittest_crush_wrapper_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL) $(LIBCRUSH)
 unittest_crush_wrapper_CXXFLAGS = $(UNITTEST_CXXFLAGS) -O2
-check_PROGRAMS += unittest_crush_wrapper
+check_TESTPROGRAMS += unittest_crush_wrapper
 
 unittest_crush_SOURCES = test/crush/crush.cc
 unittest_crush_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_crush_LDADD = $(LIBCOMMON) -lm $(UNITTEST_LDADD) $(CEPH_CRUSH) $(EXTRALIBS) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_crush
+check_TESTPROGRAMS += unittest_crush
 
 unittest_osdmap_SOURCES = test/osd/TestOSDMap.cc
 unittest_osdmap_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_osdmap_LDADD = $(UNITTEST_LDADD) $(LIBCOMMON) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_osdmap
+check_TESTPROGRAMS += unittest_osdmap
 
 unittest_workqueue_SOURCES = test/test_workqueue.cc
 unittest_workqueue_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_workqueue_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_workqueue
+check_TESTPROGRAMS += unittest_workqueue
 
 unittest_striper_SOURCES = test/test_striper.cc
 unittest_striper_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_striper_LDADD = $(LIBOSDC) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_striper
+check_TESTPROGRAMS += unittest_striper
 
 unittest_prebufferedstreambuf_SOURCES = test/test_prebufferedstreambuf.cc
 unittest_prebufferedstreambuf_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_prebufferedstreambuf_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD) $(EXTRALIBS)
-check_PROGRAMS += unittest_prebufferedstreambuf
+check_TESTPROGRAMS += unittest_prebufferedstreambuf
 
 unittest_str_list_SOURCES = test/test_str_list.cc
 unittest_str_list_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_str_list_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_str_list
+check_TESTPROGRAMS += unittest_str_list
 
 unittest_log_SOURCES = log/test.cc
 unittest_log_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD)
 unittest_log_CXXFLAGS = $(UNITTEST_CXXFLAGS) -O2
-check_PROGRAMS += unittest_log
+check_TESTPROGRAMS += unittest_log
 
 unittest_throttle_SOURCES = test/common/Throttle.cc
 unittest_throttle_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_throttle_CXXFLAGS = $(UNITTEST_CXXFLAGS) -O2
-check_PROGRAMS += unittest_throttle
+check_TESTPROGRAMS += unittest_throttle
 
 unittest_ceph_argparse_SOURCES = test/ceph_argparse.cc
 unittest_ceph_argparse_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_ceph_argparse_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_ceph_argparse
+check_TESTPROGRAMS += unittest_ceph_argparse
 
 unittest_ceph_compatset_SOURCES = test/ceph_compatset.cc
 unittest_ceph_compatset_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_ceph_compatset_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_ceph_compatset
+check_TESTPROGRAMS += unittest_ceph_compatset
 
 unittest_mds_types_SOURCES = test/fs/mds_types.cc
 unittest_mds_types_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_mds_types_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_mds_types
+check_TESTPROGRAMS += unittest_mds_types
 
 unittest_osd_types_SOURCES = test/osd/types.cc
 unittest_osd_types_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_osd_types_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_osd_types
+check_TESTPROGRAMS += unittest_osd_types
 
 unittest_lru_SOURCES = test/common/test_lru.cc
 unittest_lru_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_lru_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_lru
+check_TESTPROGRAMS += unittest_lru
 
 unittest_io_priority_SOURCES = test/common/test_io_priority.cc
 unittest_io_priority_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_io_priority_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_io_priority
+check_TESTPROGRAMS += unittest_io_priority
 
 unittest_gather_SOURCES = test/gather.cc
 unittest_gather_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_gather_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_gather
+check_TESTPROGRAMS += unittest_gather
 
 unittest_signals_SOURCES = test/signals.cc
 unittest_signals_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_signals_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_signals
+check_TESTPROGRAMS += unittest_signals
 
 unittest_bufferlist_SOURCES = test/bufferlist.cc
 unittest_bufferlist_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_bufferlist_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_bufferlist
+check_TESTPROGRAMS += unittest_bufferlist
 
 unittest_xlist_SOURCES = test/test_xlist.cc
 unittest_xlist_LDADD = $(UNITTEST_LDADD) $(LIBCOMMON)
 unittest_xlist_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_xlist
+check_TESTPROGRAMS += unittest_xlist
 
 unittest_crc32c_SOURCES = test/common/test_crc32c.cc
 unittest_crc32c_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_crc32c_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_crc32c
+check_TESTPROGRAMS += unittest_crc32c
 
 unittest_arch_SOURCES = test/test_arch.cc
 unittest_arch_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_arch_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_arch
+check_TESTPROGRAMS += unittest_arch
 
 unittest_crypto_SOURCES = test/crypto.cc
 unittest_crypto_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_crypto_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_crypto
+check_TESTPROGRAMS += unittest_crypto
 
 unittest_crypto_init_SOURCES = test/crypto_init.cc
 unittest_crypto_init_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_crypto_init_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_crypto_init
+check_TESTPROGRAMS += unittest_crypto_init
 
 unittest_perf_counters_SOURCES = test/perf_counters.cc
 unittest_perf_counters_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_perf_counters_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_perf_counters
+check_TESTPROGRAMS += unittest_perf_counters
 
 unittest_admin_socket_SOURCES = test/admin_socket.cc
 unittest_admin_socket_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_admin_socket_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_admin_socket
+check_TESTPROGRAMS += unittest_admin_socket
 
 unittest_ceph_crypto_SOURCES = test/ceph_crypto.cc
 unittest_ceph_crypto_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_ceph_crypto_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_ceph_crypto
+check_TESTPROGRAMS += unittest_ceph_crypto
 
 unittest_utf8_SOURCES = test/utf8.cc
 unittest_utf8_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_utf8_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_utf8
+check_TESTPROGRAMS += unittest_utf8
 
 unittest_mime_SOURCES = test/mime.cc
 unittest_mime_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_mime_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_mime
+check_TESTPROGRAMS += unittest_mime
 
 unittest_escape_SOURCES = test/escape.cc
 unittest_escape_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_escape_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_escape
+check_TESTPROGRAMS += unittest_escape
 
 unittest_strtol_SOURCES = test/strtol.cc
 unittest_strtol_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_strtol_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_strtol
+check_TESTPROGRAMS += unittest_strtol
 
 unittest_confutils_SOURCES = test/confutils.cc
 unittest_confutils_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_confutils_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_confutils
+check_TESTPROGRAMS += unittest_confutils
 
 unittest_config_SOURCES = test/common/test_config.cc
 unittest_config_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_config_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_config
+check_TESTPROGRAMS += unittest_config
 
 unittest_context_SOURCES = test/common/test_context.cc
 unittest_context_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_context_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_context
+check_TESTPROGRAMS += unittest_context
 
 unittest_safe_io_SOURCES = test/common/test_safe_io.cc
 unittest_safe_io_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_safe_io_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_safe_io
+check_TESTPROGRAMS += unittest_safe_io
 
 unittest_heartbeatmap_SOURCES = test/heartbeat_map.cc
 unittest_heartbeatmap_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_heartbeatmap_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_heartbeatmap
+check_TESTPROGRAMS += unittest_heartbeatmap
 
 # why does this include rgw/rgw_formats.cc...?
 unittest_formatter_SOURCES = \
@@ -375,41 +375,41 @@ unittest_formatter_SOURCES = \
 	rgw/rgw_formats.cc
 unittest_formatter_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_formatter_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_formatter
+check_TESTPROGRAMS += unittest_formatter
 
 unittest_daemon_config_SOURCES = test/daemon_config.cc
 unittest_daemon_config_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_daemon_config_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_daemon_config
+check_TESTPROGRAMS += unittest_daemon_config
 
 unittest_ipaddr_SOURCES = test/test_ipaddr.cc
 unittest_ipaddr_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_ipaddr_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_ipaddr
+check_TESTPROGRAMS += unittest_ipaddr
 
 unittest_texttable_SOURCES = test/test_texttable.cc
 unittest_texttable_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD)
 unittest_texttable_CXXFLAGS = $(UNITTEST_CXXFLAGS)
-check_PROGRAMS += unittest_texttable
+check_TESTPROGRAMS += unittest_texttable
 
 unittest_on_exit_SOURCES = test/on_exit.cc
 unittest_on_exit_LDADD = $(PTHREAD_LIBS)
-check_PROGRAMS += unittest_on_exit
+check_TESTPROGRAMS += unittest_on_exit
 
 unittest_readahead_SOURCES = test/common/Readahead.cc
 unittest_readahead_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_readahead_CXXFLAGS = $(UNITTEST_CXXFLAGS) -O2
-check_PROGRAMS += unittest_readahead
+check_TESTPROGRAMS += unittest_readahead
 
 unittest_tableformatter_SOURCES = test/common/test_tableformatter.cc
 unittest_tableformatter_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_tableformatter_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_tableformatter
+check_TESTPROGRAMS += unittest_tableformatter
 
 unittest_bit_vector_SOURCES = test/common/test_bit_vector.cc
 unittest_bit_vector_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_bit_vector_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_bit_vector
+check_TESTPROGRAMS += unittest_bit_vector
 
 check_SCRIPTS += test/pybind/test_ceph_argparse.py
 check_SCRIPTS += test/pybind/test_ceph_daemon.py

--- a/src/test/erasure-code/Makefile.am
+++ b/src/test/erasure-code/Makefile.am
@@ -121,14 +121,14 @@ unittest_erasure_code_plugin_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDADD) $(
 if LINUX
 unittest_erasure_code_plugin_LDADD += -ldl
 endif
-check_PROGRAMS += unittest_erasure_code_plugin
+check_TESTPROGRAMS += unittest_erasure_code_plugin
 
 unittest_erasure_code_SOURCES = \
 	erasure-code/ErasureCode.cc \
 	test/erasure-code/TestErasureCode.cc
 unittest_erasure_code_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_erasure_code_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_erasure_code
+check_TESTPROGRAMS += unittest_erasure_code
 
 unittest_erasure_code_jerasure_SOURCES = \
 	test/erasure-code/TestErasureCodeJerasure.cc \
@@ -143,7 +143,7 @@ unittest_erasure_code_jerasure_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDADD) 
 if LINUX
 unittest_erasure_code_jerasure_LDADD += -ldl
 endif
-check_PROGRAMS += unittest_erasure_code_jerasure
+check_TESTPROGRAMS += unittest_erasure_code_jerasure
 
 unittest_erasure_code_plugin_jerasure_SOURCES = \
 	test/erasure-code/TestErasureCodePluginJerasure.cc
@@ -152,7 +152,7 @@ unittest_erasure_code_plugin_jerasure_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_
 if LINUX
 unittest_erasure_code_plugin_jerasure_LDADD += -ldl
 endif
-check_PROGRAMS += unittest_erasure_code_plugin_jerasure
+check_TESTPROGRAMS += unittest_erasure_code_plugin_jerasure
 
 if WITH_BETTER_YASM_ELF64
 unittest_erasure_code_isa_SOURCES = \
@@ -163,7 +163,7 @@ unittest_erasure_code_isa_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDADD) $(CEP
 if LINUX
 unittest_erasure_code_isa_LDADD += -ldl
 endif
-check_PROGRAMS += unittest_erasure_code_isa
+check_TESTPROGRAMS += unittest_erasure_code_isa
 
 unittest_erasure_code_plugin_isa_SOURCES = \
 	erasure-code/ErasureCode.cc \
@@ -173,7 +173,7 @@ unittest_erasure_code_plugin_isa_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDADD
 if LINUX
 unittest_erasure_code_plugin_isa_LDADD += -ldl
 endif
-check_PROGRAMS += unittest_erasure_code_plugin_isa
+check_TESTPROGRAMS += unittest_erasure_code_plugin_isa
 endif
 
 unittest_erasure_code_lrc_SOURCES = \
@@ -184,7 +184,7 @@ unittest_erasure_code_lrc_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDADD) $(CEP
 if LINUX
 unittest_erasure_code_lrc_LDADD += -ldl
 endif
-check_PROGRAMS += unittest_erasure_code_lrc
+check_TESTPROGRAMS += unittest_erasure_code_lrc
 
 unittest_erasure_code_plugin_lrc_SOURCES = \
 	test/erasure-code/TestErasureCodePluginLrc.cc
@@ -193,7 +193,7 @@ unittest_erasure_code_plugin_lrc_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDADD
 if LINUX
 unittest_erasure_code_plugin_lrc_LDADD += -ldl
 endif
-check_PROGRAMS += unittest_erasure_code_plugin_lrc
+check_TESTPROGRAMS += unittest_erasure_code_plugin_lrc
 
 unittest_erasure_code_shec_SOURCES = \
 	test/erasure-code/TestErasureCodeShec.cc \
@@ -204,7 +204,7 @@ unittest_erasure_code_shec_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDADD) $(CE
 if LINUX
 unittest_erasure_code_shec_LDADD += -ldl
 endif
-check_PROGRAMS += unittest_erasure_code_shec
+check_TESTPROGRAMS += unittest_erasure_code_shec
 
 unittest_erasure_code_shec_all_SOURCES = \
 	test/erasure-code/TestErasureCodeShec_all.cc \
@@ -215,7 +215,7 @@ unittest_erasure_code_shec_all_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDADD) 
 if LINUX
 unittest_erasure_code_shec_all_LDADD += -ldl
 endif
-check_PROGRAMS += unittest_erasure_code_shec_all
+check_TESTPROGRAMS += unittest_erasure_code_shec_all
 
 unittest_erasure_code_shec_thread_SOURCES = \
 	test/erasure-code/TestErasureCodeShec_thread.cc \
@@ -226,7 +226,7 @@ unittest_erasure_code_shec_thread_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDAD
 if LINUX
 unittest_erasure_code_shec_thread_LDADD += -ldl
 endif
-check_PROGRAMS += unittest_erasure_code_shec_thread
+check_TESTPROGRAMS += unittest_erasure_code_shec_thread
 
 unittest_erasure_code_example_SOURCES = \
 	erasure-code/ErasureCode.cc \
@@ -234,7 +234,7 @@ unittest_erasure_code_example_SOURCES = \
 noinst_HEADERS += test/erasure-code/ErasureCodeExample.h
 unittest_erasure_code_example_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_erasure_code_example_LDADD = $(LIBOSD) $(LIBCOMMON) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
-check_PROGRAMS += unittest_erasure_code_example
+check_TESTPROGRAMS += unittest_erasure_code_example
 
 endif # WITH_OSD
 endif # ENABLE_SERVER


### PR DESCRIPTION
A community member reported that the build doesn't work without the "with-debug" flag to configure, and this is why.