### PR TITLE
mon: show # of PGs at high flush mode in the command output

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1239,6 +1239,46 @@ void PGMap::cache_io_rate_summary(Formatter *f, ostream *out,
       have_output = true;
     }
   }
+  if (pos_delta.stats.sum.num_flush_mode_low) {
+    if (f) {
+      f->dump_int("num_flush_mode_low", pos_delta.stats.sum.num_flush_mode_low);
+    } else {
+      if (have_output)
+	*out << ", ";
+      *out << pretty_si_t(pos_delta.stats.sum.num_flush_mode_low) << "PG(s) flushing";
+      have_output = true;
+    }
+  }
+  if (pos_delta.stats.sum.num_flush_mode_high) {
+    if (f) {
+      f->dump_int("num_flush_mode_high", pos_delta.stats.sum.num_flush_mode_high);
+    } else {
+      if (have_output)
+	*out << ", ";
+      *out << pretty_si_t(pos_delta.stats.sum.num_flush_mode_high) << "PG(s) flushing (high)";
+      have_output = true;
+    }
+  }
+  if (pos_delta.stats.sum.num_evict_mode_some) {
+    if (f) {
+      f->dump_int("num_evict_mode_some", pos_delta.stats.sum.num_evict_mode_some);
+    } else {
+      if (have_output)
+	*out << ", ";
+      *out << pretty_si_t(pos_delta.stats.sum.num_evict_mode_some) << "PG(s) evicting";
+      have_output = true;
+    }
+  }
+  if (pos_delta.stats.sum.num_evict_mode_full) {
+    if (f) {
+      f->dump_int("num_evict_mode_full", pos_delta.stats.sum.num_evict_mode_full);
+    } else {
+      if (have_output)
+	*out << ", ";
+      *out << pretty_si_t(pos_delta.stats.sum.num_evict_mode_full) << "PG(s) evicting (full)";
+      have_output = true;
+    }
+  }
 }
 
 void PGMap::overall_cache_io_rate_summary(Formatter *f, ostream *out) const

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1206,32 +1206,37 @@ void PGMap::cache_io_rate_summary(Formatter *f, ostream *out,
 {
   pool_stat_t pos_delta = delta_sum;
   pos_delta.floor(0);
-  if (pos_delta.stats.sum.num_flush ||
-      pos_delta.stats.sum.num_evict ||
-      pos_delta.stats.sum.num_promote) {
-    if (pos_delta.stats.sum.num_flush) {
-      int64_t flush = (pos_delta.stats.sum.num_flush_kb << 10) / (double)delta_stamp;
-      if (f) {
-	f->dump_int("flush_bytes_sec", flush);
-      } else {
-	*out << pretty_si_t(flush) << "B/s flush";
-      }
+  bool have_output = false;
+
+  if (pos_delta.stats.sum.num_flush) {
+    int64_t flush = (pos_delta.stats.sum.num_flush_kb << 10) / (double)delta_stamp;
+    if (f) {
+      f->dump_int("flush_bytes_sec", flush);
+    } else {
+      *out << pretty_si_t(flush) << "B/s flush";
+      have_output = true;
     }
-    if (pos_delta.stats.sum.num_evict) {
-      int64_t evict = (pos_delta.stats.sum.num_evict_kb << 10) / (double)delta_stamp;
-      if (f) {
-	f->dump_int("evict_bytes_sec", evict);
-      } else {
-	*out << ", " << pretty_si_t(evict) << "B/s evict";
-      }
+  }
+  if (pos_delta.stats.sum.num_evict) {
+    int64_t evict = (pos_delta.stats.sum.num_evict_kb << 10) / (double)delta_stamp;
+    if (f) {
+      f->dump_int("evict_bytes_sec", evict);
+    } else {
+      if (have_output)
+	*out << ", ";
+      *out << pretty_si_t(evict) << "B/s evict";
+      have_output = true;
     }
-    if (pos_delta.stats.sum.num_promote) {
-      int64_t promote = pos_delta.stats.sum.num_promote / (double)delta_stamp;
-      if (f) {
-        f->dump_int("promote_op_per_sec", promote);
-      } else {
-        *out << ", " << pretty_si_t(promote) << "op/s promote";
-      }
+  }
+  if (pos_delta.stats.sum.num_promote) {
+    int64_t promote = pos_delta.stats.sum.num_promote / (double)delta_stamp;
+    if (f) {
+      f->dump_int("promote_op_per_sec", promote);
+    } else {
+      if (have_output)
+	*out << ", ";
+      *out << pretty_si_t(promote) << "op/s promote";
+      have_output = true;
     }
   }
 }

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -11156,10 +11156,18 @@ bool ReplicatedPG::agent_choose_mode(bool restart, OpRequestRef op)
 	    << " -> "
 	    << TierAgentState::get_flush_mode_name(flush_mode)
 	    << dendl;
-    if (flush_mode == TierAgentState::FLUSH_MODE_HIGH)
+    if (flush_mode == TierAgentState::FLUSH_MODE_HIGH) {
       osd->agent_inc_high_count();
-    if (agent_state->flush_mode == TierAgentState::FLUSH_MODE_HIGH)
+      info.stats.stats.sum.num_flush_mode_high = 1;
+    } else if (flush_mode == TierAgentState::FLUSH_MODE_LOW) {
+      info.stats.stats.sum.num_flush_mode_low = 1;
+    }
+    if (agent_state->flush_mode == TierAgentState::FLUSH_MODE_HIGH) {
       osd->agent_dec_high_count();
+      info.stats.stats.sum.num_flush_mode_high = 0;
+    } else if (agent_state->flush_mode == TierAgentState::FLUSH_MODE_LOW) {
+      info.stats.stats.sum.num_flush_mode_low = 0;
+    }
     agent_state->flush_mode = flush_mode;
   }
   if (evict_mode != agent_state->evict_mode) {
@@ -11175,6 +11183,16 @@ bool ReplicatedPG::agent_choose_mode(bool restart, OpRequestRef op)
       requeue_ops(waiting_for_active);
       requeue_ops(waiting_for_cache_not_full);
       requeued = true;
+    }
+    if (evict_mode == TierAgentState::EVICT_MODE_SOME) {
+      info.stats.stats.sum.num_evict_mode_some = 1;
+    } else if (evict_mode == TierAgentState::EVICT_MODE_FULL) {
+      info.stats.stats.sum.num_evict_mode_full = 1;
+    }
+    if (agent_state->evict_mode == TierAgentState::EVICT_MODE_SOME) {
+      info.stats.stats.sum.num_evict_mode_some = 0;
+    } else if (agent_state->evict_mode == TierAgentState::EVICT_MODE_FULL) {
+      info.stats.stats.sum.num_evict_mode_full = 0;
     }
     agent_state->evict_mode = evict_mode;
   }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1560,11 +1560,15 @@ void object_stat_sum_t::dump(Formatter *f) const
   f->dump_int("num_evict", num_evict);
   f->dump_int("num_evict_kb", num_evict_kb);
   f->dump_int("num_promote", num_promote);
+  f->dump_int("num_flush_mode_high", num_flush_mode_high);
+  f->dump_int("num_flush_mode_low", num_flush_mode_low);
+  f->dump_int("num_evict_mode_some", num_evict_mode_some);
+  f->dump_int("num_evict_mode_full", num_evict_mode_full);
 }
 
 void object_stat_sum_t::encode(bufferlist& bl) const
 {
-  ENCODE_START(12, 3, bl);
+  ENCODE_START(13, 3, bl);
   ::encode(num_bytes, bl);
   ::encode(num_objects, bl);
   ::encode(num_object_clones, bl);
@@ -1593,12 +1597,16 @@ void object_stat_sum_t::encode(bufferlist& bl) const
   ::encode(num_evict, bl);
   ::encode(num_evict_kb, bl);
   ::encode(num_promote, bl);
+  ::encode(num_flush_mode_high, bl);
+  ::encode(num_flush_mode_low, bl);
+  ::encode(num_evict_mode_some, bl);
+  ::encode(num_evict_mode_full, bl);
   ENCODE_FINISH(bl);
 }
 
 void object_stat_sum_t::decode(bufferlist::iterator& bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(12, 3, 3, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(13, 3, 3, bl);
   ::decode(num_bytes, bl);
   if (struct_v < 3) {
     uint64_t num_kb;
@@ -1675,6 +1683,17 @@ void object_stat_sum_t::decode(bufferlist::iterator& bl)
     num_evict_kb = 0;
     num_promote = 0;
   }
+  if (struct_v >= 13) {
+    ::decode(num_flush_mode_high, bl);
+    ::decode(num_flush_mode_low, bl);
+    ::decode(num_evict_mode_some, bl);
+    ::decode(num_evict_mode_full, bl);
+  } else {
+    num_flush_mode_high = 0;
+    num_flush_mode_low = 0;
+    num_evict_mode_some = 0;
+    num_evict_mode_full = 0;
+  }
   DECODE_FINISH(bl);
 }
 
@@ -1707,6 +1726,10 @@ void object_stat_sum_t::generate_test_instances(list<object_stat_sum_t*>& o)
   a.num_evict = 7;
   a.num_evict_kb = 8;
   a.num_promote = 9;
+  a.num_flush_mode_high = 0;
+  a.num_flush_mode_low = 1;
+  a.num_evict_mode_some = 1;
+  a.num_evict_mode_full = 0;
   o.push_back(new object_stat_sum_t(a));
 }
 
@@ -1740,6 +1763,10 @@ void object_stat_sum_t::add(const object_stat_sum_t& o)
   num_evict += o.num_evict;
   num_evict_kb += o.num_evict_kb;
   num_promote += o.num_promote;
+  num_flush_mode_high += o.num_flush_mode_high;
+  num_flush_mode_low += o.num_flush_mode_low;
+  num_evict_mode_some += o.num_evict_mode_some;
+  num_evict_mode_full += o.num_evict_mode_full;
 }
 
 void object_stat_sum_t::sub(const object_stat_sum_t& o)
@@ -1772,6 +1799,10 @@ void object_stat_sum_t::sub(const object_stat_sum_t& o)
   num_evict -= o.num_evict;
   num_evict_kb -= o.num_evict_kb;
   num_promote -= o.num_promote;
+  num_flush_mode_high -= o.num_flush_mode_high;
+  num_flush_mode_low -= o.num_flush_mode_low;
+  num_evict_mode_some -= o.num_evict_mode_some;
+  num_evict_mode_full -= o.num_evict_mode_full;
 }
 
 bool operator==(const object_stat_sum_t& l, const object_stat_sum_t& r)
