### PR TITLE
examples/librados/Makefile:missing CXXFLAGS for c++11 and include for…

### DIFF
--- a/examples/librados/Makefile
+++ b/examples/librados/Makefile
@@ -1,7 +1,9 @@
+CXXFLAGS = -std=c++0x -I../../src/include
+CFLAGS = -I../../src/include
 all: librados_hello_world librados_hello_world_c
 
 librados_hello_world: hello_world.cc
-	g++ -g -c hello_world.cc -o hello_world.o $(CFLAGS)
+	g++ -g -c hello_world.cc -o hello_world.o $(CXXFLAGS)
 	g++ -g hello_world.o -lrados -o librados_hello_world $(LDFLAGS)
 
 librados_hello_world_c: hello_world_c.c


### PR DESCRIPTION
… header files.

Signed-off-by: You Ji <jiyou09@gmail.com>