### PR TITLE
ceph-disk: always check zap is applied on a full device

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1055,6 +1055,9 @@ def zap(dev):
     """
     Destroy the partition table and content of a given disk.
     """
+    dmode = os.stat(dev).st_mode
+    if not stat.S_ISBLK(dmode) or is_partition(dev):
+        raise Error('not full block device; cannot zap', dev)
     try:
         LOG.debug('Zapping partition table on %s', dev)
 
@@ -1540,10 +1543,7 @@ def main_prepare(args):
                 verify_not_in_use(args.journal, False)
 
         if args.zap_disk is not None:
-            if stat.S_ISBLK(dmode) and not is_partition(args.data):
-                zap(args.data)
-            else:
-                raise Error('not full block device; cannot zap', args.data)
+            zap(args.data)
 
         if args.cluster_uuid is None:
             args.cluster_uuid = get_fsid(cluster=args.cluster)

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -220,6 +220,15 @@ function test_mark_init() {
     $rm -fr $osd_data
 }
 
+function test_zap() {
+    local osd_data=$DIR/dir
+    $mkdir -p $osd_data
+
+    ./ceph-disk $CEPH_DISK_ARGS zap $osd_data 2>&1 | grep 'not full block device' || return 1
+
+    $rm -fr $osd_data
+}
+
 # ceph-disk prepare returns immediately on success if the magic file
 # exists in the --osd-data directory.
 function test_activate_dir_magic() {
@@ -613,6 +622,7 @@ function run() {
     default_actions+="test_activate_dir "
     default_actions+="test_keyring_path "
     default_actions+="test_mark_init "
+    default_actions+="test_zap "
     local actions=${@:-$default_actions}
     local status
     for action in $actions  ; do


### PR DESCRIPTION
zap only makes sense on a full device and this is verified for

    ceph-disk prepare --zap-disk

but not for

    ceph-disk zap

Unify the two and add a test to check that it fails as expected when
trying to zap a directory.

http://tracker.ceph.com/issues/11272 Fixes: #11272

Signed-off-by: Loic Dachary <ldachary@redhat.com>