### PR TITLE
[DNM] c++11: fix shared ptr

### DIFF
--- a/src/osd/HitSet.h
+++ b/src/osd/HitSet.h
@@ -170,7 +170,7 @@ private:
 WRITE_CLASS_ENCODER(HitSet)
 WRITE_CLASS_ENCODER(HitSet::Params)
 
-typedef boost::shared_ptr<HitSet> HitSetRef;
+typedef std::shared_ptr<HitSet> HitSetRef;
 
 ostream& operator<<(ostream& out, const HitSet::Params& p);
 

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -195,7 +195,7 @@ public:
       results.mirror_snapset = mirror_snapset;
     }
   };
-  typedef boost::shared_ptr<CopyOp> CopyOpRef;
+  typedef std::shared_ptr<CopyOp> CopyOpRef;
 
   /**
    * The CopyCallback class defines an interface for completions to the
@@ -240,7 +240,7 @@ public:
 	user_version(0), data_offset(0),
 	canceled(false) { }
   };
-  typedef boost::shared_ptr<ProxyReadOp> ProxyReadOpRef;
+  typedef std::shared_ptr<ProxyReadOp> ProxyReadOpRef;
 
   struct FlushOp {
     ObjectContextRef obc;       ///< obc we are flushing
@@ -259,7 +259,7 @@ public:
 	on_flush(NULL) {}
     ~FlushOp() { assert(!on_flush); }
   };
-  typedef boost::shared_ptr<FlushOp> FlushOpRef;
+  typedef std::shared_ptr<FlushOp> FlushOpRef;
 
   boost::scoped_ptr<PGBackend> pgbackend;
   PGBackend *get_pgbackend() {

--- a/src/rbd_replay/PendingIO.hpp
+++ b/src/rbd_replay/PendingIO.hpp
@@ -15,7 +15,7 @@
 #ifndef _INCLUDED_RBD_REPLAY_PENDINGIO_HPP
 #define _INCLUDED_RBD_REPLAY_PENDINGIO_HPP
 
-#include <boost/enable_shared_from_this.hpp>
+#include <memory>
 #include "actions.hpp"
 
 /// Do not call outside of rbd_replay::PendingIO.
@@ -27,9 +27,9 @@ namespace rbd_replay {
 /**
    A PendingIO is an I/O operation that has been started but not completed.
 */
