### PR TITLE
FileStore: Collect device partition information

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -268,25 +268,36 @@ ACX_PTHREAD
 
 AC_CHECK_LIB([uuid], [uuid_parse], [true], AC_MSG_FAILURE([libuuid not found]))
 
-# rbd {map,unmap,showmapped} dependencies, Linux only
-if test x"$linux" = x"yes" -a x"$with_rbd" = x"yes"; then
+#Linux only dependencies
+if test x"$linux" = x"yes"; then
   # libblkid
   AC_CHECK_HEADER([blkid/blkid.h], [],
     AC_MSG_ERROR([blkid/blkid.h not found (libblkid-dev, libblkid-devel)]))
-  AC_CHECK_LIB([blkid], [blkid_devno_to_wholedisk], [true],
+  AC_CHECK_LIB([blkid], [blkid_get_cache], [true],
+    AC_MSG_FAILURE([libblkid not found]))
+  AC_CHECK_LIB([blkid], [blkid_find_dev_with_tag], [true],
+    AC_MSG_FAILURE([libblkid not found]))
+  AC_CHECK_LIB([blkid], [blkid_dev_devname], [true],
     AC_MSG_FAILURE([libblkid not found]))
 
-  # libudev
-  AC_CHECK_HEADER([libudev.h], [],
-    AC_MSG_ERROR([libudev.h not found (libudev-dev, libudev-devel)]))
-  AC_CHECK_LIB([udev], [udev_monitor_receive_device], [true],
-    AC_MSG_FAILURE([libudev not found]))
+  # rbd {map,unmap,showmapped} dependencies, Linux only
+  if test x"$with_rbd" = x"yes"; then
+    # libblkid
+    AC_CHECK_LIB([blkid], [blkid_devno_to_wholedisk], [true],
+      AC_MSG_FAILURE([libblkid not found]))
 
-  # libexpat
-  AC_CHECK_HEADER([expat.h], [],
-    AC_MSG_ERROR([expat.h not found (libexpat-devel)]))
-  AC_CHECK_LIB([expat], [XML_Parse], [true],
-    AC_MSG_FAILURE([libexpat not found]))
+    # libudev
+    AC_CHECK_HEADER([libudev.h], [],
+      AC_MSG_ERROR([libudev.h not found (libudev-dev, libudev-devel)]))
+    AC_CHECK_LIB([udev], [udev_monitor_receive_device], [true],
+      AC_MSG_FAILURE([libudev not found]))
+
+    # libexpat
+    AC_CHECK_HEADER([expat.h], [],
+      AC_MSG_ERROR([expat.h not found (libexpat-devel)]))
+    AC_CHECK_LIB([expat], [XML_Parse], [true],
+      AC_MSG_FAILURE([libexpat not found]))
+  fi
 fi
 
 #

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -135,7 +135,7 @@ LIBCOMMON_DEPS += \
 	$(LIBCRUSH) $(LIBJSON_SPIRIT) $(LIBLOG) $(LIBARCH)
 
 if LINUX
-LIBCOMMON_DEPS += -lrt
+LIBCOMMON_DEPS += -lrt -lblkid -luuid
 endif # LINUX
 
 libcommon_la_SOURCES = common/buffer.cc

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -9,4 +9,6 @@ extern int get_block_device_size(int fd, int64_t *psize);
 extern int64_t get_block_device_int_property(const char *devname, const char *property);
 extern bool block_device_support_discard(const char *devname);
 extern int block_device_discard(int fd, int64_t offset, int64_t len);
+extern int get_device_by_uuid(uuid_d dev_uuid, const char* label,
+		char* partition, char* device);
 #endif

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -81,6 +81,8 @@ TEST_P(StoreTest, collect_metadata) {
   if (GetParam() == string("filestore")) {
     ASSERT_NE(pm.count("filestore_backend"), 0u);
     ASSERT_NE(pm.count("filestore_f_type"), 0u);
+    ASSERT_NE(pm.count("backend_filestore_partition_path"), 0u);
+    ASSERT_NE(pm.count("backend_filestore_dev_node"), 0u);
   } else if (GetParam() == string("keyvaluestore")) {
     ASSERT_NE(pm.count("keyvaluestore_backend"), 0u);
   }

--- a/src/test/test_get_blkdev_size.cc
+++ b/src/test/test_get_blkdev_size.cc
@@ -5,6 +5,7 @@
 #include <inttypes.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "include/uuid.h"
 #include "common/blkdev.h"
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Use blkid APIs to get device parition information into the metadata bundle.

Signed-off-by: Joe Handzik <joseph.t.handzik@hp.com>