### PR TITLE
xio: several bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,4 +241,6 @@ set(OperatingSystem "Mac OS X")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 add_subdirectory(src)
-add_subdirectory(man)
+
+# man pages must be preprocessed, not supported yet
+#add_subdirectory(man)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -336,7 +336,8 @@ set(librados_srcs
   )
 add_library(librados ${CEPH_SHARED} ${librados_srcs}
   $<TARGET_OBJECTS:cls_references_objs>
-  $<TARGET_OBJECTS:heap_profiler_objs>)
+  $<TARGET_OBJECTS:heap_profiler_objs>
+  $<TARGET_OBJECTS:common_util_obj>)
 add_dependencies(librados osdc)
 target_link_libraries(librados PRIVATE osdc osd os global common cls_lock_client
   ${CRYPTO_LIBS} ${EXTRALIBS} ${TCMALLOC_LIBS})
@@ -482,7 +483,9 @@ target_link_libraries(osd dl leveldb)
 set(ceph_osd_srcs
   ceph_osd.cc
   objclass/class_api.cc)
-add_executable(ceph-osd ${ceph_osd_srcs} $<TARGET_OBJECTS:heap_profiler_objs>)
+add_executable(ceph-osd ${ceph_osd_srcs}
+  $<TARGET_OBJECTS:heap_profiler_objs>
+  $<TARGET_OBJECTS:common_util_obj>)
 target_link_libraries(ceph-osd osd os global ${TCMALLOC_LIBS})
 install(TARGETS ceph-osd DESTINATION bin)
 
@@ -524,7 +527,9 @@ if(${WITH_MDS})
   add_library(mds ${mds_srcs})
   set(ceph_mds_srcs
     ceph_mds.cc)
-  add_executable(ceph-mds ${ceph_mds_srcs} $<TARGET_OBJECTS:heap_profiler_objs>)
+  add_executable(ceph-mds ${ceph_mds_srcs}
+    $<TARGET_OBJECTS:heap_profiler_objs>
+    $<TARGET_OBJECTS:common_util_obj>)
   target_link_libraries(ceph-mds mds osdc ${CMAKE_DL_LIBS} global
     ${TCMALLOC_LIBS} boost_thread)
   install(TARGETS ceph-mds DESTINATION bin)

--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -520,8 +520,7 @@ int XioConnection::discard_input_queue(uint32_t flags)
     pthread_spin_unlock(&sp);
 
   // mqueue
-  int ix, q_size =  disc_q.size();
-  for (ix = 0; ix < q_size; ++ix) {
+  while (!disc_q.empty()) {
     Message::Queue::iterator q_iter = disc_q.begin();
     Message* m = &(*q_iter);
     disc_q.erase(q_iter);
@@ -529,8 +528,7 @@ int XioConnection::discard_input_queue(uint32_t flags)
   }
 
   // requeue
-  q_size =  deferred_q.size();
-  for (ix = 0; ix < q_size; ++ix) {
+  while (!deferred_q.empty()) {
     XioSubmit::Queue::iterator q_iter = deferred_q.begin();
     XioSubmit* xs = &(*q_iter);
     XioMsg* xmsg;
@@ -539,8 +537,7 @@ int XioConnection::discard_input_queue(uint32_t flags)
 	xmsg = static_cast<XioMsg*>(xs);
 	deferred_q.erase(q_iter);
 	// release once for each chained xio_msg
-	for (ix = 0; ix < int(xmsg->hdr.msg_cnt); ++ix)
-	  xmsg->put();
+	xmsg->put(xmsg->hdr.msg_cnt);
 	break;
       case XioSubmit::INCOMING_MSG_RELEASE:
 	deferred_q.erase(q_iter);

--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -228,8 +228,6 @@ private:
     connected.set(false);
     pthread_spin_lock(&sp);
     discard_input_queue(CState::OP_FLAG_LOCKED);
-    if (!conn)
-      this->put();
     pthread_spin_unlock(&sp);
     return 0;
   }

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -529,11 +529,13 @@ int XioMessenger::session_event(struct xio_session *session,
 	  conns_entity_map.erase(conn_iter);
 	}
       }
-      /* now find xcon on conns_list, erase, and release sentinel ref */
-      XioConnection::ConnList::iterator citer =
-	XioConnection::ConnList::s_iterator_to(*xcon);
-      /* XXX check if citer on conn_list? */
-      conns_list.erase(citer);
+      /* check if citer on conn_list */
+      if (xcon->conns_hook.is_linked()) {
+        /* now find xcon on conns_list and erase */
+        XioConnection::ConnList::iterator citer =
+            XioConnection::ConnList::s_iterator_to(*xcon);
+        conns_list.erase(citer);
+      }
       xcon->on_disconnect_event();
     }
     break;

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -733,6 +733,7 @@ int XioMessenger::bind(const entity_addr_t& addr)
   int r = portals.bind(&xio_msgr_ops, base_uri, shift_addr.get_port(), &port0);
   if (r == 0) {
     shift_addr.set_port(port0);
+    shift_addr.nonce = nonce;
     set_myaddr(shift_addr);
     did_bind = true;
   }

--- a/src/msg/xio/XioPortal.h
+++ b/src/msg/xio/XioPortal.h
@@ -67,7 +67,7 @@ private:
 
     inline Lane* get_lane(XioConnection *xcon)
       {
-	return &qlane[((uint64_t) xcon) % nlanes];
+	return &qlane[(((uint64_t) xcon) / 16) % nlanes];
       }
 
     void enq(XioConnection *xcon, XioSubmit* xs)

--- a/src/msg/xio/XioPortal.h
+++ b/src/msg/xio/XioPortal.h
@@ -159,17 +159,16 @@ public:
     struct xio_msg *msg = xrsp->dequeue();
     struct xio_msg *next_msg = NULL;
     int code;
-    while (msg) {
+    if (unlikely(!xrsp->xcon->conn || !xrsp->xcon->is_connected())) {
+      // NOTE: msg is not safe to dereference if the connection was torn down
+      xrsp->xcon->msg_release_fail(msg, ENOTCONN);
+    }
+    else while (msg) {
       next_msg = static_cast<struct xio_msg *>(msg->user_context);
-      if (unlikely(!xrsp->xcon->conn || !xrsp->xcon->is_connected()))
-        code = ENOTCONN;
-      else
-        code = xio_release_msg(msg);
-      if (unlikely(code)) {
-	/* very unlikely, so log it */
+      code = xio_release_msg(msg);
+      if (unlikely(code)) /* very unlikely, so log it */
 	xrsp->xcon->msg_release_fail(msg, code);
-      }
-      msg =  next_msg;
+      msg = next_msg;
     }
     xrsp->finalize(); /* unconditional finalize */
   }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1111,6 +1111,7 @@ add_executable(test_librbd
   librbd/test_fixture.cc
   librbd/test_ImageWatcher.cc
   librbd/test_internal.cc
+  librbd/test_support.cc
   librbd/test_main.cc
   $<TARGET_OBJECTS:heap_profiler_objs>
   ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc


### PR DESCRIPTION
xio:
 + fix reuse of outer loop index in inner loop
 + malloc if xio_mempool_alloc fails
 + fix for xio_msg release after teardown
 + use ceph clock for timestamps
 + save nonce for bind address
 + check if connection is on list before erasing
 + better way to assign connections to specific lane
cmake: add missing source files & update CMakelists.txt