### PR TITLE
rgw:dont update entrypoint when removing bucket 

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -450,7 +450,7 @@ int rgw_remove_bucket(RGWRados *store, const string& bucket_owner, rgw_bucket& b
     return ret;
   }
 
-  ret = rgw_unlink_bucket(store, info.owner, bucket.name);
+  ret = rgw_unlink_bucket(store, info.owner, bucket.name,false);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: unable to remove user bucket information" << dendl;
   }


### PR DESCRIPTION
when removing bucket,we unlink the bucket bucket but we don't want to update the entrypoint here.Because the update_entrypoint's default value is true,so we need to indicate it to false.

Signed-off-by: Zengran Zhang <zhangzengran@h3c.com>