### PR TITLE
rgw: Fix typo in RGWHTTPClient::process error message

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -108,7 +108,7 @@ int RGWHTTPClient::process(const char *method, const char *url)
   }
   CURLcode status = curl_easy_perform(curl_handle);
   if (status) {
-    dout(0) << "curl_easy_performed returned error: " << error_buf << dendl;
+    dout(0) << "curl_easy_perform returned error: " << error_buf << dendl;
     ret = -EINVAL;
   }
   curl_easy_cleanup(curl_handle);


### PR DESCRIPTION
Change curl_easy_performed to curl_easy_perform in RGWHTTPClient::process error output.