### PR TITLE
mon,osd: improve mon scalability by vastly simplyfing the osd <-> mon communications

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -47,7 +47,7 @@ Synopsis
 
 | **ceph** **osd** **tier** [ *add* \| *add-cache* \| *cache-mode* \| *remove* \| *remove-overlay* \| *set-overlay* ] ...
 
-| **ceph** **pg** [ *debug* \| *deep-scrub* \| *dump* \| *dump_json* \| *dump_pools_json* \| *dump_stuck* \| *force_create_pg* \| *getmap* \| *ls* \| *ls-by-osd* \| *ls-by-pool* \| *ls-by-primary* \| *map* \| *repair* \| *scrub* \| *send_pg_creates* \| *set_full_ratio* \| *set_nearfull_ratio* \| *stat* ] ...
+| **ceph** **pg** [ *debug* \| *deep-scrub* \| *dump* \| *dump_json* \| *dump_pools_json* \| *dump_stuck* \| *force_create_pg* \| *getmap* \| *ls* \| *ls-by-osd* \| *ls-by-pool* \| *ls-by-primary* \| *map* \| *repair* \| *scrub* \| *set_full_ratio* \| *set_nearfull_ratio* \| *stat* ] ...
 
 | **ceph** **quorum** [ *enter* \| *exit* ]
 
@@ -1229,12 +1229,6 @@ Subcommand ``scrub`` starts scrub on <pgid>.
 Usage::
 
 	ceph pg scrub <pgid>
-
-Subcommand ``send_pg_creates`` triggers pg creates to be issued.
-
-Usage::
-
-	ceph pg send_pg_creates
 
 Subcommand ``set_full_ratio`` sets ratio at which pgs are considered full.
 

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1281,7 +1281,6 @@ function test_mon_pg()
   ceph pg repair 0.0
   ceph pg scrub 0.0
 
-  ceph pg send_pg_creates
   ceph pg set_full_ratio 0.90
   ceph pg dump --format=plain | grep '^full_ratio 0.9'
   ceph pg set_full_ratio 0.95

--- a/qa/workunits/mon/caps.py
+++ b/qa/workunits/mon/caps.py
@@ -233,9 +233,6 @@ def test_all():
         {
           'cmd':('pg getmap', '', 'r'),
           },
-        {
-          'cmd':('pg send_pg_creates', '', 'rw'),
-          },
         ],
       'mds':[
         {

--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -369,8 +369,6 @@ if __name__ == '__main__':
     expect('pg/repair?pgid=0.0', 'PUT', 200, '')
     expect('pg/scrub?pgid=0.0', 'PUT', 200, '')
 
-    expect('pg/send_pg_creates', 'PUT', 200, '')
-
     expect('pg/set_full_ratio?ratio=0.90', 'PUT', 200, '')
     r = expect('pg/dump', 'GET', 200, 'json', JSONHDR)
     assert(float(r.myjson['output']['full_ratio']) == 0.90)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -195,7 +195,7 @@ OPTION(mon_osd_cache_size, OPT_INT, 10)  // the size of osdmaps cache, not to re
 
 OPTION(mon_tick_interval, OPT_INT, 5)
 OPTION(mon_session_timeout, OPT_INT, 300)    // must send keepalive or subscribe
-OPTION(mon_subscribe_interval, OPT_DOUBLE, 300)
+OPTION(mon_subscribe_interval, OPT_DOUBLE, 24*3600)  // for legacy clients only
 OPTION(mon_delta_reset_interval, OPT_DOUBLE, 10)   // seconds of inactivity before we reset the pg delta to 0
 OPTION(mon_osd_laggy_halflife, OPT_INT, 60*60)        // (seconds) how quickly our laggy estimations decay
 OPTION(mon_osd_laggy_weight, OPT_DOUBLE, .3)          // weight for new 'samples's in laggy estimations

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -194,6 +194,7 @@ OPTION(mon_compact_on_trim, OPT_BOOL, true)       // compact (a prefix) when we 
 OPTION(mon_osd_cache_size, OPT_INT, 10)  // the size of osdmaps cache, not to rely on underlying store's cache
 
 OPTION(mon_tick_interval, OPT_INT, 5)
+OPTION(mon_session_timeout, OPT_INT, 300)    // must send keepalive or subscribe
 OPTION(mon_subscribe_interval, OPT_DOUBLE, 300)
 OPTION(mon_delta_reset_interval, OPT_DOUBLE, 10)   // seconds of inactivity before we reset the pg delta to 0
 OPTION(mon_osd_laggy_halflife, OPT_INT, 60*60)        // (seconds) how quickly our laggy estimations decay

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -230,6 +230,7 @@ OPTION(mon_pg_warn_max_per_osd, OPT_INT, 300)  // max # pgs per (in) osd before 
 OPTION(mon_pg_warn_max_object_skew, OPT_FLOAT, 10.0) // max skew few average in objects per pg
 OPTION(mon_pg_warn_min_objects, OPT_INT, 10000)  // do not warn below this object #
 OPTION(mon_pg_warn_min_pool_objects, OPT_INT, 1000)  // do not warn on pools below this object #
+OPTION(mon_pg_check_down_all_threshold, OPT_FLOAT, .5) // threshold of down osds after which we check all pgs
 OPTION(mon_cache_target_full_warn_ratio, OPT_FLOAT, .66) // position between pool cache_target_full and max where we start warning
 OPTION(mon_osd_full_ratio, OPT_FLOAT, .95) // what % full makes an OSD "full"
 OPTION(mon_osd_nearfull_ratio, OPT_FLOAT, .85) // what % full makes an OSD near full

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -713,8 +713,6 @@ OPTION(osd_op_log_threshold, OPT_INT, 5) // how many op log messages to show in 
 OPTION(osd_verify_sparse_read_holes, OPT_BOOL, false)  // read fiemap-reported holes and verify they are zeros
 OPTION(osd_debug_drop_ping_probability, OPT_DOUBLE, 0)
 OPTION(osd_debug_drop_ping_duration, OPT_INT, 0)
-OPTION(osd_debug_drop_pg_create_probability, OPT_DOUBLE, 0)
-OPTION(osd_debug_drop_pg_create_duration, OPT_INT, 1)
 OPTION(osd_debug_drop_op_probability, OPT_DOUBLE, 0)   // probability of stalling/dropping a client op
 OPTION(osd_debug_op_order, OPT_BOOL, false)
 OPTION(osd_debug_scrub_chance_rewrite_digest, OPT_U64, 0)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -660,6 +660,8 @@ OPTION(osd_mon_report_interval_max, OPT_INT, 120)
 OPTION(osd_mon_report_interval_min, OPT_INT, 5)  // pg stats, failures, up_thru, boot.
 OPTION(osd_pg_stat_report_interval_max, OPT_INT, 500)  // report pg stats for any given pg at least this often
 OPTION(osd_mon_ack_timeout, OPT_INT, 30) // time out a mon if it doesn't ack stats
+OPTION(osd_stats_ack_timeout_factor, OPT_DOUBLE, 2.0) // multiples of mon_ack_timeout
+OPTION(osd_stats_ack_timeout_decay, OPT_DOUBLE, .9)
 OPTION(osd_default_data_pool_replay_window, OPT_INT, 45)
 OPTION(osd_preserve_trimmed_log, OPT_BOOL, false)
 OPTION(osd_auto_mark_unfound_lost, OPT_BOOL, false)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -658,6 +658,7 @@ OPTION(osd_heartbeat_min_healthy_ratio, OPT_FLOAT, .33)
 OPTION(osd_mon_heartbeat_interval, OPT_INT, 30)  // (seconds) how often to ping monitor if no peers
 OPTION(osd_mon_report_interval_max, OPT_INT, 120)
 OPTION(osd_mon_report_interval_min, OPT_INT, 5)  // pg stats, failures, up_thru, boot.
+OPTION(osd_mon_report_max_in_flight, OPT_INT, 2)  // max updates in flight
 OPTION(osd_pg_stat_report_interval_max, OPT_INT, 500)  // report pg stats for any given pg at least this often
 OPTION(osd_mon_ack_timeout, OPT_INT, 30) // time out a mon if it doesn't ack stats
 OPTION(osd_stats_ack_timeout_factor, OPT_DOUBLE, 2.0) // multiples of mon_ack_timeout

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -656,7 +656,7 @@ OPTION(osd_pg_max_concurrent_snap_trims, OPT_U64, 2)
 OPTION(osd_heartbeat_min_healthy_ratio, OPT_FLOAT, .33)
 
 OPTION(osd_mon_heartbeat_interval, OPT_INT, 30)  // (seconds) how often to ping monitor if no peers
-OPTION(osd_mon_report_interval_max, OPT_INT, 120)
+OPTION(osd_mon_report_interval_max, OPT_INT, 600)
 OPTION(osd_mon_report_interval_min, OPT_INT, 5)  // pg stats, failures, up_thru, boot.
 OPTION(osd_mon_report_max_in_flight, OPT_INT, 2)  // max updates in flight
 OPTION(osd_pg_stat_report_interval_max, OPT_INT, 500)  // report pg stats for any given pg at least this often

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -764,7 +764,7 @@ OPTION(keyvaluestore_rocksdb_options, OPT_STR, "")
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR, "")
 // rocksdb options that will be used in monstore
-OPTION(mon_rocksdb_options, OPT_STR, "")
+OPTION(mon_rocksdb_options, OPT_STR, "compression=kNoCompression")
 
 /**
  * osd_*_priority adjust the relative priority of client io, recovery io,

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -276,7 +276,7 @@ OPTION(mon_sync_debug_leader, OPT_INT, -1) // monitor to be used as the sync lea
 OPTION(mon_sync_debug_provider, OPT_INT, -1) // monitor to be used as the sync provider
 OPTION(mon_sync_debug_provider_fallback, OPT_INT, -1) // monitor to be used as fallback if sync provider fails
 OPTION(mon_inject_sync_get_chunk_delay, OPT_DOUBLE, 0)  // inject N second delay on each get_chunk request
-OPTION(mon_osd_min_down_reporters, OPT_INT, 1)   // number of OSDs who need to report a down OSD for it to count
+OPTION(mon_osd_min_down_reporters, OPT_INT, 2)   // number of OSDs who need to report a down OSD for it to count
 OPTION(mon_osd_force_trim_to, OPT_INT, 0)   // force mon to trim maps to this point, regardless of min_last_epoch_clean (dangerous, use with care)
 OPTION(mon_mds_force_trim_to, OPT_INT, 0)   // force mon to trim mdsmaps to this point (dangerous, use with care)
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -764,7 +764,7 @@ OPTION(keyvaluestore_rocksdb_options, OPT_STR, "")
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR, "")
 // rocksdb options that will be used in monstore
-OPTION(mon_rocksdb_options, OPT_STR, "compression=kNoCompression")
+OPTION(mon_rocksdb_options, OPT_STR, "cache_size=536870912,write_buffer_size=33554432,block_size=65536,compression=kNoCompression")
 
 /**
  * osd_*_priority adjust the relative priority of client io, recovery io,

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -277,7 +277,6 @@ OPTION(mon_sync_debug_provider, OPT_INT, -1) // monitor to be used as the sync p
 OPTION(mon_sync_debug_provider_fallback, OPT_INT, -1) // monitor to be used as fallback if sync provider fails
 OPTION(mon_inject_sync_get_chunk_delay, OPT_DOUBLE, 0)  // inject N second delay on each get_chunk request
 OPTION(mon_osd_min_down_reporters, OPT_INT, 1)   // number of OSDs who need to report a down OSD for it to count
-OPTION(mon_osd_min_down_reports, OPT_INT, 3)     // number of times a down OSD must be reported for it to count
 OPTION(mon_osd_force_trim_to, OPT_INT, 0)   // force mon to trim maps to this point, regardless of min_last_epoch_clean (dangerous, use with care)
 OPTION(mon_mds_force_trim_to, OPT_INT, 0)   // force mon to trim mdsmaps to this point (dangerous, use with care)
 

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -70,6 +70,7 @@
 #define CEPH_FEATURE_OSD_HITSET_GMT (1ULL<<54)
 #define CEPH_FEATURE_HAMMER_0_94_4 (1ULL<<55)
 #define CEPH_FEATURE_NEW_OSDOP_ENCODING   (1ULL<<56) /* New, v7 encoding */
+#define CEPH_FEATURE_MON_STATEFUL_SUB (1ULL<<57) /* stateful mon subscription */
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */
@@ -162,6 +163,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
          CEPH_FEATURE_OSD_PROXY_WRITE_FEATURES |         \
 	 CEPH_FEATURE_OSD_HITSET_GMT |			 \
 	 CEPH_FEATURE_HAMMER_0_94_4 |		 \
+	 CEPH_FEATURE_MON_STATEFUL_SUB |	 \
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -71,6 +71,7 @@
 #define CEPH_FEATURE_HAMMER_0_94_4 (1ULL<<55)
 #define CEPH_FEATURE_NEW_OSDOP_ENCODING   (1ULL<<56) /* New, v7 encoding */
 #define CEPH_FEATURE_MON_STATEFUL_SUB (1ULL<<57) /* stateful mon subscription */
+#define CEPH_FEATURE_MON_ROUTE_OSDMAP (1ULL<<57) /* peon sends osdmaps */
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */
@@ -164,6 +165,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_OSD_HITSET_GMT |			 \
 	 CEPH_FEATURE_HAMMER_0_94_4 |		 \
 	 CEPH_FEATURE_MON_STATEFUL_SUB |	 \
+	 CEPH_FEATURE_MON_ROUTE_OSDMAP |	 \
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL

--- a/src/messages/MLog.h
+++ b/src/messages/MLog.h
@@ -37,7 +37,8 @@ public:
   void print(ostream& out) const {
     out << "log(";
     if (entries.size())
-      out << entries.size() << " entries";
+      out << entries.size() << " entries from seq " << entries.front().seq
+	  << " at " << entries.front().stamp;
     out << ")";
   }
 

--- a/src/messages/MOSDPGCreate.h
+++ b/src/messages/MOSDPGCreate.h
@@ -81,13 +81,11 @@ public:
   }
 
   void print(ostream& out) const {
-    out << "osd_pg_create(";
-    map<pg_t,utime_t>::const_iterator ci = ctimes.begin();
+    out << "osd_pg_create(e" << epoch;
     for (map<pg_t,pg_create_t>::const_iterator i = mkpg.begin();
          i != mkpg.end();
-         ++i, ++ci) {
-      assert(ci != ctimes.end() && ci->first == i->first);
-      out << "pg" << i->first << "," << i->second.created << "@" << ci->second << "; ";
+         ++i) {
+      out << " " << i->first << ":" << i->second.created;
     }
     out << ")";
   }

