### PR TITLE
osd : fix the leak of scrubbing slots

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3803,10 +3803,8 @@ void PG::scrub(ThreadPool::TPHandle &handle)
 
   if (!is_primary() || !is_active() || !is_clean() || !is_scrubbing()) {
     dout(10) << "scrub -- not primary or active or not clean" << dendl;
-    state_clear(PG_STATE_SCRUBBING);
-    state_clear(PG_STATE_REPAIR);
-    state_clear(PG_STATE_DEEP_SCRUB);
-    publish_stats_to_osd();
+    scrub_clear_state();
+    scrub_unreserve_replicas();
     unlock();
     return;
   }

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8864,6 +8864,7 @@ void ReplicatedPG::on_change(ObjectStore::Transaction *t)
 
   // requeues waiting_for_active
   scrub_clear_state();
+  scrub_unreserve_replicas();
 
   context_registry_on_change();
 


### PR DESCRIPTION
Each time we clear PG's scrubbing state, we should release scrubbing slots
of replicas and myself.

Fixes: #11856
Signed-off-by: Guang Yang <yguang@yahoo-inc.com>