### PR TITLE
rgw: don't allow negative / invalid content length

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -863,7 +863,7 @@ struct req_state {
    string decoded_uri;
    string relative_uri;
    const char *length;
-   uint64_t content_length;
+   int64_t content_length;
    map<string, string> generic_attrs;
    struct rgw_err err;
    bool expect_cont;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1670,7 +1670,7 @@ void RGWPutObj::execute()
     ofs += len;
   } while (len > 0);
 
-  if (!chunked_upload && (uint64_t)ofs != s->content_length) {
+  if (!chunked_upload && ofs != s->content_length) {
     ret = -ERR_REQUEST_TIMEOUT;
     goto done;
   }

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1240,10 +1240,21 @@ int RGWREST::preprocess(struct req_state *s, RGWClientIO *cio)
   url_decode(s->info.request_uri, s->decoded_uri);
   s->length = info.env->get("CONTENT_LENGTH");
   if (s->length) {
-    if (*s->length == '\0')
+    if (*s->length == '\0') {
       s->content_length = 0;
-    else
-      s->content_length = atoll(s->length);
+    } else {
+      string err;
+      s->content_length = strict_strtol(s->length, 10, &err);
+      if (!err.empty()) {
+        ldout(s->cct, 10) << "bad content length, aborting" << dendl;
+        return -EINVAL;
+      }
+    }
+  }
+
+  if (s->content_length < 0) {
+    ldout(s->cct, 10) << "negative content length, aborting" << dendl;
+    return -EINVAL;
   }
 
   map<string, string>::iterator giter;


### PR DESCRIPTION
Certain frontends (e.g., civetweb) don't filter such requests.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
(cherry picked from commit 0e74b7a1d56733358e2f1d3df4386125a94c2966)