### PR TITLE
Wip ceph spec mandir

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -487,6 +487,7 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--localstatedir=/var \
 		--sysconfdir=/etc \
 		--docdir=%{_docdir}/ceph \
+		--mandir="%_mandir" \
 		--with-nss \
 		--without-cryptopp \
 		--with-rest-bench \

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -487,6 +487,7 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--localstatedir=/var \
 		--sysconfdir=/etc \
 		--docdir=%{_docdir}/ceph \
+		--with-man-pages \
 		--mandir="%_mandir" \
 		--with-nss \
 		--without-cryptopp \


### PR DESCRIPTION
This removes a breakage in fedora build see here for details.

https://build.opensuse.org/package/live_build_log/home:osynge:ceph:wip:wip_obs_fedora/master+4898/Fedora_22/x86_64