### PR TITLE
common/Thread: pthread_attr_destroy(thread_attr) when done with it

### DIFF
--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -136,6 +136,10 @@ int Thread::try_create(size_t stacksize)
   r = pthread_create(&thread_id, thread_attr, _entry_func, (void*)this);
   restore_sigset(&old_sigset);
 
+  if (thread_attr) {
+    pthread_attr_destroy(thread_attr);	
+  }
+
   return r;
 }
 


### PR DESCRIPTION
When a thread attributes object is no longer required, it should be destroyed using  the
pthread_attr_destroy() function. Destroying a thread attributes object has no effect on threads that were created using that object.    
Fixes: #12570
Signed-off-by: zqkqkz <zheng.qiankun@h3c.com>                                                                                                                                            