### PR TITLE
msg/async: support of non-block connect in async messenger

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2076,7 +2076,7 @@ void AsyncConnection::fault()
   }
 
   write_lock.Lock();
-  if (sd >= 0) {
+  if (sd >= 0 && state != STATE_CONNECTING_RE) {
     shutdown_socket();
     center->delete_file_event(sd, EVENT_READABLE|EVENT_WRITABLE);
     ::close(sd);

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -988,6 +988,8 @@ int AsyncConnection::_process_connection()
           goto fail;
         }
 
+        first_connect = false;
+
         net.set_socket_options(sd);
 
         state = STATE_CONNECTING_WAIT_BANNER;

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -178,7 +178,7 @@ AsyncConnection::AsyncConnection(CephContext *cct, AsyncMessenger *m, EventCente
     write_lock("AsyncConnection::write_lock"), can_write(NOWRITE),
     open_write(false), keepalive(false), lock("AsyncConnection::lock"), recv_buf(NULL),
     recv_max_prefetch(MIN(msgr->cct->_conf->ms_tcp_prefetch_max_size, TCP_PREFETCH_MIN_SIZE)),
-    recv_start(0), recv_end(0), got_bad_auth(false), authorizer(NULL), replacing(false),
+    recv_start(0), recv_end(0), got_bad_auth(false), first_connect(false), authorizer(NULL), replacing(false),
     is_reset_from_peer(false), once_ready(false), state_buffer(NULL), state_offset(0), net(cct), center(c)
 {
   read_handler.reset(new C_handle_read(this));
@@ -972,6 +972,7 @@ int AsyncConnection::_process_connection()
           goto fail;
         }
         center->create_file_event(sd, EVENT_READABLE, read_handler);
+        first_connect = true;
         state = STATE_CONNECTING_RE;
         break;
       }
@@ -980,6 +981,10 @@ int AsyncConnection::_process_connection()
       {
         r = net.reconnect(get_peer_addr(), sd);
         if (r < 0) {
+          if (first_connect == true) {
+            first_connect = false;
+            break;
+          }
           goto fail;
         }
 

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -270,6 +270,7 @@ class AsyncConnection : public Connection {
   bufferlist front, middle, data;
   ceph_msg_connect connect_msg;
   // Connecting state
+  bool first_connect;
   bool got_bad_auth;
   AuthAuthorizer *authorizer;
   ceph_msg_connect_reply connect_reply;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -270,7 +270,6 @@ class AsyncConnection : public Connection {
   bufferlist front, middle, data;
   ceph_msg_connect connect_msg;
   // Connecting state
-  bool reconnect;
   bool got_bad_auth;
   AuthAuthorizer *authorizer;
   ceph_msg_connect_reply connect_reply;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -160,6 +160,7 @@ class AsyncConnection : public Connection {
     STATE_OPEN_TAG_CLOSE,
     STATE_WAIT_SEND,
     STATE_CONNECTING,
+    STATE_CONNECTING_RE,
     STATE_CONNECTING_WAIT_BANNER,
     STATE_CONNECTING_WAIT_IDENTIFY_PEER,
     STATE_CONNECTING_SEND_CONNECT_MSG,
@@ -196,6 +197,7 @@ class AsyncConnection : public Connection {
                                         "STATE_OPEN_TAG_CLOSE",
                                         "STATE_WAIT_SEND",
                                         "STATE_CONNECTING",
+                                        "STATE_CONNECTING_RE",
                                         "STATE_CONNECTING_WAIT_BANNER",
                                         "STATE_CONNECTING_WAIT_IDENTIFY_PEER",
                                         "STATE_CONNECTING_SEND_CONNECT_MSG",
@@ -268,6 +270,7 @@ class AsyncConnection : public Connection {
   bufferlist front, middle, data;
   ceph_msg_connect connect_msg;
   // Connecting state
+  bool reconnect;
   bool got_bad_auth;
   AuthAuthorizer *authorizer;
   ceph_msg_connect_reply connect_reply;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -270,7 +270,6 @@ class AsyncConnection : public Connection {
   bufferlist front, middle, data;
   ceph_msg_connect connect_msg;
   // Connecting state
-  bool first_connect;
   bool got_bad_auth;
   AuthAuthorizer *authorizer;
   ceph_msg_connect_reply connect_reply;

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -131,6 +131,18 @@ int NetHandler::generic_connect(const entity_addr_t& addr, bool nonblock)
   return s;
 }
 
+int NetHandler::reconnect(const entity_addr_t &addr, int sd)
+{
+  int ret = ::connect(sd, (sockaddr*)&addr.addr, addr.addr_size());
+
+  if (ret < 0 && errno != EISCONN) {
+    ldout(cct, 10) << __func__ << " reconnect: " << strerror(errno) << dendl;
+    return -errno;
+  }
+
+  return sd;
+}
+
 int NetHandler::connect(const entity_addr_t &addr)
 {
   return generic_connect(addr, false);

--- a/src/msg/async/net_handler.h
+++ b/src/msg/async/net_handler.h
@@ -30,6 +30,7 @@ namespace ceph {
     int set_nonblock(int sd);
     void set_socket_options(int sd);
     int connect(const entity_addr_t &addr);
+    int reconnect(const entity_addr_t &addr, int sd);
     int nonblock_connect(const entity_addr_t &addr);
   };
 }


### PR DESCRIPTION
Async messenger should avoid all potential blocking point, but we use a block connect now.
So we must add this feature.