### PR TITLE
pybind/cephfs: fix DirEntry helpers

### DIFF
--- a/src/ceph-detect-init/.gitignore
+++ b/src/ceph-detect-init/.gitignore
@@ -10,4 +10,4 @@ build
 wheelhouse*
 *.log
 *.trs
-
+.cache

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -501,7 +501,8 @@ int* ErasureCodeShec::shec_reedsolomon_coding_matrix(int is_single)
         if (true) {
           double r_e1;
           r_e1 = shec_calc_recovery_efficiency1(k, m1, m2, c1, c2);
-          if (r_e1 < min_r_e1){
+          if (min_r_e1 - r_e1 > std::numeric_limits<double>::epsilon() &&
+	      r_e1 < min_r_e1) {
             min_r_e1 = r_e1;
             c1_best = c1;
             m1_best = m1;

--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -124,12 +124,7 @@ public:
 private:
   virtual int parse(const ErasureCodeProfile &profile) = 0;
 
-  virtual double shec_calc_recovery_efficiency1(int k, int m1, int m2, int c1, int c2)
-  // http://tracker.ceph.com/issues/12936 shec fails i386 make check
-#if defined(__i386__) && defined(__GNUC__)
-    __attribute__((optimize(0)))
-#endif    
-    ;
+  virtual double shec_calc_recovery_efficiency1(int k, int m1, int m2, int c1, int c2);
   virtual int shec_make_decoding_matrix(bool prepare,
                                         int *want, int *avails,
                                         int *decoding_matrix,

--- a/src/pybind/cephfs.py
+++ b/src/pybind/cephfs.py
@@ -156,13 +156,13 @@ class DirEntry(namedtuple('DirEntry',
     DT_REG = 0xA
     DT_LNK = 0xC
     def is_dir(self):
-        return self.d_type == DT_DIR
+        return self.d_type == self.DT_DIR
 
     def is_symbol_file(self):
-        return self.d_type == DT_LNK
+        return self.d_type == self.DT_LNK
 
     def is_file(self):
-        return self.d_type == DT_REG
+        return self.d_type == self.DT_REG
 
 StatResult = namedtuple('StatResult',
                         ["st_dev", "st_ino", "st_mode", "st_nlink", "st_uid",


### PR DESCRIPTION
These were referring to constants incorrectly, would
throw exception if called.

Signed-off-by: John Spray <john.spray@redhat.com>