### PR TITLE
ceph-disk: fix dmcrypt typo

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -2370,7 +2370,7 @@ def main_activate_journal(args):
                 raise Error('activate-journal --dmcrypt called for invalid dev %s' % (rawdev))
             part_uuid = get_partition_uuid(rawdev)
             dmcrypt_key_path = os.path.join(args.dmcrypt_key_dir, part_uuid)
-            dev = dmcrypt_map(rawdev, dmcrypt_key_path, partd_uuid)
+            dev = dmcrypt_map(rawdev, dmcrypt_key_path, part_uuid)
         else:
             dev = args.dev
 


### PR DESCRIPTION
Fix the typo introduced by 29431944c77adbc3464a8faeb7e052b24f821780

http://tracker.ceph.com/issues/12781 Fixes: #12781

Signed-off-by: Loic Dachary <ldachary@redhat.com>