### PR TITLE
osd: fix the snapshot reads of evicted tiering pool

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -6430,7 +6430,8 @@ void ReplicatedPG::finish_ctx(OpContext *ctx, int log_op_type, bool maintain_ssc
   // apply new object state.
   ctx->obc->obs = ctx->new_obs;
 
-  if (!maintain_ssc && soid.is_head()) {
+  if (soid.is_head() && !ctx->obc->obs.exists &&
+      (!maintain_ssc || ctx->cache_evict)) {
     ctx->obc->ssc->exists = false;
     ctx->obc->ssc->snapset = SnapSet();
   } else {


### PR DESCRIPTION
reset ssc->exsits in finish_ctx() if the ctx->cache_evict is true, and
the head is removed.

Fixes: #12748
Signed-off-by: Kefu Chai <kchai@redhat.com>