### PR TITLE
Avoid cache pollution by rbd export etc v2

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8679,6 +8679,15 @@ int OSD::init_op_flags(OpRequestRef& op)
       }
       break;
 
+    case CEPH_OSD_OP_READ:
+    case CEPH_OSD_OP_SYNC_READ:
+    case CEPH_OSD_OP_SPARSE_READ:
+      if (m->ops.size() == 1 &&
+          (iter->op.flags & CEPH_OSD_OP_FLAG_FADVISE_NOCACHE ||
+           iter->op.flags & CEPH_OSD_OP_FLAG_FADVISE_DONTNEED)) {
+        op->set_skip_promote();
+      }
+      break;
     default:
       break;
     }

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1954,9 +1954,12 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
       }
 
       // Promote too?
-      bool promoted = maybe_promote(obc, missing_oid, oloc, in_hit_set,
-	                            pool.info.min_read_recency_for_promote,
-				    promote_op);
+      bool promoted = false;
+      if (!op->need_skip_promote()) {
+        promoted = maybe_promote(obc, missing_oid, oloc, in_hit_set,
+                                 pool.info.min_read_recency_for_promote,
+                                 promote_op);
+      }
       if (!promoted && !can_proxy_read) {
 	// redirect the op if it's not proxied and not promoting
 	do_cache_redirect(op);


### PR DESCRIPTION
This patch allows one-time read operations, for example, rbd export, to bypass cache to avoid cache pollution.
