### PR TITLE
ceph.spec.in: only run systemd-tmpfiles on ceph run directory

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -921,7 +921,7 @@ exit 0
 
 %post -n ceph-common
 %if 0%{?_with_systemd}
-systemd-tmpfiles --create
+systemd-tmpfiles --create --prefix=/run/ceph
 %endif
 
 %postun -n ceph-common


### PR DESCRIPTION
There is a kmod bug that affects RHEL7 derivatives which will
result in device permissions being reset back to defaults.

Fixes: #13305
Signed-off-by: Jason Dillaman <dillaman@redhat.com>