### PR TITLE
ceph.spec.in: Changes needed to support mock git builds on Fedora 22.

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -81,6 +81,7 @@ BuildRequires:	python-sphinx10
 %endif
 %if 0%{?fedora} || 0%{defined suse_version} || 0%{?rhel} >= 7 || 0%{?centos} >= 7
 BuildRequires:	python-sphinx
+BuildRequires:	git
 %endif
 
 BuildRequires:	python-virtualenv
@@ -104,7 +105,6 @@ BuildRequires:	sharutils
 BuildRequires:	net-tools
 BuildRequires:	libbz2-devel
 BuildRequires:	sharutils
-BuildRequires:	git
 %if 0%{?suse_version} > 1210
 Requires:	gptfdisk
 %if 0%{with tcmalloc}


### PR DESCRIPTION
You can't build git versions of ceph without... git!

The other packages where added out of safety.

Signed-off-by: Ira Cooper <ira@samba.org>