### PR TITLE
ceph-create-keys: set mds "allow *"

### DIFF
--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -106,7 +106,7 @@ def get_key(cluster, mon_id):
                         'client.admin',
                         'mon', 'allow *',
                         'osd', 'allow *',
-                        'mds', 'allow',
+                        'mds', 'allow *',
                         ],
                     stdout=f,
                     )


### PR DESCRIPTION
So that 'tell' works out of the box.

Signed-off-by: John Spray <john.spray@redhat.com>