### PR TITLE
By O_RDWR into O_RDONLY fsid open way, prevent fsid_fd is modified

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -1644,6 +1644,8 @@ int FileStore::mount()
   }
 
   // all okay.
+  VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
+  fsid_fd = -1;
   return 0;
 
 close_current_fd:

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -1001,6 +1001,8 @@ int KeyValueStore::mount()
   ondisk_finisher.start();
 
   // all okay.
+  VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
+  fsid_fd = -1;
   return 0;
 
 close_current_fd:


### PR DESCRIPTION
By O_RDWR into O_RDONLY fsid open way, prevent fsid_fd is modified

Fixes: #13289
Signed-off-by: sky_atlantis@sina.com
