### PR TITLE
pybind/ceph_argparse: do not choke on non-ascii prefix

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -513,6 +513,13 @@ class CephPrefix(CephArgtype):
         self.prefix = prefix
 
     def valid(self, s, partial=False):
+        try:
+            # `prefix` can always be converted into unicode when being compared,
+            # but `s` could be anything passed by user.
+            s = unicode(s)
+        except UnicodeDecodeError:
+            raise ArgumentPrefix("no match for {0}".format(s))
+
         if partial:
             if self.prefix.startswith(s):
                 self.val = s

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -1,6 +1,6 @@
 #!/usr/bin/nosetests --nocapture
-# -*- mode:python; tab-width:4; indent-tabs-mode:t -*-
-# vim: ts=4 sw=4 smarttab expandtab
+# -*- mode:python; tab-width:4; indent-tabs-mode:t; coding:utf-8 -*-
+# vim: ts=4 sw=4 smarttab expandtab fileencoding=utf-8
 #
 # Ceph - scalable distributed file system
 #
@@ -84,6 +84,15 @@ class TestArgparse:
         assert_equal({}, validate_command(sigdict, [prefix,
                                                     command,
                                                     'toomany']))
+
+
+class TestBasic:
+
+	def test_non_ascii_in_non_options(self):
+		# unicode() is not able to convert this str parameter into unicode
+		# using the default encoding 'ascii'. and validate_command() should
+		# not choke on it.
+		assert_is_none(validate_command(sigdict, ['章鱼和鱿鱼']))
 
 
 class TestPG(TestArgparse):


### PR DESCRIPTION
* add a test for it
* add the comments for utf-8 encoding, which is needed by python
  module loader. because the new test has a non-ascii string in
  it. it's the Chinese translation of "octopus and squid".

Fixes: #12287 http://tracker.ceph.com/issues/12287
Signed-off-by: Kefu Chai <kchai@redhat.com>