### PR TITLE
osd: handle backend op_commit on cancelled op

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -623,6 +623,11 @@ void ReplicatedBackend::op_applied(
   InProgressOp *op)
 {
   dout(10) << __func__ << ": " << op->tid << dendl;
+  if (!in_progress_ops.count(op->tid) || &(in_progress_ops.find(op->tid)->second) != op) {
+    // the op has been cancelled because of a change
+    return;
+  }
+
   if (op->op)
     op->op->mark_event("op_applied");
 
@@ -643,6 +648,11 @@ void ReplicatedBackend::op_commit(
   InProgressOp *op)
 {
   dout(10) << __func__ << ": " << op->tid << dendl;
+  if (!in_progress_ops.count(op->tid) || &(in_progress_ops.find(op->tid)->second) != op) {
+    // the op has been cancelled because of a change
+    return;
+  }
+
   if (op->op)
     op->op->mark_event("op_commit");
 


### PR DESCRIPTION
When the in progress op is cancelled because of a change in the PG, the
InProgressOp is removed, which makes the op pointer in
op_commit/op_applied invalid. Continue using this pointer may lead to
segment fault.

Fixes: #12803

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>