### PR TITLE
mon: MonitorDBStore: get_next_key() only if prefix matches

### DIFF
--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -448,11 +448,13 @@ class MonitorDBStore
 
     virtual pair<string,string> get_next_key() {
       assert(iter->valid());
-      pair<string,string> r = iter->raw_key();
-      do {
-	iter->next();
-      } while (iter->valid() && sync_prefixes.count(iter->raw_key().first) == 0);
-      return r;
+
+      for (; iter->valid(); iter->next()) {
+        pair<string,string> r = iter->raw_key();
+        if (sync_prefixes.count(r.first) > 0)
+          return r;
+      }
+      return pair<string,string>();
     }
 
     virtual bool _is_valid() {

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -451,8 +451,10 @@ class MonitorDBStore
 
       for (; iter->valid(); iter->next()) {
         pair<string,string> r = iter->raw_key();
-        if (sync_prefixes.count(r.first) > 0)
+        if (sync_prefixes.count(r.first) > 0) {
+          iter->next();
           return r;
+        }
       }
       return pair<string,string>();
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/12483