### PR TITLE
Update ceph-selinux rpm spec

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -426,7 +426,7 @@ Summary:	SELinux support for Ceph MON, OSD and MDS
 Group:		System Environment/Base
 Requires:	%{name}
 Requires:	policycoreutils, libselinux-utils
-Requires(post):	selinux-policy >= %{_selinux_policy_version}, policycoreutils
+Requires(post): selinux-policy-base >= %{_selinux_policy_version}, policycoreutils
 Requires(postun): policycoreutils
 %description selinux
 This package contains SELinux support for Ceph MON, OSD and MDS. The package

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1143,9 +1143,9 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
     /sbin/service ceph stop >/dev/null 2>&1 || :
 %endif
 
-semodule -n -i %{_datadir}/selinux/packages/ceph.pp
-if /usr/sbin/selinuxenabled ; then
-    /usr/sbin/load_policy
+%{_sbindir}/semodule -n -i %{_datadir}/selinux/packages/ceph.pp
+if %{_sbindir}/selinuxenabled ; then
+    %{_sbindir}/load_policy
     %relabel_files
 fi
 
@@ -1163,9 +1163,9 @@ if [ $1 -eq 0 ]; then
     %else
 	/sbin/service ceph stop >/dev/null 2>&1 || :
     %endif
-    semodule -n -r ceph
-    if /usr/sbin/selinuxenabled ; then
-       /usr/sbin/load_policy
+    %{_sbindir}/semodule -n -r ceph
+    if %{_sbindir}/selinuxenabled ; then
+       %{_sbindir}/load_policy
        %relabel_files
     fi;
     %if 0%{?_with_systemd}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1137,24 +1137,42 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_mandir}/man8/ceph_selinux.8.*
 
 %post selinux
-/sbin/service ceph stop >/dev/null 2>&1
+%if 0%{?_with_systemd}
+    /usr/bin/systemctl stop ceph.target > /dev/null 2>&1 || :
+%else
+    /sbin/service ceph stop >/dev/null 2>&1 || :
+%endif
+
 semodule -n -i %{_datadir}/selinux/packages/ceph.pp
 if /usr/sbin/selinuxenabled ; then
     /usr/sbin/load_policy
     %relabel_files
 fi
-/sbin/service ceph start >/dev/null 2>&1
+
+%if 0%{?_with_systemd}
+    /usr/bin/systemctl start ceph.target > /dev/null 2>&1 || :
+%else
+    /sbin/service ceph start >/dev/null 2>&1 || :
+%endif
 exit 0
 
 %postun selinux
 if [ $1 -eq 0 ]; then
-    /sbin/service ceph stop >/dev/null 2>&1
+    %if 0%{?_with_systemd}
+	/usr/bin/systemctl stop ceph.target > /dev/null 2>&1 || :
+    %else
+	/sbin/service ceph stop >/dev/null 2>&1 || :
+    %endif
     semodule -n -r ceph
     if /usr/sbin/selinuxenabled ; then
        /usr/sbin/load_policy
        %relabel_files
     fi;
-    /sbin/service ceph start >/dev/null 2>&1
+    %if 0%{?_with_systemd}
+	/usr/bin/systemctl start ceph.target > /dev/null 2>&1 || :
+    %else
+	/sbin/service ceph start >/dev/null 2>&1 || :
+    %endif
 fi;
 exit 0
 


### PR DESCRIPTION
Two important fixes:
- With merged systemd changes it fails to install (we need to use ceph.target).
- Fix to installation in kickstart (policy was installed but not activated because of initial installation order). (Normal installation worked though because base policy files were already installed.)