### PR TITLE
tests: fix the ObjectStore/StoreTest.SimpleCloneTest in "ceph_test_objectstore"

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -4072,7 +4072,7 @@ int FileStore::getattr(coll_t cid, const ghobject_t& oid, const char *name, buff
     return -EIO;
   } else {
     tracepoint(objectstore, getattr_exit, r);
-    return r;
+    return r < 0 ? r : 0;
   }
 }
 

--- a/src/os/GenericObjectMap.cc
+++ b/src/os/GenericObjectMap.cc
@@ -534,6 +534,7 @@ int GenericObjectMap::clear(const Header header,
 
 int GenericObjectMap::rm_keys(const Header header,
                               const string &prefix,
+                              const set<string> &buffered_keys,
                               const set<string> &to_clear,
                               KeyValueDB::Transaction t)
 {
@@ -563,7 +564,7 @@ int GenericObjectMap::rm_keys(const Header header,
         begin = new_complete.rbegin()->first;
       }
       while (iter->valid() && copied < 20) {
-        if (!to_clear.count(iter->key()))
+        if (!to_clear.count(iter->key()) && !buffered_keys.count(iter->key()))
           to_write[iter->key()].append(iter->value());
         if (i != to_clear.end() && *i <= iter->key()) {
           ++i;
@@ -692,6 +693,7 @@ void GenericObjectMap::clone(const Header parent, const coll_t &cid,
   // to find parent header. So it will let lookup_parent fail when "clone" and
   // "rm_keys" in one transaction. Here have to sync transaction to make
   // visiable for lookup_parent
+  // FIXME: Clear transaction operations here
   int r = submit_transaction_sync(t);
   assert(r == 0);
 }

--- a/src/os/GenericObjectMap.h
+++ b/src/os/GenericObjectMap.h
@@ -240,6 +240,7 @@ class GenericObjectMap {
   int rm_keys(
     const Header header,
     const string &prefix,
+    const set<string> &buffered_keys,
     const set<string> &to_clear,
     KeyValueDB::Transaction t
     );

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -428,24 +428,29 @@ TEST_P(StoreTest, SimpleCloneTest) {
     cerr << "Clone object and rm attr" << std::endl;
     r = store->apply_transaction(t);
     ASSERT_EQ(r, 0);
+
     r = store->read(cid, hoid, 10, 5, newdata);
     ASSERT_EQ(r, 5);
     ASSERT_TRUE(newdata.contents_equal(large));
+
     newdata.clear();
     r = store->read(cid, hoid2, 10, 5, newdata);
     ASSERT_EQ(r, 5);
     ASSERT_TRUE(newdata.contents_equal(small));
+
     r = store->getattr(cid, hoid2, "attr2", attr);
-    ASSERT_EQ(r, 5);
+    ASSERT_EQ(r, 0);
     ASSERT_TRUE(attr.contents_equal(small));
+
     attr.clear();
     r = store->getattr(cid, hoid2, "attr3", attr);
-    ASSERT_EQ(r, 6);
+    ASSERT_EQ(r, 0);
     ASSERT_TRUE(attr.contents_equal(xlarge));
+
     attr.clear();
     r = store->getattr(cid, hoid, "attr1", attr);
-    ASSERT_EQ(r, 5);
-    ASSERT_TRUE(attr.contents_equal(small));
+    ASSERT_EQ(r, 0);
+    ASSERT_TRUE(attr.contents_equal(large));
   }
   {
     ObjectStore::Transaction t;
@@ -952,7 +957,7 @@ public:
 
     bufferlist bl;
     r = store->getattr(cid, obj, it->first, bl);
-    ASSERT_TRUE(r >= 0);
+    ASSERT_EQ(r, 0);
     ASSERT_TRUE(it->second.contents_equal(bl));
   }
 
@@ -1650,7 +1655,7 @@ TEST_P(StoreTest, XattrTest) {
   ASSERT_EQ(r, -ENODATA);
 
   r = store->getattr(cid, hoid, "attr3", bp);
-  ASSERT_GE(r, 0);
+  ASSERT_EQ(r, 0);
   bufferlist bl2;
   bl2.push_back(bp);
   ASSERT_TRUE(bl2 == attrs["attr3"]);
@@ -1859,7 +1864,7 @@ TEST_P(StoreTest, MoveRename) {
     ASSERT_TRUE(newdata.contents_equal(data));
     bufferlist newattr;
     r = store->getattr(cid, oid, "attr", newattr);
-    ASSERT_GE(r, 0);
+    ASSERT_EQ(r, 0);
     ASSERT_TRUE(newattr.contents_equal(attr));
     set<string> keys;
     keys.insert("omap_key");


### PR DESCRIPTION
* fix the test of ObjectStore/StoreTest.SimpleCloneTest, otherwise it fails on objectstore backends of "memstore" and "keyvaluestore".
* change FileStore::getattr() to return 0 on success
* tighten related tests in ceph_test_objectstore, to test the return value
  of getattr() using ASSERT_EQ(r, 0) instead of ASSERT_GE(r, 0)
