### PR TITLE
tests: ceph-erasure-code-corpus must test SIMD variants

### DIFF
--- a/src/test/erasure-code/ceph_erasure_code.cc
+++ b/src/test/erasure-code/ceph_erasure_code.cc
@@ -88,6 +88,7 @@ int ErasureCodeCommand::setup(int argc, char** argv) {
     CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);
   g_ceph_context->_conf->apply_changes(NULL);
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   if (vm.count("help")) {
     cout << desc << std::endl;

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -87,6 +87,7 @@ int ErasureCodeBench::setup(int argc, char** argv) {
     CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);
   g_ceph_context->_conf->apply_changes(NULL);
+  g_conf->set_val("erasure_code_dir", ".libs", false, false);
 
   if (vm.count("help")) {
     cout << desc << std::endl;


### PR DESCRIPTION
ceph_erasure_code.cc and ceph_erasure_code_benchmark.cc failed to load
the plugins. It went unnoticed when
660ae5bcbb250b06cf88ec7f9a3f37b05c6c8118 was reviewed because

  * ceph_erasure_code_benchmark is not used in make check
  * qa/workunits/erasure-code/encode-decode-non-regression.sh silently
    interpreted the failure as the absence of SIMD variants

http://tracker.ceph.com/issues/12933 Fixes: #12933

Signed-off-by: Loic Dachary <ldachary@redhat.com>