### PR TITLE
Website feature

### DIFF
--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -40,6 +40,7 @@ librgw_la_SOURCES =  \
 	rgw/rgw_env.cc \
 	rgw/rgw_cors.cc \
 	rgw/rgw_cors_s3.cc \
+	rgw/rgw_ws_s3.cc \
 	rgw/rgw_auth_s3.cc \
 	rgw/rgw_metadata.cc \
 	rgw/rgw_replica_log.cc \
@@ -135,6 +136,8 @@ noinst_HEADERS += \
 	rgw/rgw_cors.h \
 	rgw/rgw_cors_s3.h \
 	rgw/rgw_cors_swift.h \
+	rgw/rgw_ws.h \
+	rgw/rgw_ws_s3.h \
 	rgw/rgw_string.h \
 	rgw/rgw_formats.h \
 	rgw/rgw_http_errors.h \

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -605,6 +605,7 @@ int RGWHTTPArgs::parse()
       if ((name.compare("acl") == 0) ||
           (name.compare("cors") == 0) ||
           (name.compare("location") == 0) ||
+          (name.compare("website") == 0) ||
           (name.compare("logging") == 0) ||
           (name.compare("delete") == 0) ||
           (name.compare("uploads") == 0) ||

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -70,6 +70,7 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_SHADOW_OBJ    	RGW_ATTR_PREFIX "shadow_name"
 #define RGW_ATTR_MANIFEST    	RGW_ATTR_PREFIX "manifest"
 #define RGW_ATTR_USER_MANIFEST  RGW_ATTR_PREFIX "user_manifest"
+#define RGW_ATTR_WEBSITE        RGW_ATTR_PREFIX "website"
 
 #define RGW_ATTR_TEMPURL_KEY1   RGW_ATTR_META_PREFIX "temp-url-key"
 #define RGW_ATTR_TEMPURL_KEY2   RGW_ATTR_META_PREFIX "temp-url-key-2"
@@ -150,6 +151,7 @@ using ceph::crypto::MD5;
 #define ERR_INVALID_ACCESS_KEY   2028
 #define ERR_MALFORMED_XML        2029
 #define ERR_USER_EXIST           2030
+#define ERR_NOT_SET_WEBSITE      2031
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
 #define ERR_NOT_IMPLEMENTED      2201

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -47,6 +47,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ERR_NO_SUCH_BUCKET, 404, "NoSuchBucket" },
     { ERR_NO_SUCH_UPLOAD, 404, "NoSuchUpload" },
     { ERR_NOT_FOUND, 404, "Not Found"},
+    { ERR_NOT_SET_WEBSITE, 404, "NoSuchWebsiteConfiguration"},
     { ERR_METHOD_NOT_ALLOWED, 405, "MethodNotAllowed" },
     { ETIMEDOUT, 408, "RequestTimeout" },
     { EEXIST, 409, "BucketAlreadyExists" },

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -24,6 +24,7 @@
 #include "rgw_acl.h"
 #include "rgw_cors.h"
 #include "rgw_quota.h"
+#include "rgw_ws.h"
 
 using namespace std;
 
@@ -367,6 +368,25 @@ public:
   virtual void send_response() = 0;
   virtual const string name() { return "stat_bucket"; }
   virtual RGWOpType get_type() { return RGW_OP_STAT_BUCKET; }
+  virtual uint32_t op_mask() { return RGW_OP_TYPE_READ; }
+};
+
+class RGWGetBucketWS : public RGWOp {
+protected:
+  int ret;
+  RGWWebsiteConfiguration website;
+  bool ws_exist;
+
+public:
+  RGWGetBucketWS() : ret(0), ws_exist(0) {}
+  ~RGWGetBucketWS() {}
+
+  int verify_permission();
+  void pre_exec();
+  void execute();
+
+  virtual void send_response() = 0;
+  virtual const string name() { return "get_bucket_ws"; }
   virtual uint32_t op_mask() { return RGW_OP_TYPE_READ; }
 };
 
