### PR TITLE
fix radosgw-admin mdlog list blank lines

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -126,8 +126,6 @@ void JSONFormatter::flush(std::ostream& os)
 {
   finish_pending_string();
   os << m_ss.str();
-  if (m_pretty)
-    os << "\n";
   m_ss.clear();
   m_ss.str("");
 }
@@ -238,6 +236,8 @@ void JSONFormatter::close_section()
   }
   m_ss << (entry.is_array ? ']' : '}');
   m_stack.pop_back();
+  if (m_pretty && m_stack.empty())
+    m_ss << "\n";
 }
 
 void JSONFormatter::finish_pending_string()

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -686,11 +686,13 @@ TEST(CrushWrapper, dump_rules) {
   // no ruleset by default
   {
     Formatter *f = Formatter::create("json-pretty");
+    f->open_array_section("rules");
     c->dump_rules(f);
+    f->close_section();
     stringstream ss;
     f->flush(ss);
     delete f;
-    EXPECT_EQ("\n", ss.str());
+    EXPECT_EQ("[]\n", ss.str());
   }
 
   string name("NAME");


### PR DESCRIPTION
When executed the gateway command : radosgw-admin mdlog list ,these are some useless blank lines  (default is 64 lines) in the output message.this is marked when no meta log in the gateway.

Signed-off-by: Aran85 <zhangzengran@h3c.com> 