### PR TITLE
os/KeyValueDB: reduce malloc/free/string copy count

### DIFF
--- a/src/os/KeyValueDB.h
+++ b/src/os/KeyValueDB.h
@@ -115,6 +115,7 @@ public:
     virtual int prev() = 0;
     virtual string key() = 0;
     virtual pair<string,string> raw_key() = 0;
+    virtual bool raw_key_is_prefixed(const string &prefix) = 0;
     virtual bufferlist value() = 0;
     virtual int status() = 0;
     virtual ~WholeSpaceIteratorImpl() { }
@@ -144,8 +145,7 @@ public:
     bool valid() {
       if (!generic_iter->valid())
 	return false;
-      pair<string,string> raw_key = generic_iter->raw_key();
-      return (raw_key.first.compare(0, prefix.length(), prefix) == 0);
+      return generic_iter->raw_key_is_prefixed(prefix);
     }
     int next() {
       if (valid())

--- a/src/os/KineticStore.cc
+++ b/src/os/KineticStore.cc
@@ -205,14 +205,22 @@ bufferlist KineticStore::to_bufferlist(const kinetic::KineticRecord &record)
 
 int KineticStore::split_key(string in_prefix, string *prefix, string *key)
 {
-  size_t prefix_len = in_prefix.find('\1');
+  size_t prefix_len = 0;
+  char* in_data = in.c_str();
+  
+  // Find separator inside Slice
+  char* separator = (char*) memchr((void*)in_data, 1, in.size());
+  if (separator == NULL)
+     return -EINVAL;
+  prefix_len = size_t(separator - in_data);
   if (prefix_len >= in_prefix.size())
     return -EINVAL;
 
+  // Fetch prefix and/or key directly from Slice
   if (prefix)
-    *prefix = string(in_prefix, 0, prefix_len);
+    *prefix = string(in_data, 0, prefix_len);
   if (key)
-    *key= string(in_prefix, prefix_len + 1);
+    *key = string(separator+1, 0, in_prefix.size()-prefix_len-1);
   return 0;
 }
 
@@ -315,6 +323,17 @@ pair<string,string> KineticStore::KineticWholeSpaceIteratorImpl::raw_key() {
   split_key(*keys_iter, &prefix, &key);
   return make_pair(prefix, key);
 }
+
+bool KineticStore::KineticWholeSpaceIteratorImpl::raw_key_is_prefixed(const string &prefix) {
+  // Look for "prefix\1" right in *keys_iter without making a copy
+  string key = *keys_iter;
+  if ((key.size() > prefix.length()) && (key[prefix.length()] == '\1')) {
+    return memcmp(key.c_str(), prefix.c_str(), prefix.length()) == 0;
+  } else {
+    return false;
+  }
+}
+
 
 bufferlist KineticStore::KineticWholeSpaceIteratorImpl::value() {
   dout(30) << "kinetic iterator value()" << dendl;

--- a/src/os/KineticStore.h
+++ b/src/os/KineticStore.h
@@ -130,6 +130,7 @@ public:
     int prev();
     string key();
     pair<string,string> raw_key();
+    bool raw_key_is_prefixed(const string &prefix);
     bufferlist value();
     int status();
   };

--- a/src/os/LevelDBStore.h
+++ b/src/os/LevelDBStore.h
@@ -276,6 +276,14 @@ public:
       split_key(dbiter->key(), &prefix, &key);
       return make_pair(prefix, key);
     }
+    bool raw_key_is_prefixed(const string &prefix) {
+      leveldb::Slice key = dbiter->key();
+      if ((key.size() > prefix.length()) && (key[prefix.length()] == '\0')) {
+        return memcmp(key.data(), prefix.c_str(), prefix.length()) == 0;
+      } else {
+        return false;
+      }
+    }
     bufferlist value() {
       return to_bufferlist(dbiter->value());
     }

