### PR TITLE
rgw: fix response of delete expired objects

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2428,7 +2428,16 @@ void RGWDeleteObj::execute()
 {
   ret = -EINVAL;
   rgw_obj obj(s->bucket, s->object);
+  map<string, bufferlist> orig_attrs;
+
   if (!s->object.empty()) {
+    if (need_object_expiration()) {
+      /* check if obj exists, read orig attrs */
+      ret = get_obj_attrs(store, s, obj, orig_attrs);
+      if (ret < 0) {
+        return;
+      }
+    }
     RGWObjectCtx *obj_ctx = static_cast<RGWObjectCtx *>(s->obj_ctx);
 
     obj_ctx->set_atomic(obj);
@@ -2448,6 +2457,13 @@ void RGWDeleteObj::execute()
     if (ret >= 0) {
       delete_marker = del_op.result.delete_marker;
       version_id = del_op.result.version_id;
+    }
+
+    /* Check whether the object has expired. Swift API documentation
+     * stands that we should return 404 Not Found in such case. */
+    if (need_object_expiration() && object_is_expired(orig_attrs)) {
+      ret = -ENOENT;
+      return;
     }
   }
 }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -625,6 +625,7 @@ public:
   virtual const string name() { return "delete_obj"; }
   virtual RGWOpType get_type() { return RGW_OP_DELETE_OBJ; }
   virtual uint32_t op_mask() { return RGW_OP_TYPE_DELETE; }
+  virtual bool need_object_expiration() { return false; }
 };
 
 class RGWCopyObj : public RGWOp {

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -124,6 +124,7 @@ public:
   RGWDeleteObj_ObjStore_SWIFT() {}
   ~RGWDeleteObj_ObjStore_SWIFT() {}
 
+  bool need_object_expiration() { return true; }
   void send_response();
 };
 


### PR DESCRIPTION
GET/HEAD requests to the expired-but-not-yet-deleted objects will
'404 Not Found' currently.

Swift's response to a DELETE of an expired object is 404; however,
the object does get deleted.

This patch fixes this issue by checking the expire time in Swift DELETE
op, delete the object with a 404 http code.

Fixes #13469

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>