### PR TITLE
rgw [experimental]: rework RGWClientIO in order to unify behaviour between frontends

### DIFF
--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -42,6 +42,11 @@ public:
     return 0;
   }
 
+  int send_content_length(RGWClientIO& controller,
+                          const RGWDynamicLengthMode) override {
+    return 0;
+  }
+
   RGWEnv& get_env() override {
     return env;
   }

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -11,9 +11,10 @@
 struct mg_connection;
 
 
-class RGWMongoose : public RGWClientIO
+class RGWMongoose : public RGWClientIOEngine
 {
-  mg_connection *conn;
+  mg_connection * const conn;
+  RGWEnv env;
 
   int port;
 
@@ -22,19 +23,28 @@ class RGWMongoose : public RGWClientIO
   bool explicit_conn_close;
 
 public:
-  void init_env(CephContext *cct);
-
-  int write_data(const char *buf, int len);
-  int read_data(char *buf, int len);
-
-  int send_status(const char *status, const char *status_name);
-  int send_100_continue();
-  int complete_header();
-  int complete_request();
-  int send_content_length(uint64_t len);
-
   RGWMongoose(mg_connection *_conn, int _port);
-  void flush();
+
+  void init_env(CephContext *cct) override;
+  int write_data(const char *buf, int len) override;
+  int read_data(char *buf, int len) override;
+
+  void flush(RGWClientIO& controller) override;
+  int send_status(RGWClientIO& controller,
+                  const char *status,
+                  const char *status_name) override;
+  int send_100_continue(RGWClientIO& controller) override;
+  int complete_header(RGWClientIO& controller) override;
+  int send_content_length(RGWClientIO& controller,
+                          uint64_t len) override;
+
+  int complete_request(RGWClientIO& controller) override {
+    return 0;
+  }
+
+  RGWEnv& get_env() override {
+    return env;
+  }
 };
 
 

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -15,14 +15,8 @@ class RGWMongoose : public RGWClientIO
 {
   mg_connection *conn;
 
-  bufferlist header_data;
-  bufferlist data;
-
   int port;
 
-  bool header_done;
-  bool sent_header;
-  bool has_content_length;
   bool explicit_keepalive;
   bool explicit_conn_close;
 

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -17,6 +17,7 @@ class RGWMongoose : public RGWClientIO
 
   int port;
 
+  bool has_content_length;
   bool explicit_keepalive;
   bool explicit_conn_close;
 

--- a/src/rgw/rgw_client_io.cc
+++ b/src/rgw/rgw_client_io.cc
@@ -10,10 +10,11 @@
 #define dout_subsys ceph_subsys_rgw
 
 void RGWClientIO::init(CephContext *cct) {
-  init_env(cct);
+  engine->init_env(cct);
 
   if (cct->_conf->subsys.should_gather(ceph_subsys_rgw, 20)) {
-    std::map<string, string, ltstr_nocase>& env_map = env.get_map();
+    std::map<string, string, ltstr_nocase>& env_map = \
+        engine->get_env().get_map();
     std::map<string, string, ltstr_nocase>::iterator iter = env_map.begin();
 
     for (iter = env_map.begin(); iter != env_map.end(); ++iter) {
@@ -40,10 +41,11 @@ int RGWClientIO::print(const char *format, ...)
       return write(buf, ret);
     }
 
-    if (ret >= 0)
+    if (ret >= 0) {
       size = ret + 1;
-    else
+    } else {
       size *= 2;
+    }
   }
 
   /* not reachable */
@@ -51,12 +53,14 @@ int RGWClientIO::print(const char *format, ...)
 
 int RGWClientIO::write(const char *buf, int len)
 {
-  int ret = write_data(buf, len);
-  if (ret < 0)
+  int ret = engine->write_data(buf, len);
+  if (ret < 0) {
     return ret;
+  }
 
-  if (account)
+  if (account) {
     bytes_sent += ret;
+  }
 
   if (ret < len) {
     /* sent less than tried to send, error out */
@@ -69,9 +73,10 @@ int RGWClientIO::write(const char *buf, int len)
 
 int RGWClientIO::read(char *buf, int max, int *actual)
 {
-  int ret = read_data(buf, max);
-  if (ret < 0)
+  int ret = engine->read_data(buf, max);
+  if (ret < 0) {
     return ret;
+  }
 
   *actual = ret;
 

--- a/src/rgw/rgw_client_io.cc
+++ b/src/rgw/rgw_client_io.cc
@@ -196,3 +196,16 @@ int RGWClientIOEngineBufferAware::complete_request(RGWClientIO& controller)
 
   return RGWClientIOEngineDecorator::complete_request(controller);
 }
+
+
+RGWEnv& RGWClientIOEnginePrefixer::get_env()
+{
+  char remapped_uri[256];
+
+  env = RGWClientIOEngineDecorator::get_env();
+  snprintf(remapped_uri, sizeof(remapped_uri), "%s%s",
+          prefix.c_str(), env.get("REQUEST_URI"));
+  env.set("REQUEST_URI", remapped_uri);
+
+  return env;
+}

--- a/src/rgw/rgw_client_io.cc
+++ b/src/rgw/rgw_client_io.cc
@@ -160,6 +160,17 @@ int RGWClientIOEngineBufferAware::write_data(const char *buf, int len) {
 }
 
 int RGWClientIOEngineBufferAware::send_content_length(RGWClientIO& controller,
+                                                      const RGWDynamicLengthMode mode)
+{
+  if (RGWDynamicLengthMode::LENGTH_CALCULATE != mode) {
+    /* Deactivate. Buffering is not necessary. */
+    has_content_length = false;
+  }
+
+  return RGWClientIOEngineDecorator::send_content_length(controller, mode);
+}
+
+int RGWClientIOEngineBufferAware::send_content_length(RGWClientIO& controller,
                                                       const uint64_t len) {
   has_content_length = true;
   return RGWClientIOEngineDecorator::send_content_length(controller, len);

--- a/src/rgw/rgw_client_io.h
+++ b/src/rgw/rgw_client_io.h
@@ -31,6 +31,62 @@ public:
 };
 
 
+class RGWClientIOEngineDecorator : public RGWClientIOEngine {
+  std::shared_ptr<RGWClientIOEngine> decorated;
+
+public:
+  RGWClientIOEngineDecorator(std::shared_ptr<RGWClientIOEngine> impl)
+    : decorated(impl) {
+  }
+
+  /* A lot of wrappers */
+  virtual void init_env(CephContext *cct) override {
+    return decorated->init_env(cct);
+  }
+
+  virtual int write_data(const char * const buf,
+                         const int len) override {
+    return decorated->write_data(buf, len);
+  }
+
+  virtual int read_data(char * const buf,
+                        const int max) override {
+    return decorated->read_data(buf, max);
+  }
+
+  virtual void flush(RGWClientIO& controller) {
+    return decorated->flush(controller);
+  }
+
+  virtual int send_status(RGWClientIO& controller,
+                          const char * const status,
+                          const char * const status_name) override {
+    return decorated->send_status(controller, status, status_name);
+  }
+
+  virtual int send_100_continue(RGWClientIO& controller) override {
+    return decorated->send_100_continue(controller);
+  }
+
+  virtual int complete_header(RGWClientIO& controller) override {
+    return decorated->complete_header(controller);
+  }
+
+  virtual int complete_request(RGWClientIO& controller) override {
+    return decorated->complete_request(controller);
+  }
+
+  virtual int send_content_length(RGWClientIO& controller,
+                                  const uint64_t len) override {
+    return decorated->send_content_length(controller, len);
+  }
+
+  virtual RGWEnv& get_env() override {
+    return decorated->get_env();
+  }
+};
+
+
 class RGWClientIO {
   bool account;
 

--- a/src/rgw/rgw_client_io.h
+++ b/src/rgw/rgw_client_io.h
@@ -113,6 +113,29 @@ public:
 };
 
 
+class RGWClientIOEngineBufferAware : public RGWClientIOEngineDecorator {
+protected:
+  bufferlist data;
+
+  bool has_content_length;
+  bool buffer_data;
+
+  virtual int write_data(const char *buf, const int len) override;
+
+public:
+  RGWClientIOEngineBufferAware(std::shared_ptr<RGWClientIOEngine> engine)
+    : RGWClientIOEngineDecorator(engine),
+      has_content_length(false),
+      buffer_data(false) {
+  }
+
+  int send_content_length(RGWClientIO& controller,
+                          const uint64_t len) override;
+  int complete_request(RGWClientIO& controller) override;
+  int complete_header(RGWClientIO& controller) override;
+};
+
+
 class RGWClientIO {
   bool account;
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <string>
 #include <map>
+#include <memory>
 #include "include/types.h"
 #include "include/utime.h"
 #include "rgw_acl.h"
@@ -303,7 +304,7 @@ class RGWConf;
 class RGWEnv {
   std::map<string, string, ltstr_nocase> env_map;
 public:
-  RGWConf *conf; 
+  std::shared_ptr<RGWConf> conf;
 
   RGWEnv();
   ~RGWEnv();

--- a/src/rgw/rgw_env.cc
+++ b/src/rgw/rgw_env.cc
@@ -6,17 +6,18 @@
 
 #include <string>
 #include <map>
+#include <memory>
 
 #define dout_subsys ceph_subsys_rgw
 
 RGWEnv::RGWEnv()
+  : conf(std::make_shared<RGWConf>())
 {
-  conf = new RGWConf;
 }
 
 RGWEnv::~RGWEnv()
 {
-  delete conf;
+  /* NOP */
 }
 
 void RGWEnv::init(CephContext *cct)

--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -21,7 +21,7 @@ int RGWFCGX::read_data(char *buf, int len)
   return FCGX_GetStr(buf, len, fcgx->in);
 }
 
-void RGWFCGX::flush()
+void RGWFCGX::flush(RGWClientIO& controller)
 {
   FCGX_FFlush(fcgx->out);
 }
@@ -31,29 +31,31 @@ void RGWFCGX::init_env(CephContext *cct)
   env.init(cct, (char **)fcgx->envp);
 }
 
-int RGWFCGX::send_status(const char *status, const char *status_name)
+int RGWFCGX::send_status(RGWClientIO& controller,
+                         const char * const status,
+                         const char * const status_name)
 {
-  return print("Status: %s %s\r\n", status, status_name);
+  return controller.print("Status: %s %s\r\n", status, status_name);
 }
 
-int RGWFCGX::send_100_continue()
+int RGWFCGX::send_100_continue(RGWClientIO& controller)
 {
-  int r = send_status("100", "Continue");
+  int r = send_status(controller, "100", "Continue");
   if (r >= 0) {
-    flush();
+    flush(controller);
   }
   return r;
 }
 
-int RGWFCGX::send_content_length(uint64_t len)
+int RGWFCGX::send_content_length(RGWClientIO& controller,
+                                 const uint64_t len)
 {
   char buf[21];
   snprintf(buf, sizeof(buf), "%" PRIu64, len);
-  return print("Content-Length: %s\r\n", buf);
+  return controller.print("Content-Length: %s\r\n", buf);
 }
 
-int RGWFCGX::complete_header()
+int RGWFCGX::complete_header(RGWClientIO& controller)
 {
-  return print("\r\n");
+  return controller.print("\r\n");
 }
-

--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -35,6 +35,11 @@ public:
     return 0;
   }
 
+  int send_content_length(RGWClientIO& controller,
+                          const RGWDynamicLengthMode) override {
+    return 0;
+  }
+
   RGWEnv& get_env() override {
     return env;
   }

--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -10,22 +10,34 @@
 struct FCGX_Request;
 
 
-class RGWFCGX : public RGWClientIO
+class RGWFCGX : public RGWClientIOEngine
 {
   FCGX_Request *fcgx;
-protected:
-  void init_env(CephContext *cct);
-  int write_data(const char *buf, int len);
-  int read_data(char *buf, int len);
+  RGWEnv env;
 
-  int send_status(const char *status, const char *status_name);
-  int send_100_continue();
-  int complete_header();
-  int complete_request() { return 0; }
-  int send_content_length(uint64_t len);
 public:
   RGWFCGX(FCGX_Request *_fcgx) : fcgx(_fcgx) {}
-  void flush();
+
+  void init_env(CephContext *cct) override;
+  int write_data(const char *buf, int len) override;
+  int read_data(char *buf, int len) override;
+
+  int send_status(RGWClientIO& controller,
+                  const char *status,
+                  const char *status_name) override;
+  int send_100_continue(RGWClientIO& controller) override;
+  int complete_header(RGWClientIO& controller) override;
+  int send_content_length(RGWClientIO& controller,
+                          uint64_t len) override;
+  void flush(RGWClientIO& controller) override;
+
+  int complete_request(RGWClientIO& controller) override {
+    return 0;
+  }
+
+  RGWEnv& get_env() override {
+    return env;
+  }
 };
 
 

--- a/src/rgw/rgw_loadgen.cc
+++ b/src/rgw/rgw_loadgen.cc
@@ -44,23 +44,23 @@ int RGWLoadGenRequestEnv::sign(RGWAccessKey& access_key)
   return 0;
 }
 
-int RGWLoadGenIO::write_data(const char *buf, int len)
+int RGWLoadGenIO::write_data(const char * const buf, const int len)
 {
   return len;
 }
 
-int RGWLoadGenIO::read_data(char *buf, int len)
+int RGWLoadGenIO::read_data(char *buf, const int len)
 {
   int read_len = MIN(left_to_read, (uint64_t)len);
   left_to_read -= read_len;
   return read_len;
 }
 
-void RGWLoadGenIO::flush()
+void RGWLoadGenIO::flush(RGWClientIO& controller)
 {
 }
 
-int RGWLoadGenIO::complete_request()
+int RGWLoadGenIO::complete_request(RGWClientIO& controller)
 {
   return 0;
 }
@@ -92,22 +92,25 @@ void RGWLoadGenIO::init_env(CephContext *cct)
   env.set("SERVER_PORT", port_buf);
 }
 
-int RGWLoadGenIO::send_status(const char *status, const char *status_name)
+int RGWLoadGenIO::send_status(RGWClientIO& controller,
+                              const char * const conststatus,
+                              const char * const status_name)
 {
   return 0;
 }
 
-int RGWLoadGenIO::send_100_continue()
+int RGWLoadGenIO::send_100_continue(RGWClientIO& controller)
 {
   return 0;
 }
 
-int RGWLoadGenIO::complete_header()
+int RGWLoadGenIO::complete_header(RGWClientIO& controller)
 {
   return 0;
 }
 
-int RGWLoadGenIO::send_content_length(uint64_t len)
+int RGWLoadGenIO::send_content_length(RGWClientIO& controller,
+                                      const uint64_t len)
 {
   return 0;
 }

--- a/src/rgw/rgw_loadgen.h
+++ b/src/rgw/rgw_loadgen.h
@@ -47,6 +47,11 @@ public:
   int send_content_length(RGWClientIO& controller, uint64_t len);
   void flush(RGWClientIO& controller);
 
+  int send_content_length(RGWClientIO& controller,
+                          const RGWDynamicLengthMode) override {
+    return 0;
+  }
+
   RGWEnv& get_env() override {
     return env;
   }

--- a/src/rgw/rgw_loadgen.h
+++ b/src/rgw/rgw_loadgen.h
@@ -24,24 +24,32 @@ struct RGWLoadGenRequestEnv {
   int sign(RGWAccessKey& access_key);
 };
 
-class RGWLoadGenIO : public RGWClientIO
+class RGWLoadGenIO : public RGWClientIOEngine
 {
   uint64_t left_to_read;
   RGWLoadGenRequestEnv *req;
+  RGWEnv env;
+
 public:
+  RGWLoadGenIO(RGWLoadGenRequestEnv *_re) : left_to_read(0), req(_re) {}
+
   void init_env(CephContext *cct);
 
   int write_data(const char *buf, int len);
   int read_data(char *buf, int len);
 
-  int send_status(const char *status, const char *status_name);
-  int send_100_continue();
-  int complete_header();
-  int complete_request();
-  int send_content_length(uint64_t len);
+  int send_status(RGWClientIO& controller,
+                  const char *status,
+                  const char *status_name);
+  int send_100_continue(RGWClientIO& controller);
+  int complete_header(RGWClientIO& controller);
+  int complete_request(RGWClientIO& controller);
+  int send_content_length(RGWClientIO& controller, uint64_t len);
+  void flush(RGWClientIO& controller);
 
-  RGWLoadGenIO(RGWLoadGenRequestEnv *_re) : left_to_read(0), req(_re) {}
-  void flush();
+  RGWEnv& get_env() override {
+    return env;
+  }
 };
 
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -725,6 +725,7 @@ static int civetweb_callback(struct mg_connection *conn) {
 
   RGWClientIO::Builder cio_builder(
           std::make_shared<RGWMongoose>(conn, pe->port));
+  cio_builder.set_reordering(true);
   RGWClientIO client_io = cio_builder.getResult();
 
   int ret = process_request(store, rest, req, client_io, olog);


### PR DESCRIPTION
This PR tries to unify behaviour between multiple radosgw's frontends. A lot of differentiated functions (like data reordering, enforcing proper _Content-Length_ HTTP header and so on) have been moved from per-frontend derivative of _RGWClientIO_ into separated filters which could be easily shared and reused.
