### PR TITLE
doc: fix the build

### DIFF
--- a/doc/dev/quick_guide.rst
+++ b/doc/dev/quick_guide.rst
@@ -18,7 +18,7 @@ the result behaves as expected.
 
 Running a development deployment
 --------------------------------
-Ceph contains a script called ``vstart.sh`` (see also `deploying a development cluster<https://ceph.com/docs/master/dev/dev_cluster_deployement/>`_) which allows developers to quickly test their code using
+Ceph contains a script called ``vstart.sh`` (see also :doc:`/dev/dev_cluster_deployement`) which allows developers to quickly test their code using
 a simple deployment on your development system. Once the build finishes successfully, start the ceph
 deployment using the following command:
 

--- a/doc/rados/operations/add-or-rm-osds.rst
+++ b/doc/rados/operations/add-or-rm-osds.rst
@@ -79,10 +79,10 @@ weight).
    Note, in this case the command may fail if the number is already in use.
 
    .. warning:: In general, explicitly specifying {id} is not recommended.
-   IDs are allocated as an array, and skipping entries consumes some extra
-   memory. This can become significant if there are large gaps and/or
-   clusters are large. If {id} is not specified, the smallest available is
-   used.
+      IDs are allocated as an array, and skipping entries consumes some extra
+      memory. This can become significant if there are large gaps and/or
+      clusters are large. If {id} is not specified, the smallest available is
+      used.
 
 #. Create the default directory on your new OSD. :: 
 


### PR DESCRIPTION
see http://gitbuilder.sepia.ceph.com/gitbuilder-doc/log.cgi?log=8202767f3f7b981af9bb845f25ea112b6eff0976
```
ERROR: /srv/autobuild-ceph/gitbuilder.git/build/doc/dev/quick_guide.rst:21: Unknown target name: "deploying a development cluster".
```