### PR TITLE
cmake: Added fallback to libexecinfo for backtrace(3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ CHECK_INCLUDE_FILES("fcgios.h" FASTCGI_FASTCGIOS_DIR)
 CHECK_INCLUDE_FILES("fcgi_stdio.h" HAVE_FASTCGI_STDIO_H)
 CHECK_INCLUDE_FILES("openssl/ssl.h" HAVE_SSL_H)
 CHECK_INCLUDE_FILES("keyutils.h" HAVE_KEYUTILS_H)
+CHECK_INCLUDE_FILES("execinfo.h" HAVE_EXECINFO_H)
 
 include(CheckSymbolExists)
 CHECK_SYMBOL_EXISTS(__u8 "sys/types.h;linux/types.h" HAVE___U8)
@@ -99,6 +100,8 @@ if(${ENABLE_SHARED})
 else(${ENABLE_SHARED})
  set(CEPH_SHARED STATIC)
 endif(${ENABLE_SHARED})
+
+find_package(execinfo)
 
 find_package(udev REQUIRED)
 set(HAVE_UDEV ${UDEV_FOUND})

--- a/cmake/modules/Findexecinfo.cmake
+++ b/cmake/modules/Findexecinfo.cmake
@@ -1,0 +1,28 @@
+# - Find execinfo
+# Find the execinfo headers and libraries.
+#
+#  EXECINFO_INCLUDE_DIRS - where to find execinfo.h, etc.
+#  EXECINFO_LIBRARIES    - List of libraries when using execinfo.
+#  EXECINFO_FOUND        - True if execinfo found.
+
+# Look for the header file.
+FIND_PATH(EXECINFO_INCLUDE_DIR NAMES execinfo.h)
+
+# Look for the library.
+FIND_LIBRARY(EXECINFO_LIBRARY NAMES execinfo)
+
+# handle the QUIETLY and REQUIRED arguments and set EXECINFO_FOUND to TRUE if
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(execinfo DEFAULT_MSG EXECINFO_LIBRARY EXECINFO_INCLUDE_DIR)
+
+# Copy the results to the output variables.
+IF(EXECINFO_FOUND)
+  SET(EXECINFO_LIBRARIES ${EXECINFO_LIBRARY})
+  SET(EXECINFO_INCLUDE_DIRS ${EXECINFO_INCLUDE_DIR})
+ELSE(EXECINFO_FOUND)
+  SET(EXECINFO_LIBRARIES)
+  SET(EXECINFO_INCLUDE_DIRS)
+ENDIF(EXECINFO_FOUND)
+
+MARK_AS_ADVANCED(EXECINFO_INCLUDE_DIR EXECINFO_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -348,7 +348,7 @@ endif(${HAVE_GPERFTOOLS})
 
 add_library(common_utf8 STATIC common/utf8.c)
 
-target_link_libraries( common json_spirit common_utf8 erasure_code rt uuid ${CRYPTO_LIBS} ${Boost_LIBRARIES} ${BLKID_LIBRARIES})
+target_link_libraries( common json_spirit common_utf8 erasure_code rt uuid ${CRYPTO_LIBS} ${Boost_LIBRARIES} ${BLKID_LIBRARIES} ${EXECINFO_LIBRARIES})
 
 set(libglobal_srcs
   global/global_init.cc

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -176,6 +176,9 @@
 /* Define to 1 if you have the <utime.h> header file. */
 #cmakedefine HAVE_UTIME_H
 
+/* Define if you have the <execinfo.h> header file. */
+#cmakedefine HAVE_EXECINFO_H
+
 /* Define to 1 if strerror_r returns char *. */
 #cmakedefine STRERROR_R_CHAR_P 1
 


### PR DESCRIPTION
Added logic to cmake only because there is no source dependency. Don't really need Alpine build to work in cmake and autotools.