### PR TITLE
mon: periodic scrub

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -244,7 +244,7 @@ OPTION(mon_data_avail_crit, OPT_INT, 5)
 OPTION(mon_data_avail_warn, OPT_INT, 30)
 OPTION(mon_data_size_warn, OPT_U64, 15*1024*1024*1024) // issue a warning when the monitor's data store goes over 15GB (in bytes)
 OPTION(mon_scrub_interval, OPT_INT, 3600*24) // once a day
-OPTION(mon_scrub_max_keys, OPT_INT, -1) // max number of keys to scrub each time
+OPTION(mon_scrub_max_keys, OPT_INT, 100) // max number of keys to scrub each time
 OPTION(mon_config_key_max_entry_size, OPT_INT, 4096) // max num bytes per config-key entry
 OPTION(mon_sync_timeout, OPT_DOUBLE, 60.0)
 OPTION(mon_sync_max_payload_size, OPT_U32, 1048576) // max size for a sync chunk payload (say, 1MB)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -244,6 +244,7 @@ OPTION(mon_data_avail_crit, OPT_INT, 5)
 OPTION(mon_data_avail_warn, OPT_INT, 30)
 OPTION(mon_data_size_warn, OPT_U64, 15*1024*1024*1024) // issue a warning when the monitor's data store goes over 15GB (in bytes)
 OPTION(mon_scrub_interval, OPT_INT, 3600*24) // once a day
+OPTION(mon_scrub_max_keys, OPT_INT, -1) // max number of keys to scrub each time
 OPTION(mon_config_key_max_entry_size, OPT_INT, 4096) // max num bytes per config-key entry
 OPTION(mon_sync_timeout, OPT_DOUBLE, 60.0)
 OPTION(mon_sync_max_payload_size, OPT_U32, 1048576) // max size for a sync chunk payload (say, 1MB)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -243,6 +243,7 @@ OPTION(mon_health_to_clog_tick_interval, OPT_DOUBLE, 60.0)
 OPTION(mon_data_avail_crit, OPT_INT, 5)
 OPTION(mon_data_avail_warn, OPT_INT, 30)
 OPTION(mon_data_size_warn, OPT_U64, 15*1024*1024*1024) // issue a warning when the monitor's data store goes over 15GB (in bytes)
+OPTION(mon_scrub_interval, OPT_INT, 3600*24) // once a day
 OPTION(mon_config_key_max_entry_size, OPT_INT, 4096) // max num bytes per config-key entry
 OPTION(mon_sync_timeout, OPT_DOUBLE, 60.0)
 OPTION(mon_sync_max_payload_size, OPT_U32, 1048576) // max size for a sync chunk payload (say, 1MB)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -246,6 +246,7 @@ OPTION(mon_data_size_warn, OPT_U64, 15*1024*1024*1024) // issue a warning when t
 OPTION(mon_scrub_interval, OPT_INT, 3600*24) // once a day
 OPTION(mon_scrub_max_keys, OPT_INT, 100) // max number of keys to scrub each time
 OPTION(mon_scrub_inject_crc_mismatch, OPT_DOUBLE, 0.0) // probability of injected crc mismatch [0.0, 1.0]
+OPTION(mon_scrub_inject_missing_keys, OPT_DOUBLE, 0.0) // probability of injected missing keys [0.0, 1.0]
 OPTION(mon_config_key_max_entry_size, OPT_INT, 4096) // max num bytes per config-key entry
 OPTION(mon_sync_timeout, OPT_DOUBLE, 60.0)
 OPTION(mon_sync_max_payload_size, OPT_U32, 1048576) // max size for a sync chunk payload (say, 1MB)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -245,6 +245,7 @@ OPTION(mon_data_avail_warn, OPT_INT, 30)
 OPTION(mon_data_size_warn, OPT_U64, 15*1024*1024*1024) // issue a warning when the monitor's data store goes over 15GB (in bytes)
 OPTION(mon_scrub_interval, OPT_INT, 3600*24) // once a day
 OPTION(mon_scrub_max_keys, OPT_INT, 100) // max number of keys to scrub each time
