### PR TITLE
rgw, doc: remove remark for lack of custom account metadata of Swift.

### DIFF
--- a/doc/radosgw/swift.rst
+++ b/doc/radosgw/swift.rst
@@ -31,7 +31,7 @@ The following table describes the support status for current Swift functional fe
 +=================================+=================+========================================+
 | **Authentication**              | Supported       |                                        |
 +---------------------------------+-----------------+----------------------------------------+
-| **Get Account Metadata**        | Supported       | No custom metadata                     |
+| **Get Account Metadata**        | Supported       |                                        |
 +---------------------------------+-----------------+----------------------------------------+
 | **Swift ACLs**                  | Supported       | Supports a subset of Swift ACLs        |
 +---------------------------------+-----------------+----------------------------------------+


### PR DESCRIPTION
@dachary This PR is version of #6248 targeting ```master``` branch instead of ```infernalis```. I'm not sure whether this is necessary, but I've spotted that the commit isn't in ```master``` yet.