### PR TITLE
rgw: restore buffer of multipart upload after EEXIST

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1807,6 +1807,12 @@ void RGWPutObj::execute()
      */
     bool need_to_wait = (ofs == 0) && multipart;
 
+    bufferlist orig_data;
+
+    if (need_to_wait) {
+      orig_data = data;
+    }
+
     ret = put_data_and_throttle(processor, data, ofs, (need_calc_md5 ? &hash : NULL), need_to_wait);
     if (ret < 0) {
       if (!need_to_wait || ret != -EEXIST) {
@@ -1815,6 +1821,9 @@ void RGWPutObj::execute()
       }
 
       ldout(s->cct, 5) << "NOTICE: processor->throttle_data() returned -EEXIST, need to restart write" << dendl;
+
+      /* restore original data */
+      data.swap(orig_data);
 
       /* restart processing with different oid suffix */
 


### PR DESCRIPTION
Fixes #11604
Backport: hammer, firefly

When we need to restart a write of part data, we need to revert to
buffer to before the write, otherwise we're going to skip some data.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
(cherry picked from commit 1976b369c013e79028b6ca41003e34599955f38a)