### PR TITLE
Throttle fix

### DIFF
--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -80,6 +80,8 @@ Throttle::~Throttle()
 void Throttle::_reset_max(int64_t m)
 {
   assert(lock.is_locked());
+  if ((int64_t)max.read() == m)
+    return;
   if (!cond.empty())
     cond.front()->SignalOne();
   if (logger)

--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -124,7 +124,7 @@ bool Throttle::_wait(int64_t c)
 
 bool Throttle::wait(int64_t m)
 {
-  if (0 == max.read()) {
+  if (0 == max.read() && 0 == m) {
     return false;
   }
 
@@ -158,7 +158,7 @@ int64_t Throttle::take(int64_t c)
 
 bool Throttle::get(int64_t c, int64_t m)
 {
-  if (0 == max.read()) {
+  if (0 == max.read() && 0 == m) {
     return false;
   }
 

--- a/src/test/common/Throttle.cc
+++ b/src/test/common/Throttle.cc
@@ -74,7 +74,15 @@ TEST_F(ThrottleTest, take) {
 
 TEST_F(ThrottleTest, get) {
   int64_t throttle_max = 10;
-  Throttle throttle(g_ceph_context, "throttle", throttle_max);
+  Throttle throttle(g_ceph_context, "throttle");
+
+  // test increasing max from 0 to throttle_max
+  {
+    ASSERT_FALSE(throttle.get(throttle_max, throttle_max));
+    ASSERT_EQ(throttle.get_max(), throttle_max);
+    ASSERT_EQ(throttle.put(throttle_max), 0);
+  }
+
   ASSERT_THROW(throttle.get(-1), FailedAssertion);
   ASSERT_FALSE(throttle.get(5)); 
   ASSERT_EQ(throttle.put(5), 0); 
@@ -161,7 +169,13 @@ TEST_F(ThrottleTest, get_or_fail) {
 
 TEST_F(ThrottleTest, wait) {
   int64_t throttle_max = 10;
-  Throttle throttle(g_ceph_context, "throttle", throttle_max);
+  Throttle throttle(g_ceph_context, "throttle");
+
+  // test increasing max from 0 to throttle_max
+  {
+    ASSERT_FALSE(throttle.wait(throttle_max));
+    ASSERT_EQ(throttle.get_max(), throttle_max);
+  }
 
   useconds_t delay = 1;
 


### PR DESCRIPTION
The first commit is a bug fix - we were unable to set a new max if the original max was 0.
The second one is to save some CPU cycles.