### PR TITLE
Fh ref count will leak if readahead does not need to do read from osd

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7054,11 +7054,14 @@ Client::C_Readahead::C_Readahead(Client *c, Fh *f) :
     f->get();
 }
 
+Client::C_Readahead::~C_Readahead() {
+  client->_put_fh(f);
+}
+
 void Client::C_Readahead::finish(int r) {
   lgeneric_subdout(client->cct, client, 20) << "client." << client->get_nodeid() << " " << "C_Readahead on " << f->inode << dendl;
   client->put_cap_ref(f->inode, CEPH_CAP_FILE_RD | CEPH_CAP_FILE_CACHE);
   f->readahead.dec_pending();
-  client->_put_fh(f);
 }
 
 int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl)

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -635,6 +635,7 @@ private:
     Client *client;
     Fh *f;
     C_Readahead(Client *c, Fh *f);
+    ~C_Readahead();
     void finish(int r);
   };
 


### PR DESCRIPTION
Fixes: #12088

Signed-off-by: Zhi Zhang zhangz.david@outlook.com