### PR TITLE
auth: keyring without mon entity type should return -EACCES

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -574,6 +574,27 @@ function test_auth_profiles()
   rm -f client.xx.keyring client.xx.keyring.2
 }
 
+function test_mon_caps()
+{
+  ./ceph-authtool --create-keyring $TMPDIR/ceph.client.bug.keyring
+  chmod +r  $TMPDIR/ceph.client.bug.keyring
+  ./ceph-authtool  $TMPDIR/ceph.client.bug.keyring -n client.bug --gen-key
+  ./ceph auth add client.bug -i  $TMPDIR/ceph.client.bug.keyring
+
+  ./rados lspools --keyring $TMPDIR/ceph.client.bug.keyring -n client.bug >& $TMPFILE || true
+  check_response "Permission denied"
+
+  rm -rf $TMPDIR/ceph.client.bug.keyring
+  ./ceph auth del client.bug
+  ./ceph-authtool --create-keyring $TMPDIR/ceph.client.bug.keyring
+  chmod +r  $TMPDIR/ceph.client.bug.keyring
+  ./ceph-authtool  $TMPDIR/ceph.client.bug.keyring -n client.bug --gen-key
+  ./ceph-authtool -n client.bug --cap mon '' $TMPDIR/ceph.client.bug.keyring
+  ./ceph auth add client.bug -i  $TMPDIR/ceph.client.bug.keyring
+  ./rados lspools --keyring $TMPDIR/ceph.client.bug.keyring -n client.bug >& $TMPFILE || true
+  check_response "Permission denied"  
+}
+
 function test_mon_misc()
 {
   # with and without verbosity
@@ -1720,7 +1741,7 @@ MON_TESTS+=" mon_tell"
 MON_TESTS+=" mon_crushmap_validation"
 MON_TESTS+=" mon_ping"
 MON_TESTS+=" mon_deprecated_commands"
-
+MON_TESTS+=" mon_caps"
 OSD_TESTS+=" osd_bench"
 OSD_TESTS+=" tiering_agent"
 

--- a/src/auth/cephx/CephxServiceHandler.cc
+++ b/src/auth/cephx/CephxServiceHandler.cc
@@ -139,6 +139,13 @@ int CephxServiceHandler::handle_request(bufferlist::iterator& indata, bufferlist
 
       if (!key_server->get_service_caps(entity_name, CEPH_ENTITY_TYPE_MON, caps)) {
         ldout(cct, 0) << " could not get mon caps for " << entity_name << dendl;
+        ret = -EACCES;
+      } else {
+        char *caps_str = caps.caps.c_str();
+        if (!caps_str || !caps_str[0]) {
+          ldout(cct,0) << "mon caps null for " << entity_name << dendl;
+          ret = -EACCES;
+        }
       }
     }
     break;

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -710,6 +710,10 @@ def main():
     except KeyboardInterrupt:
         print >> sys.stderr, 'Cluster connection aborted'
         return 1
+    except rados.PermissionDeniedError as e:
+        print >> sys.stderr, 'Error connecting to cluster: {0}'.\
+            format(e.__class__.__name__)
+        return errno.EACCES
     except Exception as e:
         print >> sys.stderr, 'Error connecting to cluster: {0}'.\
             format(e.__class__.__name__)

--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -41,6 +41,9 @@ class PermissionError(Error):
     """ `PermissionError` class, derived from `Error` """
     pass
 
+class PermissionDeniedError(Error):
+    """ deal with EACCES related. """
+    pass
 
 class ObjectNotFound(Error):
     """ `ObjectNotFound` class, derived from `Error` """
@@ -122,7 +125,8 @@ def make_ex(ret, msg):
         errno.EBUSY     : ObjectBusy,
         errno.ENODATA   : NoData,
         errno.EINTR     : InterruptedOrTimeoutError,
-        errno.ETIMEDOUT : TimedOut
+        errno.ETIMEDOUT : TimedOut,
+        errno.EACCES    : PermissionDeniedError
         }
     ret = abs(ret)
     if ret in errors:


### PR DESCRIPTION
 test:
    see test.sh:test_mon_caps
    before modify:
    when we first exec test.sh, it stuck.
    after modify:
    exec test.sh, return EACCES.
    
    but the up operations also lead another bug: see:
    https://github.com/ceph/ceph/pull/5733
    
Signed-off-by: Xiaowei Chen <chen.xiaowei@h3c.com>