### PR TITLE
AsyncConnection: Don't use unsafe feature as message encode feature

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1965,7 +1965,7 @@ int AsyncConnection::send_message(Message *m)
   }
   if (!is_queued() && can_write == CANWRITE) {
     if (!can_fast_prepare)
-      prepare_send_message(f, m, bl);
+      prepare_send_message(get_features(), m, bl);
     if (write_message(m, bl) < 0) {
       ldout(async_msgr->cct, 1) << __func__ << " send msg failed" << dendl;
       // we want to handle fault within internal thread


### PR DESCRIPTION
Fix #12908
Signed-off-by: Haomai Wang <haomaiwang@gmail.com>