### PR TITLE
os/Newstore:Fix collection_list_range

### DIFF
--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -1574,14 +1574,18 @@ int NewStore::collection_list_range(
     }
     it->upper_bound(k);
   }
-  get_object_key(end, &end_str);
-  if (end.hobj.is_temp()) {
-    if (temp)
-      pend = end_str.c_str();
-    else
-      goto out;
+  if (end.hobj.is_max()) {
+    pend = temp ? temp_end_key.c_str() : end_key.c_str();
   } else {
-    pend = temp ? temp_end_key.c_str() : end_str.c_str();
+    get_object_key(end, &end_str);
+    if (end.hobj.is_temp()) {
+      if (temp)
+	pend = end_str.c_str();
+      else
+	goto out;
+    } else {
+      pend = temp ? temp_end_key.c_str() : end_str.c_str();
+    }
   }
   while (true) {
     if (!it->valid() || strcmp(it->key().c_str(), pend) > 0) {


### PR DESCRIPTION
We need to rule out hobject_t::max before calling get_object_key
(in which will call get_filestore_key_u32 and get an assert failure)

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>