### PR TITLE
PG::handle_advance_map: on_pool_change after handling the map change

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5279,12 +5279,12 @@ void PG::handle_advance_map(
 	   << dendl;
   update_osdmap_ref(osdmap);
   pool.update(osdmap);
-  if (pool.info.last_change == osdmap_ref->get_epoch())
-    on_pool_change();
   AdvMap evt(
     osdmap, lastmap, newup, up_primary,
     newacting, acting_primary);
   recovery_state.handle_event(evt, rctx);
+  if (pool.info.last_change == osdmap_ref->get_epoch())
+    on_pool_change();
 }
 
 void PG::handle_activate_map(RecoveryCtx *rctx)


### PR DESCRIPTION
Otherwise, the is_active() checks in the hitset code can erroneously
return true firing off repops stamped with the new epoch which then get
cleared in the map change code.  The filestore callbacks then pass the
interval check and call into a destroyed repop structure.

Fixes: 12809
Backport: hammer,firefly
Signed-off-by: Samuel Just <sjust@redhat.com>