### PR TITLE
ObjectStore: refactor Sequencer.

### DIFF
--- a/src/os/FileStore.h
+++ b/src/os/FileStore.h
@@ -182,24 +182,33 @@ private:
 
   // -- op workqueue --
   struct Op {
-    utime_t start;
-    uint64_t op;
-    list<Transaction*> tls;
-    Context *onreadable, *onreadable_sync;
-    uint64_t ops, bytes;
+    utime_t start; ///< Time when this op was created
+    uint64_t op; ///< Sequence number of this group of transactions
+    list<Transaction*> tls; ///< List of transactions that are part of this operation
+    Context *onreadable, *onreadable_sync; ///< Callbacks that are executed once the transactions are applied
+    uint64_t ops; ///< Total number of primitive operations in the transaction list
+    uint64_t bytes; ///< Total size of the transactions in the list
     TrackedOpRef osd_op;
   };
   class OpSequencer : public Sequencer_impl {
     Mutex qlock; // to protect q, for benefit of flush (peek/dequeue also protected by lock)
-    list<Op*> q;
-    list<uint64_t> jq;
+    list<Op*> q; ///< Queue for operations
+    list<uint64_t> jq; ///< Queue for journal operations
+
+    /// List of callbacks waiting for an operation to be completed.
+    /// The first member of the pair is the seq number of an operation that must complete
+    /// before the callback in the second member can be invoked.
     list<pair<uint64_t, Context*> > flush_commit_waiters;
-    Cond cond;
+    Cond cond; ///< condition variable to wait for completion of some transactions
   public:
-    Sequencer *parent;
-    Mutex apply_lock;  // for apply mutual exclusion
-    
-    /// get_max_uncompleted
+    Sequencer *parent; ///< Public interface for this internal object
+    Mutex apply_lock;  ///< must be taken when starting to apply an operation and released when done
+
+  private:
+    /** @brief Get the maximum sequence number of a queued operation.
+     * This will correspond to the latest submitted operation.
+     * If both queues are empty, seq will be set to zero.
+     * @returns true if both queues are empty */
     bool _get_max_uncompleted(
       uint64_t *seq ///< [out] max uncompleted seq
       ) {
@@ -215,9 +224,13 @@ private:
 	*seq = jq.back();
 
       return false;
-    } /// @returns true if both queues are empty
+    }
 
-    /// get_min_uncompleted
+    /** @brief Get the minimum sequence number of a queued operation.
+     * This will correspond to the earliest operation that was not completed yet.
+     * Every operation with a number lower than seq has already been completed.
+     * If both queues are empty, seq will be set to zero.
+     * @returns true if both queues are empty */
     bool _get_min_uncompleted(
       uint64_t *seq ///< [out] min uncompleted seq
       ) {
@@ -235,10 +248,13 @@ private:
       return false;
     } /// @returns true if both queues are empty
 
