### PR TITLE
A client opening an image mid-resize can result in the object map being invalidated

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -103,6 +103,7 @@ noinst_HEADERS += \
 	include/rbd/features.h \
 	include/rbd/librbd.h \
 	include/rbd/librbd.hpp\
+	include/rbd/object_map_types.h \
 	include/util.h\
 	include/stat.h \
 	include/on_exit.h \

--- a/src/include/rbd/object_map_types.h
+++ b/src/include/rbd/object_map_types.h
@@ -1,0 +1,12 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef CEPH_RBD_OBJECT_MAP_TYPES_H
+#define CEPH_RBD_OBJECT_MAP_TYPES_H
+
+#include "include/int_types.h"
+
+static const uint8_t OBJECT_NONEXISTENT  = 0;
+static const uint8_t OBJECT_EXISTS       = 1;
+static const uint8_t OBJECT_PENDING      = 2;
+
+#endif // CEPH_RBD_OBJECT_MAP_TYPES_H

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -56,8 +56,13 @@ ImageWatcher::~ImageWatcher()
 }
 
 bool ImageWatcher::is_lock_supported() const {
-  assert(m_image_ctx.owner_lock.is_locked());
   RWLock::RLocker l(m_image_ctx.snap_lock);
+  return is_lock_supported(m_image_ctx.snap_lock);
+}
+
+bool ImageWatcher::is_lock_supported(const RWLock &) const {
+  assert(m_image_ctx.owner_lock.is_locked());
+  assert(m_image_ctx.snap_lock.is_locked());
   uint64_t snap_features;
   m_image_ctx.get_features(m_image_ctx.snap_id, &snap_features);
   return ((snap_features & RBD_FEATURE_EXCLUSIVE_LOCK) != 0 &&

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -31,6 +31,7 @@ namespace librbd {
     ~ImageWatcher();
 
     bool is_lock_supported() const;
+    bool is_lock_supported(const RWLock &snap_lock) const;
     bool is_lock_owner() const;
 
     int register_watch();

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -338,13 +338,25 @@ void ObjectMap::invalidate() {
   m_image_ctx.update_flags(m_image_ctx.snap_id, RBD_FLAG_OBJECT_MAP_INVALID,
                            true);
 
+  // do not update on-disk flags if not image owner
+  if (m_image_ctx.image_watcher->is_lock_supported(m_image_ctx.snap_lock) &&
+      !m_image_ctx.image_watcher->is_lock_owner()) {
+    return;
+  }
+
   librados::ObjectWriteOperation op;
+  if (m_image_ctx.snap_id == CEPH_NOSNAP) {
+    m_image_ctx.image_watcher->assert_header_locked(&op);
+  }
   cls_client::set_flags(&op, m_image_ctx.snap_id, m_image_ctx.flags,
                         RBD_FLAG_OBJECT_MAP_INVALID);
 
   int r = m_image_ctx.md_ctx.operate(m_image_ctx.header_oid, &op);
-  if (r < 0) {
-    lderr(cct) << "failed to invalidate object map: " << cpp_strerror(r)
+  if (r == -EBUSY) {
+    ldout(cct, 5) << "skipping on-disk object map invalidation: "
+                  << "image not locked by client" << dendl;
+  } else if (r < 0) {
+    lderr(cct) << "failed to invalidate on-disk object map: " << cpp_strerror(r)
 	       << dendl;
   }
 }
@@ -403,6 +415,7 @@ bool ObjectMap::Request::invalidate() {
   m_image_ctx.flags |= RBD_FLAG_OBJECT_MAP_INVALID;
 
   librados::ObjectWriteOperation op;
+  m_image_ctx.image_watcher->assert_header_locked(&op);
   cls_client::set_flags(&op, CEPH_NOSNAP, m_image_ctx.flags,
                         RBD_FLAG_OBJECT_MAP_INVALID);
 

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -5,6 +5,7 @@
 
 #include "include/int_types.h"
 #include "include/rados/librados.hpp"
+#include "include/rbd/object_map_types.h"
 #include "common/bit_vector.hpp"
 #include "librbd/AsyncRequest.h"
 #include <boost/optional.hpp>
@@ -12,10 +13,6 @@
 class Context;
 
 namespace librbd {
-
-static const uint8_t OBJECT_NONEXISTENT = 0;
-static const uint8_t OBJECT_EXISTS = 1;
-static const uint8_t OBJECT_PENDING = 2;
 
 class ImageCtx;
 

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -303,7 +303,8 @@ librbd_test_la_SOURCES = \
 	test/librbd/test_support.cc \
 	test/librbd/test_librbd.cc \
 	test/librbd/test_ImageWatcher.cc \
-	test/librbd/test_internal.cc
+	test/librbd/test_internal.cc \
+	test/librbd/test_ObjectMap.cc
 librbd_test_la_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 noinst_LTLIBRARIES += librbd_test.la
 

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -241,7 +241,7 @@ int TestMemIoCtxImpl::read(const std::string& oid, size_t len, uint64_t off,
     bit.substr_of(file->data, off, len);
     append_clone(bit, bl);
   }
-  return 0;
+  return len;
 }
 
 int TestMemIoCtxImpl::remove(const std::string& oid) {

--- a/src/test/librbd/test_ObjectMap.cc
+++ b/src/test/librbd/test_ObjectMap.cc
@@ -1,0 +1,124 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#include "test/librbd/test_fixture.h"
+#include "test/librbd/test_support.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageWatcher.h"
+#include "librbd/internal.h"
+#include "librbd/ObjectMap.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include <list>
+
+void register_test_object_map() {
+}
+
+class TestObjectMap : public TestFixture {
+public:
+};
+
+TEST_F(TestObjectMap, RefreshInvalidatesWhenCorrupt) {
+  REQUIRE_FEATURE(RBD_FEATURE_OBJECT_MAP);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ASSERT_FALSE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
+
+  {
+    RWLock::WLocker owner_locker(ictx->owner_lock);
+    ASSERT_EQ(0, ictx->image_watcher->try_lock());
+  }
+
+  std::string oid = librbd::ObjectMap::object_map_name(ictx->id, CEPH_NOSNAP);
+  bufferlist bl;
+  bl.append("corrupt");
+  ASSERT_EQ(0, ictx->data_ctx.write_full(oid, bl));
+
+  {
+    RWLock::RLocker owner_locker(ictx->owner_lock);
+    RWLock::WLocker snap_locker(ictx->snap_lock);
+    ictx->object_map.refresh(CEPH_NOSNAP);
+  }
+  ASSERT_TRUE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
+}
+
+TEST_F(TestObjectMap, RefreshInvalidatesWhenTooSmall) {
+  REQUIRE_FEATURE(RBD_FEATURE_OBJECT_MAP);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ASSERT_FALSE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
+
+  {
+    RWLock::WLocker owner_locker(ictx->owner_lock);
+    ASSERT_EQ(0, ictx->image_watcher->try_lock());
+  }
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::object_map_resize(&op, 0, OBJECT_NONEXISTENT);
+
+  std::string oid = librbd::ObjectMap::object_map_name(ictx->id, CEPH_NOSNAP);
+  ASSERT_EQ(0, ictx->data_ctx.operate(oid, &op));
+
+  {
+    RWLock::RLocker owner_locker(ictx->owner_lock);
+    RWLock::WLocker snap_locker(ictx->snap_lock);
+    ictx->object_map.refresh(CEPH_NOSNAP);
+  }
+  ASSERT_TRUE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
+}
+
+TEST_F(TestObjectMap, InvalidateFlagOnDisk) {
+  REQUIRE_FEATURE(RBD_FEATURE_OBJECT_MAP);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ASSERT_FALSE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
+
+  {
+    RWLock::WLocker owner_locker(ictx->owner_lock);
+    ASSERT_EQ(0, ictx->image_watcher->try_lock());
+  }
+
+  std::string oid = librbd::ObjectMap::object_map_name(ictx->id, CEPH_NOSNAP);
+  bufferlist bl;
+  bl.append("corrupt");
+  ASSERT_EQ(0, ictx->data_ctx.write_full(oid, bl));
+
+  {
+    RWLock::RLocker owner_locker(ictx->owner_lock);
+    RWLock::WLocker snap_locker(ictx->snap_lock);
+    ictx->object_map.refresh(CEPH_NOSNAP);
+  }
+  ASSERT_TRUE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
+
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ASSERT_TRUE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
+}
+
+TEST_F(TestObjectMap, InvalidateFlagInMemoryOnly) {
+  REQUIRE_FEATURE(RBD_FEATURE_OBJECT_MAP);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ASSERT_FALSE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
+
+  std::string oid = librbd::ObjectMap::object_map_name(ictx->id, CEPH_NOSNAP);
+  bufferlist valid_bl;
+  ASSERT_EQ(0, ictx->data_ctx.read(oid, valid_bl, 0, 0));
+
+  bufferlist corrupt_bl;
+  corrupt_bl.append("corrupt");
+  ASSERT_EQ(0, ictx->data_ctx.write_full(oid, corrupt_bl));
+
+  {
+    RWLock::RLocker owner_locker(ictx->owner_lock);
+    RWLock::WLocker snap_locker(ictx->snap_lock);
+    ictx->object_map.refresh(CEPH_NOSNAP);
+  }
+  ASSERT_TRUE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
+
+  ASSERT_EQ(0, ictx->data_ctx.write_full(oid, valid_bl));
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ASSERT_FALSE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
+}
+

--- a/src/test/librbd/test_ObjectMap.cc
+++ b/src/test/librbd/test_ObjectMap.cc
@@ -104,7 +104,7 @@ TEST_F(TestObjectMap, InvalidateFlagInMemoryOnly) {
 
   std::string oid = librbd::ObjectMap::object_map_name(ictx->id, CEPH_NOSNAP);
   bufferlist valid_bl;
-  ASSERT_EQ(0, ictx->data_ctx.read(oid, valid_bl, 0, 0));
+  ASSERT_LT(0, ictx->data_ctx.read(oid, valid_bl, 0, 0));
 
   bufferlist corrupt_bl;
   corrupt_bl.append("corrupt");

--- a/src/test/librbd/test_main.cc
+++ b/src/test/librbd/test_main.cc
@@ -11,6 +11,7 @@ extern void register_test_librbd();
 #ifdef TEST_LIBRBD_INTERNALS
 extern void register_test_image_watcher();
 extern void register_test_internal();
+extern void register_test_object_map();
 #endif // TEST_LIBRBD_INTERNALS
 
 int main(int argc, char **argv)
@@ -19,6 +20,7 @@ int main(int argc, char **argv)
 #ifdef TEST_LIBRBD_INTERNALS
   register_test_image_watcher();
   register_test_internal();
+  register_test_object_map();
 #endif // TEST_LIBRBD_INTERNALS
 
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
http://tracker.ceph.com/issues/12237