### PR TITLE
client: don't choose dirfrag when opendir

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6256,7 +6256,6 @@ int Client::_opendir(Inode *in, dir_result_t **dirpp, int uid, int gid)
   if (!in->is_dir())
     return -ENOTDIR;
   *dirpp = new dir_result_t(in);
-  (*dirpp)->set_frag(in->dirfragtree[0]);
   if (in->dir) {
     (*dirpp)->release_count = in->dir->release_count;
     (*dirpp)->ordered_count = in->dir->ordered_count;


### PR DESCRIPTION
When the directory is fragmented, choosing dirfrag makes dir_result_t::offset
non-zero. This results missing '.' and '..' in readdir result.

Signed-off-by: Yan, Zheng <zyan@redhat.com>