### PR TITLE
osd: bug fix when op.extent.length == 0 in ecbackend

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1635,10 +1635,17 @@ struct CallClientContexts :
 	&bl);
       assert(i->second.second);
       assert(i->second.first);
-      i->second.first->substr_of(
-	bl,
-	i->first.get<0>() - adjusted.first,
-	MIN(i->first.get<1>(), bl.length() - (i->first.get<0>() - adjusted.first)));
+      if (i->first.get<1>()) {
+        i->second.first->substr_of(
+	  bl,
+	  i->first.get<0>() - adjusted.first,
+	  MIN(i->first.get<1>(), bl.length() - (i->first.get<0>() - adjusted.first)));
+      } else {
+        i->second.first->substr_of(
+	  bl,
+	  i->first.get<0>() - adjusted.first,
+	  bl.length() - (i->first.get<0>() - adjusted.first));
+      }
       if (i->second.second) {
 	i->second.second->complete(i->second.first->length());
       }


### PR DESCRIPTION
if no-ecbackend, if op.extent.length == 0, osd would return the range of
(op.extent.offset ~ object.length) to client, but in ecbackend it would
return empty data.

Frankly speaking,  I am not sure whether it is bug.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>