### PR TITLE
rgw: fix lack of account name attribute in XML-formatted bucket listing of Swift account

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -78,7 +78,8 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
 
   if (!ret) {
     dump_start(s);
-    s->formatter->open_array_section("account");
+    s->formatter->open_array_section_with_attrs("account",
+            FormatterAttrs("name", s->user.display_name.c_str(), NULL));
 
     sent_data = true;
   }


### PR DESCRIPTION
Fixes: #11431
Backport: hammer
Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>