### PR TITLE
Avoid cache pollution by rbd export etc

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8651,7 +8651,16 @@ int OSD::init_op_flags(OpRequestRef& op)
       if (m->ops.size() == 1) {
 	op->set_skip_promote();
       }
+      break;
 
+    case CEPH_OSD_OP_READ:
+    case CEPH_OSD_OP_SYNC_READ:
+    case CEPH_OSD_OP_SPARSE_READ:
+      if (m->ops.size() == 1 &&
+          iter->op.flags & CEPH_OSD_OP_FLAG_FADVISE_NOCACHE) {
+        op->set_bypass_cache();
+      }
+      break;
     default:
       break;
     }

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -104,6 +104,9 @@ bool OpRequest::need_promote() {
 bool OpRequest::need_skip_promote() {
   return check_rmw(CEPH_OSD_RMW_FLAG_SKIP_PROMOTE);
 }
+bool OpRequest::need_bypass_cache() {
+  return check_rmw(CEPH_OSD_RMW_FLAG_BYPASS_CACHE);
+}
 
 void OpRequest::set_rmw_flags(int flags) {
 #ifdef WITH_LTTNG
@@ -123,6 +126,7 @@ void OpRequest::set_pg_op() { set_rmw_flags(CEPH_OSD_RMW_FLAG_PGOP); }
 void OpRequest::set_cache() { set_rmw_flags(CEPH_OSD_RMW_FLAG_CACHE); }
 void OpRequest::set_promote() { set_rmw_flags(CEPH_OSD_RMW_FLAG_FORCE_PROMOTE); }
 void OpRequest::set_skip_promote() { set_rmw_flags(CEPH_OSD_RMW_FLAG_SKIP_PROMOTE); }
+void OpRequest::set_bypass_cache() { set_rmw_flags(CEPH_OSD_RMW_FLAG_BYPASS_CACHE); }
 
 void OpRequest::mark_flag_point(uint8_t flag, const string& s) {
 #ifdef WITH_LTTNG

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -67,6 +67,7 @@ struct OpRequest : public TrackedOp {
   bool need_class_write_cap();
   bool need_promote();
   bool need_skip_promote();
+  bool need_bypass_cache();
   void set_read();
   void set_write();
   void set_cache();
@@ -75,6 +76,7 @@ struct OpRequest : public TrackedOp {
   void set_pg_op();
   void set_promote();
   void set_skip_promote();
+  void set_bypass_cache();
 
   void _dump(utime_t now, Formatter *f) const;
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1856,6 +1856,11 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
       return true;
     }
 
+    if (can_proxy_read && op->need_bypass_cache()) {
+      // skip promote
+      return true;
+    }
+
     // Promote too?
     switch (pool.info.min_read_recency_for_promote) {
     case 0:

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1529,7 +1529,7 @@ void ReplicatedPG::do_op(OpRequestRef& op)
   }
 
   bool in_hit_set = false;
-  if (hit_set) {
+  if (!op->need_bypass_cache() && hit_set) {
     if (obc.get()) {
       if (obc->obs.oi.soid != hobject_t() && hit_set->contains(obc->obs.oi.soid))
 	in_hit_set = true;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -261,6 +261,7 @@ enum {
   CEPH_OSD_RMW_FLAG_CACHE       = (1 << 6),
   CEPH_OSD_RMW_FLAG_FORCE_PROMOTE   = (1 << 7),
   CEPH_OSD_RMW_FLAG_SKIP_PROMOTE    = (1 << 8),
+  CEPH_OSD_RMW_FLAG_BYPASS_CACHE = (1 << 9),
 };
 
 


### PR DESCRIPTION
This patch allows one-time read operations,  for example, rbd export, to bypass cache to avoid cache pollution