### PR TITLE
osd:the fuction osd::shutdown Lock failed.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6469,8 +6469,10 @@ void OSD::handle_osd_map(MOSDMap *m)
   else if (do_restart)
     start_boot();
 
+  osd_lock.Unlock();
   if (do_shutdown)
     shutdown();
+  osd_lock.Lock();
 
   m->put();
 }


### PR DESCRIPTION
when i test ceph ,i see the following log info, i find that OSD::ms_dispatch has called osd_lock.Lock(),then the fuction osd::shutdown called osd_lock.Lock() again.
2015-09-09 16:47:27.723271 7fb5debf8700 -1 common/Mutex.cc: In function 'void Mu
tex::Lock(bool)' thread 7fb5debf8700 time 2015-09-09 16:47:27.718511            
common/Mutex.cc: 95: FAILED assert(r == 0)                                      
                                                              15377,0-1     57% 
 ceph version 0.94.2 (5fb85614ca8f354284c713a2f9c610860720bbf3)                 
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x8b) 
[0xbc2b8b]                                                    15379,2       57% 
 2: (Mutex::Lock(bool)+0x105) [0xb737b5]                                        
 3: (OSD::shutdown()+0x55) [0x687805]                                           
 4: (OSD::handle_osd_map(MOSDMap*)+0x1c0f) [0x6bf6ff]         15382,2       57% 
 5: (OSD::_dispatch(Message*)+0x3eb) [0x6c197b]                                 
 6: (OSD::ms_dispatch(Message*)+0x257) [0x6c1e87]                               

Signed-off-by: Lu Shi <shi.lu@h3c.com>