### PR TITLE
install-deps.sh: increase pip install timeout

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -92,7 +92,7 @@ for interpreter in python2.7 python3 ; do
     rm -fr install-deps
     virtualenv --python $interpreter install-deps
     . install-deps/bin/activate
-    pip --log install-deps/log.txt install wheel || exit 1
+    pip --timeout 600 --log install-deps/log.txt install wheel || exit 1
     find . -name tox.ini | while read ini ; do
         (
             cd $(dirname $ini)
@@ -100,7 +100,7 @@ for interpreter in python2.7 python3 ; do
             if test "$require" ; then
                 # although pip comes with virtualenv, having a recent version
                 # of pip matters when it comes to using wheel packages
-                pip --log install-deps/log.txt wheel $require 'distribute >= 0.7' 'pip >= 6.1' || exit 1
+                pip --timeout 600 --log install-deps/log.txt wheel $require 'distribute >= 0.7' 'pip >= 6.1' || exit 1
             fi
         )
     done


### PR DESCRIPTION
It is not uncommon for pip install to timeout with:

   Cannot fetch index base URL https://pypi.python.org/simple

because the default timeout is 15 seconds. When running from a CI, it
translates into bursts of false negatives when the network is saturated.

Increase the timeout to 10 minutes which is hopefully large enough to
only happen when there is a serious network problem.

Signed-off-by: Loic Dachary <ldachary@redhat.com>