### PR TITLE
osd/PG: fix generate_past_intervals

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -753,10 +753,8 @@ void PG::generate_past_intervals()
     }
   }
 
-  // Verify same_interval_since is correct
-  if (info.history.same_interval_since) {
-    assert(info.history.same_interval_since == same_interval_since);
-  } else {
+  // PG import needs recalculated same_interval_since
+  if (info.history.same_interval_since == 0) {
     assert(same_interval_since);
     dout(10) << __func__ << " fix same_interval_since " << same_interval_since << " pg " << *this << dendl;
     dout(10) << __func__ << " past_intervals " << past_intervals << dendl;


### PR DESCRIPTION
We may be only calculating older past intervals and have a valid
history.same_interval_since value, in which case the local
same_interval_since value will end at the newest old interval we had to
generate.

This was introduced by 70316541bbb115d9a35954bfba373cf1dc084b7e.

Signed-off-by: Sage Weil <sage@redhat.com>