### PR TITLE
logrotate: ignore exit status 1 from killall

### DIFF
--- a/src/logrotate.conf
+++ b/src/logrotate.conf
@@ -4,7 +4,7 @@
     compress
     sharedscripts
     postrotate
-	killall -q -1 ceph-mon ceph-mds ceph-osd
+        killall -q -1 ceph-mon ceph-mds ceph-osd || true
     endscript
     missingok
     notifempty

--- a/src/rgw/logrotate.conf
+++ b/src/rgw/logrotate.conf
@@ -4,7 +4,7 @@
     compress
     sharedscripts
     postrotate
-	killall -q -1 radosgw
+        killall -q -1 radosgw || true
     endscript
     missingok
     notifempty


### PR DESCRIPTION
If any of ceph-osd, ceph-mon, ceph-mds were not running then
killall -q will exit status 1, leading to anacron sending a mail

  error: error running shared postrotate script for '/var/log/ceph/*.log '

Fix by overriding the exit status with || true.

Fixes: #13033
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>