### PR TITLE
osd: try evicting after flushing is done

### DIFF
--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -934,7 +934,7 @@ protected:
   }
   bool agent_work(int max, int agent_flush_quota);
   bool agent_maybe_flush(ObjectContextRef& obc);  ///< maybe flush
-  bool agent_maybe_evict(ObjectContextRef& obc);  ///< maybe evict
+  bool agent_maybe_evict(ObjectContextRef& obc, bool after_flush);  ///< maybe evict
 
   void agent_load_hit_sets();  ///< load HitSets, if needed
 


### PR DESCRIPTION
When the evict mode is not idle, after successfully flushing an object
to the base pool, we can try to evict it. We don't need to clear the
dirty bit in this case.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>