### PR TITLE
#11388 debian: move ceph_argparse into ceph-common

### DIFF
--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -26,3 +26,4 @@ usr/share/ceph/id_dsa_drop.ceph.com.pub
 etc/ceph/rbdmap
 etc/init.d/rbdmap
 lib/udev/rules.d/50-rbd.rules
+usr/lib/python*/dist-packages/ceph_argparse.py*

--- a/debian/ceph.install
+++ b/debian/ceph.install
@@ -37,5 +37,4 @@ usr/share/man/man8/ceph-rest-api.8
 usr/share/man/man8/crushtool.8
 usr/share/man/man8/monmaptool.8
 usr/share/man/man8/osdmaptool.8
-usr/lib/python*/dist-packages/ceph_argparse.py*
 usr/lib/python*/dist-packages/ceph_daemon.py*

--- a/debian/control
+++ b/debian/control
@@ -61,7 +61,7 @@ Standards-Version: 3.9.3
 Package: ceph
 Architecture: linux-any
 Depends: binutils,
-         ceph-common (>= 0.78-500),
+         ceph-common (>= 9.0.0-943),
          cryptsetup-bin | cryptsetup,
          gdisk,
          parted,
@@ -190,10 +190,10 @@ Depends: librbd1 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends},
 	 python-requests
 Conflicts: ceph-client-tools
 Replaces: ceph-client-tools,
-	  ceph (<< 0.78-500),
+	  ceph (<< 9.0.0-943),
 	  python-ceph (<< 0.92-1223),
 	  librbd1 (<< 0.92-1238)
-Breaks: ceph (<< 0.78-500),
+Breaks: ceph (<< 9.0.0-943),
 	python-ceph (<< 0.92-1223),
 	librbd1 (<< 0.92-1238)
 Suggests: ceph, ceph-mds


### PR DESCRIPTION
Prior to this commit, if a user installed the "ceph-common" Debian package without installing "ceph", then `/usr/bin/ceph` would crash because it was missing the ceph_argparse library.

Ship the ceph_argparse library in "ceph-common" instead of "ceph". (This was probably the intention of the original commit that moved argparse to "ceph", 2a23eac54957e596d99985bb9e187a668251a9ec)

This fixes the issue described at http://tracker.ceph.com/issues/11388

Reported-by: @jrosenboom 

@javacruft, would you like to review? Jens pointed out that you might already have this patch downstream (the `0.93-0ubuntu3` entry at https://launchpad.net/ubuntu/vivid/+source/ceph/+changelog mentions something similar)?