### PR TITLE
systemd: increase nproc ulimit

### DIFF
--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -6,6 +6,7 @@ PartOf=ceph.target
 
 [Service]
 LimitNOFILE=1048576
+LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -12,6 +12,7 @@ PartOf=ceph.target
 
 [Service]
 LimitNOFILE=1048576
+LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -6,6 +6,7 @@ PartOf=ceph.target
 
 [Service]
 LimitNOFILE=1048576
+LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -6,6 +6,7 @@ PartOf=ceph.target
 
 [Service]
 LimitNOFILE=1048576
+LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph


### PR DESCRIPTION
We were observed to be hitting the limit on centos7
(triggering pthread_create failures) on a ~2000 OSD cluster.

Increasing this resolves it!

Reported-by: Dan van der Ster <daniel.vanderster@cern.ch>
Signed-off-by: Sage Weil <sage@redhat.com>