### PR TITLE
Correct handling of supplementary groups in ceph-fuse (Bug 12617)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -965,6 +965,9 @@ AC_CHECK_FUNC([fallocate],
 	[AC_DEFINE([CEPH_HAVE_FALLOCATE], [], [fallocate(2) is supported])],
 	[])
 
+# getgrouplist
+AC_CHECK_FUNCS([getgrouplist])
+
 #
 # Test for time-related `struct stat` members.
 #

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -91,6 +91,11 @@ using namespace std;
 #include "include/assert.h"
 #include "include/stat.h"
 
+#if HAVE_GETGROUPLIST
+#include <grp.h>
+#include <pwd.h>
+#endif
+
 #undef dout_prefix
 #define dout_prefix *_dout << "client." << whoami << " "
 
@@ -4545,6 +4550,10 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, MClient
 
 int Client::check_permissions(Inode *in, int flags, int uid, int gid)
 {
+  // initial number of group entries, defaults to posix standard of 16
+  // PAM implementations may provide more than 16 groups....
+  int initial_group_count = 16;
+
   gid_t *sgids = NULL;
   int sgid_count = 0;
   if (getgroups_cb) {
@@ -4554,11 +4563,45 @@ int Client::check_permissions(Inode *in, int flags, int uid, int gid)
       return sgid_count;
     }
   }
-  // check permissions before doing anything else
-  if (uid != 0 && !in->check_mode(uid, gid, sgids, sgid_count, flags)) {
-    return -EACCES;
+#if HAVE_GETGROUPLIST
+  else {
+    //use PAM to get the group list
+    sgid_count = initial_group_count;
+    sgids = (gid_t*)malloc(sgid_count * sizeof(gid_t));
+    if (sgids == NULL) {
+      ldout(cct, 3) << "allocating group memory failed" << dendl;
+      return -EACCES;
+    }
+    struct passwd *pw;
+    pw = getpwuid(uid);
+    if (pw == NULL) {
+      ldout(cct, 3) << "getting user entry failed" << dendl;
+      return -EACCES;
+    }
+    while (1) {
+      if (getgrouplist(pw->pw_name, gid, sgids, &sgid_count) == -1) {
+        // we need to resize the group list and try again
+        sgids = (gid_t*)realloc(sgids, sgid_count * sizeof(gid_t));
+        if (sgids == NULL) {
+          ldout(cct, 3) << "allocating group memory failed" << dendl;
+          return -EACCES;
+        }
+        continue;
+      }
+      // list was successfully retrieved
+      break;
+    }    
   }
-  return 0;
+#endif
+
+  // check permissions before doing anything else
+  int ret = 0;
+  if (uid != 0 && !in->check_mode(uid, gid, sgids, sgid_count, flags)) {
+    ret = -EACCES;
+  }
+  if (sgids)
+    free(sgids);
+  return ret;
 }
 
 vinodeno_t Client::_get_vino(Inode *in)


### PR DESCRIPTION
The PR fixes Bug 12617 by using the getgrouplist function to retrieve a list of all supplementary groups.

The function should be compatible with PAM (works in a sssd based setup for the submitter) and shoud be reentrant. The also used function getpwuid might needs to be replaced with getpwuid_r if necessary.

The PR might be merged with https://github.com/ceph/ceph/pull/5480, which skipped permission checks if already done in the kernel itself.