### PR TITLE
test/perf_local: disable tests on unsupported archs

### DIFF
--- a/src/test/perf_local.cc
+++ b/src/test/perf_local.cc
@@ -381,6 +381,7 @@ double cond_ping_pong()
 // probably pick worse values.
 double div32()
 {
+#if defined(__i386__) || defined(__x86_64__)
   int count = 1000000;
   uint64_t start = Cycles::rdtsc();
   // NB: Expect an x86 processor exception is there's overflow.
@@ -397,6 +398,9 @@ double div32()
   }
   uint64_t stop = Cycles::rdtsc();
   return Cycles::to_seconds(stop - start)/count;
+#else
+  return -1;
+#endif
 }
 
 // Measure the cost of a 64-bit divide. Divides don't take a constant
@@ -659,6 +663,7 @@ double perf_prefetch()
 #endif
 }
 
+#if defined(__i386__) || defined(__x86_64__)
 /**
  * This function is used to seralize machine instructions so that no
  * instructions that appear after it in the current thread can run before any
@@ -674,9 +679,11 @@ static inline void serialize() {
         : "=a" (eax), "=b" (ebx), "=c" (ecx), "=d" (edx)
         : "a" (1U));
 }
+#endif
 
 // Measure the cost of cpuid
 double perf_serialize() {
+#if defined(__i386__) || defined(__x86_64__)
   int count = 1000000;
   uint64_t start = Cycles::rdtsc();
   for (int i = 0; i < count; i++) {
@@ -684,6 +691,9 @@ double perf_serialize() {
   }
   uint64_t stop = Cycles::rdtsc();
   return Cycles::to_seconds(stop - start)/count;
+#else
+  return -1;
+#endif
 }
 
 // Measure the cost of an lfence instruction.


### PR DESCRIPTION
* disable cpuid test on unsupported archs (ARM has cpuid register though, but i am not sure if reading it would serve the same purpose of the serialize benchmark)
* disable div32, we could use udiv on ARM, but it does not allow 64bit denominator

Reported-by: Tom Deneau <tom.deneau@amd.com>
Signed-off-by: Kefu Chai <kchai@redhat.com>