### PR TITLE
Wip int option overflow

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -902,12 +902,22 @@ int md_config_t::set_val_raw(const char *val, const config_option *opt)
     case OPT_STR:
       *(std::string*)opt->conf_ptr(this) = val ? val : "";
       return 0;
-    case OPT_FLOAT:
-      *(float*)opt->conf_ptr(this) = atof(val);
+    case OPT_FLOAT: {
+      std::string err;
+      float f = strict_strtof(val, &err);
+      if (!err.empty())
+	return -EINVAL;
+      *(float*)opt->conf_ptr(this) = f;
       return 0;
-    case OPT_DOUBLE:
-      *(double*)opt->conf_ptr(this) = atof(val);
+    }
+    case OPT_DOUBLE: {
+      std::string err;
+      double f = strict_strtod(val, &err);
+      if (!err.empty())
+	return -EINVAL;
+      *(double*)opt->conf_ptr(this) = f;
       return 0;
+    }
     case OPT_BOOL:
       if (strcasecmp(val, "false") == 0)
 	*(bool*)opt->conf_ptr(this) = false;

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -885,7 +885,7 @@ int md_config_t::set_val_raw(const char *val, const config_option *opt)
   switch (opt->type) {
     case OPT_INT: {
       std::string err;
-      int f = strict_sistrtoll(val, &err);
+      int f = strict_si_cast<int>(val, &err);
       if (!err.empty())
 	return -EINVAL;
       *(int*)opt->conf_ptr(this) = f;
@@ -893,7 +893,7 @@ int md_config_t::set_val_raw(const char *val, const config_option *opt)
     }
     case OPT_LONGLONG: {
       std::string err;
-      long long f = strict_sistrtoll(val, &err);
+      long long f = strict_si_cast<long long>(val, &err);
       if (!err.empty())
 	return -EINVAL;
       *(long long*)opt->conf_ptr(this) = f;
@@ -923,7 +923,7 @@ int md_config_t::set_val_raw(const char *val, const config_option *opt)
       return 0;
     case OPT_U32: {
       std::string err;
-      int f = strict_sistrtoll(val, &err);
+      int f = strict_si_cast<int>(val, &err);
       if (!err.empty())
 	return -EINVAL;
       *(uint32_t*)opt->conf_ptr(this) = f;
@@ -931,7 +931,7 @@ int md_config_t::set_val_raw(const char *val, const config_option *opt)
     }
     case OPT_U64: {
       std::string err;
-      long long f = strict_sistrtoll(val, &err);
+      uint64_t f = strict_si_cast<uint64_t>(val, &err);
       if (!err.empty())
 	return -EINVAL;
       *(uint64_t*)opt->conf_ptr(this) = f;

--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -12,14 +12,12 @@
  *
  */
 
+#include "strtol.h"
+
 #include <errno.h>
 #include <limits.h>
 #include <sstream>
 #include <stdlib.h>
-#include <string>
-extern "C" {
-#include <stdint.h>
-}
 
 using std::ostringstream;
 
@@ -134,10 +132,8 @@ float strict_strtof(const char *str, std::string *err)
 uint64_t strict_sistrtoll(const char *str, std::string *err)
 {
   std::string s(str);
-  if (s.size() == 0) {
-    ostringstream oss;
-    oss << "strict_sistrtoll: value not specified";
-    *err = oss.str();
+  if (s.empty()) {
+    *err = "strict_sistrtoll: value not specified";
     return 0;
   }
   const char &u = s.at(s.size()-1); //str[std::strlen(str)-1];
@@ -164,9 +160,25 @@ uint64_t strict_sistrtoll(const char *str, std::string *err)
     s = std::string(str, s.size()-1);
   v = s.c_str();
 
-  uint64_t r = strict_strtoll(v, 10, err);
+  long long r_ll = strict_strtoll(v, 10, err);
+
+  if (r_ll < 0) {
+    *err = "strict_sistrtoll: value should not be negative";
+    return 0;
+  }
+
+  uint64_t r = r_ll;
   if (err->empty() && m > 0) {
-    r = (r << m);
+    if (r > (std::numeric_limits<uint64_t>::max() >> m)) {
+      *err = "strict_sistrtoll: value seems to be too large";
+      return 0;
+    }
+    r <<= m;
   }
   return r;
+}
+
+template <>
+uint64_t strict_si_cast(const char *str, std::string *err) {
+  return strict_sistrtoll(str, err);
 }

--- a/src/common/strtol.h
+++ b/src/common/strtol.h
@@ -16,6 +16,7 @@
 #define CEPH_COMMON_STRTOL_H
 
 #include <string>
+#include <limits>
 extern "C" {
 #include <stdint.h>
 }
@@ -29,5 +30,22 @@ double strict_strtod(const char *str, std::string *err);
 float strict_strtof(const char *str, std::string *err);
 
 uint64_t strict_sistrtoll(const char *str, std::string *err);
+
+template <typename Target>
+Target strict_si_cast(const char *str, std::string *err) {
+  uint64_t ret = strict_sistrtoll(str, err);
+  if (!err->empty())
+    return ret;
+  if (ret > (uint64_t)std::numeric_limits<Target>::max()) {
+    err->append("The option value '");
+    err->append(str);
+    err->append("' seems to be too large");
+    return 0;
+  }
+  return ret;
+}
+
+template <>
+uint64_t strict_si_cast(const char *str, std::string *err);
 
 #endif

--- a/src/test/daemon_config.cc
+++ b/src/test/daemon_config.cc
@@ -360,6 +360,25 @@ TEST(DaemonConfig, InvalidIntegers) {
   }
 }
 
+TEST(DaemonConfig, InvalidFloats) {
+  {
+    double bad_value = 2 * (double)std::numeric_limits<float>::max();
+    string str = boost::lexical_cast<string>(-bad_value);
+    int ret = g_ceph_context->_conf->set_val("log_stop_at_utilization", str);
+    ASSERT_EQ(ret, -EINVAL);
+  }
+  {
+    double bad_value = 2 * (double)std::numeric_limits<float>::max();
+    string str = boost::lexical_cast<string>(bad_value);
+    int ret = g_ceph_context->_conf->set_val("log_stop_at_utilization", str);
+    ASSERT_EQ(ret, -EINVAL);
+  }
+  {
+    int ret = g_ceph_context->_conf->set_val("log_stop_at_utilization", "not a float");
+    ASSERT_EQ(ret, -EINVAL);
+  }
+}
+
 /*
  * Local Variables:
  * compile-command: "cd .. ; make unittest_daemon_config && ./unittest_daemon_config"

--- a/src/test/daemon_config.cc
+++ b/src/test/daemon_config.cc
@@ -23,6 +23,9 @@
 #include <string>
 #include <string.h>
 
+#include <boost/lexical_cast.hpp>
+
+
 using std::string;
 
 TEST(DaemonConfig, SimpleSet) {
@@ -333,6 +336,30 @@ TEST(DaemonConfig, ThreadSafety1) {
 				       "false"));
   ASSERT_EQ(ret, 0);
 }
+
+TEST(DaemonConfig, InvalidIntegers) {
+  {
+    int ret = g_ceph_context->_conf->set_val("num_client", "-1");
+    ASSERT_EQ(ret, -EINVAL);
+  }
+  {
+    int ret = g_ceph_context->_conf->set_val("num_client", "-1K");
+    ASSERT_EQ(ret, -EINVAL);
+  }
+  {
+    long long bad_value = (long long)std::numeric_limits<int>::max() + 1;
+    string str = boost::lexical_cast<string>(bad_value);
+    int ret = g_ceph_context->_conf->set_val("num_client", str);
+    ASSERT_EQ(ret, -EINVAL);
+  }
+  {
+    // 4G must be greater than INT_MAX
+    ASSERT_GT(4LL * 1024 * 1024 * 1024, (long long)std::numeric_limits<int>::max());
+    int ret = g_ceph_context->_conf->set_val("num_client", "4G");
+    ASSERT_EQ(ret, -EINVAL);
+  }
+}
+
 /*
  * Local Variables:
  * compile-command: "cd .. ; make unittest_daemon_config && ./unittest_daemon_config"

--- a/src/test/strtol.cc
+++ b/src/test/strtol.cc
@@ -174,7 +174,8 @@ TEST(SIStrToLL, WithUnits) {
 
   for (std::map<char,int>::iterator p = units.begin();
        p != units.end(); ++p) {
-    test_strict_sistrtoll_units("1024", p->first, p->second);
+    // the upper bound of uint64_t is 2^64 = 4E
+    test_strict_sistrtoll_units("4", p->first, p->second);
     test_strict_sistrtoll_units("1", p->first, p->second);
     test_strict_sistrtoll_units("0", p->first, p->second);
   }
@@ -208,4 +209,14 @@ TEST(SIStrToLL, Error) {
   test_strict_sistrtoll_err("BM");
   test_strict_sistrtoll_err("B0wef");
   test_strict_sistrtoll_err("0m");
+  test_strict_sistrtoll_err("-1"); // it returns uint64_t
+  test_strict_sistrtoll_err("-1K");
+  // the upper bound of uint64_t is 2^64 = 4E, so 1024E overflows
+  test_strict_sistrtoll_err("1024E"); // overflows after adding the suffix
 }
+
+/*
+ * Local Variables:
+ * compile-command: "cd .. ; make unittest_strtol && ./unittest_strtol"
+ * End:
+ */


### PR DESCRIPTION
fix the number config parsing to detect overflow/underflows

Fixes: #11484 http://tracker.ceph.com/issues/11484