### PR TITLE
tests: test-erasure-code.sh/rados_osds_out_in must wait_for_clean

### DIFF
--- a/src/test/erasure-code/test-erasure-code.sh
+++ b/src/test/erasure-code/test-erasure-code.sh
@@ -125,6 +125,7 @@ function rados_osds_out_in() {
     # implies the PG have been moved to use the remaining OSDs.  Check
     # the object can still be retrieved.
     #
+    wait_for_clean || return 1
     local osds_list=$(get_osds $poolname $objname)
     local -a osds=($osds_list)
     for osd in 0 1 ; do


### PR DESCRIPTION
get_osds $poolname $objname must be called after wait_for_clean to
ensure the mapping is final (no pg_temp). Otherwise, depending on how
fast the machine is, a temporary mapping will be returned and it won't
match the final mapping returned later.

http://tracker.ceph.com/issues/12356 Fixes: #12356

Signed-off-by: Loic Dachary <ldachary@redhat.com>