### PR TITLE
librbd: error closing image while set to invalid snapshot

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2140,11 +2140,12 @@ reprotect_and_return_err:
     if (ictx->parent) {
       uint64_t overlap;
       r = ictx->get_parent_overlap(ictx->snap_id, &overlap);
-      if (r < 0)
+      if (r < 0 && r != -ENOENT) {
 	return r;
-      if (!overlap ||
+      }
+      if (r == -ENOENT || overlap == 0 ||
 	  ictx->parent->md_ctx.get_id() !=
-	  ictx->get_parent_pool_id(ictx->snap_id) ||
+            ictx->get_parent_pool_id(ictx->snap_id) ||
 	  ictx->parent->id != ictx->get_parent_image_id(ictx->snap_id) ||
 	  ictx->parent->snap_id != ictx->get_parent_snap_id(ictx->snap_id)) {
 	ictx->clear_nonexistence_cache();


### PR DESCRIPTION
With cache disabled, closing the image will result in a flush
which might result in the image being refreshed.  If this happens
while the image is set to an invalid snapshot, an error will be
returned while closing the image.

Fixes: #12765
Backport: infernalis
Signed-off-by: Jason Dillaman <dillaman@redhat.com>