### PR TITLE
osd: load all shards fd concurrenttly in cold pool

### DIFF
--- a/src/os/FileStore.h
+++ b/src/os/FileStore.h
@@ -395,6 +395,7 @@ public:
     bool create,
     FDRef *outfd,
     Index *index = 0);
+  bool fd_has_cache(coll_t cid, const ghobject_t& oid);
 
   void lfn_close(FDRef fd);
   int lfn_link(coll_t c, coll_t newcid, const ghobject_t& o, const ghobject_t& newoid) ;

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -21,6 +21,7 @@
 #include "common/TrackedOp.h"
 #include "common/WorkQueue.h"
 #include "ObjectMap.h"
+#include "FDCache.h"
 
 #include <errno.h>
 #include <sys/stat.h>
@@ -1805,6 +1806,16 @@ public:
     uint32_t op_flags = 0,
     bool allow_eio = false) = 0;
 
+   virtual bool fd_has_cache(
+    coll_t cid,
+    const ghobject_t& oid) { return true; }
+
+   virtual int lfn_open(
+    coll_t cid,
+    const ghobject_t& oid,
+    bool create,
+    FDRef *outfd,
+    Index *index = 0) { return 0; }
   /**
    * fiemap -- get extent map of data of an object
    *

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -671,6 +671,22 @@ bool ECBackend::can_handle_while_inactive(
   return false;
 }
 
+void ECBackend::object_fd_load(ECSubRead &op)
+{
+  for (map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> > >::iterator i =
+       op.to_read.begin();
+       i != op.to_read.end();
+       ++i) {
+    for (list<boost::tuple<uint64_t, uint64_t, uint32_t> >::iterator j = i->second.begin();
+         j != i->second.end();
+         ++j) {
+      ghobject_t g(i->first, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard);
+      FDRef fd;
+      store->lfn_open(coll, g, false, &fd);
+    }
+  }
+}
+
 bool ECBackend::handle_message(
   OpRequestRef _op)
 {
@@ -691,13 +707,17 @@ bool ECBackend::handle_message(
   }
   case MSG_OSD_EC_READ: {
     MOSDECSubOpRead *op = static_cast<MOSDECSubOpRead*>(_op->get_req());
-    MOSDECSubOpReadReply *reply = new MOSDECSubOpReadReply;
-    reply->pgid = get_parent()->primary_spg_t();
-    reply->map_epoch = get_parent()->get_epoch();
-    handle_sub_read(op->op.from, op->op, &(reply->op));
-    op->set_priority(priority);
-    get_parent()->send_message_osd_cluster(
-      op->op.from.osd, reply, get_parent()->get_epoch());
+    if (op->op.fd_load) {
+      object_fd_load(op->op);
+    } else {
+      MOSDECSubOpReadReply *reply = new MOSDECSubOpReadReply;
+      reply->pgid = get_parent()->primary_spg_t();
+      reply->map_epoch = get_parent()->get_epoch();
+      handle_sub_read(op->op.from, op->op, &(reply->op));
+      op->set_priority(priority);
+      get_parent()->send_message_osd_cluster(
+        op->op.from.osd, reply, get_parent()->get_epoch());
+    }
     return true;
   }
   case MSG_OSD_EC_READ_REPLY: {
@@ -1582,6 +1602,7 @@ void ECBackend::start_read_op(
 	messages[*k].to_read[i->first].push_back(boost::make_tuple(chunk_off_len.first,
 								    chunk_off_len.second,
 								    j->get<2>()));
+        messages[*k].fd_load = false;
       }
       assert(!need_attrs);
     }
@@ -1673,6 +1694,64 @@ void ECBackend::start_remaining_read_op(
       get_parent()->get_epoch());
   }
   dout(10) << __func__ << ": started additional " << op << dendl;
+}
+
+void ECBackend::warmup_object_fd(const hobject_t &hoid, OpRequestRef op, bool fast_read)
+{
+  // if primary has cache fd, we think other shards also cache it?
+  bool fd_cache = store->fd_has_cache(
+    coll,
+    ghobject_t(
+      hoid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard));
+  if (fd_cache) {
+     dout(10) << __func__ << " hoid " << hoid << " fd has been cache" << dendl;
+     return;
+  }
+
+  map<pg_shard_t, ECSubRead> messages;
+  const vector<int> &chunk_mapping = ec_impl->get_chunk_mapping();
+  set<int> want_to_read;
+  for (int i = 0; i < (int)ec_impl->get_data_chunk_count(); ++i) {
+    int chunk = (int)chunk_mapping.size() > i ? chunk_mapping[i] : i;
+    want_to_read.insert(chunk);
+  }
+  set<pg_shard_t> shards;
+  int r = get_min_avail_to_read_shards(
+    hoid,
+    want_to_read,
+    false,
+    fast_read,
+    &shards);
+  assert(r == 0);
+  for (set<pg_shard_t>::const_iterator k = shards.begin();
+       k != shards.end();
+       ++k) {
+    messages[*k].to_read[hoid].push_back(boost::make_tuple(0, 0, 0));
+    messages[*k].fd_load = true;
+  }
+  int priority = cct->_conf->osd_client_op_priority;
+  ceph_tid_t tid = get_parent()->get_tid();
+  for (map<pg_shard_t, ECSubRead>::iterator i = messages.begin();
+       i != messages.end();
+       ++i) {
+    if (i->first == get_parent()->whoami_shard()) {
+      continue;
+    }
+    i->second.tid = tid;
+    MOSDECSubOpRead *msg = new MOSDECSubOpRead;
+    msg->set_priority(priority);
+    msg->pgid = spg_t(
+      get_parent()->whoami_spg_t().pgid,
+      i->first.shard);
+    msg->map_epoch = get_parent()->get_epoch();
+    msg->op = i->second;
+    msg->op.from = get_parent()->whoami_shard();
+    msg->op.tid = tid;
+    get_parent()->send_message_osd_cluster(
+      i->first.osd,
+      msg,
+      get_parent()->get_epoch());
+  }
 }
 
 ECUtil::HashInfoRef ECBackend::get_hash_info(

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -147,6 +147,8 @@ public:
 		    pair<bufferlist*, Context*> > > &to_read,
     Context *on_complete,
     bool fast_read = false);
+  void object_fd_load(ECSubRead &op);
+  void warmup_object_fd(const hobject_t &hoid, OpRequestRef op, bool fast_read);
 
 private:
   friend struct ECRecoveryHandle;

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -171,21 +171,23 @@ void ECSubRead::encode(bufferlist &bl, uint64_t features) const
     }
     ::encode(tmp, bl);
     ::encode(attrs_to_read, bl);
+    ::encode(fd_load, bl);
     ENCODE_FINISH(bl);
     return;
   }
 
-  ENCODE_START(2, 2, bl);
+  ENCODE_START(3, 2, bl);
   ::encode(from, bl);
   ::encode(tid, bl);
   ::encode(to_read, bl);
   ::encode(attrs_to_read, bl);
+  ::encode(fd_load, bl);
   ENCODE_FINISH(bl);
 }
 
 void ECSubRead::decode(bufferlist::iterator &bl)
 {
-  DECODE_START(2, bl);
+  DECODE_START(3, bl);
   ::decode(from, bl);
   ::decode(tid, bl);
   if (struct_v == 1) {
@@ -204,6 +206,9 @@ void ECSubRead::decode(bufferlist::iterator &bl)
     ::decode(to_read, bl);
   }
   ::decode(attrs_to_read, bl);
+  if (struct_v >= 3) {
+    ::decode(fd_load, bl);
+  }
   DECODE_FINISH(bl);
 }
 
@@ -213,7 +218,8 @@ std::ostream &operator<<(
   return lhs
     << "ECSubRead(tid=" << rhs.tid
     << ", to_read=" << rhs.to_read
-    << ", attrs_to_read=" << rhs.attrs_to_read << ")";
+    << ", attrs_to_read=" << rhs.attrs_to_read
+    << ", fd_load=" << rhs.fd_load << ")";
 }
 
 void ECSubRead::dump(Formatter *f) const

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -102,10 +102,12 @@ struct ECSubRead {
   ceph_tid_t tid;
   map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >, hobject_t::BitwiseComparator> to_read;
   set<hobject_t, hobject_t::BitwiseComparator> attrs_to_read;
+  bool fd_load;
   void encode(bufferlist &bl, uint64_t features) const;
   void decode(bufferlist::iterator &bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ECSubRead*>& o);
+  ECSubRead() : fd_load(false) {}
 };
 WRITE_CLASS_ENCODER_FEATURES(ECSubRead)
 

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -547,6 +547,9 @@
 		pair<bufferlist*, Context*> > > &to_read,
      Context *on_complete, bool fast_read = false) = 0;
 
+   virtual void warmup_object_fd(
+     const hobject_t &hoid, OpRequestRef op, bool fast_read) {}
+
    virtual bool scrub_supported() { return false; }
    void be_scan_list(
      ScrubMap &map, const vector<hobject_t> &ls, bool deep, uint32_t seed,

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1628,6 +1628,10 @@ void ReplicatedPG::do_op(OpRequestRef& op)
     return;
   }
 
+  if (pool.info.require_rollback()) {
+    pgbackend->warmup_object_fd(oid, op, get_pool().fast_read);
+  }
+
   int r = find_object_context(
     oid, &obc, can_create,
     m->has_flag(CEPH_OSD_FLAG_MAP_SNAP_CLONE),


### PR DESCRIPTION
in tier pool, there may be millions of objects in each osd because the object is much smaller in cool pool. so it is hard to cache too many object's fd. osd spend more time on getting fd than readding data especially for 4k read . Because there are too many subdirectories, such as
```
/var/lib/ceph/osd/ceph-48/current/2.44b_head/DIR_B/DIR_4/DIR_4/DIR_0/rb.0.5923a8.6b8b4567.000000002feb__head_6DD4044B__2 
```
When read miss in hot pool, hot pool send do proxy read to cool pool. Primary osd get the obc (if fd is not cache it, it should get the fd first) when receive the read and then the osd send sub_read to all shards. The shards may get the fd first and then read data. But in this case, cool pool should get the object fd of primary osd first and then get the object fd of other shards' second. This would take
more time.

I think maybe we could get fd of primary and other shards concurrenttly. primary osd send 'load fd msg' to other shards to complete it.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>