### PR TITLE
qa/fsstress.sh: fix 'cp not writing through dangling symlink'

### DIFF
--- a/qa/workunits/suites/fsstress.sh
+++ b/qa/workunits/suites/fsstress.sh
@@ -11,7 +11,7 @@ then
     cd /tmp/fsstress/ltp-full-20091231/testcases/kernel/fs/fsstress
     make
     sudo mkdir -p /usr/lib/ltp/testcases/bin
-    sudo cp -avf /tmp/fsstress/ltp-full-20091231/testcases/kernel/fs/fsstress/fsstress /usr/lib/ltp/testcases/bin/fsstress
+    sudo cp -av --remove-destination /tmp/fsstress/ltp-full-20091231/testcases/kernel/fs/fsstress/fsstress /usr/lib/ltp/testcases/bin/fsstress
     sudo chmod 755 /usr/lib/ltp/testcases/bin/fsstress
     rm -Rf /tmp/fsstress
     cd $path


### PR DESCRIPTION
On some test machines, /usr/lib/ltp/testcases/bin/fsstress is
dangling symlink. 'cp -f' is impotent in this case.

Fixes: #12710
Signed-off-by: Yan, Zheng <zyan@redhat.com>