### PR TITLE
rgw: Do not enclose the Bucket header in quotes

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -362,7 +362,7 @@ void dump_bucket_from_state(struct req_state *s)
   int expose_bucket = g_conf->rgw_expose_bucket;
   if (expose_bucket) {
     if (!s->bucket_name_str.empty())
-      s->cio->print("Bucket: \"%s\"\r\n", s->bucket_name_str.c_str());
+      s->cio->print("Bucket: %s\r\n", s->bucket_name_str.c_str());
   }
 }
 


### PR DESCRIPTION
Fixes: #11860

HTTP headers don't have to be enclosed when it's a string.