### PR TITLE
os/FileJournal: For linux use logic block size as alignment for directio.

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -53,6 +53,14 @@ int get_block_device_size(int fd, int64_t *psize)
   return ret;
 }
 
+int get_logic_block_size(int fd, size_t *bsize)
+{
+  int ret = ::ioctl(fd, BLKSSZGET, bsize);
+  if (ret < 0)
+    *bsize = CEPH_PAGE_SIZE;
+  return 0;
+}
+
 /**
  * get the base device (strip off partition suffix and /dev/ prefix)
  *  e.g.,
@@ -210,6 +218,12 @@ int get_device_by_uuid(uuid_d dev_uuid, const char* label, char* partition,
 #elif defined(__APPLE__)
 #include <sys/disk.h>
 
+int get_logic_block_size(int fd, size_t *bsize)
+{
+  *bsize = CEPH_PAGE_SIZE;
+  return 0;
+}
+
 int get_block_device_size(int fd, int64_t *psize)
 {
   unsigned long blocksize = 0;
@@ -242,6 +256,12 @@ int get_device_by_uuid(uuid_d dev_uuid, const char* label, char* partition,
 }
 #elif defined(__FreeBSD__)
 #include <sys/disk.h>
+
+int get_logic_block_size(int fd, size_t *bsize)
+{
+  *bsize = CEPH_PAGE_SIZE;
+  return 0;
+}
 
 int get_block_device_size(int fd, int64_t *psize)
 {

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -6,6 +6,7 @@ extern void set_block_device_sandbox_dir(const char *dir);
 
 extern int get_block_device_base(const char *dev, char *out, size_t out_len);
 extern int get_block_device_size(int fd, int64_t *psize);
+extern int get_logic_block_size(int fd, size_t *bsize);
 extern int64_t get_block_device_int_property(const char *devname, const char *property);
 extern bool block_device_support_discard(const char *devname);
 extern int block_device_discard(int fd, int64_t offset, int64_t len);


### PR DESCRIPTION

For directio, it limited by offset and size. At present, it use
CEPH_PAGE_SIZE(4k) as alignment to limit offset and size. But in linux,
in really it limited by logic size(at present is 512Byte).
Using 512B have two benefits:
a)decrease the pad size,especially for small write.
b)reduce the memcopy when tune aligment of buffer.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>