### PR TITLE
FilesJournal：sync avoid tp pause

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1128,6 +1128,8 @@ OPTION(rgw_replica_log_obj_prefix, OPT_STR, "replica_log") //
 OPTION(rgw_bucket_quota_ttl, OPT_INT, 600) // time for cached bucket stats to be cached within rgw instance
 OPTION(rgw_bucket_quota_soft_threshold, OPT_DOUBLE, 0.95) // threshold from which we don't rely on cached info for quota decisions
 OPTION(rgw_bucket_quota_cache_size, OPT_INT, 10000) // number of entries in bucket quota cache
+OPTION(rgw_bucket_default_quota_max_objects, OPT_INT, -1) // number of objects allowed
+OPTION(rgw_bucket_default_quota_max_size, OPT_LONGLONG, -1) // Max size of object in kB
 
 OPTION(rgw_expose_bucket, OPT_BOOL, false) // Return the bucket name in the 'Bucket' response header
 
@@ -1137,6 +1139,8 @@ OPTION(rgw_user_quota_bucket_sync_interval, OPT_INT, 180) // time period for acc
 OPTION(rgw_user_quota_sync_interval, OPT_INT, 3600 * 24) // time period for accumulating modified buckets before syncing entire user stats
 OPTION(rgw_user_quota_sync_idle_users, OPT_BOOL, false) // whether stats for idle users be fully synced
 OPTION(rgw_user_quota_sync_wait_time, OPT_INT, 3600 * 24) // min time between two full stats sync for non-idle users
+OPTION(rgw_user_default_quota_max_objects, OPT_INT, -1) // number of objects allowed
+OPTION(rgw_user_default_quota_max_size, OPT_LONGLONG, -1) // Max size of object in kB
 
 OPTION(rgw_multipart_min_part_size, OPT_INT, 5 * 1024 * 1024) // min size for each part (except for last one) in multipart upload
 OPTION(rgw_multipart_part_upload_limit, OPT_INT, 10000) // parts limit in multipart upload

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -526,7 +526,7 @@ int FileJournal::open(uint64_t fs_op_seq)
 	    << " to fs op_seq " << fs_op_seq << dendl;
     last_committed_seq = fs_op_seq;
   }
-
+  
   while (1) {
     bufferlist bl;
     off64_t old_pos = read_pos;

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -3608,7 +3608,6 @@ void FileStore::sync_entry()
     fin.swap(sync_waiters);
     lock.Unlock();
     
-    op_tp.pause();
     if (apply_manager.commit_start()) {
       utime_t start = ceph_clock_now(g_ceph_context);
       uint64_t cp = apply_manager.get_committing_seq();
@@ -3647,7 +3646,6 @@ void FileStore::sync_entry()
 
 	snaps.push_back(cp);
 	apply_manager.commit_started();
-	op_tp.unpause();
 
 	if (cid > 0) {
 	  dout(20) << " waiting for checkpoint " << cid << " to complete" << dendl;
@@ -3661,7 +3659,6 @@ void FileStore::sync_entry()
       } else
       {
 	apply_manager.commit_started();
-	op_tp.unpause();
 
 	object_map->sync();
 	int err = backend->syncfs();
@@ -3716,9 +3713,7 @@ void FileStore::sync_entry()
       sync_entry_timeo_lock.Lock();
       timer.cancel_event(sync_entry_timeo);
       sync_entry_timeo_lock.Unlock();
-    } else {
-      op_tp.unpause();
-    }
+    } 
     
     lock.Lock();
     finish_contexts(g_ceph_context, fin, 0);

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -1867,7 +1867,6 @@ void FileStore::_do_op(OpSequencer *osr, ThreadPool::TPHandle &handle)
 
   osr->apply_lock.Lock();
   Op *o = osr->peek_queue();
-  apply_manager.op_apply_start(o->op);
   dout(5) << "_do_op " << o << " seq " << o->op << " " << *osr << "/" << osr->parent << " start" << dendl;
   int r = _do_transactions(o->tls, o->op, &handle);
   apply_manager.op_apply_finish(o->op);

--- a/src/os/JournalingObjectStore.cc
+++ b/src/os/JournalingObjectStore.cc
@@ -119,13 +119,7 @@ int JournalingObjectStore::journal_replay(uint64_t fs_op_seq)
 uint64_t JournalingObjectStore::ApplyManager::op_apply_start(uint64_t op)
 {
   Mutex::Locker l(apply_lock);
-  while (blocked) {
-    // note: this only happens during journal replay
-    dout(10) << "op_apply_start blocked, waiting" << dendl;
-    blocked_cond.Wait(apply_lock);
-  }
   dout(10) << "op_apply_start " << op << " open_ops " << open_ops << " -> " << (open_ops+1) << dendl;
-  assert(!blocked);
   assert(op > committed_seq);
   open_ops++;
   applying_seq_set.insert(op);
@@ -141,11 +135,6 @@ void JournalingObjectStore::ApplyManager::op_apply_finish(uint64_t op)
 	   << dendl;
   --open_ops;
   assert(open_ops >= 0);
-
-  // signal a blocked commit_start (only needed during journal replay)
-  if (blocked) {
-    blocked_cond.Signal();
-  }
 
   applying_seq_set.erase(op);
   // there can be multiple applies in flight; track the max value we
@@ -195,7 +184,6 @@ bool JournalingObjectStore::ApplyManager::commit_start()
     dout(10) << "commit_start max_applied_seq " << max_applied_seq
 	     << ", open_ops " << open_ops << dendl;
   
-    blocked = true;
     {
       Mutex::Locker l(com_lock);
 
@@ -218,7 +206,6 @@ bool JournalingObjectStore::ApplyManager::commit_start()
       
       if (committing_seq == committed_seq) {
        	dout(10) << "commit_start nothing to do" << dendl;
-	blocked = false;
 	goto out;
       }
     } 
@@ -236,8 +223,6 @@ void JournalingObjectStore::ApplyManager::commit_started()
   Mutex::Locker l(apply_lock);
   // allow new ops. (underlying fs should now be committing all prior ops)
   dout(10) << "commit_started committing " << committing_seq << ", unblocking" << dendl;
-  blocked = false;
-  blocked_cond.Signal();
 }
 
 void JournalingObjectStore::ApplyManager::commit_finish()

--- a/src/os/JournalingObjectStore.cc
+++ b/src/os/JournalingObjectStore.cc
@@ -128,6 +128,7 @@ uint64_t JournalingObjectStore::ApplyManager::op_apply_start(uint64_t op)
   assert(!blocked);
   assert(op > committed_seq);
   open_ops++;
+  applying_seq_set.insert(op);
   return op;
 }
 
