### PR TITLE
doc: remove references to default data/metadata pools

### DIFF
--- a/doc/rados/operations/crush-map.rst
+++ b/doc/rados/operations/crush-map.rst
@@ -479,11 +479,7 @@ CRUSH maps support the notion of 'CRUSH rules', which are the rules that
 determine data placement for a pool. For large clusters, you will likely create
 many pools where each pool may have its own CRUSH ruleset and rules. The default
 CRUSH map has a rule for each pool, and one ruleset assigned to each of the
-default pools, which include:
-
-- ``data``
-- ``metadata``
-- ``rbd``
+default pools.
 
 .. note:: In most cases, you will not need to modify the default rules. When
    you create a new pool, its default ruleset is ``0``.

--- a/doc/rados/operations/monitoring-osd-pg.rst
+++ b/doc/rados/operations/monitoring-osd-pg.rst
@@ -230,9 +230,9 @@ few cases:
    Placement group IDs consist of the pool number (not pool name) followed 
    by a period (.) and the placement group ID--a hexadecimal number. You
    can view pool numbers and their names from the output of ``ceph osd 
-   lspools``. The default pool names ``data``, ``metadata`` and ``rbd`` 
-   correspond to pool numbers ``0``, ``1`` and ``2`` respectively. A fully 
-   qualified placement group ID has the following form::
+   lspools``. For example, the default pool ``rbd`` corresponds to
+   pool number ``0``. A fully qualified placement group ID has the
+   following form::
    
    	{pool-num}.{pg-id}
    

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -38,11 +38,7 @@ To list your cluster's pools, execute::
 
 	ceph osd lspools
 
-The default pools include:
-
-- ``data``
-- ``metadata``
-- ``rbd``
+On a freshly installed cluster, only the ``rbd`` pool exists.
 
 
 .. _createpool:

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -201,8 +201,7 @@ The following entries describe each capability.
 Pool
 ----
 
-A pool is a logical partition where users store data. By default, a Ceph Storage
-Cluster has `pools`_ for ``data``, ``rbd`` and ``metadata`` (metadata server).
+A pool is a logical partition where users store data.
 In Ceph deployments, it is common to create a pool as a logical partition for
 similar types of data. For example, when deploying Ceph as a backend for
 OpenStack, a typical deployment would have pools for volumes, images, backups


### PR DESCRIPTION
These haven't existed since 0.84 -- the cephfs documentation
was updated at the time, but there were also references in the
rados documentation.

Signed-off-by: John Spray <john.spray@redhat.com>