### PR TITLE
Autotools to install systemd unit files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ py-compile
 release
 stamp-h1
 systemd/ceph-osd@.service
+systemd/Makefile
 vgcore.*
 
 # specific local dir files

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = gnu
 ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = autogen.sh ceph.spec.in ceph.spec install-deps.sh
 # the "." here makes sure check-local builds gtest and gmock before they are used
-SUBDIRS = . src man doc
+SUBDIRS = . src man doc systemd
 
 EXTRA_DIST += \
 	src/test/run-cli-tests \

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -486,6 +486,12 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--prefix=/usr \
 		--localstatedir=/var \
 		--sysconfdir=/etc \
+%if 0%{?rhel} || 0%{?fedora}
+		--with-systemd-libexec-dir=/usr/lib/systemd/system) \
+%endif
+%if 0%{?opensuse} || 0%{?suse_version}
+		--with-systemd-unit-dir=%_unitdir \
+%endif
 		--docdir=%{_docdir}/ceph \
 		--with-nss \
 		--without-cryptopp \

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -653,6 +653,10 @@ fi
 %{_initrddir}/ceph
 %if 0%{?_with_systemd}
 %{_tmpfilesdir}/%{name}.conf
+%{_unitdir}/ceph-mds@.service
+%{_unitdir}/ceph-mon@.service
+%{_unitdir}/ceph-osd@.service
+%{_unitdir}/ceph.target
 %endif
 %{_sbindir}/ceph-disk
 %{_sbindir}/ceph-disk-activate

--- a/configure.ac
+++ b/configure.ac
@@ -1204,6 +1204,23 @@ AC_ARG_WITH(
     ]
 )
 
+AC_SUBST(systemd_unit_dir)
+AC_ARG_WITH(
+    systemd-unit-dir,
+    AS_HELP_STRING(
+	    [--with-systemd-unit-dir=DIR],
+	    [systemd unit directory @<:@SYSTEMD_UNIT_DIR@:>@
+        Defaults to /etc/systemd/system/]
+    ),
+    [
+	    systemd_unit_dir="$withval"
+    ],
+    [
+        # default to the system admin unit directory
+        systemd_unit_dir="/etc/systemd/system/"
+    ]
+)
+
 # Checks for typedefs, structures, and compiler characteristics.
 #AC_HEADER_STDBOOL
 #AC_C_CONST
@@ -1264,6 +1281,7 @@ AC_CONFIG_FILES([Makefile
 	src/ocf/rbd
 	src/java/Makefile
 	src/tracing/Makefile
+	systemd/Makefile
 	man/Makefile
 	doc/Makefile
 	systemd/ceph-osd@.service

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -1,0 +1,11 @@
+unitfiles = \
+	ceph.target \
+	ceph-mds@.service \
+	ceph-mon@.service \
+	ceph-osd@.service
+
+unitdir = $(systemd_unit_dir)
+
+unit_DATA = $(unitfiles)
+
+EXTRA_DIST = $(unitfiles)


### PR DESCRIPTION
To simplify the spec file we should install as much using autotools
and as little as possible in the spec file.

Signed-off-by: Owen Synge <osynge@suse.com>