### PR TITLE
osd: fix blacklist field in OSDMap::dump

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -893,8 +893,13 @@ function test_mon_osd()
   # osd blacklist
   #
   bl=192.168.0.1:0/1000
+  # Escaped form which may appear in JSON output
+  bl_json=192.168.0.1:0\\\\/1000
   ceph osd blacklist add $bl
   ceph osd blacklist ls | grep $bl
+  ceph osd blacklist ls --format=json-pretty | grep $bl_json
+  ceph osd dump --format=json-pretty | grep $bl
+  ceph osd dump | grep "^blacklist $bl"
   ceph osd blacklist rm $bl
   expect_false "ceph osd blacklist ls | grep $bl"
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2318,7 +2318,7 @@ void OSDMap::dump(Formatter *f) const
   }
   f->close_section(); // primary_temp
 
-  f->open_array_section("blacklist");
+  f->open_object_section("blacklist");
   for (ceph::unordered_map<entity_addr_t,utime_t>::const_iterator p = blacklist.begin();
        p != blacklist.end();
        ++p) {


### PR DESCRIPTION
This was using an array_section so we were getting
a list of only the times, instead of an array
mapping addr to time.

Signed-off-by: John Spray <john.spray@redhat.com>