### PR TITLE
ceph.spec.in: test %preun argument is zero for removal-only operations

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -683,12 +683,14 @@ mkdir -p %{_localstatedir}/run/ceph/
   # /etc/systemd/system.  May as well stop them too for completeness
   # (although strictly service_del_preun would do that anyway by dint
   # of stopping ceph.target)
-  SERVICE_LIST=$(systemctl | grep -E '^ceph-mon@|^ceph-create-keys@|^ceph-osd@|^ceph-mds@|^ceph-disk-'  | cut -d' ' -f1)
-  if [ -n "$SERVICE_LIST" ]; then
-    for SERVICE in $SERVICE_LIST; do
-      /usr/bin/systemctl --no-reload disable $SERVICE > /dev/null 2>&1 || :
-      /usr/bin/systemctl stop $SERVICE > /dev/null 2>&1 || :
-    done
+  if [ $1 = 0 ] ; then
+    SERVICE_LIST=$(systemctl | grep -E '^ceph-mon@|^ceph-create-keys@|^ceph-osd@|^ceph-mds@|^ceph-disk-'  | cut -d' ' -f1)
+    if [ -n "$SERVICE_LIST" ]; then
+      for SERVICE in $SERVICE_LIST; do
+        /usr/bin/systemctl --no-reload disable $SERVICE > /dev/null 2>&1 || :
+        /usr/bin/systemctl stop $SERVICE > /dev/null 2>&1 || :
+      done
+    fi
   fi
 %else
   %if 0%{?opensuse} || 0%{?suse_version}


### PR DESCRIPTION
The %preun section now contains logic for disabling and stopping all the
Ceph systemd units when the ceph package is removed. However, there is no
conditional around it, so the units are disabled and stopped on RPM upgrade
as well as removal.

http://tracker.ceph.com/issues/12685 Fixes: #12685

Signed-off-by: Nathan Cutler <ncutler@suse.com>
Signed-off-by: Tim Serong <tserong@suse.com>