### PR TITLE
Added tmpfiles.d for rgw.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ py-compile
 release
 stamp-h1
 systemd/ceph-osd@.service
+systemd/ceph-rgw.tmpfiles.d
 vgcore.*
 
 # specific local dir files

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -497,9 +497,13 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--with-librocksdb-static=check \
 %if 0%{?rhel} || 0%{?fedora}
 		--with-systemd-libexec-dir=/usr/libexec/ceph \
+		--with-rgw-user=apache \
+		--with-rgw-group=apache \
 %endif
 %if 0%{?opensuse} || 0%{?suse_version}
 		--with-systemd-libexec-dir=/usr/lib/ceph/ \
+		--with-rgw-user=wwwrun \
+		--with-rgw-group=www \
 %endif
 		$MY_CONF_OPT \
 		%{?_with_ocf} \
@@ -537,6 +541,7 @@ install -D src/init-rbdmap $RPM_BUILD_ROOT%{_initrddir}/rbdmap
 install -D src/rbdmap $RPM_BUILD_ROOT%{_sysconfdir}/ceph/rbdmap
 %if 0%{?_with_systemd}
   install -m 0644 -D systemd/ceph.tmpfiles.d $RPM_BUILD_ROOT%{_tmpfilesdir}/%{name}.conf
+  install -m 0644 -D systemd/ceph-rgw.tmpfiles.d $RPM_BUILD_ROOT%{_tmpfilesdir}/%{name}-rgw.conf
 %endif
 mkdir -p $RPM_BUILD_ROOT%{_sbindir}
 ln -sf ../../etc/init.d/ceph %{buildroot}/%{_sbindir}/rcceph
@@ -795,6 +800,9 @@ fi
 %config %{_sysconfdir}/bash_completion.d/radosgw-admin
 %dir %{_localstatedir}/log/radosgw/
 %dir %{_localstatedir}/lib/ceph/radosgw
+%if 0%{?_with_systemd}
+%{_tmpfilesdir}/%{name}-rgw.conf
+%endif
 
 %post radosgw
 /sbin/ldconfig

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -497,8 +497,8 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--with-librocksdb-static=check \
 %if 0%{?rhel} || 0%{?fedora}
 		--with-systemd-libexec-dir=/usr/libexec/ceph \
-		--with-rgw-user=apache \
-		--with-rgw-group=apache \
+		--with-rgw-user=root \
+		--with-rgw-group=root \
 %endif
 %if 0%{?opensuse} || 0%{?suse_version}
 		--with-systemd-libexec-dir=/usr/lib/ceph/ \

--- a/configure.ac
+++ b/configure.ac
@@ -1204,6 +1204,50 @@ AC_ARG_WITH(
     ]
 )
 
+dnl rgw-user
+AC_SUBST(user_rgw)
+AC_ARG_WITH(
+    rgw-user,
+    AS_HELP_STRING(
+        [--with-rgw-user=USER],
+        [systemd unit directory @<:@USER_RGW@:>@
+        Defaults to "www-data"]
+    ),
+    [
+        user_rgw="$withval"
+    ],
+    [
+        if test "x$USER_RGW" = "x"; then
+            user_rgw=www-data
+        else
+            user_rgw="$USER_RGW"
+        fi
+    ]
+)
+
+
+dnl rgw-group
+AC_SUBST(group_rgw)
+AC_ARG_WITH(
+    rgw-group,
+    AS_HELP_STRING(
+        [--with-rgw-group=GROUP],
+        [systemd unit directory @<:@GROUP_RGW@:>@
+        Defaults to "www-data"]
+    ),
+    [
+        group_rgw="$withval"
+    ],
+    [
+        if test "x$GROUP_RGW" = "x"; then
+            group_rgw=www-data
+        else
+            group_rgw="$GROUP_RGW"
+        fi
+    ]
+)
+
+
 # Checks for typedefs, structures, and compiler characteristics.
 #AC_HEADER_STDBOOL
 #AC_C_CONST
@@ -1267,5 +1311,6 @@ AC_CONFIG_FILES([Makefile
 	man/Makefile
 	doc/Makefile
 	systemd/ceph-osd@.service
+	systemd/ceph-rgw.tmpfiles.d
 	ceph.spec])
 AC_OUTPUT

--- a/systemd/ceph-rgw.tmpfiles.d.in
+++ b/systemd/ceph-rgw.tmpfiles.d.in
@@ -1,0 +1,2 @@
+# create rgw socket directory
+d /var/run/ceph-rgw 0755 @user_rgw@ @group_rgw@ - -


### PR DESCRIPTION
tmpfiles.d are part of system.d and define how temporary directories are setup.
rgw needs a socket directory.

Note1: Added to spec file.
Note2: Name changed to rgw from radosgw as is preferred name by Sage.

Signed-off-by: Owen Synge <osynge@suse.com>