### PR TITLE
FileJournal:_fdump wrongly returns if journal is currently unreadable.

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -292,7 +292,7 @@ int FileJournal::_open_file(int64_t oldsize, blksize_t blksize,
     char *buf;
     ret = ::posix_memalign((void **)&buf, block_size, write_size);
     if (ret != 0) {
-      return ret;
+      return -ret;
     }
     memset(static_cast<void*>(buf), 0, write_size);
     uint64_t i = 0;
@@ -629,7 +629,8 @@ int FileJournal::_fdump(Formatter &f, bool simple)
 
     if (!pos) {
       dout(2) << "_dump -- not readable" << dendl;
-      return false;
+      err = -EINVAL;
+      break;
     }
     stringstream ss;
     read_entry_result result = do_read_entry(
@@ -643,7 +644,7 @@ int FileJournal::_fdump(Formatter &f, bool simple)
         dout(2) << "Unable to read past sequence " << seq
 	    << " but header indicates the journal has committed up through "
 	    << header.committed_up_to << ", journal is corrupt" << dendl;
-        err = EINVAL;
+        err = -EINVAL;
       }
       dout(25) << ss.str() << dendl;
       dout(25) << "No further valid entries found, journal is most likely valid"


### PR DESCRIPTION
_fdump wrongly returns if journal is currently unreadable, and fix some other errors also.
Fixes: #13626
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>