### PR TITLE
rgw: include RequestId as part of the Error response

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -553,6 +553,8 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
       s->formatter->dump_string("Code", s->err.s3_code);
     if (!s->err.message.empty())
       s->formatter->dump_string("Message", s->err.message);
+    if (!s->trans_id.empty())
+      s->formatter->dump_string("RequestId", s->trans_id);
     s->formatter->close_section();
     dump_content_length(s, s->formatter->get_len());
   } else {


### PR DESCRIPTION
The RGW error responses must contain a RequestId to be compliant with
the Amazon S3 errors. This RequestId is the ID of the request associated
with the error.

Fixes: #13020

Signed-off-by: Javier M. Mellid <jmunhoz@igalia.com>