### PR TITLE
librbd: Add option to allow disabling issuing alloc hint

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -897,6 +897,7 @@ OPTION(rbd_blacklist_on_break_lock, OPT_BOOL, true) // whether to blacklist clie
 OPTION(rbd_blacklist_expire_seconds, OPT_INT, 0) // number of seconds to blacklist - set to 0 for OSD default
 OPTION(rbd_request_timed_out_seconds, OPT_INT, 30) // number of seconds before maint request times out
 OPTION(rbd_skip_partial_discard, OPT_BOOL, false) // when trying to discard a range inside an object, set to true to skip zeroing the range.
+OPTION(rbd_enable_alloc_hint, OPT_BOOL, true) // when writing a object, it will issue a hint to osd backend to indicate the expected size object need
 
 /*
  * The following options change the behavior for librbd's image creation methods that

--- a/src/librbd/AioRequest.cc
+++ b/src/librbd/AioRequest.cc
@@ -497,7 +497,8 @@ namespace librbd {
   }
 
   void AioWrite::add_write_ops(librados::ObjectWriteOperation *wr) {
-    wr->set_alloc_hint(m_ictx->get_object_size(), m_ictx->get_object_size());
+    if (m_ictx->enable_alloc_hint)
+      wr->set_alloc_hint(m_ictx->get_object_size(), m_ictx->get_object_size());
     wr->write(m_object_off, m_write_data);
     wr->set_op_flags2(m_op_flags);
   }

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -931,5 +931,6 @@ public:
     ASSIGN_OPTION(blacklist_on_break_lock);
     ASSIGN_OPTION(blacklist_expire_seconds);
     ASSIGN_OPTION(request_timed_out_seconds);
+    ASSIGN_OPTION(enable_alloc_hint);
   }
 }

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -157,6 +157,7 @@ namespace librbd {
     bool blacklist_on_break_lock;
     uint32_t blacklist_expire_seconds;
     uint32_t request_timed_out_seconds;
+    bool enable_alloc_hint;
     static bool _filter_metadata_confs(const string &prefix, std::map<string, bool> &configs,
                                        map<string, bufferlist> &pairs, map<string, bufferlist> *res);
 


### PR DESCRIPTION
For HDD osd backend, a alloc hint is good for local filesystem to ensure
extent continuous. But for SSD, the available capacity is useful and
precious, user may not expect lots of capacity is used by reserving.
Then ssd is good for random rw.

Signed-off-by: Haomai Wang <haomaiwang@gmail.com>