### PR TITLE
Solve the 'Flapping',which is caused by the disconnection of the back…

### DIFF
--- a/src/msg/simple/SimpleMessenger.cc
+++ b/src/msg/simple/SimpleMessenger.cc
@@ -396,19 +396,23 @@ bool SimpleMessenger::verify_authorizer(Connection *con, int peer_type,
 
 ConnectionRef SimpleMessenger::get_connection(const entity_inst_t& dest)
 {
-  Mutex::Locker l(lock);
-  if (my_inst.addr == dest.addr) {
-    // local
-    return local_connection;
+  {
+    Mutex::Locker l(lock);
+    if (my_inst.addr == dest.addr) {
+      // local
+      return local_connection;
+    }
   }
-
   // remote
   while (true) {
     Pipe *pipe = _lookup_pipe(dest.addr);
     if (pipe) {
       ldout(cct, 10) << "get_connection " << dest << " existing " << pipe << dendl;
     } else {
-      pipe = connect_rank(dest.addr, dest.name.type(), NULL, NULL);
+      Mutex::Locker l(lock);
+      pipe = _lookup_pipe(dest.addr);
+      if (!pipe)
+        pipe = connect_rank(dest.addr, dest.name.type(), NULL, NULL);
       ldout(cct, 10) << "get_connection " << dest << " new " << pipe << dendl;
     }
     Mutex::Locker l(pipe->pipe_lock);


### PR DESCRIPTION
Stop the heartbeat and empty the heartbeat information, when the back of the network is disconnected;
Restart the heartbeat process, when the back-end network connection;
If the back-end network is disconnected, the start_boot is then called to wait for the back-end network connection "

Fixes : #13532
Signed-off-by: Jie Chen <chen.jie@h3c.com>