### PR TITLE
Thread.h: move copy constructor and assignment op

### DIFF
--- a/src/common/Thread.h
+++ b/src/common/Thread.h
@@ -29,8 +29,8 @@ class Thread {
   void *entry_wrapper();
 
  public:
-  explicit Thread(const Thread& other);
-  const Thread& operator=(const Thread& other);
+  Thread(const Thread&) = delete;
+  Thread& operator=(const Thread&) = delete;
 
   Thread();
   virtual ~Thread();


### PR DESCRIPTION
Move copy constructor and assignemnt operator under the private access
specifier. They are not defined and it makes it confusing when they are
under public. They also don't need const and explicit specifiers.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>