### PR TITLE
osd: don't update epoch and rollback_info if no need

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2791,7 +2791,7 @@ void PG::write_if_dirty(ObjectStore::Transaction& t)
   map<string,bufferlist> km;
   if (dirty_big_info || dirty_info)
     prepare_write_info(&km);
-  pg_log.write_log(t, &km, coll, pgmeta_oid);
+  pg_log.write_log(t, &km, coll, pgmeta_oid, pool.info.require_rollback());
   if (!km.empty())
     t.omap_setkeys(coll, pgmeta_oid, km);
 }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -218,7 +218,8 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   peer_features(CEPH_FEATURES_SUPPORTED_DEFAULT),
   acting_features(CEPH_FEATURES_SUPPORTED_DEFAULT),
   upacting_features(CEPH_FEATURES_SUPPORTED_DEFAULT),
-  do_sort_bitwise(false)
+  do_sort_bitwise(false),
+  last_epoch(0)
 {
 #ifdef PG_DEBUG_REFS
   osd->add_pgid(p, this);
@@ -2657,11 +2658,13 @@ int PG::_prepare_write_info(map<string,bufferlist> *km,
 			    pg_info_t &info, coll_t coll,
 			    map<epoch_t,pg_interval_t> &past_intervals,
 			    ghobject_t &pgmeta_oid,
-			    bool dirty_big_info)
+			    bool dirty_big_info,
+			    bool dirty_epoch)
 {
   // info.  store purged_snaps separately.
   interval_set<snapid_t> purged_snaps;
-  ::encode(epoch, (*km)[epoch_key]);
+  if (dirty_epoch)
+    ::encode(epoch, (*km)[epoch_key]);
   purged_snaps.swap(info.purged_snaps);
   ::encode(info, (*km)[info_key]);
   purged_snaps.swap(info.purged_snaps);
@@ -2711,10 +2714,13 @@ void PG::prepare_write_info(map<string,bufferlist> *km)
   info.stats.stats.add(unstable_stats);
   unstable_stats.clear();
 
+  bool need_update_epoch = last_epoch < get_osdmap()->get_epoch();
   int ret = _prepare_write_info(km, get_osdmap()->get_epoch(), info, coll,
 				past_intervals, pgmeta_oid,
-				dirty_big_info);
+				dirty_big_info, need_update_epoch);
   assert(ret == 0);
+  if (need_update_epoch)
+    last_epoch = get_osdmap()->get_epoch();
   last_persisted_osdmap_ref = osdmap_ref;
 
   dirty_info = false;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2043,6 +2043,7 @@ public:
   uint64_t upacting_features;
 
   bool do_sort_bitwise;
+  epoch_t last_epoch;
 
  public:
   const spg_t&      get_pgid() const { return pg_id; }
@@ -2161,7 +2162,8 @@ public:
     pg_info_t &info, coll_t coll,
     map<epoch_t,pg_interval_t> &past_intervals,
     ghobject_t &pgmeta_oid,
-    bool dirty_big_info);
+    bool dirty_big_info,
+    bool dirty_epoch);
   void write_if_dirty(ObjectStore::Transaction& t);
 
   eversion_t get_next_version() const {

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -646,14 +646,16 @@ public:
   void write_log(ObjectStore::Transaction& t,
 		 map<string,bufferlist> *km,
 		 const coll_t& coll,
-		 const ghobject_t &log_oid);
+		 const ghobject_t &log_oid,
+		 bool require_rollback);
 
   static void write_log(
     ObjectStore::Transaction& t,
     map<string,bufferlist>* km,
     pg_log_t &log,
     const coll_t& coll,
-    const ghobject_t &log_oid, map<eversion_t, hobject_t> &divergent_priors);
+    const ghobject_t &log_oid, map<eversion_t, hobject_t> &divergent_priors,
+    bool require_rollback);
 
   static void _write_log(
     ObjectStore::Transaction& t,
@@ -667,6 +669,7 @@ public:
     const set<eversion_t> &trimmed,
     bool dirty_divergent_priors,
     bool touch_log,
+    bool require_rollback,
     set<string> *log_keys_debug
     );
 

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -545,7 +545,7 @@ int write_pg(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
     return ret;
   coll_t coll(info.pgid);
   map<string,bufferlist> km;
-  PGLog::write_log(t, &km, log, coll, info.pgid.make_pgmeta_oid(), divergent_priors);
+  PGLog::write_log(t, &km, log, coll, info.pgid.make_pgmeta_oid(), divergent_priors, true);
   t.omap_setkeys(coll, info.pgid.make_pgmeta_oid(), km);
   return 0;
 }

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -530,7 +530,7 @@ int write_info(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
     info, coll,
     past_intervals,
     pgmeta_oid,
-    true);
+    true, true);
   if (ret) cerr << "Failed to write info" << std::endl;
   t.omap_setkeys(coll, pgmeta_oid, km);
   return ret;


### PR DESCRIPTION
there is no need to update epoch if no change, also rollback_info is just needed for ecpool, skip it when using replicated pool

Signed-off-by: Ning Yao <zay11022@gmail.com>