### PR TITLE
README: simplify build deps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,12 @@ contributed under the terms of the applicable license.
 Build Prerequisites
 ===================
 
-debian-based
-------------
-
-The list of debian packages dependencies can be installed with:
+The list of Debian or RPM packages dependencies can be installed with:
 
 	./install-deps.sh
 
 Note: libsnappy-dev and libleveldb-dev are not available upstream for
 Debian Squeeze.  Backports for Ceph can be found at ceph.com/debian-leveldb.
-
-rpm-based
----------
-
-The list of RPM packages dependencies can be installed with:
-
-	./install-deps.sh
 
 Building Ceph
 =============


### PR DESCRIPTION
The `install-deps.sh` step is the same for Debian and RPM-based systems. Simplify the two README sections into a single section.