### PR TITLE
install-deps.sh: only pip install after make clean

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,7 @@ clean-local:
 	fi
 
 	@rm -rf src/test/virtualenv
+	@rm -rf install-deps-*
 
 
 # NOTE: This only works when enough dependencies are installed for


### PR DESCRIPTION
Do not re-install all python dependencies if there already exists a
wheelhouse directory. It makes it so running install-deps.sh twice will
only access the network the first time. The directories where the python
dependencies are installed are removed by make clean. Refreshing the
python dependencies cache can be done via make clean ; install-deps.sh

Signed-off-by: Loic Dachary <ldachary@redhat.com>