### PR TITLE
fix: use right init_flags to finish CephContext

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -187,7 +187,7 @@ int main(int argc, const char **argv)
     exit(1);
 
   if (shadow != MDSMap::STATE_ONESHOT_REPLAY)
-    global_init_daemonize(g_ceph_context, 0);
+    global_init_daemonize(g_ceph_context);
   common_init_finish(g_ceph_context);
 
   // get monmap

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -339,7 +339,7 @@ int main(int argc, const char **argv)
     // resolve public_network -> public_addr
     pick_addresses(g_ceph_context, CEPH_PICK_ADDRESS_PUBLIC);
 
-    common_init_finish(g_ceph_context, flags);
+    common_init_finish(g_ceph_context);
 
     bufferlist monmapbl, osdmapbl;
     std::string error;
@@ -496,7 +496,7 @@ int main(int argc, const char **argv)
   // screwing us over
   Preforker prefork;
   if (!(flags & CINIT_FLAG_NO_DAEMON_ACTIONS)) {
-    if (global_init_prefork(g_ceph_context, 0) >= 0) {
+    if (global_init_prefork(g_ceph_context) >= 0) {
       string err_msg;
       err = prefork.prefork(err_msg);
       if (err < 0) {
@@ -749,7 +749,7 @@ int main(int argc, const char **argv)
   }
 
   if (g_conf->daemonize) {
-    global_init_postfork_finish(g_ceph_context, 0);
+    global_init_postfork_finish(g_ceph_context);
     prefork.daemonize();
   }
 

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -535,7 +535,7 @@ int main(int argc, const char **argv)
     exit(1);
 
   // Set up crypto, daemonize, etc.
-  global_init_daemonize(g_ceph_context, 0);
+  global_init_daemonize(g_ceph_context);
   common_init_finish(g_ceph_context);
 
   TracepointProvider::initialize<osd_tracepoint_traits>(g_ceph_context);

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -398,11 +398,12 @@ void CephContext::do_command(std::string command, cmdmap_t& cmdmap,
 }
 
 
-CephContext::CephContext(uint32_t module_type_)
+CephContext::CephContext(uint32_t module_type_, int init_flags_)
   : nref(1),
     _conf(new md_config_t()),
     _log(NULL),
     _module_type(module_type_),
+    _init_flags(init_flags_),
     _crypto_inited(false),
     _service_thread(NULL),
     _log_obs(NULL),
@@ -584,6 +585,11 @@ void CephContext::join_service_thread()
 uint32_t CephContext::get_module_type() const
 {
   return _module_type;
+}
+
+int CephContext::get_init_flags() const
+{
+  return _init_flags;
 }
 
 PerfCountersCollection *CephContext::get_perfcounters_collection()

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -55,7 +55,7 @@ using ceph::bufferlist;
  */
 class CephContext {
 public:
-  CephContext(uint32_t module_type_);
+  CephContext(uint32_t module_type_, int init_flags_ = 0);
 
   // ref count!
 private:
@@ -85,6 +85,8 @@ public:
 
   /* Get the module type (client, mon, osd, mds, etc.) */
   uint32_t get_module_type() const;
+
+  int get_init_flags() const;
 
   /* Get the PerfCountersCollection of this CephContext */
   PerfCountersCollection *get_perfcounters_collection();
@@ -172,6 +174,8 @@ private:
   void join_service_thread();
 
   uint32_t _module_type;
+
+  int _init_flags;
 
   bool _crypto_inited;
 

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -39,7 +39,7 @@ CephContext *common_preinit(const CephInitParameters &iparams,
   g_code_env = code_env;
 
   // Create a configuration object
-  CephContext *cct = new CephContext(iparams.module_type);
+  CephContext *cct = new CephContext(iparams.module_type, flags);
 
   md_config_t *conf = cct->_conf;
   // add config observers here
@@ -113,10 +113,10 @@ void complain_about_parse_errors(CephContext *cct,
 
 /* Please be sure that this can safely be called multiple times by the
  * same application. */
-void common_init_finish(CephContext *cct, int flags)
+void common_init_finish(CephContext *cct)
 {
   cct->init_crypto();
 
-  if (!(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))
+  if (!(cct->get_init_flags() & CINIT_FLAG_NO_DAEMON_ACTIONS))
     cct->start_service_thread();
 }

--- a/src/common/common_init.h
+++ b/src/common/common_init.h
@@ -75,6 +75,6 @@ void complain_about_parse_errors(CephContext *cct,
  * libraries. The most obvious reason for this is that the threads started by
  * the Ceph libraries would be destroyed by a fork().
  */
-void common_init_finish(CephContext *cct, int flags = 0);
+void common_init_finish(CephContext *cct);
 
 #endif

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -257,7 +257,7 @@ static void pidfile_remove_void(void)
   pidfile_remove();
 }
 
-int global_init_prefork(CephContext *cct, int flags)
+int global_init_prefork(CephContext *cct)
 {
   if (g_code_env != CODE_ENVIRONMENT_DAEMON)
     return -1;
@@ -279,9 +279,9 @@ int global_init_prefork(CephContext *cct, int flags)
   return 0;
 }
 
-void global_init_daemonize(CephContext *cct, int flags)
+void global_init_daemonize(CephContext *cct)
 {
-  if (global_init_prefork(cct, flags) < 0)
+  if (global_init_prefork(cct) < 0)
     return;
 
   int ret = daemon(1, 1);
@@ -293,7 +293,7 @@ void global_init_daemonize(CephContext *cct, int flags)
   }
 
   global_init_postfork_start(cct);
-  global_init_postfork_finish(cct, flags);
+  global_init_postfork_finish(cct);
 }
 
 void global_init_postfork_start(CephContext *cct)
@@ -332,13 +332,13 @@ void global_init_postfork_start(CephContext *cct)
   pidfile_write(g_conf);
 }
 
-void global_init_postfork_finish(CephContext *cct, int flags)
+void global_init_postfork_finish(CephContext *cct)
 {
   /* We only close stderr once the caller decides the daemonization
    * process is finished.  This way we can allow error messages to be
    * propagated in a manner that the user is able to see.
    */
-  if (!(flags & CINIT_FLAG_NO_CLOSE_STDERR)) {
+  if (!(cct->get_init_flags() & CINIT_FLAG_NO_CLOSE_STDERR)) {
     int ret = global_init_shutdown_stderr(cct);
     if (ret) {
       derr << "global_init_daemonize: global_init_shutdown_stderr failed with "

--- a/src/global/global_init.h
+++ b/src/global/global_init.h
@@ -46,7 +46,7 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
  * to actually forking (via daemon(3)).  return 0 if we are going to proceed
  * with the fork, or -1 otherwise.
  */
-int global_init_prefork(CephContext *cct, int flags);
+int global_init_prefork(CephContext *cct);
 
 /*
  * perform all the steps that global_init_daemonize performs just after
@@ -57,7 +57,7 @@ void global_init_postfork_start(CephContext *cct);
 /*
  * close stderr, thus completing the postfork.
  */
-void global_init_postfork_finish(CephContext *cct, int flags);
+void global_init_postfork_finish(CephContext *cct);
 
 
 /*
@@ -67,7 +67,7 @@ void global_init_postfork_finish(CephContext *cct, int flags);
  * Note that this is equivalent to calling _prefork(), daemon(), and
  * _postfork.
  */
-void global_init_daemonize(CephContext *cct, int flags);
+void global_init_daemonize(CephContext *cct);
 
 /*
  * global_init_chdir changes the process directory.

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -1046,7 +1046,7 @@ int main(int argc, const char **argv)
   check_curl();
 
   if (g_conf->daemonize) {
-    global_init_daemonize(g_ceph_context, 0);
+    global_init_daemonize(g_ceph_context);
   }
   Mutex mutex("main");
   SafeTimer init_timer(g_ceph_context, mutex);

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -73,7 +73,7 @@ int main(const int argc, const char **argv)
   }
 
   if (g_conf->daemonize) {
-    global_init_daemonize(g_ceph_context, 0);
+    global_init_daemonize(g_ceph_context);
   }
 
   common_init_finish(g_ceph_context);


### PR DESCRIPTION
The constructor of RadosClient will use CephContext,
and RadosClient.connect func will *always* use 0 as
init_flags to call common_init_finish.

So, save the init_flags to CephContex, will let
RadosClient.connect use right init_flags to finish
the cct.