### PR TITLE
mon: Total size of OSDs is a maginitude less than it is supposed to be.

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -738,7 +738,7 @@ public:
     dump_stray(tbl);
 
     *tbl << "" << "" << "TOTAL"
-	 << si_t(pgm->osd_sum.kb)
+	 << si_t(pgm->osd_sum.kb << 10)
 	 << si_t(pgm->osd_sum.kb_used << 10)
 	 << si_t(pgm->osd_sum.kb_avail << 10)
 	 << lowprecision_t(average_util)


### PR DESCRIPTION
http://tracker.ceph.com/issues/11534
Signed-off-by: Zhe Zhang <zzxuanyuan@gmail.com>
(cherry picked from commit 73d16f69d6f58fe8be262b0fb8db28c94605ea7d)