### PR TITLE
[DNM] doc: RGW pools naming convention

### DIFF
--- a/doc/radosgw/config.rst
+++ b/doc/radosgw/config.rst
@@ -88,8 +88,9 @@ configuration file.
    hierarchy, or performance may suffer.
 
 When configuring a gateway with the default region and zone, the naming
-convention for pools typically omits region and zone naming, but you can use any
-naming convention you prefer. For example:
+convention for pools typically omits region and zone naming, but you can
+use any naming convention you prefer, The only requirement currently is
+that it starts with a period. For example:
 
 
 - ``.rgw.root``


### PR DESCRIPTION
Currently RGW pools document was missing that
we still need Period for starting RGW pools name.

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>