### PR TITLE
rgw: fix reload on non Debian systems.

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -118,7 +118,7 @@ case "$1" in
 	if [ $DEBIAN -eq 1 ]; then
             start-stop-daemon --stop --signal HUP -x $RADOSGW --oknodo
 	else
-            killproc $RADOSGW -SIGHUP
+            killproc $RADOSGW -HUP
 	fi
 	;;
     restart|force-reload)


### PR DESCRIPTION
When using reload in non-debian systems, /bin/sh's kill is used to send the HUP signal to the radosgw process.
This kill version doesn't understand -SIGHUP as a valid signal, using -HUP does work.

Fix: #13709
Backport: hammer
Signed-off-by: Hervé Rousseau <hroussea@cern.ch>