### PR TITLE
ceph.spec.in: remove SUSE-specific apache2-mod_fcgid dependency

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -188,7 +188,6 @@ Requires:	librados2 = %{epoch}:%{version}-%{release}
 %if 0%{defined suse_version}
 BuildRequires:	libexpat-devel
 BuildRequires:	FastCGI-devel
-Requires:	apache2-mod_fcgid
 %endif
 %if 0%{?rhel} || 0%{?fedora}
 BuildRequires:	expat-devel


### PR DESCRIPTION
This package is no longer required for RGW to work in SUSE.

http://tracker.ceph.com/issues/12358 Fixes: #12358

Signed-off-by: Nathan Cutler <ncutler@suse.com>