### PR TITLE
rbd:dest image name can not include snap name

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -3404,6 +3404,12 @@ if (!set_conf_param(v, p1, p2, p3)) { \
 
   set_pool_image_name(destname, (char **)&dest_poolname,
 		      (char **)&destname, (char **)&dest_snapname);
+			  
+  if (dest_snapname) {
+    cerr << "rbd: dest snapname specified for a command that doesn't use it"
+	     << std::endl;
+    return EXIT_FAILURE;
+  }
 
   if (opt_cmd == OPT_IMPORT) {
     if (poolname && dest_poolname) {
@@ -3444,11 +3450,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
   if ((opt_cmd == OPT_COPY || opt_cmd == OPT_CLONE || opt_cmd == OPT_RENAME) &&
       !destname ) {
     cerr << "rbd: destination image name was not specified" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  if ((opt_cmd == OPT_CLONE) && dest_snapname) {
-    cerr << "rbd: cannot clone to a snapshot" << std::endl;
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Check the dest image name, If it includes snap name, refuse to execute and give a message

In rbd.cc, main will check the dest_snapname , If it is not null, give a message and return EXIT_FAILURE

test fix:
    rbd cp foo foo1@1
   before：
   it will create a rbd block named foo1, @1 will be ignored
  after changes：
    The block can not be copied, will give a message "rbd: dest snapname specified for a command that doesn't use it"  

Signed-off-by:cesc2011<zhengbin.08747@h3c.com>