### PR TITLE
logrotate.conf: Simplify log files reopening after log rotation

### DIFF
--- a/src/logrotate.conf
+++ b/src/logrotate.conf
@@ -4,28 +4,7 @@
     compress
     sharedscripts
     postrotate
-        if which service > /dev/null 2>&1 && [ -x `which service` ]; then
-            service ceph reload >/dev/null
-        elif which invoke-rc.d > /dev/null 2>&1 && [ -x `which invoke-rc.d` ]; then
-            invoke-rc.d ceph reload >/dev/null
-        elif which systemctl > /dev/null 2>&1 && [ -x `which systemctl` ]; then
-	    # systemd does not provide an easy way to list (active) units
-	    killall -q -1 ceph-mon ceph-mds ceph-osd
-        fi
-        # Possibly reload twice, but depending on ceph.conf the reload above may be a no-op
-        if which initctl > /dev/null 2>&1 && [ -x `which initctl` ]; then
-            for daemon in osd mon mds ; do
-              find -L /var/lib/ceph/$daemon/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
-                | while read f; do
-                    if [ -e "/var/lib/ceph/$daemon/$f/done" -o -e "/var/lib/ceph/$daemon/$f/ready" ] && [ -e "/var/lib/ceph/$daemon/$f/upstart" ] && [ ! -e "/var/lib/ceph/$daemon/$f/sysvinit" ]; then
-                      cluster="${f%%-*}"
-                      id="${f#*-}"
-
-                      initctl reload ceph-$daemon cluster="$cluster" id="$id" 2>/dev/null || :
-                    fi
-                  done
-            done
-        fi
+	killall -q -1 ceph-mon ceph-mds ceph-osd
     endscript
     missingok
     notifempty

--- a/src/rgw/logrotate.conf
+++ b/src/rgw/logrotate.conf
@@ -4,25 +4,7 @@
     compress
     sharedscripts
     postrotate
-        if which service > /dev/null 2>&1 && [ -x `which service` ]; then
-            service ceph-radosgw reload >/dev/null
-        elif which invoke-rc.d > /dev/null 2>&1 && [ -x `which invoke-rc.d` ]; then
-            invoke-rc.d radosgw reload >/dev/null
-        elif which systemctl > /dev/null 2>&1 && [ -x `which systemctl` ]; then
-	    # systemd does not provide an easy way to list (active) units
-	    killall -q -1 radosgw
-        fi
-        # Possibly reload twice, but depending on ceph.conf the reload above may be a no-op
-        if which initctl > /dev/null 2>&1 && [ -x `which initctl` ]; then
-          find -L /var/lib/ceph/radosgw/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
-          | while read f; do
-            if [ -e "/var/lib/ceph/radosgw/$f/done" ]; then
-                cluster="${f%%-*}"
-                id="${f#*-}"
-                initctl reload radosgw cluster="$cluster" id="$id" 2>/dev/null || :
-            fi
-          done
-        fi
+	killall -q -1 radosgw
     endscript
     missingok
     notifempty


### PR DESCRIPTION
SIGHUP (1) signal makes ceph services reopen its log files so we do not
need to call any init scripts magic, here.

Additionally, the old approach caused problems with rhel-based systems
since it found the service command and tried to reload ceph.service
instead of ceph.target.

This also caused problems with SELinux as processes with context
logrotate_t are not allowed to issue systemctl reload on a process.

This patch is also in sync with other logrotate postrotate scripts which
do exactly the same thing (send SIGHUP to the daemon).

btw: I manually tried to send a SIGHUP to a running ceph-mon/ceph-osd daemon with removed log file and the process was able to re-create the log file afterwards so this should be safe.