### PR TITLE
make: fix the build of "rbd"

### DIFF
--- a/src/Makefile-client.am
+++ b/src/Makefile-client.am
@@ -60,7 +60,7 @@ noinst_LTLIBRARIES += libkrbd.la
 endif # LINUX
 
 rbd_SOURCES = rbd.cc
-rbd_LDADD = $(LIBKRBD) $(LIBRBD) $(LIBRADOS)
+rbd_LDADD = $(LIBKRBD) $(LIBRBD) $(LIBRADOS) $(PTHREAD_LIBS) $(CRYPTO_LIBS)
 if LINUX
 bin_PROGRAMS += rbd
 endif # LINUX


### PR DESCRIPTION
see
-  http://gitbuilder.sepia.ceph.com/gitbuilder-ceph-deb-trusty-amd64-basic/log.cgi?log=d5142ba29e839ff55364a2536ae673f14122b5bb
- http://gitbuilder.sepia.ceph.com/gitbuilder-ceph-deb-trusty-amd64-basic/log.cgi?log=03491ae843527ac9c15088c745f7b6ae2e8d42b3

`CEPH_GLOBAL` was removed in fa78739, but the linked libraries does not
offer all needed symbol for "rbd". so add them back.

Signed-off-by: Kefu Chai <kchai@redhat.com>