### PR TITLE
ceph-rest-api: add --readonly switch

### DIFF
--- a/src/ceph-rest-api
+++ b/src/ceph-rest-api
@@ -34,6 +34,7 @@ def parse_args():
     parser.add_argument('--cluster', help='Ceph cluster name')
     parser.add_argument('-n', '--name', help='Ceph client name')
     parser.add_argument('-i', '--id', help='Ceph client id')
+    parser.add_argument('--readonly', action='store_true', help='Only allow readonly commands')
 
     return parser.parse_known_args()
 
@@ -56,6 +57,7 @@ app = ceph_rest_api.generate_app(
     parsed_args.cluster,
     parsed_args.name,
     parsed_args.id,
+    parsed_args.readonly,
     rest,
 )
 

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -666,7 +666,7 @@ def parse_funcsig(sig):
     return newsig
 
 
-def parse_json_funcsigs(s, consumer):
+def parse_json_funcsigs(s, consumer, readonly=False):
     """
     A function signature is mostly an array of argdesc; it's represented
     in JSON as
@@ -695,7 +695,8 @@ def parse_json_funcsigs(s, consumer):
     the cluster state perspective), and 'avail' as a hint for
     whether the command should be advertised by CLI, REST, or both.
     If avail does not contain 'consumer', don't include the command
-    in the returned dict.
+    in the returned dict. Optionally filter out wx commands if
+    'readonly' is True.
     """
     try:
         overall = json.loads(s)
@@ -710,6 +711,10 @@ def parse_json_funcsigs(s, consumer):
         # check 'avail' and possibly ignore this command
         if 'avail' in cmd:
             if consumer not in cmd['avail']:
+                continue
+        # filter out w/x cmds if readonly
+        if readonly and 'perm' in cmd:
+            if 'w' in cmd['perm'] or 'x' in cmd['perm']:
                 continue
         # rewrite the 'sig' item with the argdesc-ized version, and...
         cmd['sig'] = parse_funcsig(cmd['sig'])


### PR DESCRIPTION
Add a --readonly switch to ceph-rest-api which filters out all w/x
and osd-specific commands from the API. In particular this makes the
ceph-rest-api usable with a restricted cephx keyring, namely:

[client.restapi]
    key = ...
    caps mon = "allow r"

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>