### PR TITLE
rgw: fix reset_loc()

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1234,7 +1234,7 @@ public:
      * having object locator at all for most objects but the ones that started with underscore as
      * these were escaped.
      */
-    if (orig_obj[0] == '_') {
+    if (orig_obj[0] == '_' && ns.empty()) {
       loc = orig_obj;
     }
   }


### PR DESCRIPTION
Fixes: #11974

Only need to set locator for underscore if namespace is empty

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>