### PR TITLE
doc/rados/operations/add-or-rm-mons: simplify the steps to add a mon

### DIFF
--- a/doc/rados/operations/add-or-rm-mons.rst
+++ b/doc/rados/operations/add-or-rm-mons.rst
@@ -114,11 +114,6 @@ on ``mon.a``).
 	sudo ceph-mon -i {mon-id} --mkfs --monmap {tmp}/{map-filename} --keyring {tmp}/{key-filename}
 	
 
-#. Add the new monitor to the list of monitors for you cluster (runtime). This enables 
-   other nodes to use this monitor during their initial startup. ::
-
-	ceph mon add <mon-id> <ip>[:<port>]
-
 #. Start the new monitor and it will automatically join the cluster.
    The daemon needs to know which address to bind to, either via
    ``--public-addr {ip:port}`` or by setting ``mon addr`` in the


### PR DESCRIPTION
actually "ceph mon add" is not necessary, so remove it.

http://tracker.ceph.com/issues/12620 Fixes: #12620
Signed-off-by: Kefu Chai <kchai@redhat.com>