### PR TITLE
rbd: make config changes actually apply

### DIFF
--- a/src/tools/rbd/Shell.cc
+++ b/src/tools/rbd/Shell.cc
@@ -27,8 +27,7 @@ void validate(boost::any& v, const std::vector<std::string>& values,
 
   po::validators::check_first_occurrence(v);
   const std::string &s = po::validators::get_single_string(values);
-  int r = g_conf->set_val("keyfile", s.c_str());
-  assert(r == 0);
+  g_conf->set_val_or_die("keyfile", s.c_str());
   v = boost::any(s);
 }
 

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -337,6 +337,7 @@ int get_formatter(const po::variables_map &vm,
 
 void init_context() {
   g_conf->set_val_or_die("rbd_cache_writethrough_until_flush", "false");
+  g_conf->apply_changes(NULL);
   common_init_finish(g_ceph_context);
 }
 


### PR DESCRIPTION
The problem was noticed when I got unexpected output running 'config set' command for `rbd watch ...` process admin socket:

 % ./ceph --admin-daemon out/client.admin.6771.asok config set debug_rbd 10 
 *** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
 {
     "success": "rbd_cache_writethrough_until_flush = 'false' "
 }

when running again, it produced expected output:

 % ./ceph --admin-daemon out/client.admin.6771.asok config set debug_rbd 10
 *** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
 {
     "success": ""
 }