### PR TITLE
osd/ReplicatedPG: need to queue op when avoiding dup promotion in maybe_handle_cache

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1852,6 +1852,9 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
 
     // Avoid duplicate promotion
     if (obc.get() && obc->is_blocked()) {
+      if (!can_proxy_read) {
+        wait_for_blocked_object(obc->obs.oi.soid, op);
+      }
       return true;
     }
 

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -1188,6 +1188,7 @@ public:
 	}
       }
     }
+    completion->release();
     context->kick();
     done = true;
     context->state_lock.Unlock();
@@ -1195,7 +1196,7 @@ public:
 
   bool finished()
   {
-    return done && completion->is_complete();
+    return done;
   }
 
   string getType()


### PR DESCRIPTION
Need to queue the op before returning from maybe_handle_cache.
Otherwise, this op is lost.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>