### PR TITLE
ScrubStack and "tag path" command

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -678,6 +678,7 @@ if(${WITH_MDS})
     mds/JournalPointer.cc
     mds/MDSTableClient.cc
     mds/MDSTableServer.cc
+    mds/ScrubStack.cc
     mds/SimpleLock.cc
     mds/SnapRealm.cc
     mds/SnapServer.cc

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -507,6 +507,8 @@ OPTION(mds_max_purge_ops_per_pg, OPT_FLOAT, 0.5)
 OPTION(mds_root_ino_uid, OPT_INT, 0) // The UID of / on new filesystems
 OPTION(mds_root_ino_gid, OPT_INT, 0) // The GID of / on new filesystems
 
+OPTION(mds_max_scrub_ops_in_progress, OPT_INT, 5) // the number of simultaneous scrubs allowed
+
 // If true, compact leveldb store on mount
 OPTION(osd_compact_leveldb_on_mount, OPT_BOOL, false)
 

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -351,7 +351,8 @@ enum {
 	CEPH_MDS_OP_FRAGMENTDIR= 0x01500,
 	CEPH_MDS_OP_EXPORTDIR  = 0x01501,
 	CEPH_MDS_OP_VALIDATE   = 0x01502,
-	CEPH_MDS_OP_FLUSH      = 0x01503
+	CEPH_MDS_OP_FLUSH      = 0x01503,
+	CEPH_MDS_OP_ENQUEUE_SCRUB = 0x01504
 };
 
 extern const char *ceph_mds_op_name(int op);

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -657,7 +657,6 @@ void CDentry::scrub_finished(Context **c)
     LogChannelRef clog = dir->cache->mds->clog;
     clog->info() << "scrub complete with tag '"
       << scrub_infop->header->tag << "'";
-    
   }
 
   delete scrub_infop;

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -623,6 +623,7 @@ std::string CDentry::linkage_t::get_remote_d_type_string() const
 }
 
 void CDentry::scrub_initialize(CDir *parent, bool recurse, bool children,
+                        ScrubHeaderRefConst header,
                                Context *f)
 {
   if (!scrub_infop)
@@ -635,6 +636,7 @@ void CDentry::scrub_initialize(CDir *parent, bool recurse, bool children,
   scrub_infop->scrub_children = children;
   scrub_infop->dentry_scrubbing = true;
   scrub_infop->on_finish = f;
+  scrub_infop->header = header;
 
   auth_pin(this);
 }
@@ -649,6 +651,14 @@ void CDentry::scrub_finished(Context **c)
   }
 
   *c = scrub_infop->on_finish;
+
+  if (scrub_infop->header && scrub_infop->header->origin == this) {
+    // We are at the point that a tagging scrub was initiated
+    LogChannelRef clog = dir->cache->mds->clog;
+    clog->info() << "scrub complete with tag '"
+      << scrub_infop->header->tag << "'";
+    
+  }
 
   delete scrub_infop;
   scrub_infop = NULL;

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -149,10 +149,12 @@ public:
     bool dentry_scrubbing; /// safety check
     Context *on_finish; /// called when we finish scrubbing
     ScrubHeaderRefConst header;
+    bool inode_validated;  /// Has our inode's validate_disk_state run?
 
     scrub_info_t() :
       scrub_parent(NULL), scrub_recursive(false),
-      scrub_children(false), dentry_scrubbing(false), on_finish(NULL)
+      scrub_children(false), dentry_scrubbing(false), on_finish(NULL),
+      inode_validated(false)
     {}
   };
 

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -165,6 +165,7 @@ protected:
 public:
   elist<CDentry*>::item item_dirty;
   elist<CDentry*>::item item_stray;
+  elist<CDentry*>::item item_scrub;
 
   const scrub_info_t *scrub_info() const {
     if(!scrub_infop)
@@ -230,6 +231,7 @@ public:
   }
   ~CDentry() {
     assert(!scrub_infop);
+    assert(!item_scrub.is_on_list());
     g_num_dn--;
     g_num_dns++;
   }

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -29,6 +29,7 @@
 
 #include "SimpleLock.h"
 #include "LocalLock.h"
+#include "ScrubHeader.h"
 
 class CInode;
 class CDir;
@@ -147,6 +148,8 @@ public:
     bool scrub_children; /// true if we have to scrub all direct children
     bool dentry_scrubbing; /// safety check
     Context *on_finish; /// called when we finish scrubbing
+    ScrubHeaderRefConst header;
+
     scrub_info_t() :
       scrub_parent(NULL), scrub_recursive(false),
       scrub_children(false), dentry_scrubbing(false), on_finish(NULL)
@@ -173,6 +176,7 @@ public:
     return scrub_infop;
   }
   void scrub_initialize(CDir *parent, bool recurse, bool children,
+                        ScrubHeaderRefConst header,
                         Context *f);
   void scrub_finished(Context **c);
 

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -186,6 +186,9 @@ public:
   void scrub_children_finished() {
     scrub_infop->dentry_children_done = true;
   }
