### PR TITLE
osd: wait for cleanup from bench

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5162,6 +5162,12 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
 
     // clean up
     store->queue_transaction_and_cleanup(osr.get(), cleanupt);
+    {
+      C_SaferCond waiter;
+      if (!osr->flush_commit(&waiter)) {
+	waiter.wait();
+      }
+    }
 
     uint64_t rate = (double)count / (end - start);
     if (f) {


### PR DESCRIPTION
We need to wait for cleanup to flush before we destroy the
sequencer or else we get a use-after-free.

Introduced e7bbafa3bfbd5e936a8be026a30b83a89f6121c3.

Fixes: #12766
Signed-off-by: Sage Weil <sage@redhat.com>