### PR TITLE
librados: do cleanup

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -262,7 +262,6 @@ int librados::IoCtxImpl::rollback(const object_t& oid, const char *snapName)
   if (r < 0) {
     return r;
   }
-  string sName(snapName);
 
   return selfmanaged_snap_rollback_object(oid, snapc, snap);
 }

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -1169,14 +1169,14 @@ int librados::IoCtx::mapext(const std::string& oid, uint64_t off, size_t len,
 			    std::map<uint64_t,uint64_t>& m)
 {
   object_t obj(oid);
-  return io_ctx_impl->mapext(oid, off, len, m);
+  return io_ctx_impl->mapext(obj, off, len, m);
 }
 
 int librados::IoCtx::sparse_read(const std::string& oid, std::map<uint64_t,uint64_t>& m,
 				 bufferlist& bl, size_t len, uint64_t off)
 {
   object_t obj(oid);
-  return io_ctx_impl->sparse_read(oid, m, bl, len, off);
+  return io_ctx_impl->sparse_read(obj, m, bl, len, off);
 }
 
 int librados::IoCtx::getxattr(const std::string& oid, const char *name, bufferlist& bl)
@@ -1760,7 +1760,7 @@ int librados::IoCtx::aio_stat(const std::string& oid, librados::AioCompletion *c
 			      uint64_t *psize, time_t *pmtime)
 {
   object_t obj(oid);
-  return io_ctx_impl->aio_stat(oid, c->pc, psize, pmtime);
+  return io_ctx_impl->aio_stat(obj, c->pc, psize, pmtime);
 }
 
 int librados::IoCtx::aio_cancel(librados::AioCompletion *c)
@@ -1784,7 +1784,6 @@ int librados::IoCtx::watch2(const string& oid, uint64_t *cookie,
 
 int librados::IoCtx::unwatch(const string& oid, uint64_t handle)
 {
-  object_t obj(oid);
   return io_ctx_impl->unwatch(handle);
 }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1994,7 +1994,6 @@ reprotect_and_return_err:
     int r = ictx_check(ictx);
     if (r < 0)
       return r;
-    bufferlist bl, bl2;
 
     RWLock::RLocker l(ictx->snap_lock);
     for (map<snap_t, SnapInfo>::iterator it = ictx->snap_info.begin();
@@ -2172,7 +2171,6 @@ reprotect_and_return_err:
     RWLock::WLocker md_locker(ictx->md_lock);
 
     CephContext *cct = ictx->cct;
-    bufferlist bl, bl2;
 
     ldout(cct, 20) << "ictx_refresh " << ictx << dendl;
 


### PR DESCRIPTION
Remove unused local variables and perform explicit cast when call ioctx methods.
Signed-off-by: xie xingguo xie.xingguo@zte.com.cn