### PR TITLE
fix systemd-run cant't start ceph daemon sometimes

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -304,7 +304,8 @@ for name in $what; do
 	    [ -n "$max_open_files" ] && files="ulimit -n $max_open_files;"
 
 	    if [ -n "$SYSTEMD_RUN" ]; then
-		cmd="$SYSTEMD_RUN -r bash -c '$files $cmd --cluster $cluster -f'"
+                time=`date +%s.%N` 
+		cmd="$SYSTEMD_RUN --unit=ceph-$name.$time -r bash -c '$files $cmd --cluster $cluster -f'"
 	    else
 		cmd="$files $wrap $cmd --cluster $cluster $runmode"
 	    fi


### PR DESCRIPTION
The service name generated by systemd-run isn't unique, it would be better to attach the ceph daemon name with time stamp to generate the service name . http://tracker.ceph.com/issues/13474 fix 13474    Signed-off-by: wang.chuanhong@zte.com.cn