### PR TITLE
librbd: perf counters might not be initialized on error

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -108,7 +108,9 @@ public:
   }
 
   ImageCtx::~ImageCtx() {
-    perf_stop();
+    if (perfcounter) {
+      perf_stop();
+    }
     if (object_cacher) {
       delete object_cacher;
       object_cacher = NULL;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2884,7 +2884,8 @@ reprotect_and_return_err:
     if (ictx->object_cacher) {
       r = ictx->shutdown_cache(); // implicitly flushes
     } else {
-      r = flush(ictx);
+      RWLock::RLocker owner_locker(ictx->owner_lock);
+      r = _flush(ictx);
     }
     if (r < 0) {
       lderr(ictx->cct) << "error flushing IO: " << cpp_strerror(r)


### PR DESCRIPTION
Fixes: #13740
Signed-off-by: Jason Dillaman <dillaman@redhat.com>