### PR TITLE
mds: avoid emitting cap warnings before evicting session

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -183,8 +183,8 @@ void MDSRankDispatcher::tick()
 
   // ...
   if (is_clientreplay() || is_active() || is_stopping()) {
-    locker->tick();
     server->find_idle_sessions();
+    locker->tick();
   }
   
   if (is_reconnect())


### PR DESCRIPTION
In the case where a client dies, and another client immediately
tries to access a file locked by the dead client, we would
previously *sometimes* emit a "client.xyz isn't responding to
mclientcaps" warning to the cluster log, right before
evicting the stale session.  This was because the timeout
for the session eviction and the timeout for the
warning message are both 60s.

Fix this by checking the stale sessions before doing the
warning message check in Locker.  If a session is going
to get evicted in this tick, it will already be gone
by the time Locker thinks about emitting the warning
message.

Fixes: #13334
Signed-off-by: John Spray <john.spray@redhat.com>