### PR TITLE
CMake: update for boost_random

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ else(${ENABLE_SHARED})
 endif(${ENABLE_SHARED})
 
 set(Boost_USE_MULTITHREADED ON)
-find_package(Boost COMPONENTS thread system regex REQUIRED)
+find_package(Boost COMPONENTS thread system regex random REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 find_package(Threads REQUIRED)


### PR DESCRIPTION
This became a dependency in dbcaa544

Signed-off-by: John Spray <john.spray@redhat.com>