### PR TITLE
perf_serialize: fix i386 build

### DIFF
--- a/src/test/perf_local.cc
+++ b/src/test/perf_local.cc
@@ -666,7 +666,7 @@ double perf_prefetch()
 #endif
 }
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__x86_64__)
 /**
  * This function is used to seralize machine instructions so that no
  * instructions that appear after it in the current thread can run before any
@@ -686,7 +686,7 @@ static inline void serialize() {
 
 // Measure the cost of cpuid
 double perf_serialize() {
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__x86_64__)
   int count = 1000000;
   uint64_t start = Cycles::rdtsc();
   for (int i = 0; i < count; i++) {


### PR DESCRIPTION
test/perf_local.cc: In function ‘double perf_serialize()’:
error: test/perf_local.cc:683:20: inconsistent operand constraints in an ‘asm’
: "a" (1U));
^

on ubuntu 14.04.

Signed-off-by: Sage Weil <sage@redhat.com>