### PR TITLE
[DNM] ceph-dencoder links to libtcmalloc, and shouldn't

### DIFF
--- a/src/mds/Makefile.am
+++ b/src/mds/Makefile.am
@@ -1,4 +1,4 @@
-libmds_la_SOURCES = \
+LIBMDS_SOURCES = \
 	mds/Anchor.cc \
 	mds/Capability.cc \
 	mds/Dumper.cc \
@@ -28,7 +28,14 @@ libmds_la_SOURCES = \
 	mds/SessionMap.cc \
 	mds/MDLog.cc \
 	mds/MDSUtility.cc
-libmds_la_LIBADD = $(LIBOSDC)
+LIBMDS_DEPS = $(LIBOSDC)
+
+# There are no libmds_types so use the full mds library for dencoder for now
+DENCODER_SOURCES += $(LIBMDS_SOURCES)
+DENCODER_DEPS += $(LIBMDS_DEPS)
+
+libmds_la_SOURCES = $(LIBMDS_SOURCES)
+libmds_la_LIBADD = $(LIBMDS_DEPS)
 noinst_LTLIBRARIES += libmds.la
 
 noinst_HEADERS += \

--- a/src/perfglue/Makefile.am
+++ b/src/perfglue/Makefile.am
@@ -17,6 +17,11 @@ endif # WITH_PROFILER
 
 noinst_LTLIBRARIES += libperfglue.la
 
+# Do not use TCMALLOC with dencoder
+DENCODER_SOURCES += \
+	perfglue/disabled_heap_profiler.cc \
+	perfglue/disabled_stubs.cc
+
 noinst_HEADERS += \
 	perfglue/cpu_profiler.h \
 	perfglue/heap_profiler.h

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -1,3 +1,11 @@
+# inject rgw stuff in the decoder testcase
+DENCODER_SOURCES += \
+	rgw/rgw_dencoder.cc \
+	rgw/rgw_acl.cc \
+	rgw/rgw_common.cc \
+	rgw/rgw_env.cc \
+	rgw/rgw_json_enc.cc
+
 if WITH_RADOSGW
 librgw_la_SOURCES =  \
 	rgw/librgw.cc \
@@ -103,14 +111,6 @@ ceph_rgw_jsonparser_SOURCES = \
 	rgw/rgw_json_enc.cc
 ceph_rgw_jsonparser_LDADD = $(LIBRGW) $(LIBRGW_DEPS) $(CEPH_GLOBAL)
 bin_DEBUGPROGRAMS += ceph_rgw_jsonparser
-
-# inject rgw stuff in the decoder testcase
-DENCODER_SOURCES += \
-	rgw/rgw_dencoder.cc \
-	rgw/rgw_acl.cc \
-	rgw/rgw_common.cc \
-	rgw/rgw_env.cc \
-	rgw/rgw_json_enc.cc
 
 
 endif # WITH_RADOSGW


### PR DESCRIPTION
http://tracker.ceph.com/issues/12461