### PR TITLE
Common: Do not use CEPH_PAGE_SIZE when appending buffers in Ceph

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1347,8 +1347,7 @@ void buffer::list::rebuild_page_aligned()
     unsigned gap = append_buffer.unused_tail_length();
     if (!gap) {
       // make a new append_buffer!
-      unsigned alen = CEPH_PAGE_SIZE;
-      append_buffer = create_page_aligned(alen);
+      append_buffer = create_aligned(CEPH_BUFFER_APPEND_SIZE, CEPH_BUFFER_APPEND_SIZE);
       append_buffer.set_length(0);   // unused, so far.
     }
     append_buffer.append(c);
@@ -1372,8 +1371,8 @@ void buffer::list::rebuild_page_aligned()
 	break;  // done!
       
       // make a new append_buffer!
-      unsigned alen = CEPH_PAGE_SIZE * (((len-1) / CEPH_PAGE_SIZE) + 1);
-      append_buffer = create_page_aligned(alen);
+      unsigned alen = CEPH_BUFFER_APPEND_SIZE * (((len-1) / CEPH_BUFFER_APPEND_SIZE) + 1);
+      append_buffer = create_aligned(alen, CEPH_BUFFER_APPEND_SIZE);
       append_buffer.set_length(0);   // unused, so far.
     }
   }
@@ -1682,8 +1681,8 @@ ssize_t buffer::list::read_fd(int fd, size_t len)
     // available for raw_pipe until we actually inspect the data
     return 0;
   }
-  int s = ROUND_UP_TO(len, CEPH_PAGE_SIZE);
-  bufferptr bp = buffer::create_page_aligned(s);
+  int s = ROUND_UP_TO(len, CEPH_BUFFER_APPEND_SIZE);
+  bufferptr bp = buffer::create_aligned(s, CEPH_BUFFER_APPEND_SIZE);
   ssize_t ret = safe_read(fd, (void*)bp.c_str(), len);
   if (ret >= 0) {
     bp.set_length(ret);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -65,6 +65,8 @@ class XioDispatchHook;
 
 namespace ceph {
 
+const static int CEPH_BUFFER_APPEND_SIZE(4096);
+
 class CEPH_BUFFER_API buffer {
   /*
    * exceptions

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1416,7 +1416,7 @@ TEST(BufferList, rebuild) {
     bl.append(str.c_str(), str.size());
     bl.append(str.c_str(), str.size());
     EXPECT_EQ((unsigned)2, bl.buffers().size());
-    EXPECT_TRUE(bl.is_page_aligned());
+    EXPECT_TRUE(bl.is_aligned(CEPH_BUFFER_APPEND_SIZE));
     bl.rebuild();
     EXPECT_TRUE(bl.is_page_aligned());
     EXPECT_EQ((unsigned)1, bl.buffers().size());
@@ -1650,7 +1650,7 @@ TEST(BufferList, append) {
     EXPECT_EQ((unsigned)0, bl.buffers().size());
     bl.append('A');
     EXPECT_EQ((unsigned)1, bl.buffers().size());
-    EXPECT_TRUE(bl.is_page_aligned());
+    EXPECT_TRUE(bl.is_aligned(CEPH_BUFFER_APPEND_SIZE));
   }
   //
   // void append(const char *data, unsigned len);
@@ -1904,7 +1904,7 @@ TEST(BufferList, read_fd) {
   EXPECT_EQ(-EBADF, bl.read_fd(fd, len));
   fd = ::open(FILENAME, O_RDONLY);
   EXPECT_EQ(len, (unsigned)bl.read_fd(fd, len));
-  EXPECT_EQ(CEPH_PAGE_SIZE - len, bl.buffers().front().unused_tail_length());
+  EXPECT_EQ(CEPH_BUFFER_APPEND_SIZE - len, bl.buffers().front().unused_tail_length());
   EXPECT_EQ(len, bl.length());
   ::close(fd);
   ::unlink(FILENAME);


### PR DESCRIPTION
Hello,
Here is a pull request to address an issue whereby memory usage can spike quite severely on 64-bit ARM systems running with a 64KB PAGE_SIZE. This should not have any noticeable effect on systems running with a 4KB PAGE_SIZE (i.e. x86). 

I noticed a rather large memory spike in ceph-mds when I unmounted the filesystem (having just rsynced over the kernel sources). Before applying this patch, the memory spike was ~10GB after the patch it was down to ~1GB (i.e. the memory usage I observed when running with a 4KB PAGE_SIZE).

I have run this through the `make check` tests supplied with Ceph on both x86 and ARM.

Please let me know if this needs tweaking in any way.

Cheers,
Steve

---

Whenever one grows a Buffer in Ceph, it is increased by the system
PAGE_SIZE.

Unfortunately, when one is running with a 64KB PAGE_SIZE, they can
witness quite a large memory spike under certain workloads, over what
can be observed when using a 4KB PAGE_SIZE.

This patch adjusts the Buffer append logic s.t. the buffer is expanded
in chunks of 4KB no matter what PAGE_SIZE is in operation. On systems
that run only with a 4KB PAGE_SIZE, this patch should not have any
noticeable effect. For architectures that can run with a 64KB PAGE_SIZE
(such as ARM and PowerPC), this patch should help reduce the size of
memory spikes under certain workloads.

With this patch applied on 64-bit ARM, the peak resident memory use by
ceph-mds running on 64KB pages is reduced from 10GB to 1GB. (One can
exacerbate a spike in memory use by unmounting a CephFS filesystem.)
The size of the virtual memory use by ceph-mds is reduced by a similar
magnitude.

Signed-off-by: Steve Capper <steve.capper@linaro.org>