### PR TITLE
crypto: fix unbalanced ceph::crypto::init/ceph::crypto:shutdown

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -399,6 +399,7 @@ CephContext::CephContext(uint32_t module_type_)
     _conf(new md_config_t()),
     _log(NULL),
     _module_type(module_type_),
+    _crypto_inited(false),
     _service_thread(NULL),
     _log_obs(NULL),
     _admin_socket(NULL),
@@ -507,7 +508,14 @@ CephContext::~CephContext()
 
   delete _crypto_none;
   delete _crypto_aes;
-  ceph::crypto::shutdown();
+  if (_crypto_inited)
+    ceph::crypto::shutdown();
+}
+
+void CephContext::init_crypto()
+{
+  ceph::crypto::init(this);
+  _crypto_inited = true;
 }
 
 void CephContext::start_service_thread()

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -75,6 +75,9 @@ public:
   md_config_t *_conf;
   ceph::log::Log *_log;
 
+  /* init ceph::crypto */
+  void init_crypto();
+
   /* Start the Ceph Context's service thread */
   void start_service_thread();
 
@@ -136,6 +139,8 @@ private:
   void join_service_thread();
 
   uint32_t _module_type;
+
+  bool _crypto_inited;
 
   /* libcommon service thread.
    * SIGHUP wakes this thread, which then reopens logfiles */

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -76,6 +76,7 @@ void ceph::crypto::init(CephContext *cct)
 void ceph::crypto::shutdown()
 {
   pthread_mutex_lock(&crypto_init_mutex);
+  assert(crypto_refs > 0);
   if (--crypto_refs == 0) {
     NSS_ShutdownContext(crypto_context);
     crypto_context = NULL;

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -115,7 +115,7 @@ void complain_about_parse_errors(CephContext *cct,
  * same application. */
 void common_init_finish(CephContext *cct, int flags)
 {
-  ceph::crypto::init(cct);
+  cct->init_crypto();
 
   if (!(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))
     cct->start_service_thread();


### PR DESCRIPTION
we may create a CephContext without calling common_init_finish(), then
delete the CephContext. In this case, ceph::crypto:init() is not called, so
CephContext::~CephContext() should not call ceph::crypto::shutdown().

Fixes: #12598
Signed-off-by: Yan, Zheng <zyan@redhat.com>