+  void scrub_set_finisher(Context *c) {
+    scrub_infop->on_finish = c;
+  }
 
 private:
   /**

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -147,14 +147,16 @@ public:
     bool scrub_recursive; /// true if we are scrubbing everything under this
     bool scrub_children; /// true if we have to scrub all direct children
     bool dentry_scrubbing; /// safety check
+    bool dentry_children_done; /// safety check
+    bool inode_validated;  /// Has our inode's validate_disk_state run?
     Context *on_finish; /// called when we finish scrubbing
     ScrubHeaderRefConst header;
-    bool inode_validated;  /// Has our inode's validate_disk_state run?
 
     scrub_info_t() :
       scrub_parent(NULL), scrub_recursive(false),
-      scrub_children(false), dentry_scrubbing(false), on_finish(NULL),
-      inode_validated(false)
+      scrub_children(false), dentry_scrubbing(false),
+      dentry_children_done(false), inode_validated(false),
+      on_finish(NULL)
     {}
   };
 
@@ -181,6 +183,9 @@ public:
                         ScrubHeaderRefConst header,
                         Context *f);
   void scrub_finished(Context **c);
+  void scrub_children_finished() {
+    scrub_infop->dentry_children_done = true;
+  }
 
 private:
   /**

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2937,8 +2937,6 @@ void CDir::scrub_finished()
   scrub_infop->others_scrubbed.clear();
   scrub_infop->directory_scrubbing = false;
 
-  scrub_infop->last_scrub_dirty = true;
-
   scrub_infop->last_recursive = scrub_infop->recursive_start;
   scrub_infop->last_scrub_dirty = true;
 }

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2909,11 +2909,15 @@ void CDir::scrub_initialize()
     if (i->first.snapid != CEPH_NOSNAP)
       continue;
 
-    CInode *in = i->second->get_projected_linkage()->get_inode();
-    if (in && in->is_dir())
-      scrub_infop->directories_to_scrub.insert(i->first);
-    else if (in)
-      scrub_infop->others_to_scrub.insert(i->first);
+    CDentry::linkage_t *dnl = i->second->get_projected_linkage();
+    if (dnl->is_primary()) {
+      if (dnl->get_inode()->is_dir())
+	scrub_infop->directories_to_scrub.insert(i->first);
+      else
+	scrub_infop->others_to_scrub.insert(i->first);
+    } else if (dnl->is_remote()) {
+      // TODO: check remote linkage
+    }
   }
   scrub_infop->directory_scrubbing = true;
 

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -185,6 +185,7 @@ CDir::CDir(CInode *in, frag_t fg, MDCache *mdcache, bool auth) :
   first(2),
   dirty_rstat_inodes(member_offset(CInode, dirty_rstat_item)),
   projected_version(0),  item_dirty(this), item_new(this),
+  scrub_infop(NULL),
   num_head_items(0), num_head_null(0),
   num_snap_items(0), num_snap_null(0),
   num_dirty(0), committing_version(0), committed_version(0),
@@ -1263,6 +1264,11 @@ fnode_t *CDir::project_fnode()
   fnode_t *p = new fnode_t;
   *p = *get_projected_fnode();
   projected_fnode.push_back(p);
+  if (scrub_infop && scrub_infop->last_scrub_dirty) {
+    p->recursive_scrub_stamp = scrub_infop->last_recursive.time;
+    p->recursive_scrub_version = scrub_infop->last_recursive.version;
+    scrub_infop->last_scrub_dirty = false;
+    scrub_maybe_delete_info();
   dout(10) << "project_fnode " << p << dendl;
   return p;
 }
@@ -2848,3 +2854,170 @@ void CDir::dump(Formatter *f) const
   MDSCacheObject::dump(f);
 }
 
+/****** Scrub Stuff *******/
+
+void CDir::scrub_info_create() const
+{
+  assert(!scrub_infop);
+
+  // break out of const-land to set up implicit initial state
+  CDir *me = const_cast<CDir*>(this);
+  fnode_t *fn = me->get_projected_fnode();
+
+  scrub_info_t *si = new scrub_info_t();
+
+  si->last_recursive.version = si->recursive_start.version =
+      fn->recursive_scrub_version;
+  si->last_recursive.time = si->recursive_start.time =
+      fn->recursive_scrub_stamp;
+
+  me->scrub_infop = si;
+}
+
+void CDir::scrub_initialize()
+{
+  dout(20) << __func__ << dendl;
+  assert(is_complete());
+
+  // FIXME: weird implicit construction, is someone else meant
+  // to be calling scrub_info_create first?
+  scrub_info();
+  assert(scrub_infop && !scrub_infop->directory_scrubbing);
+
+  scrub_infop->recursive_start.version = get_projected_version();
+  scrub_infop->recursive_start.time = ceph_clock_now(g_ceph_context);
+
+  scrub_infop->directories_to_scrub.clear();
+  scrub_infop->directories_scrubbing.clear();
+  scrub_infop->directories_scrubbed.clear();
+  scrub_infop->others_to_scrub.clear();
+  scrub_infop->others_scrubbing.clear();
+  scrub_infop->others_scrubbed.clear();
+
+  for (map_t::iterator i = items.begin();
+      i != items.end();
+      ++i) {
+    // TODO: handle snapshot scrubbing
+    if (i->first.snapid != CEPH_NOSNAP)
+      continue;
+
+    CInode *in = i->second->get_projected_linkage()->get_inode();
+    if (in && in->is_dir())
+      scrub_infop->directories_to_scrub.insert(i->first);
+    else if (in)
+      scrub_infop->others_to_scrub.insert(i->first);
+  }
+  scrub_infop->directory_scrubbing = true;
+}
+
+void CDir::scrub_finished()
+{
+  dout(20) << __func__ << dendl;
+  assert(scrub_infop && scrub_infop->directory_scrubbing);
+
+  assert(scrub_infop->directories_to_scrub.empty());
+  assert(scrub_infop->directories_scrubbing.empty());
+  scrub_infop->directories_scrubbed.clear();
+  assert(scrub_infop->others_to_scrub.empty());
+  assert(scrub_infop->others_scrubbing.empty());
+  scrub_infop->others_scrubbed.clear();
+  scrub_infop->directory_scrubbing = false;
+
+  scrub_infop->last_scrub_dirty = true;
+
+  scrub_infop->last_recursive = scrub_infop->recursive_start;
+  scrub_infop->last_scrub_dirty = true;
+}
+
+int CDir::_next_dentry_on_set(set<dentry_key_t>& dns, bool missing_okay,
+                              MDSInternalContext *cb, CDentry **dnout)
+{
+  dentry_key_t dnkey;
+
+  while (!dns.empty()) {
+    set<dentry_key_t>::iterator front = dns.begin();
+    dnkey = *front;
+    *dnout = lookup(dnkey.name);
+    if (!*dnout) {
+      if (!is_complete() &&
+          (!has_bloom() || is_in_bloom(dnkey.name))) {
+        // need to re-read this dirfrag
+        fetch(cb);
+        return EAGAIN;
+      }
+      // okay, we lost it
+      if (missing_okay) {
+	dout(15) << " we no longer have directory dentry "
+		 << dnkey.name << ", assuming it got renamed" << dendl;
+	dns.erase(dnkey);
+	continue;
+      } else {
+	dout(5) << " we lost dentry " << dnkey.name
+		<< ", bailing out because that's impossible!" << dendl;
+	assert(0);
+      }
+    }
+    // okay, we got a  dentry
+    dns.erase(dnkey);
+
+    return 0;
+  }
+  *dnout = NULL;
+  return ENOENT;
+}
+
+int CDir::scrub_dentry_next(MDSInternalContext *cb, CDentry **dnout)
+{
+  dout(20) << __func__ << dendl;
+  assert(scrub_infop && scrub_infop->directory_scrubbing);
+
+  dout(20) << "trying to scrub directories underneath us" << dendl;
+  int rval = _next_dentry_on_set(scrub_infop->directories_to_scrub, true,
+                                 cb, dnout);
+  if (rval == 0) {
+    dout(20) << __func__ << " inserted to directories scrubbing: "
+      << *dnout << dendl;
+    scrub_infop->directories_scrubbing.insert((*dnout)->key());
+  } else if (rval < 0 || rval == EAGAIN) {
+    // we don't need to do anything else
+  } else { // we emptied out the directory scrub set
+    assert(rval == ENOENT);
+    dout(20) << "no directories left, moving on to other kinds of dentries"
+             << dendl;
+    
+    rval = _next_dentry_on_set(scrub_infop->others_to_scrub, false, cb, dnout);
+    if (rval == 0) {
+      dout(20) << __func__ << " inserted to others scrubbing: "
+        << *dnout << dendl;
+      scrub_infop->others_scrubbing.insert((*dnout)->key());
+    }
+  }
+  dout(20) << " returning " << rval << " with dn=" << *dnout << dendl;
+  return rval;
+}
+
+void CDir::scrub_dentry_finished(CDentry *dn)
+{
+  dout(20) << __func__ << " on dn " << *dn << dendl;
+  assert(scrub_infop && scrub_infop->directory_scrubbing);
+  dentry_key_t dn_key = dn->key();
+  if (scrub_infop->directories_scrubbing.count(dn_key)) {
+    scrub_infop->directories_scrubbing.erase(dn_key);
+    scrub_infop->directories_scrubbed.insert(dn_key);
+  } else {
+    assert(scrub_infop->others_scrubbing.count(dn_key));
+    scrub_infop->others_scrubbing.erase(dn_key);
+    scrub_infop->others_scrubbed.insert(dn_key);
+  }
+}
+
+void CDir::scrub_maybe_delete_info()
+{
+  if (scrub_infop &&
+      !scrub_infop->directory_scrubbing &&
+      !scrub_infop->last_scrub_dirty &&
+      scrub_infop->dirty_scrub_stamps.empty()) {
+    delete scrub_infop;
+    scrub_infop = NULL;
+  }
+}

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -181,51 +181,35 @@ ostream& CDir::print_db_line_prefix(ostream& out)
 // CDir
 
 CDir::CDir(CInode *in, frag_t fg, MDCache *mdcache, bool auth) :
+  cache(mdcache), inode(in), frag(fg),
+  first(2),
   dirty_rstat_inodes(member_offset(CInode, dirty_rstat_item)),
-  item_dirty(this), item_new(this),
+  projected_version(0),  item_dirty(this), item_new(this),
+  num_head_items(0), num_head_null(0),
+  num_snap_items(0), num_snap_null(0),
+  num_dirty(0), committing_version(0), committed_version(0),
+  dir_auth_pins(0), request_pins(0),
+  dir_rep(REP_NONE),
   pop_me(ceph_clock_now(g_ceph_context)),
   pop_nested(ceph_clock_now(g_ceph_context)),
   pop_auth_subtree(ceph_clock_now(g_ceph_context)),
   pop_auth_subtree_nested(ceph_clock_now(g_ceph_context)),
