### PR TITLE
osd: fix OSDService vs Objecter init order

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -480,11 +480,15 @@ void OSDService::init()
   reserver_finisher.start();
   objecter_finisher.start();
   objecter->set_client_incarnation(0);
-  objecter->start();
   watch_timer.init();
   agent_timer.init();
 
   agent_thread.create();
+}
+
+void OSDService::final_init()
+{
+  objecter->start();
 }
 
 void OSDService::activate_map()
@@ -1929,6 +1933,10 @@ int OSD::init()
     tick_timer_without_osd_lock.add_event_after(cct->_conf->osd_heartbeat_interval, new C_Tick_WithoutOSDLock(this));
   }
 
+  service.init();
+  service.publish_map(osdmap);
+  service.publish_superblock(superblock);
+
   osd_lock.Unlock();
 
   r = monc->authenticate();
@@ -1947,9 +1955,9 @@ int OSD::init()
   if (is_stopping())
     return 0;
 
-  service.init();
-  service.publish_map(osdmap);
-  service.publish_superblock(superblock);
+  // start objecter *after* we have authenticated, so that we don't ignore
+  // the OSDMaps it requests.
+  service.final_init();
 
   check_config();
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -881,6 +881,7 @@ public:
   void pg_stat_queue_dequeue(PG *pg);
 
   void init();
+  void final_init();  
   void start_shutdown();
   void shutdown();
 


### PR DESCRIPTION
This reverts c7d96a5ed1d2cb844622af29b13705b8f7be6be7, but still keeps
the Objecter init *after* we have authenticated.  This way we don't
crash when we get mon messages like MOSDPGCreate, and we also don't
request maps we aren't prepared to handle.

Signed-off-by: Sage Weil <sage@redhat.com>