### PR TITLE
client: use null snapc to check pool permission

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11350,21 +11350,21 @@ int Client::check_pool_perm(Inode *in, int need)
     snprintf(oid_buf, sizeof(oid_buf), "%llx.00000000", (unsigned long long)in->ino);
     object_t oid = oid_buf;
 
+    SnapContext nullsnapc;
+
     C_SaferCond rd_cond;
     ObjectOperation rd_op;
     rd_op.stat(NULL, (utime_t*)NULL, NULL);
 
     objecter->mutate(oid, OSDMap::file_to_object_locator(in->layout), rd_op,
-		     in->snaprealm->get_snap_context(), ceph_clock_now(cct), 0,
-		     &rd_cond, NULL);
+		     nullsnapc, ceph_clock_now(cct), 0, &rd_cond, NULL);
 
     C_SaferCond wr_cond;
     ObjectOperation wr_op;
     wr_op.create(true);
 
     objecter->mutate(oid, OSDMap::file_to_object_locator(in->layout), wr_op,
-		     in->snaprealm->get_snap_context(), ceph_clock_now(cct), 0,
-		     &wr_cond, NULL);
+		     nullsnapc, ceph_clock_now(cct), 0, &wr_cond, NULL);
 
     client_lock.Unlock();
     int rd_ret = rd_cond.wait();


### PR DESCRIPTION
snap inodes' ->snaprealm can be NULL, so dereferencing it in
check_pool_perm() can cause segment fault. The pool permission
check does not write any data, so it's safe to use null snapc.

Fixes: #13714
Signed-off-by: Yan, Zheng <zyan@redhat.com>