### PR TITLE
rbd: cli help and arg parsing fixes

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -448,10 +448,6 @@ Examples
 
 To create a new rbd image that is 100 GB::
 
-       rbd -p mypool create myimage --size 102400
-
-or alternatively::
-
        rbd create mypool/myimage --size 102400
 
 To use a non-default object size (8 MB)::
@@ -489,13 +485,13 @@ To unmap an image::
 To create an image and a clone from it::
 
        rbd import --image-format 2 image mypool/parent
-       rbd snap create --snap snapname mypool/parent
+       rbd snap create mypool/parent@snap
        rbd snap protect mypool/parent@snap
        rbd clone mypool/parent@snap otherpool/child
 
 To create an image with a smaller stripe_unit (to better distribute small writes in some workloads)::
 
-       rbd -p mypool create myimage --size 102400 --stripe-unit 65536 --stripe-count 16
+       rbd create mypool/myimage --size 102400 --stripe-unit 65536 --stripe-count 16
 
 To change an image from one image format to another, export it and then
 import it as the desired image format::

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -144,7 +144,7 @@ Parameters
    This will disable features that are dependent upon exclusive ownership
    of the image.
 
-.. option:: --object-extents
+.. option:: --whole-object
 
    Specifies that the diff should be limited to the extents of a full object
    instead of showing intra-object deltas. When the object map feature is
@@ -223,7 +223,7 @@ Commands
   The --stripe-unit and --stripe-count arguments are optional, but must be
   used together.
 
-:command:`export-diff` [--from-snap *snap-name*] [--object-extents] (*image-spec* | *snap-spec*) *dest-path*
+:command:`export-diff` [--from-snap *snap-name*] [--whole-object] (*image-spec* | *snap-spec*) *dest-path*
   Exports an incremental diff for an image to dest path (use - for stdout).  If
   an initial snapshot is specified, only changes since that snapshot are included; otherwise,
   any regions of the image that contain data are included.  The end snapshot is specified
@@ -245,7 +245,7 @@ Commands
   continuing.  If there was an end snapshot we verify it does not already exist before
   applying the changes, and create the snapshot when we are done.
 
-:command:`diff` [--from-snap *snap-name*] [--object-extents] *image-spec* | *snap-spec*
+:command:`diff` [--from-snap *snap-name*] [--whole-object] *image-spec* | *snap-spec*
   Dump a list of byte extents in the image that have changed since the specified start
   snapshot, or since the image was created.  Each output line includes the starting offset
   (in bytes), the length of the region (in bytes), and either 'zero' or 'data' to indicate

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -35,7 +35,7 @@ Options
 
    Connect to specified monitor (instead of looking through ceph.conf).
 
-.. option:: -p pool, --pool pool
+.. option:: -p pool-name, --pool pool-name
 
    Interact with the given pool. Required by most commands.
 
@@ -170,16 +170,17 @@ Commands
 
   If the RBD fast-diff feature isn't enabled on images, this operation will
   require querying the OSDs for every potential object within the image.
-:command:`info` [*image-name*]
+
+:command:`info` [*image-spec*] | [*snap-spec*]
   Will dump information (such as size and order) about a specific rbd image.
   If image is a clone, information about its parent is also displayed.
   If a snapshot is specified, whether it is protected is shown as well.
 
-:command:`create` [*image-name*]
+:command:`create` [*image-spec*]
   Will create a new rbd image. You must also specify the size via --size.  The
   --stripe-unit and --stripe-count arguments are optional, but must be used together.
 
-:command:`clone` [*parent-snapname*] [*image-name*]
+:command:`clone` [*parent-snap-spec*] [*child-image-spec*]
   Will create a clone (copy-on-write child) of the parent snapshot.
   Object order will be identical to that of the parent image unless
   specified. Size will be the same as the parent snapshot. The --stripe-unit
@@ -188,7 +189,7 @@ Commands
   The parent snapshot must be protected (see `rbd snap protect`).
   This requires image format 2.
 
-:command:`flatten` [*image-name*]
+:command:`flatten` [*image-spec*]
   If image is a clone, copy all shared blocks from the parent snapshot and
   make the child independent of the parent, severing the link between
   parent snap and child.  The parent snapshot can be unprotected and
@@ -196,24 +197,24 @@ Commands
 
   This requires image format 2.
 
-:command:`children` [*image-name*]
+:command:`children` [*snap-spec*]
   List the clones of the image at the given snapshot. This checks
   every pool, and outputs the resulting poolname/imagename.
 
   This requires image format 2.
 
-:command:`resize` [*image-name*] [--allow-shrink]
+:command:`resize` [*image-spec*] [--allow-shrink]
   Resizes rbd image. The size parameter also needs to be specified.
   The --allow-shrink option lets the size be reduced.
 
-:command:`rm` [*image-name*]
+:command:`rm` [*image-spec*]
   Deletes an rbd image (including all data blocks). If the image has
   snapshots, this fails and nothing is deleted.
 
-:command:`export` [*image-name*] [*dest-path*]
+:command:`export` ([*image-spec*] | [*snap-spec*]) [*dest-path*]
   Exports image to dest path (use - for stdout).
 
-:command:`import` [*path*] [*dest-image*]
+:command:`import` [*path*] [*image-spec*]
   Creates a new image and imports its data from path (use - for
   stdin).  The import operation will try to create sparse rbd images 
   if possible.  For import from stdin, the sparsification unit is
@@ -222,7 +223,7 @@ Commands
   The --stripe-unit and --stripe-count arguments are optional, but must be
   used together.
 
-:command:`export-diff` [*image-name*] [*dest-path*] [--from-snap *snapname*] [--object-extents]
+:command:`export-diff` ([*image-spec*] | [*snap-spec*]) [*dest-path*] [--from-snap *snap-name*] [--object-extents]
   Exports an incremental diff for an image to dest path (use - for stdout).  If
   an initial snapshot is specified, only changes since that snapshot are included; otherwise,
   any regions of the image that contain data are included.  The end snapshot is specified
@@ -238,59 +239,59 @@ Commands
   'rbd merge-diff first second - | rbd merge-diff - third result'. Note this command
   currently only support the source incremental diff with stripe_count == 1
 
-:command:`import-diff` [*src-path*] [*image-name*]
+:command:`import-diff` [*src-path*] [*image-spec*]
   Imports an incremental diff of an image and applies it to the current image.  If the diff
   was generated relative to a start snapshot, we verify that snapshot already exists before
   continuing.  If there was an end snapshot we verify it does not already exist before
   applying the changes, and create the snapshot when we are done.
 
-:command:`diff` [*image-name*] [--from-snap *snapname*] [--object-extents]
+:command:`diff` [*image-spec*] | [*snap-spec*] [--from-snap *snap-name*] [--object-extents]
   Dump a list of byte extents in the image that have changed since the specified start
   snapshot, or since the image was created.  Each output line includes the starting offset
   (in bytes), the length of the region (in bytes), and either 'zero' or 'data' to indicate
   whether the region is known to be zeros or may contain other data.
 
-:command:`cp` [*src-image*] [*dest-image*]
+:command:`cp` ([*src-image-spec*] | [*src-snap-spec*]) [*dest-image-spec*]
   Copies the content of a src-image into the newly created dest-image.
   dest-image will have the same size, order, and image format as src-image.
 
-:command:`mv` [*src-image*] [*dest-image*]
+:command:`mv` [*src-image-spec*] [*dest-image-spec*]
   Renames an image.  Note: rename across pools is not supported.
 
-:command:`image-meta list` [*image-name*]
+:command:`image-meta list` [*image-spec*]
   Show metadata held on the image. The first column is the key
   and the second column is the value.
 
-:command:`image-meta get` [*image-name*] [*key*]
+:command:`image-meta get` [*image-spec*] [*key*]
   Get metadata value with the key.
 
-:command:`image-meta set` [*image-name*] [*key*] [*value*]
+:command:`image-meta set` [*image-spec*] [*key*] [*value*]
   Set metadata key with the value. They will displayed in `metadata-list`
 
-:command:`image-meta remove` [*image-name*] [*key*]
+:command:`image-meta remove` [*image-spec*] [*key*]
   Remove metadata key with the value.
 
-:command:`object-map` rebuild [*image-name*]
+:command:`object-map` rebuild [*image-spec*] | [*snap-spec*]
   Rebuilds an invalid object map for the specified image. An image snapshot can be
   specified to rebuild an invalid object map for a snapshot.
 
-:command:`snap` ls [*image-name*]
+:command:`snap` ls [*image-spec*]
   Dumps the list of snapshots inside a specific image.
 
-:command:`snap` create [*image-name*]
+:command:`snap` create [*snap-spec*]
   Creates a new snapshot. Requires the snapshot name parameter specified.
 
