### PR TITLE
rgw : enable or disable bucket and user quota via ceph.conf options

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1114,6 +1114,9 @@ OPTION(rgw_data_log_num_shards, OPT_INT, 128) // number of objects to keep data 
 OPTION(rgw_data_log_obj_prefix, OPT_STR, "data_log") //
 OPTION(rgw_replica_log_obj_prefix, OPT_STR, "replica_log") //
 
+OPTION(rgw_bucket_quota_enabled, OPT_BOOL, false) // enable/disbale bucket quota
+OPTION(rgw_bucket_quota_max_size_kb, OPT_INT, -1) // the maximum number of bytes. A negative value disables this setting. 
+OPTION(rgw_bucket_quota_max_objects, OPT_INT, -1) // the maximum number of objects. A negative value disables this setting.
 OPTION(rgw_bucket_quota_ttl, OPT_INT, 600) // time for cached bucket stats to be cached within rgw instance
 OPTION(rgw_bucket_quota_soft_threshold, OPT_DOUBLE, 0.95) // threshold from which we don't rely on cached info for quota decisions
 OPTION(rgw_bucket_quota_cache_size, OPT_INT, 10000) // number of entries in bucket quota cache
@@ -1122,6 +1125,9 @@ OPTION(rgw_expose_bucket, OPT_BOOL, false) // Return the bucket name in the 'Buc
 
 OPTION(rgw_frontends, OPT_STR, "fastcgi, civetweb port=7480") // rgw front ends
 
+OPTION(rgw_user_quota_enabled, OPT_BOOL, false) // enable/disbale user quota
+OPTION(rgw_user_quota_max_size_kb, OPT_INT, -1) // the maximum number of bytes. A negative value disables this setting. 
+OPTION(rgw_user_quota_max_objects, OPT_INT, -1) // the maximum number of objects. A negative value disables this setting.
 OPTION(rgw_user_quota_bucket_sync_interval, OPT_INT, 180) // time period for accumulating modified buckets before syncing stats
 OPTION(rgw_user_quota_sync_interval, OPT_INT, 3600 * 24) // time period for accumulating modified buckets before syncing entire user stats
 OPTION(rgw_user_quota_sync_idle_users, OPT_BOOL, false) // whether stats for idle users be fully synced

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -72,6 +72,15 @@ void RGWOp_User_Create::execute()
 
   uint32_t max_buckets;
   uint32_t default_max_buckets = s->cct->_conf->rgw_user_max_buckets;
+  
+  RGWQuotaInfo quota;
+  bool bucket_quota_enabled = s->cct->_conf->rgw_bucket_quota_enabled;
+  int32_t bucket_quota_max_size_kb = rgw_rounded_kb(s->cct->_conf->rgw_bucket_quota_max_size_kb);
+  int32_t bucket_quota_max_objects = s->cct->_conf->rgw_bucket_quota_max_objects;
+  
+  bool user_quota_enabled = s->cct->_conf->rgw_user_quota_enabled;
+  int32_t user_quota_max_size_kb = rgw_rounded_kb(s->cct->_conf->rgw_user_quota_max_size_kb);
+  int32_t user_quota_max_objects = s->cct->_conf->rgw_user_quota_max_objects;
 
   RGWUserAdminOpState op_state;
 
@@ -137,6 +146,20 @@ void RGWOp_User_Create::execute()
 
   if (gen_key)
     op_state.set_generate_key();
+
+  if (bucket_quota_enabled) {
+    quota.enabled = bucket_quota_enabled;
+    quota.max_size_kb = bucket_quota_max_size_kb;
+    quota.max_objects = bucket_quota_max_objects;
+    op_state.set_bucket_quota(quota);
+  }
+  
+  if (user_quota_enabled) {
+    quota.enabled = user_quota_enabled;
+    quota.max_size_kb = user_quota_max_size_kb;
+    quota.max_objects = user_quota_max_objects;
+    op_state.set_user_quota(quota);
+  }
 
   http_ret = RGWUserAdminOp_User::create(store, op_state, flusher);
 }

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1851,8 +1851,13 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
   if (op_state.op_mask_specified)
     user_info.op_mask = op_state.get_op_mask();
 
-  if (op_state.has_bucket_quota())
+  if (op_state.has_bucket_quota()) {
     user_info.bucket_quota = op_state.get_bucket_quota();
+  } else {
+    user_info.bucket_quota.enabled = cct->_conf->rgw_bucket_quota_enabled;
+    user_info.bucket_quota.max_size_kb = rgw_rounded_kb(cct->_conf->rgw_bucket_quota_max_size_kb);
+    user_info.bucket_quota.max_objects = cct->_conf->rgw_bucket_quota_max_objects;
+  }
 
   if (op_state.temp_url_key_specified) {
     map<int, string>::iterator iter;
@@ -1862,8 +1867,13 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
     }
   }
 
-  if (op_state.has_user_quota())
+  if (op_state.has_user_quota()) {
     user_info.user_quota = op_state.get_user_quota();
+  } else {
+    user_info.user_quota.enabled = cct->_conf->rgw_user_quota_enabled;
+    user_info.user_quota.max_size_kb = rgw_rounded_kb(cct->_conf->rgw_user_quota_max_size_kb);
+    user_info.user_quota.max_objects = cct->_conf->rgw_user_quota_max_objects;
+  }
 
   // update the request
   op_state.set_user_info(user_info);


### PR DESCRIPTION
This patch adds new options:

rgw_bucket_quota_enabled
rgw_bucket_quota_max_size_kb
rgw_bucket_quota_max_objects

rgw_user_quota_enabled
rgw_user_quota_max_size_kb
rgw_user_quota_max_objects

for enabling or disabling bucket and user quota via ceph.conf

Fixes #12919

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>