### PR TITLE
Bufferlist tuning

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1349,12 +1349,13 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     for (std::list<ptr>::iterator it = _buffers.begin();
 	 it != _buffers.end();
 	 ++it) {
-      nb.copy_in(pos, it->length(), it->c_str());
+      nb.copy_in(pos, it->length(), it->c_str(), false);
       pos += it->length();
     }
     _memcopy_count += pos;
     _buffers.clear();
     _buffers.push_back(nb);
+    invalidate_crc();
   }
 
 void buffer::list::rebuild_aligned(unsigned align)

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -882,14 +882,16 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     return true;
   }
 
-  void buffer::ptr::append(char c)
+  unsigned buffer::ptr::append(char c)
   {
     assert(_raw);
     assert(1 <= unused_tail_length());
-    (c_str())[_len] = c;
+    char* ptr = _raw->data + _off + _len;
+    *ptr = c;
     _len++;
+    return _len + _off;
   }
-  
+
   unsigned buffer::ptr::append(const char *p, unsigned l)
   {
     assert(_raw);
@@ -1487,10 +1489,9 @@ void buffer::list::rebuild_page_aligned()
       append_buffer = create_page_aligned(alen);
       append_buffer.set_length(0);   // unused, so far.
     }
-    append_buffer.append(c);
-    append(append_buffer, append_buffer.end() - 1, 1);	// add segment to the list
+    append(append_buffer, append_buffer.append(c) - 1, 1);	// add segment to the list
   }
-  
+
   void buffer::list::append(const char *data, unsigned len)
   {
     while (len > 0) {

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -239,7 +239,7 @@ public:
       _len = l;
     }
 
-    void append(char c);
+    unsigned append(char c);
     unsigned append(const char *p, unsigned l);
     void copy_in(unsigned o, unsigned l, const char *src);
     void zero();

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -241,9 +241,9 @@ public:
 
     unsigned append(char c);
     unsigned append(const char *p, unsigned l);
-    void copy_in(unsigned o, unsigned l, const char *src);
-    void zero();
-    void zero(unsigned o, unsigned l);
+    void copy_in(unsigned o, unsigned l, const char *src, bool crc_reset = true);
+    void zero(bool crc_reset = true);
+    void zero(unsigned o, unsigned l, bool crc_reset = true);
 
   };
 
@@ -307,7 +307,7 @@ public:
       void copy_all(list &dest);
 
       // copy data in
-      void copy_in(unsigned len, const char *src);
+      void copy_in(unsigned len, const char *src, bool crc_reset = true);
       void copy_in(unsigned len, const list& otherl);
 
     };
@@ -442,7 +442,7 @@ public:
     void copy(unsigned off, unsigned len, char *dest) const;
     void copy(unsigned off, unsigned len, list &dest) const;
     void copy(unsigned off, unsigned len, std::string& dest) const;
-    void copy_in(unsigned off, unsigned len, const char *src);
+    void copy_in(unsigned off, unsigned len, const char *src, bool crc_reset = true);
     void copy_in(unsigned off, unsigned len, const list& src);
 
     void append(char c);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -245,7 +245,7 @@ public:
     }
 
     void append(char c);
-    void append(const char *p, unsigned l);
+    unsigned append(const char *p, unsigned l);
     void copy_in(unsigned o, unsigned l, const char *src);
     void zero();
     void zero(unsigned o, unsigned l);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -219,12 +219,7 @@ public:
     unsigned raw_length() const;
     int raw_nref() const;
 
-    void copy_out(unsigned o, unsigned l, char *dest) const {
-      assert(_raw);
-      if (!((o <= _len) && (o+l <= _len)))
-	throw end_of_buffer();
-      memcpy(dest, c_str()+o, l);
-    }
+    void copy_out(unsigned o, unsigned l, char *dest) const;
 
     bool can_zero_copy() const;
     int zero_copy_to_fd(int fd, int64_t *offset) const;

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -164,7 +164,8 @@ inline void encode(const std::string& s, bufferlist& bl, uint64_t features=0)
 {
   __u32 len = s.length();
   encode(len, bl);
-  bl.append(s.data(), len);
+  if (len)
+    bl.append(s.data(), len);
 }
 inline void decode(std::string& s, bufferlist::iterator& p)
 {
@@ -189,7 +190,8 @@ inline void encode(const char *s, bufferlist& bl)
 {
   __u32 len = strlen(s);
   encode(len, bl);
-  bl.append(s, len);
+  if (len)
+    bl.append(s, len);
 }
 
 


### PR DESCRIPTION
A bunch of changes in bufferlist code, all relating to bufferlist performance.

1. Tuning small appends
2. Rewrite of is_zero for up to 15x speed increase
3. Short-circuiting in copy_in, copy_out and append
4. Reusing result of bufferptr::append for less calls
5. Omiting CRC cache invalidation
6. Omiting 0-byte appends in encoding.h

Except for is_zero, performance increase is around 10-40% per call.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>
