### PR TITLE
configure.ac:Detect if header gtest/gtest.h exists

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -891,6 +891,9 @@ AC_CHECK_HEADER([boost/statechart/state.hpp], [],
 AC_CHECK_HEADER([boost/program_options/option.hpp], [],
     AC_MSG_FAILURE(["Can't find boost program_options headers"]))
 
+AC_CHECK_HEADER([gtest/gtest.h], [],
+    AC_MSG_FAILURE(["Can't find googletest headers"]))
+
 # If we have the boost system library installed, then we may want to link
 # with it.
 AC_CHECK_LIB(boost_system-mt, main, [],


### PR DESCRIPTION
googletest-devel is a build dependency but is not detected by autotools.

Signed-off-by: Owen Synge <osynge@suse.com>