### PR TITLE
client: reference counting 'struct Fh'

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -628,14 +628,13 @@ private:
 
   Fh *_create_fh(Inode *in, int flags, int cmode);
   int _release_fh(Fh *fh);
+  void _put_fh(Fh *fh);
 
 
   struct C_Readahead : public Context {
     Client *client;
     Fh *f;
-    C_Readahead(Client *c, Fh *f)
-      : client(c),
-	f(f) { }
+    C_Readahead(Client *c, Fh *f);
     void finish(int r);
   };
 

--- a/src/client/Fh.h
+++ b/src/client/Fh.h
@@ -11,7 +11,8 @@ class ceph_lock_state_t;
 // file handle for any open file state
 
 struct Fh {
-  Inode    *inode;
+  int	    _ref;
+  Inode     *inode;
   loff_t    pos;
   int       mds;        // have to talk to mds we opened with (for now)
   int       mode;       // the mode i opened the file with
@@ -26,8 +27,10 @@ struct Fh {
   ceph_lock_state_t *fcntl_locks;
   ceph_lock_state_t *flock_locks;
 
-  Fh() : inode(0), pos(0), mds(0), mode(0), flags(0), pos_locked(false),
+  Fh() : _ref(1), inode(0), pos(0), mds(0), mode(0), flags(0), pos_locked(false),
       readahead(), fcntl_locks(NULL), flock_locks(NULL) {}
+  void get() { ++_ref; }
+  int put() { return --_ref; }
 };
 
 


### PR DESCRIPTION
The async readahead finisher needs to reference 'struct Fh'. But
it's possible user closes FD and free the corresponding 'struct Fh'
before async readahead finishes.

Fixes: #12088
Signed-off-by: Yan, Zheng <zyan@redhat.com>
(cherry picked from commit 34b939a81d38173b882c429b28dedce778504ba8)