### PR TITLE
RGW: Multipart Upload: Configure and enforce no of parts

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1050,6 +1050,7 @@ OPTION(rgw_user_quota_sync_idle_users, OPT_BOOL, false) // whether stats for idl
 OPTION(rgw_user_quota_sync_wait_time, OPT_INT, 3600 * 24) // min time between two full stats sync for non-idle users
 
 OPTION(rgw_multipart_min_part_size, OPT_INT, 5 * 1024 * 1024) // min size for each part (except for last one) in multipart upload
+OPTION(rgw_multipart_part_upload_limit, OPT_INT, 10000) // parts limit in multipart upload
 
 OPTION(rgw_olh_pending_timeout_sec, OPT_INT, 3600) // time until we retire a pending olh change
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3003,6 +3003,11 @@ void RGWCompleteMultipart::execute()
     return;
   }
 
+  if (parts->parts.size() > s->cct->_conf->rgw_multipart_part_upload_limit) {
+    ret = -ERANGE;
+    return;
+  }
+
   mp.init(s->object.name, upload_id);
   meta_oid = mp.get_meta();
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/12146
RGW: Multipart Upload: Support to configure and enforce no of parts allowed
Config parameter added for no of parts limit in multipart upload and checked while completing multipart upload
Signed-off-by: Abhishek Dixit dixitabhi@gmail.com