### PR TITLE
Civetweb RGW appears to report full size of object as downloaded when only partially downloaded

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -13,13 +13,18 @@ int RGWMongoose::write_data(const char *buf, int len)
 {
   if (!header_done) {
     header_data.append(buf, len);
-    return 0;
+    return len;
   }
   if (!sent_header) {
     data.append(buf, len);
-    return 0;
+    return len;
   }
-  return mg_write(conn, buf, len);
+  int r = mg_write(conn, buf, len);
+  if (r == 0) {
+    /* didn't send anything, error out */
+    return -EIO;
+  }
+  return r;
 }
 
 RGWMongoose::RGWMongoose(mg_connection *_conn, int _port) : conn(_conn), port(_port), header_done(false), sent_header(false), has_content_length(false),

--- a/src/rgw/rgw_client_io.cc
+++ b/src/rgw/rgw_client_io.cc
@@ -56,7 +56,12 @@ int RGWClientIO::write(const char *buf, int len)
     return ret;
 
   if (account)
-    bytes_sent += len;
+    bytes_sent += ret;
+
+  if (ret < len) {
+    /* sent less than tried to send, error out */
+    return -EIO;
+  }
 
   return 0;
 }


### PR DESCRIPTION
http://tracker.ceph.com/issues/12243