### PR TITLE
doc:radosgw: correct the command typo to remove a subuser

### DIFF
--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -182,7 +182,7 @@ subuser), specify ``user rm`` and the user ID. ::
 
 To remove the subuser only, specify ``subuser rm`` and the subuser ID. ::
 
-	radosgw-admin subuser rm --uid=johndoe:swift
+	radosgw-admin subuser rm --subuser=johndoe:swift
 
 
 Options include:
@@ -201,7 +201,7 @@ When you remove a sub user, you are removing access to the Swift interface.
 The user will remain in the system. The Ceph Object Gateway  To remove the subuser, specify 
 ``subuser rm`` and the subuser ID. ::
 
-	radosgw-admin subuser rm --uid=johndoe:swift
+	radosgw-admin subuser rm --subuser=johndoe:swift
 
 
 


### PR DESCRIPTION
Fix a typo in the example command to remove a subuser

Signed-off-by: Sangdi Xu <xu.sangdi@h3c.com>