### PR TITLE
fine-grained control systemd to start/stop/restart ceph services at once

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -621,6 +621,10 @@ install -m 0644 -D etc/sysconfig/ceph $RPM_BUILD_ROOT%{_localstatedir}/adm/fillu
   install -m 0644 -D systemd/ceph-mds@.service $RPM_BUILD_ROOT%{_unitdir}/ceph-mds@.service
   install -m 0644 -D systemd/ceph-radosgw@.service $RPM_BUILD_ROOT%{_unitdir}/ceph-radosgw@.service
   install -m 0644 -D systemd/ceph.target $RPM_BUILD_ROOT%{_unitdir}/ceph.target
+  install -m 0644 -D systemd/ceph-osd.target $RPM_BUILD_ROOT%{_unitdir}/ceph-osd.target
+  install -m 0644 -D systemd/ceph-mon.target $RPM_BUILD_ROOT%{_unitdir}/ceph-mon.target
+  install -m 0644 -D systemd/ceph-mds.target $RPM_BUILD_ROOT%{_unitdir}/ceph-mds.target
+  install -m 0644 -D systemd/ceph-radosgw.target $RPM_BUILD_ROOT%{_unitdir}/ceph-radosgw.target
   install -m 0644 -D systemd/ceph-disk@.service $RPM_BUILD_ROOT%{_unitdir}/ceph-disk@.service
   install -m 0755 -D systemd/ceph $RPM_BUILD_ROOT%{_sbindir}/rcceph
 %else
@@ -778,6 +782,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-disk@.service
 %{_unitdir}/ceph.target
+%{_unitdir}/ceph-osd.target
+%{_unitdir}/ceph-mon.target
+%{_unitdir}/ceph-mds.target
+%{_unitdir}/ceph-radosgw.target
 %else
 %{_initrddir}/ceph
 %endif

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -1,5 +1,9 @@
 unitfiles = \
 	ceph.target \
+        ceph-osd.target \
+        ceph-mon.target \
+        ceph-mds.target \
+        ceph-radosgw.target \
 	ceph-mds@.service \
 	ceph-mon@.service \
 	ceph-create-keys@.service \

--- a/systemd/ceph-mds.target
+++ b/systemd/ceph-mds.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph-mds@.service instances at once
+PartOf=ceph.target
+[Install]
+WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -2,7 +2,7 @@
 Description=Ceph metadata server daemon
 After=network-online.target local-fs.target
 Wants=network-online.target local-fs.target
-PartOf=ceph.target
+PartOf=ceph-mds.target
 
 [Service]
 LimitNOFILE=1048576
@@ -13,4 +13,4 @@ ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --set
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
-WantedBy=ceph.target
+WantedBy=ceph-mds.target

--- a/systemd/ceph-mon.target
+++ b/systemd/ceph-mon.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph-mon@.service instances at once
+PartOf=ceph.target
+[Install]
+WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -8,7 +8,7 @@ Description=Ceph cluster monitor daemon
 After=network-online.target local-fs.target ceph-create-keys@%i.service
 Wants=network-online.target local-fs.target ceph-create-keys@%i.service
 
-PartOf=ceph.target
+PartOf=ceph-mon.target
 
 [Service]
 LimitNOFILE=1048576
@@ -19,4 +19,4 @@ ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --set
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
-WantedBy=ceph.target
+WantedBy=ceph-mon.target

--- a/systemd/ceph-osd.target
+++ b/systemd/ceph-osd.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph-osd@.service instances at once
+PartOf=ceph.target
+[Install]
+WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -2,7 +2,7 @@
 Description=Ceph object storage daemon
 After=network-online.target local-fs.target
 Wants=network-online.target local-fs.target
-PartOf=ceph.target
+PartOf=ceph-osd.target
 
 [Service]
 LimitNOFILE=1048576
@@ -14,4 +14,4 @@ ExecStartPre=/usr/libexec/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
-WantedBy=ceph.target
+WantedBy=ceph-osd.target

--- a/systemd/ceph-radosgw.target
+++ b/systemd/ceph-radosgw.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph-radosgw@.service instances at once
+PartOf=ceph.target
+[Install]
+WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -2,7 +2,7 @@
 Description=Ceph rados gateway
 After=network-online.target local-fs.target
 Wants=network-online.target local-fs.target
-PartOf=ceph.target
+PartOf=ceph-radosgw.target
 
 [Service]
 LimitNOFILE=1048576
@@ -12,4 +12,4 @@ Environment=CLUSTER=ceph
 ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
 
 [Install]
-WantedBy=ceph.target
+WantedBy=ceph-radosgw.target


### PR DESCRIPTION
http://tracker.ceph.com/issues/13497

This will be more convenient to start/stop/restart each kind of ceph services itself at once even if multiple services are running on the same machine.

Fixes: #13497
Signed-off-by: Zhi Zhang zhangz.david@outlook.com