### PR TITLE
Use the uuid we've created the partition with

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -502,6 +502,16 @@ def get_partition_mpath(dev, pnum):
     else:
         return None
 
+def get_partition_dev_by_partuuid(uuid):
+    """
+    get the device name for a partition given that partition's uuid
+    """
+    if uuid in os.listdir('/dev/disk/by-partuuid'):
+        return os.path.join('/dev/disk/by-partuuid', uuid)
+    else:
+        raise Error('partition {} does not appear to exist'.format(uuid))
+
+
 def get_partition_dev(dev, pnum):
     """
     get the device name for a partition
@@ -1593,7 +1603,10 @@ def prepare_dev(
         except subprocess.CalledProcessError as e:
             raise Error(e)
 
-        rawdev = get_partition_dev(data, 1)
+        try:
+            rawdev = get_partition_dev_by_partuuid(osd_uuid)
+        except Error:
+            rawdev = get_partition_dev(data, 1)
 
     dev = None
     if osd_dm_keypath:


### PR DESCRIPTION
Simplify and be more accurate with finding the new partition
by using the uuid we created the partition with instead of guessing what
the next device name will be.

Fall back to the old way for distributions that don't include
udev >= 211

Add tests for lvm based osds. Don't run this test with udev < 211

Signed-off-by: Joe Julian <jjulian@io.com>