### PR TITLE
rgw: fix objects can not be displayed which object name does not cont…

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -715,16 +715,19 @@ int RGWBucket::check_bad_index_multipart(RGWBucketAdminOpState& op_state,
       string oid = key.name;
 
       int pos = oid.find_last_of('.');
-      if (pos < 0)
-        continue;
-
-      string name = oid.substr(0, pos);
-      string suffix = oid.substr(pos + 1);
-
-      if (suffix.compare("meta") == 0) {
-        meta_objs[name] = true;
+      if (pos < 0) {
+        /* obj has no suffix */
+        all_objs[key] = oid;
       } else {
-        all_objs[key] = name;
+        /* obj has suffix */
+        string name = oid.substr(0, pos);
+        string suffix = oid.substr(pos + 1);
+
+        if (suffix.compare("meta") == 0) {
+          meta_objs[name] = true;
+        } else {
+          all_objs[key] = name;
+        }
       }
     }
 


### PR DESCRIPTION
objects can not be displayed which object name does not contain '.' when get the bucket index.

There is those obj in bucket bkt-test:
```
ceph-master.zip
ceph-test
ceph_0.94.2-1.tar.gz
rm
rm.sh
```

// get the bucket index use Admin Ops API
```
./s3curl.pl --id=personal  -- http://node110/admin/bucket?index\&bucket=bkt-test
[
    "_multipart_ceph-master.zip",
    "_multipart_ceph_0.94.2-1.tar.gz",
    "_multipart_rm.sh"
]
```

// check bucket
```
radosgw-admin bucket check --bucket=bkt-test`
[
    "_multipart_ceph-master.zip",
    "_multipart_ceph_0.94.2-1.tar.gz",
    "_multipart_rm.sh"
]
```
Signed-off-by: Weijun Duan <duanweijun@h3c.com>