### PR TITLE
Optimize get object context

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8574,9 +8574,6 @@ int ReplicatedPG::find_object_context(const hobject_t& oid,
        << dendl;
     *pobc = obc;
 
-    if (can_create && !obc->ssc)
-      obc->ssc = get_snapset_context(oid, true);
-
     return 0;
   }
 

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1039,7 +1039,8 @@ protected:
   SnapSetContext *get_snapset_context(
     const hobject_t& oid,
     bool can_create,
-    map<string, bufferlist> *attrs = 0
+    map<string, bufferlist> *attrs = 0,
+    bool oid_existed = true //indicate this oid whether exsited in backend
     );
   void register_snapset_context(SnapSetContext *ssc) {
     Mutex::Locker l(snapset_contexts_lock);


### PR DESCRIPTION
We create a new object. It will find object context.
1)find head object by get head xattr. But don't found
2)because we can create so alloc context
3)find snapset context by get head xattr or snapdir xattr.
In fact we can remove the second get head xattr.(although one getxattr and because the previous getxattr don't cause other io, but it still need some syscall especial when PG splited)