### PR TITLE
RFC: tolerate removed_snaps that shrinks

### DIFF
--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -226,6 +226,9 @@ class interval_set {
   bool operator==(const interval_set& other) const {
     return _size == other._size && m == other.m;
   }
+  bool operator!=(const interval_set& other) const {
+    return !(*this == other);
+  }
 
   int size() const {
     return _size;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2488,7 +2488,7 @@ PGPool OSD::_get_pool(int id, OSDMapRef createmap)
   p.snapc = pi->get_snap_context();
 
   pi->build_removed_snaps(p.cached_removed_snaps);
-  dout(10) << "_get_pool " << p.id << dendl;
+  dout(10) << "_get_pool " << p.id << " cached_removed_snaps " << p.cached_removed_snaps << dendl;
   return p;
 }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -166,10 +166,12 @@ void PGPool::update(OSDMapRef map)
 	<< dendl;
     }
 
+    // trust pool's set
+    cached_removed_snaps = newly_removed_snaps;
+
     // subtract off cached value (if it intersects!)
     newly_removed_snaps.subtract(intersection);
 
-    cached_removed_snaps.union_of(newly_removed_snaps);
     snapc = pi->get_snap_context();
   } else {
     newly_removed_snaps.clear();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1543,7 +1543,9 @@ void PG::activate(ObjectStore::Transaction& t,
     dout(20) << "activate - purged_snaps " << info.purged_snaps
 	     << " cached_removed_snaps " << pool.cached_removed_snaps << dendl;
     snap_trimq = pool.cached_removed_snaps;
-    snap_trimq.subtract(info.purged_snaps);
+    interval_set<snapid_t> intersection = info.purged_snaps;
+    intersection.intersection_of(pool.cached_removed_snaps);
+    snap_trimq.subtract(intersection);
     dout(10) << "activate - snap_trimq " << snap_trimq << dendl;
     if (!snap_trimq.empty() && is_clean())
       queue_snap_trim();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -154,7 +154,21 @@ void PGPool::update(OSDMapRef map)
   name = map->get_pool_name(id);
   if (pi->get_snap_epoch() == map->get_epoch()) {
     pi->build_removed_snaps(newly_removed_snaps);
-    newly_removed_snaps.subtract(cached_removed_snaps);
+
+    interval_set<snapid_t> intersection;
+    intersection = newly_removed_snaps;
+    intersection.intersection_of(cached_removed_snaps);
+    if (intersection != cached_removed_snaps) {
+      lgeneric_subdout(g_ceph_context, osd, 1)
+	<< "PGPool::update " << id << " warning: cached_removed_snaps "
+	<< cached_removed_snaps << " not a subset of latest removed_snaps "
+	<< newly_removed_snaps << "; intersection is " << intersection
+	<< dendl;
+    }
+
+    // subtract off cached value (if it intersects!)
+    newly_removed_snaps.subtract(intersection);
+
     cached_removed_snaps.union_of(newly_removed_snaps);
     snapc = pi->get_snap_context();
   } else {


### PR DESCRIPTION
(do not merge this; we want this against master and will then backport it)

This just tolerates an already-broken pool.  We also need to fix the root
cause.