### PR TITLE
deleting the assert in the fuction md_config_t::set_val_or_die.

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -663,8 +663,7 @@ int md_config_t::injectargs(const std::string& s, std::ostream *oss)
 
 void md_config_t::set_val_or_die(const char *key, const char *val)
 {
-  int ret = set_val(key, val);
-  assert(ret == 0);
+  (void)set_val(key, val);
 }
 
 int md_config_t::set_val(const char *key, const char *val, bool meta, bool safe)


### PR DESCRIPTION
when i input the command rbd create foo --size 100 --image-format -2 
the fuction call will be set_val_or_die->set_val->set_val_impl->set_val_raw->strict_si_cast<int>->strict_sistrtoll
in the fuction strict_sistrtoll will have a error below because the --image-format is -2
 if (r_ll < 0) {
    *err = "strict_sistrtoll: value should not be negative";
    return 0;
  }
then the fuction set_val_raw will return -EINVAL
 case OPT_INT: {
      std::string err;
      int f = strict_si_cast<int>(val, &err);
      if (!err.empty())
	return -EINVAL;
      *(int*)opt->conf_ptr(this) = f;
      return 0;
    }
finally the assert(ret == 0) in the fuction set_val_or_die will fail
test fix:
before:
root@ubuntu1:/# rbd create foo --size 100 --image-format -2 
common/config.cc: In function 'void md_config_t::set_val_or_die(const char*, con
st char*)' thread 7fcf62849840 time 2015-08-11 08:33:57.082063                  
common/config.cc: 667: FAILED assert(ret == 0)                                  
 ceph version 9.0.2-1209-g3a12f7d (3a12f7d35491e53011b40568ef6d603bc44db6b5)    
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x8b) 
[0x7fcf6297daeb]                                                                
 2: (()+0x13a50c) [0x7fcf629a550c]                                              
 3: (main()+0x465) [0x7fcf62939ea5]                                             
 4: (__libc_start_main()+0xf5) [0x7fcf5b612ec5]                                 
 5: (()+0xd8dd7) [0x7fcf62943dd7]                                               
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is needed to int
erpret this.                                                                    
2015-08-11 08:33:57.082438 7fcf62849840 -1 common/config.cc: In function 'void m
d_config_t::set_val_or_die(const char*, const char*)' thread 7fcf62849840 time 2
015-08-11 08:33:57.082063                                                       
common/config.cc: 667: FAILED assert(ret == 0)  
after:
root@ubuntu1:/# rbd create foo --size 100 --image-format -2                     
rbd: image format must be 1 or 2      

I feel that deleting the assert is inappropriate,but i can not think of a perfect way. Because the fuction strict_sistrtoll is called by many other fuctions. I want to discuss with you to look for a perfect way which will make the code more robust.
Signed-off-by: s09816 shi.lu@h3c.com