### PR TITLE
Bug #13207:  Rados Gateway: Anonymous user is able to read bucket with authenticated read ACL

### DIFF
--- a/src/rgw/rgw_acl_s3.cc
+++ b/src/rgw/rgw_acl_s3.cc
@@ -568,7 +568,7 @@ bool RGWAccessControlPolicy_S3::compare_group_name(string& id, ACLGroupTypeEnum 
 {
   switch (group) {
   case ACL_GROUP_ALL_USERS:
-    return (id.compare(rgw_uri_all_users) == 0);
+    return (id.compare(RGW_USER_ANON_ID) == 0);
   case ACL_GROUP_AUTHENTICATED_USERS:
     return (id.compare(rgw_uri_auth_users) == 0);
   default:

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -17,6 +17,7 @@
 #include "rgw_rest.h"
 #include "rgw_acl.h"
 #include "rgw_acl_s3.h"
+#include "rgw_acl_swift.h"
 #include "rgw_user.h"
 #include "rgw_bucket.h"
 #include "rgw_log.h"
@@ -356,7 +357,13 @@ static int rgw_build_policies(RGWRados *store, struct req_state *s, bool only_bu
     }
   }
 
-  s->bucket_acl = new RGWAccessControlPolicy(s->cct);
+  if(s->dialect.compare("s3") == 0) {
+    s->bucket_acl = new RGWAccessControlPolicy_S3(s->cct);
+  } else if(s->dialect.compare("swift")  == 0) {
+    s->bucket_acl = new RGWAccessControlPolicy_SWIFT(s->cct);
+  } else {
+    s->bucket_acl = new RGWAccessControlPolicy(s->cct);
+  }
 
   if (s->copy_source) { /* check if copy source is within the current domain */
     const char *src = s->copy_source;


### PR DESCRIPTION
Fix for http://tracker.ceph.com/issues/13207

The public user id in rados gateway is "anonymous" defined by RGW_USER_ANON_ID
During a public read of a bucket (for example by generating a public url and accessing it), the method to know whether the user is public or not, the id is being compared with the public user group's uri and not with RGW_USER_ANON_ID. This led to the public user being considered as an authenticated user and hence read of a bucket is working even when the canned acl for the bucket is set to "authenticated-read".
Also, the bucket_acl  object is always being created of the base type RGWAccessControlPolicy while it should be created based on the dialect of the the request (s3 or swift)