@@ -1804,7 +1835,11 @@ bool operator==(const object_stat_sum_t& l, const object_stat_sum_t& r)
     l.num_flush_kb == r.num_flush_kb &&
     l.num_evict == r.num_evict &&
     l.num_evict_kb == r.num_evict_kb &&
-    l.num_promote == r.num_promote;
+    l.num_promote == r.num_promote &&
+    l.num_flush_mode_high == r.num_flush_mode_high &&
+    l.num_flush_mode_low == r.num_flush_mode_low &&
+    l.num_evict_mode_some == r.num_evict_mode_some &&
+    l.num_evict_mode_full == r.num_evict_mode_full;
 }
 
 // -- object_stat_collection_t --

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1330,6 +1330,10 @@ struct object_stat_sum_t {
   int64_t num_evict;
   int64_t num_evict_kb;
   int64_t num_promote;
+  int32_t num_flush_mode_high;  // 1 when in high flush mode, otherwise 0
+  int32_t num_flush_mode_low;   // 1 when in low flush mode, otherwise 0
+  int32_t num_evict_mode_some;  // 1 when in evict some mode, otherwise 0
+  int32_t num_evict_mode_full;  // 1 when in evict full mode, otherwise 0
 
   object_stat_sum_t()
     : num_bytes(0),
@@ -1352,7 +1356,9 @@ struct object_stat_sum_t {
       num_flush_kb(0),
       num_evict(0),
       num_evict_kb(0),
-      num_promote(0)
+      num_promote(0),
+      num_flush_mode_high(0), num_flush_mode_low(0),
+      num_evict_mode_some(0), num_evict_mode_full(0)
   {}
 
   void floor(int64_t f) {
@@ -1385,6 +1391,10 @@ struct object_stat_sum_t {
     FLOOR(num_evict);
     FLOOR(num_evict_kb);
     FLOOR(num_promote);
+    FLOOR(num_flush_mode_high);
+    FLOOR(num_flush_mode_low);
+    FLOOR(num_evict_mode_some);
+    FLOOR(num_evict_mode_full);
 #undef FLOOR
   }
 
@@ -1425,6 +1435,10 @@ struct object_stat_sum_t {
     SPLIT(num_evict);
     SPLIT(num_evict_kb);
     SPLIT(num_promote);
+    SPLIT(num_flush_mode_high);
+    SPLIT(num_flush_mode_low);
+    SPLIT(num_evict_mode_some);
+    SPLIT(num_evict_mode_full);
 #undef SPLIT
   }
 


### PR DESCRIPTION
The commands are now look like:

```
$ sudo ./ceph -s
    cluster 2b3434c4-f21a-407c-8f31-c79956115f03
     health HEALTH_WARN
            'cache' at/near target max
     monmap e1: 3 mons at {a=127.0.0.1:6789/0,b=127.0.0.1:6790/0,c=127.0.0.1:6791/0}
            election epoch 6, quorum 0,1,2 a,b,c
     mdsmap e13: 3/3/3 up {0=a=up:active,1=b=up:active,2=c=up:active}
     osdmap e20: 3 osds: 3 up, 3 in
      pgmap v29: 32 pgs, 5 pools, 24784 bytes data, 739 objects
            73630 MB used, 74453 MB / 152 GB avail
                  32 active+clean
  client io 100 kB/s rd, 318 kB/s wr, 723 op/s
  cache io 2637 B/s flush, 100 op/s promote, 2 PG(s) are flushing at the high threshold

$ sudo ./ceph osd pool stats
pool rbd id 0
  nothing is going on

pool cephfs_data id 1
  nothing is going on

pool cephfs_metadata id 2
  nothing is going on

pool base id 3
  client io 12271 B/s wr, 11 op/s

pool cache id 4
  client io 118 kB/s rd, 371 kB/s wr, 850 op/s
  cache tier io 9934 B/s flush, 2101 B/s evict, 119 op/s promote, 2 PG(s) are flushing at the high threshold
```