--- a/src/os/RocksDBStore.cc
+++ b/src/os/RocksDBStore.cc
@@ -302,15 +302,21 @@ bufferlist RocksDBStore::to_bufferlist(rocksdb::Slice in)
 
 int RocksDBStore::split_key(rocksdb::Slice in, string *prefix, string *key)
 {
-  string in_prefix = in.ToString();
-  size_t prefix_len = in_prefix.find('\0');
-  if (prefix_len >= in_prefix.size())
+  size_t prefix_len = 0;
+  
+  // Find separator inside Slice
+  char* separator = (char*) memchr(in.data(), 0, in.size());
+  if (separator == NULL)
+     return -EINVAL;
+  prefix_len = size_t(separator - in.data());
+  if (prefix_len >= in.size())
     return -EINVAL;
 
+  // Fetch prefix and/or key directly from Slice
   if (prefix)
-    *prefix = string(in_prefix, 0, prefix_len);
+    *prefix = string(in.data(), 0, prefix_len);
   if (key)
-    *key= string(in_prefix, prefix_len + 1);
+    *key = string(separator+1, 0, in.size()-prefix_len-1);
   return 0;
 }
 
@@ -472,6 +478,17 @@ pair<string,string> RocksDBStore::RocksDBWholeSpaceIteratorImpl::raw_key()
   split_key(dbiter->key(), &prefix, &key);
   return make_pair(prefix, key);
 }
+
+bool RocksDBStore::RocksDBWholeSpaceIteratorImpl::raw_key_is_prefixed(const string &prefix) {
+  // Look for "prefix\0" right in rocksb::Slice
+  rocksdb::Slice key = dbiter->key();
+  if ((key.size() > prefix.length()) && (key[prefix.length()] == '\0')) {
+    return memcmp(key.data(), prefix.c_str(), prefix.length()) == 0;
+  } else {
+    return false;
+  }
+}
+
 bufferlist RocksDBStore::RocksDBWholeSpaceIteratorImpl::value()
 {
   return to_bufferlist(dbiter->value());

--- a/src/os/RocksDBStore.h
+++ b/src/os/RocksDBStore.h
@@ -182,6 +182,7 @@ public:
     int prev();
     string key();
     pair<string,string> raw_key();
+    bool raw_key_is_prefixed(const string &prefix);
     bufferlist value();
     int status();
   };

--- a/src/test/ObjectMap/KeyValueDBMemory.cc
+++ b/src/test/ObjectMap/KeyValueDBMemory.cc
@@ -139,6 +139,15 @@ public:
     else
       return make_pair("", "");
   }
+  
+  bool raw_key_is_prefixed(const string &prefix) {
+    string key = (*it).first.first;
+    if ((key.size() > prefix.length()) && (key[prefix.length()] == '\0')) {
+      return memcmp(key.c_str(), prefix.c_str(), prefix.length()) == 0;
+    } else {
+      return false;
+    }
+  }
 
   bufferlist value() {
     if (valid())

--- a/src/test/ObjectMap/test_keyvaluedb_iterators.cc
+++ b/src/test/ObjectMap/test_keyvaluedb_iterators.cc
@@ -101,6 +101,21 @@ public:
 	      << __func__
 	      << " iterator not valid";
     }
+    
+    if (!it->raw_key_is_prefixed(expected_prefix)) {
+      return ::testing::AssertionFailure()
+	      << __func__
+	      << " expected raw_key_is_prefixed() == TRUE"
+	      << " got FALSE";
+    }
+    
+    if (it->raw_key_is_prefixed("??__SomeUnexpectedValue__??")) {
+      return ::testing::AssertionFailure()
+	      << __func__
+	      << " expected raw_key_is_prefixed() == FALSE"
+	      << " got TRUE";
+    }
+ 
     pair<string,string> key = it->raw_key();
 
     if (expected_prefix != key.first) {


### PR DESCRIPTION
In RocksDB, LevelDB and Kinetic wrapper code, there is unnecessary
string copying. In particular, split_key makes an extra copy of string
(as a basis for extracted key and/or value), which can be easily omitted.
Also, checking for iterator validity generates std::pair with prefix
and key and checks prefix with the one from pair, wasting memory for
key.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>