### PR TITLE
rgw: init-radosgw: run RGW as root

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -35,7 +35,7 @@ done
 PREFIX='client.radosgw.'
 
 # user to run radosgw as (it not specified in ceph.conf)
-DEFAULT_USER='www-data'
+DEFAULT_USER='root'
 
 RADOSGW=`which radosgw`
 if [ ! -x "$RADOSGW" ]; then

--- a/src/init-radosgw.sysv
+++ b/src/init-radosgw.sysv
@@ -37,7 +37,7 @@ PREFIX='client.radosgw.'
 
 # user to run radosgw as (it not specified in ceph.conf)
 #DEFAULT_USER='www-data'
-DEFAULT_USER='apache'
+DEFAULT_USER='root'
 
 RADOSGW=`which radosgw`
 if [ ! -x "$RADOSGW" ]; then


### PR DESCRIPTION
The ceph-radosgw service fails to start if the httpd package is not installed. This is because the init.d file attempts to start the RGW process with the "apache" UID. If a user is running civetweb, there is no reason for the httpd or apache2 package to be present on the system.

Switch the init scripts to use "root" as is done on Ubuntu.

http://tracker.ceph.com/issues/11453 Refs: #11453

Reported-by: Vickey Singh <vickey.singh22693@gmail.com>
(cherry picked from commit 47339c5ac352d305e68a58f3d744c3ce0fd3a2ac)