### PR TITLE
SubmittingPatches: clarify backport procedure

### DIFF
--- a/SubmittingPatches
+++ b/SubmittingPatches
@@ -266,11 +266,12 @@ A: The target branch depends on the nature of your change:
 
    If you are fixing a bug (see above) *and* the bug exists in older stable
    branches (for example, the "dumpling" or "firefly" branches), then you
-   should add a "Backport: <branchname>" line to your commit message. This will
-   notify other developers that your commit should be cherry-picked to these
-   stable branches. For example, you should add "Backport: firefly" to
-   indicate that you are fixing a bug that exists on the "firefly" branch and
-   that you desire that your change be cherry-picked to that branch.
+   should file a Redmine ticket describing your issue and fill out the
+   "Backport: <branchname>" form field. This will notify other developers that
+   your commit should be cherry-picked to these stable branches. For example,
+   you should set "Backport: firefly" in your Redmine ticket to indicate that
+   you are fixing a bug that exists on the "firefly" branch and that you
+   desire that your change be cherry-picked to that branch.
 
 2) Patch submission via ceph-devel@vger.kernel.org
 


### PR DESCRIPTION
Developers should not add "Backport: " fields to Git commits, because this data is immutable after the commits are merged. It makes more sense to handle this information in Redmine instead.