### PR TITLE
mds: initialize 'divergent' to false when comparing inode_t

### DIFF
--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -443,6 +443,7 @@ void inode_t::generate_test_instances(list<inode_t*>& ls)
 int inode_t::compare(const inode_t &other, bool *divergent) const
 {
   assert(ino == other.ino);
+  *divergent = false;
   if (version == other.version) {
     if (rdev != other.rdev ||
         ctime != other.ctime ||


### PR DESCRIPTION
Fix the bot build failure in http://jenkins.ceph.dachary.org/job/ceph/LABELS=centos-7&&x86_64/7024/

The failure is something like below:

```
FAIL: unittest_mds_types
========================

Running main() from gmock_main.cc
[==========] Running 6 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 3 tests from inode_t
[ RUN      ] inode_t.compare_equal
test/fs/mds_types.cc:29: Failure
Value of: divergent
  Actual: true
Expected: false
test/fs/mds_types.cc:32: Failure
Value of: divergent
  Actual: true
Expected: false
test/fs/mds_types.cc:46: Failure
Value of: divergent
  Actual: true
Expected: false
test/fs/mds_types.cc:49: Failure
Value of: divergent
  Actual: true
Expected: false
[  FAILED  ] inode_t.compare_equal (0 ms)
```