### PR TITLE
osd: do not let OSD_HITSET_GMT reuse the feature bit

### DIFF
--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -65,9 +65,9 @@
 #define CEPH_FEATURE_OSD_PROXY_FEATURES (1ULL<<49)  /* overlap w/ above */
 #define CEPH_FEATURE_MON_METADATA (1ULL<<50)
 #define CEPH_FEATURE_OSD_BITWISE_HOBJ_SORT (1ULL<<51) /* can sort objs bitwise */
-#define CEPH_FEATURE_OSD_HITSET_GMT (1ULL<<51) /* overlap with bitwise sort */
 #define CEPH_FEATURE_OSD_PROXY_WRITE_FEATURES (1ULL<<52)
 #define CEPH_FEATURE_ERASURE_CODE_PLUGINS_V3 (1ULL<<53)
+#define CEPH_FEATURE_OSD_HITSET_GMT (1ULL<<54)
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */
@@ -157,6 +157,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_OSD_BITWISE_HOBJ_SORT |		 \
          CEPH_FEATURE_ERASURE_CODE_PLUGINS_V3 |   \
          CEPH_FEATURE_OSD_PROXY_WRITE_FEATURES |         \
+     CEPH_FEATURE_OSD_HITSET_GMT |                       \
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL


### PR DESCRIPTION
* to ease the backport to hammer

Signed-off-by: Kefu Chai <kchai@redhat.com>