-:command:`snap` rollback [*image-name*]
+:command:`snap` rollback [*snap-spec*]
   Rollback image content to snapshot. This will iterate through the entire blocks
   array and update the data head content to the snapshotted version.
 
-:command:`snap` rm [*image-name*]
+:command:`snap` rm [*snap-spec*]
   Removes the specified snapshot.
 
-:command:`snap` purge [*image-name*]
+:command:`snap` purge [*image-spec*]
   Removes all snapshots from an image.
 
-:command:`snap` protect [*image-name*]
+:command:`snap` protect [*snap-spec*]
   Protect a snapshot from deletion, so that clones can be made of it
   (see `rbd clone`).  Snapshots must be protected before clones are made;
   protection implies that there exist dependent cloned children that
@@ -299,38 +300,38 @@ Commands
 
   This requires image format 2.
 
-:command:`snap` unprotect [*image-name*]
+:command:`snap` unprotect [*snap-spec*]
   Unprotect a snapshot from deletion (undo `snap protect`).  If cloned
   children remain, `snap unprotect` fails.  (Note that clones may exist
   in different pools than the parent snapshot.)
 
   This requires image format 2.
 
-:command:`map` [*image-name*] [-o | --options *map-options* ] [--read-only]
+:command:`map` [*image-spec*] | [*snap-spec*] [-o | --options *map-options* ] [--read-only]
   Maps the specified image to a block device via the rbd kernel module.
 
-:command:`unmap` [*image-name*] | [*device-path*]
+:command:`unmap` [*image-spec*] | [*snap-spec*] | [*device-path*]
   Unmaps the block device that was mapped via the rbd kernel module.
 
 :command:`showmapped`
   Show the rbd images that are mapped via the rbd kernel module.
 
-:command:`status` [*image-name*]
+:command:`status` [*image-spec*]
   Show the status of the image, including which clients have it open.
 
-:command:`feature` disable [*image-name*] [*feature*]
+:command:`feature` disable [*image-spec*] [*feature*]
   Disables the specified feature on the specified image. Multiple features can
   be specified.
 
-:command:`feature` enable [*image-name*] [*feature*]
+:command:`feature` enable [*image-spec*] [*feature*]
   Enables the specified feature on the specified image. Multiple features can
   be specified.
 
-:command:`lock` list [*image-name*]
+:command:`lock` list [*image-spec*]
   Show locks held on the image. The first column is the locker
   to use with the `lock remove` command.
 
-:command:`lock` add [*image-name*] [*lock-id*]
+:command:`lock` add [*image-spec*] [*lock-id*]
   Lock an image. The lock-id is an arbitrary name for the user's
   convenience. By default, this is an exclusive lock, meaning it
   will fail if the image is already locked. The --shared option
@@ -338,26 +339,26 @@ Commands
   any operation other than adding a lock. It does not
   protect an image from being deleted.
 
-:command:`lock` remove [*image-name*] [*lock-id*] [*locker*]
+:command:`lock` remove [*image-spec*] [*lock-id*] [*locker*]
   Release a lock on an image. The lock id and locker are
   as output by lock ls.
 
-:command:`bench-write` [*image-name*] --io-size [*io-size-in-bytes*] --io-threads [*num-ios-in-flight*] --io-total [*total-bytes-to-write*]
+:command:`bench-write` [*image-spec*] --io-size [*io-size-in-bytes*] --io-threads [*num-ios-in-flight*] --io-total [*total-bytes-to-write*]
   Generate a series of sequential writes to the image and measure the
   write throughput and latency.  Defaults are: --io-size 4096, --io-threads 16, 
   --io-total 1GB
 
-Image name
-==========
+Image and snap specs
+====================
 
