### PR TITLE
os/newstore: fix deadlock when newstore_sync_transaction=true

### DIFF
--- a/src/os/newstore/NewStore.h
+++ b/src/os/newstore/NewStore.h
@@ -279,7 +279,8 @@ public:
     Mutex wal_apply_lock;
 
     OpSequencer()
-      : qlock("NewStore::OpSequencer::qlock", false, false),
+	//set the qlock to to PTHREAD_MUTEX_RECURSIVE mode
+      : qlock("NewStore::OpSequencer::qlock", true, false),
 	parent(NULL),
 	wal_apply_lock("NewStore::OpSequencer::wal_apply_lock") {
     }


### PR DESCRIPTION
There is a deadlock issue in Newstore when newstore_sync_transaction = true.
With sync_transaction to true, the txc state machine will go all the way down
from STATE_IO_DONE to STATE_FINISHING in the same thread, while holding the osr->qlock().
The deadlock is caused in _txc_finish and _osr_reap_done, when trying to
lock osr->qlock again.

Since the _txc_finish can be called with(in sync transaction mode) or without
(in async transaction mode) holding the qlock, so fix this by setting the qlock
to PTHREAD_MUTEX_RECURSIVE, thus we can recursive acquire the qlock.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>