### PR TITLE
OSD:reset primary and up_primary when building a new past_interval.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3062,6 +3062,8 @@ void OSD::build_past_intervals_parallel()
 		 << " " << debug.str() << dendl;
 	p.old_up = up;
 	p.old_acting = acting;
+	p.primary = primary;
+	p.up_primary = up_primary;
 	p.same_interval_since = cur_epoch;
       }
     }


### PR DESCRIPTION
Shall reset primary and up_primary fields when we start over a new past_interval in OSD::build_past_intervals_parallel().
Fixes: #13471
Signed-off-by: xie.xingguo@zte.com.cn