### PR TITLE
Fixes to rcceph script

### DIFF
--- a/systemd/ceph
+++ b/systemd/ceph
@@ -33,14 +33,14 @@ prefix="${cluster}-"
 
 case $action in start | stop | status | enable | disable | mask | unmask | restart | is-active | is-failed | show | kill | reset-failed  )
     n=0
-    if test -n ${lmon} ; then
+    if test -n "${lmon}" ; then
         for s in ${lmon#=${prefix}} ; do
             systemctl "${action}" ceph-mon@${s#$prefix}.service
             rc_check
             ((++n))
         done
     fi
-    if test -n ${losd} ; then
+    if test -n "${losd}" ; then
         for s in ${losd#=${prefix}} ; do
             systemctl "${action}" ceph-osd@${s#$prefix}.service
             rc_check

--- a/systemd/ceph
+++ b/systemd/ceph
@@ -16,51 +16,50 @@ SYSTEMD_NO_WRAP=1 . /etc/rc.status
 rc_reset
 
 action=$1 ; shift
+
+# default cluster name to "ceph"
 cluster="ceph"
-config=$1 ; shift
 
 # Shared variables by many actions
 dir_mon="/var/lib/ceph/mon/"
 dir_osd="/var/lib/ceph/osd/"
 if test -d ${dir_mon} ; then
-lmon=`ls ${dir_mon} | grep ${cluster}`
+    lmon=`ls ${dir_mon} | grep ${cluster}`
 fi
 if test -d ${dir_osd} ; then
-losd=`ls ${dir_osd} | grep ${cluster}`
+    losd=`ls ${dir_osd} | grep ${cluster}`
 fi
 prefix="${cluster}-"
 
-if test -n "$config" ; then
-	systemctl "${action}" "ceph-mon@${config}.service"
-else
-	case $action in
-    start | stop | status | enable | disable | restart | is-active | is-failed | show | kill | reset-failed  )
-        n=0
-        if test -n ${lmon} ; then
-            for s in ${lmon#=${prefix}} ; do
-                systemctl "${action}" ceph-mon@${s#$prefix}.service
-                rc_check
-                ((++n))
-            done
-        fi
-        if test -n ${lmon} ; then
-            for s in ${losd#=${prefix}} ; do
-                systemctl "${action}" ceph-osd@${s#$prefix}.service
-                rc_check
-                ((++n))
-            done
-        fi
-        if test $n -gt 0 ; then
-			rc_status
-		else
-			rc_status -u
-		fi
-    ;;
-	*)
-		echo "Invalid paramter : $action"
-        echo "Valid paramters  : start | stop | status | enable | disable | restart | is-active | is-failed | show | kill | reset-failed"
-	;;
-	esac
-fi
+case $action in start | stop | status | enable | disable | mask | unmask | restart | is-active | is-failed | show | kill | reset-failed  )
+    n=0
+    if test -n ${lmon} ; then
+        for s in ${lmon#=${prefix}} ; do
+            systemctl "${action}" ceph-mon@${s#$prefix}.service
+            rc_check
+            ((++n))
+        done
+    fi
+    if test -n ${losd} ; then
+        for s in ${losd#=${prefix}} ; do
+            systemctl "${action}" ceph-osd@${s#$prefix}.service
+            rc_check
+            ((++n))
+        done
+    fi
+    if test $n -gt 0 ; then
+        rc_status
+    else
+        rc_status -u
+    fi
+    systemctl "${action}" ceph.target
+    rc_check
+;;
+*)
+    echo "Invalid paramter : $action"
+    echo "Valid paramters  : start | stop | status | enable | disable | mask | unmask | restart | is-active | is-failed | show | kill | reset-failed"
+;;
+esac
+
 rc_exit
 


### PR DESCRIPTION
 - only start OSDs if mon daemons are also present
 - adds support for mask and unmask
 - removes support for cluster with non default cluster name,
   as this was very limited and inconsistent
 - Reapplied from a patch as could not cherry-pick
   66cb46c411d874be009c225450eea5021cf1219b from Mon Jan 12
   as this produced issues with src/gmock

Signed-off-by: Owen Synge <osynge@suse.com>