### PR TITLE
doc: fix the typo in command example

### DIFF
--- a/doc/dev/mon-bootstrap.rst
+++ b/doc/dev/mon-bootstrap.rst
@@ -146,7 +146,7 @@ their own address).  For example::
 When these daemons are started, they will know their own address, but
 not their peers.  They can learn those addresses via the admin socket::
 
-     ceph mon.<id> add_bootstrap_peer_hint <peer ip>
+     ceph daemon mon.<id> add_bootstrap_peer_hint <peer ip>
 
 Once they learn enough of their peers from the initial member set,
 they will be able to create the cluster.

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -272,8 +272,8 @@ following command::
 
 For example, the following are equivalent::
 
-        ceph daemon osd.0 foo
-	ceph daemon /var/run/ceph/ceph-osd.0.asok foo
+    ceph daemon osd.0 foo
+    ceph daemon /var/run/ceph/ceph-osd.0.asok foo
 
 To view the available admin socket commands, execute the following command:: 
 


### PR DESCRIPTION
always indent using tab, the rendered html looks good, but it helps with
editor to highlight the codeblock properly.

Signed-off-by: Kefu Chai <kchai@redhat.com>