### PR TITLE
librados: wrongly passed in argument for stat command

### DIFF
--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -1206,7 +1206,7 @@ int librados::IoCtx::rmxattr(const std::string& oid, const char *name)
 int librados::IoCtx::stat(const std::string& oid, uint64_t *psize, time_t *pmtime)
 {
   object_t obj(oid);
-  return io_ctx_impl->stat(oid, psize, pmtime);
+  return io_ctx_impl->stat(obj, psize, pmtime);
 }
 
 int librados::IoCtx::exec(const std::string& oid, const char *cls, const char *method,


### PR DESCRIPTION
The first argument of io_ctx_impl->stat() requires an obj(of type object_t), but an oid(of type string) is directly passed in instead.
Fixes: #13703
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>