### PR TITLE
Adding a generic framework to integrate any backend for keyvaluestore

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1827,6 +1827,7 @@ def main_prepare(args):
             prepare_dir(
                 path=args.data,
                 journal=journal_symlink,
+                dbstore_symlink=None,
                 cluster_uuid=args.cluster_uuid,
                 osd_uuid=args.osd_uuid,
                 journal_uuid=journal_uuid,

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -85,6 +85,8 @@ DMCRYPT_LUKS_OSD_UUID =     '4fbd7e29-9d25-41b8-afd0-35865ceff05d'
 TOBE_UUID =                 '89c57f98-2fe5-4dc0-89c1-f3ad0ceff2be'
 DMCRYPT_TOBE_UUID =         '89c57f98-2fe5-4dc0-89c1-5ec00ceff2be'
 DMCRYPT_JOURNAL_TOBE_UUID = '89c57f98-2fe5-4dc0-89c1-35865ceff2be'
+OSD_DB_UUID =               '4fbd7e29-9d25-41b8-afd0-062c0ceff05d'
+DMCRYPT_OSD_DB_UUID =       '4fbd7e29-9d25-41b8-afd0-5ec00ceff05d'
 
 DEFAULT_FS_TYPE = 'xfs'
 
@@ -1253,6 +1255,16 @@ def prepare_journal_dev(
     except subprocess.CalledProcessError as e:
         raise Error(e)
 
+def prepare_dbstore_file(dbstore_file):
+    if not os.path.exists(dbstore_file):
+        LOG.debug('Creating dbstore file %s with size 0', dbstore_file)
+        with file(dbstore_file, 'wb') as db_file:
+            pass
+
+    LOG.debug('dbstore file is %s',dbstore_file)
+    return dbstore_file
+
+
 def prepare_journal_file(
     journal):
 
@@ -1330,6 +1342,7 @@ def adjust_symlink(target, path):
 def prepare_dir(
     path,
     journal,
+    dbstore_symlink,
     cluster_uuid,
     osd_uuid,
     journal_uuid,
@@ -1345,6 +1358,9 @@ def prepare_dir(
     if osd_uuid is None:
         osd_uuid = str(uuid.uuid4())
 
+    if dbstore_symlink is not None:
+        dbstore_file = prepare_dbstore_file(os.path.join(path, 'dbstore'))
+        adjust_symlink(dbstore_symlink, dbstore_file)
     if journal is not None:
         # we're using an external journal; point to it here
         adjust_symlink(journal, os.path.join(path, 'journal'))
@@ -1378,6 +1394,8 @@ def prepare_dev(
     journal_uuid,
     journal_dmcrypt,
     osd_dm_keypath,
+    keyvalue_store,
+    dbstore,
     cryptsetup_parameters,
     luks
     ):
@@ -1407,19 +1425,70 @@ def prepare_dev(
     else:
         LOG.debug('Creating osd partition on %s', data)
         try:
-            command_check_call(
-                [
-                    'sgdisk',
-                    '--largest-new=1',
-                    '--change-name=1:ceph data',
-                    '--partition-guid=1:{osd_uuid}'.format(
-                        osd_uuid=osd_uuid,
-                        ),
-                    '--typecode=1:%s' % ptype_tobe,
-                    '--',
-                    data,
-                ],
-            )
+            if keyvalue_store and dbstore:
+                num = 1
+                data_size = 10240
+                data_part = '{num}:0:{size}M'.format(
+                    num=num,
+                    size=data_size,
+                )
+                print "num : "+str(num)+" data+size: "+str(data_size)+" data_part:"+str(data_part)
+                try:
+                    LOG.debug('Creating osd partition num %d size %d on %s', num, data_size, data_part)
+                    #LOG.debug('Creating osdi partition  on %s', journal)
+                    print " creating ceph data"
+                    command_check_call(
+                        [
+                            'sgdisk',
+                            '--new={part}'.format(part=data_part),
+                            '--change-name={num}:ceph data'.format(num=num),
+                            '--partition-guid={num}:{osd_uuid}'.format(
+                                num=num,
+                                osd_uuid=osd_uuid,
+                            ),
+                            '--typecode={num}:{uuid}'.format(
+                                num=num,
+                                uuid=ptype_tobe,
+                            ),
+                            '--mbrtogpt',
+                            '--',
+                            data,
+                        ],
+                    )
+
+                except subprocess.CalledProcessError as e:
+                    raise Error(e)
+                ptype_tobe_db = OSD_DB_UUID
+                osd_db_uuid = str(uuid.uuid4())
+                print "ceph db data "
+                command_check_call(
+                    [
+                        'sgdisk',
+                        '--largest-new=2',
+                        '--change-name=2:ceph db data',
+                        '--partition-guid=2:{osd_db_uuid}'.format(
+                            osd_db_uuid=osd_db_uuid,
+                            ),
+                        '--typecode=2:%s' % ptype_tobe_db,
+                        '--',
+                        data,
+                    ],
+                )
+            else:
+                print " if not dbstore"
+                command_check_call(
+                    [
+                        'sgdisk',
+                        '--largest-new=1',
+                        '--change-name=1:ceph data',
+                        '--partition-guid=1:{osd_uuid}'.format(
+                            osd_uuid=osd_uuid,
+                            ),
+                        '--typecode=1:%s' % ptype_tobe,
+                        '--',
+                        data,
+                    ],
+                )
             update_partition('-a', data, 'created')
             command(
                 [
@@ -1468,14 +1537,42 @@ def prepare_dev(
         path = mount(dev=dev, fstype=fstype, options=mount_options)
 
         try:
-            prepare_dir(
-                path=path,
-                journal=journal,
-                cluster_uuid=cluster_uuid,
-                osd_uuid=osd_uuid,
-                journal_uuid=journal_uuid,
-                journal_dmcrypt=journal_dmcrypt,
+            if keyvalue_store and dbstore:
+                print "calling prepare_dir1"
+                dbstore_symlink = '/dev/disk/by-partuuid/{osd_db_uuid}'.format(
+                osd_db_uuid=osd_db_uuid,
                 )
+
+                prepare_dir(
+                    path=path,
+                    journal=journal,
+                    dbstore_symlink=dbstore_symlink,
+                    cluster_uuid=cluster_uuid,
+                    osd_uuid=osd_uuid,
+                    journal_uuid=journal_uuid,
+                    journal_dmcrypt=journal_dmcrypt,
+                    )
+
+            if keyvalue_store and not dbstore:
+                prepare_dir(
+                    path=path,
+                    journal=journal,
+                    dbstore_symlink=None,
+                    cluster_uuid=cluster_uuid,
+                    osd_uuid=osd_uuid,
+                    journal_uuid=None,
+                    journal_dmcrypt=None,
+                    )
+            else:
+                prepare_dir(
+                    path=path,
+                    journal=journal,
+                    dbstore_symlink=None,
+                    cluster_uuid=cluster_uuid,
+                    osd_uuid=osd_uuid,
+                    journal_uuid=journal_uuid,
+                    journal_dmcrypt=journal_dmcrypt,
+                    )
         finally:
             unmount(path)
     finally:
@@ -1494,6 +1591,9 @@ def prepare_dev(
             )
         except subprocess.CalledProcessError as e:
             raise Error(e)
+
+def prepare_dbstore(data):
+    pass
 
 def check_journal_reqs(args):
     _, allows_journal = command([
@@ -1593,11 +1693,14 @@ def main_prepare(args):
                     ),
                 )
 
-        journal_size = get_conf_with_default(
+        obstore = get_conf_with_default(
             cluster=args.cluster,
-            variable='osd_journal_size',
+            variable='osd_objectstore',
             )
-        journal_size = int(journal_size)
+        keyvaluestore_backend = get_conf_with_default(
+            cluster=args.cluster,
+            variable='keyvaluestore_backend',
+            )
 
         cryptsetup_parameters_str = get_conf(
             cluster=args.cluster,
@@ -1671,21 +1774,50 @@ def main_prepare(args):
                 journal_dm_keypath = get_or_create_dmcrypt_key(args.journal_uuid, args.dmcrypt_key_dir, dmcrypt_keysize, luks)
             osd_dm_keypath = get_or_create_dmcrypt_key(args.osd_uuid, args.dmcrypt_key_dir, dmcrypt_keysize, luks)
 
+
+        if obstore == "keyvaluestore":
+            journal_symlink = None
+            journal_dmcrypt = None
+            journal_uuid = None
+            journal_size = None
+            args.journal = None
+            journal_dm_keypath = None
+            if args.dmcrypt:
+                journal_dm_keypath = None
+                osd_dm_keypath = get_or_create_dmcrypt_key(args.osd_uuid, args.dmcrypt_key_dir)
+        else:
+            journal_size = get_conf_with_default(
+                cluster=args.cluster,
+                variable='osd_journal_size',
+                )
+            journal_size = int(journal_size)
+
+            # colocate journal with data?
+            if stat.S_ISBLK(dmode) and not is_partition(args.data) and args.journal is None and args.journal_file is None:
+                LOG.info('Will colocate journal with data on %s', args.data)
+                args.journal = args.data
+
+            if args.journal_uuid is None:
+                args.journal_uuid = str(uuid.uuid4())
+            if args.osd_uuid is None:
+                args.osd_uuid = str(uuid.uuid4())
+
+            # dm-crypt keys?
+            if args.dmcrypt:
+                journal_dm_keypath = get_or_create_dmcrypt_key(args.journal_uuid, args.dmcrypt_key_dir)
+                osd_dm_keypath = get_or_create_dmcrypt_key(args.osd_uuid, args.dmcrypt_key_dir)
+
         # prepare journal
-        journal_symlink = None
-        journal_dmcrypt = None
-        journal_uuid = None
-        if args.journal:
-            (journal_symlink, journal_dmcrypt, journal_uuid) = prepare_journal(
-                data=args.data,
-                journal=args.journal,
-                journal_size=journal_size,
-                journal_uuid=args.journal_uuid,
-                force_file=args.journal_file,
-                force_dev=args.journal_dev,
-                journal_dm_keypath=journal_dm_keypath,
-                cryptsetup_parameters=cryptsetup_parameters,
-                luks=luks
+        (journal_symlink, journal_dmcrypt, journal_uuid) = prepare_journal(
+            data=args.data,
+            journal=args.journal,
+            journal_size=journal_size,
+            journal_uuid=args.journal_uuid,
+            force_file=args.journal_file,
+            force_dev=args.journal_dev,
+            journal_dm_keypath=journal_dm_keypath,
+            cryptsetup_parameters=cryptsetup_parameters,
+            luks=luks
             )
 
         # prepare data
@@ -1714,6 +1846,8 @@ def main_prepare(args):
                 journal_uuid=journal_uuid,
                 journal_dmcrypt=journal_dmcrypt,
                 osd_dm_keypath=osd_dm_keypath,
+                keyvalue_store = (obstore == "keyvaluestore"),
+                dbstore = (keyvaluestore_backend == "pluggabledb"),
                 cryptsetup_parameters=cryptsetup_parameters,
                 luks=luks
                 )
@@ -1762,20 +1896,45 @@ def mkfs(
             ],
         )
 
-    command_check_call(
-        [
-            'ceph-osd',
-            '--cluster', cluster,
-            '--mkfs',
-            '--mkkey',
-            '-i', osd_id,
-            '--monmap', monmap,
-            '--osd-data', path,
-            '--osd-journal', os.path.join(path, 'journal'),
-            '--osd-uuid', fsid,
-            '--keyring', os.path.join(path, 'keyring'),
-            ],
-        )
+    obstore = get_conf_with_default(
+            cluster=cluster,
+            variable='osd_objectstore',
+            )
+    keyvaluestore_backend = get_conf_with_default(
+            cluster=cluster,
+            variable='keyvaluestore_backend',
+            )
+    if obstore == "keyvaluestore" and  keyvaluestore_backend == "pluggabledb":
+        print "Backend is pluggabledb"
+        command_check_call(
+            [
+                'ceph-osd',
+                '--cluster', cluster,
+                '--mkfs',
+                '--mkkey',
+                '-i', osd_id,
+                '--monmap', monmap,
+                '--osd-data', path,
+                '--osd-uuid', fsid,
+                '--keyring', os.path.join(path, 'keyring'),
+                ],
+            )
+    else:
+        command_check_call(
+            [
+                'ceph-osd',
+                '--cluster', cluster,
+                '--mkfs',
+                '--mkkey',
+                '-i', osd_id,
+                '--monmap', monmap,
+                '--osd-data', path,
+                '--osd-journal', os.path.join(path, 'journal'),
+                '--osd-uuid', fsid,
+                '--keyring', os.path.join(path, 'keyring'),
+                ],
+            )
+
     # TODO ceph-osd --mkfs removes the monmap file?
     # os.unlink(monmap)
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -858,6 +858,7 @@ OPTION(keyvaluestore_max_expected_write_size, OPT_U64, 1ULL << 24) // bytes
 OPTION(keyvaluestore_header_cache_size, OPT_INT, 4096)    // Header cache size
 OPTION(keyvaluestore_backend, OPT_STR, "leveldb")
 OPTION(keyvaluestore_dump_file, OPT_STR, "")         // file onto which store transaction dumps
+OPTION(keyvaluestore_backend_library, OPT_STR, "")
 
 // max bytes to search ahead in journal searching for corruption
 OPTION(journal_max_corrupt_search, OPT_U64, 10<<20)

--- a/src/os/KeyValueDB.cc
+++ b/src/os/KeyValueDB.cc
@@ -3,6 +3,7 @@
 
 #include "KeyValueDB.h"
 #include "LevelDBStore.h"
+#include "PluggableDBStore.h"
 #ifdef HAVE_LIBROCKSDB
 #include "RocksDBStore.h"
 #endif
@@ -15,6 +16,9 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 {
   if (type == "leveldb") {
     return new LevelDBStore(cct, dir);
+  }
+  if (type == "pluggabledb") {
+    return new PluggableDBStore(cct);
   }
 #ifdef HAVE_KINETIC
   if (type == "kinetic" &&
@@ -35,6 +39,9 @@ int KeyValueDB::test_init(const string& type, const string& dir)
 {
   if (type == "leveldb") {
     return LevelDBStore::_test_init(dir);
+  }
+  if (type == "pluggabledb") {
+    return PluggableDBStore::_test_init();
   }
 #ifdef HAVE_KINETIC
   if (type == "kinetic") {

--- a/src/os/KeyValueDB.h
+++ b/src/os/KeyValueDB.h
@@ -145,6 +145,9 @@ public:
     string key() {
       return generic_iter->key();
     }
+    pair<string,string> raw_key() {
+	  return generic_iter->raw_key();
+	}
     bufferlist value() {
       return generic_iter->value();
     }
@@ -176,6 +179,7 @@ public:
   }
 
   virtual uint64_t get_estimated_size(map<string,uint64_t> &extra) = 0;
+  virtual int get_statfs(struct statfs *buf) { int r = 0; return r; }
 
   virtual ~KeyValueDB() {}
 

--- a/src/os/KeyValueDB.h
+++ b/src/os/KeyValueDB.h
@@ -179,7 +179,9 @@ public:
   }
 
   virtual uint64_t get_estimated_size(map<string,uint64_t> &extra) = 0;
-  virtual int get_statfs(struct statfs *buf) { int r = 0; return r; }
+  virtual int get_statfs(struct statfs *buf) {
+    return -EOPNOTSUPP;
+  }
 
   virtual ~KeyValueDB() {}
 

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -582,13 +582,12 @@ KeyValueStore::~KeyValueStore()
 
 int KeyValueStore::statfs(struct statfs *buf)
 {
-  if (g_conf->keyvaluestore_backend != "pluggabledb") {
+  int r = backend->db->get_statfs(buf);
+  if (r < 0) {
     if (::statfs(basedir.c_str(), buf) < 0) {
       int r = -errno;
       return r;
     }
-  } else {
-    backend->db->get_statfs(buf);
   }
   return 0;
 }

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -582,7 +582,7 @@ KeyValueStore::~KeyValueStore()
 
 int KeyValueStore::statfs(struct statfs *buf)
 {
-  if (g_conf->keyvaluestore_backend != "propdb") {
+  if (g_conf->keyvaluestore_backend != "pluggabledb") {
     if (::statfs(basedir.c_str(), buf) < 0) {
       int r = -errno;
       return r;

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -582,9 +582,13 @@ KeyValueStore::~KeyValueStore()
 
 int KeyValueStore::statfs(struct statfs *buf)
 {
-  if (::statfs(basedir.c_str(), buf) < 0) {
-    int r = -errno;
-    return r;
+  if (g_conf->keyvaluestore_backend != "propdb") {
+    if (::statfs(basedir.c_str(), buf) < 0) {
+      int r = -errno;
+      return r;
+    }
+  } else {
+    backend->db->get_statfs(buf);
   }
   return 0;
 }

--- a/src/os/KeyValueStore.h
+++ b/src/os/KeyValueStore.h
@@ -217,7 +217,7 @@ class KeyValueStore : public ObjectStore,
 
   string strip_object_key(uint64_t no) {
     char n[100];
-    snprintf(n, 100, "%lld", (long long)no);
+    snprintf(n, 100, "%08lld", (long long)no);
     return string(n);
   }
 

--- a/src/os/Makefile.am
+++ b/src/os/Makefile.am
@@ -17,13 +17,13 @@ libos_la_SOURCES = \
 	os/IndexManager.cc \
 	os/JournalingObjectStore.cc \
 	os/LevelDBStore.cc \
+	os/PluggableDBStore.cc \
 	os/LFNIndex.cc \
 	os/MemStore.cc \
 	os/KeyValueDB.cc \
 	os/KeyValueStore.cc \
 	os/ObjectStore.cc \
 	os/WBThrottle.cc \
-        os/KeyValueDB.cc \
 	common/TrackedOp.cc
 
 if LINUX
@@ -64,6 +64,9 @@ noinst_HEADERS += \
 	os/JournalingObjectStore.h \
 	os/KeyValueDB.h \
 	os/LevelDBStore.h \
+	os/PluggableDBStore.h \
+	os/PluggableDBInterfaces.h \
+	os/PluggableDBIterator.h \
 	os/LFNIndex.h \
 	os/MemStore.h \
 	os/KeyValueStore.h \

--- a/src/os/PluggableDBInterfaces.h
+++ b/src/os/PluggableDBInterfaces.h
@@ -1,0 +1,53 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 SanDisk
+ *
+ * Author: Varada Kari<varada.kari@sandisk.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it. 
+ *
+ */
+
+/*
+ *  Contains the interfaces what a backend DB plugin should implement to use DB
+ *  as keyvalue store backend adhearing to KeyValueDB semantics.
+ */
+#ifndef PLUGGABLEDB_INTERFACES_H
+#define PLUGGABLEDB_INTERFACES_H
+#include <string>
+#include <vector>
+#include "PluggableDBIterator.h"
+#include <stdint.h>
+
+using namespace std;
+
+enum DBOpType {
+  DB_OP_WRITE,
+  DB_OP_DELETE,
+};
+
+typedef struct value {
+  char *data;
+  uint64_t datalen;
+}value_t;
+
+typedef struct DBOp {
+  DBOpType type;
+  std::string data;
+}DBOp;
+      	  
+extern "C" {
+int dbinit(const char* osd_data, int osdid, std::map<string, string> *options);
+void dbclose();
+int submit_transaction(map<string, DBOp>& ops);
+value_t* getobject(const string& key);
+PluggableDBIterator* get_iterator();
+uint64_t getdbsize();
+int getstatfs(struct statfs *buf);
+}
+
+#endif

--- a/src/os/PluggableDBInterfaces.h
+++ b/src/os/PluggableDBInterfaces.h
@@ -44,7 +44,8 @@ extern "C" {
 int dbinit(const char* osd_data, int osdid, std::map<string, string> *options);
 void dbclose();
 int submit_transaction(map<string, DBOp>& ops);
-value_t* getobject(const string& key);
+int submit_transaction_sync(map<string, DBOp>& ops);
+value_t* getvalue(const string& key);
 PluggableDBIterator* get_iterator();
 uint64_t getdbsize();
 int getstatfs(struct statfs *buf);

--- a/src/os/PluggableDBIterator.h
+++ b/src/os/PluggableDBIterator.h
@@ -1,0 +1,39 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 SanDisk
+ *
+ * Author: Varada Kari<varada.kari@sandisk.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it
+ */
+
+/*
+ *  Contains the interfaces what an Iterator should implement in the backendDB
+ *  plugin to use Iterator functionality on the backend.
+ */
+#ifndef PLUGGABLEDB_ITERATOR_H
+#define PLUGGABLEDB_ITERATOR_H
+#include <string>
+using namespace std;
+
+  class PluggableDBIterator {
+  public:
+    virtual int seek_to_first() = 0;
+    virtual int seek_to_first(const string &prefix) = 0;
+    virtual int seek_to_last() = 0;
+    virtual int seek_to_last(const string &prefix) = 0;
+    virtual int upper_bound(const string &prefix) = 0;
+    virtual int lower_bound(const string &prefix) = 0;
+    virtual bool valid() = 0;
+    virtual int next() = 0;
+    virtual int prev() = 0;
+    virtual string key() = 0;
+    virtual string value() = 0;
+    virtual int status() = 0;
+    virtual ~PluggableDBIterator() { }
+  };
+#endif

--- a/src/os/PluggableDBStore.cc
+++ b/src/os/PluggableDBStore.cc
@@ -1,0 +1,481 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 SanDisk
+ *
+ * Author: Varada Kari<varada.kari@sandisk.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#include "common/ceph_crypto.h"
+#include <set>
+#include <map>
+#include <string>
+#include "include/memory.h"
+#include <errno.h>
+#include "common/perf_counters.h"
+#include "PluggableDBStore.h"
+#include <dlfcn.h>
+#include <sys/stat.h>
+
+#define dout_subsys ceph_subsys_keyvaluestore
+using std::string;
+
+#define numelems(a)      (sizeof(a)/sizeof(*(a)))
+
+bool PluggableDBStore::create_if_missing = false;
+
+/*
+ * Function pointers.
+ */
+static int
+(*ptr_init)(const char* osd_data, int osdid, map<string, string> *options);
+
+static void
+(*ptr_close)();
+
+static int
+(*ptr_submit_transaction)(map<string, DBOp>& ops);
+
+static PluggableDBIterator*
+(*ptr_get_iterator)();
+
+static value_t*
+(*ptr_getobject)(const string& key);
+
+static uint64_t
+(*ptr_getdbsize)();
+
+static int
+(*ptr_getstatfs)(struct statfs *buf);
+
+/*
+ * Linkage table.
+ */
+static struct {
+    const char *name;
+    void       *func;
+} table[] ={
+    { "dbinit",                &ptr_init},
+    { "dbclose",               &ptr_close},
+    { "submit_transaction",    &ptr_submit_transaction},
+    { "get_iterator",          &ptr_get_iterator},
+    { "getobject",             &ptr_getobject},
+    { "getdbsize",             &ptr_getdbsize},
+    { "getstatfs",             &ptr_getstatfs},
+};
+
+static void
+undefined(const char *sym)
+{
+	derr << "Undefined symbol" << sym << dendl;
+}
+
+/*
+ * init
+ */
+int
+PluggableDBStore::DBInit(const char* osd_data, int osdid, map<string, string> *options)
+{
+    if (unlikely(!ptr_init))
+        undefined("init");
+
+    return (*ptr_init)(osd_data, osdid, options);
+}
+
+/*
+ * close
+ */
+void
+PluggableDBStore::DBClose()
+{
+    if (unlikely(!ptr_close))
+        undefined("close");
+
+    (*ptr_close)();
+}
+
+/*
+ * submit TX
+ */
+int
+PluggableDBStore::DBSubmitTransaction(map<string, DBOp>& ops)
+{
+    if (unlikely(!ptr_submit_transaction))
+        undefined("submit_transaction");
+
+    return (*ptr_submit_transaction)(ops);
+}
+/*
+ * Get Iterator
+ */
+PluggableDBIterator*
+PluggableDBStore::DBGetIterator()
+{
+    if (unlikely(!ptr_get_iterator))
+        undefined("get_iterator");
+
+    return (*ptr_get_iterator)();
+}
+
+/*
+ * GetObject
+ */
+value_t*
+PluggableDBStore::DBGetObject(const string& key)
+{
+    if (unlikely(!ptr_getobject))
+        undefined("getobject");
+
+    return (*ptr_getobject)(key);
+}
+
+/*
+ * GetDBSize
+ */
+uint64_t
+PluggableDBStore::DBGetSize()
+{
+    if (unlikely(!ptr_getdbsize))
+        undefined("getobject");
+
+    return (*ptr_getdbsize)();
+}
+
+/*
+ * GetStatFs
+ */
+int
+PluggableDBStore::DBGetStatfs(struct statfs *buf)
+{
+    if (unlikely(!ptr_getstatfs))
+        undefined("getstatfs");
+
+    return (*ptr_getstatfs)(buf);
+}
+
+
+uint64_t PluggableDBStore::get_estimated_size(map<string,uint64_t> &extra) {
+	uint64_t size = DBGetSize();
+	extra["total"] = size;
+    return size;
+}
+
+int PluggableDBStore::get_statfs(struct statfs *buf) {
+    int r = DBGetStatfs(buf);
+
+    return r;
+}
+
+/*
+ * Given a pathname, assume it is a Store library and try loading it.
+ */
+int
+PluggableDBStore::load_symbols(const char *path)
+{
+    int i;
+    void  *dl = dlopen(path, RTLD_NOW);
+    char *err = dlerror();
+
+    if (!dl) {
+       derr <<" Error opening the library" << err << dendl;
+       return -1;
+    }
+	library = dl;
+    
+    int n = numelems(table);
+    for (i = 0; i < n; i++) {
+        const char *name = table[i].name;
+        void *func = dlsym(dl, name);
+        if (func) {
+            *(void **)table[i].func = func;
+	    } else {
+	       derr << "Error loading symbol: " << name << dendl;	
+    	   err = dlerror();
+           derr <<" Error loading symbol: " << err << dendl;
+	       return -1;
+	    }
+    }
+    return 0;
+}
+
+int PluggableDBStore::_test_init()
+{
+  dout(10) << __func__ << dendl;
+  PluggableDBStore::create_if_missing = true;
+  return 0;
+}
+
+int PluggableDBStore::getosdid()
+{
+  dout(30) << __func__ << dendl;
+  char *end;
+  const char *id = g_conf->name.get_id().c_str();
+  int whoami = strtol(id, &end, 10);
+  return whoami;
+}
+
+int PluggableDBStore::init(string opt_str)
+{
+  dout(10) << __func__ << opt_str << dendl;
+  int ret = load_symbols(g_conf->keyvaluestore_backend_library.c_str());
+  assert(ret ==0);
+  const char* path = g_conf->osd_data.data();
+  map<string, string> options;
+  if (PluggableDBStore::create_if_missing) {
+    options["create_if_missing"] = "true";
+  } else {
+    options["create_if_missing"] = "false";
+  }
+  int status = DBInit(path, getosdid(), &options);
+  assert(status);
+  init_done = true;
+  return 0;
+}
+
+int PluggableDBStore::do_open(ostream &out, bool create_if_missing)
+{
+  dout(10) << __func__ <<dendl;
+  if (!init_done) {
+    init(string());
+  }
+  PerfCountersBuilder plb(g_ceph_context, "db", l_PluggableDB_first, l_PluggableDB_last);
+  plb.add_u64_counter(l_PluggableDB_gets, "db_get");
+  plb.add_u64_counter(l_PluggableDB_txns, "db_transaction");
+  logger = plb.create_perf_counters();
+  cct->get_perfcounters_collection()->add(logger);
+  return 0;
+}
+
+PluggableDBStore::PluggableDBStore(CephContext *c) :
+  cct(c),
+  logger(NULL),init_done(false)
+{
+}
+
+PluggableDBStore::~PluggableDBStore()
+{
+  close();
+  dlclose(library);
+  delete logger;
+}
+
+void PluggableDBStore::close()
+{
+  //shutdown the DB backend
+  DBClose();
+  if (logger)
+    cct->get_perfcounters_collection()->remove(logger);
+}
+
+int PluggableDBStore::submit_transaction(KeyValueDB::Transaction t)
+{
+  dout(20) << __func__ <<dendl;
+  PluggableDBTransactionImpl * _t =
+    static_cast<PluggableDBTransactionImpl *>(t.get());
+
+  int ret = DBSubmitTransaction(_t->ops);
+  logger->inc(l_PluggableDB_txns);
+  return ret;
+}
+
+int PluggableDBStore::submit_transaction_sync(KeyValueDB::Transaction t)
+{
+  return submit_transaction(t);
+}
+
+void PluggableDBStore::PluggableDBTransactionImpl::set(
+  const string &prefix,
+  const string &k,
+  const bufferlist &to_set_bl)
+{
+  string key = combine_strings(prefix, k);
+  DBOp op;
+  op.type = DB_OP_WRITE;
+  string data;
+  to_set_bl.copy(0,to_set_bl.length(), data);
+  op.data = data;
+  ops[key] = op;
+}
+
+void PluggableDBStore::PluggableDBTransactionImpl::rmkey(const string &prefix,
+												         const string &k)
+{
+  string key = combine_strings(prefix, k);
+  DBOp op;
+  op.type = DB_OP_DELETE;
+  ops[key] = op;
+}
+
+void PluggableDBStore::PluggableDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
+{
+  KeyValueDB::Iterator it = db->get_iterator(prefix);
+  for (it->seek_to_first();
+       it->valid();
+       it->next()) {
+    pair<string,string> key1 = it->raw_key();
+    string key =  key1.first + "\001" + key1.second;
+    DBOp op;
+    op.type = DB_OP_DELETE;
+    ops[key] = op;
+  }
+}
+
+int PluggableDBStore::get(
+    const string &prefix,
+    const std::set<string> &keys,
+    std::map<string, bufferlist> *out
+    )
+{
+  dout(30) << __func__ << dendl;
+  for (std::set<string>::const_iterator i = keys.begin();
+       i != keys.end();
+       ++i) {
+    string key = combine_strings(prefix, *i);
+	value_t *value = DBGetObject(key);
+	if (value->datalen == 0) {
+		free(value);
+		break;
+	}
+	bufferlist bl;
+	bufferptr bp = buffer::claim_char(value->datalen, value->data);
+	bl.push_back(bp);
+    out->insert(make_pair(*i, bl));
+	free(value);
+  }
+  logger->inc(l_PluggableDB_gets);
+  return 0;
+}
+
+
+string PluggableDBStore::combine_strings(const string &prefix, const string &value)
+{
+  string out = prefix;
+  out.push_back(1);
+  out.append(value);
+  return out;
+}
+
+ceph::bufferlist PluggableDBStore::to_bufferlist(const string& obj)
+{
+  bufferlist bl;
+  bufferptr bp = buffer::create(obj.length());
+  memcpy(bp.c_str(), obj.data(), obj.length());
+  bl.push_back(bp);
+  return bl;
+}
+
+int PluggableDBStore::split_key(string in_prefix, string *prefix, string *key)
+{
+  dout(30) << __func__ << "Key : " << in_prefix << dendl;	
+  size_t prefix_len = in_prefix.find('\1');
+  if (prefix_len >= in_prefix.size())
+    return -EINVAL;
+
+  if (prefix)
+    *prefix = string(in_prefix, 0, prefix_len);
+  if (key)
+    *key= string(in_prefix, prefix_len + 1);
+  return 0;
+}
+
+PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::PluggableDBWholeSpaceIteratorImpl(PluggableDBStore *parent)
+	:store(parent)
+{
+		iter = store->DBGetIterator();
+}
+
+int PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::seek_to_first(const string &prefix)
+{
+  dout(30) << __func__ << " prefix: " << prefix << dendl;
+  iter->seek_to_first(prefix);
+  return 0;
+}
+
+int PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::seek_to_last()
+{
+  dout(30) << __func__ << dendl;
+  iter->seek_to_last();
+  return valid();
+}
+
+int PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::seek_to_last(const string &prefix)
+{
+  dout(30) << __func__ <<" prefix: " << prefix << dendl;
+  iter->seek_to_first(prefix);
+  while (valid()) {
+    pair<string,string> key = raw_key();
+    if (key.first == prefix)
+      next();
+    else
+      break;
+  }
+  return 0;
+}
+
+int PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::upper_bound(const string &prefix, const string &after) {
+  dout(30) << __func__ <<" prefix: " << prefix << " after: " <<  dendl;
+  string key = combine_strings(prefix, after);
+  iter->upper_bound(key);
+  return 0;
+}
+
+int PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::lower_bound(const string &prefix, const string &to) {
+  dout(30) << __func__ <<" Prefix: " << prefix <<" to: " << to << dendl;
+  string key = combine_strings(prefix, to);
+  iter->lower_bound(key);
+  return 0;
+}
+
+bool PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::valid() {
+  dout(30) << __func__ << ":" << iter->valid() << dendl;
+  return iter->valid();
+}
+
+int PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::next() {
+  string key_ = iter->key();
+  dout(30) << __func__ <<" key: "  << key_ << dendl;
+  string prefix, key;
+  split_key(key_, &prefix, &key);
+  return upper_bound(prefix, key);
+}
+
+int PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::prev() {
+  string key_ = iter->key();
+  dout(30) << __func__ << " key: " << key_ << dendl;
+  iter->prev();
+  return 0;
+}
+
+string PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::key() {
+  dout(30) << __func__ << dendl;
+  string key_ = iter->key();
+  string prefix, key;
+  split_key(key_, &prefix, &key);
+  return key;
+}
+
+pair<string,string> PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::raw_key() {
+  dout(30) << __func__ << dendl;
+  string key_ = iter->key();
+  string prefix, key;
+  split_key(key_, &prefix, &key);
+  return make_pair(prefix, key);
+}
+
+bufferlist PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::value() {
+  dout(30) << __func__ << dendl;
+  string value = iter->value();
+  return store->to_bufferlist(value);
+}
+
+int PluggableDBStore::PluggableDBWholeSpaceIteratorImpl::status() {
+  dout(30) << __func__ << dendl;
+  return 0;
+}

--- a/src/os/PluggableDBStore.h
+++ b/src/os/PluggableDBStore.h
@@ -62,12 +62,13 @@ class PluggableDBStore : public KeyValueDB {
   int do_open(ostream &out, bool create_if_missing);
   int getosdid();
   PluggableDBIterator* DBGetIterator();
-  value_t* DBGetObject(const string& key);
+  value_t* DBGetValue(const string& key);
   int DBInit(const char*, int, map<string, string>*);
   void DBClose();
   uint64_t DBGetSize();
   int DBGetStatfs(struct statfs *buf);
   int DBSubmitTransaction(map<string, DBOp>& ops);
+  int DBSubmitTransactionSync(map<string, DBOp>& ops);
   int load_symbols(const char *path);
   void load_dll(const char *path);
 public:

--- a/src/os/PluggableDBStore.h
+++ b/src/os/PluggableDBStore.h
@@ -1,0 +1,172 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 SanDisk
+ *
+ * Author: Varada Kari<varada.kari@sandisk.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it.
+ */
+
+/* 
+ * Contains a generic interface to integrate any backend DB in form a shared
+ * object. All needed interfaces should be implemented mentioned in
+ * PluggableDBInterfaces.h and PluggableDBIterator.h in the layer which
+ * interacts with the backend DB. 
+ */
+#ifndef PLUGGABLEDB_STORE_H
+#define PLUGGABLEDB_STORE_H
+
+#include "include/types.h"
+#include "include/buffer.h"
+#include "KeyValueDB.h"
+#include <set>
+#include <map>
+#include <string>
+#include "include/memory.h"
+#include <tr1/memory>
+#include <boost/scoped_ptr.hpp>
+#include <boost/thread/tss.hpp>
+#include <tr1/unordered_map>
+#include <errno.h>
+#include "common/errno.h"
+#include "common/dout.h"
+#include "include/assert.h"
+#include "common/Formatter.h"
+#include "common/ceph_context.h"
+#include "PluggableDBIterator.h"
+#include "PluggableDBInterfaces.h"
+#include <sys/stat.h>
+
+class PerfCounters;
+
+enum {
+  l_PluggableDB_first = 34400,
+  l_PluggableDB_gets,
+  l_PluggableDB_txns,
+  l_PluggableDB_last,
+};
+
+/**
+ * Interface to implement proprietary KeyValue stores
+ */
+class PluggableDBStore : public KeyValueDB {
+  CephContext *cct;
+  PerfCounters *logger;
+  bool init_done;
+  static bool create_if_missing;
+  void *library;
+  int do_open(ostream &out, bool create_if_missing);
+  int getosdid();
+  PluggableDBIterator* DBGetIterator();
+  value_t* DBGetObject(const string& key);
+  int DBInit(const char*, int, map<string, string>*);
+  void DBClose();
+  uint64_t DBGetSize();
+  int DBGetStatfs(struct statfs *buf);
+  int DBSubmitTransaction(map<string, DBOp>& ops);
+  int load_symbols(const char *path);
+  void load_dll(const char *path);
+public:
+  PluggableDBStore(CephContext *c);
+  ~PluggableDBStore();
+
+  static int _test_init();
+  int init(string opt_str);
+
+  // Opens underlying db
+  int open(ostream &out) {
+    return do_open(out, false);
+  }
+  // Creates underlying db if missing and opens it
+  int create_and_open(ostream &out) {
+    return do_open(out, true);
+  }
+
+  void close();
+
+  class PluggableDBTransactionImpl : public KeyValueDB::TransactionImpl {
+  public:
+	map<string, DBOp> ops;
+    PluggableDBStore *db;
+
+    PluggableDBTransactionImpl(PluggableDBStore *db) : db(db) {}
+    void set(
+      const string &prefix,
+      const string &k,
+      const bufferlist &bl);
+    void rmkey(
+      const string &prefix,
+      const string &k);
+    void rmkeys_by_prefix(
+      const string &prefix
+      );
+  };
+
+  KeyValueDB::Transaction get_transaction() {
+    return ceph::shared_ptr< PluggableDBTransactionImpl >(
+      new PluggableDBTransactionImpl(this));
+  }
+
+  int submit_transaction(KeyValueDB::Transaction t);
+  int submit_transaction_sync(KeyValueDB::Transaction t);
+  int get(
+    const string &prefix,
+    const std::set<string> &key,
+    std::map<string, bufferlist> *out
+    );
+
+  class PluggableDBWholeSpaceIteratorImpl :
+    public KeyValueDB::WholeSpaceIteratorImpl {
+    PluggableDBStore *store;
+    PluggableDBIterator *iter;
+
+  public:
+    PluggableDBWholeSpaceIteratorImpl(PluggableDBStore *parent);
+    virtual ~PluggableDBWholeSpaceIteratorImpl() {
+       delete iter;
+    }
+
+    int seek_to_first() {
+      return seek_to_first("");
+    }
+    int seek_to_first(const string &prefix);
+    int seek_to_last();
+    int seek_to_last(const string &prefix);
+    int upper_bound(const string &prefix, const string &after);
+    int lower_bound(const string &prefix, const string &to);
+    bool valid();
+    int next();
+    int prev();
+    string key();
+    pair<string,string> raw_key();
+    bufferlist value();
+    int status();
+  };
+
+  // Utility
+  static string combine_strings(const string &prefix, const string &value);
+  static int split_key(string in_prefix, string *prefix, string *key);
+  static bufferlist to_bufferlist(const string &in);
+  virtual uint64_t get_estimated_size(map<string,uint64_t> &extra);
+  virtual int get_statfs(struct statfs *buf);
+
+
+protected:
+  WholeSpaceIterator _get_iterator() {
+    return ceph::shared_ptr<KeyValueDB::WholeSpaceIteratorImpl>(
+								new PluggableDBWholeSpaceIteratorImpl(this));
+  }
+
+  // TODO: get a snapshot iterator, time being let us handle the AFS as
+  // snapshot
+  WholeSpaceIterator _get_snapshot_iterator() {
+    return _get_iterator();
+  }
+
+};
+
+#endif


### PR DESCRIPTION
1. Assumes a wrapper to the DB as a shared object.
2. Loads the symbols mentioned in PluggableDBInterfaces.h
3. Assumes iterator is implemented in the layer abstracting the DB
functionality.
4. KeyValueDB semantics have to honoured for the implementation.
5. Assumes generic read and write menchanisim with char pointers and length to
work any implementation of DB, C or C++.
6. Couldn't add verification checks as the backend DB can be running any
version.
7. ceph-disk is modified to a create a new partition for the DB to host.
8. DB abstration has to take care of statfs and estimated_size.
9. Modified ceph-osd.prestart.sh to add correct weight to the crush of the osd.

Signed-off-by: Varada Kari <varada.kari@sandisk.com>
Signed-off-by: Aanchal Agrawal <aanchal.agrawal@sandisk.com>