### PR TITLE
FileJournal: fix check_for_full

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -751,8 +751,8 @@ int FileJournal::check_for_full(uint64_t seq, off64_t pos, off64_t size)
 	   << " top " << get_top() << dendl;
 
   if (do_sync_cond) {
-    if (room < (header.max_size >> 1) &&
-	room + size > (header.max_size >> 1)) {
+    if (room >= (header.max_size >> 1) &&
+        room - size < (header.max_size >> 1)) {
       dout(10) << " passing half full mark, triggering commit" << dendl;
       do_sync_cond->SloppySignal();  // initiate a real commit so we can trim
     }


### PR DESCRIPTION
The condition to test if journal is passing half full mark is
incorrect. Consider the following simplified case:

Assume header.max_size = 100 and journal has 48 bytes already.

1st write (10 bytes):
max=100, room=52, size=10  --> condition not satisfied

2nd write (4 bytes):
max=100, room=42, size=4   --> condition not satisfied

It passed the half full mark without triggering filestore commit.

Signed-off-by: Henry Chang <henry@bigtera.com>