### PR TITLE
tests: automake 1.11 needs parallel-tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,8 +50,8 @@ AM_PROG_LIBTOOL
 AM_PROG_AS
 
 
+AM_INIT_AUTOMAKE([foreign parallel-tests])
 # enable make V=0 (if automake >1.11)
-AM_INIT_AUTOMAKE([foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # Platform


### PR DESCRIPTION
Prior to automake 1.12 the default behavior was serial-tests meaning
tests from make check were run one after the other and their output sent
to stdout/stderr. From automake 1.12 up the default became
parallel-tests which logs the output of each individual test in a
separate .log file and allows them to run in parallel.

http://lists.gnu.org/archive/html/automake/2012-12/msg00038.html

Enable parallel-tests so that tests can always run in parallel, even
with automake 1.11 which is the version found in CentOS 6.5 and Ubuntu
12.04 precise.

A nice side effect of always having the logs in separate files is that
tests do not need to worry about being too verbose because their output
will only be read for diagnostic purposes.

http://tracker.ceph.com/issues/11931 Fixes: #11931
http://tracker.ceph.com/issues/11906 Fixes: #11906

Signed-off-by: Loic Dachary <ldachary@redhat.com>