### PR TITLE
mon: add cache tier IO rate in the 'osd pool stats' command

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3597,6 +3597,22 @@ bool OSDMonitor::preprocess_command(MMonCommand *m)
       if (!f && !rss.str().empty())
         tss << "  client io " << rss.str() << "\n";
 
+      // dump cache tier IO rate for cache pool
+      const pg_pool_t *pool = osdmap.get_pg_pool(poolid);
+      if (pool->is_tier()) {
+        if (f) {
+          f->close_section();
+          f->open_object_section("cache_io_rate");
+        }
+
+        rss.clear();
+        rss.str("");
+
+        pg_map.pool_cache_io_rate_summary(f.get(), &rss, poolid);
+        if (!f && !rss.str().empty())
+          tss << "  cache tier io " << rss.str() << "\n";
+      }
+
       if (f) {
         f->close_section();
         f->close_section();

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1224,6 +1224,11 @@ void PGMap::cache_io_rate_summary(Formatter *f, ostream *out,
   }
 }
 
+void PGMap::overall_cache_io_rate_summary(Formatter *f, ostream *out) const
+{
+  cache_io_rate_summary(f, out, pg_sum_delta, stamp_delta);
+}
+
 void PGMap::pool_cache_io_rate_summary(Formatter *f, ostream *out,
                                        uint64_t poolid) const
 {
@@ -1423,6 +1428,13 @@ void PGMap::print_summary(Formatter *f, ostream *out) const
   overall_client_io_rate_summary(f, &ssr);
   if (!f && ssr.str().length())
     *out << "  client io " << ssr.str() << "\n";
+
+  ssr.clear();
+  ssr.str("");
+
+  overall_cache_io_rate_summary(f, &ssr);
+  if (!f && ssr.str().length())
+    *out << "  cache io " << ssr.str() << "\n";
 }
 
 void PGMap::print_oneline_summary(Formatter *f, ostream *out) const

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -334,6 +334,20 @@ public:
    */
   void pool_client_io_rate_summary(Formatter *f, ostream *out,
                                    uint64_t poolid) const;
