### PR TITLE
rados cli: setomapval can now read from stdin

### DIFF
--- a/qa/workunits/rados/test_rados_tool.sh
+++ b/qa/workunits/rados/test_rados_tool.sh
@@ -17,7 +17,11 @@ test_omap() {
     cleanup
     for i in $(seq 1 1 600)
     do
-        rados -p $POOL setomapval $OBJ $i $i
+	if [ $(($i % 2)) -eq 0 ]; then
+            rados -p $POOL setomapval $OBJ $i $i
+	else
+            echo -n "$i" | rados -p $POOL setomapval $OBJ $i
+	fi
         rados -p $POOL getomapval $OBJ $i | grep -q "\\: $i\$"
     done
     rados -p $POOL listomapvals $OBJ | grep -c value | grep 600


### PR DESCRIPTION
This will allow a user to store binary values within omap.  Since
RBD uses binary omap values, this will assist with certain recovery
operations.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>