### PR TITLE
librbd: invoking RBD::open twice will leak memory

### DIFF
--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -99,6 +99,11 @@ namespace librbd {
     ImageCtx *ictx = new ImageCtx(name, "", snap_name, io_ctx, false);
     tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
+    if (image.ctx != NULL) {
+      close_image(reinterpret_cast<ImageCtx*>(image.ctx));
+      image.ctx = NULL;
+    }
+
     int r = librbd::open_image(ictx);
     if (r < 0) {
       tracepoint(librbd, open_image_exit, r);
@@ -115,6 +120,11 @@ namespace librbd {
   {
     ImageCtx *ictx = new ImageCtx(name, "", snap_name, io_ctx, true);
     tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
+
+    if (image.ctx != NULL) {
+      close_image(reinterpret_cast<ImageCtx*>(image.ctx));
+      image.ctx = NULL;
+    }
 
     int r = librbd::open_image(ictx);
     if (r < 0) {


### PR DESCRIPTION
Signed-off-by: Jason Dillaman <dillaman@redhat.com>