### PR TITLE
RFC: debian/rules: install systemd files on non-old distros

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -83,6 +83,7 @@ install: build
 	install -D -m 644 udev/50-rbd.rules $(DESTDIR)/lib/udev/rules.d/50-rbd.rules
 	install -D -m 644 udev/60-ceph-partuuid-workaround.rules $(DESTDIR)/lib/udev/rules.d/60-ceph-partuuid-workaround.rules
 	install -D -m 644 udev/95-ceph-osd.rules $(DESTDIR)/lib/udev/rules.d/95-ceph-osd.rules
+	install -D -m 644 udev/95-ceph-osd.rules.systemd $(DESTDIR)/lib/udev/rules.d/95-ceph-osd.rules
 	install -D -m 644 src/rbdmap $(DESTDIR)/etc/ceph/rbdmap
 	install -D -m 755 src/init-rbdmap $(DESTDIR)/etc/init.d/rbdmap
 
@@ -128,6 +129,26 @@ binary-arch: build install
 	mv debian/ceph/etc/init/ceph-mds* debian/ceph-mds/etc/init
 	install -d -m0755 debian/radosgw/etc/init
 	install -m0644 src/upstart/radosgw*.conf debian/radosgw/etc/init
+	# install the systemd stuff manually since we have funny service names
+	install -d -m0755 debian/ceph-common/lib/systemd/service
+	install -m0644 systemd/ceph.target debian/ceph-common/lib/systemd
+	install -d -m0755 debian/ceph/lib/systemd/service
+	install -m0644 systemd/ceph-mon@.service debian/ceph/lib/systemd
+	install -m0644 systemd/ceph-create-keys@.service debian/ceph/lib/systemd
+	install -m0644 systemd/ceph-osd@.service debian/ceph/lib/systemd
+	install -m0644 systemd/ceph-disk-activate@.service debian/ceph/lib/systemd
+	install -m0644 systemd/ceph-disk-activate-journal@.service debian/ceph/lib/systemd
+	install -m0644 systemd/ceph-disk-dmcrypt-activate@.service debian/ceph/lib/systemd
+	install -d -m0755 debian/ceph-mds/lib/systemd/service
+	install -m0644 systemd/ceph-mds@.service debian/ceph-mds/lib/systemd
+	install -d -m0755 debian/radosgw/lib/systemd/service
+	install -m0644 systemd/ceph-radosgw@.service debian/radosgw/lib/systemd
+
+	install -d -m0755 debian/ceph-common/lib/tmpfiles.d
+	install -m 0644 -D systemd/ceph.tmpfiles.d debian/ceph-common/lib/tmpfiles.d/ceph.conf
+	install -d -m0755 debian/radosgw/lib/tmpfiles.d
+	install -m 0644 -D systemd/ceph-rgw.tmpfiles.d debian/radosgw/lib/tmpfiles.d/ceph-rgw.conf
+
 	dh_installman -a
 	dh_lintian -a
 	dh_link -a


### PR DESCRIPTION
Old distros are defined as

 precise
 raring
 trusty
 squeeze
 wheezy

So anything super old (who cares) or newer will use systemd instead
of upstart or sysvinit.

@javacruft I'm pretty sure I'm making a mess of how debian is supposed to
handle the systemd transition... do yo uahve other suggestoins?  The main
difference here (vs upstart) is that we do *not* want to install either
upstart or sysvinit files at all in teh systemd case, whereas before we played
games to let them coexist (sort of).