### PR TITLE
OSD: Add lightweight ShardedOpWQ statistics for worker threads

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1632,6 +1632,31 @@ public:
   }
 };
 
+void OSD::ShardedOpWQ::dump_worker_stats(Formatter *f, bool clear)
+{
+  /* Stats & Clearing are 'fuzzy' */
+  f->open_object_section("shard_stats");
+  f->dump_int("num_shards", num_shards);
+  f->open_array_section("shards");
+  for (unsigned int s = 0; s < num_shards; s++)
+  {
+    ShardData *sdata = shard_list[s];
+    f->open_object_section("shard");
+    
+    f->dump_int("num_dispatches", sdata->num_dispatches);
+    f->dump_int("ql_accum", sdata->ql_accum);
+    f->dump_int("num_stalls", sdata->num_stalls);
+
+    if (clear) { 
+      sdata->num_dispatches = sdata->ql_accum = sdata->num_stalls = 0;
+    }
+
+    f->close_section(); /* shard */
+  }
+  f->close_section(); /* shard array */
+  f->close_section(); /* shard stats */
+}
+
 bool OSD::asok_command(string command, cmdmap_t& cmdmap, string format,
 		       ostream& ss)
 {
@@ -1664,6 +1689,10 @@ bool OSD::asok_command(string command, cmdmap_t& cmdmap, string format,
     } else {
       op_tracker.dump_historic_ops(f);
     }
+  } else if (command == "dump_shard_stats") { 
+      op_shardedwq.dump_worker_stats(f, false);
+  } else if (command == "dump_shard_stats_and_clear") { 
+      op_shardedwq.dump_worker_stats(f, true);
   } else if (command == "dump_op_pq_state") {
     f->open_object_section("pq");
     op_shardedwq.dump(f);
@@ -1982,6 +2011,14 @@ void OSD::final_init()
   r = admin_socket->register_command("dump_historic_ops", "dump_historic_ops",
 				     asok_hook,
 				     "show slowest recent ops");
+  assert(r == 0);
+  r = admin_socket->register_command("dump_shard_stats", "dump_shard_stats",
+				     asok_hook,
+				     "dump shard worker stats");
+  assert(r == 0);
+  r = admin_socket->register_command("dump_shard_stats_and_clear", "dump_shard_stats_and_clear",
+				     asok_hook,
+				     "dump shard worker stats, clearing them after");
   assert(r == 0);
   r = admin_socket->register_command("dump_op_pq_state", "dump_op_pq_state",
 				     asok_hook,
@@ -8172,7 +8209,9 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb ) 
   ShardData* sdata = shard_list[shard_index];
   assert(NULL != sdata);
   sdata->sdata_op_ordering_lock.Lock();
+  sdata->num_dispatches++; 
   if (sdata->pqueue.empty()) {
+    sdata->num_stalls++; 
     sdata->sdata_op_ordering_lock.Unlock();
     osd->cct->get_heartbeat_map()->reset_timeout(hb, 4, 0);
     sdata->sdata_lock.Lock();
@@ -8184,7 +8223,9 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb ) 
       return;
     }
   }
+  sdata->ql_accum += sdata->pqueue.length(); 
   pair<PGRef, PGQueueable> item = sdata->pqueue.dequeue();
+  
   sdata->pg_for_processing[&*(item.first)].push_back(item.second);
   sdata->sdata_op_ordering_lock.Unlock();
   ThreadPool::TPHandle tp_handle(osd->cct, hb, timeout_interval, 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1689,9 +1689,9 @@ bool OSD::asok_command(string command, cmdmap_t& cmdmap, string format,
     } else {
       op_tracker.dump_historic_ops(f);
     }
-  } else if (command == "dump_shard_stats") { 
+  } else if (command == "dump_opwq_thread_stats") { 
       op_shardedwq.dump_worker_stats(f, false);
-  } else if (command == "dump_shard_stats_and_clear") { 
+  } else if (command == "dump_opwq_thread_stats_and_clear") { 
       op_shardedwq.dump_worker_stats(f, true);
   } else if (command == "dump_op_pq_state") {
     f->open_object_section("pq");
@@ -2012,13 +2012,13 @@ void OSD::final_init()
 				     asok_hook,
 				     "show slowest recent ops");
   assert(r == 0);
