### PR TITLE
librbd: do write_full for whole object write

### DIFF
--- a/src/librbd/AioRequest.cc
+++ b/src/librbd/AioRequest.cc
@@ -508,7 +508,11 @@ namespace librbd {
   void AioWrite::add_write_ops(librados::ObjectWriteOperation *wr) {
     if (m_ictx->enable_alloc_hint && !m_ictx->object_map.object_may_exist(m_object_no))
       wr->set_alloc_hint(m_ictx->get_object_size(), m_ictx->get_object_size());
-    wr->write(m_object_off, m_write_data);
+    if (m_object_off == 0 && m_object_len == m_ictx->get_object_size()) {
+      wr->write_full(m_write_data);
+    } else {
+      wr->write(m_object_off, m_write_data);
+    }
     wr->set_op_flags2(m_op_flags);
   }
 


### PR DESCRIPTION
This is useful when ec is the base tier in the cache tiering setup. The
write_full can be proxied from the cache tier to the base tier. So that
we don't need to promote the object.

Signed-off-by: Zhiqiang Wang <zhiqiang.wang@intel.com>
Suggested-by: Nick Fisk<nick@fisk.me.uk>