### PR TITLE
debian: add bootstrap-rgw dir to ceph package

### DIFF
--- a/debian/ceph.dirs
+++ b/debian/ceph.dirs
@@ -3,3 +3,4 @@ var/lib/ceph/mon
 var/lib/ceph/osd
 var/lib/ceph/bootstrap-osd
 var/lib/ceph/bootstrap-mds
+var/lib/ceph/bootstrap-rgw


### PR DESCRIPTION
Signed-off-by: Travis Rhoden <trhoden@redhat.com>