### PR TITLE
tests: install sudo on ubuntu-12.04 container

### DIFF
--- a/src/test/ubuntu-12.04/Dockerfile.in
+++ b/src/test/ubuntu-12.04/Dockerfile.in
@@ -27,5 +27,5 @@ RUN apt-get update
 # build dependencies
 RUN cd /root ; ./install-deps.sh
 # development tools
-RUN apt-get install -y ccache valgrind gdb python-virtualenv gdisk kpartx hdparm xmlstarlet
+RUN apt-get install -y sudo ccache valgrind gdb python-virtualenv gdisk kpartx hdparm xmlstarlet
 RUN useradd -M --uid %%user_id%% %%USER%% && echo '%%USER%% ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Contrary to Ubuntu 14.04 it is not installed by default.

Signed-off-by: Loic Dachary <ldachary@redhat.com>