### PR TITLE
Few more fixes for ceph user/group

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -547,22 +547,6 @@ mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/log/radosgw
 %fdupes %buildroot
 %endif
 
-%pre
-CEPH_GROUP_ID=""
-CEPH_USER_ID=""
-# disabled for now until we have the numbers
-%if 0%{?rhel} || 0%{?centos} || 0%{?fedora}
-CEPH_GROUP_ID="-g 167"
-CEPH_USER_ID="-u 167"
-%endif
-# %if 0%{?suse_version}
-# CEPH_GROUP_ID="-g "
-# CEPH_USER_ID="-u "
-# %endif
-
-%{_sbindir}/groupadd ceph $CEPH_GROUP_ID -o -r 2>/dev/null || :
-%{_sbindir}/useradd ceph $CEPH_USER_ID -o -r -g ceph -s /sbin/nologin -c "Ceph daemons" -d %{_localstatedir}/lib/ceph 2> /dev/null || :
-
 %clean
 rm -rf $RPM_BUILD_ROOT
 
@@ -718,6 +702,22 @@ fi
 /lib/udev/rules.d/50-rbd.rules
 %endif
 %attr(2750,ceph,ceph) %dir %{_localstatedir}/log/ceph/
+
+%pre -n ceph-common
+CEPH_GROUP_ID=""
+CEPH_USER_ID=""
+# disabled for now until we have the numbers
+%if 0%{?rhel} || 0%{?centos} || 0%{?fedora}
+CEPH_GROUP_ID="-g 167"
+CEPH_USER_ID="-u 167"
+%endif
+# %if 0%{?suse_version}
+# CEPH_GROUP_ID="-g "
+# CEPH_USER_ID="-u "
+# %endif
+
+%{_sbindir}/groupadd ceph $CEPH_GROUP_ID -o -r 2>/dev/null || :
+%{_sbindir}/useradd ceph $CEPH_USER_ID -o -r -g ceph -s /sbin/nologin -c "Ceph daemons" -d %{_localstatedir}/lib/ceph 2> /dev/null || :
 
 %postun -n ceph-common
 # Package removal cleanup

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -670,14 +670,14 @@ fi
 %{_mandir}/man8/ceph-clsinfo.8*
 %{_mandir}/man8/librados-config.8*
 #set up placeholder directories
-%dir %{_localstatedir}/lib/ceph/
-%dir %{_localstatedir}/lib/ceph/tmp
-%dir %{_localstatedir}/lib/ceph/mon
-%dir %{_localstatedir}/lib/ceph/osd
-%dir %{_localstatedir}/lib/ceph/mds
-%dir %{_localstatedir}/lib/ceph/bootstrap-osd
-%dir %{_localstatedir}/lib/ceph/bootstrap-mds
-%dir %{_localstatedir}/run/ceph/
+%attr(770,ceph,ceph) %dir %{_localstatedir}/lib/ceph/
+%attr(770,ceph,ceph) %dir %{_localstatedir}/lib/ceph/tmp
+%attr(770,ceph,ceph) %dir %{_localstatedir}/lib/ceph/mon
+%attr(770,ceph,ceph) %dir %{_localstatedir}/lib/ceph/osd
+%attr(770,ceph,ceph) %dir %{_localstatedir}/lib/ceph/mds
+%attr(770,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-osd
+%attr(770,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-mds
+%attr(770,ceph,ceph) %dir %{_localstatedir}/run/ceph/
 
 #################################################################################
 %files -n ceph-common
@@ -717,7 +717,6 @@ fi
 %else
 /lib/udev/rules.d/50-rbd.rules
 %endif
-%attr(770,ceph,ceph) %dir %{_localstatedir}/lib/ceph/
 %attr(2750,ceph,ceph) %dir %{_localstatedir}/log/ceph/
 
 %postun -n ceph-common

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -304,9 +304,9 @@ for name in $what; do
 	    [ -n "$max_open_files" ] && files="ulimit -n $max_open_files;"
 
 	    if [ -n "$SYSTEMD_RUN" ]; then
-		cmd="$SYSTEMD_RUN -r bash -c '$files $cmd --cluster $cluster -f'"
+		cmd="$SYSTEMD_RUN -r bash -c '$files $cmd --cluster $cluster --setuser ceph --setgroup ceph -f'"
 	    else
-		cmd="$files $wrap $cmd --cluster $cluster $runmode"
+		cmd="$files $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
 	    fi
 
 	    if [ $dofsmount -eq 1 ] && [ -n "$fs_devs" ]; then


### PR DESCRIPTION
1.) /var/lib/ceph is owned by ceph package, we should not change that (it causes file conflicts).
2.) User and group must be created in ceph-common pre-install script
3.) User and group must be set in init script