### PR TITLE
rgw_admin:metadata rm may take risks,add specified opt to administrator

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2724,6 +2724,11 @@ next:
   }
 
   if (opt_cmd == OPT_METADATA_RM) {
+	if (!yes_i_really_mean_it) {
+	  cerr << "usage metadata rm without user specified may take risks" << endl;
+	  cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << endl;
+	  return 1;
+	}
     int ret = store->meta_mgr->remove(metadata_key);
     if (ret < 0) {
       cerr << "ERROR: can't remove key: " << cpp_strerror(-ret) << std::endl;


### PR DESCRIPTION
i think the raodsgw-admin metadata rm will take risks,eg:rm one user who has some buckets,if it works,all buckets will out of control.

Signed-off-by: Zengran Zhang <zhangzengran@h3c.com>