### PR TITLE
release-notes.txt: fix version number in section heading

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -488,7 +488,7 @@ Upgrading
   until we find a way to avoid violating distro security policies when linking
   libust.
 
-Upgrading from v0.80.x Giant
+Upgrading from v0.87.x Giant
 ----------------------------
 
 * librbd and librados include lttng tracepoints on distros with


### PR DESCRIPTION
From context it is obvious that this section is about upgrading from Giant, not
Firefly, so change the version number to match Giant.

Signed-off-by: Nathan Cutler <ncutler@suse.com>