### PR TITLE
mon: ceph-monstore-tool must do out_store.close() in "store-copy" comman...

### DIFF
--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -686,7 +686,7 @@ int main(int argc, char **argv) {
                 << stringify(si_t(total_size)) << ")" << std::endl;
 
     } while (it->valid());
-
+    out_store.close();
     std::cout << "summary: copied " << total_keys << " keys, using "
               << total_tx << " transactions, totalling "
               << stringify(si_t(total_size)) << std::endl;


### PR DESCRIPTION
...d.

Like the bug reported http://tracker.ceph.com/issues/10093.

Signed-off-by: huangjun <hjwsm1989@gmail.com>