### PR TITLE
ceph-disk: get Nonetype when ceph-disk list with --format plain on single device.

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -2738,6 +2738,8 @@ def list_format_dev_plain(dev, devices=[], prefix=''):
             desc = ['ceph data (dmcrypt %s)' % dmcrypt['type'], 'not currently mapped']
         elif len(dmcrypt['holders']) == 1:
             holder = '/dev/' + dmcrypt['holders'][0]
+            # re-list with the dm-x path
+            devices = list_devices([holder])
             def lookup_dev(devices, path):
                 for device in devices:
                     if device['path'] == path:
@@ -2851,8 +2853,8 @@ def list_dev(dev, uuid_map, journal_map):
 
     return info
 
-def list_devices(args):
-    partmap = list_all_partitions(args.path)
+def list_devices(path):
+    partmap = list_all_partitions(path)
 
     uuid_map = {}
     journal_map = {}
@@ -2912,7 +2914,7 @@ def list_devices(args):
     return devices
 
 def main_list(args):
-    devices = list_devices(args)
+    devices = list_devices(args.path)
     if args.format == 'json':
         print json.dumps(devices)
     else:

--- a/src/test/python/ceph-disk/tests/test_ceph_disk.py
+++ b/src/test/python/ceph-disk/tests/test_ceph_disk.py
@@ -136,7 +136,11 @@ class TestCephDisk(object):
                     'ptype': ptype,
                     'state': 'prepared',
                 }
-                out = ceph_disk.list_format_dev_plain(dev, devices)
+                with patch.multiple(
+                        ceph_disk,
+                        list_devices=lambda path: devices,
+                        ):
+                    out = ceph_disk.list_format_dev_plain(dev, devices)
                 assert 'data' in out
                 assert 'dmcrypt' in out
                 assert type in out


### PR DESCRIPTION

    with dmcrypt device, ceph-disk list will get Nonetype with the real device
    i.e. /dev/sdb1 for /dev/dm-1, `ceph-disk --list /dev/sdb1` will get Nonetype

    that because the holder we query is `dm-x`, the devices includ the path
    is `sdX`, it cannot match.

    if we list format plain and meet dmcrypt device, query again with the
    holder (dm-x).

    Also change the list_devices() parameter to let other function to use it
    easily.

Signed-off-by: Vicente Cheng <freeze.bilsted@gmail.com>