### PR TITLE
LTTng-UST tracing should be dynamically enabled

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -45,6 +45,10 @@ restorecon -R /var/log/ceph > /dev/null 2>&1;
 %global _with_systemd 1
 %endif
 
+# LTTng-UST enabled on Fedora, RHEL 6, and SLES 12
+%if 0%{?fedora} || 0%{?rhel} == 6 || 0%{?suse_version} == 1315
+%global _with_lttng 1
+%endif
 
 #################################################################################
 # common
@@ -177,13 +181,15 @@ Requires:	python-flask
 BuildRequires:  boost-random
 %endif
 # lttng and babeltrace for rbd-replay-prep
-%if 0%{?fedora} || 0%{?rhel} == 6
+%if 0%{?_with_lttng}
+%if 0%{?fedora} || 0%{?rhel}
 BuildRequires:	lttng-ust-devel
 BuildRequires:	libbabeltrace-devel
 %endif
-%if 0%{?suse_version} == 1315
+%if 0%{?suse_version}
 BuildRequires:	lttng-ust-devel
 BuildRequires:  babeltrace-devel
+%endif
 %endif
 
 %description
@@ -808,6 +814,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/rados-classes/libcls_version.so*
 %dir %{_libdir}/ceph/erasure-code
 %{_libdir}/ceph/erasure-code/libec_*.so*
+%if 0%{?_with_lttng}
+%{_libdir}/libos_tp.so.*
+%{_libdir}/libosd_tp.so.*
+%endif
 %{_udevrulesdir}/60-ceph-partuuid-workaround.rules
 %{_udevrulesdir}/95-ceph-osd.rules
 %config %{_sysconfdir}/bash_completion.d/ceph
@@ -864,7 +874,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/rbd
 %{_bindir}/rbd-replay
 %{_bindir}/rbd-replay-many
-%if 0%{?fedora} || 0%{?rhel} == 6 || 0%{?suse_version} == 1315
+%if 0%{?_with_lttng}
 %{_bindir}/rbd-replay-prep
 %endif
 %{_bindir}/ceph-post-file
@@ -1020,6 +1030,9 @@ fi
 %files -n librados2
 %defattr(-,root,root,-)
 %{_libdir}/librados.so.*
+%if 0%{?_with_lttng}
+%{_libdir}/librados_tp.so.*
+%endif
 
 %post -n librados2
 /sbin/ldconfig
@@ -1069,6 +1082,9 @@ fi
 %files -n librbd1
 %defattr(-,root,root,-)
 %{_libdir}/librbd.so.*
+%if 0%{?_with_lttng}
+%{_libdir}/librbd_tp.so.*
+%endif
 
 %post -n librbd1
 /sbin/ldconfig

