### PR TITLE
ceph-detect-init: disable python3

### DIFF
--- a/src/ceph-detect-init/tox.ini
+++ b/src/ceph-detect-init/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py27,py3
+envlist = pep8,py27 # ,py3
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Disable python3 support until
https://bitbucket.org/pypa/wheel/issues/148/unorderable-types-error-for-python-3
is fixed.

http://tracker.ceph.com/issues/13136 Fixes: #13136

Signed-off-by: Loic Dachary <ldachary@redhat.com>