### PR TITLE
rgw: fix the condition of  authenticated user's permit check .

### DIFF
--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -82,7 +82,7 @@ int RGWAccessControlPolicy::get_perm(rgw_user& id, int perm_mask) {
   if ((perm & perm_mask) != perm_mask) {
     perm |= acl.get_group_perm(ACL_GROUP_ALL_USERS, perm_mask);
 
-    if (!compare_group_name(id.id, ACL_GROUP_ALL_USERS)) {
+    if (id.compare(RGW_USER_ANON_ID)) {
       /* this is not the anonymous user */
       perm |= acl.get_group_perm(ACL_GROUP_AUTHENTICATED_USERS, perm_mask);
     }


### PR DESCRIPTION
before fix:
put a bucket under one user with authenticated-read permit
$ ./s3curl.pl  http://myobs.com/mybucket --put --H "x-amz-acl: authenticated-read"
GET the bucket with anonymous user
$ curl http://myobs.com/mybucket -X GET
> successed!

after fix:
anonymous cant GET the authenticated-read bucket
other users who authenticated could GET it

Signed-off-by: Zengran Zhang <zhangzengran@h3c.com>