### PR TITLE
rgw: expose the number of unhealthy workers through admin socket

### DIFF
--- a/src/common/HeartbeatMap.cc
+++ b/src/common/HeartbeatMap.cc
@@ -32,7 +32,9 @@ namespace ceph {
 HeartbeatMap::HeartbeatMap(CephContext *cct)
   : m_cct(cct),
     m_rwlock("HeartbeatMap::m_rwlock"),
-    m_inject_unhealthy_until(0)
+    m_inject_unhealthy_until(0),
+    m_unhealthy_workers(0),
+    m_total_workers(0)
 {
 }
 
@@ -109,6 +111,8 @@ void HeartbeatMap::clear_timeout(heartbeat_handle_d *h)
 
 bool HeartbeatMap::is_healthy()
 {
+  int unhealthy = 0;
+  int total = 0;
   m_rwlock.get_read();
   time_t now = time(NULL);
   if (m_cct->_conf->heartbeat_inject_failure) {
@@ -129,11 +133,28 @@ bool HeartbeatMap::is_healthy()
     heartbeat_handle_d *h = *p;
     if (!_check(h, "is_healthy", now)) {
       healthy = false;
+      unhealthy++;
     }
+    total++;
   }
   m_rwlock.put_read();
-  ldout(m_cct, 20) << "is_healthy = " << (healthy ? "healthy" : "NOT HEALTHY") << dendl;
+
+  m_unhealthy_workers.set(unhealthy);
+  m_total_workers.set(total);
+
+  ldout(m_cct, 20) << "is_healthy = " << (healthy ? "healthy" : "NOT HEALTHY")
+    << ", total workers: " << total << ", number of unhealthy: " << unhealthy << dendl;
   return healthy;
+}
+
+int HeartbeatMap::get_unhealthy_workers() const
+{
+  return m_unhealthy_workers.read();
+}
+
+int HeartbeatMap::get_total_workers() const
+{
+  return m_total_workers.read();
 }
 
 void HeartbeatMap::check_touch_file()

--- a/src/common/HeartbeatMap.h
+++ b/src/common/HeartbeatMap.h
@@ -68,6 +68,12 @@ class HeartbeatMap {
   // touch cct->_conf->heartbeat_file if is_healthy()
   void check_touch_file();
 
+  // get the number of unhealthy workers
+  int get_unhealthy_workers() const;
+
+  // get the number of total workers
+  int get_total_workers() const;
+
   HeartbeatMap(CephContext *cct);
   ~HeartbeatMap();
 
@@ -76,6 +82,8 @@ class HeartbeatMap {
   RWLock m_rwlock;
   time_t m_inject_unhealthy_until;
   std::list<heartbeat_handle_d*> m_workers;
+  atomic_t m_unhealthy_workers;
+  atomic_t m_total_workers;
 
   bool _check(const heartbeat_handle_d *h, const char *who, time_t now);
 };

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -106,6 +106,9 @@ public:
         _reopen_logs = false;
       }
       _cct->_heartbeat_map->check_touch_file();
+
+      // refresh the perf coutners
+      _cct->refresh_perf_values();
     }
     return NULL;
   }
@@ -407,11 +410,13 @@ CephContext::CephContext(uint32_t module_type_)
     _heartbeat_map(NULL),
     _crypto_none(NULL),
     _crypto_aes(NULL),
