### PR TITLE
Pipe: Drop connect_seq increase line

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1694,10 +1694,8 @@ void Pipe::writer()
 			<< " policy.server=" << policy.server << dendl;
 
     // standby?
-    if (is_queued() && state == STATE_STANDBY && !policy.server) {
-      connect_seq++;
+    if (is_queued() && state == STATE_STANDBY && !policy.server)
       state = STATE_CONNECTING;
-    }
 
     // connect?
     if (state == STATE_CONNECTING) {


### PR DESCRIPTION
Revert commit 0fc47e267b6f8dcd4511d887d5ad37d460374c25.

When accepting and "connect.connect_seq == existing->connect_seq",
existing->state maybe STATE_OPEN, STATE_STANDBY or STANDY_CONNECTING.
This commit only fix partial problem and want to assert
"(existing->state == STATE_CONNECTING)".

So later we added codes to catch
"(existing->state == STATE_OPEN || existing->state == STATE_STANDBY)"
before asserting.

Backport: dumpling, firefly, giant

Signed-off-by: Haomai Wang <haomaiwang@gmail.com>
(cherry picked from commit 67225cb3ee1f6d274a02293724942bdb25cec8ca)