### PR TITLE
os/RocksdbStore: delete useless member variable

### DIFF
--- a/src/os/RocksDBStore.cc
+++ b/src/os/RocksDBStore.cc
@@ -173,9 +173,7 @@ RocksDBStore::~RocksDBStore()
   close();
   delete logger;
 
-  // Ensure db is destroyed before dependent db_cache and filterpolicy
   delete db;
-  delete filterpolicy;
 }
 
 void RocksDBStore::close()

--- a/src/os/RocksDBStore.h
+++ b/src/os/RocksDBStore.h
@@ -39,7 +39,6 @@ enum {
 namespace rocksdb{
   class DB;
   class Cache;
-  class FilterPolicy;
   class Snapshot;
   class Slice;
   class WriteBatch;
@@ -53,7 +52,6 @@ class RocksDBStore : public KeyValueDB {
   CephContext *cct;
   PerfCounters *logger;
   string path;
-  const rocksdb::FilterPolicy *filterpolicy;
   rocksdb::DB *db;
 
   int do_open(ostream &out, bool create_if_missing);


### PR DESCRIPTION
filterpolicy do not initialize by NULL, but delete it.

I am not sure whether is bug, although we do not use it now.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>