### PR TITLE
rgw: Use attrs from source bucket on copy

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2305,6 +2305,7 @@ int RGWCopyObj::verify_permission()
 
   if (src_bucket_name.compare(dest_bucket_name) == 0) { /* will only happen if s->local_source */
     dest_bucket_info = src_bucket_info;
+    dest_attrs = src_attrs;
   } else {
     ret = store->get_bucket_info(obj_ctx, dest_bucket_name, dest_bucket_info, NULL, &dest_attrs);
     if (ret < 0)


### PR DESCRIPTION
On copy objects, when bucket source is the same as the destination, use attrs
from source bucket.

This commit fixes #11639

Signed-off-by: Javier M. Mellid <jmunhoz@igalia.com>