### PR TITLE
config: skip lockdep for intentionally recursive md_config_t lock

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -150,7 +150,7 @@ md_config_t::md_config_t()
 #undef OPTION
 #undef SUBSYS
 #undef DEFAULT_SUBSYS
-  lock("md_config_t", true)
+  lock("md_config_t", true, false)
 {
   init_subsys();
 }


### PR DESCRIPTION
lockdep can't handle recursive locks, resulting in false positive
reports for certain set_val_or_die() calls, like via
md_config_t::parse_argv() passed "-m".

Fixes: #12614
Signed-off-by: Josh Durgin <jdurgin@redhat.com>