### PR TITLE
Objecter: pool_op callback may hang forever.

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3773,6 +3773,13 @@ void Objecter::handle_pool_op_reply(MPoolOpReply *m)
         ldout(cct, 20) << "waiting for client to reach epoch " << m->epoch << " before calling back" << dendl;
         _wait_for_new_map(op->onfinish, m->epoch, m->replyCode);
       }
+      else {
+	// map epoch changed, probalbly because a MOSDMap message
+	// sneaked in. Do caller-specified callback now or else
+	// we lost it forever.
+	if (op->onfinish)
+	  op->onfinish->complete(m->replyCode);	
+      }
     }
     else {
       op->onfinish->complete(m->replyCode);


### PR DESCRIPTION
pool_op callback may hang forever due to osdmap update during reply handling.
Fixes: #13642
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>
Fixup https://github.com/ceph/ceph/pull/6426, coming back later.