### PR TITLE
Jemalloc/tcmalloc build option for librbd and librados

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -218,6 +218,8 @@ LIBMON += -ljemalloc
 LIBOSD += -ljemalloc
 LIBMDS += -ljemalloc
 LIBRGW += -ljemalloc
+LIBRBD += -ljemalloc
+LIBRADOS += -ljemalloc
 endif # WITH_JEMALLOC
 
 if ENABLE_COVERAGE

--- a/src/librados/Makefile.am
+++ b/src/librados/Makefile.am
@@ -38,6 +38,10 @@ if WITH_JEMALLOC
 librados_la_LDFLAGS += -ljemalloc
 endif
 
+if WITH_TCMALLOC
+librados_la_LDFLAGS += -ltcmalloc
+endif
+
 lib_LTLIBRARIES += librados.la
 
 noinst_HEADERS += \

--- a/src/librados/Makefile.am
+++ b/src/librados/Makefile.am
@@ -33,6 +33,11 @@ if LINUX
 librados_la_CXXFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
 librados_la_LDFLAGS += -Xcompiler -Xlinker -Xcompiler '--exclude-libs=ALL'
 endif
+
+if WITH_JEMALLOC
+librados_la_LDFLAGS += -ljemalloc
+endif
+
 lib_LTLIBRARIES += librados.la
 
 noinst_HEADERS += \

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -48,6 +48,11 @@ if LINUX
 librbd_la_CXXFLAGS = -fvisibility=hidden -fvisibility-inlines-hidden
 librbd_la_LDFLAGS += -Xcompiler -Xlinker -Xcompiler '--exclude-libs=ALL'
 endif
+
+if WITH_JEMALLOC
+librbd_la_LDFLAGS += -ljemalloc
+endif
+
 lib_LTLIBRARIES += librbd.la
 
 noinst_HEADERS += \

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -53,6 +53,10 @@ if WITH_JEMALLOC
 librbd_la_LDFLAGS += -ljemalloc
 endif
 
+if WITH_TCMALLOC
+librbd_la_LDFLAGS += -ltcmalloc
+endif
+
 lib_LTLIBRARIES += librbd.la
 
 noinst_HEADERS += \


### PR DESCRIPTION
Currently librados and librbd is not built with jemalloc, or tcmalloc even when build with tcmalloc is enabled.

The changes should build both with libs with tcmalloc as default(if tcmalloc is available) and with jemalloc if specified in config options