### PR TITLE
Allow do_autogen.sh pass configure parameters

### DIFF
--- a/do_autogen.sh
+++ b/do_autogen.sh
@@ -16,6 +16,7 @@ do_autogen.sh: make a ceph build by running autogen, etc.
 -p                               google profiler
 -O <level>                       optimize
 -c                               use cryptopp
+-C <parameter>                   add parameters to configure
 -j                               with java
 -r                               with rocksdb
 -J				 --with-jemalloc

--- a/do_autogen.sh
+++ b/do_autogen.sh
@@ -33,7 +33,7 @@ debug_level=0
 verbose=0
 profile=0
 CONFIGURE_FLAGS="--disable-static --with-lttng"
-while getopts  "d:e:hHrTPJLjpcvO:" flag
+while getopts  "d:e:hHrTPJLjpcvO:C:" flag
 do
     case $flag in
     d) debug_level=$OPTARG;;
@@ -41,6 +41,8 @@ do
     O) CFLAGS="${CFLAGS} -O$OPTARG";;
 
     c) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-cryptopp --without-nss";;
+
+    C) CONFIGURE_FLAGS="$CONFIGURE_FLAGS $OPTARG";;
 
     P) profile=1;;
     p) with_profiler="--with-profiler" ;;


### PR DESCRIPTION
Currently do_autogen.sh does not allow to pass parameters 
of configure to disable/enable components during building, which is not
flexible, this patch add the ability to it.