### PR TITLE
log: fix fd locking during reopen_log_file

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -120,6 +120,7 @@ void Log::set_log_file(string fn)
 
 void Log::reopen_log_file()
 {
+  pthread_mutex_lock(&m_flush_mutex);
   if (m_fd >= 0)
     VOID_TEMP_FAILURE_RETRY(::close(m_fd));
   if (m_log_file.length()) {
@@ -127,6 +128,7 @@ void Log::reopen_log_file()
   } else {
     m_fd = -1;
   }
+  pthread_mutex_unlock(&m_flush_mutex);
 }
 
 void Log::set_syslog_level(int log, int crash)


### PR DESCRIPTION
We need to ensure there are no users of m_fd while we reopen the file.
Otherwise, a racing thread may open a new file with the same fd and log
data may get erroneously written to that fd instead.  This can cause data
corruption if that fd happens to be a user objects and writeable.

Fixes: #11586
Backport: hammer, giant, firefly
Signed-off-by: Sage Weil <sage@redhat.com>