### PR TITLE
osd/ReplicatedPG: optimize check_offset_and_length.

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3285,14 +3285,12 @@ int ReplicatedPG::do_tmapup(OpContext *ctx, bufferlist::iterator& bp, OSDOp& osd
   return result;
 }
 
+//EFBIG if attempt to WRITE/WRITEFULL/TRUNCATE beyond max, and length 0 writes are allowed.
 static int check_offset_and_length(uint64_t offset, uint64_t length, uint64_t max)
 {
-  if (offset >= max ||
-      length > max ||
-      offset + length > max)
-    return -EFBIG;
-
-  return 0;
+  if (offset + length < max || (offset + length == max && length) )
+    return 0;
+  return -EFBIG;
 }
 
 struct FillInExtent : public Context {


### PR DESCRIPTION
For check_offset_and_length, the most case is offset + length < max.
So we should first check positive case rather than negative case.
BTW, becase we allow length is zero, we should also check "offset + lengh
== max && length != 0."

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>