### PR TITLE
WorkQueue: add/remove_work_queue methods now thread safe

### DIFF
--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -340,10 +340,12 @@ public:
   
   /// assign a work queue to this thread pool
   void add_work_queue(WorkQueue_* wq) {
+    Mutex::Locker l(_lock);
     work_queues.push_back(wq);
   }
   /// remove a work queue from this thread pool
   void remove_work_queue(WorkQueue_* wq) {
+    Mutex::Locker l(_lock);
     unsigned i = 0;
     while (work_queues[i] != wq)
       i++;


### PR DESCRIPTION
These methods were not acquiring the ThreadPool lock when
manipulating the work_queue collection.  This was causing
occasional crashes within librbd when opening and closing
images.

Fixes: #12662
Backport: hammer, firefly
Signed-off-by: Jason Dillaman <dillaman@redhat.com>