### PR TITLE
tools: add a tool to restore crush map after a faulty one is injected

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -16,3 +16,5 @@ v9.0.3
 * 'ceph mon_metadata' should now be used as 'ceph mon metadata'. There is no
   need to deprecate this command (same major release since it was first
   introduced).
+
+* The `--dump-json` option of "osdmaptool" is replaced by `--dump json`.

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -969,6 +969,8 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %if (0%{?fedora} || 0%{?rhel} == 6)
 %{_bindir}/rbd-replay-prep
 %endif
+%dir %{_libdir}/ceph
+%{_libdir}/ceph/ceph-monstore-update-crush.sh
 
 #################################################################################
 %if 0%{with cephfs_java}

--- a/debian/ceph-test.install
+++ b/debian/ceph-test.install
@@ -29,3 +29,4 @@ usr/bin/ceph-kvstore-tool
 usr/share/java/libcephfs-test.jar
 usr/bin/rbd-replay*
 usr/share/man/man8/rbd-replay*.8
+usr/lib/ceph/ceph-monstore-update-crush.sh

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,7 @@ EXTRA_DIST += \
 	$(srcdir)/make_version \
 	$(srcdir)/.git_version \
 	$(srcdir)/ceph-rbdnamer \
+	$(srcdir)/tools/ceph-monstore-update-crush.sh \
 	$(srcdir)/upstart/ceph-all.conf \
 	$(srcdir)/upstart/ceph-mon.conf \
 	$(srcdir)/upstart/ceph-mon-all.conf \

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2223,15 +2223,6 @@ void OSDMap::dump_erasure_code_profiles(const map<string,map<string,string> > &p
   f->close_section();
 }
 
