### PR TITLE
packaging: include ceph_perf_objectstore

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -855,6 +855,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_bindir}/ceph_erasure_code
 %{_bindir}/ceph_erasure_code_benchmark
 %{_bindir}/ceph_omapbench
+%{_bindir}/ceph_perf_objectstore
 %{_bindir}/ceph_psim
 %{_bindir}/ceph_radosacl
 %{_bindir}/ceph_rgw_jsonparser

--- a/debian/ceph-test.install
+++ b/debian/ceph-test.install
@@ -5,6 +5,7 @@ usr/bin/ceph_multi_stress_watch
 usr/bin/ceph_erasure_code
 usr/bin/ceph_erasure_code_benchmark
 usr/bin/ceph_omapbench
+usr/bin/ceph_perf_objectstore
 usr/bin/ceph_psim
 usr/bin/ceph_radosacl
 usr/bin/ceph_rgw_jsonparser


### PR DESCRIPTION
The `/usr/bin/ceph_perf_objectstore` file is installed by default. Prior to this commit it was missing from the packaging. This caused the RPM to fail to build in mock.

Add `ceph_perf_objectstore` to the "ceph-test" RPM and Debian package.

-----

This is a hammer-based cherry-pick of the PR that went into master at #3992.

For reviewers: you can verify this PR fix by looking at Gitbuilder's results.

Gitbuilder will display the following error text for the "hammer" branch:

```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /srv/autobuild-ceph/gitbuilder.git/build/rpmbuild/BUILDROOT/ceph-0.94.1-111.gb69fb89.el7.x86_64
warning: Installed (but unpackaged) file(s) found:
/usr/bin/ceph_perf_objectstore
```

The reason this is not a fatal error is that the gitbuilders run with `--define '_unpackaged_files_terminate_build 0'`, although this option is going to be turned off (https://github.com/ceph/autobuild-ceph/pull/40) as soon as the gitbuilders get updated.

After the commit in this PR is merged, the "`Installed (but unpackaged) file(s) found`" text will go away.