### PR TITLE
librbd: remove duplicate read_only test in librbd::async_flatten

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2844,7 +2844,7 @@ reprotect_and_return_err:
 	lderr(cct) << "image has no parent" << dendl;
 	return -EINVAL;
       }
-      if (ictx->snap_id != CEPH_NOSNAP || ictx->read_only) {
+      if (ictx->snap_id != CEPH_NOSNAP) {
 	lderr(cct) << "snapshots cannot be flattened" << dendl;
 	return -EROFS;
       }


### PR DESCRIPTION
`ictx->read_only` has been tested at line `2838`, so the same test at line `2847` can be removed.

Signed-off-by: runsisi <runsisi@hust.edu.cn>