### PR TITLE
rbd:snap purge image will remove all the unprotected snaps

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -761,12 +761,30 @@ static int do_purge_snaps(librbd::Image& image)
 {
   MyProgressContext pc("Removing all snapshots");
   std::vector<librbd::snap_info_t> snaps;
+  bool is_protected = false;
   int r = image.snap_list(snaps);
   if (r < 0) {
     pc.fail();
     return r;
   }
-
+   
+  if (0 == snaps.size())
+  {
+	return 0;
+  }
+  for (size_t i = 0; i < snaps.size(); ++i) {
+	r = image.snap_is_protected(snaps[i].name.c_str(), &is_protected);
+	 if (r < 0) {
+		pc.fail();
+		return r;
+	 }
+	 if (is_protected == true)
+	  {
+		pc.fail();
+		cerr << "\r" <<snaps[i].name.c_str()<< " is a protected snap."<< std::endl;
+		return -EBUSY;	
+	  }
+  }
   for (size_t i = 0; i < snaps.size(); ++i) {
     r = image.snap_remove(snaps[i].name.c_str());
     if (r < 0) {


### PR DESCRIPTION
1、Check whether the image has snap or not,if not,do not show any information instead of "Removing all snapshots: 100% complete...done. "
In rbd.cc,function do_purge_snaps
test fix:
An image doesn't have any snap, execute 'rbd snap purge image'
before:
Removing all snapshots: 100% complete...done. 
after:
Without any hints


2、"rbd snap purge image" will remove all the unprotected snaps of the image.
In rbd.cc,function do_purge_snaps
test fix:
An image has 3 snaps(such as a、b、c),and b is a protected snap,then execute 'rbd snap purge image’
before：
Removing all snapshots: 33% complete...failed. and image still have b、c snap.
after：
Removing all snapshots: 66% complete...failed. and image only have b snap.

Signed-off-by: mingyuez <zhao.mingyue@h3c.com>