### PR TITLE
osd: silence gcc -Wparentheses warning

### DIFF
--- a/src/include/CompatSet.h
+++ b/src/include/CompatSet.h
@@ -29,19 +29,26 @@ struct CompatSet {
     Feature(uint64_t _id, const string& _name) : id(_id), name(_name) {}
   };
 
-  struct FeatureSet {
+  class FeatureSet {
     uint64_t mask;
     map <uint64_t,string> names;
 
+  public:
+    friend struct CompatSet;
+    friend class CephCompatSet_AllSet_Test;
+    friend class CephCompatSet_other_Test;
+    friend class CephCompatSet_merge_Test;
+    friend ostream& operator<<(ostream& out, const CompatSet::FeatureSet& fs);
+    friend ostream& operator<<(ostream& out, const CompatSet& compat);
     FeatureSet() : mask(1), names() {}
-    void insert(Feature f) {
+    void insert(const Feature& f) {
       assert(f.id > 0);
       assert(f.id < 64);
       mask |= ((uint64_t)1<<f.id);
       names[f.id] = f.name;
     }
 
-    bool contains(Feature f) const {
+    bool contains(const Feature& f) const {
       return names.count(f.id);
     }
     bool contains(uint64_t f) const {
@@ -55,13 +62,14 @@ struct CompatSet {
       assert(i != names.end());
       return i->second;
     }
+
     void remove(uint64_t f) {
       if (names.count(f)) {
 	names.erase(f);
 	mask &= ~((uint64_t)1<<f);
       }
     }
-    void remove(Feature f) {
+    void remove(const Feature& f) {
       remove(f.id);
     }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2401,8 +2401,7 @@ void OSD::write_superblock(ObjectStore::Transaction& t)
   dout(10) << "write_superblock " << superblock << dendl;
 
   //hack: at minimum it's using the baseline feature set
-  if (!superblock.compat_features.incompat.mask |
-      CEPH_OSD_FEATURE_INCOMPAT_BASE.id)
+  if (!superblock.compat_features.incompat.contains(CEPH_OSD_FEATURE_INCOMPAT_BASE))
     superblock.compat_features.incompat.insert(CEPH_OSD_FEATURE_INCOMPAT_BASE);
 
   bufferlist bl;


### PR DESCRIPTION
otherwise we have following warning:
warning: suggest parentheses around operand of ‘!’ or change ‘|’ to
‘||’ or ‘!’ to ‘~’ [-Wparentheses]

Signed-off-by: Kefu Chai <kchai@redhat.com>