### PR TITLE
Log::reopen_log_file: take m_flush_mutex

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -116,6 +116,8 @@ void Log::set_log_file(string fn)
 
 void Log::reopen_log_file()
 {
+  pthread_mutex_lock(&m_flush_mutex);
+  m_flush_mutex_holder = pthread_self();
   if (m_fd >= 0)
     VOID_TEMP_FAILURE_RETRY(::close(m_fd));
   if (m_log_file.length()) {
@@ -123,6 +125,8 @@ void Log::reopen_log_file()
   } else {
     m_fd = -1;
   }
+  m_flush_mutex_holder = 0;
+  pthread_mutex_unlock(&m_flush_mutex);
 }
 
 void Log::set_syslog_level(int log, int crash)


### PR DESCRIPTION
Otherwise, _flush() might continue to write to m_fd after it's closed.
This might cause log data to go to a data object if the filestore then
reuses the fd during that time.

Fixes: #12465
Backport: firefly, hammer
Signed-off-by: Samuel Just <sjust@redhat.com>
(cherry picked from commit 8778ab3a1ced7fab07662248af0c773df759653d)