### PR TITLE
Simple Messenger optimization

### DIFF
--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -75,21 +75,19 @@ public:
   void set_snap_seq(const snapid_t& s) { snap_seq = s; }
 
   // Fields decoded in partial decoding
-  const pg_t&     get_pg() const { return pgid; }
-  epoch_t  get_map_epoch() { return osdmap_epoch; }
-  int get_flags() const { return flags; }
+  const pg_t&     get_pg() const { assert(partialDecoded); return pgid; }
+  epoch_t  get_map_epoch() { assert(partialDecoded); return osdmap_epoch; }
+  int get_flags() const { assert(partialDecoded); return flags; }
 
   // Fields decoded in final decoding
-  int get_client_inc() { return client_inc; }
-  utime_t get_mtime() { return mtime; }
-  const eversion_t& get_version() { return reassert_version; }
-  const object_locator_t& get_object_locator() const {
-    return oloc;
-  }
-  object_t& get_oid() { return oid; }
-  const snapid_t& get_snapid() { return snapid; }
-  const snapid_t& get_snap_seq() const { return snap_seq; }
-  const vector<snapid_t> &get_snaps() const { return snaps; }
+  int get_client_inc() { assert(finalDecoded); return client_inc; }
+  utime_t get_mtime() { assert(finalDecoded); return mtime; }
+  const eversion_t& get_version() { assert(finalDecoded); return reassert_version; }
+  const object_locator_t& get_object_locator() const { assert(finalDecoded); return oloc; }
+  object_t& get_oid() { assert(finalDecoded); return oid; }
+  const snapid_t& get_snapid() { assert(finalDecoded); return snapid; }
+  const snapid_t& get_snap_seq() const { assert(finalDecoded); return snap_seq; }
+  const vector<snapid_t> &get_snaps() const { assert(finalDecoded); return snaps; }
   /**
    * get retry attempt
    *
@@ -114,7 +112,7 @@ public:
     : Message(CEPH_MSG_OSD_OP, HEAD_VERSION, COMPAT_VERSION),
       client_inc(inc),
       osdmap_epoch(_osdmap_epoch), flags(_flags), retry_attempt(-1),
-      oid(_oid), oloc(_oloc), pgid(_pgid), partialDecoded(false), finalDecoded(false),
+      oid(_oid), oloc(_oloc), pgid(_pgid), partialDecoded(true), finalDecoded(false),
       features(feat) {
     set_tid(tid);
   }
@@ -428,7 +426,7 @@ struct ceph_osd_request_head {
       out << " RETRY=" << get_retry_attempt();
     if (reassert_version != eversion_t())
       out << " reassert_version=" << reassert_version;
-    if (get_snap_seq())
+    if (finalDecoded)
       out << " snapc " << get_snap_seq() << "=" << snaps;
     out << " " << ceph_osd_flag_string(get_flags());
     out << " e" << osdmap_epoch;

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -47,6 +47,7 @@ private:
   object_locator_t oloc;
   pg_t pgid;
   bufferlist::iterator p;
+  // decoding flags. Messages constructed in objecter are already decoded.
   bool partialDecoded;
   bool finalDecoded;
 public:
@@ -112,7 +113,7 @@ public:
     : Message(CEPH_MSG_OSD_OP, HEAD_VERSION, COMPAT_VERSION),
       client_inc(inc),
       osdmap_epoch(_osdmap_epoch), flags(_flags), retry_attempt(-1),
-      oid(_oid), oloc(_oloc), pgid(_pgid), partialDecoded(true), finalDecoded(false),
+      oid(_oid), oloc(_oloc), pgid(_pgid), partialDecoded(true), finalDecoded(true),
       features(feat) {
     set_tid(tid);
   }

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -47,7 +47,8 @@ private:
   object_locator_t oloc;
   pg_t pgid;
   bufferlist::iterator p;
-  // decoding flags. Messages constructed in objecter are already decoded.
+  // Decoding flags. Valuable only after catching message with pipe reader.
+  // For objecter constructor, both of them are set to true
   bool partialDecoded;
   bool finalDecoded;
 public:

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -366,7 +366,7 @@ struct ceph_osd_request_head {
   }
 
   void finish_decode() {
-    assert(partialDecoded);
+    assert(partialDecoded); // partial decoding required
 
     if (finalDecoded)
       return; //Message is already final decoded

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -326,34 +326,6 @@ struct ceph_osd_request_head {
 	::decode(pgid, p);
       }
 
-      ::decode(oid, p);
-
-      //::decode(ops, p);
-      __u16 num_ops;
-      ::decode(num_ops, p);
-      ops.resize(num_ops);
-      for (unsigned i = 0; i < num_ops; i++)
-	::decode(ops[i].op, p);
-
-      ::decode(snapid, p);
-      ::decode(snap_seq, p);
-      ::decode(snaps, p);
-
-      if (header.version >= 4)
-	::decode(retry_attempt, p);
-      else
-	retry_attempt = -1;
-
-      if (header.version >= 5)
-	::decode(features, p);
-      else
-	features = 0;
-
-      OSDOp::split_osd_op_vector_in_data(ops, data);
-
-      // In old versions, final decoding is done in first step
-      finalDecoded = true;
-
     } else { // Current version is 6
       // new, splitted decode to partial and final
       ::decode(pgid, p);
@@ -371,27 +343,56 @@ struct ceph_osd_request_head {
     if (finalDecoded)
       return; //Message is already final decoded
 
-    ::decode(client_inc, p);
-    ::decode(mtime, p);
-    ::decode(reassert_version, p);
-    ::decode(oloc, p);
-    ::decode(oid, p);
+    if (header.version < 6) {
+      ::decode(oid, p);
 
-    __u16 num_ops;
-    ::decode(num_ops, p);
-    ops.resize(num_ops);
-    for (unsigned i = 0; i < num_ops; i++)
-      ::decode(ops[i].op, p);
+      //::decode(ops, p);
+      __u16 num_ops;
+      ::decode(num_ops, p);
+      ops.resize(num_ops);
+      for (unsigned i = 0; i < num_ops; i++)
+        ::decode(ops[i].op, p);
 
-    ::decode(snapid, p);
-    ::decode(snap_seq, p);
-    ::decode(snaps, p);
+      ::decode(snapid, p);
+      ::decode(snap_seq, p);
+      ::decode(snaps, p);
 
-    ::decode(retry_attempt, p);
+      if (header.version >= 4)
+        ::decode(retry_attempt, p);
+      else
+        retry_attempt = -1;
 
-    ::decode(features, p);
+      if (header.version >= 5)
+        ::decode(features, p);
+      else
+        features = 0;
 
-    OSDOp::split_osd_op_vector_in_data(ops, data);
+      OSDOp::split_osd_op_vector_in_data(ops, data);
+
+    } else {
+      ::decode(client_inc, p);
+      ::decode(mtime, p);
+      ::decode(reassert_version, p);
+      ::decode(oloc, p);
+      ::decode(oid, p);
+
+      __u16 num_ops;
+      ::decode(num_ops, p);
+      ops.resize(num_ops);
+      for (unsigned i = 0; i < num_ops; i++)
+        ::decode(ops[i].op, p);
+
+      ::decode(snapid, p);
+      ::decode(snap_seq, p);
+      ::decode(snaps, p);
+
+      ::decode(retry_attempt, p);
+
+      ::decode(features, p);
+
+      OSDOp::split_osd_op_vector_in_data(ops, data);
+
+    }
 
     finalDecoded = true;
   }

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1245,10 +1245,6 @@ void ReplicatedPG::do_request(
   OpRequestRef& op,
   ThreadPool::TPHandle &handle)
 {
-  if (!op_has_sufficient_caps(op)) {
-    osd->reply_op_error(op, -EPERM);
-    return;
-  }
   assert(!op_must_wait_for_map(get_osdmap()->get_epoch(), op));
   if (can_discard_request(op)) {
     return;
@@ -1372,6 +1368,18 @@ void ReplicatedPG::do_op(OpRequestRef& op)
 {
   MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
   assert(m->get_type() == CEPH_MSG_OSD_OP);
+
+  m->finish_decode();
+  m->clear_payload();
+
+  if (op->rmw_flags == 0) {
+    int r = osd->osd->init_op_flags(op);
+    if (r) {
+      osd->reply_op_error(op, r);
+      return;
+    }
+  }
+
   if (op->includes_pg_op()) {
     if (pg_op_must_wait(m)) {
       wait_for_all_missing(op);
@@ -1380,10 +1388,55 @@ void ReplicatedPG::do_op(OpRequestRef& op)
     return do_pg_op(op);
   }
 
+  if (!op_has_sufficient_caps(op)) {
+    osd->reply_op_error(op, -EPERM);
+    return;
+  }
+
+  // object name too long?
+  unsigned max_name_len = MIN(g_conf->osd_max_object_name_len,
+                              osd->osd->store->get_max_object_name_length());
+  if (m->get_oid().name.size() > max_name_len) {
+    dout(4) << "do_op '" << m->get_oid().name << "' is longer than "
+            << max_name_len << " bytes" << dendl;
+    osd->reply_op_error(op, -ENAMETOOLONG);
+    return;
+  }
+
+  // blacklisted?
   if (get_osdmap()->is_blacklisted(m->get_source_addr())) {
     dout(10) << "do_op " << m->get_source_addr() << " is blacklisted" << dendl;
     osd->reply_op_error(op, -EBLACKLISTED);
     return;
+  }
+
+  if (op->may_write()) {
+    // full?
+    if ((osd->check_failsafe_full() ||
+         get_osdmap()->test_flag(CEPH_OSDMAP_FULL) ||
+         m->get_map_epoch() < osd->osd->superblock.last_map_marked_full) &&
+        !m->get_source().is_mds()) {  // FIXME: we'll exclude mds writes for now.
+      // Drop the request, since the client will retry when the full
+      // flag is unset.
+      return;
+    }
+
+    // invalid?
+    if (m->get_snapid() != CEPH_NOSNAP) {
+      osd->reply_op_error(op, -EINVAL);
+      return;
+    }
+
+    // too big?
+    if (cct->_conf->osd_max_write_size &&
+        m->get_data_len() > cct->_conf->osd_max_write_size << 20) {
+      // journal can't hold commit!
+      derr << "do_op msg data len " << m->get_data_len()
+           << " > osd_max_write_size " << (cct->_conf->osd_max_write_size << 20)
+           << " on " << *m << dendl;
+      osd->reply_op_error(op, -OSD_WRITETOOBIG);
+      return;
+    }
   }
 
   // order this op as a write?


### PR DESCRIPTION
Optimization of Simple Messenger according to Sage's proposition, consulted with other teams.
1. Couple of checks moved to parallelized workers
2. Message decoding splitted to partial and final decoding, and move final decoding to workers
3. Partial decoding optimized to contain only fields necessary to enqueue message to workers