### PR TITLE
11864: packaging: RGW depends on /etc/mime.types

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -193,6 +193,7 @@ Requires:	apache2-mod_fcgid
 %if 0%{?rhel} || 0%{?fedora}
 BuildRequires:	expat-devel
 BuildRequires:	fcgi-devel
+Requires:	mailcap
 %endif
 %description radosgw
 This package is an S3 HTTP REST gateway for the RADOS object store. It

--- a/debian/control
+++ b/debian/control
@@ -426,7 +426,8 @@ Description: Ceph distributed file system client library (development files)
 
 Package: radosgw
 Architecture: linux-any
-Depends: ceph-common (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}
+Depends: ceph-common (= ${binary:Version}), mime-support,
+         ${misc:Depends}, ${shlibs:Depends}
 Description: REST gateway for RADOS distributed object store
  RADOS is a distributed object store used by the Ceph distributed
  storage system.  This package provides a REST gateway to the


### PR DESCRIPTION
If the mimecap RPM or mime-support DEB is not installed, then the `/etc/mime.types` file is not present on the system. RGW attempts to read this file during startup, and if the file is not present, RGW logs an
error:

```
  ext_mime_map_init(): failed to open file=/etc/mime.types ret=-2
```

Make the radosgw package depend on the mailcap/mime-support packages so that `/etc/mime.types` is always available on RGW systems.

http://tracker.ceph.com/issues/11864