### PR TITLE
Don't always succeed

### DIFF
--- a/qa/workunits/ceph-disk/ceph-disk.sh
+++ b/qa/workunits/ceph-disk/ceph-disk.sh
@@ -1,10 +1,26 @@
-source $(dirname $0)/../ceph-helpers-root.sh true
+#!/bin/bash -e
+if [ -f $(dirname $0)/../ceph-helpers-root.sh ]; then
+    source $(dirname $0)/../ceph-helpers-root.sh
+else
+    echo "$(dirname $0)/../ceph-helpers-root.sh does not exist."
+    exit 1
+fi
 
 install python-pytest
 install pytest
+
+PATH=$(dirname $0)/..:$PATH
+
+if ! which py.test > /dev/null; then
+    echo "py.test not installed"
+    exit 1
+fi
+
 sudo env PATH=$(dirname $0)/..:$PATH py.test -v $(dirname $0)/ceph-disk-test.py
+result=$?
+
 # own whatever was created as a side effect of the py.test run
 # so that it can successfully be removed later on by a non privileged 
 # process
 sudo chown -R $(id -u) $(dirname $0)
-
+exit $result


### PR DESCRIPTION
ceph-disk.sh fails to report the result of its tests, or failure to
perform those tests.

Catch installation failures and report them
Catch the test result and exit with that status code instead of
the result of chown.