### PR TITLE
ceph.spec.in: drop sysvinit-specific macros that run only on SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -705,9 +705,6 @@ mkdir -p %{_localstatedir}/run/ceph/
 
 %postun
 /sbin/ldconfig
-%if %{defined suse_version}
-%insserv_cleanup
-%endif
 
 #################################################################################
 # files
@@ -908,10 +905,6 @@ fi
   # service_add_post; the rest is all sysvinit --> systemd migration which
   # isn't applicable in this context (see above comment).
   /usr/bin/systemctl daemon-reload >/dev/null 2>&1 || :
-%else
-  %if 0%{?suse_version} || 0%{?opensuse}
-    %fillup_and_insserv -f -y ceph-radosgw
-  %endif
 %endif
 
 %preun radosgw
@@ -923,10 +916,6 @@ fi
       /usr/bin/systemctl stop $SERVICE > /dev/null 2>&1 || :
     done
   fi
-%else
-  %if 0%{?suse_version} || 0%{?opensuse}
-    %stop_on_removal ceph-radosgw
-  %endif
 %endif
 
 %postun radosgw
@@ -939,19 +928,11 @@ fi
       /usr/bin/systemctl try-restart $SERVICE > /dev/null 2>&1 || :
     done
   fi
-%else
-  %if 0%{?suse_version} || 0%{?opensuse}
-    %restart_on_update ceph-radosgw
-  %endif
 %endif
 # Package removal cleanup
 if [ "$1" -eq "0" ] ; then
     rm -rf /var/log/radosgw
 fi
-
-%if 0%{?suse_version} || 0%{?opensuse}
-  %insserv_cleanup
-%endif
 
 #################################################################################
 %if %{with ocf}


### PR DESCRIPTION
All sysvinit-based versions of openSUSE/SLE are EOL as far as upstream Ceph is
concerned.

Signed-off-by: Nathan Cutler <ncutler@suse.com>