### PR TITLE
erasure-code: fix error reporting

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -193,7 +193,7 @@ int preload_erasure_code()
   stringstream ss;
   int r = ErasureCodePluginRegistry::instance().preload(plugins,
 							directory,
-							ss);
+							&ss);
   if (r)
     derr << ss.str() << dendl;
   else

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -89,7 +89,7 @@ int preload_erasure_code()
   stringstream ss;
   int r = ErasureCodePluginRegistry::instance().preload(plugins,
 							directory,
-							ss);
+							&ss);
   if (r)
     derr << ss.str() << dendl;
   else

--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -163,21 +163,21 @@ int ErasureCode::decode_chunks(const set<int> &want_to_read,
   assert("ErasureCode::decode_chunks not implemented" == 0);
 }
 
-int ErasureCode::parse(const map<std::string,std::string> &parameters,
+int ErasureCode::parse(const ErasureCodeProfile &profile,
 		       ostream *ss)
 {
-  return to_mapping(parameters, ss);
+  return to_mapping(profile, ss);
 }
 
 const vector<int> &ErasureCode::get_chunk_mapping() const {
   return chunk_mapping;
 }
 
-int ErasureCode::to_mapping(const map<std::string,std::string> &parameters,
+int ErasureCode::to_mapping(const ErasureCodeProfile &profile,
 			    ostream *ss)
 {
-  if (parameters.find("mapping") != parameters.end()) {
-    std::string mapping = parameters.find("mapping")->second;
+  if (profile.find("mapping") != profile.end()) {
+    std::string mapping = profile.find("mapping")->second;
     int position = 0;
     vector<int> coding_chunk_mapping;
     for(std::string::iterator it = mapping.begin(); it != mapping.end(); ++it) {
@@ -195,17 +195,17 @@ int ErasureCode::to_mapping(const map<std::string,std::string> &parameters,
 }
 
 int ErasureCode::to_int(const std::string &name,
-			const map<std::string,std::string> &parameters,
+			ErasureCodeProfile &profile,
 			int *value,
 			int default_value,
 			ostream *ss)
 {
-  if (parameters.find(name) == parameters.end() ||
-      parameters.find(name)->second.size() == 0) {
+  if (profile.find(name) == profile.end() ||
+      profile.find(name)->second.size() == 0) {
     *value = default_value;
     return 0;
   }
-  std::string p = parameters.find(name)->second;
+  std::string p = profile.find(name)->second;
   std::string err;
   int r = strict_strtol(p.c_str(), 10, &err);
   if (!err.empty()) {
@@ -220,17 +220,17 @@ int ErasureCode::to_int(const std::string &name,
 }
 
 int ErasureCode::to_bool(const std::string &name,
-			 const map<std::string,std::string> &parameters,
+			 ErasureCodeProfile &profile,
 			 bool *value,
 			 bool default_value,
 			 ostream *ss)
 {
-  if (parameters.find(name) == parameters.end() ||
-      parameters.find(name)->second.size() == 0) {
+  if (profile.find(name) == profile.end() ||
+      profile.find(name)->second.size() == 0) {
     *value = default_value;
     return 0;
   }
-  const std::string p = parameters.find(name)->second;
+  const std::string p = profile.find(name)->second;
   *value = (p == "yes") || (p == "true");
   return 0;
 }

--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -66,22 +66,22 @@ namespace ceph {
                               const map<int, bufferlist> &chunks,
                               map<int, bufferlist> *decoded);
 
-    virtual int parse(const map<std::string,std::string> &parameters,
+    virtual int parse(const ErasureCodeProfile &profile,
 		      ostream *ss);
 
     virtual const vector<int> &get_chunk_mapping() const;
 
-    int to_mapping(const map<std::string,std::string> &parameters,
+    int to_mapping(const ErasureCodeProfile &profile,
 		   ostream *ss);
 
     static int to_int(const std::string &name,
-		      const map<std::string,std::string> &parameters,
+		      ErasureCodeProfile &profile,
 		      int *value,
 		      int default_value,
 		      ostream *ss);
 
     static int to_bool(const std::string &name,
-		       const map<std::string,std::string> &parameters,
+		       ErasureCodeProfile &profile,
 		       bool *value,
 		       bool default_value,
 		       ostream *ss);

--- a/src/erasure-code/ErasureCodeInterface.h
+++ b/src/erasure-code/ErasureCodeInterface.h
@@ -152,6 +152,7 @@ using namespace std;
 
 namespace ceph {
 
+  typedef map<std::string,std::string> ErasureCodeProfile;
   class ErasureCodeInterface {
   public:
     virtual ~ErasureCodeInterface() {}

--- a/src/erasure-code/ErasureCodeInterface.h
+++ b/src/erasure-code/ErasureCodeInterface.h
@@ -158,6 +158,22 @@ namespace ceph {
     virtual ~ErasureCodeInterface() {}
 
     /**
+     * Initialize the instance according to the content of
+     * **profile**. The **ss** stream is set with debug messages or
+     * error messages, the content of which depend on the
+     * implementation.
+     *
+     * Return 0 on success or a negative errno on error. When
+     * returning on error, the implementation is expected to
+     * provide a human readable explanation in **ss**.
+     *
+     * @param [in] profile a key/value map
+     * @param [out] ss contains informative messages when an error occurs
+     * @return 0 on success or a negative errno on error.
+     */
+    virtual int init(ErasureCodeProfile &profile, ostream *ss) = 0;
+
+    /**
      * Create a new ruleset in **crush** under the name **name**,
      * unless it already exists.
      *

--- a/src/erasure-code/ErasureCodePlugin.cc
+++ b/src/erasure-code/ErasureCodePlugin.cc
@@ -84,7 +84,7 @@ ErasureCodePlugin *ErasureCodePluginRegistry::get(const std::string &name)
 }
 
 int ErasureCodePluginRegistry::factory(const std::string &plugin_name,
-				       const map<std::string,std::string> &parameters,
+				       ErasureCodeProfile &profile,
 				       ErasureCodeInterfaceRef *erasure_code,
 				       ostream &ss)
 {
@@ -94,15 +94,15 @@ int ErasureCodePluginRegistry::factory(const std::string &plugin_name,
     plugin = get(plugin_name);
     if (plugin == 0) {
       loading = true;
-      assert(parameters.count("directory") != 0);
-      int r = load(plugin_name, parameters.find("directory")->second, &plugin, ss);
+      assert(profile.count("directory") != 0);
+      int r = load(plugin_name, profile.find("directory")->second, &plugin, ss);
       loading = false;
       if (r != 0)
 	return r;
     }
   }
 
-  return plugin->factory(parameters, erasure_code);
+  return plugin->factory(profile, erasure_code);
 }
 
 static const char *an_older_version() {

--- a/src/erasure-code/ErasureCodePlugin.h
+++ b/src/erasure-code/ErasureCodePlugin.h
@@ -36,7 +36,7 @@ namespace ceph {
       library(0) {}
     virtual ~ErasureCodePlugin() {}
 
-    virtual int factory(const map<std::string,std::string> &parameters,
+    virtual int factory(ErasureCodeProfile &profile,
                         ErasureCodeInterfaceRef *erasure_code) = 0;
   };
 
@@ -57,7 +57,7 @@ namespace ceph {
     }
 
     int factory(const std::string &plugin,
-		const map<std::string,std::string> &parameters,
+		ErasureCodeProfile &profile,
 		ErasureCodeInterfaceRef *erasure_code,
 		ostream &ss);
 

--- a/src/erasure-code/ErasureCodePlugin.h
+++ b/src/erasure-code/ErasureCodePlugin.h
@@ -37,7 +37,8 @@ namespace ceph {
     virtual ~ErasureCodePlugin() {}
 
     virtual int factory(ErasureCodeProfile &profile,
-                        ErasureCodeInterfaceRef *erasure_code) = 0;
+                        ErasureCodeInterfaceRef *erasure_code,
+			ostream *ss) = 0;
   };
 
   class ErasureCodePluginRegistry {
@@ -59,7 +60,7 @@ namespace ceph {
     int factory(const std::string &plugin,
 		ErasureCodeProfile &profile,
 		ErasureCodeInterfaceRef *erasure_code,
-		ostream &ss);
+		ostream *ss);
 
     int add(const std::string &name, ErasureCodePlugin *plugin);
     int remove(const std::string &name);
@@ -68,11 +69,11 @@ namespace ceph {
     int load(const std::string &plugin_name,
 	     const std::string &directory,
 	     ErasureCodePlugin **plugin,
-	     ostream &ss);
+	     ostream *ss);
 
     int preload(const std::string &plugins,
 		const std::string &directory,
-		ostream &ss);
+		ostream *ss);
   };
 }
 

--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -64,18 +64,18 @@ ErasureCodeIsa::create_ruleset(const string &name,
 // -----------------------------------------------------------------------------
 
 void
-ErasureCodeIsa::init(const map<string, string> &parameters)
+ErasureCodeIsa::init(ErasureCodeProfile &profile)
 {
   dout(10) << "technique=" << technique << dendl;
   map<string, string>::const_iterator parameter;
-  parameter = parameters.find("ruleset-root");
-  if (parameter != parameters.end())
+  parameter = profile.find("ruleset-root");
+  if (parameter != profile.end())
     ruleset_root = parameter->second;
-  parameter = parameters.find("ruleset-failure-domain");
-  if (parameter != parameters.end())
+  parameter = profile.find("ruleset-failure-domain");
+  if (parameter != profile.end())
     ruleset_failure_domain = parameter->second;
   ostringstream ss;
-  if (parse(parameters, &ss))
+  if (parse(profile, &ss))
     derr << ss.str() << dendl;
   prepare();
 }
@@ -340,13 +340,12 @@ ErasureCodeIsaDefault::get_alignment() const
 
 // -----------------------------------------------------------------------------
 
-int ErasureCodeIsaDefault::parse(const map<std::string,
-                                 std::string> &parameters,
+int ErasureCodeIsaDefault::parse(ErasureCodeProfile &profile,
                                  ostream *ss)
 {
-  int err = ErasureCode::parse(parameters, ss);
-  err |= to_int("k", parameters, &k, DEFAULT_K, ss);
-  err |= to_int("m", parameters, &m, DEFAULT_M, ss);
+  int err = ErasureCode::parse(profile, ss);
+  err |= to_int("k", profile, &k, DEFAULT_K, ss);
+  err |= to_int("m", profile, &m, DEFAULT_M, ss);
 
   if (matrixtype == kVandermonde) {
     // these are verified safe values evaluated using the

--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -63,9 +63,10 @@ ErasureCodeIsa::create_ruleset(const string &name,
 
 // -----------------------------------------------------------------------------
 
-void
-ErasureCodeIsa::init(ErasureCodeProfile &profile)
+int
+ErasureCodeIsa::init(ErasureCodeProfile &profile, ostream *ss)
 {
+  int err = 0;
   dout(10) << "technique=" << technique << dendl;
   map<string, string>::const_iterator parameter;
   parameter = profile.find("ruleset-root");
@@ -74,10 +75,11 @@ ErasureCodeIsa::init(ErasureCodeProfile &profile)
   parameter = profile.find("ruleset-failure-domain");
   if (parameter != profile.end())
     ruleset_failure_domain = parameter->second;
-  ostringstream ss;
-  if (parse(profile, &ss))
-    derr << ss.str() << dendl;
+  err |= parse(profile, ss);
+  if (err)
+    return err;
   prepare();
+  return err;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/erasure-code/isa/ErasureCodeIsa.h
+++ b/src/erasure-code/isa/ErasureCodeIsa.h
@@ -91,7 +91,7 @@ public:
                             const map<int, bufferlist> &chunks,
                             map<int, bufferlist> *decoded);
 
-  void init(ErasureCodeProfile &profile);
+  virtual int init(ErasureCodeProfile &profile, ostream *ss);
 
   virtual void isa_encode(char **data,
                           char **coding,

--- a/src/erasure-code/isa/ErasureCodeIsa.h
+++ b/src/erasure-code/isa/ErasureCodeIsa.h
@@ -91,7 +91,7 @@ public:
                             const map<int, bufferlist> &chunks,
                             map<int, bufferlist> *decoded);
 
-  void init(const map<std::string, std::string> &parameters);
+  void init(ErasureCodeProfile &profile);
 
   virtual void isa_encode(char **data,
                           char **coding,
@@ -105,8 +105,7 @@ public:
 
   virtual unsigned get_alignment() const = 0;
 
-  virtual int parse(const map<std::string,
-                    std::string> &parameters,
+  virtual int parse(ErasureCodeProfile &profile,
                     ostream *ss) = 0;
 
   virtual void prepare() = 0;
@@ -155,8 +154,7 @@ public:
 
   virtual unsigned get_alignment() const;
 
-  virtual int parse(const map<std::string,
-                    std::string> &parameters,
+  virtual int parse(ErasureCodeProfile &profile,
                     ostream *ss);
 
   virtual void prepare();

--- a/src/erasure-code/isa/ErasureCodePluginIsa.cc
+++ b/src/erasure-code/isa/ErasureCodePluginIsa.cc
@@ -36,7 +36,8 @@ public:
   ErasureCodeIsaTableCache tcache;
 
   virtual int factory(ErasureCodeProfile &profile,
-                      ErasureCodeInterfaceRef *erasure_code)
+                      ErasureCodeInterfaceRef *erasure_code,
+                      ostream *ss)
   {
     ErasureCodeIsa *interface;
     std::string t = "reed_sol_van";
@@ -50,15 +51,19 @@ public:
         interface = new ErasureCodeIsaDefault(tcache,
                                               ErasureCodeIsaDefault::kCauchy);
       } else {
-        derr << "technique=" << t << " is not a valid coding technique. "
+        *ss << "technique=" << t << " is not a valid coding technique. "
           << " Choose one of the following: "
           << "reed_sol_van,"
-          << "cauchy" << dendl;
+          << "cauchy" << std::endl;
         return -ENOENT;
       }
     }
 
-    interface->init(profile);
+    int r = interface->init(profile, ss);
+    if (r) {
+      delete interface;
+      return r;
+    }
     *erasure_code = ErasureCodeInterfaceRef(interface);
     return 0;
   }

--- a/src/erasure-code/isa/ErasureCodePluginIsa.cc
+++ b/src/erasure-code/isa/ErasureCodePluginIsa.cc
@@ -35,13 +35,13 @@ class ErasureCodePluginIsa : public ErasureCodePlugin {
 public:
   ErasureCodeIsaTableCache tcache;
 
-  virtual int factory(const map<std::string, std::string> &parameters,
+  virtual int factory(ErasureCodeProfile &profile,
                       ErasureCodeInterfaceRef *erasure_code)
   {
     ErasureCodeIsa *interface;
     std::string t = "reed_sol_van";
-    if (parameters.find("technique") != parameters.end())
-      t = parameters.find("technique")->second;
+    if (profile.find("technique") != profile.end())
+      t = profile.find("technique")->second;
     if ((t == "reed_sol_van")) {
       interface = new ErasureCodeIsaDefault(tcache,
                                             ErasureCodeIsaDefault::kVandermonde);
@@ -58,7 +58,7 @@ public:
       }
     }
 
-    interface->init(parameters);
+    interface->init(profile);
     *erasure_code = ErasureCodeInterfaceRef(interface);
     return 0;
   }

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.cc
@@ -52,8 +52,9 @@ int ErasureCodeJerasure::create_ruleset(const string &name,
   }
 }
 
-void ErasureCodeJerasure::init(ErasureCodeProfile& profile)
+int ErasureCodeJerasure::init(ErasureCodeProfile& profile, ostream *ss)
 {
+  int err = 0;
   dout(10) << "technique=" << technique << dendl;
   map<string,string>::const_iterator parameter;
   parameter = profile.find("ruleset-root");
@@ -62,10 +63,11 @@ void ErasureCodeJerasure::init(ErasureCodeProfile& profile)
   parameter = profile.find("ruleset-failure-domain");
   if (parameter != profile.end())
     ruleset_failure_domain = parameter->second;
-  ostringstream ss;
-  if (parse(profile, &ss))
-    derr << ss.str() << dendl;
+  err |= parse(profile, ss);
+  if (err)
+    return err;
   prepare();
+  return err;
 }
 
 int ErasureCodeJerasure::parse(ErasureCodeProfile &profile,

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -71,7 +71,7 @@ public:
 			    const map<int, bufferlist> &chunks,
 			    map<int, bufferlist> *decoded);
 
-  void init(ErasureCodeProfile &profile);
+  virtual int init(ErasureCodeProfile &profile, ostream *ss);
 
   virtual void jerasure_encode(char **data,
                                char **coding,

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -48,8 +48,7 @@ public:
 
   virtual ~ErasureCodeJerasure() {}
   
-  virtual int parse(const map<std::string,std::string> &parameters,
-		    ostream *ss);
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
 
   virtual int create_ruleset(const string &name,
 			     CrushWrapper &crush,
@@ -72,7 +71,8 @@ public:
 			    const map<int, bufferlist> &chunks,
 			    map<int, bufferlist> *decoded);
 
-  void init(const map<std::string,std::string> &parameters);
+  void init(ErasureCodeProfile &profile);
+
   virtual void jerasure_encode(char **data,
                                char **coding,
                                int blocksize) = 0;
@@ -110,8 +110,7 @@ public:
                                char **coding,
                                int blocksize);
   virtual unsigned get_alignment() const;
-  virtual int parse(const map<std::string,std::string> &parameters,
-		    ostream *ss);
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   virtual void prepare();
 };
 
@@ -139,8 +138,7 @@ public:
                                char **coding,
                                int blocksize);
   virtual unsigned get_alignment() const;
-  virtual int parse(const map<std::string,std::string> &parameters,
-		    ostream *ss);
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   virtual void prepare();
 };
 
@@ -175,8 +173,7 @@ public:
                                char **coding,
                                int blocksize);
   virtual unsigned get_alignment() const;
-  virtual int parse(const map<std::string,std::string> &parameters,
-		    ostream *ss);
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   void prepare_schedule(int *matrix);
 };
 
@@ -229,8 +226,7 @@ public:
   virtual bool check_packetsize_set(ostream *ss) const;
   virtual bool check_packetsize(ostream *ss) const;
   virtual void revert_to_default(ostream *ss);
-  virtual int parse(const map<std::string,std::string> &parameters,
-		    ostream *ss);
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   virtual void prepare();
 };
 
@@ -255,8 +251,7 @@ public:
     DEFAULT_W = 8;
   }
 
-  virtual int parse(const map<std::string,std::string> &parameters,
-		    ostream *ss);
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   virtual void prepare();
 };
 

--- a/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
@@ -32,7 +32,8 @@ static ostream& _prefix(std::ostream* _dout)
 class ErasureCodePluginJerasure : public ErasureCodePlugin {
 public:
   virtual int factory(ErasureCodeProfile &profile,
-		      ErasureCodeInterfaceRef *erasure_code) {
+		      ErasureCodeInterfaceRef *erasure_code,
+		      ostream *ss) {
     ErasureCodeJerasure *interface;
     std::string t;
     if (profile.find("technique") != profile.end())
@@ -59,7 +60,12 @@ public:
 	   << dendl;
       return -ENOENT;
     }
-    interface->init(profile);
+    dout(20) << __func__ << ": " << profile << dendl;
+    int r = interface->init(profile, ss);
+    if (r) {
+      delete interface;
+      return r;
+    }
     *erasure_code = ErasureCodeInterfaceRef(interface);
     return 0;
   }

--- a/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
@@ -31,12 +31,12 @@ static ostream& _prefix(std::ostream* _dout)
 
 class ErasureCodePluginJerasure : public ErasureCodePlugin {
 public:
-  virtual int factory(const map<std::string,std::string> &parameters,
+  virtual int factory(ErasureCodeProfile &profile,
 		      ErasureCodeInterfaceRef *erasure_code) {
     ErasureCodeJerasure *interface;
     std::string t;
-    if (parameters.find("technique") != parameters.end())
-      t = parameters.find("technique")->second;
+    if (profile.find("technique") != profile.end())
+      t = profile.find("technique")->second;
     if (t == "reed_sol_van") {
       interface = new ErasureCodeJerasureReedSolomonVandermonde();
     } else if (t == "reed_sol_r6_op") {
@@ -59,7 +59,7 @@ public:
 	   << dendl;
       return -ENOENT;
     }
-    interface->init(parameters);
+    interface->init(profile);
     *erasure_code = ErasureCodeInterfaceRef(interface);
     return 0;
   }

--- a/src/erasure-code/jerasure/ErasureCodePluginSelectJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodePluginSelectJerasure.cc
@@ -55,9 +55,9 @@ static string get_variant() {
 class ErasureCodePluginSelectJerasure : public ErasureCodePlugin {
 public:
   virtual int factory(ErasureCodeProfile &profile,
-		      ErasureCodeInterfaceRef *erasure_code) {
+		      ErasureCodeInterfaceRef *erasure_code,
+		      ostream *ss) {
     ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
-    stringstream ss;
     int ret;
     string name = "jerasure";
     if (profile.count("jerasure-name"))
@@ -72,8 +72,6 @@ public:
       dout(10) << variant << " plugin" << dendl;
       ret = instance.factory(name + "_" + variant, profile, erasure_code, ss);
     }
-    if (ret)
-      derr << ss.str() << dendl;
     return ret;
   }
 };
@@ -87,7 +85,7 @@ int __erasure_code_init(char *plugin_name, char *directory)
   ErasureCodePlugin *plugin;
   stringstream ss;
   int r = instance.load(plugin_name + string("_") + variant,
-			directory, &plugin, ss);
+			directory, &plugin, &ss);
   if (r) {
     derr << ss.str() << dendl;
     return r;

--- a/src/erasure-code/jerasure/ErasureCodePluginSelectJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodePluginSelectJerasure.cc
@@ -54,23 +54,23 @@ static string get_variant() {
 
 class ErasureCodePluginSelectJerasure : public ErasureCodePlugin {
 public:
-  virtual int factory(const map<string,string> &parameters,
+  virtual int factory(ErasureCodeProfile &profile,
 		      ErasureCodeInterfaceRef *erasure_code) {
     ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
     stringstream ss;
     int ret;
     string name = "jerasure";
-    if (parameters.count("jerasure-name"))
-      name = parameters.find("jerasure-name")->second;
-    if (parameters.count("jerasure-variant")) {
+    if (profile.count("jerasure-name"))
+      name = profile.find("jerasure-name")->second;
+    if (profile.count("jerasure-variant")) {
       dout(10) << "jerasure-variant " 
-	       << parameters.find("jerasure-variant")->second << dendl;
-      ret = instance.factory(name + "_" + parameters.find("jerasure-variant")->second,
-			     parameters, erasure_code, ss);
+	       << profile.find("jerasure-variant")->second << dendl;
+      ret = instance.factory(name + "_" + profile.find("jerasure-variant")->second,
+			     profile, erasure_code, ss);
     } else {
       string variant = get_variant();
       dout(10) << variant << " plugin" << dendl;
-      ret = instance.factory(name + "_" + variant, parameters, erasure_code, ss);
+      ret = instance.factory(name + "_" + variant, profile, erasure_code, ss);
     }
     if (ret)
       derr << ss.str() << dendl;

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -197,7 +197,7 @@ int ErasureCodeLrc::layers_parse(string description_string,
   return 0;
 }
 
-int ErasureCodeLrc::layers_init()
+int ErasureCodeLrc::layers_init(ostream *ss)
 {
   ErasureCodePluginRegistry &registry = ErasureCodePluginRegistry::instance();
   for (unsigned int i = 0; i < layers.size(); i++) {
@@ -217,7 +217,6 @@ int ErasureCodeLrc::layers_init()
     layer.chunks = layer.data;
     layer.chunks.insert(layer.chunks.end(),
 			layer.coding.begin(), layer.coding.end());
-    stringstream ss;
     if (layer.profile.find("k") == layer.profile.end())
       layer.profile["k"] = stringify(layer.data.size());
     if (layer.profile.find("m") == layer.profile.end())
@@ -232,10 +231,8 @@ int ErasureCodeLrc::layers_init()
 			       layer.profile,
 			       &layer.erasure_code,
 			       ss);
-    if (err) {
-      derr << ss.str() << dendl;
+    if (err)
       return err;
-    }
   }
   return 0;
 }
@@ -505,7 +502,7 @@ int ErasureCodeLrc::init(ErasureCodeProfile &profile,
   if (r)
     return r;
 
-  r = layers_init();
+  r = layers_init(ss);
   if (r)
     return r;
 

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -126,7 +126,7 @@ public:
   int layers_parse(string description_string,
 		   json_spirit::mArray description,
 		   ostream *ss);
-  int layers_init();
+  int layers_init(ostream *ss);
   int layers_sanity_checks(string description_string,
 			   ostream *ss) const;
 };

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -54,7 +54,7 @@ public:
     vector<int> chunks;
     set<int> chunks_as_set;
     string chunks_map;
-    map<string,string> parameters;
+    ErasureCodeProfile profile;
   };
   vector<Layer> layers;
   string directory;
@@ -108,19 +108,19 @@ public:
 			    const map<int, bufferlist> &chunks,
 			    map<int, bufferlist> *decoded);
 
-  int init(const map<string,string> &parameters, ostream *ss);
+  virtual int init(ErasureCodeProfile &profile, ostream *ss);
 
-  virtual int parse(const map<string,string> &parameters, ostream *ss);
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
 
-  int parse_kml(map<string,string> &parameters, ostream *ss);
+  int parse_kml(ErasureCodeProfile &profile, ostream *ss);
 
-  int parse_ruleset(const map<string,string> &parameters, ostream *ss);
+  int parse_ruleset(ErasureCodeProfile &profile, ostream *ss);
 
   int parse_ruleset_step(string description_string,
 			 json_spirit::mArray description,
 			 ostream *ss);
 
-  int layers_description(const map<string,string> &parameters,
+  int layers_description(const ErasureCodeProfile &profile,
 			 json_spirit::mArray *description,
 			 ostream *ss) const;
   int layers_parse(string description_string,

--- a/src/erasure-code/lrc/ErasureCodePluginLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodePluginLrc.cc
@@ -34,13 +34,13 @@ static ostream& _prefix(std::ostream* _dout)
 
 class ErasureCodePluginLrc : public ErasureCodePlugin {
 public:
-  virtual int factory(const map<std::string,std::string> &parameters,
+  virtual int factory(ErasureCodeProfile &profile,
 		      ErasureCodeInterfaceRef *erasure_code) {
     ErasureCodeLrc *interface;
     interface = new ErasureCodeLrc();
     stringstream ss;
-    assert(parameters.count("directory") != 0);
-    int r = interface->init(parameters, &ss);
+    assert(profile.count("directory") != 0);
+    int r = interface->init(profile, &ss);
     if (r) {
       derr << ss.str() << dendl;
       delete interface;

--- a/src/erasure-code/lrc/ErasureCodePluginLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodePluginLrc.cc
@@ -27,22 +27,16 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)
 
-static ostream& _prefix(std::ostream* _dout)
-{
-  return *_dout << "ErasureCodePluginLrc: ";
-}
-
 class ErasureCodePluginLrc : public ErasureCodePlugin {
 public:
   virtual int factory(ErasureCodeProfile &profile,
-		      ErasureCodeInterfaceRef *erasure_code) {
+		      ErasureCodeInterfaceRef *erasure_code,
+		      ostream *ss) {
     ErasureCodeLrc *interface;
     interface = new ErasureCodeLrc();
-    stringstream ss;
     assert(profile.count("directory") != 0);
-    int r = interface->init(profile, &ss);
+    int r = interface->init(profile, ss);
     if (r) {
-      derr << ss.str() << dendl;
       delete interface;
       return r;
     }

--- a/src/erasure-code/shec/ErasureCodePluginShec.cc
+++ b/src/erasure-code/shec/ErasureCodePluginShec.cc
@@ -59,6 +59,7 @@ public:
     }
     int r = interface->init(profile);
     if (r) {
+      delete interface;
       return r;
     }
     *erasure_code = ErasureCodeInterfaceRef(interface);

--- a/src/erasure-code/shec/ErasureCodePluginShec.cc
+++ b/src/erasure-code/shec/ErasureCodePluginShec.cc
@@ -38,7 +38,8 @@ public:
   ErasureCodeShecTableCache tcache;
 
   virtual int factory(ErasureCodeProfile &profile,
-		      ErasureCodeInterfaceRef *erasure_code) {
+		      ErasureCodeInterfaceRef *erasure_code,
+		      ostream *ss) {
     ErasureCodeShec *interface;
     std::string t = "multiple";
 
@@ -57,7 +58,7 @@ public:
 	   << dendl;
       return -ENOENT;
     }
-    int r = interface->init(profile);
+    int r = interface->init(profile, ss);
     if (r) {
       delete interface;
       return r;

--- a/src/erasure-code/shec/ErasureCodePluginShec.cc
+++ b/src/erasure-code/shec/ErasureCodePluginShec.cc
@@ -37,13 +37,13 @@ class ErasureCodePluginShec : public ErasureCodePlugin {
 public:
   ErasureCodeShecTableCache tcache;
 
-  virtual int factory(const map<std::string,std::string> &parameters,
+  virtual int factory(ErasureCodeProfile &profile,
 		      ErasureCodeInterfaceRef *erasure_code) {
     ErasureCodeShec *interface;
     std::string t = "multiple";
 
-    if (parameters.find("technique") != parameters.end()){
-      t = parameters.find("technique")->second;
+    if (profile.find("technique") != profile.end()){
+      t = profile.find("technique")->second;
     }
 
     if (t == "single"){
@@ -57,9 +57,9 @@ public:
 	   << dendl;
       return -ENOENT;
     }
-    int err = interface->init(parameters);
-    if (err) {
-      return err;
+    int r = interface->init(profile);
+    if (r) {
+      return r;
     }
     *erasure_code = ErasureCodeInterfaceRef(interface);
 

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -54,8 +54,10 @@ int ErasureCodeShec::create_ruleset(const string &name,
   }
 }
 
-int ErasureCodeShec::init(ErasureCodeProfile &profile)
+int ErasureCodeShec::init(ErasureCodeProfile &profile,
+			  ostream *ss)
 {
+  int err = 0;
   map<string,string>::const_iterator parameter;
   parameter = profile.find("ruleset-root");
   if (parameter != profile.end())
@@ -63,12 +65,11 @@ int ErasureCodeShec::init(ErasureCodeProfile &profile)
   parameter = profile.find("ruleset-failure-domain");
   if (parameter != profile.end())
     ruleset_failure_domain = parameter->second;
-  int err = parse(profile);
-  if (err) {
+  err |= parse(profile);
+  if (err)
     return err;
-  }
   prepare();
-  return 0;
+  return err;
 }
 
 unsigned int ErasureCodeShec::get_chunk_size(unsigned int object_size) const

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -54,17 +54,16 @@ int ErasureCodeShec::create_ruleset(const string &name,
   }
 }
 
-int ErasureCodeShec::init(const map<std::string,std::string> &parameters)
+int ErasureCodeShec::init(ErasureCodeProfile &profile)
 {
-  dout(10) << "technique=" << technique << dendl;
   map<string,string>::const_iterator parameter;
-  parameter = parameters.find("ruleset-root");
-  if (parameter != parameters.end())
+  parameter = profile.find("ruleset-root");
+  if (parameter != profile.end())
     ruleset_root = parameter->second;
-  parameter = parameters.find("ruleset-failure-domain");
-  if (parameter != parameters.end())
+  parameter = profile.find("ruleset-failure-domain");
+  if (parameter != profile.end())
     ruleset_failure_domain = parameter->second;
-  int err = parse(parameters);
+  int err = parse(profile);
   if (err) {
     return err;
   }
@@ -279,26 +278,26 @@ unsigned ErasureCodeShecReedSolomonVandermonde::get_alignment() const
   return k*w*sizeof(int);
 }
 
-int ErasureCodeShecReedSolomonVandermonde::parse(const map<std::string,std::string> &parameters)
+int ErasureCodeShecReedSolomonVandermonde::parse(const ErasureCodeProfile &profile)
 {
   int err = 0;
   // k, m, c
-  if (parameters.find("k") == parameters.end() &&
-      parameters.find("m") == parameters.end() &&
-      parameters.find("c") == parameters.end()){
+  if (profile.find("k") == profile.end() &&
+      profile.find("m") == profile.end() &&
+      profile.find("c") == profile.end()){
     dout(10) << "(k, m, c) default to " << "(" << DEFAULT_K
 	     << ", " << DEFAULT_M << ", " << DEFAULT_C << ")" << dendl;
     k = DEFAULT_K; m = DEFAULT_M; c = DEFAULT_C;
-  } else if (parameters.find("k") == parameters.end() ||
-	     parameters.find("m") == parameters.end() ||
-	     parameters.find("c") == parameters.end()){
+  } else if (profile.find("k") == profile.end() ||
+	     profile.find("m") == profile.end() ||
+	     profile.find("c") == profile.end()){
     dout(10) << "(k, m, c) must be choosed" << dendl;
     err = -EINVAL;
   } else {
     std::string err_k, err_m, err_c, value_k, value_m, value_c;
-    value_k = parameters.find("k")->second;
-    value_m = parameters.find("m")->second;
-    value_c = parameters.find("c")->second;
+    value_k = profile.find("k")->second;
+    value_m = profile.find("m")->second;
+    value_c = profile.find("c")->second;
     k = strict_strtol(value_k.c_str(), 10, &err_k);
     m = strict_strtol(value_m.c_str(), 10, &err_m);
     c = strict_strtol(value_c.c_str(), 10, &err_c);
@@ -353,12 +352,12 @@ int ErasureCodeShecReedSolomonVandermonde::parse(const map<std::string,std::stri
 	   << c << ")"<< dendl;
 
   // w
-  if (parameters.find("w") == parameters.end()){
+  if (profile.find("w") == profile.end()){
     dout(10) << "w default to " << DEFAULT_W << dendl;
     w = DEFAULT_W;
   } else {
     std::string err_w, value_w;
-    value_w = parameters.find("w")->second;
+    value_w = profile.find("w")->second;
     w = strict_strtol(value_w.c_str(), 10, &err_w);
 
     if (!err_w.empty()){

--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -102,7 +102,7 @@ public:
 			    const map<int, bufferlist> &chunks,
 			    map<int, bufferlist> *decoded);
 
-  int init(const map<std::string,std::string> &parameters);
+  int init(ErasureCodeProfile &profile);
   virtual void shec_encode(char **data,
 			   char **coding,
 			   int blocksize) = 0;
@@ -112,7 +112,7 @@ public:
 			  char **coding,
 			  int blocksize) = 0;
   virtual unsigned get_alignment() const = 0;
-  virtual int parse(const map<std::string,std::string> &parameters) = 0;
+  virtual int parse(const ErasureCodeProfile &profile) = 0;
   virtual void prepare() = 0;
 };
 
@@ -136,7 +136,7 @@ public:
 			  char **coding,
 			  int blocksize);
   virtual unsigned get_alignment() const;
-  virtual int parse(const map<std::string,std::string> &parameters);
+  virtual int parse(const ErasureCodeProfile &profile);
   virtual void prepare();
 };
 

--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -102,7 +102,7 @@ public:
 			    const map<int, bufferlist> &chunks,
 			    map<int, bufferlist> *decoded);
 
-  int init(ErasureCodeProfile &profile);
+  virtual int init(ErasureCodeProfile &profile, ostream *ss);
   virtual void shec_encode(char **data,
 			   char **coding,
 			   int blocksize) = 0;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3983,14 +3983,14 @@ int OSDMonitor::get_erasure_code(const string &erasure_code_profile,
 {
   if (pending_inc.has_erasure_code_profile(erasure_code_profile))
     return -EAGAIN;
-  const map<string,string> &profile =
+  ErasureCodeProfile profile =
     osdmap.get_erasure_code_profile(erasure_code_profile);
-  map<string,string>::const_iterator plugin =
+  ErasureCodeProfile::const_iterator plugin =
     profile.find("plugin");
   if (plugin == profile.end()) {
     ss << "cannot determine the erasure code plugin"
-       << " because there is no 'plugin' entry in the erasure_code_profile "
-       << profile << std::endl;
+	<< " because there is no 'plugin' entry in the erasure_code_profile "
+	<< profile << std::endl;
     return -EINVAL;
   }
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3900,12 +3900,12 @@ int OSDMonitor::prepare_new_pool(MPoolOp *m)
     return prepare_new_pool(m->name, m->auid, m->crush_rule, ruleset_name,
 			    0, 0,
                             erasure_code_profile,
-			    pg_pool_t::TYPE_REPLICATED, 0, ss);
+			    pg_pool_t::TYPE_REPLICATED, 0, &ss);
   else
     return prepare_new_pool(m->name, session->auid, m->crush_rule, ruleset_name,
 			    0, 0,
                             erasure_code_profile,
-			    pg_pool_t::TYPE_REPLICATED, 0, ss);
+			    pg_pool_t::TYPE_REPLICATED, 0, &ss);
 }
 
 int OSDMonitor::crush_rename_bucket(const string& srcname,
@@ -3943,7 +3943,7 @@ int OSDMonitor::crush_rename_bucket(const string& srcname,
 int OSDMonitor::crush_ruleset_create_erasure(const string &name,
 					     const string &profile,
 					     int *ruleset,
-					     stringstream &ss)
+					     ostream *ss)
 {
   int ruleid = osdmap.crush->get_rule_id(name);
   if (ruleid != -ENOENT) {
@@ -3962,11 +3962,11 @@ int OSDMonitor::crush_ruleset_create_erasure(const string &name,
     ErasureCodeInterfaceRef erasure_code;
     int err = get_erasure_code(profile, &erasure_code, ss);
     if (err) {
-      ss << "failed to load plugin using profile " << profile << std::endl;
+      *ss << "failed to load plugin using profile " << profile << std::endl;
       return err;
     }
 
-    err = erasure_code->create_ruleset(name, newcrush, &ss);
+    err = erasure_code->create_ruleset(name, newcrush, ss);
     erasure_code.reset();
     if (err < 0)
       return err;
@@ -3979,7 +3979,7 @@ int OSDMonitor::crush_ruleset_create_erasure(const string &name,
 
 int OSDMonitor::get_erasure_code(const string &erasure_code_profile,
 				 ErasureCodeInterfaceRef *erasure_code,
-				 stringstream &ss) const
+				 ostream *ss) const
 {
   if (pending_inc.has_erasure_code_profile(erasure_code_profile))
     return -EAGAIN;
@@ -3988,7 +3988,7 @@ int OSDMonitor::get_erasure_code(const string &erasure_code_profile,
   ErasureCodeProfile::const_iterator plugin =
     profile.find("plugin");
   if (plugin == profile.end()) {
-    ss << "cannot determine the erasure code plugin"
+    *ss << "cannot determine the erasure code plugin"
 	<< " because there is no 'plugin' entry in the erasure_code_profile "
 	<< profile << std::endl;
     return -EINVAL;
@@ -4065,29 +4065,29 @@ bool OSDMonitor::validate_crush_against_features(const CrushWrapper *newcrush,
 
 bool OSDMonitor::erasure_code_profile_in_use(const map<int64_t, pg_pool_t> &pools,
 					     const string &profile,
-					     ostream &ss)
+					     ostream *ss)
 {
   bool found = false;
   for (map<int64_t, pg_pool_t>::const_iterator p = pools.begin();
        p != pools.end();
        ++p) {
     if (p->second.erasure_code_profile == profile) {
-      ss << osdmap.pool_name[p->first] << " ";
+      *ss << osdmap.pool_name[p->first] << " ";
       found = true;
     }
   }
   if (found) {
-    ss << "pool(s) are using the erasure code profile '" << profile << "'";
+    *ss << "pool(s) are using the erasure code profile '" << profile << "'";
   }
   return found;
 }
 
 int OSDMonitor::parse_erasure_code_profile(const vector<string> &erasure_code_profile,
 					   map<string,string> *erasure_code_profile_map,
-					   stringstream &ss)
+					   ostream *ss)
 {
   int r = get_json_str_map(g_conf->osd_pool_default_erasure_code_profile,
-		           ss,
+		           *ss,
 		           erasure_code_profile_map);
   if (r)
     return r;
@@ -4123,7 +4123,7 @@ int OSDMonitor::parse_erasure_code_profile(const vector<string> &erasure_code_pr
 int OSDMonitor::prepare_pool_size(const unsigned pool_type,
 				  const string &erasure_code_profile,
 				  unsigned *size, unsigned *min_size,
-				  stringstream &ss)
+				  ostream *ss)
 {
   int err = 0;
   switch (pool_type) {
@@ -4142,7 +4142,7 @@ int OSDMonitor::prepare_pool_size(const unsigned pool_type,
     }
     break;
   default:
-    ss << "prepare_pool_size: " << pool_type << " is not a known pool type";
+    *ss << "prepare_pool_size: " << pool_type << " is not a known pool type";
     err = -EINVAL;
     break;
   }
@@ -4152,7 +4152,7 @@ int OSDMonitor::prepare_pool_size(const unsigned pool_type,
 int OSDMonitor::prepare_pool_stripe_width(const unsigned pool_type,
 					  const string &erasure_code_profile,
 					  uint32_t *stripe_width,
-					  stringstream &ss)
+					  ostream *ss)
 {
   int err = 0;
   switch (pool_type) {
@@ -4170,7 +4170,7 @@ int OSDMonitor::prepare_pool_stripe_width(const unsigned pool_type,
     }
     break;
   default:
-    ss << "prepare_pool_stripe_width: "
+    *ss << "prepare_pool_stripe_width: "
        << pool_type << " is not a known pool type";
     err = -EINVAL;
     break;
@@ -4182,7 +4182,7 @@ int OSDMonitor::prepare_pool_crush_ruleset(const unsigned pool_type,
 					   const string &erasure_code_profile,
 					   const string &ruleset_name,
 					   int *crush_ruleset,
-					   stringstream &ss)
+					   ostream *ss)
 {
   if (*crush_ruleset < 0) {
     switch (pool_type) {
@@ -4193,7 +4193,7 @@ int OSDMonitor::prepare_pool_crush_ruleset(const unsigned pool_type,
 	  *crush_ruleset = osdmap.crush->get_osd_pool_default_crush_replicated_ruleset(g_ceph_context);
 	  if (*crush_ruleset < 0) {
 	    // Errors may happen e.g. if no valid ruleset is available
-	    ss << "No suitable CRUSH ruleset exists";
+	    *ss << "No suitable CRUSH ruleset exists";
 	    return *crush_ruleset;
 	  }
 	} else {
@@ -4222,14 +4222,14 @@ int OSDMonitor::prepare_pool_crush_ruleset(const unsigned pool_type,
       }
       break;
     default:
-      ss << "prepare_pool_crush_ruleset: " << pool_type
+      *ss << "prepare_pool_crush_ruleset: " << pool_type
 	 << " is not a known pool type";
       return -EINVAL;
       break;
     }
   } else {
     if (!osdmap.crush->ruleset_exists(*crush_ruleset)) {
-      ss << "CRUSH ruleset " << *crush_ruleset << " not found";
+      *ss << "CRUSH ruleset " << *crush_ruleset << " not found";
       return -ENOENT;
     }
   }
@@ -4239,7 +4239,7 @@ int OSDMonitor::prepare_pool_crush_ruleset(const unsigned pool_type,
 
 int OSDMonitor::get_crush_ruleset(const string &ruleset_name,
 				  int *crush_ruleset,
-				  stringstream &ss)
+				  ostream *ss)
 {
   int ret;
   ret = osdmap.crush->get_rule_id(ruleset_name);
@@ -4258,7 +4258,7 @@ int OSDMonitor::get_crush_ruleset(const string &ruleset_name,
       return -EAGAIN;
     } else {
       //Cannot find it , return error
-      ss << "specified ruleset " << ruleset_name << " doesn't exist";
+      *ss << "specified ruleset " << ruleset_name << " doesn't exist";
       return ret;
     }
   }
@@ -4286,7 +4286,7 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
 				 const string &erasure_code_profile,
                                  const unsigned pool_type,
                                  const uint64_t expected_num_objects,
-				 stringstream &ss)
+				 ostream *ss)
 {
   if (name.length() == 0)
     return -EINVAL;
@@ -4510,7 +4510,7 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
        ErasureCodeInterfaceRef erasure_code;
        int k;
        stringstream tmp;
-       int err = get_erasure_code(p.erasure_code_profile, &erasure_code, tmp);
+       int err = get_erasure_code(p.erasure_code_profile, &erasure_code, &tmp);
        if (err == 0) {
 	 k = erasure_code->get_data_chunk_count();
        } else {
@@ -5399,10 +5399,10 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
     string name;
     cmd_getval(g_ceph_context, cmdmap, "name", name);
 
-    if (erasure_code_profile_in_use(pending_inc.new_pools, name, ss))
+    if (erasure_code_profile_in_use(pending_inc.new_pools, name, &ss))
       goto wait;
 
-    if (erasure_code_profile_in_use(osdmap.pools, name, ss)) {
+    if (erasure_code_profile_in_use(osdmap.pools, name, &ss)) {
       err = -EBUSY;
       goto reply;
     }
@@ -5439,7 +5439,7 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
       force = false;
     }
     map<string,string> profile_map;
-    err = parse_erasure_code_profile(profile, &profile_map, ss);
+    err = parse_erasure_code_profile(profile, &profile_map, &ss);
     if (err)
       goto reply;
     if (profile_map.find("plugin") == profile_map.end()) {
@@ -5523,7 +5523,7 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
     }
 
     int ruleset;
-    err = crush_ruleset_create_erasure(name, profile, &ruleset, ss);
+    err = crush_ruleset_create_erasure(name, profile, &ruleset, &ss);
     if (err < 0) {
       switch(err) {
       case -EEXIST: // return immediately
@@ -6297,7 +6297,7 @@ done:
 
     if (!implicit_ruleset_creation && ruleset_name != "") {
       int ruleset;
-      err = get_crush_ruleset(ruleset_name, &ruleset, ss);
+      err = get_crush_ruleset(ruleset_name, &ruleset, &ss);
       if (err == -EAGAIN) {
 	wait_for_finished_proposal(new C_RetryMessage(this, m));
 	return true;
@@ -6319,7 +6319,7 @@ done:
 			   pg_num, pgp_num,
 			   erasure_code_profile, pool_type,
                            (uint64_t)expected_num_objects,
-			   ss);
+			   &ss);
     if (err < 0) {
       switch(err) {
       case -EEXIST:

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -280,32 +280,32 @@ private:
   int crush_ruleset_create_erasure(const string &name,
 				   const string &profile,
 				   int *ruleset,
-				   stringstream &ss);
+				   ostream *ss);
   int get_crush_ruleset(const string &ruleset_name,
 			int *crush_ruleset,
-			stringstream &ss);
+			ostream *ss);
   int get_erasure_code(const string &erasure_code_profile,
 		       ErasureCodeInterfaceRef *erasure_code,
-		       stringstream &ss) const;
+		       ostream *ss) const;
   int prepare_pool_crush_ruleset(const unsigned pool_type,
 				 const string &erasure_code_profile,
 				 const string &ruleset_name,
 				 int *crush_ruleset,
-				 stringstream &ss);
+				 ostream *ss);
   bool erasure_code_profile_in_use(const map<int64_t, pg_pool_t> &pools,
 				   const string &profile,
-				   ostream &ss);
+				   ostream *ss);
   int parse_erasure_code_profile(const vector<string> &erasure_code_profile,
 				 map<string,string> *erasure_code_profile_map,
-				 stringstream &ss);
+				 ostream *ss);
   int prepare_pool_size(const unsigned pool_type,
 			const string &erasure_code_profile,
 			unsigned *size, unsigned *min_size,
-			stringstream &ss);
+			ostream *ss);
   int prepare_pool_stripe_width(const unsigned pool_type,
 				const string &erasure_code_profile,
 				unsigned *stripe_width,
-				stringstream &ss);
+				ostream *ss);
   int prepare_new_pool(string& name, uint64_t auid,
 		       int crush_ruleset,
 		       const string &crush_ruleset_name,
@@ -313,7 +313,7 @@ private:
 		       const string &erasure_code_profile,
                        const unsigned pool_type,
                        const uint64_t expected_num_objects,
-		       stringstream &ss);
+		       ostream *ss);
   int prepare_new_pool(MPoolOp *m);
 
   void update_pool_flags(int64_t pool_id, uint64_t flags);

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -292,7 +292,7 @@ PGBackend *PGBackend::build_pg_backend(
   }
   case pg_pool_t::TYPE_ERASURE: {
     ErasureCodeInterfaceRef ec_impl;
-    const map<string,string> &profile = curmap->get_erasure_code_profile(pool.erasure_code_profile);
+    ErasureCodeProfile profile = curmap->get_erasure_code_profile(pool.erasure_code_profile);
     assert(profile.count("plugin"));
     stringstream ss;
     ceph::ErasureCodePluginRegistry::instance().factory(

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -299,7 +299,7 @@ PGBackend *PGBackend::build_pg_backend(
       profile.find("plugin")->second,
       profile,
       &ec_impl,
-      ss);
+      &ss);
     assert(ec_impl);
     return new ECBackend(
       l,

--- a/src/test/erasure-code/ErasureCodeExample.h
+++ b/src/test/erasure-code/ErasureCodeExample.h
@@ -39,6 +39,10 @@ class ErasureCodeExample : public ErasureCode {
 public:
   virtual ~ErasureCodeExample() {}
 
+  virtual int init(ErasureCodeProfile &profile, ostream *ss) {
+    return 0;
+  }
+
   virtual int create_ruleset(const string &name,
 			     CrushWrapper &crush,
 			     ostream *ss) const {

--- a/src/test/erasure-code/ErasureCodePluginExample.cc
+++ b/src/test/erasure-code/ErasureCodePluginExample.cc
@@ -24,7 +24,8 @@
 class ErasureCodePluginExample : public ErasureCodePlugin {
 public:
   virtual int factory(ErasureCodeProfile &profile,
-                      ErasureCodeInterfaceRef *erasure_code)
+                      ErasureCodeInterfaceRef *erasure_code,
+		      ostream *ss)
   {
     *erasure_code = ErasureCodeInterfaceRef(new ErasureCodeExample());
     return 0;

--- a/src/test/erasure-code/ErasureCodePluginExample.cc
+++ b/src/test/erasure-code/ErasureCodePluginExample.cc
@@ -23,7 +23,7 @@
 
 class ErasureCodePluginExample : public ErasureCodePlugin {
 public:
-  virtual int factory(const map<std::string,std::string> &parameters,
+  virtual int factory(ErasureCodeProfile &profile,
                       ErasureCodeInterfaceRef *erasure_code)
   {
     *erasure_code = ErasureCodeInterfaceRef(new ErasureCodeExample());

--- a/src/test/erasure-code/TestErasureCode.cc
+++ b/src/test/erasure-code/TestErasureCode.cc
@@ -33,6 +33,10 @@ public:
     k(_k), m(_m), chunk_size(_chunk_size) {}
   virtual ~ErasureCodeTest() {}
 
+  virtual int init(ErasureCodeProfile &profile, ostream *ss) {
+    return 0;
+  }
+
   virtual unsigned int get_chunk_count() const { return k + m; }
   virtual unsigned int get_data_chunk_count() const { return k; }
   virtual unsigned int get_chunk_size(unsigned int object_size) const {

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -50,10 +50,10 @@ void IsaErasureCodeTest::encode_decode(unsigned object_size)
 {
   ErasureCodeIsaDefault Isa(tcache);
 
-  map<std::string, std::string> parameters;
-  parameters["k"] = "2";
-  parameters["m"] = "2";
-  Isa.init(parameters);
+  ErasureCodeProfile profile;
+  profile["k"] = "2";
+  profile["m"] = "2";
+  Isa.init(profile);
 
   string payload(object_size, 'X');
   bufferlist in;
@@ -190,10 +190,10 @@ TEST_F(IsaErasureCodeTest, encode_decode)
 TEST_F(IsaErasureCodeTest, minimum_to_decode)
 {
   ErasureCodeIsaDefault Isa(tcache);
-  map<std::string, std::string> parameters;
-  parameters["k"] = "2";
-  parameters["m"] = "2";
-  Isa.init(parameters);
+  ErasureCodeProfile profile;
+  profile["k"] = "2";
+  profile["m"] = "2";
+  Isa.init(profile);
 
   //
   // If trying to read nothing, the minimum is empty.
@@ -287,10 +287,10 @@ TEST_F(IsaErasureCodeTest, chunk_size)
 {
   {
     ErasureCodeIsaDefault Isa(tcache);
-    map<std::string, std::string> parameters;
-    parameters["k"] = "2";
-    parameters["m"] = "1";
-    Isa.init(parameters);
+    ErasureCodeProfile profile;
+    profile["k"] = "2";
+    profile["m"] = "1";
+    Isa.init(profile);
     int k = 2;
 
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT, Isa.get_chunk_size(1));
@@ -299,10 +299,10 @@ TEST_F(IsaErasureCodeTest, chunk_size)
   }
   {
     ErasureCodeIsaDefault Isa(tcache);
-    map<std::string, std::string> parameters;
-    parameters["k"] = "3";
-    parameters["m"] = "1";
-    Isa.init(parameters);
+    ErasureCodeProfile profile;
+    profile["k"] = "3";
+    profile["m"] = "1";
+    Isa.init(profile);
     int k = 3;
 
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT, Isa.get_chunk_size(1));
@@ -320,10 +320,10 @@ TEST_F(IsaErasureCodeTest, chunk_size)
 TEST_F(IsaErasureCodeTest, encode)
 {
   ErasureCodeIsaDefault Isa(tcache);
-  map<std::string, std::string> parameters;
-  parameters["k"] = "2";
-  parameters["m"] = "2";
-  Isa.init(parameters);
+  ErasureCodeProfile profile;
+  profile["k"] = "2";
+  profile["m"] = "2";
+  Isa.init(profile);
 
   unsigned aligned_object_size = Isa.get_alignment() * 2;
   {
@@ -391,10 +391,10 @@ TEST_F(IsaErasureCodeTest, isa_vandermonde_exhaustive)
   // a (12,4) configuration using the vandermonde matrix
 
   ErasureCodeIsaDefault Isa(tcache);
-  map<std::string, std::string> parameters;
-  parameters["k"] = "12";
-  parameters["m"] = "4";
-  Isa.init(parameters);
+  ErasureCodeProfile profile;
+  profile["k"] = "12";
+  profile["m"] = "4";
+  Isa.init(profile);
 
   int k = 12;
   int m = 4;
@@ -516,12 +516,12 @@ TEST_F(IsaErasureCodeTest, isa_cauchy_exhaustive)
   // Test all possible failure scenarios and reconstruction cases for
   // a (12,4) configuration using the cauchy matrix
   ErasureCodeIsaDefault Isa(tcache,ErasureCodeIsaDefault::kCauchy);
-  map<std::string, std::string> parameters;
-  parameters["k"] = "12";
-  parameters["m"] = "4";
-  parameters["technique"] = "cauchy";
+  ErasureCodeProfile profile;
+  profile["k"] = "12";
+  profile["m"] = "4";
+  profile["technique"] = "cauchy";
 
-  Isa.init(parameters);
+  Isa.init(profile);
 
   int k = 12;
   int m = 4;
@@ -643,12 +643,12 @@ TEST_F(IsaErasureCodeTest, isa_cauchy_cache_trash)
   // Test all possible failure scenarios and reconstruction cases for
   // a (12,4) configuration using the cauchy matrix
   ErasureCodeIsaDefault Isa(tcache,ErasureCodeIsaDefault::kCauchy);
-  map<std::string, std::string> parameters;
-  parameters["k"] = "16";
-  parameters["m"] = "4";
-  parameters["technique"] = "cauchy";
+  ErasureCodeProfile profile;
+  profile["k"] = "16";
+  profile["m"] = "4";
+  profile["technique"] = "cauchy";
 
-  Isa.init(parameters);
+  Isa.init(profile);
 
   int k = 16;
   int m = 4;
@@ -771,10 +771,10 @@ TEST_F(IsaErasureCodeTest, isa_xor_codec)
   // a (4,1) RAID-5 like configuration 
 
   ErasureCodeIsaDefault Isa(tcache);
-  map<std::string, std::string> parameters;
-  parameters["k"] = "4";
-  parameters["m"] = "1";
-  Isa.init(parameters);
+  ErasureCodeProfile profile;
+  profile["k"] = "4";
+  profile["m"] = "1";
+  Isa.init(profile);
 
   int k = 4;
   int m = 1;
@@ -895,11 +895,11 @@ TEST_F(IsaErasureCodeTest, create_ruleset)
   {
     stringstream ss;
     ErasureCodeIsaDefault isa(tcache);
-    map<std::string,std::string> parameters;
-    parameters["k"] = "2";
-    parameters["m"] = "2";
-    parameters["w"] = "8";
-    isa.init(parameters);
+    ErasureCodeProfile profile;
+    profile["k"] = "2";
+    profile["m"] = "2";
+    profile["w"] = "8";
+    isa.init(profile);
     int ruleset = isa.create_ruleset("myrule", *c, &ss);
     EXPECT_EQ(0, ruleset);
     EXPECT_EQ(-EEXIST, isa.create_ruleset("myrule", *c, &ss));
@@ -919,24 +919,24 @@ TEST_F(IsaErasureCodeTest, create_ruleset)
   {
     stringstream ss;
     ErasureCodeIsaDefault isa(tcache);
-    map<std::string,std::string> parameters;
-    parameters["k"] = "2";
-    parameters["m"] = "2";
-    parameters["w"] = "8";
-    parameters["ruleset-root"] = "BAD";
-    isa.init(parameters);
+    ErasureCodeProfile profile;
+    profile["k"] = "2";
+    profile["m"] = "2";
+    profile["w"] = "8";
+    profile["ruleset-root"] = "BAD";
+    isa.init(profile);
     EXPECT_EQ(-ENOENT, isa.create_ruleset("otherrule", *c, &ss));
     EXPECT_EQ("root item BAD does not exist", ss.str());
   }
   {
     stringstream ss;
     ErasureCodeIsaDefault isa(tcache);
-    map<std::string,std::string> parameters;
-    parameters["k"] = "2";
-    parameters["m"] = "2";
-    parameters["w"] = "8";
-    parameters["ruleset-failure-domain"] = "WORSE";
-    isa.init(parameters);
+    ErasureCodeProfile profile;
+    profile["k"] = "2";
+    profile["m"] = "2";
+    profile["w"] = "8";
+    profile["ruleset-failure-domain"] = "WORSE";
+    isa.init(profile);
     EXPECT_EQ(-EINVAL, isa.create_ruleset("otherrule", *c, &ss));
     EXPECT_EQ("unknown type WORSE", ss.str());
   }
@@ -957,7 +957,7 @@ int main(int argc, char **argv)
 /*
  * Local Variables:
  * compile-command: "cd ../.. ; make -j4 unittest_erasure_code_isa &&
- *   libtool --mode=execute valgrind --tool=memcheck --leak-check=full \
+ *   libtool --mode=execute valgrind --tool=memcheck \
  *      ./unittest_erasure_code_isa \
  *      --gtest_filter=*.* --log-to-stderr=true --debug-osd=20"
  * End:

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -53,7 +53,7 @@ void IsaErasureCodeTest::encode_decode(unsigned object_size)
   ErasureCodeProfile profile;
   profile["k"] = "2";
   profile["m"] = "2";
-  Isa.init(profile);
+  Isa.init(profile, &cerr);
 
   string payload(object_size, 'X');
   bufferlist in;
@@ -193,7 +193,7 @@ TEST_F(IsaErasureCodeTest, minimum_to_decode)
   ErasureCodeProfile profile;
   profile["k"] = "2";
   profile["m"] = "2";
-  Isa.init(profile);
+  Isa.init(profile, &cerr);
 
   //
   // If trying to read nothing, the minimum is empty.
@@ -290,7 +290,7 @@ TEST_F(IsaErasureCodeTest, chunk_size)
     ErasureCodeProfile profile;
     profile["k"] = "2";
     profile["m"] = "1";
-    Isa.init(profile);
+    Isa.init(profile, &cerr);
     int k = 2;
 
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT, Isa.get_chunk_size(1));
@@ -302,7 +302,7 @@ TEST_F(IsaErasureCodeTest, chunk_size)
     ErasureCodeProfile profile;
     profile["k"] = "3";
     profile["m"] = "1";
-    Isa.init(profile);
+    Isa.init(profile, &cerr);
     int k = 3;
 
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT, Isa.get_chunk_size(1));
@@ -323,7 +323,7 @@ TEST_F(IsaErasureCodeTest, encode)
   ErasureCodeProfile profile;
   profile["k"] = "2";
   profile["m"] = "2";
-  Isa.init(profile);
+  Isa.init(profile, &cerr);
 
   unsigned aligned_object_size = Isa.get_alignment() * 2;
   {
@@ -394,7 +394,7 @@ TEST_F(IsaErasureCodeTest, isa_vandermonde_exhaustive)
   ErasureCodeProfile profile;
   profile["k"] = "12";
   profile["m"] = "4";
-  Isa.init(profile);
+  Isa.init(profile, &cerr);
 
   int k = 12;
   int m = 4;
@@ -521,7 +521,7 @@ TEST_F(IsaErasureCodeTest, isa_cauchy_exhaustive)
   profile["m"] = "4";
   profile["technique"] = "cauchy";
 
-  Isa.init(profile);
+  Isa.init(profile, &cerr);
 
   int k = 12;
   int m = 4;
@@ -648,7 +648,7 @@ TEST_F(IsaErasureCodeTest, isa_cauchy_cache_trash)
   profile["m"] = "4";
   profile["technique"] = "cauchy";
 
-  Isa.init(profile);
+  Isa.init(profile, &cerr);
 
   int k = 16;
   int m = 4;
@@ -774,7 +774,7 @@ TEST_F(IsaErasureCodeTest, isa_xor_codec)
   ErasureCodeProfile profile;
   profile["k"] = "4";
   profile["m"] = "1";
-  Isa.init(profile);
+  Isa.init(profile, &cerr);
 
   int k = 4;
   int m = 1;
@@ -899,7 +899,7 @@ TEST_F(IsaErasureCodeTest, create_ruleset)
     profile["k"] = "2";
     profile["m"] = "2";
     profile["w"] = "8";
-    isa.init(profile);
+    isa.init(profile, &cerr);
     int ruleset = isa.create_ruleset("myrule", *c, &ss);
     EXPECT_EQ(0, ruleset);
     EXPECT_EQ(-EEXIST, isa.create_ruleset("myrule", *c, &ss));
@@ -924,7 +924,7 @@ TEST_F(IsaErasureCodeTest, create_ruleset)
     profile["m"] = "2";
     profile["w"] = "8";
     profile["ruleset-root"] = "BAD";
-    isa.init(profile);
+    isa.init(profile, &cerr);
     EXPECT_EQ(-ENOENT, isa.create_ruleset("otherrule", *c, &ss));
     EXPECT_EQ("root item BAD does not exist", ss.str());
   }
@@ -936,7 +936,7 @@ TEST_F(IsaErasureCodeTest, create_ruleset)
     profile["m"] = "2";
     profile["w"] = "8";
     profile["ruleset-failure-domain"] = "WORSE";
-    isa.init(profile);
+    isa.init(profile, &cerr);
     EXPECT_EQ(-EINVAL, isa.create_ruleset("otherrule", *c, &ss));
     EXPECT_EQ("unknown type WORSE", ss.str());
   }

--- a/src/test/erasure-code/TestErasureCodeJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodeJerasure.cc
@@ -54,7 +54,7 @@ TYPED_TEST(ErasureCodeTest, encode_decode)
     profile["packetsize"] = "8";
     profile["jerasure-per-chunk-alignment"] =
       per_chunk_alignments[per_chunk_alignment];
-    jerasure.init(profile);
+    jerasure.init(profile, &cerr);
 
 #define LARGE_ENOUGH 2048
     bufferptr in_ptr(buffer::create_page_aligned(LARGE_ENOUGH));
@@ -124,7 +124,7 @@ TYPED_TEST(ErasureCodeTest, minimum_to_decode)
   profile["m"] = "2";
   profile["w"] = "7";
   profile["packetsize"] = "8";
-  jerasure.init(profile);
+  jerasure.init(profile, &cerr);
 
   //
   // If trying to read nothing, the minimum is empty.
@@ -221,7 +221,7 @@ TEST(ErasureCodeTest, encode)
   profile["k"] = "2";
   profile["m"] = "2";
   profile["w"] = "8";
-  jerasure.init(profile);
+  jerasure.init(profile, &cerr);
 
   unsigned aligned_object_size = jerasure.get_alignment() * 2;
   {
@@ -300,7 +300,7 @@ TEST(ErasureCodeTest, create_ruleset)
     profile["k"] = "2";
     profile["m"] = "2";
     profile["w"] = "8";
-    jerasure.init(profile);
+    jerasure.init(profile, &cerr);
     int ruleset = jerasure.create_ruleset("myrule", *c, &ss);
     EXPECT_EQ(0, ruleset);
     EXPECT_EQ(-EEXIST, jerasure.create_ruleset("myrule", *c, &ss));
@@ -325,7 +325,7 @@ TEST(ErasureCodeTest, create_ruleset)
     profile["m"] = "2";
     profile["w"] = "8";
     profile["ruleset-root"] = "BAD";
-    jerasure.init(profile);
+    jerasure.init(profile, &cerr);
     EXPECT_EQ(-ENOENT, jerasure.create_ruleset("otherrule", *c, &ss));
     EXPECT_EQ("root item BAD does not exist", ss.str());
   }
@@ -337,7 +337,7 @@ TEST(ErasureCodeTest, create_ruleset)
     profile["m"] = "2";
     profile["w"] = "8";
     profile["ruleset-failure-domain"] = "WORSE";
-    jerasure.init(profile);
+    jerasure.init(profile, &cerr);
     EXPECT_EQ(-EINVAL, jerasure.create_ruleset("otherrule", *c, &ss));
     EXPECT_EQ("unknown type WORSE", ss.str());
   }

--- a/src/test/erasure-code/TestErasureCodeJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodeJerasure.cc
@@ -48,13 +48,13 @@ TYPED_TEST(ErasureCodeTest, encode_decode)
        per_chunk_alignment < 2;
        per_chunk_alignment++) {
     TypeParam jerasure;
-    map<std::string,std::string> parameters;
-    parameters["k"] = "2";
-    parameters["m"] = "2";
-    parameters["packetsize"] = "8";
-    parameters["jerasure-per-chunk-alignment"] =
+    ErasureCodeProfile profile;
+    profile["k"] = "2";
+    profile["m"] = "2";
+    profile["packetsize"] = "8";
+    profile["jerasure-per-chunk-alignment"] =
       per_chunk_alignments[per_chunk_alignment];
-    jerasure.init(parameters);
+    jerasure.init(profile);
 
 #define LARGE_ENOUGH 2048
     bufferptr in_ptr(buffer::create_page_aligned(LARGE_ENOUGH));
@@ -119,12 +119,12 @@ TYPED_TEST(ErasureCodeTest, encode_decode)
 TYPED_TEST(ErasureCodeTest, minimum_to_decode)
 {
   TypeParam jerasure;
-  map<std::string,std::string> parameters;
-  parameters["k"] = "2";
-  parameters["m"] = "2";
-  parameters["w"] = "7";
-  parameters["packetsize"] = "8";
-  jerasure.init(parameters);
+  ErasureCodeProfile profile;
+  profile["k"] = "2";
+  profile["m"] = "2";
+  profile["w"] = "7";
+  profile["packetsize"] = "8";
+  jerasure.init(profile);
 
   //
   // If trying to read nothing, the minimum is empty.
@@ -217,11 +217,11 @@ TYPED_TEST(ErasureCodeTest, minimum_to_decode)
 TEST(ErasureCodeTest, encode)
 {
   ErasureCodeJerasureReedSolomonVandermonde jerasure;
-  map<std::string,std::string> parameters;
-  parameters["k"] = "2";
-  parameters["m"] = "2";
-  parameters["w"] = "8";
-  jerasure.init(parameters);
+  ErasureCodeProfile profile;
+  profile["k"] = "2";
+  profile["m"] = "2";
+  profile["w"] = "8";
+  jerasure.init(profile);
 
   unsigned aligned_object_size = jerasure.get_alignment() * 2;
   {
@@ -296,11 +296,11 @@ TEST(ErasureCodeTest, create_ruleset)
   {
     stringstream ss;
     ErasureCodeJerasureReedSolomonVandermonde jerasure;
-    map<std::string,std::string> parameters;
-    parameters["k"] = "2";
-    parameters["m"] = "2";
-    parameters["w"] = "8";
-    jerasure.init(parameters);
+    ErasureCodeProfile profile;
+    profile["k"] = "2";
+    profile["m"] = "2";
+    profile["w"] = "8";
+    jerasure.init(profile);
     int ruleset = jerasure.create_ruleset("myrule", *c, &ss);
     EXPECT_EQ(0, ruleset);
     EXPECT_EQ(-EEXIST, jerasure.create_ruleset("myrule", *c, &ss));
@@ -320,24 +320,24 @@ TEST(ErasureCodeTest, create_ruleset)
   {
     stringstream ss;
     ErasureCodeJerasureReedSolomonVandermonde jerasure;
-    map<std::string,std::string> parameters;
-    parameters["k"] = "2";
-    parameters["m"] = "2";
-    parameters["w"] = "8";
-    parameters["ruleset-root"] = "BAD";
-    jerasure.init(parameters);
+    ErasureCodeProfile profile;
+    profile["k"] = "2";
+    profile["m"] = "2";
+    profile["w"] = "8";
+    profile["ruleset-root"] = "BAD";
+    jerasure.init(profile);
     EXPECT_EQ(-ENOENT, jerasure.create_ruleset("otherrule", *c, &ss));
     EXPECT_EQ("root item BAD does not exist", ss.str());
   }
   {
     stringstream ss;
     ErasureCodeJerasureReedSolomonVandermonde jerasure;
-    map<std::string,std::string> parameters;
-    parameters["k"] = "2";
-    parameters["m"] = "2";
-    parameters["w"] = "8";
-    parameters["ruleset-failure-domain"] = "WORSE";
-    jerasure.init(parameters);
+    ErasureCodeProfile profile;
+    profile["k"] = "2";
+    profile["m"] = "2";
+    profile["w"] = "8";
+    profile["ruleset-failure-domain"] = "WORSE";
+    jerasure.init(profile);
     EXPECT_EQ(-EINVAL, jerasure.create_ruleset("otherrule", *c, &ss));
     EXPECT_EQ("unknown type WORSE", ss.str());
   }
@@ -359,7 +359,7 @@ int main(int argc, char **argv)
  * Local Variables:
  * compile-command: "cd ../.. ;
  *   make -j4 unittest_erasure_code_jerasure &&
- *   valgrind --tool=memcheck --leak-check=full \
+ *   valgrind --tool=memcheck \
  *      ./unittest_erasure_code_jerasure \
  *      --gtest_filter=*.* --log-to-stderr=true --debug-osd=20"
  * End:

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -32,47 +32,47 @@ TEST(ErasureCodeLrc, parse_ruleset)
   EXPECT_EQ("default", lrc.ruleset_root);
   EXPECT_EQ("host", lrc.ruleset_steps.front().type);
 
-  map<std::string,std::string> parameters;
-  parameters["ruleset-root"] = "other";
-  EXPECT_EQ(0, lrc.parse_ruleset(parameters, &cerr));
+  ErasureCodeProfile profile;
+  profile["ruleset-root"] = "other";
+  EXPECT_EQ(0, lrc.parse_ruleset(profile, &cerr));
   EXPECT_EQ("other", lrc.ruleset_root);
 
-  parameters["ruleset-steps"] = "[]";
-  EXPECT_EQ(0, lrc.parse_ruleset(parameters, &cerr));
+  profile["ruleset-steps"] = "[]";
+  EXPECT_EQ(0, lrc.parse_ruleset(profile, &cerr));
   EXPECT_TRUE(lrc.ruleset_steps.empty());
 
-  parameters["ruleset-steps"] = "0";
-  EXPECT_EQ(ERROR_LRC_ARRAY, lrc.parse_ruleset(parameters, &cerr));
+  profile["ruleset-steps"] = "0";
+  EXPECT_EQ(ERROR_LRC_ARRAY, lrc.parse_ruleset(profile, &cerr));
 
-  parameters["ruleset-steps"] = "{";
-  EXPECT_EQ(ERROR_LRC_PARSE_JSON, lrc.parse_ruleset(parameters, &cerr));
+  profile["ruleset-steps"] = "{";
+  EXPECT_EQ(ERROR_LRC_PARSE_JSON, lrc.parse_ruleset(profile, &cerr));
 
-  parameters["ruleset-steps"] = "[0]";
-  EXPECT_EQ(ERROR_LRC_ARRAY, lrc.parse_ruleset(parameters, &cerr));
+  profile["ruleset-steps"] = "[0]";
+  EXPECT_EQ(ERROR_LRC_ARRAY, lrc.parse_ruleset(profile, &cerr));
 
-  parameters["ruleset-steps"] = "[[0]]";
-  EXPECT_EQ(ERROR_LRC_RULESET_OP, lrc.parse_ruleset(parameters, &cerr));
+  profile["ruleset-steps"] = "[[0]]";
+  EXPECT_EQ(ERROR_LRC_RULESET_OP, lrc.parse_ruleset(profile, &cerr));
 
-  parameters["ruleset-steps"] = "[[\"choose\", 0]]";
-  EXPECT_EQ(ERROR_LRC_RULESET_TYPE, lrc.parse_ruleset(parameters, &cerr));
+  profile["ruleset-steps"] = "[[\"choose\", 0]]";
+  EXPECT_EQ(ERROR_LRC_RULESET_TYPE, lrc.parse_ruleset(profile, &cerr));
 
-  parameters["ruleset-steps"] = "[[\"choose\", \"host\", []]]";
-  EXPECT_EQ(ERROR_LRC_RULESET_N, lrc.parse_ruleset(parameters, &cerr));
+  profile["ruleset-steps"] = "[[\"choose\", \"host\", []]]";
+  EXPECT_EQ(ERROR_LRC_RULESET_N, lrc.parse_ruleset(profile, &cerr));
 
-  parameters["ruleset-steps"] = "[[\"choose\", \"host\", 2]]";
-  EXPECT_EQ(0, lrc.parse_ruleset(parameters, &cerr));
+  profile["ruleset-steps"] = "[[\"choose\", \"host\", 2]]";
+  EXPECT_EQ(0, lrc.parse_ruleset(profile, &cerr));
 
   const ErasureCodeLrc::Step &step = lrc.ruleset_steps.front();
   EXPECT_EQ("choose", step.op);
   EXPECT_EQ("host", step.type);
   EXPECT_EQ(2, step.n);
 
-  parameters["ruleset-steps"] =
+  profile["ruleset-steps"] =
     "["
     " [\"choose\", \"rack\", 2], "
     " [\"chooseleaf\", \"host\", 5], "
     "]";
-  EXPECT_EQ(0, lrc.parse_ruleset(parameters, &cerr));
+  EXPECT_EQ(0, lrc.parse_ruleset(profile, &cerr));
   EXPECT_EQ(2U, lrc.ruleset_steps.size());
   {
     const ErasureCodeLrc::Step &step = lrc.ruleset_steps[0];
@@ -131,16 +131,16 @@ TEST(ErasureCodeTest, create_ruleset)
   ErasureCodeLrc lrc;
   EXPECT_EQ(0, lrc.create_ruleset("rule1", *c, &cerr));
 
-  map<std::string,std::string> parameters;
+  ErasureCodeProfile profile;
   unsigned int racks = 2;
   unsigned int hosts = 5;
-  parameters["ruleset-steps"] =
+  profile["ruleset-steps"] =
     "["
     " [\"choose\", \"rack\", " + stringify(racks) + "], "
     " [\"chooseleaf\", \"host\", " + stringify(hosts) + "], "
     "]";
   const char *rule_name = "rule2";
-  EXPECT_EQ(0, lrc.parse_ruleset(parameters, &cerr));
+  EXPECT_EQ(0, lrc.parse_ruleset(profile, &cerr));
   EXPECT_EQ(1, lrc.create_ruleset(rule_name, *c, &cerr));
 
   vector<__u32> weight;
@@ -170,67 +170,67 @@ TEST(ErasureCodeTest, create_ruleset)
 TEST(ErasureCodeLrc, parse_kml)
 {
   ErasureCodeLrc lrc;
-  map<std::string,std::string> parameters;
-  EXPECT_EQ(0, lrc.parse_kml(parameters, &cerr));
-  parameters["k"] = "4";
-  EXPECT_EQ(ERROR_LRC_ALL_OR_NOTHING, lrc.parse_kml(parameters, &cerr));
+  ErasureCodeProfile profile;
+  EXPECT_EQ(0, lrc.parse_kml(profile, &cerr));
+  profile["k"] = "4";
+  EXPECT_EQ(ERROR_LRC_ALL_OR_NOTHING, lrc.parse_kml(profile, &cerr));
   const char *generated[] = { "mapping",
 			      "layers",
 			      "ruleset-steps" };
-  parameters["m"] = "2";
-  parameters["l"] = "3";
+  profile["m"] = "2";
+  profile["l"] = "3";
 
   for (int i = 0; i < 3; i++) {
-    parameters[generated[i]] = "SET";
-    EXPECT_EQ(ERROR_LRC_GENERATED, lrc.parse_kml(parameters, &cerr));
-    parameters.erase(parameters.find(generated[i]));
+    profile[generated[i]] = "SET";
+    EXPECT_EQ(ERROR_LRC_GENERATED, lrc.parse_kml(profile, &cerr));
+    profile.erase(profile.find(generated[i]));
   }
 
-  parameters["k"] = "4";
-  parameters["m"] = "2";
-  parameters["l"] = "7";
-  EXPECT_EQ(ERROR_LRC_K_M_MODULO, lrc.parse_kml(parameters, &cerr));
+  profile["k"] = "4";
+  profile["m"] = "2";
+  profile["l"] = "7";
+  EXPECT_EQ(ERROR_LRC_K_M_MODULO, lrc.parse_kml(profile, &cerr));
 
-  parameters["k"] = "3";
-  parameters["m"] = "3";
-  parameters["l"] = "3";
-  EXPECT_EQ(ERROR_LRC_K_MODULO, lrc.parse_kml(parameters, &cerr));
+  profile["k"] = "3";
+  profile["m"] = "3";
+  profile["l"] = "3";
+  EXPECT_EQ(ERROR_LRC_K_MODULO, lrc.parse_kml(profile, &cerr));
 
-  parameters["k"] = "4";
-  parameters["m"] = "2";
-  parameters["l"] = "3";
-  EXPECT_EQ(0, lrc.parse_kml(parameters, &cerr));
+  profile["k"] = "4";
+  profile["m"] = "2";
+  profile["l"] = "3";
+  EXPECT_EQ(0, lrc.parse_kml(profile, &cerr));
   EXPECT_EQ("[ "
 	    " [ \"DDc_DDc_\", \"\" ],"
 	    " [ \"DDDc____\", \"\" ],"
 	    " [ \"____DDDc\", \"\" ],"
-	    "]", parameters["layers"]);
-  EXPECT_EQ("DD__DD__", parameters["mapping"]);
+	    "]", profile["layers"]);
+  EXPECT_EQ("DD__DD__", profile["mapping"]);
   EXPECT_EQ("chooseleaf", lrc.ruleset_steps[0].op);
   EXPECT_EQ("host", lrc.ruleset_steps[0].type);
   EXPECT_EQ(0, lrc.ruleset_steps[0].n);
   EXPECT_EQ(1U, lrc.ruleset_steps.size());
-  parameters.erase(parameters.find("mapping"));
-  parameters.erase(parameters.find("layers"));
+  profile.erase(profile.find("mapping"));
+  profile.erase(profile.find("layers"));
 
-  parameters["k"] = "4";
-  parameters["m"] = "2";
-  parameters["l"] = "3";
-  parameters["ruleset-failure-domain"] = "osd";
-  EXPECT_EQ(0, lrc.parse_kml(parameters, &cerr));
+  profile["k"] = "4";
+  profile["m"] = "2";
+  profile["l"] = "3";
+  profile["ruleset-failure-domain"] = "osd";
+  EXPECT_EQ(0, lrc.parse_kml(profile, &cerr));
   EXPECT_EQ("chooseleaf", lrc.ruleset_steps[0].op);
   EXPECT_EQ("osd", lrc.ruleset_steps[0].type);
   EXPECT_EQ(0, lrc.ruleset_steps[0].n);
   EXPECT_EQ(1U, lrc.ruleset_steps.size());
-  parameters.erase(parameters.find("mapping"));
-  parameters.erase(parameters.find("layers"));
+  profile.erase(profile.find("mapping"));
+  profile.erase(profile.find("layers"));
 
-  parameters["k"] = "4";
-  parameters["m"] = "2";
-  parameters["l"] = "3";
-  parameters["ruleset-failure-domain"] = "osd";
-  parameters["ruleset-locality"] = "rack";
-  EXPECT_EQ(0, lrc.parse_kml(parameters, &cerr));
+  profile["k"] = "4";
+  profile["m"] = "2";
+  profile["l"] = "3";
+  profile["ruleset-failure-domain"] = "osd";
+  profile["ruleset-locality"] = "rack";
+  EXPECT_EQ(0, lrc.parse_kml(profile, &cerr));
   EXPECT_EQ("choose", lrc.ruleset_steps[0].op);
   EXPECT_EQ("rack", lrc.ruleset_steps[0].type);
   EXPECT_EQ(2, lrc.ruleset_steps[0].n);
@@ -238,35 +238,35 @@ TEST(ErasureCodeLrc, parse_kml)
   EXPECT_EQ("osd", lrc.ruleset_steps[1].type);
   EXPECT_EQ(4, lrc.ruleset_steps[1].n);
   EXPECT_EQ(2U, lrc.ruleset_steps.size());
-  parameters.erase(parameters.find("mapping"));
-  parameters.erase(parameters.find("layers"));
+  profile.erase(profile.find("mapping"));
+  profile.erase(profile.find("layers"));
 }
 
 TEST(ErasureCodeLrc, layers_description)
 {
   ErasureCodeLrc lrc;
-  map<std::string,std::string> parameters;
+  ErasureCodeProfile profile;
 
   json_spirit::mArray description;
   EXPECT_EQ(ERROR_LRC_DESCRIPTION,
-	    lrc.layers_description(parameters, &description, &cerr));
+	    lrc.layers_description(profile, &description, &cerr));
 
   {
     const char *description_string = "\"not an array\"";
-    parameters["layers"] = description_string;
+    profile["layers"] = description_string;
     EXPECT_EQ(ERROR_LRC_ARRAY,
-	      lrc.layers_description(parameters, &description, &cerr));
+	      lrc.layers_description(profile, &description, &cerr));
   }
   {
     const char *description_string = "invalid json";
-    parameters["layers"] = description_string;
+    profile["layers"] = description_string;
     EXPECT_EQ(ERROR_LRC_PARSE_JSON,
-	      lrc.layers_description(parameters, &description, &cerr));
+	      lrc.layers_description(profile, &description, &cerr));
   }
   {
     const char *description_string = "[]";
-    parameters["layers"] = description_string;
-    EXPECT_EQ(0, lrc.layers_description(parameters, &description, &cerr));
+    profile["layers"] = description_string;
+    EXPECT_EQ(0, lrc.layers_description(profile, &description, &cerr));
   }
 }
 
@@ -274,71 +274,71 @@ TEST(ErasureCodeLrc, layers_parse)
 {
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
+    ErasureCodeProfile profile;
 
     const char *description_string ="[ 0 ]";
-    parameters["layers"] = description_string;
+    profile["layers"] = description_string;
     json_spirit::mArray description;
-    EXPECT_EQ(0, lrc.layers_description(parameters, &description, &cerr));
+    EXPECT_EQ(0, lrc.layers_description(profile, &description, &cerr));
     EXPECT_EQ(ERROR_LRC_ARRAY,
 	      lrc.layers_parse(description_string, description, &cerr));
   }
 
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
+    ErasureCodeProfile profile;
 
     const char *description_string ="[ [ 0 ] ]";
-    parameters["layers"] = description_string;
+    profile["layers"] = description_string;
     json_spirit::mArray description;
-    EXPECT_EQ(0, lrc.layers_description(parameters, &description, &cerr));
+    EXPECT_EQ(0, lrc.layers_description(profile, &description, &cerr));
     EXPECT_EQ(ERROR_LRC_STR,
 	      lrc.layers_parse(description_string, description, &cerr));
   }
 
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
+    ErasureCodeProfile profile;
 
     const char *description_string ="[ [ \"\", 0 ] ]";
-    parameters["layers"] = description_string;
+    profile["layers"] = description_string;
     json_spirit::mArray description;
-    EXPECT_EQ(0, lrc.layers_description(parameters, &description, &cerr));
+    EXPECT_EQ(0, lrc.layers_description(profile, &description, &cerr));
     EXPECT_EQ(ERROR_LRC_CONFIG_OPTIONS,
 	      lrc.layers_parse(description_string, description, &cerr));
   }
 
   //
   // The second element can be an object describing the plugin
-  // parameters.
+  // profile.
   //
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
+    ErasureCodeProfile profile;
 
     const char *description_string ="[ [ \"\", { \"a\": \"b\" }, \"ignored\" ] ]";
-    parameters["layers"] = description_string;
+    profile["layers"] = description_string;
     json_spirit::mArray description;
-    EXPECT_EQ(0, lrc.layers_description(parameters, &description, &cerr));
+    EXPECT_EQ(0, lrc.layers_description(profile, &description, &cerr));
     EXPECT_EQ(0, lrc.layers_parse(description_string, description, &cerr));
-    EXPECT_EQ("b", lrc.layers.front().parameters["a"]);
+    EXPECT_EQ("b", lrc.layers.front().profile["a"]);
   }
 
   //
   // The second element can be a str_map parseable string describing the plugin
-  // parameters.
+  // profile.
   //
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
+    ErasureCodeProfile profile;
 
     const char *description_string ="[ [ \"\", \"a=b c=d\" ] ]";
-    parameters["layers"] = description_string;
+    profile["layers"] = description_string;
     json_spirit::mArray description;
-    EXPECT_EQ(0, lrc.layers_description(parameters, &description, &cerr));
+    EXPECT_EQ(0, lrc.layers_description(profile, &description, &cerr));
     EXPECT_EQ(0, lrc.layers_parse(description_string, description, &cerr));
-    EXPECT_EQ("b", lrc.layers.front().parameters["a"]);
-    EXPECT_EQ("d", lrc.layers.front().parameters["c"]);
+    EXPECT_EQ("b", lrc.layers.front().profile["a"]);
+    EXPECT_EQ("d", lrc.layers.front().profile["c"]);
   }
 
 }
@@ -347,43 +347,43 @@ TEST(ErasureCodeLrc, layers_sanity_checks)
 {
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
-    parameters["mapping"] =
+    ErasureCodeProfile profile;
+    profile["mapping"] =
 	    "__DDD__DD";
-    parameters["directory"] = ".libs";
+    profile["directory"] = ".libs";
     const char *description_string =
       "[ "
       "  [ \"_cDDD_cDD\", \"\" ],"
       "  [ \"c_DDD____\", \"\" ],"
       "  [ \"_____cDDD\", \"\" ],"
       "]";
-    parameters["layers"] = description_string;
-    EXPECT_EQ(0, lrc.init(parameters, &cerr));
+    profile["layers"] = description_string;
+    EXPECT_EQ(0, lrc.init(profile, &cerr));
   }
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
+    ErasureCodeProfile profile;
     const char *description_string =
       "[ "
       "]";
-    parameters["layers"] = description_string;
-    EXPECT_EQ(ERROR_LRC_MAPPING, lrc.init(parameters, &cerr));
+    profile["layers"] = description_string;
+    EXPECT_EQ(ERROR_LRC_MAPPING, lrc.init(profile, &cerr));
   }
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
-    parameters["mapping"] = "";
+    ErasureCodeProfile profile;
+    profile["mapping"] = "";
     const char *description_string =
       "[ "
       "]";
-    parameters["layers"] = description_string;
-    EXPECT_EQ(ERROR_LRC_LAYERS_COUNT, lrc.init(parameters, &cerr));
+    profile["layers"] = description_string;
+    EXPECT_EQ(ERROR_LRC_LAYERS_COUNT, lrc.init(profile, &cerr));
   }
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
-    parameters["directory"] = ".libs";
-    parameters["mapping"] =
+    ErasureCodeProfile profile;
+    profile["directory"] = ".libs";
+    profile["mapping"] =
 	    "AA";
     const char *description_string =
       "[ "
@@ -391,8 +391,8 @@ TEST(ErasureCodeLrc, layers_sanity_checks)
       "  [ \"AA\", \"\" ], "
       "  [ \"AA\", \"\" ], "
       "]";
-    parameters["layers"] = description_string;
-    EXPECT_EQ(ERROR_LRC_MAPPING_SIZE, lrc.init(parameters, &cerr));
+    profile["layers"] = description_string;
+    EXPECT_EQ(ERROR_LRC_MAPPING_SIZE, lrc.init(profile, &cerr));
   }
 }
 
@@ -400,30 +400,30 @@ TEST(ErasureCodeLrc, layers_init)
 {
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
+    ErasureCodeProfile profile;
 
     const char *description_string =
       "[ "
       "  [ \"_cDDD_cDD_\", \"directory=.libs\" ],"
       "]";
-    parameters["layers"] = description_string;
-    parameters["directory"] = ".libs";
+    profile["layers"] = description_string;
+    profile["directory"] = ".libs";
     json_spirit::mArray description;
-    EXPECT_EQ(0, lrc.layers_description(parameters, &description, &cerr));
+    EXPECT_EQ(0, lrc.layers_description(profile, &description, &cerr));
     EXPECT_EQ(0, lrc.layers_parse(description_string, description, &cerr));
     EXPECT_EQ(0, lrc.layers_init());
-    EXPECT_EQ("5", lrc.layers.front().parameters["k"]);
-    EXPECT_EQ("2", lrc.layers.front().parameters["m"]);
-    EXPECT_EQ("jerasure", lrc.layers.front().parameters["plugin"]);
-    EXPECT_EQ("reed_sol_van", lrc.layers.front().parameters["technique"]);
+    EXPECT_EQ("5", lrc.layers.front().profile["k"]);
+    EXPECT_EQ("2", lrc.layers.front().profile["m"]);
+    EXPECT_EQ("jerasure", lrc.layers.front().profile["plugin"]);
+    EXPECT_EQ("reed_sol_van", lrc.layers.front().profile["technique"]);
   }
 }
 
 TEST(ErasureCodeLrc, init)
 {
   ErasureCodeLrc lrc;
-  map<std::string,std::string> parameters;
-  parameters["mapping"] =
+  ErasureCodeProfile profile;
+  profile["mapping"] =
     "__DDD__DD";
   const char *description_string =
     "[ "
@@ -431,20 +431,20 @@ TEST(ErasureCodeLrc, init)
     "  [ \"c_DDD____\", \"\" ],"
     "  [ \"_____cDDD\", \"\" ],"
     "]";
-  parameters["layers"] = description_string;
-  parameters["directory"] = ".libs";
-  EXPECT_EQ(0, lrc.init(parameters, &cerr));
+  profile["layers"] = description_string;
+  profile["directory"] = ".libs";
+  EXPECT_EQ(0, lrc.init(profile, &cerr));
 }
 
 TEST(ErasureCodeLrc, init_kml)
 {
   ErasureCodeLrc lrc;
-  map<std::string,std::string> parameters;
-  parameters["k"] = "4";
-  parameters["m"] = "2";
-  parameters["l"] = "3";
-  parameters["directory"] = ".libs";
-  EXPECT_EQ(0, lrc.init(parameters, &cerr));
+  ErasureCodeProfile profile;
+  profile["k"] = "4";
+  profile["m"] = "2";
+  profile["l"] = "3";
+  profile["directory"] = ".libs";
+  EXPECT_EQ(0, lrc.init(profile, &cerr));
   EXPECT_EQ((unsigned int)(4 + 2 + (4 + 2) / 3), lrc.get_chunk_count());
 }
 
@@ -453,8 +453,8 @@ TEST(ErasureCodeLrc, minimum_to_decode)
   // trivial : no erasures, the minimum is want_to_read
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
-    parameters["mapping"] =
+    ErasureCodeProfile profile;
+    profile["mapping"] =
       "__DDD__DD";
     const char *description_string =
       "[ "
@@ -462,9 +462,9 @@ TEST(ErasureCodeLrc, minimum_to_decode)
       "  [ \"c_DDD____\", \"\" ],"
       "  [ \"_____cDDD\", \"\" ],"
       "]";
-    parameters["layers"] = description_string;
-    parameters["directory"] = ".libs";
-    EXPECT_EQ(0, lrc.init(parameters, &cerr));
+    profile["layers"] = description_string;
+    profile["directory"] = ".libs";
+    EXPECT_EQ(0, lrc.init(profile, &cerr));
     set<int> want_to_read;
     want_to_read.insert(1);
     set<int> available_chunks;
@@ -477,8 +477,8 @@ TEST(ErasureCodeLrc, minimum_to_decode)
   // locally repairable erasure
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
-    parameters["mapping"] =
+    ErasureCodeProfile profile;
+    profile["mapping"] =
 	    "__DDD__DD_";
     const char *description_string =
       "[ "
@@ -487,10 +487,10 @@ TEST(ErasureCodeLrc, minimum_to_decode)
       "  [ \"_____cDDD_\", \"\" ],"
       "  [ \"_____DDDDc\", \"\" ],"
       "]";
-    parameters["layers"] = description_string;
-    parameters["directory"] = ".libs";
-    EXPECT_EQ(0, lrc.init(parameters, &cerr));
-    EXPECT_EQ(parameters["mapping"].length(),
+    profile["layers"] = description_string;
+    profile["directory"] = ".libs";
+    EXPECT_EQ(0, lrc.init(profile, &cerr));
+    EXPECT_EQ(profile["mapping"].length(),
 	      lrc.get_chunk_count());
     {
       // want to read the last chunk
@@ -528,8 +528,8 @@ TEST(ErasureCodeLrc, minimum_to_decode)
   // implicit parity required
   {
     ErasureCodeLrc lrc;
-    map<std::string,std::string> parameters;
-    parameters["mapping"] =
+    ErasureCodeProfile profile;
+    profile["mapping"] =
 	    "__DDD__DD";
     const char *description_string =
       "[ "
@@ -537,10 +537,10 @@ TEST(ErasureCodeLrc, minimum_to_decode)
       "  [ \"c_DDD____\", \"\" ],"
       "  [ \"_____cDDD\", \"\" ],"
       "]";
-    parameters["layers"] = description_string;
-    parameters["directory"] = ".libs";
-    EXPECT_EQ(0, lrc.init(parameters, &cerr));
-    EXPECT_EQ(parameters["mapping"].length(),
+    profile["layers"] = description_string;
+    profile["directory"] = ".libs";
+    EXPECT_EQ(0, lrc.init(profile, &cerr));
+    EXPECT_EQ(profile["mapping"].length(),
 	      lrc.get_chunk_count());
     set<int> want_to_read;
     want_to_read.insert(8);
@@ -607,8 +607,8 @@ TEST(ErasureCodeLrc, minimum_to_decode)
 TEST(ErasureCodeLrc, encode_decode)
 {
   ErasureCodeLrc lrc;
-  map<std::string,std::string> parameters;
-  parameters["mapping"] =
+  ErasureCodeProfile profile;
+  profile["mapping"] =
     "__DD__DD";
   const char *description_string =
     "[ "
@@ -616,9 +616,9 @@ TEST(ErasureCodeLrc, encode_decode)
     "  [ \"c_DD____\", \"\" ]," // first local layer
     "  [ \"____cDDD\", \"\" ]," // second local layer
     "]";
-  parameters["layers"] = description_string;
-  parameters["directory"] = ".libs";
-  EXPECT_EQ(0, lrc.init(parameters, &cerr));
+  profile["layers"] = description_string;
+  profile["directory"] = ".libs";
+  EXPECT_EQ(0, lrc.init(profile, &cerr));
   EXPECT_EQ(4U, lrc.get_data_chunk_count());
   unsigned int stripe_width = g_conf->osd_pool_erasure_code_stripe_width;
   unsigned int chunk_size = stripe_width / lrc.get_data_chunk_count();
@@ -738,8 +738,8 @@ TEST(ErasureCodeLrc, encode_decode)
 TEST(ErasureCodeLrc, encode_decode_2)
 {
   ErasureCodeLrc lrc;
-  map<std::string,std::string> parameters;
-  parameters["mapping"] =
+  ErasureCodeProfile profile;
+  profile["mapping"] =
     "DD__DD__";
   const char *description_string =
     "[ "
@@ -747,9 +747,9 @@ TEST(ErasureCodeLrc, encode_decode_2)
     " [ \"DDDc____\", \"\" ],"
     " [ \"____DDDc\", \"\" ],"
     "]";
-  parameters["layers"] = description_string;
-  parameters["directory"] = ".libs";
-  EXPECT_EQ(0, lrc.init(parameters, &cerr));
+  profile["layers"] = description_string;
+  profile["directory"] = ".libs";
+  EXPECT_EQ(0, lrc.init(profile, &cerr));
   EXPECT_EQ(4U, lrc.get_data_chunk_count());
   unsigned int stripe_width = g_conf->osd_pool_erasure_code_stripe_width;
   unsigned int chunk_size = stripe_width / lrc.get_data_chunk_count();
@@ -929,7 +929,7 @@ int main(int argc, char **argv)
 /*
  * Local Variables:
  * compile-command: "cd ../.. ;
- *   make -j4 && valgrind --tool=memcheck --leak-check=full \
+ *   make -j4 unittest_erasure_code_lrc && valgrind --tool=memcheck \
  *      ./unittest_erasure_code_lrc \
  *      --gtest_filter=*.* --log-to-stderr=true --debug-osd=20"
  * End:

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -384,12 +384,12 @@ TEST(ErasureCodeLrc, layers_sanity_checks)
     ErasureCodeProfile profile;
     profile["directory"] = ".libs";
     profile["mapping"] =
-	    "AA";
+	    "DD";
     const char *description_string =
       "[ "
-      "  [ \"AA??\", \"\" ], "
-      "  [ \"AA\", \"\" ], "
-      "  [ \"AA\", \"\" ], "
+      "  [ \"DD??\", \"\" ], "
+      "  [ \"DD\", \"\" ], "
+      "  [ \"DD\", \"\" ], "
       "]";
     profile["layers"] = description_string;
     EXPECT_EQ(ERROR_LRC_MAPPING_SIZE, lrc.init(profile, &cerr));

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -411,7 +411,7 @@ TEST(ErasureCodeLrc, layers_init)
     json_spirit::mArray description;
     EXPECT_EQ(0, lrc.layers_description(profile, &description, &cerr));
     EXPECT_EQ(0, lrc.layers_parse(description_string, description, &cerr));
-    EXPECT_EQ(0, lrc.layers_init());
+    EXPECT_EQ(0, lrc.layers_init(&cerr));
     EXPECT_EQ("5", lrc.layers.front().profile["k"]);
     EXPECT_EQ("2", lrc.layers.front().profile["m"]);
     EXPECT_EQ("jerasure", lrc.layers.front().profile["plugin"]);

--- a/src/test/erasure-code/TestErasureCodePlugin.cc
+++ b/src/test/erasure-code/TestErasureCodePlugin.cc
@@ -34,8 +34,7 @@ protected:
       profile["directory"] = ".libs";
       ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
       ErasureCodeInterfaceRef erasure_code;
-      stringstream ss;
-      instance.factory("hangs", profile, &erasure_code, ss);
+      instance.factory("hangs", profile, &erasure_code, &cerr);
       return NULL;
     }
   };
@@ -77,31 +76,30 @@ TEST_F(ErasureCodePluginRegistryTest, all)
   profile["directory"] = directory;
   ErasureCodeInterfaceRef erasure_code;
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
-  stringstream ss;
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-EIO, instance.factory("invalid", profile, &erasure_code, ss));
+  EXPECT_EQ(-EIO, instance.factory("invalid", profile, &erasure_code, &cerr));
   EXPECT_FALSE(erasure_code);
   EXPECT_EQ(-EXDEV, instance.factory("missing_version", profile,
-				     &erasure_code, ss));
+				     &erasure_code, &cerr));
   EXPECT_FALSE(erasure_code);
   EXPECT_EQ(-ENOENT, instance.factory("missing_entry_point", profile,
-				      &erasure_code, ss));
+				      &erasure_code, &cerr));
   EXPECT_FALSE(erasure_code);
   EXPECT_EQ(-ESRCH, instance.factory("fail_to_initialize", profile,
-				     &erasure_code, ss));
+				     &erasure_code, &cerr));
   EXPECT_FALSE(erasure_code);
   EXPECT_EQ(-EBADF, instance.factory("fail_to_register", profile,
-				     &erasure_code, ss));
+				     &erasure_code, &cerr));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(0, instance.factory("example", profile, &erasure_code, ss));
+  EXPECT_EQ(0, instance.factory("example", profile, &erasure_code, &cerr));
   EXPECT_TRUE(erasure_code);
   ErasureCodePlugin *plugin = 0;
   {
     Mutex::Locker l(instance.lock);
-    EXPECT_EQ(-EEXIST, instance.load("example", directory, &plugin, ss));
+    EXPECT_EQ(-EEXIST, instance.load("example", directory, &plugin, &cerr));
     EXPECT_EQ(-ENOENT, instance.remove("does not exist"));
     EXPECT_EQ(0, instance.remove("example"));
-    EXPECT_EQ(0, instance.load("example", directory, &plugin, ss));
+    EXPECT_EQ(0, instance.load("example", directory, &plugin, &cerr));
   }
 }
 

--- a/src/test/erasure-code/TestErasureCodePlugin.cc
+++ b/src/test/erasure-code/TestErasureCodePlugin.cc
@@ -30,12 +30,12 @@ protected:
   class Thread_factory : public Thread {
   public:
     virtual void *entry() {
-      map<std::string,std::string> parameters;
-      parameters["directory"] = ".libs";
+      ErasureCodeProfile profile;
+      profile["directory"] = ".libs";
       ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
       ErasureCodeInterfaceRef erasure_code;
       stringstream ss;
-      instance.factory("hangs", parameters, &erasure_code, ss);
+      instance.factory("hangs", profile, &erasure_code, ss);
       return NULL;
     }
   };
@@ -72,28 +72,28 @@ TEST_F(ErasureCodePluginRegistryTest, factory_mutex) {
 
 TEST_F(ErasureCodePluginRegistryTest, all)
 {
-  map<std::string,std::string> parameters;
+  ErasureCodeProfile profile;
   string directory(".libs");
-  parameters["directory"] = directory;
+  profile["directory"] = directory;
   ErasureCodeInterfaceRef erasure_code;
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   stringstream ss;
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-EIO, instance.factory("invalid", parameters, &erasure_code, ss));
+  EXPECT_EQ(-EIO, instance.factory("invalid", profile, &erasure_code, ss));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-EXDEV, instance.factory("missing_version", parameters,
+  EXPECT_EQ(-EXDEV, instance.factory("missing_version", profile,
 				     &erasure_code, ss));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-ENOENT, instance.factory("missing_entry_point", parameters,
+  EXPECT_EQ(-ENOENT, instance.factory("missing_entry_point", profile,
 				      &erasure_code, ss));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-ESRCH, instance.factory("fail_to_initialize", parameters,
+  EXPECT_EQ(-ESRCH, instance.factory("fail_to_initialize", profile,
 				     &erasure_code, ss));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-EBADF, instance.factory("fail_to_register", parameters,
+  EXPECT_EQ(-EBADF, instance.factory("fail_to_register", profile,
 				     &erasure_code, ss));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(0, instance.factory("example", parameters, &erasure_code, ss));
+  EXPECT_EQ(0, instance.factory("example", profile, &erasure_code, ss));
   EXPECT_TRUE(erasure_code);
   ErasureCodePlugin *plugin = 0;
   {
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
  * Local Variables:
  * compile-command: "cd ../.. ; make -j4 && 
  *   make unittest_erasure_code_plugin && 
- *   valgrind  --leak-check=full --tool=memcheck \
+ *   valgrind --tool=memcheck \
  *      ./unittest_erasure_code_plugin \
  *      --gtest_filter=*.* --log-to-stderr=true --debug-osd=20"
  * End:

--- a/src/test/erasure-code/TestErasureCodePluginIsa.cc
+++ b/src/test/erasure-code/TestErasureCodePluginIsa.cc
@@ -30,7 +30,7 @@ TEST(ErasureCodePlugin, factory)
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
     EXPECT_EQ(-EIO, instance.factory("no-isa", profile,
-                                        &erasure_code, cerr));
+                                        &erasure_code, &cerr));
     EXPECT_FALSE(erasure_code);
   }
   const char *techniques[] = {
@@ -42,7 +42,7 @@ TEST(ErasureCodePlugin, factory)
     profile["technique"] = *technique;
     EXPECT_FALSE(erasure_code);
     EXPECT_EQ(0, instance.factory("isa", profile,
-                                  &erasure_code, cerr));
+                                  &erasure_code, &cerr));
     EXPECT_TRUE(erasure_code);
   }
 }

--- a/src/test/erasure-code/TestErasureCodePluginIsa.cc
+++ b/src/test/erasure-code/TestErasureCodePluginIsa.cc
@@ -24,12 +24,12 @@
 TEST(ErasureCodePlugin, factory)
 {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
-  map<std::string,std::string> parameters;
-  parameters["directory"] = ".libs";
+  ErasureCodeProfile profile;
+  profile["directory"] = ".libs";
   {
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(-EIO, instance.factory("no-isa", parameters,
+    EXPECT_EQ(-EIO, instance.factory("no-isa", profile,
                                         &erasure_code, cerr));
     EXPECT_FALSE(erasure_code);
   }
@@ -39,9 +39,9 @@ TEST(ErasureCodePlugin, factory)
   };
   for(const char **technique = techniques; *technique; technique++) {
     ErasureCodeInterfaceRef erasure_code;
-    parameters["technique"] = *technique;
+    profile["technique"] = *technique;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(0, instance.factory("isa", parameters,
+    EXPECT_EQ(0, instance.factory("isa", profile,
                                   &erasure_code, cerr));
     EXPECT_TRUE(erasure_code);
   }

--- a/src/test/erasure-code/TestErasureCodePluginJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodePluginJerasure.cc
@@ -34,7 +34,7 @@ TEST(ErasureCodePlugin, factory)
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
     EXPECT_EQ(-ENOENT, instance.factory("jerasure", profile,
-                                        &erasure_code, cerr));
+                                        &erasure_code, &cerr));
     EXPECT_FALSE(erasure_code);
   }
   const char *techniques[] = {
@@ -54,7 +54,7 @@ TEST(ErasureCodePlugin, factory)
     profile["technique"] = *technique;
     EXPECT_FALSE(erasure_code);
     EXPECT_EQ(0, instance.factory("jerasure", profile,
-                                  &erasure_code, cerr));
+                                  &erasure_code, &cerr));
     EXPECT_TRUE(erasure_code);
   }
 }
@@ -92,7 +92,7 @@ TEST(ErasureCodePlugin, select)
     ErasureCodeInterfaceRef erasure_code;
     int sse4_side_effect = -444;
     EXPECT_EQ(sse4_side_effect, instance.factory("jerasure", profile,
-                                                 &erasure_code, cerr));
+                                                 &erasure_code, &cerr));
   }
   // pclmul is missing, load the SSE3 plugin
   {
@@ -107,7 +107,7 @@ TEST(ErasureCodePlugin, select)
     ErasureCodeInterfaceRef erasure_code;
     int sse3_side_effect = -333;
     EXPECT_EQ(sse3_side_effect, instance.factory("jerasure", profile,
-                                                 &erasure_code, cerr));
+                                                 &erasure_code, &cerr));
   }
   // pclmul and sse3 are missing, load the generic plugin
   {
@@ -122,7 +122,7 @@ TEST(ErasureCodePlugin, select)
     ErasureCodeInterfaceRef erasure_code;
     int generic_side_effect = -111;
     EXPECT_EQ(generic_side_effect, instance.factory("jerasure", profile,
-						    &erasure_code, cerr));
+						    &erasure_code, &cerr));
   }
   // neon is set, load the neon plugin
   {
@@ -137,7 +137,7 @@ TEST(ErasureCodePlugin, select)
     ErasureCodeInterfaceRef erasure_code;
     int generic_side_effect = -555;
     EXPECT_EQ(generic_side_effect, instance.factory("jerasure", profile,
-						    &erasure_code, cerr));
+						    &erasure_code, &cerr));
   }
 
 
@@ -200,7 +200,7 @@ TEST(ErasureCodePlugin, sse)
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
     EXPECT_EQ(0, instance.factory("jerasure_" + *sse_variant, profile,
-                                  &erasure_code, cerr));
+                                  &erasure_code, &cerr));
     EXPECT_TRUE(erasure_code);
 
     //

--- a/src/test/erasure-code/TestErasureCodePluginJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodePluginJerasure.cc
@@ -28,12 +28,12 @@
 TEST(ErasureCodePlugin, factory)
 {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
-  map<std::string,std::string> parameters;
-  parameters["directory"] = ".libs";
+  ErasureCodeProfile profile;
+  profile["directory"] = ".libs";
   {
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(-ENOENT, instance.factory("jerasure", parameters,
+    EXPECT_EQ(-ENOENT, instance.factory("jerasure", profile,
                                         &erasure_code, cerr));
     EXPECT_FALSE(erasure_code);
   }
@@ -49,9 +49,11 @@ TEST(ErasureCodePlugin, factory)
   };
   for(const char **technique = techniques; *technique; technique++) {
     ErasureCodeInterfaceRef erasure_code;
-    parameters["technique"] = *technique;
+    ErasureCodeProfile profile;
+    profile["directory"] = ".libs";
+    profile["technique"] = *technique;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(0, instance.factory("jerasure", parameters,
+    EXPECT_EQ(0, instance.factory("jerasure", profile,
                                   &erasure_code, cerr));
     EXPECT_TRUE(erasure_code);
   }
@@ -70,12 +72,12 @@ TEST(ErasureCodePlugin, select)
   int arch_neon		= ceph_arch_neon;
 
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
-  map<std::string,std::string> parameters;
+  ErasureCodeProfile profile;
   // load test plugins instead of actual plugins to assert the desired side effect
   // happens
-  parameters["jerasure-name"] = "test_jerasure";
-  parameters["directory"] = ".libs";
-  parameters["technique"] = "reed_sol_van";
+  profile["jerasure-name"] = "test_jerasure";
+  profile["directory"] = ".libs";
+  profile["technique"] = "reed_sol_van";
 
   // all features are available, load the SSE4 plugin
   {
@@ -89,7 +91,7 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int sse4_side_effect = -444;
-    EXPECT_EQ(sse4_side_effect, instance.factory("jerasure", parameters,
+    EXPECT_EQ(sse4_side_effect, instance.factory("jerasure", profile,
                                                  &erasure_code, cerr));
   }
   // pclmul is missing, load the SSE3 plugin
@@ -104,7 +106,7 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int sse3_side_effect = -333;
-    EXPECT_EQ(sse3_side_effect, instance.factory("jerasure", parameters,
+    EXPECT_EQ(sse3_side_effect, instance.factory("jerasure", profile,
                                                  &erasure_code, cerr));
   }
   // pclmul and sse3 are missing, load the generic plugin
@@ -119,7 +121,7 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int generic_side_effect = -111;
-    EXPECT_EQ(generic_side_effect, instance.factory("jerasure", parameters,
+    EXPECT_EQ(generic_side_effect, instance.factory("jerasure", profile,
 						    &erasure_code, cerr));
   }
   // neon is set, load the neon plugin
@@ -134,7 +136,7 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int generic_side_effect = -555;
-    EXPECT_EQ(generic_side_effect, instance.factory("jerasure", parameters,
+    EXPECT_EQ(generic_side_effect, instance.factory("jerasure", profile,
 						    &erasure_code, cerr));
   }
 
@@ -184,11 +186,11 @@ TEST(ErasureCodePlugin, sse)
   in.push_front(in_ptr);
 
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
-  map<std::string,std::string> parameters;
-  parameters["directory"] = ".libs";
-  parameters["technique"] = "reed_sol_van";
-  parameters["k"] = "2";
-  parameters["m"] = "1";
+  ErasureCodeProfile profile;
+  profile["directory"] = ".libs";
+  profile["technique"] = "reed_sol_van";
+  profile["k"] = "2";
+  profile["m"] = "1";
   for (vector<string>::iterator sse_variant = sse_variants.begin();
        sse_variant != sse_variants.end();
        ++sse_variant) {
@@ -197,7 +199,7 @@ TEST(ErasureCodePlugin, sse)
     //
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(0, instance.factory("jerasure_" + *sse_variant, parameters,
+    EXPECT_EQ(0, instance.factory("jerasure_" + *sse_variant, profile,
                                   &erasure_code, cerr));
     EXPECT_TRUE(erasure_code);
 

--- a/src/test/erasure-code/TestErasureCodePluginLrc.cc
+++ b/src/test/erasure-code/TestErasureCodePluginLrc.cc
@@ -33,7 +33,7 @@ TEST(ErasureCodePlugin, factory)
   profile["layers"] = "[ [ \"DDc\", \"\" ] ]";
   ErasureCodeInterfaceRef erasure_code;
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(0, instance.factory("lrc", profile, &erasure_code, cerr));
+  EXPECT_EQ(0, instance.factory("lrc", profile, &erasure_code, &cerr));
   EXPECT_TRUE(erasure_code);
 }
 

--- a/src/test/erasure-code/TestErasureCodePluginLrc.cc
+++ b/src/test/erasure-code/TestErasureCodePluginLrc.cc
@@ -27,13 +27,13 @@
 TEST(ErasureCodePlugin, factory)
 {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
-  map<std::string,std::string> parameters;
-  parameters["directory"] = ".libs";
-  parameters["mapping"] = "DD_";
-  parameters["layers"] = "[ [ \"DDc\", \"\" ] ]";
+  ErasureCodeProfile profile;
+  profile["directory"] = ".libs";
+  profile["mapping"] = "DD_";
+  profile["layers"] = "[ [ \"DDc\", \"\" ] ]";
   ErasureCodeInterfaceRef erasure_code;
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(0, instance.factory("lrc", parameters, &erasure_code, cerr));
+  EXPECT_EQ(0, instance.factory("lrc", profile, &erasure_code, cerr));
   EXPECT_TRUE(erasure_code);
 }
 

--- a/src/test/erasure-code/TestErasureCodeShec.cc
+++ b/src/test/erasure-code/TestErasureCodeShec.cc
@@ -46,19 +46,18 @@ TEST(ErasureCodeShec, init_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["directory"] = "/usr/lib64/ceph/erasure-code";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-
-  int r = shec->init(*parameters);
-
   //check parameters
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["directory"] = "/usr/lib64/ceph/erasure-code";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+
+  int r = shec->init(*profile);
+
   EXPECT_EQ(6, shec->k);
   EXPECT_EQ(4, shec->m);
   EXPECT_EQ(3, shec->c);
@@ -70,7 +69,7 @@ TEST(ErasureCodeShec, init_1)
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_2)
@@ -80,20 +79,19 @@ TEST(ErasureCodeShec, init_2)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-root"] = "test";
-  (*parameters)["ruleset-failure-domain"] = "host";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  (*parameters)["w"] = "8";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-root"] = "test";
+  (*profile)["ruleset-failure-domain"] = "host";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  (*profile)["w"] = "8";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
-  //check parameters
+  //check profile
   EXPECT_EQ(6, shec->k);
   EXPECT_EQ(4, shec->m);
   EXPECT_EQ(3, shec->c);
@@ -105,7 +103,7 @@ TEST(ErasureCodeShec, init_2)
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_3)
@@ -115,19 +113,18 @@ TEST(ErasureCodeShec, init_3)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  (*parameters)["w"] = "16";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  (*profile)["w"] = "16";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
-  //check parameters
+  //check profile
   EXPECT_EQ(6, shec->k);
   EXPECT_EQ(4, shec->m);
   EXPECT_EQ(3, shec->c);
@@ -139,7 +136,7 @@ TEST(ErasureCodeShec, init_3)
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_4)
@@ -149,19 +146,18 @@ TEST(ErasureCodeShec, init_4)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  (*parameters)["w"] = "32";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  (*profile)["w"] = "32";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
-  //check parameters
+  //check profile
   EXPECT_EQ(6, shec->k);
   EXPECT_EQ(4, shec->m);
   EXPECT_EQ(3, shec->c);
@@ -173,7 +169,7 @@ TEST(ErasureCodeShec, init_4)
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_5)
@@ -182,22 +178,21 @@ TEST(ErasureCodeShec, init_5)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
   //plugin is not specified
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_6)
@@ -206,22 +201,21 @@ TEST(ErasureCodeShec, init_6)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "jerasure";	//unexpected value
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "jerasure";	//unexpected value
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_7)
@@ -230,22 +224,21 @@ TEST(ErasureCodeShec, init_7)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "abc";	//unexpected value
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "abc";	//unexpected value
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_8)
@@ -254,23 +247,22 @@ TEST(ErasureCodeShec, init_8)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["directory"] = "/usr/lib64/";	//unexpected value
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["directory"] = "/usr/lib64/";	//unexpected value
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_9)
@@ -279,23 +271,22 @@ TEST(ErasureCodeShec, init_9)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-root"] = "abc";	//unexpected value
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-root"] = "abc";	//unexpected value
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_10)
@@ -304,22 +295,21 @@ TEST(ErasureCodeShec, init_10)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "abc";	//unexpected value
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "abc";	//unexpected value
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_11)
@@ -328,22 +318,21 @@ TEST(ErasureCodeShec, init_11)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "abc";		//unexpected value
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "abc";		//unexpected value
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_12)
@@ -352,21 +341,20 @@ TEST(ErasureCodeShec, init_12)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "-1";	//unexpected value
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "-1";	//unexpected value
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_13)
@@ -375,21 +363,20 @@ TEST(ErasureCodeShec, init_13)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "abc";
-  (*parameters)["k"] = "0.1";	//unexpected value
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "abc";
+  (*profile)["k"] = "0.1";	//unexpected value
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_14)
@@ -398,21 +385,20 @@ TEST(ErasureCodeShec, init_14)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "a";		//unexpected value
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "a";		//unexpected value
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_15)
@@ -421,21 +407,20 @@ TEST(ErasureCodeShec, init_15)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
   //k is not specified
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_16)
@@ -444,21 +429,20 @@ TEST(ErasureCodeShec, init_16)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "-1";		//unexpected value
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "-1";		//unexpected value
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_17)
@@ -467,21 +451,20 @@ TEST(ErasureCodeShec, init_17)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "0.1";		//unexpected value
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "0.1";		//unexpected value
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_18)
@@ -490,21 +473,20 @@ TEST(ErasureCodeShec, init_18)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "a";		//unexpected value
-  (*parameters)["c"] = "3";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "a";		//unexpected value
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_19)
@@ -513,21 +495,20 @@ TEST(ErasureCodeShec, init_19)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
   //m is not specified
-  (*parameters)["c"] = "3";
+  (*profile)["c"] = "3";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_20)
@@ -536,21 +517,20 @@ TEST(ErasureCodeShec, init_20)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "-1";		//unexpected value
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "-1";		//unexpected value
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_21)
@@ -559,21 +539,20 @@ TEST(ErasureCodeShec, init_21)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "0.1";		//unexpected value
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "0.1";		//unexpected value
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_22)
@@ -582,21 +561,20 @@ TEST(ErasureCodeShec, init_22)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "a";		//unexpected value
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "a";		//unexpected value
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_23)
@@ -605,21 +583,20 @@ TEST(ErasureCodeShec, init_23)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
   //c is not specified
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_24)
@@ -628,17 +605,16 @@ TEST(ErasureCodeShec, init_24)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  (*parameters)["w"] = "1";		//unexpected value
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  (*profile)["w"] = "1";		//unexpected value
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -649,7 +625,7 @@ TEST(ErasureCodeShec, init_24)
   //w is default value
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_25)
@@ -658,17 +634,16 @@ TEST(ErasureCodeShec, init_25)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  (*parameters)["w"] = "-1";		//unexpected value
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  (*profile)["w"] = "-1";		//unexpected value
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -679,7 +654,7 @@ TEST(ErasureCodeShec, init_25)
   //w is default value
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_26)
@@ -688,17 +663,16 @@ TEST(ErasureCodeShec, init_26)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  (*parameters)["w"] = "0.1";		//unexpected value
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  (*profile)["w"] = "0.1";		//unexpected value
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -709,7 +683,7 @@ TEST(ErasureCodeShec, init_26)
   //w is default value
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_27)
@@ -718,17 +692,16 @@ TEST(ErasureCodeShec, init_27)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  (*parameters)["w"] = "a";		//unexpected value
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  (*profile)["w"] = "a";		//unexpected value
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -739,7 +712,7 @@ TEST(ErasureCodeShec, init_27)
   //w is default value
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_28)
@@ -748,21 +721,20 @@ TEST(ErasureCodeShec, init_28)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "10";	//c > m
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "10";	//c > m
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_29)
@@ -771,16 +743,15 @@ TEST(ErasureCodeShec, init_29)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
   //k is not specified
   //m is not specified
   //c is not specified
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -790,7 +761,7 @@ TEST(ErasureCodeShec, init_29)
   EXPECT_EQ(2, shec->c);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_30)
@@ -799,16 +770,15 @@ TEST(ErasureCodeShec, init_30)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "12";
-  (*parameters)["m"] = "8";
-  (*parameters)["c"] = "8";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "12";
+  (*profile)["m"] = "8";
+  (*profile)["c"] = "8";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -817,7 +787,7 @@ TEST(ErasureCodeShec, init_30)
   EXPECT_EQ(8, shec->c);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_31)
@@ -826,21 +796,20 @@ TEST(ErasureCodeShec, init_31)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "13";
-  (*parameters)["m"] = "7";
-  (*parameters)["c"] = "7";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "13";
+  (*profile)["m"] = "7";
+  (*profile)["c"] = "7";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_32)
@@ -849,21 +818,20 @@ TEST(ErasureCodeShec, init_32)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "7";
-  (*parameters)["m"] = "13";
-  (*parameters)["c"] = "13";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "7";
+  (*profile)["m"] = "13";
+  (*profile)["c"] = "13";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_33)
@@ -872,21 +840,20 @@ TEST(ErasureCodeShec, init_33)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "12";
-  (*parameters)["m"] = "9";
-  (*parameters)["c"] = "8";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "12";
+  (*profile)["m"] = "9";
+  (*profile)["c"] = "8";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init_34)
@@ -895,21 +862,20 @@ TEST(ErasureCodeShec, init_34)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "8";
-  (*parameters)["m"] = "12";
-  (*parameters)["c"] = "12";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "8";
+  (*profile)["m"] = "12";
+  (*profile)["c"] = "12";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init2_4)
@@ -919,18 +885,17 @@ TEST(ErasureCodeShec, init2_4)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
-  int r = shec->init(*parameters);	//init executed twice
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
+  int r = shec->init(*profile);	//init executed twice
 
-  //check parameters
+  //check profile
   EXPECT_EQ(6, shec->k);
   EXPECT_EQ(4, shec->m);
   EXPECT_EQ(3, shec->c);
@@ -942,7 +907,7 @@ TEST(ErasureCodeShec, init2_4)
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, init2_5)
@@ -952,28 +917,26 @@ TEST(ErasureCodeShec, init2_5)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  map < std::string, std::string > *parameters2 = new map<std::string,
-      std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "host";
-  (*parameters)["k"] = "10";
-  (*parameters)["m"] = "6";
-  (*parameters)["c"] = "5";
-  (*parameters)["w"] = "16";
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  ErasureCodeProfile *profile2 = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "host";
+  (*profile)["k"] = "10";
+  (*profile)["m"] = "6";
+  (*profile)["c"] = "5";
+  (*profile)["w"] = "16";
 
-  int r = shec->init(*parameters);
+  int r = shec->init(*profile);
 
   //reexecute init
-  (*parameters2)["plugin"] = "shec";
-  (*parameters2)["technique"] = "";
-  (*parameters2)["ruleset-failure-domain"] = "osd";
-  (*parameters2)["k"] = "6";
-  (*parameters2)["m"] = "4";
-  (*parameters2)["c"] = "3";
-  shec->init(*parameters2);
+  (*profile2)["plugin"] = "shec";
+  (*profile2)["technique"] = "";
+  (*profile2)["ruleset-failure-domain"] = "osd";
+  (*profile2)["k"] = "6";
+  (*profile2)["m"] = "4";
+  (*profile2)["c"] = "3";
+  shec->init(*profile2);
 
   EXPECT_EQ(6, shec->k);
   EXPECT_EQ(4, shec->m);
@@ -986,7 +949,7 @@ TEST(ErasureCodeShec, init2_5)
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_1)
@@ -996,15 +959,14 @@ TEST(ErasureCodeShec, minimum_to_decode_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1023,7 +985,7 @@ TEST(ErasureCodeShec, minimum_to_decode_1)
   EXPECT_TRUE(minimum_chunks.size());
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_2)
@@ -1033,15 +995,14 @@ TEST(ErasureCodeShec, minimum_to_decode_2)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1060,7 +1021,7 @@ TEST(ErasureCodeShec, minimum_to_decode_2)
   EXPECT_TRUE(minimum_chunks.size());
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_3)
@@ -1070,15 +1031,14 @@ TEST(ErasureCodeShec, minimum_to_decode_3)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1096,7 +1056,7 @@ TEST(ErasureCodeShec, minimum_to_decode_3)
   EXPECT_EQ(0u, minimum_chunks.size());
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_4)
@@ -1106,15 +1066,14 @@ TEST(ErasureCodeShec, minimum_to_decode_4)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1133,7 +1092,7 @@ TEST(ErasureCodeShec, minimum_to_decode_4)
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_5)
@@ -1143,15 +1102,14 @@ TEST(ErasureCodeShec, minimum_to_decode_5)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1170,7 +1128,7 @@ TEST(ErasureCodeShec, minimum_to_decode_5)
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_6)
@@ -1180,15 +1138,14 @@ TEST(ErasureCodeShec, minimum_to_decode_6)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1206,7 +1163,7 @@ TEST(ErasureCodeShec, minimum_to_decode_6)
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_7)
@@ -1216,15 +1173,14 @@ TEST(ErasureCodeShec, minimum_to_decode_7)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1243,7 +1199,7 @@ TEST(ErasureCodeShec, minimum_to_decode_7)
   EXPECT_EQ(-EIO, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_8)
@@ -1253,15 +1209,14 @@ TEST(ErasureCodeShec, minimum_to_decode_8)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1277,7 +1232,7 @@ TEST(ErasureCodeShec, minimum_to_decode_8)
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_9)
@@ -1287,15 +1242,14 @@ TEST(ErasureCodeShec, minimum_to_decode_9)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1319,7 +1273,7 @@ TEST(ErasureCodeShec, minimum_to_decode_9)
   EXPECT_EQ(minimum, minimum_chunks);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode2_1)
@@ -1329,15 +1283,14 @@ TEST(ErasureCodeShec, minimum_to_decode2_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1356,7 +1309,7 @@ TEST(ErasureCodeShec, minimum_to_decode2_1)
   EXPECT_TRUE(minimum_chunks.size());
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode2_3)
@@ -1366,15 +1319,14 @@ TEST(ErasureCodeShec, minimum_to_decode2_3)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1406,7 +1358,7 @@ TEST(ErasureCodeShec, minimum_to_decode2_3)
   pthread_join(tid, NULL);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_with_cost_1)
@@ -1416,15 +1368,14 @@ TEST(ErasureCodeShec, minimum_to_decode_with_cost_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode_with_cost
   set<int> want_to_decode;
@@ -1443,7 +1394,7 @@ TEST(ErasureCodeShec, minimum_to_decode_with_cost_1)
   EXPECT_TRUE(minimum_chunks.size());
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, minimum_to_decode_with_cost_2_3)
@@ -1453,15 +1404,14 @@ TEST(ErasureCodeShec, minimum_to_decode_with_cost_2_3)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //minimum_to_decode_with_cost
   set<int> want_to_decode;
@@ -1493,7 +1443,7 @@ TEST(ErasureCodeShec, minimum_to_decode_with_cost_2_3)
   pthread_join(tid, NULL);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, encode_1)
@@ -1503,15 +1453,14 @@ TEST(ErasureCodeShec, encode_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -1556,7 +1505,7 @@ TEST(ErasureCodeShec, encode_1)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, encode_2)
@@ -1566,15 +1515,14 @@ TEST(ErasureCodeShec, encode_2)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -1615,7 +1563,7 @@ TEST(ErasureCodeShec, encode_2)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, encode_3)
@@ -1624,15 +1572,14 @@ TEST(ErasureCodeShec, encode_3)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   bufferlist in;
   in.append("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"//length = 62
@@ -1673,7 +1620,7 @@ TEST(ErasureCodeShec, encode_3)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, encode_4)
@@ -1683,15 +1630,14 @@ TEST(ErasureCodeShec, encode_4)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -1734,7 +1680,7 @@ TEST(ErasureCodeShec, encode_4)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, encode_8)
@@ -1744,15 +1690,14 @@ TEST(ErasureCodeShec, encode_8)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -1770,7 +1715,7 @@ TEST(ErasureCodeShec, encode_8)
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, encode_9)
@@ -1780,15 +1725,14 @@ TEST(ErasureCodeShec, encode_9)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -1810,7 +1754,7 @@ TEST(ErasureCodeShec, encode_9)
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, encode2_1)
@@ -1820,15 +1764,14 @@ TEST(ErasureCodeShec, encode2_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -1871,7 +1814,7 @@ TEST(ErasureCodeShec, encode2_1)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, encode2_3)
@@ -1881,15 +1824,14 @@ TEST(ErasureCodeShec, encode2_3)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -1944,7 +1886,7 @@ TEST(ErasureCodeShec, encode2_3)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, decode_1)
@@ -1954,15 +1896,14 @@ TEST(ErasureCodeShec, decode_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -2000,7 +1941,7 @@ TEST(ErasureCodeShec, decode_1)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, decode_2)
@@ -2010,15 +1951,14 @@ TEST(ErasureCodeShec, decode_2)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -2056,7 +1996,7 @@ TEST(ErasureCodeShec, decode_2)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, decode_3)
@@ -2066,15 +2006,14 @@ TEST(ErasureCodeShec, decode_3)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -2119,7 +2058,7 @@ TEST(ErasureCodeShec, decode_3)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, decode_4)
@@ -2129,15 +2068,14 @@ TEST(ErasureCodeShec, decode_4)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -2182,7 +2120,7 @@ TEST(ErasureCodeShec, decode_4)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, decode_7)
@@ -2192,15 +2130,14 @@ TEST(ErasureCodeShec, decode_7)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -2250,7 +2187,7 @@ TEST(ErasureCodeShec, decode_7)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, decode_8)
@@ -2260,15 +2197,14 @@ TEST(ErasureCodeShec, decode_8)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -2299,7 +2235,7 @@ TEST(ErasureCodeShec, decode_8)
   EXPECT_NE(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, decode_9)
@@ -2309,15 +2245,14 @@ TEST(ErasureCodeShec, decode_9)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -2355,7 +2290,7 @@ TEST(ErasureCodeShec, decode_9)
   EXPECT_NE(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, decode2_1)
@@ -2365,15 +2300,14 @@ TEST(ErasureCodeShec, decode2_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -2412,7 +2346,7 @@ TEST(ErasureCodeShec, decode2_1)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, decode2_3)
@@ -2422,15 +2356,14 @@ TEST(ErasureCodeShec, decode2_3)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -2480,7 +2413,7 @@ TEST(ErasureCodeShec, decode2_3)
   EXPECT_TRUE(usable == in);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, decode2_4)
@@ -2490,15 +2423,14 @@ TEST(ErasureCodeShec, decode2_4)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //encode
   bufferlist in;
@@ -2533,7 +2465,7 @@ TEST(ErasureCodeShec, decode2_4)
   EXPECT_EQ(-1, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, create_ruleset_1_2)
@@ -2569,15 +2501,14 @@ TEST(ErasureCodeShec, create_ruleset_1_2)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //create_ruleset
   stringstream ss;
@@ -2591,7 +2522,7 @@ TEST(ErasureCodeShec, create_ruleset_1_2)
   EXPECT_EQ(-EEXIST, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
   delete crush;
 }
 
@@ -2628,22 +2559,21 @@ TEST(ErasureCodeShec, create_ruleset_4)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //create_ruleset
   int r = shec->create_ruleset("myrule", *crush, NULL);	//ss = NULL
   EXPECT_EQ(0, r);
 
   delete shec;
-  delete parameters;
+  delete profile;
   delete crush;
 }
 
@@ -2680,15 +2610,14 @@ TEST(ErasureCodeShec, create_ruleset2_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //create_ruleset
   stringstream ss;
@@ -2698,7 +2627,7 @@ TEST(ErasureCodeShec, create_ruleset2_1)
   EXPECT_STREQ("myrule", crush->rule_name_map[0].c_str());
 
   delete shec;
-  delete parameters;
+  delete profile;
   delete crush;
 }
 
@@ -2740,15 +2669,14 @@ TEST(ErasureCodeShec, create_ruleset2_3)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //create_ruleset
   stringstream ss;
@@ -2768,7 +2696,7 @@ TEST(ErasureCodeShec, create_ruleset2_3)
   pthread_join(tid, NULL);
 
   delete shec;
-  delete parameters;
+  delete profile;
   delete crush;
 }
 
@@ -2779,21 +2707,20 @@ TEST(ErasureCodeShec, get_chunk_count_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //get_chunk_count
   EXPECT_EQ(10u, shec->get_chunk_count());
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, get_data_chunk_count_1)
@@ -2803,21 +2730,20 @@ TEST(ErasureCodeShec, get_data_chunk_count_1)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  shec->init(*profile);
 
   //get_data_chunk_count
   EXPECT_EQ(6u, shec->get_data_chunk_count());
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 TEST(ErasureCodeShec, get_chunk_size_1_2)
@@ -2827,16 +2753,15 @@ TEST(ErasureCodeShec, get_chunk_size_1_2)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = "6";
-  (*parameters)["m"] = "4";
-  (*parameters)["c"] = "3";
-  (*parameters)["w"] = "8";
-  shec->init(*parameters);
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = "6";
+  (*profile)["m"] = "4";
+  (*profile)["c"] = "3";
+  (*profile)["w"] = "8";
+  shec->init(*profile);
 
   //when there is no padding(192=k*w*4)
   EXPECT_EQ(32u, shec->get_chunk_size(192));
@@ -2844,7 +2769,7 @@ TEST(ErasureCodeShec, get_chunk_size_1_2)
   EXPECT_EQ(32u, shec->get_chunk_size(190));
 
   delete shec;
-  delete parameters;
+  delete profile;
 }
 
 int main(int argc, char **argv)

--- a/src/test/erasure-code/TestErasureCodeShec.cc
+++ b/src/test/erasure-code/TestErasureCodeShec.cc
@@ -56,7 +56,7 @@ TEST(ErasureCodeShec, init_1)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(6, shec->k);
   EXPECT_EQ(4, shec->m);
@@ -89,7 +89,7 @@ TEST(ErasureCodeShec, init_2)
   (*profile)["c"] = "3";
   (*profile)["w"] = "8";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   //check profile
   EXPECT_EQ(6, shec->k);
@@ -122,7 +122,7 @@ TEST(ErasureCodeShec, init_3)
   (*profile)["c"] = "3";
   (*profile)["w"] = "16";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   //check profile
   EXPECT_EQ(6, shec->k);
@@ -155,7 +155,7 @@ TEST(ErasureCodeShec, init_4)
   (*profile)["c"] = "3";
   (*profile)["w"] = "32";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   //check profile
   EXPECT_EQ(6, shec->k);
@@ -186,7 +186,7 @@ TEST(ErasureCodeShec, init_5)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -209,7 +209,7 @@ TEST(ErasureCodeShec, init_6)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -232,7 +232,7 @@ TEST(ErasureCodeShec, init_7)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -256,7 +256,7 @@ TEST(ErasureCodeShec, init_8)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -280,7 +280,7 @@ TEST(ErasureCodeShec, init_9)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -303,7 +303,7 @@ TEST(ErasureCodeShec, init_10)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -326,7 +326,7 @@ TEST(ErasureCodeShec, init_11)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -349,7 +349,7 @@ TEST(ErasureCodeShec, init_12)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -371,7 +371,7 @@ TEST(ErasureCodeShec, init_13)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -393,7 +393,7 @@ TEST(ErasureCodeShec, init_14)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -415,7 +415,7 @@ TEST(ErasureCodeShec, init_15)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -437,7 +437,7 @@ TEST(ErasureCodeShec, init_16)
   (*profile)["m"] = "-1";		//unexpected value
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -459,7 +459,7 @@ TEST(ErasureCodeShec, init_17)
   (*profile)["m"] = "0.1";		//unexpected value
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -481,7 +481,7 @@ TEST(ErasureCodeShec, init_18)
   (*profile)["m"] = "a";		//unexpected value
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -503,7 +503,7 @@ TEST(ErasureCodeShec, init_19)
   //m is not specified
   (*profile)["c"] = "3";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -525,7 +525,7 @@ TEST(ErasureCodeShec, init_20)
   (*profile)["m"] = "4";
   (*profile)["c"] = "-1";		//unexpected value
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -547,7 +547,7 @@ TEST(ErasureCodeShec, init_21)
   (*profile)["m"] = "4";
   (*profile)["c"] = "0.1";		//unexpected value
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -569,7 +569,7 @@ TEST(ErasureCodeShec, init_22)
   (*profile)["m"] = "4";
   (*profile)["c"] = "a";		//unexpected value
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -591,7 +591,7 @@ TEST(ErasureCodeShec, init_23)
   (*profile)["m"] = "4";
   //c is not specified
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -614,7 +614,7 @@ TEST(ErasureCodeShec, init_24)
   (*profile)["c"] = "3";
   (*profile)["w"] = "1";		//unexpected value
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -643,7 +643,7 @@ TEST(ErasureCodeShec, init_25)
   (*profile)["c"] = "3";
   (*profile)["w"] = "-1";		//unexpected value
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -672,7 +672,7 @@ TEST(ErasureCodeShec, init_26)
   (*profile)["c"] = "3";
   (*profile)["w"] = "0.1";		//unexpected value
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -701,7 +701,7 @@ TEST(ErasureCodeShec, init_27)
   (*profile)["c"] = "3";
   (*profile)["w"] = "a";		//unexpected value
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -729,7 +729,7 @@ TEST(ErasureCodeShec, init_28)
   (*profile)["m"] = "4";
   (*profile)["c"] = "10";	//c > m
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -751,7 +751,7 @@ TEST(ErasureCodeShec, init_29)
   //m is not specified
   //c is not specified
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -778,7 +778,7 @@ TEST(ErasureCodeShec, init_30)
   (*profile)["m"] = "8";
   (*profile)["c"] = "8";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -804,7 +804,7 @@ TEST(ErasureCodeShec, init_31)
   (*profile)["m"] = "7";
   (*profile)["c"] = "7";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -826,7 +826,7 @@ TEST(ErasureCodeShec, init_32)
   (*profile)["m"] = "13";
   (*profile)["c"] = "13";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -848,7 +848,7 @@ TEST(ErasureCodeShec, init_33)
   (*profile)["m"] = "9";
   (*profile)["c"] = "8";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -870,7 +870,7 @@ TEST(ErasureCodeShec, init_34)
   (*profile)["m"] = "12";
   (*profile)["c"] = "12";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   EXPECT_EQ(-EINVAL, r);
 
@@ -892,8 +892,8 @@ TEST(ErasureCodeShec, init2_4)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
-  int r = shec->init(*profile);	//init executed twice
+  shec->init(*profile, &cerr);
+  int r = shec->init(*profile, &cerr);	//init executed twice
 
   //check profile
   EXPECT_EQ(6, shec->k);
@@ -927,7 +927,7 @@ TEST(ErasureCodeShec, init2_5)
   (*profile)["c"] = "5";
   (*profile)["w"] = "16";
 
-  int r = shec->init(*profile);
+  int r = shec->init(*profile, &cerr);
 
   //reexecute init
   (*profile2)["plugin"] = "shec";
@@ -936,7 +936,7 @@ TEST(ErasureCodeShec, init2_5)
   (*profile2)["k"] = "6";
   (*profile2)["m"] = "4";
   (*profile2)["c"] = "3";
-  shec->init(*profile2);
+  shec->init(*profile2, &cerr);
 
   EXPECT_EQ(6, shec->k);
   EXPECT_EQ(4, shec->m);
@@ -966,7 +966,7 @@ TEST(ErasureCodeShec, minimum_to_decode_1)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1002,7 +1002,7 @@ TEST(ErasureCodeShec, minimum_to_decode_2)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1038,7 +1038,7 @@ TEST(ErasureCodeShec, minimum_to_decode_3)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1073,7 +1073,7 @@ TEST(ErasureCodeShec, minimum_to_decode_4)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1109,7 +1109,7 @@ TEST(ErasureCodeShec, minimum_to_decode_5)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1145,7 +1145,7 @@ TEST(ErasureCodeShec, minimum_to_decode_6)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1180,7 +1180,7 @@ TEST(ErasureCodeShec, minimum_to_decode_7)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1216,7 +1216,7 @@ TEST(ErasureCodeShec, minimum_to_decode_8)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1249,7 +1249,7 @@ TEST(ErasureCodeShec, minimum_to_decode_9)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1290,7 +1290,7 @@ TEST(ErasureCodeShec, minimum_to_decode2_1)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1326,7 +1326,7 @@ TEST(ErasureCodeShec, minimum_to_decode2_3)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode
   set<int> want_to_decode;
@@ -1375,7 +1375,7 @@ TEST(ErasureCodeShec, minimum_to_decode_with_cost_1)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode_with_cost
   set<int> want_to_decode;
@@ -1411,7 +1411,7 @@ TEST(ErasureCodeShec, minimum_to_decode_with_cost_2_3)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //minimum_to_decode_with_cost
   set<int> want_to_decode;
@@ -1460,7 +1460,7 @@ TEST(ErasureCodeShec, encode_1)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -1522,7 +1522,7 @@ TEST(ErasureCodeShec, encode_2)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -1579,7 +1579,7 @@ TEST(ErasureCodeShec, encode_3)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   bufferlist in;
   in.append("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"//length = 62
@@ -1637,7 +1637,7 @@ TEST(ErasureCodeShec, encode_4)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -1697,7 +1697,7 @@ TEST(ErasureCodeShec, encode_8)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -1732,7 +1732,7 @@ TEST(ErasureCodeShec, encode_9)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -1771,7 +1771,7 @@ TEST(ErasureCodeShec, encode2_1)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -1831,7 +1831,7 @@ TEST(ErasureCodeShec, encode2_3)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -1903,7 +1903,7 @@ TEST(ErasureCodeShec, decode_1)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -1958,7 +1958,7 @@ TEST(ErasureCodeShec, decode_2)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -2013,7 +2013,7 @@ TEST(ErasureCodeShec, decode_3)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -2075,7 +2075,7 @@ TEST(ErasureCodeShec, decode_4)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -2137,7 +2137,7 @@ TEST(ErasureCodeShec, decode_7)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -2204,7 +2204,7 @@ TEST(ErasureCodeShec, decode_8)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -2252,7 +2252,7 @@ TEST(ErasureCodeShec, decode_9)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -2307,7 +2307,7 @@ TEST(ErasureCodeShec, decode2_1)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -2363,7 +2363,7 @@ TEST(ErasureCodeShec, decode2_3)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -2430,7 +2430,7 @@ TEST(ErasureCodeShec, decode2_4)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //encode
   bufferlist in;
@@ -2508,7 +2508,7 @@ TEST(ErasureCodeShec, create_ruleset_1_2)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //create_ruleset
   stringstream ss;
@@ -2566,7 +2566,7 @@ TEST(ErasureCodeShec, create_ruleset_4)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //create_ruleset
   int r = shec->create_ruleset("myrule", *crush, NULL);	//ss = NULL
@@ -2617,7 +2617,7 @@ TEST(ErasureCodeShec, create_ruleset2_1)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //create_ruleset
   stringstream ss;
@@ -2676,7 +2676,7 @@ TEST(ErasureCodeShec, create_ruleset2_3)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //create_ruleset
   stringstream ss;
@@ -2714,7 +2714,7 @@ TEST(ErasureCodeShec, get_chunk_count_1)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //get_chunk_count
   EXPECT_EQ(10u, shec->get_chunk_count());
@@ -2737,7 +2737,7 @@ TEST(ErasureCodeShec, get_data_chunk_count_1)
   (*profile)["k"] = "6";
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //get_data_chunk_count
   EXPECT_EQ(6u, shec->get_data_chunk_count());
@@ -2761,7 +2761,7 @@ TEST(ErasureCodeShec, get_chunk_size_1_2)
   (*profile)["m"] = "4";
   (*profile)["c"] = "3";
   (*profile)["w"] = "8";
-  shec->init(*profile);
+  shec->init(*profile, &cerr);
 
   //when there is no padding(192=k*w*4)
   EXPECT_EQ(32u, shec->get_chunk_size(192));

--- a/src/test/erasure-code/TestErasureCodeShec_all.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_all.cc
@@ -73,19 +73,18 @@ TEST_P(ParameterTest, parameter_all)
   ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				  tcache,
 				  ErasureCodeShec::MULTIPLE);
-  map < std::string, std::string > *parameters = new map<std::string,
-							 std::string>();
-  (*parameters)["plugin"] = "shec";
-  (*parameters)["technique"] = "";
-  (*parameters)["directory"] = "/usr/lib64/ceph/erasure-code";
-  (*parameters)["ruleset-failure-domain"] = "osd";
-  (*parameters)["k"] = k;
-  (*parameters)["m"] = m;
-  (*parameters)["c"] = c;
+  ErasureCodeProfile *profile = new ErasureCodeProfile();
+  (*profile)["plugin"] = "shec";
+  (*profile)["technique"] = "";
+  (*profile)["directory"] = "/usr/lib64/ceph/erasure-code";
+  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["k"] = k;
+  (*profile)["m"] = m;
+  (*profile)["c"] = c;
 
-  result = shec->init(*parameters);
+  result = shec->init(*profile);
 
-  //check parameters
+  //check profile
   EXPECT_EQ(i_k, shec->k);
   EXPECT_EQ(i_m, shec->m);
   EXPECT_EQ(i_c, shec->c);
@@ -257,7 +256,7 @@ TEST_P(ParameterTest, parameter_all)
   EXPECT_EQ(c_size, shec->get_chunk_size(192));
 
   delete shec;
-  delete parameters;
+  delete profile;
   delete crush;
 }
 

--- a/src/test/erasure-code/TestErasureCodeShec_all.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_all.cc
@@ -82,7 +82,7 @@ TEST_P(ParameterTest, parameter_all)
   (*profile)["m"] = m;
   (*profile)["c"] = c;
 
-  result = shec->init(*profile);
+  result = shec->init(*profile, &cerr);
 
   //check profile
   EXPECT_EQ(i_k, shec->k);

--- a/src/test/erasure-code/TestErasureCodeShec_thread.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_thread.cc
@@ -147,7 +147,7 @@ void* thread1(void* pParam)
     (*profile)["m"] = param->m;
     (*profile)["c"] = param->c;
     (*profile)["w"] = param->w;
-    r = shec->init(*profile);
+    r = shec->init(*profile, &cerr);
 
     int i_k = std::atoi(param->k.c_str());
     int i_m = std::atoi(param->m.c_str());

--- a/src/test/erasure-code/TestErasureCodeShec_thread.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_thread.cc
@@ -139,16 +139,15 @@ void* thread1(void* pParam)
     ErasureCodeShec* shec = new ErasureCodeShecReedSolomonVandermonde(
 				    tcache,
 				    ErasureCodeShec::MULTIPLE);
-    map < std::string, std::string > *parameters = new map<std::string,
-							   std::string>();
-    (*parameters)["plugin"] = "shec";
-    (*parameters)["technique"] = "multiple";
-    (*parameters)["ruleset-failure-domain"] = "osd";
-    (*parameters)["k"] = param->k;
-    (*parameters)["m"] = param->m;
-    (*parameters)["c"] = param->c;
-    (*parameters)["w"] = param->w;
-    r = shec->init(*parameters);
+    ErasureCodeProfile *profile = new ErasureCodeProfile();
+    (*profile)["plugin"] = "shec";
+    (*profile)["technique"] = "multiple";
+    (*profile)["ruleset-failure-domain"] = "osd";
+    (*profile)["k"] = param->k;
+    (*profile)["m"] = param->m;
+    (*profile)["c"] = param->c;
+    (*profile)["w"] = param->w;
+    r = shec->init(*profile);
 
     int i_k = std::atoi(param->k.c_str());
     int i_m = std::atoi(param->m.c_str());
@@ -216,7 +215,7 @@ void* thread1(void* pParam)
     }
 
     delete shec;
-    delete parameters;
+    delete profile;
     want_to_encode.clear();
     encoded.clear();
     decoded.clear();

--- a/src/test/erasure-code/ceph_erasure_code.cc
+++ b/src/test/erasure-code/ceph_erasure_code.cc
@@ -36,7 +36,7 @@ namespace po = boost::program_options;
 
 class ErasureCodeCommand {
   po::variables_map vm;
-  map<string,string> parameters;
+  ErasureCodeProfile profile;
 public:
   int setup(int argc, char** argv);
   int run();
@@ -105,13 +105,13 @@ int ErasureCodeCommand::setup(int argc, char** argv) {
 	cerr << "--parameter " << *i
 	     << " ignored because it does not contain exactly one =" << endl;
       } else {
-	parameters[strs[0]] = strs[1];
+	profile[strs[0]] = strs[1];
       }
     }
   }
 
-  if (parameters.count("directory") == 0)
-    parameters["directory"] = ".libs";
+  if (profile.count("directory") == 0)
+    profile["directory"] = ".libs";
 
   return 0;
 }
@@ -128,7 +128,7 @@ int ErasureCodeCommand::plugin_exists() {
   ErasureCodePlugin *plugin = 0;
   Mutex::Locker l(instance.lock);
   stringstream ss;
-  int code = instance.load(vm["plugin_exists"].as<string>(), parameters["directory"], &plugin, ss);
+  int code = instance.load(vm["plugin_exists"].as<string>(), profile["directory"], &plugin, &ss);
   if (code)
     cerr << ss.str() << endl;
   return code;
@@ -138,13 +138,13 @@ int ErasureCodeCommand::display_information() {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeInterfaceRef erasure_code;
 
-  if (parameters.count("plugin") == 0) {
+  if (profile.count("plugin") == 0) {
     cerr << "--parameter plugin=<plugin> is mandatory" << endl;
     return 1;
   }
 
-  int code = instance.factory(parameters["plugin"],
-			      parameters,
+  int code = instance.factory(profile["plugin"],
+			      profile,
 			      &erasure_code, cerr);
   if (code)
     return code;

--- a/src/test/erasure-code/ceph_erasure_code.cc
+++ b/src/test/erasure-code/ceph_erasure_code.cc
@@ -145,7 +145,7 @@ int ErasureCodeCommand::display_information() {
 
   int code = instance.factory(profile["plugin"],
 			      profile,
-			      &erasure_code, cerr);
+			      &erasure_code, &cerr);
   if (code)
     return code;
 

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -60,7 +60,7 @@ int ErasureCodeBench::setup(int argc, char** argv) {
      " (i.e. k=4,m=3 with one erasure will try to recover from the erasure of "
      " the first chunk, then the second etc.)")
     ("parameter,P", po::value<vector<string> >(),
-     "parameters")
+     "add a parameter to the erasure code profile")
     ;
 
   po::variables_map vm;
@@ -103,13 +103,13 @@ int ErasureCodeBench::setup(int argc, char** argv) {
       if (strs.size() != 2) {
 	cerr << "--parameter " << *i << " ignored because it does not contain exactly one =" << endl;
       } else {
-	parameters[strs[0]] = strs[1];
+	profile[strs[0]] = strs[1];
       }
     }
   }
 
-  if (parameters.count("directory") == 0)
-    parameters["directory"] = ".libs";
+  if (profile.count("directory") == 0)
+    profile["directory"] = ".libs";
 
   in_size = vm["size"].as<int>();
   max_iterations = vm["iterations"].as<int>();
@@ -124,8 +124,8 @@ int ErasureCodeBench::setup(int argc, char** argv) {
   if (vm.count("erased") > 0)
     erased = vm["erased"].as<vector<int> >();
 
-  k = atoi(parameters["k"].c_str());
-  m = atoi(parameters["m"].c_str());
+  k = atoi(profile["k"].c_str());
+  m = atoi(profile["m"].c_str());
   
   if (k <= 0) {
     cout << "parameter k is " << k << ". But k needs to be > 0." << endl;
@@ -155,7 +155,7 @@ int ErasureCodeBench::encode()
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeInterfaceRef erasure_code;
   stringstream messages;
-  int code = instance.factory(plugin, parameters, &erasure_code, messages);
+  int code = instance.factory(plugin, profile, &erasure_code, &messages);
   if (code) {
     cerr << messages.str() << endl;
     return code;
@@ -257,7 +257,7 @@ int ErasureCodeBench::decode()
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeInterfaceRef erasure_code;
   stringstream messages;
-  int code = instance.factory(plugin, parameters, &erasure_code, messages);
+  int code = instance.factory(plugin, profile, &erasure_code, &messages);
   if (code) {
     cerr << messages.str() << endl;
     return code;

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.h
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.h
@@ -35,7 +35,7 @@ class ErasureCodeBench {
   vector<int> erased;
   string workload;
 
-  map<string,string> parameters;
+  ErasureCodeProfile profile;
 
   bool verbose;
 public:

--- a/src/test/erasure-code/ceph_erasure_code_non_regression.cc
+++ b/src/test/erasure-code/ceph_erasure_code_non_regression.cc
@@ -41,7 +41,7 @@ class ErasureCodeNonRegression {
   bool check;
   string base;
   string directory;
-  map<string,string> parameters;
+  ErasureCodeProfile profile;
 public:
   int setup(int argc, char** argv);
   int run();
@@ -66,7 +66,7 @@ int ErasureCodeNonRegression::setup(int argc, char** argv) {
     ("base", po::value<string>()->default_value("."),
      "prefix all paths with base")
     ("parameter,P", po::value<vector<string> >(),
-     "parameters")
+     "add a parameter to the erasure code profile")
     ("create", "create the erasure coded content in the directory")
     ("check", "check the content in the directory matches the chunks and vice versa")
     ;
@@ -128,14 +128,14 @@ int ErasureCodeNonRegression::setup(int argc, char** argv) {
       if (strs.size() != 2) {
 	cerr << "--parameter " << *i << " ignored because it does not contain exactly one =" << endl;
       } else {
-	parameters[strs[0]] = strs[1];
+	profile[strs[0]] = strs[1];
       }
       if (strs[0] != "directory")
 	directory += " " + *i;
     }
   }
-  if (parameters.count("directory") == 0)
-    parameters["directory"] = ".libs";
+  if (profile.count("directory") == 0)
+    profile["directory"] = ".libs";
 
   return 0;
 }
@@ -155,7 +155,7 @@ int ErasureCodeNonRegression::run_create()
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeInterfaceRef erasure_code;
   stringstream messages;
-  int code = instance.factory(plugin, parameters, &erasure_code, messages);
+  int code = instance.factory(plugin, profile, &erasure_code, &messages);
   if (code) {
     cerr << messages.str() << endl;
     return code;
@@ -225,7 +225,7 @@ int ErasureCodeNonRegression::run_check()
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeInterfaceRef erasure_code;
   stringstream messages;
-  int code = instance.factory(plugin, parameters, &erasure_code, messages);
+  int code = instance.factory(plugin, profile, &erasure_code, &messages);
   if (code) {
     cerr << messages.str() << endl;
     return code;


### PR DESCRIPTION
The error message from a failed erasure code plugin initialization is lost to the user and must be recovered from the mon or osd logs. This was not fixed before because it requires a tedious refactoring that modifies a number of prototypes. Take advantage of this necessary change to also change the type of erasure code profiles from map&lt;string,string> to ErasureCodeProfile.
