### PR TITLE
os/FileStore: clean up code for lfn_open.

### DIFF
--- a/src/os/FDCache.h
+++ b/src/os/FDCache.h
@@ -77,7 +77,7 @@ public:
     return registry[registry_id].lookup(hoid);
   }
 
-  FDRef add(const ghobject_t &hoid, int fd, bool *existed) {
+  FDRef add(const ghobject_t &hoid, int fd, bool *existed = NULL) {
     int registry_id = hoid.hobj.get_hash() % registry_shards;
     return registry[registry_id].add(hoid, new FD(fd), existed);
   }

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -311,11 +311,8 @@ int FileStore::lfn_open(coll_t cid,
   }
 
   if (!replaying) {
-    bool existed;
-    *outfd = fdcache.add(oid, fd, &existed);
-    if (existed) {
-      TEMP_FAILURE_RETRY(::close(fd));
-    }
+    assert(((*index).index)->access_lock.is_wlocked());
+    *outfd = fdcache.add(oid, fd);
   } else {
     *outfd = FDRef(new FDCache::FD(fd));
   }


### PR DESCRIPTION
We already get wlock of index, so there is no chance find fd in fdcache.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>