### PR TITLE
mon: allow a monitor out of monmap to join

### DIFF
--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -36,7 +36,7 @@ static ostream& _prefix(std::ostream *_dout, Monitor *mon, Paxos *paxos, string 
 
 bool PaxosService::dispatch(MonOpRequestRef op)
 {
-  assert(op->is_type_service() || op->is_type_command());
+  assert(op->is_type_service() || op->is_type_monitor() || op->is_type_command());
   PaxosServiceMessage *m = static_cast<PaxosServiceMessage*>(op->get_req());
   op->mark_event("psvc:dispatch");
 


### PR DESCRIPTION
if a monitor is not listed in monmap, it sends an MMonJoin to join
the existing cluster. and this message is handled by MonmapMonitor
which is a subclass of PaxosService, and `PaxosService::dispatch()`
asserts on unexpected op request type. but MMonJoin is marked as
an OP_TYPE_MONITOR request in `Monitor::dispatch_op()`, not is
not changed later before being passed to `PaxosService::dispatch()`.
so we'd better add monitor messages into this function's white list.

Signed-off-by: Kefu Chai <kchai@redhat.com>