### PR TITLE
Fix casing of Content-Type header

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -557,7 +557,7 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
 
   int r;
   if (content_type) {
-      r = s->cio->print("Content-type: %s\r\n", content_type);
+      r = s->cio->print("Content-Type: %s\r\n", content_type);
       if (r < 0) {
 	ldout(s->cct, 0) << "ERROR: s->cio->print() returned err=" << r << dendl;
       }


### PR DESCRIPTION
It turns out, despite the HTTP spec declaring that header field names
should be case-insensitive, some clients treat them wrongly, and
consider "Content-type" to not match "Content-Type".

CyberDuck was one of those clients, now fixed upstream in
https://trac.cyberduck.io/ticket/8999

To reduce future occurances of this bug, fix the casing of the
Content-Type header, to strictly comply with the HTTP specification (be
strict about what you send, and generous about what you receive).

Backport: infernalis, hammer, firefly
Fixes: #12939
Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>