### PR TITLE
rbd:refuse lock the image when features not support exclusive

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2965,6 +2965,10 @@ reprotect_and_return_err:
      * checks that we think we will succeed. But for now, let's not
      * duplicate that code.
      */
+    RWLock::RLocker l(ictx->owner_lock);
+    if (!ictx->image_watcher->is_lock_supported()) {
+      return -ENOSYS;
+    }
     RWLock::RLocker locker(ictx->md_lock);
     r = rados::cls::lock::lock(&ictx->md_ctx, ictx->header_oid, RBD_LOCK_NAME,
 			       exclusive ? LOCK_EXCLUSIVE : LOCK_SHARED,

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -4027,6 +4027,8 @@ if (!set_conf_param(v, p1, p2, p3)) { \
 	} else {
 	  cerr << "rbd: lock is already held by someone else" << std::endl;
 	}
+      } else if (r == -ENOSYS) {
+        cerr << "rbd: lock is not supported by the image features" << std::endl;
       } else {
 	cerr << "rbd: taking lock failed: " << cpp_strerror(r) << std::endl;
       }


### PR DESCRIPTION
 When we add lock to image, we should check if the image features support exclusive. 
There will lock fail if the image format is 1 or image format is 2 but features not support exclusive.