### PR TITLE
RFC: buffer: reduce allocations

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1628,7 +1628,7 @@ void buffer::list::rebuild_page_aligned()
       throw end_of_buffer();
 
     assert(len > 0);
-    //cout << "splice off " << off << " len " << len << " ... mylen = " << length() << std::endl;
+    bdout << "splice off " << off << " len " << len << " ... mylen = " << length() << bendl;
       
     // skip off
     ptr_list_t::iterator curbuf = _ptrs.begin();
@@ -1636,12 +1636,12 @@ void buffer::list::rebuild_page_aligned()
       assert(curbuf != _ptrs.end());
       if (off >= (*curbuf).length()) {
 	// skip this buffer
-	//cout << "off = " << off << " skipping over " << *curbuf << std::endl;
+	bdout << "off = " << off << " skipping over " << *curbuf << bendl;
 	off -= (*curbuf).length();
 	++curbuf;
       } else {
 	// somewhere in this buffer!
-	//cout << "off = " << off << " somewhere in " << *curbuf << std::endl;
+	bdout << "off = " << off << " somewhere in " << *curbuf << bendl;
 	break;
       }
     }
@@ -1649,7 +1649,7 @@ void buffer::list::rebuild_page_aligned()
     if (off) {
       // add a reference to the front bit
       //  insert it before curbuf (which we'll hose)
-      //cout << "keeping front " << off << " of " << *curbuf << std::endl;
+      bdout << "keeping front " << off << " of " << *curbuf << bendl;
       _ptrs.insert(curbuf, *(new ptr(*curbuf, 0, off)));
       _len += off;
     }
@@ -1657,19 +1657,19 @@ void buffer::list::rebuild_page_aligned()
     while (len > 0) {
       // partial?
       if (off + len < (*curbuf).length()) {
-	//cout << "keeping end of " << *curbuf << ", losing first " << off+len << std::endl;
+	bdout << "keeping end of " << *curbuf << ", losing first " << off+len << bendl;
 	if (claim_by) 
 	  claim_by->append( *curbuf, off, len );
 	(*curbuf).set_offset( off+len + (*curbuf).offset() );    // ignore beginning big
 	(*curbuf).set_length( (*curbuf).length() - (len+off) );
 	_len -= off+len;
-	//cout << " now " << *curbuf << std::endl;
+	bdout << " now " << *curbuf << bendl;
 	break;
       }
       
       // hose though the end
       unsigned howmuch = (*curbuf).length() - off;
-      //cout << "discarding " << howmuch << " of " << *curbuf << std::endl;
+      bdout << "discarding " << howmuch << " of " << *curbuf << bendl;
       if (claim_by) 
 	claim_by->append( *curbuf, off, howmuch );
       _len -= (*curbuf).length();
@@ -1683,6 +1683,7 @@ void buffer::list::rebuild_page_aligned()
     // splice in *replace (implement me later?)
     
     last_p = begin();  // just in case we were in the removed region.
+    bdout << "splice done" << bendl;
   }
 
   void buffer::list::write(int off, int len, std::ostream& out) const

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -697,6 +697,12 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     r->nref.inc();
     bdout << "ptr " << this << " get " << _raw << bendl;
   }
+  buffer::ptr::ptr(raw *r, unsigned o, unsigned l)
+    : _raw(r), _off(o), _len(l), embed(false)
+  {
+    r->nref.inc();
+    bdout << "ptr " << this << " get " << _raw << bendl;
+  }
   buffer::ptr::ptr(unsigned l) : _off(0), _len(l), embed(false)
   {
     _raw = create(l);
@@ -1450,12 +1456,6 @@ void buffer::list::rebuild_page_aligned()
     }
   }
 
-  void buffer::list::append(const ptr& bp)
-  {
-    if (bp.length())
-      push_back(bp);
-  }
-
   void buffer::list::append(const ptr& bp, unsigned off, unsigned len)
   {
     assert(len+off <= bp.length());
@@ -1470,8 +1470,7 @@ void buffer::list::rebuild_page_aligned()
       }
     }
     // add new item to list
-    _ptrs.push_back(*(new ptr(bp, off, len)));
-    _len += len;
+    push_back(bp.get_raw(), bp.offset() + off, len);
   }
 
   void buffer::list::append(const list& bl)

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -568,7 +568,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     raw_unshareable(unsigned l, char *b) : raw(b, l) {
     }
     raw* clone_empty() {
-      return new raw_char(len);
+      return buffer::create(len);
     }
     bool is_shareable() {
       return false; // !shareable, will force make_shareable()
@@ -583,7 +583,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     raw_static(const char *d, unsigned l) : raw((char*)d, l) { }
     ~raw_static() {}
     raw* clone_empty() {
-      return new buffer::raw_char(len);
+      return buffer::create(len);
     }
   };
 
@@ -617,7 +617,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     { }
     ~xio_mempool() {}
     raw* clone_empty() {
-      return new buffer::raw_char(len);
+      return buffer::create(len);
     }
   };
 

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -749,6 +749,14 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     return *this;
   }
 
+  void buffer::ptr::reset(raw *raw, unsigned off, unsigned len) {
+    bdout << "ptr::reset raw " << raw << " " << off << "~" << len << bendl;
+    _raw = raw;
+    _off = off;
+    _len = len;
+    _raw->nref.inc();
+  }
+
   buffer::raw *buffer::ptr::clone()
   {
     return _raw->clone();
@@ -1451,8 +1459,7 @@ void buffer::list::rebuild_page_aligned()
       
       // make a new append_buffer!
       unsigned alen = CEPH_BUFFER_APPEND_SIZE * (((len-1) / CEPH_BUFFER_APPEND_SIZE) + 1);
-      append_buffer = create_aligned(alen, CEPH_BUFFER_APPEND_SIZE);
-      append_buffer.set_length(0);   // unused, so far.
+      append_buffer.reset(create_aligned(alen, CEPH_BUFFER_APPEND_SIZE), 0, 0);
     }
   }
 

