### PR TITLE
rados:in function 'do_get',the rbd id include id length in the front,cut off it.

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -273,15 +273,20 @@ static int do_get(IoCtx& io_ctx, RadosStriper& striper,
   uint64_t offset = 0;
   int ret;
   while (true) {
-    bufferlist outdata;
+    bufferlist outdatatemp;
     if (use_striper) {
-      ret = striper.read(oid, &outdata, op_size, offset);
+      ret = striper.read(oid, &outdatatemp, op_size, offset);
     } else {
-      ret = io_ctx.read(oid, outdata, op_size, offset);
+      ret = io_ctx.read(oid, outdatatemp, op_size, offset);
     }
     if (ret <= 0) {
       goto out;
     }
+
+    bufferlist outdata;
+	uint32_t len = outdatatemp.length();
+	outdatatemp.copy((unsigned)4,  len - (unsigned)4, outdata);
+
     ret = outdata.write_fd(fd);
     if (ret < 0) {
       cerr << "error writing to file: " << cpp_strerror(ret) << std::endl;
@@ -291,6 +296,7 @@ static int do_get(IoCtx& io_ctx, RadosStriper& striper,
       break;
     offset += outdata.length();
   }
+  cout<<std::endl;
   ret = 0;
 
  out:


### PR DESCRIPTION
rados:in function 'do_get',the rbd id include id length in the front,cut off it.
the bufferlist include the rbd id length,the buffer usual will be 
"\f\000\000\000\00010b52ae8944a".  "\f\000\000\000\000" indicate the length is 12,this will cause a blank line because '\f' is a formfeed.

test fix:
before
The command 'rados get -p rbd rbd_id.ff -.'will output a blank line and the rbd id link up to next line.
such as:
root@ubuntu4:/# rados get -p rbd rbd_id.ff -                                  

10b52ae8944aroot@ubuntu4:/#

after:
root@ubuntu4:/# rados get -p rbd rbd_id.ff -                                                                                                                  
10b52ae8944a
root@ubuntu4:/#   

Signed-off-by: s09816 <shi.lu@h3c.com>