### PR TITLE
rgw: Change variable length array of std::strings (not legal in C++) to std::vector<std::string>

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -372,7 +372,7 @@ void RGWLoadGenProcess::run()
   int num_buckets;
   conf->get_val("num_buckets", 1, &num_buckets);
 
-  string buckets[num_buckets];
+  vector<string> buckets(num_buckets);
 
   atomic_t failed;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/11542