### PR TITLE
os/FileStore: kludge sloppy hammer temp objects into temp collection

### DIFF
--- a/src/os/FileStore.h
+++ b/src/os/FileStore.h
@@ -141,7 +141,10 @@ private:
   int init_index(coll_t c);
 
   void _kludge_temp_object_collection(coll_t& cid, const ghobject_t& oid) {
-    if (oid.hobj.pool < -1 && !cid.is_temp())
+    // - normal temp case: cid is pg, object is temp (pool < -1)
+    // - hammer temp case: cid is pg (or already temp), object pool is -1
+    if (cid.is_pg() && (oid.hobj.pool < -1 ||
+			oid.hobj.pool == -1))
       cid = cid.get_temp();
   }
   void init_temp_collections();


### PR DESCRIPTION
When we are running with a mixed hammer cluster, hammer primaries
will generate temp object names that are sloppy.  Make sure we still
put them into the temp collection.

Note that this isn't a problem on write because the primary (hammer)
OSD generated the transaction and explicitly specified a temp
collection; it's only transactions we do on our own with the sloppy
temp ghobject_t that trip over this.

Fixes: #13395
Signed-off-by: Sage Weil <sage@redhat.com>