### PR TITLE
mds: update CInode::oldest_snap during migration

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2564,12 +2564,14 @@ void CInode::encode_snap(bufferlist& bl)
   bufferlist snapbl;
   encode_snap_blob(snapbl);
   ::encode(snapbl, bl);
+  ::encode(oldest_snap, bl);
 }    
 
 void CInode::decode_snap(bufferlist::iterator& p)
 {
   bufferlist snapbl;
   ::decode(snapbl, p);
+  ::decode(oldest_snap, p);
   decode_snap_blob(snapbl);
 }
 

--- a/src/mds/MDS.h
+++ b/src/mds/MDS.h
@@ -39,7 +39,7 @@
 #include "Beacon.h"
 
 
-#define CEPH_MDS_PROTOCOL    25 /* cluster internal */
+#define CEPH_MDS_PROTOCOL    26 /* cluster internal */
 
 enum {
   l_mds_first = 2000,


### PR DESCRIPTION
Fixes: #12105
Signed-off-by: Yan, Zheng <zyan@redhat.com>