### PR TITLE
pybind: Add Python 3 support for rados and rbd modules

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -19,6 +19,7 @@ License version 2, as published by the Free Software
 Foundation.  See file COPYING.
 """
 
+import codecs
 import os
 import sys
 import platform
@@ -108,6 +109,12 @@ from ceph_daemon import DaemonWatcher, admin_socket
 
 verbose = False
 cluster_handle = None
+
+# Always use Unicode (UTF-8) for stdout
+raw_stdout = sys.__stdout__
+raw_stderr = sys.__stderr__
+sys.stdout = codecs.getwriter('utf-8')(raw_stdout)
+sys.stderr = codecs.getwriter('utf-8')(raw_stderr)
 
 ############################################################################
 
@@ -887,6 +894,8 @@ def main():
             if outs:
                 print >> sys.stderr, prefix + outs
 
+        sys.stdout.flush()
+
         if (parsed_args.output_file):
             outf.write(outbuf)
         else:
@@ -897,13 +906,16 @@ def main():
             if parsed_args.output_format and \
                parsed_args.output_format.startswith('json') and \
                not compat:
-                sys.stdout.write('\n')
+                raw_stdout.write('\n')
 
             # if we are prettifying things, normalize newlines.  sigh.
             if suffix != '':
                 outbuf = outbuf.rstrip()
             if outbuf != '':
-                sys.stdout.write(prefix + outbuf + suffix)
+                # Write directly to binary stdout
+                raw_stdout.write(prefix)
+                raw_stdout.write(outbuf)
+                raw_stdout.write(suffix)
 
         sys.stdout.flush()
 

--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -29,7 +29,11 @@ LIBRADOS_OP_FLAG_FADVISE_DONTNEED = 0x20
 LIBRADOS_OP_FLAG_FADVISE_NOCACHE = 0x40
 
 
-if sys.hexversion < 0x03000000:
+# Are we running Python 2.x
+_python2 = sys.hexversion < 0x03000000
+
+
+if _python2:
     str_type = basestring
 else:
     str_type = str
@@ -279,7 +283,11 @@ def cstr(val, encoding="utf-8"):
     if val is None:
         return c_char_p(None)
 
-    return c_char_p(val.encode(encoding))
+    if _python2 and isinstance(val, str):
+        # Don't encode str on Python 2, as it's already an 8-bit string
+        return c_char_p(val)
+    else:
+        return c_char_p(val.encode(encoding))
 
 
 class Rados(object):

--- a/src/pybind/rbd.py
+++ b/src/pybind/rbd.py
@@ -9,10 +9,6 @@ Error codes from librbd are turned into exceptions that subclass
 (the base class of all rbd exceptions), :class:`PermissionError`
 and :class:`IOError`, in addition to those documented for the
 method.
-
-A number of methods have string arguments, which must not be unicode
-to interact correctly with librbd. If unicode is passed to these
-methods, a :class:`TypeError` will be raised.
 """
 # Copyright 2011 Josh Durgin
 from collections import Iterable
