### PR TITLE
debian/control: ceph-common (>> 0.94.2) must be >= 0.94.2-2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -60,7 +60,7 @@ Standards-Version: 3.9.3
 Package: ceph
 Architecture: linux-any
 Depends: binutils,
-         ceph-common (>> 0.94.2),
+         ceph-common (>= 0.94.2-2),
          cryptsetup-bin | cryptsetup,
          gdisk,
          parted,
@@ -92,8 +92,8 @@ Architecture: linux-any
 Section: debug
 Priority: extra
 Depends: ceph (= ${binary:Version}), ${misc:Depends}
-Replaces: ceph-test-dbg (<= 0.94.2)
-Breaks: ceph-test-dbg (<= 0.94.2)
+Replaces: ceph-test-dbg (<< 0.94.2-2)
+Breaks: ceph-test-dbg (<< 0.94.2-2)
 Description: debugging symbols for ceph
  Ceph is a distributed storage system designed to provide excellent
  performance, reliability, and scalability.
@@ -191,10 +191,10 @@ Depends: librbd1 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends},
 	 python-requests
 Conflicts: ceph-client-tools
 Replaces: ceph-client-tools,
-	  ceph (<= 0.94.2),
+	  ceph (<< 0.94.2-2),
 	  python-ceph (<< 0.92-1223),
 	  librbd1 (<< 0.92-1238)
-Breaks: ceph (<= 0.94.2),
+Breaks: ceph (<< 0.94.2-2),
 	python-ceph (<< 0.92-1223),
 	librbd1 (<< 0.92-1238)
 Suggests: ceph, ceph-mds


### PR DESCRIPTION
The d8733be2ef8874b9a858a7ffddfb81b9b656e9a6 backport introduced a
regression by adding an incorrect Depends / Break combo supposed to
reflect the fact that ceph_argparse moved from ceph to ceph-common after
v0.94.2. It assumed the package is released under the 0.94.2 version
where in reality it is released under the 0.94.2-1xxx version (where xxx
is trusty, jessie etc.).

The Depends / Break combo is changed to use 0.94.2-2 instead.

See also http://tracker.ceph.com/issues/12529 for a larger discussion.

http://tracker.ceph.com/issues/11998 Fixes: #11998

Signed-off-by: Loic Dachary <ldachary@redhat.com>