### PR TITLE
Flush cluster log before MDS::damaged

### DIFF
--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -2372,6 +2372,7 @@ void MDS::handle_signal(int signum)
 void MDS::damaged()
 {
   set_want_state(MDSMap::STATE_DAMAGED);
+  monc->flush_log();  // Flush any clog error from before we were called
   beacon.notify_health(this);  // Include latest status in our swan song
   beacon.send_and_wait(g_conf->mds_mon_shutdown_timeout);
 

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -314,6 +314,12 @@ void MonClient::send_log()
   }
 }
 
+void MonClient::flush_log()
+{
+  Mutex::Locker l(monc_lock);
+  send_log();
+}
+
 void MonClient::handle_monmap(MMonMap *m)
 {
   ldout(cct, 10) << "handle_monmap " << *m << dendl;

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -200,6 +200,13 @@ public:
 
   int authenticate(double timeout=0.0);
 
+  /**
+   * Try to flush as many log messages as we can in a single
+   * message.  Use this before shutting down to transmit your
+   * last message.
+   */
+  void flush_log();
+
   // mon subscriptions
 private:
   map<string,ceph_mon_subscribe_item> sub_have;  // my subs, and current versions


### PR DESCRIPTION
Previously our clog death-throes were not necessarily getting through to mons before the DAMAGED beacon.