### PR TITLE
FileStore: sync object_map when we syncfs

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -2021,7 +2021,12 @@ void FileStore::_set_global_replay_guard(coll_t cid,
     return;
 
   // sync all previous operations on this sequencer
-  int ret = sync_filesystem(basedir_fd);
+  int ret = object_map->sync();
+  if (ret < 0) {
+    derr << __func__ << " : omap sync error " << cpp_strerror(ret) << dendl;
+    assert(0 == "_set_global_replay_guard failed");
+  }
+  ret = sync_filesystem(basedir_fd);
   if (ret < 0) {
     derr << __func__ << " :sync_filesytem error " << cpp_strerror(ret) << dendl;
     assert(0 == "_set_global_replay_guard failed");
@@ -3624,6 +3629,7 @@ void FileStore::sync_entry()
 	apply_manager.commit_started();
 	op_tp.unpause();
 
+	object_map->sync();
 	int err = backend->syncfs();
 	if (err < 0) {
 	  derr << "syncfs got " << cpp_strerror(err) << dendl;


### PR DESCRIPTION
This way, even if leveldb/rocksdb is on another filesystem/disk,
it will still be synced before trimming the journal.  Note, this
patch only syncs the object_map in the !backend->can_checkpoint()
case since if the backend can checkpoint, the checkpoint must
also capture the object_map since we have not been setting replay
guards in the object_map.

Signed-off-by: Samuel Just <sjust@redhat.com>