### PR TITLE
tests: disable deep-flatten feature for the krbd fsx test

### DIFF
--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -483,7 +483,8 @@ __librbd_clone(struct rbd_ctx *ctx, const char *src_snapname,
 	if (krbd) {
 		features &= ~(RBD_FEATURE_EXCLUSIVE_LOCK |
 		              RBD_FEATURE_OBJECT_MAP     |
-                              RBD_FEATURE_FAST_DIFF);
+                              RBD_FEATURE_FAST_DIFF      |
+                              RBD_FEATURE_DEEP_FLATTEN);
 	}
 	ret = rbd_clone2(ioctx, ctx->name, src_snapname, ioctx,
 			 dst_imagename, features, order,


### PR DESCRIPTION
The kernel does not yet support deep-flatten.

Fixes: #11551
Signed-off-by: Jason Dillaman <dillaman@redhat.com>