### PR TITLE
selinux: Relabel files if and only if the policy version changed

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -426,7 +426,7 @@ Summary:	SELinux support for Ceph MON, OSD and MDS
 Group:		System Environment/Base
 Requires:	%{name}
 Requires:	policycoreutils, libselinux-utils
-Requires(post): selinux-policy-base >= %{_selinux_policy_version}, policycoreutils
+Requires(post): selinux-policy-base >= %{_selinux_policy_version}, policycoreutils, gawk
 Requires(postun): policycoreutils
 %description selinux
 This package contains SELinux support for Ceph MON, OSD and MDS. The package

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1143,10 +1143,14 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
     /sbin/service ceph stop >/dev/null 2>&1 || :
 %endif
 
+OLD_POLVER=$(%{_sbindir}/semodule -l | grep -P '^ceph[\t ]' | awk '{print $2}')
 %{_sbindir}/semodule -n -i %{_datadir}/selinux/packages/ceph.pp
-if %{_sbindir}/selinuxenabled ; then
+NEW_POLVER=$(%{_sbindir}/semodule -l | grep -P '^ceph[\t ]' | awk '{print $2}')
+if %{_sbindir}/selinuxenabled; then
     %{_sbindir}/load_policy
-    %relabel_files
+    if test "$OLD_POLVER" != "$NEW_POLVER"; then
+        %relabel_files
+   fi
 fi
 
 %if 0%{?_with_systemd}


### PR DESCRIPTION
Currently, the ceph files are being relabelled every time the package is
rebuilt. Fix this by checking the policy versions and relabel the files
only if the policy actually changed (different policy version was
detected).