### PR TITLE
signal_handler: fallback to strsignal when sys_siglist is not implemented

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ CHECK_SYMBOL_EXISTS(__u8 "sys/types.h;linux/types.h" HAVE___U8)
 CHECK_SYMBOL_EXISTS(__u64 "sys/types.h;linux/types.h" HAVE___U64)
 CHECK_SYMBOL_EXISTS(__s64 "sys/types.h;linux/types.h" HAVE___S64)
 
+CHECK_SYMBOL_EXISTS(sys_siglist "signal.h;string.h" HAVE_SYS_SIGLIST)
+
 set(CEPH_MAN_DIR "share/man" CACHE STRING "Install location for man pages (relative to prefix).")
 
 option(ENABLE_SHARED "build shared libraries" ON)

--- a/configure.ac
+++ b/configure.ac
@@ -1055,6 +1055,9 @@ AC_CHECK_FUNC([pthread_spin_init],
 LIBS="$saved_LIBS"
 CFLAGS="$saved_CFLAGS"
 
+
+AC_CHECK_DECL([sys_siglist],[AC_DEFINE(HAVE_SYS_SIGLIST, 1, [Define if you have sys_siglist])],[], [#include <signal.h> #include <string.h>])
+
 AC_CHECK_TYPES([int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
   int64_t, uint64_t])
 

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -42,7 +42,7 @@ void install_sighandler(int signum, signal_handler_t handler, int flags)
     char buf[1024];
     snprintf(buf, sizeof(buf), "install_sighandler: sigaction returned "
 	    "%d when trying to install a signal handler for %s\n",
-	     ret, sys_siglist[signum]);
+	     ret, sig_str(signum));
     dout_emergency(buf);
     exit(1);
   }
@@ -80,7 +80,7 @@ static void handle_fatal_signal(int signum)
   // presumably dump core-- will handle it.
   char buf[1024];
   snprintf(buf, sizeof(buf), "*** Caught signal (%s) **\n "
-	    "in thread %llx\n", sys_siglist[signum], (unsigned long long)pthread_self());
+	    "in thread %llx\n", sig_str(signum), (unsigned long long)pthread_self());
   dout_emergency(buf);
   pidfile_remove();
 

--- a/src/global/signal_handler.h
+++ b/src/global/signal_handler.h
@@ -18,7 +18,15 @@
 #include <signal.h>
 #include <string>
 
+#include "acconfig.h"
+
 typedef void (*signal_handler_t)(int);
+
+#ifdef HAVE_SYS_SIGLIST
+# define sig_str(signum) sys_siglist[signum]
+#else
+# define sig_str(signum) strsignal(signum)
+#endif
 
 void install_sighandler(int signum, signal_handler_t handler, int flags);
 

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -234,4 +234,7 @@
 #cmakedefine HAVE_GPERFTOOLS_MALLOC_EXTENSION_H
 #cmakedefine HAVE_GPERFTOOLS_PROFILER_H
 
+/* Define if HAVE_SYS_SIGLIST */
+#cmakedefine HAVE_SYS_SIGLIST
+
 #endif /* CONFIG_H */

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -966,7 +966,7 @@ void MDSDaemon::_handle_mds_map(MDSMap *oldmap)
 void MDSDaemon::handle_signal(int signum)
 {
   assert(signum == SIGINT || signum == SIGTERM);
-  derr << "*** got signal " << sys_siglist[signum] << " ***" << dendl;
+  derr << "*** got signal " << sig_str(signum) << " ***" << dendl;
   {
     Mutex::Locker l(mds_lock);
     if (stopping) {

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -62,6 +62,8 @@
 #include "common/perf_counters.h"
 #include "common/admin_socket.h"
 
+#include "global/signal_handler.h"
+
 #include "include/color.h"
 #include "include/ceph_fs.h"
 #include "include/str_list.h"
@@ -356,7 +358,7 @@ abort:
 void Monitor::handle_signal(int signum)
 {
   assert(signum == SIGINT || signum == SIGTERM);
-  derr << "*** Got Signal " << sys_siglist[signum] << " ***" << dendl;
+  derr << "*** Got Signal " << sig_str(signum) << " ***" << dendl;
   shutdown();
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1605,7 +1605,7 @@ void cls_initialize(ClassHandler *ch);
 void OSD::handle_signal(int signum)
 {
   assert(signum == SIGINT || signum == SIGTERM);
-  derr << "*** Got signal " << sys_siglist[signum] << " ***" << dendl;
+  derr << "*** Got signal " << sig_str(signum) << " ***" << dendl;
   shutdown();
 }
 

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -935,7 +935,7 @@ void handle_test_signal(int signum)
   if ((signum != SIGINT) && (signum != SIGTERM))
     return;
 
-  std::cerr << "*** Got signal " << sys_siglist[signum] << " ***" << std::endl;
+  std::cerr << "*** Got signal " << sig_str(signum) << " ***" << std::endl;
   Mutex::Locker l(shutdown_lock);
   if (shutdown_timer) {
     shutdown_timer->cancel_all_events();


### PR DESCRIPTION
musl libc does not provide sys_siglist.

Added feature check for sys_siglist and a fallback to strsignal().

Signed-off-by: John Coyle dx9err@gmail.com