### PR TITLE
mds: open base inode's snaprealm after decoding snapblob

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2577,6 +2577,10 @@ void CInode::decode_snap_blob(bufferlist& snapbl)
     open_snaprealm();
     bufferlist::iterator p = snapbl.begin();
     ::decode(snaprealm->srnode, p);
+    if (is_base()) {
+      bool ok = snaprealm->_open_parents(NULL);
+      assert(ok);
+    }
     dout(20) << "decode_snap_blob " << *snaprealm << dendl;
   }
 }

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -551,7 +551,7 @@ bool StrayManager::__eval_stray(CDentry *dn, bool delay)
     // past snaprealm parents imply snapped dentry remote links.
     // only important for directories.  normal file data snaps are handled
     // by the object store.
-    if (in->snaprealm && in->snaprealm->has_past_parents()) {
+    if (in->snaprealm) {
       if (!in->snaprealm->have_past_parents_open() &&
           !in->snaprealm->open_parents(new C_MDC_EvalStray(this, dn))) {
         return false;


### PR DESCRIPTION
base inode has no parent, so can we mark its snaprealm open
immediately. This change makes sure replica mdsdir's snaplream
is opened.

Fixes: #12578
Signed-off-by: Yan, Zheng <zyan@redhat.com>