### PR TITLE
FileStore::_check_replay_guard avoids double check on replaying and can_checkpoint()

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -2126,9 +2126,6 @@ void FileStore::_set_global_replay_guard(coll_t cid,
 int FileStore::_check_global_replay_guard(coll_t cid,
 					  const SequencerPosition& spos)
 {
-  if (!replaying || backend->can_checkpoint())
-    return 1;
-
   char fn[PATH_MAX];
   get_cdir(cid, fn, sizeof(fn));
   int fd = ::open(fn, O_RDONLY);


### PR DESCRIPTION
Already checked in _check_replay_guard, avoid double check in the inner function _check_global_replay_guard

Signed-off-by: Ning Yao <zay11022@gmail.com>