### PR TITLE
filestore: fix peek_queue for OpSequencer

### DIFF
--- a/src/os/FileStore.h
+++ b/src/os/FileStore.h
@@ -258,6 +258,7 @@ private:
       q.push_back(o);
     }
     Op *peek_queue() {
+      Mutex::Locker l(qlock);
       assert(apply_lock.is_locked());
       return q.front();
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/13338