### PR TITLE
#11610 ceph.spec.in: include SUSE in _with_systemd

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -5,12 +5,12 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 %endif
 
-# Use systemd files on RHEL 7 and above.
+# Use systemd files on RHEL 7 and above and in SUSE/openSUSE.
 # Note: We don't install unit files for the services yet. For now,
 # the _with_systemd variable only implies that we'll install
 # /etc/tmpfiles.d/ceph.conf in order to set up the socket directory in
 # /var/run/ceph.
-%if 0%{?fedora} || 0%{?rhel} >= 7
+%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version}
   %global _with_systemd 1
 %endif
 


### PR DESCRIPTION
The master specfile newly defines a _with_systemd variable that should be true for the set of distros that are using systemd. Since this set of distros includes SUSE/openSUSE (at least for the more recent versions where ceph is supported), this commit sets _with_systemd to true on SUSE/openSUSE.

http://tracker.ceph.com/issues/11610 Fixes: #11610

Signed-off-by: Nathan Cutler <ncutler@suse.cz>
(cherry picked from commit 61303656faa913880008e6a6a1725d2fd7002c1f)