### PR TITLE
test: disable newstore test until it's merged

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -55,6 +55,10 @@ public:
                                               string(GetParam()),
                                               string("store_test_temp_dir"),
                                               string("store_test_temp_journal"));
+    if (!store_) {
+      cerr << __func__ << ": objectstore type " << string(GetParam()) << " doesn't exist yet!" << std::endl;
+      return;
+    }
     store.reset(store_);
     EXPECT_EQ(store->mkfs(), 0);
     EXPECT_EQ(store->mount(), 0);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -65,7 +65,8 @@ public:
   }
 
   virtual void TearDown() {
-    store->umount();
+    if (store)
+      store->umount();
   }
 };
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2413,7 +2413,7 @@ TEST_P(StoreTest, SetAllocHint) {
 INSTANTIATE_TEST_CASE_P(
   ObjectStore,
   StoreTest,
-  ::testing::Values("memstore", "filestore", "keyvaluestore", "newstore"));
+  ::testing::Values("memstore", "filestore", "keyvaluestore"/*, "newstore" */));
 
 #else
 


### PR DESCRIPTION
Newstore hasn't been merged. It leads to a segment fault in one of the
teuthology testing job since ObjectStore::create() returns NULL.