### PR TITLE
os: write file journal optimization

### DIFF
--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -893,7 +893,7 @@ int FileJournal::prepare_multi_write(bufferlist& bl, uint64_t& orig_ops, uint64_
 	// throw out what we have so far
 	full_state = FULL_FULL;
 	while (!writeq_empty()) {
-	  put_throttle(1, peek_write().bl.length());
+	  put_throttle(1, peek_write().orig_len);
 	  pop_write();
 	}  
 	print_header(header);
@@ -973,54 +973,39 @@ int FileJournal::prepare_single_write(bufferlist& bl, off64_t& queue_pos, uint64
   write_item &next_write = peek_write();
   uint64_t seq = next_write.seq;
   bufferlist &ebl = next_write.bl;
-  unsigned head_size = sizeof(entry_header_t);
-  off64_t base_size = 2*head_size + ebl.length();
-
-  int alignment = next_write.alignment; // we want to start ebl with this alignment
-  unsigned pre_pad = 0;
-  if (alignment >= 0)
-    pre_pad = ((unsigned int)alignment - (unsigned int)head_size) & ~CEPH_PAGE_MASK;
-  off64_t size = ROUND_UP_TO(base_size + pre_pad, header.alignment);
-  unsigned post_pad = size - base_size - pre_pad;
+  off64_t size = ebl.length();
 
   int r = check_for_full(seq, queue_pos, size);
   if (r < 0)
     return r;   // ENOSPC or EAGAIN
 
-  orig_bytes += ebl.length();
+  uint32_t orig_len = next_write.orig_len;
+  orig_bytes += orig_len;
   orig_ops++;
 
   // add to write buffer
   dout(15) << "prepare_single_write " << orig_ops << " will write " << queue_pos << " : seq " << seq
-	   << " len " << ebl.length() << " -> " << size
-	   << " (head " << head_size << " pre_pad " << pre_pad
-	   << " ebl " << ebl.length() << " post_pad " << post_pad << " tail " << head_size << ")"
-	   << " (ebl alignment " << alignment << ")"
-	   << dendl;
+	   << " len " << orig_len << " -> " << size << dendl;
     
-  // add it this entry
-  entry_header_t h;
-  memset(&h, 0, sizeof(h));
-  h.seq = seq;
-  h.pre_pad = pre_pad;
-  h.len = ebl.length();
-  h.post_pad = post_pad;
-  h.make_magic(queue_pos, header.get_fsid64());
-  h.crc32c = ebl.crc32c(0);
+  unsigned seq_offset = offsetof(entry_header_t, seq);
+  unsigned magic1_offset = offsetof(entry_header_t, magic1);
+  unsigned magic2_offset = offsetof(entry_header_t, magic2);
 
-  bl.append((const char*)&h, sizeof(h));
-  if (pre_pad) {
-    bufferptr bp = buffer::create_static(pre_pad, zero_buf);
-    bl.push_back(bp);
-  }
-  bl.claim_append(ebl, buffer::list::CLAIM_ALLOW_NONSHAREABLE); // potential zero-copy
+  bufferptr headerptr = ebl.buffers().front();
+  uint64_t _seq = seq;
+  uint64_t _queue_pos = queue_pos;
+  uint64_t magic2 = entry_header_t::make_magic(seq, orig_len, header.get_fsid64());
+  headerptr.copy_in(seq_offset, sizeof(uint64_t), (char *)&_seq);
+  headerptr.copy_in(magic1_offset, sizeof(uint64_t), (char *)&_queue_pos);
+  headerptr.copy_in(magic2_offset, sizeof(uint64_t), (char *)&magic2);
 
-  if (h.post_pad) {
-    bufferptr bp = buffer::create_static(post_pad, zero_buf);
-    bl.push_back(bp);
-  }
-  bl.append((const char*)&h, sizeof(h));
+  bufferptr footerptr = ebl.buffers().back();
+  unsigned post_offset  = footerptr.length() - sizeof(entry_header_t);
+  footerptr.copy_in(post_offset + seq_offset, sizeof(uint64_t), (char *)&_seq);
+  footerptr.copy_in(post_offset + magic1_offset, sizeof(uint64_t), (char *)&_queue_pos);
+  footerptr.copy_in(post_offset + magic2_offset, sizeof(uint64_t), (char *)&magic2);
 
+  bl.claim_append(ebl);
   if (next_write.tracked_op)
     next_write.tracked_op->mark_event("write_thread_in_journal_buffer");
 
@@ -1041,8 +1026,7 @@ void FileJournal::align_bl(off64_t pos, bufferlist& bl)
   // make sure list segments are page aligned
   if (directio && (!bl.is_aligned(block_size) ||
 		   !bl.is_n_align_sized(CEPH_MINIMUM_BLOCK_SIZE))) {
-    bl.rebuild_aligned(CEPH_MINIMUM_BLOCK_SIZE);
-    dout(10) << __func__ << " total memcopy: " << bl.get_memcopy_count() << dendl;
+    assert(0 == "bl should be align");
     if ((bl.length() & (CEPH_MINIMUM_BLOCK_SIZE - 1)) != 0 ||
 	(pos & (CEPH_MINIMUM_BLOCK_SIZE - 1)) != 0)
       dout(0) << "rebuild_page_aligned failed, " << bl << dendl;
@@ -1300,7 +1284,7 @@ void FileJournal::write_thread_entry()
       if (write_stop) {
 	dout(20) << "write_thread_entry full and stopping, throw out queue and finish up" << dendl;
 	while (!writeq_empty()) {
-	  put_throttle(1, peek_write().bl.length());
+	  put_throttle(1, peek_write().orig_len);
 	  pop_write();
 	}  
 	print_header(header);
@@ -1576,7 +1560,60 @@ void FileJournal::check_aio_completion()
 }
 #endif
 
-void FileJournal::submit_entry(uint64_t seq, bufferlist& e, int alignment,
+int FileJournal::prepare_entry(list<ObjectStore::Transaction*>& tls, bufferlist* tbl) {
+  dout(10) << "prepare_entry " << tls << dendl;
+  unsigned data_len = 0;
+  int data_align = -1; // -1 indicates that we don't care about the alignment
+  bufferlist bl;
+  for (list<ObjectStore::Transaction*>::iterator p = tls.begin();
+      p != tls.end(); ++p) {
+    ObjectStore::Transaction *t = *p;
+    if (t->get_data_length() > data_len &&
+     (int)t->get_data_length() >= g_conf->journal_align_min_size) {
+     data_len = t->get_data_length();
+     data_align = (t->get_data_alignment() - bl.length()) & ~CEPH_PAGE_MASK;
+    }
+    ::encode(*t, bl);
+  }
+  if (tbl->length()) {
+    bl.claim_append(*tbl);
+  }
+  // add it this entry
+  entry_header_t h;
+  unsigned head_size = sizeof(entry_header_t);
+  off64_t base_size = 2*head_size + bl.length();
+  memset(&h, 0, sizeof(h));
+  if (data_align >= 0)
+    h.pre_pad = ((unsigned int)data_align - (unsigned int)head_size) & ~CEPH_PAGE_MASK;
+  off64_t size = ROUND_UP_TO(base_size + h.pre_pad, header.alignment);
+  unsigned post_pad = size - base_size - h.pre_pad;
+  h.len = bl.length();
+  h.post_pad = post_pad;
+  h.crc32c = bl.crc32c(0);
+  dout(10) << " len " << bl.length() << " -> " << size
+       << " (head " << head_size << " pre_pad " << h.pre_pad
+       << " bl " << bl.length() << " post_pad " << post_pad << " tail " << head_size << ")"
+       << " (bl alignment " << data_align << ")"
+       << dendl;
+  bufferlist ebl;
+  // header
+  ebl.append((const char*)&h, sizeof(h));
+  if (h.pre_pad) {
+    ebl.push_back(buffer::create_static(h.pre_pad, zero_buf));
+  }
+  // payload
+  ebl.claim_append(bl, buffer::list::CLAIM_ALLOW_NONSHAREABLE); // potential zero-copy
+  if (h.post_pad) {
+    ebl.push_back(buffer::create_static(h.post_pad, zero_buf));
+  }
+  // footer
+  ebl.append((const char*)&h, sizeof(h));
+  ebl.rebuild_aligned(CEPH_MINIMUM_BLOCK_SIZE);
+  tbl->claim(ebl);
+  return h.len;
+}
+
+void FileJournal::submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
 			       Context *oncommit, TrackedOpRef osd_op)
 {
   // dump on queue
@@ -1586,7 +1623,7 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, int alignment,
   assert(e.length() > 0);
 
   throttle_ops.take(1);
-  throttle_bytes.take(e.length());
+  throttle_bytes.take(orig_len);
   if (osd_op)
     osd_op->mark_event("commit_queued_for_journal_write");
   if (logger) {
@@ -1604,7 +1641,7 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, int alignment,
 	seq, oncommit, ceph_clock_now(g_ceph_context), osd_op));
     if (writeq.empty())
       writeq_cond.Signal();
-    writeq.push_back(write_item(seq, e, alignment, osd_op));
+    writeq.push_back(write_item(seq, e, orig_len, osd_op));
   }
 }
 
@@ -1737,7 +1774,7 @@ void FileJournal::committed_thru(uint64_t seq)
     dout(15) << " dropping committed but unwritten seq " << peek_write().seq 
 	     << " len " << peek_write().bl.length()
 	     << dendl;
-    put_throttle(1, peek_write().bl.length());
+    put_throttle(1, peek_write().orig_len);
     pop_write();
   }
   

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -1959,7 +1959,10 @@ int FileStore::queue_transactions(Sequencer *posr, list<Transaction*> &tls,
     journal->throttle();
     //prepare and encode transactions data out of lock
     bufferlist tbl;
-    int data_align = _op_journal_transactions_prepare(o->tls, tbl);
+    int orig_len = -1;
+    if (journal && journal->is_writeable()) {
+      orig_len = journal->prepare_entry(o->tls, &tbl);
+    }
     uint64_t op_num = submit_manager.op_submit_start();
     o->op = op_num;
 
@@ -1969,7 +1972,7 @@ int FileStore::queue_transactions(Sequencer *posr, list<Transaction*> &tls,
     if (m_filestore_journal_parallel) {
       dout(5) << "queue_transactions (parallel) " << o->op << " " << o->tls << dendl;
       
-      _op_journal_transactions(tbl, data_align, o->op, ondisk, osd_op);
+      _op_journal_transactions(tbl, orig_len, o->op, ondisk, osd_op);
       
       // queue inside submit_manager op submission lock
       queue_op(osr, o);
@@ -1978,7 +1981,7 @@ int FileStore::queue_transactions(Sequencer *posr, list<Transaction*> &tls,
       
       osr->queue_journal(o->op);
 
-      _op_journal_transactions(tbl, data_align, o->op,
+      _op_journal_transactions(tbl, orig_len, o->op,
 			       new C_JournaledAhead(this, osr, o, ondisk),
 			       osd_op);
     } else {
@@ -2011,7 +2014,10 @@ int FileStore::queue_transactions(Sequencer *posr, list<Transaction*> &tls,
 
   //prepare and encode transactions data out of lock
   bufferlist tbl;
-  int data_align = _op_journal_transactions_prepare(tls, tbl);
+  int orig_len = -1;
+  if (journal && journal->is_writeable()) {
+    orig_len = journal->prepare_entry(tls, &tbl);
+  }
   uint64_t op = submit_manager.op_submit_start();
   dout(5) << "queue_transactions (trailing journal) " << op << " " << tls << dendl;
 
@@ -2022,7 +2028,7 @@ int FileStore::queue_transactions(Sequencer *posr, list<Transaction*> &tls,
   int r = do_transactions(tls, op);
     
   if (r >= 0) {
-    _op_journal_transactions(tbl, data_align, op, ondisk, osd_op);
+    _op_journal_transactions(tbl, orig_len, op, ondisk, osd_op);
   } else {
     delete ondisk;
   }

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -1959,10 +1959,7 @@ int FileStore::queue_transactions(Sequencer *posr, list<Transaction*> &tls,
     journal->throttle();
     //prepare and encode transactions data out of lock
     bufferlist tbl;
-    int orig_len = -1;
-    if (journal && journal->is_writeable()) {
-      orig_len = journal->prepare_entry(o->tls, &tbl);
-    }
+    int orig_len = journal->prepare_entry(o->tls, &tbl);
     uint64_t op_num = submit_manager.op_submit_start();
     o->op = op_num;
 
@@ -2011,11 +2008,11 @@ int FileStore::queue_transactions(Sequencer *posr, list<Transaction*> &tls,
     return 0;
   }
 
-
+  assert(journal);
   //prepare and encode transactions data out of lock
   bufferlist tbl;
   int orig_len = -1;
-  if (journal && journal->is_writeable()) {
+  if (journal->is_writeable()) {
     orig_len = journal->prepare_entry(tls, &tbl);
   }
   uint64_t op = submit_manager.op_submit_start();

--- a/src/os/Journal.h
+++ b/src/os/Journal.h
@@ -22,6 +22,7 @@
 #include "include/Context.h"
 #include "common/Finisher.h"
 #include "common/TrackedOp.h"
+#include "os/ObjectStore.h"
 
 class PerfCounters;
 
@@ -57,7 +58,7 @@ public:
   // writes
   virtual bool is_writeable() = 0;
   virtual int make_writeable() = 0;
-  virtual void submit_entry(uint64_t seq, bufferlist& e, int alignment,
+  virtual void submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
 			    Context *oncommit,
 			    TrackedOpRef osd_op = TrackedOpRef()) = 0;
   virtual void commit_start(uint64_t seq) = 0;
@@ -70,6 +71,8 @@ public:
     ) = 0; ///< @return true on successful read, false on journal end
 
   virtual bool should_commit_now() = 0;
+
+  virtual int prepare_entry(list<ObjectStore::Transaction*>& tls, bufferlist* tbl) = 0;
 
   // reads/recovery
   

--- a/src/os/JournalingObjectStore.cc
+++ b/src/os/JournalingObjectStore.cc
@@ -251,7 +251,7 @@ void JournalingObjectStore::ApplyManager::commit_finish()
 }
 
 void JournalingObjectStore::_op_journal_transactions(
-  bufferlist& tbl, int data_align,  uint64_t op,
+  bufferlist& tbl, uint32_t orig_len, uint64_t op,
   Context *onjournal, TrackedOpRef osd_op)
 {
   if (osd_op.get())
@@ -261,27 +261,9 @@ void JournalingObjectStore::_op_journal_transactions(
     dout(10) << "op_journal_transactions " << op  << dendl;
 
   if (journal && journal->is_writeable()) {
-    journal->submit_entry(op, tbl, data_align, onjournal, osd_op);
+    journal->submit_entry(op, tbl, orig_len, onjournal, osd_op);
   } else if (onjournal) {
     apply_manager.add_waiter(op, onjournal);
   }
 }
 
-int JournalingObjectStore::_op_journal_transactions_prepare(
-  list<ObjectStore::Transaction*>& tls, bufferlist& tbl)
-{
-  dout(10) << "_op_journal_transactions_prepare " << tls << dendl;
-  unsigned data_len = 0;
-  int data_align = -1; // -1 indicates that we don't care about the alignment
-  for (list<ObjectStore::Transaction*>::iterator p = tls.begin();
-      p != tls.end(); ++p) {
-    ObjectStore::Transaction *t = *p;
-    if (t->get_data_length() > data_len &&
-     (int)t->get_data_length() >= g_conf->journal_align_min_size) {
-     data_len = t->get_data_length();
-     data_align = (t->get_data_alignment() - tbl.length()) & ~CEPH_PAGE_MASK;
-    }
-    ::encode(*t, tbl);
-  }
-  return data_align;
-}

--- a/src/os/JournalingObjectStore.h
+++ b/src/os/JournalingObjectStore.h
@@ -17,6 +17,7 @@
 
 #include "ObjectStore.h"
 #include "Journal.h"
+#include "FileJournal.h"
 #include "common/RWLock.h"
 
 class JournalingObjectStore : public ObjectStore {
@@ -114,9 +115,7 @@ protected:
   void journal_write_close();
   int journal_replay(uint64_t fs_op_seq);
 
-  int _op_journal_transactions_prepare(
-    list<ObjectStore::Transaction*>& tls, bufferlist& tbl);
-  void _op_journal_transactions(bufferlist& tls, int data_align, uint64_t op,
+  void _op_journal_transactions(bufferlist& tls, uint32_t orig_len, uint64_t op,
 				Context *onjournal, TrackedOpRef osd_op);
 
   virtual int do_transactions(list<ObjectStore::Transaction*>& tls, uint64_t op_seq) = 0;
@@ -136,7 +135,9 @@ public:
       finisher(g_ceph_context),
       apply_manager(journal, finisher),
       replaying(false) {}
-  
+
+  ~JournalingObjectStore() {
+  }
 };
 
 #endif

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -12,6 +12,7 @@
 #include "include/Context.h"
 #include "common/Mutex.h"
 #include "common/safe_io.h"
+#include "os/JournalingObjectStore.h"
 
 Finisher *finisher;
 Cond sync_cond;
@@ -137,9 +138,11 @@ TEST(TestFileJournal, WriteSmall) {
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
+    list<ObjectStore::Transaction*> tls;
     bufferlist bl;
     bl.append("small");
-    j.submit_entry(1, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
+    int orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(1, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
     wait();
 
     j.close();
@@ -165,9 +168,10 @@ TEST(TestFileJournal, WriteBig) {
       memset(foo, 1, sizeof(foo));
       bl.append(foo, sizeof(foo));
     }
-    j.submit_entry(1, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
+    list<ObjectStore::Transaction*> tls;
+    int orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(1, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
     wait();
-
     j.close();
   }
 }
@@ -187,14 +191,15 @@ TEST(TestFileJournal, WriteMany) {
 
     C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
+    list<ObjectStore::Transaction*> tls;
     bufferlist bl;
     bl.append("small");
     uint64_t seq = 1;
     for (int i=0; i<100; i++) {
       bl.append("small");
-      j.submit_entry(seq++, bl, 0, gb.new_sub());
+      int orig_len = j.prepare_entry(tls, &bl);
+      j.submit_entry(seq++, bl, orig_len, gb.new_sub());
     }
-
     gb.activate();
 
     wait();
@@ -220,7 +225,9 @@ TEST(TestFileJournal, WriteManyVecs) {
 
     bufferlist first;
     first.append("small");
-    j.submit_entry(1, first, 0, gb.new_sub());
+    list<ObjectStore::Transaction*> tls;
+    int orig_len = j.prepare_entry(tls, &first);
+    j.submit_entry(1, first, orig_len, gb.new_sub());
 
     bufferlist bl;
     for (int i=0; i<IOV_MAX * 2; i++) {
@@ -229,7 +236,8 @@ TEST(TestFileJournal, WriteManyVecs) {
       bl.append(bp);
     }
     bufferlist origbl = bl;
-    j.submit_entry(2, bl, 0, gb.new_sub());
+    orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(2, bl, orig_len, gb.new_sub());
     gb.activate();
     wait();
 
@@ -253,6 +261,8 @@ TEST(TestFileJournal, ReplaySmall) {
   g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
   g_ceph_context->_conf->apply_changes(NULL);
 
+  list<ObjectStore::Transaction*> tls;
+
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -265,11 +275,14 @@ TEST(TestFileJournal, ReplaySmall) {
 
     bufferlist bl;
     bl.append("small");
-    j.submit_entry(1, bl, 0, gb.new_sub());
+    int orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(1, bl, orig_len, gb.new_sub());
     bl.append("small");
-    j.submit_entry(2, bl, 0, gb.new_sub());
+    orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(2, bl, orig_len, gb.new_sub());
     bl.append("small");
-    j.submit_entry(3, bl, 0, gb.new_sub());
+    orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(3, bl, orig_len, gb.new_sub());
     gb.activate();
     wait();
 
@@ -306,6 +319,7 @@ TEST(TestFileJournal, ReplayCorrupt) {
   g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
   g_ceph_context->_conf->apply_changes(NULL);
 
+  list<ObjectStore::Transaction*> tls;
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -320,13 +334,17 @@ TEST(TestFileJournal, ReplayCorrupt) {
     const char *newneedle = "in a haystack";
     bufferlist bl;
     bl.append(needle);
-    j.submit_entry(1, bl, 0, gb.new_sub());
+    int orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(1, bl, orig_len, gb.new_sub());
     bl.append(needle);
-    j.submit_entry(2, bl, 0, gb.new_sub());
+    orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(2, bl, orig_len, gb.new_sub());
     bl.append(needle);
-    j.submit_entry(3, bl, 0, gb.new_sub());
+    orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(3, bl, orig_len, gb.new_sub());
     bl.append(needle);
-    j.submit_entry(4, bl, 0, gb.new_sub());
+    orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(4, bl, orig_len, gb.new_sub());
     gb.activate();
     wait();
 
@@ -342,10 +360,10 @@ TEST(TestFileJournal, ReplayCorrupt) {
     for (unsigned o=0; o < sizeof(buf) - strlen(needle); o++) {
       if (memcmp(buf+o, needle, strlen(needle)) == 0) {
         if (n >= 2) {
-	cout << "replacing at offset " << o << std::endl;
-	memcpy(buf+o, newneedle, strlen(newneedle));
+	  cout << "replacing at offset " << o << std::endl;
+	  memcpy(buf+o, newneedle, strlen(newneedle));
         } else {
-	cout << "leaving at offset " << o << std::endl;
+	  cout << "leaving at offset " << o << std::endl;
         }
         n++;
       }
@@ -398,13 +416,15 @@ TEST(TestFileJournal, WriteTrim) {
     memset(foo, 1, sizeof(foo));
 
     uint64_t seq = 1, committed = 0;
+    list<ObjectStore::Transaction*> tls;
 
     for (unsigned i=0; i<size_mb*2; i++) {
       bl.clear();
       bl.push_back(buffer::copy(foo, sizeof(foo)));
       bl.zero();
       ls.push_back(new C_Sync);
-      j.submit_entry(seq++, bl, 0, ls.back()->c);
+      int orig_len = j.prepare_entry(tls, &bl);
+      j.submit_entry(seq++, bl, orig_len, ls.back()->c);
 
       while (ls.size() > size_mb/2) {
         delete ls.front();
@@ -430,6 +450,7 @@ TEST(TestFileJournal, WriteTrimSmall) {
   g_ceph_context->_conf->set_val("journal_ignore_corruption", "false");
   g_ceph_context->_conf->set_val("journal_write_header_frequency", "0");
   g_ceph_context->_conf->apply_changes(NULL);
+  list<ObjectStore::Transaction*> tls;
 
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
@@ -453,7 +474,8 @@ TEST(TestFileJournal, WriteTrimSmall) {
         bl.push_back(buffer::copy(foo, sizeof(foo) / 128));
       bl.zero();
       ls.push_back(new C_Sync);
-      j.submit_entry(seq++, bl, 0, ls.back()->c);
+      int orig_len = j.prepare_entry(tls, &bl);
+      j.submit_entry(seq++, bl, orig_len, ls.back()->c);
 
       while (ls.size() > size_mb/2) {
         delete ls.front();
@@ -478,6 +500,7 @@ TEST(TestFileJournal, ReplayDetectCorruptFooterMagic) {
   g_ceph_context->_conf->set_val("journal_write_header_frequency", "1");
   g_ceph_context->_conf->apply_changes(NULL);
 
+  list<ObjectStore::Transaction*> tls;
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -492,14 +515,16 @@ TEST(TestFileJournal, ReplayDetectCorruptFooterMagic) {
     for (unsigned i = 1; i <= 4; ++i) {
       bufferlist bl;
       bl.append(needle);
-      j.submit_entry(i, bl, 0, gb.new_sub());
+      int orig_len = j.prepare_entry(tls, &bl);
+      j.submit_entry(i, bl, orig_len, gb.new_sub());
     }
     gb.activate();
     wait();
 
     bufferlist bl;
     bl.append("needle");
-    j.submit_entry(5, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
+    int orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(5, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
     wait();
 
     j.close();
@@ -532,6 +557,7 @@ TEST(TestFileJournal, ReplayDetectCorruptPayload) {
   g_ceph_context->_conf->set_val("journal_write_header_frequency", "1");
   g_ceph_context->_conf->apply_changes(NULL);
 
+  list<ObjectStore::Transaction*> tls;
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -546,14 +572,16 @@ TEST(TestFileJournal, ReplayDetectCorruptPayload) {
     for (unsigned i = 1; i <= 4; ++i) {
       bufferlist bl;
       bl.append(needle);
-      j.submit_entry(i, bl, 0, gb.new_sub());
+      int orig_len = j.prepare_entry(tls, &bl);
+      j.submit_entry(i, bl, orig_len, gb.new_sub());
     }
     gb.activate();
     wait();
 
     bufferlist bl;
     bl.append("needle");
-    j.submit_entry(5, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
+    int orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(5, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
     wait();
 
     j.close();
@@ -586,6 +614,7 @@ TEST(TestFileJournal, ReplayDetectCorruptHeader) {
   g_ceph_context->_conf->set_val("journal_write_header_frequency", "1");
   g_ceph_context->_conf->apply_changes(NULL);
 
+  list<ObjectStore::Transaction*> tls;
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
@@ -600,14 +629,16 @@ TEST(TestFileJournal, ReplayDetectCorruptHeader) {
     for (unsigned i = 1; i <= 4; ++i) {
       bufferlist bl;
       bl.append(needle);
-      j.submit_entry(i, bl, 0, gb.new_sub());
+      int orig_len = j.prepare_entry(tls, &bl);
+      j.submit_entry(i, bl, orig_len, gb.new_sub());
     }
     gb.activate();
     wait();
 
     bufferlist bl;
     bl.append("needle");
-    j.submit_entry(5, bl, 0, new C_SafeCond(&wait_lock, &cond, &done));
+    int orig_len = j.prepare_entry(tls, &bl);
+    j.submit_entry(5, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
     wait();
 
     j.close();


### PR DESCRIPTION
Currently, there is single write thread for file journal, so it would be bottleneck.
It is important to keep logic of the journal write thread simple. According to the
implementation of transaction encoding, it is almost impossible that the write
bufferlist would be align. So write journal would call rebuild_aligned almost every time.
Because of the memory fragmentation, the bufferlist crc and rebuild would be bottleneck.

My implementation would move the complex logic out of journal write thread.

Signed-off-by: Xinze Chi <xinze@xsky.com>
Reviewed-by: Haomai Wang <haomai@xsky.com>