### PR TITLE
make EC plugin path static

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -298,7 +298,7 @@ function run_mon() {
         --mon-data-avail-crit=1 \
         --paxos-propose-interval=0.1 \
         --osd-crush-chooseleaf-type=0 \
-        --osd-pool-default-erasure-code-directory=.libs \
+        --erasure-code-dir=.libs \
         --debug-mon 20 \
         --debug-ms 20 \
         --debug-paxos 20 \
@@ -492,7 +492,7 @@ function activate_osd() {
     ceph_args+=" --osd-journal-size=100"
     ceph_args+=" --osd-data=$osd_data"
     ceph_args+=" --chdir="
-    ceph_args+=" --osd-pool-default-erasure-code-directory=.libs"
+    ceph_args+=" --erasure-code-dir=.libs"
     ceph_args+=" --osd-class-dir=.libs"
     ceph_args+=" --run-dir=$dir"
     ceph_args+=" --debug-osd=20"

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -188,12 +188,12 @@ void usage()
 
 int preload_erasure_code()
 {
-  string directory = g_conf->osd_pool_default_erasure_code_directory;
   string plugins = g_conf->osd_erasure_code_plugins;
   stringstream ss;
-  int r = ErasureCodePluginRegistry::instance().preload(plugins,
-							directory,
-							&ss);
+  int r = ErasureCodePluginRegistry::instance().preload(
+    plugins,
+    g_conf->erasure_code_dir,
+    &ss);
   if (r)
     derr << ss.str() << dendl;
   else

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -83,12 +83,12 @@ void usage()
 
 int preload_erasure_code()
 {
-  string directory = g_conf->osd_pool_default_erasure_code_directory;
   string plugins = g_conf->osd_erasure_code_plugins;
   stringstream ss;
-  int r = ErasureCodePluginRegistry::instance().preload(plugins,
-							directory,
-							&ss);
+  int r = ErasureCodePluginRegistry::instance().preload(
+    plugins,
+    g_conf->erasure_code_dir,
+    &ss);
   if (r)
     derr << ss.str() << dendl;
   else

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -35,6 +35,7 @@ OPTION(max_open_files, OPT_LONGLONG, 0)
 OPTION(restapi_log_level, OPT_STR, "") 	// default set by Python code
 OPTION(restapi_base_url, OPT_STR, "")	// "
 OPTION(fatal_signal_handlers, OPT_BOOL, true)
+OPTION(erasure_code_dir, OPT_STR, CEPH_PKGLIBDIR"/erasure-code") // default location for erasure-code plugins
 
 OPTION(log_file, OPT_STR, "/var/log/ceph/$cluster-$name.log") // default changed by common_preinit()
 OPTION(log_max_new, OPT_INT, 1000) // default changed by common_preinit()
@@ -540,7 +541,6 @@ OPTION(osd_pool_default_size, OPT_INT, 3)
 OPTION(osd_pool_default_min_size, OPT_INT, 0)  // 0 means no specific default; ceph will use size-size/2
 OPTION(osd_pool_default_pg_num, OPT_INT, 8) // number of PGs for new pools. Configure in global or mon section of ceph.conf
 OPTION(osd_pool_default_pgp_num, OPT_INT, 8) // number of PGs for placement purposes. Should be equal to pg_num
-OPTION(osd_pool_default_erasure_code_directory, OPT_STR, CEPH_PKGLIBDIR"/erasure-code") // default for the erasure-code-directory=XXX property of osd pool create
 OPTION(osd_pool_default_erasure_code_profile,
        OPT_STR,
        "plugin=jerasure "

--- a/src/erasure-code/ErasureCodePlugin.cc
+++ b/src/erasure-code/ErasureCodePlugin.cc
@@ -84,6 +84,7 @@ ErasureCodePlugin *ErasureCodePluginRegistry::get(const std::string &name)
 }
 
 int ErasureCodePluginRegistry::factory(const std::string &plugin_name,
+				       const std::string &directory,
 				       ErasureCodeProfile &profile,
 				       ErasureCodeInterfaceRef *erasure_code,
 				       ostream *ss)
@@ -94,15 +95,14 @@ int ErasureCodePluginRegistry::factory(const std::string &plugin_name,
     plugin = get(plugin_name);
     if (plugin == 0) {
       loading = true;
-      assert(profile.count("directory") != 0);
-      int r = load(plugin_name, profile.find("directory")->second, &plugin, ss);
+      int r = load(plugin_name, directory, &plugin, ss);
       loading = false;
       if (r != 0)
 	return r;
     }
   }
 
-  int r = plugin->factory(profile, erasure_code, ss);
+  int r = plugin->factory(directory, profile, erasure_code, ss);
   if (r)
     return r;
   if (profile != (*erasure_code)->get_profile()) {

--- a/src/erasure-code/ErasureCodePlugin.h
+++ b/src/erasure-code/ErasureCodePlugin.h
@@ -36,7 +36,8 @@ namespace ceph {
       library(0) {}
     virtual ~ErasureCodePlugin() {}
 
-    virtual int factory(ErasureCodeProfile &profile,
+    virtual int factory(const std::string &directory,
+			ErasureCodeProfile &profile,
                         ErasureCodeInterfaceRef *erasure_code,
 			ostream *ss) = 0;
   };
@@ -58,6 +59,7 @@ namespace ceph {
     }
 
     int factory(const std::string &plugin,
+		const std::string &directory,
 		ErasureCodeProfile &profile,
 		ErasureCodeInterfaceRef *erasure_code,
 		ostream *ss);

--- a/src/erasure-code/isa/ErasureCodePluginIsa.cc
+++ b/src/erasure-code/isa/ErasureCodePluginIsa.cc
@@ -35,7 +35,8 @@ class ErasureCodePluginIsa : public ErasureCodePlugin {
 public:
   ErasureCodeIsaTableCache tcache;
 
-  virtual int factory(ErasureCodeProfile &profile,
+  virtual int factory(const std::string &directory,
+		      ErasureCodeProfile &profile,
                       ErasureCodeInterfaceRef *erasure_code,
                       ostream *ss)
   {

--- a/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
@@ -31,7 +31,8 @@ static ostream& _prefix(std::ostream* _dout)
 
 class ErasureCodePluginJerasure : public ErasureCodePlugin {
 public:
-  virtual int factory(ErasureCodeProfile &profile,
+  virtual int factory(const std::string& directory,
+		      ErasureCodeProfile &profile,
 		      ErasureCodeInterfaceRef *erasure_code,
 		      ostream *ss) {
     ErasureCodeJerasure *interface;

--- a/src/erasure-code/jerasure/ErasureCodePluginSelectJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodePluginSelectJerasure.cc
@@ -54,7 +54,8 @@ static string get_variant() {
 
 class ErasureCodePluginSelectJerasure : public ErasureCodePlugin {
 public:
-  virtual int factory(ErasureCodeProfile &profile,
+  virtual int factory(const std::string &directory,
+		      ErasureCodeProfile &profile,
 		      ErasureCodeInterfaceRef *erasure_code,
 		      ostream *ss) {
     ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
@@ -66,11 +67,13 @@ public:
       dout(10) << "jerasure-variant " 
 	       << profile.find("jerasure-variant")->second << dendl;
       ret = instance.factory(name + "_" + profile.find("jerasure-variant")->second,
+			     directory,
 			     profile, erasure_code, ss);
     } else {
       string variant = get_variant();
       dout(10) << variant << " plugin" << dendl;
-      ret = instance.factory(name + "_" + variant, profile, erasure_code, ss);
+      ret = instance.factory(name + "_" + variant, directory,
+			     profile, erasure_code, ss);
     }
     return ret;
   }

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -225,8 +225,6 @@ int ErasureCodeLrc::layers_init(ostream *ss)
       layer.profile["plugin"] = "jerasure";
     if (layer.profile.find("technique") == layer.profile.end())
       layer.profile["technique"] = "reed_sol_van";
-    if (layer.profile.find("directory") == layer.profile.end())
-      layer.profile["directory"] = directory;
     int err = registry.factory(layer.profile["plugin"],
 			       directory,
 			       layer.profile,
@@ -273,9 +271,6 @@ int ErasureCodeLrc::parse(ErasureCodeProfile &profile,
   int r = ErasureCode::parse(profile, ss);
   if (r)
     return r;
-
-  if (profile.count("directory") != 0)
-    directory = profile.find("directory")->second;
 
   return parse_ruleset(profile, ss);
 }

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -228,6 +228,7 @@ int ErasureCodeLrc::layers_init(ostream *ss)
     if (layer.profile.find("directory") == layer.profile.end())
       layer.profile["directory"] = directory;
     int err = registry.factory(layer.profile["plugin"],
+			       directory,
 			       layer.profile,
 			       &layer.erasure_code,
 			       ss);

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -74,8 +74,9 @@ public:
   };
   vector<Step> ruleset_steps;
 
-  ErasureCodeLrc() :
-    chunk_count(0), data_chunk_count(0), ruleset_root("default")
+  ErasureCodeLrc(const std::string &dir)
+    : directory(dir),
+      chunk_count(0), data_chunk_count(0), ruleset_root("default")
   {
     ruleset_steps.push_back(Step("chooseleaf", "host", 0));
   }

--- a/src/erasure-code/lrc/ErasureCodePluginLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodePluginLrc.cc
@@ -29,11 +29,12 @@
 
 class ErasureCodePluginLrc : public ErasureCodePlugin {
 public:
-  virtual int factory(ErasureCodeProfile &profile,
+  virtual int factory(const std::string &directory,
+		      ErasureCodeProfile &profile,
 		      ErasureCodeInterfaceRef *erasure_code,
 		      ostream *ss) {
     ErasureCodeLrc *interface;
-    interface = new ErasureCodeLrc();
+    interface = new ErasureCodeLrc(directory);
     assert(profile.count("directory") != 0);
     int r = interface->init(profile, ss);
     if (r) {

--- a/src/erasure-code/lrc/ErasureCodePluginLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodePluginLrc.cc
@@ -35,7 +35,6 @@ public:
 		      ostream *ss) {
     ErasureCodeLrc *interface;
     interface = new ErasureCodeLrc(directory);
-    assert(profile.count("directory") != 0);
     int r = interface->init(profile, ss);
     if (r) {
       delete interface;

--- a/src/erasure-code/shec/ErasureCodePluginSelectShec.cc
+++ b/src/erasure-code/shec/ErasureCodePluginSelectShec.cc
@@ -58,7 +58,8 @@ static string get_variant() {
 
 class ErasureCodePluginSelectShec : public ErasureCodePlugin {
 public:
-  virtual int factory(ErasureCodeProfile &profile,
+  virtual int factory(const std::string &directory,
+		      ErasureCodeProfile &profile,
 		      ErasureCodeInterfaceRef *erasure_code,
 		      ostream *ss) {
     ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
@@ -70,11 +71,13 @@ public:
       dout(10) << "shec-variant "
 	       << profile.find("shec-variant")->second << dendl;
       ret = instance.factory(name + "_" + profile.find("shec-variant")->second,
+			     directory,
 			     profile, erasure_code, ss);
     } else {
       string variant = get_variant();
       dout(10) << variant << " plugin" << dendl;
-      ret = instance.factory(name + "_" + variant, profile, erasure_code, ss);
+      ret = instance.factory(name + "_" + variant, directory,
+			     profile, erasure_code, ss);
     }
     return ret;
   }

--- a/src/erasure-code/shec/ErasureCodePluginShec.cc
+++ b/src/erasure-code/shec/ErasureCodePluginShec.cc
@@ -37,7 +37,8 @@ class ErasureCodePluginShec : public ErasureCodePlugin {
 public:
   ErasureCodeShecTableCache tcache;
 
-  virtual int factory(ErasureCodeProfile &profile,
+  virtual int factory(const std::string &directory,
+		      ErasureCodeProfile &profile,
 		      ErasureCodeInterfaceRef *erasure_code,
 		      ostream *ss) {
     ErasureCodeShec *interface;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3994,7 +3994,9 @@ int OSDMonitor::normalize_profile(ErasureCodeProfile &profile, ostream *ss)
   ErasureCodeInterfaceRef erasure_code;
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeProfile::const_iterator plugin = profile.find("plugin");
-  int err = instance.factory(plugin->second, profile, &erasure_code, ss);
+  int err = instance.factory(plugin->second,
+			     g_conf->erasure_code_dir,
+			     profile, &erasure_code, ss);
   if (err)
     return err;
   return erasure_code->init(profile, ss);
@@ -4054,7 +4056,9 @@ int OSDMonitor::get_erasure_code(const string &erasure_code_profile,
     return -EINVAL;
   }
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
-  return instance.factory(plugin->second, profile, erasure_code, ss);
+  return instance.factory(plugin->second,
+			  g_conf->erasure_code_dir,
+			  profile, erasure_code, ss);
 }
 
 int OSDMonitor::check_cluster_features(uint64_t features,
@@ -4175,7 +4179,7 @@ int OSDMonitor::parse_erasure_code_profile(const vector<string> &erasure_code_pr
 
   if ((*erasure_code_profile_map).count("directory") == 0)
     (*erasure_code_profile_map)["directory"] =
-      g_conf->osd_pool_default_erasure_code_directory;
+      g_conf->erasure_code_dir;
 
   return 0;
 }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4177,10 +4177,6 @@ int OSDMonitor::parse_erasure_code_profile(const vector<string> &erasure_code_pr
   if (user_map.count("plugin") && user_map["plugin"] != default_plugin)
     (*erasure_code_profile_map) = user_map;
 
-  if ((*erasure_code_profile_map).count("directory") == 0)
-    (*erasure_code_profile_map)["directory"] =
-      g_conf->erasure_code_dir;
-
   return 0;
 }
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2719,7 +2719,7 @@ int OSDMap::get_erasure_code_profile_default(CephContext *cct,
 		      *ss,
 		      &profile_map);
   profile_map["directory"] =
-    cct->_conf->osd_pool_default_erasure_code_directory;
+    cct->_conf->erasure_code_dir;
   return r;
 }
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2718,8 +2718,6 @@ int OSDMap::get_erasure_code_profile_default(CephContext *cct,
   int r = get_json_str_map(cct->_conf->osd_pool_default_erasure_code_profile,
 		      *ss,
 		      &profile_map);
-  profile_map["directory"] =
-    cct->_conf->erasure_code_dir;
   return r;
 }
 

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -288,6 +288,7 @@ PGBackend *PGBackend::build_pg_backend(
     stringstream ss;
     ceph::ErasureCodePluginRegistry::instance().factory(
       profile.find("plugin")->second,
+      g_conf->erasure_code_dir,
       profile,
       &ec_impl,
       &ss);

--- a/src/test/ceph-disk.sh
+++ b/src/test/ceph-disk.sh
@@ -46,7 +46,7 @@ CEPH_ARGS+=" --osd-failsafe-full-ratio=.99"
 CEPH_ARGS+=" --mon-host=$MONA"
 CEPH_ARGS+=" --log-file=$DIR/\$name.log"
 CEPH_ARGS+=" --pid-file=$DIR/\$name.pidfile"
-CEPH_ARGS+=" --osd-pool-default-erasure-code-directory=.libs"
+CEPH_ARGS+=" --erasure-code-dir=.libs"
 CEPH_ARGS+=" --auth-supported=none"
 CEPH_ARGS+=" --osd-journal-size=100"
 CEPH_DISK_ARGS=

--- a/src/test/erasure-code/ErasureCodePluginExample.cc
+++ b/src/test/erasure-code/ErasureCodePluginExample.cc
@@ -23,7 +23,8 @@
 
 class ErasureCodePluginExample : public ErasureCodePlugin {
 public:
-  virtual int factory(ErasureCodeProfile &profile,
+  virtual int factory(const std::string &directory,
+		      ErasureCodeProfile &profile,
                       ErasureCodeInterfaceRef *erasure_code,
 		      ostream *ss)
   {

--- a/src/test/erasure-code/TestErasureCode.cc
+++ b/src/test/erasure-code/TestErasureCode.cc
@@ -20,6 +20,7 @@
 #include "erasure-code/ErasureCode.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
+#include "common/config.h"
 #include "gtest/gtest.h"
 
 class ErasureCodeTest : public ErasureCode {
@@ -158,6 +159,8 @@ int main(int argc, char **argv)
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
+
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/erasure-code/TestErasureCodeExample.cc
+++ b/src/test/erasure-code/TestErasureCodeExample.cc
@@ -240,6 +240,8 @@ int main(int argc, char **argv) {
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
+
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -24,6 +24,7 @@
 #include "erasure-code/isa/xor_op.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
+#include "common/config.h"
 #include "gtest/gtest.h"
 
 ErasureCodeIsaTableCache tcache;
@@ -960,6 +961,8 @@ int main(int argc, char **argv)
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
+
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/erasure-code/TestErasureCodeJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodeJerasure.cc
@@ -23,6 +23,7 @@
 #include "erasure-code/jerasure/ErasureCodeJerasure.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
+#include "common/config.h"
 #include "gtest/gtest.h"
 
 template <typename T>
@@ -362,6 +363,8 @@ int main(int argc, char **argv)
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
+
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -351,7 +351,6 @@ TEST(ErasureCodeLrc, layers_sanity_checks)
     ErasureCodeProfile profile;
     profile["mapping"] =
 	    "__DDD__DD";
-    profile["directory"] = ".libs";
     const char *description_string =
       "[ "
       "  [ \"_cDDD_cDD\", \"\" ],"
@@ -383,7 +382,6 @@ TEST(ErasureCodeLrc, layers_sanity_checks)
   {
     ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
-    profile["directory"] = ".libs";
     profile["mapping"] =
 	    "DD";
     const char *description_string =
@@ -408,7 +406,6 @@ TEST(ErasureCodeLrc, layers_init)
       "  [ \"_cDDD_cDD_\", \"directory=.libs\" ],"
       "]";
     profile["layers"] = description_string;
-    profile["directory"] = ".libs";
     json_spirit::mArray description;
     EXPECT_EQ(0, lrc.layers_description(profile, &description, &cerr));
     EXPECT_EQ(0, lrc.layers_parse(description_string, description, &cerr));
@@ -433,7 +430,6 @@ TEST(ErasureCodeLrc, init)
     "  [ \"_____cDDD\", \"\" ],"
     "]";
   profile["layers"] = description_string;
-  profile["directory"] = ".libs";
   EXPECT_EQ(0, lrc.init(profile, &cerr));
 }
 
@@ -444,7 +440,6 @@ TEST(ErasureCodeLrc, init_kml)
   profile["k"] = "4";
   profile["m"] = "2";
   profile["l"] = "3";
-  profile["directory"] = ".libs";
   EXPECT_EQ(0, lrc.init(profile, &cerr));
   EXPECT_EQ((unsigned int)(4 + 2 + (4 + 2) / 3), lrc.get_chunk_count());
 }
@@ -464,7 +459,6 @@ TEST(ErasureCodeLrc, minimum_to_decode)
       "  [ \"_____cDDD\", \"\" ],"
       "]";
     profile["layers"] = description_string;
-    profile["directory"] = ".libs";
     EXPECT_EQ(0, lrc.init(profile, &cerr));
     set<int> want_to_read;
     want_to_read.insert(1);
@@ -489,7 +483,6 @@ TEST(ErasureCodeLrc, minimum_to_decode)
       "  [ \"_____DDDDc\", \"\" ],"
       "]";
     profile["layers"] = description_string;
-    profile["directory"] = ".libs";
     EXPECT_EQ(0, lrc.init(profile, &cerr));
     EXPECT_EQ(profile["mapping"].length(),
 	      lrc.get_chunk_count());
@@ -539,7 +532,6 @@ TEST(ErasureCodeLrc, minimum_to_decode)
       "  [ \"_____cDDD\", \"\" ],"
       "]";
     profile["layers"] = description_string;
-    profile["directory"] = ".libs";
     EXPECT_EQ(0, lrc.init(profile, &cerr));
     EXPECT_EQ(profile["mapping"].length(),
 	      lrc.get_chunk_count());
@@ -618,7 +610,6 @@ TEST(ErasureCodeLrc, encode_decode)
     "  [ \"____cDDD\", \"\" ]," // second local layer
     "]";
   profile["layers"] = description_string;
-  profile["directory"] = ".libs";
   EXPECT_EQ(0, lrc.init(profile, &cerr));
   EXPECT_EQ(4U, lrc.get_data_chunk_count());
   unsigned int stripe_width = g_conf->osd_pool_erasure_code_stripe_width;
@@ -749,7 +740,6 @@ TEST(ErasureCodeLrc, encode_decode_2)
     " [ \"____DDDc\", \"\" ],"
     "]";
   profile["layers"] = description_string;
-  profile["directory"] = ".libs";
   EXPECT_EQ(0, lrc.init(profile, &cerr));
   EXPECT_EQ(4U, lrc.get_data_chunk_count());
   unsigned int stripe_width = g_conf->osd_pool_erasure_code_stripe_width;

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -24,11 +24,12 @@
 #include "erasure-code/lrc/ErasureCodeLrc.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
+#include "common/config.h"
 #include "gtest/gtest.h"
 
 TEST(ErasureCodeLrc, parse_ruleset)
 {
-  ErasureCodeLrc lrc;
+  ErasureCodeLrc lrc(g_conf->erasure_code_dir);
   EXPECT_EQ("default", lrc.ruleset_root);
   EXPECT_EQ("host", lrc.ruleset_steps.front().type);
 
@@ -128,7 +129,7 @@ TEST(ErasureCodeTest, create_ruleset)
     }
   }
 
-  ErasureCodeLrc lrc;
+  ErasureCodeLrc lrc(g_conf->erasure_code_dir);
   EXPECT_EQ(0, lrc.create_ruleset("rule1", *c, &cerr));
 
   ErasureCodeProfile profile;
@@ -169,7 +170,7 @@ TEST(ErasureCodeTest, create_ruleset)
 
 TEST(ErasureCodeLrc, parse_kml)
 {
-  ErasureCodeLrc lrc;
+  ErasureCodeLrc lrc(g_conf->erasure_code_dir);
   ErasureCodeProfile profile;
   EXPECT_EQ(0, lrc.parse_kml(profile, &cerr));
   profile["k"] = "4";
@@ -244,7 +245,7 @@ TEST(ErasureCodeLrc, parse_kml)
 
 TEST(ErasureCodeLrc, layers_description)
 {
-  ErasureCodeLrc lrc;
+  ErasureCodeLrc lrc(g_conf->erasure_code_dir);
   ErasureCodeProfile profile;
 
   json_spirit::mArray description;
@@ -273,7 +274,7 @@ TEST(ErasureCodeLrc, layers_description)
 TEST(ErasureCodeLrc, layers_parse)
 {
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
 
     const char *description_string ="[ 0 ]";
@@ -285,7 +286,7 @@ TEST(ErasureCodeLrc, layers_parse)
   }
 
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
 
     const char *description_string ="[ [ 0 ] ]";
@@ -297,7 +298,7 @@ TEST(ErasureCodeLrc, layers_parse)
   }
 
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
 
     const char *description_string ="[ [ \"\", 0 ] ]";
@@ -313,7 +314,7 @@ TEST(ErasureCodeLrc, layers_parse)
   // profile.
   //
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
 
     const char *description_string ="[ [ \"\", { \"a\": \"b\" }, \"ignored\" ] ]";
@@ -329,7 +330,7 @@ TEST(ErasureCodeLrc, layers_parse)
   // profile.
   //
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
 
     const char *description_string ="[ [ \"\", \"a=b c=d\" ] ]";
@@ -346,7 +347,7 @@ TEST(ErasureCodeLrc, layers_parse)
 TEST(ErasureCodeLrc, layers_sanity_checks)
 {
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
     profile["mapping"] =
 	    "__DDD__DD";
@@ -361,7 +362,7 @@ TEST(ErasureCodeLrc, layers_sanity_checks)
     EXPECT_EQ(0, lrc.init(profile, &cerr));
   }
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
     const char *description_string =
       "[ "
@@ -370,7 +371,7 @@ TEST(ErasureCodeLrc, layers_sanity_checks)
     EXPECT_EQ(ERROR_LRC_MAPPING, lrc.init(profile, &cerr));
   }
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
     profile["mapping"] = "";
     const char *description_string =
@@ -380,7 +381,7 @@ TEST(ErasureCodeLrc, layers_sanity_checks)
     EXPECT_EQ(ERROR_LRC_LAYERS_COUNT, lrc.init(profile, &cerr));
   }
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
     profile["directory"] = ".libs";
     profile["mapping"] =
@@ -399,7 +400,7 @@ TEST(ErasureCodeLrc, layers_sanity_checks)
 TEST(ErasureCodeLrc, layers_init)
 {
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
 
     const char *description_string =
@@ -421,7 +422,7 @@ TEST(ErasureCodeLrc, layers_init)
 
 TEST(ErasureCodeLrc, init)
 {
-  ErasureCodeLrc lrc;
+  ErasureCodeLrc lrc(g_conf->erasure_code_dir);
   ErasureCodeProfile profile;
   profile["mapping"] =
     "__DDD__DD";
@@ -438,7 +439,7 @@ TEST(ErasureCodeLrc, init)
 
 TEST(ErasureCodeLrc, init_kml)
 {
-  ErasureCodeLrc lrc;
+  ErasureCodeLrc lrc(g_conf->erasure_code_dir);
   ErasureCodeProfile profile;
   profile["k"] = "4";
   profile["m"] = "2";
@@ -452,7 +453,7 @@ TEST(ErasureCodeLrc, minimum_to_decode)
 {
   // trivial : no erasures, the minimum is want_to_read
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
     profile["mapping"] =
       "__DDD__DD";
@@ -476,7 +477,7 @@ TEST(ErasureCodeLrc, minimum_to_decode)
   }
   // locally repairable erasure
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
     profile["mapping"] =
 	    "__DDD__DD_";
@@ -527,7 +528,7 @@ TEST(ErasureCodeLrc, minimum_to_decode)
   }
   // implicit parity required
   {
-    ErasureCodeLrc lrc;
+    ErasureCodeLrc lrc(g_conf->erasure_code_dir);
     ErasureCodeProfile profile;
     profile["mapping"] =
 	    "__DDD__DD";
@@ -606,7 +607,7 @@ TEST(ErasureCodeLrc, minimum_to_decode)
 
 TEST(ErasureCodeLrc, encode_decode)
 {
-  ErasureCodeLrc lrc;
+  ErasureCodeLrc lrc(g_conf->erasure_code_dir);
   ErasureCodeProfile profile;
   profile["mapping"] =
     "__DD__DD";
@@ -737,7 +738,7 @@ TEST(ErasureCodeLrc, encode_decode)
 
 TEST(ErasureCodeLrc, encode_decode_2)
 {
-  ErasureCodeLrc lrc;
+  ErasureCodeLrc lrc(g_conf->erasure_code_dir);
   ErasureCodeProfile profile;
   profile["mapping"] =
     "DD__DD__";
@@ -921,6 +922,8 @@ int main(int argc, char **argv)
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
+
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/erasure-code/TestErasureCodePlugin.cc
+++ b/src/test/erasure-code/TestErasureCodePlugin.cc
@@ -32,7 +32,6 @@ protected:
   public:
     virtual void *entry() {
       ErasureCodeProfile profile;
-      profile["directory"] = ".libs";
       ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
       ErasureCodeInterfaceRef erasure_code;
       instance.factory("hangs",
@@ -76,7 +75,6 @@ TEST_F(ErasureCodePluginRegistryTest, all)
 {
   ErasureCodeProfile profile;
   string directory(".libs");
-  profile["directory"] = directory;
   ErasureCodeInterfaceRef erasure_code;
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   EXPECT_FALSE(erasure_code);

--- a/src/test/erasure-code/TestErasureCodePlugin.cc
+++ b/src/test/erasure-code/TestErasureCodePlugin.cc
@@ -22,6 +22,7 @@
 #include "erasure-code/ErasureCodePlugin.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
+#include "common/config.h"
 #include "gtest/gtest.h"
 
 class ErasureCodePluginRegistryTest : public ::testing::Test {
@@ -34,7 +35,9 @@ protected:
       profile["directory"] = ".libs";
       ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
       ErasureCodeInterfaceRef erasure_code;
-      instance.factory("hangs", profile, &erasure_code, &cerr);
+      instance.factory("hangs",
+		       g_conf->erasure_code_dir,
+		       profile, &erasure_code, &cerr);
       return NULL;
     }
   };
@@ -77,21 +80,33 @@ TEST_F(ErasureCodePluginRegistryTest, all)
   ErasureCodeInterfaceRef erasure_code;
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-EIO, instance.factory("invalid", profile, &erasure_code, &cerr));
+  EXPECT_EQ(-EIO, instance.factory("invalid",
+				   g_conf->erasure_code_dir,
+				   profile, &erasure_code, &cerr));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-EXDEV, instance.factory("missing_version", profile,
+  EXPECT_EQ(-EXDEV, instance.factory("missing_version",
+				     g_conf->erasure_code_dir,
+				     profile,
 				     &erasure_code, &cerr));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-ENOENT, instance.factory("missing_entry_point", profile,
+  EXPECT_EQ(-ENOENT, instance.factory("missing_entry_point",
+				      g_conf->erasure_code_dir,
+				      profile,
 				      &erasure_code, &cerr));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-ESRCH, instance.factory("fail_to_initialize", profile,
+  EXPECT_EQ(-ESRCH, instance.factory("fail_to_initialize",
+				     g_conf->erasure_code_dir,
+				     profile,
 				     &erasure_code, &cerr));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(-EBADF, instance.factory("fail_to_register", profile,
+  EXPECT_EQ(-EBADF, instance.factory("fail_to_register",
+				     g_conf->erasure_code_dir,
+				     profile,
 				     &erasure_code, &cerr));
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(0, instance.factory("example", profile, &erasure_code, &cerr));
+  EXPECT_EQ(0, instance.factory("example",
+				g_conf->erasure_code_dir,
+				profile, &erasure_code, &cerr));
   EXPECT_TRUE(erasure_code.get());
   ErasureCodePlugin *plugin = 0;
   {
@@ -109,6 +124,8 @@ int main(int argc, char **argv) {
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
+
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/erasure-code/TestErasureCodePluginIsa.cc
+++ b/src/test/erasure-code/TestErasureCodePluginIsa.cc
@@ -19,6 +19,7 @@
 #include "erasure-code/ErasureCodePlugin.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
+#include "common/config.h"
 #include "gtest/gtest.h"
 
 TEST(ErasureCodePlugin, factory)
@@ -29,8 +30,10 @@ TEST(ErasureCodePlugin, factory)
   {
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(-EIO, instance.factory("no-isa", profile,
-                                        &erasure_code, &cerr));
+    EXPECT_EQ(-EIO, instance.factory("no-isa",
+				     g_conf->erasure_code_dir,
+				     profile,
+				     &erasure_code, &cerr));
     EXPECT_FALSE(erasure_code);
   }
   const char *techniques[] = {
@@ -41,7 +44,9 @@ TEST(ErasureCodePlugin, factory)
     ErasureCodeInterfaceRef erasure_code;
     profile["technique"] = *technique;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(0, instance.factory("isa", profile,
+    EXPECT_EQ(0, instance.factory("isa",
+				  g_conf->erasure_code_dir,
+				  profile,
                                   &erasure_code, &cerr));
     EXPECT_TRUE(erasure_code.get());
   }
@@ -54,6 +59,8 @@ int main(int argc, char **argv)
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
+
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/erasure-code/TestErasureCodePluginIsa.cc
+++ b/src/test/erasure-code/TestErasureCodePluginIsa.cc
@@ -26,7 +26,6 @@ TEST(ErasureCodePlugin, factory)
 {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeProfile profile;
-  profile["directory"] = ".libs";
   {
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);

--- a/src/test/erasure-code/TestErasureCodePluginJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodePluginJerasure.cc
@@ -30,7 +30,6 @@ TEST(ErasureCodePlugin, factory)
 {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeProfile profile;
-  profile["directory"] = ".libs";
   {
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
@@ -53,7 +52,6 @@ TEST(ErasureCodePlugin, factory)
   for(const char **technique = techniques; *technique; technique++) {
     ErasureCodeInterfaceRef erasure_code;
     ErasureCodeProfile profile;
-    profile["directory"] = ".libs";
     profile["technique"] = *technique;
     EXPECT_FALSE(erasure_code);
     EXPECT_EQ(0, instance.factory("jerasure",
@@ -81,7 +79,6 @@ TEST(ErasureCodePlugin, select)
   // load test plugins instead of actual plugins to assert the desired side effect
   // happens
   profile["jerasure-name"] = "test_jerasure";
-  profile["directory"] = ".libs";
   profile["technique"] = "reed_sol_van";
 
   // all features are available, load the SSE4 plugin
@@ -200,7 +197,6 @@ TEST(ErasureCodePlugin, sse)
 
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeProfile profile;
-  profile["directory"] = ".libs";
   profile["technique"] = "reed_sol_van";
   profile["k"] = "2";
   profile["m"] = "1";

--- a/src/test/erasure-code/TestErasureCodePluginJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodePluginJerasure.cc
@@ -23,6 +23,7 @@
 #include "erasure-code/ErasureCodePlugin.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
+#include "common/config.h"
 #include "gtest/gtest.h"
 
 TEST(ErasureCodePlugin, factory)
@@ -33,7 +34,9 @@ TEST(ErasureCodePlugin, factory)
   {
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(-ENOENT, instance.factory("jerasure", profile,
+    EXPECT_EQ(-ENOENT, instance.factory("jerasure",
+					g_conf->erasure_code_dir,
+					profile,
                                         &erasure_code, &cerr));
     EXPECT_FALSE(erasure_code);
   }
@@ -53,7 +56,9 @@ TEST(ErasureCodePlugin, factory)
     profile["directory"] = ".libs";
     profile["technique"] = *technique;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(0, instance.factory("jerasure", profile,
+    EXPECT_EQ(0, instance.factory("jerasure",
+				  g_conf->erasure_code_dir,
+				  profile,
                                   &erasure_code, &cerr));
     EXPECT_TRUE(erasure_code.get());
   }
@@ -91,7 +96,9 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int sse4_side_effect = -444;
-    EXPECT_EQ(sse4_side_effect, instance.factory("jerasure", profile,
+    EXPECT_EQ(sse4_side_effect, instance.factory("jerasure",
+						 g_conf->erasure_code_dir,
+						 profile,
                                                  &erasure_code, &cerr));
   }
   // pclmul is missing, load the SSE3 plugin
@@ -106,7 +113,9 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int sse3_side_effect = -333;
-    EXPECT_EQ(sse3_side_effect, instance.factory("jerasure", profile,
+    EXPECT_EQ(sse3_side_effect, instance.factory("jerasure",
+						 g_conf->erasure_code_dir,
+						 profile,
                                                  &erasure_code, &cerr));
   }
   // pclmul and sse3 are missing, load the generic plugin
@@ -121,7 +130,9 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int generic_side_effect = -111;
-    EXPECT_EQ(generic_side_effect, instance.factory("jerasure", profile,
+    EXPECT_EQ(generic_side_effect, instance.factory("jerasure",
+						    g_conf->erasure_code_dir,
+						    profile,
 						    &erasure_code, &cerr));
   }
   // neon is set, load the neon plugin
@@ -136,7 +147,9 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int generic_side_effect = -555;
-    EXPECT_EQ(generic_side_effect, instance.factory("jerasure", profile,
+    EXPECT_EQ(generic_side_effect, instance.factory("jerasure",
+						    g_conf->erasure_code_dir,
+						    profile,
 						    &erasure_code, &cerr));
   }
 
@@ -199,7 +212,9 @@ TEST(ErasureCodePlugin, sse)
     //
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(0, instance.factory("jerasure_" + *sse_variant, profile,
+    EXPECT_EQ(0, instance.factory("jerasure_" + *sse_variant,
+				  g_conf->erasure_code_dir,
+				  profile,
                                   &erasure_code, &cerr));
     EXPECT_TRUE(erasure_code.get());
 
@@ -244,6 +259,8 @@ int main(int argc, char **argv)
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
+
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/erasure-code/TestErasureCodePluginLrc.cc
+++ b/src/test/erasure-code/TestErasureCodePluginLrc.cc
@@ -22,6 +22,7 @@
 #include "erasure-code/ErasureCodePlugin.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
+#include "common/config.h"
 #include "gtest/gtest.h"
 
 TEST(ErasureCodePlugin, factory)
@@ -33,7 +34,9 @@ TEST(ErasureCodePlugin, factory)
   profile["layers"] = "[ [ \"DDc\", \"\" ] ]";
   ErasureCodeInterfaceRef erasure_code;
   EXPECT_FALSE(erasure_code);
-  EXPECT_EQ(0, instance.factory("lrc", profile, &erasure_code, &cerr));
+  EXPECT_EQ(0, instance.factory("lrc",
+				g_conf->erasure_code_dir,
+				profile, &erasure_code, &cerr));
   EXPECT_TRUE(erasure_code.get());
 }
 
@@ -44,6 +47,8 @@ int main(int argc, char **argv)
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
+
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/erasure-code/TestErasureCodePluginLrc.cc
+++ b/src/test/erasure-code/TestErasureCodePluginLrc.cc
@@ -29,7 +29,6 @@ TEST(ErasureCodePlugin, factory)
 {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeProfile profile;
-  profile["directory"] = ".libs";
   profile["mapping"] = "DD_";
   profile["layers"] = "[ [ \"DDc\", \"\" ] ]";
   ErasureCodeInterfaceRef erasure_code;

--- a/src/test/erasure-code/TestErasureCodePluginShec.cc
+++ b/src/test/erasure-code/TestErasureCodePluginShec.cc
@@ -31,7 +31,6 @@ TEST(ErasureCodePlugin, factory)
 {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   map<std::string,std::string> profile;
-  profile["directory"] = ".libs";
   {
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
@@ -48,7 +47,6 @@ TEST(ErasureCodePlugin, factory)
   };
   for(const char **technique = techniques; *technique; technique++) {
     ErasureCodeInterfaceRef erasure_code;
-    profile["directory"] = ".libs";
     profile["technique"] = *technique;
     EXPECT_FALSE(erasure_code);
     EXPECT_EQ(0, instance.factory("shec",
@@ -76,7 +74,6 @@ TEST(ErasureCodePlugin, select)
   // load test plugins instead of actual plugins to assert the desired side effect
   // happens
   profile["shec-name"] = "test_shec";
-  profile["directory"] = ".libs";
   profile["technique"] = "multiple";
 
   // all features are available, load the SSE4 plugin
@@ -195,7 +192,6 @@ TEST(ErasureCodePlugin, sse)
 
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   map<std::string,std::string> profile;
-  profile["directory"] = ".libs";
   profile["technique"] = "multiple";
   profile["k"] = "2";
   profile["m"] = "1";

--- a/src/test/erasure-code/TestErasureCodePluginShec.cc
+++ b/src/test/erasure-code/TestErasureCodePluginShec.cc
@@ -24,6 +24,7 @@
 #include "erasure-code/ErasureCodePlugin.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
+#include "common/config.h"
 #include "gtest/gtest.h"
 
 TEST(ErasureCodePlugin, factory)
@@ -34,8 +35,10 @@ TEST(ErasureCodePlugin, factory)
   {
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(0, instance.factory("shec", profile,
-                                        &erasure_code, &cerr));
+    EXPECT_EQ(0, instance.factory("shec",
+				  g_conf->erasure_code_dir,
+				  profile,
+				  &erasure_code, &cerr));
     EXPECT_TRUE(erasure_code.get());
   }
   const char *techniques[] = {
@@ -48,7 +51,9 @@ TEST(ErasureCodePlugin, factory)
     profile["directory"] = ".libs";
     profile["technique"] = *technique;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(0, instance.factory("shec", profile,
+    EXPECT_EQ(0, instance.factory("shec",
+				  g_conf->erasure_code_dir,
+				  profile,
                                   &erasure_code, &cerr));
     EXPECT_TRUE(erasure_code.get());
   }
@@ -86,7 +91,9 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int sse4_side_effect = -444;
-    EXPECT_EQ(sse4_side_effect, instance.factory("shec", profile,
+    EXPECT_EQ(sse4_side_effect, instance.factory("shec",
+						 g_conf->erasure_code_dir,
+						 profile,
                                                  &erasure_code, &cerr));
   }
   // pclmul is missing, load the SSE3 plugin
@@ -101,7 +108,9 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int sse3_side_effect = -333;
-    EXPECT_EQ(sse3_side_effect, instance.factory("shec", profile,
+    EXPECT_EQ(sse3_side_effect, instance.factory("shec",
+						 g_conf->erasure_code_dir,
+						 profile,
                                                  &erasure_code, &cerr));
   }
   // pclmul and sse3 are missing, load the generic plugin
@@ -116,7 +125,9 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int generic_side_effect = -111;
-    EXPECT_EQ(generic_side_effect, instance.factory("shec", profile,
+    EXPECT_EQ(generic_side_effect, instance.factory("shec",
+						    g_conf->erasure_code_dir,
+						    profile,
 						    &erasure_code, &cerr));
   }
   // neon is set, load the neon plugin
@@ -131,7 +142,9 @@ TEST(ErasureCodePlugin, select)
 
     ErasureCodeInterfaceRef erasure_code;
     int generic_side_effect = -555;
-    EXPECT_EQ(generic_side_effect, instance.factory("shec", profile,
+    EXPECT_EQ(generic_side_effect, instance.factory("shec",
+						    g_conf->erasure_code_dir,
+						    profile,
 						    &erasure_code, &cerr));
   }
 
@@ -195,7 +208,9 @@ TEST(ErasureCodePlugin, sse)
     //
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
-    EXPECT_EQ(0, instance.factory("shec_" + *sse_variant, profile,
+    EXPECT_EQ(0, instance.factory("shec_" + *sse_variant,
+				  g_conf->erasure_code_dir,
+				  profile,
                                   &erasure_code, &cerr));
     EXPECT_TRUE(erasure_code.get());
 
@@ -240,6 +255,8 @@ int main(int argc, char **argv)
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
+
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/erasure-code/TestErasureCodeShec.cc
+++ b/src/test/erasure-code/TestErasureCodeShec.cc
@@ -49,7 +49,6 @@ TEST(ErasureCodeShec, init_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["directory"] = "/usr/lib64/ceph/erasure-code";
   (*profile)["ruleset-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
@@ -249,7 +248,6 @@ TEST(ErasureCodeShec, init_8)
 				  ErasureCodeShec::MULTIPLE);
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
-  (*profile)["directory"] = "/usr/lib64/";	//unexpected value
   (*profile)["technique"] = "";
   (*profile)["ruleset-failure-domain"] = "osd";
   (*profile)["k"] = "4";

--- a/src/test/erasure-code/TestErasureCodeShec.cc
+++ b/src/test/erasure-code/TestErasureCodeShec.cc
@@ -2676,6 +2676,8 @@ int main(int argc, char **argv)
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
+
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/test/erasure-code/TestErasureCodeShec_all.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_all.cc
@@ -76,7 +76,6 @@ TEST_P(ParameterTest, parameter_all)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["directory"] = "/usr/lib64/ceph/erasure-code";
   (*profile)["ruleset-failure-domain"] = "osd";
   (*profile)["k"] = k;
   (*profile)["m"] = m;

--- a/src/test/erasure-code/TestErasureCodeShec_all.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_all.cc
@@ -297,6 +297,8 @@ int main(int argc, char **argv)
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
+
   ::testing::InitGoogleTest(&argc, argv);
 
   r = RUN_ALL_TESTS();

--- a/src/test/erasure-code/TestErasureCodeShec_arguments.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_arguments.cc
@@ -396,6 +396,8 @@ int main(int argc, char **argv)
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
+
   ::testing::InitGoogleTest(&argc, argv);
 
   create_table_shec432();

--- a/src/test/erasure-code/TestErasureCodeShec_arguments.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_arguments.cc
@@ -188,7 +188,6 @@ TEST(ParameterTest, combination_all)
 							 std::string>();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["directory"] = "/usr/lib64/ceph/erasure-code";
   (*profile)["ruleset-failure-domain"] = "osd";
   (*profile)["k"] = k;
   (*profile)["m"] = m;

--- a/src/test/erasure-code/TestErasureCodeShec_thread.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_thread.cc
@@ -93,6 +93,8 @@ int main(int argc, char **argv)
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
+
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/test/erasure-code/ceph_erasure_code.cc
+++ b/src/test/erasure-code/ceph_erasure_code.cc
@@ -110,9 +110,6 @@ int ErasureCodeCommand::setup(int argc, char** argv) {
     }
   }
 
-  if (profile.count("directory") == 0)
-    profile["directory"] = ".libs";
-
   return 0;
 }
 

--- a/src/test/erasure-code/ceph_erasure_code.cc
+++ b/src/test/erasure-code/ceph_erasure_code.cc
@@ -128,7 +128,8 @@ int ErasureCodeCommand::plugin_exists() {
   ErasureCodePlugin *plugin = 0;
   Mutex::Locker l(instance.lock);
   stringstream ss;
-  int code = instance.load(vm["plugin_exists"].as<string>(), profile["directory"], &plugin, &ss);
+  int code = instance.load(vm["plugin_exists"].as<string>(),
+			   g_conf->erasure_code_dir, &plugin, &ss);
   if (code)
     cerr << ss.str() << endl;
   return code;
@@ -144,6 +145,7 @@ int ErasureCodeCommand::display_information() {
   }
 
   int code = instance.factory(profile["plugin"],
+			      g_conf->erasure_code_dir,
 			      profile,
 			      &erasure_code, &cerr);
   if (code)

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -108,9 +108,6 @@ int ErasureCodeBench::setup(int argc, char** argv) {
     }
   }
 
-  if (profile.count("directory") == 0)
-    profile["directory"] = ".libs";
-
   in_size = vm["size"].as<int>();
   max_iterations = vm["iterations"].as<int>();
   plugin = vm["plugin"].as<string>();

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -155,7 +155,9 @@ int ErasureCodeBench::encode()
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeInterfaceRef erasure_code;
   stringstream messages;
-  int code = instance.factory(plugin, profile, &erasure_code, &messages);
+  int code = instance.factory(plugin,
+			      g_conf->erasure_code_dir,
+			      profile, &erasure_code, &messages);
   if (code) {
     cerr << messages.str() << endl;
     return code;
@@ -257,7 +259,9 @@ int ErasureCodeBench::decode()
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeInterfaceRef erasure_code;
   stringstream messages;
-  int code = instance.factory(plugin, profile, &erasure_code, &messages);
+  int code = instance.factory(plugin,
+			      g_conf->erasure_code_dir,
+			      profile, &erasure_code, &messages);
   if (code) {
     cerr << messages.str() << endl;
     return code;

--- a/src/test/erasure-code/ceph_erasure_code_non_regression.cc
+++ b/src/test/erasure-code/ceph_erasure_code_non_regression.cc
@@ -136,16 +136,12 @@ int ErasureCodeNonRegression::setup(int argc, char** argv) {
       } else {
 	profile[strs[0]] = strs[1];
       }
-      if (strs[0] != "directory")
-	directory += " " + *i;
+      directory += " " + *i;
     }
   }
 
   if (vm.count("path"))
     directory = vm["path"].as<string>();
-
-  if (profile.count("directory") == 0)
-    profile["directory"] = ".libs";
 
   return 0;
 }

--- a/src/test/erasure-code/ceph_erasure_code_non_regression.cc
+++ b/src/test/erasure-code/ceph_erasure_code_non_regression.cc
@@ -99,6 +99,7 @@ int ErasureCodeNonRegression::setup(int argc, char** argv) {
     CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);
   g_ceph_context->_conf->apply_changes(NULL);
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   if (vm.count("help")) {
     cout << desc << std::endl;
@@ -172,7 +173,9 @@ int ErasureCodeNonRegression::run_create()
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeInterfaceRef erasure_code;
   stringstream messages;
-  int code = instance.factory(plugin, profile, &erasure_code, &messages);
+  int code = instance.factory(plugin,
+			      g_conf->erasure_code_dir,
+			      profile, &erasure_code, &messages);
   if (code) {
     cerr << messages.str() << endl;
     return code;
@@ -242,7 +245,9 @@ int ErasureCodeNonRegression::run_check()
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   ErasureCodeInterfaceRef erasure_code;
   stringstream messages;
-  int code = instance.factory(plugin, profile, &erasure_code, &messages);
+  int code = instance.factory(plugin,
+			      g_conf->erasure_code_dir,
+			      profile, &erasure_code, &messages);
   if (code) {
     cerr << messages.str() << endl;
     return code;

--- a/src/test/mon/mkfs.sh
+++ b/src/test/mon/mkfs.sh
@@ -42,7 +42,7 @@ function mon_mkfs() {
     ./ceph-mon \
         --id $MON_ID \
         --fsid $fsid \
-        --osd-pool-default-erasure-code-directory=.libs \
+        --erasure-code-dir=.libs \
         --mkfs \
         --mon-data=$MON_DIR \
         --mon-initial-members=$MON_ID \
@@ -56,7 +56,7 @@ function mon_run() {
         --chdir= \
         --mon-osd-full-ratio=.99 \
         --mon-data-avail-crit=1 \
-        --osd-pool-default-erasure-code-directory=.libs \
+        --erasure-code-dir=.libs \
         --mon-data=$MON_DIR \
         --log-file=$MON_DIR/log \
         --mon-cluster-log-file=$MON_DIR/log \
@@ -83,7 +83,7 @@ function auth_none() {
         --id $MON_ID \
         --mon-osd-full-ratio=.99 \
         --mon-data-avail-crit=1 \
-        --osd-pool-default-erasure-code-directory=.libs \
+        --erasure-code-dir=.libs \
         --mon-data=$MON_DIR \
         --extract-monmap $MON_DIR/monmap
 
@@ -150,7 +150,7 @@ function makedir() {
         --id $MON_ID \
         --mon-osd-full-ratio=.99 \
         --mon-data-avail-crit=1 \
-        --osd-pool-default-erasure-code-directory=.libs \
+        --erasure-code-dir=.libs \
         --mkfs \
         --mon-data=$toodeep 2>&1 | tee $DIR/makedir.log
     grep 'toodeep.*No such file' $DIR/makedir.log > /dev/null

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -384,7 +384,7 @@ if [ "$start_mon" -eq 1 ]; then
         mon osd full ratio = .99
         mon data avail warn = 10
         mon data avail crit = 1
-        osd pool default erasure code directory = $EC_PATH
+        erasure code dir = $EC_PATH
         osd pool default erasure code profile = plugin=jerasure technique=reed_sol_van k=2 m=1 ruleset-failure-domain=osd
         rgw frontends = fastcgi, civetweb port=$CEPH_RGW_PORT
         rgw dns name = localhost


### PR DESCRIPTION
See bug: http://tracker.ceph.com/issues/12747

I see two options:

1) Make the directory optional.  Backport teh OSD patch that uses the default
path when not specified to hammer along with the batch of stuff we'll require
before an infernalis upgrade, and in infernalis and later leave the directory
blank in new profiles.

2) Drop the profile 'directory' completely and make the OSD *only* look in
the configured (/usr/lib/ceph/erasure-code/*) path.  This is probably okay
anyway since the plugin has to be built at the same time with a matching
ceph version string, so it is highly unlikely we'll have 3rd party plugins
that won't be carefully built/packaged and need a custom per-profile path.

I'm leaning towards 2... much simpler!  We'll still want to do the same
backport dance though so that we can stop putting the directory property
in new profiles immediately.

-> okay, did option 2.