### PR TITLE
librbd: internal.cc: 1967: FAILED assert(watchers.size() == 1)

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1420,7 +1420,6 @@ reprotect_and_return_err:
         close_image(ictx);
         return -EBUSY;
       }
-      assert(watchers.size() == 1);
 
       ictx->md_lock.get_read();
       trim_image(ictx, 0, prog_ctx);


### PR DESCRIPTION
http://tracker.ceph.com/issues/12240