-    _lockdep_obs(NULL)
+    _lockdep_obs(NULL),
+    _cct_perf(NULL)
 {
   ceph_spin_init(&_service_thread_lock);
   ceph_spin_init(&_associated_objs_lock);
   ceph_spin_init(&_feature_lock);
+  ceph_spin_init(&_cct_perf_lock);
 
   _log = new ceph::log::Log(&_conf->subsys);
   _log->start();
@@ -426,6 +431,7 @@ CephContext::CephContext(uint32_t module_type_)
   _conf->add_observer(_lockdep_obs);
 
   _perf_counters_collection = new PerfCountersCollection(this);
+ 
   _admin_socket = new AdminSocket(this);
   _heartbeat_map = new HeartbeatMap(this);
 
@@ -458,6 +464,12 @@ CephContext::~CephContext()
   for (map<string, AssociatedSingletonObject*>::iterator it = _associated_objs.begin();
        it != _associated_objs.end(); ++it)
     delete it->second;
+
+  if (_cct_perf) {
+    _perf_counters_collection->remove(_cct_perf);
+    delete _cct_perf;
+    _cct_perf = NULL;
+  }
 
   _admin_socket->unregister_command("perfcounters_dump");
   _admin_socket->unregister_command("perf dump");
@@ -504,6 +516,7 @@ CephContext::~CephContext()
   ceph_spin_destroy(&_service_thread_lock);
   ceph_spin_destroy(&_associated_objs_lock);
   ceph_spin_destroy(&_feature_lock);
+  ceph_spin_destroy(&_cct_perf_lock);
 
   delete _crypto_none;
   delete _crypto_aes;
@@ -567,6 +580,41 @@ uint32_t CephContext::get_module_type() const
 PerfCountersCollection *CephContext::get_perfcounters_collection()
 {
   return _perf_counters_collection;
+}
+
+void CephContext::enable_perf_counter()
+{
+  PerfCountersBuilder plb(this, "cct", l_cct_first, l_cct_last);
+  plb.add_u64_counter(l_cct_total_workers, "total_workers", "Total workers");
+  plb.add_u64_counter(l_cct_unhealthy_workers, "unhealthy_workers", "Unhealthy workers");
+  PerfCounters *perf_tmp = plb.create_perf_counters();
+
+  ceph_spin_lock(&_cct_perf_lock);
+  assert(_cct_perf == NULL);
+  _cct_perf = perf_tmp;
+  ceph_spin_unlock(&_cct_perf_lock);
+
+  _perf_counters_collection->add(_cct_perf);
+}
+
+void CephContext::disable_perf_counter()
+{
+  _perf_counters_collection->remove(_cct_perf);
+
+  ceph_spin_lock(&_cct_perf_lock);
+  delete _cct_perf;
+  _cct_perf = NULL;
+  ceph_spin_unlock(&_cct_perf_lock);
+}
+
+void CephContext::refresh_perf_values()
+{
+  ceph_spin_lock(&_cct_perf_lock);
+  if (_cct_perf) {
+    _cct_perf->set(l_cct_total_workers, _heartbeat_map->get_total_workers());
+    _cct_perf->set(l_cct_unhealthy_workers, _heartbeat_map->get_unhealthy_workers());
+  }
+  ceph_spin_unlock(&_cct_perf_lock);
 }
 
 AdminSocket *CephContext::get_admin_socket()

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -28,6 +28,7 @@
 class AdminSocket;
 class CephContextServiceThread;
 class PerfCountersCollection;
+class PerfCounters;
 class md_config_obs_t;
 struct md_config_t;
 class CephContextHook;
@@ -90,6 +91,22 @@ public:
   ceph::HeartbeatMap *get_heartbeat_map() {
     return _heartbeat_map;
   }
+
+  /**
+   * Enable the performance counter, currently we only have counter for the
+   * number of total/unhealthy workers.
+   */
+  void enable_perf_counter();
+
+  /**
+   * Disable the performance counter.
+   */
+  void disable_perf_counter();
+
+  /**
+   * Refresh perf counter values.
+   */
+  void refresh_perf_values();
 
   /**
    * Get the admin socket associated with this CephContext.
@@ -172,6 +189,15 @@ private:
   std::set<std::string> _experimental_features;
 
   md_config_obs_t *_lockdep_obs;
+
+  enum {
+    l_cct_first,
+    l_cct_total_workers,
+    l_cct_unhealthy_workers,
+    l_cct_last
+  };
+  PerfCounters *_cct_perf;
+  ceph_spinlock_t _cct_perf_lock;
 
   friend class CephContextObs;
 };

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -1056,6 +1056,9 @@ int main(int argc, const char **argv)
   init_timer.add_event_after(g_conf->rgw_init_timeout, new C_InitTimeout);
   mutex.Unlock();
 
+  // Enable the perf counter before starting the service thread
+  g_ceph_context->enable_perf_counter();
+
   common_init_finish(g_ceph_context);
 
   rgw_tools_init(g_ceph_context);

--- a/src/test/perf_counters.cc
+++ b/src/test/perf_counters.cc
@@ -187,3 +187,16 @@ TEST(PerfCounters, MultiplePerfCounters) {
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ("{}", msg);
 }
+
+TEST(PerfCounters, CephContextPerfCounters) {
+  // Enable the perf counter
+  g_ceph_context->enable_perf_counter();
+  AdminSocketClient client(get_rand_socket_path());
+  std::string msg;
+
+  ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
+  ASSERT_EQ(sd("{\"cct\":{\"total_workers\":0,\"unhealthy_workers\":0}}"), msg);
+
+  // Restore to avoid impact to other test cases
+  g_ceph_context->disable_perf_counter();
+}


### PR DESCRIPTION
rgw daemon disable the suicide timeout (for a good reason), a problem we came across several times, was that all rgw workers were stuck (e.g. because of stuck peering PG), and thus all following request would result in 500 as there is no thread taking care of the requests.

This PR expose a way to query the number of unhealthy threads in the daemon, and with that information, we can restart rgw daemon when the number of unhealthy workers are close to the total number of workers, as a work-around to improve system availability.

Fixes: 12666
Signed-off-by: Guang Yang <yguang@yahoo-inc.com>