### PR TITLE
doc: Adding Hewlett-Packard copyright messages

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -1,3 +1,14 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -4,6 +4,7 @@
  * Ceph - scalable distributed file system
  *
  * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ * Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
We have a discussion going in the Calamari github repo about the right way to do this sort of thing going forward (see: https://github.com/ceph/calamari/issues/324). For now though, our open source powers-that-be request that I add an HP copyright to any file containing more than "bug fixes and minor enhancements". Let me know if you'd like me to handle this some other way.