### PR TITLE
ceph-disk: Add destroy and deactivate option

### DIFF
--- a/qa/workunits/ceph-disk/ceph-disk-test.py
+++ b/qa/workunits/ceph-disk/ceph-disk-test.py
@@ -191,6 +191,7 @@ class TestCephDisk(object):
         c.check_osd_status(osd_uuid, have_journal)
         data_partition = c.get_osd_partition(osd_uuid)
         c.sh("ceph-disk deactivate " + data_partition['path'])
+        c.wait_for_osd_down(osd_uuid)
         c.sh("ceph-disk activate " + data_partition['path'] + " --reactivate")
         # check again
         c.wait_for_osd_up(osd_uuid)
@@ -219,6 +220,7 @@ class TestCephDisk(object):
         assert partition['type'] == 'data'
         assert partition['state'] == 'active'
         c.sh("ceph-disk deactivate " + partition['path'])
+        c.wait_for_osd_down(osd_uuid)
         c.sh("ceph-disk destroy " + partition['path'] + " --zap")
 
     def test_deactivate_reactivate_dmcrypt_plain(self):
@@ -248,6 +250,7 @@ class TestCephDisk(object):
         c.check_osd_status(osd_uuid, have_journal)
         data_partition = c.get_osd_partition(osd_uuid)
         c.sh("ceph-disk deactivate " + data_partition['path'])
+        c.wait_for_osd_down(osd_uuid)
         c.sh("ceph-disk activate " + data_partition['path'] +
              " --reactivate" + " --dmcrypt")
         # check again

--- a/qa/workunits/ceph-disk/ceph-disk-test.py
+++ b/qa/workunits/ceph-disk/ceph-disk-test.py
@@ -112,30 +112,9 @@ class CephDisk:
 
     def destroy_osd(self, uuid):
         id = self.sh("ceph osd create " + uuid)
-        self.helper("control_osd stop " + id + " || true")
-        self.wait_for_osd_down(uuid)
-        try:
-            partition = self.get_journal_partition(uuid)
-            if partition:
-                if partition.get('mount'):
-                    self.sh("umount '" + partition['mount'] + "' || true")
-                if partition['dmcrypt']:
-                    holder = partition['dmcrypt']['holders'][0]
-                    self.sh("cryptsetup close $(cat /sys/block/" + holder + "/dm/name) || true")
-        except:
-            pass
-        try:
-            partition = self.get_osd_partition(uuid)
-            if partition.get('mount'):
-                self.sh("umount '" + partition['mount'] + "' || true")
-            if partition['dmcrypt']:
-                holder = partition['dmcrypt']['holders'][0]
-                self.sh("cryptsetup close $(cat /sys/block/" + holder + "/dm/name) || true")
-        except:
-            pass
         self.sh("""
         ceph-disk deactivate --deactivate-by-id {id}
-        ceph-disk destroy --destroy-by-id {id}
+        ceph-disk destroy --destroy-by-id {id} --zap
         """.format(id=id))
 
     @staticmethod
@@ -173,6 +152,13 @@ class CephDisk:
             time.sleep(delay)
         raise Exception('timeout waiting for osd ' + uuid + ' to be ' + info)
 
+    def check_osd_status(self, uuid, have_journal=False):
+        data_partition = self.get_osd_partition(uuid)
+        assert data_partition['type'] == 'data'
+        assert data_partition['state'] == 'active'
+        if have_journal:
+            journal_partition = self.get_journal_partition(uuid)
+            assert journal_partition
 
 class TestCephDisk(object):
 
@@ -191,7 +177,39 @@ class TestCephDisk(object):
                 del c.conf['global'][key]
         c.save_conf()
 
-    def test_destroy_osd(self):
+    def test_deactivate_reactivate_osd(self):
+        c = CephDisk()
+        have_journal=True
+        disk = c.unused_disks()[0]
+        osd_uuid = str(uuid.uuid1())
+        c.sh("ceph-disk zap " + disk)
+        c.sh("ceph-disk prepare --osd-uuid " + osd_uuid +
+             " " + disk)
+        c.wait_for_osd_up(osd_uuid)
+        device = json.loads(c.sh("ceph-disk list --format json " + disk))[0]
+        assert len(device['partitions']) == 2
+        c.check_osd_status(osd_uuid, have_journal)
+        data_partition = c.get_osd_partition(osd_uuid)
+        c.sh("ceph-disk deactivate " + data_partition['path'])
+        c.sh("ceph-disk activate " + data_partition['path'] + " --reactivate")
+        # check again
+        c.wait_for_osd_up(osd_uuid)
+        device = json.loads(c.sh("ceph-disk list --format json " + disk))[0]
+        assert len(device['partitions']) == 2
+        c.check_osd_status(osd_uuid, have_journal)
+        c.helper("pool_read_write")
+        c.destroy_osd(osd_uuid)
+
+    def test_destroy_osd_by_id(self):
+        c = CephDisk()
+        disk = c.unused_disks()[0]
+        osd_uuid = str(uuid.uuid1())
+        c.sh("ceph-disk prepare --osd-uuid " + osd_uuid + " " + disk)
+        c.wait_for_osd_up(osd_uuid)
+        c.check_osd_status(osd_uuid)
+        c.destroy_osd(osd_uuid)
+
+    def test_destroy_osd_by_dev_path(self):
         c = CephDisk()
         disk = c.unused_disks()[0]
         osd_uuid = str(uuid.uuid1())
@@ -200,13 +218,16 @@ class TestCephDisk(object):
         partition = c.get_osd_partition(osd_uuid)
         assert partition['type'] == 'data'
         assert partition['state'] == 'active'
-        c.destroy_osd(osd_uuid)
-        c.sh("ceph-disk zap " + disk)
+        c.sh("ceph-disk deactivate " + partition['path'])
+        c.sh("ceph-disk destroy " + partition['path'] + " --zap")
 
     def test_activate_dmcrypt_plain(self):
         c = CephDisk()
         c.conf['global']['osd dmcrypt type'] = 'plain'
         c.save_conf()
+
+    def test_deactivate_reactivate_dmcrypt_plain(self):
+        CephDisk.augtool("set /files/etc/ceph/ceph.conf/global/osd_dmcrypt_type plain")
         self.activate_dmcrypt('plain')
         c.save_conf()
 
@@ -214,8 +235,13 @@ class TestCephDisk(object):
         c = CephDisk()
         self.activate_dmcrypt('luks')
 
+    def test_deactivate_reactivate_dmcrypt_luks(self):
+        CephDisk.augtool("rm /files/etc/ceph/ceph.conf/global/osd_dmcrypt_type")
+        self.activate_dmcrypt('luks')
+
     def activate_dmcrypt(self, type):
         c = CephDisk()
+        have_journal = True
         disk = c.unused_disks()[0]
         osd_uuid = str(uuid.uuid1())
         journal_uuid = str(uuid.uuid1())
@@ -226,13 +252,41 @@ class TestCephDisk(object):
              " --dmcrypt " +
              " " + disk)
         c.wait_for_osd_up(osd_uuid)
+        c.check_osd_status(osd_uuid, have_journal)
         data_partition = c.get_osd_partition(osd_uuid)
-        assert data_partition['type'] == 'data'
-        assert data_partition['state'] == 'active'
-        journal_partition = c.get_journal_partition(osd_uuid)
-        assert journal_partition
+        c.sh("ceph-disk deactivate " + data_partition['path'])
+        c.sh("ceph-disk activate " + data_partition['path'] +
+             " --reactivate" + " --dmcrypt")
+        # check again
+        c.wait_for_osd_up(osd_uuid)
+        c.check_osd_status(osd_uuid, have_journal)
         c.destroy_osd(osd_uuid)
+
+
+    def test_activate_dmcrypt_plain(self):
+        CephDisk.augtool("set /files/etc/ceph/ceph.conf/global/osd_dmcrypt_type plain")
+        self.activate_dmcrypt('plain')
+        CephDisk.augtool("rm /files/etc/ceph/ceph.conf/global/osd_dmcrypt_type")
+
+    def test_activate_dmcrypt_luks(self):
+        CephDisk.augtool("rm /files/etc/ceph/ceph.conf/global/osd_dmcrypt_type")
+        self.activate_dmcrypt('luks')
+
+    def activate_dmcrypt(self, type):
+        c = CephDisk()
+        have_journal = True
+        disk = c.unused_disks()[0]
+        osd_uuid = str(uuid.uuid1())
+        journal_uuid = str(uuid.uuid1())
         c.sh("ceph-disk zap " + disk)
+        c.sh("ceph-disk -v prepare " +
+             " --osd-uuid " + osd_uuid +
+             " --journal-uuid " + journal_uuid +
+             " --dmcrypt " +
+             " " + disk)
+        c.wait_for_osd_up(osd_uuid)
+        c.check_osd_status(osd_uuid, have_journal)
+        c.destroy_osd(osd_uuid)
 
     def test_activate_no_journal(self):
         c = CephDisk()
@@ -257,6 +311,7 @@ class TestCephDisk(object):
 
     def test_activate_with_journal(self):
         c = CephDisk()
+        have_journal = True
         disk = c.unused_disks()[0]
         osd_uuid = str(uuid.uuid1())
         c.sh("ceph-disk zap " + disk)
@@ -265,14 +320,9 @@ class TestCephDisk(object):
         c.wait_for_osd_up(osd_uuid)
         device = json.loads(c.sh("ceph-disk list --format json " + disk))[0]
         assert len(device['partitions']) == 2
-        data_partition = c.get_osd_partition(osd_uuid)
-        assert data_partition['type'] == 'data'
-        assert data_partition['state'] == 'active'
-        journal_partition = c.get_journal_partition(osd_uuid)
-        assert journal_partition
+        c.check_osd_status(osd_uuid, have_journal)
         c.helper("pool_read_write")
         c.destroy_osd(osd_uuid)
-        c.sh("ceph-disk zap " + disk)
 
     def test_activate_separated_journal(self):
         c = CephDisk()
@@ -286,17 +336,14 @@ class TestCephDisk(object):
 
     def activate_separated_journal(self, data_disk, journal_disk):
         c = CephDisk()
+        have_journal = True
         osd_uuid = str(uuid.uuid1())
         c.sh("ceph-disk prepare --osd-uuid " + osd_uuid +
              " " + data_disk + " " + journal_disk)
         c.wait_for_osd_up(osd_uuid)
         device = json.loads(c.sh("ceph-disk list --format json " + data_disk))[0]
         assert len(device['partitions']) == 1
-        data_partition = c.get_osd_partition(osd_uuid)
-        assert data_partition['type'] == 'data'
-        assert data_partition['state'] == 'active'
-        journal_partition = c.get_journal_partition(osd_uuid)
-        assert journal_partition
+        c.check_osd_status(osd_uuid, have_journal)
         return osd_uuid
 
     #
@@ -349,9 +396,7 @@ class TestCephDisk(object):
         c.wait_for_osd_up(osd_uuid)
         device = json.loads(c.sh("ceph-disk list --format json " + data_disk))[0]
         assert len(device['partitions']) == 1
-        data_partition = c.get_osd_partition(osd_uuid)
-        assert data_partition['type'] == 'data'
-        assert data_partition['state'] == 'active'
+        c.check_osd_status(osd_uuid)
         journal_partition = c.get_journal_partition(osd_uuid)
         #
         # Verify the previous OSD partition has been reused
@@ -392,7 +437,6 @@ class TestCephDisk(object):
         assert journal_partition
         c.helper("pool_read_write")
         c.destroy_osd(osd_uuid)
-        c.sh("ceph-disk zap " + multipath)
         c.sh("udevadm settle")
         c.sh("multipath -F")
         c.unload_scsi_debug()

