### PR TITLE
Improve rgw HEAD request by avoiding read the body of the first chunk

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -448,7 +448,8 @@ int RGWGetObj::verify_permission()
 {
   obj = rgw_obj(s->bucket, s->object);
   store->set_atomic(s->obj_ctx, obj);
-  store->set_prefetch_data(s->obj_ctx, obj);
+  if (get_data)
+    store->set_prefetch_data(s->obj_ctx, obj);
 
   if (!verify_object_permission(s, RGW_PERM_READ))
     return -EACCES;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -157,7 +157,7 @@ public:
     ret = 0;
  }
 
-  virtual bool prefetch_data() { return true; }
+  virtual bool prefetch_data() { return get_data; }
 
   void set_get_data(bool get_data) {
     this->get_data = get_data;


### PR DESCRIPTION
http://tracker.ceph.com/issues/11001