### PR TITLE
rbd:check the image name, if it is empty string, return error and give a message--maybe a simpler way

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -3506,7 +3506,7 @@ if (!set_conf_param(v, p1, p2, p3)) { \
 		      (char **)&imgname, (char **)&snapname);
   if ((imgname) && (imgname[0] == '\0')) {
     cerr << "rbd: image name was not specified" << std::endl;
-    return EXIT_FAILRE;
+    return EXIT_FAILURE;
   }
 
   if (snapname && opt_cmd != OPT_SNAP_CREATE && opt_cmd != OPT_SNAP_ROLLBACK &&

--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -3504,6 +3504,11 @@ if (!set_conf_param(v, p1, p2, p3)) { \
   // the relevant parts
   set_pool_image_name(imgname, (char **)&poolname,
 		      (char **)&imgname, (char **)&snapname);
+  if ((imgname) && (imgname[0] == '\0')) {
+    cerr << "rbd: image name was not specified" << std::endl;
+    return EXIT_FAILRE;
+  }
+
   if (snapname && opt_cmd != OPT_SNAP_CREATE && opt_cmd != OPT_SNAP_ROLLBACK &&
       opt_cmd != OPT_SNAP_REMOVE && opt_cmd != OPT_INFO &&
       opt_cmd != OPT_EXPORT && opt_cmd != OPT_EXPORT_DIFF &&


### PR DESCRIPTION
add a judgment after function set_pool_image_name(imgname, ...) to make it no need to call function do_create in case OPT_CREATE.

before:
input: rbd create @ --size 1024
output:  "2015-09-22 05:39:18.666681 7f8d4c052840 -1 librbd: error adding image to directory: (22) Invalid argument                                                       
rbd: create error: (22) Invalid argument"
                                     
after:
input: rbd create @ --size 1024
output: "rbd: image name was not specified"

Signed-off-by: chenyehua11692 <chen.yehua@h3c.com>