### PR TITLE
librbd: assertion failure race condition if watch disconnected

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1964,7 +1964,6 @@ reprotect_and_return_err:
         close_image(ictx);
         return -EBUSY;
       }
-      assert(watchers.size() == 1);
 
       trim_image(ictx, 0, prog_ctx);
 


### PR DESCRIPTION
It's possible for librbd's watch of the header object to be reset by
connection issues just prior to the image being removed.  This will
causes an assertion failure which assumes at least one watcher on the
image.

Fixes: #12176
Backport: hammer, firefly
Signed-off-by: Jason Dillaman <dillaman@redhat.com>