### PR TITLE
ceph.spec.in: Forward port suse build deps and recomends

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -79,8 +79,6 @@ BuildRequires:	python-nose
 BuildRequires:	python-requests
 %if ( 0%{?rhel} > 0 && 0%{?rhel} < 7 ) || ( 0%{?centos} > 0 && 0%{?centos} < 7 )
 BuildRequires:	python-sphinx10
-%else
-BuildRequires:	python-sphinx
 %endif
 BuildRequires:	python-virtualenv
 BuildRequires:	util-linux
@@ -91,9 +89,6 @@ BuildRequires:	yasm
 %if 0%{?rhel} || 0%{?fedora} || 0%{?suse_version}
 BuildRequires:	snappy-devel
 %endif
-%if 0%{?suse_version}
-BuildRequires:	net-tools
-%endif
 
 #################################################################################
 # specific
@@ -103,6 +98,15 @@ BuildRequires:	sharutils
 %endif
 
 %if 0%{defined suse_version}
+BuildRequires:	python-sphinx
+BuildRequires:	net-tools
+BuildRequires:	xmlstarlet
+BuildRequires:	yasm
+BuildRequires:	libbz2-devel
+BuildRequires:	python-sphinx
+BuildRequires:	net-tools
+BuildRequires:	sharutils
+BuildRequires:	git
 %if 0%{?suse_version} > 1210
 Requires:	gptfdisk
 BuildRequires:	gperftools-devel
@@ -123,8 +127,8 @@ BuildRequires:	keyutils-libs-devel
 BuildRequires:	libatomic_ops-devel
 Requires:	gdisk
 Requires(post):	chkconfig
-Requires(preun):chkconfig
-Requires(preun):initscripts
+Requires(preun):	chkconfig
+Requires(preun):	initscripts
 BuildRequires:	gperftools-devel
 %endif
 
@@ -150,7 +154,10 @@ Requires:	python-requests
 Requires:  python-argparse
 %endif
 %if 0%{?rhel} || 0%{?fedora}
-Requires:  redhat-lsb-core
+Requires:	redhat-lsb-core
+%endif
+%if 0%{defined suse_version}
+Requires:	lsb-release
 %endif
 %description -n ceph-common
 Common utilities to mount and interact with a ceph storage cluster.
@@ -182,7 +189,8 @@ Requires:	librados2 = %{epoch}:%{version}-%{release}
 BuildRequires:	libexpat-devel
 BuildRequires:	FastCGI-devel
 Requires:	apache2-mod_fcgid
-%else
+%endif
+%if 0%{?rhel} || 0%{?fedora}
 BuildRequires:	expat-devel
 BuildRequires:	fcgi-devel
 %endif


### PR DESCRIPTION
SUSE spec file got very out of sync with upstream master. This patch
helps resolve teh build depednancies from suse ceph.

Signed-off-by: Owen Synge <osynge@suse.com>