### PR TITLE
rgw: don't use end_marker for namespaced object listing

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2347,7 +2347,9 @@ int RGWRados::Bucket::List::list_objects(int max, vector<RGWObjEnt> *result,
   end_marker_obj.set_ns(params.ns);
   end_marker_obj.set_obj(params.end_marker.name);
   rgw_obj_key cur_end_marker;
-  end_marker_obj.get_index_key(&cur_end_marker);
+  if (params.ns.empty()) { /* no support for end marker for namespaced objects */
+    end_marker_obj.get_index_key(&cur_end_marker);
+  }
   const bool cur_end_marker_valid = !cur_end_marker.empty();
 
   prefix_obj.set_ns(params.ns);


### PR DESCRIPTION
Fixes: #11437

Don't deal with end_marker if there's a namespace set for the object
listing. The cur_end_marker.empty() check is incorrect if no end_marker
is provided, but a namespace is set. Just avoid this issue entirely, as
it's not needed.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>