### PR TITLE
ceph-objectstore-tool: delete ObjectStore::Sequencer after umount

### DIFF
--- a/src/tools/ceph_objectstore_tool.h
+++ b/src/tools/ceph_objectstore_tool.h
@@ -25,13 +25,15 @@ class ObjectStoreTool : public RadosDump
     {}
 
     int do_import(ObjectStore *store, OSDSuperblock& sb, bool force,
-        std::string pgidstr);
+		  std::string pgidstr,
+		  ObjectStore::Sequencer &osr);
     int do_export(ObjectStore *fs, coll_t coll, spg_t pgid,
           pg_info_t &info, epoch_t map_epoch, __u8 struct_ver,
           const OSDSuperblock& superblock,
           map<epoch_t,pg_interval_t> &past_intervals);
     int get_object(ObjectStore *store, coll_t coll,
-        bufferlist &bl, OSDMap &curmap, bool *skipped_objects);
+		   bufferlist &bl, OSDMap &curmap, bool *skipped_objects,
+		   ObjectStore::Sequencer &osr);
     int export_file(
         ObjectStore *store, coll_t cid, ghobject_t &obj);
     int export_files(ObjectStore *store, coll_t coll);


### PR DESCRIPTION
An ObjectStore::Sequencer provided to an ObjectStore must not be
deallocated before umount. The ObjectStore::Sequencer may hold a pointer
to the instance with no reference counting. If a Context completes after
the ObjectStore::Sequencer is deleted, it could try to use it and fail.

http://tracker.ceph.com/issues/13176 Fixes: #13176

Signed-off-by: Loic Dachary <ldachary@redhat.com>