### PR TITLE
 doc: Adding a link to documentation on admin socket

### DIFF
--- a/doc/rados/troubleshooting/log-and-debug.rst
+++ b/doc/rados/troubleshooting/log-and-debug.rst
@@ -151,7 +151,7 @@ verbose. In general, the logs in-memory are not sent to the output log unless:
 
 - a fatal signal is raised or
 - an ``assert`` in source code is triggered or
-- upon requested. Please consult document on admin socket for more details.
+- upon requested. Please consult `document on admin socket <http://docs.ceph.com/docs/master/man/8/ceph/#daemon>`_ for more details.
 
 A debug logging setting can take a single value for the log level and the
 memory level, which sets them both as the same value. For example, if you


### PR DESCRIPTION
We add a link on  "document on admin socket" to redirect on to the page "http://docs.ceph.com/docs/master/man/8/ceph/#daemon".