### PR TITLE
[DNM] Rbd: support copy-on-read option

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -430,6 +430,7 @@ the running kernel.
 
 * ro - Map the image read-only.  Equivalent to --read-only.
 
+* cor - Map the image with copy-on-read turned on.
 
 Examples
 ========

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -2545,6 +2545,8 @@ static int parse_map_options(char *options)
         return 1;
     } else if (!strcmp(this_char, "rw") || !strcmp(this_char, "ro")) {
       put_map_option("rw", this_char);
+    } else if (!strcmp(this_char, "cor")) {
+      put_map_option("cor", this_char);
     } else {
       cerr << "rbd: unknown map option '" << this_char << "'" << std::endl;
       return 1;


### PR DESCRIPTION
This is corresponding to the copy-on-read support for kernel rbd client at
https://github.com/ceph/ceph-client/pull/11