--- a/src/messages/MRoute.h
+++ b/src/messages/MRoute.h
@@ -22,24 +22,35 @@
 
 struct MRoute : public Message {
 
-  static const int HEAD_VERSION = 2;
+  static const int HEAD_VERSION = 3;
   static const int COMPAT_VERSION = 2;
 
   uint64_t session_mon_tid;
   Message *msg;
   entity_inst_t dest;
+  epoch_t send_osdmap_first;
   
-  MRoute() : Message(MSG_ROUTE, HEAD_VERSION, COMPAT_VERSION), msg(NULL) {}
+  MRoute() : Message(MSG_ROUTE, HEAD_VERSION, COMPAT_VERSION),
+	     session_mon_tid(0),
+	     msg(NULL),
+	     send_osdmap_first(0) {}
   MRoute(uint64_t t, Message *m)
-    : Message(MSG_ROUTE, HEAD_VERSION, COMPAT_VERSION), session_mon_tid(t), msg(m) {}
+    : Message(MSG_ROUTE, HEAD_VERSION, COMPAT_VERSION),
+      session_mon_tid(t),
+      msg(m),
+      send_osdmap_first(0) {}
   MRoute(bufferlist bl, const entity_inst_t& i)
-    : Message(MSG_ROUTE, HEAD_VERSION, COMPAT_VERSION), session_mon_tid(0), dest(i) {
+    : Message(MSG_ROUTE, HEAD_VERSION, COMPAT_VERSION),
+      session_mon_tid(0),
+      dest(i),
+      send_osdmap_first(0) {
     bufferlist::iterator p = bl.begin();
     msg = decode_message(NULL, 0, p);
   }
 private:
   ~MRoute() {
-    if (msg) msg->put();
+    if (msg)
+      msg->put();
   }
 
 public:
@@ -55,23 +66,25 @@ public:
     } else {
       msg = decode_message(NULL, 0, p);
     }
+    if (header.version >= 3) {
+      ::decode(send_osdmap_first, p);
+    }
   }
   void encode_payload(uint64_t features) {
     ::encode(session_mon_tid, payload);
     ::encode(dest, payload);
-    if (features & CEPH_FEATURE_MON_NULLROUTE) {
-      header.version = HEAD_VERSION;
-      header.compat_version = COMPAT_VERSION;
-      bool m = msg ? true : false;
-      ::encode(m, payload);
-      if (msg)
-	encode_message(msg, features, payload);
-    } else {
+    if ((features & CEPH_FEATURE_MON_NULLROUTE) == 0) {
       header.version = 1;
       header.compat_version = 1;
       assert(msg);
       encode_message(msg, features, payload);
+      return;
     }
+    bool m = msg ? true : false;
+    ::encode(m, payload);
+    if (msg)
+      encode_message(msg, features, payload);
+    ::encode(send_osdmap_first, payload);
   }
 
   const char *get_type_name() const { return "route"; }
@@ -80,6 +93,8 @@ public:
       o << "route(" << *msg;
     else
       o << "route(no-reply";
+    if (send_osdmap_first)
+      o << " send_osdmap_first " << send_osdmap_first;
     if (session_mon_tid)
       o << " tid " << session_mon_tid << ")";
     else

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -719,8 +719,6 @@ void MonClient::tick()
     cur_con->send_keepalive();
 
     if (state == MC_STATE_HAVE_SESSION) {
-      send_log();
-
       if (cct->_conf->mon_client_ping_timeout > 0 &&
 	  cur_con->has_feature(CEPH_FEATURE_MSGR_KEEPALIVE2)) {
 	utime_t lk = cur_con->get_last_keepalive_ack();
@@ -731,6 +729,8 @@ void MonClient::tick()
 	  _reopen_session();
 	}
       }
+
+      send_log();
     }
   }
 

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -209,31 +209,42 @@ public:
 
   // mon subscriptions
 private:
-  map<string,ceph_mon_subscribe_item> sub_have;  // my subs, and current versions
+  map<string,ceph_mon_subscribe_item> sub_sent; // my subs, and current versions
+  map<string,ceph_mon_subscribe_item> sub_new;  // unsent new subs
   utime_t sub_renew_sent, sub_renew_after;
 
   void _renew_subs();
   void handle_subscribe_ack(MMonSubscribeAck* m);
 
   bool _sub_want(string what, version_t start, unsigned flags) {
-    if (sub_have.count(what) &&
-	sub_have[what].start == start &&
-	sub_have[what].flags == flags)
+    if ((sub_new.count(what) == 0 &&
+	 sub_sent.count(what) &&
+	 sub_sent[what].start == start &&
+	 sub_sent[what].flags == flags) ||
+	(sub_new.count(what) &&
+	 sub_new[what].start == start &&
+	 sub_new[what].flags == flags))
       return false;
-    sub_have[what].start = start;
-    sub_have[what].flags = flags;
+    sub_new[what].start = start;
+    sub_new[what].flags = flags;
     return true;
   }
   void _sub_got(string what, version_t got) {
-    if (sub_have.count(what)) {
-      if (sub_have[what].flags & CEPH_SUBSCRIBE_ONETIME)
-	sub_have.erase(what);
+    if (sub_new.count(what)) {
+      if (sub_new[what].flags & CEPH_SUBSCRIBE_ONETIME)
+	sub_new.erase(what);
       else
-	sub_have[what].start = got + 1;
+	sub_new[what].start = got + 1;
+    } else if (sub_sent.count(what)) {
+      if (sub_sent[what].flags & CEPH_SUBSCRIBE_ONETIME)
+	sub_sent.erase(what);
+      else
+	sub_sent[what].start = got + 1;
     }
   }
   void _sub_unwant(string what) {
-    sub_have.erase(what);
+    sub_sent.erase(what);
+    sub_new.erase(what);
   }
 
   // auth tickets
@@ -262,10 +273,18 @@ public:
    */
   bool sub_want_increment(string what, version_t start, unsigned flags) {
     Mutex::Locker l(monc_lock);
-    map<string,ceph_mon_subscribe_item>::iterator i =
-            sub_have.find(what);
-    if (i == sub_have.end() || i->second.start < start) {
-      ceph_mon_subscribe_item& item = sub_have[what];
+    map<string,ceph_mon_subscribe_item>::iterator i = sub_new.find(what);
+    if (i != sub_new.end()) {
+      if (i->second.start >= start)
+	return false;
+      i->second.start = start;
+      i->second.flags = flags;
+      return true;
+    }
+
+    i = sub_sent.find(what);
+    if (i == sub_sent.end() || i->second.start < start) {
+      ceph_mon_subscribe_item& item = sub_new[what];
       item.start = start;
       item.flags = flags;
       return true;

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -231,15 +231,19 @@ private:
   }
   void _sub_got(string what, version_t got) {
     if (sub_new.count(what)) {
-      if (sub_new[what].flags & CEPH_SUBSCRIBE_ONETIME)
-	sub_new.erase(what);
-      else
-	sub_new[what].start = got + 1;
+      if (sub_new[what].start <= got) {
+	if (sub_new[what].flags & CEPH_SUBSCRIBE_ONETIME)
+	  sub_new.erase(what);
+	else
+	  sub_new[what].start = got + 1;
+      }
     } else if (sub_sent.count(what)) {
-      if (sub_sent[what].flags & CEPH_SUBSCRIBE_ONETIME)
-	sub_sent.erase(what);
-      else
-	sub_sent[what].start = got + 1;
+      if (sub_sent[what].start <= got) {
+	if (sub_sent[what].flags & CEPH_SUBSCRIBE_ONETIME)
+	  sub_sent.erase(what);
+	else
+	  sub_sent[what].start = got + 1;
+      }
     }
   }
   void _sub_unwant(string what) {

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3427,9 +3427,10 @@ void Monitor::_ms_dispatch(Message *m)
       return;
     }
 
-    s = session_map.new_session(m->get_source_inst(), m->get_connection().get());
+    ConnectionRef con = m->get_connection();
+    s = session_map.new_session(m->get_source_inst(), con.get());
     assert(s);
-    m->get_connection()->set_priv(s->get());
+    con->set_priv(s->get());
     dout(10) << __func__ << " new session " << s << " " << *s << dendl;
     op->set_session(s);
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3272,6 +3272,11 @@ void Monitor::handle_route(MonOpRequestRef op)
 	rr->con->send_message(m->msg);
 	m->msg = NULL;
       }
+      if (m->send_osdmap_first) {
+	dout(10) << " sending osdmaps from " << m->send_osdmap_first << dendl;
+	osdmon()->send_incremental(m->send_osdmap_first, session,
+				   true, MonOpRequestRef());
+      }
       routed_requests.erase(m->session_mon_tid);
       rr->session->routed_request_tids.insert(rr->tid);
       delete rr;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4159,10 +4159,14 @@ void Monitor::handle_subscribe(MonOpRequestRef op)
     }
   }
 
-  // ???
-
-  if (reply)
-    m->get_connection()->send_message(new MMonSubscribeAck(monmap->get_fsid(), (int)g_conf->mon_subscribe_interval));
+  if (reply) {
+    // we only need to reply if the client is old enough to think it
+    // has to send renewals.
+    ConnectionRef con = m->get_connection();
+    if (!con->has_feature(CEPH_FEATURE_MON_STATEFUL_SUB))
+      m->get_connection()->send_message(new MMonSubscribeAck(
+	monmap->get_fsid(), (int)g_conf->mon_subscribe_interval));
+  }
 
 }
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3437,13 +3437,7 @@ void Monitor::_ms_dispatch(Message *m)
     logger->set(l_mon_num_sessions, session_map.get_size());
     logger->inc(l_mon_session_add);
 
