### PR TITLE
rados.cc: fix an issue in the output of the 'rados df' command

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1497,7 +1497,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       librados::pool_stat_t& s = i->second;
       if (!formatter) {
 	printf("%-15s "
-	       "%12lld %12lld %12lld %12lld"
+	       "%12lld %12lld %12lld %12lld "
 	       "%12lld %12lld %12lld %12lld %12lld\n",
 	       pool_name,
 	       (long long)s.num_kb,


### PR DESCRIPTION
Before the fix, the output is like this:
```
$ rados df
pool name       category                 KB      objects       clones     degraded      unfound           rd        rd KB           wr        wr KB
cephfs_data     -                          0            0            0            0           0            0            0            0            0
cephfs_metadata -                          5           54            0            0           0            0            0          117           17
rbd             -                         30         1024            0            0           0       308097       268864         7219         4401
  total used        69449556         1078
  total avail       82188096
  total space      159825444
```

After the fix, the output is:
```
$ rados df
pool name                 KB      objects       clones     degraded      unfound           rd        rd KB           wr        wr KB
cephfs_data                0            0            0            0            0            0            0            0            0
cephfs_metadata            5           54            0            0            0            0            0          117           17
rbd                       30         1024            0            0            0       218976       190868         6595         4019
  total used        69348404         1078
  total avail       82289248
  total space      159825444
```