### PR TITLE
rgw: fix swift API returning incorrect account metadata

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1138,7 +1138,7 @@ void RGWStatAccount::execute()
   do {
     RGWUserBuckets buckets;
 
-    ret = rgw_read_user_buckets(store, s->user.user_id, buckets, marker, max_buckets, true);
+    ret = rgw_read_user_buckets(store, s->user.user_id, buckets, marker, max_buckets, false);
     if (ret < 0) {
       /* hmm.. something wrong here.. the user was authenticated, so it
          should exist */


### PR DESCRIPTION
Fixes: #13140

Fix the bug that swift account stat command returns doubled object count and bytes used

Signed-off-by: Sangdi Xu <xu.sangdi@h3c.com>