### PR TITLE
rgw:add --reset-regions for regionmap update

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -165,6 +165,7 @@ void _usage()
   cout << "   --categories=<list>       comma separated list of categories, used in usage show\n";
   cout << "   --caps=<caps>             list of caps (e.g., \"usage=read, write; user=read\"\n";
   cout << "   --yes-i-really-mean-it    required for certain operations\n";
+  cout << "   --reset-regions           reset regionmap when regionmap update";
   cout << "\n";
   cout << "<date> := \"YYYY-MM-DD[ hh:mm:ss]\"\n";
   cout << "\nQuota options:\n";
@@ -1142,6 +1143,7 @@ int main(int argc, char **argv)
   int include_all = false;
 
   int sync_stats = false;
+  int reset_regions = false;
 
   uint64_t min_rewrite_size = 4 * 1024 * 1024;
   uint64_t max_rewrite_size = ULLONG_MAX;
@@ -1313,6 +1315,8 @@ int main(int argc, char **argv)
     } else if (ceph_argparse_binary_flag(args, i, &sync_stats, NULL, "--sync-stats", (char*)NULL)) {
      // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &include_all, NULL, "--include-all", (char*)NULL)) {
+     // do nothing
+    } else if (ceph_argparse_binary_flag(args, i, &reset_regions, NULL, "--reset-regions", (char*)NULL)) {
      // do nothing
     } else if (ceph_argparse_witharg(args, i, &val, "--caps", (char*)NULL)) {
       caps = val;
@@ -1550,6 +1554,10 @@ int main(int argc, char **argv)
       if (ret < 0) {
         cerr << "failed to list regions: " << cpp_strerror(-ret) << std::endl;
 	return -ret;
+      }
+
+      if (reset_regions) {
+        regionmap.regions.clear();
       }
 
       for (list<string>::iterator iter = regions.begin(); iter != regions.end(); ++iter) {

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -122,7 +122,8 @@
      --categories=<list>       comma separated list of categories, used in usage show
      --caps=<caps>             list of caps (e.g., "usage=read, write; user=read"
      --yes-i-really-mean-it    required for certain operations
-  
+     --reset-regions           reset regionmap when regionmap update
+ 
   <date> := "YYYY-MM-DD[ hh:mm:ss]"
   
   Quota options:


### PR DESCRIPTION

Delete a region and update region-map, region-map still contain the deleted region data.
region-map update just add new but did not remove the old.

Since operational errors，The original pull request was closed
https://github.com/ceph/ceph/pull/5363

Signed-off-by: duanweijun duanweijun@h3c.com