### PR TITLE
ceph.spec.in: add a bcond_with for jemalloc

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2,12 +2,16 @@
 %bcond_without cephfs_java
 %bcond_with tests
 %bcond_without tcmalloc
+%bcond_with jemalloc
+
 %bcond_without libs_compat
 
 %if (0%{?el5} || (0%{?rhel_version} >= 500 && 0%{?rhel_version} <= 600))
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 %endif
+
+
 
 # Use systemd files on RHEL 7 and above and in SUSE/openSUSE.
 # Note: We don't install unit files for the services yet. For now,
@@ -55,6 +59,9 @@ Requires: systemd
 %endif
 %if 0%{with cephfs_java}
 BuildRequires: sharutils
+%endif
+%if 0%{with jemalloc}
+BuildRequires:	jemalloc-devel
 %endif
 BuildRequires:	gcc-c++
 BuildRequires:	git
@@ -512,7 +519,14 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 %endif
 		$MY_CONF_OPT \
 		%{?_with_ocf} \
-		%{?_with_tcmalloc} \
+%if 0%{with tcmalloc}
+		--with-tcmalloc \
+		--without-jemalloc \
+%endif
+%if 0%{with jemalloc}
+		--without-tcmalloc \
+		--with-jemalloc \
+%endif
 		CFLAGS="$RPM_OPT_FLAGS" CXXFLAGS="$RPM_OPT_FLAGS"
 
 # fix bug in specific version of libedit-devel


### PR DESCRIPTION
ceph.spec.in: add a bcond_with for jemalloc

jemalloc like tcmalloc is a high performance replacement for glibc malloc.
Which is better for ceph can only be told via benchmarks and testing.
This patch makes it easer to test this as an rpm install.

Please note this pull request should not be tested with out pr "https://github.com/ceph/ceph/pull/5068" due to a wrong default in the spec file causing build to fail when "--with-librocksdb-static=check" is on the configure command line parameter list.