### PR TITLE
rocksdb: only disableDataSync from FileStore

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -728,7 +728,6 @@ OPTION(rocksdb_paranoid, OPT_BOOL, false) // RocksDB will aggressively check con
 OPTION(rocksdb_log, OPT_STR, "/dev/null")  // enable rocksdb log file
 OPTION(rocksdb_info_log_level, OPT_STR, "info")  // info log level : debug , info , warn, error, fatal
 OPTION(rocksdb_wal_dir, OPT_STR, "")  //  rocksdb write ahead log file, put it to fast device will benifit wrtie performance
-OPTION(rocksdb_disableDataSync, OPT_BOOL, false) // if true, data files are not synced to stable storage
 OPTION(rocksdb_disableWAL, OPT_BOOL, false)  // if true, writes will not first go to the write ahead log
 
 

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -1457,9 +1457,10 @@ int FileStore::mount()
   }
 
   if (!(generic_flags & SKIP_MOUNT_OMAP)) {
+    //set disableDataSync to true since we rely on syncfs
     KeyValueDB * omap_store = KeyValueDB::create(g_ceph_context,
 						 superblock.omap_backend,
-						 omap_dir);
+						 omap_dir, true);
     if (omap_store == NULL)
     {
       derr << "Error creating " << superblock.omap_backend << dendl;

--- a/src/os/KeyValueDB.cc
+++ b/src/os/KeyValueDB.cc
@@ -11,7 +11,7 @@
 #endif
 
 KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
-			       const string& dir)
+			       const string& dir, const bool disable_DataSync)
 {
   if (type == "leveldb") {
     return new LevelDBStore(cct, dir);
@@ -25,7 +25,7 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 #ifdef HAVE_LIBROCKSDB
   if (type == "rocksdb" &&
       cct->check_experimental_feature_enabled("rocksdb")) {
-    return new RocksDBStore(cct, dir);
+    return new RocksDBStore(cct, dir, disable_DataSync);
   }
 #endif
   return NULL;

--- a/src/os/KeyValueDB.h
+++ b/src/os/KeyValueDB.h
@@ -66,7 +66,7 @@ public:
 
   /// create a new instance
   static KeyValueDB *create(CephContext *cct, const string& type,
-			    const string& dir);
+			    const string& dir, bool disableDataSync = false);
 
   /// test whether we can successfully initialize; may have side effects (e.g., create)
   static int test_init(const string& type, const string& dir);

--- a/src/os/RocksDBStore.cc
+++ b/src/os/RocksDBStore.cc
@@ -51,7 +51,6 @@ int RocksDBStore::init()
   options.log_file = g_conf->rocksdb_log;
   options.info_log_level = g_conf->rocksdb_info_log_level;
   options.wal_dir = g_conf->rocksdb_wal_dir;
-  options.disableDataSync = g_conf->rocksdb_disableDataSync;
   options.disableWAL = g_conf->rocksdb_disableWAL;
   return 0;
 }
@@ -102,10 +101,7 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
   else
     ldoptions.compression = rocksdb::kNoCompression;
 
-  if(options.disableDataSync) {
-    derr << "Warning: DataSync is disabled, may lose data on node failure" << dendl;
-    ldoptions.disableDataSync = options.disableDataSync;
-  }
+  ldoptions.disableDataSync = disableDataSync; 
 
   if(options.disableWAL) {
     derr << "Warning: Write Ahead Log is disabled, may lose data on failure" << dendl;

--- a/src/os/RocksDBStore.h
+++ b/src/os/RocksDBStore.h
@@ -52,6 +52,7 @@ class RocksDBStore : public KeyValueDB {
   string path;
   const rocksdb::FilterPolicy *filterpolicy;
   rocksdb::DB *db;
+  bool disableDataSync;
 
   int do_open(ostream &out, bool create_if_missing);
 
@@ -137,7 +138,6 @@ public:
     string log_file;
     string wal_dir;
     string info_log_level;
-    bool disableDataSync;
     bool disableWAL;
 
     int block_restart_interval;
@@ -167,7 +167,6 @@ public:
       compression_type("none"),
       paranoid_checks(false), //< set to true if you want paranoid checks
       info_log_level("info"),
-      disableDataSync(false),
       disableWAL(false),
 
       block_restart_interval(0), //< 0 means default
@@ -175,14 +174,15 @@ public:
     {}
   } options;
 
-  RocksDBStore(CephContext *c, const string &path) :
+  RocksDBStore(CephContext *c, const string &path, bool _disable_datasync) :
     cct(c),
     logger(NULL),
     path(path),
     compact_queue_lock("RocksDBStore::compact_thread_lock"),
     compact_queue_stop(false),
     compact_thread(this),
-    options()
+    options(),
+    disableDataSync(_disable_datasync)
   {}
 
   ~RocksDBStore();


### PR DESCRIPTION
With sync=false, RocksDB and LevelDB doesn't guarantee new data is persistent
to disk, but that is faster.

This is fine for Filestore because is relying on the syncfs(2) at commit time
for everything.But other component might not.

For filestore, we default sync=false, unless using submit_transaction_sync API.
For MonitorDBStore and KeyValueStore(althought KeyValueStore only use submit_transaction_sync),
we default sync=true till we audit the code to make sure they are properly handle the persistency.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>