### PR TITLE
tests: pip must not log in $HOME/.pip

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -92,7 +92,7 @@ for interpreter in python2.7 python3 ; do
     rm -fr install-deps
     virtualenv --python $interpreter install-deps
     . install-deps/bin/activate
-    pip install wheel
+    pip --log install-deps/log.txt install wheel
     find . -name tox.ini | while read ini ; do
         (
             cd $(dirname $ini)
@@ -100,7 +100,7 @@ for interpreter in python2.7 python3 ; do
             if test "$require" ; then
                 # although pip comes with virtualenv, having a recent version
                 # of pip matters when it comes to using wheel packages
-                pip wheel $require 'distribute >= 0.7' 'pip >= 6.1'
+                pip --log install-deps/log.txt wheel $require 'distribute >= 0.7' 'pip >= 6.1'
             fi
         )
     done

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Ceph distributed storage system
 #
@@ -52,7 +52,7 @@ Ubuntu|Debian|Devuan)
                 ;;
         esac
         packages=$(echo $packages) # change newlines into spaces
-        $SUDO bash -c "DEBIAN_FRONTEND=noninteractive apt-get install $backports -y $packages"
+        $SUDO bash -c "DEBIAN_FRONTEND=noninteractive apt-get install $backports -y $packages" || exit 1
         ;;
 CentOS|Fedora|RedHatEnterpriseServer)
         case $(lsb_release -si) in
@@ -73,11 +73,11 @@ CentOS|Fedora|RedHatEnterpriseServer)
                 ;;
         esac
         sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-        $SUDO yum-builddep -y $DIR/ceph.spec
+        $SUDO yum-builddep -y $DIR/ceph.spec || exit 1
         ;;
 *SUSE*)
         sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-        $SUDO zypper --non-interactive install $(rpmspec -q --buildrequires $DIR/ceph.spec)
+        $SUDO zypper --non-interactive install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
         ;;
 *)
         echo "$(lsb_release -si) is unknown, dependencies will have to be installed manually."
@@ -92,7 +92,7 @@ for interpreter in python2.7 python3 ; do
     rm -fr install-deps
     virtualenv --python $interpreter install-deps
     . install-deps/bin/activate
-    pip --log install-deps/log.txt install wheel
+    pip --log install-deps/log.txt install wheel || exit 1
     find . -name tox.ini | while read ini ; do
         (
             cd $(dirname $ini)
@@ -100,7 +100,7 @@ for interpreter in python2.7 python3 ; do
             if test "$require" ; then
                 # although pip comes with virtualenv, having a recent version
                 # of pip matters when it comes to using wheel packages
-                pip --log install-deps/log.txt wheel $require 'distribute >= 0.7' 'pip >= 6.1'
+                pip --log install-deps/log.txt wheel $require 'distribute >= 0.7' 'pip >= 6.1' || exit 1
             fi
         )
     done

--- a/src/ceph-detect-init/run-tox.sh
+++ b/src/ceph-detect-init/run-tox.sh
@@ -24,10 +24,10 @@ virtualenv make-check
 . make-check/bin/activate
 # older versions of pip will not install wrap_console scripts
 # when using wheel packages
-pip install --upgrade 'pip >= 6.1'
+pip --log make-check/log.txt install --upgrade 'pip >= 6.1'
 if test -d wheelhouse ; then
     export NO_INDEX=--no-index
 fi
-pip install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse --upgrade distribute
-pip install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9' 
+pip --log make-check/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse --upgrade distribute
+pip --log make-check/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9' 
 tox 2>&1 | grep -v InterpreterNotFound

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -27,7 +27,7 @@ virtualenv virtualenv-$DIR
     if test -d ceph-detect-init/wheelhouse ; then
         wheelhouse="--no-index --use-wheel --find-links=ceph-detect-init/wheelhouse"
     fi
-    pip install $wheelhouse --editable ceph-detect-init
+    pip --log virtualenv-$DIR/log.txt install $wheelhouse --editable ceph-detect-init
 )
 OSD_DATA=$DIR/osd
 MON_ID=a

--- a/src/test/run-cli-tests
+++ b/src/test/run-cli-tests
@@ -30,7 +30,7 @@ if [ ! -e "$CRAM_BIN" ]; then
     # patched cram to support that. See upstream ticket at
     # https://bitbucket.org/brodie/cram/issue/9/allow-read-only-directories-for-t
     # -- tv@inktank.com
-    virtualenv "$VENV" && $VENV/bin/pip install "$SRCDIR/downloads/cram-0.5.0ceph.2011-01-14.tar.gz"
+    virtualenv "$VENV" && $VENV/bin/pip --log "$VENV"/log.txt install "$SRCDIR/downloads/cram-0.5.0ceph.2011-01-14.tar.gz"
 fi
 
 SRCDIR_ABS="$(readlink -f "$SRCDIR")"


### PR DESCRIPTION
Because it may not have permission to when running in a container and
scripts run from source are not expected to modify anything outside of
the source tree anyway.

Signed-off-by: Loic Dachary <loic@dachary.org>