### PR TITLE
common/PrioritizedQueue: dequeue highest priority item in non-strict q

### DIFF
--- a/src/common/PrioritizedQueue.h
+++ b/src/common/PrioritizedQueue.h
@@ -26,8 +26,8 @@
 /**
  * Manages queue for normal and strict priority items
  *
- * On dequeue, the queue will select the lowest priority queue
- * such that the q has bucket > cost of front queue item.
+ * On dequeue, the queue will select the highest priority queue
+ * such that the q has bucket >= cost of front queue item.
  *
  * If there is no such queue, we choose the next queue item for
  * the highest priority queue.

--- a/src/common/PrioritizedQueue.h
+++ b/src/common/PrioritizedQueue.h
@@ -345,11 +345,11 @@ public:
     // if there are multiple buckets/subqueues with sufficient tokens,
     // we behave like a strict priority queue among all subqueues that
     // are eligible to run.
-    for (typename map<unsigned, SubQueue>::iterator i = queue.begin();
-	 i != queue.end();
+    for (typename map<unsigned, SubQueue>::reverse_iterator i = queue.rbegin();
+	 i != queue.rend();
 	 ++i) {
       assert(!(i->second.empty()));
-      if (i->second.front().first < i->second.num_tokens()) {
+      if (i->second.front().first <= i->second.num_tokens()) {
 	T ret = i->second.front().second;
 	unsigned cost = i->second.front().first;
 	i->second.take_tokens(cost);


### PR DESCRIPTION
Changes the token bucket to dequeue high priority OPs before low priority OPs if they are able to run. Also if there are just enough tokens for the op, let it run.