### PR TITLE
Change osd journal padding mode.

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -629,6 +629,7 @@ int FileJournal::_fdump(Formatter &f, bool simple)
 
     if (!pos) {
       dout(2) << "_dump -- not readable" << dendl;
+      close();
       return false;
     }
     stringstream ss;

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -819,7 +819,7 @@ void FileJournal::write_header_sync()
   dout(20) << __func__ << " finish" << dendl;
 }
 
-int FileJournal::check_for_full(uint64_t seq, off64_t pos, off64_t size)
+int FileJournal::check_for_full(off64_t pos, off64_t size)
 {
   // already full?
   if (full_state != FULL_NOTFULL)
@@ -980,7 +980,7 @@ int FileJournal::prepare_single_write(bufferlist& bl, off64_t& queue_pos, uint64
   off64_t size = ROUND_UP_TO(base_size + pre_pad, header.alignment);
   unsigned post_pad = size - base_size - pre_pad;
 
-  int r = check_for_full(seq, queue_pos, size);
+  int r = check_for_full(queue_pos, size);
   if (r < 0)
     return r;   // ENOSPC or EAGAIN
 

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -1097,13 +1097,14 @@ void FileJournal::do_write(bufferlist& bl)
   // entry
   off64_t pos = write_pos;
 
-  // Adjust write_pos
-  align_bl(pos, bl);
   write_pos += bl.length();
   if (write_pos >= header.max_size)
     write_pos = write_pos - header.max_size + get_top();
 
   write_lock.Unlock();
+
+  // Adjust write_pos
+  align_bl(pos, bl);
 
   // split?
   off64_t split = 0;

--- a/src/os/FileJournal.h
+++ b/src/os/FileJournal.h
@@ -309,7 +309,8 @@ private:
 
   void queue_completions_thru(uint64_t seq);
 
-  int check_for_full(off64_t pos, off64_t size);
+  int check_for_full(off64_t pos, off64_t size, bool skip_full=false);
+  int prepare_padding_entry(bufferlist& bl, off64_t& queue_pos);
   int prepare_multi_write(bufferlist& bl, uint64_t& orig_ops, uint64_t& orig_bytee);
   int prepare_single_write(bufferlist& bl, off64_t& queue_pos, uint64_t& orig_ops, uint64_t& orig_bytes);
   void do_write(bufferlist& bl);
@@ -443,7 +444,8 @@ private:
   enum read_entry_result {
     SUCCESS,
     FAILURE,
-    MAYBE_CORRUPT
+    MAYBE_CORRUPT,
+    SKIP //this entry is padding entry
   };
 
   /**

--- a/src/os/FileJournal.h
+++ b/src/os/FileJournal.h
@@ -309,7 +309,7 @@ private:
 
   void queue_completions_thru(uint64_t seq);
 
-  int check_for_full(uint64_t seq, off64_t pos, off64_t size);
+  int check_for_full(off64_t pos, off64_t size);
   int prepare_multi_write(bufferlist& bl, uint64_t& orig_ops, uint64_t& orig_bytee);
   int prepare_single_write(bufferlist& bl, off64_t& queue_pos, uint64_t& orig_ops, uint64_t& orig_bytes);
   void do_write(bufferlist& bl);


### PR DESCRIPTION
Now for every entry, we pad data if need. But for most case, we fetch more entries as a system-write. So we can add padding data at the end of system-write content if need. This can reduce much padding data for small write.