### PR TITLE
mon: fix auth get-or-create output

### DIFF
--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -864,17 +864,25 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       goto done;
     }
 
+    // Parse the list of caps into a map
+    std::map<std::string, bufferlist> wanted_caps;
+    for (vector<string>::const_iterator it = caps_vec.begin();
+	 it != caps_vec.end() && (it + 1) != caps_vec.end();
+	 it += 2) {
+      const std::string &sys = *it;
+      bufferlist cap;
+      ::encode(*(it+1), cap);
+      wanted_caps[sys] = cap;
+    }
+
     // do we have it?
     EntityAuth entity_auth;
     if (mon->key_server.get_auth(entity, entity_auth)) {
-      for (vector<string>::iterator it = caps_vec.begin();
-	   it != caps_vec.end(); it += 2) {
-	string sys = *it;
-	bufferlist cap;
-	::encode(*(it+1), cap);
-	if (entity_auth.caps.count(sys) == 0 ||
-	    !entity_auth.caps[sys].contents_equal(cap)) {
-	  ss << "key for " << entity << " exists but cap " << sys << " does not match";
+      for (const auto &sys_cap : wanted_caps) {
+	if (entity_auth.caps.count(sys_cap.first) == 0 ||
+	    !entity_auth.caps[sys_cap.first].contents_equal(sys_cap.second)) {
+	  ss << "key for " << entity << " exists but cap " << sys_cap.first
+            << " does not match";
 	  err = -EINVAL;
 	  goto done;
 	}
@@ -890,6 +898,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 	KeyRing kr;
 	kr.add(entity, entity_auth.key);
         if (f) {
+          kr.set_caps(entity, entity_auth.caps);
           kr.encode_formatted("auth", f.get(), rdata);
         } else {
           kr.encode_plaintext(rdata);
@@ -921,9 +930,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     auth_inc.op = KeyServerData::AUTH_INC_ADD;
     auth_inc.name = entity;
     auth_inc.auth.key.create(g_ceph_context, CEPH_CRYPTO_AES);
-    for (vector<string>::iterator it = caps_vec.begin();
-	 it != caps_vec.end(); it += 2)
-      ::encode(*(it+1), auth_inc.auth.caps[*it]);
+    auth_inc.auth.caps = wanted_caps;
 
     push_cephx_inc(auth_inc);
 
@@ -937,6 +944,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       KeyRing kr;
       kr.add(entity, auth_inc.auth.key);
       if (f) {
+        kr.set_caps(entity, wanted_caps);
         kr.encode_formatted("auth", f.get(), rdata);
       } else {
         kr.encode_plaintext(rdata);


### PR DESCRIPTION
Previously the caps were omitted from the
output: they should be present for this
to fulfil the 'get' part of get-or-create.

Signed-off-by: John Spray <john.spray@redhat.com>