### PR TITLE
memstore: fix the build on i386

### DIFF
--- a/src/os/MemStore.cc
+++ b/src/os/MemStore.cc
@@ -1511,7 +1511,7 @@ int MemStore::PageSetObject::clone(Object *src, uint64_t srcoff,
   const int64_t delta = dstoff - srcoff;
 
   auto &src_data = static_cast<PageSetObject*>(src)->data;
-  const auto src_page_size = src_data.get_page_size();
+  const uint64_t src_page_size = src_data.get_page_size();
 
   auto &dst_data = data;
   const auto dst_page_size = dst_data.get_page_size();


### PR DESCRIPTION
on i386, uint64 is `unsigned long long`, while size_t is `unsigned int`.
std::min(uint64, size_t) can not be resolved.

Signed-off-by: Kefu Chai <kchai@redhat.com>