### PR TITLE
rgw: we should not overide Swift sent content type

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -518,7 +518,7 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
     dump_access_control(s, op);
   }
 
-  if (s->prot_flags & RGW_REST_SWIFT) {
+  if (s->prot_flags & RGW_REST_SWIFT && !content_type) {
     force_content_type = true;
   }
 


### PR DESCRIPTION
Fixes: #12363
backport: hammer

Signed-off-by: Orit Wasserman <owasserm@redhat.com>