### PR TITLE
ceph.spec.in: python-argparse only in Python 2.6

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -41,7 +41,6 @@ Requires:	python-rados = %{epoch}:%{version}-%{release}
 Requires:	python-rbd = %{epoch}:%{version}-%{release}
 Requires:	python-cephfs = %{epoch}:%{version}-%{release}
 Requires:	python
-Requires:	python-argparse
 Requires:	python-requests
 Requires:	python-flask
 Requires:	xfsprogs
@@ -77,7 +76,6 @@ BuildRequires:	perl
 BuildRequires:	parted
 BuildRequires:	pkgconfig
 BuildRequires:	python
-BuildRequires:	python-argparse
 BuildRequires:	python-nose
 BuildRequires:	python-requests
 %if ( 0%{?rhel} > 0 && 0%{?rhel} < 7 ) || ( 0%{?centos} > 0 && 0%{?centos} < 7 )
@@ -149,14 +147,16 @@ Requires:	python-rados = %{epoch}:%{version}-%{release}
 Requires:	python-rbd = %{epoch}:%{version}-%{release}
 Requires:	python-cephfs = %{epoch}:%{version}-%{release}
 Requires:	python-requests
-%if 0%{defined suse_version}
-Requires:  python-argparse
-%endif
 %if 0%{?rhel} || 0%{?fedora}
 Requires:	redhat-lsb-core
 %endif
 %if 0%{defined suse_version}
 Requires:	lsb-release
+%endif
+# python-argparse is only needed in distros with Python 2.6 or lower
+%if (0%{?rhel} && 0%{?rhel} <= 6) || (0%{?suse_version} && 0%{?suse_version} <= 1110)
+Requires:	python-argparse
+BuildRequires:	python-argparse
 %endif
 %description -n ceph-common
 Common utilities to mount and interact with a ceph storage cluster.


### PR DESCRIPTION
    ceph.spec.in: python-argparse only in Python 2.6
    
    argparse is a widely-used Python module for parsing command-line arguments.
    Ceph makes heavy use of Python scripts, both in the build environment and on
    cluster nodes and clients.
    
    Until Python 2.6, argparse was distributed separately from Python proper.
    As of 2.7 it is part of the Python standard library.
    
    Although the python package in a given distro may or may not Provide:
    python-argparse, this cannot be relied upon.
    
    Therefore, this commit puts appropriate conditionals around Requires:
    python-argparse and BuildRequires: python-argparse. It does so for Red
    Hat/CentOS and SUSE only, because the last Fedora version with Python 2.6
    was Fedora 13, which is EOL.
    
    http://tracker.ceph.com/issues/12034 Fixes: #12034
    
    Signed-off-by: Nathan Cutler <ncutler@suse.com>
