### PR TITLE
is_new_interval() fixes

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2205,6 +2205,8 @@ bool pg_interval_t::is_new_interval(
   int new_up_primary,
   const vector<int> &old_up,
   const vector<int> &new_up,
+  int old_size,
+  int new_size,
   int old_min_size,
   int new_min_size,
   unsigned old_pg_num,
@@ -2215,6 +2217,7 @@ bool pg_interval_t::is_new_interval(
     old_up_primary != new_up_primary ||
     new_up != old_up ||
     old_min_size != new_min_size ||
+    old_size != new_size ||
     pgid.is_split(old_pg_num, new_pg_num, 0);
 }
 
@@ -2240,6 +2243,8 @@ bool pg_interval_t::is_new_interval(
 		    new_up_primary,
 		    old_up,
 		    new_up,
+		    lastmap->get_pools().find(pgid.pool())->second.size,
+		    osdmap->get_pools().find(pgid.pool())->second.size,
 		    lastmap->get_pools().find(pgid.pool())->second.min_size,
 		    osdmap->get_pools().find(pgid.pool())->second.min_size,
 		    lastmap->get_pg_num(pgid.pool()),

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1764,6 +1764,8 @@ struct pg_interval_t {
     int new_up_primary,
     const vector<int> &old_up,
     const vector<int> &new_up,
+    int old_size,
+    int new_size,
     int old_min_size,
     int new_min_size,
     unsigned old_pg_num,

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1490,6 +1490,7 @@ int Objecter::calc_target(op_target_t *t, epoch_t *last_force_resend, bool any_c
       return RECALC_OP_TARGET_POOL_DNE;
   }
 
+  int size = pi->size;
   int min_size = pi->min_size;
   unsigned pg_num = pi->get_pg_num();
   int up_primary, acting_primary;
@@ -1505,6 +1506,8 @@ int Objecter::calc_target(op_target_t *t, epoch_t *last_force_resend, bool any_c
 	  up_primary,
 	  t->up,
 	  up,
+	  t->size,
+	  size,
 	  t->min_size,
 	  min_size,
 	  t->pg_num,
@@ -1531,6 +1534,7 @@ int Objecter::calc_target(op_target_t *t, epoch_t *last_force_resend, bool any_c
     t->acting_primary = acting_primary;
     t->up_primary = up_primary;
     t->up = up;
+    t->size = size;
     t->min_size = min_size;
     t->pg_num = pg_num;
     ldout(cct, 10) << __func__ << " "

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1497,6 +1497,7 @@ int Objecter::calc_target(op_target_t *t, epoch_t *last_force_resend, bool any_c
   vector<int> up, acting;
   osdmap->pg_to_up_acting_osds(pgid, &up, &up_primary,
 			       &acting, &acting_primary);
+  unsigned prev_seed = ceph_stable_mod(pgid.ps(), t->pg_num, t->pg_num_mask);
   if (any_change && pg_interval_t::is_new_interval(
           t->acting_primary,
 	  acting_primary,
@@ -1512,7 +1513,7 @@ int Objecter::calc_target(op_target_t *t, epoch_t *last_force_resend, bool any_c
 	  min_size,
 	  t->pg_num,
 	  pg_num,
-	  pi->raw_pg_to_pg(pgid))) {
+	  pg_t(prev_seed, pgid.pool(), pgid.preferred()))) {
     force_resend = true;
   }
 
@@ -1537,6 +1538,7 @@ int Objecter::calc_target(op_target_t *t, epoch_t *last_force_resend, bool any_c
     t->size = size;
     t->min_size = min_size;
     t->pg_num = pg_num;
+    t->pg_num_mask = pi->get_pg_num_mask();
     ldout(cct, 10) << __func__ << " "
 		   << " pgid " << pgid << " acting " << acting << dendl;
     t->used_replica = false;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1077,6 +1077,7 @@ public:
     vector<int> acting;  ///< set of acting osds for last pg we mapped to
     int up_primary;      ///< primary for last pg we mapped to based on the up set
     int acting_primary;  ///< primary for last pg we mapped to based on the acting set
+    int size;        ///< the size of the pool when were were last mapped
     int min_size;        ///< the min size of the pool when were were last mapped
 
     bool used_replica;
@@ -1092,6 +1093,7 @@ public:
 	pg_num(0),
 	up_primary(-1),
 	acting_primary(-1),
+	size(-1),
 	min_size(-1),
 	used_replica(false),
 	paused(false),

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1068,17 +1068,18 @@ public:
     object_t target_oid;
     object_locator_t target_oloc;
 
-    bool precalc_pgid;   ///< true if we are directed at base_pgid, not base_oid
-    pg_t base_pgid;      ///< explciti pg target, if any
+    bool precalc_pgid;    ///< true if we are directed at base_pgid, not base_oid
+    pg_t base_pgid;       ///< explciti pg target, if any
 
-    pg_t pgid;           ///< last pg we mapped to
-    unsigned pg_num;     ///< last pg_num we mapped to
-    vector<int> up;      ///< set of up osds for last pg we mapped to
-    vector<int> acting;  ///< set of acting osds for last pg we mapped to
-    int up_primary;      ///< primary for last pg we mapped to based on the up set
-    int acting_primary;  ///< primary for last pg we mapped to based on the acting set
-    int size;        ///< the size of the pool when were were last mapped
-    int min_size;        ///< the min size of the pool when were were last mapped
+    pg_t pgid;            ///< last pg we mapped to
+    unsigned pg_num;      ///< last pg_num we mapped to
+    unsigned pg_num_mask; ///< last pg_num_mask we mapped to
+    vector<int> up;       ///< set of up osds for last pg we mapped to
+    vector<int> acting;   ///< set of acting osds for last pg we mapped to
+    int up_primary;       ///< primary for last pg we mapped to based on the up set
+    int acting_primary;   ///< primary for last pg we mapped to based on the acting set
+    int size;             ///< the size of the pool when were were last mapped
+    int min_size;         ///< the min size of the pool when were were last mapped
 
     bool used_replica;
     bool paused;
@@ -1091,6 +1092,7 @@ public:
 	base_oloc(oloc),
 	precalc_pgid(false),
 	pg_num(0),
+        pg_num_mask(0),
 	up_primary(-1),
 	acting_primary(-1),
 	size(-1),


### PR DESCRIPTION
http://tracker.ceph.com/issues/12842 and http://tracker.ceph.com/issues/12752

The first commit preserves watches if the replication factor of pool is changed,
so rbd snapshots continue working in this case.

The 2nd one fixes an error in split handling that can cause a client
to crash while pg_num is increased for a pool.