### PR TITLE
fix the fedora build of rpm

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -175,7 +175,8 @@ Requires:	librados2 = %{epoch}:%{version}-%{release}
 BuildRequires:	libexpat-devel
 BuildRequires:	FastCGI-devel
 Requires:	apache2-mod_fcgid
-%else
+%endif
+%if (0%{?rhel} || 0%{?centos} || 0%{?fedora})
 BuildRequires:	expat-devel
 BuildRequires:	fcgi-devel
 %endif


### PR DESCRIPTION
Fedora build requires fcgi-devel just like rhel and centos.

Signed-off-by: Owen Synge <osynge@suse.com>