### PR TITLE
common/obj_bencher.cc: fix verification crashing when there's no objects

### DIFF
--- a/src/common/obj_bencher.h
+++ b/src/common/obj_bencher.h
@@ -36,7 +36,7 @@ struct bench_history {
 
 struct bench_data {
   bool done; //is the benchmark is done
-  int object_size; //the size of the objects
+  size_t object_size; //the size of the objects
   // same as object_size for write tests
   int in_flight; //number of reads/writes being waited on
   int started;
@@ -71,7 +71,7 @@ protected:
 
   struct bench_data data;
 
-  int fetch_bench_metadata(const std::string& metadata_file, int* object_size, int* num_objects, int* prevPid);
+  int fetch_bench_metadata(const std::string& metadata_file, size_t* object_size, int* num_objects, int* prevPid);
 
   int write_bench(int secondsToRun, int concurrentios, const string& run_name_meta);
   int seq_read_bench(int secondsToRun, int num_objects, int concurrentios, int writePid, bool no_verify=false);
@@ -107,7 +107,7 @@ public:
   virtual ~ObjBencher() {}
   int aio_bench(
     int operation, int secondsToRun,
-    int concurrentios, int op_size, bool cleanup, const std::string& run_name, bool no_verify=false);
+    int concurrentios, size_t op_size, bool cleanup, const std::string& run_name, bool no_verify=false);
   int clean_up(const std::string& prefix, int concurrentios, const std::string& run_name);
 
   void set_show_time(bool dt) {

--- a/src/test/test_rados_tool.sh
+++ b/src/test/test_rados_tool.sh
@@ -38,6 +38,12 @@ run_expect_succ() {
     [ $? -ne 0 ] && die "expected success, but got failure! cmd: $@"
 }
 
+run_expect_nosignal() {
+    echo "RUN_EXPECT_NOSIGNAL: " "$@"
+    do_run "$@"
+    [ $? -ge 128 ] && die "expected succes or fail, but got signal! cmd: $@"
+}
+
 run() {
     echo "RUN: " $@
     do_run "$@"
@@ -225,6 +231,12 @@ run_expect_succ "$RADOS_TOOL" --pool "$POOL" bench 5 write --format json --no-cl
 run_expect_succ "$RADOS_TOOL" --pool "$POOL" bench 1 rand --format json
 run_expect_succ "$RADOS_TOOL" --pool "$POOL" bench 1 seq --format json
 
+for i in $("$RADOS_TOOL" --pool "$POOL" ls | grep "benchmark_data"); do
+    "$RADOS_TOOL" --pool "$POOL" truncate $i 0
+done
+
+run_expect_nosignal "$RADOS_TOOL" --pool "$POOL" bench 1 rand
+run_expect_nosignal "$RADOS_TOOL" --pool "$POOL" bench 1 seq
 
 echo "SUCCESS!"
 exit 0


### PR DESCRIPTION
When specified pool is empty or doesn't contain valid bench objects, rados
can crash because it attempts to memcmp through NULL pointer. Added check
for valid object size (which also fixes the case when objects are there, but
they're truncated), and made object_size being size_t instead of int.

Also, fix lock issue under similar conditions in seq_read_bench().

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>