+OPTION(mon_scrub_inject_crc_mismatch, OPT_DOUBLE, 0.0) // probability of injected crc mismatch [0.0, 1.0]
 OPTION(mon_config_key_max_entry_size, OPT_INT, 4096) // max num bytes per config-key entry
 OPTION(mon_sync_timeout, OPT_DOUBLE, 60.0)
 OPTION(mon_sync_max_payload_size, OPT_U32, 1048576) // max size for a sync chunk payload (say, 1MB)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -244,6 +244,7 @@ OPTION(mon_data_avail_crit, OPT_INT, 5)
 OPTION(mon_data_avail_warn, OPT_INT, 30)
 OPTION(mon_data_size_warn, OPT_U64, 15*1024*1024*1024) // issue a warning when the monitor's data store goes over 15GB (in bytes)
 OPTION(mon_scrub_interval, OPT_INT, 3600*24) // once a day
+OPTION(mon_scrub_timeout, OPT_INT, 60*5) // let's give it 5 minutes; why not.
 OPTION(mon_scrub_max_keys, OPT_INT, 100) // max number of keys to scrub each time
 OPTION(mon_scrub_inject_crc_mismatch, OPT_DOUBLE, 0.0) // probability of injected crc mismatch [0.0, 1.0]
 OPTION(mon_scrub_inject_missing_keys, OPT_DOUBLE, 0.0) // probability of injected missing keys [0.0, 1.0]

--- a/src/messages/MMonScrub.h
+++ b/src/messages/MMonScrub.h
@@ -18,7 +18,7 @@
 
 class MMonScrub : public Message
 {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -38,14 +38,17 @@ public:
   op_type_t op;
   version_t version;
   ScrubResult result;
+  int32_t num_keys;
+  pair<string,string> key;
 
   MMonScrub()
-    : Message(MSG_MON_SCRUB, HEAD_VERSION, COMPAT_VERSION)
+    : Message(MSG_MON_SCRUB, HEAD_VERSION, COMPAT_VERSION),
+      num_keys(-1)
   { }
 
-  MMonScrub(op_type_t op, version_t v)
+  MMonScrub(op_type_t op, version_t v, int32_t num_keys)
     : Message(MSG_MON_SCRUB, HEAD_VERSION, COMPAT_VERSION),
-      op(op), version(v)
+      op(op), version(v), num_keys(num_keys)
   { }
 
   const char *get_type_name() const { return "mon_scrub"; }
@@ -55,6 +58,8 @@ public:
     out << " v " << version;
     if (op == OP_RESULT)
       out << " " << result;
+    out << " num_keys " << num_keys;
+    out << " key (" << key << ")";
     out << ")";
   }
 
@@ -63,6 +68,8 @@ public:
     ::encode(o, payload);
     ::encode(version, payload);
     ::encode(result, payload);
+    ::encode(num_keys, payload);
+    ::encode(key, payload);
   }
 
   void decode_payload() {
@@ -72,6 +79,10 @@ public:
     op = (op_type_t)o;
     ::decode(version, p);
     ::decode(result, p);
+    if (header.version >= 2) {
+      ::decode(num_keys, p);
+      ::decode(key, p);
+    }
   }
 };
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4329,6 +4329,13 @@ bool Monitor::_scrub(ScrubResult *r,
     if (prefixes.count(k.first) == 0)
       continue;
 
+    if (cct->_conf->mon_scrub_inject_missing_keys > 0.0 &&
+        (rand() % 10000 < cct->_conf->mon_scrub_inject_missing_keys*10000.0)) {
+      dout(10) << __func__ << " inject missing key, skipping (" << k << ")"
+               << dendl;
+      continue;
+    }
+
     bufferlist bl;
     store->get(k.first, k.second, bl);
     uint32_t key_crc = bl.crc32c(0);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4339,6 +4339,12 @@ bool Monitor::_scrub(ScrubResult *r,
       r->prefix_crc[k.first] = 0;
     r->prefix_crc[k.first] = bl.crc32c(r->prefix_crc[k.first]);
 
+    if (cct->_conf->mon_scrub_inject_crc_mismatch > 0.0 &&
+        (rand() % 10000 < cct->_conf->mon_scrub_inject_crc_mismatch*10000.0)) {
+      dout(10) << __func__ << " inject failure at (" << k << ")" << dendl;
+      r->prefix_crc[k.first] += 1;
+    }
+
     ++scrubbed_keys;
     last_key = k;
   }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4210,7 +4210,6 @@ int Monitor::scrub_start()
   }
 
   scrub_result.clear();
-  scrub_version = paxos->get_version();
   scrub_state.reset(new ScrubState);
 
   scrub();
