### PR TITLE
mds: fix mds crash when mds_max_log_events smaller.

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -387,7 +387,7 @@ OPTION(mds_log_max_events, OPT_INT, -1)
 OPTION(mds_log_events_per_segment, OPT_INT, 1024)
 OPTION(mds_log_segment_size, OPT_INT, 0)  // segment size for mds log,
 	      // defaults to g_default_file_layout.fl_object_size (4MB)
-OPTION(mds_log_max_segments, OPT_INT, 30)
+OPTION(mds_log_max_segments, OPT_U32, 30)
 OPTION(mds_log_max_expiring, OPT_INT, 20)
 OPTION(mds_bal_sample_interval, OPT_FLOAT, 3.0)  // every 5 seconds
 OPTION(mds_bal_replicate_threshold, OPT_FLOAT, 8000)

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -542,7 +542,7 @@ void MDLog::_journal_segment_subtree_map(MDSInternalContextBase *onsync)
 
 void MDLog::trim(int m)
 {
-  int max_segments = g_conf->mds_log_max_segments;
+  unsigned max_segments = g_conf->mds_log_max_segments;
   int max_events = g_conf->mds_log_max_events;
   if (m >= 0)
     max_events = m;
@@ -575,8 +575,7 @@ void MDLog::trim(int m)
   while (segments.size() > 1 && p != segments.end() &&
 	 ((max_events >= 0 &&
 	   num_events - expiring_events - expired_events > max_events) ||
-	  (max_segments >= 0 &&
-	   segments.size() - expiring_segments.size() - expired_segments.size() > (unsigned)max_segments))) {
+	  (segments.size() - expiring_segments.size() - expired_segments.size() > max_segments))) {
     
     if (stop < ceph_clock_now(g_ceph_context))
       break;

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -572,7 +572,7 @@ void MDLog::trim(int m)
   stop += 2.0;
 
   map<uint64_t,LogSegment*>::iterator p = segments.begin();
-  while (p != segments.end() && 
+  while (segments.size() > 1 && p != segments.end() &&
 	 ((max_events >= 0 &&
 	   num_events - expiring_events - expired_events > max_events) ||
 	  (max_segments >= 0 &&


### PR DESCRIPTION
If 'mds max log events' small, it met this bug:

mds/journal.cc: 155: FAILED assert(ls != this)
 ceph version 9.0.1-1117-gb0dc971
(b0dc97198a45791c8b9661d4be8e531e63202005)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char
const*)+0x80) [0x16ef7bf]
 2: (LogSegment::try_to_expire(MDS*,
C_GatherBuilderBase<MDSInternalContextBase, MDSGather>&, int)+0x1925)
[0x15475e5]
 3: (MDLog::try_expire(LogSegment*, int)+0x66) [0x14c50a0]
 4: (MDLog::trim(int)+0xd67) [0x14c4511]
 5: (MDS::tick()+0x265) [0x1146e0b]
 6: (MDS::C_MDS_Tick::finish(int)+0x32) [0x11693b2]
 7: (Context::complete(int)+0x27) [0x11611a7]
 8: (MDSInternalContextBase::complete(int)+0x1a4) [0x14977fa]
 9: (SafeTimer::timer_thread()+0x37a) [0x16e28fa]
 10: (SafeTimerThread::entry()+0x1c) [0x16e3c56]
 11: (Thread::entry_wrapper()+0xa8) [0x16df0ee]
 12: (Thread::_entry_func(void*)+0x18) [0x16df03c]
 13: /lib64/libpthread.so.0() [0x30c9c07555]
 14: (clone()+0x6d) [0x30c9901f3d]

Like mds asok command: flush journal, if there is only one segment, we
start a new segment to avoid this. But expect mds is stopping.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>