### PR TITLE
tests: fix test_activate_dmcrypt uuid usage

### DIFF
--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -324,7 +324,7 @@ function test_activate_dmcrypt() {
         --mark-init=none \
         /dev/mapper/$uuid || return 1
 
-    test_pool_read_write $osd_uuid || return 1
+    test_pool_read_write $uuid || return 1
 }
 
 function test_activate_dir() {


### PR DESCRIPTION
4601e10800a63cf0e03108e1da0bf11c19c33e26 introduced a regression in that
an empty (uninitialised) OSD uuid is passed to test_pool_read_write for
IO. As a result, the "rados put" request times out causing test failure.

This change ensures that a correct OSD uuid is passed to
test_pool_read_write.

Signed-off-by: David Disseldorp <ddiss@suse.de>