### PR TITLE
qa: fix multiple_rsync.sh to avoid using /usr/ directly

### DIFF
--- a/qa/workunits/fs/misc/multiple_rsync.sh
+++ b/qa/workunits/fs/misc/multiple_rsync.sh
@@ -1,16 +1,26 @@
 #!/bin/sh -ex
 
-sudo rsync -av --exclude local/ /usr/ usr.1
-sudo rsync -av --exclude local/ /usr/ usr.2
+
+# Populate with some arbitrary files from the local system.  Take
+# a copy to protect against false fails from system updates during test.
+export PAYLOAD=/tmp/multiple_rsync_payload.$$
+cp -r /usr/lib/ $PAYLOAD
+
+set -e
+
+sudo rsync -av $PAYLOAD payload.1
+sudo rsync -av $PAYLOAD payload.2
 
 # this shouldn't transfer any additional files
 echo we should get 4 here if no additional files are transfered
-sudo rsync -auv --exclude local/ /usr/ usr.1 | tee /tmp/$$
+sudo rsync -auv $PAYLOAD payload.1 | tee /tmp/$$
 hexdump -C /tmp/$$
 wc -l /tmp/$$ | grep 4
-sudo rsync -auv --exclude local/ /usr/ usr.2 | tee /tmp/$$
+sudo rsync -auv $PAYLOAD payload.2 | tee /tmp/$$
 hexdump -C /tmp/$$
 wc -l /tmp/$$ | grep 4
 rm /tmp/$$
 
 echo OK
+
+rm -rf $PAYLOAD


### PR DESCRIPTION
While we're at it, take only /usr/lib instead of all of /usr
to keep the overall file count more modest.

Fixes: #11807
Signed-off-by: John Spray <john.spray@redhat.com>