### PR TITLE
cmake: add missing RadosDump.cc, RadosImport.cc and PoolDump.cc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -357,6 +357,9 @@ install(TARGETS librados DESTINATION lib)
 
 set(rados_srcs
   tools/rados/rados.cc
+  tools/RadosDump.cc
+  tools/rados/RadosImport.cc
+  tools/rados/PoolDump.cc
   common/obj_bencher.cc)
 add_executable(rados ${rados_srcs} $<TARGET_OBJECTS:heap_profiler_objs>)
 target_link_libraries(rados librados global ${CMAKE_DL_LIBS} ${TCMALLOC_LIBS})


### PR DESCRIPTION
Signed-off-by: Orit Wasserman <owasserm@redhat.com>