### PR TITLE
osd: do evict before flush in agent_work

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -10694,8 +10694,8 @@ bool ReplicatedPG::agent_work(int start_max, int agent_flush_quota)
     if (agent_state->evict_mode != TierAgentState::EVICT_MODE_IDLE &&
 	agent_maybe_evict(obc))
       ++started;
-    if (agent_state->flush_mode != TierAgentState::FLUSH_MODE_IDLE &&
-	agent_flush_quota > 0 && agent_maybe_flush(obc)) {
+    else if (agent_state->flush_mode != TierAgentState::FLUSH_MODE_IDLE &&
+             agent_flush_quota > 0 && agent_maybe_flush(obc)) {
       ++started;
       --agent_flush_quota;
     }

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -10691,14 +10691,14 @@ bool ReplicatedPG::agent_work(int start_max, int agent_flush_quota)
       continue;
     }
 
+    if (agent_state->evict_mode != TierAgentState::EVICT_MODE_IDLE &&
+	agent_maybe_evict(obc))
+      ++started;
     if (agent_state->flush_mode != TierAgentState::FLUSH_MODE_IDLE &&
 	agent_flush_quota > 0 && agent_maybe_flush(obc)) {
       ++started;
       --agent_flush_quota;
     }
-    if (agent_state->evict_mode != TierAgentState::EVICT_MODE_IDLE &&
-	agent_maybe_evict(obc))
-      ++started;
     if (started >= start_max) {
       // If finishing early, set "next" to the next object
       if (++p != ls.end())


### PR DESCRIPTION
This is to avoid the extreme case that the agent continuously does
flush, but not evict. This may lead to the cache pool to be full.