### PR TITLE
ceph.spec.in: Do not always restart the daemons on upgrades/removal

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1177,6 +1177,18 @@ exit 0
 
 %postun selinux
 if [ $1 -eq 0 ]; then
+    # Remove the module
+    %{_sbindir}/semodule -n -r ceph
+
+    # Reload the policy if SELinux is enabled
+    if %{_sbindir}/selinuxenabled ; then
+        %{_sbindir}/load_policy
+    else
+        # Do not relabel if SELinux is not enabled
+        exit 0
+    fi
+
+    # Check whether the daemons are running
     %if 0%{?_with_systemd}
         /usr/bin/systemctl status ceph.target > /dev/null 2>&1
     %else
@@ -1184,6 +1196,7 @@ if [ $1 -eq 0 ]; then
     %endif
     STATUS=$?
 
+    # Stop the daemons if they were running
     if test $STATUS -eq 0; then
     %if 0%{?_with_systemd}
         /usr/bin/systemctl stop ceph.target > /dev/null 2>&1
@@ -1192,12 +1205,10 @@ if [ $1 -eq 0 ]; then
     %endif
     fi
 
-    %{_sbindir}/semodule -n -r ceph
-    if %{_sbindir}/selinuxenabled ; then
-       %{_sbindir}/load_policy
-       %relabel_files
-    fi;
+    # Now, relabel the files
+    %relabel_files
 
+    # Start the daemons if they were running before
     if test $STATUS -eq 0; then
     %if 0%{?_with_systemd}
 	/usr/bin/systemctl start ceph.target > /dev/null 2>&1 || :

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1126,6 +1126,25 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_mandir}/man8/ceph_selinux.8.*
 
 %post selinux
+# Install the policy
+OLD_POLVER=$(%{_sbindir}/semodule -l | grep -P '^ceph[\t ]' | awk '{print $2}')
+%{_sbindir}/semodule -n -i %{_datadir}/selinux/packages/ceph.pp
+NEW_POLVER=$(%{_sbindir}/semodule -l | grep -P '^ceph[\t ]' | awk '{print $2}')
+
+# Load the policy if SELinux is enabled
+if %{_sbindir}/selinuxenabled; then
+    %{_sbindir}/load_policy
+else
+    # Do not relabel if selinux is not enabled
+    exit 0
+fi
+
+if test "$OLD_POLVER" == "$NEW_POLVER"; then
+   # Do not relabel if policy version did not change
+   exit 0
+fi
+
+# Check whether the daemons are running
 %if 0%{?_with_systemd}
     /usr/bin/systemctl status ceph.target > /dev/null 2>&1
 %else
@@ -1133,6 +1152,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %endif
 STATUS=$?
 
+# Stop the daemons if they were running
 if test $STATUS -eq 0; then
 %if 0%{?_with_systemd}
     /usr/bin/systemctl stop ceph.target > /dev/null 2>&1
@@ -1141,17 +1161,10 @@ if test $STATUS -eq 0; then
 %endif
 fi
 
-OLD_POLVER=$(%{_sbindir}/semodule -l | grep -P '^ceph[\t ]' | awk '{print $2}')
-%{_sbindir}/semodule -n -i %{_datadir}/selinux/packages/ceph.pp
-NEW_POLVER=$(%{_sbindir}/semodule -l | grep -P '^ceph[\t ]' | awk '{print $2}')
-if %{_sbindir}/selinuxenabled; then
-    %{_sbindir}/load_policy
-    if test "$OLD_POLVER" != "$NEW_POLVER"; then
-        %relabel_files
-   fi
-fi
+# Now, relabel the files
+%relabel_files
 
-# Start iff it was started before
+# Start the daemons iff they were running before
 if test $STATUS -eq 0; then
 %if 0%{?_with_systemd}
     /usr/bin/systemctl start ceph.target > /dev/null 2>&1 || :


### PR DESCRIPTION
http://tracker.ceph.com/issues/13061

These patches minimize the amount of daemon stop/start procedures when upgrading/removing ceph-selinux package.