### PR TITLE
rgw: doc: Mark S3 object version API as supported

### DIFF
--- a/doc/radosgw/s3.rst
+++ b/doc/radosgw/s3.rst
@@ -50,7 +50,7 @@ The following table describes the support status for current Amazon S3 functiona
 +---------------------------------+-----------------+----------------------------------------+
 | **Bucket Notification**         | Not Supported   |                                        |
 +---------------------------------+-----------------+----------------------------------------+
-| **Bucket Object Versions**      | Not Supported   |                                        |
+| **Bucket Object Versions**      | Supported       |                                        |
 +---------------------------------+-----------------+----------------------------------------+
 | **Get Bucket Info (HEAD)**      | Supported       |                                        |
 +---------------------------------+-----------------+----------------------------------------+


### PR DESCRIPTION
S3 object version is already in since Hammer.
Ref: http://marc.info/?l=ceph-devel&m=143715290627682

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>