### PR TITLE
librbd: test crash during client upgrade suite

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -20,6 +20,7 @@
 #include "common/perf_counters.h"
 #include "common/Thread.h"
 #include "common/ceph_context.h"
+#include "common/ceph_crypto.h"
 #include "common/config.h"
 #include "common/debug.h"
 #include "common/HeartbeatMap.h"
@@ -467,6 +468,7 @@ CephContext::~CephContext()
 
   delete _crypto_none;
   delete _crypto_aes;
+  ceph::crypto::shutdown();
 }
 
 void CephContext::start_service_thread()

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -171,6 +171,8 @@ private:
   ceph_spinlock_t _feature_lock;
   std::set<std::string> _experimental_features;
 
+  md_config_obs_t *_lockdep_obs;
+
   friend class CephContextObs;
 };
 

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -119,9 +119,4 @@ void common_init_finish(CephContext *cct, int flags)
 
   if (!(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))
     cct->start_service_thread();
-
-  if (cct->_conf->lockdep) {
-    g_lockdep = true;
-    lockdep_register_ceph_context(cct);
-  }
 }

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -67,6 +67,7 @@ void lockdep_register_ceph_context(CephContext *cct)
 {
   pthread_mutex_lock(&lockdep_mutex);
   if (g_lockdep_ceph_ctx == NULL) {
+    g_lockdep = true;
     g_lockdep_ceph_ctx = cct;
     lockdep_dout(0) << "lockdep start" << dendl;
 

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -120,8 +120,6 @@ void global_init(std::vector < const char * > *alt_def_args,
 {
   global_pre_init(alt_def_args, args, module_type, code_env, flags);
 
-  g_lockdep = g_ceph_context->_conf->lockdep;
-
   // signal stuff
   int siglist[] = { SIGPIPE, 0 };
   block_signals(siglist, NULL);
@@ -142,9 +140,6 @@ void global_init(std::vector < const char * > *alt_def_args,
     }
   }
 
-  if (g_lockdep) {
-    lockdep_register_ceph_context(g_ceph_context);
-  }
   register_assert_context(g_ceph_context);
 
   // call all observers now.  this has the side-effect of configuring

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -1260,8 +1260,6 @@ int main(int argc, const char **argv)
   dout(1) << "final shutdown" << dendl;
   g_ceph_context->put();
 
-  ceph::crypto::shutdown();
-
   signal_fd_finalize();
 
   return 0;

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -337,8 +337,7 @@ ceph_test_librbd_api_SOURCES = \
 	test/librbd/test_main.cc
 ceph_test_librbd_api_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 ceph_test_librbd_api_LDADD = \
-	$(LIBRBD) $(LIBRADOS) $(UNITTEST_LDADD) \
-	$(CEPH_GLOBAL) $(RADOS_TEST_LDADD)
+	$(LIBRBD) $(LIBRADOS) $(LIBCOMMON) $(UNITTEST_LDADD) $(RADOS_TEST_LDADD)
 bin_DEBUGPROGRAMS += ceph_test_librbd_api
 
 if WITH_LTTNG

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -42,7 +42,6 @@
 #include "include/krbd.h"
 #include "include/rados/librados.h"
 #include "include/rbd/librbd.h"
-#include "common/ceph_crypto.h"
 
 #define NUMPRINTCOLUMNS 32	/* # columns of data to print on each line */
 
@@ -2333,7 +2332,6 @@ main(int argc, char **argv)
 	krbd_destroy(krbd);
 	rados_shutdown(cluster);
 
-        ceph::crypto::shutdown();
 	free(original_buf);
 	free(good_buf);
 	free(temp_buf);

--- a/src/test/librbd/test_main.cc
+++ b/src/test/librbd/test_main.cc
@@ -1,12 +1,12 @@
 // -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "gtest/gtest.h"
-#include "common/ceph_argparse.h"
-#include "common/config.h"
+#include "include/rados/librados.hpp"
 #include "global/global_context.h"
-#include "global/global_init.h"
-#include <vector>
+#include "test/librados/test.h"
+#include "gtest/gtest.h"
+#include <iostream>
+#include <string>
 
 extern void register_test_librbd();
 #ifdef TEST_LIBRBD_INTERNALS
@@ -26,14 +26,21 @@ int main(int argc, char **argv)
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  librados::Rados rados;
+  std::string result = connect_cluster_pp(rados);
+  if (result != "" ) {
+    std::cerr << result << std::endl;
+    return 1;
+  }
 
-  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
-  g_conf->set_val("lockdep", "true");
-  common_init_finish(g_ceph_context);
+#ifdef TEST_LIBRBD_INTERNALS
+  g_ceph_context = reinterpret_cast<CephContext*>(rados.cct());
+#endif // TEST_LIBRBD_INTERNALS
 
-  int r = RUN_ALL_TESTS();
-  g_ceph_context->put();
-  return r;
+  int r = rados.conf_set("lockdep", "true");
+  if (r < 0) {
+    std::cerr << "failed to enable lockdep" << std::endl;
+    return -r;
+  }
+  return RUN_ALL_TESTS();
 }

--- a/src/test/librbd/test_main.cc
+++ b/src/test/librbd/test_main.cc
@@ -3,7 +3,6 @@
 
 #include "gtest/gtest.h"
 #include "common/ceph_argparse.h"
-#include "common/ceph_crypto.h"
 #include "common/config.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
@@ -36,6 +35,5 @@ int main(int argc, char **argv)
 
   int r = RUN_ALL_TESTS();
   g_ceph_context->put();
-  ceph::crypto::shutdown();
   return r;
 }


### PR DESCRIPTION
ceph_test_librbd_api relied on md_config_t, which most likely will change between versions.  Switched direct usage of md_config_t with exposed librados get/set configuration methods.