### PR TITLE
osd: the osd proxy feature bit is not turned on

### DIFF
--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -148,6 +148,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_MDS_QUOTA | \
          CEPH_FEATURE_CRUSH_V4 |	     \
          CEPH_FEATURE_OSD_MIN_SIZE_RECOVERY |		 \
+         CEPH_FEATURE_OSD_PROXY_FEATURES |	\
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL


### PR DESCRIPTION
Put it in CEPH_FEATURES_ALL to turn it on.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>