### PR TITLE
tools: remove obsolete aio_bench argument placeholder

### DIFF
--- a/src/tools/rest_bench.cc
+++ b/src/tools/rest_bench.cc
@@ -789,7 +789,7 @@ int main(int argc, const char **argv)
     if (ret != 0)
       cerr << "error during cleanup: " << ret << std::endl;
   } else {
-    ret = bencher.aio_bench(operation, seconds, 0,
+    ret = bencher.aio_bench(operation, seconds,
 			    concurrent_ios, op_size, cleanup, run_name.c_str());
     if (ret != 0) {
         cerr << "error during benchmark: " << ret << std::endl;


### PR DESCRIPTION
It was a noop and has been removed by
1ac727982213bf676beefe9340d6822193dbb700

Signed-off-by: Loic Dachary <ldachary@redhat.com>