### PR TITLE
osd: set different size of object_context_cache for different pool

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -669,6 +669,10 @@ OPTION(osd_failsafe_full_ratio, OPT_FLOAT, .97) // what % full makes an OSD "ful
 OPTION(osd_failsafe_nearfull_ratio, OPT_FLOAT, .90) // what % full makes an OSD near full (failsafe)
 
 OPTION(osd_pg_object_context_cache_count, OPT_INT, 64)
+OPTION(osd_pg_object_context_cache_count_pool,
+       OPT_STR,
+       "" // "rbd=64 " means the size of object_context_cache for rbd pool is 64
+       ) // default the number of object_context_cache for earch pool, default value is osd_pg_object_context_cache_count
 
 // determines whether PGLog::check() compares written out log to stored log
 OPTION(osd_debug_pg_log_writeout, OPT_BOOL, false)


### PR DESCRIPTION
each pool has different workload, osd may contain different pools

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>