### PR TITLE
fix: qa/workunits/rados/test_cache_pool.sh

### DIFF
--- a/qa/workunits/rados/test_cache_pool.sh
+++ b/qa/workunits/rados/test_cache_pool.sh
@@ -79,6 +79,8 @@ expect_false diff -q tmp.txt empty.txt
 
 # cleanup
 ceph osd tier remove-overlay base_pool
+ceph osd tier remove base_pool wrong_cache
+ceph osd tier remove base_pool partial_wrong
 ceph osd tier remove base_pool empty_cache
 ceph osd pool delete base_pool base_pool --yes-i-really-really-mean-it
 ceph osd pool delete empty_cache empty_cache --yes-i-really-really-mean-it
@@ -127,7 +129,6 @@ rados -p cache ls - | wc -l | grep 0
 
 # cleanup
 ceph osd tier remove-overlay base
-ceph osd tier cache-mode cache none
 ceph osd tier remove base cache
 
 ceph osd pool delete cache cache --yes-i-really-really-mean-it


### PR DESCRIPTION
The test script will result the following error:
Error EBUSY: pool 'base_pool' has tiers partial_wrong wrong_cache
Error EINVAL: unable to set cache-mode 'none' on a 'writeback' pool; only 'forward','readforward','readproxy' allowed.
Removing tiering relationship before the pool could be deleted. There is no need to set cache-mode as none before removing tier, and the cache-mode can not be changed from writeback to none.