### PR TITLE
Bucket naming restrictions

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1020,7 +1020,18 @@ OPTION(rgw_extended_http_attrs, OPT_STR, "") // list of extended attrs that can 
 OPTION(rgw_exit_timeout_secs, OPT_INT, 120) // how many seconds to wait for process to go down before exiting unconditionally
 OPTION(rgw_get_obj_window_size, OPT_INT, 16 << 20) // window size in bytes for single get obj request
 OPTION(rgw_get_obj_max_req_size, OPT_INT, 4 << 20) // max length of a single get obj rados op
-OPTION(rgw_relaxed_s3_bucket_names, OPT_BOOL, false) // enable relaxed bucket name rules for US region buckets
+
+/*
+ * RGW Bucket name restriction option. values can be {0,1,2). Default value is 1.
+ * Setting value as 0 : enable relaxed bucket name rules for US region buckets.
+ * Setting as 1 : name can't start with a non-alphanumeric. rest same as value =1.
+ *
+ * Setting as 2 : further restricts name so as to follow AWS S3 bucket naming conventions for non-standard regions.
+ */
+OPTION(rgw_s3_bucket_name_create_strictness, OPT_INT, 2)
+
+OPTION(rgw_s3_bucket_name_access_strictness, OPT_INT, 1) // option for bucket access. Values similar to above option for creation
+
 OPTION(rgw_defer_to_bucket_acls, OPT_STR, "") // if the user has bucket perms, use those before key perms (recurse and full_control)
 OPTION(rgw_list_buckets_max_chunk, OPT_INT, 1000) // max buckets to retrieve in a single op when listing user buckets
 OPTION(rgw_md_log_max_shards, OPT_INT, 64) // max shards for metadata log

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1315,6 +1315,7 @@ void RGWCreateBucket::execute()
   rgw_obj obj(store->zone.domain_root, s->bucket_name_str);
   obj_version objv, *pobjv = NULL;
 
+  // Check if pre_exec changed it
   if (ret < 0)
 	  return;
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1427,7 +1427,7 @@ void RGWCreateBucket::execute()
       ldout(s->cct, 0) << "WARNING: failed to unlink bucket: ret=" << ret << dendl;
     }
   } else if (ret == -EEXIST || (ret == 0 && existed)) {
-    ret = -ERR_BUCKET_EXISTS;
+		 ret = -ERR_BUCKET_EXISTS;
   }
 }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1300,7 +1300,7 @@ void RGWCreateBucket::pre_exec()
 {
   //validating bucket name as per creation strictness configuration, before creation
   if (s->cct->_conf->rgw_s3_bucket_name_create_strictness > s->cct->_conf->rgw_s3_bucket_name_access_strictness)
-	  ret = dialect_handler->validate_bucket_name(s->bucket_name_str, s->cct->_conf->rgw_s3_bucket_name_create_strictness);
+    ret = dialect_handler->validate_bucket_name(s->bucket_name_str, s->cct->_conf->rgw_s3_bucket_name_create_strictness);
 
   rgw_bucket_object_pre_exec(s);
 }
@@ -1317,7 +1317,7 @@ void RGWCreateBucket::execute()
 
   // Check if pre_exec changed it
   if (ret < 0)
-	  return;
+    return;
 
   ret = get_params();
   if (ret < 0)
@@ -1402,7 +1402,6 @@ void RGWCreateBucket::execute()
     cors_config.encode(corsbl);
     attrs[RGW_ATTR_CORS] = corsbl;
   }
-
   s->bucket.name = s->bucket_name_str;
   ret = store->create_bucket(s->user, s->bucket, region_name, placement_rule, attrs, info, pobjv,
                              &ep_objv, creation_time, pmaster_bucket, true);
@@ -1436,7 +1435,7 @@ void RGWCreateBucket::execute()
       ldout(s->cct, 0) << "WARNING: failed to unlink bucket: ret=" << ret << dendl;
     }
   } else if (ret == -EEXIST || (ret == 0 && existed)) {
-	  ret = -ERR_BUCKET_EXISTS;
+      ret = -ERR_BUCKET_EXISTS;
   }
 }
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1043,6 +1043,9 @@ public:
   virtual ~RGWHandler();
   virtual int init(RGWRados *store, struct req_state *_s, RGWClientIO *cio);
 
