### PR TITLE
Drop redhat-lsb-core dependency

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -227,9 +227,6 @@ Requires:	python-requests
 %if 0%{?_with_systemd}
 %{?systemd_requires}
 %endif
-%if 0%{?rhel} || 0%{?fedora}
-Requires:	redhat-lsb-core
-%endif
 %if 0%{?suse_version}
 Requires(pre):	pwdutils
 %endif

--- a/src/init-rbdmap
+++ b/src/init-rbdmap
@@ -20,7 +20,9 @@
 
 RBDMAPFILE="/etc/ceph/rbdmap"
 
-. /lib/lsb/init-functions
+if [ -e /lib/lsb/init-functions ]; then
+    . /lib/lsb/init-functions
+fi
 
 do_map() {
 	if [ ! -f "$RBDMAPFILE" ]; then

--- a/src/init-rbdmap
+++ b/src/init-rbdmap
@@ -18,14 +18,13 @@
 # Description:       Ceph RBD Mapping
 ### END INIT INFO
 
-DESC="RBD Mapping:"
 RBDMAPFILE="/etc/ceph/rbdmap"
 
 . /lib/lsb/init-functions
 
 do_map() {
 	if [ ! -f "$RBDMAPFILE" ]; then
-		log_warning_msg "$DESC : No $RBDMAPFILE found."
+		logger -p "daemon.warning" -t init-rbdmap "No $RBDMAPFILE found."
 		exit 0
 	fi
 
@@ -42,37 +41,39 @@ do_map() {
 			DEV=rbd/$DEV
 			;;
 		esac
-		log_action_begin_msg "${DESC} '${DEV}'"
+		logger -p "daemon.debug" -t init-rbdmap "Mapping '${DEV}'"
 		newrbd=""
 		MAP_RV=""
-		RET_OP=0
 		OIFS=$IFS
 		IFS=','
 		for PARAM in ${PARAMS[@]}; do
 			CMDPARAMS="$CMDPARAMS --$(echo $PARAM | tr '=' ' ')"
 		done
 		IFS=$OIFS
-		if [ ! -b /dev/rbd/$DEV ]; then
-			MAP_RV=$(rbd map $DEV $CMDPARAMS 2>&1)
+		if [ -b /dev/rbd/$DEV ]; then
+			MAP_RV="$(readlink -f /dev/rbd/$DEV)"
+		else
+			MAP_RV="$(rbd map $DEV $CMDPARAMS 2>&1)"
 			if [ $? -eq 0 ]; then
 			    newrbd="yes"
 			else
 			    RET=$((${RET}+$?))
-			    RET_OP=1
+			    logger -p "daemon.warning" -t init-rbdmap "Failed to map '${DEV}"
+			    continue
 			fi
 		fi
-		log_action_end_msg ${RET_OP} "${MAP_RV}"
+		logger -p "daemon.debug" -t init-rbdmap "Mapped '${DEV}' to '${MAP_RV}'"
 
 		if [ "$newrbd" ]; then
 			## Mount new rbd
 			MNT_RV=""
 			mount --fake /dev/rbd/$DEV >>/dev/null 2>&1 \
 			&& MNT_RV=$(mount -vn /dev/rbd/$DEV 2>&1)
-			[ -n "${MNT_RV}" ] && log_action_msg "mount: ${MNT_RV}"
+			[ -n "${MNT_RV}" ] && logger -p "daemon.debug" -t init-rbdmap "Mounted '${MAP_RV}' to '${MNT_RV}'"
 
 			## post-mapping
 			if [ -x "/etc/ceph/rbd.d/${DEV}" ]; then
-			    log_action_msg "RBD Running post-map hook '/etc/ceph/rbd.d/${DEV}'"
+			    logger -p "daemon.debug" -t init-rbdmap "Running post-map hook '/etc/ceph/rbd.d/${DEV}'"
 			    /etc/ceph/rbd.d/${DEV} map "/dev/rbd/${DEV}"
 			fi
 		fi
@@ -91,35 +92,32 @@ do_unmap() {
 			    LL="${L##/dev/rbd/}"
 			    if [ "$(readlink -f $L)" = "${DEV}" ] \
 			    && [ -x "/etc/ceph/rbd.d/${LL}" ]; then
-			        log_action_msg "RBD pre-unmap:  '${DEV}' hook '/etc/ceph/rbd.d/${LL}'"
+			        logger -p "daemon.debug" -t init-rbdmap "Running pre-unmap hook for '${DEV}': '/etc/ceph/rbd.d/${LL}'"
 			        /etc/ceph/rbd.d/${LL} unmap "$L"
 			        break
 			    fi
 			done
 
-			log_action_begin_msg "RBD un-mapping: '${DEV}'"
-			UMNT_RV=""
-			UMAP_RV=""
-			RET_OP=0
+			logger -p "daemon.debug" -t init-rbdmap "Unmapping '${DEV}'"
 			MNT=$(findmnt --mtab --source ${DEV} --noheadings | awk '{print $1'})
 			if [ -n "${MNT}" ]; then
-			    log_action_cont_msg "un-mounting '${MNT}'"
-			    UMNT_RV=$(umount "${MNT}" 2>&1)
+			    logger -p "daemon.debug" -t init-rbdmap "Unmounting '${MNT}'"
+			    umount "${MNT}" >>/dev/null 2>&1
 			fi
 			if mountpoint -q "${MNT}"; then
 			    ## Un-mounting failed.
-			    RET_OP=1
+			    logger -p "daemon.warning" -t init-rbdmap "Failed to unmount '${MNT}'"
 			    RET=$((${RET}+1))
-			else
-			    ## Un-mapping.
-			    UMAP_RV=$(rbd unmap $DEV 2>&1)
-			    if [ $? -ne 0 ]; then
-			        RET=$((${RET}+$?))
-			        RET_OP=1
-			    fi
+			    continue
 			fi
-			log_action_end_msg ${RET_OP} "${UMAP_RV}"
-			[ -n "${UMNT_RV}" ] && log_action_msg "${UMNT_RV}"
+			## Un-mapping.
+			rbd unmap $DEV >>/dev/null 2>&1
+			if [ $? -ne 0 ]; then
+			    logger -p "daemon.warning" -t init-rbdmap "Failed to unmap '${MNT}'"
+			    RET=$((${RET}+$?))
+			    continue
+			fi
+			logger -p "daemon.debug" -t init-rbdmap "Unmapped '${DEV}'"
 		done
 	fi
 	exit ${RET}
@@ -149,7 +147,7 @@ case "$1" in
 	;;
 
   *)
-	log_success_msg "Usage: rbdmap {start|stop|restart|force-reload|reload|status}"
+	echo "Usage: rbdmap {start|stop|restart|force-reload|reload|status}"
 	exit 1
 	;;
 esac


### PR DESCRIPTION
The first patch rewrites the init-rbdmap init script so that it uses logger
instead of the log_* functions. The patch also fixes various smaller
bugs like:
* MAP_RV was undefined if mapping already existed
* UMNT_RV and UMAP_RV were almost always empty (if they succeeded) ->
  removed them
* use of continue instead RET_OP in various places (RET_OP was not being
  checked after the switch to logger messages)
* removed use of DESC (used only twice and only one occurrence actually
  made sense)


The second patch drops the redhat-lsb-core dependency as it is no longer necessary on
fedora/rhel.

The other two init scripts do not use redhat-lsb-core. The
init-ceph.in conditionally requires /lib/lsb/init-functions and does not
use any of the functions defined in that file (at least not directly).
The init-radosgw file includes /etc/rc.d/init.d/functions on non-debian
platforms instead of /lib/lsb/init-functions file so it does not require
redhat-lsb-core either.
