### PR TITLE
ceph.spec.in: fix lttng/babeltrace conditionals

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -97,6 +97,7 @@ BuildRequires:  cmake
 BuildRequires:	cryptsetup
 BuildRequires:	gdbm
 BuildRequires:	hdparm
+BuildRequires:	leveldb-devel > 1.2
 BuildRequires:	libaio-devel
 BuildRequires:	libcurl-devel
 BuildRequires:	libedit-devel
@@ -104,10 +105,9 @@ BuildRequires:	libxml2-devel
 BuildRequires:	libblkid-devel >= 2.17
 BuildRequires:	libudev-devel
 BuildRequires:	libtool
-BuildRequires:	leveldb-devel > 1.2
 BuildRequires:	make
-BuildRequires:	perl
 BuildRequires:	parted
+BuildRequires:	perl
 BuildRequires:	pkgconfig
 BuildRequires:	python
 BuildRequires:	python-nose
@@ -158,6 +158,15 @@ Requires(preun):	chkconfig
 Requires(preun):	initscripts
 BuildRequires:	gperftools-devel
 Requires:	python-flask
+%endif
+# lttng and babeltrace for rbd-replay-prep
+%if 0%{?fedora} || 0%{?rhel} == 6
+BuildRequires:	lttng-ust-devel
+BuildRequires:	libbabeltrace-devel
+%endif
+%if 0%{?suse_version} >= 1310
+BuildRequires:	lttng-ust-devel
+BuildRequires:  babeltrace-devel
 %endif
 
 %description
@@ -371,10 +380,6 @@ Group:		System Environment/Libraries
 License:	LGPL-2.0
 Requires:	ceph-common
 Requires:	xmlstarlet
-%if (0%{?fedora} || 0%{?rhel} == 6)
-BuildRequires:	lttng-ust-devel
-BuildRequires:	libbabeltrace-devel
-%endif
 %description -n ceph-test
 This package contains Ceph benchmarks and test tools.
 
@@ -1093,7 +1098,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_mandir}/man8/rbd-replay-prep.8*
 %{_bindir}/rbd-replay
 %{_bindir}/rbd-replay-many
-%if (0%{?fedora} || 0%{?rhel} == 6)
+%if 0%{?fedora} || 0%{?rhel} == 6 || 0%{?suse_version} >= 1310
 %{_bindir}/rbd-replay-prep
 %endif
 %dir %{_libdir}/ceph


### PR DESCRIPTION
This commit makes sure that, for SLE/openSUSE, babeltrace-devel is a
BuildRequires and rbd-replay-prep is packaged.

Background quote from https://github.com/ceph/ceph/pull/5082 :

"Since we BuildRequire: libbabeltrace-devel, autoconf will see that babeltrace
is available during the build, and make will build/install the rbd-replay-prep
utility."

http://tracker.ceph.com/issues/12360 Fixes: #12360

Signed-off-by: Nathan Cutler <ncutler@suse.com>