### PR TITLE
rbdnamer: drop unneccessary tr usage

### DIFF
--- a/src/ceph-rbdnamer
+++ b/src/ceph-rbdnamer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 DEV=$1
-NUM=`echo $DEV | sed 's#p.*##g' | tr -d 'a-z'`
+NUM=`echo $DEV | sed 's#p.*##g; s#[a-z]##g'`
 POOL=`cat /sys/devices/rbd/$NUM/pool`
 IMAGE=`cat /sys/devices/rbd/$NUM/name`
 SNAP=`cat /sys/devices/rbd/$NUM/current_snap`


### PR DESCRIPTION
tr is not present by default in Dracut generated initramfs images. The
same logic can anyhow be performed via the existing sed call.

Signed-off-by: David Disseldorp <ddiss@suse.de>