### PR TITLE
Allow object classes to define PGLS filters

### DIFF
--- a/src/cls/hello/cls_hello.cc
+++ b/src/cls/hello/cls_hello.cc
@@ -258,6 +258,35 @@ static int bad_writer(cls_method_context_t hctx, bufferlist *in, bufferlist *out
 }
 
 
+class PGLSHelloFilter : public PGLSFilter {
+  string val;
+public:
+  PGLSHelloFilter(bufferlist::iterator& params) {
+    ::decode(xattr, params);
+    ::decode(val, params);
+  }
+  virtual ~PGLSHelloFilter() {}
+  virtual bool filter(const hobject_t &obj, bufferlist& xattr_data,
+                      bufferlist& outdata)
+  {
+    if (val.size() != xattr_data.length())
+      return false;
+
+    if (memcmp(val.c_str(), xattr_data.c_str(), val.size()))
+      return false;
+
+    return true;
+  }
+};
+
+
+PGLSFilter *hello_filter(bufferlist::iterator *q)
+{
+  assert(q);
+  return new PGLSHelloFilter(*q);
+}
+
+
 /**
  * initialize class
  *
@@ -304,4 +333,7 @@ void __cls_init()
 			  bad_reader, &h_bad_reader);
   cls_register_cxx_method(h_class, "bad_writer", CLS_METHOD_RD,
 			  bad_writer, &h_bad_writer);
+
+  // A PGLS filter
+  cls_register_cxx_filter(h_class, "hello", hello_filter);
 }

--- a/src/cls/hello/cls_hello.cc
+++ b/src/cls/hello/cls_hello.cc
@@ -261,10 +261,15 @@ static int bad_writer(cls_method_context_t hctx, bufferlist *in, bufferlist *out
 class PGLSHelloFilter : public PGLSFilter {
   string val;
 public:
-  PGLSHelloFilter(bufferlist::iterator& params) {
-    ::decode(xattr, params);
-    ::decode(val, params);
+  int init(bufferlist::iterator& params) {
+    try {
+      ::decode(xattr, params);
+      ::decode(val, params);
+    } catch (buffer::error &e) {
+      return -EINVAL;
+    }
   }
+
   virtual ~PGLSHelloFilter() {}
   virtual bool filter(const hobject_t &obj, bufferlist& xattr_data,
                       bufferlist& outdata)
@@ -280,10 +285,9 @@ public:
 };
 
 
-PGLSFilter *hello_filter(bufferlist::iterator *q)
+PGLSFilter *hello_filter()
 {
-  assert(q);
-  return new PGLSHelloFilter(*q);
+  return new PGLSHelloFilter();
 }
 
 

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -82,12 +82,23 @@ int cls_unregister_method(cls_method_handle_t handle)
   return 1;
 }
 
-int cls_register_cxx_filter(cls_handle_t hclass, const std::string &filter_name,
-			    cls_cxx_filter_factory_t fn)
+int cls_register_cxx_filter(cls_handle_t hclass,
+                            const std::string &filter_name,
+                            cls_cxx_filter_factory_t fn,
+                            cls_filter_handle_t *handle)
 {
   ClassHandler::ClassData *cls = (ClassHandler::ClassData *)hclass;
-  cls->register_cxx_filter(filter_name, fn);
-  return 0;
+  cls_filter_handle_t hfilter = (cls_filter_handle_t)cls->register_cxx_filter(filter_name, fn);
+  if (handle) {
+    *handle = hfilter;
+  }
+  return (hfilter != NULL);
+}
+
+void cls_unregister_filter(cls_filter_handle_t handle)
+{
+  ClassHandler::ClassFilter *filter = (ClassHandler::ClassFilter *)handle;
+  filter->unregister();
 }
 
 int cls_call(cls_method_context_t hctx, const char *cls, const char *method,

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -82,6 +82,14 @@ int cls_unregister_method(cls_method_handle_t handle)
   return 1;
 }
 
+int cls_register_cxx_filter(cls_handle_t hclass, const std::string &filter_name,
+			    cls_cxx_filter_factory_t fn)
+{
+  ClassHandler::ClassData *cls = (ClassHandler::ClassData *)hclass;
+  cls->register_cxx_filter(filter_name, fn);
+  return 0;
+}
+
 int cls_call(cls_method_context_t hctx, const char *cls, const char *method,
                                  char *indata, int datalen,
                                  char **outdata, int *outdatalen)

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -107,6 +107,13 @@ public:
                       bufferlist& outdata) = 0;
 
   /**
+   * Arguments passed from the RADOS client.  Implementations must
+   * handle any encoding errors, and return an appropriate error code,
+   * or 0 on valid input.
+   */
+  virtual int init(bufferlist::iterator &params) = 0;
+
+  /**
    * xattr key, or empty string.  If non-empty, this xattr will be fetched
    * and the value passed into ::filter
    */
