### PR TITLE
ceph-detect-init: do not require "argparse" on py2.6

### DIFF
--- a/src/ceph-detect-init/setup.py
+++ b/src/ceph-detect-init/setup.py
@@ -19,6 +19,7 @@
 # along with this program.  If not, see `<http://www.gnu.org/licenses/>`.
 #
 import os
+import sys
 from setuptools import setup
 from setuptools import find_packages
 
@@ -26,6 +27,15 @@ def read(fname):
     path = os.path.join(os.path.dirname(__file__), fname)
     f = open(path)
     return f.read()
+
+
+def filter_included_modules(*m):
+    modules = sum(m, [])
+    if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
+        return modules
+    included_modules = set(['argparse', 'importlib', 'sysconfig'])
+    return list(set(modules) - included_modules)
+
 
 install_requires = read('requirements.txt').split()
 tests_require = read('test-requirements.txt').split()
@@ -43,11 +53,9 @@ setup(
     keywords='ceph',
     url="https://git.ceph.com/?p=ceph.git;a=summary",
 
-    install_requires=[
-        'setuptools',
-        ] + install_requires,
-
-    tests_require=tests_require,
+    install_requires=filter_included_modules(['setuptools'],
+                                             install_requires),
+    tests_require=filter_included_modules(tests_require),
 
     classifiers=[
         'Environment :: Console',


### PR DESCRIPTION
argparse is included in python2.6 and up, and pkg_resources is not
able to find it by .egg-info. so we should not list it as "requires"
if python's version is greater than 2.6.

Fixes: #12167 http://tracker.ceph.com/issues/12167
Signed-off-by: Kefu Chai <kchai@redhat.com>