### PR TITLE
RGW swift API: Response header of POST request for object does not contain content-length and x-trans-id headers

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -491,6 +491,8 @@ void RGWPutMetadata_ObjStore_SWIFT::send_response()
       ret = STATUS_ACCEPTED;
   }
   set_req_state_err(s, ret);
+  if (!s->err.is_err())
+    dump_content_length(s, 0);
   dump_errno(s);
   end_header(s, this);
   rgw_flush_formatter_and_reset(s, s->formatter);


### PR DESCRIPTION
http://tracker.ceph.com/issues/10661