### PR TITLE
mds: fix setting whole layout in one vxattr

### DIFF
--- a/qa/workunits/fs/misc/layout_vxattrs.sh
+++ b/qa/workunits/fs/misc/layout_vxattrs.sh
@@ -45,6 +45,12 @@ getfattr -n ceph.file.layout.stripe_count file2 | grep -q 16
 getfattr -n ceph.file.layout.object_size file2 | grep -q 41943040
 getfattr -n ceph.file.layout.pool file2 | grep -q data
 
+setfattr -n ceph.file.layout -v "stripe_unit=2097152 stripe_count=4 object_size=2097152 pool=data" file2
+getfattr -n ceph.file.layout.stripe_unit file2 | grep -q 2097152
+getfattr -n ceph.file.layout.stripe_count file2 | grep -q 4
+getfattr -n ceph.file.layout.object_size file2 | grep -q 2097152
+getfattr -n ceph.file.layout.pool file2 | grep -q data
+
 # dir
 rm -f dir/file || true
 rmdir dir || true

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3865,7 +3865,7 @@ struct keys_and_values
 };
 
 int Server::parse_layout_vxattr(string name, string value, const OSDMap *osdmap,
-				ceph_file_layout *layout)
+				ceph_file_layout *layout, bool validate)
 {
   dout(20) << "parse_layout_vxattr name " << name << " value '" << value << "'" << dendl;
   try {
@@ -3882,7 +3882,10 @@ int Server::parse_layout_vxattr(string name, string value, const OSDMap *osdmap,
       if (begin != end)
 	return -EINVAL;
       for (map<string,string>::iterator q = m.begin(); q != m.end(); ++q) {
-	int r = parse_layout_vxattr(string("layout.") + q->first, q->second, osdmap, layout);
+        // Skip validation on each attr, we do it once at the end (avoid
+        // rejecting intermediate states if the overall result is ok)
+	int r = parse_layout_vxattr(string("layout.") + q->first, q->second,
+                                    osdmap, layout, false);
 	if (r < 0)
 	  return r;
       }
@@ -3912,7 +3915,7 @@ int Server::parse_layout_vxattr(string name, string value, const OSDMap *osdmap,
     return -EINVAL;
   }
 
-  if (!ceph_file_layout_is_valid(layout)) {
+  if (validate && !ceph_file_layout_is_valid(layout)) {
     dout(10) << "bad layout" << dendl;
     return -EINVAL;
   }

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -176,7 +176,7 @@ public:
   void handle_client_setdirlayout(MDRequestRef& mdr);
 
   int parse_layout_vxattr(string name, string value, const OSDMap *osdmap,
-			  ceph_file_layout *layout);
+			  ceph_file_layout *layout, bool validate=true);
   int parse_quota_vxattr(string name, string value, quota_info_t *quota);
   void handle_set_vxattr(MDRequestRef& mdr, CInode *cur,
 			 ceph_file_layout *dir_layout,


### PR DESCRIPTION
Previously we were validating the layout
after setting each field, so even when
setting multiple fields in one go (to
something valid) the intermediate states
could be invalid and cause a bogus EINVAL.

For example try setting object_size and stripe_unit
both to 2M in one go.

Signed-off-by: John Spray <john.spray@redhat.com>