### PR TITLE
ceph.spec.in: useless %py_requires breaks SLE11-SP3 build

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -213,9 +213,6 @@ Group:		System Environment/Libraries
 License:	LGPL-2.0
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 Obsoletes:	python-ceph < %{epoch}:%{version}-%{release}
-%if 0%{defined suse_version}
-%py_requires
-%endif
 %description -n python-rados
 This package contains Python libraries for interacting with Cephs RADOS
 object store.


### PR DESCRIPTION
http://tracker.ceph.com/issues/12448