### PR TITLE
.gitignore: systemd/ceph-osd@.service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ missing
 py-compile
 release
 stamp-h1
+systemd/ceph-osd@.service
 vgcore.*
 
 # specific local dir files


### PR DESCRIPTION
systemd/ceph-osd@.service is now auto-generated by autotools.

This means the file should be added to gitignored list.

Signed-off-by: Owen Synge <osynge@suse.com>