### PR TITLE
rgw: force content-type header for swift account responses without body

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -494,7 +494,8 @@ void dump_start(struct req_state *s)
   }
 }
 
-void end_header(struct req_state *s, RGWOp *op, const char *content_type, const int64_t proposed_content_length)
+void end_header(struct req_state *s, RGWOp *op, const char *content_type, const int64_t proposed_content_length,
+		bool force_content_type)
 {
   string ctype;
 
@@ -504,7 +505,7 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
 
   /* do not send content type if content length is zero
      and the content type was not set by the user */
-  if ((s->formatter->get_len()  != 0 && !content_type) || s->err.is_err()){
+  if (force_content_type || (!content_type &&  s->formatter->get_len()  != 0) || s->err.is_err()){
     switch (s->format) {
     case RGW_FORMAT_XML:
       ctype = "application/xml";

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -365,7 +365,8 @@ extern void dump_errno(struct req_state *s, int ret);
 extern void end_header(struct req_state *s,
                        RGWOp *op = NULL,
                        const char *content_type = NULL,
-                       const int64_t proposed_content_length = NO_CONTENT_LENGTH);
+                       const int64_t proposed_content_length = NO_CONTENT_LENGTH,
+		       bool force_content_type = false);
 extern void dump_start(struct req_state *s);
 extern void list_all_buckets_start(struct req_state *s);
 extern void dump_owner(struct req_state *s, string& id, string& name, const char *section = NULL);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -80,7 +80,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
   /* Adding account stats in the header to keep align with Swift API */
   dump_account_metadata(s, buckets_count, buckets_objcount, buckets_size, buckets_size_rounded);
   dump_errno(s);
-  end_header(s, NULL);
+  end_header(s, NULL, NULL, true);
 
   if (!ret) {
     dump_start(s);
@@ -307,7 +307,8 @@ void RGWStatAccount_ObjStore_SWIFT::send_response()
   set_req_state_err(s, ret);
   dump_errno(s);
 
-  end_header(s, NULL, NULL, 0);
+  end_header(s, NULL, NULL, 0,  true);
+
   dump_start(s);
 }
 


### PR DESCRIPTION

Fixes: #11438

Signed-off-by: Orit Wasserman <owasserm@redhat.com>