### PR TITLE
rbd: do not provide librados the global context

### DIFF
--- a/src/Makefile-client.am
+++ b/src/Makefile-client.am
@@ -60,7 +60,7 @@ noinst_LTLIBRARIES += libkrbd.la
 endif # LINUX
 
 rbd_SOURCES = rbd.cc
-rbd_LDADD = $(LIBKRBD) $(LIBRBD) $(LIBRADOS)
+rbd_LDADD = $(LIBKRBD) $(LIBRBD) $(LIBRADOS) $(CEPH_GLOBAL)
 if LINUX
 bin_PROGRAMS += rbd
 endif # LINUX

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -10,11 +10,13 @@
  */
 #include "include/int_types.h"
 
-#include "common/debug.h"
-#include "common/dout.h"
+#include "mon/MonClient.h"
+#include "common/config.h"
+
 #include "common/errno.h"
 #include "common/ceph_argparse.h"
 #include "common/strtol.h"
+#include "global/global_init.h"
 #include "common/safe_io.h"
 #include "include/krbd.h"
 #include "include/stringify.h"
@@ -73,10 +75,7 @@ bool resize_allow_shrink = false;
 
 map<string, string> map_options; // -o / --options map
 
-CephContext *g_ceph_context = NULL;
 #define dout_subsys ceph_subsys_rbd
