### PR TITLE
FileJournal: sync avoid tp pause

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -517,16 +517,8 @@ int FileJournal::open(uint64_t fs_op_seq)
   // find next entry
   read_pos = header.start;
   uint64_t seq = header.start_seq;
-
-  // last_committed_seq is 1 before the start of the journal or
-  // 0 if the start is 0
-  last_committed_seq = seq > 0 ? seq - 1 : seq;
-  if (last_committed_seq < fs_op_seq) {
-    dout(2) << "open advancing committed_seq " << last_committed_seq
-	    << " to fs op_seq " << fs_op_seq << dendl;
-    last_committed_seq = fs_op_seq;
-  }
-
+  last_committed_seq = fs_op_seq;
+  
   while (1) {
     bufferlist bl;
     off64_t old_pos = read_pos;

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -517,7 +517,15 @@ int FileJournal::open(uint64_t fs_op_seq)
   // find next entry
   read_pos = header.start;
   uint64_t seq = header.start_seq;
-  last_committed_seq = fs_op_seq;
+
+  // last_committed_seq is 1 before the start of the journal or
+  // 0 if the start is 0
+  last_committed_seq = seq > 0 ? seq - 1 : seq;
+  if (last_committed_seq < fs_op_seq) {
+    dout(2) << "open advancing committed_seq " << last_committed_seq
+	    << " to fs op_seq " << fs_op_seq << dendl;
+    last_committed_seq = fs_op_seq;
+  }
   
   while (1) {
     bufferlist bl;

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -3608,7 +3608,6 @@ void FileStore::sync_entry()
     fin.swap(sync_waiters);
     lock.Unlock();
     
-    op_tp.pause();
     if (apply_manager.commit_start()) {
       utime_t start = ceph_clock_now(g_ceph_context);
       uint64_t cp = apply_manager.get_committing_seq();
@@ -3647,7 +3646,6 @@ void FileStore::sync_entry()
 
 	snaps.push_back(cp);
 	apply_manager.commit_started();
-	op_tp.unpause();
 
 	if (cid > 0) {
 	  dout(20) << " waiting for checkpoint " << cid << " to complete" << dendl;
@@ -3661,7 +3659,6 @@ void FileStore::sync_entry()
       } else
       {
 	apply_manager.commit_started();
-	op_tp.unpause();
 
 	object_map->sync();
 	int err = backend->syncfs();
@@ -3716,9 +3713,7 @@ void FileStore::sync_entry()
       sync_entry_timeo_lock.Lock();
       timer.cancel_event(sync_entry_timeo);
       sync_entry_timeo_lock.Unlock();
-    } else {
-      op_tp.unpause();
-    }
+    } 
     
     lock.Lock();
     finish_contexts(g_ceph_context, fin, 0);

--- a/src/os/JournalingObjectStore.cc
+++ b/src/os/JournalingObjectStore.cc
@@ -128,6 +128,9 @@ uint64_t JournalingObjectStore::ApplyManager::op_apply_start(uint64_t op)
   assert(!blocked);
   assert(op > committed_seq);
   open_ops++;
+
+  applying_seq_set.insert(op);
+
   return op;
 }
 
@@ -146,11 +149,13 @@ void JournalingObjectStore::ApplyManager::op_apply_finish(uint64_t op)
     blocked_cond.Signal();
   }
 
+  applying_seq_set.erase(op);
   // there can be multiple applies in flight; track the max value we
   // note.  note that we can't _read_ this value and learn anything
   // meaningful unless/until we've quiesced all in-flight applies.
   if (op > max_applied_seq)
     max_applied_seq = op;
+  
 }
 
 uint64_t JournalingObjectStore::SubmitManager::op_submit_start()
@@ -193,27 +198,38 @@ bool JournalingObjectStore::ApplyManager::commit_start()
     dout(10) << "commit_start max_applied_seq " << max_applied_seq
 	     << ", open_ops " << open_ops
 	     << dendl;
+  
     blocked = true;
