### PR TITLE
cmake: fix the build on debian sid

### DIFF
--- a/cmake/modules/FindNSS.cmake
+++ b/cmake/modules/FindNSS.cmake
@@ -34,6 +34,14 @@ else (NSS_LIBRARIES AND NSS_INCLUDE_DIRS)
       /sw/include
     PATH_SUFFIXES
       nss3
+    NO_DEFAULT_PATH
+  )
+
+  find_path(NSS_INCLUDE_DIR
+    NAMES
+      nss.h
+    PATH_SUFFIXES
+      nss3
   )
 
   find_library(SSL3_LIBRARY

--- a/cmake/modules/Findsnappy.cmake
+++ b/cmake/modules/Findsnappy.cmake
@@ -37,6 +37,8 @@ find_library(SNAPPY_LIBRARY NAMES ${SNAPPY_NAMES} NO_DEFAULT_PATH PATHS
     /opt/local/lib
     /usr/lib
     )
+find_library(SNAPPY_LIBRARY
+  NAMES ${SNAPPY_NAMES})
 
 if (SNAPPY_INCLUDE_DIR AND SNAPPY_LIBRARY)
   set(SNAPPY_FOUND TRUE)


### PR DESCRIPTION
libc6-dev puts its own nss.h at /usr/include/nss.h, and find_path()
checks for the default paths first by default. so disable it when
search for the file in the first pass, and enable it in the second
if not found.

Signed-off-by: Kefu Chai <kchai@redhat.com>