### PR TITLE
mon: OSDMonitor: fallback to json-pretty in case of invalid formatter

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -467,7 +467,9 @@ function test_mon_osd()
 
   ceph osd dump | grep 'osd.0 up'
   ceph osd find 1
+  ceph --format plain osd find 1 # falls back to json-pretty
   ceph osd metadata 1 | grep 'distro'
+  ceph --format plain osd metadata 1 | grep 'distro' # falls back to json-pretty
   ceph osd out 0
   ceph osd dump | grep 'osd.0.*out'
   ceph osd in 0

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2301,6 +2301,8 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
     string format;
     cmd_getval(g_ceph_context, cmdmap, "format", format, string("json-pretty"));
     boost::scoped_ptr<Formatter> f(new_formatter(format));
+    if (!f)
+      f.reset(new_formatter("json-pretty"));
 
     f->open_object_section("osd_location");
     f->dump_int("osd", osd);
@@ -2328,6 +2330,8 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
     string format;
     cmd_getval(g_ceph_context, cmdmap, "format", format, string("json-pretty"));
     boost::scoped_ptr<Formatter> f(new_formatter(format));
+    if (!f)
+      f.reset(new_formatter("json-pretty"));
     f->open_object_section("osd_metadata");
     r = dump_osd_metadata(osd, f.get(), &ss);
     if (r < 0)


### PR DESCRIPTION
http://tracker.ceph.com/issues/9538

Backport of 13780d755115387591888f94ea6c58ac0db3ecc4 to firefly