### PR TITLE
rbd: add --object-size option

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -10,7 +10,7 @@ Synopsis
 ========
 
 | **rbd** [ -c *ceph.conf* ] [ -m *monaddr* ] [ -p | --pool *pool* ] [
-  --size *size* ] [ --order *bits* ] [ *command* ... ]
+  --size *size* ] [ --object-size *B/K/M* ] [ *command* ... ]
 
 
 Description
@@ -65,10 +65,10 @@ Parameters
 
    Specifies the size (in M/G/T) of the new rbd image.
 
-.. option:: --order bits
+.. option:: --object-size B/K/M
 
-   Specifies the object size expressed as a number of bits, such that
-   the object size is ``1 << order``. The default is 22 (4 MB).
+   Specifies the object size in B/K/M, it will be rounded up the nearest power of two.
+   The default object size is 4 MB, smallest is 4K and maximum is 32M.
 
 .. option:: --stripe-unit size-in-B/K/M
 
@@ -172,17 +172,17 @@ Commands
   require querying the OSDs for every potential object within the image.
 
 :command:`info` *image-spec* | *snap-spec*
-  Will dump information (such as size and order) about a specific rbd image.
+  Will dump information (such as size and object size) about a specific rbd image.
   If image is a clone, information about its parent is also displayed.
   If a snapshot is specified, whether it is protected is shown as well.
 
