### PR TITLE
msg: ignore request_redirect_t encode/decode when we not need

### DIFF
--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -73,6 +73,8 @@
 #define CEPH_FEATURE_MON_STATEFUL_SUB (1ULL<<57) /* stateful mon subscription */
 #define CEPH_FEATURE_MON_ROUTE_OSDMAP (1ULL<<57) /* peon sends osdmaps */
 #define CEPH_FEATURE_CRUSH_TUNABLES5	(1ULL<<58) /* chooseleaf stable mode */
+// duplicated since it was introduced at the same time as CEPH_FEATURE_CRUSH_TUNABLES5
+#define CEPH_FEATURE_NEW_OSDOPREPLY_ENCODING   (1ULL<<58) /* New, v7 encoding */
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */
@@ -136,6 +138,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_MDSENC |			\
 	 CEPH_FEATURE_OSDHASHPSPOOL |       \
 	 CEPH_FEATURE_NEW_OSDOP_ENCODING |        \
+         CEPH_FEATURE_NEW_OSDOPREPLY_ENCODING | \
 	 CEPH_FEATURE_MON_SINGLE_PAXOS |    \
 	 CEPH_FEATURE_OSD_SNAPMAPPER |	    \
 	 CEPH_FEATURE_MON_SCRUB	|	    \

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -32,7 +32,7 @@
 
 class MOSDOpReply : public Message {
 
-  static const int HEAD_VERSION = 6;
+  static const int HEAD_VERSION = 7;
   static const int COMPAT_VERSION = 2;
 
   object_t oid;
@@ -45,6 +45,7 @@ class MOSDOpReply : public Message {
   version_t user_version;
   epoch_t osdmap_epoch;
   int32_t retry_attempt;
+  bool do_redirect;
   request_redirect_t redirect;
 
 public:
@@ -91,7 +92,7 @@ public:
 
   void set_redirect(const request_redirect_t& redir) { redirect = redir; }
   const request_redirect_t& get_redirect() const { return redirect; }
-  bool is_redirect_reply() const { return !redirect.empty(); }
+  bool is_redirect_reply() const { return do_redirect; }
 
   void add_flags(int f) { flags |= f; }
 
@@ -136,6 +137,7 @@ public:
     osdmap_epoch = e;
     user_version = 0;
     retry_attempt = req->get_retry_attempt();
+    do_redirect = false;
 
     // zero out ops payload_len and possibly out data
     for (unsigned i = 0; i < ops.size(); i++) {
@@ -189,7 +191,16 @@ public:
 
       ::encode(replay_version, payload);
       ::encode(user_version, payload);
-      ::encode(redirect, payload);
+      if ((features & CEPH_FEATURE_NEW_OSDOPREPLY_ENCODING) == 0) {
+        header.version = 6;
+        ::encode(redirect, payload);
+      } else {
+        do_redirect = !redirect.empty();
+        ::encode(do_redirect, payload);
+        if (do_redirect) {
+          ::encode(redirect, payload);
+        }
+      }
     }
   }
   virtual void decode_payload() {
@@ -268,8 +279,16 @@ public:
 	user_version = replay_version.version;
       }
 
-      if (header.version >= 6)
+      if (header.version == 6) {
 	::decode(redirect, p);
+        do_redirect = !redirect.empty();
+      }
+      else if (header.version >= 7) {
+        ::decode(do_redirect, p);
+        if (do_redirect) {
+	  ::decode(redirect, p);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
reusing the feature introduced by commit 39e06ef

Signed-off-by: Xinze Chi <xinze@xsky.com>