### PR TITLE
Debian: ceph-test and rest-bench debug packages should require their respective binary packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -451,7 +451,8 @@ Package: rest-bench-dbg
 Architecture: linux-any
 Section: debug
 Priority: extra
-Depends: ceph-common, curl, xml2, ${misc:Depends}, ${shlibs:Depends}
+Depends: rest-bench (= ${binary:Version}), ceph-common, curl, xml2,
+          ${misc:Depends}, ${shlibs:Depends}
 Description: debugging symbols for rest-bench
  radosgw performance.
  .
@@ -467,7 +468,8 @@ Package: ceph-test-dbg
 Architecture: linux-any
 Section: debug
 Priority: extra
-Depends: ceph-common, curl, xml2, ${misc:Depends}, ${shlibs:Depends}
+Depends: ceph-test (= ${binary:Version}), ceph-common, curl, xml2,
+         ${misc:Depends}, ${shlibs:Depends}
 Description: Ceph test and benchmarking tools
  .
  This package contains the debugging symbols for ceph-test.


### PR DESCRIPTION
http://tracker.ceph.com/issues/11733