### PR TITLE
Fix test ceph disk dmcrypt uuid v2

### DIFF
--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -15,8 +15,6 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Library Public License for more details.
 #
-source test/test_btrfs_common.sh
-
 PS4='${FUNCNAME[0]}: $LINENO: '
 
 export PATH=.:$PATH # make sure program from sources are prefered
@@ -69,10 +67,6 @@ function setup() {
 
 function teardown() {
     kill_daemons
-    if [ $(stat -f -c '%T' .) == "btrfs" ]; then
-        rm -fr $DIR/*/*db
-        teardown_btrfs $DIR
-    fi
     grep " $(pwd)/$DIR/" < /proc/mounts | while read mounted rest ; do
         umount $mounted
     done

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -309,7 +309,7 @@ function test_activate_dmcrypt() {
         --mark-init=none \
         /dev/mapper/$uuid || return 1
 
-    test_pool_read_write $osd_uuid || return 1
+    test_pool_read_write $uuid || return 1
 }
 
 function test_activate_dir() {


### PR DESCRIPTION
Changes since V1 (https://github.com/ceph/ceph/pull/4806):
- Add Ceph issue tracker tag to btrfs teardown removal