### PR TITLE
selinux: Update policy for radosgw

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -212,6 +212,9 @@ FUSE based client to map Ceph rbd images to files
 Summary:	Rados REST gateway
 Group:		Development/Libraries
 Requires:	ceph-common = %{epoch}:%{version}-%{release}
+%if 0%{with selinux}
+Requires:	ceph-selinux = %{epoch}:%{version}-%{release}
+%endif
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 %if 0%{defined suse_version}
 BuildRequires:	libexpat-devel

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -20,10 +20,13 @@
 restorecon -R /usr/bin/ceph-mon > /dev/null 2>&1; \
 restorecon -R /usr/bin/ceph-osd > /dev/null 2>&1; \
 restorecon -R /usr/bin/ceph-mds > /dev/null 2>&1; \
+restorecon -R /usr/bin/radosgw > /dev/null 2>&1; \
 restorecon -R /etc/rc\.d/init\.d/ceph > /dev/null 2>&1; \
+restorecon -R /etc/rc\.d/init\.d/radosgw > /dev/null 2>&1; \
 restorecon -R /var/run/ceph > /dev/null 2>&1; \
 restorecon -R /var/lib/ceph > /dev/null 2>&1; \
-restorecon -R /var/log/ceph > /dev/null 2>&1;
+restorecon -R /var/log/ceph > /dev/null 2>&1; \
+restorecon -R /var/log/radosgw > /dev/null 2>&1;
 %endif
 
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}

--- a/selinux/ceph.fc
+++ b/selinux/ceph.fc
@@ -1,11 +1,14 @@
-/etc/rc\.d/init\.d/ceph	--	gen_context(system_u:object_r:ceph_initrc_exec_t,s0)
+/etc/rc\.d/init\.d/ceph		--	gen_context(system_u:object_r:ceph_initrc_exec_t,s0)
+/etc/rc\.d/init\.d/radosgw	--	gen_context(system_u:object_r:ceph_initrc_exec_t,s0)
 
 /usr/bin/ceph-mon		--	gen_context(system_u:object_r:ceph_exec_t,s0)
 /usr/bin/ceph-mds		--	gen_context(system_u:object_r:ceph_exec_t,s0)
 /usr/bin/ceph-osd		--	gen_context(system_u:object_r:ceph_exec_t,s0)
+/usr/bin/radosgw		--	gen_context(system_u:object_r:ceph_exec_t,s0)
 
 /var/lib/ceph(/.*)?		gen_context(system_u:object_r:ceph_var_lib_t,s0)
 
 /var/log/ceph(/.*)?		gen_context(system_u:object_r:ceph_log_t,s0)
+/var/log/radosgw(/.*)?		gen_context(system_u:object_r:ceph_log_t,s0)
 
 /var/run/ceph(/.*)?		gen_context(system_u:object_r:ceph_var_run_t,s0)

