### PR TITLE
scripts: Add a helper to make release notes

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# Originally modified from A. Israel's script seen at
+# https://gist.github.com/aisrael/b2b78d9dfdd176a232b9
+"""To run this script first install the dependencies
+
+$ pip install githubpy GitPython
+
+Generate a github access token; this is needed as the anonymous access
+to Github's API will easily hit the limit even with a single invocation.
+For details see:
+https://help.github.com/articles/creating-an-access-token-for-command-line-use/
+
+Next either set the github token as an env variable
+`GITHUB_ACCESS_TOKEN` or alternatively invoke the script with
+`--token` switch.
+
+Example:
+ceph_release_notes -r tags/v0.87..giant /path/to/ceph/repo
+
+"""
+
+from __future__ import print_function
+import re
+import os
+import argparse
+import github
+
+from git import Repo
+
+
+merge_re = re.compile("Merge pull request #(\d+).*")
+fixes_re = re.compile(r"Fixes\:? #(\d+)")
+tracker_re = re.compile("http://tracker.ceph.com/issues/(\d+)")
+signed_off_re = re.compile("Signed-off-by: (.+) <")
+
+
+def make_release_notes(gh, repo, ref):
+
+    for commit in repo.iter_commits(ref):
+        merge = merge_re.match(commit.summary)
+        if merge:
+            pr = {}
+            issue = ''
+            pr = gh.repos("ceph")("ceph").pulls(merge.group(1)).get()
+            # We are not handling multiple issues here yet
+            if pr['body']:
+                fixes = fixes_re.findall(pr['body'])
+                tracker = tracker_re.findall(pr['body'])
+                if tracker:
+                    issue = ','.join(tracker)
+                elif fixes:
+                    issue = ','.join(fixes)
+
+            title = pr['title']
+
+            # Big assumption, do a sanity check in the end, we are
+            # getting the author of final merge commit
+            author = commit.parents[-1].author.name
+            if issue:
+                print ("{0} (#{1}, {2})".format(title, issue, author))
+            elif author:
+                print ("{0} ({1})".format(title, author))
+            else:
+                print (title)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rev", "-r",
+                        help="git revision range for creating release notes")
+    parser.add_argument("repo", metavar="repo",
+                        help="path to ceph git repo")
+    parser.add_argument("--token", default=os.getenv("GITHUB_ACCESS_TOKEN"),
+                        help="Github Access Token ($GITHUB_ACCESS_TOKEN otherwise)")
+
+    args = parser.parse_args()
+    gh = github.GitHub(
+        access_token=args.token)
+
+    make_release_notes(gh, Repo(args.repo), args.rev)


### PR DESCRIPTION
First cut for a `ceph-release-notes` script added which looks at merge
commits and picks out issue numbers. Though this ideally suits for
backport releases workflow where the commit messages always follow a
specific pattern, it is partly useful for preparing release notes for
normal releases as well.

Signed-off-by: Abhishek Lekshmanan <abhishek.lekshmanan@ril.com>