### PR TITLE
ceph.spec.in: SUSE/openSUSE builds need libbz2-devel

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -52,7 +52,9 @@ Requires: systemd
 %endif
 BuildRequires:	gcc-c++
 BuildRequires:	boost-devel
-%if ! 0%{defined suse_version}
+%if 0%{defined suse_version}
+BuildRequires:  libbz2-devel
+%else
 BuildRequires:  bzip2-devel
 %endif
 BuildRequires:	cryptsetup


### PR DESCRIPTION
http://tracker.ceph.com/issues/11629 Fixes: #11629

Signed-off-by: Nathan Cutler <ncutler@suse.cz>