### PR TITLE
RGW Swift API: responses for several request types don't contain mandatory Content-Type header

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -501,6 +501,10 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
     dump_access_control(s, op);
   }
 
+  if (s->prot_flags & RGW_REST_SWIFT) {
+    force_content_type = true;
+  }
+
   /* do not send content type if content length is zero
      and the content type was not set by the user */
   if (force_content_type || (!content_type &&  s->formatter->get_len()  != 0) || s->err.is_err()){

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -500,7 +500,9 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
     dump_access_control(s, op);
   }
 
-  if (!content_type || s->err.is_err()) {
+  /* do not send content type if content length is zero
+     and the content type was not set by the user */
+  if ((s->formatter->get_len()  != 0 && !content_type) || s->err.is_err()){
     switch (s->format) {
     case RGW_FORMAT_XML:
       ctype = "application/xml";
@@ -530,9 +532,13 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
       dump_content_length(s, proposed_content_length);
     }
   }
-  int r = s->cio->print("Content-type: %s\r\n", content_type);
-  if (r < 0) {
-    ldout(s->cct, 0) << "ERROR: s->cio->print() returned err=" << r << dendl;
+
+  int r;
+  if (content_type) {
+      r = s->cio->print("Content-type: %s\r\n", content_type);
+      if (r < 0) {
+	ldout(s->cct, 0) << "ERROR: s->cio->print() returned err=" << r << dendl;
+      }
   }
   r = s->cio->complete_header();
   if (r < 0) {

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -492,7 +492,8 @@ void dump_start(struct req_state *s)
   }
 }
 
-void end_header(struct req_state *s, RGWOp *op, const char *content_type, const int64_t proposed_content_length)
+void end_header(struct req_state *s, RGWOp *op, const char *content_type, const int64_t proposed_content_length,
+		bool force_content_type)
 {
   string ctype;
 
@@ -502,7 +503,7 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
 
   /* do not send content type if content length is zero
      and the content type was not set by the user */
-  if ((s->formatter->get_len()  != 0 && !content_type) || s->err.is_err()){
+  if (force_content_type || (!content_type &&  s->formatter->get_len()  != 0) || s->err.is_err()){
     switch (s->format) {
     case RGW_FORMAT_XML:
       ctype = "application/xml";

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -365,7 +365,8 @@ extern void dump_errno(struct req_state *s, int ret);
 extern void end_header(struct req_state *s,
                        RGWOp *op = NULL,
                        const char *content_type = NULL,
-                       const int64_t proposed_content_length = NO_CONTENT_LENGTH);
+                       const int64_t proposed_content_length = NO_CONTENT_LENGTH,
+		       bool force_content_type = false);
 extern void dump_start(struct req_state *s);
 extern void list_all_buckets_start(struct req_state *s);
 extern void dump_owner(struct req_state *s, string& id, string& name, const char *section = NULL);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -54,7 +54,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
     set_req_state_err(s, ret);
   }
   dump_errno(s);
-  end_header(s, NULL);
+  end_header(s, NULL, NULL, true);
 
   if (!ret) {
     dump_start(s);
@@ -295,7 +295,8 @@ void RGWStatAccount_ObjStore_SWIFT::send_response()
   set_req_state_err(s, ret);
   dump_errno(s);
 
-  end_header(s, NULL, NULL, 0);
+  end_header(s, NULL, NULL, 0,  true);
+
   dump_start(s);
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/12246
http://tracker.ceph.com/issues/12632
http://tracker.ceph.com/issues/12634
