### PR TITLE
tests: be more generous with mon tests timeouts

### DIFF
--- a/src/test/mon/misc.sh
+++ b/src/test/mon/misc.sh
@@ -99,7 +99,7 @@ function TEST_mon_add_to_single_mon() {
     setup $dir || return 1
     run_mon $dir a --public-addr $MONA || return 1
     # wait for the quorum
-    timeout 3 ceph -s > /dev/null || return 1
+    timeout 120 ceph -s > /dev/null || return 1
     # strictly speaking it's not a feature, but an expected hahaviour.
     timeout 3 ceph mon add b $MONB || [ $? = 124 ] || return 1
     run_mon $dir b --public-addr $MONB || return 1
@@ -111,12 +111,12 @@ function TEST_mon_add_to_single_mon() {
     # from mon.b
     run_mon $dir b --public-addr $MONB || return 1
     # wait for the quorum
-    timeout 9 ceph -s > /dev/null || return 1
+    timeout 120 ceph -s > /dev/null || return 1
     local num_mons
     num_mons=$(ceph mon dump --format=xml 2>/dev/null | $XMLSTARLET sel -t -v "count(//mons/mon)") || return 1
     [ $num_mons == 2 ] || return 1
-    # no reason to take more than 2 secs to get this submitted
-    timeout 1 ceph mon add b $MONB || return 1
+    # no reason to take more than 120 secs to get this submitted
+    timeout 120 ceph mon add b $MONB || return 1
     teardown $dir || return 1
 }
 

--- a/src/test/mon/misc.sh
+++ b/src/test/mon/misc.sh
@@ -100,8 +100,6 @@ function TEST_mon_add_to_single_mon() {
     run_mon $dir a --public-addr $MONA || return 1
     # wait for the quorum
     timeout 120 ceph -s > /dev/null || return 1
-    # strictly speaking it's not a feature, but an expected hahaviour.
-    timeout 3 ceph mon add b $MONB || [ $? = 124 ] || return 1
     run_mon $dir b --public-addr $MONB || return 1
     teardown $dir || return 1
 


### PR DESCRIPTION
Change the timeouts of the TEST_mon_add_to_single_mon tests to be 120
seconds. They have value to guard against blocking forever. The exact
timing does not matter as long as the operation completes.

When a timeout is too short, it will create false negatives when running
on slow machines. It could be argued that being too generous with
timeout in general may hide problems. But not in this specific case.

Signed-off-by: Loic Dachary <ldachary@redhat.com>