### PR TITLE
osd: make ghobject_t(hobject_t) ctor explicit

### DIFF
--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -273,7 +273,7 @@ public:
       shard_id(shard_id_t::NO_SHARD),
       max(false) {}
 
-  ghobject_t(const hobject_t &obj)
+  explicit ghobject_t(const hobject_t &obj)
     : hobj(obj),
       generation(NO_GEN),
       shard_id(shard_id_t::NO_SHARD),

--- a/src/os/FlatIndex.cc
+++ b/src/os/FlatIndex.cc
@@ -368,7 +368,7 @@ static int get_hobject_from_oinfo(const char *dir, const char *file,
   bufferlist bl;
   bl.push_back(bp);
   object_info_t oi(bl);
-  *o = oi.soid;
+  *o = ghobject_t(oi.soid);
   return 0;
 }
 

--- a/src/os/LFNIndex.cc
+++ b/src/os/LFNIndex.cc
@@ -390,7 +390,7 @@ static int get_hobject_from_oinfo(const char *dir, const char *file,
   bufferlist bl;
   bl.push_back(bp);
   object_info_t oi(bl);
-  *o = oi.soid;
+  *o = ghobject_t(oi.soid);
   return 0;
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4095,7 +4095,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
 
       val.append(valstr);
       newattrs[key] = val;
-      t.omap_setkeys(coll_t(pgid), obj, newattrs);
+      t.omap_setkeys(coll_t(pgid), ghobject_t(obj), newattrs);
       r = store->apply_transaction(t);
       if (r < 0)
         ss << "error=" << r;
@@ -4107,7 +4107,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       cmd_getval(service->cct, cmdmap, "key", key);
 
       keys.insert(key);
-      t.omap_rmkeys(coll_t(pgid), obj, keys);
+      t.omap_rmkeys(coll_t(pgid), ghobject_t(obj), keys);
       r = store->apply_transaction(t);
       if (r < 0)
         ss << "error=" << r;
@@ -4119,7 +4119,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
 
       cmd_getval(service->cct, cmdmap, "header", headerstr);
       newheader.append(headerstr);
-      t.omap_setheader(coll_t(pgid), obj, newheader);
+      t.omap_setheader(coll_t(pgid), ghobject_t(obj), newheader);
       r = store->apply_transaction(t);
       if (r < 0)
         ss << "error=" << r;
@@ -4129,7 +4129,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       //Debug: Output entire omap
       bufferlist hdrbl;
       map<string, bufferlist> keyvals;
-      r = store->omap_get(coll_t(pgid), obj, &hdrbl, &keyvals);
+      r = store->omap_get(coll_t(pgid), ghobject_t(obj), &hdrbl, &keyvals);
       if (r >= 0) {
           ss << "header=" << string(hdrbl.c_str(), hdrbl.length());
           for (map<string, bufferlist>::iterator it = keyvals.begin();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5087,9 +5087,9 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       object_t oid(nm);
       hobject_t soid(sobject_t(oid, 0));
       ObjectStore::Transaction *t = new ObjectStore::Transaction;
-      t->write(coll_t::meta(), soid, 0, bsize, bl);
+      t->write(coll_t::meta(), ghobject_t(soid), 0, bsize, bl);
       store->queue_transaction_and_cleanup(NULL, t);
-      cleanupt->remove(coll_t::meta(), soid);
+      cleanupt->remove(coll_t::meta(), ghobject_t(soid));
     }
     store->sync_and_flush();
     utime_t end = ceph_clock_now(cct);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6113,7 +6113,7 @@ void OSD::handle_osd_map(MOSDMap *m)
       if (o->test_flag(CEPH_OSDMAP_FULL))
 	last_marked_full = e;
 
-      hobject_t fulloid = get_osdmap_pobject_name(e);
+      ghobject_t fulloid = get_osdmap_pobject_name(e);
       t.write(coll_t::meta(), fulloid, 0, bl.length(), bl);
       pin_map_bl(e, bl);
       pinned_maps.push_back(add_map(o));
@@ -6124,7 +6124,7 @@ void OSD::handle_osd_map(MOSDMap *m)
     if (p != m->incremental_maps.end()) {
       dout(10) << "handle_osd_map  got inc map for epoch " << e << dendl;
       bufferlist& bl = p->second;
-      hobject_t oid = get_inc_osdmap_pobject_name(e);
+      ghobject_t oid = get_inc_osdmap_pobject_name(e);
       t.write(coll_t::meta(), oid, 0, bl.length(), bl);
       pin_map_inc_bl(e, bl);
 
@@ -6170,7 +6170,7 @@ void OSD::handle_osd_map(MOSDMap *m)
       }
 
 
-      hobject_t fulloid = get_osdmap_pobject_name(e);
+      ghobject_t fulloid = get_osdmap_pobject_name(e);
       t.write(coll_t::meta(), fulloid, 0, fbl.length(), fbl);
       pin_map_bl(e, fbl);
       pinned_maps.push_back(add_map(o));

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4142,7 +4142,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
     } else if (command == "truncobj") {
       int64_t trunclen;
       cmd_getval(service->cct, cmdmap, "len", trunclen);
-      t.truncate(coll_t(pgid), obj, trunclen);
+      t.truncate(coll_t(pgid), ghobject_t(obj), trunclen);
       r = store->apply_transaction(t);
       if (r < 0)
 	ss << "error=" << r;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1082,15 +1082,15 @@ public:
   ClassHandler  *class_handler;
   int get_nodeid() { return whoami; }
   
-  static hobject_t get_osdmap_pobject_name(epoch_t epoch) { 
+  static ghobject_t get_osdmap_pobject_name(epoch_t epoch) {
     char foo[20];
     snprintf(foo, sizeof(foo), "osdmap.%d", epoch);
-    return hobject_t(sobject_t(object_t(foo), 0)); 
+    return ghobject_t(hobject_t(sobject_t(object_t(foo), 0)));
   }
-  static hobject_t get_inc_osdmap_pobject_name(epoch_t epoch) { 
+  static ghobject_t get_inc_osdmap_pobject_name(epoch_t epoch) {
     char foo[20];
     snprintf(foo, sizeof(foo), "inc_osdmap.%d", epoch);
-    return hobject_t(sobject_t(object_t(foo), 0)); 
+    return ghobject_t(hobject_t(sobject_t(object_t(foo), 0)));
   }
 
   static ghobject_t make_snapmapper_oid() {
@@ -1100,24 +1100,24 @@ public:
 	0)));
   }
 
-  static hobject_t make_pg_log_oid(spg_t pg) {
+  static ghobject_t make_pg_log_oid(spg_t pg) {
     stringstream ss;
     ss << "pglog_" << pg;
     string s;
     getline(ss, s);
-    return hobject_t(sobject_t(object_t(s.c_str()), 0));
+    return ghobject_t(hobject_t(sobject_t(object_t(s.c_str()), 0)));
   }
   
-  static hobject_t make_pg_biginfo_oid(spg_t pg) {
+  static ghobject_t make_pg_biginfo_oid(spg_t pg) {
     stringstream ss;
     ss << "pginfo_" << pg;
     string s;
     getline(ss, s);
-    return hobject_t(sobject_t(object_t(s.c_str()), 0));
+    return ghobject_t(hobject_t(sobject_t(object_t(s.c_str()), 0)));
   }
-  static hobject_t make_infos_oid() {
+  static ghobject_t make_infos_oid() {
     hobject_t oid(sobject_t("infos", CEPH_NOSNAP));
-    return oid;
+    return ghobject_t(oid);
   }
   static void recursive_remove_collection(ObjectStore *store,
 					  spg_t pgid,

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1093,11 +1093,11 @@ public:
     return hobject_t(sobject_t(object_t(foo), 0)); 
   }
 
-  static hobject_t make_snapmapper_oid() {
-    return hobject_t(
+  static ghobject_t make_snapmapper_oid() {
+    return ghobject_t(hobject_t(
       sobject_t(
 	object_t("snapmapper"),
-	0));
+	0)));
   }
 
   static hobject_t make_pg_log_oid(spg_t pg) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2602,8 +2602,8 @@ void PG::upgrade(ObjectStore *store)
 
   // 7 -> 8
   pg_log.mark_log_for_rewrite();
-  hobject_t log_oid(OSD::make_pg_log_oid(pg_id));
-  hobject_t biginfo_oid(OSD::make_pg_biginfo_oid(pg_id));
+  ghobject_t log_oid(OSD::make_pg_log_oid(pg_id));
+  ghobject_t biginfo_oid(OSD::make_pg_biginfo_oid(pg_id));
   t.remove(coll_t::meta(), log_oid);
   t.remove(coll_t::meta(), biginfo_oid);
   t.collection_rmattr(coll, "info");
@@ -2729,7 +2729,7 @@ epoch_t PG::peek_map_epoch(ObjectStore *store,
 			   bufferlist *bl)
 {
   coll_t coll(pgid);
-  hobject_t legacy_infos_oid(OSD::make_infos_oid());
+  ghobject_t legacy_infos_oid(OSD::make_infos_oid());
   ghobject_t pgmeta_oid(pgid.make_pgmeta_oid());
   epoch_t cur_epoch = 0;
 
@@ -2952,7 +2952,7 @@ int PG::read_info(
   }
 
   // legacy (ver < 8)
-  hobject_t infos_oid(OSD::make_infos_oid());
+  ghobject_t infos_oid(OSD::make_infos_oid());
   bufferlist::iterator p = bl.begin();
   ::decode(struct_v, p);
   assert(struct_v == 7);
@@ -2964,7 +2964,7 @@ int PG::read_info(
   keys.insert(k);
   keys.insert(bk);
   values.clear();
-  store->omap_get_values(coll_t::meta(), infos_oid, keys, &values);
+  store->omap_get_values(coll_t::meta(), ghobject_t(infos_oid), keys, &values);
   assert(values.size() == 2);
 
   p = values[k].begin();
@@ -2988,7 +2988,7 @@ void PG::read_state(ObjectStore *store, bufferlist &bl)
   pg_log.read_log(store,
 		  coll,
 		  info_struct_v < 8 ? coll_t::meta() : coll,
-		  info_struct_v < 8 ? OSD::make_pg_log_oid(pg_id) : pgmeta_oid,
+		  ghobject_t(info_struct_v < 8 ? OSD::make_pg_log_oid(pg_id) : pgmeta_oid),
 		  info, oss);
   if (oss.str().length())
     osd->clog->error() << oss;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3511,7 +3511,9 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
       {
 	// read into a buffer
 	bufferlist bl;
-	int r = osd->store->fiemap(coll, soid, op.extent.offset, op.extent.length, bl);
+	int r = osd->store->fiemap(coll, ghobject_t(soid, ghobject_t::NO_GEN,
+						    info.pgid.shard),
+				   op.extent.offset, op.extent.length, bl);
 	osd_op.outdata.claim(bl);
 	if (r < 0)
 	  result = r;
@@ -3539,7 +3541,9 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	// read into a buffer
 	bufferlist bl;
         int total_read = 0;
-	int r = osd->store->fiemap(coll, soid, op.extent.offset, op.extent.length, bl);
+	int r = osd->store->fiemap(coll, ghobject_t(soid, ghobject_t::NO_GEN,
+						    info.pgid.shard),
+				   op.extent.offset, op.extent.length, bl);
 	if (r < 0)  {
 	  result = r;
           break;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -213,7 +213,8 @@ void ReplicatedPG::on_local_recover(
       recovery_info.oi.version = latest->version;
       bufferlist bl;
       ::encode(recovery_info.oi, bl);
-      t->setattr(coll, recovery_info.soid, OI_ATTR, bl);
+      assert(!pool.info.require_rollback());
+      t->setattr(coll, ghobject_t(recovery_info.soid), OI_ATTR, bl);
       if (obc)
 	obc->attr_cache[OI_ATTR] = bl;
     }
@@ -8532,7 +8533,8 @@ ObjectContextRef ReplicatedPG::mark_object_lost(ObjectStore::Transaction *t,
 
   bufferlist b2;
   obc->obs.oi.encode(b2);
-  t->setattr(coll, oid, OI_ATTR, b2);
+  assert(!pool.info.require_rollback());
+  t->setattr(coll, ghobject_t(oid), OI_ATTR, b2);
 
   return obc;
 }
@@ -9335,7 +9337,8 @@ int ReplicatedPG::recover_primary(int max, ThreadPool::TPHandle &handle)
 	      t->register_on_applied(new ObjectStore::C_DeleteTransaction(t));
 	      bufferlist b2;
 	      obc->obs.oi.encode(b2);
-	      t->setattr(coll, soid, OI_ATTR, b2);
+	      assert(!pool.info.require_rollback());
+	      t->setattr(coll, ghobject_t(soid), OI_ATTR, b2);
 
 	      recover_got(soid, latest->version);
 	      missing_loc.add_location(soid, pg_whoami);

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1149,7 +1149,7 @@ void ReplicatedPG::do_pg_op(OpRequestRef op)
 	    wait_for_unreadable_object(oid, op);
 	    return;
 	  }
-	  result = osd->store->read(coll, oid, 0, 0, osd_op.outdata);
+	  result = osd->store->read(coll, ghobject_t(oid), 0, 0, osd_op.outdata);
 	}
       }
       break;
@@ -10770,7 +10770,7 @@ void ReplicatedPG::agent_load_hit_sets()
 	bufferlist bl;
 	{
 	  obc->ondisk_read_lock();
-	  int r = osd->store->read(coll, oid, 0, 0, bl);
+	  int r = osd->store->read(coll, ghobject_t(oid), 0, 0, bl);
 	  assert(r >= 0);
 	  obc->ondisk_read_unlock();
 	}

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -30,17 +30,17 @@
 class OSDriver : public MapCacher::StoreDriver<std::string, bufferlist> {
   ObjectStore *os;
   coll_t cid;
-  hobject_t hoid;
+  ghobject_t hoid;
 
 public:
   class OSTransaction : public MapCacher::Transaction<std::string, bufferlist> {
     friend class OSDriver;
     coll_t cid;
-    hobject_t hoid;
+    ghobject_t hoid;
     ObjectStore::Transaction *t;
     OSTransaction(
       coll_t cid,
-      const hobject_t &hoid,
+      const ghobject_t &hoid,
       ObjectStore::Transaction *t)
       : cid(cid), hoid(hoid), t(t) {}
   public:
@@ -63,7 +63,7 @@ public:
     return OSTransaction(cid, hoid, t);
   }
 
-  OSDriver(ObjectStore *os, coll_t cid, const hobject_t &hoid) :
+  OSDriver(ObjectStore *os, coll_t cid, const ghobject_t &hoid) :
     os(os), cid(cid), hoid(hoid) {}
   int get_keys(
     const std::set<std::string> &keys,

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -248,7 +248,7 @@ enum {
 
 // pg stuff
 
-#define OSD_SUPERBLOCK_POBJECT hobject_t(sobject_t(object_t("osd_superblock"), 0))
+#define OSD_SUPERBLOCK_POBJECT ghobject_t(hobject_t(sobject_t(object_t("osd_superblock"), 0)))
 
 // placement seed (a hash value)
 typedef uint32_t ps_t;

--- a/src/test/bench/testfilestore_backend.cc
+++ b/src/test/bench/testfilestore_backend.cc
@@ -45,14 +45,14 @@ void TestFileStoreBackend::write(
 
   hobject_t h(sobject_t(oid.substr(sep+1), 0));
   h.pool = 0;
-  t->write(c, h, offset, bl.length(), bl);
+  t->write(c, ghobject_t(h), offset, bl.length(), bl);
 
   if (write_infos) {
     bufferlist bl2;
     for (uint64_t j = 0; j < 128; ++j) bl2.append(0);
     coll_t meta;
     hobject_t info(sobject_t(string("info_")+coll_str, 0));
-    t->write(meta, info, 0, bl2.length(), bl2);
+    t->write(meta, ghobject_t(info), 0, bl2.length(), bl2);
   }
 
   os->queue_transaction(
@@ -77,6 +77,6 @@ void TestFileStoreBackend::read(
   assert(valid_coll);
   hobject_t h(sobject_t(oid.substr(sep+1), 0));
   h.pool = 0;
-  os->read(c, h, offset, length, *bl);
+  os->read(c, ghobject_t(h), offset, length, *bl);
   finisher.queue(on_complete);
 }

--- a/src/test/objectstore/DeterministicOpSequence.cc
+++ b/src/test/objectstore/DeterministicOpSequence.cc
@@ -132,8 +132,8 @@ void DeterministicOpSequence::note_txn(ObjectStore::Transaction *t)
 {
   bufferlist bl;
   ::encode(txn, bl);
-  t->truncate(txn_coll, txn_object, 0);
-  t->write(txn_coll, txn_object, 0, bl.length(), bl);
+  t->truncate(txn_coll, ghobject_t(txn_object), 0);
+  t->write(txn_coll, ghobject_t(txn_object), 0, bl.length(), bl);
   dout(10) << __func__ << " " << txn << dendl;
 }
 
@@ -459,7 +459,7 @@ void DeterministicOpSequence::_do_touch(coll_t coll, hobject_t& obj)
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.touch(coll, obj);
+  t.touch(coll, ghobject_t(obj));
   m_store->apply_transaction(t);
 }
 
@@ -467,7 +467,7 @@ void DeterministicOpSequence::_do_remove(coll_t coll, hobject_t& obj)
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.remove(coll, obj);
+  t.remove(coll, ghobject_t(obj));
   m_store->apply_transaction(t);
 }
 
@@ -477,7 +477,7 @@ void DeterministicOpSequence::_do_set_attrs(coll_t coll,
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.omap_setkeys(coll, obj, attrs);
+  t.omap_setkeys(coll, ghobject_t(obj), attrs);
   m_store->apply_transaction(t);
 }
 
@@ -486,7 +486,7 @@ void DeterministicOpSequence::_do_write(coll_t coll, hobject_t& obj,
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.write(coll, obj, off, len, data);
+  t.write(coll, ghobject_t(obj), off, len, data);
   m_store->apply_transaction(t);
 }
 
@@ -495,7 +495,7 @@ void DeterministicOpSequence::_do_clone(coll_t coll, hobject_t& orig_obj,
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.clone(coll, orig_obj, new_obj);
+  t.clone(coll, ghobject_t(orig_obj), ghobject_t(new_obj));
   m_store->apply_transaction(t);
 }
 
@@ -505,7 +505,8 @@ void DeterministicOpSequence::_do_clone_range(coll_t coll,
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.clone_range(coll, orig_obj, new_obj, srcoff, srclen, dstoff);
+  t.clone_range(coll, ghobject_t(orig_obj), ghobject_t(new_obj),
+		srcoff, srclen, dstoff);
   m_store->apply_transaction(t);
 }
 
@@ -519,8 +520,9 @@ void DeterministicOpSequence::_do_write_and_clone_range(coll_t coll,
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.write(coll, orig_obj, srcoff, bl.length(), bl);
-  t.clone_range(coll, orig_obj, new_obj, srcoff, srclen, dstoff);
+  t.write(coll, ghobject_t(orig_obj), srcoff, bl.length(), bl);
+  t.clone_range(coll, ghobject_t(orig_obj), ghobject_t(new_obj),
+		srcoff, srclen, dstoff);
   m_store->apply_transaction(t);
 }
 
@@ -529,8 +531,8 @@ void DeterministicOpSequence::_do_coll_move(coll_t orig_coll, coll_t new_coll,
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.remove(new_coll, obj);
-  t.collection_move_rename(orig_coll, obj, new_coll, obj);
+  t.remove(new_coll, ghobject_t(obj));
+  t.collection_move_rename(orig_coll, ghobject_t(obj), new_coll, ghobject_t(obj));
   m_store->apply_transaction(t);
 }
 

--- a/src/test/objectstore/FileStoreTracker.cc
+++ b/src/test/objectstore/FileStoreTracker.cc
@@ -104,7 +104,7 @@ void FileStoreTracker::write(const pair<coll_t, string> &obj,
     to_write.append(*iter);
   }
   out->t->write(coll_t(obj.first),
-		hobject_t(sobject_t(obj.second, CEPH_NOSNAP)),
+		ghobject_t(hobject_t(sobject_t(obj.second, CEPH_NOSNAP))),
 		offset,
 		len,
 		to_write);
@@ -120,7 +120,7 @@ void FileStoreTracker::remove(const pair<coll_t, string> &obj,
   if (!old_contents.exists())
     return;
   out->t->remove(coll_t(obj.first),
-		 hobject_t(sobject_t(obj.second, CEPH_NOSNAP)));
+		 ghobject_t(hobject_t(sobject_t(obj.second, CEPH_NOSNAP))));
   ObjectContents contents;
   out->in_flight->push_back(make_pair(obj, set_content(obj, contents)));
 }
@@ -148,8 +148,8 @@ void FileStoreTracker::clone_range(const pair<coll_t, string> &from,
   interval_to_clone.insert(offset, len);
   to_contents.clone_range(from_contents, interval_to_clone);
   out->t->clone_range(coll_t(from.first),
-		      hobject_t(sobject_t(from.second, CEPH_NOSNAP)),
-		      hobject_t(sobject_t(to.second, CEPH_NOSNAP)),
+		      ghobject_t(hobject_t(sobject_t(from.second, CEPH_NOSNAP))),
+		      ghobject_t(hobject_t(sobject_t(to.second, CEPH_NOSNAP))),
 		      offset,
 		      len,
 		      offset);
@@ -173,10 +173,10 @@ void FileStoreTracker::clone(const pair<coll_t, string> &from,
 
   if (to_contents.exists())
     out->t->remove(coll_t(to.first),
-		   hobject_t(sobject_t(to.second, CEPH_NOSNAP)));
+		   ghobject_t(hobject_t(sobject_t(to.second, CEPH_NOSNAP))));
   out->t->clone(coll_t(from.first),
-		hobject_t(sobject_t(from.second, CEPH_NOSNAP)),
-		hobject_t(sobject_t(to.second, CEPH_NOSNAP)));
+		ghobject_t(hobject_t(sobject_t(from.second, CEPH_NOSNAP))),
+		ghobject_t(hobject_t(sobject_t(to.second, CEPH_NOSNAP))));
   out->in_flight->push_back(make_pair(to, set_content(to, from_contents)));
 }
 
@@ -281,7 +281,7 @@ void FileStoreTracker::verify(const coll_t &coll, const string &obj,
   std::cerr << "valid_reads is " << valid_reads << std::endl;
   bufferlist contents;
   int r = store->read(coll_t(coll),
-		      hobject_t(sobject_t(obj, CEPH_NOSNAP)),
+		      ghobject_t(hobject_t(sobject_t(obj, CEPH_NOSNAP))),
 		      0,
 		      2*SIZE,
 		      contents);

--- a/src/test/objectstore/TestObjectStoreState.cc
+++ b/src/test/objectstore/TestObjectStoreState.cc
@@ -46,7 +46,7 @@ void TestObjectStoreState::init(int colls, int objs)
     int coll_id = i;
     coll_entry_t *entry = coll_create(coll_id);
     dout(5) << "init create collection " << entry->m_coll.to_str()
-        << " meta " << entry->m_meta_obj.oid.name << dendl;
+        << " meta " << entry->m_meta_obj << dendl;
 
     t = new ObjectStore::Transaction;
     t->create_collection(entry->m_coll);
@@ -61,7 +61,7 @@ void TestObjectStoreState::init(int colls, int objs)
 
     for (int i = 0; i < objs; i++) {
       hobject_t *obj = entry->touch_obj(i + baseid);
-      t->touch(entry->m_coll, *obj);
+      t->touch(entry->m_coll, ghobject_t(*obj));
       ceph_assert(i + baseid == m_num_objects);
       m_num_objects++;
     }

--- a/src/test/objectstore/TestObjectStoreState.h
+++ b/src/test/objectstore/TestObjectStoreState.h
@@ -28,7 +28,7 @@ public:
     int m_id;
     spg_t m_pgid;
     coll_t m_coll;
-    hobject_t m_meta_obj;
+    ghobject_t m_meta_obj;
     ObjectStore::Sequencer m_osr;
     map<int, hobject_t*> m_objects;
     int m_next_object_id;
@@ -37,7 +37,7 @@ public:
       : m_id(i),
 	m_pgid(pg_t(i, 1), shard_id_t::NO_SHARD),
 	m_coll(m_pgid),
-      m_meta_obj(sobject_t(object_t(meta_obj_buf), CEPH_NOSNAP)),
+	m_meta_obj(hobject_t(sobject_t(object_t(meta_obj_buf), CEPH_NOSNAP))),
       m_osr(coll_buf), m_next_object_id(0) {
     }
     ~coll_entry_t();

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1758,8 +1758,8 @@ TEST_P(StoreTest, TwoHash) {
 
 TEST_P(StoreTest, MoveRename) {
   coll_t cid(spg_t(pg_t(212,0),shard_id_t::NO_SHARD));
-  hobject_t temp_oid("tmp_oid", "", CEPH_NOSNAP, 0, 0, "");
-  hobject_t oid("dest_oid", "", CEPH_NOSNAP, 0, 0, "");
+  ghobject_t temp_oid(hobject_t("tmp_oid", "", CEPH_NOSNAP, 0, 0, ""));
+  ghobject_t oid(hobject_t("dest_oid", "", CEPH_NOSNAP, 0, 0, ""));
   int r;
   {
     ObjectStore::Transaction t;

--- a/src/test/objectstore/test_idempotent_sequence.cc
+++ b/src/test/objectstore/test_idempotent_sequence.cc
@@ -110,7 +110,7 @@ int run_get_last_op(std::string& filestore_path, std::string& journal_path)
   }
 
   coll_t txn_coll;
-  hobject_t txn_object(sobject_t("txn", CEPH_NOSNAP));
+  ghobject_t txn_object(hobject_t(sobject_t("txn", CEPH_NOSNAP)));
   bufferlist bl;
   store->read(txn_coll, txn_object, 0, 100, bl);
   int32_t txn = 0;

--- a/src/test/objectstore/workload_generator.cc
+++ b/src/test/objectstore/workload_generator.cc
@@ -268,7 +268,7 @@ void WorkloadGenerator::do_write_object(ObjectStore::Transaction *t,
   if (m_do_stats && (stat != NULL))
     stat->written_data += bl.length();
 
-  t->write(coll, obj, 0, bl.length(), bl);
+  t->write(coll, ghobject_t(obj), 0, bl.length(), bl);
 }
 
 void WorkloadGenerator::do_setattr_object(ObjectStore::Transaction *t,
@@ -292,7 +292,7 @@ void WorkloadGenerator::do_setattr_object(ObjectStore::Transaction *t,
   if (m_do_stats && (stat != NULL))
       stat->written_data += bl.length();
 
-  t->setattr(coll, obj, "objxattr", bl);
+  t->setattr(coll, ghobject_t(obj), "objxattr", bl);
 }
 
 void WorkloadGenerator::do_pgmeta_omap_set(ObjectStore::Transaction *t, spg_t pgid,
@@ -333,7 +333,7 @@ void WorkloadGenerator::do_append_log(ObjectStore::Transaction *t,
 
   bufferlist bl;
   get_filled_byte_array(bl, size);
-  hobject_t log_obj = entry->m_meta_obj;
+  ghobject_t log_obj = entry->m_meta_obj;
 
   dout(2) << __func__ << " coll " << entry->m_coll << " "
       << coll_t::meta() << " /" << log_obj << " (" << bl.length() << ")" << dendl;

--- a/src/test/streamtest.cc
+++ b/src/test/streamtest.cc
@@ -159,7 +159,7 @@ int main(int argc, const char **argv)
 
     set_start(pos, ceph_clock_now(g_ceph_context));
     ObjectStore::Transaction *t = new ObjectStore::Transaction;
-    t->write(coll_t(), hobject_t(poid), pos, bytes, bl);
+    t->write(coll_t(), ghobject_t(hobject_t(poid)), pos, bytes, bl);
     fs->queue_transaction(NULL, t, new C_Ack(pos), new C_Commit(pos));
     pos += bytes;
 

--- a/src/test/test_trans.cc
+++ b/src/test/test_trans.cc
@@ -65,7 +65,7 @@ int main(int argc, const char **argv)
     char f[30];
     snprintf(f, sizeof(f), "foo%d\n", i);
     sobject_t soid(f, CEPH_NOSNAP);
-    t.write(coll_t(), hobject_t(soid), 0, bl.length(), bl);
+    t.write(coll_t(), ghobject_t(hobject_t(soid)), 0, bl.length(), bl);
   }
   
   dout(0) << "starting thread" << dendl;

--- a/src/test/xattr_bench.cc
+++ b/src/test/xattr_bench.cc
@@ -100,7 +100,7 @@ uint64_t do_run(ObjectStore *store, int attrsize, int numattrs,
       stringstream obj_str;
       obj_str << i;
       t.touch(coll,
-	      hobject_t(sobject_t(obj_str.str(), CEPH_NOSNAP)));
+	      ghobject_t(hobject_t(sobject_t(obj_str.str(), CEPH_NOSNAP))));
       objects.insert(obj_str.str());
     }
     collections[coll] = make_pair(objects, new ObjectStore::Sequencer(coll.to_str()));
@@ -129,7 +129,7 @@ uint64_t do_run(ObjectStore *store, int attrsize, int numattrs,
 	stringstream ss;
 	ss << i << ", " << j << ", " << *obj;
 	t->setattr(iter->first,
-		   hobject_t(sobject_t(*obj, CEPH_NOSNAP)),
+		   ghobject_t(hobject_t(sobject_t(*obj, CEPH_NOSNAP))),
 		   ss.str().c_str(),
 		   bl);
       }

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -272,9 +272,9 @@ struct lookup_ghobject : public action_on_object_t {
   }
 };
 
-hobject_t infos_oid = OSD::make_infos_oid();
+ghobject_t infos_oid = OSD::make_infos_oid();
 ghobject_t log_oid;
-hobject_t biginfo_oid;
+ghobject_t biginfo_oid;
 
 int file_fd = fd_none;
 bool debug = false;
@@ -488,9 +488,9 @@ int mark_pg_for_removal(ObjectStore *fs, spg_t pgid, ObjectStore::Transaction *t
     bufferlist one;
     one.append('1');
     t->collection_setattr(coll, "remove", one);
-    cout << "remove " << coll_t::meta() << " " << log_oid.hobj.oid << std::endl;
+    cout << "remove " << coll_t::meta() << " " << log_oid << std::endl;
     t->remove(coll_t::meta(), log_oid);
-    cout << "remove " << coll_t::meta() << " " << biginfo_oid.oid << std::endl;
+    cout << "remove " << coll_t::meta() << " " << biginfo_oid << std::endl;
     t->remove(coll_t::meta(), biginfo_oid);
   } else {
     // new omap key

--- a/src/tools/ceph_osdomap_tool.cc
+++ b/src/tools/ceph_osdomap_tool.cc
@@ -137,7 +137,7 @@ int main(int argc, char **argv) {
 	 i != objects.end();
 	 ++i) {
       std::cout << "Object: " << *i << std::endl;
-      ObjectMap::ObjectMapIterator j = omap.get_iterator(i->hobj);
+      ObjectMap::ObjectMapIterator j = omap.get_iterator(ghobject_t(i->hobj));
       for (j->seek_to_first(); j->valid(); j->next()) {
 	std::cout << j->key() << std::endl;
 	j->value().hexdump(std::cout);


### PR DESCRIPTION
This guards against misusing the magic conversion.  Didn't uncover
any bugs doing this, fortunately!