### PR TITLE
rbd:improve the error handle of rbd,check the return value.

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -3097,7 +3097,10 @@ int main(int argc, const char **argv)
 	return EXIT_FAILURE;
       }
       format_specified = true;
-      g_conf->set_val_or_die("rbd_default_format", val.c_str());
+      if (0 != g_conf->set_val("rbd_default_format", val.c_str())) {
+        cerr << "rbd: image format must be 1 or 2" << std::endl;
+        return EXIT_FAILURE;
+      }
     } else if (ceph_argparse_witharg(args, i, &val, "-p", "--pool", (char*)NULL)) {
       poolname = strdup(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--dest-pool", (char*)NULL)) {


### PR DESCRIPTION
when i input the command rbd create foo --size 100 --image-format -2
the assert(ret == 0) in the fuction set_val_or_die will fail
test fix:
before
common/config.cc: In function 'void md_config_t::set_val_or_die(const char, con
st char)' thread 7fcf62849840 time 2015-08-11 08:33:57.082063
common/config.cc: 667: FAILED assert(ret == 0)
ceph version 9.0.2-1209-g3a12f7d (3a12f7d)
after
root@ubuntu1:/# rbd create foo --size 100 --image-format -2                     
rbd: image format must be 1 or 2            
   
Signed-off-by: s09816 shi.lu@h3c.com             

