### PR TITLE
DNM: osd: allow peek_map_epoch to return an error

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2819,7 +2819,13 @@ void OSD::load_pgs()
 
     dout(10) << "pgid " << pgid << " coll " << coll_t(pgid) << dendl;
     bufferlist bl;
-    epoch_t map_epoch = PG::peek_map_epoch(store, pgid, &bl);
+    epoch_t map_epoch = 0;
+    int r = PG::peek_map_epoch(store, pgid, &map_epoch, &bl);
+    if (r < 0) {
+      derr << __func__ << " unable to peek at " << pgid << " metadata, skipping"
+	   << dendl;
+      continue;
+    }
 
     PG *pg = NULL;
     if (map_epoch > 0) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2808,9 +2808,10 @@ bool PG::_has_removal_flag(ObjectStore *store,
   return false;
 }
 
-epoch_t PG::peek_map_epoch(ObjectStore *store,
-			   spg_t pgid,
-			   bufferlist *bl)
+int PG::peek_map_epoch(ObjectStore *store,
+		       spg_t pgid,
+		       epoch_t *pepoch,
+		       bufferlist *bl)
 {
   coll_t coll(pgid);
   hobject_t legacy_infos_oid(OSD::make_infos_oid());
@@ -2855,7 +2856,8 @@ epoch_t PG::peek_map_epoch(ObjectStore *store,
       return 0;
     if (struct_v < 6) {
       ::decode(cur_epoch, bp);
-      return cur_epoch;
+      *pepoch = cur_epoch;
+      return 0;
     }
 
     // get epoch out of leveldb
@@ -2870,7 +2872,8 @@ epoch_t PG::peek_map_epoch(ObjectStore *store,
   } else {
     assert(0 == "unable to open pg metadata");
   }
-  return cur_epoch;
+  *pepoch = cur_epoch;
+  return 0;
 }
 
 #pragma GCC diagnostic pop

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2866,7 +2866,12 @@ int PG::peek_map_epoch(ObjectStore *store,
     values.clear();
     keys.insert(ek);
     store->omap_get_values(META_COLL, legacy_infos_oid, keys, &values);
-    assert(values.size() == 1);
+    if (values.size() < 1) {
+      // see #13060: this suggests we failed to upgrade this pg
+      // because it was a zombie and then removed the legacy infos
+      // object.  skip it.
+      return -1;
+    }
     bufferlist::iterator p = values[ek].begin();
     ::decode(cur_epoch, p);
   } else {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2146,7 +2146,8 @@ public:
     __u8 &);
   void read_state(ObjectStore *store, bufferlist &bl);
   static bool _has_removal_flag(ObjectStore *store, spg_t pgid);
-  static epoch_t peek_map_epoch(ObjectStore *store, spg_t pgid, bufferlist *bl);
+  static int peek_map_epoch(ObjectStore *store, spg_t pgid,
+			    epoch_t *pepoch, bufferlist *bl);
   void update_snap_map(
     const vector<pg_log_entry_t> &log_entries,
     ObjectStore::Transaction& t);

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -738,10 +738,14 @@ int mark_pg_for_removal(ObjectStore *fs, spg_t pgid, ObjectStore::Transaction *t
   ghobject_t pgmeta_oid(info.pgid.make_pgmeta_oid());
 
   bufferlist bl;
-  PG::peek_map_epoch(fs, pgid, &bl);
+  epoch_t pg_epoch = 0;
+  int r = PG::peek_map_epoch(fs, pgid, &pg_epoch, &bl);
+  if (r < 0)
+    cerr << __func__ << " warning: peek_map_epoch fails" << std::endl;
+
   map<epoch_t,pg_interval_t> past_intervals;
   __u8 struct_v;
-  int r = PG::read_info(fs, pgid, coll, bl, info, past_intervals, struct_v);
+  r = PG::read_info(fs, pgid, coll, bl, info, past_intervals, struct_v);
   if (r < 0) {
     cerr << __func__ << " error on read_info " << cpp_strerror(-r) << std::endl;
     return r;
@@ -3058,7 +3062,11 @@ int main(int argc, char **argv)
     }
 
     bufferlist bl;
-    map_epoch = PG::peek_map_epoch(fs, pgid, &bl);
+    map_epoch = 0;
+    r = PG::peek_map_epoch(fs, pgid, &map_epoch, &bl);
+    if (r < 0)
+      cerr << "peek_map_epoch returns an error" << std::endl;
+
     if (debug)
       cerr << "map_epoch " << map_epoch << std::endl;
 


### PR DESCRIPTION
Allow PG::peek_map_epoch to return an error indicating the PG
should be skipped.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 8a84ad63fb9ca3dc2d619811bccc1e941023ceb3)

[fixed *pepoch default of 0]
[fixed other return paths in peek_map_epoch]