### PR TITLE
os/Newstore: flush_commit return true on STATE_KV_DONE

### DIFF
--- a/src/os/newstore/NewStore.h
+++ b/src/os/newstore/NewStore.h
@@ -304,10 +304,10 @@ public:
 	return true;
       }
       TransContext *txc = &q.back();
-      if (txc->state > TransContext::STATE_KV_DONE) {
+      if (txc->state >= TransContext::STATE_KV_DONE) {
 	return true;
       }
-      assert(txc->state <= TransContext::STATE_KV_DONE);
+      assert(txc->state < TransContext::STATE_KV_DONE);
       txc->oncommits.push_back(c);
       return false;
     }


### PR DESCRIPTION
There is a racing condition here, if the flush_commit() call
happened after _txc_finish_kv and before next state, the context
was pushed to on_commits but no one will handle the context since
we already pass _txc_finish_kv. This bug can be easily reproduce
by putting a sleep(5) after _txc_finish_kv, and trigger the bug by
ceph-osd -i 0 --mkfs.

Fix this bug by return true directly when state >= STATE_KV_DONE(instead
of > in previous code). We already persist the data in STATE_KV_DONE so
it's safe for us to do this.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>