### PR TITLE
fix the FTBFS on i386 due to libcls_cephfs

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -665,6 +665,7 @@ fi
 %{_libdir}/ceph/ceph_common.sh
 %{_libexecdir}/ceph/ceph-osd-prestart.sh
 %dir %{_libdir}/rados-classes
+%{_libdir}/rados-classes/libcls_cephfs.so*
 %{_libdir}/rados-classes/libcls_rbd.so*
 %{_libdir}/rados-classes/libcls_hello.so*
 %{_libdir}/rados-classes/libcls_rgw.so*

--- a/src/cls/cephfs/cls_cephfs.h
+++ b/src/cls/cephfs/cls_cephfs.h
@@ -59,7 +59,7 @@ class AccumulateArgs
 public:
   uint64_t obj_index;
   uint64_t obj_size;
-  time_t mtime;
+  int64_t mtime;
   std::string obj_xattr_name;
   std::string mtime_xattr_name;
   std::string obj_size_xattr_name;


### PR DESCRIPTION
- include libcls_cephfs.so in spec.in
- fix the FTBFS on i386 due to time_t is not supported by encode()