### PR TITLE
rgw: fix wrong etag calculation during POST on S3 bucket.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2122,6 +2122,7 @@ void RGWPostObj::execute()
     goto done;
   }
 
+  processor->complete_hash(&hash);
   hash.Final(m);
   buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
 


### PR DESCRIPTION
Bug page: [#11241](http://tracker.ceph.com/issues/11241).