### PR TITLE
src/script/ceph-release-notes: add --text for plain text output

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -3,7 +3,10 @@
 # https://gist.github.com/aisrael/b2b78d9dfdd176a232b9
 """To run this script first install the dependencies
 
-$ pip install githubpy GitPython
+
+  virtualenv v
+  source v/bin/activate
+  pip install githubpy GitPython
 
 Generate a github access token; this is needed as the anonymous access
 to Github's API will easily hit the limit even with a single invocation.
@@ -15,7 +18,8 @@ Next either set the github token as an env variable
 `--token` switch.
 
 Example:
-ceph_release_notes -r tags/v0.87..giant /path/to/ceph/repo
+
+  ceph-release-notes -r tags/v0.87..origin/giant $(git rev-parse --show-toplevel)
 
 """
 
@@ -35,7 +39,7 @@ tracker_re = re.compile("http://tracker.ceph.com/issues/(\d+)")
 signed_off_re = re.compile("Signed-off-by: (.+) <")
 
 
-def make_release_notes(gh, repo, ref):
+def make_release_notes(gh, repo, ref, plaintext):
 
     issue2prs = {}
 
@@ -75,13 +79,19 @@ def make_release_notes(gh, repo, ref):
         if len(prs) > 1:
             print (">>>>>>> " + str(len(prs)) + " pr for issue " + issue)
         for (author, title, number) in prs:
-            print ("* {title} (`issue#{issue} <http://tracker.ceph.com/issues/{issue}>`_, `pr#{number} <http://github.com/ceph/ceph/pull/{number}>`_, {author})".format(title=title, issue=issue, author=author, number=number))
+            if plaintext:
+                print ("* {title} (#{issue}, {author})".format(title=title, issue=issue, author=author))
+            else:
+                print ("* {title} (`issue#{issue} <http://tracker.ceph.com/issues/{issue}>`_, `pr#{number} <http://github.com/ceph/ceph/pull/{number}>`_, {author})".format(title=title, issue=issue, author=author, number=number))
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--rev", "-r",
                         help="git revision range for creating release notes")
+    parser.add_argument("--text", "-t",
+                        action='store_true', default=None,
+                        help="output plain text only, no links")
     parser.add_argument("repo", metavar="repo",
                         help="path to ceph git repo")
     parser.add_argument("--token", default=os.getenv("GITHUB_ACCESS_TOKEN"),
@@ -91,4 +101,4 @@ if __name__ == "__main__":
     gh = github.GitHub(
         access_token=args.token)
 
-    make_release_notes(gh, Repo(args.repo), args.rev)
+    make_release_notes(gh, Repo(args.repo), args.rev, args.text)


### PR DESCRIPTION
This is a format that's easier to consume when sending a mail.

Signed-off-by: Loic Dachary <loic@dachary.org>