-class PendingIO : public boost::enable_shared_from_this<PendingIO> {
+class PendingIO : public std::enable_shared_from_this<PendingIO> {
 public:
-  typedef boost::shared_ptr<PendingIO> ptr;
+  typedef std::shared_ptr<PendingIO> ptr;
 
   PendingIO(action_id_t id,
             ActionCtx &worker);

--- a/src/rbd_replay/actions.hpp
+++ b/src/rbd_replay/actions.hpp
@@ -15,7 +15,7 @@
 #ifndef _INCLUDED_RBD_REPLAY_ACTIONS_HPP
 #define _INCLUDED_RBD_REPLAY_ACTIONS_HPP
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "include/rbd/librbd.hpp"
 #include "Deser.hpp"
 #include "rbd_loc.hpp"
@@ -101,11 +101,11 @@ public:
 
   virtual librados::IoCtx* ioctx() = 0;
 
-  virtual void add_pending(boost::shared_ptr<PendingIO> io) = 0;
+  virtual void add_pending(std::shared_ptr<PendingIO> io) = 0;
 
   virtual bool readonly() const = 0;
 
-  virtual void remove_pending(boost::shared_ptr<PendingIO> io) = 0;
+  virtual void remove_pending(std::shared_ptr<PendingIO> io) = 0;
 
   virtual void set_action_complete(action_id_t id) = 0;
 
@@ -129,7 +129,7 @@ public:
  */
 class Action {
 public:
-  typedef boost::shared_ptr<Action> ptr;
+  typedef std::shared_ptr<Action> ptr;
 
   Action(action_id_t id,
 	 thread_id_t thread_id,

--- a/src/rbd_replay/ios.cc
+++ b/src/rbd_replay/ios.cc
@@ -16,6 +16,7 @@
 // In other words, (a.id < b.id) == (a.timestamp < b.timestamp) for all IOs a and b.
 
 #include "ios.hpp"
+#include <algorithm>
 
 using namespace std;
 using namespace rbd_replay;
@@ -134,9 +135,9 @@ void rbd_replay::batch_unreachable_from(const io_set_t& deps, const io_set_t& ba
     // Take an IO from the end, which has the highest timestamp.
     // This reduces the boundary horizon as early as possible,
     // which means we can short cut as soon as possible.
-    map<action_id_t, boost::shared_ptr<IO> >::iterator b_itr(boundary.end());
+    map<action_id_t, std::shared_ptr<IO> >::iterator b_itr(boundary.end());
     --b_itr;
-    boost::shared_ptr<IO> io(b_itr->second);
+    std::shared_ptr<IO> io(b_itr->second);
     boundary.erase(b_itr);
 
     for (io_set_t::const_iterator itr = io->dependencies().begin(), end = io->dependencies().end(); itr != end; ++itr) {

--- a/src/rbd_replay/ios.hpp
+++ b/src/rbd_replay/ios.hpp
@@ -18,8 +18,7 @@
 // This code assumes that IO IDs and timestamps are related monotonically.
 // In other words, (a.id < b.id) == (a.timestamp < b.timestamp) for all IOs a and b.
 
-#include <boost/enable_shared_from_this.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <iostream>
 #include <map>
 #include <set>
@@ -31,9 +30,9 @@ namespace rbd_replay {
 
 class IO;
 
-typedef std::set<boost::shared_ptr<IO> > io_set_t;
+typedef std::set<std::shared_ptr<IO> > io_set_t;
 
-typedef std::map<action_id_t, boost::shared_ptr<IO> > io_map_t;
+typedef std::map<action_id_t, std::shared_ptr<IO> > io_map_t;
 
 /**
    Calculates reachability of IOs in the dependency graph.
@@ -57,11 +56,11 @@ void batch_unreachable_from(const io_set_t& deps, const io_set_t& base, io_set_t
    Corresponds to the Action class, except that Actions are executed by rbd-replay,
    and IOs are used by rbd-replay-prep for processing the raw trace.
  */
-class IO : public boost::enable_shared_from_this<IO> {
+class IO : public std::enable_shared_from_this<IO> {
 public:
-  typedef boost::shared_ptr<IO> ptr;
+  typedef std::shared_ptr<IO> ptr;
 
-  typedef boost::weak_ptr<IO> weak_ptr;
+  typedef std::weak_ptr<IO> weak_ptr;
 
   /**
      @param ionum ID of this %IO
@@ -151,7 +150,7 @@ private:
   action_id_t m_ionum;
   uint64_t m_start_time;
   io_set_t m_dependencies;
-  boost::weak_ptr<IO> m_completion;
+  std::weak_ptr<IO> m_completion;
   uint32_t m_num_successors;
   thread_id_t m_thread_id;
   ptr m_prev;

--- a/src/rbd_replay/rbd-replay-prep.cc
+++ b/src/rbd_replay/rbd-replay-prep.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include <assert.h>
 #include <fstream>
+#include <memory>
 #include <boost/thread/thread.hpp>
 #include "ios.hpp"
 
@@ -31,7 +32,7 @@ using namespace rbd_replay;
 
 class Thread {
 public:
-  typedef boost::shared_ptr<Thread> ptr;
+  typedef std::shared_ptr<Thread> ptr;
 
   Thread(thread_id_t id,
 	 uint64_t window)
@@ -379,7 +380,7 @@ private:
     } else if (strcmp(event_name, "librbd:open_image_exit") == 0) {
       IO::ptr completionIO(thread->pending_io()->create_completion(ts, threadID));
       m_ios.push_back(completionIO);
-      boost::shared_ptr<OpenImageIO> io(boost::dynamic_pointer_cast<OpenImageIO>(thread->pending_io()));
+      std::shared_ptr<OpenImageIO> io(std::dynamic_pointer_cast<OpenImageIO>(thread->pending_io()));
       assert(io);
       m_open_images.insert(io->imagectx());
     } else if (strcmp(event_name, "librbd:close_image_enter") == 0) {
@@ -393,7 +394,7 @@ private:
       IO::ptr completionIO(thread->pending_io()->create_completion(ts, threadID));
       m_ios.push_back(completionIO);
       completed(completionIO);
-      boost::shared_ptr<CloseImageIO> io(boost::dynamic_pointer_cast<CloseImageIO>(thread->pending_io()));
+      std::shared_ptr<CloseImageIO> io(std::dynamic_pointer_cast<CloseImageIO>(thread->pending_io()));
       assert(io);
       m_open_images.erase(io->imagectx());
     } else if (strcmp(event_name, "librbd:read_exit") == 0) {

--- a/src/rbd_replay/rbd-replay.cc
+++ b/src/rbd_replay/rbd-replay.cc
@@ -13,7 +13,7 @@
  */
 
 #include <vector>
-#include <boost/thread.hpp>
+#include <thread>
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
 #include "Replayer.hpp"
@@ -116,7 +116,7 @@ int main(int argc, const char **argv) {
     return 1;
   }
 
-  unsigned int nthreads = boost::thread::hardware_concurrency();
+  unsigned int nthreads = std::thread::hardware_concurrency();
   Replayer replayer(2 * nthreads + 1);
   replayer.set_latency_multiplier(latency_multiplier);
   replayer.set_pool_name(pool_name);


### PR DESCRIPTION
this is not enough to appease gcc4.8.1 + boost 1.46.
rbd_replay heavily uses boost::thread, guess we need to replace boost::thread stuff with the c++11 counterparts. but one problem is `shared_mutex`, it is missing in c++11. still looking for the viable approaches. i am working on the translation.

```
 CXX mds/ceph_dencoder-Locker.o
In file included from /usr/include/boost/thread/pthread/condition_variable.hpp:10:0,
from /usr/include/boost/thread/condition_variable.hpp:16,
from /usr/include/boost/thread/pthread/shared_mutex.hpp:13,
from /usr/include/boost/thread/shared_mutex.hpp:16,
from rbd_replay/Replayer.hpp:19,
from rbd_replay/rbd-replay.cc:19:
/usr/include/boost/thread/pthread/thread_data.hpp: In constructor ‘boost::detail::tss_data_node::tss_data_node(boost::shared_ptr, void*)’:

    error: /usr/include/boost/thread/pthread/thread_data.hpp:36:41: use of deleted function ‘boost::shared_ptr::shared_ptr(const boost::shared_ptr&)’ 

func(func_),value(value_)
^
```