### PR TITLE
Objecter: pg_interval_t::is_new_interval needs pgid from previous pool

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2481,6 +2481,9 @@ int Objecter::_calc_target(op_target_t *t, epoch_t *last_force_resend,  bool any
   vector<int> up, acting;
   osdmap->pg_to_up_acting_osds(pgid, &up, &up_primary,
 			       &acting, &acting_primary);
+  int prev_pg_num_mask = (1 << pg_pool_t::calc_bits_of(t->pg_num - 1)) - 1;
+  unsigned prev_seed = ceph_stable_mod(pgid.ps(), t->pg_num, prev_pg_num_mask);
+
   if (any_change && pg_interval_t::is_new_interval(
           t->acting_primary,
 	  acting_primary,
@@ -2496,7 +2499,7 @@ int Objecter::_calc_target(op_target_t *t, epoch_t *last_force_resend,  bool any
 	  min_size,
 	  t->pg_num,
 	  pg_num,
-	  pi->raw_pg_to_pg(pgid))) {
+	  pg_t(prev_seed, pgid.pool(), pgid.preferred()))) {
     force_resend = true;
   }
 


### PR DESCRIPTION
When increasing the pg_num of a pool, an assert would fail since the
calculated pgid seed would be for the pool's new pg_num value instead
of the previous pg_num value.

Fixes: #10399
Backport: hammer, giant, firefly
Signed-off-by: Jason Dillaman <dillaman@redhat.com>