### PR TITLE
qa: avoid using sudo in fsstress

### DIFF
--- a/qa/workunits/suites/fsstress.sh
+++ b/qa/workunits/suites/fsstress.sh
@@ -1,23 +1,19 @@
 #!/bin/bash
 
-if [ ! -f /usr/lib/ltp/testcases/bin/fsstress ]
-then
-    path=`pwd`
-    mkdir -p /tmp/fsstress
-    cd /tmp/fsstress
-    wget -q -O /tmp/fsstress/ltp-full.tgz http://download.ceph.com/qa/ltp-full-20091231.tgz
-    tar xzf /tmp/fsstress/ltp-full.tgz
-    rm /tmp/fsstress/ltp-full.tgz
-    cd /tmp/fsstress/ltp-full-20091231/testcases/kernel/fs/fsstress
-    make
-    sudo mkdir -p /usr/lib/ltp/testcases/bin
-    sudo cp -av --remove-destination /tmp/fsstress/ltp-full-20091231/testcases/kernel/fs/fsstress/fsstress /usr/lib/ltp/testcases/bin/fsstress
-    sudo chmod 755 /usr/lib/ltp/testcases/bin/fsstress
-    rm -Rf /tmp/fsstress
-    cd $path
-fi
+BIN_PATH=${TESTDIR}/fsstress/ltp-full-20091231/testcases/kernel/fs/fsstress/fsstress
 
-command="/usr/lib/ltp/testcases/bin/fsstress -d fsstress-`hostname`$$ -l 1 -n 1000 -p 10 -v"
+path=`pwd`
+trap "rm -rf ${TESTDIR}/fsstress" EXIT
+mkdir -p ${TESTDIR}/fsstress
+cd ${TESTDIR}/fsstress
+wget -q -O ${TESTDIR}/fsstress/ltp-full.tgz http://download.ceph.com/qa/ltp-full-20091231.tgz
+tar xzf ${TESTDIR}/fsstress/ltp-full.tgz
+rm ${TESTDIR}/fsstress/ltp-full.tgz
+cd ${TESTDIR}/fsstress/ltp-full-20091231/testcases/kernel/fs/fsstress
+make
+cd $path
+
+command="${BIN_PATH} -d fsstress-`hostname`$$ -l 1 -n 1000 -p 10 -v"
 
 echo "Starting fsstress $command"
 mkdir fsstress`hostname`-$$


### PR DESCRIPTION
This test required root in order to copy its built
binary into /usr (presumably to avoid rebuilding it).

That's not really a good thing anyway because there's
no guarantee that a binary in that path is the binary
we wanted, so just run the thing straight out of /tmp.  The
build is really quick anyway.

Signed-off-by: John Spray <john.spray@redhat.com>