### PR TITLE
tests: TEST_crush_reject_empty must not run a mon

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -61,11 +61,6 @@ function main() {
         echo "make check: successful run on $(git rev-parse HEAD)"
         return 0
     else
-        find . -name '*.trs' | xargs grep -l FAIL | while read file ; do
-            log=$(dirname $file)/$(basename $file .trs).log
-            echo FAIL: $log
-            cat $log
-        done
         return 1
     fi
 }

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -35,6 +35,9 @@ check_PROGRAMS =
 # tests scripts will be appended to this
 check_SCRIPTS =
 
+# display the output of failed check_SCRIPTS after a failed make check
+export VERBOSE = true
+
 # python unit tests need to know where the scripts are located
 export PYTHONPATH=$(top_srcdir)/src/pybind
 

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -435,7 +435,7 @@ int CrushTester::test_with_crushtool(const string& crushtool,
   // something else entirely happened
   // log it and consider an invalid crush map
   err << "error running crushmap through crushtool: " << cpp_strerror(r);
-  return -r;
+  return -EINVAL;
 }
 
 namespace {

--- a/src/test/mon/osd-crush.sh
+++ b/src/test/mon/osd-crush.sh
@@ -15,7 +15,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Library Public License for more details.
 #
-source test/mon/mon-test-helpers.sh
+source test/ceph-helpers.sh
 
 function run() {
     local dir=$1
@@ -30,7 +30,7 @@ function run() {
 	setup $dir || return 1
 	run_mon $dir a --public-addr $CEPH_MON
 	if ! $TEST_function $dir ; then
-	  cat $dir/a/log
+	  cat $dir/mon.a.log
 	  return 1
 	fi
 	teardown $dir || return 1
@@ -103,8 +103,8 @@ function TEST_crush_rule_create_erasure() {
     ./ceph osd erasure-code-profile rm default || return 1
     ! ./ceph osd erasure-code-profile ls | grep default || return 1
     ./ceph osd crush rule create-erasure $ruleset || return 1
-    CEPH_ARGS='' ./ceph --admin-daemon $dir/a/ceph-mon.a.asok log flush || return 1
-    grep 'profile default set' $dir/a/log || return 1
+    CEPH_ARGS='' ./ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+    grep 'profile default set' $dir/mon.a.log || return 1
     ./ceph osd erasure-code-profile ls | grep default || return 1
     ./ceph osd crush rule rm $ruleset || return 1
     ! ./ceph osd crush rule ls | grep $ruleset || return 1
@@ -190,7 +190,6 @@ function TEST_crush_rename_bucket() {
 
 function TEST_crush_reject_empty() {
     local dir=$1
-    run_mon $dir a || return 1
     # should have at least one OSD
     run_osd $dir 0 || return 1
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/12285 and http://tracker.ceph.com/issues/11975

this pull request adds some commits on top of #5195 to make `osd-crush.sh` tests happy.