-  bloom(NULL)
+  num_dentries_nested(0), num_dentries_auth_subtree(0),
+  num_dentries_auth_subtree_nested(0),
+  bloom(NULL),
+  dir_auth(CDIR_AUTH_DEFAULT)
 {
   g_num_dir++;
   g_num_dira++;
 
-  inode = in;
-  frag = fg;
-  this->cache = mdcache;
-
-  first = 2;
-  
-  num_head_items = num_head_null = 0;
-  num_snap_items = num_snap_null = 0;
-  num_dirty = 0;
-
-  num_dentries_nested = 0;
-  num_dentries_auth_subtree = 0;
-  num_dentries_auth_subtree_nested = 0;
-
   state = STATE_INITIAL;
 
   memset(&fnode, 0, sizeof(fnode));
-  projected_version = 0;
-
-  committing_version = 0;
-  committed_version = 0;
-
-  // dir_auth
-  dir_auth = CDIR_AUTH_DEFAULT;
 
   // auth
   assert(in->is_dir());
   if (auth) 
     state |= STATE_AUTH;
- 
-  dir_auth_pins = 0;
-  request_pins = 0;
-
-  dir_rep = REP_NONE;
 }
 
 /**

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1264,11 +1264,16 @@ fnode_t *CDir::project_fnode()
   fnode_t *p = new fnode_t;
   *p = *get_projected_fnode();
   projected_fnode.push_back(p);
+
   if (scrub_infop && scrub_infop->last_scrub_dirty) {
+    p->localized_scrub_stamp = scrub_infop->last_local.time;
+    p->localized_scrub_version = scrub_infop->last_local.version;
     p->recursive_scrub_stamp = scrub_infop->last_recursive.time;
     p->recursive_scrub_version = scrub_infop->last_recursive.version;
     scrub_infop->last_scrub_dirty = false;
     scrub_maybe_delete_info();
+  }
+
   dout(10) << "project_fnode " << p << dendl;
   return p;
 }
@@ -2871,6 +2876,9 @@ void CDir::scrub_info_create() const
   si->last_recursive.time = si->recursive_start.time =
       fn->recursive_scrub_stamp;
 
+  si->last_local.version = fn->localized_scrub_version;
+  si->last_local.time = fn->localized_scrub_stamp;
+
   me->scrub_infop = si;
 }
 
@@ -2908,6 +2916,8 @@ void CDir::scrub_initialize()
       scrub_infop->others_to_scrub.insert(i->first);
   }
   scrub_infop->directory_scrubbing = true;
+
+  assert(scrub_local()); // TODO: handle failure
 }
 
 void CDir::scrub_finished()
@@ -3042,4 +3052,18 @@ void CDir::scrub_maybe_delete_info()
     delete scrub_infop;
     scrub_infop = NULL;
   }
+}
+
+bool CDir::scrub_local()
+{
+  assert(is_complete());
+  bool rval = check_rstats();
+
+  if (rval) {
+    scrub_info();
+    scrub_infop->last_local.time = ceph_clock_now(g_ceph_context);
+    scrub_infop->last_local.version = get_projected_version();
+    scrub_infop->last_scrub_dirty = true;
+  }
+  return rval;
 }

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2996,6 +2996,28 @@ int CDir::scrub_dentry_next(MDSInternalContext *cb, CDentry **dnout)
   return rval;
 }
 
+void CDir::scrub_dentries_scrubbing(list<CDentry*> *out_dentries)
+{
+  dout(20) << __func__ << dendl;
+  assert(scrub_infop && scrub_infop->directory_scrubbing);
+
+  for (set<dentry_key_t>::iterator i =
+        scrub_infop->directories_scrubbing.begin();
+      i != scrub_infop->directories_scrubbing.end();
+      ++i) {
+    CDentry *d = lookup(i->name, i->snapid);
+    assert(d);
+    out_dentries->push_back(d);
+  }
+  for (set<dentry_key_t>::iterator i = scrub_infop->others_scrubbing.begin();
+      i != scrub_infop->others_scrubbing.end();
+      ++i) {
+    CDentry *d = lookup(i->name, i->snapid);
+    assert(d);
+    out_dentries->push_back(d);
+  }
+}
+
 void CDir::scrub_dentry_finished(CDentry *dn)
 {
   dout(20) << __func__ << " on dn " << *dn << dendl;

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -233,7 +233,89 @@ private:
 
 public:
   typedef std::map<dentry_key_t, CDentry*> map_t;
+
+  class scrub_info_t {
+  public:
+    /// inodes we contain with dirty scrub stamps
+    map<dentry_key_t,CInode*> dirty_scrub_stamps; // TODO: make use of this!
+    struct scrub_stamps {
+      version_t version;
+      utime_t time;
+      scrub_stamps() : version(0) {}
+      void operator=(const scrub_stamps &o) {
+        version = o.version;
+        time = o.time;
+      }
+    };
+
+    scrub_stamps recursive_start; // when we last started a recursive scrub
+    scrub_stamps last_recursive; // when we last finished a recursive scrub
+    bool directory_scrubbing; /// safety check
+    bool last_scrub_dirty; /// is scrub info dirty or is it flushed to fnode?
+
+    /// these are lists of children in each stage of scrubbing
+    set<dentry_key_t> directories_to_scrub;
+    set<dentry_key_t> directories_scrubbing;
+    set<dentry_key_t> directories_scrubbed;
+    set<dentry_key_t> others_to_scrub;
+    set<dentry_key_t> others_scrubbing;
+    set<dentry_key_t> others_scrubbed;
+
+    scrub_info_t() : directory_scrubbing(false), last_scrub_dirty(false) {}
+  };
+  /**
+   * Call to start this CDir on a new scrub.
+   * @pre It is not currently scrubbing
+   * @pre The CDir is marked complete.
+   * @post It has set up its internal scrubbing state.
+   */
+  void scrub_initialize();
+  /**
+   * Get the next dentry to scrub. Gives you a CDentry* and its meaning. This
+   * function will give you all directory-representing dentries before any
+   * others.
+   * 0: success, you should scrub this CDentry right now
+   * EAGAIN: is currently fetching the next CDentry into memory for you.
+   *   It will activate your callback when done; try again when it does!
+   * ENOENT: there are no remaining dentries to scrub
+   * <0: There was an unexpected error
+   *
+   * @param cb An MDSInternalContext which will be activated only if
+   *   we return EAGAIN via rcode, or else ignored
+   * @param dnout CDentry * which you should next scrub, or NULL
+   * @returns a value as described above
+   */
+  int scrub_dentry_next(MDSInternalContext *cb, CDentry **dnout);
+  /**
+   * Report to the CDir that a CDentry has been scrubbed. Call this
+   * for every CDentry returned from scrub_dentry_next().
+   * @param dn The CDentry which has been scrubbed.
+   */
+  void scrub_dentry_finished(CDentry *dn);
+  /**
+   * Call this once all CDentries have been scrubbed, according to
+   * scrub_dentry_next's listing. It finalizes the scrub statistics.
+   */
+  void scrub_finished();
+private:
+  /**
+   * Create a scrub_info_t struct for the scrub_infop pointer.
+   */
+  void scrub_info_create() const;
+  /**
+   * Delete the scrub_infop if it's not got any useful data.
+   */
+  void scrub_maybe_delete_info();
+  /**
+   * Check the given set (presumably one of those in scrub_info_t) for the
+   * next key to scrub and look it up (or fail!).
+   */
+  int _next_dentry_on_set(set<dentry_key_t>& dns, bool missing_okay,
+                          MDSInternalContext *cb, CDentry **dnout);
+
+
 protected:
+  scrub_info_t *scrub_infop;
 
   // contents of this directory
   map_t items;       // non-null AND null
@@ -297,11 +379,18 @@ protected:
  public:
   CDir(CInode *in, frag_t fg, MDCache *mdcache, bool auth);
   ~CDir() {
+    delete scrub_infop;
     remove_bloom();
     g_num_dir--;
     g_num_dirs++;
   }
 
+  const scrub_info_t *scrub_info() const {
+    if (!scrub_infop) {
+      scrub_info_create();
+    }
+    return scrub_infop;
+  }
 
 
   // -- accessors --

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -287,6 +287,12 @@ public:
    */
   int scrub_dentry_next(MDSInternalContext *cb, CDentry **dnout);
   /**
+   * Get the currently scrubbing dentries. When returned, the passed-in
+   * list will be filled with all CDentry * which have been returned
+   * from scrub_dentry_next() but not sent back via scrub_dentry_finished().
+   */
+  void scrub_dentries_scrubbing(list<CDentry*> *out_dentries);
+  /**
    * Report to the CDir that a CDentry has been scrubbed. Call this
    * for every CDentry returned from scrub_dentry_next().
    * @param dn The CDentry which has been scrubbed.

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -250,6 +250,8 @@ public:
 
     scrub_stamps recursive_start; // when we last started a recursive scrub
     scrub_stamps last_recursive; // when we last finished a recursive scrub
+    scrub_stamps last_local; // when we last did a local scrub
+
     bool directory_scrubbing; /// safety check
     bool last_scrub_dirty; /// is scrub info dirty or is it flushed to fnode?
 
@@ -303,6 +305,12 @@ public:
    * scrub_dentry_next's listing. It finalizes the scrub statistics.
    */
   void scrub_finished();
+  /**
+   * Tell the CDir to do a local scrub of itself.
+   * @pre The CDir is_complete().
+   * @returns true if the rstats and directory contents match, false otherwise.
+   */
+  bool scrub_local();
 private:
   /**
    * Create a scrub_info_t struct for the scrub_infop pointer.

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3883,6 +3883,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
           results->raw_rstats.error_str << "dirfrag is INCOMPLETE despite fetching; probably too large compared to MDS cache size?\n";
           return true;
         }
+        // FIXME!!! Don't assert out on damage!
         assert(p->second->scrub_local());
         sub_info.add(p->second->fnode.accounted_rstat);
       }
@@ -3910,6 +3911,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
   };
 
 
+  dout(10) << "scrub starting validate_disk_state on " << *this << dendl;
   ValidationContinuation *vc = new ValidationContinuation(this,
                                                           results,
                                                           mdr,

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3812,7 +3812,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
           results->raw_rstats.error_str << "dirfrag is INCOMPLETE despite fetching; probably too large compared to MDS cache size?\n";
           return true;
         }
-        assert(p->second->check_rstats());
+        assert(p->second->scrub_local());
         sub_info.add(p->second->fnode.accounted_rstat);
       }
       // ...and that their sum matches our inode settings

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3626,6 +3626,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
 {
   class ValidationContinuation : public MDSContinuation {
   public:
+    MDRequestRef mdr;
     CInode *in;
     CInode::validated_data *results;
     bufferlist bl;
@@ -3640,8 +3641,9 @@ void CInode::validate_disk_state(CInode::validated_data *results,
 
     ValidationContinuation(CInode *i,
                            CInode::validated_data *data_r,
-                           MDRequestRef &mdr) :
-                             MDSContinuation(mdr, i->mdcache->mds->server),
+                           MDRequestRef &_mdr) :
+                             MDSContinuation(i->mdcache->mds->server),
+                             mdr(_mdr),
                              in(i),
                              results(data_r),
                              shadow_in(NULL) {
@@ -3825,6 +3827,10 @@ void CInode::validate_disk_state(CInode::validated_data *results,
       // Hurray! We made it through!
       results->passed_validation = true;
       return true;
+    }
+
+    void _done() {
+      server->respond_to_request(mdr, get_rval());
     }
   };
 

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -1095,10 +1095,12 @@ public:
    * @param results A freshly-created validated_data struct, with values set
    * as described in the struct documentation.
    * @param mdr The request to be responeded upon the completion of the
-   * validation.
+   * validation (or NULL)
+   * @param fin Context to call back on completion (or NULL)
    */
   void validate_disk_state(validated_data *results,
-                           MDRequestRef& mdr);
+                           MDRequestRef& mdr,
+                           MDSInternalContext *fin);
   static void dump_validation_results(const validated_data& results,
                                       Formatter *f);
 private:

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -242,6 +242,87 @@ public:
   snapid_t          first, last;
   compact_set<snapid_t> dirty_old_rstats;
 
