### PR TITLE
ceph.spec.in: /var/run/ceph fixes

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -584,7 +584,9 @@ mv $RPM_BUILD_ROOT/sbin/mount.fuse.ceph $RPM_BUILD_ROOT/usr/sbin/mount.fuse.ceph
 
 #set up placeholder directories
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/ceph
+%if  (! 0%{?suse_version}) || ( 0%{?suse_version} && (! 0%{?_with_systemd}) )
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/run/ceph
+%endif
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/log/ceph
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/ceph/tmp
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/ceph/mon
@@ -725,7 +727,9 @@ fi
 %dir %{_localstatedir}/lib/ceph/bootstrap-osd
 %dir %{_localstatedir}/lib/ceph/bootstrap-mds
 %dir %{_localstatedir}/lib/ceph/bootstrap-rgw
+%if  (! 0%{?suse_version}) || ( 0%{?suse_version} && (! 0%{?_with_systemd}) )
 %dir %{_localstatedir}/run/ceph/
+%endif
 
 #################################################################################
 %files -n ceph-common

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -14,8 +14,8 @@
 # the _with_systemd variable only implies that we'll install
 # /etc/tmpfiles.d/ceph.conf in order to set up the socket directory in
 # /var/run/ceph.
-%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version}
-  %global _with_systemd 1
+%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} > 1300
+%global _with_systemd 1
 %endif
 
 Name:		ceph


### PR DESCRIPTION
On systemd distros we should not be creating /var/run/ceph at all because: (1) `/var/run` is symlinked or bind mounted to `/run`, and (2) `/run` is tmpfs (re-created at every boot).

See https://lists.fedoraproject.org/pipermail/devel/2011-March/150031.html

Plus some related specfile cleanups.

http://tracker.ceph.com/issues/12201 Fixes: #12201

Signed-off-by: Nathan Cutler <ncutler@suse.com>