### PR TITLE
rgw, qa: integrate object storage tests of Tempest with Ceph QA suite

### DIFF
--- a/qa/workunits/rgw/tempest.sh
+++ b/qa/workunits/rgw/tempest.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+#
+# Script to run Tempest's test for verifying radosgw compliance
+# with Swift API (a.k.a OpenStack Object Storage API v1).
+set -ex
+
+KEYSTONE_HOME_DIR=/tmp/keystone
+KEYSTONE_REPO_URL=https://git.openstack.org/openstack/keystone.git
+KEYSTONE_RELEASE=stable/kilo
+KEYSTONE_IP=127.0.0.1
+KEYSTONE_PORT=5010
+KEYSTONE_PORT_ADMIN=35367
+
+RADOSGW_URL=http://127.0.0.1:8000/swift/v1
+
+keystone_download()
+{
+  rm -rf ${KEYSTONE_HOME_DIR}
+  mkdir -p ${KEYSTONE_HOME_DIR}
+
+  git clone --quiet -- ${KEYSTONE_REPO_URL} ${KEYSTONE_HOME_DIR}
+  cd ${KEYSTONE_HOME_DIR} \
+      && git checkout ${KEYSTONE_RELEASE}
+}
+
+keystone_make_venv()
+{
+  cd ${KEYSTONE_HOME_DIR}
+
+  python tools/install_venv.py > /dev/null
+}
+
+keystone_configure()
+{
+  cd ${KEYSTONE_HOME_DIR}
+
+  cp etc/keystone.conf.sample etc/keystone.conf
+
+  sed -e "s/#public_port = 5000/public_port = ${KEYSTONE_PORT}/" \
+      -i etc/keystone.conf
+  sed -e "s/#admin_port = 35357/admin_port = ${KEYSTONE_PORT_ADMIN}/" \
+      -i etc/keystone.conf
+
+  # We also have to create DB schema for Keystone.
+  tools/with_venv.sh keystone-manage db_sync
+}
+
+keystone_stop()
+{
+  if [[ -n "${KEYSTONE_SHELL_PID}" ]]; then
+    kill -HUP ${KEYSTONE_SHELL_PID}
+  fi
+}
+
+keystone_start()
+{
+  cd ${KEYSTONE_HOME_DIR}
+
+  trap keystone_stop EXIT
+
+  # tools/with_env.sh cannot be used here due to problems with
+  # tearing down Keystone. We need to start a new shell instead,
+  # activate the venv in its context and run keystone-all.
+  (
+    source .venv/bin/activate
+    trap 'kill $(jobs -p)' EXIT
+    keystone-all &
+    wait
+  ) &
+
+  # Save PID of the subshell spawned for Keystone controll.
+  KEYSTONE_SHELL_PID=$!
+
+  # FIXME: a dirty hack
+  sleep 2
+}
+
+get_id()
+{
+  echo `"$@" | grep ' id ' | awk '{print $4}'`
+}
+
+keystone_put_authinfo()
+{
+  cd ${KEYSTONE_HOME_DIR}
+
+  export OS_AUTH_URL="http://${KEYSTONE_IP}:${KEYSTONE_PORT}/v2.0/"
+  export SERVICE_ENDPOINT="http://${KEYSTONE_IP}:${KEYSTONE_PORT_ADMIN}/v2.0/"
+  export SERVICE_TOKEN=ADMIN
+
+  # tenants
+  ADMIN_TENANT_ID=$(get_id tools/with_venv.sh keystone tenant-create \
+                            --name admin \
+                            --description "Admin Tenant")
+
+  TEMPEST_TENANT_ID=$(get_id tools/with_venv.sh keystone tenant-create \
+                            --name tempest \
+                            --description "Tempest")
+
+  # users
+  ADMIN_USER_ID=$(get_id tools/with_venv.sh keystone user-create \
+                            --name admin \
+                            --pass ${SERVICE_TOKEN})
+
+  TEMPEST_USER1_ID=$(get_id tools/with_venv.sh keystone user-create \
+                            --name tempest_u1 \
+                            --pass tempest \
+                            --tenant-id "${TEMPEST_TENANT_ID}")
+
+  TEMPEST_USER2_ID=$(get_id tools/with_venv.sh keystone user-create \
+                            --name tempest_u2 \
+                            --pass tempest \
+                            --tenant-id "${TEMPEST_TENANT_ID}")
+
+  # roles
+  ADMIN_ROLE_ID=$(get_id tools/with_venv.sh keystone role-create \
+                            --name admin)
+
+  MEMBER_ROLE_ID=$(get_id tools/with_venv.sh keystone role-create \
+                            --name Member)
+
+  # users privileges
+  tools/with_venv.sh keystone user-role-add \
+                            --user-id ${ADMIN_USER_ID} \
+                            --role-id ${ADMIN_ROLE_ID} \
+                            --tenant-id ${ADMIN_TENANT_ID}
+
+  tools/with_venv.sh keystone user-role-add \
+                            --user-id ${TEMPEST_USER1_ID} \
+                            --role-id ${MEMBER_ROLE_ID} \
+                            --tenant-id ${TEMPEST_TENANT_ID}
+
+  tools/with_venv.sh keystone user-role-add \
+                            --user-id ${TEMPEST_USER2_ID} \
+                            --role-id ${MEMBER_ROLE_ID} \
+                            --tenant-id ${TEMPEST_TENANT_ID}
+
+  # keystone service
+  KEYSTONE_SERVICE_ID=$(get_id tools/with_venv.sh keystone service-create \
+                            --name keystone \
+                            --type identity \
+                            --description "Keystone Identity Service")
+
+  tools/with_venv.sh keystone endpoint-create --region RegionOne \
+                            --service-id ${KEYSTONE_SERVICE_ID} \
+                            --publicurl "http://127.0.1:\$(public_port)s/v2.0" \
+                            --adminurl "http://127.0.0.1:\$(admin_port)s/v2.0" \
+                            --internalurl "http://127.0.0.1:\$(public_port)s/v2.0"
+
+  # object store service
+  SWIFT_SERVICE_ID=$(get_id tools/with_venv.sh keystone service-create \
+                            --name swift \
+                            --type "object-store" \
+                            --description "Swift Service")
+
+  tools/with_venv.sh keystone endpoint-create --region RegionOne \
+                            --service-id ${SWIFT_SERVICE_ID} \
+                            --publicurl "${RADOSGW_URL}" \
+                            --adminurl "${RADOSGW_URL}" \
+                            --internalurl "${RADOSGW_URL}"
+}
+
+deploy_keystone()
+{
+  keystone_download
+
+  if [[ -z "${KESTONE_SKIP_VENV}" ]]; then
+    keystone_make_venv
+  fi
+
+  keystone_configure
+  keystone_start
+  keystone_put_authinfo
+}
+
+
+deploy_keystone

