### PR TITLE
DNM : ceph.spec.in: enable-client rbd and rados for all platforms.

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -490,6 +490,9 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 
 %{configure}	CPPFLAGS="$java_inc" \
 		--prefix=/usr \
+		--enable-client \
+		--with_rbd \
+		--with_rados \
 		--localstatedir=/var \
 		--sysconfdir=/etc \
 		--docdir=%{_docdir}/ceph \
@@ -978,9 +981,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_mandir}/man8/rbd-replay-prep.8*
 %{_bindir}/rbd-replay
 %{_bindir}/rbd-replay-many
-%if (0%{?fedora} == 20 || 0%{?rhel} == 6)
 %{_bindir}/rbd-replay-prep
-%endif
 
 #################################################################################
 %if 0%{with cephfs_java}


### PR DESCRIPTION
Fedora 22 is currently building these features and SUSE is not.

This causes failures for Fedora 22 (as /usr/bin/rbd-replay-prep 
is built but not in spec file) and SUSE has a man page for a
binary that does not exist.

Signed-off-by: Owen Synge <osynge@suse.com>