### PR TITLE
DNM: include/ceph_features: define HAMMER_0_94_4 feature

### DIFF
--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -64,6 +64,8 @@
 // duplicated since it was introduced at the same time as MIN_SIZE_RECOVERY
 #define CEPH_FEATURE_OSD_PROXY_FEATURES (1ULL<<49)  /* overlap w/ above */
 #define CEPH_FEATURE_MON_METADATA (1ULL<<50)
+/* ... */
+#define CEPH_FEATURE_HAMMER_0_94_4 (1ULL<<55)
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */
@@ -149,6 +151,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_MDS_QUOTA | \
          CEPH_FEATURE_CRUSH_V4 |	     \
          CEPH_FEATURE_OSD_MIN_SIZE_RECOVERY |		 \
+	 CEPH_FEATURE_HAMMER_0_94_4 |		 \
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL


### PR DESCRIPTION
This is to constrain upgrades past hammer to version that include
the appropriate compatibility fixes (e.g., hobject_t encoding).

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 2868b49c0e39fdc7ae72af81962370c4f95a859e)