### PR TITLE
mon: check new crush for unknown name/type

### DIFF
--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -3,6 +3,7 @@
 
 #include "include/stringify.h"
 #include "CrushTester.h"
+#include "CrushTreeDumper.h"
 
 #include <algorithm>
 #include <stdlib.h>
@@ -381,6 +382,54 @@ int CrushTester::test_with_crushtool(const char *crushtool_cmd, int timeout)
   }
 
   return 0;
+}
+
+namespace {
+  class BadCrushMap : public std::runtime_error {
+  public:
+    int item;
+    BadCrushMap(const char* msg, int id)
+      : std::runtime_error(msg), item(id) {}
+  };
+  // throws if any node in the crush fail to print
+  class CrushWalker : public CrushTreeDumper::Dumper<void> {
+    typedef void DumbFormatter;
+    typedef CrushTreeDumper::Dumper<DumbFormatter> Parent;
+  public:
+    CrushWalker(const CrushWrapper *crush)
+      : Parent(crush) {}
+    void dump_item(const CrushTreeDumper::Item &qi, DumbFormatter *) {
+      int type = -1;
+      if (qi.is_bucket()) {
+	if (!crush->get_item_name(qi.id)) {
+	  throw BadCrushMap("unknown item name", qi.id);
+	}
+	type = crush->get_bucket_type(qi.id);
+      } else {
+	type = 0;
+      }
+      if (!crush->get_type_name(type)) {
+	throw BadCrushMap("unknown type name", qi.id);
+      }
+    }
+  };
+}
+
+bool CrushTester::check_name_maps() const
+{
+  CrushWalker crush_walker(&crush);
+  try {
+    // walk through the crush, to see if its self-contained
+    crush_walker.dump(NULL);
+    // and see if the maps is also able to handle straying OSDs, whose id >= 0.
+    // "ceph osd tree" will try to print them, even they are not listed in the
+    // crush map.
+    crush_walker.dump_item(CrushTreeDumper::Item(0, 0, 0), NULL);
+  } catch (const BadCrushMap& e) {
+    err << e.what() << ": item#" << e.item << std::endl;
+    return false;
+  }
+  return true;
 }
 
 int CrushTester::test()

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -7,7 +7,7 @@
 
 #include <algorithm>
 #include <stdlib.h>
-
+#include <boost/lexical_cast.hpp>
 #include <common/SubProcess.h>
 
 void CrushTester::set_device_weight(int dev, float f)
@@ -355,10 +355,11 @@ void CrushTester::write_integer_indexed_scalar_data_string(vector<string> &dst, 
   dst.push_back( data_buffer.str() );
 }
 
