### PR TITLE
rbd: fix the FTBFS on old boost introduced by 2050d08

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -1357,7 +1357,7 @@ static int do_export_diff(librbd::Image& image, const char *fromsnapname,
   if (fd < 0)
     return -errno;
 
-  BOOST_SCOPE_EXIT(&r, &fd, &path) {
+  BOOST_SCOPE_EXIT((&r) (&fd) (&path)) {
     close(fd);
     if (r < 0 && fd != 1) {
       remove(path);


### PR DESCRIPTION
in boost 1.49, BOOST_SCOPE_EXIT() does not accept capture_tuple,
only `(capture) (capture) ...` is supported.

Signed-off-by: Kefu Chai <kchai@redhat.com>