### PR TITLE
librbd: deep-flatten of cloned images

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -136,6 +136,7 @@ Parameters
    exclusive-lock: exclusive locking support
    object-map: object map support (requires exclusive-lock)
    fast-diff: fast diff calculations (requires object-map)
+   deep-flatten: snapshot flatten support
 
 .. option:: --image-shared
 

--- a/src/include/rbd/features.h
+++ b/src/include/rbd/features.h
@@ -6,23 +6,26 @@
 #define RBD_FEATURE_EXCLUSIVE_LOCK	(1<<2)
 #define RBD_FEATURE_OBJECT_MAP		(1<<3)
 #define RBD_FEATURE_FAST_DIFF           (1<<4)
+#define RBD_FEATURE_DEEP_FLATTEN        (1<<5)
 
 #define RBD_FEATURES_INCOMPATIBLE 	(RBD_FEATURE_LAYERING |       \
 					 RBD_FEATURE_STRIPINGV2)
 
-#define RBD_FEATURES_RW_INCOMPATIBLE	(RBD_FEATURES_INCOMPATIBLE |  \
+#define RBD_FEATURES_RW_INCOMPATIBLE	(RBD_FEATURES_INCOMPATIBLE  | \
 					 RBD_FEATURE_EXCLUSIVE_LOCK | \
-					 RBD_FEATURE_OBJECT_MAP | \
-                                         RBD_FEATURE_FAST_DIFF)
+					 RBD_FEATURE_OBJECT_MAP     | \
+                                         RBD_FEATURE_FAST_DIFF      | \
+                                         RBD_FEATURE_DEEP_FLATTEN)
 
-#define RBD_FEATURES_ALL          	(RBD_FEATURE_LAYERING |       \
-					 RBD_FEATURE_STRIPINGV2 |     \
+#define RBD_FEATURES_ALL          	(RBD_FEATURE_LAYERING       | \
+					 RBD_FEATURE_STRIPINGV2     | \
                                    	 RBD_FEATURE_EXCLUSIVE_LOCK | \
-                                         RBD_FEATURE_OBJECT_MAP |     \
-                                         RBD_FEATURE_FAST_DIFF)
+                                         RBD_FEATURE_OBJECT_MAP     | \
+                                         RBD_FEATURE_FAST_DIFF      | \
+                                         RBD_FEATURE_DEEP_FLATTEN)
 
 #define RBD_FEATURES_MUTABLE            (RBD_FEATURE_EXCLUSIVE_LOCK | \
-                                         RBD_FEATURE_OBJECT_MAP | \
+                                         RBD_FEATURE_OBJECT_MAP     | \
                                          RBD_FEATURE_FAST_DIFF)
 
 #endif

--- a/src/librbd/AsyncFlattenRequest.cc
+++ b/src/librbd/AsyncFlattenRequest.cc
@@ -100,7 +100,7 @@ void AsyncFlattenRequest::send() {
       boost::lambda::_1, &m_image_ctx, m_object_size, m_snapc,
       boost::lambda::_2));
   AsyncObjectThrottle *throttle = new AsyncObjectThrottle(
-    *this, context_factory, create_callback_context(), &m_prog_ctx, 0,
+    this, context_factory, create_callback_context(), &m_prog_ctx, 0,
     m_overlap_objects);
   throttle->start_ops(m_image_ctx.concurrent_management_ops);
 }

--- a/src/librbd/AsyncFlattenRequest.cc
+++ b/src/librbd/AsyncFlattenRequest.cc
@@ -166,7 +166,8 @@ bool AsyncFlattenRequest::send_update_children() {
       // (if snapshots remain, they have their own parent info, and the child
       // will be removed when the last snap goes away)
       RWLock::RLocker l2(m_image_ctx.snap_lock);
-      if (!m_image_ctx.snaps.empty()) {
+      if ((m_image_ctx.features & RBD_FEATURE_DEEP_FLATTEN) == 0 &&
+          !m_image_ctx.snaps.empty()) {
         return true;
       }
 
@@ -180,7 +181,7 @@ bool AsyncFlattenRequest::send_update_children() {
       assert(r == 0);
       rados_completion->release();
     }
-  }  
+  }
 
   if (lost_exclusive_lock) {
     complete(-ERESTART);

--- a/src/librbd/AsyncFlattenRequest.cc
+++ b/src/librbd/AsyncFlattenRequest.cc
@@ -100,7 +100,7 @@ void AsyncFlattenRequest::send() {
       boost::lambda::_1, &m_image_ctx, m_object_size, m_snapc,
       boost::lambda::_2));
   AsyncObjectThrottle *throttle = new AsyncObjectThrottle(
-    *this, context_factory, create_callback_context(), m_prog_ctx, 0,
+    *this, context_factory, create_callback_context(), &m_prog_ctx, 0,
     m_overlap_objects);
   throttle->start_ops(m_image_ctx.concurrent_management_ops);
 }

