### PR TITLE
rados: implement rm --force option to force remove when full.

### DIFF
--- a/qa/workunits/rados/test_rados_tool.sh
+++ b/qa/workunits/rados/test_rados_tool.sh
@@ -304,9 +304,24 @@ test_xattr() {
     rm $V1 $V2
     cleanup
 }
+test_rmobj() {
+    p=`uuidgen`
+    ceph osd pool create $p 1
+    ceph osd pool set-quota $p max_objects 1
+    V1=`mktemp fooattrXXXXXXX`
+    rados put $OBJ $V1 -p $p
+    while ! ceph osd dump | grep 'full max_objects'
+    do
+	sleep 2
+    done
+    rados -p $p rm $OBJ --force-full
+    rados rmpool $p $p --yes-i-really-really-mean-it
+    rm $V1
+}
 
 test_xattr
 test_omap
+test_rmobj
 
 echo "SUCCESS!"
 exit 0

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -677,6 +677,7 @@ namespace librados
                    size_t len);
     int read(const std::string& oid, bufferlist& bl, size_t len, uint64_t off);
     int remove(const std::string& oid);
+    int remove(const std::string& oid, int flags);
     int trunc(const std::string& oid, uint64_t size);
     int mapext(const std::string& o, uint64_t off, size_t len, std::map<uint64_t,uint64_t>& m);
     int sparse_read(const std::string& o, std::map<uint64_t,uint64_t>& m, bufferlist& bl, size_t len, uint64_t off);

--- a/src/include/radosstriper/libradosstriper.hpp
+++ b/src/include/radosstriper/libradosstriper.hpp
@@ -190,7 +190,7 @@ namespace libradosstriper
      * during deletion (same EBUSY return code)
      */
     int remove(const std::string& soid);
-
+    int remove(const std::string& soid, int flags);
     /**
      * Resizes a striped object
      * the truncation can not happen if any I/O is ongoing (it

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -948,6 +948,14 @@ int librados::IoCtxImpl::remove(const object_t& oid)
   return operate(oid, &op, NULL);
 }
 
+int librados::IoCtxImpl::remove(const object_t& oid, int flags)
+{
+  ::ObjectOperation op;
+  prepare_assert_ops(&op);
+  op.remove();
+  return operate(oid, &op, NULL, flags);
+}
+
 int librados::IoCtxImpl::trunc(const object_t& oid, uint64_t size)
 {
   ::ObjectOperation op;

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -127,6 +127,7 @@ struct librados::IoCtxImpl {
   int sparse_read(const object_t& oid, std::map<uint64_t,uint64_t>& m,
 		  bufferlist& bl, size_t len, uint64_t off);
   int remove(const object_t& oid);
+  int remove(const object_t& oid, int flags);
   int stat(const object_t& oid, uint64_t *psize, time_t *pmtime);
   int trunc(const object_t& oid, uint64_t size);
 

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -1159,6 +1159,12 @@ int librados::IoCtx::remove(const std::string& oid)
   return io_ctx_impl->remove(obj);
 }
 
+int librados::IoCtx::remove(const std::string& oid, int flags)
+{
+  object_t obj(oid);
+  return io_ctx_impl->remove(obj, flags); 
+}
+
 int librados::IoCtx::trunc(const std::string& oid, uint64_t size)
 {
   object_t obj(oid);

--- a/src/libradosstriper/RadosStriperImpl.h
+++ b/src/libradosstriper/RadosStriperImpl.h
@@ -187,7 +187,7 @@ struct libradosstriper::RadosStriperImpl {
 
   // stat, deletion and truncation
   int stat(const std::string& soid, uint64_t *psize, time_t *pmtime);
-  int remove(const std::string& soid);
+  int remove(const std::string& soid, int flags=0);
   int trunc(const std::string& soid, uint64_t size);
 
   // reference counting

--- a/src/libradosstriper/libradosstriper.cc
+++ b/src/libradosstriper/libradosstriper.cc
@@ -273,6 +273,10 @@ int libradosstriper::RadosStriper::remove(const std::string& soid)
 {
   return rados_striper_impl->remove(soid);
 }
+int libradosstriper::RadosStriper::remove(const std::string& soid, int flags)
+{
+  return rados_striper_impl->remove(soid, flags); 
+}
 
 int libradosstriper::RadosStriper::trunc(const std::string& soid, uint64_t size)
 {

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -84,7 +84,7 @@ void usage(ostream& out)
 "   put <obj-name> [infile]          write object\n"
 "   truncate <obj-name> length       truncate object\n"
 "   create <obj-name>                create object\n"
-"   rm <obj-name> ...                remove object(s)\n"
+"   rm <obj-name> ...[--force-full]  [force no matter full or not]remove object(s)\n"
 "   cp <obj-name> [target-obj]       copy object\n"
 "   clonedata <src-obj> <dst-obj>    clone object data\n"
 "   listxattr <obj-name>\n"
@@ -1239,7 +1239,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
   std::string run_name;
   std::string prefix;
-
+  bool forcefull = false;
   Formatter *formatter = NULL;
   bool pretty_format = false;
   const char *output = NULL;
@@ -1281,6 +1281,11 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   i = opts.find("run-name");
   if (i != opts.end()) {
     run_name = i->second;
+  }
+
+  i = opts.find("force-full");
+  if (i != opts.end()) {
+    forcefull = true;
   }
   i = opts.find("prefix");
   if (i != opts.end()) {
@@ -2146,7 +2151,11 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       if (use_striper) {
 	ret = striper.remove(oid);
       } else {
-	ret = io_ctx.remove(oid);
+	if (forcefull) {
+	  ret = io_ctx.remove(oid, CEPH_OSD_FLAG_FULL_FORCE);
+	} else {
+	  ret = io_ctx.remove(oid);
+	}
       }
       if (ret < 0) {
         string name = (nspace.size() ? nspace + "/" : "" ) + oid;
@@ -2929,6 +2938,8 @@ int main(int argc, const char **argv)
       exit(0);
     } else if (ceph_argparse_flag(args, i, "-f", "--force", (char*)NULL)) {
       opts["force"] = "true";
+    } else if (ceph_argparse_flag(args, i, "--force-full", (char*)NULL)) {
+      opts["force-full"] = "true";
     } else if (ceph_argparse_flag(args, i, "-d", "--delete-after", (char*)NULL)) {
       opts["delete-after"] = "true";
     } else if (ceph_argparse_flag(args, i, "-C", "--create", "--create-pool",

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2149,7 +2149,11 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     for (; iter != nargs.end(); ++iter) {
       const string & oid = *iter;
       if (use_striper) {
-	ret = striper.remove(oid);
+	if (forcefull) {
+	  ret = striper.remove(oid, CEPH_OSD_FLAG_FULL_FORCE);
+	} else {
+	  ret = striper.remove(oid);
+	}
       } else {
 	if (forcefull) {
 	  ret = io_ctx.remove(oid, CEPH_OSD_FLAG_FULL_FORCE);


### PR DESCRIPTION
[librados] extend remove interface, add flags parameter
rados tool use the extended librados interface to implement force remove.

test: 
when cluster full, ceph -s show: 3 full osd(s)(only 3 osds in my cluster),
use:
./rados -p poolname rm objname --force (delete ok)
but ./rados -p poolname rm objname will stuck.

Signed-off-by: Xiaowei Chen <chen.xiaowei@h3c.com>