### PR TITLE
test: fix the plugin_exists()

### DIFF
--- a/src/test/erasure-code/test-erasure-code.sh
+++ b/src/test/erasure-code/test-erasure-code.sh
@@ -105,15 +105,13 @@ function plugin_exists() {
     local plugin=$1
 
     local status
-    ./ceph osd erasure-code-profile set TESTPROFILE plugin=$plugin
-    if ./ceph osd crush rule create-erasure TESTRULE TESTPROFILE 2>&1 |
+    if ./ceph osd erasure-code-profile set TESTPROFILE plugin=$plugin 2>&1 |
         grep "$plugin.*No such file" ; then
         status=1
     else
-        ./ceph osd crush rule rm TESTRULE
         status=0
+        ./ceph osd erasure-code-profile rm TESTPROFILE
     fi
-    ./ceph osd erasure-code-profile rm TESTPROFILE 
     return $status
 }
 


### PR DESCRIPTION
in 8e61a99, we try to init the plugin when user sets a profile using
"ceph osd erasure-code-profile set <profile-name> <profile>", so
if user passes in an unknown plugin, ceph will reject it right away,
instead of loading the plugin when "ceph osd crush rule create-erasure".

Fixes: #11870
Signed-off-by: Kefu Chai <kchai@redhat.com>