@@ -4221,6 +4220,9 @@ int Monitor::scrub()
 {
   assert(is_leader());
   assert(scrub_state);
+
+  wait_for_paxos_write();
+  scrub_version = paxos->get_version();
 
   // scrub all keys if we're the only monitor in the quorum
   int32_t num_keys =
@@ -4259,6 +4261,9 @@ void Monitor::handle_scrub(MMonScrub *m)
     {
       if (!is_peon())
 	break;
+
+      wait_for_paxos_write();
+
       if (m->version != paxos->get_version())
 	break;
 

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -242,11 +242,13 @@ private:
    *
    * Verify all mons are storing identical content
    */
+  int scrub_start();
   int scrub();
   void handle_scrub(MMonScrub *m);
   bool _scrub(ScrubResult *r,
-              pair<string,string> &start,
-              int num_keys);
+              pair<string,string> *start,
+              int *num_keys);
+  void scrub_check_results();
   void scrub_finish();
   void scrub_reset();
 
@@ -254,7 +256,7 @@ private:
     Monitor *mon;
     C_Scrub(Monitor *m) : mon(m) { }
     void finish(int r) {
-      mon->scrub();
+      mon->scrub_start();
     }
   };
   Context *scrub_event;       ///< periodic event to trigger scrub (leader)
@@ -263,8 +265,9 @@ private:
 
   struct ScrubState {
     pair<string,string> last_key; ///< last scrubbed key
+    bool finished;
 
-    ScrubState() { }
+    ScrubState() : finished(false) { }
     virtual ~ScrubState() { }
   };
   ceph::shared_ptr<ScrubState> scrub_state; ///< keeps track of current scrub

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -244,7 +244,9 @@ private:
    */
   int scrub();
   void handle_scrub(MMonScrub *m);
-  void _scrub(ScrubResult *r);
+  bool _scrub(ScrubResult *r,
+              pair<string,string> &start,
+              int num_keys);
   void scrub_finish();
   void scrub_reset();
 

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -255,9 +255,17 @@ private:
       mon->scrub();
     }
   };
-  Context *scrub_event;
+  Context *scrub_event;       ///< periodic event to trigger scrub (leader)
   void scrub_event_start();
   void scrub_event_cancel();
+
+  struct ScrubState {
+    pair<string,string> last_key; ///< last scrubbed key
+
+    ScrubState() { }
+    virtual ~ScrubState() { }
+  };
+  ceph::shared_ptr<ScrubState> scrub_state; ///< keeps track of current scrub
 
   /**
    * @defgroup Monitor_h_sync Synchronization

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -252,6 +252,7 @@ private:
   void scrub_timeout();
   void scrub_finish();
   void scrub_reset();
+  void scrub_update_interval(int secs);
 
   struct C_Scrub : public Context {
     Monitor *mon;

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -248,6 +248,17 @@ private:
   void scrub_finish();
   void scrub_reset();
 
+  struct C_Scrub : public Context {
+    Monitor *mon;
+    C_Scrub(Monitor *m) : mon(m) { }
+    void finish(int r) {
+      mon->scrub();
+    }
+  };
+  Context *scrub_event;
+  void scrub_event_start();
+  void scrub_event_cancel();
+
   /**
    * @defgroup Monitor_h_sync Synchronization
    * @{

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -249,6 +249,7 @@ private:
               pair<string,string> *start,
               int *num_keys);
   void scrub_check_results();
+  void scrub_timeout();
   void scrub_finish();
   void scrub_reset();
 
@@ -259,9 +260,19 @@ private:
       mon->scrub_start();
     }
   };
+  struct C_ScrubTimeout : public Context {
+    Monitor *mon;
+    C_ScrubTimeout(Monitor *m) : mon(m) { }
+    void finish(int r) {
+      mon->scrub_timeout();
+    }
+  };
   Context *scrub_event;       ///< periodic event to trigger scrub (leader)
+  Context *scrub_timeout_event;  ///< scrub round timeout (leader)
   void scrub_event_start();
   void scrub_event_cancel();
+  void scrub_reset_timeout();
+  void scrub_cancel_timeout();
 
   struct ScrubState {
     pair<string,string> last_key; ///< last scrubbed key


### PR DESCRIPTION
Every 3600 seconds after the last scrub finishes or the first election.  Could have made it a bit smarter, but given we expose 'ceph scrub' to the user we'll let the administrator schedule a manual scrub if they really want it at a specific time.

Also, scrub is now happening in chunks instead of performing a full store sweep.  This will maintain quorum while the scrub is in progress.

`Signed-off-by: Joao Eduardo Luis <joao@suse.de>`