### PR TITLE
MDS: improve handling of damaged metadata

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1773,8 +1773,14 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
 	}
       }
     } else {
-      dout(1) << "corrupt directory, i got tag char '" << type << "' pos " << pos << dendl;
-      assert(0);
+      dout(1) << "corrupt directory, i got tag char '" << type << "' pos "
+        << pos << dendl;
+      cache->mds->clog->error() << "Corrupt directory entry '" << p->first
+        << "' in dirfrag " << *this;
+      // TODO: add a mechanism for selectively marking a path
+      // damaged, rather than marking the whole rank damaged.
+      cache->mds->damaged();
+      assert(0);  // Unreachable: damaged() respawns us
     }
     
     if (dn && want_dn.length() && want_dn == dname) {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -626,6 +626,14 @@ void MDCache::populate_mydir()
 
   dout(10) << "populate_mydir " << *mydir << dendl;
 
+  if (mydir->get_version() == 0) {
+    // A fresh dirfrag, we must dirty it before dirtying
+    // any of the strays we create within it.
+    LogSegment *ls = mds->mdlog->get_current_segment();
+    mydir->mark_complete();
+    mydir->mark_dirty(mydir->pre_dirty(), ls);
+  }
+
   if (!mydir->is_complete()) {
     mydir->fetch(new C_MDS_RetryOpenRoot(this));
     return;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -671,15 +671,6 @@ void MDCache::populate_mydir()
     }
   }
 
-  // open or create journal file
-  string jname("journal");
-  CDentry *jdn = mydir->lookup(jname);
-  if (!jdn || !jdn->get_linkage()->get_inode()) {
-    _create_system_file(mydir, jname.c_str(), create_system_inode(MDS_INO_LOG_OFFSET + mds->whoami, S_IFREG),
-			new C_MDS_RetryOpenRoot(this));
-    return;
-  }
-
   // okay!
   dout(10) << "populate_mydir done" << dendl;
   assert(!open);    

--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -2249,8 +2249,15 @@ void MDS::rejoin_done()
 
   // funny case: is our cache empty?  no subtrees?
   if (!mdcache->is_subtrees()) {
-    dout(1) << " empty cache, no subtrees, leaving cluster" << dendl;
-    request_state(MDSMap::STATE_STOPPED);
+    if (whoami == 0) {
+      // The root should always have a subtree!
+      clog->error() << "No subtrees found for root MDS rank!";
+      damaged();
+      assert(mdcache->is_subtrees());
+    } else {
+      dout(1) << " empty cache, no subtrees, leaving cluster" << dendl;
+      request_state(MDSMap::STATE_STOPPED);
+    }
     return;
   }
 

--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -1939,7 +1939,14 @@ void MDS::boot_start(BootStep step, int r)
       dout(0) << "boot_start encountered an error EAGAIN"
               << ", respawning since we fell behind journal" << dendl;
       respawn();
+    } else if (r == -EINVAL || r == -ENOENT) {
+      // Invalid or absent data, indicates damaged on-disk structures
+      clog->error() << "Error loading MDS rank " << whoami << ": "
+        << cpp_strerror(r);
+      damaged();
+      assert(r == 0);  // Unreachable, damaged() calls respawn()
     } else {
+      // Completely unexpected error, give up and die
       dout(0) << "boot_start encountered an error, failing" << dendl;
       suicide();
       return;


### PR DESCRIPTION
There are various cases that one hits when starting up an MDS with a critically damaged metadata pool (e.g. one with all the objects missing!).

Soon we will want to make some of these (e.g. bad dentries) finer-grained rather than marking a whole rank damaged, but for the moment it's a good thing to have a well defined behaviour that's easy to see from the mon.