### PR TITLE
radosgw-admin: after subuser modify print only once user info

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1772,14 +1772,6 @@ int main(int argc, char **argv)
       return -ret;
     }
 
-    ret = user.info(info, &err_msg);
-    if (ret < 0) {
-      cerr << "could not fetch user info: " << err_msg << std::endl;
-      return -ret;
-    }
-
-    show_user_info(info, formatter);
-
     break;
   case OPT_SUBUSER_RM:
     ret = user.subusers.remove(user_op, &err_msg);


### PR DESCRIPTION
remove rgw_admin.cc OPT_SUBUSER_MODIFY, show_user_info code block.

  switch (opt_cmd) {
  ...
  case OPT_SUBUSER_MODIFY:
    show_user_info(info, formatter);                //show first time (remove this)
    break;
  ...
  }

  // output the result of a user operation
  if (output_user_info) {
    ...
    show_user_info(info, formatter);                //show second time
  }

test fix:
    before: after subuser modify print twice user info.
    after changes, do the same procedure, print only once user info.

Signed-off-by: guce <guce@h3c.com>