-void OSDMap::dump_json(ostream& out) const
-{
-  JSONFormatter jsf(true);
-  jsf.open_object_section("osdmap");
-  dump(&jsf);
-  jsf.close_section();
-  jsf.flush(out);
-}
-
 void OSDMap::dump(Formatter *f) const
 {
   f->dump_int("epoch", get_epoch());

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -125,7 +125,7 @@ public:
     int32_t new_flags;
 
     // full (rare)
-    bufferlist fullmap;  // in leiu of below.
+    bufferlist fullmap;  // in lieu of below.
     bufferlist crush;
 
     // incremental

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -848,7 +848,6 @@ public:
   static string get_flag_string(unsigned flags);
   static void dump_erasure_code_profiles(const map<string,map<string,string> > &profiles,
 					 Formatter *f);
-  void dump_json(ostream& out) const;
   void dump(Formatter *f) const;
   static void generate_test_instances(list<OSDMap*>& o);
   bool check_new_blacklist_entries() const { return new_blacklist_entries; }

--- a/src/tools/Makefile-server.am
+++ b/src/tools/Makefile-server.am
@@ -11,6 +11,10 @@ ceph_kvstore_tool_LDADD = $(LIBOS) $(CEPH_GLOBAL)
 ceph_kvstore_tool_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph-kvstore-tool
 
+if WITH_MON
+ceph_monstore_update_crushdir = $(libdir)/ceph
+ceph_monstore_update_crush_SCRIPTS = tools/ceph-monstore-update-crush.sh
+endif
 
 if WITH_OSD
 

--- a/src/tools/ceph-monstore-update-crush.sh
+++ b/src/tools/ceph-monstore-update-crush.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Red Hat <contact@redhat.com>
+#
+# Author: Kefu Chai <kchai@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+verbose=
+
+test -d ../src && export PATH=$PATH:.
+
+if type xmlstarlet > /dev/null 2>&1; then
+    XMLSTARLET=xmlstarlet
+elif type xml > /dev/null 2>&1; then
+    XMLSTARLET=xml
+else
+    echo "Missing xmlstarlet binary!"
+    exit 1
+fi
+
+function osdmap_get() {
+    local store_path=$1
+    local query=$2
+    local epoch=${3:+-v $3}
+    local osdmap=`mktemp`
+
+    ceph-monstore-tool $store_path get osdmap -- \
+                       $epoch -o $osdmap > /dev/null
+    echo $(osdmaptool --dump xml $osdmap 2> /dev/null | \
+           $XMLSTARLET sel -t -m "$query" -v .)
+
+    rm -f $osdmap
+}
+
+function test_crush() {
+    local store_path=$1
+    local epoch=$2
+    local max_osd=$3
+    local crush=$4
+    local osdmap=`mktemp`
+
+    ceph-monstore-tool $store_path get osdmap -- \
+                       -v $epoch -o $osdmap > /dev/null
+    osdmaptool --export-crush $crush $osdmap &> /dev/null
+
+    if crushtool --check $max_osd -i $crush > /dev/null; then
+        good=true
+    else
+        good=false
+    fi
+    rm -f $osdmap
+    $good || return 1
+}
+
+function get_crush()  {
+    local store_path=$1
+    local osdmap_epoch=$2
+    local osdmap_path=`mktemp`
+    local crush_path=`mktemp`
+
+    ceph-monstore-tool $store_path get osdmap -- \
+                       -v $osdmap_epoch -o $osdmap_path
+    osdmaptool --export-crush $crush $osdmap_path 2>&1 > /dev/null
+}
+
+function usage() {
+    [ $# -gt 0 ] && echo -e "\n$@"
+    cat <<EOF
+
+Usage: $0 [options ...] <mon-store>
+
+Search backward for a latest known-good epoch in monstore. Rewrite the osdmap
+epochs after it with the crush map in the found epoch if asked to do so. By
+default, print out the crush map in the good epoch.
+
+  [-h|--help]            display this message
+  [--out]                write the found crush map to given file (default: stdout)
+  [--rewrite]            rewrite the monitor storage with the found crush map
+  [--verbose]            be more chatty
+EOF
+    [ $# -gt 0 ] && exit 1
+    exit 0
+}
+
+function main() {
+    local temp
+    temp=$(getopt -o h --long verbose,help,mon-store:,out:,rewrite -n $0 -- "$@") || return 1
+
+    eval set -- "$temp"
+    local rewrite
+    while [ "$1" != "--" ]; do
+        case "$1" in
+            --verbose)
+                verbose=true
+                # set -xe
+                # PS4='${FUNCNAME[0]}: $LINENO: '
+                shift;;
+            -h|--help)
+                usage
+                return 0;;
+            --out)
+                output=$2
+                shift 2;;
+            --osdmap-epoch)
+                osdmap_epoch=$2
+                shift 2;;
+            --rewrite)
+                rewrite=true
+                shift;;
+            *)
+                usage "unexpected argument $1"
+                shift;;
+        esac
+    done
+    shift
+
+    local store_path="$1"
+    test $store_path || usage "I need the path to mon-store."
+
+    local last_osdmap_epoch=$(osdmap_get $store_path "/osdmap/epoch")
+    # get the max_osd # in last osdmap epoch, crushtool will use it to check
+    # the crush maps in previous osdmaps
+    max_osd=$(osdmap_get $store_path "/osdmap/max_osd" $last_osdmap_epoch)
+
+    local good_crush
+    local good_epoch
+    test $verbose && echo "the latest osdmap epoch is $last_osdmap_epoch"
+    for epoch in `seq $last_osdmap_epoch -1 1`; do
+        local crush_path=`mktemp`
+        test $verbose && echo "checking crush map #$epoch"
+        if test_crush $store_path $epoch $max_osd $crush_path; then
+            test $verbose && echo "crush map version #$epoch works with osdmap epoch #$osdmap_epoch"
+            good_epoch=$epoch
+            good_crush=$crush_path
+            break
+        fi
+        rm -f $crush_path
+    done
+
+    if test $good_epoch; then
+        echo "good crush map found at epoch $epoch/$last_osdmap_epoch"
+    else
+        echo "Unable to find a crush map for osdmap version #$osdmap_epoch." 2>&1
+        return 1
+    fi
+
+    if test $good_epoch -eq $last_osdmap_epoch; then
+        echo "and mon store has no faulty crush maps."
+    elif test $output; then
+        crushtool --decompile $good_crush --outfn $output
+    elif test $rewrite; then
+        ceph-monstore-tool $store_path rewrite-crush --  \
+                           --crush $good_crush      \
+                           --good-epoch $good_epoch
+    else
+        echo
+        crushtool --decompile $good_crush
+    fi
+    rm -f $good_crush
+}
+
+main "$@"

