### PR TITLE
#12994: packaging: move rbd-replay* to ceph-common

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -835,6 +835,11 @@ mkdir -p %{_localstatedir}/run/ceph/
 %{_bindir}/ceph-crush-location
 %{_bindir}/rados
 %{_bindir}/rbd
+%{_bindir}/rbd-replay
+%{_bindir}/rbd-replay-many
+%if 0%{?fedora} || 0%{?rhel} == 6 || 0%{?suse_version} >= 1310
+%{_bindir}/rbd-replay-prep
+%endif
 %{_bindir}/ceph-post-file
 %{_bindir}/ceph-brag
 %{_mandir}/man8/ceph-authtool.8*
@@ -846,6 +851,9 @@ mkdir -p %{_localstatedir}/run/ceph/
 %{_mandir}/man8/ceph.8*
 %{_mandir}/man8/rados.8*
 %{_mandir}/man8/rbd.8*
+%{_mandir}/man8/rbd-replay.8*
+%{_mandir}/man8/rbd-replay-many.8*
+%{_mandir}/man8/rbd-replay-prep.8*
 %{_datadir}/ceph/known_hosts_drop.ceph.com
 %{_datadir}/ceph/id_dsa_drop.ceph.com
 %{_datadir}/ceph/id_dsa_drop.ceph.com.pub
@@ -1096,14 +1104,6 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_bindir}/ceph-monstore-tool
 %{_bindir}/ceph-osdomap-tool
 %{_bindir}/ceph-kvstore-tool
-%{_mandir}/man8/rbd-replay.8*
-%{_mandir}/man8/rbd-replay-many.8*
-%{_mandir}/man8/rbd-replay-prep.8*
-%{_bindir}/rbd-replay
-%{_bindir}/rbd-replay-many
-%if 0%{?fedora} || 0%{?rhel} == 6 || 0%{?suse_version} >= 1310
-%{_bindir}/rbd-replay-prep
-%endif
 %dir %{_libdir}/ceph
 %{_libdir}/ceph/ceph-monstore-update-crush.sh
 

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -9,6 +9,7 @@ usr/bin/ceph-syn
 usr/bin/ceph-crush-location
 usr/bin/rados
 usr/bin/rbd
+usr/bin/rbd-replay*
 usr/bin/ceph-post-file
 usr/bin/ceph-brag
 usr/share/man/man8/ceph-authtool.8
@@ -20,6 +21,7 @@ usr/share/man/man8/ceph-post-file.8
 usr/share/man/man8/ceph.8
 usr/share/man/man8/rados.8
 usr/share/man/man8/rbd.8
+usr/share/man/man8/rbd-replay*.8
 usr/share/ceph/known_hosts_drop.ceph.com
 usr/share/ceph/id_dsa_drop.ceph.com
 usr/share/ceph/id_dsa_drop.ceph.com.pub

--- a/debian/ceph-test.install
+++ b/debian/ceph-test.install
@@ -27,6 +27,4 @@ usr/bin/ceph-monstore-tool
 usr/bin/ceph-osdomap-tool
 usr/bin/ceph-kvstore-tool
 usr/share/java/libcephfs-test.jar
-usr/bin/rbd-replay*
-usr/share/man/man8/rbd-replay*.8
 usr/lib/ceph/ceph-monstore-update-crush.sh

--- a/debian/control
+++ b/debian/control
@@ -199,9 +199,11 @@ Depends: librbd1 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends},
 Conflicts: ceph-client-tools
 Replaces: ceph-client-tools,
 	  ceph (<< 9.0.0-943),
+	  ceph-test (<< 9.0.3-1646),
 	  python-ceph (<< 0.92-1223),
 	  librbd1 (<< 0.92-1238)
 Breaks: ceph (<< 9.0.0-943),
+	ceph-test (<< 9.0.3-1646),
 	python-ceph (<< 0.92-1223),
 	librbd1 (<< 0.92-1238)
 Suggests: ceph, ceph-mds


### PR DESCRIPTION
The `rbd-replay*` utilities are useful for Ceph users with RBD clients. Currently the `rbd-replay*` utilities ship in the "ceph-test" package, and we intend this ceph-test package for Ceph developers and contributors, not normal users.

Move the `rbd-replay*` utilities to "ceph-common".

Fixes http://tracker.ceph.com/issues/12994