--- a/qa/workunits/ceph-disk/ceph-disk-test.py
+++ b/qa/workunits/ceph-disk/ceph-disk-test.py
@@ -134,10 +134,8 @@ class CephDisk:
         except:
             pass
         self.sh("""
-        ceph osd down {id}
-        ceph osd rm {id}
-        ceph auth del osd.{id}
-        ceph osd crush rm osd.{id}
+        ceph-disk deactivate --deactivate-by-id {id}
+        ceph-disk destroy --destroy-by-id {id}
         """.format(id=id))
 
     @staticmethod

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -62,15 +62,18 @@ Activate:
  - triggered on ceph service startup with 'ceph-disk activate-all'
 
 Deactivate:
+ - check partition type (support dmcrypt, mpath, normal)
  - stop ceph-osd service if needed (make osd out with option --mark-out)
  - remove 'ready', 'active', and INIT-specific files
  - create deactive flag
  - umount device and remove mount point
 
 Destroy:
+ - check partition type (support dmcrypt, mpath, normal)
  - remove OSD from CRUSH map
  - remove OSD cephx key
  - deallocate OSD ID
+ - if the partition type is dmcrypt, remove the dmcrypt map.
  - destroy data (with --zap option)
 
 We rely on /dev/disk/by-partuuid to find partitions by their UUID;
