### PR TITLE
mon: fix checks on mds add_data_pool

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1680,22 +1680,14 @@ int MDSMonitor::filesystem_command(
 	return -ENOENT;
       }
     }
-    const pg_pool_t *p = mon->osdmon()->osdmap.get_pg_pool(poolid);
-    if (!p) {
-      ss << "pool '" << poolname << "' does not exist";
-      return -ENOENT;
+
+    r = _check_pool(poolid, &ss);
+    if (r != 0) {
+      return r;
     }
-    if (p->is_erasure()) {
-      // I'm sorry Dave, I'm afraid I can't do that
-      poolid = -1;
-      ss << "can't use pool '" << poolname << "' as it's an erasure-code pool";
-      return -EINVAL;
-    }
-    if (poolid >= 0) {
-      pending_mdsmap.add_data_pool(poolid);
-      ss << "added data pool " << poolid << " to mdsmap";
-      r = 0;
-    }
+
+    pending_mdsmap.add_data_pool(poolid);
+    ss << "added data pool " << poolid << " to mdsmap";
   } else if (prefix == "mds remove_data_pool") {
     string poolname;
     cmd_getval(g_ceph_context, cmdmap, "pool", poolname);


### PR DESCRIPTION
Use same _check_pool helper as during fs creation.

Fixes: #12426

Signed-off-by: John Spray <john.spray@redhat.com>