### PR TITLE
Librados map object

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -2832,6 +2832,20 @@ CEPH_RADOS_API int rados_blacklist_add(rados_t cluster,
 				       uint32_t expire_seconds);
 
 /**
+ * Give the up set of OSDs for specific object
+ *
+ * @param cluster cluster handle
+ * @param obj_name object name
+ * @param pool_id id of pool to look up (-1 for default to look up in pool 0)
+ * @param up up set of OSDs
+ * @param up_size size of the up set
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_map_object(rados_t cluster, const char *obj_name,
+                                    char **up, size_t *up_size,
+                                    int64_t pool_id);
+
+/**
  * @name Mon/OSD/PG Commands
  *
  * These interfaces send commands relating to the monitor, OSD, or PGs.

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1143,6 +1143,7 @@ namespace librados
     int blacklist_add(const std::string& client_address,
                       uint32_t expire_seconds);
 
+    int map_object(const char *obj_name, std::vector<int>& up, int64_t pool_id);
     /*
      * pool aio
      *

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -117,6 +117,8 @@ public:
 
   int blacklist_add(const string& client_address, uint32_t expire_seconds);
 
+  int map_object(const char *obj_name, vector<int>& up, int64_t pool_id=-1);
+
   int mon_command(const vector<string>& cmd, const bufferlist &inbl,
 	          bufferlist *outbl, string *outs);
   int mon_command(int rank,

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -96,6 +96,7 @@ class TestRadosStateError(object):
         assert_raises(RadosStateError, rados.pg_command, '', '', '')
         assert_raises(RadosStateError, rados.wait_for_latest_osdmap)
         assert_raises(RadosStateError, rados.blacklist_add, '127.0.0.1/123', 0)
+        assert_raises(RadosStateError, rados.map_object, 'foo', -2)
 
     def test_configuring(self):
         rados = Rados(conffile='')
@@ -206,6 +207,9 @@ class TestRados(object):
 
     def test_blacklist_add(self):
         self.rados.blacklist_add("1.2.3.4/123", 1)
+
+    def test_map_object(self):
+        self.rados.map_object("foo", 1)
 
 class TestIoctx(object):
 


### PR DESCRIPTION
Ceph use crush algorithm to provide the mapping of objects to OSD servers.
However if you want to get the layout, there's public API for this instead 
you'll have to rely on the command to monitor:

$ ceph osd map pool_name obj_name

The "ceph_get_osd_crush_location" method is made available via libcephfs
but not available in librados.

This patch provides API to render the object distribution layout. With this
the application could choose which nodes to access, for load-balance purpose.

This patch also adds the API for python bindings