### PR TITLE
rgw: add a new error message for user conflict when using Admin Ops API

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -149,6 +149,7 @@ using ceph::crypto::MD5;
 #define ERR_SIGNATURE_NO_MATCH   2027
 #define ERR_INVALID_ACCESS_KEY   2028
 #define ERR_MALFORMED_XML        2029
+#define ERR_USER_EXIST           2030
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
 #define ERR_NOT_IMPLEMENTED      2201

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -50,6 +50,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ERR_METHOD_NOT_ALLOWED, 405, "MethodNotAllowed" },
     { ETIMEDOUT, 408, "RequestTimeout" },
     { EEXIST, 409, "BucketAlreadyExists" },
+    { ERR_USER_EXIST, 409, "UserAlreadyExists" },
     { ENOTEMPTY, 409, "BucketNotEmpty" },
     { ERR_PRECONDITION_FAILED, 412, "PreconditionFailed" },
     { ERANGE, 416, "InvalidRange" },

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2200,8 +2200,11 @@ int RGWUserAdminOp_User::create(RGWRados *store, RGWUserAdminOpState& op_state,
   Formatter *formatter = flusher.get_formatter();
 
   ret = user.add(op_state, NULL);
-  if (ret < 0)
+  if (ret < 0) {
+    if (ret == -EEXIST)
+      ret = -ERR_USER_EXIST;
     return ret;
+  }
 
   ret = user.info(info, NULL);
   if (ret < 0)


### PR DESCRIPTION
When trying to create a user with existed access key through admin ops API, it prints error message "BucketAlreadyExists", which is for bucket confilct. So I add a new error message to correctly indicate user conflict.

Signed-off-by: Sangdi Xu <xu.sangdi@h3c.com>