### PR TITLE
pybind/cephfs: fix DirEntry helpers

### DIFF
--- a/src/pybind/cephfs.py
+++ b/src/pybind/cephfs.py
@@ -156,13 +156,13 @@ class DirEntry(namedtuple('DirEntry',
     DT_REG = 0xA
     DT_LNK = 0xC
     def is_dir(self):
-        return self.d_type == DT_DIR
+        return self.d_type == self.DT_DIR
 
     def is_symbol_file(self):
-        return self.d_type == DT_LNK
+        return self.d_type == self.DT_LNK
 
     def is_file(self):
-        return self.d_type == DT_REG
+        return self.d_type == self.DT_REG
 
 StatResult = namedtuple('StatResult',
                         ["st_dev", "st_ino", "st_mode", "st_nlink", "st_uid",


### PR DESCRIPTION
These were referring to constants incorrectly, would
throw exception if called.

Signed-off-by: John Spray <john.spray@redhat.com>