### PR TITLE
ceph-disk: only call restorecon when available

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -963,12 +963,13 @@ def mount(
                 path,
                 ],
             )
-        command(
-           [
-                'restorecon',
-                path,
+        if which('restorecon'):
+            command(
+                [
+                    'restorecon',
+                    path,
                 ],
-           )
+            )
     except subprocess.CalledProcessError as e:
         try:
             os.rmdir(path)


### PR DESCRIPTION
9db80da12803d42bb676d67f37442c0c54d83448 added an unconditional call to
restorecon after mounting the filesystem. It fails when restorecon is
not available and must be made conditional.

http://tracker.ceph.com/issues/12718 Fixes: #12718

Signed-off-by: Loic Dachary <ldachary@redhat.com>