### PR TITLE
rbd:If the image has any protected snaps,'snap purge image' will return failure without removing any snaps.

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -771,11 +771,6 @@ static int do_purge_snaps(librbd::Image& image)
 {
   MyProgressContext pc("Removing all snapshots");
   std::vector<librbd::snap_info_t> snaps;
-<<<<<<< HEAD
-=======
-  size_t isnapsSize = 0;
-  size_t j = 0;
->>>>>>> e74f469390a9de937534163c4527a42cb9013c0b
   bool is_protected = false;
   int r = image.snap_list(snaps);
   if (r < 0) {
@@ -783,7 +778,6 @@ static int do_purge_snaps(librbd::Image& image)
     return r;
   }
    
-<<<<<<< HEAD
   if (0 == snaps.size())
   {
 	return 0;
@@ -808,42 +802,10 @@ static int do_purge_snaps(librbd::Image& image)
       return r;
     }
     pc.update_progress(i + 1, snaps.size());
-=======
-  isnapsSize = snaps.size();
-  if (0 == isnapsSize)
-  {
-	return 0;
->>>>>>> e74f469390a9de937534163c4527a42cb9013c0b
   }
-  
-  for (size_t i = 0; i < isnapsSize; ++i) {
-	r = image.snap_is_protected(snaps[i].name.c_str(), &is_protected);
-	 if (r < 0) {
-		pc.fail();
-		return r;
-	 }
-	 if (is_protected == false)
-	 {
-		r = image.snap_remove(snaps[i].name.c_str());
-		if (r < 0) {
-		  pc.fail();
-		  return r;
-		}
-		j++;
-		pc.update_progress(j, isnapsSize);
-	 }		  
-   }
-  
-  if (j == isnapsSize)
-  {
-	 pc.finish();
-	 return 0;
-  }
-  else
-  {
-	 pc.fail(); 
-	 return -EBUSY;  
-  } 
+
+  pc.finish();
+  return 0;
 }
 
 static int do_protect_snap(librbd::Image& image, const char *snapname)

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -761,12 +761,30 @@ static int do_purge_snaps(librbd::Image& image)
 {
   MyProgressContext pc("Removing all snapshots");
   std::vector<librbd::snap_info_t> snaps;
+  bool is_protected = false;
   int r = image.snap_list(snaps);
   if (r < 0) {
     pc.fail();
     return r;
   }
-
+   
+  if (0 == snaps.size())
+  {
+	return 0;
+  }
+  for (size_t i = 0; i < snaps.size(); ++i) {
+	r = image.snap_is_protected(snaps[i].name.c_str(), &is_protected);
+	 if (r < 0) {
+		pc.fail();
+		return r;
+	 }
+	 if (is_protected == true)
+	  {
+		pc.fail();
+		cerr << "\r" <<snaps[i].name.c_str()<< " is a protected snap."<< std::endl;
+		return -EBUSY;	
+	  }
+  }
   for (size_t i = 0; i < snaps.size(); ++i) {
     r = image.snap_remove(snaps[i].name.c_str());
     if (r < 0) {


### PR DESCRIPTION
1、Check whether the image has snap or not,if not,do not show any information instead of "Removing all snapshots: 100% complete...done. "
In rbd.cc,function do_purge_snaps
test fix:
An image doesn't have any snap, execute 'rbd snap purge image'
before:
Removing all snapshots: 100% complete...done. 
after:
Without any hints.
2、"rbd snap purge image" will return failure directly without removing any snaps if the image has any protected snaps.
In rbd.cc,function do_purge_snaps
test fix:
An image has 3 snaps(such as a、b、c),and b is a protected snap,then execute 'rbd snap purge image’
before：
Removing all snapshots: 33% complete...failed. and image still have b、c snap.
after：
Removing all snapshots: 0% complete...failed. 
b is a protected snap.

Signed-off-by: mingyuez zhao.mingyue@h3c.com