### PR TITLE
Reduce CPU usage by reusing stringstream in stringify function

### DIFF
--- a/src/include/stringify.h
+++ b/src/include/stringify.h
@@ -6,7 +6,8 @@
 
 template<typename T>
 inline std::string stringify(const T& a) {
-  std::ostringstream ss;
+  static __thread std::ostringstream ss;
+  ss.str("");
   ss << a;
   return ss.str();
 }

--- a/src/include/stringify.h
+++ b/src/include/stringify.h
@@ -6,8 +6,12 @@
 
 template<typename T>
 inline std::string stringify(const T& a) {
+#if defined(__GNUC__) && !(defined(__clang__) || defined(__INTEL_COMPILER))
   static __thread std::ostringstream ss;
   ss.str("");
+#else
+  std::ostringstream ss;
+#endif
   ss << a;
   return ss.str();
 }


### PR DESCRIPTION
About 10% CPU reduction and 10% TPS bump in CPU bound workload.
Blanks in the fourth column is saved CPU after the change.

![screen shot 2015-10-07 at 11 10 15 am](https://cloud.githubusercontent.com/assets/3436058/11102680/e0a05fba-8872-11e5-9e9d-5c15bd1f843e.png)
