### PR TITLE
os/KeyValueStore.cc : remove keyvaluestore queue and thread

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -851,9 +851,6 @@ OPTION(journal_force_aio, OPT_BOOL, false)
 OPTION(keyvaluestore_queue_max_ops, OPT_INT, 50)
 OPTION(keyvaluestore_queue_max_bytes, OPT_INT, 100 << 20)
 OPTION(keyvaluestore_debug_check_backend, OPT_BOOL, 0) // Expensive debugging check on sync
-OPTION(keyvaluestore_op_threads, OPT_INT, 2)
-OPTION(keyvaluestore_op_thread_timeout, OPT_INT, 60)
-OPTION(keyvaluestore_op_thread_suicide_timeout, OPT_INT, 180)
 OPTION(keyvaluestore_default_strip_size, OPT_INT, 4096) // Only affect new object
 OPTION(keyvaluestore_max_expected_write_size, OPT_U64, 1ULL << 24) // bytes
 OPTION(keyvaluestore_header_cache_size, OPT_INT, 4096)    // Header cache size

--- a/src/os/KeyValueStore.h
+++ b/src/os/KeyValueStore.h
@@ -424,50 +424,13 @@ class KeyValueStore : public ObjectStore,
   Mutex op_throttle_lock;
   Finisher op_finisher;
 
-  ThreadPool op_tp;
-  struct OpWQ : public ThreadPool::WorkQueue<OpSequencer> {
-    KeyValueStore *store;
-    OpWQ(KeyValueStore *fs, time_t timeout, time_t suicide_timeout,
-         ThreadPool *tp) :
-      ThreadPool::WorkQueue<OpSequencer>("KeyValueStore::OpWQ",
-                                         timeout, suicide_timeout, tp),
-      store(fs) {}
-
-    bool _enqueue(OpSequencer *osr) {
-      store->op_queue.push_back(osr);
-      return true;
-    }
-    void _dequeue(OpSequencer *o) {
-      assert(0);
-    }
-    bool _empty() {
-      return store->op_queue.empty();
-    }
-    OpSequencer *_dequeue() {
-      if (store->op_queue.empty())
-	return NULL;
-      OpSequencer *osr = store->op_queue.front();
-      store->op_queue.pop_front();
-      return osr;
-    }
-    void _process(OpSequencer *osr, ThreadPool::TPHandle &handle) {
-      store->_do_op(osr, handle);
-    }
-    void _process_finish(OpSequencer *osr) {
-      store->_finish_op(osr);
-    }
-    void _clear() {
-      assert(store->op_queue.empty());
-    }
-  } op_wq;
-
   Op *build_op(list<Transaction*>& tls, Context *ondisk, Context *onreadable,
                Context *onreadable_sync, TrackedOpRef osd_op);
   void queue_op(OpSequencer *osr, Op *o);
   void op_queue_reserve_throttle(Op *o, ThreadPool::TPHandle *handle = NULL);
-  void _do_op(OpSequencer *osr, ThreadPool::TPHandle &handle);
+  void do_op(OpSequencer *osr, ThreadPool::TPHandle &handle);
   void op_queue_release_throttle(Op *o);
-  void _finish_op(OpSequencer *osr);
+  void finish_op(OpSequencer *osr);
 
   PerfCounters *perf_logger;
 


### PR DESCRIPTION
make write path short for keyvaluestore by removing KeyValueStore queue and thread

Signed-off-by: xinxin shu <xinxin.shu@intel.com>