### PR TITLE
qa: update to newer Linux tarball

### DIFF
--- a/qa/workunits/kernel_untar_build.sh
+++ b/qa/workunits/kernel_untar_build.sh
@@ -2,12 +2,11 @@
 
 set -e
 
-#wget -q http://ceph.com/qa/linux-2.6.33.tar.bz2
-wget -q http://ceph.com/qa/linux-3.2.9.tar.bz2
+wget -q http://ceph.com/qa/linux-4.0.5.tar.xz
 
 mkdir t
 cd t
-tar jxvf ../linux*.bz2
+tar Jxvf ../linux*.xz
 cd linux*
 make defconfig
 make -j`grep -c processor /proc/cpuinfo`


### PR DESCRIPTION
This should make newer gcc releases happier in their default configuration.
kernel.org is now distributing tarballs as .xz files so we change to that
as well when decompressing (it is supported by Ubuntu Precise so we should
be all good).

Fixes: #11758

Signed-off-by: Greg Farnum <gfarnum@redhat.com>