### PR TITLE
RBD: expunge test broken by xfs commit

### DIFF
--- a/qa/run_xfstests_krbd.sh
+++ b/qa/run_xfstests_krbd.sh
@@ -42,6 +42,7 @@ cat > "${EXPUNGE}" <<-!
 	generic/099	# not for Linux
 	generic/204	# stripe size throws off test's math for when to
 			#  expect ENOSPC
+	generic/231 # broken for disk and rbd by xfs kernel commit 4162bb
 
 	shared/272	# not for xfs
 	shared/289	# not for xfs


### PR DESCRIPTION
expunge generic/231, broken for disk and rbd by kernel commit 04162bb

Signed-off-by: Douglas Fuller <dfuller@redhat.com>