### PR TITLE
LibRBD: Adjust correct op latency scope

### DIFF
--- a/src/librbd/AioCompletion.h
+++ b/src/librbd/AioCompletion.h
@@ -93,8 +93,12 @@ namespace librbd {
         ictx = i;
         aio_type = t;
         start_time = ceph_clock_now(ictx->cct);
-
-	async_op.start_op(*ictx);
+      }
+    }
+    void start_op(ImageCtx *i, aio_type_t t) {
+      init_time(i, t);
+      if (!async_op.started()) {
+        async_op.start_op(*ictx);
       }
     }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -3391,7 +3391,7 @@ reprotect_and_return_err:
     c->add_request();
     ictx->flush_async_operations(flush_ctx);
 
-    c->init_time(ictx, AIO_TYPE_FLUSH);
+    c->start_op(ictx, AIO_TYPE_FLUSH);
     C_AioWrite *req_comp = new C_AioWrite(cct, c);
     c->add_request();
     if (ictx->object_cacher) {
@@ -3498,8 +3498,7 @@ reprotect_and_return_err:
       }
 
       snapc = ictx->snapc;
-
-      c->init_time(ictx, AIO_TYPE_WRITE);
+      c->start_op(ictx, AIO_TYPE_WRITE);
     }
 
     if (ictx->image_watcher->is_lock_supported() &&
@@ -3638,8 +3637,7 @@ reprotect_and_return_err:
 
       // TODO: check for snap
       snapc = ictx->snapc;
-
-      c->init_time(ictx, AIO_TYPE_DISCARD);
+      c->start_op(ictx, AIO_TYPE_DISCARD);
     }
 
     if (ictx->image_watcher->is_lock_supported() &&
@@ -3813,8 +3811,7 @@ reprotect_and_return_err:
 			         p->first, len, 0, object_extents, buffer_ofs);
         buffer_ofs += len;
       }
-
-      c->init_time(ictx, AIO_TYPE_READ);
+      c->start_op(ictx, AIO_TYPE_READ);
     }
 
     c->read_buf = buf;

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -129,6 +129,7 @@ private:
 void submit_aio_read(librbd::ImageCtx *ictx, uint64_t off, size_t len,
                      char *buf, bufferlist *pbl, librbd::AioCompletion *c,
                      int op_flags) {
+  c->init_time(ictx, librbd::AIO_TYPE_READ);
   if (ictx->non_blocking_aio) {
     ictx->aio_work_queue->queue(new C_AioReadWQ(ictx, off, len, buf, pbl, c,
                                                 op_flags));
@@ -139,6 +140,7 @@ void submit_aio_read(librbd::ImageCtx *ictx, uint64_t off, size_t len,
 
 void submit_aio_write(librbd::ImageCtx *ictx, uint64_t off, size_t len,
                       const char *buf, librbd::AioCompletion *c, int op_flags) {
+  c->init_time(ictx, librbd::AIO_TYPE_WRITE);
   if (ictx->non_blocking_aio) {
     ictx->aio_work_queue->queue(new C_AioWriteWQ(ictx, off, len, buf, c,
                                                  op_flags));
@@ -149,6 +151,7 @@ void submit_aio_write(librbd::ImageCtx *ictx, uint64_t off, size_t len,
 
 void submit_aio_discard(librbd::ImageCtx *ictx, uint64_t off, uint64_t len,
                         librbd::AioCompletion *c) {
+  c->init_time(ictx, librbd::AIO_TYPE_DISCARD);
   if (ictx->non_blocking_aio) {
     ictx->aio_work_queue->queue(new C_AioDiscardWQ(ictx, off, len, c));
   } else {
@@ -157,6 +160,7 @@ void submit_aio_discard(librbd::ImageCtx *ictx, uint64_t off, uint64_t len,
 }
 
 void submit_aio_flush(librbd::ImageCtx *ictx, librbd::AioCompletion *c) {
+  c->init_time(ictx, librbd::AIO_TYPE_FLUSH);
   if (ictx->non_blocking_aio) {
     ictx->aio_work_queue->queue(new C_AioFlushWQ(ictx, c));
   } else {


### PR DESCRIPTION
Op latency need to cover from queuing to finishing op.