### PR TITLE
test/librbd/fsx: musl libc doesn't implement random_r. Use c++11 std::mt19937 generator instead.

### DIFF
--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -37,6 +37,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <math.h>
+#include <fcntl.h>
 
 #include "include/intarith.h"
 #include "include/krbd.h"

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -38,6 +38,7 @@
 #include <errno.h>
 #include <math.h>
 #include <fcntl.h>
+#include <random>
 
 #include "include/intarith.h"
 #include "include/krbd.h"
@@ -231,22 +232,12 @@ simple_err(const char *msg, int err)
 /*
  * random
  */
+std::mt19937 random_generator;
 
-#define RND_STATE_LEN	256
-char	rnd_state[RND_STATE_LEN];
-struct random_data rnd_data;
-
-int32_t
+uint_fast32_t
 get_random(void)
 {
-	int32_t val;
-
-	if (random_r(&rnd_data, &val) < 0) {
-		prterr("random_r");
-		exit(1);
-	}
-
-	return val;
+	return random_generator();
 }
 
 /*
@@ -2206,14 +2197,7 @@ main(int argc, char **argv)
 	signal(SIGUSR1,	cleanup);
 	signal(SIGUSR2,	cleanup);
 
-	if (initstate_r(seed, rnd_state, RND_STATE_LEN, &rnd_data) < 0) {
-		prterr("initstate_r");
-		exit(1);
-	}
-	if (setstate_r(rnd_state, &rnd_data) < 0) {
-		prterr("setstate_r");
-		exit(1);
-	}
+	random_generator.seed(seed);
 
 	ret = create_image();
 	if (ret < 0) {


### PR DESCRIPTION
Is it possible to use random instead of random_r? random_r is a glibc extension, musl libc doesn't implement it.