### PR TITLE
erasure-code: shec must compare for equality with epsilon

### DIFF
--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -501,7 +501,8 @@ int* ErasureCodeShec::shec_reedsolomon_coding_matrix(int is_single)
         if (true) {
           double r_e1;
           r_e1 = shec_calc_recovery_efficiency1(k, m1, m2, c1, c2);
-          if (r_e1 < min_r_e1){
+          if (min_r_e1 - r_e1 > std::numeric_limits<double>::epsilon() &&
+	      r_e1 < min_r_e1) {
             min_r_e1 = r_e1;
             c1_best = c1;
             m1_best = m1;

--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -124,12 +124,7 @@ public:
 private:
   virtual int parse(const ErasureCodeProfile &profile) = 0;
 
-  virtual double shec_calc_recovery_efficiency1(int k, int m1, int m2, int c1, int c2)
-  // http://tracker.ceph.com/issues/12936 shec fails i386 make check
-#if defined(__i386__) && defined(__GNUC__)
-    __attribute__((optimize(0)))
-#endif    
-    ;
+  virtual double shec_calc_recovery_efficiency1(int k, int m1, int m2, int c1, int c2);
   virtual int shec_make_decoding_matrix(bool prepare,
                                         int *want, int *avails,
                                         int *decoding_matrix,


### PR DESCRIPTION
When comparing two double for strict inequality, a test for equality
using epsilon must also be done to ensure the results do not vary cross
platform.

http://tracker.ceph.com/issues/12936 Fixes: #12936

Signed-off-by: Loic Dachary <ldachary@redhat.com>