### PR TITLE
rgw: restore buffer of multipart upload after EEXIST

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,2 +1,3 @@
 /overview.png
 /object_store.png
+/Makefile

--- a/qa/workunits/ceph-deploy/ceph-deploy_hello_world.sh
+++ b/qa/workunits/ceph-deploy/ceph-deploy_hello_world.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+#check ceph health
+ceph -s
+#list pools
+rados lspools
+#lisr rbd images
+rbd ls
+#check that the monitors work
+ceph osd set nodown
+ceph osd unset nodown
+
+exit 0

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1807,6 +1807,12 @@ void RGWPutObj::execute()
      */
     bool need_to_wait = (ofs == 0) && multipart;
 
+    bufferlist orig_data;
+
+    if (need_to_wait) {
+      orig_data = data;
+    }
+
     ret = put_data_and_throttle(processor, data, ofs, (need_calc_md5 ? &hash : NULL), need_to_wait);
     if (ret < 0) {
       if (!need_to_wait || ret != -EEXIST) {
@@ -1815,6 +1821,9 @@ void RGWPutObj::execute()
       }
 
       ldout(s->cct, 5) << "NOTICE: processor->throttle_data() returned -EEXIST, need to restart write" << dendl;
+
+      /* restore original data */
+      data.swap(orig_data);
 
       /* restart processing with different oid suffix */
 


### PR DESCRIPTION
Fixes #11604
Backport: hammer, firefly

When we need to restart a write of part data, we need to revert to
buffer to before the write, otherwise we're going to skip some data.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>