### PR TITLE
erasure-code: Update ISA-L to 2.14

### DIFF
--- a/src/erasure-code/isa/CMakeLists.txt
+++ b/src/erasure-code/isa/CMakeLists.txt
@@ -54,5 +54,5 @@ set(isa_srcs
 add_library(ec_isa SHARED ${isa_srcs})
 add_dependencies(ec_isa ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ec_isa ${EXTRALIBS})
-set_target_properties(ec_isa PROPERTIES VERSION 2.10.0 SOVERSION 2)
+set_target_properties(ec_isa PROPERTIES VERSION 2.14.0 SOVERSION 2)
 install(TARGETS ec_isa DESTINATION lib/erasure-code)

--- a/src/erasure-code/isa/Makefile.am
+++ b/src/erasure-code/isa/Makefile.am
@@ -67,7 +67,7 @@ libec_isa_la_CXXFLAGS = ${AM_CXXFLAGS} -I $(srcdir)/erasure-code/isa/isa-l/inclu
 libec_isa_la_CCASFLAGS = ${AM_CCASFLAGS} -I $(abs_srcdir)/erasure-code/isa/isa-l/include/
 
 libec_isa_la_LIBADD = $(LIBCRUSH) $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_isa_la_LDFLAGS = ${AM_LDFLAGS} -version-info 2:13:0
+libec_isa_la_LDFLAGS = ${AM_LDFLAGS} -version-info 2:14:0
 if LINUX
 libec_isa_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif

--- a/src/erasure-code/isa/isa-l/erasure_code/ec_multibinary.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/ec_multibinary.asm.s
@@ -387,20 +387,9 @@ _done_gf_vect_mad_init:
 	pop	arg1
 	ret
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
-
 ;;;       func                 		core, ver, snum
-slversion ec_encode_data,		00,   03,  0133
-slversion gf_vect_mul,			00,   02,  0134
-slversion ec_encode_data_update,	00,   02,  0212
-slversion gf_vect_dot_prod,		00,   02,  0138
-slversion gf_vect_mad,			00,   01,  0213
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion ec_encode_data,		00,   04,  0133
+slversion gf_vect_mul,			00,   03,  0134
+slversion ec_encode_data_update,	00,   03,  0212
+slversion gf_vect_dot_prod,		00,   03,  0138
+slversion gf_vect_mad,			00,   02,  0213

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_2vect_dot_prod_avx(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -331,15 +333,5 @@ section .data
 align 16
 mask0f: ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_2vect_dot_prod_avx, 02,  04,  0191
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_2vect_dot_prod_avx, 02,  05,  0191

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_2vect_dot_prod_avx2(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -350,15 +352,5 @@ endproc_frame
 
 section .data
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                   core, ver, snum
-slversion gf_2vect_dot_prod_avx2, 04,  04,  0196
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_2vect_dot_prod_avx2, 04,  05,  0196

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_dot_prod_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_2vect_dot_prod_sse(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -333,15 +335,5 @@ section .data
 align 16
 mask0f: ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_2vect_dot_prod_sse, 00,  03,  0062
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_2vect_dot_prod_sse, 00,  04,  0062

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_2vect_mad_avx(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -230,15 +232,5 @@ section .data
 align 16
 mask0f: ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_2vect_mad_avx, 02,  00,  0204
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_2vect_mad_avx, 02,  01,  0204

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_2vect_mad_avx2(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -241,15 +243,5 @@ endproc_frame
 
 section .data
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func              core, ver, snum
-slversion gf_2vect_mad_avx2, 04,  00,  0205
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_2vect_mad_avx2, 04,  01,  0205

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_2vect_mad_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_2vect_mad_sse(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -233,15 +235,5 @@ align 16
 mask0f:
 	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_2vect_mad_sse, 00,  00,  0203
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_2vect_mad_sse, 00,  01,  0203

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_3vect_dot_prod_avx(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -371,15 +373,5 @@ section .data
 align 16
 mask0f: ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_3vect_dot_prod_avx, 02,  04,  0192
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_3vect_dot_prod_avx, 02,  05,  0192

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_3vect_dot_prod_avx2(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -391,15 +393,5 @@ endproc_frame
 
 section .data
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                   core, ver, snum
-slversion gf_3vect_dot_prod_avx2, 04,  04,  0197
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_3vect_dot_prod_avx2, 04,  05,  0197

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_dot_prod_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_3vect_dot_prod_sse(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -372,15 +374,5 @@ section .data
 align 16
 mask0f: ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_3vect_dot_prod_sse, 00,  05,  0063
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_3vect_dot_prod_sse, 00,  06,  0063

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_3vect_mad_avx(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -282,15 +284,5 @@ mask0f: ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 constip16:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_3vect_mad_avx, 02,  00,  0207
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_3vect_mad_avx, 02,  01,  0207

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_3vect_mad_avx2(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -311,15 +313,5 @@ constip32:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 	ddq 0xe0e1e2e3e4e5e6e7e8e9eaebecedeeef
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func              core, ver, snum
-slversion gf_3vect_mad_avx2, 04,  00,  0208
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_3vect_mad_avx2, 04,  01,  0208

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_3vect_mad_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_3vect_mad_sse(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 %ifidn __OUTPUT_FORMAT__, win64
  %define arg0  rcx
@@ -292,15 +294,5 @@ mask0f:
 constip16:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_3vect_mad_sse, 00,  00,  0206
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_3vect_mad_sse, 00,  01,  0206

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_4vect_dot_prod_avx(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -435,15 +437,5 @@ section .data
 align 16
 mask0f:	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_4vect_dot_prod_avx, 02,  04,  0193
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_4vect_dot_prod_avx, 02,  05,  0193

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_4vect_dot_prod_avx2(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -454,15 +456,5 @@ endproc_frame
 
 section .data
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                   core, ver, snum
-slversion gf_4vect_dot_prod_avx2, 04,  04,  0198
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_4vect_dot_prod_avx2, 04,  05,  0198

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_dot_prod_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_4vect_dot_prod_sse(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -437,15 +439,5 @@ section .data
 align 16
 mask0f:	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_4vect_dot_prod_sse, 00,  05,  0064
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_4vect_dot_prod_sse, 00,  06,  0064

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_4vect_mad_avx(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -330,16 +332,5 @@ mask0f:	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 constip16:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 
-
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_4vect_mad_avx, 02,  00,  020a
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_4vect_mad_avx, 02,  01,  020a

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_4vect_mad_avx2(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -336,15 +338,5 @@ constip32:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 	ddq 0xe0e1e2e3e4e5e6e7e8e9eaebecedeeef
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func              core, ver, snum
-slversion gf_4vect_mad_avx2, 04,  00,  020b
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_4vect_mad_avx2, 04,  01,  020b

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_4vect_mad_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_4vect_mad_sse(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -336,15 +338,5 @@ mask0f:
 constip16:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_4vect_mad_sse, 00,  00,  0209
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_4vect_mad_sse, 00,  01,  0209

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_5vect_dot_prod_avx(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -297,15 +299,5 @@ section .data
 align 16
 mask0f:	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_5vect_dot_prod_avx, 02,  03,  0194
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_5vect_dot_prod_avx, 02,  04,  0194

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_5vect_dot_prod_avx2(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -309,15 +311,5 @@ endproc_frame
 
 section .data
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_5vect_dot_prod_avx2, 04,  03,  0199
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_5vect_dot_prod_avx2, 04,  04,  0199

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_dot_prod_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_5vect_dot_prod_sse(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -298,15 +300,5 @@ section .data
 align 16
 mask0f:	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_5vect_dot_prod_sse, 00,  04,  0065
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_5vect_dot_prod_sse, 00,  05,  0065

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_5vect_mad_avx(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -359,15 +361,5 @@ mask0f:	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 constip16:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_5vect_mad_avx, 02,  00,  020d
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_5vect_mad_avx, 02,  01,  020d

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_5vect_mad_avx2(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -357,15 +359,5 @@ constip32:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 	ddq 0xe0e1e2e3e4e5e6e7e8e9eaebecedeeef
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_5vect_mad_avx2, 04,  00,  020e
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_5vect_mad_avx2, 04,  01,  020e

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_5vect_mad_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_5vect_mad_sse(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -367,15 +369,5 @@ mask0f:
 constip16:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_5vect_mad_sse, 00,  00,  020c
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_5vect_mad_sse, 00,  01,  020c

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_6vect_dot_prod_avx(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -309,15 +311,5 @@ section .data
 align 16
 mask0f:	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_6vect_dot_prod_avx, 02,  03,  0195
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_6vect_dot_prod_avx, 02,  04,  0195

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_6vect_dot_prod_avx2(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -320,15 +322,5 @@ endproc_frame
 
 section .data
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                   core, ver, snum
-slversion gf_6vect_dot_prod_avx2, 04,  03,  019a
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_6vect_dot_prod_avx2, 04,  04,  019a

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_dot_prod_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_6vect_dot_prod_sse(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -309,15 +311,5 @@ section .data
 align 16
 mask0f:	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_6vect_dot_prod_sse, 00,  04,  0066
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_6vect_dot_prod_sse, 00,  05,  0066

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_6vect_mad_avx(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -388,15 +390,5 @@ mask0f:	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 constip16:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_6vect_mad_avx, 02,  00,  0210
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_6vect_mad_avx, 02,  01,  0210

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_avx2.asm.s
@@ -31,6 +31,7 @@
 ;;; gf_6vect_mad_avx2(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
 
 %define PS 8
 
@@ -395,15 +396,5 @@ constip32:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 	ddq 0xe0e1e2e3e4e5e6e7e8e9eaebecedeeef
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func              core, ver, snum
-slversion gf_6vect_mad_avx2, 04,  00,  0211
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_6vect_mad_avx2, 04,  01,  0211

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_6vect_mad_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_6vect_mad_sse(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %define PS 8
 
 %ifidn __OUTPUT_FORMAT__, win64
@@ -400,15 +402,5 @@ mask0f: ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 constip16:
 	ddq 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_6vect_mad_sse, 00,  00,  020f
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_6vect_mad_sse, 00,  01,  020f

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_vect_dot_prod_avx(len, vec, *g_tbls, **buffs, *dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -265,15 +267,5 @@ align 16
 mask0f:
 ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                 core, ver, snum
-slversion gf_vect_dot_prod_avx, 02,  04,  0061
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_vect_dot_prod_avx, 02,  05,  0061

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_vect_dot_prod_avx2(len, vec, *g_tbls, **buffs, *dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -274,15 +276,5 @@ endproc_frame
 
 section .data
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                  core, ver, snum
-slversion gf_vect_dot_prod_avx2, 04,  04,  0190
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_vect_dot_prod_avx2, 04,  05,  0190

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_dot_prod_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_vect_dot_prod_sse(len, vec, *g_tbls, **buffs, *dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -265,15 +267,5 @@ align 16
 
 mask0f:	ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func                 core, ver, snum
-slversion gf_vect_dot_prod_sse, 00,  04,  0060
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_vect_dot_prod_sse, 00,  05,  0060

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_vect_mad_avx(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, win64
  %define arg0  rcx
  %define arg0.w ecx
@@ -190,15 +192,5 @@ align 16
 
 mask0f: ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func            core, ver, snum
-slversion gf_vect_mad_avx, 02,  00,  0201
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_vect_mad_avx, 02,  01,  0201

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_avx2.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_avx2.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_vect_mad_avx2(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, win64
  %define arg0   rcx
  %define arg0.w ecx
@@ -197,15 +199,5 @@ endproc_frame
 
 section .data
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_vect_mad_avx2, 04,  00,  0202
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_vect_mad_avx2, 04,  01,  0202

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mad_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_vect_mad_sse(len, vec, vec_i, mul_array, src, dest);
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, win64
  %define arg0  rcx
  %define arg0.w ecx
@@ -191,15 +193,5 @@ align 16
 
 mask0f: ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func            core, ver, snum
-slversion gf_vect_mad_sse, 00,  00,  0200
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_vect_mad_sse, 00,  01,  0200

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_avx.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_avx.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_vect_mul_avx(len, mul_array, src, dest)
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -158,15 +160,5 @@ align 16
 mask0f:
 ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func             core, ver, snum
-slversion gf_vect_mul_avx, 01,   02,  0036
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_vect_mul_avx, 01,   03,  0036

--- a/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_sse.asm.s
+++ b/src/erasure-code/isa/isa-l/erasure_code/gf_vect_mul_sse.asm.s
@@ -31,6 +31,8 @@
 ;;; gf_vect_mul_sse(len, mul_array, src, dest)
 ;;;
 
+%include "reg_sizes.asm"
+
 %ifidn __OUTPUT_FORMAT__, elf64
  %define arg0  rdi
  %define arg1  rsi
@@ -164,15 +166,5 @@ align 16
 mask0f:
 ddq 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
 ;;;       func        core, ver, snum
-slversion gf_vect_mul_sse, 00,   02,  0034
-; inform linker that this doesn't require executable stack
-section .note.GNU-stack noalloc noexec nowrite progbits
+slversion gf_vect_mul_sse, 00,   03,  0034

--- a/src/erasure-code/isa/isa-l/include/reg_sizes.asm
+++ b/src/erasure-code/isa/isa-l/include/reg_sizes.asm
@@ -27,6 +27,9 @@
 ;  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+%ifndef _REG_SIZES_ASM_
+%define _REG_SIZES_ASM_
+
 %define EFLAGS_HAS_CPUID        (1<<21)
 %define FLAG_CPUID1_ECX_CLMUL   (1<<1)
 %define FLAG_CPUID1_EDX_SSE2    (1<<26)
@@ -94,3 +97,27 @@
 %define BYTE(reg)  reg %+ b
 
 %define XWORD(reg) reg %+ x
+
+%ifidn __OUTPUT_FORMAT__,elf32
+section .note.GNU-stack noalloc noexec nowrite progbits
+section .text
+%endif
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+section .text
+%endif
+%ifidn __OUTPUT_FORMAT__, macho64
+%define elf64 macho64
+%endif
+
+%macro slversion 4
+	section .text
+	global %1_slver_%2%3%4
+	global %1_slver
+	%1_slver:
+	%1_slver_%2%3%4:
+		dw 0x%4
+		db 0x%3, 0x%2
+%endmacro
+
+%endif ; ifndef _REG_SIZES_ASM_

--- a/src/erasure-code/isa/isa-l/include/types.h
+++ b/src/erasure-code/isa/isa-l/include/types.h
@@ -41,7 +41,7 @@
 extern "C" {
 #endif
 
-#ifndef __unix__
+#ifdef __WIN32__
 #ifdef __MINGW32__
 # include <_mingw.h>
 #endif
@@ -59,12 +59,20 @@ typedef unsigned char      UINT8;
 #endif
 
 
-#ifdef __unix__
+#if defined  __unix__ || defined __APPLE__
 # define DECLARE_ALIGNED(decl, alignval) decl __attribute__((aligned(alignval)))
 # define __forceinline static inline
+# define aligned_free(x) free(x)
 #else
-# define DECLARE_ALIGNED(decl, alignval) __declspec(align(alignval)) decl
-# define posix_memalign(p, algn, len) (NULL == (*((char**)(p)) = (void*) _aligned_malloc(len, algn)))
+# ifdef __MINGW32__
+#   define DECLARE_ALIGNED(decl, alignval) decl __attribute__((aligned(alignval)))
+#   define posix_memalign(p, algn, len) (NULL == (*((char**)(p)) = (void*) _aligned_malloc(len, algn)))
+#   define aligned_free(x) _aligned_free(x)
+# else
+#   define DECLARE_ALIGNED(decl, alignval) __declspec(align(alignval)) decl
+#   define posix_memalign(p, algn, len) (NULL == (*((char**)(p)) = (void*) _aligned_malloc(len, algn)))
+#   define aligned_free(x) _aligned_free(x)
+# endif
 #endif
 
 #ifdef DEBUG


### PR DESCRIPTION
Ceph requires all .s files to annotated to assert that stack
should not be executable. see bug #10114, f60da6b and 06a245a.
In ISA-L 2.14 this issue gets fixed.
(see src/erasure-code/isa/isa-l/include/reg_sizes.asm:L102-L106)

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>