### PR TITLE
mds: nuke the unused mds_mem_max option

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -359,7 +359,6 @@ OPTION(mds_max_file_size, OPT_U64, 1ULL << 40) // Used when creating new CephFS.
 OPTION(mds_cache_size, OPT_INT, 100000)
 OPTION(mds_cache_mid, OPT_FLOAT, .7)
 OPTION(mds_max_file_recover, OPT_U32, 32)
-OPTION(mds_mem_max, OPT_INT, 1048576)        // KB
 OPTION(mds_dir_max_commit_size, OPT_INT, 10) // MB
 OPTION(mds_decay_halflife, OPT_FLOAT, 5)
 OPTION(mds_beacon_interval, OPT_FLOAT, 4)

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7179,7 +7179,6 @@ void MDCache::check_memory_usage()
 	   << ", malloc " << last.malloc << " mmap " << last.mmap
 	   << ", baseline " << baseline.get_heap()
 	   << ", buffers " << (buffer::get_total_alloc() >> 10)
-	   << ", max " << g_conf->mds_mem_max
 	   << ", " << num_inodes_with_caps << " / " << inode_map.size() << " inodes have caps"
 	   << ", " << num_caps << " caps, " << caps_per_inode << " caps per inode"
 	   << dendl;
@@ -7188,13 +7187,6 @@ void MDCache::check_memory_usage()
   mds->mlogger->set(l_mdm_heap, last.get_heap());
   mds->mlogger->set(l_mdm_malloc, last.malloc);
 
-  /*int size = last.get_total();
-  if (size > g_conf->mds_mem_max * .9) {
-    float ratio = (float)g_conf->mds_mem_max * .9 / (float)size;
-    if (ratio < 1.0)
-      mds->server->recall_client_state(ratio);
-  } else 
-    */
   if (num_inodes_with_caps > g_conf->mds_cache_size) {
     float ratio = (float)g_conf->mds_cache_size * .9 / (float)num_inodes_with_caps;
     if (ratio < 1.0)

--- a/src/sample.ceph.conf
+++ b/src/sample.ceph.conf
@@ -266,8 +266,6 @@
     # (Default: 100000)
     ;mds cache size             = 250000
 
-    ;mds mem max                = 1048576     # KB
-
 ;[mds.alpha]
 ;    host                       = alpha
 


### PR DESCRIPTION
AFAICT mds_mem_max has been unused since argonaut. Nuke it because it is misleading.

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>