### PR TITLE
os: write EIO error, osd tidy shutdown rather than assert directly.

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -38,7 +38,7 @@ using namespace std;
 
 #include "global/global_init.h"
 #include "global/signal_handler.h"
-
+#include "global/error_handlers.h"
 #include "include/color.h"
 #include "common/errno.h"
 #include "common/pick_address.h"
@@ -67,7 +67,11 @@ void handle_osd_signal(int signum)
   if (osd)
     osd->handle_signal(signum);
 }
-
+void handle_io_error_tidy_shutdown()
+{
+  if (osd)
+    osd->io_error_tidy_shutdown();
+}
 void usage() 
 {
   cout << "usage: ceph-osd -i <osdid>\n"
@@ -589,7 +593,7 @@ int main(int argc, const char **argv)
   register_async_signal_handler(SIGHUP, sighup_handler);
   register_async_signal_handler_oneshot(SIGINT, handle_osd_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_osd_signal);
-
+  register_ceph_io_error_handler(handle_io_error_tidy_shutdown);
   osd->final_init();
 
   if (g_conf->inject_early_sigterm)

--- a/src/global/Makefile.am
+++ b/src/global/Makefile.am
@@ -2,7 +2,8 @@ libglobal_la_SOURCES = \
 	global/global_context.cc \
 	global/global_init.cc \
 	global/pidfile.cc \
-	global/signal_handler.cc
+	global/signal_handler.cc \
+	global/error_handlers.cc
 libglobal_la_LIBADD = $(LIBCOMMON)
 noinst_LTLIBRARIES += libglobal.la
 
@@ -10,5 +11,5 @@ noinst_HEADERS += \
 	global/pidfile.h \
 	global/global_init.h \
 	global/global_context.h \
-	global/signal_handler.h
-
+	global/signal_handler.h \
+	global/error_handlers.h

--- a/src/global/error_handlers.cc
+++ b/src/global/error_handlers.cc
@@ -1,0 +1,15 @@
+#include "global/error_handlers.h"
+
+static error_handler_t io_tidy_handler;
+
+void register_ceph_io_error_handler(error_handler_t handler) 
+{
+  io_tidy_handler = handler;
+}
+
+void ceph_io_error_tidy_shutdown() 
+{
+  if (io_tidy_handler) {
+    io_tidy_handler();
+  }
+}

--- a/src/global/error_handlers.h
+++ b/src/global/error_handlers.h
@@ -1,0 +1,9 @@
+#ifndef CEPH_GLOBAL_ERROR_HANDLER_H
+#define CEPH_GLOBAL_ERROR_HANDLER_H
+
+typedef void (*error_handler_t)();
+
+void register_ceph_io_error_handler(error_handler_t handler);
+void ceph_io_error_tidy_shutdown(); 
+
+#endif

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -34,7 +34,9 @@
 
 #include "common/blkdev.h"
 #include "common/linux_version.h"
+#include "global/error_handlers.h"
 
+ 
 #if defined(__FreeBSD__)
 #define O_DSYNC O_SYNC
 #endif
@@ -1136,12 +1138,14 @@ void FileJournal::do_write(bufferlist& bl)
     if (write_bl(pos, second)) {
       derr << "FileJournal::do_write: write_bl(pos=" << orig_pos
 	   << ") failed" << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
     orig_pos = first_pos;
     if (write_bl(first_pos, first)) {
       derr << "FileJournal::do_write: write_bl(pos=" << orig_pos
 	   << ") failed" << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
     assert(first_pos == get_top());
@@ -1153,6 +1157,7 @@ void FileJournal::do_write(bufferlist& bl)
 	derr << "FileJournal::do_write: pwrite(fd=" << fd
 	     << ", hbp.length=" << hbp.length() << ") failed :"
 	     << cpp_strerror(err) << dendl;
+	ceph_io_error_tidy_shutdown();
 	ceph_abort();
       }
     }
@@ -1160,6 +1165,7 @@ void FileJournal::do_write(bufferlist& bl)
     if (write_bl(pos, bl)) {
       derr << "FileJournal::do_write: write_bl(pos=" << pos
 	   << ") failed" << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
   }
@@ -1190,6 +1196,7 @@ void FileJournal::do_write(bufferlist& bl)
 #endif
     if (ret < 0) {
       derr << __func__ << " fsync/fdatasync failed: " << cpp_strerror(errno) << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
 #ifdef HAVE_POSIX_FADVISE

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -78,6 +78,7 @@ using ceph::crypto::SHA1;
 
 #include "common/config.h"
 #include "common/blkdev.h"
+#include "global/error_handlers.h"
 
 #ifdef WITH_LTTNG
 #define TRACEPOINT_DEFINE
@@ -1248,6 +1249,9 @@ int FileStore::write_op_seq(int fd, uint64_t seq)
   int ret = TEMP_FAILURE_RETRY(::pwrite(fd, s, strlen(s), 0));
   if (ret < 0) {
     ret = -errno;
+    if (m_filestore_fail_eio && ret == -EIO) {
+      ceph_io_error_tidy_shutdown();
+    }
     assert(!m_filestore_fail_eio || ret != -EIO);
   }
   return ret;
@@ -2835,7 +2839,7 @@ unsigned FileStore::_do_transaction(
 	if (r == -EMFILE) {
 	  dump_open_fds(g_ceph_context);
 	}
-
+	ceph_io_error_tidy_shutdown();
 	assert(0 == "unexpected error");
       }
     }
@@ -3632,6 +3636,7 @@ void FileStore::sync_entry()
 	int err = write_op_seq(op_fd, cp);
 	if (err < 0) {
 	  derr << "Error during write_op_seq: " << cpp_strerror(err) << dendl;
+	  ceph_io_error_tidy_shutdown();
 	  assert(0 == "error during write_op_seq");
 	}
 
@@ -3673,11 +3678,13 @@ void FileStore::sync_entry()
 	err = write_op_seq(op_fd, cp);
 	if (err < 0) {
 	  derr << "Error during write_op_seq: " << cpp_strerror(err) << dendl;
+	  ceph_io_error_tidy_shutdown();
 	  assert(0 == "error during write_op_seq");
 	}
 	err = ::fsync(op_fd);
 	if (err < 0) {
 	  derr << "Error during fsync of op_seq: " << cpp_strerror(err) << dendl;
+	  ceph_io_error_tidy_shutdown();
 	  assert(0 == "error during fsync of op_seq");
 	}
       }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1610,7 +1610,12 @@ void OSD::handle_signal(int signum)
 {
   assert(signum == SIGINT || signum == SIGTERM);
   derr << "*** Got signal " << sys_siglist[signum] << " ***" << dendl;
-  shutdown();
+  shutdown();  
+}
+
+void OSD::io_error_tidy_shutdown() 
+{
+  service.prepare_to_stop();
 }
 
 int OSD::pre_init()

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2369,7 +2369,7 @@ public:
   int shutdown();
 
   void handle_signal(int signum);
-
+  void io_error_tidy_shutdown();
   /// check if we can throw out op from a disconnected client
   static bool op_is_discardable(MOSDOp *m);
 


### PR DESCRIPTION
assert directly will cost cluster too long to be normal, but if notify
    monitor to mark me down before exit will let cluster recover faster!
 
test:
    have tested by unpin the disk, cluster write latency very very little
    compared to just assert and exit.
    
Signed-off-by: Xiaowei Chen <chen.xiaowei@h3c.com>