### PR TITLE
rgw: do not erase etag and content_type when setting ACL

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2789,7 +2789,15 @@ void RGWPutACLs::execute()
   new_policy.encode(bl);
   obj = rgw_obj(s->bucket, s->object);
   map<string, bufferlist> attrs;
+
+  if (!s->object.empty()) {
+    ret = get_obj_attrs(store, s, obj, attrs);
+    if (ret < 0)
+      return;
+  }
+  
   attrs[RGW_ATTR_ACL] = bl;
+
   store->set_atomic(s->obj_ctx, obj);
   if (!s->object.empty()) {
     ret = store->set_attrs(s->obj_ctx, obj, attrs, NULL, ptracker);


### PR DESCRIPTION
http://tracker.ceph.com/issues/12955

When ACLs on an object are modified as a distinct operation (read: not as part of an object put), the etag and content_type attributes will be overwritten to empty strings.  This patch populates the attrs bufferlist in RGWPutACLs::execute before calling RGWRados::set_attrs to prevent this from happening.

Patch tested on a 0.94.3 cluster.

Signed-off-by: Brian Felton <bjfelton@gmail.com>
Reported-by: Mike Beyer <miketbeyer@gmail.com>
