### PR TITLE
os/DBObjectMap:move iterator to first record of object

### DIFF
--- a/src/os/DBObjectMap.cc
+++ b/src/os/DBObjectMap.cc
@@ -771,7 +771,7 @@ int DBObjectMap::get_keys(const ghobject_t &oid,
   Header header = lookup_map_header(hl, oid);
   if (!header)
     return -ENOENT;
-  ObjectMapIterator iter = get_iterator(oid);
+  ObjectMapIterator iter = _get_iterator(header);
   for (iter->seek_to_first(); iter->valid(); iter->next()) {
     if (iter->status())
       return iter->status();

--- a/src/os/DBObjectMap.cc
+++ b/src/os/DBObjectMap.cc
@@ -772,7 +772,7 @@ int DBObjectMap::get_keys(const ghobject_t &oid,
   if (!header)
     return -ENOENT;
   ObjectMapIterator iter = get_iterator(oid);
-  for (; iter->valid(); iter->next()) {
+  for (iter->seek_to_first(); iter->valid(); iter->next()) {
     if (iter->status())
       return iter->status();
     keys->insert(iter->key());

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1330,6 +1330,11 @@ TEST_P(StoreTest, OMapTest) {
     ASSERT_EQ(r, 0);
     ASSERT_EQ(cur_attrs.size(), size_t(1));
     ASSERT_TRUE(bl3.contents_equal(bl1));
+ 
+    set<string> keys;
+    r = store->omap_get_keys(cid, hoid, &keys);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(keys.size(), size_t(1));
   }
 
   ObjectStore::Transaction t;


### PR DESCRIPTION
iter->valid is always false if we do not initialize the iterator with init(), seek_to_first will initialize this iterator

Signed-off-by: xinxin shu <xinxin.shu@intel.com>