### PR TITLE
ceph.spec.in: fix babeltrace handling on Fedora

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -354,7 +354,7 @@ Group:		System Environment/Libraries
 License:	LGPL-2.0
 Requires:	ceph-common
 Requires:	xmlstarlet
-%if (0%{?fedora} >= 20 || 0%{?rhel} == 6)
+%if (0%{?fedora} || 0%{?rhel} == 6)
 BuildRequires:	lttng-ust-devel
 BuildRequires:	libbabeltrace-devel
 %endif

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -974,7 +974,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_mandir}/man8/rbd-replay-prep.8*
 %{_bindir}/rbd-replay
 %{_bindir}/rbd-replay-many
-%if (0%{?fedora} == 20 || 0%{?rhel} == 6)
+%if (0%{?fedora} || 0%{?rhel} == 6)
 %{_bindir}/rbd-replay-prep
 %endif
 


### PR DESCRIPTION
The first commit in this PR ensures that `rbd-replay-prep` is packaged on all Fedoras. This reverts the change in commit https://github.com/ceph/ceph/commit/85517d611b7bf4cb6cbffcd2c65303be0d038264.  Since we `BuildRequire: libbabeltrace-devel`, autoconf will see that babeltrace is available during the build, and `make` will build/install the `rbd-replay-prep` utility. (CC'ing @branto1 in case he wants to review this.)

The first commit in this PR also simplifies Fedora selection logic, because Fedora 19 is EOL, so "`%{fedora}`" implies "Fedora 20 and above".

The second commit in this PR does an similar simplification by removing a reference to Fedoras < 20.

Reported-by: @ilc
