### PR TITLE
rgw: backport content-type casing

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -555,7 +555,7 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
 
   int r;
   if (content_type) {
-      r = s->cio->print("Content-type: %s\r\n", content_type);
+      r = s->cio->print("Content-Type: %s\r\n", content_type);
       if (r < 0) {
 	ldout(s->cct, 0) << "ERROR: s->cio->print() returned err=" << r << dendl;
       }


### PR DESCRIPTION
Addresses: http://tracker.ceph.com/issues/13047

Since https://github.com/ceph/ceph/pull/5718 was recently merged into hammer (improving the
surrouding content-type code) it appears now is a good time to backport the content-type casing
fix.