### PR TITLE
rgw: add minimum support for copy multipart part

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -148,6 +148,7 @@ using ceph::crypto::MD5;
 #define ERR_MALFORMED_XML        2029
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
+#define ERR_NOT_IMPLEMENTED      2201
 
 #ifndef UINT32_MAX
 #define UINT32_MAX (0xffffffffu)

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -56,6 +56,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ERR_UNPROCESSABLE_ENTITY, 422, "UnprocessableEntity" },
     { ERR_LOCKED, 423, "Locked" },
     { ERR_INTERNAL_ERROR, 500, "InternalError" },
+    { ERR_NOT_IMPLEMENTED, 501, "NotImplemented" },
 };
 
 const static struct rgw_http_errors RGW_HTTP_SWIFT_ERRORS[] = {
@@ -109,6 +110,7 @@ const static struct rgw_http_status_code http_codes[] = {
   { 417, "Expectation Failed" },
   { 422, "Unprocessable Entity" },
   { 500, "Internal Server Error" },
+  { 501, "Not Implemented" },
   { 0, NULL },
 };
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1422,6 +1422,10 @@ int RGWCopyObj_ObjStore_S3::init_dest_policy()
 
 int RGWCopyObj_ObjStore_S3::get_params()
 {
+  if (s->info.env->get("HTTP_X_AMZ_COPY_SOURCE_RANGE")) {
+    return -ERR_NOT_IMPLEMENTED;
+  }
+
   if_mod = s->info.env->get("HTTP_X_AMZ_COPY_IF_MODIFIED_SINCE");
   if_unmod = s->info.env->get("HTTP_X_AMZ_COPY_IF_UNMODIFIED_SINCE");
   if_match = s->info.env->get("HTTP_X_AMZ_COPY_IF_MATCH");


### PR DESCRIPTION
Add minimum support in order to return a NotImplemented error code,
rather than NoSuchKey.

It adds a new step in the process request processing flow in order to
check if the requested feature is supported (fully or partially). This
way, it can return a NotImplemented error as soon as possible if needed.

This approach improves the performance per request. The NotImplemented
check happens as soon as possible. Server side doesn't need to compute
request authorization on NotImplemented features.

Related: #7817

Signed-off-by: Javier M. Mellid <jmunhoz@igalia.com>