--- a/qa/workunits/rgw/tempest/etc/accounts.yaml
+++ b/qa/workunits/rgw/tempest/etc/accounts.yaml
@@ -1,0 +1,11 @@
+# The number of accounts required can be estimated as CONCURRENCY x 2
+# Valid fields for credentials are defined in the descendants of
+# auth.Credentials - see KeystoneV[2|3]Credentials.CONF_ATTRIBUTES
+
+- username: 'tempest_u1'
+  tenant_name: 'tempest'
+  password: 'tempest'
+
+- username: 'tempest_u2'
+  tenant_name: 'tempest'
+  password: 'tempest'

--- a/qa/workunits/rgw/tempest/etc/tempest.conf
+++ b/qa/workunits/rgw/tempest/etc/tempest.conf
@@ -1,0 +1,25 @@
+[DEFAULT]
+lock_path = /tmp
+
+[auth]
+test_accounts_file = etc/accounts.yaml
+
+[identity]
+uri = http://<KEYSTONE_IP>:<KEYSTONE_PORT>/v2.0/
+username = admin
+admin_role = admin
+password = ADMIN
+admin_username = admin
+admin_tenant_name = admin
+admin_password = ADMIN
+
+[identity-feature-enabled]
+trust = false
+api_v2 = true
+api_v3 = false
+
+[object-storage]
+endpoint_type = publicURL
+container_sync_timeout = 10
+operator_role = Member
+reseller_admin_role = admin

--- a/src/test/radosgw-tempest.sh
+++ b/src/test/radosgw-tempest.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Mirantis
+#
+# Author: Radoslaw Zarzynski <rzarzynski@mirantis.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+
+RGW_PARAMS='--rgw_swift_enforce_content_length=true
+            --rgw_keystone_url=http://127.0.0.1:35367
+            --rgw keystone_accepted_roles=tempest,admin
+            --rgw_keystone_admin_token=ADMIN' \
+MON=1 OSD=3 CEPH_START='mon osd -r' CEPH_PORT=7212 test/vstart_wrapper.sh \
+    ../qa/workunits/rgw/tempest.sh

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -697,8 +697,9 @@ do_rgw()
     fi
 
     RGWSUDO=
-    [ $CEPH_RGW_PORT -lt 1024 ] && RGWSUDO=sudo
-    $RGWSUDO $CEPH_BIN/radosgw -c $conf_fn --log-file=${CEPH_OUT_DIR}/rgw.log ${RGWDEBUG} --debug-ms=1
+    [ ${CEPH_RGW_PORT} -lt 1024 ] && RGWSUDO=sudo
+    ${RGWSUDO} ${CEPH_BIN}/radosgw -c ${conf_fn} --log-file=${CEPH_OUT_DIR}/rgw.log \
+	    --pid-file=${CEPH_OUT_DIR}/rgw.pid ${RGWDEBUG} ${RGW_PARAMS}
 
     # Create S3 user
     local akey='0555b35654ad1656d804'


### PR DESCRIPTION
This PR is an very early result of works on Tempest integration. We still need to:
- improve cleaning,
- load test list from file in order to facilitate test masking,
- add a trigger for `make check` or teuthology.
