### PR TITLE
ceph-disk: {CentOS,RHEL} >= 7 && Fedora >= 22 are systemd

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/centos/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/centos/__init__.py
@@ -8,4 +8,6 @@ def choose_init():
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
+    if release and int(release.split('.')[0]) >= 7:
+        return 'systemd'
     return 'sysvinit'

--- a/src/ceph-detect-init/ceph_detect_init/fedora/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/fedora/__init__.py
@@ -8,4 +8,6 @@ def choose_init():
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
+    if release and int(release.split('.')[0]) >= 22:
+        return 'systemd'
     return 'sysvinit'

--- a/src/ceph-detect-init/ceph_detect_init/rhel/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/rhel/__init__.py
@@ -8,4 +8,6 @@ def choose_init():
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
+    if release and int(release.split('.')[0]) >= 7:
+        return 'systemd'
     return 'sysvinit'

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -38,6 +38,9 @@ logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s',
 class TestCephDetectInit(testtools.TestCase):
 
     def test_centos(self):
+        with mock.patch('ceph_detect_init.centos.release',
+                        '7.0'):
+            self.assertEqual('systemd', centos.choose_init())
         self.assertEqual('sysvinit', centos.choose_init())
 
     def test_debian(self):
@@ -49,9 +52,15 @@ class TestCephDetectInit(testtools.TestCase):
             self.assertEqual('upstart', debian.choose_init())
 
     def test_fedora(self):
+        with mock.patch('ceph_detect_init.fedora.release',
+                        '22'):
+            self.assertEqual('systemd', fedora.choose_init())
         self.assertEqual('sysvinit', fedora.choose_init())
 
     def test_rhel(self):
+        with mock.patch('ceph_detect_init.rhel.release',
+                        '7.0'):
+            self.assertEqual('systemd', rhel.choose_init())
         self.assertEqual('sysvinit', rhel.choose_init())
 
     def test_suse(self):


### PR DESCRIPTION
http://tracker.ceph.com/issues/12786 Fixes: #12786

Signed-off-by: Loic Dachary <ldachary@redhat.com>