### PR TITLE
ceph.spec.in: radosgw requires apache for SUSE only -- makes no sense

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -161,7 +161,6 @@ Requires:	librados2 = %{epoch}:%{version}-%{release}
 %if 0%{defined suse_version}
 BuildRequires:	libexpat-devel
 BuildRequires:	FastCGI-devel
-Requires:	apache2-mod_fcgid
 %else
 BuildRequires:	expat-devel
 BuildRequires:	fcgi-devel


### PR DESCRIPTION
http://tracker.ceph.com/issues/12446