### PR TITLE
client: a better check for MDS availability

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5035,17 +5035,21 @@ int Client::mount(const std::string &mount_root, bool require_mds)
   ldout(cct, 2) << "mounted: have mdsmap " << mdsmap->get_epoch() << dendl;
   if (require_mds) {
     while (1) {
-      if (mdsmap->cluster_unavailable()) {
-        // If the cluster is stuck unavailable, error out
+      auto availability = mdsmap->is_cluster_available();
+      if (availability == MDSMap::STUCK_UNAVAILABLE) {
+        // Error out
         ldout(cct, 10) << "mds cluster unavailable: epoch=" << mdsmap->get_epoch() << dendl;
         return CEPH_FUSE_NO_MDS_UP;
-      } else if (mdsmap->get_num_mds(CEPH_MDS_STATE_ACTIVE) > 0) {
-        // If somebody is active, continue to mount
+      } else if (availability == MDSMap::AVAILABLE) {
+        // Continue to mount
         break;
-      } else {
+      } else if (availability == MDSMap::TRANSIENT_UNAVAILABLE) {
         // Else, wait.  MDSMonitor will update the map to bring
         // us to a conclusion eventually.
         wait_on_list(waiting_for_mdsmap);
+      } else {
+        // Unexpected value!
+        assert(0);
       }
     }
   }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5035,14 +5035,16 @@ int Client::mount(const std::string &mount_root, bool require_mds)
   ldout(cct, 2) << "mounted: have mdsmap " << mdsmap->get_epoch() << dendl;
   if (require_mds) {
     while (1) {
-      if (mdsmap->get_epoch() > 0) {
-        if (mdsmap->get_num_mds(CEPH_MDS_STATE_ACTIVE) == 0) {
-          ldout(cct, 10) << "no mds up: epoch=" << mdsmap->get_epoch() << dendl;
-          return CEPH_FUSE_NO_MDS_UP;
-        } else {
-          break;
-        }
+      if (mdsmap->cluster_unavailable()) {
+        // If the cluster is stuck unavailable, error out
+        ldout(cct, 10) << "mds cluster unavailable: epoch=" << mdsmap->get_epoch() << dendl;
+        return CEPH_FUSE_NO_MDS_UP;
+      } else if (mdsmap->get_num_mds(CEPH_MDS_STATE_ACTIVE) > 0) {
+        // If somebody is active, continue to mount
+        break;
       } else {
+        // Else, wait.  MDSMonitor will update the map to bring
+        // us to a conclusion eventually.
         wait_on_list(waiting_for_mdsmap);
       }
     }

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -660,7 +660,8 @@ bool MDSMap::cluster_unavailable() const
     if (up.count(rank) != 0) {
       name = mds_info.at(up.at(rank)).name;
     }
-    const bool standby_avail = find_replacement_for(rank, name) != MDS_GID_NONE;
+    const mds_rank_t replacement = find_replacement_for(rank, name, false);
+    const bool standby_avail = replacement != MDS_GID_NONE;
 
     // If the rank is unfilled, and there are no standbys, we're unavailable
     if (up.count(rank) == 0 && !standby_avail) {

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -459,12 +459,30 @@ public:
   void get_health(list<pair<health_status_t,std::string> >& summary,
 		  list<pair<health_status_t,std::string> > *detail) const;
 
+  typedef enum
+  {
+    AVAILABLE = 0,
+    TRANSIENT_UNAVAILABLE = 1,
+    STUCK_UNAVAILABLE = 2
+
+  } availability_t;
+
   /**
-   * If any of the ranks are stuck unavailable, return true.  This is a
+   * Return indication of whether cluster is available.  This is a
    * heuristic for clients to see if they should bother waiting to talk to
    * MDSs, or whether they should error out at startup/mount.
+   *
+   * A TRANSIENT_UNAVAILABLE result indicates that the cluster is in a
+   * transition state like replaying, or is potentially about the fail over.
+   * Clients should wait for an updated map before making a final decision
+   * about whether the filesystem is mountable.
+   *
+   * A STUCK_UNAVAILABLE result indicates that we can't see a way that
+   * the cluster is about to recover on its own, so it'll probably require
+   * administrator intervention: clients should probaly not bother trying
+   * to mount.
    */
-  bool cluster_unavailable() const;
+  availability_t is_cluster_available() const;
 
   // mds states
   bool is_down(mds_rank_t m) const { return up.count(m) == 0; }

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -429,7 +429,8 @@ public:
     return MDS_GID_NONE;
   }
 
-  mds_gid_t find_unused_for(mds_rank_t mds, std::string& name) const {
+  mds_gid_t find_unused_for(mds_rank_t mds, std::string& name,
+                            bool force_standby_active) const {
     for (std::map<mds_gid_t,mds_info_t>::const_iterator p = mds_info.begin();
          p != mds_info.end();
          ++p) {
@@ -439,19 +440,20 @@ public:
         continue;
       if ((p->second.standby_for_rank == MDS_NO_STANDBY_PREF ||
            p->second.standby_for_rank == MDS_MATCHED_ACTIVE ||
-           (p->second.standby_for_rank == MDS_STANDBY_ANY && g_conf->mon_force_standby_active))) {
+           (p->second.standby_for_rank == MDS_STANDBY_ANY && force_standby_active))) {
         return p->first;
       }
     }
     return MDS_GID_NONE;
   }
 
-  mds_gid_t find_replacement_for(mds_rank_t mds, std::string& name) const {
+  mds_gid_t find_replacement_for(mds_rank_t mds, std::string& name,
+                                 bool force_standby_active) const {
     const mds_gid_t standby = find_standby_for(mds, name);
     if (standby)
       return standby;
     else
-      return find_unused_for(mds, name);
+      return find_unused_for(mds, name, force_standby_active);
   }
 
   void get_health(list<pair<health_status_t,std::string> >& summary,

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -409,7 +409,7 @@ public:
     return NULL;
   }
 
-  mds_gid_t find_standby_for(mds_rank_t mds, std::string& name) {
+  mds_gid_t find_standby_for(mds_rank_t mds, std::string& name) const {
     std::map<mds_gid_t, mds_info_t>::const_iterator generic_standby
       = mds_info.end();
     for (std::map<mds_gid_t, mds_info_t>::const_iterator p = mds_info.begin();
@@ -446,7 +446,7 @@ public:
     return MDS_GID_NONE;
   }
 
-  mds_gid_t find_replacement_for(mds_rank_t mds, std::string& name) {
+  mds_gid_t find_replacement_for(mds_rank_t mds, std::string& name) const {
     const mds_gid_t standby = find_standby_for(mds, name);
     if (standby)
       return standby;
@@ -456,6 +456,13 @@ public:
 
   void get_health(list<pair<health_status_t,std::string> >& summary,
 		  list<pair<health_status_t,std::string> > *detail) const;
+
+  /**
+   * If any of the ranks are stuck unavailable, return true.  This is a
+   * heuristic for clients to see if they should bother waiting to talk to
+   * MDSs, or whether they should error out at startup/mount.
+   */
+  bool cluster_unavailable() const;
 
   // mds states
   bool is_down(mds_rank_t m) const { return up.count(m) == 0; }

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1906,7 +1906,8 @@ void MDSMonitor::tick()
     string name;
     while (pending_mdsmap.is_in(mds))
       mds++;
-    mds_gid_t newgid = pending_mdsmap.find_replacement_for(mds, name);
+    mds_gid_t newgid = pending_mdsmap.find_replacement_for(mds, name,
+                         g_conf->mon_force_standby_active);
     if (!newgid)
       break;
 
@@ -1976,7 +1977,8 @@ void MDSMonitor::tick()
       if (info.rank >= 0 &&
 	  info.state != MDSMap::STATE_STANDBY &&
 	  info.state != MDSMap::STATE_STANDBY_REPLAY &&
-	  (sgid = pending_mdsmap.find_replacement_for(info.rank, info.name)) != MDS_GID_NONE) {
+	  (sgid = pending_mdsmap.find_replacement_for(info.rank, info.name, 
+                    g_conf->mon_force_standby_active)) != MDS_GID_NONE) {
 	MDSMap::mds_info_t& si = pending_mdsmap.mds_info[sgid];
 	dout(10) << " replacing " << gid << " " << info.addr << " mds." << info.rank << "." << info.inc
 		 << " " << ceph_mds_state_name(info.state)
@@ -2063,7 +2065,8 @@ void MDSMonitor::tick()
     while (p != failed.end()) {
       mds_rank_t f = *p++;
       string name;  // FIXME
-      mds_gid_t sgid = pending_mdsmap.find_replacement_for(f, name);
+      mds_gid_t sgid = pending_mdsmap.find_replacement_for(f, name,
+          g_conf->mon_force_standby_active);
       if (sgid) {
 	MDSMap::mds_info_t& si = pending_mdsmap.mds_info[sgid];
 	dout(0) << " taking over failed mds." << f << " with " << sgid << "/" << si.name << " " << si.addr << dendl;


### PR DESCRIPTION
Requiring active daemons was pretty annoying in practice,
because:
 * a client starting up in the middle of a failover event (e.g. a
 daemon was up and in replay, or a daemon was active+laggy but a
 standby was ready and waiting) would fail out instead of waiting
 for the cluster to progress.
 * a client starting up with a dead standby-less MDS would see and
 active rank and not care that it was actually laggy.

Signed-off-by: John Spray <john.spray@redhat.com>