### PR TITLE
doc:radosgw: correct typos of the command removing a subuser

### DIFF
--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -182,7 +182,7 @@ subuser), specify ``user rm`` and the user ID. ::
 
 To remove the subuser only, specify ``subuser rm`` and the subuser ID. ::
 
-	radosgw-admin subuser rm --uid=johndoe:swift
+	radosgw-admin subuser rm --subuser=johndoe:swift
 
 
 Options include:
@@ -198,10 +198,10 @@ Remove a Subuser
 ----------------
 
 When you remove a sub user, you are removing access to the Swift interface. 
-The user will remain in the system. The Ceph Object Gateway  To remove the subuser, specify 
+The user will remain in the system. To remove the subuser, specify 
 ``subuser rm`` and the subuser ID. ::
 
-	radosgw-admin subuser rm --uid=johndoe:swift
+	radosgw-admin subuser rm --subuser=johndoe:swift
 
 
 


### PR DESCRIPTION
Fix typos in the example command removing a subuser, and delete the 'The Ceph Object Gateway' tag as it should not appear there.

Signed-off-by: Sangdi Xu <xu.sangdi@h3c.com>