### PR TITLE
doc: Fix typo in writeback throttle section

### DIFF
--- a/doc/dev/osd_internals/wbthrottle.rst
+++ b/doc/dev/osd_internals/wbthrottle.rst
@@ -24,5 +24,5 @@ Filestore syncs have a sideeffect of flushing all outstanding objects
 in the wbthrottle.
 
 lfn_unlink clears the cached FDRef and wbthrottle entries for the
-unlinked object when then last link is removed and asserts that all
+unlinked object when the last link is removed and asserts that all
 outstanding FDRefs for that object are dead.


### PR DESCRIPTION
Fix typo in doc/dev/osd_internals/wbthrottle.rst

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>