+  virtual int validate_bucket_name(const string& bucket, int name_strictness) { return 0; }
+  virtual int validate_object_name(const string& object) { return 0; }
+
   virtual RGWOp *get_op(RGWRados *store);
   virtual void put_op(RGWOp *op);
   virtual int read_permissions(RGWOp *op) = 0;

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1138,7 +1138,7 @@ int RGWHandler_ObjStore::allocate_formatter(struct req_state *s, int default_typ
 
 // This function enforces Amazon's spec for bucket names.
 // (The requirements, not the recommendations.)
-int RGWHandler_ObjStore::validate_bucket_name(const string& bucket)
+int RGWHandler_ObjStore::validate_bucket_name(const string& bucket, int strictness_option)
 {
   int len = bucket.size();
   if (len < 3) {

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1138,7 +1138,7 @@ int RGWHandler_ObjStore::allocate_formatter(struct req_state *s, int default_typ
 
 // This function enforces Amazon's spec for bucket names.
 // (The requirements, not the recommendations.)
-int RGWHandler_ObjStore::validate_bucket_name(const string& bucket, int strictness_option)
+int RGWHandler_ObjStore::validate_bucket_name(const string& bucket, int name_strictness)
 {
   int len = bucket.size();
   if (len < 3) {

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -296,7 +296,7 @@ protected:
   virtual RGWOp *op_copy() { return NULL; }
   virtual RGWOp *op_options() { return NULL; }
 
-  virtual int validate_bucket_name(const string& bucket, int strictness_option);
+  virtual int validate_bucket_name(const string& bucket, int name_strictness);
   virtual int validate_object_name(const string& object);
 
   static int allocate_formatter(struct req_state *s, int default_formatter, bool configurable);

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -296,7 +296,7 @@ protected:
   virtual RGWOp *op_copy() { return NULL; }
   virtual RGWOp *op_options() { return NULL; }
 
-  virtual int validate_bucket_name(const string& bucket);
+  virtual int validate_bucket_name(const string& bucket, int strictness_option);
   virtual int validate_object_name(const string& object);
 
   static int allocate_formatter(struct req_state *s, int default_formatter, bool configurable);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2261,6 +2261,12 @@ int RGWHandler_ObjStore_S3::init(RGWRados *store, struct req_state *s, RGWClient
       ldout(s->cct, 0) << "failed to parse copy location" << dendl;
       return -EINVAL;
     }
+    ret = validate_bucket_name(s->src_bucket_name, bucket_name_strictness_value);
+    if (ret)
+      return ret;
+    ret = validate_object_name(s->src_object.name);
+    if (ret)
+      return ret;
   }
 
   s->dialect = "s3";

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2137,60 +2137,60 @@ static bool looks_like_ip_address(const char *bucket)
 }
 
 static int check_bucket_name_characters_for_relaxed(const string& bucket) {
-  	for (const char *s = bucket.c_str(); *s; ++s) {
-  	  char c = *s;
-  	  if (isdigit(c) || isalpha(c))
-  		continue;
-  	  else if ((c == '-') || (c == '_') || (c == '.'))
-  		continue;
-  	  // Invalid character
-  	  return -ERR_INVALID_BUCKET_NAME;
-  	}
-  	return 0;
+  for (const char *s = bucket.c_str(); *s; ++s) {
+    char c = *s;
+    if (isdigit(c) || isalpha(c))
+      continue;
+    else if ((c == '-') || (c == '_') || (c == '.'))
+      continue;
+    // Invalid character
+    return -ERR_INVALID_BUCKET_NAME;
+  }
+  return 0;
 }
 
 static int check_bucket_name_characters_for_DNS(const string& bucket, int len) {
-	// bucket name length cannot exceed 63 characters.
-	if (len > 63)
-		return -ERR_INVALID_BUCKET_NAME;
-	// bucket name must start with either letter or number.
-	if (!(isalpha(bucket[0]) || isdigit(bucket[0])))
-		return -ERR_INVALID_BUCKET_NAME;
-	// bucket name must end with either letter or number.
-	if (!(isalpha(bucket[len-1]) || isdigit(bucket[len-1])))
-		return -ERR_INVALID_BUCKET_NAME;
-	// bucket name cannot contain a sequence of ".-" , ".." or "-."
-	bool last_char_dot = false; // last character occurred was a '.'
-	bool last_char_hyphen = false; // last character occurred was a '-'
-	for (const char *s = bucket.c_str(); *s; ++s) {
-		char c = *s;
-		// bucket name cannot contain uppercase letters.
-		if (isdigit(c) || (isalpha(c) && islower(c))) {
-			last_char_hyphen = false;
-			last_char_dot = false;
-			continue;
-		}
-		else if (c == '.') {
-			if ((last_char_hyphen || last_char_dot))
-				return -ERR_INVALID_BUCKET_NAME;
-			else {
-				last_char_dot = true;
-				continue;
-			}
-		}
-		else if (c == '-') {
-			if (last_char_dot)
-				return -ERR_INVALID_BUCKET_NAME;
-			else {
-				last_char_hyphen = true;
-				continue;
-			}
-		}
-	  // Invalid character (cannot contain anything except alphanumeric, '.' and '-' )
-		else
-			return -ERR_INVALID_BUCKET_NAME;
-	}
-	return 0;
+  // bucket name length cannot exceed 63 characters.
+  if (len > 63)
+    return -ERR_INVALID_BUCKET_NAME;
+  // bucket name must start with either letter or number.
+  if (!(isalpha(bucket[0]) || isdigit(bucket[0])))
+    return -ERR_INVALID_BUCKET_NAME;
+  // bucket name must end with either letter or number.
+  if (!(isalpha(bucket[len-1]) || isdigit(bucket[len-1])))
+    return -ERR_INVALID_BUCKET_NAME;
+  // bucket name cannot contain a sequence of ".-" , ".." or "-."
+  bool last_char_dot = false; // last character occurred was a '.'
+  bool last_char_hyphen = false; // last character occurred was a '-'
+  for (const char *s = bucket.c_str(); *s; ++s) {
+    char c = *s;
+    // bucket name cannot contain uppercase letters.
+    if (isdigit(c) || (isalpha(c) && islower(c))) {
+      last_char_hyphen = false;
+      last_char_dot = false;
+      continue;
+    }
+    else if (c == '.') {
+      if ((last_char_hyphen || last_char_dot))
+        return -ERR_INVALID_BUCKET_NAME;
+      else {
+        last_char_dot = true;
+        continue;
+      }
+    }
+    else if (c == '-') {
+      if (last_char_dot)
+        return -ERR_INVALID_BUCKET_NAME;
+      else {
+        last_char_hyphen = true;
+        continue;
+      }
+    }
+    // Invalid character (cannot contain anything except alphanumeric, '.' and '-' )
+    else
+      return -ERR_INVALID_BUCKET_NAME;
+  }
+  return 0;
 }
 
 int RGWHandler_ObjStore_S3::validate_bucket_name(const string& bucket, int name_strictness)
@@ -2204,31 +2204,31 @@ int RGWHandler_ObjStore_S3::validate_bucket_name(const string& bucket, int name_
     return 0;
 
   switch(name_strictness) {
-  	  case 0:
-  		  // bucket name cannot contain anything except alphanumeric, '.', '-' and '_'.
-  		  ret = check_bucket_name_characters_for_relaxed(bucket);
-  		  break;
+    case 0:
+      // bucket name cannot contain anything except alphanumeric, '.', '-' and '_'.
+      ret = check_bucket_name_characters_for_relaxed(bucket);
+      break;
 
-  	  case 1:
-  		  // bucket names must start with a number or letter
-  		  if (!(isalpha(bucket[0]) || isdigit(bucket[0])))
-  			  return -ERR_INVALID_BUCKET_NAME;
-  		  // bucket name cannot contain anything except alphanumeric, '.', '-' and '_'.
-  		  ret = check_bucket_name_characters_for_relaxed(bucket);
-  		  break;
+    case 1:
+      // bucket names must start with a number or letter
+      if (!(isalpha(bucket[0]) || isdigit(bucket[0])))
+        return -ERR_INVALID_BUCKET_NAME;
+      // bucket name cannot contain anything except alphanumeric, '.', '-' and '_'.
+      ret = check_bucket_name_characters_for_relaxed(bucket);
+      break;
 
-  	  case 2:
-  		  // check other conditions so as to confirm DNS compliance.
-  		  ret = check_bucket_name_characters_for_DNS(bucket, len);
-  		  break;
+    case 2:
+      // check other conditions so as to confirm DNS compliance.
+      ret = check_bucket_name_characters_for_DNS(bucket, len);
+      break;
 
-  	  default: // default is case 1.
-  		  if (!(isalpha(bucket[0]) || isdigit(bucket[0])))
-  			  return -ERR_INVALID_BUCKET_NAME;
-  		  ret = check_bucket_name_characters_for_relaxed(bucket);
+    default: // default is case 1.
+      if (!(isalpha(bucket[0]) || isdigit(bucket[0])))
+        return -ERR_INVALID_BUCKET_NAME;
+      ret = check_bucket_name_characters_for_relaxed(bucket);
   }
   if (ret < 0)
-	  return ret;
+    return ret;
 
   if (looks_like_ip_address(bucket.c_str()))
     return -ERR_INVALID_BUCKET_NAME;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2136,71 +2136,99 @@ static bool looks_like_ip_address(const char *bucket)
   return (num_periods == 3);
 }
 
-int RGWHandler_ObjStore_S3::validate_bucket_name(const string& bucket, bool relaxed_names)
+static int check_bucket_name_characters_for_relaxed(const string& bucket) {
+  	for (const char *s = bucket.c_str(); *s; ++s) {
+  	  char c = *s;
+  	  if (isdigit(c) || isalpha(c))
+  		continue;
+  	  else if ((c == '-') || (c == '_') || (c == '.'))
+  		continue;
+  	  // Invalid character
+  	  return -ERR_INVALID_BUCKET_NAME;
+  	}
+  	return 0;
+}
+
+static int check_bucket_name_characters_for_DNS(const string& bucket, int len) {
+	// bucket name length cannot exceed 63 characters.
+	if (len > 63)
+		return -ERR_INVALID_BUCKET_NAME;
+	// bucket name must start with either letter or number.
+	if (!(isalpha(bucket[0]) || isdigit(bucket[0])))
+		return -ERR_INVALID_BUCKET_NAME;
+	// bucket name must end with either letter or number.
+	if (!(isalpha(bucket[len-1]) || isdigit(bucket[len-1])))
+		return -ERR_INVALID_BUCKET_NAME;
+	// bucket name cannot contain a sequence of ".-" , ".." or "-."
+	bool last_char_dot = false; // last character occurred was a '.'
+	bool last_char_hyphen = false; // last character occurred was a '-'
+	for (const char *s = bucket.c_str(); *s; ++s) {
+		char c = *s;
+		// bucket name cannot contain uppercase letters.
+		if (isdigit(c) || (isalpha(c) && islower(c))) {
+			last_char_hyphen = false;
+			last_char_dot = false;
+			continue;
+		}
+		else if (c == '.') {
+			if ((last_char_hyphen || last_char_dot))
+				return -ERR_INVALID_BUCKET_NAME;
+			else {
+				last_char_dot = true;
+				continue;
+			}
+		}
+		else if (c == '-') {
+			if (last_char_dot)
+				return -ERR_INVALID_BUCKET_NAME;
+			else {
+				last_char_hyphen = true;
+				continue;
+			}
+		}
+	  // Invalid character (cannot contain anything except alphanumeric, '.' and '-' )
+		else
+			return -ERR_INVALID_BUCKET_NAME;
+	}
+	return 0;
+}
+
+int RGWHandler_ObjStore_S3::validate_bucket_name(const string& bucket, int name_strictness)
 {
-  int ret = RGWHandler_ObjStore::validate_bucket_name(bucket);
+  int ret = RGWHandler_ObjStore::validate_bucket_name(bucket, name_strictness);
   if (ret < 0)
     return ret;
 
   int len = bucket.size();
   if (len == 0)
     return 0;
-  if (!relaxed_names && len > 63)
-	return -ERR_INVALID_BUCKET_NAME;
 
-  // bucket names must start with a number, letter, or underscore
-  if (!(isalpha(bucket[0]) || isdigit(bucket[0]))) {
-    if (!relaxed_names)
-      return -ERR_INVALID_BUCKET_NAME;
-    else if (!(bucket[0] == '_' || bucket[0] == '.' || bucket[0] == '-'))
-      return -ERR_INVALID_BUCKET_NAME;
-  } 
+  switch(name_strictness) {
+  	  case 0:
+  		  // bucket name cannot contain anything except alphanumeric, '.', '-' and '_'.
+  		  ret = check_bucket_name_characters_for_relaxed(bucket);
+  		  break;
 
-  if (!relaxed_names) {
-  	if (!(isalpha(bucket[len-1]) || isdigit(bucket[len-1]))) {
-  	  return -ERR_INVALID_BUCKET_NAME;
-  	}
-    }
+  	  case 1:
+  		  // bucket names must start with a number or letter
+  		  if (!(isalpha(bucket[0]) || isdigit(bucket[0])))
+  			  return -ERR_INVALID_BUCKET_NAME;
+  		  // bucket name cannot contain anything except alphanumeric, '.', '-' and '_'.
+  		  ret = check_bucket_name_characters_for_relaxed(bucket);
+  		  break;
 
-    // in case of non US-Standard regions, a sequence of '.-' , '..' and '-.' is not allowed
-    if (!relaxed_names) {
-  	bool last_char_dot = false; // last character occurred was a '.'
-  	bool last_char_hyphen = false; // last character occurred was a '-'
-  	for (const char *s = bucket.c_str(); *s; ++s) {
-  	  char c = *s;
-  	  if (isdigit(c) || (isalpha(c) && islower(c))) {
-  		last_char_hyphen = false;
-  		last_char_dot = false;
-  		continue;
-  	  }
-  	  if (c == '.') {
-  		if (!(last_char_hyphen || last_char_dot)) {
-  		  last_char_dot = true;
-  		  continue;
-  		}
-  	  }
-  	  if (c == '-') {
-  		if (!last_char_dot) {
-  		  last_char_hyphen = true;
-  		  continue;
-  		}
-  	  }
-  	  // Invalid character
-  	  return -ERR_INVALID_BUCKET_NAME;
-  	}
-    } else {
-  	for (const char *s = bucket.c_str(); *s; ++s) {
-  	  char c = *s;
-  	  if (isdigit(c) || (c == '.'))
-  		continue;
-  	  if (isalpha(c))
-  		continue;
-  	  if ((c == '-') || (c == '_'))
-  		continue;
-  	  // Invalid character
-  	  return -ERR_INVALID_BUCKET_NAME;
-  	}
-    }
+  	  case 2:
+  		  // check other conditions so as to confirm DNS compliance.
+  		  ret = check_bucket_name_characters_for_DNS(bucket, len);
+  		  break;
+
+  	  default: // default is case 1.
+  		  if (!(isalpha(bucket[0]) || isdigit(bucket[0])))
+  			  return -ERR_INVALID_BUCKET_NAME;
+  		  ret = check_bucket_name_characters_for_relaxed(bucket);
+  }
+  if (ret < 0)
+	  return ret;
 
   if (looks_like_ip_address(bucket.c_str()))
     return -ERR_INVALID_BUCKET_NAME;
@@ -2212,8 +2240,8 @@ int RGWHandler_ObjStore_S3::init(RGWRados *store, struct req_state *s, RGWClient
 {
   dout(10) << "s->object=" << (!s->object.empty() ? s->object : rgw_obj_key("<NULL>")) << " s->bucket=" << (!s->bucket_name_str.empty() ? s->bucket_name_str : "<NULL>") << dendl;
 
-  bool relaxed_names = s->cct->_conf->rgw_relaxed_s3_bucket_names;
-  int ret = validate_bucket_name(s->bucket_name_str, relaxed_names);
+  int bucket_name_strictness_value = s->cct->_conf->rgw_s3_bucket_name_access_strictness;
+  int ret = validate_bucket_name(s->bucket_name_str, bucket_name_strictness_value);
   if (ret)
     return ret;
   ret = validate_object_name(s->object.name);

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -351,7 +351,7 @@ public:
   RGWHandler_Auth_S3() : RGWHandler_ObjStore() {}
   virtual ~RGWHandler_Auth_S3() {}
 
-  virtual int validate_bucket_name(const string& bucket) {
+  virtual int validate_bucket_name(const string& bucket, int name_strictness) {
     return 0;
   }
 

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -371,7 +371,7 @@ public:
   RGWHandler_ObjStore_S3() : RGWHandler_ObjStore() {}
   virtual ~RGWHandler_ObjStore_S3() {}
 
-  int validate_bucket_name(const string& bucket, bool relaxed_names);
+  int validate_bucket_name(const string& bucket, int name_strictness);
 
   virtual int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
   virtual int authorize() {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -905,7 +905,8 @@ int RGWHandler_ObjStore_SWIFT::authorize()
 
 int RGWHandler_ObjStore_SWIFT::validate_bucket_name(const string& bucket)
 {
-  int ret = RGWHandler_ObjStore::validate_bucket_name(bucket);
+  int strictness_option = s->cct->_conf->rgw_s3_bucket_name_access_strictness;
+  int ret = RGWHandler_ObjStore::validate_bucket_name(bucket, strictness_option);
   if (ret < 0)
     return ret;
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -903,10 +903,9 @@ int RGWHandler_ObjStore_SWIFT::authorize()
   return 0;
 }
 
-int RGWHandler_ObjStore_SWIFT::validate_bucket_name(const string& bucket)
+int RGWHandler_ObjStore_SWIFT::validate_bucket_name(const string& bucket, int name_strictness)
 {
-  int strictness_option = s->cct->_conf->rgw_s3_bucket_name_access_strictness;
-  int ret = RGWHandler_ObjStore::validate_bucket_name(bucket, strictness_option);
+  int ret = RGWHandler_ObjStore::validate_bucket_name(bucket, name_strictness);
   if (ret < 0)
     return ret;
 
@@ -1043,7 +1042,8 @@ int RGWHandler_ObjStore_SWIFT::init(RGWRados *store, struct req_state *s, RGWCli
 {
   dout(10) << "s->object=" << (!s->object.empty() ? s->object : rgw_obj_key("<NULL>")) << " s->bucket=" << (!s->bucket_name_str.empty() ? s->bucket_name_str : "<NULL>") << dendl;
 
-  int ret = validate_bucket_name(s->bucket_name_str.c_str());
+  int name_strictness = s->cct->_conf->rgw_s3_bucket_name_access_strictness;
+  int ret = validate_bucket_name(s->bucket_name_str.c_str(), name_strictness);
   if (ret)
     return ret;
   ret = validate_object_name(s->object.name);
@@ -1072,7 +1072,7 @@ int RGWHandler_ObjStore_SWIFT::init(RGWRados *store, struct req_state *s, RGWCli
 
     string dest_object = dest_obj_key.name;
     if (dest_bucket_name != s->bucket_name_str) {
-      ret = validate_bucket_name(dest_bucket_name.c_str());
+      ret = validate_bucket_name(dest_bucket_name.c_str(), name_strictness);
       if (ret < 0)
         return ret;
     }

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -162,7 +162,7 @@ public:
   RGWHandler_ObjStore_SWIFT() {}
   virtual ~RGWHandler_ObjStore_SWIFT() {}
 
-  int validate_bucket_name(const string& bucket);
+  int validate_bucket_name(const string& bucket, int name_strictness);
 
   int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
   int authorize();


### PR DESCRIPTION
Changes for Bucket Name restriction: Added two cofiguration option prameters in place of existing 'rgw_relaxed_s3_bucket_names'
a. rgw_s3_bucket_name_access_strictness (default value = 1) for accessing older buckets(access param)
b. rgw_s3_bucket_name_create_strictness (default value = 2) for creating new ones. (create param)
Both can have values(indepently) 0, 1 and 2 which signifies : 
0 - Follows same validation rules as already present with flag relaxed_name=true.
1 - Follows same validation rules as already present with flag relaxed_names=false.
2 - Follows new naming rules as per DNS compliance. (similar to what S3 follows)
Rules get stricter with increasing value. So a name passing rule 2 will always pass 0 and 1 and a name passing rule 1 will pass 0 but may not pass 2. 
Theses parameters are passed to validate_bucket_name(const string&, bool relaxed_names) in place of bool 'relaxed_names' as int 'name_strictness'. Based on these params checks are done on bucket name when trying to create a new bucket or access an existing one,

Example : 
User created a bucket "bucket1_" and have set option rgw_relaxed_s3_bucket_names = false.
Now after These changes, user need to set appropriate values to both option params. If user sets access param to 2, he/she will not be able to access "bucket1_" as this name will become invalid because it ends with '_' which doesnt confirm to DNS naming convention. So he/she must set rgw_s3_bucket_name_access_strictness = 1/2 to access "bucket1_" .And if he/she wants to create new buckets with names which confirms to DNS compliance, he/she should set rgw_s3_bucket_name_create_strictness =2.

Signed-off-by : Harshal Gupta harshal.gupta001@gmail.com