### PR TITLE
mon: MonitorDBStore: get_next_key() only if prefix matches

### DIFF
--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -448,11 +448,13 @@ class MonitorDBStore
 
     virtual pair<string,string> get_next_key() {
       assert(iter->valid());
-      pair<string,string> r = iter->raw_key();
-      do {
-	iter->next();
-      } while (iter->valid() && sync_prefixes.count(iter->raw_key().first) == 0);
-      return r;
+
+      for (; iter->valid(); iter->next()) {
+        pair<string,string> r = iter->raw_key();
+        if (sync_prefixes.count(r.first) > 0)
+          return r;
+      }
+      return pair<string,string>();
     }
 
     virtual bool _is_valid() {


### PR DESCRIPTION
get_next_key() had a bug in which we would always return the first key
from the iterator, regardless of whether its prefix had been specified
to the iterator.

Fixes: #11786

Signed-off-by: Joao Eduardo Luis <joao@suse.de>