### PR TITLE
osd/ReplicatedPG: If object exist and not whiteout, don't do touch for

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -4764,10 +4764,12 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	    // category is no longer implemented.
 	  }
           if (result >= 0) {
+	    bool is_whiteout = obs.exists && oi.is_whiteout();
 	    if (maybe_create_new_object(ctx)) {
-              ctx->mod_desc.create();
-	    }
-            t->touch(soid);
+	      ctx->mod_desc.create();
+	      t->touch(soid);
+	    } else if (is_whiteout) //change whiteout to non-whiteout, it need a op to update xattr.
+	      t->nop();
           }
 	}
       }


### PR DESCRIPTION
create.

Also, if object is whiteout, it need transaction op to update xattr
which chanage whiteout to no-whiteout. For this we can use nop rather
that touch.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>