### PR TITLE
DNM: Wip systemd autotools install unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ py-compile
 release
 stamp-h1
 systemd/ceph-osd@.service
+systemd/Makefile
 vgcore.*
 
 # specific local dir files

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = gnu
 ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = autogen.sh ceph.spec.in ceph.spec install-deps.sh
 # the "." here makes sure check-local builds gtest and gmock before they are used
-SUBDIRS = . src man doc
+SUBDIRS = . src man doc systemd
 
 EXTRA_DIST += \
 	src/test/run-cli-tests \

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -656,6 +656,10 @@ fi
 %{_initrddir}/ceph
 %if 0%{?_with_systemd}
 %{_tmpfilesdir}/%{name}.conf
+%{_unitdir}/ceph-mds@.service
+%{_unitdir}/ceph-mon@.service
+%{_unitdir}/ceph-osd@.service
+%{_unitdir}/ceph.target
 %endif
 %{_sbindir}/ceph-disk
 %{_sbindir}/ceph-disk-activate

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -493,6 +493,12 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--prefix=/usr \
 		--localstatedir=/var \
 		--sysconfdir=/etc \
+%if 0%{?rhel} || 0%{?fedora}
+		--with-systemd-libexec-dir=/usr/lib/systemd/system \
+%endif
+%if 0%{?opensuse} || 0%{?suse_version}
+		--with-systemdsystemunitdir=%_unitdir \
+%endif
 		--docdir=%{_docdir}/ceph \
 		--with-man-pages \
 		--mandir="%_mandir" \

--- a/configure.ac
+++ b/configure.ac
@@ -1204,6 +1204,29 @@ AC_ARG_WITH(
     ]
 )
 
+AC_SUBST(systemd_unit_dir)
+AC_ARG_WITH(
+    systemd-unit-dir,
+    AS_HELP_STRING(
+	    [--with-systemdsystemunitdir=DIR],
+	    [systemd unit directory @<:@SYSTEMD_UNIT_DIR@:>@
+        Defaults to the correct value for debian /etc/systemd/system/]
+    ),
+    [
+	    systemd_unit_dir="$withval"
+    ],
+    [
+        # default to the systemd admin unit directory
+        which pkg-config
+        pkg_config_exists=$?
+        if test x"$pkg_config_exists" = x"0"; then
+            systemd_unit_dir=`pkg-config systemd --variable=systemdsystemunitdir`
+        else
+            systemd_unit_dir="/etc/systemd/system/"
+        fi
+    ]
+)
+
 # Checks for typedefs, structures, and compiler characteristics.
 #AC_HEADER_STDBOOL
 #AC_C_CONST
@@ -1264,6 +1287,7 @@ AC_CONFIG_FILES([Makefile
 	src/ocf/rbd
 	src/java/Makefile
 	src/tracing/Makefile
+	systemd/Makefile
 	man/Makefile
 	doc/Makefile
 	systemd/ceph-osd@.service

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -1,0 +1,11 @@
+unitfiles = \
+	ceph.target \
+	ceph-mds@.service \
+	ceph-mon@.service \
+	ceph-osd@.service
+
+unitdir = $(systemd_unit_dir)
+
+unit_DATA = $(unitfiles)
+
+EXTRA_DIST = $(unitfiles)


### PR DESCRIPTION
This installs the systemd unit files with autotools.
Adds for the fast cgi the ceph-radosgw@.service

Replaces pull request #4770 as that cant be resurrected as I did a force update in the branch while it was closed.
