### PR TITLE
rbd: add disk usage tool

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -163,6 +163,13 @@ Commands
   -l, also show snapshots, and use longer-format output including
   size, parent (if clone), format, etc.
 
+:command:`du` [--image *image-name*] [*pool-name*]
+  Will calculate the provisioned and actual disk usage of all images and
+  associated snapshots within the specified pool. It can also be used against
+  individual images.
+
+  If the RBD fast-diff feature isn't enabled on images, this operation will
+  require querying the OSDs for every potential object within the image.
 :command:`info` [*image-name*]
   Will dump information (such as size and order) about a specific rbd image.
   If image is a clone, information about its parent is also displayed.

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -3,6 +3,8 @@
   where 'pool' is a rados pool name (default is 'rbd') and 'cmd' is one of:
     (ls | list) [-l | --long ] [pool-name] list rbd images
                                                 (-l includes snapshots/clones)
+    (du | disk-usage) [--image <name>] [pool-name]
+                                                show pool image disk usage stats
     info <image-name>                           show information about image size,
                                                 striping, etc.
     create [--order <bits>] [--image-features <features>] [--image-shared]


### PR DESCRIPTION
The new disk usage tool uses the new fast diff object map feature
(when enabled) to quickly calculate the provisioned vs actual usage
of images and associated snapshots within a pool.

Fixes: #7746
Signed-off-by: Jason Dillaman <dillaman@redhat.com>