### PR TITLE
Yghannam workunit fixes blogbench ffsb

### DIFF
--- a/qa/workunits/suites/blogbench.sh
+++ b/qa/workunits/suites/blogbench.sh
@@ -6,6 +6,7 @@ wget http://ceph.com/qa/blogbench-1.0.tar.bz2
 #cp /home/gregf/src/blogbench-1.0.tar.bz2 .
 tar -xvf blogbench-1.0.tar.bz2
 cd blogbench*
+wget -O config.guess "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD"
 echo "making blogbench"
 ./configure
 make

--- a/qa/workunits/suites/ffsb.sh
+++ b/qa/workunits/suites/ffsb.sh
@@ -7,6 +7,7 @@ mydir=`dirname $0`
 wget http://ceph.com/qa/ffsb.tar.bz2
 tar jxvf ffsb.tar.bz2
 cd ffsb-*
+wget -O config.guess "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD"
 ./configure
 make
 cd ..


### PR DESCRIPTION
Get the latest config.guess file. 

A more recent config.guess is required to build on aarch64. However, this doesn't necessarily need to be fetched if the archives on http://ceph.com/qa/ are updated.