### PR TITLE
use get_linux_version() instead ad-hoc uname().release parsing

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -30,6 +30,7 @@ using namespace std;
 
 #include "common/Timer.h"
 #include "common/ceph_argparse.h"
+#include "common/linux_version.h"
 #include "global/global_init.h"
 #include "common/safe_io.h"
        
@@ -121,20 +122,11 @@ int main(int argc, const char **argv, const char *envp[]) {
       }
       virtual ~RemountTest() {}
       virtual void *entry() {
-	struct utsname os_info;
-	int tr = uname(&os_info);
-	assert(tr == 0);
-	assert(memcmp(os_info.sysname, "Linux", 5) == 0);
-	int major, minor;	
-	char *end_num;
-	major = strtol(os_info.release, &end_num, 10);
-	assert(major > 0);
-	++end_num;
-	minor = strtol(end_num, NULL, 10);
+	int ver = get_linux_version();
+	assert(ver != 0);
 	bool can_invalidate_dentries = g_conf->client_try_dentry_invalidate &&
-	  (major < 3 ||
-	   (major == 3 && minor < 18));
-	tr = client->test_dentry_handling(can_invalidate_dentries);
+				       ver < KERNEL_VERSION(3, 18, 0);
+	int tr = client->test_dentry_handling(can_invalidate_dentries);
 	if (tr != 0) {
 	  cerr << "ceph-fuse[" << getpid()
 	       << "]: fuse failed dentry invalidate/remount test with error "


### PR DESCRIPTION
Tested by booting various kernels.