### PR TITLE
rgw: fix unconditional return in RGWGetObj::execute()

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -963,8 +963,8 @@ void RGWGetObj::execute()
     ret = handle_user_manifest(attr_iter->second.c_str());
     if (ret < 0) {
       ldout(s->cct, 0) << "ERROR: failed to handle user manifest ret=" << ret << dendl;
+      return;
     }
-    return;
   }
 
   ofs = new_ofs;


### PR DESCRIPTION
In RGWGetObj::execute() we are returning unconditionally after handling the
user manifest, either if it succeed or not.

We should return only if handling the manifest fails.

Signed-off-by: Juan A. Suarez Romero <jasuarez@igalia.com>