### PR TITLE
rgw multisite: RGWPeriodPusher shares periods between zones/groups

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -938,6 +938,7 @@ if(${WITH_RADOSGW})
     rgw/rgw_sync.cc
     rgw/rgw_data_sync.cc
     rgw/rgw_dencoder.cc
+    rgw/rgw_period_pusher.cc
     rgw/rgw_realm_reloader.cc
     rgw/rgw_realm_watcher.cc
     rgw/rgw_coroutine.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -938,6 +938,8 @@ if(${WITH_RADOSGW})
     rgw/rgw_sync.cc
     rgw/rgw_data_sync.cc
     rgw/rgw_dencoder.cc
+    rgw/rgw_realm_reloader.cc
+    rgw/rgw_realm_watcher.cc
     rgw/rgw_coroutine.cc
     rgw/rgw_cr_rados.cc
     rgw/rgw_object_expirer_core.cc)
@@ -975,7 +977,6 @@ if(${WITH_RADOSGW})
     rgw/rgw_civetweb_log.cc
     civetweb/src/civetweb.c
     rgw/rgw_main.cc
-    rgw/rgw_realm_watcher.cc
     rgw/rgw_sync.cc
     rgw/rgw_data_sync.cc)
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1144,6 +1144,8 @@ OPTION(rgw_run_sync_thread, OPT_BOOL, true) // whether radosgw (not radosgw-admi
 OPTION(rgw_sync_lease_period, OPT_INT, 30) // time in second for lease that rgw takes on a specific log (or log shard)
 
 OPTION(rgw_realm_reconfigure_delay, OPT_DOUBLE, 2) // seconds to wait before reloading realm configuration
+OPTION(rgw_period_push_interval, OPT_DOUBLE, 2) // seconds to wait before retrying "period push"
+OPTION(rgw_period_push_interval_max, OPT_DOUBLE, 30) // maximum interval after exponential backoff
 
 OPTION(mutex_perf_counter, OPT_BOOL, false) // enable/disable mutex perf counter
 OPTION(throttler_perf_counter, OPT_BOOL, true) // enable/disable throttler perf counter

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -52,6 +52,8 @@ librgw_la_SOURCES =  \
 	rgw/rgw_keystone.cc \
 	rgw/rgw_quota.cc \
 	rgw/rgw_dencoder.cc \
+	rgw/rgw_realm_reloader.cc \
+	rgw/rgw_realm_watcher.cc \
 	rgw/rgw_object_expirer_core.cc \
 	rgw/rgw_sync.cc \
 	rgw/rgw_data_sync.cc
@@ -106,7 +108,6 @@ radosgw_SOURCES = \
 	rgw/rgw_swift.cc \
 	rgw/rgw_swift_auth.cc \
 	rgw/rgw_loadgen.cc \
-	rgw/rgw_realm_watcher.cc \
 	rgw/rgw_main.cc
 radosgw_CFLAGS = -I$(srcdir)/civetweb/include
 radosgw_LDADD = $(LIBRGW) $(LIBCIVETWEB) $(LIBRGW_DEPS) $(RESOLV_LIBS) $(CEPH_GLOBAL)
@@ -192,6 +193,7 @@ noinst_HEADERS += \
 	rgw/rgw_user.h \
 	rgw/rgw_bucket.h \
 	rgw/rgw_keystone.h \
+	rgw/rgw_realm_reloader.h \
 	rgw/rgw_realm_watcher.h \
 	rgw/rgw_civetweb.h \
 	rgw/rgw_boost_asio_coroutine.h \

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -52,6 +52,7 @@ librgw_la_SOURCES =  \
 	rgw/rgw_keystone.cc \
 	rgw/rgw_quota.cc \
 	rgw/rgw_dencoder.cc \
+	rgw/rgw_period_pusher.cc \
 	rgw/rgw_realm_reloader.cc \
 	rgw/rgw_realm_watcher.cc \
 	rgw/rgw_object_expirer_core.cc \
@@ -193,6 +194,7 @@ noinst_HEADERS += \
 	rgw/rgw_user.h \
 	rgw/rgw_bucket.h \
 	rgw/rgw_keystone.h \
+	rgw/rgw_period_pusher.h \
 	rgw/rgw_realm_reloader.h \
 	rgw/rgw_realm_watcher.h \
 	rgw/rgw_civetweb.h \

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -33,6 +33,7 @@
 #include "rgw_sync.h"
 #include "rgw_data_sync.h"
 #include "rgw_rest_conn.h"
+#include "rgw_realm_watcher.h"
 
 using namespace std;
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1401,7 +1401,7 @@ static int commit_period(RGWRealm& realm, RGWPeriod& period,
     cerr << "Error updating period epoch: " << cpp_strerror(ret) << std::endl;
     return ret;
   }
