### PR TITLE
error in ext_mime_map_init() when /etc/mime.types is missing

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -165,6 +165,7 @@ Requires:	apache2-mod_fcgid
 %else
 BuildRequires:	expat-devel
 BuildRequires:	fcgi-devel
+Requires:	mailcap
 %endif
 %description radosgw
 This package is an S3 HTTP REST gateway for the RADOS object store. It

--- a/debian/control
+++ b/debian/control
@@ -421,7 +421,8 @@ Description: Ceph distributed file system client library (development files)
 
 Package: radosgw
 Architecture: linux-any
-Depends: ceph-common (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}
+Depends: ceph-common (= ${binary:Version}), mime-support,
+         ${misc:Depends}, ${shlibs:Depends}
 Description: REST gateway for RADOS distributed object store
  RADOS is a distributed object store used by the Ceph distributed
  storage system.  This package provides a REST gateway to the


### PR DESCRIPTION
http://tracker.ceph.com/issues/12501