### PR TITLE
mmds/MDLog: No make sense set offset for LogEvent in _start_entry.

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -235,7 +235,6 @@ void MDLog::_start_entry(LogEvent *e)
 
   assert(cur_event == NULL);
   cur_event = e;
-  e->set_start_off(get_write_pos());
 
   event_seq++;
 


### PR DESCRIPTION
For offset of LogEvent only determine in submit_thread. So in
_start_entry it's no make sense set.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>