### PR TITLE
doc: fix the build of placement-groups.rst

### DIFF
--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -430,3 +430,4 @@ entirely. To mark the "unfound" objects as "lost", execute the following::
 
 
 .. _Create a Pool: ../pools#createpool
+.. _Mapping PGs to OSDs: ../../../architecture#mapping-pgs-to-osds


### PR DESCRIPTION
add a reference target of "mapping pgs to osds"

this fixes the error at http://gitbuilder.sepia.ceph.com/gitbuilder-doc/log.cgi?log=f0084407651c5edf143b33e8a5be3ec65d1ba365 
```
ERROR: /srv/autobuild-ceph/gitbuilder.git/build/doc/rados/operations/placement-groups.rst:61: Unknown target name: "mapping pgs to osds".
```