### PR TITLE
mon: have mon-specific commands under 'mon' module

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -4,3 +4,7 @@ v9.0.4
 * The return code for librbd's rbd_aio_read and Image::aio_read API methods no
   longer returns the number of bytes read upon success.  Instead, it returns 0
   upon success and a negative value upon failure.
+
+* 'ceph scrub', 'ceph compact' and 'ceph sync force are now DEPRECATED.  Users
+  should instead use 'ceph mon scrub', 'ceph mon compact' and
+  'ceph mon sync force'.

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1578,6 +1578,30 @@ function test_mon_ping()
   ceph ping mon.*
 }
 
+function test_mon_deprecated_commands()
+{
+  # current DEPRECATED commands are:
+  #  ceph compact
+  #  ceph scrub
+  #  ceph sync force
+  #
+  # Testing should be accomplished by setting
+  # 'mon_debug_deprecated_as_obsolete = true' and expecting ENOTSUP for
+  # each one of these commands.
+
+  ceph tell mon.a injectargs '--mon-debug-deprecated-as-obsolete'
+  expect_false ceph tell mon.a compact 2> $TMPFILE
+  check_response "ENOTSUP: command is obsolete"
+
+  expect_false ceph tell mon.a scrub 2> $TMPFILE
+  check_response "ENOTSUP: command is obsolete"
+
+  expect_false ceph tell mon.a sync force 2> $TMPFILE
+  check_response "ENOTSUP: command is obsolete"
+
+  ceph tell mon.a injectargs '--no-mon-debug-deprecated-as-obsolete'
+}
+
 #
 # New tests should be added to the TESTS array below
 #
@@ -1614,6 +1638,7 @@ MON_TESTS+=" mon_heap_profiler"
 MON_TESTS+=" mon_tell"
 MON_TESTS+=" mon_crushmap_validation"
 MON_TESTS+=" mon_ping"
+MON_TESTS+=" mon_deprecated_commands"
 
 OSD_TESTS+=" osd_bench"
 

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -576,7 +576,7 @@ function test_mon_misc()
   ceph log "$mymsg"
   ceph_watch_wait "$mymsg"
 
-  ceph mon_metadata a
+  ceph mon metadata a
 }
 
 function check_mds_active()

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -256,6 +256,9 @@ OPTION(mon_osd_min_down_reports, OPT_INT, 3)     // number of times a down OSD m
 OPTION(mon_osd_force_trim_to, OPT_INT, 0)   // force mon to trim maps to this point, regardless of min_last_epoch_clean (dangerous, use with care)
 OPTION(mon_mds_force_trim_to, OPT_INT, 0)   // force mon to trim mdsmaps to this point (dangerous, use with care)
 
+// monitor debug options
+OPTION(mon_debug_deprecated_as_obsolete, OPT_BOOL, false) // consider deprecated commands as obsolete
+
 // dump transactions
 OPTION(mon_debug_dump_transactions, OPT_BOOL, false)
 OPTION(mon_debug_dump_location, OPT_STR, "/var/log/ceph/$cluster-$name.tdump")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -285,6 +285,12 @@ COMMAND_WITH_FLAG("mon scrub",
     "scrub the monitor stores", \
     "mon", "rw", "cli,rest", \
     FLAG(NONE))
+COMMAND_WITH_FLAG("mon sync force " \
+    "name=validate1,type=CephChoices,strings=--yes-i-really-mean-it,req=false " \
+    "name=validate2,type=CephChoices,strings=--i-know-what-i-am-doing,req=false", \
+    "force sync of and clear monitor store", \
+    "mon", "rw", "cli,rest", \
+    FLAG(NOFORWARD))
 
 
 /*

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -104,7 +104,8 @@
  * type, so the monitor is expected to know the type of each argument.
  * See cmdparse.cc/h for more details.
  *
- * The flag parameter for COMMAND_WITH_FLAGS macro may be:
+ * The flag parameter for COMMAND_WITH_FLAGS macro must be passed using
+ * FLAG(f), where 'f' may be one of the following:
  *
  *  NOFORWARD - command may not be forwarded
  */
