### PR TITLE
common/HeartBeat: include types

### DIFF
--- a/src/common/RWLock.h
+++ b/src/common/RWLock.h
@@ -19,6 +19,7 @@
 
 #include <pthread.h>
 #include "lockdep.h"
+#include "include/assert.h"
 #include "include/atomic.h"
 
 class RWLock
@@ -26,7 +27,7 @@ class RWLock
   mutable pthread_rwlock_t L;
   const char *name;
   mutable int id;
-  mutable atomic_t nrlock, nwlock;
+  mutable ceph::atomic_t nrlock, nwlock;
 
 public:
   RWLock(const RWLock& other);


### PR DESCRIPTION
Fixes atomic_t build issue without libatomic-ops.

Fixes: #13088
Signed-off-by: Sage Weil <sage@redhat.com>