### PR TITLE
S wip 13422

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -261,6 +261,11 @@ int global_init_prefork(CephContext *cct, int flags)
 {
   if (g_code_env != CODE_ENVIRONMENT_DAEMON)
     return -1;
+    
+  if (test_pidFile_in_use(g_conf) < 0){
+     exit(1);
+  } 
+  
   const md_config_t *conf = cct->_conf;
   if (!conf->daemonize) {
     if (atexit(pidfile_remove_void)) {
@@ -282,13 +287,13 @@ int global_init_prefork(CephContext *cct, int flags)
 void global_init_daemonize(CephContext *cct, int flags)
 {
   
+  if (global_init_prefork(cct, flags) < 0)
+    return;
+  
   if (test_pidFile_in_use(g_conf) < 0){
      exit(1);
   } 
   
-  if (global_init_prefork(cct, flags) < 0)
-    return;
-
   int ret = daemon(1, 1);
   if (ret) {
     ret = errno;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -281,6 +281,11 @@ int global_init_prefork(CephContext *cct, int flags)
 
 void global_init_daemonize(CephContext *cct, int flags)
 {
+  
+  if (test_pidFile_in_use(g_conf) < 0){
+     exit(1);
+  } 
+  
   if (global_init_prefork(cct, flags) < 0)
     return;
 

--- a/src/global/pidfile.h
+++ b/src/global/pidfile.h
@@ -25,4 +25,6 @@ int pidfile_write(const md_config_t *conf);
 // This is safe to call in a signal handler context.
 int pidfile_remove(void);
 
+//check pid file at whether it's used by another osd or monitor,then to protect pid-file from deteling
+int test_pidFile_in_use(const md_config_t *conf)
 #endif


### PR DESCRIPTION
add a function named test_pidFile_in_use for checking whether pid-file is in using by another osd or monitor to advoid pid-file from deleted
Fixes: #13422
Signed-off-by: songshun <songshun134@126.com>