### PR TITLE
build: Add info about tests to --with-debug option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -432,7 +432,7 @@ AS_IF([test "$with_profiler" = "yes"],
 
 # debug crap?
 AC_ARG_WITH([debug],
-            [AS_HELP_STRING([--with-debug], [build extra debug binaries])],
+            [AS_HELP_STRING([--with-debug], [build extra debug binaries and tests])],
             [case "${withval}" in
 		  yes) with_debug=yes ;;
 		  no)  with_debug=no ;;


### PR DESCRIPTION
The configure's --with-debug option builds also some of the tests so this should be mentioned in its doc string in order to let users know how to build all the tests.

I am, in fact, submitting this because it took me a while to understand how some of the tests were being built and others weren't.
While I think that a better way to fix that would be to have a --with-tests option in the configure that would enable/disable compiling all the tests, having this small doc string addition might already help users out until we eventually have that more coherent option.