### PR TITLE
XIO: Add missing fastpath events to OSD

### DIFF
--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -178,6 +178,7 @@ int XioConnection::passive_setup()
 
   /* notify hook */
   msgr->ms_deliver_handle_accept(this);
+  msgr->ms_deliver_handle_fast_accept(this);
 
   /* try to insert in conns_entity_map */
   msgr->try_insert(this);

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -461,6 +461,7 @@ int XioMessenger::session_event(struct xio_session *session,
 
     /* notify hook */
     this->ms_deliver_handle_connect(xcon);
+    this->ms_deliver_handle_fast_connect(xcon);
   }
   break;
 


### PR DESCRIPTION
Without this incoming fastpath messages will be dropped at OSD due to missing OSD::Session

Signed-off-by: Raju Kurunkad <raju.kurunkad@sandisk.com>