### PR TITLE
osd: memory fragment for transaction encoding

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -265,7 +265,8 @@ public:
     std::list<ptr> _buffers;
     unsigned _len;
     unsigned _memcopy_count; //the total of memcopy using rebuild().
-    ptr append_buffer;  // where i put small appends.
+    ptr* append_buffer;  // where i put small appends.
+    bool outer_buf;  // whether the append_buffer is outer one
 
     template <bool is_const>
     class iterator_impl: public std::iterator<std::forward_iterator_tag, char> {
@@ -362,14 +363,22 @@ public:
 
   public:
     // cons/des
-    list() : _len(0), _memcopy_count(0), last_p(this) {}
+    list() : _len(0), _memcopy_count(0), append_buffer(NULL), outer_buf(false), last_p(this) {}
     list(unsigned prealloc) : _len(0), _memcopy_count(0), last_p(this) {
-      append_buffer = buffer::create(prealloc);
-      append_buffer.set_length(0);   // unused, so far.
+      append_buffer = new ptr(buffer::create(prealloc));
+      append_buffer->set_length(0);   // unused, so far.
+      outer_buf = false;
+    }
+    ~list() {
+      if (!outer_buf && append_buffer) {
+        delete append_buffer;
+        append_buffer = NULL;
+      }
     }
 
     list(const list& other) : _buffers(other._buffers), _len(other._len),
-			      _memcopy_count(other._memcopy_count), last_p(this) {
+			      _memcopy_count(other._memcopy_count),
+                              append_buffer(NULL), outer_buf(false), last_p(this) {
       make_shareable();
     }
     list(list&& other);
@@ -380,6 +389,17 @@ public:
 	make_shareable();
       }
       return *this;
+    }
+
+    void set_append_buffer(ptr* bp) {
+      if (bp == NULL) {
+        return;
+      }
+      if (!outer_buf && append_buffer) {
+        delete append_buffer;
+      }
+      outer_buf = true;
+      append_buffer = bp;
     }
 
     unsigned get_memcopy_count() const {return _memcopy_count; }
@@ -415,6 +435,10 @@ public:
       _buffers.clear();
       _len = 0;
       _memcopy_count = 0;
