### PR TITLE
install-deps.sh: openSUSE-release/sles-release/sled-release are always present

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -28,7 +28,7 @@ if type apt-get > /dev/null 2>&1 ; then
 fi
 
 if type zypper > /dev/null 2>&1 ; then
-    $SUDO zypper --gpg-auto-import-keys --non-interactive install openSUSE-release lsb-release
+    $SUDO zypper --gpg-auto-import-keys --non-interactive install lsb-release
 fi
 
 case $(lsb_release -si) in


### PR DESCRIPTION
http://tracker.ceph.com/issues/13318 Fixes: #13318

Signed-off-by: Nathan Cutler <ncutler@suse.com>