### PR TITLE
tests: display the output of failed make check runs

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -70,11 +70,6 @@ function main() {
         echo "make check: successful run on $(git rev-parse HEAD)"
         return 0
     else
-        find . -name '*.trs' | xargs grep -l FAIL | while read file ; do
-            log=$(dirname $file)/$(basename $file .trs).log
-            echo FAIL: $log
-            cat $log
-        done
         return 1
     fi
 }

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -36,6 +36,9 @@ check_PROGRAMS = $(check_TESTPROGRAMS)
 # tests scripts will be appended to this
 check_SCRIPTS =
 
+# display the output of failed check_SCRIPTS after a failed make check
+export VERBOSE = true
+
 # python unit tests need to know where the scripts are located
 export PYTHONPATH=$(top_srcdir)/src/pybind
 


### PR DESCRIPTION
After a make check fails, it shows a summary but not the output of the
failed tests although they contain information to diagnose the problem.

Set the VERBOSE=true automake variable which is documented to collect
and display the failed script output at the end of a run (the content of
the test-suite.log file (valid from automake-1.11 up).

http://www.gnu.org/software/automake/manual/automake.html#index-VERBOSE

Also remove the run-make-check.sh that did the same in a way that is not
compatible with automake-1.11.

Signed-off-by: Loic Dachary <ldachary@redhat.com>