### PR TITLE
Rgw keystone v3

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -931,6 +931,7 @@ if(${WITH_RADOSGW})
     rgw/rgw_acl_s3.cc
     rgw/rgw_acl_swift.cc
     rgw/rgw_client_io.cc
+    rgw/rgw_cms.cc
     rgw/rgw_fcgi.cc
     rgw/rgw_xml.cc
     rgw/rgw_usage.cc
@@ -967,6 +968,7 @@ if(${WITH_RADOSGW})
   include_directories("${CMAKE_SOURCE_DIR}/src/civetweb/include")
 
   set(radosgw_srcs
+    rgw/rgw_cms.cc
     rgw/rgw_resolve.cc
     rgw/rgw_rest.cc
     rgw/rgw_rest_swift.cc

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1055,7 +1055,10 @@ OPTION(rgw_keystone_url, OPT_STR, "")  // url for keystone server
 OPTION(rgw_keystone_admin_token, OPT_STR, "")  // keystone admin token (shared secret)
 OPTION(rgw_keystone_admin_user, OPT_STR, "")  // keystone admin user name
 OPTION(rgw_keystone_admin_password, OPT_STR, "")  // keystone admin user password
-OPTION(rgw_keystone_admin_tenant, OPT_STR, "")  // keystone admin user tenant
+OPTION(rgw_keystone_admin_tenant, OPT_STR, "")  // keystone admin user tenant (for keystone v2.0)
+OPTION(rgw_keystone_admin_project, OPT_STR, "")  // keystone admin user project (for keystone v3)
+OPTION(rgw_keystone_admin_domain, OPT_STR, "")  // keystone admin user domain
+OPTION(rgw_keystone_api_version, OPT_STR, "2.0") // Version of Keystone API to use ("2.0" or "3")
 OPTION(rgw_keystone_accepted_roles, OPT_STR, "Member, admin")  // roles required to serve requests
 OPTION(rgw_keystone_token_cache_size, OPT_INT, 10000)  // max number of entries in keystone token cache
 OPTION(rgw_keystone_revocation_interval, OPT_INT, 15 * 60)  // seconds between tokens revocation check

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1058,7 +1058,7 @@ OPTION(rgw_keystone_admin_password, OPT_STR, "")  // keystone admin user passwor
 OPTION(rgw_keystone_admin_tenant, OPT_STR, "")  // keystone admin user tenant (for keystone v2.0)
 OPTION(rgw_keystone_admin_project, OPT_STR, "")  // keystone admin user project (for keystone v3)
 OPTION(rgw_keystone_admin_domain, OPT_STR, "")  // keystone admin user domain
-OPTION(rgw_keystone_api_version, OPT_STR, "2.0") // Version of Keystone API to use ("2.0" or "3")
+OPTION(rgw_keystone_api_version, OPT_INT, 2) // Version of Keystone API to use (2 or 3)
 OPTION(rgw_keystone_accepted_roles, OPT_STR, "Member, admin")  // roles required to serve requests
 OPTION(rgw_keystone_token_cache_size, OPT_INT, 10000)  // max number of entries in keystone token cache
 OPTION(rgw_keystone_revocation_interval, OPT_INT, 15 * 60)  // seconds between tokens revocation check

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -16,6 +16,7 @@ librgw_la_SOURCES =  \
 	rgw/rgw_acl.cc \
 	rgw/rgw_acl_s3.cc \
 	rgw/rgw_acl_swift.cc \
+	rgw/rgw_cms.cc \
 	rgw/rgw_client_io.cc \
 	rgw/rgw_fcgi.cc \
 	rgw/rgw_xml.cc \
@@ -80,6 +81,7 @@ libcivetweb_la_CFLAGS = -I$(srcdir)/civetweb/include ${CIVETWEB_INCLUDE}
 noinst_LTLIBRARIES += libcivetweb.la
 
 radosgw_SOURCES = \
+	rgw/rgw_cms.cc \
 	rgw/rgw_resolve.cc \
 	rgw/rgw_rest.cc \
 	rgw/rgw_rest_swift.cc \
@@ -131,6 +133,7 @@ noinst_HEADERS += \
 	rgw/rgw_fcgi.h \
 	rgw/rgw_xml.h \
 	rgw/rgw_cache.h \
+	rgw/rgw_cms.h \
 	rgw/rgw_common.h \
 	rgw/rgw_cors.h \
 	rgw/rgw_cors_s3.h \

--- a/src/rgw/rgw_cms.cc
+++ b/src/rgw/rgw_cms.cc
@@ -1,0 +1,82 @@
+#include "common/ceph_json.h"
+#include "rgw_common.h"
+#include "common/ceph_crypto_cms.h"
+#include "common/armor.h"
+#include "rgw_cms.h"
+
+#define PKI_ANS1_PREFIX "MII"
+#define BEGIN_CMS "-----BEGIN CMS-----"
+#define END_CMS "-----END CMS-----"
+
+#define dout_subsys ceph_subsys_rgw
+
+bool is_pki_token(const string& token)
+{
+  return token.compare(0, sizeof(PKI_ANS1_PREFIX) - 1, PKI_ANS1_PREFIX) == 0;
+}
+
+int open_cms_envelope(CephContext *cct, string& src, string& dst)
+{
+
+  int start = src.find(BEGIN_CMS);
+  if (start < 0) {
+    ldout(cct, 0) << "failed to find " << BEGIN_CMS << " in response" << dendl;
+    return -EINVAL;
+  }
+  start += sizeof(BEGIN_CMS) - 1;
+
+  int end = src.find(END_CMS);
+  if (end < 0) {
+    ldout(cct, 0) << "failed to find " << END_CMS << " in response" << dendl;
+    return -EINVAL;
+  }
+
+  string s = src.substr(start, end - start);
+
+  int pos = 0;
+
+  do {
+    int next = s.find('\n', pos);
+    if (next < 0) {
+      dst.append(s.substr(pos));
+      break;
+    } else {
+      dst.append(s.substr(pos, next - pos));
+    }
+    pos = next + 1;
+  } while (pos < (int)s.size());
+
+  return 0;
+}
+
+int decode_b64_cms(CephContext *cct, const string& signed_b64, bufferlist& bl)
+{
+  bufferptr signed_ber(signed_b64.size() * 2);
+  char *dest = signed_ber.c_str();
+  const char *src = signed_b64.c_str();
+  size_t len = signed_b64.size();
+  char buf[len + 1];
+  buf[len] = '\0';
+  for (size_t i = 0; i < len; i++, src++) {
+    if (*src != '-')
+      buf[i] = *src;
+    else
+      buf[i] = '/';
+  }
+  int ret = ceph_unarmor(dest, dest + signed_ber.length(), buf, buf + signed_b64.size());
+  if (ret < 0) {
+    ldout(cct, 0) << "ceph_unarmor() failed, ret=" << ret << dendl;
+    return ret;
+  }
+
+  bufferlist signed_ber_bl;
+  signed_ber_bl.append(signed_ber);
+
+  ret = ceph_decode_cms(cct, signed_ber_bl, bl);
+  if (ret < 0) {
+    ldout(cct, 0) << "ceph_decode_cms returned " << ret << dendl;
+    return ret;
+  }
+
+  return 0;
+}

--- a/src/rgw/rgw_cms.h
+++ b/src/rgw/rgw_cms.h
@@ -1,0 +1,13 @@
+#ifndef CEPH_RGW_CMS_H
+#define CEPH_RGW_CMS_H
+
+#include "common/ceph_json.h"
+#include "rgw_common.h"
+#include "common/ceph_crypto_cms.h"
+#include "common/armor.h"
+
+bool is_pki_token(const string& token);
+int open_cms_envelope(CephContext *cct, string& src, string& dst);
+int decode_b64_cms(CephContext *cct, const string& signed_b64, bufferlist& bl);
+
+#endif

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -821,10 +821,10 @@ void KeystoneToken::User::decode_json(JSONObj *obj)
 
 void KeystoneToken::decode_json(JSONObj *root_obj)
 {
-  if (version == "2.0") {
+  if (version == 2) {
     JSONDecoder::decode_json("token", token, root_obj, true);
   }
-  if (version == "3") {
+  if (version == 3) {
     string expires_iso8601;
     struct tm t;
 
@@ -841,7 +841,7 @@ void KeystoneToken::decode_json(JSONObj *root_obj)
   }
 
   JSONDecoder::decode_json("user", user, root_obj, true);
-  if (version == "2.0") {
+  if (version == 2) {
     roles = user.roles_v2;
     project = token.tenant_v2;
   }

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -1,20 +1,27 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <stdio.h>
 #include <errno.h>
 #include <fnmatch.h>
 
 #include "common/errno.h"
 #include "common/ceph_json.h"
+#include "common/ceph_crypto_cms.h"
+
 #include "include/types.h"
 #include "include/str_list.h"
 
 #include "rgw_common.h"
+#include "rgw_http_client.h"
 #include "rgw_keystone.h"
+#include "rgw_cms.h"
 
 #define dout_subsys ceph_subsys_rgw
 
-bool KeystoneToken::User::has_role(const string& r) {
+static list<string> roles_list;
+
+bool KeystoneToken::has_role(const string &r) {
   list<Role>::iterator iter;
   for (iter = roles.begin(); iter != roles.end(); ++iter) {
       if (fnmatch(r.c_str(), ((*iter).name.c_str()), 0) == 0) {
@@ -33,16 +40,20 @@ int KeystoneToken::parse(CephContext *cct, bufferlist& bl)
   }
 
   try {
-    JSONDecoder::decode_json("access", *this, &parser);
+    if (version == "2.0") {
+      JSONDecoder::decode_json("access", *this, &parser);
+    }
+    if (version == "3") {
+      JSONDecoder::decode_json("token", *this, &parser);
+    }
   } catch (JSONDecoder::err& err) {
     ldout(cct, 0) << "Keystone token parse error: " << err.message << dendl;
     return -EINVAL;
   }
-
   return 0;
 }
 
-bool RGWKeystoneTokenCache::find(const string& token_id, KeystoneToken& token)
+bool Keystone::RGWKeystoneTokenCache::find(const string& token_id, KeystoneToken& token)
 {
   lock.Lock();
   map<string, token_entry>::iterator iter = tokens.find(token_id);
@@ -58,7 +69,7 @@ bool RGWKeystoneTokenCache::find(const string& token_id, KeystoneToken& token)
   if (entry.token.expired()) {
     tokens.erase(iter);
     lock.Unlock();
-    if (perfcounter) perfcounter->inc(l_rgw_keystone_token_cache_hit);
+    if (perfcounter) perfcounter->inc(l_rgw_keystone_token_cache_miss);
     return false;
   }
   token = entry.token;
@@ -72,7 +83,7 @@ bool RGWKeystoneTokenCache::find(const string& token_id, KeystoneToken& token)
   return true;
 }
 
-void RGWKeystoneTokenCache::add(const string& token_id, KeystoneToken& token)
+void Keystone::RGWKeystoneTokenCache::add(const string& token_id, KeystoneToken& token)
 {
   lock.Lock();
   map<string, token_entry>::iterator iter = tokens.find(token_id);
@@ -97,7 +108,7 @@ void RGWKeystoneTokenCache::add(const string& token_id, KeystoneToken& token)
   lock.Unlock();
 }
 
-void RGWKeystoneTokenCache::invalidate(const string& token_id)
+void Keystone::RGWKeystoneTokenCache::invalidate(const string& token_id)
 {
   Mutex::Locker l(lock);
   map<string, token_entry>::iterator iter = tokens.find(token_id);
@@ -108,4 +119,400 @@ void RGWKeystoneTokenCache::invalidate(const string& token_id)
   token_entry& e = iter->second;
   tokens_lru.erase(e.lru_iter);
   tokens.erase(iter);
+}
+
+int RGWPostHTTPData::receive_header(void *ptr, size_t len)
+{
+  char line[len + 1];
+
+  char *s = (char *)ptr, *end = (char *)ptr + len;
+  char *p = line;
+  ldout(cct, 10) << "read_http_header" << dendl;
+
+  while (s != end) {
+    if (*s == '\r') {
+      s++;
+      continue;
+    }
+    if (*s == '\n') {
+      *p = '\0';
+      ldout(cct, 10) << "os_auth:" << line << dendl;
+      // TODO: fill whatever data required here
+      char *l = line;
+      char *tok = strsep(&l, " \t:");
+      if (tok) {
+        while (l && *l == ' ')
+          l++;
+
+        if (strcasecmp(tok, "X-Subject-Token") == 0) {
+          subject_token = l;
+        }
+      }
+    }
+    if (s != end)
+      *p++ = *s++;
+  }
+  return 0;
+}
+
+int Keystone::get_keystone_url(std::string &url) {
+  bufferlist bl;
+
+  url = cct->_conf->rgw_keystone_url;
+  if (url.empty()) {
+    ldout(cct, 0) << "ERROR: keystone url is not configured" << dendl;
+    return -EINVAL;
+  }
+  if (url[url.size() - 1] != '/')
+    url.append("/");
+  return 0;
+}
+
+int Keystone::get_keystone_admin_token(std::string &token) {
+  std::string token_url;
+
+  if (get_keystone_url(token_url) < 0)
+    return -EINVAL;
+  if (!cct->_conf->rgw_keystone_admin_token.empty()) {
+    token = cct->_conf->rgw_keystone_admin_token;
+    return 0;
+  }
+  bufferlist token_bl;
+  RGWGetKeystoneAdminToken token_req(cct, &token_bl);
+  token_req.append_header("Content-Type", "application/json");
+  JSONFormatter jf;
+  std::string keystone_version = cct->_conf->rgw_keystone_api_version;
+  if (keystone_version == "2.0") {
+    jf.open_object_section("token_request");
+      jf.open_object_section("auth");
+        jf.open_object_section("passwordCredentials");
+          encode_json("username", cct->_conf->rgw_keystone_admin_user, &jf);
+          encode_json("password", cct->_conf->rgw_keystone_admin_password, &jf);
+        jf.close_section();
+        encode_json("tenantName", cct->_conf->rgw_keystone_admin_tenant, &jf);
+      jf.close_section();
+    jf.close_section();
+    std::stringstream ss;
+    jf.flush(ss);
+    token_req.set_post_data(ss.str());
+    token_req.set_send_length(ss.str().length());
+    token_url.append("v2.0/tokens");
+    int ret = token_req.process("POST", token_url.c_str());
+    if (ret < 0)
+      return ret;
+    KeystoneToken t = KeystoneToken(keystone_version);
+    if (t.parse(cct, token_bl) != 0)
+      return -EINVAL;
+    token = t.token.id;
+    return 0;
+  }
+  else if (keystone_version == "3") {
+    jf.open_object_section("auth");
+      jf.open_object_section("identity");
+        jf.open_array_section("methods");
+          jf.dump_string("", "password");
+        jf.close_section();
+        jf.open_object_section("password");
+          jf.open_object_section("user");
+            jf.open_object_section("domain");
+              encode_json("name", cct->_conf->rgw_keystone_admin_domain, &jf);
+            jf.close_section();
+            encode_json("name", cct->_conf->rgw_keystone_admin_user, &jf);
+            encode_json("password", cct->_conf->rgw_keystone_admin_password, &jf);
+          jf.close_section();
+        jf.close_section();
+      jf.close_section();
+      jf.open_object_section("scope");
+        jf.open_object_section("project");
+          if (!cct->_conf->rgw_keystone_admin_project.empty()) {
+            encode_json("name", cct->_conf->rgw_keystone_admin_project, &jf);
+          }
+          else {
+            encode_json("name", cct->_conf->rgw_keystone_admin_tenant, &jf);
+          }
+          jf.open_object_section("domain");
+            encode_json("name", cct->_conf->rgw_keystone_admin_domain, &jf);
+          jf.close_section();
+        jf.close_section();
+      jf.close_section();
+    jf.close_section();
+    std::stringstream ss;
+    jf.flush(ss);
+    token_req.set_post_data(ss.str());
+    token_req.set_send_length(ss.str().length());
+    token_url.append("v3/auth/tokens");
+    int ret = token_req.process("POST", token_url.c_str());
+    if (ret < 0)
+      return ret;
+    token = token_req.get_subject_token();
+    return 0;
+  }
+  return -EINVAL;
+}
+
+int Keystone::parse_response(const string &token, bufferlist bl, KeystoneToken &t)
+{
+  int ret = t.parse(cct, bl);
+  if (ret < 0)
+    return ret;
+
+  bool found = false;
+  list<string>::iterator iter;
+  for (iter = roles_list.begin(); iter != roles_list.end(); ++iter) {
+    const string& role = *iter;
+    if ((found=t.has_role(role))==true)
+      break;
+  }
+
+  if (!found) {
+    ldout(cct, 0) << "user does not hold a matching role; required roles: " << g_conf->rgw_keystone_accepted_roles << dendl;
+    return -EPERM;
+  }
+  ldout(cct, 0) << "validated token: " << t.get_project_name() << ":" << t.get_user_name() << " expires: " << t.get_expires() << dendl;
+  return 0;
+}
+
+static void get_token_id(const string& token, string& token_id)
+{
+  if (!is_pki_token(token)) {
+    token_id = token;
+    return;
+  }
+
+  unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+
+  MD5 hash;
+  hash.Update((const byte *)token.c_str(), token.size());
+  hash.Final(m);
+
+
+  char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+  buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
+  token_id = calc_md5;
+}
+
+static bool decode_pki_token(CephContext *cct, const string& token, bufferlist& bl)
+{
+  if (!is_pki_token(token))
+    return false;
+
+  int ret = decode_b64_cms(cct, token, bl);
+  if (ret < 0)
+    return false;
+
+  ldout(cct, 20) << "successfully decoded pki token" << dendl;
+
+  return true;
+}
+
+int Keystone::validate_token(const string& token, KeystoneToken& t)
+{
+  string token_id;
+  get_token_id(token, token_id);
+
+  /* check cache first */
+  if (cache->find(token_id, t)) {
+    ldout(cct, 20) << "cached token.project.id=" << t.get_project_id() << dendl;
+    return 0;
+  }
+
+  std::string url;
+  if (get_keystone_url(url) < 0)
+    return -EINVAL;
+
+  std::string admin_token;
+  if (get_keystone_admin_token(admin_token) < 0)
+    return -EINVAL;
+
+  bufferlist bl;
+  int ret;
+  /* check if that's a self signed token that we can decode */
+  if (!decode_pki_token(cct, token, bl)) {
+
+    /* can't decode, just go to the keystone server for validation */
+    RGWValidateKeystoneToken validate(cct, &bl);
+    validate.append_header("X-Auth-Token", admin_token);
+
+    std::string keystone_version = cct->_conf->rgw_keystone_api_version;
+    if (keystone_version == "2.0") {
+      url.append("v2.0/tokens/");
+      url.append(token);
+    }
+    if (keystone_version == "3") {
+      url.append("v3/auth/tokens");
+      validate.append_header("X-Subject-Token", token);
+    }
+    validate.set_send_length(0);
+
+    ret = validate.process(url.c_str());
+    if (ret < 0)
+      return ret;
+  }
+
+  bl.append((char)0); // NULL terminate for debug output
+
+  ldout(cct, 20) << "received response: " << bl.c_str() << dendl;
+
+  ret = parse_response(token, bl, t);
+  if (ret < 0)
+    return ret;
+
+  if (t.expired()) {
+    ldout(cct, 0) << "got expired token: " << t.get_project_name() << ":" << t.get_user_name() << " expired: " << t.get_expires() << dendl;
+    return -EPERM;
+  }
+
+  cache->add(token_id, t);
+  return 0;
+}
+
+
+int Keystone::check_revoked() {
+  string url;
+  string token;
+
+  bufferlist bl;
+  RGWGetRevokedTokens req(cct, &bl);
+
+  if (get_keystone_admin_token(token) < 0)
+    return -EINVAL;
+  if (get_keystone_url(url) < 0)
+    return -EINVAL;
+  req.append_header("X-Auth-Token", token);
+  std::string keystone_version = cct->_conf->rgw_keystone_api_version;
+  if (keystone_version == "2.0") {
+    url.append("v2.0/tokens/revoked");
+  }
+  if (keystone_version == "3") {
+    url.append("v3/auth/tokens/OS-PKI/revoked");
+  }
+  req.set_send_length(0);
+  int ret = req.process(url.c_str());
+  if (ret < 0)
+    return ret;
+
+  bl.append((char) 0); // NULL terminate for debug output
+
+  ldout(cct, 10) << "request returned " << bl.c_str() << dendl;
+
+  JSONParser parser;
+
+  if (!parser.parse(bl.c_str(), bl.length())) {
+    ldout(cct, 0) << "malformed json" << dendl;
+    return -EINVAL;
+  }
+
+  JSONObjIter iter = parser.find_first("signed");
+  if (iter.end()) {
+    ldout(cct, 0) << "revoked tokens response is missing signed section" << dendl;
+    return -EINVAL;
+  }
+
+  JSONObj *signed_obj = *iter;
+
+  string signed_str = signed_obj->get_data();
+
+  ldout(cct, 10) << "signed=" << signed_str << dendl;
+
+  string signed_b64;
+  ret = open_cms_envelope(cct, signed_str, signed_b64);
+  if (ret < 0)
+    return ret;
+
+  ldout(cct, 10) << "content=" << signed_b64 << dendl;
+
+  bufferlist json;
+  ret = decode_b64_cms(cct, signed_b64, json);
+  if (ret < 0) {
+    return ret;
+  }
+
+  ldout(cct, 10) << "ceph_decode_cms: decoded: " << json.c_str() << dendl;
+
+  JSONParser list_parser;
+  if (!list_parser.parse(json.c_str(), json.length())) {
+    ldout(cct, 0) << "malformed json" << dendl;
+    return -EINVAL;
+  }
+
+  JSONObjIter revoked_iter = list_parser.find_first("revoked");
+  if (revoked_iter.end()) {
+    ldout(cct, 0) << "no revoked section in json" << dendl;
+    return -EINVAL;
+  }
+
+  JSONObj *revoked_obj = *revoked_iter;
+
+  JSONObjIter tokens_iter = revoked_obj->find_first();
+  for (; !tokens_iter.end(); ++tokens_iter) {
+    JSONObj *o = *tokens_iter;
+
+    JSONObj *token = o->find_obj("id");
+    if (!token) {
+      ldout(cct, 0) << "bad token in array, missing id" << dendl;
+      continue;
+    }
+
+    string token_id = token->get_data();
+    cache->invalidate(token_id);
+  }
+
+  return 0;
+}
+
+void Keystone::init() {
+  if (enabled()) {
+    get_str_list(cct->_conf->rgw_keystone_accepted_roles, roles_list);
+    cache = new RGWKeystoneTokenCache(cct, cct->_conf->rgw_keystone_token_cache_size);
+
+    keystone_revoke_thread = new KeystoneRevokeThread(cct, this);
+    keystone_revoke_thread->create();
+  }
+}
+
+void Keystone::stop() {
+  if (enabled()) {
+    delete cache;
+    cache = NULL;
+
+    stopping_flag.inc();
+    if (keystone_revoke_thread) {
+      keystone_revoke_thread->stop();
+      keystone_revoke_thread->join();
+    }
+    delete keystone_revoke_thread;
+    keystone_revoke_thread = NULL;
+  }
+}
+
+void Keystone::finalize() {
+  stop();
+}
+
+bool Keystone::stopping() {
+  return (stopping_flag.read() != 0);
+}
+
+void *Keystone::KeystoneRevokeThread::entry() {
+  do {
+    dout(2) << "keystone revoke thread: start" << dendl;
+    int r = keystone->check_revoked();
+    if (r < 0) {
+      dout(0) << "ERROR: keystone revocation processing returned error r=" << r << dendl;
+    }
+
+    if (keystone->stopping())
+      break;
+
+    lock.Lock();
+    cond.WaitInterval(cct, lock, utime_t(cct->_conf->rgw_keystone_revocation_interval, 0));
+    lock.Unlock();
+  } while (!keystone->stopping());
+
+  return NULL;
+}
+
+void Keystone::KeystoneRevokeThread::stop() {
+  Mutex::Locker l(lock);
+  cond.Signal();
 }

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -5,80 +5,73 @@
 #define CEPH_RGW_KEYSTONE_H
 
 #include "rgw_common.h"
+#include "common/Cond.h"
+#include "rgw_http_client.h"
 
 class KeystoneToken {
+protected:
+  string version;
+
 public:
-  class Metadata {
+  class Domain {
   public:
-    Metadata() : is_admin(false) { }
-    bool is_admin;
-    void decode_json(JSONObj *obj);
-  };
-
-  class Service {
-  public:
-    class Endpoint {
-    public:
-      string id;
-      string admin_url;
-      string public_url;
-      string internal_url;
-      string region;
-      void decode_json(JSONObj *obj);
-    };
-    string type;
+    string id;
     string name;
-    list<Endpoint> endpoints;
     void decode_json(JSONObj *obj);
   };
-
+  class Project {
+  public:
+    Domain domain;
+    string id;
+    string name;
+    void decode_json(JSONObj *obj);
+  };
   class Token {
   public:
     Token() : expires(0) { }
-    class Tenant {
-    public:
-      Tenant() : enabled(false) { }
-      string id;
-      string name;
-      string description;
-      bool enabled;
-      void decode_json(JSONObj *obj);
-    };
     string id;
     time_t expires;
-    Tenant tenant;
+    Project tenant_v2;
+    void decode_json(JSONObj *obj);
+  };
+
+  class Role {
+  public:
+    string id;
+    string name;
     void decode_json(JSONObj *obj);
   };
 
   class User {
   public:
-    class Role {
-    public:
-      string id;
-      string name;
-      void decode_json(JSONObj *obj);
-    };
     string id;
     string name;
-    string user_name;
-    list<Role> roles;
+    Domain domain;
+    list<Role> roles_v2;
     void decode_json(JSONObj *obj);
-    bool has_role(const string& r);
   };
 
-  Metadata metadata;
-  list<Service> service_catalog;
   Token token;
+  Project project;
   User user;
+  list<Role> roles;
 
 public:
-  int parse(CephContext *cct, bufferlist& bl);
-
+  KeystoneToken() : version("") {};
+  KeystoneToken(string _version) : version(_version) {};
+  time_t get_expires() { return token.expires; }
+  string get_domain_id() {return project.domain.id;};
+  string get_domain_name()  {return project.domain.name;};
+  string get_project_id() {return project.id;};
+  string get_project_name() {return project.name;};
+  string get_user_id() {return user.id;};
+  string get_user_name() {return user.name;};
+  bool has_role(const string& r);
   bool expired() {
     uint64_t now = ceph_clock_now(NULL).sec();
-    return (now >= (uint64_t)token.expires);
+    return (now >= (uint64_t)get_expires());
   }
-
+  int parse(CephContext *cct, bufferlist& bl);
   void decode_json(JSONObj *access_obj);
 };
 
@@ -87,23 +80,102 @@ struct token_entry {
   list<string>::iterator lru_iter;
 };
 
-class RGWKeystoneTokenCache {
-  CephContext *cct;
-
-  map<string, token_entry> tokens;
-  list<string> tokens_lru;
-
-  Mutex lock;
-
-  size_t max;
-
+class RGWPostHTTPData : public RGWHTTPClient {
+  bufferlist *bl;
+  string post_data;
+  size_t post_data_index;
+  string subject_token;
 public:
-  RGWKeystoneTokenCache(CephContext *_cct, int _max) : cct(_cct), lock("RGWKeystoneTokenCache"), max(_max) {}
+  RGWPostHTTPData(CephContext *_cct, bufferlist *_bl) : RGWHTTPClient(_cct), bl(_bl), post_data_index(0) { }
 
-  bool find(const string& token_id, KeystoneToken& token);
-  void add(const string& token_id, KeystoneToken& token);
-  void invalidate(const string& token_id);
+  void set_post_data(const string &_post_data) {
+    this->post_data = _post_data;
+  }
+
+  int send_data(void *ptr, size_t len) {
+    int length_to_copy = 0;
+    if (post_data_index < post_data.length()) {
+      length_to_copy = min(post_data.length() - post_data_index, len);
+      memcpy(ptr, post_data.data() + post_data_index, length_to_copy);
+      post_data_index += length_to_copy;
+    }
+    return length_to_copy;
+  }
+
+  int receive_data(void *ptr, size_t len) {
+    bl->append((char *) ptr, len);
+    return 0;
+  }
+
+  int receive_header(void *ptr, size_t len);
+
+  string get_subject_token() {
+    return subject_token;
+  }
 };
 
+typedef RGWPostHTTPData RGWValidateKeystoneToken;
+typedef RGWPostHTTPData RGWGetKeystoneAdminToken;
+typedef RGWPostHTTPData RGWGetRevokedTokens;
+
+class Keystone {
+  CephContext *cct;
+  atomic_t stopping_flag;
+
+protected:
+  class KeystoneRevokeThread : public Thread {
+    CephContext *cct;
+    Keystone *keystone;
+    Mutex lock;
+    Cond cond;
+
+  public:
+    KeystoneRevokeThread(CephContext *_cct, Keystone *_keystone) : cct(_cct), keystone(_keystone), lock("KeystoneRevokeThread") {}
+    void *entry();
+    void stop();
+  };
+  class RGWKeystoneTokenCache {
+    CephContext *cct;
+
+    map<string, token_entry> tokens;
+    list<string> tokens_lru;
+
+    Mutex lock;
+
+    size_t max;
+
+  public:
+    RGWKeystoneTokenCache(CephContext *_cct, int _max) : cct(_cct), lock("RGWKeystoneTokenCache"), max(_max) {}
+
+    bool find(const string& token_id, KeystoneToken& token);
+    void add(const string& token_id, KeystoneToken& token);
+    void invalidate(const string& token_id);
+  };
+
+  KeystoneRevokeThread *keystone_revoke_thread;
+  RGWKeystoneTokenCache *cache;
+  int check_revoked();
+  int get_keystone_url(std::string& url);
+  int get_keystone_admin_token(std::string& token);
+  int parse_response(const string &token, bufferlist bl, KeystoneToken &t);
+  void init();
+  void finalize();
+
+public:
+  Keystone(CephContext *_cct) : cct(_cct) {
+    cache = NULL;
+    init();
+  }
+  ~Keystone() {
+    finalize();
+  }
+  bool enabled() {
+    return !cct->_conf->rgw_keystone_url.empty();
+  }
+  int validate_token(const string& token, KeystoneToken& t);
+
+  bool stopping();
+  void stop();
+};
 
 #endif

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -10,7 +10,7 @@
 
 class KeystoneToken {
 protected:
-  string version;
+  int version;
 
 public:
   class Domain {
@@ -57,8 +57,8 @@ public:
   list<Role> roles;
 
 public:
-  KeystoneToken() : version("") {};
-  KeystoneToken(string _version) : version(_version) {};
+  KeystoneToken() : version(0) {};
+  KeystoneToken(int _version) : version(_version) {};
   time_t get_expires() { return token.expires; }
   string get_domain_id() {return project.domain.id;};
   string get_domain_name()  {return project.domain.name;};

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2244,10 +2244,10 @@ int RGWHandler_ObjStore_S3::init(RGWRados *store, struct req_state *s, RGWClient
 int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(const string& auth_id, const string& auth_token, const string& auth_sign) {
   /* prepare keystone url */
   string keystone_url = cct->_conf->rgw_keystone_url;
-  string keystone_version = cct->_conf->rgw_keystone_api_version;
+  int keystone_version = cct->_conf->rgw_keystone_api_version;
   if (keystone_url[keystone_url.size() - 1] != '/')
     keystone_url.append("/");
-  if (keystone_version == "3") {
+  if (keystone_version == 3) {
     keystone_url.append("v3/s3tokens");
   }
   else {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -308,8 +308,9 @@ private:
   }
 
 public:
-  RGW_Auth_S3_Keystone_ValidateToken(CephContext *_cct)
-      : RGWHTTPClient(_cct) {
+  RGW_Auth_S3_Keystone_ValidateToken(CephContext *_cct) :
+          RGWHTTPClient(_cct),
+          response(KeystoneToken(_cct->_conf->rgw_keystone_api_version)) {
     get_str_list(cct->_conf->rgw_keystone_accepted_roles, roles_list);
   }
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -9,6 +9,7 @@
 #include "rgw_cors_swift.h"
 #include "rgw_formats.h"
 #include "rgw_client_io.h"
+#include "rgw_cms.h"
 
 #include <sstream>
 

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -6,21 +6,18 @@
 #include <unistd.h>
 
 #include "common/ceph_json.h"
+#include "common/ceph_crypto_cms.h"
 #include "rgw_common.h"
 #include "rgw_swift.h"
 #include "rgw_swift_auth.h"
 #include "rgw_user.h"
 #include "rgw_http_client.h"
 #include "rgw_keystone.h"
+#include "rgw_cms.h"
 
 #include "include/str_list.h"
 
-#include "common/ceph_crypto_cms.h"
-#include "common/armor.h"
-
 #define dout_subsys ceph_subsys_rgw
-
-static list<string> roles_list;
 
 class RGWValidateSwiftToken : public RGWHTTPClient {
   struct rgw_swift_auth_info *info;
@@ -107,301 +104,11 @@ int RGWSwift::validate_token(const char *token, struct rgw_swift_auth_info *info
   return 0;
 }
 
-class RGWPostHTTPData : public RGWHTTPClient {
-  bufferlist *bl;
-  std::string post_data;
-  size_t post_data_index;
-public:
-  RGWPostHTTPData(CephContext *_cct, bufferlist *_bl) : RGWHTTPClient(_cct), bl(_bl), post_data_index(0) {}
-
-  void set_post_data(const std::string& _post_data) {
-    this->post_data = _post_data;
-  }
-
-  int send_data(void* ptr, size_t len) {
-    int length_to_copy = 0;
-    if (post_data_index < post_data.length()) {
-      length_to_copy = min(post_data.length() - post_data_index, len);
-      memcpy(ptr, post_data.data() + post_data_index, length_to_copy);
-      post_data_index += length_to_copy;
-    }
-    return length_to_copy;
-  }
-
-  int receive_data(void *ptr, size_t len) {
-    bl->append((char *)ptr, len);
-    return 0;
-  }
-
-  int receive_header(void *ptr, size_t len) {
-    return 0;
-  }
-};
-
-typedef RGWPostHTTPData RGWGetKeystoneAdminToken;
-typedef RGWPostHTTPData RGWGetRevokedTokens;
-
-class RGWValidateKeystoneToken : public RGWHTTPClient {
-  bufferlist *bl;
-public:
-  RGWValidateKeystoneToken(CephContext *_cct, bufferlist *_bl) : RGWHTTPClient(_cct), bl(_bl) {}
-
-  int receive_data(void *ptr, size_t len) {
-    bl->append((char *)ptr, len);
-    return 0;
-  }
-  int receive_header(void *ptr, size_t len) {
-    return 0;
-  }
-  int send_data(void *ptr, size_t len) {
-    return 0;
-  }
-
-};
-
-static RGWKeystoneTokenCache *keystone_token_cache = NULL;
-
-static int open_cms_envelope(CephContext *cct, string& src, string& dst)
-{
-#define BEGIN_CMS "-----BEGIN CMS-----"
-#define END_CMS "-----END CMS-----"
-
-  int start = src.find(BEGIN_CMS);
-  if (start < 0) {
-    ldout(cct, 0) << "failed to find " << BEGIN_CMS << " in response" << dendl;
-    return -EINVAL;
-  }
-  start += sizeof(BEGIN_CMS) - 1;
-
-  int end = src.find(END_CMS);
-  if (end < 0) {
-    ldout(cct, 0) << "failed to find " << END_CMS << " in response" << dendl;
-    return -EINVAL;
-  }
-
-  string s = src.substr(start, end - start);
-
-  int pos = 0;
-
-  do {
-    int next = s.find('\n', pos);
-    if (next < 0) {
-      dst.append(s.substr(pos));
-      break;
-    } else {
-      dst.append(s.substr(pos, next - pos));
-    }
-    pos = next + 1;
-  } while (pos < (int)s.size());
-
-  return 0;
-}
-
-static int decode_b64_cms(CephContext *cct, const string& signed_b64, bufferlist& bl)
-{
-  bufferptr signed_ber(signed_b64.size() * 2);
-  char *dest = signed_ber.c_str();
-  const char *src = signed_b64.c_str();
-  size_t len = signed_b64.size();
-  char buf[len + 1];
-  buf[len] = '\0';
-  for (size_t i = 0; i < len; i++, src++) {
-    if (*src != '-')
-      buf[i] = *src;
-    else
-      buf[i] = '/';
-  }
-  int ret = ceph_unarmor(dest, dest + signed_ber.length(), buf, buf + signed_b64.size());
-  if (ret < 0) {
-    ldout(cct, 0) << "ceph_unarmor() failed, ret=" << ret << dendl;
-    return ret;
-  }
-
-  bufferlist signed_ber_bl;
-  signed_ber_bl.append(signed_ber);
-
-  ret = ceph_decode_cms(cct, signed_ber_bl, bl);
-  if (ret < 0) {
-    ldout(cct, 0) << "ceph_decode_cms returned " << ret << dendl;
-    return ret;
-  }
-
-  return 0;
-}
-
-int	RGWSwift::get_keystone_url(std::string& url)
-{
-  bufferlist bl;
-  RGWGetRevokedTokens req(cct, &bl);
-
-  url = cct->_conf->rgw_keystone_url;
-  if (url.empty()) {
-    ldout(cct, 0) << "ERROR: keystone url is not configured" << dendl;
-    return -EINVAL;
-  }
-  if (url[url.size() - 1] != '/')
-    url.append("/");
-  return 0;
-}
-
-int	RGWSwift::get_keystone_admin_token(std::string& token)
-{
-  std::string token_url;
-
-  if (get_keystone_url(token_url) < 0)
-    return -EINVAL;
-  if (cct->_conf->rgw_keystone_admin_token.empty()) {
-    token_url.append("v2.0/tokens");
-    KeystoneToken t;
-    bufferlist token_bl;
-    RGWGetKeystoneAdminToken token_req(cct, &token_bl);
-    token_req.append_header("Content-Type", "application/json");
-    JSONFormatter jf;
-    jf.open_object_section("token_request");
-    jf.open_object_section("auth");
-    jf.open_object_section("passwordCredentials");
-    encode_json("username", cct->_conf->rgw_keystone_admin_user, &jf);
-    encode_json("password", cct->_conf->rgw_keystone_admin_password, &jf);
-    jf.close_section();
-    encode_json("tenantName", cct->_conf->rgw_keystone_admin_tenant, &jf);
-    jf.close_section();
-    jf.close_section();
-    std::stringstream ss;
-    jf.flush(ss);
-    token_req.set_post_data(ss.str());
-    token_req.set_send_length(ss.str().length());
-    int ret = token_req.process("POST", token_url.c_str());
-    if (ret < 0)
-      return ret;
-    if (t.parse(cct, token_bl) != 0)
-      return -EINVAL;
-    token = t.token.id;
-  } else {
-    token = cct->_conf->rgw_keystone_admin_token;
-  }
-  return 0; 
-}
-
-
-int RGWSwift::check_revoked()
-{
-  string url;
-  string token;
-
-  bufferlist bl;
-  RGWGetRevokedTokens req(cct, &bl);
-
-  if (get_keystone_admin_token(token) < 0)
-    return -EINVAL;
-  if (get_keystone_url(url) < 0)
-    return -EINVAL;
-  url.append("v2.0/tokens/revoked");
-  req.append_header("X-Auth-Token", token);
-  req.set_send_length(0);
-  int ret = req.process(url.c_str());
-  if (ret < 0)
-    return ret;
-
-  bl.append((char)0); // NULL terminate for debug output
-
-  ldout(cct, 10) << "request returned " << bl.c_str() << dendl;
-
-  JSONParser parser;
-
-  if (!parser.parse(bl.c_str(), bl.length())) {
-    ldout(cct, 0) << "malformed json" << dendl;
-    return -EINVAL;
-  }
-
-  JSONObjIter iter = parser.find_first("signed");
-  if (iter.end()) {
-    ldout(cct, 0) << "revoked tokens response is missing signed section" << dendl;
-    return -EINVAL;
-  }  
-
-  JSONObj *signed_obj = *iter;
-
-  string signed_str = signed_obj->get_data();
-
-  ldout(cct, 10) << "signed=" << signed_str << dendl;
-
-  string signed_b64;
-  ret = open_cms_envelope(cct, signed_str, signed_b64);
-  if (ret < 0)
-    return ret;
-
-  ldout(cct, 10) << "content=" << signed_b64 << dendl;
-  
-  bufferlist json;
-  ret = decode_b64_cms(cct, signed_b64, json);
-  if (ret < 0) {
-    return ret;
-  }
-
-  ldout(cct, 10) << "ceph_decode_cms: decoded: " << json.c_str() << dendl;
-
-  JSONParser list_parser;
-  if (!list_parser.parse(json.c_str(), json.length())) {
-    ldout(cct, 0) << "malformed json" << dendl;
-    return -EINVAL;
-  }
-
-  JSONObjIter revoked_iter = list_parser.find_first("revoked");
-  if (revoked_iter.end()) {
-    ldout(cct, 0) << "no revoked section in json" << dendl;
-    return -EINVAL;
-  }
-
-  JSONObj *revoked_obj = *revoked_iter;
-
-  JSONObjIter tokens_iter = revoked_obj->find_first();
-  for (; !tokens_iter.end(); ++tokens_iter) {
-    JSONObj *o = *tokens_iter;
-
-    JSONObj *token = o->find_obj("id");
-    if (!token) {
-      ldout(cct, 0) << "bad token in array, missing id" << dendl;
-      continue;
-    }
-
-    string token_id = token->get_data();
-    keystone_token_cache->invalidate(token_id);
-  }
-  
-  return 0;
-}
-
 static void rgw_set_keystone_token_auth_info(KeystoneToken& token, struct rgw_swift_auth_info *info)
 {
-  info->user = token.token.tenant.id;
-  info->display_name = token.token.tenant.name;
+  info->user = token.get_project_id();
+  info->display_name = token.get_project_name();
   info->status = 200;
-}
-
-int RGWSwift::parse_keystone_token_response(const string& token, bufferlist& bl, struct rgw_swift_auth_info *info, KeystoneToken& t)
-{
-  int ret = t.parse(cct, bl);
-  if (ret < 0)
-    return ret;
-
-  bool found = false;
-  list<string>::iterator iter;
-  for (iter = roles_list.begin(); iter != roles_list.end(); ++iter) {
-    const string& role = *iter;
-    if ((found=t.user.has_role(role))==true)
-      break;
-  }
-
-  if (!found) {
-    ldout(cct, 0) << "user does not hold a matching role; required roles: " << g_conf->rgw_keystone_accepted_roles << dendl;
-    return -EPERM;
-  }
-
-  ldout(cct, 0) << "validated token: " << t.token.tenant.name << ":" << t.user.name << " expires: " << t.token.expires << dendl;
-
-  rgw_set_keystone_token_auth_info(t, info);
-
-  return 0;
 }
 
 int RGWSwift::update_user_info(RGWRados *store, struct rgw_swift_auth_info *info, RGWUserInfo& user_info)
@@ -420,118 +127,17 @@ int RGWSwift::update_user_info(RGWRados *store, struct rgw_swift_auth_info *info
   return 0;
 }
 
-#define PKI_ANS1_PREFIX "MII"
-
-static bool is_pki_token(const string& token)
-{
-  return token.compare(0, sizeof(PKI_ANS1_PREFIX) - 1, PKI_ANS1_PREFIX) == 0;
-}
-
-static void get_token_id(const string& token, string& token_id)
-{
-  if (!is_pki_token(token)) {
-    token_id = token;
-    return;
-  }
-
-  unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
-
-  MD5 hash;
-  hash.Update((const byte *)token.c_str(), token.size());
-  hash.Final(m);
-
-
-  char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
-  buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
-  token_id = calc_md5;
-}
-
-static bool decode_pki_token(CephContext *cct, const string& token, bufferlist& bl)
-{
-  if (!is_pki_token(token))
-    return false;
-
-  int ret = decode_b64_cms(cct, token, bl);
-  if (ret < 0)
-    return false;
-
-  ldout(cct, 20) << "successfully decoded pki token" << dendl;
-
-  return true;
-}
-
 int RGWSwift::validate_keystone_token(RGWRados *store, const string& token, struct rgw_swift_auth_info *info,
 				      RGWUserInfo& rgw_user)
 {
-  KeystoneToken t;
+  KeystoneToken t = KeystoneToken(g_conf->rgw_keystone_api_version);
 
-  string token_id;
-  get_token_id(token, token_id);
-
-  ldout(cct, 20) << "token_id=" << token_id << dendl;
-
-  /* check cache first */
-  if (keystone_token_cache->find(token_id, t)) {
-    rgw_set_keystone_token_auth_info(t, info);
-
-    ldout(cct, 20) << "cached token.tenant.id=" << t.token.tenant.id << dendl;
-
-    int ret = update_user_info(store, info, rgw_user);
-    if (ret < 0)
-      return ret;
-
-    return 0;
-  }
-
-  bufferlist bl;
-
-  /* check if that's a self signed token that we can decode */
-  if (!decode_pki_token(cct, token, bl)) {
-
-    /* can't decode, just go to the keystone server for validation */
-
-    RGWValidateKeystoneToken validate(cct, &bl);
-
-    string url = g_conf->rgw_keystone_url;
-    if (url.empty()) {
-      ldout(cct, 0) << "ERROR: keystone url is not configured" << dendl;
-      return -EINVAL;
-    }
-    if (url[url.size() - 1] != '/')
-      url.append("/");
-    std::string admin_token;
-    if (get_keystone_admin_token(admin_token) < 0)
-      return -EINVAL;
-    if (get_keystone_url(url) < 0)
-      return -EINVAL;
-
-    url.append("v2.0/tokens/");
-    url.append(token);
-
-    validate.append_header("X-Auth-Token", admin_token);
-
-    validate.set_send_length(0);
-
-    int ret = validate.process(url.c_str());
-    if (ret < 0)
-      return ret;
-  }
-
-  bl.append((char)0); // NULL terminate for debug output
-
-  ldout(cct, 20) << "received response: " << bl.c_str() << dendl;
-
-  int ret = parse_keystone_token_response(token, bl, info, t);
-  if (ret < 0)
+  int ret = keystone->validate_token(token, t);
+  if (ret < 0) {
     return ret;
-
-  if (t.expired()) {
-    ldout(cct, 0) << "got expired token: " << t.token.tenant.name << ":" << t.user.name << " expired: " << t.token.expires << dendl;
-    return -EPERM;
   }
 
-  keystone_token_cache->add(token_id, t);
-
+  rgw_set_keystone_token_auth_info(t, info);
   ret = update_user_info(store, info, rgw_user);
   if (ret < 0)
     return ret;
@@ -670,7 +276,7 @@ bool RGWSwift::do_verify_swift_token(RGWRados *store, req_state *s)
 
   int ret;
 
-  if (supports_keystone()) {
+  if (keystone->enabled()) {
     ret = validate_keystone_token(store, s->os_auth_token, &info, s->user);
     return (ret >= 0);
   }
@@ -701,82 +307,16 @@ bool RGWSwift::do_verify_swift_token(RGWRados *store, req_state *s)
   return true;
 }
 
-void RGWSwift::init()
-{
-  get_str_list(cct->_conf->rgw_keystone_accepted_roles, roles_list);
-  if (supports_keystone())
-      init_keystone();
-}
-
-
-void RGWSwift::init_keystone()
-{
-  keystone_token_cache = new RGWKeystoneTokenCache(cct, cct->_conf->rgw_keystone_token_cache_size);
-
-  keystone_revoke_thread = new KeystoneRevokeThread(cct, this);
-  keystone_revoke_thread->create();
-}
-
-
-void RGWSwift::finalize()
-{
-  if (supports_keystone())
-    finalize_keystone();
-}
-
-void RGWSwift::finalize_keystone()
-{
-  delete keystone_token_cache;
-  keystone_token_cache = NULL;
-
-  down_flag.set(1);
-  if (keystone_revoke_thread) {
-    keystone_revoke_thread->stop();
-    keystone_revoke_thread->join();
-  }
-  delete keystone_revoke_thread;
-  keystone_revoke_thread = NULL;
-}
-
+Keystone *rgw_keystone = NULL;
 RGWSwift *rgw_swift = NULL;
 
 void swift_init(CephContext *cct)
 {
-  rgw_swift = new RGWSwift(cct);
+  rgw_keystone = new Keystone(cct);
+  rgw_swift = new RGWSwift(cct, rgw_keystone);
 }
 
 void swift_finalize()
 {
-  delete rgw_swift;
+  delete rgw_keystone;
 }
-
-bool RGWSwift::going_down()
-{
-  return (down_flag.read() != 0);
-}
-
-void *RGWSwift::KeystoneRevokeThread::entry() {
-  do {
-    dout(2) << "keystone revoke thread: start" << dendl;
-    int r = swift->check_revoked();
-    if (r < 0) {
-      dout(0) << "ERROR: keystone revocation processing returned error r=" << r << dendl;
-    }
-
-    if (swift->going_down())
-      break;
-
-    lock.Lock();
-    cond.WaitInterval(cct, lock, utime_t(cct->_conf->rgw_keystone_revocation_interval, 0));
-    lock.Unlock();
-  } while (!swift->going_down());
-
-  return NULL;
-}
-
-void RGWSwift::KeystoneRevokeThread::stop()
-{
-  Mutex::Locker l(lock);
-  cond.Signal();
-}
-

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -7,9 +7,9 @@
 
 #include "rgw_common.h"
 #include "common/Cond.h"
+#include "rgw_keystone.h"
 
 class RGWRados;
-class KeystoneToken;
 
 struct rgw_swift_auth_info {
   int status;
@@ -23,53 +23,20 @@ struct rgw_swift_auth_info {
 
 class RGWSwift {
   CephContext *cct;
-  atomic_t down_flag;
+  Keystone *keystone;
 
   int validate_token(const char *token, struct rgw_swift_auth_info *info);
   int validate_keystone_token(RGWRados *store, const string& token, struct rgw_swift_auth_info *info,
 			      RGWUserInfo& rgw_user);
 
-  int parse_keystone_token_response(const string& token, bufferlist& bl, struct rgw_swift_auth_info *info,
-		                    KeystoneToken& t);
   int update_user_info(RGWRados *store, struct rgw_swift_auth_info *info, RGWUserInfo& user_info);
-  int get_keystone_url(std::string& url);
-  int get_keystone_admin_token(std::string& token);
 
-  class KeystoneRevokeThread : public Thread {
-    CephContext *cct;
-    RGWSwift *swift;
-    Mutex lock;
-    Cond cond;
-
-  public:
-    KeystoneRevokeThread(CephContext *_cct, RGWSwift *_swift) : cct(_cct), swift(_swift), lock("KeystoneRevokeThread") {}
-    void *entry();
-    void stop();
-  };
-
-  KeystoneRevokeThread *keystone_revoke_thread;
-
-  void init();
-  void finalize();
-  void init_keystone();
-  void finalize_keystone();
-  bool supports_keystone() {
-    return !cct->_conf->rgw_keystone_url.empty();
-  }
   bool do_verify_swift_token(RGWRados *store, req_state *s);
-protected:
-  int check_revoked();
 public:
 
-  RGWSwift(CephContext *_cct) : cct(_cct), keystone_revoke_thread(NULL) {
-    init();
-  }
-  ~RGWSwift() {
-    finalize();
-  }
+  RGWSwift(CephContext *_cct, Keystone *_keystone) : cct(_cct), keystone(_keystone) { }
 
   bool verify_swift_token(RGWRados *store, req_state *s);
-  bool going_down();
 };
 
 extern RGWSwift *rgw_swift;


### PR DESCRIPTION
We've improved the current rgw to support authv3 using keystone.

Rather than introduce a factory and inheritance of the keystone token structure, the token now accommodates both formats and the parser populates the relevant structure dependent on the version of the API and then normalises it to the v3 layout, which uses project rather than tenant. 

As for documentation there are new options in ceph.conf

rgw keystone api version = \[ 2.0 / 3 \] ( default = 2.0 )

For admin authentication without a token, the following is required

rgw keystone admin domain = acme.org
rgw keystone admin project = project_name