### PR TITLE
osd/PG: tolerate missing pgmeta object

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2858,7 +2858,13 @@ void OSD::load_pgs()
 
     dout(10) << "pgid " << pgid << " coll " << coll_t(pgid) << dendl;
     bufferlist bl;
-    epoch_t map_epoch = PG::peek_map_epoch(store, pgid, &bl);
+    epoch_t map_epoch;
+    int r = PG::peek_map_epoch(store, pgid, &map_epoch, &bl);
+    if (r < 0) {
+      derr << __func__ << " unable to peek at " << pgid << " metadata, skipping"
+	   << dendl;
+      continue;
+    }
 
     PG *pg = NULL;
     if (map_epoch > 0) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2728,9 +2728,10 @@ bool PG::_has_removal_flag(ObjectStore *store,
   return false;
 }
 
-epoch_t PG::peek_map_epoch(ObjectStore *store,
-			   spg_t pgid,
-			   bufferlist *bl)
+int PG::peek_map_epoch(ObjectStore *store,
+		       spg_t pgid,
+		       epoch_t *pepoch,
+		       bufferlist *bl)
 {
   coll_t coll(pgid);
   ghobject_t legacy_infos_oid(OSD::make_infos_oid());
@@ -2764,7 +2765,8 @@ epoch_t PG::peek_map_epoch(ObjectStore *store,
   bp = values[epoch_key].begin();
   ::decode(cur_epoch, bp);
 
-  return cur_epoch;
+  *pepoch = cur_epoch;
+  return 0;
 }
 
 void PG::write_if_dirty(ObjectStore::Transaction& t)

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2751,7 +2751,8 @@ int PG::peek_map_epoch(ObjectStore *store,
   map<string,bufferlist> values;
   int r = store->omap_get_values(coll, pgmeta_oid, keys, &values);
   if (r != 0) {
-    assert(0 == "unable to open pg metadata");
+    // probably bug 10617; see OSD::load_pgs()
+    return -1;
   }
   assert(values.size() == 2);
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2187,7 +2187,8 @@ public:
     __u8 &);
   void read_state(ObjectStore *store, bufferlist &bl);
   static bool _has_removal_flag(ObjectStore *store, spg_t pgid);
-  static epoch_t peek_map_epoch(ObjectStore *store, spg_t pgid, bufferlist *bl);
+  static int peek_map_epoch(ObjectStore *store, spg_t pgid,
+			    epoch_t *pepoch, bufferlist *bl);
   void update_snap_map(
     const vector<pg_log_entry_t> &log_entries,
     ObjectStore::Transaction& t);


### PR DESCRIPTION
Bug 10617 left stray PG dirs around in firefly.  Hammer correctly
ignores these, assuming they are leftover cruft.  We broke this
when we dropped compat support in cd4e676e6d45c8166290ef834d73c2a0bda98fa2

Signed-off-by: Sage Weil <sage@redhat.com>