### PR TITLE
libcephfs: fix calling init() then mount()

### DIFF
--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -108,9 +108,11 @@ public:
     if (mounted)
       return -EISCONN;
 
-    ret = init();
-    if (ret != 0) {
-      return ret;
+    if (!inited) {
+      ret = init();
+      if (ret != 0) {
+        return ret;
+      }
     }
 
     ret = client->mount(mount_root);


### PR DESCRIPTION
Previously only ever called these separately, but
it should be allowed for callers to use one after
the other.

Fixes: #13138
Signed-off-by: John Spray <john.spray@redhat.com>