### PR TITLE
radosgw-admin: user modify only when display-name or email changed.

### DIFF
--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1730,12 +1730,10 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
 
   // fail if the user exists already
   if (op_state.has_existing_user()) {
-    if (!op_state.exclusive &&
-        (user_email.empty() || old_info.user_email == user_email) &&
-        old_info.display_name == display_name) {
+    if ( !op_state.exclusive && (old_info.user_email != user_email 
+      || old_info.display_name != display_name)){
       return execute_modify(op_state, err_msg);
     }
-
     set_err_msg(err_msg, "user: " + op_state.user_id + " exists");
 
     return -EEXIST;


### PR DESCRIPTION
when use radosgw-admin user create --uid=user --display-name="user"
everytime if I specifiy display-name parameter or email parameter, and same or different, always call execute_modify, it's wrong to do so, cause I think only when display-name or email really changed, there's need to call execute_modify.