### PR TITLE
Fix out-of-tree build.

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -21,7 +21,7 @@ $(dist_man_MANS): sphinx-build.stamp
 # in a tree populated from dist tarball, the $(top_srcdir)/doc is not included
 sphinx-build.stamp:
 	if [ -d $(top_srcdir)/doc/man ] ; then \
-		${SPHINX_BUILD} -b man -d doctrees -c . $(top_srcdir)/doc/man $(top_builddir)/man; \
+		${SPHINX_BUILD} -b man -d doctrees -c $(top_srcdir)/man $(top_srcdir)/doc/man $(top_builddir)/man; \
 	fi
 
 clean-local:

--- a/src/Makefile-client.am
+++ b/src/Makefile-client.am
@@ -20,9 +20,9 @@ bin_PROGRAMS += ceph-syn
 ceph: ceph.in ./ceph_ver.h Makefile
 	rm -f $@ $@.tmp
 	echo "#!/usr/bin/env python" >$@.tmp
-	grep "#define CEPH_GIT_NICE_VER" ./ceph_ver.h | \
+	grep "#define CEPH_GIT_NICE_VER" $(srcdir)/ceph_ver.h | \
 		sed -e 's/#define \(.*VER\) /\1=/' >>$@.tmp
-	grep "#define CEPH_GIT_VER" ./ceph_ver.h | \
+	grep "#define CEPH_GIT_VER" $(srcdir)/ceph_ver.h | \
 	  sed -e 's/#define \(.*VER\) /\1=/' -e 's/=\(.*\)$$/="\1"/' >>$@.tmp
 	cat $(srcdir)/$@.in >>$@.tmp
 	chmod a+x $@.tmp

--- a/src/ceph-detect-init/Makefile.am
+++ b/src/ceph-detect-init/Makefile.am
@@ -54,13 +54,13 @@ EXTRA_DIST += \
 	ceph-detect-init/tox.ini
 
 all-local::
-	cd ceph-detect-init ; python setup.py build
+	cd $(srcdir)/ceph-detect-init ; python setup.py build
 
 clean-local::
-	cd ceph-detect-init ; python setup.py clean ; rm -fr wheelhouse .tox build .coverage *.egg-info
+	cd $(srcdir)/ceph-detect-init ; python setup.py clean ; rm -fr wheelhouse .tox build .coverage *.egg-info
 
 install-data-local::
-	cd ceph-detect-init ; \
+	cd $(srcdir)/ceph-detect-init ; \
 	if test "$(DESTDIR)" ; then \
 		if lsb_release -si | grep --quiet 'Ubuntu\|Debian\|Devuan' ; then \
 			options=--install-layout=deb ; \

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -65,7 +65,7 @@ LIBRGW_DEPS += \
 	-lfcgi \
 	-ldl
 
-CIVETWEB_INCLUDE = --include civetweb/include/civetweb_conf.h
+CIVETWEB_INCLUDE = --include $(srcdir)/civetweb/include/civetweb_conf.h
 
 libcivetweb_la_SOURCES =  \
 	rgw/rgw_civetweb.cc \
@@ -73,7 +73,7 @@ libcivetweb_la_SOURCES =  \
 	civetweb/src/civetweb.c
 
 libcivetweb_la_CXXFLAGS = ${CIVETWEB_INCLUDE} -Woverloaded-virtual ${AM_CXXFLAGS}
-libcivetweb_la_CFLAGS = -Icivetweb/include ${CIVETWEB_INCLUDE}
+libcivetweb_la_CFLAGS = -I$(srcdir)/civetweb/include ${CIVETWEB_INCLUDE}
 
 noinst_LTLIBRARIES += libcivetweb.la
 

--- a/src/tracing/Makefile.am
+++ b/src/tracing/Makefile.am
@@ -24,6 +24,7 @@ nodist_libosd_tp_la_SOURCES = \
 endif
 libosd_tp_la_LIBADD = -llttng-ust -ldl
 libosd_tp_la_CPPFLAGS = -DTRACEPOINT_PROBE_DYNAMIC_LINKAGE
+libosd_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS)
 libosd_tp_la_LDFLAGS =
 
 if WITH_LTTNG


### PR DESCRIPTION
Corrects minor Automake errors which prevented Ceph from building
when configure was invoked from a different directory than
the toplevel source directory.

Signed-off-by: Krzysztof Kosiński <krzysztof.kosinski@intel.com>