### PR TITLE
Shun-s patch 13422

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -261,6 +261,11 @@ int global_init_prefork(CephContext *cct, int flags)
 {
   if (g_code_env != CODE_ENVIRONMENT_DAEMON)
     return -1;
+  
+  if (test_pidFile_in_use(g_conf) < 0){
+     exit(1);
+  }
+  
   const md_config_t *conf = cct->_conf;
   if (!conf->daemonize) {
     if (atexit(pidfile_remove_void)) {
@@ -284,6 +289,10 @@ void global_init_daemonize(CephContext *cct, int flags)
   if (global_init_prefork(cct, flags) < 0)
     return;
 
+  if (test_pidFile_in_use(g_conf) < 0){
+     exit(1);
+  }
+  
   int ret = daemon(1, 1);
   if (ret) {
     ret = errno;

--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -96,3 +96,28 @@ int pidfile_remove(void)
   pid_file[0] = '\0';
   return 0;
 }
+
+int test_pidFile_in_use(const md_config_t *conf){
+    int fd;
+    snprintf(pid_file, PATH_MAX, "%s", conf->pid_file.c_str());
+    fd = TEMP_FAILURE_RETRY(::open(pid_file,
+                                 O_CREAT|O_WRONLY, 0644));
+    if (fd < 0) {
+        int err = errno;
+        derr << "write_pid_file: failed to open pid file '"
+             << pid_file << "': " << cpp_strerror(err) << dendl;
+        return err;
+    }
+    struct flock l;
+    memset(&l, 0, sizeof(l));
+    l.l_type = F_WRLCK;
+    l.l_whence = SEEK_SET;
+    l.l_start = 0;
+    l.l_len = 0;
+    int r = ::fcntl(fd, F_SETLK, &l);
+    if( r < 0 ){
+        derr << "pidFile failed to lock, " << "is there other osd in using?" <<dendl;
+        return r;
+    }
+    return 0;
+}

--- a/src/global/pidfile.h
+++ b/src/global/pidfile.h
@@ -25,4 +25,7 @@ int pidfile_write(const md_config_t *conf);
 // This is safe to call in a signal handler context.
 int pidfile_remove(void);
 
+//protect pid-file from deleting by multiple startup
+int test_pidFile_in_use(const md_config_t *conf);
+
 #endif


### PR DESCRIPTION
add a interface for protecting pid-file from removed when multiple osds or mons startup to compete the same pid-file.
#13422