### PR TITLE
common/SubProcess: Updated stdin, stdout, stderr method names to avoid g++ error.

### DIFF
--- a/src/common/SubProcess.h
+++ b/src/common/SubProcess.h
@@ -67,9 +67,9 @@ public:
 
   bool is_spawned() const { return pid > 0; }
 
-  int stdin() const;
-  int stdout() const;
-  int stderr() const;
+  int stdin_fd() const;
+  int stdout_fd() const;
+  int stderr_fd() const;
 
   void close_stdin();
   void close_stdout();
@@ -152,21 +152,21 @@ void SubProcess::add_cmd_arg(const char *arg) {
   cmd_args.push_back(arg);
 }
 
-int SubProcess::stdin() const {
+int SubProcess::stdin_fd() const {
   assert(is_spawned());
   assert(pipe_stdin);
 
   return stdin_pipe_out_fd;
 }
 
-int SubProcess::stdout() const {
+int SubProcess::stdout_fd() const {
   assert(is_spawned());
   assert(pipe_stdout);
 
   return stdout_pipe_in_fd;
 }
 
-int SubProcess::stderr() const {
+int SubProcess::stderr_fd() const {
   assert(is_spawned());
   assert(pipe_stderr);
 

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -381,10 +381,10 @@ int CrushTester::test_with_crushtool(const char *crushtool_cmd,
 
   bufferlist bl;
   ::encode(crush, bl);
-  bl.write_fd(crushtool.stdin());
+  bl.write_fd(crushtool.stdin_fd());
   crushtool.close_stdin();
   bl.clear();
-  ret = bl.read_fd(crushtool.stderr(), 100 * 1024);
+  ret = bl.read_fd(crushtool.stderr_fd(), 100 * 1024);
   if (ret < 0) {
     err << "failed read from crushtool: " << cpp_strerror(-ret);
     return ret;

--- a/src/test/test_subprocess.cc
+++ b/src/test/test_subprocess.cc
@@ -54,7 +54,7 @@ TEST(SubProcess, NotFound)
   SubProcess p("NOTEXISTENTBINARY", false, false, true);
   ASSERT_EQ(p.spawn(), 0);
   std::string buf;
-  ASSERT_TRUE(read_from_fd(p.stderr(), buf));
+  ASSERT_TRUE(read_from_fd(p.stderr_fd(), buf));
   std::cerr << "stderr: " << buf;
   ASSERT_EQ(p.join(), 1);
   std::cerr << "err: " << p.err() << std::endl;
@@ -68,7 +68,7 @@ TEST(SubProcess, Echo)
 
   ASSERT_EQ(echo.spawn(), 0);
   std::string buf;
-  ASSERT_TRUE(read_from_fd(echo.stdout(), buf));
+  ASSERT_TRUE(read_from_fd(echo.stdout_fd(), buf));
   std::cerr << "stdout: " << buf;
   ASSERT_EQ(buf, "1 2 3\n");
   ASSERT_EQ(echo.join(), 0);
@@ -81,14 +81,14 @@ TEST(SubProcess, Cat)
 
   ASSERT_EQ(cat.spawn(), 0);
   std::string msg("to my, trociny!");
-  int n = write(cat.stdin(), msg.c_str(), msg.size());
+  int n = write(cat.stdin_fd(), msg.c_str(), msg.size());
   ASSERT_EQ(n, (int)msg.size());
   cat.close_stdin();
   std::string buf;
-  ASSERT_TRUE(read_from_fd(cat.stdout(), buf));
+  ASSERT_TRUE(read_from_fd(cat.stdout_fd(), buf));
   std::cerr << "stdout: " << buf << std::endl;
   ASSERT_EQ(buf, msg);
-  ASSERT_TRUE(read_from_fd(cat.stderr(), buf));
+  ASSERT_TRUE(read_from_fd(cat.stderr_fd(), buf));
   ASSERT_EQ(buf, "");
   ASSERT_EQ(cat.join(), 0);
   ASSERT_TRUE(cat.err()[0] == '\0');
@@ -101,9 +101,9 @@ TEST(SubProcess, CatDevNull)
 
   ASSERT_EQ(cat.spawn(), 0);
   std::string buf;
-  ASSERT_TRUE(read_from_fd(cat.stdout(), buf));
+  ASSERT_TRUE(read_from_fd(cat.stdout_fd(), buf));
   ASSERT_EQ(buf, "");
-  ASSERT_TRUE(read_from_fd(cat.stderr(), buf));
+  ASSERT_TRUE(read_from_fd(cat.stderr_fd(), buf));
   ASSERT_EQ(buf, "");
   ASSERT_EQ(cat.join(), 0);
   ASSERT_TRUE(cat.err()[0] == '\0');
@@ -127,14 +127,14 @@ TEST(SubProcess, CatWithArgs)
 
   ASSERT_EQ(cat.spawn(), 0);
   std::string msg("Hello, Word!");
-  int n = write(cat.stdin(), msg.c_str(), msg.size());
+  int n = write(cat.stdin_fd(), msg.c_str(), msg.size());
   ASSERT_EQ(n, (int)msg.size());
   cat.close_stdin();
   std::string buf;
-  ASSERT_TRUE(read_from_fd(cat.stdout(), buf));
+  ASSERT_TRUE(read_from_fd(cat.stdout_fd(), buf));
   std::cerr << "stdout: " << buf << std::endl;
   ASSERT_EQ(buf, msg);
-  ASSERT_TRUE(read_from_fd(cat.stderr(), buf));
+  ASSERT_TRUE(read_from_fd(cat.stderr_fd(), buf));
   std::cerr << "stderr: " << buf;
   ASSERT_FALSE(buf.empty());
   ASSERT_EQ(cat.join(), 1);
@@ -152,14 +152,14 @@ TEST(SubProcess, Subshell)
       "/bin/sh -c 'exit 13'", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string msg("hello via subshell");
-  int n = write(sh.stdin(), msg.c_str(), msg.size());
+  int n = write(sh.stdin_fd(), msg.c_str(), msg.size());
   ASSERT_EQ(n, (int)msg.size());
   sh.close_stdin();
   std::string buf;
-  ASSERT_TRUE(read_from_fd(sh.stdout(), buf));
+  ASSERT_TRUE(read_from_fd(sh.stdout_fd(), buf));
   std::cerr << "stdout: " << buf << std::endl;
   ASSERT_EQ(buf, msg);
-  ASSERT_TRUE(read_from_fd(sh.stderr(), buf));
+  ASSERT_TRUE(read_from_fd(sh.stderr_fd(), buf));
   std::cerr << "stderr: " << buf;
   ASSERT_EQ(buf, "error from subshell\n");
   ASSERT_EQ(sh.join(), 13);
@@ -192,9 +192,9 @@ TEST(SubProcessTimed, Killed)
   ASSERT_EQ(cat.spawn(), 0);
   cat.kill();
   std::string buf;
-  ASSERT_TRUE(read_from_fd(cat.stdout(), buf));
+  ASSERT_TRUE(read_from_fd(cat.stdout_fd(), buf));
   ASSERT_TRUE(buf.empty());
-  ASSERT_TRUE(read_from_fd(cat.stderr(), buf));
+  ASSERT_TRUE(read_from_fd(cat.stderr_fd(), buf));
   ASSERT_TRUE(buf.empty());
   ASSERT_EQ(cat.join(), 128 + SIGTERM);
   std::cerr << "err: " << cat.err() << std::endl;
@@ -208,7 +208,7 @@ TEST(SubProcessTimed, SleepTimedout)
 
   ASSERT_EQ(sleep.spawn(), 0);
   std::string buf;
-  ASSERT_TRUE(read_from_fd(sleep.stderr(), buf));
+  ASSERT_TRUE(read_from_fd(sleep.stderr_fd(), buf));
   std::cerr << "stderr: " << buf;
   ASSERT_FALSE(buf.empty());
   ASSERT_EQ(sleep.join(), 128 + SIGKILL);
@@ -222,14 +222,14 @@ TEST(SubProcessTimed, SubshellNoTimeout)
   sh.add_cmd_args("-c", "cat >&2", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string msg("the quick brown fox jumps over the lazy dog");
-  int n = write(sh.stdin(), msg.c_str(), msg.size());
+  int n = write(sh.stdin_fd(), msg.c_str(), msg.size());
   ASSERT_EQ(n, (int)msg.size());
   sh.close_stdin();
   std::string buf;
-  ASSERT_TRUE(read_from_fd(sh.stdout(), buf));
+  ASSERT_TRUE(read_from_fd(sh.stdout_fd(), buf));
   std::cerr << "stdout: " << buf << std::endl;
   ASSERT_TRUE(buf.empty());
-  ASSERT_TRUE(read_from_fd(sh.stderr(), buf));
+  ASSERT_TRUE(read_from_fd(sh.stderr_fd(), buf));
   std::cerr << "stderr: " << buf << std::endl;
   ASSERT_EQ(buf, msg);
   ASSERT_EQ(sh.join(), 0);
@@ -242,11 +242,11 @@ TEST(SubProcessTimed, SubshellKilled)
   sh.add_cmd_args("-c", "sh -c cat", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string msg("etaoin shrdlu");
-  int n = write(sh.stdin(), msg.c_str(), msg.size());
+  int n = write(sh.stdin_fd(), msg.c_str(), msg.size());
   ASSERT_EQ(n, (int)msg.size());
   sh.kill();
   std::string buf;
-  ASSERT_TRUE(read_from_fd(sh.stderr(), buf));
+  ASSERT_TRUE(read_from_fd(sh.stderr_fd(), buf));
   ASSERT_TRUE(buf.empty());
   ASSERT_EQ(sh.join(), 128 + SIGTERM);
   std::cerr << "err: " << sh.err() << std::endl;
@@ -259,7 +259,7 @@ TEST(SubProcessTimed, SubshellTimedout)
   sh.add_cmd_args("-c", "sleep 1000& cat; NEVER REACHED", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string buf;
-  ASSERT_TRUE(read_from_fd(sh.stderr(), buf));
+  ASSERT_TRUE(read_from_fd(sh.stderr_fd(), buf));
   std::cerr << "stderr: " << buf;
   ASSERT_FALSE(buf.empty());
   ASSERT_EQ(sh.join(), 128 + SIGTERM);


### PR DESCRIPTION
In file included from /usr/include/fortify/stdio.h:20:0,
                 from /usr/include/c++/5.2.0/cstdio:42,
                 from /usr/include/c++/5.2.0/ext/string_conversions.h:43,
                 from /usr/include/c++/5.2.0/bits/basic_string.h:5247,
                 from /usr/include/c++/5.2.0/string:52,
                 from /build/ceph/src/include/stringify.h:4,
                 from /build/ceph/src/crush/CrushTester.cc:4:
/build/ceph/src/common/SubProcess.h:155:17: error: expected unqualified-id before '(' token
 int SubProcess::stdin() const {
                 ^
/build/ceph/src/common/SubProcess.h:162:17: error: expected unqualified-id before '(' token
 int SubProcess::stdout() const {
                 ^
/build/ceph/src/common/SubProcess.h:169:17: error: expected unqualified-id before '(' token
 int SubProcess::stderr() const {