### PR TITLE
librbd: prevent object map updates from being interrupted

### DIFF
--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -71,6 +71,9 @@ private:
   protected:
     const uint64_t m_snap_id;
 
+    virtual bool safely_cancel(int r) {
+      return false;
+    }
     virtual bool should_complete(int r);
     virtual int filter_return_code(int r) {
       // never propagate an error back to the caller


### PR DESCRIPTION
Object map updates were being canceled in-flight when the exclusive lock
is released.  This resulted in an ERESTART error code bubbling up to
AioRequest.

Fixes: 12165
Backport: hammer
Signed-off-by: Jason Dillaman <dillaman@redhat.com>