### PR TITLE
vstart: set cephfs root uid/gid to caller

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -450,6 +450,8 @@ $CMDSDEBUG
         mds debug auth pins = true
         mds debug subtrees = true
         mds data = $CEPH_DEV_DIR/mds.\$id
+        mds root ino uid = `id -u`
+        mds root ino gid = `id -g`
 $extra_conf
 [osd]
 $DAEMONOPTS


### PR DESCRIPTION
So that when running cluster as unprivileged user,
can do a ceph-fuse mount and then access it without
going root.

Signed-off-by: John Spray <john.spray@redhat.com>