### PR TITLE
Add support for NVMe SSD partitions in ceph-disk

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -2435,7 +2435,10 @@ def get_partition_type(part):
     if 'blkid' not in warned_about:
         LOG.warning('Old blkid does not support ID_PART_ENTRY_* fields, trying sgdisk; may not correctly identify ceph volumes with dmcrypt')
         warned_about['blkid'] = True
-    (base, partnum) = re.match('(\D+)(\d+)', part).group(1, 2)
+    if 'nvme' in part:
+        (base, partnum) = re.match('(.*\d+)p(\d+)', part).group(1, 2)
+    else:
+        (base, partnum) = re.match('(\D+)(\d+)', part).group(1, 2)
     sgdisk, _ = command(
         [
             'sgdisk',
@@ -2461,7 +2464,7 @@ def get_partition_type(part):
 
 
 def get_partition_uuid(dev):
-    if 'loop' in dev or 'cciss' in dev:
+    if 'loop' in dev or 'cciss' in dev or 'nvme' in dev:
         (base, partnum) = re.match('(.*\d+)p(\d+)', dev).group(1, 2)
     else:
         (base, partnum) = re.match('(\D+)(\d+)', dev).group(1, 2)


### PR DESCRIPTION
http://tracker.ceph.com/issues/11612

Linux nvme kernel module v0.9 enumerate devices as following:
/dev/nvme0 - characted special device
/dev/nvme0n1 - whole block device
/dev/nvme0n1p1 - first partition
/dev/nvme0n1p2 - second partition