### PR TITLE
osd: copy the RecoveryCtx::handle for when creating RecoveryCtx instance from another one

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -556,7 +556,7 @@ public:
 	on_applied(rctx.on_applied),
 	on_safe(rctx.on_safe),
 	transaction(rctx.transaction),
-        handle(NULL) {}
+        handle(rctx.handle) {}
 
     void accept_buffered_messages(BufferedRecoveryMessages &m) {
       assert(query_map);


### PR DESCRIPTION
Fixes: 12523
Signed-off-by: Guang Yang <yguang@yahoo-inc.com>