+  class scrub_stamp_info_t {
+  public:
+    /// version we started our latest scrub (whether in-progress or finished)
+    version_t scrub_start_version;
+    /// time we started our latest scrub (whether in-progress or finished)
+    utime_t scrub_start_stamp;
+    /// version we started our most recent finished scrub
+    version_t last_scrub_version;
+    /// time we started our most recent finished scrub
+    utime_t last_scrub_stamp;
+    scrub_stamp_info_t() : scrub_start_version(0), last_scrub_version(0) {}
+  };
+
+  class scrub_info_t : public scrub_stamp_info_t {
+  public:
+    bool last_scrub_dirty; /// are our stamps dirty with respect to disk state?
+    bool scrub_in_progress; /// are we currently scrubbing?
+    /// my own (temporary) stamps and versions for each dirfrag we have
+    std::map<frag_t, scrub_stamp_info_t> dirfrag_stamps;
+
+    scrub_info_t() : scrub_stamp_info_t(), last_scrub_dirty(false),
+        scrub_in_progress(false) {}
+  };
+
+  const scrub_info_t *scrub_info() const{
+    if (!scrub_infop)
+      scrub_info_create();
+    return scrub_infop;
+  }
+  /**
+   * Start scrubbing on this inode. That could be very short if it's
+   * a file, or take a long time if we're recursively scrubbing a directory.
+   * @pre It is not currently scrubbing
+   * @post it has set up internal scrubbing state
+   * @param scrub_version What version are we scrubbing at (usually, parent
+   * directory's get_projected_version())
+   */
+  void scrub_initialize(version_t scrub_version);
+  /**
+   * Get the next dirfrag to scrub. Gives you a frag_t in output param which
+   * you must convert to a CDir (and possibly load off disk).
+   * @param dir A pointer to frag_t, will be filled in with the next dirfrag to
+   * scrub if there is one.
+   * @returns 0 on success, you should scrub the passed-out frag_t right now;
+   * ENOENT: There are no remaining dirfrags to scrub
+   * <0 There was some other error (It will return -ENOTDIR if not a directory)
+   */
+  int scrub_dirfrag_next(frag_t* out_dirfrag);
+  /**
+   * Get the currently scrubbing dirfrags. When returned, the
+   * passed-in list will be filled in with all frag_ts which have
+   * been returned from scrub_dirfrag_next but not sent back
+   * via scrub_dirfrag_finished.
+   */
+  void scrub_dirfrags_scrubbing(list<frag_t> *out_dirfrags);
+  /**
+   * Report to the CInode that a dirfrag it owns has been scrubbed. Call
+   * this for every frag_t returned from scrub_dirfrag_next().
+   * @param dirfrag The frag_t that was scrubbed
+   */
+  void scrub_dirfrag_finished(frag_t dirfrag);
+  /**
+   * Call this once the scrub has been completed, whether it's a full
+   * recursive scrub on a directory or simply the data on a file (or
+   * anything in between).
+   * @param c An out param which is filled in with a Context* that must
+   * be complete()ed.
+   */
+  void scrub_finished(Context **c);
+
+private:
+  /**
+   * Create a scrub_info_t struct for the scrub_infop poitner.
+   */
+  void scrub_info_create() const;
+  /**
+   * Delete the scrub_info_t struct if it's not got any useful data
+   */
+  void scrub_maybe_delete_info();
+public:
+
   bool is_multiversion() const {
     return snaprealm ||  // other snaprealms will link to me
       inode.is_dir() ||  // links to me in other snaps
@@ -401,6 +482,7 @@ public:
 private:
   compact_map<frag_t,CDir*> dirfrags; // cached dir fragments under this Inode
   int stickydir_ref;
+  scrub_info_t *scrub_infop;
 
 public:
   bool has_dirfrags() { return !dirfrags.empty(); }
@@ -539,6 +621,7 @@ public:
     num_projected_xattrs(0),
     num_projected_srnodes(0),
     stickydir_ref(0),
+    scrub_infop(NULL),
     parent(0),
     inode_auth(CDIR_AUTH_DEFAULT),
     replica_caps_wanted(0),
@@ -1024,5 +1107,7 @@ private:
   friend class ValidationContinuation;
   /** @} Scrubbing and fsck */
 };
+
+ostream& operator<<(ostream& out, const CInode::scrub_stamp_info_t& si);
 
 #endif

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11710,7 +11710,7 @@ void MDCache::scrub_dentry_work(MDRequestRef& mdr)
   CInode::validated_data *vr =
       static_cast<CInode::validated_data*>(mdr->internal_op_private);
 
-  in->validate_disk_state(vr, mdr);
+  in->validate_disk_state(vr, mdr, NULL);
   return;
 }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11739,7 +11739,10 @@ public:
   }
 };
 
-void MDCache::enqueue_scrub(const string& path, Formatter *f, Context *fin)
+void MDCache::enqueue_scrub(
+    const string& path,
+    const std::string &tag,
+    Formatter *f, Context *fin)
 {
   dout(10) << "scrub_dentry " << path << dendl;
   MDRequestRef mdr = request_start_internal(CEPH_MDS_OP_ENQUEUE_SCRUB);
@@ -11749,7 +11752,7 @@ void MDCache::enqueue_scrub(const string& path, Formatter *f, Context *fin)
   C_ScrubEnqueued *se = new C_ScrubEnqueued(mdr, fin, f);
   mdr->internal_op_finish = se;
   // TODO pass through tag/args
-  mdr->internal_op_private = new EnqueueScrubParams(true, true, "foobar");
+  mdr->internal_op_private = new EnqueueScrubParams(true, true, tag);
   enqueue_scrub_work(mdr);
 }
 
@@ -11784,7 +11787,12 @@ void MDCache::enqueue_scrub_work(MDRequestRef& mdr)
     return;
   }
 
-  mds->scrubstack->enqueue_dentry_bottom(dn, true, true, args->tag, NULL);
+  ScrubHeaderRef header(new ScrubHeader());
+
+  header->tag = args->tag;
+  header->origin = dn;
+
+  mds->scrubstack->enqueue_dentry_bottom(dn, true, true, header, NULL);
   delete args;
   mdr->internal_op_private = NULL;
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1128,7 +1128,8 @@ public:
   /**
    * Create and start an OP_ENQUEUE_SCRUB
    */
-  void enqueue_scrub(const string& path, Formatter *f, Context *fin);
+  void enqueue_scrub(const string& path, const std::string &tag,
+                     Formatter *f, Context *fin);
 
   /**
    * Resolve path to a dentry and pass it onto the ScrubStack.

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1115,10 +1115,30 @@ public:
     while (n--) ++p;
     return p->second;
   }
+
   void scrub_dentry(const string& path, Formatter *f, Context *fin);
+  /**
+   * Scrub the named dentry only (skip the scrubstack)
+   */
   void scrub_dentry_work(MDRequestRef& mdr);
+
   void flush_dentry(const string& path, Context *fin);
   void flush_dentry_work(MDRequestRef& mdr);
+
+  /**
+   * Create and start an OP_ENQUEUE_SCRUB
+   */
+  void enqueue_scrub(const string& path, Formatter *f, Context *fin);
+
+  /**
+   * Resolve path to a dentry and pass it onto the ScrubStack.
+   *
+   * TODO: return enough information to the original mdr formatter
+   * and completion that they can subsequeuntly check the progress of
+   * this scrub (we won't block them on a whole scrub as it can take a very
+   * long time)
+   */
+  void enqueue_scrub_work(MDRequestRef& mdr);
 };
 
 class C_MDS_RetryRequest : public MDSInternalContext {

--- a/src/mds/MDSContinuation.h
+++ b/src/mds/MDSContinuation.h
@@ -17,19 +17,15 @@
 #include "mds/Server.h"
  
 class MDSContinuation : public Continuation {
-  MDRequestRef mdr;
-  Server *server;
-public:
-  MDSContinuation(MDRequestRef& mdrequest, Server *s) :
-    Continuation(NULL), mdr(mdrequest), server(s) {}
 protected:
-  void _done() {
-    server->respond_to_request(mdr, get_rval());
-  }
+  Server *server;
   MDSInternalContextBase *get_internal_callback(int stage) {
     return new MDSInternalContextWrapper(server->mds, get_callback(stage));
   }
   MDSIOContextBase *get_io_callback(int stage) {
     return new MDSIOContextWrapper(server->mds, get_callback(stage));
   }
+public:
+  MDSContinuation(Server *s) :
+    Continuation(NULL), server(s) {}
 };

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -236,6 +236,12 @@ void MDSDaemon::set_up_admin_socket()
                                      asok_hook,
                                      "scrub an inode and output results");
   assert(r == 0);
+  r = admin_socket->register_command("tag path",
+                                     "tag path name=path,type=CephString"
+                                     " name=tag,type=CephString",
+                                     asok_hook,
+                                     "Apply scrub tag recursively");
+   assert(r == 0);
   r = admin_socket->register_command("flush_path",
                                      "flush_path name=path,type=CephString",
                                      asok_hook,

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1715,6 +1715,10 @@ bool MDSRankDispatcher::handle_asok_command(
     string path;
     cmd_getval(g_ceph_context, cmdmap, "path", path);
     command_scrub_path(f, path);
+  } else if (command == "tag path") {
+    string path;
+    cmd_getval(g_ceph_context, cmdmap, "path", path);
+    command_tag_path(f, path);
   } else if (command == "flush_path") {
     string path;
     cmd_getval(g_ceph_context, cmdmap, "path", path);
@@ -1852,6 +1856,16 @@ void MDSRank::command_scrub_path(Formatter *f, const string& path)
   }
   scond.wait();
   // scrub_dentry() finishers will dump the data for us; we're done!
+}
+
+void MDSRank::command_tag_path(Formatter *f, const string& path)
+{
+  C_SaferCond scond;
+  {
+    Mutex::Locker l(mds_lock);
+    mdcache->enqueue_scrub(path, f, &scond);
+  }
+  scond.wait();
 }
 
 void MDSRank::command_flush_path(Formatter *f, const string& path)

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1718,7 +1718,9 @@ bool MDSRankDispatcher::handle_asok_command(
   } else if (command == "tag path") {
     string path;
     cmd_getval(g_ceph_context, cmdmap, "path", path);
-    command_tag_path(f, path);
+    string tag;
+    cmd_getval(g_ceph_context, cmdmap, "tag", tag);
+    command_tag_path(f, path, tag);
   } else if (command == "flush_path") {
     string path;
     cmd_getval(g_ceph_context, cmdmap, "path", path);
@@ -1858,12 +1860,13 @@ void MDSRank::command_scrub_path(Formatter *f, const string& path)
   // scrub_dentry() finishers will dump the data for us; we're done!
 }
 
