### PR TITLE
mon/OSDMonitor: put crushtool error in log

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4520,13 +4520,16 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
   }
   CrushWrapper newcrush;
   _get_pending_crush(newcrush);
-  CrushTester tester(newcrush, *ss);
+  ostringstream err;
+  CrushTester tester(newcrush, err);
   r = tester.test_with_crushtool(g_conf->crushtool.c_str(),
 				 osdmap.get_max_osd(),
 				 g_conf->mon_lease,
 				 crush_ruleset);
   if (r) {
-    dout(10) << " tester.test_with_crushtool returns " << r << dendl;
+    dout(10) << " tester.test_with_crushtool returns " << r
+	     << ": " << err.str() << dendl;
+    *ss << "crushtool check failed with " << r << ": " << err.str();
     return r;
   }
   unsigned size, min_size;


### PR DESCRIPTION
Putting it in *ss is useless for mkpool callers who don't return
an error string.  Log it to the mon log, too.

Signed-off-by: Sage Weil <sage@redhat.com>