### PR TITLE
Mon:  delete 'auth print_key' command

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -9,7 +9,7 @@
 Synopsis
 ========
 
-| **ceph** **auth** [ *add* \| *caps* \| *del* \| *export* \| *get* \| *get-key* \| *get-or-create* \| *get-or-create-key* \| *import* \| *list* \| *print-key* \| *print_key* ] ...
+| **ceph** **auth** [ *add* \| *caps* \| *del* \| *export* \| *get* \| *get-key* \| *get-or-create* \| *get-or-create-key* \| *import* \| *list* \| *print-key* ] ...
 
 | **ceph** **compact**
 
@@ -154,12 +154,6 @@ Subcommand ``print-key`` displays requested key.
 Usage::
 
 	ceph auth print-key <entity>
-
-Subcommand ``print_key`` displays requested key.
-
-Usage::
-
-	ceph auth print_key <entity>
 
 
 compact

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -464,7 +464,6 @@ function test_auth()
   ceph auth get client.xx | grep caps | grep osd
   ceph auth get-key client.xx
   ceph auth print-key client.xx
-  ceph auth print_key client.xx
   ceph auth caps client.xx osd "allow rw"
   expect_false "ceph auth get client.xx | grep caps | grep mon"
   ceph auth get client.xx | grep osd | grep "allow rw"

--- a/qa/workunits/mon/auth_caps.sh
+++ b/qa/workunits/mon/auth_caps.sh
@@ -72,7 +72,6 @@ read_ops() {
   expect $ret ceph auth export client.admin $args
   expect $ret ceph auth list $args
   expect $ret ceph auth print-key client.admin $args
-  expect $ret ceph auth print_key client.admin $args
 }
 
 write_ops() {

--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -99,7 +99,6 @@ if __name__ == '__main__':
 
     expect('auth/get-key?entity=client.xx', 'GET', 200, 'json', JSONHDR)
     expect('auth/print-key?entity=client.xx', 'GET', 200, 'json', JSONHDR)
-    expect('auth/print_key?entity=client.xx', 'GET', 200, 'json', JSONHDR)
 
     expect('auth/caps?entity=client.xx&caps=osd&caps=allow+rw', 'PUT', 200,
            'json', JSONHDR)

--- a/src/bash_completion/ceph
+++ b/src/bash_completion/ceph
@@ -33,7 +33,7 @@ _ceph()
                 return 0
                 ;;
             auth)
-                COMPREPLY=( $(compgen -W "list add del print_key print-key export get get-key import get-or-create get-or-create-key" -- ${cur}) )
+                COMPREPLY=( $(compgen -W "list add del print-key export get get-key import get-or-create get-or-create-key" -- ${cur}) )
                 return 0
                 ;;
             pg)

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -604,7 +604,6 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
       r = 0;
     }
   } else if (prefix == "auth print-key" ||
-	     prefix == "auth print_key" ||
 	     prefix == "auth get-key") {
     EntityAuth auth;
     if (!mon->key_server.get_auth(entity, auth)) {

--- a/src/mon/DumplingMonCommands.h
+++ b/src/mon/DumplingMonCommands.h
@@ -156,8 +156,6 @@ COMMAND("auth get-key name=entity,type=CephString", "display requested key", \
 	"auth", "r", "cli,rest")
 COMMAND("auth print-key name=entity,type=CephString", "display requested key", \
 	"auth", "r", "cli,rest")
-COMMAND("auth print_key name=entity,type=CephString", "display requested key", \
-	"auth", "r", "cli,rest")
 COMMAND("auth list", "list authentication state", "auth", "r", "cli,rest")
 COMMAND("auth import", "auth import: read keyring file from -i <file>", \
 	"auth", "rw", "cli,rest")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -189,8 +189,6 @@ COMMAND("auth get-key name=entity,type=CephString", "display requested key", \
 	"auth", "rx", "cli,rest")
 COMMAND("auth print-key name=entity,type=CephString", "display requested key", \
 	"auth", "rx", "cli,rest")
-COMMAND("auth print_key name=entity,type=CephString", "display requested key", \
-	"auth", "rx", "cli,rest")
 COMMAND("auth list", "list authentication state", "auth", "rx", "cli,rest")
 COMMAND("auth import", "auth import: read keyring file from -i <file>", \
 	"auth", "rwx", "cli,rest")

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -213,7 +213,6 @@ class TestAuth(TestArgparse):
 
     def test_print_key(self):
         self.check_1_string_arg('auth', 'print-key')
-        self.check_1_string_arg('auth', 'print_key')
 
     def test_list(self):
         self.check_no_arg('auth', 'list')


### PR DESCRIPTION
'auth print-key' and 'auth print_key' are the same, so we delete one of the two.

Signed-off-by: Hongwei Bi <hwbi2008@gmail.com>