### PR TITLE
mds: big refactor of MDS into MDSDaemon, MDSRank, MDSRank Dispatcher

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -236,10 +236,7 @@ int main(int argc, const char **argv)
 
   pidfile_remove();
 
-  // only delete if it was a clean shutdown (to aid memory leak
-  // detection, etc.).  don't bother if it was a suicide.
-  if (mds->is_stopped())
-    delete mds;
+  delete mds;
 
   g_ceph_context->put();
 

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -205,7 +205,7 @@ int main(int argc, const char **argv)
   mds->orig_argc = argc;
   mds->orig_argv = argv;
 
-  if (shadow)
+  if (shadow != MDSMap::STATE_NULL)
     r = mds->init(shadow);
   else
     r = mds->init();
@@ -237,6 +237,7 @@ int main(int argc, const char **argv)
   pidfile_remove();
 
   delete mds;
+  delete msgr;
 
   g_ceph_context->put();
 

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -26,7 +26,7 @@ using namespace std;
 #include "common/strtol.h"
 
 #include "mon/MonMap.h"
-#include "mds/MDS.h"
+#include "mds/MDSDaemon.h"
 
 #include "msg/Messenger.h"
 
@@ -78,7 +78,7 @@ static int parse_rank(const char *opt_name, const std::string &val)
 
 
 
-MDS *mds = NULL;
+MDSDaemon *mds = NULL;
 
 
 static void handle_mds_signal(int signum)
@@ -199,7 +199,7 @@ int main(int argc, const char **argv)
   msgr->start();
 
   // start mds
-  mds = new MDS(g_conf->name.get_id().c_str(), msgr, &mc);
+  mds = new MDSDaemon(g_conf->name.get_id().c_str(), msgr, &mc);
 
   // in case we have to respawn...
   mds->orig_argc = argc;

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -236,8 +236,12 @@ int main(int argc, const char **argv)
 
   pidfile_remove();
 
-  delete mds;
-  delete msgr;
+  // only delete if it was a clean shutdown (to aid memory leak
+  // detection, etc.).  don't bother if it was a suicide.
+  if (mds->is_clean_shutdown()) {
+    delete mds;
+    delete msgr;
+  }
 
   g_ceph_context->put();
 

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -246,6 +246,7 @@ struct ceph_mon_subscribe_ack {
 #define CEPH_MDS_STATE_STARTING    -7  /* up, starting previously stopped mds */
 #define CEPH_MDS_STATE_STANDBY_REPLAY -8 /* up, tailing active node's journal */
 #define CEPH_MDS_STATE_REPLAYONCE   -9 /* up, replaying an active node's journal */
+#define CEPH_MDS_STATE_NULL         -10
 
 #define CEPH_MDS_STATE_REPLAY       8  /* up, replaying journal. */
 #define CEPH_MDS_STATE_RESOLVE      9  /* up, disambiguating distributed

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -21,7 +21,7 @@
 #include "messages/MMDSBeacon.h"
 #include "mon/MonClient.h"
 #include "mds/MDLog.h"
-#include "mds/MDS.h"
+#include "mds/MDSRank.h"
 #include "mds/MDSMap.h"
 #include "mds/Locker.h"
 
@@ -283,7 +283,7 @@ void Beacon::notify_want_state(MDSMap::DaemonState const newstate)
  * some health metrics that we will send in the next
  * beacon.
  */
-void Beacon::notify_health(MDS const *mds)
+void Beacon::notify_health(MDSRank const *mds)
 {
   Mutex::Locker l(lock);
 

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -270,11 +270,16 @@ utime_t Beacon::get_laggy_until() const
   return laggy_until;
 }
 
-void Beacon::notify_want_state(MDSMap::DaemonState const newstate)
+void Beacon::set_want_state(MDSMap::DaemonState const newstate)
 {
   Mutex::Locker l(lock);
 
-  want_state = newstate;
+  if (want_state != newstate) {
+    dout(10) << __func__ << ": "
+      << ceph_mds_state_name(want_state) << " -> "
+      << ceph_mds_state_name(newstate) << dendl;
+    want_state = newstate;
+  }
 }
 
 
@@ -410,5 +415,11 @@ void Beacon::notify_health(MDSRank const *mds)
       large_completed_requests_metrics.clear();
     }
   }
