### PR TITLE
Wip user specified flushing

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -568,6 +568,8 @@ OPTION(osd_tier_default_cache_hit_set_count, OPT_INT, 4)
 OPTION(osd_tier_default_cache_hit_set_period, OPT_INT, 1200)
 OPTION(osd_tier_default_cache_hit_set_type, OPT_STR, "bloom")
 OPTION(osd_tier_default_cache_min_read_recency_for_promote, OPT_INT, 1) // number of recent HitSets the object must appear in to be promoted (on read)
+OPTION(osd_tier_schedule_flush_start, OPT_STR, "0:0") //hour:munite, user defined schedule_flush start time
+OPTION(osd_tier_schedule_flush_end, OPT_STR, "0:0") //schedule_flush end time
 
 OPTION(osd_map_dedup, OPT_BOOL, true)
 OPTION(osd_map_max_advance, OPT_INT, 200) // make this < cache_size!

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -508,6 +508,7 @@ void OSDService::agent_entry()
 {
   dout(10) << __func__ << " start" << dendl;
   agent_lock.Lock();
+  agent_schedule_flush_setup();
 
   while (!agent_stop_flag) {
     if (agent_queue.empty()) {
@@ -575,6 +576,7 @@ void OSDService::agent_stop()
       assert(0 == "agent queue not empty");
     }
 
+    agent_in_schedule_time = false;
     agent_stop_flag = true;
     agent_cond.Signal();
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -226,7 +226,7 @@ OSDService::OSDService(OSD *osd) :
   agent_in_schedule_time(false),
   agent_schedule_flush_version(0),
   agent_timer_lock("OSD::agent_timer_lock"),
-  agent_timer(osd->client_messenger->cct, agent_timer_lock),
+  agent_timer(osd->client_messenger->cct, agent_timer_lock, false),
   objecter(new Objecter(osd->client_messenger->cct, osd->objecter_messenger, osd->monc, NULL, 0, 0)),
   objecter_finisher(osd->client_messenger->cct),
   watch_lock("OSD::watch_lock"),
@@ -617,6 +617,15 @@ void OSDService::agent_schedule_flush_start()
     dout(10) << p->first.pgid << " agent_state reset" << dendl;
     p->second->unlock();
   }
+}
+
+//on schedule_flush ending, setup the next period's schedule jobs.
+void OSDService::agent_schedule_flush_end()
+{
+  agent_in_schedule_time = false;
+  dout(10) << __func__ << " END "
+           << " agent_in_schedule_time " << agent_in_schedule_time << dendl;
+  agent_schedule_flush_setup();
 }
 
 void OSDService::agent_schedule_flush_setup()

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -603,6 +603,22 @@ public:
   }
 };
 
+void OSDService::agent_schedule_flush_start()
+{
+  agent_in_schedule_time = true;
+  dout(10) << __func__ << " START "
+           << " agent_in_schedule_time " << agent_in_schedule_time << dendl;
+
+  RWLock::RLocker rl(osd->pg_map_lock);
+  for (ceph::unordered_map<spg_t, PG*>::iterator p = osd->pg_map.begin();
+        p != osd->pg_map.end(); ++p) {
+    p->second->lock();
+    p->second->agent_setup();
+    dout(10) << p->first.pgid << " agent_state reset" << dendl;
+    p->second->unlock();
+  }
+}
+
 void OSDService::agent_schedule_flush_setup()
 {
   dout(10) << __func__ << " start" << dendl;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -658,11 +658,16 @@ public:
     }
   } agent_thread;
   bool agent_stop_flag;
-  Mutex agent_timer_lock;
-  SafeTimer agent_timer;
-
   void agent_entry();
   void agent_stop();
+
+  bool agent_in_schedule_time;
+  int agent_schedule_flush_version;
+  Mutex agent_timer_lock;
+  SafeTimer agent_timer;
+  void agent_schedule_flush_setup();
+  void agent_schedule_flush_start();  //start schedule flush work
+  void agent_schedule_flush_end();  //finish schedule flush work
 
   void _enqueue(PG *pg, uint64_t priority) {
     if (!agent_queue.empty() &&

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2283,6 +2283,7 @@ public:
   virtual void agent_delay() = 0;
   virtual void agent_clear() = 0;
   virtual void agent_choose_mode_restart() = 0;
+  virtual void agent_setup() = 0;
 };
 
 ostream& operator<<(ostream& out, const PG& pg);

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -11090,7 +11090,8 @@ bool ReplicatedPG::agent_choose_mode(bool restart, OpRequestRef op)
   if (info.stats.stats_invalid) {
     // idle; stats can't be trusted until we scrub.
     dout(20) << __func__ << " stats invalid (post-split), idle" << dendl;
-  } else if (dirty_micro > flush_high_target) {
+  } else if (dirty_micro > flush_high_target ||
+             (osd->agent_in_schedule_time && dirty_micro > 0)) {
     flush_mode = TierAgentState::FLUSH_MODE_HIGH;
   } else if (dirty_micro > flush_target) {
     flush_mode = TierAgentState::FLUSH_MODE_LOW;


### PR DESCRIPTION
This patch implements user specified cache flushing for cache tiering. In 
many use cases, the user traffic is high in only some fixed time, fox example,
work hour. In those cases, it is desirable that the flushing job could be scheduled 
in the idle time, and do as much as possible, to reduce the bandwidth contention
with user traffic.

Signed-off-by: Mingxin Liu <mingxinliu@ubuntukylin.com>
Reviewed-by: Li Wang <liwang@ubuntukylin.com>
Suggested-by: Xinze Chi <xmdxcxz@gmail.com>