### PR TITLE
tools: Don't delete, recreate and re-fill buffers in rados bench. Fixes…

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1866,6 +1866,15 @@ __u32 buffer::list::crc32c(__u32 crc) const
   return crc;
 }
 
+void buffer::list::invalidate_crc()
+{
+  for (std::list<ptr>::const_iterator p = _buffers.begin(); p != _buffers.end(); ++p) {
+    raw *r = p->get_raw();
+    if (r) {
+      r->invalidate_crc();
+    }
+  }
+}
 
 /**
  * Binary write all contents to a C++ stream

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -388,10 +388,12 @@ int ObjBencher::write_bench(int secondsToRun,
     }
     lock.Unlock();
     //create new contents and name on the heap, and fill them
-    newContents = new bufferlist();
     newName = generate_object_name(data.started);
-    snprintf(data.object_contents, data.object_size, "I'm the %16dth object!", data.started);
-    newContents->append(data.object_contents, data.object_size);
+    newContents = contents[slot];
+    snprintf(newContents->c_str(), data.object_size, "I'm the %16dth object!", data.started);
+    // we wrote to buffer, going around internal crc cache, so invalidate it now.
+    newContents->invalidate_crc();
+
     completion_wait(slot);
     lock.Lock();
     r = completion_ret(slot);
@@ -411,8 +413,7 @@ int ObjBencher::write_bench(int secondsToRun,
     release_completion(slot);
     timePassed = ceph_clock_now(cct) - data.start_time;
 
-    //write new stuff to backend, then delete old stuff
-    //and save locations of new stuff for later deletion
+    //write new stuff to backend
     start_times[slot] = ceph_clock_now(cct);
     r = create_completion(slot, _aio_cb, &lc);
     if (r < 0)
@@ -421,10 +422,7 @@ int ObjBencher::write_bench(int secondsToRun,
     if (r < 0) {//naughty; doesn't clean up heap space.
       goto ERR;
     }
-    delete contents[slot];
     name[slot] = newName;
-    contents[slot] = newContents;
-    newContents = 0;
     lock.Lock();
     ++data.started;
     ++data.in_flight;
@@ -451,6 +449,7 @@ int ObjBencher::write_bench(int secondsToRun,
     lock.Unlock();
     release_completion(slot);
     delete contents[slot];
+    contents[slot] = 0;
   }
 
   timePassed = ceph_clock_now(cct) - data.start_time;
@@ -489,6 +488,9 @@ int ObjBencher::write_bench(int secondsToRun,
   sync_write(run_name_meta, b_write, sizeof(int)*3);
 
   completions_done();
+  for (int i = 0; i < concurrentios; i++)
+      if (contents[i])
+          delete contents[i];
 
   return 0;
 
@@ -497,7 +499,9 @@ int ObjBencher::write_bench(int secondsToRun,
   data.done = 1;
   lock.Unlock();
   pthread_join(print_thread, NULL);
-  delete newContents;
+  for (int i = 0; i < concurrentios; i++)
+      if (contents[i])
+          delete contents[i];
   return r;
 }
 
@@ -606,9 +610,11 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
     release_completion(slot);
     cur_contents = contents[slot];
 
+    // invalidate internal crc cache
+    cur_contents->invalidate_crc();
+
     //start new read and check data if requested
     start_times[slot] = ceph_clock_now(cct);
-    contents[slot] = new bufferlist();
     create_completion(slot, _aio_cb, (void *)&lc);
     r = aio_read(newName, slot, contents[slot], data.object_size);
     if (r < 0) {
@@ -624,7 +630,6 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
       ++errors;
     }
     name[slot] = newName;
-    delete cur_contents;
   }
 
   //wait for final reads to complete
@@ -799,9 +804,11 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
     release_completion(slot);
     cur_contents = contents[slot];
 
+    // invalidate internal crc cache
+    cur_contents->invalidate_crc();
+
     //start new read and check data if requested
     start_times[slot] = ceph_clock_now(g_ceph_context);
-    contents[slot] = new bufferlist();
     create_completion(slot, _aio_cb, (void *)&lc);
     r = aio_read(newName, slot, contents[slot], data.object_size);
     if (r < 0) {
@@ -817,7 +824,6 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
       ++errors;
     }
     name[slot] = newName;
-    delete cur_contents;
   }
 
   //wait for final reads to complete

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -490,6 +490,7 @@ public:
     int write_fd(int fd) const;
     int write_fd_zero_copy(int fd) const;
     uint32_t crc32c(uint32_t crc) const;
+	void invalidate_crc();
   };
 
   /*

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2374,6 +2374,46 @@ TEST(BufferList, TestCopyAll) {
   ASSERT_EQ(memcmp(big.get(), big2.get(), BIG_SZ), 0);
 }
 
+TEST(BufferList, InvalidateCrc) {
+  const static size_t buffer_size = 262144;
+  ceph::shared_ptr <unsigned char> big(
+      (unsigned char*)malloc(buffer_size), free);
+  unsigned char c = 0;
+  char* ptr = (char*) big.get();
+  char* inptr;
+  for (size_t i = 0; i < buffer_size; ++i) {
+    ptr[i] = c++;
+  }
+  bufferlist bl;
+  
+  // test for crashes (shouldn't crash)
+  bl.invalidate_crc();
+  
+  // put data into bufferlist
+  bl.append((const char*)big.get(), buffer_size);
+  
+  // get its crc
+  __u32 crc = bl.crc32c(0);
+  
+  // modify data in bl without its knowledge
+  inptr = (char*) bl.c_str();
+  c = 0;
+  for (size_t i = 0; i < buffer_size; ++i) {
+    inptr[i] = c--;
+  }
+  
+  // make sure data in bl are now different than in big
+  EXPECT_NE(memcmp((void*) ptr, (void*) inptr, buffer_size), 0);
+  
+  // crc should remain the same
+  __u32 new_crc = bl.crc32c(0);
+  EXPECT_EQ(crc, new_crc);
+  
+  // force crc invalidate, check if it is updated
+  bl.invalidate_crc();
+  EXPECT_NE(crc, bl.crc32c(0));
+}
+
 TEST(BufferHash, all) {
   {
     bufferlist bl;


### PR DESCRIPTION
… the high CPU usage by rados bench on fast SSDs and ramdisks/memstore.

In both write, seq and rand, buffers are constantly created, filled up, sent and finally destroyed. This change preserves them, so there's no unnecessary memmove/alloc/free involved. On Intel Xeon CPU E5-2640 v2 @ 2.00GHz the original cpu times were:

```
write: real 0m31.149s user 0m13.684s sys 0m31.359s
seq:   real 0m27.102s user 0m13.361s sys 0m49.975s
rand:  real 0m31.098s user 0m14.622s sys 0m54.125s
```
After applying this change:
```
write: real 0m31.147s user 0m1.608s sys 0m16.984s
seq:   real 0m21.104s user 0m13.916s sys 0m30.358s
rand:  real 0m31.099s user 0m19.278s sys 0m41.827s
```

Tests taken using "rados -p ssd bench 30 write|seq|rand --no-cleanup".
Note the increase in user time cpu on seq/read tests,
along with decreased sys cpu time; this is because there's
additional memcmp() that compares read objects with expected
contents. With less time spent memory juggling, more time is
spent performing more reads per second, increasing memcmp call
count and increasing amount of user cpu time used. 

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>