### PR TITLE
DNM: osd: reduce actual size of pg_log_entry_t

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3148,15 +3148,15 @@ void PG::update_snap_map(
 	  &_t);
 	assert(r == 0);
       } else {
-	assert(i->snaps.length() > 0);
-	vector<snapid_t> snaps;
-	bufferlist snapbl = i->snaps;
-	bufferlist::iterator p = snapbl.begin();
-	try {
-	  ::decode(snaps, p);
-	} catch (...) {
-	  snaps.clear();
-	}
+	      assert(i->snaps && i->snaps->length() > 0);
+        vector<snapid_t> snaps;
+        bufferlist *snapbl = i->snaps;
+        bufferlist::iterator p = snapbl->begin();
+        try {
+           ::decode(snaps, p);
+        } catch (...) {
+           snaps.clear();
+        }
 	set<snapid_t> _snaps(snaps.begin(), snaps.end());
 
 	if (i->is_clone() || i->is_promote()) {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3365,7 +3365,10 @@ ReplicatedPG::RepGather *ReplicatedPG::trim_object(const hobject_t &coid)
       ctx->log.back().mod_desc.mark_unrollbackable();
     }
     
-    ::encode(coi.snaps, ctx->log.back().snaps);
+    if (!ctx->log.back().snaps) {
+      ctx->log.back().snaps = new bufferlist();
+    }
+    ::encode(coi.snaps, *(ctx->log.back().snaps));
     ctx->at_version.version++;
   }
 
@@ -6204,7 +6207,10 @@ void ReplicatedPG::make_writeable(OpContext *ctx)
 				      ctx->obs->oi.version,
 				      ctx->obs->oi.user_version,
 				      osd_reqid_t(), ctx->new_obs.oi.mtime));
-    ::encode(snaps, ctx->log.back().snaps);
+    if (!ctx->log.back().snaps) {
+      ctx->log.back().snaps = new bufferlist();
+    }
+    ::encode(snaps, *(ctx->log.back().snaps));
     ctx->log.back().mod_desc.create();
 
     ctx->at_version.version++;
@@ -6598,7 +6604,10 @@ void ReplicatedPG::finish_ctx(OpContext *ctx, int log_op_type, bool maintain_ssc
     case pg_log_entry_t::CLEAN:
       dout(20) << __func__ << " encoding snaps " << ctx->new_obs.oi.snaps
 	       << dendl;
-      ::encode(ctx->new_obs.oi.snaps, ctx->log.back().snaps);
+      if (!ctx->log.back().snaps) {
+        ctx->log.back().snaps = new bufferlist();
+      }
+      ::encode(ctx->new_obs.oi.snaps, *(ctx->log.back().snaps));
       break;
     default:
       break;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2501,28 +2501,31 @@ struct pg_log_entry_t {
 
   // describes state for a locally-rollbackable entry
   ObjectModDesc mod_desc;
-  bufferlist snaps;   // only for clone entries
   hobject_t  soid;
   osd_reqid_t reqid;  // caller+tid to uniquely identify request
   vector<pair<osd_reqid_t, version_t> > extra_reqids;
   eversion_t version, prior_version, reverting_to;
+
   version_t user_version; // the user version for this entry
   utime_t     mtime;  // this is the _user_ mtime, mind you
+  bufferlist* snaps;   // only for clone entries
 
   __s32      op;
   bool invalid_hash; // only when decoding sobject_t based entries
   bool invalid_pool; // only when decoding pool-less hobject based entries
 
+  pg_log_entry_t(const pg_log_entry_t& other);
   pg_log_entry_t()
-   : user_version(0), op(0),
+   : user_version(0), snaps(NULL), op(0),
      invalid_hash(false), invalid_pool(false) {}
   pg_log_entry_t(int _op, const hobject_t& _soid,
                 const eversion_t& v, const eversion_t& pv,
                 version_t uv,
                 const osd_reqid_t& rid, const utime_t& mt)
    : soid(_soid), reqid(rid), version(v), prior_version(pv), user_version(uv),
-     mtime(mt), op(_op), invalid_hash(false), invalid_pool(false)
+     mtime(mt), snaps(NULL), op(_op), invalid_hash(false), invalid_pool(false)
      {}
+  ~pg_log_entry_t() { if (snaps) delete snaps; }
       
   bool is_clone() const { return op == CLONE; }
   bool is_modify() const { return op == MODIFY; }


### PR DESCRIPTION
- Reorder fields in this structure, so less space is wasted for alignment.
  This reduces size of single pg_log_entry_t by 8 bytes (from 368 to 360).
- Remove unused "offset" field, reducing struct size by 8 bytes (down to
  352 bytes).
- In many use cases, snapshots aren't used and bufferlist object in the
  pg_log_entry_t structure just takes memory without any benefits. Replace
  bfferlist with a pointer to it and allocate bufferlist as needed.
  This reduces size of single pg_log_entry_t by 72 bytes (down to 280 bytes),
  effectively reducing OSD memory consumption by around 10%.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>