### PR TITLE
rbd:rbd block size should not be zero

### DIFF
--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -162,8 +162,8 @@ uint64_t strict_sistrtoll(const char *str, std::string *err)
 
   long long r_ll = strict_strtoll(v, 10, err);
 
-  if (r_ll < 0) {
-    *err = "strict_sistrtoll: value should not be negative";
+  if (r_ll <= 0) {
+    *err = "strict_sistrtoll: value should be positive";
     return 0;
   }
 


### PR DESCRIPTION
Check the rbd block size, If it is zero, refuse to execute and give a message

In strtol.cc, strict_sistrtoll will check the r_ll, if (r_ll <= 0),give a message and return 0

test fix:
rbd create foo --size 0
before：
it will create a rbd block named foo, whose size is zero
after changes：
The block can not be created, will give a message 

PS:
About this, I had sent mails to dmick, his reply is that "Why not zero?If the answer is it can't be used, then, what arbitrary minuim size is too small?(also, given that resize exists, it can be used for storage after a resize.)"

Last night I think about it, I still insist on my opinion.I once was confused about why do ceph permit to create a rbd block whose size is zero, After dmick's explain, I understand it. But other people will be confused about it too.Create a rbd block whose size is zero does not make any sense, why do we permit it?We permit the size is 1byte,2byte,100byte,1KB...(Those size is too small, we can not use it),the reason is that we can not define the accurate minuim size. It seems like 'size=0' is ok, According to this logic，we can permit negative size,you just can not use it.

When I do one thing, I want to do the best. Hope my option will be accepted, thank you.

Signed-off-by:s09816 shi.lu@h3c.com