### PR TITLE
mon: fix the FTBFS

### DIFF
--- a/src/messages/Makefile.am
+++ b/src/messages/Makefile.am
@@ -65,6 +65,7 @@ noinst_HEADERS += \
 	messages/MMonHealth.h \
 	messages/MMonJoin.h \
 	messages/MMonMap.h \
+	messages/MMonMetadata.h \
 	messages/MMonPaxos.h \
 	messages/MMonProbe.h \
 	messages/MMonScrub.h \


### PR DESCRIPTION
put the messages/MMonMetadata.h into the dist tarball.

Fixes: #10904
Signed-off-by: Kefu Chai <kchai@redhat.com>