### PR TITLE
ReplicatedPG:  result code not correctly set in some cases.

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -5050,7 +5050,7 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	newop.op.op = CEPH_OSD_OP_SYNC_READ;
 	newop.op.extent.offset = 0;
 	newop.op.extent.length = 0;
-	do_osd_ops(ctx, nops);
+	result = do_osd_ops(ctx, nops);
 	osd_op.outdata.claim(newop.outdata);
       }
       break;
@@ -5109,7 +5109,8 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  ::encode(m, newbl);
 	  newop.indata = newbl;
 	}
-	do_osd_ops(ctx, nops);
+	result = do_osd_ops(ctx, nops);
+	assert(result == 0);
       }
       break;
 
@@ -5216,7 +5217,9 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
       }
       ++ctx->num_read;
       {
-	osd->store->omap_get_header(coll, ghobject_t(soid), &osd_op.outdata);
+	result = osd->store->omap_get_header(coll, ghobject_t(soid), &osd_op.outdata);
+	if (result < 0)
+	  break;
 	ctx->delta_stats.num_rd_kb += SHIFT_ROUND_UP(osd_op.outdata.length(), 10);
 	ctx->delta_stats.num_rd++;
       }
@@ -5237,7 +5240,9 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	tracepoint(osd, do_osd_op_pre_omapgetvalsbykeys, soid.oid.name.c_str(), soid.snap.val, list_entries(keys_to_get).c_str());
 	map<string, bufferlist> out;
 	if (pool.info.supports_omap()) {
-	  osd->store->omap_get_values(coll, ghobject_t(soid), keys_to_get, &out);
+	  result = osd->store->omap_get_values(coll, ghobject_t(soid), keys_to_get, &out);
+	  if (result < 0)
+	    break;
 	} // else return empty omap entries
 	::encode(out, osd_op.outdata);
 	ctx->delta_stats.num_rd_kb += SHIFT_ROUND_UP(osd_op.outdata.length(), 10);
@@ -5272,12 +5277,10 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	       i != assertions.end();
 	       ++i)
 	    to_get.insert(i->first);
-	  int r = osd->store->omap_get_values(coll, ghobject_t(soid),
+	  result = osd->store->omap_get_values(coll, ghobject_t(soid),
 					      to_get, &out);
-	  if (r < 0) {
-	    result = r;
+	  if (result < 0)
 	    break;
-	  }
 	} // else leave out empty
 
 	//Should set num_rd_kb based on encode length of map


### PR DESCRIPTION
In ReplicatedPG::do_osd_ops(), the result code is not correctly set in some cases and may mislead caller.
Fixes: #13566
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>