### PR TITLE
FileStore::mount No close fsid_fd\basedir_fd\current_fd

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -1643,9 +1643,6 @@ int FileStore::mount()
     }
   }
 
-  // all okay.
-  return 0;
-
 close_current_fd:
   VOID_TEMP_FAILURE_RETRY(::close(current_fd));
   current_fd = -1;


### PR DESCRIPTION
FileStore::mount No close fsid_fd\basedir_fd\current_fd

Fixes: #13289
Signed-off-by: ren.huanwen@zte.com.cn