### PR TITLE
.gitignore: add install-deps-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ GTAGS
 /examples/librados/.libs/
 /examples/librados/librados_hello_world
 /examples/librados/librados_hello_world_c
+
+# pip cache, and virtualenvs from install-deps.sh
+/install-deps-*


### PR DESCRIPTION
install-deps-cache is created to cach pip downloads, which
is called by install-deps.sh

Signed-off-by: Kefu Chai <kchai@redhat.com>