@@ -120,9 +127,7 @@ public:
 };
 
 // Classes expose a filter constructor that returns a subclass of PGLSFilter
-typedef PGLSFilter* (*cls_cxx_filter_factory_t)(
-    bufferlist::iterator *args);
-
+typedef PGLSFilter* (*cls_cxx_filter_factory_t)();
 
 
 extern int cls_register_cxx_method(cls_handle_t hclass, const char *method, int flags,

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -35,6 +35,7 @@ void __cls_init();
 
 typedef void *cls_handle_t;
 typedef void *cls_method_handle_t;
+typedef void *cls_filter_handle_t;
 typedef void *cls_method_context_t;
 typedef int (*cls_method_call_t)(cls_method_context_t ctx,
 				 char *indata, int datalen,
@@ -71,6 +72,7 @@ extern int cls_unregister(cls_handle_t);
 extern int cls_register_method(cls_handle_t hclass, const char *method, int flags,
                         cls_method_call_t class_call, cls_method_handle_t *handle);
 extern int cls_unregister_method(cls_method_handle_t handle);
+extern void cls_unregister_filter(cls_filter_handle_t handle);
 
 
 
@@ -128,7 +130,8 @@ extern int cls_register_cxx_method(cls_handle_t hclass, const char *method, int 
 
 extern int cls_register_cxx_filter(cls_handle_t hclass,
                                    const std::string &filter_name,
-				   cls_cxx_filter_factory_t fn);
+				   cls_cxx_filter_factory_t fn,
+                                   cls_filter_handle_t *handle=NULL);
 
 extern int cls_cxx_create(cls_method_context_t hctx, bool exclusive);
 extern int cls_cxx_remove(cls_method_context_t hctx);

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -221,11 +221,15 @@ ClassHandler::ClassMethod *ClassHandler::ClassData::register_cxx_method(const ch
   return &method;
 }
 
-void ClassHandler::ClassData::register_cxx_filter(
+ClassHandler::ClassFilter *ClassHandler::ClassData::register_cxx_filter(
     const std::string &filter_name,
     cls_cxx_filter_factory_t fn)
 {
-  filters_map[filter_name] = fn;
+  ClassFilter &filter = filters_map[filter_name];
+  filter.fn = fn;
+  filter.name = filter_name;
+  filter.cls = this;
+  return &filter;
 }
 
 ClassHandler::ClassMethod *ClassHandler::ClassData::_get_method(const char *mname)
@@ -257,6 +261,20 @@ void ClassHandler::ClassData::unregister_method(ClassHandler::ClassMethod *metho
 void ClassHandler::ClassMethod::unregister()
 {
   cls->unregister_method(this);
+}
+
+void ClassHandler::ClassData::unregister_filter(ClassHandler::ClassFilter *filter)
+{
+  /* no need for locking, called under the class_init mutex */
+   map<string, ClassFilter>::iterator iter = filters_map.find(filter->name);
+   if (iter == filters_map.end())
+     return;
+   filters_map.erase(iter);
+}
+
+void ClassHandler::ClassFilter::unregister()
+{
+  cls->unregister_filter(this);
 }
 
 int ClassHandler::ClassMethod::exec(cls_method_context_t ctx, bufferlist& indata, bufferlist& outdata)

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -221,6 +221,13 @@ ClassHandler::ClassMethod *ClassHandler::ClassData::register_cxx_method(const ch
   return &method;
 }
 
+void ClassHandler::ClassData::register_cxx_filter(
+    const std::string &filter_name,
+    cls_cxx_filter_factory_t fn)
+{
+  filters_map[filter_name] = fn;
+}
+
 ClassHandler::ClassMethod *ClassHandler::ClassData::_get_method(const char *mname)
 {
   map<string, ClassHandler::ClassMethod>::iterator iter = methods_map.find(mname);

--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -49,6 +49,7 @@ public:
     void *handle;
 
     map<string, ClassMethod> methods_map;
+    map<string, cls_cxx_filter_factory_t> filters_map;
 
     set<ClassData *> dependencies;         /* our dependencies */
     set<ClassData *> missing_dependencies; /* only missing dependencies */
@@ -64,11 +65,21 @@ public:
     ClassMethod *register_cxx_method(const char *mname, int flags, cls_method_cxx_call_t func);
     void unregister_method(ClassMethod *method);
 
+    void register_cxx_filter(
+        const std::string &filter_name,
+        cls_cxx_filter_factory_t fn);
+
     ClassMethod *get_method(const char *mname) {
       Mutex::Locker l(handler->mutex);
       return _get_method(mname);
     }
     int get_method_flags(const char *mname);
+
+    cls_cxx_filter_factory_t get_filter(const std::string &filter_name)
+    {
+      Mutex::Locker l(handler->mutex);
+      return filters_map[filter_name];
+    }
   };
 
 private:

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -623,13 +623,13 @@ int ReplicatedPG::get_pgls_filter(bufferlist::iterator& iter, PGLSFilter **pfilt
       assert(cls);
     }
 
-    cls_cxx_filter_factory_t fn = cls->get_filter(filter_name);
-    if (fn == NULL) {
+    ClassHandler::ClassFilter *class_filter = cls->get_filter(filter_name);
+    if (class_filter == NULL) {
       derr << "Error finding filter '" << filter_name << "' in class "
            << class_name << dendl;
       return -EINVAL;
     }
-    filter = fn(&iter);
+    filter = class_filter->fn(&iter);
     assert(filter);
   }
 

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -46,6 +46,7 @@ class CopyFromCallback;
 class PromoteCallback;
 
 class ReplicatedPG;
+class PGLSFilter;
 void intrusive_ptr_add_ref(ReplicatedPG *pg);
 void intrusive_ptr_release(ReplicatedPG *pg);
 uint64_t get_with_id(ReplicatedPG *pg);
@@ -56,53 +57,6 @@ void put_with_id(ReplicatedPG *pg, uint64_t id);
 #else
   typedef boost::intrusive_ptr<ReplicatedPG> ReplicatedPGRef;
 #endif
-
-class PGLSFilter {
-protected:
-  string xattr;
-public:
-  PGLSFilter();
-  virtual ~PGLSFilter();
-  virtual bool filter(const hobject_t &obj, bufferlist& xattr_data,
-                      bufferlist& outdata) = 0;
-
-  /**
-   * xattr key, or empty string.  If non-empty, this xattr will be fetched
-   * and the value passed into ::filter
-   */
-   virtual string& get_xattr() { return xattr; }
-
-  /**
-   * If true, objects without the named xattr (if xattr name is not empty)
-   * will be rejected without calling ::filter
-   */
-  virtual bool reject_empty_xattr() { return true; }
-};
-
-class PGLSPlainFilter : public PGLSFilter {
-  string val;
-public:
-  PGLSPlainFilter(bufferlist::iterator& params) {
-    ::decode(xattr, params);
-    ::decode(val, params);
-  }
-  virtual ~PGLSPlainFilter() {}
-  virtual bool filter(const hobject_t &obj, bufferlist& xattr_data,
-                      bufferlist& outdata);
-};
-
-class PGLSParentFilter : public PGLSFilter {
-  inodeno_t parent_ino;
-public:
-  PGLSParentFilter(bufferlist::iterator& params) {
-    xattr = "_parent";
-    ::decode(parent_ino, params);
-    generic_dout(0) << "parent_ino=" << parent_ino << dendl;
-  }
-  virtual ~PGLSParentFilter() {}
-  virtual bool filter(const hobject_t &obj, bufferlist& xattr_data,
-                      bufferlist& outdata);
-};
 
 class ReplicatedPG : public PG, public PGBackend::Listener {
   friend class OSD;


### PR DESCRIPTION
These are then usable by clients as `<class name>.<filter name>`

I have left the existing filters inline in the OSD code rather than moving them into object classes, so that they could keep their existing dot-less names.

The interface is only available to C++ object classes