### PR TITLE
ceph.spec.in: SUSE/openSUSE builds need libbz2-devel

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -39,7 +39,9 @@ Requires:	cryptsetup
 Requires(post):	binutils
 BuildRequires:	gcc-c++
 BuildRequires:	boost-devel
-%if ! 0%{defined suse_version}
+%if 0%{defined suse_version}
+BuildRequires:  libbz2-devel
+%else
 BuildRequires:  bzip2-devel
 %endif
 BuildRequires:	cryptsetup


### PR DESCRIPTION
http://tracker.ceph.com/issues/11629