### PR TITLE
osd: remove duplicate checks

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3834,7 +3834,7 @@ void PG::scrub(epoch_t queued, ThreadPool::TPHandle &handle)
     lock();
     dout(20) << __func__ << " slept for " << t << dendl;
   }
-  if (deleting || pg_has_reset_since(queued)) {
+  if (pg_has_reset_since(queued)) {
     return;
   }
   assert(scrub_queued);


### PR DESCRIPTION
Within pg_has_reset_since, it checkes if the PG is being deleted or not,
no need a duplicate check

Signed-off-by: Guang Yang <yguang@yahoo-inc.com>