### PR TITLE
osd, msg: Keep a reference count on Connection while calling send_mes…

### DIFF
--- a/src/msg/simple/PipeConnection.h
+++ b/src/msg/simple/PipeConnection.h
@@ -22,7 +22,6 @@ class Pipe;
 class PipeConnection : public Connection {
   Pipe* pipe;
 
-  friend class boost::intrusive_ptr<PipeConnection>;
   friend class Pipe;
 
 public:

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -696,8 +696,8 @@ void OSDService::send_message_osd_cluster(int peer, Message *m, epoch_t from_epo
     return;
   }
   const entity_inst_t& peer_inst = next_map->get_cluster_inst(peer);
-  Connection *peer_con = osd->cluster_messenger->get_connection(peer_inst).get();
-  share_map_peer(peer, peer_con, next_map);
+  ConnectionRef peer_con = osd->cluster_messenger->get_connection(peer_inst).get();
+  share_map_peer(peer, peer_con.get(), next_map);
   peer_con->send_message(m);
   release_map(next_map);
 }


### PR DESCRIPTION
…sage()

Also, remove unnecessary friend in PipeConnection class

Fixes: #12437

Signed-off-by: David Zafman <dzafman@redhat.com>