### PR TITLE
  init-ceph.in: Create osd data dir if don't exists.

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -344,6 +344,7 @@ for name in $what; do
 		[ -n "$fs_opt" ] && fs_opt="-o $fs_opt"
 		[ -n "$pre_mount" ] && do_cmd "$pre_mount"
 
+		do_root_cmd_okfail "mkdir -p $fs_path"
 		if [ "$fs_type" = "btrfs" ]; then
 		    echo Mounting Btrfs on $host:$fs_path
 		    do_root_cmd_okfail "modprobe btrfs ; btrfs device scan || btrfsctl -a ; egrep -q '^[^ ]+ $fs_path ' /proc/mounts || mount -t btrfs $fs_opt $first_dev $fs_path"


### PR DESCRIPTION
  One host in cluster crashed and rebuilded, but failed to start osds
  because the data dir not exist.

  Signed-off-by: huangjun <hjwsm1989@gmail.com>