-    while (open_ops > 0) {
-      dout(10) << "commit_start waiting for " << open_ops << " open ops to drain" << dendl;
-      blocked_cond.Wait(apply_lock);
-    }
-    assert(open_ops == 0);
-    dout(10) << "commit_start blocked, all open_ops have completed" << dendl;
     {
       Mutex::Locker l(com_lock);
-      if (max_applied_seq == committed_seq) {
-	dout(10) << "commit_start nothing to do" << dendl;
+
+      set<uint64_t>::iterator it = applying_seq_set.begin();
+      if(it == applying_seq_set.end()){
+       		_committing_seq = committing_seq = max_applied_seq; 
+		
+        	dout(10) << "commit_start committing from end: " << committing_seq 
+			 << ",current applying_seq_set size:"<< applying_seq_set.size()
+			<< ", still blocked" << dendl;
+		assert(applying_seq_set.size() ==0);
+      }else
+      {
+        	_committing_seq = committing_seq = *it;
+       		dout(10) << "commit_start committing from head: " << committing_seq 
+			 << ",current applying_seq_set size:"<< applying_seq_set.size()
+			<< ", still blocked" << dendl;
+		assert(applying_seq_set.size() == open_ops);
+      }
+      
+      if(committing_seq == committed_seq){
+      	dout(10) << "commit_start nothing to do" << dendl;
 	blocked = false;
-	assert(commit_waiters.empty());
 	goto out;
       }
+      
+    } 
+    
+  
 
-      _committing_seq = committing_seq = max_applied_seq;
-
-      dout(10) << "commit_start committing " << committing_seq
-	       << ", still blocked" << dendl;
-    }
   }
   ret = true;
 

--- a/src/os/JournalingObjectStore.cc
+++ b/src/os/JournalingObjectStore.cc
@@ -217,7 +217,6 @@ bool JournalingObjectStore::ApplyManager::commit_start()
        		dout(10) << "commit_start committing from head: " << committing_seq 
 			 << ",current applying_seq_set size:"<< applying_seq_set.size()
 			<< ", still blocked" << dendl;
-		assert(applying_seq_set.size() == open_ops);
       }
       
       if(committing_seq == committed_seq){

--- a/src/os/JournalingObjectStore.h
+++ b/src/os/JournalingObjectStore.h
@@ -59,13 +59,16 @@ protected:
     map<version_t, vector<Context*> > commit_waiters;
     uint64_t committing_seq, committed_seq;
 
+    //std::set use red-black tree, default ascending order
+    set<uint64_t>   applying_seq_set;
+
   public:
     ApplyManager(Journal *&j, Finisher &f) :
       journal(j), finisher(f),
       apply_lock("JOS::ApplyManager::apply_lock", false, true, false, g_ceph_context),
       blocked(false),
       open_ops(0),
-      max_applied_seq(0),
+      max_applied_seq(1),
       com_lock("JOS::ApplyManager::com_lock", false, true, false, g_ceph_context),
       committing_seq(0), committed_seq(0) {}
     void reset() {

--- a/src/os/JournalingObjectStore.h
+++ b/src/os/JournalingObjectStore.h
@@ -68,7 +68,7 @@ protected:
       apply_lock("JOS::ApplyManager::apply_lock", false, true, false, g_ceph_context),
       blocked(false),
       open_ops(0),
-      max_applied_seq(1),
+      max_applied_seq(0),
       com_lock("JOS::ApplyManager::com_lock", false, true, false, g_ceph_context),
       committing_seq(0), committed_seq(0) {}
     void reset() {


### PR DESCRIPTION
when sync file journal ,it is needed to do:
1)it firstly calls op_tp.pause() to stop applying operation
2) wait all the in flight  apply operatons completed
3)calls op_tp.unpause() to continue applying operation

In this way, apply operation must be interrupted by sync of file journal, which may has performance affection.

Actually, it doesn't need waiting all the in flight applying operations complete.  It should just sync the apply operation that has been completed , leave the in flight apply operations to be synced next time

Signed-off-by: changtao changtao@hihuron.com