### PR TITLE
librbd: diff_iterate needs to handle holes in parent images

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2824,12 +2824,12 @@ reprotect_and_return_err:
 
   int simple_diff_cb(uint64_t off, size_t len, int exists, void *arg)
   {
-    // This reads the existing extents in a parent from the beginning
-    // of time.  Since images are thin-provisioned, the extents will
-    // always represent data, not holes.
-    assert(exists);
-    interval_set<uint64_t> *diff = static_cast<interval_set<uint64_t> *>(arg);
-    diff->insert(off, len);
+    // it's possible for a discard to create a hole in the parent image --
+    // ignore
+    if (exists) {
+      interval_set<uint64_t> *diff = static_cast<interval_set<uint64_t> *>(arg);
+      diff->insert(off, len);
+    }
     return 0;
   }
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -219,6 +219,11 @@ namespace librbd {
     ImageCtx *ictx = new ImageCtx(name, "", snap_name, io_ctx, false);
     tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
+    if (image.ctx != NULL) {
+      close_image(reinterpret_cast<ImageCtx*>(image.ctx));
+      image.ctx = NULL;
+    }
+
     int r = librbd::open_image(ictx);
     if (r < 0) {
       tracepoint(librbd, open_image_exit, r);
@@ -235,6 +240,11 @@ namespace librbd {
   {
     ImageCtx *ictx = new ImageCtx(name, "", snap_name, io_ctx, true);
     tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
+
+    if (image.ctx != NULL) {
+      close_image(reinterpret_cast<ImageCtx*>(image.ctx));
+      image.ctx = NULL;
+    }
 
     int r = librbd::open_image(ictx);
     if (r < 0) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/13045