### PR TITLE
os/NewStore: need to increase the wal op length when combining overlays

### DIFF
--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -3299,6 +3299,7 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
         bl_next_data.substr_of(bl_next, next->second.value_offset,
                                next->second.length);
         bl.claim_append(bl_next_data);
+        op->length += next->second.length;
         txc->t->rmkey(PREFIX_OVERLAY, key_next);
 
 	++prev;


### PR DESCRIPTION
Need to add the length of the combining overlays to the length of the
wal op.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>