### PR TITLE
ceph.spec.in: put distro conditionals around Group:

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -47,7 +47,9 @@ Release:	@RPM_RELEASE@%{?dist}
 Epoch:		1
 Summary:	User space components of the Ceph file system
 License:	LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and GPL-2.0-with-autoconf-exception and BSD-3-Clause and MIT
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:         System/Filesystems
+%endif
 URL:		http://ceph.com/
 Source0:	http://ceph.com/download/%{name}-%{version}.tar.bz2
 %if 0%{?fedora} || 0%{?rhel}


### PR DESCRIPTION
RHEL and Fedora use System Environment/Base
SUSE needs System/Filesystems

Signed-off-by: Nathan Cutler <ncutler@suse.com>