### PR TITLE
rbd: support size suffixes for size-based options

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -70,9 +70,9 @@ Parameters
    Specifies the object size expressed as a number of bits, such that
    the object size is ``1 << order``. The default is 22 (4 MB).
 
-.. option:: --stripe-unit size-in-bytes
+.. option:: --stripe-unit size-in-B/K/M
 
-   Specifies the stripe unit size in bytes.  See striping section (below) for more details.
+   Specifies the stripe unit size in B/K/M.  See striping section (below) for more details.
 
 .. option:: --stripe-count num
 
@@ -176,11 +176,11 @@ Commands
   If image is a clone, information about its parent is also displayed.
   If a snapshot is specified, whether it is protected is shown as well.
 
-:command:`create` (-s | --size *size-in-M/G/T*) [--image-format *format-id*] [--order *bits*] [--stripe-unit *size-in-bytes* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *image-spec*
+:command:`create` (-s | --size *size-in-M/G/T*) [--image-format *format-id*] [--order *bits*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *image-spec*
   Will create a new rbd image. You must also specify the size via --size.  The
   --stripe-unit and --stripe-count arguments are optional, but must be used together.
 
-:command:`clone` [--order *bits*] [--stripe-unit *size-in-bytes* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *parent-snap-spec* *child-image-spec*
+:command:`clone` [--order *bits*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*] [--image-shared] *parent-snap-spec* *child-image-spec*
   Will create a clone (copy-on-write child) of the parent snapshot.
   Object order will be identical to that of the parent image unless
   specified. Size will be the same as the parent snapshot. The --stripe-unit
@@ -214,7 +214,7 @@ Commands
 :command:`export` (*image-spec* | *snap-spec*) [*dest-path*]
   Exports image to dest path (use - for stdout).
 
-:command:`import` [--image-format *format-id*] [--order *bits*] [--stripe-unit *size-in-bytes* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *src-path* [*image-spec*]
+:command:`import` [--image-format *format-id*] [--order *bits*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *src-path* [*image-spec*]
   Creates a new image and imports its data from path (use - for
   stdin).  The import operation will try to create sparse rbd images 
   if possible.  For import from stdin, the sparsification unit is
@@ -343,9 +343,9 @@ Commands
   Release a lock on an image. The lock id and locker are
   as output by lock ls.
 
-:command:`bench-write` [--io-size *size-in-bytes*] [--io-threads *num-ios-in-flight*] [--io-total *total-bytes-to-write*] [--io-pattern seq | rand] *image-spec*
+:command:`bench-write` [--io-size *size-in-B/K/M/G/T*] [--io-threads *num-ios-in-flight*] [--io-total *total-size-to-write-in-B/K/M/G/T*] [--io-pattern seq | rand] *image-spec*
   Generate a series of writes to the image and measure the write throughput and
-  latency.  Defaults are: --io-size 4096, --io-threads 16, --io-total 1GB,
+  latency.  Defaults are: --io-size 4096, --io-threads 16, --io-total 1G,
   --io-pattern seq.
 
 Image and snap specs
@@ -491,7 +491,7 @@ To create an image and a clone from it::
 
 To create an image with a smaller stripe_unit (to better distribute small writes in some workloads)::
 
-       rbd create mypool/myimage --size 102400 --stripe-unit 65536 --stripe-count 16
+       rbd create mypool/myimage --size 102400 --stripe-unit 65536B --stripe-count 16
 
 To change an image from one image format to another, export it and then
 import it as the desired image format::

--- a/src/test/cli-integration/rbd/defaults.t
+++ b/src/test/cli-integration/rbd/defaults.t
@@ -94,6 +94,63 @@ Plain create with various options specified via usual cli arguments
       "stripe_unit": 1048576
   }
   $ rbd rm test --no-progress
+  $ rbd create -s 1 test --image-format 2 --stripe-unit 1048576B --stripe-count 8
+  $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
+  {
+      "block_name_prefix": "rbd_data.*",  (glob)
+      "features": [
+          "layering", 
+          "striping", 
+          "exclusive"
+      ], 
+      "format": 2, 
+      "name": "test", 
+      "object_size": 4194304, 
+      "objects": 1, 
+      "order": 22, 
+      "size": 1048576, 
+      "stripe_count": 8, 
+      "stripe_unit": 1048576
+  }
+  $ rbd rm test --no-progress
+  $ rbd create -s 1G test --image-format 2 --stripe-unit 4K --stripe-count 8
+  $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
+  {
+      "block_name_prefix": "rbd_data.*",  (glob)
+      "features": [
+          "layering", 
+          "striping", 
+          "exclusive"
+      ], 
+      "format": 2, 
+      "name": "test", 
+      "object_size": 4194304, 
+      "objects": 256, 
+      "order": 22, 
+      "size": 1073741824, 
+      "stripe_count": 8, 
+      "stripe_unit": 4096
+  }
+  $ rbd rm test --no-progress
+  $ rbd create -s 1G test --image-format 2 --stripe-unit 1M --stripe-count 8
+  $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
+  {
+      "block_name_prefix": "rbd_data.*",  (glob)
+      "features": [
+          "layering", 
+          "striping", 
+          "exclusive"
+      ], 
+      "format": 2, 
+      "name": "test", 
+      "object_size": 4194304, 
+      "objects": 256, 
+      "order": 22, 
+      "size": 1073741824, 
+      "stripe_count": 8, 
+      "stripe_unit": 1048576
+  }
+  $ rbd rm test --no-progress
 
 Format 2 Usual arguments with custom rbd_default_* params
 =========================================================

--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -35,7 +35,7 @@ clone
   $ rbd clone bar@snap rbd_other/child
   $ rbd snap create rbd_other/child@snap
   $ rbd flatten rbd_other/child 2> /dev/null
-  $ rbd bench-write rbd_other/child --io-pattern seq --io-total 1 > /dev/null 2>&1
+  $ rbd bench-write rbd_other/child --io-pattern seq --io-total 1B > /dev/null 2>&1
 
 lock
 ====

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -71,10 +71,10 @@
     lock add <image-spec> <id> [--shared <tag>] take a lock called id on an image
     lock remove <image-spec> <id> <locker>      release a lock on an image
     bench-write <image-spec>                    simple write benchmark
-                   --io-size <bytes>              write size
-                   --io-threads <num>             ios in flight
-                   --io-total <bytes>             total bytes to write
-                   --io-pattern <seq|rand>        write pattern
+                 --io-size <size in B/K/M/G/T>    write size
+                 --io-threads <num>               ios in flight
+                 --io-total <size in B/K/M/G/T>   total size to write
+                 --io-pattern <seq|rand>          write pattern
   
   <image-spec> is [<pool-name>]/<image-name>,
   <snap-spec> is [<pool-name>]/<image-name>@<snap-name>,
@@ -98,7 +98,7 @@
                                        use multiple times to enable multiple features
     --image-shared                     image will be used concurrently (disables
                                        RBD exclusive lock and dependent features)
-    --stripe-unit <size-in-bytes>      size (in bytes) of a block of data
+    --stripe-unit <size in B/K/M>      size of a block of data
     --stripe-count <num>               number of consecutive objects in a stripe
     --id <username>                    rados user (without 'client.'prefix) to
                                        authenticate as


### PR DESCRIPTION
This patch will provide support for size suffixes for
below given options:

--stripe-unit [size in B/K/M]
--io-size [size in B/K/M/G/T]
--io-total [size in B/K/M/G/T]

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>