### PR TITLE
KeyValueStore: fix the name's typo of keyvaluestore_default_strip_size

### DIFF
--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -2888,7 +2888,7 @@ const char** KeyValueStore::get_tracked_conf_keys() const
   static const char* KEYS[] = {
     "keyvaluestore_queue_max_ops",
     "keyvaluestore_queue_max_bytes",
-    "keyvaluestore_strip_size",
+    "keyvaluestore_default_strip_size",
     "keyvaluestore_dump_file",
     NULL
   };


### PR DESCRIPTION
This should be a name's typo of keyvaluestore_default_strip_size, which causes the dynamically changing of this option doesn't work. 

Signed-off-by: Zhi Zhang zhangz.david@outlook.com