### PR TITLE
add an option to limit the number of snapshots an image can have

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -924,6 +924,7 @@ OPTION(rbd_blacklist_expire_seconds, OPT_INT, 0) // number of seconds to blackli
 OPTION(rbd_request_timed_out_seconds, OPT_INT, 30) // number of seconds before maint request times out
 OPTION(rbd_skip_partial_discard, OPT_BOOL, false) // when trying to discard a range inside an object, set to true to skip zeroing the range.
 OPTION(rbd_enable_alloc_hint, OPT_BOOL, true) // when writing a object, it will issue a hint to osd backend to indicate the expected size object need
+OPTION(rbd_snap_max_nums, OPT_U64, 255) // Max number snap of image
 
 /*
  * The following options change the behavior for librbd's image creation methods that

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -735,7 +735,7 @@ int invoke_async_request(ImageCtx *ictx, const std::string& request_type,
     
     ldout(ictx->cct, 20) << "snap_create_helper " << ictx << " " << snap_name
                          << dendl;
-	
+
     int r = ictx_check(ictx, true);
     if (r < 0) {
       return r;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2132,6 +2132,8 @@ reprotect_and_return_err:
     return 0;
   }
   
+  // Before the call snap_list_nums ()
+  // use ictx_check () detection
   int snap_list_nums(ImageCtx *ictx, uint64_t *snap_nums)
   {
     ldout(ictx->cct, 20) << "snap_list " << ictx << dendl;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2131,7 +2131,16 @@ reprotect_and_return_err:
 
     return 0;
   }
+  
+  int snap_list_nums(ImageCtx *ictx, uint64_t *snap_nums)
+  {
+    ldout(ictx->cct, 20) << "snap_list " << ictx << dendl;
 
+    RWLock::RLocker l(ictx->snap_lock);
+	*snap_nums = ictx->snap_info.size();
+    return 0;
+  } 
+  
   bool snap_exists(ImageCtx *ictx, const char *snap_name)
   {
     ldout(ictx->cct, 20) << "snap_exists " << ictx << " " << snap_name << dendl;

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -105,6 +105,7 @@ namespace librbd {
   int snap_create(ImageCtx *ictx, const char *snap_name);
   int snap_create_helper(ImageCtx *ictx, Context* ctx, const char *snap_name);
   int snap_list(ImageCtx *ictx, std::vector<snap_info_t>& snaps);
+  int snap_list_nums(ImageCtx *ictx, uint64_t *snap_nums);
   bool snap_exists(ImageCtx *ictx, const char *snap_name);
   int snap_rollback(ImageCtx *ictx, const char *snap_name,
 		    ProgressContext& prog_ctx);


### PR DESCRIPTION
Get the number of the Snap in the Image
snap_create_helper add rule "determine whether more than the maximum number of snap Settings"

Fixes: #12892
Signed-off-by: ren.huanwen@zte.com.cn