@@ -758,6 +778,63 @@ public:
   virtual void send_response() = 0;
   virtual const string name() { return "put_acls"; }
   virtual RGWOpType get_type() { return RGW_OP_PUT_ACLS; }
+  virtual uint32_t op_mask() { return RGW_OP_TYPE_WRITE; }
+};
+
+class RGWGetWS : public RGWOp {
+protected:
+  int ret;
+  RGWWebsiteConfiguration website;
+public:
+  RGWGetWS() : ret(0) {}
+
+  int verify_permission();
+  void pre_exec();
+  void execute();
+
+  virtual void send_response() = 0;
+  virtual const string name() { return "get_ws"; }
+  virtual uint32_t op_mask() { return RGW_OP_TYPE_READ; }
+};
+
+class RGWPutWS : public RGWOp {
+protected:
+  int ret;
+  size_t len;
+  char *data;
+
+public:
+  RGWPutWS() {
+    ret = 0;
+    len = 0;
+    data = NULL;
+  }
+  virtual ~RGWPutWS() {
+    free(data);
+  }
+
+  int verify_permission();
+  void pre_exec();
+  void execute();
+
+  virtual int get_params() = 0;
+  virtual void send_response() = 0;
+  virtual const string name() { return "put_ws"; }
+  virtual uint32_t op_mask() { return RGW_OP_TYPE_WRITE; }
+};
+
+class RGWDeleteWS : public RGWOp {
+protected:
+  int ret;
+
+public:
+  RGWDeleteWS() : ret(0) {}
+
+  int verify_permission();
+  void execute();
+
+  virtual void send_response() = 0;
+  virtual const string name() { return "delete_ws"; }
   virtual uint32_t op_mask() { return RGW_OP_TYPE_WRITE; }
 };
 

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -921,6 +921,30 @@ int RGWPutACLs_ObjStore::get_params()
   return ret;
 }
 
+int RGWPutWS_ObjStore::get_params()
+{
+  size_t cl = 0;
+  if (s->length)
+    cl = atoll(s->length);
+  if (cl) {
+    data = (char *)malloc(cl + 1);
+    if (!data) {
+       ret = -ENOMEM;
+       return ret;
+    }
+    int read_len;
+    int r = s->cio->read(data, cl, &read_len);
+    len = read_len;
+    if (r < 0)
+      return r;
+    data[len] = '\0';
+  } else {
+    len = 0;
+  }
+
+  return ret;
+}
+
 static int read_all_chunked_input(req_state *s, char **pdata, int *plen, int max_read)
 {
 #define READ_CHUNK 4096

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -131,6 +131,12 @@ public:
   ~RGWStatBucket_ObjStore() {}
 };
 
+class RGWGetBucketWS_ObjStore : public RGWGetBucketWS {
+public:
+  RGWGetBucketWS_ObjStore() {}
+  ~RGWGetBucketWS_ObjStore() {}
+};
+
 class RGWCreateBucket_ObjStore : public RGWCreateBucket {
 public:
   RGWCreateBucket_ObjStore() {}
@@ -208,6 +214,26 @@ public:
   ~RGWPutACLs_ObjStore() {}
 
   int get_params();
+};
+
+class RGWGetWS_ObjStore : public RGWGetWS {
+public:
+  RGWGetWS_ObjStore() {}
+  ~RGWGetWS_ObjStore() {}
+};
+
+class RGWPutWS_ObjStore : public RGWPutWS {
+public:
+  RGWPutWS_ObjStore() {}
+  ~RGWPutWS_ObjStore() {}
+
+  int get_params();
+};
+
+class RGWDeleteWS_ObjStore : public RGWDeleteWS {
+public:
+  RGWDeleteWS_ObjStore() {}
+  ~RGWDeleteWS_ObjStore() {}
 };
 
 class RGWGetCORS_ObjStore : public RGWGetCORS {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -92,6 +92,14 @@ public:
   void send_response();
 };
 
