### PR TITLE
Fix debug message in osd::is_healthy

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4513,7 +4513,8 @@ bool OSD::_is_healthy()
       ++num;
     }
     if ((float)up < (float)num * cct->_conf->osd_heartbeat_min_healthy_ratio) {
-      dout(1) << "is_healthy false -- only " << up << "/" << num << " up peers (less than 1/3)" << dendl;
+      dout(1) << "is_healthy false -- only " << up << "/" << num << " up peers (less than "
+	      << int(cct->_conf->osd_heartbeat_min_healthy_ratio * 100.0) << "%)" << dendl;
       return false;
     }
   }


### PR DESCRIPTION
Display the actual vaule of osd_heartbeat_min_healthy_ratio instead
of 1/3 (default value).

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>