### PR TITLE
osd: check OSDSuperblock in mkfs() when it already have superblock

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1347,7 +1347,11 @@ int OSD::mkfs(CephContext *cct, ObjectStore *store, const string &dev,
     bufferlist sbbl;
     ret = store->read(coll_t::meta(), OSD_SUPERBLOCK_POBJECT, 0, 0, sbbl);
     if (ret >= 0) {
+      /* if we already have superblock, check content of superblock */
       dout(0) << " have superblock" << dendl;
+      bufferlist::iterator p;
+      p = sbbl.begin();
+      ::decode(sb, p);
       if (whoami != sb.whoami) {
 	derr << "provided osd id " << whoami << " != superblock's " << sb.whoami << dendl;
 	ret = -EINVAL;


### PR DESCRIPTION
ref: http://tracker.ceph.com/issues/13586#note-1

    When we remove the ready flag from osd directory, it will execute mkfs again.
    It will read superblock but can not check osd id and cluster fsid correctly.

    It need to decode the superblock that we read from osd.
    It will always failure now, so I modify it for read osd id and fsid correctly.

If you have any questions, feel free to let me know.
Thanks!

Signed-off-by: Vicente Cheng <freeze.bilsted@gmail.com>