+class RGWGetBucketWS_ObjStore_S3 : public RGWGetBucketWS_ObjStore {
+public:
+  RGWGetBucketWS_ObjStore_S3() {}
+  ~RGWGetBucketWS_ObjStore_S3() {}
+
+  void send_response();
+};
+
 class RGWCreateBucket_ObjStore_S3 : public RGWCreateBucket_ObjStore {
 public:
   RGWCreateBucket_ObjStore_S3() {}
@@ -199,6 +207,30 @@ public:
   ~RGWPutACLs_ObjStore_S3() {}
 
   int get_policy_from_state(RGWRados *store, struct req_state *s, stringstream& ss);
+  void send_response();
+};
+
+class RGWGetWS_ObjStore_S3 : public RGWGetWS_ObjStore {
+public:
+  RGWGetWS_ObjStore_S3() {}
+  ~RGWGetWS_ObjStore_S3() {}
+
+  void send_response();
+};
+
+class RGWPutWS_ObjStore_S3 : public RGWPutWS_ObjStore {
+public:
+  RGWPutWS_ObjStore_S3() {}
+  ~RGWPutWS_ObjStore_S3() {}
+
+  void send_response();
+};
+
+class RGWDeleteWS_ObjStore_S3 : public RGWDeleteWS_ObjStore {
+public:
+  RGWDeleteWS_ObjStore_S3() {}
+  ~RGWDeleteWS_ObjStore_S3() {}
+
   void send_response();
 };
 
