### PR TITLE
rgw:user email can modify to empty

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1186,6 +1186,7 @@ int main(int argc, char **argv)
       secret_key = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-e", "--email", (char*)NULL)) {
       user_email = val;
+      user_op.user_email_specified=true;
     } else if (ceph_argparse_witharg(args, i, &val, "-n", "--display-name", (char*)NULL)) {
       display_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-b", "--bucket", (char*)NULL)) {

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2048,8 +2048,17 @@ int RGWUser::execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg)
       }
     }
     user_info.user_email = op_email;
-  }
+  } else if (op_email.empty() && op_state.user_email_specified) {
 
+    rgw_obj email_obj(store->zone.user_email_pool, user_info.user_email);
+    ldout(store->ctx(), 10) << "removing email index: " << user_info.user_email << dendl;
+    ret = store->delete_system_obj(email_obj);
+    if (ret < 0 && ret != -ENOENT) {
+      ldout(store->ctx(), 0) << "ERROR: could not remove " << user_info.user_id << ":" << email_obj << ", should be fixed (err=" << ret << ")" << dendl;
+      return ret;
+    }
+    user_info.user_email = "";
+  }
 
   // update the remaining user info
   if (!display_name.empty())


### PR DESCRIPTION
user email can be empty in default
but can't  modify to empty when it has value

now it can modify to empty when need

Signed-off-by: Weijun Duan <duanweijun@h3c.com>