### PR TITLE
common: add debug option to deliberately leak some memory

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1136,3 +1136,5 @@ OPTION(throttler_perf_counter, OPT_BOOL, true) // enable/disable throttler perf 
 // This will be set to true when it is safe to start threads.
 // Once it is true, it will never change.
 OPTION(internal_safe_to_start_threads, OPT_BOOL, false)
+
+OPTION(debug_deliberately_leak_memory, OPT_BOOL, false)

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -240,6 +240,13 @@ void global_init(std::vector < const char * > *alt_def_args,
   // and opening the log file immediately.
   g_conf->call_all_observers();
 
+  // test leak checking
+  if (g_conf->debug_deliberately_leak_memory) {
+    derr << "deliberately leaking some memory" << dendl;
+    char *s = new char[1234567];
+    (void)s;
+  }
+
   if (code_env == CODE_ENVIRONMENT_DAEMON && !(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))
     output_ceph_version();
 }


### PR DESCRIPTION
This will be used to verify leak detection tests are working.

Signed-off-by: Sage Weil <sage@redhat.com>