### PR TITLE
doc:modified librados-intro.rst an error of document representation

### DIFF
--- a/doc/rados/api/librados-intro.rst
+++ b/doc/rados/api/librados-intro.rst
@@ -72,7 +72,7 @@ distributions, execute the following::
 
 	sudo apt-get install python-rados
 
-To install ``librados`` development support files for C/C++ on RHEL/CentOS
+To install ``librados`` development support files for Python on RHEL/CentOS
 distributions, execute the following::
 
 	sudo yum install python-rados


### PR DESCRIPTION
An error of document representation
In doc/API,FILE librados-intro.rst
test fix:
before:
To install ``librados`` development support files for c/c++ on RHEL/CentOS
after:
To install ``librados`` development support files for Python on RHEL/CentOS


Signed-off-by: x11507 <xu.donghai@h3c.com>