-int CrushTester::test_with_crushtool(const char *crushtool_cmd, int timeout)
+int CrushTester::test_with_crushtool(const char *crushtool_cmd, int max_id, int timeout)
 {
   SubProcessTimed crushtool(crushtool_cmd, true, false, true, timeout);
-  crushtool.add_cmd_args("-i", "-", "--test", NULL);
+  string opt_max_id = boost::lexical_cast<string>(max_id);
+  crushtool.add_cmd_args("-i", "-", "--test", "--check", opt_max_id.c_str(), NULL);
   int ret = crushtool.spawn();
   if (ret != 0) {
     err << "failed run crushtool: " << crushtool.err();

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -395,9 +395,10 @@ namespace {
   class CrushWalker : public CrushTreeDumper::Dumper<void> {
     typedef void DumbFormatter;
     typedef CrushTreeDumper::Dumper<DumbFormatter> Parent;
+    unsigned max_id;
   public:
-    CrushWalker(const CrushWrapper *crush)
-      : Parent(crush) {}
+    CrushWalker(const CrushWrapper *crush, unsigned max_id)
+      : Parent(crush), max_id(max_id) {}
     void dump_item(const CrushTreeDumper::Item &qi, DumbFormatter *) {
       int type = -1;
       if (qi.is_bucket()) {
@@ -406,6 +407,9 @@ namespace {
 	}
 	type = crush->get_bucket_type(qi.id);
       } else {
+	if (max_id > 0 && qi.id >= max_id) {
+	  throw BadCrushMap("item id too large", qi.id);
+	}
 	type = 0;
       }
       if (!crush->get_type_name(type)) {
@@ -415,9 +419,9 @@ namespace {
   };
 }
 
-bool CrushTester::check_name_maps() const
+bool CrushTester::check_name_maps(unsigned max_id) const
 {
-  CrushWalker crush_walker(&crush);
+  CrushWalker crush_walker(&crush, max_id);
   try {
     // walk through the crush, to see if its self-contained
     crush_walker.dump(NULL);

--- a/src/crush/CrushTester.h
+++ b/src/crush/CrushTester.h
@@ -333,6 +333,11 @@ public:
     min_rule = max_rule = rule;
   }
 
+  /**
+   * check if any bucket/nodes is referencing an unknown name or type
+   * @return false if an dangling name/type is referenced, true otherwise
+   */
+  bool check_name_maps() const;
   int test();
   int test_with_crushtool(const char *crushtool_cmd = "crushtool",
 			  int timeout = 0);

--- a/src/crush/CrushTester.h
+++ b/src/crush/CrushTester.h
@@ -335,9 +335,12 @@ public:
 
   /**
    * check if any bucket/nodes is referencing an unknown name or type
-   * @return false if an dangling name/type is referenced, true otherwise
+   * @param max_id rejects any non-bucket items with id less than this number,
+   *               pass 0 to disable this check
+   * @return false if an dangling name/type is referenced or an item id is too
+   *         large, true otherwise
    */
-  bool check_name_maps() const;
+  bool check_name_maps(unsigned max_id = 0) const;
   int test();
   int test_with_crushtool(const char *crushtool_cmd = "crushtool",
 			  int timeout = 0);

--- a/src/crush/CrushTester.h
+++ b/src/crush/CrushTester.h
@@ -343,6 +343,7 @@ public:
   bool check_name_maps(unsigned max_id = 0) const;
   int test();
   int test_with_crushtool(const char *crushtool_cmd = "crushtool",
+			  int max_id = -1,
 			  int timeout = 0);
 };
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4841,7 +4841,7 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
     dout(10) << " testing map" << dendl;
     stringstream ess;
     CrushTester tester(crush, ess);
-    if (!tester.check_name_maps()) {
+    if (!tester.check_name_maps(osdmap.get_max_osd())) {
       err = -EINVAL;
       ss << ess.str();
       goto reply;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4841,6 +4841,11 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
     dout(10) << " testing map" << dendl;
     stringstream ess;
     CrushTester tester(crush, ess);
+    if (!tester.check_name_maps()) {
+      err = -EINVAL;
+      ss << ess.str();
+      goto reply;
+    }
     // XXX: Use mon_lease as a timeout value for crushtool.
     // If the crushtool consistently takes longer than 'mon_lease' seconds,
     // then we would consistently trigger an election before the command

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4841,16 +4841,12 @@ bool OSDMonitor::prepare_command_impl(MMonCommand *m,
     dout(10) << " testing map" << dendl;
     stringstream ess;
     CrushTester tester(crush, ess);
-    if (!tester.check_name_maps(osdmap.get_max_osd())) {
-      err = -EINVAL;
-      ss << ess.str();
-      goto reply;
-    }
     // XXX: Use mon_lease as a timeout value for crushtool.
     // If the crushtool consistently takes longer than 'mon_lease' seconds,
     // then we would consistently trigger an election before the command
     // finishes, having a flapping monitor unable to hold quorum.
     int r = tester.test_with_crushtool(g_conf->crushtool.c_str(),
+				       osdmap.get_max_osd(),
 				       g_conf->mon_lease);
     if (r < 0) {
       derr << "error on crush map: " << ess.str() << dendl;

--- a/src/test/cli/crushtool/check-names.empty.crushmap.txt
+++ b/src/test/cli/crushtool/check-names.empty.crushmap.txt
@@ -1,0 +1,11 @@
+# begin crush map
+
+# devices
+
+# types
+
+# buckets
+
+# rules
+
+# end crush map

--- a/src/test/cli/crushtool/check-names.empty.t
+++ b/src/test/cli/crushtool/check-names.empty.t
@@ -1,0 +1,4 @@
+  $ crushtool -c "$TESTDIR/check-names.empty.crushmap.txt" -o "$TESTDIR/check-names.empty.crushmap"
+  $ crushtool -i "$TESTDIR/check-names.empty.crushmap" --check-names
+  unknown type name: item#0
+  $ rm -f "$TESTDIR/check-names.empty.crushmap"

--- a/src/test/cli/crushtool/check-names.max-id.t
+++ b/src/test/cli/crushtool/check-names.max-id.t
@@ -1,7 +1,7 @@
   $ crushtool -i "$TESTDIR/simple.template" --add-item 0 1.0 device0 --loc host host0 --loc cluster cluster0 -o check-names.crushmap > /dev/null
   $ crushtool -i check-names.crushmap       --add-item 1 1.0 device1 --loc host host0 --loc cluster cluster0 -o check-names.crushmap > /dev/null
-  $ crushtool -i check-names.crushmap --check-names=2
+  $ crushtool -i check-names.crushmap --check 2
   $ crushtool -i check-names.crushmap       --add-item 2 1.0 device2 --loc host host0 --loc cluster cluster0 -o check-names.crushmap > /dev/null
-  $ crushtool -i check-names.crushmap --check-names=2
+  $ crushtool -i check-names.crushmap --check 2
   item id too large: item#2
-  $ crushtool -i check-names.crushmap --check-names
+  $ crushtool -i check-names.crushmap --check

--- a/src/test/cli/crushtool/check-names.max-id.t
+++ b/src/test/cli/crushtool/check-names.max-id.t
@@ -1,0 +1,7 @@
+  $ crushtool -i "$TESTDIR/simple.template" --add-item 0 1.0 device0 --loc host host0 --loc cluster cluster0 -o check-names.crushmap > /dev/null
+  $ crushtool -i check-names.crushmap       --add-item 1 1.0 device1 --loc host host0 --loc cluster cluster0 -o check-names.crushmap > /dev/null
+  $ crushtool -i check-names.crushmap --check-names=2
+  $ crushtool -i check-names.crushmap       --add-item 2 1.0 device2 --loc host host0 --loc cluster cluster0 -o check-names.crushmap > /dev/null
+  $ crushtool -i check-names.crushmap --check-names=2
+  item id too large: item#2
+  $ crushtool -i check-names.crushmap --check-names

--- a/src/test/cli/crushtool/help.t
+++ b/src/test/cli/crushtool/help.t
@@ -59,7 +59,8 @@
   Options for the display/test stage
   
      --tree                print map summary as a tree
-     --check-names         check if any item is referencing an unknown name/type
+     --check-names [max_id]
+                           check if any item is referencing an unknown name/type
      -i mapfn --show-location id
                            show location for given device id
      -i mapfn --test       test a range of inputs on the map

--- a/src/test/cli/crushtool/help.t
+++ b/src/test/cli/crushtool/help.t
@@ -59,8 +59,7 @@
   Options for the display/test stage
   
      --tree                print map summary as a tree
-     --check-names [max_id]
-                           check if any item is referencing an unknown name/type
+     --check [max_id]      check if any item is referencing an unknown name/type
      -i mapfn --show-location id
                            show location for given device id
      -i mapfn --test       test a range of inputs on the map

--- a/src/test/cli/crushtool/help.t
+++ b/src/test/cli/crushtool/help.t
@@ -59,6 +59,7 @@
   Options for the display/test stage
   
      --tree                print map summary as a tree
+     --check-names         check if any item is referencing an unknown name/type
      -i mapfn --show-location id
                            show location for given device id
      -i mapfn --test       test a range of inputs on the map

--- a/src/test/mon/osd-crush.sh
+++ b/src/test/mon/osd-crush.sh
@@ -205,6 +205,19 @@ function TEST_crush_rename_bucket() {
     ./ceph osd crush rename-bucket nonexistent something 2>&1 | grep "Error ENOENT" || return 1
 }
 
+function TEST_crush_reject_empty() {
+    local dir=$1
+    run_mon $dir a || return 1
+    # should have at least one OSD
+    run_osd $dir 0 || return 1
+
+    local empty_map=$dir/empty_map
+    :> $empty_map.txt
+    ./crushtool -c $empty_map.txt -o $empty_map.map || return 1
+    expect_failure $dir "Error EINVAL" \
+        ./ceph osd setcrushmap -i $empty_map.map || return 1
+}
+
 main osd-crush "$@"
 
 # Local Variables:

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -165,7 +165,8 @@ void usage()
   cout << "Options for the display/test stage\n";
   cout << "\n";
   cout << "   --tree                print map summary as a tree\n";
-  cout << "   --check-names         check if any item is referencing an unknown name/type\n";
+  cout << "   --check-names [max_id]\n";
+  cout << "                         check if any item is referencing an unknown name/type\n";
   cout << "   -i mapfn --show-location id\n";
   cout << "                         show location for given device id\n";
   cout << "   -i mapfn --test       test a range of inputs on the map\n";
@@ -228,6 +229,7 @@ int main(int argc, const char **argv)
   bool compile = false;
   bool decompile = false;
   bool check_names = false;
+  int max_id = -1;
   bool test = false;
   bool display = false;
   bool tree = false;
@@ -313,7 +315,7 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "-c", "--compile", (char*)NULL)) {
       srcfn = val;
       compile = true;
-    } else if (ceph_argparse_flag(args, i, "--check-names", (char*)NULL)) {
+    } else if (ceph_argparse_witharg(args, i, &max_id, err, "--check-names", (char*)NULL)) {
       check_names = true;
     } else if (ceph_argparse_flag(args, i, "-t", "--test", (char*)NULL)) {
       test = true;
@@ -828,7 +830,7 @@ int main(int argc, const char **argv)
   }
 
   if (check_names) {
-    if (!tester.check_name_maps()) {
+    if (!tester.check_name_maps(max_id)) {
       exit(1);
     }
   }

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -165,8 +165,7 @@ void usage()
   cout << "Options for the display/test stage\n";
   cout << "\n";
   cout << "   --tree                print map summary as a tree\n";
-  cout << "   --check-names [max_id]\n";
-  cout << "                         check if any item is referencing an unknown name/type\n";
+  cout << "   --check [max_id]      check if any item is referencing an unknown name/type\n";
   cout << "   -i mapfn --show-location id\n";
   cout << "                         show location for given device id\n";
   cout << "   -i mapfn --test       test a range of inputs on the map\n";
@@ -228,7 +227,7 @@ int main(int argc, const char **argv)
   std::string infn, srcfn, outfn, add_name, remove_name, reweight_name;
   bool compile = false;
   bool decompile = false;
-  bool check_names = false;
+  bool check = false;
   int max_id = -1;
   bool test = false;
   bool display = false;
@@ -315,8 +314,8 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "-c", "--compile", (char*)NULL)) {
       srcfn = val;
       compile = true;
-    } else if (ceph_argparse_witharg(args, i, &max_id, err, "--check-names", (char*)NULL)) {
-      check_names = true;
+    } else if (ceph_argparse_witharg(args, i, &max_id, err, "--check", (char*)NULL)) {
+      check = true;
     } else if (ceph_argparse_flag(args, i, "-t", "--test", (char*)NULL)) {
       test = true;
     } else if (ceph_argparse_witharg(args, i, &full_location, err, "--show-location", (char*)NULL)) {
@@ -503,7 +502,7 @@ int main(int argc, const char **argv)
     }
   }
 
-  if (test && !check_name && !display && !write_to_file) {
+  if (test && !check && !display && !write_to_file) {
     cerr << "WARNING: no output selected; use --output-csv or --show-X" << std::endl;
   }
 
@@ -511,7 +510,7 @@ int main(int argc, const char **argv)
     cerr << "cannot specify more than one of compile, decompile, and build" << std::endl;
     exit(EXIT_FAILURE);
   }
-  if (!check_names && !compile && !decompile && !build && !test && !reweight && !adjust && !tree &&
+  if (!check && !compile && !decompile && !build && !test && !reweight && !adjust && !tree &&
       add_item < 0 && full_location < 0 &&
       remove_name.empty() && reweight_name.empty()) {
     cerr << "no action specified; -h for help" << std::endl;
@@ -829,7 +828,7 @@ int main(int argc, const char **argv)
     }
   }
 
-  if (check_names) {
+  if (check) {
     if (!tester.check_name_maps(max_id)) {
       exit(1);
     }

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -165,6 +165,7 @@ void usage()
   cout << "Options for the display/test stage\n";
   cout << "\n";
   cout << "   --tree                print map summary as a tree\n";
+  cout << "   --check-names         check if any item is referencing an unknown name/type\n";
   cout << "   -i mapfn --show-location id\n";
   cout << "                         show location for given device id\n";
   cout << "   -i mapfn --test       test a range of inputs on the map\n";
@@ -226,6 +227,7 @@ int main(int argc, const char **argv)
   std::string infn, srcfn, outfn, add_name, remove_name, reweight_name;
   bool compile = false;
   bool decompile = false;
+  bool check_names = false;
   bool test = false;
   bool display = false;
   bool tree = false;
@@ -311,6 +313,8 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "-c", "--compile", (char*)NULL)) {
       srcfn = val;
       compile = true;
+    } else if (ceph_argparse_flag(args, i, "--check-names", (char*)NULL)) {
+      check_names = true;
     } else if (ceph_argparse_flag(args, i, "-t", "--test", (char*)NULL)) {
       test = true;
     } else if (ceph_argparse_witharg(args, i, &full_location, err, "--show-location", (char*)NULL)) {
@@ -497,7 +501,7 @@ int main(int argc, const char **argv)
     }
   }
 
-  if (test && !display && !write_to_file) {
+  if (test && !check_name && !display && !write_to_file) {
     cerr << "WARNING: no output selected; use --output-csv or --show-X" << std::endl;
   }
 
@@ -505,7 +509,7 @@ int main(int argc, const char **argv)
     cerr << "cannot specify more than one of compile, decompile, and build" << std::endl;
     exit(EXIT_FAILURE);
   }
-  if (!compile && !decompile && !build && !test && !reweight && !adjust && !tree &&
+  if (!check_names && !compile && !decompile && !build && !test && !reweight && !adjust && !tree &&
       add_item < 0 && full_location < 0 &&
       remove_name.empty() && reweight_name.empty()) {
     cerr << "no action specified; -h for help" << std::endl;
@@ -820,6 +824,12 @@ int main(int argc, const char **argv)
       o.close();
     } else {
       cc.decompile(cout);
+    }
+  }
+
+  if (check_names) {
+    if (!tester.check_name_maps()) {
+      exit(1);
     }
   }
 


### PR DESCRIPTION
* check to see if all OSDs in current osdmap are covered by provided
  crush map, reject it if any OSD is absent.

Fixes: #11680
Signed-off-by: Kefu Chai <kchai@redhat.com>