### PR TITLE
SCA and compiler warning fixes

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -25,6 +25,7 @@ Makefile
 /ceph-mon
 /ceph-osd
 /ceph-syn
+/ceph.tmpe
 /ceph.conf
 /ceph_bench_log
 /ceph-objectstore-tool
@@ -71,6 +72,7 @@ Makefile
 /rados
 /radosgw
 /radosgw-admin
+/radosgw-object-expirer
 /rbd
 /rbd-fuse
 /rbd-replay

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4584,6 +4584,7 @@ int Client::check_permissions(Inode *in, int flags, int uid, int gid)
     pw = getpwuid(uid);
     if (pw == NULL) {
       ldout(cct, 3) << "getting user entry failed" << dendl;
+      free(sgids); 
       return -EACCES;
     }
     while (1) {

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4560,12 +4560,6 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, MClient
 
 int Client::check_permissions(Inode *in, int flags, int uid, int gid)
 {
-  // initial number of group entries, defaults to posix standard of 16
-  // PAM implementations may provide more than 16 groups....
-#if HAVE_GETGROUPLIST
-  int initial_group_count = 16;
-#endif
-
   gid_t *sgids = NULL;
   int sgid_count = 0;
   if (getgroups_cb) {
@@ -4578,7 +4572,9 @@ int Client::check_permissions(Inode *in, int flags, int uid, int gid)
 #if HAVE_GETGROUPLIST
   else {
     //use PAM to get the group list
-    sgid_count = initial_group_count;
+    // initial number of group entries, defaults to posix standard of 16
+    // PAM implementations may provide more than 16 groups....
+    sgid_count = 16;
     sgids = (gid_t*)malloc(sgid_count * sizeof(gid_t));
     if (sgids == NULL) {
       ldout(cct, 3) << "allocating group memory failed" << dendl;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4597,11 +4597,13 @@ int Client::check_permissions(Inode *in, int flags, int uid, int gid)
       if (getgrouplist(pw->pw_name, gid, sgids, &sgid_count) == -1) {
 #endif
         // we need to resize the group list and try again
-        sgids = (gid_t*)realloc(sgids, sgid_count * sizeof(gid_t));
-        if (sgids == NULL) {
+	void *_realloc = NULL;
+        if ((_realloc = realloc(sgids, sgid_count * sizeof(gid_t))) == NULL) {
           ldout(cct, 3) << "allocating group memory failed" << dendl;
+	  free(sgids);
           return -EACCES;
         }
+	sgids = (gid_t*)_realloc;
         continue;
       }
       // list was successfully retrieved

--- a/src/compressor/SnappyCompressor.h
+++ b/src/compressor/SnappyCompressor.h
@@ -40,7 +40,7 @@ class BufferlistSource : public snappy::Source {
   }
   virtual void Skip(size_t n) {
     if (n + pb_off == pb->length()) {
-      pb++;
+      ++pb;
       pb_off = 0;
     } else {
       pb_off += n;

--- a/src/erasure-code/shec/ErasureCodeShecTableCache.cc
+++ b/src/erasure-code/shec/ErasureCodeShecTableCache.cc
@@ -289,7 +289,7 @@ ErasureCodeShecTableCache::putDecodingTableToCache(int* decoding_matrix,
 
     // allocate a new buffer
     lru_list_t::iterator it_end = decode_tbls_lru->end();
-    it_end--;
+    --it_end;
 
     lru_entry_t &map_value =
       (*decode_tbls_map)[signature] =

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8167,7 +8167,7 @@ void MDCache::_open_ino_parent_opened(inodeno_t ino, int ret)
     _open_ino_traverse_dir(ino, info, 0);
   } else {
     if (ret >= 0) {
-      mds_rank_t checked_rank;
+      mds_rank_t checked_rank = mds_rank_t(ret);
       info.check_peers = true;
       info.auth_hint = checked_rank;
       info.checked.erase(checked_rank);

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -139,8 +139,12 @@ MDSDaemon::MDSDaemon(const std::string &n, Messenger *m, MonClient *mc) :
 MDSDaemon::~MDSDaemon() {
   Mutex::Locker lock(mds_lock);
 
-  if (mds_rank) {delete mds_rank ; mds_rank = NULL; }
-  if (objecter) {delete objecter ; objecter = NULL; }
+  delete mds_rank; 
+  mds_rank = NULL; 
+  delete objecter; 
+  objecter = NULL;
+  delete mdsmap;
+  mdsmap = NULL;
 
   delete authorize_handler_service_registry;
   delete authorize_handler_cluster_registry;

--- a/src/mon/ConfigKeyService.cc
+++ b/src/mon/ConfigKeyService.cc
@@ -91,13 +91,14 @@ void ConfigKeyService::store_list(stringstream &ss)
 bool ConfigKeyService::service_dispatch(MonOpRequestRef op)
 {
   Message *m = op->get_req();
+  assert(m != NULL);
   dout(10) << __func__ << " " << *m << dendl;
+
   if (!in_quorum()) {
     dout(1) << __func__ << " not in quorum -- ignore message" << dendl;
     return false;
   }
 
-  assert(m != NULL);
   assert(m->get_type() == MSG_MON_COMMAND);
 
   MMonCommand *cmd = static_cast<MMonCommand*>(m);

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -2026,7 +2026,7 @@ int KeyValueStore::_zero(coll_t cid, const ghobject_t& oid, uint64_t offset,
   r = check_get_rc(header->cid, header->oid, r, lookup_keys.size() == values.size());
   if (r < 0)
     return r;
-  for(set<string>::iterator it = lookup_keys.begin(); it != lookup_keys.end(); it++)
+  for(set<string>::iterator it = lookup_keys.begin(); it != lookup_keys.end(); ++it)
   {
     pair<uint64_t, uint64_t> p = off_len[*it];
     values[*it].zero(p.first, p.second);

--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -284,7 +284,7 @@ void ObjectStore::Transaction::_build_actions_from_tbl()
 	assert(ocid2 == ocid);
 	assert(oid2 == oid);
 
-	collection_move(ncid, ocid, oid);
+	collection_move_rename(ocid, oid, ncid, oid);
       }
       break;
 

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -463,7 +463,7 @@ int NewStore::OnodeHashLRU::trim(int max)
   int num = onode_map.size() - max;
   lru_list_t::iterator p = lru.end();
   if (num)
-    p--;
+    --p;
   while (num > 0) {
     Onode *o = &*p;
     int refs = o->nref.read();
@@ -2487,7 +2487,7 @@ void NewStore::_kv_sync_thread()
       if (!g_conf->newstore_sync_submit_transaction) {
 	for (std::deque<TransContext *>::iterator it = kv_committing.begin();
 	     it != kv_committing.end();
-	     it++) {
+	     ++it) {
 	  db->submit_transaction((*it)->t);
 	}
       }
@@ -2497,7 +2497,7 @@ void NewStore::_kv_sync_thread()
       KeyValueDB::Transaction txc_cleanup_sync = db->get_transaction();
       for (std::deque<TransContext *>::iterator it = wal_cleaning.begin();
 	    it != wal_cleaning.end();
-	    it++) {
+	    ++it) {
 	wal_transaction_t& wt =*(*it)->wal_txn;
 	// cleanup the data in overlays
 	for (list<wal_op_t>::iterator p = wt.ops.begin(); p != wt.ops.end(); ++p) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8797,7 +8797,7 @@ void OSD::set_pool_last_map_marked_full(OSDMap *o, epoch_t &e)
 {
   map<int64_t, epoch_t> &pool_last_map_marked_full = superblock.pool_last_map_marked_full;
   for (map<int64_t, pg_pool_t>::const_iterator it = o->get_pools().begin();
-       it != o->get_pools().end(); it++) {
+       it != o->get_pools().end(); ++it) {
     bool exist = pool_last_map_marked_full.count(it->first);
     if (it->second.has_flag(pg_pool_t::FLAG_FULL) && !exist)
       pool_last_map_marked_full[it->first] = e;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -12352,7 +12352,7 @@ void ReplicatedPG::setattrs_maybe_cache(
 {
   if (pool.info.require_rollback()) {
     for (map<string, bufferlist>::iterator it = attrs.begin();
-      it != attrs.end(); it++ ) {
+      it != attrs.end(); ++it) {
       op->pending_attrs[obc][it->first] = it->second;
     }
   }

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1019,7 +1019,7 @@ void Objecter::handle_osd_map(MOSDMap *m)
   bool was_pausewr = osdmap->test_flag(CEPH_OSDMAP_PAUSEWR) || cluster_full || _osdmap_has_pool_full();
   map<int64_t, bool> pool_full_map;
   for (map<int64_t, pg_pool_t>::const_iterator it = osdmap->get_pools().begin();
-       it != osdmap->get_pools().end(); it++)
+       it != osdmap->get_pools().end(); ++it)
     pool_full_map[it->first] = it->second.has_flag(pg_pool_t::FLAG_FULL);
 
   
@@ -2413,7 +2413,7 @@ bool Objecter::_osdmap_pool_full(const int64_t pool_id) const
 bool Objecter::_osdmap_has_pool_full() const
 {
   for (map<int64_t, pg_pool_t>::const_iterator it = osdmap->get_pools().begin();
-       it != osdmap->get_pools().end(); it++) {
+       it != osdmap->get_pools().end(); ++it) {
     if (it->second.has_flag(pg_pool_t::FLAG_FULL))
       return true;
   }
@@ -2432,7 +2432,7 @@ bool Objecter::_osdmap_full_flag() const
 void Objecter::update_pool_full_map(map<int64_t, bool>& pool_full_map)
 {
   for (map<int64_t, pg_pool_t>::const_iterator it = osdmap->get_pools().begin();
-       it != osdmap->get_pools().end(); it++) {
+       it != osdmap->get_pools().end(); ++it) {
     if (pool_full_map.find(it->first) == pool_full_map.end()) {
       pool_full_map[it->first] = it->second.has_flag(pg_pool_t::FLAG_FULL);
     } else {

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -2311,6 +2311,7 @@ static int do_metadata_remove(librbd::Image& image, const char *key)
   if (r < 0) {
     cerr << "failed to remove metadata " << key << " of image : " << cpp_strerror(r) << std::endl;
   }
+  return r;
 }
 
 static int do_metadata_get(librbd::Image& image, const char *key)

--- a/src/rgw/rgw_object_expirer_core.cc
+++ b/src/rgw/rgw_object_expirer_core.cc
@@ -181,7 +181,6 @@ void RGWObjectExpirer::process_single_shard(const string& shard,
 
 void RGWObjectExpirer::inspect_all_shards(const utime_t& last_run, const utime_t& round_start)
 {
-  bool is_next_available;
   utime_t shard_marker;
 
   CephContext *cct = store->ctx();
@@ -194,7 +193,7 @@ void RGWObjectExpirer::inspect_all_shards(const utime_t& last_run, const utime_t
     ldout(store->ctx(), 20) << "proceeding shard = " << shard << dendl;
 
     process_single_shard(shard, last_run, round_start);
-  } while (is_next_available);
+  }
 
   return;
 }

--- a/src/test/common/test_async_compressor.cc
+++ b/src/test/common/test_async_compressor.cc
@@ -142,7 +142,7 @@ class SyntheticWorkload {
       for (set<pair<uint64_t, uint64_t> >::iterator it = compress_jobs.begin();
            it != compress_jobs.end();) {
         prev = it;
-        it++;
+        ++it;
         ASSERT_EQ(0, async_compressor->get_compress_data(prev->first, data, blocking, &finished));
         if (finished) {
           c_reap++;
@@ -157,7 +157,7 @@ class SyntheticWorkload {
       for (set<pair<uint64_t, uint64_t> >::iterator it = decompress_jobs.begin();
            it != decompress_jobs.end();) {
         prev = it;
-        it++;
+        ++it;
         ASSERT_EQ(0, async_compressor->get_decompress_data(prev->first, data, blocking, &finished));
         if (finished) {
           d_reap++;

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -396,7 +396,7 @@ TEST_F(TestInternal, MetadatConfig) {
   map<string, bufferlist> pairs;
   r = librbd::metadata_list(ictx, "", 0, &pairs);
   ASSERT_EQ(0, r);
-  ASSERT_EQ(5, pairs.size());
+  ASSERT_EQ(5u, pairs.size());
   r = librbd::metadata_remove(ictx, "abcd");
   ASSERT_EQ(0, r);
   r = librbd::metadata_remove(ictx, "xyz");
@@ -404,7 +404,7 @@ TEST_F(TestInternal, MetadatConfig) {
   pairs.clear();
   r = librbd::metadata_list(ictx, "", 0, &pairs);
   ASSERT_EQ(0, r);
-  ASSERT_EQ(3, pairs.size());
+  ASSERT_EQ(3u, pairs.size());
   string val;
   r = librbd::metadata_get(ictx, it->first, &val);
   ASSERT_EQ(0, r);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -408,7 +408,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
 
     bufferlist in;
     r = store->read(cid, hoid, 0, bl.length(), in);
-    ASSERT_EQ(bl.length(), r);
+    ASSERT_EQ((int)bl.length(), r);
     in.hexdump(cout);
     ASSERT_TRUE(in.contents_equal(bl));
   }
@@ -2000,14 +2000,14 @@ TEST_P(StoreTest, OMapTest) {
       bufferlist hdr;
       map<string,bufferlist> m;
       store->omap_get(cid, hoid, &hdr, &m);
-      ASSERT_EQ(6, hdr.length());
+      ASSERT_EQ(6u, hdr.length());
       ASSERT_TRUE(m.count("2"));
       ASSERT_TRUE(!m.count("3"));
       ASSERT_TRUE(!m.count("6"));
       ASSERT_TRUE(m.count("7"));
       ASSERT_TRUE(m.count("8"));
       //cout << m << std::endl;
-      ASSERT_EQ(6, m.size());
+      ASSERT_EQ(6u, m.size());
     }
     {
       ObjectStore::Transaction t;
@@ -2018,8 +2018,8 @@ TEST_P(StoreTest, OMapTest) {
       bufferlist hdr;
       map<string,bufferlist> m;
       store->omap_get(cid, hoid, &hdr, &m);
-      ASSERT_EQ(0, hdr.length());
-      ASSERT_EQ(0, m.size());
+      ASSERT_EQ(0u, hdr.length());
+      ASSERT_EQ(0u, m.size());
     }
   }
 
@@ -2077,7 +2077,7 @@ TEST_P(StoreTest, OMapIterator) {
       }
       ASSERT_EQ(correct, true);
     }
-    ASSERT_EQ(attrs.size(), count);
+    ASSERT_EQ((int)attrs.size(), count);
 
     // FileStore may deadlock an active iterator vs apply_transaction
     iter = ObjectMap::ObjectMapIterator();


### PR DESCRIPTION
Fixes for several SCA and compiler warning issues like:
- realloc memory leak
- prefer ++/--operator for non-primitive types
- uninit vars
- remove unused vars
- resource/memory leaks
- fix return from non-void function
- replace deprecated function call
- fix -Wsign-compare