### PR TITLE
rgw: fix the quota check when S3 multipart upload

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -663,7 +663,7 @@ public:
     policy.set_ctx(s->cct);
   }
 
-  RGWPutObjProcessor *select_processor(RGWObjectCtx& obj_ctx, bool *is_multipart);
+  RGWPutObjProcessor *select_processor(RGWObjectCtx& obj_ctx, bool is_multipart);
   void dispose_processor(RGWPutObjProcessor *processor);
 
   int verify_permission();

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -732,7 +732,7 @@ public:
     if (ret < 0)
       return ret;
 
-    if (bucket_quota.enabled) {
+    if (bucket_quota.enabled && num_objs) {
       ret = check_quota("bucket", bucket_quota, bucket_stats, num_objs, size_kb);
       if (ret < 0)
         return ret;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8866,9 +8866,10 @@ int RGWRados::cls_user_remove_bucket(rgw_obj& obj, const cls_user_bucket& bucket
 }
 
 int RGWRados::check_quota(const rgw_user& bucket_owner, rgw_bucket& bucket,
-                          RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size)
+                          RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota,
+                          uint64_t num_objs, uint64_t obj_size)
 {
-  return quota_handler->check_quota(bucket_owner, bucket, user_quota, bucket_quota, 1, obj_size);
+  return quota_handler->check_quota(bucket_owner, bucket, user_quota, bucket_quota, num_objs, obj_size);
 }
 
 void RGWRados::get_bucket_index_objects(const string& bucket_oid_base,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2217,7 +2217,7 @@ public:
   int cls_user_remove_bucket(rgw_obj& obj, const cls_user_bucket& bucket);
 
   int check_quota(const rgw_user& bucket_owner, rgw_bucket& bucket,
-                  RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size);
+                  RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t num_objs, uint64_t obj_size);
 
   string unique_id(uint64_t unique_num) {
     char buf[32];


### PR DESCRIPTION
when the remainder quota of one bucket exceed the maxnum's 95%,then the next file upload can't succeed if it's multipart num more than maxnum's 5%.

chang the quota check timing,only multi post request check quota,multi put will not check obj num again.

Fix: #13223

Signed-off-by: Zengran Zhang zhangzengran@h3c.com
