### PR TITLE
messages/MOSDOp: Cast in assert to eliminate warnings

### DIFF
--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -99,7 +99,7 @@ public:
       return reqid;
     } else {
       if (!final_decode_needed)
-	assert(reqid.inc == client_inc);  // decode() should have done this
+	assert(reqid.inc == (int32_t)client_inc);  // decode() should have done this
       return osd_reqid_t(get_orig_source(),
                          reqid.inc,
 			 header.tid);


### PR DESCRIPTION
Fixes: #13625
Caused by 0bf2a79e

Signed-off-by: David Zafman <dzafman@redhat.com>