-In addition to using the --pool and the --snap options, the image name can include both
-the pool name and the snapshot name. The image name format is as follows::
+| *image-spec* is [*pool-name*]/*image-name*
+| *snap-spec*  is [*pool-name*]/*image-name*\ @\ *snap-name*
 
-       [pool/]image-name[@snap]
+The default for *pool-name* is "rbd".  If an image name contains a slash
+character ('/'), *pool-name* is required.
 
-Thus an image name that contains a slash character ('/') requires specifying the pool
-name explicitly.
-
+You may specify each name individually, using --pool, --image and --snap
+options, but this is discouraged in favor of the above spec syntax.
 
 Striping
 ========

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -48,7 +48,7 @@ Options
 Parameters
 ==========
 
-.. option:: --image-format format
+.. option:: --image-format format-id
 
    Specifies which object layout to use. The default is 1.
 
@@ -98,7 +98,7 @@ Parameters
    to use with the map command.  If not specified, the default keyring
    locations will be searched.
 
-.. option:: --shared tag
+.. option:: --shared lock-tag
 
    Option for `lock add` that allows multiple clients to lock the
    same image if they use the same tag. The tag is an arbitrary
@@ -125,18 +125,18 @@ Parameters
 
    Map the image read-only.  Equivalent to -o ro.
 
-.. option:: --image-feature feature
+.. option:: --image-feature feature-name
 
    Specifies which RBD format 2 feature should be enabled when creating
    an image. Multiple features can be enabled by repeating this option
    multiple times. The following features are supported:
 
-   layering: layering support
-   striping: striping v2 support
-   exclusive-lock: exclusive locking support
-   object-map: object map support (requires exclusive-lock)
-   fast-diff: fast diff calculations (requires object-map)
-   deep-flatten: snapshot flatten support
+   * layering: layering support
+   * striping: striping v2 support
+   * exclusive-lock: exclusive locking support
+   * object-map: object map support (requires exclusive-lock)
+   * fast-diff: fast diff calculations (requires object-map)
+   * deep-flatten: snapshot flatten support
 
 .. option:: --image-shared
 
@@ -158,7 +158,7 @@ Commands
 
 .. TODO rst "option" directive seems to require --foo style options, parsing breaks on subcommands.. the args show up as bold too
 
-:command:`ls` [-l | --long] [pool-name]
+:command:`ls` [-l | --long] [*pool-name*]
   Will list all rbd images listed in the rbd_directory object.  With
   -l, also show snapshots, and use longer-format output including
   size, parent (if clone), format, etc.
@@ -171,16 +171,16 @@ Commands
   If the RBD fast-diff feature isn't enabled on images, this operation will
   require querying the OSDs for every potential object within the image.
 
-:command:`info` [*image-spec*] | [*snap-spec*]
+:command:`info` *image-spec* | *snap-spec*
   Will dump information (such as size and order) about a specific rbd image.
   If image is a clone, information about its parent is also displayed.
   If a snapshot is specified, whether it is protected is shown as well.
 
-:command:`create` [*image-spec*]
+:command:`create` (-s | --size *size-in-M/G/T*) [--image-format *format-id*] [--order *bits*] [--stripe-unit *size-in-bytes* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *image-spec*
   Will create a new rbd image. You must also specify the size via --size.  The
   --stripe-unit and --stripe-count arguments are optional, but must be used together.
 
-:command:`clone` [*parent-snap-spec*] [*child-image-spec*]
+:command:`clone` [--order *bits*] [--stripe-unit *size-in-bytes* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *parent-snap-spec* *child-image-spec*
   Will create a clone (copy-on-write child) of the parent snapshot.
   Object order will be identical to that of the parent image unless
   specified. Size will be the same as the parent snapshot. The --stripe-unit
@@ -189,7 +189,7 @@ Commands
   The parent snapshot must be protected (see `rbd snap protect`).
   This requires image format 2.
 
-:command:`flatten` [*image-spec*]
+:command:`flatten` *image-spec*
   If image is a clone, copy all shared blocks from the parent snapshot and
   make the child independent of the parent, severing the link between
   parent snap and child.  The parent snapshot can be unprotected and
@@ -197,24 +197,24 @@ Commands
 
   This requires image format 2.
 
-:command:`children` [*snap-spec*]
+:command:`children` *snap-spec*
   List the clones of the image at the given snapshot. This checks
   every pool, and outputs the resulting poolname/imagename.
 
   This requires image format 2.
 
-:command:`resize` [*image-spec*] [--allow-shrink]
+:command:`resize` (-s | --size *size-in-M/G/T*) [--allow-shrink] *image-spec*
   Resizes rbd image. The size parameter also needs to be specified.
   The --allow-shrink option lets the size be reduced.
 
-:command:`rm` [*image-spec*]
+:command:`rm` *image-spec*
   Deletes an rbd image (including all data blocks). If the image has
   snapshots, this fails and nothing is deleted.
 
-:command:`export` ([*image-spec*] | [*snap-spec*]) [*dest-path*]
+:command:`export` (*image-spec* | *snap-spec*) [*dest-path*]
   Exports image to dest path (use - for stdout).
 
-:command:`import` [*path*] [*image-spec*]
+:command:`import` [--image-format *format-id*] [--order *bits*] [--stripe-unit *size-in-bytes* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *src-path* [*image-spec*]
   Creates a new image and imports its data from path (use - for
   stdin).  The import operation will try to create sparse rbd images 
   if possible.  For import from stdin, the sparsification unit is
@@ -223,7 +223,7 @@ Commands
   The --stripe-unit and --stripe-count arguments are optional, but must be
   used together.
 
-:command:`export-diff` ([*image-spec*] | [*snap-spec*]) [*dest-path*] [--from-snap *snap-name*] [--object-extents]
+:command:`export-diff` [--from-snap *snap-name*] [--object-extents] (*image-spec* | *snap-spec*) *dest-path*
   Exports an incremental diff for an image to dest path (use - for stdout).  If
   an initial snapshot is specified, only changes since that snapshot are included; otherwise,
   any regions of the image that contain data are included.  The end snapshot is specified
@@ -231,7 +231,7 @@ Commands
   metadata about image size changes, and the start and end snapshots.  It efficiently represents
   discarded or 'zero' regions of the image.
 
-:command:`merge-diff` [*first-diff-path*] [*second-diff-path*] [*merged-diff-path*]
+:command:`merge-diff` *first-diff-path* *second-diff-path* *merged-diff-path*
   Merge two continuous incremental diffs of an image into one single diff. The
   first diff's end snapshot must be equal with the second diff's start snapshot.
   The first diff could be - for stdin, and merged diff could be - for stdout, which
@@ -239,59 +239,59 @@ Commands
   'rbd merge-diff first second - | rbd merge-diff - third result'. Note this command
   currently only support the source incremental diff with stripe_count == 1
 
-:command:`import-diff` [*src-path*] [*image-spec*]
+:command:`import-diff` *src-path* *image-spec*
   Imports an incremental diff of an image and applies it to the current image.  If the diff
   was generated relative to a start snapshot, we verify that snapshot already exists before
   continuing.  If there was an end snapshot we verify it does not already exist before
   applying the changes, and create the snapshot when we are done.
 
-:command:`diff` [*image-spec*] | [*snap-spec*] [--from-snap *snap-name*] [--object-extents]
+:command:`diff` [--from-snap *snap-name*] [--object-extents] *image-spec* | *snap-spec*
   Dump a list of byte extents in the image that have changed since the specified start
   snapshot, or since the image was created.  Each output line includes the starting offset
   (in bytes), the length of the region (in bytes), and either 'zero' or 'data' to indicate
   whether the region is known to be zeros or may contain other data.
 
-:command:`cp` ([*src-image-spec*] | [*src-snap-spec*]) [*dest-image-spec*]
+:command:`cp` (*src-image-spec* | *src-snap-spec*) *dest-image-spec*
   Copies the content of a src-image into the newly created dest-image.
   dest-image will have the same size, order, and image format as src-image.
 
-:command:`mv` [*src-image-spec*] [*dest-image-spec*]
+:command:`mv` *src-image-spec* *dest-image-spec*
   Renames an image.  Note: rename across pools is not supported.
 
-:command:`image-meta list` [*image-spec*]
+:command:`image-meta list` *image-spec*
   Show metadata held on the image. The first column is the key
   and the second column is the value.
 
-:command:`image-meta get` [*image-spec*] [*key*]
+:command:`image-meta get` *image-spec* *key*
   Get metadata value with the key.
 
-:command:`image-meta set` [*image-spec*] [*key*] [*value*]
-  Set metadata key with the value. They will displayed in `metadata-list`
+:command:`image-meta set` *image-spec* *key* *value*
+  Set metadata key with the value. They will displayed in `image-meta list`.
 
-:command:`image-meta remove` [*image-spec*] [*key*]
+:command:`image-meta remove` *image-spec* *key*
   Remove metadata key with the value.
 
-:command:`object-map` rebuild [*image-spec*] | [*snap-spec*]
+:command:`object-map rebuild` *image-spec* | *snap-spec*
   Rebuilds an invalid object map for the specified image. An image snapshot can be
   specified to rebuild an invalid object map for a snapshot.
 
-:command:`snap` ls [*image-spec*]
+:command:`snap ls` *image-spec*
   Dumps the list of snapshots inside a specific image.
 
-:command:`snap` create [*snap-spec*]
+:command:`snap create` *snap-spec*
   Creates a new snapshot. Requires the snapshot name parameter specified.
 
-:command:`snap` rollback [*snap-spec*]
+:command:`snap rollback` *snap-spec*
   Rollback image content to snapshot. This will iterate through the entire blocks
   array and update the data head content to the snapshotted version.
 
-:command:`snap` rm [*snap-spec*]
+:command:`snap rm` *snap-spec*
   Removes the specified snapshot.
 
-:command:`snap` purge [*image-spec*]
+:command:`snap purge` *image-spec*
   Removes all snapshots from an image.
 
-:command:`snap` protect [*snap-spec*]
+:command:`snap protect` *snap-spec*
   Protect a snapshot from deletion, so that clones can be made of it
   (see `rbd clone`).  Snapshots must be protected before clones are made;
   protection implies that there exist dependent cloned children that
@@ -300,38 +300,38 @@ Commands
 
   This requires image format 2.
 
-:command:`snap` unprotect [*snap-spec*]
+:command:`snap unprotect` *snap-spec*
   Unprotect a snapshot from deletion (undo `snap protect`).  If cloned
   children remain, `snap unprotect` fails.  (Note that clones may exist
   in different pools than the parent snapshot.)
 
   This requires image format 2.
 
-:command:`map` [*image-spec*] | [*snap-spec*] [-o | --options *map-options* ] [--read-only]
+:command:`map` [-o | --options *map-options* ] [--read-only] *image-spec* | *snap-spec*
   Maps the specified image to a block device via the rbd kernel module.
 
-:command:`unmap` [*image-spec*] | [*snap-spec*] | [*device-path*]
+:command:`unmap` *image-spec* | *snap-spec* | *device-path*
   Unmaps the block device that was mapped via the rbd kernel module.
 
 :command:`showmapped`
   Show the rbd images that are mapped via the rbd kernel module.
 
-:command:`status` [*image-spec*]
+:command:`status` *image-spec*
   Show the status of the image, including which clients have it open.
 
-:command:`feature` disable [*image-spec*] [*feature*]
+:command:`feature disable` *image-spec* *feature-name*...
   Disables the specified feature on the specified image. Multiple features can
   be specified.
 
-:command:`feature` enable [*image-spec*] [*feature*]
+:command:`feature enable` *image-spec* *feature-name*...
   Enables the specified feature on the specified image. Multiple features can
   be specified.
 
-:command:`lock` list [*image-spec*]
+:command:`lock list` *image-spec*
   Show locks held on the image. The first column is the locker
   to use with the `lock remove` command.
 
-:command:`lock` add [*image-spec*] [*lock-id*]
+:command:`lock add` [--shared *lock-tag*] *image-spec* *lock-id*
   Lock an image. The lock-id is an arbitrary name for the user's
   convenience. By default, this is an exclusive lock, meaning it
   will fail if the image is already locked. The --shared option
@@ -339,14 +339,14 @@ Commands
   any operation other than adding a lock. It does not
   protect an image from being deleted.
 
-:command:`lock` remove [*image-spec*] [*lock-id*] [*locker*]
+:command:`lock remove` *image-spec* *lock-id* *locker*
   Release a lock on an image. The lock id and locker are
   as output by lock ls.
 
-:command:`bench-write` [*image-spec*] --io-size [*io-size-in-bytes*] --io-threads [*num-ios-in-flight*] --io-total [*total-bytes-to-write*]
-  Generate a series of sequential writes to the image and measure the
-  write throughput and latency.  Defaults are: --io-size 4096, --io-threads 16, 
-  --io-total 1GB
+:command:`bench-write` [--io-size *size-in-bytes*] [--io-threads *num-ios-in-flight*] [--io-total *total-bytes-to-write*] [--io-pattern seq | rand] *image-spec*
+  Generate a series of writes to the image and measure the write throughput and
+  latency.  Defaults are: --io-size 4096, --io-threads 16, --io-total 1GB,
+  --io-pattern seq.
 
 Image and snap specs
 ====================

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -163,10 +163,10 @@ Commands
   -l, also show snapshots, and use longer-format output including
   size, parent (if clone), format, etc.
 
-:command:`du` [--image *image-name*] [*pool-name*]
+:command:`du` [-p | --pool *pool-name*] [*image-spec* | *snap-spec*]
   Will calculate the provisioned and actual disk usage of all images and
-  associated snapshots within the specified pool. It can also be used against
-  individual images.
+  associated snapshots within the specified pool.  It can also be used against
+  individual images and snapshots.
 
   If the RBD fast-diff feature isn't enabled on images, this operation will
   require querying the OSDs for every potential object within the image.

--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -137,7 +137,7 @@ because it requires partial writes. It is however possible to create
 an RBD image on an erasure coded pools when a replicated pool tier set
 a cache tier::
 
-    $ rbd --pool ecpool create --size 10 myvolume
+    $ rbd create --size 10G ecpool/myvolume
 
 More information can be found in the `cache tiering
 <../cache-tiering>`_ documentation.

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -601,7 +601,7 @@ Ceph supports the following usage for user name and secret:
               preferred approach, because you can switch user names without 
               switching the keyring path. For example:: 
 
-               sudo rbd map foo --pool rbd myimage --id client.foo --keyring /path/to/keyring
+               sudo rbd map --id foo --keyring /path/to/keyring mypool/myimage
 
 
 .. _pools: ../pools

--- a/doc/rbd/rados-rbd-cmds.rst
+++ b/doc/rbd/rados-rbd-cmds.rst
@@ -21,18 +21,18 @@ Before you can add a block device to a node, you must create an image for it in
 the :term:`Ceph Storage Cluster` first. To create a block device image, execute
 the  following::
 
-	rbd create {image-name} --size {megabytes} --pool {pool-name}
+	rbd create --size {megabytes} {pool-name}/{image-name}
 	
 For example, to create a 1GB image named ``bar`` that stores information in a
 pool named ``swimmingpool``, execute the following::
 
-	rbd create bar --size 1024 --pool swimmingpool
+	rbd create --size 1024 swimmingpool/bar
 
 If you don't specify pool when creating an image, it will be stored in the
 default pool ``rbd``. For example, to create a 1GB image named ``foo`` stored in
 the default pool ``rbd``, execute the following::
 
-        rbd create foo --size 1024
+	rbd create --size 1024 foo
 
 .. note:: You must create a pool first before you can specify it as a 
    source. See `Storage Pools`_ for details.
@@ -60,21 +60,21 @@ Retrieving Image Information
 To retrieve information from a particular image, execute the following,
 but replace ``{image-name}`` with the name for the image:: 
 
-	rbd --image {image-name} info
+	rbd info {image-name}
 	
 For example::
 
-	rbd --image foo info
+	rbd info foo
 	
 To retrieve information from an image within a pool, execute the following,
 but replace ``{image-name}`` with the name of the image and replace ``{pool-name}``
 with the name of the pool:: 
 
-	rbd --image {image-name} -p {pool-name} info
+	rbd info {pool-name}/{image-name}
 
 For example:: 
 
-	rbd --image bar -p swimmingpool info	
+	rbd info swimmingpool/bar
 
 Resizing a Block Device Image
 =============================
@@ -85,7 +85,7 @@ a maximum capacity  that you set with the ``--size`` option. If you want to
 increase (or decrease) the maximum size of a Ceph Block Device image, execute
 the following:: 
 
-	rbd resize --image foo --size 2048
+	rbd resize --size 2048 foo
 
 
 Removing a Block Device Image
@@ -104,11 +104,11 @@ To remove a block device from a pool, execute the following, but replace
 ``{image-name}`` with the name of the image to remove and replace 
 ``{pool-name}`` with the name of the pool:: 
 
-	rbd rm {image-name} -p {pool-name}
+	rbd rm {pool-name}/{image-name}
 	
 For example:: 
 
-	rbd rm bar -p swimmingpool
+	rbd rm swimmingpool/bar
 
 
 

--- a/doc/rbd/rbd-ko.rst
+++ b/doc/rbd/rbd-ko.rst
@@ -20,17 +20,17 @@ Use ``rbd`` to map an image name to a kernel module. You must specify the
 image name, the pool name, and the user name. ``rbd`` will load RBD kernel
 module on your behalf if it's not already loaded. ::
 
-  sudo rbd map {image-name} --pool {pool-name} --id {user-name}
+  sudo rbd map {pool-name}/{image-name} --id {user-name}
 
 For example:: 
 
-  sudo rbd map --pool rbd myimage --id admin
+  sudo rbd map rbd/myimage --id admin
  
 If you use `cephx`_ authentication, you must also specify a secret.  It may come
 from a keyring or a file containing the secret. ::
 
-  sudo rbd map --pool rbd myimage --id admin --keyring /path/to/keyring
-  sudo rbd map --pool rbd myimage --id admin --keyfile /path/to/file
+  sudo rbd map rbd/myimage --id admin --keyring /path/to/keyring
+  sudo rbd map rbd/myimage --id admin --keyfile /path/to/file
 
 
 Show Mapped Block Devices

--- a/doc/rbd/rbd-snapshot.rst
+++ b/doc/rbd/rbd-snapshot.rst
@@ -58,12 +58,10 @@ Create Snapshot
 To create a snapshot with ``rbd``, specify the ``snap create`` option,  the pool
 name and the image name.  ::
 
-	rbd --pool {pool-name} snap create --snap {snap-name} {image-name}
 	rbd snap create {pool-name}/{image-name}@{snap-name}
 
 For example:: 
 
-	rbd --pool rbd snap create --snap snapname foo
 	rbd snap create rbd/foo@snapname
 	
 
@@ -72,12 +70,10 @@ List Snapshots
 
 To list snapshots of an image, specify the pool name and the image name. ::
 
-	rbd --pool {pool-name} snap ls {image-name} 
 	rbd snap ls {pool-name}/{image-name}
 
 For example::
 
-	rbd --pool rbd snap ls foo 
 	rbd snap ls rbd/foo
 
 
@@ -87,12 +83,10 @@ Rollback Snapshot
 To rollback to a snapshot with ``rbd``, specify the ``snap rollback`` option, the
 pool name, the image name and the snap name. ::
 
-	rbd --pool {pool-name} snap rollback --snap {snap-name} {image-name}
 	rbd snap rollback {pool-name}/{image-name}@{snap-name}
 
 For example::
 
-	rbd --pool rbd snap rollback --snap snapname foo
 	rbd snap rollback rbd/foo@snapname
 
 
@@ -110,12 +104,10 @@ Delete a Snapshot
 To delete a snapshot with ``rbd``, specify the ``snap rm`` option, the pool
 name, the image name and the snap name. ::
 
-	rbd --pool {pool-name} snap rm --snap {snap-name} {image-name}
 	rbd snap rm {pool-name}/{image-name}@{snap-name}
 	
 For example:: 
 
-	rbd --pool rbd snap rm --snap snapname foo
 	rbd snap rm rbd/foo@snapname
 
 
@@ -128,12 +120,10 @@ Purge Snapshots
 To delete all snapshots for an image with ``rbd``, specify the ``snap purge``
 option and the image name. ::
 
-	rbd --pool {pool-name} snap purge {image-name}
 	rbd snap purge {pool-name}/{image-name}
 
 For example:: 
 
-	rbd --pool rbd snap purge foo
 	rbd snap purge rbd/foo
 
 
@@ -236,12 +226,10 @@ Clones access the parent snapshots. All clones would break if a user inadvertent
 deleted the parent snapshot. To prevent data loss, you **MUST** protect the
 snapshot before you can clone it. ::
 
-	rbd --pool {pool-name} snap protect --image {image-name} --snap {snapshot-name}	
 	rbd snap protect {pool-name}/{image-name}@{snapshot-name}
 
 For example::
 
-	rbd --pool rbd snap protect --image my-image --snap my-snapshot
 	rbd snap protect rbd/my-image@my-snapshot
 
 .. note:: You cannot delete a protected snapshot.
@@ -253,8 +241,7 @@ To clone a snapshot, specify you need to specify the parent pool, image and
 snapshot; and, the child pool and image name. You must protect the snapshot
 before  you can clone it. ::
 
-   rbd --pool {pool-name} --image {parent-image} --snap {snap-name} --dest-pool {pool-name} --dest {child-image}
-   rbd clone {pool-name}/{parent-image}@{snap-name} {pool-name}/{child-image-name}
+	rbd clone {pool-name}/{parent-image}@{snap-name} {pool-name}/{child-image-name}
 	
 For example:: 
 
@@ -271,12 +258,10 @@ Before you can delete a snapshot, you must unprotect it first. Additionally,
 you may *NOT* delete snapshots that have references from clones. You must
 flatten each clone of a snapshot, before you can delete the snapshot. :: 
 
-	rbd --pool {pool-name} snap unprotect --image {image-name} --snap {snapshot-name}
 	rbd snap unprotect {pool-name}/{image-name}@{snapshot-name}
 
 For example::
 
-	rbd --pool rbd snap unprotect --image my-image --snap my-snapshot
 	rbd snap unprotect rbd/my-image@my-snapshot
 
 
@@ -285,12 +270,10 @@ Listing Children of a Snapshot
 
 To list the children of a snapshot, execute the following::
 
-	rbd --pool {pool-name} children --image {image-name} --snap {snap-name}
 	rbd children {pool-name}/{image-name}@{snapshot-name}
 
 For example::
 
-	rbd --pool rbd children --image my-image --snap my-snapshot
 	rbd children rbd/my-image@my-snapshot
 
 
@@ -303,12 +286,10 @@ the image by copying the information from the snapshot to the clone. The time
 it takes to flatten a clone increases with the size of the snapshot. To delete 
 a snapshot, you must flatten the child images first. ::
 
-	rbd --pool {pool-name} flatten --image {image-name}
 	rbd flatten {pool-name}/{image-name}
 
 For example:: 
 
-	rbd --pool rbd flatten --image my-image 
 	rbd flatten rbd/my-image
 
 .. note:: Since a flattened image contains all the information from the snapshot, 

--- a/doc/start/quick-rbd.rst
+++ b/doc/start/quick-rbd.rst
@@ -57,7 +57,7 @@ Configure a Block Device
 
 #. On the ``ceph-client`` node, map the image to a block device. :: 
 
-	sudo rbd map foo --pool rbd --name client.admin [-m {mon-IP}] [-k /path/to/ceph.client.admin.keyring]
+	sudo rbd map foo --name client.admin [-m {mon-IP}] [-k /path/to/ceph.client.admin.keyring]
 	
 #. Use the block device by creating a file system on the ``ceph-client`` 
    node. :: 

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -367,7 +367,7 @@ static int va_ceph_argparse_witharg(std::vector<const char*> &args,
       else if (first[strlen_a] == '\0') {
 	// find second part (or not)
 	if (i+1 == args.end()) {
-	  oss << "Option " << *i << " requires an argument.";
+	  oss << "Option " << *i << " requires an argument." << std::endl;
 	  i = args.erase(i);
 	  return -EINVAL;
 	}

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -93,8 +93,9 @@ void usage()
 "where 'pool' is a rados pool name (default is 'rbd') and 'cmd' is one of:\n"
 "  (ls | list) [-l | --long ] [pool-name]      list rbd images\n"
 "                                              (-l includes snapshots/clones)\n"
-"  (du | disk-usage) [--image <name>] [pool-name]\n"
-"                                              show pool image disk usage stats\n"
+"  (du | disk-usage) [<image-spec> | <snap-spec>]\n"
+"                                              show disk usage stats for pool,\n"
+"                                              image or snapshot\n"
 "  info <image-spec> | <snap-spec>             show information about image size,\n"
 "                                              striping, etc.\n"
 "  create [--order <bits>] [--image-features <features>] [--image-shared]\n"
@@ -3182,7 +3183,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     const char *v = *i;
     switch (opt_cmd) {
       case OPT_LIST:
-      case OPT_DISK_USAGE:
 	SET_CONF_PARAM(v, &poolname, NULL, NULL);
 	break;
       case OPT_INFO:
@@ -3206,6 +3206,7 @@ if (!set_conf_param(v, p1, p2, p3)) { \
       case OPT_METADATA_LIST:
       case OPT_DIFF:
       case OPT_OBJECT_MAP_REBUILD:
+      case OPT_DISK_USAGE:
 	SET_CONF_PARAM(v, &imgname, NULL, NULL);
 	break;
       case OPT_EXPORT:

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -3408,6 +3408,12 @@ if (!set_conf_param(v, p1, p2, p3)) { \
 
   set_pool_image_name(destname, (char **)&dest_poolname,
 		      (char **)&destname, (char **)&dest_snapname);
+  if (dest_snapname) {
+    // no command uses dest_snapname
+    cerr << "rbd: destination snapname specified for a command that doesn't use it"
+         << std::endl;
+    return EXIT_FAILURE;
+  }
 
   if (opt_cmd == OPT_IMPORT) {
     if (poolname && dest_poolname) {
@@ -3451,11 +3457,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
   if ((opt_cmd == OPT_COPY || opt_cmd == OPT_CLONE || opt_cmd == OPT_RENAME) &&
       !destname ) {
     cerr << "rbd: destination image name was not specified" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  if ((opt_cmd == OPT_CLONE) && dest_snapname) {
-    cerr << "rbd: cannot clone to a snapshot" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -91,82 +91,88 @@ void usage()
   cout <<
 "usage: rbd [-n <auth user>] [OPTIONS] <cmd> ...\n"
 "where 'pool' is a rados pool name (default is 'rbd') and 'cmd' is one of:\n"
-"  (ls | list) [-l | --long ] [pool-name] list rbd images\n"
+"  (ls | list) [-l | --long ] [pool-name]      list rbd images\n"
 "                                              (-l includes snapshots/clones)\n"
 "  (du | disk-usage) [--image <name>] [pool-name]\n"
 "                                              show pool image disk usage stats\n"
-"  info <image-name>                           show information about image size,\n"
+"  info <image-spec> | <snap-spec>             show information about image size,\n"
 "                                              striping, etc.\n"
 "  create [--order <bits>] [--image-features <features>] [--image-shared]\n"
-"         --size <M/G/T> <image-name>          create an empty image\n"
+"         --size <M/G/T> <image-spec>          create an empty image\n"
 "  clone [--order <bits>] [--image-features <features>] [--image-shared]\n"
-"        <parentsnap> <clonename>              clone a snapshot into a COW\n"
+"         <parent-snap-spec> <child-image-spec>\n"
+"                                              clone a snapshot into a COW\n"
 "                                              child image\n"
-"  children <snap-name>                        display children of snapshot\n"
-"  flatten <image-name>                        fill clone with parent data\n"
+"  children <snap-spec>                        display children of snapshot\n"
+"  flatten <image-spec>                        fill clone with parent data\n"
 "                                              (make it independent)\n"
-"  resize --size <M/G/T> <image-name>          resize (expand or contract) image\n"
-"  rm <image-name>                             delete an image\n"
-"  export <image-name> <path>                  export image to file\n"
+"  resize --size <M/G/T> <image-spec>          resize (expand or contract) image\n"
+"  rm <image-spec>                             delete an image\n"
+"  export (<image-spec> | <snap-spec>) <path>  export image to file\n"
 "                                              \"-\" for stdout\n"
 "  import [--image-features <features>] [--image-shared]\n"
-"         <path> <image-name>                  import image from file (dest\n"
+"         <path> <image-spec>                  import image from file (dest\n"
 "                                              defaults as the filename part\n"
 "                                              of file). \"-\" for stdin\n"
-"  diff [--from-snap <snap-name>] [--object-extents] <image-name>\n"
-"                                              print extents that differ since\n"
+"  diff [--from-snap <snap-name>] [--object-extents]\n"
+"         <image-spec> | <snap-spec>           print extents that differ since\n"
 "                                              a previous snap, or image creation\n"
-"  export-diff [--from-snap <snap-name>] [--object-extents] <image-name> <path>\n"
-"                                              export an incremental diff to\n"
+"  export-diff [--from-snap <snap-name>] [--object-extents]\n"
+"         (<image-spec> | <snap-spec>) <path>  export an incremental diff to\n"
 "                                              path, or \"-\" for stdout\n"
 "  merge-diff <diff1> <diff2> <path>           merge <diff1> and <diff2> into\n"
 "                                              <path>, <diff1> could be \"-\"\n"
 "                                              for stdin, and <path> could be \"-\"\n"
 "                                              for stdout\n"
-"  import-diff <path> <image-name>             import an incremental diff from\n"
+"  import-diff <path> <image-spec>             import an incremental diff from\n"
 "                                              path or \"-\" for stdin\n"
-"  (cp | copy) <src> <dest>                    copy src image to dest\n"
-"  (mv | rename) <src> <dest>                  rename src image to dest\n"
-"  image-meta list <image-name>                image metadata list keys with values\n"
-"  image-meta get <image-name> <key>           image metadata get the value associated with the key\n"
-"  image-meta set <image-name> <key> <value>   image metadata set key with value\n"
-"  image-meta remove <image-name> <key>        image metadata remove the key and value associated\n"
-"  object-map rebuild <image-name>             rebuild an invalid object map\n"
-"  snap ls <image-name>                        dump list of image snapshots\n"
-"  snap create <snap-name>                     create a snapshot\n"
-"  snap rollback <snap-name>                   rollback image to snapshot\n"
-"  snap rm <snap-name>                         deletes a snapshot\n"
-"  snap purge <image-name>                     deletes all snapshots\n"
-"  snap protect <snap-name>                    prevent a snapshot from being deleted\n"
-"  snap unprotect <snap-name>                  allow a snapshot to be deleted\n"
-"  watch <image-name>                          watch events on image\n"
-"  status <image-name>                         show the status of this image\n"
-"  map <image-name>                            map image to a block device\n"
+"  (cp | copy) (<src-image-spec> | <src-snap-spec>) <dest-image-spec>\n"
+"                                              copy src image to dest\n"
+"  (mv | rename) <src-image-spec> <dest-image-spec>\n"
+"                                              rename src image to dest\n"
+"  image-meta list <image-spec>                image metadata list keys with values\n"
+"  image-meta get <image-spec> <key>           image metadata get the value associated with the key\n"
+"  image-meta set <image-spec> <key> <value>   image metadata set key with value\n"
+"  image-meta remove <image-spec> <key>        image metadata remove the key and value associated\n"
+"  object-map rebuild <image-spec> | <snap-spec>\n"
+"                                              rebuild an invalid object map\n"
+"  snap ls <image-spec>                        dump list of image snapshots\n"
+"  snap create <snap-spec>                     create a snapshot\n"
+"  snap rollback <snap-spec>                   rollback image to snapshot\n"
+"  snap rm <snap-spec>                         deletes a snapshot\n"
+"  snap purge <image-spec>                     deletes all snapshots\n"
+"  snap protect <snap-spec>                    prevent a snapshot from being deleted\n"
+"  snap unprotect <snap-spec>                  allow a snapshot to be deleted\n"
+"  watch <image-spec>                          watch events on image\n"
+"  status <image-spec>                         show the status of this image\n"
+"  map <image-spec> | <snap-spec>              map image to a block device\n"
 "                                              using the kernel\n"
-"  unmap <image-name> | <device>               unmap a rbd device that was\n"
+"  unmap <image-spec> | <snap-spec> | <device> unmap a rbd device that was\n"
 "                                              mapped by the kernel\n"
 "  showmapped                                  show the rbd images mapped\n"
 "                                              by the kernel\n"
-"  feature disable <image-name> <feature>      disable the specified image feature\n"
-"  feature enable <image-name> <feature>       enable the specified image feature\n"
-"  lock list <image-name>                      show locks held on an image\n"
-"  lock add <image-name> <id> [--shared <tag>] take a lock called id on an image\n"
-"  lock remove <image-name> <id> <locker>      release a lock on an image\n"
-"  bench-write <image-name>                    simple write benchmark\n"
+"  feature disable <image-spec> <feature>      disable the specified image feature\n"
+"  feature enable <image-spec> <feature>       enable the specified image feature\n"
+"  lock list <image-spec>                      show locks held on an image\n"
+"  lock add <image-spec> <id> [--shared <tag>] take a lock called id on an image\n"
+"  lock remove <image-spec> <id> <locker>      release a lock on an image\n"
+"  bench-write <image-spec>                    simple write benchmark\n"
 "                 --io-size <bytes>              write size\n"
 "                 --io-threads <num>             ios in flight\n"
 "                 --io-total <bytes>             total bytes to write\n"
 "                 --io-pattern <seq|rand>        write pattern\n"
 "\n"
-"<image-name>, <snap-name> are [pool/]name[@snap], or you may specify\n"
-"individual pieces of names with -p/--pool, --image, and/or --snap.\n"
+"<image-spec> is [<pool-name>]/<image-name>,\n"
+"<snap-spec> is [<pool-name>]/<image-name>@<snap-name>,\n"
+"or you may specify individual pieces of names with -p/--pool <pool-name>,\n"
+"--image <image-name> and/or --snap <snap-name>.\n"
 "\n"
 "Other input options:\n"
-"  -p, --pool <pool>                  source pool name\n"
+"  -p, --pool <pool-name>             source pool name\n"
+"  --dest-pool <pool-name>            destination pool name\n"
 "  --image <image-name>               image name\n"
-"  --dest <image-name>                destination [pool and] image name\n"
+"  --dest <image-name>                destination image name\n"
 "  --snap <snap-name>                 snapshot name\n"
-"  --dest-pool <name>                 destination pool name\n"
 "  --path <path-name>                 path name for import/export\n"
 "  -s, --size <size in M/G/T>         size of image for create and resize\n"
 "  --order <bits>                     the object size in bits; object size will be\n"
@@ -3294,11 +3300,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     }
   }
 
-  if (opt_cmd == OPT_EXPORT && !imgname) {
-    cerr << "rbd: image name was not specified" << std::endl;
-    return EXIT_FAILURE;
-  }
-
   if ((opt_cmd == OPT_IMPORT || opt_cmd == OPT_IMPORT_DIFF) && !path) {
     cerr << "rbd: path was not specified" << std::endl;
     return EXIT_FAILURE;
@@ -3663,10 +3664,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     break;
 
   case OPT_SNAP_LIST:
-    if (!imgname) {
-      cerr << "rbd: snap list requires an image parameter" << std::endl;
-      return EXIT_FAILURE;
-    }
     r = do_list_snaps(image, formatter.get());
     if (r < 0) {
       cerr << "rbd: failed to list snapshots: " << cpp_strerror(-r)
@@ -3676,10 +3673,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     break;
 
   case OPT_SNAP_CREATE:
-    if (!imgname || !snapname) {
-      cerr << "rbd: snap create requires image and snapname" << std::endl;
-      return EINVAL;
-    }
     r = do_add_snap(image, snapname);
     if (r < 0) {
       cerr << "rbd: failed to create snapshot: " << cpp_strerror(-r)
@@ -3689,10 +3682,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     break;
 
   case OPT_SNAP_ROLLBACK:
-    if (!imgname) {
-      cerr << "rbd: snap rollback requires image name" << std::endl;
-      return EINVAL;
-    }
     r = do_rollback_snap(image, snapname);
     if (r < 0) {
       cerr << "rbd: rollback failed: " << cpp_strerror(-r) << std::endl;
@@ -3701,10 +3690,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     break;
 
   case OPT_SNAP_REMOVE:
-    if (!imgname) {
-      cerr << "rbd: snap remove requires image name" << std::endl;
-      return EINVAL;
-    }
     r = do_remove_snap(image, snapname);
     if (r < 0) {
       if (r == -EBUSY) {
@@ -3719,10 +3704,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     break;
 
   case OPT_SNAP_PURGE:
-    if (!imgname) {
-      cerr << "rbd: snap purge requires image name" << std::endl;
-      return EINVAL;
-    }
     r = do_purge_snaps(image);
     if (r < 0) {
       cerr << "rbd: removing snaps failed: " << cpp_strerror(-r) << std::endl;
@@ -3731,10 +3712,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     break;
 
   case OPT_SNAP_PROTECT:
-    if (!imgname) {
-      cerr << "rbd: snap protect requires image name" << std::endl;
-      return EINVAL;
-    }
     r = do_protect_snap(image, snapname);
     if (r < 0) {
       cerr << "rbd: protecting snap failed: " << cpp_strerror(-r) << std::endl;
@@ -3743,10 +3720,6 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     break;
 
   case OPT_SNAP_UNPROTECT:
-    if (!imgname) {
-      cerr << "rbd: snap unprotect requires image name" << std::endl;
-      return EINVAL;
-    }
     r = do_unprotect_snap(image, snapname);
     if (r < 0) {
       cerr << "rbd: unprotecting snap failed: " << cpp_strerror(-r)

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -1,82 +1,88 @@
   $ rbd --help
   usage: rbd [-n <auth user>] [OPTIONS] <cmd> ...
   where 'pool' is a rados pool name (default is 'rbd') and 'cmd' is one of:
-    (ls | list) [-l | --long ] [pool-name] list rbd images
+    (ls | list) [-l | --long ] [pool-name]      list rbd images
                                                 (-l includes snapshots/clones)
     (du | disk-usage) [--image <name>] [pool-name]
                                                 show pool image disk usage stats
-    info <image-name>                           show information about image size,
+    info <image-spec> | <snap-spec>             show information about image size,
                                                 striping, etc.
     create [--order <bits>] [--image-features <features>] [--image-shared]
-           --size <M/G/T> <image-name>          create an empty image
+           --size <M/G/T> <image-spec>          create an empty image
     clone [--order <bits>] [--image-features <features>] [--image-shared]
-          <parentsnap> <clonename>              clone a snapshot into a COW
+           <parent-snap-spec> <child-image-spec>
+                                                clone a snapshot into a COW
                                                 child image
-    children <snap-name>                        display children of snapshot
-    flatten <image-name>                        fill clone with parent data
+    children <snap-spec>                        display children of snapshot
+    flatten <image-spec>                        fill clone with parent data
                                                 (make it independent)
-    resize --size <M/G/T> <image-name>          resize (expand or contract) image
-    rm <image-name>                             delete an image
-    export <image-name> <path>                  export image to file
+    resize --size <M/G/T> <image-spec>          resize (expand or contract) image
+    rm <image-spec>                             delete an image
+    export (<image-spec> | <snap-spec>) <path>  export image to file
                                                 "-" for stdout
     import [--image-features <features>] [--image-shared]
-           <path> <image-name>                  import image from file (dest
+           <path> <image-spec>                  import image from file (dest
                                                 defaults as the filename part
                                                 of file). "-" for stdin
-    diff [--from-snap <snap-name>] [--object-extents] <image-name>
-                                                print extents that differ since
+    diff [--from-snap <snap-name>] [--object-extents]
+           <image-spec> | <snap-spec>           print extents that differ since
                                                 a previous snap, or image creation
-    export-diff [--from-snap <snap-name>] [--object-extents] <image-name> <path>
-                                                export an incremental diff to
+    export-diff [--from-snap <snap-name>] [--object-extents]
+           (<image-spec> | <snap-spec>) <path>  export an incremental diff to
                                                 path, or "-" for stdout
     merge-diff <diff1> <diff2> <path>           merge <diff1> and <diff2> into
                                                 <path>, <diff1> could be "-"
                                                 for stdin, and <path> could be "-"
                                                 for stdout
-    import-diff <path> <image-name>             import an incremental diff from
+    import-diff <path> <image-spec>             import an incremental diff from
                                                 path or "-" for stdin
-    (cp | copy) <src> <dest>                    copy src image to dest
-    (mv | rename) <src> <dest>                  rename src image to dest
-    image-meta list <image-name>                image metadata list keys with values
-    image-meta get <image-name> <key>           image metadata get the value associated with the key
-    image-meta set <image-name> <key> <value>   image metadata set key with value
-    image-meta remove <image-name> <key>        image metadata remove the key and value associated
-    object-map rebuild <image-name>             rebuild an invalid object map
-    snap ls <image-name>                        dump list of image snapshots
-    snap create <snap-name>                     create a snapshot
-    snap rollback <snap-name>                   rollback image to snapshot
-    snap rm <snap-name>                         deletes a snapshot
-    snap purge <image-name>                     deletes all snapshots
-    snap protect <snap-name>                    prevent a snapshot from being deleted
-    snap unprotect <snap-name>                  allow a snapshot to be deleted
-    watch <image-name>                          watch events on image
-    status <image-name>                         show the status of this image
-    map <image-name>                            map image to a block device
+    (cp | copy) (<src-image-spec> | <src-snap-spec>) <dest-image-spec>
+                                                copy src image to dest
+    (mv | rename) <src-image-spec> <dest-image-spec>
+                                                rename src image to dest
+    image-meta list <image-spec>                image metadata list keys with values
+    image-meta get <image-spec> <key>           image metadata get the value associated with the key
+    image-meta set <image-spec> <key> <value>   image metadata set key with value
+    image-meta remove <image-spec> <key>        image metadata remove the key and value associated
+    object-map rebuild <image-spec> | <snap-spec>
+                                                rebuild an invalid object map
+    snap ls <image-spec>                        dump list of image snapshots
+    snap create <snap-spec>                     create a snapshot
+    snap rollback <snap-spec>                   rollback image to snapshot
+    snap rm <snap-spec>                         deletes a snapshot
+    snap purge <image-spec>                     deletes all snapshots
+    snap protect <snap-spec>                    prevent a snapshot from being deleted
+    snap unprotect <snap-spec>                  allow a snapshot to be deleted
+    watch <image-spec>                          watch events on image
+    status <image-spec>                         show the status of this image
+    map <image-spec> | <snap-spec>              map image to a block device
                                                 using the kernel
-    unmap <image-name> | <device>               unmap a rbd device that was
+    unmap <image-spec> | <snap-spec> | <device> unmap a rbd device that was
                                                 mapped by the kernel
     showmapped                                  show the rbd images mapped
                                                 by the kernel
-    feature disable <image-name> <feature>      disable the specified image feature
-    feature enable <image-name> <feature>       enable the specified image feature
-    lock list <image-name>                      show locks held on an image
-    lock add <image-name> <id> [--shared <tag>] take a lock called id on an image
-    lock remove <image-name> <id> <locker>      release a lock on an image
-    bench-write <image-name>                    simple write benchmark
+    feature disable <image-spec> <feature>      disable the specified image feature
+    feature enable <image-spec> <feature>       enable the specified image feature
+    lock list <image-spec>                      show locks held on an image
+    lock add <image-spec> <id> [--shared <tag>] take a lock called id on an image
+    lock remove <image-spec> <id> <locker>      release a lock on an image
+    bench-write <image-spec>                    simple write benchmark
                    --io-size <bytes>              write size
                    --io-threads <num>             ios in flight
                    --io-total <bytes>             total bytes to write
                    --io-pattern <seq|rand>        write pattern
   
-  <image-name>, <snap-name> are [pool/]name[@snap], or you may specify
-  individual pieces of names with -p/--pool, --image, and/or --snap.
+  <image-spec> is [<pool-name>]/<image-name>,
+  <snap-spec> is [<pool-name>]/<image-name>@<snap-name>,
+  or you may specify individual pieces of names with -p/--pool <pool-name>,
+  --image <image-name> and/or --snap <snap-name>.
   
   Other input options:
-    -p, --pool <pool>                  source pool name
+    -p, --pool <pool-name>             source pool name
+    --dest-pool <pool-name>            destination pool name
     --image <image-name>               image name
-    --dest <image-name>                destination [pool and] image name
+    --dest <image-name>                destination image name
     --snap <snap-name>                 snapshot name
-    --dest-pool <name>                 destination pool name
     --path <path-name>                 path name for import/export
     -s, --size <size in M/G/T>         size of image for create and resize
     --order <bits>                     the object size in bits; object size will be

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -28,10 +28,10 @@
                                                 "rbd/$(basename <path>)" is
                                                 assumed for <image-spec> if
                                                 omitted
-    diff [--from-snap <snap-name>] [--object-extents]
+    diff [--from-snap <snap-name>] [--whole-object]
            <image-spec> | <snap-spec>           print extents that differ since
                                                 a previous snap, or image creation
-    export-diff [--from-snap <snap-name>] [--object-extents]
+    export-diff [--from-snap <snap-name>] [--whole-object]
            (<image-spec> | <snap-spec>) <path>  export an incremental diff to
                                                 path, or "-" for stdout
     merge-diff <diff1> <diff2> <path>           merge <diff1> and <diff2> into

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -3,8 +3,9 @@
   where 'pool' is a rados pool name (default is 'rbd') and 'cmd' is one of:
     (ls | list) [-l | --long ] [pool-name]      list rbd images
                                                 (-l includes snapshots/clones)
-    (du | disk-usage) [--image <name>] [pool-name]
-                                                show pool image disk usage stats
+    (du | disk-usage) [<image-spec> | <snap-spec>]
+                                                show disk usage stats for pool,
+                                                image or snapshot
     info <image-spec> | <snap-spec>             show information about image size,
                                                 striping, etc.
     create [--order <bits>] [--image-features <features>] [--image-shared]

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -18,12 +18,15 @@
                                                 (make it independent)
     resize --size <M/G/T> <image-spec>          resize (expand or contract) image
     rm <image-spec>                             delete an image
-    export (<image-spec> | <snap-spec>) <path>  export image to file
+    export (<image-spec> | <snap-spec>) [<path>]
+                                                export image to file
                                                 "-" for stdout
     import [--image-features <features>] [--image-shared]
-           <path> <image-spec>                  import image from file (dest
-                                                defaults as the filename part
-                                                of file). "-" for stdin
+           <path> [<image-spec>]                import image from file
+                                                "-" for stdin
+                                                "rbd/$(basename <path>)" is
+                                                assumed for <image-spec> if
+                                                omitted
     diff [--from-snap <snap-name>] [--object-extents]
            <image-spec> | <snap-spec>           print extents that differ since
                                                 a previous snap, or image creation

--- a/src/test/cli/rbd/invalid-snap-usage.t
+++ b/src/test/cli/rbd/invalid-snap-usage.t
@@ -34,3 +34,19 @@
   $ rbd lock remove --snap=snap img id client.1234
   rbd: snapname specified for a command that doesn't use it
   [1]
+
+  $ rbd clone foo@snap bar@snap
+  rbd: destination snapname specified for a command that doesn't use it
+  [1]
+  $ rbd import /bin/ls ls@snap
+  rbd: destination snapname specified for a command that doesn't use it
+  [1]
+  $ rbd cp foo bar@snap
+  rbd: destination snapname specified for a command that doesn't use it
+  [1]
+  $ rbd cp foo@snap bar@snap
+  rbd: destination snapname specified for a command that doesn't use it
+  [1]
+  $ rbd mv foo bar@snap
+  rbd: destination snapname specified for a command that doesn't use it
+  [1]

--- a/src/test/cli/rbd/invalid-snap-usage.t
+++ b/src/test/cli/rbd/invalid-snap-usage.t
@@ -1,37 +1,94 @@
-  $ rbd resize --snap=snap1 img
+  $ rbd create foo@snap
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd resize img@snap
+  $ rbd flatten foo@snap
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd import --snap=snap1 /bin/ls ls
+  $ rbd resize foo@snap
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd create --snap=snap img
+  $ rbd rm foo@snap
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd rm --snap=snap img
+  $ rbd import-diff /tmp/diff foo@snap
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd rename --snap=snap img
+  $ rbd mv foo@snap
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd ls --snap=snap rbd
+  $ rbd mv foo@snap bar
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd snap ls --snap=snap img
+  $ rbd mv foo@snap bar@snap
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd watch --snap=snap img
+  $ rbd image-meta list foo@snap
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd lock list --snap=snap img
+  $ rbd image-meta get foo@snap
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd lock add --snap=snap img id
+  $ rbd image-meta get foo@snap key
   rbd: snapname specified for a command that doesn't use it
   [1]
-  $ rbd lock remove --snap=snap img id client.1234
+  $ rbd image-meta set foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd image-meta set foo@snap key
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd image-meta set foo@snap key val
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd image-meta remove foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd image-meta remove foo@snap key
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd snap ls foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd snap purge foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd watch foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd status foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd feature disable foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd feature disable foo@snap layering
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd feature enable foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd feature enable foo@snap layering
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd lock list foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd lock add foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd lock add foo@snap id
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd lock remove foo@snap
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd lock remove foo@snap id
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd lock remove foo@snap id client.1234
+  rbd: snapname specified for a command that doesn't use it
+  [1]
+  $ rbd bench-write foo@snap
   rbd: snapname specified for a command that doesn't use it
   [1]
 

--- a/src/test/cli/rbd/not-enough-args.t
+++ b/src/test/cli/rbd/not-enough-args.t
@@ -4,9 +4,6 @@
   $ rbd unmap
   rbd: unmap requires either image name or device path
   [1]
-  $ rbd clone foo@snap bar@snap
-  rbd: cannot clone to a snapshot
-  [1]
   $ rbd cp foo
   rbd: destination image name was not specified
   [1]

--- a/src/test/cli/rbd/not-enough-args.t
+++ b/src/test/cli/rbd/not-enough-args.t
@@ -1,30 +1,192 @@
+  $ rbd info
+  rbd: image name was not specified
+  [1]
+  $ rbd create
+  rbd: image name was not specified
+  [1]
+  $ rbd clone
+  rbd: image name was not specified
+  [1]
+  $ rbd clone foo
+  rbd: snap name was not specified
+  [1]
+  $ rbd clone foo@snap
+  rbd: destination image name was not specified
+  [1]
+  $ rbd clone foo bar
+  rbd: snap name was not specified
+  [1]
+  $ rbd clone foo bar@snap
+  rbd: snap name was not specified
+  [1]
+  $ rbd children
+  rbd: image name was not specified
+  [1]
+  $ rbd children foo
+  rbd: snap name was not specified
+  [1]
+  $ rbd flatten
+  rbd: image name was not specified
+  [1]
+  $ rbd resize
+  rbd: image name was not specified
+  [1]
+  $ rbd rm
+  rbd: image name was not specified
+  [1]
+  $ rbd export
+  rbd: image name was not specified
+  [1]
+  $ rbd import
+  rbd: path was not specified
+  [1]
+  $ rbd diff
+  rbd: image name was not specified
+  [1]
+  $ rbd export-diff
+  rbd: image name was not specified
+  [1]
+  $ rbd export-diff foo
+  rbd: path was not specified
+  [1]
+  $ rbd export-diff foo@snap
+  rbd: path was not specified
+  [1]
+  $ rbd merge-diff
+  rbd: first diff was not specified
+  [1]
+  $ rbd merge-diff /tmp/diff1
+  rbd: second diff was not specified
+  [1]
+  $ rbd merge-diff /tmp/diff1 /tmp/diff2
+  rbd: path was not specified
+  [1]
+  $ rbd import-diff
+  rbd: path was not specified
+  [1]
+  $ rbd import-diff /tmp/diff
+  rbd: image name was not specified
+  [1]
+  $ rbd cp
+  rbd: image name was not specified
+  [1]
+  $ rbd cp foo
+  rbd: destination image name was not specified
+  [1]
+  $ rbd cp foo@snap
+  rbd: destination image name was not specified
+  [1]
+  $ rbd mv
+  rbd: image name was not specified
+  [1]
+  $ rbd mv foo
+  rbd: destination image name was not specified
+  [1]
+  $ rbd image-meta list
+  rbd: image name was not specified
+  [1]
+  $ rbd image-meta get
+  rbd: image name was not specified
+  [1]
+  $ rbd image-meta get foo
+  rbd: metadata key was not specified
+  [1]
+  $ rbd image-meta set
+  rbd: image name was not specified
+  [1]
+  $ rbd image-meta set foo
+  rbd: metadata key was not specified
+  [1]
+  $ rbd image-meta set foo key
+  rbd: metadata value was not specified
+  [1]
+  $ rbd image-meta remove
+  rbd: image name was not specified
+  [1]
+  $ rbd image-meta remove foo
+  rbd: metadata key was not specified
+  [1]
+  $ rbd object-map rebuild
+  rbd: image name was not specified
+  [1]
+  $ rbd snap ls
+  rbd: image name was not specified
+  [1]
+  $ rbd snap create
+  rbd: image name was not specified
+  [1]
+  $ rbd snap create foo
+  rbd: snap name was not specified
+  [1]
+  $ rbd snap rollback
+  rbd: image name was not specified
+  [1]
+  $ rbd snap rollback foo
+  rbd: snap name was not specified
+  [1]
+  $ rbd snap rm
+  rbd: image name was not specified
+  [1]
+  $ rbd snap rm foo
+  rbd: snap name was not specified
+  [1]
+  $ rbd snap purge
+  rbd: image name was not specified
+  [1]
+  $ rbd snap protect
+  rbd: image name was not specified
+  [1]
+  $ rbd snap protect foo
+  rbd: snap name was not specified
+  [1]
+  $ rbd snap unprotect
+  rbd: image name was not specified
+  [1]
+  $ rbd snap unprotect foo
+  rbd: snap name was not specified
+  [1]
+  $ rbd watch
+  rbd: image name was not specified
+  [1]
+  $ rbd status
+  rbd: image name was not specified
+  [1]
   $ rbd map
   rbd: image name was not specified
   [1]
   $ rbd unmap
   rbd: unmap requires either image name or device path
   [1]
-  $ rbd cp foo
-  rbd: destination image name was not specified
+  $ rbd feature disable
+  rbd: image name was not specified
   [1]
-  $ rbd cp foo@bar
-  rbd: destination image name was not specified
+  $ rbd feature disable foo
+  rbd: at least one feature name must be specified
   [1]
-  $ rbd copy foo
-  rbd: destination image name was not specified
+  $ rbd feature enable
+  rbd: image name was not specified
   [1]
-  $ rbd copy foo@bar
-  rbd: destination image name was not specified
+  $ rbd feature enable foo
+  rbd: at least one feature name must be specified
   [1]
-  $ rbd mv foo
-  rbd: destination image name was not specified
+  $ rbd lock list
+  rbd: image name was not specified
   [1]
-  $ rbd rename foo
-  rbd: destination image name was not specified
+  $ rbd lock add
+  rbd: image name was not specified
   [1]
-  $ rbd clone foo@bar
-  rbd: destination image name was not specified
+  $ rbd lock add foo
+  rbd: lock id was not specified
   [1]
-  $ rbd clone foo
-  rbd: snap name was not specified
+  $ rbd lock remove
+  rbd: image name was not specified
+  [1]
+  $ rbd lock remove foo
+  rbd: lock id was not specified
+  [1]
+  $ rbd lock remove foo id
+  rbd: locker was not specified
+  [1]
+  $ rbd bench-write
+  rbd: image name was not specified
   [1]


### PR DESCRIPTION
- more precise help and man page: distinguish between commands that take image, snap, or either image or snap
- assorted arg parsing fixes for various commands (may not be complete, just what I spotted while reviewing #5034)
- expanded not-enough-args and invalid-snap-usage cli tests
- new du syntax
- rename --object-extents to --whole-objects

The last two change rbd cli syntax, which has made it to a dev v9.0.2, so this is against next.