### PR TITLE
logrotate: logs are now owned by ceph:ceph

### DIFF
--- a/src/logrotate.conf
+++ b/src/logrotate.conf
@@ -8,4 +8,5 @@
     endscript
     missingok
     notifempty
+    su ceph ceph
 }

--- a/src/rgw/logrotate.conf
+++ b/src/rgw/logrotate.conf
@@ -8,4 +8,5 @@
     endscript
     missingok
     notifempty
+    su ceph ceph
 }


### PR DESCRIPTION
Add the su directive to avoid this error during logrotate:

error: skipping "/var/log/ceph/ceph-osd.0.log" because parent
directory has insecure permissions (It's world writable or writable
by group which is not "root") Set "su" directive in config file to
tell logrotate which user/group should be used for rotation.

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>