### PR TITLE
osd/PG: compensate for sloppy hobject scrub bounds from hammer

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3647,8 +3647,14 @@ void PG::replica_scrub(
     return;
   }
 
+  // compensate for hobject_t's with wrong pool from sloppy hammer OSDs
+  hobject_t start = msg->start;
+  hobject_t end = msg->end;
+  start.pool = info.pgid.pool();
+  end.pool = info.pgid.pool();
+
   build_scrub_map_chunk(
-    map, msg->start, msg->end, msg->deep, msg->seed,
+    map, start, end, msg->deep, msg->seed,
     handle);
 
   vector<OSDOp> scrub(1);


### PR DESCRIPTION
Hammer is sloppy about the hobject_t's it uses for the scrub bounds in that
the pool isn't set.  (Hammer FileStore doesn't care, but post-hammer is
much more careful about this sort of thing.)

Compensate by setting the pool on any scrub messages we receive.

Signed-off-by: Sage Weil <sage@redhat.com>