### PR TITLE
Add additional required yum repos, ceph and ceph-source, to quick-start preflight page.

### DIFF
--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -68,9 +68,25 @@ following steps:
    or Fedora 20. Finally, save the contents to the 
    ``/etc/yum.repos.d/ceph.repo`` file. ::
 
+	[ceph]
+	name=Ceph 64-bit packages
+	baseurl=http://ceph.com/rpm-{ceph-release}/{distro}/x86_64
+	enabled=1
+	gpgcheck=1
+	type=rpm-md
+	gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+
 	[ceph-noarch]
 	name=Ceph noarch packages
 	baseurl=http://ceph.com/rpm-{ceph-release}/{distro}/noarch
+	enabled=1
+	gpgcheck=1
+	type=rpm-md
+	gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+
+	[ceph-source]
+	name=Ceph source packages
+	baseurl=http://ceph.com/rpm-{ceph-release}/{distro}/SRPMS
 	enabled=1
 	gpgcheck=1
 	type=rpm-md


### PR DESCRIPTION
The preflight instructions currently only mention the ceph-noarch repo in the ceph.repo yum repository file. This change adds the two other required sections, ceph and ceph-source, which refer to their respective repository locations. Without these sections, ceph-deploy fails with missing section errors.