@@ -216,7 +217,7 @@ COMMAND("auth del " \
  * Monitor commands (Monitor.cc)
  */
 COMMAND_WITH_FLAG("compact", "cause compaction of monitor's leveldb storage", \
-	     "mon", "rw", "cli,rest", NOFORWARD)
+	     "mon", "rw", "cli,rest", FLAG(NOFORWARD))
 COMMAND("scrub", "scrub the monitor stores", "mon", "rw", "cli,rest")
 COMMAND("fsid", "show cluster FSID/UUID", "mon", "r", "cli,rest")
 COMMAND("log name=logtext,type=CephString,n=N", \
@@ -224,7 +225,7 @@ COMMAND("log name=logtext,type=CephString,n=N", \
 COMMAND_WITH_FLAG("injectargs " \
 	     "name=injected_args,type=CephString,n=N",			\
 	     "inject config arguments into monitor", "mon", "rw", "cli,rest",
-	     NOFORWARD)
+	     FLAG(NOFORWARD))
 COMMAND("status", "show cluster status", "mon", "r", "cli,rest")
 COMMAND("health name=detail,type=CephChoices,strings=detail,req=false", \
 	"show cluster health", "mon", "r", "cli,rest")
@@ -240,7 +241,7 @@ COMMAND("mon_metadata name=id,type=CephString",
 	"mon", "r", "cli,rest")
 
 COMMAND_WITH_FLAG("mon_status", "report status of monitors", "mon", "r", "cli,rest",
-	     NOFORWARD)
+	     FLAG(NOFORWARD))
 COMMAND("sync force " \
 	"name=validate1,type=CephChoices,strings=--yes-i-really-mean-it,req=false " \
 	"name=validate2,type=CephChoices,strings=--i-know-what-i-am-doing,req=false", \
@@ -248,7 +249,7 @@ COMMAND("sync force " \
 COMMAND_WITH_FLAG("heap " \
 	     "name=heapcmd,type=CephChoices,strings=dump|start_profiler|stop_profiler|release|stats", \
 	     "show heap usage info (available only if compiled with tcmalloc)", \
-	     "mon", "rw", "cli,rest", NOFORWARD)
+	     "mon", "rw", "cli,rest", FLAG(NOFORWARD))
 COMMAND("quorum name=quorumcmd,type=CephChoices,strings=enter|exit,n=1", \
 	"enter or exit quorum", "mon", "rw", "cli,rest")
 COMMAND("tell " \
@@ -256,7 +257,8 @@ COMMAND("tell " \
 	"name=args,type=CephString,n=N", \
 	"send a command to a specific daemon", "mon", "rw", "cli,rest")
 COMMAND_WITH_FLAG("version", "show mon daemon version", "mon", "r", "cli,rest",
-	     NOFORWARD)
+                  FLAG(NOFORWARD))
+
 COMMAND("node ls " \
 	"name=type,type=CephChoices,strings=all|osd|mon|mds,req=false",
 	"list all nodes in cluster [type]", "mon", "r", "cli,rest")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -223,8 +223,9 @@ COMMAND("auth del " \
 /*
  * Monitor commands (Monitor.cc)
  */
-COMMAND_WITH_FLAG("compact", "cause compaction of monitor's leveldb storage", \
-	     "mon", "rw", "cli,rest", FLAG(NOFORWARD))
+COMMAND_WITH_FLAG("compact", "cause compaction of monitor's leveldb storage (DEPRECATED)", \
+	     "mon", "rw", "cli,rest", \
+             FLAG(NOFORWARD)|FLAG(DEPRECATED))
 COMMAND_WITH_FLAG("scrub", "scrub the monitor stores (DEPRECATED)", \
              "mon", "rw", "cli,rest", \
              FLAG(DEPRECATED))

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -255,8 +255,9 @@ COMMAND_WITH_FLAG("mon_status", "report status of monitors", "mon", "r", "cli,re
 COMMAND_WITH_FLAG("sync force " \
 	"name=validate1,type=CephChoices,strings=--yes-i-really-mean-it,req=false " \
 	"name=validate2,type=CephChoices,strings=--i-know-what-i-am-doing,req=false", \
-	"force sync of and clear monitor store", "mon", "rw", "cli,rest", \
-        FLAG(NOFORWARD))
+	"force sync of and clear monitor store (DEPRECATED)", \
+        "mon", "rw", "cli,rest", \
+        FLAG(NOFORWARD)|FLAG(DEPRECATED))
 COMMAND_WITH_FLAG("heap " \
 	     "name=heapcmd,type=CephChoices,strings=dump|start_profiler|stop_profiler|release|stats", \
 	     "show heap usage info (available only if compiled with tcmalloc)", \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -109,6 +109,7 @@
  *
  *  NONE      - no flag assigned
  *  NOFORWARD - command may not be forwarded
+ *  OBSOLETE  - command is considered obsolete
  */
 
 /*

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -243,10 +243,11 @@ COMMAND("mon_metadata name=id,type=CephString",
 
 COMMAND_WITH_FLAG("mon_status", "report status of monitors", "mon", "r", "cli,rest",
 	     FLAG(NOFORWARD))
-COMMAND("sync force " \
+COMMAND_WITH_FLAG("sync force " \
 	"name=validate1,type=CephChoices,strings=--yes-i-really-mean-it,req=false " \
 	"name=validate2,type=CephChoices,strings=--i-know-what-i-am-doing,req=false", \
-	"force sync of and clear monitor store", "mon", "rw", "cli,rest")
+	"force sync of and clear monitor store", "mon", "rw", "cli,rest", \
+        FLAG(NOFORWARD))
 COMMAND_WITH_FLAG("heap " \
 	     "name=heapcmd,type=CephChoices,strings=dump|start_profiler|stop_profiler|release|stats", \
 	     "show heap usage info (available only if compiled with tcmalloc)", \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -225,7 +225,9 @@ COMMAND("auth del " \
  */
 COMMAND_WITH_FLAG("compact", "cause compaction of monitor's leveldb storage", \
 	     "mon", "rw", "cli,rest", FLAG(NOFORWARD))
-COMMAND("scrub", "scrub the monitor stores", "mon", "rw", "cli,rest")
+COMMAND_WITH_FLAG("scrub", "scrub the monitor stores (DEPRECATED)", \
+             "mon", "rw", "cli,rest", \
+             FLAG(DEPRECATED))
 COMMAND("fsid", "show cluster FSID/UUID", "mon", "r", "cli,rest")
 COMMAND("log name=logtext,type=CephString,n=N", \
 	"log supplied text to the monitor log", "mon", "rw", "cli,rest")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -281,6 +281,10 @@ COMMAND_WITH_FLAG("mon compact", \
     "cause compaction of monitor's leveldb storage", \
     "mon", "rw", "cli,rest", \
     FLAG(NOFORWARD))
+COMMAND_WITH_FLAG("mon scrub",
+    "scrub the monitor stores", \
+    "mon", "rw", "cli,rest", \
+    FLAG(NONE))
 
 
 /*

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -246,9 +246,6 @@ COMMAND("report name=tags,type=CephString,n=N,req=false", \
 	"mon", "r", "cli,rest")
 COMMAND("quorum_status", "report status of monitor quorum", \
 	"mon", "r", "cli,rest")
-COMMAND("mon_metadata name=id,type=CephString",
-	"fetch metadata for mon <id>",
-	"mon", "r", "cli,rest")
 
 COMMAND_WITH_FLAG("mon_status", "report status of monitors", "mon", "r", "cli,rest",
 	     FLAG(NOFORWARD))
@@ -291,6 +288,9 @@ COMMAND_WITH_FLAG("mon sync force " \
     "force sync of and clear monitor store", \
     "mon", "rw", "cli,rest", \
     FLAG(NOFORWARD))
+COMMAND("mon metadata name=id,type=CephString",
+	"fetch metadata for mon <id>",
+	"mon", "r", "cli,rest")
 
 
 /*

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -275,6 +275,15 @@ COMMAND("node ls " \
 	"name=type,type=CephChoices,strings=all|osd|mon|mds,req=false",
 	"list all nodes in cluster [type]", "mon", "r", "cli,rest")
 /*
+ * Monitor-specific commands under module 'mon'
+ */
+COMMAND_WITH_FLAG("mon compact", \
+    "cause compaction of monitor's leveldb storage", \
+    "mon", "rw", "cli,rest", \
+    FLAG(NOFORWARD))
+
+
+/*
  * MDS commands (MDSMonitor.cc)
  */
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -107,6 +107,7 @@
  * The flag parameter for COMMAND_WITH_FLAGS macro must be passed using
  * FLAG(f), where 'f' may be one of the following:
  *
+ *  NONE      - no flag assigned
  *  NOFORWARD - command may not be forwarded
  */
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -110,6 +110,11 @@
  *  NONE      - no flag assigned
  *  NOFORWARD - command may not be forwarded
  *  OBSOLETE  - command is considered obsolete
+ *  DEPRECATED - command is considered deprecated
+ *
+ * A command should always be first considered DEPRECATED before being
+ * considered OBSOLETE, giving due consideration to users and conforming
+ * to any guidelines regarding deprecating commands.
  */
 
 /*

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2691,8 +2691,12 @@ void Monitor::handle_command(MMonCommand *m)
     return;
   }
   if (module == "mon" &&
-      /* 'mon compact' will be handled by the Monitor class */
-      prefix != "mon compact") {
+      /* Let the Monitor class handle the following commands:
+       *  'mon compact'
+       *  'mon scrub'
+       */
+      prefix != "mon compact" &&
+      prefix != "mon scrub") {
     monmon()->dispatch(m);
     return;
   }
@@ -2724,7 +2728,7 @@ void Monitor::handle_command(MMonCommand *m)
     return;
   }
 
-  if (prefix == "scrub") {
+  if (prefix == "scrub" || prefix == "mon scrub") {
     wait_for_paxos_write();
     if (is_leader()) {
       int r = scrub();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -291,7 +291,7 @@ void Monitor::do_admin_command(string command, cmdmap_t& cmdmap, string format,
   args = "[" + args + "]";
  
   bool read_only = (command == "mon_status" ||
-		    command == "mon_metadata" ||
+		    command == "mon metadata" ||
 		    command == "quorum_status");
 
   (read_only ? audit_clog->debug() : audit_clog->info())
@@ -2698,7 +2698,8 @@ void Monitor::handle_command(MMonCommand *m)
        */
       prefix != "mon compact" &&
       prefix != "mon scrub" &&
-      prefix != "mon sync force") {
+      prefix != "mon sync force" &&
+      prefix != "mon metadata") {
     monmon()->dispatch(m);
     return;
   }
@@ -2885,7 +2886,7 @@ void Monitor::handle_command(MMonCommand *m)
     rdata.append(ds);
     rs = "";
     r = 0;
-  } else if (prefix == "mon_metadata") {
+  } else if (prefix == "mon metadata") {
     string name;
     cmd_getval(g_ceph_context, cmdmap, "id", name);
     int mon = monmap->get_rank(name);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2633,7 +2633,9 @@ void Monitor::handle_command(MMonCommand *m)
     }
   }
 
-  if (mon_cmd->is_obsolete()) {
+  if (mon_cmd->is_obsolete() ||
+      (cct->_conf->mon_debug_deprecated_as_obsolete
+       && mon_cmd->is_deprecated())) {
     reply_command(m, -ENOTSUP,
                   "command is obsolete; please check usage and/or man page",
                   0);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -102,7 +102,7 @@ const string Monitor::MONITOR_STORE_PREFIX = "monitor_store";
 MonCommand mon_commands[] = {
 #define FLAG(f) (MonCommand::FLAG_##f)
 #define COMMAND(parsesig, helptext, modulename, req_perms, avail)	\
-  {parsesig, helptext, modulename, req_perms, avail, 0},
+  {parsesig, helptext, modulename, req_perms, avail, FLAG(NONE)},
 #define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, avail, flags) \
   {parsesig, helptext, modulename, req_perms, avail, flags},
 #include <mon/MonCommands.h>

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2633,6 +2633,13 @@ void Monitor::handle_command(MMonCommand *m)
     }
   }
 
+  if (mon_cmd->is_obsolete()) {
+    reply_command(m, -ENOTSUP,
+                  "command is obsolete; please check usage and/or man page",
+                  0);
+    return;
+  }
+
   if (session->proxy_con && mon_cmd->has_flag(MonCommand::FLAG_NOFORWARD)) {
     dout(10) << "Got forward for noforward command " << m << dendl;
     reply_command(m, -EINVAL, "forward for noforward command", rdata, 0);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2609,7 +2609,7 @@ void Monitor::handle_command(MMonCommand *m)
                                               ARRAY_SIZE(mon_commands));
   if (!is_leader()) {
     if (!mon_cmd) {
-      if (leader_cmd->has_flag(MonCommand::FLAG_NOFORWARD)) {
+      if (leader_cmd->is_noforward()) {
 	reply_command(m, -EINVAL,
 		      "command not locally supported and not allowed to forward",
 		      0);
@@ -2620,7 +2620,7 @@ void Monitor::handle_command(MMonCommand *m)
       forward_request_leader(m);
       return;
     } else if (!mon_cmd->is_compat(leader_cmd)) {
-      if (mon_cmd->has_flag(MonCommand::FLAG_NOFORWARD)) {
+      if (mon_cmd->is_noforward()) {
 	reply_command(m, -EINVAL,
 		      "command not compatible with leader and not allowed to forward",
 		      0);
@@ -2640,7 +2640,7 @@ void Monitor::handle_command(MMonCommand *m)
     return;
   }
 
-  if (session->proxy_con && mon_cmd->has_flag(MonCommand::FLAG_NOFORWARD)) {
+  if (session->proxy_con && mon_cmd->is_noforward()) {
     dout(10) << "Got forward for noforward command " << m << dendl;
     reply_command(m, -EINVAL, "forward for noforward command", rdata, 0);
     return;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -96,13 +96,15 @@ const string Monitor::MONITOR_NAME = "monitor";
 const string Monitor::MONITOR_STORE_PREFIX = "monitor_store";
 
 
+#undef FLAG
 #undef COMMAND
 #undef COMMAND_WITH_FLAG
 MonCommand mon_commands[] = {
+#define FLAG(f) (MonCommand::FLAG_##f)
 #define COMMAND(parsesig, helptext, modulename, req_perms, avail)	\
   {parsesig, helptext, modulename, req_perms, avail, 0},
-#define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, avail, flag) \
-  {parsesig, helptext, modulename, req_perms, avail, MonCommand::FLAG_##flag},
+#define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, avail, flags) \
+  {parsesig, helptext, modulename, req_perms, avail, flags},
 #include <mon/MonCommands.h>
 };
 #undef COMMAND

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2690,7 +2690,9 @@ void Monitor::handle_command(MMonCommand *m)
     pgmon()->dispatch(m);
     return;
   }
-  if (module == "mon") {
+  if (module == "mon" &&
+      /* 'mon compact' will be handled by the Monitor class */
+      prefix != "mon compact") {
     monmon()->dispatch(m);
     return;
   }
@@ -2735,7 +2737,7 @@ void Monitor::handle_command(MMonCommand *m)
     return;
   }
 
-  if (prefix == "compact") {
+  if (prefix == "compact" || prefix == "mon compact") {
     dout(1) << "triggering manual compaction" << dendl;
     utime_t start = ceph_clock_now(g_ceph_context);
     store->compact();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2694,9 +2694,11 @@ void Monitor::handle_command(MMonCommand *m)
       /* Let the Monitor class handle the following commands:
        *  'mon compact'
        *  'mon scrub'
+       *  'mon sync force'
        */
       prefix != "mon compact" &&
-      prefix != "mon scrub") {
+      prefix != "mon scrub" &&
+      prefix != "mon sync force") {
     monmon()->dispatch(m);
     return;
   }
@@ -2918,7 +2920,8 @@ void Monitor::handle_command(MMonCommand *m)
     rdata.append(ds);
     rs = "";
     r = 0;
-  } else if (prefix == "sync force") {
+  } else if (prefix == "sync force" ||
+             prefix == "mon sync force") {
     string validate1, validate2;
     cmd_getval(g_ceph_context, cmdmap, "validate1", validate1);
     cmd_getval(g_ceph_context, cmdmap, "validate2", validate2);

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -979,6 +979,10 @@ struct MonCommand {
 	availability == o->availability;
   }
 
+  bool is_noforward() const {
+    return has_flag(MonCommand::FLAG_NOFORWARD);
+  }
+
   bool is_obsolete() const {
     return has_flag(MonCommand::FLAG_OBSOLETE);
   }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -949,6 +949,7 @@ struct MonCommand {
   static const uint64_t FLAG_NONE       = 0;
   static const uint64_t FLAG_NOFORWARD  = 1 << 0;
   static const uint64_t FLAG_OBSOLETE   = 1 << 1;
+  static const uint64_t FLAG_DEPRECATED = 1 << 2;
   
   bool has_flag(uint64_t flag) const { return (flags & flag) != 0; }
   void set_flag(uint64_t flag) { flags |= flag; }
@@ -986,6 +987,11 @@ struct MonCommand {
   bool is_obsolete() const {
     return has_flag(MonCommand::FLAG_OBSOLETE);
   }
+
+  bool is_deprecated() const {
+    return has_flag(MonCommand::FLAG_DEPRECATED);
+  }
+
   static void encode_array(const MonCommand *cmds, int size, bufferlist &bl) {
     ENCODE_START(2, 1, bl);
     uint16_t s = size;

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -973,7 +973,7 @@ struct MonCommand {
     ::decode(availability, bl);
   }
   bool is_compat(const MonCommand* o) const {
-    return cmdstring == o->cmdstring && helpstring == o->helpstring &&
+    return cmdstring == o->cmdstring &&
 	module == o->module && req_perms == o->req_perms &&
 	availability == o->availability;
   }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -946,10 +946,8 @@ struct MonCommand {
   uint64_t flags;
 
   // MonCommand flags
-  enum {
-    FLAG_NOFORWARD = (1 << 0),
-  };
-
+  static const uint64_t FLAG_NOFORWARD  = 1 << 0;
+  
   bool has_flag(uint64_t flag) const { return (flags & flag) != 0; }
   void set_flag(uint64_t flag) { flags |= flag; }
   void unset_flag(uint64_t flag) { flags &= ~flag; }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -946,6 +946,7 @@ struct MonCommand {
   uint64_t flags;
 
   // MonCommand flags
+  static const uint64_t FLAG_NONE       = 0;
   static const uint64_t FLAG_NOFORWARD  = 1 << 0;
   
   bool has_flag(uint64_t flag) const { return (flags & flag) != 0; }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -948,6 +948,7 @@ struct MonCommand {
   // MonCommand flags
   static const uint64_t FLAG_NONE       = 0;
   static const uint64_t FLAG_NOFORWARD  = 1 << 0;
+  static const uint64_t FLAG_OBSOLETE   = 1 << 1;
   
   bool has_flag(uint64_t flag) const { return (flags & flag) != 0; }
   void set_flag(uint64_t flag) { flags |= flag; }
@@ -978,6 +979,9 @@ struct MonCommand {
 	availability == o->availability;
   }
 
+  bool is_obsolete() const {
+    return has_flag(MonCommand::FLAG_OBSOLETE);
+  }
   static void encode_array(const MonCommand *cmds, int size, bufferlist &bl) {
     ENCODE_START(2, 1, bl);
     uint16_t s = size;

--- a/src/test/common/get_command_descriptions.cc
+++ b/src/test/common/get_command_descriptions.cc
@@ -53,13 +53,15 @@ static void json_print(const MonCommand *mon_commands, int size)
 
 static void all()
 {
+#undef FLAG
 #undef COMMAND
 #undef COMMAND_WITH_FLAG
   MonCommand mon_commands[] = {
+#define FLAG(f) (MonCommand::FLAG_##f)
 #define COMMAND(parsesig, helptext, modulename, req_perms, avail)	\
     {parsesig, helptext, modulename, req_perms, avail, 0},
-#define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, avail, flag) \
-    {parsesig, helptext, modulename, req_perms, avail, MonCommand::FLAG_##flag},
+#define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, avail, flags) \
+    {parsesig, helptext, modulename, req_perms, avail, flags},
 #include <mon/MonCommands.h>
   };
 


### PR DESCRIPTION
e.g., instead of having 'ceph scrub' or 'ceph sync force', have instead
'ceph mon scrub' and 'ceph mon sync force'.  Makes more sense and avoids
confusing the user about what component of ceph is being synchronized or
scrubbed.

Fixes: #11545

Signed-off-by: Joao Eduardo Luis <joao@suse.de>