### PR TITLE
os/NewStore: avoid dup the data of the overlays in the WAL

### DIFF
--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -3335,12 +3335,12 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
 
         bl_next_data.substr_of(bl_next, next->second.value_offset,
                                next->second.length);
-        bl.claim_append(bl_next_data);
+        op->data.claim_append(bl_next_data);
         op->length += next->second.length;
-	op->overlays.push_back(next->second);
+        op->overlays.push_back(next->second);
 
-	++prev;
-	++next;
+        ++prev;
+        ++next;
       } else {
 	break;
       }

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -2498,6 +2498,23 @@ void NewStore::_kv_sync_thread()
 	    it != wal_cleaning.end();
 	    it++) {
 	wal_transaction_t& wt =*(*it)->wal_txn; 
+	// cleanup the data in overlays
+	for (list<wal_op_t>::iterator p = wt.ops.begin(); p != wt.ops.end(); ++p) {
+	  for (vector<overlay_t>::iterator q = p->overlays.begin();
+               q != p->overlays.end(); ++q) {
+            string key;
+            get_overlay_key(p->nid, q->key, &key);
+	    txc_cleanup_sync->rmkey(PREFIX_OVERLAY, key);
+	  }
+	}
+	// cleanup the shared overlays. this may double delete something we
+	// did above, but that's less work than doing careful ref counting
+	// of the overlay key/value pairs.
+	for (vector<string>::iterator p = wt.shared_overlay_keys.begin();
+             p != wt.shared_overlay_keys.end(); ++p) {
+	  txc_cleanup_sync->rmkey(PREFIX_OVERLAY, *p);
+	}
+	// cleanup the wal
 	string key;
 	get_wal_key(wt.seq, &key);
 	txc_cleanup_sync->rmkey(PREFIX_WAL, key);	
@@ -2700,6 +2717,19 @@ int NewStore::_wal_replay()
     } catch (buffer::error& e) {
       derr << __func__ << " failed to decode wal txn " << it->key() << dendl;
       return -EIO;
+    }
+
+    // Get the overlay data of the WAL for replay
+    for (list<wal_op_t>::iterator q = wt.ops.begin(); q != wt.ops.end(); ++q) {
+      for (vector<overlay_t>::iterator oit = q->overlays.begin();
+           oit != q->overlays.end(); ++oit) {
+        string key;
+        get_overlay_key(q->nid, oit->key, &key);
+        bufferlist bl, bl_data;
+        db->get(PREFIX_OVERLAY, key, &bl);
+        bl_data.substr_of(bl, oit->value_offset, oit->length);
+        q->data.claim_append(bl_data);
+      }
     }
     dout(20) << __func__ << " replay " << it->key() << dendl;
     int r = _do_wal_transaction(wt, NULL);  // don't bother with aio here
@@ -3286,9 +3316,10 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
     op->offset = p->first;
     op->length = p->second.length;
     op->fid = f.fid;
+    // The overlays will be removed from the db after applying the WAL
+    op->nid = o->onode.nid;
+    op->overlays.push_back(p->second);
     op->data.substr_of(bl, p->second.value_offset, p->second.length);
-
-    txc->t->rmkey(PREFIX_OVERLAY, key);
 
     // Combine with later overlays if contiguous
     map<uint64_t,overlay_t>::iterator prev = p, next = p;
@@ -3306,7 +3337,7 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
                                next->second.length);
         bl.claim_append(bl_next_data);
         op->length += next->second.length;
-        txc->t->rmkey(PREFIX_OVERLAY, key_next);
+	op->overlays.push_back(next->second);
 
 	++prev;
 	++next;
@@ -3317,16 +3348,15 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
     p = next;
   }
 
