### PR TITLE
rgw: be more flexible with iso8601 timestamps

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -357,18 +357,17 @@ bool parse_iso8601(const char *s, struct tm *t)
   }
   string str;
   trim_whitespace(p, str);
-  if (str.size() == 1 && str[0] == 'Z')
+  int len = str.size();
+
+  if (len == 1 && str[0] == 'Z')
     return true;
 
-  if (str.size() != 5) {
-    return false;
-  }
   if (str[0] != '.' ||
-      str[str.size() - 1] != 'Z')
+      str[len - 1] != 'Z')
     return false;
 
   uint32_t ms;
-  int r = stringtoul(str.substr(1, 3), &ms);
+  int r = stringtoul(str.substr(1, len - 2), &ms);
   if (r < 0)
     return false;
 


### PR DESCRIPTION
make parsing 8601 more flexible by not restricting the length of seconds
to 5, this allows timestamp to be specified both as ms or us. Newer
keystone backends such as fernet token backend default to microseconds
when publishing iso8601 timestamps, so this allows these timestamps to
be allowed when specifying the token expiry time.

Fixes: #12761
Reported-by: Ian Unruh <ianunruh@gmail.com>
Signed-off-by: Abhishek Lekshmanan <abhishek.lekshmanan@ril.com>