### PR TITLE
Remove git build-time dependency

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -57,7 +57,6 @@ Requires: systemd
 BuildRequires: sharutils
 %endif
 BuildRequires:	gcc-c++
-BuildRequires:	git
 BuildRequires:	boost-devel
 BuildRequires:	cryptsetup
 BuildRequires:	gdbm

--- a/src/make_version
+++ b/src/make_version
@@ -5,7 +5,11 @@ CEPH_VER_HEADER=
 NO_VERSION=0
 
 is_git() {
-    type git > /dev/null 2>&1 || { echo "Could not find git command. Please install. Aborting."; exit 1; }
+    type git > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Could not find git command. Assuming this is not a git repository, not updating .git_version"
+        return 1
+    fi
     git status > /dev/zero 2>&1;
     if [ $? -ne 0 ]; then
         echo "This is no git repository, not updating .git_version"


### PR DESCRIPTION
The git command is currently only needed in the src/make_version script.
However, we can simply avoid it by assuming that if the git command is
not installed then the current dir is not a git repo.

Note: Let this go through git builders before merging, please.