### PR TITLE
vstart: explicitly set conf file option for rgw

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -669,7 +669,7 @@ do_rgw()
 
     RGWSUDO=
     [ $CEPH_RGW_PORT -lt 1024 ] && RGWSUDO=sudo
-    $RGWSUDO $CEPH_BIN/radosgw --log-file=${CEPH_OUT_DIR}/rgw.log ${RGWDEBUG} --debug-ms=1
+    $RGWSUDO $CEPH_BIN/radosgw --log-file=${CEPH_OUT_DIR}/rgw.log ${RGWDEBUG} --debug-ms=1 -c $conf_fn
 
     # Create S3 user
     local akey='0555b35654ad1656d804'
@@ -695,7 +695,7 @@ do_rgw()
 
     # Create Swift user
     echo "setting up user tester"
-    $CEPH_BIN/radosgw-admin user create --subuser=test:tester --display-name=Tester-Subuser --key-type=swift --secret=testing > /dev/null
+    $CEPH_BIN/radosgw-admin user create --subuser=test:tester --display-name=Tester-Subuser --key-type=swift --secret=testing -c $conf_fn > /dev/null
 
     echo ""
     echo "S3 User Info:"


### PR DESCRIPTION
running vstart without sudo fails when radosgw-admin tries to create
subuser as it starts looking for ceph conf in etc; similar failure
happens with rgw as well as it tries to place admin socket in `/var/run`
directory. Explicitly specifiying conf directory option fixes this
issue.

Signed-off-by: Abhishek Lekshmanan <abhishek.lekshmanan@ril.com>