### PR TITLE
Workunits : fs/misc/chmod.sh : Include ACL characters in permission c…

### DIFF
--- a/qa/workunits/fs/misc/chmod.sh
+++ b/qa/workunits/fs/misc/chmod.sh
@@ -12,7 +12,9 @@ check_perms() {
 	fi
 
 	perms=$2
-	if test "${perms}" != $(echo ${r} | awk '{print $1}'); then
+	if test "${perms}" != $(echo ${r} | awk '{print $1}') && \
+           test "${perms}." != $(echo ${r} | awk '{print $1}') && \
+           test "${perms}+" != $(echo ${r} | awk '{print $1}'); then
 		echo "ERROR: Permissions should be ${perms}"
 		exit 1
 	fi


### PR DESCRIPTION
…heck.

Distros can use various access methods for files which are represented by extra characters ("." or "+") in their permissions. Include these when checking permissions in chmod.sh.

From (https://www.gnu.org/software/coreutils/manual/html_node/What-information-is-listed.html):
Following the file mode bits is a single character that specifies whether an alternate access method such as an access control list applies to the file. When the character following the file mode bits is a space, there is no alternate access method. When it is a printing character, then there is such a method.

GNU ls uses a ‘.’ character to indicate a file with a security context, but no other alternate access method.

A file with any other combination of alternate access methods is marked with a ‘+’ character.


Examples
Ubuntu 15.04:
-rw-rw-r-- 1 yghannam yghannam 0 Jul  9 04:47 test

Fedora 21:
-rw-r--r--. 1 yazen.ghannam users 0 Jul  9 04:47 test