### PR TITLE
mon/OSDMonitor.cc: total size of OSDs is a magnitude less than it is supposed to be 

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -754,7 +754,7 @@ public:
     dump_stray(tbl);
 
     *tbl << "" << "" << "TOTAL"
-	 << si_t(pgm->osd_sum.kb)
+	 << si_t(pgm->osd_sum.kb << 10)
 	 << si_t(pgm->osd_sum.kb_used << 10)
 	 << si_t(pgm->osd_sum.kb_avail << 10)
 	 << lowprecision_t(average_util)


### PR DESCRIPTION
When dumping statistics of OSDs such as running command 'ceph osd df'. The sum of OSDs' size is 2^10 times less than their real size.

Signed-off-by: Zhe Zhang <zzxuanyuan@gmail.com>