### PR TITLE
rgw: init_rados failed leads to repeated delete

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1508,10 +1508,13 @@ fail:
   for (uint32_t i=0; i < num_rados_handles; i++) {
     if (rados[i]) {
       delete rados[i];
+      rados[i] = NULL;
     }
   }
+  num_rados_handles = 0;
   if (rados) {
     delete[] rados;
+    rados = NULL;
   }
 
   return ret;


### PR DESCRIPTION
Fixes: #12989

Signed-off-by: Xiaowei Chen chen.xiaowei@h3c.com