### PR TITLE
bufferptr: Offset should not beyond raw_length rather than _len.

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -237,7 +237,7 @@ public:
 
     // modifiers
     void set_offset(unsigned o) {
-      assert(_len >= o);
+      assert(raw_length() >= o);
       _off = o;
     }
     void set_length(unsigned l) {

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1865,6 +1865,18 @@ TEST(BufferList, splice) {
   bl.splice(4, 4);
   EXPECT_EQ((unsigned)4, bl.length());
   EXPECT_EQ(0, ::memcmp("ABCD", bl.c_str(), bl.length()));
+
+  {
+    bl.clear();
+    bufferptr ptr1("0123456789", 10);
+    bl.push_back(ptr1);
+    bufferptr ptr2("abcdefghij", 10);
+    bl.append(ptr2, 5, 5);
+    other.clear();
+    bl.splice(10, 4, &other);
+    EXPECT_EQ((unsigned)11, bl.length());
+    EXPECT_EQ(0, ::memcmp("fghi", other.c_str(), other.length()));
+  }
 }
 
 TEST(BufferList, write) {


### PR DESCRIPTION
Fixes: #11526

Commit dfccd3d19c introduce this bug"
./include/buffer.h: 240: FAILED assert(_len >= o)

 ceph version 0.94-1402-g5ac962d
(5ac962d879d920805bd661857592860caae27f2b)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char
const*)+0x80) [0x1640e50]
 2: (ceph::buffer::ptr::set_offset(unsigned int)+0x3a) [0x1647462]
 3: (ceph::buffer::list::splice(unsigned int, unsigned int,
ceph::buffer::list*)+0x238) [0x16458ba]
 4: (JournalStream::read(ceph::buffer::list&, ceph::buffer::list*,
unsigned long*)+0x17c) [0x145588e]
 5: (Journaler::try_read_entry(ceph::buffer::list&)+0x1ef) [0x1453d65]
 6: (MDLog::_replay_thread()+0xc6a) [0x1434200]
 7: (MDLog::ReplayThread::entry()+0x1c) [0x10f0d88]
 8: (Thread::entry_wrapper()+0xa8) [0x16310ee]
 9: (Thread::_entry_func(void*)+0x18) [0x163103c]
 10: /lib64/libpthread.so.0() [0x334c607ee5]
 11: (clone()+0x6d) [0x334bef4d1d]
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is
needed to interpret this.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>