### PR TITLE
HashIndex: cancel merge if it is going to trigger another split on it…

### DIFF
--- a/src/os/HashIndex.cc
+++ b/src/os/HashIndex.cc
@@ -653,6 +653,12 @@ int HashIndex::complete_merge(const vector<string> &path, subdir_info_s info) {
   r = get_info(dst, &dstinfo);
   if (r < 0)
     return r;
+  // Cancel merge if adopting these objects will cause an immediate
+  // split on its direct parent dirent.
+  subdir_info_s tmpinfo(dstinfo);
+  tmpinfo.objs += info.objs;
+  if (must_split(tmpinfo))
+    return end_split_or_merge(path);
   if (exists) {
     r = move_objects(path, dst);
     if (r < 0)


### PR DESCRIPTION
…s direct parent

HashIndex: shall cancel merge if it is going to trigger another split on its direct parent, otherwise the cost of the merge may be very expensive.
Fixes: #13530
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>