--- a/src/compressor/SnappyCompressor.h
+++ b/src/compressor/SnappyCompressor.h
@@ -21,12 +21,13 @@
 #include "Compressor.h"
 
 class BufferlistSource : public snappy::Source {
-  list<bufferptr>::const_iterator pb;
+  buffer::list::ptr_list_t::const_iterator pb;
   size_t pb_off;
   size_t left;
 
  public:
-  BufferlistSource(bufferlist &data): pb(data.buffers().begin()), pb_off(0), left(data.length()) {}
+  BufferlistSource(bufferlist &data)
+    : pb(data.get_raw_ptr_list().begin()), pb_off(0), left(data.length()) {}
   virtual ~BufferlistSource() {}
   virtual size_t Available() const { return left; }
   virtual const char* Peek(size_t* len) {

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -345,6 +345,10 @@ public:
       return *this;
     }
 
+    unsigned get_num_buffers() const { return _buffers.size(); }
+    const ptr& front() const { return _buffers.front(); }
+    const ptr& back() const { return _buffers.back(); }
+
     unsigned get_memcopy_count() const {return _memcopy_count; }
     const std::list<ptr>& buffers() const { return _buffers; }
     void swap(list& other);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -185,6 +185,7 @@ public:
   public:
     ptr() : _raw(0), _off(0), _len(0), embed(false) {}
     ptr(raw *r);
+    ptr(raw *r, unsigned o, unsigned l);
     ptr(unsigned l);
     ptr(const char *d, unsigned l);
     ptr(const ptr& p);
@@ -424,27 +425,35 @@ public:
       _memcopy_count = 0;
       last_p = begin();
     }
+
     void push_front(ptr& bp) {
       if (bp.length() == 0)
 	return;
-      ptr *p = new ptr(bp);
-      _ptrs.push_front(*p);
-      _len += bp.length();
+      push_front(bp.get_raw(), bp.offset(), bp.length());
     }
     void push_front(raw *r) {
       ptr *p = new ptr(r);
       _ptrs.push_front(*p);
       _len += p->length();
     }
+    void push_front(raw *r, unsigned off, unsigned len) {
+      ptr *p = new ptr(r, off, len);
+      _ptrs.push_front(*p);
+      _len += p->length();
+    }
+
     void push_back(const ptr& bp) {
       if (bp.length() == 0)
 	return;
-      ptr *p = new ptr(bp);
-      _ptrs.push_back(*p);
-      _len += bp.length();
+      push_back(bp.get_raw(), bp.offset(), bp.length());
     }
     void push_back(raw *r) {
       ptr *p = new ptr(r);
+      _ptrs.push_back(*p);
+      _len += p->length();
+    }
+    void push_back(raw *r, unsigned off, unsigned len) {
+      ptr *p = new ptr(r, off, len);
       _ptrs.push_back(*p);
       _len += p->length();
     }
@@ -506,7 +515,12 @@ public:
     void append(const std::string& s) {
       append(s.data(), s.length());
     }
-    void append(const ptr& bp);
+    void append(raw *raw) {
+      push_back(raw);
+    }
+    void append(const ptr& bp) {
+      push_back(bp);
+    }
     void append(const ptr& bp, unsigned off, unsigned len);
     void append(const list& bl);
     void append(std::istream& in);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -139,6 +139,7 @@ private:
   class raw_char;
   class raw_pipe;
   class raw_unshareable; // diagnostic, unshareable char buffer
+  class raw_combined;
 
   friend std::ostream& operator<<(std::ostream& out, const raw &r);
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -159,6 +159,7 @@ public:
   static raw* claim_malloc(unsigned len, char *buf);
   static raw* create_static(unsigned len, char *buf);
   static raw* create_aligned(unsigned len, unsigned align);
+  static raw* create_combined(unsigned len, unsigned align);
   static raw* create_page_aligned(unsigned len);
   static raw* create_zero_copy(unsigned len, int fd, int64_t *offset);
   static raw* create_unshareable(unsigned len);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -174,6 +174,7 @@ public:
   private:
     raw *_raw;
     unsigned _off, _len;
+    bool embed;
 
   public:
     boost::intrusive::list_member_hook<> _list_item;
@@ -182,7 +183,7 @@ public:
     void release();
 
   public:
-    ptr() : _raw(0), _off(0), _len(0) {}
+    ptr() : _raw(0), _off(0), _len(0), embed(false) {}
     ptr(raw *r);
     ptr(unsigned l);
     ptr(const char *d, unsigned l);
@@ -191,6 +192,13 @@ public:
     ptr& operator= (const ptr& p);
     ~ptr() {
       release();
+    }
+
+    void unlinked_from_list() {
+      if (!embed)
+	delete this;
+      else
+	release();
     }
 
     bool have_raw() const { return _raw ? true:false; }
@@ -410,7 +418,7 @@ public:
       while (!_ptrs.empty()) {
 	ptr *p = &_ptrs.front();
 	_ptrs.pop_front();
-	delete p;
+	p->unlinked_from_list();
       }
       _len = 0;
       _memcopy_count = 0;

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -175,6 +175,7 @@ public:
     raw *_raw;
     unsigned _off, _len;
     bool embed;
+    friend class raw;
 
   public:
     boost::intrusive::list_member_hook<> _list_item;
@@ -428,18 +429,22 @@ public:
       last_p = begin();
     }
 
+  private:
+    ptr *_get_raw_ptr(raw *r, unsigned off, unsigned len);
+
+  public:
     void push_front(ptr& bp) {
       if (bp.length() == 0)
 	return;
       push_front(bp.get_raw(), bp.offset(), bp.length());
     }
     void push_front(raw *r) {
-      ptr *p = new ptr(r);
+      ptr *p = _get_raw_ptr(r, 0, 0);
       _ptrs.push_front(*p);
       _len += p->length();
     }
     void push_front(raw *r, unsigned off, unsigned len) {
-      ptr *p = new ptr(r, off, len);
+      ptr *p = _get_raw_ptr(r, off, len);
       _ptrs.push_front(*p);
       _len += p->length();
     }
