### PR TITLE
Response header of swift API PUT /container/object returned by RGW does not contain last-modified, content-length, x-trans-id headers. But Swift returns these headers.

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -436,6 +436,7 @@ void RGWPutObj_ObjStore_SWIFT::send_response()
   if (!ret)
     ret = STATUS_CREATED;
   dump_etag(s, etag.c_str());
+  dump_last_modified(s, mtime);
   set_req_state_err(s, ret);
   dump_errno(s);
   end_header(s, this);


### PR DESCRIPTION
http://tracker.ceph.com/issues/10650