### PR TITLE
rbd: document mount_timeout in the man page

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -422,6 +422,11 @@ the running kernel.
 
 * notcp_nodelay - Enable Nagle's algorithm on client sockets (since 4.0).
 
+* mount_timeout=x - A timeout on various steps in `rbd map` and `rbd unmap`
+  sequences (default is 60 seconds).  In particular, since 4.2 this can be used
+  to ensure that `rbd unmap` eventually times out when there is no network
+  connection to a cluster.
+
 * osdkeepalive=x - OSD keepalive timeout (default is 5 seconds).
 
 * osd_idle_ttl=x - OSD idle TTL (default is 60 seconds).


### PR DESCRIPTION
With "rbd: timeout watch teardown on unmap with mount_timeout" going
into kernel 4.2, document its effect in the man page.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>