### PR TITLE
ceph.spec.in: fix libs-compat / devel-compat conditional

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -996,12 +996,12 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %files libs-compat
 # We need an empty %%files list for ceph-libs-compat, to tell rpmbuild to actually
 # build this meta package.
+%endif
 
 #################################################################################
 %files devel-compat
 # We need an empty %%files list for ceph-devel-compat, to tell rpmbuild to
 # actually build this meta package.
-%endif
 
 #################################################################################
 %files -n python-ceph-compat


### PR DESCRIPTION
In the RPM .spec's `%files` list, the "with libs-compat" conditional was inadvertantly exended to cover the files list for ceph-devel-compat as well.

The "with libs-compat" conditional should only cover the "ceph-libs-compat" package, and not affect "ceph-devel-compat".

Fixes http://tracker.ceph.com/issues/12315