### PR TITLE
mon: add an "osd crush dump tree" command

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -699,6 +699,12 @@ Usage::
 
 	ceph osd crush show-tunables
 
+Subcommand ``tree`` shows the crush buckets and items in a tree view.
+
+Usage::
+
+	ceph osd crush tree
+
 Subcommand ``tunables`` sets crush tunables values to <profile>.
 
 Usage::

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1060,6 +1060,7 @@ public:
   void dump_tunables(Formatter *f) const;
   void list_rules(Formatter *f) const;
   void dump_tree(ostream *out, Formatter *f) const;
+  void dump_tree(Formatter *f) const;
   static void generate_test_instances(list<CrushWrapper*>& o);
 
   int _get_osd_pool_default_crush_replicated_ruleset(CephContext *cct,

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -531,6 +531,9 @@ COMMAND("osd crush rule create-erasure " \
 COMMAND("osd crush rule rm " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] ",	\
 	"remove crush rule <name>", "osd", "rw", "cli,rest")
+COMMAND("osd crush tree",
+	"dump crush buckets and items in a tree view",
+	"osd", "r", "cli,rest")
 COMMAND("osd setmaxosd " \
 	"name=newmax,type=CephInt,range=0", \
 	"set new maximum osd value", "osd", "rw", "cli,rest")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3706,6 +3706,12 @@ stats_out:
     f->flush(rs);
     rs << "\n";
     rdata.append(rs.str());
+  } else if (prefix == "osd crush tree") {
+    boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
+    f->open_array_section("crush_map_roots");
+    osdmap.crush->dump_tree(f.get());
+    f->close_section();
+    f->flush(rdata);
   } else if (prefix == "osd erasure-code-profile ls") {
     const map<string,map<string,string> > &profiles =
       osdmap.get_erasure_code_profiles();

--- a/src/test/mon/osd-crush-tree.rng
+++ b/src/test/mon/osd-crush-tree.rng
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <ref name="crush_map_roots"/>
+  </start>
+  <define name="item">
+    <choice>
+      <ref name="bucket"/>
+      <ref name="device"/>
+    </choice>
+  </define>
+  <define name="device">
+    <element name="device">
+      <element name="id">
+        <text/>
+      </element>
+      <element name="name">
+        <text/>
+      </element>
+      <element name="type">
+        <text/>
+      </element>
+      <element name="type_id">
+        <text/>
+      </element>
+      <element name="crush_weight">
+        <text/>
+      </element>
+      <element name="depth">
+        <text/>
+      </element>
+    </element>
+  </define>
+  <define name="bucket">
+    <element name="bucket">
+      <element name="id">
+        <text/>
+      </element>
+      <element name="name">
+        <text/>
+      </element>
+      <element name="type">
+        <text/>
+      </element>
+      <element name="type_id">
+        <text/>
+      </element>
+      <element name="items">
+        <zeroOrMore>
+          <ref name="item"/>
+        </zeroOrMore>
+      </element>
+    </element>
+  </define>
+  <define name="crush_map_roots">
+    <element name="crush_map_roots">
+      <oneOrMore>
+        <ref name="bucket"/>
+      </oneOrMore>
+    </element>
+  </define>
+</grammar>

--- a/src/test/mon/osd-crush.sh
+++ b/src/test/mon/osd-crush.sh
@@ -218,6 +218,14 @@ function TEST_crush_reject_empty() {
         ./ceph osd setcrushmap -i $empty_map.map || return 1
 }
 
+function TEST_crush_tree() {
+    local dir=$1
+    run_mon $dir a || return 1
+
+    ./ceph osd crush tree --format=xml | \
+        $XMLSTARLET val -e -r test/mon/osd-crush-tree.rng - || return 1
+}
+
 main osd-crush "$@"
 
 # Local Variables:


### PR DESCRIPTION
* to print crush items in a tree

Fixes: #11833
Signed-off-by: Kefu Chai <kchai@redhat.com>