### PR TITLE
Compare parted output with the dereferenced path

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -996,7 +996,7 @@ def get_free_partition_index(dev):
         'BYT;' not in lines):
         raise Error('parted output expected to contain one of ' +
                     'CHH; CYL; or BYT; : ' + lines)
-    if dev not in lines:
+    if os.path(dev) not in lines:
         raise Error('parted output expected to contain ' + dev + ': ' + lines)
     _, partitions = lines.split(dev)
     partition_numbers = extract_parted_partition_numbers(partitions)


### PR DESCRIPTION
Compare parted output with the dereferenced path of the device as parted prints that instead of the symlink we called it with.

Signed-off-by: Joe Julian <jjulian@io.com>