### PR TITLE
common/TrackedOp: make asok command 'dump_historic_ops' make more sense.

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -32,7 +32,6 @@ void OpHistory::on_shutdown()
 {
   Mutex::Locker history_lock(ops_history_lock);
   arrived.clear();
-  duration.clear();
   shutdown = true;
 }
 
@@ -42,7 +41,6 @@ void OpHistory::insert(utime_t now, TrackedOpRef op)
     return;
 
   Mutex::Locker history_lock(ops_history_lock);
-  duration.insert(make_pair(op->get_duration(), op));
   arrived.insert(make_pair(op->get_initiated(), op));
   cleanup(now);
 }
@@ -52,17 +50,11 @@ void OpHistory::cleanup(utime_t now)
   while (arrived.size() &&
 	 (now - arrived.begin()->first >
 	  (double)(history_duration))) {
-    duration.erase(make_pair(
-	arrived.begin()->second->get_duration(),
-	arrived.begin()->second));
-    arrived.erase(arrived.begin());
+     arrived.erase(arrived.begin());
   }
 
-  while (duration.size() > history_size) {
-    arrived.erase(make_pair(
-	duration.begin()->second->get_initiated(),
-	duration.begin()->second));
-    duration.erase(duration.begin());
+  while (arrived.size() > history_size) {
+    arrived.erase(arrived.begin());
   }
 }
 

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -28,7 +28,6 @@ typedef ceph::shared_ptr<TrackedOp> TrackedOpRef;
 class OpTracker;
 class OpHistory {
   set<pair<utime_t, TrackedOpRef> > arrived;
-  set<pair<double, TrackedOpRef> > duration;
   Mutex ops_history_lock;
   void cleanup(utime_t now);
   bool shutdown;
@@ -40,7 +39,6 @@ public:
   history_size(0), history_duration(0) {}
   ~OpHistory() {
     assert(arrived.empty());
-    assert(duration.empty());
   }
   void insert(utime_t now, TrackedOpRef op);
   void dump_ops(utime_t now, Formatter *f);

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -356,7 +356,11 @@ struct ceph_osd_request_head {
   }
 
   void clear_buffers() {
+    vector<OSDOp> tmp(ops.size()); //asok dump_historic_ops use
+    for (unsigned i = 0; i < ops.size(); i++)
+      tmp[i].op = ops[i].op;
     ops.clear();
+    ops = tmp;
   }
 
   const char *get_type_name() const { return "osd_op"; }


### PR DESCRIPTION
dump_historic_ops dump the history ops limited by history_duration and
history_size.
Firstly, check op duration don't beyond the history_duration. Later
check size don't beyond history_size.
If size beyond history_size, it remove ths ops which duration(the
lifetime of op) is the largest.
So there is a chance: opA first, opB later. But the duration of opB is
larger than opA. So it first remove opB.
We hope dump_historic_ops dump ops base on the start time.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>