### PR TITLE
#12137: cephfs-data-scan scan_frags

### DIFF
--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -626,6 +626,9 @@ int DataScan::scan_inodes()
       have_backtrace = false;
     }
 
+    InodeStore dentry;
+    build_file_dentry(obj_name_ino, file_size, file_mtime, guessed_layout, &dentry);
+
     // Inject inode to the metadata pool
     if (have_backtrace) {
       inode_backpointer_t root_bp = *(backtrace.ancestors.rbegin());
@@ -633,8 +636,7 @@ int DataScan::scan_inodes()
         /* Special case for strays: even if we have a good backtrace,
          * don't put it in the stray dir, because while that would technically
          * give it linkage it would still be invisible to the user */
-        r = driver->inject_lost_and_found(
-            obj_name_ino, file_size, file_mtime, guessed_layout);
+        r = driver->inject_lost_and_found(obj_name_ino, dentry);
         if (r < 0) {
           dout(4) << "Error injecting 0x" << std::hex << backtrace.ino
             << std::dec << " into lost+found: " << cpp_strerror(r) << dendl;
@@ -645,8 +647,7 @@ int DataScan::scan_inodes()
         }
       } else {
         /* Happy case: we will inject a named dentry for this inode */
-        r = driver->inject_with_backtrace(
-            backtrace, file_size, file_mtime, guessed_layout);
+        r = driver->inject_with_backtrace(backtrace, dentry);
         if (r < 0) {
           dout(4) << "Error injecting 0x" << std::hex << backtrace.ino
             << std::dec << " with backtrace: " << cpp_strerror(r) << dendl;
@@ -659,7 +660,7 @@ int DataScan::scan_inodes()
     } else {
       /* Backtrace-less case: we will inject a lost+found dentry */
       r = driver->inject_lost_and_found(
-          obj_name_ino, file_size, file_mtime, guessed_layout);
+          obj_name_ino, dentry);
       if (r < 0) {
         dout(4) << "Error injecting 0x" << std::hex << obj_name_ino
           << std::dec << " into lost+found: " << cpp_strerror(r) << dendl;
@@ -749,8 +750,8 @@ int MetadataDriver::read_dentry(inodeno_t parent_ino, frag_t frag,
   return 0;
 }
 
-int MetadataDriver::inject_lost_and_found(inodeno_t ino, uint64_t file_size,
-    time_t file_mtime, const ceph_file_layout &layout)
+int MetadataDriver::inject_lost_and_found(
+    inodeno_t ino, const InodeStore &dentry)
 {
   // Create lost+found if doesn't exist
   bool created = false;
@@ -796,31 +797,12 @@ int MetadataDriver::inject_lost_and_found(inodeno_t ino, uint64_t file_size,
   }
 
   InodeStore recovered_ino;
-  recovered_ino.inode.mode = 0500 | S_IFREG;
-  recovered_ino.inode.size = file_size;
-  recovered_ino.inode.max_size_ever = file_size;
-  recovered_ino.inode.mtime.tv.tv_sec = file_mtime;
-  recovered_ino.inode.atime.tv.tv_sec = file_mtime;
-  recovered_ino.inode.ctime.tv.tv_sec = file_mtime;
 
-  recovered_ino.inode.layout = layout;
-
-  recovered_ino.inode.truncate_seq = 1;
-  recovered_ino.inode.truncate_size = -1ull;
-
-  recovered_ino.inode.inline_data.version = CEPH_INLINE_NONE;
-
-  recovered_ino.inode.nlink = 1;
-  recovered_ino.inode.ino = ino;
-  recovered_ino.inode.version = 1;
-  recovered_ino.inode.backtrace_version = 1;
-  recovered_ino.inode.uid = g_conf->mds_root_ino_uid;
-  recovered_ino.inode.gid = g_conf->mds_root_ino_gid;
 
   const std::string dname = lost_found_dname(ino);
 
   // Write dentry into lost+found dirfrag
-  return inject_linkage(lf_ino.inode.ino, dname, frag_t(), recovered_ino);
+  return inject_linkage(lf_ino.inode.ino, dname, frag_t(), dentry);
 }
 
 
@@ -932,8 +914,7 @@ int MetadataDriver::get_frag_of(
 
 
 int MetadataDriver::inject_with_backtrace(
-    const inode_backtrace_t &backtrace, uint64_t file_size, time_t file_mtime,
-    const ceph_file_layout &layout)
+    const inode_backtrace_t &backtrace, const InodeStore &dentry)
     
 {
 
@@ -1042,53 +1023,41 @@ int MetadataDriver::inject_with_backtrace(
           << dname << " already exists but points to 0x"
           << std::hex << existing_dentry.inode.ino << std::dec << dendl;
         // Fall back to lost+found!
-        return inject_lost_and_found(backtrace.ino, file_size, file_mtime,
-            layout);
+        return inject_lost_and_found(backtrace.ino, dentry);
       }
     }
 
     // Inject linkage
     // ==============
+
     if (write_dentry) {
-      InodeStore dentry;
       if (i == backtrace.ancestors.begin()) {
-        // This is the linkage for a file
-        dentry.inode.mode = 0500 | S_IFREG;
+        // This is the linkage for the file of interest
         dout(10) << "Linking inode 0x" << std::hex << ino
           << " at 0x" << parent_ino << "/" << dname << std::dec
-          << " with size=" << file_size << " bytes" << dendl;
+          << " with size=" << dentry.inode.size << " bytes" << dendl;
 
-        // The file size and mtime we learned by scanning globally
-        dentry.inode.size = file_size;
-        dentry.inode.max_size_ever = file_size;
-        dentry.inode.mtime.tv.tv_sec = file_mtime;
-        dentry.inode.atime.tv.tv_sec = file_mtime;
-        dentry.inode.ctime.tv.tv_sec = file_mtime;
-
-        dentry.inode.layout = layout;
-
-        dentry.inode.truncate_seq = 1;
-        dentry.inode.truncate_size = -1ull;
-
-        dentry.inode.inline_data.version = CEPH_INLINE_NONE;
+        r = inject_linkage(parent_ino, dname, fragment, dentry);
       } else {
-        // This is the linkage for a directory
-        dentry.inode.mode = 0755 | S_IFDIR;
+        // This is the linkage for an ancestor directory
+        InodeStore ancestor_dentry;
+        ancestor_dentry.inode.mode = 0755 | S_IFDIR;
 
         // Set nfiles to something non-zero, to fool any other code
         // that tries to ignore 'empty' directories.  This won't be
         // accurate, but it should avoid functional issues.
-        dentry.inode.dirstat.nfiles = 1;
-        dentry.inode.size = 1;
+        ancestor_dentry.inode.dirstat.nfiles = 1;
+        ancestor_dentry.inode.size = 1;
 
+        ancestor_dentry.inode.nlink = 1;
+        ancestor_dentry.inode.ino = ino;
+        ancestor_dentry.inode.uid = g_conf->mds_root_ino_uid;
+        ancestor_dentry.inode.gid = g_conf->mds_root_ino_gid;
+        ancestor_dentry.inode.version = 1;
+        ancestor_dentry.inode.backtrace_version = 1;
+        r = inject_linkage(parent_ino, dname, fragment, ancestor_dentry);
       }
-      dentry.inode.nlink = 1;
-      dentry.inode.ino = ino;
-      dentry.inode.uid = g_conf->mds_root_ino_uid;
-      dentry.inode.gid = g_conf->mds_root_ino_gid;
-      dentry.inode.version = 1;
-      dentry.inode.backtrace_version = 1;
-      r = inject_linkage(parent_ino, dname, fragment, dentry);
+
       if (r < 0) {
         return r;
       }
@@ -1287,9 +1256,7 @@ int LocalFileDriver::inject_data(
 
 int LocalFileDriver::inject_with_backtrace(
     const inode_backtrace_t &bt,
-    uint64_t size,
-    time_t mtime,
-    const ceph_file_layout &layout)
+    const InodeStore &dentry)
 {
   std::string path_builder = path;
 
@@ -1307,7 +1274,7 @@ int LocalFileDriver::inject_with_backtrace(
     if (is_file) {
       // FIXME: inject_data won't cope with interesting (i.e. striped)
       // layouts (need a librados-compatible Filer to read these)
-      inject_data(path_builder, size, layout.fl_object_size, bt.ino);
+      inject_data(path_builder, dentry.inode.size, dentry.inode.layout.fl_object_size, bt.ino);
     } else {
       int r = mkdir(path_builder.c_str(), 0755);
       if (r != 0 && r != -EPERM) {
@@ -1323,9 +1290,7 @@ int LocalFileDriver::inject_with_backtrace(
 
 int LocalFileDriver::inject_lost_and_found(
     inodeno_t ino,
-    uint64_t size,
-    time_t mtime,
-    const ceph_file_layout &layout)
+    const InodeStore &dentry)
 {
   std::string lf_path = path + "/lost+found";
   int r = mkdir(lf_path.c_str(), 0755);
@@ -1336,7 +1301,7 @@ int LocalFileDriver::inject_lost_and_found(
   }
   
   std::string file_path = lf_path + "/" + lost_found_dname(ino);
-  return inject_data(file_path, size, layout.fl_object_size, ino);
+  return inject_data(file_path, dentry.inode.size, dentry.inode.layout.fl_object_size, ino);
 }
 
 int LocalFileDriver::init_roots(int64_t data_pool_id)
@@ -1372,5 +1337,33 @@ int LocalFileDriver::check_roots(bool *result)
   }
 
   return 0;
+}
+
+void DataScan::build_file_dentry(
+    inodeno_t ino, uint64_t file_size, time_t file_mtime,
+    const ceph_file_layout &layout, InodeStore *out)
+{
+  assert(out != NULL);
+
+  out->inode.mode = 0500 | S_IFREG;
+  out->inode.size = file_size;
+  out->inode.max_size_ever = file_size;
+  out->inode.mtime.tv.tv_sec = file_mtime;
+  out->inode.atime.tv.tv_sec = file_mtime;
+  out->inode.ctime.tv.tv_sec = file_mtime;
+
+  out->inode.layout = layout;
+
+  out->inode.truncate_seq = 1;
+  out->inode.truncate_size = -1ull;
+
+  out->inode.inline_data.version = CEPH_INLINE_NONE;
+
+  out->inode.nlink = 1;
+  out->inode.ino = ino;
+  out->inode.version = 1;
+  out->inode.backtrace_version = 1;
+  out->inode.uid = g_conf->mds_root_ino_uid;
+  out->inode.gid = g_conf->mds_root_ino_gid;
 }
 

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -863,7 +863,7 @@ int DataScan::scan_frags()
 
     InodeStore dentry;
     build_dir_dentry(obj_name_ino, fnode.fragstat.nfiles,
-        fnode.fragstat.nsubdirs, fnode.fragstat.mtime, loaded_layout, &dentry);
+        fnode.fragstat.mtime, loaded_layout, &dentry);
 
     // Inject inode to the metadata pool
     if (have_backtrace) {
@@ -1008,7 +1008,7 @@ int MetadataDriver::inject_lost_and_found(
     memset(&inherit_layout, 0, sizeof(inherit_layout));
 
     // Construct LF inode
-    build_dir_dentry(CEPH_INO_LOST_AND_FOUND, 1, 0, 0, inherit_layout, &lf_ino);
+    build_dir_dentry(CEPH_INO_LOST_AND_FOUND, 1, 0, inherit_layout, &lf_ino);
 
     // Inject link to LF inode in the root dir
     r = inject_linkage(CEPH_INO_ROOT, "lost+found", frag_t(), lf_ino);
@@ -1602,7 +1602,7 @@ void MetadataTool::build_file_dentry(
 }
 
 void MetadataTool::build_dir_dentry(
-    inodeno_t ino, uint64_t nfiles, uint64_t nsubdirs,
+    inodeno_t ino, uint64_t nfiles,
     time_t mtime, const ceph_file_layout &layout, InodeStore *out)
 {
   assert(out != NULL);
@@ -1622,7 +1622,7 @@ void MetadataTool::build_dir_dentry(
 
   out->inode.inline_data.version = CEPH_INLINE_NONE;
 
-  out->inode.nlink = 2 + nsubdirs;
+  out->inode.nlink = 1;
   out->inode.ino = ino;
   out->inode.version = 1;
   out->inode.backtrace_version = 1;

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -149,7 +149,7 @@ class MetadataTool
    * Construct a synthetic InodeStore for a directory
    */
   void build_dir_dentry(
-    inodeno_t ino, uint64_t nfiles, uint64_t nsubdirs,
+    inodeno_t ino, uint64_t nfiles,
     time_t mtime,
     const ceph_file_layout &layout,
     InodeStore *out);

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -128,14 +128,51 @@ class LocalFileDriver : public RecoveryDriver
 };
 
 /**
- * A class that knows how to manipulate CephFS metadata pools
+ * A class that knows how to work with objects in a CephFS
+ * metadata pool.
  */
-class MetadataDriver : public RecoveryDriver
+class MetadataTool
 {
   protected:
 
-    librados::IoCtx metadata_io;
+  librados::IoCtx metadata_io;
 
+  /**
+   * Construct a synthetic InodeStore for a normal file
+   */
+  void build_file_dentry(
+    inodeno_t ino, uint64_t file_size, time_t file_mtime,
+    const ceph_file_layout &layout,
+    InodeStore *out);
+
+  /**
+   * Construct a synthetic InodeStore for a directory
+   */
+  void build_dir_dentry(
+    inodeno_t ino, uint64_t nfiles, uint64_t nsubdirs,
+    time_t mtime,
+    const ceph_file_layout &layout,
+    InodeStore *out);
+
+  /**
+   * Try and read an fnode from a dirfrag
+   */
+  int read_fnode(inodeno_t ino, frag_t frag,
+                 fnode_t *fnode, uint64_t *read_version);
+
+  /**
+   * Try and read a dentry from a dirfrag
+   */
+  int read_dentry(inodeno_t parent_ino, frag_t frag,
+                  const std::string &dname, InodeStore *inode);
+};
+
+/**
+ * A class that knows how to manipulate CephFS metadata pools
+ */
+class MetadataDriver : public RecoveryDriver, public MetadataTool
+{
+  protected:
     /**
      * Create a .inode object, i.e. root or mydir
      */
@@ -146,19 +183,6 @@ class MetadataDriver : public RecoveryDriver
      * trying to go ahead and inject metadata.
      */
     int root_exists(inodeno_t ino, bool *result);
-
-    /**
-     * Try and read an fnode from a dirfrag
-     */
-    int read_fnode(inodeno_t ino, frag_t frag,
-                   fnode_t *fnode, uint64_t *read_version);
-
-    /**
-     * Try and read a dentry from a dirfrag
-     */
-    int read_dentry(inodeno_t parent_ino, frag_t frag,
-                    const std::string &dname, InodeStore *inode);
-
     int find_or_create_dirfrag(
         inodeno_t ino,
         frag_t fragment,
@@ -196,12 +220,12 @@ class MetadataDriver : public RecoveryDriver
     int check_roots(bool *result);
 };
 
-class DataScan : public MDSUtility
+class DataScan : public MDSUtility, public MetadataTool
 {
   protected:
     RecoveryDriver *driver;
 
-    // IoCtx for data pool (where we scrape backtraces from)
+    // IoCtx for data pool (where we scrape file backtraces from)
     librados::IoCtx data_io;
     // Remember the data pool ID for use in layouts
     int64_t data_pool_id;
@@ -218,6 +242,12 @@ class DataScan : public MDSUtility
      * Scan data pool for file sizes and mtimes
      */
     int scan_extents();
+
+    /**
+     * Scan metadata pool for 0th dirfrags to link orphaned
+     * directory inodes.
+     */
+    int scan_frags();
 
     // Accept pools which are not in the MDSMap
     bool force_pool;
@@ -242,10 +272,6 @@ class DataScan : public MDSUtility
       const std::vector<const char*> &arg,
       std::vector<const char *>::const_iterator &i);
 
-    void build_file_dentry(
-      inodeno_t ino, uint64_t file_size, time_t file_mtime,
-      const ceph_file_layout &layout,
-      InodeStore *out);
 
 
   public:

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -47,9 +47,7 @@ class RecoveryDriver {
      */
     virtual int inject_with_backtrace(
         const inode_backtrace_t &bt,
-        uint64_t size,
-        time_t mtime,
-        const ceph_file_layout &layout) = 0;
+        const InodeStore &dentry) = 0;
 
     /**
      * Inject an inode + dentry into the lost+found directory,
@@ -57,9 +55,7 @@ class RecoveryDriver {
      */
     virtual int inject_lost_and_found(
         inodeno_t ino,
-        uint64_t size,
-        time_t mtime,
-        const ceph_file_layout &layout) = 0;
+        const InodeStore &dentry) = 0;
 
     /**
      * Create any missing roots (i.e. mydir, strays, root inode)
@@ -120,15 +116,11 @@ class LocalFileDriver : public RecoveryDriver
 
     int inject_with_backtrace(
         const inode_backtrace_t &bt,
-        uint64_t size,
-        time_t mtime,
-        ceph_file_layout const &layout);
+        const InodeStore &dentry);
 
     int inject_lost_and_found(
         inodeno_t ino,
-        uint64_t size,
-        time_t mtime,
-        ceph_file_layout const &layout);
+        const InodeStore &dentry);
 
     int init_roots(int64_t data_pool_id);
 
@@ -193,15 +185,11 @@ class MetadataDriver : public RecoveryDriver
 
     int inject_with_backtrace(
         const inode_backtrace_t &bt,
-        uint64_t size,
-        time_t mtime,
-        ceph_file_layout const &layout);
+        const InodeStore &dentry);
 
     int inject_lost_and_found(
         inodeno_t ino,
-        uint64_t size,
-        time_t mtime,
-        ceph_file_layout const &layout);
+        const InodeStore &dentry);
 
     int init_roots(int64_t data_pool_id);
 
@@ -253,6 +241,12 @@ class DataScan : public MDSUtility
     bool parse_arg(
       const std::vector<const char*> &arg,
       std::vector<const char *>::const_iterator &i);
+
+    void build_file_dentry(
+      inodeno_t ino, uint64_t file_size, time_t file_mtime,
+      const ceph_file_layout &layout,
+      InodeStore *out);
+
 
   public:
     void usage();


### PR DESCRIPTION
This is the basic version (no fragmented dirs) that lets us repair a system where we've somehow lost the linkage to a directory.