### PR TITLE
Fixes for coverity and SCA issues

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1360,7 +1360,7 @@ Options
 
 	Name of the Ceph cluster.
 
-.. option:: daemon ADMIN_SOCKET, daemon DAEMON_NAME, --admin-socket ADMIN_SOCKET, --admin-socket DAEMON_NAME
+.. option:: --admin-daemon ADMIN_SOCKET, daemon DAEMON_NAME
 
 	Submit admin-socket commands via admin sockets in /var/run/ceph.
 

--- a/src/auth/AuthClientHandler.h
+++ b/src/auth/AuthClientHandler.h
@@ -40,7 +40,7 @@ protected:
   RWLock lock;
 
 public:
-  AuthClientHandler(CephContext *cct_) 
+  explicit AuthClientHandler(CephContext *cct_)
     : cct(cct_), global_id(0), want(CEPH_ENTITY_TYPE_AUTH), have(0), need(0),
       lock("AuthClientHandler::lock") {}
   virtual ~AuthClientHandler() {}

--- a/src/auth/AuthServiceHandler.h
+++ b/src/auth/AuthServiceHandler.h
@@ -29,7 +29,7 @@ public:
   EntityName entity_name;
   uint64_t global_id;
 
-  AuthServiceHandler(CephContext *cct_) : cct(cct_), global_id(0) {}
+  explicit AuthServiceHandler(CephContext *cct_) : cct(cct_), global_id(0) {}
 
   virtual ~AuthServiceHandler() { }
 

--- a/src/auth/AuthSessionHandler.h
+++ b/src/auth/AuthSessionHandler.h
@@ -44,7 +44,7 @@ public:
   int messages_encrypted;
   int messages_decrypted;
 
