### PR TITLE
tests: don't choke on deleted losetup paths

### DIFF
--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -419,7 +419,9 @@ function reset_leftover_dev() {
     local path=$1
 
     losetup --all | sed -e 's/://' | while read dev id associated_path ; do
-        if test $associated_path = "($path)" ; then
+        # if $path has been deleted with a dev attached, then $associated_path
+        # will carry "($path (deleted))".
+        if test "$associated_path" = "($path)" ; then
             reset_dev $dev
             losetup --detach $dev
         fi


### PR DESCRIPTION
If a file has been deleted with a loopback device attached, then the
`losetup --all` output will carry:
/dev/loopX: [0032]:344213 (/.../src/test-ceph-disk/vdf.disk (deleted))

This causes the losetup parsing in reset_leftover_dev() to throw an
error, e.g.:
rreset_leftover_dev: 430: test
'(/home/ddiss/ceph/src/test-ceph-disk/vdf.disk' '(deleted))' =
'(/home/ddiss/ceph/src/test-ceph-disk/vdf.disk)'
test/ceph-disk.sh: line 430: test: too many arguments

Fix this by quoting the path variable for the string comparison.

Signed-off-by: David Disseldorp <ddiss@suse.de>