### PR TITLE
log/Log.cc: speed optimization. Introduced cache of pre-formatted dates.

### DIFF
--- a/src/common/PrebufferedStreambuf.cc
+++ b/src/common/PrebufferedStreambuf.cc
@@ -67,29 +67,29 @@ size_t PrebufferedStreambuf::size() const
   if(m_overflow.size() == 0) {
     return this->pptr() - m_buf;
   } else {
-    return m_buf_len + m_overflow.size();
+    return m_buf_len + this->pptr() - &m_overflow[0];
   }
 }
 
 // extracts up to avail chars of content
 int PrebufferedStreambuf::snprintf(char* dst, size_t avail) const
 {
-  size_t o_size=m_overflow.size();
+  size_t o_size = m_overflow.size();
   size_t len_a;
   size_t len_b;
   if(o_size>0){
     len_a = m_buf_len;
-    len_b = o_size;
+    len_b = this->pptr() - &m_overflow[0];
   } else {
     len_a = this->pptr() - m_buf;
     len_b = 0;
   }
-  if(avail > len_a + len_b ) {
+  if(avail > len_a + len_b) {
     memcpy(dst, m_buf, len_a);
     memcpy(dst + m_buf_len, m_overflow.c_str(), len_b);
     dst[len_a + len_b] = 0;
   } else {
-    if(avail > len_a ) {
+    if(avail > len_a) {
       memcpy(dst, m_buf, len_a);
       memcpy(dst + m_buf_len, m_overflow.c_str(), avail - len_a - 1);
       dst[avail - 1] = 0;

--- a/src/common/PrebufferedStreambuf.cc
+++ b/src/common/PrebufferedStreambuf.cc
@@ -1,6 +1,6 @@
 
 #include "common/PrebufferedStreambuf.h"
-
+#include <string.h>
 PrebufferedStreambuf::PrebufferedStreambuf(char *buf, size_t len)
   : m_buf(buf), m_buf_len(len)
 {
@@ -60,4 +60,43 @@ std::string PrebufferedStreambuf::get_str() const
   } else {
     return std::string(m_buf, this->pptr() - m_buf);
   }  
+}
+// returns current size of content
+size_t PrebufferedStreambuf::size() const
+{
+  if(m_overflow.size() == 0) {
+    return this->pptr() - m_buf;
+  } else {
+    return m_buf_len + m_overflow.size();
+  }
+}
+
+// extracts up to avail chars of content
+int PrebufferedStreambuf::snprintf(char* dst, size_t avail) const
+{
+  size_t o_size=m_overflow.size();
+  size_t len_a;
+  size_t len_b;
+  if(o_size>0){
+    len_a = m_buf_len;
+    len_b = o_size;
+  } else {
+    len_a = this->pptr() - m_buf;
+    len_b = 0;
+  }
+  if(avail > len_a + len_b ) {
+    memcpy(dst, m_buf, len_a);
+    memcpy(dst + m_buf_len, m_overflow.c_str(), len_b);
+    dst[len_a + len_b] = 0;
+  } else {
+    if(avail > len_a ) {
+      memcpy(dst, m_buf, len_a);
+      memcpy(dst + m_buf_len, m_overflow.c_str(), avail - len_a - 1);
+      dst[avail - 1] = 0;
+    } else {
+      memcpy(dst, m_buf, avail - 1);
+      dst[avail - 1] = 0;
+    }
+  }
+  return len_a + len_b;
 }

--- a/src/common/PrebufferedStreambuf.h
+++ b/src/common/PrebufferedStreambuf.h
@@ -37,6 +37,12 @@ public:
 
   /// return a string copy (inefficiently)
   std::string get_str() const;
-};    
+
+  // returns current size of content
+  size_t size() const;
+
+  // extracts up to avail chars of content
+  int snprintf(char* dst, size_t avail) const;
+};
 
 #endif

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -239,10 +239,20 @@ public:
     time_t tt = sec();
     localtime_r(&tt, &bdt);
 
-    return snprintf(out, outlen,
+    return ::snprintf(out, outlen,
 		    "%04d-%02d-%02d %02d:%02d:%02d.%06ld",
 		    bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
 		    bdt.tm_hour, bdt.tm_min, bdt.tm_sec, usec());
+  }
+
+  static int snprintf(char *out, int outlen, time_t tt) {
+    struct tm bdt;
+    localtime_r(&tt, &bdt);
+
+    return ::snprintf(out, outlen,
+        "%04d-%02d-%02d %02d:%02d:%02d",
+        bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
+        bdt.tm_hour, bdt.tm_min, bdt.tm_sec);
   }
 
   static int parse_date(const string& date, uint64_t *epoch, uint64_t *nsec,

--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -48,6 +48,16 @@ struct Entry {
   std::string get_str() const {
     return m_streambuf.get_str();
   }
+
+  // returns current size of content
+  size_t size() const {
+    return m_streambuf.size();
+  }
+
+  // extracts up to avail chars of content
+  int snprintf(char* dst, size_t avail) const {
+    return m_streambuf.snprintf(dst, avail);
+  }
 };
 
 }

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -274,13 +274,15 @@ void Log::_flush(EntryQueue *t, EntryQueue *requeue, bool crash)
 
       if (crash)
         buflen += snprintf(buf, sizeof(buf), "%6d> ", -t->m_len);
-      buflen += m_date_cache->snprintf(buf + buflen, sizeof(buf)-buflen, e->m_stamp);
+      buflen += m_date_cache->snprintf(buf + buflen, sizeof(buf) - buflen, e->m_stamp);
       buflen += snprintf(buf + buflen, sizeof(buf)-buflen, " %lx %2d ",
 			(unsigned long)e->m_thread, e->m_prio);
 
-      buflen += e->snprintf(buf + buflen, sizeof(buf) - buflen - 1 );
-      if(buflen > sizeof(buf) - 1 ) //paranoid check, buf was declared to hold everything
+      buflen += e->snprintf(buf + buflen, sizeof(buf) - buflen - 1);
+      if(buflen > sizeof(buf) - 1) { //paranoid check, buf was declared to hold everything
         buflen = sizeof(buf) - 1;
+        buf[buflen] = 0;
+      }
 
       if (do_syslog) {
         syslog(LOG_USER, "%s", buf);
@@ -290,9 +292,8 @@ void Log::_flush(EntryQueue *t, EntryQueue *requeue, bool crash)
         cerr << buf << std::endl;
       }
       if (do_fd) {
-        buf[buflen-1]='\n';
-        buf[buflen]='\0';
-        int r=safe_write(m_fd, buf, buflen+1);
+        buf[buflen] = '\n';
+        int r = safe_write(m_fd, buf, buflen+1);
         if (r < 0)
           cerr << "problem writing to " << m_log_file << ": " << cpp_strerror(r) << std::endl;
       }

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -34,6 +34,56 @@ static void log_on_exit(void *p)
   delete (Log **)p;// Delete allocated pointer (not Log object, the pointer only!)
 }
 
+class DateCache
+{
+public:
+  DateCache (size_t size)
+  {
+    char buf[1];
+    m_date_size = utime_t::snprintf (buf, 1, 0);
+    m_cache_size = size;
+    m_date_val = new time_t[m_cache_size];
+    m_date_formatted = new char*[m_cache_size];
+    for (size_t i = 0; i < m_cache_size; i++) {
+      m_date_val[i] = 0;
+      m_date_formatted[i] = new char[m_date_size + 7 + 1];
+      utime_t::snprintf (m_date_formatted[i], m_date_size + 1, 0);
+    }
+  }
+  ~DateCache ()
+  {
+    for (size_t i = 0; i < m_cache_size; i++)
+      free (m_date_formatted[i]);
+    free (m_date_val);
+    free (m_date_formatted);
+  }
+  int
+  snprintf (char* str, size_t size, const utime_t& t)
+  {
+    time_t sec = t.sec ();
+    size_t pos = sec % m_cache_size;
+
+    if (m_date_val[pos] != sec) {
+      utime_t::snprintf (m_date_formatted[pos], m_date_size + 1, sec);
+      m_date_val[pos] = sec;
+    }
+    long usec = t.nsec () / 1000;
+    ::snprintf (m_date_formatted[pos] + m_date_size, 7 + 1, ".%06ld", usec);
+    if (m_date_size + 7 + 1 < size)
+      memcpy (str, m_date_formatted[pos], m_date_size + 7 + 1);
+    else {
+      memcpy (str, m_date_formatted[pos], size - 2);
+      str[size - 1] = 0;
+    }
+    return m_date_size + 7;
+  }
+private:
+  size_t m_date_size;
+  size_t m_cache_size;
+  time_t* m_date_val;
+  char** m_date_formatted;
+};
+
 Log::Log(SubsystemMap *s)
   : m_indirect_this(NULL),
     m_subs(s),
@@ -46,7 +96,8 @@ Log::Log(SubsystemMap *s)
     m_stop(false),
     m_max_new(DEFAULT_MAX_NEW),
     m_max_recent(DEFAULT_MAX_RECENT),
-    m_inject_segv(false)
+    m_inject_segv(false),
+    m_date_cache(new DateCache(4))
 {
   int ret;
 
@@ -77,7 +128,7 @@ Log::~Log()
   assert(!is_started());
   if (m_fd >= 0)
     VOID_TEMP_FAILURE_RETRY(::close(m_fd));
-
+  delete m_date_cache;
   pthread_mutex_destroy(&m_queue_mutex);
   pthread_mutex_destroy(&m_flush_mutex);
   pthread_cond_destroy(&m_cond_loggers);
@@ -222,8 +273,8 @@ void Log::_flush(EntryQueue *t, EntryQueue *requeue, bool crash)
       char buf[80 + e->size()];
 
       if (crash)
-	buflen += snprintf(buf, sizeof(buf), "%6d> ", -t->m_len);
-      buflen += e->m_stamp.sprintf(buf + buflen, sizeof(buf)-buflen);
+        buflen += snprintf(buf, sizeof(buf), "%6d> ", -t->m_len);
+      buflen += m_date_cache->snprintf(buf + buflen, sizeof(buf)-buflen, e->m_stamp);
       buflen += snprintf(buf + buflen, sizeof(buf)-buflen, " %lx %2d ",
 			(unsigned long)e->m_thread, e->m_prio);
 

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -14,7 +14,7 @@
 
 namespace ceph {
 namespace log {
-
+class DateCache;
 class Log : private Thread
 {
   Log **m_indirect_this;
@@ -43,6 +43,7 @@ class Log : private Thread
   int m_max_new, m_max_recent;
 
   bool m_inject_segv;
+  DateCache* m_date_cache;
 
   void *entry();
 


### PR DESCRIPTION
It skips performing localtime_r and compilicated printf.
Log entry prepared 3x faster.

Signed-off-by: Adam Kupczyk <akupczyk@mirantis.com>