### PR TITLE
osd: check do_shutdown before do_restart

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6544,16 +6544,17 @@ void OSD::handle_osd_map(MOSDMap *m)
     dout(10) << " msg say newest map is " << m->newest_map << ", requesting more" << dendl;
     osdmap_subscribe(osdmap->get_epoch()+1, true);
   }
+  else if (do_shutdown) {
+    osd_lock.Unlock();
+    shutdown();
+    osd_lock.Lock();
+  }
   else if (is_booting()) {
     start_boot();  // retry
   }
   else if (do_restart)
     start_boot();
 
-  osd_lock.Unlock();
-  if (do_shutdown)
-    shutdown();
-  osd_lock.Lock();
 
   m->put();
 }


### PR DESCRIPTION
This will save extart boot message when do_shutdown && do_restart == true,
which is the case when rebind failed.

Also move the unlock/lock inside the if statement so we don't do unnecessary
lock/unlock.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>