### PR TITLE
ceph.spec.in:ownership of dirs extension

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -717,6 +717,8 @@ fi
 %{_datadir}/ceph/known_hosts_drop.ceph.com
 %{_datadir}/ceph/id_dsa_drop.ceph.com
 %{_datadir}/ceph/id_dsa_drop.ceph.com.pub
+%dir %{_prefix}/lib/ceph
+%dir %{_prefix}/share/ceph
 %dir %{_sysconfdir}/ceph/
 %dir %{_localstatedir}/log/ceph/
 %config %{_sysconfdir}/bash_completion.d/rados


### PR DESCRIPTION
rpm lint says the following directories

/usr/share/ceph
/usr/lib/ceph

are un owned by any package and this causes
OBS to emit errors.

Signed-off-by: Owen Synge <osynge@suse.com>