### PR TITLE
common: check run_name and prefix for empty string instead of NULL

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -19,7 +19,7 @@
 #include "obj_bencher.h"
 
 #include <iostream>
-#include <fstream>
+#include <fstream> 
 
 #include <cerrno>
 
@@ -169,7 +169,7 @@ void *ObjBencher::status_printer(void *_bencher) {
 
 int ObjBencher::aio_bench(
   int operation, int secondsToRun,
-  int concurrentios, int object_size, bool cleanup, const char* run_name, bool no_verify) {
+  int concurrentios, int object_size, bool cleanup, const std::string& run_name, bool no_verify) {
 
   if (concurrentios <= 0) 
     return -EINVAL;
@@ -179,7 +179,7 @@ int ObjBencher::aio_bench(
   int prevPid = 0;
 
   // default metadata object is used if user does not specify one
-  const std::string run_name_meta = (run_name == NULL ? BENCH_LASTRUN_METADATA : std::string(run_name));
+  const std::string run_name_meta = (run_name.empty() ? BENCH_LASTRUN_METADATA : run_name);
 
   //get data from previous write run, if available
   if (operation != OP_WRITE) {
@@ -906,19 +906,19 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   return r;
 }
 
-int ObjBencher::clean_up(const char* prefix, int concurrentios, const char* run_name) {
+int ObjBencher::clean_up(const std::string& prefix, int concurrentios, const std::string& run_name) {
   int r = 0;
   int object_size;
   int num_objects;
   int prevPid;
 
   // default meta object if user does not specify one
-  const std::string run_name_meta = (run_name == NULL ? BENCH_LASTRUN_METADATA : std::string(run_name));
+  const std::string run_name_meta = (run_name.empty() ? BENCH_LASTRUN_METADATA : run_name);
 
   r = fetch_bench_metadata(run_name_meta, &object_size, &num_objects, &prevPid);
   if (r < 0) {
     // if the metadata file is not found we should try to do a linear search on the prefix
-    if (r == -ENOENT && prefix != NULL) {
+    if (r == -ENOENT && prefix != "") {
       return clean_up_slow(prefix, concurrentios);
     }
     else {

--- a/src/common/obj_bencher.h
+++ b/src/common/obj_bencher.h
@@ -100,8 +100,8 @@ public:
   virtual ~ObjBencher() {}
   int aio_bench(
     int operation, int secondsToRun,
-    int concurrentios, int op_size, bool cleanup, const char* run_name, bool no_verify=false);
-  int clean_up(const char* prefix, int concurrentios, const char* run_name);
+    int concurrentios, int op_size, bool cleanup, const std::string& run_name, bool no_verify=false);
+  int clean_up(const std::string& prefix, int concurrentios, const std::string& run_name);
 
   void set_show_time(bool dt) {
     show_time = dt;

--- a/src/tools/rest_bench.cc
+++ b/src/tools/rest_bench.cc
@@ -785,12 +785,12 @@ int main(int argc, const char **argv)
   }
 
   if (operation == OP_CLEANUP) {
-    ret = bencher.clean_up(prefix.c_str(), concurrent_ios, run_name.c_str());
+    ret = bencher.clean_up(prefix, concurrent_ios, run_name);
     if (ret != 0)
       cerr << "error during cleanup: " << ret << std::endl;
   } else {
     ret = bencher.aio_bench(operation, seconds,
-			    concurrent_ios, op_size, cleanup, run_name.c_str());
+			    concurrent_ios, op_size, cleanup, run_name);
     if (ret != 0) {
         cerr << "error during benchmark: " << ret << std::endl;
     }


### PR DESCRIPTION
common&tool:
changed const char *prefix , const char * run_name to const std::string & format.
if not, in rest_bench.cc ret = bencher.aio_bench(operation, seconds, 0,
			    concurrent_ios, op_size, cleanup, run_name.c_str());
fetch_bench_metadata in aio_bench get wrong values because the judgement :
const std::string run_name_meta = (run_name == NULL ? BENCH_LASTRUN_METADATA : std::string(run_name));   is bad, run_name is empty string, not NULL.

Signed-off-by: cxwshawn  cxwshawn@gmail.com