### PR TITLE
osd: not flush or evict object which is in object_contexts

### DIFF
--- a/src/common/shared_cache.hpp
+++ b/src/common/shared_cache.hpp
@@ -30,7 +30,7 @@ class SharedLRU {
   Mutex lock;
   size_t max_size;
   Cond cond;
-  unsigned size;
+  unsigned _size;
 public:
   int waiting;
 private:
@@ -40,7 +40,7 @@ private:
   map<K, pair<WeakVPtr, V*> > weak_refs;
 
   void trim_cache(list<VPtr> *to_release) {
-    while (size > max_size) {
+    while (_size > max_size) {
       to_release->push_back(lru.back().second);
       lru_remove(lru.back().first);
     }
@@ -52,7 +52,7 @@ private:
     if (i == contents.end())
       return;
     lru.erase(i->second);
-    --size;
+    --_size;
     contents.erase(i);
   }
 
@@ -62,7 +62,7 @@ private:
     if (i != contents.end()) {
       lru.splice(lru.begin(), lru, i->second);
     } else {
-      ++size;
+      ++_size;
       lru.push_front(make_pair(key, val));
       contents[key] = lru.begin();
       trim_cache(to_release);
@@ -92,7 +92,7 @@ private:
 public:
   SharedLRU(CephContext *cct = NULL, size_t max_size = 20)
     : cct(cct), lock("SharedLRU::lock"), max_size(max_size), 
-      size(0), waiting(0) {}
+      _size(0), waiting(0) {}
   
   ~SharedLRU() {
     contents.clear();
@@ -131,7 +131,7 @@ public:
     while (true) {
       VPtr val; // release any ref we have after we drop the lock
       Mutex::Locker l(lock);
-      if (size == 0)
+      if (_size == 0)
         break;
 
       val = lru.back().second;
@@ -290,6 +290,17 @@ public:
       lru_add(key, new_val, &to_release);
       return new_val;
     }
+  }
+
+  /**
+   * size()
+   *
+   * Returns the number of live references left to anything that has been
+   * in the cache.
+   */
+  unsigned size() {
+    Mutex::Locker l(lock);
+    return _size;
   }
 
   /**

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -10477,6 +10477,24 @@ void ReplicatedPG::agent_clear()
   agent_state.reset(NULL);
 }
 
+bool ReplicatedPG::obccache_suggests_hot(hobject_t& o)
+{
+  if (!object_contexts.lookup(o)) {
+    return false;
+  }
+  uint64_t divisor = pool.info.get_pg_num_divisor(info.pgid.pgid);
+  assert(divisor > 0);
+  uint64_t max_dirty_objects = pool.info.cache_target_dirty_ratio_micro *
+    pool.info.target_max_objects / 1000000;
+  max_dirty_objects = max_dirty_objects / divisor;
+  dout(20) << __func__ << " max_dirty_objects " << max_dirty_objects
+           << " object_contexts size " << object_contexts.size() << dendl;
+  if (max_dirty_objects > object_contexts.size() * 2) {
+    return true;
+  }
+  return false;
+}
+
 // Return false if no objects operated on since start of object hash space
 bool ReplicatedPG::agent_work(int start_max)
 {
@@ -10545,6 +10563,7 @@ bool ReplicatedPG::agent_work(int start_max)
       osd->logger->inc(l_osd_agent_skip);
       continue;
     }
+    bool hot_object = obccache_suggests_hot(*p);
     ObjectContextRef obc = get_object_context(*p, false, NULL);
     if (!obc) {
       // we didn't flush; we may miss something here.
@@ -10582,10 +10601,10 @@ bool ReplicatedPG::agent_work(int start_max)
     }
 
     if (agent_state->flush_mode != TierAgentState::FLUSH_MODE_IDLE &&
-	agent_maybe_flush(obc))
+	agent_maybe_flush(obc, hot_object))
       ++started;
     if (agent_state->evict_mode != TierAgentState::EVICT_MODE_IDLE &&
-	agent_maybe_evict(obc))
+	agent_maybe_evict(obc, hot_object))
       ++started;
     if (started >= start_max) {
       // If finishing early, set "next" to the next object
@@ -10707,7 +10726,7 @@ struct C_AgentFlushStartStop : public Context {
   }
 };
 
-bool ReplicatedPG::agent_maybe_flush(ObjectContextRef& obc)
+bool ReplicatedPG::agent_maybe_flush(ObjectContextRef& obc, bool hot_object)
 {
   if (!obc->obs.oi.is_dirty()) {
     dout(20) << __func__ << " skip (clean) " << obc->obs.oi << dendl;
@@ -10726,7 +10745,7 @@ bool ReplicatedPG::agent_maybe_flush(ObjectContextRef& obc)
     (agent_state->evict_mode == TierAgentState::EVICT_MODE_FULL);
   if (!evict_mode_full &&
       obc->obs.oi.soid.snap == CEPH_NOSNAP &&  // snaps immutable; don't delay
-      (ob_local_mtime + utime_t(pool.info.cache_min_flush_age, 0) > now)) {
+      ((ob_local_mtime + utime_t(pool.info.cache_min_flush_age, 0) > now) || hot_object)) {
     dout(20) << __func__ << " skip (too young) " << obc->obs.oi << dendl;
     osd->logger->inc(l_osd_agent_skip);
     return false;
@@ -10759,7 +10778,7 @@ bool ReplicatedPG::agent_maybe_flush(ObjectContextRef& obc)
   return true;
 }
 
-bool ReplicatedPG::agent_maybe_evict(ObjectContextRef& obc)
+bool ReplicatedPG::agent_maybe_evict(ObjectContextRef& obc, bool hot_object)
 {
   const hobject_t& soid = obc->obs.oi.soid;
   if (obc->obs.oi.is_dirty()) {
@@ -10785,6 +10804,10 @@ bool ReplicatedPG::agent_maybe_evict(ObjectContextRef& obc)
 
   if (agent_state->evict_mode != TierAgentState::EVICT_MODE_FULL) {
     // is this object old and/or cold enough?
+    if (hot_object) {
+      dout(20) << __func__ << " skip (hot object) " << obc->obs.oi << dendl;
+      return false;
+    }
     int atime = -1, temp = 0;
     if (hit_set)
       agent_estimate_atime_temp(soid, &atime, NULL /*FIXME &temp*/);

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -897,8 +897,9 @@ protected:
 
   void agent_setup();       ///< initialize agent state
   bool agent_work(int max); ///< entry point to do some agent work
-  bool agent_maybe_flush(ObjectContextRef& obc);  ///< maybe flush
-  bool agent_maybe_evict(ObjectContextRef& obc);  ///< maybe evict
+  bool obccache_suggests_hot(hobject_t& o);
+  bool agent_maybe_flush(ObjectContextRef& obc, bool hot_object);  ///< maybe flush
+  bool agent_maybe_evict(ObjectContextRef& obc, bool hot_object);  ///< maybe evict
 
   void agent_load_hit_sets();  ///< load HitSets, if needed
 


### PR DESCRIPTION
I think object in object_contexts is hot object.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>