### PR TITLE
ceph.spec.in: add missing -%{release}

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -252,7 +252,7 @@ object store.
 Summary:	RADOS striping interface
 Group:		System Environment/Libraries
 License:	LGPL-2.0
-Requires:	librados2 = %{epoch}:%{version}
+Requires:	librados2 = %{epoch}:%{version}-%{release}
 %description -n libradosstriper1
 Striping interface built on top of the rados library, allowing
 to stripe bigger objects onto several standard rados objects using


### PR DESCRIPTION
We have it everywhere else and I can't think of any reason why
is should be omitted here.

Signed-off-by: Nathan Cutler <ncutler@suse.com>