### PR TITLE
rgw:modify the error message of creating an user with existing email or key

### DIFF
--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -202,6 +202,9 @@ struct RGWUserAdminOpState {
   bool system_specified;
   bool key_op;
   bool temp_url_key_specified;
+  bool found_existing_uid = false;
+  bool found_existing_email = false;
+  bool found_existing_key = false;
 
   // req parameters
   bool populated;


### PR DESCRIPTION
when creating an user with existing email or key,the error message is "user:xxx exists"

eg.execute " radosgw-admin user  create --uid=tid --display-name=tname --email=temail",then user  
     tid create.
     execute "radosgw-admin user  create --uid=testid --display-name=testname --email=temail",it's  
     failed ,the error message is "could not create user: unable to create user, user: tid exists"

we don't know it's uid or email exists,and key too.
so we have to make sure uid,email and key is exists or not 

    
Signed-off-by:Zeqiang Zhuang <zhuang.zeqiang@h3c.com>