### PR TITLE
pybind/rados: Fix binary omap values.

### DIFF
--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -2000,7 +2000,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         :para start_after: list keys starting after start_after
         :type start_after: str
         :para filter_prefix: list only keys beginning with filter_prefix
-        :type filter_prefix: int
+        :type filter_prefix: str
         :para max_return: list no more than max_return key/value pairs
         :type max_return: int
         :returns: an iterator over the the requested omap values, return value from this action

--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -846,17 +846,20 @@ class OmapIterator(object):
         Get the next key-value pair in the object
         :returns: next rados.OmapItem
         """
-        key = c_char_p()
-        value = c_char_p()
-        lens  = c_int()
-        run_in_thread(self.ioctx.librados.rados_omap_get_next,
-                      (self.ctx, pointer(key), pointer(value),
-                       pointer(lens)))
-        if key.value is None and value.value is None:
+        key_ = c_char_p(0)
+        val_ = c_char_p(0)
+        len_ = c_int(0)
+        ret = run_in_thread(self.ioctx.librados.rados_omap_get_next,
+                      (self.ctx, byref(key_), byref(val_), byref(len_)))
+        if (ret != 0):
+            raise make_ex(ret, "error iterating over the omap")
+        if key_.value is None:
             raise StopIteration()
-        if lens.value:
-            value.value = value.value[0:lens.value]
-        return (key.value, value.value)
+        key = ctypes.string_at(key_)
+        val = None
+        if val_.value is not None:
+            val = ctypes.string_at(val_, len_)
+        return (key, val)
 
     def __del__(self):
         run_in_thread(self.ioctx.librados.rados_omap_get_end, (self.ctx,))

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -338,27 +338,27 @@ class TestIoctx(object):
         eq(list(self.ioctx.list_snaps()), [])
 
     def test_set_omap(self):
-        keys = ("1", "2", "3")
-        values = ("aaa", "bbb", "ccc")
+        keys = ("1", "2", "3", "4")
+        values = ("aaa", "bbb", "ccc", "\x04\x04\x04\x04")
         with WriteOpCtx(self.ioctx) as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             self.ioctx.operate_write_op(write_op, "hw")
         with ReadOpCtx(self.ioctx) as read_op:
-            iter, ret = self.ioctx.get_omap_vals(read_op, "", "", 3)
+            iter, ret = self.ioctx.get_omap_vals(read_op, "", "", 4)
             self.ioctx.operate_read_op(read_op, "hw")
             iter.next()
-            eq(list(iter), [("2", "bbb"), ("3", "ccc")])
+            eq(list(iter), [("2", "bbb"), ("3", "ccc"), ("4", "\x04\x04\x04\x04")])
 
     def test_get_omap_vals_by_keys(self):
-        keys = ("1", "2", "3")
-        values = ("aaa", "bbb", "ccc")
+        keys = ("1", "2", "3", "4")
+        values = ("aaa", "bbb", "ccc", "\x04\x04\x04\x04")
         with WriteOpCtx(self.ioctx) as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             self.ioctx.operate_write_op(write_op, "hw")
         with ReadOpCtx(self.ioctx) as read_op:
-            iter, ret = self.ioctx.get_omap_vals_by_keys(read_op,("3",))
+            iter, ret = self.ioctx.get_omap_vals_by_keys(read_op,("3","4",))
             self.ioctx.operate_read_op(read_op, "hw")
-            eq(list(iter), [("3", "ccc")])
+            eq(list(iter), [("3", "ccc"), ("4", "\x04\x04\x04\x04")])
 
     def test_get_omap_keys(self):
         keys = ("1", "2", "3")


### PR DESCRIPTION
The prior code caused binary omap values to be discarded. This fixes
them to use the same model as the xattr iterator, and correctly return
binary data as python strings, eg:
'object_prefix': '\x15\x00\x00\x00rbd_data.449d2ae8944a'

Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>