### PR TITLE
tests: ceph-disk.sh test zap gitbuilder false negative

### DIFF
--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -224,7 +224,7 @@ function test_zap() {
     local osd_data=$DIR/dir
     $mkdir -p $osd_data
 
-    ./ceph-disk $CEPH_DISK_ARGS zap $osd_data 2>&1 | grep 'not full block device' || return 1
+    ./ceph-disk $CEPH_DISK_ARGS zap $osd_data 2>&1 | grep -q 'not full block device' || return 1
 
     $rm -fr $osd_data
 }


### PR DESCRIPTION
When looking for an error message and testing ceph disk zap, use grep -q
to not display the error message that will be mistaken for a real error
by the gitbuilder parser.

http://tracker.ceph.com/issues/11272 Refs: #11272

Signed-off-by: Loic Dachary <ldachary@redhat.com>