### PR TITLE
librbd: fast diff should treat all _EXISTS objects as dirty

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -139,9 +139,10 @@ int diff_object_map(ImageCtx* ictx, uint64_t from_snap_id, uint64_t to_snap_id,
         if (prev_object_map[i] != OBJECT_NONEXISTENT) {
           (*object_diff_state)[i] = OBJECT_DIFF_STATE_HOLE;
         }
-      } else if (prev_object_map[i] != object_map[i] &&
-                 !(prev_object_map[i] == OBJECT_EXISTS &&
-                   object_map[i] == OBJECT_EXISTS_CLEAN)) {
+      } else if (object_map[i] == OBJECT_EXISTS ||
+                 (prev_object_map[i] != object_map[i] &&
+                  !(prev_object_map[i] == OBJECT_EXISTS &&
+                    object_map[i] == OBJECT_EXISTS_CLEAN))) {
         (*object_diff_state)[i] = OBJECT_DIFF_STATE_UPDATED;
       }
     }


### PR DESCRIPTION
With the fast-diff feature enabled, if the object map marks the
object as _EXISTS, it can only occur due to a write -- otherwise
it would be _EXISTS_CLEAN.  Therefore, ensure it is properly
flagged as an updated object for diff_iterate.

Fixes: #11553
Signed-off-by: Jason Dillaman <dillaman@redhat.com>