### PR TITLE
ceph.sepc.in broken by shell script

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -476,12 +476,6 @@ for i in /usr/{lib64,lib}/jvm/java/include{,/linux}; do
 done
 
 ./autogen.sh
-MY_CONF_OPT=""
-
-MY_CONF_OPT="$MY_CONF_OPT --with-radosgw"
-
-export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
-
 %{configure}	CPPFLAGS="$java_inc" \
 		--prefix=/usr \
 		--localstatedir=/var \
@@ -501,7 +495,6 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 %if 0%{?opensuse} || 0%{?suse_version}
 		--with-systemd-libexec-dir=/usr/lib/ceph/ \
 %endif
-		$MY_CONF_OPT \
 		%{?_with_ocf} \
 		%{?_with_tcmalloc} \
 		CFLAGS="$RPM_OPT_FLAGS" CXXFLAGS="$RPM_OPT_FLAGS"


### PR DESCRIPTION
this can be seen eaisly if you apply pull request

https://github.com/ceph/ceph/pull/4905/files

    $sh autogen.sh ; configure ; make rpm

And bug is shown with the rpm errors.

Signed-off-by: Owen Synge <osynge@suse.com>