### PR TITLE
FileStore: remove unused local variable 'handle'

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -4489,7 +4489,6 @@ bool FileStore::collection_empty(coll_t c)
   RWLock::RLocker l((index.index)->access_lock);
 
   vector<ghobject_t> ls;
-  collection_list_handle_t handle;
   r = index->collection_list_partial(ghobject_t(), ghobject_t::get_max(), true,
 				     1, &ls, NULL);
   if (r < 0) {


### PR DESCRIPTION
Remove unused local variable 'handle' in FileStore::collection_empty
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>