--- a/src/librbd/AsyncObjectThrottle.cc
+++ b/src/librbd/AsyncObjectThrottle.cc
@@ -9,7 +9,7 @@ namespace librbd
 
 AsyncObjectThrottle::AsyncObjectThrottle(const AsyncRequest& async_request,
                                          const ContextFactory& context_factory,
-				 	 Context *ctx, ProgressContext &prog_ctx,
+				 	 Context *ctx, ProgressContext *prog_ctx,
 					 uint64_t object_no,
 					 uint64_t end_object_no)
   : m_lock("librbd::AsyncThrottle::m_lock"),
@@ -81,7 +81,9 @@ void AsyncObjectThrottle::start_next_op() {
       ++m_current_ops;
       done = true;
     }
-    m_prog_ctx.update_progress(ono, m_end_object_no);
+    if (m_prog_ctx != NULL) {
+      m_prog_ctx->update_progress(ono, m_end_object_no);
+    }
   }
 }
 

--- a/src/librbd/AsyncObjectThrottle.cc
+++ b/src/librbd/AsyncObjectThrottle.cc
@@ -7,7 +7,7 @@
 namespace librbd
 {
 
-AsyncObjectThrottle::AsyncObjectThrottle(const AsyncRequest& async_request,
+AsyncObjectThrottle::AsyncObjectThrottle(const AsyncRequest* async_request,
                                          const ContextFactory& context_factory,
 				 	 Context *ctx, ProgressContext *prog_ctx,
 					 uint64_t object_no,
@@ -58,7 +58,8 @@ void AsyncObjectThrottle::finish_op(int r) {
 void AsyncObjectThrottle::start_next_op() {
   bool done = false;
   while (!done) {
-    if (m_async_request.is_canceled() && m_ret == 0) {
+    if (m_async_request != NULL && m_async_request->is_canceled() &&
+        m_ret == 0) {
       // allow in-flight ops to complete, but don't start new ops
       m_ret = -ERESTART;
       return;

--- a/src/librbd/AsyncObjectThrottle.h
+++ b/src/librbd/AsyncObjectThrottle.h
@@ -45,7 +45,7 @@ public:
 
   AsyncObjectThrottle(const AsyncRequest &async_request,
                       const ContextFactory& context_factory, Context *ctx,
-		      ProgressContext &prog_ctx, uint64_t object_no,
+		      ProgressContext *prog_ctx, uint64_t object_no,
 		      uint64_t end_object_no);
 
   void start_ops(uint64_t max_concurrent);
@@ -56,7 +56,7 @@ private:
   const AsyncRequest &m_async_request;
   ContextFactory m_context_factory;
   Context *m_ctx;
-  ProgressContext &m_prog_ctx;
+  ProgressContext *m_prog_ctx;
   uint64_t m_object_no;
   uint64_t m_end_object_no;
   uint64_t m_current_ops;

--- a/src/librbd/AsyncObjectThrottle.h
+++ b/src/librbd/AsyncObjectThrottle.h
@@ -43,7 +43,7 @@ public:
   typedef boost::function<C_AsyncObjectThrottle*(AsyncObjectThrottle&,
       					   uint64_t)> ContextFactory;
 
-  AsyncObjectThrottle(const AsyncRequest &async_request,
+  AsyncObjectThrottle(const AsyncRequest *async_request,
                       const ContextFactory& context_factory, Context *ctx,
 		      ProgressContext *prog_ctx, uint64_t object_no,
 		      uint64_t end_object_no);
@@ -53,7 +53,7 @@ public:
 
 private:
   Mutex m_lock;
-  const AsyncRequest &m_async_request;
+  const AsyncRequest *m_async_request;
   ContextFactory m_context_factory;
   Context *m_ctx;
   ProgressContext *m_prog_ctx;

--- a/src/librbd/AsyncTrimRequest.cc
+++ b/src/librbd/AsyncTrimRequest.cc
@@ -149,7 +149,7 @@ void AsyncTrimRequest::send_remove_objects() {
     boost::lambda::bind(boost::lambda::new_ptr<AsyncTrimObjectContext>(),
       boost::lambda::_1, &m_image_ctx, boost::lambda::_2));
   AsyncObjectThrottle *throttle = new AsyncObjectThrottle(
-    *this, context_factory, ctx, m_prog_ctx, m_delete_start, m_num_objects);
+    *this, context_factory, ctx, &m_prog_ctx, m_delete_start, m_num_objects);
   throttle->start_ops(m_image_ctx.concurrent_management_ops);
 }
 

--- a/src/librbd/AsyncTrimRequest.cc
+++ b/src/librbd/AsyncTrimRequest.cc
@@ -149,7 +149,7 @@ void AsyncTrimRequest::send_remove_objects() {
     boost::lambda::bind(boost::lambda::new_ptr<AsyncTrimObjectContext>(),
       boost::lambda::_1, &m_image_ctx, boost::lambda::_2));
   AsyncObjectThrottle *throttle = new AsyncObjectThrottle(
-    *this, context_factory, ctx, &m_prog_ctx, m_delete_start, m_num_objects);
+    this, context_factory, ctx, &m_prog_ctx, m_delete_start, m_num_objects);
   throttle->start_ops(m_image_ctx.concurrent_management_ops);
 }
 

--- a/src/librbd/CopyupRequest.cc
+++ b/src/librbd/CopyupRequest.cc
@@ -35,20 +35,12 @@ namespace librbd {
     m_async_op.finish_op();
   }
 
-  ceph::bufferlist& CopyupRequest::get_copyup_data() {
-    return m_copyup_data;
-  }
-
   void CopyupRequest::append_request(AioRequest *req) {
     ldout(m_ictx->cct, 20) << __func__ << " " << this << ": " << req << dendl;
     m_pending_requests.push_back(req);
   }
 
-  bool CopyupRequest::complete_requests(int r) {
-    if (m_pending_requests.empty()) {
-      return false;
-    }
-
+  void CopyupRequest::complete_requests(int r) {
     while (!m_pending_requests.empty()) {
       vector<AioRequest *>::iterator it = m_pending_requests.begin();
       AioRequest *req = *it;
@@ -57,13 +49,9 @@ namespace librbd {
       req->complete(r);
       m_pending_requests.erase(it);
     }
-    return true;
   }
 
-  void CopyupRequest::send_copyup() {
-    ldout(m_ictx->cct, 20) << __func__ << " " << this
-			   << ": oid " << m_oid << dendl;
-
+  bool CopyupRequest::send_copyup() {
     m_ictx->snap_lock.get_read();
     ::SnapContext snapc = m_ictx->snapc;
     m_ictx->snap_lock.put_read();
@@ -72,12 +60,33 @@ namespace librbd {
     snaps.insert(snaps.end(), snapc.snaps.begin(), snapc.snaps.end());
 
     librados::ObjectWriteOperation copyup_op;
-    copyup_op.exec("rbd", "copyup", m_copyup_data);
+    if (!m_copyup_data.is_zero()) {
+      copyup_op.exec("rbd", "copyup", m_copyup_data);
+    }
+
+    // merge all pending write ops into this single RADOS op
+    for (size_t i=0; i<m_pending_requests.size(); ++i) {
+      AioRequest *req = m_pending_requests[i];
+      ldout(m_ictx->cct, 20) << __func__ << " add_copyup_ops " << req << dendl;
+      req->add_copyup_ops(&copyup_op);
+    }
+
+    if (copyup_op.size() == 0) {
+      return true;
+    }
+
+    ldout(m_ictx->cct, 20) << __func__ << " " << this
+			   << ": oid " << m_oid << dendl;
+    m_state = STATE_COPYUP;
 
     librados::AioCompletion *comp =
-      librados::Rados::aio_create_completion(NULL, NULL, NULL);
-    m_ictx->md_ctx.aio_operate(m_oid, comp, &copyup_op, snapc.seq.val, snaps);
+      librados::Rados::aio_create_completion(create_callback_context(), NULL,
+                                             rados_ctx_cb);
+    int r = m_ictx->md_ctx.aio_operate(m_oid, comp, &copyup_op, snapc.seq.val,
+                                       snaps);
+    assert(r == 0);
     comp->release();
+    return false;
   }
 
   void CopyupRequest::send()
@@ -124,7 +133,7 @@ namespace librbd {
   bool CopyupRequest::should_complete(int r)
   {
     CephContext *cct = m_ictx->cct;
-    ldout(cct, 20) << __func__ << " "
+    ldout(cct, 20) << __func__ << " " << this
 		   << ": oid " << m_oid
 		   << ", extents " << m_image_extents
 		   << ", r " << r << dendl;
@@ -133,28 +142,34 @@ namespace librbd {
     case STATE_READ_FROM_PARENT:
       ldout(cct, 20) << "READ_FROM_PARENT" << dendl;
       remove_from_list();
-      if (complete_requests(r)) {
-	// pending write operation: it will handle object map / copyup
-	return true;
-      } else if (r < 0) {
-	// nothing to copyup
-	return true;
-      } else if (send_object_map()) {
-	return true;
+      if (r >= 0) {
+        return send_object_map();
+      } else if (r == -ENOENT) {
+        return send_copyup();
       }
       break;
 
     case STATE_OBJECT_MAP:
       ldout(cct, 20) << "OBJECT_MAP" << dendl;
       if (r == 0) {
-	send_copyup();
+	return send_copyup();
       }
+      break;
+
+    case STATE_COPYUP:
+      ldout(cct, 20) << "COPYUP" << dendl;
+      complete_requests(r);
       return true;
 
     default:
       lderr(cct) << "invalid state: " << m_state << dendl;
       assert(false);
       break;
+    }
+
+    if (r < 0) {
+      complete_requests(r);
+      return true;
     }
     return false;
   }
@@ -170,37 +185,40 @@ namespace librbd {
   }
 
   bool CopyupRequest::send_object_map() {
-    ldout(m_ictx->cct, 20) << __func__ << " " << this
-			   << ": oid " << m_oid
-                           << ", extents " << m_image_extents
-                           << dendl;
-
     bool copyup = false;
     {
       RWLock::RLocker l(m_ictx->owner_lock);
       if (!m_ictx->object_map.enabled()) {
 	copyup = true;
       } else if (!m_ictx->image_watcher->is_lock_owner()) {
-	ldout(m_ictx->cct, 20) << "exclusive lock not held for copy-on-read"
+	ldout(m_ictx->cct, 20) << "exclusive lock not held for copyup request"
 			       << dendl;
-	return true;
+        assert(m_pending_requests.empty());
+        return true;
       } else {
-	m_state = STATE_OBJECT_MAP;
-        Context *ctx = create_callback_context();
         RWLock::WLocker object_map_locker(m_ictx->object_map_lock);
-        if (!m_ictx->object_map.aio_update(m_object_no, OBJECT_EXISTS,
-					   boost::optional<uint8_t>(), ctx)) {
-          delete ctx;
-	  copyup = true;
-	}
+        if (m_ictx->object_map[m_object_no] != OBJECT_EXISTS) {
+          ldout(m_ictx->cct, 20) << __func__ << " " << this
+			         << ": oid " << m_oid
+                                 << ", extents " << m_image_extents
+                                 << dendl;
+  	  m_state = STATE_OBJECT_MAP;
+
+          Context *ctx = create_callback_context();
+          bool sent = m_ictx->object_map.aio_update(m_object_no, OBJECT_EXISTS,
+                                                    boost::optional<uint8_t>(),
+                                                    ctx);
+          assert(sent);
+        } else {
+          copyup = true;
+        }
       }
     }
 
     // avoid possible recursive lock attempts
     if (copyup) {
       // no object map update required
-      send_copyup();
-      return true;
+      return send_copyup();
     }
     return false;
   }

--- a/src/librbd/CopyupRequest.h
+++ b/src/librbd/CopyupRequest.h
@@ -36,13 +36,16 @@ namespace librbd {
      * <start>
      *    |
      *    v
-     * STATE_READ_FROM_PARENT ----> STATE_OBJECT_MAP . . .
-     *    .               .            |                 .
-     *    .               .            v                 .
-     *    .               . . . . > STATE_COPYUP         .
-     *    .                            |                 .
-     *    .                            v                 .
-     *    . . . . . . . . . . . . > <finish> < . . . . . .
+     *  STATE_READ_FROM_PARENT
+     *    .   .        |
+     *    .   .        v
+     *    .   .     STATE_OBJECT_MAP . .
+     *    .   .        |               .
+     *    .   .        v               .
+     *    .   . . > STATE_COPYUP       .
+     *    .            |               .
+     *    .            v               .
+     *    . . . . > <finish> < . . . . .
      *
      * @endverbatim
      *
@@ -66,6 +69,8 @@ namespace librbd {
     atomic_t m_pending_copyups;
 
     AsyncOperation m_async_op;
+
+    std::vector<uint64_t> m_snap_ids;
 
     void complete_requests(int r);
 

--- a/src/librbd/CopyupRequest.h
+++ b/src/librbd/CopyupRequest.h
@@ -63,6 +63,7 @@ namespace librbd {
     State m_state;
     ceph::bufferlist m_copyup_data;
     vector<AioRequest *> m_pending_requests;
+    atomic_t m_pending_copyups;
 
     AsyncOperation m_async_op;
 

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -46,6 +46,11 @@ public:
 		  const boost::optional<uint8_t> &current_state,
 		  Context *on_finish);
 
+  void aio_update(uint64_t snap_id, uint64_t start_object_no,
+                  uint64_t end_object_no, uint8_t new_state,
+                  const boost::optional<uint8_t> &current_state,
+                  Context *on_finish);
+
   void refresh(uint64_t snap_id);
   void rollback(uint64_t snap_id);
   void snapshot_add(uint64_t snap_id);

--- a/src/librbd/RebuildObjectMapRequest.cc
+++ b/src/librbd/RebuildObjectMapRequest.cc
@@ -321,7 +321,7 @@ void RebuildObjectMapRequest::send_verify_objects() {
     boost::lambda::bind(boost::lambda::new_ptr<C_VerifyObject>(),
       boost::lambda::_1, &m_image_ctx, snap_id, boost::lambda::_2));
   AsyncObjectThrottle *throttle = new AsyncObjectThrottle(
-    *this, context_factory, create_callback_context(), m_prog_ctx, 0,
+    *this, context_factory, create_callback_context(), &m_prog_ctx, 0,
     num_objects);
   throttle->start_ops(cct->_conf->rbd_concurrent_management_ops);
 }

--- a/src/librbd/RebuildObjectMapRequest.cc
+++ b/src/librbd/RebuildObjectMapRequest.cc
@@ -321,7 +321,7 @@ void RebuildObjectMapRequest::send_verify_objects() {
     boost::lambda::bind(boost::lambda::new_ptr<C_VerifyObject>(),
       boost::lambda::_1, &m_image_ctx, snap_id, boost::lambda::_2));
   AsyncObjectThrottle *throttle = new AsyncObjectThrottle(
-    *this, context_factory, create_callback_context(), &m_prog_ctx, 0,
+    this, context_factory, create_callback_context(), &m_prog_ctx, 0,
     num_objects);
   throttle->start_ops(cct->_conf->rbd_concurrent_management_ops);
 }

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -82,7 +82,8 @@ static std::map<uint64_t, std::string> feature_mapping =
     RBD_FEATURE_STRIPINGV2, "striping")(
     RBD_FEATURE_EXCLUSIVE_LOCK, "exclusive-lock")(
     RBD_FEATURE_OBJECT_MAP, "object-map")(
-    RBD_FEATURE_FAST_DIFF, "fast-diff");
+    RBD_FEATURE_FAST_DIFF, "fast-diff")(
+    RBD_FEATURE_DEEP_FLATTEN, "deep-flatten");
 
 void usage()
 {

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -100,7 +100,7 @@
     --allow-shrink                     allow shrinking of an image when resizing
   
   Supported image features:
-    layering (+), striping (+), exclusive-lock (*), object-map (*), fast-diff (*)
+    layering (+), striping (+), exclusive-lock (*), object-map (*), fast-diff (*), deep-flatten
   
     (*) supports enabling/disabling on existing images
     (+) enabled by default for new images if features are not specified

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -676,6 +676,22 @@ TEST_F(TestClsRbd, parents)
   ASSERT_EQ(pspec.snap_id, snapid_t(3));
   ASSERT_EQ(size, 2ull<<20);
 
+  ASSERT_EQ(0, ioctx.remove(oid));
+  ASSERT_EQ(0, create_image(&ioctx, oid, 33<<20, 22,
+                            RBD_FEATURE_LAYERING | RBD_FEATURE_DEEP_FLATTEN,
+                            "foo."));
+  ASSERT_EQ(0, set_parent(&ioctx, oid, parent_spec(1, "parent", 3), 100<<20));
+  ASSERT_EQ(0, snapshot_add(&ioctx, oid, 1, "snap1"));
+  ASSERT_EQ(0, snapshot_add(&ioctx, oid, 2, "snap2"));
+  ASSERT_EQ(0, remove_parent(&ioctx, oid));
+
+  ASSERT_EQ(0, get_parent(&ioctx, oid, 1, &pspec, &size));
+  ASSERT_EQ(-1, pspec.pool_id);
+  ASSERT_EQ(0, get_parent(&ioctx, oid, 2, &pspec, &size));
+  ASSERT_EQ(-1, pspec.pool_id);
+  ASSERT_EQ(0, get_parent(&ioctx, oid, CEPH_NOSNAP, &pspec, &size));
+  ASSERT_EQ(-1, pspec.pool_id);
+
   ioctx.close();
 }
 

--- a/src/test/librados_test_stub/TestClassHandler.cc
+++ b/src/test/librados_test_stub/TestClassHandler.cc
@@ -100,10 +100,12 @@ cls_method_cxx_call_t TestClassHandler::get_method(const std::string &cls,
 }
 
 TestClassHandler::SharedMethodContext TestClassHandler::get_method_context(
-    TestIoCtxImpl *io_ctx_impl, const std::string &oid) {
+    TestIoCtxImpl *io_ctx_impl, const std::string &oid,
+    const SnapContext &snapc) {
   SharedMethodContext ctx(new MethodContext());
   ctx->io_ctx_impl = io_ctx_impl;
   ctx->oid = oid;
+  ctx->snapc = snapc;
   return ctx;
 }
 

--- a/src/test/librados_test_stub/TestClassHandler.h
+++ b/src/test/librados_test_stub/TestClassHandler.h
@@ -5,6 +5,7 @@
 #define CEPH_TEST_CLASS_HANDLER_H
 
 #include "objclass/objclass.h"
+#include "common/snap_types.h"
 #include <boost/shared_ptr.hpp>
 #include <list>
 #include <map>
@@ -24,6 +25,7 @@ public:
   struct MethodContext {
     TestIoCtxImpl *io_ctx_impl;
     std::string oid;
+    SnapContext snapc;
   };
   typedef boost::shared_ptr<MethodContext> SharedMethodContext;
 
@@ -47,7 +49,8 @@ public:
   cls_method_cxx_call_t get_method(const std::string &cls,
                                    const std::string &method);
   SharedMethodContext get_method_context(TestIoCtxImpl *io_ctx_impl,
-                                         const std::string &oid);
+                                         const std::string &oid,
+                                         const SnapContext &snapc);
 
 private:
 

--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -18,7 +18,8 @@ class TestRadosClient;
 
 typedef boost::function<int(TestIoCtxImpl*,
 			    const std::string&,
-			    bufferlist *)> ObjectOperationTestImpl;
+			    bufferlist *,
+                            const SnapContext &)> ObjectOperationTestImpl;
 typedef std::list<ObjectOperationTestImpl> ObjectOperations;
 
 struct TestObjectOperationImpl {
@@ -74,7 +75,8 @@ public:
   virtual int create(const std::string& oid, bool exclusive) = 0;
   virtual int exec(const std::string& oid, TestClassHandler &handler,
                    const char *cls, const char *method,
-                   bufferlist& inbl, bufferlist* outbl);
+                   bufferlist& inbl, bufferlist* outbl,
+                   const SnapContext &snapc);
   virtual int list_snaps(const std::string& o, snap_set_t *out_snaps) = 0;
   virtual int list_watchers(const std::string& o,
                             std::list<obj_watch_t> *out_watchers);
@@ -117,8 +119,9 @@ public:
   virtual int watch(const std::string& o, uint64_t *handle,
                     librados::WatchCtx *ctx, librados::WatchCtx2 *ctx2);
   virtual int write(const std::string& oid, bufferlist& bl, size_t len,
-                    uint64_t off) = 0;
-  virtual int write_full(const std::string& oid, bufferlist& bl) = 0;
+                    uint64_t off, const SnapContext &snapc) = 0;
+  virtual int write_full(const std::string& oid, bufferlist& bl,
+                         const SnapContext &snapc) = 0;
   virtual int xattr_get(const std::string& oid,
                         std::map<std::string, bufferlist>* attrset) = 0;
   virtual int xattr_set(const std::string& oid, const std::string &name,
@@ -129,8 +132,9 @@ protected:
   TestIoCtxImpl(const TestIoCtxImpl& rhs);
   virtual ~TestIoCtxImpl();
 
-  int execute_aio_operations(const std::string& oid, TestObjectOperationImpl *ops,
-                             bufferlist *pbl);
+  int execute_aio_operations(const std::string& oid,
+                             TestObjectOperationImpl *ops,
+                             bufferlist *pbl, const SnapContext &snapc);
 
 private:
 

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -45,7 +45,8 @@ int TestMemIoCtxImpl::aio_remove(const std::string& oid, AioCompletionImpl *c) {
 
 int TestMemIoCtxImpl::assert_exists(const std::string &oid) {
   RWLock::RLocker l(m_pool->file_lock);
-  TestMemRadosClient::SharedFile file = get_file(oid, false);
+  TestMemRadosClient::SharedFile file = get_file(oid, false,
+                                                 get_snap_context());
   if (file == NULL) {
     return -ENOENT;
   }
@@ -58,7 +59,7 @@ int TestMemIoCtxImpl::create(const std::string& oid, bool exclusive) {
   }
 
   RWLock::WLocker l(m_pool->file_lock);
-  get_file(oid, true);
+  get_file(oid, true, get_snap_context());
   return 0;
 }
 
@@ -140,7 +141,7 @@ int TestMemIoCtxImpl::omap_get_vals(const std::string& oid,
   TestMemRadosClient::SharedFile file;
   {
     RWLock::RLocker l(m_pool->file_lock);
-    file = get_file(oid, false);
+    file = get_file(oid, false, get_snap_context());
     if (file == NULL) {
       return -ENOENT;
     }
@@ -180,7 +181,7 @@ int TestMemIoCtxImpl::omap_rm_keys(const std::string& oid,
   TestMemRadosClient::SharedFile file;
   {
     RWLock::WLocker l(m_pool->file_lock);
-    file = get_file(oid, true);
+    file = get_file(oid, true, get_snap_context());
     if (file == NULL) {
       return -ENOENT;
     }
@@ -203,7 +204,7 @@ int TestMemIoCtxImpl::omap_set(const std::string& oid,
   TestMemRadosClient::SharedFile file;
   {
     RWLock::WLocker l(m_pool->file_lock);
-    file = get_file(oid, true);
+    file = get_file(oid, true, get_snap_context());
     if (file == NULL) {
       return -ENOENT;
     }
@@ -225,7 +226,7 @@ int TestMemIoCtxImpl::read(const std::string& oid, size_t len, uint64_t off,
   TestMemRadosClient::SharedFile file;
   {
     RWLock::RLocker l(m_pool->file_lock);
-    file = get_file(oid, false);
+    file = get_file(oid, false, get_snap_context());
     if (file == NULL) {
       return -ENOENT;
     }
@@ -250,11 +251,12 @@ int TestMemIoCtxImpl::remove(const std::string& oid) {
   }
 
   RWLock::WLocker l(m_pool->file_lock);
-  TestMemRadosClient::SharedFile file = get_file(oid, false);
+  TestMemRadosClient::SharedFile file = get_file(oid, false,
+                                                 get_snap_context());
   if (file == NULL) {
     return -ENOENT;
   }
-  file = get_file(oid, true);
+  file = get_file(oid, true, get_snap_context());
 
   RWLock::WLocker l2(file->lock);
   file->exists = false;
@@ -340,7 +342,7 @@ int TestMemIoCtxImpl::sparse_read(const std::string& oid, uint64_t off,
   TestMemRadosClient::SharedFile file;
   {
     RWLock::RLocker l(m_pool->file_lock);
-    file = get_file(oid, false);
+    file = get_file(oid, false, get_snap_context());
     if (file == NULL) {
       return -ENOENT;
     }
@@ -367,7 +369,7 @@ int TestMemIoCtxImpl::stat(const std::string& oid, uint64_t *psize,
   TestMemRadosClient::SharedFile file;
   {
     RWLock::RLocker l(m_pool->file_lock);
-    file = get_file(oid, false);
+    file = get_file(oid, false, get_snap_context());
     if (file == NULL) {
       return -ENOENT;
     }
@@ -391,7 +393,7 @@ int TestMemIoCtxImpl::truncate(const std::string& oid, uint64_t size) {
   TestMemRadosClient::SharedFile file;
   {
     RWLock::WLocker l(m_pool->file_lock);
-    file = get_file(oid, true);
+    file = get_file(oid, true, get_snap_context());
   }
 
   RWLock::WLocker l(file->lock);
@@ -419,7 +421,7 @@ int TestMemIoCtxImpl::truncate(const std::string& oid, uint64_t size) {
 }
 
 int TestMemIoCtxImpl::write(const std::string& oid, bufferlist& bl, size_t len,
-                            uint64_t off) {
+                            uint64_t off, const SnapContext &snapc) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
   }
@@ -427,7 +429,7 @@ int TestMemIoCtxImpl::write(const std::string& oid, bufferlist& bl, size_t len,
   TestMemRadosClient::SharedFile file;
   {
     RWLock::WLocker l(m_pool->file_lock);
-    file = get_file(oid, true);
+    file = get_file(oid, true, snapc);
   }
 
   RWLock::WLocker l(file->lock);
@@ -443,7 +445,8 @@ int TestMemIoCtxImpl::write(const std::string& oid, bufferlist& bl, size_t len,
   return 0;
 }
 
-int TestMemIoCtxImpl::write_full(const std::string& oid, bufferlist& bl) {
+int TestMemIoCtxImpl::write_full(const std::string& oid, bufferlist& bl,
+                                 const SnapContext &snapc) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
   }
@@ -451,7 +454,7 @@ int TestMemIoCtxImpl::write_full(const std::string& oid, bufferlist& bl) {
   TestMemRadosClient::SharedFile file;
   {
     RWLock::WLocker l(m_pool->file_lock);
-    file = get_file(oid, true);
+    file = get_file(oid, true, snapc);
     if (file == NULL) {
       return -ENOENT;
     }
@@ -494,11 +497,11 @@ int TestMemIoCtxImpl::zero(const std::string& oid, uint64_t off, uint64_t len) {
   TestMemRadosClient::SharedFile file;
   {
     RWLock::WLocker l(m_pool->file_lock);
-    file = get_file(oid, false);
+    file = get_file(oid, false, get_snap_context());
     if (!file) {
       return 0;
     }
-    file = get_file(oid, true);
+    file = get_file(oid, true, get_snap_context());
 
     RWLock::RLocker l2(file->lock);
     if (len > 0 && off + len >= file->data.length()) {
@@ -512,7 +515,7 @@ int TestMemIoCtxImpl::zero(const std::string& oid, uint64_t off, uint64_t len) {
 
   bufferlist bl;
   bl.append_zero(len);
-  return write(oid, bl, len, off);
+  return write(oid, bl, len, off, get_snap_context());
 }
 
 void TestMemIoCtxImpl::append_clone(bufferlist& src, bufferlist* dest) {
@@ -544,7 +547,7 @@ void TestMemIoCtxImpl::ensure_minimum_length(size_t len, bufferlist *bl) {
 }
 
 TestMemRadosClient::SharedFile TestMemIoCtxImpl::get_file(
-    const std::string &oid, bool write) {
+    const std::string &oid, bool write, const SnapContext &snapc) {
   assert(m_pool->file_lock.is_locked() || m_pool->file_lock.is_wlocked());
   assert(!write || m_pool->file_lock.is_wlocked());
 
@@ -557,7 +560,6 @@ TestMemRadosClient::SharedFile TestMemIoCtxImpl::get_file(
   }
 
   if (write) {
-    const SnapContext &snapc = get_snap_context();
     bool new_version = false;
     if (!file || !file->exists) {
       file = TestMemRadosClient::SharedFile(new TestMemRadosClient::File());
@@ -572,11 +574,13 @@ TestMemRadosClient::SharedFile TestMemIoCtxImpl::get_file(
           }
         }
 
-        uint64_t prev_size = file->data.length();
+        bufferlist prev_data = file->data;
         file = TestMemRadosClient::SharedFile(
           new TestMemRadosClient::File(*file));
-        if (prev_size > 0) {
-          file->snap_overlap.insert(0, prev_size);
+        file->data.clear();
+        append_clone(prev_data, &file->data);
+        if (prev_data.length() > 0) {
+          file->snap_overlap.insert(0, prev_data.length());
         }
         new_version = true;
       }

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.h
@@ -45,8 +45,9 @@ public:
   virtual int stat(const std::string& oid, uint64_t *psize, time_t *pmtime);
   virtual int truncate(const std::string& oid, uint64_t size);
   virtual int write(const std::string& oid, bufferlist& bl, size_t len,
-                    uint64_t off);
-  virtual int write_full(const std::string& oid, bufferlist& bl);
+                    uint64_t off, const SnapContext &snapc);
+  virtual int write_full(const std::string& oid, bufferlist& bl,
+                         const SnapContext &snapc);
   virtual int xattr_get(const std::string& oid,
                         std::map<std::string, bufferlist>* attrset);
   virtual int xattr_set(const std::string& oid, const std::string &name,
@@ -63,7 +64,8 @@ private:
   size_t clip_io(size_t off, size_t len, size_t bl_len);
   void ensure_minimum_length(size_t len, bufferlist *bl);
 
-  TestMemRadosClient::SharedFile get_file(const std::string &oid, bool write);
+  TestMemRadosClient::SharedFile get_file(const std::string &oid, bool write,
+                                          const SnapContext &snapc);
 
 };
 

--- a/src/test/run-rbd-tests
+++ b/src/test/run-rbd-tests
@@ -35,7 +35,7 @@ run_cli_tests
 export RBD_CREATE_ARGS="--format 2"
 run_cli_tests
 
-for i in 0 1 5 13 29
+for i in 0 1 5 13 29 45
 do
     export RBD_FEATURES=$i
     run_api_tests

--- a/src/test/run-rbd-unit-tests.sh
+++ b/src/test/run-rbd-unit-tests.sh
@@ -7,7 +7,7 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CEPH_SRC/.libs"
 PATH="$CEPH_SRC:$PATH"
 
 unittest_librbd
-for i in 0 1 5 13 29
+for i in 0 1 5 13 29 45
 do
     RBD_FEATURES=$i unittest_librbd
 done


### PR DESCRIPTION
This allows flatten to fully disconnect the child image (and its snapshots) from its parent.