### PR TITLE
make setuid/gid conditional on a matching file/directory on disk

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,34 @@
+
 v9.0.4
 ======
+
+Upgrading
+---------
+
+* Ceph daemons now run as user and group ceph by default.  During upgrade,
+  administrators have two options:
+
+   #. Add the following line to ``ceph.conf`` on all hosts::
+
+        setuser match path = /var/lib/ceph/$type/$cluster-$id
+
+      This will make the daemon remain root (i.e., not drop privileges and
+      switch to user ceph) if the daemon's data directory is still owned by
+      root.  Newly deployed daemons will be created with data owned by user
+      ceph and will run with reduced privileges, but upgraded daemons will
+      continue to run as root.
+
+   #. Fix the data ownership during the upgrade.  This is the preferred option,
+      but is more work.  The process for each host would be to:
+
+      #. Upgrade the ceph package.  This creates the ceph user and group.
+      #. Stop the daemon(s)
+      #. Fix the ownership.  E.g.,::
+
+          chown -R ceph:ceph /var/lib/ceph/mon/ceph-foo
+	  ceph-disk chown /dev/sdb1
+
+      #. Restart the daemon(s)
 
 
 v9.0.3

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -31,6 +31,7 @@ OPTION(crushtool, OPT_STR, "crushtool") // crushtool utility path
 OPTION(daemonize, OPT_BOOL, false) // default changed by common_preinit()
 OPTION(setuser, OPT_STR, "")        // uid or user name
 OPTION(setgroup, OPT_STR, "")        // gid or group name
+OPTION(setuser_match_path, OPT_STR, "")  // make setuser/group conditional on this patch matching ownership
 OPTION(pid_file, OPT_STR, "") // default changed by common_preinit()
 OPTION(chdir, OPT_STR, "/")
 OPTION(max_open_files, OPT_LONGLONG, 0)

--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -7,9 +7,7 @@ PartOf=ceph.target
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-User=ceph
-Group=ceph
-ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i
+ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -13,9 +13,7 @@ PartOf=ceph.target
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-User=ceph
-Group=ceph
-ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i
+ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -8,7 +8,7 @@ PartOf=ceph.target
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecStartPre=/usr/libexec/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --setuser ceph --setgroup ceph --id %i
+ExecStartPre=/usr/libexec/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -7,7 +7,7 @@ PartOf=ceph.target
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i
+ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
 
 [Install]
 WantedBy=ceph.target


### PR DESCRIPTION
We need to handle newly-deployed daemons, where teh data dir is owned by
ceph:ceph, as well as upgraded daemons, where the data is owned by root:root.

Do this my only doing the setuid if the specified path matches.

The only problem I see with this is that if the directory is owned by some
random user (neither root nor ceph) we will still start and run the daemon
as root.  (The exceptoin is the osd, which has an explicit check for this in
ceph-osd-prestart.sh.)  I think this is okay... but open to adding more
strict checks here too!