### PR TITLE
common: 'enable experimental data corrupting features' now understand '*'

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -230,7 +230,8 @@ bool CephContext::check_experimental_feature_enabled(const std::string& feat,
 						     std::ostream *message)
 {
   ceph_spin_lock(&_feature_lock);
-  bool enabled = _experimental_features.count(feat);
+  bool enabled = (_experimental_features.count(feat) ||
+		  _experimental_features.count("*"));
   ceph_spin_unlock(&_feature_lock);
 
   if (enabled) {

--- a/src/test/common/test_context.cc
+++ b/src/test/common/test_context.cc
@@ -82,6 +82,13 @@ TEST(CephContext, experimental_features)
   ASSERT_FALSE(cct->check_experimental_feature_enabled("bar"));
   ASSERT_TRUE(cct->check_experimental_feature_enabled("baz"));
 
+  cct->_conf->set_val("enable_experimental_unrecoverable_data_corrupting_features",
+		      "*");
+  cct->_conf->apply_changes(&cout);
+  ASSERT_TRUE(cct->check_experimental_feature_enabled("foo"));
+  ASSERT_TRUE(cct->check_experimental_feature_enabled("bar"));
+  ASSERT_TRUE(cct->check_experimental_feature_enabled("baz"));
+
   cct->_log->flush();
 }
 


### PR DESCRIPTION
'*' allows any feature.

Signed-off-by: Kefu Chai <kchai@redhat.com>