### PR TITLE
mon/PGMonitor: Make blocked Op message more readable.

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -2061,7 +2061,7 @@ void PGMonitor::get_health(list<pair<health_status_t,string> >& summary,
   // slow requests
   if (g_conf->mon_osd_max_op_age > 0 &&
       pg_map.osd_sum.op_queue_age_hist.upper_bound() > g_conf->mon_osd_max_op_age) {
-    unsigned sum = _warn_slow_request_histogram(pg_map.osd_sum.op_queue_age_hist, "", summary, detail);
+    unsigned sum = _warn_slow_request_histogram(pg_map.osd_sum.op_queue_age_hist, "", summary, NULL);
     if (sum > 0) {
       ostringstream ss;
       ss << sum << " requests are blocked > " << g_conf->mon_osd_max_op_age << " sec";


### PR DESCRIPTION
W/O this patch:
```
root@dev:/var/log/ceph# ceph health detail
HEALTH_WARN 1 pgs stuck unclean; 2 requests are blocked > 32 sec; 1 osds
have slow requests; recovery 5/115 objects degraded (4.348%); recovery
1/38 unfound (2.632%); too few PGs per OSD (15 < min 30)
pg 2.1 is stuck unclean for 899.708271, current state active, last
acting [2,3,0,1]
1 ops are blocked > 1048.58 sec
1 ops are blocked > 262.144 sec
1 ops are blocked > 1048.58 sec on osd.2
1 ops are blocked > 262.144 sec on osd.2
1 osds have slow requests
recovery 5/115 objects degraded (4.348%)
recovery 1/38 unfound (2.632%)
too few PGs per OSD (15 < min 30)
```
W/ this patch:
```
root@dev:/var/log/ceph# ceph health detail
HEALTH_WARN 1 pgs stuck unclean; 2 requests are blocked > 32 sec; 1 osds
have slow requests; recovery 5/115 objects degraded (4.348%); recovery
1/38 unfound (2.632%); too few PGs per OSD (15 < min 30)
pg 2.1 is stuck unclean for 427.103877, current state active, last
acting [2,3,0,1]
1 ops are blocked > 524.288 sec on osd.2
1 ops are blocked > 131.072 sec on osd.2
1 osds have slow requests
recovery 5/115 objects degraded (4.348%)
recovery 1/38 unfound (2.632%)
too few PGs per OSD (15 < min 30
```
Later messages looks better.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>