### PR TITLE
rgw/logrotate.conf calls service with wrong init script name

### DIFF
--- a/src/rgw/logrotate.conf
+++ b/src/rgw/logrotate.conf
@@ -7,7 +7,7 @@
         if which invoke-rc.d > /dev/null 2>&1 && [ -x `which invoke-rc.d` ]; then
             invoke-rc.d radosgw reload >/dev/null
         elif which service > /dev/null 2>&1 && [ -x `which service` ]; then
-            service radosgw reload >/dev/null
+            service ceph-radosgw reload >/dev/null
         fi
         # Possibly reload twice, but depending on ceph.conf the reload above may be a no-op
         if which initctl > /dev/null 2>&1 && [ -x `which initctl` ]; then


### PR DESCRIPTION
http://tracker.ceph.com/issues/12503