### PR TITLE
tests: test/librados/test.cc must create profile

### DIFF
--- a/src/test/librados/test.cc
+++ b/src/test/librados/test.cc
@@ -69,6 +69,18 @@ std::string create_one_ec_pool(const std::string &pool_name, rados_t *cluster)
     
   char *cmd[2];
   cmd[1] = NULL;
+
+  std::string profile_create = "{\"prefix\": \"osd erasure-code-profile set\", \"name\": \"testprofile\", \"profile\": [ \"k=2\", \"m=1\", \"ruleset-failure-domain=osd\"]}";
+  cmd[0] = (char *)profile_create.c_str();
+  ret = rados_mon_command(*cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0);
+  if (ret) {
+    std::ostringstream oss;
+
+    rados_shutdown(*cluster);
+    oss << "rados_mon_command erasure-code-profile set name:testprofile failed with error " << ret;
+    return oss.str();
+  }
+
   std::string cmdstr = "{\"prefix\": \"osd pool create\", \"pool\": \"" +
      pool_name + "\", \"pool_type\":\"erasure\", \"pg_num\":8, \"pgp_num\":8, \"erasure_code_profile\":\"testprofile\"}";
   cmd[0] = (char *)cmdstr.c_str();
@@ -81,7 +93,7 @@ std::string create_one_ec_pool(const std::string &pool_name, rados_t *cluster)
       oss << "rados_mon_command osd erasure-code-profile rm name:testprofile failed with error " << ret2 << std::endl;
 
     rados_shutdown(*cluster);
-    oss << "rados_mon_command erasure-code-profile set name:testprofile failed with error " << ret;
+    oss << "rados_mon_command osd pool create failed with error " << ret;
     return oss.str();
   }
 


### PR DESCRIPTION
Now that the create_one_ec_pool function removes the testprofile each
time it is called, it must create the testprofile erasure code profile
again for the test to use.

http://tracker.ceph.com/issues/13664 Refs: #13664

Signed-off-by: Loic Dachary <ldachary@redhat.com>