-:command:`create` (-s | --size *size-in-M/G/T*) [--image-format *format-id*] [--order *bits*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *image-spec*
+:command:`create` (-s | --size *size-in-M/G/T*) [--image-format *format-id*] [--object-size *B/K/M*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *image-spec*
   Will create a new rbd image. You must also specify the size via --size.  The
   --stripe-unit and --stripe-count arguments are optional, but must be used together.
 
-:command:`clone` [--order *bits*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*] [--image-shared] *parent-snap-spec* *child-image-spec*
+:command:`clone` [--object-size *B/K/M*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*] [--image-shared] *parent-snap-spec* *child-image-spec*
   Will create a clone (copy-on-write child) of the parent snapshot.
-  Object order will be identical to that of the parent image unless
+  Object size will be identical to that of the parent image unless
   specified. Size will be the same as the parent snapshot. The --stripe-unit
   and --stripe-count arguments are optional, but must be used together.
 
@@ -214,11 +214,11 @@ Commands
 :command:`export` (*image-spec* | *snap-spec*) [*dest-path*]
   Exports image to dest path (use - for stdout).
 
-:command:`import` [--image-format *format-id*] [--order *bits*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *src-path* [*image-spec*]
+:command:`import` [--image-format *format-id*] [--object-size *B/K/M*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *src-path* [*image-spec*]
   Creates a new image and imports its data from path (use - for
   stdin).  The import operation will try to create sparse rbd images 
   if possible.  For import from stdin, the sparsification unit is
-  the data block size of the destination image (1 << order).
+  the data block size of the destination image (object size).
 
   The --stripe-unit and --stripe-count arguments are optional, but must be
   used together.
@@ -253,7 +253,7 @@ Commands
 
 :command:`cp` (*src-image-spec* | *src-snap-spec*) *dest-image-spec*
   Copies the content of a src-image into the newly created dest-image.
-  dest-image will have the same size, order, and image format as src-image.
+  dest-image will have the same size, object size, and image format as src-image.
 
 :command:`mv` *src-image-spec* *dest-image-spec*
   Renames an image.  Note: rename across pools is not supported.
@@ -371,10 +371,10 @@ bottleneck when individual images get large or busy.
 
 The striping is controlled by three parameters:
 
-.. option:: order
+.. option:: object-size
 
-  The size of objects we stripe over is a power of two, specifically 2^[*order*] bytes.  The default
-  is 22, or 4 MB.
+  The size of objects we stripe over is a power of two. It will be rounded up the nearest power of two.
+  The default object size is 4 MB, smallest is 4K and maximum is 32M.
 
 .. option:: stripe_unit
 
@@ -384,8 +384,8 @@ The striping is controlled by three parameters:
 .. option:: stripe_count
 
   After we write [*stripe_unit*] bytes to [*stripe_count*] objects, we loop back to the initial object
-  and write another stripe, until the object reaches its maximum size (as specified by [*order*].  At that
-  point, we move on to the next [*stripe_count*] objects.
+  and write another stripe, until the object reaches its maximum size.  At that point,
+  we move on to the next [*stripe_count*] objects.
 
 By default, [*stripe_unit*] is the same as the object size and [*stripe_count*] is 1.  Specifying a different
 [*stripe_unit*] requires that the STRIPINGV2 feature be supported (added in Ceph v0.53) and format 2 images be
@@ -452,7 +452,7 @@ To create a new rbd image that is 100 GB::
 
 To use a non-default object size (8 MB)::
 
-       rbd create mypool/myimage --size 102400 --order 23
+       rbd create mypool/myimage --size 102400 --object-size 8M
 
 To delete an rbd image (be careful!)::
 

--- a/src/test/cli-integration/rbd/defaults.t
+++ b/src/test/cli-integration/rbd/defaults.t
@@ -12,7 +12,7 @@ Plain create with various options specified via usual cli arguments
       "size": 1048576
   }
   $ rbd rm test --no-progress
-  $ rbd create -s 1 --order 20 test
+  $ rbd create -s 1 --object-size 1M test
   $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "block_name_prefix": "rb.0.*",  (glob)
@@ -22,6 +22,18 @@ Plain create with various options specified via usual cli arguments
       "objects": 1, 
       "order": 20, 
       "size": 1048576
+  }
+  $ rbd rm test --no-progress
+  $ rbd create -s 1G --object-size 4K test
+  $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
+  {
+      "block_name_prefix": "rb.0.*",  (glob)
+      "format": 1, 
+      "name": "test", 
+      "object_size": 4096, 
+      "objects": 262144, 
+      "order": 12, 
+      "size": 1073741824
   }
   $ rbd rm test --no-progress
   $ rbd create -s 1 test --image-format 2
@@ -58,7 +70,7 @@ Plain create with various options specified via usual cli arguments
       "size": 1073741824
   }
   $ rbd rm test --no-progress
-  $ rbd create -s 1 test --image-format 2 --order 20
+  $ rbd create -s 1 test --image-format 2 --object-size 1M
   $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "block_name_prefix": "rbd_data.*",  (glob)
@@ -173,7 +185,7 @@ Format 2 Usual arguments with custom rbd_default_* params
       "stripe_unit": 1048576
   }
   $ rbd rm test --no-progress
-  $ rbd create -s 1 test --image-format 2 --stripe-unit 1048576 --stripe-count 8 --order 23 --rbd-default-order 20
+  $ rbd create -s 1 test --image-format 2 --stripe-unit 1048576 --stripe-count 8 --object-size 8M --rbd-default-order 20
   $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "block_name_prefix": "rbd_data.*",  (glob)

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -8,9 +8,9 @@
                                                 image or snapshot
     info <image-spec> | <snap-spec>             show information about image size,
                                                 striping, etc.
-    create [--order <bits>] [--image-features <features>] [--image-shared]
+    create [--object-size <B/K/M>] [--image-features <features>] [--image-shared]
            --size <M/G/T> <image-spec>          create an empty image
-    clone [--order <bits>] [--image-features <features>] [--image-shared]
+    clone [--object-size <B/K/M>] [--image-features <features>] [--image-shared]
            <parent-snap-spec> <child-image-spec>
                                                 clone a snapshot into a COW
                                                 child image
@@ -89,8 +89,8 @@
     --snap <snap-name>                 snapshot name
     --path <path-name>                 path name for import/export
     -s, --size <size in M/G/T>         size of image for create and resize
-    --order <bits>                     the object size in bits; object size will be
-                                       (1 << order) bytes. Default is 22 (4 MB).
+    --object-size <B/K/M>              the object size in B/K/M
+                                       default object size is 4 MB.
     --image-format <format-number>     format to use when creating an image
                                        format 1 is the original format
                                        format 2 supports cloning (default)


### PR DESCRIPTION
Object size can be specified when creating an image with the --order option,
as a number of bits in the size.

This patch is adding new option --object-size. This new  option will specify
object size directly for example  --object-size 2M.

It would be easier to use. --order is still present for backwards compatibility.
For simplicity, we are rounding up the object size to the nearest power of 2.

Fixes #12112

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>