### PR TITLE
osd/ReplicatedPG: promote snapdir when both head and snapdir are missing

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -7819,7 +7819,7 @@ int ReplicatedPG::find_object_context(const hobject_t& oid,
     ObjectContextRef obc = get_object_context(oid, can_create);
     if (!obc) {
       if (pmissing)
-  *pmissing = oid;
+        *pmissing = oid;
       return -ENOENT;
     }
     dout(10) << "find_object_context " << oid
@@ -7843,9 +7843,9 @@ int ReplicatedPG::find_object_context(const hobject_t& oid,
     if (!obc || !obc->obs.exists)
       obc = get_object_context(oid, can_create);
     if (!obc || !obc->obs.exists) {
-      // if we have neither, we would want to promote the head.
+      // if we have neither, we would want to promote the snapdir.
       if (pmissing)
-	*pmissing = head;
+	*pmissing = oid;
       return -ENOENT;
     }
     dout(10) << "find_object_context " << oid


### PR DESCRIPTION
When the client op is on snapdir, and both the head and snapdir are
missing on the cache tier, we should promote the snapdir, instead of the
head. This is because if we have snapdir, but no head on the base tier,
promoting head will get nothing. And promoting the snapdir will first
look for the head, and then the snapdir, which would be always correct.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>