### PR TITLE
librbd: invalidate object map on error even w/o holding lock

### DIFF
--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -131,7 +131,7 @@ private:
 
   bool m_enabled;
 
-  void invalidate();
+  void invalidate(bool force);
 
 };
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/13461