### PR TITLE
tests: robust test for the pool create crushmap test

### DIFF
--- a/src/test/mon/osd-crush.sh
+++ b/src/test/mon/osd-crush.sh
@@ -120,14 +120,14 @@ function TEST_crush_rule_create_erasure() {
     ./ceph osd crush rule rm $ruleset || return 1
     ! ./ceph osd crush rule ls | grep $ruleset || return 1
     #
-    # create a bugous ruleset and verify it cannot be used
-    # to create a pool.
+    # verify that if the crushmap contains a bugous ruleset,
+    # it will prevent the creation of a pool.
     #
-    ceph osd erasure-code-profile set myprofile plugin=lrc mapping=__DD__DD layers='[[ "_cDD_cDD", "" ],[ "cDDD____", "" ],[ "____cDDD", "" ],]' ruleset-steps='[ [ "choose", "datacenter", 3 ], [ "chooseleaf", "osd", 0] ]'
+    local crushtool_path_old=`ceph-conf --show-config-value crushtool`
+    ceph tell mon.* injectargs --crushtool "false"
+
     expect_failure $dir "Error EINVAL" \
-        ./ceph osd pool create mypool 1 1 erasure myprofile || return 1
-    ./ceph osd crush rule rm mypool || return 1
-    ./ceph osd erasure-code-profile rm myprofile || return 1
+        ./ceph osd pool create mypool 1 1 erasure || return 1
 }
 
 function check_ruleset_id_match_rule_id() {


### PR DESCRIPTION
The test that goes with f1e86be589803596e86acc964ac5c5c03b4038d8 to
verify that a bugous crush ruleset will prevent the creation of a pool
trying to use it was fragile. I depends on the implementation of the
erasure code lrc plugin and turns out to not work on i386.

The test is modified to use a fake crushtool that always returns false
and validate that it prevents the creation of a pool, which demonstrate
it is used for crushmap validation prior to the pool creation.

http://tracker.ceph.com/issues/12419 Fixes: #12419

Signed-off-by: Loic Dachary <ldachary@redhat.com>