--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -164,6 +164,7 @@ int parse_cmd_args(
  *  dump-trace < --trace-file arg >
  *  replay-trace
  *  random-gen
+ *  rewrite-crush
  *
  * wanted syntax:
  *
@@ -202,6 +203,8 @@ void usage(const char *n, po::options_description &d)
   << "                                  (replay-trace -- --help for more info)\n"
   << "  random-gen [-- options]         add randomly generated ops to the store\n"
   << "                                  (random-gen -- --help for more info)\n"
+  << "  rewrite-crush [-- options]      add a rewrite commit to the store\n"
+  << "                                  (rewrite-crush -- --help for more info)\n"
   << std::endl;
   std::cerr << d << std::endl;
   std::cerr
@@ -211,6 +214,195 @@ void usage(const char *n, po::options_description &d)
     << "* Command-specific options need to be passed after a '--'\n"
     << "  e.g., 'get monmap -- --version 10 --out /tmp/foo'"
     << std::endl;
+}
+
+int update_osdmap(MonitorDBStore& store, version_t ver, bool copy,
+		  ceph::shared_ptr<CrushWrapper> crush,
+		  MonitorDBStore::Transaction* t) {
+  const string prefix("osdmap");
+
+  // full
+  bufferlist bl;
+  int r = 0;
+  r = store.get(prefix, store.combine_strings("full", ver), bl);
+  if (r) {
+    std::cerr << "Error getting full map: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+  OSDMap osdmap;
+  osdmap.decode(bl);
+  osdmap.crush = crush;
+  if (copy) {
+    osdmap.inc_epoch();
+  }
+  bl.clear();
+  // be consistent with OSDMonitor::update_from_paxos()
+  osdmap.encode(bl, CEPH_FEATURES_ALL|CEPH_FEATURE_RESERVED);
+  t->put(prefix, store.combine_strings("full", osdmap.get_epoch()), bl);
+
+  // incremental
+  OSDMap::Incremental inc;
+  if (copy) {
+    inc.epoch = osdmap.get_epoch();
+    inc.fsid = osdmap.get_fsid();
+  } else {
+    bl.clear();
+    r = store.get(prefix, ver, bl);
+    if (r) {
+      std::cerr << "Error getting inc map: " << cpp_strerror(r) << std::endl;
+      return r;
+    }
+    OSDMap::Incremental inc(bl);
+    if (inc.crush.length()) {
+      inc.crush.clear();
+      crush->encode(inc.crush);
+    }
+    if (inc.fullmap.length()) {
+      OSDMap fullmap;
+      fullmap.decode(inc.fullmap);
+      fullmap.crush = crush;
+      inc.fullmap.clear();
+      fullmap.encode(inc.fullmap);
+    }
+  }
+  assert(osdmap.have_crc());
+  inc.full_crc = osdmap.get_crc();
+  bl.clear();
+  // be consistent with OSDMonitor::update_from_paxos()
+  inc.encode(bl, CEPH_FEATURES_ALL|CEPH_FEATURE_RESERVED);
+  t->put(prefix, inc.epoch, bl);
+  return 0;
+}
+
+int rewrite_transaction(MonitorDBStore& store, int version,
+			const string& crush_file,
+			MonitorDBStore::Transaction* t) {
+  const string prefix("osdmap");
+
+  // calc the known-good epoch
+  version_t last_committed = store.get(prefix, "last_committed");
+  version_t good_version = 0;
+  if (version <= 0) {
+    if (last_committed >= (unsigned)-version) {
+      good_version = last_committed + version;
+    } else {
+      std::cerr << "osdmap-version is less than: -" << last_committed << std::endl;
+      return EINVAL;
+    }
+  } else {
+    good_version = version;
+  }
+  if (good_version >= last_committed) {
+    std::cout << "good epoch is greater or equal to the last committed one: "
+	      << good_version << " >= " << last_committed << std::endl;
+    return 0;
+  }
+
+  // load/extract the crush map
+  int r = 0;
+  ceph::shared_ptr<CrushWrapper> crush(new CrushWrapper);
+  if (crush_file.empty()) {
+    bufferlist bl;
+    r = store.get(prefix, store.combine_strings("full", good_version), bl);
+    if (r) {
+      std::cerr << "Error getting map: " << cpp_strerror(r) << std::endl;
+      return r;
+    }
+    OSDMap osdmap;
+    osdmap.decode(bl);
+    crush = osdmap.crush;
+  } else {
+    string err;
+    bufferlist bl;
+    r = bl.read_file(crush_file.c_str(), &err);
+    if (r) {
+      std::cerr << err << ": " << cpp_strerror(r) << std::endl;
+      return r;
+    }
+    bufferlist::iterator p = bl.begin();
+    crush->decode(p);
+  }
+
+  // prepare a transaction to rewrite the epochs
+  // (good_version, last_committed]
+  // with the good crush map.
+  // XXX: may need to break this into several paxos versions?
+  assert(good_version < last_committed);
+  for (version_t v = good_version + 1; v <= last_committed; v++) {
+    cout << "rewriting epoch #" << v << "/" << last_committed << std::endl;
+    r = update_osdmap(store, v, false, crush, t);
+    if (r)
+      return r;
+  }
+
+  // add a new osdmap epoch to store, so monitors will update their current osdmap
+  // in addition to the ones stored in epochs.
+  cout << "adding a new epoch #" << last_committed+1 << std::endl;
+  r = update_osdmap(store, last_committed++, true, crush, t);
+  if (r)
+    return r;
+  t->put(prefix, store.combine_strings("full", "latest"), last_committed);
+  t->put(prefix, "last_committed", last_committed);
+  return 0;
+}
+
+/**
+ * create a new paxos version which carries a proposal to rewrite all epochs
+ * of incremental and full map of "osdmap" after a faulty crush map is injected.
+ * so the leader will trigger a recovery and propagate this fix to its peons,
+ * after the proposal is accepted, and the transaction in it is applied. all
+ * monitors will rewrite the bad crush map with the good one, and have a new
+ * osdmap epoch with the good crush map in it.
+ */
+int rewrite_crush(const char* progname,
+		  vector<string>& subcmds,
+		  MonitorDBStore& store) {
+  po::options_description op_desc("Allowed 'rewrite-crush' options");
+  int version = -1;
+  string crush_file;
+  op_desc.add_options()
+    ("help,h", "produce this help message")
+    ("crush", po::value<string>(&crush_file),
+     ("path to the crush map file "
+      "(default: will instead extract it from the known-good osdmap)"))
+    ("good-epoch", po::value<int>(&version),
+     "known-good epoch of osdmap, if a negative number '-N' is given, the "
+     "$last_committed-N is used instead (default: -1). "
+     "Please note, -1 is not necessarily a good epoch, because there are "
+     "good chance that we have more epochs slipped into the monstore after "
+     "the one where the crushmap is firstly injected.")
+    ;
+  po::variables_map op_vm;
+  int r = parse_cmd_args(&op_desc, NULL, NULL, subcmds, &op_vm);
+  if (r) {
+    return -r;
+  }
+  if (op_vm.count("help")) {
+    usage(progname, op_desc);
+    return 0;
+  }
+
+  MonitorDBStore::Transaction rewrite_txn;
+  r = rewrite_transaction(store, version, crush_file, &rewrite_txn);
+  if (r) {
+    return r;
+  }
+
+  // store the transaction into store as a proposal
+  const string prefix("paxos");
+  version_t pending_v = store.get(prefix, "last_committed") + 1;
+  MonitorDBStore::TransactionRef t(new MonitorDBStore::Transaction);
+  bufferlist bl;
+  rewrite_txn.encode(bl);
+  cout << "adding pending commit " << pending_v
+       << " " << bl.length() << " bytes" << std::endl;
+  t->put(prefix, pending_v, bl);
+  t->put(prefix, "pending_v", pending_v);
+  // a large enough yet unique proposal number will probably do the trick
+  version_t pending_pn = (store.get(prefix, "accepted_pn") / 100 + 4) * 100 + 1;
+  t->put(prefix, "pending_pn", pending_pn);
+  store.apply_transaction(t);
+  return 0;
 }
 
 int main(int argc, char **argv) {
@@ -692,6 +884,8 @@ int main(int argc, char **argv) {
               << stringify(si_t(total_size)) << std::endl;
     std::cout << "from '" << store_path << "' to '" << out_path << "'"
               << std::endl;
+  } else if (cmd == "rewrite-crush") {
+    err = rewrite_crush(argv[0], subcmds, st);
   } else {
     std::cerr << "Unrecognized command: " << cmd << std::endl;
     usage(argv[0], desc);


### PR DESCRIPTION
- add "--dump <format>" command to osdmaptool, so we are able to extract osdmap epoch using xmlstarlet
- add a command to ceph-monstore-tool to rewrite monstore
- add a script to help fix the crush map

see http://tracker.ceph.com/issues/11815