### PR TITLE
fix compile warning

### DIFF
--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -32,7 +32,7 @@
 struct osd_reqid_t {
   entity_name_t name; // who
   ceph_tid_t         tid;
-  int32_t       inc;  // incarnation
+  uint32_t       inc;  // incarnation
 
   osd_reqid_t()
     : tid(0), inc(0) {}


### PR DESCRIPTION
…-Wsign-compare]

./messages/MOSDOp.h:102:22: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  assert(reqid.inc == client_inc);  // decode() should have done this

Signed-off-by: xinxin shu <xinxin.shu@intel.com>