### PR TITLE
11955: ceph.spec.in: package mkcephfs on EL6

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -448,10 +448,11 @@ fi
 %{_sbindir}/ceph-disk-udev
 %{_sbindir}/ceph-create-keys
 %{_sbindir}/rcceph
-%{_sbindir}/mkcephfs
 %if 0%{?rhel} >= 7 || 0%{?fedora}
+%{_sbindir}/mkcephfs
 %{_sbindir}/mount.ceph
 %else
+/sbin/mkcephfs
 /sbin/mount.ceph
 %endif
 %dir %{_libdir}/ceph


### PR DESCRIPTION
Commit efbca0465c2946e113771966df08cf7cf37b1196 added `mkcephfs` to the RPM `%files` listing, but this `/usr/sbin` path is only correct for CentOS 7. In CentOS 6, the utility is present at `/sbin/mkcephfs` instead. This causes rpmbuild to fail to build the tip of the firefly branch on EL6.

This pull request adjusts the RPM `%files` list so we properly package mkcephfs on both EL7 and EL6.

http://tracker.ceph.com/issues/11955