### PR TITLE
src/ceph_ver.h.in : autotools makes src/ceph_ver.h

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -491,6 +491,8 @@ MY_CONF_OPT="$MY_CONF_OPT --with-radosgw"
 export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 
 %{configure}	CPPFLAGS="$java_inc" \
+		--with-ceph-git-ver="@ceph_git_ver@" \
+		--with-ceph-git-nice-ver="@ceph_git_nice_ver@" \
 		--prefix=/usr \
 		--localstatedir=/var \
 		--sysconfdir=/etc \

--- a/configure.ac
+++ b/configure.ac
@@ -1126,6 +1126,52 @@ AM_COND_IF([WITH_LTTNG], [
   AC_DEFINE([tracepoint(...)], [], [LTTng is disabled, so define this macro to be nothing.])
 ])
 
+dnl CEPH_GIT_VER
+AC_SUBST(ceph_git_ver)
+AC_ARG_WITH(
+    ceph-git-ver,
+    AS_HELP_STRING(
+        [--with-ceph-git-ver=CEPH_GIT_VER],
+        [Versioning information]
+    ),
+    [
+        ceph_git_ver="$withval"
+    ],
+    [
+        if test "x$CEPH_GIT_VER" = "x"; then
+            ./src/make_version -c /dev/null -g sillyfifo
+            ceph_git_ver=$(head -n 1 sillyfifo)
+            ceph_git_nice_ver=$(tail -n 1 sillyfifo)
+            rm sillyfifo
+        else
+            ceph_git_ver="$CEPH_GIT_VER"
+        fi
+    ]
+)
+
+
+dnl CEPH_GIT_NICE_VER
+AC_SUBST(ceph_git_nice_ver)
+AC_ARG_WITH(
+    ceph-git-nice-ver,
+    AS_HELP_STRING(
+        [--with-ceph-git-nice-ver=CEPH_GIT_NICE_VER],
+        [Versioning information]
+    ),
+    [
+        ceph_git_nice_ver="$withval"
+    ],
+    [
+        if test "x$CEPH_GIT_NICE_VER" = "x"; then
+            ./src/make_version -c /dev/null -g sillyfifo
+            ceph_git_ver=$(head -n 1 sillyfifo)
+            ceph_git_nice_ver=$(tail -n 1 sillyfifo)
+            rm sillyfifo
+        else
+            ceph_git_nice_ver="$CEPH_GIT_NICE_VER"
+        fi
+    ]
+)
 
 AC_CHECK_HEADERS([babeltrace/ctf/events.h babeltrace/babeltrace.h])
 AC_CHECK_DECL([BT_CLOCK_REAL],
@@ -1255,6 +1301,7 @@ AM_PATH_PYTHON([2.4],
 
 AC_CONFIG_HEADERS([src/acconfig.h])
 AC_CONFIG_FILES([Makefile
+	src/ceph_ver.h
 	src/Makefile
 	src/ocf/Makefile
 	src/ocf/ceph

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -178,21 +178,6 @@ FORCE:
 .git_version: FORCE
 	$(srcdir)/make_version -g $(srcdir)/.git_version
 
-# if NO_VERSION is set, only generate a new ceph_ver.h if there currently 
-# is none, and call "make_version -n" to fill it with a fixed string.
-# Otherwise, set it from the contents of .git_version.
-
-ceph_ver.h: .git_version FORCE
-	if [ -n "$$NO_VERSION" ] ; then \
-		$(srcdir)/make_version -g $(srcdir)/.git_version -c $(srcdir)/ceph_ver.h -n ; \
-	else \
-		$(srcdir)/make_version -g $(srcdir)/.git_version -c $(srcdir)/ceph_ver.h ; \
-	fi
-
-ceph_ver.c: ./ceph_ver.h
-common/version.cc: ./ceph_ver.h
-test/encoding/ceph_dencoder.cc: ./ceph_ver.h
-
 sample.fetch_config: fetch_config
 	cp -f $(srcdir)/fetch_config ./sample.fetch_config
 

--- a/src/ceph_ver.h.in
+++ b/src/ceph_ver.h.in
@@ -1,0 +1,7 @@
+#ifndef CEPH_VERSION_H
+#define CEPH_VERSION_H
+
+#define CEPH_GIT_VER @ceph_git_ver@
+#define CEPH_GIT_NICE_VER "@ceph_git_nice_ver@"
+
+#endif


### PR DESCRIPTION
Added configure options:
    	--with-ceph-git-ver="63ba622423b071bd0c56c11a9e8b499d269d7804"
    	--with-ceph-git-nice-ver="v9.0.0-1244-g63ba622"
Use ./src/make_version to default version.

Signed-off-by: Owen Synge <osynge@suse.com>