### PR TITLE
qa: use "sudo cp" in multiple_rsync.sh

### DIFF
--- a/qa/workunits/fs/misc/multiple_rsync.sh
+++ b/qa/workunits/fs/misc/multiple_rsync.sh
@@ -4,7 +4,7 @@
 # Populate with some arbitrary files from the local system.  Take
 # a copy to protect against false fails from system updates during test.
 export PAYLOAD=/tmp/multiple_rsync_payload.$$
-cp -r /usr/lib/ $PAYLOAD
+sudo cp -r /usr/lib/ $PAYLOAD
 
 set -e
 


### PR DESCRIPTION
VirtualBox has some files with weird
permissions in its /usr/lib, which was
tripping up this usually-safe operation
when run as an unprivileged user.

Fixes: #11959
Signed-off-by: John Spray <john.spray@redhat.com>