### PR TITLE
rgw: avoid stuck worker thread infinitely when there are PG stuck at peering

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1015,6 +1015,12 @@ OPTION(rgw_override_bucket_index_max_shards, OPT_U32, 0)
 OPTION(rgw_bucket_index_max_aio, OPT_U32, 8)
 
 /**
+ * Represents the number of seconds radosgw would tolerate when communicating with
+ * OSD (including retry), 0 means it would wati infinitely
+ */
+OPTION(rgw_osd_op_could_wait_secs, OPT_U32,  0)
+
+/**
  * whether or not the quota/gc threads should be started
  */
 OPTION(rgw_enable_quota_threads, OPT_BOOL, true)

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1038,6 +1038,13 @@ namespace librados
 
     config_t cct();
 
+    /**
+     * Set number of seconds the client could wait (upon unavailable)  for
+     * the following operations on this IoCtx.  A value of 0 (by default) means
+     * client want to wait infinitely.
+     */
+    void set_could_wait_secs(uint32_t t);
+
   private:
     /* You can only get IoCtx instances from Rados */
     IoCtx(IoCtxImpl *io_ctx_impl_);

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -50,6 +50,10 @@ struct librados::IoCtxImpl {
   std::list<std::string> cached_pool_names;
 
   Objecter *objecter;
+  
+  // Number of seconds client could wait for operations on this Ctx,
+  // a value of 0 means client could wait infinitely
+  uint32_t could_wait_secs;
 
   IoCtxImpl();
   IoCtxImpl(RadosClient *c, Objecter *objecter,
@@ -79,6 +83,10 @@ struct librados::IoCtxImpl {
   void put() {
     if (ref_cnt.dec() == 0)
       delete this;
+  }
+
+  void set_could_wait_secs(uint32_t t) {
+    could_wait_secs = t;
   }
 
   void queue_aio_write(struct AioCompletionImpl *c);
@@ -146,7 +154,7 @@ struct librados::IoCtxImpl {
   int operate_read(const object_t& oid, ::ObjectOperation *o, bufferlist *pbl, int flags=0);
   int aio_operate(const object_t& oid, ::ObjectOperation *o,
 		  AioCompletionImpl *c, const SnapContext& snap_context,
-		  int flags);
+                  int flags);
   int aio_operate_read(const object_t& oid, ::ObjectOperation *o,
 		       AioCompletionImpl *c, int flags, bufferlist *pbl);
 

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -1329,7 +1329,7 @@ int librados::IoCtx::operate(const std::string& oid, librados::ObjectWriteOperat
   return io_ctx_impl->operate(obj, (::ObjectOperation*)o->impl, o->pmtime);
 }
 
-int librados::IoCtx::operate(const std::string& oid, librados::ObjectReadOperation *o, bufferlist *pbl)
+int librados::IoCtx::operate(const std::string& oid, librados::ObjectReadOperation *o, bufferlist *pbl) 
 {
   object_t obj(oid);
   return io_ctx_impl->operate_read(obj, (::ObjectOperation*)o->impl, pbl);
@@ -1857,6 +1857,11 @@ uint32_t librados::IoCtx::get_object_pg_hash_position(const std::string& oid)
 librados::config_t librados::IoCtx::cct()
 {
   return (config_t)io_ctx_impl->client->cct;
+}
+
+void librados::IoCtx::set_could_wait_secs(uint32_t t)
+{
+  io_ctx_impl->set_could_wait_secs(t);
 }
 
 librados::IoCtx::IoCtx(IoCtxImpl *io_ctx_impl_)

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1456,6 +1456,8 @@ private:
   hobject_t generate_temp_object();  ///< generate a new temp object name
   /// generate a new temp object name (for recovery)
   hobject_t get_temp_recovery_object(eversion_t version, snapid_t snap);
+  /// check if the op has the want_wait flag set or not
+  bool want_wait(OpRequestRef& op);
 public:
   coll_t get_coll() {
     return coll;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2127,6 +2127,14 @@ void Objecter::_send_op_account(Op *op)
   }
 }
 
+void Objecter::_op_resubmit(Op *op)
+{
+  RWLock::RLocker l(rwlock);
+  RWLock::Context lc(rwlock, RWLock::Context::TakenForRead);
+  assert(initialized.read());
+  _op_submit(op, lc);
+}
+
 ceph_tid_t Objecter::_op_submit(Op *op, RWLock::Context& lc)
 {
   assert(rwlock.is_locked());
@@ -2832,6 +2840,13 @@ MOSDOp *Objecter::_prepare_osd_op(Op *op)
 			 osdmap->get_epoch(),
 			 flags, op->features);
 
+  // if the wait interval is given, we hint to OSD that we don't
+  // want to wait if the OP couldn't be processed at the moment,
+  // and we can decide the retry at client side
+  if (op->could_wait_secs) {
+    m->set_op_want_wait(false);
+  }
+
   m->set_snapid(op->snapid);
   m->set_snap_seq(op->snapc.seq);
   m->set_snaps(op->snapc.snaps);
@@ -3038,6 +3053,24 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     return;
   }
 
+  if (rc == -EHOSTDOWN) {
+    ldout(cct, 7) << " got -EHOSTDOWN " << dendl;
+
+    utime_t now = ceph_clock_now(cct);
+    uint32_t to_wait = op->attempts * 2; // expotential backoff for wait
+    if ((now - op->mtime).sec() + to_wait  < op->could_wait_secs) {
+      ldout(cct, 7) << " wait " << to_wait << " seconds and will resubmit" << dendl;
+
+      _session_op_remove(s, op);
+      Mutex::Locker l(timer_lock);
+      timer.add_event_after(to_wait, new ResubmitOpContext(op, this));
+
+      s->lock.unlock();
+      put_session(s);
+      m->put();
+      return;
+    }
+  }
   if (rc == -EAGAIN) {
     ldout(cct, 7) << " got -EAGAIN, resubmitting" << dendl;
 

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1213,6 +1213,10 @@ public:
 
     osd_reqid_t reqid; // explicitly setting reqid
 
+    /// number of seconds client could  wait/retry,
+    /// A value of 0 means client could wait infinitely
+    uint32_t could_wait_secs;
+
     Op(const object_t& o, const object_locator_t& ol, vector<OSDOp>& op,
        int f, Context *ac, Context *co, version_t *ov, int *offset = NULL) :
       session(NULL), incarnation(0),
@@ -1235,7 +1239,8 @@ public:
       should_resend(true),
       ctx_budgeted(false),
       data_offset(offset),
-      last_force_resend(0) {
+      last_force_resend(0),
+      could_wait_secs(0) {
       ops.swap(op);
       
       /* initialize out_* to match op vector */
@@ -1450,6 +1455,15 @@ public:
       } else {
         final_finish->complete(r);
       }
+    }
+  };
+
+  struct ResubmitOpContext: public Context {
+    Op *op;
+    Objecter *objecter;
+    ResubmitOpContext(Op *o, Objecter *ob) : op(o), objecter(ob) {}
+    void finish(int r) {
+      objecter->_op_resubmit(op);
     }
   };
   
@@ -1972,6 +1986,7 @@ private:
   // low-level
   ceph_tid_t _op_submit(Op *op, RWLock::Context& lc);
   ceph_tid_t _op_submit_with_budget(Op *op, RWLock::Context& lc, int *ctx_budget = NULL);
+  void _op_resubmit(Op *op);
   inline void unregister_op(Op *op);
 
   // public interface
@@ -2066,27 +2081,30 @@ public:
 	       ObjectOperation& op,
 	       const SnapContext& snapc, utime_t mtime, int flags,
 	       Context *onack, Context *oncommit, version_t *objver = NULL,
-	       osd_reqid_t reqid = osd_reqid_t()) {
+	       osd_reqid_t reqid = osd_reqid_t(),
+               uint32_t could_wait_secs = 0) {
     Op *o = new Op(oid, oloc, op.ops, flags | global_op_flags.read() | CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
     o->priority = op.priority;
     o->mtime = mtime;
     o->snapc = snapc;
     o->out_rval.swap(op.out_rval);
     o->reqid = reqid;
+    o->could_wait_secs = could_wait_secs;
     return o;
   }
   ceph_tid_t mutate(const object_t& oid, const object_locator_t& oloc,
 	       ObjectOperation& op,
 	       const SnapContext& snapc, utime_t mtime, int flags,
 	       Context *onack, Context *oncommit, version_t *objver = NULL,
-	       osd_reqid_t reqid = osd_reqid_t()) {
-    Op *o = prepare_mutate_op(oid, oloc, op, snapc, mtime, flags, onack, oncommit, objver, reqid);
+	       osd_reqid_t reqid = osd_reqid_t(), uint32_t could_wait_secs = 0) {
+    Op *o = prepare_mutate_op(oid, oloc, op, snapc, mtime, flags, onack, oncommit, objver, reqid, could_wait_secs);
     return op_submit(o);
   }
   Op *prepare_read_op(const object_t& oid, const object_locator_t& oloc,
 	     ObjectOperation& op,
 	     snapid_t snapid, bufferlist *pbl, int flags,
-	     Context *onack, version_t *objver = NULL, int *data_offset = NULL) {
+	     Context *onack, version_t *objver = NULL, int *data_offset = NULL,
+             uint32_t could_wait_secs = 0) {
     Op *o = new Op(oid, oloc, op.ops, flags | global_op_flags.read() | CEPH_OSD_FLAG_READ, onack, NULL, objver, data_offset);
     o->priority = op.priority;
     o->snapid = snapid;
@@ -2096,6 +2114,7 @@ public:
     o->out_bl.swap(op.out_bl);
     o->out_handler.swap(op.out_handler);
     o->out_rval.swap(op.out_rval);
+    o->could_wait_secs = could_wait_secs;
     return o;
   }
   ceph_tid_t read(const object_t& oid, const object_locator_t& oloc,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1871,6 +1871,7 @@ int RGWRados::open_bucket_pool_ctx(const string& bucket_name, const string& pool
     return r;
 
   r = rad->ioctx_create(pool.c_str(), io_ctx);
+  io_ctx.set_could_wait_secs(cct->_conf->rgw_osd_op_could_wait_secs);
 
   return r;
 }
@@ -2792,6 +2793,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     librados::IoCtx id_io_ctx;
     librados::Rados *rad = get_rados_handle();
     int r = rad->ioctx_create(pool_str, id_io_ctx);
+    id_io_ctx.set_could_wait_secs(cct->_conf->rgw_osd_op_could_wait_secs);
     if (r < 0)
       return r;
 
@@ -3199,6 +3201,7 @@ int RGWRados::get_obj_ref(const rgw_obj& obj, rgw_rados_ref *ref, rgw_bucket *bu
     return r;
 
   ref->ioctx.locator_set_key(ref->key);
+  ref->ioctx.set_could_wait_secs(cct->_conf->rgw_osd_op_could_wait_secs);
 
   return 0;
 }


### PR DESCRIPTION
At OSD side - if the op has a flag that it does not want to wait, and the PG it is hitting is at peering, reply back immediately with -EAGAIN, rather than queue it into waiting list

At librados side - Extend the API to support a timeout passed from caller, once it is set, it will switch to 'do not wait' mode and retry (polling) at client side until the timeout reaches.

At radosgw - leverage the new API and add a configuration to turn the flag to do timeout when communicating with OSD.