### PR TITLE
Wip 10809 11135 10290

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -616,10 +616,10 @@ int FileJournal::dump(ostream& out)
     }
     f.close_section();
     f.close_section();
-    f.flush(cout);
   }
 
   f.close_section();
+  f.flush(out);
   dout(10) << "dump finish" << dendl;
   return 0;
 }

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -588,8 +588,22 @@ int FileJournal::dump(ostream& out)
   read_pos = header.start;
 
   JSONFormatter f(true);
+  f.open_object_section("journal");
 
-  f.open_array_section("journal");
+  f.open_object_section("header");
+  f.dump_unsigned("flags", header.flags);
+  ostringstream os;
+  os << header.fsid;
+  f.dump_string("fsid", os.str());
+  f.dump_unsigned("block_size", header.block_size);
+  f.dump_unsigned("alignment", header.alignment);
+  f.dump_int("max_size", header.max_size);
+  f.dump_int("start", header.start);
+  f.dump_unsigned("committed_up_to", header.committed_up_to);
+  f.dump_unsigned("start_seq", header.start_seq);
+  f.close_section();
+
+  f.open_array_section("entries");
   uint64_t seq = 0;
   while (1) {
     bufferlist bl;
@@ -618,6 +632,7 @@ int FileJournal::dump(ostream& out)
     f.close_section();
   }
 
+  f.close_section();
   f.close_section();
   f.flush(out);
   dout(10) << "dump finish" << dendl;

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -1778,7 +1778,7 @@ bool FileJournal::read_entry(
   }
 
   stringstream errss;
