### PR TITLE
mon: remove osd_epoch to avoid out-dated osdmap_cache

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4178,6 +4178,10 @@ void Monitor::handle_subscribe(MonOpRequestRef op)
       }
     } else if (p->first == "osdmap") {
       if ((int)s->is_capable("osd", MON_CAP_R)) {
+	if (s->osd_epoch > p->second.start) {
+	  // client needs earlier osdmaps on purpose, so reset the sent epoch
+	  s->osd_epoch = 0;
+	}
         osdmon()->check_sub(s->sub_map["osdmap"]);
       }
     } else if (p->first == "osd_pg_creates") {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -269,9 +269,6 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
 
   for (int o = 0; o < osdmap.get_max_osd(); o++) {
     if (osdmap.is_down(o)) {
-      // invalidate osd_epoch cache
-      osd_epoch.erase(o);
-
       // populate down -> out map
       if (osdmap.is_in(o) &&
 	  down_pending_out.count(o) == 0) {
@@ -280,11 +277,7 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
       }
     }
   }
-  // blow away any osd_epoch items beyond max_osd
-  map<int,epoch_t>::iterator p = osd_epoch.upper_bound(osdmap.get_max_osd());
-  while (p != osd_epoch.end()) {
-    osd_epoch.erase(p++);
-  }
+  // XXX: need to trim MonSession connected with a osd whose id > max_osd?
 
   /** we don't have any of the feature bit infrastructure in place for
    * supporting primary_temp mappings without breaking old clients/OSDs.*/
@@ -2350,19 +2343,17 @@ void OSDMonitor::send_incremental(MonOpRequestRef op, epoch_t first)
 	  << " to " << op->get_req()->get_orig_source_inst()
 	  << dendl;
 
-  int osd = -1;
+  MonSession *s = NULL;
   if (op->get_req()->get_source().is_osd()) {
-    osd = op->get_req()->get_source().num();
-    map<int,epoch_t>::iterator p = osd_epoch.find(osd);
-    if (p != osd_epoch.end()) {
-      if (first <= p->second) {
-	dout(10) << __func__ << " osd." << osd << " should already have epoch "
-		 << p->second << dendl;
-	first = p->second + 1;
-	if (first > osdmap.get_epoch())
-	  return;
-      }
-    }
+    s = op->get_session();
+  }
+
+  if (s && first <= s->osd_epoch) {
+    dout(10) << __func__ << s->inst << " should already have epoch "
+	     << s->osd_epoch << dendl;
+    first = s->osd_epoch + 1;
+    if (first > osdmap.get_epoch())
+      return;
   }
 
   if (first < get_first_committed()) {
@@ -2381,8 +2372,8 @@ void OSDMonitor::send_incremental(MonOpRequestRef op, epoch_t first)
     m->maps[first] = bl;
     mon->send_reply(op, m);
 
-    if (osd >= 0)
-      note_osd_has_epoch(osd, osdmap.get_epoch());
+    if (s)
+      s->osd_epoch = osdmap.get_epoch();
     return;
   }
 
@@ -2394,28 +2385,8 @@ void OSDMonitor::send_incremental(MonOpRequestRef op, epoch_t first)
   m->newest_map = osdmap.get_epoch();
   mon->send_reply(op, m);
 
-  if (osd >= 0)
-    note_osd_has_epoch(osd, last);
-}
-
-// FIXME: we assume the OSD actually receives this.  if the mon
-// session drops and they reconnect we may not share the same maps
-// with them again, which could cause a strange hang (perhaps stuck
-// 'waiting for osdmap' requests?).  this information should go in the
-// MonSession, but I think these functions need to be refactored in
-// terms of MonSession first for that to work.
-void OSDMonitor::note_osd_has_epoch(int osd, epoch_t epoch)
-{
-  dout(20) << __func__ << " osd." << osd << " epoch " << epoch << dendl;
-  map<int,epoch_t>::iterator p = osd_epoch.find(osd);
-  if (p != osd_epoch.end()) {
-    dout(20) << __func__ << " osd." << osd << " epoch " << epoch
-	     << " (was " << p->second << ")" << dendl;
-    p->second = epoch;
-  } else {
-    dout(20) << __func__ << " osd." << osd << " epoch " << epoch << dendl;
-    osd_epoch[osd] = epoch;
-  }
+  if (s)
+    s->osd_epoch = last;
 }
 
 void OSDMonitor::send_incremental(epoch_t first, MonSession *session,
@@ -2439,6 +2410,9 @@ void OSDMonitor::send_incremental(epoch_t first, MonSession *session,
     m->newest_map = osdmap.get_epoch();
     m->maps[first] = bl;
     session->con->send_message(m);
+    if (session->inst.name.is_osd()) {
+      session->osd_epoch = first;
+    }
     first++;
   }
 
@@ -2448,8 +2422,9 @@ void OSDMonitor::send_incremental(epoch_t first, MonSession *session,
     session->con->send_message(m);
     first = last + 1;
 
-    if (session->inst.name.is_osd())
-      note_osd_has_epoch(session->inst.name.num(), last);
+    if (session->inst.name.is_osd()) {
+      session->osd_epoch = last;
+    }
 
     if (onetime)
       break;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2329,68 +2329,29 @@ void OSDMonitor::send_full(MonOpRequestRef op)
   mon->send_reply(op, build_latest_full());
 }
 
-/* TBH, I'm fairly certain these two functions could somehow be using a single
- * helper function to do the heavy lifting. As this is not our main focus right
- * now, I'm leaving it to the next near-future iteration over the services'
- * code. We should not forget it though.
- *
- * TODO: create a helper function and get rid of the duplicated code.
- */
 void OSDMonitor::send_incremental(MonOpRequestRef op, epoch_t first)
 {
   op->mark_osdmon_event(__func__);
-  dout(5) << "send_incremental [" << first << ".." << osdmap.get_epoch() << "]"
-	  << " to " << op->get_req()->get_orig_source_inst()
-	  << dendl;
 
   MonSession *s = op->get_session();
   assert(s);
-
-  if (first <= s->osd_epoch) {
-    dout(10) << __func__ << s->inst << " should already have epoch "
-	     << s->osd_epoch << dendl;
-    first = s->osd_epoch + 1;
-    if (first > osdmap.get_epoch())
-      return;
-  }
-
-  if (first < get_first_committed()) {
-    first = get_first_committed();
-    bufferlist bl;
-    int err = get_version_full(first, bl);
-    assert(err == 0);
-    assert(bl.length());
-
-    dout(20) << "send_incremental starting with base full "
-	     << first << " " << bl.length() << " bytes" << dendl;
-
-    MOSDMap *m = new MOSDMap(osdmap.get_fsid());
-    m->oldest_map = first;
-    m->newest_map = osdmap.get_epoch();
-    m->maps[first] = bl;
-    mon->send_reply(op, m);
-
-    s->osd_epoch = osdmap.get_epoch();
-    return;
-  }
-
-  // send some maps.  it may not be all of them, but it will get them
-  // started.
-  epoch_t last = MIN(first + g_conf->osd_map_message_max, osdmap.get_epoch());
-  MOSDMap *m = build_incremental(first, last);
-  m->oldest_map = get_first_committed();
-  m->newest_map = osdmap.get_epoch();
-  mon->send_reply(op, m);
-
-  s->osd_epoch = last;
+  send_incremental(first, s, false, op);
 }
 
-void OSDMonitor::send_incremental(epoch_t first, MonSession *session,
-				  bool onetime)
+void OSDMonitor::send_incremental(epoch_t first,
+				  MonSession *session,
+				  bool onetime,
+				  MonOpRequestRef req)
 {
   dout(5) << "send_incremental [" << first << ".." << osdmap.get_epoch() << "]"
 	  << " to " << session->inst << dendl;
 
+  if (first <= session->osd_epoch) {
+    dout(10) << __func__ << session->inst << " should already have epoch "
+	     << session->osd_epoch << dendl;
+    first = session->osd_epoch + 1;
+  }
+
   if (first < get_first_committed()) {
     first = get_first_committed();
     bufferlist bl;
@@ -2405,24 +2366,37 @@ void OSDMonitor::send_incremental(epoch_t first, MonSession *session,
     m->oldest_map = first;
     m->newest_map = osdmap.get_epoch();
     m->maps[first] = bl;
-    session->con->send_message(m);
-    session->osd_epoch = first;
+
+    if (req) {
+      mon->send_reply(req, m);
+      session->osd_epoch = first;
+      return;
+    } else {
+      session->con->send_message(m);
+      session->osd_epoch = first;
+    }
     first++;
   }
 
   while (first <= osdmap.get_epoch()) {
     epoch_t last = MIN(first + g_conf->osd_map_message_max, osdmap.get_epoch());
     MOSDMap *m = build_incremental(first, last);
-    session->con->send_message(m);
-    first = last + 1;
-    session->osd_epoch = last;
 
-    if (onetime)
+    if (req) {
+      // send some maps.  it may not be all of them, but it will get them
+      // started.
+      m->oldest_map = get_first_committed();
+      m->newest_map = osdmap.get_epoch();
+      mon->send_reply(req, m);
+    } else {
+      session->con->send_message(m);
+      first = last + 1;
+    }
+    session->osd_epoch = last;
+    if (onetime || req)
       break;
   }
 }
-
-
 
 
 epoch_t OSDMonitor::blacklist(const entity_addr_t& a, utime_t until)

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2343,12 +2343,10 @@ void OSDMonitor::send_incremental(MonOpRequestRef op, epoch_t first)
 	  << " to " << op->get_req()->get_orig_source_inst()
 	  << dendl;
 
-  MonSession *s = NULL;
-  if (op->get_req()->get_source().is_osd()) {
-    s = op->get_session();
-  }
+  MonSession *s = op->get_session();
+  assert(s);
 
-  if (s && first <= s->osd_epoch) {
+  if (first <= s->osd_epoch) {
     dout(10) << __func__ << s->inst << " should already have epoch "
 	     << s->osd_epoch << dendl;
     first = s->osd_epoch + 1;
@@ -2372,8 +2370,7 @@ void OSDMonitor::send_incremental(MonOpRequestRef op, epoch_t first)
     m->maps[first] = bl;
     mon->send_reply(op, m);
 
-    if (s)
-      s->osd_epoch = osdmap.get_epoch();
+    s->osd_epoch = osdmap.get_epoch();
     return;
   }
 
@@ -2385,8 +2382,7 @@ void OSDMonitor::send_incremental(MonOpRequestRef op, epoch_t first)
   m->newest_map = osdmap.get_epoch();
   mon->send_reply(op, m);
 
-  if (s)
-    s->osd_epoch = last;
+  s->osd_epoch = last;
 }
 
 void OSDMonitor::send_incremental(epoch_t first, MonSession *session,
@@ -2410,9 +2406,7 @@ void OSDMonitor::send_incremental(epoch_t first, MonSession *session,
     m->newest_map = osdmap.get_epoch();
     m->maps[first] = bl;
     session->con->send_message(m);
-    if (session->inst.name.is_osd()) {
-      session->osd_epoch = first;
-    }
+    session->osd_epoch = first;
     first++;
   }
 
@@ -2421,10 +2415,7 @@ void OSDMonitor::send_incremental(epoch_t first, MonSession *session,
     MOSDMap *m = build_incremental(first, last);
     session->con->send_message(m);
     first = last + 1;
-
-    if (session->inst.name.is_osd()) {
-      session->osd_epoch = last;
-    }
+    session->osd_epoch = last;
 
     if (onetime)
       break;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -136,14 +136,6 @@ private:
 
   map<int,double> osd_weight;
 
-  /*
-   * cache what epochs we think osds have.  this is purely
-   * optimization to try to avoid sending the same inc maps twice.
-   */
-  map<int,epoch_t> osd_epoch;
-
-  void note_osd_has_epoch(int osd, epoch_t epoch);
-
   void check_failures(utime_t now);
   bool check_failure(utime_t now, int target_osd, failure_info_t& fi);
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -218,7 +218,10 @@ private:
   MOSDMap *build_incremental(epoch_t first, epoch_t last);
   void send_full(MonOpRequestRef op);
   void send_incremental(MonOpRequestRef op, epoch_t first);
-  void send_incremental(epoch_t first, MonSession *session, bool onetime);
+  // @param req an optional op request, if the osdmaps are replies to it. so
+  //            @c Monitor::send_reply() can mark_event with it.
+  void send_incremental(epoch_t first, MonSession *session, bool onetime,
+			MonOpRequestRef req = MonOpRequestRef());
 
   int reweight_by_utilization(int oload, std::string& out_str, bool by_pg,
 			      const set<int64_t> *pools);

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -50,6 +50,7 @@ struct MonSession : public RefCountedObject {
   uint64_t global_id;
 
   map<string, Subscription*> sub_map;
+  epoch_t osd_epoch;		// the osdmap epoch sent to the mon client
 
   AuthServiceHandler *auth_handler;
   EntityName entity_name;
@@ -60,7 +61,9 @@ struct MonSession : public RefCountedObject {
   MonSession(const entity_inst_t& i, Connection *c) :
     con(c), inst(i), closed(false), item(this),
     auid(0),
-    global_id(0), auth_handler(NULL),
+    global_id(0),
+    osd_epoch(0),
+    auth_handler(NULL),
     proxy_con(NULL), proxy_tid(0) {
     time_established = ceph_clock_now(g_ceph_context);
   }


### PR DESCRIPTION
* replace the `OSDMonitor::osd_epoch` with the `MonSession::osd_epoch`
* apply this optimisation to all MonClients
* remove the duplicated code of the two `OSDMonitor::send_incremental()`

due to the refactory, one of the `OSDMonitor::send_incremental()` is not able to mark op events anymore.

FIxes: #10930 http://tracker.ceph.com/issues/10930