### PR TITLE
bugfix: sparse read should return (extent_map, data_bufferlist)

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3605,7 +3605,7 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 
         op.extent.length = total_read;
 
-        ::encode_destructively(bl, osd_op.outdata);
+        osd_op.outdata.claim_append(bl);
         ::encode_destructively(data_bl, osd_op.outdata);
 
 	ctx->delta_stats.num_rd_kb += SHIFT_ROUND_UP(op.extent.length, 10);


### PR DESCRIPTION
From the C_ObjectOperation_sparse_read,
the code of decode likes:
::decode(*extents, iter); // map<uint64_t, uint64_t)
::decode(*data_bl, iter); // bufferlist

but in do_osd_ops, it's looks like:
::encode_destructively(bl, osd_op.outdata); // bufferlist
::encode_destructively(data_bl, osd_op.outdata); // bufferlist

So, this patch fixes it.