### PR TITLE
Wip make dist rpm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,11 +88,13 @@ dist-hook:
 	  git log --oneline --decorate --no-merges > $(distdir)/ChangeLog; \
 	fi
 
-rpm: dist-bzip2 @PACKAGE@.spec
+srpm: dist-bzip2 @PACKAGE@.spec
 	mkdir -p $(rpmtopdir)/SOURCES \
 		$(rpmtopdir)/SPECS \
 		$(rpmtopdir)/BUILD \
 		$(rpmtopdir)/RPMS $(rpmtopdir)/SRPMS
 	cp @PACKAGE@-@VERSION@.tar.bz2 $(rpmtopdir)/SOURCES
 	cp @PACKAGE@.spec $(rpmtopdir)/SPECS
+
+rpm: srpm
 	rpmbuild --define "_rpmtopdir $(rpmtopdir)" -ba @PACKAGE@.spec

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,7 @@ ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = autogen.sh ceph.spec.in ceph.spec install-deps.sh
 # the "." here makes sure check-local builds gtest and gmock before they are used
 SUBDIRS = . src man doc
+rpmtopdir=@RPM_DIR@
 
 EXTRA_DIST += \
 	src/test/run-cli-tests \
@@ -86,3 +87,12 @@ dist-hook:
 	  cd $(srcdir); \
 	  git log --oneline --decorate --no-merges > $(distdir)/ChangeLog; \
 	fi
+
+rpm: dist-bzip2 @PACKAGE@.spec
+	mkdir -p $(rpmtopdir)/SOURCES \
+		$(rpmtopdir)/SPECS \
+		$(rpmtopdir)/BUILD \
+		$(rpmtopdir)/RPMS $(rpmtopdir)/SRPMS
+	cp @PACKAGE@-@VERSION@.tar.bz2 $(rpmtopdir)/SOURCES
+	cp @PACKAGE@.spec $(rpmtopdir)/SPECS
+	rpmbuild --define "_rpmtopdir $(rpmtopdir)" -ba @PACKAGE@.spec

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -485,11 +485,6 @@ for i in /usr/{lib64,lib}/jvm/java/include{,/linux}; do
 done
 
 ./autogen.sh
-MY_CONF_OPT=""
-
-MY_CONF_OPT="$MY_CONF_OPT --with-radosgw"
-
-export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 
 %{configure}	CPPFLAGS="$java_inc" \
 		--prefix=/usr \

--- a/configure.ac
+++ b/configure.ac
@@ -1204,6 +1204,24 @@ AC_ARG_WITH(
     ]
 )
 
+
+dnl Set RPM topdir
+RPMD=`pwd`/RPM
+AC_MSG_CHECKING([for directory where to create rpms])
+AC_ARG_WITH(rpm-dir,[  --with-rpm-dir=<dir> Default is \$RPMD/],
+            rpm_dir="$withval", rpm_dir="$RPMD")
+if test -d "$rpm_dir" ; then
+    AC_MSG_RESULT([found $rpm_dir])
+    RPM_DIR=$rpm_dir
+else
+    AC_MSG_RESULT([no such directory $rpm_dir])
+    AC_MSG_RESULT([the directory $rpm_dir will be created for you if possible])
+    RPM_DIR=$rpm_dir
+fi
+
+AC_SUBST(RPM_DIR)
+
+
 # Checks for typedefs, structures, and compiler characteristics.
 #AC_HEADER_STDBOOL
 #AC_C_CONST


### PR DESCRIPTION
This allows make rpm to execute.

It seems to be failing as the code is I hope it proves useful to the team.
On a fresh debian install I keep hiting dependancy issues not caught by autotools sadly.