### PR TITLE
rbd:Check the dest image name, if it is empty string, return error and give a message

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -3474,7 +3474,7 @@ if (!set_conf_param(v, p1, p2, p3)) { \
   }
 
   if ((opt_cmd == OPT_COPY || opt_cmd == OPT_CLONE || opt_cmd == OPT_RENAME) &&
-      !destname ) {
+      ((!destname) || (destname[0] == '\0')) ) {
     cerr << "rbd: destination image name was not specified" << std::endl;
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
If the command is "rbd mv foo @" , it will refuse to execute and give a message

test fix:
first  time: rbd mv foo @
second  time : rbd mv foo @

before：
first time,it will give a message :
"rbd: rename error: (22) Invalid argument2015-08-12 23:40:36.749020 7f02e98f4840 
-1 librbd: error updating directory: (22) Invalid argument" 

second time, it will show that:
"rbd: rename error: (17) File exists                                             
2015-08-12 23:41:27.340171 7f5089dfe840 -1 librbd: rbd image  already exists"

after：
No matter how many times user will input, command would not be executed, and give a message "rbd: destination image name was not specified"

Signed-off-by: solesoul1127 <chen.yehua@h3c.com>