### PR TITLE
ceph.spec.in: refrain from duplicating %{_sbindir}/rcceph

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -750,7 +750,6 @@ mkdir -p %{_localstatedir}/run/ceph/
 %{_unitdir}/ceph.target
 %else
 %{_initrddir}/ceph
-%{_sbindir}/rcceph
 %endif
 %{_sbindir}/ceph-disk
 %{_sbindir}/ceph-disk-udev


### PR DESCRIPTION
On systemd, systemd/ceph is installed to /usr/sbin/rcceph.

On non-systemd, src/init-ceph is installed to /etc/init.d/ceph and
/usr/sbin/rcceph is created as a symlink to the latter.

In the %files section, we mention %{_sbindir}/rcceph twice: once
in a non-systemd conditional and once outside of any conditional.
Drop the former.

Signed-off-by: Nathan Cutler <ncutler@suse.com>