### PR TITLE
common/Cycles.cc: skip initialization if rdtsc is not implemented

### DIFF
--- a/src/common/Cycles.cc
+++ b/src/common/Cycles.cc
@@ -52,6 +52,10 @@ void Cycles::init()
   if (cycles_per_sec != 0)
     return;
 
+  // Skip initialization if rtdsc is not implemented
+  if (rdtsc() == 0)
+    return;
+
   // Compute the frequency of the fine-grained CPU timer: to do this,
   // take parallel time readings using both rdtsc and gettimeofday.
   // After 10ms have elapsed, take the ratio between these readings.


### PR DESCRIPTION
The Cycles initialization gets stuck in infinite loop if rdtsc is not
implemented. This patch fixes the issue by quitting the initialization
if rtdsc fails.

The patch was cherry-picked from ubuntu patch by James Page, see

https://bugzilla.redhat.com/show_bug.cgi?id=1222286

for more details on the patch.