### PR TITLE
mds: add dirfrag split/merge asok commands

### DIFF
--- a/src/mds/MDS.h
+++ b/src/mds/MDS.h
@@ -382,9 +382,22 @@ private:
   void command_get_subtrees(Formatter *f);
   void command_export_dir(Formatter *f,
       const std::string &path, mds_rank_t dest);
+  bool command_dirfrag_split(
+      cmdmap_t cmdmap,
+      std::ostream &ss);
+  bool command_dirfrag_merge(
+      cmdmap_t cmdmap,
+      std::ostream &ss);
+  bool command_dirfrag_ls(
+      cmdmap_t cmdmap,
+      std::ostream &ss,
+      Formatter *f);
  private:
   int _command_export_dir(const std::string &path, mds_rank_t dest);
   int _command_flush_journal(std::stringstream *ss);
+  CDir *_command_dirfrag_get(
+      const cmdmap_t &cmdmap,
+      std::ostream &ss);
  public:
     // config observer bits
   virtual const char** get_tracked_conf_keys() const;


### PR DESCRIPTION
Analogous to those from the old-style mds tell.  Also
add an 'ls' that gives you the frags in the same format
that frag_t::parse expects them, so that it's a bit
less obscure to use.

Signed-off-by: John Spray <john.spray@redhat.com>