### PR TITLE
rgw:modify the error message when operating radosgw-admin metadata list user

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2747,9 +2747,13 @@ next:
     do {
       list<string> keys;
       ret = store->meta_mgr->list_keys_next(handle, max, keys, &truncated);
-      if (ret < 0) {
+      if (ret < 0 && ret != -ENOENT) {
         cerr << "ERROR: lists_keys_next(): " << cpp_strerror(-ret) << std::endl;
         return -ret;
+      }
+      if (ret == -ENOENT){
+        ret = 0;
+        break;
       }
 
       for (list<string>::iterator iter = keys.begin(); iter != keys.end(); ++iter) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2751,7 +2751,7 @@ next:
         cerr << "ERROR: lists_keys_next(): " << cpp_strerror(-ret) << std::endl;
         return -ret;
       }
-      if (ret == -ENOENT){
+      if (ret == -ENOENT) {
         ret = 0;
         break;
       }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7910,10 +7910,13 @@ int RGWRados::list_raw_objects(rgw_bucket& pool, const string& prefix_filter,
 
   vector<RGWObjEnt> objs;
   int r = pool_iterate(ctx.iter_ctx, max, objs, is_truncated, &filter);
-  if (r < 0) {
+  if (r < 0 && r != -ENOENT) {
     lderr(cct) << "failed to list objects pool_iterate returned r=" << r << dendl;
     return r;
   }
+  if(r == -ENOENT){
+    return r;
+  }	
 
   vector<RGWObjEnt>::iterator iter;
   for (iter = objs.begin(); iter != objs.end(); ++iter) {


### PR DESCRIPTION
 when no user exists,,the error  message appears by operating radosgw-admin metadata list user .I changed the error message to the "[]".

Signed-off-by:  Peiyang Liu  <liu.peiyang@h3c.com>