### PR TITLE
Change key format to preserve order of keys in backend db.

### DIFF
--- a/src/os/KeyValueStore.h
+++ b/src/os/KeyValueStore.h
@@ -220,7 +220,7 @@ class KeyValueStore : public ObjectStore,
 
   string strip_object_key(uint64_t no) {
     char n[100];
-    snprintf(n, 100, "%lld", (long long)no);
+    snprintf(n, 100, "%08lld", (long long)no);
     return string(n);
   }
 


### PR DESCRIPTION
Changing the key format to add additional digits to preserve the order
for the read aheads and lookups to be faster. Number of digits are
selected based on the default object size and default strip size supported
by osd.

Signed-off-by: Varada Kari <varada.kari@sandisk.com>