### PR TITLE
test/librados/tier.cc: we can exceed the hitset limit while backfilling

### DIFF
--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -2216,7 +2216,6 @@ TEST_F(LibRadosTwoPoolsPP, HitSetTrim) {
     c->wait_for_complete();
     c->release();
 
-    ASSERT_TRUE(ls.size() <= count + 1);
     cout << " got ls " << ls << std::endl;
     if (!ls.empty()) {
       if (!first) {
@@ -4264,7 +4263,6 @@ TEST_F(LibRadosTwoPoolsECPP, HitSetTrim) {
     c->wait_for_complete();
     c->release();
 
-    ASSERT_TRUE(ls.size() <= count + 1);
     cout << " got ls " << ls << std::endl;
     if (!ls.empty()) {
       if (!first) {


### PR DESCRIPTION
We leave the time limit as the actual test, but we are allowed to
temperarily exceed the number of hitsets during backfilling.

Fixes: 8193
Related: d0f1806d57646ec24e844af368c46285ab9a59f8
Signed-off-by: Samuel Just <sjust@redhat.com>