### PR TITLE
erasure-code: bench.sh compares isa & jerasure, vandermonde & cauchy

### DIFF
--- a/qa/workunits/erasure-code/bench.html
+++ b/qa/workunits/erasure-code/bench.html
@@ -28,27 +28,6 @@
       </div>
       <p>decode: Y = GB/s, X = K/M/erasures</p>
 
-      <div class="demo-container">
-	<div id="encode4KB" class="demo-placeholder"></div>
-      </div>
-      <p>encode 4KB: Y = GB/s, X = K/M</p>
-
-      <div class="demo-container">
-	<div id="decode4KB" class="demo-placeholder"></div>
-      </div>
-      <p>decode 4KB: Y = GB/s, X = K/M/erasures</p>
-
-      <div class="demo-container">
-	<div id="encode1MB" class="demo-placeholder"></div>
-      </div>
-      <p>encode 1MB: Y = GB/s, X = K/M</p>
-
-      <div class="demo-container">
-	<div id="decode1MB" class="demo-placeholder"></div>
-      </div>
-      <p>decode 1MB: Y = GB/s, X = K/M/erasures</p>
-
-
     </div>
 
   </body>

--- a/qa/workunits/erasure-code/bench.sh
+++ b/qa/workunits/erasure-code/bench.sh
@@ -16,7 +16,6 @@
 #
 # Test that it works from sources with:
 #
-#  TOTAL_SIZE=$((1024 * 1024)) \
 #  CEPH_ERASURE_CODE_BENCHMARK=src/ceph_erasure_code_benchmark  \
 #  PLUGIN_DIRECTORY=src/.libs \
 #      qa/workunits/erasure-code/bench.sh fplot jerasure |
@@ -24,7 +23,7 @@
 #
 # This should start immediately and display:
 #
-# var encode_reed_sol_van_4096 = [
+# ...
 # [ '2/1',  .48035538612887358583  ],
 # [ '3/2',  .21648470405675016626  ],
 # etc.
@@ -36,6 +35,7 @@
 # Once it is confirmed to work, it can be run with a more significant
 # volume of data so that the measures are more reliable:
 #
+#  TOTAL_SIZE=$((4 * 1024 * 1024 * 1024)) \
 #  CEPH_ERASURE_CODE_BENCHMARK=src/ceph_erasure_code_benchmark  \
 #  PLUGIN_DIRECTORY=src/.libs \
 #      qa/workunits/erasure-code/bench.sh fplot jerasure |
@@ -49,8 +49,8 @@ export PATH=/sbin:$PATH
 : ${CEPH_ERASURE_CODE_BENCHMARK:=ceph_erasure_code_benchmark}
 : ${PLUGIN_DIRECTORY:=/usr/lib/ceph/erasure-code}
 : ${PLUGINS:=example jerasure isa}
