### PR TITLE
osd: concurrently read when finish promote

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -589,6 +589,7 @@ OPTION(osd_tier_default_cache_hit_set_period, OPT_INT, 1200)
 OPTION(osd_tier_default_cache_hit_set_type, OPT_STR, "bloom")
 OPTION(osd_tier_default_cache_min_read_recency_for_promote, OPT_INT, 1) // number of recent HitSets the object must appear in to be promoted (on read)
 OPTION(osd_tier_default_cache_min_write_recency_for_promote, OPT_INT, 1) // number of recent HitSets the object must appear in to be promoted (on write)
+OPTION(osd_tier_kick_read_after_promote, OPT_BOOL, true)
 
 OPTION(osd_map_dedup, OPT_BOOL, true)
 OPTION(osd_map_max_advance, OPT_INT, 200) // make this < cache_size!

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -24,7 +24,7 @@ OpRequest::OpRequest(Message *req, OpTracker *tracker) :
   rmw_flags(0), request(req),
   hit_flag_points(0), latest_flag_point(0),
   send_map_update(false), sent_epoch(0),
-  hitset_inserted(false) {
+  hitset_inserted(false), already_reply(false) {
   if (req->get_priority() < tracker->cct->_conf->osd_client_op_priority) {
     // don't warn as quickly for low priority ops
     warn_interval_multiplier = tracker->cct->_conf->osd_recovery_op_warn_multiple;

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -110,6 +110,7 @@ public:
   bool send_map_update;
   epoch_t sent_epoch;
   bool hitset_inserted;
+  bool already_reply;
   Message *get_req() const { return request; }
   bool been_queued_for_pg() { return hit_flag_points & flag_queued_for_pg; }
   bool been_reached_pg() { return hit_flag_points & flag_reached_pg; }
@@ -123,6 +124,7 @@ public:
   bool currently_started() { return latest_flag_point & flag_started; }
   bool currently_sub_op_sent() { return latest_flag_point & flag_sub_op_sent; }
   bool currently_commit_sent() { return latest_flag_point & flag_commit_sent; }
+  bool been_reply() { return already_reply; }
 
   const char *state_string() const {
     switch(latest_flag_point) {
@@ -163,6 +165,9 @@ public:
     dequeued_time = deq_time;
   }
 
+  void set_reply() {
+    already_reply = true;
+  }
   osd_reqid_t get_reqid() const {
     return reqid;
   }

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2316,6 +2316,26 @@ void ReplicatedPG::kick_proxy_ops_blocked(hobject_t& soid)
   in_progress_proxy_ops.erase(p);
 }
 
+void ReplicatedPG::requeue_proxy_ops(hobject_t& soid)
+{
+  map<hobject_t, list<OpRequestRef>, hobject_t::BitwiseComparator>::iterator p = in_progress_proxy_ops.find(soid);
+  if (p == in_progress_proxy_reads.end())
+    return;
+
+  list<OpRequestRef> ls = p->second;
+  for (list<OpRequestRef>::iterator it = ls.begin(); it != ls.end(); ++it) {
+    MOSDOp *m = static_cast<MOSDOp*>((*it)->get_req());
+    for (uint32_t i = 0; i < m->ops.size(); i++) {
+      // in order not to race with ops's outdate used by inflight proxy ops,
+      // we should alloc new buffer for requeue_ops
+      bufferlist bl;
+      m->ops[i].outdata = bl;
+    }
+  }
+  dout(10) << __func__ << " " << soid << " requeuing " << ls.size() << " requests" << dendl;
+  requeue_ops(ls);
+}
+
 void ReplicatedPG::cancel_proxy_read(ProxyReadOpRef prdop)
 {
   dout(10) << __func__ << " " << prdop->soid << dendl;
@@ -6328,6 +6348,11 @@ void ReplicatedPG::finish_ctx(OpContext *ctx, int log_op_type, bool maintain_ssc
 
 void ReplicatedPG::complete_read_ctx(int result, OpContext *ctx)
 {
+  if (ctx->op->been_reply()) {
+    close_op_ctx(ctx, 0);
+    return;
+  }
+  ctx->op->set_reply();
   MOSDOp *m = static_cast<MOSDOp*>(ctx->op->get_req());
   assert(ctx->async_reads_complete());
 
@@ -6844,21 +6869,25 @@ void ReplicatedPG::process_copy_chunk(hobject_t oid, ceph_tid_t tid, int r)
 
   // cancel and requeue proxy ops on this object
   if (!r) {
-    kick_proxy_ops_blocked(cobc->obs.oi.soid);
-    for (map<ceph_tid_t, ProxyReadOpRef>::iterator it = proxyread_ops.begin();
-	it != proxyread_ops.end(); ++it) {
-      if (it->second->soid == cobc->obs.oi.soid) {
-	cancel_proxy_read(it->second);
+    if (g_conf->osd_tier_kick_read_after_promote) {
+      // cancel and requeue proxy ops on this object
+      kick_proxy_ops_blocked(cobc->obs.oi.soid);
+      for (map<ceph_tid_t, ProxyReadOpRef>::iterator it = proxyread_ops.begin();
+          it != proxyread_ops.end(); ++it) {
+        if (it->second->soid == cobc->obs.oi.soid) {
+          cancel_proxy_read(it->second);
+        }
       }
-    }
-    for (map<ceph_tid_t, ProxyWriteOpRef>::iterator it = proxywrite_ops.begin();
-	 it != proxywrite_ops.end(); ++it) {
-      if (it->second->soid == cobc->obs.oi.soid) {
-	cancel_proxy_write(it->second);
+      for (map<ceph_tid_t, ProxyWriteOpRef>::iterator it = proxywrite_ops.begin();
+           it != proxywrite_ops.end(); ++it) {
+        if (it->second->soid == cobc->obs.oi.soid) {
+          cancel_proxy_write(it->second);
+        }
       }
+    } else {
+      requeue_proxy_ops(cobc->obs.oi.soid);
     }
   }
-
   kick_object_context_blocked(cobc);
 }
 

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -197,7 +197,7 @@ public:
     OpRequestRef op;
     hobject_t soid;
     ceph_tid_t objecter_tid;
-    vector<OSDOp> &ops;
+    vector<OSDOp> ops;
     version_t user_version;
     int data_offset;
     bool canceled;              ///< true if canceled

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1403,6 +1403,7 @@ protected:
 
   void do_proxy_read(OpRequestRef op);
   void finish_proxy_read(hobject_t oid, ceph_tid_t tid, int r);
+  void requeue_proxy_ops(hobject_t& soid);
   void cancel_proxy_read(ProxyReadOpRef prdop);
 
   friend struct C_ProxyRead;


### PR DESCRIPTION
when finish promote, osd would kick the proxy read in flight.
But the requeue read would not read object until the promoted object
writen to filestore. I think this latency maybe not less
than do_proxy_read in some case.
 
Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>