### PR TITLE
rbd: expunge xfstests generic/078

### DIFF
--- a/qa/run_xfstests_krbd.sh
+++ b/qa/run_xfstests_krbd.sh
@@ -34,6 +34,8 @@ cat > "${EXPUNGE}" <<-!
 			#  remove newlines. This breaks parsing on some
 			#  platforms.
 	generic/050	# blockdev --setro right after mkfs returns EBUSY
+	generic/078 # RENAME_WHITEOUT was enabled in kernel commit 7dcf5c, but causes
+			# a BUG for now
 	generic/081	# ubuntu lvm2 doesn't suport --yes argument
 	generic/083	# mkfs.xfs -dxize=104857600,agcount=6 fails
 			#  when sunit=swidth=8192


### PR DESCRIPTION
This tests RENAME_WHITEOUT, which was enabled for xfs in kernel commit
7dcf5c3e4527cfa2807567b00387cf2ed5e07f00. At first execution, it throws a BUG.
Subsequent executions appear to work correctly. This issue manifests for disks
and RBD instances.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>