### PR TITLE
Add unit/tox structure for ceph python script

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -64,9 +64,7 @@ import json
 import rados
 import shlex
 import signal
-import socket
 import string
-import struct
 import subprocess
 
 from ceph_argparse import \
@@ -211,7 +209,7 @@ def do_extended_help(parser, args):
 
     def help_for_target(target, partial=None):
         ret, outbuf, outs = json_command(cluster_handle, target=target,
-                                         prefix='get_command_descriptions', 
+                                         prefix='get_command_descriptions',
                                          timeout=10)
         if ret:
             print >> sys.stderr, \
@@ -382,7 +380,7 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
             if sys.stdin.isatty():
                 # do the command-interpreter looping
                 # for raw_input to do readline cmd editing
-                import readline
+                import readline  # noqa
 
             while True:
                 interactive_input = read_input()
@@ -423,7 +421,7 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
 def complete(sigdict, args, target):
     """
     Command completion.  Match as much of [args] as possible,
-    and print every possible match separated by newlines. 
+    and print every possible match separated by newlines.
     Return exitcode.
     """
     # XXX this looks a lot like the front of validate_command().  Refactor?
@@ -513,7 +511,7 @@ def main():
     parser, parsed_args, childargs = parse_cmdargs()
 
     if parsed_args.version:
-        print 'ceph version {0} ({1})'.format(CEPH_GIT_NICE_VER, CEPH_GIT_VER)
+        print 'ceph version {0} ({1})'.format(CEPH_GIT_NICE_VER, CEPH_GIT_VER)  # noqa
         return 0
 
     global verbose
@@ -721,7 +719,7 @@ def main():
 
         # this instance keeps the watch connection alive, but is
         # otherwise unused
-        logwatch = rados.MonitorLog(cluster_handle, level, watch_cb, 0)
+        rados.MonitorLog(cluster_handle, level, watch_cb, 0)
 
         # loop forever letting watch_cb print lines
         try:

--- a/src/test/python/ceph-disk/.gitignore
+++ b/src/test/python/ceph-disk/.gitignore
@@ -1,0 +1,3 @@
+# this is a generated file used for testing and symlinked and should be ignored
+# as paths are absolute to the test machine
+ceph_disk.py

--- a/src/test/python/ceph/.gitignore
+++ b/src/test/python/ceph/.gitignore
@@ -1,0 +1,3 @@
+# this is a generated file used for testing and symlinked and should be ignored
+# as paths are absolute to the test machine
+ceph.py

--- a/src/test/python/ceph/setup.py
+++ b/src/test/python/ceph/setup.py
@@ -1,0 +1,27 @@
+import os
+from setuptools import setup, find_packages
+
+# link ceph script here so we can "install" it
+current_dir = os.path.abspath(os.path.dirname(__file__))
+src_dir = os.path.dirname(os.path.dirname(os.path.dirname(current_dir)))
+script_path = os.path.join(src_dir, 'ceph.in')
+
+
+def link_target(source, destination):
+    if not os.path.exists(destination):
+        try:
+            os.symlink(source, destination)
+        except (IOError, OSError) as error:
+            print 'Ignoring linking of target: %s' % str(error)
+
+link_target(script_path, 'ceph.py')
+
+setup(
+    name='ceph',
+    version='0.1',
+    description='',
+    author='',
+    author_email='',
+    zip_safe=False,
+    packages=find_packages(),
+)

--- a/src/test/python/ceph/tests/test_ceph.py
+++ b/src/test/python/ceph/tests/test_ceph.py
@@ -1,0 +1,10 @@
+import ceph
+
+# This file tests nothing (yet) except for being able to import ceph
+# correctly and thus ensuring somewhat that it will work under different Python
+# versions. You must write unittests here so that code has adequate coverage.
+
+class TestCeph(object):
+
+    def test_basic(self):
+        assert True

--- a/src/test/python/ceph/tox.ini
+++ b/src/test/python/ceph/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py26, py27, flake8
+skipsdist=True
+
+[testenv]
+deps=
+  pytest
+setenv =
+    PYTHONPATH = {toxinidir}/../../../pybind
+
+commands=
+  python setup.py develop
+  py.test -v
+
+[testenv:flake8]
+deps=
+  flake8
+commands=flake8 --select=F ceph.py


### PR DESCRIPTION
And a few changes to `ceph.in` to fix some linter issues. This will allow tox to pass python 2.7 and Flake8 (the linter) locally but will fail 2.6 as that doesn't have argparse.

As seen on https://github.com/ceph/ceph/pull/4970 the package should install argparse for python 2.6 

Reference issue: http://tracker.ceph.com/issues/12037