-
-namespace {
 
 static std::map<uint64_t, std::string> feature_mapping =
   boost::assign::map_list_of(
@@ -87,22 +86,7 @@ static std::map<uint64_t, std::string> feature_mapping =
     RBD_FEATURE_FAST_DIFF, "fast-diff")(
     RBD_FEATURE_DEEP_FLATTEN, "deep-flatten");
 
-template <typename T>
-T get_config_value(librados::Rados &rados, const std::string &key) {
-  std::string value;
-  int r = rados.conf_get(key.c_str(), value);
-  assert(r == 0);
-
-  std::istringstream ss(value);
-  T typed_value;
-  ss >> typed_value;
-  return typed_value;
-}
-
-} // anonymous namespace
-
-
-void usage(librados::Rados &rados)
+void usage()
 {
   cout <<
 "usage: rbd [-n <auth user>] [OPTIONS] <cmd> ...\n"
@@ -220,8 +204,6 @@ void usage(librados::Rados &rados)
 "Supported image features:\n"
 "  ";
 
-uint64_t default_features = get_config_value<uint64_t>(
-  rados, "rbd_default_features");
 for (std::map<uint64_t, std::string>::const_iterator it = feature_mapping.begin();
      it != feature_mapping.end(); ++it) {
   if (it != feature_mapping.begin()) {
@@ -231,7 +213,7 @@ for (std::map<uint64_t, std::string>::const_iterator it = feature_mapping.begin(
   if ((it->first & RBD_FEATURES_MUTABLE) != 0) {
     cout << " (*)";
   }
-  if ((it->first & default_features) != 0) {
+  if ((it->first & g_conf->rbd_default_features) != 0) {
     cout << " (+)";
   }
 }
@@ -1198,8 +1180,7 @@ private:
   int m_fd;
 };
 
-static int do_export(librados::Rados &rados, librbd::Image& image,
-                     const char *path)
+static int do_export(librbd::Image& image, const char *path)
 {
   librbd::image_info_t info;
   int64_t r = image.stat(info, sizeof(info));
@@ -1213,8 +1194,7 @@ static int do_export(librados::Rados &rados, librbd::Image& image,
     fd = STDOUT_FILENO;
     max_concurrent_ops = 1;
   } else {
-    max_concurrent_ops = max(
-      get_config_value<int>(rados, "rbd_concurrent_management_ops"), 1);
+    max_concurrent_ops = max(g_conf->rbd_concurrent_management_ops, 1);
     fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0644);
     if (fd < 0) {
       return -errno;
@@ -1523,7 +1503,6 @@ static int do_import(librbd::RBD &rbd, librados::IoCtx& io_ctx,
 		     int format, uint64_t features, uint64_t size,
                      uint64_t stripe_unit, uint64_t stripe_count)
 {
-  librados::Rados rados(io_ctx);
   int fd, r;
   struct stat stat_buf;
   MyProgressContext pc("Importing image");
@@ -1551,8 +1530,7 @@ static int do_import(librbd::RBD &rbd, librados::IoCtx& io_ctx,
     size = 1ULL << *order;
   } else {
     throttle.reset(new SimpleThrottle(
-      max(get_config_value<int>(rados, "rbd_concurrent_management_ops"), 1),
-      false));
+      max(g_conf->rbd_concurrent_management_ops, 1), false));
     if ((fd = open(path, O_RDONLY)) < 0) {
       r = -errno;
       cerr << "rbd: error opening " << path << std::endl;
@@ -2970,41 +2948,18 @@ bool size_set;
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
-  env_to_vec(args);
-
-  std::string cluster_name = "ceph";
-  std::string conf_file_list;
-  CephInitParameters init_params = ceph_argparse_early_args(
-    args, CEPH_ENTITY_TYPE_CLIENT, 0, &cluster_name, &conf_file_list);
-
   librados::Rados rados;
-  int r = rados.init2(init_params.name.to_cstr(), cluster_name.c_str(),
-                      0);
-  if (r < 0) {
-    std::cerr << "rbd: couldn't initialize rados!" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  r = rados.conf_read_file(
-    conf_file_list.empty() ? NULL : conf_file_list.c_str());
-  if (r == -EINVAL) {
-    std::cerr << "rbd: did not load config file, using default settings."
-              << std::endl;
-  } else if (r < 0) {
-    std::cerr << "rbd: failed to read configuration" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // required for dout usage within rbd
-  g_ceph_context = reinterpret_cast<CephContext *>(rados.cct());
-
   librbd::RBD rbd;
   librados::IoCtx io_ctx, dest_io_ctx;
   librbd::Image image;
 
+  vector<const char*> args;
+
+  argv_to_vec(argc, argv, args);
+  env_to_vec(args);
+
   int opt_cmd = OPT_NO_CMD;
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
 
   const char *poolname = NULL;
   uint64_t size = 0;  // in bytes
@@ -3039,10 +2994,10 @@ int main(int argc, const char **argv)
     if (ceph_argparse_double_dash(args, i)) {
       break;
     } else if (ceph_argparse_witharg(args, i, &val, "--secret", (char*)NULL)) {
-      r = rados.conf_set("keyfile", val.c_str());
+      int r = g_conf->set_val("keyfile", val.c_str());
       assert(r == 0);
     } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage(rados);
+      usage();
       return 0;
     } else if (ceph_argparse_flag(args, i, "--new-format", (char*)NULL)) {
       cerr << "rbd: --new-format is deprecated" << std::endl;
@@ -3056,8 +3011,7 @@ int main(int argc, const char **argv)
 	return EXIT_FAILURE;
       }
       format_specified = true;
-      r = rados.conf_set("rbd_default_format", val.c_str());
-      assert(r == 0);
+      g_conf->set_val_or_die("rbd_default_format", val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "-p", "--pool", (char*)NULL)) {
       poolname = strdup(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--dest-pool", (char*)NULL)) {
@@ -3150,8 +3104,7 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--format", (char *) NULL)) {
       long long ret = strict_strtoll(val.c_str(), 10, &parse_err);
       if (parse_err.empty()) {
-        r = rados.conf_set("rbd_default_format", val.c_str());
-        assert(r == 0);
+	g_conf->set_val_or_die("rbd_default_format", val.c_str());
 	format = ret;
 	format_specified = true;
 	cerr << "rbd: using --format for specifying the rbd image format is"
@@ -3173,7 +3126,7 @@ int main(int argc, const char **argv)
     format = 2;
     format_specified = true;
   } else if (features == 0) {
-    features = get_config_value<uint64_t>(rados, "rbd_default_features");
+    features = g_conf->rbd_default_features;
   }
   if (shared) {
     features &= ~(RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_OBJECT_MAP);
@@ -3184,6 +3137,8 @@ int main(int argc, const char **argv)
          << "the object map" << std::endl;
     return EXIT_FAILURE;
   }
+
+  common_init_finish(g_ceph_context);
 
   std::map<std::string, CommandType> command_map = boost::assign::map_list_of
     ("snap", COMMAND_TYPE_SNAP)
@@ -3303,19 +3258,18 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     }
   }
 
-  r = rados.conf_set("rbd_cache_writethrough_until_flush", "false");
-  assert(r == 0);
+  g_conf->set_val_or_die("rbd_cache_writethrough_until_flush", "false");
 
   /* get defaults from rbd_default_* options to keep behavior consistent with
      manual short-form options */
   if (!format_specified)
-    format = get_config_value<int>(rados, "rbd_default_format");
+    format = g_conf->rbd_default_format;
   if (!order)
-    order = get_config_value<int>(rados, "rbd_default_order");
+    order = g_conf->rbd_default_order;
   if (!stripe_unit)
-    stripe_unit = get_config_value<long long>(rados, "rbd_default_stripe_unit");
+    stripe_unit = g_conf->rbd_default_stripe_unit;
   if (!stripe_count)
-    stripe_count = get_config_value<long long>(rados, "rbd_default_stripe_count");
+    stripe_count = g_conf->rbd_default_stripe_count;
 
   if (format_specified && opt_cmd != OPT_IMPORT && opt_cmd != OPT_CREATE) {
     cerr << "rbd: image format can only be set when "
@@ -3379,8 +3333,7 @@ if (!set_conf_param(v, p1, p2, p3)) { \
   }
 
   if (opt_cmd == OPT_MAP) {
-    char *default_map_options = strdup(
-      get_config_value<std::string>(rados, "rbd_default_map_options").c_str());
+    char *default_map_options = strdup(g_conf->rbd_default_map_options.c_str());
 
     // parse default options first so they can be overwritten by cli options
     if (parse_map_options(default_map_options)) {
@@ -3539,11 +3492,17 @@ if (!set_conf_param(v, p1, p2, p3)) { \
 			  opt_cmd != OPT_UNMAP &&
 			  opt_cmd != OPT_SHOWMAPPED &&
                           opt_cmd != OPT_MERGE_DIFF);
+  if (talk_to_cluster && rados.init_with_context(g_ceph_context) < 0) {
+    cerr << "rbd: couldn't initialize rados!" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   if (talk_to_cluster && rados.connect() < 0) {
     cerr << "rbd: couldn't connect to the cluster!" << std::endl;
     return EXIT_FAILURE;
   }
 
+  int r;
   if (talk_to_cluster && opt_cmd != OPT_IMPORT) {
     r = rados.ioctx_create(poolname, io_ctx);
     if (r < 0) {
@@ -3623,7 +3582,7 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     if ((stripe_unit && !stripe_count) || (!stripe_unit && stripe_count)) {
       cerr << "must specify both (or neither) of stripe-unit and stripe-count"
 	   << std::endl;
-      usage(rados);
+      usage();
       return EINVAL;
     }
 
@@ -3801,7 +3760,7 @@ if (!set_conf_param(v, p1, p2, p3)) { \
     break;
 
   case OPT_EXPORT:
-    r = do_export(rados, image, path);
+    r = do_export(image, path);
     if (r < 0) {
       cerr << "rbd: export error: " << cpp_strerror(-r) << std::endl;
       return -r;


### PR DESCRIPTION
Alternative approach to fixing ABI issues with CephContext.  First approach left potential issues with logging and ```Cond.WaitInterval``` -- along with confirmed issues with krbd map/unmap.  This new approach uses a separate context for local operations and a librados-built context for librados operations.