### PR TITLE
Wip fix libcephfs crash

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7138,6 +7138,8 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl)
   // trim read based on file size?
   if (off >= in->size)
     return 0;
+  if (len == 0)
+    return 0;
   if (off + len > in->size) {
     len = in->size - off;    
   }

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -886,6 +886,24 @@ TEST(LibCephFS, HardlinkNoOriginal) {
   ceph_shutdown(cmount);
 }
 
+TEST(LibCephFS, BadArgument) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(ceph_mount(cmount, NULL), 0);
+
+  int fd = ceph_open(cmount, "test_file", O_CREAT|O_RDWR, 0666);
+  ASSERT_GT(fd, 0);
+  char buf[100];
+  ASSERT_EQ(ceph_write(cmount, fd, buf, sizeof(buf), 0), (int)sizeof(buf));
+  ASSERT_EQ(ceph_read(cmount, fd, buf, 5, 0), 0);
+  ceph_close(cmount, fd);
+  ASSERT_EQ(ceph_unlink(cmount, "test_file"), 0);
+
+  ceph_shutdown(cmount);
+}
+
 TEST(LibCephFS, BadFileDesc) {
   struct ceph_mount_info *cmount;
   ASSERT_EQ(ceph_create(&cmount, NULL), 0);


### PR DESCRIPTION
if cephfs_read length is 0:
    osdc/Striper.cc: 50: FAILED assert(len > 0)
     2: (Striper::file_to_extents(CephContext*, char const*, ceph_file_layout const*, unsigned long, unsigned long, unsigned long, std::map<object_t, std::vector<ObjectExtent, std::allocator<ObjectExtent> >, std::less<object_t>, std::allocator<std::pair<object_t const, std::vector<ObjectExtent, std::allocator<ObjectExtent> > > > >&, unsigned long)+0x1c6) [0x7fd1a0f4f522]
     3: (Striper::file_to_extents(CephContext*, char const*, ceph_file_layout const*, unsigned long, unsigned long, unsigned long, std::vector<ObjectExtent, std::allocator<ObjectExtent> >&, unsigned long)+0x69) [0x7fd1a0f4f315]
     4: (Striper::file_to_extents(CephContext*, inodeno_t, ceph_file_layout const*, unsigned long, unsigned long, unsigned long, std::vector<ObjectExtent, std::allocator<ObjectExtent> >&)+0x8a) [0x7fd1a0ef9c3c]
     5: (ObjectCacher::file_read(ObjectCacher::ObjectSet*, ceph_file_layout*, snapid_t, long, unsigned long, ceph::buffer::list*, int, Context*)+0x7e) [0x7fd1a0efb186]
     6: (Client::_read_async(Fh*, unsigned long, unsigned long, ceph::buffer::list*)+0x4ca) [0x7fd1a0ec90d4]
     7: (Client::_read(Fh*, long, unsigned long, ceph::buffer::list*)+0x3dc) [0x7fd1a0ec8744]
     8: (Client::read(int, char*, long, long)+0x208) [0x7fd1a0ec8100]
     9: (ceph_read()+0x5e) [0x7fd1a0e80603]