-  r = admin_socket->register_command("dump_shard_stats", "dump_shard_stats",
+  r = admin_socket->register_command("dump_opwq_thread_stats", "dump_opwq_thread_stats",
 				     asok_hook,
-				     "dump shard worker stats");
+				     "dump OpWQ thread worker stats");
   assert(r == 0);
-  r = admin_socket->register_command("dump_shard_stats_and_clear", "dump_shard_stats_and_clear",
+  r = admin_socket->register_command("dump_opwq_thread_stats_and_clear", "dump_opwq_thread_stats_and_clear",
 				     asok_hook,
-				     "dump shard worker stats, clearing them after");
+				     "dump OpWQ thread  worker stats, clearing them after");
   assert(r == 0);
   r = admin_socket->register_command("dump_op_pq_state", "dump_op_pq_state",
 				     asok_hook,
@@ -8223,8 +8223,8 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb ) 
       return;
     }
   }
-  sdata->ql_accum += sdata->pqueue.length(); 
   pair<PGRef, PGQueueable> item = sdata->pqueue.dequeue();
+  sdata->ql_accum += sdata->pqueue.empty() ? 1 : 2; 
   
   sdata->pg_for_processing[&*(item.first)].push_back(item.second);
   sdata->sdata_op_ordering_lock.Unlock();

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1575,12 +1575,16 @@ private:
       Cond sdata_cond;
       Mutex sdata_op_ordering_lock;
       map<PG*, list<PGQueueable> > pg_for_processing;
+      uint64_t num_dispatches;
+      uint64_t ql_accum;
+      uint64_t num_stalls;
       PrioritizedQueue< pair<PGRef, PGQueueable>, entity_inst_t> pqueue;
       ShardData(
 	string lock_name, string ordering_lock,
 	uint64_t max_tok_per_prio, uint64_t min_cost)
 	: sdata_lock(lock_name.c_str()),
 	  sdata_op_ordering_lock(ordering_lock.c_str()),
+	  num_dispatches(0), ql_accum(0), num_stalls(0),
 	  pqueue(max_tok_per_prio, min_cost) {}
     };
     
@@ -1617,6 +1621,8 @@ private:
     void _process(uint32_t thread_index, heartbeat_handle_d *hb);
     void _enqueue(pair <PGRef, PGQueueable> item);
     void _enqueue_front(pair <PGRef, PGQueueable> item);
+
+    void dump_worker_stats(Formatter *f, bool clear); 
       
     void return_waiting_threads() {
       for(uint32_t i = 0; i < num_shards; i++) {


### PR DESCRIPTION
Add lightweight statistics to the ShardedOpWQ worker threads for monitoring and benchmarking.
Each worker thread will track # times dispatched, # times stalled (sleep due to empty work
queue), and the length of the thread's work queue when it dispatches an op.  These stats are
accessible by the admin socket and will be viewable live with a companion utility in
Ceph/cbt utils.


Uses:
* Stats have been used for evaluation of the simple messenger changes (see PR 5211, graphed data). 
* Also presented in perf meeting 7/15/15.  Also see attached gnuplot data.
* Plan to use in evaluating OSD Worker thread to core affinity with various OSD backends.

Graphs from 7/15/15 perf meeting:
![nvme_qd16_iops_vs_runpct_shards](https://cloud.githubusercontent.com/assets/11448123/8947546/19fe4e54-3551-11e5-9f3b-694450e19b9c.png)
![nvme_qd32_iops_vs_runpct_shards](https://cloud.githubusercontent.com/assets/11448123/8947547/2302ff9a-3551-11e5-8f73-f164f2478d05.png)


Signed-off by: Stephen Blinick <stephen.l.blinick@intel.com>