### PR TITLE
ceph.spec.in: drop SUSE-specific %py_requires macro

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -242,9 +242,6 @@ Group:		System Environment/Libraries
 License:	LGPL-2.0
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 Obsoletes:	python-ceph < %{epoch}:%{version}-%{release}
-%if 0%{defined suse_version}
-%py_requires
-%endif
 %description -n python-rados
 This package contains Python libraries for interacting with Cephs RADOS
 object store.


### PR DESCRIPTION
%py_requires expands to

BuildRequires: /usr/bin/python
PreReq: python = 2.7

The BuildRequires: is already provided, and the PreReq is wrong because
e.g. SLE11-SP3 (a platform we are trying to support) has Python 2.6.

http://tracker.ceph.com/issues/12351 Fixes: #12351

Signed-off-by: Nathan Cutler <ncutler@suse.com>