@@ -411,6 +443,12 @@ class RGWHandler_ObjStore_Bucket_S3 : public RGWHandler_ObjStore_S3 {
 protected:
   bool is_acl_op() {
     return s->info.args.exists("acl");
+  }
+  bool is_ws_op() {
+    return s->info.args.exists("website");
+  }
+  bool is_auth_op() {
+    return (s->http_auth ? 1 : 0);
   }
   bool is_cors_op() {
       return s->info.args.exists("cors");

--- a/src/rgw/rgw_ws.h
+++ b/src/rgw/rgw_ws.h
@@ -1,0 +1,65 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_RGW_WS_H
+#define CEPH_RGW_WS_H
+
+#include <map>
+#include <string>
+#include <iostream>
+#include <include/types.h>
+
+class WSIdxDoc
+{
+protected:
+  string suffix;
+public:
+  WSIdxDoc() {}
+  ~WSIdxDoc() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    ::encode(suffix, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
+    ::decode(suffix, bl);
+    DECODE_FINISH(bl);
+  }
+  void set_suffix(const string& _suffix) { suffix = _suffix; }
+  string& get_suffix() { return suffix; }
+};
+WRITE_CLASS_ENCODER(WSIdxDoc)
+
+class RGWWebsiteConfiguration
+{
+  protected:
+    CephContext *cct;
+    WSIdxDoc idx_doc;
+  public:
+    RGWWebsiteConfiguration() {}
+    ~RGWWebsiteConfiguration() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    ::encode(idx_doc, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START(1, bl);
+    ::decode(idx_doc, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void set_idx_doc(WSIdxDoc& o) { idx_doc = o; }
+  WSIdxDoc& get_idx_doc() {
+    return idx_doc;
+  }
+
+};
+WRITE_CLASS_ENCODER(RGWWebsiteConfiguration)
+
+
+
+#endif /*CEPH_RGW_WS_H*/

--- a/src/rgw/rgw_ws_s3.cc
+++ b/src/rgw/rgw_ws_s3.cc
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+
+#include <string.h>
+#include <limits.h>
+
+#include <iostream>
+#include <map>
+
+#include "include/types.h"
+
+#include "rgw_ws_s3.h"
+#include "rgw_user.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+using namespace std;
+
+class WSIdxDocSuffix_S3 : public XMLObj {
+  public:
+    WSIdxDocSuffix_S3() {}
+    ~WSIdxDocSuffix_S3() {}
+};
+
+bool WSIdxDoc_S3::xml_end(const char *el) {
+  WSIdxDocSuffix_S3 *ws_suffix = static_cast<WSIdxDocSuffix_S3 *>(find_first("Suffix"));
+
+  // Suffix is mandatory
+  if (!ws_suffix)
+    return false;
+  suffix = ws_suffix->get_data();
+
+  return true;
+}
+
+bool RGWWebsiteConfiguration_S3::xml_end(const char *el) {
+  WSIdxDoc_S3 *idx_doc_p = static_cast<WSIdxDoc_S3 *>(find_first("IndexDocument"));
+  if (!idx_doc_p)
+    return false;
+
+  idx_doc = *idx_doc_p;
+  return true;
+}
+
+XMLObj *RGWWSXMLParser_S3::alloc_obj(const char *el) {
+  if (strcmp(el, "WebsiteConfiguration") == 0) {
+    return new RGWWebsiteConfiguration_S3;
+  } else if (strcmp(el, "IndexDocument") == 0) {
+    return new WSIdxDoc_S3;
+  } else if (strcmp(el, "Suffix") == 0) {
+    return new WSIdxDocSuffix_S3;
+  }
+  return NULL;
+}

--- a/src/rgw/rgw_ws_s3.h
+++ b/src/rgw/rgw_ws_s3.h
@@ -1,0 +1,59 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_RGW_WS_S3_H
+#define CEPH_RGW_WS_S3_H
+
+#include <map>
+#include <string>
+#include <iostream>
+#include <expat.h>
+
+#include <include/types.h>
+#include <common/Formatter.h>
+#include "rgw_xml.h"
+#include "rgw_ws.h"
+
+using namespace std;
+
+class WSIdxDoc_S3 : public WSIdxDoc, public XMLObj
+{
+public:
+  WSIdxDoc_S3() {}
+  ~WSIdxDoc_S3() {}
+
+  bool xml_end(const char *el);
+  void to_xml(ostream& out) {
+    if (suffix.empty())
+      return;
+    out << "<IndexDocument>" << "<Suffix>" << suffix << "</Suffix>";
+    out << "</IndexDocument>";
+  }
+};
+
+class RGWWebsiteConfiguration_S3 : public RGWWebsiteConfiguration, public XMLObj
+{
+  public:
+    RGWWebsiteConfiguration_S3() {}
+    ~RGWWebsiteConfiguration_S3() {}
+
+    bool xml_end(const char *el);
+    void to_xml(ostream& out) {
+      out << "<WebsiteConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
+      WSIdxDoc_S3& _idx_doc = static_cast<WSIdxDoc_S3 &>(idx_doc);
+      _idx_doc.to_xml(out);
+      out << "</WebsiteConfiguration>";
+    }
+};
+
+class RGWWSXMLParser_S3 : public RGWXMLParser
+{
+  CephContext *cct;
+
+  XMLObj *alloc_obj(const char *el);
+public:
+  RGWWSXMLParser_S3(CephContext *_cct) : cct(_cct) {}
+};
+
+#endif /*CEPH_RGW_WS_S3_H*/
+


### PR DESCRIPTION
As same as amazon S3 interface, the website attribute of bucket have
been added. The "ErrorDocument" and "redirect rules" of website have not
been realized now. The "IndexDocument" of website have been implemented.

To configure a bucket as a website, you can add this subresource on the
bucket with website configuration information such as the file name of
the index document and any redirect rules.

For example:
s3cmd ws-create s3://mytest --ws-index=index.html
curl http://localhost/mytest  -L
the return of curl will be the content of index.html

Signed-off-by: sunfangchen <richard.sun1999@gmail.com>