### PR TITLE
Enable security hardening flags globally

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -59,8 +59,7 @@ HARDENING_CFLAGS = \
                    -Wp,-D_FORTIFY_SOURCE=2 \
                    -fexceptions \
                    --param=ssp-buffer-size=4 \
-                   -fPIE \
-                   -fPIC
+                   -fPIE
 
 SET_STACK_PROTECTOR_STRONG = $(shell expr `gcc -dumpversion` \>= 4.9)
 

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -51,6 +51,33 @@ endif
 ##################################
 ## automake environment
 
+HARDENING_CFLAGS = \
+                   -O2 \
+                   -g \
+                   -pipe \
+                   -Wl,-z,relro \
+                   -Wall \
+                   -Wp,-D_FORTIFY_SOURCE=2 \
+                   -fexceptions \
+                   --param=ssp-buffer-size=4 \
+                   -grecord-gcc-switches \
+                   -fPIE
+
+SET_STACK_PROTECTOR_STRONG = $(shell expr `gcc -dumpversion` \>= 4.9)
+
+		ifeq ($(SET_STACK_PROTECTOR_STRONG),1)
+				HARDENING_CFLAGS += -fstack-protector-strong
+		else
+				HARDENING_CFLAGS += -fstack-protector
+		endif
+
+
+HARDENING_LDFLAGS =  \
+                     -pie \
+                     -Wl,-z,relro \
+                     -Wl,-z,now
+
+
 AM_COMMON_CPPFLAGS = \
 	-D__CEPH__ \
 	-D_FILE_OFFSET_BITS=64 \
@@ -75,14 +102,14 @@ if !CLANG
 	AM_COMMON_CFLAGS += -rdynamic
 endif
 
-AM_CFLAGS = $(AM_COMMON_CFLAGS)
+AM_CFLAGS = $(AM_COMMON_CFLAGS) $(HARDENING_CFLAGS)
 AM_CPPFLAGS = $(AM_COMMON_CPPFLAGS)
 AM_CXXFLAGS = \
 	@AM_CXXFLAGS@ \
 	$(AM_COMMON_CFLAGS) \
 	-ftemplate-depth-1024 \
 	-Wnon-virtual-dtor \
-	-Wno-invalid-offsetof
+	-Wno-invalid-offsetof $(HARDENING_CFLAGS)
 if !CLANG
 	AM_CXXFLAGS += -Wstrict-null-sentinel
 endif
@@ -97,7 +124,7 @@ endif
 # http://sigquit.wordpress.com/2011/02/16/why-asneeded-doesnt-work-as-expected-for-your-libraries-on-your-autotools-project/
 AM_LDFLAGS =
 if LINUX
-AM_LDFLAGS += -Wl,--as-needed
+AM_LDFLAGS += -Wl,--as-needed $(HARDENING_LDFLAGS)
 endif
 
 if USE_BOOST_SPIRIT_OLD_HDR

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -55,13 +55,12 @@ HARDENING_CFLAGS = \
                    -O2 \
                    -g \
                    -pipe \
-                   -Wl,-z,relro \
                    -Wall \
                    -Wp,-D_FORTIFY_SOURCE=2 \
                    -fexceptions \
                    --param=ssp-buffer-size=4 \
-                   -grecord-gcc-switches \
-                   -fPIE
+                   -fPIE \
+                   -fPIC
 
 SET_STACK_PROTECTOR_STRONG = $(shell expr `gcc -dumpversion` \>= 4.9)
 


### PR DESCRIPTION
Ubuntu builds are also fixed now

RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH      FILE
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./ceph-authtool
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./ceph-conf
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./ceph-dencoder
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./ceph_erasure_code_non_regression
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./cephfs
No RELRO        Canary found      NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./cephfs.o
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./ceph-fuse
No RELRO        Canary found      NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./ceph_fuse.o
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./ceph-mds
No RELRO        Canary found      NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./ceph_mds.o
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./ceph-mon
No RELRO        Canary found      NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./ceph_mon.o
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./ceph-osd
No RELRO        Canary found      NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./ceph_osd.o
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./ceph-syn
No RELRO        Canary found      NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./ceph_syn.o
No RELRO        No canary found   NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./ceph_ver.o
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./crushtool
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./get_command_descriptions
No RELRO        Canary found      NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./krbd.o
No RELRO        Canary found      NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./libcephfs.o
No RELRO        No canary found   NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./librados-config.o
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./monmaptool
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./mount.ceph
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   ./osdmaptool
No RELRO        Canary found      NX enabled    Not an ELF file   No RPATH   No RUNPATH   ./rbd.o