-  if (seq < header.committed_up_to) {
+  if (seq && seq < header.committed_up_to) {
     derr << "Unable to read past sequence " << seq
 	 << " but header indicates the journal has committed up through "
 	 << header.committed_up_to << ", journal is corrupt" << dendl;

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -583,7 +583,15 @@ int FileJournal::simple_dump(ostream& out)
 
 int FileJournal::_dump(ostream& out, bool simple)
 {
-  dout(10) << "dump" << dendl;
+  JSONFormatter f(true);
+  int ret = _fdump(f, simple);
+  f.flush(out);
+  return ret;
+}
+
+int FileJournal::_fdump(Formatter &f, bool simple)
+{
+  dout(10) << "_fdump" << dendl;
 
   assert(fd == -1);
   int err = _open(false, false);
@@ -598,7 +606,6 @@ int FileJournal::_dump(ostream& out, bool simple)
 
   off64_t next_pos = header.start;
 
-  JSONFormatter f(true);
   f.open_object_section("journal");
 
   f.open_object_section("header");
@@ -669,7 +676,6 @@ int FileJournal::_dump(ostream& out, bool simple)
 
   f.close_section();
   f.close_section();
-  f.flush(out);
   dout(10) << "dump finish" << dendl;
 
   close();

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -1834,7 +1834,6 @@ bool FileJournal::read_entry(
     }
   }
 
-  stringstream errss;
   if (seq && seq < header.committed_up_to) {
     derr << "Unable to read past sequence " << seq
 	 << " but header indicates the journal has committed up through "
@@ -1848,7 +1847,7 @@ bool FileJournal::read_entry(
     }
   }
 
-  dout(25) << errss.str() << dendl;
+  dout(25) << ss.str() << dendl;
   dout(2) << "No further valid entries found, journal is most likely valid"
 	  << dendl;
   return false;

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -45,17 +45,6 @@ int FileJournal::_open(bool forwrite, bool create)
 {
   int flags, ret;
 
-  if (aio && !directio) {
-    derr << "FileJournal::_open: aio not supported without directio; disabling aio" << dendl;
-    aio = false;
-  }
-#ifndef HAVE_LIBAIO
-  if (aio) {
-    derr << "FileJournal::_open: libaio not compiled in; disabling aio" << dendl;
-    aio = false;
-  }
-#endif
-
   if (forwrite) {
     flags = O_RDWR;
     if (directio)
@@ -331,15 +320,17 @@ int FileJournal::_open_file(int64_t oldsize, blksize_t blksize,
   return 0;
 }
 
+// This can not be used on an active journal
 int FileJournal::check()
 {
   int ret;
 
+  assert(fd == -1);
   ret = _open(false, false);
   if (ret)
-    goto done;
+    return ret;
 
-  ret = read_header();
+  ret = read_header(&header);
   if (ret < 0)
     goto done;
 
@@ -354,8 +345,7 @@ int FileJournal::check()
   ret = 0;
 
  done:
-  VOID_TEMP_FAILURE_RETRY(::close(fd));
-  fd = -1;
+  close();
   return ret;
 }
 
@@ -386,7 +376,7 @@ int FileJournal::create()
   header.start = get_top();
   header.start_seq = 0;
 
-  print_header();
+  print_header(header);
 
   // static zeroed buffer for alignment padding
   delete [] zero_buf;
@@ -443,16 +433,20 @@ done:
   return ret;
 }
 
+// This can not be used on an active journal
 int FileJournal::peek_fsid(uuid_d& fsid)
 {
+  assert(fd == -1);
   int r = _open(false, false);
   if (r)
     return r;
-  r = read_header();
+  r = read_header(&header);
   if (r < 0)
-    return r;
+    goto out;
   fsid = header.fsid;
-  return 0;
+out:
+  close();
+  return r;
 }
 
 int FileJournal::open(uint64_t fs_op_seq)
@@ -470,7 +464,7 @@ int FileJournal::open(uint64_t fs_op_seq)
   write_pos = get_top();
 
   // read header?
-  err = read_header();
+  err = read_header(&header);
   if (err < 0)
     return err;
 
@@ -556,6 +550,11 @@ int FileJournal::open(uint64_t fs_op_seq)
   return 0;
 }
 
+void FileJournal::_close(int fd) const
+{
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
+}
+
 void FileJournal::close()
 {
   dout(1) << "close " << fn << dendl;
@@ -567,25 +566,27 @@ void FileJournal::close()
   assert(writeq_empty());
   assert(!must_write_header);
   assert(fd >= 0);
-  VOID_TEMP_FAILURE_RETRY(::close(fd));
+  _close(fd);
   fd = -1;
 }
 
 
 int FileJournal::dump(ostream& out)
 {
-  int err = 0;
-
   dout(10) << "dump" << dendl;
-  err = _open(false, false);
+
+  assert(fd == -1);
+  int err = _open(false, false);
   if (err)
     return err;
 
-  err = read_header();
-  if (err < 0)
+  err = read_header(&header);
+  if (err < 0) {
+    close();
     return err;
+  }
 
-  read_pos = header.start;
+  off64_t next_pos = header.start;
 
   JSONFormatter f(true);
   f.open_object_section("journal");
@@ -604,12 +605,32 @@ int FileJournal::dump(ostream& out)
   f.close_section();
 
   f.open_array_section("entries");
-  uint64_t seq = 0;
+  uint64_t seq = header.start_seq;
   while (1) {
     bufferlist bl;
-    uint64_t pos = read_pos;
-    if (!read_entry(bl, seq)) {
-      dout(3) << "journal_replay: end of journal, done." << dendl;
+    off64_t pos = next_pos;
+
+    if (!pos) {
+      dout(2) << "_dump -- not readable" << dendl;
+      return false;
+    }
+    stringstream ss;
+    read_entry_result result = do_read_entry(
+      pos,
+      &next_pos,
+      &bl,
+      &seq,
+      &ss);
+    if (result != SUCCESS) {
+      if (seq < header.committed_up_to) {
+        dout(2) << "Unable to read past sequence " << seq
+	    << " but header indicates the journal has committed up through "
+	    << header.committed_up_to << ", journal is corrupt" << dendl;
+        err = EINVAL;
+      }
+      dout(25) << ss.str() << dendl;
+      dout(25) << "No further valid entries found, journal is most likely valid"
+	  << dendl;
       break;
     }
 
@@ -636,7 +657,9 @@ int FileJournal::dump(ostream& out)
   f.close_section();
   f.flush(out);
   dout(10) << "dump finish" << dendl;
-  return 0;
+
+  close();
+  return err;
 }
 
 
@@ -653,24 +676,28 @@ void FileJournal::start_writer()
 
 void FileJournal::stop_writer()
 {
+  // Do nothing if writer already stopped or never started
+  if (!write_stop)
   {
-    Mutex::Locker l(write_lock);
-    Mutex::Locker p(writeq_lock);
-    write_stop = true;
-    writeq_cond.Signal();
-    // Doesn't hurt to signal commit_cond in case thread is waiting there
-    // and caller didn't use committed_thru() first.
-    commit_cond.Signal();
-  }
-  write_thread.join();
+    {
+      Mutex::Locker l(write_lock);
+      Mutex::Locker p(writeq_lock);
+      write_stop = true;
+      writeq_cond.Signal();
+      // Doesn't hurt to signal commit_cond in case thread is waiting there
+      // and caller didn't use committed_thru() first.
+      commit_cond.Signal();
+    }
+    write_thread.join();
 
-  // write journal header now so that we have less to replay on remount
-  write_header_sync();
+    // write journal header now so that we have less to replay on remount
+    write_header_sync();
+  }
 
 #ifdef HAVE_LIBAIO
   // stop aio completeion thread *after* writer thread has stopped
   // and has submitted all of its io
-  if (aio) {
+  if (aio && !aio_stop) {
     aio_lock.Lock();
     aio_stop = true;
     aio_cond.Signal();
@@ -683,7 +710,7 @@ void FileJournal::stop_writer()
 
 
 
-void FileJournal::print_header()
+void FileJournal::print_header(const header_t &header) const
 {
   dout(10) << "header: block_size " << header.block_size
 	   << " alignment " << header.alignment
@@ -693,7 +720,7 @@ void FileJournal::print_header()
   dout(10) << " write_pos " << write_pos << dendl;
 }
 
-int FileJournal::read_header()
+int FileJournal::read_header(header_t *hdr) const
 {
   dout(10) << "read_header" << dendl;
   bufferlist bl;
@@ -712,7 +739,7 @@ int FileJournal::read_header()
 
   try {
     bufferlist::iterator p = bl.begin();
-    ::decode(header, p);
+    ::decode(*hdr, p);
   }
   catch (buffer::error& e) {
     derr << "read_header error decoding journal header" << dendl;
@@ -727,12 +754,12 @@ int FileJournal::read_header()
    * remove this or else this (eventually old) code will clobber newer
    * code's flags.
    */
-  if (header.flags > 3) {
+  if (hdr->flags > 3) {
     derr << "read_header appears to have gibberish flags; assuming 0" << dendl;
-    header.flags = 0;
+    hdr->flags = 0;
   }
 
-  print_header();
+  print_header(*hdr);
 
   return 0;
 }
@@ -834,7 +861,7 @@ int FileJournal::prepare_multi_write(bufferlist& bl, uint64_t& orig_ops, uint64_
 	  put_throttle(1, peek_write().bl.length());
 	  pop_write();
 	}  
-	print_header();
+	print_header(header);
       }
 
       return -ENOSPC;  // hrm, full on first op
@@ -1241,7 +1268,7 @@ void FileJournal::write_thread_entry()
 	  put_throttle(1, peek_write().bl.length());
 	  pop_write();
 	}  
-	print_header();
+	print_header(header);
 	r = 0;
       } else {
 	dout(20) << "write_thread_entry full, going to sleep (waiting for commit)" << dendl;
@@ -1666,7 +1693,7 @@ void FileJournal::committed_thru(uint64_t seq)
   }
 
   must_write_header = true;
-  print_header();
+  print_header(header);
 
   // committed but unjournaled items
   while (!writeq_empty() && peek_write().seq <= seq) {
@@ -1725,7 +1752,7 @@ void FileJournal::wrap_read_bl(
   int64_t olen,
   bufferlist* bl,
   off64_t *out_pos
-  )
+  ) const
 {
   while (olen > 0) {
     while (pos >= header.max_size)
@@ -1781,6 +1808,7 @@ bool FileJournal::read_entry(
     &seq,
     &ss);
   if (result == SUCCESS) {
+    journalq.push_back( pair<uint64_t,off64_t>(seq, pos));
     if (next_seq > seq) {
       return false;
     } else {
@@ -1818,7 +1846,7 @@ FileJournal::read_entry_result FileJournal::do_read_entry(
   bufferlist *bl,
   uint64_t *seq,
   ostream *ss,
-  entry_header_t *_h)
+  entry_header_t *_h) const
 {
   off64_t cur_pos = init_pos;
   bufferlist _bl;
@@ -1888,11 +1916,6 @@ FileJournal::read_entry_result FileJournal::do_read_entry(
   if (seq)
     *seq = h->seq;
 
-  // works around an apparent GCC 4.8(?) compiler bug about unaligned
-  // bind by reference to (packed) h->seq
-  journalq.push_back(
-    pair<uint64_t,off64_t>(static_cast<uint64_t>(h->seq),
-			   static_cast<off64_t>(init_pos)));
 
   if (next_pos)
     *next_pos = cur_pos;

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -1958,6 +1958,7 @@ void FileJournal::get_header(
   off64_t next_pos = pos;
   bufferlist bl;
   uint64_t seq = 0;
+  dout(2) << __func__ << dendl;
   while (1) {
     bl.clear();
     pos = next_pos;
@@ -1983,6 +1984,7 @@ void FileJournal::corrupt(
   int wfd,
   off64_t corrupt_at)
 {
+  dout(2) << __func__ << dendl;
   if (corrupt_at >= header.max_size)
     corrupt_at = corrupt_at + get_top() - header.max_size;
 
@@ -2005,6 +2007,7 @@ void FileJournal::corrupt_payload(
   int wfd,
   uint64_t seq)
 {
+  dout(2) << __func__ << dendl;
   off64_t pos = 0;
   entry_header_t h;
   get_header(seq, &pos, &h);
@@ -2018,6 +2021,7 @@ void FileJournal::corrupt_footer_magic(
   int wfd,
   uint64_t seq)
 {
+  dout(2) << __func__ << dendl;
   off64_t pos = 0;
   entry_header_t h;
   get_header(seq, &pos, &h);
@@ -2033,6 +2037,7 @@ void FileJournal::corrupt_header_magic(
   int wfd,
   uint64_t seq)
 {
+  dout(2) << __func__ << dendl;
   off64_t pos = 0;
   entry_header_t h;
   get_header(seq, &pos, &h);

--- a/src/os/FileJournal.h
+++ b/src/os/FileJournal.h
@@ -297,6 +297,7 @@ private:
   void _close(int fd) const;
   void _check_disk_write_cache() const;
   int _open_file(int64_t oldsize, blksize_t blksize, bool create);
+  int _dump(ostream& out, bool simple);
   void print_header(const header_t &hdr) const;
   int read_header(header_t *hdr) const;
   bufferptr prepare_header();
@@ -411,6 +412,7 @@ private:
   int peek_fsid(uuid_d& fsid);
 
   int dump(ostream& out);
+  int simple_dump(ostream& out);
 
   void flush();
 

--- a/src/os/FileJournal.h
+++ b/src/os/FileJournal.h
@@ -415,6 +415,7 @@ private:
 
   int dump(ostream& out);
   int simple_dump(ostream& out);
+  int _fdump(Formatter &f, bool simple);
 
   void flush();
 

--- a/src/os/FileJournal.h
+++ b/src/os/FileJournal.h
@@ -214,6 +214,8 @@ public:
     }
   } __attribute__((__packed__, aligned(4)));
 
+  bool journalq_empty() { return journalq.empty(); }
+
 private:
   string fn;
 

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -658,7 +658,7 @@ int FileStore::statfs(struct statfs *buf)
 }
 
 
-int FileStore::open_journal()
+void FileStore::new_journal()
 {
   if (journalpath.length()) {
     dout(10) << "open_journal at " << journalpath << dendl;
@@ -667,7 +667,7 @@ int FileStore::open_journal()
     if (journal)
       journal->logger = logger;
   }
-  return 0;
+  return;
 }
 
 int FileStore::dump_journal(ostream& out)
@@ -915,7 +915,7 @@ int FileStore::mkjournal()
 
   ret = 0;
 
-  open_journal();
+  new_journal();
   if (journal) {
     ret = journal->check();
     if (ret < 0) {
@@ -1497,7 +1497,7 @@ int FileStore::mount()
   }
 
   // journal
-  open_journal();
+  new_journal();
 
   // select journal mode?
   if (journal) {

--- a/src/os/FileStore.h
+++ b/src/os/FileStore.h
@@ -376,7 +376,7 @@ private:
   void _journaled_ahead(OpSequencer *osr, Op *o, Context *ondisk);
   friend struct C_JournaledAhead;
 
-  int open_journal();
+  void new_journal();
 
   PerfCounters *logger;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2019,6 +2019,13 @@ void OSD::final_init()
     test_ops_hook,
     "inject metadata error");
   assert(r == 0);
+  r = admin_socket->register_command(
+    "set_recovery_delay",
+    "set_recovery_delay " \
+    "name=utime,type=CephInt,req=false",
+    test_ops_hook,
+     "Delay osd recovery by specified seconds");
+  assert(r == 0);
 }
 
 void OSD::create_logger()
@@ -2276,6 +2283,7 @@ int OSD::shutdown()
   cct->get_admin_socket()->unregister_command("truncobj");
   cct->get_admin_socket()->unregister_command("injectdataerr");
   cct->get_admin_socket()->unregister_command("injectmdataerr");
+  cct->get_admin_socket()->unregister_command("set_recovery_delay");
   delete test_ops_hook;
   test_ops_hook = NULL;
 
@@ -3963,6 +3971,8 @@ void OSD::check_ops_in_flight()
 //   truncobj <pool-id> [namespace/]<obj-name> <newlen>
 //   injectmdataerr [namespace/]<obj-name> [shardid]
 //   injectdataerr [namespace/]<obj-name> [shardid]
+//
+//   set_recovery_delay [utime]
 void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
      std::string command, cmdmap_t& cmdmap, ostream &ss)
 {
@@ -4089,6 +4099,24 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       store->inject_mdata_error(gobj);
       ss << "ok";
     }
+    return;
+  }
+  if (command == "set_recovery_delay") {
+    int64_t delay;
+    cmd_getval(service->cct, cmdmap, "utime", delay, (int64_t)0);
+    ostringstream oss;
+    oss << delay;
+    int r = service->cct->_conf->set_val("osd_recovery_delay_start",
+					 oss.str().c_str());
+    if (r != 0) {
+      ss << "set_recovery_delay: error setting "
+	 << "osd_recovery_delay_start to '" << delay << "': error "
+	 << r;
+      return;
+    }
+    service->cct->_conf->apply_changes(NULL);
+    ss << "set_recovery_delay: set osd_recovery_delay_start "
+       << "to " << service->cct->_conf->osd_recovery_delay_start;
     return;
   }
   ss << "Internal error - command=" << command;

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -727,10 +727,12 @@ void PGLog::write_log(
   const coll_t& coll, const ghobject_t &log_oid)
 {
   if (is_dirty()) {
-    dout(10) << "write_log with: "
+    dout(5) << "write_log with: "
 	     << "dirty_to: " << dirty_to
 	     << ", dirty_from: " << dirty_from
-	     << ", dirty_divergent_priors: " << dirty_divergent_priors
+	     << ", dirty_divergent_priors: "
+	     << (dirty_divergent_priors ? "true" : "false")
+	     << ", divergent_priors: " << divergent_priors.size()
 	     << ", writeout_from: " << writeout_from
 	     << ", trimmed: " << trimmed
 	     << dendl;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -4613,7 +4613,6 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	result = -EOPNOTSUPP;
 	break;
       }
-      ++ctx->num_read;
       {
 	vector<OSDOp> nops(1);
 	OSDOp& newop = nops[0];
@@ -4631,7 +4630,6 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	result = -EOPNOTSUPP;
 	break;
       }
-      ++ctx->num_write;
       {
 	//_dout_lock.Lock();
 	//osd_op.data.hexdump(*_dout);

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -124,10 +124,10 @@ def cat_file(level, filename):
     print "<EOF>"
 
 
-def vstart(new):
+def vstart(new, opt=""):
     print "vstarting....",
-    OPT = new and "-n" or ""
-    call("MON=1 OSD=4 CEPH_PORT=7400 ./vstart.sh -l {opt} -d mon osd > /dev/null 2>&1".format(opt=OPT), shell=True)
+    NEW = new and "-n" or ""
+    call("MON=1 OSD=4 CEPH_PORT=7400 ./vstart.sh -l {new} -d mon osd {opt} > /dev/null 2>&1".format(new=NEW, opt=opt), shell=True)
     print "DONE"
 
 

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -34,7 +34,10 @@ logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.WARNING)
 
 def wait_for_health():
     print "Wait for health_ok...",
+    tries = 0
     while call("./ceph health 2> /dev/null | grep -v 'HEALTH_OK\|HEALTH_WARN' > /dev/null", shell=True) == 0:
+        if ++tries == 30:
+            raise Exception("Time exceeded to go to health")
         time.sleep(5)
     print "DONE"
 

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -474,6 +474,13 @@ def main(argv):
     cmd = "./ceph-objectstore-tool --type filestore --data-path {dir}/{osd} --op list --pgid {pg}".format(dir=OSDDIR, osd=ONEOSD, pg=ONEPG)
     ERRORS += test_failure(cmd, "Must provide --journal-path")
 
+    cmd = (CFSD_PREFIX + "--op remove").format(osd=ONEOSD)
+    ERRORS += test_failure(cmd, "Must provide pgid")
+
+    # Don't secify a --op
+    cmd = CFSD_PREFIX.format(osd=ONEOSD)
+    ERRORS += test_failure(cmd, "Must provide --op or object command...")
+
     # Test --op list and generate json for all objects
     TMPFILE = r"/tmp/tmp.{pid}".format(pid=pid)
     ALLPGS = OBJREPPGS + OBJECPGS

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -739,6 +739,7 @@ def main(argv):
                     if ret != 0:
                         logging.error("Bad exit status {ret} from set-bytes to restore object".format(ret=ret))
                         ERRORS += 1
+                    fd.close()
 
     try:
         os.unlink(GETNAME)

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -392,7 +392,7 @@ def main(argv):
             logging.debug(cmd)
             ret = call(cmd, shell=True, stderr=nullfd)
             if ret != 0:
-                logging.critical("Replicated pool object creation failed with {ret}".format(ret=ret))
+                logging.critical("Rados put command failed with {ret}".format(ret=ret))
                 return 1
 
             db[nspace][NAME] = {}

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -299,7 +299,7 @@ def main(argv):
     sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
     nullfd = open(os.devnull, "w")
 
-    call("rm -fr ceph_objectstore_tool_dir ; mkdir ceph_objectstore_tool_dir", shell=True)
+    call("rm -fr {dir}; mkdir {dir}".format(dir=CEPH_DIR), shell=True)
     os.environ["CEPH_DIR"] = CEPH_DIR
     OSDDIR = os.path.join(CEPH_DIR, "dev")
     REP_POOL = "rep_pool"
@@ -1033,5 +1033,5 @@ if __name__ == "__main__":
         status = main(sys.argv[1:])
     finally:
         kill_daemons()
-        call("/bin/rm -fr ceph_objectstore_tool_dir", shell=True)
+        call("/bin/rm -fr {dir}".format(dir=CEPH_DIR), shell=True)
     sys.exit(status)

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -525,7 +525,7 @@ def main(argv):
     # retrieve all objects with a given name in a given PG
     cmd = (CFSD_PREFIX + "--op list --pgid {pg} {object} --format json").format(osd=osd, pg=pgid, object=jsondict['oid'])
     logging.debug(cmd);
-    tmpfd = open(OTHERFILE, "a")
+    tmpfd = open(OTHERFILE, "w")
     logging.debug(cmd)
     ret = call(cmd, shell=True, stdout=tmpfd)
     if ret != 0:

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -206,6 +206,84 @@ def verify(DATADIR, POOL, NAME_PREFIX):
             pass
     return ERRORS
 
+
+def check_journal(jsondict):
+    errors = 0
+    if 'header' not in jsondict:
+        logging.error("Key 'header' not in dump-journal")
+        errors += 1
+    elif 'max_size' not in jsondict['header']:
+        logging.error("Key 'max_size' not in dump-journal header")
+        errors += 1
+    else:
+        print "\tJournal max_size = {size}".format(size=jsondict['header']['max_size'])
+    if 'entries' not in jsondict:
+        logging.error("Key 'entries' not in dump-journal output")
+        errors += 1
+    elif len(jsondict['entries']) == 0:
+        logging.warning("No entries in journal found, probably a problem")
+        errors += 1
+    else:
+        errors += check_journal_entries(jsondict['entries'])
+    return errors
+
+
+def check_journal_entries(entries):
+    errors = 0
+    for enum in range(len(entries)):
+        if 'offset' not in entries[enum]:
+            logging.error("No 'offset' key in entry {e}".format(e=enum))
+            errors += 1
+        if 'seq' not in entries[enum]:
+            logging.error("No 'seq' key in entry {e}".format(e=enum))
+            errors += 1
+        if 'transactions' not in entries[enum]:
+            logging.error("No 'transactions' key in entry {e}".format(e=enum))
+            errors += 1
+        elif len(entries[enum]['transactions']) == 0:
+            logging.error("No transactions found in entry {e}".format(e=enum))
+            errors += 1
+        else:
+            errors += check_entry_transactions(entries[enum], enum)
+    return errors
+
+
+def check_entry_transactions(entry, enum):
+    errors = 0
+    for tnum in range(len(entry['transactions'])):
+        if 'trans_num' not in entry['transactions'][tnum]:
+            logging.error("Key 'trans_num' missing from entry {e} trans {t}".format(e=enum, t=tnum))
+            errors += 1
+        elif entry['transactions'][tnum]['trans_num'] != tnum:
+            ft = entry['transactions'][tnum]['trans_num']
+            logging.error("Bad trans_num ({ft}) entry {e} trans {t}".format(ft=ft, e=enum, t=tnum))
+            errors += 1
+        if 'ops' not in entry['transactions'][tnum]:
+            logging.error("Key 'ops' missing from entry {e} trans {t}".format(e=enum, t=tnum))
+            errors += 1
+        else:
+            errors += check_transaction_ops(entry['transactions'][tnum]['ops'], enum, tnum)
+    return errors
+
+
+def check_transaction_ops(ops, enum, tnum):
+    if len(ops) is 0:
+        logging.warning("No ops found in entry {e} trans {t}".format(e=enum, t=tnum))
+    errors = 0
+    for onum in range(len(ops)):
+        if 'op_num' not in ops[onum]:
+            logging.error("Key 'op_num' missing from entry {e} trans {t} op {o}".format(e=enum, t=tnum, o=onum))
+            errors += 1
+        elif ops[onum]['op_num'] != onum:
+            fo = ops[onum]['op_num']
+            logging.error("Bad op_num ({fo}) from entry {e} trans {t} op {o}".format(fo=fo, e=enum, t=tnum, o=onum))
+            errors += 1
+        if 'op_name' not in ops[onum]:
+            logging.error("Key 'op_name' missing from entry {e} trans {t} op {o}".format(e=enum, t=tnum, o=onum))
+            errors += 1
+    return errors
+
+
 CEPH_DIR = "ceph_objectstore_tool_dir"
 CEPH_CONF = os.path.join(CEPH_DIR, 'ceph.conf')
 
@@ -486,18 +564,38 @@ def main(argv):
     cmd = CFSD_PREFIX.format(osd=ONEOSD)
     ERRORS += test_failure(cmd, "Must provide --op or object command...")
 
-    # Test --op list and generate json for all objects
     TMPFILE = r"/tmp/tmp.{pid}".format(pid=pid)
     ALLPGS = OBJREPPGS + OBJECPGS
-
-    print "Test --op list variants"
     OSDS = get_osds(ALLPGS[0], OSDDIR)
     osd = OSDS[0]
+
+    # Test --op dump-journal by loading json
+    print "Test --op dump-journal"
+    cmd = (CFSD_PREFIX + "--op dump-journal --format json").format(osd=osd)
+    logging.debug(cmd)
+    tmpfd = open(TMPFILE, "w")
+    ret = call(cmd, shell=True, stdout=tmpfd)
+    if ret != 0:
+        logging.error("Bad exit status {ret} from {cmd}".format(ret=ret, cmd=cmd))
+        ERRORS += 1
+    tmpfd.close()
+    tmpfd = open(TMPFILE, "r")
+    jsondict = json.load(tmpfd)
+    tmpfd.close()
+    os.unlink(TMPFILE)
+
+    journal_errors = check_journal(jsondict)
+    if journal_errors is not 0:
+        logging.error(jsondict)
+    ERRORS += journal_errors
+
+    # Test --op list and generate json for all objects
+    print "Test --op list variants"
 
     # retrieve all objects from all PGs
     cmd = (CFSD_PREFIX + "--op list --format json").format(osd=osd)
     logging.debug(cmd)
-    tmpfd = open(TMPFILE, "a")
+    tmpfd = open(TMPFILE, "w")
     logging.debug(cmd)
     ret = call(cmd, shell=True, stdout=tmpfd)
     if ret != 0:

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -596,9 +596,8 @@ def main(argv):
     print "Test --op list variants"
 
     # retrieve all objects from all PGs
-    cmd = (CFSD_PREFIX + "--op list --format json").format(osd=osd)
-    logging.debug(cmd)
     tmpfd = open(TMPFILE, "w")
+    cmd = (CFSD_PREFIX + "--op list --format json").format(osd=osd)
     logging.debug(cmd)
     ret = call(cmd, shell=True, stdout=tmpfd)
     if ret != 0:
@@ -610,9 +609,8 @@ def main(argv):
     (pgid, jsondict) = json.loads(JSONOBJ[0])[0]
 
     # retrieve all objects in a given PG
-    cmd = (CFSD_PREFIX + "--op list --pgid {pg} --format json").format(osd=osd, pg=pgid)
-    logging.debug(cmd)
     tmpfd = open(OTHERFILE, "a")
+    cmd = (CFSD_PREFIX + "--op list --pgid {pg} --format json").format(osd=osd, pg=pgid)
     logging.debug(cmd)
     ret = call(cmd, shell=True, stdout=tmpfd)
     if ret != 0:
@@ -629,9 +627,8 @@ def main(argv):
         ERRORS += 1
 
     # retrieve all objects with a given name in a given PG
-    cmd = (CFSD_PREFIX + "--op list --pgid {pg} {object} --format json").format(osd=osd, pg=pgid, object=jsondict['oid'])
-    logging.debug(cmd)
     tmpfd = open(OTHERFILE, "w")
+    cmd = (CFSD_PREFIX + "--op list --pgid {pg} {object} --format json").format(osd=osd, pg=pgid, object=jsondict['oid'])
     logging.debug(cmd)
     ret = call(cmd, shell=True, stdout=tmpfd)
     if ret != 0:
@@ -651,8 +648,8 @@ def main(argv):
     for pg in ALLPGS:
         OSDS = get_osds(pg, OSDDIR)
         for osd in OSDS:
-            cmd = (CFSD_PREFIX + "--op list --pgid {pg}").format(osd=osd, pg=pg)
             tmpfd = open(TMPFILE, "a")
+            cmd = (CFSD_PREFIX + "--op list --pgid {pg}").format(osd=osd, pg=pg)
             logging.debug(cmd)
             ret = call(cmd, shell=True, stdout=tmpfd)
             if ret != 0:

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -676,6 +676,7 @@ def main(argv):
             GETNAME = "/tmp/getbytes.{pid}".format(pid=pid)
             TESTNAME = "/tmp/testbytes.{pid}".format(pid=pid)
             SETNAME = "/tmp/setbytes.{pid}".format(pid=pid)
+            BADNAME = "/tmp/badbytes.{pid}".format(pid=pid)
             for pg in OBJREPPGS:
                 OSDS = get_osds(pg, OSDDIR)
                 for osd in OSDS:
@@ -732,6 +733,37 @@ def main(argv):
                         logging.debug("Expected:")
                         cat_file(logging.DEBUG, SETNAME)
                         ERRORS += 1
+
+                    # Use set-bytes with --dry-run and make sure contents haven't changed
+                    fd = open(BADNAME, "w")
+                    data = "Bad data for --dry-run in {file}\n".format(file=file)
+                    fd.write(data)
+                    fd.close()
+                    cmd = (CFSD_PREFIX + "--dry-run --pgid {pg} '{json}' set-bytes {sname}").format(osd=osd, pg=pg, json=JSON, sname=BADNAME)
+                    logging.debug(cmd)
+                    ret = call(cmd, shell=True, stdout=nullfd, stderr=nullfd)
+                    if ret != 0:
+                        logging.error("Bad exit status {ret} from set-bytes --dry-run".format(ret=ret))
+                        ERRORS += 1
+                    fd = open(TESTNAME, "w")
+                    cmd = (CFSD_PREFIX + "--pgid {pg} '{json}' get-bytes -").format(osd=osd, pg=pg, json=JSON)
+                    logging.debug(cmd)
+                    ret = call(cmd, shell=True, stdout=fd)
+                    fd.close()
+                    if ret != 0:
+                        logging.error("Bad exit status {ret} from get-bytes".format(ret=ret))
+                        ERRORS += 1
+                    cmd = "diff -q {setfile} {testfile}".format(setfile=SETNAME, testfile=TESTNAME)
+                    logging.debug(cmd)
+                    ret = call(cmd, shell=True)
+                    if ret != 0:
+                        logging.error("Data after set-bytes --dry-run changed!")
+                        logging.debug("Got:")
+                        cat_file(logging.DEBUG, TESTNAME)
+                        logging.debug("Expected:")
+                        cat_file(logging.DEBUG, SETNAME)
+                        ERRORS += 1
+
                     fd = open(file, "r")
                     cmd = (CFSD_PREFIX + "--pgid {pg} '{json}' set-bytes").format(osd=osd, pg=pg, json=JSON)
                     logging.debug(cmd)
@@ -751,6 +783,10 @@ def main(argv):
         pass
     try:
         os.unlink(SETNAME)
+    except:
+        pass
+    try:
+        os.unlink(BADNAME)
     except:
         pass
 
@@ -895,11 +931,38 @@ def main(argv):
             logging.error("Got {pgs}".format(pgs=TEST_PGS))
             ERRORS += 1
 
-    print "Test pg export"
     EXP_ERRORS = 0
+    print "Test pg export --dry-run"
+    pg = ALLREPPGS[0]
+    osd = get_osds(pg, OSDDIR)[0]
+    fname = "/tmp/fname.{pid}".format(pid=pid)
+    cmd = (CFSD_PREFIX + "--dry-run --op export --pgid {pg} --file {file}").format(osd=osd, pg=pg, file=fname)
+    logging.debug(cmd)
+    ret = call(cmd, shell=True, stdout=nullfd, stderr=nullfd)
+    if ret != 0:
+        logging.error("Exporting --dry-run failed for pg {pg} on {osd} with {ret}".format(pg=pg, osd=osd, ret=ret))
+        EXP_ERRORS += 1
+    elif os.path.exists(fname):
+        logging.error("Exporting --dry-run created file")
+        EXP_ERRORS += 1
+
+    cmd = (CFSD_PREFIX + "--dry-run --op export --pgid {pg} > {file}").format(osd=osd, pg=pg, file=fname)
+    logging.debug(cmd)
+    ret = call(cmd, shell=True, stdout=nullfd, stderr=nullfd)
+    if ret != 0:
+        logging.error("Exporting --dry-run failed for pg {pg} on {osd} with {ret}".format(pg=pg, osd=osd, ret=ret))
+        EXP_ERRORS += 1
+    else:
+        outdata = get_lines(fname)
+        if len(outdata) > 0:
+            logging.error("Exporting --dry-run to stdout not empty")
+            logging.error("Data: " + outdata)
+            EXP_ERRORS += 1
+
     os.mkdir(TESTDIR)
     for osd in [f for f in os.listdir(OSDDIR) if os.path.isdir(os.path.join(OSDDIR, f)) and string.find(f, "osd") == 0]:
         os.mkdir(os.path.join(TESTDIR, osd))
+    print "Test pg export"
     for pg in ALLREPPGS + ALLECPGS:
         for osd in get_osds(pg, OSDDIR):
             mydir = os.path.join(TESTDIR, osd)
@@ -922,6 +985,13 @@ def main(argv):
     RM_ERRORS = 0
     for pg in ALLREPPGS + ALLECPGS:
         for osd in get_osds(pg, OSDDIR):
+            # This should do nothing
+            cmd = (CFSD_PREFIX + "--op remove --pgid {pg} --dry-run").format(pg=pg, osd=osd)
+            logging.debug(cmd)
+            ret = call(cmd, shell=True, stdout=nullfd)
+            if ret != 0:
+                logging.error("Removing --dry-run failed for pg {pg} on {osd} with {ret}".format(pg=pg, osd=osd, ret=ret))
+                RM_ERRORS += 1
             cmd = (CFSD_PREFIX + "--op remove --pgid {pg}").format(pg=pg, osd=osd)
             logging.debug(cmd)
             ret = call(cmd, shell=True, stdout=nullfd)
@@ -939,6 +1009,13 @@ def main(argv):
             PGS = [f for f in os.listdir(dir) if os.path.isfile(os.path.join(dir, f))]
             for pg in PGS:
                 file = os.path.join(dir, pg)
+                # This should do nothing
+                cmd = (CFSD_PREFIX + "--op import --file {file} --dry-run").format(osd=osd, file=file)
+                logging.debug(cmd)
+                ret = call(cmd, shell=True, stdout=nullfd)
+                if ret != 0:
+                    logging.error("Import failed from {file} with {ret}".format(file=file, ret=ret))
+                    IMP_ERRORS += 1
                 if pg == PGS[0]:
                     cmd = ("cat {file} |".format(file=file) + CFSD_PREFIX + "--op import").format(osd=osd)
                 elif pg == PGS[1]:
@@ -1004,6 +1081,13 @@ def main(argv):
                 if string.find(pg, "{id}.".format(id=REPID)) != 0:
                     continue
                 file = os.path.join(dir, pg)
+                # This should do nothing
+                cmd = "./ceph-objectstore-tool --dry-run import-rados {pool} {file}".format(pool=NEWPOOL, file=file)
+                logging.debug(cmd)
+                ret = call(cmd, shell=True, stdout=nullfd)
+                if ret != 0:
+                    logging.error("Import-rados failed from {file} with {ret}".format(file=file, ret=ret))
+                    ERRORS += 1
                 cmd = "./ceph-objectstore-tool import-rados {pool} {file}".format(pool=NEWPOOL, file=file)
                 logging.debug(cmd)
                 ret = call(cmd, shell=True, stdout=nullfd)

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -1094,6 +1094,12 @@ def main(argv):
                 if ret != 0:
                     logging.error("Import-rados failed from {file} with {ret}".format(file=file, ret=ret))
                     ERRORS += 1
+                cmd = "./ceph-objectstore-tool --no-overwrite import-rados {pool} {file}".format(pool=NEWPOOL, file=file)
+                logging.debug(cmd)
+                ret = call(cmd, shell=True, stdout=nullfd)
+                if ret != 0:
+                    logging.error("Import-rados failed from {file} with {ret}".format(file=file, ret=ret))
+                    ERRORS += 1
 
         ERRORS += verify(DATADIR, NEWPOOL, REP_NAME)
     else:

--- a/src/test/encoding/ceph_dencoder.cc
+++ b/src/test/encoding/ceph_dencoder.cc
@@ -23,6 +23,8 @@
 #undef TYPE_NOCOPY
 #undef MESSAGE
 
+#define MB(m) ((m) * 1024 * 1024)
+
 void usage(ostream &out)
 {
   out << "usage: ceph-dencoder [commands ...]" << std::endl;
@@ -358,7 +360,14 @@ int main(int argc, const char **argv)
 	usage(cerr);
 	exit(1);
       }
-      int r = encbl.read_file(*i, &err);
+      int r;
+      if (*i == string("-")) {
+        *i = "stdin";
+	// Read up to 1mb if stdin specified
+	r = encbl.read_fd(STDIN_FILENO, MB(1));
+      } else {
+	r = encbl.read_file(*i, &err);
+      }
       if (r < 0) {
         cerr << "error reading " << *i << ": " << err << std::endl;
         exit(1);

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -370,7 +370,7 @@ TEST(TestFileJournal, WriteTrim) {
 
 TEST(TestFileJournal, WriteTrimSmall) {
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
 

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -360,8 +360,10 @@ TEST(TestFileJournal, WriteTrim) {
   while (ls.size()) {
     delete ls.front();
     ls.pop_front();
-    j.committed_thru(committed);
+    j.committed_thru(++committed);
   }
+
+  ASSERT_TRUE(j.journalq_empty());
 
   j.close();
 }

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -19,6 +19,7 @@ char path[200];
 uuid_d fsid;
 bool directio = false;
 bool aio = false;
+bool faio = false;
 
 // ----
 Cond cond;
@@ -107,6 +108,7 @@ int main(int argc, char **argv) {
     if (r >= 0) {
       cout << "DIRECTIO ON  AIO ON" << std::endl;
       aio = true;
+      faio = true;
       r = RUN_ALL_TESTS();
     }
   }
@@ -120,13 +122,13 @@ int main(int argc, char **argv) {
 
 TEST(TestFileJournal, Create) {
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
 }
 
 TEST(TestFileJournal, WriteSmall) {
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
 
@@ -140,7 +142,7 @@ TEST(TestFileJournal, WriteSmall) {
 
 TEST(TestFileJournal, WriteBig) {
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
 
@@ -158,7 +160,7 @@ TEST(TestFileJournal, WriteBig) {
 
 TEST(TestFileJournal, WriteMany) {
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
 
@@ -181,7 +183,7 @@ TEST(TestFileJournal, WriteMany) {
 
 TEST(TestFileJournal, WriteManyVecs) {
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
 
@@ -218,7 +220,7 @@ TEST(TestFileJournal, WriteManyVecs) {
 
 TEST(TestFileJournal, ReplaySmall) {
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
   
@@ -263,7 +265,7 @@ TEST(TestFileJournal, ReplaySmall) {
 
 TEST(TestFileJournal, ReplayCorrupt) {
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
   
@@ -330,7 +332,7 @@ TEST(TestFileJournal, ReplayCorrupt) {
 
 TEST(TestFileJournal, WriteTrim) {
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
 
@@ -370,7 +372,7 @@ TEST(TestFileJournal, WriteTrim) {
 
 TEST(TestFileJournal, WriteTrimSmall) {
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
 
@@ -413,7 +415,7 @@ TEST(TestFileJournal, ReplayDetectCorruptFooterMagic) {
   g_ceph_context->_conf->apply_changes(NULL);
 
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
 
@@ -463,7 +465,7 @@ TEST(TestFileJournal, ReplayDetectCorruptPayload) {
   g_ceph_context->_conf->apply_changes(NULL);
 
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
 
@@ -513,7 +515,7 @@ TEST(TestFileJournal, ReplayDetectCorruptHeader) {
   g_ceph_context->_conf->apply_changes(NULL);
 
   fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio);
+  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
   ASSERT_EQ(0, j.create());
   j.make_writeable();
 

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -111,6 +111,10 @@ int main(int argc, char **argv) {
 }
 
 TEST(TestFileJournal, Create) {
+  g_ceph_context->_conf->set_val("journal_ignore_corruption", "false");
+  g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
+  g_ceph_context->_conf->apply_changes(NULL);
+
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -121,6 +125,10 @@ TEST(TestFileJournal, Create) {
 }
 
 TEST(TestFileJournal, WriteSmall) {
+  g_ceph_context->_conf->set_val("journal_ignore_corruption", "false");
+  g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
+  g_ceph_context->_conf->apply_changes(NULL);
+
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -139,6 +147,10 @@ TEST(TestFileJournal, WriteSmall) {
 }
 
 TEST(TestFileJournal, WriteBig) {
+  g_ceph_context->_conf->set_val("journal_ignore_corruption", "false");
+  g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
+  g_ceph_context->_conf->apply_changes(NULL);
+
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -161,6 +173,10 @@ TEST(TestFileJournal, WriteBig) {
 }
 
 TEST(TestFileJournal, WriteMany) {
+  g_ceph_context->_conf->set_val("journal_ignore_corruption", "false");
+  g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
+  g_ceph_context->_conf->apply_changes(NULL);
+
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -188,6 +204,10 @@ TEST(TestFileJournal, WriteMany) {
 }
 
 TEST(TestFileJournal, WriteManyVecs) {
+  g_ceph_context->_conf->set_val("journal_ignore_corruption", "false");
+  g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
+  g_ceph_context->_conf->apply_changes(NULL);
+
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -229,6 +249,10 @@ TEST(TestFileJournal, WriteManyVecs) {
 }
 
 TEST(TestFileJournal, ReplaySmall) {
+  g_ceph_context->_conf->set_val("journal_ignore_corruption", "false");
+  g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
+  g_ceph_context->_conf->apply_changes(NULL);
+
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -278,6 +302,10 @@ TEST(TestFileJournal, ReplaySmall) {
 }
 
 TEST(TestFileJournal, ReplayCorrupt) {
+  g_ceph_context->_conf->set_val("journal_ignore_corruption", "true");
+  g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
+  g_ceph_context->_conf->apply_changes(NULL);
+
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -341,7 +369,9 @@ TEST(TestFileJournal, ReplayCorrupt) {
     ASSERT_EQ(needle, v);
     inbl.clear();
     v.clear();
-    ASSERT_TRUE(!j.read_entry(inbl, seq));
+    bool corrupt;
+    ASSERT_FALSE(j.read_entry(inbl, seq, &corrupt));
+    ASSERT_TRUE(corrupt);
 
     j.make_writeable();
     j.close();
@@ -349,6 +379,10 @@ TEST(TestFileJournal, ReplayCorrupt) {
 }
 
 TEST(TestFileJournal, WriteTrim) {
+  g_ceph_context->_conf->set_val("journal_ignore_corruption", "false");
+  g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
+  g_ceph_context->_conf->apply_changes(NULL);
+
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -393,6 +427,10 @@ TEST(TestFileJournal, WriteTrim) {
 }
 
 TEST(TestFileJournal, WriteTrimSmall) {
+  g_ceph_context->_conf->set_val("journal_ignore_corruption", "false");
+  g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
+  g_ceph_context->_conf->apply_changes(NULL);
+
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -17,9 +17,14 @@ Finisher *finisher;
 Cond sync_cond;
 char path[200];
 uuid_d fsid;
-bool directio = false;
-bool aio = false;
-bool faio = false;
+struct test_info {
+    bool directio, aio, faio;
+    const char *description;
+} subtests[3] = {
+    { false, false, false, "DIRECTIO OFF  AIO OFF" },
+    { true, false, false, "DIRECTIO ON  AIO OFF" },
+    { true, true, true, "DIRECTIO ON  AIO ON"}
+};
 
 // ----
 Cond cond;
@@ -96,22 +101,7 @@ int main(int argc, char **argv) {
 
   finisher->start();
 
-  cout << "DIRECTIO OFF  AIO OFF" << std::endl;
-  directio = false;
-  aio = false;
   int r = RUN_ALL_TESTS();
-  if (r >= 0) {
-    cout << "DIRECTIO ON  AIO OFF" << std::endl;
-    directio = true;
-    r = RUN_ALL_TESTS();
-
-    if (r >= 0) {
-      cout << "DIRECTIO ON  AIO ON" << std::endl;
-      aio = true;
-      faio = true;
-      r = RUN_ALL_TESTS();
-    }
-  }
   
   finisher->stop();
 
@@ -121,292 +111,328 @@ int main(int argc, char **argv) {
 }
 
 TEST(TestFileJournal, Create) {
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+  }
 }
 
 TEST(TestFileJournal, WriteSmall) {
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  bufferlist bl;
-  bl.append("small");
-  j.submit_entry(1, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
-  wait();
+    bufferlist bl;
+    bl.append("small");
+    j.submit_entry(1, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
+    wait();
 
-  j.close();
+    j.close();
+  }
 }
 
 TEST(TestFileJournal, WriteBig) {
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  bufferlist bl;
-  while (bl.length() < size_mb*1000/2) {
-    char foo[1024*1024];
-    memset(foo, 1, sizeof(foo));
-    bl.append(foo, sizeof(foo));
+    bufferlist bl;
+    while (bl.length() < size_mb*1000/2) {
+      char foo[1024*1024];
+      memset(foo, 1, sizeof(foo));
+      bl.append(foo, sizeof(foo));
+    }
+    j.submit_entry(1, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
+    wait();
+
+    j.close();
   }
-  j.submit_entry(1, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
-  wait();
-
-  j.close();
 }
 
 TEST(TestFileJournal, WriteMany) {
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
-  
-  bufferlist bl;
-  bl.append("small");
-  uint64_t seq = 1;
-  for (int i=0; i<100; i++) {
+    C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
+
+    bufferlist bl;
     bl.append("small");
-    j.submit_entry(seq++, bl, 0, gb.new_sub());
+    uint64_t seq = 1;
+    for (int i=0; i<100; i++) {
+      bl.append("small");
+      j.submit_entry(seq++, bl, 0, gb.new_sub());
+    }
+
+    gb.activate();
+
+    wait();
+
+    j.close();
   }
-
-  gb.activate();
-
-  wait();
-
-  j.close();
 }
 
 TEST(TestFileJournal, WriteManyVecs) {
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
+    C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
-  bufferlist first;
-  first.append("small");
-  j.submit_entry(1, first, 0, gb.new_sub());
+    bufferlist first;
+    first.append("small");
+    j.submit_entry(1, first, 0, gb.new_sub());
 
-  bufferlist bl;
-  for (int i=0; i<IOV_MAX * 2; i++) {
-    bufferptr bp = buffer::create_page_aligned(4096);
-    memset(bp.c_str(), (char)i, 4096);
-    bl.append(bp);
+    bufferlist bl;
+    for (int i=0; i<IOV_MAX * 2; i++) {
+      bufferptr bp = buffer::create_page_aligned(4096);
+      memset(bp.c_str(), (char)i, 4096);
+      bl.append(bp);
+    }
+    bufferlist origbl = bl;
+    j.submit_entry(2, bl, 0, gb.new_sub());
+    gb.activate();
+    wait();
+
+    j.close();
+
+    j.open(1);
+    bufferlist inbl;
+    string v;
+    uint64_t seq = 0;
+    ASSERT_EQ(true, j.read_entry(inbl, seq));
+    ASSERT_EQ(seq, 2ull);
+    ASSERT_TRUE(inbl.contents_equal(origbl));
+    j.make_writeable();
+    j.close();
+
   }
-  bufferlist origbl = bl;
-  j.submit_entry(2, bl, 0, gb.new_sub());
-  gb.activate();
-  wait();
-
-  j.close();
-
-  j.open(1);
-  bufferlist inbl;
-  string v;
-  uint64_t seq = 0;
-  ASSERT_EQ(true, j.read_entry(inbl, seq));
-  ASSERT_EQ(seq, 2ull);
-  ASSERT_TRUE(inbl.contents_equal(origbl));
-  j.make_writeable();
-  j.close();
-
 }
 
 TEST(TestFileJournal, ReplaySmall) {
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
-  
-  C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
-  
-  bufferlist bl;
-  bl.append("small");
-  j.submit_entry(1, bl, 0, gb.new_sub());
-  bl.append("small");
-  j.submit_entry(2, bl, 0, gb.new_sub());
-  bl.append("small");
-  j.submit_entry(3, bl, 0, gb.new_sub());
-  gb.activate();
-  wait();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  j.close();
+    C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
-  j.open(1);
+    bufferlist bl;
+    bl.append("small");
+    j.submit_entry(1, bl, 0, gb.new_sub());
+    bl.append("small");
+    j.submit_entry(2, bl, 0, gb.new_sub());
+    bl.append("small");
+    j.submit_entry(3, bl, 0, gb.new_sub());
+    gb.activate();
+    wait();
 
-  bufferlist inbl;
-  string v;
-  uint64_t seq = 0;
-  ASSERT_EQ(true, j.read_entry(inbl, seq));
-  ASSERT_EQ(seq, 2ull);
-  inbl.copy(0, inbl.length(), v);
-  ASSERT_EQ("small", v);
-  inbl.clear();
-  v.clear();
+    j.close();
 
-  ASSERT_EQ(true, j.read_entry(inbl, seq));
-  ASSERT_EQ(seq, 3ull);
-  inbl.copy(0, inbl.length(), v);
-  ASSERT_EQ("small", v);
-  inbl.clear();
-  v.clear();
+    j.open(1);
 
-  ASSERT_TRUE(!j.read_entry(inbl, seq));
+    bufferlist inbl;
+    string v;
+    uint64_t seq = 0;
+    ASSERT_EQ(true, j.read_entry(inbl, seq));
+    ASSERT_EQ(seq, 2ull);
+    inbl.copy(0, inbl.length(), v);
+    ASSERT_EQ("small", v);
+    inbl.clear();
+    v.clear();
 
-  j.make_writeable();
-  j.close();
+    ASSERT_EQ(true, j.read_entry(inbl, seq));
+    ASSERT_EQ(seq, 3ull);
+    inbl.copy(0, inbl.length(), v);
+    ASSERT_EQ("small", v);
+    inbl.clear();
+    v.clear();
+
+    ASSERT_TRUE(!j.read_entry(inbl, seq));
+
+    j.make_writeable();
+    j.close();
+  }
 }
 
 TEST(TestFileJournal, ReplayCorrupt) {
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
-  
-  C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
-  
-  const char *needle =    "i am a needle";
-  const char *newneedle = "in a haystack";
-  bufferlist bl;
-  bl.append(needle);
-  j.submit_entry(1, bl, 0, gb.new_sub());
-  bl.append(needle);
-  j.submit_entry(2, bl, 0, gb.new_sub());
-  bl.append(needle);
-  j.submit_entry(3, bl, 0, gb.new_sub());
-  bl.append(needle);
-  j.submit_entry(4, bl, 0, gb.new_sub());
-  gb.activate();
-  wait();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  j.close();
+    C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
-  cout << "corrupting journal" << std::endl;
-  char buf[1024*128];
-  int fd = open(path, O_RDONLY);
-  ASSERT_GE(fd, 0);
-  int r = safe_read_exact(fd, buf, sizeof(buf));
-  ASSERT_EQ(0, r);
-  int n = 0;
-  for (unsigned o=0; o < sizeof(buf) - strlen(needle); o++) {
-    if (memcmp(buf+o, needle, strlen(needle)) == 0) {
-      if (n >= 2) {
+    const char *needle =    "i am a needle";
+    const char *newneedle = "in a haystack";
+    bufferlist bl;
+    bl.append(needle);
+    j.submit_entry(1, bl, 0, gb.new_sub());
+    bl.append(needle);
+    j.submit_entry(2, bl, 0, gb.new_sub());
+    bl.append(needle);
+    j.submit_entry(3, bl, 0, gb.new_sub());
+    bl.append(needle);
+    j.submit_entry(4, bl, 0, gb.new_sub());
+    gb.activate();
+    wait();
+
+    j.close();
+
+    cout << "corrupting journal" << std::endl;
+    char buf[1024*128];
+    int fd = open(path, O_RDONLY);
+    ASSERT_GE(fd, 0);
+    int r = safe_read_exact(fd, buf, sizeof(buf));
+    ASSERT_EQ(0, r);
+    int n = 0;
+    for (unsigned o=0; o < sizeof(buf) - strlen(needle); o++) {
+      if (memcmp(buf+o, needle, strlen(needle)) == 0) {
+        if (n >= 2) {
 	cout << "replacing at offset " << o << std::endl;
 	memcpy(buf+o, newneedle, strlen(newneedle));
-      } else {
+        } else {
 	cout << "leaving at offset " << o << std::endl;
+        }
+        n++;
       }
-      n++;
     }
+    ASSERT_EQ(n, 4);
+    close(fd);
+    fd = open(path, O_WRONLY);
+    ASSERT_GE(fd, 0);
+    r = safe_write(fd, buf, sizeof(buf));
+    ASSERT_EQ(r, 0);
+    close(fd);
+
+    j.open(1);
+
+    bufferlist inbl;
+    string v;
+    uint64_t seq = 0;
+    ASSERT_EQ(true, j.read_entry(inbl, seq));
+    ASSERT_EQ(seq, 2ull);
+    inbl.copy(0, inbl.length(), v);
+    ASSERT_EQ(needle, v);
+    inbl.clear();
+    v.clear();
+    ASSERT_TRUE(!j.read_entry(inbl, seq));
+
+    j.make_writeable();
+    j.close();
   }
-  ASSERT_EQ(n, 4);
-  close(fd);
-  fd = open(path, O_WRONLY);
-  ASSERT_GE(fd, 0);
-  r = safe_write(fd, buf, sizeof(buf));
-  ASSERT_EQ(r, 0);
-  close(fd);
-
-  j.open(1);
-
-  bufferlist inbl;
-  string v;
-  uint64_t seq = 0;
-  ASSERT_EQ(true, j.read_entry(inbl, seq));
-  ASSERT_EQ(seq, 2ull);
-  inbl.copy(0, inbl.length(), v);
-  ASSERT_EQ(needle, v);
-  inbl.clear();
-  v.clear();
-  ASSERT_TRUE(!j.read_entry(inbl, seq));
-
-  j.make_writeable();
-  j.close();
 }
 
 TEST(TestFileJournal, WriteTrim) {
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  list<C_Sync*> ls;
-  
-  bufferlist bl;
-  char foo[1024*1024];
-  memset(foo, 1, sizeof(foo));
+    list<C_Sync*> ls;
 
-  uint64_t seq = 1, committed = 0;
+    bufferlist bl;
+    char foo[1024*1024];
+    memset(foo, 1, sizeof(foo));
 
-  for (unsigned i=0; i<size_mb*2; i++) {
-    bl.clear();
-    bl.push_back(buffer::copy(foo, sizeof(foo)));
-    bl.zero();
-    ls.push_back(new C_Sync);
-    j.submit_entry(seq++, bl, 0, ls.back()->c);
+    uint64_t seq = 1, committed = 0;
 
-    while (ls.size() > size_mb/2) {
+    for (unsigned i=0; i<size_mb*2; i++) {
+      bl.clear();
+      bl.push_back(buffer::copy(foo, sizeof(foo)));
+      bl.zero();
+      ls.push_back(new C_Sync);
+      j.submit_entry(seq++, bl, 0, ls.back()->c);
+
+      while (ls.size() > size_mb/2) {
+        delete ls.front();
+        ls.pop_front();
+        committed++;
+        j.committed_thru(committed);
+      }
+    }
+
+    while (ls.size()) {
       delete ls.front();
       ls.pop_front();
-      committed++;
-      j.committed_thru(committed);
+      j.committed_thru(++committed);
     }
+
+    ASSERT_TRUE(j.journalq_empty());
+
+    j.close();
   }
-
-  while (ls.size()) {
-    delete ls.front();
-    ls.pop_front();
-    j.committed_thru(++committed);
-  }
-
-  ASSERT_TRUE(j.journalq_empty());
-
-  j.close();
 }
 
 TEST(TestFileJournal, WriteTrimSmall) {
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  list<C_Sync*> ls;
-  
-  bufferlist bl;
-  char foo[1024*1024];
-  memset(foo, 1, sizeof(foo));
+    list<C_Sync*> ls;
 
-  uint64_t seq = 1, committed = 0;
+    bufferlist bl;
+    char foo[1024*1024];
+    memset(foo, 1, sizeof(foo));
 
-  for (unsigned i=0; i<size_mb*2; i++) {
-    bl.clear();
-    for (int k=0; k<128; k++)
-      bl.push_back(buffer::copy(foo, sizeof(foo) / 128));
-    bl.zero();
-    ls.push_back(new C_Sync);
-    j.submit_entry(seq++, bl, 0, ls.back()->c);
+    uint64_t seq = 1, committed = 0;
 
-    while (ls.size() > size_mb/2) {
+    for (unsigned i=0; i<size_mb*2; i++) {
+      bl.clear();
+      for (int k=0; k<128; k++)
+        bl.push_back(buffer::copy(foo, sizeof(foo) / 128));
+      bl.zero();
+      ls.push_back(new C_Sync);
+      j.submit_entry(seq++, bl, 0, ls.back()->c);
+
+      while (ls.size() > size_mb/2) {
+        delete ls.front();
+        ls.pop_front();
+        committed++;
+        j.committed_thru(committed);
+      }
+    }
+
+    while (ls.size()) {
       delete ls.front();
       ls.pop_front();
-      committed++;
       j.committed_thru(committed);
     }
-  }
 
-  while (ls.size()) {
-    delete ls.front();
-    ls.pop_front();
-    j.committed_thru(committed);
+    j.close();
   }
-
-  j.close();
 }
 
 TEST(TestFileJournal, ReplayDetectCorruptFooterMagic) {
@@ -414,49 +440,53 @@ TEST(TestFileJournal, ReplayDetectCorruptFooterMagic) {
   g_ceph_context->_conf->set_val("journal_write_header_frequency", "1");
   g_ceph_context->_conf->apply_changes(NULL);
 
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
+    C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
-  const char *needle =    "i am a needle";
-  for (unsigned i = 1; i <= 4; ++i) {
+    const char *needle =    "i am a needle";
+    for (unsigned i = 1; i <= 4; ++i) {
+      bufferlist bl;
+      bl.append(needle);
+      j.submit_entry(i, bl, 0, gb.new_sub());
+    }
+    gb.activate();
+    wait();
+
     bufferlist bl;
-    bl.append(needle);
-    j.submit_entry(i, bl, 0, gb.new_sub());
+    bl.append("needle");
+    j.submit_entry(5, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
+    wait();
+
+    j.close();
+    int fd = open(path, O_WRONLY);
+
+    cout << "corrupting journal" << std::endl;
+    j.open(0);
+    j.corrupt_footer_magic(fd, 2);
+
+    uint64_t seq = 0;
+    bl.clear();
+    bool corrupt = false;
+    bool result = j.read_entry(bl, seq, &corrupt);
+    ASSERT_TRUE(result);
+    ASSERT_EQ(seq, 1UL);
+    ASSERT_FALSE(corrupt);
+
+    result = j.read_entry(bl, seq, &corrupt);
+    ASSERT_FALSE(result);
+    ASSERT_TRUE(corrupt);
+
+    j.make_writeable();
+    j.close();
+    ::close(fd);
   }
-  gb.activate();
-  wait();
-
-  bufferlist bl;
-  bl.append("needle");
-  j.submit_entry(5, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
-  wait();
-
-  j.close();
-  int fd = open(path, O_WRONLY);
-
-  cout << "corrupting journal" << std::endl;
-  j.open(0);
-  j.corrupt_footer_magic(fd, 2);
-
-  uint64_t seq = 0;
-  bl.clear();
-  bool corrupt = false;
-  bool result = j.read_entry(bl, seq, &corrupt);
-  ASSERT_TRUE(result);
-  ASSERT_EQ(seq, 1UL);
-  ASSERT_FALSE(corrupt);
-
-  result = j.read_entry(bl, seq, &corrupt);
-  ASSERT_FALSE(result);
-  ASSERT_TRUE(corrupt);
-
-  j.make_writeable();
-  j.close();
-  ::close(fd);
 }
 
 TEST(TestFileJournal, ReplayDetectCorruptPayload) {
@@ -464,49 +494,53 @@ TEST(TestFileJournal, ReplayDetectCorruptPayload) {
   g_ceph_context->_conf->set_val("journal_write_header_frequency", "1");
   g_ceph_context->_conf->apply_changes(NULL);
 
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
+    C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
-  const char *needle =    "i am a needle";
-  for (unsigned i = 1; i <= 4; ++i) {
+    const char *needle =    "i am a needle";
+    for (unsigned i = 1; i <= 4; ++i) {
+      bufferlist bl;
+      bl.append(needle);
+      j.submit_entry(i, bl, 0, gb.new_sub());
+    }
+    gb.activate();
+    wait();
+
     bufferlist bl;
-    bl.append(needle);
-    j.submit_entry(i, bl, 0, gb.new_sub());
+    bl.append("needle");
+    j.submit_entry(5, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
+    wait();
+
+    j.close();
+    int fd = open(path, O_WRONLY);
+
+    cout << "corrupting journal" << std::endl;
+    j.open(0);
+    j.corrupt_payload(fd, 2);
+
+    uint64_t seq = 0;
+    bl.clear();
+    bool corrupt = false;
+    bool result = j.read_entry(bl, seq, &corrupt);
+    ASSERT_TRUE(result);
+    ASSERT_EQ(seq, 1UL);
+    ASSERT_FALSE(corrupt);
+
+    result = j.read_entry(bl, seq, &corrupt);
+    ASSERT_FALSE(result);
+    ASSERT_TRUE(corrupt);
+
+    j.make_writeable();
+    j.close();
+    ::close(fd);
   }
-  gb.activate();
-  wait();
-
-  bufferlist bl;
-  bl.append("needle");
-  j.submit_entry(5, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
-  wait();
-
-  j.close();
-  int fd = open(path, O_WRONLY);
-
-  cout << "corrupting journal" << std::endl;
-  j.open(0);
-  j.corrupt_payload(fd, 2);
-
-  uint64_t seq = 0;
-  bl.clear();
-  bool corrupt = false;
-  bool result = j.read_entry(bl, seq, &corrupt);
-  ASSERT_TRUE(result);
-  ASSERT_EQ(seq, 1UL);
-  ASSERT_FALSE(corrupt);
-
-  result = j.read_entry(bl, seq, &corrupt);
-  ASSERT_FALSE(result);
-  ASSERT_TRUE(corrupt);
-
-  j.make_writeable();
-  j.close();
-  ::close(fd);
 }
 
 TEST(TestFileJournal, ReplayDetectCorruptHeader) {
@@ -514,47 +548,51 @@ TEST(TestFileJournal, ReplayDetectCorruptHeader) {
   g_ceph_context->_conf->set_val("journal_write_header_frequency", "1");
   g_ceph_context->_conf->apply_changes(NULL);
 
-  fsid.generate_random();
-  FileJournal j(fsid, finisher, &sync_cond, path, directio, aio, faio);
-  ASSERT_EQ(0, j.create());
-  j.make_writeable();
+  for (unsigned i = 0 ; i < 3; ++i) {
+    SCOPED_TRACE(subtests[i].description);
+    fsid.generate_random();
+    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
+		  subtests[i].aio, subtests[i].faio);
+    ASSERT_EQ(0, j.create());
+    j.make_writeable();
 
-  C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
+    C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
-  const char *needle =    "i am a needle";
-  for (unsigned i = 1; i <= 4; ++i) {
+    const char *needle =    "i am a needle";
+    for (unsigned i = 1; i <= 4; ++i) {
+      bufferlist bl;
+      bl.append(needle);
+      j.submit_entry(i, bl, 0, gb.new_sub());
+    }
+    gb.activate();
+    wait();
+
     bufferlist bl;
-    bl.append(needle);
-    j.submit_entry(i, bl, 0, gb.new_sub());
+    bl.append("needle");
+    j.submit_entry(5, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
+    wait();
+
+    j.close();
+    int fd = open(path, O_WRONLY);
+
+    cout << "corrupting journal" << std::endl;
+    j.open(0);
+    j.corrupt_header_magic(fd, 2);
+
+    uint64_t seq = 0;
+    bl.clear();
+    bool corrupt = false;
+    bool result = j.read_entry(bl, seq, &corrupt);
+    ASSERT_TRUE(result);
+    ASSERT_EQ(seq, 1UL);
+    ASSERT_FALSE(corrupt);
+
+    result = j.read_entry(bl, seq, &corrupt);
+    ASSERT_FALSE(result);
+    ASSERT_TRUE(corrupt);
+
+    j.make_writeable();
+    j.close();
+    ::close(fd);
   }
-  gb.activate();
-  wait();
-
-  bufferlist bl;
-  bl.append("needle");
-  j.submit_entry(5, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
-  wait();
-
-  j.close();
-  int fd = open(path, O_WRONLY);
-
-  cout << "corrupting journal" << std::endl;
-  j.open(0);
-  j.corrupt_header_magic(fd, 2);
-
-  uint64_t seq = 0;
-  bl.clear();
-  bool corrupt = false;
-  bool result = j.read_entry(bl, seq, &corrupt);
-  ASSERT_TRUE(result);
-  ASSERT_EQ(seq, 1UL);
-  ASSERT_FALSE(corrupt);
-
-  result = j.read_entry(bl, seq, &corrupt);
-  ASSERT_FALSE(result);
-  ASSERT_TRUE(corrupt);
-
-  j.make_writeable();
-  j.close();
-  ::close(fd);
 }

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2517,6 +2517,11 @@ int main(int argc, char **argv)
     return 1;
   }
 
+  if (pgidstr.length() && !pgid.parse(pgidstr.c_str())) {
+    cerr << "Invalid pgid '" << pgidstr << "' specified" << std::endl;
+    return 1;
+  }
+
   ObjectStore *fs = ObjectStore::create(g_ceph_context, type, dpath, jpath, flags);
   if (fs == NULL) {
     cerr << "Must provide --type (filestore, memstore, keyvaluestore)" << std::endl;
@@ -2579,11 +2584,6 @@ int main(int argc, char **argv)
       << unsupported << std::endl;
     ret = EINVAL;
     goto out;
-  }
-
-  if (pgidstr.length() && !pgid.parse(pgidstr.c_str())) {
-    cerr << "Invalid pgid '" << pgidstr << "' specified" << std::endl;
-    return 1;
   }
 
   if (op != "list" && vm.count("object")) {

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1339,6 +1339,12 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl, bool no_overwrite)
           return ret;
         }
         ret = ioctx.create(ob.hoid.hobj.oid.name, true);
+        // If object re-appeared after removal, let's just skip it
+        if (ret == -EEXIST) {
+          skipping = true;
+          msg = "Skipping in-use object";
+          ret = 0;
+        }
         if (ret < 0) {
           cerr << "create failed: " << cpp_strerror(ret) << std::endl;
           return ret;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -26,6 +26,7 @@
 
 #include "os/ObjectStore.h"
 #include "os/FileStore.h"
+#include "os/FileJournal.h"
 
 #include "osd/PGLog.h"
 #include "osd/OSD.h"
@@ -2291,6 +2292,20 @@ bool ends_with(const string& check, const string& ending)
     return check.size() >= ending.size() && check.rfind(ending) == (check.size() - ending.size());
 }
 
+// Based on FileStore::dump_journal(), set-up enough to only dump
+int mydump_journal(Formatter *f, string journalpath, bool m_journal_dio)
+{
+  int r;
+
+  if (!journalpath.length())
+    return -EINVAL;
+
+  FileJournal *journal = new FileJournal(uuid_d(), NULL, NULL, journalpath.c_str(), m_journal_dio);
+  r = journal->_fdump(*f, false);
+  delete journal;
+  return r;
+}
+
 int main(int argc, char **argv)
 {
   string dpath, jpath, pgidstr, op, file, object, objcmd, arg1, arg2, type, format;
@@ -2311,7 +2326,7 @@ int main(int argc, char **argv)
     ("pgid", po::value<string>(&pgidstr),
      "PG id, mandatory except for import, list-lost, fix-lost, list-pgs, set-allow-sharded-objects")
     ("op", po::value<string>(&op),
-     "Arg is one of [info, log, remove, export, import, list, list-lost, fix-lost, list-pgs, rm-past-intervals, set-allow-sharded-objects]")
+     "Arg is one of [info, log, remove, export, import, list, list-lost, fix-lost, list-pgs, rm-past-intervals, set-allow-sharded-objects, dump-journal]")
     ("file", po::value<string>(&file),
      "path of file to export or import")
     ("format", po::value<string>(&format)->default_value("json-pretty"),
@@ -2409,13 +2424,14 @@ int main(int argc, char **argv)
     myexit(ret != 0);
   }
 
-  if (!vm.count("data-path")) {
+  if (!vm.count("type")) {
+    type = "filestore";
+  }
+  if (!vm.count("data-path") &&
+     !(op == "dump-journal" && type == "filestore")) {
     cerr << "Must provide --data-path" << std::endl;
     usage(desc);
     myexit(1);
-  }
-  if (!vm.count("type")) {
-    type = "filestore";
   }
   if (type == "filestore" && !vm.count("journal-path")) {
     cerr << "Must provide --journal-path" << std::endl;
@@ -2489,6 +2505,27 @@ int main(int argc, char **argv)
     g_conf->set_val_or_die("err_to_stderr", "true");
   }
   g_conf->apply_changes(NULL);
+
+  // Special list handling.  Treating pretty_format as human readable,
+  // with one object per line and not an enclosing array.
+  human_readable = ends_with(format, "-pretty");
+  if (op == "list" && human_readable) {
+    // Remove -pretty from end of format which we know is there
+    format = format.substr(0, format.size() - strlen("-pretty"));
+  }
+
+  formatter = Formatter::create(format);
+  if (formatter == NULL) {
+    cerr << "unrecognized format: " << format << std::endl;
+    myexit(1);
+  }
+
+  // Special handling for filestore journal, so we can dump it without mounting
+  if (op == "dump-journal" && type == "filestore") {
+    int ret = mydump_journal(formatter, jpath, g_conf->journal_dio);
+    formatter->flush(cout);
+    myexit(ret != 0);
+  }
 
   //Verify that data-path really exists
   struct stat st;
@@ -2675,7 +2712,7 @@ int main(int argc, char **argv)
 
   if (op != "list" && op != "import" && op != "list-lost" && op != "fix-lost"
       && op != "list-pgs"  && op != "set-allow-sharded-objects" &&
-      (pgidstr.length() == 0)) {
+      op != "dump-journal-mount" && (pgidstr.length() == 0)) {
     cerr << "Must provide pgid" << std::endl;
     usage(desc);
     ret = 1;
@@ -2787,6 +2824,19 @@ int main(int argc, char **argv)
     if (ret == 0)
       cout << "Import successful" << std::endl;
     goto out;
+  } else if (op == "dump-journal-mount") {
+    // Undocumented feature to dump journal with mounted fs
+    // This doesn't support the format option, but it uses the
+    // ObjectStore::dump_journal() and mounts to get replay to run.
+    int r = fs->dump_journal(cout);
+    if (r) {
+      if (r == -EOPNOTSUPP) {
+        cerr << "Object store type \"" << type << "\" doesn't support journal dump" << std::endl;
+      } else {
+        cerr << "Journal dump failed with error " << r << std::endl;
+      }
+    }
+    goto out;
   }
 
   log_oid = OSD::make_pg_log_oid(pgid);
@@ -2815,21 +2865,6 @@ int main(int argc, char **argv)
       ret = action_on_all_objects_in_pg(fs, coll_t(pgid), *action, debug);
     else
       ret = action_on_all_objects(fs, *action, debug);
-    goto out;
-  }
-
-  // Special list handling.  Treating pretty_format as human readable,
-  // with one object per line and not an enclosing array.
-  human_readable = ends_with(format, "-pretty");
-  if (op == "list" && human_readable) {
-    // Remove -pretty from end of format which we know is there
-    format = format.substr(0, format.size() - strlen("-pretty"));
-  }
-
-  formatter = Formatter::create(format);
-  if (formatter == NULL) {
-    cerr << "unrecognized format: " << format << std::endl;
-    ret = 1;
     goto out;
   }
 

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2355,18 +2355,13 @@ int do_set_omaphdr(ObjectStore *store, coll_t coll, ghobject_t &ghobj, int fd)
   return 0;
 }
 
-struct do_list_lost : public action_on_object_t {
-  virtual int call(ObjectStore *store, coll_t coll, ghobject_t &ghobj, object_info_t &oi) {
-    if (oi.is_lost())
-      cout << coll << "/" << ghobj << " is lost" << std::endl;
-    return 0;
-  }
-};
-
 struct do_fix_lost : public action_on_object_t {
   virtual int call(ObjectStore *store, coll_t coll, ghobject_t &ghobj, object_info_t &oi) {
     if (oi.is_lost()) {
-      cout << coll << "/" << ghobj << " is lost, fixing" << std::endl;
+      cout << coll << "/" << ghobj << " is lost";
+      if (!dry_run)
+        cout << ", fixing";
+      cout << std::endl;
       if (dry_run)
         return 0;
       oi.clear_flag(object_info_t::FLAG_LOST);
@@ -2481,9 +2476,9 @@ int main(int argc, char **argv)
     ("journal-path", po::value<string>(&jpath),
      "path to journal, mandatory for filestore type")
     ("pgid", po::value<string>(&pgidstr),
-     "PG id, mandatory except for import, list-lost, fix-lost, list-pgs, set-allow-sharded-objects")
+     "PG id, mandatory except for import, fix-lost, list-pgs, set-allow-sharded-objects")
     ("op", po::value<string>(&op),
-     "Arg is one of [info, log, remove, export, import, list, list-lost, fix-lost, list-pgs, rm-past-intervals, set-allow-sharded-objects, dump-journal]")
+     "Arg is one of [info, log, remove, export, import, list, fix-lost, list-pgs, rm-past-intervals, set-allow-sharded-objects, dump-journal]")
     ("file", po::value<string>(&file),
      "path of file to export or import")
     ("format", po::value<string>(&format)->default_value("json-pretty"),
@@ -2882,7 +2877,7 @@ int main(int argc, char **argv)
     }
   }
 
-  if (op != "list" && op != "import" && op != "list-lost" && op != "fix-lost"
+  if (op != "list" && op != "import" && op != "fix-lost"
       && op != "list-pgs"  && op != "set-allow-sharded-objects" &&
       op != "dump-journal-mount" && (pgidstr.length() == 0)) {
     cerr << "Must provide pgid" << std::endl;
@@ -3024,12 +3019,9 @@ int main(int argc, char **argv)
     goto out;
   }
 
-  if (op == "list-lost" || op == "fix-lost") {
+  if (op == "fix-lost") {
     boost::scoped_ptr<action_on_object_t> action;
-    if (op == "list-lost")
-      action.reset(new do_list_lost());
-    if (op == "fix-lost")
-      action.reset(new do_fix_lost());
+    action.reset(new do_fix_lost());
     if (pgidstr.length())
       ret = action_on_all_objects_in_pg(fs, coll_t(pgid), *action, debug);
     else
@@ -3363,7 +3355,7 @@ int main(int argc, char **argv)
         cout << "Removal succeeded" << std::endl;
       }
     } else {
-      cerr << "Must provide --op (info, log, remove, export, import, list, list-lost, fix-lost, list-pgs, rm-past-intervals)"
+      cerr << "Must provide --op (info, log, remove, export, import, list, fix-lost, list-pgs, rm-past-intervals)"
 	<< std::endl;
       usage(desc);
       ret = 1;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2334,6 +2334,33 @@ struct do_fix_lost : public action_on_object_t {
   }
 };
 
+int print_obj_info(ObjectStore *store, coll_t coll, ghobject_t &ghobj, Formatter* formatter)
+{
+  bufferlist attr;
+  int r = store->getattr(coll, ghobj, OI_ATTR, attr);
+  if (r < 0) {
+    cerr << "Error getting attr on : " << make_pair(coll, ghobj) << ", "
+       << cpp_strerror(r) << std::endl;
+    return r;
+  }
+  object_info_t oi;
+  bufferlist::iterator bp = attr.begin();
+  try {
+    ::decode(oi, bp);
+  } catch (...) {
+    r = -EINVAL;
+    cerr << "Error getting attr on : " << make_pair(coll, ghobj) << ", "
+         << cpp_strerror(r) << std::endl;
+    return r;
+  }
+  formatter->open_object_section("info");
+  oi.dump(formatter);
+  formatter->close_section();
+  formatter->flush(cout);
+  cout << std::endl;
+  return 0;
+}
+
 void usage(po::options_description &desc)
 {
     cerr << std::endl;
@@ -2349,6 +2376,7 @@ void usage(po::options_description &desc)
     cerr << "ceph-objectstore-tool ... <object> list-attrs" << std::endl;
     cerr << "ceph-objectstore-tool ... <object> list-omap" << std::endl;
     cerr << "ceph-objectstore-tool ... <object> remove" << std::endl;
+    cerr << "ceph-objectstore-tool ... <object> dump-info" << std::endl;
     cerr << std::endl;
     cerr << "ceph-objectstore-tool import-rados <pool> [file]" << std::endl;
     cerr << std::endl;
@@ -3186,6 +3214,9 @@ int main(int argc, char **argv)
 	if (fd != STDIN_FILENO)
 	  close(fd);
         goto out;
+      } else if (objcmd == "dump-info") {
+	ret = print_obj_info(fs, coll, ghobj, formatter);
+	goto out;
       }
       cerr << "Unknown object command '" << objcmd << "'" << std::endl;
       usage(desc);

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1279,13 +1279,14 @@ int skip_object(bufferlist &bl)
   return 0;
 }
 
-int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
+int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl, bool no_overwrite)
 {
   bufferlist::iterator ebliter = bl.begin();
   object_begin ob;
   ob.decode(ebliter);
   map<string,bufferptr>::iterator i;
   bufferlist abl;
+  bool skipping;
 
   data_section ds;
   attr_section as;
@@ -1308,12 +1309,18 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
   ioctx.set_namespace(ob.hoid.hobj.get_namespace());
 
   string msg("Write");
+  skipping = false;
   if (dry_run) {
     uint64_t psize;
     time_t pmtime;
     int ret = ioctx.stat(ob.hoid.hobj.oid.name, &psize, &pmtime);
-    if (ret == 0)
-      msg = "***Overwrite***";
+    if (ret == 0) {
+      if (no_overwrite)
+        // Could set skipping, but dry-run doesn't change anything either
+        msg = "Skipping existing";
+      else
+        msg = "***Overwrite***";
+    }
   } else {
     int ret = ioctx.create(ob.hoid.hobj.oid.name, true);
     if (ret && ret != -EEXIST) {
@@ -1321,17 +1328,23 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
       return ret;
     }
     if (ret == -EEXIST) {
-      msg = "***Overwrite***";
-      ret = ioctx.remove(ob.hoid.hobj.oid.name);
-      if (ret < 0) {
-        cerr << "remove failed: " << cpp_strerror(ret) << std::endl;
-        return ret;
+      if (no_overwrite) {
+        msg = "Skipping existing";
+        skipping = true;
+      } else {
+        msg = "***Overwrite***";
+        ret = ioctx.remove(ob.hoid.hobj.oid.name);
+        if (ret < 0) {
+          cerr << "remove failed: " << cpp_strerror(ret) << std::endl;
+          return ret;
+        }
+        ret = ioctx.create(ob.hoid.hobj.oid.name, true);
+        if (ret < 0) {
+          cerr << "create failed: " << cpp_strerror(ret) << std::endl;
+          return ret;
+        }
       }
-      ret = ioctx.create(ob.hoid.hobj.oid.name, true);
-      if (ret < 0) {
-        cerr << "create failed: " << cpp_strerror(ret) << std::endl;
-        return ret;
-      }
+    }
   }
 
   cout << msg << " " << ob.hoid << std::endl;
@@ -1381,7 +1394,7 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
         if (databl.length() >= alignment) {
           uint64_t rndlen = uint64_t(databl.length() / alignment) * alignment;
           if (debug) cerr << "write offset=" << out_offset << " len=" << rndlen << std::endl;
-          if (!dry_run) {
+          if (!dry_run && !skipping) {
             ret = ioctx.write(ob.hoid.hobj.oid.name, databl, rndlen, out_offset);
             if (ret) {
               cerr << "write failed: " << cpp_strerror(ret) << std::endl;
@@ -1398,7 +1411,7 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
         }
         break;
       }
-      if (!dry_run) {
+      if (!dry_run && !skipping) {
         ret = ioctx.write(ob.hoid.hobj.oid.name, ds.databl, ds.len, ds.offset);
         if (ret) {
           cerr << "write failed: " << cpp_strerror(ret) << std::endl;
@@ -1411,7 +1424,7 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
 
       if (debug)
         cerr << "\tattrs: len " << as.data.size() << std::endl;
-      if (dry_run)
+      if (dry_run || skipping)
         break;
       for (i = as.data.begin(); i != as.data.end(); ++i) {
         if (i->first == "_" || i->first == "snapset")
@@ -1432,7 +1445,7 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
       if (debug)
         cerr << "\tomap header: " << string(oh.hdr.c_str(), oh.hdr.length())
           << std::endl;
-      if (dry_run)
+      if (dry_run || skipping)
         break;
       ret = ioctx.omap_set_header(ob.hoid.hobj.oid.name, oh.hdr);
       if (ret) {
@@ -1446,7 +1459,7 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
 
       if (debug)
         cerr << "\tomap: size " << os.omap.size() << std::endl;
-      if (dry_run)
+      if (dry_run || skipping)
         break;
       ret = ioctx.omap_set(ob.hoid.hobj.oid.name, os.omap);
       if (ret) {
@@ -1460,7 +1473,7 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
       if (need_align && databl.length() > 0) {
         assert(databl.length() < alignment);
         if (debug) cerr << "END write offset=" << out_offset << " len=" << databl.length() << std::endl;
-        if (dry_run)
+        if (dry_run || skipping)
           break;
         ret = ioctx.write(ob.hoid.hobj.oid.name, databl, databl.length(), out_offset);
         if (ret) {
@@ -1662,7 +1675,7 @@ int get_pg_metadata(ObjectStore *store, bufferlist &bl, metadata_section &ms,
   return 0;
 }
 
-int do_import_rados(string pool)
+int do_import_rados(string pool, bool no_overwrite)
 {
   bufferlist ebl;
   pg_info_t info;
@@ -1760,7 +1773,7 @@ int do_import_rados(string pool)
     }
     switch(type) {
     case TYPE_OBJECT_BEGIN:
-      ret = get_object_rados(ioctx, ebl);
+      ret = get_object_rados(ioctx, ebl, no_overwrite);
       if (ret) return ret;
       break;
     case TYPE_PG_METADATA:
@@ -2462,7 +2475,7 @@ int main(int argc, char **argv)
   string dpath, jpath, pgidstr, op, file, object, objcmd, arg1, arg2, type, format;
   spg_t pgid;
   ghobject_t ghobj;
-  bool human_readable;
+  bool human_readable, no_overwrite;
   bool force;
   Formatter *formatter;
 
@@ -2488,6 +2501,7 @@ int main(int argc, char **argv)
     ("skip-journal-replay", "Disable journal replay")
     ("skip-mount-omap", "Disable mounting of omap")
     ("dry-run", "Don't modify the objectstore")
+    ("no-overwrite", "For import-rados don't overwrite existing files")
     ;
 
   po::options_description positional("Positional options");
@@ -2536,6 +2550,9 @@ int main(int argc, char **argv)
     force = true;
   }
 
+  no_overwrite = false;
+  if (vm.count("no-overwrite"))
+    no_overwrite = true;
   if (vm.count("dry-run"))
     dry_run = true;
   osflagbits_t flags = 0;
@@ -2586,7 +2603,7 @@ int main(int argc, char **argv)
     global_init(NULL, ceph_options, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
     common_init_finish(g_ceph_context);
 
-    int ret = do_import_rados(pool);
+    int ret = do_import_rados(pool, no_overwrite);
     if (ret == 0)
       cout << "Import successful" << std::endl;
     myexit(ret != 0);

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2460,11 +2460,6 @@ int main(int argc, char **argv)
     return 1;
   }
 
-  if (dpath.length() == 0) {
-    cerr << "Invalid params" << std::endl;
-    return 1;
-  }
-
   osflagbits_t flags = 0;
   if (vm.count("skip-journal-replay"))
     flags |= SKIP_JOURNAL_REPLAY;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2356,6 +2356,8 @@ void usage(po::options_description &desc)
     cerr << "by --op list." << std::endl;
     cerr << "<object> can be an object name which will be looked up in all" << std::endl;
     cerr << "the OSD's PGs." << std::endl;
+    cerr << "<object> can be the empty string ('') which with a provided pgid " << std::endl;
+    cerr << "specifies the pgmeta object" << std::endl;
     cerr << std::endl;
     cerr << "The optional [file] argument will read stdin or write stdout" << std::endl;
     cerr << "if not specified or if '-' specified." << std::endl;
@@ -2414,7 +2416,7 @@ int main(int argc, char **argv)
 
   po::options_description positional("Positional options");
   positional.add_options()
-    ("object", po::value<string>(&object), "object name or ghobject in json")
+    ("object", po::value<string>(&object), "'' for pgmeta_oid, object name or ghobject in json")
     ("objcmd", po::value<string>(&objcmd), "command [(get|set)-bytes, (get|set|rm)-(attr|omap), (get|set)-omaphdr, list-attrs, list-omap, remove]")
     ("arg1", po::value<string>(&arg1), "arg1 based on cmd")
     ("arg2", po::value<string>(&arg2), "arg2 based on cmd")
@@ -2717,6 +2719,11 @@ int main(int argc, char **argv)
   }
 
   if (op != "list" && vm.count("object")) {
+    // Special case: Create pgmeta_oid if empty string specified
+    // This can't conflict with any actual object names.
+    if (object == "") {
+      ghobj = pgid.make_pgmeta_oid();
+    } else {
     json_spirit::Value v;
     try {
       if (!json_spirit::read(object, v)) {
@@ -2788,6 +2795,7 @@ int main(int argc, char **argv)
       cerr << e.what() << std::endl;
       ret = 1;
       goto out;
+    }
     }
   }
 

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -328,20 +328,23 @@ struct metadata_section {
   map<epoch_t,pg_interval_t> past_intervals;
   OSDMap osdmap;
   bufferlist osdmap_bl;  // Used in lieu of encoding osdmap due to crc checking
+  map<eversion_t, hobject_t> divergent_priors;
 
   metadata_section(__u8 struct_ver, epoch_t map_epoch, const pg_info_t &info,
-		   const pg_log_t &log, map<epoch_t,pg_interval_t> &past_intervals)
+		   const pg_log_t &log, map<epoch_t,pg_interval_t> &past_intervals,
+		   map<eversion_t, hobject_t> &divergent_priors)
     : struct_ver(struct_ver),
       map_epoch(map_epoch),
       info(info),
       log(log),
-      past_intervals(past_intervals) { }
+      past_intervals(past_intervals),
+      divergent_priors(divergent_priors) { }
   metadata_section()
     : struct_ver(0),
       map_epoch(0) { }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(3, 1, bl);
+    ENCODE_START(4, 1, bl);
     ::encode(struct_ver, bl);
     ::encode(map_epoch, bl);
     ::encode(info, bl);
@@ -350,10 +353,11 @@ struct metadata_section {
     // Equivalent to osdmap.encode(bl, features); but
     // preserving exact layout for CRC checking.
     bl.append(osdmap_bl);
+    ::encode(divergent_priors, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(3, bl);
+    DECODE_START(4, bl);
     ::decode(struct_ver, bl);
     ::decode(map_epoch, bl);
     ::decode(info, bl);
@@ -367,6 +371,9 @@ struct metadata_section {
       osdmap.decode(bl);
     } else {
       cout << "WARNING: Older export without OSDMap information" << std::endl;
+    }
+    if (struct_v > 3) {
+      ::decode(divergent_priors, bl);
     }
     DECODE_FINISH(bl);
   }
@@ -630,9 +637,9 @@ static void invalid_filestore_path(string &path)
 
 int get_log(ObjectStore *fs, __u8 struct_ver,
    coll_t coll, spg_t pgid, const pg_info_t &info,
-   PGLog::IndexedLog &log, pg_missing_t &missing)
+   PGLog::IndexedLog &log, pg_missing_t &missing,
+   map<eversion_t, hobject_t> &divergent_priors)
 {
-  map<eversion_t, hobject_t> divergent_priors;
   try {
     ostringstream oss;
     assert(struct_ver > 0);
@@ -852,12 +859,12 @@ int write_info(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
 }
 
 int write_pg(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
-    pg_log_t &log, map<epoch_t,pg_interval_t> &past_intervals)
+    pg_log_t &log, map<epoch_t,pg_interval_t> &past_intervals,
+    map<eversion_t, hobject_t> &divergent_priors)
 {
   int ret = write_info(t, epoch, info, past_intervals);
   if (ret)
     return ret;
-  map<eversion_t, hobject_t> divergent_priors;
   coll_t coll(info.pgid);
   map<string,bufferlist> km;
   PGLog::write_log(t, &km, log, coll, info.pgid.make_pgmeta_oid(), divergent_priors);
@@ -1065,10 +1072,12 @@ int do_export(ObjectStore *fs, coll_t coll, spg_t pgid, pg_info_t &info,
 {
   PGLog::IndexedLog log;
   pg_missing_t missing;
+  map<eversion_t, hobject_t> divergent_priors;
 
   cerr << "Exporting " << pgid << std::endl;
 
-  int ret = get_log(fs, struct_ver, coll, pgid, info, log, missing);
+  int ret = get_log(fs, struct_ver, coll, pgid, info, log, missing,
+                    divergent_priors);
   if (ret > 0)
       return ret;
 
@@ -1085,7 +1094,7 @@ int do_export(ObjectStore *fs, coll_t coll, spg_t pgid, pg_info_t &info,
 
   // The metadata_section is now before files, so import can detect
   // errors and abort without wasting time.
-  metadata_section ms(struct_ver, map_epoch, info, log, past_intervals);
+  metadata_section ms(struct_ver, map_epoch, info, log, past_intervals, divergent_priors);
   ret = add_osdmap(fs, ms);
   if (ret)
     return ret;
@@ -1559,6 +1568,18 @@ int get_pg_metadata(ObjectStore *store, bufferlist &bl, metadata_section &ms,
   formatter->close_section();
   formatter->flush(cout);
   cout << std::endl;
+
+  formatter->open_array_section("divergent_priors");
+  for (map<eversion_t, hobject_t>::iterator it = ms.divergent_priors.begin();
+       it != ms.divergent_priors.end(); ++ it) {
+      formatter->open_object_section("item");
+      formatter->dump_stream("eversion") << it->first;
+      formatter->dump_stream("hobject") << it->second;
+      formatter->close_section();
+  }
+  formatter->close_section();
+  formatter->flush(cout);
+  cout << std::endl;
 #endif
 
   if (ms.map_epoch > sb.current_epoch) {
@@ -1724,6 +1745,38 @@ int do_import_rados(string pool)
   return 0;
 }
 
+
+typedef map<eversion_t, hobject_t> divergent_priors_t;
+
+// out: pg_log_t that only has entries that apply to import_pgid using curmap
+// reject: Entries rejected from "in" are in the reject.log.  Other fields not set.
+void filter_divergent_priors(spg_t import_pgid, const OSDMap &curmap,
+  const string &hit_set_namespace, const divergent_priors_t &in,
+  divergent_priors_t &out, divergent_priors_t &reject)
+{
+  out.clear();
+  reject.clear();
+
+  for (divergent_priors_t::const_iterator i = in.begin();
+       i != in.end(); ++i) {
+
+    if (i->second.nspace != hit_set_namespace) {
+      object_t oid = i->second.oid;
+      object_locator_t loc(i->second);
+      pg_t raw_pgid = curmap.object_locator_to_pg(oid, loc);
+      pg_t pgid = curmap.raw_pg_to_pg(raw_pgid);
+
+      if (import_pgid.pgid == pgid) {
+        out.insert(*i);
+      } else {
+        reject.insert(*i);
+      }
+    } else {
+      out.insert(*i);
+    }
+  }
+}
+
 int do_import(ObjectStore *store, OSDSuperblock& sb, bool force)
 {
   bufferlist ebl;
@@ -1880,8 +1933,21 @@ int do_import(ObjectStore *store, OSDSuperblock& sb, bool force)
       cerr << "Skipping log entry " << *i << std::endl;
   }
 
+  divergent_priors_t newdp, rejectdp;
+  filter_divergent_priors(pgid, curmap, g_ceph_context->_conf->osd_hit_set_namespace,
+    ms.divergent_priors, newdp, rejectdp);
+  ms.divergent_priors = newdp;
+  if (debug) {
+    for (divergent_priors_t::iterator i = newdp.begin();
+         i != newdp.end(); ++i)
+      cerr << "Keeping divergent_prior " << *i << std::endl;
+    for (divergent_priors_t::iterator i = rejectdp.begin();
+         i != rejectdp.end(); ++i)
+      cerr << "Skipping divergent_prior " << *i << std::endl;
+  }
+
   t = new ObjectStore::Transaction;
-  ret = write_pg(*t, ms.map_epoch, ms.info, newlog, ms.past_intervals);
+  ret = write_pg(*t, ms.map_epoch, ms.info, newlog, ms.past_intervals, ms.divergent_priors);
   if (ret) return ret;
 
   // done, clear removal flag
@@ -3183,17 +3249,32 @@ int main(int argc, char **argv)
     } else if (op == "log") {
       PGLog::IndexedLog log;
       pg_missing_t missing;
-      ret = get_log(fs, struct_ver, coll, pgid, info, log, missing);
+      map<eversion_t, hobject_t> divergent_priors;
+      ret = get_log(fs, struct_ver, coll, pgid, info, log, missing,
+                    divergent_priors);
       if (ret > 0)
           goto out;
 
-      formatter->open_object_section("log");
+      formatter->open_object_section("pg_log_t");
       log.dump(formatter);
       formatter->close_section();
       formatter->flush(cout);
       cout << std::endl;
-      formatter->open_object_section("missing");
+      formatter->open_object_section("pg_missing_t");
       missing.dump(formatter);
+      formatter->close_section();
+      formatter->flush(cout);
+      cout << std::endl;
+      formatter->open_object_section("map");
+      formatter->open_array_section("divergent_priors");
+      for (map<eversion_t, hobject_t>::iterator it = divergent_priors.begin();
+           it != divergent_priors.end(); ++ it) {
+          formatter->open_object_section("item");
+          formatter->dump_stream("eversion") << it->first;
+          formatter->dump_stream("hobject") << it->second;
+          formatter->close_section();
+      }
+      formatter->close_section();
       formatter->close_section();
       formatter->flush(cout);
       cout << std::endl;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2520,6 +2520,11 @@ int main(int argc, char **argv)
   ObjectStore *fs = ObjectStore::create(g_ceph_context, type, dpath, jpath, flags);
   if (fs == NULL) {
     cerr << "Must provide --type (filestore, memstore, keyvaluestore)" << std::endl;
+    if (type == "keyvaluestore") {
+      cerr << "Add \"keyvaluestore\" to "
+           << "enable_experimental_unrecoverable_data_corrupting_features"
+           << std::endl;
+    }
     exit(1);
   }
 

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -3255,16 +3255,15 @@ int main(int argc, char **argv)
       if (ret > 0)
           goto out;
 
+      formatter->open_object_section("op_log");
       formatter->open_object_section("pg_log_t");
       log.dump(formatter);
       formatter->close_section();
       formatter->flush(cout);
-      cout << std::endl;
       formatter->open_object_section("pg_missing_t");
       missing.dump(formatter);
       formatter->close_section();
       formatter->flush(cout);
-      cout << std::endl;
       formatter->open_object_section("map");
       formatter->open_array_section("divergent_priors");
       for (map<eversion_t, hobject_t>::iterator it = divergent_priors.begin();
@@ -3276,8 +3275,8 @@ int main(int argc, char **argv)
       }
       formatter->close_section();
       formatter->close_section();
+      formatter->close_section();
       formatter->flush(cout);
-      cout << std::endl;
     } else if (op == "rm-past-intervals") {
       ObjectStore::Transaction tran;
       ObjectStore::Transaction *t = &tran;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -662,6 +662,33 @@ int get_log(ObjectStore *fs, __u8 struct_ver,
   return 0;
 }
 
+void dump_log(Formatter *formatter, ostream &out, pg_log_t &log,
+      pg_missing_t &missing, map<eversion_t, hobject_t> &divergent_priors)
+{
+  formatter->open_object_section("op_log");
+  formatter->open_object_section("pg_log_t");
+  log.dump(formatter);
+  formatter->close_section();
+  formatter->flush(out);
+  formatter->open_object_section("pg_missing_t");
+  missing.dump(formatter);
+  formatter->close_section();
+  formatter->flush(out);
+  formatter->open_object_section("map");
+  formatter->open_array_section("divergent_priors");
+  for (map<eversion_t, hobject_t>::iterator it = divergent_priors.begin();
+       it != divergent_priors.end(); ++ it) {
+      formatter->open_object_section("item");
+      formatter->dump_stream("eversion") << it->first;
+      formatter->dump_stream("hobject") << it->second;
+      formatter->close_section();
+  }
+  formatter->close_section();
+  formatter->close_section();
+  formatter->close_section();
+  formatter->flush(out);
+}
+
 //Based on RemoveWQ::_process()
 void remove_coll(ObjectStore *store, const coll_t &coll)
 {
@@ -1092,6 +1119,12 @@ int do_export(ObjectStore *fs, coll_t coll, spg_t pgid, pg_info_t &info,
   if (ret > 0)
       return ret;
 
+  if (debug) {
+    Formatter *formatter = Formatter::create("json-pretty");
+    assert(formatter);
+    dump_log(formatter, cerr, log, missing, divergent_priors);
+    delete formatter;
+  }
   write_super();
 
   pg_begin pgb(pgid, superblock);
@@ -2007,6 +2040,13 @@ int do_import(ObjectStore *store, OSDSuperblock& sb, bool force)
       for (divergent_priors_t::iterator i = rejectdp.begin();
            i != rejectdp.end(); ++i)
         cerr << "Skipping divergent_prior " << *i << std::endl;
+    }
+
+    if (debug) {
+      pg_missing_t missing;
+      Formatter *formatter = Formatter::create("json-pretty");
+      dump_log(formatter, cerr, newlog, missing, ms.divergent_priors);
+      delete formatter;
     }
 
     ret = write_pg(t, ms.map_epoch, ms.info, newlog, ms.past_intervals, ms.divergent_priors);
@@ -3334,28 +3374,7 @@ int main(int argc, char **argv)
       if (ret < 0)
           goto out;
 
-      formatter->open_object_section("op_log");
-      formatter->open_object_section("pg_log_t");
-      log.dump(formatter);
-      formatter->close_section();
-      formatter->flush(cout);
-      formatter->open_object_section("pg_missing_t");
-      missing.dump(formatter);
-      formatter->close_section();
-      formatter->flush(cout);
-      formatter->open_object_section("map");
-      formatter->open_array_section("divergent_priors");
-      for (map<eversion_t, hobject_t>::iterator it = divergent_priors.begin();
-           it != divergent_priors.end(); ++ it) {
-          formatter->open_object_section("item");
-          formatter->dump_stream("eversion") << it->first;
-          formatter->dump_stream("hobject") << it->second;
-          formatter->close_section();
-      }
-      formatter->close_section();
-      formatter->close_section();
-      formatter->close_section();
-      formatter->flush(cout);
+      dump_log(formatter, cout, log, missing, divergent_priors);
     } else if (op == "rm-past-intervals") {
       ObjectStore::Transaction tran;
       ObjectStore::Transaction *t = &tran;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -92,6 +92,7 @@ const uint16_t shortmagic = 0xffce;	//goes into stream as "ceff"
 const mymagic_t endmagic = (0xecff << 16) | shortmagic;
 const int fd_none = INT_MIN;
 bool outistty;
+bool dry_run = false;
 
 //The first FIXED_LENGTH bytes are a fixed
 //portion of the export output.  This includes the overall
@@ -555,6 +556,8 @@ uint64_t testalign;
 
 template <typename T>
 int write_section(sectiontype_t type, const T& obj, int fd) {
+  if (dry_run)
+    return 0;
   bufferlist blhdr, bl, blftr;
   obj.encode(bl);
   header hdr(type, bl.length());
@@ -595,6 +598,8 @@ static void cleanbin(string &str)
 
 int write_simple(sectiontype_t type, int fd)
 {
+  if (dry_run)
+    return 0;
   bufferlist hbl;
 
   header hdr(type, 0);
@@ -786,10 +791,14 @@ int mark_pg_for_removal(ObjectStore *fs, spg_t pgid, ObjectStore::Transaction *t
 
 int initiate_new_remove_pg(ObjectStore *store, spg_t r_pgid)
 {
+  if (!dry_run)
+    finish_remove_pgs(store);
   if (!store->collection_exists(coll_t(r_pgid)))
     return -ENOENT;
 
   cout << " marking collection for removal" << std::endl;
+  if (dry_run)
+    return 0;
   ObjectStore::Transaction *rmt = new ObjectStore::Transaction;
   int r = mark_pg_for_removal(store, r_pgid, rmt);
   if (r < 0) {
@@ -797,6 +806,7 @@ int initiate_new_remove_pg(ObjectStore *store, spg_t r_pgid)
     return r;
   }
   store->apply_transaction(*rmt);
+  finish_remove_pgs(store);
   return r;
 }
 
@@ -1045,6 +1055,8 @@ int add_osdmap(ObjectStore *store, metadata_section &ms)
 //Write super_header with its fixed 16 byte length
 void write_super()
 {
+  if (dry_run)
+    return;
   bufferlist superbl;
   super_header sh;
   footer ft;
@@ -1296,23 +1308,30 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
   ioctx.set_namespace(ob.hoid.hobj.get_namespace());
 
   string msg("Write");
-  int ret = ioctx.create(ob.hoid.hobj.oid.name, true);
-  if (ret && ret != -EEXIST) {
-    cerr << "create failed: " << cpp_strerror(ret) << std::endl;
-    return ret;
-  }
-  if (ret == -EEXIST) {
-    msg = "***Overwrite***";
-    ret = ioctx.remove(ob.hoid.hobj.oid.name);
-    if (ret < 0) {
-      cerr << "remove failed: " << cpp_strerror(ret) << std::endl;
-      return ret;
-    }
-    ret = ioctx.create(ob.hoid.hobj.oid.name, true);
-    if (ret < 0) {
+  if (dry_run) {
+    uint64_t psize;
+    time_t pmtime;
+    int ret = ioctx.stat(ob.hoid.hobj.oid.name, &psize, &pmtime);
+    if (ret == 0)
+      msg = "***Overwrite***";
+  } else {
+    int ret = ioctx.create(ob.hoid.hobj.oid.name, true);
+    if (ret && ret != -EEXIST) {
       cerr << "create failed: " << cpp_strerror(ret) << std::endl;
       return ret;
     }
+    if (ret == -EEXIST) {
+      msg = "***Overwrite***";
+      ret = ioctx.remove(ob.hoid.hobj.oid.name);
+      if (ret < 0) {
+        cerr << "remove failed: " << cpp_strerror(ret) << std::endl;
+        return ret;
+      }
+      ret = ioctx.create(ob.hoid.hobj.oid.name, true);
+      if (ret < 0) {
+        cerr << "create failed: " << cpp_strerror(ret) << std::endl;
+        return ret;
+      }
   }
 
   cout << msg << " " << ob.hoid << std::endl;
@@ -1362,10 +1381,12 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
         if (databl.length() >= alignment) {
           uint64_t rndlen = uint64_t(databl.length() / alignment) * alignment;
           if (debug) cerr << "write offset=" << out_offset << " len=" << rndlen << std::endl;
-          ret = ioctx.write(ob.hoid.hobj.oid.name, databl, rndlen, out_offset);
-          if (ret) {
-            cerr << "write failed: " << cpp_strerror(ret) << std::endl;
-            return ret;
+          if (!dry_run) {
+            ret = ioctx.write(ob.hoid.hobj.oid.name, databl, rndlen, out_offset);
+            if (ret) {
+              cerr << "write failed: " << cpp_strerror(ret) << std::endl;
+              return ret;
+            }
           }
           out_offset += rndlen;
           bufferlist n;
@@ -1377,10 +1398,12 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
         }
         break;
       }
-      ret = ioctx.write(ob.hoid.hobj.oid.name, ds.databl, ds.len, ds.offset);
-      if (ret) {
-        cerr << "write failed: " << cpp_strerror(ret) << std::endl;
-        return ret;
+      if (!dry_run) {
+        ret = ioctx.write(ob.hoid.hobj.oid.name, ds.databl, ds.len, ds.offset);
+        if (ret) {
+          cerr << "write failed: " << cpp_strerror(ret) << std::endl;
+          return ret;
+        }
       }
       break;
     case TYPE_ATTRS:
@@ -1388,6 +1411,8 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
 
       if (debug)
         cerr << "\tattrs: len " << as.data.size() << std::endl;
+      if (dry_run)
+        break;
       for (i = as.data.begin(); i != as.data.end(); ++i) {
         if (i->first == "_" || i->first == "snapset")
           continue;
@@ -1407,6 +1432,8 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
       if (debug)
         cerr << "\tomap header: " << string(oh.hdr.c_str(), oh.hdr.length())
           << std::endl;
+      if (dry_run)
+        break;
       ret = ioctx.omap_set_header(ob.hoid.hobj.oid.name, oh.hdr);
       if (ret) {
         cerr << "omap_set_header failed: " << cpp_strerror(ret) << std::endl;
@@ -1419,6 +1446,8 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
 
       if (debug)
         cerr << "\tomap: size " << os.omap.size() << std::endl;
+      if (dry_run)
+        break;
       ret = ioctx.omap_set(ob.hoid.hobj.oid.name, os.omap);
       if (ret) {
         cerr << "omap_set failed: " << cpp_strerror(ret) << std::endl;
@@ -1427,16 +1456,18 @@ int get_object_rados(librados::IoCtx &ioctx, bufferlist &bl)
       }
       break;
     case TYPE_OBJECT_END:
+      done = true;
       if (need_align && databl.length() > 0) {
         assert(databl.length() < alignment);
         if (debug) cerr << "END write offset=" << out_offset << " len=" << databl.length() << std::endl;
+        if (dry_run)
+          break;
         ret = ioctx.write(ob.hoid.hobj.oid.name, databl, databl.length(), out_offset);
         if (ret) {
            cerr << "write failed: " << cpp_strerror(ret) << std::endl;
           return ret;
         }
       }
-      done = true;
       break;
     default:
       return -EFAULT;
@@ -1486,7 +1517,8 @@ int get_object(ObjectStore *store, coll_t coll, bufferlist &bl, OSDMap &curmap)
     }
   }
 
-  t->touch(coll, ob.hoid);
+  if (!dry_run)
+    t->touch(coll, ob.hoid);
 
   cout << "Write " << ob.hoid << std::endl;
 
@@ -1506,18 +1538,22 @@ int get_object(ObjectStore *store, coll_t coll, bufferlist &bl, OSDMap &curmap)
     }
     switch(type) {
     case TYPE_DATA:
+      if (dry_run) break;
       ret = get_data(store, coll, ob.hoid, t, ebl);
       if (ret) return ret;
       break;
     case TYPE_ATTRS:
+      if (dry_run) break;
       ret = get_attrs(store, coll, ob.hoid, t, ebl, driver, mapper);
       if (ret) return ret;
       break;
     case TYPE_OMAP_HDR:
+      if (dry_run) break;
       ret = get_omap_hdr(store, coll, ob.hoid, t, ebl);
       if (ret) return ret;
       break;
     case TYPE_OMAP:
+      if (dry_run) break;
       ret = get_omap(store, coll, ob.hoid, t, ebl);
       if (ret) return ret;
       break;
@@ -1529,7 +1565,8 @@ int get_object(ObjectStore *store, coll_t coll, bufferlist &bl, OSDMap &curmap)
       return -EFAULT;
     }
   }
-  store->apply_transaction(*t);
+  if (!dry_run)
+    store->apply_transaction(*t);
   return 0;
 }
 
@@ -1784,7 +1821,8 @@ int do_import(ObjectStore *store, OSDSuperblock& sb, bool force)
   pg_info_t info;
   PGLog::IndexedLog log;
 
-  finish_remove_pgs(store);
+  if (!dry_run)
+    finish_remove_pgs(store);
 
   int ret = sh.read_super();
   if (ret)
@@ -1872,17 +1910,19 @@ int do_import(ObjectStore *store, OSDSuperblock& sb, bool force)
     return -EEXIST;
   }
 
-  ObjectStore::Transaction *t = new ObjectStore::Transaction;
-  PG::_create(*t, pgid);
-  PG::_init(*t, pgid, NULL);
+  if (!dry_run) {
+    ObjectStore::Transaction *t = new ObjectStore::Transaction;
+    PG::_create(*t, pgid);
+    PG::_init(*t, pgid, NULL);
 
-  // mark this coll for removal until we're done
-  map<string,bufferlist> values;
-  ::encode((char)1, values["_remove"]);
-  t->omap_setkeys(coll, pgid.make_pgmeta_oid(), values);
+    // mark this coll for removal until we're done
+    map<string,bufferlist> values;
+    ::encode((char)1, values["_remove"]);
+    t->omap_setkeys(coll, pgid.make_pgmeta_oid(), values);
 
-  store->apply_transaction(*t);
-  delete t;
+    store->apply_transaction(*t);
+    delete t;
+  }
 
   cout << "Importing pgid " << pgid << std::endl;
 
@@ -1923,43 +1963,47 @@ int do_import(ObjectStore *store, OSDSuperblock& sb, bool force)
     return -EFAULT;
   }
 
-  pg_log_t newlog, reject;
-  pg_log_t::filter_log(pgid, curmap, g_ceph_context->_conf->osd_hit_set_namespace,
-    ms.log, newlog, reject);
-  if (debug) {
-    for (list<pg_log_entry_t>::iterator i = newlog.log.begin();
-         i != newlog.log.end(); ++i)
-      cerr << "Keeping log entry " << *i << std::endl;
-    for (list<pg_log_entry_t>::iterator i = reject.log.begin();
-         i != reject.log.end(); ++i)
-      cerr << "Skipping log entry " << *i << std::endl;
-  }
+  ObjectStore::Transaction t;
+  if (!dry_run) {
+    pg_log_t newlog, reject;
+    pg_log_t::filter_log(pgid, curmap, g_ceph_context->_conf->osd_hit_set_namespace,
+      ms.log, newlog, reject);
+    if (debug) {
+      for (list<pg_log_entry_t>::iterator i = newlog.log.begin();
+           i != newlog.log.end(); ++i)
+        cerr << "Keeping log entry " << *i << std::endl;
+      for (list<pg_log_entry_t>::iterator i = reject.log.begin();
+           i != reject.log.end(); ++i)
+        cerr << "Skipping log entry " << *i << std::endl;
+    }
 
-  divergent_priors_t newdp, rejectdp;
-  filter_divergent_priors(pgid, curmap, g_ceph_context->_conf->osd_hit_set_namespace,
-    ms.divergent_priors, newdp, rejectdp);
-  ms.divergent_priors = newdp;
-  if (debug) {
-    for (divergent_priors_t::iterator i = newdp.begin();
-         i != newdp.end(); ++i)
-      cerr << "Keeping divergent_prior " << *i << std::endl;
-    for (divergent_priors_t::iterator i = rejectdp.begin();
-         i != rejectdp.end(); ++i)
-      cerr << "Skipping divergent_prior " << *i << std::endl;
-  }
+    divergent_priors_t newdp, rejectdp;
+    filter_divergent_priors(pgid, curmap, g_ceph_context->_conf->osd_hit_set_namespace,
+      ms.divergent_priors, newdp, rejectdp);
+    ms.divergent_priors = newdp;
+    if (debug) {
+      for (divergent_priors_t::iterator i = newdp.begin();
+           i != newdp.end(); ++i)
+        cerr << "Keeping divergent_prior " << *i << std::endl;
+      for (divergent_priors_t::iterator i = rejectdp.begin();
+           i != rejectdp.end(); ++i)
+        cerr << "Skipping divergent_prior " << *i << std::endl;
+    }
 
-  t = new ObjectStore::Transaction;
-  ret = write_pg(*t, ms.map_epoch, ms.info, newlog, ms.past_intervals, ms.divergent_priors);
-  if (ret) return ret;
+    ret = write_pg(t, ms.map_epoch, ms.info, newlog, ms.past_intervals, ms.divergent_priors);
+    if (ret) return ret;
+  }
 
   // done, clear removal flag
   if (debug)
     cerr << "done, clearing removal flag" << std::endl;
-  set<string> remove;
-  remove.insert("_remove");
-  t->omap_rmkeys(coll, pgid.make_pgmeta_oid(), remove);
-  store->apply_transaction(*t);
-  delete t;
+
+  if (!dry_run) {
+    set<string> remove;
+    remove.insert("_remove");
+    t.omap_rmkeys(coll, pgid.make_pgmeta_oid(), remove);
+    store->apply_transaction(t);
+  }
 
   return 0;
 }
@@ -2000,9 +2044,11 @@ int do_remove_object(ObjectStore *store, coll_t coll, ghobject_t &ghobj)
     return r;
   }
 
+  cout << "remove " << ghobj << std::endl;
+  if (dry_run)
+    return 0;
   ObjectStore::Transaction *t = new ObjectStore::Transaction;
   OSDriver::OSTransaction _t(driver.get_transaction(t));
-  cout << "remove " << ghobj << std::endl;
   r = mapper.remove_oid(ghobj.hobj, &_t);
   if (r < 0 && r != -ENOENT) {
     cerr << "remove_oid returned " << cpp_strerror(r) << std::endl;
@@ -2109,8 +2155,10 @@ int do_set_bytes(ObjectStore *store, coll_t coll, ghobject_t &ghobj, int fd)
   if (debug)
     cerr << "Write " << ghobj << std::endl;
 
-  t->touch(coll, ghobj);
-  t->truncate(coll, ghobj, 0);
+  if (!dry_run) {
+    t->touch(coll, ghobj);
+    t->truncate(coll, ghobj, 0);
+  }
 
   uint64_t offset = 0;
   bufferlist rawdatabl;
@@ -2127,13 +2175,15 @@ int do_set_bytes(ObjectStore *store, coll_t coll, ghobject_t &ghobj, int fd)
 
     if (debug)
       cerr << "\tdata: offset " << offset << " bytes " << bytes << std::endl;
-    t->write(coll, ghobj, offset, bytes,  rawdatabl);
+    if (!dry_run)
+      t->write(coll, ghobj, offset, bytes,  rawdatabl);
 
     offset += bytes;
     // XXX: Should we apply_transaction() every once in a while for very large files
   } while(true);
 
-  store->apply_transaction(*t);
+  if (!dry_run)
+    store->apply_transaction(*t);
   return 0;
 }
 
@@ -2317,6 +2367,8 @@ struct do_fix_lost : public action_on_object_t {
   virtual int call(ObjectStore *store, coll_t coll, ghobject_t &ghobj, object_info_t &oi) {
     if (oi.is_lost()) {
       cout << coll << "/" << ghobj << " is lost, fixing" << std::endl;
+      if (dry_run)
+        return 0;
       oi.clear_flag(object_info_t::FLAG_LOST);
       bufferlist bl;
       ::encode(oi, bl);
@@ -2440,6 +2492,7 @@ int main(int argc, char **argv)
     ("force", "Ignore some types of errors and proceed with operation - USE WITH CAUTION: CORRUPTION POSSIBLE NOW OR IN THE FUTURE")
     ("skip-journal-replay", "Disable journal replay")
     ("skip-mount-omap", "Disable mounting of omap")
+    ("dry-run", "Don't modify the objectstore")
     ;
 
   po::options_description positional("Positional options");
@@ -2487,6 +2540,14 @@ int main(int argc, char **argv)
   } else {
     force = true;
   }
+
+  if (vm.count("dry-run"))
+    dry_run = true;
+  osflagbits_t flags = 0;
+  if (dry_run || vm.count("skip-journal-replay"))
+    flags |= SKIP_JOURNAL_REPLAY;
+  if (vm.count("skip-mount-omap"))
+    flags |= SKIP_MOUNT_OMAP;
 
   vector<const char *> ceph_options;
   env_to_vec(ceph_options);
@@ -2568,7 +2629,7 @@ int main(int argc, char **argv)
   outistty = isatty(STDOUT_FILENO);
 
   file_fd = fd_none;
-  if (op == "export") {
+  if (op == "export" && !dry_run) {
     if (!vm.count("file") || file == "-") {
       if (outistty) {
         cerr << "stdout is a tty and no --file filename specified" << std::endl;
@@ -2590,7 +2651,7 @@ int main(int argc, char **argv)
     }
   }
 
-  if (vm.count("file") && file_fd == fd_none) {
+  if (vm.count("file") && file_fd == fd_none && !dry_run) {
     cerr << "--file option only applies to import or export" << std::endl;
     myexit(1);
   }
@@ -2599,12 +2660,6 @@ int main(int argc, char **argv)
     perror("open");
     myexit(1);
   }
-
-  osflagbits_t flags = 0;
-  if (vm.count("skip-journal-replay"))
-    flags |= SKIP_JOURNAL_REPLAY;
-  if (vm.count("skip-mount-omap"))
-    flags |= SKIP_MOUNT_OMAP;
 
   global_init(
     NULL, ceph_options, CEPH_ENTITY_TYPE_OSD,
@@ -2890,19 +2945,20 @@ int main(int argc, char **argv)
         goto out;
     }
 
-    superblock.compat_features.incompat.insert(CEPH_OSD_FEATURE_INCOMPAT_SHARDS);
-    ObjectStore::Transaction t;
-    bl.clear();
-    ::encode(superblock, bl);
-    t.write(META_COLL, OSD_SUPERBLOCK_POBJECT, 0, bl.length(), bl);
-    ret = fs->apply_transaction(t);
-    if (ret < 0) {
-      cerr << "Error writing OSD superblock: " << cpp_strerror(ret) << std::endl;
-      goto out;
+    if (!dry_run) {
+      superblock.compat_features.incompat.insert(CEPH_OSD_FEATURE_INCOMPAT_SHARDS);
+      ObjectStore::Transaction t;
+      bl.clear();
+      ::encode(superblock, bl);
+      t.write(META_COLL, OSD_SUPERBLOCK_POBJECT, 0, bl.length(), bl);
+      ret = fs->apply_transaction(t);
+      if (ret < 0) {
+        cerr << "Error writing OSD superblock: " << cpp_strerror(ret) << std::endl;
+        goto out;
+      }
+
+      fs->set_allow_sharded_objects();
     }
-
-    fs->set_allow_sharded_objects();
-
     cout << "Enabled on-disk sharded objects" << std::endl;
 
     ret = 0;
@@ -2959,13 +3015,11 @@ int main(int argc, char **argv)
   biginfo_oid = OSD::make_pg_biginfo_oid(pgid);
 
   if (op == "remove") {
-    finish_remove_pgs(fs);
     ret = initiate_new_remove_pg(fs, pgid);
     if (ret < 0) {
       cerr << "PG '" << pgid << "' not found" << std::endl;
       goto out;
     }
-    finish_remove_pgs(fs);
     cout << "Remove successful" << std::endl;
     goto out;
   }
@@ -3326,6 +3380,14 @@ out:
     // If no previous error, then use umount() error
     if (ret == 0)
       ret = r;
+  }
+
+  if (dry_run) {
+    // Export output can go to stdout, so put this message on stderr
+    if (op == "export")
+      cerr << "dry-run: Nothing changed" << std::endl;
+    else
+      cout << "dry-run: Nothing changed" << std::endl;
   }
 
   if (ret < 0)

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1724,7 +1724,7 @@ int do_import_rados(string pool)
   return 0;
 }
 
-int do_import(ObjectStore *store, OSDSuperblock& sb)
+int do_import(ObjectStore *store, OSDSuperblock& sb, bool force)
 {
   bufferlist ebl;
   pg_info_t info;
@@ -1786,8 +1786,11 @@ int do_import(ObjectStore *store, OSDSuperblock& sb)
       cerr << "OSD requires sharding to be enabled" << std::endl;
       cerr << std::endl;
       cerr << "If you wish to import, first do 'ceph-objectstore-tool...--op set-allow-sharded-objects'" << std::endl;
+      return 1;
     }
-    return 11;  // Assume no +EAGAIN gets to end of main() until we clean up error code handling
+    // Let them import if they specify the --force option
+    if (!force)
+        return 11;  // Assume no +EAGAIN gets to end of main() until we clean up error code handling
   }
 
   // Don't import if pool no longer exists
@@ -2312,6 +2315,7 @@ int main(int argc, char **argv)
   spg_t pgid;
   ghobject_t ghobj;
   bool human_readable;
+  bool force;
   Formatter *formatter;
 
   po::options_description desc("Allowed options");
@@ -2332,6 +2336,7 @@ int main(int argc, char **argv)
     ("format", po::value<string>(&format)->default_value("json-pretty"),
      "Output format which may be json, json-pretty, xml, xml-pretty")
     ("debug", "Enable diagnostic output to stderr")
+    ("force", "Ignore some types of errors and proceed with operation - USE WITH CAUTION: CORRUPTION POSSIBLE NOW OR IN THE FUTURE")
     ("skip-journal-replay", "Disable journal replay")
     ("skip-mount-omap", "Disable mounting of omap")
     ;
@@ -2374,6 +2379,12 @@ int main(int argc, char **argv)
     debug = false;
   } else {
     debug = true;
+  }
+
+  if (!vm.count("force")) {
+    force = false;
+  } else {
+    force = true;
   }
 
   vector<const char *> ceph_options;
@@ -2812,7 +2823,7 @@ int main(int argc, char **argv)
   if (op == "import") {
 
     try {
-      ret = do_import(fs, superblock);
+      ret = do_import(fs, superblock, force);
     }
     catch (const buffer::error &e) {
       cerr << "do_import threw exception error " << e.what() << std::endl;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1525,6 +1525,7 @@ int get_object(ObjectStore *store, coll_t coll, bufferlist &bl, OSDMap &curmap)
       done = true;
       break;
     default:
+      cerr << "Unknown section type " << type << std::endl;
       return -EFAULT;
     }
   }
@@ -1650,6 +1651,7 @@ int do_import_rados(string pool)
   if (ret)
     return ret;
   if (type != TYPE_PG_BEGIN) {
+    cerr << "Invalid first section type " << type << std::endl;
     return -EFAULT;
   }
 
@@ -1911,6 +1913,7 @@ int do_import(ObjectStore *store, OSDSuperblock& sb, bool force)
       done = true;
       break;
     default:
+      cerr << "Unknown section type " << type << std::endl;
       return -EFAULT;
     }
   }

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2903,8 +2903,9 @@ int main(int argc, char **argv)
     if (op != "list-pgs" && tmppgid != pgid) {
       continue;
     }
-    if (snap != CEPH_NOSNAP && debug) {
-      cout << "skipping snapped dir " << *it
+    if (snap != CEPH_NOSNAP) {
+      if (debug)
+        cerr << "skipping snapped dir " << *it
 	       << " (pg " << pgid << " snap " << snap << ")" << std::endl;
       continue;
     }


### PR DESCRIPTION
Fixes for the following bugs/features:

10809: ceph-objectstore-tool can exit and lose logging output
11135: ceph-objectstore-tool should let you dump a filestore journal
10290: ceph_objectstore_tool should support --dry-run option
11237: ceph-objectstore-tool needs to export and import the divergent_priors

Let's get this in so we can resolve conflicts with the rados import/export code.