### PR TITLE
librbd: updated cache max objects calculation

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -226,10 +226,9 @@ namespace librbd {
     if (object_cacher) {
       uint64_t obj = cache_max_dirty_object;
       if (!obj) {
-        obj = cache_size / (1ull << order);
-        obj = obj * 4 + 10;
+        obj = MIN(2000, MAX(10, cache_size / 100 / sizeof(ObjectCacher::Object)));
       }
-      ldout(cct, 10) << " cache bytes " << cache_size << " order " << (int)order
+      ldout(cct, 10) << " cache bytes " << cache_size
 		     << " -> about " << obj << " objects" << dendl;
       object_cacher->set_max_objects(obj);
     }


### PR DESCRIPTION
The previous calculation was based upon the image's object size.
Since the cache stores smaller bufferheads, the object size is not
a good indicator of cache usage and was resulting in objects being
evicted from the cache too often.  Instead, base the max number of
objects on the memory load required to store the extra metadata
for the objects.

Fixes: #7385
Backport: firefly, hammer
Signed-off-by: Jason Dillaman <dillaman@redhat.com>