### PR TITLE
ceph-disk: fix luks dmcrypt mapping during activation

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -879,7 +879,8 @@ def dmcrypt_map(
     keypath,
     _uuid,
     cryptsetup_parameters,
-    luks
+    luks,
+    format_dev=False,
     ):
     """
     Maps a device to a dmcrypt device.
@@ -916,7 +917,8 @@ def dmcrypt_map(
 
     try:
         if luks:
-            command_check_call(luksFormat_args)
+            if format_dev:
+		    command_check_call(luksFormat_args)
             command_check_call(luksOpen_args)
         else:
             # Plain mode has no format function, nor any validation that the key is correct.
@@ -1485,7 +1487,14 @@ def prepare_dev(
 
     dev = None
     if osd_dm_keypath:
-        dev = dmcrypt_map(rawdev, osd_dm_keypath, osd_uuid, cryptsetup_parameters, luks)
+        dev = dmcrypt_map(
+                rawdev=rawdev,
+                keypath=osd_dm_keypath,
+                _uuid=osd_uuid,
+                cryptsetup_parameters=cryptsetup_parameters,
+                luks=luks,
+                format_dev=True,
+                )
     else:
         dev = rawdev
 
@@ -2018,11 +2027,24 @@ def mount_activate(
             # proceeding.
             rawdev = dev
             ptype = get_partition_type(rawdev)
-            if ptype not in [DMCRYPT_OSD_UUID]:
+            if ptype in [DMCRYPT_OSD_UUID]:
+                luks = False
+                cryptsetup_parameters = ['--key-size', '256']
+            elif ptype in [DMCRYPT_LUKS_OSD_UUID]:
+                luks = True
+                cryptsetup_parameters = []
+            else:
                 raise Error('activate --dmcrypt called for invalid dev %s' % (dev))
             part_uuid = get_partition_uuid(rawdev)
-            dmcrypt_key_path = os.path.join(dmcrypt_key_dir, part_uuid)
-            dev = dmcrypt_map(rawdev, dmcrypt_key_path, part_uuid)
+            dmcrypt_key_path = get_dmcrypt_key_path(part_uuid, dmcrypt_key_dir, luks)
+            dev = dmcrypt_map(
+                    rawdev=rawdev,
+                    keypath=dmcrypt_key_path,
+                    _uuid=part_uuid,
+                    cryptsetup_parameters=cryptsetup_parameters,
+                    luks=luks,
+                    format_dev=False,
+                    )
 
     try:
         fstype = detect_fstype(dev=dev)
@@ -2366,11 +2388,24 @@ def main_activate_journal(args):
             # it before proceeding.
             rawdev = args.dev
             ptype = get_partition_type(rawdev)
-            if ptype not in [DMCRYPT_JOURNAL_UUID]:
+            if ptype in [DMCRYPT_JOURNAL_UUID]:
+                luks = False
+                cryptsetup_parameters = ['--key-size', '256']
+            elif ptype in [DMCRYPT_LUKS_JOURNAL_UUID]:
+                luks = True
+                cryptsetup_parameters = []
+            else:
                 raise Error('activate-journal --dmcrypt called for invalid dev %s' % (rawdev))
             part_uuid = get_partition_uuid(rawdev)
-            dmcrypt_key_path = os.path.join(args.dmcrypt_key_dir, part_uuid)
-            dev = dmcrypt_map(rawdev, dmcrypt_key_path, partd_uuid)
+            dmcrypt_key_path = get_dmcrypt_key_path(part_uuid, args.dmcrypt_key_dir, luks)
+            dev = dmcrypt_map(
+                    rawdev=rawdev,
+                    keypath=dmcrypt_key_path,
+                    _uuid=part_uuid,
+                    cryptsetup_parameters=cryptsetup_parameters,
+                    luks=luks,
+                    format_dev=False,
+                    )
         else:
             dev = args.dev
 

--- a/src/test/ceph-disk-root.sh
+++ b/src/test/ceph-disk-root.sh
@@ -15,7 +15,11 @@
 # GNU Library Public License for more details.
 #
 set -e
-sudo test/ceph-disk.sh test_activate_dev test_activate_dmcrypt_dev test_activate_dmcrypt_plain_dev
+sudo test/ceph-disk.sh	test_activate_dev \
+			test_activate_dmcrypt_dev \
+			test_activate_dmcrypt_plain_dev \
+			test_activate_dmcrypt_map \
+			test_activate_dmcrypt_map_plain
 test/ceph-disk.sh
 
 # Local Variables:

--- a/udev/95-ceph-osd.rules.systemd
+++ b/udev/95-ceph-osd.rules.systemd
@@ -14,19 +14,34 @@ ACTION=="add", SUBSYSTEM=="block", \
   TAG+="systemd", \
   ENV{SYSTEMD_WANTS}+="ceph-disk-activate-journal@/dev/$name.service"
 
-# Map journal if using dm-crypt
+# Map journal if using dm-crypt and plain
 ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="45b0969e-9b03-4f30-b4c6-5ec00ceff106", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
   RUN+="/sbin/cryptsetup --key-file /etc/ceph/dmcrypt-keys/$env{ID_PART_ENTRY_UUID} --key-size 256 create $env{ID_PART_ENTRY_UUID} /dev/$name"
 
+# Map journal if using dm-crypt and luks
+ACTION=="add" SUBSYSTEM=="block", \
+  ENV{DEVTYPE}=="partition", \
+  ENV{ID_PART_ENTRY_TYPE}=="45b0969e-9b03-4f30-b4c6-35865ceff106", \
+  RUN+="/sbin/cryptsetup --key-file /etc/ceph/dmcrypt-keys/$env{ID_PART_ENTRY_UUID}.luks.key luksOpen /dev/$name $env{ID_PART_ENTRY_UUID}"
+
 # Map data device and
 # activate ceph-tagged partitions
-# for dm-crypted data devices
+# for dm-crypted data devices and plain
 ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-5ec00ceff05d", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
+  TAG+="systemd", \
+  ENV{SYSTEMD_WANTS}+="ceph-disk-dmcrypt-activate@/dev/$name.service"
+
+# Map data device and
+# activate ceph-tagged partitions
+# for dm-crypted data devices and luks
+ACTION=="add" SUBSYSTEM=="block", \
+  ENV{DEVTYPE}=="partition", \
+  ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-35865ceff05d", \
   TAG+="systemd", \
   ENV{SYSTEMD_WANTS}+="ceph-disk-dmcrypt-activate@/dev/$name.service"


### PR DESCRIPTION
This patchset fixes some issues with the recently merged ceph-disk activate --dmcrypt support, and additionally adds unit test coverage.