### PR TITLE
osd: Correct the object_info_t::decode() version

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4449,7 +4449,7 @@ void object_info_t::encode(bufferlist& bl) const
 void object_info_t::decode(bufferlist::iterator& bl)
 {
   object_locator_t myoloc;
-  DECODE_START_LEGACY_COMPAT_LEN(14, 8, 8, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(15, 8, 8, bl);
   map<entity_name_t, watch_info_t> old_watchers;
   ::decode(soid, bl);
   ::decode(myoloc, bl);


### PR DESCRIPTION
Caused by: 13b9dc70

Fixes: #13462
Backport: Hammer, Firefly

Signed-off-by: David Zafman <dzafman@redhat.com>