-void MDSRank::command_tag_path(Formatter *f, const string& path)
+void MDSRank::command_tag_path(Formatter *f,
+    const string& path, const std::string &tag)
 {
   C_SaferCond scond;
   {
     Mutex::Locker l(mds_lock);
-    mdcache->enqueue_scrub(path, f, &scond);
+    mdcache->enqueue_scrub(path, tag, f, &scond);
   }
   scond.wait();
 }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -19,8 +19,6 @@
 #include "messages/MMDSMap.h"
 
 #include "MDSMap.h"
-//#include "MDS.h"
-#include "mds_table_types.h"
 #include "SnapClient.h"
 #include "SnapServer.h"
 #include "MDBalancer.h"
@@ -30,6 +28,7 @@
 #include "InoTable.h"
 #include "mon/MonClient.h"
 #include "common/HeartbeatMap.h"
+#include "ScrubStack.h"
 
 
 #include "MDSRank.h"
@@ -56,7 +55,8 @@ MDSRank::MDSRank(
     mdsmap(mdsmap_),
     objecter(objecter_),
     server(NULL), mdcache(NULL), locker(NULL), mdlog(NULL),
-    balancer(NULL), inotable(NULL), snapserver(NULL), snapclient(NULL),
+    balancer(NULL), scrubstack(NULL),
+    inotable(NULL), snapserver(NULL), snapclient(NULL),
     sessionmap(this), logger(NULL), mlogger(NULL),
     op_tracker(g_ceph_context, g_conf->mds_enable_op_tracker, 
                g_conf->osd_num_op_tracker_shard),
@@ -79,6 +79,8 @@ MDSRank::MDSRank(
   mdlog = new MDLog(this);
   balancer = new MDBalancer(this, messenger, monc);
 
+  scrubstack = new ScrubStack(mdcache, finisher);
+
   inotable = new InoTable(this);
   snapserver = new SnapServer(this, monc);
   snapclient = new SnapClient(this);
@@ -98,6 +100,7 @@ MDSRank::~MDSRank()
     g_ceph_context->get_heartbeat_map()->remove_worker(hb);
   }
 
+  if (scrubstack) { delete scrubstack; scrubstack = NULL; }
   if (mdcache) { delete mdcache; mdcache = NULL; }
   if (mdlog) { delete mdlog; mdlog = NULL; }
   if (balancer) { delete balancer; balancer = NULL; }

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -107,6 +107,7 @@ class Objecter;
 class MonClient;
 class Finisher;
 class MMDSMap;
+class ScrubStack;
 
 /**
  * The public part of this class's interface is what's exposed to all
@@ -151,6 +152,7 @@ class MDSRank {
     Locker       *locker;
     MDLog        *mdlog;
     MDBalancer   *balancer;
+    ScrubStack   *scrubstack;
 
     InoTable     *inotable;
 

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -368,7 +368,8 @@ class MDSRank {
 
   protected:
     void command_scrub_path(Formatter *f, const string& path);
-    void command_tag_path(Formatter *f, const string& path);
+    void command_tag_path(Formatter *f, const string& path,
+                          const string &tag);
     void command_flush_path(Formatter *f, const string& path);
     void command_flush_journal(Formatter *f);
     void command_get_subtrees(Formatter *f);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -368,6 +368,7 @@ class MDSRank {
 
   protected:
     void command_scrub_path(Formatter *f, const string& path);
+    void command_tag_path(Formatter *f, const string& path);
     void command_flush_path(Formatter *f, const string& path);
     void command_flush_journal(Formatter *f);
     void command_get_subtrees(Formatter *f);

--- a/src/mds/Makefile-server.am
+++ b/src/mds/Makefile-server.am
@@ -37,6 +37,7 @@ noinst_HEADERS += \
 	mds/Migrator.h \
 	mds/ScatterLock.h \
 	mds/ScrubStack.h \
+	mds/ScrubHeader.h \
 	mds/Server.h \
 	mds/SessionMap.h \
 	mds/SimpleLock.h \

--- a/src/mds/Makefile-server.am
+++ b/src/mds/Makefile-server.am
@@ -36,6 +36,7 @@ noinst_HEADERS += \
 	mds/Mutation.h \
 	mds/Migrator.h \
 	mds/ScatterLock.h \
+	mds/ScrubStack.h \
 	mds/Server.h \
 	mds/SessionMap.h \
 	mds/SimpleLock.h \

--- a/src/mds/Makefile.am
+++ b/src/mds/Makefile.am
@@ -23,6 +23,7 @@ LIBMDS_SOURCES = \
 	mds/MDSTableClient.cc \
 	mds/MDSTableServer.cc \
 	mds/SimpleLock.cc \
+	mds/ScrubStack.cc \
 	mds/SnapRealm.cc \
 	mds/SnapServer.cc \
 	mds/snap.cc \

--- a/src/mds/ScrubHeader.h
+++ b/src/mds/ScrubHeader.h
@@ -1,0 +1,23 @@
+
+#ifndef SCRUB_HEADER_H_
+#define SCRUB_HEADER_H_
+
+class CDentry;
+
+/**
+ * Externally input parameters for a scrub, associated with the root
+ * of where we are doing a recursive scrub
+ *
+ * TODO: swallow up 'recurse' and 'children' settings here instead of
+ * passing them down into every scrub_info structure
+ */
+class ScrubHeader {
+public:
+  std::string tag;
+  CDentry *origin;
+};
+typedef ceph::shared_ptr<ScrubHeader> ScrubHeaderRef;
+typedef ceph::shared_ptr<const ScrubHeader> ScrubHeaderRefConst;
+
+#endif // SCRUB_HEADER_H_
+

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -153,9 +153,6 @@ void ScrubStack::scrub_dir_dentry(CDentry *dn,
     // the stack... or actually is that right?  Should we perhaps
     // only see ourselves once on the way down and once on the way
     // back up again, and not do this?
-
-    // Hmm, bigger problem, we can only actually 
-
     in->scrub_initialize(in->get_version());
   }
 
@@ -288,18 +285,15 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children,
   *is_terminal = false;
   *done = false;
 
-  // XXX HACK get the frag complete before calling
-  // scrub intiialize
-  if (!dir->is_complete()) {
-    dir->fetch(new C_KickOffScrubs(mdcache->mds, this));
-    return;
-  }
-
   if (!dir->scrub_info()->directory_scrubbing) {
-    // FIXME: greg - the CDir API seems inconsistent here, as
-    // scrub_initialize wants the dir to be complete before
-    // we start, but scrub_dentry_next handles incompleteness
-    // via its EAGAIN path.
+    // Get the frag complete before calling
+    // scrub initialize, so that it can populate its lists
+    // of dentries.
+    if (!dir->is_complete()) {
+      dir->fetch(new C_KickOffScrubs(mdcache->mds, this));
+      return;
+    }
+
     dir->scrub_initialize();
   }
 

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -1,0 +1,430 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <iostream>
+
+#include "ScrubStack.h"
+#include "common/Finisher.h"
+#include "mds/MDSRank.h"
+#include "mds/MDCache.h"
+#include "mds/MDSContinuation.h"
+
+#define dout_subsys ceph_subsys_mds
+#undef dout_prefix
+#define dout_prefix _prefix(_dout, scrubstack->mdcache->mds)
+static ostream& _prefix(std::ostream *_dout, MDSRank *mds) {
+  return *_dout << "mds." << mds->get_nodeid() << ".scrubstack ";
+}
+
+void ScrubStack::push_dentry(CDentry *dentry)
+{
+  dout(20) << "pushing " << *dentry << " on top of ScrubStack" << dendl;
+  dentry->get(CDentry::PIN_SCRUBQUEUE);
+  if (!dentry->item_scrub.is_on_list()) {
+    stack_size++;
+  }
+  dentry_stack.push_front(&dentry->item_scrub);
+}
+
+void ScrubStack::push_dentry_bottom(CDentry *dentry)
+{
+  dout(20) << "pushing " << *dentry << " on bottom of ScrubStack" << dendl;
+  dentry->get(CDentry::PIN_SCRUBQUEUE);
+  if (!dentry->item_scrub.is_on_list()) {
+    stack_size++;
+  }
+  dentry_stack.push_back(&dentry->item_scrub);
+}
+
+void ScrubStack::pop_dentry(CDentry *dn)
+{
+  dout(20) << "popping " << *dn
+          << " off of ScrubStack" << dendl;
+  assert(dn->item_scrub.is_on_list());
+  dn->put(CDentry::PIN_SCRUBQUEUE);
+  dn->item_scrub.remove_myself();
+  stack_size--;
+}
+
+void ScrubStack::_enqueue_dentry(CDentry *dn, CDir *parent, bool recursive,
+    bool children, const std::string &tag,
+    MDSInternalContextBase *on_finish, bool top)
+{
+  dout(10) << __func__ << " with {" << *dn << "}"
+           << ", recursive=" << recursive << ", children=" << children
+           << ", on_finish=" << on_finish << ", top=" << top << dendl;
+  assert(mdcache->mds->mds_lock.is_locked_by_me());
+  dn->scrub_initialize(parent, recursive, children, on_finish);
+  if (top)
+    push_dentry(dn);
+  else
+    push_dentry_bottom(dn);
+}
+
+void ScrubStack::enqueue_dentry(CDentry *dn, bool recursive, bool children,
+                                const std::string &tag,
+                                 MDSInternalContextBase *on_finish, bool top)
+{
+  _enqueue_dentry(dn, NULL, recursive, children, tag, on_finish, top);
+  kick_off_scrubs();
+}
+
+void ScrubStack::kick_off_scrubs()
+{
+  dout(20) << __func__ << " entering with " << scrubs_in_progress << " in "
+              "progress and " << stack_size << " in the stack" << dendl;
+  bool can_continue = true;
+  elist<CDentry*>::iterator i = dentry_stack.begin();
+  while (g_conf->mds_max_scrub_ops_in_progress > scrubs_in_progress &&
+      can_continue && !i.end()) {
+    CDentry *cur = *i;
+
+    dout(20) << __func__ << " examining dentry " << *cur << dendl;
+
+    CInode *curi = cur->get_projected_inode();
+    ++i; // we have our reference, push iterator forward
+
+    if (!curi->is_dir()) {
+      // it's a regular file, symlink, or hard link
+      pop_dentry(cur); // we only touch it this once, so remove from stack
+
+      if (curi->is_file()) {
+        scrub_file_dentry(cur);
+        can_continue = true;
+      } else {
+        // drat, we don't do anything with these yet :(
+        dout(5) << "skipping scrub on non-dir, non-file dentry "
+                << *cur << dendl;
+      }
+    } else {
+      bool completed; // it's done, so pop it off the stack
+      bool terminal; // not done, but we can start ops on other directories
+      bool progress; // it added new dentries to the top of the stack
+      scrub_dir_dentry(cur, &progress, &terminal, &completed);
+      if (completed) {
+        dout(20) << __func__ << " dir completed" << dendl;
+        pop_dentry(cur);
+      } else if (progress) {
+        dout(20) << __func__ << " dir progressed" << dendl;
+        // we added new stuff to top of stack, so reset ourselves there
+        i = dentry_stack.begin();
+      } else {
+        dout(20) << __func__ << " dir no-op" << dendl;
+      }
+
+      can_continue = progress || terminal || completed;
+    }
+  }
+}
+
+void ScrubStack::scrub_dir_dentry(CDentry *dn,
+                                  bool *added_children,
+                                  bool *terminal,
+                                  bool *done)
+{
+  assert(dn != NULL);
+  dout(10) << __func__ << *dn << dendl;
+
+  if (!dn->scrub_info()->scrub_children &&
+      !dn->scrub_info()->scrub_recursive) {
+    // TODO: we have to scrub the local dentry/inode, but nothing else
+  }
+
+  *added_children = false;
+  *terminal = false;
+  *done = false;
+
+  CInode *in = dn->get_projected_inode();
+  // FIXME: greg -- is get_version the appropriate version?  (i.e. is scrub_version
+  // meant to be an actual version that we're scrubbing, or something else?)
+  if (!in->scrub_info()->scrub_in_progress) {
+    // We may come through here more than once on our way up and down
+    // the stack... or actually is that right?  Should we perhaps
+    // only see ourselves once on the way down and once on the way
+    // back up again, and not do this?
+
+    // Hmm, bigger problem, we can only actually 
+
+    in->scrub_initialize(in->get_version());
+  }
+
+  list<frag_t> scrubbing_frags;
+  list<CDir*> scrubbing_cdirs;
+  in->scrub_dirfrags_scrubbing(&scrubbing_frags);
+  dout(20) << __func__ << " iterating over " << scrubbing_frags.size()
+    << " scrubbing frags" << dendl;
+  for (list<frag_t>::iterator i = scrubbing_frags.begin();
+      i != scrubbing_frags.end();
+      ++i) {
+    // turn frags into CDir *
+    CDir *dir = in->get_dirfrag(*i);
+    scrubbing_cdirs.push_back(dir);
+    dout(25) << __func__ << " got CDir " << *dir << " presently scrubbing" << dendl;
+  }
+
+
+  dout(20) << __func__ << " consuming from " << scrubbing_cdirs.size()
+    << " scrubbing cdirs" << dendl;
+
+  list<CDir*>::iterator i = scrubbing_cdirs.begin();
+  bool all_frags_terminal = true;
+  bool all_frags_done = true;
+  bool finally_done = false;
+  while (g_conf->mds_max_scrub_ops_in_progress > scrubs_in_progress) {
+    // select next CDir
+    CDir *cur_dir = NULL;
+    if (i != scrubbing_cdirs.end()) {
+      cur_dir = *i;
+      ++i;
+      dout(20) << __func__ << " got cur_dir = " << *cur_dir << dendl;
+    } else {
+      bool ready = get_next_cdir(in, &cur_dir);
+      dout(20) << __func__ << " get_next_cdir ready=" << ready << dendl;
+      if (cur_dir) {
+        cur_dir->scrub_initialize();
+      }
+
+      if (ready && cur_dir) {
+        scrubbing_cdirs.push_back(cur_dir);
+      } else if (!ready) {
+        // We are waiting for load of a frag
+        all_frags_done = false;
+        all_frags_terminal = false;
+        break;
+      } else {
+        // Finished with all frags
+        break;
+      }
+    }
+    // scrub that CDir
+    bool frag_added_children = false;
+    bool frag_terminal = true;
+    bool frag_done = false;
+    scrub_dirfrag(cur_dir, &frag_added_children, &frag_terminal, &frag_done);
+    if (frag_done) {
+      // FIXME is this right?  Can we end up hitting this more than
+      // once and is that a problem?
+      cur_dir->inode->scrub_dirfrag_finished(cur_dir->frag);
+    }
+    *added_children |= frag_added_children;
+    all_frags_terminal = all_frags_terminal && frag_terminal;
+    all_frags_done = all_frags_done && frag_done;
+  }
+
+  dout(20) << "finished looping; all_frags_terminal=" << all_frags_terminal
+           << ", all_frags_done=" << all_frags_done << dendl;
+  if (all_frags_done) {
+    assert (!*added_children); // can't do this if children are still pending
+    scrub_dir_dentry_final(dn, &finally_done);
+  }
+
+  *terminal = all_frags_terminal;
+  *done = all_frags_done && finally_done;
+  dout(10) << __func__ << " is exiting " << *terminal << " " << *done << dendl;
+  return;
+}
+
+bool ScrubStack::get_next_cdir(CInode *in, CDir **new_dir)
+{
+  dout(20) << __func__ << " on " << *in << dendl;
+  frag_t next_frag;
+  int r = in->scrub_dirfrag_next(&next_frag);
+  assert (r >= 0);
+
+  if (r == 0) {
+    // we got a frag to scrub, otherwise it would be ENOENT
+    dout(25) << "looking up new frag " << next_frag << dendl;
+    CDir *next_dir = in->get_or_open_dirfrag(mdcache, next_frag);
+    if (!next_dir->is_complete()) {
+      C_KickOffScrubs *c = new C_KickOffScrubs(mdcache->mds, this);
+      next_dir->fetch(c);
+      dout(25) << "fetching frag from RADOS" << dendl;
+      return false;
+    }
+    *new_dir = next_dir;
+    dout(25) << "returning dir " << *new_dir << dendl;
+    return true;
+  }
+  assert(r == ENOENT);
+  // there are no dirfrags left
+  *new_dir = NULL;
+  return true;
+}
+
+void ScrubStack::scrub_dir_dentry_final(CDentry *dn, bool *finally_done)
+{
+  dout(20) << __func__ << *dn << dendl;
+  *finally_done =true;
+  // FIXME: greg -- is this the right lifetime from the inode's scrub_info?
+  CInode *in = dn->get_projected_inode();
+
+  Context *fin = NULL;
+  in->scrub_finished(&fin);
+  if (fin) {
+    // FIXME: pass some error code in?
+    finisher->queue(new MDSIOContextWrapper(mdcache->mds, fin), 0);
+  }
+  return;
+}
+
+void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children,
+                               bool *is_terminal, bool *done)
+{
+  assert(dir != NULL);
+
+  dout(20) << __func__ << " on " << *dir << dendl;
+  *added_children = false;
+  *is_terminal = false;
+  *done = false;
+
+  // XXX HACK get the frag complete before calling
+  // scrub intiialize
+  if (!dir->is_complete()) {
+    dir->fetch(new C_KickOffScrubs(mdcache->mds, this));
+    return;
+  }
+
+  if (!dir->scrub_info()->directory_scrubbing) {
+    // FIXME: greg - the CDir API seems inconsistent here, as
+    // scrub_initialize wants the dir to be complete before
+    // we start, but scrub_dentry_next handles incompleteness
+    // via its EAGAIN path.
+    dir->scrub_initialize();
+  }
+
+  int r = 0;
+  while(r == 0) {
+    MDSInternalContext *kick = new C_KickOffScrubs(mdcache->mds, this);
+    CDentry *dn = NULL;
+    r = dir->scrub_dentry_next(kick, &dn);
+    if (r != EAGAIN) {
+      // ctx only used by scrub_dentry_next in EAGAIN case
+      // FIXME It's kind of annoying to keep allocating and deleting a ctx here
+      delete kick;
+    }
+
+    if (r == EAGAIN) {
+      // Drop out, CDir fetcher will call back our kicker context
+      return;
+    }
+
+    if (r == ENOENT) {
+      // Nothing left to scrub, are we done?
+      std::list<CDentry*> scrubbing;
+      dir->scrub_dentries_scrubbing(&scrubbing);
+      if (scrubbing.empty()) {
+        // FIXME: greg: What's the diff meant to be between done and terminal
+        *done = true;
+        *is_terminal = true;
+        continue;
+      } else {
+        return;
+      }
+    }
+
+    if (r < 0) {
+      // FIXME: how can I handle an error here?  I can't hold someone up
+      // forever, but I can't say "sure you're scrubbed"
+      //  -- should change scrub_dentry_next definition to never
+      //  give out IO errors (handle them some other way)
+      //     
+      derr << __func__ << " error from scrub_dentry_next: "
+           << r << dendl;
+      return;
+    }
+
+    // scrub_dentry_next defined to only give -ve, EAGAIN, ENOENT, 0 -- we should
+    // never get random IO errors here.
+    assert(r == 0);
+
+    // FIXME: Do I *really* need to construct a kick context for every
+    // single dentry I'm going to scrub?
+    MDSInternalContext *on_d_scrub = new C_KickOffScrubs(mdcache->mds, this);
+    _enqueue_dentry(dn,
+        dir,
+        /*
+         * FIXME: look up params from dir's inode's parent
+         */
+#if 0
+        dir->scrub_info()->scrub_recursive,
+        dir->scrub_info()->scrub_children,
+#else
+        true,
+        true,
+#endif
+        // FIXME: carry tag through
+        "foobar",
+        on_d_scrub,
+        true);
+
+    *added_children = true;
+  }
+
+#if 0
+  bool any_unscrubbed = false;
+
+  for (CDir::map_t::iterator i = dir->begin(); i != dir->end(); ++ i) {
+    CDentry *dn = i->second;
+
+    if (dir->scrub_info()->directories_scrubbed.count(i->first) == 0
+        && dir->scrub_info()->others_scrubbed.count(i->first) == 0) {
+      dout(20) << __func__ << " dn not yet scrubbed: " << *dn << dendl;
+      any_unscrubbed = true;
+    }
+
+    if (dn->scrub_info()->dentry_scrubbing
+      ||  dir->scrub_info()->directories_scrubbed.count(i->first)
+      || dir->scrub_info()->others_scrubbed.count(i->first)) {
+      dout(20) << __func__ << " skipping already scrubbing or scrubbed " << *dn << dendl;
+      continue;
+    }
+
+    C_KickOffScrubs *c = new C_KickOffScrubs(mdcache->mds, this);
+
+    _enqueue_dentry(dn,
+        dir,
+        /*
+         * FIXME: look up params from dir's inode's parent
+         */
+#if 0
+        dir->scrub_info()->scrub_recursive,
+        dir->scrub_info()->scrub_children,
+#else
+        true,
+        true,
+#endif
+        // FIXME: carry tag through
+        "foobar",
+        c,
+        true);
+
+    *added_children = true;
+  }
+
+  *done = !any_unscrubbed;
+#endif
+}
+
+void ScrubStack::scrub_file_dentry(CDentry *dn)
+{
+  // No-op:
+  // TODO: hook into validate_disk_state
+  Context *c = NULL;
+  dn->scrub_finished(&c);
+  if (c) {
+    // FIXME: pass some error code in?
+    finisher->queue(new MDSIOContextWrapper(mdcache->mds, c), 0);
+  }
+}
+

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -350,14 +350,14 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children,
       if (scrubbing.empty()) {
         dout(20) << __func__ << " dirfrag done: " << *dir << dendl;
         // FIXME: greg: What's the diff meant to be between done and terminal
+	dir->scrub_finished();
         *done = true;
         *is_terminal = true;
-        continue;
       } else {
         dout(20) << __func__ << " " << scrubbing.size() << " dentries still "
                    "scrubbing in " << *dir << dendl;
-        return;
       }