@@ -877,6 +880,31 @@ def allocate_osd_id(
     return osd_id
 
 
+def get_osd_id_journal_dm(dev, dmcrypt=False):
+    """
+    Try to mount to tmp.directory and get osd_id.
+
+    :return: osd_id/-1
+    """
+    dm_journal = ''
+    osd_id = -1
+    try:
+        fs_type = get_dev_fs(dev)
+        if fs_type != None:
+            tpath = mount(dev=dev, fstype=fs_type, options='')
+            if tpath:
+                try:
+                    journal_path_dm = os.path.join(tpath, 'journal_dmcrypt')
+                    if dmcrypt and os.path.islink(journal_path_dm):
+                        dm_journal = os.path.realpath(journal_path_dm)
+                    osd_id = get_osd_id(tpath)
+                finally:
+                    unmount(tpath)
+        return osd_id, dm_journal
+    except:
+        raise MountError
+
+
 def get_osd_id(path):
     """
     Gets the OSD id of the OSD at the given path.
@@ -998,6 +1026,28 @@ def get_fsid(cluster):
     if fsid is None:
         raise Error('getting cluster uuid from configuration failed')
     return fsid.lower()
+
+
+def get_dmcrypt_status(_uuid):
+    """
+    Get status on dm-crypt device.
+
+    :return: the dm-crypt device status, True: active, False: inactive
+    """
+    try:
+        out, ret = command(
+                [
+                    '/sbin/cryptsetup',
+                    'status',
+                    _uuid,
+                    ],
+                )
+    except:
+        raise Error('Get dmcrypt status fail!')
+    if 'inactive' in out:
+        return False
+    else:
+        return True
 
 
 def get_dmcrypt_key_path(
@@ -1942,7 +1992,7 @@ def main_prepare(args):
             raise Error('not a dir or block device', args.data)
         prepare_lock.release()  # noqa
 
-    except Error as e:
+    except Error:
         if journal_dm_keypath:
             try:
                 os.unlink(journal_dm_keypath)
@@ -2242,28 +2292,33 @@ def mount_activate(
     ):
 
     if dmcrypt:
-            # dev corresponds to a dmcrypt cyphertext device - map it before
-            # proceeding.
-            rawdev = dev
-            ptype = get_partition_type(rawdev)
-            if ptype in [DMCRYPT_OSD_UUID]:
-                luks = False
-                cryptsetup_parameters = ['--key-size', '256']
-            elif ptype in [DMCRYPT_LUKS_OSD_UUID]:
-                luks = True
-                cryptsetup_parameters = []
-            else:
-                raise Error('activate --dmcrypt called for invalid dev %s' % (dev))
-            part_uuid = get_partition_uuid(rawdev)
-            dmcrypt_key_path = get_dmcrypt_key_path(part_uuid, dmcrypt_key_dir, luks)
+        # dev corresponds to a dmcrypt cyphertext device - map it before
+        # proceeding.
+        rawdev = dev
+        ptype = get_partition_type(rawdev)
+        if ptype in [DMCRYPT_OSD_UUID]:
+            luks = False
+            cryptsetup_parameters = ['--key-size', '256']
+        elif ptype in [DMCRYPT_LUKS_OSD_UUID]:
+            luks = True
+            cryptsetup_parameters = []
+        else:
+            raise Error('activate --dmcrypt called for invalid dev %s' % (dev))
+        part_uuid = get_partition_uuid(rawdev)
+        dmcrypt_key_path = get_dmcrypt_key_path(part_uuid, dmcrypt_key_dir, luks)
+        # if osd is deactive, we do not remove dmcrypt map.
+        # return the dm path and do not map when the osd is still mapped (avoid fail).
+        if not get_dmcrypt_status(part_uuid):
             dev = dmcrypt_map(
-                    rawdev=rawdev,
-                    keypath=dmcrypt_key_path,
-                    _uuid=part_uuid,
-                    cryptsetup_parameters=cryptsetup_parameters,
-                    luks=luks,
-                    format_dev=False,
-                    )
+                rawdev=rawdev,
+                keypath=dmcrypt_key_path,
+                _uuid=part_uuid,
+                cryptsetup_parameters=cryptsetup_parameters,
+                luks=luks,
+                format_dev=False,
+                )
+        else:
+            dev = '/dev/mapper/' + part_uuid
 
     try:
         fstype = detect_fstype(dev=dev)
@@ -2308,25 +2363,40 @@ def mount_activate(
             raise Error('OSD deactivated! reactivate with: --reactivate')
         # flag to activate a deactive osd.
         deactive = True
-        journal_dev = os.path.realpath(os.path.join(path,'journal'))
-        try:
-            if get_ceph_user() == 'ceph':
-                command(
-                    [
-                    'chown', '-R', 'ceph:ceph',
-                    journal_dev,
-                    ],
-                )
-                command(
-                    [
-                    'chmod', '660',
-                    journal_dev,
-                    ]
-                )
-        except OSError:
-            pass
     else:
         deactive = False
+
+    journal_dev = os.path.realpath(os.path.join(path,'journal'))
+    try:
+        if get_ceph_user() == 'ceph':
+            command(
+                [
+                'chown', '-R', 'ceph:ceph',
+                journal_dev,
+                ],
+            )
+            command(
+                [
+                'chmod', '660',
+                journal_dev,
+                ]
+            )
+        if dmcrypt:
+            journal_dev_dmcrypt = os.path.realpath(os.path.join(path,'journal_dmcrypt'))
+            command(
+                [
+                'chown', '-R', 'ceph:ceph',
+                journal_dev_dmcrypt,
+                ],
+            )
+            command(
+                [
+                'chmod', '660',
+                journal_dev_dmcrypt,
+                ]
+            )
+    except OSError:
+        pass
 
     osd_id = None
     cluster = None
@@ -2709,11 +2779,20 @@ def main_deactivate(args):
        if not os.path.exists(args.path):
            raise Error('%s does not exist' % args.path)
        else:
-           mounted_path = is_mounted(args.path)
+           # check dmcrypt first.
+           part_type = get_partition_type(args.path)
+           if part_type == DMCRYPT_OSD_UUID or \
+              part_type == DMCRYPT_LUKS_OSD_UUID:
+              part_uuid = get_partition_uuid(args.path)
+              dev_path = '/dev/mapper/' + part_uuid
+           else:
+               # other cases will return args.path
+               dev_path = args.path
+           mounted_path = is_mounted(dev_path)
            if mounted_path is None:
-               raise Error('%s is not mounted' % args.path)
-           osd_id = get_oneliner(mounted_path, 'whoami')
-           mount_info.append(args.path)
+               raise Error('%s is not mounted' % dev_path)
+           osd_id = get_osd_id(mounted_path)
+           mount_info.append(dev_path)
            mount_info.append(mounted_path)
 
     # Do not do anything if osd is already down.
@@ -2797,25 +2876,79 @@ def _deallocate_osd_id(cluster, osd_id):
         raise Error(e)
 
 def main_destroy(args):
+    dmcrypt = False
     mount_info = []
+    # get everything we need when we start destroy.
     if args.destroy_by_id:
         osd_id = args.destroy_by_id
+        # try to find osd data device.
+        partmap = list_all_partitions(None)
+        # list all partition which have the partition name with
+        # deactive flag
+        devtocheck = []
+        found = False
+        for base, parts in sorted(partmap.iteritems()):
+            if not parts:
+                continue
+            for p in parts:
+                (dev, p_num) = split_dev_base_partnum(os.path.join("/dev", p))
+                LOG.debug("device: %s, p_num: %s" % (dev, p_num))
+                devtocheck.append(os.path.join("/dev", p))
+
+        # check all above device's osd_id
+        # if the osd_id is correct, zap it.
+        for item in devtocheck:
+            try:
+                # one more try to check dmcrypt, or raise mounterror
+                # Do nothing when we get some specific part_type
+                # that because in some situation we can not update
+                # partition table immediately
+                dmcrypt = False
+                part_type = get_partition_type(item)
+                if part_type == DMCRYPT_OSD_UUID or \
+                   part_type == DMCRYPT_LUKS_OSD_UUID:
+                    dmcrypt = True
+                    part_uuid_journal = ''
+                    part_uuid = get_partition_uuid(item)
+                    dev_path = '/dev/mapper/' + part_uuid
+                    whoami, dm_journal = get_osd_id_journal_dm(dev_path, dmcrypt)
+                    part_uuid_journal = get_partition_uuid(dm_journal)
+                elif part_type == OSD_UUID or \
+                     part_type == MPATH_OSD_UUID:
+                    whoami, dm_journal = get_osd_id_journal_dm(item, dmcrypt)
+                else:
+                    continue
+            except:
+                # other cases will return MountError
+                raise MountError
+            # break when we found the target osd_id.
+            # that can avoid handle the redundant checking
+            if whoami == osd_id:
+                found = True
+                (base_dev, part_num) = split_dev_base_partnum(item)
+                break
+        if not found:
+            raise Error('Could not find the partition of osd.%s!' % osd_id)
     else:
        if not os.path.exists(args.path):
            raise Error('%s does not exist' % args.path)
        else:
+           # check dmcrypt first.
+           part_type = get_partition_type(args.path)
+           if part_type == DMCRYPT_OSD_UUID or \
+              part_type == DMCRYPT_LUKS_OSD_UUID:
+              dmcrypt = True
+              part_uuid_journal = ''
+              part_uuid = get_partition_uuid(args.path)
+              dev_path = '/dev/mapper/' + part_uuid
+           else:
+               # other cases will return args.path
+               dev_path = args.path
            # mount point is removed, try to mount to tmp.folder
-           try:
-                fs_type = get_dev_fs(args.path)
-                if fs_type != None:
-                    tpath = mount(dev=args.path, fstype=fs_type, options='')
-                    if tpath:
-                        try:
-                            osd_id = get_oneliner(tpath, 'whoami')
-                        finally:
-                            unmount(tpath)
-           except:
-               raise MountError
+           osd_id, dm_journal = get_osd_id_journal_dm(dev_path, dmcrypt)
+           if dm_journal:
+               part_uuid_journal = get_partition_uuid(dm_journal)
+           base_dev = get_partition_base(args.path)
            mount_info.append(args.path)
 
 
@@ -2835,49 +2968,18 @@ def main_destroy(args):
     # Deallocate OSD ID
     _deallocate_osd_id(args.cluster, osd_id)
 
+    # we remove the crypt map and device mapper (if dmcrypt is True)
+    if dmcrypt:
+        dmcrypt_unmap(part_uuid)
+        if part_uuid_journal:
+            try:
+                dmcrypt_unmap(part_uuid_journal)
+            except:
+                pass
+
     # Check zap flag. If we found zap flag, we need to find device for
     # destroy this osd data.
     if args.zap is True:
-
-        # easy to do when we get device
-        if mount_info:
-            base_dev = get_partition_base(mount_info[0])
-        else:
-            # try to find osd data device.
-            partmap = list_all_partitions(None)
-            # list all partition which have the partition name with
-            # deactive flag
-            devtocheck = []
-            found = False
-            for base, parts in sorted(partmap.iteritems()):
-                if not parts:
-                    continue
-                for p in parts:
-                    (dev, p_num) = split_dev_base_partnum(os.path.join("/dev", p))
-                    LOG.debug("device: %s, p_num: %s" % (dev, p_num))
-                    devtocheck.append(os.path.join("/dev", p))
-
-            # check all above device's osd_id
-            # if the osd_id is correct, zap it.
-            for item in devtocheck:
-                try:
-                    whoami = -1
-                    fs_type = get_dev_fs(item)
-                    if fs_type != None:
-                        tpath = mount(dev=item, fstype=fs_type, options='')
-                        if tpath:
-                            try:
-                                whoami = get_oneliner(tpath, 'whoami')
-                            finally:
-                                unmount(tpath)
-                    if whoami is osd_id:
-                        found = True
-                        (base_dev, part_num) = split_dev_base_partnum(item)
-                except:
-                    raise MountError
-            if not found:
-                raise Error('Could not find the partition of osd.%s!' % osd_id)
-
         # earse the osd data
         LOG.info("Prepare to zap the device %s" % base_dev)
         zap(base_dev)
@@ -4029,7 +4131,7 @@ def setup_logging(verbose, log_stdout):
     if log_stdout:
         ch = logging.StreamHandler(stream=sys.stdout)
         ch.setLevel(loglevel)
-        formatter = logging.Formatter('%(filename): %(message)s')
+        formatter = logging.Formatter('%(filename)s: %(message)s')
         ch.setFormatter(formatter)
         LOG.addHandler(ch)
         LOG.setLevel(loglevel)

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -61,7 +61,7 @@ Activate:
  - triggered on ceph service startup with 'ceph-disk activate-all'
 
 Deactivate:
- - stop ceph-osd service if needed (If osd still in osd map, make it out first)
+ - stop ceph-osd service if needed (make osd out with option --mark-out)
  - remove 'ready', 'active', and INIT-specific files
  - remove gpt partition type and change partition name (prevent triggered by udev)
  - create deactive flag
@@ -2743,10 +2743,12 @@ def main_deactivate(args):
     # Do not do anything if osd is already down.
     status_code = _check_osd_status(args.cluster, args.osd_id)
     if status_code == OSD_STATUS_IN_UP:
-        _mark_osd_out(args.cluster, args.osd_id)
+        if args.mark_out is True:
+            _mark_osd_out(args.cluster, args.osd_id)
         stop_daemon(args.cluster, args.osd_id)
     elif status_code == OSD_STATUS_IN_DOWN:
-        _mark_osd_out(args.cluster, args.osd_id)
+        if args.mark_out is True:
+            _mark_osd_out(args.cluster, args.osd_id)
     elif status_code == OSD_STATUS_OUT_UP:
         stop_daemon(args.cluster, args.osd_id)
     elif status_code == OSD_STATUS_OUT_DOWN:
@@ -3957,6 +3959,11 @@ def make_deactivate_parser(subparsers):
         '--osd-id',
         metavar='OSDID',
         help='ID of OSD to deactivate'
+        )
+    deactivate_parser.add_argument(
+        '--mark-out',
+        action='store_true', default=False,
+        help='option to mark this osd out',
         )
     deactivate_parser.set_defaults(
         func=main_deactivate,

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -51,12 +51,21 @@ Activate:
  - if encrypted, map the dmcrypt volume
  - mount the volume in a temp location
  - allocate an osd id (if needed)
+ - if deactived, change the gpt partition info correctly
  - remount in the correct location /var/lib/ceph/osd/$cluster-$id
+ - remove the deactive flag
  - start ceph-osd
 
  - triggered by udev when it sees the OSD gpt partition type
  - triggered by admin 'ceph-disk activate <path>'
  - triggered on ceph service startup with 'ceph-disk activate-all'
+
+Deactivate:
+ - stop ceph-osd service if needed (If osd still in osd map, make it out first)
+ - remove 'ready', 'active', and INIT-specific files
+ - remove gpt partition type and change partition name (prevent triggered by udev)
+ - create deactive flag
+ - umount device and remove mount point
 
 We rely on /dev/disk/by-partuuid to find partitions by their UUID;
 this is what the journal symlink inside the osd data volume normally
@@ -80,6 +89,7 @@ knew the GPT partition type.
 
 CEPH_OSD_ONDISK_MAGIC = 'ceph osd volume v026'
 
+LINUX_RESERVED_TYPE =       '8da63339-0007-60c0-c436-083ac8230908'
 JOURNAL_UUID =              '45b0969e-9b03-4f30-b4c6-b4b80ceff106'
 MPATH_JOURNAL_UUID =        '45b0969e-8ae0-4982-bf9d-5a8d867af560'
 DMCRYPT_JOURNAL_UUID =      '45b0969e-9b03-4f30-b4c6-5ec00ceff106'
@@ -95,6 +105,14 @@ DMCRYPT_JOURNAL_TOBE_UUID = '89c57f98-2fe5-4dc0-89c1-35865ceff2be'
 
 DEFAULT_FS_TYPE = 'xfs'
 SYSFS = '/sys'
+
+"""
+OSD STATUS Definition
+"""
+OSD_STATUS_OUT_DOWN = 	0
+OSD_STATUS_OUT_UP = 	1
+OSD_STATUS_IN_DOWN =	2
+OSD_STATUS_IN_UP =	3
 
 MOUNT_OPTIONS = dict(
     btrfs='noatime,user_subvol_rm_allowed',
@@ -790,6 +808,27 @@ def check_osd_magic(path):
         raise BadMagicError(path)
     if magic != CEPH_OSD_ONDISK_MAGIC:
         raise BadMagicError(path)
+
+
+def convert_osd_id(cluster, osd_id):
+    """
+    Convert the OSD id to OS device (ex. sdx)
+    """
+    mountsp_name = '%s-%s' % (cluster, osd_id)
+
+    # mount_info's first fields means `device`, Second means `mount point`
+    mount_info = []
+    with file('/proc/mounts', 'rb') as proc_mounts:
+        for line in proc_mounts:
+            if mountsp_name in line:
+                fields = line.split()
+                mount_info.append(fields[0])
+                mount_info.append(fields[1])
+            else:
+                continue
+    if not mount_info:
+        raise Error('Can not find mount point by osd-id')
+    return mount_info
 
 
 def check_osd_id(osd_id):
@@ -2108,6 +2147,66 @@ def start_daemon(
         raise Error('ceph osd start failed', e)
 
 
+def stop_daemon(
+    cluster,
+    osd_id,
+    ):
+    LOG.debug('Stoping %s osd.%s...', cluster, osd_id)
+
+    path = (STATEDIR + '/osd/{cluster}-{osd_id}').format(
+        cluster=cluster, osd_id=osd_id)
+
+    # upstart?
+    try:
+        if os.path.exists(os.path.join(path,'upstart')):
+            command_check_call(
+                [
+                    '/sbin/initctl',
+                    'stop',
+                    # I remove --no-wait parameter because we must guarantee
+                    # this service stop.
+                    'ceph-osd',
+                    'cluster={cluster}'.format(cluster=cluster),
+                    'id={osd_id}'.format(osd_id=osd_id),
+                    ],
+                )
+        elif os.path.exists(os.path.join(path, 'sysvinit')):
+            if os.path.exists('/usr/sbin/service'):
+                svc = '/usr/sbin/service'
+            else:
+                svc = '/sbin/service'
+            command_check_call(
+                [
+                    svc,
+                    'ceph',
+                    '--cluster',
+                    '{cluster}'.format(cluster=cluster),
+                    'stop',
+                    'osd.{osd_id}'.format(osd_id=osd_id),
+                    ],
+                )
+        elif os.path.exists(os.path.join(path, 'systemd')):
+            command_check_call(
+                [
+                    'systemctl',
+                    'disable',
+                    'ceph-osd@{osd_id}'.format(osd_id=osd_id),
+                    ],
+                )
+            command_check_call(
+                [
+                    'systemctl',
+                    'stop',
+                    'ceph-osd@{osd_id}'.format(osd_id=osd_id),
+                    ],
+                )
+        else:
+            raise Error('{cluster} osd.{osd_id} is not tagged with an init '\
+                        ' system'.format(cluster=cluster,osd_id=osd_id,))
+    except:
+        raise Error('ceph osd stop failed')
+
+
 def detect_fstype(
     dev,
     ):
@@ -2191,10 +2290,59 @@ def mount_activate(
 
     path = mount(dev=dev, fstype=fstype, options=mount_options)
 
+    # check if the disk is deactive, change the journal owner, group
+    # mode for correct user and group.
+    if os.path.exists(os.path.join(path, 'deactive')):
+        # flag to activate a deactive osd.
+        deactive = True
+        journal_dev = os.path.realpath(os.path.join(path,'journal'))
+        try:
+            if get_ceph_user() == 'ceph':
+                command(
+                    [
+                    'chown', '-R', 'ceph:ceph',
+                    journal_dev,
+                    ],
+                )
+                command(
+                    [
+                    'chmod', '660',
+                    journal_dev,
+                    ]
+                )
+        except OSError:
+            pass
+    else:
+        deactive = False
+
     osd_id = None
     cluster = None
     try:
         (osd_id, cluster) = activate(path, activate_key_template, init)
+
+        # Now active successfully
+        # change the gpt partition type for bootup (meet the udev rules)
+        if deactive:
+            # Change OSD gpt partition type
+            if is_mpath(dev):
+                type_code = MPATH_OSD_UUID
+            else:
+                type_code = OSD_UUID
+            _change_gpt_partition_info(dev, type_code)
+
+            # Change Journal gpt partition type
+            if is_mpath(journal_dev):
+                type_code = MPATH_JOURNAL_UUID
+            else:
+                type_code = JOURNAL_UUID
+            _change_gpt_partition_info(journal_dev, type_code)
+
+            # Remove the deactive flag
+            try:
+                os.remove(os.path.join(path, 'deactive'))
+                LOG.info('Remove `deactive` file.')
+            except OSError:
+                pass
 
         # check if the disk is already active, or if something else is already
         # mounted there
@@ -2461,6 +2609,176 @@ def main_activate(args):
 
 ###########################
 
+def _mark_osd_out(cluster, osd_id):
+    LOG.info('Prepare to mark osd.%s out...', osd_id)
+    try:
+        out, ret = command(
+                [
+                    'ceph',
+                    'osd',
+                    'out',
+                    'osd.%s' % osd_id,
+                    ],
+                )
+    except:
+        raise Error('Could not find osd.%s, is a vaild/exist osd id?' % osd_id)
+
+
+def _check_osd_status(cluster, osd_id):
+    """
+    report the osd status:
+    00(0) : means OSD OUT AND DOWN
+    01(1) : means OSD OUT AND UP
+    10(2) : means OSD IN AND DOWN
+    11(3) : means OSD IN AND UP
+    """
+    LOG.info("Checking osd id: %s ..." % osd_id)
+    status_code = 0
+    try:
+        out, ret = command(
+                [
+                    'ceph',
+                    'osd',
+                    'find',
+                    osd_id,
+                    '--cluster={cluster}'.format(
+                        cluster=cluster,
+                        ),
+                    '--format',
+                    'json',
+                    ],
+                )
+    except subprocess.CalledProcessError as e:
+        raise Error(e)
+    out_json = json.loads(out)
+    if out_json['status IN/OUT'] == u'IN':
+        status_code += 2
+    if out_json['status UP/DOWN'] == u'UP':
+        status_code += 1
+    return status_code
+
+
+def _remove_osd_directory_files(mounted_path, cluster):
+    """
+    To remove the 'ready', 'active', INIT-specific files.
+    """
+    if os.path.exists(os.path.join(mounted_path, 'ready')):
+        try:
+            os.remove(os.path.join(mounted_path, 'ready'))
+            LOG.info('Remove `ready` file.')
+        except OSError:
+            pass
+    else:
+        LOG.info('`ready` file is already removed.')
+
+    if os.path.exists(os.path.join(mounted_path, 'active')):
+        try:
+            os.remove(os.path.join(mounted_path, 'active'))
+            LOG.info('Remove `active` file.')
+        except OSError:
+            pass
+    else:
+        LOG.info('`active` file is already removed.')
+
+    # Just check `upstart` and `sysvinit` directly if filename is init-spec.
+    conf_val = get_conf(
+        cluster=cluster,
+        variable='init'
+        )
+    if conf_val is not None:
+        init = conf_val
+    else:
+        init = init_get()
+    try:
+        os.remove(os.path.join(mounted_path, init))
+        LOG.info('Remove `%s` file.', init)
+        return
+    except OSError:
+        pass
+
+
+def _change_gpt_partition_info(device_part, type_code=LINUX_RESERVED_TYPE):
+    """
+    Due to udev rule 95-ceph-osd.rules, we need to remove the
+    gpt partition type to prevent trigger ceph-disk-activate.
+
+    Also change partition name for zap in destroy stage
+    """
+
+    (device, part_num) = split_dev_base_partnum(device_part)
+
+    part_name = get_partition_name(device_part)
+
+    if type_code is LINUX_RESERVED_TYPE:
+        part_name = part_name + ' (deactive)'
+
+    if type_code is MPATH_JOURNAL_UUID or type_code is JOURNAL_UUID or \
+       type_code is MPATH_OSD_UUID or type_code is OSD_UUID:
+        part_name = part_name.replace(" (deactive)", "")
+
+    try:
+        command_check_call(
+                    [
+                        'sgdisk',
+                        '--change-name=%s:%s' % (part_num, part_name),
+                        '--typecode=%s:%s' % (part_num, type_code),
+                        '--',
+                        device,
+                    ],
+                )
+    except subprocess.CalledProcessError as e:
+        raise Error(e)
+
+
+def main_deactivate(args):
+    if args.cluster is None:
+        args.cluster = 'ceph'
+    if args.osd_id is None:
+        raise Error("osd id can not be zero. Try to use --osd-id <OSDID>.")
+    # Do not do anything if osd is already down.
+    status_code = _check_osd_status(args.cluster, args.osd_id)
+    if status_code == OSD_STATUS_IN_UP:
+        _mark_osd_out(args.cluster, args.osd_id)
+        stop_daemon(args.cluster, args.osd_id)
+    elif status_code == OSD_STATUS_IN_DOWN:
+        _mark_osd_out(args.cluster, args.osd_id)
+    elif status_code == OSD_STATUS_OUT_UP:
+        stop_daemon(args.cluster, args.osd_id)
+    elif status_code == OSD_STATUS_OUT_DOWN:
+        LOG.info("OSD already out/down. Do not do anything now.")
+        return
+
+    # GET the mounted device and mount point.
+    mount_info = convert_osd_id(args.cluster, args.osd_id)
+
+    # remove 'ready', 'active', and INIT-specific files.
+    _remove_osd_directory_files(mount_info[1], args.cluster)
+
+    # Remove filesystem gpt partition type
+    _change_gpt_partition_info(mount_info[0], LINUX_RESERVED_TYPE)
+
+    # Check journal
+    # if journal is exist, remove the gpt partition type
+    journal_path = os.path.join(mount_info[1], 'journal')
+    if os.path.exists(journal_path) and os.path.islink(journal_path):
+        _change_gpt_partition_info(os.path.realpath(journal_path), \
+                                   LINUX_RESERVED_TYPE)
+    else:
+        LOG.info('Journal is not exist on osd.%s (or not symlink).', \
+                 args.osd_id)
+
+    # Write deactivate to osd directory!
+    with file(os.path.join(mount_info[1], 'deactive'), 'w'):
+        path_set_context(os.path.join(mount_info[1], 'deactive'))
+        pass
+
+    unmount(mount_info[1])
+    LOG.info("Umount `%s` successfully.", mount_info[1])
+
+    return
+
+###########################
+
 def get_journal_osd_uuid(path):
     if not os.path.exists(path):
         raise Error('%s does not exist' % path)
@@ -2671,6 +2989,10 @@ def get_partition_type(part):
 
 def get_partition_uuid(part):
     return get_sgdisk_partition_info(part, 'Partition unique GUID: (\S+)')
+
+def get_partition_name(part):
+    regexp = "Partition name: \'*([A-Za-z ]+[ ()A-Za-z]*)\'*"
+    return get_sgdisk_partition_info(part, regexp)
 
 def get_sgdisk_partition_info(dev, regexp):
     (base, partnum) = split_dev_base_partnum(dev)
@@ -3252,6 +3574,7 @@ def parse_args(argv):
     make_activate_all_parser(subparsers)
     make_list_parser(subparsers)
     make_suppress_parser(subparsers)
+    make_deactivate_parser(subparsers)
     make_zap_parser(subparsers)
     make_trigger_parser(subparsers)
 
@@ -3502,6 +3825,23 @@ def make_suppress_parser(subparsers):
         func=main_unsuppress,
         )
     return suppress_parser
+
+def make_deactivate_parser(subparsers):
+    deactivate_parser = subparsers.add_parser('deactivate', help='Deactivate a Ceph OSD')
+    deactivate_parser.add_argument(
+        '--cluster',
+        metavar='NAME',
+        default='ceph',
+        help='cluster name to assign this disk to',
+        )
+    deactivate_parser.add_argument(
+        '--osd-id',
+        metavar='OSDID',
+        help='ID of OSD to deactivate'
+        )
+    deactivate_parser.set_defaults(
+        func=main_deactivate,
+        )
 
 def make_zap_parser(subparsers):
     zap_parser = subparsers.add_parser('zap', help='Zap/erase/destroy a device\'s partition table (and contents)')

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -2645,8 +2645,7 @@ def _check_osd_status(cluster, osd_id):
                 [
                     'ceph',
                     'osd',
-                    'find',
-                    osd_id,
+                    'dump',
                     '--cluster={cluster}'.format(
                         cluster=cluster,
                         ),
@@ -2657,9 +2656,9 @@ def _check_osd_status(cluster, osd_id):
     except subprocess.CalledProcessError as e:
         raise Error(e)
     out_json = json.loads(out)
-    if out_json['status IN/OUT'] == u'IN':
+    if out_json[u'osds'][int(osd_id)][u'in'] is 1:
         status_code += 2
-    if out_json['status UP/DOWN'] == u'UP':
+    if out_json[u'osds'][int(osd_id)][u'up'] is 1:
         status_code += 1
     return status_code
 

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -35,7 +35,6 @@ import time
 import shlex
 import pwd
 import grp
-import syslog
 
 """
 Prepare:
@@ -67,13 +66,14 @@ Deactivate:
  - remove 'ready', 'active', and INIT-specific files
  - create deactive flag
  - umount device and remove mount point
+ - if the partition type is dmcrypt, remove the data dmcrypt map.
 
 Destroy:
  - check partition type (support dmcrypt, mpath, normal)
  - remove OSD from CRUSH map
  - remove OSD cephx key
  - deallocate OSD ID
- - if the partition type is dmcrypt, remove the dmcrypt map.
+ - if the partition type is dmcrypt, remove the journal dmcrypt map.
  - destroy data (with --zap option)
 
 We rely on /dev/disk/by-partuuid to find partitions by their UUID;
@@ -818,29 +818,6 @@ def check_osd_magic(path):
         raise BadMagicError(path)
 
 
-def convert_osd_id(cluster, osd_id):
-    """
-    Convert the OSD id to OS device (ex. sdx)
-    """
-    mountsp_name = '%s-%s' % (cluster, osd_id)
-
-    # mount_info's first fields means `device`, Second means `mount point`
-    mount_info = []
-    try:
-        proc_mounts = open('/proc/mounts', 'rb')
-        if proc_mounts:
-            for line in proc_mounts:
-                if mountsp_name in line:
-                    fields = line.split()
-                    mount_info.append(fields[0])
-                    mount_info.append(fields[1])
-    except:
-        raise Error('Open/Read file Error.')
-    if not mount_info:
-        raise Error('Can not find mount point by osd-id')
-    return mount_info
-
-
 def check_osd_id(osd_id):
     """
     Ensures osd id is numeric.
@@ -878,31 +855,6 @@ def allocate_osd_id(
     osd_id = must_be_one_line(osd_id)
     check_osd_id(osd_id)
     return osd_id
-
-
-def get_osd_id_journal_dm(dev, dmcrypt=False):
-    """
-    Try to mount to tmp.directory and get osd_id.
-
-    :return: osd_id/-1
-    """
-    dm_journal = ''
-    osd_id = -1
-    try:
-        fs_type = get_dev_fs(dev)
-        if fs_type != None:
-            tpath = mount(dev=dev, fstype=fs_type, options='')
-            if tpath:
-                try:
-                    journal_path_dm = os.path.join(tpath, 'journal_dmcrypt')
-                    if dmcrypt and os.path.islink(journal_path_dm):
-                        dm_journal = os.path.realpath(journal_path_dm)
-                    osd_id = get_osd_id(tpath)
-                finally:
-                    unmount(tpath)
-        return osd_id, dm_journal
-    except:
-        raise MountError
 
 
 def get_osd_id(path):
@@ -1026,28 +978,6 @@ def get_fsid(cluster):
     if fsid is None:
         raise Error('getting cluster uuid from configuration failed')
     return fsid.lower()
-
-
-def get_dmcrypt_status(_uuid):
-    """
-    Get status on dm-crypt device.
-
-    :return: the dm-crypt device status, True: active, False: inactive
-    """
-    try:
-        out, ret = command(
-                [
-                    '/sbin/cryptsetup',
-                    'status',
-                    _uuid,
-                    ],
-                )
-    except:
-        raise Error('Get dmcrypt status fail!')
-    if 'inactive' in out:
-        return False
-    else:
-        return True
 
 
 def get_dmcrypt_key_path(
@@ -2220,18 +2150,13 @@ def stop_daemon(
                 [
                     '/sbin/initctl',
                     'stop',
-                    # I remove --no-wait parameter because we must guarantee
-                    # this service stop.
                     'ceph-osd',
                     'cluster={cluster}'.format(cluster=cluster),
                     'id={osd_id}'.format(osd_id=osd_id),
                     ],
                 )
         elif os.path.exists(os.path.join(path, 'sysvinit')):
-            if os.path.exists('/usr/sbin/service'):
-                svc = '/usr/sbin/service'
-            else:
-                svc = '/sbin/service'
+            svc = which('service')
             command_check_call(
                 [
                     svc,
@@ -2273,7 +2198,7 @@ def detect_fstype(
             # we don't want stale cached results
             '-p',
             '-s', 'TYPE',
-            '-o' 'value',
+            '-o', 'value',
             '--',
             dev,
             ],
@@ -2292,33 +2217,28 @@ def mount_activate(
     ):
 
     if dmcrypt:
-        # dev corresponds to a dmcrypt cyphertext device - map it before
-        # proceeding.
-        rawdev = dev
-        ptype = get_partition_type(rawdev)
-        if ptype in [DMCRYPT_OSD_UUID]:
-            luks = False
-            cryptsetup_parameters = ['--key-size', '256']
-        elif ptype in [DMCRYPT_LUKS_OSD_UUID]:
-            luks = True
-            cryptsetup_parameters = []
-        else:
-            raise Error('activate --dmcrypt called for invalid dev %s' % (dev))
-        part_uuid = get_partition_uuid(rawdev)
-        dmcrypt_key_path = get_dmcrypt_key_path(part_uuid, dmcrypt_key_dir, luks)
-        # if osd is deactive, we do not remove dmcrypt map.
-        # return the dm path and do not map when the osd is still mapped (avoid fail).
-        if not get_dmcrypt_status(part_uuid):
+            # dev corresponds to a dmcrypt cyphertext device - map it before
+            # proceeding.
+            rawdev = dev
+            ptype = get_partition_type(rawdev)
+            if ptype in [DMCRYPT_OSD_UUID]:
+                luks = False
+                cryptsetup_parameters = ['--key-size', '256']
+            elif ptype in [DMCRYPT_LUKS_OSD_UUID]:
+                luks = True
+                cryptsetup_parameters = []
+            else:
+                raise Error('activate --dmcrypt called for invalid dev %s' % (dev))
+            part_uuid = get_partition_uuid(rawdev)
+            dmcrypt_key_path = get_dmcrypt_key_path(part_uuid, dmcrypt_key_dir, luks)
             dev = dmcrypt_map(
-                rawdev=rawdev,
-                keypath=dmcrypt_key_path,
-                _uuid=part_uuid,
-                cryptsetup_parameters=cryptsetup_parameters,
-                luks=luks,
-                format_dev=False,
-                )
-        else:
-            dev = '/dev/mapper/' + part_uuid
+                    rawdev=rawdev,
+                    keypath=dmcrypt_key_path,
+                    _uuid=part_uuid,
+                    cryptsetup_parameters=cryptsetup_parameters,
+                    luks=luks,
+                    format_dev=False,
+                    )
 
     try:
         fstype = detect_fstype(dev=dev)
@@ -2359,44 +2279,17 @@ def mount_activate(
         # logging to syslog will help us easy to know udev triggered failure
         if not reactivate:
             unmount(path)
-            syslog.syslog(syslog.LOG_ERR, 'OSD deactivated! reactivate with: --reactivate')
+            # we need to unmap again because dmcrypt map will create again
+            # on bootup stage (due to deactivate)
+            if '/dev/mapper/' in dev:
+                part_uuid = dev.replace('/dev/mapper/', '')
+                dmcrypt_unmap(part_uuid)
+            LOG.info('OSD deactivated! reactivate with: --reactivate')
             raise Error('OSD deactivated! reactivate with: --reactivate')
         # flag to activate a deactive osd.
         deactive = True
     else:
         deactive = False
-
-    journal_dev = os.path.realpath(os.path.join(path,'journal'))
-    try:
-        if get_ceph_user() == 'ceph':
-            command(
-                [
-                'chown', '-R', 'ceph:ceph',
-                journal_dev,
-                ],
-            )
-            command(
-                [
-                'chmod', '660',
-                journal_dev,
-                ]
-            )
-        if dmcrypt:
-            journal_dev_dmcrypt = os.path.realpath(os.path.join(path,'journal_dmcrypt'))
-            command(
-                [
-                'chown', '-R', 'ceph:ceph',
-                journal_dev_dmcrypt,
-                ],
-            )
-            command(
-                [
-                'chmod', '660',
-                journal_dev_dmcrypt,
-                ]
-            )
-    except OSError:
-        pass
 
     osd_id = None
     cluster = None
@@ -2410,7 +2303,7 @@ def mount_activate(
                 os.remove(os.path.join(path, 'deactive'))
                 LOG.info('Remove `deactive` file.')
             except OSError:
-                pass
+                raise Error('Cannot remove `deactive` file!')
 
         # check if the disk is already active, or if something else is already
         # mounted there
@@ -2679,14 +2572,14 @@ def main_activate(args):
 ###########################
 
 def _mark_osd_out(cluster, osd_id):
-    LOG.info('Prepare to mark osd.%s out...', osd_id)
+    LOG.info('Prepare to mark osd.%d out...', osd_id)
     try:
         out, ret = command(
                 [
                     'ceph',
                     'osd',
                     'out',
-                    'osd.%s' % osd_id,
+                    'osd.%d' % osd_id,
                     ],
                 )
     except:
@@ -2704,21 +2597,18 @@ def _check_osd_status(cluster, osd_id):
     LOG.info("Checking osd id: %s ..." % osd_id)
     found = False
     status_code = 0
-    try:
-        out, ret = command(
-                [
-                    'ceph',
-                    'osd',
-                    'dump',
-                    '--cluster={cluster}'.format(
-                        cluster=cluster,
-                        ),
-                    '--format',
-                    'json',
-                    ],
-                )
-    except subprocess.CalledProcessError as e:
-        raise Error(e)
+    out, ret = command(
+            [
+                'ceph',
+                'osd',
+                'dump',
+                '--cluster={cluster}'.format(
+                    cluster=cluster,
+                    ),
+                '--format',
+                'json',
+                ],
+            )
     out_json = json.loads(out)
     for item in out_json[u'osds']:
         if item.get(u'osd') == int(osd_id):
@@ -2741,7 +2631,7 @@ def _remove_osd_directory_files(mounted_path, cluster):
             os.remove(os.path.join(mounted_path, 'ready'))
             LOG.info('Remove `ready` file.')
         except OSError:
-            pass
+            raise Error('Could not remove `ready` file!')
     else:
         LOG.info('`ready` file is already removed.')
 
@@ -2750,7 +2640,7 @@ def _remove_osd_directory_files(mounted_path, cluster):
             os.remove(os.path.join(mounted_path, 'active'))
             LOG.info('Remove `active` file.')
         except OSError:
-            pass
+            raise Error('Could not remove `active` file!')
     else:
         LOG.info('`active` file is already removed.')
 
@@ -2768,42 +2658,49 @@ def _remove_osd_directory_files(mounted_path, cluster):
         LOG.info('Remove `%s` file.', init)
         return
     except OSError:
-        pass
+        raise Error('Could not remove %s (init) file!' % init)
 
 
 def main_deactivate(args):
-    mount_info = []
-    if args.deactivate_by_id:
-        osd_id = args.deactivate_by_id
-    else:
-       if not os.path.exists(args.path):
-           raise Error('%s does not exist' % args.path)
-       else:
-           # check dmcrypt first.
-           part_type = get_partition_type(args.path)
-           if part_type == DMCRYPT_OSD_UUID or \
-              part_type == DMCRYPT_LUKS_OSD_UUID:
-              part_uuid = get_partition_uuid(args.path)
-              dev_path = '/dev/mapper/' + part_uuid
-           else:
-               # other cases will return args.path
-               dev_path = args.path
-           mounted_path = is_mounted(dev_path)
-           if mounted_path is None:
-               raise Error('%s is not mounted' % dev_path)
-           osd_id = get_osd_id(mounted_path)
-           mount_info.append(dev_path)
-           mount_info.append(mounted_path)
+    osd_id = args.deactivate_by_id
+    path = args.path
+    target_dev = None
+    dmcrypt = False
+    devices = list_devices([])
+
+    # list all devices and found we need
+    for device in devices:
+        if 'partitions' in device:
+            for dev_part in device.get('partitions'):
+                if osd_id and \
+                   'whoami' in dev_part and \
+                   dev_part['whoami'] == osd_id:
+                    target_dev = dev_part
+                elif path and \
+                   'path' in dev_part and \
+                   dev_part['path'] == path:
+                    target_dev = dev_part
+    if not target_dev:
+        raise Error('Cannot find any match device!!')
+
+    # set up all we need variable
+    osd_id = target_dev['whoami']
+    part_type = target_dev['ptype']
+    mounted_path = target_dev['mount']
+    part_uuid = target_dev['uuid']
+    if part_type == DMCRYPT_OSD_UUID or \
+       part_type == DMCRYPT_LUKS_OSD_UUID:
+        dmcrypt = True
 
     # Do not do anything if osd is already down.
     status_code = _check_osd_status(args.cluster, osd_id)
     if status_code == OSD_STATUS_IN_UP:
         if args.mark_out is True:
-            _mark_osd_out(args.cluster, osd_id)
+            _mark_osd_out(args.cluster, int(osd_id))
         stop_daemon(args.cluster, osd_id)
     elif status_code == OSD_STATUS_IN_DOWN:
         if args.mark_out is True:
-            _mark_osd_out(args.cluster, osd_id)
+            _mark_osd_out(args.cluster, int(osd_id))
         LOG.info("OSD already out/down. Do not do anything now.")
         return
     elif status_code == OSD_STATUS_OUT_UP:
@@ -2812,21 +2709,19 @@ def main_deactivate(args):
         LOG.info("OSD already out/down. Do not do anything now.")
         return
 
-    # GET the mounted device and mount point.
-    # If we already get mount_info (with specific parameter), pass this stage
-    if not mount_info:
-        mount_info = convert_osd_id(args.cluster, osd_id)
-
     # remove 'ready', 'active', and INIT-specific files.
-    _remove_osd_directory_files(mount_info[1], args.cluster)
+    _remove_osd_directory_files(mounted_path, args.cluster)
 
     # Write deactivate to osd directory!
-    with file(os.path.join(mount_info[1], 'deactive'), 'w'):
-        path_set_context(os.path.join(mount_info[1], 'deactive'))
-        pass
+    with open(os.path.join(mounted_path, 'deactive'), 'w'):
+        path_set_context(os.path.join(mounted_path, 'deactive'))
 
-    unmount(mount_info[1])
-    LOG.info("Umount `%s` successfully.", mount_info[1])
+    unmount(mounted_path)
+    LOG.info("Umount `%s` successfully.", mounted_path)
+
+    # we remove the crypt map and device mapper (if dmcrypt is True)
+    if dmcrypt:
+        dmcrypt_unmap(part_uuid)
 
     return
 
@@ -2876,81 +2771,79 @@ def _deallocate_osd_id(cluster, osd_id):
         raise Error(e)
 
 def main_destroy(args):
+    osd_id = args.destroy_by_id
+    path = args.path
+    dmcrypt_key_dir = args.dmcrypt_key_dir
     dmcrypt = False
-    mount_info = []
-    # get everything we need when we start destroy.
-    if args.destroy_by_id:
-        osd_id = args.destroy_by_id
-        # try to find osd data device.
-        partmap = list_all_partitions(None)
-        # list all partition which have the partition name with
-        # deactive flag
-        devtocheck = []
-        found = False
-        for base, parts in sorted(partmap.iteritems()):
-            if not parts:
-                continue
-            for p in parts:
-                (dev, p_num) = split_dev_base_partnum(os.path.join("/dev", p))
-                LOG.debug("device: %s, p_num: %s" % (dev, p_num))
-                devtocheck.append(os.path.join("/dev", p))
+    target_dev = None
 
-        # check all above device's osd_id
-        # if the osd_id is correct, zap it.
-        for item in devtocheck:
-            try:
-                # one more try to check dmcrypt, or raise mounterror
-                # Do nothing when we get some specific part_type
-                # that because in some situation we can not update
-                # partition table immediately
-                dmcrypt = False
-                part_type = get_partition_type(item)
-                if part_type == DMCRYPT_OSD_UUID or \
-                   part_type == DMCRYPT_LUKS_OSD_UUID:
-                    dmcrypt = True
-                    part_uuid_journal = ''
-                    part_uuid = get_partition_uuid(item)
-                    dev_path = '/dev/mapper/' + part_uuid
-                    whoami, dm_journal = get_osd_id_journal_dm(dev_path, dmcrypt)
-                    part_uuid_journal = get_partition_uuid(dm_journal)
-                elif part_type == OSD_UUID or \
-                     part_type == MPATH_OSD_UUID:
-                    whoami, dm_journal = get_osd_id_journal_dm(item, dmcrypt)
-                else:
+    if path and not is_partition(path):
+        raise Error("It should input the partition dev!!")
+
+    devices = list_devices([])
+    for device in devices:
+        if 'partitions' in device:
+            for dev_part in device.get('partitions'):
+                """
+                re-map the unmapped device for check device information
+                we need more overhead if user pass the osd_id
+
+                the reason is we must re-map the dmcrypt map that we can
+                confirm the osd_id match with whoami
+                """
+                if path and 'path' in dev_part and \
+                   dev_part['path'] != path:
                     continue
-            except:
-                # other cases will return MountError
-                raise MountError
-            # break when we found the target osd_id.
-            # that can avoid handle the redundant checking
-            if whoami == osd_id:
-                found = True
-                (base_dev, part_num) = split_dev_base_partnum(item)
-                break
-        if not found:
-            raise Error('Could not find the partition of osd.%s!' % osd_id)
+                elif osd_id and 'whoami' in dev_part and \
+                     dev_part['whoami'] != osd_id:
+                    continue
+                elif path and dev_part['path'] == path and \
+                   not dev_part['dmcrypt']:
+                    target_dev = dev_part
+                    break
+                elif osd_id and 'whoami' in dev_part and \
+                     dev_part['whoami'] == osd_id and not dev_part['dmcrypt']:
+                    target_dev = dev_part
+                    break
+                elif dev_part['dmcrypt'] and \
+                     not dev_part['dmcrypt']['holders']:
+                    rawdev = dev_part['path']
+                    ptype = dev_part['ptype']
+                    if ptype in [DMCRYPT_OSD_UUID]:
+                        luks = False
+                        cryptsetup_parameters = ['--key-size', '256']
+                    elif ptype in [DMCRYPT_LUKS_OSD_UUID]:
+                        luks = True
+                        cryptsetup_parameters = []
+                    else:
+                        raise Error('Cannot identify the device partiton type!!!')
+                    part_uuid = dev_part['uuid']
+                    dmcrypt_key_path = get_dmcrypt_key_path(part_uuid, dmcrypt_key_dir, luks)
+                    dev_path = dmcrypt_map(
+                            rawdev=rawdev,
+                            keypath=dmcrypt_key_path,
+                            _uuid=part_uuid,
+                            cryptsetup_parameters=cryptsetup_parameters,
+                            luks=luks,
+                            format_dev=False,
+                            )
+                    devices = list_devices([rawdev])
+                    for dev in devices:
+                        if (path and 'path' in dev and dev['path'] == path) or \
+                           (osd_id and 'whoami' in dev and dev['whoami'] == osd_id):
+                            dmcrypt = True
+                            target_dev = dev
+                            break
+                    dmcrypt_unmap(part_uuid)
+    if not target_dev:
+        raise Error('Cannot find any match device!!')
+    osd_id = target_dev['whoami']
+    dev_path = target_dev['path']
+    journal_part_uuid = target_dev['journal_uuid']
+    if target_dev['ptype'] == MPATH_OSD_UUID:
+        base_dev = get_partition_base_mpath(dev_path)
     else:
-       if not os.path.exists(args.path):
-           raise Error('%s does not exist' % args.path)
-       else:
-           # check dmcrypt first.
-           part_type = get_partition_type(args.path)
-           if part_type == DMCRYPT_OSD_UUID or \
-              part_type == DMCRYPT_LUKS_OSD_UUID:
-              dmcrypt = True
-              part_uuid_journal = ''
-              part_uuid = get_partition_uuid(args.path)
-              dev_path = '/dev/mapper/' + part_uuid
-           else:
-               # other cases will return args.path
-               dev_path = args.path
-           # mount point is removed, try to mount to tmp.folder
-           osd_id, dm_journal = get_osd_id_journal_dm(dev_path, dmcrypt)
-           if dm_journal:
-               part_uuid_journal = get_partition_uuid(dm_journal)
-           base_dev = get_partition_base(args.path)
-           mount_info.append(args.path)
-
+        base_dev = get_partition_base(dev_path)
 
     # Before osd deactivate, we cannot destroy it
     status_code = _check_osd_status(args.cluster, osd_id)
@@ -2970,12 +2863,8 @@ def main_destroy(args):
 
     # we remove the crypt map and device mapper (if dmcrypt is True)
     if dmcrypt:
-        dmcrypt_unmap(part_uuid)
-        if part_uuid_journal:
-            try:
-                dmcrypt_unmap(part_uuid_journal)
-            except:
-                pass
+        if journal_part_uuid:
+            dmcrypt_unmap(journal_part_uuid)
 
     # Check zap flag. If we found zap flag, we need to find device for
     # destroy this osd data.
@@ -4083,6 +3972,12 @@ def make_destroy_parser(subparsers):
         '--destroy-by-id',
         metavar='<id>',
         help='ID of OSD to destroy'
+        )
+    destroy_parser.add_argument(
+        '--dmcrypt-key-dir',
+        metavar='KEYDIR',
+        default='/etc/ceph/dmcrypt-keys',
+        help='directory where dm-crypt keys are stored (If you don\'t know how it work, dont use it. we have default value)',
         )
     destroy_parser.add_argument(
         '--zap',

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -823,14 +823,16 @@ def convert_osd_id(cluster, osd_id):
 
     # mount_info's first fields means `device`, Second means `mount point`
     mount_info = []
-    with file('/proc/mounts', 'rb') as proc_mounts:
-        for line in proc_mounts:
-            if mountsp_name in line:
-                fields = line.split()
-                mount_info.append(fields[0])
-                mount_info.append(fields[1])
-            else:
-                continue
+    try:
+        proc_mounts = open('/proc/mounts', 'rb')
+        if proc_mounts:
+            for line in proc_mounts:
+                if mountsp_name in line:
+                    fields = line.split()
+                    mount_info.append(fields[0])
+                    mount_info.append(fields[1])
+    except:
+        raise Error('Open/Read file Error.')
     if not mount_info:
         raise Error('Can not find mount point by osd-id')
     return mount_info
@@ -2207,9 +2209,9 @@ def stop_daemon(
                 )
         else:
             raise Error('{cluster} osd.{osd_id} is not tagged with an init '\
-                        ' system'.format(cluster=cluster,osd_id=osd_id,))
-    except:
-        raise Error('ceph osd stop failed')
+                        ' system'.format(cluster=cluster,osd_id=osd_id))
+    except subprocess.CalledProcessError as e:
+        raise Error('ceph osd stop failed', e)
 
 
 def detect_fstype(
@@ -2649,7 +2651,7 @@ def _check_osd_status(cluster, osd_id):
         raise Error(e)
     out_json = json.loads(out)
     for item in out_json[u'osds']:
-        if item.get(u'osd') is int(osd_id):
+        if item.get(u'osd') == int(osd_id):
             found = True
             if item.get(u'in') is 1:
                 status_code += 2
@@ -2701,9 +2703,6 @@ def _remove_osd_directory_files(mounted_path, cluster):
 
 def main_deactivate(args):
     mount_info = []
-    if args.cluster is None:
-        args.cluster = 'ceph'
-
     if args.deactivate_by_id:
         osd_id = args.deactivate_by_id
     else:
@@ -2799,9 +2798,6 @@ def _deallocate_osd_id(cluster, osd_id):
 
 def main_destroy(args):
     mount_info = []
-    if args.cluster is None:
-        args.cluster = 'ceph'
-
     if args.destroy_by_id:
         osd_id = args.destroy_by_id
     else:
@@ -2818,8 +2814,8 @@ def main_destroy(args):
                             osd_id = get_oneliner(tpath, 'whoami')
                         finally:
                             unmount(tpath)
-           except MountError:
-               pass
+           except:
+               raise MountError
            mount_info.append(args.path)
 
 
@@ -2877,8 +2873,8 @@ def main_destroy(args):
                     if whoami is osd_id:
                         found = True
                         (base_dev, part_num) = split_dev_base_partnum(item)
-                except MountError:
-                     pass
+                except:
+                    raise MountError
             if not found:
                 raise Error('Could not find the partition of osd.%s!' % osd_id)
 

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -35,6 +35,7 @@ import time
 import shlex
 import pwd
 import grp
+import syslog
 
 """
 Prepare:
@@ -51,9 +52,9 @@ Activate:
  - if encrypted, map the dmcrypt volume
  - mount the volume in a temp location
  - allocate an osd id (if needed)
- - if deactived, change the gpt partition info correctly
+ - if deactived, no-op (to activate with --reactivate flag)
  - remount in the correct location /var/lib/ceph/osd/$cluster-$id
- - remove the deactive flag
+ - remove the deactive flag (with --reactivate flag)
  - start ceph-osd
 
  - triggered by udev when it sees the OSD gpt partition type
@@ -63,7 +64,6 @@ Activate:
 Deactivate:
  - stop ceph-osd service if needed (make osd out with option --mark-out)
  - remove 'ready', 'active', and INIT-specific files
- - remove gpt partition type and change partition name (prevent triggered by udev)
  - create deactive flag
  - umount device and remove mount point
 
@@ -95,7 +95,6 @@ knew the GPT partition type.
 
 CEPH_OSD_ONDISK_MAGIC = 'ceph osd volume v026'
 
-LINUX_RESERVED_TYPE =       '8da63339-0007-60c0-c436-083ac8230908'
 JOURNAL_UUID =              '45b0969e-9b03-4f30-b4c6-b4b80ceff106'
 MPATH_JOURNAL_UUID =        '45b0969e-8ae0-4982-bf9d-5a8d867af560'
 DMCRYPT_JOURNAL_UUID =      '45b0969e-9b03-4f30-b4c6-5ec00ceff106'
@@ -2237,6 +2236,7 @@ def mount_activate(
     init,
     dmcrypt,
     dmcrypt_key_dir,
+    reactivate=False,
     ):
 
     if dmcrypt:
@@ -2299,6 +2299,11 @@ def mount_activate(
     # check if the disk is deactive, change the journal owner, group
     # mode for correct user and group.
     if os.path.exists(os.path.join(path, 'deactive')):
+        # logging to syslog will help us easy to know udev triggered failure
+        if not reactivate:
+            unmount(path)
+            syslog.syslog(syslog.LOG_ERR, 'OSD deactivated! reactivate with: --reactivate')
+            raise Error('OSD deactivated! reactivate with: --reactivate')
         # flag to activate a deactive osd.
         deactive = True
         journal_dev = os.path.realpath(os.path.join(path,'journal'))
@@ -2327,23 +2332,8 @@ def mount_activate(
         (osd_id, cluster) = activate(path, activate_key_template, init)
 
         # Now active successfully
-        # change the gpt partition type for bootup (meet the udev rules)
-        if deactive:
-            # Change OSD gpt partition type
-            if is_mpath(dev):
-                type_code = MPATH_OSD_UUID
-            else:
-                type_code = OSD_UUID
-            _change_gpt_partition_info(dev, type_code)
-
-            # Change Journal gpt partition type
-            if is_mpath(journal_dev):
-                type_code = MPATH_JOURNAL_UUID
-            else:
-                type_code = JOURNAL_UUID
-            _change_gpt_partition_info(journal_dev, type_code)
-
-            # Remove the deactive flag
+        # If we got reactivate and deactive, remove the deactive file
+        if deactive and reactivate:
             try:
                 os.remove(os.path.join(path, 'deactive'))
                 LOG.info('Remove `deactive` file.')
@@ -2576,6 +2566,7 @@ def main_activate(args):
                 init=args.mark_init,
                 dmcrypt=args.dmcrypt,
                 dmcrypt_key_dir=args.dmcrypt_key_dir,
+                reactivate=args.reactivate,
                 )
             osd_data = get_mount_point(cluster, osd_id)
 
@@ -2639,6 +2630,7 @@ def _check_osd_status(cluster, osd_id):
     11(3) : means OSD IN AND UP
     """
     LOG.info("Checking osd id: %s ..." % osd_id)
+    found = False
     status_code = 0
     try:
         out, ret = command(
@@ -2656,10 +2648,15 @@ def _check_osd_status(cluster, osd_id):
     except subprocess.CalledProcessError as e:
         raise Error(e)
     out_json = json.loads(out)
-    if out_json[u'osds'][int(osd_id)][u'in'] is 1:
-        status_code += 2
-    if out_json[u'osds'][int(osd_id)][u'up'] is 1:
-        status_code += 1
+    for item in out_json[u'osds']:
+        if item.get(u'osd') is int(osd_id):
+            found = True
+            if item.get(u'in') is 1:
+                status_code += 2
+            if item.get(u'up') is 1:
+                status_code += 1
+    if not found:
+        raise Error('Could not osd.%s in osd tree!' % osd_id)
     return status_code
 
 
@@ -2702,77 +2699,48 @@ def _remove_osd_directory_files(mounted_path, cluster):
         pass
 
 
-def _change_gpt_partition_info(device_part, type_code=LINUX_RESERVED_TYPE):
-    """
-    Due to udev rule 95-ceph-osd.rules, we need to remove the
-    gpt partition type to prevent trigger ceph-disk-activate.
-
-    Also change partition name for zap in destroy stage
-    """
-
-    (device, part_num) = split_dev_base_partnum(device_part)
-
-    part_name = get_partition_name(device_part)
-
-    if type_code is LINUX_RESERVED_TYPE:
-        part_name = part_name + ' (deactive)'
-
-    if type_code is MPATH_JOURNAL_UUID or type_code is JOURNAL_UUID or \
-       type_code is MPATH_OSD_UUID or type_code is OSD_UUID:
-        part_name = part_name.replace(" (deactive)", "")
-
-    try:
-        command_check_call(
-                    [
-                        'sgdisk',
-                        '--change-name=%s:%s' % (part_num, part_name),
-                        '--typecode=%s:%s' % (part_num, type_code),
-                        '--',
-                        device,
-                    ],
-                )
-    except subprocess.CalledProcessError as e:
-        raise Error(e)
-
-
 def main_deactivate(args):
+    mount_info = []
     if args.cluster is None:
         args.cluster = 'ceph'
-    if args.osd_id is None:
-        raise Error("osd id can not be zero. Try to use --osd-id <OSDID>.")
+
+    if args.deactivate_by_id:
+        osd_id = args.deactivate_by_id
+    else:
+       if not os.path.exists(args.path):
+           raise Error('%s does not exist' % args.path)
+       else:
+           mounted_path = is_mounted(args.path)
+           if mounted_path is None:
+               raise Error('%s is not mounted' % args.path)
+           osd_id = get_oneliner(mounted_path, 'whoami')
+           mount_info.append(args.path)
+           mount_info.append(mounted_path)
+
     # Do not do anything if osd is already down.
-    status_code = _check_osd_status(args.cluster, args.osd_id)
+    status_code = _check_osd_status(args.cluster, osd_id)
     if status_code == OSD_STATUS_IN_UP:
         if args.mark_out is True:
-            _mark_osd_out(args.cluster, args.osd_id)
-        stop_daemon(args.cluster, args.osd_id)
+            _mark_osd_out(args.cluster, osd_id)
+        stop_daemon(args.cluster, osd_id)
     elif status_code == OSD_STATUS_IN_DOWN:
         if args.mark_out is True:
-            _mark_osd_out(args.cluster, args.osd_id)
+            _mark_osd_out(args.cluster, osd_id)
+        LOG.info("OSD already out/down. Do not do anything now.")
+        return
     elif status_code == OSD_STATUS_OUT_UP:
-        stop_daemon(args.cluster, args.osd_id)
+        stop_daemon(args.cluster, osd_id)
     elif status_code == OSD_STATUS_OUT_DOWN:
         LOG.info("OSD already out/down. Do not do anything now.")
         return
 
     # GET the mounted device and mount point.
-    mount_info = convert_osd_id(args.cluster, args.osd_id)
+    # If we already get mount_info (with specific parameter), pass this stage
+    if not mount_info:
+        mount_info = convert_osd_id(args.cluster, osd_id)
 
     # remove 'ready', 'active', and INIT-specific files.
     _remove_osd_directory_files(mount_info[1], args.cluster)
-
-    # Remove filesystem gpt partition type
-    _change_gpt_partition_info(mount_info[0], LINUX_RESERVED_TYPE)
-
-    # Check journal
-    # if journal is exist, remove the gpt partition type
-    journal_path = os.path.join(mount_info[1], 'journal')
-    if os.path.exists(journal_path) and os.path.islink(journal_path):
-        _change_gpt_partition_info(os.path.realpath(journal_path), \
-                                   LINUX_RESERVED_TYPE)
-    else:
-        LOG.info('Journal is not exist on osd.%s (or not symlink).', \
-                 args.osd_id)
 
     # Write deactivate to osd directory!
     with file(os.path.join(mount_info[1], 'deactive'), 'w'):
@@ -2830,70 +2798,93 @@ def _deallocate_osd_id(cluster, osd_id):
         raise Error(e)
 
 def main_destroy(args):
+    mount_info = []
     if args.cluster is None:
         args.cluster = 'ceph'
-    if args.osd_id is None:
-        raise Error("osd id can not be zero. Try to use --osd-id <OSDID>.")
+
+    if args.destroy_by_id:
+        osd_id = args.destroy_by_id
+    else:
+       if not os.path.exists(args.path):
+           raise Error('%s does not exist' % args.path)
+       else:
+           # mount point is removed, try to mount to tmp.folder
+           try:
+                fs_type = get_dev_fs(args.path)
+                if fs_type != None:
+                    tpath = mount(dev=args.path, fstype=fs_type, options='')
+                    if tpath:
+                        try:
+                            osd_id = get_oneliner(tpath, 'whoami')
+                        finally:
+                            unmount(tpath)
+           except MountError:
+               pass
+           mount_info.append(args.path)
+
 
     # Before osd deactivate, we cannot destroy it
-    status_code = _check_osd_status(args.cluster, args.osd_id)
-    if status_code != OSD_STATUS_OUT_DOWN:
+    status_code = _check_osd_status(args.cluster, osd_id)
+    if status_code != OSD_STATUS_OUT_DOWN and \
+       status_code != OSD_STATUS_IN_DOWN:
         raise Error("Could not destroy the active osd. (osd-id: %s)" % \
-                    args.osd_id)
-
-    # GET the mounted device and mount point.
-    mount_info = convert_osd_id(args.cluster, args.osd_id)
+                    osd_id)
 
     # Remove OSD from crush map
-    _remove_from_crush_map(args.cluster, args.osd_id)
+    _remove_from_crush_map(args.cluster, osd_id)
 
     # Remove OSD cephx key
-    _delete_osd_auth_key(args.cluster, args.osd_id)
+    _delete_osd_auth_key(args.cluster, osd_id)
 
     # Deallocate OSD ID
-    _deallocate_osd_id(args.cluster, args.osd_id)
+    _deallocate_osd_id(args.cluster, osd_id)
 
     # Check zap flag. If we found zap flag, we need to find device for
     # destroy this osd data.
     if args.zap is True:
 
-        # try to find osd data device.
-        partmap = list_all_partitions(None)
-        # list all partition which have the partition name with
-        # deactive flag
-        devtocheck = []
-        for base, parts in sorted(partmap.iteritems()):
-            if not parts:
-                continue
-            for p in parts:
-                (dev, p_num) = split_dev_base_partnum(os.path.join("/dev", p))
-                part_name = get_partition_name(os.path.join("/dev", p))
-                LOG.debug("device: %s, p_num: %s" % (dev, p_num))
-                LOG.debug("part_name: %s" % part_name)
-                if part_name == "ceph data (deactive)" or \
-                   part_name == "ceph journal (deactive)":
+        # easy to do when we get device
+        if mount_info:
+            base_dev = get_partition_base(mount_info[0])
+        else:
+            # try to find osd data device.
+            partmap = list_all_partitions(None)
+            # list all partition which have the partition name with
+            # deactive flag
+            devtocheck = []
+            found = False
+            for base, parts in sorted(partmap.iteritems()):
+                if not parts:
+                    continue
+                for p in parts:
+                    (dev, p_num) = split_dev_base_partnum(os.path.join("/dev", p))
+                    LOG.debug("device: %s, p_num: %s" % (dev, p_num))
                     devtocheck.append(os.path.join("/dev", p))
 
-        # check all above device's osd_id
-        # if the osd_id is correct, zap it.
-        for item in devtocheck:
-            try:
-                fs_type = get_dev_fs(item)
-                if fs_type != None:
-                    tpath = mount(dev=item, fstype=fs_type, options='')
-                    if tpath:
-                        try:
-                            whoami = get_oneliner(tpath, 'whoami')
-                        finally:
-                            unmount(tpath)
-                if whoami is args.osd_id:
-                    (dev, part_num) = split_dev_base_partnum(item)
-            except MountError:
-                pass
+            # check all above device's osd_id
+            # if the osd_id is correct, zap it.
+            for item in devtocheck:
+                try:
+                    whoami = -1
+                    fs_type = get_dev_fs(item)
+                    if fs_type != None:
+                        tpath = mount(dev=item, fstype=fs_type, options='')
+                        if tpath:
+                            try:
+                                whoami = get_oneliner(tpath, 'whoami')
+                            finally:
+                                unmount(tpath)
+                    if whoami is osd_id:
+                        found = True
+                        (base_dev, part_num) = split_dev_base_partnum(item)
+                except MountError:
+                     pass
+            if not found:
+                raise Error('Could not find the partition of osd.%s!' % osd_id)
 
         # earse the osd data
-        LOG.info("Prepare to zap the device %s" % dev)
-        zap(dev)
+        LOG.info("Prepare to zap the device %s" % base_dev)
+        zap(base_dev)
 
     return
 
@@ -3109,10 +3100,6 @@ def get_partition_type(part):
 
 def get_partition_uuid(part):
     return get_sgdisk_partition_info(part, 'Partition unique GUID: (\S+)')
-
-def get_partition_name(part):
-    regexp = "Partition name: \'*([A-Za-z ]+[ ()A-Za-z]*)\'*"
-    return get_sgdisk_partition_info(part, regexp)
 
 def get_sgdisk_partition_info(dev, regexp):
     (base, partnum) = split_dev_base_partnum(dev)
@@ -3840,6 +3827,11 @@ def make_activate_parser(subparsers):
         default='/etc/ceph/dmcrypt-keys',
         help='directory where dm-crypt keys are stored',
         )
+    activate_parser.add_argument(
+        '--reactivate',
+        action='store_true', default=False,
+        help='activate the deactived OSD',
+        )
     activate_parser.set_defaults(
         activate_key_template='{statedir}/bootstrap-osd/{cluster}.keyring',
         func=main_activate,
@@ -3956,14 +3948,20 @@ def make_deactivate_parser(subparsers):
         help='cluster name to assign this disk to',
         )
     deactivate_parser.add_argument(
-        '--osd-id',
-        metavar='OSDID',
-        help='ID of OSD to deactivate'
+        'path',
+        metavar='PATH',
+        nargs='?',
+        help='path to block device or directory',
+        )
+    deactivate_parser.add_argument(
+        '--deactivate-by-id',
+        metavar='<id>',
+        help='ID of OSD to deactive'
         )
     deactivate_parser.add_argument(
         '--mark-out',
         action='store_true', default=False,
-        help='option to mark this osd out',
+        help='option to mark the osd out',
         )
     deactivate_parser.set_defaults(
         func=main_deactivate,
@@ -3978,8 +3976,14 @@ def make_destroy_parser(subparsers):
         help='cluster name to assign this disk to',
         )
     destroy_parser.add_argument(
-        '--osd-id',
-        metavar='OSDID',
+        'path',
+        metavar='PATH',
+        nargs='?',
+        help='path to block device or directory',
+        )
+    destroy_parser.add_argument(
+        '--destroy-by-id',
+        metavar='<id>',
         help='ID of OSD to destroy'
         )
     destroy_parser.add_argument(

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -2143,7 +2143,6 @@ def stop_daemon(
     path = (STATEDIR + '/osd/{cluster}-{osd_id}').format(
         cluster=cluster, osd_id=osd_id)
 
-    # upstart?
     try:
         if os.path.exists(os.path.join(path,'upstart')):
             command_check_call(
@@ -2299,11 +2298,8 @@ def mount_activate(
         # Now active successfully
         # If we got reactivate and deactive, remove the deactive file
         if deactive and reactivate:
-            try:
-                os.remove(os.path.join(path, 'deactive'))
-                LOG.info('Remove `deactive` file.')
-            except OSError:
-                raise Error('Cannot remove `deactive` file!')
+            os.remove(os.path.join(path, 'deactive'))
+            LOG.info('Remove `deactive` file.')
 
         # check if the disk is already active, or if something else is already
         # mounted there
@@ -2573,17 +2569,14 @@ def main_activate(args):
 
 def _mark_osd_out(cluster, osd_id):
     LOG.info('Prepare to mark osd.%d out...', osd_id)
-    try:
-        out, ret = command(
-                [
-                    'ceph',
-                    'osd',
-                    'out',
-                    'osd.%d' % osd_id,
-                    ],
-                )
-    except:
-        raise Error('Could not find osd.%s, is a vaild/exist osd id?' % osd_id)
+    command(
+            [
+                'ceph',
+                'osd',
+                'out',
+                'osd.%d' % osd_id,
+                ],
+            )
 
 
 def _check_osd_status(cluster, osd_id):
@@ -2627,20 +2620,14 @@ def _remove_osd_directory_files(mounted_path, cluster):
     To remove the 'ready', 'active', INIT-specific files.
     """
     if os.path.exists(os.path.join(mounted_path, 'ready')):
-        try:
-            os.remove(os.path.join(mounted_path, 'ready'))
-            LOG.info('Remove `ready` file.')
-        except OSError:
-            raise Error('Could not remove `ready` file!')
+        os.remove(os.path.join(mounted_path, 'ready'))
+        LOG.info('Remove `ready` file.')
     else:
         LOG.info('`ready` file is already removed.')
 
     if os.path.exists(os.path.join(mounted_path, 'active')):
-        try:
-            os.remove(os.path.join(mounted_path, 'active'))
-            LOG.info('Remove `active` file.')
-        except OSError:
-            raise Error('Could not remove `active` file!')
+        os.remove(os.path.join(mounted_path, 'active'))
+        LOG.info('Remove `active` file.')
     else:
         LOG.info('`active` file is already removed.')
 
@@ -2653,12 +2640,9 @@ def _remove_osd_directory_files(mounted_path, cluster):
         init = conf_val
     else:
         init = init_get()
-    try:
-        os.remove(os.path.join(mounted_path, init))
-        LOG.info('Remove `%s` file.', init)
-        return
-    except OSError:
-        raise Error('Could not remove %s (init) file!' % init)
+    os.remove(os.path.join(mounted_path, init))
+    LOG.info('Remove `%s` file.', init)
+    return
 
 
 def main_deactivate(args):
@@ -2729,46 +2713,37 @@ def main_deactivate(args):
 
 def _remove_from_crush_map(cluster, osd_id):
     LOG.info("Prepare to remove osd.%s from crush map..." % osd_id)
-    try:
-        out, ret = command(
-                [
-                    'ceph',
-                    'osd',
-                    'crush',
-                    'remove',
-                    'osd.%s' % osd_id,
-                    ],
-                )
-    except subprocess.CalledProcessError as e:
-        raise Error(e)
+    command(
+            [
+                'ceph',
+                'osd',
+                'crush',
+                'remove',
+                'osd.%s' % osd_id,
+                ],
+            )
 
 def _delete_osd_auth_key(cluster, osd_id):
     LOG.info("Prepare to delete osd.%s cephx key..." % osd_id)
-    try:
-        out, ret = command(
-                [
-                    'ceph',
-                    'auth',
-                    'del',
-                    'osd.%s' % osd_id,
-                    ],
-                )
-    except subprocess.CalledProcessError as e:
-        raise Error(e)
+    command(
+            [
+                'ceph',
+                'auth',
+                'del',
+                'osd.%s' % osd_id,
+                ],
+            )
 
 def _deallocate_osd_id(cluster, osd_id):
     LOG.info("Prepare to deallocate the osd-id: %s..." % osd_id)
-    try:
-        out, ret = command(
-                [
-                    'ceph',
-                    'osd',
-                    'rm',
-                    '%s' % osd_id,
-                    ],
-                )
-    except subprocess.CalledProcessError as e:
-        raise Error(e)
+    command(
+            [
+                'ceph',
+                'osd',
+                'rm',
+                '%s' % osd_id,
+                ],
+            )
 
 def main_destroy(args):
     osd_id = args.destroy_by_id

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -67,6 +67,12 @@ Deactivate:
  - create deactive flag
  - umount device and remove mount point
 
+Destroy:
+ - remove OSD from CRUSH map
+ - remove OSD cephx key
+ - deallocate OSD ID
+ - destroy data (with --zap option)
+
 We rely on /dev/disk/by-partuuid to find partitions by their UUID;
 this is what the journal symlink inside the osd data volume normally
 points to.
@@ -2779,6 +2785,119 @@ def main_deactivate(args):
 
 ###########################
 
+def _remove_from_crush_map(cluster, osd_id):
+    LOG.info("Prepare to remove osd.%s from crush map..." % osd_id)
+    try:
+        out, ret = command(
+                [
+                    'ceph',
+                    'osd',
+                    'crush',
+                    'remove',
+                    'osd.%s' % osd_id,
+                    ],
+                )
+    except subprocess.CalledProcessError as e:
+        raise Error(e)
+
+def _delete_osd_auth_key(cluster, osd_id):
+    LOG.info("Prepare to delete osd.%s cephx key..." % osd_id)
+    try:
+        out, ret = command(
+                [
+                    'ceph',
+                    'auth',
+                    'del',
+                    'osd.%s' % osd_id,
+                    ],
+                )
+    except subprocess.CalledProcessError as e:
+        raise Error(e)
+
+def _deallocate_osd_id(cluster, osd_id):
+    LOG.info("Prepare to deallocate the osd-id: %s..." % osd_id)
+    try:
+        out, ret = command(
+                [
+                    'ceph',
+                    'osd',
+                    'rm',
+                    '%s' % osd_id,
+                    ],
+                )
+    except subprocess.CalledProcessError as e:
+        raise Error(e)
+
+def main_destroy(args):
+    if args.cluster is None:
+        args.cluster = 'ceph'
+    if args.osd_id is None:
+        raise Error("osd id can not be zero. Try to use --osd-id <OSDID>.")
+
+    # Before osd deactivate, we cannot destroy it
+    status_code = _check_osd_status(args.cluster, args.osd_id)
+    if status_code != OSD_STATUS_OUT_DOWN:
+        raise Error("Could not destroy the active osd. (osd-id: %s)" % \
+                    args.osd_id)
+
+    # GET the mounted device and mount point.
+    mount_info = convert_osd_id(args.cluster, args.osd_id)
+
+    # Remove OSD from crush map
+    _remove_from_crush_map(args.cluster, args.osd_id)
+
+    # Remove OSD cephx key
+    _delete_osd_auth_key(args.cluster, args.osd_id)
+
+    # Deallocate OSD ID
+    _deallocate_osd_id(args.cluster, args.osd_id)
+
+    # Check zap flag. If we found zap flag, we need to find device for
+    # destroy this osd data.
+    if args.zap is True:
+
+        # try to find osd data device.
+        partmap = list_all_partitions(None)
+        # list all partition which have the partition name with
+        # deactive flag
+        devtocheck = []
+        for base, parts in sorted(partmap.iteritems()):
+            if not parts:
+                continue
+            for p in parts:
+                (dev, p_num) = split_dev_base_partnum(os.path.join("/dev", p))
+                part_name = get_partition_name(os.path.join("/dev", p))
+                LOG.debug("device: %s, p_num: %s" % (dev, p_num))
+                LOG.debug("part_name: %s" % part_name)
+                if part_name == "ceph data (deactive)" or \
+                   part_name == "ceph journal (deactive)":
+                    devtocheck.append(os.path.join("/dev", p))
+
+        # check all above device's osd_id
+        # if the osd_id is correct, zap it.
+        for item in devtocheck:
+            try:
+                fs_type = get_dev_fs(item)
+                if fs_type != None:
+                    tpath = mount(dev=item, fstype=fs_type, options='')
+                    if tpath:
+                        try:
+                            whoami = get_oneliner(tpath, 'whoami')
+                        finally:
+                            unmount(tpath)
+                if whoami is args.osd_id:
+                    (dev, part_num) = split_dev_base_partnum(item)
+            except MountError:
+                pass
+
+        # earse the osd data
+        LOG.info("Prepare to zap the device %s" % dev)
+        zap(dev)
+
+    return
+
+###########################
+
 def get_journal_osd_uuid(path):
     if not os.path.exists(path):
         raise Error('%s does not exist' % path)
@@ -3575,6 +3694,7 @@ def parse_args(argv):
     make_list_parser(subparsers)
     make_suppress_parser(subparsers)
     make_deactivate_parser(subparsers)
+    make_destroy_parser(subparsers)
     make_zap_parser(subparsers)
     make_trigger_parser(subparsers)
 
@@ -3841,6 +3961,28 @@ def make_deactivate_parser(subparsers):
         )
     deactivate_parser.set_defaults(
         func=main_deactivate,
+        )
+
+def make_destroy_parser(subparsers):
+    destroy_parser = subparsers.add_parser('destroy', help='Destroy a Ceph OSD')
+    destroy_parser.add_argument(
+        '--cluster',
+        metavar='NAME',
+        default='ceph',
+        help='cluster name to assign this disk to',
+        )
+    destroy_parser.add_argument(
+        '--osd-id',
+        metavar='OSDID',
+        help='ID of OSD to destroy'
+        )
+    destroy_parser.add_argument(
+        '--zap',
+        action='store_true', default=False,
+        help='option to erase data and partition',
+        )
+    destroy_parser.set_defaults(
+        func=main_destroy,
         )
 
 def make_zap_parser(subparsers):


### PR DESCRIPTION
    Ref: http://tracker.ceph.com/issues/7454
    Implement ceph-disk destroy feature (including deactivate and destroy).

    This implementation not including drain (set CRUSH weight to 0)
    I don't know how to confirm that drain is done.

    Destroy osd will split two stage. 
    First stage is deactiveate:
        - stop ceph-osd service if needed (If osd still in osd map, make it out first)
        - remove 'ready', 'active', and INIT-specific files
        - remove gpt partition type and change partition name (prevent triggered by udev)
        - create deactive flag
        - umount device and remove mount point

    Second stage is destroy:
        - remove OSD from CRUSH map
        - remove OSD cephx key
        - deallocate OSD ID
        - destroy data (with --zap option)

If you have any questions, feel free to let me know.
Thanks!

Signed-off-by: Vicente Cheng <freeze.bilsted@gmail.com>