### PR TITLE
wip-kvs-iterator

### DIFF
--- a/src/os/GenericObjectMap.cc
+++ b/src/os/GenericObjectMap.cc
@@ -621,7 +621,7 @@ int GenericObjectMap::get_keys(const coll_t &cid, const ghobject_t &oid,
     return -ENOENT;
 
   ObjectMap::ObjectMapIterator iter = _get_iterator(header, prefix);
-  for (; iter->valid(); iter->next()) {
+  for (iter->seek_to_first(); iter->valid(); iter->next()) {
     if (iter->status())
       return iter->status();
     keys->insert(iter->key());

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -268,7 +268,7 @@ int StripObjectMap::get_keys_with_header(const StripObjectHeaderRef header,
                                          set<string> *keys)
 {
   ObjectMap::ObjectMapIterator iter = _get_iterator(header->header, prefix);
-  for (; iter->valid(); iter->next()) {
+  for (iter->seek_to_first(); iter->valid(); iter->next()) {
     if (iter->status())
       return iter->status();
     keys->insert(iter->key());


### PR DESCRIPTION
Initialize the iterator in get_keys and get_keys_with_header.
This fixes the issues with ceph_test_rados_api_aio.

Signed-off-by: Varada Kari <varada.kari@sandisk.com>