### PR TITLE
mon: revert MonitorDBStore's WholeStoreIteratorImpl::get

### DIFF
--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -507,12 +507,14 @@ class MonitorDBStore
   }
 
   int get(const string& prefix, const string& key, bufferlist& bl) {
-    
-    bufferlist outbl;
-    db->get(prefix, key, &outbl);
-    if (outbl.length() == 0) 
+    set<string> k;
+    k.insert(key);
+    map<string,bufferlist> out;
+
+    db->get(prefix, k, &out);
+    if (out.empty())
       return -ENOENT;
-    bl.append(outbl);
+    bl.append(out[key]);
 
     return 0;
   }


### PR DESCRIPTION
Revert MonitorDBStore's WholeStoreIteratorImpl::get method to state
before commit 66b7b920cf5a0a9c71212573ef47fb2c7ea9b5ff until better,
long-term solution for #13742 will be provided.
Temporary fix for http://tracker.ceph.com/issues/13742.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>