### PR TITLE
tests: ceph_erasure_code_non_regression s/stipe/stripe/

### DIFF
--- a/src/test/erasure-code/ceph_erasure_code_non_regression.cc
+++ b/src/test/erasure-code/ceph_erasure_code_non_regression.cc
@@ -119,7 +119,7 @@ int ErasureCodeNonRegression::setup(int argc, char** argv) {
 
   {
     stringstream path;
-    path << base << "/" << "plugin=" << plugin << " stipe-width=" << stripe_width;
+    path << base << "/" << "plugin=" << plugin << " stripe-width=" << stripe_width;
     directory = path.str();
   }
 


### PR DESCRIPTION
Synchronize withe the ceph-erasure-code-corpus submodule in which all
file names were modified to fix the typo.

http://tracker.ceph.com/issues/11932 Fixes: #11932

Signed-off-by: Loic Dachary <ldachary@redhat.com>