### PR TITLE
doc: Fix typo in recovery reservation section

### DIFF
--- a/doc/dev/osd_internals/recovery_reservation.rst
+++ b/doc/dev/osd_internals/recovery_reservation.rst
@@ -61,7 +61,7 @@ The recovery reservation state chart controls the PG state as reported
 to the monitor. The state chart can set:
 
  - recovery_wait: waiting for local/remote reservations
- - recovering: recoverying
+ - recovering: recovering
  - wait_backfill: waiting for remote backfill reservations
  - backfilling: backfilling
  - backfill_toofull: backfill reservation rejected, OSD too full

--- a/doc/dev/osd_internals/wbthrottle.rst
+++ b/doc/dev/osd_internals/wbthrottle.rst
@@ -24,5 +24,5 @@ Filestore syncs have a sideeffect of flushing all outstanding objects
 in the wbthrottle.
 
 lfn_unlink clears the cached FDRef and wbthrottle entries for the
-unlinked object when then last link is removed and asserts that all
+unlinked object when the last link is removed and asserts that all
 outstanding FDRefs for that object are dead.


### PR DESCRIPTION
Fix typo in doc/dev/osd_internals/recovery_reservation.rst

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>