### PR TITLE
Mutex: fix memory leak in lockdep _register

### DIFF
--- a/src/common/Mutex.cc
+++ b/src/common/Mutex.cc
@@ -55,6 +55,7 @@ Mutex::Mutex(const char *n, bool r, bool ld,
     pthread_mutexattr_init(&attr);
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
     pthread_mutex_init(&_m, &attr);
+    pthread_mutexattr_destroy(&attr);
     if (g_lockdep)
       _register();
   }


### PR DESCRIPTION
Need pthread_mutexattr_destroy after pthread_mutexattr_init,
or there will be memory leak.

Signed-off-by: Ketor Meng <d.ketor@gmail.com>