### PR TITLE
cmake fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -291,7 +291,9 @@ if(${WITH_PROFILER})
   target_link_libraries(common profiler)
 endif(${WITH_PROFILER})
 
-target_link_libraries( common json_spirit erasure_code rt uuid ${CRYPTO_LIBS} ${Boost_LIBRARIES})
+add_library(common_utf8 STATIC common/utf8.c)
+
+target_link_libraries( common json_spirit common_utf8 erasure_code rt uuid ${CRYPTO_LIBS} ${Boost_LIBRARIES})
 
 set(libglobal_srcs
   global/global_init.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 include(GetGitRevisionDescription)
 
+enable_language(C ASM)
 set(bindir ${CMAKE_INSTALL_PREFIX}/bin)
 set(sbindir ${CMAKE_INSTALL_PREFIX}/sbin)
 set(libdir ${CMAKE_INSTALL_PREFIX}/lib)
@@ -10,6 +11,10 @@ set(prefix ${CMAKE_INSTALL_PREFIX})
 add_definitions("-DCEPH_LIBDIR=\"${libdir}\"")
 add_definitions("-DCEPH_PKGLIBDIR=\"${libdir}\"")
 add_definitions("-DHAVE_CONFIG_H -D__CEPH__ -D_FILE_OFFSET_BITS=64 -D_REENTRANT -D_THREAD_SAFE -D__STDC_FORMAT_MACROS -D_GNU_SOURCE")
+
+set(CMAKE_ASM_COMPILER  ${PROJECT_SOURCE_DIR}/src/yasm-wrapper)
+message(status " ams compiler ${CMAKE_ASM_COMPILER}")
+set(CMAKE_ASM_FLAGS "-f elf64")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -rdynamic -Wall -Wtype-limits -Wignored-qualifiers -Winit-self -Wpointer-arith -Werror=format-security -fno-strict-aliasing -fsigned-char -fPIC")
 
@@ -166,6 +171,8 @@ set(libcommon_files
   common/crc32c.cc
   common/crc32c_intel_baseline.c
   common/crc32c_intel_fast.c
+  common/crc32c_intel_fast_asm.S
+  common/crc32c_intel_fast_zero_asm.S
   common/assert.cc
   common/run_cmd.cc
   common/WorkQueue.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,6 @@ add_definitions("-DHAVE_CONFIG_H -D__CEPH__ -D_FILE_OFFSET_BITS=64 -D_REENTRANT 
 set(CMAKE_ASM_COMPILER  ${PROJECT_SOURCE_DIR}/src/yasm-wrapper)
 message(status " ams compiler ${CMAKE_ASM_COMPILER}")
 set(CMAKE_ASM_FLAGS "-f elf64")
-
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -rdynamic -Wall -Wtype-limits -Wignored-qualifiers -Winit-self -Wpointer-arith -Werror=format-security -fno-strict-aliasing -fsigned-char -fPIC")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -ftemplate-depth-1024 -Wno-invalid-offsetof -Wnon-virtual-dtor -Wno-invalid-offsetof -Wstrict-null-sentinel -Woverloaded-virtual")
@@ -292,7 +291,7 @@ if(${WITH_PROFILER})
   target_link_libraries(common profiler)
 endif(${WITH_PROFILER})
 
-target_link_libraries(common json_spirit erasure_code rt uuid ${CRYPTO_LIBS} ${Boost_LIBRARIES})
+target_link_libraries( common json_spirit erasure_code rt uuid ${CRYPTO_LIBS} ${Boost_LIBRARIES})
 
 set(libglobal_srcs
   global/global_init.cc
@@ -517,6 +516,8 @@ if(${WITH_MDS})
     mds/MDSAuthCaps.cc
     mds/MDLog.cc
     mds/JournalPointer.cc
+    mds/StrayManager.cc
+    mds/SimpleLock.cc
     ${CMAKE_SOURCE_DIR}/src/osdc/Journaler.cc)
   add_library(mds ${mds_srcs})
   set(ceph_mds_srcs
@@ -670,7 +671,8 @@ if(${WITH_RBD})
     librbd/internal.cc
     librbd/librbd.cc
     librbd/LibrbdWriteback.cc
-    librbd/ObjectMap.cc)
+    librbd/ObjectMap.cc
+    librbd/RebuildObjectMapRequest.cc)
   add_library(librbd ${CEPH_SHARED} ${librbd_srcs}
     $<TARGET_OBJECTS:osdc_rbd_objs>
     $<TARGET_OBJECTS:common_util_obj>)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1747,6 +1747,7 @@ add_executable(test_get_blkdev_size
   )
 target_link_libraries(test_get_blkdev_size
   common
+  pthread
   ${EXTRALIBS}
   ${TCMALLOC_LIBS}
   ${CMAKE_DL_LIBS}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -400,8 +400,8 @@ add_executable(unittest_str_map
   ${unittest_str_map_srcs}
   $<TARGET_OBJECTS:heap_profiler_objs>
   )
-target_link_libraries(unittest_str_map global
-  ${CMAKE_DL_LIBS} ${TCMALLOC_LIBS} ${UNITTEST_LIBS})
+target_link_libraries(unittest_str_map common global
+  ${CMAKE_DL_LIBS} ${TCMALLOC_LIBS} ${UNITTEST_LIBS} common)
 set_target_properties(unittest_str_map
   PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 


### PR DESCRIPTION
enable compilation using cmake on fedora without cryptopp.