### PR TITLE
rgw: shouldn't return content-type: application/xml if content length is 0

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -435,7 +435,9 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
     dump_access_control(s, op);
   }
 
-  if (!content_type || s->err.is_err()) {
+  /* do not send content type if content length is zero
+     and the content type was not set by the user */
+  if ((s->formatter->get_len()  != 0 && !content_type) || s->err.is_err()){
     switch (s->format) {
     case RGW_FORMAT_XML:
       ctype = "application/xml";
@@ -465,9 +467,13 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
       dump_content_length(s, proposed_content_length);
     }
   }
-  int r = s->cio->print("Content-type: %s\r\n", content_type);
-  if (r < 0) {
-    ldout(s->cct, 0) << "ERROR: s->cio->print() returned err=" << r << dendl;
+
+  int r;
+  if (content_type) {
+      r = s->cio->print("Content-type: %s\r\n", content_type);
+      if (r < 0) {
+	ldout(s->cct, 0) << "ERROR: s->cio->print() returned err=" << r << dendl;
+      }
   }
   r = s->cio->complete_header();
   if (r < 0) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/12633