### PR TITLE
rgw: add support for bucket namespaces

### DIFF
--- a/doc/radosgw/layout.rst
+++ b/doc/radosgw/layout.rst
@@ -34,7 +34,7 @@ $ radosgw-admin metadata list user
 
 $ radosgw-admin metadata get bucket:<bucket>
 $ radosgw-admin metadata get bucket.instance:<bucket>:<bucket_id>
-$ radosgw-admin metadata get user:<user>   # or set
+$ radosgw-admin metadata get user:<user>   # get or set
 
 user: Holds user information
 bucket: Holds a mapping between bucket name and bucket instance id
@@ -149,7 +149,7 @@ Known pools:
 
 .rgw
   <bucket>
-  .bucket.meta.<bucket>:<marker>
+  .bucket.meta.<bucket>:<marker>   # see put_bucket_instance_info()
 
 .rgw.gc
   gc.<N>
@@ -176,3 +176,6 @@ Known pools:
   <marker>_<key>
 
 An example of a marker would be "default.16004.1" or "default.7593.4".
+The current format is "<zone>.<instance_id>.<bucket_id>". But once
+generated, a marker is not parsed again, so its format may change
+freely in the future.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1038,6 +1038,7 @@ OPTION(rgw_swift_url_prefix, OPT_STR, "swift") // entry point for which a url is
 OPTION(rgw_swift_auth_url, OPT_STR, "")        // default URL to go and verify tokens for v1 auth (if not using internal swift auth)
 OPTION(rgw_swift_auth_entry, OPT_STR, "auth")  // entry point for which a url is considered a swift auth url
 OPTION(rgw_swift_tenant_name, OPT_STR, "")  // tenant name to use for swift access
+OPTION(rgw_swift_account_in_url, OPT_BOOL, false)  // assume that URL always contain the account (aka tenant) part
 OPTION(rgw_swift_enforce_content_length, OPT_BOOL, false)  // enforce generation of Content-Length even in cost of performance or scalability
 OPTION(rgw_swift_create_account_with_bns, OPT_BOOL, true)  // whether to create Swift accounts with a dedicated namespace for its buckets
 OPTION(rgw_keystone_url, OPT_STR, "")  // url for keystone server

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1047,6 +1047,7 @@ OPTION(rgw_keystone_admin_user, OPT_STR, "")  // keystone admin user name
 OPTION(rgw_keystone_admin_password, OPT_STR, "")  // keystone admin user password
 OPTION(rgw_keystone_admin_tenant, OPT_STR, "")  // keystone admin user tenant
 OPTION(rgw_keystone_accepted_roles, OPT_STR, "Member, admin")  // roles required to serve requests
+OPTION(rgw_keystone_accepted_admin_roles, OPT_STR, "") // list of roles allowing an user to gain admin privileges
 OPTION(rgw_keystone_token_cache_size, OPT_INT, 10000)  // max number of entries in keystone token cache
 OPTION(rgw_keystone_revocation_interval, OPT_INT, 15 * 60)  // seconds between tokens revocation check
 OPTION(rgw_s3_auth_use_rados, OPT_BOOL, true)  // should we try to use the internal credentials for s3?

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1039,6 +1039,7 @@ OPTION(rgw_swift_auth_url, OPT_STR, "")        // default URL to go and verify t
 OPTION(rgw_swift_auth_entry, OPT_STR, "auth")  // entry point for which a url is considered a swift auth url
 OPTION(rgw_swift_tenant_name, OPT_STR, "")  // tenant name to use for swift access
 OPTION(rgw_swift_enforce_content_length, OPT_BOOL, false)  // enforce generation of Content-Length even in cost of performance or scalability
+OPTION(rgw_swift_create_account_with_bns, OPT_BOOL, true)  // whether to create Swift accounts with a dedicated namespace for its buckets
 OPTION(rgw_keystone_url, OPT_STR, "")  // url for keystone server
 OPTION(rgw_keystone_admin_token, OPT_STR, "")  // keystone admin token (shared secret)
 OPTION(rgw_keystone_admin_user, OPT_STR, "")  // keystone admin user name

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -4,6 +4,7 @@ if ENABLE_CLIENT
 DENCODER_SOURCES += \
 	rgw/rgw_dencoder.cc \
 	rgw/rgw_acl.cc \
+	rgw/rgw_basic_types.cc \
 	rgw/rgw_common.cc \
 	rgw/rgw_env.cc \
 	rgw/rgw_json_enc.cc
@@ -29,6 +30,7 @@ librgw_la_SOURCES =  \
 	rgw/rgw_rest_client.cc \
 	rgw/rgw_rest_conn.cc \
 	rgw/rgw_op.cc \
+	rgw/rgw_basic_types.cc \
 	rgw/rgw_common.cc \
 	rgw/rgw_cache.cc \
 	rgw/rgw_formats.cc \
@@ -130,6 +132,7 @@ noinst_HEADERS += \
 	rgw/rgw_client_io.h \
 	rgw/rgw_fcgi.h \
 	rgw/rgw_xml.h \
+	rgw/rgw_basic_types.h \
 	rgw/rgw_cache.h \
 	rgw/rgw_common.h \
 	rgw/rgw_cors.h \

