### PR TITLE
bug fix: osd: avoid multi set osd_op.outdata in tier pool

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2240,6 +2240,9 @@ void ReplicatedPG::cancel_proxy_read(ProxyReadOpRef prdop)
   // cancel objecter op, if we can
   if (prdop->objecter_tid) {
     osd->objecter->op_cancel(prdop->objecter_tid, -ECANCELED);
+    for (uint32_t i = 0; i < prdop->ops.size(); i++) {
+      prdop->ops[i].outdata.clear();
+    }
     proxyread_ops.erase(prdop->objecter_tid);
     prdop->objecter_tid = 0;
   }
@@ -6697,7 +6700,6 @@ void ReplicatedPG::process_copy_chunk(hobject_t oid, ceph_tid_t tid, int r)
 
   // cancel and requeue proxy ops on this object
   if (!r) {
-    kick_proxy_ops_blocked(cobc->obs.oi.soid);
     for (map<ceph_tid_t, ProxyReadOpRef>::iterator it = proxyread_ops.begin();
 	it != proxyread_ops.end(); ++it) {
       if (it->second->soid == cobc->obs.oi.soid) {
@@ -6710,6 +6712,7 @@ void ReplicatedPG::process_copy_chunk(hobject_t oid, ceph_tid_t tid, int r)
 	cancel_proxy_write(it->second);
       }
     }
+    kick_proxy_ops_blocked(cobc->obs.oi.soid);
   }
 
   kick_object_context_blocked(cobc);


### PR DESCRIPTION
There are two read op on the same object for ec pool. First op read
miss happend, calling `do_proxy_read` and `promote_object`, The second op only
`do_proxy_read`. but before first op `process_copy_chunk` finish, the second op
`finish_proxy_read`. first op receive reply from base pool
first and then second received. so the second op set the field "outdata"
in m->ops first. And then first op `requeue_ops` in `process_copy_chunk`,
At last in `do_osd_ops`, it append outdata field.

Fixes: 12540
Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>