### PR TITLE
mon: LogMonitor: handle boolean options consistently

### DIFF
--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -69,10 +69,7 @@ private:
     string expand_channel_meta(const string &input,
                                const string &change_to);
 
-    bool do_log_to_syslog(const string &channel) {
-      return (get_str_map_key(log_to_syslog, channel,
-                              &CLOG_CONFIG_DEFAULT_KEY) == "true");
-    }
+    bool do_log_to_syslog(const string &channel);
 
     string get_facility(const string &channel) {
       return get_str_map_key(syslog_facility, channel,


### PR DESCRIPTION
'mon_cluster_log_to_syslog' gets a string of key/value pairs, values
in the pair being booleans, and keys being optional (one can simply
specify the value). However, we weren't being consistent with the
boolean behavior when handling option values. e.g., the user expects
'1' and '0' to mean 'true' and 'false' respectively, and expects
'mon_cluster_log_to_syslog' to understand both '1' and '0', alongside
with 'true' and 'false'.

All values not 'true' or '1' will be considered 'false'.

Fixes: #12325

Signed-off-by: Joao Eduardo Luis <joao@suse.de>