### PR TITLE
newstore: allow multiple fixed-size fragments per object

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -799,6 +799,8 @@ OPTION(memstore_page_set, OPT_BOOL, true)
 OPTION(memstore_page_size, OPT_U64, 64 << 10)
 
 OPTION(newstore_max_dir_size, OPT_U32, 1000000)
+OPTION(newstore_min_frag_size, OPT_U32, 1048576)   // smallest allowed frag size
+OPTION(newstore_max_frag_size, OPT_U32, 1048576*16) // largest allowed fag size
 OPTION(newstore_onode_map_size, OPT_U32, 1024)   // onodes per collection
 OPTION(newstore_backend, OPT_STR, "rocksdb")
 OPTION(newstore_rocksdb_options, OPT_STR, "max_write_buffer_number=16,min_write_buffer_number_to_merge=6")

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -801,7 +801,7 @@ OPTION(memstore_page_size, OPT_U64, 64 << 10)
 OPTION(newstore_max_dir_size, OPT_U32, 1000000)
 OPTION(newstore_onode_map_size, OPT_U32, 1024)   // onodes per collection
 OPTION(newstore_backend, OPT_STR, "rocksdb")
-OPTION(newstore_backend_options, OPT_STR, "")
+OPTION(newstore_backend_options, OPT_STR, "max_write_buffer_number=16,min_write_buffer_number_to_merge=6")
 OPTION(newstore_fail_eio, OPT_BOOL, true)
 OPTION(newstore_sync_io, OPT_BOOL, false)  // perform initial io synchronously
 OPTION(newstore_sync_transaction, OPT_BOOL, false)  // perform kv txn synchronously

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -823,7 +823,6 @@ OPTION(newstore_overlay_max_length, OPT_INT, 65536)
 OPTION(newstore_overlay_max, OPT_INT, 32)
 OPTION(newstore_open_by_handle, OPT_BOOL, true)
 OPTION(newstore_o_direct, OPT_BOOL, true)
-OPTION(newstore_db_path, OPT_STR, "")
 OPTION(newstore_aio, OPT_BOOL, true)
 OPTION(newstore_aio_poll_ms, OPT_INT, 250)  // milliseconds
 OPTION(newstore_aio_max_queue_depth, OPT_INT, 4096)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -750,7 +750,7 @@ OPTION(keyvaluestore_rocksdb_options, OPT_STR, "")
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR, "")
 // rocksdb options that will be used in monstore
-OPTION(mon_rocksdb_options, OPT_STR, "compression=kNoCompression")
+OPTION(mon_rocksdb_options, OPT_STR, "cache_size=536870912,write_buffer_size=33554432,block_size=65536,compression=kNoCompression")
 
 /**
  * osd_*_priority adjust the relative priority of client io, recovery io,

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -801,7 +801,7 @@ OPTION(memstore_page_size, OPT_U64, 64 << 10)
 OPTION(newstore_max_dir_size, OPT_U32, 1000000)
 OPTION(newstore_onode_map_size, OPT_U32, 1024)   // onodes per collection
 OPTION(newstore_backend, OPT_STR, "rocksdb")
-OPTION(newstore_backend_options, OPT_STR, "max_write_buffer_number=16,min_write_buffer_number_to_merge=6")
+OPTION(newstore_rocksdb_options, OPT_STR, "max_write_buffer_number=16,min_write_buffer_number_to_merge=6")
 OPTION(newstore_fail_eio, OPT_BOOL, true)
 OPTION(newstore_sync_io, OPT_BOOL, false)  // perform initial io synchronously
 OPTION(newstore_sync_transaction, OPT_BOOL, false)  // perform kv txn synchronously

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -750,7 +750,7 @@ OPTION(keyvaluestore_rocksdb_options, OPT_STR, "")
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR, "")
 // rocksdb options that will be used in monstore
-OPTION(mon_rocksdb_options, OPT_STR, "")
+OPTION(mon_rocksdb_options, OPT_STR, "compression=kNoCompression")
 
 /**
  * osd_*_priority adjust the relative priority of client io, recovery io,

--- a/src/os/RocksDBStore.h
+++ b/src/os/RocksDBStore.h
@@ -123,9 +123,7 @@ public:
     return do_open(out, false);
   }
   /// Creates underlying db if missing and opens it
-  int create_and_open(ostream &out) {
-    return do_open(out, true);
-  }
+  int create_and_open(ostream &out);
 
   void close();
 

--- a/src/os/fs/FS.cc
+++ b/src/os/fs/FS.cc
@@ -140,7 +140,7 @@ int FS::zero(int fd, uint64_t offset, uint64_t length)
     bufferptr bp(length);
     bp.zero();
     bl.append(bp);
-    int r = ::lseek64(fd, offset, SEEK_SET);
+    r = ::lseek64(fd, offset, SEEK_SET);
     if (r < 0) {
       r = -errno;
       goto out;

--- a/src/os/fs/FS.cc
+++ b/src/os/fs/FS.cc
@@ -121,16 +121,49 @@ int FS::zero(int fd, uint64_t offset, uint64_t length)
 {
   int r;
 
-#ifdef CEPH_HAVE_FALLOCATE
-# if !defined(DARWIN) && !defined(__FreeBSD__)
+  /*
+
+    From the fallocate(2) man page:
+
+       Specifying the FALLOC_FL_PUNCH_HOLE flag (available since Linux 2.6.38)
+       in mode deallocates space (i.e., creates a  hole)  in  the  byte  range
+       starting  at offset and continuing for len bytes.  Within the specified
+       range, partial filesystem  blocks  are  zeroed,  and  whole  filesystem
+       blocks  are removed from the file.  After a successful call, subsequent
+       reads from this range will return zeroes.
+
+       The FALLOC_FL_PUNCH_HOLE flag must be ORed with FALLOC_FL_KEEP_SIZE  in
+       mode;  in  other words, even when punching off the end of the file, the
+       file size (as reported by stat(2)) does not change.
+
+       Not all  filesystems  support  FALLOC_FL_PUNCH_HOLE;  if  a  filesystem
+       doesn't  support the operation, an error is returned.  The operation is
+       supported on at least the following filesystems:
+
+       *  XFS (since Linux 2.6.38)
+
+       *  ext4 (since Linux 3.0)
+
+       *  Btrfs (since Linux 3.7)
+
+       *  tmpfs (since Linux 3.5)
+
+   So: we only do this is PUNCH_HOLE *and* KEEP_SIZE are defined.
+
+  */
+#if !defined(DARWIN) && !defined(__FreeBSD__)
+# ifdef CEPH_HAVE_FALLOCATE
+#  ifdef FALLOC_FL_KEEP_SIZE
   // first try fallocate
