### PR TITLE
tests: ceph-disk tests need to install pip > 6.1

### DIFF
--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -24,6 +24,9 @@ DIR=test-ceph-disk
 virtualenv virtualenv-$DIR
 . virtualenv-$DIR/bin/activate
 (
+    # older versions of pip will not install wrap_console scripts
+    # when using wheel packages
+    pip install --upgrade 'pip >= 6.1'
     if test -d ceph-detect-init/wheelhouse ; then
         wheelhouse="--no-index --use-wheel --find-links=ceph-detect-init/wheelhouse"
     fi


### PR DESCRIPTION
Otherwise it will not be able to use the wheelhouse.

http://tracker.ceph.com/issues/11952 Fixes: #11952

Signed-off-by: Loic Dachary <loic@dachary.org>