### PR TITLE
Thread.cc: remove malloc/free pair

### DIFF
--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -110,11 +110,11 @@ int Thread::kill(int signal)
 int Thread::try_create(size_t stacksize)
 {
   pthread_attr_t *thread_attr = NULL;
+  pthread_attr_t thread_attr_loc;
+  
   stacksize &= CEPH_PAGE_MASK;  // must be multiple of page
   if (stacksize) {
-    thread_attr = (pthread_attr_t*) malloc(sizeof(pthread_attr_t));
-    if (!thread_attr)
-      return -ENOMEM;
+    thread_attr = &thread_attr_loc;
     pthread_attr_init(thread_attr);
     pthread_attr_setstacksize(thread_attr, stacksize);
   }
@@ -136,8 +136,6 @@ int Thread::try_create(size_t stacksize)
   r = pthread_create(&thread_id, thread_attr, _entry_func, (void*)this);
   restore_sigset(&old_sigset);
 
-  if (thread_attr)
-    free(thread_attr);
   return r;
 }
 


### PR DESCRIPTION
There's no need for mallocing pthread_attr_t in Thread::try_create(),
it can be located on stack as it is freed in same function. This reduces
pressure put on memory manager.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>