### PR TITLE
rgw: fix radosgw start-up script.

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -102,7 +102,7 @@ case "$1" in
 	    if [ $DEBIAN -eq 1 ]; then
 		start-stop-daemon --start -u $user -x $RADOSGW -- -n $name
 	    elif [ -n "$SYSTEMD_RUN" ]; then
-                $SYSTEMD_RUN -r sudo -u "$user" bash -c "ulimit -n 32768; $RADOSGW -n $name"
+                $SYSTEMD_RUN -r su "$user" -c "ulimit -n 32768; $RADOSGW -n $name"
             else
 		ulimit -n 32768
                 daemon --user="$user" "$RADOSGW -n $name"


### PR DESCRIPTION
radosgw init script is unable to start radosgw daemon.
as it is relies on requiretty being disabled.
once init script start this daemon with sudo it fails
to start the daemon.

Removing 'sudo' fixes the issue as there is no need
calling sudo since radosgw runs as root.

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>