+  /**
+   * Obtain a formatted/plain output for cache tier IO, source from stats for a
+   * given @p delta_sum pool over a given @p delta_stamp period of time.
+   */
+  void cache_io_rate_summary(Formatter *f, ostream *out,
+                             const pool_stat_t& delta_sum,
+                             utime_t delta_stamp) const;
+  /**
+   * Obtain a formatted/plain output for cache tier IO over a given pool
+   * with id @p pool_id.  We will then obtain pool-specific data
+   * from @p per_pool_sum_delta.
+   */
+  void pool_cache_io_rate_summary(Formatter *f, ostream *out,
+                                  uint64_t poolid) const;
 
   void print_summary(Formatter *f, ostream *out) const;
   void print_oneline_summary(Formatter *f, ostream *out) const;

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -342,6 +342,11 @@ public:
                              const pool_stat_t& delta_sum,
                              utime_t delta_stamp) const;
   /**
+   * Obtain a formatted/plain output for the overall cache tier IO, which is
+   * calculated resorting to @p pg_sum_delta and @p stamp_delta.
+   */
+  void overall_cache_io_rate_summary(Formatter *f, ostream *out) const;
+  /**
    * Obtain a formatted/plain output for cache tier IO over a given pool
    * with id @p pool_id.  We will then obtain pool-specific data
    * from @p per_pool_sum_delta.

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2213,6 +2213,7 @@ void ReplicatedPG::promote_object(ObjectContextRef obc,
 
   if (op)
     wait_for_blocked_object(obc->obs.oi.soid, op);
+  info.stats.stats.sum.num_promote++;
 }
 
 void ReplicatedPG::execute_ctx(OpContext *ctx)

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -7052,6 +7052,8 @@ int ReplicatedPG::start_flush(
   fop->objecter_tid = tid;
 
   flush_ops[soid] = fop;
+  info.stats.stats.sum.num_flush++;
+  info.stats.stats.sum.num_flush_kb += SHIFT_ROUND_UP(oi.size, 10);
   return -EINPROGRESS;
 }
 
@@ -10949,6 +10951,8 @@ bool ReplicatedPG::agent_maybe_evict(ObjectContextRef& obc)
   int r = _delete_oid(ctx, true);
   if (obc->obs.oi.is_omap())
     ctx->delta_stats.num_objects_omap--;
+  ctx->delta_stats.num_evict++;
+  ctx->delta_stats.num_evict_kb += SHIFT_ROUND_UP(obc->obs.oi.size, 10);
   assert(r == 0);
   finish_ctx(ctx, pg_log_entry_t::DELETE, false);
   simple_repop_submit(repop);

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1545,11 +1545,15 @@ void object_stat_sum_t::dump(Formatter *f) const
   f->dump_int("num_objects_omap", num_objects_omap);
   f->dump_int("num_objects_hit_set_archive", num_objects_hit_set_archive);
   f->dump_int("num_bytes_hit_set_archive", num_bytes_hit_set_archive);
+  f->dump_int("num_flush", num_flush);
+  f->dump_int("num_flush_kb", num_flush_kb);
+  f->dump_int("num_evict", num_evict);
+  f->dump_int("num_evict_kb", num_evict_kb);
 }
 
 void object_stat_sum_t::encode(bufferlist& bl) const
 {
-  ENCODE_START(11, 3, bl);
+  ENCODE_START(12, 3, bl);
   ::encode(num_bytes, bl);
   ::encode(num_objects, bl);
   ::encode(num_object_clones, bl);
@@ -1573,12 +1577,16 @@ void object_stat_sum_t::encode(bufferlist& bl) const
   ::encode(num_objects_hit_set_archive, bl);
   ::encode(num_objects_misplaced, bl);
   ::encode(num_bytes_hit_set_archive, bl);
+  ::encode(num_flush, bl);
+  ::encode(num_flush_kb, bl);
+  ::encode(num_evict, bl);
+  ::encode(num_evict_kb, bl);
   ENCODE_FINISH(bl);
 }
 
 void object_stat_sum_t::decode(bufferlist::iterator& bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(11, 3, 3, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(12, 3, 3, bl);
   ::decode(num_bytes, bl);
   if (struct_v < 3) {
     uint64_t num_kb;
@@ -1642,6 +1650,17 @@ void object_stat_sum_t::decode(bufferlist::iterator& bl)
   } else {
     num_bytes_hit_set_archive = 0;
   }
+  if (struct_v >= 12) {
+    ::decode(num_flush, bl);
+    ::decode(num_flush_kb, bl);
+    ::decode(num_evict, bl);
+    ::decode(num_evict_kb, bl);
+  } else {
+    num_flush = 0;
+    num_flush_kb = 0;
+    num_evict = 0;
+    num_evict_kb = 0;
+  }
   DECODE_FINISH(bl);
 }
 
@@ -1669,6 +1688,10 @@ void object_stat_sum_t::generate_test_instances(list<object_stat_sum_t*>& o)
   a.num_objects_misplaced = 1232;
   a.num_objects_hit_set_archive = 2;
   a.num_bytes_hit_set_archive = 27;
+  a.num_flush = 5;
+  a.num_flush_kb = 6;
+  a.num_evict = 7;
+  a.num_evict_kb = 8;
   o.push_back(new object_stat_sum_t(a));
 }
 
@@ -1697,6 +1720,10 @@ void object_stat_sum_t::add(const object_stat_sum_t& o)
   num_objects_omap += o.num_objects_omap;
   num_objects_hit_set_archive += o.num_objects_hit_set_archive;
   num_bytes_hit_set_archive += o.num_bytes_hit_set_archive;
+  num_flush += o.num_flush;
+  num_flush_kb += o.num_flush_kb;
+  num_evict += o.num_evict;
+  num_evict_kb += o.num_evict_kb;
 }
 
 void object_stat_sum_t::sub(const object_stat_sum_t& o)
@@ -1724,6 +1751,10 @@ void object_stat_sum_t::sub(const object_stat_sum_t& o)
   num_objects_omap -= o.num_objects_omap;
   num_objects_hit_set_archive -= o.num_objects_hit_set_archive;
   num_bytes_hit_set_archive -= o.num_bytes_hit_set_archive;
+  num_flush -= o.num_flush;
+  num_flush_kb -= o.num_flush_kb;
+  num_evict -= o.num_evict;
+  num_evict_kb -= o.num_evict_kb;
 }
 
 bool operator==(const object_stat_sum_t& l, const object_stat_sum_t& r)
@@ -1751,7 +1782,11 @@ bool operator==(const object_stat_sum_t& l, const object_stat_sum_t& r)
     l.num_whiteouts == r.num_whiteouts &&
     l.num_objects_omap == r.num_objects_omap &&
     l.num_objects_hit_set_archive == r.num_objects_hit_set_archive &&
-    l.num_bytes_hit_set_archive == r.num_bytes_hit_set_archive;
+    l.num_bytes_hit_set_archive == r.num_bytes_hit_set_archive &&
+    l.num_flush == r.num_flush &&
+    l.num_flush_kb == r.num_flush_kb &&
+    l.num_evict == r.num_evict &&
+    l.num_evict_kb == r.num_evict_kb;
 }
 
 // -- object_stat_collection_t --

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1549,6 +1549,7 @@ void object_stat_sum_t::dump(Formatter *f) const
   f->dump_int("num_flush_kb", num_flush_kb);
   f->dump_int("num_evict", num_evict);
   f->dump_int("num_evict_kb", num_evict_kb);
+  f->dump_int("num_promote", num_promote);
 }
 
 void object_stat_sum_t::encode(bufferlist& bl) const
@@ -1581,6 +1582,7 @@ void object_stat_sum_t::encode(bufferlist& bl) const
   ::encode(num_flush_kb, bl);
   ::encode(num_evict, bl);
   ::encode(num_evict_kb, bl);
+  ::encode(num_promote, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -1655,11 +1657,13 @@ void object_stat_sum_t::decode(bufferlist::iterator& bl)
     ::decode(num_flush_kb, bl);
     ::decode(num_evict, bl);
     ::decode(num_evict_kb, bl);
+    ::decode(num_promote, bl);
   } else {
     num_flush = 0;
     num_flush_kb = 0;
     num_evict = 0;
     num_evict_kb = 0;
+    num_promote = 0;
   }
   DECODE_FINISH(bl);
 }
@@ -1692,6 +1696,7 @@ void object_stat_sum_t::generate_test_instances(list<object_stat_sum_t*>& o)
   a.num_flush_kb = 6;
   a.num_evict = 7;
   a.num_evict_kb = 8;
+  a.num_promote = 9;
   o.push_back(new object_stat_sum_t(a));
 }
 
@@ -1724,6 +1729,7 @@ void object_stat_sum_t::add(const object_stat_sum_t& o)
   num_flush_kb += o.num_flush_kb;
   num_evict += o.num_evict;
   num_evict_kb += o.num_evict_kb;
+  num_promote += o.num_promote;
 }
 
 void object_stat_sum_t::sub(const object_stat_sum_t& o)
@@ -1755,6 +1761,7 @@ void object_stat_sum_t::sub(const object_stat_sum_t& o)
   num_flush_kb -= o.num_flush_kb;
   num_evict -= o.num_evict;
   num_evict_kb -= o.num_evict_kb;
+  num_promote -= o.num_promote;
 }
 
 bool operator==(const object_stat_sum_t& l, const object_stat_sum_t& r)
@@ -1786,7 +1793,8 @@ bool operator==(const object_stat_sum_t& l, const object_stat_sum_t& r)
     l.num_flush == r.num_flush &&
     l.num_flush_kb == r.num_flush_kb &&
     l.num_evict == r.num_evict &&
-    l.num_evict_kb == r.num_evict_kb;
+    l.num_evict_kb == r.num_evict_kb &&
+    l.num_promote == r.num_promote;
 }
 
 // -- object_stat_collection_t --

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1308,6 +1308,7 @@ struct object_stat_sum_t {
   int64_t num_flush_kb;
   int64_t num_evict;
   int64_t num_evict_kb;
+  int64_t num_promote;
 
   object_stat_sum_t()
     : num_bytes(0),
@@ -1329,7 +1330,8 @@ struct object_stat_sum_t {
       num_flush(0),
       num_flush_kb(0),
       num_evict(0),
-      num_evict_kb(0)
+      num_evict_kb(0),
+      num_promote(0)
   {}
 
   void floor(int64_t f) {
@@ -1361,6 +1363,7 @@ struct object_stat_sum_t {
     FLOOR(num_flush_kb);
     FLOOR(num_evict);
     FLOOR(num_evict_kb);
+    FLOOR(num_promote);
 #undef FLOOR
   }
 
@@ -1400,6 +1403,7 @@ struct object_stat_sum_t {
     SPLIT(num_flush_kb);
     SPLIT(num_evict);
     SPLIT(num_evict_kb);
+    SPLIT(num_promote);
 #undef SPLIT
   }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1304,6 +1304,10 @@ struct object_stat_sum_t {
   int64_t num_objects_omap;
   int64_t num_objects_hit_set_archive;
   int64_t num_bytes_hit_set_archive;
+  int64_t num_flush;
+  int64_t num_flush_kb;
+  int64_t num_evict;
+  int64_t num_evict_kb;
 
   object_stat_sum_t()
     : num_bytes(0),
@@ -1321,7 +1325,11 @@ struct object_stat_sum_t {
       num_whiteouts(0),
       num_objects_omap(0),
       num_objects_hit_set_archive(0),
-      num_bytes_hit_set_archive(0)
+      num_bytes_hit_set_archive(0),
+      num_flush(0),
+      num_flush_kb(0),
+      num_evict(0),
+      num_evict_kb(0)
   {}
 
   void floor(int64_t f) {
@@ -1349,6 +1357,10 @@ struct object_stat_sum_t {
     FLOOR(num_objects_omap);
     FLOOR(num_objects_hit_set_archive);
     FLOOR(num_bytes_hit_set_archive);
+    FLOOR(num_flush);
+    FLOOR(num_flush_kb);
+    FLOOR(num_evict);
+    FLOOR(num_evict_kb);
 #undef FLOOR
   }
 
@@ -1384,6 +1396,10 @@ struct object_stat_sum_t {
     SPLIT(num_objects_omap);
     SPLIT(num_objects_hit_set_archive);
     SPLIT(num_bytes_hit_set_archive);
+    SPLIT(num_flush);
+    SPLIT(num_flush_kb);
+    SPLIT(num_evict);
+    SPLIT(num_evict_kb);
 #undef SPLIT
   }
 


### PR DESCRIPTION
This additionally shows the flush/evict bandwidth and promote IOPS in the output of the 'osd pool stats' command.