### PR TITLE
rgw: don't preserve acls when copying object

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4017,6 +4017,8 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
     return ret;
   }
 
+  src_attrs[RGW_ATTR_ACL] = attrs[RGW_ATTR_ACL];
+
   set_copy_attrs(src_attrs, attrs, attrs_mod);
   attrs.erase(RGW_ATTR_ID_TAG);
 


### PR DESCRIPTION
Fixes: #12370

When copying an object we need to use the acls we calculated earlier,
and not the source acls.
This was broken at e41d97c8e38bb60d7e09e9801c0179efe7af1734.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>