### PR TITLE
erasure-code: add --erased option to ceph_erasure_code_benchmark

### DIFF
--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -185,6 +185,20 @@ int ErasureCodeBench::encode()
   return 0;
 }
 
+static void display_chunks(const map<int,bufferlist> &chunks,
+			   unsigned int chunk_count) {
+  cout << "chunks ";
+  for (unsigned int chunk = 0; chunk < chunk_count; chunk++) {
+    if (chunks.count(chunk) == 0) {
+      cout << "(" << chunk << ")";
+    } else {
+      cout << " " << chunk << " ";
+    }
+    cout << " ";
+  }
+  cout << "(X) is an erased chunk" << endl;
+}
+
 int ErasureCodeBench::decode_erasures(const map<int,bufferlist> &all_chunks,
 				      const map<int,bufferlist> &chunks,
 				      unsigned i,
@@ -195,22 +209,11 @@ int ErasureCodeBench::decode_erasures(const map<int,bufferlist> &all_chunks,
 
   if (want_erasures == 0) {
     if (verbose)
-      cout << "chunks ";
+      display_chunks(chunks, erasure_code->get_chunk_count());
     set<int> want_to_read;
-    for (unsigned int chunk = 0; chunk < erasure_code->get_chunk_count(); chunk++) {
-      if (chunks.count(chunk) == 0) {
-	if (verbose)
-	  cout << "(" << chunk << ")";
+    for (unsigned int chunk = 0; chunk < erasure_code->get_chunk_count(); chunk++)
+      if (chunks.count(chunk) == 0)
 	want_to_read.insert(chunk);
-      } else {
-	if (verbose)
-	  cout << " " << chunk << " ";
-      }
-      if (verbose)
-	cout << " ";
-    }
-    if (verbose)
-      cout << "(X) is an erased chunk" << endl;
 
     map<int,bufferlist> decoded;
     code = erasure_code->decode(want_to_read, chunks, &decoded);

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -52,6 +52,8 @@ int ErasureCodeBench::setup(int argc, char** argv) {
      "run either encode or decode")
     ("erasures,e", po::value<int>()->default_value(1),
      "number of erasures when decoding")
+    ("erased", po::value<vector<int> >(),
+     "erased chunk (repeat if more than one chunk is erased)")
     ("erasures-generation,E", po::value<string>()->default_value("random"),
      "If set to 'random', pick the number of chunks to recover (as specified by "
      " --erasures) at random. If set to 'exhaustive' try all combinations of erasures "
@@ -119,6 +121,8 @@ int ErasureCodeBench::setup(int argc, char** argv) {
     exhaustive_erasures = true;
   else
     exhaustive_erasures = false;
+  if (vm.count("erased") > 0)
+    erased = vm["erased"].as<vector<int> >();
 
   k = atoi(parameters["k"].c_str());
   m = atoi(parameters["m"].c_str());
@@ -282,10 +286,23 @@ int ErasureCodeBench::decode()
 
   set<int> want_to_read = want_to_encode;
 
+  if (erased.size() > 0) {
+    for (vector<int>::const_iterator i = erased.begin();
+	 i != erased.end();
+	 i++)
+      encoded.erase(*i);
+    display_chunks(encoded, erasure_code->get_chunk_count());
+  }
+
   utime_t begin_time = ceph_clock_now(g_ceph_context);
   for (int i = 0; i < max_iterations; i++) {
     if (exhaustive_erasures) {
       code = decode_erasures(encoded, encoded, 0, erasures, erasure_code);
+      if (code)
+	return code;
+    } else if (erased.size() > 0) {
+      map<int,bufferlist> decoded;
+      code = erasure_code->decode(want_to_read, encoded, &decoded);
       if (code)
 	return code;
     } else {

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.h
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.h
@@ -32,6 +32,7 @@ class ErasureCodeBench {
   string plugin;
 
   bool exhaustive_erasures;
+  vector<int> erased;
   string workload;
 
   map<string,string> parameters;


### PR DESCRIPTION
The --erased option specifies which chunks are erased when running the
decode workload. It is useful to precisely measure the code path
involved by a given recovery strategy. If only one chunk is missing
the code path won't be the same as if two chunks are missing.

Signed-off-by: Loic Dachary <ldachary@redhat.com>