### PR TITLE
LFNIndex: remove redundant local variable 'obj'.

### DIFF
--- a/src/os/LFNIndex.cc
+++ b/src/os/LFNIndex.cc
@@ -467,7 +467,6 @@ int LFNIndex::list_subdirs(const vector<string> &to_list,
     }
     string short_name(de->d_name);
     string demangled_name;
-    ghobject_t obj;
     if (lfn_is_subdir(short_name, &demangled_name)) {
       out->push_back(demangled_name);
     }


### PR DESCRIPTION
local variable 'obj' in LFNIndex::list_subdirs() never used and shall be removed.
Fixes: #13552
Signed-off-by: xie.xingguo@zte.com.cn