### PR TITLE
ceph_test_rados_api_tier: tolerate 0 or ENOENT for evict

### DIFF
--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -789,7 +789,8 @@ TEST_F(LibRadosTwoPoolsPP, Evict) {
       "fooberdoodle", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
     completion->wait_for_safe();
-    ASSERT_EQ(-ENOENT, completion->get_return_value());
+    ASSERT_TRUE((-ENOENT == completion->get_return_value()) ||
+		(0 == completion->get_return_value()));
     completion->release();
   }
   {
@@ -2991,7 +2992,8 @@ TEST_F(LibRadosTwoPoolsECPP, Evict) {
       "fooberdoodle", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
     completion->wait_for_safe();
-    ASSERT_EQ(-ENOENT, completion->get_return_value());
+    ASSERT_TRUE((-ENOENT == completion->get_return_value()) ||
+		(0 == completion->get_return_value()));
     completion->release();
   }
   {


### PR DESCRIPTION
Post-hammer we change this to 0; tolerate that.  This is basically a
more forgiving backport of 41b132fc9ab1eeb39f919c56a284bb1bbf4212e3.

Signed-off-by: Sage Weil <sage@redhat.com>