### PR TITLE
rgw: modify documents and help infos' descriptions to the usage of option date when executing command "log show"

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -148,6 +148,7 @@ which are as follows:
 
 :command:`log show`
   Dump a log from specific object or (bucket + date + bucket-id).
+  (NOTE: required to specify formatting of date to "YYYY-MM-DD-hh")
 
 :command:`log rm`
   Remove log object.
@@ -436,7 +437,7 @@ Remove a bucket::
 
 Show the logs of a bucket from April 1st, 2012::
 
-        $ radosgw-admin log show --bucket=foo --date=2012-04-01
+        $ radosgw-admin log show --bucket=foo --date=2012-04-01-01 --bucket-id=default.14193.1
 
 Show usage information for user from March 1st to (but not including) April 1st, 2012::
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -87,6 +87,8 @@ void _usage()
   cout << "  log list                   list log objects\n";
   cout << "  log show                   dump a log from specific object or (bucket + date\n";
   cout << "                             + bucket-id)\n";
+  cout << "                             (NOTE: required to specify formatting of date\n";
+  cout << "                             to \"YYYY-MM-DD-hh\")\n";
   cout << "  log rm                     remove log object\n";
   cout << "  usage show                 show usage (by user, date range)\n";
   cout << "  usage trim                 trim usage (by user, date range)\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -44,6 +44,8 @@
     log list                   list log objects
     log show                   dump a log from specific object or (bucket + date
                                + bucket-id)
+                               (NOTE: required to specify formatting of date
+                               to "YYYY-MM-DD-hh")
     log rm                     remove log object
     usage show                 show usage (by user, date range)
     usage trim                 trim usage (by user, date range)


### PR DESCRIPTION
DOCUMENTATION #13235

This modification concerns documents and help infos. To the documents, we delete original incorrect instruction about the usage of the option date which induces user to type the value of date in the format of "YYYY-MM-DD" when executing "log show" command, and we add the actual usage of "YYYY-MM-DD-hh". To the help infos, we add the NOTE to make user notice that the usage of option date here is different with default's and of cource we give the right formatting.

Signed-off-by: Kongming Wu <wu.kongming@h3c.com>