### PR TITLE
common: fix the macros for malformed_input::what()

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -87,8 +87,8 @@ public:
     }
   };
   struct malformed_input : public error {
-    explicit malformed_input(const char *w) {
-      snprintf(buf, sizeof(buf), "buffer::malformed_input: %s", w);
+    explicit malformed_input(const std::string& w) {
+      snprintf(buf, sizeof(buf), "buffer::malformed_input: %s", w.c_str());
     }
     const char *what() const throw () {
       return buf;

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -807,13 +807,13 @@ inline void decode(std::deque<T>& ls, bufferlist::iterator& p)
 #define ENCODE_FINISH(bl) ENCODE_FINISH_NEW_COMPAT(bl, 0)
 
 #define DECODE_ERR_VERSION(func, v)			\
-  "" #func " unknown encoding version > " #v
+  (std::string(func) + " unknown encoding version > " #v)
 
 #define DECODE_ERR_OLDVERSION(func, v)			\
-  "" #func " no longer understand old encoding version < " #v
+  (std::string(func) + " no longer understand old encoding version < " #v)
 
 #define DECODE_ERR_PAST(func) \
-  "" #func " decode past end of struct encoding"
+  (std::string(func) + " decode past end of struct encoding")
 
 /**
  * check for very old encoding


### PR DESCRIPTION
the thrown exception of malformed_input should carry the function name in
which it was thrown. but what we have now is something like:
"buffer::malformed_input: __PRETTY_FUNCTION__ unknown encoding version >
100"
because __PRETTY_FUNCTION__ is not a macro any more. see
- https://gcc.gnu.org/onlinedocs/gcc-3.1/gcc/Function-Names.html
- https://gcc.gnu.org/onlinedocs/gcc/Function-Names.html
and it is not a string literal, so neither can we concat it with
the literal err message.

Signed-off-by: Kefu Chai <kchai@redhat.com>