### PR TITLE
ceph-disk: minor improve the list_all_partition()

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -529,6 +529,8 @@ def list_all_partitions(names):
         names = os.listdir('/sys/block')
     dev_part_list = {}
     for name in names:
+        if 'ram' in name or 'loop' in name:
+            continue
         LOG.debug("list_all_partitions: " + name)
         # /dev/fd0 may hang http://tracker.ceph.com/issues/6827
         if re.match(r'^fd\d$', name):


### PR DESCRIPTION
    We don't need to check some block devices like ram, loop.
    I just skip these block devices when ceph-disk list.

If you have any questions, feel free to let me know.
Thanks!

Signed-off-by: Vicente Cheng <freeze.bilsted@gmail.com>