### PR TITLE
doc/releases-notes: fix build error

### DIFF
--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -9,8 +9,8 @@ Timeline
 |                            |`Dumpling`_|`Emperor`_ |`Firefly`_ |`Giant`_   |`Hammer`_  |`Infernalis`_ |
 |                            |LTS        |Stable     |LTS        |Stable     |LTS        |Stable        |
 +----------------------------+-----------+-----------+-----------+-----------+-----------+--------------+
-|     First release          | August    | November  | May       | October   | April     | November      |
-|                            | 2013      | 2013      | 2014      | 2014      | 2015      | 2014         |
+|     First release          | August    | November  | May       | October   | April     | November     |
+|                            | 2013      | 2013      | 2014      | 2014      | 2015      | 2015         |
 +----------------------------+-----------+-----------+-----------+-----------+-----------+--------------+
 |  Estimated retirement      | March     |           | January   |           | November  |              |
 |                            | 2015      |           | 2016      |           | 2016      |              |


### PR DESCRIPTION
see http://gitbuilder.sepia.ceph.com/gitbuilder-doc/log.cgi?log=2c968db0f24d74b541c028e15a7eff2e430d5ad0

```
ERROR: /srv/autobuild-ceph/gitbuilder.git/build/doc/releases.rst:8: Malformed table.
+----------------------------+-----------+-----------+-----------+-----------+-----------+--------------+
| |`Dumpling`_|`Emperor`_ |`Firefly`_ |`Giant`_ |`Hammer`_ |`Infernalis`_ |
| |LTS |Stable |LTS |Stable |LTS |Stable |
+----------------------------+-----------+-----------+-----------+-----------+-----------+--------------+
| First release | August | November | May | October | April | November |
| | 2013 | 2013 | 2014 | 2014 | 2015 | 2014 |
+----------------------------+-----------+-----------+-----------+-----------+-----------+--------------+
| Estimated retirement | March | | January | | November | |
| | 2015 | | 2016 | | 2016 | |
+----------------------------+-----------+-----------+-----------+-----------+-----------+--------------+
| Actual retirement | May | May | | April | | |
| | 2015 | 2014 | | 2015 | | |
+----------------------------+-----------+-----------+-----------+-----------+-----------+--------------+
```

Signed-off-by: Kefu Chai <kchai@redhat.com>