### PR TITLE
osdc: remove conf observer on objecter shutdown

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -429,6 +429,8 @@ void Objecter::shutdown()
   }
 
   assert(tick_event == NULL);
+
+  cct->_conf->remove_observer(this);
 }
 
 void Objecter::_send_linger(LingerOp *info)


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@mirantis.com>