### PR TITLE
fix PG::all_unfound_are_queried_or_lost for non-existent osds

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -763,6 +763,8 @@ bool PG::all_unfound_are_queried_or_lost(const OSDMapRef osdmap) const
     if (iter != peer_info.end() &&
         (iter->second.is_empty() || iter->second.dne()))
       continue;
+    if (!osdmap->exists(peer->osd))
+      continue;
     const osd_info_t &osd_info(osdmap->get_info(peer->osd));
     if (osd_info.lost_at <= osd_info.up_from) {
       // If there is even one OSD in might_have_unfound that isn't lost, we


### PR DESCRIPTION
http://tracker.ceph.com/issues/10976