### PR TITLE
AsyncMessenger: Implement slab memory pool per worker

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -562,7 +562,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     uint32_t index;
 
   public:
-    raw_slab(SlabAllocator *slab, unsigned l) : raw(NULL, l) {
+    raw_slab(SlabAllocator *slab, unsigned l) : raw(NULL, l), slab(NULL), index(0) {
       if (slab->create(len, &index, (void**)&data) < 0) {
         throw bad_alloc();
       }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -562,7 +562,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     uint32_t index;
 
   public:
-    raw_slab(SlabAllocator *slab, unsigned l) : raw(NULL, l), slab(NULL), index(0) {
+    raw_slab(SlabAllocator *slab, unsigned l) : raw(NULL, l), slab(slab), index(0) {
       if (slab->create(len, &index, (void**)&data) < 0) {
         throw bad_alloc();
       }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -28,7 +28,7 @@
 #if defined(HAVE_XIO)
 #include "msg/xio/XioMsg.h"
 #endif
-#include "msg/async/SlabAllocator.h"
+#include "msg/async/SlabPool.h"
 
 #include <errno.h>
 #include <fstream>
@@ -563,7 +563,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
 
   public:
     raw_slab(SlabAllocator *slab, unsigned l) : raw(NULL, l) {
-      if (slab->create(len, &index, &data) < 0) {
+      if (slab->create(len, &index, (void**)&data) < 0) {
         throw bad_alloc();
       }
     }
@@ -678,8 +678,8 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     return new raw_unshareable(len);
   }
 
-  buffer::raw* buffer::create_unshareable(SlabAllocator *slab, unsigned len) {
-    return new raw_slab(len);
+  buffer::raw* buffer::create_slab(SlabAllocator *slab, unsigned len) {
+    return new raw_slab(slab, len);
   }
 
   buffer::ptr::ptr(raw *r) : _raw(r), _off(0), _len(r->len)   // no lock needed; this is an unref raw.

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -28,6 +28,7 @@
 #if defined(HAVE_XIO)
 #include "msg/xio/XioMsg.h"
 #endif
+#include "msg/async/SlabAllocator.h"
 
 #include <errno.h>
 #include <fstream>
@@ -556,6 +557,24 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     }
   };
 
+  class buffer::raw_slab : public buffer::raw {
+    SlabAllocator *slab;
+    uint32_t index;
+
+  public:
+    raw_slab(SlabAllocator *slab, unsigned l) : raw(NULL, l) {
+      if (slab->create(len, &index, &data) < 0) {
+        throw bad_alloc();
+      }
+    }
+    ~raw_slab() {
+      slab->free(index, data);
+    }
+    raw* clone_empty() {
+      return new buffer::raw_slab(slab, len);
+    }
+  };
+
 #if defined(HAVE_XIO)
   class buffer::xio_msg_buffer : public buffer::raw {
   private:
@@ -657,6 +676,10 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
 
   buffer::raw* buffer::create_unshareable(unsigned len) {
     return new raw_unshareable(len);
+  }
+
+  buffer::raw* buffer::create_unshareable(SlabAllocator *slab, unsigned len) {
+    return new raw_slab(len);
   }
 
   buffer::ptr::ptr(raw *r) : _raw(r), _off(0), _len(r->len)   // no lock needed; this is an unref raw.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -185,7 +185,7 @@ OPTION(ms_async_affinity_cores, OPT_STR, "")
 // each worker memory bytes will be "ms_async_slab_pool_resident_bytes/ms_async_op_threads"
 OPTION(ms_async_slab_pool_resident_bytes, OPT_U64, 100ul << 20)
 OPTION(ms_async_slab_grow_factor, OPT_FLOAT, 2)
-OPTION(ms_async_slab_max_unit_size, OPT_FLOAT, 4 << 20)
+OPTION(ms_async_slab_unit_size, OPT_FLOAT, 4 << 20)
 
 OPTION(inject_early_sigterm, OPT_BOOL, false)
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -183,7 +183,7 @@ OPTION(ms_async_set_affinity, OPT_BOOL, true)
 // core
 OPTION(ms_async_affinity_cores, OPT_STR, "")
 // each worker memory bytes will be "ms_async_slab_pool_resident_bytes/ms_async_op_threads"
-OPTION(ms_async_slab_pool_resident_bytes, OPT_U64, 200ul << 20)
+OPTION(ms_async_slab_pool_resident_bytes, OPT_U64, 100ul << 20)
 OPTION(ms_async_slab_grow_factor, OPT_FLOAT, 2)
 OPTION(ms_async_slab_max_unit_size, OPT_FLOAT, 4 << 20)
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -182,6 +182,10 @@ OPTION(ms_async_set_affinity, OPT_BOOL, true)
 // If ms_async_affinity_cores is empty, all threads will be bind to current running
 // core
 OPTION(ms_async_affinity_cores, OPT_STR, "")
+// each worker memory bytes will be "ms_async_slab_pool_resident_bytes/ms_async_op_threads"
+OPTION(ms_async_slab_pool_resident_bytes, OPT_U64, 200ul << 20)
+OPTION(ms_async_slab_grow_factor, OPT_FLOAT, 2)
+OPTION(ms_async_slab_max_unit_size, OPT_FLOAT, 4 << 20)
 
 OPTION(inject_early_sigterm, OPT_BOOL, false)
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1146,6 +1146,7 @@ OPTION(rgw_objexp_chunk_size, OPT_U32, 100) // maximum number of entries in a si
 
 OPTION(mutex_perf_counter, OPT_BOOL, false) // enable/disable mutex perf counter
 OPTION(throttler_perf_counter, OPT_BOOL, true) // enable/disable throttler perf counter
+OPTION(slab_perf_counter, OPT_BOOL, true) // enable/disable throttler perf counter
 
 // This will be set to true when it is safe to start threads.
 // Once it is true, it will never change.

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -65,6 +65,8 @@ struct xio_reg_mem;
 class XioDispatchHook;
 #endif
 
+class SlabAllocator;
+
 namespace ceph {
 
 const static int CEPH_BUFFER_APPEND_SIZE(4096);
@@ -134,13 +136,13 @@ private:
   class raw_char;
   class raw_pipe;
   class raw_unshareable; // diagnostic, unshareable char buffer
+  class raw_slab;
 
   friend std::ostream& operator<<(std::ostream& out, const raw &r);
 
 public:
   class xio_mempool;
   class xio_msg_buffer;
-  class SlabAllocator;
 
   /*
    * named constructors 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -140,6 +140,7 @@ private:
 public:
   class xio_mempool;
   class xio_msg_buffer;
+  class SlabAllocator;
 
   /*
    * named constructors 
@@ -154,6 +155,7 @@ public:
   static raw* create_page_aligned(unsigned len);
   static raw* create_zero_copy(unsigned len, int fd, int64_t *offset);
   static raw* create_unshareable(unsigned len);
+  static raw* create_slab(SlabAllocator *slab, unsigned len);
 
 #if defined(HAVE_XIO)
   static raw* create_msg(unsigned len, char *buf, XioDispatchHook *m_hook);

--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -50,9 +50,6 @@ private:
 public:
   bool failed; // true if we are a lossy connection that has failed.
 
-  int rx_buffers_version;
-  map<ceph_tid_t,pair<bufferlist,int> > rx_buffers;
-
   friend class boost::intrusive_ptr<Connection>;
   friend class PipeConnection;
 
@@ -66,8 +63,7 @@ public:
       priv(NULL),
       peer_type(-1),
       features(0),
-      failed(false),
-      rx_buffers_version(0) {
+      failed(false) {
   }
 
   virtual ~Connection() {
@@ -167,16 +163,8 @@ public:
   void set_features(uint64_t f) { features = f; }
   void set_feature(uint64_t f) { features |= f; }
 
-  void post_rx_buffer(ceph_tid_t tid, bufferlist& bl) {
-    Mutex::Locker l(lock);
-    ++rx_buffers_version;
-    rx_buffers[tid] = pair<bufferlist,int>(bl, rx_buffers_version);
-  }
-
-  void revoke_rx_buffer(ceph_tid_t tid) {
-    Mutex::Locker l(lock);
-    rx_buffers.erase(tid);
-  }
+  virtual void post_rx_buffer(ceph_tid_t tid, bufferlist& bl) {}
+  virtual void revoke_rx_buffer(ceph_tid_t tid) {}
 
   utime_t get_last_keepalive_ack() const {
     return last_keepalive_ack;

--- a/src/msg/Makefile.am
+++ b/src/msg/Makefile.am
@@ -47,6 +47,7 @@ noinst_HEADERS += \
 	msg/async/Event.h \
 	msg/async/EventEpoll.h \
 	msg/async/EventSelect.h \
+	msg/async/SlabPool.h \
 	msg/async/net_handler.h
 
 if LINUX

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1961,6 +1961,7 @@ int AsyncConnection::send_message(Message *m)
   if (!is_queued() && can_write == CANWRITE) {
     if (!can_fast_prepare)
       prepare_send_message(get_features(), m, bl);
+    logger->inc(l_msgr_send_messages_inline);
     if (write_message(m, bl) < 0) {
       ldout(async_msgr->cct, 1) << __func__ << " send msg failed" << dendl;
       // we want to handle fault within internal thread

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -654,7 +654,7 @@ void AsyncConnection::process()
       case STATE_OPEN_MESSAGE_READ_FRONT:
         {
           if (current_header.front_len) {
-            if (front.empty()) {
+            if (!front.length()) {
               try {
                 alloc_slab_buffer(slab, front, current_header.front_len);
               } catch (buffer::bad_alloc &e) {
@@ -680,7 +680,7 @@ void AsyncConnection::process()
       case STATE_OPEN_MESSAGE_READ_MIDDLE:
         {
           if (current_header.middle_len) {
-            if (middle.empty()) {
+            if (!middle.length()) {
               try {
                 alloc_slab_buffer(slab, middle, current_header.middle_len);
               } catch (buffer::bad_alloc &e) {

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -168,9 +168,11 @@ static void alloc_aligned_buffer(SlabAllocator *slab, bufferlist& data, unsigned
     data.push_back(bp);
     left -= middle;
   }
-  if (left) {
-    bufferptr bp = buffer::create_slab(slab, left);
+  while (left > 0) {
+    uint64_t size = MIN(slab->max_size(), left);
+    bufferptr bp = buffer::create_slab(slab, size);
     data.push_back(bp);
+    left -= size;
   }
 }
 

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -32,6 +32,7 @@ using namespace std;
 
 #include "Event.h"
 #include "net_handler.h"
+#include "SlabPool.h"
 
 class AsyncMessenger;
 
@@ -114,7 +115,7 @@ class AsyncConnection : public Connection {
   }
 
  public:
-  AsyncConnection(CephContext *cct, AsyncMessenger *m, EventCenter *c, PerfCounters *p);
+  AsyncConnection(CephContext *cct, AsyncMessenger *m, EventCenter *c, SlabPool *p, PerfCounters *pc);
   ~AsyncConnection();
 
   ostream& _conn_prefix(std::ostream *_dout);
@@ -216,6 +217,7 @@ class AsyncConnection : public Connection {
   }
 
   AsyncMessenger *async_msgr;
+  SlabPool *slab;
   PerfCounters *logger;
   int global_seq;
   __u32 connect_seq, peer_global_seq;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -115,7 +115,7 @@ class AsyncConnection : public Connection {
   }
 
  public:
-  AsyncConnection(CephContext *cct, AsyncMessenger *m, EventCenter *c, SlabPool *p, PerfCounters *pc);
+  AsyncConnection(CephContext *cct, AsyncMessenger *m, EventCenter *c, SlabAllocator *p, PerfCounters *pc);
   ~AsyncConnection();
 
   ostream& _conn_prefix(std::ostream *_dout);
@@ -217,7 +217,7 @@ class AsyncConnection : public Connection {
   }
 
   AsyncMessenger *async_msgr;
-  SlabPool *slab;
+  SlabAllocator *slab;
   PerfCounters *logger;
   int global_seq;
   __u32 connect_seq, peer_global_seq;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -322,8 +322,9 @@ WorkerPool::WorkerPool(CephContext *c): cct(c), seq(0), started(false),
                                         barrier_count(0)
 {
   assert(cct->_conf->ms_async_op_threads > 0);
+  uint64_t resident = cct->_conf->ms_async_slab_pool_resident_bytes;
   for (int i = 0; i < cct->_conf->ms_async_op_threads; ++i) {
-    Worker *w = new Worker(cct, this, i);
+    Worker *w = new Worker(cct, this, i, resident);
     workers.push_back(w);
   }
   vector<string> corestrs;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -395,7 +395,7 @@ AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
   ceph_spin_init(&global_seq_lock);
   cct->lookup_or_create_singleton_object<WorkerPool>(pool, WorkerPool::name);
   Worker *w = pool->get_worker();
-  local_connection = new AsyncConnection(cct, this, &w->center, w->get_perf_counter());
+  local_connection = new AsyncConnection(cct, this, &w->center, w->slab, w->get_perf_counter());
   local_features = features;
   init_local_connection();
 }
@@ -522,7 +522,7 @@ AsyncConnectionRef AsyncMessenger::add_accept(int sd)
 {
   lock.Lock();
   Worker *w = pool->get_worker();
-  AsyncConnectionRef conn = new AsyncConnection(cct, this, &w->center, w->get_perf_counter());
+  AsyncConnectionRef conn = new AsyncConnection(cct, this, &w->center, w->slab, w->get_perf_counter());
   conn->accept(sd);
   accepting_conns.insert(conn);
   lock.Unlock();
@@ -539,7 +539,7 @@ AsyncConnectionRef AsyncMessenger::create_connect(const entity_addr_t& addr, int
 
   // create connection
   Worker *w = pool->get_worker();
-  AsyncConnectionRef conn = new AsyncConnection(cct, this, &w->center, w->get_perf_counter());
+  AsyncConnectionRef conn = new AsyncConnection(cct, this, &w->center, w->slab, w->get_perf_counter());
   conn->connect(addr, type);
   assert(!conns.count(addr));
   conns[addr] = conn;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -304,6 +304,7 @@ void *Worker::entry()
     ldout(cct, 30) << __func__ << " calling event process" << dendl;
     if (cold) {
       r = center.process_events(EventMaxWaitUs);
+      cold = false;
     } else {
       r = center.process_events(EventMinWaitUs);
     }

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -64,14 +64,15 @@ class Worker : public Thread {
   PerfCounters *perf_logger;
 
  public:
-  SlabPool *slab;
+  SlabAllocator *slab;
   EventCenter center;
   Worker(CephContext *c, WorkerPool *p, int i)
     : cct(c), pool(p), done(false), id(i), perf_logger(NULL),
-      slab(new SlabAllocator(2, 1 << 30, 4 << 10)), center(c) {
+      slab(NULL), center(c) {
     center.init(InitEventNumber);
     char name[128];
     sprintf(name, "AsyncMessenger::Worker-%d", id);
+    slab = new SlabAllocator(c, name, 2, 1 << 30, 4 << 10);
     // initialize perf_logger
     PerfCountersBuilder plb(cct, name, l_msgr_first, l_msgr_last);
 

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -32,6 +32,9 @@ using namespace std;
 #include "common/Thread.h"
 #include "common/Throttle.h"
 
+#include "msg/SimplePolicyMessenger.h"
+#include "include/assert.h"
+#include "AsyncConnection.h"
 #include "Event.h"
 #include "SlabPool.h"
 
@@ -59,9 +62,9 @@ class Worker : public Thread {
   bool done;
   int id;
   PerfCounters *perf_logger;
-  SlabPool *slab;
 
  public:
+  SlabPool *slab;
   EventCenter center;
   Worker(CephContext *c, WorkerPool *p, int i)
     : cct(c), pool(p), done(false), id(i), perf_logger(NULL),

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -56,7 +56,7 @@ enum {
 
 class Worker : public Thread {
   static const uint64_t InitEventNumber = 5000;
-  static const uint64_t EventMinWaitUs = 10 * 1000;
+  static const uint64_t EventMinWaitUs = 0;
   static const uint64_t EventMaxWaitUs = 30 * 1000 * 1000;
   static const uint64_t MaxSlabObjectLowBound = 1 << 20;
   CephContext *cct;

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -56,7 +56,7 @@ enum {
 
 class Worker : public Thread {
   static const uint64_t InitEventNumber = 5000;
-  static const uint64_t EventMinWaitUs = 30 * 1000;
+  static const uint64_t EventMinWaitUs = 10 * 1000;
   static const uint64_t EventMaxWaitUs = 30 * 1000 * 1000;
   static const uint64_t MaxSlabObjectLowBound = 1 << 20;
   CephContext *cct;

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -46,6 +46,7 @@ enum {
   l_msgr_first = 94000,
   l_msgr_recv_messages,
   l_msgr_send_messages,
+  l_msgr_send_messages_inline,
   l_msgr_recv_bytes,
   l_msgr_send_bytes,
   l_msgr_created_connections,
@@ -82,6 +83,7 @@ class Worker : public Thread {
 
     plb.add_u64_counter(l_msgr_recv_messages, "msgr_recv_messages", "Network received messages");
     plb.add_u64_counter(l_msgr_send_messages, "msgr_send_messages", "Network sent messages");
+    plb.add_u64_counter(l_msgr_send_messages_inline, "msgr_send_messages_inline", "Network sent messages without extra dispatch");
     plb.add_u64_counter(l_msgr_recv_bytes, "msgr_recv_bytes", "Network received bytes");
     plb.add_u64_counter(l_msgr_send_bytes, "msgr_send_bytes", "Network received bytes");
     plb.add_u64_counter(l_msgr_created_connections, "msgr_active_connections", "Active connection number");

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -56,7 +56,8 @@ enum {
 
 class Worker : public Thread {
   static const uint64_t InitEventNumber = 5000;
-  static const uint64_t EventMaxWaitUs = 30000000;
+  static const uint64_t EventMinWaitUs = 30 * 1000;
+  static const uint64_t EventMaxWaitUs = 30 * 1000 * 1000;
   static const uint64_t MaxSlabObjectLowBound = 1 << 20;
   CephContext *cct;
   WorkerPool *pool;

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -76,7 +76,7 @@ class Worker : public Thread {
     sprintf(name, "AsyncMessenger::Worker-%d", id);
     slab = new SlabAllocator(c, name, cct->_conf->ms_async_slab_grow_factor,
                              resident,
-                             MAX(cct->_conf->ms_async_slab_max_unit_size, MaxSlabObjectLowBound));
+                             MAX(cct->_conf->ms_async_slab_unit_size, MaxSlabObjectLowBound));
     // initialize perf_logger
     PerfCountersBuilder plb(cct, name, l_msgr_first, l_msgr_last);
 
@@ -95,6 +95,8 @@ class Worker : public Thread {
       cct->get_perfcounters_collection()->remove(perf_logger);
       delete perf_logger;
     }
+    if (slab)
+      slab->release();
   }
   void *entry();
   void stop();

--- a/src/msg/async/MemoryPool.cc
+++ b/src/msg/async/MemoryPool.cc
@@ -1,0 +1,17 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 XSky <haomai@xsky.com>
+ *
+ * Author: Haomai Wang <haomaiwang@gmail.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+

--- a/src/msg/async/SlabPool.h
+++ b/src/msg/async/SlabPool.h
@@ -1,0 +1,274 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 XSky <haomai@xsky.com>
+ *
+ * Author: Haomai Wang <haomaiwang@gmail.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MSG_SLABPOOL_H
+#define CEPH_MSG_SLABPOOL_H
+
+#include <vector>
+#include <list>
+
+static const uint16_t SLAB_MAGIC_NUMBER = 0x51AB; // meant to be 'SLAB' :-)
+typedef uint64_t uintptr_t;
+
+/*
+ * SlabPageDesc is 1:1 mapped to slab page.
+ * footprint: 80b for each slab page.
+ */
+struct SlabPageDesc {
+ private:
+  void *slab_page;
+  std::vector<uintptr_t> free_objects;
+  uint32_t index; // index into slab page vector
+  uint16_t magic;
+  uint8_t slab_class_id;
+
+ public:
+  SlabPageDesc(void *slab_page, size_t objects, size_t object_size, uint8_t id, uint32_t idx)
+    : slab_page(slab_page), index(idx), magic(SLAB_MAGIC_NUMBER), slab_class_id(id) {
+    uintptr_t object = reinterpret_cast<uintptr_t>(slab_page);
+    // we already return the first object to caller, see 'create_from_new_page'
+    free_objects.reserve(objects - 1);
+    for (size_t i = 1u; i < objects; i++) {
+      object += object_size;
+      free_objects.push_back(object);
+    }
+  }
+
+  bool empty() const {
+    return free_objects.empty();
+  }
+
+  size_t size() const {
+    return free_objects.size();
+  }
+
+  uint32_t index() const {
+    return index;
+  }
+
+  uint16_t magic() const {
+    return magic;
+  }
+
+  uint8_t slab_class_id() const {
+    return slab_class_id;
+  }
+
+  void* slab_page() const {
+    return slab_page;
+  }
+
+  std::vector<uintptr_t>& free_objects() {
+    return free_objects;
+  }
+
+  void* allocate_object() {
+    assert(!free_objects.empty());
+    void *object = reinterpret_cast<void*>(free_objects.back());
+    free_objects.pop_back();
+    return object;
+  }
+
+  void free_object(void *object) {
+    free_objects.push_back(reinterpret_cast<uintptr_t>(object));
+  }
+};
+
+class SlabClass {
+ private:
+  std::list<SlabPageDesc*> free_slab_pages;
+  size_t count; // the number of objects
+  uint8_t slab_class_id;
+
+ public:
+  SlabClass(size_t s, uint8_t slab_class_id): count(s), slab_class_id(slab_class_id) {}
+  ~SlabClass() {
+    free_slab_pages.clear();
+  }
+
+  size_t count() const {
+    return count;
+  }
+
+  bool empty() const {
+    return free_slab_pages.empty();
+  }
+
+  void *create(uint32_t *idx) {
+    assert(!free_slab_pages.empty());
+    SlabPageDesc *desc = free_slab_pages.back();
+    void *object = desc->allocate_object();
+    if (desc.empty()) {
+      // if empty, remove desc from the list of slab pages with free objects.
+      free_slab_pages.pop_back();
+    }
+    *idx = desc->index();
+    return object;
+  }
+
+  int create_from_new_page(SlabAllocator *alloc, uint64_t max_object_size, uint32_t slab_page_index, void **data) {
+    // allocate slab page.
+    void *slab_page = ::posix_memalign(data, CEPH_PAGE_SIZE, max_object_size);
+    if (!slab_page) {
+        return -ENOMEM;
+    }
+    // allocate descriptor to slab page.
+    SlabPageDesc *desc = NULL;
+    assert(count % CEPH_PAGE_SIZE == 0);
+    uint64_t objects = max_object_size / _size;
+
+    try {
+      desc = new SlabPageDesc(slab_page, objects, _size, slab_class_id, slab_page_index);
+    } catch (const std::bad_alloc& e) {
+      ::free(slab_page);
+      throw std::bad_alloc{};
+    }
+
+    free_slab_pages.push_front(*desc);
+    // first object from the allocated slab page is returned.
+    alloc->slab_pages_vector.push_back(&desc);
+    return 0;
+  }
+
+  void free_item(Item *item, SlabPageDesc& desc) {
+    void *object = item;
+    desc.free_object(object);
+    if (desc.size() == 1) {
+      // push back desc into the list of slab pages with free objects.
+      free_slab_pages.push_back(desc);
+    }
+  }
+};
+
+class SlabAllocator {
+ private:
+  std::vector<size_t> slab_class_sizes;
+  std::vector<SlabClass> slab_classes;
+  std::vector<SlabPageDesc*> slab_pages_vector;
+  uint64_t max_object_size;
+  uint64_t available_slab_pages;
+
+ private:
+  void initialize_slab_allocator(double growth_factor, uint64_t limit) {
+    const size_t initial_size = CEPH_PAGE_SIZE;
+    size_t size = initial_size; // initial object size
+    uint8_t slab_class_id = 0U;
+
+    while (max_object_size / size > 1) {
+      size = (size + CEPH_PAGE_SIZE - 1) & ~(size - 1)
+      slab_class_sizes.push_back(size);
+      slab_classes.push_back(SlabClass(size, slab_class_id));
+      size *= growth_factor;
+      assert(slab_class_id < std::numeric_limits<uint8_t>::max());
+      slab_class_id++;
+    }
+    slab_class_sizes.push_back(_max_object_size);
+    slab_classes.push_back(SlabClass(max_object_size, slab_class_id));
+
+    // If slab limit is zero, enable reclaimer.
+    slab_pages_vector.reserve(available_slab_pages);
+  }
+
+  SlabClass* get_slab_class(const size_t size) {
+      // given a size, find slab class with binary search.
+      std::vector<size_t>::iterator i = slab_class_sizes.lower_bound(size);
+      if (i == slab_class_sizes.end())
+          return NULL;
+      return &slab_classes[std::distance(slab_class_sizes.begin(), i)];
+  }
+
+  SlabClass* get_slab_class(const uint8_t slab_class_id) {
+      assert(slab_class_id >= 0 && slab_class_id < _slab_classes.size());
+      return &slab_classes[slab_class_id];
+  }
+
+ public:
+  SlabAllocator(double growth_factor, uint64_t limit, uint64_t max_obj_size)
+      : max_object_size(max_obj_size), available_slab_pages(limit / max_obj_size) {
+    initialize_slab_allocator(growth_factor, limit);
+  }
+
+  ~SlabAllocator() {
+    for (std::vector<SlabPageDesc*>::iterator it = slab_pages_vector;
+         it != slab_pages_vector.end(); ++it) {
+      if (*it == NULL) {
+        continue;
+      }
+      ::free(desc->slab_page());
+      delete desc;
+    }
+  }
+
+  int create(const size_t size, uint32_t *idx, void **data) {
+    SlabClass *slab_class = get_slab_class(size);
+    if (!slab_class)
+      return -EINVAL;
+
+    int r = 0;
+    if (!slab_class->empty()) {
+      data = slab_class->create(idx);
+    } else {
+      if (available_slab_pages > 0) {
+        size_t index_to_insert = slab_pages_vector.size();
+        r = slab_class->create_from_new_page(this, max_object_size, index_to_insert, data);
+        *idx = index_to_insert;
+        if (r < 0)
+          return r;
+        slab_pages_vector.push_back(&desc);
+        if (available_slab_pages > 0)
+          --available_slab_pages;
+      } else {
+        r = -ENOMEM;
+      }
+    }
+    return r;
+  }
+
+  /**
+   * Free an item back to its original slab class.
+   */
+  void free(uint32_t slab_class_id, void *data) {
+    if (data) {
+      SlabPageDesc *desc = slab_pages_vector[slab_class_id];
+      assert(desc != NULL);
+      assert(desc->magic() == SLAB_MAGIC_NUMBER);
+      SlabClass* slab_class = get_slab_class(desc.slab_class_id());
+      slab_class->free_item(item, desc);
+    }
+  }
+
+  /**
+   * Helper function: Print all available slab classes and their respective properties.
+   */
+  void print_slab_classes() {
+    uint8_t class_id = 0;
+    for (std::vector<SlabClass>::const_iterator it = slab_classes.const_begin();
+       it != slab_classes.const_end(); ++it) {
+      printf("slab[%3d]\tsize: %10lu\tper-slab-page: %5lu\n", class_id, it->size(), max_object_size / size);
+      class_id++;
+    }
+  }
+
+  /**
+   * Helper function: Useful for getting a slab class' chunk size from a size parameter.
+   */
+  size_t class_size(const size_t size) {
+    SlabClass *slab_class = get_slab_class(size);
+    return (slab_class) ? slab_class->size() : 0;
+  }
+};
+
+#endif /* CEPH_MSG_SLABPOOL_H */

--- a/src/msg/async/SlabPool.h
+++ b/src/msg/async/SlabPool.h
@@ -20,8 +20,13 @@
 #include <vector>
 #include <list>
 
+#include "include/page.h"
+#include "include/error.h"
+
 static const uint16_t SLAB_MAGIC_NUMBER = 0x51AB; // meant to be 'SLAB' :-)
 typedef uint64_t uintptr_t;
+
+class SlabAllocator;
 
 /*
  * SlabPageDesc is 1:1 mapped to slab page.
@@ -29,16 +34,16 @@ typedef uint64_t uintptr_t;
  */
 struct SlabPageDesc {
  private:
-  void *slab_page;
+  void *page;
   std::vector<uintptr_t> free_objects;
-  uint32_t index; // index into slab page vector
-  uint16_t magic;
-  uint8_t slab_class_id;
+  uint32_t id; // index into slab page vector
+  uint16_t magic_number;
+  uint8_t class_id;
 
  public:
-  SlabPageDesc(void *slab_page, size_t objects, size_t object_size, uint8_t id, uint32_t idx)
-    : slab_page(slab_page), index(idx), magic(SLAB_MAGIC_NUMBER), slab_class_id(id) {
-    uintptr_t object = reinterpret_cast<uintptr_t>(slab_page);
+  SlabPageDesc(void *data, size_t objects, size_t object_size, uint8_t id, uint32_t idx)
+    : page(data), id(idx), magic_number(SLAB_MAGIC_NUMBER), class_id(id) {
+    uintptr_t object = reinterpret_cast<uintptr_t>(page);
     // we already return the first object to caller, see 'create_from_new_page'
     free_objects.reserve(objects - 1);
     for (size_t i = 1u; i < objects; i++) {
@@ -56,23 +61,19 @@ struct SlabPageDesc {
   }
 
   uint32_t index() const {
-    return index;
+    return id;
   }
 
   uint16_t magic() const {
-    return magic;
+    return magic_number;
   }
 
   uint8_t slab_class_id() const {
-    return slab_class_id;
+    return class_id;
   }
 
   void* slab_page() const {
-    return slab_page;
-  }
-
-  std::vector<uintptr_t>& free_objects() {
-    return free_objects;
+    return page;
   }
 
   void* allocate_object() {
@@ -90,17 +91,17 @@ struct SlabPageDesc {
 class SlabClass {
  private:
   std::list<SlabPageDesc*> free_slab_pages;
-  size_t count; // the number of objects
+  size_t num_obj; // the number of objects
   uint8_t slab_class_id;
 
  public:
-  SlabClass(size_t s, uint8_t slab_class_id): count(s), slab_class_id(slab_class_id) {}
+  SlabClass(size_t s, uint8_t slab_class_id): num_obj(s), slab_class_id(slab_class_id) {}
   ~SlabClass() {
     free_slab_pages.clear();
   }
 
   size_t count() const {
-    return count;
+    return num_obj;
   }
 
   bool empty() const {
@@ -111,7 +112,7 @@ class SlabClass {
     assert(!free_slab_pages.empty());
     SlabPageDesc *desc = free_slab_pages.back();
     void *object = desc->allocate_object();
-    if (desc.empty()) {
+    if (desc->empty()) {
       // if empty, remove desc from the list of slab pages with free objects.
       free_slab_pages.pop_back();
     }
@@ -119,34 +120,31 @@ class SlabClass {
     return object;
   }
 
-  int create_from_new_page(SlabAllocator *alloc, uint64_t max_object_size, uint32_t slab_page_index, void **data) {
+  int create_from_new_page(uint64_t max_object_size, uint32_t slab_page_index, SlabPageDesc **desc, void **data) {
     // allocate slab page.
-    void *slab_page = ::posix_memalign(data, CEPH_PAGE_SIZE, max_object_size);
-    if (!slab_page) {
-        return -ENOMEM;
+    int r = ::posix_memalign(data, CEPH_PAGE_SIZE, max_object_size);
+    if (r != 0) {
+        return -errno;
     }
     // allocate descriptor to slab page.
-    SlabPageDesc *desc = NULL;
-    assert(count % CEPH_PAGE_SIZE == 0);
-    uint64_t objects = max_object_size / _size;
+    assert(num_obj % CEPH_PAGE_SIZE == 0);
+    uint64_t objects = max_object_size / num_obj;
 
     try {
-      desc = new SlabPageDesc(slab_page, objects, _size, slab_class_id, slab_page_index);
+      *desc = new SlabPageDesc(*data, objects, num_obj, slab_class_id, slab_page_index);
     } catch (const std::bad_alloc& e) {
-      ::free(slab_page);
+      ::free(data);
       return -ENOMEM;
     }
 
     free_slab_pages.push_front(*desc);
     // first object from the allocated slab page is returned.
-    alloc->slab_pages_vector.push_back(&desc);
     return 0;
   }
 
-  void free_item(Item *item, SlabPageDesc& desc) {
-    void *object = item;
-    desc.free_object(object);
-    if (desc.size() == 1) {
+  void free(void *object, SlabPageDesc *desc) {
+    desc->free_object(object);
+    if (desc->size() == 1) {
       // push back desc into the list of slab pages with free objects.
       free_slab_pages.push_back(desc);
     }
@@ -168,14 +166,14 @@ class SlabAllocator {
     uint8_t slab_class_id = 0U;
 
     while (max_object_size / size > 1) {
-      size = (size + CEPH_PAGE_SIZE - 1) & ~(size - 1)
+      size = (size + CEPH_PAGE_SIZE - 1) & ~(size - 1);
       slab_class_sizes.push_back(size);
       slab_classes.push_back(SlabClass(size, slab_class_id));
       size *= growth_factor;
       assert(slab_class_id < std::numeric_limits<uint8_t>::max());
       slab_class_id++;
     }
-    slab_class_sizes.push_back(_max_object_size);
+    slab_class_sizes.push_back(max_object_size);
     slab_classes.push_back(SlabClass(max_object_size, slab_class_id));
 
     // If slab limit is zero, enable reclaimer.
@@ -184,14 +182,14 @@ class SlabAllocator {
 
   SlabClass* get_slab_class(const size_t size) {
       // given a size, find slab class with binary search.
-      std::vector<size_t>::iterator i = slab_class_sizes.lower_bound(size);
+      std::vector<size_t>::iterator i = std::lower_bound(slab_class_sizes.begin(), slab_class_sizes.end(), size);
       if (i == slab_class_sizes.end())
           return NULL;
       return &slab_classes[std::distance(slab_class_sizes.begin(), i)];
   }
 
   SlabClass* get_slab_class(const uint8_t slab_class_id) {
-      assert(slab_class_id >= 0 && slab_class_id < _slab_classes.size());
+      assert(slab_class_id < slab_classes.size());
       return &slab_classes[slab_class_id];
   }
 
@@ -202,13 +200,13 @@ class SlabAllocator {
   }
 
   ~SlabAllocator() {
-    for (std::vector<SlabPageDesc*>::iterator it = slab_pages_vector;
+    for (std::vector<SlabPageDesc*>::iterator it = slab_pages_vector.begin();
          it != slab_pages_vector.end(); ++it) {
       if (*it == NULL) {
         continue;
       }
-      ::free(desc->slab_page());
-      delete desc;
+      ::free((*it)->slab_page());
+      delete *it;
     }
   }
 
@@ -219,15 +217,16 @@ class SlabAllocator {
 
     int r = 0;
     if (!slab_class->empty()) {
-      data = slab_class->create(idx);
+      *data = slab_class->create(idx);
     } else {
       if (available_slab_pages > 0) {
         size_t index_to_insert = slab_pages_vector.size();
-        r = slab_class->create_from_new_page(this, max_object_size, index_to_insert, data);
-        *idx = index_to_insert;
+        SlabPageDesc *desc;
+        r = slab_class->create_from_new_page(max_object_size, index_to_insert, &desc, data);
         if (r < 0)
           return r;
-        slab_pages_vector.push_back(&desc);
+        *idx = index_to_insert;
+        slab_pages_vector.push_back(desc);
         if (available_slab_pages > 0)
           --available_slab_pages;
       } else {
@@ -243,10 +242,9 @@ class SlabAllocator {
   void free(uint32_t slab_class_id, void *data) {
     if (data) {
       SlabPageDesc *desc = slab_pages_vector[slab_class_id];
-      assert(desc != NULL);
-      assert(desc->magic() == SLAB_MAGIC_NUMBER);
-      SlabClass* slab_class = get_slab_class(desc.slab_class_id());
-      slab_class->free_item(item, desc);
+      assert(desc && desc->magic() == SLAB_MAGIC_NUMBER);
+      SlabClass* slab_class = get_slab_class(desc->slab_class_id());
+      slab_class->free(data, desc);
     }
   }
 
@@ -255,9 +253,9 @@ class SlabAllocator {
    */
   void print_slab_classes() {
     uint8_t class_id = 0;
-    for (std::vector<SlabClass>::const_iterator it = slab_classes.const_begin();
-       it != slab_classes.const_end(); ++it) {
-      printf("slab[%3d]\tsize: %10lu\tper-slab-page: %5lu\n", class_id, it->size(), max_object_size / size);
+    for (std::vector<SlabClass>::const_iterator it = slab_classes.begin();
+       it != slab_classes.end(); ++it) {
+      printf("slab[%3d]\tsize: %10lu\tper-slab-page: %5lu\n", class_id, it->count(), max_object_size / it->count());
       class_id++;
     }
   }
@@ -267,7 +265,7 @@ class SlabAllocator {
    */
   size_t class_size(const size_t size) {
     SlabClass *slab_class = get_slab_class(size);
-    return (slab_class) ? slab_class->size() : 0;
+    return (slab_class) ? slab_class->count() : 0;
   }
 };
 

--- a/src/msg/async/SlabPool.h
+++ b/src/msg/async/SlabPool.h
@@ -134,7 +134,7 @@ class SlabClass {
       desc = new SlabPageDesc(slab_page, objects, _size, slab_class_id, slab_page_index);
     } catch (const std::bad_alloc& e) {
       ::free(slab_page);
-      throw std::bad_alloc{};
+      return -ENOMEM;
     }
 
     free_slab_pages.push_front(*desc);

--- a/src/msg/async/SlabPool.h
+++ b/src/msg/async/SlabPool.h
@@ -19,6 +19,7 @@
 
 #include <vector>
 #include <list>
+#include <limits>
 
 #include "include/page.h"
 #include "include/error.h"
@@ -137,7 +138,8 @@ class SlabClass {
       return -ENOMEM;
     }
 
-    free_slab_pages.push_front(*desc);
+    if (!(*desc)->empty())
+      free_slab_pages.push_front(*desc);
     // first object from the allocated slab page is returned.
     return 0;
   }
@@ -166,7 +168,7 @@ class SlabAllocator {
     uint8_t slab_class_id = 0U;
 
     while (max_object_size / size > 1) {
-      size = (size + CEPH_PAGE_SIZE - 1) & ~(size - 1);
+      size = (size + CEPH_PAGE_SIZE - 1) & ~(CEPH_PAGE_SIZE - 1);
       slab_class_sizes.push_back(size);
       slab_classes.push_back(SlabClass(size, slab_class_id));
       size *= growth_factor;

--- a/src/msg/async/SlabPool.h
+++ b/src/msg/async/SlabPool.h
@@ -413,7 +413,8 @@ class SlabAllocator {
     size_t freed = 0;
     pending_free_lock.lock();
     if (!pending_frees.empty()) {
-      std::vector<pair<uint32_t, void*> > freeing(pending_frees.size());
+      std::vector<pair<uint32_t, void*> > freeing;
+      freeing.reserve(pending_frees.size());
       freeing.swap(pending_frees);
       pending_free_lock.unlock();
       freed = actual_free(freeing);

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -414,6 +414,11 @@ unittest_async_compressor_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_async_compressor_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL) $(LIBCOMPRESSOR)
 check_PROGRAMS += unittest_async_compressor
 
+unittest_slab_pool_SOURCES = test/msgr/test_slab_pool.cc
+unittest_slab_pool_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+unittest_slab_pool_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
+check_PROGRAMS += unittest_slab_pool
+
 check_SCRIPTS += test/pybind/test_ceph_argparse.py
 check_SCRIPTS += test/pybind/test_ceph_daemon.py
 

--- a/src/test/msgr/test_slab_pool.cc
+++ b/src/test/msgr/test_slab_pool.cc
@@ -1,0 +1,98 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 XSky <haomai@xsky.com>
+ *
+ * Author: Haomai Wang <haomaiwang@gmail.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#include <iostream>
+#include <assert.h>
+#include "msg/async/SlabPool.h"
+
+#include <gtest/gtest.h>
+
+static const size_t max_object_size = 1024*1024;
+
+static void free_vector(slab_allocator &slab, std::map<uint32_t, void*> &items) {
+  for (std::map<uint32_t, void*>::iterator it = items.begin();
+       it != items.end(); ++it {
+    slab.free(it->first, it->second);
+  }
+}
+
+static void test_allocation_1(const double growth_factor, const unsigned slab_limit_size) {
+    slab_allocator slab(growth_factor, slab_limit_size, max_object_size);
+    size_t size = max_object_size;
+
+    slab.print_slab_classes();
+
+    std::map<uint32_t, void*> datas;
+
+    assert(slab_limit_size % size == 0);
+    uint32_t idx;
+    void *data;
+    for (unsigned i = 0u; i < (slab_limit_size / size); i++) {
+        int r = slab.create(size, &idx, &data);
+        assert(r == 0);
+        datas[idx] = data;
+    }
+    assert(slab.create(size, &idx, &data) < 0);
+    free_vector(slab, datas);
+}
+
+static void test_allocation_2(const double growth_factor, const unsigned slab_limit_size) {
+    slab_allocator slab(growth_factor, slab_limit_size, max_object_size);
+    size_t size = 1024;
+
+    std::map<uint32_t, void*> datas;
+
+    size_t allocations = 0u;
+    uint32_t idx;
+    void *data;
+    for (;;) {
+      int r = slab.create(size, &idx, &data);
+      if (r < 0) {
+        break;
+      }
+      datas[idx] = data;
+      allocations++;
+    }
+
+    size_t class_size = slab.class_size(size);
+    size_t per_slab_page = max_object_size / class_size;
+    unsigned available_slab_pages = slab_limit_size / max_object_size;
+    assert(allocations == (per_slab_page * available_slab_pages));
+    free_vector(slab, datas);
+}
+
+TEST(SlabPool, test_allocation) {
+  test_allocation_1(1.25, 5*1024*1024);
+  test_allocation_2(1.07, 5*1024*1024); // 1.07 is the growth factor used by facebook.
+}
+
+int main(int argc, char **argv) {
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+/*
+ * Local Variables:
+ * compile-command: "cd ../.. ; make unittest_slab_pool && 
+ *    ./unittest_slab_pool
+ *
+ * End:
+ *

--- a/src/test/msgr/test_slab_pool.cc
+++ b/src/test/msgr/test_slab_pool.cc
@@ -142,6 +142,7 @@ TEST(SlabPool, test_concurrency) {
     uint32_t idx;
     void *d;
     int r = slab->create(size, &idx, &d);
+    ASSERT_TRUE(d != NULL);
     ASSERT_EQ(r, 0);
     workers[i%workers.size()]->post_data(idx, d);
     if (i % 1000 == 0) {

--- a/src/test/msgr/test_slab_pool.cc
+++ b/src/test/msgr/test_slab_pool.cc
@@ -34,7 +34,7 @@ static void free_map(SlabAllocator &slab, std::map<uint32_t, void*> &items) {
 }
 
 static void test_allocation_1(const double growth_factor, const unsigned slab_limit_size) {
-    SlabAllocator slab(growth_factor, slab_limit_size, max_object_size);
+    SlabAllocator slab(NULL, "", growth_factor, slab_limit_size, max_object_size);
     size_t size = max_object_size;
 
     slab.print_slab_classes();
@@ -54,7 +54,7 @@ static void test_allocation_1(const double growth_factor, const unsigned slab_li
 }
 
 static void test_allocation_2(const double growth_factor, const unsigned slab_limit_size) {
-    SlabAllocator slab(growth_factor, slab_limit_size, max_object_size);
+    SlabAllocator slab(NULL, "", growth_factor, slab_limit_size, max_object_size);
     size_t size = 1024;
 
     std::map<uint32_t, void*> datas;


### PR DESCRIPTION
We know lots of memory allocations happened in messenger layer, rely on system or generic memory library will cause lots of redundant cpu times. Actually async msgr has significant characteristics for memory usage. It will only malloc memory in local thread, then other threads will free them.

Here I implement a special slab memory pool which only allow alloc/reclaim locally, permitting free remotely. 