### PR TITLE
build/ops: ceph-detect-init must ignore .cache

### DIFF
--- a/src/ceph-detect-init/.gitignore
+++ b/src/ceph-detect-init/.gitignore
@@ -10,4 +10,4 @@ build
 wheelhouse*
 *.log
 *.trs
-
+.cache


### PR DESCRIPTION
In case the test fails, it may leave files behind:

src/ceph-detect-init/.cache/v/cache/lastfailed

Signed-off-by: Loic Dachary <ldachary@redhat.com>