-  realm.notify_zone();
+  realm.notify_new_period(period);
   return ret;
 }
 

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -809,7 +809,7 @@ static void decode_placement_targets(map<string, RGWZoneGroupPlacementTarget>& t
 void RGWZoneGroup::decode_json(JSONObj *obj)
 {
   RGWSystemMetaObj::decode_json(obj);
-  if (!id.empty()) {
+  if (id.empty()) {
     derr << "old format " << dendl;
     JSONDecoder::decode_json("name", name, obj);
     id = name;

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -1054,7 +1054,7 @@ public:
 };
 
 // FrontendPauser implementation for RGWRealmReloader
-class RGWFrontendPauser : public RGWRealmReloader::FrontendPauser {
+class RGWFrontendPauser : public RGWRealmReloader::Pauser {
   std::list<RGWFrontend*> &frontends;
  public:
   RGWFrontendPauser(std::list<RGWFrontend*> &frontends)

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -38,7 +38,7 @@
 #include "rgw_acl.h"
 #include "rgw_user.h"
 #include "rgw_op.h"
-#include "rgw_realm_watcher.h"
+#include "rgw_realm_reloader.h"
 #include "rgw_rest.h"
 #include "rgw_rest_s3.h"
 #include "rgw_rest_swift.h"
@@ -1053,8 +1053,8 @@ public:
   }
 };
 
-// FrontendPauser implementation for RGWRealmWatcher
-class RGWFrontendPauser : public RGWRealmWatcher::FrontendPauser {
+// FrontendPauser implementation for RGWRealmReloader
+class RGWFrontendPauser : public RGWRealmReloader::FrontendPauser {
   std::list<RGWFrontend*> &frontends;
  public:
   RGWFrontendPauser(std::list<RGWFrontend*> &frontends)
@@ -1282,7 +1282,10 @@ int main(int argc, const char **argv)
 
   // add a watcher to respond to realm configuration changes
   RGWFrontendPauser pauser(fes);
-  RGWRealmWatcher realm_watcher(g_ceph_context, store, &pauser);
+  RGWRealmReloader reloader(store, &pauser);
+
+  RGWRealmWatcher realm_watcher(g_ceph_context, store->realm);
+  realm_watcher.set_watcher(&reloader);
 
   wait_shutdown();
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -1285,7 +1285,7 @@ int main(int argc, const char **argv)
   RGWRealmReloader reloader(store, &pauser);
 
   RGWRealmWatcher realm_watcher(g_ceph_context, store->realm);
-  realm_watcher.set_watcher(&reloader);
+  realm_watcher.add_watcher(RGWRealmNotify::Reload, reloader);
 
   wait_shutdown();
 

--- a/src/rgw/rgw_period_pusher.cc
+++ b/src/rgw/rgw_period_pusher.cc
@@ -1,0 +1,285 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <map>
+#include <thread>
+
+#include "rgw_period_pusher.h"
+#include "rgw_cr_rest.h"
+#include "common/errno.h"
+
+#include "rgw_boost_asio_yield.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+#undef dout_prefix
+#define dout_prefix (*_dout << "rgw period pusher: ")
+
+/// A coroutine to post the period over the given connection.
+using PushCR = RGWPostRESTResourceCR<RGWPeriod, int>;
+
+/// A coroutine that calls PushCR, and retries with backoff until success.
+class PushAndRetryCR : public RGWCoroutine {
+  const std::string& zone;
+  RGWRESTConn *const conn;
+  RGWHTTPManager *const http;
+  RGWPeriod& period;
+  const std::string epoch; //< epoch string for params
+  double timeout; //< current interval between retries
+  const double timeout_max; //< maximum interval between retries
+  uint32_t counter; //< number of failures since backoff increased
+
+ public:
+  PushAndRetryCR(CephContext* cct, const std::string& zone, RGWRESTConn* conn,
+                 RGWHTTPManager* http, RGWPeriod& period)
+    : RGWCoroutine(cct), zone(zone), conn(conn), http(http), period(period),
+      epoch(std::to_string(period.get_epoch())),
+      timeout(cct->_conf->rgw_period_push_interval),
+      timeout_max(cct->_conf->rgw_period_push_interval_max),
+      counter(0)
+  {}
+
+  int operate() override;
+};
+
+int PushAndRetryCR::operate()
+{
+  reenter(this) {
+    for (;;) {
+      yield {
+        ldout(cct, 10) << "pushing period " << period.get_id()
+            << " to " << zone << dendl;
+        // initialize the http params
+        rgw_http_param_pair params[] = {
+          { "period", period.get_id().c_str() },
+          { "epoch", epoch.c_str() },
+          { nullptr, nullptr }
+        };
+        call(new PushCR(cct, conn, http, "/admin/realm/period",
+                        params, period, nullptr));
+      }
+
+      // stop on success
+      if (get_ret_status() == 0) {
+        ldout(cct, 10) << "push to " << zone << " succeeded" << dendl;
+        return set_cr_done();
+      }
+
+      // try each endpoint in the connection before waiting
+      if (++counter < conn->get_endpoint_count())
+        continue;
+      counter = 0;
+
+      // wait with exponential backoff up to timeout_max
+      yield {
+        utime_t dur;
+        dur.set_from_double(timeout);
+
+        ldout(cct, 10) << "waiting " << dur << "s for retry.." << dendl;
+        wait(dur);
+
+        timeout *= 2;
+        if (timeout > timeout_max)
+          timeout = timeout_max;
+      }
+    }
+  }
+  return 0;
+}
+
+/**
+ * PushAllCR is a coroutine that sends the period over all of the given
+ * connections, retrying until they are all marked as completed.
+ */
+class PushAllCR : public RGWCoroutine {
+  RGWHTTPManager *const http;
+  RGWPeriod period; //< period object to push
+  std::map<std::string, RGWRESTConn> conns; //< zones that need the period
+
+ public:
+  PushAllCR(CephContext* cct, RGWHTTPManager* http, RGWPeriod&& period,
+            std::map<std::string, RGWRESTConn>&& conns)
+    : RGWCoroutine(cct), http(http),
+      period(std::move(period)),
+      conns(std::move(conns))
+  {}
+
+  int operate() override;
+};
+
+int PushAllCR::operate()
+{
+  reenter(this) {
+    // spawn a coroutine to push the period over each connection
+    yield {
+      ldout(cct, 4) << "sending " << conns.size() << " periods" << dendl;
+      for (auto& c : conns)
+        spawn(new PushAndRetryCR(cct, c.first, &c.second, http, period), false);
+    }
+    // wait for all to complete
+    drain_all();
+    return set_cr_done();
+  }
+  return 0;
+}
+
+/// A background thread to run the PushAllCR coroutine and exit.
+class RGWPeriodPusher::CRThread {
+  RGWCoroutinesManager coroutines;
+  RGWHTTPManager http;
+  boost::intrusive_ptr<PushAllCR> push_all;
+  std::thread thread;
+
+ public:
+  CRThread(CephContext* cct, RGWPeriod&& period,
+           std::map<std::string, RGWRESTConn>&& conns)
+    : coroutines(cct),
+      http(cct, coroutines.get_completion_mgr()),
+      push_all(new PushAllCR(cct, &http, std::move(period), std::move(conns))),
+      thread([this] { coroutines.run(push_all.get()); })
+  {
+    http.set_threaded();
+  }
+  ~CRThread()
+  {
+    push_all.reset();
+    coroutines.stop();
+    if (thread.joinable())
+      thread.join();
+  }
+};
+
+
+RGWPeriodPusher::RGWPeriodPusher(RGWRados* store)
+  : cct(store->ctx()), store(store)
+{}
+
+// destructor is here because CRThread is incomplete in the header
+RGWPeriodPusher::~RGWPeriodPusher() = default;
+
+void RGWPeriodPusher::handle_notify(RGWRealmNotify type,
+                                    bufferlist::iterator& p)
+{
+  // decode the period
+  RGWZonesNeedPeriod info;
+  try {
+    ::decode(info, p);
+  } catch (buffer::error& e) {
+    derr(cct) << "Failed to decode the period: " << e.what() << dendl;
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex);
+
+  // we can't process this notification without access to our current realm
+  // configuration. queue it until resume()
+  if (store == nullptr) {
+    pending_periods.emplace_back(std::move(info));
+    return;
+  }
+
+  handle_notify(std::move(info));
+}
+
+// expects the caller to hold a lock on mutex
+void RGWPeriodPusher::handle_notify(RGWZonesNeedPeriod&& period)
+{
+  if (period.get_id() != period_id) {
+    // new period must follow current period
+    if (period.get_predecessor() != period_id) {
+      ldout(cct, 10) << "current period " << period_id << " is not period "
+          << period.get_id() << "'s predecessor" << dendl;
+      return;
+    }
+  } else if (period.get_epoch() <= period_epoch) {
+    ldout(cct, 10) << "period epoch " << period.get_epoch() << " is not newer "
+        "than current epoch " << period_epoch << ", discarding update" << dendl;
+    return;
+  }
+
+  // find our zonegroup in the new period
+  auto& zonegroups = period.get_map().zonegroups;
+  auto i = zonegroups.find(store->get_zonegroup().get_id());
+  if (i == zonegroups.end()) {
+    lderr(cct) << "The new period does not contain my zonegroup!" << dendl;
+    return;
+  }
+  auto& my_zonegroup = i->second;
+
+  // if we're not a master zone, we're not responsible for pushing any updates
+  if (my_zonegroup.master_zone != store->get_zone_params().get_id())
+    return;
+
+  // construct a map of the zones that need this period. the map uses the same
+  // keys/ordering as the zone[group] map, so we can use a hint for insertions
+  std::map<std::string, RGWRESTConn> conns;
+  auto hint = conns.end();
+
+  // are we the master zonegroup in this period?
+  if (period.get_map().master_zonegroup == store->get_zonegroup().get_id()) {
+    // update other zonegroup endpoints
+    for (auto& zg : zonegroups) {
+      auto& zonegroup = zg.second;
+      if (zonegroup.get_id() == store->get_zonegroup().get_id())
+        continue;
+      if (zonegroup.endpoints.empty())
+        continue;
+
+      hint = conns.emplace_hint(
+          hint, std::piecewise_construct,
+          std::forward_as_tuple(zonegroup.get_id()),
+          std::forward_as_tuple(cct, store, zonegroup.endpoints));
+    }
+  }
+
+  // update other zone endpoints
+  for (auto& z : my_zonegroup.zones) {
+    auto& zone = z.second;
+    if (zone.id == store->get_zone_params().get_id())
+      continue;
+    if (zone.endpoints.empty())
+      continue;
+
+    hint = conns.emplace_hint(
+        hint, std::piecewise_construct,
+        std::forward_as_tuple(zone.id),
+        std::forward_as_tuple(cct, store, zone.endpoints));
+  }
+
+  if (conns.empty()) {
+    ldout(cct, 4) << "No zones to update" << dendl;
+    return;
+  }
+
+  period_id = period.get_id();
+  period_epoch = period.get_epoch();
+
+  ldout(cct, 4) << "Zone master pushing period " << period_id
+      << " epoch " << period_epoch << " to "
+      << conns.size() << " other zones" << dendl;
+
+  // spawn a new coroutine thread, destroying the previous one
+  cr_thread.reset(new CRThread(cct, std::move(period), std::move(conns)));
+}
+
+void RGWPeriodPusher::pause()
+{
+  ldout(cct, 4) << "paused for realm update" << dendl;
+  std::lock_guard<std::mutex> lock(mutex);
+  store = nullptr;
+}
+
+void RGWPeriodPusher::resume(RGWRados* store)
+{
+  std::lock_guard<std::mutex> lock(mutex);
+  this->store = store;
+
+  ldout(cct, 4) << "resume with " << pending_periods.size()
+      << " periods pending" << dendl;
+
+  // process notification queue
+  for (auto& info : pending_periods) {
+    handle_notify(std::move(info));
+  }
+  pending_periods.clear();
+}

--- a/src/rgw/rgw_period_pusher.h
+++ b/src/rgw/rgw_period_pusher.h
@@ -1,0 +1,56 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RGW_PERIOD_PUSHER_H
+#define RGW_PERIOD_PUSHER_H
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "rgw_realm_reloader.h"
+
+class RGWRados;
+class RGWPeriod;
+
+// RGWRealmNotify payload for push coordination
+using RGWZonesNeedPeriod = RGWPeriod;
+
+/**
+ * RGWPeriodPusher coordinates with other nodes via the realm watcher to manage
+ * the responsibility for pushing period updates to other zones or zonegroups.
+ */
+class RGWPeriodPusher final : public RGWRealmWatcher::Watcher,
+                              public RGWRealmReloader::Pauser {
+ public:
+  RGWPeriodPusher(RGWRados* store);
+  ~RGWPeriodPusher();
+
+  /// respond to realm notifications by pushing new periods to other zones
+  void handle_notify(RGWRealmNotify type, bufferlist::iterator& p) override;
+
+  /// avoid accessing RGWRados while dynamic reconfiguration is in progress.
+  /// notifications will be enqueued until resume()
+  void pause() override;
+
+  /// continue processing notifications with a new RGWRados instance
+  void resume(RGWRados* store) override;
+
+ private:
+  void handle_notify(RGWZonesNeedPeriod&& period);
+
+  CephContext *const cct;
+  RGWRados* store;
+
+  std::mutex mutex;
+  std::string period_id; //< the current period id being sent
+  epoch_t period_epoch; //< the current period epoch being sent
+
+  /// while paused for reconfiguration, we need to queue up notifications
+  std::vector<RGWZonesNeedPeriod> pending_periods;
+
+  class CRThread; //< contains thread, coroutine manager, http manager
+  std::unique_ptr<CRThread> cr_thread; //< thread to run the push coroutines
+};
+
+#endif // RGW_PERIOD_PUSHER_H

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1089,7 +1089,7 @@ int RGWPeriod::update()
     return ret;
   }
 
-  for (auto iter : zonegroups) {
+  for (auto& iter : zonegroups) {
     RGWZoneGroup zg(string(), iter);
     ret = zg.init(cct, store);
     if (ret < 0) {
@@ -1098,7 +1098,7 @@ int RGWPeriod::update()
     }
 
     if (zg.realm_id != realm_id) {
-      ldout(cct, 20) << "skippinh zonegroup " << zg.get_name() << ", not on our realm" << dendl;
+      ldout(cct, 20) << "skipping zonegroup " << zg.get_name() << ", not on our realm" << dendl;
       continue;
     }
     

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -792,6 +792,10 @@ int RGWRealm::notify_zone()
   return 0;
 }
 
+int RGWRealm::notify_new_period(const RGWPeriod& period)
+{
+  return notify_zone();
+}
 
 int RGWPeriod::init(CephContext *_cct, RGWRados *_store, const string& period_realm_id,
 		    const string& period_realm_name, bool setup_obj)
@@ -1209,7 +1213,7 @@ int RGWPeriod::commit(RGWRealm& realm, const RGWPeriod& current_period)
     }
     ldout(cct, 4) << "Promoted to master zone and committed new period "
         << id << dendl;
-    realm.notify_zone();
+    realm.notify_new_period(*this);
     return 0;
   }
   // period must be based on predecessor's current epoch
@@ -1236,7 +1240,7 @@ int RGWPeriod::commit(RGWRealm& realm, const RGWPeriod& current_period)
   }
   ldout(cct, 4) << "Committed new epoch " << epoch
       << " for period " << id << dendl;
-  realm.notify_zone();
+  realm.notify_new_period(*this);
   return 0;
 }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -795,6 +795,9 @@ int RGWRealm::notify_zone(bufferlist& bl)
 int RGWRealm::notify_new_period(const RGWPeriod& period)
 {
   bufferlist bl;
+  // push the period to dependent zonegroups/zones
+  ::encode(RGWRealmNotify::ZonesNeedPeriod, bl);
+  ::encode(period, bl);
   // reload the gateway with the new period
   ::encode(RGWRealmNotify::Reload, bl);
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1297,7 +1297,7 @@ public:
 
   string get_control_oid();
   /// send a notify on the realm control object
-  int notify_zone();
+  int notify_zone(bufferlist& bl);
   /// notify the zone of a new period
   int notify_new_period(const RGWPeriod& period);
 };

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1245,6 +1245,8 @@ struct objexp_hint_entry {
 };
 WRITE_CLASS_ENCODER(objexp_hint_entry)
 
+class RGWPeriod;
+
 class RGWRealm : public RGWSystemMetaObj
 {
   string master_zonegroup;
@@ -1294,7 +1296,10 @@ public:
   int set_current_period(const string& period_id);
 
   string get_control_oid();
+  /// send a notify on the realm control object
   int notify_zone();
+  /// notify the zone of a new period
+  int notify_new_period(const RGWPeriod& period);
 };
 WRITE_CLASS_ENCODER(RGWRealm)
 

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -21,7 +21,7 @@
 static constexpr bool USE_SAFE_TIMER_CALLBACKS = false;
 
 
-RGWRealmReloader::RGWRealmReloader(RGWRados*& store, FrontendPauser* frontends)
+RGWRealmReloader::RGWRealmReloader(RGWRados*& store, Pauser* frontends)
   : store(store),
     frontends(frontends),
     timer(store->ctx(), mutex, USE_SAFE_TIMER_CALLBACKS),

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -1,0 +1,142 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "rgw_realm_reloader.h"
+#include "rgw_rados.h"
+
+#include "rgw_bucket.h"
+#include "rgw_log.h"
+#include "rgw_rest.h"
+#include "rgw_user.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+#undef dout_prefix
+#define dout_prefix (*_dout << "rgw realm reloader: ")
+
+
+// safe callbacks from SafeTimer are unneccessary. reload() can take a long
+// time, so we don't want to hold the mutex and block handle_notify() for the
+// duration
+static constexpr bool USE_SAFE_TIMER_CALLBACKS = false;
+
+
+RGWRealmReloader::RGWRealmReloader(RGWRados*& store, FrontendPauser* frontends)
+  : store(store),
+    frontends(frontends),
+    timer(store->ctx(), mutex, USE_SAFE_TIMER_CALLBACKS),
+    mutex("RGWRealmReloader"),
+    reload_scheduled(nullptr)
+{
+  timer.init();
+}
+
+RGWRealmReloader::~RGWRealmReloader()
+{
+  Mutex::Locker lock(mutex);
+  timer.shutdown();
+}
+
+class RGWRealmReloader::C_Reload : public Context {
+  RGWRealmReloader* reloader;
+ public:
+  C_Reload(RGWRealmReloader* reloader) : reloader(reloader) {}
+  void finish(int r) { reloader->reload(); }
+};
+
+void RGWRealmReloader::handle_notify(bufferlist::iterator& p)
+{
+  CephContext *const cct = store->ctx();
+
+  Mutex::Locker lock(mutex);
+  if (reload_scheduled) {
+    ldout(cct, 4) << "Notification on realm, reconfiguration "
+        "already scheduled" << dendl;
+    return;
+  }
+
+  reload_scheduled = new C_Reload(this);
+  cond.SignalOne(); // wake reload() if it blocked on a bad configuration
+
+  // schedule reload() with a delay so we can batch up changes
+  auto delay = cct->_conf->rgw_realm_reconfigure_delay;
+  timer.add_event_after(delay, reload_scheduled);
+
+  ldout(cct, 4) << "Notification on realm, reconfiguration scheduled in "
+      << delay << 's' << dendl;
+}
+
+void RGWRealmReloader::reload()
+{
+  CephContext *const cct = store->ctx();
+  ldout(cct, 1) << "Pausing frontends for realm update..." << dendl;
+
+  frontends->pause();
+
+  // destroy the existing store
+  RGWStoreManager::close_storage(store);
+  store = nullptr;
+
+  {
+    // allow a new notify to reschedule us. it's important that we do this
+    // before we start loading the new realm, or we could miss some updates
+    Mutex::Locker lock(mutex);
+    reload_scheduled = nullptr;
+  }
+
+  while (!store) {
+    // recreate and initialize a new store
+    store = RGWStoreManager::get_storage(cct,
+                                         cct->_conf->rgw_enable_gc_threads,
+                                         cct->_conf->rgw_enable_quota_threads,
+                                         cct->_conf->rgw_run_sync_thread);
+
+    RGWRados* store_cleanup = nullptr;
+    {
+      Mutex::Locker lock(mutex);
+
+      // failure to recreate RGWRados is not a recoverable error, but we
+      // don't want to assert or abort the entire cluster.  instead, just
+      // sleep until we get another notification, and retry until we get
+      // a working configuration
+      if (store == nullptr) {
+        lderr(cct) << "Failed to reinitialize RGWRados after a realm "
+            "configuration update. Waiting for a new update." << dendl;
+
+        // sleep until another event is scheduled
+        while (!reload_scheduled)
+          cond.Wait(mutex);
+
+        ldout(cct, 1) << "Woke up with a new configuration, retrying "
+            "RGWRados initialization." << dendl;
+      }
+
+      if (reload_scheduled) {
+        // cancel the event; we'll handle it now
+        timer.cancel_event(reload_scheduled);
+        reload_scheduled = nullptr;
+
+        // if we successfully created a store, clean it up outside of the lock,
+        // then continue to loop and recreate another
+        std::swap(store, store_cleanup);
+      }
+    }
+
+    if (store_cleanup) {
+      ldout(cct, 4) << "Got another notification, restarting RGWRados "
+          "initialization." << dendl;
+
+      RGWStoreManager::close_storage(store_cleanup);
+    }
+  }
+
+  // finish initializing the new store
+  rgw_rest_init(cct, store->get_zonegroup());
+  rgw_user_init(store);
+  rgw_bucket_init(store->meta_mgr);
+  rgw_log_usage_init(cct, store);
+
+  ldout(cct, 1) << "Resuming frontends with new realm configuration." << dendl;
+
+  frontends->resume(store);
+}

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -44,7 +44,8 @@ class RGWRealmReloader::C_Reload : public Context {
   void finish(int r) { reloader->reload(); }
 };
 
-void RGWRealmReloader::handle_notify(bufferlist::iterator& p)
+void RGWRealmReloader::handle_notify(RGWRealmNotify type,
+                                     bufferlist::iterator& p)
 {
   CephContext *const cct = store->ctx();
 

--- a/src/rgw/rgw_realm_reloader.h
+++ b/src/rgw/rgw_realm_reloader.h
@@ -16,16 +16,16 @@ class RGWRados;
 class RGWRealmReloader : public RGWRealmWatcher::Watcher {
  public:
   /**
-   * FrontendPauser is an interface to pause/resume frontends. Frontend
-   * cooperation is required to ensure that they stop issuing requests on the
-   * old RGWRados instance, and restart with the updated configuration.
+   * Pauser is an interface to pause/resume frontends. Frontend cooperation
+   * is required to ensure that they stop issuing requests on the old
+   * RGWRados instance, and restart with the updated configuration.
    *
    * This abstraction avoids a depency on class RGWFrontend, which is only
    * defined in rgw_main.cc
    */
-  class FrontendPauser {
+  class Pauser {
    public:
-    virtual ~FrontendPauser() = default;
+    virtual ~Pauser() = default;
 
     /// pause all frontends while realm reconfiguration is in progress
     virtual void pause() = 0;
@@ -33,7 +33,7 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
     virtual void resume(RGWRados* store) = 0;
   };
 
-  RGWRealmReloader(RGWRados*& store, FrontendPauser* frontends);
+  RGWRealmReloader(RGWRados*& store, Pauser* frontends);
   ~RGWRealmReloader();
 
   /// respond to realm notifications by scheduling a reload()
@@ -47,7 +47,7 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
 
   /// main()'s RGWRados pointer as a reference, modified by reload()
   RGWRados*& store;
-  FrontendPauser *const frontends;
+  Pauser *const frontends;
 
   /// reload() takes a significant amount of time, so we don't want to run
   /// it in the handle_notify() thread. we choose a timer thread because we

--- a/src/rgw/rgw_realm_reloader.h
+++ b/src/rgw/rgw_realm_reloader.h
@@ -1,0 +1,62 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RGW_REALM_RELOADER_H
+#define RGW_REALM_RELOADER_H
+
+#include "rgw_realm_watcher.h"
+#include "common/Cond.h"
+
+class RGWRados;
+
+/**
+ * RGWRealmReloader responds to notifications by recreating RGWRados with the
+ * updated realm configuration.
+ */
+class RGWRealmReloader : public RGWRealmWatcher::Watcher {
+ public:
+  /**
+   * FrontendPauser is an interface to pause/resume frontends. Frontend
+   * cooperation is required to ensure that they stop issuing requests on the
+   * old RGWRados instance, and restart with the updated configuration.
+   *
+   * This abstraction avoids a depency on class RGWFrontend, which is only
+   * defined in rgw_main.cc
+   */
+  class FrontendPauser {
+   public:
+    virtual ~FrontendPauser() = default;
+
+    /// pause all frontends while realm reconfiguration is in progress
+    virtual void pause() = 0;
+    /// resume all frontends with the given RGWRados instance
+    virtual void resume(RGWRados* store) = 0;
+  };
+
+  RGWRealmReloader(RGWRados*& store, FrontendPauser* frontends);
+  ~RGWRealmReloader();
+
+  /// respond to realm notifications by scheduling a reload()
+  void handle_notify(bufferlist::iterator& p) override;
+
+ private:
+  /// pause frontends and replace the RGWRados instance
+  void reload();
+
+  class C_Reload; //< Context that calls reload()
+
+  /// main()'s RGWRados pointer as a reference, modified by reload()
+  RGWRados*& store;
+  FrontendPauser *const frontends;
+
+  /// reload() takes a significant amount of time, so we don't want to run
+  /// it in the handle_notify() thread. we choose a timer thread because we
+  /// also want to add a delay (see rgw_realm_reconfigure_delay) so that we
+  /// can batch up notifications within that window
+  SafeTimer timer;
+  Mutex mutex; //< protects access to timer and reload_scheduled
+  Cond cond; //< to signal reload() after an invalid realm config
+  C_Reload* reload_scheduled; //< reload() context if scheduled
+};
+
+#endif // RGW_REALM_RELOADER_H

--- a/src/rgw/rgw_realm_reloader.h
+++ b/src/rgw/rgw_realm_reloader.h
@@ -37,7 +37,7 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
   ~RGWRealmReloader();
 
   /// respond to realm notifications by scheduling a reload()
-  void handle_notify(bufferlist::iterator& p) override;
+  void handle_notify(RGWRealmNotify type, bufferlist::iterator& p) override;
 
  private:
   /// pause frontends and replace the RGWRados instance

--- a/src/rgw/rgw_realm_watcher.cc
+++ b/src/rgw/rgw_realm_watcher.cc
@@ -1,17 +1,10 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <system_error>
-
 #include "common/errno.h"
 
 #include "rgw_realm_watcher.h"
 #include "rgw_rados.h"
-
-#include "rgw_bucket.h"
-#include "rgw_log.h"
-#include "rgw_rest.h"
-#include "rgw_user.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -19,128 +12,33 @@
 #define dout_prefix (*_dout << "rgw realm watcher: ")
 
 
-// safe callbacks from SafeTimer are unneccessary. reconfigure() can take a long
-// time, so we don't want to hold the mutex and block handle_notify() for the
-// duration
-static constexpr bool USE_SAFE_TIMER_CALLBACKS = false;
-
-
-RGWRealmWatcher::RGWRealmWatcher(CephContext *cct, RGWRados *&store,
-                                 FrontendPauser *frontends)
-  : cct(cct),
-    store(store),
-    frontends(frontends),
-    timer(cct, mutex, USE_SAFE_TIMER_CALLBACKS),
-    mutex("RGWRealmWatcher"),
-    reconfigure_scheduled(nullptr)
+RGWRealmWatcher::RGWRealmWatcher(CephContext* cct, RGWRealm& realm)
+  : cct(cct), watcher(nullptr)
 {
   // no default realm, nothing to watch
-  if (store->realm.get_id().empty()) {
+  if (realm.get_id().empty()) {
     ldout(cct, 4) << "No realm, disabling dynamic reconfiguration." << dendl;
     return;
   }
 
   // establish the watch on RGWRealm
-  int r = watch_start();
+  int r = watch_start(realm);
   if (r < 0) {
     lderr(cct) << "Failed to establish a watch on RGWRealm, "
         "disabling dynamic reconfiguration." << dendl;
     return;
   }
-
-  timer.init();
 }
 
 RGWRealmWatcher::~RGWRealmWatcher()
 {
   watch_stop();
-
-  Mutex::Locker lock(mutex);
-  timer.shutdown();
 }
 
-
-void RGWRealmWatcher::reconfigure()
+void RGWRealmWatcher::set_watcher(Watcher* watcher)
 {
-  ldout(cct, 1) << "Pausing frontends for realm update..." << dendl;
-
-  frontends->pause();
-
-  // destroy the existing store
-  RGWStoreManager::close_storage(store);
-  store = nullptr;
-
-  {
-    // allow a new notify to reschedule us. it's important that we do this
-    // before we start loading the new realm, or we could miss some updates
-    Mutex::Locker lock(mutex);
-    reconfigure_scheduled = nullptr;
-  }
-
-  while (!store) {
-    // recreate and initialize a new store
-    store = RGWStoreManager::get_storage(cct,
-                                         cct->_conf->rgw_enable_gc_threads,
-                                         cct->_conf->rgw_enable_quota_threads,
-                                         cct->_conf->rgw_run_sync_thread);
-
-    RGWRados *store_cleanup = nullptr;
-    {
-      Mutex::Locker lock(mutex);
-
-      // failure to recreate RGWRados is not a recoverable error, but we
-      // don't want to assert or abort the entire cluster.  instead, just
-      // sleep until we get another notification, and retry until we get
-      // a working configuration
-      if (store == nullptr) {
-        lderr(cct) << "Failed to reinitialize RGWRados after a realm "
-            "configuration update. Waiting for a new update." << dendl;
-
-        // sleep until another event is scheduled
-        while (!reconfigure_scheduled)
-          cond.Wait(mutex);
-
-        ldout(cct, 1) << "Woke up with a new configuration, retrying "
-            "RGWRados initialization." << dendl;
-      }
-
-      if (reconfigure_scheduled) {
-        // cancel the event; we'll handle it now
-        timer.cancel_event(reconfigure_scheduled);
-        reconfigure_scheduled = nullptr;
-
-        // if we successfully created a store, clean it up outside of the lock,
-        // then continue to loop and recreate another
-        std::swap(store, store_cleanup);
-      }
-    }
-
-    if (store_cleanup) {
-      ldout(cct, 4) << "Got another notification, restarting RGWRados "
-          "initialization." << dendl;
-
-      RGWStoreManager::close_storage(store_cleanup);
-    }
-  }
-
-  // finish initializing the new store
-  rgw_rest_init(cct, store->get_zonegroup());
-  rgw_user_init(store);
-  rgw_bucket_init(store->meta_mgr);
-  rgw_log_usage_init(cct, store);
-
-  ldout(cct, 1) << "Resuming frontends with new realm configuration." << dendl;
-
-  frontends->resume(store);
+  this->watcher = watcher;
 }
-
-
-class RGWRealmWatcher::C_Reconfigure : public Context {
-  RGWRealmWatcher *watcher;
- public:
-  C_Reconfigure(RGWRealmWatcher *watcher) : watcher(watcher) {}
-  void finish(int r) { watcher->reconfigure(); }
-};
 
 void RGWRealmWatcher::handle_notify(uint64_t notify_id, uint64_t cookie,
                                     uint64_t notifier_id, bufferlist& bl)
@@ -148,26 +46,12 @@ void RGWRealmWatcher::handle_notify(uint64_t notify_id, uint64_t cookie,
   if (cookie != watch_handle)
     return;
 
+  auto p = bl.begin();
+  watcher->handle_notify(p);
+
   // send an empty notify ack
-  bufferlist reply_bl;
-  pool_ctx.notify_ack(watch_oid, notify_id, cookie, reply_bl);
-
-  Mutex::Locker lock(mutex);
-  if (reconfigure_scheduled) {
-    ldout(cct, 4) << "Notification on " << watch_oid << ", reconfiguration "
-        "already scheduled" << dendl;
-    return;
-  }
-
-  reconfigure_scheduled = new C_Reconfigure(this);
-  cond.SignalOne(); // wake reconfigure() if it blocked on a bad configuration
-
-  // schedule reconfigure() with a delay so we can batch up changes
-  auto delay = cct->_conf->rgw_realm_reconfigure_delay;
-  timer.add_event_after(delay, reconfigure_scheduled);
-
-  ldout(cct, 4) << "Notification on " << watch_oid << ", reconfiguration "
-      "scheduled in " << delay << 's' << dendl;
+  bufferlist reply;
+  pool_ctx.notify_ack(watch_oid, notify_id, cookie, reply);
 }
 
 void RGWRealmWatcher::handle_error(uint64_t cookie, int err)
@@ -181,8 +65,7 @@ void RGWRealmWatcher::handle_error(uint64_t cookie, int err)
   }
 }
 
-
-int RGWRealmWatcher::watch_start()
+int RGWRealmWatcher::watch_start(RGWRealm& realm)
 {
   // initialize a Rados client
   int r = rados.init_with_context(cct);
@@ -199,7 +82,6 @@ int RGWRealmWatcher::watch_start()
   }
 
   // open an IoCtx for the realm's pool
-  auto& realm = store->realm;
   auto pool = realm.get_pool_name(cct);
   r = rados.ioctx_create(pool.c_str(), pool_ctx);
   if (r < 0) {

--- a/src/rgw/rgw_realm_watcher.h
+++ b/src/rgw/rgw_realm_watcher.h
@@ -71,7 +71,7 @@ class RGWRealmWatcher : public librados::WatchCtx2 {
   SafeTimer timer;
   Mutex mutex; //< protects access to timer and reconfigure_scheduled
   Cond cond; //< to signal reconfigure() after an invalid realm config
-  bool reconfigure_scheduled; //< true if reconfigure() is scheduled in timer
+  Context *reconfigure_scheduled; //< reconfigure() context if scheduled
 
   /// pause frontends and replace the RGWRados
   void reconfigure();

--- a/src/rgw/rgw_realm_watcher.h
+++ b/src/rgw/rgw_realm_watcher.h
@@ -14,6 +14,7 @@ class RGWRealm;
 
 enum class RGWRealmNotify {
   Reload,
+  ZonesNeedPeriod,
 };
 WRITE_RAW_ENCODER(RGWRealmNotify);
 

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -76,6 +76,7 @@ public:
   CephContext *get_ctx() {
     return cct;
   }
+  size_t get_endpoint_count() const { return endpoints.size(); }
 
   /* sync request */
   int forward(const string& uid, req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl);

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -148,7 +148,7 @@ void RGWOp_Period_Post::execute()
     ldout(cct, 4) << "current period " << current_period.get_id()
         << " is period " << period.get_id() << "'s predecessor, "
         "updating current period and notifying zone" << dendl;
-    realm.notify_zone();
+    realm.notify_new_period(period);
     return;
   }
 
@@ -175,7 +175,7 @@ void RGWOp_Period_Post::execute()
   ldout(cct, 4) << "period epoch " << period.get_epoch()
       << " is newer than current epoch " << current_period.get_epoch()
       << ", updating latest epoch and notifying zone" << dendl;
-  realm.notify_zone();
+  realm.notify_new_period(period);
 }
 
 class RGWHandler_Period : public RGWHandler_Auth_S3 {

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -156,7 +156,6 @@ void RGWOp_Period_Post::execute()
     lderr(cct) << "period epoch " << period.get_epoch() << " is not newer "
         "than current epoch " << current_period.get_epoch()
         << ", discarding update" << dendl;
-    http_ret = -EEXIST; // XXX: error code
     return;
   }
 


### PR DESCRIPTION
RGWPeriodPusher implements the RGWRealmWatcher interface to get notifications for new periods.  when it discovers that it needs to push a period to other zones, it spawns a thread to send them (and keep retrying) until all of those zones successfully acknowledge the period