### PR TITLE
Dont keeping key_list in transaction

### DIFF
--- a/src/os/LevelDBStore.cc
+++ b/src/os/LevelDBStore.cc
@@ -162,21 +162,19 @@ void LevelDBStore::LevelDBTransactionImpl::set(
   const string &k,
   const bufferlist &to_set_bl)
 {
-  buffers.push_back(to_set_bl);
-  bufferlist &bl = *(buffers.rbegin());
   string key = combine_strings(prefix, k);
-  keys.push_back(key);
-  bat.Delete(leveldb::Slice(*(keys.rbegin())));
-  bat.Put(leveldb::Slice(*(keys.rbegin())),
-	  leveldb::Slice(bl.c_str(), bl.length()));
+  //bufferlist::c_str() is non-constant, so we need to make a copy
+  bufferlist val = to_set_bl;
+  bat.Delete(leveldb::Slice(key));
+  bat.Put(leveldb::Slice(key),
+	  leveldb::Slice(val.c_str(), val.length()));
 }
 
 void LevelDBStore::LevelDBTransactionImpl::rmkey(const string &prefix,
 					         const string &k)
 {
   string key = combine_strings(prefix, k);
-  keys.push_back(key);
-  bat.Delete(leveldb::Slice(*(keys.rbegin())));
+  bat.Delete(leveldb::Slice(key));
 }
 
 void LevelDBStore::LevelDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
@@ -186,8 +184,7 @@ void LevelDBStore::LevelDBTransactionImpl::rmkeys_by_prefix(const string &prefix
        it->valid();
        it->next()) {
     string key = combine_strings(prefix, it->key());
-    keys.push_back(key);
-    bat.Delete(*(keys.rbegin()));
+    bat.Delete(key);
   }
 }
 

--- a/src/os/LevelDBStore.h
+++ b/src/os/LevelDBStore.h
@@ -177,10 +177,7 @@ public:
   class LevelDBTransactionImpl : public KeyValueDB::TransactionImpl {
   public:
     leveldb::WriteBatch bat;
-    list<bufferlist> buffers;
-    list<string> keys;
     LevelDBStore *db;
-
     LevelDBTransactionImpl(LevelDBStore *db) : db(db) {}
     void set(
       const string &prefix,

--- a/src/os/RocksDBStore.cc
+++ b/src/os/RocksDBStore.cc
@@ -237,21 +237,19 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const string &k,
   const bufferlist &to_set_bl)
 {
-  buffers.push_back(to_set_bl);
-  bufferlist &bl = *(buffers.rbegin());
   string key = combine_strings(prefix, k);
-  keys.push_back(key);
-  bat->Delete(rocksdb::Slice(*(keys.rbegin())));
-  bat->Put(rocksdb::Slice(*(keys.rbegin())),
-	  rocksdb::Slice(bl.c_str(), bl.length()));
+  //bufferlist::c_str() is non-constant, so we need to make a copy
+  bufferlist val = to_set_bl;
+  bat->Delete(rocksdb::Slice(key));
+  bat->Put(rocksdb::Slice(key),
+	  rocksdb::Slice(val.c_str(), val.length()));
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 					         const string &k)
 {
   string key = combine_strings(prefix, k);
-  keys.push_back(key);
-  bat->Delete(rocksdb::Slice(*(keys.rbegin())));
+  bat->Delete(rocksdb::Slice(k));
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
@@ -261,8 +259,7 @@ void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix
        it->valid();
        it->next()) {
     string key = combine_strings(prefix, it->key());
-    keys.push_back(key);
-    bat->Delete(*(keys.rbegin()));
+    bat->Delete(key);
   }
 }
 

--- a/src/os/RocksDBStore.h
+++ b/src/os/RocksDBStore.h
@@ -131,8 +131,6 @@ public:
   class RocksDBTransactionImpl : public KeyValueDB::TransactionImpl {
   public:
     rocksdb::WriteBatch *bat;
-    list<bufferlist> buffers;
-    list<string> keys;
     RocksDBStore *db;
 
     RocksDBTransactionImpl(RocksDBStore *_db);


### PR DESCRIPTION
The RocksDB/LevelDB  PUT/DELETE api already make a deep copy of key/value, we don't need to maintain a copy outside.