### PR TITLE
KVStore: Adding statfs and key format fixes to keyvalue store

### DIFF
--- a/src/os/KeyValueDB.h
+++ b/src/os/KeyValueDB.h
@@ -145,6 +145,9 @@ public:
     string key() {
       return generic_iter->key();
     }
+    pair<string,string> raw_key() {
+	  return generic_iter->raw_key();
+	}
     bufferlist value() {
       return generic_iter->value();
     }
@@ -176,6 +179,9 @@ public:
   }
 
   virtual uint64_t get_estimated_size(map<string,uint64_t> &extra) = 0;
+  virtual int get_statfs(struct statfs *buf) {
+    return -EOPNOTSUPP;
+  }
 
   virtual ~KeyValueDB() {}
 

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -593,7 +593,7 @@ KeyValueStore::~KeyValueStore()
 int KeyValueStore::statfs(struct statfs *buf)
 {
   int r = backend->db->get_statfs(buf);
-  if (r < 0) {
+  if (r == -EOPNOTSUPP) {
     if (::statfs(basedir.c_str(), buf) < 0) {
       int r = -errno;
       return r;

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -592,9 +592,12 @@ KeyValueStore::~KeyValueStore()
 
 int KeyValueStore::statfs(struct statfs *buf)
 {
-  if (::statfs(basedir.c_str(), buf) < 0) {
-    int r = -errno;
-    return r;
+  int r = backend->db->get_statfs(buf);
+  if (r < 0) {
+    if (::statfs(basedir.c_str(), buf) < 0) {
+      int r = -errno;
+      return r;
+    }
   }
   return 0;
 }

--- a/src/os/KeyValueStore.h
+++ b/src/os/KeyValueStore.h
@@ -220,7 +220,7 @@ class KeyValueStore : public ObjectStore,
 
   string strip_object_key(uint64_t no) {
     char n[100];
-    snprintf(n, 100, "%lld", (long long)no);
+    snprintf(n, 100, "%08lld", (long long)no);
     return string(n);
   }
 

--- a/src/os/Makefile.am
+++ b/src/os/Makefile.am
@@ -23,7 +23,6 @@ libos_la_SOURCES = \
 	os/KeyValueStore.cc \
 	os/ObjectStore.cc \
 	os/WBThrottle.cc \
-        os/KeyValueDB.cc \
 	common/TrackedOp.cc
 
 if LINUX


### PR DESCRIPTION
1. Changing to key format to to preserve the order in backend db
2. Changing the statfs to probe backend if it supports its own statfs

Signed-off-by: Varada Kari <varada.kari@sandisk.com>