### PR TITLE
rgw: delete finisher only after finalizing watches

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1432,10 +1432,16 @@ void RGWRados::finalize()
 {
   if (finisher) {
     finisher->stop();
-    delete finisher;
   }
   if (need_watch_notify()) {
     finalize_watch();
+  }
+  if (finisher) {
+    /* delete finisher only after cleaning up watches, as watch error path might call
+     * into finisher. We stop finisher before finalizing watch to make sure we don't
+     * actually handle any racing work
+     */
+    delete finisher;
   }
   delete meta_mgr;
   delete data_log;


### PR DESCRIPTION
Fixes: #12208

The watch error path might try to schedule a finisher work, delete finisher
only after watch destruction.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>