### PR TITLE
rgw: skip prefetch first chunk if range get falls to shadow objects

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -134,6 +134,7 @@ protected:
   int ret;
   bool get_data;
   bool partial_content;
+  bool range_parsed;
   rgw_obj obj;
   utime_t gc_invalidate_time;
 
@@ -156,10 +157,11 @@ public:
     unmod_ptr = NULL;
     get_data = false;
     partial_content = false;
+    range_parsed = false;
     ret = 0;
  }
 
-  virtual bool prefetch_data() { return get_data; }
+  bool prefetch_data();
 
   void set_get_data(bool get_data) {
     this->get_data = get_data;


### PR DESCRIPTION
Currently the head object will be prefetched in each GET:
 a) This is unnecessary if the Range GET falls to shadow objects.
 b) The GET request would be quite slow if we have a big head object
This patch adds some check on the Range. If it's not in the head
object( >=rgw_max_chunk_size) then skip the prefetch.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>