### PR TITLE
osd : fix the leak of scrubbing slots

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4165,8 +4165,12 @@ void PG::scrub_clear_state()
   publish_stats_to_osd();
 
   // active -> nothing.
-  if (scrubber.active)
+  if (scrubber.active) {
     osd->dec_scrubs_active();
+  } else if (scrubber.reserved) {
+    // pending scrub not yet turn to active
+    osd->dec_scrubs_pending();
+  }
 
   requeue_ops(waiting_for_active);
 


### PR DESCRIPTION
While clearing the local scrubbing state, currently it only tries to
release the *active* slot, however, there is a chance that the pending
has not yet turn to active, in which case the pending slot could be leaked.

Fixes: #11856
Signed-off-by: Guang Yang <yguang@yahoo-inc.com>