### PR TITLE
#11453 init-radosgw: run RGW as root

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -35,7 +35,7 @@ done
 PREFIX='client.radosgw.'
 
 # user to run radosgw as (it not specified in ceph.conf)
-DEFAULT_USER='www-data'
+DEFAULT_USER='root'
 
 RADOSGW=`which radosgw`
 if [ ! -x "$RADOSGW" ]; then

--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -37,7 +37,7 @@ PREFIX='client.radosgw.'
 
 # user to run radosgw as (it not specified in ceph.conf)
 #DEFAULT_USER='www-data'
-DEFAULT_USER='apache'
+DEFAULT_USER='root'
 
 RADOSGW=`which radosgw`
 if [ ! -x "$RADOSGW" ]; then


### PR DESCRIPTION
The ceph-radosgw service fails to start if the httpd package is not installed. This is because the init.d file attempts to start the RGW process with the "apache" UID. If a user is running civetweb, there is no reason for the httpd package to be present on the system.

We should switch the init script to use "root" as is done on Ubuntu.

http://tracker.ceph.com/issues/11453 Refs: #11453

Reported-by: Vickey Singh <vickey.singh22693@gmail.com>
