### PR TITLE
erasure-code: do not hide overloaded ErasureCode::parse()

### DIFF
--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -78,9 +78,6 @@ namespace ceph {
                               const map<int, bufferlist> &chunks,
                               map<int, bufferlist> *decoded);
 
-    virtual int parse(const ErasureCodeProfile &profile,
-		      ostream *ss);
-
     virtual const vector<int> &get_chunk_mapping() const;
 
     int to_mapping(const ErasureCodeProfile &profile,
@@ -106,6 +103,10 @@ namespace ceph {
 
     virtual int decode_concat(const map<int, bufferlist> &chunks,
 			      bufferlist *decoded);
+
+  protected:
+    int parse(const ErasureCodeProfile &profile,
+	      ostream *ss);
 
   private:
     int chunk_index(unsigned int i) const;

--- a/src/erasure-code/isa/ErasureCodeIsa.h
+++ b/src/erasure-code/isa/ErasureCodeIsa.h
@@ -108,11 +108,11 @@ public:
 
   virtual unsigned get_alignment() const = 0;
 
-  virtual int parse(ErasureCodeProfile &profile,
-                    ostream *ss) = 0;
-
   virtual void prepare() = 0;
 
+ private:
+  virtual int parse(ErasureCodeProfile &profile,
+                    ostream *ss) = 0;
 };
 
 // -----------------------------------------------------------------------------
@@ -157,12 +157,11 @@ public:
 
   virtual unsigned get_alignment() const;
 
-  virtual int parse(ErasureCodeProfile &profile,
-                    ostream *ss);
-
   virtual void prepare();
 
-
+ private:
+  virtual int parse(ErasureCodeProfile &profile,
+                    ostream *ss);
 };
 
 #endif

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -51,8 +51,6 @@ public:
 
   virtual ~ErasureCodeJerasure() {}
   
-  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
-
   virtual int create_ruleset(const string &name,
 			     CrushWrapper &crush,
 			     ostream *ss) const;
@@ -86,6 +84,8 @@ public:
   virtual unsigned get_alignment() const = 0;
   virtual void prepare() = 0;
   static bool is_prime(int value);
+protected:
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
 };
 
 class ErasureCodeJerasureReedSolomonVandermonde : public ErasureCodeJerasure {
@@ -113,8 +113,9 @@ public:
                                char **coding,
                                int blocksize);
   virtual unsigned get_alignment() const;
-  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   virtual void prepare();
+private:
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
 };
 
 class ErasureCodeJerasureReedSolomonRAID6 : public ErasureCodeJerasure {
@@ -141,8 +142,9 @@ public:
                                char **coding,
                                int blocksize);
   virtual unsigned get_alignment() const;
-  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   virtual void prepare();
+private:
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
 };
 
 #define DEFAULT_PACKETSIZE "2048"
@@ -177,8 +179,9 @@ public:
                                char **coding,
                                int blocksize);
   virtual unsigned get_alignment() const;
-  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   void prepare_schedule(int *matrix);
+private:
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
 };
 
 class ErasureCodeJerasureCauchyOrig : public ErasureCodeJerasureCauchy {
@@ -230,8 +233,9 @@ public:
   virtual bool check_packetsize(ostream *ss) const;
   virtual int revert_to_default(ErasureCodeProfile &profile,
 				ostream *ss);
-  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   virtual void prepare();
+private:
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
 };
 
 class ErasureCodeJerasureBlaumRoth : public ErasureCodeJerasureLiberation {
@@ -255,8 +259,9 @@ public:
     DEFAULT_W = "8";
   }
 
-  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
   virtual void prepare();
+private:
+  virtual int parse(ErasureCodeProfile &profile, ostream *ss);
 };
 
 #endif

--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -115,8 +115,9 @@ public:
 			  char **coding,
 			  int blocksize) = 0;
   virtual unsigned get_alignment() const = 0;
-  virtual int parse(const ErasureCodeProfile &profile) = 0;
   virtual void prepare() = 0;
+private:
+  virtual int parse(const ErasureCodeProfile &profile) = 0;
 };
 
 class ErasureCodeShecReedSolomonVandermonde : public ErasureCodeShec {
@@ -139,8 +140,9 @@ public:
 			  char **coding,
 			  int blocksize);
   virtual unsigned get_alignment() const;
-  virtual int parse(const ErasureCodeProfile &profile);
   virtual void prepare();
+private:
+  virtual int parse(const ErasureCodeProfile &profile);
 };
 
 #endif


### PR DESCRIPTION
* this change fix the warning from clang:
  ErasureCodeJerasure::parse' hides overloaded virtual function
  [-Woverloaded-virtual]
* some erasure codecs' ErasureCode::parse() rewrite the profile
  using the default values if when parsing it if the corresponding
  items are not specified. and we don't call ErasureCode::parse()
  via its children's references. so no need to make it a virtual
  function.
* and ErasureCode::parse() is used as a helper function by its
  children, so make it `proceted`
* and parse() in ErasureCode's children is but a helper function
  called by ctor, descendants' parse() and init() so make them
  protected or private accordingly.

Signed-off-by: Kefu Chai <kchai@redhat.com>