### PR TITLE
mds: store layout on header object

### DIFF
--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -1078,3 +1078,9 @@ void MDSCacheObject::dump_states(Formatter *f) const
   if (state_test(STATE_REJOINUNDEF))
     f->dump_string("state", "rejoinundef");
 }
+
+void ceph_file_layout_wrapper::dump(Formatter *f) const
+{
+  ::dump(static_cast<const ceph_file_layout&>(*this), f);
+}
+

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1577,7 +1577,25 @@ inline std::ostream& operator<<(std::ostream& out, mdsco_db_line_prefix o) {
   return out;
 }
 
+class ceph_file_layout_wrapper : public ceph_file_layout
+{
+public:
+  void encode(bufferlist &bl) const
+  {
+    ::encode(static_cast<const ceph_file_layout&>(*this), bl);
+  }
 
+  void decode(bufferlist::iterator &p)
+  {
+    ::decode(static_cast<ceph_file_layout&>(*this), p);
+  }
+
+  static void generate_test_instances(std::list<ceph_file_layout_wrapper*>& ls)
+  {
+  }
+
+  void dump(Formatter *f) const;
+};
 
 
 

--- a/src/test/encoding/ceph_dencoder.cc
+++ b/src/test/encoding/ceph_dencoder.cc
@@ -1,3 +1,18 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+
 #include <errno.h>
 #include "include/types.h"
 #include "ceph_ver.h"

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -169,6 +169,7 @@ TYPE(cap_reconnect_t)
 TYPE(inode_backtrace_t)
 TYPE(inode_backpointer_t)
 TYPE(quota_info_t)
+TYPE(ceph_file_layout_wrapper)
 
 #include "mds/CInode.h"
 TYPE(InodeStore)


### PR DESCRIPTION
This is surprisingly simple because we were already redundantly
calling store_backtrace whenever the layout changed!  That was
a side effect of the way add_old_pool is handled, the backtrace
version is bumped to latest even if the "old" pool is the
current one.

The upshot is that if we accept the existing behaviour of
also unnecessarily updating the 'parent' xattr, keeping
the new 'layout' xattr update requires no new dirty flags.  This
is a twitchy enough behaviour that new tests are needed to guard
against regressions though.

Fixes: #4161
Signed-off-by: John Spray <john.spray@redhat.com>