### PR TITLE
rgw: doc: Fix radosgw stripe size config ref

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -208,7 +208,7 @@ Ceph configuration file, the default value will be set automatically.
 :Default: ``false``
 
 
-``rgw object stripe size``
+``rgw obj stripe size``
 
 :Description: The size of an object stripe for Ceph Object Gateway objects.
               See `Architecture`_ for details on striping.


### PR DESCRIPTION
s/rgw object stripe size/rgw obj stripe size
https://github.com/ceph/ceph/blob/master/src/common/config_opts.h#L1024

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>