+      if (!outer_buf && append_buffer) {
+        delete append_buffer;
+        append_buffer = NULL;
+      }
       last_p = begin();
     }
     void push_front(ptr& bp) {

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -24,6 +24,8 @@
 
 using namespace ceph;
 
+const static int CEPH_BUFFERLIST_ENCODING_COPY_SIZE(32);
+
 /*
  * Notes on feature encoding:
  *
@@ -245,7 +247,15 @@ inline void encode(const bufferlist& s, bufferlist& bl)
 {
   __u32 len = s.length();
   encode(len, bl);
-  bl.append(s);
+  if (len <= CEPH_BUFFERLIST_ENCODING_COPY_SIZE) {
+    for (std::list<bufferptr>::const_iterator it = s.buffers().begin();
+         it != s.buffers().end();
+         ++it) {
+      bl.append(it->c_str(), it->length());
+    }
+  } else if (len > 0) {
+    bl.append(s);
+  }
 }
 inline void encode_destructively(bufferlist& s, bufferlist& bl) 
 {

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -452,7 +452,20 @@ public:
     list<Context *> on_commit;
     list<Context *> on_applied_sync;
 
+    bufferptr* trans_buf;
   public:
+     
+     void set_trans_buf(bufferptr* bp) {
+       trans_buf = bp;
+     }
+
+     bufferptr* get_trans_buf() {
+       if (trans_buf == NULL) {
+         trans_buf = new bufferptr(buffer::create_page_aligned(CEPH_PAGE_SIZE));
+         trans_buf->set_length(0);
+       }
+       return trans_buf;
+     }
 
     /* Operations on callback contexts */
     void register_on_applied(Context *c) {
@@ -886,7 +899,7 @@ private:
         op_ptr = bufferptr(sizeof(Op) * OPS_PER_PTR);
       }
       bufferptr ptr(op_ptr, 0, sizeof(Op));
-      op_bl.append(ptr);
+      op_bl.append(ptr, 0, ptr.length());
 
       op_ptr.set_offset(op_ptr.offset() + sizeof(Op));
 
@@ -1583,13 +1596,15 @@ public:
       osr(NULL),
       use_tbl(false),
       coll_id(0),
-      object_id(0) { }
+      object_id(0),
+      trans_buf(NULL) { }
 
     Transaction(bufferlist::iterator &dp) :
       osr(NULL),
       use_tbl(false),
       coll_id(0),
-      object_id(0) {
+      object_id(0),
+      trans_buf(NULL) {
       decode(dp);
     }
 
@@ -1597,9 +1612,15 @@ public:
       osr(NULL),
       use_tbl(false),
       coll_id(0),
-      object_id(0) {
+      object_id(0),
+      trans_buf(NULL) {
       bufferlist::iterator dp = nbl.begin();
       decode(dp);
+    }
+
+    ~Transaction() {
+      delete trans_buf;
+      trans_buf = NULL;
     }
 
     void encode(bufferlist& bl) const {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2703,19 +2703,29 @@ int PG::_prepare_write_info(map<string,bufferlist> *km,
 			    map<epoch_t,pg_interval_t> &past_intervals,
 			    ghobject_t &pgmeta_oid,
 			    bool dirty_big_info,
-			    bool dirty_epoch)
+			    bool dirty_epoch,
+			    ObjectStore::Transaction* t)
 {
   // info.  store purged_snaps separately.
   interval_set<snapid_t> purged_snaps;
-  if (dirty_epoch)
+  if (dirty_epoch) {
+    if (t)
+      (*km)[epoch_key].set_append_buffer(t->get_trans_buf());
     ::encode(epoch, (*km)[epoch_key]);
+  }
+
   purged_snaps.swap(info.purged_snaps);
+  if (t)
+    (*km)[info_key].set_append_buffer(t->get_trans_buf());
   ::encode(info, (*km)[info_key]);
+
   purged_snaps.swap(info.purged_snaps);
 
   if (dirty_big_info) {
     // potentially big stuff
     bufferlist& bigbl = (*km)[biginfo_key];
+    if (t)
+      bigbl.set_append_buffer(t->get_trans_buf());
     ::encode(past_intervals, bigbl);
     ::encode(info.purged_snaps, bigbl);
     //dout(20) << "write_info bigbl " << bigbl.length() << dendl;
@@ -2753,7 +2763,7 @@ void PG::_init(ObjectStore::Transaction& t, spg_t pgid, const pg_pool_t *pool)
   t.omap_setkeys(coll, pgmeta_oid, values);
 }
 
-void PG::prepare_write_info(map<string,bufferlist> *km)
+void PG::prepare_write_info(map<string,bufferlist> *km, ObjectStore::Transaction* t)
 {
   info.stats.stats.add(unstable_stats);
   unstable_stats.clear();
@@ -2761,7 +2771,7 @@ void PG::prepare_write_info(map<string,bufferlist> *km)
   bool need_update_epoch = last_epoch < get_osdmap()->get_epoch();
   int ret = _prepare_write_info(km, get_osdmap()->get_epoch(), info, coll,
 				past_intervals, pgmeta_oid,
-				dirty_big_info, need_update_epoch);
+				dirty_big_info, need_update_epoch, t);
   assert(ret == 0);
   if (need_update_epoch)
     last_epoch = get_osdmap()->get_epoch();
@@ -2874,7 +2884,7 @@ void PG::write_if_dirty(ObjectStore::Transaction& t)
 {
   map<string,bufferlist> km;
   if (dirty_big_info || dirty_info)
-    prepare_write_info(&km);
+    prepare_write_info(&km, &t);
   pg_log.write_log(t, &km, coll, pgmeta_oid, pool.info.require_rollback());
   if (!km.empty())
     t.omap_setkeys(coll, pgmeta_oid, km);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2166,7 +2166,7 @@ public:
 		    spg_t pgid, const pg_pool_t *pool);
 
 private:
-  void prepare_write_info(map<string,bufferlist> *km);
+  void prepare_write_info(map<string,bufferlist> *km, ObjectStore::Transaction* t = NULL);
 
 public:
   static int _prepare_write_info(map<string,bufferlist> *km,
@@ -2175,7 +2175,8 @@ public:
     map<epoch_t,pg_interval_t> &past_intervals,
     ghobject_t &pgmeta_oid,
     bool dirty_big_info,
-    bool dirty_epoch);
+    bool dirty_epoch,
+    ObjectStore::Transaction* t = NULL);
   void write_if_dirty(ObjectStore::Transaction& t);
 
   eversion_t get_next_version() const {

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -460,7 +460,22 @@
      virtual void nop() = 0;
      virtual bool empty() const = 0;
      virtual uint64_t get_bytes_written() const = 0;
-     virtual ~PGTransaction() {}
+     bufferptr* trans_buf;
+
+     PGTransaction() : trans_buf(NULL) {}
+
+     bufferptr* get_trans_buf() {
+       if (trans_buf == NULL) {
+         trans_buf = new bufferptr(buffer::create_page_aligned(CEPH_PAGE_SIZE));
+         trans_buf->set_length(0);
+       }
+       return trans_buf;
+     }
+
+     virtual ~PGTransaction() {
+        delete trans_buf;
+        trans_buf = NULL;
+     }
    };
    /// Get implementation specific empty transaction
    virtual PGTransaction *get_transaction() = 0;
@@ -599,6 +614,7 @@
      coll_t coll,
      ObjectStore *store,
      CephContext *cct);
+
  };
 
 struct PG_SendMessageOnConn: public Context {

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -830,7 +830,8 @@ void PGLog::_write_log(
   for (list<pg_log_entry_t>::iterator p = log.log.begin();
        p != log.log.end() && p->version <= dirty_to;
        ++p) {
-    bufferlist bl(sizeof(*p) * 2);
+    bufferlist bl;
+    bl.set_append_buffer(t.get_trans_buf());
     p->encode_with_checksum(bl);
     (*km)[p->get_key_name()].claim(bl);
   }
@@ -840,7 +841,8 @@ void PGLog::_write_log(
 	 (p->version >= dirty_from || p->version >= writeout_from) &&
 	 p->version >= dirty_to;
        ++p) {
-    bufferlist bl(sizeof(*p) * 2);
+    bufferlist bl;
+    bl.set_append_buffer(t.get_trans_buf());
     p->encode_with_checksum(bl);
     (*km)[p->get_key_name()].claim(bl);
   }
@@ -858,10 +860,13 @@ void PGLog::_write_log(
 
   if (dirty_divergent_priors) {
     //dout(10) << "write_log: writing divergent_priors" << dendl;
+    (*km)["divergent_priors"].set_append_buffer(t.get_trans_buf());
     ::encode(divergent_priors, (*km)["divergent_priors"]);
   }
   if (require_rollback) {
+    (*km)["can_rollback_to"].set_append_buffer(t.get_trans_buf());
     ::encode(log.can_rollback_to, (*km)["can_rollback_to"]);
+    (*km)["rollback_info_trimmed_to"].set_append_buffer(t.get_trans_buf());
     ::encode(log.rollback_info_trimmed_to, (*km)["rollback_info_trimmed_to"]);
   }
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -6428,6 +6428,7 @@ void ReplicatedPG::finish_ctx(OpContext *ctx, int log_op_type, bool maintain_ssc
 
   // snapset
   bufferlist bss;
+  bss.set_append_buffer(ctx->op_t->get_trans_buf());
 
   if (soid.snap == CEPH_NOSNAP && maintain_ssc) {
     ::encode(ctx->new_snapset, bss);
@@ -6495,8 +6496,10 @@ void ReplicatedPG::finish_ctx(OpContext *ctx, int log_op_type, bool maintain_ssc
       ctx->snapset_obc->obs.oi.local_mtime = now;
 
       map<string, bufferlist> attrs;
-      bufferlist bv(sizeof(ctx->new_obs.oi));
+      bufferlist bv;
+      bv.set_append_buffer(ctx->op_t->get_trans_buf());
       ::encode(ctx->snapset_obc->obs.oi, bv);
+
       ctx->op_t->touch(snapoid);
       attrs[OI_ATTR].claim(bv);
       attrs[SS_ATTR].claim(bss);
@@ -6541,7 +6544,8 @@ void ReplicatedPG::finish_ctx(OpContext *ctx, int log_op_type, bool maintain_ssc
     }
 
     map <string, bufferlist> attrs;
-    bufferlist bv(sizeof(ctx->new_obs.oi));
+    bufferlist bv;
+    bv.set_append_buffer(ctx->op_t->get_trans_buf());
     ::encode(ctx->new_obs.oi, bv);
     attrs[OI_ATTR].claim(bv);
 

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2573,6 +2573,24 @@ TEST(BufferList, InvalidateCrc) {
   EXPECT_NE(crc, bl.crc32c(0));
 }
 
+TEST(BufferList, append_buffer) {
+  bufferptr* ptr = new bufferptr(buffer::create_page_aligned(CEPH_PAGE_SIZE));
+  ptr->set_length(0);
+  bufferlist bl;
+  bl.set_append_buffer(ptr);
+  int64_t a = 123, b = 456;
+  ::encode(a, bl);
+  ::encode(b, bl);
+  int64_t c = 0, d = 0;
+  bufferlist::iterator p = bl.begin();
+  ::decode(c, p);
+  ::decode(d, p);
+  assert(a == c);
+  assert(b == d);
+  assert(bl.buffers().front().get_raw() == ptr->get_raw());
+  delete ptr;
+}
+
 TEST(BufferHash, all) {
   {
     bufferlist bl;


### PR DESCRIPTION
now, ceph osd use buferlist for transaction encoding in many places,
But if the bufflist is emtpy, it would create 4k memory even if
it only stores a bit bytes. The memory fragment is inefficient
specially cpu is bottleneck. we use the bufferptr for reusing the memory.

I think the defalut size CEPH_PAGE_SIZE(4K) is enough for most case.

Signed-off-by: Xinze Chi <xinze@xsky.com>