### PR TITLE
osd:fill_in_one_address's not retry on pick_address.cc

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -157,6 +157,8 @@ OPTION(ms_bind_port_min, OPT_INT, 6800)
 OPTION(ms_bind_port_max, OPT_INT, 7300)
 OPTION(ms_bind_retry_count, OPT_INT, 3) // If binding fails, how many times do we retry to bind
 OPTION(ms_bind_retry_delay, OPT_INT, 5) // Delay between attemps to bind
+OPTION(ms_pick_addr_retry_count, OPT_INT, 13) // If binding fails, how many times do we retry to bind
+OPTION(ms_pick_addr_delay, OPT_INT, 5) // Delay between attemps to bind
 OPTION(ms_rwthread_stack_bytes, OPT_U64, 1024 << 10)
 OPTION(ms_tcp_read_timeout, OPT_U64, 900)
 OPTION(ms_pq_max_tokens_per_priority, OPT_U64, 16777216)

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -70,25 +70,59 @@ static void fill_in_one_address(CephContext *cct,
 				const string networks,
 				const char *conf_var)
 {
-  const struct sockaddr *found = find_ip_in_subnet_list(cct, ifa, networks);
-  if (!found) {
-    lderr(cct) << "unable to find any IP address in networks: " << networks << dendl;
+  struct ifaddrs *ifa_again;
+  const struct sockaddr *found_for = NULL;
+  char buf[INET6_ADDRSTRLEN];
+  int err_for = 0;
+  int r_for = 0;
+  for (int i = 0; i < cct->_conf->ms_pick_addr_retry_count; i++) {
+    if (i > 0) {
+      lderr(cct) << "unable to find any IP address in networks. Trying again in " << cct->_conf->ms_pick_addr_delay << " seconds " << dendl;
+      sleep(cct->_conf->ms_pick_addr_delay);
+	  // To get the local IP information again
+	  int r = getifaddrs(&ifa_again);
+	  r_for = r;
+	  if (r < 0) {
+        string err = cpp_strerror(errno);
+        lderr(cct) << "unable to fetch interfaces and addresses: " << err << dendl;
+        continue;
+      }
+	  ifa = ifa_again;
+    }
+    const struct sockaddr *found = find_ip_in_subnet_list(cct, ifa, networks);
+    found_for = found;
+    if (!found) {
+      lderr(cct) << "unable to find any IP address in networks: " << networks << dendl;
+	  continue;
+    }
+
+    int err;
+    err = getnameinfo(found,
+		      (found->sa_family == AF_INET)
+		      ? sizeof(struct sockaddr_in)
+		      : sizeof(struct sockaddr_in6),
+
+		      buf, sizeof(buf),
+		      NULL, 0,
+		      NI_NUMERICHOST);
+    err_for = err;
+    if (err != 0) {
+      lderr(cct) << "unable to convert chosen address to string: " << gai_strerror(err) << dendl;
+      continue;
+    }
+    break;
+  }
+  if (r_for < 0) {
+    string err = cpp_strerror(errno);
+    lderr(cct) << "unable to fetch interfaces and addresses: " << err << "after " << cct->_conf->ms_pick_addr_retry_count << " attempts" << dendl;
     exit(1);
   }
-
-  char buf[INET6_ADDRSTRLEN];
-  int err;
-
-  err = getnameinfo(found,
-		    (found->sa_family == AF_INET)
-		    ? sizeof(struct sockaddr_in)
-		    : sizeof(struct sockaddr_in6),
-
-		    buf, sizeof(buf),
-		    NULL, 0,
-		    NI_NUMERICHOST);
-  if (err != 0) {
-    lderr(cct) << "unable to convert chosen address to string: " << gai_strerror(err) << dendl;
+  if (!found_for) {
+    lderr(cct) << "unable to find any IP address in networks: " << networks << "after " << cct->_conf->ms_pick_addr_retry_count << " attempts" << dendl;
+    exit(1);
+  }
+  if (err_for != 0) {
+    lderr(cct) << "unable to convert chosen address to string: " << gai_strerror(err_for) << "after " << cct->_conf->ms_pick_addr_retry_count << " attempts" << dendl;
     exit(1);
   }
 

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -79,15 +79,15 @@ static void fill_in_one_address(CephContext *cct,
     if (i > 0) {
       lderr(cct) << "unable to find any IP address in networks. Trying again in " << cct->_conf->ms_pick_addr_delay << " seconds " << dendl;
       sleep(cct->_conf->ms_pick_addr_delay);
-	  // To get the local IP information again
-	  int r = getifaddrs(&ifa_again);
-	  r_for = r;
-	  if (r < 0) {
+      // To get the local IP information again
+      int r = getifaddrs(&ifa_again);
+      r_for = r;
+      if (r < 0) {
         string err = cpp_strerror(errno);
         lderr(cct) << "unable to fetch interfaces and addresses: " << err << dendl;
         continue;
       }
-	  ifa = ifa_again;
+      ifa = ifa_again;
     }
     const struct sockaddr *found = find_ip_in_subnet_list(cct, ifa, networks);
     found_for = found;


### PR DESCRIPTION
If the server node starts, cluster network configuration and OSD process simultaneously, so some of the OSD boot failure.
Add：Retry in function “fill_in_one_address” find cluster network

Fixes: #12696
Signed-off-by: ren.huanwen@zte.com.cn
