### PR TITLE
ReplicatedPG::finish_promote: do not prefill new_clones

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -6628,7 +6628,7 @@ void ReplicatedPG::finish_promote(int r, CopyResults *results,
     OpContext *tctx = repop->ctx;
     tctx->at_version = get_next_version();
     filter_snapc(tctx->new_snapset.snaps);
-    vector<snapid_t> new_clones(tctx->new_snapset.clones.size());
+    vector<snapid_t> new_clones;
     for (vector<snapid_t>::iterator i = tctx->new_snapset.clones.begin();
 	 i != tctx->new_snapset.clones.end();
 	 ++i) {


### PR DESCRIPTION
new_clones will end up smaller than clones.  The removed clone
will leave a 0 at the end.

Fixes: 12263
Backport: firefly, hammer
Signed-off-by: Samuel Just <sjust@redhat.com>