### PR TITLE
osd: avoid duplicate MMonGetOSDMap requests

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2014,6 +2014,12 @@ protected:
   void queue_want_up_thru(epoch_t want);
   void send_alive();
 
+  // -- full map requests --
+  epoch_t requested_full_first, requested_full_last;
+
+  void request_full_map(epoch_t first, epoch_t last);
+  void got_full_map(epoch_t e);
+
   // -- failures --
   map<int,utime_t> failure_queue;
   map<int,entity_inst_t> failure_pending;


### PR DESCRIPTION
These are relatively expensive (we grab the full map from the mon) so we
should avoid duplicating our requests.

Track which requests are in flight.  Only send a new request when new
maps are asked for.  Resend requests when there is a new mon session.

Signed-off-by: Sage Weil <sage@redhat.com>