### PR TITLE
ceph.spec: respect CEPH_EXTRA_CONFIGURE_ARGS

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -524,7 +524,7 @@ done
 %endif
 
 ./autogen.sh
-MY_CONF_OPT=""
+MY_CONF_OPT="$CEPH_EXTRA_CONFIGURE_ARGS"
 
 MY_CONF_OPT="$MY_CONF_OPT --with-radosgw"
 


### PR DESCRIPTION
this fixes leak tcmalloc (non)linkage on rpms and leak checking in sepia.