### PR TITLE
ObjectStore/FileJournal: reduce impact of memset()

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -872,7 +872,6 @@ private:
     Op* _get_next_op() {
       if (op_ptr.length() == 0 || op_ptr.offset() >= op_ptr.length()) {
         op_ptr = bufferptr(sizeof(Op) * OPS_PER_PTR);
-	op_ptr.zero();
       }
       bufferptr ptr(op_ptr, 0, sizeof(Op));
       op_bl.append(ptr);
@@ -880,6 +879,7 @@ private:
       op_ptr.set_offset(op_ptr.offset() + sizeof(Op));
 
       char* p = ptr.c_str();
+      memset(p, 0, sizeof(Op));
       return reinterpret_cast<Op*>(p);
     }
     __le32 _get_coll_id(const coll_t& coll) {


### PR DESCRIPTION
In all of mentioned cases, there's bufferptr::zero() call, which is followed by partial or full overwrite with actual data, making this zero() call unnecessary partially or at all. These changes change what is actually zeroed and/or don't call bufferptr::zero() - which also does mutex lock/unlock with crc cache clearing (which is also unnecessary because at this point of time, it is empty anyway).
This should be beneficial especially on random, small object accesses.