### PR TITLE
qa/workunits: cephtool: take EOPNOTSUPP as an alias of ENOTSUP

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1632,13 +1632,13 @@ function test_mon_deprecated_commands()
 
   ceph tell mon.a injectargs '--mon-debug-deprecated-as-obsolete'
   expect_false ceph tell mon.a compact 2> $TMPFILE
-  check_response "ENOTSUP: command is obsolete"
+  check_response "\(EOPNOTSUPP\|ENOTSUP\): command is obsolete"
 
   expect_false ceph tell mon.a scrub 2> $TMPFILE
-  check_response "ENOTSUP: command is obsolete"
+  check_response "\(EOPNOTSUPP\|ENOTSUP\): command is obsolete"
 
   expect_false ceph tell mon.a sync force 2> $TMPFILE
-  check_response "ENOTSUP: command is obsolete"
+  check_response "\(EOPNOTSUPP\|ENOTSUP\): command is obsolete"
 
   ceph tell mon.a injectargs '--no-mon-debug-deprecated-as-obsolete'
 }


### PR DESCRIPTION
the proble breaks `test_mon_deprecated_commands` on ubuntu precise,
on the python shipped with ubuntu precise, errno.errorcode[95]
evalutes to `EOPNOTSUPP` but not `ENOTSUP`. but these two errnos
are equal in glibc.

Signed-off-by: Kefu Chai <kchai@redhat.com>