### PR TITLE
Anotate all the .s files

### DIFF
--- a/src/erasure-code/isa/isa-l/erasure_code/ec_multibinary.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/ec_multibinary.asm.s
@@ -402,3 +402,5 @@ slversion gf_vect_mul,			00,   02,  0134
 slversion ec_encode_data_update,	00,   02,  0212
 slversion gf_vect_dot_prod,		00,   02,  0138
 slversion gf_vect_mad,			00,   01,  0213
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx.asm.s
@@ -341,3 +341,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_2vect_dot_prod_avx, 02,  04,  0191
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx2.asm.s
@@ -360,3 +360,5 @@ global %1_slver
 %endmacro
 ;;;       func                   core, ver, snum
 slversion gf_2vect_dot_prod_avx2, 04,  04,  0196
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_sse.asm.s
@@ -343,3 +343,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_2vect_dot_prod_sse, 00,  03,  0062
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_avx.asm.s
@@ -240,3 +240,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_2vect_mad_avx, 02,  00,  0204
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_avx2.asm.s
@@ -251,3 +251,5 @@ global %1_slver
 %endmacro
 ;;;       func              core, ver, snum
 slversion gf_2vect_mad_avx2, 04,  00,  0205
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_sse.asm.s
@@ -243,3 +243,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_2vect_mad_sse, 00,  00,  0203
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx.asm.s
@@ -381,3 +381,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_3vect_dot_prod_avx, 02,  04,  0192
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx2.asm.s
@@ -401,3 +401,5 @@ global %1_slver
 %endmacro
 ;;;       func                   core, ver, snum
 slversion gf_3vect_dot_prod_avx2, 04,  04,  0197
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_sse.asm.s
@@ -382,3 +382,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_3vect_dot_prod_sse, 00,  05,  0063
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_avx.asm.s
@@ -292,3 +292,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_3vect_mad_avx, 02,  00,  0207
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_avx2.asm.s
@@ -321,3 +321,5 @@ global %1_slver
 %endmacro
 ;;;       func              core, ver, snum
 slversion gf_3vect_mad_avx2, 04,  00,  0208
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_sse.asm.s
@@ -302,3 +302,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_3vect_mad_sse, 00,  00,  0206
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx.asm.s
@@ -445,3 +445,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_4vect_dot_prod_avx, 02,  04,  0193
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx2.asm.s
@@ -464,3 +464,5 @@ global %1_slver
 %endmacro
 ;;;       func                   core, ver, snum
 slversion gf_4vect_dot_prod_avx2, 04,  04,  0198
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_sse.asm.s
@@ -447,3 +447,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_4vect_dot_prod_sse, 00,  05,  0064
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_avx.asm.s
@@ -341,3 +341,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_4vect_mad_avx, 02,  00,  020a
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_avx2.asm.s
@@ -346,3 +346,5 @@ global %1_slver
 %endmacro
 ;;;       func              core, ver, snum
 slversion gf_4vect_mad_avx2, 04,  00,  020b
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_sse.asm.s
@@ -346,3 +346,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_4vect_mad_sse, 00,  00,  0209
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx.asm.s
@@ -307,3 +307,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_5vect_dot_prod_avx, 02,  03,  0194
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx2.asm.s
@@ -319,3 +319,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_5vect_dot_prod_avx2, 04,  03,  0199
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_sse.asm.s
@@ -308,3 +308,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_5vect_dot_prod_sse, 00,  04,  0065
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_avx.asm.s
@@ -369,3 +369,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_5vect_mad_avx, 02,  00,  020d
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_avx2.asm.s
@@ -367,3 +367,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_5vect_mad_avx2, 04,  00,  020e
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_sse.asm.s
@@ -377,3 +377,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_5vect_mad_sse, 00,  00,  020c
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx.asm.s
@@ -319,3 +319,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_6vect_dot_prod_avx, 02,  03,  0195
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx2.asm.s
@@ -330,3 +330,5 @@ global %1_slver
 %endmacro
 ;;;       func                   core, ver, snum
 slversion gf_6vect_dot_prod_avx2, 04,  03,  019a
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_sse.asm.s
@@ -319,3 +319,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_6vect_dot_prod_sse, 00,  04,  0066
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_avx.asm.s
@@ -398,3 +398,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_6vect_mad_avx, 02,  00,  0210
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_avx2.asm.s
@@ -405,3 +405,5 @@ global %1_slver
 %endmacro
 ;;;       func              core, ver, snum
 slversion gf_6vect_mad_avx2, 04,  00,  0211
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_sse.asm.s
@@ -410,3 +410,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_6vect_mad_sse, 00,  00,  020f
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx.asm.s
@@ -275,3 +275,5 @@ global %1_slver
 %endmacro
 ;;;       func                 core, ver, snum
 slversion gf_vect_dot_prod_avx, 02,  04,  0061
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm.s
@@ -284,3 +284,5 @@ global %1_slver
 %endmacro
 ;;;       func                  core, ver, snum
 slversion gf_vect_dot_prod_avx2, 04,  04,  0190
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_sse.asm.s
@@ -275,3 +275,5 @@ global %1_slver
 %endmacro
 ;;;       func                 core, ver, snum
 slversion gf_vect_dot_prod_sse, 00,  04,  0060
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_avx.asm.s
@@ -200,3 +200,5 @@ global %1_slver
 %endmacro
 ;;;       func            core, ver, snum
 slversion gf_vect_mad_avx, 02,  00,  0201
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_avx2.asm.s
@@ -207,3 +207,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_vect_mad_avx2, 04,  00,  0202
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_sse.asm.s
@@ -201,3 +201,5 @@ global %1_slver
 %endmacro
 ;;;       func            core, ver, snum
 slversion gf_vect_mad_sse, 00,  00,  0200
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_avx.asm.s
@@ -168,3 +168,5 @@ global %1_slver
 %endmacro
 ;;;       func             core, ver, snum
 slversion gf_vect_mul_avx, 01,   02,  0036
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_sse.asm.s
@@ -174,3 +174,5 @@ global %1_slver
 %endmacro
 ;;;       func        core, ver, snum
 slversion gf_vect_mul_sse, 00,   02,  0034
+; inform linker that this doesn't require executable stack
+section .note.GNU-stack noalloc noexec nowrite progbits


### PR DESCRIPTION
Recent update to erasure code library in 59aa6700 caused a regression
where .s files are no longer properly annotated and yasm sets the exec
stack for them. This patch brings back the annotations as was done before
by Dan Mick, see Bug #10114.

Looking at the upstream files (https://01.org/intel%C2%AE-storage-acceleration-library-open-source-version/downloads), this might have already been fixed in the upstream release of erasure code library.

@zhouyuan: You seemed to have done the update, can you please confirm that this is indeed fixed in 2.14?