### PR TITLE
ceph.spec.in: re-re-drop fdupes

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -650,12 +650,6 @@ mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/ceph/bootstrap-osd
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/ceph/bootstrap-mds
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/ceph/bootstrap-rgw
 
-%if 0%{?suse_version}
-# Fedora seems to have some problems with this macro, use it only on SUSE
-%fdupes -s $RPM_BUILD_ROOT/%{python_sitelib}
-%fdupes %buildroot
-%endif
-
 %clean
 rm -rf $RPM_BUILD_ROOT
 


### PR DESCRIPTION
The %fdupes call was dropped by 53072b9019caf72e0313b2804ea174237ed7da33
Later, it got accidentally reinstated by ceb93e8e69e125c9358f63b0099e7509b6624bcf

Signed-off-by: Nathan Cutler <ncutler@suse.com>