### PR TITLE
ceph.spec.in: add missing BuildRequires from SUSE block

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -116,8 +116,10 @@ Requires:	gptfdisk
 %if 0%{with tcmalloc}
 BuildRequires:	gperftools-devel
 %endif
+%else
 Requires:	scsirastools
 BuildRequires:	google-perftools-devel
+%endif
 Recommends:	logrotate
 BuildRequires:	%insserv_prereq
 BuildRequires:	mozilla-nss-devel
@@ -134,7 +136,6 @@ Requires(post):	chkconfig
 Requires(preun):	chkconfig
 Requires(preun):	initscripts
 BuildRequires:	gperftools-devel
-%endif
 %endif
 
 %description

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -73,7 +73,8 @@ CentOS|Fedora|RedHatEnterpriseServer)
                 ;;
         esac
         sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-        $SUDO yum-builddep -y $DIR/ceph.spec || exit 1
+        $SUDO yum-builddep -y $DIR/ceph.spec 2>&1 | tee $DIR/yum-builddep.out
+        ! grep -q -i error: $DIR/yum-builddep.out || exit 1
         ;;
 *SUSE*)
         sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec


### PR DESCRIPTION
http://tracker.ceph.com/issues/11901