### PR TITLE
common/syncfs: fall back to sync(2) if syncfs(2) not available

### DIFF
--- a/src/common/sync_filesystem.h
+++ b/src/common/sync_filesystem.h
@@ -34,18 +34,21 @@ inline int sync_filesystem(int fd)
 #ifdef HAVE_SYS_SYNCFS
   if (syncfs(fd) == 0)
     return 0;
-  else
-    return -errno;
 #elif defined(SYS_syncfs)
   if (syscall(SYS_syncfs, fd) == 0)
     return 0;
-  else
-    return -errno;
 #elif defined(__NR_syncfs)
   if (syscall(__NR_syncfs, fd) == 0)
     return 0;
-  else
+#endif
+
+#if defined(HAVE_SYS_SYNCFS) || defined(SYS_syncfs) || defined(__NR_syncfs)
+  else if (errno == ENOSYS) {
+    sync();
+    return 0;
+  } else {
     return -errno;
+  }
 #else
   sync();
   return 0;


### PR DESCRIPTION
Fixes: #12512, http://tracker.ceph.com/issues/12512
Signed-off-by: Kefu Chai <kchai@redhat.com>