### PR TITLE
os: add a field indicate xattr only one chunk for set xattr.

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -297,7 +297,7 @@ int FileStore::lfn_open(coll_t cid,
       goto fail;
     }
     r = chain_fsetxattr(fd, XATTR_SPILL_OUT_NAME,
-                        XATTR_NO_SPILL_OUT, sizeof(XATTR_NO_SPILL_OUT));
+                        XATTR_NO_SPILL_OUT, sizeof(XATTR_NO_SPILL_OUT), true);
     if (r < 0) {
       VOID_TEMP_FAILURE_RETRY(::close(fd));
       derr << "error setting spillout xattr for oid " << oid << " (" << (*path)->path()
@@ -2110,7 +2110,7 @@ void FileStore::_set_global_replay_guard(coll_t cid,
   // then record that we did it
   bufferlist v;
   ::encode(spos, v);
-  int r = chain_fsetxattr(fd, GLOBAL_REPLAY_GUARD_XATTR, v.c_str(), v.length());
+  int r = chain_fsetxattr(fd, GLOBAL_REPLAY_GUARD_XATTR, v.c_str(), v.length(), true);
   if (r < 0) {
     derr << __func__ << ": fsetxattr " << GLOBAL_REPLAY_GUARD_XATTR
 	 << " got " << cpp_strerror(r) << dendl;
@@ -2203,7 +2203,7 @@ void FileStore::_set_replay_guard(int fd,
   bufferlist v(40);
   ::encode(spos, v);
   ::encode(in_progress, v);
-  int r = chain_fsetxattr(fd, REPLAY_GUARD_XATTR, v.c_str(), v.length());
+  int r = chain_fsetxattr(fd, REPLAY_GUARD_XATTR, v.c_str(), v.length(), true);
   if (r < 0) {
     derr << "fsetxattr " << REPLAY_GUARD_XATTR << " got " << cpp_strerror(r) << dendl;
     assert(0 == "fsetxattr failed");
@@ -2246,7 +2246,7 @@ void FileStore::_close_replay_guard(int fd, const SequencerPosition& spos)
   ::encode(spos, v);
   bool in_progress = false;
   ::encode(in_progress, v);
-  int r = chain_fsetxattr(fd, REPLAY_GUARD_XATTR, v.c_str(), v.length());
+  int r = chain_fsetxattr(fd, REPLAY_GUARD_XATTR, v.c_str(), v.length(), true);
   if (r < 0) {
     derr << "fsetxattr " << REPLAY_GUARD_XATTR << " got " << cpp_strerror(r) << dendl;
     assert(0 == "fsetxattr failed");
@@ -3302,10 +3302,10 @@ int FileStore::_clone(coll_t cid, const ghobject_t& oldoid, const ghobject_t& ne
     r = chain_fgetxattr(**o, XATTR_SPILL_OUT_NAME, buf, sizeof(buf));
     if (r >= 0 && !strncmp(buf, XATTR_NO_SPILL_OUT, sizeof(XATTR_NO_SPILL_OUT))) {
       r = chain_fsetxattr(**n, XATTR_SPILL_OUT_NAME, XATTR_NO_SPILL_OUT,
-                          sizeof(XATTR_NO_SPILL_OUT));
+                          sizeof(XATTR_NO_SPILL_OUT), true);
     } else {
       r = chain_fsetxattr(**n, XATTR_SPILL_OUT_NAME, XATTR_SPILL_OUT,
-                          sizeof(XATTR_SPILL_OUT));
+                          sizeof(XATTR_SPILL_OUT), true);
     }
     if (r < 0)
       goto out3;

--- a/src/os/IndexManager.cc
+++ b/src/os/IndexManager.cc
@@ -37,7 +37,7 @@ static int set_version(const char *path, uint32_t version) {
   bufferlist bl;
   ::encode(version, bl);
   return chain_setxattr(path, "user.cephos.collection_version", bl.c_str(), 
-		     bl.length());
+		     bl.length(), true);
 }
 
 static int get_version(const char *path, uint32_t *version) {

--- a/src/os/chain_xattr.cc
+++ b/src/os/chain_xattr.cc
@@ -256,7 +256,7 @@ static int get_xattr_block_size(size_t size)
   return CHAIN_XATTR_MAX_BLOCK_LEN;
 }
 
-int chain_setxattr(const char *fn, const char *name, const void *val, size_t size)
+int chain_setxattr(const char *fn, const char *name, const void *val, size_t size, bool onechunk)
 {
   int i = 0, pos = 0;
   char raw_name[CHAIN_XATTR_MAX_NAME_LEN * 2 + 16];
@@ -278,7 +278,7 @@ int chain_setxattr(const char *fn, const char *name, const void *val, size_t siz
     i++;
   } while (size);
 
-  if (ret >= 0 ) {
+  if (ret >= 0 && !onechunk) {
     int r;
     do {
       get_raw_xattr_name(name, i, raw_name, sizeof(raw_name));
@@ -292,7 +292,7 @@ int chain_setxattr(const char *fn, const char *name, const void *val, size_t siz
   return ret;
 }
 
-int chain_fsetxattr(int fd, const char *name, const void *val, size_t size)
+int chain_fsetxattr(int fd, const char *name, const void *val, size_t size, bool onechunk)
 {
   int i = 0, pos = 0;
   char raw_name[CHAIN_XATTR_MAX_NAME_LEN * 2 + 16];
@@ -314,7 +314,7 @@ int chain_fsetxattr(int fd, const char *name, const void *val, size_t size)
     i++;
   } while (size);
 
-  if (ret >= 0) {
+  if (ret >= 0 && !onechunk) {
     int r;
     do {
       get_raw_xattr_name(name, i, raw_name, sizeof(raw_name));

--- a/src/os/chain_xattr.h
+++ b/src/os/chain_xattr.h
@@ -78,8 +78,8 @@ static inline int sys_fremovexattr(int fd, const char *name)
 
 int chain_getxattr(const char *fn, const char *name, void *val, size_t size);
 int chain_fgetxattr(int fd, const char *name, void *val, size_t size);
-int chain_setxattr(const char *fn, const char *name, const void *val, size_t size);
-int chain_fsetxattr(int fd, const char *name, const void *val, size_t size);
+int chain_setxattr(const char *fn, const char *name, const void *val, size_t size, bool onechunk=false);
+int chain_fsetxattr(int fd, const char *name, const void *val, size_t size, bool onechunk=false);
 int chain_listxattr(const char *fn, char *names, size_t len);
 int chain_flistxattr(int fd, char *names, size_t len);
 int chain_removexattr(const char *fn, const char *name);


### PR DESCRIPTION
Because the limit of osd backend, we split xattr into a lot of small
pieces. When set xatt, it should remove the old pieces.
But for some xattr especially for inline xattr, we know it only
one chunk. So it can skip this remove operation.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>