### PR TITLE
ceph.spec.in: fix:Add missing directories breaking suse rpm build

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -751,6 +751,8 @@ fi
 %{_datadir}/ceph/id_dsa_drop.ceph.com.pub
 %dir %{_sysconfdir}/ceph/
 %dir %{_localstatedir}/log/ceph/
+%dir %{_datarootdir}/ceph/
+%dir %{_libexecdir}/ceph/
 %config %{_sysconfdir}/bash_completion.d/rados
 %config %{_sysconfdir}/bash_completion.d/rbd
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap


### PR DESCRIPTION
SUSE builds on OBS are failing with the missing dir entries:

    /usr/share/ceph
    /usr/lib/ceph

On suse these correspond to:

    %dir %{_datarootdir}/%{name}
    %dir %{_libexecdir}/%{name}

Signed-off-by: Owen Synge <osynge@suse.com>