### PR TITLE
doc: download GPG key from download.ceph.com

### DIFF
--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -70,13 +70,13 @@ APT
 
 To install the ``release.asc`` key, execute the following::
 
-	wget -q -O- 'https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | sudo apt-key add -
+	wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
 
 
 To install the ``autobuild.asc`` key, execute the following
 (QA and developers only)::
 
-	wget -q -O- 'https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc' | sudo apt-key add -
+	wget -q -O- 'https://download.ceph.com/keys/autobuild.asc' | sudo apt-key add -
 
 
 RPM
@@ -84,12 +84,12 @@ RPM
 
 To install the ``release.asc`` key, execute the following::
 
-	sudo rpm --import 'https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+	sudo rpm --import 'https://download.ceph.com/keys/release.asc'
 
 To install the ``autobuild.asc`` key, execute the following
 (QA and developers only)::
 
-	sudo rpm --import 'https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc'
+	sudo rpm --import 'https://download.ceph.com/keys/autobuild.asc'
 
 
 .. _mirrors:
@@ -216,7 +216,7 @@ take priority over standard packages, so you must ensure that you set
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-noarch]
 	name=Ceph noarch packages
@@ -225,7 +225,7 @@ take priority over standard packages, so you must ensure that you set
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-source]
 	name=Ceph source packages
@@ -234,7 +234,7 @@ take priority over standard packages, so you must ensure that you set
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 
 For development release packages, you may specify the repository
@@ -247,7 +247,7 @@ for development releases instead. ::
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-noarch]
 	name=Ceph noarch packages
@@ -256,7 +256,7 @@ for development releases instead. ::
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-source]
 	name=Ceph source packages
@@ -265,7 +265,7 @@ for development releases instead. ::
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 
 For specific packages, you may retrieve them by specifically downloading the
@@ -324,7 +324,7 @@ install. ::
 	enabled=0
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 
 You may view http://gitbuilder.ceph.com directory to see which distributions
@@ -366,7 +366,7 @@ http://gitbuilder.ceph.com directory to see which distributions Ceph supports.
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 	[apache2-ceph-source]
 	name=Apache source packages for Ceph
@@ -375,7 +375,7 @@ http://gitbuilder.ceph.com directory to see which distributions Ceph supports.
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 
 Repeat the forgoing process by creating a ``ceph-fastcgi.repo`` file. ::
@@ -387,7 +387,7 @@ Repeat the forgoing process by creating a ``ceph-fastcgi.repo`` file. ::
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 	[fastcgi-ceph-noarch]
 	name=FastCGI noarch packages for Ceph
@@ -396,7 +396,7 @@ Repeat the forgoing process by creating a ``ceph-fastcgi.repo`` file. ::
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 	[fastcgi-ceph-source]
 	name=FastCGI source packages for Ceph
@@ -405,7 +405,7 @@ Repeat the forgoing process by creating a ``ceph-fastcgi.repo`` file. ::
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://git.ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 
 Download Packages

--- a/doc/install/install-storage-cluster.rst
+++ b/doc/install/install-storage-cluster.rst
@@ -47,7 +47,7 @@ To install Ceph with RPMs, execute the following steps:
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-noarch]
 	name=Ceph noarch packages
@@ -56,7 +56,7 @@ To install Ceph with RPMs, execute the following steps:
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-source]
 	name=Ceph source packages
@@ -65,7 +65,7 @@ To install Ceph with RPMs, execute the following steps:
 	priority=2
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 
 #. Install pre-requisite packages::  

--- a/doc/install/upgrading-ceph.rst
+++ b/doc/install/upgrading-ceph.rst
@@ -275,7 +275,7 @@ Then add a new ``ceph.repo`` repository entry with the following contents.
 	enabled=1
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc	
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 
 .. note:: Ensure you use the correct URL for your distribution. Check the
@@ -313,7 +313,7 @@ replace ``{distro}`` with your distribution (e.g., ``el6``, ``rhel6``, etc).
 	enabled=1
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc	
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 
 .. note:: Ensure you use the correct URL for your distribution. Check the
@@ -439,7 +439,7 @@ replace ``{distro}`` with your distribution (e.g., ``el6``, ``rhel6``,
 	enabled=1
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc	
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 
 Upgrade daemons in the following order:
@@ -512,7 +512,7 @@ replace ``{distro}`` with your distribution (e.g., ``el6``, ``rhel6``,
 	enabled=1
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc	
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 
 .. note:: Ensure you use the correct URL for your distribution. Check the

--- a/doc/rados/deployment/preflight-checklist.rst
+++ b/doc/rados/deployment/preflight-checklist.rst
@@ -89,7 +89,7 @@ Install ceph-deploy
 
 To install ``ceph-deploy``, execute the following:: 
 
-	wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | sudo apt-key add -
+	wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
 	echo deb http://ceph.com/debian-dumpling/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 	sudo apt-get update	
 	sudo apt-get install ceph-deploy

--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -31,7 +31,7 @@ For Debian and Ubuntu distributions, perform the following steps:
 
 #. Add the release key::
 
-	wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | sudo apt-key add -
+	wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
 
 #. Add the Ceph packages to your repository. Replace ``{ceph-stable-release}``
    with a stable Ceph release (e.g., ``cuttlefish``, ``dumpling``,
@@ -74,7 +74,7 @@ following steps:
 	enabled=1
 	gpgcheck=1
 	type=rpm-md
-	gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+	gpgkey=https://download.ceph.com/keys/release.asc
 
 
 #. Update your repository and install ``ceph-deploy``::


### PR DESCRIPTION
The GPG public keys are now present at https://download.ceph.com/keys. Our docs should recommend that users download the keys from this location.

Fixes http://tracker.ceph.com/issues/13603