### PR TITLE
bug fix: osd: do not cache unused buffer in attrs

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -372,6 +372,7 @@ void ECBackend::handle_recovery_read_complete(
     op.xattrs.swap(*attrs);
 
     if (!op.obc) {
+      op.xattrs.rebuild();
       op.obc = get_parent()->get_obc(hoid, op.xattrs);
       op.recovery_info.size = op.obc->obs.oi.size;
       op.recovery_info.oi = op.obc->obs.oi;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1799,6 +1799,7 @@ bool ReplicatedBackend::handle_pull_response(
 
   bool first = pi.recovery_progress.first;
   if (first) {
+    pop.attrset.rebuild();
     pi.obc = get_parent()->get_obc(pi.recovery_info.soid, pop.attrset);
     pi.recovery_info.oi = pi.obc->obs.oi;
     pi.recovery_info = recalc_subsets(pi.recovery_info, pi.obc->ssc);


### PR DESCRIPTION
attrs may be only a range of bufferlist in recovery, If obc cache it,
this causes the whole memory in bufferlist would not be free.
So rebuild the bufferlist before cache it.

The log said:

2015-08-02 17:00:14.177715 7fd8aa80d700 10 osd.0 pg_epoch: 397 pg[4.54s0( v 125'88 (0'0,125'88] local-les=387 n=86 ec=86 les/c 387/383 386/386/347) [0,20,14,7,19,8] r=0 lpr=386 pi=382-385/1 rops=9
crt=125'88 lcod 0'0 mlcod 0'0 active+recovering+degraded] handle_sub_read_reply readop not complete: ReadOp(tid=1865136, to_read={338b0ed4/rb.0.108f.6b8b4567.000000001e2f/head//4=read_request_t(t
o_read=[0,8388608,0], need=0(0),0,2097152,14(2),0,2097152,19(4),0,2097152,20(1),0,2097152, want_attrs=1),1e6c1ed4/rb.0.108f.6b8b4567.000000001caf/head//4=read_request_t(to_read=[0,
8388608,0], need=0(0),0,2097152,14(2),0,2097152,19(4),0,2097152,20(1),0,2097152, want_attrs=1)}, complete={338b0ed4/rb.0.108f.6b8b4567.000000001e2f/head//4=read_result_t(r=0, error
s={}, attrs={_=buffer::list(len=266,
        buffer::ptr(2031840~266 0x183780e0 in raw 0x18188000 len 2033591 nref 11)
),hinfo_key=buffer::list(len=42,
        buffer::ptr(2032584~42 0x183783c8 in raw 0x18188000 len 2033591 nref 11)
),snapset=buffer::list(len=31,
        buffer::ptr(2032641~31 0x18378401 in raw 0x18188000 len 2033591 nref 11)
)}, returned=(0, 8388608, [14(2),401902, 19(4),981140, 20(1),418554]), partial_read=0,1e6c1ed4/rb.0.108f.6b8b4567.000000001caf/head//4=read_result_t(r=0, errors={}, attrs={_=buffer::list(len=266,
        buffer::ptr(2032755~266 0x18378473 in raw 0x18188000 len 2033591 nref 11)
),hinfo_key=buffer::list(len=42,
        buffer::ptr(2033499~42 0x1837875b in raw 0x18188000 len 2033591 nref 11)
),snapset=buffer::list(len=31,
        buffer::ptr(2033556~31 0x18378794 in raw 0x18188000 len 2033591 nref 11)

Fixes: #12565
Signed-off-by: Ning Yao <zay11022@gmail.com>
Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>