### PR TITLE
Make librados pool_create respect default_crush_ruleset

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -553,7 +553,7 @@ bool librados::RadosClient::put() {
 }
  
 int librados::RadosClient::pool_create(string& name, unsigned long long auid,
-				       __u8 crush_rule)
+				       int16_t crush_rule)
 {
   int r = wait_for_osdmap();
   if (r < 0) {
@@ -580,7 +580,7 @@ int librados::RadosClient::pool_create(string& name, unsigned long long auid,
 
 int librados::RadosClient::pool_create_async(string& name, PoolAsyncCompletionImpl *c,
 					     unsigned long long auid,
-					     __u8 crush_rule)
+					     int16_t crush_rule)
 {
   int r = wait_for_osdmap();
   if (r < 0)

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -101,9 +101,15 @@ public:
   int get_pool_stats(std::list<string>& ls, map<string,::pool_stat_t>& result);
   int get_fs_stats(ceph_statfs& result);
 
-  int pool_create(string& name, unsigned long long auid=0, __u8 crush_rule=0);
+  /*
+  -1 was set as the default value and monitor will pickup the right crush rule with below order:
+    a) osd pool default crush replicated ruleset
+    b) the first ruleset in crush ruleset
+    c) error out if no value find
+  */
+  int pool_create(string& name, unsigned long long auid=0, int16_t crush_rule=-1);
   int pool_create_async(string& name, PoolAsyncCompletionImpl *c, unsigned long long auid=0,
-			__u8 crush_rule=0);
+			int16_t crush_rule=-1);
   int pool_get_base_tier(int64_t pool_id, int64_t* base_tier);
   int pool_delete(const char *name);
 

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1462,7 +1462,7 @@ public:
     Context *onfinish, *ontimeout;
     int pool_op;
     uint64_t auid;
-    __u8 crush_rule;
+    int16_t crush_rule;
     snapid_t snapid;
     bufferlist *blp;
 


### PR DESCRIPTION
Make pool_create in librados use the osd_pool_default_crush_replicated_ruleset

Fixes: #11640

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>