### PR TITLE
mds: fix val used in inode->last_journaled

### DIFF
--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -2932,7 +2932,8 @@ int Migrator::decode_import_dir(bufferlist::iterator& blp,
     else if (icode == 'I') {
       // inode
       assert(le);
-      decode_import_inode(dn, blp, oldauth, ls, le->get_start_off(), peer_exports, updated_scatterlocks);
+      decode_import_inode(dn, blp, oldauth, ls, le->get_metablob()->event_seq,
+          peer_exports, updated_scatterlocks);
     }
     
     // add dentry to journal entry


### PR DESCRIPTION
This was getting assigned with LogEvent::get_start_offset
on an uncommitted LogEvent, which is junk.  During replay
last_journaled is compared with the metablob's event_seq,
so that's what should be used here.

This change just from code inspection -- haven't seen this
manifest as an actual misbehaviour.

Signed-off-by: John Spray <john.spray@redhat.com>