### PR TITLE
FileStore::mount No close fsid_fd\basedir_fd\current_fd

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -1642,7 +1642,13 @@ int FileStore::mount()
       return err;
     }
   }
-
+  VOID_TEMP_FAILURE_RETRY(::close(current_fd));
+  current_fd = -1;
+  VOID_TEMP_FAILURE_RETRY(::close(basedir_fd));
+  basedir_fd = -1;
+  VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
+  fsid_fd = -1;
+  
   // all okay.
   return 0;
 


### PR DESCRIPTION
FileStore::mount No close fsid_fd\basedir_fd\current_fd

Fixes: #13289
Signed-off-by: sky_atlantis@sina.com