-  AuthSessionHandler(CephContext *cct_) : cct(cct_), protocol(CEPH_AUTH_UNKNOWN), messages_signed(0),
+  explicit AuthSessionHandler(CephContext *cct_) : cct(cct_), protocol(CEPH_AUTH_UNKNOWN), messages_signed(0),
     signatures_checked(0), signatures_matched(0), signatures_failed(0), messages_encrypted(0),
     messages_decrypted(0) {}
 

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -354,6 +354,7 @@ CryptoKeyHandler *CryptoAES::get_key_handler(const bufferptr& secret,
   ostringstream oss;
   if (ckh->init(secret, oss) < 0) {
     error = oss.str();
+    delete ckh;
     return NULL;
   }
   return ckh;

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -35,7 +35,7 @@ struct KeyServerData {
   version_t rotating_ver;
   map<uint32_t, RotatingSecrets> rotating_secrets;
 
-  KeyServerData(KeyRing *extra)
+  explicit KeyServerData(KeyRing *extra)
     : version(0),
       extra_secrets(extra),
       rotating_ver(0) {}

--- a/src/auth/cephx/CephxProtocol.h
+++ b/src/auth/cephx/CephxProtocol.h
@@ -277,7 +277,7 @@ private:
 public:
   uint64_t nonce;
 
-  CephXAuthorizer(CephContext *cct_)
+  explicit CephXAuthorizer(CephContext *cct_)
     : AuthAuthorizer(CEPH_AUTH_CEPHX), cct(cct_), nonce(0) {}
 
   bool build_authorizer();
@@ -320,7 +320,7 @@ struct CephXTicketManager {
   tickets_map_t tickets_map;
   uint64_t global_id;
 
-  CephXTicketManager(CephContext *cct_) : global_id(0), cct(cct_) {}
+  explicit CephXTicketManager(CephContext *cct_) : global_id(0), cct(cct_) {}
 
   bool verify_service_ticket_reply(CryptoKey& principal_secret,
 				 bufferlist::iterator& indata);

--- a/src/auth/none/AuthNoneServiceHandler.h
+++ b/src/auth/none/AuthNoneServiceHandler.h
@@ -22,7 +22,7 @@ class CephContext;
 
 class AuthNoneServiceHandler  : public AuthServiceHandler {
 public:
-  AuthNoneServiceHandler(CephContext *cct_) 
+  explicit AuthNoneServiceHandler(CephContext *cct_)
     : AuthServiceHandler(cct_) {}
   ~AuthNoneServiceHandler() {}
   

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -139,7 +139,7 @@ int main(int argc, const char **argv, const char *envp[]) {
     public:
       CephFuse *cfuse;
       Client *client;
-      RemountTest() : Thread() {}
+      RemountTest() : cfuse(NULL), client(NULL) {}
       void init(CephFuse *cf, Client *cl) {
 	cfuse = cf;
 	client = cl;

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -393,7 +393,7 @@ int main(int argc, const char **argv)
 	  string name;
 	  monmap.get_addr_name(local, name);
 
-	  if (name.find("noname-") == 0) {
+	  if (name.compare(0, 7, "noname-") == 0) {
 	    cout << argv[0] << ": mon." << name << " " << local
 		 << " is local, renaming to mon." << g_conf->name.get_id() << std::endl;
 	    monmap.rename(name, g_conf->name.get_id());

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3793,7 +3793,7 @@ class C_Client_Remount : public Context  {
 private:
   Client *client;
 public:
-  C_Client_Remount(Client *c) : client(c) {}
+  explicit C_Client_Remount(Client *c) : client(c) {}
   void finish(int r) {
     assert (r == 0);
     r = client->remount_cb(client->callback_handle);
@@ -5564,7 +5564,7 @@ void Client::unmount()
 class C_C_Tick : public Context {
   Client *client;
 public:
-  C_C_Tick(Client *c) : client(c) {}
+  explicit C_C_Tick(Client *c) : client(c) {}
   void finish(int r) {
     // Called back via Timer, which takes client_lock for us
     assert(client->client_lock.is_locked_by_me());

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -118,7 +118,7 @@ struct DirEntry {
   string d_name;
   struct stat st;
   int stmask;
-  DirEntry(const string &s) : d_name(s), stmask(0) {}
+  explicit DirEntry(const string &s) : d_name(s), stmask(0) {}
   DirEntry(const string &n, struct stat& s, int stm) : d_name(n), st(s), stmask(stm) {}
 };
 
@@ -192,7 +192,7 @@ struct dir_result_t {
 
   string at_cache_name;  // last entry we successfully returned
 
-  dir_result_t(Inode *in);
+  explicit dir_result_t(Inode *in);
 
   frag_t frag() { return frag_t(offset >> SHIFT); }
   unsigned fragpos() { return offset & MASK; }
@@ -231,7 +231,7 @@ class Client : public Dispatcher, public md_config_obs_t {
   class CommandHook : public AdminSocketHook {
     Client *m_client;
   public:
-    CommandHook(Client *client);
+    explicit CommandHook(Client *client);
     bool call(std::string command, cmdmap_t &cmdmap, std::string format,
 	      bufferlist& out);
   };

--- a/src/client/ClientSnapRealm.h
+++ b/src/client/ClientSnapRealm.h
@@ -31,7 +31,7 @@ private:
 public:
   xlist<Inode*> inodes_with_caps;
 
-  SnapRealm(inodeno_t i) : 
+  explicit SnapRealm(inodeno_t i) :
     ino(i), nref(0), created(0), seq(0),
     pparent(NULL) { }
 

--- a/src/client/Dir.h
+++ b/src/client/Dir.h
@@ -11,7 +11,7 @@ class Dir {
   uint64_t release_count;
   uint64_t ordered_count;
 
-  Dir(Inode* in) : release_count(0), ordered_count(0) { parent_inode = in; }
+  explicit Dir(Inode* in) : release_count(0), ordered_count(0) { parent_inode = in; }
 
   bool is_empty() {  return dentries.empty(); }
 };

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -66,7 +66,7 @@ struct CapSnap {
   uint64_t flush_tid;
   xlist<CapSnap*>::item flushing_item;
 
-  CapSnap(Inode *i)
+  explicit CapSnap(Inode *i)
     : in(i), issued(0), dirty(0),
       size(0), time_warp_seq(0), mode(0), uid(0), gid(0), xattr_version(0),
       inline_version(0), writing(false), dirty_data(false), flush_tid(0),
@@ -95,7 +95,7 @@ private:
   }
   ~QuotaTree() {}
 public:
-  QuotaTree(Inode *i) :
+  explicit QuotaTree(Inode *i) :
     _in(i),
     _ancestor_ref(0),
     _ancestor(NULL),

--- a/src/client/MetaRequest.h
+++ b/src/client/MetaRequest.h
@@ -81,7 +81,7 @@ public:
 
   InodeRef target;
 
-  MetaRequest(int op) :
+  explicit MetaRequest(int op) :
     _dentry(NULL), _old_dentry(NULL), abort_rc(0),
     tid(0),
     inode_drop(0), inode_unless(0),

--- a/src/client/Trace.h
+++ b/src/client/Trace.h
@@ -39,7 +39,7 @@ class Trace {
   string line;
 
  public:
-  Trace(const char* f) : _line(0), filename(f), fs(0) {}
+  explicit Trace(const char* f) : _line(0), filename(f), fs(0) {}
   ~Trace() { 
     delete fs; 
   }

--- a/src/client/hypertable/CephBroker.h
+++ b/src/client/hypertable/CephBroker.h
@@ -58,7 +58,7 @@ namespace Hypertable {
   class OpenFileDataCephPtr : public OpenFileDataPtr {
   public:
     OpenFileDataCephPtr() : OpenFileDataPtr() { }
-    OpenFileDataCephPtr(OpenFileDataCeph *ofdl) : OpenFileDataPtr(ofdl, true) { }
+    explicit OpenFileDataCephPtr(OpenFileDataCeph *ofdl) : OpenFileDataPtr(ofdl, true) { }
     OpenFileDataCeph *operator->() const { return static_cast<OpenFileDataCeph *>(get()); }
   };
 
@@ -67,7 +67,7 @@ namespace Hypertable {
    */
   class CephBroker : public DfsBroker::Broker {
   public:
-    CephBroker(PropertiesPtr& cfg);
+    explicit CephBroker(PropertiesPtr& cfg);
     virtual ~CephBroker();
 
     virtual void open(ResponseCallbackOpen *cb, const char *fname,

--- a/src/cls/log/cls_log_client.cc
+++ b/src/cls/log/cls_log_client.cc
@@ -127,7 +127,7 @@ void cls_log_list(librados::ObjectReadOperation& op, utime_t& from, utime_t& to,
 class LogInfoCtx : public ObjectOperationCompletion {
   cls_log_header *header;
 public:
-  LogInfoCtx(cls_log_header *_header) : header(_header) {}
+  explicit LogInfoCtx(cls_log_header *_header) : header(_header) {}
   void handle_completion(int r, bufferlist& outbl) {
     if (r >= 0) {
       cls_log_info_ret ret;

--- a/src/cls/replica_log/cls_replica_log_ops.h
+++ b/src/cls/replica_log/cls_replica_log_ops.h
@@ -16,7 +16,7 @@
 struct cls_replica_log_delete_marker_op {
   string entity_id;
   cls_replica_log_delete_marker_op() {}
-  cls_replica_log_delete_marker_op(const string& id) : entity_id(id) {}
+  explicit cls_replica_log_delete_marker_op(const string& id) : entity_id(id) {}
 
   void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
@@ -39,7 +39,7 @@ WRITE_CLASS_ENCODER(cls_replica_log_delete_marker_op)
 struct cls_replica_log_set_marker_op {
   cls_replica_log_progress_marker marker;
   cls_replica_log_set_marker_op() {}
-  cls_replica_log_set_marker_op(const cls_replica_log_progress_marker& m) :
+  explicit cls_replica_log_set_marker_op(const cls_replica_log_progress_marker& m) :
     marker(m) {}
 
   void encode(bufferlist& bl) const {

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -476,7 +476,7 @@ int CLSRGWIssueGetDirHeader::issue_op(int shard_id, const string& oid)
 class GetDirHeaderCompletion : public ObjectOperationCompletion {
   RGWGetDirHeader_CB *ret_ctx;
 public:
-  GetDirHeaderCompletion(RGWGetDirHeader_CB *_ctx) : ret_ctx(_ctx) {}
+  explicit GetDirHeaderCompletion(RGWGetDirHeader_CB *_ctx) : ret_ctx(_ctx) {}
   ~GetDirHeaderCompletion() {
     ret_ctx->put();
   }

--- a/src/cls/version/cls_version_client.cc
+++ b/src/cls/version/cls_version_client.cc
@@ -60,7 +60,7 @@ void cls_version_check(librados::ObjectOperation& op, obj_version& objv, Version
 class VersionReadCtx : public ObjectOperationCompletion {
   obj_version *objv;
 public:
-  VersionReadCtx(obj_version *_objv) : objv(_objv) {}
+  explicit VersionReadCtx(obj_version *_objv) : objv(_objv) {}
   void handle_completion(int r, bufferlist& outbl) {
     if (r >= 0) {
       cls_version_read_ret ret;

--- a/src/common/BackTrace.h
+++ b/src/common/BackTrace.h
@@ -18,7 +18,7 @@ struct BackTrace {
   size_t size;
   char **strings;
 
-  BackTrace(int s) : skip(s) {
+  explicit BackTrace(int s) : skip(s) {
 #ifdef HAVE_EXECINFO_H
     size = backtrace(array, max);
     strings = backtrace_symbols(array, size);

--- a/src/common/DecayCounter.h
+++ b/src/common/DecayCounter.h
@@ -56,7 +56,7 @@ public:
   void dump(Formatter *f) const;
   static void generate_test_instances(list<DecayCounter*>& ls);
 
-  DecayCounter(const utime_t &now)
+  explicit DecayCounter(const utime_t &now)
     : val(0), delta(0), vel(0), last_decay(now)
   {
   }

--- a/src/common/DecayCounter.h
+++ b/src/common/DecayCounter.h
@@ -35,6 +35,7 @@ class DecayRate {
 
 public:
   DecayRate() : k(0) {}
+  // cppcheck-suppress noExplicitConstructor
   DecayRate(double hl) { set_halflife(hl); }
   void set_halflife(double hl) {
     k = ::log(.5) / hl;

--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -62,7 +62,7 @@ class Finisher {
 
   struct FinisherThread : public Thread {
     Finisher *fin;    
-    FinisherThread(Finisher *f) : fin(f) {}
+    explicit FinisherThread(Finisher *f) : fin(f) {}
     void* entry() { return (void*)fin->finisher_thread_entry(); }
   } finisher_thread;
 
@@ -134,7 +134,7 @@ class Finisher {
 
   /// Construct an anonymous Finisher.
   /// Anonymous finishers do not log their queue length.
-  Finisher(CephContext *cct_) :
+  explicit Finisher(CephContext *cct_) :
     cct(cct_), finisher_lock("Finisher::finisher_lock"),
     finisher_stop(false), finisher_running(false),
     thread_name("fn_anonymous"), logger(0),

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -91,7 +91,7 @@ namespace ceph {
 
   class JSONFormatter : public Formatter {
   public:
-    JSONFormatter(bool p = false);
+    explicit JSONFormatter(bool p = false);
 
     virtual void set_status(int status, const char* status_name) {};
     virtual void output_header() {};
@@ -178,7 +178,7 @@ namespace ceph {
 
   class TableFormatter : public Formatter {
   public:
-    TableFormatter(bool keyval = false);
+    explicit TableFormatter(bool keyval = false);
 
     virtual void set_status(int status, const char* status_name) {};
     virtual void output_header() {};

--- a/src/common/HTMLFormatter.h
+++ b/src/common/HTMLFormatter.h
@@ -20,7 +20,7 @@
 namespace ceph {
   class HTMLFormatter : public XMLFormatter {
   public:
-    HTMLFormatter(bool pretty = false);
+    explicit HTMLFormatter(bool pretty = false);
     ~HTMLFormatter();
     void reset();
 

--- a/src/common/HeartbeatMap.h
+++ b/src/common/HeartbeatMap.h
@@ -46,7 +46,7 @@ struct heartbeat_handle_d {
   time_t grace, suicide_grace;
   std::list<heartbeat_handle_d*>::iterator list_item;
 
-  heartbeat_handle_d(const std::string& n)
+  explicit heartbeat_handle_d(const std::string& n)
     : name(n), grace(0), suicide_grace(0)
   { }
 };
@@ -74,7 +74,7 @@ class HeartbeatMap {
   // get the number of total workers
   int get_total_workers() const;
 
-  HeartbeatMap(CephContext *cct);
+  explicit HeartbeatMap(CephContext *cct);
   ~HeartbeatMap();
 
  private:

--- a/src/common/Initialize.h
+++ b/src/common/Initialize.h
@@ -69,7 +69,7 @@ class Initialize {
    *      function should normally contain an internal guard so that it
    *      only performs its initialization the first time it is invoked.
    */
-  Initialize(void (*func)()) {
+  explicit Initialize(void (*func)()) {
     (*func)();
   }
 

--- a/src/common/MemoryModel.h
+++ b/src/common/MemoryModel.h
@@ -43,7 +43,7 @@ private:
   void _sample(snap *p);
 
 public:
-  MemoryModel(CephContext *cct);
+  explicit MemoryModel(CephContext *cct);
   void sample(snap *p = 0) {
     _sample(&last);
     if (p)

--- a/src/common/Mutex.h
+++ b/src/common/Mutex.h
@@ -111,7 +111,7 @@ public:
     Mutex &mutex;
 
   public:
-    Locker(Mutex& m) : mutex(m) {
+    explicit Locker(Mutex& m) : mutex(m) {
       mutex.Lock();
     }
     ~Locker() {

--- a/src/common/PluginRegistry.h
+++ b/src/common/PluginRegistry.h
@@ -39,7 +39,7 @@ namespace ceph {
     void *library;
     CephContext *cct;
 
-    Plugin(CephContext *cct) : cct(cct) {}
+    explicit Plugin(CephContext *cct) : cct(cct) {}
     virtual ~Plugin() {}
   };
 
@@ -51,7 +51,7 @@ namespace ceph {
     bool disable_dlclose;
     std::map<std::string,std::map<std::string,Plugin*> > plugins;
 
-    PluginRegistry(CephContext *cct);
+    explicit PluginRegistry(CephContext *cct);
     ~PluginRegistry();
 
     int add(const std::string& type, const std::string& name,

--- a/src/common/RWLock.h
+++ b/src/common/RWLock.h
@@ -140,7 +140,7 @@ public:
     bool locked;
 
   public:
-    RLocker(const RWLock& lock) : m_lock(lock) {
+   explicit  RLocker(const RWLock& lock) : m_lock(lock) {
       m_lock.get_read();
       locked = true;
     }
@@ -162,7 +162,7 @@ public:
     bool locked;
 
   public:
-    WLocker(RWLock& lock) : m_lock(lock) {
+    explicit WLocker(RWLock& lock) : m_lock(lock) {
       m_lock.get_write();
       locked = true;
     }
@@ -192,7 +192,7 @@ public:
     LockState state;
 
   public:
-    Context(RWLock& l) : lock(l), state(Untaken) {}
+    explicit Context(RWLock& l) : lock(l), state(Untaken) {}
     Context(RWLock& l, LockState s) : lock(l), state(s) {}
 
     void get_write() {

--- a/src/common/RWLock.h
+++ b/src/common/RWLock.h
@@ -192,7 +192,7 @@ public:
     LockState state;
 
   public:
-    Context(RWLock& l) : lock(l) {}
+    Context(RWLock& l) : lock(l), state(Untaken) {}
     Context(RWLock& l, LockState s) : lock(l), state(s) {}
 
     void get_write() {

--- a/src/common/Timer.cc
+++ b/src/common/Timer.cc
@@ -33,7 +33,7 @@
 class SafeTimerThread : public Thread {
   SafeTimer *parent;
 public:
-  SafeTimerThread(SafeTimer *s) : parent(s) {}
+  explicit SafeTimerThread(SafeTimer *s) : parent(s) {}
   void *entry() {
     parent->timer_thread();
     return NULL;

--- a/src/common/TracepointProvider.h
+++ b/src/common/TracepointProvider.h
@@ -45,7 +45,7 @@ public:
   template <const Traits &traits>
   class TypedSingleton : public Singleton {
   public:
-    TypedSingleton(CephContext *cct)
+    explicit TypedSingleton(CephContext *cct)
       : Singleton(cct, traits.library, traits.config_key) {
     }
   };

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -56,7 +56,7 @@ class OpTracker {
   class RemoveOnDelete {
     OpTracker *tracker;
   public:
-    RemoveOnDelete(OpTracker *tracker) : tracker(tracker) {}
+    explicit RemoveOnDelete(OpTracker *tracker) : tracker(tracker) {}
     void operator()(TrackedOp *op);
   };
   friend class RemoveOnDelete;
@@ -65,7 +65,7 @@ class OpTracker {
   struct ShardedTrackingData {
     Mutex ops_in_flight_lock_sharded;
     xlist<TrackedOp *> ops_in_flight_sharded;
-    ShardedTrackingData(string lock_name):
+    explicit ShardedTrackingData(string lock_name):
         ops_in_flight_lock_sharded(lock_name.c_str()) {}
   };
   vector<ShardedTrackingData*> sharded_in_flight_list;

--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -443,6 +443,7 @@ private:
   // threads
   struct WorkThread : public Thread {
     ThreadPool *pool;
+    // cppcheck-suppress noExplicitConstructor
     WorkThread(ThreadPool *p) : pool(p) {}
     void *entry() {
       pool->worker(this);

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -473,7 +473,7 @@ public:
 class HelpHook : public AdminSocketHook {
   AdminSocket *m_as;
 public:
-  HelpHook(AdminSocket *as) : m_as(as) {}
+  explicit HelpHook(AdminSocket *as) : m_as(as) {}
   bool call(string command, cmdmap_t &cmdmap, string format, bufferlist& out) {
     Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
     f->open_object_section("help");
@@ -495,7 +495,7 @@ public:
 class GetdescsHook : public AdminSocketHook {
   AdminSocket *m_as;
 public:
-  GetdescsHook(AdminSocket *as) : m_as(as) {}
+  explicit GetdescsHook(AdminSocket *as) : m_as(as) {}
   bool call(string command, cmdmap_t &cmdmap, string format, bufferlist& out) {
     int cmdnum = 0;
     JSONFormatter jf(false);

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -176,6 +176,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     virtual ~raw() {}
 
     // no copying.
+    // cppcheck-suppress noExplicitConstructor
     raw(const raw &other);
     const raw& operator=(const raw &other);
 

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -165,7 +165,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     mutable simple_spinlock_t crc_spinlock;
     map<pair<size_t, size_t>, pair<uint32_t, uint32_t> > crc_map;
 
-    raw(unsigned l)
+    explicit raw(unsigned l)
       : data(NULL), len(l), nref(0),
 	crc_spinlock(SIMPLE_SPINLOCK_INITIALIZER)
     { }
@@ -236,7 +236,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
 
   class buffer::raw_malloc : public buffer::raw {
   public:
-    raw_malloc(unsigned l) : raw(l) {
+    explicit raw_malloc(unsigned l) : raw(l) {
       if (len) {
 	data = (char *)malloc(len);
         if (!data)
@@ -265,7 +265,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
 #ifndef __CYGWIN__
   class buffer::raw_mmap_pages : public buffer::raw {
   public:
-    raw_mmap_pages(unsigned l) : raw(l) {
+    explicit raw_mmap_pages(unsigned l) : raw(l) {
       data = (char*)::mmap(NULL, len, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0);
       if (!data)
 	throw bad_alloc();
@@ -347,7 +347,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
 #ifdef CEPH_HAVE_SPLICE
   class buffer::raw_pipe : public buffer::raw {
   public:
-    raw_pipe(unsigned len) : raw(len), source_consumed(false) {
+    explicit raw_pipe(unsigned len) : raw(len), source_consumed(false) {
       size_t max = get_max_pipe_size();
       if (len > max) {
 	bdout << "raw_pipe: requested length " << len
@@ -527,7 +527,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
    */
   class buffer::raw_char : public buffer::raw {
   public:
-    raw_char(unsigned l) : raw(l) {
+    explicit raw_char(unsigned l) : raw(l) {
       if (len)
 	data = new char[len];
       else
@@ -552,7 +552,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
 
   class buffer::raw_unshareable : public buffer::raw {
   public:
-    raw_unshareable(unsigned l) : raw(l) {
+    explicit raw_unshareable(unsigned l) : raw(l) {
       if (len)
 	data = new char[len];
       else

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -35,7 +35,7 @@
 class CephInitParameters
 {
 public:
-  CephInitParameters(uint32_t module_type_);
+  explicit CephInitParameters(uint32_t module_type_);
   std::list<std::string> get_conf_files() const;
 
   uint32_t module_type;

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -46,7 +46,7 @@ namespace {
 
 class LockdepObs : public md_config_obs_t {
 public:
-  LockdepObs(CephContext *cct) : m_cct(cct), m_registered(false) {
+  explicit LockdepObs(CephContext *cct) : m_cct(cct), m_registered(false) {
   }
   virtual ~LockdepObs() {
     if (m_registered) {
@@ -80,7 +80,7 @@ private:
 class CephContextServiceThread : public Thread
 {
 public:
-  CephContextServiceThread(CephContext *cct)
+  explicit CephContextServiceThread(CephContext *cct)
     : _lock("CephContextServiceThread::_lock"),
       _reopen_logs(false), _exit_thread(false), _cct(cct)
   {
@@ -149,7 +149,7 @@ class LogObs : public md_config_obs_t {
   ceph::log::Log *log;
 
 public:
-  LogObs(ceph::log::Log *l) : log(l) {}
+  explicit LogObs(ceph::log::Log *l) : log(l) {}
 
   const char** get_tracked_conf_keys() const {
     static const char *KEYS[] = {
@@ -201,7 +201,7 @@ class CephContextObs : public md_config_obs_t {
   CephContext *cct;
 
 public:
-  CephContextObs(CephContext *cct) : cct(cct) {}
+  explicit CephContextObs(CephContext *cct) : cct(cct) {}
 
   const char** get_tracked_conf_keys() const {
     static const char *KEYS[] = {
@@ -264,7 +264,7 @@ class CephContextHook : public AdminSocketHook {
   CephContext *m_cct;
 
 public:
-  CephContextHook(CephContext *cct) : m_cct(cct) {}
+  explicit CephContextHook(CephContext *cct) : m_cct(cct) {}
 
   bool call(std::string command, cmdmap_t& cmdmap, std::string format,
 	    bufferlist& out) {

--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -285,7 +285,7 @@ public:
 
   struct Comparator {
     bool bitwise;
-    Comparator(bool b) : bitwise(b) {}
+    explicit Comparator(bool b) : bitwise(b) {}
     bool operator()(const hobject_t& l, const hobject_t& r) const {
       if (bitwise)
 	return cmp_bitwise(l, r) < 0;
@@ -295,7 +295,7 @@ public:
   };
   struct ComparatorWithDefault {
     bool bitwise;
-    ComparatorWithDefault(bool b=true) : bitwise(b) {}
+    explicit ComparatorWithDefault(bool b=true) : bitwise(b) {}
     bool operator()(const hobject_t& l, const hobject_t& r) const {
       if (bitwise)
 	return cmp_bitwise(l, r) < 0;
@@ -463,7 +463,7 @@ public:
 
   struct Comparator {
     bool bitwise;
-    Comparator(bool b) : bitwise(b) {}
+    explicit Comparator(bool b) : bitwise(b) {}
     bool operator()(const ghobject_t& l, const ghobject_t& r) const {
          if (bitwise)
 	return cmp_bitwise(l, r) < 0;

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -293,7 +293,7 @@ int ObjBencher::aio_bench(
 }
 
 struct lock_cond {
-  lock_cond(Mutex *_lock) : lock(_lock) {}
+  explicit lock_cond(Mutex *_lock) : lock(_lock) {}
   Mutex *lock;
   Cond cond;
 };

--- a/src/common/obj_bencher.h
+++ b/src/common/obj_bencher.h
@@ -105,7 +105,7 @@ protected:
   ostream& out(ostream& os);
   ostream& out(ostream& os, utime_t& t);
 public:
-  ObjBencher(CephContext *cct_) : show_time(false), cct(cct_), lock("ObjBencher::lock") {}
+  explicit ObjBencher(CephContext *cct_) : show_time(false), cct(cct_), lock("ObjBencher::lock") {}
   virtual ~ObjBencher() {}
   int aio_bench(
     int operation, int secondsToRun,

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -51,7 +51,7 @@ static const struct sockaddr *find_ip_in_subnet_list(CephContext *cct,
 // observe this change
 struct Observer : public md_config_obs_t {
   const char *keys[2];
-  Observer(const char *c) {
+  explicit Observer(const char *c) {
     keys[0] = c;
     keys[1] = NULL;
   }

--- a/src/compressor/AsyncCompressor.h
+++ b/src/compressor/AsyncCompressor.h
@@ -108,7 +108,7 @@ class AsyncCompressor {
   void _decompress(bufferlist &in, bufferlist &out);
 
  public:
-  AsyncCompressor(CephContext *c);
+  explicit AsyncCompressor(CephContext *c);
   virtual ~AsyncCompressor() {}
 
   int get_cpuid(int id) {

--- a/src/compressor/CompressionPlugin.h
+++ b/src/compressor/CompressionPlugin.h
@@ -28,7 +28,7 @@ namespace ceph {
   public:
     CompressorRef compressor;
 
-    CompressionPlugin(CephContext *cct) : Plugin(cct),
+    explicit CompressionPlugin(CephContext *cct) : Plugin(cct),
                                           compressor(0) 
     {}
     

--- a/src/compressor/snappy/CompressionPluginSnappy.cc
+++ b/src/compressor/snappy/CompressionPluginSnappy.cc
@@ -23,7 +23,7 @@ class CompressionPluginSnappy : public CompressionPlugin {
 
 public:
 
-  CompressionPluginSnappy(CephContext* cct) : CompressionPlugin(cct)
+  explicit CompressionPluginSnappy(CephContext* cct) : CompressionPlugin(cct)
   {}
 
   virtual int factory(CompressorRef *cs,

--- a/src/compressor/snappy/SnappyCompressor.h
+++ b/src/compressor/snappy/SnappyCompressor.h
@@ -26,7 +26,7 @@ class BufferlistSource : public snappy::Source {
   size_t left;
 
  public:
-  BufferlistSource(const bufferlist &data): pb(data.buffers().begin()), pb_off(0), left(data.length()) {}
+  explicit BufferlistSource(const bufferlist &data): pb(data.buffers().begin()), pb_off(0), left(data.length()) {}
   virtual ~BufferlistSource() {}
   virtual size_t Available() const { return left; }
   virtual const char* Peek(size_t* len) {

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -565,7 +565,6 @@ int CrushTester::test()
 
       // create a structure to hold data for post-processing
       tester_data_set tester_data;
-      vector<int> vector_data_buffer;
       vector<float> vector_data_buffer_f;
 
       // create a map to hold batch-level placement information

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -254,12 +254,6 @@ int CrushTester::random_placement(int ruleno, vector<int>& out, int maxout, vect
       crush.get_max_devices() == 0)
     return -EINVAL;
 
-  // compute each device's proportional weight
-  vector<float> proportional_weights( weight.size() );
-  for (unsigned i = 0; i < weight.size(); i++) {
-    proportional_weights[i] = (float) weight[i] / (float) total_weight;
-  }
-
   // determine the real maximum number of devices to return
   int devices_requested = min(maxout, get_maximum_affected_by_rule(ruleno));
   bool accept_placement = false;

--- a/src/crush/CrushTreeDumper.h
+++ b/src/crush/CrushTreeDumper.h
@@ -63,7 +63,7 @@ namespace CrushTreeDumper {
   template <typename F>
   class Dumper : public list<Item> {
   public:
-    Dumper(const CrushWrapper *crush_) : crush(crush_) {
+    explicit Dumper(const CrushWrapper *crush_) : crush(crush_) {
       crush->find_roots(roots);
       root = roots.begin();
     }
@@ -155,7 +155,7 @@ namespace CrushTreeDumper {
 
   class FormattingDumper : public Dumper<Formatter> {
   public:
-    FormattingDumper(const CrushWrapper *crush) : Dumper<Formatter>(crush) {}
+    explicit FormattingDumper(const CrushWrapper *crush) : Dumper<Formatter>(crush) {}
 
   protected:
     virtual void dump_item(const Item &qi, Formatter *f) {

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1498,7 +1498,7 @@ namespace {
     typedef CrushTreeDumper::Item Item;
     const CrushWrapper *crush;
   public:
-    TreeDumper(const CrushWrapper *crush)
+    explicit TreeDumper(const CrushWrapper *crush)
       : crush(crush) {}
 
     void dump(Formatter *f) {
@@ -1670,7 +1670,7 @@ class CrushTreePlainDumper : public CrushTreeDumper::Dumper<ostream> {
 public:
   typedef CrushTreeDumper::Dumper<ostream> Parent;
 
-  CrushTreePlainDumper(const CrushWrapper *crush)
+  explicit CrushTreePlainDumper(const CrushWrapper *crush)
     : Parent(crush) {}
 
   void dump(ostream *out) {
@@ -1704,7 +1704,7 @@ class CrushTreeFormattingDumper : public CrushTreeDumper::FormattingDumper {
 public:
   typedef CrushTreeDumper::FormattingDumper Parent;
 
-  CrushTreeFormattingDumper(const CrushWrapper *crush)
+  explicit CrushTreeFormattingDumper(const CrushWrapper *crush)
     : Parent(crush) {}
 
   void dump(Formatter *f) {

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -36,7 +36,7 @@ public:
   string ruleset_failure_domain;
   bool per_chunk_alignment;
 
-  ErasureCodeJerasure(const char *_technique) :
+  explicit ErasureCodeJerasure(const char *_technique) :
     k(0),
     DEFAULT_K("2"),
     m(0),
@@ -155,7 +155,7 @@ public:
   int **schedule;
   int packetsize;
 
-  ErasureCodeJerasureCauchy(const char *technique) :
+  explicit ErasureCodeJerasureCauchy(const char *technique) :
     ErasureCodeJerasure(technique),
     bitmatrix(0),
     schedule(0)
@@ -208,7 +208,7 @@ public:
   int **schedule;
   int packetsize;
 
-  ErasureCodeJerasureLiberation(const char *technique = "liberation") :
+  explicit ErasureCodeJerasureLiberation(const char *technique = "liberation") :
     ErasureCodeJerasure(technique),
     bitmatrix(0),
     schedule(0)

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -49,7 +49,7 @@ public:
   static const string DEFAULT_KML;
 
   struct Layer {
-    Layer(string _chunks_map) : chunks_map(_chunks_map) { }
+    explicit Layer(string _chunks_map) : chunks_map(_chunks_map) { }
     ErasureCodeInterfaceRef erasure_code;
     vector<int> data;
     vector<int> coding;
@@ -74,7 +74,7 @@ public:
   };
   vector<Step> ruleset_steps;
 
-  ErasureCodeLrc(const std::string &dir)
+  explicit ErasureCodeLrc(const std::string &dir)
     : directory(dir),
       chunk_count(0), data_chunk_count(0), ruleset_root("default")
   {

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -241,6 +241,7 @@ void global_init(std::vector < const char * > *alt_def_args,
     derr << "deliberately leaking some memory" << dendl;
     char *s = new char[1234567];
     (void)s;
+    // cppcheck-suppress memleak
   }
 
   if (code_env == CODE_ENVIRONMENT_DAEMON && !(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -168,7 +168,9 @@ namespace buffer CEPH_BUFFER_API {
 
   public:
     ptr() : _raw(0), _off(0), _len(0) {}
+    // cppcheck-suppress noExplicitConstructor
     ptr(raw *r);
+    // cppcheck-suppress noExplicitConstructor
     ptr(unsigned l);
     ptr(const char *d, unsigned l);
     ptr(const ptr& p);
@@ -354,6 +356,7 @@ namespace buffer CEPH_BUFFER_API {
   public:
     // cons/des
     list() : _len(0), _memcopy_count(0), last_p(this) {}
+    // cppcheck-suppress noExplicitConstructor
     list(unsigned prealloc) : _len(0), _memcopy_count(0), last_p(this) {
       append_buffer = buffer::create(prealloc);
       append_buffer.set_length(0);   // unused, so far.
@@ -543,6 +546,7 @@ namespace buffer CEPH_BUFFER_API {
 
   public:
     hash() : crc(0) { }
+    // cppcheck-suppress noExplicitConstructor
     hash(uint32_t init) : crc(init) { }
 
     void update(buffer::list& bl) {

--- a/src/include/object.h
+++ b/src/include/object.h
@@ -33,7 +33,9 @@ struct object_t {
   string name;
 
   object_t() {}
+  // cppcheck-suppress noExplicitConstructor
   object_t(const char *s) : name(s) {}
+  // cppcheck-suppress noExplicitConstructor
   object_t(const string& s) : name(s) {}
 
   void swap(object_t& o) {
@@ -110,6 +112,7 @@ struct file_object_t {
 
 struct snapid_t {
   uint64_t val;
+  // cppcheck-suppress noExplicitConstructor
   snapid_t(uint64_t v=0) : val(v) {}
   snapid_t operator+=(snapid_t o) { val += o.val; return *this; }
   snapid_t operator++() { ++val; return *this; }

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -280,6 +280,7 @@ typedef __u32 epoch_t;       // map epoch  (32bits -> 13 epochs/second for 10 ye
 struct client_t {
   int64_t v;
 
+  // cppcheck-suppress noExplicitConstructor
   client_t(int64_t _v = -2) : v(_v) {}
   
   void encode(bufferlist& bl) const {
@@ -315,6 +316,7 @@ typedef uint64_t _inodeno_t;
 struct inodeno_t {
   _inodeno_t val;
   inodeno_t() : val(0) {}
+  // cppcheck-suppress noExplicitConstructor
   inodeno_t(_inodeno_t v) : val(v) {}
   inodeno_t operator+=(inodeno_t o) { val += o.val; return *this; }
   operator _inodeno_t() const { return val; }
@@ -366,6 +368,7 @@ void dump(const ceph_dir_layout& l, ceph::Formatter *f);
 
 struct prettybyte_t {
   uint64_t v;
+  // cppcheck-suppress noExplicitConstructor
   prettybyte_t(uint64_t _v) : v(_v) {}
 };
 
@@ -389,6 +392,7 @@ inline ostream& operator<<(ostream& out, const prettybyte_t& b)
 
 struct si_t {
   uint64_t v;
+  // cppcheck-suppress noExplicitConstructor
   si_t(uint64_t _v) : v(_v) {}
 };
 
@@ -412,6 +416,7 @@ inline ostream& operator<<(ostream& out, const si_t& b)
 
 struct pretty_si_t {
   uint64_t v;
+  // cppcheck-suppress noExplicitConstructor
   pretty_si_t(uint64_t _v) : v(_v) {}
 };
 
@@ -435,6 +440,7 @@ inline ostream& operator<<(ostream& out, const pretty_si_t& b)
 
 struct kb_t {
   uint64_t v;
+  // cppcheck-suppress noExplicitConstructor
   kb_t(uint64_t _v) : v(_v) {}
 };
 
@@ -483,6 +489,7 @@ inline ostream& operator<<(ostream &oss, health_status_t status) {
 
 struct weightf_t {
   float v;
+  // cppcheck-suppress noExplicitConstructor
   weightf_t(float _v) : v(_v) {}
 };
 
@@ -530,6 +537,7 @@ struct errorcode32_t {
   int32_t code;
 
   errorcode32_t() {}
+  // cppcheck-suppress noExplicitConstructor
   errorcode32_t(int32_t i) : code(i) {}
 
   operator int() const { return code; }

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -479,7 +479,7 @@ std::ostream &operator<<(std::ostream &os,
 			 const JournalMetadata::RegisteredClients &clients) {
   os << "[";
   for (JournalMetadata::RegisteredClients::const_iterator c = clients.begin();
-       c != clients.end(); c++) {
+       c != clients.end(); ++c) {
     os << (c == clients.begin() ? "" : ", " ) << *c;
   }
   os << "]";

--- a/src/journal/JournalPlayer.cc
+++ b/src/journal/JournalPlayer.cc
@@ -18,7 +18,7 @@ namespace {
 struct C_HandleComplete : public Context {
   ReplayHandler *replay_handler;
 
-  C_HandleComplete(ReplayHandler *_replay_handler)
+  explicit C_HandleComplete(ReplayHandler *_replay_handler)
     : replay_handler(_replay_handler) {
     replay_handler->get();
   }
@@ -33,7 +33,7 @@ struct C_HandleComplete : public Context {
 struct C_HandleEntriesAvailable : public Context {
   ReplayHandler *replay_handler;
 
-  C_HandleEntriesAvailable(ReplayHandler *_replay_handler)
+  explicit C_HandleEntriesAvailable(ReplayHandler *_replay_handler)
       : replay_handler(_replay_handler) {
     replay_handler->get();
   }

--- a/src/kv/KineticStore.h
+++ b/src/kv/KineticStore.h
@@ -45,7 +45,7 @@ class KineticStore : public KeyValueDB {
   int do_open(ostream &out, bool create_if_missing);
 
 public:
-  KineticStore(CephContext *c);
+  explicit KineticStore(CephContext *c);
   ~KineticStore();
 
   static int _test_init(CephContext *c);
@@ -81,7 +81,7 @@ public:
     vector<KineticOp> ops;
     KineticStore *db;
 
-    KineticTransactionImpl(KineticStore *db) : db(db) {}
+    explicit KineticTransactionImpl(KineticStore *db) : db(db) {}
     void set(
       const string &prefix,
       const string &k,
@@ -115,7 +115,7 @@ public:
     kinetic::BlockingKineticConnection *kinetic_conn;
     kinetic::KineticStatus kinetic_status;
   public:
-    KineticWholeSpaceIteratorImpl(kinetic::BlockingKineticConnection *conn);
+    explicit KineticWholeSpaceIteratorImpl(kinetic::BlockingKineticConnection *conn);
     virtual ~KineticWholeSpaceIteratorImpl() { }
 
     int seek_to_first() {

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -18,7 +18,7 @@ using std::string;
 class CephLevelDBLogger : public leveldb::Logger {
   CephContext *cct;
 public:
-  CephLevelDBLogger(CephContext *c) : cct(c) {
+  explicit CephLevelDBLogger(CephContext *c) : cct(c) {
     cct->get();
   }
   ~CephLevelDBLogger() {

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -73,7 +73,7 @@ class LevelDBStore : public KeyValueDB {
   class CompactThread : public Thread {
     LevelDBStore *db;
   public:
-    CompactThread(LevelDBStore *d) : db(d) {}
+    explicit CompactThread(LevelDBStore *d) : db(d) {}
     void *entry() {
       db->compact_thread_entry();
       return NULL;
@@ -185,7 +185,7 @@ public:
   public:
     leveldb::WriteBatch bat;
     LevelDBStore *db;
-    LevelDBTransactionImpl(LevelDBStore *db) : db(db) {}
+    explicit LevelDBTransactionImpl(LevelDBStore *db) : db(db) {}
     void set(
       const string &prefix,
       const string &k,
@@ -220,7 +220,7 @@ public:
   protected:
     boost::scoped_ptr<leveldb::Iterator> dbiter;
   public:
-    LevelDBWholeSpaceIteratorImpl(leveldb::Iterator *iter) :
+    explicit LevelDBWholeSpaceIteratorImpl(leveldb::Iterator *iter) :
       dbiter(iter) { }
     virtual ~LevelDBWholeSpaceIteratorImpl() { }
 

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -35,7 +35,7 @@ using std::string;
 class CephRocksdbLogger : public rocksdb::Logger {
   CephContext *cct;
 public:
-  CephRocksdbLogger(CephContext *c) : cct(c) {
+  explicit CephRocksdbLogger(CephContext *c) : cct(c) {
     cct->get();
   }
   ~CephRocksdbLogger() {

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -72,7 +72,7 @@ class RocksDBStore : public KeyValueDB {
   class CompactThread : public Thread {
     RocksDBStore *db;
   public:
-    CompactThread(RocksDBStore *d) : db(d) {}
+    explicit CompactThread(RocksDBStore *d) : db(d) {}
     void *entry() {
       db->compact_thread_entry();
       return NULL;
@@ -142,7 +142,7 @@ public:
     rocksdb::WriteBatch *bat;
     RocksDBStore *db;
 
-    RocksDBTransactionImpl(RocksDBStore *_db);
+    explicit RocksDBTransactionImpl(RocksDBStore *_db);
     ~RocksDBTransactionImpl();
     void set(
       const string &prefix,
@@ -179,7 +179,7 @@ public:
   protected:
     rocksdb::Iterator *dbiter;
   public:
-    RocksDBWholeSpaceIteratorImpl(rocksdb::Iterator *iter) :
+    explicit RocksDBWholeSpaceIteratorImpl(rocksdb::Iterator *iter) :
       dbiter(iter) { }
     //virtual ~RocksDBWholeSpaceIteratorImpl() { }
     ~RocksDBWholeSpaceIteratorImpl();

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -37,7 +37,7 @@
 struct ceph_mount_info
 {
 public:
-  ceph_mount_info(CephContext *cct_)
+  explicit ceph_mount_info(CephContext *cct_)
     : mounted(false),
       inited(false),
       client(NULL),

--- a/src/librados/AioCompletionImpl.h
+++ b/src/librados/AioCompletionImpl.h
@@ -170,7 +170,7 @@ namespace librados {
 struct C_AioComplete : public Context {
   AioCompletionImpl *c;
 
-  C_AioComplete(AioCompletionImpl *cc) : c(cc) {
+  explicit C_AioComplete(AioCompletionImpl *cc) : c(cc) {
     c->_get();
   }
 
@@ -189,7 +189,7 @@ struct C_AioComplete : public Context {
 struct C_AioSafe : public Context {
   AioCompletionImpl *c;
 
-  C_AioSafe(AioCompletionImpl *cc) : c(cc) {
+  explicit C_AioSafe(AioCompletionImpl *cc) : c(cc) {
     c->_get();
   }
 
@@ -216,7 +216,7 @@ struct C_AioSafe : public Context {
 struct C_AioCompleteAndSafe : public Context {
   AioCompletionImpl *c;
 
-  C_AioCompleteAndSafe(AioCompletionImpl *cc) : c(cc) {
+  explicit C_AioCompleteAndSafe(AioCompletionImpl *cc) : c(cc) {
     c->get();
   }
 

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -762,7 +762,7 @@ int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
 class C_ObjectOperation : public Context {
 public:
   ::ObjectOperation m_ops;
-  C_ObjectOperation(Context *c) : m_ctx(c) {}
+  explicit C_ObjectOperation(Context *c) : m_ctx(c) {}
   virtual void finish(int r) {
     m_ctx->complete(r);
   }

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -161,7 +161,7 @@ struct librados::IoCtxImpl {
 
   struct C_aio_Ack : public Context {
     librados::AioCompletionImpl *c;
-    C_aio_Ack(AioCompletionImpl *_c);
+    explicit C_aio_Ack(AioCompletionImpl *_c);
     void finish(int r);
   };
 
@@ -175,7 +175,7 @@ struct librados::IoCtxImpl {
 
   struct C_aio_Safe : public Context {
     AioCompletionImpl *c;
-    C_aio_Safe(AioCompletionImpl *_c);
+    explicit C_aio_Safe(AioCompletionImpl *_c);
     void finish(int r);
   };
 

--- a/src/librados/PoolAsyncCompletionImpl.h
+++ b/src/librados/PoolAsyncCompletionImpl.h
@@ -91,7 +91,7 @@ namespace librados {
     PoolAsyncCompletionImpl *c;
 
   public:
-    C_PoolAsync_Safe(PoolAsyncCompletionImpl *_c) : c(_c) {
+    explicit C_PoolAsync_Safe(PoolAsyncCompletionImpl *_c) : c(_c) {
       c->get();
     }
     ~C_PoolAsync_Safe() {

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -75,7 +75,7 @@ private:
 public:
   Finisher finisher;
 
-  RadosClient(CephContext *cct_);
+  explicit RadosClient(CephContext *cct_);
   ~RadosClient();
   int ping_monitor(string mon_id, string *result);
   int connect();

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -188,7 +188,7 @@ class ObjectOpCompletionCtx : public Context {
   librados::ObjectOperationCompletion *completion;
   bufferlist bl;
 public:
-  ObjectOpCompletionCtx(librados::ObjectOperationCompletion *c) : completion(c) {}
+  explicit ObjectOpCompletionCtx(librados::ObjectOperationCompletion *c) : completion(c) {}
   void finish(int r) {
     completion->handle_completion(r, bl);
     delete completion;
@@ -4873,7 +4873,7 @@ struct RadosOmapIter {
 class C_OmapIter : public Context {
   RadosOmapIter *iter;
 public:
-  C_OmapIter(RadosOmapIter *iter) : iter(iter) {}
+  explicit C_OmapIter(RadosOmapIter *iter) : iter(iter) {}
   void finish(int r) {
     iter->i = iter->values.begin();
   }
@@ -4882,7 +4882,7 @@ public:
 class C_XattrsIter : public Context {
   librados::RadosXattrsIter *iter;
 public:
-  C_XattrsIter(librados::RadosXattrsIter *iter) : iter(iter) {}
+  explicit C_XattrsIter(librados::RadosXattrsIter *iter) : iter(iter) {}
   void finish(int r) {
     iter->i = iter->attrset.begin();
   }
@@ -4924,7 +4924,7 @@ extern "C" void rados_read_op_omap_get_vals(rados_read_op_t read_op,
 struct C_OmapKeysIter : public Context {
   RadosOmapIter *iter;
   std::set<std::string> keys;
-  C_OmapKeysIter(RadosOmapIter *iter) : iter(iter) {}
+  explicit C_OmapKeysIter(RadosOmapIter *iter) : iter(iter) {}
   void finish(int r) {
     // map each key to an empty bl
     for (std::set<std::string>::const_iterator i = keys.begin();

--- a/src/librbd/AsyncOperation.cc
+++ b/src/librbd/AsyncOperation.cc
@@ -18,7 +18,7 @@ struct C_CompleteFlushes : public Context {
   ImageCtx *image_ctx;
   std::list<Context *> flush_contexts;
 
-  C_CompleteFlushes(ImageCtx *image_ctx, std::list<Context *> &&flush_contexts)
+  explicit C_CompleteFlushes(ImageCtx *image_ctx, std::list<Context *> &&flush_contexts)
     : image_ctx(image_ctx), flush_contexts(std::move(flush_contexts)) {
   }
   virtual void finish(int r) {

--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -28,7 +28,7 @@ const std::string WATCHER_LOCK_COOKIE_PREFIX = "auto";
 template <typename I>
 struct C_SendReleaseRequest : public Context {
   ReleaseRequest<I>* request;
-  C_SendReleaseRequest(ReleaseRequest<I>* request) : request(request) {
+  explicit C_SendReleaseRequest(ReleaseRequest<I>* request) : request(request) {
   }
   virtual void finish(int r) override {
     request->send();

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -48,7 +48,7 @@ namespace {
 
 class ThreadPoolSingleton : public ThreadPool {
 public:
-  ThreadPoolSingleton(CephContext *cct)
+  explicit ThreadPoolSingleton(CephContext *cct)
     : ThreadPool(cct, "librbd::thread_pool", "tp_librbd", cct->_conf->rbd_op_threads,
                  "rbd_op_threads") {
     start();

--- a/src/librbd/LibrbdAdminSocketHook.cc
+++ b/src/librbd/LibrbdAdminSocketHook.cc
@@ -21,7 +21,7 @@ public:
 
 class FlushCacheCommand : public LibrbdAdminSocketCommand {
 public:
-  FlushCacheCommand(ImageCtx *ictx) : ictx(ictx) {}
+  explicit FlushCacheCommand(ImageCtx *ictx) : ictx(ictx) {}
 
   bool call(stringstream *ss) {
     int r = flush(ictx);
@@ -38,7 +38,7 @@ private:
 
 struct InvalidateCacheCommand : public LibrbdAdminSocketCommand {
 public:
-  InvalidateCacheCommand(ImageCtx *ictx) : ictx(ictx) {}
+  explicit InvalidateCacheCommand(ImageCtx *ictx) : ictx(ictx) {}
 
   bool call(stringstream *ss) {
     int r = invalidate_cache(ictx);

--- a/src/librbd/LibrbdAdminSocketHook.cc
+++ b/src/librbd/LibrbdAdminSocketHook.cc
@@ -81,7 +81,7 @@ LibrbdAdminSocketHook::LibrbdAdminSocketHook(ImageCtx *ictx) :
 
 LibrbdAdminSocketHook::~LibrbdAdminSocketHook() {
   for (Commands::const_iterator i = commands.begin(); i != commands.end();
-       i++) {
+       ++i) {
     (void)admin_socket->unregister_command(i->first);
     delete i->second;
   }

--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -13,7 +13,7 @@ namespace {
 
 class EncodePayloadVisitor : public boost::static_visitor<void> {
 public:
-  EncodePayloadVisitor(bufferlist &bl) : m_bl(bl) {}
+  explicit EncodePayloadVisitor(bufferlist &bl) : m_bl(bl) {}
 
   template <typename Payload>
   inline void operator()(const Payload &payload) const {
@@ -42,7 +42,7 @@ private:
 
 class DumpPayloadVisitor : public boost::static_visitor<void> {
 public:
-  DumpPayloadVisitor(Formatter *formatter) : m_formatter(formatter) {}
+  explicit DumpPayloadVisitor(Formatter *formatter) : m_formatter(formatter) {}
 
   template <typename Payload>
   inline void operator()(const Payload &payload) const {

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1729,7 +1729,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
   }
 
   struct CopyProgressCtx {
-    CopyProgressCtx(ProgressContext &p)
+    explicit CopyProgressCtx(ProgressContext &p)
       : destictx(NULL), src_size(0), prog_ctx(p)
     { }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -399,7 +399,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     os << "[";
 
     for (image_options_t::const_iterator i = (*opts_)->begin();
-	 i != (*opts_)->end(); i++) {
+	 i != (*opts_)->end(); ++i) {
       os << (i == (*opts_)->begin() ? "" : ", ") << image_option_name(i->first)
 	 << "=" << i->second;
     }

--- a/src/librbd/journal/Entries.cc
+++ b/src/librbd/journal/Entries.cc
@@ -21,7 +21,7 @@ public:
 
 class EncodeEventVisitor : public boost::static_visitor<void> {
 public:
-  EncodeEventVisitor(bufferlist &bl) : m_bl(bl) {
+  explicit EncodeEventVisitor(bufferlist &bl) : m_bl(bl) {
   }
 
   template <typename Event>
@@ -50,7 +50,7 @@ private:
 
 class DumpEventVisitor : public boost::static_visitor<void> {
 public:
-  DumpEventVisitor(Formatter *formatter) : m_formatter(formatter) {}
+  explicit DumpEventVisitor(Formatter *formatter) : m_formatter(formatter) {}
 
   template <typename Event>
   inline void operator()(const Event &event) const {

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -51,7 +51,7 @@ class Log : private Thread
   void _log_message(const char *s, bool crash);
 
 public:
-  Log(SubsystemMap *s);
+  explicit Log(SubsystemMap *s);
   virtual ~Log();
 
   void set_flush_on_exit();

--- a/src/mds/Beacon.h
+++ b/src/mds/Beacon.h
@@ -67,7 +67,7 @@ class Beacon : public Dispatcher
   class C_MDS_BeaconSender : public Context {
     Beacon *beacon;
   public:
-    C_MDS_BeaconSender(Beacon *beacon_) : beacon(beacon_) {}
+    explicit C_MDS_BeaconSender(Beacon *beacon_) : beacon(beacon_) {}
     void finish(int r) {
       assert(beacon->lock.is_locked_by_me());
       beacon->sender = NULL;

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -51,7 +51,7 @@ protected:
   MDSRank* get_mds() {return dir->cache->mds;}
 
 public:
-  CDirContext(CDir *d) : dir(d) {
+  explicit CDirContext(CDir *d) : dir(d) {
     assert(dir != NULL);
   }
 };
@@ -64,7 +64,7 @@ protected:
   MDSRank* get_mds() {return dir->cache->mds;}
 
 public:
-  CDirIOContext(CDir *d) : dir(d) {
+  explicit CDirIOContext(CDir *d) : dir(d) {
     assert(dir != NULL);
   }
 };
@@ -2714,7 +2714,7 @@ CDir *CDir::get_frozen_tree_root()
 
 class C_Dir_AuthUnpin : public CDirContext {
   public:
-  C_Dir_AuthUnpin(CDir *d) : CDirContext(d) {}
+  explicit C_Dir_AuthUnpin(CDir *d) : CDirContext(d) {}
   void finish(int r) {
     dir->auth_unpin(dir->get_inode());
   }

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -58,7 +58,7 @@ protected:
   CInode *in;
   MDSRank *get_mds() {return in->mdcache->mds;}
 public:
-  CInodeIOContext(CInode *in_) : in(in_) {
+  explicit CInodeIOContext(CInode *in_) : in(in_) {
     assert(in != NULL);
   }
 };

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -26,7 +26,7 @@ class InoTable : public MDSTable {
   interval_set<inodeno_t> projected_free;
 
  public:
-  InoTable(MDSRank *m) : MDSTable(m, "inotable", true) { }
+  explicit InoTable(MDSRank *m) : MDSTable(m, "inotable", true) { }
 
   inodeno_t project_alloc_id(inodeno_t id=0);
   void apply_alloc_id(inodeno_t id);

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -64,7 +64,7 @@ class LockerContext : public MDSInternalContextBase {
   }
 
   public:
-  LockerContext(Locker *locker_) : locker(locker_) {
+  explicit LockerContext(Locker *locker_) : locker(locker_) {
     assert(locker != NULL);
   }
 };

--- a/src/mds/LogEvent.h
+++ b/src/mds/LogEvent.h
@@ -68,7 +68,7 @@ protected:
 public:
   LogSegment *_segment;
 
-  LogEvent(int t)
+  explicit LogEvent(int t)
     : _type(t), _start_off(0), _segment(0) { }
   virtual ~LogEvent() { }
 

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -113,7 +113,7 @@ void MDBalancer::tick()
 
 class C_Bal_SendHeartbeat : public MDSInternalContext {
 public:
-  C_Bal_SendHeartbeat(MDSRank *mds_) : MDSInternalContext(mds_) { }
+  explicit C_Bal_SendHeartbeat(MDSRank *mds_) : MDSInternalContext(mds_) { }
   virtual void finish(int f) {
     mds->balancer->send_heartbeat();
   }

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -143,7 +143,7 @@ protected:
     return mdcache->mds;
   }
 public:
-  MDCacheContext(MDCache *mdc_) : mdcache(mdc_) {}
+  explicit MDCacheContext(MDCache *mdc_) : mdcache(mdc_) {}
 };
 
 
@@ -163,7 +163,7 @@ protected:
     return mdcache->mds;
   }
 public:
-  MDCacheIOContext(MDCache *mdc_) : mdcache(mdc_) {}
+  explicit MDCacheIOContext(MDCache *mdc_) : mdcache(mdc_) {}
 };
 
 
@@ -574,7 +574,7 @@ void MDCache::_create_system_file_finish(MutationRef& mut, CDentry *dn, version_
 
 struct C_MDS_RetryOpenRoot : public MDSInternalContext {
   MDCache *cache;
-  C_MDS_RetryOpenRoot(MDCache *c) : MDSInternalContext(c->mds), cache(c) {}
+  explicit C_MDS_RetryOpenRoot(MDCache *c) : MDSInternalContext(c->mds), cache(c) {}
   void finish(int r) {
     if (r < 0)
       cache->mds->suicide();
@@ -4475,7 +4475,7 @@ void MDCache::handle_cache_rejoin_weak(MMDSCacheRejoin *weak)
 
 class C_MDC_RejoinGatherFinish : public MDCacheContext {
 public:
-  C_MDC_RejoinGatherFinish(MDCache *c) : MDCacheContext(c) {}
+  explicit C_MDC_RejoinGatherFinish(MDCache *c) : MDCacheContext(c) {}
   void finish(int r) {
     mdcache->rejoin_gather_finish();
   }
@@ -5633,7 +5633,7 @@ void MDCache::do_delayed_cap_imports()
 }
 
 struct C_MDC_OpenSnapParents : public MDCacheContext {
-  C_MDC_OpenSnapParents(MDCache *c) : MDCacheContext(c) {}
+  explicit C_MDC_OpenSnapParents(MDCache *c) : MDCacheContext(c) {}
   void finish(int r) {
     mdcache->open_snap_parents();
   }
@@ -7251,7 +7251,7 @@ void MDCache::check_memory_usage()
 
 class C_MDC_ShutdownCheck : public MDCacheContext {
 public:
-  C_MDC_ShutdownCheck(MDCache *m) : MDCacheContext(m) {}
+  explicit C_MDC_ShutdownCheck(MDCache *m) : MDCacheContext(m) {}
   void finish(int) {
     mdcache->shutdown_check();
   }

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -629,7 +629,7 @@ public:
   Migrator *migrator;
 
  public:
-  MDCache(MDSRank *m);
+  explicit MDCache(MDSRank *m);
   ~MDCache();
   
   // debug

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -104,7 +104,7 @@ class C_MDL_WriteError : public MDSIOContextBase {
   }
 
   public:
-  C_MDL_WriteError(MDLog *m) : mdlog(m) {}
+  explicit C_MDL_WriteError(MDLog *m) : mdlog(m) {}
 };
 
 

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -87,7 +87,7 @@ protected:
   class ReplayThread : public Thread {
     MDLog *log;
   public:
-    ReplayThread(MDLog *l) : log(l) {}
+    explicit ReplayThread(MDLog *l) : log(l) {}
     void* entry() {
       log->_replay_thread();
       return 0;
@@ -109,7 +109,7 @@ protected:
     MDSInternalContextBase *completion;
   public:
     void set_completion(MDSInternalContextBase *c) {completion = c;}
-    RecoveryThread(MDLog *l) : log(l), completion(NULL) {}
+    explicit RecoveryThread(MDLog *l) : log(l), completion(NULL) {}
     void* entry() {
       log->_recovery_thread(completion);
       return 0;
@@ -141,7 +141,7 @@ protected:
   class SubmitThread : public Thread {
     MDLog *log;
   public:
-    SubmitThread(MDLog *l) : log(l) {}
+    explicit SubmitThread(MDLog *l) : log(l) {}
     void* entry() {
       log->_submit_thread();
       return 0;
@@ -182,7 +182,7 @@ public:
   void set_write_iohint(unsigned iohint_flags);
 
 public:
-  MDLog(MDSRank *m) : mds(m),
+  explicit MDLog(MDSRank *m) : mds(m),
                       num_events(0), 
                       unflushed(0),
                       capped(false),

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -74,7 +74,7 @@ struct MDSCapMatch {
 
   MDSCapMatch() : uid(MDS_AUTH_UID_ANY) {}
   MDSCapMatch(int64_t uid_, std::vector<gid_t>& gids_) : uid(uid_), gids(gids_) {}
-  MDSCapMatch(std::string path_)
+  explicit MDSCapMatch(std::string path_)
     : uid(MDS_AUTH_UID_ANY), path(path_) {
     normalize_path();
   }
@@ -119,11 +119,11 @@ class MDSAuthCaps
   std::vector<MDSCapGrant> grants;
 
 public:
-  MDSAuthCaps(CephContext *cct_=NULL)
+  explicit MDSAuthCaps(CephContext *cct_=NULL)
     : cct(cct_) { }
 
   // this ctor is used by spirit/phoenix; doesn't need cct.
-  MDSAuthCaps(const std::vector<MDSCapGrant> &grants_)
+  explicit MDSAuthCaps(const std::vector<MDSCapGrant> &grants_)
     : cct(NULL), grants(grants_) { }
 
   void set_allow_all();

--- a/src/mds/MDSContext.h
+++ b/src/mds/MDSContext.h
@@ -55,7 +55,7 @@ protected:
   virtual MDSRank* get_mds();
 
 public:
-  MDSInternalContext(MDSRank *mds_) : mds(mds_) {
+  explicit MDSInternalContext(MDSRank *mds_) : mds(mds_) {
     assert(mds != NULL);
   }
 };
@@ -91,7 +91,7 @@ protected:
   virtual MDSRank* get_mds();
 
 public:
-  MDSIOContext(MDSRank *mds_) : mds(mds_) {
+  explicit MDSIOContext(MDSRank *mds_) : mds(mds_) {
     assert(mds != NULL);
   }
 };

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -153,7 +153,7 @@ MDSDaemon::~MDSDaemon() {
 class MDSSocketHook : public AdminSocketHook {
   MDSDaemon *mds;
 public:
-  MDSSocketHook(MDSDaemon *m) : mds(m) {}
+  explicit MDSSocketHook(MDSDaemon *m) : mds(m) {}
   bool call(std::string command, cmdmap_t& cmdmap, std::string format,
 	    bufferlist& out) {
     stringstream ss;
@@ -700,7 +700,7 @@ int MDSDaemon::_handle_command(
     MDSDaemon *mds;
 
     public:
-    SuicideLater(MDSDaemon *mds_) : mds(mds_) {}
+    explicit SuicideLater(MDSDaemon *mds_) : mds(mds_) {}
     void finish(int r) {
       // Wait a little to improve chances of caller getting
       // our response before seeing us disappear from mdsmap
@@ -717,7 +717,7 @@ int MDSDaemon::_handle_command(
 
     public:
 
-    RespawnLater(MDSDaemon *mds_) : mds(mds_) {}
+    explicit RespawnLater(MDSDaemon *mds_) : mds(mds_) {}
     void finish(int r) {
       // Wait a little to improve chances of caller getting
       // our response before seeing us disappear from mdsmap

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -178,9 +178,8 @@ bool MDSDaemon::asok_command(string command, cmdmap_t& cmdmap, string format,
       dout(1) << "Can't run that command on an inactive MDS!" << dendl;
       f->dump_string("error", "mds_not_active");
     } else {
-      handled =  mds_rank->handle_asok_command(command, cmdmap, f, ss);
+      handled = mds_rank->handle_asok_command(command, cmdmap, f, ss);
     }
-
   }
   f->flush(ss);
   delete f;

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -130,7 +130,7 @@ class MDSDaemon : public Dispatcher, public md_config_obs_t {
     protected:
       MDSDaemon *mds_daemon;
   public:
-    C_MDS_Tick(MDSDaemon *m) : mds_daemon(m) {}
+    explicit C_MDS_Tick(MDSDaemon *m) : mds_daemon(m) {}
     void finish(int r) {
       assert(mds_daemon->mds_lock.is_locked_by_me());
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1686,7 +1686,6 @@ bool MDSRankDispatcher::handle_asok_command(
     
     if (!got_val) {
       ss << "no target epoch given";
-      delete f;
       return true;
     }
     
@@ -1748,13 +1747,11 @@ bool MDSRankDispatcher::handle_asok_command(
     string path;
     if(!cmd_getval(g_ceph_context, cmdmap, "path", path)) {
       ss << "malformed path";
-      delete f;
       return true;
     }
     int64_t rank;
     if(!cmd_getval(g_ceph_context, cmdmap, "rank", rank)) {
       ss << "malformed rank";
-      delete f;
       return true;
     }
     command_export_dir(f, path, (mds_rank_t)rank);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1080,7 +1080,7 @@ inline void MDSRank::standby_replay_restart()
 
 class MDSRank::C_MDS_StandbyReplayRestart : public MDSInternalContext {
 public:
-  C_MDS_StandbyReplayRestart(MDSRank *m) : MDSInternalContext(m) {}
+  explicit C_MDS_StandbyReplayRestart(MDSRank *m) : MDSInternalContext(m) {}
   void finish(int r) {
     assert(!r);
     mds->standby_replay_restart();

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -205,7 +205,7 @@ class MDSRank {
       MDSRank *mds;
       Cond cond;
       public:
-      ProgressThread(MDSRank *mds_) : mds(mds_) {}
+      explicit ProgressThread(MDSRank *mds_) : mds(mds_) {}
       void * entry(); 
       void shutdown();
       void signal() {cond.Signal();}

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -39,7 +39,7 @@ class MDSTableIOContext : public MDSIOContextBase
     MDSTable *ida;
     MDSRank *get_mds() {return ida->mds;}
   public:
-    MDSTableIOContext(MDSTable *ida_) : ida(ida_) {
+    explicit MDSTableIOContext(MDSTable *ida_) : ida(ida_) {
       assert(ida != NULL);
     }
 };

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -90,7 +90,7 @@ protected:
     return mig->mds;
   }
 public:
-  MigratorContext(Migrator *mig_) : mig(mig_) {
+  explicit MigratorContext(Migrator *mig_) : mig(mig_) {
     assert(mig != NULL);
   }
 };

--- a/src/mds/RecoveryQueue.h
+++ b/src/mds/RecoveryQueue.h
@@ -30,7 +30,7 @@ public:
   void enqueue(CInode *in);
   void advance();
   void prioritize(CInode *in);   ///< do this inode now/soon
-  RecoveryQueue(MDSRank *mds_);
+  explicit RecoveryQueue(MDSRank *mds_);
 
   void set_logger(PerfCounters *p) {logger=p;}
 

--- a/src/mds/ScatterLock.h
+++ b/src/mds/ScatterLock.h
@@ -26,7 +26,7 @@ class ScatterLock : public SimpleLock {
     xlist<ScatterLock*>::item item_updated;
     utime_t update_stamp;
 
-    more_bits_t(ScatterLock *lock) :
+    explicit more_bits_t(ScatterLock *lock) :
       state_flags(0),
       item_updated(lock)
     {}

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -80,7 +80,7 @@ class ServerContext : public MDSInternalContextBase {
   }
 
   public:
-  ServerContext(Server *s) : server(s) {
+  explicit ServerContext(Server *s) : server(s) {
     assert(server != NULL);
   }
 };
@@ -558,7 +558,7 @@ class C_MDS_TerminatedSessions : public ServerContext {
     server->terminating_sessions = false;
   }
   public:
-  C_MDS_TerminatedSessions(Server *s) : ServerContext(s) {}
+  explicit C_MDS_TerminatedSessions(Server *s) : ServerContext(s) {}
 };
 
 void Server::terminate_sessions()

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4086,158 +4086,154 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur,
   string value (bl.c_str(), bl.length());
   dout(10) << "handle_set_vxattr " << name << " val " << value.length() << " bytes on " << *cur << dendl;
 
-  // layout or quota
-  if (name.find("ceph.file.layout") == 0 ||
-      name.find("ceph.dir.layout") == 0 ||
-      name.find("ceph.quota") == 0) {
-    inode_t *pi = NULL;
-    string rest;
-    if (name.find("ceph.dir.layout") == 0) {
-      if (!cur->is_dir()) {
-	respond_to_request(mdr, -EINVAL);
-	return;
-      }
+  inode_t *pi = NULL;
+  string rest;
 
-      ceph_file_layout layout;
-      if (cur->get_projected_inode()->has_layout())
-	layout = cur->get_projected_inode()->layout;
-      else if (dir_layout)
-	layout = *dir_layout;
-      else
-	layout = mdcache->default_file_layout;
-
-      rest = name.substr(name.find("layout"));
-      const OSDMap *osdmap = mds->objecter->get_osdmap_read();
-      int r = parse_layout_vxattr(rest, value, osdmap, &layout);
-      epoch_t epoch = osdmap->get_epoch();
-      mds->objecter->put_osdmap_read();
-      if (r < 0) {
-	if (r == -ENOENT) {
-	  epoch_t req_epoch = req->get_osdmap_epoch();
-	  if (req_epoch > epoch) {
-	    if (!mds->objecter->wait_for_map(req_epoch,
-		  new C_OnFinisher(new C_IO_Wrapper(mds, new C_MDS_RetryRequest(mdcache, mdr)), mds->finisher)))
-	    return;
-	  } else  if (req_epoch == 0 && !mdr->waited_for_osdmap) {
-	    // For compatibility with client w/ old code, we still need get the latest map. 
-	    // One day if COMPACT_VERSION of MClientRequest >=3, we can remove those code.
-	    mdr->waited_for_osdmap = true;
-	    mds->objecter->wait_for_latest_osdmap(
-		new C_OnFinisher(new C_IO_Wrapper(mds, new C_MDS_RetryRequest(mdcache, mdr)), mds->finisher));
-	    return;
-	  }
-	  r = -EINVAL;
-	}
-	respond_to_request(mdr, r);
-	return;
-      }
-
-      xlocks.insert(&cur->policylock);
-      if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))
-	return;
-
-      if (cur->inode.layout.fl_pg_pool != layout.fl_pg_pool) {
-        if (!check_access(mdr, cur, MAY_SET_POOL)) {
-          return;
-        }
-      }
-
-      pi = cur->project_inode();
-      pi->layout = layout;
-    } else if (name.find("ceph.file.layout") == 0) {
-      if (!cur->is_file()) {
-	respond_to_request(mdr, -EINVAL);
-	return;
-      }
-      if (cur->get_projected_inode()->size ||
-	  cur->get_projected_inode()->truncate_seq > 1) {
-	respond_to_request(mdr, -ENOTEMPTY);
-	return;
-      }
-      ceph_file_layout layout = cur->get_projected_inode()->layout;
-      rest = name.substr(name.find("layout"));
-      const OSDMap *osdmap = mds->objecter->get_osdmap_read();
-      int r = parse_layout_vxattr(rest, value, osdmap, &layout);
-      epoch_t epoch = osdmap->get_epoch();
-      mds->objecter->put_osdmap_read();
-      if (r < 0) {
-	if (r == -ENOENT) {
-	  epoch_t req_epoch = req->get_osdmap_epoch();
-	  if (req_epoch > epoch) {
-	    if (!mds->objecter->wait_for_map(req_epoch,
-		new C_OnFinisher(new C_IO_Wrapper(mds, new C_MDS_RetryRequest(mdcache, mdr)), mds->finisher)))
-	    return;
-	  } else if (req_epoch == 0 && !mdr->waited_for_osdmap) {
-	    // For compatibility with client w/ old code, we still need get the latest map. 
-	    // One day if COMPACT_VERSION of MClientRequest >=3, we can remove those code.
-	    mdr->waited_for_osdmap = true;
-	    mds->objecter->wait_for_latest_osdmap(
-	      new C_OnFinisher(new C_IO_Wrapper(mds, new C_MDS_RetryRequest(mdcache, mdr)), mds->finisher));
-	    return;
-	  }
-	  r = -EINVAL;
-	}
-	respond_to_request(mdr, r);
-	return;
-      }
-
-      xlocks.insert(&cur->filelock);
-      if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))
-	return;
-
-      if (cur->inode.layout.fl_pg_pool != layout.fl_pg_pool) {
-        if (!check_access(mdr, cur, MAY_SET_POOL)) {
-          return;
-        }
-      }
-
-      pi = cur->project_inode();
-      int64_t old_pool = pi->layout.fl_pg_pool;
-      pi->add_old_pool(old_pool);
-      pi->layout = layout;
-      pi->ctime = mdr->get_op_stamp();
-    } else {
-      // expect this to be "ceph.quota"
-      if (!cur->is_dir() || cur->is_root()) {
-        respond_to_request(mdr, -EINVAL);
-        return;
-      }
-
-      quota_info_t quota = cur->get_projected_inode()->quota;
-
-      rest = name.substr(name.find("quota"));
-      int r = parse_quota_vxattr(rest, value, &quota);
-      if (r < 0) {
-        respond_to_request(mdr, r);
-        return;
-      }
-
-      xlocks.insert(&cur->policylock);
-      if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))
-        return;
-
-      pi = cur->project_inode();
-      pi->quota = quota;
+  if (name.compare(0, 15, "ceph.dir.layout") == 0) {
+    if (!cur->is_dir()) {
+      respond_to_request(mdr, -EINVAL);
+      return;
     }
 
-    pi->version = cur->pre_dirty();
-    if (cur->is_file())
-      pi->update_backtrace();
+    ceph_file_layout layout;
+    if (cur->get_projected_inode()->has_layout())
+      layout = cur->get_projected_inode()->layout;
+    else if (dir_layout)
+      layout = *dir_layout;
+    else
+      layout = mdcache->default_file_layout;
 
-    // log + wait
-    mdr->ls = mdlog->get_current_segment();
-    EUpdate *le = new EUpdate(mdlog, "set vxattr layout");
-    mdlog->start_entry(le);
-    le->metablob.add_client_req(req->get_reqid(), req->get_oldest_client_tid());
-    mdcache->predirty_journal_parents(mdr, &le->metablob, cur, 0, PREDIRTY_PRIMARY);
-    mdcache->journal_dirty_inode(mdr.get(), &le->metablob, cur);
+    rest = name.substr(name.find("layout"));
+    const OSDMap *osdmap = mds->objecter->get_osdmap_read();
+    int r = parse_layout_vxattr(rest, value, osdmap, &layout);
+    epoch_t epoch = osdmap->get_epoch();
+    mds->objecter->put_osdmap_read();
+    if (r < 0) {
+      if (r == -ENOENT) {
+        epoch_t req_epoch = req->get_osdmap_epoch();
+        if (req_epoch > epoch) {
+          if (!mds->objecter->wait_for_map(req_epoch,
+      	  new C_OnFinisher(new C_IO_Wrapper(mds, new C_MDS_RetryRequest(mdcache, mdr)), mds->finisher)))
+          return;
+        } else  if (req_epoch == 0 && !mdr->waited_for_osdmap) {
+          // For compatibility with client w/ old code, we still need get the latest map. 
+          // One day if COMPACT_VERSION of MClientRequest >=3, we can remove those code.
+          mdr->waited_for_osdmap = true;
+          mds->objecter->wait_for_latest_osdmap(
+      	new C_OnFinisher(new C_IO_Wrapper(mds, new C_MDS_RetryRequest(mdcache, mdr)), mds->finisher));
+          return;
+        }
+        r = -EINVAL;
+      }
+      respond_to_request(mdr, r);
+      return;
+    }
 
-    journal_and_reply(mdr, cur, 0, le, new C_MDS_inode_update_finish(mds, mdr, cur));
+    xlocks.insert(&cur->policylock);
+    if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))
+      return;
+
+    if (cur->inode.layout.fl_pg_pool != layout.fl_pg_pool) {
+      if (!check_access(mdr, cur, MAY_SET_POOL)) {
+        return;
+      }
+    }
+
+    pi = cur->project_inode();
+    pi->layout = layout;
+  } else if (name.compare(0, 16, "ceph.file.layout") == 0) {
+    if (!cur->is_file()) {
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+    if (cur->get_projected_inode()->size ||
+        cur->get_projected_inode()->truncate_seq > 1) {
+      respond_to_request(mdr, -ENOTEMPTY);
+      return;
+    }
+    ceph_file_layout layout = cur->get_projected_inode()->layout;
+    rest = name.substr(name.find("layout"));
+    const OSDMap *osdmap = mds->objecter->get_osdmap_read();
+    int r = parse_layout_vxattr(rest, value, osdmap, &layout);
+    epoch_t epoch = osdmap->get_epoch();
+    mds->objecter->put_osdmap_read();
+    if (r < 0) {
+      if (r == -ENOENT) {
+        epoch_t req_epoch = req->get_osdmap_epoch();
+        if (req_epoch > epoch) {
+          if (!mds->objecter->wait_for_map(req_epoch,
+      	new C_OnFinisher(new C_IO_Wrapper(mds, new C_MDS_RetryRequest(mdcache, mdr)), mds->finisher)))
+          return;
+        } else if (req_epoch == 0 && !mdr->waited_for_osdmap) {
+          // For compatibility with client w/ old code, we still need get the latest map. 
+          // One day if COMPACT_VERSION of MClientRequest >=3, we can remove those code.
+          mdr->waited_for_osdmap = true;
+          mds->objecter->wait_for_latest_osdmap(
+            new C_OnFinisher(new C_IO_Wrapper(mds, new C_MDS_RetryRequest(mdcache, mdr)), mds->finisher));
+          return;
+        }
+        r = -EINVAL;
+      }
+      respond_to_request(mdr, r);
+      return;
+    }
+
+    xlocks.insert(&cur->filelock);
+    if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))
+      return;
+
+    if (cur->inode.layout.fl_pg_pool != layout.fl_pg_pool) {
+      if (!check_access(mdr, cur, MAY_SET_POOL)) {
+        return;
+      }
+    }
+
+    pi = cur->project_inode();
+    int64_t old_pool = pi->layout.fl_pg_pool;
+    pi->add_old_pool(old_pool);
+    pi->layout = layout;
+    pi->ctime = mdr->get_op_stamp();
+  } else if (name.compare(0, 10, "ceph.quota") == 0) { 
+    if (!cur->is_dir() || cur->is_root()) {
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+
+    quota_info_t quota = cur->get_projected_inode()->quota;
+
+    rest = name.substr(name.find("quota"));
+    int r = parse_quota_vxattr(rest, value, &quota);
+    if (r < 0) {
+      respond_to_request(mdr, r);
+      return;
+    }
+
+    xlocks.insert(&cur->policylock);
+    if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))
+      return;
+
+    pi = cur->project_inode();
+    pi->quota = quota;
+  } else {
+    dout(10) << " unknown vxattr " << name << dendl;
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
-  dout(10) << " unknown vxattr " << name << dendl;
-  respond_to_request(mdr, -EINVAL);
+  pi->version = cur->pre_dirty();
+  if (cur->is_file())
+    pi->update_backtrace();
+
+  // log + wait
+  mdr->ls = mdlog->get_current_segment();
+  EUpdate *le = new EUpdate(mdlog, "set vxattr layout");
+  mdlog->start_entry(le);
+  le->metablob.add_client_req(req->get_reqid(), req->get_oldest_client_tid());
+  mdcache->predirty_journal_parents(mdr, &le->metablob, cur, 0, PREDIRTY_PRIMARY);
+  mdcache->journal_dirty_inode(mdr.get(), &le->metablob, cur);
+
+  journal_and_reply(mdr, cur, 0, le, new C_MDS_inode_update_finish(mds, mdr, cur));
+  return;
 }
 
 void Server::handle_remove_vxattr(MDRequestRef& mdr, CInode *cur,

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -63,7 +63,7 @@ private:
 public:
   bool terminating_sessions;
 
-  Server(MDSRank *m);
+  explicit Server(MDSRank *m);
   ~Server() {
     g_ceph_context->get_perfcounters_collection()->remove(logger);
     delete logger;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -35,7 +35,7 @@ class SessionMapIOContext : public MDSIOContextBase
     SessionMap *sessionmap;
     MDSRank *get_mds() {return sessionmap->mds;}
   public:
-    SessionMapIOContext(SessionMap *sessionmap_) : sessionmap(sessionmap_) {
+    explicit SessionMapIOContext(SessionMap *sessionmap_) : sessionmap(sessionmap_) {
       assert(sessionmap != NULL);
     }
 };
@@ -253,7 +253,7 @@ void SessionMap::load(MDSInternalContextBase *onload)
 class C_IO_SM_LoadLegacy : public SessionMapIOContext {
 public:
   bufferlist bl;
-  C_IO_SM_LoadLegacy(SessionMap *cm) : SessionMapIOContext(cm) {}
+  explicit C_IO_SM_LoadLegacy(SessionMap *cm) : SessionMapIOContext(cm) {}
   void finish(int r) {
     sessionmap->_load_legacy_finish(r, bl);
   }

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -428,7 +428,7 @@ public:
   uint64_t set_state(Session *session, int state);
   map<version_t, list<MDSInternalContextBase*> > commit_waiters;
 
-  SessionMap(MDSRank *m) : mds(m),
+  explicit SessionMap(MDSRank *m) : mds(m),
 		       projected(0), committing(0), committed(0),
                        loaded_legacy(false)
   { }

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -58,7 +58,7 @@ struct LockType {
   int type;
   const sm_t *sm;
 
-  LockType(int t) : type(t) {
+  explicit LockType(int t) : type(t) {
     switch (type) {
     case CEPH_LOCK_DN:
     case CEPH_LOCK_IAUTH:

--- a/src/mds/SnapClient.h
+++ b/src/mds/SnapClient.h
@@ -24,7 +24,7 @@ class LogSegment;
 
 class SnapClient : public MDSTableClient {
 public:
-  SnapClient(MDSRank *m) : MDSTableClient(m, TABLE_SNAP) {}
+  explicit SnapClient(MDSRank *m) : MDSTableClient(m, TABLE_SNAP) {}
 
   void resend_queries() {}
   void handle_query_result(MMDSTableRequest *m) {}

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -42,7 +42,7 @@ protected:
     return sm->mds;
   }
 public:
-  StrayManagerIOContext(StrayManager *sm_) : sm(sm_) {}
+  explicit StrayManagerIOContext(StrayManager *sm_) : sm(sm_) {}
 };
 
 
@@ -54,7 +54,7 @@ protected:
     return sm->mds;
   }
 public:
-  StrayManagerContext(StrayManager *sm_) : sm(sm_) {}
+  explicit StrayManagerContext(StrayManager *sm_) : sm(sm_) {}
 };
 
 

--- a/src/mds/StrayManager.h
+++ b/src/mds/StrayManager.h
@@ -150,7 +150,7 @@ class StrayManager
 
   // My public interface is for consumption by MDCache
   public:
-  StrayManager(MDSRank *mds);
+  explicit StrayManager(MDSRank *mds);
   void set_logger(PerfCounters *l) {logger = l;}
 
   bool eval_stray(CDentry *dn, bool delay=false);

--- a/src/mds/events/ECommitted.h
+++ b/src/mds/events/ECommitted.h
@@ -23,7 +23,7 @@ public:
   metareqid_t reqid;
 
   ECommitted() : LogEvent(EVENT_COMMITTED) { }
-  ECommitted(metareqid_t r) : 
+  explicit ECommitted(metareqid_t r) :
     LogEvent(EVENT_COMMITTED), reqid(r) { }
 
   void print(ostream& out) const {

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -94,7 +94,7 @@ public:
 	old_inodes = *oi;
       snapbl = sbl;
     }
-    fullbit(bufferlist::iterator &p) {
+    explicit fullbit(bufferlist::iterator &p) {
       decode(p);
     }
     fullbit() {}
@@ -144,7 +144,7 @@ public:
 
     remotebit(const string& d, snapid_t df, snapid_t dl, version_t v, inodeno_t i, unsigned char dt, bool dr) : 
       dn(d), dnfirst(df), dnlast(dl), dnv(v), ino(i), d_type(dt), dirty(dr) { }
-    remotebit(bufferlist::iterator &p) { decode(p); }
+    explicit remotebit(bufferlist::iterator &p) { decode(p); }
     remotebit(): dnfirst(0), dnlast(0), dnv(0), ino(0),
 	d_type('\0'), dirty(false) {}
 
@@ -171,7 +171,7 @@ public:
 
     nullbit(const string& d, snapid_t df, snapid_t dl, version_t v, bool dr) : 
       dn(d), dnfirst(df), dnlast(dl), dnv(v), dirty(dr) { }
-    nullbit(bufferlist::iterator &p) { decode(p); }
+    explicit nullbit(bufferlist::iterator &p) { decode(p); }
     nullbit(): dnfirst(0), dnlast(0), dnv(0), dirty(false) {}
 
     void encode(bufferlist& bl) const;
@@ -333,7 +333,7 @@ private:
   // for replay, in certain cases
   //LogSegment *_segment;
 
-  EMetaBlob(MDLog *mdl = 0);  // defined in journal.cc
+  explicit EMetaBlob(MDLog *mdl = 0);  // defined in journal.cc
   ~EMetaBlob() { }
 
   void print(ostream& out) {

--- a/src/mds/events/ENoOp.h
+++ b/src/mds/events/ENoOp.h
@@ -22,7 +22,7 @@ class ENoOp : public LogEvent {
 
 public:
   ENoOp() : LogEvent(EVENT_NOOP), pad_size(0) { }
-  ENoOp(uint32_t size_) : LogEvent(EVENT_NOOP), pad_size(size_){ }
+  explicit ENoOp(uint32_t size_) : LogEvent(EVENT_NOOP), pad_size(size_){ }
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& bl);

--- a/src/mds/events/EOpen.h
+++ b/src/mds/events/EOpen.h
@@ -24,7 +24,7 @@ public:
   vector<inodeno_t> inos;
 
   EOpen() : LogEvent(EVENT_OPEN) { }
-  EOpen(MDLog *mdlog) : 
+  explicit EOpen(MDLog *mdlog) :
     LogEvent(EVENT_OPEN), metablob(mdlog) { }
 
   void print(ostream& out) const {

--- a/src/mds/flock.h
+++ b/src/mds/flock.h
@@ -39,7 +39,7 @@ inline bool operator==(ceph_filelock& l, ceph_filelock& r) {
 class ceph_lock_state_t {
   CephContext *cct;
 public:
-  ceph_lock_state_t(CephContext *cct_) : cct(cct_) {}
+  explicit ceph_lock_state_t(CephContext *cct_) : cct(cct_) {}
   multimap<uint64_t, ceph_filelock> held_locks;    // current locks
   multimap<uint64_t, ceph_filelock> waiting_locks; // locks waiting for other locks
   // both of the above are keyed by starting offset

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -980,7 +980,7 @@ class inode_load_vec_t {
   static const int NUM = 2;
   std::vector < DecayCounter > vec;
 public:
-  inode_load_vec_t(const utime_t &now)
+  explicit inode_load_vec_t(const utime_t &now)
      : vec(NUM, DecayCounter(now))
   {}
   // for dencoder infrastructure
@@ -1011,7 +1011,7 @@ class dirfrag_load_vec_t {
 public:
   static const int NUM = 5;
   std::vector < DecayCounter > vec;
-  dirfrag_load_vec_t(const utime_t &now)
+  explicit dirfrag_load_vec_t(const utime_t &now)
      : vec(NUM, DecayCounter(now))
   { }
   // for dencoder infrastructure
@@ -1115,7 +1115,7 @@ struct mds_load_t {
 
   double cpu_load_avg;
 
-  mds_load_t(const utime_t &t) : 
+  explicit mds_load_t(const utime_t &t) : 
     auth(t), all(t), req_rate(0), cache_hit_rate(0),
     queue_len(0), cpu_load_avg(0)
   {}
@@ -1227,7 +1227,7 @@ struct ClientLease {
 // print hack
 struct mdsco_db_line_prefix {
   MDSCacheObject *object;
-  mdsco_db_line_prefix(MDSCacheObject *o) : object(o) {}
+  explicit mdsco_db_line_prefix(MDSCacheObject *o) : object(o) {}
 };
 std::ostream& operator<<(std::ostream& out, mdsco_db_line_prefix o);
 

--- a/src/messages/MMonMap.h
+++ b/src/messages/MMonMap.h
@@ -24,7 +24,7 @@ public:
   bufferlist monmapbl;
 
   MMonMap() : Message(CEPH_MSG_MON_MAP) { }
-  MMonMap(bufferlist &bl) : Message(CEPH_MSG_MON_MAP) { 
+  explicit MMonMap(bufferlist &bl) : Message(CEPH_MSG_MON_MAP) { 
     monmapbl.claim(bl);
   }
 private:

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -169,7 +169,7 @@ class Elector {
   class C_ElectionExpire : public Context {
     Elector *elector;
   public:
-    C_ElectionExpire(Elector *e) : elector(e) { }
+    explicit C_ElectionExpire(Elector *e) : elector(e) { }
     void finish(int r) {
       elector->expire();
     }
@@ -348,7 +348,7 @@ class Elector {
    *
    * @param m A Monitor instance
    */
-  Elector(Monitor *m) : mon(m),
+  explicit Elector(Monitor *m) : mon(m),
 			expire_event(0),
 			epoch(0),
 			participating(true),

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -118,7 +118,7 @@ struct MonCap {
   std::vector<MonCapGrant> grants;
 
   MonCap() {}
-  MonCap(std::vector<MonCapGrant> g) : grants(g) {}
+  explicit MonCap(std::vector<MonCapGrant> g) : grants(g) {}
 
   string get_str() const {
     return text;

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -21,6 +21,7 @@ static const __u8 MON_CAP_ANY   = 0xff;          // *
 struct mon_rwxa_t {
   __u8 val;
 
+  // cppcheck-suppress noExplicitConstructor
   mon_rwxa_t(__u8 v = 0) : val(v) {}
   mon_rwxa_t& operator=(__u8 v) {
     val = v;
@@ -79,8 +80,10 @@ struct MonCapGrant {
   void expand_profile(EntityName name) const;
 
   MonCapGrant() : allow(0) {}
+  // cppcheck-suppress noExplicitConstructor
   MonCapGrant(mon_rwxa_t a) : allow(a) {}
   MonCapGrant(string s, mon_rwxa_t a) : service(s), allow(a) {}
+  // cppcheck-suppress noExplicitConstructor  
   MonCapGrant(string c) : command(c) {}
   MonCapGrant(string c, string a, StringConstraint co) : command(c) {
     command_args[a] = co;

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -155,7 +155,7 @@ private:
 
   struct C_Tick : public Context {
     MonClient *monc;
-    C_Tick(MonClient *m) : monc(m) {}
+    explicit C_Tick(MonClient *m) : monc(m) {}
     void finish(int r) {
       monc->tick();
     }
@@ -300,7 +300,7 @@ public:
   RotatingKeyRing *rotating_secrets;
 
  public:
-  MonClient(CephContext *cct_);
+  explicit MonClient(CephContext *cct_);
   ~MonClient();
 
   int init();
@@ -406,7 +406,7 @@ private:
     int *prval;
     Context *onfinish, *ontimeout;
 
-    MonCommand(uint64_t t)
+    explicit MonCommand(uint64_t t)
       : target_rank(-1),
 	tid(t),
 	poutbl(NULL), prs(NULL), prval(NULL), onfinish(NULL), ontimeout(NULL)

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -319,7 +319,7 @@ void Monitor::do_admin_command(string command, cmdmap_t& cmdmap, string format,
       goto abort;
     }
     sync_force(f.get(), ss);
-  } else if (command.find("add_bootstrap_peer_hint") == 0) {
+  } else if (command.compare(0, 23, "add_bootstrap_peer_hint") == 0) {
     if (!_add_bootstrap_peer_hint(command, cmdmap, ss))
       goto abort;
   } else if (command == "quorum enter") {
@@ -1676,7 +1676,7 @@ void Monitor::handle_probe_reply(MonOpRequestRef op)
 
   // rename peer?
   string peer_name = monmap->get_name(m->get_source_addr());
-  if (monmap->get_epoch() == 0 && peer_name.find("noname-") == 0) {
+  if (monmap->get_epoch() == 0 && peer_name.compare(0, 7, "noname-") == 0) {
     dout(10) << " renaming peer " << m->get_source_addr() << " "
 	     << peer_name << " -> " << m->name << " in my monmap"
 	     << dendl;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -266,7 +266,7 @@ Monitor::~Monitor()
 class AdminHook : public AdminSocketHook {
   Monitor *mon;
 public:
-  AdminHook(Monitor *m) : mon(m) {}
+  explicit AdminHook(Monitor *m) : mon(m) {}
   bool call(std::string command, cmdmap_t& cmdmap, std::string format,
 	    bufferlist& out) {
     stringstream ss;
@@ -3091,7 +3091,7 @@ void Monitor::forward_request_leader(MonOpRequestRef op)
 
 // fake connection attached to forwarded messages
 struct AnonConnection : public Connection {
-  AnonConnection(CephContext *cct) : Connection(cct, NULL) {}
+  explicit AnonConnection(CephContext *cct) : Connection(cct, NULL) {}
 
   int send_message(Message *m) override {
     assert(!"send_message on anonymous connection");
@@ -4692,7 +4692,7 @@ void Monitor::scrub_reset_timeout()
 class C_Mon_Tick : public Context {
   Monitor *mon;
 public:
-  C_Mon_Tick(Monitor *m) : mon(m) {}
+  explicit C_Mon_Tick(Monitor *m) : mon(m) {}
   void finish(int r) {
     mon->tick();
   }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -260,14 +260,14 @@ private:
 
   struct C_Scrub : public Context {
     Monitor *mon;
-    C_Scrub(Monitor *m) : mon(m) { }
+    explicit C_Scrub(Monitor *m) : mon(m) { }
     void finish(int r) {
       mon->scrub_start();
     }
   };
   struct C_ScrubTimeout : public Context {
     Monitor *mon;
-    C_ScrubTimeout(Monitor *m) : mon(m) { }
+    explicit C_ScrubTimeout(Monitor *m) : mon(m) { }
     void finish(int r) {
       mon->scrub_timeout();
     }
@@ -351,7 +351,7 @@ private:
 
   struct C_SyncTimeout : public Context {
     Monitor *mon;
-    C_SyncTimeout(Monitor *m) : mon(m) {}
+    explicit C_SyncTimeout(Monitor *m) : mon(m) {}
     void finish(int r) {
       mon->sync_timeout();
     }
@@ -509,7 +509,7 @@ private:
 
   struct C_TimeCheck : public Context {
     Monitor *mon;
-    C_TimeCheck(Monitor *m) : mon(m) { }
+    explicit C_TimeCheck(Monitor *m) : mon(m) { }
     void finish(int r) {
       mon->timecheck_start_round();
     }
@@ -565,7 +565,7 @@ private:
 
   struct C_ProbeTimeout : public Context {
     Monitor *mon;
-    C_ProbeTimeout(Monitor *m) : mon(m) {}
+    explicit C_ProbeTimeout(Monitor *m) : mon(m) {}
     void finish(int r) {
       mon->probe_timeout(r);
     }
@@ -714,7 +714,7 @@ public:
 
   struct C_HealthToClogTick : public Context {
     Monitor *mon;
-    C_HealthToClogTick(Monitor *m) : mon(m) { }
+    explicit C_HealthToClogTick(Monitor *m) : mon(m) { }
     void finish(int r) {
       if (r < 0)
         return;
@@ -725,7 +725,7 @@ public:
 
   struct C_HealthToClogInterval : public Context {
     Monitor *mon;
-    C_HealthToClogInterval(Monitor *m) : mon(m) { }
+    explicit C_HealthToClogInterval(Monitor *m) : mon(m) { }
     void finish(int r) {
       if (r < 0)
         return;

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -621,7 +621,7 @@ class MonitorDBStore
     return db->get_estimated_size(extras);
   }
 
-  MonitorDBStore(const string& path)
+  explicit MonitorDBStore(const string& path)
     : db(0),
       do_dump(false),
       dump_fd_binary(-1),

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -781,7 +781,7 @@ public:
 protected:
   struct lowprecision_t {
     float v;
-    lowprecision_t(float _v) : v(_v) {}
+    explicit lowprecision_t(float _v) : v(_v) {}
   };
   friend std::ostream &operator<<(ostream& out, const lowprecision_t& v);
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -55,7 +55,7 @@ struct failure_reporter_t {
   MonOpRequestRef op;       ///< failure op request
 
   failure_reporter_t() {}
-  failure_reporter_t(utime_t s) : failed_since(s) {}
+  explicit failure_reporter_t(utime_t s) : failed_since(s) {}
   ~failure_reporter_t() { }
 };
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -386,7 +386,6 @@ private:
   bool preprocess_remove_snaps(MonOpRequestRef op);
   bool prepare_remove_snaps(MonOpRequestRef op);
 
-  CephContext *cct;
   OpTracker op_tracker;
 
   int load_metadata(int osd, map<string, string>& m, ostream *err);

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1604,8 +1604,7 @@ bool PGMonitor::preprocess_command(MonOpRequestRef op)
     prefix = "pg ls";
     string poolstr;
     cmd_getval(g_ceph_context, cmdmap, "poolstr", poolstr);
-    int64_t pool = -2;
-    pool = mon->osdmon()->osdmap.lookup_pg_pool_name(poolstr.c_str());
+    int64_t pool = mon->osdmon()->osdmap.lookup_pg_pool_name(poolstr.c_str());
     if (pool < 0) {
       r = -ENOENT;
       ss << "pool " << poolstr << " does not exist";

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1748,7 +1748,10 @@ bool PGMonitor::preprocess_command(MonOpRequestRef op)
                int64_t(g_conf->mon_pg_stuck_threshold));
 
     r = dump_stuck_pg_stats(ds, f.get(), (int)threshold, stuckop_vec);
-    ss << "ok";
+    if (r < 0)
+      ss << "failed";  
+    else 
+      ss << "ok";
     r = 0;
   } else if (prefix == "pg map") {
     pg_t pgid;
@@ -2437,7 +2440,7 @@ int PGMonitor::dump_stuck_pg_stats(stringstream &ds,
       stuck_types |= PGMap::STUCK_STALE;
     else {
       ds << "Unknown type: " << *i << std::endl;
-      return 0;
+      return -EINVAL;
     }
   }
 

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -809,7 +809,7 @@ void Paxos::accept_timeout()
 
 struct C_Committed : public Context {
   Paxos *paxos;
-  C_Committed(Paxos *p) : paxos(p) {}
+  explicit C_Committed(Paxos *p) : paxos(p) {}
   void finish(int r) {
     assert(r >= 0);
     Mutex::Locker l(paxos->mon->lock);

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -629,7 +629,7 @@ private:
   class C_CollectTimeout : public Context {
     Paxos *paxos;
   public:
-    C_CollectTimeout(Paxos *p) : paxos(p) {}
+    explicit C_CollectTimeout(Paxos *p) : paxos(p) {}
     void finish(int r) {
       if (r == -ECANCELED)
 	return;
@@ -643,7 +643,7 @@ private:
   class C_AcceptTimeout : public Context {
     Paxos *paxos;
   public:
-    C_AcceptTimeout(Paxos *p) : paxos(p) {}
+    explicit C_AcceptTimeout(Paxos *p) : paxos(p) {}
     void finish(int r) {
       if (r == -ECANCELED)
 	return;
@@ -657,7 +657,7 @@ private:
   class C_LeaseAckTimeout : public Context {
     Paxos *paxos;
   public:
-    C_LeaseAckTimeout(Paxos *p) : paxos(p) {}
+    explicit C_LeaseAckTimeout(Paxos *p) : paxos(p) {}
     void finish(int r) {
       if (r == -ECANCELED)
 	return;
@@ -671,7 +671,7 @@ private:
   class C_LeaseTimeout : public Context {
     Paxos *paxos;
   public:
-    C_LeaseTimeout(Paxos *p) : paxos(p) {}
+    explicit C_LeaseTimeout(Paxos *p) : paxos(p) {}
     void finish(int r) {
       if (r == -ECANCELED)
 	return;
@@ -685,7 +685,7 @@ private:
   class C_LeaseRenew : public Context {
     Paxos *paxos;
   public:
-    C_LeaseRenew(Paxos *p) : paxos(p) {}
+    explicit C_LeaseRenew(Paxos *p) : paxos(p) {}
     void finish(int r) {
       if (r == -ECANCELED)
 	return;
@@ -696,7 +696,7 @@ private:
   class C_Trimmed : public Context {
     Paxos *paxos;
   public:
-    C_Trimmed(Paxos *p) : paxos(p) { }
+    explicit C_Trimmed(Paxos *p) : paxos(p) { }
     void finish(int r) {
       paxos->trimming = false;
     }

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -128,7 +128,7 @@ protected:
   class C_Active : public Context {
     PaxosService *svc;
   public:
-    C_Active(PaxosService *s) : svc(s) {}
+    explicit C_Active(PaxosService *s) : svc(s) {}
     void finish(int r) {
       if (r >= 0)
 	svc->_active();
@@ -142,7 +142,7 @@ protected:
   class C_Propose : public Context {
     PaxosService *ps;
   public:
-    C_Propose(PaxosService *p) : ps(p) { }
+    explicit C_Propose(PaxosService *p) : ps(p) { }
     void finish(int r) {
       ps->proposal_timer = 0;
       if (r >= 0)
@@ -167,7 +167,7 @@ protected:
   class C_Committed : public Context {
     PaxosService *ps;
   public:
-    C_Committed(PaxosService *p) : ps(p) { }
+    explicit C_Committed(PaxosService *p) : ps(p) { }
     void finish(int r) {
       ps->proposing = false;
       if (r >= 0)

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -212,7 +212,7 @@ struct C_MonOp : public Context
 {
   MonOpRequestRef op;
 
-  C_MonOp(MonOpRequestRef o) :
+  explicit C_MonOp(MonOpRequestRef o) :
     op(o) { }
 
   void finish(int r) {

--- a/src/msg/Dispatcher.h
+++ b/src/msg/Dispatcher.h
@@ -28,7 +28,7 @@ class CephContext;
 
 class Dispatcher {
 public:
-  Dispatcher(CephContext *cct_)
+  explicit Dispatcher(CephContext *cct_)
     : cct(cct_)
   {
   }

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -231,7 +231,7 @@ public:
     Message *m;
     friend class Message;
   public:
-    CompletionHook(Message *_m) : m(_m) {}
+    explicit CompletionHook(Message *_m) : m(_m) {}
     virtual void set_message(Message *_m) { m = _m; }
   };
 

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -50,7 +50,7 @@ class C_time_wakeup : public EventCallback {
   AsyncConnectionRef conn;
 
  public:
-  C_time_wakeup(AsyncConnectionRef c): conn(c) {}
+  explicit C_time_wakeup(AsyncConnectionRef c): conn(c) {}
   void do_request(int fd_or_id) {
     conn->wakeup_from(fd_or_id);
   }
@@ -60,7 +60,7 @@ class C_handle_read : public EventCallback {
   AsyncConnectionRef conn;
 
  public:
-  C_handle_read(AsyncConnectionRef c): conn(c) {}
+  explicit C_handle_read(AsyncConnectionRef c): conn(c) {}
   void do_request(int fd_or_id) {
     conn->process();
   }
@@ -70,7 +70,7 @@ class C_handle_write : public EventCallback {
   AsyncConnectionRef conn;
 
  public:
-  C_handle_write(AsyncConnectionRef c): conn(c) {}
+  explicit C_handle_write(AsyncConnectionRef c): conn(c) {}
   void do_request(int fd) {
     conn->handle_write();
   }
@@ -136,7 +136,7 @@ class C_deliver_accept : public EventCallback {
 class C_local_deliver : public EventCallback {
   AsyncConnectionRef conn;
  public:
-  C_local_deliver(AsyncConnectionRef c): conn(c) {}
+  explicit C_local_deliver(AsyncConnectionRef c): conn(c) {}
   void do_request(int id) {
     conn->local_deliver();
   }
@@ -146,7 +146,7 @@ class C_local_deliver : public EventCallback {
 class C_clean_handler : public EventCallback {
   AsyncConnectionRef conn;
  public:
-  C_clean_handler(AsyncConnectionRef c): conn(c) {}
+  explicit C_clean_handler(AsyncConnectionRef c): conn(c) {}
   void do_request(int id) {
     conn->cleanup_handler();
     delete this;

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -109,7 +109,7 @@ class Processor {
     Processor *pro;
 
    public:
-    C_processor_accept(Processor *p): pro(p) {}
+    explicit C_processor_accept(Processor *p): pro(p) {}
     void do_request(int id) {
       pro->accept();
     }
@@ -143,7 +143,7 @@ class WorkerPool {
   class C_barrier : public EventCallback {
     WorkerPool *pool;
    public:
-    C_barrier(WorkerPool *p): pool(p) {}
+    explicit C_barrier(WorkerPool *p): pool(p) {}
     void do_request(int id) {
       Mutex::Locker l(pool->barrier_lock);
       pool->barrier_count.dec();
@@ -153,7 +153,7 @@ class WorkerPool {
   };
   friend class C_barrier;
  public:
-  WorkerPool(CephContext *c);
+  explicit WorkerPool(CephContext *c);
   virtual ~WorkerPool();
   void start();
   Worker *get_worker() {
@@ -332,7 +332,7 @@ private:
     AsyncMessenger *msgr;
 
    public:
-    C_handle_reap(AsyncMessenger *m): msgr(m) {}
+    explicit C_handle_reap(AsyncMessenger *m): msgr(m) {}
     void do_request(int id) {
       // judge whether is a time event
       msgr->reap_dead();

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -127,7 +127,7 @@ class EventCenter {
  public:
   atomic_t already_wakeup;
 
-  EventCenter(CephContext *c):
+  explicit EventCenter(CephContext *c):
     cct(c), nevent(0),
     external_lock("AsyncMessenger::external_lock"),
     file_lock("AsyncMessenger::file_lock"),

--- a/src/msg/async/EventEpoll.h
+++ b/src/msg/async/EventEpoll.h
@@ -29,7 +29,7 @@ class EpollDriver : public EventDriver {
   int size;
 
  public:
-  EpollDriver(CephContext *c): epfd(-1), events(NULL), cct(c), size(0) {}
+  explicit EpollDriver(CephContext *c): epfd(-1), events(NULL), cct(c), size(0) {}
   virtual ~EpollDriver() {
     if (epfd != -1)
       close(epfd);

--- a/src/msg/async/EventKqueue.h
+++ b/src/msg/async/EventKqueue.h
@@ -30,7 +30,7 @@ class KqueueDriver : public EventDriver {
   int size;
 
  public:
-  KqueueDriver(CephContext *c): kqfd(-1), events(NULL), cct(c), size(0) {}
+  explicit KqueueDriver(CephContext *c): kqfd(-1), events(NULL), cct(c), size(0) {}
   virtual ~KqueueDriver() {
     if (kqfd != -1)
       close(kqfd);

--- a/src/msg/async/EventSelect.h
+++ b/src/msg/async/EventSelect.h
@@ -31,7 +31,7 @@ class SelectDriver : public EventDriver {
   CephContext *cct;
 
  public:
-  SelectDriver(CephContext *c): max_fd(0), cct(c) {}
+  explicit SelectDriver(CephContext *c): max_fd(0), cct(c) {}
   virtual ~SelectDriver() {}
 
   int init(int nevent);

--- a/src/msg/async/net_handler.h
+++ b/src/msg/async/net_handler.h
@@ -26,7 +26,7 @@ namespace ceph {
 
     CephContext *cct;
    public:
-    NetHandler(CephContext *c): cct(c) {}
+    explicit NetHandler(CephContext *c): cct(c) {}
     int set_nonblock(int sd);
     void set_socket_options(int sd);
     int connect(const entity_addr_t &addr);

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -424,6 +424,7 @@ struct entity_inst_t {
   entity_addr_t addr;
   entity_inst_t() {}
   entity_inst_t(entity_name_t n, const entity_addr_t& a) : name(n), addr(a) {}
+  // cppcheck-suppress noExplicitConstructor
   entity_inst_t(const ceph_entity_inst& i) : name(i.name), addr(i.addr) { }
   entity_inst_t(const ceph_entity_name& n, const ceph_entity_addr &a) : name(n), addr(a) {}
   operator ceph_entity_inst() {

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -43,7 +43,7 @@ public:
   // cons
   entity_name_t() : _type(0), _num(0) { }
   entity_name_t(int t, int64_t n) : _type(t), _num(n) { }
-  entity_name_t(const ceph_entity_name &n) : 
+  explicit entity_name_t(const ceph_entity_name &n) : 
     _type(n.type), _num(n.num) { }
 
   // static cons
@@ -222,7 +222,7 @@ struct entity_addr_t {
   entity_addr_t() : type(0), nonce(0) { 
     memset(&addr, 0, sizeof(addr));
   }
-  entity_addr_t(const ceph_entity_addr &o) {
+  explicit entity_addr_t(const ceph_entity_addr &o) {
     type = o.type;
     nonce = o.nonce;
     addr = o.in_addr;

--- a/src/msg/simple/DispatchQueue.h
+++ b/src/msg/simple/DispatchQueue.h
@@ -44,7 +44,7 @@ class DispatchQueue {
     ConnectionRef con;
     MessageRef m;
   public:
-    QueueItem(Message *m) : type(-1), con(0), m(m) {}
+    explicit QueueItem(Message *m) : type(-1), con(0), m(m) {}
     QueueItem(int type, Connection *con) : type(type), con(con), m(0) {}
     bool is_code() const {
       return type != -1;
@@ -98,7 +98,7 @@ class DispatchQueue {
   class DispatchThread : public Thread {
     DispatchQueue *dq;
   public:
-    DispatchThread(DispatchQueue *dq) : dq(dq) {}
+    explicit DispatchThread(DispatchQueue *dq) : dq(dq) {}
     void *entry() {
       dq->entry();
       return 0;
@@ -112,7 +112,7 @@ class DispatchQueue {
   class LocalDeliveryThread : public Thread {
     DispatchQueue *dq;
   public:
-    LocalDeliveryThread(DispatchQueue *dq) : dq(dq) {}
+    explicit LocalDeliveryThread(DispatchQueue *dq) : dq(dq) {}
     void *entry() {
       dq->run_local_delivery();
       return 0;

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1717,9 +1717,8 @@ void Pipe::writer()
       state_closed.set(1);
       pipe_lock.Unlock();
       if (sd) {
-	int r = ::write(sd, &tag, 1);
-	// we can ignore r, actually; we don't care if this succeeds.
-	r++; r = 0; // placate gcc
+	// we can ignore return value, actually; we don't care if this succeeds.
+	if(::write(sd, &tag, 1));
       }
       pipe_lock.Lock();
       continue;

--- a/src/msg/simple/Pipe.h
+++ b/src/msg/simple/Pipe.h
@@ -46,7 +46,7 @@ class DispatchQueue;
     class Reader : public Thread {
       Pipe *pipe;
     public:
-      Reader(Pipe *p) : pipe(p) {}
+      explicit Reader(Pipe *p) : pipe(p) {}
       void *entry() { pipe->reader(); return 0; }
     } reader_thread;
 
@@ -57,7 +57,7 @@ class DispatchQueue;
     class Writer : public Thread {
       Pipe *pipe;
     public:
-      Writer(Pipe *p) : pipe(p) {}
+      explicit Writer(Pipe *p) : pipe(p) {}
       void *entry() { pipe->writer(); return 0; }
     } writer_thread;
 
@@ -81,7 +81,7 @@ class DispatchQueue;
       bool stop_fast_dispatching_flag; // we need to stop fast dispatching
 
     public:
-      DelayedDelivery(Pipe *p)
+      explicit DelayedDelivery(Pipe *p)
 	: pipe(p),
 	  delay_lock("Pipe::DelayedDelivery::delay_lock"), flush_count(0),
 	  active_flush(false),

--- a/src/msg/simple/SimpleMessenger.h
+++ b/src/msg/simple/SimpleMessenger.h
@@ -191,7 +191,7 @@ private:
   class ReaperThread : public Thread {
     SimpleMessenger *msgr;
   public:
-    ReaperThread(SimpleMessenger *m) : msgr(m) {}
+    explicit ReaperThread(SimpleMessenger *m) : msgr(m) {}
     void *entry() {
       msgr->reaper_entry();
       return 0;

--- a/src/msg/xio/QueueStrategy.h
+++ b/src/msg/xio/QueueStrategy.h
@@ -34,7 +34,7 @@ class QueueStrategy : public DispatchStrategy {
     bi::list_member_hook<> thread_q;
     QueueStrategy *dq;
     Cond cond;
-    QSThread(QueueStrategy *dq) : thread_q(), dq(dq), cond() {}
+    explicit QSThread(QueueStrategy *dq) : thread_q(), dq(dq), cond() {}
     void* entry() {
       dq->entry(this);
       delete(this);
@@ -50,7 +50,7 @@ class QueueStrategy : public DispatchStrategy {
   QSThread::Queue disp_threads;
 
 public:
-  QueueStrategy(int n_threads);
+  explicit QueueStrategy(int n_threads);
   virtual void ds_dispatch(Message *m);
   virtual void shutdown();
   virtual void start();

--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -142,7 +142,7 @@ private:
 
     uint32_t flags;
 
-    CState(XioConnection* _xcon)
+    explicit CState(XioConnection* _xcon)
       : xcon(_xcon),
 	protocol_version(0),
 	session_state(INIT),
@@ -322,7 +322,7 @@ class XioLoopbackConnection : public Connection
 private:
   atomic_t seq;
 public:
-  XioLoopbackConnection(Messenger *m) : Connection(m->cct, m), seq(0)
+  explicit XioLoopbackConnection(Messenger *m) : Connection(m->cct, m), seq(0)
     {
       const entity_inst_t& m_inst = m->get_myinst();
       peer_addr = m_inst.addr;

--- a/src/msg/xio/XioMsg.h
+++ b/src/msg/xio/XioMsg.h
@@ -34,7 +34,7 @@ public:
   __le32 msg_cnt;
   buffer::list bl;
 public:
-  XioMsgCnt(buffer::ptr p)
+  explicit XioMsgCnt(buffer::ptr p)
     {
       bl.append(p);
       buffer::list::iterator bl_iter = bl.begin();
@@ -145,7 +145,7 @@ struct xio_msg_ex
   struct xio_msg msg;
   struct xio_iovec_ex iovs[XIO_MSGR_IOVLEN];
 
-  xio_msg_ex(void* user_context) {
+  explicit xio_msg_ex(void* user_context) {
     // go in structure order
     msg.in.header.iov_len = 0;
     msg.in.header.iov_base = NULL;  /* XXX Accelio requires this currently */

--- a/src/msg/xio/XioPool.h
+++ b/src/msg/xio/XioPool.h
@@ -48,7 +48,7 @@ public:
     char payload[MB];
   } *first;
 
-  XioPool(struct xio_mempool *_handle) :
+  explicit XioPool(struct xio_mempool *_handle) :
     handle(_handle), first(0)
     {
     }

--- a/src/msg/xio/XioPortal.h
+++ b/src/msg/xio/XioPortal.h
@@ -129,7 +129,7 @@ private:
   friend class XioMessenger;
 
 public:
-  XioPortal(Messenger *_msgr) :
+  explicit XioPortal(Messenger *_msgr) :
   msgr(_msgr), ctx(NULL), server(NULL), submit_q(), xio_uri(""),
   portal_id(NULL), _shutdown(false), drained(false),
   magic(0),

--- a/src/os/FuseStore.h
+++ b/src/os/FuseStore.h
@@ -16,7 +16,7 @@ public:
   class FuseThread : public Thread {
     FuseStore *fs;
   public:
-    FuseThread(FuseStore *f) : fs(f) {}
+    explicit FuseThread(FuseStore *f) : fs(f) {}
     void *entry() {
       fs->loop();
       return NULL;

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -181,7 +181,7 @@ public:
     string name;
     Sequencer_implRef p;
 
-    Sequencer(string n)
+    explicit Sequencer(string n)
       : name(n), p(NULL) {}
     ~Sequencer() {
     }
@@ -214,7 +214,7 @@ public:
 
   struct CompatCollectionHandle : public CollectionImpl {
     coll_t cid;
-    CompatCollectionHandle(coll_t c) : cid(c) {}
+    explicit CompatCollectionHandle(coll_t c) : cid(c) {}
     const coll_t &get_cid() override {
       return cid;
     }
@@ -509,10 +509,10 @@ public:
   public:
     Transaction() = default;
 
-    Transaction(bufferlist::iterator &dp) {
+    explicit Transaction(bufferlist::iterator &dp) {
       decode(dp);
     }
-    Transaction(bufferlist &nbl) {
+    explicit Transaction(bufferlist &nbl) {
       bufferlist::iterator dp = nbl.begin();
       decode(dp);
     }
@@ -896,7 +896,7 @@ public:
       vector<ghobject_t> objects;
 
     private:
-      iterator(Transaction *t)
+      explicit iterator(Transaction *t)
         : t(t),
 	  data_bl_p(t->data_bl.begin()),
           colls(t->coll_index.size()),
@@ -1853,11 +1853,11 @@ public:
   }
 
  public:
-  ObjectStore(const std::string& path_) : path(path_), logger(NULL) {}
+  explicit ObjectStore(const std::string& path_) : path(path_), logger(NULL) {}
   virtual ~ObjectStore() {}
 
   // no copying
-  ObjectStore(const ObjectStore& o);
+  explicit ObjectStore(const ObjectStore& o);
   const ObjectStore& operator=(const ObjectStore& o);
 
   // versioning

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -22,7 +22,7 @@ struct IOContext {
   atomic_t num_reading;
   atomic_t num_waiting;
 
-  IOContext(void *p)
+  explicit IOContext(void *p)
     : priv(p),
       lock("IOContext::lock")
     {}
@@ -69,7 +69,7 @@ private:
 
   struct AioCompletionThread : public Thread {
     BlockDevice *bdev;
-    AioCompletionThread(BlockDevice *b) : bdev(b) {}
+    explicit AioCompletionThread(BlockDevice *b) : bdev(b) {}
     void *entry() {
       bdev->_aio_thread();
       return NULL;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -110,7 +110,7 @@ public:
     uint64_t pos;           ///< current logical offset
     uint64_t max_prefetch;  ///< max allowed prefetch
 
-    FileReaderBuffer(uint64_t mpf)
+    explicit FileReaderBuffer(uint64_t mpf)
       : bl_off(0),
 	pos(0),
 	max_prefetch(mpf) {}
@@ -152,7 +152,7 @@ public:
 
   struct FileLock {
     FileRef file;
-    FileLock(FileRef f) : file(f) {}
+    explicit FileLock(FileRef f) : file(f) {}
   };
 
 private:

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -288,7 +288,7 @@ class BlueRocksWritableFile : public rocksdb::WritableFile {
 class BlueRocksDirectory : public rocksdb::Directory {
   BlueFS *fs;
  public:
-  BlueRocksDirectory(BlueFS *f) : fs(f) {}
+  explicit BlueRocksDirectory(BlueFS *f) : fs(f) {}
 
   // Fsync directory. Can be called concurrently from multiple threads.
   rocksdb::Status Fsync() {

--- a/src/os/bluestore/BlueRocksEnv.h
+++ b/src/os/bluestore/BlueRocksEnv.h
@@ -150,7 +150,7 @@ public:
   rocksdb::Status GetAbsolutePath(const std::string& db_path,
       std::string* output_path);
 
-  BlueRocksEnv(BlueFS *f);
+  explicit BlueRocksEnv(BlueFS *f);
 private:
   BlueFS *fs;
 };

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -758,6 +758,7 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
     mounted(false),
     coll_lock("BlueStore::coll_lock"),
     nid_lock("BlueStore::nid_lock"),
+    nid_last(0),
     nid_max(0),
     throttle_ops(cct, "bluestore_max_ops", cct->_conf->bluestore_max_ops),
     throttle_bytes(cct, "bluestore_max_bytes", cct->_conf->bluestore_max_bytes),

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5578,7 +5578,7 @@ int BlueStore::_zero(TransContext *txc,
       dout(20) << __func__ << "  wal zero " << x_off << "~" << x_len
 	       << " " << op->extent << dendl;
     }
-    bp++;
+    ++bp;
   }
 
   if (offset + length > o->onode.size) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -93,7 +93,7 @@ public:
 
     boost::intrusive::unordered_set<Enode> uset;
 
-    EnodeSet(unsigned n)
+    explicit EnodeSet(unsigned n)
       : num_buckets(n),
 	buckets(n),
 	uset(bucket_traits(buckets.data(), num_buckets)) {
@@ -286,7 +286,7 @@ public:
 
     CollectionRef first_collection;  ///< first referenced collection
 
-    TransContext(OpSequencer *o)
+    explicit TransContext(OpSequencer *o)
       : state(STATE_PREPARE),
 	osr(o),
 	ops(0),
@@ -448,7 +448,7 @@ public:
 
   struct KVSyncThread : public Thread {
     BlueStore *store;
-    KVSyncThread(BlueStore *s) : store(s) {}
+    explicit KVSyncThread(BlueStore *s) : store(s) {}
     void *entry() {
       store->_kv_sync_thread();
       return NULL;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -285,7 +285,7 @@ struct bluestore_wal_transaction_t {
 
   int64_t _bytes;  ///< cached byte count
 
-  bluestore_wal_transaction_t() : _bytes(-1) {}
+  bluestore_wal_transaction_t() : seq(0), _bytes(-1) {}
 
 #if 0
   no users for htis

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -45,7 +45,7 @@ ostream& operator<<(ostream& out, const bluestore_bdev_label_t& l);
 struct bluestore_cnode_t {
   uint32_t bits;   ///< how many bits of coll pgid are significant
 
-  bluestore_cnode_t(int b=0) : bits(b) {}
+  explicit bluestore_cnode_t(int b=0) : bits(b) {}
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& p);

--- a/src/os/filestore/BtrfsFileStoreBackend.h
+++ b/src/os/filestore/BtrfsFileStoreBackend.h
@@ -29,7 +29,7 @@ private:
   bool m_filestore_btrfs_clone_range;
   bool m_filestore_btrfs_snap;
 public:
-  BtrfsFileStoreBackend(FileStore *fs);
+  explicit BtrfsFileStoreBackend(FileStore *fs);
   ~BtrfsFileStoreBackend() {}
   const char *get_name() {
     return "btrfs";

--- a/src/os/filestore/CollectionIndex.h
+++ b/src/os/filestore/CollectionIndex.h
@@ -176,7 +176,7 @@ protected:
   /// Call prior to removing directory
   virtual int prep_delete() { return 0; }
 
-  CollectionIndex(coll_t collection):
+  explicit CollectionIndex(coll_t collection):
     access_lock_name ("CollectionIndex::access_lock::" + collection.to_str()),
     access_lock(access_lock_name.c_str()) {}
 

--- a/src/os/filestore/DBObjectMap.h
+++ b/src/os/filestore/DBObjectMap.h
@@ -83,7 +83,7 @@ public:
     MapHeaderLock(const MapHeaderLock &);
     MapHeaderLock &operator=(const MapHeaderLock &);
   public:
-    MapHeaderLock(DBObjectMap *db) : db(db) {}
+    explicit MapHeaderLock(DBObjectMap *db) : db(db) {}
     MapHeaderLock(DBObjectMap *db, const ghobject_t &oid) : db(db), locked(oid) {
       Mutex::Locker l(db->header_lock);
       while (db->map_header_in_use.count(*locked))
@@ -115,9 +115,9 @@ public:
     }
   };
 
-  DBObjectMap(KeyValueDB *db) : db(db), header_lock("DBOBjectMap"),
-                                cache_lock("DBObjectMap::CacheLock"),
-                                caches(g_conf->filestore_omap_header_cache_size)
+  explicit DBObjectMap(KeyValueDB *db) : db(db), header_lock("DBOBjectMap"),
+           	                         cache_lock("DBObjectMap::CacheLock"),
+      	                                 caches(g_conf->filestore_omap_header_cache_size)
     {}
 
   int set_keys(
@@ -241,7 +241,7 @@ public:
     __u8 v;
     uint64_t seq;
     State() : v(0), seq(1) {}
-    State(uint64_t seq) : v(0), seq(seq) {}
+    explicit State(uint64_t seq) : v(0), seq(seq) {}
 
     void encode(bufferlist &bl) const {
       ENCODE_START(2, 1, bl);
@@ -516,7 +516,7 @@ private:
   class RemoveOnDelete {
   public:
     DBObjectMap *db;
-    RemoveOnDelete(DBObjectMap *db) :
+    explicit RemoveOnDelete(DBObjectMap *db) :
       db(db) {}
     void operator() (_Header *header) {
       Mutex::Locker l(db->header_lock);

--- a/src/os/filestore/FDCache.h
+++ b/src/os/filestore/FDCache.h
@@ -38,7 +38,7 @@ public:
   class FD {
   public:
     const int fd;
-    FD(int _fd) : fd(_fd) {
+    explicit FD(int _fd) : fd(_fd) {
       assert(_fd >= 0);
     }
     int operator*() const {
@@ -55,7 +55,7 @@ private:
   SharedLRU<ghobject_t, FD, ghobject_t::BitwiseComparator> *registry;
 
 public:
-  FDCache(CephContext *cct) : cct(cct),
+  explicit FDCache(CephContext *cct) : cct(cct),
   registry_shards(cct->_conf->filestore_fd_cache_shards) {
     assert(cct);
     cct->_conf->add_observer(this);

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -347,7 +347,7 @@ private:
   class Writer : public Thread {
     FileJournal *journal;
   public:
-    Writer(FileJournal *fj) : journal(fj) {}
+    explicit Writer(FileJournal *fj) : journal(fj) {}
     void *entry() {
       journal->write_thread_entry();
       return 0;
@@ -357,7 +357,7 @@ private:
   class WriteFinisher : public Thread {
     FileJournal *journal;
   public:
-    WriteFinisher(FileJournal *fj) : journal(fj) {}
+    explicit WriteFinisher(FileJournal *fj) : journal(fj) {}
     void *entry() {
       journal->write_finish_thread_entry();
       return 0;

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3586,7 +3586,7 @@ int FileStore::_clone_range(coll_t cid, const ghobject_t& oldoid, const ghobject
 
 class SyncEntryTimeout : public Context {
 public:
-  SyncEntryTimeout(int commit_timeo)
+  explicit SyncEntryTimeout(int commit_timeo)
     : m_commit_timeo(commit_timeo)
   {
   }

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -174,7 +174,7 @@ private:
   void sync_entry();
   struct SyncThread : public Thread {
     FileStore *fs;
-    SyncThread(FileStore *f) : fs(f) {}
+    explicit SyncThread(FileStore *f) : fs(f) {}
     void *entry() {
       fs->sync_entry();
       return 0;
@@ -314,7 +314,7 @@ private:
       }
     }
 
-    OpSequencer(int i)
+    explicit OpSequencer(int i)
       : qlock("FileStore::OpSequencer::qlock", false, false),
 	parent(0),
 	apply_lock("FileStore::OpSequencer::apply_lock", false, false),
@@ -785,7 +785,7 @@ protected:
   }
 
 public:
-  FileStoreBackend(FileStore *fs) : filestore(fs) {}
+  explicit FileStoreBackend(FileStore *fs) : filestore(fs) {}
   virtual ~FileStoreBackend() {}
 
   static FileStoreBackend *create(long f_type, FileStore *fs);

--- a/src/os/filestore/GenericFileStoreBackend.h
+++ b/src/os/filestore/GenericFileStoreBackend.h
@@ -28,7 +28,7 @@ private:
   bool m_filestore_fsync_flushes_journal_data;
   bool m_filestore_splice;
 public:
-  GenericFileStoreBackend(FileStore *fs);
+  explicit GenericFileStoreBackend(FileStore *fs);
   virtual ~GenericFileStoreBackend() {}
 
   virtual const char *get_name() {

--- a/src/os/filestore/HashIndex.h
+++ b/src/os/filestore/HashIndex.h
@@ -106,7 +106,7 @@ private:
     InProgressOp(int op, const vector<string> &path)
       : op(op), path(path) {}
 
-    InProgressOp(bufferlist::iterator &bl) {
+    explicit InProgressOp(bufferlist::iterator &bl) {
       decode(bl);
     }
 

--- a/src/os/filestore/IndexManager.h
+++ b/src/os/filestore/IndexManager.h
@@ -31,7 +31,7 @@ struct Index {
   CollectionIndex *index;
 
   Index() : index(NULL) {}
-  Index(CollectionIndex* index) : index(index) {}
+  explicit Index(CollectionIndex* index) : index(index) {}
 
   CollectionIndex *operator->() { return index; }
   CollectionIndex &operator*() { return *index; }
@@ -67,8 +67,8 @@ class IndexManager {
   int build_index(coll_t c, const char *path, CollectionIndex **index);
 public:
   /// Constructor
-  IndexManager(bool upgrade) : lock("IndexManager lock"),
-			       upgrade(upgrade) {}
+  explicit IndexManager(bool upgrade) : lock("IndexManager lock"),
+		    		        upgrade(upgrade) {}
 
   ~IndexManager();
 

--- a/src/os/filestore/JournalingObjectStore.h
+++ b/src/os/filestore/JournalingObjectStore.h
@@ -129,7 +129,7 @@ public:
   }
 
 public:
-  JournalingObjectStore(const std::string& path)
+  explicit JournalingObjectStore(const std::string& path)
     : ObjectStore(path),
       journal(NULL),
       finisher(g_ceph_context, "JournalObjectStore", "fn_jrn_objstore"),

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -65,7 +65,7 @@ void LFNIndex::maybe_inject_failure()
 // in combination with RetryException, thrown by the above.
 struct FDCloser {
   int fd;
-  FDCloser(int f) : fd(f) {}
+  explicit FDCloser(int f) : fd(f) {}
   ~FDCloser() {
     VOID_TEMP_FAILURE_RETRY(::close(fd));
   }

--- a/src/os/filestore/WBThrottle.h
+++ b/src/os/filestore/WBThrottle.h
@@ -146,7 +146,7 @@ private:
   }
 
 public:
-  WBThrottle(CephContext *cct);
+  explicit WBThrottle(CephContext *cct);
   ~WBThrottle();
 
   void start();

--- a/src/os/filestore/XfsFileStoreBackend.h
+++ b/src/os/filestore/XfsFileStoreBackend.h
@@ -24,7 +24,7 @@ private:
   bool m_has_extsize;
   int set_extsize(int fd, unsigned int val);
 public:
-  XfsFileStoreBackend(FileStore *fs);
+  explicit XfsFileStoreBackend(FileStore *fs);
   ~XfsFileStoreBackend() {}
   const char *get_name() {
     return "xfs";

--- a/src/os/filestore/ZFSFileStoreBackend.h
+++ b/src/os/filestore/ZFSFileStoreBackend.h
@@ -16,7 +16,7 @@ private:
   bool m_filestore_zfs_snap;
   int update_current_zh();
 public:
-  ZFSFileStoreBackend(FileStore *fs);
+  explicit ZFSFileStoreBackend(FileStore *fs);
   ~ZFSFileStoreBackend();
   int detect_features();
   bool can_checkpoint();

--- a/src/os/fs/FS.h
+++ b/src/os/fs/FS.h
@@ -89,7 +89,7 @@ public:
     int max_iodepth;
     io_context_t ctx;
 
-    aio_queue_t(unsigned max_iodepth)
+    explicit aio_queue_t(unsigned max_iodepth)
       : max_iodepth(max_iodepth),
 	ctx(0) {
     }

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -201,7 +201,7 @@ public:
 
     CollectionRef first_collection;  ///< first referenced collection
 
-    TransContext(OpSequencer *o)
+    explicit TransContext(OpSequencer *o)
       : state(STATE_PREPARE),
 	osr(o),
 	ops(0),
@@ -272,7 +272,7 @@ public:
 
   struct KVSyncThread : public Thread {
     KStore *store;
-    KVSyncThread(KStore *s) : store(s) {}
+    explicit KVSyncThread(KStore *s) : store(s) {}
     void *entry() {
       store->_kv_sync_thread();
       return NULL;

--- a/src/os/kstore/kstore_types.h
+++ b/src/os/kstore/kstore_types.h
@@ -28,7 +28,7 @@ namespace ceph {
 struct kstore_cnode_t {
   uint32_t bits;   ///< how many bits of coll pgid are significant
 
-  kstore_cnode_t(int b=0) : bits(b) {}
+  explicit kstore_cnode_t(int b=0) : bits(b) {}
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& p);

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -130,7 +130,7 @@ public:
     static thread_local PageSet::page_vector tls_pages;
 #endif
 
-    PageSetObject(size_t page_size) : data(page_size), data_len(0) {}
+    explicit PageSetObject(size_t page_size) : data(page_size), data_len(0) {}
 
     size_t get_size() const override { return data_len; }
 
@@ -243,7 +243,7 @@ public:
       return result;
     }
 
-    Collection(CephContext *cct)
+    explicit Collection(CephContext *cct)
       : cct(cct), use_page_set(cct->_conf->memstore_page_set),
         lock("MemStore::Collection::lock"), exists(true) {}
   };

--- a/src/os/memstore/PageSet.h
+++ b/src/os/memstore/PageSet.h
@@ -126,7 +126,7 @@ class PageSet {
   }
 
  public:
-  PageSet(size_t page_size) : page_size(page_size) {}
+  explicit PageSet(size_t page_size) : page_size(page_size) {}
   PageSet(PageSet &&rhs)
     : pages(std::move(rhs.pages)), page_size(rhs.page_size) {}
   ~PageSet() {

--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -107,7 +107,7 @@ private:
   int _load_class(ClassData *cls);
 
 public:
-  ClassHandler(CephContext *cct_) : cct(cct_), mutex("ClassHandler") {}
+  explicit ClassHandler(CephContext *cct_) : cct(cct_), mutex("ClassHandler") {}
   
   int open_all_classes();
 

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -861,7 +861,8 @@ void ECBackend::handle_sub_write(
     !(op.t.empty()),
     &localt);
 
-  if (!(dynamic_cast<ReplicatedPG *>(get_parent())->is_undersized()) &&
+  ReplicatedPG *_rPG = dynamic_cast<ReplicatedPG *>(get_parent());
+  if (_rPG && !_rPG->is_undersized() &&
       (unsigned)get_parent()->whoami_shard().shard >= ec_impl->get_data_chunk_count())
     op.t.set_fadvise_flag(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
 

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -137,7 +137,7 @@ public:
   struct ClientAsyncReadStatus {
     bool complete;
     Context *on_complete;
-    ClientAsyncReadStatus(Context *on_complete)
+    explicit ClientAsyncReadStatus(Context *on_complete)
     : complete(false), on_complete(on_complete) {}
   };
   list<ClientAsyncReadStatus> in_progress_client_reads;
@@ -412,7 +412,7 @@ public:
     set<int> want;
     ErasureCodeInterfaceRef ec_impl;
   public:
-    ECRecPred(ErasureCodeInterfaceRef ec_impl) : ec_impl(ec_impl) {
+    explicit ECRecPred(ErasureCodeInterfaceRef ec_impl) : ec_impl(ec_impl) {
       for (unsigned i = 0; i < ec_impl->get_chunk_count(); ++i) {
 	want.insert(i);
       }

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -24,7 +24,7 @@
 
 struct AppendObjectsGenerator: public boost::static_visitor<void> {
   set<hobject_t, hobject_t::BitwiseComparator> *out;
-  AppendObjectsGenerator(set<hobject_t, hobject_t::BitwiseComparator> *out) : out(out) {}
+  explicit AppendObjectsGenerator(set<hobject_t, hobject_t::BitwiseComparator> *out) : out(out) {}
   void operator()(const ECTransaction::AppendOp &op) {
     out->insert(op.oid);
   }

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -52,11 +52,11 @@ public:
   };
   struct TouchOp {
     hobject_t oid;
-    TouchOp(const hobject_t &oid) : oid(oid) {}
+    explicit TouchOp(const hobject_t &oid) : oid(oid) {}
   };
   struct RemoveOp {
     hobject_t oid;
-    RemoveOp(const hobject_t &oid) : oid(oid) {}
+    explicit RemoveOp(const hobject_t &oid) : oid(oid) {}
   };
   struct SetAttrsOp {
     hobject_t oid;

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -109,7 +109,7 @@ class HashInfo {
   vector<uint32_t> cumulative_shard_hashes;
 public:
   HashInfo() : total_chunk_size(0) {}
-  HashInfo(unsigned num_chunks)
+  explicit HashInfo(unsigned num_chunks)
   : total_chunk_size(0),
     cumulative_shard_hashes(num_chunks, -1) {}
   void append(uint64_t old_size, map<int, bufferlist> &to_append);

--- a/src/osd/HitSet.h
+++ b/src/osd/HitSet.h
@@ -92,7 +92,7 @@ public:
     };
 
     Params()  {}
-    Params(Impl *i) : impl(i) {}
+    explicit Params(Impl *i) : impl(i) {}
     virtual ~Params() {}
 
     boost::scoped_ptr<Params::Impl> impl;
@@ -115,8 +115,8 @@ public:
   };
 
   HitSet() : impl(NULL), sealed(false) {}
-  HitSet(Impl *i) : impl(i), sealed(false) {}
-  HitSet(const HitSet::Params& params);
+  explicit HitSet(Impl *i) : impl(i), sealed(false) {}
+  explicit HitSet(const HitSet::Params& params);
 
   HitSet(const HitSet& o) {
     sealed = o.sealed;
@@ -195,7 +195,7 @@ public:
   };
 
   ExplicitHashHitSet() : count(0) {}
-  ExplicitHashHitSet(const ExplicitHashHitSet::Params *p) : count(0) {}
+  explicit ExplicitHashHitSet(const ExplicitHashHitSet::Params *p) : count(0) {}
   ExplicitHashHitSet(const ExplicitHashHitSet &o) : count(o.count),
       hits(o.hits) {}
 
@@ -272,7 +272,7 @@ public:
   };
 
   ExplicitObjectHitSet() : count(0) {}
-  ExplicitObjectHitSet(const ExplicitObjectHitSet::Params *p) : count(0) {}
+  explicit ExplicitObjectHitSet(const ExplicitObjectHitSet::Params *p) : count(0) {}
   ExplicitObjectHitSet(const ExplicitObjectHitSet &o) : count(o.count),
       hits(o.hits) {}
 
@@ -409,7 +409,7 @@ public:
   BloomHitSet(unsigned inserts, double fpp, int seed)
     : bloom(inserts, fpp, seed)
   {}
-  BloomHitSet(const BloomHitSet::Params *p) : bloom(p->target_size,
+  explicit BloomHitSet(const BloomHitSet::Params *p) : bloom(p->target_size,
                                                     p->get_fpp(),
                                                     p->seed)
   {}

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -507,7 +507,7 @@ void OSDService::activate_map()
 class AgentTimeoutCB : public Context {
   PGRef pg;
 public:
-  AgentTimeoutCB(PGRef _pg) : pg(_pg) {}
+  explicit AgentTimeoutCB(PGRef _pg) : pg(_pg) {}
   void finish(int) {
     pg->agent_choose_mode_restart();
   }
@@ -1670,7 +1670,7 @@ int OSD::pre_init()
 class OSDSocketHook : public AdminSocketHook {
   OSD *osd;
 public:
-  OSDSocketHook(OSD *o) : osd(o) {}
+  explicit OSDSocketHook(OSD *o) : osd(o) {}
   bool call(std::string command, cmdmap_t& cmdmap, std::string format,
 	    bufferlist& out) {
     stringstream ss;
@@ -4500,7 +4500,7 @@ bool OSD::ms_handle_reset(Connection *con)
 struct C_OSD_GetVersion : public Context {
   OSD *osd;
   uint64_t oldest, newest;
-  C_OSD_GetVersion(OSD *o) : osd(o), oldest(0), newest(0) {}
+  explicit C_OSD_GetVersion(OSD *o) : osd(o), oldest(0), newest(0) {}
   void finish(int r) {
     if (r >= 0)
       osd->_got_mon_epochs(oldest, newest);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3848,7 +3848,7 @@ void OSD::heartbeat_check()
   assert(heartbeat_lock.is_locked());
   utime_t now = ceph_clock_now(cct);
   double age = hbclient_messenger->get_dispatch_queue_max_age(now);
-  if (age > (cct->_conf->osd_heartbeat_grace / 2)) {
+  if (age > ((double)cct->_conf->osd_heartbeat_grace / 2.0)) {
     derr << "skipping heartbeat_check, hbqueue max age: " << age << dendl;
     return; // hb dispatch is too backed up for our hb status to be meaningful
   }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -364,6 +364,7 @@ class PGQueueable {
     void operator()(PGScrub &op);
   };
 public:
+  // cppcheck-suppress noExplicitConstructor
   PGQueueable(OpRequestRef op)
     : qvariant(op), cost(op->get_req()->get_cost()),
       priority(op->get_req()->get_priority()),

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -237,7 +237,7 @@ class DeletingState {
 public:
   const spg_t pgid;
   const PGRef old_pg_state;
-  DeletingState(const pair<spg_t, PGRef> &in) :
+  explicit DeletingState(const pair<spg_t, PGRef> &in) :
     lock("DeletingState::lock"), status(QUEUED), stop_deleting(false),
     pgid(in.first), old_pg_state(in.second) {
     }
@@ -328,7 +328,7 @@ class OSD;
 
 struct PGScrub {
   epoch_t epoch_queued;
-  PGScrub(epoch_t e) : epoch_queued(e) {}
+  explicit PGScrub(epoch_t e) : epoch_queued(e) {}
   ostream &operator<<(ostream &rhs) {
     return rhs << "PGScrub";
   }
@@ -336,7 +336,7 @@ struct PGScrub {
 
 struct PGSnapTrim {
   epoch_t epoch_queued;
-  PGSnapTrim(epoch_t e) : epoch_queued(e) {}
+  explicit PGSnapTrim(epoch_t e) : epoch_queued(e) {}
   ostream &operator<<(ostream &rhs) {
     return rhs << "PGSnapTrim";
   }
@@ -667,7 +667,7 @@ public:
   bool agent_active;
   struct AgentThread : public Thread {
     OSDService *osd;
-    AgentThread(OSDService *o) : osd(o) {}
+    explicit AgentThread(OSDService *o) : osd(o) {}
     void *entry() {
       osd->agent_entry();
       return NULL;
@@ -1032,7 +1032,7 @@ public:
   }
 #endif
 
-  OSDService(OSD *osd);
+  explicit OSDService(OSD *osd);
   ~OSDService();
 };
 
@@ -1092,7 +1092,7 @@ protected:
   class C_Tick : public Context {
     OSD *osd;
   public:
-    C_Tick(OSD *o) : osd(o) {}
+    explicit C_Tick(OSD *o) : osd(o) {}
     void finish(int r) {
       osd->tick();
     }
@@ -1101,7 +1101,7 @@ protected:
   class C_Tick_WithoutOSDLock : public Context {
     OSD *osd;
   public:
-    C_Tick_WithoutOSDLock(OSD *o) : osd(o) {}
+    explicit C_Tick_WithoutOSDLock(OSD *o) : osd(o) {}
     void finish(int r) {
       osd->tick_without_osd_lock();
     }
@@ -1316,7 +1316,7 @@ public:
     Spinlock received_map_lock;
     epoch_t received_map_epoch; // largest epoch seen in MOSDMap from here
 
-    Session(CephContext *cct) :
+    explicit Session(CephContext *cct) :
       RefCountedObject(cct),
       auid(-1), con(0),
       session_dispatch_lock("Session::session_dispatch_lock"), 
@@ -1509,7 +1509,7 @@ private:
   /// state attached to outgoing heartbeat connections
   struct HeartbeatSession : public RefCountedObject {
     int peer;
-    HeartbeatSession(int p) : peer(p) {}
+    explicit HeartbeatSession(int p) : peer(p) {}
   };
   Mutex heartbeat_lock;
   map<int, int> debug_heartbeat_drops_remaining;
@@ -1550,7 +1550,7 @@ private:
 
   struct T_Heartbeat : public Thread {
     OSD *osd;
-    T_Heartbeat(OSD *o) : osd(o) {}
+    explicit T_Heartbeat(OSD *o) : osd(o) {}
     void *entry() {
       osd->heartbeat_entry();
       return 0;
@@ -1562,7 +1562,7 @@ public:
 
   struct HeartbeatDispatcher : public Dispatcher {
     OSD *osd;
-    HeartbeatDispatcher(OSD *o) : Dispatcher(cct), osd(o) {}
+    explicit HeartbeatDispatcher(OSD *o) : Dispatcher(cct), osd(o) {}
     bool ms_dispatch(Message *m) {
       return osd->heartbeat_dispatch(m);
     }
@@ -1687,7 +1687,7 @@ private:
 
     struct Pred {
       PG *pg;
-      Pred(PG *pg) : pg(pg) {}
+      explicit Pred(PG *pg) : pg(pg) {}
       bool operator()(const pair<PGRef, PGQueueable> &op) {
 	return op.first == pg;
       }

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -60,8 +60,8 @@ struct OSDCapSpec {
   std::string class_allow;
 
   OSDCapSpec() : allow(0) {}
-  OSDCapSpec(osd_rwxa_t v) : allow(v) {}
-  OSDCapSpec(std::string n) : allow(0), class_name(n) {}
+  explicit OSDCapSpec(osd_rwxa_t v) : allow(v) {}
+  explicit OSDCapSpec(std::string n) : allow(0), class_name(n) {}
   OSDCapSpec(std::string n, std::string a) : allow(0), class_name(n), class_allow(a) {}
 
   bool allow_all() const {
@@ -119,7 +119,7 @@ struct OSDCap {
   std::vector<OSDCapGrant> grants;
 
   OSDCap() {}
-  OSDCap(std::vector<OSDCapGrant> g) : grants(g) {}
+  explicit OSDCap(std::vector<OSDCapGrant> g) : grants(g) {}
 
   bool allow_all() const;
   void set_allow_all();

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -42,6 +42,7 @@ static const __u8 OSD_CAP_ANY   = 0xff;          // *
 struct osd_rwxa_t {
   __u8 val;
 
+  // cppcheck-suppress noExplicitConstructor
   osd_rwxa_t(__u8 v = 0) : val(v) {}
   osd_rwxa_t& operator=(__u8 v) {
     val = v;

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -171,17 +171,17 @@ public:
     void dump(Formatter *f) const;
     static void generate_test_instances(list<Incremental*>& o);
 
-    Incremental(epoch_t e=0) :
+    explicit Incremental(epoch_t e=0) :
       encode_features(0),
       epoch(e), new_pool_max(-1), new_flags(-1), new_max_osd(-1),
       have_crc(false), full_crc(0), inc_crc(0) {
       memset(&fsid, 0, sizeof(fsid));
     }
-    Incremental(bufferlist &bl) {
+    explicit Incremental(bufferlist &bl) {
       bufferlist::iterator p = bl.begin();
       decode(p);
     }
-    Incremental(bufferlist::iterator &p) {
+    explicit Incremental(bufferlist::iterator &p) {
       decode(p);
     }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2069,7 +2069,7 @@ bool PG::queue_scrub()
 
 struct C_PG_FinishRecovery : public Context {
   PGRef pg;
-  C_PG_FinishRecovery(PG *p) : pg(p) {}
+  explicit C_PG_FinishRecovery(PG *p) : pg(p) {}
   void finish(int r) {
     pg->_finish_recovery(this);
   }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -320,7 +320,7 @@ public:
   public:
     boost::scoped_ptr<IsPGReadablePredicate> is_readable;
     boost::scoped_ptr<IsPGRecoverablePredicate> is_recoverable;
-    MissingLoc(PG *pg)
+    explicit MissingLoc(PG *pg)
       : pg(pg) {}
     void set_backend_predicates(
       IsPGReadablePredicate *_is_readable,
@@ -658,7 +658,7 @@ public:
     hobject_t begin;
     hobject_t end;
 
-    BackfillInterval(bool bitwise=true)
+    explicit BackfillInterval(bool bitwise=true)
       : objects(hobject_t::Comparator(bitwise)),
 	sort_bitwise(bitwise)
     {}
@@ -1333,7 +1333,7 @@ public:
 
   struct QueryState : boost::statechart::event< QueryState > {
     Formatter *f;
-    QueryState(Formatter *f) : f(f) {}
+    explicit QueryState(Formatter *f) : f(f) {}
     void print(std::ostream *out) const {
       *out << "Query";
     }
@@ -1412,7 +1412,7 @@ public:
   };
   struct Activate : boost::statechart::event< Activate > {
     epoch_t activation_epoch;
-    Activate(epoch_t q) : boost::statechart::event< Activate >(),
+    explicit Activate(epoch_t q) : boost::statechart::event< Activate >(),
 			  activation_epoch(q) {}
     void print(std::ostream *out) const {
       *out << "Activate from " << activation_epoch;
@@ -1420,7 +1420,7 @@ public:
   };
   struct RequestBackfillPrio : boost::statechart::event< RequestBackfillPrio > {
     unsigned priority;
-    RequestBackfillPrio(unsigned prio) :
+    explicit RequestBackfillPrio(unsigned prio) :
               boost::statechart::event< RequestBackfillPrio >(),
 			  priority(prio) {}
     void print(std::ostream *out) const {
@@ -1544,14 +1544,14 @@ public:
     /* States */
 
     struct Crashed : boost::statechart::state< Crashed, RecoveryMachine >, NamedState {
-      Crashed(my_context ctx);
+      explicit Crashed(my_context ctx);
     };
 
     struct Started;
     struct Reset;
 
     struct Initial : boost::statechart::state< Initial, RecoveryMachine >, NamedState {
-      Initial(my_context ctx);
+      explicit Initial(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1571,7 +1571,7 @@ public:
     };
 
     struct Reset : boost::statechart::state< Reset, RecoveryMachine >, NamedState {
-      Reset(my_context ctx);
+      explicit Reset(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1596,7 +1596,7 @@ public:
     struct Start;
 
     struct Started : boost::statechart::state< Started, RecoveryMachine, Start >, NamedState {
-      Started(my_context ctx);
+      explicit Started(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1626,7 +1626,7 @@ public:
     struct Stray;
 
     struct Start : boost::statechart::state< Start, Started >, NamedState {
-      Start(my_context ctx);
+      explicit Start(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1646,7 +1646,7 @@ public:
     };
 
     struct Primary : boost::statechart::state< Primary, Started, Peering >, NamedState {
-      Primary(my_context ctx);
+      explicit Primary(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1667,7 +1667,7 @@ public:
 	boost::statechart::custom_reaction< MInfoRec >,
 	boost::statechart::custom_reaction< MNotifyRec >
 	> reactions;
-      WaitActingChange(my_context ctx);
+      explicit WaitActingChange(my_context ctx);
       boost::statechart::result react(const QueryState& q);
       boost::statechart::result react(const AdvMap&);
       boost::statechart::result react(const MLogRec&);
@@ -1682,7 +1682,7 @@ public:
     struct Peering : boost::statechart::state< Peering, Primary, GetInfo >, NamedState {
       std::unique_ptr< PriorSet > prior_set;
 
-      Peering(my_context ctx);
+      explicit Peering(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1697,7 +1697,7 @@ public:
     struct WaitLocalRecoveryReserved;
     struct Activating;
     struct Active : boost::statechart::state< Active, Primary, Activating >, NamedState {
-      Active(my_context ctx);
+      explicit Active(my_context ctx);
       void exit();
 
       const set<pg_shard_t> remote_shards_to_reserve_recovery;
@@ -1730,7 +1730,7 @@ public:
       typedef boost::mpl::list<
 	boost::statechart::transition< DoRecovery, WaitLocalRecoveryReserved >
       > reactions;
-      Clean(my_context ctx);
+      explicit Clean(my_context ctx);
       void exit();
     };
 
@@ -1739,7 +1739,7 @@ public:
 	boost::statechart::transition< GoClean, Clean >,
 	boost::statechart::custom_reaction< AllReplicasActivated >
       > reactions;
-      Recovered(my_context ctx);
+      explicit Recovered(my_context ctx);
       void exit();
       boost::statechart::result react(const AllReplicasActivated&) {
 	post_event(GoClean());
@@ -1752,7 +1752,7 @@ public:
 	boost::statechart::transition< Backfilled, Recovered >,
 	boost::statechart::custom_reaction< RemoteReservationRejected >
 	> reactions;
-      Backfilling(my_context ctx);
+      explicit Backfilling(my_context ctx);
       boost::statechart::result react(const RemoteReservationRejected& evt);
       void exit();
     };
@@ -1764,7 +1764,7 @@ public:
 	boost::statechart::transition< AllBackfillsReserved, Backfilling >
 	> reactions;
       set<pg_shard_t>::const_iterator backfill_osd_it;
-      WaitRemoteBackfillReserved(my_context ctx);
+      explicit WaitRemoteBackfillReserved(my_context ctx);
       void exit();
       boost::statechart::result react(const RemoteBackfillReserved& evt);
       boost::statechart::result react(const RemoteReservationRejected& evt);
@@ -1774,7 +1774,7 @@ public:
       typedef boost::mpl::list<
 	boost::statechart::transition< LocalBackfillReserved, WaitRemoteBackfillReserved >
 	> reactions;
-      WaitLocalBackfillReserved(my_context ctx);
+      explicit WaitLocalBackfillReserved(my_context ctx);
       void exit();
     };
 
@@ -1784,7 +1784,7 @@ public:
 	boost::statechart::custom_reaction< RemoteBackfillReserved >,
 	boost::statechart::custom_reaction< RemoteReservationRejected >
 	> reactions;
-      NotBackfilling(my_context ctx);
+      explicit NotBackfilling(my_context ctx);
       void exit();
       boost::statechart::result react(const RemoteBackfillReserved& evt);
       boost::statechart::result react(const RemoteReservationRejected& evt);
@@ -1792,7 +1792,7 @@ public:
 
     struct RepNotRecovering;
     struct ReplicaActive : boost::statechart::state< ReplicaActive, Started, RepNotRecovering >, NamedState {
-      ReplicaActive(my_context ctx);
+      explicit ReplicaActive(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1817,7 +1817,7 @@ public:
 	boost::statechart::transition< RemoteReservationRejected, RepNotRecovering >,
 	boost::statechart::custom_reaction< BackfillTooFull >
 	> reactions;
-      RepRecovering(my_context ctx);
+      explicit RepRecovering(my_context ctx);
       boost::statechart::result react(const BackfillTooFull &evt);
       void exit();
     };
@@ -1827,7 +1827,7 @@ public:
 	boost::statechart::custom_reaction< RemoteBackfillReserved >,
 	boost::statechart::custom_reaction< RemoteReservationRejected >
 	> reactions;
-      RepWaitBackfillReserved(my_context ctx);
+      explicit RepWaitBackfillReserved(my_context ctx);
       void exit();
       boost::statechart::result react(const RemoteBackfillReserved &evt);
       boost::statechart::result react(const RemoteReservationRejected &evt);
@@ -1837,7 +1837,7 @@ public:
       typedef boost::mpl::list<
 	boost::statechart::custom_reaction< RemoteRecoveryReserved >
 	> reactions;
-      RepWaitRecoveryReserved(my_context ctx);
+      explicit RepWaitRecoveryReserved(my_context ctx);
       void exit();
       boost::statechart::result react(const RemoteRecoveryReserved &evt);
     };
@@ -1848,7 +1848,7 @@ public:
         boost::statechart::transition< RequestRecovery, RepWaitRecoveryReserved >,
 	boost::statechart::transition< RecoveryDone, RepNotRecovering >  // for compat with pre-reservation peers
 	> reactions;
-      RepNotRecovering(my_context ctx);
+      explicit RepNotRecovering(my_context ctx);
       boost::statechart::result react(const RequestBackfillPrio &evt);
       void exit();
     };
@@ -1858,7 +1858,7 @@ public:
 	boost::statechart::custom_reaction< AllReplicasRecovered >,
 	boost::statechart::custom_reaction< RequestBackfill >
 	> reactions;
-      Recovering(my_context ctx);
+      explicit Recovering(my_context ctx);
       void exit();
       void release_reservations();
       boost::statechart::result react(const AllReplicasRecovered &evt);
@@ -1871,7 +1871,7 @@ public:
 	boost::statechart::transition< AllRemotesReserved, Recovering >
 	> reactions;
       set<pg_shard_t>::const_iterator remote_recovery_reservation_it;
-      WaitRemoteRecoveryReserved(my_context ctx);
+      explicit WaitRemoteRecoveryReserved(my_context ctx);
       boost::statechart::result react(const RemoteRecoveryReserved &evt);
       void exit();
     };
@@ -1880,7 +1880,7 @@ public:
       typedef boost::mpl::list <
 	boost::statechart::transition< LocalRecoveryReserved, WaitRemoteRecoveryReserved >
 	> reactions;
-      WaitLocalRecoveryReserved(my_context ctx);
+      explicit WaitLocalRecoveryReserved(my_context ctx);
       void exit();
     };
 
@@ -1890,14 +1890,14 @@ public:
 	boost::statechart::transition< DoRecovery, WaitLocalRecoveryReserved >,
 	boost::statechart::transition< RequestBackfill, WaitLocalBackfillReserved >
 	> reactions;
-      Activating(my_context ctx);
+      explicit Activating(my_context ctx);
       void exit();
     };
 
     struct Stray : boost::statechart::state< Stray, Started >, NamedState {
       map<int, pair<pg_query_t, epoch_t> > pending_queries;
 
-      Stray(my_context ctx);
+      explicit Stray(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1921,7 +1921,7 @@ public:
     struct GetInfo : boost::statechart::state< GetInfo, Peering >, NamedState {
       set<pg_shard_t> peer_info_requested;
 
-      GetInfo(my_context ctx);
+      explicit GetInfo(my_context ctx);
       void exit();
       void get_infos();
 
@@ -1943,7 +1943,7 @@ public:
       pg_shard_t auth_log_shard;
       boost::intrusive_ptr<MOSDPGLog> msg;
 
-      GetLog(my_context ctx);
+      explicit GetLog(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1964,7 +1964,7 @@ public:
     struct GetMissing : boost::statechart::state< GetMissing, Peering >, NamedState {
       set<pg_shard_t> peer_missing_requested;
 
-      GetMissing(my_context ctx);
+      explicit GetMissing(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1977,7 +1977,7 @@ public:
     };
 
     struct WaitUpThru : boost::statechart::state< WaitUpThru, Peering >, NamedState {
-      WaitUpThru(my_context ctx);
+      explicit WaitUpThru(my_context ctx);
       void exit();
 
       typedef boost::mpl::list <
@@ -1995,7 +1995,7 @@ public:
 	boost::statechart::custom_reaction< AdvMap >,
 	boost::statechart::custom_reaction< MNotifyRec >
 	> reactions;
-      Incomplete(my_context ctx);
+      explicit Incomplete(my_context ctx);
       boost::statechart::result react(const AdvMap &advmap);
       boost::statechart::result react(const MNotifyRec& infoevt);
       void exit();
@@ -2019,7 +2019,7 @@ public:
     boost::optional<RecoveryCtx> rctx;
 
   public:
-    RecoveryState(PG *pg)
+    explicit RecoveryState(PG *pg)
       : machine(this, pg), pg(pg), orig_ctx(0) {
       machine.initiate();
     }

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -478,6 +478,7 @@ protected:
     check();
   }
 public:
+  // cppcheck-suppress noExplicitConstructor
   PGLog(CephContext *cct = 0) :
     dirty_from(eversion_t::max()),
     writeout_from(eversion_t::max()), 

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -86,7 +86,7 @@ public:
   class RPCReadPred : public IsPGReadablePredicate {
     pg_shard_t whoami;
   public:
-    RPCReadPred(pg_shard_t whoami) : whoami(whoami) {}
+    explicit RPCReadPred(pg_shard_t whoami) : whoami(whoami) {}
     bool operator()(const set<pg_shard_t> &have) const {
       return have.count(whoami);
     }

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -132,7 +132,7 @@ public:
   ReplicatedPG::CopyResults *results;
   int retval;
   ReplicatedPG::OpContext *ctx;
-  CopyFromCallback(ReplicatedPG::OpContext *ctx_)
+  explicit CopyFromCallback(ReplicatedPG::OpContext *ctx_)
     : results(NULL),
       retval(0),
       ctx(ctx_) {}
@@ -9364,7 +9364,7 @@ ObjectContextRef ReplicatedPG::mark_object_lost(ObjectStore::Transaction *t,
 struct C_PG_MarkUnfoundLost : public Context {
   ReplicatedPGRef pg;
   list<ObjectContextRef> obcs;
-  C_PG_MarkUnfoundLost(ReplicatedPG *p) : pg(p) {}
+  explicit C_PG_MarkUnfoundLost(ReplicatedPG *p) : pg(p) {}
   void finish(int r) {
     pg->_finish_mark_all_unfound_lost(obcs);
   }
@@ -11729,7 +11729,7 @@ bool ReplicatedPG::agent_maybe_flush(ObjectContextRef& obc)
 
 struct C_AgentEvictStartStop : public Context {
   ReplicatedPGRef pg;
-  C_AgentEvictStartStop(ReplicatedPG *p) : pg(p) {
+  explicit C_AgentEvictStartStop(ReplicatedPG *p) : pg(p) {
     pg->osd->agent_start_evict_op();
   }
   void finish(int r) {
@@ -12120,7 +12120,7 @@ bool ReplicatedPG::_range_available_for_scrub(
 
 struct C_ScrubDigestUpdated : public Context {
   ReplicatedPGRef pg;
-  C_ScrubDigestUpdated(ReplicatedPG *pg) : pg(pg) {}
+  explicit C_ScrubDigestUpdated(ReplicatedPG *pg) : pg(pg) {}
   void finish(int r) {
     pg->_scrub_digest_updated();
   }

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -509,7 +509,7 @@ public:
       boost::optional<uint64_t> watch_cookie;
       uint64_t notify_id;
       bufferlist reply_bl;
-      NotifyAck(uint64_t notify_id) : notify_id(notify_id) {}
+      explicit NotifyAck(uint64_t notify_id) : notify_id(notify_id) {}
       NotifyAck(uint64_t notify_id, uint64_t cookie, bufferlist& rbl)
 	: watch_cookie(cookie), notify_id(notify_id) {
 	reply_bl.claim(rbl);
@@ -1298,7 +1298,7 @@ protected:
   };
   struct C_OSD_OndiskWriteUnlockList : public Context {
     list<ObjectContextRef> *pls;
-    C_OSD_OndiskWriteUnlockList(list<ObjectContextRef> *l) : pls(l) {}
+    explicit C_OSD_OndiskWriteUnlockList(list<ObjectContextRef> *l) : pls(l) {}
     void finish(int r) {
       for (list<ObjectContextRef>::iterator p = pls->begin(); p != pls->end(); ++p)
 	(*p)->ondisk_write_unlock();
@@ -1327,7 +1327,7 @@ protected:
   };
   struct C_OSD_AppliedRecoveredObjectReplica : public Context {
     ReplicatedPGRef pg;
-    C_OSD_AppliedRecoveredObjectReplica(ReplicatedPG *p) :
+    explicit C_OSD_AppliedRecoveredObjectReplica(ReplicatedPG *p) :
       pg(p) {}
     void finish(int r) {
       pg->_applied_recovered_object_replica();
@@ -1543,7 +1543,7 @@ private:
     set<RepGather *> repops;
     snapid_t snap_to_trim;
     bool need_share_pg_info;
-    SnapTrimmer(ReplicatedPG *pg) : pg(pg), need_share_pg_info(false) {}
+    explicit SnapTrimmer(ReplicatedPG *pg) : pg(pg), need_share_pg_info(false) {}
     ~SnapTrimmer();
     void log_enter(const char *state_name);
     void log_exit(const char *state_name, utime_t duration);
@@ -1556,7 +1556,7 @@ private:
       boost::statechart::transition< Reset, NotTrimming >
       > reactions;
     hobject_t pos;
-    TrimmingObjects(my_context ctx);
+    explicit TrimmingObjects(my_context ctx);
     void exit();
     boost::statechart::result react(const SnapTrim&);
   };
@@ -1566,7 +1566,7 @@ private:
       boost::statechart::custom_reaction< SnapTrim >,
       boost::statechart::transition< Reset, NotTrimming >
       > reactions;
-    WaitingOnReplicas(my_context ctx);
+    explicit WaitingOnReplicas(my_context ctx);
     void exit();
     boost::statechart::result react(const SnapTrim&);
   };
@@ -1576,7 +1576,7 @@ private:
       boost::statechart::custom_reaction< SnapTrim >,
       boost::statechart::transition< Reset, NotTrimming >
       > reactions;
-    NotTrimming(my_context ctx);
+    explicit NotTrimming(my_context ctx);
     void exit();
     boost::statechart::result react(const SnapTrim&);
   };

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -53,7 +53,7 @@ int OSDriver::get_next(
 struct Mapping {
   snapid_t snap;
   hobject_t hoid;
-  Mapping(const pair<snapid_t, hobject_t> &in)
+  explicit Mapping(const pair<snapid_t, hobject_t> &in)
     : snap(in.first), hoid(in.second) {}
   Mapping() : snap(0) {}
   void encode(bufferlist &bl) const {

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -71,7 +71,7 @@ class NotifyTimeoutCB : public CancelableContext {
   NotifyRef notif;
   bool canceled; // protected by notif lock
 public:
-  NotifyTimeoutCB(NotifyRef notif) : notif(notif), canceled(false) {}
+  explicit NotifyTimeoutCB(NotifyRef notif) : notif(notif), canceled(false) {}
   void finish(int) {
     notif->osd->watch_lock.Unlock();
     notif->lock.Lock();
@@ -234,7 +234,7 @@ class HandleWatchTimeout : public CancelableContext {
   WatchRef watch;
 public:
   bool canceled; // protected by watch->pg->lock
-  HandleWatchTimeout(WatchRef watch) : watch(watch), canceled(false) {}
+  explicit HandleWatchTimeout(WatchRef watch) : watch(watch), canceled(false) {}
   void cancel() {
     canceled = true;
   }
@@ -258,7 +258,7 @@ class HandleDelayedWatchTimeout : public CancelableContext {
   WatchRef watch;
 public:
   bool canceled;
-  HandleDelayedWatchTimeout(WatchRef watch) : watch(watch), canceled(false) {}
+  explicit HandleDelayedWatchTimeout(WatchRef watch) : watch(watch), canceled(false) {}
   void cancel() {
     canceled = true;
   }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1021,7 +1021,7 @@ void pool_opts_t::dump(Formatter* f) const
 class pool_opts_encoder_t : public boost::static_visitor<>
 {
 public:
-  pool_opts_encoder_t(bufferlist& bl_) : bl(bl_) {}
+  explicit pool_opts_encoder_t(bufferlist& bl_) : bl(bl_) {}
 
   void operator()(std::string s) const {
     ::encode(static_cast<int32_t>(pool_opts_t::STR), bl);
@@ -3284,7 +3284,7 @@ void ObjectModDesc::visit(Visitor *visitor) const
 
 struct DumpVisitor : public ObjectModDesc::Visitor {
   Formatter *f;
-  DumpVisitor(Formatter *f) : f(f) {}
+  explicit DumpVisitor(Formatter *f) : f(f) {}
   void append(uint64_t old_size) {
     f->open_object_section("op");
     f->dump_string("code", "APPEND");

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1007,7 +1007,7 @@ void pool_opts_t::dump(const std::string& name, Formatter* f) const
 void pool_opts_t::dump(Formatter* f) const
 {
   for (opt_mapping_t::iterator i = opt_mapping.begin(); i != opt_mapping.end();
-       i++) {
+       ++i) {
     const std::string& name = i->first;
     const opt_desc_t& desc = i->second;
     opts_t::const_iterator j = opts.find(desc.key);
@@ -1082,7 +1082,7 @@ void pool_opts_t::decode(bufferlist::iterator& bl) {
 ostream& operator<<(ostream& out, const pool_opts_t& opts)
 {
   for (opt_mapping_t::iterator i = opt_mapping.begin(); i != opt_mapping.end();
-       i++) {
+       ++i) {
     const std::string& name = i->first;
     const pool_opts_t::opt_desc_t& desc = i->second;
     pool_opts_t::opts_t::const_iterator j = opts.opts.find(desc.key);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -717,7 +717,7 @@ public:
     epoch(ce.epoch),
     __pad(0) { }
 
-  eversion_t(bufferlist& bl) : __pad(0) { decode(bl); }
+  explicit eversion_t(bufferlist& bl) : __pad(0) { decode(bl); }
 
   static eversion_t max() {
     eversion_t max;
@@ -1939,7 +1939,7 @@ struct pg_hit_set_info_t {
   utime_t begin, end;   ///< time interval
   eversion_t version;   ///< version this HitSet object was written
   bool using_gmt;	///< use gmt for creating the hit_set archive object name
-  pg_hit_set_info_t(bool using_gmt = true)
+  explicit pg_hit_set_info_t(bool using_gmt = true)
     : using_gmt(using_gmt) {}
 
   void encode(bufferlist &bl) const;
@@ -2716,7 +2716,7 @@ struct pg_missing_t {
   struct item {
     eversion_t need, have;
     item() {}
-    item(eversion_t n) : need(n) {}  // have no old version
+    explicit item(eversion_t n) : need(n) {}  // have no old version
     item(eversion_t n, eversion_t h) : need(n), have(h) {}
 
     void encode(bufferlist& bl) const {
@@ -3108,7 +3108,7 @@ struct SnapSet {
   map<snapid_t, uint64_t> clone_size;
 
   SnapSet() : seq(0), head_exists(false) {}
-  SnapSet(bufferlist& bl) {
+  explicit SnapSet(bufferlist& bl) {
     bufferlist::iterator p = bl.begin();
     decode(p);
   }
@@ -3332,14 +3332,14 @@ struct object_info_t {
       data_digest(-1), omap_digest(-1)
   {}
 
-  object_info_t(const hobject_t& s)
+  explicit object_info_t(const hobject_t& s)
     : soid(s),
       user_version(0), size(0), flags((flag_t)0),
       truncate_seq(0), truncate_size(0),
       data_digest(-1), omap_digest(-1)
   {}
 
-  object_info_t(bufferlist& bl) {
+  explicit object_info_t(bufferlist& bl) {
     decode(bl);
   }
   object_info_t operator=(bufferlist& bl) {
@@ -3366,7 +3366,7 @@ struct SnapSetContext {
   bool registered : 1;
   bool exists : 1;
 
-  SnapSetContext(const hobject_t& o) :
+  explicit SnapSetContext(const hobject_t& o) :
     oid(o), ref(0), registered(false), exists(true) { }
 };
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -303,9 +303,11 @@ struct pg_t {
   pg_t() : m_pool(0), m_seed(0), m_preferred(-1) {}
   pg_t(ps_t seed, uint64_t pool, int pref=-1) :
     m_pool(pool), m_seed(seed), m_preferred(pref) {}
+  // cppcheck-suppress noExplicitConstructor
   pg_t(const ceph_pg& cpg) :
     m_pool(cpg.pool), m_seed(cpg.ps), m_preferred((__s16)cpg.preferred) {}
 
+  // cppcheck-suppress noExplicitConstructor
   pg_t(const old_pg_t& opg) {
     *this = opg.v;
   }
@@ -712,6 +714,7 @@ public:
   eversion_t() : version(0), epoch(0), __pad(0) {}
   eversion_t(epoch_t e, version_t v) : version(v), epoch(e), __pad(0) {}
 
+  // cppcheck-suppress noExplicitConstructor
   eversion_t(const ceph_eversion& ce) : 
     version(ce.version),
     epoch(ce.epoch),
@@ -2100,6 +2103,7 @@ struct pg_info_t {
       last_backfill(hobject_t::get_max()),
       last_backfill_bitwise(false)
   { }
+  // cppcheck-suppress noExplicitConstructor
   pg_info_t(spg_t p)
     : pgid(p),
       last_epoch_started(0), last_user_version(0),

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -103,7 +103,7 @@ class Journaler::C_ReadHead : public Context {
   Journaler *ls;
 public:
   bufferlist bl;
-  C_ReadHead(Journaler *l) : ls(l) {}
+  explicit C_ReadHead(Journaler *l) : ls(l) {}
   void finish(int r) {
     ls->_finish_read_head(r, bl);
   }
@@ -125,7 +125,7 @@ class Journaler::C_ProbeEnd : public Context {
   Journaler *ls;
 public:
   uint64_t end;
-  C_ProbeEnd(Journaler *l) : ls(l), end(-1) {}
+  explicit C_ProbeEnd(Journaler *l) : ls(l), end(-1) {}
   void finish(int r) {
     ls->_finish_probe_end(r, end);
   }
@@ -849,7 +849,8 @@ public:
 class Journaler::C_RetryRead : public Context {
   Journaler *ls;
 public:
-  C_RetryRead(Journaler *l) : ls(l) {}
+  explicit C_RetryRead(Journaler *l) : ls(l) {}
+
   void finish(int r) {
     // Should only be called from waitfor_safe i.e. already inside lock
     assert(ls->lock.is_locked_by_me());

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -130,7 +130,7 @@ class ObjectCacher {
     map<loff_t, list<Context*> > waitfor_read;
 
     // cons
-    BufferHead(Object *o) :
+    explicit BufferHead(Object *o) :
       state(STATE_MISSING),
       ref(0),
       dontneed(false),
@@ -424,7 +424,7 @@ class ObjectCacher {
   class FlusherThread : public Thread {
     ObjectCacher *oc;
   public:
-    FlusherThread(ObjectCacher *o) : oc(o) {}
+    explicit FlusherThread(ObjectCacher *o) : oc(o) {}
     void *entry() {
       oc->flusher_entry();
       return 0;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1142,7 +1142,7 @@ private:
   class RequestStateHook : public AdminSocketHook {
     Objecter *m_objecter;
   public:
-    RequestStateHook(Objecter *objecter);
+    explicit RequestStateHook(Objecter *objecter);
     bool call(std::string command, cmdmap_t& cmdmap, std::string format,
 	      bufferlist& out);
   };

--- a/src/rbd_replay/ActionTypes.cc
+++ b/src/rbd_replay/ActionTypes.cc
@@ -36,7 +36,7 @@ void decode_big_endian_string(std::string &str, bufferlist::iterator &it) {
 
 class EncodeVisitor : public boost::static_visitor<void> {
 public:
-  EncodeVisitor(bufferlist &bl) : m_bl(bl) {
+  explicit EncodeVisitor(bufferlist &bl) : m_bl(bl) {
   }
 
   template <typename Action>
@@ -65,7 +65,7 @@ private:
 
 class DumpVisitor : public boost::static_visitor<void> {
 public:
-  DumpVisitor(Formatter *formatter) : m_formatter(formatter) {}
+  explicit DumpVisitor(Formatter *formatter) : m_formatter(formatter) {}
 
   template <typename Action>
   inline void operator()(const Action &action) const {

--- a/src/rbd_replay/Replayer.hpp
+++ b/src/rbd_replay/Replayer.hpp
@@ -77,7 +77,7 @@ private:
 
 class Replayer {
 public:
-  Replayer(int num_action_trackers);
+  explicit Replayer(int num_action_trackers);
 
   ~Replayer();
 

--- a/src/rbd_replay/actions.hpp
+++ b/src/rbd_replay/actions.hpp
@@ -124,7 +124,7 @@ public:
 template <typename ActionType>
 class TypedAction : public Action {
 public:
-  TypedAction(const ActionType &action) : m_action(action) {
+  explicit TypedAction(const ActionType &action) : m_action(action) {
   }
 
   virtual action_id_t id() const {
@@ -193,7 +193,7 @@ protected:
 
 class AioReadAction : public TypedAction<action::AioReadAction> {
 public:
-  AioReadAction(const action::AioReadAction &action)
+  explicit AioReadAction(const action::AioReadAction &action)
     : TypedAction<action::AioReadAction>(action) {
   }
 
@@ -208,7 +208,7 @@ protected:
 
 class ReadAction : public TypedAction<action::ReadAction> {
 public:
-  ReadAction(const action::ReadAction &action)
+  explicit ReadAction(const action::ReadAction &action)
     : TypedAction<action::ReadAction>(action) {
   }
 
@@ -223,7 +223,7 @@ protected:
 
 class AioWriteAction : public TypedAction<action::AioWriteAction> {
 public:
-  AioWriteAction(const action::AioWriteAction &action)
+  explicit AioWriteAction(const action::AioWriteAction &action)
     : TypedAction<action::AioWriteAction>(action) {
   }
 
@@ -238,7 +238,7 @@ protected:
 
 class WriteAction : public TypedAction<action::WriteAction> {
 public:
-  WriteAction(const action::WriteAction &action)
+  explicit WriteAction(const action::WriteAction &action)
     : TypedAction<action::WriteAction>(action) {
   }
 
@@ -253,7 +253,7 @@ protected:
 
 class OpenImageAction : public TypedAction<action::OpenImageAction> {
 public:
-  OpenImageAction(const action::OpenImageAction &action)
+  explicit OpenImageAction(const action::OpenImageAction &action)
     : TypedAction<action::OpenImageAction>(action) {
   }
 
@@ -268,7 +268,7 @@ protected:
 
 class CloseImageAction : public TypedAction<action::CloseImageAction> {
 public:
-  CloseImageAction(const action::CloseImageAction &action)
+  explicit CloseImageAction(const action::CloseImageAction &action)
     : TypedAction<action::CloseImageAction>(action) {
   }
 
@@ -282,7 +282,7 @@ protected:
 
 class AioOpenImageAction : public TypedAction<action::AioOpenImageAction> {
 public:
-  AioOpenImageAction(const action::AioOpenImageAction &action)
+  explicit AioOpenImageAction(const action::AioOpenImageAction &action)
     : TypedAction<action::AioOpenImageAction>(action) {
   }
 
@@ -297,7 +297,7 @@ protected:
 
 class AioCloseImageAction : public TypedAction<action::AioCloseImageAction> {
 public:
-  AioCloseImageAction(const action::AioCloseImageAction &action)
+  explicit AioCloseImageAction(const action::AioCloseImageAction &action)
     : TypedAction<action::AioCloseImageAction>(action) {
   }
 

--- a/src/rbd_replay/rbd-replay-prep.cc
+++ b/src/rbd_replay/rbd-replay-prep.cc
@@ -153,7 +153,7 @@ public:
 	  usage_exit(args[0], "--window requires an argument");
 	}
 	m_window = (uint64_t)(1e9 * atof(args[++i].c_str()));
-      } else if (arg.find("--window=") == 0) {
+      } else if (arg.compare(0, 9, "--window=") == 0) {
 	m_window = (uint64_t)(1e9 * atof(arg.c_str() + sizeof("--window=")));
       } else if (arg == "--anonymize") {
 	m_anonymize = true;
@@ -162,7 +162,7 @@ public:
       } else if (arg == "-h" || arg == "--help") {
 	usage(args[0]);
 	exit(0);
-      } else if (arg.find("-") == 0) {
+      } else if (arg.compare(0, 1, "-") == 0) {
 	usage_exit(args[0], "Unrecognized argument: " + arg);
       } else if (!got_input) {
 	input_file_name = arg;

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -195,7 +195,7 @@ protected:
   multimap<string, ACLGrant> grant_map;
   void _add_grant(ACLGrant *grant);
 public:
-  RGWAccessControlList(CephContext *_cct) : cct(_cct) {}
+  explicit RGWAccessControlList(CephContext *_cct) : cct(_cct) {}
   RGWAccessControlList() : cct(NULL) {}
 
   void set_ctx(CephContext *ctx) {
@@ -293,7 +293,7 @@ protected:
   ACLOwner owner;
 
 public:
-  RGWAccessControlPolicy(CephContext *_cct) : cct(_cct), acl(_cct) {}
+  explicit RGWAccessControlPolicy(CephContext *_cct) : cct(_cct), acl(_cct) {}
   RGWAccessControlPolicy() : cct(NULL), acl(NULL) {}
   virtual ~RGWAccessControlPolicy() {}
 

--- a/src/rgw/rgw_acl_s3.h
+++ b/src/rgw/rgw_acl_s3.h
@@ -57,7 +57,7 @@ public:
 class RGWAccessControlList_S3 : public RGWAccessControlList, public XMLObj
 {
 public:
-  RGWAccessControlList_S3(CephContext *_cct) : RGWAccessControlList(_cct) {}
+  explicit RGWAccessControlList_S3(CephContext *_cct) : RGWAccessControlList(_cct) {}
   ~RGWAccessControlList_S3() {}
 
   bool xml_end(const char *el);
@@ -82,7 +82,7 @@ class RGWEnv;
 class RGWAccessControlPolicy_S3 : public RGWAccessControlPolicy, public XMLObj
 {
 public:
-  RGWAccessControlPolicy_S3(CephContext *_cct) : RGWAccessControlPolicy(_cct) {}
+  explicit RGWAccessControlPolicy_S3(CephContext *_cct) : RGWAccessControlPolicy(_cct) {}
   ~RGWAccessControlPolicy_S3() {}
 
   bool xml_end(const char *el);
@@ -110,7 +110,7 @@ class RGWACLXMLParser_S3 : public RGWXMLParser
 
   XMLObj *alloc_obj(const char *el);
 public:
-  RGWACLXMLParser_S3(CephContext *_cct) : cct(_cct) {}
+  explicit RGWACLXMLParser_S3(CephContext *_cct) : cct(_cct) {}
 };
 
 #endif

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -16,7 +16,7 @@ using namespace std;
 class RGWAccessControlPolicy_SWIFT : public RGWAccessControlPolicy
 {
 public:
-  RGWAccessControlPolicy_SWIFT(CephContext *_cct) : RGWAccessControlPolicy(_cct) {}
+  explicit RGWAccessControlPolicy_SWIFT(CephContext *_cct) : RGWAccessControlPolicy(_cct) {}
   ~RGWAccessControlPolicy_SWIFT() {}
 
   void add_grants(RGWRados *store, list<string>& uids, int perm);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -625,7 +625,7 @@ int bucket_stats(rgw_bucket& bucket, Formatter *formatter)
 class StoreDestructor {
   RGWRados *store;
 public:
-  StoreDestructor(RGWRados *_s) : store(_s) {}
+  explicit StoreDestructor(RGWRados *_s) : store(_s) {}
   ~StoreDestructor() {
     RGWStoreManager::close_storage(store);
   }

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -10,6 +10,7 @@ struct rgw_user {
   std::string id;
 
   rgw_user() {}
+  // cppcheck-suppress noExplicitConstructor
   rgw_user(const std::string& s) {
     from_str(s);
   }

--- a/src/rgw/rgw_client_io.h
+++ b/src/rgw/rgw_client_io.h
@@ -107,7 +107,7 @@ class RGWClientIOStream : private RGWClientIOStreamBuf, public std::istream {
  * ctor is being called prior to construction of any member of this class. */
 
 public:
-  RGWClientIOStream(RGWClientIO &c)
+  explicit RGWClientIOStream(RGWClientIO &c)
     : RGWClientIOStreamBuf(c, 1, 2),
       istream(static_cast<RGWClientIOStreamBuf *>(this)) {
   }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -260,7 +260,7 @@ class NameVal
    string name;
    string val;
  public:
-    NameVal(string nv) : str(nv) {}
+    explicit NameVal(string nv) : str(nv) {}
 
     int parse();
 
@@ -1183,11 +1183,11 @@ struct RGWBucketEnt {
 
   RGWBucketEnt() : size(0), size_rounded(0), creation_time(0), count(0) {}
 
-  RGWBucketEnt(const cls_user_bucket_entry& e) : bucket(e.bucket),
-						 size(e.size), 
-						 size_rounded(e.size_rounded),
-						 creation_time(e.creation_time),
-						 count(e.count) {}
+  explicit RGWBucketEnt(const cls_user_bucket_entry& e) : bucket(e.bucket),
+		  					  size(e.size), 
+			  				  size_rounded(e.size_rounded),
+							  creation_time(e.creation_time),
+							  count(e.count) {}
 
   void convert(cls_user_bucket_entry *b) {
     bucket.convert(&b->bucket);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -622,14 +622,10 @@ struct rgw_bucket {
                     */
 
   rgw_bucket() { }
-  rgw_bucket(const cls_user_bucket& b) {
-    name = b.name;
-    data_pool = b.data_pool;
-    data_extra_pool = b.data_extra_pool;
-    index_pool = b.index_pool;
-    marker = b.marker;
-    bucket_id = b.bucket_id;
-  }
+  rgw_bucket(const cls_user_bucket& b) : name(b.name), data_pool(b.data_pool),
+					 data_extra_pool(b.data_extra_pool),
+					 index_pool(b.index_pool), marker(b.marker),
+					 bucket_id(b.bucket_id) {}
   rgw_bucket(const char *n) : name(n) {
     assert(*n == '.'); // only rgw private buckets should be initialized without pool
     data_pool = index_pool = n;
@@ -1187,13 +1183,11 @@ struct RGWBucketEnt {
 
   RGWBucketEnt() : size(0), size_rounded(0), creation_time(0), count(0) {}
 
-  RGWBucketEnt(const cls_user_bucket_entry& e) {
-    bucket = e.bucket;
-    size = e.size;
-    size_rounded = e.size_rounded;
-    creation_time = e.creation_time;
-    count = e.count;
-  }
+  RGWBucketEnt(const cls_user_bucket_entry& e) : bucket(e.bucket),
+						 size(e.size), 
+						 size_rounded(e.size_rounded),
+						 creation_time(e.creation_time),
+						 count(e.count) {}
 
   void convert(cls_user_bucket_entry *b) {
     bucket.convert(&b->bucket);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -622,10 +622,12 @@ struct rgw_bucket {
                     */
 
   rgw_bucket() { }
+  // cppcheck-suppress noExplicitConstructor
   rgw_bucket(const cls_user_bucket& b) : name(b.name), data_pool(b.data_pool),
 					 data_extra_pool(b.data_extra_pool),
 					 index_pool(b.index_pool), marker(b.marker),
 					 bucket_id(b.bucket_id) {}
+  // cppcheck-suppress noExplicitConstructor
   rgw_bucket(const char *n) : name(n) {
     assert(*n == '.'); // only rgw private buckets should be initialized without pool
     data_pool = index_pool = n;
@@ -986,6 +988,7 @@ struct rgw_obj_key {
   string instance;
 
   rgw_obj_key() {}
+  // cppcheck-suppress noExplicitConstructor
   rgw_obj_key(const string& n) {
     set(n);
   }
@@ -993,6 +996,7 @@ struct rgw_obj_key {
     set(n, i);
   }
 
+  // cppcheck-suppress noExplicitConstructor
   rgw_obj_key(const cls_rgw_obj_key& k) {
     set(k);
   }

--- a/src/rgw/rgw_cors_s3.h
+++ b/src/rgw/rgw_cors_s3.h
@@ -53,6 +53,6 @@ class RGWCORSXMLParser_S3 : public RGWXMLParser
 
   XMLObj *alloc_obj(const char *el);
 public:
-  RGWCORSXMLParser_S3(CephContext *_cct) : cct(_cct) {}
+  explicit RGWCORSXMLParser_S3(CephContext *_cct) : cct(_cct) {}
 };
 #endif /*CEPH_RGW_CORS_S3_H*/

--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -27,7 +27,7 @@ protected:
   int complete_request() { return 0; }
   int send_content_length(uint64_t len);
 public:
-  RGWFCGX(FCGX_Request *_fcgx) : fcgx(_fcgx), status_num(0) {}
+  explicit RGWFCGX(FCGX_Request *_fcgx) : fcgx(_fcgx), status_num(0) {}
   void flush();
 };
 

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -22,7 +22,7 @@ struct plain_stack_entry {
 class RGWFormatter_Plain : public Formatter {
   void reset_buf();
 public:
-  RGWFormatter_Plain(bool use_kv = false);
+  explicit RGWFormatter_Plain(bool use_kv = false);
   virtual ~RGWFormatter_Plain();
 
   virtual void set_status(int status, const char* status_name) {};
@@ -69,7 +69,7 @@ protected:
     formatter = f;
   }
 public:
-  RGWFormatterFlusher(Formatter *f) : formatter(f), flushed(false), started(false) {}
+  explicit RGWFormatterFlusher(Formatter *f) : formatter(f), flushed(false), started(false) {}
   virtual ~RGWFormatterFlusher() {}
 
   void flush() {

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -18,7 +18,7 @@ protected:
   list<pair<string, string> > headers;
 public:
   virtual ~RGWHTTPClient() {}
-  RGWHTTPClient(CephContext *_cct): send_len (0), has_send_len(false), cct(_cct) {}
+  explicit RGWHTTPClient(CephContext *_cct): send_len (0), has_send_len(false), cct(_cct) {}
 
   void append_header(const string& name, const string& val) {
     headers.push_back(pair<string, string>(name, val));

--- a/src/rgw/rgw_loadgen.h
+++ b/src/rgw/rgw_loadgen.h
@@ -40,7 +40,7 @@ public:
   int complete_request();
   int send_content_length(uint64_t len);
 
-  RGWLoadGenIO(RGWLoadGenRequestEnv *_re) : left_to_read(0), req(_re) {}
+  explicit RGWLoadGenIO(RGWLoadGenRequestEnv *_re) : left_to_read(0), req(_re) {}
   void flush();
 };
 

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -95,7 +95,7 @@ class UsageLogger {
   class C_UsageLogTimeout : public Context {
     UsageLogger *logger;
   public:
-    C_UsageLogTimeout(UsageLogger *_l) : logger(_l) {}
+    explicit C_UsageLogTimeout(UsageLogger *_l) : logger(_l) {}
     void finish(int r) {
       logger->flush();
       logger->set_timer();

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -96,7 +96,7 @@ struct RGWRequest
   RGWOp *op;
   utime_t ts;
 
-  RGWRequest(uint64_t id) : id(id), s(NULL), op(NULL) {
+  explicit RGWRequest(uint64_t id) : id(id), s(NULL), op(NULL) {
   }
 
   virtual ~RGWRequest() {}
@@ -139,7 +139,7 @@ class RGWFrontendConfig {
   int parse_config(const string& config, map<string, string>& config_map);
   string framework;
 public:
-  RGWFrontendConfig(const string& _conf) : config(_conf) {}
+  explicit RGWFrontendConfig(const string& _conf) : config(_conf) {}
   int init() {
     int ret = parse_config(config, config_map);
     if (ret < 0)
@@ -901,7 +901,7 @@ public:
 class RGWProcessControlThread : public Thread {
   RGWProcess *pprocess;
 public:
-  RGWProcessControlThread(RGWProcess *_pprocess) : pprocess(_pprocess) {}
+  explicit RGWProcessControlThread(RGWProcess *_pprocess) : pprocess(_pprocess) {}
 
   void *entry() {
     pprocess->run();

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -13,7 +13,7 @@
 struct LogStatusDump {
   RGWMDLogStatus status;
 
-  LogStatusDump(RGWMDLogStatus _status) : status(_status) {}
+  explicit LogStatusDump(RGWMDLogStatus _status) : status(_status) {}
   void dump(Formatter *f) const {
     string s;
     switch (status) {

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -41,7 +41,7 @@ class StoreDestructor {
   RGWRados *store;
 
 public:
-  StoreDestructor(RGWRados *_s) : store(_s) {}
+  explicit StoreDestructor(RGWRados *_s) : store(_s) {}
   ~StoreDestructor() {
     if (store) {
       RGWStoreManager::close_storage(store);

--- a/src/rgw/rgw_object_expirer_core.h
+++ b/src/rgw/rgw_object_expirer_core.h
@@ -62,7 +62,7 @@ protected:
   atomic_t down_flag;
 
 public:
-  RGWObjectExpirer(RGWRados *_store)
+  explicit RGWObjectExpirer(RGWRados *_store)
     : store(_store)
   {}
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -207,7 +207,7 @@ class RGWGetObj_CB : public RGWGetDataCB
 {
   RGWGetObj *op;
 public:
-  RGWGetObj_CB(RGWGetObj *_op) : op(_op) {}
+  explicit RGWGetObj_CB(RGWGetObj *_op) : op(_op) {}
   virtual ~RGWGetObj_CB() {}
 
   int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) {

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -43,7 +43,7 @@ struct RGWOrphanSearchStage {
   string marker;
 
   RGWOrphanSearchStage() : stage(ORPHAN_SEARCH_STAGE_UNKNOWN), shard(0) {}
-  RGWOrphanSearchStage(RGWOrphanSearchStageId _stage) : stage(_stage), shard(0) {}
+  explicit RGWOrphanSearchStage(RGWOrphanSearchStageId _stage) : stage(_stage), shard(0) {}
   RGWOrphanSearchStage(RGWOrphanSearchStageId _stage, int _shard, const string& _marker) : stage(_stage), shard(_shard), marker(_marker) {}
 
   void encode(bufferlist& bl) const {
@@ -127,7 +127,7 @@ class RGWOrphanStore {
   string oid;
 
 public:
-  RGWOrphanStore(RGWRados *_store) : store(_store), oid(RGW_ORPHAN_INDEX_OID) {}
+  explicit RGWOrphanStore(RGWRados *_store) : store(_store), oid(RGW_ORPHAN_INDEX_OID) {}
 
   librados::IoCtx& get_ioctx() { return ioctx; }
 

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -127,9 +127,7 @@ class RGWOrphanStore {
   string oid;
 
 public:
-  RGWOrphanStore(RGWRados *_store) : store(_store) {
-    oid = RGW_ORPHAN_INDEX_OID;
-  }
+  RGWOrphanStore(RGWRados *_store) : store(_store), oid(RGW_ORPHAN_INDEX_OID) {}
 
   librados::IoCtx& get_ioctx() { return ioctx; }
 

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -306,7 +306,7 @@ protected:
   int fetch_stats_from_storage(const rgw_user& user, rgw_bucket& bucket, RGWStorageStats& stats);
 
 public:
-  RGWBucketStatsCache(RGWRados *_store) : RGWQuotaCache<rgw_bucket>(_store, _store->ctx()->_conf->rgw_bucket_quota_cache_size) {
+  explicit RGWBucketStatsCache(RGWRados *_store) : RGWQuotaCache<rgw_bucket>(_store, _store->ctx()->_conf->rgw_bucket_quota_cache_size) {
   }
 
   AsyncRefreshHandler *allocate_refresh_handler(const rgw_user& user, rgw_bucket& bucket) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1300,7 +1300,7 @@ class RGWWatcher : public librados::WatchCtx2 {
   class C_ReinitWatch : public Context {
     RGWWatcher *watcher;
     public:
-      C_ReinitWatch(RGWWatcher *_watcher) : watcher(_watcher) {}
+      explicit C_ReinitWatch(RGWWatcher *_watcher) : watcher(_watcher) {}
       void finish(int r) {
         watcher->reinit();
       }
@@ -6121,7 +6121,7 @@ struct get_obj_data : public RefCountedObject {
   Throttle throttle;
   list<bufferlist> read_list;
 
-  get_obj_data(CephContext *_cct)
+  explicit get_obj_data(CephContext *_cct)
     : cct(_cct),
       rados(NULL), ctx(NULL),
       total_read(0), lock("get_obj_data"), data_lock("get_obj_data::data_lock"),
@@ -7421,7 +7421,7 @@ class RGWGetUserStatsContext : public RGWGetUserHeader_CB {
   RGWGetUserStats_CB *cb;
 
 public:
-  RGWGetUserStatsContext(RGWGetUserStats_CB *_cb) : cb(_cb) {}
+  explicit RGWGetUserStatsContext(RGWGetUserStats_CB *_cb) : cb(_cb) {}
   void handle_response(int r, cls_user_header& header) {
     cls_user_stats& hs = header.stats;
     if (r >= 0) {
@@ -7942,7 +7942,7 @@ int RGWRados::pool_iterate(RGWPoolIterCtx& ctx, uint32_t num, vector<RGWObjEnt>&
 struct RGWAccessListFilterPrefix : public RGWAccessListFilter {
   string prefix;
 
-  RGWAccessListFilterPrefix(const string& _prefix) : prefix(_prefix) {}
+  explicit RGWAccessListFilterPrefix(const string& _prefix) : prefix(_prefix) {}
   virtual bool filter(string& name, string& key) {
     return (prefix.compare(key.substr(0, prefix.size())) == 0);
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4122,8 +4122,10 @@ int RGWRados::copy_obj_to_remote_dest(RGWObjState *astate,
   RGWRESTStreamWriteRequest *out_stream_req;
 
   int ret = rest_master_conn->put_obj_init(user_id, dest_obj, astate->size, src_attrs, &out_stream_req);
-  if (ret < 0)
+  if (ret < 0) {
+    delete out_stream_req;
     return ret;
+  }
 
   ret = read_op.iterate(0, astate->size - 1, out_stream_req->get_out_cb());
   if (ret < 0)

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -629,8 +629,7 @@ struct RGWObjState {
   RGWObjState() : is_atomic(false), has_attrs(0), exists(false),
                   size(0), mtime(0), epoch(0), fake_tag(false), has_manifest(false),
                   has_data(false), prefetch_data(false), keep_tail(false), is_olh(false) {}
-  RGWObjState(const RGWObjState& rhs) {
-    obj = rhs.obj;
+  RGWObjState(const RGWObjState& rhs) : obj (rhs.obj) {
     is_atomic = rhs.is_atomic;
     has_attrs = rhs.has_attrs;
     exists = rhs.exists;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -464,7 +464,7 @@ public:
     obj_iterator() : manifest(NULL) {
       init();
     }
-    obj_iterator(RGWObjManifest *_m) : manifest(_m) {
+    explicit obj_iterator(RGWObjManifest *_m) : manifest(_m) {
       init();
       if (!manifest->empty()) {
         seek(0);
@@ -1130,7 +1130,7 @@ public:
     OPSTATE_CANCELLED   = 5,
   };
 
-  RGWOpState(RGWRados *_store);
+  explicit RGWOpState(RGWRados *_store);
 
   int state_from_str(const string& s, OpState *state);
   int set_state(const string& client_id, const string& op_id, const string& object, OpState state);
@@ -1161,7 +1161,7 @@ protected:
   rgw_bucket bucket;
   map<RGWObjCategory, RGWStorageStats> *stats;
 public:
-  RGWGetBucketStats_CB(rgw_bucket& _bucket) : bucket(_bucket), stats(NULL) {}
+  explicit RGWGetBucketStats_CB(rgw_bucket& _bucket) : bucket(_bucket), stats(NULL) {}
   virtual ~RGWGetBucketStats_CB() {}
   virtual void handle_response(int r) = 0;
   virtual void set_response(map<RGWObjCategory, RGWStorageStats> *_stats) {
@@ -1174,7 +1174,7 @@ protected:
   rgw_user user;
   RGWStorageStats stats;
 public:
-  RGWGetUserStats_CB(const rgw_user& _user) : user(_user) {}
+  explicit RGWGetUserStats_CB(const rgw_user& _user) : user(_user) {}
   virtual ~RGWGetUserStats_CB() {}
   virtual void handle_response(int r) = 0;
   virtual void set_response(RGWStorageStats& _stats) {
@@ -1213,7 +1213,7 @@ struct RGWObjectCtx {
   map<rgw_obj, RGWObjState> objs_state;
   void *user_ctx;
 
-  RGWObjectCtx(RGWRados *_store) : store(_store), user_ctx(NULL) { }
+  explicit RGWObjectCtx(RGWRados *_store) : store(_store), user_ctx(NULL) { }
   RGWObjectCtx(RGWRados *_store, void *_user_ctx) : store(_store), user_ctx(_user_ctx) { }
 
   RGWObjState *get_state(rgw_obj& obj);
@@ -1264,7 +1264,7 @@ class RGWRados
   class C_Tick : public Context {
     RGWRados *rados;
   public:
-    C_Tick(RGWRados *_r) : rados(_r) {}
+    explicit C_Tick(RGWRados *_r) : rados(_r) {}
     void finish(int r) {
       rados->tick();
     }
@@ -1509,7 +1509,7 @@ public:
         rgw_cache_entry_info *cache_info;
       } read_params;
 
-      Read(RGWRados::SystemObject *_source) : source(_source) {}
+      explicit Read(RGWRados::SystemObject *_source) : source(_source) {}
 
       int stat(RGWObjVersionTracker *objv_tracker);
       int read(int64_t ofs, int64_t end, bufferlist& bl, RGWObjVersionTracker *objv_tracker);
@@ -1524,7 +1524,7 @@ public:
     librados::IoCtx index_ctx;
     string bucket_obj;
 
-    BucketShard(RGWRados *_store) : store(_store), shard_id(-1) {}
+    explicit BucketShard(RGWRados *_store) : store(_store), shard_id(-1) {}
     int init(rgw_bucket& _bucket, rgw_obj& obj);
   };
 
@@ -1609,7 +1609,7 @@ public:
         Params() : lastmod(NULL), read_size(NULL), obj_size(NULL), attrs(NULL), perr(NULL) {}
       } params;
 
-      Read(RGWRados::Object *_source) : source(_source) {}
+      explicit Read(RGWRados::Object *_source) : source(_source) {}
 
       int prepare(int64_t *pofs, int64_t *pend);
       int read(int64_t ofs, int64_t end, bufferlist& bl);
@@ -1641,7 +1641,7 @@ public:
                  if_match(NULL), if_nomatch(NULL), olh_epoch(0), delete_at(0) {}
       } meta;
 
-      Write(RGWRados::Object *_target) : target(_target) {}
+      explicit Write(RGWRados::Object *_target) : target(_target) {}
 
       int write_meta(uint64_t size,  map<std::string, bufferlist>& attrs);
       int write_data(const char *data, uint64_t ofs, uint64_t len, bool exclusive);
@@ -1670,7 +1670,7 @@ public:
         DeleteResult() : delete_marker(false) {}
       } result;
       
-      Delete(RGWRados::Object *_target) : target(_target) {}
+      explicit Delete(RGWRados::Object *_target) : target(_target) {}
 
       int delete_obj();
     };
@@ -1698,7 +1698,7 @@ public:
       } state;
 
 
-      Stat(RGWRados::Object *_source) : source(_source) {}
+      explicit Stat(RGWRados::Object *_source) : source(_source) {}
 
       int stat_async();
       int wait();
@@ -1775,7 +1775,7 @@ public:
       } params;
 
     public:
-      List(RGWRados::Bucket *_target) : target(_target) {}
+      explicit List(RGWRados::Bucket *_target) : target(_target) {}
 
       int list_objects(int max, vector<RGWObjEnt> *result, map<string, bool> *common_prefixes, bool *is_truncated);
       rgw_obj_key& get_next_marker() {

--- a/src/rgw/rgw_replica_log.h
+++ b/src/rgw/rgw_replica_log.h
@@ -45,7 +45,7 @@ protected:
   RGWRados *store;
   int open_ioctx(librados::IoCtx& ctx, const string& pool);
 
-  RGWReplicaLogger(RGWRados *_store);
+  explicit RGWReplicaLogger(RGWRados *_store);
 
   int update_bound(const string& oid, const string& pool,
                    const string& daemon_id, const string& marker,
@@ -105,7 +105,7 @@ class RGWReplicaBucketLogger : private RGWReplicaLogger {
   string obj_name(const rgw_bucket& bucket, int shard_id, bool index_by_instance);
 
 public:
-  RGWReplicaBucketLogger(RGWRados *_store);
+  explicit RGWReplicaBucketLogger(RGWRados *_store);
   int update_bound(const rgw_bucket& bucket, int shard_id, const string& daemon_id,
                    const string& marker, const utime_t& time,
                    const list<RGWReplicaItemMarker> *entries);

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1290,7 +1290,7 @@ int RGWHandler_ObjStore::allocate_formatter(struct req_state *s, int default_typ
 int RGWHandler_ObjStore::validate_tenant_name(string const& t)
 {
   const char *p = t.c_str();
-  for (int i = 0; i < t.size(); i++) {
+  for (unsigned int i = 0; i < t.size(); i++) {
     char ch = p[i];
     if (!(isalnum(ch) || ch == '_'))
       return -ERR_INVALID_TENANT_NAME;

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -272,7 +272,7 @@ int RGWRESTSimpleRequest::forward_request(RGWAccessKey& key, req_info& info, siz
 class RGWRESTStreamOutCB : public RGWGetDataCB {
   RGWRESTStreamWriteRequest *req;
 public:
-  RGWRESTStreamOutCB(RGWRESTStreamWriteRequest *_req) : req(_req) {}
+  explicit RGWRESTStreamOutCB(RGWRESTStreamWriteRequest *_req) : req(_req) {}
   int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len); /* callback for object iteration when sending data */
 };
 

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -53,7 +53,7 @@ int RGWRESTConn::forward(const rgw_user& uid, req_info& info, obj_version *objv,
 class StreamObjData : public RGWGetDataCB {
   rgw_obj obj;
 public:
-    StreamObjData(rgw_obj& _obj) : obj(_obj) {}
+    explicit StreamObjData(rgw_obj& _obj) : obj(_obj) {}
 };
 
 int RGWRESTConn::put_obj_init(const rgw_user& uid, rgw_obj& obj, uint64_t obj_size,

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -351,7 +351,7 @@ private:
   }
 
 public:
-  RGW_Auth_S3_Keystone_ValidateToken(CephContext *_cct)
+  explicit RGW_Auth_S3_Keystone_ValidateToken(CephContext *_cct)
       : RGWHTTPClient(_cct) {
     get_str_list(cct->_conf->rgw_keystone_accepted_roles, roles_list);
   }
@@ -493,7 +493,7 @@ class RGWRESTMgr_S3 : public RGWRESTMgr {
 private:
   bool enable_s3website;
 public:
-  RGWRESTMgr_S3(bool enable_s3website) : enable_s3website(false) { this->enable_s3website = enable_s3website; }
+  explicit RGWRESTMgr_S3(bool enable_s3website) : enable_s3website(false) { this->enable_s3website = enable_s3website; }
   virtual ~RGWRESTMgr_S3() {}
 
   virtual RGWHandler *get_handler(struct req_state *s);

--- a/src/rgw/rgw_rest_s3website.h
+++ b/src/rgw/rgw_rest_s3website.h
@@ -73,7 +73,7 @@ private:
    bool is_errordoc_request;
 public:
   RGWGetObj_ObjStore_S3Website() : is_errordoc_request(false) {}
-  RGWGetObj_ObjStore_S3Website(bool is_errordoc_request) : is_errordoc_request(false) { this->is_errordoc_request = is_errordoc_request; }
+  explicit RGWGetObj_ObjStore_S3Website(bool is_errordoc_request) : is_errordoc_request(false) { this->is_errordoc_request = is_errordoc_request; }
   ~RGWGetObj_ObjStore_S3Website() {}
   int send_response_data_error();
   int send_response_data(bufferlist& bl, off_t ofs, off_t len);

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -646,7 +646,7 @@ struct UserQuotas {
 
   UserQuotas() {}
 
-  UserQuotas(RGWUserInfo& info) : bucket_quota(info.bucket_quota), 
+  explicit UserQuotas(RGWUserInfo& info) : bucket_quota(info.bucket_quota), 
 				  user_quota(info.user_quota) {}
 
   void dump(Formatter *f) const {

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -61,7 +61,7 @@ protected:
   int check_revoked();
 public:
 
-  RGWSwift(CephContext *_cct) : cct(_cct), keystone_revoke_thread(NULL) {
+  explicit RGWSwift(CephContext *_cct) : cct(_cct), keystone_revoke_thread(NULL) {
     init();
   }
   ~RGWSwift() {

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -526,7 +526,7 @@ private:
   int add(RGWUserAdminOpState& op_state, std::string *err_msg, bool defer_save);
   int remove(RGWUserAdminOpState& op_state, std::string *err_msg, bool defer_save);
 public:
-  RGWAccessKeyPool(RGWUser* usr);
+  explicit RGWAccessKeyPool(RGWUser* usr);
   ~RGWAccessKeyPool();
 
   int init(RGWUserAdminOpState& op_state);
@@ -561,7 +561,7 @@ private:
   int remove(RGWUserAdminOpState& op_state, std::string *err_msg, bool defer_save);
   int modify(RGWUserAdminOpState& op_state, std::string *err_msg, bool defer_save);
 public:
-  RGWSubUserPool(RGWUser *user);
+  explicit RGWSubUserPool(RGWUser *user);
   ~RGWSubUserPool();
 
   bool exists(std::string subuser);
@@ -586,7 +586,7 @@ private:
   int remove(RGWUserAdminOpState& op_state, std::string *err_msg, bool defer_save);
 
 public:
-  RGWUserCapPool(RGWUser *user);
+  explicit RGWUserCapPool(RGWUser *user);
   ~RGWUserCapPool();
 
   int init(RGWUserAdminOpState& op_state);

--- a/src/rgw/rgw_xml.h
+++ b/src/rgw/rgw_xml.h
@@ -95,7 +95,7 @@ public:
   struct err {
     string message;
 
-    err(const string& m) : message(m) {}
+    explicit err(const string& m) : message(m) {}
   };
 
   class XMLParser : public RGWXMLParser {
@@ -104,7 +104,7 @@ public:
     virtual ~XMLParser() {}
   } parser;
 
-  RGWXMLDecoder(bufferlist& bl) {
+  explicit RGWXMLDecoder(bufferlist& bl) {
     if (!parser.parse(bl.c_str(), bl.length(), 1)) {
       cout << "RGWXMLDecoder::err()" << std::endl;
       throw RGWXMLDecoder::err("failed to parse XML input");

--- a/src/test/ObjectMap/KeyValueDBMemory.cc
+++ b/src/test/ObjectMap/KeyValueDBMemory.cc
@@ -26,7 +26,7 @@ protected:
   map<pair<string,string>, bufferlist>::iterator it;
 
 public:
-  WholeSpaceMemIterator(KeyValueDBMemory *db) : db(db), ready(false) { }
+  explicit WholeSpaceMemIterator(KeyValueDBMemory *db) : db(db), ready(false) { }
   virtual ~WholeSpaceMemIterator() { }
 
   int seek_to_first() {
@@ -238,7 +238,7 @@ public:
    * keep it in mind.
    */
 
-  WholeSpaceSnapshotMemIterator(KeyValueDBMemory *db) :
+  explicit WholeSpaceSnapshotMemIterator(KeyValueDBMemory *db) :
     WholeSpaceMemIterator(db) { }
   ~WholeSpaceSnapshotMemIterator() {
     delete db;

--- a/src/test/ObjectMap/KeyValueDBMemory.h
+++ b/src/test/ObjectMap/KeyValueDBMemory.h
@@ -16,7 +16,7 @@ public:
   std::map<std::pair<string,string>,bufferlist> db;
 
   KeyValueDBMemory() { }
-  KeyValueDBMemory(KeyValueDBMemory *db) : db(db->db) { }
+  explicit KeyValueDBMemory(KeyValueDBMemory *db) : db(db->db) { }
   virtual ~KeyValueDBMemory() { }
 
   virtual int init(string _opt) {
@@ -62,7 +62,7 @@ public:
     list<Context *> on_commit;
     KeyValueDBMemory *db;
 
-    TransactionImpl_(KeyValueDBMemory *db) : db(db) {}
+    explicit TransactionImpl_(KeyValueDBMemory *db) : db(db) {}
 
 
     struct SetOp : public Context {

--- a/src/test/TestTimers.cc
+++ b/src/test/TestTimers.cc
@@ -26,7 +26,7 @@ namespace
 class TestContext : public Context
 {
 public:
-  TestContext(int num_)
+  explicit TestContext(int num_)
     : num(num_)
   {
   }
@@ -50,7 +50,7 @@ protected:
 class StrictOrderTestContext : public TestContext
 {
 public:
-  StrictOrderTestContext (int num_)
+  explicit StrictOrderTestContext (int num_)
     : TestContext(num_)
   {
   }

--- a/src/test/admin_socket.cc
+++ b/src/test/admin_socket.cc
@@ -30,7 +30,7 @@
 class AdminSocketTest
 {
 public:
-  AdminSocketTest(AdminSocket *asokc)
+  explicit AdminSocketTest(AdminSocket *asokc)
     : m_asokc(asokc)
   {
   }

--- a/src/test/bench/bencher.cc
+++ b/src/test/bench/bencher.cc
@@ -10,7 +10,7 @@
 template<typename T>
 struct C_Holder : public Context {
   T obj;
-  C_Holder(
+  explicit C_Holder(
     T obj)
     : obj(obj) {}
   void finish(int r) {
@@ -20,13 +20,13 @@ struct C_Holder : public Context {
 
 struct OnDelete {
   Context *c;
-  OnDelete(Context *c) : c(c) {}
+  explicit OnDelete(Context *c) : c(c) {}
   ~OnDelete() { c->complete(0); }
 };
 
 struct Cleanup : public Context {
   Bencher *bench;
-  Cleanup(Bencher *bench) : bench(bench) {}
+  explicit Cleanup(Bencher *bench) : bench(bench) {}
   void finish(int r) {
     bench->complete_op();
   }

--- a/src/test/bench/distribution.h
+++ b/src/test/bench/distribution.h
@@ -127,7 +127,7 @@ public:
 class Uniform : public Distribution<uint64_t> {
   uint64_t val;
 public:
-  Uniform(uint64_t val) : val(val) {}
+  explicit Uniform(uint64_t val) : val(val) {}
   virtual uint64_t operator()() {
     return val;
   }

--- a/src/test/bench/dumb_backend.h
+++ b/src/test/bench/dumb_backend.h
@@ -42,7 +42,7 @@ class DumbBackend : public Backend {
   class SyncThread : public Thread {
     DumbBackend *backend;
   public:
-    SyncThread(DumbBackend *backend) : backend(backend) {}
+    explicit SyncThread(DumbBackend *backend) : backend(backend) {}
     void *entry() {
       backend->sync_loop();
       return 0;

--- a/src/test/bench/rados_backend.h
+++ b/src/test/bench/rados_backend.h
@@ -10,7 +10,7 @@
 class RadosBackend : public Backend {
   librados::IoCtx *ioctx;
 public:
-  RadosBackend(
+  explicit RadosBackend(
     librados::IoCtx *ioctx)
     : ioctx(ioctx) {}
   void write(

--- a/src/test/bench/rbd_backend.h
+++ b/src/test/bench/rbd_backend.h
@@ -10,7 +10,7 @@
 class RBDBackend : public Backend {
   map<string, ceph::shared_ptr<librbd::Image> > *m_images;
 public:
-  RBDBackend(map<string, ceph::shared_ptr<librbd::Image> > *images)
+  explicit RBDBackend(map<string, ceph::shared_ptr<librbd::Image> > *images)
     : m_images(images) {}
   void write(
     const string &oid,

--- a/src/test/bench/small_io_bench_fs.cc
+++ b/src/test/bench/small_io_bench_fs.cc
@@ -29,7 +29,7 @@ using namespace std;
 
 struct MorePrinting : public DetailedStatCollector::AdditionalPrinting {
   CephContext *cct;
-  MorePrinting(CephContext *cct) : cct(cct) {}
+  explicit MorePrinting(CephContext *cct) : cct(cct) {}
   void operator()(std::ostream *out) {
     bufferlist bl;
     Formatter *f = Formatter::create("json-pretty");

--- a/src/test/bench_log.cc
+++ b/src/test/bench_log.cc
@@ -13,7 +13,7 @@ struct T : public Thread {
   int num;
   set<int> myset;
   map<int,string> mymap;
-  T(int n) : num(n) {
+  explicit T(int n) : num(n) {
     myset.insert(123);
     myset.insert(456);
     mymap[1] = "foo";

--- a/src/test/ceph_argparse.cc
+++ b/src/test/ceph_argparse.cc
@@ -27,7 +27,7 @@
 class VectorContainer
 {
 public:
-  VectorContainer(const char** arr_) {
+  explicit VectorContainer(const char** arr_) {
     for (const char **a = arr_; *a; ++a) {
       const char *str = (const char*)strdup(*a);
       arr.push_back(str);

--- a/src/test/common/ObjectContents.h
+++ b/src/test/common/ObjectContents.h
@@ -29,7 +29,7 @@ public:
   private:
     unsigned int get_state(uint64_t pos);
   public:
-    Iterator(ObjectContents *parent) :
+    explicit Iterator(ObjectContents *parent) :
       parent(parent), iter(parent->seeds.end()),
       current_state(0), current_val(0), pos(-1) {
       seek_to_first();
@@ -77,7 +77,7 @@ public:
     seeds[0] = 0;
   }
 
-  ObjectContents(bufferlist::iterator &bp) {
+  explicit ObjectContents(bufferlist::iterator &bp) {
     ::decode(_size, bp);
     ::decode(seeds, bp);
     ::decode(written, bp);

--- a/src/test/common/test_async_compressor.cc
+++ b/src/test/common/test_async_compressor.cc
@@ -102,7 +102,7 @@ class SyntheticWorkload {
   static const uint64_t MAX_INFLIGHT = 128;
 
  public:
-  SyntheticWorkload(AsyncCompressor *ac): async_compressor(ac), rng(time(NULL)) {
+  explicit SyntheticWorkload(AsyncCompressor *ac): async_compressor(ac), rng(time(NULL)) {
     for (int i = 0; i < 100; i++) {
       bufferlist bl;
       boost::uniform_int<> u(4096, 1<<24);

--- a/src/test/common/test_crc32c.cc
+++ b/src/test/common/test_crc32c.cc
@@ -162,14 +162,15 @@ static uint32_t crc_check_table[] = {
 
 TEST(Crc32c, Range) {
   int len = sizeof(crc_check_table) / sizeof(crc_check_table[0]);
-  const char *b = (const char *)malloc(len);
-  memset((void *)b, 1, len);
+  unsigned char *b = (unsigned char *)malloc(len);
+  memset(b, 1, len);
   uint32_t crc = 0;
   uint32_t *check = crc_check_table;
   for (int i = 0 ; i < len; i++, check++) {
-    crc = ceph_crc32c(crc, (unsigned char *)b+i, len-i);
+    crc = ceph_crc32c(crc, b+i, len-i);
     ASSERT_EQ(crc, *check);
   }
+  free(b);
 }
 
 static uint32_t crc_zero_check_table[] = {
@@ -241,15 +242,16 @@ static uint32_t crc_zero_check_table[] = {
 
 TEST(Crc32c, RangeZero) {
   int len = sizeof(crc_zero_check_table) / sizeof(crc_zero_check_table[0]);
-  const char *b = (const char *)malloc(len);
-  memset((void *)b, 0, len);
+  unsigned char *b = (unsigned char *)malloc(len);
+  memset(b, 0, len);
   uint32_t crc = 1; /* when checking zero buffer we want to start with a non zero crc, otherwise
                        all the results are going to be zero */
   uint32_t *check = crc_zero_check_table;
   for (int i = 0 ; i < len; i++, check++) {
-    crc = ceph_crc32c(crc, (unsigned char *)b+i, len-i);
+    crc = ceph_crc32c(crc, b+i, len-i);
     ASSERT_EQ(crc, *check);
   }
+  free(b);
 }
 
 TEST(Crc32c, RangeNull) {

--- a/src/test/common/test_lru.cc
+++ b/src/test/common/test_lru.cc
@@ -23,7 +23,7 @@
 class Item : public LRUObject {
 public:
   int id;
-  Item(int v) : id(v) {}
+  explicit Item(int v) : id(v) {}
 };
 
 

--- a/src/test/common/test_prioritized_queue.cc
+++ b/src/test/common/test_prioritized_queue.cc
@@ -164,7 +164,7 @@ TEST_F(PrioritizedQueueTest, fairness_by_class) {
 template <typename T>
 struct Greater {
   const T rhs;
-  Greater(const T& v) : rhs(v)
+  explicit Greater(const T& v) : rhs(v)
   {}
   bool operator()(const T& lhs) const {
     return lhs > rhs;

--- a/src/test/compressor/compressor_plugin_example.cc
+++ b/src/test/compressor/compressor_plugin_example.cc
@@ -23,7 +23,7 @@
 class CompressorPluginExample : public CompressionPlugin {
 public:
 
-  CompressorPluginExample(CephContext* cct) : CompressionPlugin(cct)
+  explicit CompressorPluginExample(CephContext* cct) : CompressionPlugin(cct)
   {}
 
   virtual int factory(CompressorRef *cs,

--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -69,7 +69,7 @@ public:
     default_ctor++;
   }
 
-  ConstructorCounter(const T& data_)
+  explicit ConstructorCounter(const T& data_)
     : data(data_)
   {
     one_arg_ctor++;

--- a/src/test/encoding/ceph_dencoder.cc
+++ b/src/test/encoding/ceph_dencoder.cc
@@ -349,7 +349,6 @@ int main(int argc, const char **argv)
 	exit(1);
       }
       features = atoi(*i);
-
     } else if (*i == string("encode")) {
       if (!den) {
 	cerr << "must first select type with 'type <name>'" << std::endl;
@@ -449,6 +448,11 @@ int main(int argc, const char **argv)
       int n = atoi(*i);
       err = den->select_generated(n);
     } else if (*i == string("is_deterministic")) {
+      if (!den) {
+	cerr << "must first select type with 'type <name>'" << std::endl;
+	usage(cerr);
+	exit(1);
+      }
       if (den->is_deterministic())
 	exit(0);
       else

--- a/src/test/librados/list.cc
+++ b/src/test/librados/list.cc
@@ -808,7 +808,7 @@ TEST_F(LibRadosListPP, EnumerateObjectsPP) {
     std::vector<ObjectItem> result;
     int r = ioctx.object_list(c, end, 12, &result, &c);
     ASSERT_GE(r, 0);
-    ASSERT_EQ(r, result.size());
+    ASSERT_EQ(r, (int)result.size());
     for (int i = 0; i < r; ++i) {
       auto oid = result[i].oid;
       if (saw_obj.count(oid)) {

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -1123,7 +1123,7 @@ check_buffers(char *good_buf, char *temp_buf, unsigned offset, unsigned size)
 					unsigned bad = short_at(&temp_buf[i]);
 				        prt("0x%5x\t0x%04x\t0x%04x", offset,
 				            short_at(&good_buf[offset]), bad);
-					unsigned op = temp_buf[offset & 1 ? i+1 : i];
+					unsigned op = temp_buf[(offset & 1) ? i+1 : i];
 				        prt("\t0x%5x\n", n);
 					if (op)
 						prt("operation# (mod 256) for "

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -47,7 +47,7 @@ public:
 
   class WatchCtx : public librados::WatchCtx2 {
   public:
-    WatchCtx(TestImageWatcher &parent) : m_parent(parent), m_handle(0) {}
+    explicit WatchCtx(TestImageWatcher &parent) : m_parent(parent), m_handle(0) {}
 
     int watch(const librbd::ImageCtx &ictx) {
       m_header_oid = ictx.header_oid;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -3316,7 +3316,7 @@ TEST_F(TestLibRBD, ResizeViaLockOwner)
 
 class RBDWriter : public Thread {
  public:
-   RBDWriter(librbd::Image &image) : m_image(image) {};
+   explicit RBDWriter(librbd::Image &image) : m_image(image) {};
  protected:
   void *entry() {
     librbd::image_info_t info;

--- a/src/test/messenger/simple_dispatcher.h
+++ b/src/test/messenger/simple_dispatcher.h
@@ -24,7 +24,7 @@ private:
   Messenger *messenger;
   uint64_t dcount;
 public:
-  SimpleDispatcher(Messenger *msgr);
+  explicit SimpleDispatcher(Messenger *msgr);
   virtual ~SimpleDispatcher();
 
   uint64_t get_dcount() { return dcount; }

--- a/src/test/messenger/xio_dispatcher.h
+++ b/src/test/messenger/xio_dispatcher.h
@@ -24,7 +24,7 @@ private:
   Messenger *messenger;
   uint64_t dcount;
 public:
-  XioDispatcher(Messenger *msgr);
+  explicit XioDispatcher(Messenger *msgr);
   virtual ~XioDispatcher();
 
   uint64_t get_dcount() { return dcount; }

--- a/src/test/mon/test-mon-msg.cc
+++ b/src/test/mon/test-mon-msg.cc
@@ -59,7 +59,7 @@ protected:
 
 public:
 
-  MonClientHelper(CephContext *cct_)
+  explicit MonClientHelper(CephContext *cct_)
     : Dispatcher(cct_),
       cct(cct_),
       monc(cct_),

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -90,7 +90,7 @@ class TestStub : public Dispatcher
 
   struct C_Tick : public Context {
     TestStub *s;
-    C_Tick(TestStub *stub) : s(stub) {}
+    explicit C_Tick(TestStub *stub) : s(stub) {}
     void finish(int r) {
       generic_dout(20) << "C_Tick::" << __func__ << dendl;
       if (r == -ECANCELED) {
@@ -230,7 +230,7 @@ class ClientStub : public TestStub
   }
 
  public:
-  ClientStub(CephContext *cct)
+  explicit ClientStub(CephContext *cct)
     : TestStub(cct, "client"),
       gen((int) time(NULL))
   { }
@@ -328,7 +328,7 @@ class OSDStub : public TestStub
 
   struct C_CreatePGs : public Context {
     OSDStub *s;
-    C_CreatePGs(OSDStub *stub) : s(stub) {}
+    explicit C_CreatePGs(OSDStub *stub) : s(stub) {}
     void finish(int r) {
       if (r == -ECANCELED) {
 	generic_dout(20) << "C_CreatePGs::" << __func__

--- a/src/test/msgr/test_async_driver.cc
+++ b/src/test/msgr/test_async_driver.cc
@@ -272,7 +272,7 @@ class Worker : public Thread {
 
  public:
   EventCenter center;
-  Worker(CephContext *c): cct(c), done(false), center(c) {
+  explicit Worker(CephContext *c): cct(c), done(false), center(c) {
     center.init(100);
   }
   void stop() {

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -76,7 +76,7 @@ class FakeDispatcher : public Dispatcher {
     uint64_t count;
     ConnectionRef con;
 
-    Session(ConnectionRef c): RefCountedObject(g_ceph_context), lock("FakeDispatcher::Session::lock"), count(0), con(c) {
+    explicit Session(ConnectionRef c): RefCountedObject(g_ceph_context), lock("FakeDispatcher::Session::lock"), count(0), con(c) {
     }
     uint64_t get_count() { return count; }
   };
@@ -89,7 +89,7 @@ class FakeDispatcher : public Dispatcher {
   bool got_connect;
   bool loopback;
 
-  FakeDispatcher(bool s): Dispatcher(g_ceph_context), lock("FakeDispatcher::lock"),
+  explicit FakeDispatcher(bool s): Dispatcher(g_ceph_context), lock("FakeDispatcher::lock"),
                           is_server(s), got_new(false), got_remote_reset(false),
                           got_connect(false), loopback(false) {}
   bool ms_can_fast_dispatch_any() const { return true; }
@@ -1238,7 +1238,7 @@ class MarkdownDispatcher : public Dispatcher {
   bool last_mark;
  public:
   atomic_t count;
-  MarkdownDispatcher(bool s): Dispatcher(g_ceph_context), lock("MarkdownDispatcher::lock"),
+  explicit MarkdownDispatcher(bool s): Dispatcher(g_ceph_context), lock("MarkdownDispatcher::lock"),
                               last_mark(false), count(0) {}
   bool ms_can_fast_dispatch_any() const { return false; }
   bool ms_can_fast_dispatch(Message *m) const {

--- a/src/test/objectstore/TestObjectStoreState.h
+++ b/src/test/objectstore/TestObjectStoreState.h
@@ -98,7 +98,7 @@ public:
   int m_next_pool;
 
  public:
-  TestObjectStoreState(ObjectStore *store) :
+  explicit TestObjectStoreState(ObjectStore *store) :
     m_next_coll_nr(0), m_num_objs_per_coll(10), m_num_objects(0),
     m_max_in_flight(0), m_finished_lock("Finished Lock"), m_next_pool(1) {
     m_in_flight.set(0);
@@ -133,7 +133,7 @@ public:
     TestObjectStoreState *m_state;
 
    public:
-    C_OnFinished(TestObjectStoreState *state) : m_state(state) { }
+    explicit C_OnFinished(TestObjectStoreState *state) : m_state(state) { }
 
     void finish(int r) {
       Mutex::Locker locker(m_state->m_finished_lock);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1617,7 +1617,7 @@ class MixedGenerator : public ObjectGenerator {
 public:
   unsigned seq;
   int64_t poolid;
-  MixedGenerator(int64_t p) : seq(0), poolid(p) {}
+  explicit MixedGenerator(int64_t p) : seq(0), poolid(p) {}
   ghobject_t create_object(gen_type *gen) {
     char buf[100];
     snprintf(buf, sizeof(buf), "OBJ_%u", seq);
@@ -1672,7 +1672,7 @@ public:
 
   struct EnterExit {
     const char *msg;
-    EnterExit(const char *m) : msg(m) {
+    explicit EnterExit(const char *m) : msg(m) {
       //cout << pthread_self() << " enter " << msg << std::endl;
     }
     ~EnterExit() {

--- a/src/test/objectstore/workload_generator.h
+++ b/src/test/objectstore/workload_generator.h
@@ -120,7 +120,7 @@ class WorkloadGenerator : public TestObjectStoreState {
   void do_stats();
 
 public:
-  WorkloadGenerator(vector<const char*> args);
+  explicit WorkloadGenerator(vector<const char*> args);
   ~WorkloadGenerator() {
     m_store->umount();
   }
@@ -129,7 +129,7 @@ public:
     WorkloadGenerator *wrkldgen_state;
 
   public:
-    C_OnReadable(WorkloadGenerator *state)
+    explicit C_OnReadable(WorkloadGenerator *state)
      :TestObjectStoreState::C_OnFinished(state), wrkldgen_state(state) { }
 
     void finish(int r)

--- a/src/test/objectstore_bench.cc
+++ b/src/test/objectstore_bench.cc
@@ -36,6 +36,7 @@ static void usage()
 // helper class for bytes with units
 struct byte_units {
   size_t v;
+  // cppcheck-suppress noExplicitConstructor
   byte_units(size_t v) : v(v) {}
 
   bool parse(const std::string &val, std::string *err);

--- a/src/test/old/testmpi.cc
+++ b/src/test/old/testmpi.cc
@@ -12,7 +12,7 @@ using namespace std;
 class Pinger : public Dispatcher {
 public:
   Messenger *messenger;
-  Pinger(Messenger *m) : messenger(m) {
+  explicit Pinger(Messenger *m) : messenger(m) {
     m->set_dispatcher(this);
   }
   void dispatch(Message *m) {

--- a/src/test/old/testnewbuffers.cc
+++ b/src/test/old/testnewbuffers.cc
@@ -13,7 +13,7 @@ using namespace std;
   class Th : public Thread {
   public:
 	bufferlist bl;
-	Th(bufferlist& o) : bl(o) { }
+	explicit Th(bufferlist& o) : bl(o) { }
 	
 	void *entry() {
 	  //cout << "start" << endl;

--- a/src/test/osd/Object.h
+++ b/src/test/osd/Object.h
@@ -127,7 +127,7 @@ public:
   class RandWrap {
   public:
     unsigned int state;
-    RandWrap(unsigned int seed)
+    explicit RandWrap(unsigned int seed)
     {
       state = seed;
     }
@@ -305,7 +305,7 @@ public:
     std::list<std::pair<ceph::shared_ptr<ContentsGenerator>,
 	      ContDesc> >::iterator cur_cont;
     
-    iterator(ObjectDesc &obj) :
+    explicit iterator(ObjectDesc &obj) :
       pos(0), obj(obj) {
       limit = obj.layers.begin()->first->get_length(obj.layers.begin()->second);
       cur_cont = obj.layers.begin();

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -122,7 +122,7 @@ public:
    */
   struct CallbackInfo {
     uint64_t id;
-    CallbackInfo(uint64_t id) : id(id) {}
+    explicit CallbackInfo(uint64_t id) : id(id) {}
     virtual ~CallbackInfo() {};
   };
 

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -111,7 +111,7 @@ public:
     : num(n),
       context(context),
       stat(stat),
-      done(0)
+      done(false)
   {}
 
   virtual ~TestOp() {};
@@ -526,11 +526,10 @@ public:
   string oid;
   librados::ObjectWriteOperation op;
   librados::AioCompletion *comp;
-  bool done;
   RemoveAttrsOp(int n, RadosTestContext *context,
 	       const string &oid,
 	       TestOpStat *stat)
-    : TestOp(n, context, stat), oid(oid), comp(NULL), done(false)
+    : TestOp(n, context, stat), oid(oid), comp(NULL)
   {}
 
   void _begin()
@@ -620,13 +619,12 @@ public:
   string oid;
   librados::ObjectWriteOperation op;
   librados::AioCompletion *comp;
-  bool done;
   SetAttrsOp(int n,
 	     RadosTestContext *context,
 	     const string &oid,
 	     TestOpStat *stat)
     : TestOp(n, context, stat),
-      oid(oid), comp(NULL), done(false)
+      oid(oid), comp(NULL)
   {}
 
   void _begin()
@@ -1482,7 +1480,6 @@ class RollbackOp : public TestOp {
 public:
   string oid;
   int roll_back_to;
-  bool done;
   librados::ObjectWriteOperation zero_write_op1;
   librados::ObjectWriteOperation zero_write_op2;
   librados::ObjectWriteOperation op;
@@ -1497,7 +1494,6 @@ public:
 	     TestOpStat *stat = 0)
     : TestOp(n, context, stat),
       oid(_oid), roll_back_to(-1), 
-      done(false),
       comps(3, NULL),
       last_finished(-1), outstanding(3)
   {}
@@ -1747,7 +1743,6 @@ public:
 };
 
 class HitSetListOp : public TestOp {
-  bool done;
   librados::AioCompletion *comp1, *comp2;
   uint32_t hash;
   std::list< std::pair<time_t, time_t> > ls;
@@ -1759,7 +1754,7 @@ public:
 	       uint32_t hash,
 	       TestOpStat *stat = 0)
     : TestOp(n, context, stat),
-      done(false), comp1(NULL), comp2(NULL),
+      comp1(NULL), comp2(NULL),
       hash(hash)
   {}
 

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -265,7 +265,7 @@ public:
 
 struct TestHandler : public PGLog::LogEntryHandler {
   list<hobject_t> &removed;
-  TestHandler(list<hobject_t> &removed) : removed(removed) {}
+  explicit TestHandler(list<hobject_t> &removed) : removed(removed) {}
 
   void rollback(
     const pg_log_entry_t &entry) {}

--- a/src/test/osd/hitset.cc
+++ b/src/test/osd/hitset.cc
@@ -18,7 +18,7 @@ class HitSetTestStrap {
 public:
   HitSet *hitset;
 
-  HitSetTestStrap(HitSet *h) : hitset(h) {}
+  explicit HitSetTestStrap(HitSet *h) : hitset(h) {}
 
   void fill(unsigned count) {
     char buf[50];

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -1074,7 +1074,7 @@ protected:
   public:
     ObjectContext &obc;
 
-    Thread_read_lock(ObjectContext& _obc) :
+    explicit Thread_read_lock(ObjectContext& _obc) :
       obc(_obc)
     {
     }
@@ -1089,7 +1089,7 @@ protected:
   public:
     ObjectContext &obc;
 
-    Thread_write_lock(ObjectContext& _obc) :
+    explicit Thread_write_lock(ObjectContext& _obc) :
       obc(_obc)
     {
     }

--- a/src/test/perf_local.cc
+++ b/src/test/perf_local.cc
@@ -329,7 +329,7 @@ class CondPingPong {
   class Consumer : public Thread {
     CondPingPong *p;
    public:
-    Consumer(CondPingPong *p): p(p) {}
+    explicit Consumer(CondPingPong *p): p(p) {}
     void* entry() {
       p->consume();
       return 0;
@@ -466,7 +466,7 @@ class CenterWorker : public Thread {
 
  public:
   EventCenter center;
-  CenterWorker(CephContext *c): cct(c), done(false), center(c) {
+  explicit CenterWorker(CephContext *c): cct(c), done(false), center(c) {
     center.init(100);
   }
   void stop() {
@@ -486,7 +486,7 @@ class CountEvent: public EventCallback {
   atomic_t *count;
 
  public:
-  CountEvent(atomic_t *atomic): count(atomic) {}
+  explicit CountEvent(atomic_t *atomic): count(atomic) {}
   void do_request(int id) {
     count->dec();
   }

--- a/src/test/system/cross_process_sem.h
+++ b/src/test/system/cross_process_sem.h
@@ -35,6 +35,6 @@ public:
   int reinit(int dval);
 
 private:
-  CrossProcessSem(struct cross_process_sem_data_t *data);
+  explicit CrossProcessSem(struct cross_process_sem_data_t *data);
   struct cross_process_sem_data_t *m_data;
 };

--- a/src/test/test_snap_mapper.cc
+++ b/src/test/test_snap_mapper.cc
@@ -45,7 +45,7 @@ class PausyAsyncMap : public MapCacher::StoreDriver<string, bufferlist> {
   typedef ceph::shared_ptr<_Op> Op;
   struct Remove : public _Op {
     set<string> to_remove;
-    Remove(const set<string> &to_remove) : to_remove(to_remove) {}
+    explicit Remove(const set<string> &to_remove) : to_remove(to_remove) {}
     void operate(map<string, bufferlist> *store) {
       for (set<string>::iterator i = to_remove.begin();
 	   i != to_remove.end();
@@ -56,7 +56,7 @@ class PausyAsyncMap : public MapCacher::StoreDriver<string, bufferlist> {
   };
   struct Insert : public _Op {
     map<string, bufferlist> to_insert;
-    Insert(const map<string, bufferlist> &to_insert) : to_insert(to_insert) {}
+    explicit Insert(const map<string, bufferlist> &to_insert) : to_insert(to_insert) {}
     void operate(map<string, bufferlist> *store) {
       for (map<string, bufferlist>::iterator i = to_insert.begin();
 	   i != to_insert.end();
@@ -68,7 +68,7 @@ class PausyAsyncMap : public MapCacher::StoreDriver<string, bufferlist> {
   };
   struct Callback : public _Op {
     Context *context;
-    Callback(Context *c) : context(c) {}
+    explicit Callback(Context *c) : context(c) {}
     void operate(map<string, bufferlist> *store) {
       context->complete(0);
     }
@@ -103,7 +103,7 @@ private:
     bool paused;
     list<Op> queue;
   public:
-    Doer(PausyAsyncMap *parent) :
+    explicit Doer(PausyAsyncMap *parent) :
       parent(parent), lock("Doer lock"), stopping(0), paused(false) {}
     virtual void *entry() {
       while (1) {

--- a/src/test/test_stress_watch.cc
+++ b/src/test/test_stress_watch.cc
@@ -40,7 +40,7 @@ public:
 
 struct WatcherUnwatcher : public Thread {
   string pool;
-  WatcherUnwatcher(string& _pool) : pool(_pool) {}
+  explicit WatcherUnwatcher(string& _pool) : pool(_pool) {}
 
   void *entry() {
     Rados cluster;

--- a/src/test/test_xlist.cc
+++ b/src/test/test_xlist.cc
@@ -10,7 +10,7 @@ struct Item {
   xlist<Item*>::item xitem;
   int val;
 
-  Item(int v) :
+  explicit Item(int v) :
     xitem(this),
     val(v)
   {}

--- a/src/tools/RadosDump.h
+++ b/src/tools/RadosDump.h
@@ -161,7 +161,7 @@ struct object_begin {
   // of object processing.
   object_info_t oi;
 
-  object_begin(const ghobject_t &hoid): hoid(hoid) { }
+  explicit object_begin(const ghobject_t &hoid): hoid(hoid) { }
   object_begin() { }
 
   // If superblock doesn't include CEPH_FS_FEATURE_INCOMPAT_SHARDS then
@@ -218,8 +218,8 @@ struct data_section {
 
 struct attr_section {
   map<string,bufferlist> data;
-  attr_section(const map<string,bufferlist> &data) : data(data) { }
-  attr_section(map<string, bufferptr> &data_)
+  explicit attr_section(const map<string,bufferlist> &data) : data(data) { }
+  explicit attr_section(map<string, bufferptr> &data_)
   {
     for (std::map<std::string, bufferptr>::iterator i = data_.begin();
          i != data_.end(); ++i) {
@@ -245,7 +245,7 @@ struct attr_section {
 
 struct omap_hdr_section {
   bufferlist hdr;
-  omap_hdr_section(bufferlist hdr) : hdr(hdr) { }
+  explicit omap_hdr_section(bufferlist hdr) : hdr(hdr) { }
   omap_hdr_section() { }
 
   void encode(bufferlist& bl) const {
@@ -262,7 +262,7 @@ struct omap_hdr_section {
 
 struct omap_section {
   map<string, bufferlist> omap;
-  omap_section(const map<string, bufferlist> &omap) :
+  explicit omap_section(const map<string, bufferlist> &omap) :
     omap(omap) { }
   omap_section() { }
 

--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -37,7 +37,7 @@ class TraceIter {
   unsigned idx;
   MonitorDBStore::TransactionRef t;
 public:
-  TraceIter(string fname) : fd(-1), idx(-1) {
+  explicit TraceIter(string fname) : fd(-1), idx(-1) {
     fd = ::open(fname.c_str(), O_RDONLY);
     t.reset(new MonitorDBStore::Transaction);
   }

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1795,7 +1795,7 @@ int do_set_omaphdr(ObjectStore *store, coll_t coll,
 struct do_fix_lost : public action_on_object_t {
   ObjectStore::Sequencer *osr;
 
-  do_fix_lost(ObjectStore::Sequencer *_osr) : osr(_osr) {}
+  explicit do_fix_lost(ObjectStore::Sequencer *_osr) : osr(_osr) {}
 
   virtual int call(ObjectStore *store, coll_t coll,
 		   ghobject_t &ghobj, object_info_t &oi) {

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -1406,7 +1406,7 @@ int MetadataDriver::find_or_create_dirfrag(
     bufferlist fnode_bl;
     fnode_t blank_fnode;
     blank_fnode.version = 1;
-    blank_fnode.damage_flags |= (DAMAGE_RSTATS | DAMAGE_RSTATS);
+    blank_fnode.damage_flags |= (DAMAGE_STATS | DAMAGE_RSTATS);
     blank_fnode.encode(fnode_bl);
 
 

--- a/src/tools/cephfs/TableTool.cc
+++ b/src/tools/cephfs/TableTool.cc
@@ -277,7 +277,7 @@ public:
 class InoTableHandler : public TableHandler<InoTable>
 {
   public:
-  InoTableHandler(mds_rank_t r)
+  explicit InoTableHandler(mds_rank_t r)
     : TableHandler(r, "inotable", true)
   {}
 

--- a/src/tools/rados/PoolDump.h
+++ b/src/tools/rados/PoolDump.h
@@ -25,7 +25,7 @@ namespace librados {
 class PoolDump : public RadosDump
 {
   public:
-    PoolDump(int file_fd_) : RadosDump(file_fd_, false) {}
+    explicit PoolDump(int file_fd_) : RadosDump(file_fd_, false) {}
     int dump(librados::IoCtx *io_ctx);
 };
 

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -569,7 +569,7 @@ public:
     utime_t now = ceph_clock_now(g_ceph_context);
     now -= start_time;
     uint64_t ns = now.nsec();
-    float total = ns / 1000000000;
+    float total = (float) ns / 1000000000.0;
     total += now.sec();
     return total;
   }

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -542,7 +542,7 @@ public:
     librados::AioCompletion *completion;
 
     LoadGenOp() : id(0), type(0), off(0), len(0), lg(NULL), completion(NULL) {}
-    LoadGenOp(LoadGen *_lg) : id(0), type(0), off(0), len(0), lg(_lg), completion(NULL) {}
+    explicit LoadGenOp(LoadGen *_lg) : id(0), type(0), off(0), len(0), lg(_lg), completion(NULL) {}
   };
 
   int max_op;
@@ -577,7 +577,7 @@ public:
   Mutex lock;
   Cond cond;
 
-  LoadGen(Rados *_rados) : rados(_rados), going_down(false), lock("LoadGen") {
+  explicit LoadGen(Rados *_rados) : rados(_rados), going_down(false), lock("LoadGen") {
     read_percent = 80;
     min_obj_len = 1024;
     max_obj_len = 5ull * 1024ull * 1024ull * 1024ull;

--- a/src/tools/rbd/action/BenchWrite.cc
+++ b/src/tools/rbd/action/BenchWrite.cc
@@ -64,7 +64,7 @@ struct rbd_bencher {
   Cond cond;
   int in_flight;
 
-  rbd_bencher(librbd::Image *i)
+  explicit rbd_bencher(librbd::Image *i)
     : image(i),
       lock("rbd_bencher::lock"),
       in_flight(0)

--- a/src/tools/rbd/action/Journal.cc
+++ b/src/tools/rbd/action/Journal.cc
@@ -113,7 +113,7 @@ static int do_show_journal_status(librados::IoCtx& io_ctx,
     f->dump_unsigned("active_set", active_set);
     f->open_object_section("registered_clients");
     for (std::set<cls::journal::Client>::iterator c =
-          registered_clients.begin(); c != registered_clients.end(); c++) {
+          registered_clients.begin(); c != registered_clients.end(); ++c) {
       c->dump(f);
     }
     f->close_section();
@@ -124,7 +124,7 @@ static int do_show_journal_status(librados::IoCtx& io_ctx,
     std::cout << "active_set: " << active_set << std::endl;
     std::cout << "registered clients: " << std::endl;
     for (std::set<cls::journal::Client>::iterator c =
-          registered_clients.begin(); c != registered_clients.end(); c++) {
+          registered_clients.begin(); c != registered_clients.end(); ++c) {
       std::cout << "\t" << *c << std::endl;
     }
   }

--- a/src/tools/rbd/action/Journal.cc
+++ b/src/tools/rbd/action/Journal.cc
@@ -262,7 +262,7 @@ public:
 protected:
   struct ReplayHandler : public ::journal::ReplayHandler {
     JournalPlayer *journal;
-    ReplayHandler(JournalPlayer *_journal) : journal(_journal) {}
+    explicit ReplayHandler(JournalPlayer *_journal) : journal(_journal) {}
 
     virtual void get() {}
     virtual void put() {}

--- a/src/tools/rbd/action/MergeDiff.cc
+++ b/src/tools/rbd/action/MergeDiff.cc
@@ -377,7 +377,7 @@ static int do_merge_diff(const char *first, const char *second,
 done:
   if (pd > 2)
     close(pd);
-  if (sd > 2)
+  if (sd)
     close(sd);
   if (fd > 2)
     close(fd);

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -66,7 +66,7 @@ static int call_nbd_cmd(const po::variables_map &vm,
   }
 
   for (std::vector<const char*>::const_iterator p = args.begin();
-       p != args.end(); p++)
+       p != args.end(); ++p)
     process.add_cmd_arg(*p);
 
   if (process.spawn()) {


### PR DESCRIPTION
Fixing Coverity issues like:
- USE_AFTER_FREE
- UNREACHABLE
- NEGATIVE_RETURNS
- FORWARD_NULL
- UNINTENDED_INTEGER_DIVISION
- UNINIT_CTOR
- RESOURCE_LEAK
- CTOR_DTOR_LEAK

Other fixes:
- make constructors with one argument explicit
- replace string::find() with compare() for performance reasons
- remove unused variable
- fix manpage for ceph --admin-daemon
- fix and clarify some expressions and calculations
- add tag for cppcheck to suppress intentional memleak
- call free after malloc 
- fix reassignment of variables before use
- fix null pointer deref
- init members in ctor init list
- fix class member hiding member from base

