### PR TITLE
mds:the ceph-mds command option "--hot-standby" is useless.

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -120,7 +120,7 @@ int main(int argc, const char **argv)
     }
     else if (ceph_argparse_witharg(args, i, &val, "--hot-standby", (char*)NULL)) {
       int r = parse_rank("hot-standby", val);
-      if (shadow) {
+      if (shadow != MDSMap::STATE_NULL) {
         dout(0) << "Error: can only select one standby state" << dendl;
         return -1;
       }


### PR DESCRIPTION
The definition of MDSMap::STATE_NULL is not 0 in this version, so you can't use "if (shadow)". 
We should use "if (shadow != MDSMap::STATE_NULL)".
If we not change, the ceph-mds command option "--hot-standby" will useless.