### PR TITLE
packaging: add find and which dependencies

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -51,6 +51,8 @@ Requires:	parted
 Requires:	util-linux
 Requires:	hdparm
 Requires:	cryptsetup
+Requires:	findutils
+Requires:	which
 Requires(post):	binutils
 # We require this to be present for %%{_tmpfilesdir}
 %if 0%{?_with_systemd}

--- a/debian/control
+++ b/debian/control
@@ -63,6 +63,8 @@ Architecture: linux-any
 Depends: binutils,
          ceph-common (>= 9.0.0-943),
          cryptsetup-bin | cryptsetup,
+         debianutils,
+         findutils,
          gdisk,
          grep,
          logrotate,


### PR DESCRIPTION
The postrotate script in src/logrotate.conf uses the which and find utilities
to do its work. Although logrotate itself is only a Recommends, I think which
and find are so ubiquitous that it makes sense to have them as hard
dependencies.

Also, I checked and the package names which and findutils are the same on all
the RPM distros we are currently targeting in the spec file.

In debian, find is also in a package called findutils. The package containing
which is called debianutils.

Signed-off-by: Nathan Cutler <ncutler@suse.com>