-  r = fallocate(fd, FALLOC_FL_PUNCH_HOLE, offset, length);
+  r = fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, length);
   if (r < 0) {
     r = -errno;
   }
   if (r != -EOPNOTSUPP) {
     goto out;  // a real error
   }
+  // if that failed (-EOPNOTSUPP), fall back to writing zeros.
+#  endif
 # endif
 #endif
 

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -817,7 +817,10 @@ int NewStore::_open_db()
     db = NULL;
     return -EIO;
   }
-  db->init(g_conf->newstore_backend_options);
+  string options;
+  if (g_conf->newstore_backend == "rocksdb")
+    options = g_conf->newstore_rocksdb_options;
+  db->init(options);
   stringstream err;
   if (db->create_and_open(err)) {
     derr << __func__ << " erroring opening db: " << err.str() << dendl;
@@ -826,8 +829,7 @@ int NewStore::_open_db()
     return -EIO;
   }
   dout(1) << __func__ << " opened " << g_conf->newstore_backend
-	  << " path " << path
-	  << " options " << g_conf->newstore_backend_options << dendl;
+	  << " path " << path << " options " << options << dendl;
   return 0;
 }
 

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -3431,6 +3431,39 @@ void NewStore::_do_read_all_overlays(wal_transaction_t& wt)
   return;
 }
 
