### PR TITLE
install-deps.sh: robust pip and wheel installation

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -42,7 +42,7 @@ Ubuntu|Debian|Devuan)
         packages=$(dpkg-checkbuilddeps --admindir=$DIR debian/control 2>&1 | \
             perl -p -e 's/.*Unmet build dependencies: *//;' \
             -e 's/build-essential:native/build-essential/;' \
-            -e 's/\|//g;' \
+            -e 's/\s*\|\s*/\|/g;' \
             -e 's/\(.*?\)//g;' \
             -e 's/ +/\n/g;' | sort)
         case $(lsb_release -sc) in
@@ -52,7 +52,7 @@ Ubuntu|Debian|Devuan)
                 ;;
         esac
         packages=$(echo $packages) # change newlines into spaces
-        $SUDO bash -c "DEBIAN_FRONTEND=noninteractive apt-get install $backports -y $packages" || exit 1
+        $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install $backports -y $packages || exit 1
         ;;
 CentOS|Fedora|RedHatEnterpriseServer)
         case $(lsb_release -si) in

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -94,6 +94,13 @@ function get_pip_and_wheel() {
     pip --timeout 300 $install 'setuptools >= 0.8' 'pip >= 7.0' 'wheel >= 0.24' || return 1
 }
 
+# use pip cache if possible but do not store it outside of the source
+# tree
+# see https://pip.pypa.io/en/stable/reference/pip_install.html#caching
+mkdir -p install-deps-cache
+top_srcdir=$(pwd)
+export XDG_CACHE_HOME=$top_srcdir/install-deps-cache
+
 #
 # preload python modules so that tox can run without network access
 #
@@ -107,7 +114,6 @@ for interpreter in python2.7 python3 ; do
 done
 
 find . -name tox.ini | while read ini ; do
-    top_srcdir=$(pwd)
     (
         cd $(dirname $ini)
         require=$(ls *requirements.txt 2>/dev/null | sed -e 's/^/-r /')


### PR DESCRIPTION
The wheel and pip module must not only be installed in each wheelhouse
directory for tox to find. They must also be installed in the virtual
environment that populates the wheelhouse directory. Otherwise older pip
modules such as the one found by default on Ubuntu 12.04 will fail.

Python 2.7.3 on Ubuntu 12.04 also requires that distribute >= 0.7.3 is
installed although it is redundant with setuptools, otherwise it will
fail to run the wheel module.

Signed-off-by: Loic Dachary <ldachary@redhat.com>