### PR TITLE
osd/ReplicatedPG: for osd_op_create, if ob existed don't do t->touch.

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -4766,8 +4766,8 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
           if (result >= 0) {
 	    if (maybe_create_new_object(ctx)) {
               ctx->mod_desc.create();
+	      t->touch(soid);
 	    }
-            t->touch(soid);
           }
 	}
       }


### PR DESCRIPTION
Although if ob existed, t->touch don't meet error. But this cause one
transaction include write journal.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>