### PR TITLE
mon/PGMap: calc min_last_epoch_clean when decode

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -374,7 +374,7 @@ void PGMap::calc_stats()
 
   redo_full_sets();
 
-  calc_min_last_epoch_clean();
+  min_last_epoch_clean = calc_min_last_epoch_clean();
 }
 
 void PGMap::update_pg(pg_t pgid, bufferlist& bl)


### PR DESCRIPTION
introduced in 208959a0dcacba40116730702021090a24865eb3
http://tracker.ceph.com/issues/13112 Fixes: #13112, 

Signed-off-by: Kefu Chai <kchai@redhat.com>