### PR TITLE
osd/ReplicatedPG: tolerate promotion completion with stopped agent

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -7244,8 +7244,8 @@ void ReplicatedPG::finish_promote(int r, CopyResults *results,
 
   osd->logger->inc(l_osd_tier_promote);
 
-  assert(agent_state);
-  if (agent_state->is_idle())
+  if (agent_state &&
+      agent_state->is_idle())
     agent_choose_mode();
 }
 


### PR DESCRIPTION
We may start a promotion, then get a pool update that disables the
agent, and then complete it.  We should not segfault in this case.

Fixes: #13190
Signed-off-by: Sage Weil <sage@redhat.com>