### PR TITLE
Fix various issues with fedora (f21+) builds

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -55,6 +55,7 @@ Requires(post):	binutils
 Requires: systemd
 %endif
 BuildRequires:	gcc-c++
+BuildRequires:	git
 BuildRequires:	boost-devel
 BuildRequires:	cryptsetup
 BuildRequires:	gdbm
@@ -104,7 +105,6 @@ BuildRequires:	sharutils
 BuildRequires:	net-tools
 BuildRequires:	libbz2-devel
 BuildRequires:	sharutils
-BuildRequires:	git
 %if 0%{?suse_version} > 1210
 Requires:	gptfdisk
 %if 0%{with tcmalloc}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -973,7 +973,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_mandir}/man8/rbd-replay-prep.8*
 %{_bindir}/rbd-replay
 %{_bindir}/rbd-replay-many
-%if (0%{?fedora} >= 20 || 0%{?rhel} == 6)
+%if (0%{?fedora} == 20 || 0%{?rhel} == 6)
 %{_bindir}/rbd-replay-prep
 %endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -629,9 +629,9 @@ if test "x$enable_cephfs_java" = "xyes"; then
         # the search path.
         AS_IF([test "x$with_debug" = "xyes"], [
         	dir='/usr/share/java'
-	        junit4_jar=`find $dir -name junit4.jar -o -name junit.jar | head -n 1`
+	        junit4_jar=`( find $dir -name junit4.jar;find $dir -name junit.jar ) | head -n 1`
 		AS_IF([test -r "$junit4_jar"], [
-		      EXTRA_CLASSPATH_JAR=$junit4_jar
+		      EXTRA_CLASSPATH_JAR="$junit4_jar"
 		      AC_SUBST(EXTRA_CLASSPATH_JAR)
 		      [have_junit4=1]], [
 		      AC_MSG_NOTICE([Cannot find junit4.jar (apt-get install junit4)])


### PR DESCRIPTION
This patchset contains various fixes for issues that uncover when you try to build ceph with upstream .spec file on f21+.

The patchset fixes missing build requires, rbd-replay-prep being in filelist on f21+, failed junit detection and man pages not being built by default anymore.