### PR TITLE
rbd:modify the log of purging snaps so that it is more appropriate.

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -787,7 +787,7 @@ static int do_purge_snaps(librbd::Image& image)
         return r;
       } else if (is_protected == true) {
         pc.fail();
-        cerr << "\r" <<snaps[i].name.c_str()<< " is a protected snap."<< std::endl;
+        cerr << "\r" << "rbd: snapshot '" <<snaps[i].name.c_str()<< "' is protected from removal." << std::endl;
         return -EBUSY;
       }
     }
@@ -3847,7 +3847,9 @@ if (!set_conf_param(v, p1, p2, p3)) { \
   case OPT_SNAP_PURGE:
     r = do_purge_snaps(image);
     if (r < 0) {
-      cerr << "rbd: removing snaps failed: " << cpp_strerror(-r) << std::endl;
+      if (r != -EBUSY) {
+        cerr << "rbd: removing snaps failed: " << cpp_strerror(-r) << std::endl;
+      }
       return -r;
     }
     break;


### PR DESCRIPTION
test fix:
before:
if there is a snap which is protected,when purging the snaps,it will print the log:
Removing all snapshots: 0% complete...failed.                                   
foo5 is a protected snap.                                                      
rbd: removing snaps failed: (16) Device or resource busy 

the log of purging snaps  is not clear comparing with removing snap 
after:
if there is a snap which is protected,when purging the snaps,it will print the log:
Removing all snapshots: 0% complete...failed.                                   
rbd: snapshot 'foo5' is protected from removal. 

the log of purging snaps is consistent with the log of removing snap,it is more appropriate.
Signed-off-by: s09816 shi.lu@h3c.com 