### PR TITLE
ceph-disk: do async startup on upstart; fix dmcrypt create/activate bug

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,6 +81,7 @@ EXTRA_DIST += \
 	$(srcdir)/ceph-rbdnamer \
 	$(srcdir)/tools/ceph-monstore-update-crush.sh \
 	$(srcdir)/upstart/ceph-all.conf \
+	$(srcdir)/upstart/ceph-disk.conf \
 	$(srcdir)/upstart/ceph-mon.conf \
 	$(srcdir)/upstart/ceph-mon-all.conf \
 	$(srcdir)/upstart/ceph-mon-all-starter.conf \

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -242,6 +242,15 @@ def is_systemd():
                 return True
     return False
 
+def is_upstart():
+    """
+    Detect whether upstart is running
+    """
+    (out, _) = command(['init', '--version'])
+    if 'upstart' in out:
+        return True
+    return False
+
 def maybe_mkdir(*a, **kw):
     """
     Creates a new directory if it doesn't exist, removes

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -3030,6 +3030,18 @@ def main_trigger(args):
             ]
         )
         return
+    if is_upstart() and not args.sync:
+        LOG.info('upstart detected, triggering ceph-disk task')
+        command(
+            [
+                'initctl',
+                'emit',
+                'ceph-disk',
+                'dev={dev}'.format(dev=args.dev),
+                'pid={pid}'.format(pid=os.getpid()),
+            ]
+        )
+        return
 
     parttype = get_partition_type(args.dev)
     partid = get_partition_uuid(args.dev)

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -2649,23 +2649,6 @@ def get_dev_fs(dev):
     else:
         return None
 
-def get_dev_udev_properties(dev):
-    out, _ = command(
-        [
-            '/sbin/blkid',
-            '-o',
-            'udev',
-            '-p',
-            dev,
-        ]
-    )
-    p = {}
-    for line in out.split('\n'):
-        if line:
-            (key, value) = line.split('=')
-            p[key] = value
-    return p
-
 def split_dev_base_partnum(dev):
     if is_mpath(dev):
         partnum = partnum_mpath(dev)
@@ -2677,10 +2660,31 @@ def split_dev_base_partnum(dev):
     return (base, partnum)
 
 def get_partition_type(part):
-    return get_sgdisk_partition_info(part, 'Partition GUID code: (\S+)')
+    return get_blkid_partition_info(part, 'ID_PART_ENTRY_TYPE')
+    #return get_sgdisk_partition_info(part, 'Partition GUID code: (\S+)')
 
 def get_partition_uuid(part):
-    return get_sgdisk_partition_info(part, 'Partition unique GUID: (\S+)')
+    return get_blkid_partition_info(part, 'ID_PART_ENTRY_UUID')
+    #return get_sgdisk_partition_info(part, 'Partition unique GUID: (\S+)')
+
+def get_blkid_partition_info(dev, what=None):
+    out, _ = command(
+        [
+            '/sbin/blkid',
+            '-o',
+            'udev',
+            '-p',
+            dev,
+        ]
+    )
+    p = {}
+    for line in out.splitlines():
+        (key, value) = line.split('=')
+        p[key] = value
+    if what:
+        return p.get(what)
+    else:
+        return p
 
 def get_sgdisk_partition_info(dev, regexp):
     (base, partnum) = split_dev_base_partnum(dev)
@@ -3018,15 +3022,8 @@ def main_trigger(args):
         )
         return
 
-    p = get_dev_udev_properties(args.dev)
-
-    if 'ID_PART_ENTRY_TYPE' not in p:
-        raise Error('no ID_PART_ENTRY_TYPE for %s' % args.dev)
-    parttype = p['ID_PART_ENTRY_TYPE']
-
-    if 'ID_PART_ENTRY_UUID' not in p:
-        raise Error('no ID_PART_ENTRY_UUID for %s' % args.dev)
-    partid = p['ID_PART_ENTRY_UUID']
+    parttype = get_partition_type(args.dev)
+    partid = get_partition_uuid(args.dev)
 
     LOG.info('trigger {dev} parttype {parttype} uuid {partid}'.format(
         dev=args.dev,

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1049,6 +1049,8 @@ def dmcrypt_map(
         else:
             # Plain mode has no format function, nor any validation that the key is correct.
             command_check_call(create_args)
+        # set proper ownership of mapped device
+        command_check_call(['chown', 'ceph:ceph', dev])
         return dev
 
     except subprocess.CalledProcessError as e:

--- a/src/upstart/ceph-disk.conf
+++ b/src/upstart/ceph-disk.conf
@@ -1,0 +1,9 @@
+description "ceph-disk async worker"
+
+start on ceph-disk
+
+instance $dev/$pid
+export dev
+export pid
+
+exec ceph-disk --verbose --log-stdout trigger --sync $dev


### PR DESCRIPTION
You can't do slow stuff from udev... it's designed to run short-running tasks, not stuff like ceph-disk activate that goes off and does *other* stuff that triggers yet more udev events (like seting up dmcrypt).  It works some/most of hte time, but is generally unreliable.. especially on boxes with lots of devices.

For systemd we fire off an async systemd job to do the work.  Do the same thing with upstart.

sysvinit is still stuck doing things synchronously; those users should switch to a modern init system.