### PR TITLE
OSD:cleanup a question about snapid

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1053,25 +1053,22 @@ void pg_pool_t::add_unmanaged_snap(uint64_t& snapid)
 {
   if (removed_snaps.empty()) {
     assert(!is_pool_snaps_mode());
-    removed_snaps.insert(snapid_t(1));
-    snap_seq = 1;
+    removed_snaps.insert(snapid_t(0));
   }
-  snapid = snap_seq = snap_seq + 1;
+  snap_seq = snap_seq + 1;
+  snapid = snap_seq;
 }
 
 void pg_pool_t::remove_snap(snapid_t s)
 {
   assert(snaps.count(s));
   snaps.erase(s);
-  snap_seq = snap_seq + 1;
 }
 
 void pg_pool_t::remove_unmanaged_snap(snapid_t s)
 {
   assert(is_unmanaged_snaps_mode());
   removed_snaps.insert(s);
-  snap_seq = snap_seq + 1;
-  removed_snaps.insert(get_snap_seq());
 }
 
 SnapContext pg_pool_t::get_snap_context() const


### PR DESCRIPTION
First ,create a new rbd named ' pi ' in pool ' test ' ,and create a snap for pi , its snapid start from 2 ;
Second,(if  you have created many snaps for  rbd ' pi ') , remove snap can make snapid +1   

Test fix:
Before :
First:
```
root@ubuntu1:/home# rbd -p test snap ls pi                          
SNAPID NAME    SIZE                                                             
     2 sss  1024 MB                                                             
     3 ppp  1024 MB                                                             
     4 ttt  1024 MB            
```
Second:
```
root@ubuntu1:/home# rbd -p test snap rm pi@ppp
root@ubuntu1:/home# rbd -p test snap create pi@snap                       
SNAPID NAME    SIZE                                                             
     2  sss  1024 MB                                                                                                                          
     4   ttt   1024 MB
     6 snap 1024MB     
```

After：
snapid start from 1;
remove snap can not make snapid +1
```
root@ubuntu1:/home/code/ceph# rbd -p apple snap ls pi                                                                                                
SNAPID NAME    SIZE                                                             
     1 sss  1024 MB                                                             
     2 ppp  1024 MB                                                             
     3 qqq  1024 MB                                                             
root@ubuntu1:/home/code/ceph# rbd -p apple snap rm pi@qqq                                                                                                 
root@ubuntu1:/home/code/ceph# rbd -p apple snap create pi@ttt                                                                                            
root@ubuntu1:/home/code/ceph# rbd -p apple snap ls pi                                                                                                       
SNAPID NAME    SIZE                                                             
     1 sss  1024 MB                                                             
     2 ppp  1024 MB                                                             
     4 ttt  1024 MB                                                             
```

Signed-off-by: h11686 <he.yongqiang.com>