### PR TITLE
osd suicide timeout during peering - search for missing objects

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -549,7 +549,7 @@ public:
 	on_applied(rctx.on_applied),
 	on_safe(rctx.on_safe),
 	transaction(rctx.transaction),
-        handle(NULL) {}
+        handle(rctx.handle) {}
 
     void accept_buffered_messages(BufferedRecoveryMessages &m) {
       assert(query_map);


### PR DESCRIPTION
http://tracker.ceph.com/issues/12844