### PR TITLE
doc: remove mention of --lazy-remove from radosgw-admin manpage

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -316,10 +316,6 @@ Options
 
    Remove all objects before bucket removal.
 
-.. option:: --lazy-remove
-
-   Defer removal of object tail.
-
 .. option:: --metadata-key=<key>
 
 	Key to retrieve metadata from with ``metadata get``.


### PR DESCRIPTION
"The --lazy-remove flag has been removed over 3 years ago. Docs need to be
updated."

http://tracker.ceph.com/issues/13317 Fixes: #13317

Signed-off-by: Nathan Cutler <ncutler@suse.com>