### PR TITLE
rgw:segmentation fault when rgw_gc_max_objs > HASH_PRIME

### DIFF
--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -95,7 +95,7 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
 {
   result.clear();
 
-  for (; *index < cct->_conf->rgw_gc_max_objs && result.size() < max; (*index)++, marker.clear()) {
+  for (; *index < max_objs && result.size() < max; (*index)++, marker.clear()) {
     std::list<cls_rgw_gc_obj_info> entries;
     int ret = cls_rgw_gc_list(store->gc_pool_ctx, obj_names[*index], marker, max - result.size(), expired_only, entries, truncated);
     if (ret == -ENOENT)
@@ -108,7 +108,7 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
       result.push_back(*iter);
     }
 
-    if (*index == cct->_conf->rgw_gc_max_objs - 1) {
+    if (*index == max_objs - 1) {
       /* we cut short here, truncated will hold the correct value */
       return 0;
     }
@@ -234,7 +234,6 @@ done:
 
 int RGWGC::process()
 {
-  int max_objs = cct->_conf->rgw_gc_max_objs;
   int max_secs = cct->_conf->rgw_gc_processor_max_time;
 
   unsigned start;


### PR DESCRIPTION
obj_names[] is index out of bounds when rgw_gc_max_objs > HASH_PRIME

Fixes: #12630
Signed-off-by: Ruifeng Yang 149233652@qq.com