### PR TITLE
Fix the disablement of pgrefdebugging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -541,8 +541,10 @@ fi
 #set pg ref debugging?
 AC_ARG_ENABLE([pgrefdebugging],
 	    [AS_HELP_STRING([--enable-pgrefdebugging], [enable pg ref debugging])],
-			[AC_DEFINE([PG_DEBUG_REFS], [1], [Defined if you want pg ref debugging])],
-			[])
+			[], [enable_pgrefdebugging=no])
+AS_IF([test "x$enable_pgrefdebugging" = "xyes"],
+	  [AC_DEFINE([PG_DEBUG_REFS], [1], [Defined if you want pg ref debugging])],
+	  [])
 
 #
 # Java is painful


### PR DESCRIPTION
Currently, if you add the flag --disable-pgrefdebugging during configure
it enables pgrefdebugging. The only way for it to actually be disabled
is to remove the flag entirely. This patch makes the flag respect the
--enable and --disable options correctly. Therefore,
--enable-pgrefdebugging is the only way to enable this now and
--enable-pgrefdebugging=no and --disable-pgrefdebugging work as
expected.