### PR TITLE
rgw:  clarify the error message when trying to create an existed user

### DIFF
--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -202,7 +202,10 @@ struct RGWUserAdminOpState {
   bool system_specified;
   bool key_op;
   bool temp_url_key_specified;
-
+  bool found_by_uid; 
+  bool found_by_email;  
+  bool found_by_key;
+ 
   // req parameters
   bool populated;
   bool initialized;
@@ -477,6 +480,9 @@ struct RGWUserAdminOpState {
     bucket_quota_specified = false;
     temp_url_key_specified = false;
     user_quota_specified = false;
+    found_by_uid = false;
+    found_by_email = false;
+    found_by_key = false;
   }
 };
 


### PR DESCRIPTION
Modify the error message when trying to create an existed user to indicate which of uid, email or key actually causes the conflict.

Signed-off-by: Zeqiang Zhuang <zhuang.zeqiang@h3c.com>