--- a/src/rgw/rgw_acl_s3.cc
+++ b/src/rgw/rgw_acl_s3.cc
@@ -141,9 +141,11 @@ bool ACLOwner_S3::xml_end(const char *el) {
 }
 
 void  ACLOwner_S3::to_xml(ostream& out) {
-  if (id.empty())
+  string s;
+  id.to_str(s);
+  if (s.empty())
     return;
-  out << "<Owner>" << "<ID>" << id << "</ID>";
+  out << "<Owner>" << "<ID>" << s << "</ID>";
   if (!display_name.empty())
     out << "<DisplayName>" << display_name << "</DisplayName>";
   out << "</Owner>";
@@ -311,7 +313,8 @@ static int parse_grantee_str(RGWRados *store, string& grantee_str,
 
     grant.set_canon(info.user_id, info.display_name, rgw_perm);
   } else if (strcasecmp(id_type.c_str(), "id") == 0) {
-    ret = rgw_get_user_info_by_uid(store, id_val, info);
+    rgw_user user(id_val);
+    ret = rgw_get_user_info_by_uid(store, user, info);
     if (ret < 0)
       return ret;
 
@@ -361,7 +364,7 @@ int RGWAccessControlList_S3::create_canned(ACLOwner& owner, ACLOwner& bucket_own
 
   ACLGrant owner_grant;
 
-  string bid = bucket_owner.get_id();
+  rgw_user bid = bucket_owner.get_id();
   string bname = bucket_owner.get_display_name();
 
   /* owner gets full control */
@@ -476,7 +479,7 @@ int RGWAccessControlPolicy_S3::rebuild(RGWRados *store, ACLOwner *owner, RGWAcce
 
   ACLOwner *requested_owner = static_cast<ACLOwner_S3 *>(find_first("Owner"));
   if (requested_owner) {
-    const string& requested_id = requested_owner->get_id();
+    rgw_user& requested_id = requested_owner->get_id();
     if (!requested_id.empty() && requested_id.compare(owner->get_id()) != 0)
       return -EPERM;
   }
@@ -502,16 +505,18 @@ int RGWAccessControlPolicy_S3::rebuild(RGWRados *store, ACLOwner *owner, RGWAcce
     ACLGranteeType& type = src_grant.get_type();
     ACLGrant new_grant;
     bool grant_ok = false;
-    string uid;
+    rgw_user uid;
     RGWUserInfo grant_user;
     switch (type.get_type()) {
     case ACL_TYPE_EMAIL_USER:
       {
         string email;
-        if (!src_grant.get_id(email)) {
+        rgw_user u;
+        if (!src_grant.get_id(u)) {
           ldout(cct, 0) << "ERROR: src_grant.get_id() failed" << dendl;
           return -EINVAL;
         }
+        email = u.id;  // XXX none of that .to_str() stuff here, but why?
         ldout(cct, 10) << "grant user email=" << email << dendl;
         if (rgw_get_user_info_by_email(store, email, grant_user) < 0) {
           ldout(cct, 10) << "grant user email not found or other error" << dendl;
@@ -535,7 +540,7 @@ int RGWAccessControlPolicy_S3::rebuild(RGWRados *store, ACLOwner *owner, RGWAcce
           ACLPermission& perm = src_grant.get_permission();
           new_grant.set_canon(uid, grant_user.display_name, perm.get_permissions());
           grant_ok = true;
-          string new_id;
+          rgw_user new_id;
           new_grant.get_id(new_id);
           ldout(cct, 10) << "new grant: " << new_id << ":" << grant_user.display_name << dendl;
         }

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -4,9 +4,9 @@
 #ifndef CEPH_RGW_ACL_SWIFT_H
 #define CEPH_RGW_ACL_SWIFT_H
 
+#include <list>
 #include <map>
 #include <string>
-#include <vector>
 #include <include/types.h>
 
 #include "rgw_acl.h"
@@ -19,8 +19,8 @@ public:
   RGWAccessControlPolicy_SWIFT(CephContext *_cct) : RGWAccessControlPolicy(_cct) {}
   ~RGWAccessControlPolicy_SWIFT() {}
 
-  void add_grants(RGWRados *store, vector<string>& uids, int perm);
-  bool create(RGWRados *store, string& id, string& name, string& read_list, string& write_list);
+  void add_grants(RGWRados *store, list<string>& uids, int perm);
+  bool create(RGWRados *store, rgw_user& id, string& name, string& read_list, string& write_list);
   void to_str(string& read, string& write);
 };
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1367,15 +1367,6 @@ int main(int argc, char **argv)
       ++i;
     }
   }
-  if (tenant.empty()) {
-    tenant = user_id.tenant;
-  } else {
-    if (user_id.empty()) {
-      cerr << "ERROR: --tennant is set, but there's no user ID" << std::endl;
-      return EINVAL;
-    }
-    user_id.tenant = tenant;
-  }
 
   if (args.empty()) {
     return usage();

--- a/src/rgw/rgw_basic_types.cc
+++ b/src/rgw/rgw_basic_types.cc
@@ -1,0 +1,14 @@
+#include "rgw_basic_types.h"
+#include "common/ceph_json.h"
+
+void decode_json_obj(rgw_user& val, JSONObj *obj)
+{
+  string s = obj->get_data();
+  val.from_str(s);
+}
+
+void encode_json(const char *name, const rgw_user& val, Formatter *f)
+{
+  string s = val.to_str();
+  f->dump_string(name, s);
+}

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -35,7 +35,6 @@ public:
 
 
 struct rgw_user {
-  std::string tenant;
   std::string id;
   bool has_own_bns;
 
@@ -64,32 +63,23 @@ struct rgw_user {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
-    ::encode(tenant, bl);
+    ENCODE_START(3, 3, bl);
     ::encode(id, bl);
     ::encode(has_own_bns, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(1, bl);
-    ::decode(tenant, bl);
+    DECODE_START(3, bl);
     ::decode(id, bl);
-    if (struct_v >= 2) {
-      ::decode(has_own_bns, bl);
-    }
+    ::decode(has_own_bns, bl);
     DECODE_FINISH(bl);
   }
 
   void to_str(std::string& str) const {
-    if (!tenant.empty()) {
-      str = tenant + ':' + id;
-    } else {
-      str = id;
-    }
+    str = id;
   }
 
   void clear() {
-    tenant.clear();
     id.clear();
   }
 
@@ -104,14 +94,7 @@ struct rgw_user {
   }
 
   void from_str(const std::string& str) {
-    ssize_t pos = str.find(':');
-    if (pos >= 0) {
-      tenant = str.substr(0, pos);
-      id = str.substr(pos + 1);
-    } else {
-      tenant.clear();
-      id = str;
-    }
+    id = str;
   }
 
   rgw_user& operator=(const string& str) {
@@ -120,10 +103,6 @@ struct rgw_user {
   }
 
   int compare(const rgw_user& u) const {
-    int r = tenant.compare(u.tenant);
-    if (r != 0)
-      return r;
-
     return id.compare(u.id);
   }
   int compare(const string& str) const {
@@ -138,11 +117,6 @@ struct rgw_user {
     return (compare(rhs) == 0);
   }
   bool operator<(const rgw_user& rhs) const {
-    if (tenant < rhs.tenant) {
-      return true;
-    } else if (tenant > rhs.tenant) {
-      return false;
-    }
     return (id < rhs.id);
   }
 };

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -1,0 +1,111 @@
+#ifndef CEPH_RGW_BASIC_TYPES_H
+#define CEPH_RGW_BASIC_TYPES_H
+
+#include <string>
+
+#include "include/types.h"
+
+struct rgw_user {
+  std::string tenant;
+  std::string id;
+
+  rgw_user() {}
+  rgw_user(const std::string& s) {
+    from_str(s);
+  }
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    ::encode(tenant, bl);
+    ::encode(id, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START(1, bl);
+    ::decode(tenant, bl);
+    ::decode(id, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void to_str(std::string& str) const {
+    if (!tenant.empty()) {
+      str = tenant + ':' + id;
+    } else {
+      str = id;
+    }
+  }
+
+  void clear() {
+    tenant.clear();
+    id.clear();
+  }
+
+  bool empty() {
+    return id.empty();
+  }
+
+  string to_str() const {
+    string s;
+    to_str(s);
+    return s;
+  }
+
+  void from_str(const std::string& str) {
+    ssize_t pos = str.find(':');
+    if (pos >= 0) {
+      tenant = str.substr(0, pos);
+      id = str.substr(pos + 1);
+    } else {
+      tenant.clear();
+      id = str;
+    }
+  }
+
+  rgw_user& operator=(const string& str) {
+    from_str(str);
+    return *this;
+  }
+
+  int compare(const rgw_user& u) const {
+    int r = tenant.compare(u.tenant);
+    if (r != 0)
+      return r;
+
+    return id.compare(u.id);
+  }
+  int compare(const string& str) const {
+    rgw_user u(str);
+    return compare(u);
+  }
+
+  bool operator!=(const rgw_user& rhs) const {
+    return (compare(rhs) != 0);
+  }
+  bool operator==(const rgw_user& rhs) const {
+    return (compare(rhs) == 0);
+  }
+  bool operator<(const rgw_user& rhs) const {
+    if (tenant < rhs.tenant) {
+      return true;
+    } else if (tenant > rhs.tenant) {
+      return false;
+    }
+    return (id < rhs.id);
+  }
+};
+WRITE_CLASS_ENCODER(rgw_user)
+
+
+class JSONObj;
+
+void decode_json_obj(rgw_user& val, JSONObj *obj);
+void encode_json(const char *name, const rgw_user& val, Formatter *f);
+
+inline ostream& operator<<(ostream& out, const rgw_user &u) {
+  string s;
+  u.to_str(s);
+  return out << s;
+}
+
+
+#endif

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -126,7 +126,6 @@ int rgw_bucket_sync_user_stats(RGWRados *store, const string& tenant_name, const
 int rgw_link_bucket(RGWRados *store, const rgw_user& user_id, rgw_bucket& bucket, time_t creation_time, bool update_entrypoint)
 {
   int ret;
-  // XXX Actually, should we use user_id.tenant when creating bucket?
   string& tenant_name = bucket.tenant;
   string& bucket_name = bucket.name;
 

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -32,9 +32,9 @@ static RGWMetadataHandler *bucket_meta_handler = NULL;
 static RGWMetadataHandler *bucket_instance_meta_handler = NULL;
 
 // define as static when RGWBucket implementation compete
-void rgw_get_buckets_obj(const string& user_id, string& buckets_obj_id)
+void rgw_get_buckets_obj(const rgw_user& user_id, string& buckets_obj_id)
 {
-  buckets_obj_id = user_id;
+  buckets_obj_id = user_id.to_str();
   buckets_obj_id += RGW_BUCKETS_OBJ_SUFFIX;
 }
 
@@ -43,7 +43,7 @@ void rgw_get_buckets_obj(const string& user_id, string& buckets_obj_id)
  * Returns: 0 on success, -ERR# on failure.
  */
 int rgw_read_user_buckets(RGWRados * store,
-                          string user_id,
+                          const rgw_user& user_id,
                           RGWUserBuckets& buckets,
                           const string& marker,
                           uint64_t max,
@@ -95,7 +95,7 @@ int rgw_read_user_buckets(RGWRados * store,
   return 0;
 }
 
-int rgw_bucket_sync_user_stats(RGWRados *store, const string& user_id, rgw_bucket& bucket)
+int rgw_bucket_sync_user_stats(RGWRados *store, const rgw_user& user_id, rgw_bucket& bucket)
 {
   string buckets_obj_id;
   rgw_get_buckets_obj(user_id, buckets_obj_id);
@@ -104,11 +104,11 @@ int rgw_bucket_sync_user_stats(RGWRados *store, const string& user_id, rgw_bucke
   return store->cls_user_sync_bucket_stats(obj, bucket);
 }
 
-int rgw_bucket_sync_user_stats(RGWRados *store, const string& bucket_name)
+int rgw_bucket_sync_user_stats(RGWRados *store, const string& tenant_name, const string& bucket_name)
 {
   RGWBucketInfo bucket_info;
   RGWObjectCtx obj_ctx(store);
-  int ret = store->get_bucket_info(obj_ctx, bucket_name, bucket_info, NULL);
+  int ret = store->get_bucket_info(obj_ctx, tenant_name, bucket_name, bucket_info, NULL);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: could not fetch bucket info: ret=" << ret << dendl;
     return ret;
@@ -123,9 +123,11 @@ int rgw_bucket_sync_user_stats(RGWRados *store, const string& bucket_name)
   return 0;
 }
 
-int rgw_link_bucket(RGWRados *store, string user_id, rgw_bucket& bucket, time_t creation_time, bool update_entrypoint)
+int rgw_link_bucket(RGWRados *store, const rgw_user& user_id, rgw_bucket& bucket, time_t creation_time, bool update_entrypoint)
 {
   int ret;
+  // XXX Actually, should we use user_id.tenant when creating bucket?
+  string& tenant_name = bucket.tenant;
   string& bucket_name = bucket.name;
 
   cls_user_bucket_entry new_bucket;
@@ -144,7 +146,7 @@ int rgw_link_bucket(RGWRados *store, string user_id, rgw_bucket& bucket, time_t 
   RGWObjectCtx obj_ctx(store);
 
   if (update_entrypoint) {
-    ret = store->get_bucket_entrypoint_info(obj_ctx, bucket_name, ep, &ot, NULL, &attrs);
+    ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, ep, &ot, NULL, &attrs);
     if (ret < 0 && ret != -ENOENT) {
       ldout(store->ctx(), 0) << "ERROR: store->get_bucket_entrypoint_info() returned " << ret << dendl;
     } else if (ret >= 0 && ep.linked && ep.owner != user_id) {
@@ -169,20 +171,20 @@ int rgw_link_bucket(RGWRados *store, string user_id, rgw_bucket& bucket, time_t 
 
   ep.linked = true;
   ep.owner = user_id;
-  ret = store->put_bucket_entrypoint_info(bucket_name, ep, false, ot, 0, &attrs);
+  ret = store->put_bucket_entrypoint_info(tenant_name, bucket_name, ep, false, ot, 0, &attrs);
   if (ret < 0)
     goto done_err;
 
   return 0;
 done_err:
-  int r = rgw_unlink_bucket(store, user_id, bucket.name);
+  int r = rgw_unlink_bucket(store, user_id, bucket.tenant, bucket.name);
   if (r < 0) {
     ldout(store->ctx(), 0) << "ERROR: failed unlinking bucket on error cleanup: " << cpp_strerror(-r) << dendl;
   }
   return ret;
 }
 
-int rgw_unlink_bucket(RGWRados *store, string user_id, const string& bucket_name, bool update_entrypoint)
+int rgw_unlink_bucket(RGWRados *store, const rgw_user& user_id, const string& tenant_name, const string& bucket_name, bool update_entrypoint)
 {
   int ret;
 
@@ -207,7 +209,7 @@ int rgw_unlink_bucket(RGWRados *store, string user_id, const string& bucket_name
   RGWObjVersionTracker ot;
   map<string, bufferlist> attrs;
   RGWObjectCtx obj_ctx(store);
-  ret = store->get_bucket_entrypoint_info(obj_ctx, bucket_name, ep, &ot, NULL, &attrs);
+  ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, ep, &ot, NULL, &attrs);
   if (ret == -ENOENT)
     return 0;
   if (ret < 0)
@@ -222,7 +224,7 @@ int rgw_unlink_bucket(RGWRados *store, string user_id, const string& bucket_name
   }
 
   ep.linked = false;
-  ret = store->put_bucket_entrypoint_info(bucket_name, ep, false, ot, 0, &attrs);
+  ret = store->put_bucket_entrypoint_info(tenant_name, bucket_name, ep, false, ot, 0, &attrs);
   if (ret < 0)
     return ret;
 
@@ -281,7 +283,7 @@ int rgw_bucket_set_attrs(RGWRados *store, RGWBucketInfo& bucket_info,
   if (!bucket_info.has_instance_obj) {
     /* an old bucket object, need to convert it */
     RGWObjectCtx obj_ctx(store);
-    int ret = store->convert_old_bucket_info(obj_ctx, bucket.name);
+    int ret = store->convert_old_bucket_info(obj_ctx, bucket.tenant, bucket.name);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "ERROR: failed converting old bucket info: " << ret << dendl;
       return ret;
@@ -313,7 +315,7 @@ static void dump_mulipart_index_results(list<rgw_obj_key>& objs_to_unlink,
   f->close_section();
 }
 
-void check_bad_user_bucket_mapping(RGWRados *store, const string& user_id, bool fix)
+void check_bad_user_bucket_mapping(RGWRados *store, const rgw_user& user_id, bool fix)
 {
   RGWUserBuckets user_buckets;
   bool done;
@@ -342,7 +344,7 @@ void check_bad_user_bucket_mapping(RGWRados *store, const string& user_id, bool 
       RGWBucketInfo bucket_info;
       time_t mtime;
       RGWObjectCtx obj_ctx(store);
-      int r = store->get_bucket_info(obj_ctx, bucket.name, bucket_info, &mtime);
+      int r = store->get_bucket_info(obj_ctx, user_id.tenant, bucket.name, bucket_info, &mtime);
       if (r < 0) {
         ldout(store->ctx(), 0) << "could not get bucket info for bucket=" << bucket << dendl;
         continue;
@@ -351,6 +353,7 @@ void check_bad_user_bucket_mapping(RGWRados *store, const string& user_id, bool 
       rgw_bucket& actual_bucket = bucket_info.bucket;
 
       if (actual_bucket.name.compare(bucket.name) != 0 ||
+          actual_bucket.tenant.compare(bucket.tenant) != 0 ||
           actual_bucket.data_pool.compare(bucket.data_pool) != 0 ||
           actual_bucket.index_pool.compare(bucket.index_pool) != 0 ||
           actual_bucket.marker.compare(bucket.marker) != 0 ||
@@ -392,7 +395,7 @@ int rgw_remove_object(RGWRados *store, RGWBucketInfo& bucket_info, rgw_bucket& b
   return ret;
 }
 
-int rgw_remove_bucket(RGWRados *store, const string& bucket_owner, rgw_bucket& bucket, bool delete_children)
+int rgw_remove_bucket(RGWRados *store, rgw_bucket& bucket, bool delete_children)
 {
   int ret;
   map<RGWObjCategory, RGWStorageStats> stats;
@@ -411,7 +414,7 @@ int rgw_remove_bucket(RGWRados *store, const string& bucket_owner, rgw_bucket& b
 
   obj.bucket = bucket;
 
-  ret = store->get_bucket_info(obj_ctx, bucket.name, info, NULL);
+  ret = store->get_bucket_info(obj_ctx, bucket.tenant, bucket.name, info, NULL);
   if (ret < 0)
     return ret;
 
@@ -450,7 +453,7 @@ int rgw_remove_bucket(RGWRados *store, const string& bucket_owner, rgw_bucket& b
     return ret;
   }
 
-  ret = rgw_unlink_bucket(store, info.owner, bucket.name);
+  ret = rgw_unlink_bucket(store, info.owner, bucket.tenant, bucket.name);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: unable to remove user bucket information" << dendl;
   }
@@ -476,7 +479,8 @@ int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state)
 
   store = storage;
 
-  string user_id = op_state.get_user_id();
+  rgw_user user_id = op_state.get_user_id();
+  tenant = user_id.tenant;
   bucket_name = op_state.get_bucket_name();
   RGWUserBuckets user_buckets;
   RGWObjectCtx obj_ctx(store);
@@ -485,7 +489,7 @@ int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state)
     return -EINVAL;
 
   if (!bucket_name.empty()) {
-    int r = store->get_bucket_info(obj_ctx, bucket_name, bucket_info, NULL);
+    int r = store->get_bucket_info(obj_ctx, tenant, bucket_name, bucket_info, NULL);
     if (r < 0) {
       ldout(store->ctx(), 0) << "could not get bucket info for bucket=" << bucket_name << dendl;
       return r;
@@ -551,9 +555,9 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
       return -EIO;
     }
 
-    r = rgw_unlink_bucket(store, owner.get_id(), bucket.name);
+    r = rgw_unlink_bucket(store, owner.get_id(), bucket.tenant, bucket.name);
     if (r < 0) {
-      set_err_msg(err_msg, "could not unlink policy from user " + owner.get_id());
+      set_err_msg(err_msg, "could not unlink policy from user " + owner.get_id().to_str());
       return r;
     }
 
@@ -595,7 +599,7 @@ int RGWBucket::unlink(RGWBucketAdminOpState& op_state, std::string *err_msg)
     return -EINVAL;
   }
 
-  int r = rgw_unlink_bucket(store, user_info.user_id, bucket.name);
+  int r = rgw_unlink_bucket(store, user_info.user_id, bucket.tenant, bucket.name);
   if (r < 0) {
     set_err_msg(err_msg, "error unlinking bucket" + cpp_strerror(-r));
   }
@@ -608,7 +612,7 @@ int RGWBucket::remove(RGWBucketAdminOpState& op_state, std::string *err_msg)
   bool delete_children = op_state.will_delete_children();
   rgw_bucket bucket = op_state.get_bucket();
 
-  int ret = rgw_remove_bucket(store, bucket_info.owner, bucket, delete_children);
+  int ret = rgw_remove_bucket(store, bucket, delete_children);
   if (ret < 0) {
     set_err_msg(err_msg, "unable to remove bucket" + cpp_strerror(-ret));
     return ret;
@@ -844,7 +848,7 @@ int RGWBucket::get_policy(RGWBucketAdminOpState& op_state, ostream& o)
 
   RGWBucketInfo bucket_info;
   map<string, bufferlist> attrs;
-  int ret = store->get_bucket_info(obj_ctx, bucket.name, bucket_info, NULL, &attrs);
+  int ret = store->get_bucket_info(obj_ctx, bucket.tenant, bucket.name, bucket_info, NULL, &attrs);
   if (ret < 0) {
     return ret;
   }
@@ -875,7 +879,7 @@ int RGWBucket::get_policy(RGWBucketAdminOpState& op_state, ostream& o)
 int RGWBucketAdminOp::get_policy(RGWRados *store, RGWBucketAdminOpState& op_state,
                   ostream& os)
 {
-   RGWBucket bucket;
+  RGWBucket bucket;
 
   int ret = bucket.init(store, op_state);
   if (ret < 0)
@@ -998,7 +1002,7 @@ int RGWBucketAdminOp::remove_object(RGWRados *store, RGWBucketAdminOpState& op_s
   return bucket.remove_object(op_state);
 }
 
-static int bucket_stats(RGWRados *store, std::string&  bucket_name, Formatter *formatter)
+static int bucket_stats(RGWRados *store, std::string& tenant_name, std::string&  bucket_name, Formatter *formatter)
 {
   RGWBucketInfo bucket_info;
   rgw_bucket bucket;
@@ -1006,7 +1010,7 @@ static int bucket_stats(RGWRados *store, std::string&  bucket_name, Formatter *f
 
   time_t mtime;
   RGWObjectCtx obj_ctx(store);
-  int r = store->get_bucket_info(obj_ctx, bucket_name, bucket_info, &mtime);
+  int r = store->get_bucket_info(obj_ctx, tenant_name, bucket_name, bucket_info, &mtime);
   if (r < 0)
     return r;
 
@@ -1028,7 +1032,7 @@ static int bucket_stats(RGWRados *store, std::string&  bucket_name, Formatter *f
   formatter->dump_string("index_pool", bucket.index_pool);
   formatter->dump_string("id", bucket.bucket_id);
   formatter->dump_string("marker", bucket.marker);
-  formatter->dump_string("owner", bucket_info.owner);
+  ::encode_json("owner", bucket_info.owner, formatter);
   formatter->dump_string("ver", bucket_ver);
   formatter->dump_string("master_ver", master_ver);
   formatter->dump_stream("mtime") << ut;
@@ -1063,6 +1067,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
   size_t max_entries = cct->_conf->rgw_list_buckets_max_chunk;
 
   bool show_stats = op_state.will_fetch_stats();
+  rgw_user user_id = op_state.get_user_id();
   if (op_state.is_user_op()) {
     formatter->open_array_section("buckets");
 
@@ -1071,7 +1076,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
     bool done;
 
     do {
-      ret = rgw_read_user_buckets(store, op_state.get_user_id(), buckets, marker, max_entries, false);
+      ret = rgw_read_user_buckets(store, user_id, buckets, marker, max_entries, false);
       if (ret < 0)
         return ret;
 
@@ -1081,7 +1086,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
       for (iter = m.begin(); iter != m.end(); ++iter) {
         std::string  obj_name = iter->first;
         if (show_stats)
-          bucket_stats(store, obj_name, formatter);
+          bucket_stats(store, user_id.tenant, obj_name, formatter);
         else
           formatter->dump_string("bucket", obj_name);
 
@@ -1094,7 +1099,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
 
     formatter->close_section();
   } else if (!bucket_name.empty()) {
-    bucket_stats(store, bucket_name, formatter);
+    bucket_stats(store, user_id.tenant, bucket_name, formatter);
   } else {
     RGWAccessHandle handle;
 
@@ -1104,7 +1109,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
       while (store->list_buckets_next(obj, &handle) >= 0) {
 	formatter->dump_string("bucket", obj.key.name);
         if (show_stats)
-          bucket_stats(store, obj.key.name, formatter);
+          bucket_stats(store, user_id.tenant, obj.key.name, formatter);
       }
     }
 
@@ -1523,6 +1528,17 @@ public:
 
 class RGWBucketMetadataHandler : public RGWMetadataHandler {
 
+  /*
+   * The tenant_name is always returned on purpose. May be empty, of course.
+   */
+  static void parse_bucket(const string &bucket,
+                           string &tenant_name, string &bucket_name)
+  {
+    int pos = bucket.find('/');
+    tenant_name = bucket.substr(0, pos);
+    bucket_name = bucket.substr(pos + 1);
+  }
+
 public:
   string get_type() { return "bucket"; }
 
@@ -1534,7 +1550,9 @@ public:
     map<string, bufferlist> attrs;
     RGWObjectCtx obj_ctx(store);
 
-    int ret = store->get_bucket_entrypoint_info(obj_ctx, entry, be, &ot, &mtime, &attrs);
+    string tenant_name, bucket_name;
+    parse_bucket(entry, tenant_name, bucket_name);
+    int ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, be, &ot, &mtime, &attrs);
     if (ret < 0)
       return ret;
 
@@ -1556,7 +1574,9 @@ public:
     RGWObjVersionTracker old_ot;
     RGWObjectCtx obj_ctx(store);
 
-    int ret = store->get_bucket_entrypoint_info(obj_ctx, entry, old_be, &old_ot, &orig_mtime, &attrs);
+    string tenant_name, bucket_name;
+    parse_bucket(entry, tenant_name, bucket_name);
+    int ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, old_be, &old_ot, &orig_mtime, &attrs);
     if (ret < 0 && ret != -ENOENT)
       return ret;
 
@@ -1569,7 +1589,7 @@ public:
 
     objv_tracker.read_version = old_ot.read_version; /* maintain the obj version we just read */
 
-    ret = store->put_bucket_entrypoint_info(entry, be, false, objv_tracker, mtime, &attrs);
+    ret = store->put_bucket_entrypoint_info(tenant_name, bucket_name, be, false, objv_tracker, mtime, &attrs);
     if (ret < 0)
       return ret;
 
@@ -1577,7 +1597,7 @@ public:
     if (be.linked) {
       ret = rgw_link_bucket(store, be.owner, be.bucket, be.creation_time, false);
     } else {
-      ret = rgw_unlink_bucket(store, be.owner, be.bucket.name, false);
+      ret = rgw_unlink_bucket(store, be.owner, be.bucket.tenant, be.bucket.name, false);
     }
 
     return ret;
@@ -1592,7 +1612,9 @@ public:
     RGWBucketEntryPoint be;
     RGWObjectCtx obj_ctx(store);
 
-    int ret = store->get_bucket_entrypoint_info(obj_ctx, entry, be, &objv_tracker, NULL, NULL);
+    string tenant_name, bucket_name;
+    parse_bucket(entry, tenant_name, bucket_name);
+    int ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, be, &objv_tracker, NULL, NULL);
     if (ret < 0)
       return ret;
 
@@ -1601,7 +1623,7 @@ public:
      * it immediately and don't want to invalidate our cached objv_version or the bucket obj removal
      * will incorrectly fail.
      */
-    ret = rgw_unlink_bucket(store, be.owner, entry, false);
+    ret = rgw_unlink_bucket(store, be.owner, tenant_name, bucket_name, false);
     if (ret < 0) {
       lderr(store->ctx()) << "could not unlink bucket=" << entry << " owner=" << be.owner << dendl;
     }
@@ -1709,7 +1731,10 @@ public:
     if (!exists || old_bci.info.bucket.bucket_id != bci.info.bucket.bucket_id) {
       /* a new bucket, we need to select a new bucket placement for it */
       rgw_bucket bucket;
-      ret = store->set_bucket_location_by_rule(bci.info.placement_rule, oid, bucket);
+      // XXX woops, conflict with the model of set_bucket_location_by_rule:
+      // the bucket name is not oid now.
+      string empty_tenant = "";
+      ret = store->set_bucket_location_by_rule(bci.info.placement_rule, empty_tenant, oid, bucket);
       if (ret < 0) {
         ldout(store->ctx(), 0) << "ERROR: select_bucket_placement() returned " << ret << dendl;
         return ret;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -461,9 +461,15 @@ int rgw_remove_bucket(RGWRados *store, rgw_bucket& bucket, bool delete_children)
   return ret;
 }
 
-int rgw_bucket_delete_bucket_obj(RGWRados *store, string& bucket_name, RGWObjVersionTracker& objv_tracker)
+int rgw_bucket_delete_bucket_obj(RGWRados * const store,
+                                 const string& tenant_name,
+                                 const string& bucket_name,
+                                 RGWObjVersionTracker& objv_tracker)
 {
-  return store->meta_mgr->remove_entry(bucket_meta_handler, bucket_name, &objv_tracker);
+  string key;
+
+  store->make_bucket_entry_name(tenant_name, bucket_name, key);
+  return store->meta_mgr->remove_entry(bucket_meta_handler, key, &objv_tracker);
 }
 
 static void set_err_msg(std::string *sink, std::string msg)
@@ -1628,7 +1634,7 @@ public:
       lderr(store->ctx()) << "could not unlink bucket=" << entry << " owner=" << be.owner << dendl;
     }
 
-    ret = rgw_bucket_delete_bucket_obj(store, entry, objv_tracker);
+    ret = rgw_bucket_delete_bucket_obj(store, tenant_name, bucket_name, objv_tracker);
     if (ret < 0) {
       lderr(store->ctx()) << "could not delete bucket=" << entry << dendl;
     }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -344,7 +344,7 @@ void check_bad_user_bucket_mapping(RGWRados *store, const rgw_user& user_id, boo
       RGWBucketInfo bucket_info;
       time_t mtime;
       RGWObjectCtx obj_ctx(store);
-      int r = store->get_bucket_info(obj_ctx, user_id.tenant, bucket.name, bucket_info, &mtime);
+      int r = store->get_bucket_info(obj_ctx, user_id.get_bns().get_id(), bucket.name, bucket_info, &mtime);
       if (r < 0) {
         ldout(store->ctx(), 0) << "could not get bucket info for bucket=" << bucket << dendl;
         continue;
@@ -486,7 +486,7 @@ int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state)
   store = storage;
 
   rgw_user user_id = op_state.get_user_id();
-  tenant = user_id.tenant;
+  bucket_nspace = user_id.get_bns();
   bucket_name = op_state.get_bucket_name();
   RGWUserBuckets user_buckets;
   RGWObjectCtx obj_ctx(store);
@@ -495,7 +495,7 @@ int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state)
     return -EINVAL;
 
   if (!bucket_name.empty()) {
-    int r = store->get_bucket_info(obj_ctx, tenant, bucket_name, bucket_info, NULL);
+    int r = store->get_bucket_info(obj_ctx, bucket_nspace.get_id(), bucket_name, bucket_info, NULL);
     if (r < 0) {
       ldout(store->ctx(), 0) << "could not get bucket info for bucket=" << bucket_name << dendl;
       return r;
@@ -1008,7 +1008,7 @@ int RGWBucketAdminOp::remove_object(RGWRados *store, RGWBucketAdminOpState& op_s
   return bucket.remove_object(op_state);
 }
 
-static int bucket_stats(RGWRados *store, std::string& tenant_name, std::string&  bucket_name, Formatter *formatter)
+static int bucket_stats(RGWRados *store, const std::string& tenant_name, std::string&  bucket_name, Formatter *formatter)
 {
   RGWBucketInfo bucket_info;
   rgw_bucket bucket;
@@ -1092,7 +1092,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
       for (iter = m.begin(); iter != m.end(); ++iter) {
         std::string  obj_name = iter->first;
         if (show_stats)
-          bucket_stats(store, user_id.tenant, obj_name, formatter);
+          bucket_stats(store, user_id.get_bns().get_id(), obj_name, formatter);
         else
           formatter->dump_string("bucket", obj_name);
 
@@ -1105,7 +1105,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
 
     formatter->close_section();
   } else if (!bucket_name.empty()) {
-    bucket_stats(store, user_id.tenant, bucket_name, formatter);
+    bucket_stats(store, user_id.get_bns().get_id(), bucket_name, formatter);
   } else {
     RGWAccessHandle handle;
 
@@ -1115,7 +1115,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
       while (store->list_buckets_next(obj, &handle) >= 0) {
 	formatter->dump_string("bucket", obj.key.name);
         if (show_stats)
-          bucket_stats(store, user_id.tenant, obj.key.name, formatter);
+          bucket_stats(store, user_id.get_bns().get_id(), obj.key.name, formatter);
       }
     }
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -23,7 +23,7 @@
 using namespace std;
 
 // define as static when RGWBucket implementation compete
-extern void rgw_get_buckets_obj(const string& user_id, string& buckets_obj_id);
+extern void rgw_get_buckets_obj(const rgw_user& user_id, string& buckets_obj_id);
 
 extern int rgw_bucket_store_info(RGWRados *store, const string& bucket_name, bufferlist& bl, bool exclusive,
                                  map<string, bufferlist> *pattrs, RGWObjVersionTracker *objv_tracker,
@@ -38,8 +38,8 @@ extern int rgw_bucket_instance_remove_entry(RGWRados *store, string& entry, RGWO
 
 extern int rgw_bucket_delete_bucket_obj(RGWRados *store, string& bucket_name, RGWObjVersionTracker& objv_tracker);
 
-extern int rgw_bucket_sync_user_stats(RGWRados *store, const string& user_id, rgw_bucket& bucket);
-extern int rgw_bucket_sync_user_stats(RGWRados *store, const string& bucket_name);
+extern int rgw_bucket_sync_user_stats(RGWRados *store, const rgw_user& user_id, rgw_bucket& bucket);
+extern int rgw_bucket_sync_user_stats(RGWRados *store, const string& tenant_name, const string& bucket_name);
 
 /**
  * Store a list of the user's buckets, with associated functinos.
@@ -105,28 +105,29 @@ extern void rgw_bucket_init(RGWMetadataManager *mm);
  * Returns: 0 on success, -ERR# on failure.
  */
 extern int rgw_read_user_buckets(RGWRados *store,
-                                 string user_id,
+                                 const rgw_user& user_id,
                                  RGWUserBuckets& buckets,
                                  const string& marker,
                                  uint64_t max,
                                  bool need_stats,
                                  uint64_t default_amount = 1000);
 
-extern int rgw_link_bucket(RGWRados *store, string user_id, rgw_bucket& bucket, time_t creation_time, bool update_entrypoint = true);
-extern int rgw_unlink_bucket(RGWRados *store, string user_id, const string& bucket_name, bool update_entrypoint = true);
+extern int rgw_link_bucket(RGWRados *store, const rgw_user& user_id, rgw_bucket& bucket, time_t creation_time, bool update_entrypoint = true);
+extern int rgw_unlink_bucket(RGWRados *store, const rgw_user& user_id,
+                             const string& tenant_name, const string& bucket_name, bool update_entrypoint = true);
 
 extern int rgw_remove_object(RGWRados *store, RGWBucketInfo& bucket_info, rgw_bucket& bucket, rgw_obj_key& key);
-extern int rgw_remove_bucket(RGWRados *store, const string& bucket_owner, rgw_bucket& bucket, bool delete_children);
+extern int rgw_remove_bucket(RGWRados *store, rgw_bucket& bucket, bool delete_children);
 
 extern int rgw_bucket_set_attrs(RGWRados *store, RGWBucketInfo& bucket_info,
                                 map<string, bufferlist>& attrs,
                                 map<string, bufferlist>* rmattrs,
                                 RGWObjVersionTracker *objv_tracker);
 
-extern void check_bad_user_bucket_mapping(RGWRados *store, const string& user_id, bool fix);
+extern void check_bad_user_bucket_mapping(RGWRados *store, const rgw_user& user_id, bool fix);
 
 struct RGWBucketAdminOpState {
-  std::string uid;
+  rgw_user uid;
   std::string display_name;
   std::string bucket_name;
   std::string bucket_id;
@@ -146,7 +147,7 @@ struct RGWBucketAdminOpState {
   void set_fix_index(bool value) { fix_index = value; }
   void set_delete_children(bool value) { delete_child_objects = value; }
 
-  void set_user_id(std::string& user_id) {
+  void set_user_id(rgw_user& user_id) {
     if (!user_id.empty())
       uid = user_id;
   }
@@ -157,7 +158,7 @@ struct RGWBucketAdminOpState {
     object_name = object_str;
   }
 
-  std::string& get_user_id() { return uid; }
+  rgw_user& get_user_id() { return uid; }
   std::string& get_user_display_name() { return display_name; }
   std::string& get_bucket_name() { return bucket_name; }
   std::string& get_object_name() { return object_name; }
@@ -197,13 +198,12 @@ class RGWBucket
   RGWAccessHandle handle;
 
   RGWUserInfo user_info;
+  std::string tenant;
   std::string bucket_name;
 
   bool failure;
 
   RGWBucketInfo bucket_info;
-
-private:
 
 public:
   RGWBucket() : store(NULL), handle(NULL), failure(false) {}

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -201,7 +201,7 @@ class RGWBucket
   RGWAccessHandle handle;
 
   RGWUserInfo user_info;
-  std::string tenant;
+  rgw_bucket_namespace bucket_nspace;
   std::string bucket_name;
 
   bool failure;

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -36,7 +36,10 @@ extern int rgw_bucket_parse_bucket_instance(const string& bucket_instance, strin
 
 extern int rgw_bucket_instance_remove_entry(RGWRados *store, string& entry, RGWObjVersionTracker *objv_tracker);
 
-extern int rgw_bucket_delete_bucket_obj(RGWRados *store, string& bucket_name, RGWObjVersionTracker& objv_tracker);
+extern int rgw_bucket_delete_bucket_obj(RGWRados *store,
+                                        const string& tenant_name,
+                                        const string& bucket_name,
+                                        RGWObjVersionTracker& objv_tracker);
 
 extern int rgw_bucket_sync_user_stats(RGWRados *store, const rgw_user& user_id, rgw_bucket& bucket);
 extern int rgw_bucket_sync_user_stats(RGWRados *store, const string& tenant_name, const string& bucket_name);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1069,7 +1069,14 @@ struct req_state {
 
    bool has_bad_meta;
 
+   /* Identity used to authorize given RGWOp (used in verify_permission()
+    * method). It might be different than owner of the account (represented
+    * in radosgw by RGWUserInfo structure) we are operating on. */
+   rgw_user auth_user;
+
+   /* Account we are performing operations on. */
    RGWUserInfo user; 
+
    RGWAccessControlPolicy *bucket_acl;
    RGWAccessControlPolicy *object_acl;
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1068,7 +1068,6 @@ struct req_state {
    bool has_bad_meta;
 
    RGWUserInfo user; 
-   string tenant;
    RGWAccessControlPolicy *bucket_acl;
    RGWAccessControlPolicy *object_acl;
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -28,6 +28,7 @@
 #include "include/types.h"
 #include "include/utime.h"
 #include "rgw_acl.h"
+#include "rgw_basic_types.h"
 #include "rgw_cors.h"
 #include "rgw_quota.h"
 #include "rgw_string.h"
@@ -446,7 +447,7 @@ void decode_json_obj(obj_version& v, JSONObj *obj);
 struct RGWUserInfo
 {
   uint64_t auid;
-  string user_id;
+  rgw_user user_id;
   string display_name;
   string user_email;
   map<string, RGWAccessKey> access_keys;
@@ -466,7 +467,7 @@ struct RGWUserInfo
   RGWUserInfo() : auid(0), suspended(0), max_buckets(RGW_DEFAULT_MAX_BUCKETS), op_mask(RGW_OP_TYPE_ALL), system(0) {}
 
   void encode(bufferlist& bl) const {
-     ENCODE_START(16, 9, bl);
+     ENCODE_START(17, 9, bl);
      ::encode(auid, bl);
      string access_key;
      string secret_key;
@@ -490,7 +491,7 @@ struct RGWUserInfo
      }
      ::encode(swift_name, bl);
      ::encode(swift_key, bl);
-     ::encode(user_id, bl);
+     ::encode(user_id.id, bl);
      ::encode(access_keys, bl);
      ::encode(subusers, bl);
      ::encode(suspended, bl);
@@ -504,10 +505,11 @@ struct RGWUserInfo
      ::encode(bucket_quota, bl);
      ::encode(temp_url_keys, bl);
      ::encode(user_quota, bl);
+     ::encode(user_id.tenant, bl);
      ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-     DECODE_START_LEGACY_COMPAT_LEN_32(16, 9, 9, bl);
+     DECODE_START_LEGACY_COMPAT_LEN_32(17, 9, 9, bl);
      if (struct_v >= 2) ::decode(auid, bl);
      else auid = CEPH_AUTH_UID_DEFAULT;
      string access_key;
@@ -527,9 +529,9 @@ struct RGWUserInfo
     if (struct_v >= 3) ::decode(swift_name, bl);
     if (struct_v >= 4) ::decode(swift_key, bl);
     if (struct_v >= 5)
-      ::decode(user_id, bl);
+      ::decode(user_id.id, bl);
     else
-      user_id = access_key;
+      user_id.id = access_key;
     if (struct_v >= 6) {
       ::decode(access_keys, bl);
       ::decode(subusers, bl);
@@ -554,7 +556,6 @@ struct RGWUserInfo
     } else {
       op_mask = RGW_OP_TYPE_ALL;
     }
-    system = 0;
     if (struct_v >= 13) {
       ::decode(system, bl);
       ::decode(default_placement, bl);
@@ -569,25 +570,22 @@ struct RGWUserInfo
     if (struct_v >= 16) {
       ::decode(user_quota, bl);
     }
+    if (struct_v >= 17) {
+      ::decode(user_id.tenant, bl);
+    } else {
+      user_id.tenant.clear();
+    }
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
   static void generate_test_instances(list<RGWUserInfo*>& o);
 
   void decode_json(JSONObj *obj);
-
-  void clear() {
-    user_id.clear();
-    display_name.clear();
-    user_email.clear();
-    auid = CEPH_AUTH_UID_DEFAULT;
-    access_keys.clear();
-    suspended = 0;
-  }
 };
 WRITE_CLASS_ENCODER(RGWUserInfo)
 
 struct rgw_bucket {
+  std::string tenant;
   std::string name;
   std::string data_pool;
   std::string data_extra_pool; /* if not set, then we should use data_pool instead */
@@ -613,8 +611,8 @@ struct rgw_bucket {
     data_pool = index_pool = n;
     marker = "";
   }
-  rgw_bucket(const char *n, const char *dp, const char *ip, const char *m, const char *id, const char *h) :
-    name(n), data_pool(dp), index_pool(ip), marker(m), bucket_id(id) {}
+  rgw_bucket(const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id, const char *h) :
+    tenant(t), name(n), data_pool(dp), index_pool(ip), marker(m), bucket_id(id) {}
 
   void convert(cls_user_bucket *b) {
     b->name = name;
@@ -626,17 +624,18 @@ struct rgw_bucket {
   }
 
   void encode(bufferlist& bl) const {
-     ENCODE_START(7, 3, bl);
+     ENCODE_START(8, 3, bl);
     ::encode(name, bl);
     ::encode(data_pool, bl);
     ::encode(marker, bl);
     ::encode(bucket_id, bl);
     ::encode(index_pool, bl);
     ::encode(data_extra_pool, bl);
+    ::encode(tenant, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(7, 3, 3, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(8, 3, 3, bl);
     ::decode(name, bl);
     ::decode(data_pool, bl);
     if (struct_v >= 2) {
@@ -658,6 +657,9 @@ struct rgw_bucket {
     }
     if (struct_v >= 7) {
       ::decode(data_extra_pool, bl);
+    }
+    if (struct_v >= 8) {
+      ::decode(tenant, bl);
     }
     DECODE_FINISH(bl);
   }
@@ -771,7 +773,7 @@ struct RGWBucketInfo
   };
 
   rgw_bucket bucket;
-  string owner;
+  rgw_user owner;
   uint32_t flags;
   string region;
   time_t creation_time;
@@ -794,9 +796,9 @@ struct RGWBucketInfo
   const static uint32_t NUM_SHARDS_BLIND_BUCKET;
 
   void encode(bufferlist& bl) const {
-     ENCODE_START(11, 4, bl);
+     ENCODE_START(12, 4, bl);
      ::encode(bucket, bl);
-     ::encode(owner, bl);
+     ::encode(owner.id, bl);
      ::encode(flags, bl);
      ::encode(region, bl);
      uint64_t ct = (uint64_t)creation_time;
@@ -806,13 +808,17 @@ struct RGWBucketInfo
      ::encode(quota, bl);
      ::encode(num_shards, bl);
      ::encode(bucket_index_shard_hash_type, bl);
+     ::encode(owner, bl);
      ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN_32(9, 4, 4, bl);
+    DECODE_START_LEGACY_COMPAT_LEN_32(12, 4, 4, bl);
      ::decode(bucket, bl);
-     if (struct_v >= 2)
-       ::decode(owner, bl);
+     if (struct_v >= 2) {
+       string s;
+       ::decode(s, bl);
+       owner.from_str(s);
+     }
      if (struct_v >= 3)
        ::decode(flags, bl);
      if (struct_v >= 5)
@@ -832,6 +838,8 @@ struct RGWBucketInfo
        ::decode(num_shards, bl);
      if (struct_v >= 11)
        ::decode(bucket_index_shard_hash_type, bl);
+     if (struct_v >= 12)
+       ::decode(owner, bl);
      DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
@@ -850,7 +858,7 @@ WRITE_CLASS_ENCODER(RGWBucketInfo)
 struct RGWBucketEntryPoint
 {
   rgw_bucket bucket;
-  string owner;
+  rgw_user owner;
   time_t creation_time;
   bool linked;
 
@@ -860,17 +868,18 @@ struct RGWBucketEntryPoint
   RGWBucketEntryPoint() : creation_time(0), linked(false), has_bucket_info(false) {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(8, 8, bl);
+    ENCODE_START(9, 8, bl);
     ::encode(bucket, bl);
-    ::encode(owner, bl);
+    ::encode(owner.id, bl);
     ::encode(linked, bl);
     uint64_t ctime = (uint64_t)creation_time;
     ::encode(ctime, bl);
+    ::encode(owner, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
     bufferlist::iterator orig_iter = bl;
-    DECODE_START_LEGACY_COMPAT_LEN_32(8, 4, 4, bl);
+    DECODE_START_LEGACY_COMPAT_LEN_32(9, 4, 4, bl);
     if (struct_v < 8) {
       /* ouch, old entry, contains the bucket info itself */
       old_bucket_info.decode(orig_iter);
@@ -879,11 +888,14 @@ struct RGWBucketEntryPoint
     }
     has_bucket_info = false;
     ::decode(bucket, bl);
-    ::decode(owner, bl);
+    ::decode(owner.id, bl);
     ::decode(linked, bl);
     uint64_t ctime;
     ::decode(ctime, bl);
     creation_time = (uint64_t)ctime;
+    if (struct_v >= 9) {
+      ::decode(owner, bl);
+    }
     DECODE_FINISH(bl);
   }
 
@@ -1046,6 +1058,7 @@ struct req_state {
    bool has_bad_meta;
 
    RGWUserInfo user; 
+   string tenant;
    RGWAccessControlPolicy *bucket_acl;
    RGWAccessControlPolicy *object_acl;
 
@@ -1083,7 +1096,7 @@ struct req_state {
 struct RGWObjEnt {
   rgw_obj_key key;
   std::string ns;
-  std::string owner;
+  rgw_user owner;
   std::string owner_display_name;
   uint64_t size;
   utime_t mtime;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1050,6 +1050,8 @@ struct req_state {
    uint32_t perm_mask;
    utime_t header_time;
 
+   string account_name;
+
    rgw_bucket bucket;
    string bucket_name_str;
    rgw_obj_key object;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -464,10 +464,16 @@ struct RGWUserInfo
   map<int, string> temp_url_keys;
   RGWQuotaInfo user_quota;
 
-  RGWUserInfo() : auid(0), suspended(0), max_buckets(RGW_DEFAULT_MAX_BUCKETS), op_mask(RGW_OP_TYPE_ALL), system(0) {}
+  RGWUserInfo()
+    : auid(0),
+      suspended(0),
+      max_buckets(RGW_DEFAULT_MAX_BUCKETS),
+      op_mask(RGW_OP_TYPE_ALL),
+      system(0) {
+  }
 
   void encode(bufferlist& bl) const {
-     ENCODE_START(17, 9, bl);
+     ENCODE_START(18, 9, bl);
      ::encode(auid, bl);
      string access_key;
      string secret_key;
@@ -506,6 +512,7 @@ struct RGWUserInfo
      ::encode(temp_url_keys, bl);
      ::encode(user_quota, bl);
      ::encode(user_id.tenant, bl);
+     ::encode(user_id.has_own_bns, bl);
      ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
@@ -572,8 +579,15 @@ struct RGWUserInfo
     }
     if (struct_v >= 17) {
       ::decode(user_id.tenant, bl);
+      ::decode(user_id.has_own_bns, bl);
     } else {
       user_id.tenant.clear();
+      user_id.has_own_bns = false;
+    }
+    if (struct_v >= 18) {
+      ::decode(user_id.has_own_bns, bl);
+    } else {
+      user_id.has_own_bns = false;
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -511,7 +511,6 @@ struct RGWUserInfo
      ::encode(bucket_quota, bl);
      ::encode(temp_url_keys, bl);
      ::encode(user_quota, bl);
-     ::encode(user_id.tenant, bl);
      ::encode(user_id.has_own_bns, bl);
      ENCODE_FINISH(bl);
   }
@@ -577,12 +576,9 @@ struct RGWUserInfo
     if (struct_v >= 16) {
       ::decode(user_quota, bl);
     }
-    if (struct_v >= 17) {
-      ::decode(user_id.tenant, bl);
-      ::decode(user_id.has_own_bns, bl);
-    } else {
-      user_id.tenant.clear();
-      user_id.has_own_bns = false;
+    if (struct_v == 17) {
+      std::string _tenant_junk;
+      ::decode(_tenant_junk, bl);
     }
     if (struct_v >= 18) {
       ::decode(user_id.has_own_bns, bl);

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -17,7 +17,7 @@ void RGWObjManifestPart::generate_test_instances(std::list<RGWObjManifestPart*>&
   o.push_back(new RGWObjManifestPart);
 
   RGWObjManifestPart *p = new RGWObjManifestPart;
-  rgw_bucket b("bucket", ".pool", ".index_pool", "marker_", "12", "region");
+  rgw_bucket b("tenant", "bucket", ".pool", ".index_pool", "marker_", "12", "region");
   p->loc = rgw_obj(b, "object");
   p->loc_ofs = 512 * 1024;
   p->size = 128 * 1024;
@@ -133,7 +133,7 @@ void RGWObjManifest::generate_test_instances(std::list<RGWObjManifest*>& o)
   RGWObjManifest *m = new RGWObjManifest;
   for (int i = 0; i<10; i++) {
     RGWObjManifestPart p;
-    rgw_bucket b("bucket", ".pool", ".index_pool", "marker_", "12", "region");
+    rgw_bucket b("tenant", "bucket", ".pool", ".index_pool", "marker_", "12", "region");
     p.loc = rgw_obj(b, "object");
     p.loc_ofs = 0;
     p.size = 512 * 1024;
@@ -257,8 +257,8 @@ ACLGroupTypeEnum ACLGrant_S3::uri_to_group(string& uri)
 
 void ACLGrant::generate_test_instances(list<ACLGrant*>& o)
 {
-  string id, name, email;
-  id = "rgw";
+  rgw_user id("rgw");
+  string name, email;
   name = "Mr. RGW";
   email = "r@gw";
 
@@ -314,7 +314,7 @@ void RGWAccessControlPolicy::generate_test_instances(list<RGWAccessControlPolicy
     p->acl = *l;
 
     string name = "radosgw";
-    string id = "rgw";
+    rgw_user id("rgw");
     p->owner.set_name(name);
     p->owner.set_id(id);
 
@@ -404,7 +404,7 @@ void RGWUserInfo::generate_test_instances(list<RGWUserInfo*>& o)
 
 void rgw_bucket::generate_test_instances(list<rgw_bucket*>& o)
 {
-  rgw_bucket *b = new rgw_bucket("name", "pool", ".index_pool", "marker", "123", "region");
+  rgw_bucket *b = new rgw_bucket("tenant", "name", "pool", ".index_pool", "marker", "123", "region");
   o.push_back(b);
   o.push_back(new rgw_bucket);
 }
@@ -412,7 +412,7 @@ void rgw_bucket::generate_test_instances(list<rgw_bucket*>& o)
 void RGWBucketInfo::generate_test_instances(list<RGWBucketInfo*>& o)
 {
   RGWBucketInfo *i = new RGWBucketInfo;
-  i->bucket = rgw_bucket("bucket", "pool", ".index_pool", "marker", "10", "region");
+  i->bucket = rgw_bucket("tenant", "bucket", "pool", ".index_pool", "marker", "10", "region");
   i->owner = "owner";
   i->flags = BUCKET_SUSPENDED;
   o.push_back(i);
@@ -450,7 +450,7 @@ void RGWOLHInfo::generate_test_instances(list<RGWOLHInfo*> &o)
 void RGWBucketEnt::generate_test_instances(list<RGWBucketEnt*>& o)
 {
   RGWBucketEnt *e = new RGWBucketEnt;
-  e->bucket = rgw_bucket("bucket", "pool", ".index_pool", "marker", "10", "region");
+  e->bucket = rgw_bucket("tenant", "bucket", "pool", ".index_pool", "marker", "10", "region");
   e->size = 1024;
   e->size_rounded = 4096;
   e->count = 1;
@@ -470,7 +470,7 @@ void RGWUploadPartInfo::generate_test_instances(list<RGWUploadPartInfo*>& o)
 
 void rgw_obj::generate_test_instances(list<rgw_obj*>& o)
 {
-  rgw_bucket b = rgw_bucket("bucket", "pool", ".index_pool", "marker", "10", "region");
+  rgw_bucket b = rgw_bucket("tenant", "bucket", "pool", ".index_pool", "marker", "10", "region");
   rgw_obj *obj = new rgw_obj(b, "object");
   o.push_back(obj);
   o.push_back(new rgw_obj);

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -420,6 +420,7 @@ void RGWUserInfo::dump(Formatter *f) const
   encode_json("bucket_quota", bucket_quota, f);
   encode_json("user_quota", user_quota, f);
   encode_json("temp_url_keys", temp_url_keys, f);
+  encode_json("buckets_namespace", user_id.get_bns().get_id(), f);
 }
 
 
@@ -477,6 +478,12 @@ void RGWUserInfo::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("bucket_quota", bucket_quota, obj);
   JSONDecoder::decode_json("user_quota", user_quota, obj);
   JSONDecoder::decode_json("temp_url_keys", temp_url_keys, obj);
+
+  string bns;
+  JSONDecoder::decode_json("buckets_namespace", bns, obj);
+  if (bns.compare(user_id.id) == 0) {
+    user_id.has_own_bns = true;
+  }
 }
 
 void RGWQuotaInfo::dump(Formatter *f) const
@@ -495,6 +502,7 @@ void RGWQuotaInfo::decode_json(JSONObj *obj)
 
 void rgw_bucket::dump(Formatter *f) const
 {
+  encode_json("namespace", tenant, f);
   encode_json("name", name, f);
   encode_json("pool", data_pool, f);
   encode_json("data_extra_pool", data_extra_pool, f);
@@ -504,6 +512,7 @@ void rgw_bucket::dump(Formatter *f) const
 }
 
 void rgw_bucket::decode_json(JSONObj *obj) {
+  JSONDecoder::decode_json("namespace", tenant, obj);
   JSONDecoder::decode_json("name", name, obj);
   JSONDecoder::decode_json("pool", data_pool, obj);
   JSONDecoder::decode_json("data_extra_pool", data_extra_pool, obj);
@@ -546,7 +555,7 @@ void RGWBucketInfo::dump(Formatter *f) const
 {
   encode_json("bucket", bucket, f);
   encode_json("creation_time", creation_time, f);
-  encode_json("owner", owner.to_str(), f);
+  encode_json("owner", owner, f);
   encode_json("flags", flags, f);
   encode_json("region", region, f);
   encode_json("placement_rule", placement_rule, f);

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -9,6 +9,7 @@
 #include "rgw_cache.h"
 #include "rgw_bucket.h"
 #include "rgw_keystone.h"
+#include "rgw_basic_types.h"
 
 #include "common/ceph_json.h"
 #include "common/Formatter.h"
@@ -84,8 +85,8 @@ void RGWObjManifest::dump(Formatter *f) const
 
 void rgw_log_entry::dump(Formatter *f) const
 {
-  f->dump_string("object_owner", object_owner);
-  f->dump_string("bucket_owner", bucket_owner);
+  f->dump_string("object_owner", object_owner.to_str());
+  f->dump_string("bucket_owner", bucket_owner.to_str());
   f->dump_string("bucket", bucket);
   f->dump_stream("time") << time;
   f->dump_string("remote_addr", remote_addr);
@@ -122,7 +123,7 @@ void ACLGrant::dump(Formatter *f) const
   type.dump(f);
   f->close_section();
 
-  f->dump_string("id", id);
+  f->dump_string("id", id.to_str());
   f->dump_string("email", email);
 
   f->open_object_section("permission");
@@ -170,7 +171,7 @@ void RGWAccessControlList::dump(Formatter *f) const
 
 void ACLOwner::dump(Formatter *f) const
 {
-  encode_json("id", id, f);
+  encode_json("id", id.to_str(), f);
   encode_json("display_name", display_name, f);
 }
 
@@ -375,25 +376,25 @@ void RGWSubUser::decode_json(JSONObj *obj)
 static void user_info_dump_subuser(const char *name, const RGWSubUser& subuser, Formatter *f, void *parent)
 {
   RGWUserInfo *info = static_cast<RGWUserInfo *>(parent);
-  subuser.dump(f, info->user_id);
+  subuser.dump(f, info->user_id.to_str());
 }
 
 static void user_info_dump_key(const char *name, const RGWAccessKey& key, Formatter *f, void *parent)
 {
   RGWUserInfo *info = static_cast<RGWUserInfo *>(parent);
-  key.dump(f, info->user_id, false);
+  key.dump(f, info->user_id.to_str(), false);
 }
 
 static void user_info_dump_swift_key(const char *name, const RGWAccessKey& key, Formatter *f, void *parent)
 {
   RGWUserInfo *info = static_cast<RGWUserInfo *>(parent);
-  key.dump(f, info->user_id, true);
+  key.dump(f, info->user_id.to_str(), true);
 }
 
 void RGWUserInfo::dump(Formatter *f) const
 {
 
-  encode_json("user_id", user_id, f);
+  encode_json("user_id", user_id.to_str(), f);
   encode_json("display_name", display_name, f);
   encode_json("email", user_email, f);
   encode_json("suspended", (int)suspended, f);
@@ -445,7 +446,11 @@ static void decode_subusers(map<string, RGWSubUser>& m, JSONObj *o)
 
 void RGWUserInfo::decode_json(JSONObj *obj)
 {
-  JSONDecoder::decode_json("user_id", user_id, obj, true);
+  string uid;
+
+  JSONDecoder::decode_json("user_id", uid, obj, true);
+  user_id.from_str(uid);
+
   JSONDecoder::decode_json("display_name", display_name, obj);
   JSONDecoder::decode_json("email", user_email, obj);
   bool susp = false;
@@ -541,7 +546,7 @@ void RGWBucketInfo::dump(Formatter *f) const
 {
   encode_json("bucket", bucket, f);
   encode_json("creation_time", creation_time, f);
-  encode_json("owner", owner, f);
+  encode_json("owner", owner.to_str(), f);
   encode_json("flags", flags, f);
   encode_json("region", region, f);
   encode_json("placement_rule", placement_rule, f);
@@ -571,7 +576,7 @@ void RGWObjEnt::dump(Formatter *f) const
   encode_json("name", key.name, f);
   encode_json("instance", key.instance, f);
   encode_json("namespace", ns, f);
-  encode_json("owner", owner, f);
+  encode_json("owner", owner.to_str(), f);
   encode_json("owner_display_name", owner_display_name, f);
   encode_json("size", size, f);
   encode_json("mtime", mtime, f);

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -14,9 +14,9 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-bool KeystoneToken::User::has_role(const string& r) {
-  list<Role>::iterator iter;
-  for (iter = roles.begin(); iter != roles.end(); ++iter) {
+bool KeystoneToken::User::has_role(const string& r) const {
+  list<Role>::const_iterator iter;
+  for (iter = roles.cbegin(); iter != roles.cend(); ++iter) {
       if (fnmatch(r.c_str(), ((*iter).name.c_str()), 0) == 0) {
         return true;
       }

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -63,7 +63,7 @@ public:
     string user_name;
     list<Role> roles;
     void decode_json(JSONObj *obj);
-    bool has_role(const string& r);
+    bool has_role(const string& r) const;
   };
 
   Metadata metadata;

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -12,8 +12,8 @@
 class RGWRados;
 
 struct rgw_log_entry {
-  string object_owner;
-  string bucket_owner;
+  rgw_user object_owner;
+  rgw_user bucket_owner;
   string bucket;
   utime_t time;
   string remote_addr;
@@ -32,9 +32,9 @@ struct rgw_log_entry {
   string bucket_id;
 
   void encode(bufferlist &bl) const {
-    ENCODE_START(7, 5, bl);
-    ::encode(object_owner, bl);
-    ::encode(bucket_owner, bl);
+    ENCODE_START(8, 5, bl);
+    ::encode(object_owner.id, bl);
+    ::encode(bucket_owner.id, bl);
     ::encode(bucket, bl);
     ::encode(time, bl);
     ::encode(remote_addr, bl);
@@ -52,13 +52,15 @@ struct rgw_log_entry {
     ::encode(bytes_received, bl);
     ::encode(bucket_id, bl);
     ::encode(obj, bl);
+    ::encode(object_owner, bl);
+    ::encode(bucket_owner, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator &p) {
-    DECODE_START_LEGACY_COMPAT_LEN(7, 5, 5, p);
-    ::decode(object_owner, p);
+    DECODE_START_LEGACY_COMPAT_LEN(8, 5, 5, p);
+    ::decode(object_owner.id, p);
     if (struct_v > 3)
-      ::decode(bucket_owner, p);
+      ::decode(bucket_owner.id, p);
     ::decode(bucket, p);
     ::decode(time, p);
     ::decode(remote_addr, p);
@@ -93,6 +95,10 @@ struct rgw_log_entry {
     }
     if (struct_v >= 7) {
       ::decode(obj, p);
+    }
+    if (struct_v >= 8) {
+      ::decode(object_owner, p);
+      ::decode(bucket_owner, p);
     }
     DECODE_FINISH(p);
   }

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -918,12 +918,14 @@ public:
 
     pprocess = pp;
 
-    string uid;
-    conf->get_val("uid", "", &uid);
-    if (uid.empty()) {
+    string uid_str;
+    conf->get_val("uid", "", &uid_str);
+    if (uid_str.empty()) {
       derr << "ERROR: uid param must be specified for loadgen frontend" << dendl;
       return EINVAL;
     }
+
+    rgw_user uid(uid_str);
 
     RGWUserInfo user_info;
     int ret = rgw_get_user_info_by_uid(env.store, uid, user_info, NULL);

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -607,8 +607,10 @@ int RGWMetadataManager::remove_entry(RGWMetadataHandler *handler, string& key, R
   return 0;
 }
 
-int RGWMetadataManager::set_attrs(RGWMetadataHandler *handler, string& key,
-                                  rgw_obj& obj, map<string, bufferlist>& attrs,
+int RGWMetadataManager::set_attrs(RGWMetadataHandler *handler,
+                                  const string& key,
+                                  rgw_obj& obj,
+                                  map<string, bufferlist>& attrs,
                                   map<string, bufferlist>* rmattrs,
                                   RGWObjVersionTracker *objv_tracker)
 {

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -273,10 +273,6 @@ RGWMetadataHandler *RGWMetadataManager::get_handler(const char *type)
 void RGWMetadataManager::parse_metadata_key(const string& metadata_key, string& type, string& entry)
 {
   int pos = metadata_key.find(':');
-  if (pos < 0) {
-    type = metadata_key;
-  }
-
   type = metadata_key.substr(0, pos);
   entry = metadata_key.substr(pos + 1);
 }

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -193,8 +193,10 @@ public:
   int remove_entry(RGWMetadataHandler *handler, string& key, RGWObjVersionTracker *objv_tracker);
   int set_attr(RGWMetadataHandler *handler, string& key, rgw_obj& obj, string& attr, bufferlist& bl,
                RGWObjVersionTracker *objv_tracker);
-  int set_attrs(RGWMetadataHandler *handler, string& key,
-                rgw_obj& obj, map<string, bufferlist>& attrs,
+  int set_attrs(RGWMetadataHandler *handler,
+                const string& key,
+                rgw_obj& obj,
+                map<string, bufferlist>& attrs,
                 map<string, bufferlist>* rmattrs,
                 RGWObjVersionTracker *objv_tracker);
   int get(string& metadata_key, Formatter *f);

--- a/src/rgw/rgw_object_expirer_core.cc
+++ b/src/rgw/rgw_object_expirer_core.cc
@@ -39,13 +39,16 @@ using namespace std;
 
 static string objexp_lock_name = "gc_process";
 
-int RGWObjectExpirer::init_bucket_info(const string& bucket_name,
-                                    const string& bucket_id,
-                                    RGWBucketInfo& bucket_info)
+int RGWObjectExpirer::init_bucket_info(const string& bucket_namespace,
+                                       const string& bucket_name,
+                                       const string& bucket_id,
+                                       RGWBucketInfo& bucket_info)
 {
   RGWObjectCtx obj_ctx(store);
-  const string bucket_instance_id = bucket_name + ":" + bucket_id;
+  string bucket_instance_id;
 
+  store->get_bucket_instance_entry(bucket_namespace, bucket_name, bucket_id,
+          bucket_instance_id);
   int ret = store->get_bucket_instance_info(obj_ctx, bucket_instance_id,
           bucket_info, NULL, NULL);
 
@@ -56,9 +59,11 @@ int RGWObjectExpirer::garbage_single_object(objexp_hint_entry& hint)
 {
   RGWBucketInfo bucket_info;
 
-  int ret = init_bucket_info(hint.bucket_name, hint.bucket_id, bucket_info);
+  int ret = init_bucket_info(hint.bucket_namespace, hint.bucket_name,
+          hint.bucket_id, bucket_info);
   if (ret < 0) {
-    ldout(store->ctx(), 1) << "ERROR: could not init bucket: " << cpp_strerror(-ret) << dendl;
+    ldout(store->ctx(), 1) << "ERROR: could not init bucket: " << \
+        cpp_strerror(-ret) << dendl;
     return ret;
   }
 
@@ -153,10 +158,11 @@ void RGWObjectExpirer::process_single_shard(const string& shard,
   do {
     list<cls_timeindex_entry> entries;
     ret = store->objexp_hint_list(shard, last_run, round_start,
-                                      num_entries, marker, entries,
-                                      &out_marker, &truncated);
+                                  num_entries, marker, entries,
+                                  &out_marker, &truncated);
     if (ret < 0) {
-      ldout(cct, 10) << "cannot get removal hints from shard: " << shard << dendl;
+      ldout(cct, 10) << "cannot get removal hints from shard: " << shard \
+          << ", ret = " << ret << dendl;
       continue;
     }
 

--- a/src/rgw/rgw_object_expirer_core.h
+++ b/src/rgw/rgw_object_expirer_core.h
@@ -41,7 +41,8 @@ class RGWObjectExpirer {
 protected:
   RGWRados *store;
 
-  int init_bucket_info(const string& bucket_name,
+  int init_bucket_info(const string& bucket_namespace,
+                       const string& bucket_name,
                        const string& bucket_id,
                        RGWBucketInfo& bucket_info);
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1345,7 +1345,7 @@ int RGWGetBucketLocation::verify_permission()
 
 int RGWCreateBucket::verify_permission()
 {
-  if (!rgw_user_is_authenticated(s->user)) {
+  if (!rgw_user_is_authenticated(s->auth_user)) {
     return -EACCES;
   }
 
@@ -2261,7 +2261,7 @@ int RGWPutMetadataAccount::handle_temp_url_update(const map<int, string>& temp_u
 
 int RGWPutMetadataAccount::verify_permission()
 {
-  if (!rgw_user_is_authenticated(s->user)) {
+  if (!rgw_user_is_authenticated(s->auth_user)) {
     return -EACCES;
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1477,6 +1477,7 @@ void RGWCreateBucket::execute()
     attrs[RGW_ATTR_CORS] = corsbl;
   }
   s->bucket.name = s->bucket_name_str;
+  s->bucket.tenant = s->tenant;
   ret = store->create_bucket(s->user, s->bucket, region_name, placement_rule, attrs, info, pobjv,
                              &ep_objv, creation_time, pmaster_bucket, true);
   /* continue if EEXIST and create_bucket will fail below.  this way we can recover

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1459,8 +1459,12 @@ void RGWCreateBucket::execute()
   if (s->bucket_exists) {
     string selected_placement_rule;
     rgw_bucket bucket;
-    ret = store->select_bucket_placement(s->user, region_name, placement_rule,
-                                         s->user.user_id.tenant, s->bucket_name_str, bucket,
+    ret = store->select_bucket_placement(s->user,
+                                         region_name,
+                                         placement_rule,
+                                         s->user.user_id.get_bns().get_id(),
+                                         s->bucket_name_str,
+                                         bucket,
                                          &selected_placement_rule);
     if (selected_placement_rule != s->bucket_info.placement_rule) {
       ret = -EEXIST;

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -58,14 +58,14 @@ protected:
     }
   };
 
-  virtual int fetch_stats_from_storage(const string& user, rgw_bucket& bucket, RGWStorageStats& stats) = 0;
+  virtual int fetch_stats_from_storage(const rgw_user& user, rgw_bucket& bucket, RGWStorageStats& stats) = 0;
 
-  virtual bool map_find(const string& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) = 0;
+  virtual bool map_find(const rgw_user& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) = 0;
 
-  virtual bool map_find_and_update(const string& user, rgw_bucket& bucket, typename lru_map<T, RGWQuotaCacheStats>::UpdateContext *ctx) = 0;
-  virtual void map_add(const string& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) = 0;
+  virtual bool map_find_and_update(const rgw_user& user, rgw_bucket& bucket, typename lru_map<T, RGWQuotaCacheStats>::UpdateContext *ctx) = 0;
+  virtual void map_add(const rgw_user& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) = 0;
 
-  virtual void data_modified(const string& user, rgw_bucket& bucket) {}
+  virtual void data_modified(const rgw_user& user, rgw_bucket& bucket) {}
 public:
   RGWQuotaCache(RGWRados *_store, int size) : store(_store), stats_map(size) {
     async_refcount = new RefCountedWaitObject;
@@ -74,14 +74,14 @@ public:
     async_refcount->put_wait(); /* wait for all pending async requests to complete */
   }
 
-  int get_stats(const string& user, rgw_bucket& bucket, RGWStorageStats& stats, RGWQuotaInfo& quota);
-  void adjust_stats(const string& user, rgw_bucket& bucket, int objs_delta, uint64_t added_bytes, uint64_t removed_bytes);
+  int get_stats(const rgw_user& user, rgw_bucket& bucket, RGWStorageStats& stats, RGWQuotaInfo& quota);
+  void adjust_stats(const rgw_user& user, rgw_bucket& bucket, int objs_delta, uint64_t added_bytes, uint64_t removed_bytes);
 
   virtual bool can_use_cached_stats(RGWQuotaInfo& quota, RGWStorageStats& stats);
 
-  void set_stats(const string& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs, RGWStorageStats& stats);
-  int async_refresh(const string& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs);
-  void async_refresh_response(const string& user, rgw_bucket& bucket, RGWStorageStats& stats);
+  void set_stats(const rgw_user& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs, RGWStorageStats& stats);
+  int async_refresh(const rgw_user& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs);
+  void async_refresh_response(const rgw_user& user, rgw_bucket& bucket, RGWStorageStats& stats);
 
   class AsyncRefreshHandler {
   protected:
@@ -95,7 +95,7 @@ public:
     virtual void drop_reference() = 0;
   };
 
-  virtual AsyncRefreshHandler *allocate_refresh_handler(const string& user, rgw_bucket& bucket) = 0;
+  virtual AsyncRefreshHandler *allocate_refresh_handler(const rgw_user& user, rgw_bucket& bucket) = 0;
 };
 
 template<class T>
@@ -129,7 +129,7 @@ bool RGWQuotaCache<T>::can_use_cached_stats(RGWQuotaInfo& quota, RGWStorageStats
 }
 
 template<class T>
-int RGWQuotaCache<T>::async_refresh(const string& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs)
+int RGWQuotaCache<T>::async_refresh(const rgw_user& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs)
 {
   /* protect against multiple updates */
   StatsAsyncTestSet test_update;
@@ -154,7 +154,7 @@ int RGWQuotaCache<T>::async_refresh(const string& user, rgw_bucket& bucket, RGWQ
 }
 
 template<class T>
-void RGWQuotaCache<T>::async_refresh_response(const string& user, rgw_bucket& bucket, RGWStorageStats& stats)
+void RGWQuotaCache<T>::async_refresh_response(const rgw_user& user, rgw_bucket& bucket, RGWStorageStats& stats)
 {
   ldout(store->ctx(), 20) << "async stats refresh response for bucket=" << bucket << dendl;
 
@@ -168,7 +168,7 @@ void RGWQuotaCache<T>::async_refresh_response(const string& user, rgw_bucket& bu
 }
 
 template<class T>
-void RGWQuotaCache<T>::set_stats(const string& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs, RGWStorageStats& stats)
+void RGWQuotaCache<T>::set_stats(const rgw_user& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs, RGWStorageStats& stats)
 {
   qs.stats = stats;
   qs.expiration = ceph_clock_now(store->ctx());
@@ -180,7 +180,7 @@ void RGWQuotaCache<T>::set_stats(const string& user, rgw_bucket& bucket, RGWQuot
 }
 
 template<class T>
-int RGWQuotaCache<T>::get_stats(const string& user, rgw_bucket& bucket, RGWStorageStats& stats, RGWQuotaInfo& quota) {
+int RGWQuotaCache<T>::get_stats(const rgw_user& user, rgw_bucket& bucket, RGWStorageStats& stats, RGWQuotaInfo& quota) {
   RGWQuotaCacheStats qs;
   utime_t now = ceph_clock_now(store->ctx());
   if (map_find(user, bucket, qs)) {
@@ -231,7 +231,7 @@ public:
 
 
 template<class T>
-void RGWQuotaCache<T>::adjust_stats(const string& user, rgw_bucket& bucket, int objs_delta,
+void RGWQuotaCache<T>::adjust_stats(const rgw_user& user, rgw_bucket& bucket, int objs_delta,
                                  uint64_t added_bytes, uint64_t removed_bytes)
 {
   RGWQuotaStatsUpdate<T> update(objs_delta, added_bytes, removed_bytes);
@@ -242,10 +242,10 @@ void RGWQuotaCache<T>::adjust_stats(const string& user, rgw_bucket& bucket, int 
 
 class BucketAsyncRefreshHandler : public RGWQuotaCache<rgw_bucket>::AsyncRefreshHandler,
                                   public RGWGetBucketStats_CB {
-  string user;
+  rgw_user user;
 public:
   BucketAsyncRefreshHandler(RGWRados *_store, RGWQuotaCache<rgw_bucket> *_cache,
-                            const string& _user, rgw_bucket& _bucket) :
+                            const rgw_user& _user, rgw_bucket& _bucket) :
                                       RGWQuotaCache<rgw_bucket>::AsyncRefreshHandler(_store, _cache),
                                       RGWGetBucketStats_CB(_bucket), user(_user) {}
 
@@ -291,30 +291,30 @@ void BucketAsyncRefreshHandler::handle_response(int r)
 
 class RGWBucketStatsCache : public RGWQuotaCache<rgw_bucket> {
 protected:
-  bool map_find(const string& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) {
+  bool map_find(const rgw_user& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) {
     return stats_map.find(bucket, qs);
   }
 
-  bool map_find_and_update(const string& user, rgw_bucket& bucket, lru_map<rgw_bucket, RGWQuotaCacheStats>::UpdateContext *ctx) {
+  bool map_find_and_update(const rgw_user& user, rgw_bucket& bucket, lru_map<rgw_bucket, RGWQuotaCacheStats>::UpdateContext *ctx) {
     return stats_map.find_and_update(bucket, NULL, ctx);
   }
 
-  void map_add(const string& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) {
+  void map_add(const rgw_user& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) {
     stats_map.add(bucket, qs);
   }
 
-  int fetch_stats_from_storage(const string& user, rgw_bucket& bucket, RGWStorageStats& stats);
+  int fetch_stats_from_storage(const rgw_user& user, rgw_bucket& bucket, RGWStorageStats& stats);
 
 public:
   RGWBucketStatsCache(RGWRados *_store) : RGWQuotaCache<rgw_bucket>(_store, _store->ctx()->_conf->rgw_bucket_quota_cache_size) {
   }
 
-  AsyncRefreshHandler *allocate_refresh_handler(const string& user, rgw_bucket& bucket) {
+  AsyncRefreshHandler *allocate_refresh_handler(const rgw_user& user, rgw_bucket& bucket) {
     return new BucketAsyncRefreshHandler(store, this, user, bucket);
   }
 };
 
-int RGWBucketStatsCache::fetch_stats_from_storage(const string& user, rgw_bucket& bucket, RGWStorageStats& stats)
+int RGWBucketStatsCache::fetch_stats_from_storage(const rgw_user& user, rgw_bucket& bucket, RGWStorageStats& stats)
 {
   RGWBucketInfo bucket_info;
 
@@ -341,13 +341,13 @@ int RGWBucketStatsCache::fetch_stats_from_storage(const string& user, rgw_bucket
   return 0;
 }
 
-class UserAsyncRefreshHandler : public RGWQuotaCache<string>::AsyncRefreshHandler,
+class UserAsyncRefreshHandler : public RGWQuotaCache<rgw_user>::AsyncRefreshHandler,
                                 public RGWGetUserStats_CB {
   rgw_bucket bucket;
 public:
-  UserAsyncRefreshHandler(RGWRados *_store, RGWQuotaCache<string> *_cache,
-                          const string& _user, rgw_bucket& _bucket) :
-                          RGWQuotaCache<string>::AsyncRefreshHandler(_store, _cache),
+  UserAsyncRefreshHandler(RGWRados *_store, RGWQuotaCache<rgw_user> *_cache,
+                          const rgw_user& _user, rgw_bucket& _bucket) :
+                          RGWQuotaCache<rgw_user>::AsyncRefreshHandler(_store, _cache),
                           RGWGetUserStats_CB(_user),
                           bucket(_bucket) {}
 
@@ -380,10 +380,10 @@ void UserAsyncRefreshHandler::handle_response(int r)
   cache->async_refresh_response(user, bucket, stats);
 }
 
-class RGWUserStatsCache : public RGWQuotaCache<string> {
+class RGWUserStatsCache : public RGWQuotaCache<rgw_user> {
   atomic_t down_flag;
   RWLock rwlock;
-  map<rgw_bucket, string> modified_buckets;
+  map<rgw_bucket, rgw_user> modified_buckets;
 
   /* thread, sync recent modified buckets info */
   class BucketsSyncThread : public Thread {
@@ -399,13 +399,13 @@ class RGWUserStatsCache : public RGWQuotaCache<string> {
     void *entry() {
       ldout(cct, 20) << "BucketsSyncThread: start" << dendl;
       do {
-        map<rgw_bucket, string> buckets;
+        map<rgw_bucket, rgw_user> buckets;
 
         stats->swap_modified_buckets(buckets);
 
-        for (map<rgw_bucket, string>::iterator iter = buckets.begin(); iter != buckets.end(); ++iter) {
+        for (map<rgw_bucket, rgw_user>::iterator iter = buckets.begin(); iter != buckets.end(); ++iter) {
           rgw_bucket bucket = iter->first;
-          string& user = iter->second;
+          rgw_user& user = iter->second;
           ldout(cct, 20) << "BucketsSyncThread: sync user=" << user << " bucket=" << bucket << dendl;
           int r = stats->sync_bucket(user, bucket);
           if (r < 0) {
@@ -474,26 +474,26 @@ class RGWUserStatsCache : public RGWQuotaCache<string> {
   BucketsSyncThread *buckets_sync_thread;
   UserSyncThread *user_sync_thread;
 protected:
-  bool map_find(const string& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) {
+  bool map_find(const rgw_user& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) {
     return stats_map.find(user, qs);
   }
 
-  bool map_find_and_update(const string& user, rgw_bucket& bucket, lru_map<string, RGWQuotaCacheStats>::UpdateContext *ctx) {
+  bool map_find_and_update(const rgw_user& user, rgw_bucket& bucket, lru_map<rgw_user, RGWQuotaCacheStats>::UpdateContext *ctx) {
     return stats_map.find_and_update(user, NULL, ctx);
   }
 
-  void map_add(const string& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) {
+  void map_add(const rgw_user& user, rgw_bucket& bucket, RGWQuotaCacheStats& qs) {
     stats_map.add(user, qs);
   }
 
-  int fetch_stats_from_storage(const string& user, rgw_bucket& bucket, RGWStorageStats& stats);
-  int sync_bucket(const string& user, rgw_bucket& bucket);
-  int sync_user(const string& user);
+  int fetch_stats_from_storage(const rgw_user& user, rgw_bucket& bucket, RGWStorageStats& stats);
+  int sync_bucket(const rgw_user& rgw_user, rgw_bucket& bucket);
+  int sync_user(const rgw_user& user);
   int sync_all_users();
 
-  void data_modified(const string& user, rgw_bucket& bucket);
+  void data_modified(const rgw_user& user, rgw_bucket& bucket);
 
-  void swap_modified_buckets(map<rgw_bucket, string>& out) {
+  void swap_modified_buckets(map<rgw_bucket, rgw_user>& out) {
     rwlock.get_write();
     modified_buckets.swap(out);
     rwlock.unlock();
@@ -512,7 +512,7 @@ protected:
   }
 
 public:
-  RGWUserStatsCache(RGWRados *_store, bool quota_threads) : RGWQuotaCache<string>(_store, _store->ctx()->_conf->rgw_bucket_quota_cache_size),
+  RGWUserStatsCache(RGWRados *_store, bool quota_threads) : RGWQuotaCache<rgw_user>(_store, _store->ctx()->_conf->rgw_bucket_quota_cache_size),
                                         rwlock("RGWUserStatsCache::rwlock") {
     if (quota_threads) {
       buckets_sync_thread = new BucketsSyncThread(store->ctx(), this);
@@ -528,7 +528,7 @@ public:
     stop();
   }
 
-  AsyncRefreshHandler *allocate_refresh_handler(const string& user, rgw_bucket& bucket) {
+  AsyncRefreshHandler *allocate_refresh_handler(const rgw_user& user, rgw_bucket& bucket) {
     return new UserAsyncRefreshHandler(store, this, user, bucket);
   }
 
@@ -552,7 +552,7 @@ public:
   }
 };
 
-int RGWUserStatsCache::fetch_stats_from_storage(const string& user, rgw_bucket& bucket, RGWStorageStats& stats)
+int RGWUserStatsCache::fetch_stats_from_storage(const rgw_user& user, rgw_bucket& bucket, RGWStorageStats& stats)
 {
   int r = store->get_user_stats(user, stats);
   if (r < 0) {
@@ -563,7 +563,7 @@ int RGWUserStatsCache::fetch_stats_from_storage(const string& user, rgw_bucket& 
   return 0;
 }
 
-int RGWUserStatsCache::sync_bucket(const string& user, rgw_bucket& bucket)
+int RGWUserStatsCache::sync_bucket(const rgw_user& user, rgw_bucket& bucket)
 {
   int r = rgw_bucket_sync_user_stats(store, user, bucket);
   if (r < 0) {
@@ -574,10 +574,11 @@ int RGWUserStatsCache::sync_bucket(const string& user, rgw_bucket& bucket)
   return 0;
 }
 
-int RGWUserStatsCache::sync_user(const string& user)
+int RGWUserStatsCache::sync_user(const rgw_user& user)
 {
   cls_user_header header;
-  int ret = store->cls_user_get_header(user, &header);
+  string user_str = user.to_str();
+  int ret = store->cls_user_get_header(user_str, &header);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: can't read user header: ret=" << ret << dendl;
     return ret;
@@ -627,7 +628,7 @@ int RGWUserStatsCache::sync_all_users()
     for (list<string>::iterator iter = keys.begin();
          iter != keys.end() && !going_down(); 
          ++iter) {
-      string& user = *iter;
+      rgw_user user(*iter);
       ldout(store->ctx(), 20) << "RGWUserStatsCache: sync user=" << user << dendl;
       int ret = sync_user(user);
       if (ret < 0) {
@@ -645,7 +646,7 @@ done:
   return ret;
 }
 
-void RGWUserStatsCache::data_modified(const string& user, rgw_bucket& bucket)
+void RGWUserStatsCache::data_modified(const rgw_user& user, rgw_bucket& bucket)
 {
   /* racy, but it's ok */
   rwlock.get_read();
@@ -688,7 +689,7 @@ class RGWQuotaHandlerImpl : public RGWQuotaHandler {
   }
 public:
   RGWQuotaHandlerImpl(RGWRados *_store, bool quota_threads) : store(_store), bucket_stats_cache(_store), user_stats_cache(_store, quota_threads) {}
-  virtual int check_quota(const string& user, rgw_bucket& bucket,
+  virtual int check_quota(const rgw_user& user, rgw_bucket& bucket,
                           RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota,
 			  uint64_t num_objs, uint64_t size) {
 
@@ -730,7 +731,7 @@ public:
     return 0;
   }
 
-  virtual void update_stats(const string& user, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) {
+  virtual void update_stats(const rgw_user& user, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) {
     bucket_stats_cache.adjust_stats(user, bucket, obj_delta, added_bytes, removed_bytes);
     user_stats_cache.adjust_stats(user, bucket, obj_delta, added_bytes, removed_bytes);
   }

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -62,11 +62,11 @@ public:
   RGWQuotaHandler() {}
   virtual ~RGWQuotaHandler() {
   }
-  virtual int check_quota(const string& bucket_owner, rgw_bucket& bucket,
+  virtual int check_quota(const rgw_user& bucket_owner, rgw_bucket& bucket,
                           RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota,
 			  uint64_t num_objs, uint64_t size) = 0;
 
-  virtual void update_stats(const string& bucket_owner, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) = 0;
+  virtual void update_stats(const rgw_user& bucket_owner, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) = 0;
 
   static RGWQuotaHandler *generate_handler(RGWRados *store, bool quota_threads);
   static void free_handler(RGWQuotaHandler *handler);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7609,11 +7609,17 @@ void RGWRados::make_bucket_entry_name(const string& tenant_name, const string& b
 }
 
 int RGWRados::get_bucket_info(RGWObjectCtx& obj_ctx,
-                              const string& tenant, const string& bucket_name, RGWBucketInfo& info,
-                              time_t *pmtime, map<string, bufferlist> *pattrs)
+                              const string& tenant,
+                              const string& bucket_name,
+                              RGWBucketInfo& info,                      /* out */
+                              time_t * const pmtime,                    /* out */
+                              map<string, bufferlist> * const pattrs)   /* out */
 {
   bucket_info_entry e;
-  if (binfo_cache.find(bucket_name, &e)) {
+  string bucket_entry;
+  make_bucket_entry_name(tenant, bucket_name, bucket_entry);
+
+  if (binfo_cache.find(bucket_entry, &e)) {
     info = e.info;
     if (pattrs)
       *pattrs = e.attrs;
@@ -7685,7 +7691,7 @@ int RGWRados::get_bucket_info(RGWObjectCtx& obj_ctx,
 
 
   /* chain to both bucket entry point and bucket instance */
-  if (!binfo_cache.put(this, bucket_name, &e, cache_info_entries)) {
+  if (!binfo_cache.put(this, bucket_entry, &e, cache_info_entries)) {
     ldout(cct, 20) << "couldn't put binfo cache entry, might have raced with data changes" << dendl;
   }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7630,7 +7630,10 @@ int RGWRados::get_bucket_info(RGWObjectCtx& obj_ctx,
   rgw_cache_entry_info entry_cache_info;
   int ret = get_bucket_entrypoint_info(obj_ctx, tenant, bucket_name, entry_point, &ot, &ep_mtime, pattrs, &entry_cache_info);
   if (ret < 0) {
-    info.bucket.name = bucket_name; /* only init this field */
+    /* Only init these fields. */
+    info.bucket.tenant = tenant;
+    info.bucket.name = bucket_name;
+    ldout(cct, 20) << "get_bucket_entrypoint_info() returned ret=" << ret << dendl;
     return ret;
   }
 
@@ -7666,9 +7669,8 @@ int RGWRados::get_bucket_info(RGWObjectCtx& obj_ctx,
   e.info.ep_objv = ot.read_version;
   info = e.info;
   if (ret < 0) {
-    // XXX not tenant like above?
+    info.bucket.tenant = tenant;
     info.bucket.name = bucket_name;
-    // XXX and why return anything in case of an error anyway?
     return ret;
   }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4522,9 +4522,11 @@ int RGWRados::delete_bucket(rgw_bucket& bucket, RGWObjVersionTracker& objv_track
     }
   } while (is_truncated);
 
-  r = rgw_bucket_delete_bucket_obj(this, bucket.name, objv_tracker);
-  if (r < 0)
+  r = rgw_bucket_delete_bucket_obj(this, bucket.tenant, bucket.name, objv_tracker);
+  if (r < 0) {
+    ldout(cct, 0) << "rgw_bucket_delete_bucket_obj() returned r=" << r << dendl;
     return r;
+  }
 
   /* if the bucked is not synced we can remove the meta file */
   if (!is_syncing_bucket_meta(bucket)) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7543,6 +7543,7 @@ int RGWRados::get_bucket_entrypoint_info(RGWObjectCtx& obj_ctx,
   make_bucket_entry_name(tenant_name, bucket_name, bucket_entry);
   int ret = rgw_get_system_obj(this, obj_ctx, zone.domain_root, bucket_entry, bl, objv_tracker, pmtime, pattrs, cache_info);
   if (ret < 0) {
+    ldout(cct, 20) << "rgw_get_system_obj returned ret=" << ret << dendl;
     return ret;
   }
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -51,7 +51,7 @@ static inline void get_obj_bucket_and_oid_loc(const rgw_obj& obj, rgw_bucket& bu
   prepend_bucket_marker(bucket, obj.get_object(), oid);
   const string& loc = obj.get_loc();
   if (!loc.empty()) {
-    prepend_bucket_marker(bucket, obj.get_loc(), locator);
+    prepend_bucket_marker(bucket, obj.get_loc(), locator); // XXX get_loc twice
   } else {
     locator.clear();
   }
@@ -1143,10 +1143,10 @@ public:
 
 class RGWGetUserStats_CB : public RefCountedObject {
 protected:
-  string user;
+  rgw_user user;
   RGWStorageStats stats;
 public:
-  RGWGetUserStats_CB(const string& _user) : user(_user) {}
+  RGWGetUserStats_CB(const rgw_user& _user) : user(_user) {}
   virtual ~RGWGetUserStats_CB() {}
   virtual void handle_response(int r) = 0;
   virtual void set_response(RGWStorageStats& _stats) {
@@ -1208,7 +1208,7 @@ class RGWRados
   int open_gc_pool_ctx();
   int open_objexp_pool_ctx();
 
-  int open_bucket_pool_ctx(const string& bucket_name, const string& pool, librados::IoCtx&  io_ctx);
+  int open_bucket_pool_ctx(const string& pool, librados::IoCtx&  io_ctx);
   int open_bucket_index_ctx(rgw_bucket& bucket, librados::IoCtx&  index_ctx);
   int open_bucket_data_ctx(rgw_bucket& bucket, librados::IoCtx&  io_ctx);
   int open_bucket_data_extra_ctx(rgw_bucket& bucket, librados::IoCtx&  io_ctx);
@@ -1406,9 +1406,9 @@ public:
 
   // log bandwidth info
   int log_usage(map<rgw_user_bucket, RGWUsageBatch>& usage_info);
-  int read_usage(string& user, uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
+  int read_usage(const rgw_user& user, uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
                  bool *is_truncated, RGWUsageIter& read_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage);
-  int trim_usage(string& user, uint64_t start_epoch, uint64_t end_epoch);
+  int trim_usage(rgw_user& user, uint64_t start_epoch, uint64_t end_epoch);
 
   virtual int create_pool(rgw_bucket& bucket);
 
@@ -1417,12 +1417,12 @@ public:
    * returns 0 on success, -ERR# otherwise.
    */
   virtual int init_bucket_index(rgw_bucket& bucket, int num_shards);
-  int select_bucket_placement(RGWUserInfo& user_info, const string& region_name, const std::string& rule,
-                              const std::string& bucket_name, rgw_bucket& bucket, string *pselected_rule);
-  int select_legacy_bucket_placement(const string& bucket_name, rgw_bucket& bucket);
+  int select_bucket_placement(RGWUserInfo& user_info, const string& region_name, const string& rule,
+                              const string& tenant_name, const string& bucket_name, rgw_bucket& bucket, string *pselected_rule);
+  int select_legacy_bucket_placement(const string& tenant_name, const string& bucket_name, rgw_bucket& bucket);
   int select_new_bucket_location(RGWUserInfo& user_info, const string& region_name, const string& rule,
-                                 const std::string& bucket_name, rgw_bucket& bucket, string *pselected_rule);
-  int set_bucket_location_by_rule(const string& location_rule, const std::string& bucket_name, rgw_bucket& bucket);
+                                 const string& tenant_name, const string& bucket_name, rgw_bucket& bucket, string *pselected_rule);
+  int set_bucket_location_by_rule(const string& location_rule, const string& tenant_name, const string& bucket_name, rgw_bucket& bucket);
   virtual int create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
                             const string& region_name,
                             const string& placement_rule,
@@ -1600,7 +1600,7 @@ public:
         const string *ptag;
         list<rgw_obj_key> *remove_objs;
         time_t set_mtime;
-        string owner;
+        rgw_user owner;
         RGWObjCategory category;
         int flags;
         const char *if_match;
@@ -1623,7 +1623,7 @@ public:
       RGWRados::Object *target;
 
       struct DeleteParams {
-        string bucket_owner;
+        rgw_user bucket_owner;
         int versioning_status;
         ACLOwner obj_owner; /* needed for creation of deletion marker */
         uint64_t olh_epoch;
@@ -1790,7 +1790,7 @@ public:
 
   int rewrite_obj(RGWBucketInfo& dest_bucket_info, rgw_obj& obj);
   int fetch_remote_obj(RGWObjectCtx& obj_ctx,
-                       const string& user_id,
+                       const rgw_user& user_id,
                        const string& client_id,
                        const string& op_id,
                        req_info *info,
@@ -1819,7 +1819,7 @@ public:
   int copy_obj_to_remote_dest(RGWObjState *astate,
                               map<string, bufferlist>& src_attrs,
                               RGWRados::Object::Read& read_op,
-                              const string& user_id,
+                              const rgw_user& user_id,
                               rgw_obj& dest_obj,
                               time_t *mtime);
   /**
@@ -1838,7 +1838,7 @@ public:
    * Returns: 0 on success, -ERR# otherwise.
    */
   virtual int copy_obj(RGWObjectCtx& obj_ctx,
-               const string& user_id,
+               const rgw_user& user_id,
                const string& client_id,
                const string& op_id,
                req_info *info,
@@ -2049,24 +2049,29 @@ public:
   int get_bucket_stats(rgw_bucket& bucket, string *bucket_ver, string *master_ver,
       map<RGWObjCategory, RGWStorageStats>& stats, string *max_marker);
   int get_bucket_stats_async(rgw_bucket& bucket, RGWGetBucketStats_CB *cb);
-  int get_user_stats(const string& user, RGWStorageStats& stats);
-  int get_user_stats_async(const string& user, RGWGetUserStats_CB *cb);
+  int get_user_stats(const rgw_user& user, RGWStorageStats& stats);
+  int get_user_stats_async(const rgw_user& user, RGWGetUserStats_CB *cb);
   void get_bucket_instance_obj(rgw_bucket& bucket, rgw_obj& obj);
   void get_bucket_instance_entry(rgw_bucket& bucket, string& entry);
   void get_bucket_meta_oid(rgw_bucket& bucket, string& oid);
 
-  int put_bucket_entrypoint_info(const string& bucket_name, RGWBucketEntryPoint& entry_point, bool exclusive, RGWObjVersionTracker& objv_tracker, time_t mtime,
+  int put_bucket_entrypoint_info(const string& tenant_name, const string& bucket_name, RGWBucketEntryPoint& entry_point,
+                                 bool exclusive, RGWObjVersionTracker& objv_tracker, time_t mtime,
                                  map<string, bufferlist> *pattrs);
   int put_bucket_instance_info(RGWBucketInfo& info, bool exclusive, time_t mtime, map<string, bufferlist> *pattrs);
-  int get_bucket_entrypoint_info(RGWObjectCtx& obj_ctx, const string& bucket_name, RGWBucketEntryPoint& entry_point, RGWObjVersionTracker *objv_tracker, time_t *pmtime,
-                                 map<string, bufferlist> *pattrs, rgw_cache_entry_info *cache_info = NULL);
+  int get_bucket_entrypoint_info(RGWObjectCtx& obj_ctx, const string& tenant_name, const string& bucket_name,
+                                 RGWBucketEntryPoint& entry_point, RGWObjVersionTracker *objv_tracker,
+                                 time_t *pmtime, map<string, bufferlist> *pattrs, rgw_cache_entry_info *cache_info = NULL);
   int get_bucket_instance_info(RGWObjectCtx& obj_ctx, const string& meta_key, RGWBucketInfo& info, time_t *pmtime, map<string, bufferlist> *pattrs);
   int get_bucket_instance_info(RGWObjectCtx& obj_ctx, rgw_bucket& bucket, RGWBucketInfo& info, time_t *pmtime, map<string, bufferlist> *pattrs);
   int get_bucket_instance_from_oid(RGWObjectCtx& obj_ctx, string& oid, RGWBucketInfo& info, time_t *pmtime, map<string, bufferlist> *pattrs,
                                    rgw_cache_entry_info *cache_info = NULL);
 
-  int convert_old_bucket_info(RGWObjectCtx& obj_ctx, string& bucket_name);
-  virtual int get_bucket_info(RGWObjectCtx& obj_ctx, const string& bucket_name, RGWBucketInfo& info,
+  int convert_old_bucket_info(RGWObjectCtx& obj_ctx, const string& tenant_name, const string& bucket_name);
+  static void make_bucket_entry_name(const string& tenant_name, const string& bucket_name, string& bucket_entry);
+  virtual int get_bucket_info(RGWObjectCtx& obj_ctx,
+                              const string& tenant_name, const string& bucket_name,
+                              RGWBucketInfo& info,
                               time_t *pmtime, map<string, bufferlist> *pattrs = NULL);
   virtual int put_linked_bucket_info(RGWBucketInfo& info, bool exclusive, time_t mtime, obj_version *pep_objv,
                                      map<string, bufferlist> *pattrs, bool create_entry_point);
@@ -2174,11 +2179,11 @@ public:
   int cls_user_add_bucket(rgw_obj& obj, const cls_user_bucket_entry& entry);
   int cls_user_update_buckets(rgw_obj& obj, list<cls_user_bucket_entry>& entries, bool add);
   int cls_user_complete_stats_sync(rgw_obj& obj);
-  int complete_sync_user_stats(const string& user_id);
+  int complete_sync_user_stats(const rgw_user& user_id);
   int cls_user_add_bucket(rgw_obj& obj, list<cls_user_bucket_entry>& entries);
   int cls_user_remove_bucket(rgw_obj& obj, const cls_user_bucket& bucket);
 
-  int check_quota(const string& bucket_owner, rgw_bucket& bucket,
+  int check_quota(const rgw_user& bucket_owner, rgw_bucket& bucket,
                   RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size);
 
   string unique_id(uint64_t unique_num) {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1419,10 +1419,15 @@ public:
   virtual int init_bucket_index(rgw_bucket& bucket, int num_shards);
   int select_bucket_placement(RGWUserInfo& user_info, const string& region_name, const string& rule,
                               const string& tenant_name, const string& bucket_name, rgw_bucket& bucket, string *pselected_rule);
-  int select_legacy_bucket_placement(const string& tenant_name, const string& bucket_name, rgw_bucket& bucket);
+  int select_legacy_bucket_placement(const string& bucket_namespace,
+                                     const string& bucket_name,
+                                     rgw_bucket& bucket);
   int select_new_bucket_location(RGWUserInfo& user_info, const string& region_name, const string& rule,
                                  const string& tenant_name, const string& bucket_name, rgw_bucket& bucket, string *pselected_rule);
-  int set_bucket_location_by_rule(const string& location_rule, const string& tenant_name, const string& bucket_name, rgw_bucket& bucket);
+  int set_bucket_location_by_rule(const string& location_rule,
+                                  const string& bucket_namespace,
+                                  const string& bucket_name,
+                                  rgw_bucket& bucket);
   virtual int create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
                             const string& region_name,
                             const string& placement_rule,
@@ -2052,6 +2057,9 @@ public:
   int get_user_stats(const rgw_user& user, RGWStorageStats& stats);
   int get_user_stats_async(const rgw_user& user, RGWGetUserStats_CB *cb);
   void get_bucket_instance_obj(rgw_bucket& bucket, rgw_obj& obj);
+  int parse_bucket_instance_entry(const string& entry,
+                                  string& bucket_namespace,
+                                  string& bucket_name);
   void get_bucket_instance_entry(rgw_bucket& bucket, string& entry);
   void get_bucket_meta_oid(rgw_bucket& bucket, string& oid);
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -996,17 +996,19 @@ struct RGWRegionMap {
 WRITE_CLASS_ENCODER(RGWRegionMap)
 
 struct objexp_hint_entry {
+  string bucket_namespace;
   string bucket_name;
   string bucket_id;
   rgw_obj_key obj_key;
   utime_t exp_time;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     ::encode(bucket_name, bl);
     ::encode(bucket_id, bl);
     ::encode(obj_key, bl);
     ::encode(exp_time, bl);
+    ::encode(bucket_namespace, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -1016,6 +1018,9 @@ struct objexp_hint_entry {
     ::decode(bucket_id, bl);
     ::decode(obj_key, bl);
     ::decode(exp_time, bl);
+    if (struct_v >= 2) {
+      ::decode(bucket_namespace, bl);
+    }
     DECODE_FINISH(bl);
   }
 };
@@ -2060,6 +2065,10 @@ public:
   int parse_bucket_instance_entry(const string& entry,
                                   string& bucket_namespace,
                                   string& bucket_name);
+  void get_bucket_instance_entry(const string& bucket_namespace,
+                                 const string& bucket_name,
+                                 const string& bucket_id,
+                                 string& entry);
   void get_bucket_instance_entry(rgw_bucket& bucket, string& entry);
   void get_bucket_meta_oid(rgw_bucket& bucket, string& oid);
 
@@ -2131,6 +2140,7 @@ public:
   void objexp_get_shard(int shard_num,
                         string& shard);                       /* out */
   int objexp_hint_add(const utime_t& delete_at,
+                      const string& bucket_namespace,
                       const string& bucket_name,
                       const string& bucket_id,
                       const rgw_obj_key& obj_key);

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -453,12 +453,12 @@ void dump_time(struct req_state *s, const char *name, time_t *t)
   s->formatter->dump_string(name, buf);
 }
 
-void dump_owner(struct req_state *s, string& id, string& name, const char *section)
+void dump_owner(struct req_state *s, rgw_user& id, string& name, const char *section)
 {
   if (!section)
     section = "Owner";
   s->formatter->open_object_section(section);
-  s->formatter->dump_string("ID", id);
+  s->formatter->dump_string("ID", id.to_str());
   s->formatter->dump_string("DisplayName", name);
   s->formatter->close_section();
 }

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -377,7 +377,7 @@ extern void end_header(struct req_state *s,
 		       bool force_content_type = false);
 extern void dump_start(struct req_state *s);
 extern void list_all_buckets_start(struct req_state *s);
-extern void dump_owner(struct req_state *s, string& id, string& name, const char *section = NULL);
+extern void dump_owner(struct req_state *s, rgw_user& id, string& name, const char *section = NULL);
 extern void dump_string_header(struct req_state *s, const char *name, const char *val);
 extern void dump_content_length(struct req_state *s, uint64_t len);
 extern void dump_etag(struct req_state *s, const char *etag);

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -29,13 +29,15 @@ void RGWOp_Bucket_Info::execute()
 
   bool fetch_stats;
 
-  std::string uid;
   std::string bucket;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  string uid_str;
+
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "bucket", bucket, &bucket);
   RESTArgs::get_bool(s, "stats", false, &fetch_stats);
-
 
   op_state.set_user_id(uid);
   op_state.set_bucket_name(bucket);
@@ -124,16 +126,17 @@ public:
 
 void RGWOp_Bucket_Link::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string bucket;
   std::string bucket_id;
 
   RGWBucketAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "bucket", bucket, &bucket);
   RESTArgs::get_string(s, "bucket-id", bucket_id, &bucket_id);
 
+  rgw_user uid(uid_str);
   op_state.set_user_id(uid);
   op_state.set_bucket_name(bucket);
   op_state.set_bucket_id(bucket_id);
@@ -157,12 +160,14 @@ public:
 
 void RGWOp_Bucket_Unlink::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string bucket;
 
   RGWBucketAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "bucket", bucket, &bucket);
 
   op_state.set_user_id(uid);

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -329,9 +329,9 @@ static void grants_by_type_add_one_grant(map<int, string>& grants_by_type, int p
     default:
       id_type_str = "id";
   }
-  string id;
+  rgw_user id;
   grant.get_id(id);
-  s.append(id_type_str + "=\"" + id + "\"");
+  s.append(id_type_str + "=\"" + id.to_str() + "\"");
 }
 
 struct grant_type_to_header {

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -30,14 +30,15 @@ int RGWRESTConn::get_url(string& endpoint)
   return 0;
 }
 
-int RGWRESTConn::forward(const string& uid, req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl)
+int RGWRESTConn::forward(const rgw_user& uid, req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl)
 {
   string url;
   int ret = get_url(url);
   if (ret < 0)
     return ret;
+  string uid_str = uid.to_str();
   list<pair<string, string> > params;
-  params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "uid", uid));
+  params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "uid", uid_str));
   params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "region", region));
   if (objv) {
     params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "tag", objv->tag));
@@ -55,7 +56,7 @@ public:
     StreamObjData(rgw_obj& _obj) : obj(_obj) {}
 };
 
-int RGWRESTConn::put_obj_init(const string& uid, rgw_obj& obj, uint64_t obj_size,
+int RGWRESTConn::put_obj_init(const rgw_user& uid, rgw_obj& obj, uint64_t obj_size,
                                       map<string, bufferlist>& attrs, RGWRESTStreamWriteRequest **req)
 {
   string url;
@@ -63,8 +64,9 @@ int RGWRESTConn::put_obj_init(const string& uid, rgw_obj& obj, uint64_t obj_size
   if (ret < 0)
     return ret;
 
+  string uid_str = uid.to_str();
   list<pair<string, string> > params;
-  params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "uid", uid));
+  params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "uid", uid_str));
   params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "region", region));
   *req = new RGWRESTStreamWriteRequest(cct, url, NULL, &params);
   return (*req)->put_obj_init(key, obj, obj_size, attrs);
@@ -78,7 +80,7 @@ int RGWRESTConn::complete_request(RGWRESTStreamWriteRequest *req, string& etag, 
   return ret;
 }
 
-int RGWRESTConn::get_obj(const string& uid, req_info *info /* optional */, rgw_obj& obj, bool prepend_metadata,
+int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, rgw_obj& obj, bool prepend_metadata,
                                  RGWGetDataCB *cb, RGWRESTStreamReadRequest **req)
 {
   string url;
@@ -86,8 +88,9 @@ int RGWRESTConn::get_obj(const string& uid, req_info *info /* optional */, rgw_o
   if (ret < 0)
     return ret;
 
+  string uid_str = uid.to_str();
   list<pair<string, string> > params;
-  params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "uid", uid));
+  params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "uid", uid_str));
   params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "region", region));
   if (prepend_metadata) {
     params.push_back(pair<string, string>(RGW_SYS_PARAM_PREFIX "prepend-metadata", region));

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -23,14 +23,14 @@ public:
   int get_url(string& endpoint);
 
   /* sync request */
-  int forward(const string& uid, req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl);
+  int forward(const rgw_user& uid, req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl);
 
   /* async request */
-  int put_obj_init(const string& uid, rgw_obj& obj, uint64_t obj_size,
+  int put_obj_init(const rgw_user& uid, rgw_obj& obj, uint64_t obj_size,
                    map<string, bufferlist>& attrs, RGWRESTStreamWriteRequest **req);
   int complete_request(RGWRESTStreamWriteRequest *req, string& etag, time_t *mtime);
 
-  int get_obj(const string& uid, req_info *info /* optional */, rgw_obj& obj, bool prepend_metadata, RGWGetDataCB *cb, RGWRESTStreamReadRequest **req);
+  int get_obj(const rgw_user& uid, req_info *info /* optional */, rgw_obj& obj, bool prepend_metadata, RGWGetDataCB *cb, RGWRESTStreamReadRequest **req);
   int complete_request(RGWRESTStreamReadRequest *req, string& etag, time_t *mtime, map<string, string>& attrs);
 };
 

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -269,7 +269,8 @@ void RGWOp_MDLog_Unlock::execute() {
 }
 
 void RGWOp_BILog_List::execute() {
-  string bucket_name = s->info.args.get("bucket"),
+  string tenant_name = s->info.args.get("tenant"),
+         bucket_name = s->info.args.get("bucket"),
          marker = s->info.args.get("marker"),
          max_entries_str = s->info.args.get("max-entries"),
          bucket_instance = s->info.args.get("bucket-instance");
@@ -297,7 +298,7 @@ void RGWOp_BILog_List::execute() {
       return;
     }
   } else { /* !bucket_name.empty() */
-    http_ret = store->get_bucket_info(obj_ctx, bucket_name, bucket_info, NULL, NULL);
+    http_ret = store->get_bucket_info(obj_ctx, tenant_name, bucket_name, bucket_info, NULL, NULL);
     if (http_ret < 0) {
       dout(5) << "could not get bucket info for bucket=" << bucket_name << dendl;
       return;
@@ -364,7 +365,8 @@ void RGWOp_BILog_List::send_response_end() {
 }
       
 void RGWOp_BILog_Info::execute() {
-  string bucket_name = s->info.args.get("bucket"),
+  string tenant_name = s->info.args.get("tenant"),
+         bucket_name = s->info.args.get("bucket"),
          bucket_instance = s->info.args.get("bucket-instance");
   RGWBucketInfo bucket_info;
 
@@ -383,7 +385,7 @@ void RGWOp_BILog_Info::execute() {
       return;
     }
   } else { /* !bucket_name.empty() */
-    http_ret = store->get_bucket_info(obj_ctx, bucket_name, bucket_info, NULL, NULL);
+    http_ret = store->get_bucket_info(obj_ctx, tenant_name, bucket_name, bucket_info, NULL, NULL);
     if (http_ret < 0) {
       dout(5) << "could not get bucket info for bucket=" << bucket_name << dendl;
       return;
@@ -415,7 +417,8 @@ void RGWOp_BILog_Info::send_response() {
 }
 
 void RGWOp_BILog_Delete::execute() {
-  string bucket_name = s->info.args.get("bucket"),
+  string tenant_name = s->info.args.get("tenant"),
+         bucket_name = s->info.args.get("bucket"),
          start_marker = s->info.args.get("start-marker"),
          end_marker = s->info.args.get("end-marker"),
          bucket_instance = s->info.args.get("bucket-instance");
@@ -445,7 +448,7 @@ void RGWOp_BILog_Delete::execute() {
       return;
     }
   } else { /* !bucket_name.empty() */
-    http_ret = store->get_bucket_info(obj_ctx, bucket_name, bucket_info, NULL, NULL);
+    http_ret = store->get_bucket_info(obj_ctx, tenant_name, bucket_name, bucket_info, NULL, NULL);
     if (http_ret < 0) {
       dout(5) << "could not get bucket info for bucket=" << bucket_name << dendl;
       return;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1181,8 +1181,9 @@ int RGWPostObj_ObjStore_S3::get_policy()
       user_info.user_id = keystone_validator.response.token.tenant.id;
       user_info.display_name = keystone_validator.response.token.tenant.name;
 
+      rgw_user uid(keystone_validator.response.token.tenant.id);
       /* try to store user if it not already exists */
-      if (rgw_get_user_info_by_uid(store, keystone_validator.response.token.tenant.id, user_info) < 0) {
+      if (rgw_get_user_info_by_uid(store, uid, user_info) < 0) {
         int ret = rgw_store_user_info(store, user_info, NULL, NULL, 0, true);
         if (ret < 0) {
           dout(10) << "NOTICE: failed to store new user's info: ret=" << ret << dendl;
@@ -2382,8 +2383,9 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
 	s->user.user_id = keystone_validator.response.token.tenant.id;
         s->user.display_name = keystone_validator.response.token.tenant.name; // wow.
 
+        rgw_user uid(keystone_validator.response.token.tenant.id);
         /* try to store user if it not already exists */
-        if (rgw_get_user_info_by_uid(store, keystone_validator.response.token.tenant.id, s->user) < 0) {
+        if (rgw_get_user_info_by_uid(store, uid, s->user) < 0) {
           int ret = rgw_store_user_info(store, s->user, NULL, NULL, 0, true);
           if (ret < 0)
             dout(10) << "NOTICE: failed to store new user's info: ret=" << ret << dendl;
@@ -2463,7 +2465,8 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
       string effective_uid = s->info.args.get(RGW_SYS_PARAM_PREFIX "uid");
       RGWUserInfo effective_user;
       if (!effective_uid.empty()) {
-        ret = rgw_get_user_info_by_uid(store, effective_uid, effective_user);
+        rgw_user euid(effective_uid);
+        ret = rgw_get_user_info_by_uid(store, euid, effective_user);
         if (ret < 0) {
           ldout(s->cct, 0) << "User lookup failed!" << dendl;
           return -ENOENT;
@@ -2475,6 +2478,7 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
   } /* if keystone_result < 0 */
 
   // populate the owner info
+  s->tenant = s->user.user_id.tenant;
   s->owner.set_id(s->user.user_id);
   s->owner.set_name(s->user.display_name);
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2478,7 +2478,6 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
   } /* if keystone_result < 0 */
 
   // populate the owner info
-  s->tenant = s->user.user_id.tenant;
   s->owner.set_id(s->user.user_id);
   s->owner.set_name(s->user.display_name);
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1259,6 +1259,7 @@ int RGWPostObj_ObjStore_S3::get_policy()
     }
 
     s->user = user_info;
+    s->auth_user = s->user.user_id;
     s->owner.set_id(user_info.user_id);
     s->owner.set_name(user_info.display_name);
   } else {
@@ -2298,7 +2299,7 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(const string& auth_id, 
 
 static void init_anon_user(struct req_state *s)
 {
-  rgw_get_anon_user(s->user);
+  rgw_get_anon_user(s->user, s->auth_user);
   s->perm_mask = RGW_PERM_FULL_CONTROL;
 }
 
@@ -2380,6 +2381,7 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
 	}
 
 
+	s->auth_user = keystone_validator.response.token.tenant.id;
 	s->user.user_id = keystone_validator.response.token.tenant.id;
         s->user.display_name = keystone_validator.response.token.tenant.name; // wow.
 
@@ -2477,7 +2479,10 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
 
   } /* if keystone_result < 0 */
 
-  // populate the owner info
+  /* populate the owner info */
+  if (s->auth_user.empty()) {
+    s->auth_user = s->user.user_id;
+  }
   s->owner.set_id(s->user.user_id);
   s->owner.set_name(s->user.display_name);
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1167,9 +1167,28 @@ int RGWHandler_ObjStore_SWIFT::init_from_header(struct req_state *s)
 
   next_tok(req, ver, '/');
 
-  string tenant;
-  if (!tenant_path.empty()) {
-    next_tok(req, tenant, '/');
+  if (!tenant_path.empty() || g_conf->rgw_swift_account_in_url) {
+    string account_name;
+    next_tok(req, account_name, '/');
+
+    /* Erase all pre-defined prefixes like "AUTH_" or "KEY_". */
+    list<string> skipped_prefixes;
+    get_str_list("AUTH_,KEY_", skipped_prefixes);
+
+    for (const auto pfx : skipped_prefixes) {
+      const size_t comp_len = min(account_name.length(), pfx.length());
+      if (account_name.compare(0, comp_len, pfx) == 0) {
+        /* Prefix is present. Drop it. */
+        account_name = account_name.substr(comp_len);
+        break;
+      }
+    }
+
+    if (account_name.empty()) {
+      return -ERR_PRECONDITION_FAILED;
+    } else {
+      s->account_name = account_name;
+    }
   }
 
   s->os_auth_token = s->info.env->get("HTTP_X_AUTH_TOKEN");

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -356,8 +356,7 @@ void RGWStatAccount_ObjStore_SWIFT::execute()
 {
   RGWStatAccount_ObjStore::execute();
 
-  /* XXX tenant needed? */
-  ret = rgw_get_user_attrs_by_uid(store, s->user.user_id.id, attrs);
+  ret = rgw_get_user_attrs_by_uid(store, s->user.user_id.to_str(), attrs);
 }
 
 void RGWStatAccount_ObjStore_SWIFT::send_response()
@@ -815,7 +814,7 @@ void RGWCopyObj_ObjStore_SWIFT::dump_copy_info()
 
   /* Dump X-Copied-From-Account */
   string account_name;
-  url_encode(s->user.user_id.id, account_name); // XXX tenant
+  url_encode(s->user.user_id.to_str(), account_name);
   s->cio->print("X-Copied-From-Account: %s\r\n", account_name.c_str());
 
   /* Dump X-Copied-From-Last-Modified. */

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1044,7 +1044,7 @@ int RGWHandler_ObjStore_SWIFT::authorize()
   if ((!s->os_auth_token && s->info.args.get("temp_url_sig").empty()) ||
       (s->op == OP_OPTIONS)) {
     /* anonymous access */
-    rgw_get_anon_user(s->user, s->auth_user);
+    rgw_get_anon_user(s->user, s->auth_user, store, s->account_name);
     s->perm_mask = RGW_PERM_FULL_CONTROL;
     return 0;
   }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -356,7 +356,8 @@ void RGWStatAccount_ObjStore_SWIFT::execute()
 {
   RGWStatAccount_ObjStore::execute();
 
-  ret = rgw_get_user_attrs_by_uid(store, s->user.user_id, attrs);
+  /* XXX tenant needed? */
+  ret = rgw_get_user_attrs_by_uid(store, s->user.user_id.id, attrs);
 }
 
 void RGWStatAccount_ObjStore_SWIFT::send_response()
@@ -814,7 +815,7 @@ void RGWCopyObj_ObjStore_SWIFT::dump_copy_info()
 
   /* Dump X-Copied-From-Account */
   string account_name;
-  url_encode(s->user.user_id, account_name);
+  url_encode(s->user.user_id.id, account_name); // XXX tenant
   s->cio->print("X-Copied-From-Account: %s\r\n", account_name.c_str());
 
   /* Dump X-Copied-From-Last-Modified. */

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1044,14 +1044,19 @@ int RGWHandler_ObjStore_SWIFT::authorize()
   if ((!s->os_auth_token && s->info.args.get("temp_url_sig").empty()) ||
       (s->op == OP_OPTIONS)) {
     /* anonymous access */
-    rgw_get_anon_user(s->user);
+    rgw_get_anon_user(s->user, s->auth_user);
     s->perm_mask = RGW_PERM_FULL_CONTROL;
     return 0;
   }
 
-  bool authorized = rgw_swift->verify_swift_token(store, s);
-  if (!authorized)
+  const bool authorized = rgw_swift->verify_swift_token(store, s);
+  if (!authorized) {
     return -EPERM;
+  }
+
+  if (s->auth_user.empty()) {
+    s->auth_user = s->user.user_id;
+  }
 
   return 0;
 }

--- a/src/rgw/rgw_rest_usage.cc
+++ b/src/rgw/rgw_rest_usage.cc
@@ -25,12 +25,14 @@ public:
 void RGWOp_Usage_Get::execute() {
   map<std::string, bool> categories;
 
-  string uid;
+  string uid_str;
   uint64_t start, end;
   bool show_entries;
   bool show_summary;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_epoch(s, "start", 0, &start);
   RESTArgs::get_epoch(s, "end", (uint64_t)-1, &end);
   RESTArgs::get_bool(s, "show-entries", true, &show_entries);
@@ -65,10 +67,12 @@ public:
 };
 
 void RGWOp_Usage_Delete::execute() {
-  string uid;
+  string uid_str;
   uint64_t start, end;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_epoch(s, "start", 0, &start);
   RESTArgs::get_epoch(s, "end", (uint64_t)-1, &end);
 

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -29,10 +29,12 @@ void RGWOp_User_Info::execute()
 {
   RGWUserAdminOpState op_state;
 
-  std::string uid;
+  std::string uid_str;
   bool fetch_stats;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_bool(s, "stats", false, &fetch_stats);
 
   op_state.set_user_id(uid);
@@ -57,7 +59,7 @@ public:
 
 void RGWOp_User_Create::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string display_name;
   std::string email;
   std::string access_key;
@@ -75,7 +77,9 @@ void RGWOp_User_Create::execute()
 
   RGWUserAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "display-name", display_name, &display_name);
   RESTArgs::get_string(s, "email", email, &email);
   RESTArgs::get_string(s, "access-key", access_key, &access_key);
@@ -157,7 +161,7 @@ public:
 
 void RGWOp_User_Modify::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string display_name;
   std::string email;
   std::string access_key;
@@ -173,7 +177,9 @@ void RGWOp_User_Modify::execute()
 
   RGWUserAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "display-name", display_name, &display_name);
   RESTArgs::get_string(s, "email", email, &email);
   RESTArgs::get_string(s, "access-key", access_key, &access_key);
@@ -251,12 +257,14 @@ public:
 
 void RGWOp_User_Remove::execute()
 {
-  std::string uid;
+  std::string uid_str;
   bool purge_data;
 
   RGWUserAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_bool(s, "purge-data", false, &purge_data);
 
   // FIXME: no double checking
@@ -284,7 +292,7 @@ public:
 
 void RGWOp_Subuser_Create::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string subuser;
   std::string secret_key;
   std::string perm_str;
@@ -298,7 +306,9 @@ void RGWOp_Subuser_Create::execute()
 
   RGWUserAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "subuser", subuser, &subuser);
   RESTArgs::get_string(s, "secret-key", secret_key, &secret_key);
   RESTArgs::get_string(s, "access", perm_str, &perm_str);
@@ -351,7 +361,7 @@ public:
 
 void RGWOp_Subuser_Modify::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string subuser;
   std::string secret_key;
   std::string key_type_str;
@@ -364,7 +374,9 @@ void RGWOp_Subuser_Modify::execute()
 
   bool gen_secret;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "subuser", subuser, &subuser);
   RESTArgs::get_string(s, "secret-key", secret_key, &secret_key);
   RESTArgs::get_string(s, "access", perm_str, &perm_str);
@@ -414,13 +426,15 @@ public:
 
 void RGWOp_Subuser_Remove::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string subuser;
   bool purge_keys;
 
   RGWUserAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "subuser", subuser, &subuser);
   RESTArgs::get_bool(s, "purge-keys", true, &purge_keys);
 
@@ -453,7 +467,7 @@ public:
 
 void RGWOp_Key_Create::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string subuser;
   std::string access_key;
   std::string secret_key;
@@ -463,7 +477,9 @@ void RGWOp_Key_Create::execute()
 
   RGWUserAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "subuser", subuser, &subuser);
   RESTArgs::get_string(s, "access-key", access_key, &access_key);
   RESTArgs::get_string(s, "secret-key", secret_key, &secret_key);
@@ -515,14 +531,16 @@ public:
 
 void RGWOp_Key_Remove::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string subuser;
   std::string access_key;
   std::string key_type_str;
 
   RGWUserAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "subuser", subuser, &subuser);
   RESTArgs::get_string(s, "access-key", access_key, &access_key);
   RESTArgs::get_string(s, "key-type", key_type_str, &key_type_str);
@@ -566,12 +584,14 @@ public:
 
 void RGWOp_Caps_Add::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string caps;
 
   RGWUserAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "user-caps", caps, &caps);
 
   // FIXME: no double checking
@@ -600,12 +620,14 @@ public:
 
 void RGWOp_Caps_Remove::execute()
 {
-  std::string uid;
+  std::string uid_str;
   std::string caps;
 
   RGWUserAdminOpState op_state;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  rgw_user uid(uid_str);
+
   RESTArgs::get_string(s, "user-caps", caps, &caps);
 
   // FIXME: no double checking
@@ -656,16 +678,18 @@ void RGWOp_Quota_Info::execute()
 {
   RGWUserAdminOpState op_state;
 
-  std::string uid;
+  std::string uid_str;
   std::string quota_type;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "quota-type", quota_type, &quota_type);
 
-  if (uid.empty()) {
+  if (uid_str.empty()) {
     http_ret = -EINVAL;
     return;
   }
+
+  rgw_user uid(uid_str);
 
   bool show_all = quota_type.empty();
   bool show_bucket = show_all || (quota_type == "bucket");
@@ -768,16 +792,18 @@ void RGWOp_Quota_Set::execute()
 {
   RGWUserAdminOpState op_state;
 
-  std::string uid;
+  std::string uid_str;
   std::string quota_type;
 
-  RESTArgs::get_string(s, "uid", uid, &uid);
+  RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "quota-type", quota_type, &quota_type);
 
-  if (uid.empty()) {
+  if (uid_str.empty()) {
     http_ret = -EINVAL;
     return;
   }
+
+  rgw_user uid(uid_str);
 
   bool set_all = quota_type.empty();
   bool set_bucket = set_all || (quota_type == "bucket");

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -545,6 +545,8 @@ int authenticate_temp_url(RGWRados *store, req_state *s)
   if (s->bucket_name_str.empty())
     return -EPERM;
 
+  string tenant_name = "";  /* XXX Swift TempUrl bucket */
+
   if (s->object.empty())
     return -EPERM;
 
@@ -559,7 +561,7 @@ int authenticate_temp_url(RGWRados *store, req_state *s)
   /* need to get user info of bucket owner */
   RGWBucketInfo bucket_info;
 
-  int ret = store->get_bucket_info(*static_cast<RGWObjectCtx *>(s->obj_ctx), s->bucket_name_str, bucket_info, NULL);
+  int ret = store->get_bucket_info(*static_cast<RGWObjectCtx *>(s->obj_ctx), tenant_name, s->bucket_name_str, bucket_info, NULL);
   if (ret < 0)
     return -EPERM;
 
@@ -684,7 +686,7 @@ bool RGWSwift::do_verify_swift_token(RGWRados *store, req_state *s)
     return false;
   }
 
-  s->swift_user = info.user;
+  s->swift_user = info.user.to_str();
   s->swift_groups = info.auth_groups;
 
   string swift_user = s->swift_user;

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -371,9 +371,13 @@ int RGWSwift::check_revoked()
   return 0;
 }
 
-static void rgw_set_keystone_token_auth_info(KeystoneToken& token, struct rgw_swift_auth_info *info)
+static void rgw_set_keystone_token_auth_info(KeystoneToken& token,
+                                             struct rgw_swift_auth_info *info)
 {
-  info->user = token.token.tenant.id;
+  /* If the requested account currently doesn't exist, it may be created with
+   * its own namespace for buckets depending on the configuration option. */
+  info->user = rgw_user(token.token.tenant.id,
+          g_conf->rgw_swift_create_account_with_bns);
   info->display_name = token.token.tenant.name;
   info->status = 200;
 }

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -14,7 +14,7 @@ class KeystoneToken;
 struct rgw_swift_auth_info {
   int status;
   string auth_groups;
-  string user;
+  rgw_user user;
   string display_name;
   long long ttl;
 

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -26,12 +26,18 @@ class RGWSwift {
   atomic_t down_flag;
 
   int validate_token(const char *token, struct rgw_swift_auth_info *info);
-  int validate_keystone_token(RGWRados *store, const string& token, struct rgw_swift_auth_info *info,
-			      RGWUserInfo& rgw_user);
+  int validate_keystone_token(RGWRados *store,
+                              const string& account_name,
+                              const string& token,
+                              struct rgw_swift_auth_info *info,
+                              RGWUserInfo& rgw_user);
 
   int parse_keystone_token_response(const string& token, bufferlist& bl, struct rgw_swift_auth_info *info,
 		                    KeystoneToken& t);
-  int update_user_info(RGWRados *store, struct rgw_swift_auth_info *info, RGWUserInfo& user_info);
+  int update_user_info(RGWRados *store,
+                       const string& account_name,
+                       const struct rgw_swift_auth_info *info,
+                       RGWUserInfo& user_info);
   int get_keystone_url(std::string& url);
   int get_keystone_admin_token(std::string& token);
 

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -17,8 +17,13 @@ struct rgw_swift_auth_info {
   rgw_user user;
   string display_name;
   long long ttl;
+  bool is_admin;
 
-  rgw_swift_auth_info() : status(0), ttl(0) {}
+  rgw_swift_auth_info()
+    : status(0),
+      ttl(0),
+      is_admin(false) {
+  }
 };
 
 class RGWSwift {

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -207,6 +207,9 @@ void RGW_SWIFT_Auth_Get::execute()
   if (!g_conf->rgw_swift_tenant_name.empty()) {
     tenant_path = "/AUTH_";
     tenant_path.append(g_conf->rgw_swift_tenant_name);
+  } else if (g_conf->rgw_swift_account_in_url) {
+    tenant_path = "/AUTH_";
+    tenant_path.append(user_str);
   }
 
   s->cio->print("X-Storage-Url: %s/%s/v1%s\r\n", swift_url.c_str(),

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -30,7 +30,7 @@ static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log
   formatter->close_section(); // categories
 }
 
-int RGWUsage::show(RGWRados *store, string& uid, uint64_t start_epoch,
+int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
 		   uint64_t end_epoch, bool show_log_entries, bool show_log_sum,
 		   map<string, bool> *categories,
 		   RGWFormatterFlusher& flusher)
@@ -135,7 +135,7 @@ int RGWUsage::show(RGWRados *store, string& uid, uint64_t start_epoch,
   return 0;
 }
 
-int RGWUsage::trim(RGWRados *store, string& uid, uint64_t start_epoch,
+int RGWUsage::trim(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
 		   uint64_t end_epoch)
 {
   return store->trim_usage(uid, start_epoch, end_epoch);

--- a/src/rgw/rgw_usage.h
+++ b/src/rgw/rgw_usage.h
@@ -16,12 +16,12 @@ class RGWRados;
 class RGWUsage
 {
 public:
-  static int show(RGWRados *store, std::string& uid, uint64_t start_epoch,
+  static int show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
 	          uint64_t end_epoch, bool show_log_entries, bool show_log_sum,
 		  std::map<std::string, bool> *categories,
 	          RGWFormatterFlusher& flusher);
 
-  static int trim(RGWRados *store, std::string& uid, uint64_t start_epoch,
+  static int trim(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
 	          uint64_t end_epoch);
 };
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -33,18 +33,32 @@ static RGWMetadataHandler *user_meta_handler = NULL;
 /**
  * Get the anonymous (ie, unauthenticated) user info.
  */
-void rgw_get_anon_user(RGWUserInfo& info, rgw_user& auth_user)
+void rgw_get_anon_user(RGWUserInfo& info,
+                       rgw_user& auth_user,
+                       RGWRados * const store,
+                       const string& account_name)
 {
-  info.user_id = RGW_USER_ANON_ID;
-  info.display_name.clear();
-  info.access_keys.clear();
+  int ret = 0;
+  if (!account_name.empty()) {
+    const rgw_user ui_owner(account_name);
+    ret = rgw_get_user_info_by_uid(store, ui_owner, info);
+    if (ret < 0) {
+      dout(0) << "NOTICE: couldn't map swift user" << dendl;
+    }
+  }
+
+  if (account_name.empty() || ret < 0) {
+    info.user_id = RGW_USER_ANON_ID;
+    info.display_name.clear();
+    info.access_keys.clear();
+  }
 
   auth_user = RGW_USER_ANON_ID;
 }
 
-bool rgw_user_is_authenticated(RGWUserInfo& info)
+bool rgw_user_is_authenticated(const rgw_user& auth_user)
 {
-  return (info.user_id.id != RGW_USER_ANON_ID);
+  return (auth_user.id != RGW_USER_ANON_ID);
 }
 
 int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id)

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -205,7 +205,7 @@ int rgw_store_user_info(RGWRados *store,
 }
 
 int rgw_store_user_attrs(RGWRados *const store,
-                         string& user_id,
+                         const string& user_id,
                          map<string, bufferlist>& attrs,
                          map<string, bufferlist>* const rmattrs,
                          RGWObjVersionTracker * const objv_tracker)

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -33,11 +33,13 @@ static RGWMetadataHandler *user_meta_handler = NULL;
 /**
  * Get the anonymous (ie, unauthenticated) user info.
  */
-void rgw_get_anon_user(RGWUserInfo& info)
+void rgw_get_anon_user(RGWUserInfo& info, rgw_user& auth_user)
 {
   info.user_id = RGW_USER_ANON_ID;
   info.display_name.clear();
   info.access_keys.clear();
+
+  auth_user = RGW_USER_ANON_ID;
 }
 
 bool rgw_user_is_authenticated(RGWUserInfo& info)
@@ -1634,8 +1636,7 @@ RGWUser::~RGWUser()
 void RGWUser::init_default()
 {
   // use anonymous user info as a placeholder
-  rgw_get_anon_user(old_info);
-  user_id = RGW_USER_ANON_ID;
+  rgw_get_anon_user(old_info, user_id);
 
   clear_populated();
 }

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -42,10 +42,10 @@ void rgw_get_anon_user(RGWUserInfo& info)
 
 bool rgw_user_is_authenticated(RGWUserInfo& info)
 {
-  return (info.user_id != RGW_USER_ANON_ID);
+  return (info.user_id.id != RGW_USER_ANON_ID);
 }
 
-int rgw_user_sync_all_stats(RGWRados *store, const string& user_id)
+int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id)
 {
   CephContext *cct = store->ctx();
   size_t max_entries = cct->_conf->rgw_list_buckets_max_chunk;
@@ -156,7 +156,10 @@ int rgw_store_user_info(RGWRados *store,
   ::encode(ui, data_bl);
   ::encode(info, data_bl);
 
-  ret = store->meta_mgr->put_entry(user_meta_handler, info.user_id, data_bl, exclusive, &ot, mtime, pattrs);
+  string key;
+  info.user_id.to_str(key);
+
+  ret = store->meta_mgr->put_entry(user_meta_handler, key, data_bl, exclusive, &ot, mtime, pattrs);
   if (ret < 0)
     return ret;
 
@@ -275,7 +278,7 @@ int rgw_get_user_info_from_index(RGWRados *store, string& key, rgw_bucket& bucke
  * returns: 0 on success, -ERR# on failure (including nonexistence)
  */
 int rgw_get_user_info_by_uid(RGWRados *store,
-                             string& uid,
+                             rgw_user& uid,
                              RGWUserInfo& info,
                              RGWObjVersionTracker *objv_tracker,
                              time_t *pmtime,
@@ -286,7 +289,8 @@ int rgw_get_user_info_by_uid(RGWRados *store,
   RGWUID user_id;
 
   RGWObjectCtx obj_ctx(store);
-  int ret = rgw_get_system_obj(store, obj_ctx, store->zone.user_uid_pool, uid, bl, objv_tracker, pmtime, pattrs, cache_info);
+  string oid = uid.to_str();
+  int ret = rgw_get_system_obj(store, obj_ctx, store->zone.user_uid_pool, oid, bl, objv_tracker, pmtime, pattrs, cache_info);
   if (ret < 0) {
     return ret;
   }
@@ -360,7 +364,7 @@ int rgw_remove_key_index(RGWRados *store, RGWAccessKey& access_key)
   return ret;
 }
 
-int rgw_remove_uid_index(RGWRados *store, string& uid)
+int rgw_remove_uid_index(RGWRados *store, rgw_user& uid)
 {
   RGWObjVersionTracker objv_tracker;
   RGWUserInfo info;
@@ -368,7 +372,8 @@ int rgw_remove_uid_index(RGWRados *store, string& uid)
   if (ret < 0)
     return ret;
 
-  ret = store->meta_mgr->remove_entry(user_meta_handler, uid, &objv_tracker);
+  string oid = uid.to_str();
+  ret = store->meta_mgr->remove_entry(user_meta_handler, oid, &objv_tracker);
   if (ret < 0)
     return ret;
 
@@ -462,10 +467,13 @@ int rgw_delete_user(RGWRados *store, RGWUserInfo& info, RGWObjVersionTracker& ob
     ldout(store->ctx(), 0) << "ERROR: could not remove " << info.user_id << ":" << uid_bucks << ", should be fixed (err=" << ret << ")" << dendl;
     return ret;
   }
+
+  string key;
+  info.user_id.to_str(key);
   
-  rgw_obj uid_obj(store->zone.user_uid_pool, info.user_id);
+  rgw_obj uid_obj(store->zone.user_uid_pool, key);
   ldout(store->ctx(), 10) << "removing user index: " << info.user_id << dendl;
-  ret = store->meta_mgr->remove_entry(user_meta_handler, info.user_id, &objv_tracker);
+  ret = store->meta_mgr->remove_entry(user_meta_handler, key, &objv_tracker);
   if (ret < 0 && ret != -ENOENT && ret  != -ECANCELED) {
     ldout(store->ctx(), 0) << "ERROR: could not remove " << info.user_id << ":" << uid_obj << ", should be fixed (err=" << ret << ")" << dendl;
     return ret;
@@ -571,10 +579,15 @@ static bool remove_old_indexes(RGWRados *store,
   int ret;
   bool success = true;
 
-  if (!old_info.user_id.empty() && old_info.user_id.compare(new_info.user_id) != 0) {
+  if (!old_info.user_id.empty() &&
+      old_info.user_id.compare(new_info.user_id) != 0) {
+    if (old_info.user_id.tenant != new_info.user_id.tenant) {
+      ldout(store->ctx(), 0) << "ERROR: tenant mismatch: " << old_info.user_id.tenant << " != " << new_info.user_id.tenant << dendl;
+      return false;
+    }
     ret = rgw_remove_uid_index(store, old_info.user_id);
     if (ret < 0 && ret != -ENOENT) {
-      set_err_msg(err_msg, "ERROR: could not remove index for uid " + old_info.user_id);
+      set_err_msg(err_msg, "ERROR: could not remove index for uid " + old_info.user_id.to_str());
       success = false;
     }
   }
@@ -619,7 +632,9 @@ static void dump_subusers_info(Formatter *f, RGWUserInfo &info)
   for (uiter = info.subusers.begin(); uiter != info.subusers.end(); ++uiter) {
     RGWSubUser& u = uiter->second;
     f->open_object_section("user");
-    f->dump_format("id", "%s:%s", info.user_id.c_str(), u.name.c_str());
+    string s;
+    info.user_id.to_str(s);
+    f->dump_format("id", "%s:%s", s.c_str(), u.name.c_str());
     char buf[256];
     rgw_perm_to_str(u.perm_mask, buf, sizeof(buf));
     f->dump_string("permissions", buf);
@@ -637,7 +652,9 @@ static void dump_access_keys_info(Formatter *f, RGWUserInfo &info)
     const char *sep = (k.subuser.empty() ? "" : ":");
     const char *subuser = (k.subuser.empty() ? "" : k.subuser.c_str());
     f->open_object_section("key");
-    f->dump_format("user", "%s%s%s", info.user_id.c_str(), sep, subuser);
+    string s;
+    info.user_id.to_str(s);
+    f->dump_format("user", "%s%s%s", s.c_str(), sep, subuser);
     f->dump_string("access_key", k.id);
     f->dump_string("secret_key", k.key);
     f->close_section();
@@ -654,7 +671,9 @@ static void dump_swift_keys_info(Formatter *f, RGWUserInfo &info)
     const char *sep = (k.subuser.empty() ? "" : ":");
     const char *subuser = (k.subuser.empty() ? "" : k.subuser.c_str());
     f->open_object_section("key");
-    f->dump_format("user", "%s%s%s", info.user_id.c_str(), sep, subuser);
+    string s;
+    info.user_id.to_str(s);
+    f->dump_format("user", "%s%s%s", s.c_str(), sep, subuser);
     f->dump_string("secret_key", k.key);
     f->close_section();
   }
@@ -666,7 +685,8 @@ static void dump_user_info(Formatter *f, RGWUserInfo &info,
 {
   f->open_object_section("user_info");
 
-  f->dump_string("user_id", info.user_id);
+  f->dump_string("tenant", info.user_id.tenant);
+  f->dump_string("user_id", info.user_id.id);
   f->dump_string("display_name", info.display_name);
   f->dump_string("email", info.user_email);
   f->dump_int("suspended", (int)info.suspended);
@@ -713,7 +733,7 @@ int RGWAccessKeyPool::init(RGWUserAdminOpState& op_state)
     return -EINVAL;
   }
 
-  std::string uid = op_state.get_user_id();
+  rgw_user& uid = op_state.get_user_id();
   if (uid.compare(RGW_USER_ANON_ID) == 0) {
     keys_allowed = false;
     return -EACCES;
@@ -1197,7 +1217,7 @@ int RGWSubUserPool::init(RGWUserAdminOpState& op_state)
     return -EINVAL;
   }
 
-  std::string uid = op_state.get_user_id();
+  rgw_user& uid = op_state.get_user_id();
   if (uid.compare(RGW_USER_ANON_ID) == 0) {
     subusers_allowed = false;
     return -EACCES;
@@ -1490,8 +1510,8 @@ int RGWUserCapPool::init(RGWUserAdminOpState& op_state)
     return -EINVAL;
   }
 
-  std::string uid = op_state.get_user_id();
-  if (uid == RGW_USER_ANON_ID) {
+  rgw_user& uid = op_state.get_user_id();
+  if (uid.compare(RGW_USER_ANON_ID) == 0) {
     caps_allowed = false;
     return -EACCES;
   }
@@ -1642,7 +1662,7 @@ int RGWUser::init(RGWUserAdminOpState& op_state)
 {
   bool found = false;
   std::string swift_user;
-  std::string uid = op_state.get_user_id();
+  rgw_user& uid = op_state.get_user_id();
   std::string user_email = op_state.get_user_email();
   std::string access_key = op_state.get_access_key();
   std::string subuser = op_state.get_subuser();
@@ -1758,7 +1778,7 @@ int RGWUser::check_op(RGWUserAdminOpState& op_state, std::string *err_msg)
   bool same_id;
   bool populated;
   //bool existing_email = false; // this check causes a fault
-  std::string op_id = op_state.get_user_id();
+  rgw_user& op_id = op_state.get_user_id();
   std::string op_email = op_state.get_user_email();
 
   RGWUserInfo user_info;
@@ -1772,8 +1792,8 @@ int RGWUser::check_op(RGWUserAdminOpState& op_state, std::string *err_msg)
   }
 
   if (populated && !same_id) {
-    set_err_msg(err_msg, "user id mismatch, operation id: " + op_id\
-            + " does not match: " + user_id);
+    set_err_msg(err_msg, "user id mismatch, operation id: " + op_id.to_str()
+            + " does not match: " + user_id.to_str());
 
     return -EINVAL;
   }
@@ -1795,7 +1815,7 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
 
   RGWUserInfo user_info;
 
-  std::string uid = op_state.get_user_id();
+  rgw_user& uid = op_state.get_user_id();
   std::string user_email = op_state.get_user_email();
   std::string display_name = op_state.get_display_name();
 
@@ -1807,7 +1827,7 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
       return execute_modify(op_state, err_msg);
     }
 
-    set_err_msg(err_msg, "user: " + op_state.user_id + " exists");
+    set_err_msg(err_msg, "user: " + op_state.user_id.to_str() + " exists");
 
     return -EEXIST;
   }
@@ -1926,7 +1946,7 @@ int RGWUser::execute_remove(RGWUserAdminOpState& op_state, std::string *err_msg)
   int ret;
 
   bool purge_data = op_state.will_purge_data();
-  std::string uid = op_state.get_user_id();
+  rgw_user& uid = op_state.get_user_id();
   RGWUserInfo user_info = op_state.get_user_info();
 
   if (!op_state.has_existing_user()) {
@@ -1954,7 +1974,7 @@ int RGWUser::execute_remove(RGWUserAdminOpState& op_state, std::string *err_msg)
 
     std::map<std::string, RGWBucketEnt>::iterator it;
     for (it = m.begin(); it != m.end(); ++it) {
-      ret = rgw_remove_bucket(store, uid, ((*it).second).bucket, true);
+      ret = rgw_remove_bucket(store, ((*it).second).bucket, true);
       if (ret < 0) {
         set_err_msg(err_msg, "unable to delete user data");
         return ret;
@@ -2025,7 +2045,7 @@ int RGWUser::execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg)
   }
 
   // ensure that we can modify the user's attributes
-  if (user_id == RGW_USER_ANON_ID) {
+  if (user_id.compare(RGW_USER_ANON_ID) == 0) {
     set_err_msg(err_msg, "unable to modify anonymous user's info");
     return -EACCES;
   }
@@ -2037,7 +2057,7 @@ int RGWUser::execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg)
     // make sure we are not adding a duplicate email
     if (old_email.compare(op_email) != 0) {
       ret = rgw_get_user_info_by_email(store, op_email, duplicate_check);
-      if (ret >= 0 && duplicate_check.user_id != user_id) {
+      if (ret >= 0 && duplicate_check.user_id.compare(user_id) != 0) {
         set_err_msg(err_msg, "cannot add duplicate email");
         return -EEXIST;
       }
@@ -2091,7 +2111,7 @@ int RGWUser::execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg)
     do {
       ret = rgw_read_user_buckets(store, user_id, buckets, marker, max_buckets, false);
       if (ret < 0) {
-        set_err_msg(err_msg, "could not get buckets for uid:  " + user_id);
+        set_err_msg(err_msg, "could not get buckets for uid:  " + user_id.to_str());
         return ret;
       }
 
@@ -2507,7 +2527,9 @@ public:
     RGWObjVersionTracker objv_tracker;
     time_t mtime;
 
-    int ret = rgw_get_user_info_by_uid(store, entry, uci.info, &objv_tracker,
+    rgw_user uid(entry);
+
+    int ret = rgw_get_user_info_by_uid(store, uid, uci.info, &objv_tracker,
                                        &mtime, NULL, &uci.attrs);
     if (ret < 0) {
       return ret;
@@ -2530,9 +2552,11 @@ public:
       pattrs = &uci.attrs;
     }
 
+    rgw_user uid(entry);
+
     RGWUserInfo old_info;
     time_t orig_mtime;
-    int ret = rgw_get_user_info_by_uid(store, entry, old_info, &objv_tracker, &orig_mtime);
+    int ret = rgw_get_user_info_by_uid(store, uid, old_info, &objv_tracker, &orig_mtime);
     if (ret < 0 && ret != -ENOENT)
       return ret;
 
@@ -2558,7 +2582,10 @@ public:
 
   int remove(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker) {
     RGWUserInfo info;
-    int ret = rgw_get_user_info_by_uid(store, entry, info, &objv_tracker);
+
+    rgw_user uid(entry);
+
+    int ret = rgw_get_user_info_by_uid(store, uid, info, &objv_tracker);
     if (ret < 0)
       return ret;
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -581,8 +581,8 @@ static bool remove_old_indexes(RGWRados *store,
 
   if (!old_info.user_id.empty() &&
       old_info.user_id.compare(new_info.user_id) != 0) {
-    if (old_info.user_id.tenant != new_info.user_id.tenant) {
-      ldout(store->ctx(), 0) << "ERROR: tenant mismatch: " << old_info.user_id.tenant << " != " << new_info.user_id.tenant << dendl;
+    if (old_info.user_id.get_bns() != new_info.user_id.get_bns()) {
+      ldout(store->ctx(), 0) << "ERROR: tenant mismatch: " << dendl; // << old_info.user_id.default_tenant << " != " << new_info.user_id.default_tenant << dendl;
       return false;
     }
     ret = rgw_remove_uid_index(store, old_info.user_id);
@@ -685,7 +685,7 @@ static void dump_user_info(Formatter *f, RGWUserInfo &info,
 {
   f->open_object_section("user_info");
 
-  f->dump_string("tenant", info.user_id.tenant);
+  f->dump_string("bucket_namespace", info.user_id.get_bns().get_id());
   f->dump_string("user_id", info.user_id.id);
   f->dump_string("display_name", info.display_name);
   f->dump_string("email", info.user_email);

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -294,12 +294,12 @@ int rgw_get_user_info_from_index(RGWRados *store, string& key, rgw_bucket& bucke
  * returns: 0 on success, -ERR# on failure (including nonexistence)
  */
 int rgw_get_user_info_by_uid(RGWRados *store,
-                             rgw_user& uid,
+                             const rgw_user& uid,
                              RGWUserInfo& info,
-                             RGWObjVersionTracker *objv_tracker,
-                             time_t *pmtime,
-                             rgw_cache_entry_info *cache_info,
-                             map<string, bufferlist> *pattrs)
+                             RGWObjVersionTracker * const objv_tracker,
+                             time_t * const pmtime,
+                             rgw_cache_entry_info * const cache_info,
+                             map<string, bufferlist> * const pattrs)
 {
   bufferlist bl;
   RGWUID user_id;

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -49,7 +49,7 @@ extern int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id);
 /**
  * Get the anonymous (ie, unauthenticated) user info.
  */
-extern void rgw_get_anon_user(RGWUserInfo& info);
+extern void rgw_get_anon_user(RGWUserInfo& info, rgw_user& auth_user);
 
 /**
  * verify that user is an actual user, and not the anonymous user

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -49,12 +49,15 @@ extern int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id);
 /**
  * Get the anonymous (ie, unauthenticated) user info.
  */
-extern void rgw_get_anon_user(RGWUserInfo& info, rgw_user& auth_user);
+extern void rgw_get_anon_user(RGWUserInfo& info,
+                              rgw_user& auth_user,
+                              RGWRados * store = NULL,
+                              const std::string& account_name = std::string());
 
 /**
  * verify that user is an actual user, and not the anonymous user
  */
-extern bool rgw_user_is_authenticated(RGWUserInfo& info);
+extern bool rgw_user_is_authenticated(const rgw_user& auth_user);
 /**
  * Save the given user information to storage.
  * Returns: 0 on success, -ERR# on failure.

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -411,7 +411,6 @@ struct RGWUserAdminOpState {
     if (user_id.id.empty() || subuser.empty())
       return "";
 
-    // XXX have to ignore tenant here least we make a double-colon
     string kid = user_id.id;
     kid.append(":");
     kid.append(subuser);

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -85,7 +85,7 @@ extern int rgw_store_user_attrs(RGWRados *store,
  * returns: 0 on success, -ERR# on failure (including nonexistence)
  */
 extern int rgw_get_user_info_by_uid(RGWRados *store,
-                                    rgw_user& user_id,
+                                    const rgw_user& user_id,
                                     RGWUserInfo& info,
                                     RGWObjVersionTracker *objv_tracker = NULL,
                                     time_t *pmtime                     = NULL,

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -266,7 +266,7 @@ struct RGWUserAdminOpState {
     size_t pos = _subuser.find(":");
 
     if (pos != string::npos) {
-      user_id = _subuser.substr(0, pos);
+      user_id.id = _subuser.substr(0, pos);
       subuser = _subuser.substr(pos+1);
     } else {
       subuser = _subuser;
@@ -411,8 +411,9 @@ struct RGWUserAdminOpState {
     if (user_id.id.empty() || subuser.empty())
       return "";
 
+    // XXX have to ignore tenant here least we make a double-colon
     string kid;
-    user_id.to_str(kid);
+    user_id.id.to_str(kid);
     kid.append(":");
     kid.append(subuser);
 
@@ -424,7 +425,7 @@ struct RGWUserAdminOpState {
       return "";
 
     std::string generated_subuser;
-    user_id.to_str(generated_subuser);
+    user_id.to_str(generated_subuser); // P3: may blow up with nonempty tenant
     std::string rand_suffix;
 
     int sub_buf_size = RAND_SUBUSER_LEN + 1;

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -72,7 +72,7 @@ extern int rgw_store_user_info(RGWRados *store,
  * Returns: 0 on success, -ERR# on failure.
  */
 extern int rgw_store_user_attrs(RGWRados *store,
-                                string& user_id,
+                                const string& user_id,
                                 map<string, bufferlist>& attrs,
                                 map<string, bufferlist>* rmattrs,
                                 RGWObjVersionTracker *objv_tracker);

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -31,17 +31,21 @@ using namespace std;
  */
 struct RGWUID
 {
-  string user_id;
+  rgw_user user_id;
   void encode(bufferlist& bl) const {
-    ::encode(user_id, bl);
+    string s;
+    user_id.to_str(s);
+    ::encode(s, bl);
   }
   void decode(bufferlist::iterator& bl) {
-    ::decode(user_id, bl);
+    string s;
+    ::decode(s, bl);
+    user_id.from_str(s);
   }
 };
 WRITE_CLASS_ENCODER(RGWUID)
 
-extern int rgw_user_sync_all_stats(RGWRados *store, const string& user_id);
+extern int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id);
 /**
  * Get the anonymous (ie, unauthenticated) user info.
  */
@@ -78,7 +82,7 @@ extern int rgw_store_user_attrs(RGWRados *store,
  * returns: 0 on success, -ERR# on failure (including nonexistence)
  */
 extern int rgw_get_user_info_by_uid(RGWRados *store,
-                                    string& user_id,
+                                    rgw_user& user_id,
                                     RGWUserInfo& info,
                                     RGWObjVersionTracker *objv_tracker = NULL,
                                     time_t *pmtime                     = NULL,
@@ -123,7 +127,7 @@ extern int rgw_delete_user(RGWRados *store, RGWUserInfo& user, RGWObjVersionTrac
  * remove the different indexes
  */
 extern int rgw_remove_key_index(RGWRados *store, RGWAccessKey& access_key);
-extern int rgw_remove_uid_index(RGWRados *store, string& uid);
+extern int rgw_remove_uid_index(RGWRados *store, rgw_user& uid);
 extern int rgw_remove_email_index(RGWRados *store, string& email);
 extern int rgw_remove_swift_name_index(RGWRados *store, string& swift_name);
 
@@ -156,7 +160,7 @@ enum RGWUserId {
 struct RGWUserAdminOpState {
   // user attributes
   RGWUserInfo info;
-  std::string user_id;
+  rgw_user user_id;
   std::string user_email;
   std::string display_name;
   uint32_t max_buckets;
@@ -235,7 +239,7 @@ struct RGWUserAdminOpState {
     gen_secret = false;
     key_op = true;
   }
-  void set_user_id(std::string& id) {
+  void set_user_id(rgw_user& id) {
     if (id.empty())
       return;
 
@@ -386,7 +390,7 @@ struct RGWUserAdminOpState {
   RGWQuotaInfo& get_bucket_quota() { return bucket_quota; }
   RGWQuotaInfo& get_user_quota() { return user_quota; }
 
-  std::string get_user_id() { return user_id; }
+  rgw_user& get_user_id() { return user_id; }
   std::string get_subuser() { return subuser; }
   std::string get_access_key() { return id; }
   std::string get_secret_key() { return key; }
@@ -404,10 +408,11 @@ struct RGWUserAdminOpState {
   RGWUserCaps *get_caps_obj() { return &info.caps; }
 
   std::string build_default_swift_kid() {
-    if (user_id.empty() || subuser.empty())
+    if (user_id.id.empty() || subuser.empty())
       return "";
 
-    std::string kid = user_id;
+    string kid;
+    user_id.to_str(kid);
     kid.append(":");
     kid.append(subuser);
 
@@ -415,10 +420,11 @@ struct RGWUserAdminOpState {
   }
 
   std::string generate_subuser() {
-    if (user_id.empty())
+    if (user_id.id.empty())
       return "";
 
-    std::string generated_subuser = user_id;
+    std::string generated_subuser;
+    user_id.to_str(generated_subuser);
     std::string rand_suffix;
 
     int sub_buf_size = RAND_SUBUSER_LEN + 1;
@@ -437,7 +443,7 @@ struct RGWUserAdminOpState {
     return generated_subuser;
   }
 
-  RGWUserAdminOpState() : user_id(RGW_USER_ANON_ID), user_email(""), display_name(""), id(""), key ("")
+  RGWUserAdminOpState() : user_id(RGW_USER_ANON_ID)
   {
     max_buckets = RGW_DEFAULT_MAX_BUCKETS;
     key_type = -1;
@@ -489,7 +495,7 @@ class RGWAccessKeyPool
   RGWUser *user;
 
   std::map<std::string, int, ltstr_nocase> key_type_map;
-  std::string user_id;
+  rgw_user user_id;
   RGWRados *store;
 
   map<std::string, RGWAccessKey> *swift_keys;
@@ -531,7 +537,7 @@ class RGWSubUserPool
 {
   RGWUser *user;
 
-  string user_id;
+  rgw_user user_id;
   RGWRados *store;
   bool subusers_allowed;
 
@@ -593,7 +599,7 @@ private:
   RGWUserInfo old_info;
   RGWRados *store;
 
-  string user_id;
+  rgw_user user_id;
   bool info_stored;
 
   void set_populated() { info_stored = true; }

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -412,8 +412,7 @@ struct RGWUserAdminOpState {
       return "";
 
     // XXX have to ignore tenant here least we make a double-colon
-    string kid;
-    user_id.id.to_str(kid);
+    string kid = user_id.id;
     kid.append(":");
     kid.append(subuser);
 

--- a/src/test/rgw/test_rgw_manifest.cc
+++ b/src/test/rgw/test_rgw_manifest.cc
@@ -29,9 +29,9 @@
 #endif
 using namespace std;
 
-static void init_bucket(rgw_bucket *bucket, const char *name)
+static void init_bucket(rgw_bucket *bucket, const char *ten, const char *name)
 {
-  *bucket = rgw_bucket(name, ".data-pool", ".index-pool", "marker.", "bucket-id", NULL);
+  *bucket = rgw_bucket(ten, name, ".data-pool", ".index-pool", "marker.", "bucket-id", NULL);
 }
 
 void append_head(list<rgw_obj> *objs, rgw_obj& head)
@@ -62,7 +62,7 @@ static void gen_obj(uint64_t obj_size, uint64_t head_max_size, uint64_t stripe_s
 {
   manifest->set_trivial_rule(head_max_size, stripe_size);
 
-  init_bucket(bucket, "buck");
+  init_bucket(bucket, "", "buck");
 
   *head = rgw_obj(*bucket, "oid");
   gen->create_begin(g_ceph_context, manifest, *bucket, *head);

--- a/src/test/rgw/test_rgw_obj.cc
+++ b/src/test/rgw/test_rgw_obj.cc
@@ -32,7 +32,7 @@ using namespace std;
 
 static void init_bucket(rgw_bucket *bucket, const char *name)
 {
-  *bucket = rgw_bucket(name, ".data-pool", ".index-pool", "marker", "bucket-id", NULL);
+  *bucket = rgw_bucket("", name, ".data-pool", ".index-pool", "marker", "bucket-id", NULL);
 }
 
 void check_parsed_correctly(rgw_obj& obj, const string& name, const string& ns, const string& instance)


### PR DESCRIPTION
@yehudasa, @zaitcev

This is proposal of support for bucket namespaces of Swift API. The idea is to allow creation of users that will keep theirs _bucket entry points_ within RADOS objects prefixed accordingly to _UID's_.

Additionally, the PR incorporates changes from #4119 in order to bring full support for Swift URL schema - account name may be extracted from it depending on the configuration option. _rgw_user_ for authentication-related purposes is now split from the one for accessing account data. _reseller admin_ feature is also available.