### PR TITLE
ceph.spec.in: fix rpmbuild errors

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -753,8 +753,6 @@ fi
 %{_datadir}/ceph/known_hosts_drop.ceph.com
 %{_datadir}/ceph/id_dsa_drop.ceph.com
 %{_datadir}/ceph/id_dsa_drop.ceph.com.pub
-%dir %{_prefix}/lib/ceph
-%dir %{_prefix}/share/ceph
 %dir %{_sysconfdir}/ceph/
 %dir %{_localstatedir}/log/ceph/
 %config %{_sysconfdir}/bash_completion.d/rados

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -119,7 +119,6 @@ BuildRequires:	gperftools-devel
 %else
 Requires:	scsirastools
 BuildRequires:	google-perftools-devel
-%endif
 Recommends:	logrotate
 BuildRequires:	%insserv_prereq
 BuildRequires:	mozilla-nss-devel


### PR DESCRIPTION
Commit d8abde3338b0c7df373b762e35099ad5123866bf introduced a stray `%endif`. Remove it.

This fixes the build error:

`"error: /srv/autobuild-ceph/gitbuilder.git/build/ceph.spec:140: Got a %endif with no %if"`

Reported-by: @gregsfortytwo