### PR TITLE
ceph.spec.in:BuildRequires sharutils

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -54,6 +54,9 @@ Requires(post):	binutils
 %if 0%{?_with_systemd}
 Requires: systemd
 %endif
+%if 0%{with cephfs_java}
+BuildRequires: sharutils
+%endif
 BuildRequires:	gcc-c++
 BuildRequires:	boost-devel
 BuildRequires:	cryptsetup
@@ -96,10 +99,6 @@ BuildRequires:	snappy-devel
 #################################################################################
 # specific
 #################################################################################
-%if ! 0%{?rhel} || 0%{?fedora}
-BuildRequires:	sharutils
-%endif
-
 %if 0%{defined suse_version}
 BuildRequires:	net-tools
 BuildRequires:	libbz2-devel


### PR DESCRIPTION
sharutils rpm is not needed in fedora.
sharutils rpm only a dependency on opensuse.
So this conditional is not needed.

Signed-off-by: Owen Synge <osynge@suse.com>