### PR TITLE
Transaction Id added in response for S3 and Swift requests

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -169,6 +169,18 @@ req_state::~req_state() {
   delete object_acl;
 }
 
+void req_state::gen_trans_id()
+{
+  char buf[256];
+  timeval timetest;
+  gettimeofday(&timetest, NULL);
+  if (strftime(buf, sizeof(buf), "%Y%m%d:%H%M%S",gmtime(&(timetest.tv_sec))) ==  0)
+    return;
+
+  snprintf(buf + strlen(buf), sizeof(buf)-strlen(buf) ,":%03ld", timetest.tv_usec/1000);
+  trans_id = req_id + "-" + buf;
+}
+
 struct str_len {
   const char *str;
   int len;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1061,10 +1061,14 @@ struct req_state {
 
    string req_id;
 
+   string trans_id;
+
    req_info info;
 
    req_state(CephContext *_cct, class RGWEnv *e);
    ~req_state();
+
+   void gen_trans_id();
 };
 
 /** Store basic data on an object */

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -556,6 +556,8 @@ static int process_request(RGWRados *store, RGWREST *rest, RGWRequest *req, RGWC
 
   s->req_id = store->unique_id(req->id);
 
+  s->gen_trans_id();
+
   req->log(s, "initializing");
 
   RGWOp *op = NULL;

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -494,10 +494,22 @@ void dump_start(struct req_state *s)
   }
 }
 
+void dump_trans_id(req_state *s)
+{
+  if (s->prot_flags & RGW_REST_SWIFT) {
+    s->cio->print("X-Trans-Id: ts-%s\r\n", s->trans_id.c_str());
+  }
+  else {
+    s->cio->print("x-amz-request-id: %s\r\n", s->trans_id.c_str());
+  }
+}
+
 void end_header(struct req_state *s, RGWOp *op, const char *content_type, const int64_t proposed_content_length,
 		bool force_content_type)
 {
   string ctype;
+
+  dump_trans_id(s);
 
   if (op) {
     dump_access_control(s, op);


### PR DESCRIPTION
Pull request https://github.com/ceph/ceph/pull/4277 got closed.
Opening this in lieu of that.

This is to add Transaction Id in both S3 and swift response.
S3 will have id in x-amz-request-id header and Swift have X-Trans-Id header.
For S3, id is concatenation of gateway id and request id.
Swift will have additional timestamp appended in human readable format.

Signed-off-by: Abhishek Dixit dixitabhi@gmail.com