### PR TITLE
rgw: init-radosgw: try to run RGW as www-data first

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -45,7 +45,11 @@ done
 PREFIX='client.radosgw.'
 
 # user to run radosgw as (if not specified in ceph.conf)
-DEFAULT_USER='root'
+# will try use `www-data` first and then `root` if not found
+if id -u 'www-data' > /dev/null 2>&1; then
+    DEFAULT_USER='www-data'
+else
+    DEFAULT_USER='root'
 
 RADOSGW=`which radosgw`
 if [ ! -x "$RADOSGW" ]; then


### PR DESCRIPTION
If www-data user is not found then fall back to root.
This will get some backward compatibility for old setups.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>