### PR TITLE
RGW Swift API: XML document generated in response for GET on account does not contain account name

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -58,7 +58,8 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
 
   if (!ret) {
     dump_start(s);
-    s->formatter->open_array_section("account");
+    s->formatter->open_array_section_with_attrs("account",
+            FormatterAttrs("name", s->user.display_name.c_str(), NULL));
 
     sent_data = true;
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/12323