### PR TITLE
client: don't mark_down on command reply

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5005,8 +5005,6 @@ void Client::handle_command_reply(MCommandReply *m)
     *op.outs = m->rs;
   }
 
-  op.con->mark_down();
-
   if (op.on_finish) {
     op.on_finish->complete(m->r);
   }


### PR DESCRIPTION
I guess this was handy when issuing single commands
from the CLI, but it breaks things badly when
trying to issue commands from a client
that's also going to carry on and do client IO.

Signed-off-by: John Spray <john.spray@redhat.com>