### PR TITLE
osd: Adding compression support for EC pools

### DIFF
--- a/src/compressor/Compressor.h
+++ b/src/compressor/Compressor.h
@@ -25,8 +25,8 @@ typedef shared_ptr<Compressor> CompressorRef;
 class Compressor {
  public:
   virtual ~Compressor() {}
-  virtual int compress(bufferlist &in, bufferlist &out) = 0;
-  virtual int decompress(bufferlist &in, bufferlist &out) = 0;
+  virtual int compress(const bufferlist &in, bufferlist &out) = 0;
+  virtual int decompress(const bufferlist &in, bufferlist &out) = 0;
 
   static CompressorRef create(CephContext *cct, const string &type);
 };

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -662,7 +662,8 @@ COMMAND("osd pool create " \
         "name=pool_type,type=CephChoices,strings=replicated|erasure,req=false " \
 	"name=erasure_code_profile,type=CephString,req=false,goodchars=[A-Za-z0-9-_.] " \
 	"name=ruleset,type=CephString,req=false " \
-        "name=expected_num_objects,type=CephInt,req=false", \
+        "name=expected_num_objects,type=CephInt,req=false " \
+	"name=compression,type=CephString,req=false", \
 	"create pool", "osd", "rw", "cli,rest")
 COMMAND("osd pool delete " \
 	"name=pool,type=CephPoolname " \
@@ -676,11 +677,11 @@ COMMAND("osd pool rename " \
 	"rename <srcpool> to <destpool>", "osd", "rw", "cli,rest")
 COMMAND("osd pool get " \
 	"name=pool,type=CephPoolname " \
-	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset|hashpspool|nodelete|nopgchange|nosizechange|write_fadvise_dontneed|noscrub|nodeep-scrub|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp|auid|target_max_objects|target_max_bytes|cache_target_dirty_ratio|cache_target_dirty_high_ratio|cache_target_full_ratio|cache_min_flush_age|cache_min_evict_age|erasure_code_profile|min_read_recency_for_promote|all|min_write_recency_for_promote|fast_read|hit_set_grade_decay_rate|hit_set_search_last_n|scrub_min_interval|scrub_max_interval|deep_scrub_interval|recovery_priority|recovery_op_priority", \
+	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset|hashpspool|nodelete|nopgchange|nosizechange|write_fadvise_dontneed|noscrub|nodeep-scrub|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp|auid|target_max_objects|target_max_bytes|cache_target_dirty_ratio|cache_target_dirty_high_ratio|cache_target_full_ratio|cache_min_flush_age|cache_min_evict_age|erasure_code_profile|min_read_recency_for_promote|all|min_write_recency_for_promote|fast_read|hit_set_grade_decay_rate|hit_set_search_last_n|scrub_min_interval|scrub_max_interval|deep_scrub_interval|recovery_priority|recovery_op_priority|compression_type", \
 	"get pool parameter <var>", "osd", "r", "cli,rest")
 COMMAND("osd pool set " \
 	"name=pool,type=CephPoolname " \
-	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset|hashpspool|nodelete|nopgchange|nosizechange|write_fadvise_dontneed|noscrub|nodeep-scrub|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp|use_gmt_hitset|debug_fake_ec_pool|target_max_bytes|target_max_objects|cache_target_dirty_ratio|cache_target_dirty_high_ratio|cache_target_full_ratio|cache_min_flush_age|cache_min_evict_age|auid|min_read_recency_for_promote|min_write_recency_for_promote|fast_read|hit_set_grade_decay_rate|hit_set_search_last_n|scrub_min_interval|scrub_max_interval|deep_scrub_interval|recovery_priority|recovery_op_priority " \
+	"name=var,type=CephChoices,strings=size|min_size|crash_replay_interval|pg_num|pgp_num|crush_ruleset|hashpspool|nodelete|nopgchange|nosizechange|write_fadvise_dontneed|noscrub|nodeep-scrub|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp|use_gmt_hitset|debug_fake_ec_pool|target_max_bytes|target_max_objects|cache_target_dirty_ratio|cache_target_dirty_high_ratio|cache_target_full_ratio|cache_min_flush_age|cache_min_evict_age|auid|min_read_recency_for_promote|min_write_recency_for_promote|fast_read|hit_set_grade_decay_rate|hit_set_search_last_n|scrub_min_interval|scrub_max_interval|deep_scrub_interval|recovery_priority|recovery_op_priority|compression_type " \
 	"name=val,type=CephString " \
 	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"set pool parameter <var> to <val>", "osd", "rw", "cli,rest")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -55,6 +55,7 @@
 #include "common/errno.h"
 
 #include "erasure-code/ErasureCodePlugin.h"
+#include "compressor/Compressor.h"
 
 #include "include/compat.h"
 #include "include/assert.h"
@@ -2913,7 +2914,7 @@ void OSDMonitor::dump_info(Formatter *f)
 
 namespace {
   enum osd_pool_get_choices {
-    SIZE, MIN_SIZE, CRASH_REPLAY_INTERVAL,
+    COMPRESSION_TYPE, SIZE, MIN_SIZE, CRASH_REPLAY_INTERVAL,
     PG_NUM, PGP_NUM, CRUSH_RULESET, HASHPSPOOL,
     NODELETE, NOPGCHANGE, NOSIZECHANGE,
     WRITE_FADVISE_DONTNEED, NOSCRUB, NODEEP_SCRUB,
@@ -3379,6 +3380,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 
     typedef std::map<std::string, osd_pool_get_choices> choices_map_t;
     const choices_map_t ALL_CHOICES = boost::assign::map_list_of
+      ("compression_type", COMPRESSION_TYPE)
       ("size", SIZE)
       ("min_size", MIN_SIZE)
       ("crash_replay_interval", CRASH_REPLAY_INTERVAL)
@@ -3418,7 +3420,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       (CACHE_MIN_FLUSH_AGE)(CACHE_MIN_EVICT_AGE)(MIN_READ_RECENCY_FOR_PROMOTE)
       (HIT_SET_GRADE_DECAY_RATE)(HIT_SET_SEARCH_LAST_N);
     const choices_set_t ONLY_ERASURE_CHOICES = boost::assign::list_of
-      (ERASURE_CODE_PROFILE);
+      (ERASURE_CODE_PROFILE)(COMPRESSION_TYPE);
 
     choices_set_t selected_choices;
     if (var == "all") {
@@ -3564,6 +3566,9 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case CACHE_MIN_EVICT_AGE:
 	    f->dump_unsigned("cache_min_evict_age", p->cache_min_evict_age);
 	    break;
+	  case COMPRESSION_TYPE:
+	    f->dump_string("compression_type", p->compression_type);
+	    break;
 	  case ERASURE_CODE_PROFILE:
 	    f->dump_string("erasure_code_profile", p->erasure_code_profile);
 	    break;
@@ -3680,6 +3685,9 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	    break;
 	  case CACHE_MIN_EVICT_AGE:
 	    ss << "cache_min_evict_age: " << p->cache_min_evict_age << "\n";
+	    break;
+	  case COMPRESSION_TYPE:
+	    ss << "compression_type: " << p->compression_type << "\n";
 	    break;
 	  case ERASURE_CODE_PROFILE:
 	    ss << "erasure_code_profile: " << p->erasure_code_profile << "\n";
@@ -4178,12 +4186,12 @@ int OSDMonitor::prepare_new_pool(MonOpRequestRef op)
   if (m->auid)
     return prepare_new_pool(m->name, m->auid, m->crush_rule, ruleset_name,
 			    0, 0,
-                            erasure_code_profile,
+                            erasure_code_profile, "none",
 			    pg_pool_t::TYPE_REPLICATED, 0, FAST_READ_OFF, &ss);
   else
     return prepare_new_pool(m->name, session->auid, m->crush_rule, ruleset_name,
 			    0, 0,
-                            erasure_code_profile,
+                            erasure_code_profile, "none",
 			    pg_pool_t::TYPE_REPLICATED, 0, FAST_READ_OFF, &ss);
 }
 
@@ -4267,6 +4275,18 @@ int OSDMonitor::crush_ruleset_create_erasure(const string &name,
     newcrush.encode(pending_inc.crush);
     return 0;
   }
+}
+
+int OSDMonitor::get_compressor(const string &compression_type,
+         CompressorRef *compressor,
+         ostream *ss) const
+{
+  *compressor = Compressor::create(g_ceph_context, compression_type);
+
+  if (!compressor->get())
+    return -EINVAL;
+  else 
+    return 0;
 }
 
 int OSDMonitor::get_erasure_code(const string &erasure_code_profile,
@@ -4566,6 +4586,7 @@ int OSDMonitor::get_crush_ruleset(const string &ruleset_name,
  * @param pg_num The pg_num to use. If set to 0, will use the system default
  * @param pgp_num The pgp_num to use. If set to 0, will use the system default
  * @param erasure_code_profile The profile name in OSDMap to be used for erasure code
+ * @param compression_type The compression plugin to be used with erasure pool
  * @param pool_type TYPE_ERASURE, or TYPE_REP
  * @param expected_num_objects expected number of objects on the pool
  * @param fast_read fast read type. 
@@ -4578,6 +4599,7 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
 				 const string &crush_ruleset_name,
                                  unsigned pg_num, unsigned pgp_num,
 				 const string &erasure_code_profile,
+         const string &compression_type,
                                  const unsigned pool_type,
                                  const uint64_t expected_num_objects,
                                  FastReadType fast_read,
@@ -4636,6 +4658,15 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
   if (r) {
     dout(10) << " prepare_pool_stripe_width returns " << r << dendl;
     return r;
+  }
+
+  if (!compression_type.empty() && compression_type != "none") {
+    CompressorRef cs;
+    r = get_compressor(compression_type, &cs, ss);
+    if (r) {
+      dout(10) << " compressor " << compression_type << " failed to load" << dendl;
+      return r;
+    }
   }
 
   for (map<int64_t,string>::iterator p = pending_inc.new_pool_names.begin();
@@ -4702,6 +4733,7 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
     g_conf->osd_pool_default_cache_target_full_ratio * 1000000;
   pi->cache_min_flush_age = g_conf->osd_pool_default_cache_min_flush_age;
   pi->cache_min_evict_age = g_conf->osd_pool_default_cache_min_evict_age;
+  pi->compression_type = compression_type;
   pending_inc.new_pool_names[pool] = name;
   return 0;
 }
@@ -4885,6 +4917,21 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
        }
     }
     p.min_size = n;
+  } else if (var == "compression_type") {
+    if (p.type != pg_pool_t::TYPE_ERASURE) {
+      ss << "compression can be used with erasure pools only";
+      return -EINVAL;
+    }
+    if (val != "none") {
+      CompressorRef cs;
+      stringstream tmp;
+      int err = get_compressor(val, &cs, &tmp);
+      if (err) {
+        ss << "compressor " <<  val << " failed to load";
+        return -EINVAL;
+      }
+    }
+    p.compression_type = val;
   } else if (var == "auid") {
     if (interr.length()) {
       ss << "error parsing integer value '" << val << "': " << interr;
@@ -6698,6 +6745,9 @@ done:
     if (pool_type_str.empty())
       pool_type_str = pg_pool_t::get_default_type();
 
+    string compression_type;
+    cmd_getval(g_ceph_context, cmdmap, "compression", compression_type);
+
     string poolstr;
     cmd_getval(g_ceph_context, cmdmap, "pool", poolstr);
     int64_t pool_id = osdmap.lookup_pg_pool_name(poolstr);
@@ -6716,6 +6766,11 @@ done:
     int pool_type;
     if (pool_type_str == "replicated") {
       pool_type = pg_pool_t::TYPE_REPLICATED;
+      if (!compression_type.empty()) {
+    	  ss << "compression cannot be used with replicated pools";
+    	  err = -EINVAL;
+    	  goto reply;
+      }
     } else if (pool_type_str == "erasure") {
       err = check_cluster_features(CEPH_FEATURE_CRUSH_V2 |
 				   CEPH_FEATURE_OSD_ERASURE_CODES,
@@ -6805,7 +6860,7 @@ done:
 			   -1, // default crush rule
 			   ruleset_name,
 			   pg_num, pgp_num,
-			   erasure_code_profile, pool_type,
+			   erasure_code_profile, compression_type, pool_type,
                            (uint64_t)expected_num_objects,
                            fast_read,
 			   &ss);

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -43,6 +43,7 @@ class PGMap;
 #include "messages/MPoolOp.h"
 
 #include "erasure-code/ErasureCodeInterface.h"
+#include "compressor/Compressor.h"
 
 #include "common/TrackedOp.h"
 #include "mon/MonOpRequest.h"
@@ -287,6 +288,9 @@ private:
   int get_erasure_code(const string &erasure_code_profile,
 		       ErasureCodeInterfaceRef *erasure_code,
 		       ostream *ss) const;
+  int get_compressor(const string &compression_type,
+           CompressorRef *compressor,
+           ostream *ss) const;
   int prepare_pool_crush_ruleset(const unsigned pool_type,
 				 const string &erasure_code_profile,
 				 const string &ruleset_name,
@@ -311,6 +315,7 @@ private:
 		       const string &crush_ruleset_name,
                        unsigned pg_num, unsigned pgp_num,
 		       const string &erasure_code_profile,
+           const string &compression_type,
                        const unsigned pool_type,
                        const uint64_t expected_num_objects,
                        FastReadType fast_read,

--- a/src/osd/CompressBackend.cc
+++ b/src/osd/CompressBackend.cc
@@ -1,0 +1,138 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Mirantis, Inc.
+ *
+ * Author: Igor Fedotov <ifedotov@mirantis.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <boost/variant.hpp>
+#include <boost/optional/optional_io.hpp>
+#include <iostream>
+#include <sstream>
+
+#include "ECUtil.h"
+#include "ECBackend.h"
+#include "CompressBackend.h"
+
+
+#define dout_subsys ceph_subsys_osd
+#define DOUT_PREFIX_ARGS this
+#undef dout_prefix
+#define dout_prefix *_dout
+
+
+typedef pair<boost::tuple<uint64_t, uint64_t, uint32_t>, pair<bufferlist*, Context*> > ReadRangeCallParam;
+
+struct CompressBackendReadCallContext : public Context {
+
+  CompressContextRef ccontext;
+  const hobject_t hoid;
+  ReadRangeCallParam to_read;
+  bufferlist intermediate_buffer;
+
+  CompressBackendReadCallContext(
+    const CompressContextRef& ccontext,
+    const hobject_t& hoid,
+    const ReadRangeCallParam& to_read)
+    : ccontext(ccontext), hoid(hoid), to_read(to_read) {
+    assert(ccontext != NULL);
+  }
+
+  virtual void finish(int r) {
+    if (r) {
+      bufferlist bl;
+      ccontext->try_decompress(
+	hoid,
+	to_read.first.get<0>(),
+	to_read.first.get<1>(),
+	intermediate_buffer,
+	to_read.second.first
+      );
+      if (to_read.second.second) {
+	to_read.second.second->complete(to_read.second.first->length());
+	to_read.second.second = NULL;
+      }
+    }
+  }
+
+  ~CompressBackendReadCallContext() {
+    delete to_read.second.second;
+  }
+};
+
+CompressedECBackend::CompressedECBackend(
+  PGBackend::Listener* pg,
+  coll_t coll,
+  ObjectStore* store,
+  CephContext* cct,
+  ErasureCodeInterfaceRef ec_impl,
+  uint64_t stripe_width) :
+  ECBackend(pg, coll, store, cct, ec_impl, stripe_width) {
+}
+
+
+void CompressedECBackend::objects_read_async(
+  const hobject_t& hoid,
+  const list<ReadRangeCallParam>& to_read,
+  Context* on_complete,
+  bool fast_read) {
+  map<string, bufferlist> attrset;
+  int r = load_attrs(hoid, &attrset);
+  if (r != 0) {
+    derr << __func__ << ": failed loading attributes: oid=" << hoid << ":"
+	 << " null pointer returned and there is no "
+	 << " way to recover from such an error in this "
+	 << " context" << dendl;
+    assert(0);
+  }
+
+  pair<uint64_t, uint64_t> tmp;
+
+  list<ReadRangeCallParam> to_read_from_ec;
+  for (list<ReadRangeCallParam>::const_iterator it = to_read.begin(); it != to_read.end(); it++) {
+    CompressContextRef cinfo = get_compress_context_on_read(attrset, it->first.get<0>(), it->first.get<0>() + it->first.get<1>());
+    if (!cinfo) {
+      derr << __func__ << ": failed to obtain CompressionCcontext: oid=" << hoid
+	   << " (" << it->first.get<0>() << "," << it->first.get<1>()
+	   << "): null pointer returned and there is no "
+	   << " way to recover from such an error in this "
+	   << " context" << dendl;
+      assert(0);
+    }
+
+    tmp = cinfo->offset_len_to_compressed_block(make_pair(it->first.get<0>(), it->first.get<1>()));
+
+    CompressBackendReadCallContext* ctx = new CompressBackendReadCallContext(cinfo, hoid, *it);
+
+    dout(CompressContext::DEBUG_LEVEL) << __func__
+					  << " reading from EC pool: original(" << "( offs:" << it->first.get<0>() << ", len:" << it->first.get<1>() << ")"
+					  << " target ( offs:" << tmp.first << ", len:" << tmp.second << ")" << dendl;
+
+    to_read_from_ec.push_back(
+      std::make_pair(
+	boost::make_tuple(
+	  tmp.first, //new offset
+	  tmp.second, //new length
+	  it->first.get<2>()), //flags
+	std::make_pair(
+	  &ctx->intermediate_buffer,
+	  ctx))
+    );
+  }
+  ECBackend::objects_read_async(hoid, to_read_from_ec, on_complete, fast_read);
+}
+
+CompressContextRef CompressedECBackend::get_compress_context_on_read(
+  map<string, bufferlist>& attrset, uint64_t offs, uint64_t offs_last) {
+  CompressContextRef ref(new CompressContext(sinfo.get_stripe_width()));
+  ref->setup_for_read(attrset, offs, offs_last);
+  return ref;
+}

--- a/src/osd/CompressBackend.h
+++ b/src/osd/CompressBackend.h
@@ -1,0 +1,52 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Mirantis, Inc.
+ *
+ * Author: Igor Fedotov <ifedotov@mirantis.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef COMPRESS_BACKEND_H
+#define COMPRESS_BACKEND_H
+
+#include "OSD.h"
+#include "ECBackend.h"
+#include "osd_types.h"
+#include <boost/optional/optional_io.hpp>
+#include "ECMsgTypes.h"
+#include "ECUtil.h"
+#include "CompressContext.h"
+
+/*
+ECBackend extenstion to provide object data decompression on read access
+*/
+class CompressedECBackend : public ECBackend {
+ protected:
+  CompressContextRef get_compress_context_on_read(map<string, bufferlist>& attrset, uint64_t offs, uint64_t offs_last);
+
+ public:
+  CompressedECBackend(
+    PGBackend::Listener* pg,
+    coll_t coll,
+    ObjectStore* store,
+    CephContext* cct,
+    ErasureCodeInterfaceRef ec_impl,
+    uint64_t stripe_width);
+
+  virtual void objects_read_async(
+    const hobject_t& hoid,
+    const list < pair < boost::tuple<uint64_t, uint64_t, uint32_t>,
+    pair<bufferlist*, Context*> > >& to_read,
+    Context* on_complete,
+    bool fast_read);
+};
+
+#endif

--- a/src/osd/CompressContext.cc
+++ b/src/osd/CompressContext.cc
@@ -1,0 +1,672 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Mirantis, Inc.
+ *
+ * Author: Igor Fedotov <ifedotov@mirantis.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <errno.h>
+#include "include/encoding.h"
+#include "ECUtil.h"
+#include "CompressContext.h"
+#include "compressor/Compressor.h"
+#include "compressor/CompressionPlugin.h"
+#include "common/debug.h"
+
+
+#define dout_subsys ceph_subsys_osd
+#define DOUT_PREFIX_ARGS this
+#undef dout_prefix
+#define dout_prefix *_dout
+
+const unsigned CompressContext::MAX_STRIPES_PER_BLOCK = 32;      //maximum amount of stripes that can be compressed as a single block
+const unsigned CompressContext::RECS_PER_RECORDSET = 32;         //amount of comression information records per single record set, i.e. records grouped for seek speed-up.
+const unsigned CompressContext::MAX_STRIPES_PER_BLOCKSET = 1024; //maximum stripes to be described by a single attribute
+const int CompressContext::DEBUG_LEVEL = 1;  //debug level for compression stuff
+
+void CompressContext::BlockInfoRecord::encode(bufferlist& bl) const {
+  ENCODE_START(1, 1, bl);
+  ::encode(method_idx, bl);
+  ::encode(original_length, bl);
+  ::encode(compressed_length, bl);
+  ENCODE_FINISH(bl);
+}
+
+void CompressContext::BlockInfoRecord::decode(bufferlist::iterator& bl) {
+  DECODE_START(1, bl);
+  ::decode(method_idx, bl);
+  ::decode(original_length, bl);
+  ::decode(compressed_length, bl);
+  DECODE_FINISH(bl);
+}
+
+void CompressContext::BlockInfoRecordSetHeader::encode(bufferlist& bl) const {
+  ENCODE_START(1, 1, bl);
+  ::encode(start_offset, bl);
+  ::encode(compressed_offset, bl);
+  ENCODE_FINISH(bl);
+}
+
+void CompressContext::BlockInfoRecordSetHeader::decode(bufferlist::iterator& bl) {
+  DECODE_START(1, bl);
+  ::decode(start_offset, bl);
+  ::decode(compressed_offset, bl);
+  DECODE_FINISH(bl);
+}
+
+uint8_t CompressContext::MasterRecord::add_get_method(const string& method) {
+  uint8_t res = 0;
+  if (!method.empty()) {
+    for (size_t i = 0; i < methods.size() && res == 0; i++) {
+      if (methods[i] == method) {
+	res = i + 1;
+      }
+    }
+    if (res == 0) {
+      methods.push_back(method);
+      res = methods.size();
+    }
+  }
+  return res;
+}
+
+string CompressContext::MasterRecord::get_method_name(uint8_t index) const {
+  string res;
+  if (index > 0) {
+    if (index <= methods.size()) {
+      res = methods[index - 1];
+    } else {
+      res = "???";
+    }
+  }
+  return res;
+}
+
+void CompressContext::MasterRecord::encode(bufferlist& bl) const {
+  ENCODE_START(1, 1, bl);
+  ::encode(current_original_pos, bl);
+  ::encode(current_compressed_pos, bl);
+  ::encode(block_info_record_length, bl);
+  ::encode(block_info_recordset_header_length, bl);
+  ::encode(methods, bl);
+  ENCODE_FINISH(bl);
+}
+
+
+void CompressContext::MasterRecord::decode(bufferlist::iterator& bl) {
+  DECODE_START(1, bl);
+  ::decode(current_original_pos, bl);
+  ::decode(current_compressed_pos, bl);
+  ::decode(block_info_record_length, bl);
+  ::decode(block_info_recordset_header_length, bl);
+  ::decode(methods, bl);
+  DECODE_FINISH(bl);
+}
+
+CompressContext::~CompressContext() {
+}
+
+bool  CompressContext::can_compress(uint64_t offs) const {
+  return (offs == 0 && masterRec.current_compressed_pos == 0) || masterRec.current_compressed_pos != 0;
+}
+
+uint64_t CompressContext::get_block_size() const {
+  return MAX_STRIPES_PER_BLOCK * stripe_width;
+}
+
+unsigned CompressContext::get_blockset_size() const
+{
+  return MAX_STRIPES_PER_BLOCKSET * stripe_width;
+}
+
+CompressContext::BlockInfoRecordSetHeader CompressContext::search_starting_recordset(uint64_t offset, size_t record_set_size, bufferlist::iterator& it_bl)
+{
+  BlockInfoRecordSetHeader recset_header(0, 0);
+  BlockInfoRecordSetHeader recset_header_next(0, 0);
+  //searching for the record set that contains desired data range
+  ::decode(recset_header, it_bl);
+
+  bufferlist::iterator it_bl_next = it_bl;
+
+  bool found = false;
+  do {
+    if (it_bl_next.get_remaining() >= record_set_size) {
+      it_bl_next.advance(record_set_size - masterRec.block_info_recordset_header_length);
+      ::decode(recset_header_next, it_bl_next);
+      found = recset_header_next.start_offset > offset;
+      if (!found) {
+	it_bl = it_bl_next;
+	recset_header = recset_header_next;
+      }
+    }
+    else {
+      found = true;
+    }
+  } while (!found);
+  return recset_header;
+}
+
+
+void CompressContext::setup_for_read(const map<string, bufferlist>& attrset, uint64_t start_offset, uint64_t end_offset) {
+  assert(end_offset >= start_offset);
+
+  clear();
+  map<string, bufferlist>::const_iterator it_master = attrset.find(ECUtil::get_cinfo_master_key());
+  map<string, bufferlist>::const_iterator end = attrset.end();
+  if (it_master != end) {
+    bufferlist::iterator it_val = const_cast<bufferlist&>(it_master->second).begin();
+    ::decode(masterRec, it_val);
+
+    assert(end_offset <= masterRec.current_original_pos);
+    dout(DEBUG_LEVEL) << __func__
+		      << " cur pos:(" << masterRec.current_original_pos << "," << masterRec.current_compressed_pos << ") offs:("
+		      << "," << start_offset << "," << end_offset << ")" << dendl;
+
+    size_t record_set_size = masterRec.block_info_record_length * RECS_PER_RECORDSET + masterRec.block_info_recordset_header_length;
+    assert(masterRec.current_original_pos != 0 && record_set_size != 0);
+
+    std::string key;
+    offset_to_key(start_offset, key);
+    map<string, bufferlist>::const_iterator it = attrset.find(key);
+
+    if (start_offset >= get_blockset_size()) {
+      bool step_back = true;
+      if (it != end) {
+	//check if desired data range starts in the previous attribute
+	BlockInfoRecordSetHeader recset_header(0, 0);
+	bufferlist::iterator it_bl = const_cast<bufferlist&>(it->second).begin();
+	::decode(recset_header, it_bl);
+	if (recset_header.start_offset <= start_offset)
+	  step_back = false;
+      }
+      if (step_back) {
+	offset_to_key(start_offset - get_blockset_size(), key);
+	it = attrset.find(key);
+      }
+    }
+
+    if (it != end) {
+      bufferlist::iterator it_bl = const_cast<bufferlist&>(it->second).begin();
+      BlockInfoRecordSetHeader recset_header = search_starting_recordset(start_offset, record_set_size, it_bl);
+
+      bool stop = false;
+      uint64_t cur_pos = recset_header.start_offset;
+      uint64_t cur_cpos = recset_header.compressed_offset;
+      uint64_t found_start_offset = 0;
+      BlockInfo found_bi;
+      bool start_found = false;
+      boost::optional<uint64_t> last_block_offs;
+
+      do {
+
+	while (!stop && !it_bl.end()) {
+	  if ((it_bl.get_off() % record_set_size) == 0) {
+	    ::decode(recset_header, it_bl);
+	  }
+	  BlockInfoRecord rec;
+	  ::decode(rec, it_bl);
+
+	  if (cur_pos <= start_offset && (!start_found || cur_pos > found_start_offset)) {
+	    found_start_offset = cur_pos;
+	    found_bi = BlockInfo(rec.method_idx, cur_cpos);
+	    start_found = true;
+	  }
+	  if (cur_pos > start_offset) {
+	    blocks[cur_pos] = BlockInfo(rec.method_idx, cur_cpos);
+	    last_block_offs = cur_pos;
+	    if (cur_pos >= end_offset) {
+	      stop = true;
+	    }
+	  }
+
+	  cur_pos += rec.original_length;
+	  cur_cpos += rec.compressed_length;
+	  assert(cur_pos <= masterRec.current_original_pos);
+	  assert(cur_cpos <= masterRec.current_compressed_pos);
+	}
+        stop = stop || cur_pos==masterRec.current_original_pos; //an additional check to avoid garbage attributes reading that may exist after previous rollback
+
+	if( !stop ){
+	  string key0(key);
+	  offset_to_key(cur_pos, key);
+          stop = key == key0;
+	  if (!stop) {
+	    it = attrset.find(key);
+	    if (it != end)
+	      it_bl = const_cast<bufferlist&>(it->second).begin();
+	  }
+        }
+      } while (!stop && it!=end);
+
+      if (start_found) {
+	blocks[found_start_offset] = found_bi;
+	dout(DEBUG_LEVEL) << __func__
+	  << " first block:(" << found_start_offset << ", " << (int)found_bi.method_idx << "," << found_bi.target_offset << ")" << dendl;
+      }
+
+      if (last_block_offs.is_initialized()) {
+	BlockInfo& bi = blocks[last_block_offs.get()];
+	dout(DEBUG_LEVEL) << __func__
+	  << " Last block:(" << last_block_offs.get() << ", " << (int)bi.method_idx << "," << bi.target_offset << ")" << dendl;
+      }
+      else {
+	dout(DEBUG_LEVEL) << __func__ << " Last block:(Not found)" << dendl;
+      }
+    } else {
+      dout(DEBUG_LEVEL) << __func__ << " No compression info found" << dendl;
+    }
+  } //if (it_master != end) 
+}
+
+void CompressContext::setup_for_append_or_recovery(const map<string, bufferlist>& attrset) {
+  clear();
+
+  map<string, bufferlist>::const_iterator it_attrs = attrset.find(ECUtil::get_cinfo_master_key());
+  if (it_attrs != attrset.end()) {
+    bufferlist::iterator it = const_cast<bufferlist&>(it_attrs->second).begin();
+    ::decode(masterRec, it);
+    prevMasterRec = masterRec;
+  }
+  std::string key;
+  offset_to_key(prevMasterRec.current_original_pos, key);
+
+  it_attrs = attrset.find(key);
+  if (it_attrs != attrset.end()) {
+    prev_blocks_encoded = it_attrs->second;
+    prev_blocks_key = key;
+  }
+  dout(DEBUG_LEVEL) << __func__
+    << " cur pos:(" << masterRec.current_original_pos << "," << masterRec.current_compressed_pos << ")" << dendl;
+}
+
+
+void CompressContext::flush(map<string, bufferlist>* attrset) {
+  assert(attrset);
+  if (need_flush()) { //some changes have been made to the context
+    bufferlist bl(prev_blocks_encoded);
+    std::string key0 = prev_blocks_key;
+
+    size_t record_set_size = masterRec.block_info_record_length * RECS_PER_RECORDSET + masterRec.block_info_recordset_header_length;
+    assert((prevMasterRec.current_original_pos==0 && record_set_size == 0) || (prevMasterRec.current_original_pos!=0 && record_set_size != 0));
+
+    std::string key;
+    for (CompressContext::BlockMap::const_iterator it = blocks.begin(); it != blocks.end(); it++) {
+      CompressContext::BlockMap::const_iterator it_next = it;
+      ++it_next;
+      uint64_t next_offset, next_coffset;
+      if (it_next == blocks.end()) {
+	next_offset = masterRec.current_original_pos;
+	next_coffset = masterRec.current_compressed_pos;
+      } else {
+	next_offset = it_next->first;
+	next_coffset = it_next->second.target_offset;
+      }
+      offset_to_key(it->first, key);
+
+      if (key != key0) {
+	if (!key0.empty())
+	  (*attrset)[key0] = bl;
+	key0 = key;
+	bl.clear();
+      }
+
+      BlockInfoRecord rec(it->second.method_idx, next_offset - it->first, next_coffset - it->second.target_offset);
+
+      if (record_set_size == 0) { //first record to be added - need to measure rec sizes
+	BlockInfoRecordSetHeader header(it->first, it->second.target_offset);
+	size_t old_len = bl.length();
+	::encode(header, bl);
+	masterRec.block_info_recordset_header_length = bl.length() - old_len;
+	old_len = bl.length();
+	::encode(rec, bl);
+	masterRec.block_info_record_length = bl.length() - old_len;
+
+	record_set_size = masterRec.block_info_record_length * RECS_PER_RECORDSET + masterRec.block_info_recordset_header_length;
+	assert(record_set_size != 0);
+      }
+      else {
+	if ((bl.length() % record_set_size) == 0) {
+	  BlockInfoRecordSetHeader header(it->first, it->second.target_offset);
+	  ::encode(header, bl);
+	}
+	::encode(rec, bl);
+      }
+    }
+
+    (*attrset)[key] = bl;
+
+    bufferlist master_bl;
+    ::encode(masterRec, master_bl);
+    (*attrset)[ECUtil::get_cinfo_master_key()] = master_bl;
+
+    dout(DEBUG_LEVEL) << __func__ << " cctx: Lengths:( master rec:"
+		      << master_bl.length() << ", block info:"
+		      << bl.length() << ", block info rec length:"
+		      << masterRec.block_info_record_length << ", block info recset header length:"
+		      << masterRec.block_info_recordset_header_length << ") MRec: ("
+		      << masterRec.current_original_pos << "," << masterRec.current_compressed_pos << ") prev MRec("
+		      << prevMasterRec.current_original_pos << "," << prevMasterRec.current_compressed_pos << ")" << dendl;
+
+    prev_blocks_key.swap(key);
+    prev_blocks_encoded.swap(bl);
+    prevMasterRec = masterRec;
+    blocks.clear();
+  }
+}
+
+void CompressContext::flush_for_rollback(map<string, boost::optional<bufferlist> >* attrset) const {
+  assert(attrset);
+
+  if (!prev_blocks_key.empty()) {
+    (*attrset)[prev_blocks_key] = prev_blocks_encoded;
+  } else {
+    string key;
+    offset_to_key( masterRec.current_original_pos, key);
+    (*attrset)[key] = boost::optional<bufferlist>();    //to trigger record removal on rollback
+  }
+
+  if (prevMasterRec.current_original_pos != 0) {
+    bufferlist bl;
+    ::encode(prevMasterRec, bl);
+    (*attrset)[ECUtil::get_cinfo_master_key()] = bl;
+  } else {
+    (*attrset)[ECUtil::get_cinfo_master_key()] = boost::optional<bufferlist>();    //to trigger record removal on rollback
+  }
+}
+
+
+void CompressContext::dump(Formatter* f) const {
+  f->dump_unsigned("current_original_pos", masterRec.current_original_pos);
+  f->dump_unsigned("current_compressed_pos", masterRec.current_compressed_pos);
+  f->open_object_section("blocks");
+  for (CompressContext::BlockMap::const_iterator it = blocks.begin(); it != blocks.end(); it++) {
+    f->open_object_section("block");
+    f->dump_unsigned("offset", it->first);
+    f->dump_string("method", masterRec.get_method_name(it->second.method_idx));
+    f->dump_unsigned("target_offset", it->second.target_offset);
+    f->close_section();
+  }
+  f->close_section();
+}
+
+void CompressContext::append_block(uint64_t original_offset,
+				   uint64_t original_size,
+				   const string& method,
+				   uint64_t new_block_size) {
+  assert(original_size != 0);
+  assert(original_offset == masterRec.current_original_pos);
+
+  uint8_t method_idx = masterRec.add_get_method(method);
+
+  blocks[original_offset] = BlockInfo(method_idx, masterRec.current_compressed_pos);
+
+  masterRec.current_original_pos += original_size;
+  masterRec.current_compressed_pos += new_block_size;
+}
+
+pair<uint64_t, uint64_t> CompressContext::offset_len_to_compressed_block(const pair<uint64_t, uint64_t> offs_len_pair) const {
+  uint64_t start_offs = offs_len_pair.first;
+  uint64_t end_offs = offs_len_pair.first + offs_len_pair.second - 1;
+  assert(masterRec.current_original_pos == 0 || start_offs < masterRec.current_original_pos);
+  assert(masterRec.current_original_pos == 0 || end_offs < masterRec.current_original_pos);
+
+  uint64_t res_start_offs = masterRec.current_original_pos != 0 ? map_offset(start_offs, false).second : start_offs;
+  uint64_t res_end_offs = masterRec.current_original_pos != 0 ? map_offset(end_offs, true).second : end_offs + 1;
+
+  return std::pair<uint64_t, uint64_t>(res_start_offs, res_end_offs - res_start_offs);
+}
+
+bool CompressContext::less_upper(const uint64_t& val1, const BlockMap::value_type& val2) {
+  return val1 < val2.first;
+}
+
+bool CompressContext::less_lower(const BlockMap::value_type& val1, const uint64_t& val2) {
+  return val1.first < val2;
+}
+
+pair<uint64_t, uint64_t> CompressContext::map_offset(uint64_t offs, bool next_block_flag) const {
+  pair<uint64_t, uint64_t> res; //original block offset, compressed block offset
+  BlockMap::const_iterator it;
+  if (next_block_flag) {
+    it = std::upper_bound(blocks.begin(), blocks.end(), offs, less_upper);
+    if (it != blocks.end()) {
+      res = std::pair<uint64_t, uint64_t>(it->first, it->second.target_offset);
+    } else {
+      res = std::pair<uint64_t, uint64_t>(masterRec.current_original_pos, masterRec.current_compressed_pos);
+    }
+  } else {
+
+    it = std::lower_bound(blocks.begin(), blocks.end(), offs, less_lower);
+    if (it == blocks.end() || it->first != offs) { //lower_end returns iterator to the specified value if present or the next entry
+      if( it == blocks.begin() ){
+        dout(0)<<"ifed:"<<offs<<","<< blocks.size()<<dendl;
+      }
+      assert(it != blocks.begin());
+      --it;
+    }
+    res = std::pair<uint64_t, uint64_t>(it->first, it->second.target_offset);
+  }
+  return res;
+}
+
+void CompressContext::offset_to_key(uint64_t offs, std::string& key) const
+{
+  offs /= get_blockset_size();
+  char buf[9];
+  sprintf(buf, "%llx", (long long unsigned)offs);
+  key = ECUtil::get_cinfo_key_prefix();
+  key += buf;
+}
+
+int CompressContext::try_decompress(const hobject_t& oid, uint64_t orig_offs, uint64_t len, const bufferlist& cs_bl, bufferlist* res_bl) const {
+  assert(res_bl);
+  int res = 0;
+  uint64_t appended = 0;
+  if (masterRec.current_original_pos == 0) { //no compression was applied to the object
+    dout(DEBUG_LEVEL) << __func__ << " bypassing: oid=" << oid << " params:(" << cs_bl.length() << "," << orig_offs << ", " << len << ")" << dendl;    res_bl->append(cs_bl);
+    appended += cs_bl.length();
+  } else {
+    dout(DEBUG_LEVEL) << __func__ << " processing oid=" << oid << " params:(" << cs_bl.length() << "," << orig_offs << ", " << len << ")" << dendl;
+    assert(masterRec.current_original_pos >= orig_offs + len);
+    assert(blocks.size() > 0);
+
+    uint64_t cur_block_offs, cur_block_len, cur_block_coffs, cur_block_clen;
+    string cur_block_method;
+    BlockMap::const_iterator it = blocks.begin();
+
+    bufferlist::iterator cs_bl_pos = const_cast<bufferlist&>(cs_bl).begin();
+    do {
+      cur_block_offs = it->first;
+      cur_block_coffs = it->second.target_offset;
+      cur_block_method = masterRec.get_method_name(it->second.method_idx);
+      ++it;
+      if (it == blocks.end()) {
+	cur_block_len = masterRec.current_original_pos - cur_block_offs;
+	cur_block_clen = masterRec.current_compressed_pos - cur_block_coffs;
+      } else {
+	cur_block_len = it->first - cur_block_offs;
+	cur_block_clen = it->second.target_offset - cur_block_coffs;
+      }
+      if (cur_block_offs + cur_block_len >= orig_offs) { //skipping map entries for data ranges prior to the desired one.
+	bufferlist cs_bl1, tmp_bl;
+
+	CompressorRef cs_impl;
+	if( !cur_block_method.empty() ){
+	  cs_impl = Compressor::create(g_ceph_context, cur_block_method);
+	}
+	if ( cs_impl == 0 && !cur_block_method.empty()) {
+	  derr << __func__ << " failed to create decompression engine for " << cur_block_method << dendl;
+	  res = -1;
+	} else if (cs_impl == NULL) {
+	  uint64_t offs2splice = cur_block_offs < orig_offs ? orig_offs - cur_block_offs : 0;
+
+	  uint64_t len2splice = cur_block_len - offs2splice;
+	  len2splice -= cur_block_offs + cur_block_len > orig_offs + len ? cur_block_offs + cur_block_len - orig_offs - len : 0 ;
+
+	  offs2splice += cs_bl_pos.get_off();
+	  dout(DEBUG_LEVEL) << __func__ << " non-compressed block: oid=" << oid << " state:(" << cur_block_offs << "," << cur_block_len << "," << offs2splice << "," << len2splice << ")" << dendl;
+	  if (offs2splice == 0 && len2splice == cs_bl.length()) { //current block is completely within the requested range
+	    res_bl->append(cs_bl);
+	  } else {
+	    tmp_bl.substr_of(cs_bl, offs2splice, len2splice);
+	    res_bl->append(tmp_bl);
+	  }
+	  appended += len2splice;
+	} else {
+	  dout(DEBUG_LEVEL) << __func__ << " decompressing: oid = " << oid << " state : ("
+			    << cur_block_method << "," << cur_block_offs << "," << cur_block_len << "," << cur_block_coffs << "," << cur_block_clen << ", " << cs_bl_pos.get_off() << ")" << dendl;
+
+	  uint32_t real_len = 0;
+	  bufferlist::iterator it = cs_bl_pos;
+	  ::decode(real_len, it);
+	  assert(cur_block_clen >= real_len);
+	  assert(it.get_remaining() >= real_len);
+	  cs_bl1.substr_of(cs_bl, it.get_off(), real_len);
+
+	  int r = cs_impl->decompress(
+		    cs_bl1,
+		    tmp_bl);
+	  if (r < 0) {
+	    derr << __func__ << ": decompress(" << cur_block_method << ")"
+		 << " returned an error: " << r << dendl;
+	    res = -1;
+	  } else {
+	    uint64_t offs2splice = cur_block_offs < orig_offs ? orig_offs - cur_block_offs : 0;
+	    uint64_t len2splice = tmp_bl.length() - offs2splice;
+	    len2splice -= cur_block_offs + cur_block_len > orig_offs + len ? cur_block_offs + cur_block_len - orig_offs - len : 0;
+
+	    dout(DEBUG_LEVEL) << __func__ << "decompressed: oid=" << oid << " state("
+			      << offs2splice << "," << len2splice << "," << tmp_bl.length() << ")" << dendl;
+
+	    if (offs2splice == 0 && len2splice == tmp_bl.length()) { //decompressed block is completely within the requested range
+	      res_bl->append(tmp_bl);
+	    } else {
+	      tmp_bl.splice(offs2splice, len2splice, res_bl);
+	    }
+	    appended += len2splice;
+	  }
+	}
+      }
+
+      cs_bl_pos.advance(cur_block_clen);
+    } while (it != blocks.end() && appended < len && res == 0);
+  }
+  assert(res != 0 || (res == 0 && appended == len));
+  return res;
+}
+
+int CompressContext::do_compress(CompressorRef cs_impl, const bufferlist& block2compress, bufferlist* result_bl) const {
+  int res = -1;
+  bufferlist tmp_bl;
+  assert(result_bl);
+  int r = cs_impl->compress(const_cast<bufferlist&>(block2compress), tmp_bl);
+  if (r == 0) {
+    bufferlist tmp_bl0;
+    uint32_t real_len = tmp_bl.length();
+    ::encode(real_len, tmp_bl0);
+    unsigned block_len = tmp_bl.length() + tmp_bl0.length();
+    if (block_len < block2compress.length()) {
+      result_bl->append(tmp_bl0);
+      result_bl->append(tmp_bl);
+      res = 1;
+    } else {
+      result_bl->append(block2compress);
+      res = 0;
+    }
+  }
+  return res;
+}
+
+int CompressContext::try_compress(const std::string& compression_method, const hobject_t& oid, const bufferlist& bl0, uint64_t* off, bufferlist* res_bl) {
+  assert(off);
+  assert(res_bl);
+  bufferlist bl_cs(bl0);
+  bufferlist bl;
+  CompressContext new_cinfo(*this);
+
+  dout(DEBUG_LEVEL) << __func__ << " compressing oid=" << oid << " params("
+		    << compression_method << "," << *off << ", " << bl0.length() << ")" << dendl;
+
+  bool compressed = false, failure = false;
+  uint64_t prev_compressed_pos = masterRec.current_compressed_pos;
+  CompressorRef cs_impl;
+  if( !compression_method.empty() ){
+    cs_impl = Compressor::create(g_ceph_context, compression_method);
+    if (cs_impl == 0) {
+      derr << __func__ << " failed to create compression engine for " << compression_method << dendl;
+    }
+  }
+
+  //apply compression if that's a first block or it's been already applied to previous blocks
+  bool compress_permitted = can_compress(*off); //if current object metadata state is consistent to apply compression
+  if ( compress_permitted && cs_impl != NULL) {
+    if (bl_cs.length() > stripe_width) {
+
+      bufferlist::iterator it = bl_cs.begin();
+
+      uint64_t cur_offs = *off;
+      while (!it.end() && !failure) {
+	uint64_t block_size = MIN(it.get_remaining(), get_block_size());
+	bufferlist block2compress, compressed_block;
+	uint64_t prev_len = bl.length();
+	it.copy(block_size, block2compress);
+
+	int r0 = do_compress(cs_impl, block2compress, &bl);
+	if (r0 < 0) {
+	  derr << __func__ << " block compression failed, left uncompressed, oid=" << oid << " params("
+	       << compression_method << "," << block2compress.length() << ")" << dendl;
+	  failure = true;
+	} else {
+	  if (it.end()) {
+	    unsigned padded_size = ECUtil::stripe_info_t::pad_to_stripe_width(stripe_width, bl.length());
+	    if (padded_size > bl.length()) {
+	      bl.append_zero(padded_size - bl.length());
+	    }
+	  }
+	  new_cinfo.append_block(cur_offs, block2compress.length(), r0 ? compression_method : "", bl.length() - prev_len);
+	}
+	cur_offs += block2compress.length();
+      }
+      if (!failure && bl.length() < ECUtil::stripe_info_t::pad_to_stripe_width(stripe_width, bl_cs.length())) {
+	compressed = true;
+	dout(DEBUG_LEVEL) << " block(s) compressed, oid=" << oid << ", ratio = " << (float)bl_cs.length() / bl.length() << dendl;
+      } else if (failure) {
+	dout(DEBUG_LEVEL) << " block(s) compression bypassed due to failure, oid=" << oid << dendl;
+      } else {
+	dout(DEBUG_LEVEL) << "block(s) compression bypassed, oid=" << oid << dendl;
+      }
+
+    } else {
+      dout(DEBUG_LEVEL) << "block(s) compression bypassed, too small, oid=" << oid << dendl;
+    }
+  }
+  if (!compressed) { //the whole block wasn't compressed or there is no benefit in compression
+    *res_bl = bl0;
+    if( compress_permitted ) {
+      uint64_t left = res_bl->length();
+      uint64_t o =*off;
+      uint64_t bs_size = get_blockset_size();
+      while( left>0 ){
+        uint64_t to_append = MIN( left, bs_size);
+        to_append = MIN( to_append, bs_size - (o % bs_size));
+        append_block(o, to_append, "", to_append);
+        left-=to_append;
+        o+=to_append;
+      }
+    }
+  } else {
+    bl.swap(*res_bl);
+    swap(new_cinfo);
+  }
+  *off = prev_compressed_pos;
+  return 0;
+}

--- a/src/osd/CompressContext.cc
+++ b/src/osd/CompressContext.cc
@@ -31,7 +31,7 @@
 const unsigned CompressContext::MAX_STRIPES_PER_BLOCK = 32;      //maximum amount of stripes that can be compressed as a single block
 const unsigned CompressContext::RECS_PER_RECORDSET = 32;         //amount of comression information records per single record set, i.e. records grouped for seek speed-up.
 const unsigned CompressContext::MAX_STRIPES_PER_BLOCKSET = 1024; //maximum stripes to be described by a single attribute
-const int CompressContext::DEBUG_LEVEL = 1;  //debug level for compression stuff
+const int CompressContext::DEBUG_LEVEL = 10;  //debug level for compression stuff
 
 void CompressContext::BlockInfoRecord::encode(bufferlist& bl) const {
   ENCODE_START(1, 1, bl);

--- a/src/osd/CompressContext.h
+++ b/src/osd/CompressContext.h
@@ -1,0 +1,208 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Mirantis, Inc.
+ *
+ * Author: Igor Fedotov <ifedotov@mirantis.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef COMPRESSCONTEXT_H
+#define COMPRESSCONTEXT_H
+
+#include <map>
+
+#include "include/memory.h"
+#include "include/buffer.h"
+#include "include/assert.h"
+#include "include/encoding.h"
+#include "common/Formatter.h"
+#include "common/hobject.h"
+#include "compressor/Compressor.h"
+#include "osd/ECUtil.h"
+
+class CompressContext {
+ public:
+
+  static const unsigned RECS_PER_RECORDSET;          //amount of comression information records per single record set.
+  static const unsigned MAX_STRIPES_PER_BLOCK;       //maximum amount of stripes that can be compressed as a single block 
+  static const unsigned MAX_STRIPES_PER_BLOCKSET;    //maximum stripes to be described by a single attribute
+  static const int DEBUG_LEVEL;                      //debug level for compression stuff
+
+  /*
+  Compression information record for single object block.
+  To be stored along with other records under specific key in object attributes.
+  Substitutes BlockMap entry( see below ) at persistent storage to reduce object attributes space utilization.
+  */
+  struct BlockInfoRecord {
+    uint8_t method_idx;                           //an index indicating applied compression method in corresponding master record list, 0 - if no compression has been applied.
+    uint32_t original_length,                     // block original length
+	     compressed_length;                   // block compressed length
+    BlockInfoRecord() : method_idx(0), original_length(0), compressed_length(0) {}
+    BlockInfoRecord(const BlockInfoRecord& from) : method_idx(from.method_idx), original_length(from.original_length), compressed_length(from.compressed_length) {}
+    BlockInfoRecord(uint8_t idx, uint32_t olen, uint32_t clen) : method_idx(idx), original_length(olen), compressed_length(clen) {}
+
+    void encode(bufferlist& bl) const;
+    void decode(bufferlist::iterator& bl);
+  };
+
+  
+  /*Compression information record set header. Used to split compression information records into recordsets to increase specific record lookup performance.
+  To be stored before each recordset ( 32 records) under specific key in object attributes
+  */
+  struct BlockInfoRecordSetHeader {
+    uint64_t start_offset,        //original offset for the first block in the recordset
+	     compressed_offset;   //compressed offset for the first block in the recordset
+    BlockInfoRecordSetHeader(uint64_t offset, uint64_t coffset) : start_offset(offset), compressed_offset(coffset) {}
+
+    void encode(bufferlist& bl) const;
+    void decode(bufferlist::iterator& bl);
+  };
+
+  /*
+  Object compression information master record.
+  To be stored under specific key in object attributes
+  */
+  struct MasterRecord {
+    uint64_t current_original_pos;                //Object original size (position original data is appended to), if 0 - no compression has been applied.
+    uint64_t current_compressed_pos;              //Object compressed size (position compressed data to be appended to)
+    uint32_t block_info_record_length,            //The length of the single block info record
+             block_info_recordset_header_length;  //The length of the block info recordset header
+    typedef vector<string>  MethodList;
+    MethodList methods;                           //list of compression methods applied to the object. Positions to be preserved through object life-cycle to ensure proper mapping. +-1 shift to be applied to the index since 0 denotes no compression and isn't stored in the list.
+
+    MasterRecord() : current_original_pos(0), current_compressed_pos(0), block_info_record_length(0), block_info_recordset_header_length(0) {}
+    MasterRecord(const MasterRecord& other) :
+      current_original_pos(other.current_original_pos),
+      current_compressed_pos(other.current_compressed_pos),
+      block_info_record_length(other.block_info_record_length),
+      block_info_recordset_header_length( other.block_info_recordset_header_length),
+      methods(other.methods) {}
+
+    void clear() {
+      current_original_pos = current_compressed_pos = 0;
+      block_info_record_length = block_info_recordset_header_length = 0;
+      methods.clear();
+    }
+
+    string get_method_name(uint8_t index) const;
+    uint8_t add_get_method(const string& method);
+
+    void encode(bufferlist& bl) const;
+    void decode(bufferlist::iterator& bl);
+    void swap(MasterRecord& other) {
+      std::swap(current_original_pos, other.current_original_pos);
+      std::swap(current_compressed_pos, other.current_compressed_pos);
+      std::swap(block_info_record_length, other.block_info_record_length);
+      std::swap(block_info_recordset_header_length, other.block_info_recordset_header_length);
+      methods.swap(other.methods);
+    }
+  };
+
+ private:
+  /*
+  Run-time compressed block information
+  */
+  struct BlockInfo {
+    uint8_t method_idx;                 //an index indicating applied compression method in corresponding master record list, 0 - if no compression has been applied.
+    uint64_t target_offset;             //an offset of the block in the compressed data set
+    BlockInfo() : target_offset(0) {}
+    BlockInfo(uint8_t _method, uint64_t _target_offset)
+      : method_idx(_method), target_offset(_target_offset) {}
+
+  };
+
+  MasterRecord masterRec;  //Current compression information master record
+
+  typedef std::map<uint64_t, BlockInfo> BlockMap;
+  BlockMap blocks; //Map to provide original data offset to corresponding compressed one
+
+  MasterRecord prevMasterRec;     //Compression information master record replica saved before the first unflushed update
+  std::string prev_blocks_key;    //Attribute key for last compression info attribute in xattrs
+  bufferlist prev_blocks_encoded; //Attribute value for last compression info attribute in xattrs
+
+  uint64_t stripe_width;
+ protected:
+
+  static bool less_upper(const uint64_t&, const BlockMap::value_type&);
+  static bool less_lower(const BlockMap::value_type&, const uint64_t&);
+
+  int do_compress(CompressorRef csimpl, const bufferlist& block2compress, bufferlist* result_bl) const;
+
+  void append_block(uint64_t original_offset, uint64_t original_size, const string& method, uint64_t new_block_size);
+  bool can_compress(uint64_t offs) const;
+
+  void swap(CompressContext& other) {
+    blocks.swap(other.blocks);
+    masterRec.swap(other.masterRec);
+    std::swap(prev_blocks_key, other.prev_blocks_key);
+    std::swap(prev_blocks_encoded, other.prev_blocks_encoded);
+    prevMasterRec.swap(other.prevMasterRec);
+  }
+
+  uint64_t get_block_size() const;
+  unsigned get_blockset_size() const;
+  unsigned get_blocks_count() const { return blocks.size(); }
+
+  MasterRecord get_master_record() const {
+    return masterRec;
+  };
+
+  pair<uint64_t, uint64_t>  map_offset(uint64_t offs, bool next_block_flag) const; //returns <original block offset, compressed block_offset>
+
+  bool need_flush() const {
+    return prevMasterRec.current_original_pos != masterRec.current_original_pos;
+  }
+
+  void offset_to_key(uint64_t offs, std::string& key) const;
+
+  BlockInfoRecordSetHeader search_starting_recordset(uint64_t offset, size_t record_set_size, bufferlist::iterator& it_bl);
+
+
+ public:
+  CompressContext(uint64_t _stripe_width) : stripe_width(_stripe_width) {}
+  CompressContext(const CompressContext& from) :
+    masterRec(from.masterRec),
+    blocks(from.blocks),
+    prevMasterRec(from.prevMasterRec),
+    prev_blocks_key(from.prev_blocks_key),
+    prev_blocks_encoded(from.prev_blocks_encoded),
+    stripe_width(from.stripe_width) {}
+  virtual ~CompressContext();
+  void clear() {
+    masterRec.clear();
+    blocks.clear();
+    prev_blocks_key.clear();
+    prev_blocks_encoded.clear();
+    prevMasterRec.clear();
+  }
+
+  void setup_for_append_or_recovery(const map<string, bufferlist>& attrset);
+  void setup_for_read(const map<string, bufferlist>& attrset, uint64_t start_offset, uint64_t end_offset);
+  void flush(map<string, bufferlist>* attrset);
+  void flush_for_rollback(map<string, boost::optional<bufferlist> >* attrset) const;
+
+  uint64_t get_compressed_size() const {
+    return masterRec.current_compressed_pos;
+  }
+
+  pair<uint64_t, uint64_t> offset_len_to_compressed_block(const pair<uint64_t, uint64_t> offs_len_pair) const;
+
+  void dump(Formatter* f) const;
+
+  int try_decompress(const hobject_t& oid, uint64_t orig_offs, uint64_t len, const bufferlist& cs_bl, bufferlist* res_bl) const;
+  int try_compress(const std::string& compression_method, const hobject_t& oid, const bufferlist& bl, uint64_t* off, bufferlist* res_bl);
+};
+typedef ceph::shared_ptr<CompressContext> CompressContextRef;
+
+WRITE_CLASS_ENCODER(CompressContext::BlockInfoRecord)
+WRITE_CLASS_ENCODER(CompressContext::BlockInfoRecordSetHeader)
+WRITE_CLASS_ENCODER(CompressContext::MasterRecord)
+#endif

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -401,6 +401,13 @@ void ECBackend::handle_recovery_read_complete(
       ::decode(hinfo, bp);
     }
     op.hinfo = unstable_hashinfo_registry.lookup_or_create(hoid, hinfo);
+
+    CompressContext cctx(sinfo.get_stripe_width());
+    cctx.setup_for_append_or_recovery(op.xattrs);
+    uint64_t compressed_size = cctx.get_compressed_size();
+    if (compressed_size) {
+      op.set_recovered_object_size(compressed_size);
+    }
   }
   assert(op.xattrs.size());
   assert(op.obc);
@@ -535,10 +542,10 @@ void ECBackend::continue_recovery_op(
       ObjectRecoveryProgress after_progress = op.recovery_progress;
       after_progress.data_recovered_to += op.extent_requested.second;
       after_progress.first = false;
-      if (after_progress.data_recovered_to >= op.obc->obs.oi.size) {
+      if (after_progress.data_recovered_to >= op.get_recovered_object_size()) {
 	after_progress.data_recovered_to =
 	  sinfo.logical_to_next_stripe_offset(
-	    op.obc->obs.oi.size);
+          op.get_recovered_object_size());
 	after_progress.data_complete = true;
       }
       for (set<pg_shard_t>::iterator mi = op.missing_on.begin();
@@ -553,7 +560,7 @@ void ECBackend::continue_recovery_op(
 	dout(10) << __func__ << ": before_progress=" << op.recovery_progress
 		 << ", after_progress=" << after_progress
 		 << ", pop.data.length()=" << pop.data.length()
-		 << ", size=" << op.obc->obs.oi.size << dendl;
+                 << ", size=" << op.get_recovered_object_size() << "(" << op.obc->obs.oi.size << ")" << dendl;
 	assert(
 	  pop.data.length() ==
 	  sinfo.aligned_logical_offset_to_chunk_offset(
@@ -1383,10 +1390,10 @@ void ECBackend::submit_transaction(
   
   op->t = static_cast<ECTransaction*>(_t);
 
-  set<hobject_t, hobject_t::BitwiseComparator> need_hinfos;
-  op->t->get_append_objects(&need_hinfos);
-  for (set<hobject_t, hobject_t::BitwiseComparator>::iterator i = need_hinfos.begin();
-       i != need_hinfos.end();
+  set<hobject_t, hobject_t::BitwiseComparator> need_infos;
+  op->t->get_append_objects(&need_infos);
+  for (set<hobject_t, hobject_t::BitwiseComparator>::iterator i = need_infos.begin();
+       i != need_infos.end();
        ++i) {
     ECUtil::HashInfoRef ref = get_hash_info(*i, false);
     if (!ref) {
@@ -1400,6 +1407,17 @@ void ECBackend::submit_transaction(
       make_pair(
 	*i,
 	ref));
+
+    CompressContextRef cinfo = get_compress_context_basic(*i);
+    if (!cinfo) {
+      derr << __func__ << ": get_compress_context_basic(" << *i << ")"
+                       << " returned a null pointer and there is no "
+                       << " way to recover from such an error in this "
+                       << " context" << dendl;
+      assert(0);
+    }
+    op->compress_infos.insert(make_pair(*i, cinfo));
+
   }
 
   for (vector<pg_log_entry_t>::iterator i = op->log_entries.begin();
@@ -1411,11 +1429,15 @@ void ECBackend::submit_transaction(
       dout(10) << __func__ << ": stashing HashInfo for "
 	       << i->soid << " for entry " << *i << dendl;
       assert(op->unstable_hash_infos.count(i->soid));
+      assert(op->compress_infos.count(i->soid));
       ObjectModDesc desc;
       map<string, boost::optional<bufferlist> > old_attrs;
       bufferlist old_hinfo;
       ::encode(*(op->unstable_hash_infos[i->soid]), old_hinfo);
       old_attrs[ECUtil::get_hinfo_key()] = old_hinfo;
+
+      op->compress_infos[i->soid]->flush_for_rollback(&old_attrs);
+
       desc.setattrs(old_attrs);
       i->mod_desc.swap(desc);
       i->mod_desc.claim_append(desc);
@@ -1754,6 +1776,45 @@ ECUtil::HashInfoRef ECBackend::get_hash_info(
   return ref;
 }
 
+CompressContextRef ECBackend::get_compress_context_basic(const hobject_t &hoid)
+{
+  CompressContextRef ref = unstable_compressinfo_registry.lookup(hoid);
+  if (!ref) {
+    dout(10) << __func__ << ": not in cache " << hoid << dendl;
+    map<string, bufferlist> attrset;
+    CompressContext cctx(sinfo.get_stripe_width());
+    if (load_attrs(hoid, &attrset) >= 0) {
+      cctx.setup_for_append_or_recovery(attrset);
+    }
+    ref = unstable_compressinfo_registry.lookup_or_create(hoid, cctx);
+  }
+  return ref;
+}
+
+int ECBackend::load_attrs(const hobject_t &hoid, map<string, bufferlist>* attrset)
+{
+  assert(attrset);
+  dout(10) << __func__ << ": Loading attrs on " << hoid << dendl;
+  struct stat st;
+  int r = store->stat(
+    coll,
+    ghobject_t(hoid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
+    &st);
+  if (r >= 0 && st.st_size > 0) {
+    dout(10) << __func__ << ": found on disk, size " << st.st_size << dendl;
+    bufferlist bl;
+
+    r = store->getattrs(
+      coll,
+      ghobject_t(hoid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
+      *attrset);
+      if (r < 0){
+        derr << __func__ << ": failed to load attrs" << dendl;
+      }
+  }
+  return r;
+}
+
 void ECBackend::check_op(Op *op)
 {
   if (op->pending_apply.empty() && op->on_all_applied) {
@@ -1795,6 +1856,8 @@ void ECBackend::start_write(Op *op) {
   op->t->generate_transactions(
     op->unstable_hash_infos,
     ec_impl,
+    op->compress_infos,
+    get_parent()->get_pool().compression_type.c_str(),
     get_parent()->get_info().pgid.pgid,
     sinfo,
     &trans,
@@ -2041,7 +2104,7 @@ int ECBackend::objects_get_attrs(
   for (map<string, bufferlist>::iterator i = out->begin();
        i != out->end();
        ) {
-    if (ECUtil::is_hinfo_key_string(i->first))
+    if (ECUtil::is_internal_key_string(i->first))
       out->erase(i++);
     else
       ++i;

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -467,7 +467,6 @@ public:
 
   ECUtil::HashInfoRef get_hash_info(const hobject_t &hoid, bool checks = true,
 				    const map<string,bufferptr> *attr = NULL);
-);
 
   friend struct ReadCB;
   void check_op(Op *op);

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -26,7 +26,7 @@ struct AppendObjectsGenerator: public boost::static_visitor<void> {
   set<hobject_t, hobject_t::BitwiseComparator> *out;
   AppendObjectsGenerator(set<hobject_t, hobject_t::BitwiseComparator> *out) : out(out) {}
   void operator()(const ECTransaction::AppendOp &op) {
-    out->insert(op.oid);
+    out->insert( op.oid);
   }
   void operator()(const ECTransaction::TouchOp &op) {
     out->insert(op.oid);
@@ -49,6 +49,7 @@ struct AppendObjectsGenerator: public boost::static_visitor<void> {
   void operator()(const ECTransaction::RmAttrOp &op) {}
   void operator()(const ECTransaction::AllocHintOp &op) {}
   void operator()(const ECTransaction::NoOp &op) {}
+
 };
 void ECTransaction::get_append_objects(
   set<hobject_t, hobject_t::BitwiseComparator> *out) const
@@ -59,8 +60,10 @@ void ECTransaction::get_append_objects(
 
 struct TransGenerator : public boost::static_visitor<void> {
   map<hobject_t, ECUtil::HashInfoRef, hobject_t::BitwiseComparator> &hash_infos;
+  map<hobject_t, CompressContextRef, hobject_t::BitwiseComparator> &compress_infos;
 
   ErasureCodeInterfaceRef &ecimpl;
+  std::string compression_method;
   const pg_t pgid;
   const ECUtil::stripe_info_t sinfo;
   map<shard_id_t, ObjectStore::Transaction> *trans;
@@ -70,7 +73,9 @@ struct TransGenerator : public boost::static_visitor<void> {
   stringstream *out;
   TransGenerator(
     map<hobject_t, ECUtil::HashInfoRef, hobject_t::BitwiseComparator> &hash_infos,
+    map<hobject_t, CompressContextRef, hobject_t::BitwiseComparator> &compress_infos,
     ErasureCodeInterfaceRef &ecimpl,
+    const char* compression_method,
     pg_t pgid,
     const ECUtil::stripe_info_t &sinfo,
     map<shard_id_t, ObjectStore::Transaction> *trans,
@@ -78,7 +83,8 @@ struct TransGenerator : public boost::static_visitor<void> {
     set<hobject_t, hobject_t::BitwiseComparator> *temp_removed,
     stringstream *out)
     : hash_infos(hash_infos),
-      ecimpl(ecimpl), pgid(pgid),
+      compress_infos(compress_infos),
+      ecimpl(ecimpl), compression_method(compression_method), pgid(pgid),
       sinfo(sinfo),
       trans(trans),
       temp_added(temp_added), temp_removed(temp_removed),
@@ -129,32 +135,43 @@ struct TransGenerator : public boost::static_visitor<void> {
 	hbuf);
     }
   }
+
   void operator()(const ECTransaction::AppendOp &op) {
     uint64_t offset = op.off;
-    bufferlist bl(op.bl);
-    assert(bl.length());
+    bufferlist bl;
+    map<string, bufferlist> attrset;
+
+    assert(op.bl.length());
     assert(offset % sinfo.get_stripe_width() == 0);
     map<int, bufferlist> buffers;
 
     assert(hash_infos.count(op.oid));
     ECUtil::HashInfoRef hinfo = hash_infos[op.oid];
 
+    assert(compress_infos.count(op.oid));
+    CompressContextRef cinfo = compress_infos[op.oid];
+    cinfo->try_compress(compression_method, op.oid, op.bl, &offset, &bl);
+    cinfo->flush(&attrset);
+
+    assert(bl.length());
+    assert(offset % sinfo.get_stripe_width() == 0); //offset has changed - check again
+
     // align
     if (bl.length() % sinfo.get_stripe_width())
       bl.append_zero(
 	sinfo.get_stripe_width() -
 	((offset + bl.length()) % sinfo.get_stripe_width()));
-    assert(bl.length() - op.bl.length() < sinfo.get_stripe_width());
     int r = ECUtil::encode(
       sinfo, ecimpl, bl, want, &buffers);
 
     hinfo->append(
-      sinfo.aligned_logical_offset_to_chunk_offset(op.off),
+      sinfo.aligned_logical_offset_to_chunk_offset(offset),
       buffers);
     bufferlist hbuf;
     ::encode(
       *hinfo,
       hbuf);
+    attrset[ECUtil::get_hinfo_key()] = hbuf;
 
     assert(r == 0);
     for (map<shard_id_t, ObjectStore::Transaction>::iterator i = trans->begin();
@@ -170,17 +187,19 @@ struct TransGenerator : public boost::static_visitor<void> {
 	enc_bl.length(),
 	enc_bl,
 	op.fadvise_flags);
-      i->second.setattr(
+      i->second.setattrs(
 	get_coll_ct(i->first, op.oid),
 	ghobject_t(op.oid, ghobject_t::NO_GEN, i->first),
-	ECUtil::get_hinfo_key(),
-	hbuf);
+        attrset);
     }
   }
   void operator()(const ECTransaction::CloneOp &op) {
     assert(hash_infos.count(op.source));
     assert(hash_infos.count(op.target));
+    assert(compress_infos.count(op.source));
+    assert(compress_infos.count(op.target));
     *(hash_infos[op.target]) = *(hash_infos[op.source]);
+    *(compress_infos[op.target]) = *(compress_infos[op.source]);
     for (map<shard_id_t, ObjectStore::Transaction>::iterator i = trans->begin();
 	 i != trans->end();
 	 ++i) {
@@ -193,8 +212,12 @@ struct TransGenerator : public boost::static_visitor<void> {
   void operator()(const ECTransaction::RenameOp &op) {
     assert(hash_infos.count(op.source));
     assert(hash_infos.count(op.destination));
+    assert(compress_infos.count(op.source));
+    assert(compress_infos.count(op.destination));
     *(hash_infos[op.destination]) = *(hash_infos[op.source]);
+    *(compress_infos[op.destination]) = *(compress_infos[op.source]);
     hash_infos[op.source]->clear();
+    compress_infos[op.source]->clear();
     for (map<shard_id_t, ObjectStore::Transaction>::iterator i = trans->begin();
 	 i != trans->end();
 	 ++i) {
@@ -207,7 +230,9 @@ struct TransGenerator : public boost::static_visitor<void> {
   }
   void operator()(const ECTransaction::StashOp &op) {
     assert(hash_infos.count(op.oid));
+    assert(compress_infos.count(op.oid));
     hash_infos[op.oid]->clear();
+    compress_infos[op.oid]->clear();
     for (map<shard_id_t, ObjectStore::Transaction>::iterator i = trans->begin();
 	 i != trans->end();
 	 ++i) {
@@ -221,7 +246,10 @@ struct TransGenerator : public boost::static_visitor<void> {
   }
   void operator()(const ECTransaction::RemoveOp &op) {
     assert(hash_infos.count(op.oid));
+    assert(compress_infos.count(op.oid));
+
     hash_infos[op.oid]->clear();
+    compress_infos[op.oid]->clear();
     for (map<shard_id_t, ObjectStore::Transaction>::iterator i = trans->begin();
 	 i != trans->end();
 	 ++i) {
@@ -275,6 +303,8 @@ struct TransGenerator : public boost::static_visitor<void> {
 void ECTransaction::generate_transactions(
   map<hobject_t, ECUtil::HashInfoRef, hobject_t::BitwiseComparator> &hash_infos,
   ErasureCodeInterfaceRef &ecimpl,
+  map<hobject_t, CompressContextRef, hobject_t::BitwiseComparator> &compress_infos,
+  const char* compression_method,
   pg_t pgid,
   const ECUtil::stripe_info_t &sinfo,
   map<shard_id_t, ObjectStore::Transaction> *transactions,
@@ -284,7 +314,9 @@ void ECTransaction::generate_transactions(
 {
   TransGenerator gen(
     hash_infos,
+    compress_infos,
     ecimpl,
+    compression_method,
     pgid,
     sinfo,
     transactions,

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -26,7 +26,7 @@ struct AppendObjectsGenerator: public boost::static_visitor<void> {
   set<hobject_t, hobject_t::BitwiseComparator> *out;
   AppendObjectsGenerator(set<hobject_t, hobject_t::BitwiseComparator> *out) : out(out) {}
   void operator()(const ECTransaction::AppendOp &op) {
-    out->insert( op.oid);
+    out->insert(op.oid);
   }
   void operator()(const ECTransaction::TouchOp &op) {
     out->insert(op.oid);
@@ -49,7 +49,6 @@ struct AppendObjectsGenerator: public boost::static_visitor<void> {
   void operator()(const ECTransaction::RmAttrOp &op) {}
   void operator()(const ECTransaction::AllocHintOp &op) {}
   void operator()(const ECTransaction::NoOp &op) {}
-
 };
 void ECTransaction::get_append_objects(
   set<hobject_t, hobject_t::BitwiseComparator> *out) const

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -19,6 +19,7 @@
 #include "PGBackend.h"
 #include "osd_types.h"
 #include "ECUtil.h"
+#include "CompressContext.h"
 #include <boost/optional/optional_io.hpp>
 #include "erasure-code/ErasureCodeInterface.h"
 
@@ -193,11 +194,12 @@ public:
       boost::apply_visitor(vis, *i);
     }
   }
-  void get_append_objects(
-     set<hobject_t, hobject_t::BitwiseComparator> *out) const;
+  void get_append_objects( set<hobject_t, hobject_t::BitwiseComparator> *out )const;
   void generate_transactions(
     map<hobject_t, ECUtil::HashInfoRef, hobject_t::BitwiseComparator> &hash_infos,
     ErasureCodeInterfaceRef &ecimpl,
+    map<hobject_t, CompressContextRef, hobject_t::BitwiseComparator> &compress_infos,
+    const char* compression_method,
     pg_t pgid,
     const ECUtil::stripe_info_t &sinfo,
     map<shard_id_t, ObjectStore::Transaction> *transactions,

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -140,7 +140,6 @@ int ECUtil::encode(
 void ECUtil::HashInfo::append(uint64_t old_size,
 			      map<int, bufferlist> &to_append) {
   assert(to_append.size() == cumulative_shard_hashes.size());
-  assert(old_size == total_chunk_size);
   uint64_t size_to_append = to_append.begin()->second.length();
   for (map<int, bufferlist>::iterator i = to_append.begin();
        i != to_append.end();
@@ -199,13 +198,25 @@ void ECUtil::HashInfo::generate_test_instances(list<HashInfo*>& o)
 }
 
 const string HINFO_KEY = "hinfo_key";
+const string CINFO_MASTER_KEY = "@ci_master@";
+const string CINFO_KEY_PREFIX = "@ci@";
 
-bool ECUtil::is_hinfo_key_string(const string &key)
+bool ECUtil::is_internal_key_string(const string &key)
 {
-  return key == HINFO_KEY;
+  return key == HINFO_KEY || key.find(CINFO_KEY_PREFIX)==0 || key.find(CINFO_MASTER_KEY)==0;
 }
 
 const string &ECUtil::get_hinfo_key()
 {
   return HINFO_KEY;
+}
+
+const string &ECUtil::get_cinfo_key_prefix()
+{
+  return CINFO_KEY_PREFIX;
+}
+
+const string &ECUtil::get_cinfo_master_key()
+{
+  return CINFO_MASTER_KEY;
 }

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -45,6 +45,15 @@ public:
   uint64_t get_stripe_width() const {
     return stripe_width;
   }
+  static uint64_t pad_to_stripe_width(uint64_t stripe_width, uint64_t length) {
+    if (length % stripe_width)
+      length += stripe_width - (length % stripe_width);
+    return length;
+  }
+  uint64_t pad_to_stripe_width(uint64_t length) const {
+    return pad_to_stripe_width( get_stripe_width(), length );
+  }
+
   uint64_t get_chunk_size() const {
     return chunk_size;
   }
@@ -133,8 +142,10 @@ public:
 };
 typedef ceph::shared_ptr<HashInfo> HashInfoRef;
 
-bool is_hinfo_key_string(const string &key);
+bool is_internal_key_string(const string &key);
 const string &get_hinfo_key();
+const string &get_cinfo_master_key();
+const string &get_cinfo_key_prefix();
 
 }
 WRITE_CLASS_ENCODER(ECUtil::HashInfo)

--- a/src/osd/Makefile.am
+++ b/src/osd/Makefile.am
@@ -13,6 +13,8 @@ libosd_a_SOURCES = \
 	osd/ReplicatedPG.cc \
 	osd/ReplicatedBackend.cc \
 	osd/ECBackend.cc \
+	osd/CompressBackend.cc \
+	osd/CompressContext.cc \
 	osd/ECMsgTypes.cc \
 	osd/ECTransaction.cc \
 	osd/PGBackend.cc \
@@ -48,6 +50,8 @@ noinst_HEADERS += \
 	osd/ECUtil.h \
 	osd/ECMsgTypes.h \
 	osd/ECTransaction.h \
+	osd/CompressBackend.h \
+	osd/CompressContext.h \
 	osd/Watch.h \
 	osd/osd_types.h
 

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -18,6 +18,7 @@
 
 #include "common/errno.h"
 #include "ReplicatedBackend.h"
+#include "CompressBackend.h"
 #include "ECBackend.h"
 #include "PGBackend.h"
 #include "OSD.h"
@@ -293,7 +294,7 @@ PGBackend *PGBackend::build_pg_backend(
       &ec_impl,
       &ss);
     assert(ec_impl);
-    return new ECBackend(
+    return new CompressedECBackend(
       l,
       coll,
       store,

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1143,6 +1143,7 @@ void pg_pool_t::dump(Formatter *f) const
   f->dump_unsigned("cache_min_flush_age", cache_min_flush_age);
   f->dump_unsigned("cache_min_evict_age", cache_min_evict_age);
   f->dump_string("erasure_code_profile", erasure_code_profile);
+  f->dump_string("compression_type", compression_type);
   f->open_object_section("hit_set_params");
   hit_set_params.dump(f);
   f->close_section(); // hit_set_params
@@ -1521,6 +1522,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
   ::encode(hit_set_grade_decay_rate, bl);
   ::encode(hit_set_search_last_n, bl);
   ::encode(opts, bl);
+  ::encode(compression_type, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -1664,9 +1666,13 @@ void pg_pool_t::decode(bufferlist::iterator& bl)
   } else {
     hit_set_grade_decay_rate = 0;
     hit_set_search_last_n = 1;
+    compression_type.clear();
   }
   if (struct_v >= 24) {
     ::decode(opts, bl);
+    ::decode(compression_type, bl);
+  } else {
+    compression_type.clear();
   }
   DECODE_FINISH(bl);
   calc_pg_masks();
@@ -1728,6 +1734,7 @@ void pg_pool_t::generate_test_instances(list<pg_pool_t*>& o)
   a.cache_min_flush_age = 231;
   a.cache_min_evict_age = 2321;
   a.erasure_code_profile = "profile in osdmap";
+  a.compression_type = "none";
   a.expected_num_objects = 123456;
   a.fast_read = false;
   o.push_back(new pg_pool_t(a));

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1169,6 +1169,7 @@ private:
 
 public:
   map<string,string> properties;  ///< OBSOLETE
+  string compression_type;
   string erasure_code_profile; ///< name of the erasure code profile in OSDMap
   epoch_t last_change;      ///< most recent epoch changed, exclusing snapshot changes
   epoch_t last_force_op_resend; ///< last epoch that forced clients to resend

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1194,6 +1194,18 @@ target_link_libraries(unittest_ecbackend osd global ${CMAKE_DL_LIBS}
 set_target_properties(unittest_ecbackend PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 
+# unittest_compresscontext
+add_executable(unittest_compresscontext EXCLUDE_FROM_ALL
+  osd/TestCompressContext.cc
+  $<TARGET_OBJECTS:heap_profiler_objs>
+  )
+add_test(unittest_compresscontext unittest_compresscontext)
+add_dependencies(check unittest_compresscontext)
+target_link_libraries(unittest_compresscontext osd global ${CMAKE_DL_LIBS}
+  ${TCMALLOC_LIBS} ${UNITTEST_LIBS})
+set_target_properties(unittest_compresscontext PROPERTIES COMPILE_FLAGS
+  ${UNITTEST_CXX_FLAGS})
+
 # unittest_osdscrub
 add_executable(unittest_osdscrub EXCLUDE_FROM_ALL
   osd/TestOSDScrub.cc

--- a/src/test/Makefile-server.am
+++ b/src/test/Makefile-server.am
@@ -217,6 +217,11 @@ unittest_pageset_LDADD = $(UNITTEST_LDADD)
 unittest_pageset_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_TESTPROGRAMS += unittest_pageset
 
+unittest_compresscontext_SOURCES = test/osd/TestCompressContext.cc
+unittest_compresscontext_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+unittest_compresscontext_LDADD = $(LIBOSD) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
+check_TESTPROGRAMS += unittest_compresscontext
+
 endif # WITH_OSD
 
 if WITH_SLIBROCKSDB

--- a/src/test/compressor/compressor_example.h
+++ b/src/test/compressor/compressor_example.h
@@ -31,13 +31,13 @@ class CompressorExample : public Compressor {
 public:
   virtual ~CompressorExample() {}
 
-  virtual int compress(bufferlist &in, bufferlist &out)
+  virtual int compress(const bufferlist &in, bufferlist &out)
   {
     out = in;
     return 0;
   }
 
-  virtual int decompress(bufferlist &in, bufferlist &out)
+  virtual int decompress(const bufferlist &in, bufferlist &out)
   {
     out = in;
     return 0;

--- a/src/test/compressor/test_compression_snappy.cc
+++ b/src/test/compressor/test_compression_snappy.cc
@@ -27,7 +27,7 @@ TEST(SnappyCompressor, compress_decompress)
 {
   SnappyCompressor sp;
   EXPECT_EQ(sp.get_method_name(), "snappy");
-  char* test = "This is test text";
+  const char* test = "This is test text";
   int len = strlen(test);
   bufferlist in, out;
   in.append(test, len);
@@ -35,6 +35,38 @@ TEST(SnappyCompressor, compress_decompress)
   EXPECT_EQ(res, 0);
   bufferlist after;
   res = sp.decompress(out, after);
+  EXPECT_EQ(res, 0);
+}
+
+TEST(SnappyCompressor, sharded_input_decompress)
+{
+  const size_t small_prefix_size=3;
+
+  SnappyCompressor sp;
+  EXPECT_EQ(sp.get_method_name(), "snappy");
+  string test(128*1024,0);
+  int len = test.size();
+  bufferlist in, out;
+  in.append(test.c_str(), len);
+  int res = sp.compress(in, out);
+  EXPECT_EQ(res, 0);
+  EXPECT_GT(out.length(), small_prefix_size);
+  
+  bufferlist out2, tmp;
+  tmp.substr_of(out, 0, small_prefix_size );
+  out2.append( tmp );
+  size_t left = out.length()-small_prefix_size;
+  size_t offs = small_prefix_size;
+  while( left > 0 ){
+    size_t shard_size = MIN( 2048, left ); 
+    tmp.substr_of(out, offs, shard_size );
+    out2.append( tmp );
+    left -= shard_size;
+    offs += shard_size;
+  }
+
+  bufferlist after;
+  res = sp.decompress(out2, after);
   EXPECT_EQ(res, 0);
 }
 

--- a/src/test/osd/TestCompressContext.cc
+++ b/src/test/osd/TestCompressContext.cc
@@ -1,0 +1,762 @@
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph distributed storage system
+ *
+ *
+ * Author: Igor Fedotov <ifed@mirantis.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <gtest/gtest.h>
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
+#include "global/global_context.h"
+#include "common/config.h"
+#include "osd/CompressContext.h"
+#include "compressor/CompressionPlugin.h"
+
+struct TestCompressor : public Compressor {
+  enum Mode { NO_COMPRESS, COMPRESS, COMPRESS_NO_BENEFIT} mode;
+  unsigned compress_calls, decompress_calls;
+  const uint32_t TEST_MAGIC = 0xdeadbeef;
+
+  TestCompressor() {
+    clear();
+  }
+  void clear() {
+    mode = COMPRESS;
+    compress_calls = decompress_calls = 0;
+  }
+  void reset(Mode _mode = COMPRESS) {
+    clear();
+    mode = _mode;
+  }
+  virtual int compress(bufferlist& in, bufferlist& out) {
+    int res = 0;
+    ++compress_calls;
+    if (mode != NO_COMPRESS) {
+      uint32_t size = in.length();
+      assert(size <= 1024 * 1024); //introducing input block size limit to be able to validate decompressed value
+      ::encode(TEST_MAGIC, out);
+      ::encode(size, out);
+      if (mode == COMPRESS_NO_BENEFIT) {
+	out.append(in);
+      }
+      res = 0;
+    } else {
+      res = -1;
+    }
+    return res;
+  }
+  virtual int decompress(bufferlist& in, bufferlist& out) {
+    ++decompress_calls;
+    uint32_t ui;
+    bufferlist::iterator it = in.begin();
+    ::decode(ui, it);
+    EXPECT_EQ(ui,  TEST_MAGIC);
+    ::decode(ui, it);
+    EXPECT_NE(ui, 0u);
+    EXPECT_LE(ui, 1024 * 1024u); //see assert in compress method above
+    std::string res(ui, 'a');
+    out.append(res);
+    return 0;
+  }
+  virtual const char* get_method_name() {
+    return method_name().c_str();
+  }
+  static const std::string& method_name() {
+    static std::string s = "test_method";
+    return s;
+  }
+};
+
+struct TestCompressionPlugin : public CompressionPlugin {
+  static TestCompressor* compressor;
+  static CompressorRef compressorRef;
+
+  TestCompressionPlugin(CephContext* cct) : CompressionPlugin(cct)  {
+    if( compressor == NULL ) {
+      compressor  = new TestCompressor();
+      compressorRef.reset(compressor);
+    }
+  }
+  virtual int factory(CompressorRef* cs, ostream* ss) {
+    *cs = compressorRef;
+    return 0;
+  }
+};
+
+TestCompressor* TestCompressionPlugin::compressor=NULL;
+CompressorRef TestCompressionPlugin::compressorRef;
+
+/*
+Introducing CompressContextTester class to access CompressContext protected members
+*/
+class CompressContextTester : public CompressContext {
+ public:
+  enum { 
+    STRIPE_WIDTH=4096,
+  };
+  CompressContextTester() : CompressContext(STRIPE_WIDTH) {}
+  void testMapping1() {
+    clear();
+
+    //putting three blocks into the map
+    append_block(0, 8 * 1024, "some_compression", 4 * 1024);
+    append_block(8 * 1024, 7 * 1024, "", 7 * 1024);
+    append_block((8 + 7) * 1024, 1932, "another_compression", 932);
+
+    EXPECT_EQ(get_compressed_size(), (4 + 7) * 1024 + 932u);
+
+    pair<uint64_t, uint64_t> block_offs_start = map_offset(0, false);
+    EXPECT_EQ(block_offs_start.first, 0u);
+    EXPECT_EQ(block_offs_start.second, 0u);
+
+    pair<uint64_t, uint64_t> block_offs_end = map_offset(0, true);
+    EXPECT_EQ(block_offs_end.first, 8 * 1024u);
+    EXPECT_EQ(block_offs_end.second, 4 * 1024u);
+
+    block_offs_start = map_offset(1, false);
+    EXPECT_EQ(block_offs_start.first, 0u);
+    EXPECT_EQ(block_offs_start.second, 0u);
+
+    block_offs_end = map_offset(1, true);
+    EXPECT_EQ(block_offs_end.first, 8 * 1024u);
+    EXPECT_EQ(block_offs_end.second, 4 * 1024u);
+
+    block_offs_start = map_offset(8 * 1024, false);
+    EXPECT_EQ(block_offs_start.first, 8 * 1024u);
+    EXPECT_EQ(block_offs_start.second, 4 * 1024u);
+
+    block_offs_end = map_offset(8 * 1024, true);
+    EXPECT_EQ(block_offs_end.first, (8 + 7) * 1024u);
+    EXPECT_EQ(block_offs_end.second, (4 + 7) * 1024u);
+
+    block_offs_start = map_offset(8 * 1024 + 4096, false);
+    EXPECT_EQ(block_offs_start.first, 8 * 1024u);
+    EXPECT_EQ(block_offs_start.second, 4 * 1024u);
+
+    block_offs_end = map_offset(8 * 1024 + 4096, true);
+    EXPECT_EQ(block_offs_end.first, (8 + 7) * 1024u);
+    EXPECT_EQ(block_offs_end.second, (4 + 7) * 1024u);
+
+    block_offs_start = map_offset((8 + 7) * 1024, false);
+    EXPECT_EQ(block_offs_start.first, (8 + 7) * 1024u);
+    EXPECT_EQ(block_offs_start.second, (4 + 7) * 1024u);
+
+    block_offs_end = map_offset((8 + 7) * 1024, true);
+    EXPECT_EQ(block_offs_end.first, (8 + 7) * 1024u + 1932);
+    EXPECT_EQ(block_offs_end.second, (4 + 7) * 1024u + 932);
+
+    block_offs_start = map_offset((8 + 7) * 1024 + 1930, false);
+    EXPECT_EQ(block_offs_start.first, (8 + 7) * 1024u);
+    EXPECT_EQ(block_offs_start.second, (4 + 7) * 1024u);
+
+    block_offs_end = map_offset((8 + 7) * 1024 + 1930, true);
+    EXPECT_EQ(block_offs_end.first, (8 + 7) * 1024u + 1932);
+    EXPECT_EQ(block_offs_end.second, (4 + 7) * 1024u + 932);
+
+    pair<uint64_t, uint64_t> compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(0, 1));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, 4 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(0, 132));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, 4 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(131, 132));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, 4 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(0, 4 * 1024));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, 4 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(10, 4 * 1024));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, 4 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(0, 4 * 1024 + 1));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, 4 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(0, 8 * 1024 - 1));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, 4 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(0, 8 * 1024));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, 4 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(2, 8 * 1024 - 2));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, 4 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(0, 8 * 1024 + 1));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, (4 + 7) * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(1230, 8 * 1024));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, (4 + 7) * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(2, (8 + 7) * 1024 + 1930));
+    EXPECT_EQ(compressed_block.first, 0u);
+    EXPECT_EQ(compressed_block.second, (4 + 7) * 1024u + 932);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(8 * 1024, 1024));
+    EXPECT_EQ(compressed_block.first, 4 * 1024u);
+    EXPECT_EQ(compressed_block.second, 7 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(8 * 1024 + 1023, 1024));
+    EXPECT_EQ(compressed_block.first, 4 * 1024u);
+    EXPECT_EQ(compressed_block.second, 7 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(8 * 1024 + 1024, 6 * 1024));
+    EXPECT_EQ(compressed_block.first, 4 * 1024u);
+    EXPECT_EQ(compressed_block.second, 7 * 1024u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>(8 * 1024 + 1024, 6 * 1024 + 1));
+    EXPECT_EQ(compressed_block.first, 4 * 1024u);
+    EXPECT_EQ(compressed_block.second, 7 * 1024u + 932);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>((8 + 7) * 1024 + 1, 1));
+    EXPECT_EQ(compressed_block.first, (4 + 7) * 1024u);
+    EXPECT_EQ(compressed_block.second, 932u);
+
+    compressed_block = offset_len_to_compressed_block(std::pair<uint64_t, uint64_t>((8 + 7) * 1024 + 1931, 1));
+    EXPECT_EQ(compressed_block.first, (4 + 7) * 1024u);
+    EXPECT_EQ(compressed_block.second, 932u);
+  }
+
+  void testAppendAndFlush() {
+    clear();
+
+    EXPECT_FALSE(need_flush());
+    //putting three blocks into the map
+    append_block(0, 8 * 1024, "some_compression", 4 * 1024);
+    append_block(8 * 1024, 7 * 1024, "", 7 * 1024);
+    append_block((8 + 7) * 1024, 1932, "another_compression", 932);
+    EXPECT_TRUE(need_flush());
+    EXPECT_EQ(get_compressed_size(), (4 + 7) * 1024 + 932u);
+
+    map<string, boost::optional<bufferlist> > rollback_attrs;
+    map<string, bufferlist> attrs;
+    flush_for_rollback(&rollback_attrs);
+    EXPECT_EQ(rollback_attrs.size(), 1u);
+    EXPECT_EQ(rollback_attrs[ECUtil::get_cinfo_master_key()], boost::optional<bufferlist>());
+
+    flush(&attrs);
+    EXPECT_EQ(attrs.size(), 2u);
+    std::string key;
+    MasterRecord mrec = get_master_record();
+    offset_to_key(0,key);
+    EXPECT_EQ(attrs[key].length(), mrec.block_info_record_length*3 + mrec.block_info_recordset_header_length);
+    EXPECT_GT(attrs[ECUtil::get_cinfo_master_key()].length(), 0u);
+    EXPECT_FALSE(need_flush());
+    EXPECT_EQ(get_compressed_size(), (4 + 7) * 1024 + 932u);
+    rollback_attrs.clear();
+    flush_for_rollback(&rollback_attrs);
+    EXPECT_EQ(rollback_attrs.size(), 2u);
+    EXPECT_EQ(rollback_attrs[key], attrs[key]);
+    EXPECT_EQ(rollback_attrs[ECUtil::get_cinfo_master_key()], attrs[ECUtil::get_cinfo_master_key()]);
+
+    clear();
+    EXPECT_EQ(get_compressed_size(), 0u);
+    rollback_attrs.clear();
+    flush_for_rollback(&rollback_attrs);
+    EXPECT_EQ(rollback_attrs.size(), 1u);
+    EXPECT_EQ(rollback_attrs[ECUtil::get_cinfo_master_key()], boost::optional<bufferlist>());
+
+    setup_for_append_or_recovery(attrs);
+    EXPECT_EQ(get_compressed_size(), (4 + 7) * 1024 + 932u);
+    rollback_attrs.clear();
+    flush_for_rollback(&rollback_attrs);
+    EXPECT_EQ(rollback_attrs.size(), 2u);
+    EXPECT_EQ(rollback_attrs[key], attrs[key]);
+    EXPECT_EQ(rollback_attrs[ECUtil::get_cinfo_master_key()], attrs[ECUtil::get_cinfo_master_key()]);
+
+    //verifying context content encoded in attrs
+    CompressContext::BlockInfoRecordSetHeader recHdr(0, 0);
+    CompressContext::BlockInfoRecord rec;
+
+    bufferlist::iterator it = attrs[ECUtil::get_cinfo_master_key()].begin();
+    ::decode(mrec, it);
+    EXPECT_EQ(mrec.current_original_pos, (8 + 7) * 1024 + 1932u);
+    EXPECT_EQ(mrec.current_compressed_pos, (4 + 7) * 1024 + 932u);
+    EXPECT_NE(mrec.block_info_record_length, 0u);
+    EXPECT_NE(mrec.block_info_recordset_header_length, 0u);
+    EXPECT_EQ(mrec.methods.size(), 2u);
+    EXPECT_EQ(mrec.methods[0], "some_compression");
+    EXPECT_EQ(mrec.methods[1], "another_compression");
+    offset_to_key(0, key);
+    it = attrs[key].begin();
+    EXPECT_EQ(it.get_remaining(), mrec.block_info_record_length * 3 + mrec.block_info_recordset_header_length);
+
+    recHdr.start_offset = recHdr.compressed_offset = 1234; //just fill with non-zero value
+    ::decode(recHdr, it);
+    EXPECT_EQ(recHdr.start_offset, 0u);
+    EXPECT_EQ(recHdr.compressed_offset, 0u);
+
+    ::decode(rec, it);
+    EXPECT_EQ(rec.method_idx, 1u);
+    EXPECT_EQ(rec.original_length, 8 * 1024u);
+    EXPECT_EQ(rec.compressed_length, 4 * 1024u);
+    ::decode(rec, it);
+    EXPECT_EQ(rec.method_idx, 0u);
+    EXPECT_EQ(rec.original_length, 7 * 1024u);
+    EXPECT_EQ(rec.compressed_length, 7 * 1024u);
+    ::decode(rec, it);
+    EXPECT_EQ(rec.method_idx, 2u);
+    EXPECT_EQ(rec.original_length, 1932u);
+    EXPECT_EQ(rec.compressed_length, 932u);
+
+    //verifying context content encoded in attrs when >1 recordsets are present
+    attrs.clear();
+    setup_for_append_or_recovery(attrs);
+    uint64_t offs = 0, coffs = 0;
+    uint32_t block_len = 4096, cblock_len = 4090;
+    size_t recCount = CompressContext::RECS_PER_RECORDSET * 2 + 1;
+    for (size_t i = 0; i < recCount; i++) {
+      append_block(offs, block_len, "", cblock_len);
+      offs += block_len;
+    }
+    flush(&attrs);
+
+    EXPECT_EQ( attrs.size(), 2u);
+    it = attrs[ECUtil::get_cinfo_master_key()].begin();
+    mrec.clear();
+    ::decode(mrec, it);
+    EXPECT_EQ(mrec.current_original_pos, recCount * block_len);
+    EXPECT_EQ(mrec.current_compressed_pos, recCount * cblock_len);
+    EXPECT_NE(mrec.block_info_record_length, 0u);
+    EXPECT_NE(mrec.block_info_recordset_header_length, 0u);
+    EXPECT_EQ(mrec.methods.size(), 0u);
+
+    offset_to_key(0, key);
+    it = attrs[key].begin();
+    EXPECT_EQ(it.get_remaining(),
+	      mrec.block_info_record_length * recCount +
+	      mrec.block_info_recordset_header_length * (1 + recCount / CompressContext::RECS_PER_RECORDSET));
+    offs = coffs = 0;
+    for (size_t i = 0; i < recCount; i++) {
+      if ((i % CompressContext::RECS_PER_RECORDSET) == 0) {
+	::decode(recHdr, it);
+	EXPECT_EQ(recHdr.start_offset, offs);
+	EXPECT_EQ(recHdr.compressed_offset, coffs);
+      }
+      rec.method_idx = 255;
+      rec.original_length = rec.compressed_length = 1234;
+      ::decode(rec, it);
+      EXPECT_EQ(rec.method_idx, 0u);
+      EXPECT_EQ(rec.original_length, block_len);
+      EXPECT_EQ(rec.compressed_length, cblock_len);
+      offs += block_len;
+      coffs += cblock_len;
+    }
+
+    //verifying context content encoded in attrs when >1 blocksets are present
+    attrs.clear();
+    setup_for_append_or_recovery(attrs);
+    offs = 0, coffs = 0;
+    block_len = STRIPE_WIDTH, cblock_len = 4090;
+    unsigned complete_blocksets=2;
+    recCount = CompressContext::MAX_STRIPES_PER_BLOCKSET * complete_blocksets + 1;
+    for (size_t i = 0; i < recCount; i++) {
+      append_block(offs, block_len, "", cblock_len);
+      offs += block_len;
+    }
+    flush(&attrs);
+
+    EXPECT_EQ( attrs.size(), 4u);
+    it = attrs[ECUtil::get_cinfo_master_key()].begin();
+    mrec.clear();
+    ::decode(mrec, it);
+    EXPECT_EQ(mrec.current_original_pos, recCount * block_len);
+    EXPECT_EQ(mrec.current_compressed_pos, recCount * cblock_len);
+    EXPECT_NE(mrec.block_info_record_length, 0u);
+    EXPECT_NE(mrec.block_info_recordset_header_length, 0u);
+    EXPECT_EQ(mrec.methods.size(), 0u);
+
+    offs = coffs = 0;
+    for( uint64_t o = 0; o<recCount*STRIPE_WIDTH; o+=STRIPE_WIDTH*MAX_STRIPES_PER_BLOCKSET){
+      offset_to_key(o, key);
+      EXPECT_NE( attrs.find(key), attrs.end());
+      it = attrs[key].begin();
+      EXPECT_GE( it.get_remaining(), 0u);
+      if( o/(STRIPE_WIDTH*MAX_STRIPES_PER_BLOCKSET) < complete_blocksets )
+        EXPECT_EQ(it.get_remaining(),
+		  mrec.block_info_record_length * MAX_STRIPES_PER_BLOCKSET +
+		  mrec.block_info_recordset_header_length * (MAX_STRIPES_PER_BLOCKSET / CompressContext::RECS_PER_RECORDSET));
+      else //last incomplete blockset
+        EXPECT_EQ(it.get_remaining(),
+		  mrec.block_info_record_length * 1 +
+		  mrec.block_info_recordset_header_length * 1);
+
+      size_t i = 0;
+      while( it.get_remaining()>0) { // for (size_t i = 0; i < MAX_STRIPES_PER_BLOCKSET; i++) {
+        if ((i % CompressContext::RECS_PER_RECORDSET) == 0) {
+	  ::decode(recHdr, it);
+	  EXPECT_EQ(recHdr.start_offset, offs);
+	  EXPECT_EQ(recHdr.compressed_offset, coffs);
+        }
+        rec.method_idx = 255;
+        rec.original_length = rec.compressed_length = 1234;
+        ::decode(rec, it);
+        EXPECT_EQ(rec.method_idx, 0u);
+        EXPECT_EQ(rec.original_length, block_len);
+        EXPECT_EQ(rec.compressed_length, cblock_len);
+        offs += block_len;
+        coffs += cblock_len;
+        ++i;
+      }
+    }
+  }
+  void testCompressSimple(TestCompressor* compressor) {
+    hobject_t oid;
+    std::string s1(8 * 1024, 'a');
+    bufferlist in, out, out_res;
+    uint64_t offs = 0;
+    in.append(s1);
+    clear();
+    //single block compress
+    compressor->reset(TestCompressor::COMPRESS);
+    int r = try_compress(TestCompressor::method_name(), oid, in, &offs, &out);
+    EXPECT_EQ(r, 0);
+    EXPECT_NE(in.length(), out.length());
+    EXPECT_EQ(out.length(), STRIPE_WIDTH);
+    EXPECT_EQ(get_compressed_size(), STRIPE_WIDTH);
+    EXPECT_EQ(offs, 0u);
+    EXPECT_EQ(compressor->compress_calls, 1u);
+
+    map<string, bufferlist> attrs;
+    flush(&attrs);
+
+    clear();
+    offs = 0;
+    setup_for_read(attrs, 0, s1.size());
+    r = try_decompress(oid, offs, s1.size(), out, &out_res);
+    EXPECT_EQ(r, 0);
+    EXPECT_EQ(s1.size(), out_res.length());
+    EXPECT_TRUE(s1 == std::string(out_res.c_str(), out_res.length()));
+    EXPECT_EQ(compressor->decompress_calls, 1u);
+
+    //single block compress attempt - bypassed, followed by another successful compression
+    clear();
+    out.clear();
+    out_res.clear();
+    compressor->reset(TestCompressor::COMPRESS_NO_BENEFIT);
+    offs=0;
+    try_compress(TestCompressor::method_name(), oid, in, &offs, &out);
+    EXPECT_EQ(r, 0);
+    EXPECT_EQ(in.length(), out.length());
+    EXPECT_EQ(get_compressed_size(), in.length());
+    EXPECT_EQ(offs, 0u);
+    EXPECT_EQ(compressor->compress_calls, 1u);
+
+    flush(&attrs);
+
+    MasterRecord mrec = get_master_record();
+    EXPECT_EQ(mrec.current_original_pos, in.length());
+    EXPECT_EQ(mrec.current_compressed_pos, in.length());
+    EXPECT_EQ(mrec.methods.size(), 0u);
+    EXPECT_NE(mrec.block_info_record_length, 0u);
+    EXPECT_NE(mrec.block_info_recordset_header_length, 0u);
+
+    out_res.append(out);
+    out.clear();
+
+    compressor->reset(TestCompressor::COMPRESS);
+    setup_for_append_or_recovery(attrs);
+
+    EXPECT_EQ(get_compressed_size(), out_res.length());
+    offs=in.length();
+    try_compress(TestCompressor::method_name(), oid, in, &offs, &out);
+    EXPECT_EQ(r, 0);
+    EXPECT_GT(in.length(), out.length());
+    EXPECT_EQ(get_compressed_size(), out_res.length()+out.length());
+    EXPECT_EQ(offs, out_res.length());
+    EXPECT_EQ(compressor->compress_calls, 1u);
+
+    flush(&attrs);
+    mrec = get_master_record();
+    EXPECT_EQ(mrec.current_original_pos, in.length()*2);
+    EXPECT_EQ(mrec.current_compressed_pos, get_compressed_size());
+    EXPECT_EQ(mrec.methods.size(), 1u);
+    EXPECT_NE(mrec.block_info_record_length, 0u);
+    EXPECT_NE(mrec.block_info_recordset_header_length, 0u);
+
+    out_res.append(out);
+    out.clear();
+
+    //multiple (fixed-size) blocks  compress
+    vector< pair<uint64_t, uint64_t> >block_info; //compressed block offset, size
+    clear();
+    out_res.clear();
+    compressor->reset(TestCompressor::COMPRESS);
+    size_t block_count = 200;
+    uint64_t offs4append = 0;
+    for (size_t i = 0; i < block_count; i++) {
+      offs = offs4append;
+      out.clear();
+      int r = try_compress(TestCompressor::method_name(), oid, in, &offs, &out);
+      EXPECT_EQ(r, 0);
+      EXPECT_EQ(offs, out_res.length());
+      offs4append += in.length();
+      block_info.push_back(std::pair<uint64_t, uint64_t>(out_res.length(), out.length()));
+      out_res.append(out);
+    }
+    EXPECT_EQ(out_res.length(), block_count * STRIPE_WIDTH);
+    EXPECT_EQ(get_compressed_size(), block_count * STRIPE_WIDTH);
+    EXPECT_EQ(offs, (block_count - 1)*STRIPE_WIDTH);
+    EXPECT_EQ(compressor->compress_calls, block_count);
+
+    out = out_res;
+    out_res.clear();
+    flush(&attrs);
+
+    clear();
+    offs = 0;
+    uint64_t size = block_count * s1.size();
+    setup_for_read(attrs, offs, size); //read as a single block
+    r = try_decompress(oid, offs, size, out, &out_res);
+    EXPECT_EQ(r, 0);
+    for (size_t i = 0; i < block_count; i++) {
+      std::string tmpstr(out_res.get_contiguous(i * s1.size(), s1.size()), s1.size());
+      EXPECT_TRUE(s1 == tmpstr);
+    }
+    EXPECT_EQ(compressor->decompress_calls, block_count);
+
+    //reading all the object but the first and last bytes
+    clear();
+    compressor->reset();
+    out_res.clear();
+    offs = 1;
+    size = block_count * s1.size() - 1;
+    setup_for_read(attrs, offs, size); //read as a single block
+    r = try_decompress(oid, offs, size, out, &out_res);
+    EXPECT_EQ(r, 0);
+    EXPECT_EQ(size, out_res.length());
+    EXPECT_EQ(compressor->decompress_calls, block_count);
+
+    //reading Nth block ( totally and partially )
+    for (size_t i = 0; i < block_count; i++) {
+      clear();
+      compressor->reset();
+      out_res.clear();
+      offs = i * s1.size();
+      size = s1.size();
+      setup_for_read(attrs, offs, offs + size); //read as a single block
+
+      bufferlist compressed_block;
+      compressed_block.substr_of(out, block_info[i].first, block_info[i].second);
+
+      r = try_decompress(oid, offs, size, compressed_block, &out_res);
+      EXPECT_EQ(r, 0);
+      EXPECT_EQ(size, out_res.length());
+      std::string tmpstr(out_res.c_str(), s1.size());
+      EXPECT_EQ(s1, tmpstr);
+      EXPECT_EQ(compressor->decompress_calls, 1u);
+
+      out_res.clear();
+      offs = i * s1.size() + 2;
+      size = s1.size() - 3;
+      setup_for_read(attrs, offs, offs + size); //read as a single block
+      r = try_decompress(oid, offs, size, out, &out_res);
+      EXPECT_EQ(r, 0);
+      EXPECT_EQ(size, out_res.length());
+      EXPECT_EQ(compressor->decompress_calls, 2u);
+    }
+
+    //multiple blocks (variable sizes) compress
+    block_info.clear();
+    clear();
+    out_res.clear();
+    compressor->reset(TestCompressor::COMPRESS);
+    block_count = 200;
+    const unsigned num_blocks = 8;
+    string blocks[num_blocks] = {
+      std::string(4096, 'a'),
+      std::string(4096 * 3, 'a'),
+      std::string(4096 * 8, 'a'),
+      std::string(4096 * 9, 'a'),
+      std::string(4096 * 31, 'a'),
+      std::string(4096 * 127, 'a'),
+      std::string(4096 * 129, 'a'),
+      std::string(4096 * 140, 'a')
+    };
+    offs4append = 0;
+    uint64_t total_size = 0;
+    uint64_t total_blocks = 0;
+    
+    for (size_t i = 0; i < block_count; i++) {
+      in.clear();
+      in.append(blocks[ i % num_blocks]);
+      total_size += in.length();
+      unsigned blocks_to_append = in.length() / (get_block_size());
+      blocks_to_append += in.length() % (get_block_size()) ? 1 : 0;
+      total_blocks += blocks_to_append;
+
+      offs = offs4append;
+      out.clear();
+      int r = try_compress(TestCompressor::method_name(), oid, in, &offs, &out);
+      EXPECT_EQ(r, 0);
+      EXPECT_EQ(offs, out_res.length());
+      offs4append += in.length();
+      block_info.push_back(std::pair<uint64_t, uint64_t>(out_res.length(), out.length()));
+      out_res.append(out);
+    }
+    EXPECT_EQ(compressor->compress_calls,
+	      total_blocks - block_count / 8 /*these blocks aren't compressed due to small writes*/);
+    EXPECT_EQ(out_res.length(), get_compressed_size());
+    EXPECT_EQ(get_compressed_size(), block_count * STRIPE_WIDTH); //as we have pretty huge compression ratio all large blocks are expected to fit into single stripe
+
+    flush(&attrs);
+    mrec = get_master_record();
+    EXPECT_NE(mrec.block_info_record_length, 0u);
+    EXPECT_NE(mrec.block_info_recordset_header_length, 0u);
+    /*unsigned recsets = total_blocks / RECS_PER_RECORDSET +
+		       (total_blocks % RECS_PER_RECORDSET ? 1 : 0);
+
+    unsigned attrs_len = 0;*/
+    unsigned records=0;
+    for( uint64_t o = 0; o<offs4append; o+=STRIPE_WIDTH*MAX_STRIPES_PER_BLOCKSET){
+      string key;
+      offset_to_key( o, key );
+      
+      map<string, bufferlist>::iterator it = attrs.find(key);
+      EXPECT_NE(it, attrs.end());
+      bufferlist::iterator it_bl = it->second.begin();
+      unsigned cur_rec=0;
+      while( !it_bl.end()){
+        if( (cur_rec % RECS_PER_RECORDSET) == 0) {
+          BlockInfoRecordSetHeader hdr(0,0);
+          ::decode( hdr, it_bl);
+        }
+        BlockInfoRecord rec;
+        ::decode(rec, it_bl);
+        ++cur_rec;
+        ++records;
+      }
+      //attrs_len += attrs[key].length();
+    }
+    EXPECT_EQ(records, total_blocks);
+    out = out_res;
+    out_res.clear();
+
+    //reading Nth block ( totally, partially and block+1 octet )
+    uint64_t offs_to_read = 0;
+    for (size_t i = 0; i < block_count; i++) {
+      clear();
+      compressor->reset();
+      out_res.clear();
+      size = blocks[ i % num_blocks ].size();
+      offs = offs_to_read;
+      setup_for_read(attrs, offs, offs + size); //read as a single block
+      bufferlist compressed_block;
+      compressed_block.substr_of(out, block_info[i].first, block_info[i].second);
+
+      r = try_decompress(oid, offs, size, compressed_block, &out_res);
+      EXPECT_EQ(r, 0);
+      EXPECT_EQ(size, out_res.length());
+      unsigned decompress_calls = 0;
+      if (size > STRIPE_WIDTH) {
+	decompress_calls += size / (get_block_size());
+	decompress_calls += size % (get_block_size()) ? 1 : 0;
+      }
+      EXPECT_EQ(compressor->decompress_calls, decompress_calls);
+
+      out_res.clear();
+      compressor->reset();
+      size = blocks[ i % num_blocks ].size() - 3;
+      offs = offs_to_read + 2;
+      setup_for_read(attrs, offs, offs + size); //read as a single block
+      r = try_decompress(oid, offs, size, compressed_block, &out_res);
+      EXPECT_EQ(r, 0);
+      EXPECT_EQ(size, out_res.length());
+      decompress_calls = 0;
+      if (size > STRIPE_WIDTH) {
+	decompress_calls += size / (get_block_size());
+	decompress_calls += size % (get_block_size()) ? 1 : 0;
+      }
+      EXPECT_EQ(compressor->decompress_calls, decompress_calls);
+
+      if (i < block_count - 1) {
+	out_res.clear();
+	compressor->reset();
+	size = blocks[ i % num_blocks ].size() + 3; //read Nth blocks + 3 octets from the next one
+	offs = offs_to_read + 2;
+	setup_for_read(attrs, offs, offs + size);
+	compressed_block.substr_of(out,
+				   block_info[i].first,
+				   block_info[i].second + block_info[i + 1].second);
+	r = try_decompress(oid, offs, size, compressed_block, &out_res);
+	EXPECT_EQ(r, 0);
+	EXPECT_EQ(size, out_res.length());
+	decompress_calls = 0;
+	if (blocks[i % num_blocks].size() > STRIPE_WIDTH) {
+	  decompress_calls += blocks[i % num_blocks].size() / (get_block_size());
+	  decompress_calls += blocks[i % num_blocks].size() % (get_block_size()) ? 1 : 0;
+	}
+	if (blocks[(i + 1) % num_blocks].size() > STRIPE_WIDTH) {
+	  ++decompress_calls;  //we need just single block decompress as we need 3 bytes from the second block only
+	}
+	EXPECT_EQ(compressor->decompress_calls, decompress_calls);
+      }
+
+      offs_to_read += blocks[ i % num_blocks ].size();
+
+    }
+  }
+};
+
+
+TEST(CompressContext, check_mapping) {
+  CompressContextTester ctx;
+  ctx.testMapping1();
+}
+
+TEST(CompressContext, check_append) {
+  CompressContextTester ctx;
+  ctx.testAppendAndFlush();
+}
+
+
+TEST(CompressContext, check_compress_decompress) {
+  CompressContextTester ctx;
+  ctx.testCompressSimple(TestCompressionPlugin::compressor);
+}
+
+int main(int argc, char** argv) {
+  vector<const char*> args;
+  argv_to_vec(argc, (const char**)argv, args);
+
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+  PluginRegistry* reg = g_ceph_context->get_plugin_registry();
+  TestCompressionPlugin compression_plugin(g_ceph_context);
+  {
+    Mutex::Locker m(reg->lock);
+    reg->add("compressor", TestCompressor::method_name(), &compression_plugin);
+  }
+  reg->disable_dlclose = true;
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+/*
+ * Local Variables:
+ * compile-command: "cd ../.. ; make -j4 &&
+ *   make unittest_compresscontext &&
+ *   valgrind --tool=memcheck \
+ *      ./unittest_compresscontext \
+ *      --gtest_filter=*.* --log-to-stderr=true --debug-osd=20"
+ * End:
+ */

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -989,18 +989,18 @@ class TestOSD(TestArgparse):
                                                     'poolname',
                                                     '128', '128',
                                                     'erasure', '^^^',
-													'ruleset']))
+													'ruleset', '2', "snappy"], True))
         assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
                                                     'poolname',
                                                     '128', '128',
                                                     'erasure', 'profile',
                                                     'ruleset',
-												    'toomany']))
+												'2', 'snappy',  'toomany']))
         assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
                                                     'poolname',
                                                     '128', '128',
                                                     'INVALID', 'profile',
-                                                    'ruleset']))
+                                                    'ruleset', '2', 'snappy']))
 
     def test_pool_delete(self):
         self.assert_valid_command(['osd', 'pool', 'delete',


### PR DESCRIPTION
This is an implementation for Data-At-Rest compression feature we discussed some time ago. It introduces optional compression support for EC pools. One can find corresponding blueprint at 
http://tracker.ceph.com/projects/ceph/wiki/Rados_-_at-rest_compression

To enable compression for a specific EC pool one can either specify compression on pool creation or turn it on at an arbitrary moment of time, e.g.
'osd pool create ecpool 12 12 erasure default someruleset 0 zlib'
or
'osd pool set ecpool compression_type snappy'

To disable compression for a pool one should invoke
'osd pool set ecpool compression_type none'

The provided patch is based on PR #6361. Appropriate changes are incorporated into the patch via a separate commit. 

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>
Signed-off-by: Kiseleva Alyona <akiselyova@mirantis.com>