### PR TITLE
objecter:last_tid changed without protection of rwlock

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3851,6 +3851,7 @@ void Objecter::get_pool_stats(list<string>& pools, map<string,pool_stat_t> *resu
 {
   ldout(cct, 10) << "get_pool_stats " << pools << dendl;
 
+  RWLock::WLocker wl(rwlock);
   PoolStatOp *op = new PoolStatOp;
   op->tid = last_tid.inc();
   op->pools = pools;
@@ -3862,8 +3863,6 @@ void Objecter::get_pool_stats(list<string>& pools, map<string,pool_stat_t> *resu
     op->ontimeout = new C_CancelPoolStatOp(op->tid, this);
     timer.add_event_after(mon_timeout, op->ontimeout);
   }
-
-  RWLock::WLocker wl(rwlock);
 
   poolstat_ops[op->tid] = op;
 


### PR DESCRIPTION
get_pool_stats()  shall grab rwlock first before increase last_tid, otherwise order of ops' tid may not be correctly preserved.
Fixes: #13743
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>