### PR TITLE
Adding statfs api to KeyValueDB

### DIFF
--- a/src/os/KeyValueDB.h
+++ b/src/os/KeyValueDB.h
@@ -176,6 +176,9 @@ public:
   }
 
   virtual uint64_t get_estimated_size(map<string,uint64_t> &extra) = 0;
+  virtual int get_statfs(struct statfs *buf) {
+    return -EOPNOTSUPP;
+  }
 
   virtual ~KeyValueDB() {}
 

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -592,9 +592,12 @@ KeyValueStore::~KeyValueStore()
 
 int KeyValueStore::statfs(struct statfs *buf)
 {
-  if (::statfs(basedir.c_str(), buf) < 0) {
-    int r = -errno;
-    return r;
+  int r = backend->db->get_statfs(buf);
+  if (r < 0) {
+    if (::statfs(basedir.c_str(), buf) < 0) {
+      int r = -errno;
+      return r;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
If any backend supports and implements statfs will extract the 
stats from backend to show correct utilization in the status.

Signed-off-by: Varada Kari <varada.kari@sandisk.com>