### PR TITLE
MemStore locking enhancements and bufferlist alternative

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1046,6 +1046,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_bindir}/ceph_erasure_code
 %{_bindir}/ceph_erasure_code_benchmark
 %{_bindir}/ceph_omapbench
+%{_bindir}/ceph_objectstore_bench
 %{_bindir}/ceph_perf_objectstore
 %{_bindir}/ceph_perf_local
 %{_bindir}/ceph_perf_msgr_client

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -48,6 +48,7 @@ Makefile
 /ceph_xattr_bench
 /ceph_kvstorebench
 /ceph_omapbench
+/ceph_objectstore_bench
 /ceph_smalliobench
 /ceph_smalliobenchdumb
 /ceph_smalliobenchfs

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -781,6 +781,8 @@ OPTION(osd_bench_max_block_size, OPT_U64, 64 << 20) // cap the block size at 64M
 OPTION(osd_bench_duration, OPT_U32, 30) // duration of 'osd bench', capped at 30s to avoid triggering timeouts
 
 OPTION(memstore_device_bytes, OPT_U64, 1024*1024*1024)
+OPTION(memstore_page_set, OPT_BOOL, true)
+OPTION(memstore_page_size, OPT_U64, 64 << 10)
 
 OPTION(filestore_omap_backend, OPT_STR, "leveldb")
 

--- a/src/os/Makefile.am
+++ b/src/os/Makefile.am
@@ -70,6 +70,7 @@ noinst_HEADERS += \
 	os/KeyValueStore.h \
 	os/ObjectMap.h \
 	os/ObjectStore.h \
+	os/PageSet.h \
 	os/SequencerPosition.h \
 	os/WBThrottle.h \
 	os/XfsFileStoreBackend.h \

--- a/src/os/MemStore.cc
+++ b/src/os/MemStore.cc
@@ -327,7 +327,6 @@ int MemStore::read(
   return o->read(offset, l, bl);
 }
 
-
 int MemStore::fiemap(coll_t cid, const ghobject_t& oid,
 		     uint64_t offset, size_t len, bufferlist& bl)
 {
@@ -1426,22 +1425,26 @@ int MemStore::BufferlistObject::truncate(uint64_t size)
 }
 
 // PageSetObject
+
+// use a thread-local vector for the pages returned by PageSet, so we
+// can avoid allocations in read/write()
+thread_local PageSet::page_vector MemStore::PageSetObject::tls_pages;
+
 int MemStore::PageSetObject::read(uint64_t offset, uint64_t len, bufferlist& bl)
 {
   const auto start = offset;
   const auto end = offset + len;
   auto remaining = len;
 
-  PageSet::page_vector pages;
-  data.get_range(offset, len, pages);
+  data.get_range(offset, len, tls_pages);
 
   // allocate a buffer for the data
   buffer::ptr buf(len);
 
-  auto p = pages.begin();
+  auto p = tls_pages.begin();
   while (remaining) {
     // no more pages in range
-    if (p == pages.end() || (*p)->offset >= end) {
+    if (p == tls_pages.end() || (*p)->offset >= end) {
       buf.zero(offset - start, remaining);
       break;
     }
@@ -1469,6 +1472,8 @@ int MemStore::PageSetObject::read(uint64_t offset, uint64_t len, bufferlist& bl)
     ++p;
   }
 
+  tls_pages.clear(); // drop page refs
+
   bl.append(buf);
   return len;
 }
@@ -1478,10 +1483,9 @@ int MemStore::PageSetObject::write(uint64_t offset, const bufferlist &src)
   unsigned len = src.length();
 
   // make sure the page range is allocated
-  PageSet::page_vector pages;
-  data.alloc_range(offset, src.length(), pages);
+  data.alloc_range(offset, src.length(), tls_pages);
 
-  auto page = pages.begin();
+  auto page = tls_pages.begin();
 
   // XXX: cast away the const because bufferlist doesn't have a const_iterator
   auto p = const_cast<bufferlist&>(src).begin();
@@ -1497,6 +1501,7 @@ int MemStore::PageSetObject::write(uint64_t offset, const bufferlist &src)
   }
   if (data_len < offset)
     data_len = offset;
+  tls_pages.clear(); // drop page refs
   return 0;
 }
 
