### PR TITLE
rgw:the arguments 'domain' should not be assigned when return false

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -232,8 +232,8 @@ static bool rgw_find_host_in_domains(const string& host, string *domain, string 
     if (!str_ends_with(host, *iter, &pos))
       continue;
 
-    *domain = host.substr(pos);
     if (pos == 0) {
+      *domain = host;
       subdomain->clear();
     } else {
       if (host[pos - 1] != '.') {


### PR DESCRIPTION
Hostnames: [B.A]
Inputs: [X.BB.A]
Return: [false]
Output: [B.A] it is wrong.

Fixes: #12629
Signed-off-by: Ruifeng Yang <149233652@qq.com>