### PR TITLE
common/Thread: added const to 2 functions

### DIFF
--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -84,7 +84,7 @@ void *Thread::entry_wrapper()
   return entry();
 }
 
-const pthread_t &Thread::get_thread_id()
+const pthread_t &Thread::get_thread_id() const
 {
   return thread_id;
 }
@@ -94,7 +94,7 @@ bool Thread::is_started() const
   return thread_id != 0;
 }
 
-bool Thread::am_self()
+bool Thread::am_self() const
 {
   return (pthread_self() == thread_id);
 }

--- a/src/common/Thread.h
+++ b/src/common/Thread.h
@@ -42,10 +42,10 @@ class Thread {
   static void *_entry_func(void *arg);
 
  public:
-  const pthread_t &get_thread_id();
+  const pthread_t &get_thread_id() const;
   pid_t get_pid() const { return pid; }
   bool is_started() const;
-  bool am_self();
+  bool am_self() const;
   int kill(int signal);
   int try_create(size_t stacksize);
   void create(size_t stacksize = 0);


### PR DESCRIPTION
Changed get_thread_id and am_self to const member functions

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>