--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -1,9 +1,10 @@
-policy_module(ceph, 1.0.0)
+policy_module(ceph, 1.1.0)
 
 require {
 	type sysfs_t;
 	type var_run_t;
 	type random_device_t;
+	type urandom_device_t;
         type setfiles_t;
 	class sock_file unlink;
 	class lnk_file read;
@@ -42,7 +43,6 @@ files_pid_file(ceph_var_run_t)
 allow ceph_t self:process { signal_perms };
 allow ceph_t self:fifo_file rw_fifo_file_perms;
 allow ceph_t self:unix_stream_socket create_stream_socket_perms;
-# not needed at the moment, for future releases, not needed at all if we switch to systemd init scripts
 allow ceph_t self:capability { setuid setgid };
 
 manage_dirs_pattern(ceph_t, ceph_log_t, ceph_log_t)
@@ -83,9 +83,8 @@ logging_send_syslog_msg(ceph_t)
 
 sysnet_dns_name_resolve(ceph_t)
 
-# added 2015-06-17, need review
-
-allow ceph_t ceph_var_run_t:sock_file create;
+# basis for future security review
+allow ceph_t ceph_var_run_t:sock_file { create unlink write };
 allow ceph_t self:capability sys_rawio;
 
 allow ceph_t self:tcp_socket { accept listen };
@@ -96,14 +95,12 @@ fstools_exec(ceph_t)
 nis_use_ypbind_uncond(ceph_t)
 storage_raw_rw_fixed_disk(ceph_t)
 
-# added 2015-07-28, needs review just as well
-allow ceph_t ceph_var_run_t:sock_file unlink;
 allow ceph_t sysfs_t:dir read;
 allow ceph_t sysfs_t:file { read getattr open };
 allow ceph_t sysfs_t:lnk_file read;
 
-
 allow ceph_t random_device_t:chr_file getattr;
+allow ceph_t urandom_device_t:chr_file getattr;
 allow ceph_t self:process setpgid;
 allow ceph_t var_run_t:dir { write create add_name };
 allow ceph_t var_run_t:file { write create open getattr };

--- a/selinux/ceph_selinux.8
+++ b/selinux/ceph_selinux.8
@@ -1,4 +1,4 @@
-.TH  "ceph_selinux"  "8"  "15-06-17" "ceph" "SELinux Policy ceph"
+.TH  "ceph_selinux"  "8"  "15-08-10" "ceph" "SELinux Policy ceph"
 .SH "NAME"
 ceph_selinux \- Security Enhanced Linux Policy for the ceph processes
 .SH "DESCRIPTION"
@@ -18,7 +18,7 @@ The ceph_t SELinux type can be entered via the \fBceph_exec_t\fP file type.
 
 The default entrypoint paths for the ceph_t domain are the following:
 
-/usr/bin/ceph-mon, /usr/bin/ceph-mds, /usr/bin/ceph-osd
+/usr/bin/radosgw, /usr/bin/ceph-mon, /usr/bin/ceph-mds, /usr/bin/ceph-osd
 .SH PROCESS TYPES
 SELinux defines process types (domains) for each process running on the system
 .PP
@@ -145,6 +145,22 @@ If you want to allow confined applications to use nscd shared memory, you must t
 
 .EE
 
+.SH NSSWITCH DOMAIN
+
+.PP
+If you want to allow users to resolve user passwd entries directly from ldap rather then using a sssd server for the ceph_t, you must turn on the authlogin_nsswitch_use_ldap boolean.
+
+.EX
+.B setsebool -P authlogin_nsswitch_use_ldap 1
+.EE
+
+.PP
+If you want to allow confined applications to run with kerberos for the ceph_t, you must turn on the kerberos_enabled boolean.
+
+.EX
+.B setsebool -P kerberos_enabled 1
+.EE
+
 .SH "MANAGED FILES"
 
 The SELinux process type ceph_t can manage files labeled with the following file types.  The paths listed are the default paths for these file types.  Note the processes UID still need to have DAC permissions.
@@ -153,6 +169,8 @@ The SELinux process type ceph_t can manage files labeled with the following file
 .B ceph_log_t
 
 	/var/log/ceph(/.*)?
+.br
+	/var/log/radosgw(/.*)?
 .br
 
 .br
@@ -216,11 +234,33 @@ The SELinux process type ceph_t can manage files labeled with the following file
 .br
 
 .br
+.B fsadm_var_run_t
+
+	/var/run/blkid(/.*)?
+.br
+
+.br
 .B root_t
 
 	/
 .br
 	/initrd
+.br
+
+.br
+.B var_run_t
+
+	/run/.*
+.br
+	/var/run/.*
+.br
+	/run
+.br
+	/var/run
+.br
+	/var/run
+.br
+	/var/spool/postfix/pid
 .br
 
 .SH FILE CONTEXTS
@@ -238,7 +278,7 @@ SELinux ceph policy is very flexible allowing users to setup their ceph processe
 SELinux defines the file context types for the ceph, if you wanted to
 store files with these types in a diffent paths, you need to execute the semanage command to sepecify alternate labeling and then use restorecon to put the labels on disk.
 
-.B semanage fcontext -a -t ceph_var_run_t '/srv/myceph_content(/.*)?'
+.B semanage fcontext -a -t ceph_exec_t '/srv/ceph/content(/.*)?'
 .br
 .B restorecon -R -v /srv/myceph_content
 
@@ -257,7 +297,7 @@ Note: SELinux often uses regular expressions to specify labels that match multip
 .br
 .TP 5
 Paths:
-/usr/bin/ceph-mon, /usr/bin/ceph-mds, /usr/bin/ceph-osd
+/usr/bin/radosgw, /usr/bin/ceph-mon, /usr/bin/ceph-mds, /usr/bin/ceph-osd
 
 .EX
 .PP
@@ -266,6 +306,10 @@ Paths:
 
 - Set files with the ceph_initrc_exec_t type, if you want to transition an executable to the ceph_initrc_t domain.
 
+.br
+.TP 5
+Paths:
+/etc/rc\.d/init\.d/ceph, /etc/rc\.d/init\.d/radosgw
 
 .EX
 .PP
@@ -274,6 +318,10 @@ Paths:
 
 - Set files with the ceph_log_t type, if you want to treat the data as ceph log data, usually stored under the /var/log directory.
 
+.br
+.TP 5
+Paths:
+/var/log/ceph(/.*)?, /var/log/radosgw(/.*)?
 
 .EX
 .PP


### PR DESCRIPTION
The current SELinux policy does not cover radosgw daemon. This patch
introduces the SELinux support for radosgw daemon (civetweb only).

Signed-off-by: Boris Ranto <branto@redhat.com>