### PR TITLE
mon: only send MMonMetadata to peer mons that support it

### DIFF
--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -63,6 +63,7 @@
 #define CEPH_FEATURE_OSD_MIN_SIZE_RECOVERY (1ULL<<49)
 // duplicated since it was introduced at the same time as MIN_SIZE_RECOVERY
 #define CEPH_FEATURE_OSD_PROXY_FEATURES (1ULL<<49)  /* overlap w/ above */
+#define CEPH_FEATURE_MON_METADATA (1ULL<<50)
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */
@@ -148,6 +149,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_MDS_QUOTA | \
          CEPH_FEATURE_CRUSH_V4 |	     \
          CEPH_FEATURE_OSD_MIN_SIZE_RECOVERY |		 \
+	 CEPH_FEATURE_MON_METADATA |			 \
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1881,10 +1881,12 @@ void Monitor::lose_election(epoch_t epoch, set<int> &q, int l, uint64_t features
 
   finish_election();
 
-  Metadata sys_info;
-  collect_sys_info(&sys_info, g_ceph_context);
-  messenger->send_message(new MMonMetadata(sys_info),
-			  monmap->get_inst(get_leader()));
+  if (quorum_features & CEPH_FEATURE_MON_METADATA) {
+    Metadata sys_info;
+    collect_sys_info(&sys_info, g_ceph_context);
+    messenger->send_message(new MMonMetadata(sys_info),
+			    monmap->get_inst(get_leader()));
+  }
 }
 
 void Monitor::finish_election()


### PR DESCRIPTION
Avoid sending this to mons that don't support the feature or else they
will reset the connection and we'll go into a busy reconnect loop.

Fixes: #12064
Signed-off-by: Sage Weil <sage@redhat.com>