### PR TITLE
rgw: Do not send a Content-Length header on status 204

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -46,18 +46,15 @@ int RGWMongoose::complete_request()
   if (!sent_header) {
     if (!has_content_length) {
 
+      header_done = false; /* let's go back to writing the header */
+
       /*
        * Status 204 should not include a content-length header
        * RFC7230 says so
        */
       if (status_num == 204) {
-          header_done = true;
-          return 0;
-      }
-
-      header_done = false; /* let's go back to writing the header */
-
-      if (0 && data.length() == 0) {
+        has_content_length = true;
+      } else if (0 && data.length() == 0) {
         has_content_length = true;
         print("Transfer-Enconding: %s\r\n", "chunked");
         data.append("0\r\n\r\n", sizeof("0\r\n\r\n")-1);

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -45,6 +45,16 @@ int RGWMongoose::complete_request()
 {
   if (!sent_header) {
     if (!has_content_length) {
+
+      /*
+       * Status 204 should not include a content-length header
+       * RFC7230 says so
+       */
+      if (status_num == 204) {
+          header_done = true;
+          return 0;
+      }
+
       header_done = false; /* let's go back to writing the header */
 
       if (0 && data.length() == 0) {
@@ -114,7 +124,7 @@ void RGWMongoose::init_env(CephContext *cct)
       *dest = c;
     }
     *dest = '\0';
-    
+
     env.set(buf, header->value);
   }
 
@@ -150,7 +160,7 @@ int RGWMongoose::send_status(const char *status, const char *status_name)
   bl.append(header_data);
   header_data = bl;
 
-  int status_num = atoi(status);
+  status_num = atoi(status);
   mg_set_http_status(conn, status_num);
 
   return 0;

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -82,6 +82,8 @@ void RGWMongoose::init_env(CephContext *cct)
 {
   env.init(cct);
   struct mg_request_info *info = mg_get_request_info(conn);
+  status_num = 0;
+
   if (!info)
     return;
 

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -19,6 +19,7 @@ class RGWMongoose : public RGWClientIO
   bufferlist data;
 
   int port;
+  int status_num;
 
   bool header_done;
   bool sent_header;

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -19,7 +19,7 @@ class RGWMongoose : public RGWClientIO
   bufferlist data;
 
   int port;
-  int status_num = 0;
+  int status_num;
 
   bool header_done;
   bool sent_header;

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -19,7 +19,7 @@ class RGWMongoose : public RGWClientIO
   bufferlist data;
 
   int port;
-  int status_num;
+  int status_num = 0;
 
   bool header_done;
   bool sent_header;

--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -33,7 +33,7 @@ void RGWFCGX::init_env(CephContext *cct)
 
 int RGWFCGX::send_status(const char *status, const char *status_name)
 {
-  status_num = atoi(status_name);
+  status_num = atoi(status);
   return print("Status: %s %s\r\n", status, status_name);
 }
 

--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -33,6 +33,7 @@ void RGWFCGX::init_env(CephContext *cct)
 
 int RGWFCGX::send_status(const char *status, const char *status_name)
 {
+  status_num = atoi(status_name);
   return print("Status: %s %s\r\n", status, status_name);
 }
 
@@ -47,6 +48,13 @@ int RGWFCGX::send_100_continue()
 
 int RGWFCGX::send_content_length(uint64_t len)
 {
+  /*
+   * Status 204 should not include a content-length header
+   * RFC7230 says so
+   */
+  if (status_num == 204)
+    return 0;
+
   char buf[21];
   snprintf(buf, sizeof(buf), "%" PRIu64, len);
   return print("Content-Length: %s\r\n", buf);
@@ -56,4 +64,3 @@ int RGWFCGX::complete_header()
 {
   return print("\r\n");
 }
-

--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -29,6 +29,7 @@ void RGWFCGX::flush()
 void RGWFCGX::init_env(CephContext *cct)
 {
   env.init(cct, (char **)fcgx->envp);
+  status_num = 0;
 }
 
 int RGWFCGX::send_status(const char *status, const char *status_name)

--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -13,6 +13,7 @@ struct FCGX_Request;
 class RGWFCGX : public RGWClientIO
 {
   FCGX_Request *fcgx;
+  int status_num;
 protected:
   void init_env(CephContext *cct);
   int write_data(const char *buf, int len);

--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -13,7 +13,9 @@ struct FCGX_Request;
 class RGWFCGX : public RGWClientIO
 {
   FCGX_Request *fcgx;
-  int status_num = 0;
+
+  int status_num;
+
 protected:
   void init_env(CephContext *cct);
   int write_data(const char *buf, int len);

--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -13,7 +13,7 @@ struct FCGX_Request;
 class RGWFCGX : public RGWClientIO
 {
   FCGX_Request *fcgx;
-  int status_num;
+  int status_num = 0;
 protected:
   void init_env(CephContext *cct);
   int write_data(const char *buf, int len);


### PR DESCRIPTION
RFC7230 says:
  A server MUST NOT send a Content-Length header field in any response with a
  status code of 1xx (Informational) or 204 (No Content).

Fixes: #13582