### PR TITLE
mon: fix mds metadata

### DIFF
--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -74,6 +74,7 @@ class MDSMonitor : public PaxosService {
   // service methods
   void create_initial();
   void update_from_paxos(bool *need_bootstrap);
+  void init();
   void create_pending(); 
   void encode_pending(MonitorDBStore::TransactionRef t);
   // we don't require full versions; don't encode any.
@@ -146,6 +147,8 @@ private:
   // MDS daemon GID to latest health state from that GID
   std::map<uint64_t, MDSHealth> pending_daemon_health;
   std::set<uint64_t> pending_daemon_health_rm;
+
+  map<mds_gid_t, Metadata> pending_metadata;
 
   int _check_pool(const int64_t pool_id, std::stringstream *ss) const;
   mds_gid_t gid_from_arg(const std::string& arg, std::ostream& err);

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -1483,7 +1483,6 @@ void Paxos::propose_pending()
 
   bufferlist bl;
   pending_proposal->encode(bl);
-  pending_proposal.reset();
 
   dout(10) << __func__ << " " << (last_committed + 1)
 	   << " " << bl.length() << " bytes" << dendl;
@@ -1492,6 +1491,8 @@ void Paxos::propose_pending()
   pending_proposal->dump(&f);
   f.flush(*_dout);
   *_dout << dendl;
+
+  pending_proposal.reset();
 
   committing_finishers.swap(pending_finishers);
   state = STATE_UPDATING;


### PR DESCRIPTION
This pull request is to address issues found when testing recently added 'ceph node ls' (#4227).

The first one is that when an mds daemon is restarted and got a new gid, metadata for old gid remains in store. This leads to assertion violation later, when 'ceph node ls' is executed and the monitor crush.

Another issue found is that after restarting several mds daemons simultaneously (e.g vstart.sh) metadata for some of them might be missing in store. After debugging this, the root cause looks like is that in MDSMonitor::update_metadata() we read last metadata from the store, add a new metadata with the daemon to the transaction, and trigger propose, so metadata eventually are updated in the store. But it is possible that during this time window (read metadata from the store, write to the store) another update_metadata() happens which reads old metadata (without the new mds from the first update), and when it is committed the new mds from the first update is lost. I have not found the solution for this issue yet though.

Also this pull request fixes the crash when runnig with 'debug paxos = 30'.