### PR TITLE
ceph.spec.in:Add %bcond_with librocksdb

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -3,6 +3,7 @@
 %bcond_with tests
 %bcond_without tcmalloc
 %bcond_without libs_compat
+%bcond_with librocksdb
 
 %if (0%{?el5} || (0%{?rhel_version} >= 500 && 0%{?rhel_version} <= 600))
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
@@ -499,7 +500,9 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 %if 0%{with cephfs_java}
 		--enable-cephfs-java \
 %endif
+%if 0%{with librocksdb}
 		--with-librocksdb-static=check \
+%endif
 %if 0%{?rhel} || 0%{?fedora}
 		--with-systemd-libexec-dir=/usr/libexec/ceph \
 %endif


### PR DESCRIPTION
librocksdb is an experimental feature that is not by default enabled in configure.

Therefore if some one wants to enable it in the spec file they should enable it in the build rpm flags also.

Signed-off-by: Owen Synge <osynge@suse.com>