### PR TITLE
tests: test/cephtool-test-mon.sh uses 7202 7203 and 7204

### DIFF
--- a/src/test/cephtool-test-mon.sh
+++ b/src/test/cephtool-test-mon.sh
@@ -16,6 +16,8 @@
 # GNU Library Public License for more details.
 #
 CEPH_CLI_TEST_DUP_COMMAND=1 \
+# uses CEPH_PORT going from 7202 7203 and 7204 because
+# it starts at 7202 and runs 3 mons (see vstart.sh)
 MON=3 OSD=3 CEPH_START='mon osd' CEPH_PORT=7202 test/vstart_wrapper.sh \
     ../qa/workunits/cephtool/test.sh \
     --test-mon \


### PR DESCRIPTION
When running 3 mons, vstart uses ports starting from CEPH_PORT=7202 and
increments to 7203 for the second mon and 7204 for the third. Add a
comment showing the port number. The method for a test to figure out
which port is free is to grep for the port and if nothing matches, use
it. The grep will match 7204 and 7203 and 7201 from the comment and
reduce the chances of someone using 7203 because it was nowhere to be
found in the sources.

Signed-off-by: Loic Dachary <ldachary@redhat.com>