### PR TITLE
rgw: check subuser illegal access parameter.

### DIFF
--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-
+#define RGW_PERM_NONE            0x00
 #define RGW_PERM_READ            0x01
 #define RGW_PERM_WRITE           0x02
 #define RGW_PERM_READ_ACP        0x04
@@ -22,6 +22,7 @@ using namespace std;
 #define RGW_PERM_FULL_CONTROL    ( RGW_PERM_READ | RGW_PERM_WRITE | \
                                   RGW_PERM_READ_ACP | RGW_PERM_WRITE_ACP )
 #define RGW_PERM_ALL_S3          RGW_PERM_FULL_CONTROL
+#define RGW_PERM_INVALID         0xFF00
 
 enum ACLGranteeTypeEnum {
 /* numbers are encoded, should not change */

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -306,6 +306,7 @@ void RGWOp_Subuser_Create::execute()
   RESTArgs::get_bool(s, "generate-secret", false, &gen_secret);
 
   perm_mask = rgw_str_to_perm(perm_str.c_str());
+  op_state.set_perm(perm_mask);
 
   // FIXME: no double checking
   if (!uid.empty())
@@ -316,9 +317,6 @@ void RGWOp_Subuser_Create::execute()
 
   if (!secret_key.empty())
     op_state.set_secret_key(secret_key);
-
-  if (perm_mask != 0)
-    op_state.set_perm(perm_mask);
 
   op_state.set_generate_subuser(gen_subuser);
 
@@ -373,6 +371,7 @@ void RGWOp_Subuser_Modify::execute()
   RESTArgs::get_bool(s, "generate-secret", false, &gen_secret);
 
   perm_mask = rgw_str_to_perm(perm_str.c_str());
+  op_state.set_perm(perm_mask);
 
   // FIXME: no double checking
   if (!uid.empty())
@@ -386,9 +385,6 @@ void RGWOp_Subuser_Modify::execute()
 
   if (gen_secret)
     op_state.set_gen_secret();
-
-  if (perm_mask != 0)
-    op_state.set_perm(perm_mask);
 
   if (!key_type_str.empty()) {
     if (key_type_str.compare("swift") == 0)

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -534,7 +534,9 @@ void rgw_perm_to_str(uint32_t mask, char *buf, int len)
 
 uint32_t rgw_str_to_perm(const char *str)
 {
-  if (strcasecmp(str, "read") == 0)
+  if (strcasecmp(str, "") == 0)
+    return RGW_PERM_NONE;
+  else if (strcasecmp(str, "read") == 0)
     return RGW_PERM_READ;
   else if (strcasecmp(str, "write") == 0)
     return RGW_PERM_WRITE;
@@ -543,7 +545,7 @@ uint32_t rgw_str_to_perm(const char *str)
   else if (strcasecmp(str, "full") == 0)
     return RGW_PERM_FULL_CONTROL;
 
-  return 0; // better to return no permission
+  return RGW_PERM_INVALID;
 }
 
 static bool validate_access_key(string& key)
@@ -1228,6 +1230,11 @@ int RGWSubUserPool::check_op(RGWUserAdminOpState& op_state,
 
   if (subuser.empty() && !op_state.will_gen_subuser()) {
     set_err_msg(err_msg, "empty subuser name");
+    return -EINVAL;
+  }
+
+  if (op_state.get_subuser_perm() == RGW_PERM_INVALID) {
+    set_err_msg(err_msg, "invaild subuser access");
     return -EINVAL;
   }
 

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -440,7 +440,7 @@ struct RGWUserAdminOpState {
   {
     max_buckets = RGW_DEFAULT_MAX_BUCKETS;
     key_type = -1;
-    perm_mask = 0;
+    perm_mask = RGW_PERM_NONE;
     suspended = 0;
     system = 0;
     exclusive = 0;


### PR DESCRIPTION
Both empty arguments and illegal parameters, can modify the existing configuration to none permissions.

It should be modified to:
1.empty parameter modify the existing configuration to none permissions.
2.illegal parameter return an error.

test fix:
    before: subuser create or modify, illegal access parameter can modify the existing configuration.
    after changes, do the same procedure, can check for illegal access parameters.

Signed-off-by: guce <guce@h3c.com>