### PR TITLE
osd: When generating past intervals due to an import end at pg epoch

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -647,7 +647,7 @@ bool PG::_calc_past_interval_range(epoch_t *start, epoch_t *end, epoch_t oldest_
     *end = info.history.same_interval_since;
   } else {
     // PG must be imported, so let's calculate the whole range.
-    *end = osd->get_superblock().newest_map;
+    *end = osdmap_ref->get_epoch();
   }
 
   // Do we already have the intervals we want?

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2652,6 +2652,7 @@ bool pg_interval_t::check_new_interval(
     pg_interval_t& i = (*past_intervals)[same_interval_since];
     i.first = same_interval_since;
     i.last = osdmap->get_epoch() - 1;
+    assert(i.first <= i.last);
     i.acting = old_acting;
     i.up = old_up;
     i.primary = old_acting_primary;


### PR DESCRIPTION
Add assert() to make sure same_interval_since isn't too far forward

Signed-off-by: David Zafman <dzafman@redhat.com>