### PR TITLE
rgw: If the client sends a Connection: close header respond accordingly.

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -28,7 +28,7 @@ int RGWMongoose::write_data(const char *buf, int len)
 }
 
 RGWMongoose::RGWMongoose(mg_connection *_conn, int _port) : conn(_conn), port(_port), header_done(false), sent_header(false), has_content_length(false),
-                                                 explicit_keepalive(false)
+                                                 explicit_keepalive(false), explicit_conn_close(false)
 {
 }
 
@@ -93,6 +93,7 @@ void RGWMongoose::init_env(CephContext *cct)
 
     if (strcasecmp(header->name, "connection") == 0) {
       explicit_keepalive = (strcasecmp(header->value, "keep-alive") == 0);
+      explicit_conn_close = (strcasecmp(header->value, "close") == 0);
     }
 
     int len = strlen(header->name) + 5; /* HTTP_ prepended */
@@ -178,6 +179,8 @@ int RGWMongoose::complete_header()
 
   if (explicit_keepalive)
     header_data.append("Connection: Keep-Alive\r\n");
+  else if (explicit_conn_close)
+    header_data.append("Connection: close\r\n");
 
   header_data.append("\r\n");
 

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -24,6 +24,7 @@ class RGWMongoose : public RGWClientIO
   bool sent_header;
   bool has_content_length;
   bool explicit_keepalive;
+  bool explicit_conn_close;
 
 public:
   void init_env(CephContext *cct);


### PR DESCRIPTION
HTTP/1.1 assumes Keep-Alive by default, but if a Connection: close header is send
the server should respond with it as well.

This makes the client close the connection after the request.

Fixes: #12298