### PR TITLE
erasure-code: query plugin for erasure-code-profile defaults

### DIFF
--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -197,14 +197,12 @@ int ErasureCode::to_mapping(const ErasureCodeProfile &profile,
 int ErasureCode::to_int(const std::string &name,
 			ErasureCodeProfile &profile,
 			int *value,
-			int default_value,
+			const std::string &default_value,
 			ostream *ss)
 {
   if (profile.find(name) == profile.end() ||
-      profile.find(name)->second.size() == 0) {
-    *value = default_value;
-    return 0;
-  }
+      profile.find(name)->second.size() == 0)
+    profile[name] = default_value;
   std::string p = profile.find(name)->second;
   std::string err;
   int r = strict_strtol(p.c_str(), 10, &err);
@@ -212,7 +210,7 @@ int ErasureCode::to_int(const std::string &name,
     *ss << "could not convert " << name << "=" << p
 	<< " to int because " << err
 	<< ", set to default " << default_value << std::endl;
-    *value = default_value;
+    *value = strict_strtol(default_value.c_str(), 10, &err);
     return -EINVAL;
   }
   *value = r;
@@ -222,16 +220,27 @@ int ErasureCode::to_int(const std::string &name,
 int ErasureCode::to_bool(const std::string &name,
 			 ErasureCodeProfile &profile,
 			 bool *value,
-			 bool default_value,
+			 const std::string &default_value,
 			 ostream *ss)
 {
   if (profile.find(name) == profile.end() ||
-      profile.find(name)->second.size() == 0) {
-    *value = default_value;
-    return 0;
-  }
+      profile.find(name)->second.size() == 0)
+    profile[name] = default_value;
   const std::string p = profile.find(name)->second;
   *value = (p == "yes") || (p == "true");
+  return 0;
+}
+
+int ErasureCode::to_string(const std::string &name,
+			   ErasureCodeProfile &profile,
+			   std::string *value,
+			   const std::string &default_value,
+			   ostream *ss)
+{
+  if (profile.find(name) == profile.end() ||
+      profile.find(name)->second.size() == 0)
+    profile[name] = default_value;
+  *value = profile[name];
   return 0;
 }
 

--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -77,14 +77,20 @@ namespace ceph {
     static int to_int(const std::string &name,
 		      ErasureCodeProfile &profile,
 		      int *value,
-		      int default_value,
+		      const std::string &default_value,
 		      ostream *ss);
 
     static int to_bool(const std::string &name,
 		       ErasureCodeProfile &profile,
 		       bool *value,
-		       bool default_value,
+		       const std::string &default_value,
 		       ostream *ss);
+
+    static int to_string(const std::string &name,
+			 ErasureCodeProfile &profile,
+			 std::string *value,
+			 const std::string &default_value,
+			 ostream *ss);
 
     virtual int decode_concat(const map<int, bufferlist> &chunks,
 			      bufferlist *decoded);

--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -41,6 +41,9 @@ _prefix(std::ostream* _dout)
 }
 // -----------------------------------------------------------------------------
 
+const std::string ErasureCodeIsaDefault::DEFAULT_K("7");
+const std::string ErasureCodeIsaDefault::DEFAULT_M("3");
+
 int
 ErasureCodeIsa::create_ruleset(const string &name,
                                CrushWrapper &crush,
@@ -67,14 +70,12 @@ int
 ErasureCodeIsa::init(ErasureCodeProfile &profile, ostream *ss)
 {
   int err = 0;
-  dout(10) << "technique=" << technique << dendl;
-  map<string, string>::const_iterator parameter;
-  parameter = profile.find("ruleset-root");
-  if (parameter != profile.end())
-    ruleset_root = parameter->second;
-  parameter = profile.find("ruleset-failure-domain");
-  if (parameter != profile.end())
-    ruleset_failure_domain = parameter->second;
+  err |= to_string("ruleset-root", profile,
+		   &ruleset_root,
+		   DEFAULT_RULESET_ROOT, ss);
+  err |= to_string("ruleset-failure-domain", profile,
+		   &ruleset_failure_domain,
+		   DEFAULT_RULESET_FAILURE_DOMAIN, ss);
   err |= parse(profile, ss);
   if (err)
     return err;

--- a/src/erasure-code/isa/ErasureCodeIsa.h
+++ b/src/erasure-code/isa/ErasureCodeIsa.h
@@ -33,6 +33,9 @@
 #include <list>
 // -----------------------------------------------------------------------------
 
+#define DEFAULT_RULESET_ROOT "default"
+#define DEFAULT_RULESET_FAILURE_DOMAIN "host"
+
 class ErasureCodeIsa : public ErasureCode {
 public:
 
@@ -56,8 +59,8 @@ public:
   w(0),
   tcache(_tcache),
   technique(_technique),
-  ruleset_root("default"),
-  ruleset_failure_domain("host")
+  ruleset_root(DEFAULT_RULESET_ROOT),
+  ruleset_failure_domain(DEFAULT_RULESET_FAILURE_DOMAIN)
   {
   }
 
@@ -120,8 +123,8 @@ private:
 
 public:
 
-  static const int DEFAULT_K = 7;
-  static const int DEFAULT_M = 3;
+  static const std::string DEFAULT_K;
+  static const std::string DEFAULT_M;
 
   unsigned char* encode_coeff; // encoding coefficient
   unsigned char* encode_tbls; // encoding table

--- a/src/erasure-code/isa/ErasureCodePluginIsa.cc
+++ b/src/erasure-code/isa/ErasureCodePluginIsa.cc
@@ -40,9 +40,10 @@ public:
                       ostream *ss)
   {
     ErasureCodeIsa *interface;
-    std::string t = "reed_sol_van";
-    if (profile.find("technique") != profile.end())
-      t = profile.find("technique")->second;
+    std::string t;
+    if (profile.find("technique") == profile.end())
+      profile["technique"] = "reed_sol_van";
+    t = profile.find("technique")->second;
     if ((t == "reed_sol_van")) {
       interface = new ErasureCodeIsaDefault(tcache,
                                             ErasureCodeIsaDefault::kVandermonde);

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.cc
@@ -56,13 +56,13 @@ int ErasureCodeJerasure::init(ErasureCodeProfile& profile, ostream *ss)
 {
   int err = 0;
   dout(10) << "technique=" << technique << dendl;
-  map<string,string>::const_iterator parameter;
-  parameter = profile.find("ruleset-root");
-  if (parameter != profile.end())
-    ruleset_root = parameter->second;
-  parameter = profile.find("ruleset-failure-domain");
-  if (parameter != profile.end())
-    ruleset_failure_domain = parameter->second;
+  profile["technique"] = technique;
+  err |= to_string("ruleset-root", profile,
+		   &ruleset_root,
+		   DEFAULT_RULESET_ROOT, ss);
+  err |= to_string("ruleset-failure-domain", profile,
+		   &ruleset_failure_domain,
+		   DEFAULT_RULESET_FAILURE_DOMAIN, ss);
   err |= parse(profile, ss);
   if (err)
     return err;
@@ -200,12 +200,13 @@ int ErasureCodeJerasureReedSolomonVandermonde::parse(ErasureCodeProfile &profile
   err |= ErasureCodeJerasure::parse(profile, ss);
   if (w != 8 && w != 16 && w != 32) {
     *ss << "ReedSolomonVandermonde: w=" << w
-	<< " must be one of {8, 16, 32} : revert to DEFAULT_W " << std::endl;
-    w = DEFAULT_W;
+	<< " must be one of {8, 16, 32} : revert to " << DEFAULT_W << std::endl;
+    profile["w"] = "8";
+    err |= to_int("w", profile, &w, DEFAULT_W, ss);
     err = -EINVAL;
   }
   err |= to_bool("jerasure-per-chunk-alignment", profile,
-		 &per_chunk_alignment, false, ss);
+		 &per_chunk_alignment, "false", ss);
   return err;
 }
 
@@ -248,11 +249,14 @@ int ErasureCodeJerasureReedSolomonRAID6::parse(ErasureCodeProfile &profile,
 					       ostream *ss)
 {
   int err = ErasureCodeJerasure::parse(profile, ss);
+  if (profile.find("m") != profile.end())
+    profile.erase("m");
   m = 2;
   if (w != 8 && w != 16 && w != 32) {
     *ss << "ReedSolomonRAID6: w=" << w
 	<< " must be one of {8, 16, 32} : revert to 8 " << std::endl;
-    w = 8;
+    profile["w"] = "8";
+    err |= to_int("w", profile, &w, DEFAULT_W, ss);
     err = -EINVAL;
   }
   return err;
@@ -305,7 +309,7 @@ int ErasureCodeJerasureCauchy::parse(ErasureCodeProfile &profile,
   int err = ErasureCodeJerasure::parse(profile, ss);
   err |= to_int("packetsize", profile, &packetsize, DEFAULT_PACKETSIZE, ss);
   err |= to_bool("jerasure-per-chunk-alignment", profile,
-		 &per_chunk_alignment, false, ss);
+		 &per_chunk_alignment, "false", ss);
   return err;
 }
 
@@ -412,13 +416,19 @@ bool ErasureCodeJerasureLiberation::check_packetsize(ostream *ss) const
   }
 }
 
-void ErasureCodeJerasureLiberation::revert_to_default(ostream *ss)
+int ErasureCodeJerasureLiberation::revert_to_default(ErasureCodeProfile &profile,
+						     ostream *ss)
 {
+  int err = 0;
   *ss << "reverting to k=" << DEFAULT_K << ", w="
       << DEFAULT_W << ", packetsize=" << DEFAULT_PACKETSIZE << std::endl;
-  k = DEFAULT_K;
-  w = DEFAULT_W;
-  packetsize = DEFAULT_PACKETSIZE;
+  profile["k"] = DEFAULT_K;
+  err |= to_int("k", profile, &k, DEFAULT_K, ss);
+  profile["w"] = DEFAULT_W;
+  err |= to_int("w", profile, &w, DEFAULT_W, ss);
+  profile["packetsize"] = DEFAULT_PACKETSIZE;
+  err |= to_int("packetsize", profile, &packetsize, DEFAULT_PACKETSIZE, ss);
+  return err;
 }
 
 int ErasureCodeJerasureLiberation::parse(ErasureCodeProfile &profile,
@@ -435,7 +445,7 @@ int ErasureCodeJerasureLiberation::parse(ErasureCodeProfile &profile,
   if (!check_packetsize_set(ss) || !check_packetsize(ss))
     error = true;
   if (error) {
-    revert_to_default(ss);
+    revert_to_default(profile, ss);
     err = -EINVAL;
   }
   return err;
@@ -478,8 +488,12 @@ int ErasureCodeJerasureLiber8tion::parse(ErasureCodeProfile &profile,
 					 ostream *ss)
 {
   int err = ErasureCodeJerasure::parse(profile, ss);
-  m = DEFAULT_M;
-  w = DEFAULT_W;
+  if (profile.find("m") != profile.end())
+    profile.erase("m");
+  err |= to_int("m", profile, &m, DEFAULT_M, ss);
+  if (profile.find("w") != profile.end())
+    profile.erase("w");
+  err |= to_int("w", profile, &w, DEFAULT_W, ss);
   err |= to_int("packetsize", profile, &packetsize, DEFAULT_PACKETSIZE, ss);
 
   bool error = false;
@@ -488,7 +502,7 @@ int ErasureCodeJerasureLiber8tion::parse(ErasureCodeProfile &profile,
   if (!check_packetsize_set(ss))
     error = true;
   if (error) {
-    revert_to_default(ss);
+    revert_to_default(profile, ss);
     err = -EINVAL;
   }
   return err;

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -20,14 +20,17 @@
 
 #include "erasure-code/ErasureCode.h"
 
+#define DEFAULT_RULESET_ROOT "default"
+#define DEFAULT_RULESET_FAILURE_DOMAIN "host"
+
 class ErasureCodeJerasure : public ErasureCode {
 public:
   int k;
-  int DEFAULT_K;
+  std::string DEFAULT_K;
   int m;
-  int DEFAULT_M;
+  std::string DEFAULT_M;
   int w;
-  int DEFAULT_W;
+  std::string DEFAULT_W;
   const char *technique;
   string ruleset_root;
   string ruleset_failure_domain;
@@ -35,14 +38,14 @@ public:
 
   ErasureCodeJerasure(const char *_technique) :
     k(0),
-    DEFAULT_K(2),
+    DEFAULT_K("2"),
     m(0),
-    DEFAULT_M(1),
+    DEFAULT_M("1"),
     w(0),
-    DEFAULT_W(8),
+    DEFAULT_W("8"),
     technique(_technique),
-    ruleset_root("default"),
-    ruleset_failure_domain("host"),
+    ruleset_root(DEFAULT_RULESET_ROOT),
+    ruleset_failure_domain(DEFAULT_RULESET_FAILURE_DOMAIN),
     per_chunk_alignment(false)
   {}
 
@@ -93,9 +96,9 @@ public:
     ErasureCodeJerasure("reed_sol_van"),
     matrix(0)
   {
-    DEFAULT_K = 7;
-    DEFAULT_M = 3;
-    DEFAULT_W = 8;
+    DEFAULT_K = "7";
+    DEFAULT_M = "3";
+    DEFAULT_W = "8";
   }
   virtual ~ErasureCodeJerasureReedSolomonVandermonde() {
     if (matrix)
@@ -122,8 +125,8 @@ public:
     ErasureCodeJerasure("reed_sol_r6_op"),
     matrix(0)
   {
-    DEFAULT_K = 7;
-    DEFAULT_W = 8;
+    DEFAULT_K = "7";
+    DEFAULT_W = "8";
   }
   virtual ~ErasureCodeJerasureReedSolomonRAID6() {
     if (matrix)
@@ -142,9 +145,10 @@ public:
   virtual void prepare();
 };
 
+#define DEFAULT_PACKETSIZE "2048"
+
 class ErasureCodeJerasureCauchy : public ErasureCodeJerasure {
 public:
-  static const int DEFAULT_PACKETSIZE = 2048;
   int *bitmatrix;
   int **schedule;
   int packetsize;
@@ -154,9 +158,9 @@ public:
     bitmatrix(0),
     schedule(0)
   {
-    DEFAULT_K = 7;
-    DEFAULT_M = 3;
-    DEFAULT_W = 8;
+    DEFAULT_K = "7";
+    DEFAULT_M = "3";
+    DEFAULT_W = "8";
   }
   virtual ~ErasureCodeJerasureCauchy() {
     if (bitmatrix)
@@ -197,7 +201,6 @@ public:
 
 class ErasureCodeJerasureLiberation : public ErasureCodeJerasure {
 public:
-  static const int DEFAULT_PACKETSIZE = 2048;
   int *bitmatrix;
   int **schedule;
   int packetsize;
@@ -207,9 +210,9 @@ public:
     bitmatrix(0),
     schedule(0)
   {
-    DEFAULT_K = 2;
-    DEFAULT_M = 2;
-    DEFAULT_W = 7;
+    DEFAULT_K = "2";
+    DEFAULT_M = "2";
+    DEFAULT_W = "7";
   }
   virtual ~ErasureCodeJerasureLiberation();
 
@@ -225,7 +228,8 @@ public:
   virtual bool check_w(ostream *ss) const;
   virtual bool check_packetsize_set(ostream *ss) const;
   virtual bool check_packetsize(ostream *ss) const;
-  virtual void revert_to_default(ostream *ss);
+  virtual int revert_to_default(ErasureCodeProfile &profile,
+				ostream *ss);
   virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   virtual void prepare();
 };
@@ -246,9 +250,9 @@ public:
   ErasureCodeJerasureLiber8tion() :
     ErasureCodeJerasureLiberation("liber8tion")
   {
-    DEFAULT_K = 2;
-    DEFAULT_M = 2;
-    DEFAULT_W = 8;
+    DEFAULT_K = "2";
+    DEFAULT_M = "2";
+    DEFAULT_W = "8";
   }
 
   virtual int parse(ErasureCodeProfile &profile, ostream *ss);

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -279,21 +279,23 @@ int ErasureCodeLrc::parse(ErasureCodeProfile &profile,
   return parse_ruleset(profile, ss);
 }
 
+const string ErasureCodeLrc::DEFAULT_KML("-1");
+
 int ErasureCodeLrc::parse_kml(ErasureCodeProfile &profile,
 			      ostream *ss)
 {
   int err = ErasureCode::parse(profile, ss);
-  const int DEFAULT = -1;
+  const int DEFAULT_INT = -1;
   int k, m, l;
-  err |= to_int("k", profile, &k, DEFAULT, ss);
-  err |= to_int("m", profile, &m, DEFAULT, ss);
-  err |= to_int("l", profile, &l, DEFAULT, ss);
+  err |= to_int("k", profile, &k, DEFAULT_KML, ss);
+  err |= to_int("m", profile, &m, DEFAULT_KML, ss);
+  err |= to_int("l", profile, &l, DEFAULT_KML, ss);
 
-  if (k == DEFAULT && m == DEFAULT && l == DEFAULT)
-    return 0;
+  if (k == DEFAULT_INT && m == DEFAULT_INT && l == DEFAULT_INT)
+    return err;
 
-  if ((k != DEFAULT || m != DEFAULT || l != DEFAULT) &&
-      (k == DEFAULT || m == DEFAULT || l == DEFAULT)) {
+  if ((k != DEFAULT_INT || m != DEFAULT_INT || l != DEFAULT_INT) &&
+      (k == DEFAULT_INT || m == DEFAULT_INT || l == DEFAULT_INT)) {
     *ss << "All of k, m, l must be set or none of them in "
 	<< profile << std::endl;
     return ERROR_LRC_ALL_OR_NOTHING;
@@ -388,10 +390,10 @@ int ErasureCodeLrc::parse_kml(ErasureCodeProfile &profile,
 int ErasureCodeLrc::parse_ruleset(ErasureCodeProfile &profile,
 				  ostream *ss)
 {
-  ErasureCodeProfile::const_iterator parameter;
-  parameter = profile.find("ruleset-root");
-  if (parameter != profile.end())
-    ruleset_root = parameter->second;
+  int err = 0;
+  err |= to_string("ruleset-root", profile,
+		   &ruleset_root,
+		   "default", ss);
 
   if (profile.count("ruleset-steps") != 0) {
     ruleset_steps.clear();
@@ -518,7 +520,21 @@ int ErasureCodeLrc::init(ErasureCodeProfile &profile,
   }
   chunk_count = mapping.length();
 
-  return layers_sanity_checks(description_string, ss);
+  r = layers_sanity_checks(description_string, ss);
+  if (r)
+    return r;
+
+  //
+  // When initialized with kml, the profile parameters
+  // that were generated should not be stored because
+  // they would otherwise be exposed to the caller.
+  //
+  if (profile.find("l") != profile.end() &&
+      profile.find("l")->second != DEFAULT_KML) {
+    profile.erase("mapping");
+    profile.erase("layers");
+  }
+  return 0;
 }
 
 set<int> ErasureCodeLrc::get_erasures(const set<int> &want,

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -382,7 +382,7 @@ int ErasureCodeLrc::parse_kml(ErasureCodeProfile &profile,
     ruleset_steps.push_back(Step("chooseleaf", ruleset_failure_domain, 0));
   }
 
-  return 0;
+  return err;
 }
 
 int ErasureCodeLrc::parse_ruleset(ErasureCodeProfile &profile,

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -46,6 +46,8 @@
 
 class ErasureCodeLrc : public ErasureCode {
 public:
+  static const string DEFAULT_KML;
+
   struct Layer {
     Layer(string _chunks_map) : chunks_map(_chunks_map) { }
     ErasureCodeInterfaceRef erasure_code;

--- a/src/erasure-code/shec/ErasureCodePluginShec.cc
+++ b/src/erasure-code/shec/ErasureCodePluginShec.cc
@@ -41,21 +41,19 @@ public:
 		      ErasureCodeInterfaceRef *erasure_code,
 		      ostream *ss) {
     ErasureCodeShec *interface;
-    std::string t = "multiple";
 
-    if (profile.find("technique") != profile.end()){
-      t = profile.find("technique")->second;
-    }
+    if (profile.find("technique") == profile.end())
+      profile["technique"] = "multiple";
+    std::string t = profile.find("technique")->second;
 
     if (t == "single"){
       interface = new ErasureCodeShecReedSolomonVandermonde(tcache, ErasureCodeShec::SINGLE);
     } else if (t == "multiple"){
       interface = new ErasureCodeShecReedSolomonVandermonde(tcache, ErasureCodeShec::MULTIPLE);
     } else {
-      derr << "technique=" << t << " is not a valid coding technique. "
-	   << " Choose one of the following: "
-	   << "single, multiple"
-	   << dendl;
+      *ss << "technique=" << t << " is not a valid coding technique. "
+	  << "Choose one of the following: "
+	  << "single, multiple ";
       return -ENOENT;
     }
     int r = interface->init(profile, ss);

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -58,13 +58,12 @@ int ErasureCodeShec::init(ErasureCodeProfile &profile,
 			  ostream *ss)
 {
   int err = 0;
-  map<string,string>::const_iterator parameter;
-  parameter = profile.find("ruleset-root");
-  if (parameter != profile.end())
-    ruleset_root = parameter->second;
-  parameter = profile.find("ruleset-failure-domain");
-  if (parameter != profile.end())
-    ruleset_failure_domain = parameter->second;
+  err |= to_string("ruleset-root", profile,
+		   &ruleset_root,
+		   DEFAULT_RULESET_ROOT, ss);
+  err |= to_string("ruleset-failure-domain", profile,
+		   &ruleset_failure_domain,
+		   DEFAULT_RULESET_FAILURE_DOMAIN, ss);
   err |= parse(profile);
   if (err)
     return err;

--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -26,6 +26,9 @@
 #include "ErasureCodeShecTableCache.h"
 #include <list>
 
+#define DEFAULT_RULESET_ROOT "default"
+#define DEFAULT_RULESET_FAILURE_DOMAIN "host"
+
 class ErasureCodeShec : public ErasureCode {
 
 public:
@@ -60,8 +63,8 @@ public:
     w(0),
     DEFAULT_W(8),
     technique(_technique),
-    ruleset_root("default"),
-    ruleset_failure_domain("host"),
+    ruleset_root(DEFAULT_RULESET_ROOT),
+    ruleset_failure_domain(DEFAULT_RULESET_FAILURE_DOMAIN),
     matrix(0)
   {}
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/9589 

In a nutshell it exposes the default values of an erasure coded profile to the user. For instance the failure domain used to build the crush ruleset. 