@@ -1511,13 +1516,13 @@ int MemStore::PageSetObject::clone(Object *src, uint64_t srcoff,
   auto &dst_data = data;
   const auto dst_page_size = dst_data.get_page_size();
 
-  PageSet::page_vector src_pages, dst_pages;
+  PageSet::page_vector dst_pages;
 
   while (len) {
     const auto count = std::min(len, src_page_size * 16);
-    src_data.get_range(srcoff, count, src_pages);
+    src_data.get_range(srcoff, count, tls_pages);
 
-    for (auto &src_page : src_pages) {
+    for (auto &src_page : tls_pages) {
       auto sbegin = std::max(srcoff, src_page->offset);
       auto send = std::min(srcoff + count, src_page->offset + src_page_size);
       dst_data.alloc_range(sbegin + delta, send - sbegin, dst_pages);
@@ -1536,7 +1541,7 @@ int MemStore::PageSetObject::clone(Object *src, uint64_t srcoff,
       dstoff += count;
       len -= count;
     }
-    src_pages.clear(); // drop page refs
+    tls_pages.clear(); // drop page refs
   }
 
   // update object size
@@ -1556,13 +1561,13 @@ int MemStore::PageSetObject::truncate(uint64_t size)
     return 0;
 
   // write zeroes to the rest of the last page
-  PageSet::page_vector pages;
-  data.get_range(page_offset, page_size, pages);
-  if (pages.empty())
+  data.get_range(page_offset, page_size, tls_pages);
+  if (tls_pages.empty())
     return 0;
 
-  auto page = pages.begin();
+  auto page = tls_pages.begin();
   auto data = (*page)->data;
   std::fill(data + (size - page_offset), data + page_size, 0);
+  tls_pages.clear(); // drop page ref
   return 0;
 }

--- a/src/os/MemStore.cc
+++ b/src/os/MemStore.cc
@@ -1387,6 +1387,7 @@ int MemStore::_split_collection(coll_t cid, uint32_t bits, uint32_t match,
 int MemStore::BufferlistObject::read(uint64_t offset, uint64_t len,
                                      bufferlist &bl)
 {
+  std::lock_guard<Spinlock> lock(mutex);
   bl.substr_of(data, offset, len);
   return bl.length();
 }
@@ -1394,6 +1395,8 @@ int MemStore::BufferlistObject::read(uint64_t offset, uint64_t len,
 int MemStore::BufferlistObject::write(uint64_t offset, const bufferlist &src)
 {
   unsigned len = src.length();
+
+  std::lock_guard<Spinlock> lock(mutex);
 
   // before
   bufferlist newdata;
@@ -1422,21 +1425,25 @@ int MemStore::BufferlistObject::write(uint64_t offset, const bufferlist &src)
 int MemStore::BufferlistObject::clone(Object *src, uint64_t srcoff,
                                       uint64_t len, uint64_t dstoff)
 {
-  auto srcbl = dynamic_cast<const BufferlistObject*>(src);
+  auto srcbl = dynamic_cast<BufferlistObject*>(src);
   if (srcbl == nullptr)
     return -ENOTSUP;
 
-  if (srcoff == dstoff && len == src->get_size()) {
-    data = srcbl->data;
-    return 0;
-  }
   bufferlist bl;
-  bl.substr_of(srcbl->data, srcoff, len);
+  {
+    std::lock_guard<Spinlock> lock(srcbl->mutex);
+    if (srcoff == dstoff && len == src->get_size()) {
+      data = srcbl->data;
+      return 0;
+    }
+    bl.substr_of(srcbl->data, srcoff, len);
+  }
   return write(dstoff, bl);
 }
 
 int MemStore::BufferlistObject::truncate(uint64_t size)
 {
+  std::lock_guard<Spinlock> lock(mutex);
   if (get_size() > size) {
     bufferlist bl;
     bl.substr_of(data, 0, size);

--- a/src/os/MemStore.h
+++ b/src/os/MemStore.h
@@ -125,6 +125,10 @@ public:
     PageSet data;
     size_t data_len;
 
+    // use a thread-local vector for the pages returned by PageSet, so we
+    // can avoid allocations in read/write()
+    static thread_local PageSet::page_vector tls_pages;
+
     PageSetObject(size_t page_size) : data(page_size), data_len(0) {}
 
     size_t get_size() const override { return data_len; }

--- a/src/os/MemStore.h
+++ b/src/os/MemStore.h
@@ -133,7 +133,8 @@ public:
     // level.
 
     ObjectRef get_object(ghobject_t oid) {
-      ceph::unordered_map<ghobject_t,ObjectRef>::iterator o = object_hash.find(oid);
+      RWLock::RLocker l(lock);
+      auto o = object_hash.find(oid);
       if (o == object_hash.end())
 	return ObjectRef();
       return o->second;

--- a/src/os/MemStore.h
+++ b/src/os/MemStore.h
@@ -30,6 +30,7 @@
 class MemStore : public ObjectStore {
 public:
   struct Object : public RefCountedObject {
+    std::mutex xattr_mutex;
     std::mutex omap_mutex;
     map<string,bufferptr> xattr;
     bufferlist omap_header;

--- a/src/os/MemStore.h
+++ b/src/os/MemStore.h
@@ -22,6 +22,7 @@
 #include "include/assert.h"
 #include "include/unordered_map.h"
 #include "include/memory.h"
+#include "include/Spinlock.h"
 #include "common/Finisher.h"
 #include "common/RefCountedObj.h"
 #include "common/RWLock.h"
@@ -91,6 +92,7 @@ public:
   typedef Object::Ref ObjectRef;
 
   struct BufferlistObject : public Object {
+    Spinlock mutex;
     bufferlist data;
 
     size_t get_size() const override { return data.length(); }

--- a/src/os/PageSet.h
+++ b/src/os/PageSet.h
@@ -1,0 +1,227 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2013- Sage Weil <sage@inktank.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.	See file COPYING.
+ *
+ */
+
+#ifndef CEPH_PAGESET_H
+#define CEPH_PAGESET_H
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <mutex>
+#include <vector>
+#include <boost/intrusive/avl_set.hpp>
+#include <boost/intrusive_ptr.hpp>
+
+#include "include/encoding.h"
+#include "include/Spinlock.h"
+
+
+struct Page {
+  char *const data;
+  boost::intrusive::avl_set_member_hook<> hook;
+  uint64_t offset;
+
+  // avoid RefCountedObject because it has a virtual destructor
+  std::atomic<uint16_t> nrefs;
+  void get() { ++nrefs; }
+  void put() { if (--nrefs == 0) delete this; }
+
+  typedef boost::intrusive_ptr<Page> Ref;
+  friend void intrusive_ptr_add_ref(Page *p) { p->get(); }
+  friend void intrusive_ptr_release(Page *p) { p->put(); }
+
+  // key-value comparison functor for avl
+  struct Less {
+    bool operator()(uint64_t offset, const Page &page) const {
+      return offset < page.offset;
+    }
+    bool operator()(const Page &page, uint64_t offset) const {
+      return page.offset < offset;
+    }
+    bool operator()(const Page &lhs, const Page &rhs) const {
+      return lhs.offset < rhs.offset;
+    }
+  };
+  void encode(bufferlist &bl, size_t page_size) const {
+    bl.append(buffer::copy(data, page_size));
+    ::encode(offset, bl);
+  }
+  void decode(bufferlist::iterator &p, size_t page_size) {
+    ::decode_array_nohead(data, page_size, p);
+    ::decode(offset, p);
+  }
+
+  static Ref create(size_t page_size, uint64_t offset = 0) {
+    // allocate the Page and its data in a single buffer
+    auto buffer = new char[page_size + sizeof(Page)];
+    // place the Page structure at the end of the buffer
+    return new (buffer + page_size) Page(buffer, offset);
+  }
+
+  // copy disabled
+  Page(const Page&) = delete;
+  const Page& operator=(const Page&) = delete;
+
+ private: // private constructor, use create() instead
+  Page(char *data, uint64_t offset) : data(data), offset(offset), nrefs(1) {}
+
+  static void operator delete(void *p) {
+    delete[] reinterpret_cast<Page*>(p)->data;
+  }
+};
+
+class PageSet {
+ public:
+  // alloc_range() and get_range() return page refs in a vector
+  typedef std::vector<Page::Ref> page_vector;
+
+ private:
+  // store pages in a boost intrusive avl_set
+  typedef Page::Less page_cmp;
+  typedef boost::intrusive::member_hook<Page,
+          boost::intrusive::avl_set_member_hook<>,
+          &Page::hook> member_option;
+  typedef boost::intrusive::avl_set<Page,
+          boost::intrusive::compare<page_cmp>, member_option> page_set;
+
+  typedef typename page_set::iterator iterator;
+
+  page_set pages;
+  size_t page_size;
+
+  typedef Spinlock lock_type;
+  lock_type mutex;
+
+  void free_pages(iterator cur, iterator end) {
+    while (cur != end) {
+      Page *page = &*cur;
+      cur = pages.erase(cur);
+      page->put();
+    }
+  }
+
+  int count_pages(uint64_t offset, uint64_t len) const {
+    // count the overlapping pages
+    int count = 0;
+    if (offset % page_size) {
+      count++;
+      size_t rem = page_size - offset % page_size;
+      len = len <= rem ? 0 : len - rem;
+    }
+    count += len / page_size;
+    if (len % page_size)
+      count++;
+    return count;
+  }
+
+ public:
+  PageSet(size_t page_size) : page_size(page_size) {}
+  PageSet(PageSet &&rhs)
+    : pages(std::move(rhs.pages)), page_size(rhs.page_size) {}
+  ~PageSet() {
+    free_pages(pages.begin(), pages.end());
+  }
+
+  // disable copy
+  PageSet(const PageSet&) = delete;
+  const PageSet& operator=(const PageSet&) = delete;
+
+  bool empty() const { return pages.empty(); }
+  size_t size() const { return pages.size(); }
+  size_t get_page_size() const { return page_size; }
+
+  // allocate all pages that intersect the range [offset,length)
+  void alloc_range(uint64_t offset, uint64_t length, page_vector &range) {
+    // loop in reverse so we can provide hints to avl_set::insert_check()
+    //	and get O(1) insertions after the first
+    uint64_t position = offset + length - 1;
+
+    range.resize(count_pages(offset, length));
+    auto out = range.rbegin();
+
+    std::lock_guard<lock_type> lock(mutex);
+    iterator cur = pages.end();
+    while (length) {
+      const uint64_t page_offset = position & ~(page_size-1);
+
+      typename page_set::insert_commit_data commit;
+      auto insert = pages.insert_check(cur, page_offset, page_cmp(), commit);
+      if (insert.second) {
+        auto page = Page::create(page_size, page_offset);
+        cur = pages.insert_commit(*page, commit);
+
+        // assume that the caller will write to the range [offset,length),
+        //  so we only need to zero memory outside of this range
+
+        // zero end of page past offset + length
+        if (offset + length < page->offset + page_size)
+          std::fill(page->data + offset + length - page->offset,
+                    page->data + page_size, 0);
+        // zero front of page between page_offset and offset
+        if (offset > page->offset)
+          std::fill(page->data, page->data + offset - page->offset, 0);
+      } else { // exists
+        cur = insert.first;
+      }
+      // add a reference to output vector
+      out->reset(&*cur);
+      ++out;
+
+      auto c = std::min(length, (position & (page_size-1)) + 1);
+      position -= c;
+      length -= c;
+    }
+    // make sure we sized the vector correctly
+    assert(out == range.rend());
+  }
+
+  // return all allocated pages that intersect the range [offset,length)
+  void get_range(uint64_t offset, uint64_t length, page_vector &range) {
+    auto cur = pages.lower_bound(offset & ~(page_size-1), page_cmp());
+    while (cur != pages.end() && cur->offset < offset + length)
+      range.push_back(&*cur++);
+  }
+
+  void free_pages_after(uint64_t offset) {
+    std::lock_guard<lock_type> lock(mutex);
+    auto cur = pages.lower_bound(offset & ~(page_size-1), page_cmp());
+    if (cur == pages.end())
+      return;
+    if (cur->offset < offset)
+      cur++;
+    free_pages(cur, pages.end());
+  }
+
+  void encode(bufferlist &bl) const {
+    ::encode(page_size, bl);
+    unsigned count = pages.size();
+    ::encode(count, bl);
+    for (auto p = pages.rbegin(); p != pages.rend(); ++p)
+      p->encode(bl, page_size);
+  }
+  void decode(bufferlist::iterator &p) {
+    assert(empty());
+    ::decode(page_size, p);
+    unsigned count;
+    ::decode(count, p);
+    auto cur = pages.end();
+    for (unsigned i = 0; i < count; i++) {
+      auto page = Page::create(page_size);
+      page->decode(p, page_size);
+      cur = pages.insert_before(cur, *page);
+    }
+  }
+};
+
+#endif // CEPH_PAGESET_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -905,6 +905,12 @@ target_link_libraries(unittest_subprocess
 set_target_properties(unittest_subprocess PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 
+# unittest_pageset
+add_executable(unittest_pageset test_pageset.cc)
+target_link_libraries(unittest_pageset ${UNITTEST_LIBS})
+set_target_properties(unittest_pageset PROPERTIES COMPILE_FLAGS
+  ${UNITTEST_CXX_FLAGS})
+
 if(${WITH_RADOSGW})
   # test_cors
   set(test_cors_srcs test_cors.cc)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -223,6 +223,11 @@ add_executable(kvstorebench
 target_link_libraries(kvstorebench librados global ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS}
   ${TCMALLOC_LIBS})
 
+# ceph_objectstore_bench
+add_executable(ceph_objectstore_bench objectstore_bench.cc
+  $<TARGET_OBJECTS:heap_profiler_objs>)
+target_link_libraries(ceph_objectstore_bench global os ${TCMALLOC_LIBS})
+
 ## System tests
 
 # systest

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -68,6 +68,10 @@ ceph_omapbench_SOURCES = test/omap_bench.cc
 ceph_omapbench_LDADD = $(LIBRADOS) $(CEPH_GLOBAL)
 bin_DEBUGPROGRAMS += ceph_omapbench
 
+ceph_objectstore_bench_SOURCES = test/objectstore_bench.cc
+ceph_objectstore_bench_LDADD = $(LIBOS) $(CEPH_GLOBAL)
+bin_DEBUGPROGRAMS += ceph_objectstore_bench
+
 if LINUX
 ceph_kvstorebench_SOURCES = \
 	test/kv_store_bench.cc \

--- a/src/test/Makefile-server.am
+++ b/src/test/Makefile-server.am
@@ -200,6 +200,11 @@ ceph_test_snap_mapper_LDADD = $(LIBOSD) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 ceph_test_snap_mapper_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_snap_mapper
 
+unittest_pageset_SOURCES = test/test_pageset.cc
+unittest_pageset_LDADD = $(UNITTEST_LDADD)
+unittest_pageset_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+check_TESTPROGRAMS += unittest_pageset
+
 endif # WITH_OSD
 
 if WITH_SLIBROCKSDB

--- a/src/test/objectstore_bench.cc
+++ b/src/test/objectstore_bench.cc
@@ -1,0 +1,286 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <chrono>
+#include <cassert>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "os/ObjectStore.h"
+
+#include "global/global_init.h"
+
+#include "common/strtol.h"
+#include "common/ceph_argparse.h"
+
+#define dout_subsys ceph_subsys_filestore
+
+static void usage()
+{
+  derr << "usage: ceph_objectstore_bench [flags]\n"
+      "	 --size\n"
+      "	       total size in bytes\n"
+      "	 --block-size\n"
+      "	       block size in bytes for each write\n"
+      "	 --repeats\n"
+      "	       number of times to repeat the write cycle\n"
+      "	 --threads\n"
+      "	       number of threads to carry out this workload\n"
+      "	 --multi-object\n"
+      "	       have each thread write to a separate object\n" << dendl;
+  generic_server_usage();
+}
+
+// helper class for bytes with units
+struct byte_units {
+  size_t v;
+  byte_units(size_t v) : v(v) {}
+
+  bool parse(const std::string &val, std::string *err);
+
+  operator size_t() const { return v; }
+};
+
+bool byte_units::parse(const std::string &val, std::string *err)
+{
+  v = strict_sistrtoll(val.c_str(), err);
+  return err->empty();
+}
+
+std::ostream& operator<<(std::ostream &out, const byte_units &amount)
+{
+  static const char* units[] = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
+  static const int max_units = sizeof(units)/sizeof(*units);
+
+  int unit = 0;
+  auto v = amount.v;
+  while (v >= 1024 && unit < max_units) {
+    // preserve significant bytes
+    if (v < 1048576 && (v % 1024 != 0))
+      break;
+    v >>= 10;
+    unit++;
+  }
+  return out << v << ' ' << units[unit];
+}
+
+struct Config {
+  byte_units size;
+  byte_units block_size;
+  int repeats;
+  int threads;
+  bool multi_object;
+  Config()
+    : size(1048576), block_size(4096),
+      repeats(1), threads(1),
+      multi_object(false) {}
+};
+
+class C_NotifyCond : public Context {
+  std::mutex *mutex;
+  std::condition_variable *cond;
+  bool *done;
+public:
+  C_NotifyCond(std::mutex *mutex, std::condition_variable *cond, bool *done)
+    : mutex(mutex), cond(cond), done(done) {}
+  void finish(int r) {
+    std::lock_guard<std::mutex> lock(*mutex);
+    *done = true;
+    cond->notify_one();
+  }
+};
+
+void osbench_worker(ObjectStore *os, const Config &cfg,
+                    const coll_t cid, const ghobject_t oid,
+                    uint64_t starting_offset)
+{
+  bufferlist data;
+  data.append(buffer::create(cfg.block_size));
+
+  dout(0) << "Writing " << cfg.size
+      << " in blocks of " << cfg.block_size << dendl;
+
+  assert(starting_offset < cfg.size);
+  assert(starting_offset % cfg.block_size == 0);
+
+  ObjectStore::Sequencer sequencer("osbench");
+
+  for (int i = 0; i < cfg.repeats; ++i) {
+    uint64_t offset = starting_offset;
+    size_t len = cfg.size;
+
+    list<ObjectStore::Transaction*> tls;
+
+    std::cout << "Write cycle " << i << std::endl;
+    while (len) {
+      size_t count = len < cfg.block_size ? len : (size_t)cfg.block_size;
+
+      auto t = new ObjectStore::Transaction;
+      t->write(cid, oid, offset, count, data);
+      tls.push_back(t);
+
+      offset += count;
+      if (offset > cfg.size)
+        offset -= cfg.size;
+      len -= count;
+    }
+
+    // set up the finisher
+    std::mutex mutex;
+    std::condition_variable cond;
+    bool done = false;
+
+    os->queue_transactions(&sequencer, tls, nullptr,
+                           new C_NotifyCond(&mutex, &cond, &done));
+
+    std::unique_lock<std::mutex> lock(mutex);
+    cond.wait(lock, [&done](){ return done; });
+    lock.unlock();
+
+    while (!tls.empty()) {
+      auto t = tls.front();
+      tls.pop_front();
+      delete t;
+    }
+  }
+}
+
+int main(int argc, const char *argv[])
+{
+  Config cfg;
+
+  // command-line arguments
+  vector<const char*> args;
+  argv_to_vec(argc, argv, args);
+  env_to_vec(args);
+
+  global_init(nullptr, args, CEPH_ENTITY_TYPE_OSD, CODE_ENVIRONMENT_UTILITY, 0);
+
+  std::string val;
+  vector<const char*>::iterator i = args.begin();
+  while (i != args.end()) {
+    if (ceph_argparse_double_dash(args, i))
+      break;
+
+    if (ceph_argparse_witharg(args, i, &val, "--size", (char*)nullptr)) {
+      std::string err;
+      if (!cfg.size.parse(val, &err)) {
+        derr << "error parsing size: " << err << dendl;
+        usage();
+      }
+    } else if (ceph_argparse_witharg(args, i, &val, "--block-size", (char*)nullptr)) {
+      std::string err;
+      if (!cfg.block_size.parse(val, &err)) {
+        derr << "error parsing block-size: " << err << dendl;
+        usage();
+      }
+    } else if (ceph_argparse_witharg(args, i, &val, "--repeats", (char*)nullptr)) {
+      cfg.repeats = atoi(val.c_str());
+    } else if (ceph_argparse_witharg(args, i, &val, "--threads", (char*)nullptr)) {
+      cfg.threads = atoi(val.c_str());
+    } else if (ceph_argparse_flag(args, i, "--multi-object", (char*)nullptr)) {
+      cfg.multi_object = true;
+    } else {
+      derr << "Error: can't understand argument: " << *i << "\n" << dendl;
+      usage();
+    }
+  }
+
+  common_init_finish(g_ceph_context);
+
+  // create object store
+  dout(0) << "objectstore " << g_conf->osd_objectstore << dendl;
+  dout(0) << "data " << g_conf->osd_data << dendl;
+  dout(0) << "journal " << g_conf->osd_journal << dendl;
+  dout(0) << "size " << cfg.size << dendl;
+  dout(0) << "block-size " << cfg.block_size << dendl;
+  dout(0) << "repeats " << cfg.repeats << dendl;
+  dout(0) << "threads " << cfg.threads << dendl;
+
+  auto os = std::unique_ptr<ObjectStore>(
+      ObjectStore::create(g_ceph_context,
+                          g_conf->osd_objectstore,
+                          g_conf->osd_data,
+                          g_conf->osd_journal));
+  if (!os) {
+    derr << "bad objectstore type " << g_conf->osd_objectstore << dendl;
+    return 1;
+  }
+  if (os->mkfs() < 0) {
+    derr << "mkfs failed" << dendl;
+    return 1;
+  }
+  if (os->mount() < 0) {
+    derr << "mount failed" << dendl;
+    return 1;
+  }
+
+  dout(10) << "created objectstore " << os.get() << dendl;
+
+  // create a collection
+  spg_t pg;
+  const coll_t cid(pg);
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    os->apply_transaction(t);
+  }
+
+  // create the objects
+  std::vector<ghobject_t> oids;
+  if (cfg.multi_object) {
+    oids.reserve(cfg.threads);
+    for (int i = 0; i < cfg.threads; i++) {
+      std::stringstream oss;
+      oss << "osbench-thread-" << i;
+      oids.emplace_back(pg.make_temp_object(oss.str()));
+
+      ObjectStore::Transaction t;
+      t.touch(cid, oids[i]);
+      int r = os->apply_transaction(t);
+      assert(r == 0);
+    }
+  } else {
+    oids.emplace_back(pg.make_temp_object("osbench"));
+
+    ObjectStore::Transaction t;
+    t.touch(cid, oids.back());
+    int r = os->apply_transaction(t);
+    assert(r == 0);
+  }
+
+  // run the worker threads
+  std::vector<std::thread> workers;
+  workers.reserve(cfg.threads);
+
+  using namespace std::chrono;
+  auto t1 = high_resolution_clock::now();
+  for (int i = 0; i < cfg.threads; i++) {
+    const auto &oid = cfg.multi_object ? oids[i] : oids[0];
+    workers.emplace_back(osbench_worker, os.get(), std::ref(cfg),
+                         cid, oid, i * cfg.size / cfg.threads);
+  }
+  for (auto &worker : workers)
+    worker.join();
+  auto t2 = high_resolution_clock::now();
+  workers.clear();
+
+  auto duration = duration_cast<microseconds>(t2 - t1);
+  byte_units total = cfg.size * cfg.repeats * cfg.threads;
+  byte_units rate = (1000000LL * total) / duration.count();
+  size_t iops = (1000000LL * total / cfg.block_size) / duration.count();
+  dout(0) << "Wrote " << total << " in "
+      << duration.count() << "us, at a rate of " << rate << "/s and "
+      << iops << " iops" << dendl;
+
+  // remove the objects
+  ObjectStore::Transaction t;
+  for (const auto &oid : oids)
+    t.remove(cid, oid);
+  os->apply_transaction(t);
+
+  os->umount();
+  return 0;
+}

--- a/src/test/test_pageset.cc
+++ b/src/test/test_pageset.cc
@@ -1,0 +1,271 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#include "gtest/gtest.h"
+
+#include "os/PageSet.h"
+
+TEST(PageSet, AllocAligned)
+{
+  PageSet pages(1);
+  PageSet::page_vector range;
+
+  pages.alloc_range(0, 4, range);
+  ASSERT_EQ(4u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  ASSERT_EQ(1u, range[1]->offset);
+  ASSERT_EQ(2u, range[2]->offset);
+  ASSERT_EQ(3u, range[3]->offset);
+}
+
+TEST(PageSet, AllocUnaligned)
+{
+  PageSet pages(2);
+  PageSet::page_vector range;
+
+  // front of first page
+  pages.alloc_range(0, 1, range);
+  ASSERT_EQ(1u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  range.clear();
+
+  // back of first page
+  pages.alloc_range(1, 1, range);
+  ASSERT_EQ(1u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  range.clear();
+
+  // back of first page and front of second
+  pages.alloc_range(1, 2, range);
+  ASSERT_EQ(2u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  ASSERT_EQ(2u, range[1]->offset);
+  range.clear();
+
+  // back of first page and all of second
+  pages.alloc_range(1, 3, range);
+  ASSERT_EQ(2u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  ASSERT_EQ(2u, range[1]->offset);
+  range.clear();
+
+  // back of first page, all of second, and front of third
+  pages.alloc_range(1, 4, range);
+  ASSERT_EQ(3u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  ASSERT_EQ(2u, range[1]->offset);
+  ASSERT_EQ(4u, range[2]->offset);
+}
+
+TEST(PageSet, GetAligned)
+{
+  // allocate 4 pages
+  PageSet pages(1);
+  PageSet::page_vector range;
+  pages.alloc_range(0, 4, range);
+  range.clear();
+
+  // get first page
+  pages.get_range(0, 1, range);
+  ASSERT_EQ(1u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  range.clear();
+
+  // get second and third pages
+  pages.get_range(1, 2, range);
+  ASSERT_EQ(2u, range.size());
+  ASSERT_EQ(1u, range[0]->offset);
+  ASSERT_EQ(2u, range[1]->offset);
+  range.clear();
+
+  // get all four pages
+  pages.get_range(0, 4, range);
+  ASSERT_EQ(4u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  ASSERT_EQ(1u, range[1]->offset);
+  ASSERT_EQ(2u, range[2]->offset);
+  ASSERT_EQ(3u, range[3]->offset);
+  range.clear();
+}
+
+TEST(PageSet, GetUnaligned)
+{
+  // allocate 3 pages
+  PageSet pages(2);
+  PageSet::page_vector range;
+  pages.alloc_range(0, 6, range);
+  range.clear();
+
+  // front of first page
+  pages.get_range(0, 1, range);
+  ASSERT_EQ(1u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  range.clear();
+
+  // back of first page
+  pages.get_range(1, 1, range);
+  ASSERT_EQ(1u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  range.clear();
+
+  // back of first page and front of second
+  pages.get_range(1, 2, range);
+  ASSERT_EQ(2u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  ASSERT_EQ(2u, range[1]->offset);
+  range.clear();
+
+  // back of first page and all of second
+  pages.get_range(1, 3, range);
+  ASSERT_EQ(2u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  ASSERT_EQ(2u, range[1]->offset);
+  range.clear();
+
+  // back of first page, all of second, and front of third
+  pages.get_range(1, 4, range);
+  ASSERT_EQ(3u, range.size());
+  ASSERT_EQ(0u, range[0]->offset);
+  ASSERT_EQ(2u, range[1]->offset);
+  ASSERT_EQ(4u, range[2]->offset);
+  range.clear();
+
+  // back of third page with nothing beyond
+  pages.get_range(5, 999, range);
+  ASSERT_EQ(1u, range.size());
+  ASSERT_EQ(4u, range[0]->offset);
+  range.clear();
+}
+
+TEST(PageSet, GetHoles)
+{
+  // allocate pages at offsets 1, 2, 5, and 7
+  PageSet pages(1);
+  PageSet::page_vector range;
+  for (uint64_t i : {1, 2, 5, 7})
+    pages.alloc_range(i, 1, range);
+  range.clear();
+
+  // nothing at offset 0, page at offset 1
+  pages.get_range(0, 2, range);
+  ASSERT_EQ(1u, range.size());
+  ASSERT_EQ(1u, range[0]->offset);
+  range.clear();
+
+  // nothing at offset 0, pages at offset 1 and 2, nothing at offset 3
+  pages.get_range(0, 4, range);
+  ASSERT_EQ(2u, range.size());
+  ASSERT_EQ(1u, range[0]->offset);
+  ASSERT_EQ(2u, range[1]->offset);
+  range.clear();
+
+  // page at offset 2, nothing at offset 3 or 4
+  pages.get_range(2, 3, range);
+  ASSERT_EQ(1u, range.size());
+  ASSERT_EQ(2u, range[0]->offset);
+  range.clear();
+
+  // get the full range
+  pages.get_range(0, 999, range);
+  ASSERT_EQ(4u, range.size());
+  ASSERT_EQ(1u, range[0]->offset);
+  ASSERT_EQ(2u, range[1]->offset);
+  ASSERT_EQ(5u, range[2]->offset);
+  ASSERT_EQ(7u, range[3]->offset);
+  range.clear();
+}
+
+TEST(PageSet, FreeAligned)
+{
+  // allocate 4 pages
+  PageSet pages(1);
+  PageSet::page_vector range;
+  pages.alloc_range(0, 4, range);
+  range.clear();
+
+  // get the full range
+  pages.get_range(0, 4, range);
+  ASSERT_EQ(4u, range.size());
+  range.clear();
+
+  // free after offset 4 has no effect
+  pages.free_pages_after(4);
+  pages.get_range(0, 4, range);
+  ASSERT_EQ(4u, range.size());
+  range.clear();
+
+  // free page 4
+  pages.free_pages_after(3);
+  pages.get_range(0, 4, range);
+  ASSERT_EQ(3u, range.size());
+  range.clear();
+
+  // free pages 2 and 3
+  pages.free_pages_after(1);
+  pages.get_range(0, 4, range);
+  ASSERT_EQ(1u, range.size());
+  range.clear();
+}
+
+TEST(PageSet, FreeUnaligned)
+{
+  // allocate 4 pages
+  PageSet pages(2);
+  PageSet::page_vector range;
+  pages.alloc_range(0, 8, range);
+  range.clear();
+
+  // get the full range
+  pages.get_range(0, 8, range);
+  ASSERT_EQ(4u, range.size());
+  range.clear();
+
+  // free after offset 7 has no effect
+  pages.free_pages_after(7);
+  pages.get_range(0, 8, range);
+  ASSERT_EQ(4u, range.size());
+  range.clear();
+
+  // free page 4
+  pages.free_pages_after(5);
+  pages.get_range(0, 8, range);
+  ASSERT_EQ(3u, range.size());
+  range.clear();
+
+  // free pages 2 and 3
+  pages.free_pages_after(1);
+  pages.get_range(0, 8, range);
+  ASSERT_EQ(1u, range.size());
+  range.clear();
+}
+
+TEST(PageSet, FreeHoles)
+{
+  // allocate pages at offsets 1, 2, 5, and 7
+  PageSet pages(1);
+  PageSet::page_vector range;
+  for (uint64_t i : {1, 2, 5, 7})
+    pages.alloc_range(i, 1, range);
+  range.clear();
+
+  // get the full range
+  pages.get_range(0, 8, range);
+  ASSERT_EQ(4u, range.size());
+  range.clear();
+
+  // free page 7
+  pages.free_pages_after(6);
+  pages.get_range(0, 8, range);
+  ASSERT_EQ(3u, range.size());
+  range.clear();
+
+  // free page 5
+  pages.free_pages_after(3);
+  pages.get_range(0, 8, range);
+  ASSERT_EQ(2u, range.size());
+  range.clear();
+
+  // free pages 1 and 2
+  pages.free_pages_after(0);
+  pages.get_range(0, 8, range);
+  ASSERT_EQ(0u, range.size());
+}


### PR DESCRIPTION
Replaces MemStore's global apply_lock with new per-Sequencer locks.
Adds finer-grained object locks in order to reduce the scope of the Collection's rwlock.
Introduces PageSet, a tree-based alternative to bufferlist for storing object data.