-  // this may double delete something we did above, but that's less
-  // work than doing careful ref counting of the overlay key/value
-  // pairs.
+  // put the shared overlay keys into the WAL transaction, so that we
+  // can cleanup them later after applying the WAL
   for (set<uint64_t>::iterator p = o->onode.shared_overlays.begin();
        p != o->onode.shared_overlays.end();
        ++p) {
     dout(10) << __func__ << " shared overlay " << *p << dendl;
     string key;
     get_overlay_key(o->onode.nid, *p, &key);
-    txc->t->rmkey(PREFIX_OVERLAY, key);
+    txc->wal_txn->shared_overlay_keys.push_back(key);
   }
 
   o->onode.overlay_map.clear();

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -2587,6 +2587,9 @@ int NewStore::_do_wal_transaction(wal_transaction_t& wt,
   vector<int> sync_fds;
   sync_fds.reserve(wt.ops.size());
 
+  // read all the overlay data first for apply
+  _do_read_all_overlays(wt);
+
   for (list<wal_op_t>::iterator p = wt.ops.begin(); p != wt.ops.end(); ++p) {
     switch (p->op) {
     case wal_op_t::OP_WRITE:
@@ -2720,17 +2723,7 @@ int NewStore::_wal_replay()
     }
 
     // Get the overlay data of the WAL for replay
-    for (list<wal_op_t>::iterator q = wt.ops.begin(); q != wt.ops.end(); ++q) {
-      for (vector<overlay_t>::iterator oit = q->overlays.begin();
-           oit != q->overlays.end(); ++oit) {
-        string key;
-        get_overlay_key(q->nid, oit->key, &key);
-        bufferlist bl, bl_data;
-        db->get(PREFIX_OVERLAY, key, &bl);
-        bl_data.substr_of(bl, oit->value_offset, oit->length);
-        q->data.claim_append(bl_data);
-      }
-    }
+    _do_read_all_overlays(wt);
     dout(20) << __func__ << " replay " << it->key() << dendl;
     int r = _do_wal_transaction(wt, NULL);  // don't bother with aio here
     if (r < 0)
@@ -3306,10 +3299,6 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
        p != o->onode.overlay_map.end(); ) {
     dout(10) << __func__ << " overlay " << p->first
 	     << "~" << p->second << dendl;
-    string key;
-    get_overlay_key(o->onode.nid, p->second.key, &key);
-    bufferlist bl;
-    db->get(PREFIX_OVERLAY, key, &bl);
 
     wal_op_t *op = _get_wal_op(txc);
     op->op = wal_op_t::OP_WRITE;
@@ -3319,7 +3308,6 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
     // The overlays will be removed from the db after applying the WAL
     op->nid = o->onode.nid;
     op->overlays.push_back(p->second);
-    op->data.substr_of(bl, p->second.value_offset, p->second.length);
 
     // Combine with later overlays if contiguous
     map<uint64_t,overlay_t>::iterator prev = p, next = p;
@@ -3328,14 +3316,6 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
       if (prev->first + prev->second.length == next->first) {
         dout(10) << __func__ << " combining overlay " << next->first
                  << "~" << next->second << dendl;
-        string key_next;
-        get_overlay_key(o->onode.nid, next->second.key, &key_next);
-        bufferlist bl_next, bl_next_data;
-        db->get(PREFIX_OVERLAY, key_next, &bl_next);
-
-        bl_next_data.substr_of(bl_next, next->second.value_offset,
-                               next->second.length);
-        op->data.claim_append(bl_next_data);
         op->length += next->second.length;
         op->overlays.push_back(next->second);
 
@@ -3363,6 +3343,22 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
   o->onode.shared_overlays.clear();
   txc->write_onode(o);
   return 0;
+}
+
+void NewStore::_do_read_all_overlays(wal_transaction_t& wt)
+{
+  for (list<wal_op_t>::iterator p = wt.ops.begin(); p != wt.ops.end(); ++p) {
+    for (vector<overlay_t>::iterator q = p->overlays.begin();
+         q != p->overlays.end(); ++q) {
+      string key;
+      get_overlay_key(p->nid, q->key, &key);
+      bufferlist bl, bl_data;
+      db->get(PREFIX_OVERLAY, key, &bl);
+      bl_data.substr_of(bl, q->value_offset, q->length);
+      p->data.claim_append(bl_data);
+    }
+  }
+  return;
 }
 
 int NewStore::_do_write(TransContext *txc,

--- a/src/os/newstore/NewStore.h
+++ b/src/os/newstore/NewStore.h
@@ -739,6 +739,7 @@ private:
 			const bufferlist& bl);
   int _do_write_all_overlays(TransContext *txc,
 			     OnodeRef o);
+  void _do_read_all_overlays(wal_transaction_t& wt);
   int _do_write(TransContext *txc,
 		OnodeRef o,
 		uint64_t offset, uint64_t length,

--- a/src/os/newstore/newstore_types.h
+++ b/src/os/newstore/newstore_types.h
@@ -151,6 +151,8 @@ struct wal_op_t {
   fid_t fid;
   uint64_t offset, length;
   bufferlist data;
+  uint64_t nid;
+  vector<overlay_t> overlays;
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& p);
@@ -164,6 +166,7 @@ WRITE_CLASS_ENCODER(wal_op_t)
 struct wal_transaction_t {
   uint64_t seq;
   list<wal_op_t> ops;
+  vector<string> shared_overlay_keys;
 
   int64_t _bytes;  ///< cached byte count
 


### PR DESCRIPTION
When writing all the overlays, there is no need to dup the data in WAL.
Instead, we can reference the overlays in the WAL, and remove these
overlays after commiting them to the fs. When replaying, we can get
these data from the referenced overlays. Doing this way, we can save a
write and a deletion for each of the overlay data in the db.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>