### PR TITLE
rbd: change line when using json format to look up the info of the image

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -679,7 +679,8 @@ static int do_show_info(const char *imgname, librbd::Image& image,
   if (f) {
     f->close_section();
     f->flush(cout);
-  }
+    cout << std::endl;
+  } 
 
   return 0;
 }


### PR DESCRIPTION
Add command to make it change line when using json format to look up the info of the image

before:
root@ubuntu2:~# rbd info foo --format json 
{"name":"foo","size":1073741824,"objects":256,"order":22,"object_size":4194304,"
block_name_prefix":"rbd_data.2b48fb74b0dc51","format":2,"features":["layering"],
"flags":[]}root@ubuntu2:~# 

after:
root@ubuntu2:~# rbd info foo --format json 
{"name":"foo","size":1073741824,"objects":256,"order":22,"object_size":4194304,"
block_name_prefix":"rbd_data.2b48fb74b0dc51","format":2,"features":["layering"],
"flags":[]}
root@ubuntu2:~#

