### PR TITLE
osd: fix incorrect stats after failing to recover an ec object.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7827,6 +7827,7 @@ void OSD::do_recovery(PG *pg, ThreadPool::TPHandle &handle)
       pg->discover_all_missing(*rctx.query_map);
       if (rctx.query_map->empty()) {
 	dout(10) << "do_recovery  no luck, giving up on this pg for now" << dendl;
+	pg->publish_stats_to_osd();
 	recovery_wq.lock();
 	recovery_wq._dequeue(pg);
 	recovery_wq.unlock();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4421,11 +4421,11 @@ void PG::scrub_finish()
   scrub_unreserve_replicas();
 
   if (is_active() && is_primary()) {
-    share_pg_info();
+    share_pg_info(true);
   }
 }
 
-void PG::share_pg_info()
+void PG::share_pg_info(bool send_stats)
 {
   dout(10) << "share_pg_info" << dendl;
 
@@ -4439,6 +4439,8 @@ void PG::share_pg_info()
     if (peer_info.count(peer)) {
       peer_info[peer].last_epoch_started = info.last_epoch_started;
       peer_info[peer].history.merge(info.history);
+      if (send_stats && !is_backfill_targets(peer))
+	peer_info[peer].stats = info.stats;
     }
     MOSDPGInfo *m = new MOSDPGInfo(get_osdmap()->get_epoch());
     m->pg_list.push_back(

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2171,7 +2171,7 @@ public:
   bool queue_scrub();
 
   /// share pg info after a pg is active
-  void share_pg_info();
+  void share_pg_info(bool send_stats=false);
   /// share new pg log entries after a pg is active
   void share_pg_log();
 


### PR DESCRIPTION
After repairing a ec pg which has a unrecovery object, the ceph health
display the incorrectly infos. As follows:
ceph -s
    cluster 654e4bc3-9d87-4017-9d8c-c3e2f6cecde2
     health HEALTH_WARN
            1 pgs stuck unclean
            recovery 5/4 objects degraded (125.000%)
            recovery 1/1 unfound (100.000%)
            too few PGs per OSD (8 < min 30)
     monmap e1: 1 mons at {a=192.168.10.19:6789/0}
            election epoch 2, quorum 0 a
     osdmap e8: 4 osds: 4 up, 4 in
      pgmap v17: 8 pgs, 1 pools, 12065 bytes data, 1 objects
            133 MB used, 40786 MB / 40920 MB avail
            5/4 objects degraded (125.000%)
            1/1 unfound (100.000%)
                   7 active+clean
                   1 active

In func PG::PG::_update_calc_stats,
>> int64_t diff = num_objects - peer_info[*i].stats.stats.sum.num_objects;
>>      if (diff > 0)
>>        degraded += diff;
But for PG::perr_info::stats, it only updated in peering. For every
write, primary send stats to replica node, but don't update stats of
peer_info.
In share_pg_info/share_pg_log, it update replica pg info w/ primary pg info, s
o update peer_info[].stats is safe in those function.
If recovery failed, we call publish_stats_to_osd which make update pg
info.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>