### PR TITLE
tests: disable new RBD features for the krbd fsx test

### DIFF
--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -482,7 +482,8 @@ __librbd_clone(struct rbd_ctx *ctx, const char *src_snapname,
 	uint64_t features = RBD_FEATURES_ALL;
 	if (krbd) {
 		features &= ~(RBD_FEATURE_EXCLUSIVE_LOCK |
-		              RBD_FEATURE_OBJECT_MAP);
+		              RBD_FEATURE_OBJECT_MAP     |
+                              RBD_FEATURE_FAST_DIFF);
 	}
 	ret = rbd_clone2(ioctx, ctx->name, src_snapname, ioctx,
 			 dst_imagename, features, order,


### PR DESCRIPTION
The kernel does not yet support fast-diff and deep-flatten.

Fixes: #11551
Signed-off-by: Jason Dillaman <dillaman@redhat.com>