### PR TITLE
cls_rbd: change object_map_update to return 0 on success, add logging

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -2199,6 +2199,7 @@ int object_map_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out
     ::decode(new_object_state, iter);
     ::decode(current_object_state, iter);
   } catch (const buffer::error &err) {
+    CLS_ERR("failed to decode message");
     return -EINVAL;
   }
 
@@ -2212,6 +2213,7 @@ int object_map_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out
   bufferlist header_bl;
   r = cls_cxx_read(hctx, 0, object_map.get_header_length(), &header_bl);
   if (r < 0) {
+    CLS_ERR("object map header read failed");
     return r;
   }
 
@@ -2247,6 +2249,7 @@ int object_map_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out
   r = cls_cxx_read(hctx, object_map.get_header_length() + byte_offset,
 		   byte_length, &data_bl); 
   if (r < 0) {
+    CLS_ERR("object map data read failed");
     return r;
   }
 
@@ -2285,8 +2288,15 @@ int object_map_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out
     object_map.encode_footer(footer_bl);
     r = cls_cxx_write(hctx, object_map.get_footer_offset(), footer_bl.length(),
 		      &footer_bl);
+  } else {
+    CLS_LOG(20, "object_map_update: no update necessary");
   }
-  return r;
+
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
 }
 
 /**


### PR DESCRIPTION
The rbd_object_map_update class method returns the size of the data read
from the object map when no update is necessary. Change this to return 0
on success. Add error logging to differentiate error cases.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>