-: ${TOTAL_SIZE:=$((10 * 1024 * 1024))}
-: ${SIZES:=4096 $((1024 * 1024))}
+: ${TOTAL_SIZE:=$((1024 * 1024))}
+: ${SIZE:=4096}
 : ${PARAMETERS:=--parameter jerasure-per-chunk-alignment=true}
 
 function bench_header() {
@@ -85,15 +85,6 @@ function bench() {
     echo -e "$result\t$plugin\t$k\t$m\t$workload\t$iterations\t$size\t$erasures\t$command ""$@"
 }
 
-function example_test() {
-    local plugin=example
-    local size
-    for size in $SIZES ; do
-        bench $plugin 2 1 encode $ITERATIONS $size 0
-        bench $plugin 2 1 decode $ITERATIONS $size 1
-    done
-}
-
 function packetsize() {
     local k=$1
     local w=$2
@@ -107,7 +98,7 @@ function packetsize() {
     echo $p
 }
 
-function jerasure_test() {
+function bench_run() {
     local plugin=jerasure
     local w=8
     local VECTOR_WORDSIZE=16
@@ -118,31 +109,39 @@ function jerasure_test() {
     k2ms[4]="2 3"
     k2ms[6]="2 3 4"
     k2ms[10]="3 4"
-    for technique in reed_sol_van cauchy_good ; do
-        for size in $SIZES ; do
-            echo "serie encode_${technique}_${size}"
+    local isa2technique_vandermonde='reed_sol_van'
+    local isa2technique_cauchy='cauchy'
+    local jerasure_generic2technique_vandermonde='reed_sol_van'
+    local jerasure_generic2technique_cauchy='cauchy_good'
+    local jerasure_sse42technique_vandermonde='reed_sol_van'
+    local jerasure_sse42technique_cauchy='cauchy_good'
+    for technique in vandermonde cauchy ; do
+        for plugin in isa jerasure_generic jerasure_sse4 ; do
+            eval technique_parameter=\$${plugin}2technique_${technique}
+            echo "serie encode_${technique}_${plugin}"
             for k in $ks ; do
                 for m in ${k2ms[$k]} ; do
-                    bench $plugin $k $m encode $(($TOTAL_SIZE / $size)) $size 0 \
-                        --parameter packetsize=$(packetsize $k $w $VECTOR_WORDSIZE $size) \
+                    bench $plugin $k $m encode $(($TOTAL_SIZE / $SIZE)) $SIZE 0 \
+                        --parameter packetsize=$(packetsize $k $w $VECTOR_WORDSIZE $SIZE) \
                         ${PARAMETERS} \
-                        --parameter technique=$technique
+                        --parameter technique=$technique_parameter
 
                 done
             done
         done
     done
-    for technique in reed_sol_van cauchy_good ; do
-        for size in $SIZES ; do
-            echo "serie decode_${technique}_${size}"
+    for technique in vandermonde cauchy ; do
+        for plugin in isa jerasure_generic jerasure_sse4 ; do
+            eval technique_parameter=\$${plugin}2technique_${technique}
+            echo "serie decode_${technique}_${plugin}"
             for k in $ks ; do
                 for m in ${k2ms[$k]} ; do
                     echo
                     for erasures in $(seq 1 $m) ; do
-                        bench $plugin $k $m decode $(($TOTAL_SIZE / $size)) $size $erasures \
-                            --parameter packetsize=$(packetsize $k $w $VECTOR_WORDSIZE  $size) \
+                        bench $plugin $k $m decode $(($TOTAL_SIZE / $SIZE)) $SIZE $erasures \
+                            --parameter packetsize=$(packetsize $k $w $VECTOR_WORDSIZE  $SIZE) \
                             ${PARAMETERS} \
-                            --parameter technique=$technique
+                            --parameter technique=$technique_parameter
                     done
                 done
             done
@@ -150,46 +149,9 @@ function jerasure_test() {
     done
 }
 
-function isa_test() {
-    local plugin=isa
-    local ks="2 3 4 6 10"
-    declare -A k2ms
-    k2ms[2]="1"
-    k2ms[3]="2"
-    k2ms[4]="2 3"
-    k2ms[6]="2 3 4"
-    k2ms[10]="3 4"
-    for technique in reed_sol_van cauchy ; do
-        for size in $SIZES ; do
-            echo "serie encode_${technique}_${size}"
-            for k in $ks ; do
-                for m in ${k2ms[$k]} ; do
-                    bench $plugin $k $m encode $(($TOTAL_SIZE / $size)) $size 0 \
-                        --parameter technique=$technique
-
-                done
-            done
-        done
-    done
-    for technique in reed_sol_van cauchy ; do
-        for size in $SIZES ; do
-            echo "serie decode_${technique}_${size}"
-            for k in $ks ; do
-                for m in ${k2ms[$k]} ; do
-                    echo
-                    for erasures in $(seq 1 $m) ; do
-                        bench $plugin $k $m decode $(($TOTAL_SIZE / $size)) $size $erasures \
-                            --parameter technique=$technique
-                    done
-                done
-            done
-        done
-    done
-}
 function fplot() {
-    local plugin=$1
     local serie
-    ${plugin}_test | while read seconds total plugin k m workload iteration size erasures rest ; do 
+    bench_run | while read seconds total plugin k m workload iteration size erasures rest ; do 
         if [ -z $seconds ] ; then
             echo null,
         elif [ $seconds = serie ] ; then
@@ -213,209 +175,10 @@ function fplot() {
 
 function main() {
     bench_header
-    for plugin in ${PLUGINS} ; do
-        ${plugin}_test || return 1
-    done
+    bench_run
 }
 
-if [ "$1" = TEST ] ; then
-    set -x
-    set -o functrace
-    PS4=' ${FUNCNAME[0]}: $LINENO: '
-
-    TOTAL_SIZE=1024
-    SIZE=1024
-
-    function run_test() {
-        dir=/tmp/erasure-code
-        rm -fr $dir
-        mkdir $dir
-        expected=$(cat <<EOF
-plugin	k	m	work.	iter.	size	eras.
-serie encode_reed_sol_van_4096
-jerasure	2	1	encode	0	4096	0
-jerasure	3	2	encode	0	4096	0
-jerasure	4	2	encode	0	4096	0
-jerasure	4	3	encode	0	4096	0
-jerasure	6	2	encode	0	4096	0
-jerasure	6	3	encode	0	4096	0
-jerasure	6	4	encode	0	4096	0
-jerasure	10	3	encode	0	4096	0
-jerasure	10	4	encode	0	4096	0
-serie encode_reed_sol_van_1048576
-jerasure	2	1	encode	0	1048576	0
-jerasure	3	2	encode	0	1048576	0
-jerasure	4	2	encode	0	1048576	0
-jerasure	4	3	encode	0	1048576	0
-jerasure	6	2	encode	0	1048576	0
-jerasure	6	3	encode	0	1048576	0
-jerasure	6	4	encode	0	1048576	0
-jerasure	10	3	encode	0	1048576	0
-jerasure	10	4	encode	0	1048576	0
-serie encode_cauchy_good_4096
-jerasure	2	1	encode	0	4096	0
-jerasure	3	2	encode	0	4096	0
-jerasure	4	2	encode	0	4096	0
-jerasure	4	3	encode	0	4096	0
-jerasure	6	2	encode	0	4096	0
-jerasure	6	3	encode	0	4096	0
-jerasure	6	4	encode	0	4096	0
-jerasure	10	3	encode	0	4096	0
-jerasure	10	4	encode	0	4096	0
-serie encode_cauchy_good_1048576
-jerasure	2	1	encode	0	1048576	0
-jerasure	3	2	encode	0	1048576	0
-jerasure	4	2	encode	0	1048576	0
-jerasure	4	3	encode	0	1048576	0
-jerasure	6	2	encode	0	1048576	0
-jerasure	6	3	encode	0	1048576	0
-jerasure	6	4	encode	0	1048576	0
-jerasure	10	3	encode	0	1048576	0
-jerasure	10	4	encode	0	1048576	0
-serie decode_reed_sol_van_4096
-
-jerasure	2	1	decode	0	4096	1
-
-jerasure	3	2	decode	0	4096	1
-jerasure	3	2	decode	0	4096	2
-
-jerasure	4	2	decode	0	4096	1
-jerasure	4	2	decode	0	4096	2
-
-jerasure	4	3	decode	0	4096	1
-jerasure	4	3	decode	0	4096	2
-jerasure	4	3	decode	0	4096	3
-
-jerasure	6	2	decode	0	4096	1
-jerasure	6	2	decode	0	4096	2
-
-jerasure	6	3	decode	0	4096	1
-jerasure	6	3	decode	0	4096	2
-jerasure	6	3	decode	0	4096	3
-
-jerasure	6	4	decode	0	4096	1
-jerasure	6	4	decode	0	4096	2
-jerasure	6	4	decode	0	4096	3
-jerasure	6	4	decode	0	4096	4
-
-jerasure	10	3	decode	0	4096	1
-jerasure	10	3	decode	0	4096	2
-jerasure	10	3	decode	0	4096	3
-
-jerasure	10	4	decode	0	4096	1
-jerasure	10	4	decode	0	4096	2
-jerasure	10	4	decode	0	4096	3
-jerasure	10	4	decode	0	4096	4
-serie decode_reed_sol_van_1048576
-
-jerasure	2	1	decode	0	1048576	1
-
-jerasure	3	2	decode	0	1048576	1
-jerasure	3	2	decode	0	1048576	2
-
-jerasure	4	2	decode	0	1048576	1
-jerasure	4	2	decode	0	1048576	2
-
-jerasure	4	3	decode	0	1048576	1
-jerasure	4	3	decode	0	1048576	2
-jerasure	4	3	decode	0	1048576	3
-
-jerasure	6	2	decode	0	1048576	1
-jerasure	6	2	decode	0	1048576	2
-
-jerasure	6	3	decode	0	1048576	1
-jerasure	6	3	decode	0	1048576	2
-jerasure	6	3	decode	0	1048576	3
-
-jerasure	6	4	decode	0	1048576	1
-jerasure	6	4	decode	0	1048576	2
-jerasure	6	4	decode	0	1048576	3
-jerasure	6	4	decode	0	1048576	4
-
-jerasure	10	3	decode	0	1048576	1
-jerasure	10	3	decode	0	1048576	2
-jerasure	10	3	decode	0	1048576	3
-
-jerasure	10	4	decode	0	1048576	1
-jerasure	10	4	decode	0	1048576	2
-jerasure	10	4	decode	0	1048576	3
-jerasure	10	4	decode	0	1048576	4
-serie decode_cauchy_good_4096
-
-jerasure	2	1	decode	0	4096	1
-
-jerasure	3	2	decode	0	4096	1
-jerasure	3	2	decode	0	4096	2
-
-jerasure	4	2	decode	0	4096	1
-jerasure	4	2	decode	0	4096	2
-
-jerasure	4	3	decode	0	4096	1
-jerasure	4	3	decode	0	4096	2
-jerasure	4	3	decode	0	4096	3
-
-jerasure	6	2	decode	0	4096	1
-jerasure	6	2	decode	0	4096	2
-
-jerasure	6	3	decode	0	4096	1
-jerasure	6	3	decode	0	4096	2
-jerasure	6	3	decode	0	4096	3
-
-jerasure	6	4	decode	0	4096	1
-jerasure	6	4	decode	0	4096	2
-jerasure	6	4	decode	0	4096	3
-jerasure	6	4	decode	0	4096	4
-
-jerasure	10	3	decode	0	4096	1
-jerasure	10	3	decode	0	4096	2
-jerasure	10	3	decode	0	4096	3
-
-jerasure	10	4	decode	0	4096	1
-jerasure	10	4	decode	0	4096	2
-jerasure	10	4	decode	0	4096	3
-jerasure	10	4	decode	0	4096	4
-serie decode_cauchy_good_1048576
-
-jerasure	2	1	decode	0	1048576	1
-
-jerasure	3	2	decode	0	1048576	1
-jerasure	3	2	decode	0	1048576	2
-
-jerasure	4	2	decode	0	1048576	1
-jerasure	4	2	decode	0	1048576	2
-
-jerasure	4	3	decode	0	1048576	1
-jerasure	4	3	decode	0	1048576	2
-jerasure	4	3	decode	0	1048576	3
-
-jerasure	6	2	decode	0	1048576	1
-jerasure	6	2	decode	0	1048576	2
-
-jerasure	6	3	decode	0	1048576	1
-jerasure	6	3	decode	0	1048576	2
-jerasure	6	3	decode	0	1048576	3
-
-jerasure	6	4	decode	0	1048576	1
-jerasure	6	4	decode	0	1048576	2
-jerasure	6	4	decode	0	1048576	3
-jerasure	6	4	decode	0	1048576	4
-
-jerasure	10	3	decode	0	1048576	1
-jerasure	10	3	decode	0	1048576	2
-jerasure	10	3	decode	0	1048576	3
-
-jerasure	10	4	decode	0	1048576	1
-jerasure	10	4	decode	0	1048576	2
-jerasure	10	4	decode	0	1048576	3
-jerasure	10	4	decode	0	1048576	4
-EOF
-)
-        test "$(PLUGINS=jerasure main | cut --fields=3-9 )" = "$expected" || return 1
-    }
-
-    run_test
-
-elif [ "$1" = fplot ] ; then
+if [ "$1" = fplot ] ; then
     "$@"
 else
     main
@@ -424,6 +187,6 @@ fi
 # compile-command: "\
 #   CEPH_ERASURE_CODE_BENCHMARK=../../../src/ceph_erasure_code_benchmark \
 #   PLUGIN_DIRECTORY=../../../src/.libs \
-#   ./bench.sh TEST
+#   ./bench.sh
 # "
 # End:

--- a/qa/workunits/erasure-code/plot.js
+++ b/qa/workunits/erasure-code/plot.js
@@ -1,26 +1,32 @@
 $(function() {
     $.plot("#encode", [
         {
-	    data: encode_cauchy_good_4096,
-            label: "Cauchy 4KB",
+	    data: encode_vandermonde_isa,
+            label: "ISA, Vandermonde",
 	    points: { show: true },
 	    lines: { show: true },
 	},
         {
-	    data: encode_cauchy_good_1048576,
-            label: "Cauchy 1MB",
+	    data: encode_vandermonde_jerasure_generic,
+            label: "Jerasure Generic, Vandermonde",
 	    points: { show: true },
 	    lines: { show: true },
 	},
         {
-	    data: encode_reed_sol_van_4096,
-            label: "Reed Solomon 4KB",
+	    data: encode_vandermonde_jerasure_sse4,
+            label: "Jerasure SIMD, Vandermonde",
 	    points: { show: true },
 	    lines: { show: true },
 	},
         {
-	    data: encode_reed_sol_van_1048576,
-            label: "Reed Solomon 1MB",
+	    data: encode_cauchy_isa,
+            label: "ISA, Cauchy",
+	    points: { show: true },
+	    lines: { show: true },
+	},
+        {
+	    data: encode_cauchy_jerasure_generic,
+            label: "Jerasure, Cauchy",
 	    points: { show: true },
 	    lines: { show: true },
 	},
@@ -34,110 +40,32 @@ $(function() {
 
     $.plot("#decode", [
         {
-	    data: decode_cauchy_good_4096,
-            label: "Cauchy 4KB",
+	    data: decode_vandermonde_isa,
+            label: "ISA, Vandermonde",
 	    points: { show: true },
 	    lines: { show: true },
 	},
         {
-	    data: decode_cauchy_good_1048576,
-            label: "Cauchy 1MB",
+	    data: decode_vandermonde_jerasure_generic,
+            label: "Jerasure Generic, Vandermonde",
 	    points: { show: true },
 	    lines: { show: true },
 	},
         {
-	    data: decode_reed_sol_van_4096,
-            label: "Reed Solomon 4KB",
+	    data: decode_vandermonde_jerasure_sse4,
+            label: "Jerasure SIMD, Vandermonde",
 	    points: { show: true },
 	    lines: { show: true },
 	},
         {
-	    data: decode_reed_sol_van_1048576,
-            label: "Reed Solomon 1MB",
-	    points: { show: true },
-	    lines: { show: true },
-	},
-    ], {
-	xaxis: {
-	    mode: "categories",
-	    tickLength: 0
-	},
-    }
-          );
-
-    $.plot("#encode4KB", [
-        {
-	    data: encode_cauchy_good_4096,
-            label: "Cauchy 4KB",
+	    data: decode_cauchy_isa,
+            label: "ISA, Cauchy",
 	    points: { show: true },
 	    lines: { show: true },
 	},
         {
-	    data: encode_reed_sol_van_4096,
-            label: "Reed Solomon 4KB",
-	    points: { show: true },
-	    lines: { show: true },
-	},
-    ], {
-	xaxis: {
-	    mode: "categories",
-	    tickLength: 0
-	},
-    }
-          );
-
-    $.plot("#decode4KB", [
-        {
-	    data: decode_cauchy_good_4096,
-            label: "Cauchy 4KB",
-	    points: { show: true },
-	    lines: { show: true },
-	},
-        {
-	    data: decode_reed_sol_van_4096,
-            label: "Reed Solomon 4KB",
-	    points: { show: true },
-	    lines: { show: true },
-	},
-    ], {
-	xaxis: {
-	    mode: "categories",
-	    tickLength: 0
-	},
-    }
-          );
-
-    $.plot("#encode1MB", [
-        {
-	    data: encode_cauchy_good_1048576,
-            label: "Cauchy 1MB",
-	    points: { show: true },
-	    lines: { show: true },
-	},
-        {
-	    data: encode_reed_sol_van_1048576,
-            label: "Reed Solomon 1MB",
-	    points: { show: true },
-	    lines: { show: true },
-	},
-    ], {
-	xaxis: {
-	    mode: "categories",
-	    tickLength: 0
-	},
-    }
-          );
-
-    $.plot("#decode1MB", [
-        {
-	    data: decode_cauchy_good_1048576,
-            label: "Cauchy 1MB",
-	    points: { show: true },
-	    lines: { show: true },
-	},
-        {
-	    data: decode_reed_sol_van_1048576,
-            label: "Reed Solomon 1MB",
+	    data: decode_cauchy_jerasure_generic,
+            label: "Jerasure, Cauchy",
 	    points: { show: true },
 	    lines: { show: true },
 	},


### PR DESCRIPTION
ISA and Jerasure can be compared for the default stripe width (4KB) and
the two most commonly used Reed Solomon matrices. Comparing the
bandwidth for large chunks (1MB) is not relevant because it is not
commonly used.

Signed-off-by: Loic Dachary <ldachary@redhat.com>