+}
+
+MDSMap::DaemonState Beacon::get_want_state() const
+{
+  Mutex::Locker l(lock);
+  return want_state;
 }
 

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -302,6 +302,10 @@ void Beacon::set_want_state(MDSMap const *mdsmap, MDSMap::DaemonState const news
 void Beacon::notify_health(MDSRank const *mds)
 {
   Mutex::Locker l(lock);
+  if (!mds) {
+    // No MDS rank held
+    return;
+  }
 
   // I'm going to touch this MDS, so it must be locked
   assert(mds->mds_lock.is_locked_by_me());

--- a/src/mds/Beacon.h
+++ b/src/mds/Beacon.h
@@ -25,7 +25,7 @@
 class MonClient;
 class MMDSBeacon;
 class Message;
-class MDS;
+class MDSRank;
 
 
 /**
@@ -95,7 +95,7 @@ public:
 
   void notify_mdsmap(MDSMap const *mdsmap);
   void notify_want_state(MDSMap::DaemonState const newstate);
-  void notify_health(MDS const *mds);
+  void notify_health(MDSRank const *mds);
 
   void set_standby_for(mds_rank_t rank_, std::string const &name_);
 

--- a/src/mds/Beacon.h
+++ b/src/mds/Beacon.h
@@ -101,7 +101,7 @@ public:
   void handle_mds_beacon(MMDSBeacon *m);
   void send();
 
-  void set_want_state(MDSMap::DaemonState const newstate);
+  void set_want_state(MDSMap const *mdsmap, MDSMap::DaemonState const newstate);
   MDSMap::DaemonState get_want_state() const;
 
   /**

--- a/src/mds/Beacon.h
+++ b/src/mds/Beacon.h
@@ -94,13 +94,15 @@ public:
   void ms_handle_remote_reset(Connection *c) {}
 
   void notify_mdsmap(MDSMap const *mdsmap);
-  void notify_want_state(MDSMap::DaemonState const newstate);
   void notify_health(MDSRank const *mds);
 
   void set_standby_for(mds_rank_t rank_, std::string const &name_);
 
   void handle_mds_beacon(MMDSBeacon *m);
   void send();
+
+  void set_want_state(MDSMap::DaemonState const newstate);
+  MDSMap::DaemonState get_want_state() const;
 
   /**
    * Send a beacon, and block until the ack is received from the mon

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -18,7 +18,7 @@
 #include "CInode.h"
 #include "CDir.h"
 
-#include "MDS.h"
+#include "MDSRank.h"
 #include "MDCache.h"
 #include "Locker.h"
 #include "LogSegment.h"

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -21,7 +21,7 @@
 #include "Mutation.h"
 
 #include "MDSMap.h"
-#include "MDS.h"
+#include "MDSRank.h"
 #include "MDCache.h"
 #include "Locker.h"
 #include "MDLog.h"
@@ -47,7 +47,7 @@ class CDirContext : public MDSInternalContextBase
 {
 protected:
   CDir *dir;
-  MDS* get_mds() {return dir->cache->mds;}
+  MDSRank* get_mds() {return dir->cache->mds;}
 
 public:
   CDirContext(CDir *d) : dir(d) {
@@ -60,7 +60,7 @@ class CDirIOContext : public MDSIOContextBase
 {
 protected:
   CDir *dir;
-  MDS* get_mds() {return dir->cache->mds;}
+  MDSRank* get_mds() {return dir->cache->mds;}
 
 public:
   CDirIOContext(CDir *d) : dir(d) {
@@ -1467,7 +1467,7 @@ void CDir::_tmap_fetch(const string& want_dn)
   ObjectOperation rd;
   rd.tmap_get(&fin->bl, NULL);
   cache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
-			     new C_OnFinisher(fin, &cache->mds->finisher));
+			     new C_OnFinisher(fin, cache->mds->finisher));
 }
 
 void CDir::_tmap_fetched(bufferlist& bl, const string& want_dn, int r)
@@ -1537,7 +1537,7 @@ void CDir::_omap_fetch(const string& want_dn)
   }
 
   cache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
-			     new C_OnFinisher(fin, &cache->mds->finisher));
+			     new C_OnFinisher(fin, cache->mds->finisher));
 }
 
 CDentry *CDir::_load_dentry(
@@ -1973,7 +1973,7 @@ void CDir::_omap_commit(int op_prio)
   C_GatherBuilder gather(g_ceph_context,
 			 new C_OnFinisher(new C_IO_Dir_Committed(this,
 								 get_version()),
-					  &cache->mds->finisher));
+					  cache->mds->finisher));
 
   SnapContext snapc;
   object_t oid = get_ondisk_object();

--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -13,7 +13,7 @@
  */
 
 #include "InoTable.h"
-#include "MDS.h"
+#include "MDSRank.h"
 
 #include "include/types.h"
 

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -19,14 +19,14 @@
 #include "MDSTable.h"
 #include "include/interval_set.h"
 
-class MDS;
+class MDSRank;
 
 class InoTable : public MDSTable {
   interval_set<inodeno_t> free;   // unused ids
   interval_set<inodeno_t> projected_free;
 
  public:
-  InoTable(MDS *m) : MDSTable(m, "inotable", true) { }
+  InoTable(MDSRank *m) : MDSTable(m, "inotable", true) { }
 
   inodeno_t project_alloc_id(inodeno_t id=0);
   void apply_alloc_id(inodeno_t id);

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -13,7 +13,7 @@
  */
 
 
-#include "MDS.h"
+#include "MDSRank.h"
 #include "MDCache.h"
 #include "Locker.h"
 #include "CInode.h"
@@ -50,7 +50,7 @@
 #undef DOUT_COND
 #define DOUT_COND(cct, l) l<=cct->_conf->debug_mds || l <= cct->_conf->debug_mds_locker
 #define dout_prefix _prefix(_dout, mds)
-static ostream& _prefix(std::ostream *_dout, MDS *mds) {
+static ostream& _prefix(std::ostream *_dout, MDSRank *mds) {
   return *_dout << "mds." << mds->get_nodeid() << ".locker ";
 }
 
@@ -58,7 +58,7 @@ static ostream& _prefix(std::ostream *_dout, MDS *mds) {
 class LockerContext : public MDSInternalContextBase {
   protected:
   Locker *locker;
-  MDS *get_mds()
+  MDSRank *get_mds()
   {
     return locker->mds;
   }

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -24,7 +24,7 @@ using std::map;
 using std::list;
 using std::set;
 
-class MDS;
+class MDSRank;
 class Session;
 class CInode;
 class CDentry;
@@ -47,11 +47,11 @@ typedef ceph::shared_ptr<MDRequestImpl> MDRequestRef;
 
 class Locker {
 private:
-  MDS *mds;
+  MDSRank *mds;
   MDCache *mdcache;
  
  public:
-  Locker(MDS *m, MDCache *c) : mds(m), mdcache(c) {}  
+  Locker(MDSRank *m, MDCache *c) : mds(m), mdcache(c) {}  
 
   SimpleLock *get_lock(int lock_type, MDSCacheObjectInfo &info);
   

--- a/src/mds/LogEvent.cc
+++ b/src/mds/LogEvent.cc
@@ -15,7 +15,7 @@
 #include "common/config.h"
 #include "LogEvent.h"
 
-#include "MDS.h"
+#include "MDSRank.h"
 
 // events i know of
 #include "events/ESubtreeMap.h"

--- a/src/mds/LogEvent.h
+++ b/src/mds/LogEvent.h
@@ -46,7 +46,7 @@
 #include "include/Context.h"
 #include "include/utime.h"
 
-class MDS;
+class MDSRank;
 class LogSegment;
 class EMetaBlob;
 
@@ -109,7 +109,7 @@ public:
   /*** recovery ***/
   /* replay() - replay given event.  this is idempotent.
    */
-  virtual void replay(MDS *m) { assert(0); }
+  virtual void replay(MDSRank *m) { assert(0); }
 
   /**
    * If the subclass embeds a MetaBlob, return it here so that

--- a/src/mds/LogSegment.h
+++ b/src/mds/LogSegment.h
@@ -30,7 +30,7 @@ using ceph::unordered_set;
 class CDir;
 class CInode;
 class CDentry;
-class MDS;
+class MDSRank;
 struct MDSlaveUpdate;
 
 typedef uint64_t log_segment_seq_t;
@@ -72,7 +72,7 @@ class LogSegment {
   map<int,version_t> tablev;
 
   // try to expire
-  void try_to_expire(MDS *mds, MDSGatherBuilder &gather_bld, int op_prio);
+  void try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int op_prio);
 
   std::list<MDSInternalContextBase*> expiry_waiters;
 

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -15,7 +15,7 @@
 #include "mdstypes.h"
 
 #include "MDBalancer.h"
-#include "MDS.h"
+#include "MDSRank.h"
 #include "mon/MonClient.h"
 #include "MDSMap.h"
 #include "CInode.h"
@@ -113,7 +113,7 @@ void MDBalancer::tick()
 
 class C_Bal_SendHeartbeat : public MDSInternalContext {
 public:
-  C_Bal_SendHeartbeat(MDS *mds_) : MDSInternalContext(mds_) { }
+  C_Bal_SendHeartbeat(MDSRank *mds_) : MDSInternalContext(mds_) { }
   virtual void finish(int f) {
     mds->balancer->send_heartbeat();
   }
@@ -159,7 +159,7 @@ mds_load_t MDBalancer::get_load(utime_t now)
   }
 
   load.req_rate = mds->get_req_rate();
-  load.queue_len = mds->messenger->get_dispatch_queue_len();
+  load.queue_len = messenger->get_dispatch_queue_len();
 
   ifstream cpu("/proc/loadavg");
   if (cpu.is_open())
@@ -224,8 +224,8 @@ void MDBalancer::send_heartbeat()
       continue;
     MHeartbeat *hb = new MHeartbeat(load, beat_epoch);
     hb->get_import_map() = import_map;
-    mds->messenger->send_message(hb,
-                                 mds->mdsmap->get_inst(*p));
+    messenger->send_message(hb,
+                            mds->mdsmap->get_inst(*p));
   }
 }
 
@@ -805,8 +805,8 @@ bool MDBalancer::check_targets()
   dout(10) << "check_targets have " << map_targets << " need " << need_targets << " want " << want_targets << dendl;
 
   if (send) {
-    MMDSLoadTargets* m = new MMDSLoadTargets(mds_gid_t(mds->monc->get_global_id()), want_targets);
-    mds->monc->send_mon_message(m);
+    MMDSLoadTargets* m = new MMDSLoadTargets(mds_gid_t(mds->get_global_id()), want_targets);
+    mds->send_mon_message(m);
   }
   return ok;
 }

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -758,7 +758,7 @@ void MDBalancer::try_rebalance()
 bool MDBalancer::check_targets()
 {
   // get MonMap's idea of my_targets
-  const set<mds_rank_t>& map_targets = mds->mdsmap->get_mds_info(mds->whoami).export_targets;
+  const set<mds_rank_t>& map_targets = mds->mdsmap->get_mds_info(mds->get_nodeid()).export_targets;
 
   bool send = false;
   bool ok = true;

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -805,8 +805,8 @@ bool MDBalancer::check_targets()
   dout(10) << "check_targets have " << map_targets << " need " << need_targets << " want " << want_targets << dendl;
 
   if (send) {
-    MMDSLoadTargets* m = new MMDSLoadTargets(mds_gid_t(mds->get_global_id()), want_targets);
-    mds->send_mon_message(m);
+    MMDSLoadTargets* m = new MMDSLoadTargets(mds_gid_t(mon_client->get_global_id()), want_targets);
+    mon_client->send_mon_message(m);
   }
   return ok;
 }

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -27,15 +27,17 @@ using std::map;
 #include "CInode.h"
 
 
-class MDS;
+class MDSRank;
 class Message;
 class MHeartbeat;
 class CInode;
 class CDir;
+class Messenger;
 
 class MDBalancer {
  protected:
-  MDS *mds;
+  MDSRank *mds;
+  Messenger *messenger;
   int beat_epoch;
 
   int last_epoch_under;  
@@ -73,8 +75,9 @@ class MDBalancer {
   }
 
 public:
-  MDBalancer(MDS *m) : 
+  MDBalancer(MDSRank *m, Messenger *msgr) : 
     mds(m),
+    messenger(msgr),
     beat_epoch(0),
     last_epoch_under(0), last_epoch_over(0), my_load(0.0), target_load(0.0) { }
   

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -33,11 +33,13 @@ class MHeartbeat;
 class CInode;
 class CDir;
 class Messenger;
+class MonClient;
 
 class MDBalancer {
  protected:
   MDSRank *mds;
   Messenger *messenger;
+  MonClient *mon_client;
   int beat_epoch;
 
   int last_epoch_under;  
@@ -75,9 +77,10 @@ class MDBalancer {
   }
 
 public:
-  MDBalancer(MDSRank *m, Messenger *msgr) : 
+  MDBalancer(MDSRank *m, Messenger *msgr, MonClient *monc) : 
     mds(m),
     messenger(msgr),
+    mon_client(monc),
     beat_epoch(0),
     last_epoch_under(0), last_epoch_over(0), my_load(0.0), target_load(0.0) { }
   

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11804,3 +11804,8 @@ void MDCache::notify_mdsmap_changed()
   stray_manager.update_op_limit();
 }
 
+void MDCache::notify_osdmap_changed()
+{
+  stray_manager.update_op_limit();
+}
+

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -20,7 +20,7 @@
 #include <map>
 
 #include "MDCache.h"
-#include "MDS.h"
+#include "MDSRank.h"
 #include "Server.h"
 #include "Locker.h"
 #include "MDLog.h"

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1093,6 +1093,7 @@ public:
   void discard_delayed_expire(CDir *dir);
 
   void notify_mdsmap_changed();
+  void notify_osdmap_changed();
 
 protected:
   void dump_cache(const char *fn, Formatter *f);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -37,7 +37,7 @@
 
 class PerfCounters;
 
-class MDS;
+class MDSRank;
 class Session;
 class Migrator;
 
@@ -117,7 +117,7 @@ static const int PREDIRTY_SHALLOW = 4; // only go to immediate parent (for easie
 class MDCache {
  public:
   // my master
-  MDS *mds;
+  MDSRank *mds;
 
   // -- my cache --
   LRU lru;   // dentry lru for expiring items from cache
@@ -620,7 +620,7 @@ public:
   Migrator *migrator;
 
  public:
-  MDCache(MDS *m);
+  MDCache(MDSRank *m);
   ~MDCache();
   
   // debug

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -50,7 +50,7 @@ enum {
 class Journaler;
 class JournalPointer;
 class LogEvent;
-class MDS;
+class MDSRank;
 class LogSegment;
 class ESubtreeMap;
 
@@ -64,7 +64,7 @@ using std::map;
 
 class MDLog {
 public:
-  MDS *mds;
+  MDSRank *mds;
 protected:
   int num_events; // in events
 
@@ -182,20 +182,20 @@ public:
 
 
 public:
-  MDLog(MDS *m) : mds(m),
-		  num_events(0), 
-		  unflushed(0),
-		  capped(false),
-		  safe_pos(0),
-		  journaler(0),
-		  logger(0),
-		  replay_thread(this),
-		  already_replayed(false),
-		  recovery_thread(this),
-		  event_seq(0), expiring_events(0), expired_events(0),
-		  submit_mutex("MDLog::submit_mutex"),
-		  submit_thread(this),
-		  cur_event(NULL) { }		  
+  MDLog(MDSRank *m) : mds(m),
+                      num_events(0), 
+                      unflushed(0),
+                      capped(false),
+                      safe_pos(0),
+                      journaler(0),
+                      logger(0),
+                      replay_thread(this),
+                      already_replayed(false),
+                      recovery_thread(this),
+                      event_seq(0), expiring_events(0), expired_events(0),
+                      submit_mutex("MDLog::submit_mutex"),
+                      submit_thread(this),
+                      cur_event(NULL) { }		  
   ~MDLog();
 
 

--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -174,7 +174,7 @@ bool MDS::asok_command(string command, cmdmap_t& cmdmap, string format,
     f->open_object_section("status");
     f->dump_stream("cluster_fsid") << monc->get_fsid();
     if (mds_rank) {
-      f->dump_unsigned("whoami", mds_rank->whoami);
+      f->dump_unsigned("whoami", mds_rank->get_nodeid());
     } else {
       f->dump_unsigned("whoami", MDS_RANK_NONE);
     }
@@ -914,11 +914,13 @@ void MDS::handle_mds_map(MMDSMap *m)
 
     // Did I previously not hold a rank?  Initialize!
     if (mds_rank == NULL) {
-      mds_rank = new MDSRankDispatcher(mds_lock, clog, timer, beacon, mdsmap,
-          messenger, monc, objecter,
+      mds_rank = new MDSRankDispatcher(whoami, incarnation, mds_lock, clog,
+          timer, beacon, mdsmap, messenger, monc, objecter,
           new C_VoidFn(this, &MDS::respawn),
           new C_VoidFn(this, &MDS::suicide));
-      mds_rank->init(whoami, incarnation);
+      dout(10) <<  __func__ << ": initializing MDS rank "
+               << mds_rank->get_nodeid() << dendl;
+      mds_rank->init();
     }
 
     // MDSRank is active: let him process the map, we have no say.

--- a/src/mds/MDS.cc
+++ b/src/mds/MDS.cc
@@ -914,8 +914,8 @@ void MDS::handle_mds_map(MMDSMap *m)
 
     // Did I previously not hold a rank?  Initialize!
     if (mds_rank == NULL) {
-      mds_rank = new MDSRank(mds_lock, clog, timer, beacon, mdsmap, messenger,
-          monc, objecter,
+      mds_rank = new MDSRankDispatcher(mds_lock, clog, timer, beacon, mdsmap,
+          messenger, monc, objecter,
           new C_VoidFn(this, &MDS::respawn),
           new C_VoidFn(this, &MDS::suicide));
       mds_rank->init(whoami, incarnation);

--- a/src/mds/MDS.h
+++ b/src/mds/MDS.h
@@ -84,18 +84,14 @@ class MDS : public MDSRank, public Dispatcher, public md_config_obs_t {
 
   SafeTimer    timer;
 
- public:
-  // XXX fixme beacon only public for the benefit of MDSRank who wants
-  // to see if it's laggy
+ protected:
   Beacon  beacon;
- private:
   void set_want_state(MDSMap::DaemonState newstate);
- public:
 
   AuthAuthorizeHandlerRegistry *authorize_handler_cluster_registry;
   AuthAuthorizeHandlerRegistry *authorize_handler_service_registry;
 
-  string name;
+  std::string name;
 
   mds_rank_t standby_for_rank;
   MDSMap::DaemonState standby_type;  // one of STANDBY_REPLAY, ONESHOT_REPLAY
@@ -113,10 +109,24 @@ class MDS : public MDSRank, public Dispatcher, public md_config_obs_t {
 
   Finisher finisher;
 
+ public:
+  MDS(const std::string &n, Messenger *m, MonClient *mc);
+  ~MDS();
   int orig_argc;
   const char **orig_argv;
 
-public:
+  // handle a signal (e.g., SIGTERM)
+  void handle_signal(int signum);
+
+  // start up, shutdown
+  int init(MDSMap::DaemonState wanted_state=MDSMap::STATE_BOOT);
+
+  // config observer bits
+  virtual const char** get_tracked_conf_keys() const;
+  virtual void handle_conf_change(const struct md_config_t *conf,
+				  const std::set <std::string> &changed);
+ protected:
+
   void request_state(MDSMap::DaemonState s);
 
   // tick and other timer fun
@@ -147,16 +157,7 @@ public:
   bool ms_handle_reset(Connection *con);
   void ms_handle_remote_reset(Connection *con);
 
- public:
-  MDS(const std::string &n, Messenger *m, MonClient *mc);
-  ~MDS();
-
-  // handle a signal (e.g., SIGTERM)
-  void handle_signal(int signum);
-
-  // start up, shutdown
-  int init(MDSMap::DaemonState wanted_state=MDSMap::STATE_BOOT);
-
+ protected:
   // admin socket handling
   friend class MDSSocketHook;
   class MDSSocketHook *asok_hook;
@@ -187,11 +188,7 @@ public:
   CDir *_command_dirfrag_get(
       const cmdmap_t &cmdmap,
       std::ostream &ss);
- public:
-    // config observer bits
-  virtual const char** get_tracked_conf_keys() const;
-  virtual void handle_conf_change(const struct md_config_t *conf,
-				  const std::set <std::string> &changed);
+ protected:
   void create_logger();
   void update_log_config();
 
@@ -199,7 +196,7 @@ public:
 
   void boot_create();             // i am new mds.
 
- private:
+ protected:
   typedef enum {
     // The MDSMap is available, configure default layouts and structures
     MDS_BOOT_INITIAL = 0,
@@ -215,7 +212,6 @@ public:
   friend class C_MDS_InternalBootStart;
   void boot_start(BootStep step=MDS_BOOT_INITIAL, int r=0);    // starting|replay
   void calc_recovery_set();
- public:
 
   void replay_start();
   void creating_done();
@@ -228,7 +224,6 @@ public:
 
   void reopen_log();
 
- protected:
   void resolve_start();
   void resolve_done();
   void reconnect_start();
@@ -242,11 +237,11 @@ public:
   void active_start();
   void stopping_start();
   void stopping_done();
- public:
 
   void handle_mds_recovery(mds_rank_t who);
   void handle_mds_failure(mds_rank_t who);
 
+public:
   /**
    * Report state DAMAGED to the mon, and then pass on to respawn().  Call
    * this when an unrecoverable error is encountered while attempting
@@ -295,7 +290,7 @@ public:
   // messages
   bool _dispatch(Message *m, bool new_msg);
 
-  protected:
+protected:
   bool handle_core_message(Message *m);
   
   // special message types

--- a/src/mds/MDS.h
+++ b/src/mds/MDS.h
@@ -182,35 +182,7 @@ class MDS : public MDSRank, public Dispatcher, public md_config_obs_t {
   void update_log_config();
 
   void bcast_mds_map();  // to mounted clients
- protected:
-
-  void handle_mds_recovery(mds_rank_t who);
-  void handle_mds_failure(mds_rank_t who);
-
 public:
-  /**
-   * Report state DAMAGED to the mon, and then pass on to respawn().  Call
-   * this when an unrecoverable error is encountered while attempting
-   * to load an MDS rank's data structures.  This is *not* for use with
-   * errors affecting normal dirfrag/inode objects -- they should be handled
-   * through cleaner scrub/repair mechanisms.
-   *
-   * Callers must already hold mds_lock.
-   */
-  void damaged();
-
-  /**
-   * Wrapper around `damaged` for users who are not
-   * already holding mds_lock.
-   *
-   * Callers must not already hold mds_lock.
-   */
-  void damaged_unlocked()
-  {
-    Mutex::Locker l(mds_lock);
-    damaged();
-  }
-
   /**
    * Terminate this daemon process.
    *
@@ -247,6 +219,7 @@ protected:
   void handle_command(class MMonCommand *m);
   void handle_command(class MCommand *m);
   void handle_mds_map(class MMDSMap *m);
+  void _handle_mds_map(MDSMap *oldmap);
 };
 
 

--- a/src/mds/MDS.h
+++ b/src/mds/MDS.h
@@ -98,7 +98,7 @@ class MDS : public Dispatcher, public md_config_obs_t {
   LogClient    log_client;
   LogChannelRef clog;
 
-  MDSRank *mds_rank;
+  MDSRankDispatcher *mds_rank;
 
  public:
   MDS(const std::string &n, Messenger *m, MonClient *mc);

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -13,7 +13,7 @@
  */
 
 
-#include "MDS.h"
+#include "MDSRank.h"
 
 #include "MDSContext.h"
 
@@ -22,7 +22,7 @@
 
 
 void MDSInternalContextBase::complete(int r) {
-  MDS *mds = get_mds();
+  MDSRank *mds = get_mds();
 
   dout(10) << "MDSInternalContextBase::complete: " << typeid(*this).name() << dendl;
   assert(mds != NULL);
@@ -31,11 +31,11 @@ void MDSInternalContextBase::complete(int r) {
 }
 
 
-MDS *MDSInternalContext::get_mds() {
+MDSRank *MDSInternalContext::get_mds() {
   return mds;
 }
 
-MDS *MDSInternalContextWrapper::get_mds()
+MDSRank *MDSInternalContextWrapper::get_mds()
 {
   return mds;
 }
@@ -47,12 +47,12 @@ void MDSInternalContextWrapper::finish(int r)
 
 
 void MDSIOContextBase::complete(int r) {
-  MDS *mds = get_mds();
+  MDSRank *mds = get_mds();
 
   dout(10) << "MDSIOContextBase::complete: " << typeid(*this).name() << dendl;
   assert(mds != NULL);
   Mutex::Locker l(mds->mds_lock);
-  if (mds->stopping) {
+  if (mds->is_daemon_stopping()) {
     dout(4) << "MDSIOContextBase::complete: dropping for stopping "
             << typeid(*this).name() << dendl;
     return;
@@ -66,11 +66,11 @@ void MDSIOContextBase::complete(int r) {
   }
 }
 
-MDS *MDSIOContext::get_mds() {
+MDSRank *MDSIOContext::get_mds() {
   return mds;
 }
 
-MDS *MDSIOContextWrapper::get_mds() {
+MDSRank *MDSIOContextWrapper::get_mds() {
   return mds;
 }
 
@@ -79,7 +79,7 @@ void MDSIOContextWrapper::finish(int r)
   fin->complete(r);
 }
 
-MDS *MDSInternalContextGather::get_mds()
+MDSRank *MDSInternalContextGather::get_mds()
 {
   derr << "Forbidden call to MDSInternalContextGather::get_mds by " << typeid(*this).name() << dendl;
   assert(0);

--- a/src/mds/MDSContext.h
+++ b/src/mds/MDSContext.h
@@ -18,7 +18,7 @@
 
 #include "include/Context.h"
 
-class MDS;
+class MDSRank;
 
 
 /**
@@ -31,7 +31,7 @@ class MDS;
 class MDSContext : public Context
 {
 protected:
-  virtual MDS *get_mds() = 0;
+  virtual MDSRank *get_mds() = 0;
 };
 
 
@@ -51,11 +51,11 @@ public:
 class MDSInternalContext : public MDSInternalContextBase
 {
 protected:
-  MDS *mds;
-  virtual MDS* get_mds();
+  MDSRank *mds;
+  virtual MDSRank* get_mds();
 
 public:
-  MDSInternalContext(MDS *mds_) : mds(mds_) {
+  MDSInternalContext(MDSRank *mds_) : mds(mds_) {
     assert(mds != NULL);
   }
 };
@@ -67,11 +67,11 @@ public:
 class MDSInternalContextWrapper : public MDSInternalContextBase
 {
 protected:
-  MDS *mds;
+  MDSRank *mds;
   Context *fin;
-  MDS *get_mds();
+  MDSRank *get_mds();
 public:
-  MDSInternalContextWrapper(MDS *m, Context *c) : mds(m), fin(c) {}
+  MDSInternalContextWrapper(MDSRank *m, Context *c) : mds(m), fin(c) {}
   void finish(int r);
 };
 
@@ -81,17 +81,17 @@ class MDSIOContextBase : public MDSContext
 };
 
 /**
- * Completion for an I/O operation, takes big MDS lock
+ * Completion for an I/O operation, takes big MDSRank lock
  * before executing finish function.
  */
 class MDSIOContext : public MDSIOContextBase
 {
 protected:
-  MDS *mds;
-  virtual MDS* get_mds();
+  MDSRank *mds;
+  virtual MDSRank* get_mds();
 
 public:
-  MDSIOContext(MDS *mds_) : mds(mds_) {
+  MDSIOContext(MDSRank *mds_) : mds(mds_) {
     assert(mds != NULL);
   }
 };
@@ -103,11 +103,11 @@ public:
 class MDSIOContextWrapper : public MDSIOContextBase
 {
 protected:
-  MDS *mds;
+  MDSRank *mds;
   Context *fin;
-  MDS *get_mds();
+  MDSRank *get_mds();
 public:
-  MDSIOContextWrapper(MDS *m, Context *c) : mds(m), fin(c) {}
+  MDSIOContextWrapper(MDSRank *m, Context *c) : mds(m), fin(c) {}
   void finish(int r);
 };
 
@@ -116,7 +116,7 @@ public:
  */
 class C_MDSInternalNoop : public MDSInternalContextBase
 {
-  virtual MDS* get_mds() {assert(0);}
+  virtual MDSRank* get_mds() {assert(0);}
 public:
   void finish(int r) {}
   void complete(int r) {}
@@ -132,7 +132,7 @@ class C_IO_Wrapper : public MDSIOContext
 private:
   MDSInternalContextBase *wrapped;
 public:
-  C_IO_Wrapper(MDS *mds_, MDSInternalContextBase *wrapped_) : MDSIOContext(mds_), wrapped(wrapped_) {
+  C_IO_Wrapper(MDSRank *mds_, MDSInternalContextBase *wrapped_) : MDSIOContext(mds_), wrapped(wrapped_) {
     assert(wrapped != NULL);
   }
   virtual void finish(int r) {
@@ -147,7 +147,7 @@ public:
 class MDSInternalContextGather : public MDSInternalContextBase
 {
 protected:
-  MDS *get_mds();
+  MDSRank *get_mds();
 };
 
 
@@ -156,7 +156,7 @@ class MDSGather : public C_GatherBase<MDSInternalContextBase, MDSInternalContext
 public:
   MDSGather(CephContext *cct, MDSInternalContextBase *onfinish) : C_GatherBase<MDSInternalContextBase, MDSInternalContextGather>(cct, onfinish) {}
 protected:
-  virtual MDS *get_mds() {return NULL;}
+  virtual MDSRank *get_mds() {return NULL;}
 };
 
 

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1317,3 +1317,12 @@ void MDSDaemon::ms_handle_accept(Connection *con)
   }
 }
 
+bool MDSDaemon::is_clean_shutdown()
+{
+  if (mds_rank) {
+    return mds_rank->is_stopped();
+  } else {
+    return true;
+  }
+}
+

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -815,15 +815,16 @@ void MDSDaemon::handle_mds_map(MMDSMap *m)
     return;
   }
 
+  entity_addr_t addr;
+
   // keep old map, for a moment
   MDSMap *oldmap = mdsmap;
-  const MDSMap::DaemonState new_state = mdsmap->get_state_gid(mds_gid_t(monc->get_global_id()));
-  const int incarnation = mdsmap->get_inc_gid(mds_gid_t(monc->get_global_id()));
-  entity_addr_t addr;
 
   // decode and process
   mdsmap = new MDSMap;
   mdsmap->decode(m->get_encoded());
+  const MDSMap::DaemonState new_state = mdsmap->get_state_gid(mds_gid_t(monc->get_global_id()));
+  const int incarnation = mdsmap->get_inc_gid(mds_gid_t(monc->get_global_id()));
 
   monc->sub_got("mdsmap", mdsmap->get_epoch());
 

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -72,7 +72,7 @@ class MDSTableClient;
 
 class AuthAuthorizeHandlerRegistry;
 
-class MDS : public Dispatcher, public md_config_obs_t {
+class MDSDaemon : public Dispatcher, public md_config_obs_t {
  public:
   /* Global MDS lock: every time someone takes this, they must
    * also check the `stopping` flag.  If stopping is true, you
@@ -101,8 +101,8 @@ class MDS : public Dispatcher, public md_config_obs_t {
   MDSRankDispatcher *mds_rank;
 
  public:
-  MDS(const std::string &n, Messenger *m, MonClient *mc);
-  ~MDS();
+  MDSDaemon(const std::string &n, Messenger *m, MonClient *mc);
+  ~MDSDaemon();
   int orig_argc;
   const char **orig_argv;
 
@@ -120,9 +120,9 @@ class MDS : public Dispatcher, public md_config_obs_t {
   // tick and other timer fun
   class C_MDS_Tick : public Context {
     protected:
-      MDS *mds_daemon;
+      MDSDaemon *mds_daemon;
   public:
-    C_MDS_Tick(MDS *m) : mds_daemon(m) {}
+    C_MDS_Tick(MDSDaemon *m) : mds_daemon(m) {}
     void finish(int r) {
       assert(mds_daemon->mds_lock.is_locked_by_me());
 

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -112,6 +112,14 @@ class MDSDaemon : public Dispatcher, public md_config_obs_t {
   // start up, shutdown
   int init(MDSMap::DaemonState wanted_state=MDSMap::STATE_BOOT);
 
+  /**
+   * Hint at whether we were shutdown gracefully (i.e. we were only
+   * in standby, or our rank was stopped).  Should be removed once
+   * we handle shutdown properly (e.g. clear out all message queues)
+   * such that deleting xlists doesn't assert.
+   */
+  bool is_clean_shutdown();
+
   // config observer bits
   virtual const char** get_tracked_conf_keys() const;
   virtual void handle_conf_change(const struct md_config_t *conf,

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -372,6 +372,9 @@ void MDSMap::get_health(list<pair<health_status_t,string> >& summary,
   set<string> laggy;
   for (; u != u_end; ++u) {
     map<mds_gid_t, mds_info_t>::const_iterator m = mds_info.find(u->second);
+    if (m == m_end) {
+      std::cerr << "Up rank " << u->first << " GID " << u->second << " not found!" << std::endl;
+    }
     assert(m != m_end);
     const mds_info_t &mds_info(m->second);
     if (mds_info.laggy()) {

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -80,7 +80,7 @@ public:
   typedef enum {
     // States of an MDS daemon not currently holding a rank
     // ====================================================
-    STATE_NULL     =   0,                                  // null value for fns returning this type.
+    STATE_NULL     =   CEPH_MDS_STATE_NULL,                                  // null value for fns returning this type.
     STATE_BOOT     =   CEPH_MDS_STATE_BOOT,                // up, boot announcement.  destiny unknown.
     STATE_STANDBY  =   CEPH_MDS_STATE_STANDBY,             // up, idle.  waiting for assignment by monitor.
     STATE_STANDBY_REPLAY = CEPH_MDS_STATE_STANDBY_REPLAY,  // up, replaying active node, ready to take over.

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1,0 +1,501 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#include "common/debug.h"
+#include "common/errno.h"
+
+#include "messages/MClientRequestForward.h"
+#include "messages/MMDSMap.h"
+
+#include "MDSMap.h"
+#include "MDS.h"
+#include "mds_table_types.h"
+#include "SnapClient.h"
+#include "SnapServer.h"
+#include "MDBalancer.h"
+#include "messages/MMDSTableRequest.h"
+#include "Locker.h"
+#include "Server.h"
+#include "mon/MonClient.h"
+#include "common/HeartbeatMap.h"
+
+
+#include "MDSRank.h"
+
+#define dout_subsys ceph_subsys_mds
+#undef dout_prefix
+#define dout_prefix *_dout << "mds." << whoami << '.' << incarnation << ' '
+
+MDSRank::MDSRank(
+    Mutex &mds_lock_,
+    LogChannelRef &clog_,
+    SafeTimer &timer_,
+    MDSMap *& mdsmap_,
+    Finisher *finisher_,
+    MDS *mds_daemon_,
+    Messenger *msgr,
+    MonClient *monc_)
+  :
+    whoami(MDS_RANK_NONE),
+    incarnation(0),
+    mds_lock(mds_lock_), clog(clog_), timer(timer_),
+    mdsmap(mdsmap_),
+    objecter(NULL),
+    server(NULL), mdcache(NULL), locker(NULL), mdlog(NULL),
+    balancer(NULL), inotable(NULL), snapserver(NULL), snapclient(NULL),
+    sessionmap(this), logger(NULL), mlogger(NULL),
+    op_tracker(g_ceph_context, g_conf->mds_enable_op_tracker, 
+               g_conf->osd_num_op_tracker_shard),
+    last_state(MDSMap::STATE_NULL), want_state(MDSMap::STATE_NULL),
+    state(MDSMap::STATE_NULL),
+    progress_thread(this),
+    hb(NULL), last_tid(0), osd_epoch_barrier(0),
+    finisher(finisher_), mds_daemon(mds_daemon_), messenger(msgr), monc(monc_)
+{
+  hb = g_ceph_context->get_heartbeat_map()->add_worker("MDSRank");
+}
+
+MDSRank::~MDSRank()
+{
+  if (hb) {
+    g_ceph_context->get_heartbeat_map()->remove_worker(hb);
+  }
+}
+
+uint64_t MDSRank::get_metadata_pool()
+{
+    return mdsmap->get_metadata_pool();
+}
+
+MDSTableClient *MDSRank::get_table_client(int t)
+{
+  switch (t) {
+  case TABLE_ANCHOR: return NULL;
+  case TABLE_SNAP: return snapclient;
+  default: assert(0);
+  }
+}
+
+MDSTableServer *MDSRank::get_table_server(int t)
+{
+  switch (t) {
+  case TABLE_ANCHOR: return NULL;
+  case TABLE_SNAP: return snapserver;
+  default: assert(0);
+  }
+}
+
+void MDSRank::suicide(bool fast)
+{
+  mds_daemon->suicide(fast);
+}
+
+void MDSRank::respawn()
+{
+  mds_daemon->respawn();
+}
+
+void MDSRank::damaged()
+{
+  mds_daemon->damaged();
+}
+
+void MDSRank::damaged_unlocked()
+{
+  mds_daemon->damaged_unlocked();
+}
+
+void MDSRank::handle_write_error(int err)
+{
+  if (err == -EBLACKLISTED) {
+    derr << "we have been blacklisted (fenced), respawning..." << dendl;
+    mds_daemon->respawn();
+    return;
+  }
+
+  if (g_conf->mds_action_on_write_error >= 2) {
+    derr << "unhandled write error " << cpp_strerror(err) << ", suicide..." << dendl;
+    mds_daemon->suicide();
+  } else if (g_conf->mds_action_on_write_error == 1) {
+    derr << "unhandled write error " << cpp_strerror(err) << ", force readonly..." << dendl;
+    mdcache->force_readonly();
+  } else {
+    // ignore;
+    derr << "unhandled write error " << cpp_strerror(err) << ", ignore..." << dendl;
+  }
+}
+
+void *MDSRank::ProgressThread::entry()
+{
+  Mutex::Locker l(mds->mds_lock);
+  while (true) {
+    while (!mds->mds_daemon->stopping &&
+	   mds->finished_queue.empty() &&
+	   (mds->waiting_for_nolaggy.empty() || mds->mds_daemon->beacon.is_laggy())) {
+      cond.Wait(mds->mds_lock);
+    }
+
+    if (mds->mds_daemon->stopping) {
+      break;
+    }
+
+    mds->_advance_queues();
+  }
+
+  return NULL;
+}
+
+
+void MDSRank::ProgressThread::shutdown()
+{
+  assert(mds->mds_lock.is_locked_by_me());
+  assert(mds->mds_daemon->stopping);
+
+  if (am_self()) {
+    // Stopping is set, we will fall out of our main loop naturally
+  } else {
+    // Kick the thread to notice mds->stopping, and join it
+    cond.Signal();
+    mds->mds_lock.Unlock();
+    if (is_started())
+      join();
+    mds->mds_lock.Lock();
+  }
+}
+
+/*
+ * lower priority messages we defer if we seem laggy
+ */
+bool MDSRank::handle_deferrable_message(Message *m)
+{
+  int port = m->get_type() & 0xff00;
+
+  switch (port) {
+  case MDS_PORT_CACHE:
+    ALLOW_MESSAGES_FROM(CEPH_ENTITY_TYPE_MDS);
+    mdcache->dispatch(m);
+    break;
+    
+  case MDS_PORT_MIGRATOR:
+    ALLOW_MESSAGES_FROM(CEPH_ENTITY_TYPE_MDS);
+    mdcache->migrator->dispatch(m);
+    break;
+    
+  default:
+    switch (m->get_type()) {
+      // SERVER
+    case CEPH_MSG_CLIENT_SESSION:
+    case CEPH_MSG_CLIENT_RECONNECT:
+      ALLOW_MESSAGES_FROM(CEPH_ENTITY_TYPE_CLIENT);
+      // fall-thru
+    case CEPH_MSG_CLIENT_REQUEST:
+      server->dispatch(m);
+      break;
+    case MSG_MDS_SLAVE_REQUEST:
+      ALLOW_MESSAGES_FROM(CEPH_ENTITY_TYPE_MDS);
+      server->dispatch(m);
+      break;
+      
+    case MSG_MDS_HEARTBEAT:
+      ALLOW_MESSAGES_FROM(CEPH_ENTITY_TYPE_MDS);
+      balancer->proc_message(m);
+      break;
+	  
+    case MSG_MDS_TABLE_REQUEST:
+      ALLOW_MESSAGES_FROM(CEPH_ENTITY_TYPE_MDS);
+      {
+	MMDSTableRequest *req = static_cast<MMDSTableRequest*>(m);
+	if (req->op < 0) {
+	  MDSTableClient *client = get_table_client(req->table);
+	      client->handle_request(req);
+	} else {
+	  MDSTableServer *server = get_table_server(req->table);
+	  server->handle_request(req);
+	}
+      }
+      break;
+
+    case MSG_MDS_LOCK:
+    case MSG_MDS_INODEFILECAPS:
+      ALLOW_MESSAGES_FROM(CEPH_ENTITY_TYPE_MDS);
+      locker->dispatch(m);
+      break;
+      
+    case CEPH_MSG_CLIENT_CAPS:
+    case CEPH_MSG_CLIENT_CAPRELEASE:
+    case CEPH_MSG_CLIENT_LEASE:
+      ALLOW_MESSAGES_FROM(CEPH_ENTITY_TYPE_CLIENT);
+      locker->dispatch(m);
+      break;
+      
+    default:
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Advance finished_queue and waiting_for_nolaggy.
+ *
+ * Usually drain both queues, but may not drain waiting_for_nolaggy
+ * if beacon is currently laggy.
+ */
+void MDSRank::_advance_queues()
+{
+  assert(mds_lock.is_locked_by_me());
+
+  while (!finished_queue.empty()) {
+    dout(7) << "mds has " << finished_queue.size() << " queued contexts" << dendl;
+    dout(10) << finished_queue << dendl;
+    list<MDSInternalContextBase*> ls;
+    ls.swap(finished_queue);
+    while (!ls.empty()) {
+      dout(10) << " finish " << ls.front() << dendl;
+      ls.front()->complete(0);
+      ls.pop_front();
+
+      heartbeat_reset();
+    }
+  }
+
+  while (!waiting_for_nolaggy.empty()) {
+    // stop if we're laggy now!
+    if (mds_daemon->beacon.is_laggy())
+      break;
+
+    Message *old = waiting_for_nolaggy.front();
+    waiting_for_nolaggy.pop_front();
+
+    if (is_stale_message(old)) {
+      old->put();
+    } else {
+      dout(7) << " processing laggy deferred " << *old << dendl;
+      handle_deferrable_message(old);
+    }
+
+    heartbeat_reset();
+  }
+}
+
+/**
+ * Call this when you take mds_lock, or periodically if you're going to
+ * hold the lock for a long time (e.g. iterating over clients/inodes)
+ */
+void MDSRank::heartbeat_reset()
+{
+  // Any thread might jump into mds_lock and call us immediately
+  // after a call to suicide() completes, in which case MDSRank::hb
+  // has been freed and we are a no-op.
+  if (!hb) {
+      assert(want_state == CEPH_MDS_STATE_DNE);
+      return;
+  }
+
+  // NB not enabling suicide grace, because the mon takes care of killing us
+  // (by blacklisting us) when we fail to send beacons, and it's simpler to
+  // only have one way of dying.
+  g_ceph_context->get_heartbeat_map()->reset_timeout(hb, g_conf->mds_beacon_grace, 0);
+}
+
+bool MDSRank::is_stale_message(Message *m)
+{
+  // from bad mds?
+  if (m->get_source().is_mds()) {
+    mds_rank_t from = mds_rank_t(m->get_source().num());
+    if (!mdsmap->have_inst(from) ||
+	mdsmap->get_inst(from) != m->get_source_inst() ||
+	mdsmap->is_down(from)) {
+      // bogus mds?
+      if (m->get_type() == CEPH_MSG_MDS_MAP) {
+	dout(5) << "got " << *m << " from old/bad/imposter mds " << m->get_source()
+		<< ", but it's an mdsmap, looking at it" << dendl;
+      } else if (m->get_type() == MSG_MDS_CACHEEXPIRE &&
+		 mdsmap->get_inst(from) == m->get_source_inst()) {
+	dout(5) << "got " << *m << " from down mds " << m->get_source()
+		<< ", but it's a cache_expire, looking at it" << dendl;
+      } else {
+	dout(5) << "got " << *m << " from down/old/bad/imposter mds " << m->get_source()
+		<< ", dropping" << dendl;
+	return true;
+      }
+    }
+  }
+  return false;
+}
+
+
+void MDSRank::send_message(Message *m, Connection *c)
+{ 
+  assert(c);
+  c->send_message(m);
+}
+
+
+void MDSRank::send_message_mds(Message *m, mds_rank_t mds)
+{
+  if (!mdsmap->is_up(mds)) {
+    dout(10) << "send_message_mds mds." << mds << " not up, dropping " << *m << dendl;
+    m->put();
+    return;
+  }
+
+  // send mdsmap first?
+  if (mds != whoami && peer_mdsmap_epoch[mds] < mdsmap->get_epoch()) {
+    messenger->send_message(new MMDSMap(monc->get_fsid(), mdsmap), 
+			    mdsmap->get_inst(mds));
+    peer_mdsmap_epoch[mds] = mdsmap->get_epoch();
+  }
+
+  // send message
+  messenger->send_message(m, mdsmap->get_inst(mds));
+}
+
+void MDSRank::forward_message_mds(Message *m, mds_rank_t mds)
+{
+  assert(mds != whoami);
+
+  // client request?
+  if (m->get_type() == CEPH_MSG_CLIENT_REQUEST &&
+      (static_cast<MClientRequest*>(m))->get_source().is_client()) {
+    MClientRequest *creq = static_cast<MClientRequest*>(m);
+    creq->inc_num_fwd();    // inc forward counter
+
+    /*
+     * don't actually forward if non-idempotent!
+     * client has to do it.  although the MDS will ignore duplicate requests,
+     * the affected metadata may migrate, in which case the new authority
+     * won't have the metareq_id in the completed request map.
+     */
+    // NEW: always make the client resend!  
+    bool client_must_resend = true;  //!creq->can_forward();
+
+    // tell the client where it should go
+    messenger->send_message(new MClientRequestForward(creq->get_tid(), mds, creq->get_num_fwd(),
+						      client_must_resend),
+			    creq->get_source_inst());
+    
+    if (client_must_resend) {
+      m->put();
+      return; 
+    }
+  }
+
+  // these are the only types of messages we should be 'forwarding'; they
+  // explicitly encode their source mds, which gets clobbered when we resend
+  // them here.
+  assert(m->get_type() == MSG_MDS_DIRUPDATE ||
+	 m->get_type() == MSG_MDS_EXPORTDIRDISCOVER);
+
+  // send mdsmap first?
+  if (peer_mdsmap_epoch[mds] < mdsmap->get_epoch()) {
+    messenger->send_message(new MMDSMap(monc->get_fsid(), mdsmap), 
+			    mdsmap->get_inst(mds));
+    peer_mdsmap_epoch[mds] = mdsmap->get_epoch();
+  }
+
+  messenger->send_message(m, mdsmap->get_inst(mds));
+}
+
+
+
+void MDSRank::send_message_client_counted(Message *m, client_t client)
+{
+  Session *session =  sessionmap.get_session(entity_name_t::CLIENT(client.v));
+  if (session) {
+    send_message_client_counted(m, session);
+  } else {
+    dout(10) << "send_message_client_counted no session for client." << client << " " << *m << dendl;
+  }
+}
+
+void MDSRank::send_message_client_counted(Message *m, Connection *connection)
+{
+  Session *session = static_cast<Session *>(connection->get_priv());
+  if (session) {
+    session->put();  // do not carry ref
+    send_message_client_counted(m, session);
+  } else {
+    dout(10) << "send_message_client_counted has no session for " << m->get_source_inst() << dendl;
+    // another Connection took over the Session
+  }
+}
+
+void MDSRank::send_message_client_counted(Message *m, Session *session)
+{
+  version_t seq = session->inc_push_seq();
+  dout(10) << "send_message_client_counted " << session->info.inst.name << " seq "
+	   << seq << " " << *m << dendl;
+  if (session->connection) {
+    session->connection->send_message(m);
+  } else {
+    session->preopen_out_queue.push_back(m);
+  }
+}
+
+void MDSRank::send_message_client(Message *m, Session *session)
+{
+  dout(10) << "send_message_client " << session->info.inst << " " << *m << dendl;
+  if (session->connection) {
+    session->connection->send_message(m);
+  } else {
+    session->preopen_out_queue.push_back(m);
+  }
+}
+
+/**
+ * This is used whenever a RADOS operation has been cancelled
+ * or a RADOS client has been blacklisted, to cause the MDS and
+ * any clients to wait for this OSD epoch before using any new caps.
+ *
+ * See doc/cephfs/eviction
+ */
+void MDSRank::set_osd_epoch_barrier(epoch_t e)
+{
+  dout(4) << __func__ << ": epoch=" << e << dendl;
+  osd_epoch_barrier = e;
+}
+
+/**
+ * FIXME ugly call up to MDS daemon until the dispatching is separated out
+ */
+void MDSRank::dispatch(Message *m)
+{
+  mds_daemon->inc_dispatch_depth();
+  mds_daemon->_dispatch(m, false);
+  mds_daemon->dec_dispatch_depth();
+}
+
+utime_t MDSRank::get_laggy_until() const
+{
+  return mds_daemon->beacon.get_laggy_until();
+}
+
+// FIXME maybe instead of exposing this to the world, we should just
+// share a MonClient reference with the guys who need it (balancer+snapserver)
+void MDSRank::send_mon_message(Message *m)
+{
+  monc->send_mon_message(m);
+}
+
+uint64_t MDSRank::get_global_id() const
+{
+  return monc->get_global_id();
+}
+
+bool MDSRank::is_daemon_stopping() const
+{
+  return mds_daemon->stopping;
+}

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -132,6 +132,9 @@ MDSRank::~MDSRank()
 
 void MDSRank::init(mds_rank_t rank_, int incarnation_)
 {
+  update_log_config();
+  create_logger();
+
   incarnation = incarnation;
   whoami = rank_;
 
@@ -202,12 +205,7 @@ void MDSRank::shutdown()
   assert(stopping == false);
   stopping = true;
 
-  // FIXME this check no longer needed once MDSRank object lifetime
-  // is just while a real rank is held
-  if (whoami == MDS_RANK_NONE) {
-    beacon.shutdown();
-    return;
-  }
+  dout(1) << __func__ << ": shutting down rank " << whoami << dendl;
 
   if (!mdsmap->is_dne_gid(mds_gid_t(monc->get_global_id()))) {
     // Notify the MDSMonitor that we're dying, so that it doesn't have to

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -139,12 +139,25 @@ void MDSRank::respawn()
 
 void MDSRank::damaged()
 {
-  mds_daemon->damaged();
+  assert(whoami != MDS_RANK_NONE);
+  assert(mds_lock.is_locked_by_me());
+
+  set_want_state(MDSMap::STATE_DAMAGED);
+  monc->flush_log();  // Flush any clog error from before we were called
+  beacon.notify_health(this);  // Include latest status in our swan song
+  beacon.send_and_wait(g_conf->mds_mon_shutdown_timeout);
+
+  // It's okay if we timed out and the mon didn't get our beacon, because
+  // another daemon (or ourselves after respawn) will eventually take the
+  // rank and report DAMAGED again when it hits same problem we did.
+
+  respawn();  // Respawn into standby in case mon has other work for us
 }
 
 void MDSRank::damaged_unlocked()
 {
-  mds_daemon->damaged_unlocked();
+  Mutex::Locker l(mds_lock);
+  damaged();
 }
 
 void MDSRank::handle_write_error(int err)
@@ -1010,8 +1023,9 @@ void MDSRank::reconnect_start()
 {
   dout(1) << "reconnect_start" << dendl;
 
-  if (last_state == MDSMap::STATE_REPLAY)
+  if (last_state == MDSMap::STATE_REPLAY) {
     reopen_log();
+  }
 
   server->reconnect_clients(new C_VoidFn(this, &MDSRank::reconnect_done));
   finish_contexts(g_ceph_context, waiting_for_reconnect);
@@ -1075,8 +1089,9 @@ void MDSRank::active_start()
 {
   dout(1) << "active_start" << dendl;
 
-  if (last_state == MDSMap::STATE_CREATING)
+  if (last_state == MDSMap::STATE_CREATING) {
     mdcache->open_root();
+  }
 
   mdcache->clean_open_file_lists();
   mdcache->export_remaining_imported_caps();
@@ -1200,3 +1215,271 @@ void MDSRank::set_want_state(MDSMap::DaemonState newstate)
 }
 
 // <<<<<<<<
+
+void MDSRank::handle_mds_map_rank(
+    MMDSMap *m,
+    MDSMap *oldmap,
+    int oldwhoami,
+    MDSMap::DaemonState oldstate)
+{
+  // I am only to be passed MDSMaps in which I hold a rank
+  assert(whoami != MDS_RANK_NONE);
+
+  version_t epoch = m->get_epoch();
+
+  // note source's map version
+  if (m->get_source().is_mds() && 
+      peer_mdsmap_epoch[mds_rank_t(m->get_source().num())] < epoch) {
+    dout(15) << " peer " << m->get_source()
+	     << " has mdsmap epoch >= " << epoch
+	     << dendl;
+    peer_mdsmap_epoch[mds_rank_t(m->get_source().num())] = epoch;
+  }
+
+  // Once I hold a rank it can't be taken away without
+  // restarting this daemon
+  if (whoami != oldwhoami && oldwhoami != MDS_RANK_NONE) {
+    derr << "Invalid rank transition " << oldwhoami << "->" << whoami << dendl;
+    respawn();
+  }
+
+  // Validate state transitions while I hold a rank
+  bool state_valid = true;
+  if (state != oldstate) {
+    if (oldstate == MDSMap::STATE_REPLAY) {
+      if (state != MDSMap::STATE_RESOLVE && state != MDSMap::STATE_RECONNECT) {
+        state_valid = false;
+      }
+    } else if (oldstate == MDSMap::STATE_REJOIN) {
+      if (state != MDSMap::STATE_ACTIVE
+          && state != MDSMap::STATE_CLIENTREPLAY
+          && state != MDSMap::STATE_STOPPED) {
+        state_valid = false;
+      }
+    } else if (oldstate >= MDSMap::STATE_RECONNECT && oldstate < MDSMap::STATE_ACTIVE) {
+      // Once I have entered replay, the only allowable transitions are to
+      // the next state along in the sequence.
+      if (state != oldstate + 1) {
+        state_valid = false;
+      }
+    }
+  }
+
+  if (!state_valid) {
+    derr << "Invalid state transition " << ceph_mds_state_name(oldstate)
+      << "->" << ceph_mds_state_name(state) << dendl;
+    respawn();
+  }
+
+  if (oldwhoami != whoami || oldstate != state) {
+    // update messenger.
+    if (state == MDSMap::STATE_STANDBY_REPLAY || state == MDSMap::STATE_ONESHOT_REPLAY) {
+      dout(1) << "handle_mds_map i am now mds." << monc->get_global_id() << "." << incarnation
+	      << "replaying mds." << whoami << "." << incarnation << dendl;
+      messenger->set_myname(entity_name_t::MDS(monc->get_global_id()));
+    } else {
+      dout(1) << "handle_mds_map i am now mds." << whoami << "." << incarnation << dendl;
+      messenger->set_myname(entity_name_t::MDS(whoami));
+    }
+  }
+
+  // tell objecter my incarnation
+  if (objecter->get_client_incarnation() != incarnation)
+    objecter->set_client_incarnation(incarnation);
+
+  // for debug
+  if (g_conf->mds_dump_cache_on_map)
+    mdcache->dump_cache();
+
+  // did it change?
+  if (oldstate != state) {
+    dout(1) << "handle_mds_map state change "
+	    << ceph_mds_state_name(oldstate) << " --> "
+	    << ceph_mds_state_name(state) << dendl;
+    set_want_state(state);
+
+    if (oldstate == MDSMap::STATE_STANDBY_REPLAY) {
+        dout(10) << "Monitor activated us! Deactivating replay loop" << dendl;
+        assert (state == MDSMap::STATE_REPLAY);
+    } else {
+      // did i just recover?
+      if ((is_active() || is_clientreplay()) &&
+          (oldstate == MDSMap::STATE_CREATING ||
+	   oldstate == MDSMap::STATE_REJOIN ||
+	   oldstate == MDSMap::STATE_RECONNECT))
+        recovery_done(oldstate);
+
+      if (is_active()) {
+        active_start();
+      } else if (is_any_replay()) {
+        replay_start();
+      } else if (is_resolve()) {
+        resolve_start();
+      } else if (is_reconnect()) {
+        reconnect_start();
+      } else if (is_rejoin()) {
+	rejoin_start();
+      } else if (is_clientreplay()) {
+        clientreplay_start();
+      } else if (is_creating()) {
+        boot_create();
+      } else if (is_starting()) {
+        boot_start();
+      } else if (is_stopping()) {
+        assert(oldstate == MDSMap::STATE_ACTIVE);
+        stopping_start();
+      }
+    }
+  }
+  
+  // RESOLVE
+  // is someone else newly resolving?
+  if (is_resolve() || is_reconnect() || is_rejoin() ||
+      is_clientreplay() || is_active() || is_stopping()) {
+    if (!oldmap->is_resolving() && mdsmap->is_resolving()) {
+      set<mds_rank_t> resolve;
+      mdsmap->get_mds_set(resolve, MDSMap::STATE_RESOLVE);
+      dout(10) << " resolve set is " << resolve << dendl;
+      calc_recovery_set();
+      mdcache->send_resolves();
+    }
+  }
+  
+  // REJOIN
+  // is everybody finally rejoining?
+  if (is_rejoin() || is_clientreplay() || is_active() || is_stopping()) {
+    // did we start?
+    if (!oldmap->is_rejoining() && mdsmap->is_rejoining())
+      rejoin_joint_start();
+
+    // did we finish?
+    if (g_conf->mds_dump_cache_after_rejoin &&
+	oldmap->is_rejoining() && !mdsmap->is_rejoining()) 
+      mdcache->dump_cache();      // for DEBUG only
+
+    if (oldstate >= MDSMap::STATE_REJOIN) {
+      // ACTIVE|CLIENTREPLAY|REJOIN => we can discover from them.
+      set<mds_rank_t> olddis, dis;
+      oldmap->get_mds_set(olddis, MDSMap::STATE_ACTIVE);
+      oldmap->get_mds_set(olddis, MDSMap::STATE_CLIENTREPLAY);
+      oldmap->get_mds_set(olddis, MDSMap::STATE_REJOIN);
+      mdsmap->get_mds_set(dis, MDSMap::STATE_ACTIVE);
+      mdsmap->get_mds_set(dis, MDSMap::STATE_CLIENTREPLAY);
+      mdsmap->get_mds_set(dis, MDSMap::STATE_REJOIN);
+      for (set<mds_rank_t>::iterator p = dis.begin(); p != dis.end(); ++p)
+	if (*p != whoami &&            // not me
+	    olddis.count(*p) == 0) {  // newly so?
+	  mdcache->kick_discovers(*p);
+	  mdcache->kick_open_ino_peers(*p);
+	}
+    }
+  }
+
+  if (oldmap->is_degraded() && !mdsmap->is_degraded() && state >= MDSMap::STATE_ACTIVE)
+    dout(1) << "cluster recovered." << dendl;
+
+  // did someone go active?
+  if (oldstate >= MDSMap::STATE_CLIENTREPLAY &&
+      (is_clientreplay() || is_active() || is_stopping())) {
+    set<mds_rank_t> oldactive, active;
+    oldmap->get_mds_set(oldactive, MDSMap::STATE_ACTIVE);
+    oldmap->get_mds_set(oldactive, MDSMap::STATE_CLIENTREPLAY);
+    mdsmap->get_mds_set(active, MDSMap::STATE_ACTIVE);
+    mdsmap->get_mds_set(active, MDSMap::STATE_CLIENTREPLAY);
+    for (set<mds_rank_t>::iterator p = active.begin(); p != active.end(); ++p) 
+      if (*p != whoami &&            // not me
+	  oldactive.count(*p) == 0)  // newly so?
+	handle_mds_recovery(*p);
+  }
+
+  // did someone fail?
+  //   new down?
+  {
+    set<mds_rank_t> olddown, down;
+    oldmap->get_down_mds_set(&olddown);
+    mdsmap->get_down_mds_set(&down);
+    for (set<mds_rank_t>::iterator p = down.begin(); p != down.end(); ++p) {
+      if (olddown.count(*p) == 0) {
+        messenger->mark_down(oldmap->get_inst(*p).addr);
+        handle_mds_failure(*p);
+      }
+    }
+  }
+
+  // did someone fail?
+  //   did their addr/inst change?
+  {
+    set<mds_rank_t> up;
+    mdsmap->get_up_mds_set(up);
+    for (set<mds_rank_t>::iterator p = up.begin(); p != up.end(); ++p) {
+      if (oldmap->have_inst(*p) &&
+         oldmap->get_inst(*p) != mdsmap->get_inst(*p)) {
+        messenger->mark_down(oldmap->get_inst(*p).addr);
+        handle_mds_failure(*p);
+      }
+    }
+  }
+
+  if (is_clientreplay() || is_active() || is_stopping()) {
+    // did anyone stop?
+    set<mds_rank_t> oldstopped, stopped;
+    oldmap->get_stopped_mds_set(oldstopped);
+    mdsmap->get_stopped_mds_set(stopped);
+    for (set<mds_rank_t>::iterator p = stopped.begin(); p != stopped.end(); ++p) 
+      if (oldstopped.count(*p) == 0)      // newly so?
+	mdcache->migrator->handle_mds_failure_or_stop(*p);
+  }
+
+  if (!is_any_replay())
+    balancer->try_rebalance();
+
+  {
+    map<epoch_t,list<MDSInternalContextBase*> >::iterator p = waiting_for_mdsmap.begin();
+    while (p != waiting_for_mdsmap.end() && p->first <= mdsmap->get_epoch()) {
+      list<MDSInternalContextBase*> ls;
+      ls.swap(p->second);
+      waiting_for_mdsmap.erase(p++);
+      finish_contexts(g_ceph_context, ls);
+    }
+  }
+
+  if (is_active()) {
+    // Before going active, set OSD epoch barrier to latest (so that
+    // we don't risk handing out caps to clients with old OSD maps that
+    // might not include barriers from the previous incarnation of this MDS)
+    const OSDMap *osdmap = objecter->get_osdmap_read();
+    const epoch_t osd_epoch = osdmap->get_epoch();
+    objecter->put_osdmap_read();
+    set_osd_epoch_barrier(osd_epoch);
+  }
+
+  mdcache->notify_mdsmap_changed();
+}
+
+void MDSRank::handle_mds_recovery(mds_rank_t who) 
+{
+  dout(5) << "handle_mds_recovery mds." << who << dendl;
+  
+  mdcache->handle_mds_recovery(who);
+
+  if (mdsmap->get_tableserver() == whoami) {
+    snapserver->handle_mds_recovery(who);
+  }
+
+  queue_waiters(waiting_for_active_peer[who]);
+  waiting_for_active_peer.erase(who);
+}
+
+void MDSRank::handle_mds_failure(mds_rank_t who)
+{
+  if (who == whoami) {
+    dout(5) << "handle_mds_failure for myself; not doing anything" << dendl;
+    return;
+  }
+  dout(5) << "handle_mds_failure mds." << who << dendl;
+
+  mdcache->handle_mds_failure(who);
+
+  snapclient->handle_mds_failure(who);
+}
+

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -27,6 +27,7 @@
 #include "messages/MMDSTableRequest.h"
 #include "Locker.h"
 #include "Server.h"
+#include "InoTable.h"
 #include "mon/MonClient.h"
 #include "common/HeartbeatMap.h"
 
@@ -60,9 +61,13 @@ MDSRank::MDSRank(
                g_conf->osd_num_op_tracker_shard),
     last_state(MDSMap::STATE_NULL), want_state(MDSMap::STATE_NULL),
     state(MDSMap::STATE_NULL),
-    progress_thread(this),
+    progress_thread(this), dispatch_depth(0),
     hb(NULL), last_tid(0), osd_epoch_barrier(0), beacon(beacon_),
-    finisher(finisher_), mds_daemon(mds_daemon_), messenger(msgr), monc(monc_)
+    finisher(finisher_), mds_daemon(mds_daemon_), messenger(msgr), monc(monc_),
+
+    standby_for_rank(MDSMap::MDS_NO_STANDBY_PREF),
+    standby_type(MDSMap::STATE_NULL),
+    standby_replaying(false)
 {
   hb = g_ceph_context->get_heartbeat_map()->add_worker("MDSRank");
 }
@@ -73,6 +78,31 @@ MDSRank::~MDSRank()
     g_ceph_context->get_heartbeat_map()->remove_worker(hb);
   }
 }
+
+/**
+ * Helper for simple callbacks that call a void fn with no args.
+ */
+class C_VoidFn : public MDSInternalContext
+{
+  typedef void (MDSRank::*fn_ptr)();
+  protected:
+   MDSRank *mds_daemon;
+   fn_ptr fn; 
+  public:
+  C_VoidFn(MDSRank *mds_, fn_ptr fn_)
+    : MDSInternalContext(mds_), mds_daemon(mds_), fn(fn_)
+  {
+    assert(mds_);
+    assert(fn_);
+  }
+
+  void finish(int r)
+  {
+    (mds_daemon->*fn)();
+  }
+};
+
+
 
 uint64_t MDSRank::get_metadata_pool()
 {
@@ -173,6 +203,168 @@ void MDSRank::ProgressThread::shutdown()
       join();
     mds->mds_lock.Lock();
   }
+}
+
+bool MDSRank::handle_rank_message(Message *m)
+{
+  bool ret;
+  inc_dispatch_depth();
+  ret = _dispatch(m, true);
+  dec_dispatch_depth();
+  return ret;
+}
+
+/* If this function returns true, it has put the message. If it returns false,
+ * it has not put the message. */
+bool MDSRank::_dispatch(Message *m, bool new_msg)
+{
+  if (is_stale_message(m)) {
+    m->put();
+    return true;
+  }
+
+  if (beacon.is_laggy()) {
+    dout(10) << " laggy, deferring " << *m << dendl;
+    waiting_for_nolaggy.push_back(m);
+  } else if (new_msg && !waiting_for_nolaggy.empty()) {
+    dout(10) << " there are deferred messages, deferring " << *m << dendl;
+    waiting_for_nolaggy.push_back(m);
+  } else {
+    if (!handle_deferrable_message(m)) {
+      dout(0) << "unrecognized message " << *m << dendl;
+      m->put();
+      return false;
+    }
+  }
+
+  if (dispatch_depth > 1)
+    return true;
+
+  // finish any triggered contexts
+  _advance_queues();
+
+  if (beacon.is_laggy()) {
+    // We've gone laggy during dispatch, don't do any
+    // more housekeeping
+    return true;
+  }
+
+  // done with all client replayed requests?
+  if (is_clientreplay() &&
+      mdcache->is_open() &&
+      replay_queue.empty() &&
+      want_state == MDSMap::STATE_CLIENTREPLAY) {
+    int num_requests = mdcache->get_num_client_requests();
+    dout(10) << " still have " << num_requests << " active replay requests" << dendl;
+    if (num_requests == 0)
+      clientreplay_done();
+  }
+
+  // hack: thrash exports
+  static utime_t start;
+  utime_t now = ceph_clock_now(g_ceph_context);
+  if (start == utime_t()) 
+    start = now;
+  /*double el = now - start;
+  if (el > 30.0 &&
+    el < 60.0)*/
+  for (int i=0; i<g_conf->mds_thrash_exports; i++) {
+    set<mds_rank_t> s;
+    if (!is_active()) break;
+    mdsmap->get_mds_set(s, MDSMap::STATE_ACTIVE);
+    if (s.size() < 2 || mdcache->get_num_inodes() < 10) 
+      break;  // need peers for this to work.
+
+    dout(7) << "mds thrashing exports pass " << (i+1) << "/" << g_conf->mds_thrash_exports << dendl;
+    
+    // pick a random dir inode
+    CInode *in = mdcache->hack_pick_random_inode();
+
+    list<CDir*> ls;
+    in->get_dirfrags(ls);
+    if (!ls.empty()) {	// must be an open dir.
+      list<CDir*>::iterator p = ls.begin();
+      int n = rand() % ls.size();
+      while (n--)
+        ++p;
+      CDir *dir = *p;
+      if (!dir->get_parent_dir()) continue;    // must be linked.
+      if (!dir->is_auth()) continue;           // must be auth.
+  
+      mds_rank_t dest;
+      do {
+        int k = rand() % s.size();
+        set<mds_rank_t>::iterator p = s.begin();
+        while (k--) ++p;
+        dest = *p;
+      } while (dest == whoami);
+      mdcache->migrator->export_dir_nicely(dir,dest);
+    }
+  }
+  // hack: thrash fragments
+  for (int i=0; i<g_conf->mds_thrash_fragments; i++) {
+    if (!is_active()) break;
+    if (mdcache->get_num_fragmenting_dirs() > 5) break;
+    dout(7) << "mds thrashing fragments pass " << (i+1) << "/" << g_conf->mds_thrash_fragments << dendl;
+    
+    // pick a random dir inode
+    CInode *in = mdcache->hack_pick_random_inode();
+
+    list<CDir*> ls;
+    in->get_dirfrags(ls);
+    if (ls.empty()) continue;                // must be an open dir.
+    CDir *dir = ls.front();
+    if (!dir->get_parent_dir()) continue;    // must be linked.
+    if (!dir->is_auth()) continue;           // must be auth.
+    frag_t fg = dir->get_frag();
+    if (fg == frag_t() || (rand() % (1 << fg.bits()) == 0))
+      mdcache->split_dir(dir, 1);
+    else
+      balancer->queue_merge(dir);
+  }
+
+  // hack: force hash root?
+  /*
+  if (false &&
+      mdcache->get_root() &&
+      mdcache->get_root()->dir &&
+      !(mdcache->get_root()->dir->is_hashed() || 
+        mdcache->get_root()->dir->is_hashing())) {
+    dout(0) << "hashing root" << dendl;
+    mdcache->migrator->hash_dir(mdcache->get_root()->dir);
+  }
+  */
+
+  if (mlogger) {
+    mlogger->set(l_mdm_ino, g_num_ino);
+    mlogger->set(l_mdm_dir, g_num_dir);
+    mlogger->set(l_mdm_dn, g_num_dn);
+    mlogger->set(l_mdm_cap, g_num_cap);
+
+    mlogger->inc(l_mdm_inoa, g_num_inoa);  g_num_inoa = 0;
+    mlogger->inc(l_mdm_inos, g_num_inos);  g_num_inos = 0;
+    mlogger->inc(l_mdm_dira, g_num_dira);  g_num_dira = 0;
+    mlogger->inc(l_mdm_dirs, g_num_dirs);  g_num_dirs = 0;
+    mlogger->inc(l_mdm_dna, g_num_dna);  g_num_dna = 0;
+    mlogger->inc(l_mdm_dns, g_num_dns);  g_num_dns = 0;
+    mlogger->inc(l_mdm_capa, g_num_capa);  g_num_capa = 0;
+    mlogger->inc(l_mdm_caps, g_num_caps);  g_num_caps = 0;
+
+    mlogger->set(l_mdm_buf, buffer::get_total_alloc());
+  }
+
+  // shut down?
+  if (is_stopping()) {
+    mdlog->trim();
+    if (mdcache->shutdown_pass()) {
+      dout(7) << "shutdown_pass=true, finished w/ shutdown, moving to down:stopped" << dendl;
+      stopping_done();
+    }
+    else {
+      dout(7) << "shutdown_pass=false" << dendl;
+    }
+  }
+  return true;
 }
 
 /*
@@ -472,11 +664,11 @@ void MDSRank::set_osd_epoch_barrier(epoch_t e)
 /**
  * FIXME ugly call up to MDS daemon until the dispatching is separated out
  */
-void MDSRank::dispatch(Message *m)
+void MDSRank::retry_dispatch(Message *m)
 {
-  mds_daemon->inc_dispatch_depth();
-  mds_daemon->_dispatch(m, false);
-  mds_daemon->dec_dispatch_depth();
+  inc_dispatch_depth();
+  _dispatch(m, false);
+  dec_dispatch_depth();
 }
 
 utime_t MDSRank::get_laggy_until() const
@@ -500,3 +692,511 @@ bool MDSRank::is_daemon_stopping() const
 {
   return mds_daemon->stopping;
 }
+
+// FIXME>> this fns are state-machiney, not dispatchy
+// >>>>>
+
+void MDSRank::request_state(MDSMap::DaemonState s)
+{
+  dout(3) << "request_state " << ceph_mds_state_name(s) << dendl;
+  set_want_state(s);
+  beacon.send();
+}
+
+
+class C_MDS_BootStart : public MDSInternalContext {
+  MDSRank::BootStep nextstep;
+public:
+  C_MDS_BootStart(MDSRank *m, MDSRank::BootStep n)
+    : MDSInternalContext(m), nextstep(n) {}
+  void finish(int r) {
+    mds->boot_start(nextstep, r);
+  }
+};
+
+
+void MDSRank::boot_start(BootStep step, int r)
+{
+  // Handle errors from previous step
+  if (r < 0) {
+    if (is_standby_replay() && (r == -EAGAIN)) {
+      dout(0) << "boot_start encountered an error EAGAIN"
+              << ", respawning since we fell behind journal" << dendl;
+      respawn();
+    } else if (r == -EINVAL || r == -ENOENT) {
+      // Invalid or absent data, indicates damaged on-disk structures
+      clog->error() << "Error loading MDS rank " << whoami << ": "
+        << cpp_strerror(r);
+      damaged();
+      assert(r == 0);  // Unreachable, damaged() calls respawn()
+    } else {
+      // Completely unexpected error, give up and die
+      dout(0) << "boot_start encountered an error, failing" << dendl;
+      suicide();
+      return;
+    }
+  }
+
+  assert(is_starting() || is_any_replay());
+
+  switch(step) {
+    case MDS_BOOT_INITIAL:
+      {
+        mdcache->init_layouts();
+
+        MDSGatherBuilder gather(g_ceph_context,
+            new C_MDS_BootStart(this, MDS_BOOT_OPEN_ROOT));
+        dout(2) << "boot_start " << step << ": opening inotable" << dendl;
+        inotable->set_rank(whoami);
+        inotable->load(gather.new_sub());
+
+        dout(2) << "boot_start " << step << ": opening sessionmap" << dendl;
+        sessionmap.set_rank(whoami);
+        sessionmap.load(gather.new_sub());
+
+        dout(2) << "boot_start " << step << ": opening mds log" << dendl;
+        mdlog->open(gather.new_sub());
+
+        if (mdsmap->get_tableserver() == whoami) {
+          dout(2) << "boot_start " << step << ": opening snap table" << dendl;
+          snapserver->set_rank(whoami);
+          snapserver->load(gather.new_sub());
+        }
+
+        gather.activate();
+      }
+      break;
+    case MDS_BOOT_OPEN_ROOT:
+      {
+        dout(2) << "boot_start " << step << ": loading/discovering base inodes" << dendl;
+
+        MDSGatherBuilder gather(g_ceph_context,
+            new C_MDS_BootStart(this, MDS_BOOT_PREPARE_LOG));
+
+        mdcache->open_mydir_inode(gather.new_sub());
+
+        if (is_starting() ||
+            whoami == mdsmap->get_root()) {  // load root inode off disk if we are auth
+          mdcache->open_root_inode(gather.new_sub());
+        } else {
+          // replay.  make up fake root inode to start with
+          mdcache->create_root_inode();
+        }
+        gather.activate();
+      }
+      break;
+    case MDS_BOOT_PREPARE_LOG:
+      if (is_any_replay()) {
+        dout(2) << "boot_start " << step << ": replaying mds log" << dendl;
+        mdlog->replay(new C_MDS_BootStart(this, MDS_BOOT_REPLAY_DONE));
+      } else {
+        dout(2) << "boot_start " << step << ": positioning at end of old mds log" << dendl;
+        mdlog->append();
+        starting_done();
+      }
+      break;
+    case MDS_BOOT_REPLAY_DONE:
+      assert(is_any_replay());
+      replay_done();
+      break;
+  }
+}
+
+void MDSRank::starting_done()
+{
+  dout(3) << "starting_done" << dendl;
+  assert(is_starting());
+  request_state(MDSMap::STATE_ACTIVE);
+
+  mdcache->open_root();
+
+  // start new segment
+  mdlog->start_new_segment();
+}
+
+
+void MDSRank::calc_recovery_set()
+{
+  // initialize gather sets
+  set<mds_rank_t> rs;
+  mdsmap->get_recovery_mds_set(rs);
+  rs.erase(whoami);
+  mdcache->set_recovery_set(rs);
+
+  dout(1) << " recovery set is " << rs << dendl;
+}
+
+
+void MDSRank::replay_start()
+{
+  dout(1) << "replay_start" << dendl;
+
+  if (is_standby_replay())
+    standby_replaying = true;
+  
+  standby_type = MDSMap::STATE_NULL;
+
+  calc_recovery_set();
+
+  // Check if we need to wait for a newer OSD map before starting
+  Context *fin = new C_OnFinisher(new C_IO_Wrapper(this, new C_MDS_BootStart(this, MDS_BOOT_INITIAL)), finisher);
+  bool const ready = objecter->wait_for_map(
+      mdsmap->get_last_failure_osd_epoch(),
+      fin);
+
+  if (ready) {
+    delete fin;
+    boot_start();
+  } else {
+    dout(1) << " waiting for osdmap " << mdsmap->get_last_failure_osd_epoch() 
+	    << " (which blacklists prior instance)" << dendl;
+  }
+}
+
+
+class MDSRank::C_MDS_StandbyReplayRestartFinish : public MDSIOContext {
+  uint64_t old_read_pos;
+public:
+  C_MDS_StandbyReplayRestartFinish(MDSRank *mds_, uint64_t old_read_pos_) :
+    MDSIOContext(mds_), old_read_pos(old_read_pos_) {}
+  void finish(int r) {
+    mds->_standby_replay_restart_finish(r, old_read_pos);
+  }
+};
+
+void MDSRank::_standby_replay_restart_finish(int r, uint64_t old_read_pos)
+{
+  if (old_read_pos < mdlog->get_journaler()->get_trimmed_pos()) {
+    dout(0) << "standby MDS fell behind active MDS journal's expire_pos, restarting" << dendl;
+    respawn(); /* we're too far back, and this is easier than
+		  trying to reset everything in the cache, etc */
+  } else {
+    mdlog->standby_trim_segments();
+    boot_start(MDS_BOOT_PREPARE_LOG, r);
+  }
+}
+
+inline void MDSRank::standby_replay_restart()
+{
+  dout(1) << "standby_replay_restart"
+	  << (standby_replaying ? " (as standby)":" (final takeover pass)")
+	  << dendl;
+  if (standby_replaying) {
+    /* Go around for another pass of replaying in standby */
+    mdlog->get_journaler()->reread_head_and_probe(
+      new C_MDS_StandbyReplayRestartFinish(
+        this,
+	mdlog->get_journaler()->get_read_pos()));
+  } else {
+    /* We are transitioning out of standby: wait for OSD map update
+       before making final pass */
+    Context *fin = new C_OnFinisher(new C_IO_Wrapper(this,
+          new C_MDS_BootStart(this, MDS_BOOT_PREPARE_LOG)),
+      finisher);
+    bool const ready =
+      objecter->wait_for_map(mdsmap->get_last_failure_osd_epoch(), fin);
+    if (ready) {
+      delete fin;
+      mdlog->get_journaler()->reread_head_and_probe(
+        new C_MDS_StandbyReplayRestartFinish(
+          this,
+	  mdlog->get_journaler()->get_read_pos()));
+    } else {
+      dout(1) << " waiting for osdmap " << mdsmap->get_last_failure_osd_epoch() 
+              << " (which blacklists prior instance)" << dendl;
+    }
+  }
+}
+
+class MDSRank::C_MDS_StandbyReplayRestart : public MDSInternalContext {
+public:
+  C_MDS_StandbyReplayRestart(MDSRank *m) : MDSInternalContext(m) {}
+  void finish(int r) {
+    assert(!r);
+    mds->standby_replay_restart();
+  }
+};
+
+void MDSRank::replay_done()
+{
+  dout(1) << "replay_done" << (standby_replaying ? " (as standby)" : "") << dendl;
+
+  if (is_oneshot_replay()) {
+    dout(2) << "hack.  journal looks ok.  shutting down." << dendl;
+    suicide();
+    return;
+  }
+
+  if (is_standby_replay()) {
+    // The replay was done in standby state, and we are still in that state
+    assert(standby_replaying);
+    dout(10) << "setting replay timer" << dendl;
+    timer.add_event_after(g_conf->mds_replay_interval,
+                          new C_MDS_StandbyReplayRestart(this));
+    return;
+  } else if (standby_replaying) {
+    // The replay was done in standby state, we have now _left_ that state
+    dout(10) << " last replay pass was as a standby; making final pass" << dendl;
+    standby_replaying = false;
+    standby_replay_restart();
+    return;
+  } else {
+    // Replay is complete, journal read should be up to date
+    assert(mdlog->get_journaler()->get_read_pos() == mdlog->get_journaler()->get_write_pos());
+    assert(!is_standby_replay());
+
+    // Reformat and come back here
+    if (mdlog->get_journaler()->get_stream_format() < g_conf->mds_journal_format) {
+        dout(4) << "reformatting journal on standbyreplay->replay transition" << dendl;
+        mdlog->reopen(new C_MDS_BootStart(this, MDS_BOOT_REPLAY_DONE));
+        return;
+    }
+  }
+
+  dout(1) << "making mds journal writeable" << dendl;
+  mdlog->get_journaler()->set_writeable();
+  mdlog->get_journaler()->trim_tail();
+
+  if (g_conf->mds_wipe_sessions) {
+    dout(1) << "wiping out client sessions" << dendl;
+    sessionmap.wipe();
+    sessionmap.save(new C_MDSInternalNoop);
+  }
+  if (g_conf->mds_wipe_ino_prealloc) {
+    dout(1) << "wiping out ino prealloc from sessions" << dendl;
+    sessionmap.wipe_ino_prealloc();
+    sessionmap.save(new C_MDSInternalNoop);
+  }
+  if (g_conf->mds_skip_ino) {
+    inodeno_t i = g_conf->mds_skip_ino;
+    dout(1) << "skipping " << i << " inodes" << dendl;
+    inotable->skip_inos(i);
+    inotable->save(new C_MDSInternalNoop);
+  }
+
+  if (mdsmap->get_num_in_mds() == 1 &&
+      mdsmap->get_num_failed_mds() == 0) { // just me!
+    dout(2) << "i am alone, moving to state reconnect" << dendl;      
+    request_state(MDSMap::STATE_RECONNECT);
+  } else {
+    dout(2) << "i am not alone, moving to state resolve" << dendl;
+    request_state(MDSMap::STATE_RESOLVE);
+  }
+}
+
+void MDSRank::reopen_log()
+{
+  dout(1) << "reopen_log" << dendl;
+  mdcache->rollback_uncommitted_fragments();
+}
+
+
+void MDSRank::resolve_start()
+{
+  dout(1) << "resolve_start" << dendl;
+
+  reopen_log();
+
+  mdcache->resolve_start(new C_VoidFn(this, &MDSRank::resolve_done));
+  finish_contexts(g_ceph_context, waiting_for_resolve);
+}
+void MDSRank::resolve_done()
+{
+  dout(1) << "resolve_done" << dendl;
+  request_state(MDSMap::STATE_RECONNECT);
+}
+
+void MDSRank::reconnect_start()
+{
+  dout(1) << "reconnect_start" << dendl;
+
+  if (last_state == MDSMap::STATE_REPLAY)
+    reopen_log();
+
+  server->reconnect_clients(new C_VoidFn(this, &MDSRank::reconnect_done));
+  finish_contexts(g_ceph_context, waiting_for_reconnect);
+}
+void MDSRank::reconnect_done()
+{
+  dout(1) << "reconnect_done" << dendl;
+  request_state(MDSMap::STATE_REJOIN);    // move to rejoin state
+}
+
+void MDSRank::rejoin_joint_start()
+{
+  dout(1) << "rejoin_joint_start" << dendl;
+  mdcache->rejoin_send_rejoins();
+}
+void MDSRank::rejoin_start()
+{
+  dout(1) << "rejoin_start" << dendl;
+  mdcache->rejoin_start(new C_VoidFn(this, &MDSRank::rejoin_done));
+}
+void MDSRank::rejoin_done()
+{
+  dout(1) << "rejoin_done" << dendl;
+  mdcache->show_subtrees();
+  mdcache->show_cache();
+
+  // funny case: is our cache empty?  no subtrees?
+  if (!mdcache->is_subtrees()) {
+    if (whoami == 0) {
+      // The root should always have a subtree!
+      clog->error() << "No subtrees found for root MDS rank!";
+      damaged();
+      assert(mdcache->is_subtrees());
+    } else {
+      dout(1) << " empty cache, no subtrees, leaving cluster" << dendl;
+      request_state(MDSMap::STATE_STOPPED);
+    }
+    return;
+  }
+
+  if (replay_queue.empty())
+    request_state(MDSMap::STATE_ACTIVE);
+  else
+    request_state(MDSMap::STATE_CLIENTREPLAY);
+}
+
+void MDSRank::clientreplay_start()
+{
+  dout(1) << "clientreplay_start" << dendl;
+  finish_contexts(g_ceph_context, waiting_for_replay);  // kick waiters
+  queue_one_replay();
+}
+
+void MDSRank::clientreplay_done()
+{
+  dout(1) << "clientreplay_done" << dendl;
+  request_state(MDSMap::STATE_ACTIVE);
+}
+
+void MDSRank::active_start()
+{
+  dout(1) << "active_start" << dendl;
+
+  if (last_state == MDSMap::STATE_CREATING)
+    mdcache->open_root();
+
+  mdcache->clean_open_file_lists();
+  mdcache->export_remaining_imported_caps();
+  finish_contexts(g_ceph_context, waiting_for_replay);  // kick waiters
+  finish_contexts(g_ceph_context, waiting_for_active);  // kick waiters
+}
+
+void MDSRank::recovery_done(int oldstate)
+{
+  dout(1) << "recovery_done -- successful recovery!" << dendl;
+  assert(is_clientreplay() || is_active());
+  
+  // kick snaptable (resent AGREEs)
+  if (mdsmap->get_tableserver() == whoami) {
+    set<mds_rank_t> active;
+    mdsmap->get_clientreplay_or_active_or_stopping_mds_set(active);
+    snapserver->finish_recovery(active);
+  }
+
+  if (oldstate == MDSMap::STATE_CREATING)
+    return;
+
+  mdcache->start_recovered_truncates();
+  mdcache->do_file_recover();
+
+  mdcache->reissue_all_caps();
+  
+  // tell connected clients
+  //bcast_mds_map();     // not anymore, they get this from the monitor
+
+  mdcache->populate_mydir();
+}
+
+void MDSRank::creating_done()
+{
+  dout(1)<< "creating_done" << dendl;
+  request_state(MDSMap::STATE_ACTIVE);
+}
+
+void MDSRank::boot_create()
+{
+  dout(3) << "boot_create" << dendl;
+
+  MDSGatherBuilder fin(g_ceph_context, new C_VoidFn(this, &MDSRank::creating_done));
+
+  mdcache->init_layouts();
+
+  snapserver->set_rank(whoami);
+  inotable->set_rank(whoami);
+  sessionmap.set_rank(whoami);
+
+  // start with a fresh journal
+  dout(10) << "boot_create creating fresh journal" << dendl;
+  mdlog->create(fin.new_sub());
+
+  // open new journal segment, but do not journal subtree map (yet)
+  mdlog->prepare_new_segment();
+
+  if (whoami == mdsmap->get_root()) {
+    dout(3) << "boot_create creating fresh hierarchy" << dendl;
+    mdcache->create_empty_hierarchy(fin.get());
+  }
+
+  dout(3) << "boot_create creating mydir hierarchy" << dendl;
+  mdcache->create_mydir_hierarchy(fin.get());
+
+  // fixme: fake out inotable (reset, pretend loaded)
+  dout(10) << "boot_create creating fresh inotable table" << dendl;
+  inotable->reset();
+  inotable->save(fin.new_sub());
+
+  // write empty sessionmap
+  sessionmap.save(fin.new_sub());
+
+  // initialize tables
+  if (mdsmap->get_tableserver() == whoami) {
+    dout(10) << "boot_create creating fresh snaptable" << dendl;
+    snapserver->reset();
+    snapserver->save(fin.new_sub());
+  }
+
+  assert(g_conf->mds_kill_create_at != 1);
+
+  // ok now journal it
+  mdlog->journal_segment_subtree_map(fin.new_sub());
+  mdlog->flush();
+
+  fin.activate();
+}
+
+void MDSRank::stopping_start()
+{
+  dout(2) << "stopping_start" << dendl;
+
+  if (mdsmap->get_num_in_mds() == 1 && !sessionmap.empty()) {
+    // we're the only mds up!
+    dout(0) << "we are the last MDS, and have mounted clients: we cannot flush our journal.  suicide!" << dendl;
+    suicide();
+  }
+
+  mdcache->shutdown_start();
+}
+
+void MDSRank::stopping_done()
+{
+  dout(2) << "stopping_done" << dendl;
+
+  // tell monitor we shut down cleanly.
+  request_state(MDSMap::STATE_STOPPED);
+}
+
+void MDSRank::set_want_state(MDSMap::DaemonState newstate)
+{
+  if (want_state != newstate) {
+    dout(10) << __func__ << " "
+      << ceph_mds_state_name(want_state) << " -> "
+      << ceph_mds_state_name(newstate) << dendl;
+    want_state = newstate;
+    beacon.notify_want_state(newstate);
+  }
+}
+
+// <<<<<<<<

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -19,7 +19,7 @@
 #include "messages/MMDSMap.h"
 
 #include "MDSMap.h"
-#include "MDS.h"
+//#include "MDS.h"
 #include "mds_table_types.h"
 #include "SnapClient.h"
 #include "SnapServer.h"

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -39,6 +39,8 @@
 #define dout_prefix *_dout << "mds." << whoami << '.' << incarnation << ' '
 
 MDSRank::MDSRank(
+    mds_rank_t whoami_,
+    int incarnation_,
     Mutex &mds_lock_,
     LogChannelRef &clog_,
     SafeTimer &timer_,
@@ -50,8 +52,8 @@ MDSRank::MDSRank(
     Context *respawn_hook_,
     Context *suicide_hook_)
   :
-    whoami(MDS_RANK_NONE),
-    incarnation(0),
+    whoami(whoami_),
+    incarnation(incarnation_),
     mds_lock(mds_lock_), clog(clog_), timer(timer_),
     mdsmap(mdsmap_),
     objecter(objecter_),
@@ -130,13 +132,10 @@ MDSRank::~MDSRank()
   respawn_hook = NULL;
 }
 
-void MDSRankDispatcher::init(mds_rank_t rank_, int incarnation_)
+void MDSRankDispatcher::init()
 {
   update_log_config();
   create_logger();
-
-  incarnation = incarnation;
-  whoami = rank_;
 
   // Expose the OSDMap (already populated during MDS::init) to anyone
   // who is interested in it.
@@ -2371,6 +2370,8 @@ bool MDSRankDispatcher::handle_command_legacy(std::vector<std::string> args)
 }
 
 MDSRankDispatcher::MDSRankDispatcher(
+    mds_rank_t whoami_,
+    int incarnation_,
     Mutex &mds_lock_,
     LogChannelRef &clog_,
     SafeTimer &timer_,
@@ -2381,7 +2382,7 @@ MDSRankDispatcher::MDSRankDispatcher(
     Objecter *objecter_,
     Context *respawn_hook_,
     Context *suicide_hook_)
-  : MDSRank(mds_lock_, clog_, timer_, beacon_, mdsmap_, msgr, monc_, objecter_,
-            respawn_hook_, suicide_hook_)
+  : MDSRank(whoami_, incarnation_, mds_lock_, clog_, timer_, beacon_, mdsmap_,
+      msgr, monc_, objecter_, respawn_hook_, suicide_hook_)
 {}
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2298,3 +2298,87 @@ void MDSRank::bcast_mds_map()
   last_client_mdsmap_bcast = mdsmap->get_epoch();
 }
 
+
+bool MDSRank::handle_command_legacy(std::vector<std::string> args)
+{
+  if (args[0] == "dumpcache") {
+    if (args.size() > 1)
+      mdcache->dump_cache(args[1].c_str());
+    else
+      mdcache->dump_cache();
+  }
+  else if (args[0] == "session" && args[1] == "kill") {
+    Session *session = sessionmap.get_session(entity_name_t(CEPH_ENTITY_TYPE_CLIENT,
+							    strtol(args[2].c_str(), 0, 10)));
+    if (session)
+      server->kill_session(session, NULL);
+    else
+      dout(15) << "session " << session << " not in sessionmap!" << dendl;
+  } else if (args[0] == "issue_caps") {
+    long inum = strtol(args[1].c_str(), 0, 10);
+    CInode *in = mdcache->get_inode(inodeno_t(inum));
+    if (in) {
+      bool r = locker->issue_caps(in);
+      dout(20) << "called issue_caps on inode "  << inum
+	       << " with result " << r << dendl;
+    } else dout(15) << "inode " << inum << " not in mdcache!" << dendl;
+  } else if (args[0] == "try_eval") {
+    long inum = strtol(args[1].c_str(), 0, 10);
+    int mask = strtol(args[2].c_str(), 0, 10);
+    CInode * ino = mdcache->get_inode(inodeno_t(inum));
+    if (ino) {
+      locker->try_eval(ino, mask);
+      dout(20) << "try_eval(" << inum << ", " << mask << ")" << dendl;
+    } else dout(15) << "inode " << inum << " not in mdcache!" << dendl;
+  } else if (args[0] == "fragment_dir") {
+    if (args.size() == 4) {
+      filepath fp(args[1].c_str());
+      CInode *in = mdcache->cache_traverse(fp);
+      if (in) {
+	frag_t fg;
+	if (fg.parse(args[2].c_str())) {
+	  CDir *dir = in->get_dirfrag(fg);
+	  if (dir) {
+	    if (dir->is_auth()) {
+	      int by = atoi(args[3].c_str());
+	      if (by)
+		mdcache->split_dir(dir, by);
+	      else
+		dout(0) << "need to split by >0 bits" << dendl;
+	    } else dout(0) << "dir " << dir->dirfrag() << " not auth" << dendl;
+	  } else dout(0) << "dir " << in->ino() << " " << fg << " dne" << dendl;
+	} else dout(0) << " frag " << args[2] << " does not parse" << dendl;
+      } else dout(0) << "path " << fp << " not found" << dendl;
+    } else dout(0) << "bad syntax" << dendl;
+  } else if (args[0] == "merge_dir") {
+    if (args.size() == 3) {
+      filepath fp(args[1].c_str());
+      CInode *in = mdcache->cache_traverse(fp);
+      if (in) {
+	frag_t fg;
+	if (fg.parse(args[2].c_str())) {
+	  mdcache->merge_dir(in, fg);
+	} else dout(0) << " frag " << args[2] << " does not parse" << dendl;
+      } else dout(0) << "path " << fp << " not found" << dendl;
+    } else dout(0) << "bad syntax" << dendl;
+  } else if (args[0] == "export_dir") {
+    if (args.size() == 3) {
+      filepath fp(args[1].c_str());
+      mds_rank_t target = mds_rank_t(atoi(args[2].c_str()));
+      if (target != whoami && mdsmap->is_up(target) && mdsmap->is_in(target)) {
+	CInode *in = mdcache->cache_traverse(fp);
+	if (in) {
+	  CDir *dir = in->get_dirfrag(frag_t());
+	  if (dir && dir->is_auth()) {
+	    mdcache->migrator->export_dir(dir, target);
+	  } else dout(0) << "bad export_dir path dirfrag frag_t() or dir not auth" << dendl;
+	} else dout(0) << "bad export_dir path" << dendl;
+      } else dout(0) << "bad export_dir target syntax" << dendl;
+    } else dout(0) << "bad export_dir syntax" << dendl;
+  } else {
+    return false;
+  }
+
+  return true;
+}
+

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -77,10 +77,10 @@ MDSRank::MDSRank(
 
   mdcache = new MDCache(this);
   mdlog = new MDLog(this);
-  balancer = new MDBalancer(this, messenger);
+  balancer = new MDBalancer(this, messenger, monc);
 
   inotable = new InoTable(this);
-  snapserver = new SnapServer(this);
+  snapserver = new SnapServer(this, monc);
   snapclient = new SnapClient(this);
 
   server = new Server(this);
@@ -860,18 +860,6 @@ void MDSRank::retry_dispatch(Message *m)
 utime_t MDSRank::get_laggy_until() const
 {
   return beacon.get_laggy_until();
-}
-
-// FIXME maybe instead of exposing this to the world, we should just
-// share a MonClient reference with the guys who need it (balancer+snapserver)
-void MDSRank::send_mon_message(Message *m)
-{
-  monc->send_mon_message(m);
-}
-
-uint64_t MDSRank::get_global_id() const
-{
-  return monc->get_global_id();
 }
 
 bool MDSRank::is_daemon_stopping() const

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -180,13 +180,11 @@ class MDSRank {
 
     // The last different state I held before current
     MDSMap::DaemonState last_state;
-    // The state I am asking for in my beacons to the MDSMonitor
-    MDSMap::DaemonState want_state;
     // The state assigned to me by the MDSMap
     MDSMap::DaemonState state;
 
     MDSMap::DaemonState get_state() const { return state; } 
-    MDSMap::DaemonState get_want_state() const { return want_state; } 
+    MDSMap::DaemonState get_want_state() const { return beacon.get_want_state(); } 
 
     bool is_creating() { return state == MDSMap::STATE_CREATING; }
     bool is_starting() { return state == MDSMap::STATE_STARTING; }
@@ -381,7 +379,6 @@ class MDSRank {
     // >>>
     void calc_recovery_set();
     void request_state(MDSMap::DaemonState s);
-    void set_want_state(MDSMap::DaemonState newstate);
 
     mds_rank_t standby_for_rank;
     MDSMap::DaemonState standby_type;  // one of STANDBY_REPLAY, ONESHOT_REPLAY

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -1,0 +1,362 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#ifndef MDS_RANK_H_
+#define MDS_RANK_H_
+
+#include "common/TrackedOp.h"
+#include "common/LogClient.h"
+#include "common/Timer.h"
+
+#include "MDSMap.h"
+#include "SessionMap.h"
+#include "MDCache.h"
+#include "Migrator.h"
+
+// Full .h import instead of forward declaration for PerfCounter, for the
+// benefit of those including this header and using MDSRank::logger
+#include "common/perf_counters.h"
+
+enum {
+  l_mds_first = 2000,
+  l_mds_request,
+  l_mds_reply,
+  l_mds_reply_latency,
+  l_mds_forward,
+  l_mds_dir_fetch,
+  l_mds_dir_commit,
+  l_mds_dir_split,
+  l_mds_inode_max,
+  l_mds_inodes,
+  l_mds_inodes_top,
+  l_mds_inodes_bottom,
+  l_mds_inodes_pin_tail,
+  l_mds_inodes_pinned,
+  l_mds_inodes_expired,
+  l_mds_inodes_with_caps,
+  l_mds_caps,
+  l_mds_subtrees,
+  l_mds_traverse,
+  l_mds_traverse_hit,
+  l_mds_traverse_forward,
+  l_mds_traverse_discover,
+  l_mds_traverse_dir_fetch,
+  l_mds_traverse_remote_ino,
+  l_mds_traverse_lock,
+  l_mds_load_cent,
+  l_mds_dispatch_queue_len,
+  l_mds_exported,
+  l_mds_exported_inodes,
+  l_mds_imported,
+  l_mds_imported_inodes,
+  l_mds_last,
+};
+
+// memory utilization
+enum {
+  l_mdm_first = 2500,
+  l_mdm_ino,
+  l_mdm_inoa,
+  l_mdm_inos,
+  l_mdm_dir,
+  l_mdm_dira,
+  l_mdm_dirs,
+  l_mdm_dn,
+  l_mdm_dna,
+  l_mdm_dns,
+  l_mdm_cap,
+  l_mdm_capa,
+  l_mdm_caps,
+  l_mdm_rss,
+  l_mdm_heap,
+  l_mdm_malloc,
+  l_mdm_buf,
+  l_mdm_last,
+};
+
+namespace ceph {
+  struct heartbeat_handle_d;
+}
+
+class Server;
+class Locker;
+class MDCache;
+class MDLog;
+class MDBalancer;
+class InoTable;
+class SnapServer;
+class SnapClient;
+class MDSTableServer;
+class MDSTableClient;
+class MDS;
+class Messenger;
+class Objecter;
+class MonClient;
+class Finisher;
+
+/**
+ * The public part of this class's interface is what's exposed to all
+ * the various subsystems (server, mdcache, etc)
+ */
+class MDSRank {
+  public:
+    mds_rank_t whoami;
+
+    // FIXME: incarnation is logically a daemon property, not a rank property,
+    // but used in log msgs and set on objecter (objecter *is* logically
+    // a rank thing rather than daemon thing)
+    int incarnation;
+
+    mds_rank_t get_nodeid() const { return whoami; }
+    uint64_t get_metadata_pool();
+
+    // Reference to global MDS::mds_lock, so that users of MDSRank don't
+    // carry around references to the outer MDS, and we can substitute
+    // a separate lock here in future potentially.
+    Mutex &mds_lock;
+
+    bool is_daemon_stopping() const;
+
+    // Reference to global cluster log client, just to avoid initialising
+    // a separate one here.
+    LogChannelRef &clog;
+
+    // Reference to global timer utility, because MDSRank and MDSDaemon
+    // currently both use the same mds_lock, so it makes sense for them
+    // to share a timer.
+    SafeTimer &timer;
+
+    MDSMap *&mdsmap;
+
+    Objecter     *objecter;
+
+    // sub systems
+    Server       *server;
+    MDCache      *mdcache;
+    Locker       *locker;
+    MDLog        *mdlog;
+    MDBalancer   *balancer;
+
+    InoTable     *inotable;
+
+    SnapServer   *snapserver;
+    SnapClient   *snapclient;
+
+    MDSTableClient *get_table_client(int t);
+    MDSTableServer *get_table_server(int t);
+
+    SessionMap   sessionmap;
+    Session *get_session(client_t client) {
+      return sessionmap.get_session(entity_name_t::CLIENT(client.v));
+    }
+
+    PerfCounters       *logger, *mlogger;
+    OpTracker    op_tracker;
+
+    MDSMap::DaemonState last_state;
+    MDSMap::DaemonState want_state;    // the state i want
+    MDSMap::DaemonState state;         // my confirmed state
+    MDSMap::DaemonState get_state() { return state; } 
+    MDSMap::DaemonState get_want_state() { return want_state; } 
+
+
+    bool is_creating() { return state == MDSMap::STATE_CREATING; }
+    bool is_starting() { return state == MDSMap::STATE_STARTING; }
+    bool is_standby()  { return state == MDSMap::STATE_STANDBY; }
+    bool is_replay()   { return state == MDSMap::STATE_REPLAY; }
+    bool is_standby_replay() { return state == MDSMap::STATE_STANDBY_REPLAY; }
+    bool is_resolve()  { return state == MDSMap::STATE_RESOLVE; }
+    bool is_reconnect() { return state == MDSMap::STATE_RECONNECT; }
+    bool is_rejoin()   { return state == MDSMap::STATE_REJOIN; }
+    bool is_clientreplay()   { return state == MDSMap::STATE_CLIENTREPLAY; }
+    bool is_active()   { return state == MDSMap::STATE_ACTIVE; }
+    bool is_stopping() { return state == MDSMap::STATE_STOPPING; }
+    bool is_oneshot_replay()   { return state == MDSMap::STATE_ONESHOT_REPLAY; }
+    bool is_any_replay() { return (is_replay() || is_standby_replay() ||
+        is_oneshot_replay()); }
+    bool is_stopped()  { return mdsmap->is_stopped(whoami); }
+
+    void handle_write_error(int err);
+
+  protected:
+    class ProgressThread : public Thread {
+      MDSRank *mds;
+      Cond cond;
+      public:
+      ProgressThread(MDSRank *mds_) : mds(mds_) {}
+      void * entry(); 
+      void shutdown();
+      void signal() {cond.Signal();}
+    } progress_thread;
+
+    list<Message*> waiting_for_nolaggy;
+    list<MDSInternalContextBase*> finished_queue;
+
+    bool handle_deferrable_message(Message *m);
+    void _advance_queues();
+
+    ceph::heartbeat_handle_d *hb;  // Heartbeat for threads using mds_lock
+    void heartbeat_reset();
+
+    bool is_stale_message(Message *m);
+
+    map<mds_rank_t, version_t> peer_mdsmap_epoch;
+
+    ceph_tid_t last_tid;    // for mds-initiated requests (e.g. stray rename)
+
+    list<MDSInternalContextBase*> waiting_for_active, waiting_for_replay, waiting_for_reconnect, waiting_for_resolve;
+    list<MDSInternalContextBase*> replay_queue;
+    map<mds_rank_t, list<MDSInternalContextBase*> > waiting_for_active_peer;
+    map<epoch_t, list<MDSInternalContextBase*> > waiting_for_mdsmap;
+
+    epoch_t osd_epoch_barrier;
+
+  public:
+
+    void queue_waiter(MDSInternalContextBase *c) {
+      finished_queue.push_back(c);
+      progress_thread.signal();
+    }
+    void queue_waiters(list<MDSInternalContextBase*>& ls) {
+      finished_queue.splice( finished_queue.end(), ls );
+      progress_thread.signal();
+    }
+
+    MDSRank(
+        Mutex &mds_lock_,
+        LogChannelRef &clog_,
+        SafeTimer &timer_,
+        MDSMap *& mdsmap_,
+        Finisher *finisher_,
+        MDS *mds_daemon_,
+        Messenger *msgr,
+        MonClient *monc_);
+    ~MDSRank();
+
+    // Daemon functions: these guys break the abstraction
+    // and call up into the parent MDSDaemon instance.  It's kind
+    // of unavoidable: if we want any depth into our calls 
+    // to be able to e.g. tear down the whole process, we have to
+    // have a reference going all the way down.
+    //
+    // But for others, like dispatch, these can go away once the
+    // logical separate between MDSDaemon messages and MDSRank messages
+    // is put in place.
+    // >>>
+    void suicide(bool fast = false);
+    void respawn();
+    void damaged();
+    void damaged_unlocked();
+    void dispatch(Message *m);
+    utime_t get_laggy_until() const;
+    // <<<
+
+    void send_message_mds(Message *m, mds_rank_t mds);
+    void forward_message_mds(Message *req, mds_rank_t mds);
+
+    void send_message_client_counted(Message *m, client_t client);
+    void send_message_client_counted(Message *m, Session *session);
+    void send_message_client_counted(Message *m, Connection *connection);
+    void send_message_client_counted(Message *m, const ConnectionRef& con) {
+      send_message_client_counted(m, con.get());
+    }
+    void send_message_client(Message *m, Session *session);
+    void send_message(Message *m, Connection *c);
+    void send_message(Message *m, const ConnectionRef& c) {
+      send_message(m, c.get());
+    }
+
+    void wait_for_active(MDSInternalContextBase *c) { 
+      waiting_for_active.push_back(c); 
+    }
+    void wait_for_active_peer(mds_rank_t who, MDSInternalContextBase *c) { 
+      waiting_for_active_peer[who].push_back(c);
+    }
+    void wait_for_replay(MDSInternalContextBase *c) { 
+      waiting_for_replay.push_back(c); 
+    }
+    void wait_for_reconnect(MDSInternalContextBase *c) {
+      waiting_for_reconnect.push_back(c);
+    }
+    void wait_for_resolve(MDSInternalContextBase *c) {
+      waiting_for_resolve.push_back(c);
+    }
+    void wait_for_mdsmap(epoch_t e, MDSInternalContextBase *c) {
+      waiting_for_mdsmap[e].push_back(c);
+    }
+    void enqueue_replay(MDSInternalContextBase *c) {
+      replay_queue.push_back(c);
+    }
+
+    bool queue_one_replay() {
+      if (replay_queue.empty())
+        return false;
+      queue_waiter(replay_queue.front());
+      replay_queue.pop_front();
+      return true;
+    }
+
+    void set_osd_epoch_barrier(epoch_t e);
+    epoch_t get_osd_epoch_barrier() const {return osd_epoch_barrier;}
+
+    ceph_tid_t issue_tid() { return ++last_tid; }
+
+    Finisher     *finisher;
+
+    MDSMap *get_mds_map() { return mdsmap; }
+
+    // Access to monc functionality needed by balancer and snapserver
+    uint64_t get_global_id() const;
+    void send_mon_message(Message *m);
+
+    int get_req_rate() { return logger->get(l_mds_request); }
+
+  protected:
+    // FIXME: reference cycle: MDSRank should not carry a reference up to MDSDaemon
+    MDS          *mds_daemon;
+    Messenger    *messenger;
+    MonClient    *monc;
+};
+
+/* This expects to be given a reference which it is responsible for.
+ * The finish function calls functions which
+ * will put the Message exactly once.*/
+class C_MDS_RetryMessage : public MDSInternalContext {
+protected:
+  Message *m;
+public:
+  C_MDS_RetryMessage(MDSRank *mds, Message *m)
+    : MDSInternalContext(mds)
+  {
+    assert(m);
+    this->m = m;
+  }
+  virtual void finish(int r) {
+    mds->dispatch(m);
+  }
+};
+
+// This utility for MDS and MDSRank dispatchers.
+#define ALLOW_MESSAGES_FROM(peers) \
+do { \
+  if (m->get_connection() && (m->get_connection()->get_peer_type() & (peers)) == 0) { \
+    dout(0) << __FILE__ << "." << __LINE__ << ": filtered out request, peer=" << m->get_connection()->get_peer_type() \
+           << " allowing=" << #peers << " message=" << *m << dendl; \
+    m->put();							    \
+    return true; \
+  } \
+} while (0)
+
+#endif // MDS_RANK_H_
+

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -19,6 +19,7 @@
 #include "common/LogClient.h"
 #include "common/Timer.h"
 
+#include "Beacon.h"
 #include "MDSMap.h"
 #include "SessionMap.h"
 #include "MDCache.h"
@@ -222,6 +223,10 @@ class MDSRank {
 
     epoch_t osd_epoch_barrier;
 
+    // Const reference to the beacon so that we can behave differently
+    // when it's laggy.
+    Beacon &beacon;
+
   public:
 
     void queue_waiter(MDSInternalContextBase *c) {
@@ -237,6 +242,7 @@ class MDSRank {
         Mutex &mds_lock_,
         LogChannelRef &clog_,
         SafeTimer &timer_,
+        Beacon &beacon_,
         MDSMap *& mdsmap_,
         Finisher *finisher_,
         MDS *mds_daemon_,

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -261,6 +261,8 @@ class MDSRank {
      */
     void bcast_mds_map();  // to mounted clients
     epoch_t      last_client_mdsmap_bcast;
+
+    void create_logger();
   public:
 
     void queue_waiter(MDSInternalContextBase *c) {
@@ -382,13 +384,12 @@ class MDSRank {
     void init(mds_rank_t rank, int incarnation);
     void tick();
     void shutdown();
-    void create_logger();
-    void update_log_config();
     bool handle_asok_command(std::string command, cmdmap_t& cmdmap,
                              Formatter *f, std::ostream& ss);
     void handle_mds_map(MMDSMap *m, MDSMap *oldmap);
     void handle_osd_map();
     bool kill_session(int64_t session_id);
+    void update_log_config();
 
     // Call into me from MDS::ms_dispatch
     bool ms_dispatch(Message *m);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -102,7 +102,6 @@ class SnapServer;
 class SnapClient;
 class MDSTableServer;
 class MDSTableClient;
-class MDS;
 class Messenger;
 class Objecter;
 class MonClient;

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -115,15 +115,14 @@ class MMDSMap;
  * to the other subsystems, and message-sending calls.
  */
 class MDSRank {
-  public:
-    // FIXME: this should be private in favour of getter
-    mds_rank_t whoami;
+  protected:
+    const mds_rank_t whoami;
 
     // Incarnation as seen in MDSMap at the point where a rank is
-    // assigned.  FIXME this shoudl be a const once MDSRank
-    // is only constructed upon a rank being issued.
-    int incarnation;
+    // assigned.
+    const int incarnation;
 
+  public:
     mds_rank_t get_nodeid() const { return whoami; }
     uint64_t get_metadata_pool();
 
@@ -266,6 +265,8 @@ class MDSRank {
     }
 
     MDSRank(
+        mds_rank_t whoami_,
+        int incarnation_,
         Mutex &mds_lock_,
         LogChannelRef &clog_,
         SafeTimer &timer_,
@@ -480,7 +481,7 @@ public:
 class MDSRankDispatcher : public MDSRank
 {
 public:
-  void init(mds_rank_t rank, int incarnation);
+  void init();
   void tick();
   void shutdown();
   bool handle_asok_command(std::string command, cmdmap_t& cmdmap,
@@ -495,6 +496,8 @@ public:
   bool ms_dispatch(Message *m);
 
   MDSRankDispatcher(
+      mds_rank_t whoami_,
+      int incarnation_,
       Mutex &mds_lock_,
       LogChannelRef &clog_,
       SafeTimer &timer_,

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -390,6 +390,7 @@ class MDSRank {
     void handle_osd_map();
     bool kill_session(int64_t session_id);
     void update_log_config();
+    bool handle_command_legacy(std::vector<std::string> args);
 
     // Call into me from MDS::ms_dispatch
     bool ms_dispatch(Message *m);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -372,10 +372,6 @@ class MDSRank {
 
     MDSMap *get_mds_map() { return mdsmap; }
 
-    // Access to monc functionality needed by balancer and snapserver
-    uint64_t get_global_id() const;
-    void send_mon_message(Message *m);
-
     int get_req_rate() { return logger->get(l_mds_request); }
 
     // FIXME: interface for MDSDaemon to call, don't really want to expose

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -14,7 +14,7 @@
 
 #include "MDSTable.h"
 
-#include "MDS.h"
+#include "MDSRank.h"
 #include "MDLog.h"
 
 #include "osdc/Filer.h"
@@ -37,7 +37,7 @@ class MDSTableIOContext : public MDSIOContextBase
 {
   protected:
     MDSTable *ida;
-    MDS *get_mds() {return ida->mds;}
+    MDSRank *get_mds() {return ida->mds;}
   public:
     MDSTableIOContext(MDSTable *ida_) : ida(ida_) {
       assert(ida != NULL);
@@ -84,7 +84,7 @@ void MDSTable::save(MDSInternalContextBase *onfinish, version_t v)
 			    bl, ceph_clock_now(g_ceph_context), 0,
 			    NULL,
 			    new C_OnFinisher(new C_IO_MT_Save(this, version),
-					     &mds->finisher));
+					     mds->finisher));
 }
 
 void MDSTable::save_2(int r, version_t v)
@@ -151,7 +151,7 @@ void MDSTable::load(MDSInternalContextBase *onfinish)
   object_t oid = get_object_name();
   object_locator_t oloc(mds->mdsmap->get_metadata_pool());
   mds->objecter->read_full(oid, oloc, CEPH_NOSNAP, &c->bl, 0,
-			   new C_OnFinisher(c, &mds->finisher));
+			   new C_OnFinisher(c, mds->finisher));
 }
 
 void MDSTable::load_2(int r, bufferlist& bl, Context *onfinish)

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -134,7 +134,7 @@ object_t MDSTable::get_object_name()
 {
   char n[50];
   if (per_mds)
-    snprintf(n, sizeof(n), "mds%d_%s", int(mds->whoami), table_name);
+    snprintf(n, sizeof(n), "mds%d_%s", int(mds->get_nodeid()), table_name);
   else
     snprintf(n, sizeof(n), "mds_%s", table_name);
   return object_t(n);

--- a/src/mds/MDSTable.h
+++ b/src/mds/MDSTable.h
@@ -19,13 +19,13 @@
 #include "mds_table_types.h"
 #include "include/buffer.h"
 
-class MDS;
+class MDSRank;
 class Context;
 class MDSInternalContextBase;
 
 class MDSTable {
 public:
-  MDS *mds;
+  MDSRank *mds;
 protected:
   const char *table_name;
   bool per_mds;
@@ -44,7 +44,7 @@ protected:
   map<version_t, list<MDSInternalContextBase*> > waitfor_save;
   
 public:
-  MDSTable(MDS *m, const char *n, bool is_per_mds) :
+  MDSTable(MDSRank *m, const char *n, bool is_per_mds) :
     mds(m), table_name(n), per_mds(is_per_mds), rank(MDS_RANK_NONE),
     state(STATE_UNDEF),
     version(0), committing_version(0), committed_version(0), projected_version(0) {}

--- a/src/mds/MDSTableClient.cc
+++ b/src/mds/MDSTableClient.cc
@@ -91,7 +91,7 @@ void MDSTableClient::handle_request(class MMDSTableRequest *m)
 	       << ", sending ROLLBACK" << dendl;
       assert(!server_ready);
       MMDSTableRequest *req = new MMDSTableRequest(table, TABLESERVER_OP_ROLLBACK, 0, tid);
-      mds->send_message_mds(req, mds->mdsmap->get_tableserver());
+      mds->send_message_mds(req, mds->get_mds_map()->get_tableserver());
     }
     break;
 
@@ -169,7 +169,7 @@ void MDSTableClient::_prepare(bufferlist& mutation, version_t *ptid, bufferlist 
     // send message
     MMDSTableRequest *req = new MMDSTableRequest(table, TABLESERVER_OP_PREPARE, reqid);
     req->bl = mutation;
-    mds->send_message_mds(req, mds->mdsmap->get_tableserver());
+    mds->send_message_mds(req, mds->get_mds_map()->get_tableserver());
   } else
     dout(10) << "tableserver is not ready yet, deferring request" << dendl;
 }
@@ -190,7 +190,7 @@ void MDSTableClient::commit(version_t tid, LogSegment *ls)
   if (server_ready) {
     // send message
     MMDSTableRequest *req = new MMDSTableRequest(table, TABLESERVER_OP_COMMIT, 0, tid);
-    mds->send_message_mds(req, mds->mdsmap->get_tableserver());
+    mds->send_message_mds(req, mds->get_mds_map()->get_tableserver());
   } else
     dout(10) << "tableserver is not ready yet, deferring request" << dendl;
 }
@@ -222,7 +222,7 @@ void MDSTableClient::resend_commits()
        ++p) {
     dout(10) << "resending commit on " << p->first << dendl;
     MMDSTableRequest *req = new MMDSTableRequest(table, TABLESERVER_OP_COMMIT, 0, p->first);
-    mds->send_message_mds(req, mds->mdsmap->get_tableserver());
+    mds->send_message_mds(req, mds->get_mds_map()->get_tableserver());
   }
 }
 
@@ -239,13 +239,13 @@ void MDSTableClient::resend_prepares()
     dout(10) << "resending prepare on " << p->first << dendl;
     MMDSTableRequest *req = new MMDSTableRequest(table, TABLESERVER_OP_PREPARE, p->first);
     req->bl = p->second.mutation;
-    mds->send_message_mds(req, mds->mdsmap->get_tableserver());
+    mds->send_message_mds(req, mds->get_mds_map()->get_tableserver());
   }
 }
 
 void MDSTableClient::handle_mds_failure(mds_rank_t who)
 {
-  if (who != mds->mdsmap->get_tableserver())
+  if (who != mds->get_mds_map()->get_tableserver())
     return; // do nothing.
 
   dout(7) << "tableserver mds." << who << " fails" << dendl;

--- a/src/mds/MDSTableClient.cc
+++ b/src/mds/MDSTableClient.cc
@@ -19,7 +19,7 @@
 #include "MDSContext.h"
 #include "msg/Messenger.h"
 
-#include "MDS.h"
+#include "MDSRank.h"
 #include "MDLog.h"
 #include "LogSegment.h"
 

--- a/src/mds/MDSTableClient.h
+++ b/src/mds/MDSTableClient.h
@@ -19,13 +19,13 @@
 #include "MDSContext.h"
 #include "mds_table_types.h"
 
-class MDS;
+class MDSRank;
 class LogSegment;
 class MMDSTableRequest;
 
 class MDSTableClient {
 protected:
-  MDS *mds;
+  MDSRank *mds;
   int table;
 
   uint64_t last_reqid;
@@ -57,7 +57,7 @@ protected:
   friend class C_LoggedAck;
 
 public:
-  MDSTableClient(MDS *m, int tab) :
+  MDSTableClient(MDSRank *m, int tab) :
     mds(m), table(tab), last_reqid(~0ULL), server_ready(false) {}
   virtual ~MDSTableClient() {}
 

--- a/src/mds/MDSTableServer.cc
+++ b/src/mds/MDSTableServer.cc
@@ -13,7 +13,7 @@
  */
 
 #include "MDSTableServer.h"
-#include "MDS.h"
+#include "MDSRank.h"
 #include "MDLog.h"
 #include "msg/Messenger.h"
 

--- a/src/mds/MDSTableServer.h
+++ b/src/mds/MDSTableServer.h
@@ -57,7 +57,7 @@ private:
   }
   
 
-  MDSTableServer(MDS *m, int tab) : MDSTable(m, get_mdstable_name(tab), false), table(tab) {}
+  MDSTableServer(MDSRank *m, int tab) : MDSTable(m, get_mdstable_name(tab), false), table(tab) {}
   virtual ~MDSTableServer() {}
 
   void handle_request(MMDSTableRequest *m);

--- a/src/mds/Makefile-server.am
+++ b/src/mds/Makefile-server.am
@@ -24,8 +24,8 @@ noinst_HEADERS += \
 	mds/RecoveryQueue.h \
 	mds/StrayManager.h \
 	mds/MDLog.h \
-	mds/MDS.h \
 	mds/MDSRank.h \
+	mds/MDSDaemon.h \
 	mds/Beacon.h \
 	mds/MDSContext.h \
 	mds/MDSAuthCaps.h \

--- a/src/mds/Makefile-server.am
+++ b/src/mds/Makefile-server.am
@@ -25,6 +25,7 @@ noinst_HEADERS += \
 	mds/StrayManager.h \
 	mds/MDLog.h \
 	mds/MDS.h \
+	mds/MDSRank.h \
 	mds/Beacon.h \
 	mds/MDSContext.h \
 	mds/MDSAuthCaps.h \

--- a/src/mds/Makefile.am
+++ b/src/mds/Makefile.am
@@ -1,6 +1,7 @@
 LIBMDS_SOURCES = \
 	mds/Capability.cc \
 	mds/MDS.cc \
+	mds/MDSRank.cc \
 	mds/Beacon.cc \
 	mds/locks.c \
 	mds/journal.cc \

--- a/src/mds/Makefile.am
+++ b/src/mds/Makefile.am
@@ -1,6 +1,6 @@
 LIBMDS_SOURCES = \
 	mds/Capability.cc \
-	mds/MDS.cc \
+	mds/MDSDaemon.cc \
 	mds/MDSRank.cc \
 	mds/Beacon.cc \
 	mds/locks.c \

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -12,7 +12,7 @@
  * 
  */
 
-#include "MDS.h"
+#include "MDSRank.h"
 #include "MDCache.h"
 #include "CInode.h"
 #include "CDir.h"
@@ -86,7 +86,7 @@
 class MigratorContext : public MDSInternalContextBase {
 protected:
   Migrator *mig;
-  MDS *get_mds() {
+  MDSRank *get_mds() {
     return mig->mds;
   }
 public:

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -2566,7 +2566,7 @@ void Migrator::import_logged_start(dirfrag_t df, CDir *dir, mds_rank_t from,
   dout(7) << "sending ack for " << *dir << " to old auth mds." << from << dendl;
 
   // test surviving observer of a failed migration that did not complete
-  //assert(dir->replica_map.size() < 2 || mds->whoami != 0);
+  //assert(dir->replica_map.size() < 2 || mds->get_nodeid() != 0);
 
   MExportDirAck *ack = new MExportDirAck(dir->dirfrag(), it->second.tid);
   ::encode(imported_caps, ack->imported_caps);
@@ -2696,7 +2696,7 @@ void Migrator::import_finish(CDir *dir, bool notify, bool last)
   mds->mdcache->maybe_send_pending_resolves();
 
   // did i just import mydir?
-  if (dir->ino() == MDS_INO_MDSDIR(mds->whoami))
+  if (dir->ino() == MDS_INO_MDSDIR(mds->get_nodeid()))
     cache->populate_mydir();
 
   // is it empty?

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -27,7 +27,7 @@ using std::list;
 using std::set;
 
 
-class MDS;
+class MDSRank;
 class CDir;
 class CInode;
 class CDentry;
@@ -51,7 +51,7 @@ class EImportStart;
 
 class Migrator {
 private:
-  MDS *mds;
+  MDSRank *mds;
   MDCache *cache;
 
   // -- exports --
@@ -147,7 +147,7 @@ protected:
 
 public:
   // -- cons --
-  Migrator(MDS *m, MDCache *c) : mds(m), cache(c) {}
+  Migrator(MDSRank *m, MDCache *c) : mds(m), cache(c) {}
 
   void dispatch(Message*);
 

--- a/src/mds/RecoveryQueue.cc
+++ b/src/mds/RecoveryQueue.cc
@@ -14,7 +14,7 @@
 
 #include "CInode.h"
 #include "MDCache.h"
-#include "MDS.h"
+#include "MDSRank.h"
 #include "Locker.h"
 #include "osdc/Filer.h"
 
@@ -33,7 +33,7 @@ protected:
     rq->_recovered(in, r, size, mtime);
   }
 
-  MDS *get_mds() {
+  MDSRank *get_mds() {
     return rq->mds;
   }
 
@@ -47,8 +47,8 @@ public:
 };
 
 
-RecoveryQueue::RecoveryQueue(MDS *mds_)
-  : mds(mds_), logger(NULL), filer(mds_->objecter, &mds_->finisher)
+RecoveryQueue::RecoveryQueue(MDSRank *mds_)
+  : mds(mds_), logger(NULL), filer(mds_->objecter, mds_->finisher)
 {}
 
 

--- a/src/mds/RecoveryQueue.h
+++ b/src/mds/RecoveryQueue.h
@@ -22,7 +22,7 @@
 #include "osdc/Filer.h"
 
 class CInode;
-class MDS;
+class MDSRank;
 class PerfCounters;
 
 class RecoveryQueue {
@@ -30,7 +30,7 @@ public:
   void enqueue(CInode *in);
   void advance();
   void prioritize(CInode *in);   ///< do this inode now/soon
-  RecoveryQueue(MDS *mds_);
+  RecoveryQueue(MDSRank *mds_);
 
   void set_logger(PerfCounters *p) {logger=p;}
 
@@ -41,7 +41,7 @@ private:
   std::set<CInode*> file_recover_queue_front;  ///< elevated priority items
   std::set<CInode*> file_recovering;
   void _recovered(CInode *in, int r, uint64_t size, utime_t mtime);
-  MDS *mds;
+  MDSRank *mds;
   PerfCounters *logger;
   Filer filer;
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -24,6 +24,9 @@ class EMetaBlob;
 class EUpdate;
 class MMDSSlaveRequest;
 struct SnapInfo;
+class MClientRequest;
+class MClientReply;
+class MDLog;
 
 struct MutationImpl;
 struct MDRequestImpl;
@@ -43,11 +46,10 @@ enum {
 class Server {
 public:
   // XXX FIXME: can probably friend enough contexts to make this not need to be public
-  MDS *mds;
+  MDSRank *mds;
 private:
   MDCache *mdcache;
   MDLog *mdlog;
-  Messenger *messenger;
   PerfCounters *logger;
 
   // OSDMap full status, used to generate ENOSPC on some operations
@@ -60,16 +62,7 @@ private:
 public:
   bool terminating_sessions;
 
-  Server(MDS *m) : 
-    mds(m), 
-    mdcache(mds->mdcache), mdlog(mds->mdlog),
-    messenger(mds->messenger),
-    logger(0),
-    is_full(false),
-    reconnect_done(NULL),
-    failed_reconnects(0),
-    terminating_sessions(false) {
-  }
+  Server(MDSRank *m);
   ~Server() {
     g_ceph_context->get_perfcounters_collection()->remove(logger);
     delete logger;

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -15,7 +15,7 @@
 #ifndef CEPH_MDS_SERVER_H
 #define CEPH_MDS_SERVER_H
 
-#include "MDS.h"
+#include "MDSRank.h"
 
 class OSDMap;
 class PerfCounters;

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -44,10 +44,8 @@ enum {
 };
 
 class Server {
-public:
-  // XXX FIXME: can probably friend enough contexts to make this not need to be public
-  MDSRank *mds;
 private:
+  MDSRank *mds;
   MDCache *mdcache;
   MDLog *mdlog;
   PerfCounters *logger;
@@ -58,6 +56,9 @@ private:
   // State for while in reconnect
   MDSInternalContext *reconnect_done;
   int failed_reconnects;
+
+  friend class MDSContinuation;
+  friend class ServerContext;
 
 public:
   bool terminating_sessions;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -12,11 +12,12 @@
  * 
  */
 
-#include "MDS.h"
+#include "MDSRank.h"
 #include "MDCache.h"
 #include "Mutation.h"
 #include "SessionMap.h"
 #include "osdc/Filer.h"
+#include "common/Finisher.h"
 
 #include "common/config.h"
 #include "common/errno.h"
@@ -32,7 +33,7 @@ class SessionMapIOContext : public MDSIOContextBase
 {
   protected:
     SessionMap *sessionmap;
-    MDS *get_mds() {return sessionmap->mds;}
+    MDSRank *get_mds() {return sessionmap->mds;}
   public:
     SessionMapIOContext(SessionMap *sessionmap_) : sessionmap(sessionmap_) {
       assert(sessionmap != NULL);
@@ -205,7 +206,7 @@ void SessionMap::_load_finish(
     op.omap_get_vals(last_key, "", g_conf->mds_sessionmap_keys_per_op,
         &c->session_vals, &c->values_r);
     mds->objecter->read(oid, oloc, op, CEPH_NOSNAP, NULL, 0,
-        new C_OnFinisher(c, &mds->finisher));
+        new C_OnFinisher(c, mds->finisher));
   } else {
     // I/O is complete.  Update `by_state`
     dout(10) << __func__ << ": omap load complete" << dendl;
@@ -246,7 +247,7 @@ void SessionMap::load(MDSInternalContextBase *onload)
   op.omap_get_vals("", "", g_conf->mds_sessionmap_keys_per_op,
       &c->session_vals, &c->values_r);
 
-  mds->objecter->read(oid, oloc, op, CEPH_NOSNAP, NULL, 0, new C_OnFinisher(c, &mds->finisher));
+  mds->objecter->read(oid, oloc, op, CEPH_NOSNAP, NULL, 0, new C_OnFinisher(c, mds->finisher));
 }
 
 class C_IO_SM_LoadLegacy : public SessionMapIOContext {
@@ -274,7 +275,7 @@ void SessionMap::load_legacy()
   object_locator_t oloc(mds->mdsmap->get_metadata_pool());
 
   mds->objecter->read_full(oid, oloc, CEPH_NOSNAP, &c->bl, 0,
-			   new C_OnFinisher(c, &mds->finisher));
+			   new C_OnFinisher(c, mds->finisher));
 }
 
 void SessionMap::_load_legacy_finish(int r, bufferlist &bl)
@@ -402,7 +403,7 @@ void SessionMap::save(MDSInternalContextBase *onsave, version_t needv)
   null_sessions.clear();
 
   mds->objecter->mutate(oid, oloc, op, snapc, ceph_clock_now(g_ceph_context),
-      0, NULL, new C_OnFinisher(new C_IO_SM_Save(this, version), &mds->finisher));
+      0, NULL, new C_OnFinisher(new C_IO_SM_Save(this, version), mds->finisher));
 }
 
 void SessionMap::_save_finish(version_t v)
@@ -823,7 +824,7 @@ void SessionMap::save_if_dirty(const std::set<entity_name_t> &tgt_sessions,
       object_locator_t oloc(mds->mdsmap->get_metadata_pool());
       MDSInternalContextBase *on_safe = gather_bld->new_sub();
       mds->objecter->mutate(oid, oloc, op, snapc, ceph_clock_now(g_ceph_context),
-          0, NULL, new C_OnFinisher(new C_IO_SM_Save_One(this, on_safe), &mds->finisher));
+          0, NULL, new C_OnFinisher(new C_IO_SM_Save_One(this, on_safe), mds->finisher));
     }
   }
 }

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -64,7 +64,7 @@ void SessionMap::dump()
 object_t SessionMap::get_object_name()
 {
   char s[30];
-  snprintf(s, sizeof(s), "mds%d_sessionmap", int(mds->whoami));
+  snprintf(s, sizeof(s), "mds%d_sessionmap", int(mds->get_nodeid()));
   return object_t(s);
 }
 

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -308,7 +308,7 @@ public:
  * session map
  */
 
-class MDS;
+class MDSRank;
 
 /**
  * Encapsulate the serialized state associated with SessionMap.  Allows
@@ -360,7 +360,7 @@ public:
 
 class SessionMap : public SessionMapStore {
 public:
-  MDS *mds;
+  MDSRank *mds;
 
 protected:
   version_t projected, committing, committed;
@@ -369,7 +369,7 @@ public:
   uint64_t set_state(Session *session, int state);
   map<version_t, list<MDSInternalContextBase*> > commit_waiters;
 
-  SessionMap(MDS *m) : mds(m),
+  SessionMap(MDSRank *m) : mds(m),
 		       projected(0), committing(0), committed(0),
                        loaded_legacy(false)
   { }

--- a/src/mds/SnapClient.h
+++ b/src/mds/SnapClient.h
@@ -19,12 +19,12 @@
 #include "snap.h"
 
 class MDSInternalContextBase;
-class MDS;
+class MDSRank;
 class LogSegment;
 
 class SnapClient : public MDSTableClient {
 public:
-  SnapClient(MDS *m) : MDSTableClient(m, TABLE_SNAP) {}
+  SnapClient(MDSRank *m) : MDSTableClient(m, TABLE_SNAP) {}
 
   void resend_queries() {}
   void handle_query_result(MMDSTableRequest *m) {}

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -85,7 +85,7 @@ struct C_SR_RetryOpenParents : public MDSInternalContextBase {
     sr(s), first(f), last(l), parent_last(pl),  parent(p), fin(c) {
     sr->inode->get(CInode::PIN_OPENINGSNAPPARENTS);
   }
-  MDS *get_mds() { return sr->mdcache->mds; }
+  MDSRank *get_mds() { return sr->mdcache->mds; }
   void finish(int r) {
     if (r < 0)
       sr->_remove_missing_parent(parent_last, parent, r);

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -14,7 +14,7 @@
 
 #include "SnapRealm.h"
 #include "MDCache.h"
-#include "MDS.h"
+#include "MDSRank.h"
 
 #include "messages/MClientSnap.h"
 

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -13,7 +13,7 @@
  */
 
 #include "SnapServer.h"
-#include "MDS.h"
+#include "MDSRank.h"
 #include "osd/OSDMap.h"
 #include "osdc/Objecter.h"
 #include "mon/MonClient.h"
@@ -283,7 +283,7 @@ void SnapServer::check_osd_map(bool force)
   if (!all_purge.empty()) {
     dout(10) << "requesting removal of " << all_purge << dendl;
     MRemoveSnaps *m = new MRemoveSnaps(all_purge);
-    mds->monc->send_mon_message(m);
+    mds->send_mon_message(m);
   }
 
   last_checked_osdmap = version;

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -283,7 +283,7 @@ void SnapServer::check_osd_map(bool force)
   if (!all_purge.empty()) {
     dout(10) << "requesting removal of " << all_purge << dendl;
     MRemoveSnaps *m = new MRemoveSnaps(all_purge);
-    mds->send_mon_message(m);
+    mon_client->send_mon_message(m);
   }
 
   last_checked_osdmap = version;

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -46,6 +46,11 @@ void SnapServer::reset_state()
          p != mds->mdsmap->get_data_pools().end();
          ++p) {
       const pg_pool_t *pi = osdmap->get_pg_pool(*p);
+      if (!pi) {
+        // If pool isn't in OSDMap yet then can't have any snaps needing
+        // removal, skip.
+        continue;
+      }
       if (!pi->removed_snaps.empty() &&
           pi->removed_snaps.range_end() > first_free)
         first_free = pi->removed_snaps.range_end();

--- a/src/mds/SnapServer.h
+++ b/src/mds/SnapServer.h
@@ -18,7 +18,7 @@
 #include "MDSTableServer.h"
 #include "snap.h"
 
-class MDS;
+class MDSRank;
 
 class SnapServer : public MDSTableServer {
 public:
@@ -35,7 +35,7 @@ protected:
   version_t last_checked_osdmap;
 
 public:
-  SnapServer(MDS *m) : MDSTableServer(m, TABLE_SNAP),
+  SnapServer(MDSRank *m) : MDSTableServer(m, TABLE_SNAP),
 		       last_checked_osdmap(0) { }
     
   void reset_state();

--- a/src/mds/SnapServer.h
+++ b/src/mds/SnapServer.h
@@ -19,11 +19,11 @@
 #include "snap.h"
 
 class MDSRank;
+class MonClient;
 
 class SnapServer : public MDSTableServer {
-public:
-  
 protected:
+  MonClient *mon_client;
   snapid_t last_snap;
   map<snapid_t, SnapInfo> snaps;
   map<int, set<snapid_t> > need_to_purge;
@@ -35,8 +35,9 @@ protected:
   version_t last_checked_osdmap;
 
 public:
-  SnapServer(MDSRank *m) : MDSTableServer(m, TABLE_SNAP),
-		       last_checked_osdmap(0) { }
+  SnapServer(MDSRank *m, MonClient *monc)
+    : MDSTableServer(m, TABLE_SNAP), mon_client(monc), last_checked_osdmap(0)
+  {}
     
   void reset_state();
   void encode_server_state(bufferlist& bl) const {

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -755,7 +755,6 @@ StrayManager::StrayManager(MDSRank *mds)
     filer(mds->objecter, mds->finisher)
 {
   assert(mds != NULL);
-  update_op_limit();
 }
 
 void StrayManager::abort_queue()

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -751,6 +751,7 @@ StrayManager::StrayManager(MDSRank *mds)
   : delayed_eval_stray(member_offset(CDentry, item_stray)),
     mds(mds), logger(NULL),
     ops_in_flight(0), files_purging(0),
+    max_purge_ops(0), 
     num_strays(0), num_strays_purging(0), num_strays_delayed(0),
     filer(mds->objecter, mds->finisher)
 {

--- a/src/mds/StrayManager.h
+++ b/src/mds/StrayManager.h
@@ -18,7 +18,7 @@
 #include <list>
 #include "osdc/Filer.h"
 
-class MDS;
+class MDSRank;
 class PerfCounters;
 class CInode;
 class CDentry;
@@ -42,7 +42,7 @@ class StrayManager : public md_config_obs_t
   std::list<QueuedStray> ready_for_purge;
 
   // Global references for doing I/O
-  MDS *mds;
+  MDSRank *mds;
   PerfCounters *logger;
 
   // Throttled allowances
@@ -150,7 +150,7 @@ class StrayManager : public md_config_obs_t
 
   // My public interface is for consumption by MDCache
   public:
-  StrayManager(MDS *mds);
+  StrayManager(MDSRank *mds);
   void set_logger(PerfCounters *l) {logger = l;}
 
   bool eval_stray(CDentry *dn, bool delay=false);

--- a/src/mds/events/ECommitted.h
+++ b/src/mds/events/ECommitted.h
@@ -36,7 +36,7 @@ public:
   static void generate_test_instances(list<ECommitted*>& ls);
 
   void update_segment() {}
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
 };
 
 #endif

--- a/src/mds/events/EExport.h
+++ b/src/mds/events/EExport.h
@@ -48,7 +48,7 @@ public:
   void decode(bufferlist::iterator &bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<EExport*>& ls);
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
 
 };
 

--- a/src/mds/events/EExport.h
+++ b/src/mds/events/EExport.h
@@ -18,7 +18,7 @@
 #include "common/config.h"
 #include "include/types.h"
 
-#include "../MDS.h"
+#include "../MDSRank.h"
 
 #include "EMetaBlob.h"
 #include "../LogEvent.h"

--- a/src/mds/events/EFragment.h
+++ b/src/mds/events/EFragment.h
@@ -74,7 +74,7 @@ public:
   void decode(bufferlist::iterator &bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<EFragment*>& ls);
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
 };
 
 #endif

--- a/src/mds/events/EImportFinish.h
+++ b/src/mds/events/EImportFinish.h
@@ -45,7 +45,7 @@ class EImportFinish : public LogEvent {
   void dump(Formatter *f) const;
   static void generate_test_instances(list<EImportFinish*>& ls);
   
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
 
 };
 

--- a/src/mds/events/EImportFinish.h
+++ b/src/mds/events/EImportFinish.h
@@ -18,7 +18,7 @@
 #include "common/config.h"
 #include "include/types.h"
 
-#include "../MDS.h"
+#include "../MDSRank.h"
 #include "../LogEvent.h"
 
 class EImportFinish : public LogEvent {

--- a/src/mds/events/EImportStart.h
+++ b/src/mds/events/EImportStart.h
@@ -18,7 +18,8 @@
 #include "common/config.h"
 #include "include/types.h"
 
-#include "../MDS.h"
+class MDLog;
+class MDSRank;
 
 #include "EMetaBlob.h"
 #include "../LogEvent.h"
@@ -52,7 +53,7 @@ protected:
   static void generate_test_instances(list<EImportStart*>& ls);
   
   void update_segment();
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
 
 };
 

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -24,7 +24,7 @@
 
 #include "include/interval_set.h"
 
-class MDS;
+class MDSRank;
 class MDLog;
 class LogSegment;
 struct MDSlaveUpdate;
@@ -105,7 +105,7 @@ public:
     void dump(Formatter *f) const;
     static void generate_test_instances(list<EMetaBlob::fullbit*>& ls);
 
-    void update_inode(MDS *mds, CInode *in);
+    void update_inode(MDSRank *mds, CInode *in);
     bool is_dirty() const { return (state & STATE_DIRTY); }
     bool is_dirty_parent() const { return (state & STATE_DIRTYPARENT); }
     bool is_dirty_pool() const { return (state & STATE_DIRTYPOOL); }
@@ -376,7 +376,7 @@ private:
     truncate_finish[ino] = segoff;
   }
   
-  bool rewrite_truncate_finish(MDS const *mds, std::map<uint64_t, uint64_t> const &old_to_new);
+  bool rewrite_truncate_finish(MDSRank const *mds, std::map<uint64_t, uint64_t> const &old_to_new);
 
   void add_destroyed_inode(inodeno_t ino) {
     destroyed_inodes.push_back(ino);
@@ -574,7 +574,7 @@ private:
   }
 
   void update_segment(LogSegment *ls);
-  void replay(MDS *mds, LogSegment *ls, MDSlaveUpdate *su=NULL);
+  void replay(MDSRank *mds, LogSegment *ls, MDSlaveUpdate *su=NULL);
 };
 WRITE_CLASS_ENCODER(EMetaBlob)
 WRITE_CLASS_ENCODER(EMetaBlob::fullbit)

--- a/src/mds/events/ENoOp.h
+++ b/src/mds/events/ENoOp.h
@@ -28,7 +28,7 @@ public:
   void decode(bufferlist::iterator& bl);
   void dump(Formatter *f) const {}
 
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
 };
 
 #endif

--- a/src/mds/events/EOpen.h
+++ b/src/mds/events/EOpen.h
@@ -50,7 +50,7 @@ public:
   static void generate_test_instances(list<EOpen*>& ls);
 
   void update_segment();
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
 };
 
 #endif

--- a/src/mds/events/EResetJournal.h
+++ b/src/mds/events/EResetJournal.h
@@ -32,7 +32,7 @@ class EResetJournal : public LogEvent {
     out << "EResetJournal";
   }
 
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
 };
 
 #endif

--- a/src/mds/events/ESession.h
+++ b/src/mds/events/ESession.h
@@ -66,7 +66,7 @@ class ESession : public LogEvent {
   }
   
   void update_segment();
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
   entity_inst_t get_client_inst() const {return client_inst;}
 };
 

--- a/src/mds/events/ESessions.h
+++ b/src/mds/events/ESessions.h
@@ -53,7 +53,7 @@ public:
   }
   
   void update_segment();
-  void replay(MDS *mds);  
+  void replay(MDSRank *mds);  
 };
 
 #endif

--- a/src/mds/events/ESlaveUpdate.h
+++ b/src/mds/events/ESlaveUpdate.h
@@ -143,7 +143,7 @@ public:
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ESlaveUpdate*>& ls);
 
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
 };
 
 #endif

--- a/src/mds/events/ESubtreeMap.h
+++ b/src/mds/events/ESubtreeMap.h
@@ -41,7 +41,7 @@ public:
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ESubtreeMap*>& ls);
 
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
 };
 
 #endif

--- a/src/mds/events/ETableClient.h
+++ b/src/mds/events/ETableClient.h
@@ -42,7 +42,7 @@ struct ETableClient : public LogEvent {
   }  
 
   //void update_segment();
-  void replay(MDS *mds);  
+  void replay(MDSRank *mds);  
 };
 
 #endif

--- a/src/mds/events/ETableServer.h
+++ b/src/mds/events/ETableServer.h
@@ -52,7 +52,7 @@ struct ETableServer : public LogEvent {
   }  
 
   void update_segment();
-  void replay(MDS *mds);  
+  void replay(MDSRank *mds);  
 };
 
 #endif

--- a/src/mds/events/EUpdate.h
+++ b/src/mds/events/EUpdate.h
@@ -46,7 +46,7 @@ public:
   static void generate_test_instances(list<EUpdate*>& ls);
 
   void update_segment();
-  void replay(MDS *mds);
+  void replay(MDSRank *mds);
   EMetaBlob const *get_metablob() const {return &metablob;}
 };
 

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -39,7 +39,7 @@
 
 #include "LogSegment.h"
 
-#include "MDS.h"
+#include "MDSRank.h"
 #include "MDLog.h"
 #include "MDCache.h"
 #include "Server.h"
@@ -63,7 +63,7 @@
 // -----------------------
 // LogSegment
 
-void LogSegment::try_to_expire(MDS *mds, MDSGatherBuilder &gather_bld, int op_prio)
+void LogSegment::try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int op_prio)
 {
   set<CDir*> commit;
 
@@ -301,7 +301,7 @@ EMetaBlob::EMetaBlob(MDLog *mdlog) : opened_ino(0), renamed_dirino(0),
 
 void EMetaBlob::add_dir_context(CDir *dir, int mode)
 {
-  MDS *mds = dir->cache->mds;
+  MDSRank *mds = dir->cache->mds;
 
   list<CDentry*> parents;
 
@@ -532,7 +532,7 @@ void EMetaBlob::fullbit::generate_test_instances(list<EMetaBlob::fullbit*>& ls)
   ls.push_back(sample);
 }
 
-void EMetaBlob::fullbit::update_inode(MDS *mds, CInode *in)
+void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
 {
   in->inode = inode;
   in->xattrs = xattrs;
@@ -772,7 +772,7 @@ void EMetaBlob::encode(bufferlist& bl) const
   ::encode(renamed_dirino, bl);
   ::encode(renamed_dir_frags, bl);
   {
-    // make MDS use v6 format happy
+    // make MDSRank use v6 format happy
     int64_t i = -1;
     bool b = false;
     ::encode(i, bl);
@@ -1108,7 +1108,7 @@ void EMetaBlob::generate_test_instances(list<EMetaBlob*>& ls)
   ls.push_back(new EMetaBlob());
 }
 
-void EMetaBlob::replay(MDS *mds, LogSegment *logseg, MDSlaveUpdate *slaveup)
+void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDSlaveUpdate *slaveup)
 {
   dout(10) << "EMetaBlob.replay " << lump_map.size() << " dirlumps by " << client_name << dendl;
 
@@ -1623,7 +1623,7 @@ void ESession::update_segment()
     _segment->inotablev = inotablev;
 }
 
-void ESession::replay(MDS *mds)
+void ESession::replay(MDSRank *mds)
 {
   if (mds->sessionmap.get_version() >= cmapv) {
     dout(10) << "ESession.replay sessionmap " << mds->sessionmap.get_version() 
@@ -1781,7 +1781,7 @@ void ESessions::update_segment()
   _segment->sessionmapv = cmapv;
 }
 
-void ESessions::replay(MDS *mds)
+void ESessions::replay(MDSRank *mds)
 {
   if (mds->sessionmap.get_version() >= cmapv) {
     dout(10) << "ESessions.replay sessionmap " << mds->sessionmap.get_version()
@@ -1850,7 +1850,7 @@ void ETableServer::update_segment()
   _segment->tablev[table] = version;
 }
 
-void ETableServer::replay(MDS *mds)
+void ETableServer::replay(MDSRank *mds)
 {
   MDSTableServer *server = mds->get_table_server(table);
   if (!server)
@@ -1932,7 +1932,7 @@ void ETableClient::generate_test_instances(list<ETableClient*>& ls)
   ls.push_back(new ETableClient());
 }
 
-void ETableClient::replay(MDS *mds)
+void ETableClient::replay(MDSRank *mds)
 {
   dout(10) << " ETableClient.replay " << get_mdstable_name(table)
 	   << " op " << get_mdstableserver_opname(op)
@@ -1955,7 +1955,7 @@ void ESnap::update_segment()
   _segment->tablev[TABLE_SNAP] = version;
 }
 
-void ESnap::replay(MDS *mds)
+void ESnap::replay(MDSRank *mds)
 {
   if (mds->snaptable->get_version() >= version) {
     dout(10) << "ESnap.replay event " << version
@@ -2039,7 +2039,7 @@ void EUpdate::update_segment()
     _segment->uncommitted_masters.insert(reqid);
 }
 
-void EUpdate::replay(MDS *mds)
+void EUpdate::replay(MDSRank *mds)
 {
   metablob.replay(mds, _segment);
   
@@ -2117,7 +2117,7 @@ void EOpen::update_segment()
   // ??
 }
 
-void EOpen::replay(MDS *mds)
+void EOpen::replay(MDSRank *mds)
 {
   dout(10) << "EOpen.replay " << dendl;
   metablob.replay(mds, _segment);
@@ -2139,7 +2139,7 @@ void EOpen::replay(MDS *mds)
 // -----------------------
 // ECommitted
 
-void ECommitted::replay(MDS *mds)
+void ECommitted::replay(MDSRank *mds)
 {
   if (mds->mdcache->uncommitted_masters.count(reqid)) {
     dout(10) << "ECommitted.replay " << reqid << dendl;
@@ -2410,7 +2410,7 @@ void ESlaveUpdate::generate_test_instances(list<ESlaveUpdate*>& ls)
 }
 
 
-void ESlaveUpdate::replay(MDS *mds)
+void ESlaveUpdate::replay(MDSRank *mds)
 {
   MDSlaveUpdate *su;
   switch (op) {
@@ -2515,7 +2515,7 @@ void ESubtreeMap::generate_test_instances(list<ESubtreeMap*>& ls)
   ls.push_back(new ESubtreeMap());
 }
 
-void ESubtreeMap::replay(MDS *mds) 
+void ESubtreeMap::replay(MDSRank *mds) 
 {
   if (expire_pos && expire_pos > mds->mdlog->journaler->get_expire_pos())
     mds->mdlog->journaler->set_expire_pos(expire_pos);
@@ -2647,7 +2647,7 @@ void ESubtreeMap::replay(MDS *mds)
 // -----------------------
 // EFragment
 
-void EFragment::replay(MDS *mds)
+void EFragment::replay(MDSRank *mds)
 {
   dout(10) << "EFragment.replay " << op_name(op) << " " << ino << " " << basefrag << " by " << bits << dendl;
 
@@ -2770,7 +2770,7 @@ void dirfrag_rollback::decode(bufferlist::iterator &bl)
 // -----------------------
 // EExport
 
-void EExport::replay(MDS *mds)
+void EExport::replay(MDSRank *mds)
 {
   dout(10) << "EExport.replay " << base << dendl;
   metablob.replay(mds, _segment);
@@ -2844,7 +2844,7 @@ void EImportStart::update_segment()
   _segment->sessionmapv = cmapv;
 }
 
-void EImportStart::replay(MDS *mds)
+void EImportStart::replay(MDSRank *mds)
 {
   dout(10) << "EImportStart.replay " << base << " bounds " << bounds << dendl;
   //metablob.print(*_dout);
@@ -2930,7 +2930,7 @@ void EImportStart::generate_test_instances(list<EImportStart*>& ls)
 // -----------------------
 // EImportFinish
 
-void EImportFinish::replay(MDS *mds)
+void EImportFinish::replay(MDSRank *mds)
 {
   if (mds->mdcache->have_ambiguous_import(base)) {
     dout(10) << "EImportFinish.replay " << base << " success=" << success << dendl;
@@ -3015,7 +3015,7 @@ void EResetJournal::generate_test_instances(list<EResetJournal*>& ls)
   ls.push_back(new EResetJournal());
 }
 
-void EResetJournal::replay(MDS *mds)
+void EResetJournal::replay(MDSRank *mds)
 {
   dout(1) << "EResetJournal" << dendl;
 
@@ -3063,7 +3063,7 @@ void ENoOp::decode(bufferlist::iterator &bl)
 }
 
 
-void ENoOp::replay(MDS *mds)
+void ENoOp::replay(MDSRank *mds)
 {
   dout(4) << "ENoOp::replay, " << pad_size << " bytes skipped in journal" << dendl;
 }
@@ -3074,14 +3074,14 @@ void ENoOp::replay(MDS *mds)
  * it.
  *
  * @param mds
- * MDS instance, just used for logging
+ * MDSRank instance, just used for logging
  * @param old_to_new
  * Map of old journal segment segment sequence numbers to new journal segment sequence numbers
  *
  * @return
  * True if the event was modified.
  */
-bool EMetaBlob::rewrite_truncate_finish(MDS const *mds,
+bool EMetaBlob::rewrite_truncate_finish(MDSRank const *mds,
     std::map<log_segment_seq_t, log_segment_seq_t> const &old_to_new)
 {
   bool modified = false;

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -2542,7 +2542,7 @@ void ESubtreeMap::replay(MDSRank *mds)
 	++errors;
 	continue;
       }
-      if (dir->get_dir_auth().first != mds->whoami) {
+      if (dir->get_dir_auth().first != mds->get_nodeid()) {
 	mds->clog->error() << " replayed ESubtreeMap at " << get_start_off()
 			  << " subtree root " << p->first
 			  << " is not mine in cache (it's " << dir->get_dir_auth() << ")";
@@ -2596,7 +2596,7 @@ void ESubtreeMap::replay(MDSRank *mds)
     mds->mdcache->list_subtrees(subs);
     for (list<CDir*>::iterator p = subs.begin(); p != subs.end(); ++p) {
       CDir *dir = *p;
-      if (dir->get_dir_auth().first != mds->whoami)
+      if (dir->get_dir_auth().first != mds->get_nodeid())
 	continue;
       if (subtrees.count(dir->dirfrag()) == 0) {
 	mds->clog->error() << " replayed ESubtreeMap at " << get_start_off()
@@ -3022,13 +3022,13 @@ void EResetJournal::replay(MDSRank *mds)
   mds->sessionmap.wipe();
   mds->inotable->replay_reset();
 
-  if (mds->mdsmap->get_root() == mds->whoami) {
+  if (mds->mdsmap->get_root() == mds->get_nodeid()) {
     CDir *rootdir = mds->mdcache->get_root()->get_or_open_dirfrag(mds->mdcache, frag_t());
-    mds->mdcache->adjust_subtree_auth(rootdir, mds->whoami);   
+    mds->mdcache->adjust_subtree_auth(rootdir, mds->get_nodeid());   
   }
 
   CDir *mydir = mds->mdcache->get_myin()->get_or_open_dirfrag(mds->mdcache, frag_t());
-  mds->mdcache->adjust_subtree_auth(mydir, mds->whoami);   
+  mds->mdcache->adjust_subtree_auth(mydir, mds->get_nodeid());   
 
   mds->mdcache->recalc_auth_bits(true);
 

--- a/src/messages/MClientRequestForward.h
+++ b/src/messages/MClientRequestForward.h
@@ -16,6 +16,8 @@
 #ifndef CEPH_MCLIENTREQUESTFORWARD_H
 #define CEPH_MCLIENTREQUESTFORWARD_H
 
+#include "msg/Message.h"
+
 class MClientRequestForward : public Message {
   int32_t dest_mds;
   int32_t num_fwd;

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -297,8 +297,10 @@ bool MDSMonitor::preprocess_beacon(MonOpRequestRef op)
   // booted, but not in map?
   if (pending_mdsmap.is_dne_gid(gid)) {
     if (state != MDSMap::STATE_BOOT) {
-      dout(7) << "mds_beacon " << *m << " is not in mdsmap" << dendl;
+      dout(7) << "mds_beacon " << *m << " is not in mdsmap (state "
+              << ceph_mds_state_name(state) << ")" << dendl;
       mon->send_reply(op, new MMDSMap(mon->monmap->fsid, &mdsmap));
+      m->put();
       return true;
     } else {
       return false;  // not booted yet.
@@ -334,6 +336,15 @@ bool MDSMonitor::preprocess_beacon(MonOpRequestRef op)
 	 info.state == MDSMap::STATE_ONESHOT_REPLAY) && state > 0) {
       dout(10) << "mds_beacon mds can't activate itself (" << ceph_mds_state_name(info.state)
 	       << " -> " << ceph_mds_state_name(state) << ")" << dendl;
+      goto reply;
+    }
+
+    if ((state == MDSMap::STATE_STANDBY || state == MDSMap::STATE_STANDBY_REPLAY)
+        && info.rank != MDS_RANK_NONE)
+    {
+      dout(4) << "mds_beacon MDS can't go back into standby after taking rank: "
+                 "held rank " << info.rank << " while requesting state "
+              << ceph_mds_state_name(state) << dendl;
       goto reply;
     }
     

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -34,7 +34,6 @@ using namespace std;
 
 #define SOCKET_PRIORITY_MIN_DELAY 6
 
-class MDS;
 class Timer;
 
 

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -260,7 +260,6 @@ private:
 
   friend class OSDMonitor;
   friend class PGMonitor;
-  friend class MDS;
 
  public:
   OSDMap() : epoch(0), 


### PR DESCRIPTION
This is a big interface cleanup:
 * Subsystems like server, mdcache etc now only see an MDSRank* instead of the whole MDS* caboodle.
 * The start/stop/dispatch hooks for MDSRank are in a separate MDSRankDIspatcher child class, that only MDSDaemon touches
 * The pre-taking-a-rank stuff (i.e. being in standby) behaviour all lives in MDSDaemon.

This gives us the nice property that nothing that requires an MDS rank is actually instantiated until we get a rank (i.e. construct MDSRank), and gives us a nice decrease in the visibility of parts that were effectively global before.

This does *not* do the separation of the lock (MDSRank still uses a reference to MDSDaemon::mds_lock) or dispatchers (MDSRank::ms_dispatch is called through from MDSDaemon).  Those will come along later -- I think it makes sense to let this stuff land before then so that we separate this many-LOC code movement from the more fine/fiddly concurrency parts.