### PR TITLE
doc: add changes to "pg ls*" commands to pending release notes

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -18,3 +18,6 @@ v9.0.3
   introduced).
 
 * The `--dump-json` option of "osdmaptool" is replaced by `--dump json`.
+
+* The commands of "pg ls-by-{pool,primary,osd}" and "pg ls" now take "recovering"
+  instead of "recovery", to include the recovering pgs in the listed pgs.


### PR DESCRIPTION
"pg ls*" commands now accept recovering instead of recovery as
one of its states.

Fixes: #11569
Signed-off-by: Kefu Chai <kchai@redhat.com>