### PR TITLE
assert: __STRING macro is not defined by musl libc.

### DIFF
--- a/src/include/assert.h
+++ b/src/include/assert.h
@@ -3,6 +3,11 @@
 
 #if defined(__linux__)
 #include <features.h>
+
+#ifndef __STRING
+# define __STRING(x) #x
+#endif
+
 #elif defined(__FreeBSD__)
 #include <sys/cdefs.h>
 #define	__GNUC_PREREQ(minor, major)	__GNUC_PREREQ__(minor, major)


### PR DESCRIPTION
Signed-off-by: John Coyle <dx9err@gmail.com>