### PR TITLE
debian/control: ceph-dbg steals ceph-objectstore-tool from ceph-test-dbg

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -93,6 +93,8 @@ Architecture: linux-any
 Section: debug
 Priority: extra
 Depends: ceph (= ${binary:Version}), ${misc:Depends}
+Replaces: ceph-test-dbg (<< 0.94-1322)
+Breaks: ceph-test-dbg (<< 0.94-1322)
 Description: debugging symbols for ceph
  Ceph is a distributed storage system designed to provide excellent
  performance, reliability, and scalability.


### PR DESCRIPTION
http://tracker.ceph.com/issues/11546