### PR TITLE
client: close mds sessions in shutdown()

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -557,7 +557,7 @@ void Client::shutdown()
   // If we were not mounted, but were being used for sending
   // MDS commands, we may have sessions that need closing.
   client_lock.Lock();
-  close_sessions();
+  _close_sessions();
   client_lock.Unlock();
 
   cct->_conf->remove_observer(this);
@@ -5106,7 +5106,7 @@ int Client::mount(const std::string &mount_root, bool require_mds)
 
 // UNMOUNT
 
-void Client::close_sessions()
+void Client::_close_sessions()
 {
   while (!mds_sessions.empty()) {
     // send session closes!
@@ -5208,7 +5208,7 @@ void Client::unmount()
     traceout.close();
   }
 
-  close_sessions();
+  _close_sessions();
 
   mounted = false;
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -534,6 +534,8 @@ protected:
    */
   void _handle_full_flag(int64_t pool);
 
+  void close_sessions();
+
  public:
   void set_filer_flags(int flags);
   void clear_filer_flags(int flags);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -534,7 +534,7 @@ protected:
    */
   void _handle_full_flag(int64_t pool);
 
-  void close_sessions();
+  void _close_sessions();
 
  public:
   void set_filer_flags(int flags);


### PR DESCRIPTION
Usually this happens in unmount(), but when we
have instantiated Client without mounting (to
send MDS commands), we need to handle closing
any open sessions in shutdown as well.

This is the correct replacement for the mark_down()
call that was removed from handle_command_reply
in the last commit.

Signed-off-by: John Spray <john.spray@redhat.com>