### PR TITLE
librbd: always initialize perf counters

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -108,6 +108,8 @@ namespace librbd {
       pname += snap_name;
     }
 
+    perf_start(pname);
+
     if (id.length()) {
       old_format = false;
     } else {
@@ -189,7 +191,6 @@ namespace librbd {
     readahead.set_trigger_requests(readahead_trigger_requests);
     readahead.set_max_readahead_size(readahead_max_bytes);
 
-    perf_start(pname);
     return 0;
   }
 


### PR DESCRIPTION
If ImageCtx::init() fails, perf counters are still used when closing the
image. To prevent uninitialized use, it's easiest to always initialize them
before anything that can fail in ImageCtx::init().

This was moved in 6055df398557e4dbcabc66f463a0a126f9b5dc74, but it's not
necessary to delay perf counter initialization for any extra configuration.

Fixes: #11433
Signed-off-by: Josh Durgin <jdurgin@redhat.com>