-    if (!src_is_mon) {
-      dout(30) << __func__ << "  setting timeout on session" << dendl;
-      // set an initial timeout here, so we will trim this session
-      // even if they don't do anything.
-      s->until = ceph_clock_now(g_ceph_context);
-      s->until += g_conf->mon_subscribe_interval;
-    } else {
+    if (src_is_mon) {
       // give it monitor caps; the peer type has been authenticated
       dout(5) << __func__ << " setting monitor caps on this connection" << dendl;
       if (!s->caps.is_allow_all()) // but no need to repeatedly copy
@@ -4131,8 +4125,6 @@ void Monitor::handle_subscribe(MonOpRequestRef op)
   MonSession *s = op->get_session();
   assert(s);
 
-  s->until = ceph_clock_now(g_ceph_context);
-  s->until += g_conf->mon_subscribe_interval;
   for (map<string,ceph_mon_subscribe_item>::iterator p = m->what.begin();
        p != m->what.end();
        ++p) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1024,6 +1024,9 @@ void OSDMonitor::maybe_prime_pg_temp()
 void OSDMonitor::prime_pg_temp(OSDMap& next,
 			       ceph::unordered_map<pg_t, pg_stat_t>::iterator pp)
 {
+  // do not prime creating pgs
+  if (pp->second.state & PG_STATE_CREATING)
+    return;
   // do not touch a mapping if a change is pending
   if (pending_inc.new_pg_temp.count(pp->first))
     return;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -43,6 +43,7 @@
 #include "messages/MMonCommand.h"
 #include "messages/MRemoveSnaps.h"
 #include "messages/MOSDScrub.h"
+#include "messages/MRoute.h"
 
 #include "common/TextTable.h"
 #include "common/Timer.h"
@@ -2400,7 +2401,20 @@ void OSDMonitor::send_incremental(MonOpRequestRef op, epoch_t first)
 
   MonSession *s = op->get_session();
   assert(s);
-  send_incremental(first, s, false, op);
+
+  if (s->proxy_con &&
+      s->proxy_con->has_feature(CEPH_FEATURE_MON_ROUTE_OSDMAP)) {
+    // oh, we can tell the other mon to do it
+    dout(10) << __func__ << " asking proxying mon to send_incremental from "
+	     << first << dendl;
+    MRoute *r = new MRoute(s->proxy_tid, NULL);
+    r->send_osdmap_first = first;
+    s->proxy_con->send_message(r);
+    op->mark_event("reply: send routed send_osdmap_first reply");
+  } else {
+    // do it ourselves
+    send_incremental(first, s, false, op);
+  }
 }
 
 void OSDMonitor::send_incremental(epoch_t first,

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2445,7 +2445,7 @@ void OSDMonitor::send_incremental(epoch_t first,
 	     << first << " " << bl.length() << " bytes" << dendl;
 
     MOSDMap *m = new MOSDMap(osdmap.get_fsid());
-    m->oldest_map = first;
+    m->oldest_map = get_first_committed();
     m->newest_map = osdmap.get_epoch();
     m->maps[first] = bl;
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1673,9 +1673,9 @@ bool OSDMonitor::check_failure(utime_t now, int target_osd, failure_info_t& fi)
   }
 
   dout(10) << " osd." << target_osd << " has "
-	   << fi.reporters.size() << " reporters and "
-	   << fi.num_reports << " reports, "
-	   << grace << " grace (" << orig_grace << " + " << my_grace << " + " << peer_grace << "), max_failed_since " << max_failed_since
+	   << fi.reporters.size() << " reporters, "
+	   << grace << " grace (" << orig_grace << " + " << my_grace
+	   << " + " << peer_grace << "), max_failed_since " << max_failed_since
 	   << dendl;
 
   // already pending failure?
@@ -1686,13 +1686,13 @@ bool OSDMonitor::check_failure(utime_t now, int target_osd, failure_info_t& fi)
   }
 
   if (failed_for >= grace &&
-      ((int)fi.reporters.size() >= g_conf->mon_osd_min_down_reporters) &&
-      (fi.num_reports >= g_conf->mon_osd_min_down_reports)) {
-    dout(1) << " we have enough reports/reporters to mark osd." << target_osd << " down" << dendl;
+      ((int)fi.reporters.size() >= g_conf->mon_osd_min_down_reporters)) {
+    dout(1) << " we have enough reporters to mark osd." << target_osd
+	    << " down" << dendl;
     pending_inc.new_state[target_osd] = CEPH_OSD_UP;
 
     mon->clog->info() << osdmap.get_inst(target_osd) << " failed ("
-		     << fi.num_reports << " reports from " << (int)fi.reporters.size() << " peers after "
+		     << (int)fi.reporters.size() << " reporters after "
 		     << failed_for << " >= grace " << grace << ")\n";
     return true;
   }
@@ -1703,7 +1703,8 @@ bool OSDMonitor::prepare_failure(MonOpRequestRef op)
 {
   op->mark_osdmon_event(__func__);
   MOSDFailure *m = static_cast<MOSDFailure*>(op->get_req());
-  dout(1) << "prepare_failure " << m->get_target() << " from " << m->get_orig_source_inst()
+  dout(1) << "prepare_failure " << m->get_target()
+	  << " from " << m->get_orig_source_inst()
           << " is reporting failure:" << m->if_osd_failed() << dendl;
 
   int target_osd = m->get_target().name.num();
@@ -1713,7 +1714,9 @@ bool OSDMonitor::prepare_failure(MonOpRequestRef op)
 
   // calculate failure time
   utime_t now = ceph_clock_now(g_ceph_context);
-  utime_t failed_since = m->get_recv_stamp() - utime_t(m->failed_for ? m->failed_for : g_conf->osd_heartbeat_grace, 0);
+  utime_t failed_since =
+    m->get_recv_stamp() -
+    utime_t(m->failed_for ? m->failed_for : g_conf->osd_heartbeat_grace, 0);
 
   if (m->if_osd_failed()) {
     // add a report
@@ -1729,7 +1732,7 @@ bool OSDMonitor::prepare_failure(MonOpRequestRef op)
   } else {
     // remove the report
     mon->clog->debug() << m->get_target() << " failure report canceled by "
-		      << m->get_orig_source_inst() << "\n";
+		       << m->get_orig_source_inst() << "\n";
     if (failure_info.count(target_osd)) {
       failure_info_t& fi = failure_info[target_osd];
       list<MonOpRequestRef> ls;
@@ -1741,12 +1744,12 @@ bool OSDMonitor::prepare_failure(MonOpRequestRef op)
 	ls.pop_front();
       }
       if (fi.reporters.empty()) {
-	dout(10) << " removing last failure_info for osd." << target_osd << dendl;
+	dout(10) << " removing last failure_info for osd." << target_osd
+		 << dendl;
 	failure_info.erase(target_osd);
       } else {
 	dout(10) << " failure_info for osd." << target_osd << " now "
-		 << fi.reporters.size() << " reporters and "
-		 << fi.num_reports << " reports" << dendl;
+		 << fi.reporters.size() << " reporters" << dendl;
       }
     } else {
       dout(10) << " no failure_info for osd." << target_osd << dendl;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -227,11 +227,12 @@ private:
   MOSDMap *build_incremental(epoch_t first, epoch_t last);
   void send_full(MonOpRequestRef op);
   void send_incremental(MonOpRequestRef op, epoch_t first);
+public:
   // @param req an optional op request, if the osdmaps are replies to it. so
   //            @c Monitor::send_reply() can mark_event with it.
   void send_incremental(epoch_t first, MonSession *session, bool onetime,
 			MonOpRequestRef req = MonOpRequestRef());
-
+private:
   int reweight_by_utilization(int oload, std::string& out_str, bool by_pg,
 			      const set<int64_t> *pools);
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -51,22 +51,20 @@ class PGMap;
 
 /// information about a particular peer's failure reports for one osd
 struct failure_reporter_t {
-  int num_reports;          ///< reports from this reporter
   utime_t failed_since;     ///< when they think it failed
-  MonOpRequestRef op;       ///< most recent failure op request
+  MonOpRequestRef op;       ///< failure op request
 
-  failure_reporter_t() : num_reports(0) {}
-  failure_reporter_t(utime_t s) : num_reports(1), failed_since(s) {}
+  failure_reporter_t() {}
+  failure_reporter_t(utime_t s) : failed_since(s) {}
   ~failure_reporter_t() { }
 };
 
 /// information about all failure reports for one osd
 struct failure_info_t {
-  map<int, failure_reporter_t> reporters;  ///< reporter -> # reports
+  map<int, failure_reporter_t> reporters;  ///< reporter -> failed_since etc
   utime_t max_failed_since;                ///< most recent failed_since
-  int num_reports;
 
-  failure_info_t() : num_reports(0) {}
+  failure_info_t() {}
 
   utime_t get_failed_since() {
     if (max_failed_since == utime_t() && !reporters.empty()) {
@@ -83,7 +81,7 @@ struct failure_info_t {
   // set the message for the latest report.  return any old op request we had,
   // if any, so we can discard it.
   MonOpRequestRef add_report(int who, utime_t failed_since,
-                              MonOpRequestRef op) {
+			     MonOpRequestRef op) {
     map<int, failure_reporter_t>::iterator p = reporters.find(who);
     if (p == reporters.end()) {
       if (max_failed_since == utime_t())
@@ -91,10 +89,7 @@ struct failure_info_t {
       else if (max_failed_since < failed_since)
 	max_failed_since = failed_since;
       p = reporters.insert(map<int, failure_reporter_t>::value_type(who, failure_reporter_t(failed_since))).first;
-    } else {
-      p->second.num_reports++;
     }
-    num_reports++;
 
     MonOpRequestRef ret = p->second.op;
     p->second.op = op;
@@ -116,7 +111,6 @@ struct failure_info_t {
     map<int, failure_reporter_t>::iterator p = reporters.find(who);
     if (p == reporters.end())
       return;
-    num_reports -= p->second.num_reports;
     reporters.erase(p);
     if (reporters.empty())
       max_failed_since = utime_t();

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -472,7 +472,6 @@ void PGMap::stat_pg_add(const pg_t &pgid, const pg_stat_t &s, bool nocreating,
     if (s.state & PG_STATE_CREATING) {
       creating_pgs.insert(pgid);
       if (s.acting_primary >= 0) {
-	creating_pgs_by_osd[s.acting_primary].insert(pgid);
 	creating_pgs_by_osd_epoch[s.acting_primary][s.mapping_epoch].insert(pgid);
       }
     }
@@ -512,10 +511,6 @@ void PGMap::stat_pg_sub(const pg_t &pgid, const pg_stat_t &s, bool nocreating,
     if (s.state & PG_STATE_CREATING) {
       creating_pgs.erase(pgid);
       if (s.acting_primary >= 0) {
-	creating_pgs_by_osd[s.acting_primary].erase(pgid);
-	if (creating_pgs_by_osd[s.acting_primary].size() == 0)
-	  creating_pgs_by_osd.erase(s.acting_primary);
-
 	map<epoch_t,set<pg_t> >& r = creating_pgs_by_osd_epoch[s.acting_primary];
 	r[s.mapping_epoch].erase(pgid);
 	if (r[s.mapping_epoch].empty())

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -501,7 +501,9 @@ void PGMap::stat_pg_sub(const pg_t &pgid, const pg_stat_t &s, bool nocreating,
   pg_sum.sub(s);
 
   num_pg--;
-  if (--num_pg_by_state[s.state] == 0)
+  int64_t end = --num_pg_by_state[s.state];
+  assert(end >= 0);
+  if (end == 0)
     num_pg_by_state.erase(s.state);
 
   if (!nocreating) {

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -182,7 +182,6 @@ public:
  public:
 
   set<pg_t> creating_pgs;
-  map<int,set<pg_t> > creating_pgs_by_osd;
   map<int,map<epoch_t,set<pg_t> > > creating_pgs_by_osd_epoch;
 
   // Bits that use to be enum StuckPG

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -183,6 +183,7 @@ public:
 
   set<pg_t> creating_pgs;
   map<int,set<pg_t> > creating_pgs_by_osd;
+  map<int,map<epoch_t,set<pg_t> > > creating_pgs_by_osd_epoch;
 
   // Bits that use to be enum StuckPG
   static const int STUCK_INACTIVE = (1<<0);

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -181,7 +181,7 @@ public:
 
  public:
 
-  set<pg_t> creating_pgs;   // lru: front = new additions, back = recently pinged
+  set<pg_t> creating_pgs;
   map<int,set<pg_t> > creating_pgs_by_osd;
 
   // Bits that use to be enum StuckPG

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -276,11 +276,6 @@ void PGMonitor::update_from_paxos(bool *need_bootstrap)
 
   assert(version == pg_map.version);
 
-  if (mon->osdmon()->osdmap.get_epoch()) {
-    map_pg_creates();
-    send_pg_creates();
-  }
-
   update_logger();
 }
 
@@ -308,6 +303,7 @@ void PGMonitor::upgrade_format()
 
 void PGMonitor::post_paxos_update()
 {
+  dout(10) << __func__ << dendl;
   if (mon->osdmon()->osdmap.get_epoch()) {
     map_pg_creates();
     send_pg_creates();
@@ -958,11 +954,6 @@ void PGMonitor::check_osd_map(epoch_t epoch)
   
   if (propose)
     propose_pending();
-
-  if (mon->osdmon()->osdmap.get_epoch()) {
-    map_pg_creates();
-    send_pg_creates();
-  }
 }
 
 void PGMonitor::register_pg(pg_pool_t& pool, pg_t pgid, epoch_t epoch, bool new_pool)

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -128,7 +128,8 @@ void PGMonitor::tick()
   if (mon->is_leader()) {
     bool propose = false;
     
-    if (need_check_down_pgs && check_down_pgs())
+    if ((need_check_down_pgs || !need_check_down_pg_osds.empty()) &&
+	check_down_pgs())
       propose = true;
     
     if (propose) {
@@ -914,7 +915,7 @@ void PGMonitor::check_osd_map(epoch_t epoch)
 	 p != inc.new_state.end();
 	 ++p) {
       if (p->second & CEPH_OSD_UP) {   // true if marked up OR down, but we're too lazy to check which
-	need_check_down_pgs = true;
+	need_check_down_pg_osds.insert(p->first);
 
 	// clear out the last_osd_report for this OSD
         map<int, utime_t>::iterator report = last_osd_report.find(p->first);
@@ -951,7 +952,8 @@ void PGMonitor::check_osd_map(epoch_t epoch)
   if (register_new_pgs())
     propose = true;
 
-  if (need_check_down_pgs && check_down_pgs())
+  if ((need_check_down_pgs || !need_check_down_pg_osds.empty()) &&
+      check_down_pgs())
     propose = true;
   
   if (propose)
@@ -1213,6 +1215,21 @@ void PGMonitor::send_pg_creates(int osd, Connection *con)
   last_sent_pg_create[osd] = ceph_clock_now(g_ceph_context);
 }
 
+void PGMonitor::_mark_pg_stale(pg_t pgid, const pg_stat_t& cur_stat)
+{
+  dout(10) << " marking pg " << pgid << " stale" << dendl;
+  map<pg_t,pg_stat_t>::iterator q = pending_inc.pg_stat_updates.find(pgid);
+  pg_stat_t *stat;
+  if (q == pending_inc.pg_stat_updates.end()) {
+    stat = &pending_inc.pg_stat_updates[pgid];
+    *stat = cur_stat;
+  } else {
+    stat = &q->second;
+  }
+  stat->state |= PG_STATE_STALE;
+  stat->last_unstale = ceph_clock_now(g_ceph_context);
+}
+
 bool PGMonitor::check_down_pgs()
 {
   dout(10) << "check_down_pgs" << dendl;
@@ -1220,28 +1237,37 @@ bool PGMonitor::check_down_pgs()
   OSDMap *osdmap = &mon->osdmon()->osdmap;
   bool ret = false;
 
-  for (ceph::unordered_map<pg_t,pg_stat_t>::iterator p = pg_map.pg_stat.begin();
-       p != pg_map.pg_stat.end();
-       ++p) {
-    if ((p->second.state & PG_STATE_STALE) == 0 &&
-	p->second.acting_primary != -1 &&
-	osdmap->is_down(p->second.acting_primary)) {
-      dout(10) << " marking pg " << p->first << " stale with acting " << p->second.acting << dendl;
+  // if a large number of osds changed state, just iterate over the whole
+  // pg map.
+  if (need_check_down_pg_osds.size() > (unsigned)osdmap->get_num_osds() *
+      g_conf->mon_pg_check_down_all_threshold)
+    need_check_down_pgs = true;
 
-      map<pg_t,pg_stat_t>::iterator q = pending_inc.pg_stat_updates.find(p->first);
-      pg_stat_t *stat;
-      if (q == pending_inc.pg_stat_updates.end()) {
-	stat = &pending_inc.pg_stat_updates[p->first];
-	*stat = p->second;
-      } else {
-	stat = &q->second;
+  if (need_check_down_pgs) {
+    for (auto p : pg_map.pg_stat) {
+      if ((p.second.state & PG_STATE_STALE) == 0 &&
+	  p.second.acting_primary != -1 &&
+	  osdmap->is_down(p.second.acting_primary)) {
+	_mark_pg_stale(p.first, p.second);
+	ret = true;
       }
-      stat->state |= PG_STATE_STALE;
-      stat->last_unstale = ceph_clock_now(g_ceph_context);
-      ret = true;
+    }
+  } else {
+    for (auto osd : need_check_down_pg_osds) {
+      if (osdmap->is_down(osd)) {
+	for (auto pgid : pg_map.pg_by_osd[osd]) {
+	  const pg_stat_t &stat = pg_map.pg_stat[pgid];
+	  if ((stat.state & PG_STATE_STALE) == 0 &&
+	      stat.acting_primary != -1) {
+	    _mark_pg_stale(pgid, stat);
+	    ret = true;
+	  }
+	}
+      }
     }
   }
   need_check_down_pgs = false;
+  need_check_down_pg_osds.clear();
 
   return ret;
 }

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1591,14 +1591,6 @@ bool PGMonitor::preprocess_command(MonOpRequestRef op)
     pg_map.encode(rdata);
     ss << "got pgmap version " << pg_map.version;
     r = 0;
-  } else if (prefix == "pg map_pg_creates") {
-    map_pg_creates();
-    ss << "mapped pg creates ";
-    r = 0;
-  } else if (prefix == "pg send_pg_creates") {
-    send_pg_creates();
-    ss << "sent pg creates ";
-    r = 0;
   } else if (prefix == "pg dump") {
     string val;
     vector<string> dumpcontents;

--- a/src/mon/PGMonitor.h
+++ b/src/mon/PGMonitor.h
@@ -47,6 +47,7 @@ public:
   PGMap pg_map;
 
   bool need_check_down_pgs;
+  set<int> need_check_down_pg_osds;
 
   epoch_t last_map_pg_create_osd_epoch;
 
@@ -131,10 +132,13 @@ private:
    * check pgs for down primary osds
    *
    * clears need_check_down_pgs
+   * clears need_check_down_pg_osds
    *
    * @return true if we updated pending_inc (and should propose)
    */
   bool check_down_pgs();
+  void _mark_pg_stale(pg_t pgid, const pg_stat_t& cur_stat);
+
 
   /**
    * Dump stats from pgs stuck in specified states.

--- a/src/mon/PGMonitor.h
+++ b/src/mon/PGMonitor.h
@@ -126,7 +126,7 @@ private:
 
   void map_pg_creates();
   void send_pg_creates();
-  void send_pg_creates(int osd, Connection *con);
+  epoch_t send_pg_creates(int osd, Connection *con, epoch_t next);
 
   /**
    * check pgs for down primary osds
@@ -208,6 +208,7 @@ public:
 			     list<pair<health_status_t,string> > *detail,
 			     const set<int>& s, const char *desc, health_status_t sev) const;
 
+  void check_subs();
   void check_sub(Subscription *sub);
 
 private:

--- a/src/mon/PGMonitor.h
+++ b/src/mon/PGMonitor.h
@@ -49,9 +49,6 @@ public:
   bool need_check_down_pgs;
   set<int> need_check_down_pg_osds;
 
-  epoch_t last_map_pg_create_osd_epoch;
-
-
 private:
   PGMap::Incremental pending_inc;
 
@@ -115,7 +112,8 @@ private:
   // when we last received PG stats from each osd
   map<int,utime_t> last_osd_report;
 
-  void register_pg(pg_pool_t& pool, pg_t pgid, epoch_t epoch, bool new_pool);
+  void register_pg(OSDMap *osdmap, pg_pool_t& pool, pg_t pgid,
+		   epoch_t epoch, bool new_pool);
 
   /**
    * check latest osdmap for new pgs to register
@@ -124,7 +122,13 @@ private:
    */
   bool register_new_pgs();
 
-  void map_pg_creates();
+  /**
+   * recalculate creating pg mappings
+   *
+   * @return true if we updated pending_inc
+   */
+  bool map_pg_creates();
+
   void send_pg_creates();
   epoch_t send_pg_creates(int osd, Connection *con, epoch_t next);
 
@@ -160,7 +164,6 @@ public:
   PGMonitor(Monitor *mn, Paxos *p, const string& service_name)
     : PaxosService(mn, p, service_name),
       need_check_down_pgs(false),
-      last_map_pg_create_osd_epoch(0),
       pgmap_meta_prefix("pgmap_meta"),
       pgmap_pg_prefix("pgmap_pg"),
       pgmap_osd_prefix("pgmap_osd")

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -40,6 +40,7 @@ struct Subscription {
 struct MonSession : public RefCountedObject {
   ConnectionRef con;
   entity_inst_t inst;
+  utime_t session_timeout;
   utime_t until;
   utime_t time_established;
   bool closed;

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -41,7 +41,6 @@ struct MonSession : public RefCountedObject {
   ConnectionRef con;
   entity_inst_t inst;
   utime_t session_timeout;
-  utime_t until;
   utime_t time_established;
   bool closed;
   xlist<MonSession*>::item item;

--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -39,7 +39,7 @@ class Message;
 class Messenger;
 
 struct Connection : public RefCountedObject {
-  Mutex lock;
+  mutable Mutex lock;
   Messenger *msgr;
   RefCountedObject *priv;
   int peer_type;
@@ -179,15 +179,19 @@ public:
   }
 
   utime_t get_last_keepalive() const {
+    Mutex::Locker l(lock);
     return last_keepalive;
   }
   void set_last_keepalive(utime_t t) {
+    Mutex::Locker l(lock);
     last_keepalive = t;
   }
   utime_t get_last_keepalive_ack() const {
+    Mutex::Locker l(lock);
     return last_keepalive_ack;
   }
   void set_last_keepalive_ack(utime_t t) {
+    Mutex::Locker l(lock);
     last_keepalive_ack = t;
   }
 

--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -44,7 +44,7 @@ struct Connection : public RefCountedObject {
   RefCountedObject *priv;
   int peer_type;
   entity_addr_t peer_addr;
-  utime_t last_keepalive_ack;
+  utime_t last_keepalive, last_keepalive_ack;
 private:
   uint64_t features;
 public:
@@ -178,9 +178,19 @@ public:
     rx_buffers.erase(tid);
   }
 
+  utime_t get_last_keepalive() const {
+    return last_keepalive;
+  }
+  void set_last_keepalive(utime_t t) {
+    last_keepalive = t;
+  }
   utime_t get_last_keepalive_ack() const {
     return last_keepalive_ack;
   }
+  void set_last_keepalive_ack(utime_t t) {
+    last_keepalive_ack = t;
+  }
+
 };
 
 typedef boost::intrusive_ptr<Connection> ConnectionRef;

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -458,6 +458,7 @@ void AsyncConnection::process()
 
           if (tag == CEPH_MSGR_TAG_KEEPALIVE) {
             ldout(async_msgr->cct, 20) << __func__ << " got KEEPALIVE" << dendl;
+	    set_last_keepalive(ceph_clock_now(NULL));
           } else if (tag == CEPH_MSGR_TAG_KEEPALIVE2) {
             state = STATE_OPEN_KEEPALIVE2;
           } else if (tag == CEPH_MSGR_TAG_KEEPALIVE2_ACK) {
@@ -492,8 +493,9 @@ void AsyncConnection::process()
           utime_t kp_t = utime_t(*t);
           write_lock.Lock();
           _send_keepalive_or_ack(true, &kp_t);
-          write_lock.Unlock();
+	  write_lock.Unlock();
           ldout(async_msgr->cct, 20) << __func__ << " got KEEPALIVE2 " << kp_t << dendl;
+	  set_last_keepalive(ceph_clock_now(NULL));
           state = STATE_OPEN;
           break;
         }
@@ -510,7 +512,7 @@ void AsyncConnection::process()
           }
 
           t = (ceph_timespec*)state_buffer;
-          last_keepalive_ack = utime_t(*t);
+          set_last_keepalive_ack(utime_t(*t));
           ldout(async_msgr->cct, 20) << __func__ << " got KEEPALIVE_ACK" << dendl;
           state = STATE_OPEN;
           break;

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1515,7 +1515,7 @@ void Pipe::reader()
     }
 
     if (tag == CEPH_MSGR_TAG_KEEPALIVE) {
-      ldout(msgr->cct,20) << "reader got KEEPALIVE" << dendl;
+      ldout(msgr->cct,2) << "reader got KEEPALIVE" << dendl;
       pipe_lock.Lock();
       connection_state->set_last_keepalive(ceph_clock_now(NULL));
       continue;
@@ -1532,15 +1532,15 @@ void Pipe::reader()
       } else {
 	send_keepalive_ack = true;
 	keepalive_ack_stamp = utime_t(t);
-	ldout(msgr->cct,20) << "reader got KEEPALIVE2 " << keepalive_ack_stamp
-			    << dendl;
+	ldout(msgr->cct,2) << "reader got KEEPALIVE2 " << keepalive_ack_stamp
+			   << dendl;
 	connection_state->set_last_keepalive(ceph_clock_now(NULL));
 	cond.Signal();
       }
       continue;
     }
     if (tag == CEPH_MSGR_TAG_KEEPALIVE2_ACK) {
-      ldout(msgr->cct,20) << "reader got KEEPALIVE_ACK" << dendl;
+      ldout(msgr->cct,2) << "reader got KEEPALIVE_ACK" << dendl;
       struct ceph_timespec t;
       int rc = tcp_read((char*)&t, sizeof(t));
       pipe_lock.Lock();

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1517,6 +1517,7 @@ void Pipe::reader()
     if (tag == CEPH_MSGR_TAG_KEEPALIVE) {
       ldout(msgr->cct,20) << "reader got KEEPALIVE" << dendl;
       pipe_lock.Lock();
+      connection_state->set_last_keepalive(ceph_clock_now(NULL));
       continue;
     }
     if (tag == CEPH_MSGR_TAG_KEEPALIVE2) {
@@ -1533,6 +1534,7 @@ void Pipe::reader()
 	keepalive_ack_stamp = utime_t(t);
 	ldout(msgr->cct,20) << "reader got KEEPALIVE2 " << keepalive_ack_stamp
 			    << dendl;
+	connection_state->set_last_keepalive(ceph_clock_now(NULL));
 	cond.Signal();
       }
       continue;
@@ -1546,7 +1548,7 @@ void Pipe::reader()
 	ldout(msgr->cct,2) << "reader couldn't read KEEPALIVE2 stamp " << cpp_strerror(errno) << dendl;
 	fault(true);
       } else {
-	connection_state->last_keepalive_ack = utime_t(t);
+	connection_state->set_last_keepalive_ack(utime_t(t));
       }
       continue;
     }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4027,7 +4027,6 @@ void OSD::tick()
       last_mon_report = now;
 
       // do any pending reports
-      service.send_pg_temp();
       send_failures();
       send_pg_stats(now);
     }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4005,6 +4005,9 @@ void OSD::tick()
     if (now - last_pg_stats_sent > cct->_conf->osd_mon_report_interval_max) {
       osd_stat_updated = true;
       report = true;
+    } else if (outstanding_pg_stats >= cct->_conf->osd_mon_report_max_in_flight) {
+      dout(20) << __func__ << " have max " << outstanding_pg_stats
+	       << " stats updates in flight" << dendl;
     } else {
       double backoff = stats_ack_timeout / g_conf->osd_mon_ack_timeout;
       double adjusted_min = cct->_conf->osd_mon_report_interval_min * backoff;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4014,6 +4014,49 @@ void OSD::tick()
     heartbeat_check();
     heartbeat_lock.Unlock();
 
+    map_lock.put_read();
+  }
+
+  if (is_waiting_for_healthy()) {
+    if (_is_healthy()) {
+      dout(1) << "healthy again, booting" << dendl;
+      set_state(STATE_BOOTING);
+      start_boot();
+    }
+  }
+
+  if (is_active()) {
+    // periodically kick recovery work queue
+    recovery_tp.wake();
+
+    check_replay_queue();
+  }
+
+  // only do waiters if dispatch() isn't currently running.  (if it is,
+  // it'll do the waiters, and doing them here may screw up ordering
+  // of op_queue vs handle_osd_map.)
+  if (!dispatch_running) {
+    dispatch_running = true;
+    do_waiters();
+    dispatch_running = false;
+    dispatch_cond.Signal();
+  }
+
+  check_ops_in_flight();
+
+  tick_timer.add_event_after(OSD_TICK_INTERVAL, new C_Tick(this));
+}
+
+void OSD::tick_without_osd_lock()
+{
+  assert(tick_timer_lock.is_locked());
+  dout(5) << "tick_without_osd_lock" << dendl;
+
+  // osd_lock is not being held, which means the OSD state
+  // might change when doing the monitor report
+  if (is_active() || is_waiting_for_healthy()) {
+    map_lock.get_read();
+
     // mon report?
     bool reset = false;
     bool report = false;
@@ -4061,43 +4104,8 @@ void OSD::tick()
       send_failures();
       send_pg_stats(now);
     }
-
     map_lock.put_read();
   }
-
-  if (is_waiting_for_healthy()) {
-    if (_is_healthy()) {
-      dout(1) << "healthy again, booting" << dendl;
-      start_boot();
-    }
-  }
-
-  if (is_active()) {
-    // periodically kick recovery work queue
-    recovery_tp.wake();
-
-    check_replay_queue();
-  }
-
-  // only do waiters if dispatch() isn't currently running.  (if it is,
-  // it'll do the waiters, and doing them here may screw up ordering
-  // of op_queue vs handle_osd_map.)
-  if (!dispatch_running) {
-    dispatch_running = true;
-    do_waiters();
-    dispatch_running = false;
-    dispatch_cond.Signal();
-  }
-
-  check_ops_in_flight();
-
-  tick_timer.add_event_after(OSD_TICK_INTERVAL, new C_Tick(this));
-}
-
-void OSD::tick_without_osd_lock()
-{
-  assert(tick_timer_lock.is_locked());
-  dout(5) << "tick_without_osd_lock" << dendl;
 
   if (!scrub_random_backoff()) {
     sched_scrub();
@@ -4408,12 +4416,14 @@ void OSD::ms_handle_connect(Connection *con)
       last_mon_report = now;
 
       // resend everything, it's a new session
+      map_lock.get_read();
       send_alive();
       service.requeue_pg_temp();
       service.send_pg_temp();
       requeue_failures();
       send_failures();
       send_pg_stats(now);
+      map_lock.put_read();
 
       monc->sub_want("osd_pg_creates", 0, CEPH_SUBSCRIBE_ONETIME);
       monc->sub_want("osdmap", osdmap->get_epoch(), CEPH_SUBSCRIBE_ONETIME);
@@ -4756,7 +4766,6 @@ void OSD::got_full_map(epoch_t e)
 
 void OSD::requeue_failures()
 {
-  assert(osd_lock.is_locked());
   Mutex::Locker l(heartbeat_lock);
   unsigned old_queue = failure_queue.size();
   unsigned old_pending = failure_pending.size();
@@ -4772,7 +4781,7 @@ void OSD::requeue_failures()
 
 void OSD::send_failures()
 {
-  assert(osd_lock.is_locked());
+  assert(map_lock.is_locked());
   Mutex::Locker l(heartbeat_lock);
   utime_t now = ceph_clock_now(cct);
   while (!failure_queue.empty()) {
@@ -4797,8 +4806,7 @@ void OSD::send_still_alive(epoch_t epoch, const entity_inst_t &i)
 
 void OSD::send_pg_stats(const utime_t &now)
 {
-  assert(osd_lock.is_locked());
-
+  assert(map_lock.is_locked());
   dout(20) << "send_pg_stats" << dendl;
 
   osd_stat_t cur_stat = service.get_osd_stat();
@@ -4919,10 +4927,12 @@ void OSD::handle_pg_stats_ack(MPGStatsAck *ack)
 void OSD::flush_pg_stats()
 {
   dout(10) << "flush_pg_stats" << dendl;
-  utime_t now = ceph_clock_now(cct);
-  send_pg_stats(now);
-
   osd_lock.Unlock();
+  utime_t now = ceph_clock_now(cct);
+  map_lock.get_read();
+  send_pg_stats(now);
+  map_lock.put_read();
+
 
   pg_stat_queue_lock.Lock();
   uint64_t tid = pg_stat_tid;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1974,10 +1974,6 @@ int OSD::init()
     tick_timer_without_osd_lock.add_event_after(cct->_conf->osd_heartbeat_interval, new C_Tick_WithoutOSDLock(this));
   }
 
-  service.init();
-  service.publish_map(osdmap);
-  service.publish_superblock(superblock);
-
   osd_lock.Unlock();
 
   r = monc->authenticate();
@@ -2007,6 +2003,15 @@ int OSD::init()
   peering_wq.drain();
 
   dout(0) << "done with init, starting boot process" << dendl;
+
+  // subscribe to any pg creations
+  monc->sub_want("osd_pg_creates", last_pg_create_epoch, 0);
+
+  // we don't need to ask for an osdmap here; objecter will
+  //monc->sub_want("osdmap", osdmap->get_epoch(), CEPH_SUBSCRIBE_ONETIME);
+
+  monc->renew_subs();
+
   start_boot();
 
   return 0;
@@ -4433,10 +4438,6 @@ void OSD::ms_handle_connect(Connection *con)
       send_pg_stats(now);
 
       map_lock.put_read();
-
-      monc->sub_want("osd_pg_creates", last_pg_create_epoch, 0);
-      monc->sub_want("osdmap", osdmap->get_epoch(), CEPH_SUBSCRIBE_ONETIME);
-      monc->renew_subs();
     }
 
     // full map requests may happen while active or pre-boot

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4022,8 +4022,15 @@ void OSD::tick()
 
     if (reset)
       monc->reopen_session();
-    else if (report)
-      do_mon_report();
+    else if (report) {
+      last_mon_report = now;
+
+      // do any pending reports
+      send_alive();
+      service.send_pg_temp();
+      send_failures();
+      send_pg_stats(now);
+    }
 
     map_lock.put_read();
   }
@@ -4356,20 +4363,6 @@ void OSD::RemoveWQ::_process(
   item.second->finish_deleting();
 }
 // =========================================
-
-void OSD::do_mon_report()
-{
-  dout(7) << "do_mon_report" << dendl;
-
-  utime_t now(ceph_clock_now(cct));
-  last_mon_report = now;
-
-  // do any pending reports
-  send_alive();
-  service.send_pg_temp();
-  send_failures();
-  send_pg_stats(now);
-}
 
 void OSD::ms_handle_connect(Connection *con)
 {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3998,6 +3998,7 @@ void OSD::tick()
       stats_ack_timeout =
 	MAX(g_conf->osd_mon_ack_timeout,
 	    stats_ack_timeout * g_conf->osd_stats_ack_timeout_factor);
+      outstanding_pg_stats = false;
     }
     if (now - last_pg_stats_sent > cct->_conf->osd_mon_report_interval_max) {
       osd_stat_updated = true;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -750,7 +750,40 @@ pair<ConnectionRef,ConnectionRef> OSDService::get_con_osd_hb(int peer, epoch_t f
 void OSDService::queue_want_pg_temp(pg_t pgid, vector<int>& want)
 {
   Mutex::Locker l(pg_temp_lock);
-  pg_temp_wanted[pgid] = want;
+  map<pg_t,vector<int> >::iterator p = pg_temp_pending.find(pgid);
+  if (p == pg_temp_pending.end() ||
+      p->second != want) {
+    pg_temp_wanted[pgid] = want;
+  }
+}
+
+void OSDService::remove_want_pg_temp(pg_t pgid)
+{
+  Mutex::Locker l(pg_temp_lock);
+  pg_temp_wanted.erase(pgid);
+  pg_temp_pending.erase(pgid);
+}
+
+void OSDService::_sent_pg_temp()
+{
+  for (map<pg_t,vector<int> >::iterator p = pg_temp_wanted.begin();
+       p != pg_temp_wanted.end();
+       ++p)
+    pg_temp_pending[p->first] = p->second;
+  pg_temp_wanted.clear();
+}
+
+void OSDService::requeue_pg_temp()
+{
+  Mutex::Locker l(pg_temp_lock);
+  // wanted overrides pending.  note that remove_want_pg_temp
+  // clears the item out of both.
+  unsigned old_wanted = pg_temp_wanted.size();
+  unsigned old_pending = pg_temp_pending.size();
+  _sent_pg_temp();
+  pg_temp_wanted.swap(pg_temp_pending);
+  dout(10) << __func__ << " " << old_wanted << " + " << old_pending << " -> "
+	   << pg_temp_wanted.size() << dendl;
 }
 
 void OSDService::send_pg_temp()
@@ -762,6 +795,7 @@ void OSDService::send_pg_temp()
   MOSDPGTemp *m = new MOSDPGTemp(osdmap->get_epoch());
   m->pg_temp = pg_temp_wanted;
   monc->send_mon_message(m);
+  _sent_pg_temp();
 }
 
 
@@ -4380,6 +4414,7 @@ void OSD::ms_handle_connect(Connection *con)
 
       // resend everything, it's a new session
       send_alive();
+      service.requeue_pg_temp();
       service.send_pg_temp();
       requeue_failures();
       send_failures();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1566,6 +1566,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
   debug_drop_pg_create_probability(cct->_conf->osd_debug_drop_pg_create_probability),
   debug_drop_pg_create_duration(cct->_conf->osd_debug_drop_pg_create_duration),
   debug_drop_pg_create_left(-1),
+  stats_ack_timeout(cct->_conf->osd_mon_ack_timeout),
   outstanding_pg_stats(false),
   timeout_mon_on_pg_stats(true),
   up_thru_wanted(0), up_thru_pending(0),
@@ -3988,13 +3989,17 @@ void OSD::tick()
     // mon report?
     utime_t now = ceph_clock_now(cct);
     if (outstanding_pg_stats && timeout_mon_on_pg_stats &&
-	(now - cct->_conf->osd_mon_ack_timeout) > last_pg_stats_ack) {
-      dout(1) << "mon hasn't acked PGStats in " << now - last_pg_stats_ack
+	(now - stats_ack_timeout) > last_pg_stats_ack) {
+      dout(1) << __func__ << " mon hasn't acked PGStats in "
+	      << now - last_pg_stats_ack
 	      << " seconds, reconnecting elsewhere" << dendl;
       monc->reopen_session(new C_MonStatsAckTimer(this));
       timeout_mon_on_pg_stats = false;
       last_pg_stats_ack = ceph_clock_now(cct);  // reset clock
       last_pg_stats_sent = utime_t();
+      stats_ack_timeout =
+	MAX(g_conf->osd_mon_ack_timeout,
+	    stats_ack_timeout * g_conf->osd_stats_ack_timeout_factor);
     }
     if (now - last_pg_stats_sent > cct->_conf->osd_mon_report_interval_max) {
       osd_stat_updated = true;
@@ -4799,6 +4804,12 @@ void OSD::handle_pg_stats_ack(MPGStatsAck *ack)
   }
 
   last_pg_stats_ack = ceph_clock_now(cct);
+
+  // decay timeout slowly (analogous to TCP)
+  stats_ack_timeout =
+    MAX(g_conf->osd_mon_ack_timeout,
+	stats_ack_timeout * g_conf->osd_stats_ack_timeout_decay);
+  dout(20) << __func__ << "  timeout now " << stats_ack_timeout << dendl;
 
   pg_stat_queue_lock.Lock();
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4491,7 +4491,7 @@ struct C_OSD_GetVersion : public Context {
   C_OSD_GetVersion(OSD *o) : osd(o), oldest(0), newest(0) {}
   void finish(int r) {
     if (r >= 0)
-      osd->_maybe_boot(oldest, newest);
+      osd->maybe_boot(oldest, newest);
   }
 };
 
@@ -4503,9 +4503,14 @@ void OSD::start_boot()
   monc->get_version("osdmap", &c->newest, &c->oldest, c);
 }
 
-void OSD::_maybe_boot(epoch_t oldest, epoch_t newest)
+void OSD::maybe_boot(epoch_t oldest, epoch_t newest)
 {
   Mutex::Locker l(osd_lock);
+  _maybe_boot(oldest, newest);
+}
+
+void OSD::_maybe_boot(epoch_t oldest, epoch_t newest)
+{
   if (!is_booting())
     return;
   dout(10) << "_maybe_boot mon has osdmaps " << oldest << ".." << newest << dendl;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4506,7 +4506,7 @@ void OSD::start_boot()
 void OSD::_maybe_boot(epoch_t oldest, epoch_t newest)
 {
   Mutex::Locker l(osd_lock);
-  if (is_stopping())
+  if (!is_booting())
     return;
   dout(10) << "_maybe_boot mon has osdmaps " << oldest << ".." << newest << dendl;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3989,6 +3989,9 @@ void OSD::tick()
     bool report = false;
     utime_t now = ceph_clock_now(cct);
     pg_stat_queue_lock.Lock();
+    double backoff = stats_ack_timeout / g_conf->osd_mon_ack_timeout;
+    double adjusted_min = cct->_conf->osd_mon_report_interval_min * backoff;
+    double adjusted_max = cct->_conf->osd_mon_report_interval_max * backoff;
     if (!outstanding_pg_stats.empty() &&
 	(now - stats_ack_timeout) > last_pg_stats_ack) {
       dout(1) << __func__ << " mon hasn't acked PGStats in "
@@ -4002,7 +4005,7 @@ void OSD::tick()
 	    stats_ack_timeout * g_conf->osd_stats_ack_timeout_factor);
       outstanding_pg_stats.clear();
     }
-    if (now - last_pg_stats_sent > cct->_conf->osd_mon_report_interval_max) {
+    if (now - last_pg_stats_sent > adjusted_max) {
       osd_stat_updated = true;
       report = true;
     } else if ((int)outstanding_pg_stats.size() >=
@@ -4010,8 +4013,6 @@ void OSD::tick()
       dout(20) << __func__ << " have max " << outstanding_pg_stats
 	       << " stats updates in flight" << dendl;
     } else {
-      double backoff = stats_ack_timeout / g_conf->osd_mon_ack_timeout;
-      double adjusted_min = cct->_conf->osd_mon_report_interval_min * backoff;
       if (now - last_mon_report > adjusted_min) {
 	dout(20) << __func__ << " stats backoff " << backoff
 		 << " adjusted_min " << adjusted_min << " - sending report"

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3776,7 +3776,7 @@ void OSD::handle_osd_ping(MOSDPing *m)
 	}
 	if (failure_pending.count(from)) {
 	  dout(10) << "handle_osd_ping canceling in-flight failure report for osd." << from<< dendl;
-	  send_still_alive(curmap->get_epoch(), failure_pending[from]);
+	  send_still_alive(curmap->get_epoch(), failure_pending[from].second);
 	  failure_pending.erase(from);
 	}
       }
@@ -4381,6 +4381,7 @@ void OSD::ms_handle_connect(Connection *con)
       // resend everything, it's a new session
       send_alive();
       service.send_pg_temp();
+      requeue_failures();
       send_failures();
       send_pg_stats(now);
 
@@ -4719,6 +4720,22 @@ void OSD::got_full_map(epoch_t e)
   }
 }
 
+void OSD::requeue_failures()
+{
+  assert(osd_lock.is_locked());
+  Mutex::Locker l(heartbeat_lock);
+  unsigned old_queue = failure_queue.size();
+  unsigned old_pending = failure_pending.size();
+  for (map<int,pair<utime_t,entity_inst_t> >::iterator p =
+	 failure_pending.begin();
+       p != failure_pending.end();
+       ++p) {
+    failure_queue[p->first] = p->second.first;
+  }
+  dout(10) << __func__ << " " << old_queue << " + " << old_pending << " -> "
+	   << failure_queue.size() << dendl;
+}
+
 void OSD::send_failures()
 {
   assert(osd_lock.is_locked());
@@ -4730,7 +4747,7 @@ void OSD::send_failures()
     entity_inst_t i = osdmap->get_inst(osd);
     monc->send_mon_message(new MOSDFailure(monc->get_fsid(), i, failed_for,
 					   osdmap->get_epoch()));
-    failure_pending[osd] = i;
+    failure_pending[osd] = make_pair(failure_queue.begin()->second, i);
     failure_queue.erase(osd);
   }
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1568,7 +1568,6 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
   debug_drop_pg_create_left(-1),
   stats_ack_timeout(cct->_conf->osd_mon_ack_timeout),
   outstanding_pg_stats(false),
-  timeout_mon_on_pg_stats(true),
   up_thru_wanted(0), up_thru_pending(0),
   requested_full_first(0),
   requested_full_last(0),
@@ -3988,13 +3987,12 @@ void OSD::tick()
 
     // mon report?
     utime_t now = ceph_clock_now(cct);
-    if (outstanding_pg_stats && timeout_mon_on_pg_stats &&
+    if (outstanding_pg_stats &&
 	(now - stats_ack_timeout) > last_pg_stats_ack) {
       dout(1) << __func__ << " mon hasn't acked PGStats in "
 	      << now - last_pg_stats_ack
 	      << " seconds, reconnecting elsewhere" << dendl;
-      monc->reopen_session(new C_MonStatsAckTimer(this));
-      timeout_mon_on_pg_stats = false;
+      monc->reopen_session();
       last_pg_stats_ack = ceph_clock_now(cct);  // reset clock
       last_pg_stats_sent = utime_t();
       stats_ack_timeout =

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4027,7 +4027,6 @@ void OSD::tick()
       last_mon_report = now;
 
       // do any pending reports
-      send_alive();
       service.send_pg_temp();
       send_failures();
       send_pg_stats(now);
@@ -4383,7 +4382,7 @@ void OSD::ms_handle_connect(Connection *con)
       send_alive();
       service.send_pg_temp();
       send_failures();
-      send_pg_stats(ceph_clock_now(cct));
+      send_pg_stats(now);
 
       monc->sub_want("osd_pg_creates", 0, CEPH_SUBSCRIBE_ONETIME);
       monc->sub_want("osdmap", osdmap->get_epoch(), CEPH_SUBSCRIBE_ONETIME);
@@ -4639,9 +4638,6 @@ void OSD::queue_want_up_thru(epoch_t want)
 	     << ", currently " << cur
 	     << dendl;
     up_thru_wanted = want;
-
-    // expedite, a bit.  WARNING this will somewhat delay other mon queries.
-    last_mon_report = ceph_clock_now(cct);
     send_alive();
   } else {
     dout(10) << "queue_want_up_thru want " << want << " <= queued " << up_thru_wanted 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1598,9 +1598,6 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
   map_lock("OSD::map_lock"),
   pg_map_lock("OSD::pg_map_lock"),
   last_pg_create_epoch(0),
-  debug_drop_pg_create_probability(cct->_conf->osd_debug_drop_pg_create_probability),
-  debug_drop_pg_create_duration(cct->_conf->osd_debug_drop_pg_create_duration),
-  debug_drop_pg_create_left(-1),
   mon_report_lock("OSD::mon_report_lock"),
   stats_ack_timeout(cct->_conf->osd_mon_ack_timeout),
   up_thru_wanted(0), up_thru_pending(0),
@@ -2767,7 +2764,6 @@ OSD::res_result OSD::_try_resurrect_pg(
 PG *OSD::_create_lock_pg(
   OSDMapRef createmap,
   spg_t pgid,
-  bool newly_created,
   bool hold_map_lock,
   bool backfill,
   int role,
@@ -3198,34 +3194,13 @@ void OSD::handle_pg_peering_evt(
 
     if (!valid_history || epoch < history.same_interval_since) {
       dout(10) << "get_or_create_pg " << pgid << " acting changed in "
-	       << history.same_interval_since << " (msg from " << epoch << ")" << dendl;
+	       << history.same_interval_since << " (msg from " << epoch << ")"
+	       << dendl;
       return;
     }
 
     if (service.splitting(pgid)) {
       assert(0);
-    }
-
-    bool create = false;
-    if (primary) {
-      // DNE on source?
-      if (info.dne()) {
-	// is there a creation pending on this pg?
-	if (creating_pgs.count(pgid)) {
-	  creating_pgs[pgid].prior.erase(from);
-	  if (!can_create_pg(pgid))
-	    return;
-	  history = creating_pgs[pgid].history;
-	  create = true;
-	} else {
-	  dout(10) << "get_or_create_pg " << pgid
-		   << " DNE on source, but creation probe, ignoring" << dendl;
-	  return;
-	}
-      }
-      creating_pgs.erase(pgid);
-    } else {
-      assert(!info.dne());  // pg exists if we are hearing about it
     }
 
     // do we need to resurrect a deleting pg?
@@ -3246,7 +3221,7 @@ void OSD::handle_pg_peering_evt(
 
       PG *pg = _create_lock_pg(
 	get_map(epoch),
-	pgid, create, false, result == RES_SELF,
+	pgid, false, result == RES_SELF,
 	role,
 	up, up_primary,
 	acting, acting_primary,
@@ -3264,7 +3239,7 @@ void OSD::handle_pg_peering_evt(
       return;
     }
     case RES_SELF: {
-      old_pg_state->lock();
+        old_pg_state->lock();
       OSDMapRef old_osd_map = old_pg_state->get_osdmap();
       int old_role = old_pg_state->role;
       vector<int> old_up = old_pg_state->up;
@@ -3277,7 +3252,6 @@ void OSD::handle_pg_peering_evt(
       PG *pg = _create_lock_pg(
 	old_osd_map,
 	resurrected,
-	false,
 	false,
 	true,
 	old_role,
@@ -3314,7 +3288,6 @@ void OSD::handle_pg_peering_evt(
       PG *parent = _create_lock_pg(
 	old_osd_map,
 	resurrected,
-	false,
 	false,
 	true,
 	old_role,
@@ -3356,56 +3329,6 @@ void OSD::handle_pg_peering_evt(
     pg->unlock();
     return;
   }
-}
-
-
-/*
- * calculate prior pg members during an epoch interval [start,end)
- *  - from each epoch, include all osds up then AND now
- *  - if no osds from then are up now, include them all, even tho they're not reachable now
- */
-void OSD::calc_priors_during(
-  spg_t pgid, epoch_t start, epoch_t end, set<pg_shard_t>& pset)
-{
-  dout(15) << "calc_priors_during " << pgid << " [" << start
-	   << "," << end << ")" << dendl;
-  
-  for (epoch_t e = start; e < end; e++) {
-    OSDMapRef oldmap = get_map(e);
-    vector<int> acting;
-    oldmap->pg_to_acting_osds(pgid.pgid, acting);
-    dout(20) << "  " << pgid << " in epoch " << e << " was " << acting << dendl;
-    int up = 0;
-    int actual_osds = 0;
-    for (unsigned i=0; i<acting.size(); i++) {
-      if (acting[i] != CRUSH_ITEM_NONE) {
-	if (osdmap->is_up(acting[i])) {
-	  if (acting[i] != whoami) {
-	    pset.insert(
-	      pg_shard_t(
-		acting[i],
-		osdmap->pg_is_ec(pgid.pgid) ? shard_id_t(i) : shard_id_t::NO_SHARD));
-	  }
-	  up++;
-	}
-	actual_osds++;
-      }
-    }
-    if (!up && actual_osds) {
-      // sucky.  add down osds, even tho we can't reach them right now.
-      for (unsigned i=0; i<acting.size(); i++) {
-	if (acting[i] != whoami && acting[i] != CRUSH_ITEM_NONE) {
-	  pset.insert(
-	    pg_shard_t(
-	      acting[i],
-	      osdmap->pg_is_ec(pgid.pgid) ? shard_id_t(i) : shard_id_t::NO_SHARD));
-	}
-      }
-    }
-  }
-  dout(10) << "calc_priors_during " << pgid
-	   << " [" << start << "," << end 
-	   << ") = " << pset << dendl;
 }
 
 
@@ -6814,28 +6737,6 @@ void OSD::advance_map()
     }
     service.set_epochs(&boot_epoch, &up_epoch, NULL);
   }
-
-  // scan pg creations
-  ceph::unordered_map<spg_t, create_pg_info>::iterator n = creating_pgs.begin();
-  while (n != creating_pgs.end()) {
-    ceph::unordered_map<spg_t, create_pg_info>::iterator p = n++;
-    spg_t pgid = p->first;
-
-    // am i still primary?
-    vector<int> acting;
-    int primary;
-    osdmap->pg_to_acting_osds(pgid.pgid, &acting, &primary);
-    if (primary != whoami) {
-      dout(10) << " no longer primary for " << pgid << ", stopping creation" << dendl;
-      creating_pgs.erase(p);
-    } else {
-      /*
-       * adding new ppl to our pg has no effect, since we're still primary,
-       * and obviously haven't given the new nodes any data.
-       */
-      p->second.acting.swap(acting);  // keep the latest
-    }
-  }
 }
 
 void OSD::consume_map()
@@ -7076,22 +6977,6 @@ bool OSD::require_same_or_newer_map(OpRequestRef& op, epoch_t epoch,
 // ----------------------------------------
 // pg creation
 
-
-bool OSD::can_create_pg(spg_t pgid)
-{
-  assert(creating_pgs.count(pgid));
-
-  // priors empty?
-  if (!creating_pgs[pgid].prior.empty()) {
-    dout(10) << "can_create_pg " << pgid
-	     << " - waiting for priors " << creating_pgs[pgid].prior << dendl;
-    return false;
-  }
-
-  dout(10) << "can_create_pg " << pgid << " - can create now" << dendl;
-  return true;
-}
-
 void OSD::split_pgs(
   PG *parent,
   const set<spg_t> &childpgids, set<boost::intrusive_ptr<PG> > *out_pgs,
@@ -7154,21 +7039,6 @@ void OSD::handle_pg_create(OpRequestRef op)
 
   dout(10) << "handle_pg_create " << *m << dendl;
 
-  // drop the next N pg_creates in a row?
-  if (debug_drop_pg_create_left < 0 &&
-      cct->_conf->osd_debug_drop_pg_create_probability >
-      ((((double)(rand()%100))/100.0))) {
-    debug_drop_pg_create_left = debug_drop_pg_create_duration;
-  }
-  if (debug_drop_pg_create_left >= 0) {
-    --debug_drop_pg_create_left;
-    if (debug_drop_pg_create_left >= 0) {
-      dout(0) << "DEBUG dropping/ignoring pg_create, will drop the next "
-	      << debug_drop_pg_create_left << " too" << dendl;
-      return;
-    }
-  }
-
   /* we have to hack around require_mon_peer's interface limits, so
    * grab an extra reference before going in. If the peer isn't
    * a Monitor, the reference is put for us (and then cleared
@@ -7185,15 +7055,12 @@ void OSD::handle_pg_create(OpRequestRef op)
 
   op->mark_started();
 
-  int num_created = 0;
-
   map<pg_t,utime_t>::iterator ci = m->ctimes.begin();
   for (map<pg_t,pg_create_t>::iterator p = m->mkpg.begin();
        p != m->mkpg.end();
        ++p, ++ci) {
     assert(ci != m->ctimes.end() && ci->first == p->first);
     epoch_t created = p->second.created;
-    pg_t parent = p->second.parent;
     if (p->second.split_bits) // Skip split pgs
       continue;
     pg_t on = p->first;
@@ -7240,73 +7107,35 @@ void OSD::handle_pg_create(OpRequestRef op)
       continue;
     }
 
-    // figure history
     pg_history_t history;
     history.epoch_created = created;
-    history.last_epoch_clean = created;
-    // Newly created PGs don't need to scrub immediately, so mark them
-    // as scrubbed at creation time.
-    if (ci->second == utime_t()) {
-      // Older OSD doesn't send ctime, so just do what we did before
-      // The repair_test.py can fail in a mixed cluster
-      utime_t now = ceph_clock_now(NULL);
-      history.last_scrub_stamp = now;
-      history.last_deep_scrub_stamp = now;
-    } else {
-      history.last_scrub_stamp = ci->second;
-      history.last_deep_scrub_stamp = ci->second;
-    }
+    history.last_scrub_stamp = ci->second;
+    history.last_deep_scrub_stamp = ci->second;
     bool valid_history = project_pg_history(
       pgid, history, created, up, up_primary, acting, acting_primary);
     /* the pg creation message must have come from a mon and therefore
      * cannot be on the other side of a map gap
      */
     assert(valid_history);
-    
-    // register.
-    creating_pgs[pgid].history = history;
-    creating_pgs[pgid].parent = parent;
-    creating_pgs[pgid].acting.swap(acting);
-    calc_priors_during(pgid, created, history.same_interval_since, 
-		       creating_pgs[pgid].prior);
 
     PG::RecoveryCtx rctx = create_context();
-    // poll priors
-    set<pg_shard_t>& pset = creating_pgs[pgid].prior;
-    dout(10) << "mkpg " << pgid << " e" << created
-	     << " h " << history
-	     << " : querying priors " << pset << dendl;
-    for (set<pg_shard_t>::iterator p = pset.begin(); p != pset.end(); ++p)
-      if (osdmap->is_up(p->osd))
-	(*rctx.query_map)[p->osd][spg_t(pgid.pgid, p->shard)] =
-	  pg_query_t(
-	    pg_query_t::INFO,
-	    p->shard, pgid.shard,
-	    history,
-	    osdmap->get_epoch());
+    const pg_pool_t* pp = osdmap->get_pg_pool(pgid.pool());
+    PG::_create(*rctx.transaction, pgid, pgid.get_split_bits(pp->get_pg_num()));
+    PG::_init(*rctx.transaction, pgid, pp);
 
-    PG *pg = NULL;
-    if (can_create_pg(pgid)) {
-      const pg_pool_t* pp = osdmap->get_pg_pool(pgid.pool());
-      PG::_create(*rctx.transaction, pgid, pgid.get_split_bits(pp->get_pg_num()));
-      PG::_init(*rctx.transaction, pgid, pp);
-
-      pg_interval_map_t pi;
-      pg = _create_lock_pg(
-	osdmap, pgid, true, false, false,
-	0, creating_pgs[pgid].acting, whoami,
-	creating_pgs[pgid].acting, whoami,
-	history, pi,
-	*rctx.transaction);
-      pg->info.last_epoch_started = pg->info.history.last_epoch_started;
-      creating_pgs.erase(pgid);
-      pg->handle_create(&rctx);
-      pg->write_if_dirty(*rctx.transaction);
-      pg->publish_stats_to_osd();
-      pg->unlock();
-      num_created++;
-      wake_pg_waiters(pg, pgid);
-    }
+    pg_interval_map_t pi;
+    PG *pg = _create_lock_pg(
+      osdmap, pgid, false, false,
+      0, up, up_primary,
+      acting, acting_primary,
+      history, pi,
+      *rctx.transaction);
+    pg->info.last_epoch_started = created;
+    pg->handle_create(&rctx);
+    pg->write_if_dirty(*rctx.transaction);
+    pg->publish_stats_to_osd();
+    pg->unlock();
+    wake_pg_waiters(pg, pgid);
     dispatch_context(rctx, pg, osdmap);
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4743,10 +4743,12 @@ void OSD::send_failures()
   utime_t now = ceph_clock_now(cct);
   while (!failure_queue.empty()) {
     int osd = failure_queue.begin()->first;
-    int failed_for = (int)(double)(now - failure_queue.begin()->second);
     entity_inst_t i = osdmap->get_inst(osd);
-    monc->send_mon_message(new MOSDFailure(monc->get_fsid(), i, failed_for,
-					   osdmap->get_epoch()));
+    if (!failure_pending.count(osd)) {
+      int failed_for = (int)(double)(now - failure_queue.begin()->second);
+      monc->send_mon_message(new MOSDFailure(monc->get_fsid(), i, failed_for,
+					     osdmap->get_epoch()));
+    }
     failure_pending[osd] = make_pair(failure_queue.begin()->second, i);
     failure_queue.erase(osd);
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3941,7 +3941,7 @@ void OSD::heartbeat()
     if (now - last_mon_heartbeat > cct->_conf->osd_mon_heartbeat_interval && is_active()) {
       last_mon_heartbeat = now;
       dout(10) << "i have no heartbeat peers; checking mon for new map" << dendl;
-      osdmap_subscribe(osdmap->get_epoch() + 1, true);
+      osdmap_subscribe(osdmap->get_epoch() + 1, false);
     }
   }
 
@@ -4538,7 +4538,7 @@ void OSD::_preboot(epoch_t oldest, epoch_t newest)
   
   // get all the latest maps
   if (osdmap->get_epoch() + 1 >= oldest)
-    osdmap_subscribe(osdmap->get_epoch() + 1, true);
+    osdmap_subscribe(osdmap->get_epoch() + 1, false);
   else
     osdmap_subscribe(oldest - 1, true);
 }
@@ -6211,7 +6211,7 @@ void OSD::wait_for_new_map(OpRequestRef op)
 {
   // ask?
   if (waiting_for_osdmap.empty()) {
-    osdmap_subscribe(osdmap->get_epoch() + 1, true);
+    osdmap_subscribe(osdmap->get_epoch() + 1, false);
   }
   
   logger->inc(l_osd_waiting_for_map);
@@ -6330,7 +6330,7 @@ void OSD::handle_osd_map(MOSDMap *m)
     dout(10) << "handle_osd_map message skips epochs " << osdmap->get_epoch() + 1
 	     << ".." << (first-1) << dendl;
     if (m->oldest_map <= osdmap->get_epoch() + 1) {
-      osdmap_subscribe(osdmap->get_epoch()+1, true);
+      osdmap_subscribe(osdmap->get_epoch()+1, false);
       m->put();
       return;
     }
@@ -6616,7 +6616,7 @@ void OSD::handle_osd_map(MOSDMap *m)
 
   if (m->newest_map && m->newest_map > last) {
     dout(10) << " msg say newest map is " << m->newest_map << ", requesting more" << dendl;
-    osdmap_subscribe(osdmap->get_epoch()+1, true);
+    osdmap_subscribe(osdmap->get_epoch()+1, false);
   }
   else if (is_preboot()) {
     if (m->get_source().is_mon())
@@ -6917,7 +6917,7 @@ void OSD::activate_map()
 
   if (osdmap->test_flag(CEPH_OSDMAP_FULL)) {
     dout(10) << " osdmap flagged full, doing onetime osdmap subscribe" << dendl;
-    osdmap_subscribe(osdmap->get_epoch() + 1, true);
+    osdmap_subscribe(osdmap->get_epoch() + 1, false);
   }
 
   // norecover?

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4003,8 +4003,15 @@ void OSD::tick()
     if (now - last_pg_stats_sent > cct->_conf->osd_mon_report_interval_max) {
       osd_stat_updated = true;
       do_mon_report();
-    } else if (now - last_mon_report > cct->_conf->osd_mon_report_interval_min) {
-      do_mon_report();
+    } else {
+      double backoff = stats_ack_timeout / g_conf->osd_mon_ack_timeout;
+      double adjusted_min = cct->_conf->osd_mon_report_interval_min * backoff;
+      if (now - last_mon_report > adjusted_min) {
+	dout(20) << __func__ << " stats backoff " << backoff
+		 << " adjusted_min " << adjusted_min << " - sending report"
+		 << dendl;
+	do_mon_report();
+      }
     }
 
     map_lock.put_read();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4501,8 +4501,8 @@ void OSD::start_boot()
 
 void OSD::_got_mon_epochs(epoch_t oldest, epoch_t newest)
 {
+  Mutex::Locker l(osd_lock);
   if (is_preboot()) {
-    Mutex::Locker l(osd_lock);
     _preboot(oldest, newest);
   }
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6625,7 +6625,10 @@ void OSD::handle_osd_map(MOSDMap *m)
     osdmap_subscribe(osdmap->get_epoch()+1, true);
   }
   else if (is_booting()) {
-    start_boot();  // retry
+    if (m->get_source().is_mon())
+      _maybe_boot(m->oldest_map, m->newest_map);
+    else
+      start_boot();
   }
   else if (do_restart)
     start_boot();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1567,7 +1567,6 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
   debug_drop_pg_create_duration(cct->_conf->osd_debug_drop_pg_create_duration),
   debug_drop_pg_create_left(-1),
   stats_ack_timeout(cct->_conf->osd_mon_ack_timeout),
-  outstanding_pg_stats(0),
   up_thru_wanted(0), up_thru_pending(0),
   requested_full_first(0),
   requested_full_last(0),
@@ -3990,7 +3989,7 @@ void OSD::tick()
     bool report = false;
     utime_t now = ceph_clock_now(cct);
     pg_stat_queue_lock.Lock();
-    if (outstanding_pg_stats &&
+    if (!outstanding_pg_stats.empty() &&
 	(now - stats_ack_timeout) > last_pg_stats_ack) {
       dout(1) << __func__ << " mon hasn't acked PGStats in "
 	      << now - last_pg_stats_ack
@@ -4001,11 +4000,13 @@ void OSD::tick()
       stats_ack_timeout =
 	MAX(g_conf->osd_mon_ack_timeout,
 	    stats_ack_timeout * g_conf->osd_stats_ack_timeout_factor);
+      outstanding_pg_stats.clear();
     }
     if (now - last_pg_stats_sent > cct->_conf->osd_mon_report_interval_max) {
       osd_stat_updated = true;
       report = true;
-    } else if (outstanding_pg_stats >= cct->_conf->osd_mon_report_max_in_flight) {
+    } else if ((int)outstanding_pg_stats.size() >=
+	       cct->_conf->osd_mon_report_max_in_flight) {
       dout(20) << __func__ << " have max " << outstanding_pg_stats
 	       << " stats updates in flight" << dendl;
     } else {
@@ -4020,9 +4021,9 @@ void OSD::tick()
     }
     pg_stat_queue_lock.Unlock();
 
-    if (reset)
+    if (reset) {
       monc->reopen_session();
-    else if (report) {
+    } else if (report) {
       last_mon_report = now;
 
       // do any pending reports
@@ -4371,11 +4372,6 @@ void OSD::ms_handle_connect(Connection *con)
     if (is_stopping())
       return;
     dout(10) << "ms_handle_connect on mon" << dendl;
-
-    // reset pg stats state
-    pg_stat_queue_lock.Lock();
-    outstanding_pg_stats = 0;
-    pg_stat_queue_lock.Unlock();
 
     if (is_booting()) {
       start_boot();
@@ -4776,8 +4772,10 @@ void OSD::send_pg_stats(const utime_t &now)
     had_for -= had_map_since;
 
     MPGStats *m = new MPGStats(monc->get_fsid(), osdmap->get_epoch(), had_for);
-    m->set_tid(++pg_stat_tid);
+    uint64_t tid = ++pg_stat_tid;
+    m->set_tid(tid);
     m->osd_stat = cur_stat;
+    outstanding_pg_stats.insert(tid);
 
     xlist<PG*>::iterator p = pg_stat_queue.begin();
     while (!p.end()) {
@@ -4800,12 +4798,10 @@ void OSD::send_pg_stats(const utime_t &now)
       pg->pg_stats_publish_lock.Unlock();
     }
 
-    if (!outstanding_pg_stats) {
+    if (!outstanding_pg_stats.empty()) {
       last_pg_stats_ack = ceph_clock_now(cct);
     }
-    ++outstanding_pg_stats;
-    dout(20) << __func__ << "  " << outstanding_pg_stats << " updates pending"
-	     << dendl;
+    dout(20) << __func__ << "  updates pending: " << outstanding_pg_stats << dendl;
 
     monc->send_mon_message(m);
   }
@@ -4821,6 +4817,10 @@ void OSD::handle_pg_stats_ack(MPGStatsAck *ack)
     ack->put();
     return;
   }
+
+  // NOTE: we may get replies from a previous mon even while
+  // outstanding_pg_stats is empty if reconnecting races with replies
+  // in flight.
 
   pg_stat_queue_lock.Lock();
 
@@ -4863,13 +4863,8 @@ void OSD::handle_pg_stats_ack(MPGStatsAck *ack)
     }
   }
 
-  assert(outstanding_pg_stats > 0);
-  --outstanding_pg_stats;
-  if (!pg_stat_queue.size()) {
-    assert(outstanding_pg_stats == 0);
-  }
-  dout(20) << __func__ << "  " << outstanding_pg_stats << " updates pending"
-	   << dendl;
+  outstanding_pg_stats.erase(ack->get_tid());
+  dout(20) << __func__ << "  still pending: " << outstanding_pg_stats << dendl;
 
   pg_stat_queue_lock.Unlock();
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4722,21 +4722,17 @@ void OSD::got_full_map(epoch_t e)
 void OSD::send_failures()
 {
   assert(osd_lock.is_locked());
-  bool locked = false;
-  if (!failure_queue.empty()) {
-    heartbeat_lock.Lock();
-    locked = true;
-  }
+  Mutex::Locker l(heartbeat_lock);
   utime_t now = ceph_clock_now(cct);
   while (!failure_queue.empty()) {
     int osd = failure_queue.begin()->first;
     int failed_for = (int)(double)(now - failure_queue.begin()->second);
     entity_inst_t i = osdmap->get_inst(osd);
-    monc->send_mon_message(new MOSDFailure(monc->get_fsid(), i, failed_for, osdmap->get_epoch()));
+    monc->send_mon_message(new MOSDFailure(monc->get_fsid(), i, failed_for,
+					   osdmap->get_epoch()));
     failure_pending[osd] = i;
     failure_queue.erase(osd);
   }
-  if (locked) heartbeat_lock.Unlock();
 }
 
 void OSD::send_still_alive(epoch_t epoch, const entity_inst_t &i)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1600,6 +1600,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
   debug_drop_pg_create_probability(cct->_conf->osd_debug_drop_pg_create_probability),
   debug_drop_pg_create_duration(cct->_conf->osd_debug_drop_pg_create_duration),
   debug_drop_pg_create_left(-1),
+  mon_report_lock("OSD::mon_report_lock"),
   stats_ack_timeout(cct->_conf->osd_mon_ack_timeout),
   up_thru_wanted(0), up_thru_pending(0),
   requested_full_first(0),
@@ -4056,6 +4057,7 @@ void OSD::tick_without_osd_lock()
   // might change when doing the monitor report
   if (is_active() || is_waiting_for_healthy()) {
     map_lock.get_read();
+    Mutex::Locker l(mon_report_lock);
 
     // mon report?
     bool reset = false;
@@ -4412,17 +4414,20 @@ void OSD::ms_handle_connect(Connection *con)
     if (is_preboot() || is_booting()) {
       start_boot();
     } else {
+      map_lock.get_read();
+      Mutex::Locker l2(mon_report_lock);
+
       utime_t now = ceph_clock_now(NULL);
       last_mon_report = now;
 
       // resend everything, it's a new session
-      map_lock.get_read();
       send_alive();
       service.requeue_pg_temp();
       service.send_pg_temp();
       requeue_failures();
       send_failures();
       send_pg_stats(now);
+
       map_lock.put_read();
 
       monc->sub_want("osd_pg_creates", 0, CEPH_SUBSCRIBE_ONETIME);
@@ -4678,6 +4683,7 @@ void OSD::queue_want_up_thru(epoch_t want)
 {
   map_lock.get_read();
   epoch_t cur = osdmap->get_up_thru(whoami);
+  Mutex::Locker l(mon_report_lock);
   if (want > up_thru_wanted) {
     dout(10) << "queue_want_up_thru now " << want << " (was " << up_thru_wanted << ")" 
 	     << ", currently " << cur
@@ -4694,6 +4700,7 @@ void OSD::queue_want_up_thru(epoch_t want)
 
 void OSD::send_alive()
 {
+  assert(mon_report_lock.is_locked());
   if (!osdmap->exists(whoami))
     return;
   epoch_t up_thru = osdmap->get_up_thru(whoami);
@@ -4782,6 +4789,7 @@ void OSD::requeue_failures()
 void OSD::send_failures()
 {
   assert(map_lock.is_locked());
+  assert(mon_report_lock.is_locked());
   Mutex::Locker l(heartbeat_lock);
   utime_t now = ceph_clock_now(cct);
   while (!failure_queue.empty()) {
@@ -4930,7 +4938,9 @@ void OSD::flush_pg_stats()
   osd_lock.Unlock();
   utime_t now = ceph_clock_now(cct);
   map_lock.get_read();
+  mon_report_lock.Lock();
   send_pg_stats(now);
+  mon_report_lock.Unlock();
   map_lock.put_read();
 
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -803,11 +803,11 @@ public:
   // -- pg_temp --
   Mutex pg_temp_lock;
   map<pg_t, vector<int> > pg_temp_wanted;
+  map<pg_t, vector<int> > pg_temp_pending;
   void queue_want_pg_temp(pg_t pgid, vector<int>& want);
-  void remove_want_pg_temp(pg_t pgid) {
-    Mutex::Locker l(pg_temp_lock);
-    pg_temp_wanted.erase(pgid);
-  }
+  void remove_want_pg_temp(pg_t pgid);
+  void _sent_pg_temp();
+  void requeue_pg_temp();
   void send_pg_temp();
 
   void queue_for_peering(PG *pg);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1971,7 +1971,7 @@ protected:
    */
   utime_t last_pg_stats_ack;
   float stats_ack_timeout;
-  bool outstanding_pg_stats; // some stat updates haven't been acked yet
+  int outstanding_pg_stats; // how many stat updates haven't been acked yet
 
   void do_mon_report();
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1971,7 +1971,7 @@ protected:
    */
   utime_t last_pg_stats_ack;
   float stats_ack_timeout;
-  int outstanding_pg_stats; // how many stat updates haven't been acked yet
+  set<uint64_t> outstanding_pg_stats; // how many stat updates haven't been acked yet
 
   // -- boot --
   void start_boot();

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1973,8 +1973,6 @@ protected:
   float stats_ack_timeout;
   int outstanding_pg_stats; // how many stat updates haven't been acked yet
 
-  void do_mon_report();
-
   // -- boot --
   void start_boot();
   void _maybe_boot(epoch_t oldest, epoch_t newest);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1972,22 +1972,6 @@ protected:
   utime_t last_pg_stats_ack;
   float stats_ack_timeout;
   bool outstanding_pg_stats; // some stat updates haven't been acked yet
-  bool timeout_mon_on_pg_stats;
-  void restart_stats_timer() {
-    Mutex::Locker l(osd_lock);
-    last_pg_stats_ack = ceph_clock_now(cct);
-    timeout_mon_on_pg_stats = true;
-  }
-
-  class C_MonStatsAckTimer : public Context {
-    OSD *osd;
-  public:
-    C_MonStatsAckTimer(OSD *o) : osd(o) {}
-    void finish(int r) {
-      osd->restart_stats_timer();
-    }
-  };
-  friend class C_MonStatsAckTimer;
 
   void do_mon_report();
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1975,6 +1975,7 @@ protected:
 
   // -- boot --
   void start_boot();
+  void maybe_boot(epoch_t oldest, epoch_t newest);
   void _maybe_boot(epoch_t oldest, epoch_t newest);
   void _send_boot();
   void _collect_metadata(map<string,string> *pmeta);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1970,6 +1970,7 @@ protected:
    *  elsewhere.
    */
   utime_t last_pg_stats_ack;
+  float stats_ack_timeout;
   bool outstanding_pg_stats; // some stat updates haven't been acked yet
   bool timeout_mon_on_pg_stats;
   void restart_stats_timer() {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1967,6 +1967,7 @@ protected:
     PG::RecoveryCtx *rctx);
 
   // == monitor interaction ==
+  Mutex mon_report_lock;
   utime_t last_mon_report;
   utime_t last_pg_stats_sent;
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1952,6 +1952,7 @@ protected:
     pg_t parent;
   };
   ceph::unordered_map<spg_t, create_pg_info> creating_pgs;
+  epoch_t last_pg_create_epoch;
   double debug_drop_pg_create_probability;
   int debug_drop_pg_create_duration;
   int debug_drop_pg_create_left;  // 0 if we just dropped the last one, -1 if we can drop more

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2001,9 +2001,9 @@ protected:
 
   // -- failures --
   map<int,utime_t> failure_queue;
-  map<int,entity_inst_t> failure_pending;
+  map<int,pair<utime_t,entity_inst_t> > failure_pending;
 
-
+  void requeue_failures();
   void send_failures();
   void send_still_alive(epoch_t epoch, const entity_inst_t &i);
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1186,15 +1186,19 @@ private:
 
   // -- state --
 public:
-  static const int STATE_INITIALIZING = 1;
-  static const int STATE_BOOTING = 2;
-  static const int STATE_ACTIVE = 3;
-  static const int STATE_STOPPING = 4;
-  static const int STATE_WAITING_FOR_HEALTHY = 5;
+  typedef enum {
+    STATE_INITIALIZING = 1,
+    STATE_PREBOOT,
+    STATE_BOOTING,
+    STATE_ACTIVE,
+    STATE_STOPPING,
+    STATE_WAITING_FOR_HEALTHY
+  } osd_state_t;
 
   static const char *get_state_name(int s) {
     switch (s) {
     case STATE_INITIALIZING: return "initializing";
+    case STATE_PREBOOT: return "preboot";
     case STATE_BOOTING: return "booting";
     case STATE_ACTIVE: return "active";
     case STATE_STOPPING: return "stopping";
@@ -1215,6 +1219,9 @@ public:
   }
   bool is_initializing() {
     return get_state() == STATE_INITIALIZING;
+  }
+  bool is_preboot() {
+    return get_state() == STATE_PREBOOT;
   }
   bool is_booting() {
     return get_state() == STATE_BOOTING;
@@ -1975,8 +1982,8 @@ protected:
 
   // -- boot --
   void start_boot();
-  void maybe_boot(epoch_t oldest, epoch_t newest);
-  void _maybe_boot(epoch_t oldest, epoch_t newest);
+  void _got_mon_epochs(epoch_t oldest, epoch_t newest);
+  void _preboot(epoch_t oldest, epoch_t newest);
   void _send_boot();
   void _collect_metadata(map<string,string> *pmeta);
   bool _lsb_release_set(char *buf, const char *str, map<string,string> *pm, const char *key);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1887,7 +1887,6 @@ protected:
   PG   *_create_lock_pg(
     OSDMapRef createmap,
     spg_t pgid,
-    bool newly_created,
     bool hold_map_lock,
     bool backfill,
     int role,
@@ -1913,9 +1912,6 @@ protected:
   
   void load_pgs();
   void build_past_intervals_parallel();
-
-  void calc_priors_during(
-    spg_t pgid, epoch_t start, epoch_t end, set<pg_shard_t>& pset);
 
   /// project pg history from from to now
   bool project_pg_history(
@@ -1944,20 +1940,9 @@ protected:
     }
   }
 
-  // -- pg creation --
-  struct create_pg_info {
-    pg_history_t history;
-    vector<int> acting;
-    set<pg_shard_t> prior;
-    pg_t parent;
-  };
-  ceph::unordered_map<spg_t, create_pg_info> creating_pgs;
-  epoch_t last_pg_create_epoch;
-  double debug_drop_pg_create_probability;
-  int debug_drop_pg_create_duration;
-  int debug_drop_pg_create_left;  // 0 if we just dropped the last one, -1 if we can drop more
 
-  bool can_create_pg(spg_t pgid);
+  epoch_t last_pg_create_epoch;
+
   void handle_pg_create(OpRequestRef op);
 
   void split_pgs(

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -937,9 +937,19 @@ void OSDMap::set_max_osd(int m)
 int OSDMap::calc_num_osds()
 {
   num_osd = 0;
-  for (int i=0; i<max_osd; i++)
-    if (osd_state[i] & CEPH_OSD_EXISTS)
-      num_osd++;
+  num_up_osd = 0;
+  num_in_osd = 0;
+  for (int i=0; i<max_osd; i++) {
+    if (osd_state[i] & CEPH_OSD_EXISTS) {
+      ++num_osd;
+      if (osd_state[i] & CEPH_OSD_UP) {
+	++num_up_osd;
+      }
+      if (get_weight(i) != CEPH_OSD_OUT) {
+	++num_in_osd;
+      }
+    }
+  }
   return num_osd;
 }
 
@@ -956,24 +966,6 @@ void OSDMap::get_up_osds(set<int32_t>& ls) const
     if (is_up(i))
       ls.insert(i);
   }
-}
-
-unsigned OSDMap::get_num_up_osds() const
-{
-  unsigned n = 0;
-  for (int i=0; i<max_osd; i++)
-    if ((osd_state[i] & CEPH_OSD_EXISTS) &&
-	(osd_state[i] & CEPH_OSD_UP)) n++;
-  return n;
-}
-
-unsigned OSDMap::get_num_in_osds() const
-{
-  unsigned n = 0;
-  for (int i=0; i<max_osd; i++)
-    if ((osd_state[i] & CEPH_OSD_EXISTS) &&
-	get_weight(i) != CEPH_OSD_OUT) n++;
-  return n;
 }
 
 void OSDMap::calc_state_set(int state, set<string>& st)

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -212,7 +212,10 @@ private:
 
   uint32_t flags;
 
-  int num_osd;         // not saved
+  int num_osd;         // not saved; see calc_num_osds
+  int num_up_osd;      // not saved; see calc_num_osds
+  int num_in_osd;      // not saved; see calc_num_osds
+
   int32_t max_osd;
   vector<uint8_t> osd_state;
 
@@ -265,7 +268,8 @@ private:
   OSDMap() : epoch(0), 
 	     pool_max(-1),
 	     flags(0),
-	     num_osd(0), max_osd(0),
+	     num_osd(0), num_up_osd(0), num_in_osd(0),
+	     max_osd(0),
 	     osd_addrs(new addrs_s),
 	     pg_temp(new map<pg_t,vector<int32_t> >),
 	     primary_temp(new map<pg_t,int32_t>),
@@ -329,12 +333,17 @@ public:
   unsigned get_num_osds() const {
     return num_osd;
   }
+  unsigned get_num_up_osds() const {
+    return num_up_osd;
+  }
+  unsigned get_num_in_osds() const {
+    return num_in_osd;
+  }
+  /// recalculate cached values for get_num{,_up,_in}_osds
   int calc_num_osds();
 
   void get_all_osds(set<int32_t>& ls) const;
   void get_up_osds(set<int32_t>& ls) const;
-  unsigned get_num_up_osds() const;
-  unsigned get_num_in_osds() const;
   unsigned get_num_pg_temp() const {
     return pg_temp->size();
   }

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -103,9 +103,6 @@ class TestPG(TestArgparse):
     def test_getmap(self):
         self.assert_valid_command(['pg', 'getmap'])
 
-    def test_send_pg_creates(self):
-        self.assert_valid_command(['pg', 'send_pg_creates'])
-
     def test_dump(self):
         self.assert_valid_command(['pg', 'dump'])
         self.assert_valid_command(['pg', 'dump',


### PR DESCRIPTION
* mon: waste less cpu iterating over stale pgs
* osdmap: cache up/in values
* osd: exponential backoff of mon reports
* make subscribe fully stateful, no renewals
* mon: let peons send osdmap replies
* mon: redo pg creations
* osd: no dup alive, failure, or pg_temp messages
* osd: explicit preboot stage
* mon: use keepalive (not subscribe) for liveness

This made a mon cluster for 2000 osds pretty hard to break (call elections) in spite
of creating and rebalancing huge pools.