### PR TITLE
hit set clear repops fired in same epoch as map change -- segfault since they fall into the new interval even though the repops are cleared

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5272,12 +5272,12 @@ void PG::handle_advance_map(
 	   << dendl;
   update_osdmap_ref(osdmap);
   pool.update(osdmap);
-  if (pool.info.last_change == osdmap_ref->get_epoch())
-    on_pool_change();
   AdvMap evt(
     osdmap, lastmap, newup, up_primary,
     newacting, acting_primary);
   recovery_state.handle_event(evt, rctx);
+  if (pool.info.last_change == osdmap_ref->get_epoch())
+    on_pool_change();
 }
 
 void PG::handle_activate_map(RecoveryCtx *rctx)


### PR DESCRIPTION
http://tracker.ceph.com/issues/13037