### PR TITLE
tools: print the map infomation in human readable format, and clean-up when operation is completed. 

### DIFF
--- a/src/tools/Makefile-server.am
+++ b/src/tools/Makefile-server.am
@@ -3,7 +3,7 @@ ceph_osdomap_tool_LDADD = $(LIBOS) $(CEPH_GLOBAL) $(BOOST_PROGRAM_OPTIONS_LIBS)
 bin_DEBUGPROGRAMS += ceph-osdomap-tool
 
 ceph_monstore_tool_SOURCES = tools/ceph_monstore_tool.cc
-ceph_monstore_tool_LDADD = $(LIBOS) $(CEPH_GLOBAL) $(BOOST_PROGRAM_OPTIONS_LIBS)
+ceph_monstore_tool_LDADD = $(LIBOS) $(CEPH_GLOBAL) $(BOOST_PROGRAM_OPTIONS_LIBS) $(LIBMON)
 bin_DEBUGPROGRAMS += ceph-monstore-tool
 
 ceph_kvstore_tool_SOURCES = tools/ceph_kvstore_tool.cc


### PR DESCRIPTION
(1) fix bug:even get map failed, it still create a local file.
(2) add option:now we can print the map infomation in human readable format just use this tool (by -r).