### PR TITLE
tools: Don't delete, recreate and re-fill buffers in rados bench. Fixes…

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -388,10 +388,16 @@ int ObjBencher::write_bench(int secondsToRun,
     }
     lock.Unlock();
     //create new contents and name on the heap, and fill them
-    newContents = new bufferlist();
     newName = generate_object_name(data.started);
-    snprintf(data.object_contents, data.object_size, "I'm the %16dth object!", data.started);
-    newContents->append(data.object_contents, data.object_size);
+    newContents = contents[slot];
+    if (!newContents) {
+        newContents = new bufferlist();
+        contents[slot] = newContents;
+        snprintf(data.object_contents, data.object_size, "I'm the %16dth object!", data.started);
+        newContents->append(data.object_contents, data.object_size);
+    } else {
+        snprintf(newContents->c_str(), data.object_size, "I'm the %16dth object!", data.started);
+    }
     completion_wait(slot);
     lock.Lock();
     r = completion_ret(slot);
@@ -411,8 +417,7 @@ int ObjBencher::write_bench(int secondsToRun,
     release_completion(slot);
     timePassed = ceph_clock_now(cct) - data.start_time;
 
-    //write new stuff to backend, then delete old stuff
-    //and save locations of new stuff for later deletion
+    //write new stuff to backend
     start_times[slot] = ceph_clock_now(cct);
     r = create_completion(slot, _aio_cb, &lc);
     if (r < 0)
@@ -421,10 +426,7 @@ int ObjBencher::write_bench(int secondsToRun,
     if (r < 0) {//naughty; doesn't clean up heap space.
       goto ERR;
     }
-    delete contents[slot];
     name[slot] = newName;
-    contents[slot] = newContents;
-    newContents = 0;
     lock.Lock();
     ++data.started;
     ++data.in_flight;
@@ -451,6 +453,7 @@ int ObjBencher::write_bench(int secondsToRun,
     lock.Unlock();
     release_completion(slot);
     delete contents[slot];
+	contents[slot] = 0;
   }
 
   timePassed = ceph_clock_now(cct) - data.start_time;
@@ -489,6 +492,9 @@ int ObjBencher::write_bench(int secondsToRun,
   sync_write(run_name_meta, b_write, sizeof(int)*3);
 
   completions_done();
+  for (int i = 0; i < concurrentios; i++) 
+    if (contents[i])
+      delete contents[i];
 
   return 0;
 
@@ -497,7 +503,9 @@ int ObjBencher::write_bench(int secondsToRun,
   data.done = 1;
   lock.Unlock();
   pthread_join(print_thread, NULL);
-  delete newContents;
+  for (int i = 0; i < concurrentios; i++) 
+    if (contents[i])
+      delete contents[i];
   return r;
 }
 
@@ -605,10 +613,14 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
     lock.Unlock();
     release_completion(slot);
     cur_contents = contents[slot];
+    if (!cur_contents) {
+        contents[slot] = new bufferlist();
+        cur_contents = contents[slot];
+    } 
 
     //start new read and check data if requested
     start_times[slot] = ceph_clock_now(cct);
-    contents[slot] = new bufferlist();
+
     create_completion(slot, _aio_cb, (void *)&lc);
     r = aio_read(newName, slot, contents[slot], data.object_size);
     if (r < 0) {
@@ -624,7 +636,6 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
       ++errors;
     }
     name[slot] = newName;
-    delete cur_contents;
   }
 
   //wait for final reads to complete
@@ -798,10 +809,13 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
     lock.Unlock();
     release_completion(slot);
     cur_contents = contents[slot];
+    if (!cur_contents) {
+        contents[slot] = new bufferlist();
+        cur_contents = contents[slot];
+    } 
 
     //start new read and check data if requested
     start_times[slot] = ceph_clock_now(g_ceph_context);
-    contents[slot] = new bufferlist();
     create_completion(slot, _aio_cb, (void *)&lc);
     r = aio_read(newName, slot, contents[slot], data.object_size);
     if (r < 0) {
@@ -817,7 +831,6 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
       ++errors;
     }
     name[slot] = newName;
-    delete cur_contents;
   }
 
   //wait for final reads to complete


### PR DESCRIPTION
… the high CPU usage by rados bench on fast SSDs and ramdisks/memstore.

In both write, seq and rand, buffers are constantly created, filled up, sent and finally destroyed. This change preserves them, so there's no unnecessary memmove/alloc/free involved. On Intel Xeon CPU E5-2640 v2 @ 2.00GHz the original cpu times were:

```
write: real 0m31.149s user 0m13.684s sys 0m31.359s
seq:   real 0m27.102s user 0m13.361s sys 0m49.975s
rand:  real 0m31.098s user 0m14.622s sys 0m54.125s
```
After applying this change:
```
write: real 0m31.147s user 0m1.608s sys 0m16.984s
seq:   real 0m21.104s user 0m13.916s sys 0m30.358s
rand:  real 0m31.099s user 0m19.278s sys 0m41.827s
```
Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>