@@ -450,12 +455,12 @@ public:
       push_back(bp.get_raw(), bp.offset(), bp.length());
     }
     void push_back(raw *r) {
-      ptr *p = new ptr(r);
+      ptr *p = _get_raw_ptr(r, 0, 0);
       _ptrs.push_back(*p);
       _len += p->length();
     }
     void push_back(raw *r, unsigned off, unsigned len) {
-      ptr *p = new ptr(r, off, len);
+      ptr *p = _get_raw_ptr(r, off, len);
       _ptrs.push_back(*p);
       _len += p->length();
     }

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -195,6 +195,8 @@ public:
       release();
     }
 
+    void reset(raw *r, unsigned off, unsigned len);
+
     void unlinked_from_list() {
       if (!embed)
 	delete this;

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -229,8 +229,8 @@ inline void decode(buffer::ptr& bp, bufferlist::iterator& p)
   p.copy(len, s);
 
   if (len) {
-    if (s.buffers().size() == 1)
-      bp = s.buffers().front();
+    if (s.get_num_buffers() == 1)
+      bp = s.front();
     else
       bp = buffer::copy(s.c_str(), s.length());
   }

--- a/src/messages/MDataPing.h
+++ b/src/messages/MDataPing.h
@@ -64,8 +64,8 @@ private:
 	mdata_hook(&mp);
 
       if (free_data)  {
-	const std::list<buffer::ptr>& buffers = data.buffers();
-	list<bufferptr>::const_iterator pb;
+	const buffer::list::ptr_list_t& buffers = data.get_raw_ptr_list();
+	buffer::list::ptr_list_t::const_iterator pb;
 	for (pb = buffers.begin(); pb != buffers.end(); ++pb) {
 	  free((void*) pb->c_str());
 	}

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -291,8 +291,9 @@ int AsyncConnection::_try_send(bufferlist &send_bl, bool send)
   }
 
   uint64_t sent_bytes = 0;
-  list<bufferptr>::const_iterator pb = outcoming_bl.buffers().begin();
-  uint64_t left_pbrs = outcoming_bl.buffers().size();
+  buffer::list::ptr_list_t::const_iterator pb =
+    outcoming_bl.get_raw_ptr_list().begin();
+  uint64_t left_pbrs = outcoming_bl.get_num_buffers();
   while (left_pbrs) {
     struct msghdr msg;
     uint64_t size = MIN(left_pbrs, IOV_MAX);

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2282,7 +2282,7 @@ int Pipe::write_message(const ceph_msg_header& header, const ceph_msg_footer& fo
   }
 
   // payload (front+data)
-  list<bufferptr>::const_iterator pb = blist.buffers().begin();
+  buffer::list::ptr_list_t::const_iterator pb = blist.get_raw_ptr_list().begin();
   int b_off = 0;  // carry-over buffer offset, if any
   int bl_pos = 0; // blist pos
   int left = blist.length();

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -1411,7 +1411,7 @@ int FileJournal::write_aio_bl(off64_t& pos, bufferlist& bl, uint64_t seq)
   dout(20) << "write_aio_bl " << pos << "~" << bl.length() << " seq " << seq << dendl;
   
   while (bl.length() > 0) {
-    int max = MIN(bl.buffers().size(), IOV_MAX-1);
+    int max = MIN(bl.get_num_buffers(), IOV_MAX-1);
     iovec *iov = new iovec[max];
     int n = 0;
     unsigned len = 0;

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -1415,10 +1415,11 @@ int FileJournal::write_aio_bl(off64_t& pos, bufferlist& bl, uint64_t seq)
     iovec *iov = new iovec[max];
     int n = 0;
     unsigned len = 0;
-    for (std::list<buffer::ptr>::const_iterator p = bl.buffers().begin();
+    for (buffer::list::ptr_list_t::const_iterator p =
+	   bl.get_raw_ptr_list().begin();
 	 n < max;
 	 ++p, ++n) {
-      assert(p != bl.buffers().end());
+      assert(p != bl.get_raw_ptr_list().end());
       iov[n].iov_base = (void *)p->c_str();
       iov[n].iov_len = p->length();
       len += p->length();

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -620,16 +620,15 @@ public:
       vector<__le32> &cm,
       vector<__le32> &om) {
 
-      list<bufferptr> list = bl.buffers();
-      std::list<bufferptr>::iterator p;
-
-      for(p = list.begin(); p != list.end(); ++p) {
+      const buffer::list::ptr_list_t &list = bl.get_raw_ptr_list();
+      buffer::list::ptr_list_t::const_iterator p;
+      for (p = list.begin(); p != list.end(); ++p) {
         assert(p->length() % sizeof(Op) == 0);
 
-        char* raw_p = p->c_str();
-        char* raw_end = raw_p + p->length();
+        const char* raw_p = p->c_str();
+        const char* raw_end = raw_p + p->length();
         while (raw_p < raw_end) {
-          _update_op(reinterpret_cast<Op*>(raw_p), cm, om);
+          _update_op(reinterpret_cast<Op*>(const_cast<char *>(raw_p)), cm, om);
           raw_p += sizeof(Op);
         }
       }

--- a/src/test/bench/bencher.cc
+++ b/src/test/bench/bencher.cc
@@ -114,7 +114,7 @@ void Bencher::init(
 {
   bufferlist bl;
   for (uint64_t i = 0; i < size; ++i) {
-    bl.append(0);
+    bl.append((char)0);
   }
   Mutex lock("init_lock");
   Cond cond;

--- a/src/test/bench/small_io_bench_dumb.cc
+++ b/src/test/bench/small_io_bench_dumb.cc
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
   cout << "Creating objects.." << std::endl;
   bufferlist bl;
   for (uint64_t i = 0; i < vm["object-size"].as<unsigned>(); ++i) {
-    bl.append(0);
+    bl.append((char)0);
   }
   set<string> objects;
 

--- a/src/test/bench/small_io_bench_fs.cc
+++ b/src/test/bench/small_io_bench_fs.cc
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
   cout << "Creating objects.." << std::endl;
   bufferlist bl;
   for (uint64_t i = 0; i < vm["object-size"].as<unsigned>(); ++i) {
-    bl.append(0);
+    bl.append((char)0);
   }
 
   for (uint64_t num = 0; num < vm["num-colls"].as<unsigned>(); ++num) {

--- a/src/test/bench/testfilestore_backend.cc
+++ b/src/test/bench/testfilestore_backend.cc
@@ -49,7 +49,7 @@ void TestFileStoreBackend::write(
 
   if (write_infos) {
     bufferlist bl2;
-    for (uint64_t j = 0; j < 128; ++j) bl2.append(0);
+    for (uint64_t j = 0; j < 128; ++j) bl2.append((char)0);
     coll_t meta;
     hobject_t info(sobject_t(string("info_")+coll_str, 0));
     t->write(meta, ghobject_t(info), 0, bl2.length(), bl2);

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -169,6 +169,23 @@ TEST(Buffer, constructors) {
     EXPECT_EQ(0, buffer::get_total_alloc());
 }
 
+void bench_buffer_alloc(int size, int num)
+{
+  utime_t start = ceph_clock_now(NULL);
+  for (int i=0; i<num; ++i) {
+    bufferptr p = buffer::create(size);
+  }
+  utime_t end = ceph_clock_now(NULL);
+  cout << num << " alloc of size " << size
+       << " in " << (end - start) << std::endl;
+}
+
+TEST(Buffer, BenchAlloc) {
+  bench_buffer_alloc(32, 1000000);
+  bench_buffer_alloc(4096, 1000000);
+  bench_buffer_alloc(16384, 1000000);
+}
+
 TEST(BufferRaw, ostream) {
   bufferptr ptr(1);
   std::ostringstream stream;
@@ -1055,6 +1072,25 @@ TEST(BufferList, constructors) {
     bufferlist copy(bl);
     ASSERT_EQ('A', copy[0]);
   }
+}
+
+void bench_bufferlist_alloc(int size, int num, int per)
+{
+  utime_t start = ceph_clock_now(NULL);
+  for (int i=0; i<num; ++i) {
+    bufferlist bl;
+    for (int j=0; j<per; ++j)
+      bl.append(buffer::create(size));
+  }
+  utime_t end = ceph_clock_now(NULL);
+  cout << num << " alloc of size " << size
+       << " in " << (end - start) << std::endl;
+}
+
+TEST(BufferList, BenchAlloc) {
+  bench_bufferlist_alloc(32, 100000, 16);
+  bench_bufferlist_alloc(4096, 100000, 16);
+  bench_bufferlist_alloc(16384, 100000, 16);
 }
 
 TEST(BufferList, operator_equal) {

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -309,9 +309,9 @@ TEST_F(TestRawPipe, buffer_list_read_fd_zero_copy) {
   bl = bufferlist();
   EXPECT_EQ(0, bl.read_fd_zero_copy(fd, len));
   EXPECT_EQ(len, bl.length());
-  EXPECT_EQ(0u, bl.buffers().front().unused_tail_length());
-  EXPECT_EQ(1u, bl.buffers().size());
-  EXPECT_EQ(len, bl.buffers().front().raw_length());
+  EXPECT_EQ(0u, bl.front().unused_tail_length());
+  EXPECT_EQ(1u, bl.get_num_buffers());
+  EXPECT_EQ(len, bl.front().raw_length());
   EXPECT_EQ(0, memcmp(bl.c_str(), "ABC\n", len));
   EXPECT_TRUE(bl.can_zero_copy());
 }
@@ -1112,9 +1112,9 @@ TEST(BufferList, operator_equal) {
 
 TEST(BufferList, buffers) {
   bufferlist bl;
-  ASSERT_EQ((unsigned)0, bl.buffers().size());
+  ASSERT_EQ((unsigned)0, bl.get_num_buffers());
   bl.append('A');
-  ASSERT_EQ((unsigned)1, bl.buffers().size());
+  ASSERT_EQ((unsigned)1, bl.get_num_buffers());
 }
 
 TEST(BufferList, get_contiguous) {
@@ -1128,13 +1128,13 @@ TEST(BufferList, get_contiguous) {
     bl.append(a);
     bl.append(b);
     bl.append(c);
-    ASSERT_EQ(3u, bl.buffers().size());
+    ASSERT_EQ(3u, bl.get_num_buffers());
     ASSERT_EQ(0, memcmp("bar", bl.get_contiguous(3, 3), 3));
     ASSERT_EQ(0, memcmp("456", bl.get_contiguous(12, 3), 3));
     ASSERT_EQ(0, memcmp("ABC", bl.get_contiguous(18, 3), 3));
-    ASSERT_EQ(3u, bl.buffers().size());
+    ASSERT_EQ(3u, bl.get_num_buffers());
     ASSERT_EQ(0, memcmp("789ABC", bl.get_contiguous(15, 6), 6));
-    ASSERT_EQ(2u, bl.buffers().size());
+    ASSERT_EQ(2u, bl.get_num_buffers());
   }
 
   {
@@ -1148,7 +1148,7 @@ TEST(BufferList, get_contiguous) {
     bl.append(c);
 
     ASSERT_EQ(0, memcmp("789ABCDEFGHI", bl.get_contiguous(15, 12), 12));
-    ASSERT_EQ(2u, bl.buffers().size());
+    ASSERT_EQ(2u, bl.get_num_buffers());
   }
 
   {
@@ -1162,7 +1162,7 @@ TEST(BufferList, get_contiguous) {
     bl.append(c);
 
     ASSERT_EQ(0, memcmp("z123456789AB", bl.get_contiguous(8, 12), 12));
-    ASSERT_EQ(1u, bl.buffers().size());
+    ASSERT_EQ(1u, bl.get_num_buffers());
   }
 }
 
@@ -1339,13 +1339,13 @@ TEST(BufferList, rebuild_aligned_size_and_memory) {
   EXPECT_FALSE(bl.is_aligned(SIMD_ALIGN));
   EXPECT_FALSE(bl.is_n_align_sized(BUFFER_SIZE));
   EXPECT_EQ(BUFFER_SIZE * 3, bl.length());
-  EXPECT_FALSE(bl.buffers().front().is_aligned(SIMD_ALIGN));
-  EXPECT_FALSE(bl.buffers().front().is_n_align_sized(BUFFER_SIZE));
-  EXPECT_EQ(5U, bl.buffers().size());
+  EXPECT_FALSE(bl.front().is_aligned(SIMD_ALIGN));
+  EXPECT_FALSE(bl.front().is_n_align_sized(BUFFER_SIZE));
+  EXPECT_EQ(5U, bl.get_num_buffers());
   bl.rebuild_aligned_size_and_memory(BUFFER_SIZE, SIMD_ALIGN);
   EXPECT_TRUE(bl.is_aligned(SIMD_ALIGN));
   EXPECT_TRUE(bl.is_n_align_sized(BUFFER_SIZE));
-  EXPECT_EQ(3U, bl.buffers().size());
+  EXPECT_EQ(3U, bl.get_num_buffers());
 }
 
 TEST(BufferList, is_zero) {
@@ -1371,7 +1371,7 @@ TEST(BufferList, clear) {
   bl.append_zero(len);
   bl.clear();
   EXPECT_EQ((unsigned)0, bl.length());
-  EXPECT_EQ((unsigned)0, bl.buffers().size());
+  EXPECT_EQ((unsigned)0, bl.get_num_buffers());
 }
 
 TEST(BufferList, push_front) {
@@ -1383,7 +1383,7 @@ TEST(BufferList, push_front) {
     bufferptr ptr;
     bl.push_front(ptr);
     EXPECT_EQ((unsigned)0, bl.length());
-    EXPECT_EQ((unsigned)0, bl.buffers().size());
+    EXPECT_EQ((unsigned)0, bl.get_num_buffers());
   }
   unsigned len = 17;
   {
@@ -1393,9 +1393,9 @@ TEST(BufferList, push_front) {
     ptr.c_str()[0] = 'B';
     bl.push_front(ptr);
     EXPECT_EQ((unsigned)(1 + len), bl.length());
-    EXPECT_EQ((unsigned)2, bl.buffers().size());
-    EXPECT_EQ('B', bl.buffers().front()[0]);
-    EXPECT_EQ(ptr.get_raw(), bl.buffers().front().get_raw());
+    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
+    EXPECT_EQ('B', bl.front()[0]);
+    EXPECT_EQ(ptr.get_raw(), bl.front().get_raw());
   }
   //
   // void push_front(raw *r)
@@ -1407,9 +1407,9 @@ TEST(BufferList, push_front) {
     ptr.c_str()[0] = 'B';
     bl.push_front(ptr.get_raw());
     EXPECT_EQ((unsigned)(1 + len), bl.length());
-    EXPECT_EQ((unsigned)2, bl.buffers().size());
-    EXPECT_EQ('B', bl.buffers().front()[0]);
-    EXPECT_EQ(ptr.get_raw(), bl.buffers().front().get_raw());
+    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
+    EXPECT_EQ('B', bl.front()[0]);
+    EXPECT_EQ(ptr.get_raw(), bl.front().get_raw());
   }
 }
 
@@ -1422,7 +1422,7 @@ TEST(BufferList, push_back) {
     bufferptr ptr;
     bl.push_back(ptr);
     EXPECT_EQ((unsigned)0, bl.length());
-    EXPECT_EQ((unsigned)0, bl.buffers().size());
+    EXPECT_EQ((unsigned)0, bl.get_num_buffers());
   }
   unsigned len = 17;
   {
@@ -1432,9 +1432,9 @@ TEST(BufferList, push_back) {
     ptr.c_str()[0] = 'B';
     bl.push_back(ptr);
     EXPECT_EQ((unsigned)(1 + len), bl.length());
-    EXPECT_EQ((unsigned)2, bl.buffers().size());
-    EXPECT_EQ('B', bl.buffers().back()[0]);
-    EXPECT_EQ(ptr.get_raw(), bl.buffers().back().get_raw());
+    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
+    EXPECT_EQ('B', bl.back()[0]);
+    EXPECT_EQ(ptr.get_raw(), bl.back().get_raw());
   }
   //
   // void push_back(raw *r)
@@ -1446,23 +1446,23 @@ TEST(BufferList, push_back) {
     ptr.c_str()[0] = 'B';
     bl.push_back(ptr.get_raw());
     EXPECT_EQ((unsigned)(1 + len), bl.length());
-    EXPECT_EQ((unsigned)2, bl.buffers().size());
-    EXPECT_EQ('B', bl.buffers().back()[0]);
-    EXPECT_EQ(ptr.get_raw(), bl.buffers().back().get_raw());
+    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
+    EXPECT_EQ('B', bl.back()[0]);
+    EXPECT_EQ(ptr.get_raw(), bl.back().get_raw());
   }
 }
 
 TEST(BufferList, is_contiguous) {
   bufferlist bl;
   EXPECT_TRUE(bl.is_contiguous());
-  EXPECT_EQ((unsigned)0, bl.buffers().size());
+  EXPECT_EQ((unsigned)0, bl.get_num_buffers());
   bl.append('A');  
   EXPECT_TRUE(bl.is_contiguous());
-  EXPECT_EQ((unsigned)1, bl.buffers().size());
+  EXPECT_EQ((unsigned)1, bl.get_num_buffers());
   bufferptr ptr(1);
   bl.push_back(ptr);
   EXPECT_FALSE(bl.is_contiguous());
-  EXPECT_EQ((unsigned)2, bl.buffers().size());
+  EXPECT_EQ((unsigned)2, bl.get_num_buffers());
 }
 
 TEST(BufferList, rebuild) {
@@ -1481,11 +1481,11 @@ TEST(BufferList, rebuild) {
     const std::string str(CEPH_PAGE_SIZE, 'X');
     bl.append(str.c_str(), str.size());
     bl.append(str.c_str(), str.size());
-    EXPECT_EQ((unsigned)2, bl.buffers().size());
+    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
     EXPECT_TRUE(bl.is_aligned(CEPH_BUFFER_APPEND_SIZE));
     bl.rebuild();
     EXPECT_TRUE(bl.is_page_aligned());
-    EXPECT_EQ((unsigned)1, bl.buffers().size());
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
   }
 }
 
@@ -1498,11 +1498,11 @@ TEST(BufferList, rebuild_page_aligned) {
       ptr.set_length(CEPH_PAGE_SIZE);
       bl.append(ptr);
     }
-    EXPECT_EQ((unsigned)1, bl.buffers().size());
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
     EXPECT_FALSE(bl.is_page_aligned());
     bl.rebuild_page_aligned();
     EXPECT_TRUE(bl.is_page_aligned());
-    EXPECT_EQ((unsigned)1, bl.buffers().size());
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
   }
   {
     bufferlist bl;
@@ -1510,7 +1510,7 @@ TEST(BufferList, rebuild_page_aligned) {
     char *p = ptr.c_str();
     bl.append(ptr);
     bl.rebuild_page_aligned();
-    EXPECT_EQ(p, bl.buffers().front().c_str());
+    EXPECT_EQ(p, bl.front().c_str());
   }
   {
     bufferlist bl;
@@ -1554,12 +1554,12 @@ TEST(BufferList, rebuild_page_aligned) {
       EXPECT_TRUE(ptr.is_n_page_sized());
       bl.append(ptr);
     }
-    EXPECT_EQ((unsigned)6, bl.buffers().size());
+    EXPECT_EQ((unsigned)6, bl.get_num_buffers());
     EXPECT_TRUE((bl.length() & ~CEPH_PAGE_MASK) == 0);
     EXPECT_FALSE(bl.is_page_aligned());
     bl.rebuild_page_aligned();
     EXPECT_TRUE(bl.is_page_aligned());
-    EXPECT_EQ((unsigned)4, bl.buffers().size());
+    EXPECT_EQ((unsigned)4, bl.get_num_buffers());
   }
 }
 
@@ -1575,11 +1575,11 @@ TEST(BufferList, claim) {
     to.append(ptr);
   }
   EXPECT_EQ((unsigned)4, to.length());
-  EXPECT_EQ((unsigned)1, to.buffers().size());
+  EXPECT_EQ((unsigned)1, to.get_num_buffers());
   to.claim(from);
   EXPECT_EQ((unsigned)2, to.length());
-  EXPECT_EQ((unsigned)1, to.buffers().size());
-  EXPECT_EQ((unsigned)0, from.buffers().size());
+  EXPECT_EQ((unsigned)1, to.get_num_buffers());
+  EXPECT_EQ((unsigned)0, from.get_num_buffers());
   EXPECT_EQ((unsigned)0, from.length());
 }
 
@@ -1595,13 +1595,13 @@ TEST(BufferList, claim_append) {
     to.append(ptr);
   }
   EXPECT_EQ((unsigned)4, to.length());
-  EXPECT_EQ((unsigned)1, to.buffers().size());
+  EXPECT_EQ((unsigned)1, to.get_num_buffers());
   to.claim_append(from);
   EXPECT_EQ((unsigned)(4 + 2), to.length());
-  EXPECT_EQ((unsigned)4, to.buffers().front().length());
-  EXPECT_EQ((unsigned)2, to.buffers().back().length());
-  EXPECT_EQ((unsigned)2, to.buffers().size());
-  EXPECT_EQ((unsigned)0, from.buffers().size());
+  EXPECT_EQ((unsigned)4, to.front().length());
+  EXPECT_EQ((unsigned)2, to.back().length());
+  EXPECT_EQ((unsigned)2, to.get_num_buffers());
+  EXPECT_EQ((unsigned)0, from.get_num_buffers());
   EXPECT_EQ((unsigned)0, from.length());
 }
 
@@ -1617,13 +1617,13 @@ TEST(BufferList, claim_prepend) {
     to.append(ptr);
   }
   EXPECT_EQ((unsigned)4, to.length());
-  EXPECT_EQ((unsigned)1, to.buffers().size());
+  EXPECT_EQ((unsigned)1, to.get_num_buffers());
   to.claim_prepend(from);
   EXPECT_EQ((unsigned)(2 + 4), to.length());
-  EXPECT_EQ((unsigned)2, to.buffers().front().length());
-  EXPECT_EQ((unsigned)4, to.buffers().back().length());
-  EXPECT_EQ((unsigned)2, to.buffers().size());
-  EXPECT_EQ((unsigned)0, from.buffers().size());
+  EXPECT_EQ((unsigned)2, to.front().length());
+  EXPECT_EQ((unsigned)4, to.back().length());
+  EXPECT_EQ((unsigned)2, to.get_num_buffers());
+  EXPECT_EQ((unsigned)0, from.get_num_buffers());
   EXPECT_EQ((unsigned)0, from.length());
 }
 
@@ -1713,9 +1713,9 @@ TEST(BufferList, append) {
   //
   {
     bufferlist bl;
-    EXPECT_EQ((unsigned)0, bl.buffers().size());
+    EXPECT_EQ((unsigned)0, bl.get_num_buffers());
     bl.append('A');
-    EXPECT_EQ((unsigned)1, bl.buffers().size());
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
     EXPECT_TRUE(bl.is_aligned(CEPH_BUFFER_APPEND_SIZE));
   }
   //
@@ -1725,9 +1725,9 @@ TEST(BufferList, append) {
     bufferlist bl(CEPH_PAGE_SIZE);
     std::string str(CEPH_PAGE_SIZE * 2, 'X');
     bl.append(str.c_str(), str.size());
-    EXPECT_EQ((unsigned)2, bl.buffers().size());
-    EXPECT_EQ(CEPH_PAGE_SIZE, bl.buffers().front().length());
-    EXPECT_EQ(CEPH_PAGE_SIZE, bl.buffers().back().length());
+    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
+    EXPECT_EQ(CEPH_PAGE_SIZE, bl.front().length());
+    EXPECT_EQ(CEPH_PAGE_SIZE, bl.back().length());
   }
   //
   // void append(const std::string& s);
@@ -1736,27 +1736,27 @@ TEST(BufferList, append) {
     bufferlist bl(CEPH_PAGE_SIZE);
     std::string str(CEPH_PAGE_SIZE * 2, 'X');
     bl.append(str);
-    EXPECT_EQ((unsigned)2, bl.buffers().size());
-    EXPECT_EQ(CEPH_PAGE_SIZE, bl.buffers().front().length());
-    EXPECT_EQ(CEPH_PAGE_SIZE, bl.buffers().back().length());
+    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
+    EXPECT_EQ(CEPH_PAGE_SIZE, bl.front().length());
+    EXPECT_EQ(CEPH_PAGE_SIZE, bl.back().length());
   }
   //
   // void append(const ptr& bp);
   //
   {
     bufferlist bl;
-    EXPECT_EQ((unsigned)0, bl.buffers().size());
+    EXPECT_EQ((unsigned)0, bl.get_num_buffers());
     EXPECT_EQ((unsigned)0, bl.length());
     {
       bufferptr ptr;
       bl.append(ptr);
-      EXPECT_EQ((unsigned)0, bl.buffers().size());
+      EXPECT_EQ((unsigned)0, bl.get_num_buffers());
       EXPECT_EQ((unsigned)0, bl.length());
     }
     {
       bufferptr ptr(3);
       bl.append(ptr);
-      EXPECT_EQ((unsigned)1, bl.buffers().size());
+      EXPECT_EQ((unsigned)1, bl.get_num_buffers());
       EXPECT_EQ((unsigned)3, bl.length());
     }
   }
@@ -1766,27 +1766,27 @@ TEST(BufferList, append) {
   {
     bufferlist bl;
     bl.append('A');
-    bufferptr back(bl.buffers().back());
+    bufferptr back(bl.back());
     bufferptr in(back);
-    EXPECT_EQ((unsigned)1, bl.buffers().size());
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
     EXPECT_EQ((unsigned)1, bl.length());
     EXPECT_THROW(bl.append(in, (unsigned)100, (unsigned)100), FailedAssertion);
     EXPECT_LT((unsigned)0, in.unused_tail_length());
     in.append('B');
     bl.append(in, back.end(), 1);
-    EXPECT_EQ((unsigned)1, bl.buffers().size());
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
     EXPECT_EQ((unsigned)2, bl.length());
     EXPECT_EQ('B', bl[1]);
   }
   {
     bufferlist bl;
-    EXPECT_EQ((unsigned)0, bl.buffers().size());
+    EXPECT_EQ((unsigned)0, bl.get_num_buffers());
     EXPECT_EQ((unsigned)0, bl.length());
     bufferptr ptr(2);
     ptr.set_length(0);
     ptr.append("AB", 2);
     bl.append(ptr, 1, 1);
-    EXPECT_EQ((unsigned)1, bl.buffers().size());
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
     EXPECT_EQ((unsigned)1, bl.length());
   }
   //
@@ -1798,7 +1798,7 @@ TEST(BufferList, append) {
     bufferlist other;
     other.append('B');
     bl.append(other);
-    EXPECT_EQ((unsigned)2, bl.buffers().size());
+    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
     EXPECT_EQ('B', bl[1]);
   }
   //
@@ -1817,10 +1817,10 @@ TEST(BufferList, append) {
 TEST(BufferList, append_zero) {
   bufferlist bl;
   bl.append('A');
-  EXPECT_EQ((unsigned)1, bl.buffers().size());
+  EXPECT_EQ((unsigned)1, bl.get_num_buffers());
   EXPECT_EQ((unsigned)1, bl.length());
   bl.append_zero(1);
-  EXPECT_EQ((unsigned)2, bl.buffers().size());
+  EXPECT_EQ((unsigned)2, bl.get_num_buffers());
   EXPECT_EQ((unsigned)2, bl.length());
   EXPECT_EQ('\0', bl[1]);
 }
@@ -1832,7 +1832,7 @@ TEST(BufferList, operator_brackets) {
   bufferlist other;
   other.append('B');
   bl.append(other);
-  EXPECT_EQ((unsigned)2, bl.buffers().size());
+  EXPECT_EQ((unsigned)2, bl.get_num_buffers());
   EXPECT_EQ('B', bl[1]);
 }
 
@@ -1843,7 +1843,7 @@ TEST(BufferList, c_str) {
   bufferlist other;
   other.append('B');
   bl.append(other);
-  EXPECT_EQ((unsigned)2, bl.buffers().size());
+  EXPECT_EQ((unsigned)2, bl.get_num_buffers());
   EXPECT_EQ(0, ::memcmp("AB", bl.c_str(), 2));
 }
 
@@ -1860,12 +1860,12 @@ TEST(BufferList, substr_of) {
     bufferptr ptr(s[i], strlen(s[i]));
     bl.push_back(ptr);
   }
-  EXPECT_EQ((unsigned)4, bl.buffers().size());
+  EXPECT_EQ((unsigned)4, bl.get_num_buffers());
 
   bufferlist other;
   other.append("TO BE CLEARED");
   other.substr_of(bl, 4, 4);
-  EXPECT_EQ((unsigned)2, other.buffers().size());
+  EXPECT_EQ((unsigned)2, other.get_num_buffers());
   EXPECT_EQ((unsigned)4, other.length());
   EXPECT_EQ(0, ::memcmp("EFGH", other.c_str(), 4));
 }
@@ -1883,13 +1883,13 @@ TEST(BufferList, splice) {
     bufferptr ptr(s[i], strlen(s[i]));
     bl.push_back(ptr);
   }
-  EXPECT_EQ((unsigned)4, bl.buffers().size());
+  EXPECT_EQ((unsigned)4, bl.get_num_buffers());
   bl.splice(0, 0);
 
   bufferlist other;
   other.append('X');
   bl.splice(4, 4, &other);
-  EXPECT_EQ((unsigned)3, other.buffers().size());
+  EXPECT_EQ((unsigned)3, other.get_num_buffers());
   EXPECT_EQ((unsigned)5, other.length());
   EXPECT_EQ(0, ::memcmp("XEFGH", other.c_str(), other.length()));
   EXPECT_EQ((unsigned)8, bl.length());
@@ -1982,7 +1982,7 @@ TEST(BufferList, read_fd) {
   EXPECT_EQ(-EBADF, bl.read_fd(fd, len));
   fd = ::open(FILENAME, O_RDONLY);
   EXPECT_EQ(len, (unsigned)bl.read_fd(fd, len));
-  EXPECT_EQ(CEPH_BUFFER_APPEND_SIZE - len, bl.buffers().front().unused_tail_length());
+  EXPECT_EQ(CEPH_BUFFER_APPEND_SIZE - len, bl.front().unused_tail_length());
   EXPECT_EQ(len, bl.length());
   ::close(fd);
   ::unlink(FILENAME);

--- a/src/test/erasure-code/ErasureCodeExample.h
+++ b/src/test/erasure-code/ErasureCodeExample.h
@@ -128,7 +128,7 @@ public:
     // populate the bufferlist with bufferptr pointing
     // to chunk boundaries
     //
-    const bufferptr ptr = out.buffers().front();
+    const bufferptr &ptr = out.front();
     for (set<int>::iterator j = want_to_encode.begin();
          j != want_to_encode.end();
          ++j) {
@@ -172,9 +172,9 @@ public:
 	// two recovers it.
 	//
         map<int, bufferlist>::const_iterator k = chunks.begin();
-        const char *a = k->second.buffers().front().c_str();
+        const char *a = k->second.front().c_str();
         ++k;
-        const char *b = k->second.buffers().front().c_str();
+        const char *b = k->second.front().c_str();
         bufferptr chunk(chunk_length);
 	char *c = chunk.c_str();
         for (unsigned j = 0; j < chunk_length; j++) {

--- a/src/test/erasure-code/TestErasureCode.cc
+++ b/src/test/erasure-code/TestErasureCode.cc
@@ -140,10 +140,10 @@ TEST(ErasureCodeTest, encode_misaligned_non_contiguous)
   map<int, bufferlist> encoded;
 
   ASSERT_FALSE(in.is_contiguous());
-  ASSERT_TRUE(in.buffers().front().is_aligned(ErasureCode::SIMD_ALIGN));
-  ASSERT_FALSE(in.buffers().front().is_n_align_sized(chunk_size));
-  ASSERT_TRUE(in.buffers().back().is_aligned(ErasureCode::SIMD_ALIGN));
-  ASSERT_FALSE(in.buffers().back().is_n_align_sized(chunk_size));
+  ASSERT_TRUE(in.front().is_aligned(ErasureCode::SIMD_ALIGN));
+  ASSERT_FALSE(in.front().is_n_align_sized(chunk_size));
+  ASSERT_TRUE(in.back().is_aligned(ErasureCode::SIMD_ALIGN));
+  ASSERT_FALSE(in.back().is_n_align_sized(chunk_size));
   ASSERT_EQ(0, erasure_code.encode(want_to_encode, in, &encoded));
   for (unsigned int i = 0; i < erasure_code.get_chunk_count(); i++) {
     ASSERT_TRUE(encoded[i].is_aligned(ErasureCode::SIMD_ALIGN));


### PR DESCRIPTION
The first patch combines the 'raw' (refcount) and actual data buffer into 1 allocation.  That takes us from

[ RUN      ] Buffer.BenchAlloc
1000000 alloc of size 32 in 0.306848
1000000 alloc of size 4096 in 0.363294
1000000 alloc of size 16384 in 0.360565
[       OK ] Buffer.BenchAlloc (1031 ms)

to

[ RUN      ] Buffer.BenchAlloc
1000000 alloc of size 32 in 0.286422
1000000 alloc of size 4096 in 0.313642
1000000 alloc of size 16384 in 0.309992
[       OK ] Buffer.BenchAlloc (911 ms)

The rest of the patches change bufferlist to be an intrusive list (no real change in performance), and then embed ptr's in raw... ultimately taking us from 3 allocations to 1.  For the bufferlist append test, overall we go from

[ RUN      ] BufferList.BenchAlloc
100000 alloc of size 32 in 0.651433
100000 alloc of size 4096 in 0.799733
100000 alloc of size 16384 in 0.789603
[       OK ] BufferList.BenchAlloc (2241 ms)

to

[ RUN      ] BufferList.BenchAlloc
100000 alloc of size 32 in 0.305846
100000 alloc of size 4096 in 0.351239
100000 alloc of size 16384 in 1.664326
[       OK ] BufferList.BenchAlloc (2322 ms)

The 16k result is very strange... it seem sto be allocator dependent. For example, if I revert teh first change (so we still have a separate raw allocation, but are doing the intrusive bufferlist) I can get

[ RUN      ] Buffer.BenchAlloc
1000000 alloc of size 32 in 0.319626
1000000 alloc of size 4096 in 0.386397
1000000 alloc of size 16384 in 0.326450
[       OK ] Buffer.BenchAlloc (1032 ms)
[----------] 1 test from Buffer (1032 ms total)

[----------] 1 test from BufferList
[ RUN      ] BufferList.BenchAlloc
100000 alloc of size 32 in 0.342013
100000 alloc of size 4096 in 0.477699
100000 alloc of size 16384 in 0.481672
[       OK ] BufferList.BenchAlloc (1301 ms)

if I run both tests, but if I run *just* the bufferlist one, I get

[ RUN      ] BufferList.BenchAlloc
100000 alloc of size 32 in 0.323774
100000 alloc of size 4096 in 0.350287
100000 alloc of size 16384 in 1.665775
[       OK ] BufferList.BenchAlloc (2340 ms)

So, clearly there are some secondary effects with the allocator.  This will need some more thorough benchmarking than what I've done :).