### PR TITLE
rgw: improve convenience for key operate.

### DIFF
--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -190,6 +190,7 @@ struct RGWUserAdminOpState {
   bool id_specified;
   bool key_specified;
   bool type_specified;
+  bool key_type_setbycontext;   // key type set by user or subuser context
   bool purge_data;
   bool purge_keys;
   bool display_name_specified;
@@ -460,6 +461,7 @@ struct RGWUserAdminOpState {
     id_specified = false;
     key_specified = false;
     type_specified = false;
+    key_type_setbycontext = false;
     purge_data = false;
     display_name_specified = false;
     user_email_specified = false;


### PR DESCRIPTION
**1.key-type assignments based on context**
* In user    operate context, key-type assignment to `KEY_TYPE_S3`
* In subuser operate context, key-type assignment to `KEY_TYPE_SWIFT`
* In key     operate context, if key-type wasn't specified by previous process, key-type assignments based on `user type`.

**2.fix `RGWSubUserPool::add()`**
* When create subuser generate secret by default

**3.fix `RGWAccessKeyPool::generate_key()`**
* Avoid empty secret when use --access-key para
* Avoid wrong key's username when create user and subuser at the same time

Signed-off-by: Ce Gu <guce@h3c.com>