### PR TITLE
librbd: missing an argument when calling invoke_async_request

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -784,7 +784,7 @@ int invoke_async_request(ImageCtx *ictx, const std::string& request_type,
     }
 
     if (fast_diff_enabled) {
-      r = invoke_async_request(ictx, "snap_remove",
+      r = invoke_async_request(ictx, "snap_remove", true,
                                boost::bind(&snap_remove_helper, ictx, _1,
                                            snap_name),
                                boost::bind(&ImageWatcher::notify_snap_remove,


### PR DESCRIPTION
This prevents the master branch from compiling.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>