### PR TITLE
CLS numops

### DIFF
--- a/qa/workunits/cls/test_cls_numops.sh
+++ b/qa/workunits/cls/test_cls_numops.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+ceph_test_cls_numops
+
+exit 0

--- a/src/cls/Makefile-client.am
+++ b/src/cls/Makefile-client.am
@@ -51,10 +51,15 @@ noinst_LIBRARIES += libcls_user_client.a
 libcls_cephfs_client_la_SOURCES = cls/cephfs/cls_cephfs_client.cc
 noinst_LTLIBRARIES += libcls_cephfs_client.la
 
+libcls_numops_client_la_SOURCES = cls/numops/cls_numops_client.cc
+noinst_LTLIBRARIES += libcls_numops_client.la
+DENCODER_DEPS += libcls_numops_client.la
+
 noinst_HEADERS += \
 	cls/lock/cls_lock_types.h \
 	cls/lock/cls_lock_ops.h \
 	cls/lock/cls_lock_client.h \
+	cls/numops/cls_numops_client.h \
 	cls/rbd/cls_rbd.h \
 	cls/rbd/cls_rbd_client.h \
 	cls/refcount/cls_refcount_ops.h \

--- a/src/cls/Makefile-server.am
+++ b/src/cls/Makefile-server.am
@@ -6,6 +6,10 @@ libcls_hello_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
 libcls_hello_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -export-symbols-regex '.*__cls_.*'
 radoslib_LTLIBRARIES += libcls_hello.la
 
+libcls_numops_la_SOURCES = cls/numops/cls_numops.cc
+libcls_numops_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -export-symbols-regex '.*__cls_.*'
+radoslib_LTLIBRARIES += libcls_numops.la
+
 libcls_rbd_la_SOURCES = cls/rbd/cls_rbd.cc
 libcls_rbd_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
 libcls_rbd_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -export-symbols-regex '.*__cls_.*'

--- a/src/cls/numops/cls_numops.cc
+++ b/src/cls/numops/cls_numops.cc
@@ -1,0 +1,164 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 CERN
+ *
+ * Author: Joaquim Rocha <joaquim.rocha@cern.ch>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+/** \file
+ *
+ * This is an OSD class that implements methods for object numeric options on
+ * its omap values.
+ *
+ */
+
+#include "objclass/objclass.h"
+#include <asm-generic/errno.h>
+#include <iostream>
+#include <map>
+#include <string>
+#include <sstream>
+#include <cstdio>
+
+CLS_VER(1,0)
+CLS_NAME(numops)
+
+cls_handle_t h_class;
+cls_method_handle_t h_add;
+cls_method_handle_t h_mul;
+
+static int add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  string key, diff_str;
+
+  bufferlist::iterator iter = in->begin();
+  try {
+    ::decode(key, iter);
+    ::decode(diff_str, iter);
+  } catch (const buffer::error &err) {
+    CLS_LOG(20, "add: invalid decode of input");
+    return -EINVAL;
+  }
+
+  char *end_ptr = 0;
+  double difference = strtod(diff_str.c_str(), &end_ptr);
+
+  if (end_ptr && *end_ptr != '\0') {
+    CLS_ERR("add: invalid input value: %s", diff_str.c_str());
+    return -EINVAL;
+  }
+
+  bufferlist bl;
+  int ret = cls_cxx_map_get_val(hctx, key, &bl);
+
+  double value;
+
+  if (ret == -ENODATA || bl.length() == 0) {
+    value = 0;
+  } else if (ret < 0) {
+    if (ret != -ENOENT) {
+      CLS_ERR("add: error reading omap key %s: %d", key.c_str(), ret);
+    }
+    return ret;
+  } else {
+    std::string stored_value(bl.c_str(), bl.length());
+    end_ptr = 0;
+    value = strtod(stored_value.c_str(), &end_ptr);
+
+    if (end_ptr && *end_ptr != '\0') {
+      CLS_ERR("add: invalid stored value: %s", stored_value.c_str());
+      return -EBADMSG;
+    }
+  }
+
+  value += difference;
+
+  std::stringstream stream;
+
+  stream.str("");
+  stream << std::setprecision(10) << value;
+
+  bufferlist new_value;
+  new_value.append(stream.str());
+
+  return cls_cxx_map_set_val(hctx, key, &new_value);
+}
+
+static int mul(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  string key, diff_str;
+
+  bufferlist::iterator iter = in->begin();
+  try {
+    ::decode(key, iter);
+    ::decode(diff_str, iter);
+  } catch (const buffer::error &err) {
+    CLS_LOG(20, "add: invalid decode of input");
+    return -EINVAL;
+  }
+
+  char *end_ptr = 0;
+  double difference = strtod(diff_str.c_str(), &end_ptr);
+
+  if (end_ptr && *end_ptr != '\0') {
+    CLS_ERR("add: invalid input value: %s", diff_str.c_str());
+    return -EINVAL;
+  }
+
+  bufferlist bl;
+  int ret = cls_cxx_map_get_val(hctx, key, &bl);
+
+  double value;
+
+  if (ret == -ENODATA || bl.length() == 0) {
+    value = 0;
+  } else if (ret < 0) {
+    if (ret != -ENOENT) {
+      CLS_ERR("add: error reading omap key %s: %d", key.c_str(), ret);
+    }
+    return ret;
+  } else {
+    std::string stored_value(bl.c_str(), bl.length());
+    end_ptr = 0;
+    value = strtod(stored_value.c_str(), &end_ptr);
+
+    if (end_ptr && *end_ptr != '\0') {
+      CLS_ERR("add: invalid stored value: %s", stored_value.c_str());
+      return -EBADMSG;
+    }
+  }
+
+  value *= difference;
+
+  std::stringstream stream;
+
+  stream.str("");
+  stream << std::setprecision(10) << value;
+
+  bufferlist new_value;
+  new_value.append(stream.str());
+
+  return cls_cxx_map_set_val(hctx, key, &new_value);
+}
+
+void __cls_init()
+{
+  CLS_LOG(20, "loading cls_numops");
+
+  cls_register("numops", &h_class);
+
+  cls_register_cxx_method(h_class, "add",
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          add, &h_add);
+
+  cls_register_cxx_method(h_class, "mul",
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          mul, &h_mul);
+}

