### PR TITLE
ceph.spec.in libcephfs_jni1 has no %post and %postun

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -948,6 +948,12 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %defattr(-,root,root,-)
 %{_libdir}/libcephfs_jni.so.*
 
+%post -n libcephfs_jni1
+/sbin/ldconfig
+
+%postun -n libcephfs_jni1
+/sbin/ldconfig
+
 #################################################################################
 %files -n libcephfs_jni1-devel
 %defattr(-,root,root,-)


### PR DESCRIPTION
/usr/lib64/libcephfs_jni.so.1.0.0 requires /sbin/ldconfig to be
run after installing and after removing.

Signed-off-by: Owen Synge <osynge@suse.com>