### PR TITLE
KeyValueStore: Fix the prefix comparion to avoid object leaks.

### DIFF
--- a/src/os/KeyValueDB.h
+++ b/src/os/KeyValueDB.h
@@ -130,7 +130,7 @@ public:
       if (!generic_iter->valid())
 	return false;
       pair<string,string> raw_key = generic_iter->raw_key();
-      return (raw_key.first == prefix);
+      return (raw_key.first.compare(0, prefix.length(), prefix) == 0);
     }
     int next() {
       if (valid())


### PR DESCRIPTION
Iterator becomes invalid due to a partial prefix comparision in
rmkeys_by_prefix, resulting in not deleting the objects from backend.
Modified the comparision to the given prefix.

Signed-off-by: Varada Kari <varada.kari@sandisk.com>