--- a/src/cls/numops/cls_numops.cc
+++ b/src/cls/numops/cls_numops.cc
@@ -27,6 +27,8 @@
 #include <sstream>
 #include <cstdio>
 
+#define DECIMAL_PRECISION 10
+
 CLS_VER(1,0)
 CLS_NAME(numops)
 
@@ -81,9 +83,7 @@ static int add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   value += difference;
 
   std::stringstream stream;
-
-  stream.str("");
-  stream << std::setprecision(10) << value;
+  stream << std::setprecision(DECIMAL_PRECISION) << value;
 
   bufferlist new_value;
   new_value.append(stream.str());
@@ -138,9 +138,7 @@ static int mul(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   value *= difference;
 
   std::stringstream stream;
-
-  stream.str("");
-  stream << std::setprecision(10) << value;
+  stream << std::setprecision(DECIMAL_PRECISION) << value;
 
   bufferlist new_value;
   new_value.append(stream.str());

--- a/src/cls/numops/cls_numops_client.cc
+++ b/src/cls/numops/cls_numops_client.cc
@@ -1,0 +1,80 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 CERN
+ *
+ * Author: Joaquim Rocha <joaquim.rocha@cern.ch>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#include "objclass/objclass.h"
+#include "cls/numops/cls_numops_client.h"
+#include "include/encoding.h"
+
+#include <cstdlib>
+#include <errno.h>
+#include <sstream>
+
+namespace rados {
+  namespace cls {
+    namespace numops {
+
+      int add(librados::IoCtx *ioctx,
+              const std::string& oid,
+              const std::string& key,
+              double value_to_add)
+      {
+        bufferlist in, out;
+        ::encode(key, in);
+
+        std::stringstream stream;
+        stream << value_to_add;
+
+        ::encode(stream.str(), in);
+
+        return ioctx->exec(oid, "numops", "add", in, out);
+      }
+
+      int sub(librados::IoCtx *ioctx,
+              const std::string& oid,
+              const std::string& key,
+              double value_to_subtract)
+      {
+        return add(ioctx, oid, key, -value_to_subtract);
+      }
+
+      int mul(librados::IoCtx *ioctx,
+              const std::string& oid,
+              const std::string& key,
+              double value_to_multiply)
+      {
+        bufferlist in, out;
+        ::encode(key, in);
+
+        std::stringstream stream;
+        stream << value_to_multiply;
+
+        ::encode(stream.str(), in);
+
+        return ioctx->exec(oid, "numops", "mul", in, out);
+      }
+
+      int div(librados::IoCtx *ioctx,
+              const std::string& oid,
+              const std::string& key,
+              double value_to_divide)
+      {
+        if (value_to_divide == 0)
+          return -EINVAL;
+
+        return mul(ioctx, oid, key, 1 / value_to_divide);
+      }
+
+    } // namespace numops
+  } // namespace cls
+} // namespace rados

--- a/src/cls/numops/cls_numops_client.h
+++ b/src/cls/numops/cls_numops_client.h
@@ -1,0 +1,49 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 CERN
+ *
+ * Author: Joaquim Rocha <joaquim.rocha@cern.ch>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#ifndef CEPH_LIBRBD_CLS_NUMOPS_CLIENT_H
+#define CEPH_LIBRBD_CLS_NUMOPS_CLIENT_H
+
+#include "include/rados/librados.hpp"
+
+namespace rados {
+  namespace cls {
+    namespace numops {
+
+      extern int add(librados::IoCtx *ioctx,
+                     const std::string& oid,
+                     const std::string& key,
+                     double value_to_add);
+
+      extern int sub(librados::IoCtx *ioctx,
+                     const std::string& oid,
+                     const std::string& key,
+                     double value_to_subtract);
+
+      extern int mul(librados::IoCtx *ioctx,
+                     const std::string& oid,
+                     const std::string& key,
+                     double value_to_multiply);
+
+      extern int div(librados::IoCtx *ioctx,
+                     const std::string& oid,
+                     const std::string& key,
+                     double value_to_divide);
+
+    } // namespace numops
+  } // namespace cls
+} // namespace rados
+
+#endif // CEPH_LIBRBD_CLS_NUMOPS_CLIENT_H
+

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -173,6 +173,13 @@ ceph_test_cls_hello_LDADD = \
 ceph_test_cls_hello_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_cls_hello
 
+ceph_test_cls_numops_SOURCES = test/cls_numops/test_cls_numops.cc
+ceph_test_cls_numops_LDADD = \
+    $(LIBRADOS) libcls_numops_client.la \
+    $(UNITTEST_LDADD) $(CEPH_GLOBAL) $(RADOS_TEST_LDADD)
+ceph_test_cls_numops_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+bin_DEBUGPROGRAMS += ceph_test_cls_numops
+
 ceph_test_rados_api_cmd_SOURCES = test/librados/cmd.cc
 ceph_test_rados_api_cmd_LDADD = \
 	$(LIBCOMMON) $(LIBRADOS) $(CRYPTO_LIBS) \

--- a/src/test/cls_numops/test_cls_numops.cc
+++ b/src/test/cls_numops/test_cls_numops.cc
@@ -1,0 +1,414 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 CERN
+ *
+ * Author: Joaquim Rocha <joaquim.rocha@cern.ch>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#include <iostream>
+#include <errno.h>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include "cls/numops/cls_numops_client.h"
+#include "gtest/gtest.h"
+#include "include/rados/librados.hpp"
+#include "test/librados/test.h"
+
+using namespace librados;
+
+TEST(ClsNumOps, Add) {
+  Rados cluster;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
+  IoCtx ioctx;
+  cluster.ioctx_create(pool_name.c_str(), ioctx);
+
+  // exec numops add method with an empty bufferlist
+
+  bufferlist in, out;
+
+  ASSERT_EQ(-EINVAL, ioctx.exec("myobject", "numops", "add", in, out));
+
+  // add a number to a non-existing key
+
+  std::string key = "my-key";
+  double value_in = 0.5;
+
+  std::stringstream stream;
+  stream << value_in;
+
+  ASSERT_EQ(0, rados::cls::numops::add(&ioctx, "myobject", key, value_in));
+
+  // check that the omap entry was set and the value matches
+
+  std::set<std::string> keys;
+  std::map<std::string, bufferlist> omap;
+  keys.insert(key);
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  std::map<std::string, bufferlist>::iterator it = omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bufferlist bl = (*it).second;
+  std::string value_out(bl.c_str(), bl.length());
+
+  EXPECT_EQ(stream.str(), value_out);
+
+  // add another value to the existing one
+
+  double new_value_in = 3.001;
+
+  ASSERT_EQ(0, rados::cls::numops::add(&ioctx, "myobject", key, new_value_in));
+
+  // check that the omap entry's value matches
+
+  omap.clear();
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bl = (*it).second;
+  value_out.assign(bl.c_str(), bl.length());
+
+  stream.str("");
+  stream << (value_in + new_value_in);
+
+  EXPECT_EQ(stream.str(), value_out);
+
+  // set the omap entry with some non-numeric value
+
+  omap.clear();
+
+  std::string non_numeric_value("some-non-numeric-text");
+  omap[key].append(non_numeric_value);
+
+  ASSERT_EQ(0, ioctx.omap_set("myobject", omap));
+
+  // check that adding a number does not succeed
+
+  omap.clear();
+
+  ASSERT_EQ(-EBADMSG, rados::cls::numops::add(&ioctx, "myobject", key, 2.0));
+
+  // check that the omap entry was not changed
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  it = omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bl = (*it).second;
+  value_out.assign(bl.c_str(), bl.length());
+
+  EXPECT_EQ(non_numeric_value, value_out);
+
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
+}
+
+TEST(ClsNumOps, Sub) {
+  Rados cluster;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
+  IoCtx ioctx;
+  cluster.ioctx_create(pool_name.c_str(), ioctx);
+
+  // subtract a number from a non-existing key
+
+  std::string key = "my-key";
+  double value_in = 0.5;
+
+  std::stringstream stream;
+  stream << value_in;
+
+  ASSERT_EQ(0, rados::cls::numops::sub(&ioctx, "myobject", key, value_in));
+
+  // check that the omap entry was set and the value matches
+
+  std::set<std::string> keys;
+  std::map<std::string, bufferlist> omap;
+  keys.insert(key);
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  std::map<std::string, bufferlist>::iterator it = omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bufferlist bl = (*it).second;
+  std::string value_out(bl.c_str(), bl.length());
+
+  EXPECT_EQ("-" + stream.str(), value_out);
+
+  // subtract another value to the existing one
+
+  double new_value_in = 3.001;
+
+  ASSERT_EQ(0, rados::cls::numops::sub(&ioctx, "myobject", key, new_value_in));
+
+  // check that the omap entry's value matches
+
+  omap.clear();
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bl = (*it).second;
+  value_out.assign(bl.c_str(), bl.length());
+
+  stream.str("");
+  stream << -(value_in + new_value_in);
+
+  EXPECT_EQ(stream.str(), value_out);
+
+  // set the omap entry with some non-numeric value
+
+  omap.clear();
+
+  std::string non_numeric_value("some-non-numeric-text");
+  omap[key].append(non_numeric_value);
+
+  ASSERT_EQ(0, ioctx.omap_set("myobject", omap));
+
+  // check that subtracting a number does not succeed
+
+  omap.clear();
+
+  ASSERT_EQ(-EBADMSG, rados::cls::numops::sub(&ioctx, "myobject", key, 2.0));
+
+  // check that the omap entry was not changed
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  it = omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bl = (*it).second;
+  value_out.assign(bl.c_str(), bl.length());
+
+  EXPECT_EQ(non_numeric_value, value_out);
+
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
+}
+
+TEST(ClsNumOps, Mul) {
+  Rados cluster;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
+  IoCtx ioctx;
+  cluster.ioctx_create(pool_name.c_str(), ioctx);
+
+  // exec numops mul method with an empty bufferlist
+
+  bufferlist in, out;
+
+  ASSERT_EQ(-EINVAL, ioctx.exec("myobject", "numops", "mul", in, out));
+
+  // multiply a number to a non-existing key
+
+  std::string key = "my-key";
+  double value_in = 0.5;
+
+  std::stringstream stream;
+  stream << value_in;
+
+  ASSERT_EQ(0, rados::cls::numops::mul(&ioctx, "myobject", key, value_in));
+
+  // check that the omap entry was set and the value is zero
+
+  std::set<std::string> keys;
+  std::map<std::string, bufferlist> omap;
+  keys.insert(key);
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  std::map<std::string, bufferlist>::iterator it = omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bufferlist bl = (*it).second;
+  std::string value_out(bl.c_str(), bl.length());
+
+  EXPECT_EQ("0", value_out);
+
+  // set a non-zero value so we can effectively test multiplications
+
+  omap.clear();
+
+  omap[key].append(stream.str());
+
+  ASSERT_EQ(0, ioctx.omap_set("myobject", omap));
+
+  // multiply another value to the existing one
+
+  double new_value_in = 3.001;
+
+  ASSERT_EQ(0, rados::cls::numops::mul(&ioctx, "myobject", key, new_value_in));
+
+  // check that the omap entry's value matches
+
+  omap.clear();
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bl = (*it).second;
+  value_out.assign(bl.c_str(), bl.length());
+
+  stream.str("");
+  stream << (value_in * new_value_in);
+
+  EXPECT_EQ(stream.str(), value_out);
+
+  // set the omap entry with some non-numeric value
+
+  omap.clear();
+
+  std::string non_numeric_value("some-non-numeric-text");
+  omap[key].append(non_numeric_value);
+
+  ASSERT_EQ(0, ioctx.omap_set("myobject", omap));
+
+  // check that adding a number does not succeed
+
+  ASSERT_EQ(-EBADMSG, rados::cls::numops::mul(&ioctx, "myobject", key, 2.0));
+
+  // check that the omap entry was not changed
+
+  omap.clear();
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  it = omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bl = (*it).second;
+  value_out.assign(bl.c_str(), bl.length());
+
+  EXPECT_EQ(non_numeric_value, value_out);
+
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
+}
+
+TEST(ClsNumOps, Div) {
+  Rados cluster;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
+  IoCtx ioctx;
+  cluster.ioctx_create(pool_name.c_str(), ioctx);
+
+  // divide a non-existing key by a number
+
+  std::string key = "my-key";
+  double value_in = 0.5;
+
+  std::stringstream stream;
+  stream << value_in;
+
+  ASSERT_EQ(0, rados::cls::numops::div(&ioctx, "myobject", key, value_in));
+
+  // check that the omap entry was set and the value is zero
+
+  std::set<std::string> keys;
+  std::map<std::string, bufferlist> omap;
+  keys.insert(key);
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  std::map<std::string, bufferlist>::iterator it = omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bufferlist bl = (*it).second;
+  std::string value_out(bl.c_str(), bl.length());
+
+  EXPECT_EQ("0", value_out);
+
+  // check that division by zero is not allowed
+
+  ASSERT_EQ(-EINVAL, rados::cls::numops::div(&ioctx, "myobject", key, 0));
+
+  // set a non-zero value so we can effectively test divisions
+
+  omap.clear();
+
+  omap[key].append(stream.str());
+
+  ASSERT_EQ(0, ioctx.omap_set("myobject", omap));
+
+  // divide another value to the existing one
+
+  double new_value_in = 3.001;
+
+  ASSERT_EQ(0, rados::cls::numops::div(&ioctx, "myobject", key, new_value_in));
+
+  // check that the omap entry's value matches
+
+  omap.clear();
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bl = (*it).second;
+  value_out.assign(bl.c_str(), bl.length());
+
+  stream.str("");
+  stream << (value_in / new_value_in);
+
+  EXPECT_EQ(stream.str(), value_out);
+
+  omap.clear();
+
+  // set the omap entry with some non-numeric value
+
+  std::string non_numeric_value("some-non-numeric-text");
+  omap[key].append(non_numeric_value);
+
+  ASSERT_EQ(0, ioctx.omap_set("myobject", omap));
+
+  // check that adding a number does not succeed
+
+  ASSERT_EQ(-EBADMSG, rados::cls::numops::div(&ioctx, "myobject", key, 2.0));
+
+  // check that the omap entry was not changed
+
+  omap.clear();
+
+  ASSERT_EQ(0, ioctx.omap_get_vals_by_keys("myobject", keys, &omap));
+
+  it = omap.find(key);
+
+  ASSERT_NE(omap.end(), it);
+
+  bl = (*it).second;
+  value_out.assign(bl.c_str(), bl.length());
+
+  EXPECT_EQ(non_numeric_value, value_out);
+
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
+}


### PR DESCRIPTION
Hey,

This is a new and simple CLS useful for those who keep numeric values in the objects' omap and need to perform operations on them.
As an example of why this may be useful, say you have many users creating/deleting files in one go and you want to keep a count of the files in an omap entry without having to lock its object, then you can just call an *add* operation with the number of files a user is creating and it will add to whatever the omap entry's value is at that point. Currently and for simplicity, it's only performing the ops as double values but I can provide other types/ops later.

The operations provided are addition, subtraction, multiplication and division.

Hopefully you'll find this class useful enough to include it upstream.