### PR TITLE
Fix typos in librados example code

### DIFF
--- a/examples/librados/hello_world.cc
+++ b/examples/librados/hello_world.cc
@@ -132,7 +132,7 @@ int main(int argc, const char **argv)
 
     /*
      * now that we have the data to write, let's send it to an object.
-     * We'll use the asynchronous interface for simplicity.
+     * We'll use the synchronous interface for simplicity.
      */
     ret = io_ctx.write_full(object_name, bl);
     if (ret < 0) {


### PR DESCRIPTION
In `examples/librados/hello_world.cc`:

```
    /*
     * now that we have the data to write, let's send it to an object.
     * We'll use the asynchronous interface for simplicity.
     */
    ret = io_ctx.write_full(object_name, bl);
```

The comment mentioned would use the `asynchronous` interface, but the function actually be invoked was the `synchronous` version.

The comment should be corrected as `synchronous`,as http://docs.ceph.com/docs/master/rados/api/librados-intro/#id3 does.