### PR TITLE
bug fix: librados segmentation fault, when two read ops share one Aio…

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1299,6 +1299,7 @@ void librados::IoCtxImpl::set_notify_timeout(uint32_t timeout)
 
 librados::IoCtxImpl::C_aio_Ack::C_aio_Ack(AioCompletionImpl *_c) : c(_c)
 {
+  assert(!c->io);
   c->get();
 }
 
@@ -1331,6 +1332,7 @@ librados::IoCtxImpl::C_aio_stat_Ack::C_aio_stat_Ack(AioCompletionImpl *_c,
 						    time_t *pm)
    : c(_c), pmtime(pm)
 {
+  assert(!c->io);
   c->get();
 }
 

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -694,11 +694,11 @@ int librados::IoCtxImpl::aio_write(const object_t &oid, AioCompletionImpl *c,
   if (snap_seq != CEPH_NOSNAP)
     return -EROFS;
 
-  c->io = this;
-  queue_aio_write(c);
-
   Context *onack = new C_aio_Ack(c);
   Context *onsafe = new C_aio_Safe(c);
+
+  c->io = this;
+  queue_aio_write(c);
 
   c->tid = objecter->write(oid, oloc,
 		  off, len, snapc, bl, ut, 0,
@@ -718,11 +718,11 @@ int librados::IoCtxImpl::aio_append(const object_t &oid, AioCompletionImpl *c,
   if (snap_seq != CEPH_NOSNAP)
     return -EROFS;
 
-  c->io = this;
-  queue_aio_write(c);
-
   Context *onack = new C_aio_Ack(c);
   Context *onsafe = new C_aio_Safe(c);
+
+  c->io = this;
+  queue_aio_write(c);
 
   c->tid = objecter->append(oid, oloc,
 		   len, snapc, bl, ut, 0,
@@ -743,11 +743,11 @@ int librados::IoCtxImpl::aio_write_full(const object_t &oid,
   if (snap_seq != CEPH_NOSNAP)
     return -EROFS;
 
-  c->io = this;
-  queue_aio_write(c);
-
   Context *onack = new C_aio_Ack(c);
   Context *onsafe = new C_aio_Safe(c);
+
+  c->io = this;
+  queue_aio_write(c);
 
   c->tid = objecter->write_full(oid, oloc,
 		       snapc, bl, ut, 0,
@@ -764,11 +764,11 @@ int librados::IoCtxImpl::aio_remove(const object_t &oid, AioCompletionImpl *c)
   if (snap_seq != CEPH_NOSNAP)
     return -EROFS;
 
-  c->io = this;
-  queue_aio_write(c);
-
   Context *onack = new C_aio_Ack(c);
   Context *onsafe = new C_aio_Safe(c);
+
+  c->io = this;
+  queue_aio_write(c);
 
   c->tid = objecter->remove(oid, oloc,
 		   snapc, ut, 0,
@@ -781,9 +781,9 @@ int librados::IoCtxImpl::aio_remove(const object_t &oid, AioCompletionImpl *c)
 int librados::IoCtxImpl::aio_stat(const object_t& oid, AioCompletionImpl *c,
 				  uint64_t *psize, time_t *pmtime)
 {
-  c->io = this;
   C_aio_stat_Ack *onack = new C_aio_stat_Ack(c, pmtime);
 
+  c->io = this;
   c->tid = objecter->stat(oid, oloc,
 		 snap_seq, psize, &onack->mtime, 0,
 		 onack, &c->objver);

--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -463,10 +463,10 @@ int libradosstriper::RadosStriperImpl::aio_read(const std::string& soid,
   
   // create a completion object and transfer ownership of extents and resultbl
   vector<bufferlist> *resultbl = new vector<bufferlist>(extents->size());
-  c->is_read = true;
-  c->io = m_ioCtxImpl;
   ReadCompletionData *cdata = new ReadCompletionData(this, soid, lockCookie, c,
 						     bl, extents, resultbl);
+  c->is_read = true;
+  c->io = m_ioCtxImpl;
   libradosstriper::MultiAioCompletionImpl *nc = new libradosstriper::MultiAioCompletionImpl;
   nc->set_complete_callback(cdata, striper_read_aio_req_complete);
   // go through the extents


### PR DESCRIPTION
      As we know,  AioCompletionImpl is mapped to one async io request. 
Buf if there are two or more aio requests bind to one AioCompletionImpl, 
some unexpected result will happen.
      this bug fix is about two aio read opeatons bind to one AioCompletionImpl 
causing segmentaion fault. 

I use a simple librados client to test the bug, the main logic is:

rados_read_op_read(read_op, 0, len, buf, &bytes_read, &ret);
rados_read_op_read(read_op2, 0, len, buf2, &bytes_read2, &ret2);
ret = rados_aio_read_op_operate(read_op, ioctx, read_completion, object, 0);
ret = rados_aio_read_op_operate(read_op2, ioctx, read_completion, object, 0);
ret = rados_aio_wait_for_complete(read_completion);

and other misc binds are:
aio_write, aio_write
aio_read, aio_write
aio_stat, aio_read
aio_write, aio_stat
......

Maybe some binds not causing segmentaion fault, but we 
still need to make AioCompletionImpl semantic right.
