### PR TITLE
librbd: ignore lack of support for metadata on older OSDs

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -847,8 +847,11 @@ namespace librbd {
       map<string, bufferlist> pairs, res;
       r = cls_client::metadata_list(&md_ctx, header_oid, start, max_conf_items,
                                     &pairs);
-      if (r < 0) {
-        lderr(cct) << __func__ << " couldn't list conf metadatas: " << r
+      if (r == -EOPNOTSUPP || r == -EIO) {
+        ldout(cct, 10) << "config metadata not supported by OSD" << dendl;
+        break;
+      } else if (r < 0) {
+        lderr(cct) << __func__ << " couldn't list config metadata: " << r
                    << dendl;
         break;
       }


### PR DESCRIPTION
If an Infernalis librbd attempts to open an image stored on a
pre-Infernalis OSD, the new config metadata operations won't
be supported.  This error can be safely ignored.

Fixes: #11549
Signed-off-by: Jason Dillaman <dillaman@redhat.com>