### PR TITLE
Wip 11256 firefly

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -453,10 +453,11 @@ int rgw_bucket_prepare_op(cls_method_context_t hctx, bufferlist *in, bufferlist 
   }
 
   // fill in proper state
-  struct rgw_bucket_pending_info& info = entry.pending_map[op.tag];
+  struct rgw_bucket_pending_info info;
   info.timestamp = ceph_clock_now(g_ceph_context);
   info.state = CLS_RGW_STATE_PENDING_MODIFY;
   info.op = op.op;
+  entry.pending_map.insert(pair<string, rgw_bucket_pending_info>(op.tag, info));
 
 
   bufferlist header_bl;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -200,7 +200,7 @@ struct rgw_bucket_dir_entry {
   std::string locator;
   bool exists;
   struct rgw_bucket_dir_entry_meta meta;
-  map<string, struct rgw_bucket_pending_info> pending_map;
+  multimap<string, struct rgw_bucket_pending_info> pending_map;
   uint64_t index_ver;
   string tag;
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4162,10 +4162,18 @@ int RGWRados::set_attrs(void *ctx, rgw_obj& obj,
     return 0;
 
   string tag;
+  bufferlist bl;
   if (state) {
-    r = prepare_update_index(state, bucket, CLS_RGW_OP_ADD, obj, tag);
+    /* we don't pass state here, because we need to generate a new tag, not reuse the
+     * same tag, otherwise we might race and clobber another operation on the same object
+     */
+    r = prepare_update_index(NULL, bucket, CLS_RGW_OP_ADD, obj, tag);
     if (r < 0)
       return r;
+
+    bl.append(tag.c_str(), tag.size() + 1);
+
+    op.setxattr(RGW_ATTR_ID_TAG,  bl);
   }
 
   r = ref.ioctx.operate(ref.oid, &op);
@@ -4192,6 +4200,7 @@ int RGWRados::set_attrs(void *ctx, rgw_obj& obj,
     return r;
 
   if (state) {
+    state->obj_tag.swap(bl);
     if (rmattrs) {
       for (iter = rmattrs->begin(); iter != rmattrs->end(); ++iter) {
         state->attrset.erase(iter->first);


### PR DESCRIPTION

rgw: generate new tag for object when setting object attrs
cls_rgw: use multimap to keep pending operations in bucket index

Fixes: #11256