### PR TITLE
Seg fault 9.0.3-1845-gf1ead76 : RGWRESTSimpleRequest::forward_request(RGWAccessKey&, req_info&, unsigned long, ceph::buffer::list*, ceph::buffer::list*)+0x74) 

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -111,6 +111,7 @@ req_info::req_info(CephContext *cct, class RGWEnv *e) : env(e) {
   }
   host = env->get("HTTP_HOST", "");
 
+
   // strip off any trailing :port from host (added by CrossFTP and maybe others)
   size_t colon_offset = host.find_last_of(':');
   if (colon_offset != string::npos) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/13537