### PR TITLE
os/NewStore: don't clear overlay in the create/append case of write

### DIFF
--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -3332,7 +3332,6 @@ int NewStore::_do_write(TransContext *txc,
   if (o->onode.size <= offset ||
       o->onode.size == 0 ||
       o->onode.data_map.empty()) {
-    _do_overlay_clear(txc, o);
     uint64_t x_offset;
     if (o->onode.data_map.empty()) {
       // create

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -3213,20 +3213,6 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
   if (o->onode.overlay_map.empty())
     return 0;
 
-  // overwrite to new fid
-  if (o->onode.data_map.empty()) {
-    // create
-    fragment_t &f = o->onode.data_map[0];
-    f.offset = 0;
-    f.length = o->onode.size;
-    int fd = _create_fid(txc, &f.fid, O_RDWR);
-    if (fd < 0) {
-      return fd;
-    }
-    VOID_TEMP_FAILURE_RETRY(::close(fd));
-    dout(20) << __func__ << " create " << f.fid << dendl;
-  }
-
   assert(o->onode.data_map.size() == 1);
   fragment_t& f = o->onode.data_map.begin()->second;
   assert(f.offset == 0);

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -3265,6 +3265,7 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
   }
 
   o->onode.overlay_map.clear();
+  o->onode.shared_overlays.clear();
   txc->write_onode(o);
   return 0;
 }


### PR DESCRIPTION
Shouldn't clear the overlay in the create/append case of write.
Otherwise, this removes the overlay data and leads to data loss.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>