### PR TITLE
Wip dma latency

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -168,6 +168,7 @@ OPTION(ms_async_set_affinity, OPT_BOOL, true)
 // If ms_async_affinity_cores is empty, all threads will be bind to current running
 // core
 OPTION(ms_async_affinity_cores, OPT_STR, "")
+OPTION(ms_enable_dma_latency, OPT_BOOL, false)
 
 OPTION(inject_early_sigterm, OPT_BOOL, false)
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -168,6 +168,7 @@ OPTION(ms_async_set_affinity, OPT_BOOL, true)
 // If ms_async_affinity_cores is empty, all threads will be bind to current running
 // core
 OPTION(ms_async_affinity_cores, OPT_STR, "")
+// You can use "ceph_perf_local" to judge whether this option can help
 OPTION(ms_enable_dma_latency, OPT_BOOL, false)
 
 OPTION(inject_early_sigterm, OPT_BOOL, false)

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -22,11 +22,13 @@ Messenger *Messenger::create(CephContext *cct, const string &type,
     int fd = open("/dev/cpu_dma_latency", O_WRONLY);
     lderr(cct) << __func__ << " setting latency to " << latency << "us" << dendl;
     if (fd < 0) {
-      assert(0 == "open /dev/cpu_dma_latency %m - need root permissions");
+      lderr(cct) << "open /dev/cpu_dma_latency failed: " << cpp_strerror(r) << dendl;
+      assert(0 == "open /dev/cpu_dma_latency failed")
     }
     cfd.set(fd);
     if (write(fd, &latency, sizeof(latency)) != sizeof(latency)) {
-      assert(0 == "write to /dev/cpu_dma_latency %m - need root permissions");
+      lderr(cct) << "write to /dev/cpu_dma_latency failed: " << cpp_strerror(r) << dendl;
+      assert(0 == "write to /dev/cpu_dma_latency failed");
       close(fd);
       cfd.set(0);
     }

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "include/atomic.h"
 #include "include/types.h"
 #include "Messenger.h"
 
@@ -14,6 +15,23 @@ Messenger *Messenger::create(CephContext *cct, const string &type,
 			     entity_name_t name, string lname,
 			     uint64_t nonce)
 {
+  static atomic_t cfd(0);
+  // TODO: we should allow close fd when user can bear higher performance
+  if (!cfd.read() && cct->_conf->ms_enable_dma_latency) {
+    int32_t latency = 0;
+    int fd = open("/dev/cpu_dma_latency", O_WRONLY);
+    lderr(cct) << __func__ << " setting latency to " << latency << "us" << dendl;
+    if (fd < 0) {
+      assert(0 == "open /dev/cpu_dma_latency %m - need root permissions");
+    }
+    cfd.set(fd);
+    if (write(fd, &latency, sizeof(latency)) != sizeof(latency)) {
+      assert(0 == "write to /dev/cpu_dma_latency %m - need root permissions");
+      close(fd);
+      cfd.set(0);
+    }
+  }
+
   int r = -1;
   if (type == "random")
     r = rand() % 2; // random does not include xio


### PR DESCRIPTION
    Lots of sleep/wakeup threads are existed in ceph, but current cpu always try
    to use powersave or balance model to run application. If we use SSD, these
    sleep/wakeup latency is expensive and we should reduce them via close powersave
    for ceph process.
    
    A bit more fine-grained control of the power management features, is to use the
    Power Management Quality of Service interface (PM QOS). The file
    /dev/cpu_dma_latency is the interface which when opened registers a
    quality-of-service request for latency with the operating system. So we
    open /dev/cpu_dma_latency, write 0 means the lowest response time and then keep
    the file descriptor open while low-latency operation is desired.
    
    This option can greatly decrease op latency for ssd backend if your cpu idle
    driver is "intel_idle" or higher. If you already use "acpi_idle" or lower
    driver, this option can't help more.
    
    You can get your cpu idle driver by
    "cat /sys/devices/system/cpu/cpuidle/current_driver)"
    
    Also you can append boot option to grub.cfg like
    "intel_idle.max_cstate=0 processor.max_cstate=0 idle=poll"