### PR TITLE
[DNM] ceph.spec.in:BuildRequires keyutils-devel

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -127,6 +127,7 @@ Requires(post):	chkconfig
 Requires(preun):	chkconfig
 Requires(preun):	initscripts
 BuildRequires:	gperftools-devel
+BuildRequires:	keyutils-libs-devel
 %endif
 
 %description


### PR DESCRIPTION
Move keyutils-devel to common area to fix fedora /suse build.

Signed-off-by: Owen Synge <osynge@suse.com>