@@ -68,7 +64,11 @@ RBD_FEATURES_SINGLE_CLIENT = (RBD_FEATURE_EXCLUSIVE_LOCK |
 RBD_FLAG_OBJECT_MAP_INVALID = 1
 
 
-if sys.hexversion < 0x03000000:
+# Are we running Python 2.x
+_python2 = sys.hexversion < 0x03000000
+
+
+if _python2:
     str_type = basestring
 else:
     str_type = str
@@ -212,7 +212,11 @@ def cstr(val, encoding="utf-8"):
     if val is None:
         return c_char_p(None)
 
-    return c_char_p(val.encode(encoding))
+    if _python2 and isinstance(val, str):
+        # Don't encode str on Python 2, as it's already an 8-bit string
+        return c_char_p(val)
+    else:
+        return c_char_p(val.encode(encoding))
 
 
 class RBD(object):

--- a/src/pybind/rbd.py
+++ b/src/pybind/rbd.py
@@ -20,6 +20,8 @@ import ctypes
 import errno
 import sys
 
+from rados import cstr
+
 ANONYMOUS_AUID = 0xffffffffffffffff
 ADMIN_AUID = 0
 
@@ -200,23 +202,6 @@ def load_librbd():
         return CDLL('librbd.so.1')
     except OSError as e:
         raise EnvironmentError("Unable to load librbd: %s" % e)
-
-
-def cstr(val, encoding="utf-8"):
-    """
-    Create a C-style string from a Python string
-
-    :param str val: Python string
-    :rtype: c_char_p
-    """
-    if val is None:
-        return c_char_p(None)
-
-    if _python2 and isinstance(val, str):
-        # Don't encode str on Python 2, as it's already an 8-bit string
-        return c_char_p(val)
-    else:
-        return c_char_p(val.encode(encoding))
 
 
 class RBD(object):

--- a/src/pybind/rbd.py
+++ b/src/pybind/rbd.py
@@ -20,7 +20,7 @@ import ctypes
 import errno
 import sys
 
-from rados import cstr
+from rados import cstr, decode_cstr
 
 ANONYMOUS_AUID = 0xffffffffffffffff
 ADMIN_AUID = 0
@@ -343,7 +343,7 @@ class RBD(object):
             elif ret != -errno.ERANGE:
                 raise make_ex(ret, 'error listing images')
 
-        return [name for name in c_names.raw.decode("utf-8").split('\0') if len(name) > 0]
+        return [decode_cstr(name) for name in c_names.raw.split(b'\0') if len(name) > 0]
 
     def remove(self, ioctx, name):
         """
@@ -1025,7 +1025,7 @@ written." % (self.name, ret, length))
         cookies = [cookie.decode("utf-8") for cookie in c_cookies.raw[:cookies_size.value - 1].split(b'\0')]
         addrs = [addr.decode("utf-8") for addr in c_addrs.raw[:addrs_size.value - 1].split(b'\0')]
         return {
-            'tag'       : c_tag.value.decode("utf-8"),
+            'tag'       : decode_cstr(c_tag),
             'exclusive' : exclusive.value == 1,
             'lockers'   : list(zip(clients, cookies, addrs)),
             }
@@ -1125,7 +1125,7 @@ class SnapIterator(Iterable):
             yield {
                 'id'   : self.snaps[i].id,
                 'size' : self.snaps[i].size,
-                'name' : self.snaps[i].name.decode("utf-8"),
+                'name' : decode_cstr(self.snaps[i].name),
                 }
 
     def __del__(self):

--- a/src/pybind/rbd.py
+++ b/src/pybind/rbd.py
@@ -22,6 +22,7 @@ from ctypes import CDLL, c_char, c_char_p, c_size_t, c_void_p, c_int, \
 from ctypes.util import find_library
 import ctypes
 import errno
+import sys
 
 ANONYMOUS_AUID = 0xffffffffffffffff
 ADMIN_AUID = 0
@@ -65,6 +66,12 @@ RBD_FEATURES_SINGLE_CLIENT = (RBD_FEATURE_EXCLUSIVE_LOCK |
                               RBD_FEATURE_FAST_DIFF)
 
 RBD_FLAG_OBJECT_MAP_INVALID = 1
+
+
+if sys.hexversion < 0x03000000:
+    str_type = basestring
+else:
+    str_type = str
 
 
 class Error(Exception):
@@ -258,7 +265,7 @@ class RBD(object):
         """
         if order is None:
             order = 0
-        if not isinstance(name, str):
+        if not isinstance(name, str_type):
             raise TypeError('name must be a string')
         if old_format:
             if features != 0 or stripe_unit != 0 or stripe_count != 0:
@@ -317,9 +324,9 @@ class RBD(object):
         """
         if order is None:
             order = 0
-        if not isinstance(p_snapname, str) or not isinstance(p_name, str):
+        if not isinstance(p_snapname, str_type) or not isinstance(p_name, str_type):
             raise TypeError('parent name and snapname must be strings')
-        if not isinstance(c_name, str):
+        if not isinstance(c_name, str_type):
             raise TypeError('child name must be a string')
 
         ret = self.librbd.rbd_clone(p_ioctx.io, cstr(p_name),
@@ -366,7 +373,7 @@ class RBD(object):
         :raises: :class:`ImageNotFound`, :class:`ImageBusy`,
                  :class:`ImageHasSnapshots`
         """
-        if not isinstance(name, str):
+        if not isinstance(name, str_type):
             raise TypeError('name must be a string')
         ret = self.librbd.rbd_remove(ioctx.io, cstr(name))
         if ret != 0:
@@ -384,7 +391,7 @@ class RBD(object):
         :type dest: str
         :raises: :class:`ImageNotFound`, :class:`ImageExists`
         """
-        if not isinstance(src, str) or not isinstance(dest, str):
+        if not isinstance(src, str_type) or not isinstance(dest, str_type):
             raise TypeError('src and dest must be strings')
         ret = self.librbd.rbd_rename(ioctx.io, cstr(src), cstr(dest))
         if ret != 0:
@@ -427,9 +434,9 @@ class Image(object):
         self.librbd = load_librbd()
         self.image = c_void_p()
         self.name = name
-        if not isinstance(name, str):
+        if not isinstance(name, str_type):
             raise TypeError('name must be a string')
-        if snapshot is not None and not isinstance(snapshot, str):
+        if snapshot is not None and not isinstance(snapshot, str_type):
             raise TypeError('snapshot must be a string or None')
         if read_only:
             if not hasattr(self.librbd, 'rbd_open_read_only'):
@@ -657,7 +664,7 @@ class Image(object):
         :type dest_name: str
         :raises: :class:`ImageExists`
         """
-        if not isinstance(dest_name, str):
+        if not isinstance(dest_name, str_type):
             raise TypeError('dest_name must be a string')
         ret = self.librbd.rbd_copy(self.image, dest_ioctx.io, cstr(dest_name))
         if ret < 0:
@@ -679,7 +686,7 @@ class Image(object):
         :type name: str
         :raises: :class:`ImageExists`
         """
-        if not isinstance(name, str):
+        if not isinstance(name, str_type):
             raise TypeError('name must be a string')
         ret = self.librbd.rbd_snap_create(self.image, cstr(name))
         if ret != 0:
@@ -693,7 +700,7 @@ class Image(object):
         :type name: str
         :raises: :class:`IOError`, :class:`ImageBusy`
         """
-        if not isinstance(name, str):
+        if not isinstance(name, str_type):
             raise TypeError('name must be a string')
         ret = self.librbd.rbd_snap_remove(self.image, cstr(name))
         if ret != 0:
@@ -709,7 +716,7 @@ class Image(object):
         :type name: str
         :raises: :class:`IOError`
         """
-        if not isinstance(name, str):
+        if not isinstance(name, str_type):
             raise TypeError('name must be a string')
         ret = self.librbd.rbd_snap_rollback(self.image, cstr(name))
         if ret != 0:
@@ -724,7 +731,7 @@ class Image(object):
         :type name: str
         :raises: :class:`IOError`, :class:`ImageNotFound`
         """
-        if not isinstance(name, str):
+        if not isinstance(name, str_type):
             raise TypeError('name must be a string')
         ret = self.librbd.rbd_snap_protect(self.image, cstr(name))
         if ret != 0:
@@ -739,7 +746,7 @@ class Image(object):
         :type name: str
         :raises: :class:`IOError`, :class:`ImageNotFound`
         """
-        if not isinstance(name, str):
+        if not isinstance(name, str_type):
             raise TypeError('name must be a string')
         ret = self.librbd.rbd_snap_unprotect(self.image, cstr(name))
         if ret != 0:
@@ -754,7 +761,7 @@ class Image(object):
         :returns: bool - whether the snapshot is protected
         :raises: :class:`IOError`, :class:`ImageNotFound`
         """
-        if not isinstance(name, str):
+        if not isinstance(name, str_type):
             raise TypeError('name must be a string')
         is_protected = c_int()
         ret = self.librbd.rbd_snap_is_protected(self.image, cstr(name),
@@ -772,7 +779,7 @@ class Image(object):
         :param name: the snapshot to read from, or None to unset the snapshot
         :type name: str or None
         """
-        if name is not None and not isinstance(name, str):
+        if name is not None and not isinstance(name, str_type):
             raise TypeError('name must be a string')
         ret = self.librbd.rbd_snap_set(self.image, cstr(name))
         if ret != 0:
@@ -846,7 +853,7 @@ class Image(object):
         :raises: :class:`InvalidArgument`, :class:`IOError`,
                  :class:`ImageNotFound`
         """
-        if from_snapshot is not None and not isinstance(from_snapshot, str):
+        if from_snapshot is not None and not isinstance(from_snapshot, str_type):
             raise TypeError('client must be a string')
 
         RBD_DIFF_CB = CFUNCTYPE(c_int, c_uint64, c_size_t, c_int, c_void_p)
@@ -1041,7 +1048,7 @@ written." % (self.name, ret, length))
         :raises: :class:`ImageBusy` if a different client or cookie locked it
                  :class:`ImageExists` if the same client and cookie locked it
         """
-        if not isinstance(cookie, str):
+        if not isinstance(cookie, str_type):
             raise TypeError('cookie must be a string')
         ret = self.librbd.rbd_lock_exclusive(self.image, cstr(cookie))
         if ret < 0:
@@ -1055,9 +1062,9 @@ written." % (self.name, ret, length))
         :raises: :class:`ImageBusy` if a different client or cookie locked it
                  :class:`ImageExists` if the same client and cookie locked it
         """
-        if not isinstance(cookie, str):
+        if not isinstance(cookie, str_type):
             raise TypeError('cookie must be a string')
-        if not isinstance(tag, str):
+        if not isinstance(tag, str_type):
             raise TypeError('tag must be a string')
         ret = self.librbd.rbd_lock_shared(self.image, cstr(cookie),
                                           cstr(tag))
@@ -1068,7 +1075,7 @@ written." % (self.name, ret, length))
         """
         Release a lock on the image that was locked by this rados client.
         """
-        if not isinstance(cookie, str):
+        if not isinstance(cookie, str_type):
             raise TypeError('cookie must be a string')
         ret = self.librbd.rbd_unlock(self.image, cstr(cookie))
         if ret < 0:
@@ -1078,9 +1085,9 @@ written." % (self.name, ret, length))
         """
         Release a lock held by another rados client.
         """
-        if not isinstance(client, str):
+        if not isinstance(client, str_type):
             raise TypeError('client must be a string')
-        if not isinstance(cookie, str):
+        if not isinstance(cookie, str_type):
             raise TypeError('cookie must be a string')
         ret = self.librbd.rbd_break_lock(self.image, cstr(client),
                                          cstr(cookie))

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -7,6 +7,10 @@ import time
 import threading
 import json
 import errno
+import sys
+
+# Are we running Python 2.x
+_python2 = sys.hexversion < 0x03000000
 
 def test_rados_init_error():
     assert_raises(Error, Rados, conffile='', rados_id='admin',
@@ -126,6 +130,16 @@ class TestRados(object):
     def test_create(self):
         self.rados.create_pool('foo')
         self.rados.delete_pool('foo')
+
+    def test_create_utf8(self):
+        if _python2:
+            # Use encoded bytestring
+            poolname = b"\351\273\204"
+        else:
+            poolname = "\u9ec4"
+        self.rados.create_pool(poolname)
+        assert self.rados.pool_exists(u"\u9ec4")
+        self.rados.delete_pool(poolname)
 
     def test_create_auid(self):
         self.rados.create_pool('foo', 100)

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -660,6 +660,6 @@ class TestCommand(object):
                                                timeout=30)
         eq(ret, 0)
         assert len(err) > 0
-        out = json.loads(err.decode("utf-8"))
+        out = json.loads(err)
         eq(out['blocksize'], cmd['size'])
         eq(out['bytes_written'], cmd['count'])

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from nose.tools import eq_ as eq, ok_ as ok, assert_raises
 from rados import (Rados, Error, RadosStateError, Object, ObjectExists,
                    ObjectNotFound, ObjectBusy, requires, opt,
@@ -12,16 +13,6 @@ def test_rados_init_error():
                   name='client.admin')
     assert_raises(Error, Rados, conffile='', name='invalid')
     assert_raises(Error, Rados, conffile='', name='bad.invalid')
-
-def test_rados_init_type_error():
-    assert_raises(TypeError, Rados, rados_id=u'admin')
-    assert_raises(TypeError, Rados, rados_id=u'')
-    assert_raises(TypeError, Rados, name=u'client.admin')
-    assert_raises(TypeError, Rados, name=u'')
-    assert_raises(TypeError, Rados, conffile=u'blah')
-    assert_raises(TypeError, Rados, conffile=u'')
-    assert_raises(TypeError, Rados, clusternaem=u'blah')
-    assert_raises(TypeError, Rados, clustername=u'')
 
 def test_rados_init():
     with Rados(conffile='', rados_id='admin'):
@@ -91,9 +82,9 @@ class TestRadosStateError(object):
         assert_raises(RadosStateError, rados.list_pools)
         assert_raises(RadosStateError, rados.get_fsid)
         assert_raises(RadosStateError, rados.open_ioctx, 'foo')
-        assert_raises(RadosStateError, rados.mon_command, '', '')
-        assert_raises(RadosStateError, rados.osd_command, 0, '', '')
-        assert_raises(RadosStateError, rados.pg_command, '', '', '')
+        assert_raises(RadosStateError, rados.mon_command, '', b'')
+        assert_raises(RadosStateError, rados.osd_command, 0, '', b'')
+        assert_raises(RadosStateError, rados.pg_command, '', '', b'')
         assert_raises(RadosStateError, rados.wait_for_latest_osdmap)
         assert_raises(RadosStateError, rados.blacklist_add, '127.0.0.1/123', 0)
 
@@ -179,12 +170,12 @@ class TestRados(object):
                 tier_pool_id = self.rados.pool_lookup('foo-cache')
 
                 cmd = {"prefix":"osd tier add", "pool":"foo", "tierpool":"foo-cache", "force_nonempty":""}
-                ret, buf, errs = self.rados.mon_command(json.dumps(cmd), '', timeout=30)
+                ret, buf, errs = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
                 eq(ret, 0)
 
                 try:
                     cmd = {"prefix":"osd tier cache-mode", "pool":"foo-cache", "tierpool":"foo-cache", "mode":"readonly"}
-                    ret, buf, errs = self.rados.mon_command(json.dumps(cmd), '', timeout=30)
+                    ret, buf, errs = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
                     eq(ret, 0)
 
                     eq(self.rados.wait_for_latest_osdmap(), 0)
@@ -193,7 +184,7 @@ class TestRados(object):
                     eq(pool_id, self.rados.get_pool_base_tier(tier_pool_id))
                 finally:
                     cmd = {"prefix":"osd tier remove", "pool":"foo", "tierpool":"foo-cache"}
-                    ret, buf, errs = self.rados.mon_command(json.dumps(cmd), '', timeout=30)
+                    ret, buf, errs = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
                     eq(ret, 0)
             finally:
                 self.rados.delete_pool('foo-cache')
@@ -218,7 +209,7 @@ class TestIoctx(object):
 
     def tearDown(self):
         cmd = {"prefix":"osd unset", "key":"noup"}
-        self.rados.mon_command(json.dumps(cmd), '')
+        self.rados.mon_command(json.dumps(cmd), b'')
         self.ioctx.close()
         self.rados.delete_pool('test_pool')
         self.rados.shutdown()
@@ -228,29 +219,29 @@ class TestIoctx(object):
         self.ioctx.change_auid(ADMIN_AUID)
 
     def test_write(self):
-        self.ioctx.write('abc', 'abc')
-        eq(self.ioctx.read('abc'), 'abc')
+        self.ioctx.write('abc', b'abc')
+        eq(self.ioctx.read('abc'), b'abc')
 
     def test_write_full(self):
-        self.ioctx.write('abc', 'abc')
-        eq(self.ioctx.read('abc'), 'abc')
-        self.ioctx.write_full('abc', 'd')
-        eq(self.ioctx.read('abc'), 'd')
+        self.ioctx.write('abc', b'abc')
+        eq(self.ioctx.read('abc'), b'abc')
+        self.ioctx.write_full('abc', b'd')
+        eq(self.ioctx.read('abc'), b'd')
 
     def test_append(self):
-        self.ioctx.write('abc', 'a')
-        self.ioctx.append('abc', 'b')
-        self.ioctx.append('abc', 'c')
-        eq(self.ioctx.read('abc'), 'abc')
+        self.ioctx.write('abc', b'a')
+        self.ioctx.append('abc', b'b')
+        self.ioctx.append('abc', b'c')
+        eq(self.ioctx.read('abc'), b'abc')
 
     def test_write_zeros(self):
-        self.ioctx.write('abc', 'a\0b\0c')
-        eq(self.ioctx.read('abc'), 'a\0b\0c')
+        self.ioctx.write('abc', b'a\0b\0c')
+        eq(self.ioctx.read('abc'), b'a\0b\0c')
 
     def test_trunc(self):
-        self.ioctx.write('abc', 'abc')
+        self.ioctx.write('abc', b'abc')
         self.ioctx.trunc('abc', 2)
-        eq(self.ioctx.read('abc'), 'ab')
+        eq(self.ioctx.read('abc'), b'ab')
         size = self.ioctx.stat('abc')[0]
         eq(size, 2)
 
@@ -258,24 +249,24 @@ class TestIoctx(object):
         eq(list(self.ioctx.list_objects()), [])
 
     def test_list_objects(self):
-        self.ioctx.write('a', '')
-        self.ioctx.write('b', 'foo')
-        self.ioctx.write_full('c', 'bar')
-        self.ioctx.append('d', 'jazz')
+        self.ioctx.write('a', b'')
+        self.ioctx.write('b', b'foo')
+        self.ioctx.write_full('c', b'bar')
+        self.ioctx.append('d', b'jazz')
         object_names = [obj.key for obj in self.ioctx.list_objects()]
         eq(sorted(object_names), ['a', 'b', 'c', 'd'])
 
     def test_list_ns_objects(self):
-        self.ioctx.write('a', '')
-        self.ioctx.write('b', 'foo')
-        self.ioctx.write_full('c', 'bar')
-        self.ioctx.append('d', 'jazz')
+        self.ioctx.write('a', b'')
+        self.ioctx.write('b', b'foo')
+        self.ioctx.write_full('c', b'bar')
+        self.ioctx.append('d', b'jazz')
         self.ioctx.set_namespace("ns1")
-        self.ioctx.write('ns1-a', '')
-        self.ioctx.write('ns1-b', 'foo')
-        self.ioctx.write_full('ns1-c', 'bar')
-        self.ioctx.append('ns1-d', 'jazz')
-        self.ioctx.append('d', 'jazz')
+        self.ioctx.write('ns1-a', b'')
+        self.ioctx.write('ns1-b', b'foo')
+        self.ioctx.write_full('ns1-c', b'bar')
+        self.ioctx.append('ns1-d', b'jazz')
+        self.ioctx.append('d', b'jazz')
         self.ioctx.set_namespace(LIBRADOS_ALL_NSPACES)
         object_names = [(obj.nspace, obj.key) for obj in self.ioctx.list_objects()]
         eq(sorted(object_names), [('', 'a'), ('','b'), ('','c'), ('','d'),\
@@ -283,9 +274,9 @@ class TestIoctx(object):
                 ('ns1', 'ns1-c'), ('ns1', 'ns1-d')])
 
     def test_xattrs(self):
-        xattrs = dict(a='1', b='2', c='3', d='a\0b', e='\0')
-        self.ioctx.write('abc', '')
-        for key, value in xattrs.iteritems():
+        xattrs = dict(a=b'1', b=b'2', c=b'3', d=b'a\0b', e=b'\0')
+        self.ioctx.write('abc', b'')
+        for key, value in xattrs.items():
             self.ioctx.set_xattr('abc', key, value)
             eq(self.ioctx.get_xattr('abc', key), value)
         stored_xattrs = {}
@@ -294,10 +285,10 @@ class TestIoctx(object):
         eq(stored_xattrs, xattrs)
 
     def test_obj_xattrs(self):
-        xattrs = dict(a='1', b='2', c='3', d='a\0b', e='\0')
-        self.ioctx.write('abc', '')
+        xattrs = dict(a=b'1', b=b'2', c=b'3', d=b'a\0b', e=b'\0')
+        self.ioctx.write('abc', b'')
         obj = list(self.ioctx.list_objects())[0]
-        for key, value in xattrs.iteritems():
+        for key, value in xattrs.items():
             obj.set_xattr(key, value)
             eq(obj.get_xattr(key), value)
         stored_xattrs = {}
@@ -339,7 +330,7 @@ class TestIoctx(object):
 
     def test_set_omap(self):
         keys = ("1", "2", "3", "4")
-        values = ("aaa", "bbb", "ccc", "\x04\x04\x04\x04")
+        values = (b"aaa", b"bbb", b"ccc", b"\x04\x04\x04\x04")
         with WriteOpCtx(self.ioctx) as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             self.ioctx.operate_write_op(write_op, "hw")
@@ -347,22 +338,22 @@ class TestIoctx(object):
             iter, ret = self.ioctx.get_omap_vals(read_op, "", "", 4)
             self.ioctx.operate_read_op(read_op, "hw")
             iter.next()
-            eq(list(iter), [("2", "bbb"), ("3", "ccc"), ("4", "\x04\x04\x04\x04")])
+            eq(list(iter), [("2", b"bbb"), ("3", b"ccc"), ("4", b"\x04\x04\x04\x04")])
 
     def test_get_omap_vals_by_keys(self):
         keys = ("1", "2", "3", "4")
-        values = ("aaa", "bbb", "ccc", "\x04\x04\x04\x04")
+        values = (b"aaa", b"bbb", b"ccc", b"\x04\x04\x04\x04")
         with WriteOpCtx(self.ioctx) as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             self.ioctx.operate_write_op(write_op, "hw")
         with ReadOpCtx(self.ioctx) as read_op:
             iter, ret = self.ioctx.get_omap_vals_by_keys(read_op,("3","4",))
             self.ioctx.operate_read_op(read_op, "hw")
-            eq(list(iter), [("3", "ccc"), ("4", "\x04\x04\x04\x04")])
+            eq(list(iter), [("3", b"ccc"), ("4", b"\x04\x04\x04\x04")])
 
     def test_get_omap_keys(self):
         keys = ("1", "2", "3")
-        values = ("aaa", "bbb", "ccc")
+        values = (b"aaa", b"bbb", b"ccc")
         with WriteOpCtx(self.ioctx) as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             self.ioctx.operate_write_op(write_op, "hw")
@@ -373,7 +364,7 @@ class TestIoctx(object):
 
     def test_clear_omap(self):
         keys = ("1", "2", "3")
-        values = ("aaa", "bbb", "ccc")
+        values = (b"aaa", b"bbb", b"ccc")
         with WriteOpCtx(self.ioctx) as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             self.ioctx.operate_write_op(write_op, "hw")
@@ -387,17 +378,17 @@ class TestIoctx(object):
 
     def test_locator(self):
         self.ioctx.set_locator_key("bar")
-        self.ioctx.write('foo', 'contents1')
+        self.ioctx.write('foo', b'contents1')
         objects = [i for i in self.ioctx.list_objects()]
         eq(len(objects), 1)
         eq(self.ioctx.get_locator_key(), "bar")
         self.ioctx.set_locator_key("")
         objects[0].seek(0)
-        objects[0].write("contents2")
+        objects[0].write(b"contents2")
         eq(self.ioctx.get_locator_key(), "")
         self.ioctx.set_locator_key("bar")
         contents = self.ioctx.read("foo")
-        eq(contents, "contents2")
+        eq(contents, b"contents2")
         eq(self.ioctx.get_locator_key(), "bar")
         objects[0].remove()
         objects = [i for i in self.ioctx.list_objects()]
@@ -412,7 +403,7 @@ class TestIoctx(object):
                 count[0] += 1
                 lock.notify()
             return 0
-        comp = self.ioctx.aio_write("foo", "bar", 0, cb, cb)
+        comp = self.ioctx.aio_write("foo", b"bar", 0, cb, cb)
         comp.wait_for_complete()
         comp.wait_for_safe()
         with lock:
@@ -420,7 +411,7 @@ class TestIoctx(object):
                 lock.wait()
         eq(comp.get_return_value(), 0)
         contents = self.ioctx.read("foo")
-        eq(contents, "bar")
+        eq(contents, b"bar")
         [i.remove() for i in self.ioctx.list_objects()]
 
     def test_aio_append(self):
@@ -431,11 +422,11 @@ class TestIoctx(object):
                 count[0] += 1
                 lock.notify()
             return 0
-        comp = self.ioctx.aio_write("foo", "bar", 0, cb, cb)
-        comp2 = self.ioctx.aio_append("foo", "baz", cb, cb)
+        comp = self.ioctx.aio_write("foo", b"bar", 0, cb, cb)
+        comp2 = self.ioctx.aio_append("foo", b"baz", cb, cb)
         comp.wait_for_complete()
         contents = self.ioctx.read("foo")
-        eq(contents, "barbaz")
+        eq(contents, b"barbaz")
         with lock:
             while count[0] < 4:
                 lock.wait()
@@ -451,8 +442,8 @@ class TestIoctx(object):
                 count[0] += 1
                 lock.notify()
             return 0
-        self.ioctx.aio_write("foo", "barbaz", 0, cb, cb)
-        comp = self.ioctx.aio_write_full("foo", "bar", cb, cb)
+        self.ioctx.aio_write("foo", b"barbaz", 0, cb, cb)
+        comp = self.ioctx.aio_write_full("foo", b"bar", cb, cb)
         comp.wait_for_complete()
         comp.wait_for_safe()
         with lock:
@@ -460,7 +451,7 @@ class TestIoctx(object):
                 lock.wait()
         eq(comp.get_return_value(), 0)
         contents = self.ioctx.read("foo")
-        eq(contents, "bar")
+        eq(contents, b"bar")
         [i.remove() for i in self.ioctx.list_objects()]
 
     def _take_down_acting_set(self, pool, objectname):
@@ -472,14 +463,14 @@ class TestIoctx(object):
             "object":objectname,
             "format":"json",
         }
-        r, jsonout, _ = self.rados.mon_command(json.dumps(cmd), '')
-        objmap = json.loads(jsonout)
+        r, jsonout, _ = self.rados.mon_command(json.dumps(cmd), b'')
+        objmap = json.loads(jsonout.decode("utf-8"))
         acting_set = objmap['acting']
         cmd = {"prefix":"osd set", "key":"noup"}
-        r, _, _ = self.rados.mon_command(json.dumps(cmd), '')
+        r, _, _ = self.rados.mon_command(json.dumps(cmd), b'')
         eq(r, 0)
         cmd = {"prefix":"osd down", "ids":[str(i) for i in acting_set]}
-        r, _, _ = self.rados.mon_command(json.dumps(cmd), '')
+        r, _, _ = self.rados.mon_command(json.dumps(cmd), b'')
         eq(r, 0)
 
         # wait for OSDs to acknowledge the down
@@ -487,7 +478,7 @@ class TestIoctx(object):
 
     def _let_osds_back_up(self):
         cmd = {"prefix":"osd unset", "key":"noup"}
-        r, _, _ = self.rados.mon_command(json.dumps(cmd), '')
+        r, _, _ = self.rados.mon_command(json.dumps(cmd), b'')
         eq(r, 0)
 
     def test_aio_read(self):
@@ -498,7 +489,7 @@ class TestIoctx(object):
             with lock:
                 retval[0] = buf
                 lock.notify()
-        payload = "bar\000frob"
+        payload = b"bar\000frob"
         self.ioctx.write("foo", payload)
 
         # test1: use wait_for_complete() and wait for cb by
@@ -570,7 +561,7 @@ class TestObject(object):
         self.rados.create_pool('test_pool')
         assert self.rados.pool_exists('test_pool')
         self.ioctx = self.rados.open_ioctx('test_pool')
-        self.ioctx.write('foo', 'bar')
+        self.ioctx.write('foo', b'bar')
         self.object = Object(self.ioctx, 'foo')
 
     def tearDown(self):
@@ -579,21 +570,21 @@ class TestObject(object):
         self.rados.shutdown()
 
     def test_read(self):
-        eq(self.object.read(3), 'bar')
-        eq(self.object.read(100), '')
+        eq(self.object.read(3), b'bar')
+        eq(self.object.read(100), b'')
 
     def test_seek(self):
-        self.object.write('blah')
+        self.object.write(b'blah')
         self.object.seek(0)
-        eq(self.object.read(4), 'blah')
+        eq(self.object.read(4), b'blah')
         self.object.seek(1)
-        eq(self.object.read(3), 'lah')
+        eq(self.object.read(3), b'lah')
 
     def test_write(self):
-        self.object.write('barbaz')
+        self.object.write(b'barbaz')
         self.object.seek(0)
-        eq(self.object.read(3), 'bar')
-        eq(self.object.read(3), 'baz')
+        eq(self.object.read(3), b'bar')
+        eq(self.object.read(3), b'baz')
 
 class TestCommand(object):
 
@@ -608,53 +599,53 @@ class TestCommand(object):
 
         # check for success and some plain output with epoch in it
         cmd = {"prefix":"mon dump"}
-        ret, buf, errs = self.rados.mon_command(json.dumps(cmd), '', timeout=30)
+        ret, buf, errs = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
         eq(ret, 0)
         assert len(buf) > 0
-        assert('epoch' in buf)
+        assert(b'epoch' in buf)
 
         # JSON, and grab current epoch
         cmd['format'] = 'json'
-        ret, buf, errs = self.rados.mon_command(json.dumps(cmd), '', timeout=30)
+        ret, buf, errs = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
         eq(ret, 0)
         assert len(buf) > 0
-        d = json.loads(buf)
+        d = json.loads(buf.decode("utf-8"))
         assert('epoch' in d)
         epoch = d['epoch']
 
         # assume epoch + 1000 does not exist; test for ENOENT
         cmd['epoch'] = epoch + 1000
-        ret, buf, errs = self.rados.mon_command(json.dumps(cmd), '', timeout=30)
+        ret, buf, errs = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
         eq(ret, -errno.ENOENT)
         eq(len(buf), 0)
         del cmd['epoch']
 
         # send to specific target by name
         target = d['mons'][0]['name']
-        print target
-        ret, buf, errs = self.rados.mon_command(json.dumps(cmd), '', timeout=30,
+        print(target)
+        ret, buf, errs = self.rados.mon_command(json.dumps(cmd), b'', timeout=30,
                                                 target=target)
         eq(ret, 0)
         assert len(buf) > 0
-        d = json.loads(buf)
+        d = json.loads(buf.decode("utf-8"))
         assert('epoch' in d)
 
         # and by rank
         target = d['mons'][0]['rank']
-        print target
-        ret, buf, errs = self.rados.mon_command(json.dumps(cmd), '', timeout=30,
+        print(target)
+        ret, buf, errs = self.rados.mon_command(json.dumps(cmd), b'', timeout=30,
                                                 target=target)
         eq(ret, 0)
         assert len(buf) > 0
-        d = json.loads(buf)
+        d = json.loads(buf.decode("utf-8"))
         assert('epoch' in d)
 
     def test_osd_bench(self):
         cmd = dict(prefix='bench', size=4096, count=8192)
-        ret, buf, err = self.rados.osd_command(0, json.dumps(cmd), '',
+        ret, buf, err = self.rados.osd_command(0, json.dumps(cmd), b'',
                                                timeout=30)
         eq(ret, 0)
         assert len(err) > 0
-        out = json.loads(err)
+        out = json.loads(err.decode("utf-8"))
         eq(out['blocksize'], cmd['size'])
         eq(out['bytes_written'], cmd['count'])

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -1,10 +1,9 @@
 # vim: expandtab smarttab shiftwidth=4 softtabstop=4
 import functools
 import socket
-import struct
 import os
+import time
 
-from contextlib import nested
 from nose import with_setup, SkipTest
 from nose.tools import eq_ as eq, assert_raises
 from rados import (Rados,
@@ -16,7 +15,6 @@ from rbd import (RBD, Image, ImageNotFound, InvalidArgument, ImageExists,
                  FunctionNotSupported, ArgumentOutOfRange,
                  RBD_FEATURE_LAYERING, RBD_FEATURE_STRIPINGV2,
                  RBD_FEATURE_EXCLUSIVE_LOCK)
-
 
 rados = None
 ioctx = None
@@ -166,7 +164,7 @@ def check_default_params(format, order=None, features=None, stripe_count=None,
         else:
             assert_raises(exception, RBD().create, ioctx, image_name, IMG_SIZE)
     finally:
-        for k, v in orig_vals.iteritems():
+        for k, v in orig_vals.items():
             rados.conf_set(k, v)
 
 def test_create_defaults():
@@ -240,13 +238,13 @@ def test_open_read_only():
             eq(data, read)
 
 def test_open_dne():
-    for i in xrange(100):
+    for i in range(100):
         image_name = get_temp_image_name()
         assert_raises(ImageNotFound, Image, ioctx, image_name + 'dne')
         assert_raises(ImageNotFound, Image, ioctx, image_name, 'snap')
 
 def test_open_readonly_dne():
-    for i in xrange(100):
+    for i in range(100):
         image_name = get_temp_image_name()
         assert_raises(ImageNotFound, Image, ioctx, image_name + 'dne',
                       read_only=True)
@@ -301,10 +299,10 @@ class TestImage(object):
         eq(features | RBD_FEATURE_EXCLUSIVE_LOCK, self.image.features())
 
     def test_invalidate_cache(self):
-        self.image.write('abc', 0)
-        eq('abc', self.image.read(0, 3))
+        self.image.write(b'abc', 0)
+        eq(b'abc', self.image.read(0, 3))
         self.image.invalidate_cache()
-        eq('abc', self.image.read(0, 3))
+        eq(b'abc', self.image.read(0, 3))
 
     def test_stat(self):
         info = self.image.stat()
@@ -325,13 +323,13 @@ class TestImage(object):
 
     def test_read(self):
         data = self.image.read(0, 20)
-        eq(data, '\0' * 20)
+        eq(data, b'\0' * 20)
 
     def test_read_with_fadvise_flags(self):
         data = self.image.read(0, 20, LIBRADOS_OP_FLAG_FADVISE_DONTNEED)
-        eq(data, '\0' * 20)
+        eq(data, b'\0' * 20)
         data = self.image.read(0, 20, LIBRADOS_OP_FLAG_FADVISE_RANDOM)
-        eq(data, '\0' * 20)
+        eq(data, b'\0' * 20)
 
     def test_large_write(self):
         data = rand_data(IMG_SIZE)
@@ -339,7 +337,7 @@ class TestImage(object):
 
     def test_large_read(self):
         data = self.image.read(0, IMG_SIZE)
-        eq(data, '\0' * IMG_SIZE)
+        eq(data, b'\0' * IMG_SIZE)
 
     def test_write_read(self):
         data = rand_data(256)
@@ -374,24 +372,24 @@ class TestImage(object):
         self.image.remove_snap('snap2')
 
     def test_resize_down(self):
-        new_size = IMG_SIZE / 2
+        new_size = IMG_SIZE // 2
         data = rand_data(256)
-        self.image.write(data, IMG_SIZE / 2);
+        self.image.write(data, IMG_SIZE // 2);
         self.image.resize(new_size)
         self.image.resize(IMG_SIZE)
-        read = self.image.read(IMG_SIZE / 2, 256)
-        eq('\0' * 256, read)
+        read = self.image.read(IMG_SIZE // 2, 256)
+        eq(b'\0' * 256, read)
 
     def test_resize_bytes(self):
-        new_size = IMG_SIZE / 2 - 5
+        new_size = IMG_SIZE // 2 - 5
         data = rand_data(256)
-        self.image.write(data, IMG_SIZE / 2 - 10);
+        self.image.write(data, IMG_SIZE // 2 - 10);
         self.image.resize(new_size)
         self.image.resize(IMG_SIZE)
-        read = self.image.read(IMG_SIZE / 2 - 10, 5)
+        read = self.image.read(IMG_SIZE // 2 - 10, 5)
         eq(data[:5], read)
-        read = self.image.read(IMG_SIZE / 2 - 5, 251)
-        eq('\0' * 251, read)
+        read = self.image.read(IMG_SIZE // 2 - 5, 251)
+        eq(b'\0' * 251, read)
 
     def test_copy(self):
         global ioctx
@@ -410,7 +408,7 @@ class TestImage(object):
         global ioctx
         self.image.create_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         data = rand_data(256)
         self.image.write(data, 0)
         read = self.image.read(0, 256)
@@ -418,22 +416,22 @@ class TestImage(object):
         at_snapshot = Image(ioctx, image_name, 'snap1')
         snap_data = at_snapshot.read(0, 256)
         at_snapshot.close()
-        eq(snap_data, '\0' * 256)
+        eq(snap_data, b'\0' * 256)
         self.image.remove_snap('snap1')
 
     def test_list_snaps(self):
         eq([], list(self.image.list_snaps()))
         self.image.create_snap('snap1')
-        eq(['snap1'], map(lambda snap: snap['name'], self.image.list_snaps()))
+        eq(['snap1'], [snap['name'] for snap in self.image.list_snaps()])
         self.image.create_snap('snap2')
-        eq(['snap1', 'snap2'], map(lambda snap: snap['name'], self.image.list_snaps()))
+        eq(['snap1', 'snap2'], [snap['name'] for snap in self.image.list_snaps()])
         self.image.remove_snap('snap1')
         self.image.remove_snap('snap2')
 
     def test_remove_snap(self):
         eq([], list(self.image.list_snaps()))
         self.image.create_snap('snap1')
-        eq(['snap1'], map(lambda snap: snap['name'], self.image.list_snaps()))
+        eq(['snap1'], [snap['name'] for snap in self.image.list_snaps()])
         self.image.remove_snap('snap1')
         eq([], list(self.image.list_snaps()))
 
@@ -469,35 +467,35 @@ class TestImage(object):
         eq(read, data)
 
     def test_rollback_to_snap(self):
-        self.image.write('\0' * 256, 0)
+        self.image.write(b'\0' * 256, 0)
         self.image.create_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         data = rand_data(256)
         self.image.write(data, 0)
         read = self.image.read(0, 256)
         eq(read, data)
         self.image.rollback_to_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         self.image.remove_snap('snap1')
 
     def test_rollback_to_snap_sparse(self):
         self.image.create_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         data = rand_data(256)
         self.image.write(data, 0)
         read = self.image.read(0, 256)
         eq(read, data)
         self.image.rollback_to_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         self.image.remove_snap('snap1')
 
     def test_rollback_with_resize(self):
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         data = rand_data(256)
         self.image.write(data, 0)
         self.image.create_snap('snap1')
@@ -521,31 +519,31 @@ class TestImage(object):
         self.image.remove_snap('snap2')
 
     def test_set_snap(self):
-        self.image.write('\0' * 256, 0)
+        self.image.write(b'\0' * 256, 0)
         self.image.create_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         data = rand_data(256)
         self.image.write(data, 0)
         read = self.image.read(0, 256)
         eq(read, data)
         self.image.set_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         self.image.remove_snap('snap1')
 
     def test_set_no_snap(self):
-        self.image.write('\0' * 256, 0)
+        self.image.write(b'\0' * 256, 0)
         self.image.create_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         data = rand_data(256)
         self.image.write(data, 0)
         read = self.image.read(0, 256)
         eq(read, data)
         self.image.set_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         self.image.set_snap(None)
         read = self.image.read(0, 256)
         eq(read, data)
@@ -554,19 +552,19 @@ class TestImage(object):
     def test_set_snap_sparse(self):
         self.image.create_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         data = rand_data(256)
         self.image.write(data, 0)
         read = self.image.read(0, 256)
         eq(read, data)
         self.image.set_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         self.image.remove_snap('snap1')
 
     def test_many_snaps(self):
         num_snaps = 200
-        for i in xrange(num_snaps):
+        for i in range(num_snaps):
             self.image.create_snap(str(i))
         snaps = sorted(self.image.list_snaps(),
                        key=lambda snap: int(snap['name']))
@@ -574,14 +572,14 @@ class TestImage(object):
         for i, snap in enumerate(snaps):
             eq(snap['size'], IMG_SIZE)
             eq(snap['name'], str(i))
-        for i in xrange(num_snaps):
+        for i in range(num_snaps):
             self.image.remove_snap(str(i))
 
     def test_set_snap_deleted(self):
-        self.image.write('\0' * 256, 0)
+        self.image.write(b'\0' * 256, 0)
         self.image.create_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         data = rand_data(256)
         self.image.write(data, 0)
         read = self.image.read(0, 256)
@@ -594,10 +592,10 @@ class TestImage(object):
         eq(read, data)
 
     def test_set_snap_recreated(self):
-        self.image.write('\0' * 256, 0)
+        self.image.write(b'\0' * 256, 0)
         self.image.create_snap('snap1')
         read = self.image.read(0, 256)
-        eq(read, '\0' * 256)
+        eq(read, b'\0' * 256)
         data = rand_data(256)
         self.image.write(data, 0)
         read = self.image.read(0, 256)
@@ -633,14 +631,14 @@ class TestImage(object):
         eq([], self.image.list_lockers())
 
         num_shared = 10
-        for i in xrange(num_shared):
+        for i in range(num_shared):
             self.image.lock_shared(str(i), 'tag')
         lockers = self.image.list_lockers()
         eq('tag', lockers['tag'])
         assert not lockers['exclusive']
         eq(num_shared, len(lockers['lockers']))
         cookies = sorted(map(lambda x: x[1], lockers['lockers']))
-        for i in xrange(num_shared):
+        for i in range(num_shared):
             eq(str(i), cookies[i])
             self.image.unlock(str(i))
         eq([], self.image.list_lockers())
@@ -680,7 +678,7 @@ class TestClone(object):
         create_image()
         self.image = Image(ioctx, image_name)
         data = rand_data(256)
-        self.image.write(data, IMG_SIZE / 2)
+        self.image.write(data, IMG_SIZE // 2)
         self.image.create_snap('snap1')
         global features
         self.image.protect_snap('snap1')
@@ -758,52 +756,52 @@ class TestClone(object):
         eq(clone_info['size'], self.clone.overlap())
 
     def test_resize_stat(self):
-        self.clone.resize(IMG_SIZE / 2)
+        self.clone.resize(IMG_SIZE // 2)
         image_info = self.image.stat()
         clone_info = self.clone.stat()
-        eq(clone_info['size'], IMG_SIZE / 2)
+        eq(clone_info['size'], IMG_SIZE // 2)
         eq(image_info['size'], IMG_SIZE)
-        eq(self.clone.overlap(), IMG_SIZE / 2)
+        eq(self.clone.overlap(), IMG_SIZE // 2)
 
         self.clone.resize(IMG_SIZE * 2)
         image_info = self.image.stat()
         clone_info = self.clone.stat()
         eq(clone_info['size'], IMG_SIZE * 2)
         eq(image_info['size'], IMG_SIZE)
-        eq(self.clone.overlap(), IMG_SIZE / 2)
+        eq(self.clone.overlap(), IMG_SIZE // 2)
 
     def test_resize_io(self):
-        parent_data = self.image.read(IMG_SIZE / 2, 256)
+        parent_data = self.image.read(IMG_SIZE // 2, 256)
         self.image.resize(0)
-        self.clone.resize(IMG_SIZE / 2 + 128)
-        child_data = self.clone.read(IMG_SIZE / 2, 128)
+        self.clone.resize(IMG_SIZE // 2 + 128)
+        child_data = self.clone.read(IMG_SIZE // 2, 128)
         eq(child_data, parent_data[:128])
         self.clone.resize(IMG_SIZE)
-        child_data = self.clone.read(IMG_SIZE / 2, 256)
-        eq(child_data, parent_data[:128] + ('\0' * 128))
-        self.clone.resize(IMG_SIZE / 2 + 1)
-        child_data = self.clone.read(IMG_SIZE / 2, 1)
+        child_data = self.clone.read(IMG_SIZE // 2, 256)
+        eq(child_data, parent_data[:128] + (b'\0' * 128))
+        self.clone.resize(IMG_SIZE // 2 + 1)
+        child_data = self.clone.read(IMG_SIZE // 2, 1)
         eq(child_data, parent_data[0])
         self.clone.resize(0)
         self.clone.resize(IMG_SIZE)
-        child_data = self.clone.read(IMG_SIZE / 2, 256)
-        eq(child_data, '\0' * 256)
+        child_data = self.clone.read(IMG_SIZE // 2, 256)
+        eq(child_data, b'\0' * 256)
 
     def test_read(self):
-        parent_data = self.image.read(IMG_SIZE / 2, 256)
-        child_data = self.clone.read(IMG_SIZE / 2, 256)
+        parent_data = self.image.read(IMG_SIZE // 2, 256)
+        child_data = self.clone.read(IMG_SIZE // 2, 256)
         eq(child_data, parent_data)
 
     def test_write(self):
-        parent_data = self.image.read(IMG_SIZE / 2, 256)
+        parent_data = self.image.read(IMG_SIZE // 2, 256)
         new_data = rand_data(256)
-        self.clone.write(new_data, IMG_SIZE / 2 + 256)
-        child_data = self.clone.read(IMG_SIZE / 2 + 256, 256)
+        self.clone.write(new_data, IMG_SIZE // 2 + 256)
+        child_data = self.clone.read(IMG_SIZE // 2 + 256, 256)
         eq(child_data, new_data)
-        child_data = self.clone.read(IMG_SIZE / 2, 256)
+        child_data = self.clone.read(IMG_SIZE // 2, 256)
         eq(child_data, parent_data)
-        parent_data = self.image.read(IMG_SIZE / 2 + 256, 256)
-        eq(parent_data, '\0' * 256)
+        parent_data = self.image.read(IMG_SIZE // 2 + 256, 256)
+        eq(parent_data, b'\0' * 256)
 
     def check_children(self, expected):
         actual = self.image.list_children()
@@ -823,13 +821,13 @@ class TestClone(object):
 
         clone_name = get_temp_image_name() + '_'
         expected_children = []
-        for i in xrange(10):
+        for i in range(10):
             self.rbd.clone(ioctx, image_name, 'snap1', ioctx,
                            clone_name + str(i), features)
             expected_children.append((pool_name, clone_name + str(i)))
             self.check_children(expected_children)
 
-        for i in xrange(10):
+        for i in range(10):
             self.rbd.remove(ioctx, clone_name + str(i))
             expected_children.pop(0)
             self.check_children(expected_children)
@@ -899,15 +897,15 @@ class TestClone(object):
         with Image(ioctx, clone_name2) as clone:
             with Image(ioctx, clone_name2) as clone2:
                 # cache object non-existence
-                data = clone.read(IMG_SIZE / 2, 256)
-                clone2_data = clone2.read(IMG_SIZE / 2, 256)
+                data = clone.read(IMG_SIZE // 2, 256)
+                clone2_data = clone2.read(IMG_SIZE // 2, 256)
                 eq(data, clone2_data)
                 clone.flatten()
                 assert_raises(ImageNotFound, clone.parent_info)
                 assert_raises(ImageNotFound, clone2.parent_info)
-                after_flatten = clone.read(IMG_SIZE / 2, 256)
+                after_flatten = clone.read(IMG_SIZE // 2, 256)
                 eq(data, after_flatten)
-                after_flatten = clone2.read(IMG_SIZE / 2, 256)
+                after_flatten = clone2.read(IMG_SIZE // 2, 256)
                 eq(data, after_flatten)
         self.rbd.remove(ioctx, clone_name2)
 
@@ -962,8 +960,7 @@ class TestExclusiveLock(object):
         rados2.shutdown()
 
     def test_ownership(self):
-        with nested(Image(ioctx, image_name), Image(ioctx2, image_name)) as (
-                image1, image2):
+        with Image(ioctx, image_name) as image1, Image(ioctx2, image_name) as image2:
             image1.write('0'*256, 0)
             eq(image1.is_exclusive_lock_owner(), True)
             eq(image2.is_exclusive_lock_owner(), False)
@@ -974,7 +971,7 @@ class TestExclusiveLock(object):
             eq(image.is_exclusive_lock_owner(), True)
         try:
             with Image(ioctx, image_name) as image:
-                image.write('0'*256, 0)
+                image.write(b'0'*256, 0)
                 eq(image.is_exclusive_lock_owner(), True)
                 image.set_snap('snap')
                 eq(image.is_exclusive_lock_owner(), False)
@@ -994,14 +991,13 @@ class TestExclusiveLock(object):
             image.protect_snap('snap')
         try:
             RBD().clone(ioctx, image_name, 'snap', ioctx, 'clone', features)
-            with nested(Image(ioctx, 'clone'), Image(ioctx2, 'clone')) as (
-                    image1, image2):
+            with Image(ioctx, 'clone') as image1, Image(ioctx2, 'clone') as image2:
                 data = rand_data(256)
                 image1.write(data, 0)
                 image2.flatten()
                 assert_raises(ImageNotFound, image1.parent_info)
                 parent = True
-                for x in xrange(30):
+                for x in range(30):
                     try:
                         image2.parent_info()
                     except ImageNotFound:
@@ -1015,27 +1011,24 @@ class TestExclusiveLock(object):
                 image.remove_snap('snap')
 
     def test_follower_resize(self):
-        with nested(Image(ioctx, image_name), Image(ioctx2, image_name)) as (
-                image1, image2):
-            image1.write('0'*256, 0)
+        with Image(ioctx, image_name) as image1, Image(ioctx2, image_name) as image2:
+            image1.write(b'0'*256, 0)
             for new_size in [IMG_SIZE * 2, IMG_SIZE / 2]:
                 image2.resize(new_size);
                 eq(new_size, image1.size())
-                for x in xrange(30):
+                for x in range(30):
                     if new_size == image2.size():
                         break
                     time.sleep(1)
                 eq(new_size, image2.size())
 
     def test_follower_snap_create(self):
-        with nested(Image(ioctx, image_name), Image(ioctx2, image_name)) as (
-                image1, image2):
+        with Image(ioctx, image_name) as image1, Image(ioctx2, image_name) as image2:
             image2.create_snap('snap1')
             image1.remove_snap('snap1')
 
     def test_follower_snap_rollback(self):
-        with nested(Image(ioctx, image_name), Image(ioctx2, image_name)) as (
-                image1, image2):
+        with Image(ioctx, image_name) as image1, Image(ioctx2, image_name) as image2:
             image1.create_snap('snap')
             try:
                 assert_raises(ReadOnlyImage, image2.rollback_to_snap, 'snap')
@@ -1044,8 +1037,7 @@ class TestExclusiveLock(object):
                 image1.remove_snap('snap')
 
     def test_follower_discard(self):
-        with nested(Image(ioctx, image_name), Image(ioctx2, image_name)) as (
-                image1, image2):
+        with Image(ioctx, image_name) as image1, Image(ioctx2, image_name) as image2:
             data = rand_data(256)
             image1.write(data, 0)
             image2.discard(0, 256)
@@ -1055,8 +1047,7 @@ class TestExclusiveLock(object):
             eq(256*'\0', read)
 
     def test_follower_write(self):
-        with nested(Image(ioctx, image_name), Image(ioctx2, image_name)) as (
-                image1, image2):
+        with Image(ioctx, image_name) as image1, Image(ioctx2, image_name) as image2:
             data = rand_data(256)
             image1.write(data, 0)
             image2.write(data, IMG_SIZE / 2)


### PR DESCRIPTION
Due to some significant behavior changes in Python 3, the rados and rbd modules aren't currently usable  under Python 3. This PR attempts to rectify the situation by converting the code to a form that is compatible with both Python 3 and Python 2.7.

The most significant change is that Python strings are not 8-bit strings and must be explicitly encoded before they can be passed to the Ceph C APIs. Since I couldn't find any specific documentation on the string encoding, I'm currently assuming all strings should be UTF-8 encoded (the alternative being that strings are ASCII encoded which seems an overly restrictive limitation).

I've currently tested this using both Python 2.7 and Python 3.4 implementations. The corresponding unit tests should also pass for both implementations.