### PR TITLE
AsyncMessenger: Make send/receive logic independent

### DIFF
--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -194,6 +194,7 @@ public:
     }
   }
   void encode_payload(uint64_t features) {
+    header.version = HEAD_VERSION;
     head.snap_trace_len = snapbl.length();
     head.xattr_len = xattrbl.length();
 

--- a/src/messages/MClientReconnect.h
+++ b/src/messages/MClientReconnect.h
@@ -56,6 +56,7 @@ public:
     data.clear();
     if (features & CEPH_FEATURE_MDSENC) {
       ::encode(caps, data);
+      header.version = HEAD_VERSION;
     } else if (features & CEPH_FEATURE_FLOCK) {
       // encode with old cap_reconnect_t encoding
       __u32 n = caps.size();

--- a/src/messages/MClientSession.h
+++ b/src/messages/MClientSession.h
@@ -76,6 +76,7 @@ public:
       header.version = 1;
     } else {
       ::encode(client_meta, payload);
+      header.version = HEAD_VERSION;
     }
 
   }

--- a/src/messages/MMonPaxos.h
+++ b/src/messages/MMonPaxos.h
@@ -92,6 +92,8 @@ public:
   void encode_payload(uint64_t features) {
     if ((features & CEPH_FEATURE_MONCLOCKCHECK) == 0)
       header.version = 0;
+    else
+      header.version = HEAD_VERSION;
     ::encode(epoch, payload);
     ::encode(op, payload);
     ::encode(first_committed, payload);

--- a/src/messages/MMonSubscribe.h
+++ b/src/messages/MMonSubscribe.h
@@ -74,6 +74,7 @@ public:
   void encode_payload(uint64_t features) {
     if (features & CEPH_FEATURE_SUBSCRIBE2) {
       ::encode(what, payload);
+      header.version = HEAD_VERSION;
     } else {
       header.version = 0;
       map<string, ceph_mon_subscribe_item_old> oldwhat;

--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -80,6 +80,7 @@ public:
     }
   }
   void encode_payload(uint64_t features) {
+    header.version = HEAD_VERSION;
     ::encode(fsid, payload);
     if ((features & CEPH_FEATURE_PGID64) == 0 ||
 	(features & CEPH_FEATURE_PGPOOL3) == 0 ||

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -241,6 +241,7 @@ struct ceph_osd_request_head {
       ::encode_nohead(oid.name, payload);
       ::encode_nohead(snaps, payload);
     } else {
+      header.version = HEAD_VERSION;
       ::encode(client_inc, payload);
       ::encode(osdmap_epoch, payload);
       ::encode(flags, payload);

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -169,6 +169,7 @@ public:
       }
       ::encode_nohead(oid.name, payload);
     } else {
+      header.version = HEAD_VERSION;
       ::encode(oid, payload);
       ::encode(pgid, payload);
       ::encode(flags, payload);

--- a/src/messages/MRoute.h
+++ b/src/messages/MRoute.h
@@ -60,6 +60,8 @@ public:
     ::encode(session_mon_tid, payload);
     ::encode(dest, payload);
     if (features & CEPH_FEATURE_MON_NULLROUTE) {
+      header.version = HEAD_VERSION;
+      header.compat_version = COMPAT_VERSION;
       bool m = msg ? true : false;
       ::encode(m, payload);
       if (msg)

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1968,6 +1968,7 @@ int AsyncConnection::send_message(Message *m)
   if (can_write == NOWRITE || get_features() != f) {
     // ensure the correctness of message encoding
     bl.clear();
+    m->get_payload().clear();
     ldout(async_msgr->cct, 5) << __func__ << " clear encoded buffer, can_write=" << can_write << " previous "
                               << f << " != " << get_features() << dendl;
   }

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -45,13 +45,13 @@ class AsyncConnection : public Connection {
 
   int read_bulk(int fd, char *buf, int len);
   int do_sendmsg(struct msghdr &msg, int len, bool more);
-  int try_send(bufferlist bl, bool send=true) {
+  int try_send(bufferlist &bl, bool send=true) {
     Mutex::Locker l(write_lock);
     return _try_send(bl, send);
   }
   // if "send" is false, it will only append bl to send buffer
   // the main usage is avoid error happen outside messenger threads
-  int _try_send(bufferlist bl, bool send=true);
+  int _try_send(bufferlist &bl, bool send=true);
   int _send(Message *m);
   void prepare_send_message(Message *m, bufferlist &bl);
   int read_until(uint64_t needed, char *p);

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -55,20 +55,6 @@ class AsyncConnection : public Connection {
   int _try_send(bufferlist &bl, bool send=true);
   int _send(Message *m);
   void prepare_send_message(uint64_t features, Message *m, bufferlist &bl);
-#define HEADER_CRC_OFF (sizeof(char)+offset(ceph_msg_header, crc))
-  void inject_msg_header_crc(m, bl) {
-    if (msgr->crcflags & MSG_CRC_HEADER) {
-      if (has_feature(CEPH_FEATURE_NOSRCADDR)) {
-        __le32 *header_crc = static_cast<__le32*>(&bl[HEADER_CRC_OFF]);
-        m->calc_header_crc();
-        *header_crc = m->get_header().crc;
-      } else {
-        ceph_msg_header_old *oldheader = static_cast<ceph_msg_header_old*>(&bl[sizeof(char)]);
-        oldheader->crc = ceph_crc32c(0, (unsigned char*)oldheader,
-                                     sizeof(*oldheader) - sizeof(oldheader->crc));
-      }
-    }
-  }
   int read_until(uint64_t needed, char *p);
   int _process_connection();
   void _connect();
@@ -249,7 +235,7 @@ class AsyncConnection : public Connection {
   } can_write;
   bool open_write;
   map<int, list<pair<bufferlist, Message*> > > out_q;  // priority queue for outbound msgs
-  list<pair<bufferlist, Message*> > sent; // the first bufferlist need to inject seq
+  list<Message*> sent; // the first bufferlist need to inject seq
   list<Message*> local_messages;    // local deliver
   bufferlist outcoming_bl;
   bool keepalive;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -25,6 +25,7 @@ using namespace std;
 
 #include "auth/AuthSessionHandler.h"
 #include "common/Mutex.h"
+#include "common/perf_counters.h"
 #include "include/buffer.h"
 #include "msg/Connection.h"
 #include "msg/Messenger.h"
@@ -113,7 +114,7 @@ class AsyncConnection : public Connection {
   }
 
  public:
-  AsyncConnection(CephContext *cct, AsyncMessenger *m, EventCenter *c);
+  AsyncConnection(CephContext *cct, AsyncMessenger *m, EventCenter *c, PerfCounters *p);
   ~AsyncConnection();
 
   ostream& _conn_prefix(std::ostream *_dout);
@@ -215,6 +216,7 @@ class AsyncConnection : public Connection {
   }
 
   AsyncMessenger *async_msgr;
+  PerfCounters *logger;
   int global_seq;
   __u32 connect_seq, peer_global_seq;
   atomic_t out_seq;
@@ -306,6 +308,9 @@ class AsyncConnection : public Connection {
     connect_handler.reset();
     local_deliver_handler.reset();
     wakeup_handler.reset();
+  }
+  PerfCounters *get_perf_counter() {
+    return logger;
   }
 }; /* AsyncConnection */
 

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -45,10 +45,15 @@ class AsyncConnection : public Connection {
 
   int read_bulk(int fd, char *buf, int len);
   int do_sendmsg(struct msghdr &msg, int len, bool more);
+  int try_send(bufferlist bl, bool send=true) {
+    Mutex::Locker l(write_lock);
+    return _try_send(bl, send);
+  }
   // if "send" is false, it will only append bl to send buffer
   // the main usage is avoid error happen outside messenger threads
   int _try_send(bufferlist bl, bool send=true);
   int _send(Message *m);
+  void prepare_send_message(Message *m, bufferlist &bl);
   int read_until(uint64_t needed, char *p);
   int _process_connection();
   void _connect();
@@ -63,7 +68,7 @@ class AsyncConnection : public Connection {
   int randomize_out_seq();
   void handle_ack(uint64_t seq);
   void _send_keepalive_or_ack(bool ack=false, utime_t *t=NULL);
-  int write_message(const ceph_msg_header& header, const ceph_msg_footer& footer, bufferlist& blist);
+  int write_message(Message *m, bufferlist& bl);
   int _reply_accept(char tag, ceph_msg_connect &connect, ceph_msg_connect_reply &reply,
                     bufferlist authorizer_reply) {
     bufferlist reply_bl;
@@ -74,7 +79,7 @@ class AsyncConnection : public Connection {
     if (reply.authorizer_len) {
       reply_bl.append(authorizer_reply.c_str(), authorizer_reply.length());
     }
-    int r = _try_send(reply_bl);
+    int r = try_send(reply_bl);
     if (r < 0)
       return -1;
 
@@ -82,25 +87,31 @@ class AsyncConnection : public Connection {
     return 0;
   }
   bool is_queued() {
+    assert(write_lock.is_locked());
     return !out_q.empty() || outcoming_bl.length();
   }
   void shutdown_socket() {
     if (sd >= 0)
       ::shutdown(sd, SHUT_RDWR);
   }
-  Message *_get_next_outgoing() {
+  Message *_get_next_outgoing(bufferlist *bl) {
+    assert(write_lock.is_locked());
     Message *m = 0;
     while (!m && !out_q.empty()) {
-      map<int, list<Message*> >::reverse_iterator p = out_q.rbegin();
-      if (!p->second.empty()) {
-        m = p->second.front();
-        p->second.pop_front();
+      map<int, list<pair<bufferlist, Message*> > >::reverse_iterator it = out_q.rbegin();
+      if (!it->second.empty()) {
+        list<pair<bufferlist, Message*> >::iterator p = it->second.begin();
+        m = p->second;
+        if (bl)
+          bl->swap(p->first);
+        it->second.erase(p);
       }
-      if (p->second.empty())
-        out_q.erase(p->first);
+      if (it->second.empty())
+        out_q.erase(it->first);
     }
     return m;
   }
+
  public:
   AsyncConnection(CephContext *cct, AsyncMessenger *m, EventCenter *c);
   ~AsyncConnection();
@@ -206,19 +217,24 @@ class AsyncConnection : public Connection {
   AsyncMessenger *async_msgr;
   int global_seq;
   __u32 connect_seq, peer_global_seq;
-  uint64_t out_seq;
+  atomic_t out_seq;
   uint64_t in_seq, in_seq_acked;
   int state;
   int state_after_send;
   int sd;
   int port;
   Messenger::Policy policy;
-  map<int, list<Message*> > out_q;  // priority queue for outbound msgs
-  list<Message*> sent;
+
+  Mutex write_lock;
+  int can_write;  // 0. can't send 1. can send_message 2. connection is closed
+  bool open_write;
+  map<int, list<pair<bufferlist, Message*> > > out_q;  // priority queue for outbound msgs
+  list<pair<bufferlist, Message*> > sent; // the first bufferlist need to inject seq
   list<Message*> local_messages;    // local deliver
+  bufferlist outcoming_bl;
+
   Mutex lock;
   utime_t backoff;         // backoff time
-  bool open_write;
   EventCallbackRef read_handler;
   EventCallbackRef write_handler;
   EventCallbackRef reset_handler;
@@ -265,7 +281,6 @@ class AsyncConnection : public Connection {
   char *state_buffer;
   // used only by "read_until"
   uint64_t state_offset;
-  bufferlist outcoming_bl;
   NetHandler net;
   EventCenter *center;
   ceph::shared_ptr<AuthSessionHandler> session_security;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -334,6 +334,7 @@ WorkerPool::WorkerPool(CephContext *c): cct(c), seq(0), started(false),
     else
       lderr(cct) << __func__ << " failed to parse " << *it << " in " << cct->_conf->ms_async_affinity_cores << dendl;
   }
+
 }
 
 WorkerPool::~WorkerPool()
@@ -390,7 +391,8 @@ AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
 {
   ceph_spin_init(&global_seq_lock);
   cct->lookup_or_create_singleton_object<WorkerPool>(pool, WorkerPool::name);
-  local_connection = new AsyncConnection(cct, this, &pool->get_worker()->center);
+  Worker *w = pool->get_worker();
+  local_connection = new AsyncConnection(cct, this, &w->center, w->get_perf_counter());
   init_local_connection();
 }
 
@@ -516,7 +518,7 @@ AsyncConnectionRef AsyncMessenger::add_accept(int sd)
 {
   lock.Lock();
   Worker *w = pool->get_worker();
-  AsyncConnectionRef conn = new AsyncConnection(cct, this, &w->center);
+  AsyncConnectionRef conn = new AsyncConnection(cct, this, &w->center, w->get_perf_counter());
   conn->accept(sd);
   accepting_conns.insert(conn);
   lock.Unlock();
@@ -533,10 +535,11 @@ AsyncConnectionRef AsyncMessenger::create_connect(const entity_addr_t& addr, int
 
   // create connection
   Worker *w = pool->get_worker();
-  AsyncConnectionRef conn = new AsyncConnection(cct, this, &w->center);
+  AsyncConnectionRef conn = new AsyncConnection(cct, this, &w->center, w->get_perf_counter());
   conn->connect(addr, type);
   assert(!conns.count(addr));
   conns[addr] = conn;
+  w->get_perf_counter()->inc(l_msgr_active_connections);
 
   return conn;
 }
@@ -663,6 +666,7 @@ void AsyncMessenger::mark_down_all()
     AsyncConnectionRef p = it->second;
     ldout(cct, 5) << __func__ << " mark down " << it->first << " " << p << dendl;
     conns.erase(it);
+    p->get_perf_counter()->dec(l_msgr_active_connections);
     p->stop();
   }
 

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -46,9 +46,10 @@ class C_handle_notify : public EventCallback {
   C_handle_notify(EventCenter *c): center(c) {}
   void do_request(int fd_or_id) {
     char c[256];
-    center->already_wakeup.set(0);
-    int r = read(fd_or_id, c, sizeof(c));
-    assert(r > 0);
+    do {
+      center->already_wakeup.set(0);
+      read(fd_or_id, c, sizeof(c));
+    } while (center->already_wakeup.read());
   }
 };
 

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -75,7 +75,7 @@ class EventDriver {
   virtual ~EventDriver() {}       // we want a virtual destructor!!!
   virtual int init(int nevent) = 0;
   virtual int add_event(int fd, int cur_mask, int mask) = 0;
-  virtual void del_event(int fd, int cur_mask, int del_mask) = 0;
+  virtual int del_event(int fd, int cur_mask, int del_mask) = 0;
   virtual int event_wait(vector<FiredFileEvent> &fired_events, struct timeval *tp) = 0;
   virtual int resize_events(int newsize) = 0;
 };

--- a/src/msg/async/EventEpoll.h
+++ b/src/msg/async/EventEpoll.h
@@ -40,7 +40,7 @@ class EpollDriver : public EventDriver {
 
   int init(int nevent);
   int add_event(int fd, int cur_mask, int add_mask);
-  void del_event(int fd, int cur_mask, int del_mask);
+  int del_event(int fd, int cur_mask, int del_mask);
   int resize_events(int newsize);
   int event_wait(vector<FiredFileEvent> &fired_events, struct timeval *tp);
 };

--- a/src/msg/async/EventKqueue.cc
+++ b/src/msg/async/EventKqueue.cc
@@ -65,23 +65,26 @@ int KqueueDriver::add_event(int fd, int cur_mask, int add_mask)
   return 0;
 }
 
-void KqueueDriver::del_event(int fd, int cur_mask, int delmask)
+int KqueueDriver::del_event(int fd, int cur_mask, int delmask)
 {
   ldout(cct, 20) << __func__ << " del event fd=" << fd << " cur mask=" << cur_mask
                  << " delmask=" << delmask << dendl;
   struct kevent ee;
   struct kevent ke;
   int filter = 0;
+  int r = 0;
   filter |= (delmask & EVENT_READABLE) ? EVFILT_READ : 0;
   filter |= (delmask & EVENT_WRITABLE) ? EVFILT_WRITE : 0;
 
   if (filter) {
     EV_SET(&ke, fd, filter, EV_DELETE, 0, 0, NULL);
-    if (kevent(kqfd, &ke, 1, NULL, 0, NULL) < 0) {
+    if ((r = kevent(kqfd, &ke, 1, NULL, 0, NULL)) < 0) {
       lderr(cct) << __func__ << " kevent: delete fd=" << fd << " mask=" << filter
                  << " failed." << cpp_strerror(errno) << dendl;
+      return r;
     }
   }
+  return 0;
 }
 
 int KqueueDriver::resize_events(int newsize)

--- a/src/msg/async/EventKqueue.h
+++ b/src/msg/async/EventKqueue.h
@@ -40,7 +40,7 @@ class KqueueDriver : public EventDriver {
 
   int init(int nevent);
   int add_event(int fd, int cur_mask, int add_mask);
-  void del_event(int fd, int cur_mask, int del_mask);
+  int del_event(int fd, int cur_mask, int del_mask);
   int resize_events(int newsize);
   int event_wait(vector<FiredFileEvent> &fired_events, struct timeval *tp);
 };

--- a/src/msg/async/EventSelect.cc
+++ b/src/msg/async/EventSelect.cc
@@ -48,7 +48,7 @@ int SelectDriver::add_event(int fd, int cur_mask, int add_mask)
   return 0;
 }
 
-void SelectDriver::del_event(int fd, int cur_mask, int delmask)
+int SelectDriver::del_event(int fd, int cur_mask, int delmask)
 {
   ldout(cct, 10) << __func__ << " del event fd=" << fd << " cur mask=" << cur_mask
                  << dendl;
@@ -57,6 +57,7 @@ void SelectDriver::del_event(int fd, int cur_mask, int delmask)
     FD_CLR(fd, &rfds);
   if (delmask & EVENT_WRITABLE)
     FD_CLR(fd, &wfds);
+  return 0;
 }
 
 int SelectDriver::resize_events(int newsize)

--- a/src/msg/async/EventSelect.h
+++ b/src/msg/async/EventSelect.h
@@ -36,7 +36,7 @@ class SelectDriver : public EventDriver {
 
   int init(int nevent);
   int add_event(int fd, int cur_mask, int add_mask);
-  void del_event(int fd, int cur_mask, int del_mask);
+  int del_event(int fd, int cur_mask, int del_mask);
   int resize_events(int newsize);
   int event_wait(vector<FiredFileEvent> &fired_events, struct timeval *tp);
 };

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -745,10 +745,10 @@ class SyntheticDispatcher : public Dispatcher {
     ::decode(i, blp);
     ::decode(reply, blp);
     if (reply) {
-      cerr << __func__ << " reply=" << reply << " i=" << i << std::endl;
+      //cerr << __func__ << " reply=" << reply << " i=" << i << std::endl;
       reply_message(m, i);
     } else if (sent.count(i)) {
-      cerr << __func__ << " reply=" << reply << " i=" << i << std::endl;
+      //cerr << __func__ << " reply=" << reply << " i=" << i << std::endl;
       ASSERT_EQ(conn_sent[m->get_connection()].front(), i);
       ASSERT_TRUE(m->get_data().contents_equal(sent[i]));
       conn_sent[m->get_connection()].pop_front();
@@ -776,6 +776,7 @@ class SyntheticDispatcher : public Dispatcher {
     if (m->get_middle().length())
       rm->set_middle(bl);
     m->get_connection()->send_message(rm);
+    //cerr << __func__ << " conn=" << m->get_connection() << " reply m=" << m << " i=" << i << std::endl;
   }
 
   void send_message_wrap(ConnectionRef con, Message *m) {
@@ -791,6 +792,7 @@ class SyntheticDispatcher : public Dispatcher {
         sent[i] = m->get_data();
         conn_sent[con].push_back(i);
       }
+      //cerr << __func__ << " conn=" << con.get() << " send m=" << m << " i=" << i << std::endl;
     }
     ASSERT_EQ(con->send_message(m), 0);
   }

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -923,10 +923,15 @@ class SyntheticWorkload {
     pair<Messenger*, Messenger*> p;
     {
       boost::uniform_int<> choose(0, available_servers.size() - 1);
-      if (server->get_default_policy().server || choose(rng) % 2)
+      if (server->get_default_policy().server) {
         p = make_pair(client, server);
-      else
-        p = make_pair(server, client);
+      } else {
+        ConnectionRef conn = client->get_connection(server->get_myinst());
+        if (available_connections.count(conn) || choose(rng) % 2)
+          p = make_pair(client, server);
+        else
+          p = make_pair(server, client);
+      }
     }
     ConnectionRef conn = p.first->get_connection(p.second->get_myinst());
     available_connections[conn] = p;


### PR DESCRIPTION
Separate message send data structure from original lock to new write_lock, so it would like send_message's caller can directly send message without waiting reading the same fd.

And now send_message's caller will directly encode message firstly without holding any lock, so if failed(connection isn't ready to encode) the encode bufferlist will be cleared and fall down to encode again when ready. This step require each message supports encode_payload multi times, here "header.version" is the only field which prevent from reentrant. We make "header.version" can be reset if legacy version is set.