### PR TITLE
os: write EIO error, osd tidy shutdown rather than assert directly.

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -38,7 +38,7 @@ using namespace std;
 
 #include "global/global_init.h"
 #include "global/signal_handler.h"
-
+#include "global/error_handlers.h"
 #include "include/color.h"
 #include "common/errno.h"
 #include "common/pick_address.h"
@@ -67,7 +67,11 @@ void handle_osd_signal(int signum)
   if (osd)
     osd->handle_signal(signum);
 }
-
+void handle_io_error_tidy_shutdown()
+{
+  if (osd)
+    osd->io_error_tidy_shutdown();
+}
 void usage() 
 {
   cout << "usage: ceph-osd -i <osdid>\n"
@@ -589,7 +593,7 @@ int main(int argc, const char **argv)
   register_async_signal_handler(SIGHUP, sighup_handler);
   register_async_signal_handler_oneshot(SIGINT, handle_osd_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_osd_signal);
-
+  register_ceph_io_error_handler(handle_io_error_tidy_shutdown);
   osd->final_init();
 
   if (g_conf->inject_early_sigterm)

--- a/src/global/Makefile.am
+++ b/src/global/Makefile.am
@@ -3,7 +3,8 @@ libglobal_la_SOURCES = \
 	global/global_init.cc \
 	global/pidfile.cc \
 	global/signal_handler.cc \
-	common/TrackedOp.cc
+	common/TrackedOp.cc \
+	global/error_handlers.cc
 libglobal_la_LIBADD = $(LIBCOMMON)
 noinst_LTLIBRARIES += libglobal.la
 
@@ -11,5 +12,6 @@ noinst_HEADERS += \
 	global/pidfile.h \
 	global/global_init.h \
 	global/global_context.h \
-	global/signal_handler.h
+	global/signal_handler.h \
+	global/error_handlers.h
 

--- a/src/global/error_handlers.cc
+++ b/src/global/error_handlers.cc
@@ -1,0 +1,15 @@
+#include "global/error_handlers.h"
+
+static error_handler_t io_tidy_handler;
+
+void register_ceph_io_error_handler(error_handler_t handler) 
+{
+  io_tidy_handler = handler;
+}
+
+void ceph_io_error_tidy_shutdown() 
+{
+  if (io_tidy_handler) {
+    io_tidy_handler();
+  }
+}

--- a/src/global/error_handlers.h
+++ b/src/global/error_handlers.h
@@ -1,0 +1,9 @@
+#ifndef CEPH_GLOBAL_ERROR_HANDLER_H
+#define CEPH_GLOBAL_ERROR_HANDLER_H
+
+typedef void (*error_handler_t)();
+
+void register_ceph_io_error_handler(error_handler_t handler);
+void ceph_io_error_tidy_shutdown(); 
+
+#endif

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -34,7 +34,9 @@
 
 #include "common/blkdev.h"
 #include "common/linux_version.h"
+#include "global/error_handlers.h"
 
+ 
 #if defined(__FreeBSD__)
 #define O_DSYNC O_SYNC
 #endif
@@ -1136,12 +1138,14 @@ void FileJournal::do_write(bufferlist& bl)
     if (write_bl(pos, second)) {
       derr << "FileJournal::do_write: write_bl(pos=" << orig_pos
 	   << ") failed" << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
     orig_pos = first_pos;
     if (write_bl(first_pos, first)) {
       derr << "FileJournal::do_write: write_bl(pos=" << orig_pos
 	   << ") failed" << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
     assert(first_pos == get_top());
@@ -1153,6 +1157,7 @@ void FileJournal::do_write(bufferlist& bl)
 	derr << "FileJournal::do_write: pwrite(fd=" << fd
 	     << ", hbp.length=" << hbp.length() << ") failed :"
 	     << cpp_strerror(err) << dendl;
+	ceph_io_error_tidy_shutdown();
 	ceph_abort();
       }
     }
@@ -1160,6 +1165,7 @@ void FileJournal::do_write(bufferlist& bl)
     if (write_bl(pos, bl)) {
       derr << "FileJournal::do_write: write_bl(pos=" << pos
 	   << ") failed" << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
   }
@@ -1190,6 +1196,7 @@ void FileJournal::do_write(bufferlist& bl)
 #endif
     if (ret < 0) {
       derr << __func__ << " fsync/fdatasync failed: " << cpp_strerror(errno) << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
 #ifdef HAVE_POSIX_FADVISE
@@ -1374,6 +1381,7 @@ void FileJournal::do_aio_write(bufferlist& bl)
     if (write_aio_bl(pos, first, 0)) {
       derr << "FileJournal::do_aio_write: write_aio_bl(pos=" << pos
 	   << ") failed" << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
     assert(pos == header.max_size);
@@ -1386,6 +1394,7 @@ void FileJournal::do_aio_write(bufferlist& bl)
     if (write_aio_bl(pos, second, writing_seq)) {
       derr << "FileJournal::do_aio_write: write_aio_bl(pos=" << pos
 	   << ") failed" << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
   } else {
@@ -1396,6 +1405,7 @@ void FileJournal::do_aio_write(bufferlist& bl)
       loff_t pos = 0;
       if (write_aio_bl(pos, hbl, 0)) {
 	derr << "FileJournal::do_aio_write: write_aio_bl(header) failed" << dendl;
+	ceph_io_error_tidy_shutdown();
 	ceph_abort();
       }
     }
@@ -1403,6 +1413,7 @@ void FileJournal::do_aio_write(bufferlist& bl)
     if (write_aio_bl(pos, bl, writing_seq)) {
       derr << "FileJournal::do_aio_write: write_aio_bl(pos=" << pos
 	   << ") failed" << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
   }
@@ -1810,6 +1821,7 @@ void FileJournal::wrap_read_bl(
     if (r) {
       derr << "FileJournal::wrap_read_bl: safe_read_exact " << pos << "~" << len << " returned "
 	   << r << dendl;
+      ceph_io_error_tidy_shutdown();
       ceph_abort();
     }
     bl->push_back(bp);

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -78,6 +78,7 @@ using ceph::crypto::SHA1;
 
 #include "common/config.h"
 #include "common/blkdev.h"
+#include "global/error_handlers.h"
 
 #ifdef WITH_LTTNG
 #define TRACEPOINT_DEFINE
@@ -1228,6 +1229,9 @@ int FileStore::read_op_seq(uint64_t *seq)
   int op_fd = ::open(current_op_seq_fn.c_str(), O_CREAT|O_RDWR, 0644);
   if (op_fd < 0) {
     int r = -errno;
+    if (m_filestore_fail_eio && r == -EIO) {
+      ceph_io_error_tidy_shutdown();
+    }
     assert(!m_filestore_fail_eio || r != -EIO);
     return r;
   }
@@ -1237,6 +1241,9 @@ int FileStore::read_op_seq(uint64_t *seq)
   if (ret < 0) {
     derr << "error reading " << current_op_seq_fn << ": " << cpp_strerror(ret) << dendl;
     VOID_TEMP_FAILURE_RETRY(::close(op_fd));
+    if (m_filestore_fail_eio && ret == -EIO) {
+      ceph_io_error_tidy_shutdown();
+    }
     assert(!m_filestore_fail_eio || ret != -EIO);
     return ret;
   }
@@ -1251,6 +1258,9 @@ int FileStore::write_op_seq(int fd, uint64_t seq)
   int ret = TEMP_FAILURE_RETRY(::pwrite(fd, s, strlen(s), 0));
   if (ret < 0) {
     ret = -errno;
+    if (m_filestore_fail_eio && ret == -EIO) {
+      ceph_io_error_tidy_shutdown();
+    }
     assert(!m_filestore_fail_eio || ret != -EIO);
   }
   return ret;
@@ -2851,7 +2861,7 @@ unsigned FileStore::_do_transaction(
 	if (r == -EMFILE) {
 	  dump_open_fds(g_ceph_context);
 	}
-
+	ceph_io_error_tidy_shutdown();
 	assert(0 == "unexpected error");
       }
     }
@@ -3648,6 +3658,7 @@ void FileStore::sync_entry()
 	int err = write_op_seq(op_fd, cp);
 	if (err < 0) {
 	  derr << "Error during write_op_seq: " << cpp_strerror(err) << dendl;
+	  ceph_io_error_tidy_shutdown();
 	  assert(0 == "error during write_op_seq");
 	}
 
@@ -3689,11 +3700,13 @@ void FileStore::sync_entry()
 	err = write_op_seq(op_fd, cp);
 	if (err < 0) {
 	  derr << "Error during write_op_seq: " << cpp_strerror(err) << dendl;
+	  ceph_io_error_tidy_shutdown();
 	  assert(0 == "error during write_op_seq");
 	}
 	err = ::fsync(op_fd);
 	if (err < 0) {
 	  derr << "Error during fsync of op_seq: " << cpp_strerror(err) << dendl;
+	  ceph_io_error_tidy_shutdown();
 	  assert(0 == "error during fsync of op_seq");
 	}
       }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1616,6 +1616,10 @@ void OSD::handle_signal(int signum)
   derr << "*** Got signal " << sys_siglist[signum] << " ***" << dendl;
   shutdown();
 }
+void OSD::io_error_tidy_shutdown() 
+{
+  service.prepare_to_stop();
+}
 
 int OSD::pre_init()
 {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2370,7 +2370,7 @@ public:
   int shutdown();
 
   void handle_signal(int signum);
-
+  void io_error_tidy_shutdown();
   /// check if we can throw out op from a disconnected client
   static bool op_is_discardable(MOSDOp *m);
 


### PR DESCRIPTION
    assert directly will cost cluster too long to be normal, but if notify
    monitor to mark me down before exit will let cluster recover faster!

    test:
    have tested by unpin the disk, cluster write latency very very little
    compared to just assert and exit.

Signed-off-by: Xiaowei Chen <chen.xiaowei@h3c.com>