### PR TITLE
COPYing an old object onto itself produces a truncated object

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -327,6 +327,12 @@ public:
       ::decode(rules, bl);
     } else {
       explicit_objs = true;
+      if (!objs.empty()) {
+        map<uint64_t, RGWObjManifestPart>::iterator iter = objs.begin();
+        head_obj = iter->second.loc;
+        head_size = iter->second.size;
+        max_head_size = head_size;
+      }
     }
 
     if (struct_v >= 4) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/12880