--- a/configure.ac
+++ b/configure.ac
@@ -1336,7 +1336,6 @@ AC_CONFIG_FILES([Makefile
 	src/ocf/ceph
 	src/ocf/rbd
 	src/java/Makefile
-	src/tracing/Makefile
 	systemd/Makefile
 	man/Makefile
 	doc/Makefile

--- a/debian/ceph.install
+++ b/debian/ceph.install
@@ -16,6 +16,8 @@ usr/lib/python*/dist-packages/ceph_detect_init*
 usr/bin/crushtool
 usr/bin/monmaptool
 usr/bin/osdmaptool
+usr/lib/libos_tp.so.*
+usr/lib/libosd_tp.so.*
 usr/lib/ceph/ceph_common.sh
 usr/lib/ceph/erasure-code/*
 usr/lib/rados-classes/*

--- a/debian/librados2.install
+++ b/debian/librados2.install
@@ -1,2 +1,2 @@
-
 usr/lib/librados.so.*
+usr/lib/librados_tp.so.*

--- a/debian/librbd1.install
+++ b/debian/librbd1.install
@@ -1,1 +1,2 @@
 usr/lib/librbd.so.*
+usr/lib/librbd_tp.so.*

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -5,6 +5,7 @@ DIST_SUBDIRS =
 BUILT_SOURCES =
 EXTRA_DIST =
 CLEANFILES =
+dist_noinst_DATA =
 
 noinst_HEADERS =
 bin_PROGRAMS =
@@ -188,10 +189,6 @@ LIBRBD_TYPES = librbd_types.la
 LIBKRBD = libkrbd.la
 LIBCEPHFS = libcephfs.la
 LIBERASURE_CODE = liberasure_code.la
-LIBOSD_TP = tracing/libosd_tp.la
-LIBRADOS_TP = tracing/librados_tp.la
-LIBRBD_TP = tracing/librbd_tp.la
-LIBOS_TP = tracing/libos_tp.la
 
 if WITH_LIBAIO
 LIBOS += -laio

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 include Makefile-env.am
 
-SUBDIRS += ocf java tracing
-DIST_SUBDIRS += gmock ocf java tracing
+SUBDIRS += ocf java
+DIST_SUBDIRS += gmock ocf java
 
 if NO_GIT_VERSION
 export NO_VERSION="yes"
@@ -40,6 +40,7 @@ include test/Makefile.am
 include tools/Makefile.am
 include Makefile-rocksdb.am
 include compressor/Makefile.am
+include tracing/Makefile.am
 
 
 # shell scripts

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -33,6 +33,7 @@ using namespace std;
 #include "msg/Messenger.h"
 
 #include "common/Timer.h"
+#include "common/TracepointProvider.h"
 #include "common/ceph_argparse.h"
 
 #include "global/global_init.h"
@@ -49,6 +50,15 @@ using namespace std;
 #include "erasure-code/ErasureCodePlugin.h"
 
 #define dout_subsys ceph_subsys_osd
+
+namespace {
+
+TracepointProvider::Traits osd_tracepoint_traits("libosd_tp.so",
+                                                 "osd_tracing");
+TracepointProvider::Traits os_tracepoint_traits("libos_tp.so",
+                                                "osd_objectstore_tracing");
+
+} // anonymous namespace
 
 OSD *osd = NULL;
 
@@ -527,6 +537,9 @@ int main(int argc, const char **argv)
   // Set up crypto, daemonize, etc.
   global_init_daemonize(g_ceph_context, 0);
   common_init_finish(g_ceph_context);
+
+  TracepointProvider::initialize<osd_tracepoint_traits>(g_ceph_context);
+  TracepointProvider::initialize<os_tracepoint_traits>(g_ceph_context);
 
   MonClient mc(g_ceph_context);
   if (mc.build_initial_monmap() < 0)

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -73,7 +73,8 @@ libcommon_internal_la_SOURCES = \
 	common/module.c \
 	common/Readahead.cc \
 	common/Cycles.cc \
-	common/ContextCompletion.cc
+	common/ContextCompletion.cc \
+	common/TracepointProvider.cc
 
 libcommon_internal_la_SOURCES += \
 	common/blkdev.cc
@@ -235,7 +236,8 @@ noinst_HEADERS += \
 	common/ContextCompletion.h \
 	common/bit_vector.hpp \
 	common/SubProcess.h \
-	common/valgrind.h
+	common/valgrind.h \
+	common/TracepointProvider.h
 
 if ENABLE_XIO
 noinst_HEADERS += \

--- a/src/common/TracepointProvider.cc
+++ b/src/common/TracepointProvider.cc
@@ -1,0 +1,44 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/TracepointProvider.h"
+#include "common/config.h"
+
+TracepointProvider::TracepointProvider(CephContext *cct, const char *library,
+                                       const char *config_key)
+  : m_cct(cct), m_library(library), m_config_keys{config_key, NULL},
+    m_lock("TracepointProvider::m_lock"), m_enabled(false) {
+  m_cct->_conf->add_observer(this);
+  verify_config(m_cct->_conf);
+}
+
+TracepointProvider::~TracepointProvider() {
+  m_cct->_conf->remove_observer(this);
+}
+
+void TracepointProvider::handle_conf_change(
+    const struct md_config_t *conf, const std::set<std::string> &changed) {
+  if (changed.count(m_config_keys[0])) {
+    verify_config(conf);
+  }
+}
+
+void TracepointProvider::verify_config(const struct md_config_t *conf) {
+  Mutex::Locker locker(m_lock);
+  if (m_enabled) {
+    return;
+  }
+
+  char buf[10];
+  char *pbuf = buf;
+  if (conf->get_val(m_config_keys[0], &pbuf, sizeof(buf)) != 0 ||
+      strncmp(buf, "true", 5) != 0) {
+    return;
+  }
+
+  void *handle = dlopen(m_library.c_str(), RTLD_NOW);
+  if (handle != NULL) {
+    m_enabled = true;
+  }
+}
+

--- a/src/common/TracepointProvider.h
+++ b/src/common/TracepointProvider.h
@@ -1,0 +1,83 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TRACEPOINT_PROVIDER_H
+#define CEPH_TRACEPOINT_PROVIDER_H
+
+#include "include/int_types.h"
+#include "common/ceph_context.h"
+#include "common/config_obs.h"
+#include "common/Mutex.h"
+#include <dlfcn.h>
+#include <set>
+#include <string>
+#include <boost/noncopyable.hpp>
+
+struct md_config_t;
+
+class TracepointProvider : public md_config_obs_t, boost::noncopyable {
+public:
+  struct Traits {
+    const char *library;
+    const char *config_key;
+
+    Traits(const char *library, const char *config_key)
+      : library(library), config_key(config_key) {
+    }
+  };
+
+  class Singleton {
+  public:
+    Singleton(CephContext *cct, const char *library, const char *config_key)
+      : tracepoint_provider(new TracepointProvider(cct, library, config_key)) {
+    }
+    ~Singleton() {
+      delete tracepoint_provider;
+    }
+
+    inline bool is_enabled() const {
+      return tracepoint_provider->m_enabled;
+    }
+  private:
+    TracepointProvider *tracepoint_provider;
+  };
+
+  template <const Traits &traits>
+  class TypedSingleton : public Singleton {
+  public:
+    TypedSingleton(CephContext *cct)
+      : Singleton(cct, traits.library, traits.config_key) {
+    }
+  };
+
+  TracepointProvider(CephContext *cct, const char *library,
+                     const char *config_key);
+  virtual ~TracepointProvider();
+
+  template <const Traits &traits>
+  static void initialize(CephContext *cct) {
+#if WITH_LTTNG
+    TypedSingleton<traits> *singleton;
+    cct->lookup_or_create_singleton_object(singleton, traits.library);
+#endif
+  }
+
+protected:
+  virtual const char** get_tracked_conf_keys() const {
+    return m_config_keys;
+  }
+  virtual void handle_conf_change(const struct md_config_t *conf,
+                                  const std::set <std::string> &changed);
+
+private:
+  CephContext *m_cct;
+  std::string m_library;
+  mutable const char* m_config_keys[2];
+
+  Mutex m_lock;
+  bool m_enabled;
+
+  void verify_config(const struct md_config_t *conf);
+};
+
+#endif // CEPH_TRACEPOINT_PROVIDER_H

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -719,6 +719,7 @@ OPTION(osd_failsafe_full_ratio, OPT_FLOAT, .97) // what % full makes an OSD "ful
 OPTION(osd_failsafe_nearfull_ratio, OPT_FLOAT, .90) // what % full makes an OSD near full (failsafe)
 
 OPTION(osd_pg_object_context_cache_count, OPT_INT, 64)
+OPTION(osd_tracing, OPT_BOOL, false) // true if LTTng-UST tracepoints should be enabled
 
 // determines whether PGLog::check() compares written out log to stored log
 OPTION(osd_debug_pg_log_writeout, OPT_BOOL, false)
@@ -785,6 +786,7 @@ OPTION(osd_max_attr_name_len, OPT_U32, 100)    // max rados attr name len; canno
 OPTION(osd_max_attr_size, OPT_U64, 0)
 
 OPTION(osd_objectstore, OPT_STR, "filestore")  // ObjectStore backend type
+OPTION(osd_objectstore_tracing, OPT_BOOL, false) // true if LTTng-UST tracepoints should be enabled
 // Override maintaining compatibility with older OSDs
 // Set to true for testing.  Users should NOT set this.
 OPTION(osd_debug_override_acting_compat, OPT_BOOL, false)
@@ -947,6 +949,7 @@ OPTION(journal_discard, OPT_BOOL, false) //using ssd disk as journal, whether su
 
 OPTION(rados_mon_op_timeout, OPT_DOUBLE, 0) // how many seconds to wait for a response from the monitor before returning an error from a rados operation. 0 means on limit.
 OPTION(rados_osd_op_timeout, OPT_DOUBLE, 0) // how many seconds to wait for a response from osds before returning an error from a rados operation. 0 means no limit.
+OPTION(rados_tracing, OPT_BOOL, false) // true if LTTng-UST tracepoints should be enabled
 
 OPTION(rbd_op_threads, OPT_INT, 1)
 OPTION(rbd_op_thread_timeout, OPT_INT, 60)
@@ -973,6 +976,7 @@ OPTION(rbd_blacklist_expire_seconds, OPT_INT, 0) // number of seconds to blackli
 OPTION(rbd_request_timed_out_seconds, OPT_INT, 30) // number of seconds before maint request times out
 OPTION(rbd_skip_partial_discard, OPT_BOOL, false) // when trying to discard a range inside an object, set to true to skip zeroing the range.
 OPTION(rbd_enable_alloc_hint, OPT_BOOL, true) // when writing a object, it will issue a hint to osd backend to indicate the expected size object need
+OPTION(rbd_tracing, OPT_BOOL, false) // true if LTTng-UST tracepoints should be enabled
 
 /*
  * The following options change the behavior for librbd's image creation methods that

--- a/src/global/Makefile.am
+++ b/src/global/Makefile.am
@@ -4,9 +4,6 @@ libglobal_la_SOURCES = \
 	global/pidfile.cc \
 	global/signal_handler.cc
 libglobal_la_LIBADD = $(LIBCOMMON)
-if WITH_LTTNG
-libglobal_la_LIBADD += -llttng-ust -ldl
-endif
 noinst_LTLIBRARIES += libglobal.la
 
 noinst_HEADERS += \

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -34,10 +34,6 @@
 
 #include <errno.h>
 #include <deque>
-#ifdef WITH_LTTNG
-#include <lttng/ust.h>
-#endif
-
 
 #define dout_subsys ceph_subsys_
 
@@ -288,11 +284,6 @@ void global_init_daemonize(CephContext *cct, int flags)
   if (global_init_prefork(cct, flags) < 0)
     return;
 
-#ifdef WITH_LTTNG
-  sigset_t sigset;
-  ust_before_fork(&sigset);
-#endif
-
   int ret = daemon(1, 1);
   if (ret) {
     ret = errno;
@@ -301,9 +292,6 @@ void global_init_daemonize(CephContext *cct, int flags)
     exit(1);
   }
 
-#ifdef WITH_LTTNG
-  ust_after_fork_child(&sigset);
-#endif
   global_init_postfork_start(cct);
   global_init_postfork_finish(cct, flags);
 }

--- a/src/librados/Makefile.am
+++ b/src/librados/Makefile.am
@@ -23,9 +23,6 @@ librados_la_CXXFLAGS = ${AM_CXXFLAGS}
 LIBRADOS_DEPS += \
 	librados_internal.la libcls_lock_client.la \
 	$(LIBOSDC) $(LIBCOMMON_DEPS)
-if WITH_LTTNG
-LIBRADOS_DEPS += $(LIBRADOS_TP)
-endif
 
 librados_la_LIBADD = $(LIBRADOS_DEPS) $(PTHREAD_LIBS) $(CRYPTO_LIBS) $(EXTRALIBS)
 librados_la_LDFLAGS = ${AM_LDFLAGS} -version-info 2:0:0

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -39,7 +39,11 @@
 #include <stdexcept>
 
 #ifdef WITH_LTTNG
+#define TRACEPOINT_DEFINE
+#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
 #include "tracing/librados.h"
+#undef TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+#undef TRACEPOINT_DEFINE
 #else
 #define tracepoint(...)
 #endif

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -18,6 +18,7 @@
 #include "common/errno.h"
 #include "common/ceph_argparse.h"
 #include "common/common_init.h"
+#include "common/TracepointProvider.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
 #include "include/types.h"
@@ -60,6 +61,12 @@ using std::runtime_error;
 #define dout_prefix *_dout << "librados: "
 
 #define RADOS_LIST_MAX_ENTRIES 1024
+
+namespace {
+
+TracepointProvider::Traits tracepoint_traits("librados_tp.so", "rados_tracing");
+
+} // anonymous namespace
 
 /*
  * Structure of this file
@@ -2210,10 +2217,9 @@ librados::ObjectOperation::~ObjectOperation()
 }
 
 ///////////////////////////// C API //////////////////////////////
-static
-int rados_create_common(rados_t *pcluster,
-			const char * const clustername,
-			CephInitParameters *iparams)
+
+static CephContext *rados_create_cct(const char * const clustername,
+                                     CephInitParameters *iparams)
 {
   // missing things compared to global_init:
   // g_ceph_context, g_conf, g_lockdep, signal handlers
@@ -2223,26 +2229,27 @@ int rados_create_common(rados_t *pcluster,
   cct->_conf->parse_env(); // environment variables override
   cct->_conf->apply_changes(NULL);
 
-  librados::RadosClient *radosp = new librados::RadosClient(cct);
-  *pcluster = (void *)radosp;
+  TracepointProvider::initialize<tracepoint_traits>(cct);
+  return cct;
+}
+
+extern "C" int rados_create(rados_t *pcluster, const char * const id)
+{
+  CephInitParameters iparams(CEPH_ENTITY_TYPE_CLIENT);
+  if (id) {
+    iparams.name.set(CEPH_ENTITY_TYPE_CLIENT, id);
+  }
+  CephContext *cct = rados_create_cct("ceph", &iparams);
+
+  tracepoint(librados, rados_create_enter, id);
+  *pcluster = reinterpret_cast<rados_t>(new librados::RadosClient(cct));
+  tracepoint(librados, rados_create_exit, 0, *pcluster);
 
   cct->put();
   return 0;
 }
 
-extern "C" int rados_create(rados_t *pcluster, const char * const id)
-{
-  tracepoint(librados, rados_create_enter, id);
-  CephInitParameters iparams(CEPH_ENTITY_TYPE_CLIENT);
-  if (id) {
-    iparams.name.set(CEPH_ENTITY_TYPE_CLIENT, id);
-  }
-  int retval = rados_create_common(pcluster, "ceph", &iparams);
-  tracepoint(librados, rados_create_exit, retval, *pcluster);
-  return retval;
-}
-
-// as above, but 
+// as above, but
 // 1) don't assume 'client.'; name is a full type.id namestr
 // 2) allow setting clustername
 // 3) flags is for future expansion (maybe some of the global_init()
@@ -2251,16 +2258,21 @@ extern "C" int rados_create(rados_t *pcluster, const char * const id)
 extern "C" int rados_create2(rados_t *pcluster, const char *const clustername,
 			     const char * const name, uint64_t flags)
 {
-  tracepoint(librados, rados_create2_enter, clustername, name, flags);
   // client is assumed, but from_str will override
+  int retval = 0;
   CephInitParameters iparams(CEPH_ENTITY_TYPE_CLIENT);
   if (!name || !iparams.name.from_str(name)) {
-    tracepoint(librados, rados_create2_exit, -EINVAL, *pcluster);
-    return -EINVAL;
+    retval = -EINVAL;
   }
 
-  int retval = rados_create_common(pcluster, clustername, &iparams);
+  CephContext *cct = rados_create_cct(clustername, &iparams);
+  tracepoint(librados, rados_create2_enter, clustername, name, flags);
+  if (retval == 0) {
+    *pcluster = reinterpret_cast<rados_t>(new librados::RadosClient(cct));
+  }
   tracepoint(librados, rados_create2_exit, retval, *pcluster);
+
+  cct->put();
   return retval;
 }
 
@@ -2270,8 +2282,10 @@ extern "C" int rados_create2(rados_t *pcluster, const char *const clustername,
  */
 extern "C" int rados_create_with_context(rados_t *pcluster, rados_config_t cct_)
 {
-  tracepoint(librados, rados_create_with_context_enter, cct_);
   CephContext *cct = (CephContext *)cct_;
+  TracepointProvider::initialize<tracepoint_traits>(cct);
+
+  tracepoint(librados, rados_create_with_context_enter, cct_);
   librados::RadosClient *radosp = new librados::RadosClient(cct);
   *pcluster = (void *)radosp;
   tracepoint(librados, rados_create_with_context_exit, 0, *pcluster);

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -39,10 +39,6 @@ librbd_la_LIBADD = \
 	libcls_lock_client.la \
 	$(PTHREAD_LIBS) $(EXTRALIBS)
 
-if WITH_LTTNG
-librbd_la_LIBADD += $(LIBRBD_TP)
-endif
-
 librbd_la_LDFLAGS = ${AM_LDFLAGS} -version-info 1:0:0
 if LINUX
 librbd_la_CXXFLAGS = -fvisibility=hidden -fvisibility-inlines-hidden

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -35,7 +35,11 @@
 #include <vector>
 
 #ifdef WITH_LTTNG
+#define TRACEPOINT_DEFINE
+#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
 #include "tracing/librbd.h"
+#undef TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+#undef TRACEPOINT_DEFINE
 #else
 #define tracepoint(...)
 #endif

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -20,6 +20,7 @@
 #include "common/errno.h"
 #include "common/snap_types.h"
 #include "common/perf_counters.h"
+#include "common/TracepointProvider.h"
 #include "include/Context.h"
 #include "include/rbd/librbd.hpp"
 #include "osdc/ObjectCacher.h"
@@ -56,6 +57,8 @@ using librados::snap_t;
 using librados::IoCtx;
 
 namespace {
+
+TracepointProvider::Traits tracepoint_traits("librbd_tp.so", "rbd_tracing");
 
 class C_AioReadWQ : public Context {
 public:
@@ -168,6 +171,10 @@ void submit_aio_flush(librbd::ImageCtx *ictx, librbd::AioCompletion *c) {
   }
 }
 
+CephContext* get_cct(IoCtx &io_ctx) {
+  return reinterpret_cast<CephContext*>(io_ctx.cct());
+}
+
 librbd::AioCompletion* get_aio_completion(librbd::RBD::AioCompletion *comp) {
   return reinterpret_cast<librbd::AioCompletion *>(comp->pc);
 }
@@ -220,6 +227,7 @@ namespace librbd {
 		const char *snap_name)
   {
     ImageCtx *ictx = new ImageCtx(name, "", snap_name, io_ctx, false);
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
     if (image.ctx != NULL) {
@@ -242,6 +250,7 @@ namespace librbd {
 			  const char *snap_name)
   {
     ImageCtx *ictx = new ImageCtx(name, "", snap_name, io_ctx, true);
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
     if (image.ctx != NULL) {
@@ -262,6 +271,7 @@ namespace librbd {
 
   int RBD::create(IoCtx& io_ctx, const char *name, uint64_t size, int *order)
   {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, create_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name, size, *order);
     int r = librbd::create(io_ctx, name, size, order);
     tracepoint(librbd, create_exit, r, *order);
@@ -271,6 +281,7 @@ namespace librbd {
   int RBD::create2(IoCtx& io_ctx, const char *name, uint64_t size,
 		   uint64_t features, int *order)
   {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, create2_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name, size, features, *order);
     int r = librbd::create(io_ctx, name, size, false, features, order, 0, 0);
     tracepoint(librbd, create2_exit, r, *order);
@@ -281,6 +292,7 @@ namespace librbd {
 		   uint64_t features, int *order, uint64_t stripe_unit,
 		   uint64_t stripe_count)
   {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, create3_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name, size, features, *order, stripe_unit, stripe_count);
     int r = librbd::create(io_ctx, name, size, false, features, order,
 			  stripe_unit, stripe_count);
@@ -292,6 +304,7 @@ namespace librbd {
 		 IoCtx& c_ioctx, const char *c_name, uint64_t features,
 		 int *c_order)
   {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(p_ioctx));
     tracepoint(librbd, clone_enter, p_ioctx.get_pool_name().c_str(), p_ioctx.get_id(), p_name, p_snap_name, c_ioctx.get_pool_name().c_str(), c_ioctx.get_id(), c_name, features);
     int r = librbd::clone(p_ioctx, p_name, p_snap_name, c_ioctx, c_name,
 			 features, c_order, 0, 0);
@@ -303,6 +316,7 @@ namespace librbd {
 		  IoCtx& c_ioctx, const char *c_name, uint64_t features,
 		  int *c_order, uint64_t stripe_unit, int stripe_count)
   {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(p_ioctx));
     tracepoint(librbd, clone2_enter, p_ioctx.get_pool_name().c_str(), p_ioctx.get_id(), p_name, p_snap_name, c_ioctx.get_pool_name().c_str(), c_ioctx.get_id(), c_name, features, stripe_unit, stripe_count);
     int r = librbd::clone(p_ioctx, p_name, p_snap_name, c_ioctx, c_name,
 			 features, c_order, stripe_unit, stripe_count);
@@ -312,6 +326,7 @@ namespace librbd {
 
   int RBD::remove(IoCtx& io_ctx, const char *name)
   {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, remove_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name);
     librbd::NoOpProgressContext prog_ctx;
     int r = librbd::remove(io_ctx, name, prog_ctx);
@@ -322,6 +337,7 @@ namespace librbd {
   int RBD::remove_with_progress(IoCtx& io_ctx, const char *name,
 				ProgressContext& pctx)
   {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, remove_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name);
     int r = librbd::remove(io_ctx, name, pctx);
     tracepoint(librbd, remove_exit, r);
@@ -330,6 +346,7 @@ namespace librbd {
 
   int RBD::list(IoCtx& io_ctx, vector<string>& names)
   {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, list_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id());
     int r = librbd::list(io_ctx, names);
     if (r >= 0) {
@@ -343,6 +360,7 @@ namespace librbd {
 
   int RBD::rename(IoCtx& src_io_ctx, const char *srcname, const char *destname)
   {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(src_io_ctx));
     tracepoint(librbd, rename_enter, src_io_ctx.get_pool_name().c_str(), src_io_ctx.get_id(), srcname, destname);
     int r = librbd::rename(src_io_ctx, srcname, destname);
     tracepoint(librbd, rename_exit, r);
@@ -1027,6 +1045,7 @@ extern "C" int rbd_list(rados_ioctx_t p, char *names, size_t *size)
 {
   librados::IoCtx io_ctx;
   librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, list_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id());
   vector<string> cpp_names;
   int r = librbd::list(io_ctx, cpp_names);
@@ -1068,6 +1087,7 @@ extern "C" int rbd_create(rados_ioctx_t p, const char *name, uint64_t size, int 
 {
   librados::IoCtx io_ctx;
   librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, create_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name, size, *order);
   int r = librbd::create(io_ctx, name, size, order);
   tracepoint(librbd, create_exit, r, *order);
@@ -1080,6 +1100,7 @@ extern "C" int rbd_create2(rados_ioctx_t p, const char *name,
 {
   librados::IoCtx io_ctx;
   librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, create2_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name, size, features, *order);
   int r = librbd::create(io_ctx, name, size, false, features, order, 0, 0);
   tracepoint(librbd, create2_exit, r, *order);
@@ -1093,6 +1114,7 @@ extern "C" int rbd_create3(rados_ioctx_t p, const char *name,
 {
   librados::IoCtx io_ctx;
   librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, create3_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name, size, features, *order, stripe_unit, stripe_count);
   int r = librbd::create(io_ctx, name, size, false, features, order,
 			stripe_unit, stripe_count);
@@ -1107,6 +1129,7 @@ extern "C" int rbd_clone(rados_ioctx_t p_ioctx, const char *p_name,
   librados::IoCtx p_ioc, c_ioc;
   librados::IoCtx::from_rados_ioctx_t(p_ioctx, p_ioc);
   librados::IoCtx::from_rados_ioctx_t(c_ioctx, c_ioc);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(p_ioc));
   tracepoint(librbd, clone_enter, p_ioc.get_pool_name().c_str(), p_ioc.get_id(), p_name, p_snap_name, c_ioc.get_pool_name().c_str(), c_ioc.get_id(), c_name, features);
   int r = librbd::clone(p_ioc, p_name, p_snap_name, c_ioc, c_name,
 		       features, c_order, 0, 0);
@@ -1122,6 +1145,7 @@ extern "C" int rbd_clone2(rados_ioctx_t p_ioctx, const char *p_name,
   librados::IoCtx p_ioc, c_ioc;
   librados::IoCtx::from_rados_ioctx_t(p_ioctx, p_ioc);
   librados::IoCtx::from_rados_ioctx_t(c_ioctx, c_ioc);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(p_ioc));
   tracepoint(librbd, clone2_enter, p_ioc.get_pool_name().c_str(), p_ioc.get_id(), p_name, p_snap_name, c_ioc.get_pool_name().c_str(), c_ioc.get_id(), c_name, features, stripe_unit, stripe_count);
   int r = librbd::clone(p_ioc, p_name, p_snap_name, c_ioc, c_name,
 		       features, c_order, stripe_unit, stripe_count);
@@ -1133,6 +1157,7 @@ extern "C" int rbd_remove(rados_ioctx_t p, const char *name)
 {
   librados::IoCtx io_ctx;
   librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, remove_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name);
   librbd::NoOpProgressContext prog_ctx;
   int r = librbd::remove(io_ctx, name, prog_ctx);
@@ -1145,6 +1170,7 @@ extern "C" int rbd_remove_with_progress(rados_ioctx_t p, const char *name,
 {
   librados::IoCtx io_ctx;
   librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, remove_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name);
   librbd::CProgressContext prog_ctx(cb, cbdata);
   int r = librbd::remove(io_ctx, name, prog_ctx);
@@ -1228,6 +1254,7 @@ extern "C" int rbd_rename(rados_ioctx_t src_p, const char *srcname,
 {
   librados::IoCtx src_io_ctx;
   librados::IoCtx::from_rados_ioctx_t(src_p, src_io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(src_io_ctx));
   tracepoint(librbd, rename_enter, src_io_ctx.get_pool_name().c_str(), src_io_ctx.get_id(), srcname, destname);
   int r = librbd::rename(src_io_ctx, srcname, destname);
   tracepoint(librbd, rename_exit, r);
@@ -1239,6 +1266,7 @@ extern "C" int rbd_open(rados_ioctx_t p, const char *name, rbd_image_t *image,
 {
   librados::IoCtx io_ctx;
   librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   librbd::ImageCtx *ictx = new librbd::ImageCtx(name, "", snap_name, io_ctx,
 						false);
   tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
@@ -1254,6 +1282,7 @@ extern "C" int rbd_open_read_only(rados_ioctx_t p, const char *name,
 {
   librados::IoCtx io_ctx;
   librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   librbd::ImageCtx *ictx = new librbd::ImageCtx(name, "", snap_name, io_ctx,
 						true);
   tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -80,7 +80,11 @@ using ceph::crypto::SHA1;
 #include "common/blkdev.h"
 
 #ifdef WITH_LTTNG
+#define TRACEPOINT_DEFINE
+#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
 #include "tracing/objectstore.h"
+#undef TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+#undef TRACEPOINT_DEFINE
 #else
 #define tracepoint(...)
 #endif

--- a/src/os/Makefile.am
+++ b/src/os/Makefile.am
@@ -46,9 +46,6 @@ endif
 
 libos_la_CXXFLAGS = ${AM_CXXFLAGS}
 libos_la_LIBADD = $(LIBOS_TYPES)
-if WITH_LTTNG
-libos_la_LIBADD += $(LIBOS_TP)
-endif
 
 noinst_LTLIBRARIES += libos.la
 

--- a/src/osd/Makefile.am
+++ b/src/osd/Makefile.am
@@ -31,9 +31,6 @@ if WITH_KINETIC
 libosd_la_CXXFLAGS += -std=gnu++11
 endif
 libosd_la_LIBADD = $(LIBOSDC) $(LIBOS) $(LIBOSD_TYPES) $(LIBOS_TYPES)
-if WITH_LTTNG
-libosd_la_LIBADD += $(LIBOSD_TP)
-endif
 noinst_LTLIBRARIES += libosd.la
 
 noinst_HEADERS += \

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -135,7 +135,11 @@
 #include "common/config.h"
 
 #ifdef WITH_LTTNG
+#define TRACEPOINT_DEFINE
+#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
 #include "tracing/osd.h"
+#undef TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+#undef TRACEPOINT_DEFINE
 #else
 #define tracepoint(...)
 #endif

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -14,7 +14,11 @@
 #include "osd/osd_types.h"
 
 #ifdef WITH_LTTNG
+#define TRACEPOINT_DEFINE
+#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
 #include "tracing/oprequest.h"
+#undef TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+#undef TRACEPOINT_DEFINE
 #else
 #define tracepoint(...)
 #endif

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -45,7 +45,11 @@
 #include "common/BackTrace.h"
 
 #ifdef WITH_LTTNG
+#define TRACEPOINT_DEFINE
+#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
 #include "tracing/pg.h"
+#undef TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+#undef TRACEPOINT_DEFINE
 #else
 #define tracepoint(...)
 #endif

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -362,12 +362,6 @@ noinst_HEADERS += \
 	test/librbd/mock/MockImageWatcher.h \
 	test/librbd/mock/MockObjectMap.h
 
-if WITH_LTTNG
-unittest_librbd_LDADD += $(LIBRBD_TP)
-ceph_test_librbd_LDADD += $(LIBRBD_TP)
-ceph_test_librbd_api_LDADD += $(LIBRBD_TP)
-endif
-
 if LINUX
 ceph_test_librbd_fsx_SOURCES = test/librbd/fsx.cc
 ceph_test_librbd_fsx_LDADD = \

--- a/src/tracing/.gitignore
+++ b/src/tracing/.gitignore
@@ -1,2 +1,6 @@
-*.h
-*.c
+librados.h
+librbd.h
+objectstore.h
+oprequest.h
+osd.h
+pg.h

--- a/src/tracing/Makefile.am
+++ b/src/tracing/Makefile.am
@@ -1,8 +1,8 @@
 EXTRA_DIST = tracing-common.h
 
 if WITH_LTTNG
-%.c %.h: %.tp
-	$(LTTNG_GEN_TP_PROG) $< -o $*.c -o $*.h
+%.h: %.tp
+	$(LTTNG_GEN_TP_PROG) $< -o $*.h
 endif
 
 dist_noinst_DATA = \
@@ -23,8 +23,7 @@ nodist_libosd_tp_la_SOURCES = \
 	pg.c
 endif
 libosd_tp_la_LIBADD = -llttng-ust -ldl
-libosd_tp_la_CPPFLAGS = -DTRACEPOINT_PROBE_DYNAMIC_LINKAGE
-libosd_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS)
+libosd_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
 libosd_tp_la_LDFLAGS =
 
 if WITH_LTTNG
@@ -33,8 +32,7 @@ nodist_librados_tp_la_SOURCES = \
 	librados.h
 endif
 librados_tp_la_LIBADD = -llttng-ust -ldl
-librados_tp_la_CPPFLAGS = -DTRACEPOINT_PROBE_DYNAMIC_LINKAGE
-librados_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS)
+librados_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
 librados_tp_la_LDFLAGS =
 
 if WITH_LTTNG
@@ -43,8 +41,7 @@ nodist_librbd_tp_la_SOURCES = \
 	librbd.h
 endif
 librbd_tp_la_LIBADD = -llttng-ust -ldl
-librbd_tp_la_CPPFLAGS = -DTRACEPOINT_PROBE_DYNAMIC_LINKAGE
-librbd_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS)
+librbd_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
 librbd_tp_la_LDFLAGS =
 
 if WITH_LTTNG
@@ -53,28 +50,24 @@ nodist_libos_tp_la_SOURCES = \
 	objectstore.h
 endif
 libos_tp_la_LIBADD = -llttng-ust -ldl
-libos_tp_la_CPPFLAGS = -DTRACEPOINT_PROBE_DYNAMIC_LINKAGE
-libos_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS)
+libos_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
 libos_tp_la_LDFLAGS =
 
 if WITH_LTTNG
-noinst_LTLIBRARIES = \
+lib_LTLIBRARIES = \
 	libosd_tp.la \
+	libos_tp.la \
 	librados_tp.la \
-	librbd_tp.la \
-	libos_tp.la
+	librbd_tp.la
 
 BUILT_SOURCES = \
 	librados.h \
 	librbd.h \
+	objectstore.h \
 	oprequest.h \
 	osd.h \
-	pg.h \
-	objectstore.h
+	pg.h
 endif
 
 CLEANFILES = \
-	$(nodist_libosd_tp_la_SOURCES) \
-	$(nodist_librados_tp_la_SOURCES) \
-	$(nodist_librbd_tp_la_SOURCES) \
-	$(nodist_libos_tp_la_SOURCES)
+	$(BUILT_SOURCES)

--- a/src/tracing/Makefile.am
+++ b/src/tracing/Makefile.am
@@ -1,73 +1,78 @@
-EXTRA_DIST = tracing-common.h
+EXTRA_DIST += \
+	tracing/tracing-common.h
 
 if WITH_LTTNG
-%.h: %.tp
-	$(LTTNG_GEN_TP_PROG) $< -o $*.h
+tracing/%.h: tracing/%.tp
+	$(LTTNG_GEN_TP_PROG) $< -o tracing/$*.h
 endif
 
-dist_noinst_DATA = \
-	librados.tp \
-	librbd.tp \
-	oprequest.tp \
-	osd.tp \
-	pg.tp \
-	objectstore.tp
+dist_noinst_DATA += \
+	tracing/librados.tp \
+	tracing/librbd.tp \
+	tracing/oprequest.tp \
+	tracing/osd.tp \
+	tracing/pg.tp \
+	tracing/objectstore.tp
 
 if WITH_LTTNG
+libosd_tp_la_SOURCES = \
+	tracing/oprequest.c \
+	tracing/osd.c \
+	tracing/pg.c
 nodist_libosd_tp_la_SOURCES = \
-	oprequest.c \
-	oprequest.h \
-	osd.c \
-	osd.h \
-	pg.h \
-	pg.c
+	tracing/oprequest.h \
+	tracing/osd.h \
+	tracing/pg.h
 endif
 libosd_tp_la_LIBADD = -llttng-ust -ldl
-libosd_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
+libosd_tp_la_CFLAGS = -I$(top_srcdir)/src/tracing -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
 libosd_tp_la_LDFLAGS =
 
 if WITH_LTTNG
+librados_tp_la_SOURCES = \
+	tracing/librados.c
 nodist_librados_tp_la_SOURCES = \
-	librados.c \
-	librados.h
+	tracing/librados.h
 endif
 librados_tp_la_LIBADD = -llttng-ust -ldl
-librados_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
+librados_tp_la_CFLAGS = -I$(top_srcdir)/src/tracing -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
 librados_tp_la_LDFLAGS =
 
 if WITH_LTTNG
+librbd_tp_la_SOURCES = \
+	tracing/librbd.c
 nodist_librbd_tp_la_SOURCES = \
-	librbd.c \
-	librbd.h
+	tracing/librbd.h
 endif
 librbd_tp_la_LIBADD = -llttng-ust -ldl
-librbd_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
+librbd_tp_la_CFLAGS = -I$(top_srcdir)/src/tracing -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
 librbd_tp_la_LDFLAGS =
 
 if WITH_LTTNG
+libos_tp_la_SOURCES = \
+	tracing/objectstore.c
 nodist_libos_tp_la_SOURCES = \
-	objectstore.c \
-	objectstore.h
+	tracing/objectstore.h
 endif
 libos_tp_la_LIBADD = -llttng-ust -ldl
-libos_tp_la_CFLAGS = -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
+libos_tp_la_CFLAGS = -I$(top_srcdir)/src/tracing -I$(top_srcdir)/src $(AM_CFLAGS) -fpic
 libos_tp_la_LDFLAGS =
 
 if WITH_LTTNG
-lib_LTLIBRARIES = \
+lib_LTLIBRARIES += \
 	libosd_tp.la \
 	libos_tp.la \
 	librados_tp.la \
 	librbd_tp.la
 
-BUILT_SOURCES = \
-	librados.h \
-	librbd.h \
-	objectstore.h \
-	oprequest.h \
-	osd.h \
-	pg.h
+BUILT_SOURCES += \
+	tracing/librados.h \
+	tracing/librbd.h \
+	tracing/objectstore.h \
+	tracing/oprequest.h \
+	tracing/osd.h \
+	tracing/pg.h
 endif
 
-CLEANFILES = \
+CLEANFILES += \
 	$(BUILT_SOURCES)

--- a/src/tracing/librados.c
+++ b/src/tracing/librados.c
@@ -1,0 +1,6 @@
+
+#define TRACEPOINT_CREATE_PROBES
+/*
+ * The header containing our TRACEPOINT_EVENTs.
+ */
+#include "librados.h"

--- a/src/tracing/librbd.c
+++ b/src/tracing/librbd.c
@@ -1,0 +1,6 @@
+
+#define TRACEPOINT_CREATE_PROBES
+/*
+ * The header containing our TRACEPOINT_EVENTs.
+ */
+#include "librbd.h"

--- a/src/tracing/objectstore.c
+++ b/src/tracing/objectstore.c
@@ -1,0 +1,6 @@
+
+#define TRACEPOINT_CREATE_PROBES
+/*
+ * The header containing our TRACEPOINT_EVENTs.
+ */
+#include "objectstore.h"

--- a/src/tracing/oprequest.c
+++ b/src/tracing/oprequest.c
@@ -1,0 +1,6 @@
+
+#define TRACEPOINT_CREATE_PROBES
+/*
+ * The header containing our TRACEPOINT_EVENTs.
+ */
+#include "oprequest.h"

--- a/src/tracing/osd.c
+++ b/src/tracing/osd.c
@@ -1,0 +1,6 @@
+
+#define TRACEPOINT_CREATE_PROBES
+/*
+ * The header containing our TRACEPOINT_EVENTs.
+ */
+#include "osd.h"

--- a/src/tracing/pg.c
+++ b/src/tracing/pg.c
@@ -1,0 +1,6 @@
+
+#define TRACEPOINT_CREATE_PROBES
+/*
+ * The header containing our TRACEPOINT_EVENTs.
+ */
+#include "pg.h"


### PR DESCRIPTION
Currently, LTTng-UST tracepoint providers are statically linked into librbd, librados, and ceph-osd.  This forces LTTng-UST tracing to be enabled from startup.  This change separates the tracepoint providers into standalone dynamic libraries that are loaded based upon new tracing config options.