### PR TITLE
mon: Monitor: set MMonJoin's op type as service

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3670,6 +3670,7 @@ void Monitor::dispatch_op(MonOpRequestRef op)
 
     // monmap
     case MSG_MON_JOIN:
+      op->set_type_service();
       paxos_service[PAXOS_MONMAP]->dispatch(op);
       break;
 


### PR DESCRIPTION
Otherwise, when the MonmapMonitor's PaxosService::dispatch() handles the
message, it will assert (as it should) because the op is marked as being
a monitor op. And this function should never handle monitor ops.

`Signed-off-by: Joao Eduardo Luis <joao@suse.de>`