### PR TITLE
librbd: perf section name: use hyphen to separate components

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -183,9 +183,9 @@ public:
     }
 
     string pname = string("librbd-") + id + string("-") +
-      data_ctx.get_pool_name() + string("/") + name;
+      data_ctx.get_pool_name() + string("-") + name;
     if (!snap_name.empty()) {
-      pname += "@";
+      pname += "-";
       pname += snap_name;
     }
 


### PR DESCRIPTION
"/" and "@" characters make invalid xml format output.

Fixes: #13719
Signed-off-by: Mykola Golub <mgolub@mirantis.com>