### PR TITLE
cls: new force-promotion flag for class methods

### DIFF
--- a/src/cls/hello/cls_hello.cc
+++ b/src/cls/hello/cls_hello.cc
@@ -319,7 +319,7 @@ void __cls_init()
 			  CLS_METHOD_RD,
 			  say_hello, &h_say_hello);
   cls_register_cxx_method(h_class, "record_hello",
-			  CLS_METHOD_WR,
+			  CLS_METHOD_WR | CLS_METHOD_PROMOTE,
 			  record_hello, &h_record_hello);
   cls_register_cxx_method(h_class, "writes_dont_return_data",
 			  CLS_METHOD_WR,
@@ -330,7 +330,7 @@ void __cls_init()
 
   // RD | WR is a read-modify-write method.
   cls_register_cxx_method(h_class, "turn_it_to_11",
-			  CLS_METHOD_RD | CLS_METHOD_WR,
+			  CLS_METHOD_RD | CLS_METHOD_WR | CLS_METHOD_PROMOTE,
 			  turn_it_to_11, &h_turn_it_to_11);
 
   // counter-examples

--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -519,10 +519,10 @@ void __cls_init()
 
   cls_register("lock", &h_class);
   cls_register_cxx_method(h_class, "lock",
-                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          CLS_METHOD_RD | CLS_METHOD_WR | CLS_METHOD_PROMOTE,
                           lock_op, &h_lock_op);
   cls_register_cxx_method(h_class, "unlock",
-                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          CLS_METHOD_RD | CLS_METHOD_WR | CLS_METHOD_PROMOTE,
                           unlock_op, &h_unlock_op);
   cls_register_cxx_method(h_class, "break_lock",
                           CLS_METHOD_RD | CLS_METHOD_WR,
@@ -534,7 +534,7 @@ void __cls_init()
                           CLS_METHOD_RD,
                           list_locks, &h_list_locks);
   cls_register_cxx_method(h_class, "assert_locked",
-                          CLS_METHOD_RD,
+                          CLS_METHOD_RD | CLS_METHOD_PROMOTE,
                           assert_locked, &h_assert_locked);
 
   return;

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -22,9 +22,10 @@ int __cls_ver_min = min;
 int __cls_name__## name = 0; \
 const char *__cls_name = #name;
 
-#define CLS_METHOD_RD		0x1
-#define CLS_METHOD_WR		0x2
-#define CLS_METHOD_PUBLIC	0x4
+#define CLS_METHOD_RD       0x1 /// method executes read operations
+#define CLS_METHOD_WR       0x2 /// method executes write operations
+#define CLS_METHOD_PUBLIC   0x4 /// unused
+#define CLS_METHOD_PROMOTE  0x8 /// method cannot be proxied to base tier
 
 
 #define CLS_LOG(level, fmt, ...)					\

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8772,13 +8772,19 @@ int OSD::init_op_flags(OpRequestRef& op)
 	}
 	is_read = flags & CLS_METHOD_RD;
 	is_write = flags & CLS_METHOD_WR;
+        bool is_promote = flags & CLS_METHOD_PROMOTE;
 
-	dout(10) << "class " << cname << " method " << mname
-		<< " flags=" << (is_read ? "r" : "") << (is_write ? "w" : "") << dendl;
+	dout(10) << "class " << cname << " method " << mname << " "
+		 << "flags=" << (is_read ? "r" : "")
+                             << (is_write ? "w" : "")
+                             << (is_promote ? "p" : "")
+                 << dendl;
 	if (is_read)
 	  op->set_class_read();
 	if (is_write)
 	  op->set_class_write();
+        if (is_promote)
+          op->set_promote();
 	break;
       }
 


### PR DESCRIPTION
Class methods that use the cls_get_request_origin should not be
proxied to a base tier -- otherwise the origin will reflect the
cache tier instead of the client.

Fixes: #13380

Signed-off-by: Jason Dillaman <dillaman@redhat.com>