### PR TITLE
os/FileStore: For clone, first clone and later trucated size.

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -3294,15 +3294,17 @@ int FileStore::_clone(coll_t cid, const ghobject_t& oldoid, const ghobject_t& ne
     if (r < 0) {
       goto out;
     }
-    r = ::ftruncate(**n, 0);
-    if (r < 0) {
-      goto out3;
-    }
+
     struct stat st;
     ::fstat(**o, &st);
     r = _do_clone_range(**o, **n, 0, st.st_size, 0);
     if (r < 0) {
       r = -errno;
+      goto out3;
+    }
+
+    r = ::ftruncate(**n, st.st_size);
+    if (r < 0) {
       goto out3;
     }
 


### PR DESCRIPTION
When do clone(copy obA to obB). It firstly truncated size of obB to
zero. Later do clone(data and omap).
If we firstly do clone and later trucated size of obB to size of obA.
This will reduce truncate overhead when a)obB don't exist b)size obB >
obA.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>