### PR TITLE
ceph.spec.in: do not run fdupes, even on SLE/openSUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -117,7 +117,6 @@ BuildRequires:	%insserv_prereq
 BuildRequires:	mozilla-nss-devel
 BuildRequires:	keyutils-devel
 BuildRequires:	libatomic-ops-devel
-BuildRequires:	fdupes
 %else
 BuildRequires:  bzip2-devel
 BuildRequires:	nss-devel
@@ -593,12 +592,6 @@ mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/ceph/bootstrap-osd
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/ceph/bootstrap-mds
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/ceph/bootstrap-rgw
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/log/radosgw
-
-%if %{defined suse_version}
-# Fedora seems to have some problems with this macro, use it only on SUSE
-%fdupes -s $RPM_BUILD_ROOT/%{python_sitelib}
-%fdupes %buildroot
-%endif
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
In openSUSE there is a policy to use %fdupes in the spec file if RPMLINT
complains about duplicate files wasting space in the filesystem.

However, RPMLINT is not so complaining, so drop fdupes.

http://tracker.ceph.com/issues/12301 Fixes: #12301

Signed-off-by: Nathan Cutler <ncutler@suse.com>