### PR TITLE
init-ceph.in: reorder mon and others when start/stop daemons

### DIFF
--- a/src/ceph_common.sh
+++ b/src/ceph_common.sh
@@ -180,9 +180,9 @@ get_name_list() {
     orig="$*"
 
     # extract list of monitors, mdss, osds defined in startup.conf
-    allconf="$local "`$CCONF -c $conf -l mon | egrep -v '^mon$' || true ; \
-	$CCONF -c $conf -l mds | egrep -v '^mds$' || true ; \
-	$CCONF -c $conf -l osd | egrep -v '^osd$' || true`
+    allconf="`$CCONF -c $conf -l mon | egrep -v '^mon$' || true ;` $local
+	`$CCONF -c $conf -l mds | egrep -v '^mds$' || true ; \
+	$CCONF -c $conf -l osd | egrep -v '^osd$' || true`"
 
     if [ -z "$orig" ]; then
 	what="$allconf"


### PR DESCRIPTION
Fixes: #12891

http://tracker.ceph.com/issues/12891

Signed-off-by: runsisi <runsisi@hust.edu.cn>