### PR TITLE
rgw: add key parameter conflict check for radosgw-admin command line.

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1385,6 +1385,16 @@ int main(int argc, char **argv)
           break;
       }
     }
+
+    /* check key parameter conflict */
+    if ((!access_key.empty()) && gen_access_key) {
+        cerr << "ERROR: key parameter conflict, --access-key & --gen-access-key" << std::endl;
+        return -EINVAL;
+    }
+    if ((!secret_key.empty()) && gen_secret_key) {
+        cerr << "ERROR: key parameter conflict, --secret & --gen-secret" << std::endl;
+        return -EINVAL;
+    }
   }
 
   // default to pretty json


### PR DESCRIPTION
1.--access-key & --gen-access-key
radosgw-admin key create --uid=aaa --access-key='111' --gen-access-key --gen-secret
--access-key effective

2.--secret & --gen-secret
radosgw-admin key create --uid=aaa --access-key='222' --secret='222' --gen-secret
--gen-secret effective

test fix:
    before: conflict parameters can be configured.
    after changes, do the same procedure, can check for conflicts.

Signed-off-by: guce <guce@h3c.com>