### PR TITLE
librbd: Objectcacher setting max object counts too low

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -189,10 +189,9 @@ namespace librbd {
     if (object_cacher) {
       uint64_t obj = cct->_conf->rbd_cache_max_dirty_object;
       if (!obj) {
-        obj = cct->_conf->rbd_cache_size / (1ull << order);
-        obj = obj * 4 + 10;
+        obj = MIN(2000, MAX(10, cct->_conf->rbd_cache_size / 100 / sizeof(ObjectCacher::Object)));
       }
-      ldout(cct, 10) << " cache bytes " << cct->_conf->rbd_cache_size << " order " << (int)order
+      ldout(cct, 10) << " cache bytes " << cct->_conf->rbd_cache_size
 		     << " -> about " << obj << " objects" << dendl;
       object_cacher->set_max_objects(obj);
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/7385