### PR TITLE
Wip oms101 feature setup unused journel disk

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -124,6 +124,24 @@ INIT_SYSTEMS = [
     'none',
     ]
 
+BLKID_UDEV = set([
+    'ID_PART_TABLE_UUID',
+    'ID_PART_TABLE_TYPE',
+    'ID_FS_UUID',
+    'ID_FS_UUID_ENC',
+    'ID_FS_VERSION',
+    'ID_FS_TYPE',
+    'ID_FS_USAGE',
+    'ID_PART_ENTRY_SCHEME',
+    'ID_PART_ENTRY_UUID',
+    'ID_PART_ENTRY_TYPE',
+    'ID_PART_ENTRY_NUMBER',
+    'ID_PART_ENTRY_OFFSET',
+    'ID_PART_ENTRY_SIZE',
+    'ID_PART_ENTRY_DISK',
+    'ID_PART_ENTRY_FLAGS'
+    ])
+
 STATEDIR = '/var/lib/ceph'
 
 SYSCONFDIR = '/etc/ceph'
@@ -445,6 +463,44 @@ def get_partition_dev(dev, pnum):
     else:
         raise Error('partition %d for %s does not appear to exist' % (pnum, dev))
 
+
+
+def get_blkid_udev(dev,output_set=BLKID_UDEV):
+    """
+    Present a consistent list of blkid_udev what ever the device.
+    Paramaeters output_set is the keys in the dictionary of
+    posible outputs.
+
+    defaults to a complete list of output.
+
+    Since  "blkid -p -o udev", returns output the is depenet on type
+    We need some code to make this command always succeed.
+    the output_set defines the list of paramters.
+    """
+    def mdl_blkid_udev_init(local_model):
+        mdl_keys = set(local_model.keys())
+        missing = output_set.difference(mdl_keys)
+        for item in missing:
+            local_model[item] = None
+
+    def blkid_udev_read(local_mode,blkid_udev_output):
+        for line in blkid_udev_output.splitlines():
+            (key, value) = line.split('=')
+            if key in output_set:
+                local_mode[key] = value
+
+    model = {}
+    mdl_blkid_udev_init(model)
+    blkid, _ = command(
+        [
+            'blkid',
+            '-p',
+            '-o', 'udev',
+            dev,
+        ]
+    )
+    blkid_udev_read(model, blkid)
+    return model
 
 def list_all_partitions():
     """
@@ -1143,6 +1199,33 @@ def zap(dev):
         raise Error(e)
 
 
+def view_blkid_udev_is_partioned(blkid_udev):
+    """
+    Utility function for parsing output of Takes data from get_blkid_udev.
+    returns True if the device is partitioned.
+    returns False otherwise.
+
+    Note this is not a inner function as nosetests cant test inner functions.
+    """
+    partition_attribs = set([
+        "ID_PART_TABLE_TYPE",
+        "ID_PART_TABLE_UUID"
+        ])
+    for item in partition_attribs:
+        if blkid_udev[item] == None:
+            return False
+    return True
+
+
+def partition_table_exists(device):
+    if is_partition(device):
+        return True
+    status = get_blkid_udev(device)
+    if view_blkid_udev_is_partioned(status):
+        return True
+    return False
+
+
 def prepare_journal_dev(
     data,
     journal,
@@ -1199,6 +1282,10 @@ def prepare_journal_dev(
         else:
             ptype = DMCRYPT_JOURNAL_UUID
         ptype_tobe = DMCRYPT_JOURNAL_TOBE_UUID
+
+    # it is a whole disk.
+    if not partition_table_exists(journal):
+        LOG.warning('No partiotion table found on %s' % journal)
 
     # it is a whole disk.  create a partition!
     num = None
@@ -1595,6 +1682,9 @@ def main_prepare(args):
 
         if args.zap_disk is not None:
             zap(args.data)
+            if args.journal and os.path.exists(args.journal):
+                if not partition_table_exists(args.journal):
+                    zap(args.journal)
 
         if args.cluster_uuid is None:
             args.cluster_uuid = get_fsid(cluster=args.cluster)

--- a/src/test/python/ceph_disk/test_ceph_disk_blikid.py
+++ b/src/test/python/ceph_disk/test_ceph_disk_blikid.py
@@ -1,0 +1,107 @@
+from nose.tools import eq_ as eq, assert_raises
+import os
+import ceph_disk
+import subprocess
+
+class TestGet_get_blkid_udev(object):
+
+    def setup(self):
+        self.all_devices = ceph_disk.list_all_partitions()
+
+    def test_all_device(self):
+        for device in self.all_devices:
+            status = ceph_disk.get_blkid_udev("/dev/" + device)
+            assert ceph_disk.BLKID_UDEV.issuperset(status.keys())
+
+    def test_all_parition(self):
+        for device in self.all_devices:
+            for partition in self.all_devices[device]:
+                status = ceph_disk.get_blkid_udev("/dev/" + device)
+                assert ceph_disk.BLKID_UDEV.issuperset(status.keys())
+
+    def test_all_devices_with_parition(self):
+        for device in self.all_devices:
+            if len(self.all_devices[device]) > 0:
+                status = ceph_disk.get_blkid_udev("/dev/" + device)
+                assert ceph_disk.view_blkid_udev_is_partioned(status) == True
+
+
+
+class TestGet_get_blkid_udev_with_loop_back(object):
+    def setup(self):
+        """
+         dd if=/dev/zero of=/tmp/dev0-backstore bs=1M count=100
+
+        # create the loopback block device
+        # where 7 is the major number of loop device driver, grep loop /proc/devices
+
+        mknod /dev/fake-dev0 b 7 200
+        losetup /dev/fake-dev0  /tmp/dev0-backstore
+        """
+        self.blockfile = "/tmp/dev0-backstore"
+        self.device_name = "/dev/fake-dev0"
+        try:
+            ceph_disk.command_check_call(
+                [
+                    'sudo',
+                    'dd',
+                    'if=/dev/zero',
+                    'of=%s' % (self.blockfile),
+                    'bs=1M',
+                    'count=100',
+                ],
+            )
+        except ceph_disk.Error as e:
+            raise ceph_disk.Error(e)
+        try:
+            ceph_disk.command_check_call(
+                [
+                    'sudo',
+                    'mknod',
+                    self.device_name,
+                    'b',
+                    '7',
+                    '200'
+                ],
+            )
+        except ceph_disk.Error as e:
+            raise ceph_disk.Error(e)
+        try:
+            ceph_disk.command_check_call(
+                [
+                    'sudo',
+                    'losetup',
+                    self.device_name,
+                    self.blockfile
+                ],
+            )
+        except ceph_disk.Error as e:
+            raise ceph_disk.Error(e)
+
+    def teardown(self):
+        try:
+            ceph_disk.command_check_call(
+                [
+                    'sudo',
+                    'losetup',
+                    '--detach',
+                    self.device_name,
+                ],
+            )
+        except ceph_disk.Error as e:
+            raise ceph_disk.Error(e)
+        os.unlink(self.device_name)
+        os.unlink(self.blockfile)
+
+    def test_read_loop(self):
+        status = ceph_disk.get_blkid_udev(self.device_name)
+        assert status['ID_PART_TABLE_UUID'] == None
+        assert status['ID_PART_TABLE_TYPE'] == None
+        assert ceph_disk.view_blkid_udev_is_partioned(status) == False
+
+    def test_read_zapped_loop(self):
+        ceph_disk.zap(self.device_name)
+        status = ceph_disk.get_blkid_udev(self.device_name)
+        assert status['ID_PART_TABLE_UUID'] != None
+        assert status['ID_PART_TABLE_TYPE'] != None
+        assert ceph_disk.view_blkid_udev_is_partioned(status) == True


### PR DESCRIPTION
When a journal disk is wiped with dd, or a disk is new it has no partition table.

    ceph-deploy osd prepare --zap ceph-node3:/dev/vdb:/dev/vdc

will fail with the error:

    [ceph-node3][WARNIN] INFO:ceph-disk:Running command: /usr/sbin/parted --machine -- /dev/vdc print
    [ceph-node3][WARNIN] Error: /dev/vdc: unrecognised disk label

This can be resolved with:

    /usr/sbin/sgdisk --clear --mbrtogpt -- /dev/vdb

This patch resolves this by checking the journal device, throws an exception saying the journal device is not a disk or partition, if it is a block device, then it checks for a partition table, and creates on only if no partition table exists.

This patch also includes unit tests, but these are not hooked up correctly some help will be needed here, and since they only run as root this may be an issue.