### PR TITLE
cls_rbd: get_features needs to support legacy negative tests

### DIFF
--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -368,8 +368,13 @@ TEST_F(TestClsRbd, get_features)
   ASSERT_EQ(0, get_features(&ioctx, oid, CEPH_NOSNAP, &features));
   ASSERT_EQ(0u, features);
 
-  ASSERT_EQ(0, get_features(&ioctx, oid, 1, &features));
-  ASSERT_EQ(0u, features);
+  int r = get_features(&ioctx, oid, 1, &features);
+  if (r == 0) {
+    ASSERT_EQ(0u, features);
+  } else {
+    // deprecated snapshot handling
+    ASSERT_EQ(-ENOENT, r);
+  }
 
   ioctx.close();
 }


### PR DESCRIPTION
During Ceph upgrade testing, older Ceph test suites assume that
get_features will return -ENOENT if provided a missing snapshot.
Support these negative tests until the older releases are no
longer supported.

Fixes: #11380
Signed-off-by: Jason Dillaman <dillaman@redhat.com>