### PR TITLE
ceph-disk: fix ceph-disk logging format error on CentOS7.

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -3539,7 +3539,7 @@ def setup_logging(verbose, log_stdout):
     if log_stdout:
         ch = logging.StreamHandler(stream=sys.stdout)
         ch.setLevel(loglevel)
-        formatter = logging.Formatter('%(filename): %(message)s')
+        formatter = logging.Formatter('%(filename)s: %(message)s')
         ch.setFormatter(formatter)
         LOG.addHandler(ch)
         LOG.setLevel(loglevel)


### PR DESCRIPTION
    On CentOS7, udev will trigger ceph-disk setup logger.
    It will meet the following error on udev log:
        `ValueError: unsupported format character ':' (0x3a)`
    Due to logging format missing, try to fix it.
    Use `%(filename)s` instead of `%(filename)`

If you have any questions, feel free to let me know.
Thanks!

Signed-off-by: Vicente Cheng <freeze.bilsted@gmail.com>