### PR TITLE
rados/tool: handle --snapid correctly

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1404,7 +1404,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       goto out;
     }
     io_ctx.snap_set_read(snapid);
-    cout << "selected snap " << snapid << " '" << snapname << "'" << std::endl;
+    cout << "selected snap " << snapid << " '" << name << "'" << std::endl;
   }
 
   assert(!nargs.empty());


### PR DESCRIPTION
Previously if correct snapid was specified, rados tool used to error out
as we are printing `snapname` which is a null variable, fixing to print
the right variable.

Signed-off-by: Abhishek Lekshmanan <abhishek.lekshmanan@ril.com>

*EDIT*- removed reference to issue