### PR TITLE
ceph-detect-init: plain setup.py install on make install

### DIFF
--- a/src/ceph-detect-init/Makefile.am
+++ b/src/ceph-detect-init/Makefile.am
@@ -61,9 +61,12 @@ clean-local::
 
 install-data-local::
 	cd ceph-detect-init ; \
-	if lsb_release -si | grep --quiet 'Ubuntu\|Debian\|Devuan' ; then \
-		options=--install-layout=deb ; \
-	else \
-		options=--prefix=/usr ; \
+	if test "$(DESTDIR)" ; then \
+		if lsb_release -si | grep --quiet 'Ubuntu\|Debian\|Devuan' ; then \
+			options=--install-layout=deb ; \
+		else \
+			options=--prefix=/usr ; \
+		fi ; \
+		root="--root=$(DESTDIR)" ; \
 	fi ; \
-	python setup.py install --root=$(DESTDIR) $$options
+	python setup.py install $$root $$options


### PR DESCRIPTION
If no DESTDIR environment variable is set, just

  python setup.py install

instead of setting --root, --prefix or --install-layout. These options
are tested to do the right thing in the context of RPM and deb packaging
but they are presumably not what someone using make install manually
would want.

http://tracker.ceph.com/issues/11598 Fixes: #11598

Signed-off-by: Loic Dachary <ldachary@redhat.com>