### PR TITLE
tests: fail make check if nproc is too low

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,12 +33,25 @@ if WITH_DEBUG
 	@cd src/gmock && $(MAKE) $(AM_MAKEFLAGS) lib/libgmock.la lib/libgmock_main.la
 endif
 
+CHECK_ULIMIT := true
+
 check-local:: all
 #	We build gtest this way, instead of using SUBDIRS, because with that,
 #	gtest's own tests would be run and that would slow us down.
 	@cd src/gmock/gtest && $(MAKE) $(AM_MAKEFLAGS) lib/libgtest.la lib/libgtest_main.la
 	@cd src/gmock && $(MAKE) $(AM_MAKEFLAGS) lib/libgmock.la lib/libgmock_main.la
 #	exercise cli tools
+	u=`ulimit -u` ; \
+	p=`expr $(shell nproc) / 2` ; \
+	n=`expr $$p \* 100024` ; \
+	if ${CHECK_ULIMIT} && echo ${MAKEFLAGS} | grep --quiet -e -j && test $$u -lt $$n ; then \
+		echo "ulimit -u is $$u which is lower than $$n = $$p / 2 * 1024" ; \
+		echo "If running make -j$$p check you will likely exceed this limit" ; \
+		echo "and the tests will fail in mysterious ways." ; \
+		echo "Update /etc/security/limits.conf to increase the limit" ; \
+		echo "or run make CHECK_ULIMIT=false -j4 check to override this safeguard." ; \
+		exit 1 ; \
+	fi
 	$(srcdir)/src/test/run-cli-tests '$(top_builddir)/src/test'
 
 # "make distclean" both runs this and recurses into src/gtest, if


### PR DESCRIPTION
When running tests in parallel with make -jX, the ulimit -u (number of
processor / thread per user) needs to be at least X * 1024. If not it
will fail in mysterious ways. Since there is no convenient way to figure
out the value of X ( see
http://blog.jgc.org/2015/03/gnu-make-insanity-finding-value-of-j.html
for a non trivial an entertaining solution) add a very conservative
check that assumes the user will run make -jX where X is nproc / 2.

It will be annoying for users who want to run make check, not use -j,
and have a low ulimit -u. But the error suggest a way to override this
with

   make CHECK_ULIMIT=false check

This is a minor irritation compared to the puzzling behavior of make
check when ulimit is exceeded.

http://tracker.ceph.com/issues/11532 Fixes: #11532

Signed-off-by: Loic Dachary <ldachary@redhat.com>