### PR TITLE
rgw:Prohibit modifying user information when creating a user

### DIFF
--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1773,11 +1773,6 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
 
   // fail if the user exists already
   if (op_state.has_existing_user()) {
-    if (!op_state.exclusive &&
-        (user_email.empty() || old_info.user_email == user_email) &&
-        old_info.display_name == display_name) {
-      return execute_modify(op_state, err_msg);
-    }
 
     set_err_msg(err_msg, "user: " + op_state.user_id + " exists");
 


### PR DESCRIPTION
1.It is not reasonable to modify user information by creating a user's way.
2.If you want to modify the user information, you can use the modification command
Signed-off-by: Peiyang Liu liu.peiyang@h3c.com