+void NewStore::_dump_onode(OnodeRef o)
+{
+  dout(30) << __func__ << " " << o
+	   << " nid " << o->onode.nid
+	   << " size " << o->onode.size
+	   << " frag_size " << o->onode.frag_size
+	   << " expected_object_size " << o->onode.expected_object_size
+	   << " expected_write_size " << o->onode.expected_write_size
+	   << dendl;
+  for (map<string,bufferptr>::iterator p = o->onode.attrs.begin();
+       p != o->onode.attrs.end();
+       ++p) {
+    dout(30) << __func__ << "  attr " << p->first
+	     << " len " << p->second.length() << dendl;
+  }
+  for (map<uint64_t,fragment_t>::iterator p = o->onode.data_map.begin();
+       p != o->onode.data_map.end();
+       ++p) {
+    dout(30) << __func__ << "  fragment " << p->first << " " << p->second
+	     << dendl;
+  }
+  for (map<uint64_t,overlay_t>::iterator p = o->onode.overlay_map.begin();
+       p != o->onode.overlay_map.end();
+       ++p) {
+    dout(30) << __func__ << "  overlay " << p->first << " " << p->second
+	     << dendl;
+  }
+  if (!o->onode.shared_overlays.empty()) {
+    dout(30) << __func__ << "  shared_overlays " << o->onode.shared_overlays
+	     << dendl;
+  }
+}
+
 int NewStore::_do_write(TransContext *txc,
 			OnodeRef o,
 			uint64_t orig_offset, uint64_t orig_length,
@@ -3446,7 +3479,7 @@ int NewStore::_do_write(TransContext *txc,
 	   << " - have " << o->onode.size
 	   << " bytes in " << o->onode.data_map.size()
 	   << " fragments" << dendl;
-
+  _dump_onode(o);
   o->exists = true;
 
   if (!o->onode.frag_size && o->onode.data_map.empty()) {

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -3491,7 +3491,8 @@ int NewStore::_do_write(TransContext *txc,
   _dump_onode(o);
   o->exists = true;
 
-  if (!o->onode.frag_size && o->onode.data_map.empty()) {
+  if (!o->onode.frag_size && o->onode.data_map.empty() &&
+      o->onode.overlay_map.empty()) {
     o->onode.frag_size = g_conf->newstore_min_frag_size;
     dout(20) << __func__ << " set frag_size " << o->onode.frag_size << dendl;
   }
@@ -4320,7 +4321,7 @@ int NewStore::_setallochint(TransContext *txc,
   o->onode.expected_write_size = expected_write_size;
   txc->write_onode(o);
 
-  if (o->onode.data_map.empty()) {
+  if (o->onode.data_map.empty() && o->onode.overlay_map.empty()) {
     // FIXME: we could do something clever with onode.frag_size here.
   }
 

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -564,7 +564,6 @@ NewStore::NewStore(CephContext *cct, const string& path)
     cct(cct),
     db(NULL),
     fs(NULL),
-    db_path(cct->_conf->newstore_db_path),
     path_fd(-1),
     fsid_fd(-1),
     frag_fd(-1),
@@ -929,11 +928,6 @@ int NewStore::mkfs()
   if (r < 0)
     goto out_close_fsid;
 
-  if (db_path != "") {
-    r = symlinkat(db_path.c_str(), path_fd, "db");
-    if (r < 0)
-      goto out_close_frag;
-  }
   r = _open_db();
   if (r < 0)
     goto out_close_frag;

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -31,10 +31,8 @@
 
   TODO:
 
+  * alloc hint to set frag size
   * collection_list must flush pending db work
-  * multiple fragments per object (with configurable size.. maybe 1 or 2 mb default?)
-    * read path should be totally generic (handle any fragment pattern)
-    * write path should ideally tolerate any fragment pattern, but only generate a fixed layout (since the tunable may be changed over time).
   * rocksdb: use db_paths (db/ and db.bulk/ ?)
   * rocksdb: auto-detect use_fsync option when not xfs or btrfs
   * avoid mtime updates when doing open-by-handle
@@ -42,6 +40,31 @@
   * inline first fsync_item in TransContext to void allocation?
   * refcounted fragments (for efficient clone)
 
+ */
+
+/*
+ * Some invariants:
+ *
+ * - The fragment extent referenced by the fragment_t is always
+ *   defined.  It may be zeros (a hole in the underlying fs).
+ *
+ * - The fragment file may be larger than the fragment_t indicates.
+ *   If so, the trailing cruft should be ignored and can be safely
+ *   discarded (see _clean_fid_tail).
+ *
+ * - The fragment file may be smaller than the fragment_t indicates.
+ *   The content is defined to be zeros in this case.
+ *
+ * - All fragments start on a frag_size boundary, and are
+ *   at most frag_size bytes.
+ *
+ * - A fragment *may* be shorter than frag_size, even if
+ *   it isn't at the end of a file.
+ *
+ * - The fragment map never extends beyond the size of the object.
+ *
+ * - The fragment_t::offset is (currently) always 0.
+ *
  */
 
 const string PREFIX_SUPER = "S"; // field -> value
@@ -1992,6 +2015,7 @@ void NewStore::_assign_nid(TransContext *txc, OnodeRef o)
   o->onode.nid = ++nid_last;
   dout(20) << __func__ << " " << o->onode.nid << dendl;
   if (nid_last > nid_max) {
+#warning fixme this could race?
     nid_max += g_conf->newstore_nid_prealloc;
     bufferlist bl;
     ::encode(nid_max, bl);
@@ -3295,35 +3319,55 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
   if (o->onode.overlay_map.empty())
     return 0;
 
-  // overwrite to new fid
-  if (o->onode.data_map.empty()) {
-    // create
-    fragment_t &f = o->onode.data_map[0];
-    f.offset = 0;
-    f.length = o->onode.size;
-    int fd = _create_fid(txc, &f.fid, O_RDWR);
-    if (fd < 0) {
-      return fd;
-    }
-    VOID_TEMP_FAILURE_RETRY(::close(fd));
-    dout(20) << __func__ << " create " << f.fid << dendl;
-  }
-
-  assert(o->onode.data_map.size() == 1);
-  fragment_t& f = o->onode.data_map.begin()->second;
-  assert(f.offset == 0);
-  assert(f.length == o->onode.size);
-
   for (map<uint64_t,overlay_t>::iterator p = o->onode.overlay_map.begin();
        p != o->onode.overlay_map.end(); ) {
     dout(10) << __func__ << " overlay " << p->first
-	     << "~" << p->second << dendl;
+	     << "~" << p->second.length << " " << p->second << dendl;
+
+    // find or create frag
+    uint64_t frag_first = 0;
+    fragment_t *f;
+    map<uint64_t,fragment_t>::iterator fp = o->onode.find_fragment(p->first);
+    if (fp == o->onode.data_map.end() ||
+	fp->first >= p->first + p->second.length ||
+	fp->first + fp->second.length <= p->first) {
+      dout(20) << __func__ << " frag " << fp->first << " " << fp->second
+	       << dendl;
+      frag_first = p->first - p->first % o->onode.frag_size;
+      if (frag_first == fp->first) {
+	// extend existing frag
+	f = &fp->second;
+	int r = _clean_fid_tail(txc, *f);
+	if (r < 0)
+	  return r;
+	f->length = (p->first + p->second.length) - frag_first;
+	dout(20) << __func__ << " extended " << f->fid << " to "
+		 << frag_first << "~" << f->length << dendl;
+      } else {
+	// new frag
+	f = &o->onode.data_map[frag_first];
+	f->offset = 0;
+	f->length = p->first + p->second.length - frag_first;
+	assert(f->length <= o->onode.frag_size);
+	int fd = _create_fid(txc, &f->fid, O_RDWR);
+	if (fd < 0) {
+	  return fd;
+	}
+	VOID_TEMP_FAILURE_RETRY(::close(fd));
+	dout(20) << __func__ << " create " << f->fid << dendl;
+      }
+    } else {
+      frag_first = fp->first;
+      f = &fp->second;
+    }
+    assert(frag_first <= p->first);
+    assert(p->first + p->second.length <= frag_first + f->length);
 
     wal_op_t *op = _get_wal_op(txc);
     op->op = wal_op_t::OP_WRITE;
-    op->offset = p->first;
+    op->offset = p->first - frag_first;
     op->length = p->second.length;
-    op->fid = f.fid;
+    op->fid = f->fid;
     // The overlays will be removed from the db after applying the WAL
     op->nid = o->onode.nid;
     op->overlays.push_back(p->second);
@@ -3332,11 +3376,18 @@ int NewStore::_do_write_all_overlays(TransContext *txc,
     map<uint64_t,overlay_t>::iterator prev = p, next = p;
     ++next;
     while (next != o->onode.overlay_map.end()) {
-      if (prev->first + prev->second.length == next->first) {
+      if (prev->first + prev->second.length == next->first &&
+	  next->first < frag_first + o->onode.frag_size) {
         dout(10) << __func__ << " combining overlay " << next->first
                  << "~" << next->second << dendl;
         op->length += next->second.length;
         op->overlays.push_back(next->second);
+
+	if (next->first + next->second.length > frag_first + f->length) {
+	  f->length = next->first + next->second.length - frag_first;
+	  dout(20) << __func__ << "  extended fragment " << f->fid
+		   << " to " << frag_first << "~" << f->length << dendl;
+	}
 
         ++prev;
         ++next;
@@ -3382,198 +3433,234 @@ void NewStore::_do_read_all_overlays(wal_transaction_t& wt)
 
 int NewStore::_do_write(TransContext *txc,
 			OnodeRef o,
-			uint64_t offset, uint64_t length,
-			bufferlist& bl,
+			uint64_t orig_offset, uint64_t orig_length,
+			bufferlist& orig_bl,
 			uint32_t fadvise_flags)
 {
   int fd = -1;
   int r = 0;
   unsigned flags;
 
-  dout(20) << __func__ << " have " << o->onode.size
+  dout(20) << __func__
+	   << " " << o->oid << " " << orig_offset << "~" << orig_length
+	   << " - have " << o->onode.size
 	   << " bytes in " << o->onode.data_map.size()
 	   << " fragments" << dendl;
 
   o->exists = true;
 
-  if (length == 0) {
-    dout(20) << __func__ << " zero-length write" << dendl;
-    goto out;
+  if (!o->onode.frag_size && o->onode.data_map.empty()) {
+    o->onode.frag_size = g_conf->newstore_min_frag_size;
+    dout(20) << __func__ << " set frag_size " << o->onode.frag_size << dendl;
   }
 
-  if ((int)o->onode.overlay_map.size() < g_conf->newstore_overlay_max &&
-      (int)length <= g_conf->newstore_overlay_max_length) {
-    // write an overlay
-    r = _do_overlay_write(txc, o, offset, length, bl);
-    if (r < 0)
-      goto out;
-    if (offset + length > o->onode.size) {
-      // make sure the data fragment matches
-      if (!o->onode.data_map.empty()) {
-	assert(o->onode.data_map.size() == 1);
-	fragment_t& f = o->onode.data_map.begin()->second;
-	assert(f.offset == 0);
-	assert(f.length == o->onode.size);
-	r = _clean_fid_tail(txc, f);
-	if (r < 0)
-	  goto out;
-	f.length = offset + length;
+  if (orig_offset + orig_length > o->onode.size) {
+    dout(20) << __func__ << " extending size to " << orig_offset + orig_length
+	     << dendl;
+    o->onode.size = orig_offset + orig_length;
+  }
+
+  uint64_t frag_size = o->onode.frag_size;
+  uint64_t length;
+  for (uint64_t offset = orig_offset;
+       offset < orig_offset + orig_length;
+       offset += length) {
+    // calc length for this fragment / chunk
+    length = orig_offset + orig_length - offset;
+    if (offset / frag_size != (offset + length) / frag_size) {
+      length = (offset / frag_size + 1) * frag_size - offset;
+    }
+    dout(20) << __func__ << " chunk " << offset << "~" << length
+	     << " (frag_size " << frag_size << ")"
+	     << dendl;
+    bufferlist bl;
+    bl.substr_of(orig_bl, offset - orig_offset, length);    
+
+    if ((int)o->onode.overlay_map.size() < g_conf->newstore_overlay_max &&
+	(int)length <= g_conf->newstore_overlay_max_length) {
+      // write an overlay
+      r = _do_overlay_write(txc, o, offset, length, bl);
+      if (r < 0)
+	goto out;
+      txc->write_onode(o);
+      continue;
+    }
+
+    flags = O_RDWR;
+    if (g_conf->newstore_o_direct &&
+	(offset & ~CEPH_PAGE_MASK) == 0 &&
+	(length & ~CEPH_PAGE_MASK) == 0) {
+      dout(20) << __func__ << " page-aligned, can use O_DIRECT, "
+	       << bl.buffers().size() << " buffers" << dendl;
+      flags |= O_DIRECT | O_DSYNC;
+      if (!bl.is_page_aligned()) {
+	dout(20) << __func__ << " rebuilding buffer to be page-aligned" << dendl;
+	bl.rebuild();
       }
-      dout(20) << __func__ << " extending size to " << offset + length << dendl;
-      o->onode.size = offset + length;
     }
-    txc->write_onode(o);
-    r = 0;
-    goto out;
-  }
 
-  flags = O_RDWR;
-  if (g_conf->newstore_o_direct &&
-      (offset & ~CEPH_PAGE_MASK) == 0 &&
-      (length & ~CEPH_PAGE_MASK) == 0) {
-    dout(20) << __func__ << " page-aligned, can use O_DIRECT, "
-	     << bl.buffers().size() << " buffers" << dendl;
-    flags |= O_DIRECT | O_DSYNC;
-    if (!bl.is_page_aligned()) {
-      dout(20) << __func__ << " rebuilding buffer to be page-aligned" << dendl;
-      bl.rebuild();
+    map<uint64_t, fragment_t>::iterator fp =
+      o->onode.data_map.lower_bound(offset);
+
+    if ((fp == o->onode.data_map.end() || fp->first > offset) &&
+	fp != o->onode.data_map.begin()) {
+      --fp;
+      if (offset < fp->first + frag_size &&
+      	  offset >= fp->first + fp->second.length) {
+	// -- append (possibly with gap) --
+	fragment_t &f = fp->second;
+	fd = _open_fid(f.fid, flags);
+	if (fd < 0) {
+	  r = fd;
+	  goto out;
+	}
+	r = _clean_fid_tail_fd(f, fd); // in case there is trailing crap
+	if (r < 0) {
+	  goto out;
+	}
+	f.length = (offset + length) - fp->first;
+	uint64_t x_offset = offset - fp->first;
+	dout(20) << __func__ << " append " << f.fid << " writing "
+		 << offset << "~" << length << " to "
+		 << x_offset << "~" << length << dendl;
+#ifdef HAVE_LIBAIO
+	if (g_conf->newstore_aio && (flags & O_DIRECT)) {
+	  txc->pending_aios.push_back(FS::aio_t(txc, fd));
+	  FS::aio_t& aio = txc->pending_aios.back();
+	  bl.prepare_iov(&aio.iov);
+	  txc->aio_bl.append(bl);
+	  aio.pwritev(x_offset);
+	  dout(2) << __func__ << " prepared aio " << &aio << dendl;
+	} else
+#endif
+        {
+	  ::lseek64(fd, x_offset, SEEK_SET);
+	  r = bl.write_fd(fd);
+	  if (r < 0) {
+	    derr << __func__ << " bl.write_fd error: " << cpp_strerror(r)
+		 << dendl;
+	    goto out;
+	  }
+	  txc->sync_fd(fd);
+	}
+	continue;
+      }
+      ++fp;
     }
-  }
 
-  if (o->onode.size <= offset ||
-      o->onode.size == 0 ||
-      o->onode.data_map.empty()) {
-    uint64_t x_offset;
-    if (o->onode.data_map.empty()) {
-      // create
-      fragment_t &f = o->onode.data_map[0];
+    if (fp == o->onode.data_map.end() ||
+	fp->first >= offset + length) {
+      // -- new frag --
+      // Note: unless we are at EOF, allocate the full frag_size,
+      // even though we only write to part of it.
+      uint64_t frag_first = offset - (offset % frag_size);
+      fragment_t &f = o->onode.data_map[frag_first];
       f.offset = 0;
-      f.length = MAX(offset + length, o->onode.size);
+      f.length = MIN(frag_size, o->onode.size - frag_first);
+      assert(f.length <= frag_size);
       fd = _create_fid(txc, &f.fid, flags);
       if (fd < 0) {
 	r = fd;
 	goto out;
       }
-      x_offset = offset;
+      uint64_t x_offset = offset - frag_first;
       dout(20) << __func__ << " create " << f.fid << " writing "
-	       << offset << "~" << length << dendl;
-    } else {
-      // append (possibly with gap)
-      assert(o->onode.data_map.size() == 1);
-      fragment_t &f = o->onode.data_map.rbegin()->second;
-      fd = _open_fid(f.fid, flags);
+	       << offset << "~" << length
+	       << " to " << x_offset << "~" << length << dendl;
+#ifdef HAVE_LIBAIO
+      if (g_conf->newstore_aio && (flags & O_DIRECT)) {
+	txc->pending_aios.push_back(FS::aio_t(txc, fd));
+	FS::aio_t& aio = txc->pending_aios.back();
+	bl.prepare_iov(&aio.iov);
+	txc->aio_bl.append(bl);
+	aio.pwritev(x_offset);
+	dout(2) << __func__ << " prepared aio " << &aio << dendl;
+      } else
+#endif
+      {
+	::lseek64(fd, x_offset, SEEK_SET);
+	r = bl.write_fd(fd);
+	if (r < 0) {
+	  derr << __func__ << " bl.write_fd error: " << cpp_strerror(r) << dendl;
+	  goto out;
+	}
+	txc->sync_fd(fd);
+      }
+      continue;
+    }
+
+    if (fp != o->onode.data_map.end() &&
+	fp->first == offset &&
+	fp->second.length <= length) {
+      // -- overwrite/replace entire frag --
+      fragment_t& f = fp->second;
+
+      _do_overlay_trim(txc, o, offset, length);
+
+      wal_op_t *op = _get_wal_op(txc);
+      op->op = wal_op_t::OP_REMOVE;
+      op->fid = fp->second.fid;
+
+      f.length = length;
+      fd = _create_fid(txc, &f.fid, O_RDWR);
       if (fd < 0) {
 	r = fd;
 	goto out;
       }
-      r = _clean_fid_tail_fd(f, fd); // in case there is trailing crap
-      if (r < 0) {
-	goto out;
-      }
-      f.length = (offset + length) - f.offset;
-      x_offset = offset - f.offset;
-      dout(20) << __func__ << " append " << f.fid << " writing "
-	       << (offset - f.offset) << "~" << length << dendl;
-    }
-    if (offset + length > o->onode.size) {
-      o->onode.size = offset + length;
-    }
-#ifdef HAVE_LIBAIO
-    if (g_conf->newstore_aio && (flags & O_DIRECT)) {
-      txc->pending_aios.push_back(FS::aio_t(txc, fd));
-      FS::aio_t& aio = txc->pending_aios.back();
-      bl.prepare_iov(&aio.iov);
-      txc->aio_bl.append(bl);
-      aio.pwritev(x_offset);
-      dout(2) << __func__ << " prepared aio " << &aio << dendl;
-    } else
-#endif
-    {
-      ::lseek64(fd, x_offset, SEEK_SET);
-      r = bl.write_fd(fd);
-      if (r < 0) {
-	derr << __func__ << " bl.write_fd error: " << cpp_strerror(r) << dendl;
-	goto out;
-      }
-      txc->sync_fd(fd);
-    }
-    r = 0;
-    goto out;
-  }
-
-  if (offset == 0 &&
-      length >= o->onode.size) {
-    // overwrite to new fid
-    assert(o->onode.data_map.size() == 1);
-    fragment_t& f = o->onode.data_map.begin()->second;
-    assert(f.offset == 0);
-    assert(f.length == o->onode.size);
-
-    _do_overlay_clear(txc, o);
-
-    wal_op_t *op = _get_wal_op(txc);
-    op->op = wal_op_t::OP_REMOVE;
-    op->fid = f.fid;
-
-    f.length = length;
-    o->onode.size = length;
-    fd = _create_fid(txc, &f.fid, O_RDWR);
-    if (fd < 0) {
-      r = fd;
-      goto out;
-    }
-    dout(20) << __func__ << " replace old fid " << op->fid
-	     << " with new fid " << f.fid
-	     << ", writing " << offset << "~" << length << dendl;
+      dout(20) << __func__ << " replace old fid " << op->fid
+	       << " with new fid " << f.fid
+	       << ", writing " << offset << "~" << length
+	       << " to 0~" << length << dendl;
 
 #ifdef HAVE_LIBAIO
-    if (g_conf->newstore_aio && (flags & O_DIRECT)) {
-      txc->pending_aios.push_back(FS::aio_t(txc, fd));
-      FS::aio_t& aio = txc->pending_aios.back();
-      bl.prepare_iov(&aio.iov);
-      txc->aio_bl.append(bl);
-      aio.pwritev(0);
-      dout(2) << __func__ << " prepared aio " << &aio << dendl;
-    } else
+      if (g_conf->newstore_aio && (flags & O_DIRECT)) {
+	txc->pending_aios.push_back(FS::aio_t(txc, fd));
+	FS::aio_t& aio = txc->pending_aios.back();
+	bl.prepare_iov(&aio.iov);
+	txc->aio_bl.append(bl);
+	aio.pwritev(0);
+	dout(2) << __func__ << " prepared aio " << &aio << dendl;
+      } else
 #endif
-    {
-      r = bl.write_fd(fd);
-      if (r < 0) {
-	derr << __func__ << " bl.write_fd error: " << cpp_strerror(r) << dendl;
-	goto out;
+      {
+	r = bl.write_fd(fd);
+	if (r < 0) {
+	  derr << __func__ << " bl.write_fd error: " << cpp_strerror(r) << dendl;
+	  goto out;
+	}
+	txc->sync_fd(fd);
       }
-      txc->sync_fd(fd);
+      continue;
     }
-    r = 0;
-    goto out;
-  }
 
-  if (true) {
-    // WAL
-    assert(o->onode.data_map.size() == 1);
-    fragment_t& f = o->onode.data_map.begin()->second;
-    assert(f.offset == 0);
-    assert(f.length == o->onode.size);
-    r = _do_write_all_overlays(txc, o);
-    if (r < 0)
-      goto out;
-    r = _clean_fid_tail(txc, f);
-    if (r < 0)
-      goto out;
-    wal_op_t *op = _get_wal_op(txc);
-    op->op = wal_op_t::OP_WRITE;
-    op->offset = offset - f.offset;
-    op->length = length;
-    op->fid = f.fid;
-    op->data = bl;
-    if (offset + length > o->onode.size) {
-      o->onode.size = offset + length;
+    if (true) {
+      // -- WAL --
+      r = _do_write_all_overlays(txc, o);
+      if (r < 0)
+	goto out;
+      fragment_t& f = fp->second;
+      assert(fp->first <= offset);
+      assert(offset + length <= fp->first + fp->second.length);
+      r = _clean_fid_tail(txc, f);
+      if (r < 0)
+	goto out;
+      wal_op_t *op = _get_wal_op(txc);
+      op->op = wal_op_t::OP_WRITE;
+      op->offset = offset - fp->first;
+      op->length = length;
+      op->fid = f.fid;
+      op->data = bl;
+      if (offset + length - fp->first > f.length) {
+	f.length = offset + length - fp->first;
+      }
+      dout(20) << __func__ << " wal " << f.fid << " write "
+	       << offset << "~" << length << " to "
+	       << op->offset << "~" << op->length
+	       << dendl;
+      continue;
     }
-    if (offset + length - f.offset > f.length) {
-      f.length = offset + length - f.offset;
-    }
-    dout(20) << __func__ << " wal " << f.fid << " write "
-	     << (offset - f.offset) << "~" << length << dendl;
+
+    assert(0 == "don't get here");
   }
   r = 0;
 
@@ -3591,10 +3678,10 @@ int NewStore::_clean_fid_tail_fd(const fragment_t& f, int fd)
 	 << cpp_strerror(r) << dendl;
     return r;
   }
-  if (st.st_size > f.length) {
-    dout(20) << __func__ << " frag " << f.fid << " is long, truncating"
-	     << dendl;
-    r = ::ftruncate(fd, f.length);
+  if (st.st_size > f.offset + f.length) {
+    dout(20) << __func__ << " frag " << f.fid << " is long (" << st.st_size
+	     << "), truncating to " << (f.offset + f.length) << dendl;
+    r = ::ftruncate(fd, f.offset + f.length);
     if (r < 0) {
       derr << __func__ << " failed to ftruncate " << f.fid << ": "
 	   << cpp_strerror(r) << dendl;
@@ -3662,53 +3749,71 @@ int NewStore::_zero(TransContext *txc,
   _assign_nid(txc, o);
 
   // overlay
-  if (_do_overlay_trim(txc, o, offset, length) > 0)
-    txc->write_onode(o);
+  _do_overlay_trim(txc, o, offset, length);
 
-  if (o->onode.data_map.empty()) {
-    // we're already a big hole
-    if (offset + length > o->onode.size) {
-      o->onode.size = offset + length;
-      txc->write_onode(o);
+  map<uint64_t,fragment_t>::iterator fp = o->onode.find_fragment(offset);
+  while (fp != o->onode.data_map.end()) {
+    if (fp->first >= offset + length)
+      break;
+
+    fragment_t& f = fp->second;
+    if (offset <= fp->first &&
+	offset + length >= fp->first + fp->second.length) {
+      // remove fragment
+      dout(20) << __func__ << " wal rm fragment " << fp->first << " "
+	       << f << dendl;
+      wal_op_t *op = _get_wal_op(txc);
+      op->op = wal_op_t::OP_REMOVE;
+      op->fid = f.fid;
+      o->onode.data_map.erase(fp++);
+      continue;
     }
-  } else {
-    assert(o->onode.data_map.size() == 1);
-    fragment_t& f = o->onode.data_map.begin()->second;
-    assert(f.offset == 0);
-    assert(f.length == o->onode.size);
 
-    r = _clean_fid_tail(txc, f);
-    if (r < 0)
-      goto out;
+    // start,end are offsets in the fragment
+    uint64_t start = 0;
+    if (offset > fp->first) {
+      start = offset - fp->first;
+    }
+    assert(o->onode.frag_size);
+    uint64_t end = MIN(offset + length - fp->first,
+		       o->onode.frag_size);
 
-    if (offset >= o->onode.size) {
-      // after tail
-      int fd = _open_fid(f.fid, O_RDWR);
-      if (fd < 0) {
-	r = fd;
-	goto out;
-      }
-      f.length = (offset + length) - f.offset;
-      r = ::ftruncate(fd, f.length);
-      assert(r == 0);   // this shouldn't fail
-      dout(20) << __func__ << " tail " << f.fid << " truncating up to "
-	       << f.length << dendl;
-      o->onode.size = offset + length;
-      txc->write_onode(o);
+    if (end >= f.length) {
+      // truncate fragment
+      wal_op_t *op = _get_wal_op(txc);
+      op->op = wal_op_t::OP_TRUNCATE;
+      op->fid = f.fid;
+      op->offset = start;
+      dout(20) << __func__ << " wal truncate fragment " << fp->first << " "
+	       << f << " to " << start << dendl;
     } else {
       // WAL
+      r = _clean_fid_tail(txc, f);
+      if (r < 0)
+	goto out;
+
       wal_op_t *op = _get_wal_op(txc);
       op->op = wal_op_t::OP_ZERO;
-      op->offset = offset - f.offset;
-      op->length = length;
+      op->offset = start;
+      op->length = end - start;
       op->fid = f.fid;
-      if (offset + length > o->onode.size) {
-	f.length = offset + length - f.offset;
-	o->onode.size = offset + length;
-	txc->write_onode(o);
-      }
     }
+    
+    // size fragment up?
+    if (end > f.length) {
+      f.length = end;
+      dout(20) << __func__ << " frag " << f.fid << " sized up to "
+	       << f.length << dendl;
+    }
+    fp++;
   }
+  
+  if (offset + length > o->onode.size) {
+    o->onode.size = offset + length;
+    dout(20) << __func__ << " extending size to " << offset + length
+	     << dendl;
+  }
+  txc->write_onode(o);
 
  out:
   dout(10) << __func__ << " " << c->cid << " " << oid
@@ -3757,18 +3862,6 @@ int NewStore::_do_truncate(TransContext *txc, OnodeRef o, uint64_t offset)
   }
 
   // truncate up trailing fragment?
-  if (!o->onode.data_map.empty() && offset > o->onode.size) {
-    // resize file up.  make sure we don't have trailing bytes
-    assert(o->onode.data_map.size() == 1);
-    fragment_t& f = o->onode.data_map.begin()->second;
-    assert(f.offset == 0);
-    assert(f.length == o->onode.size);
-    dout(20) << __func__ << " truncate up " << f << " to " << offset << dendl;
-    int r = _clean_fid_tail(txc, f);
-    if (r < 0)
-      return r;
-    f.length = offset;
-  }
 
   // trim down overlays
   map<uint64_t,overlay_t>::iterator op = o->onode.overlay_map.end();
@@ -4184,6 +4277,10 @@ int NewStore::_setallochint(TransContext *txc,
   o->onode.expected_object_size = expected_object_size;
   o->onode.expected_write_size = expected_write_size;
   txc->write_onode(o);
+
+  if (o->onode.data_map.empty()) {
+    // FIXME: we could do something clever with onode.frag_size here.
+  }
 
  out:
   dout(10) << __func__ << " " << c->cid << " " << oid

--- a/src/os/newstore/NewStore.h
+++ b/src/os/newstore/NewStore.h
@@ -461,7 +461,6 @@ private:
   KeyValueDB *db;
   FS *fs;
   uuid_d fsid;
-  string db_path;
   int path_fd;  ///< open handle to $path
   int fsid_fd;  ///< open handle (locked) to $path/fsid
   int frag_fd;  ///< open handle to $path/fragments

--- a/src/os/newstore/NewStore.h
+++ b/src/os/newstore/NewStore.h
@@ -524,7 +524,7 @@ private:
   int _open_frag();
   int _create_frag();
   void _close_frag();
-  int _open_db();
+  int _open_db(bool create);
   void _close_db();
   int _open_collections();
   void _close_collections();

--- a/src/os/newstore/NewStore.h
+++ b/src/os/newstore/NewStore.h
@@ -541,6 +541,8 @@ private:
   int _recover_next_nid();
   void _assign_nid(TransContext *txc, OnodeRef o);
 
+  void _dump_onode(OnodeRef o);
+
   int _clean_fid_tail_fd(const fragment_t& f, int fd);
   int _clean_fid_tail(TransContext *txc, const fragment_t& f);
 

--- a/src/os/newstore/NewStore.h
+++ b/src/os/newstore/NewStore.h
@@ -534,7 +534,7 @@ private:
   void _reap_collections();
 
   int _recover_next_fid();
-  int _create_fid(TransContext *txc, fid_t *fid, unsigned flags);
+  int _create_fid(TransContext *txc, OnodeRef o, fid_t *fid, unsigned flags);
   int _open_fid(fid_t fid, unsigned flags);
   int _remove_fid(fid_t fid);
 

--- a/src/os/newstore/newstore_types.cc
+++ b/src/os/newstore/newstore_types.cc
@@ -153,6 +153,7 @@ void onode_t::encode(bufferlist& bl) const
   ::encode(omap_head, bl);
   ::encode(expected_object_size, bl);
   ::encode(expected_write_size, bl);
+  ::encode(frag_size, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -169,6 +170,7 @@ void onode_t::decode(bufferlist::iterator& p)
   ::decode(omap_head, p);
   ::decode(expected_object_size, p);
   ::decode(expected_write_size, p);
+  ::decode(frag_size, p);
   DECODE_FINISH(p);
 }
 
@@ -210,6 +212,7 @@ void onode_t::dump(Formatter *f) const
   f->close_section();
   f->dump_unsigned("last_overlay_key", last_overlay_key);
   f->dump_unsigned("omap_head", omap_head);
+  f->dump_unsigned("frag_size", frag_size);
   f->dump_unsigned("expected_object_size", expected_object_size);
   f->dump_unsigned("expected_write_size", expected_write_size);
 }

--- a/src/os/newstore/newstore_types.cc
+++ b/src/os/newstore/newstore_types.cc
@@ -272,6 +272,22 @@ void wal_op_t::dump(Formatter *f) const
   }
 }
 
+void wal_op_t::generate_test_instances(list<wal_op_t*>& o)
+{
+  o.push_back(new wal_op_t);
+  o.push_back(new wal_op_t);
+  o.back()->op = OP_WRITE;
+  o.back()->offset = 1;
+  o.back()->length = 2;
+  o.back()->data.append("my data");
+  o.back()->nid = 3;
+  o.back()->overlays.push_back(overlay_t());
+  o.back()->overlays.push_back(overlay_t());
+  o.back()->overlays.back().key = 4;
+  o.back()->overlays.back().value_offset = 5;
+  o.back()->overlays.back().length = 6;
+}
+
 void wal_transaction_t::encode(bufferlist& bl) const
 {
   ENCODE_START(1, 1, bl);
@@ -304,4 +320,18 @@ void wal_transaction_t::dump(Formatter *f) const
     f->dump_string("shared_overlay_key", *p);
   }
   f->close_section();
+}
+
+void wal_transaction_t::generate_test_instances(list<wal_transaction_t*>& o)
+{
+  o.push_back(new wal_transaction_t());
+  o.push_back(new wal_transaction_t());
+  o.back()->seq = 123;
+  o.back()->ops.push_back(wal_op_t());
+  o.back()->ops.push_back(wal_op_t());
+  o.back()->ops.back().op = wal_op_t::OP_WRITE;
+  o.back()->ops.back().offset = 2;
+  o.back()->ops.back().length = 3;
+  o.back()->ops.back().data.append("foodata");
+  o.back()->ops.back().nid = 4;
 }

--- a/src/os/newstore/newstore_types.cc
+++ b/src/os/newstore/newstore_types.cc
@@ -58,6 +58,49 @@ void fid_t::generate_test_instances(list<fid_t*>& o)
   o.push_back(new fid_t(123, 3278));
 }
 
+// fid_backpointer_t
+
+void fid_backpointer_t::encode(bufferlist& bl) const
+{
+  ENCODE_START(1, 1, bl);
+  ::encode(oid, bl);
+  ::encode(nid, bl);
+  ::encode(offset, bl);
+  ENCODE_FINISH(bl);
+}
+
+void fid_backpointer_t::decode(bufferlist::iterator& p)
+{
+  DECODE_START(1, p);
+  ::decode(oid, p);
+  ::decode(nid, p);
+  ::decode(offset, p);
+  DECODE_FINISH(p);
+}
+
+void fid_backpointer_t::dump(Formatter *f) const
+{
+  f->dump_object("oid", oid);
+  f->dump_unsigned("nid", nid);
+  f->dump_unsigned("offset", offset);
+}
+
+void fid_backpointer_t::generate_test_instances(list<fid_backpointer_t*>& o)
+{
+  o.push_back(new fid_backpointer_t);
+  o.push_back(new fid_backpointer_t);
+  o.back()->oid.hobj.oid.name = "foo";
+  o.back()->nid = 12;
+  o.back()->offset = 123;
+}
+
+ostream& operator<<(ostream& out, const fid_backpointer_t& bp)
+{
+  return out << "fidbp(" << bp.oid
+	     << " nid " << bp.nid
+	     << " offset " << bp.offset << ")";
+}
+
 // fragment_t
 
 void fragment_t::encode(bufferlist& bl) const

--- a/src/os/newstore/newstore_types.h
+++ b/src/os/newstore/newstore_types.h
@@ -120,6 +120,8 @@ struct onode_t {
   uint32_t last_overlay_key;           ///< key for next overlay
   uint64_t omap_head;                  ///< id for omap root node
 
+  uint32_t frag_size;                  ///< fixed fragment size
+
   uint32_t expected_object_size;
   uint32_t expected_write_size;
 
@@ -128,8 +130,22 @@ struct onode_t {
       size(0),
       last_overlay_key(0),
       omap_head(0),
+      frag_size(0),
       expected_object_size(0),
       expected_write_size(0) {}
+
+  map<uint64_t,fragment_t>::iterator find_fragment(uint64_t offset) {
+    map<uint64_t, fragment_t>::iterator fp = data_map.lower_bound(offset);
+    fp = data_map.lower_bound(offset);
+    if (fp != data_map.begin()) {
+      --fp;
+    }
+    if (fp != data_map.end() &&
+	fp->first + fp->second.length <= offset) {
+      ++fp;
+    }
+    return fp;
+  }
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& p);

--- a/src/os/newstore/newstore_types.h
+++ b/src/os/newstore/newstore_types.h
@@ -17,6 +17,7 @@
 
 #include <ostream>
 #include "include/types.h"
+#include "common/hobject.h"
 
 namespace ceph {
   class Formatter;
@@ -70,6 +71,24 @@ static inline bool operator==(const fid_t& a, const fid_t& b) {
 static inline bool operator!=(const fid_t& a, const fid_t& b) {
   return !(a == b);
 }
+
+struct fid_backpointer_t {
+  ghobject_t oid;
+  uint64_t nid;
+  uint64_t offset;
+
+  fid_backpointer_t() : nid(0), offset(0) {}
+  fid_backpointer_t(const ghobject_t& o, uint64_t n, uint64_t off)
+    : oid(o), nid(n), offset(off) {}
+
+  void encode(bufferlist& bl) const;
+  void decode(bufferlist::iterator& p);
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<fid_backpointer_t*>& o);
+};
+WRITE_CLASS_ENCODER(fid_backpointer_t)
+
+ostream& operator<<(ostream& out, const fid_backpointer_t& bp);
 
 /// fragment: a byte extent backed by a file
 struct fragment_t {
@@ -169,6 +188,8 @@ struct wal_op_t {
   bufferlist data;
   uint64_t nid;
   vector<overlay_t> overlays;
+
+  wal_op_t() : offset(0), length(0), nid(0) {}
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& p);

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -111,6 +111,15 @@ TYPE(ObjectStore::Transaction)
 #include "os/SequencerPosition.h"
 TYPE(SequencerPosition)
 
+#include "os/newstore/newstore_types.h"
+TYPE(cnode_t)
+TYPE(fid_t)
+TYPE(fragment_t)
+TYPE(overlay_t)
+TYPE(onode_t)
+TYPE(wal_op_t)
+TYPE(wal_transaction_t)
+
 #include "common/hobject.h"
 TYPE(hobject_t)
 TYPE(ghobject_t)

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -114,6 +114,7 @@ TYPE(SequencerPosition)
 #include "os/newstore/newstore_types.h"
 TYPE(cnode_t)
 TYPE(fid_t)
+TYPE(fid_backpointer_t)
 TYPE(fragment_t)
 TYPE(overlay_t)
 TYPE(onode_t)


### PR DESCRIPTION
This allows us to write to new files for large (but not complete object)
writes, instead of doing a WAL double-write.