+  public:
+    /// Put the async commit callbacks that can be executed now in an external list.
     void _wake_flush_waiters(list<Context*> *to_queue) {
       uint64_t seq;
+      // if the queues are empty, we can execute all callbacks.
       if (_get_min_uncompleted(&seq))
-	seq = -1;
+	seq = UINT64_MAX;
 
       for (list<pair<uint64_t, Context*> >::iterator i =
 	     flush_commit_waiters.begin();
@@ -279,27 +295,28 @@ private:
       return o;
     }
 
+    /// Block until all operations currently in the queue are processed.
     void flush() {
       Mutex::Locker l(qlock);
 
       while (g_conf->filestore_blackhole)
 	cond.Wait(qlock);  // wait forever
 
+      // get our "watermark" - the last uncompleted operation currently in the queue
+      uint64_t seq_watermark = 0;
+      bool queues_empty = _get_max_uncompleted(&seq_watermark);
 
-      // get max for journal _or_ op queues
-      uint64_t seq = 0;
-      if (!q.empty())
-	seq = q.back()->op;
-      if (!jq.empty() && jq.back() > seq)
-	seq = jq.back();
-
-      if (seq) {
-	// everything prior to our watermark to drain through either/both queues
-	while ((!q.empty() && q.front()->op <= seq) ||
-	       (!jq.empty() && jq.front() <= seq))
+      if (!queues_empty) {
+	uint64_t seq_min = 0;
+	// wait until the earliest uncompleted transaction exceeds our watermark
+	// OR both queues become empty
+	while (!_get_min_uncompleted(&seq_min) && seq_min <= seq_watermark)
 	  cond.Wait(qlock);
       }
     }
+    /** @brief If there are operations in the queue, add a callback to execute after they complete.
+     * If the queue is empty, the argument will be deleted without being executed.
+     * @return true if the queue is empty and the argument will not execute, false if the callback will execute in the future. */
     bool flush_commit(Context *c) {
       Mutex::Locker l(qlock);
       uint64_t seq = 0;

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -406,7 +406,7 @@ public:
   private:
     TransactionData data;
 
-    void *osr; // NULL on replay
+    Sequencer *osr; // NULL on replay
 
     bool use_tbl;   //use_tbl for encode/decode
     bufferlist tbl;
@@ -730,7 +730,7 @@ public:
       return data.ops;
     }
 
-    void set_osr(void *s) {
+    void set_osr(Sequencer *s) {
       osr = s;
     }
 

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -129,19 +129,26 @@ public:
    * in parallel.
    *
    * Clients of ObjectStore create and maintain their own Sequencer objects.
+   * New object are created through the ObjectStore's create_sequencer method,
+   * which returns a derived sequencer object valid for that type of store.
    * When a list of transactions is queued the caller specifies a Sequencer to be used.
    *
+   * The default implementation of the sequencer does nothing, and is suitable
+   * for cases when the store executes the transactions synchronously.
    */
+  class Sequencer {
+    string name;
 
-  /**
-   * ABC for Sequencer implementation, private to the ObjectStore derived class.
-   * created in ...::queue_transaction(s)
-   */
-  struct Sequencer_impl {
-    virtual void flush() = 0;
+  public:
+    /// return a unique string identifier for this sequencer
+    const string& get_name() const {
+      return name;
+    }
+    /// wait for any queued transactions on this sequencer to apply
+    virtual void flush() {}
 
     /**
-     * Async flush_commit
+     * @brief Add a callback to be executed asynchronously.
      *
      * There are two cases:
      * 1) sequencer is currently idle: the method returns true and
@@ -150,46 +157,17 @@ public:
      *    called asyncronously with a value of 0 once all transactions
      *    queued on this sequencer prior to the call have been applied
      *    and committed.
+     * @return true if idle, false otherwise
      */
-    virtual bool flush_commit(
-      Context *c ///< [in] context to call upon flush/commit
-      ) = 0; ///< @return true if idle, false otherwise
+    virtual bool flush_commit(Context *c) { return true; }
 
-    virtual ~Sequencer_impl() {}
-  };
+    virtual ~Sequencer() {}
 
-  /**
-   * External (opaque) sequencer implementation
-   */
-  struct Sequencer {
-    string name;
-    Sequencer_impl *p;
+  protected:
+    Sequencer(const string& n)
+      : name(n) {}
 
-    Sequencer(string n)
-      : name(n), p(NULL) {}
-    ~Sequencer() {
-      delete p;
-    }
-
-    /// return a unique string identifier for this sequencer
-    const string& get_name() const {
-      return name;
-    }
-    /// wait for any queued transactions on this sequencer to apply
-    void flush() {
-      if (p)
-	p->flush();
-    }
-
-    /// @see Sequencer_impl::flush_commit()
-    bool flush_commit(Context *c) {
-      if (!p) {
-	delete c;
-	return true;
-      } else {
-	return p->flush_commit(c);
-      }
-    }
+    friend class ObjectStore;
   };
 
   /*********************************
@@ -1665,6 +1643,10 @@ public:
       delete t;
     }
   };
+
+  virtual Sequencer *create_sequencer(const string& name) {
+    return new Sequencer(name);
+  }
 
   // synchronous wrappers
   unsigned apply_transaction(Transaction& t, Context *ondisk=0) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -195,6 +195,7 @@ CompatSet OSD::get_osd_compat_set() {
 OSDService::OSDService(OSD *osd) :
   osd(osd),
   cct(osd->cct),
+  osr_registry(NewSequencerFunctor(osd->store)),
   whoami(osd->whoami), store(osd->store),
   log_client(osd->log_client), clog(osd->clog),
   pg_recovery_stats(osd->pg_recovery_stats),

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -383,11 +383,20 @@ public:
   entity_inst_t get_owner() const { return owner; }
 };
 
+class NewSequencerFunctor {
+  ObjectStore *&store;
+public:
+  NewSequencerFunctor(ObjectStore *&os) : store(os) {}
+  ObjectStore::Sequencer *operator()(const string& name) {
+    return store->create_sequencer(name);
+  }
+};
+
 class OSDService {
 public:
   OSD *osd;
   CephContext *cct;
-  SharedPtrRegistry<spg_t, ObjectStore::Sequencer> osr_registry;
+  SharedPtrRegistry<spg_t, ObjectStore::Sequencer, NewSequencerFunctor> osr_registry;
   SharedPtrRegistry<spg_t, DeletingState> deleting_pgs;
   const int whoami;
   ObjectStore *&store;

--- a/src/test/bench/testfilestore_backend.cc
+++ b/src/test/bench/testfilestore_backend.cc
@@ -40,8 +40,8 @@ void TestFileStoreBackend::write(
   string coll_str = c.to_str();
 
   if (!osrs.count(coll_str))
-    osrs.insert(make_pair(coll_str, ObjectStore::Sequencer(coll_str)));
-  ObjectStore::Sequencer *osr = &(osrs.find(coll_str)->second);
+    osrs.insert(coll_str, os->create_sequencer(coll_str));
+  ObjectStore::Sequencer *osr = osrs.find(coll_str)->second;
 
   hobject_t h(sobject_t(oid.substr(sep+1), 0));
   h.pool = 0;

--- a/src/test/bench/testfilestore_backend.h
+++ b/src/test/bench/testfilestore_backend.h
@@ -3,6 +3,7 @@
 #ifndef TESTFILESTOREBACKENDH
 #define TESTFILESTOREBACKENDH
 
+#include <boost/ptr_container/ptr_map.hpp>
 #include "common/Finisher.h"
 #include "backend.h"
 #include "include/Context.h"
@@ -11,7 +12,7 @@
 class TestFileStoreBackend : public Backend {
   ObjectStore *os;
   Finisher finisher;
-  map<string, ObjectStore::Sequencer> osrs;
+  boost::ptr_map<string, ObjectStore::Sequencer> osrs;
   const bool write_infos;
 
 public:

--- a/src/test/objectstore/DeterministicOpSequence.cc
+++ b/src/test/objectstore/DeterministicOpSequence.cc
@@ -37,7 +37,7 @@ DeterministicOpSequence::DeterministicOpSequence(ObjectStore *store,
 						 std::string status)
   : TestObjectStoreState(store),
     txn(0),
-    m_osr("OSR")
+    m_osr(store->create_sequencer("OSR"))
 {
   txn_object = hobject_t(sobject_t("txn", CEPH_NOSNAP));
 

--- a/src/test/objectstore/DeterministicOpSequence.h
+++ b/src/test/objectstore/DeterministicOpSequence.h
@@ -52,7 +52,7 @@ class DeterministicOpSequence : public TestObjectStoreState {
   coll_t txn_coll;
   hobject_t txn_object;
 
-  ObjectStore::Sequencer m_osr;
+  ObjectStore::Sequencer *m_osr;
   std::ofstream m_status;
 
   bool run_one_op(int op, rngen_t& gen);

--- a/src/test/objectstore/TestObjectStoreState.cc
+++ b/src/test/objectstore/TestObjectStoreState.cc
@@ -67,7 +67,7 @@ void TestObjectStoreState::init(int colls, int objs)
     }
     baseid += objs;
 
-    m_store->queue_transaction(&(entry->m_osr), t,
+    m_store->queue_transaction(entry->m_osr, t,
         new C_OnFinished(this, t));
     inc_in_flight();
 
@@ -88,7 +88,8 @@ TestObjectStoreState::coll_entry_t *TestObjectStoreState::coll_create(int id)
   memset(meta_buf, 0, 100);
   snprintf(buf, 100, "0.%d_head", id);
   snprintf(meta_buf, 100, "pglog_0.%d_head", id);
-  return (new coll_entry_t(id, buf, meta_buf));
+  ObjectStore::Sequencer *osr = m_store->create_sequencer("test");
+  return (new coll_entry_t(id, buf, meta_buf, osr));
 }
 
 TestObjectStoreState::coll_entry_t*

--- a/src/test/objectstore/TestObjectStoreState.h
+++ b/src/test/objectstore/TestObjectStoreState.h
@@ -29,18 +29,9 @@ public:
     spg_t m_pgid;
     coll_t m_coll;
     ghobject_t m_meta_obj;
-    ObjectStore::Sequencer m_osr;
+    ObjectStore::Sequencer *m_osr;
     map<int, hobject_t*> m_objects;
     int m_next_object_id;
-
-    coll_entry_t(int i, char *coll_buf, char *meta_obj_buf)
-      : m_id(i),
-	m_pgid(pg_t(i, 1), shard_id_t::NO_SHARD),
-	m_coll(m_pgid),
-	m_meta_obj(hobject_t(sobject_t(object_t(meta_obj_buf), CEPH_NOSNAP))),
-      m_osr(coll_buf), m_next_object_id(0) {
-    }
-    ~coll_entry_t();
 
     hobject_t *touch_obj(int id);
     bool check_for_obj(int id);
@@ -54,6 +45,19 @@ public:
    private:
     hobject_t *get_obj(int id, bool remove);
     hobject_t *get_obj_at(int pos, bool remove, int *key = NULL);
+
+    coll_entry_t(int i, char *coll_buf, char *meta_obj_buf, ObjectStore::Sequencer *osr)
+      : m_id(i),
+	m_pgid(pg_t(i, 1), shard_id_t::NO_SHARD),
+	m_coll(m_pgid),
+	m_meta_obj(hobject_t(sobject_t(object_t(meta_obj_buf), CEPH_NOSNAP))),
+	m_osr(osr), m_next_object_id(0) {
+    }
+
+   public:
+    ~coll_entry_t();
+
+    friend class TestObjectStoreState;
   };
 
  protected:

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1172,12 +1172,12 @@ public:
 };
 
 TEST_P(StoreTest, Synthetic) {
-  ObjectStore::Sequencer osr("test");
+  ObjectStore::Sequencer *osr = store->create_sequencer("test");
   MixedGenerator gen;
   gen_type rng(time(NULL));
   coll_t cid(spg_t(pg_t(1,0), shard_id_t::NO_SHARD));
 
-  SyntheticWorkloadState test_obj(store.get(), &gen, &rng, &osr, cid);
+  SyntheticWorkloadState test_obj(store.get(), &gen, &rng, osr, cid);
   test_obj.init();
   for (int i = 0; i < 1000; ++i) {
     if (!(i % 10)) cerr << "seeding object " << i << std::endl;
@@ -1212,12 +1212,12 @@ TEST_P(StoreTest, Synthetic) {
 }
 
 TEST_P(StoreTest, AttrSynthetic) {
-  ObjectStore::Sequencer osr("test");
+  ObjectStore::Sequencer *osr = store->create_sequencer("test");
   MixedGenerator gen;
   gen_type rng(time(NULL));
   coll_t cid(spg_t(pg_t(4,0),shard_id_t::NO_SHARD));
 
-  SyntheticWorkloadState test_obj(store.get(), &gen, &rng, &osr, cid);
+  SyntheticWorkloadState test_obj(store.get(), &gen, &rng, osr, cid);
   test_obj.init();
   for (int i = 0; i < 500; ++i) {
     if (!(i % 10)) cerr << "seeding object " << i << std::endl;

--- a/src/test/objectstore/workload_generator.cc
+++ b/src/test/objectstore/workload_generator.cc
@@ -351,7 +351,7 @@ void WorkloadGenerator::do_destroy_collection(ObjectStore::Transaction *t,
 					      C_StatState *stat)
 {  
   m_nr_runs.set(0);
-  entry->m_osr.flush();
+  entry->m_osr->flush();
   vector<ghobject_t> ls;
   m_store->collection_list(entry->m_coll, ls);
   dout(2) << __func__ << " coll " << entry->m_coll
@@ -489,7 +489,7 @@ queue_tx:
       c = new C_StatWrapper(stat_state, tmp);
     }
 
-    m_store->queue_transaction(&(entry->m_osr), t, c);
+    m_store->queue_transaction(entry->m_osr, t, c);
 
     inc_in_flight();
 

--- a/src/test/xattr_bench.cc
+++ b/src/test/xattr_bench.cc
@@ -103,7 +103,8 @@ uint64_t do_run(ObjectStore *store, int attrsize, int numattrs,
 	      ghobject_t(hobject_t(sobject_t(obj_str.str(), CEPH_NOSNAP))));
       objects.insert(obj_str.str());
     }
-    collections[coll] = make_pair(objects, new ObjectStore::Sequencer(coll.to_str()));
+    ObjectStore::Sequencer *osr = store->create_sequencer(coll.to_str());
+    collections[coll] = make_pair(objects, osr);
   }
   store->apply_transaction(t);
 


### PR DESCRIPTION
This branch cleans up the use of Sequencer objects. They are now created by a virtual method on ObjectStore, instead of being "completed" by the implementation object after being first seen in queue_transactions. SharedPtrRegistry is modified to accomodate this mode of creation.

Additionally, there are some cleanups in FileStore::OpSequencer.