### PR TITLE
#11481: MDS resilience to weird mdsmaps

### DIFF
--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -1566,14 +1566,14 @@ void MDS::handle_mds_map(MMDSMap *m)
 
   // see who i am
   addr = messenger->get_myaddr();
+  state = mdsmap->get_state_gid(mds_gid_t(monc->get_global_id()));
+  incarnation = mdsmap->get_inc_gid(mds_gid_t(monc->get_global_id()));
   whoami = mdsmap->get_rank_gid(mds_gid_t(monc->get_global_id()));
   if (whoami == MDS_RANK_NONE && (
       state == MDSMap::STATE_STANDBY_REPLAY || state == MDSMap::STATE_ONESHOT_REPLAY)) {
     whoami = mdsmap->get_mds_info_gid(mds_gid_t(monc->get_global_id())).standby_for_rank;
   }
 
-  state = mdsmap->get_state_gid(mds_gid_t(monc->get_global_id()));
-  incarnation = mdsmap->get_inc_gid(mds_gid_t(monc->get_global_id()));
   dout(10) << "map says i am " << addr << " mds." << whoami << "." << incarnation
 	   << " state " << ceph_mds_state_name(state) << dendl;
 

--- a/src/mds/MDS.h
+++ b/src/mds/MDS.h
@@ -451,7 +451,19 @@ private:
    * through cleaner scrub/repair mechanisms.
    */
   void damaged();
-  void suicide();
+
+  /**
+   * Terminate this daemon process.
+   *
+   * @param fast: if true, do not send a message to the mon before shutting
+   *              down
+   */
+  void suicide(bool fast = false);
+
+  /**
+   * Start a new daemon process with the same command line parameters that
+   * this process was run with, then terminate this process
+   */
   void respawn();
   void handle_write_error(int err);
 

--- a/src/mds/RecoveryQueue.cc
+++ b/src/mds/RecoveryQueue.cc
@@ -154,7 +154,7 @@ void RecoveryQueue::_recovered(CInode *in, int r, uint64_t size, utime_t mtime)
   if (r != 0) {
     dout(0) << "recovery error! " << r << dendl;
     if (r == -EBLACKLISTED) {
-      mds->suicide();
+      mds->respawn();
       return;
     }
     assert(0 == "unexpected error from osd during recovery");


### PR DESCRIPTION
Plus some bonus bits from when I was looking through this code.

boot statemachine wasn't the right tool for the job here, as in order to use it we'd have to have code to translate the (oldstate, state) tuple into an event (and reject state transitions that weren't valid events), by which point we would have done all the validation we need.