### PR TITLE
common: osd_pg_epoch_persisted_max_stale < map_cache_size

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -679,7 +679,7 @@ OPTION(osd_default_notify_timeout, OPT_U32, 30) // default notify timeout in sec
 OPTION(osd_kill_backfill_at, OPT_INT, 0)
 
 // Bounds how infrequently a new map epoch will be persisted for a pg
-OPTION(osd_pg_epoch_persisted_max_stale, OPT_U32, 200)
+OPTION(osd_pg_epoch_persisted_max_stale, OPT_U32, 150) // make this < map_cache_size!
 
 OPTION(osd_min_pg_log_entries, OPT_U32, 3000)  // number of entries to keep in the pg log when trimming it
 OPTION(osd_max_pg_log_entries, OPT_U32, 10000) // max entries, say when degraded, before we trim


### PR DESCRIPTION
1ff51a299d20dd73a95ba55fdec57498b8c71c13 reduced map_cache_size to 200,
osd_pg_epoch_persisted_max_stale must be lowered because it does not
make sense for it to be the equal or greater than map_cache_size.

Signed-off-by: Loic Dachary <ldachary@redhat.com>