### PR TITLE
check for nosetests in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,12 @@ if test x"$SPHINX_BUILD" = x"no"; then
   AC_MSG_ERROR([sphinx-build not found (python-sphinx)])
 fi
 
+# check for /usr/bin/nosetests needed for make check 
+AC_CHECK_PROG(NOSETESTS_CHECK, nosetests, yes)
+if test x"$NOSETESTS_CHECK" != x"yes"; then
+    AC_MSG_ERROR([nosetests not found (python-nose)])
+fi
+
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_CONFIG_SUBDIRS([src/gmock])

--- a/doc/start/documenting-ceph.rst
+++ b/doc/start/documenting-ceph.rst
@@ -239,6 +239,7 @@ the following packages are required:
 - python-pip
 - python-virtualenv
 - python-sphinx
+- python-nose
 - libxml2-dev
 - libxslt1-dev
 - doxygen
@@ -258,6 +259,7 @@ the following packages are required:
 - python-jinja2
 - python-pygments
 - python-sphinx
+- python-nose
 - libxml2-devel
 - libxslt1-devel
 - doxygen
@@ -277,6 +279,7 @@ the following packages are required:
 - python-jinja2
 - python-pygments
 - python-sphinx
+- python-nose
 - libxml2-dev
 - libxslt1-dev
 - doxygen
@@ -292,13 +295,13 @@ Install each dependency that isn't installed on your host. For Debian/Ubuntu
 distributions, execute the following::
 
 	sudo apt-get install gcc python-dev python-pip python-virtualenv libxml2-dev libxslt-dev doxygen graphviz ant ditaa
-	sudo apt-get install python-sphinx
+	sudo apt-get install python-sphinx python-nose
 
 For Fedora distributions, execute the following::
 
    sudo yum install gcc python-devel python-pip python-virtualenv libxml2-devel libxslt-devel doxygen graphviz ant
    sudo pip install html2text
-   sudo yum install python-jinja2 python-pygments python-docutils python-sphinx
+   sudo yum install python-jinja2 python-pygments python-docutils python-sphinx python-nose
    sudo yum install jericho-html ditaa
 
 For CentOS/RHEL distributions, it is recommended to have ``epel`` (Extra

--- a/doc/start/documenting-ceph.rst
+++ b/doc/start/documenting-ceph.rst
@@ -321,13 +321,13 @@ For CentOS/RHEL distributions, the remaining python packages are not available i
 the default and ``epel`` repositories. So, use http://rpmfind.net/ to find the
 packages. Then, download them from a mirror and install them. For example::
 
-	wget ftp://rpmfind.net/linux/centos/7.0.1406/os/x86_64/Packages/python-jinja2-2.7.2-2.el7.noarch.rpm
+	wget ftp://rpmfind.net/linux/centos/7/os/x86_64/Packages/python-jinja2-2.7.2-2.el7.noarch.rpm
 	sudo yum install python-jinja2-2.7.2-2.el7.noarch.rpm
-	wget ftp://rpmfind.net/linux/centos/7.0.1406/os/x86_64/Packages/python-pygments-1.4-9.el7.noarch.rpm
+	wget ftp://rpmfind.net/linux/centos/7/os/x86_64/Packages/python-pygments-1.4-9.el7.noarch.rpm
 	sudo yum install python-pygments-1.4-9.el7.noarch.rpm
-	wget ftp://rpmfind.net/linux/centos/7.0.1406/os/x86_64/Packages/python-docutils-0.11-0.2.20130715svn7687.el7.noarch.rpm
+	wget ftp://rpmfind.net/linux/centos/7/os/x86_64/Packages/python-docutils-0.11-0.2.20130715svn7687.el7.noarch.rpm
 	sudo yum install python-docutils-0.11-0.2.20130715svn7687.el7.noarch.rpm
-	wget ftp://rpmfind.net/linux/centos/7.0.1406/os/x86_64/Packages/python-sphinx-1.1.3-8.el7.noarch.rpm
+	wget ftp://rpmfind.net/linux/centos/7/os/x86_64/Packages/python-sphinx-1.1.3-8.el7.noarch.rpm
 	sudo yum install python-sphinx-1.1.3-8.el7.noarch.rpm
 
 Ceph documentation makes extensive use of `ditaa`_, which isn't presently built
@@ -346,9 +346,9 @@ Then, download them from a mirror and install them. For example::
 
 	wget ftp://rpmfind.net/linux/fedora/linux/releases/20/Everything/x86_64/os/Packages/j/jericho-html-3.2-6.fc20.noarch.rpm
 	sudo yum install jericho-html-3.2-6.fc20.noarch.rpm
-	wget ftp://rpmfind.net/linux/centos/7.0.1406/os/x86_64/Packages/jai-imageio-core-1.2-0.14.20100217cvs.el7.noarch.rpm
+	wget ftp://rpmfind.net/linux/centos/7/os/x86_64/Packages/jai-imageio-core-1.2-0.14.20100217cvs.el7.noarch.rpm
 	sudo yum install jai-imageio-core-1.2-0.14.20100217cvs.el7.noarch.rpm
-	wget ftp://rpmfind.net/linux/centos/7.0.1406/os/x86_64/Packages/batik-1.8-0.12.svn1230816.el7.noarch.rpm
+	wget ftp://rpmfind.net/linux/centos/7/os/x86_64/Packages/batik-1.8-0.12.svn1230816.el7.noarch.rpm
 	sudo yum install batik-1.8-0.12.svn1230816.el7.noarch.rpm
 	wget ftp://rpmfind.net/linux/fedora/linux/releases/20/Everything/x86_64/os/Packages/d/ditaa-0.9-10.r74.fc20.noarch.rpm
 	sudo yum install ditaa-0.9-10.r74.fc20.noarch.rpm
@@ -431,9 +431,9 @@ In CentOS/RHEL7, ``gitk`` and ``git-gui`` are not available in default or
 ``epel`` repository. So, use http://rpmfind.net/ to find them. Then, download
 them from a mirror and install them. For example::
 
-	wget ftp://rpmfind.net/linux/centos/7.0.1406/os/x86_64/Packages/gitk-1.8.3.1-4.el7.noarch.rpm
+	wget ftp://rpmfind.net/linux/centos/7/os/x86_64/Packages/gitk-1.8.3.1-4.el7.noarch.rpm
 	sudo yum install gitk-1.8.3.1-4.el7.noarch.rpm
-	wget ftp://rpmfind.net/linux/centos/7.0.1406/os/x86_64/Packages/git-gui-1.8.3.1-4.el7.noarch.rpm
+	wget ftp://rpmfind.net/linux/centos/7/os/x86_64/Packages/git-gui-1.8.3.1-4.el7.noarch.rpm
 	sudo yum install git-gui-1.8.3.1-4.el7.noarch.rpm
 
 Then, execute::


### PR DESCRIPTION
'make check' needs nosetests (python-nose) for some of the checks. Added a check to configure to make sure the package is installed.

Fixed also some links in documentation related to CentOS ftp server links.