### PR TITLE
bugfix: should call md_config_t::remove_observer on shutdown

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -988,6 +988,11 @@ void MDSDaemon::suicide()
     tick_event = 0;
   }
 
+  //because add_observer is called after set_up_admin_socket
+  //so we can use asok_hook to avoid assert in the remove_observer
+  if (asok_hook != NULL) 
+    g_conf->remove_observer(this);
+
   clean_up_admin_socket();
 
   // Inform MDS we are going away, then shut down beacon

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -853,6 +853,8 @@ void Monitor::shutdown()
 
   state = STATE_SHUTDOWN;
 
+  g_conf->remove_observer(this);
+
   if (admin_hook) {
     AdminSocket* admin_socket = cct->get_admin_socket();
     admin_socket->unregister_command("mon_status");

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -314,6 +314,8 @@ void Objecter::shutdown()
 
   initialized.set(0);
 
+  cct->_conf->remove_observer(this);
+
   map<int,OSDSession*>::iterator p;
   while (!osd_sessions.empty()) {
     p = osd_sessions.begin();


### PR DESCRIPTION
Signed-off-by: Ruifeng Yang <yangruifeng.09209@h3c.com>