### PR TITLE
os/chain_xattr: On linux use linux/limits.h for XATTR_NAME_MAX.

### DIFF
--- a/src/os/chain_xattr.h
+++ b/src/os/chain_xattr.h
@@ -9,7 +9,7 @@
 #include <errno.h>
 
 #if defined(__linux__)
-#include <limits.h>
+#include <linux/limits.h>
 #define CHAIN_XATTR_MAX_NAME_LEN ((XATTR_NAME_MAX + 1) / 2)
 #elif defined(__APPLE__)
 #include <sys/xattr.h>


### PR DESCRIPTION
Was failing with:

/build/ceph/src/test/objectstore/chain_xattr.cc: In member function 'virtual void chain_xattr_get_and_set_Test::TestBody()':
/build/ceph/src/test/objectstore/chain_xattr.cc:41:41: error: 'XATTR_NAME_MAX' was not declared in this scope
     const string name = user + string(CHAIN_XATTR_MAX_NAME_LEN - user.size(), '@');
                                         ^
/build/ceph/src/test/objectstore/chain_xattr.cc:83:41: error: 'XATTR_NAME_MAX' was not declared in this scope
     const string name = user + string(CHAIN_XATTR_MAX_NAME_LEN - user.size(), '@');