### PR TITLE
ceph.spec.in: move specific BuildRequires to where they belong

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -56,11 +56,6 @@ Requires: systemd
 %endif
 BuildRequires:	gcc-c++
 BuildRequires:	boost-devel
-%if 0%{defined suse_version}
-BuildRequires:  libbz2-devel
-%else
-BuildRequires:  bzip2-devel
-%endif
 BuildRequires:	cryptsetup
 BuildRequires:	gdbm
 BuildRequires:	hdparm
@@ -127,7 +122,7 @@ BuildRequires:	keyutils-devel
 BuildRequires:	libatomic-ops-devel
 BuildRequires:	fdupes
 %else
-Requires:	gdisk
+BuildRequires:  bzip2-devel
 BuildRequires:	nss-devel
 BuildRequires:	keyutils-libs-devel
 BuildRequires:	libatomic_ops-devel


### PR DESCRIPTION
Move distro-specific BuildRequires out of "common" section and
into the appropriate %if statement in the "specific" section.
Also remove a duplicated "Requires: gdisk".

Signed-off-by: Nathan Cutler <ncutler@suse.com>