+      return;
     }
 
     if (r < 0) {

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -30,8 +30,8 @@ static ostream& _prefix(std::ostream *_dout, MDSRank *mds) {
 void ScrubStack::push_dentry(CDentry *dentry)
 {
   dout(20) << "pushing " << *dentry << " on top of ScrubStack" << dendl;
-  dentry->get(CDentry::PIN_SCRUBQUEUE);
   if (!dentry->item_scrub.is_on_list()) {
+    dentry->get(CDentry::PIN_SCRUBQUEUE);
     stack_size++;
   }
   dentry_stack.push_front(&dentry->item_scrub);
@@ -40,8 +40,8 @@ void ScrubStack::push_dentry(CDentry *dentry)
 void ScrubStack::push_dentry_bottom(CDentry *dentry)
 {
   dout(20) << "pushing " << *dentry << " on bottom of ScrubStack" << dendl;
-  dentry->get(CDentry::PIN_SCRUBQUEUE);
   if (!dentry->item_scrub.is_on_list()) {
+    dentry->get(CDentry::PIN_SCRUBQUEUE);
     stack_size++;
   }
   dentry_stack.push_back(&dentry->item_scrub);

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -19,6 +19,7 @@
 #include "CDentry.h"
 #include "CInode.h"
 #include "MDSContext.h"
+#include "ScrubHeader.h"
 
 #include "include/elist.h"
 
@@ -59,20 +60,21 @@ public:
    * @param children True if we want to scrub the direct children of
    * dn but aren't doing a recursive scrub. (Otherwise, all checks are
    * local to dn's disk state.)
-   * @param tag If non-empty, tag applied to each verified rados object
+   * @param header The ScrubHeader propagated from whereever this scrub
+   *               was initiated
    */
   void enqueue_dentry_top(CDentry *dn, bool recursive, bool children,
-                          const std::string &tag,
+                          ScrubHeaderRefConst header,
                           MDSInternalContextBase *on_finish) {
-    enqueue_dentry(dn, recursive, children, tag, on_finish, true);
+    enqueue_dentry(dn, recursive, children, header, on_finish, true);
   }
   /** Like enqueue_dentry_top, but we wait for all pending scrubs before
    * starting this one.
    */
   void enqueue_dentry_bottom(CDentry *dn, bool recursive, bool children,
-                             const std::string &tag,
+                             ScrubHeaderRefConst header,
                              MDSInternalContextBase *on_finish) {
-    enqueue_dentry(dn, recursive, children, tag, on_finish, false);
+    enqueue_dentry(dn, recursive, children, header, on_finish, false);
   }
 
 private:
@@ -81,10 +83,10 @@ private:
    * the given scrub params, and then try and kick off more scrubbing.
    */
   void enqueue_dentry(CDentry *dn, bool recursive, bool children,
-                      const std::string &tag,
+                      ScrubHeaderRefConst header,
                       MDSInternalContextBase *on_finish, bool top);
   void _enqueue_dentry(CDentry *dn, CDir *parent, bool recursive, bool children,
-                      const std::string &tag,
+                      ScrubHeaderRefConst header,
                        MDSInternalContextBase *on_finish, bool top);
   /**
    * Kick off as many scrubs as are appropriate, based on the current

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -1,0 +1,186 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef SCRUBSTACK_H_
+#define SCRUBSTACK_H_
+
+#include "CDir.h"
+#include "CDentry.h"
+#include "CInode.h"
+#include "MDSContext.h"
+
+#include "include/elist.h"
+
+class MDCache;
+class Finisher;
+
+class ScrubStack {
+  protected:
+  /// A finisher needed so that we don't re-enter kick_off_scrubs
+  Finisher *finisher;
+
+  /// The stack of dentries we want to scrub
+  elist<CDentry*> dentry_stack;
+  /// current number of dentries we're actually scrubbing
+  int scrubs_in_progress;
+  ScrubStack *scrubstack; // hack for dout
+  int stack_size;
+public:
+  MDCache *mdcache;
+  ScrubStack(MDCache *mdc, Finisher *finisher_) :
+    finisher(finisher_),
+    dentry_stack(member_offset(CDentry, item_scrub)),
+    scrubs_in_progress(0),
+    scrubstack(this),
+    stack_size(0),
+    mdcache(mdc) {}
+  ~ScrubStack() {
+    assert(dentry_stack.empty());
+    assert(!scrubs_in_progress);
+  }
+  /**
+   * Put a dentry on the top of the scrub stack, so it is the highest priority.
+   * If there are other scrubs in progress, they will not continue scrubbing new
+   * entries until this one is completed.
+   * @param dn The dentry to scrub
+   * @param recursive True if we want to recursively scrub the
+   * entire hierarchy under dn.
+   * @param children True if we want to scrub the direct children of
+   * dn but aren't doing a recursive scrub. (Otherwise, all checks are
+   * local to dn's disk state.)
+   * @param tag If non-empty, tag applied to each verified rados object
+   */
+  void enqueue_dentry_top(CDentry *dn, bool recursive, bool children,
+                          const std::string &tag,
+                          MDSInternalContextBase *on_finish) {
+    enqueue_dentry(dn, recursive, children, tag, on_finish, true);
+  }
+  /** Like enqueue_dentry_top, but we wait for all pending scrubs before
+   * starting this one.
+   */
+  void enqueue_dentry_bottom(CDentry *dn, bool recursive, bool children,
+                             const std::string &tag,
+                             MDSInternalContextBase *on_finish) {
+    enqueue_dentry(dn, recursive, children, tag, on_finish, false);
+  }
+
+private:
+  /**
+   * Put the dentry at either the top or bottom of the stack, with
+   * the given scrub params, and then try and kick off more scrubbing.
+   */
+  void enqueue_dentry(CDentry *dn, bool recursive, bool children,
+                      const std::string &tag,
+                      MDSInternalContextBase *on_finish, bool top);
+  void _enqueue_dentry(CDentry *dn, CDir *parent, bool recursive, bool children,
+                      const std::string &tag,
+                       MDSInternalContextBase *on_finish, bool top);
+  /**
+   * Kick off as many scrubs as are appropriate, based on the current
+   * state of the stack.
+   */
+  void kick_off_scrubs();
+  /**
+   * Push a dentry on top of the stack.
+   */
+  inline void push_dentry(CDentry *dentry);
+  /**
+   * Push a dentry to the bottom of the stack.
+   */
+  inline void push_dentry_bottom(CDentry *dentry);
+  /**
+   * Pop the given dentry off the stack.
+   */
+  inline void pop_dentry(CDentry *dn);
+
+  /**
+   * Scrub a file-representing dentry.
+   * @param dn The dentry to scrub
+   * @param progress Out pointer to a bool, which will be set to true.
+   * @pre dn->get_projected_inode()->is_file()==true;
+   */
+  void scrub_file_dentry(CDentry *dn);
+  /**
+   * Make progress on scrubbing a directory-representing dirfrag and
+   * its children..
+   *
+   * 1) Select the next dirfrag which hasn't been scrubbed, and make progress
+   * on it if possible.
+   *
+   * 2) If not, move on to the next dirfrag and start it up, if any.
+   *
+   * 3) If waiting for results from dirfrag scrubs, do nothing.
+   *
+   * 4) If all dirfrags have been scrubbed, scrub my inode.
+   *
+   * @param dn The CDentry to scrub as a directory
+   * @param added_dentries set to true if we pushed some of our children
+   * onto the ScrubStack
+   * @param is_terminal set to true if there are no descendant dentries
+   * remaining to start scrubbing.
+   * @param done set to true if we and all our children have finished scrubbing
+   */
+  void scrub_dir_dentry(CDentry *dn, bool *added_children, bool *is_terminal,
+                        bool *done);
+  /**
+   * Make progress on scrubbing a dirfrag. It may return after each of the
+   * following steps, but will report making progress on each one.
+   *
+   * 1) enqueues the next unscrubbed child directory dentry at the
+   * top of the stack.
+   *
+   * 2) Initiates a scrub on the next unscrubbed file dentry
+   *
+   * If there are scrubs currently in progress on child dentries, no more child
+   * dentries to scrub, and this function is invoked, it will report no
+   * progress. Try again later.
+   *
+   */
+  void scrub_dirfrag(CDir *dir, bool *added_children, bool *is_terminal,
+		     bool *done);
+  /**
+   * Scrub a directory-representing dentry.
+   *
+   * @param dn The CDentry of the directory we're doing final scrub on.
+   * @param done Set to true if the dentry scrub is finished. (That
+   * won't every actually happen, right? It needs disk accesses? I forget.)
+   */
+  void scrub_dir_dentry_final(CDentry *dn, bool *done);
+
+  /**
+   * Get a CDir into memory, and return it if it's already complete.
+   * Otherwise, fetch it and kick off scrubbing when done.
+   *
+   * @param in The Inode to get the next directory from
+   * @param new_dir The CDir we're returning to you. NULL if
+   * not ready yet or there aren't any.
+   * @returns false if you have to wait, true if there's no work
+   * left to do (we returned it, or there are none left in this inode).
+   */
+  bool get_next_cdir(CInode *in, CDir **new_dir);
+
+  class C_KickOffScrubs : public MDSInternalContext {
+    ScrubStack *stack;
+  public:
+    C_KickOffScrubs(MDSRank *mds, ScrubStack *s)
+      : MDSInternalContext(mds), stack(s)
+    {
+    }
+    void finish(int r){
+      stack->kick_off_scrubs();
+    }
+  };
+};
+
+#endif /* SCRUBSTACK_H_ */

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -113,6 +113,17 @@ private:
    * @pre dn->get_projected_inode()->is_file()==true;
    */
   void scrub_file_dentry(CDentry *dn);
+
+  /**
+   * Callback from completion of CInode::validate_disk_state
+   * @param dn The dentry owning the inode we were validating
+   * @param r The return status from validate_disk_state
+   * @param result Populated results from validate_disk_state
+   */
+  void _scrub_file_dentry_done(CDentry *dn, int r,
+    const CInode::validated_data &result);
+  friend class C_InodeValidated;
+
   /**
    * Make progress on scrubbing a directory-representing dirfrag and
    * its children..

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -120,7 +120,7 @@ private:
    * @param r The return status from validate_disk_state
    * @param result Populated results from validate_disk_state
    */
-  void _scrub_file_dentry_done(CDentry *dn, int r,
+  void _validate_inode_done(CDentry *dn, int r,
     const CInode::validated_data &result);
   friend class C_InodeValidated;
 

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -166,10 +166,8 @@ private:
    * Scrub a directory-representing dentry.
    *
    * @param dn The CDentry of the directory we're doing final scrub on.
-   * @param done Set to true if the dentry scrub is finished. (That
-   * won't every actually happen, right? It needs disk accesses? I forget.)
    */
-  void scrub_dir_dentry_final(CDentry *dn, bool *done);
+  void scrub_dir_dentry_final(CDentry *dn);
 
   /**
    * Get a CDir into memory, and return it if it's already complete.

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -44,6 +44,7 @@ protected:
     C_KickOffScrubs(MDCache *mdcache, ScrubStack *s);
     void finish(int r) { }
     void complete(int r) {
+      stack->scrubs_in_progress--;
       stack->kick_off_scrubs();
       // don't delete self
     }

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -256,7 +256,7 @@ void inline_data_t::decode(bufferlist::iterator &p)
  */
 void inode_t::encode(bufferlist &bl) const
 {
-  ENCODE_START(12, 6, bl);
+  ENCODE_START(13, 6, bl);
 
   ::encode(ino, bl);
   ::encode(rdev, bl);
@@ -300,12 +300,15 @@ void inode_t::encode(bufferlist &bl) const
 
   ::encode(stray_prior_path, bl);
 
+  ::encode(last_scrub_version, bl);
+  ::encode(last_scrub_stamp, bl);
+
   ENCODE_FINISH(bl);
 }
 
 void inode_t::decode(bufferlist::iterator &p)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(12, 6, 6, p);
+  DECODE_START_LEGACY_COMPAT_LEN(13, 6, 6, p);
 
   ::decode(ino, p);
   ::decode(rdev, p);
@@ -369,8 +372,15 @@ void inode_t::decode(bufferlist::iterator &p)
     backtrace_version = 0; // force update backtrace
   if (struct_v >= 11)
     ::decode(quota, p);
-  if (struct_v >= 12)
+
+  if (struct_v >= 12) {
     ::decode(stray_prior_path, p);
+  }
+
+  if (struct_v >= 13) {
+    ::decode(last_scrub_version, p);
+    ::decode(last_scrub_stamp, p);
+  }
 
   DECODE_FINISH(p);
 }

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -568,7 +568,7 @@ void old_inode_t::generate_test_instances(list<old_inode_t*>& ls)
  */
 void fnode_t::encode(bufferlist &bl) const
 {
-  ENCODE_START(3, 3, bl);
+  ENCODE_START(4, 3, bl);
   ::encode(version, bl);
   ::encode(snap_purged_thru, bl);
   ::encode(fragstat, bl);
@@ -576,6 +576,10 @@ void fnode_t::encode(bufferlist &bl) const
   ::encode(rstat, bl);
   ::encode(accounted_rstat, bl);
   ::encode(damage_flags, bl);
+  ::encode(recursive_scrub_version, bl);
+  ::encode(recursive_scrub_stamp, bl);
+  ::encode(localized_scrub_version, bl);
+  ::encode(localized_scrub_stamp, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -590,6 +594,12 @@ void fnode_t::decode(bufferlist::iterator &bl)
   ::decode(accounted_rstat, bl);
   if (struct_v >= 3) {
     ::decode(damage_flags, bl);
+  }
+  if (struct_v >= 4) {
+    ::decode(recursive_scrub_version, bl);
+    ::decode(recursive_scrub_stamp, bl);
+    ::decode(localized_scrub_version, bl);
+    ::decode(localized_scrub_stamp, bl);
   }
   DECODE_FINISH(bl);
 }

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -674,6 +674,8 @@ struct dentry_key_t {
   dentry_key_t() : snapid(0), name(0) {}
   dentry_key_t(snapid_t s, const char *n) : snapid(s), name(n) {}
 
+  bool is_valid() { return name || snapid; }
+
   // encode into something that can be decoded as a string.
   // name_ (head) or name_%x (!head)
   void encode(bufferlist& bl) const {

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -464,6 +464,9 @@ struct inode_t {
   version_t file_data_version; // auth only
   version_t xattr_version;
 
+  utime_t last_scrub_stamp;    // start time of last complete scrub
+  version_t last_scrub_version;// (parent) start version of last complete scrub
+
   version_t backtrace_version;
 
   snapid_t oldest_snap;
@@ -476,7 +479,8 @@ struct inode_t {
 	      truncate_seq(0), truncate_size(0), truncate_from(0),
 	      truncate_pending(0),
 	      time_warp_seq(0),
-	      version(0), file_data_version(0), xattr_version(0), backtrace_version(0) {
+	      version(0), file_data_version(0), xattr_version(0),
+	      last_scrub_version(0), backtrace_version(0) {
     clear_layout();
     memset(&dir_layout, 0, sizeof(dir_layout));
     memset(&quota, 0, sizeof(quota));

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -614,11 +614,19 @@ struct fnode_t {
   nest_info_t rstat, accounted_rstat;
   damage_flags_t damage_flags;
 
+  // we know we and all our descendants have been scrubbed since this version
+  version_t recursive_scrub_version;
+  utime_t recursive_scrub_stamp;
+  // version at which we last scrubbed our personal data structures
+  version_t localized_scrub_version;
+  utime_t localized_scrub_stamp;
+
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator& bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<fnode_t*>& ls);
-  fnode_t() : version(0) {}
+  fnode_t() : version(0),
+	      recursive_scrub_version(0), localized_scrub_version(0) {}
 };
 WRITE_CLASS_ENCODER(fnode_t)
 


### PR DESCRIPTION
This is the stuff from my branch, minus the orphan-finding stuff in data-scan (which will come later after #5545)

I would like to come back later and refactor the scrub_info_p stuff, in order to avoid putting all the methods directly onto the CDir/CInode/CDentry classes, and to avoid the slightly odd implicit construction of the info object from scrub_info().

Getting the guts of this landed (albeit probably a bit rough around the edges) is desirable to enable the other work (DamageTable, orphan finding in cephfs-data-scan) to proceed.

TestForwardScrub.test_apply_tag (from wip-scrub-jcs ceph-qa-suite branch) verifies the basics of this.