### PR TITLE
mon/PGMonitor: bug fix pg monitor get crush rule

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1023,8 +1023,8 @@ bool PGMonitor::register_new_pgs()
        ++p) {
     int64_t poolid = p->first;
     pg_pool_t &pool = p->second;
-    int ruleno = pool.get_crush_ruleset();
-    if (!osdmap->crush->rule_exists(ruleno)) 
+    int ruleno = osdmap->crush->find_rule(pool.get_crush_ruleset(), pool.get_type(), pool.get_size());
+    if (ruleno < 0 || !osdmap->crush->rule_exists(ruleno))
       continue;
 
     if (pool.get_last_change() <= pg_map.last_pg_scan ||


### PR DESCRIPTION
when some rules have been deleted before, the index in array of crush->rules
is not always equals to crush_ruleset of pool.

Fixes: #12210
Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>