@@ -146,6 +147,7 @@ void JournalingObjectStore::ApplyManager::op_apply_finish(uint64_t op)
     blocked_cond.Signal();
   }
 
+  applying_seq_set.erase(op);
   // there can be multiple applies in flight; track the max value we
   // note.  note that we can't _read_ this value and learn anything
   // meaningful unless/until we've quiesced all in-flight applies.
@@ -191,29 +193,35 @@ bool JournalingObjectStore::ApplyManager::commit_start()
   {
     Mutex::Locker l(apply_lock);
     dout(10) << "commit_start max_applied_seq " << max_applied_seq
-	     << ", open_ops " << open_ops
-	     << dendl;
+	     << ", open_ops " << open_ops << dendl;
+  
     blocked = true;
-    while (open_ops > 0) {
-      dout(10) << "commit_start waiting for " << open_ops << " open ops to drain" << dendl;
-      blocked_cond.Wait(apply_lock);
-    }
-    assert(open_ops == 0);
-    dout(10) << "commit_start blocked, all open_ops have completed" << dendl;
     {
       Mutex::Locker l(com_lock);
-      if (max_applied_seq == committed_seq) {
-	dout(10) << "commit_start nothing to do" << dendl;
+
+      set<uint64_t>::iterator it = applying_seq_set.begin();
+      if (it == applying_seq_set.end() ){
+       	_committing_seq = committing_seq = max_applied_seq; 
+		
+      dout(10) << "commit_start committing from end: " << committing_seq 
+		<< ",current applying_seq_set size:"<< applying_seq_set.size()
+		<< ", still blocked" << dendl;
+		assert( applying_seq_set.size() == 0 );
+      }else
+      {
+        _committing_seq = committing_seq = *it - 1;
+       	dout(10) << "commit_start committing from head: " << committing_seq 
+		<< ",current applying_seq_set size:"<< applying_seq_set.size()
+		<< ", still blocked" << dendl;
+		assert( (int)applying_seq_set.size() == open_ops );
+      }
+      
+      if (committing_seq == committed_seq) {
+       	dout(10) << "commit_start nothing to do" << dendl;
 	blocked = false;
-	assert(commit_waiters.empty());
 	goto out;
       }
-
-      _committing_seq = committing_seq = max_applied_seq;
-
-      dout(10) << "commit_start committing " << committing_seq
-	       << ", still blocked" << dendl;
-    }
+    } 
   }
   ret = true;
 

--- a/src/os/JournalingObjectStore.h
+++ b/src/os/JournalingObjectStore.h
@@ -50,8 +50,6 @@ protected:
     Finisher &finisher;
 
     Mutex apply_lock;
-    bool blocked;
-    Cond blocked_cond;
     int open_ops;
     uint64_t max_applied_seq;
 
@@ -65,14 +63,12 @@ protected:
     ApplyManager(Journal *&j, Finisher &f) :
       journal(j), finisher(f),
       apply_lock("JOS::ApplyManager::apply_lock", false, true, false, g_ceph_context),
-      blocked(false),
       open_ops(0),
       max_applied_seq(0),
       com_lock("JOS::ApplyManager::com_lock", false, true, false, g_ceph_context),
       committing_seq(0), committed_seq(0) {}
     void reset() {
       assert(open_ops == 0);
-      assert(blocked == false);
       max_applied_seq = 0;
       committing_seq = 0;
       committed_seq = 0;

--- a/src/os/JournalingObjectStore.h
+++ b/src/os/JournalingObjectStore.h
@@ -59,6 +59,8 @@ protected:
     map<version_t, vector<Context*> > commit_waiters;
     uint64_t committing_seq, committed_seq;
 
+    set<uint64_t>   applying_seq_set;
+
   public:
     ApplyManager(Journal *&j, Finisher &f) :
       journal(j), finisher(f),


### PR DESCRIPTION

when sync file journal ,it is needed to do:
1)it firstly calls op_tp.pause() to stop applying operation
2) wait all the in flight apply operatons completed
3)calls op_tp.unpause() to continue applying operation

In this way, apply operation must be interrupted by sync of file journal, which may has performance affection.

Actually, it doesn't need waiting all the in flight applying operations complete. It should just sync the apply operation that has been completed , leave the in flight apply operations to be synced next time

Signed-off-by: changtao changtao@hihuron.com
