### PR TITLE
mon: fixes related to mondbstore->get() changes

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -527,7 +527,7 @@ int main(int argc, const char **argv)
 
   bufferlist magicbl;
   err = store->get(Monitor::MONITOR_NAME, "magic", magicbl);
-  if (!magicbl.length()) {
+  if (err || !magicbl.length()) {
     derr << "unable to read magic from mon data" << dendl;
     prefork.exit(1);
   }

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -98,11 +98,17 @@ void AuthMonitor::create_initial()
     KeyRing keyring;
     bufferlist bl;
     int ret = mon->store->get("mkfs", "keyring", bl);
-    assert(ret == 0);
-    bufferlist::iterator p = bl.begin();
-    ::decode(keyring, p);
+    // fail hard only if there's an error we're not expecting to see
+    assert((ret == 0) || (ret == -ENOENT));
+    
+    // try importing only if there's a key
+    if (ret == 0) {
+      KeyRing keyring;
+      bufferlist::iterator p = bl.begin();
 
-    import_keyring(keyring);
+      ::decode(keyring, p);
+      import_keyring(keyring);
+    }
   }
 
   max_global_id = MIN_GLOBAL_ID;

--- a/src/mon/ConfigKeyService.cc
+++ b/src/mon/ConfigKeyService.cc
@@ -39,9 +39,6 @@ const string ConfigKeyService::STORE_PREFIX = "mon_config_key";
 
 int ConfigKeyService::store_get(string key, bufferlist &bl)
 {
-  if (!store_exists(key))
-    return -ENOENT;
-
   return mon->store->get(STORE_PREFIX, key, bl);
 }
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -419,10 +419,9 @@ void Monitor::read_features_off_disk(MonitorDBStore *store, CompatSet *features)
     //be made smarter.
     *features = get_legacy_features();
 
-    bufferlist bl;
-    features->encode(bl);
+    features->encode(featuresbl);
     MonitorDBStore::TransactionRef t(new MonitorDBStore::Transaction);
-    t->put(MONITOR_NAME, COMPAT_SET_LOC, bl);
+    t->put(MONITOR_NAME, COMPAT_SET_LOC, featuresbl);
     store->apply_transaction(t);
   } else {
     bufferlist::iterator it = featuresbl.begin();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -674,11 +674,14 @@ int Monitor::preinit()
     if (authmon()->get_last_committed() == 0) {
       dout(10) << "loading initial keyring to bootstrap authentication for mkfs" << dendl;
       bufferlist bl;
-      store->get("mkfs", "keyring", bl);
-      KeyRing keyring;
-      bufferlist::iterator p = bl.begin();
-      ::decode(keyring, p);
-      extract_save_mon_key(keyring);
+      int err = store->get("mkfs", "keyring", bl);
+      if (err == 0 && bl.length() > 0) {
+        // Attempt to decode and extract keyring only if it is found.
+        KeyRing keyring;
+        bufferlist::iterator p = bl.begin();
+        ::decode(keyring, p);
+        extract_save_mon_key(keyring);
+      }
     }
 
     string keyring_loc = g_conf->mon_data + "/keyring";

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -507,16 +507,12 @@ class MonitorDBStore
   }
 
   int get(const string& prefix, const string& key, bufferlist& bl) {
-    set<string> k;
-    k.insert(key);
-    map<string,bufferlist> out;
-
-    db->get(prefix, k, &out);
-    if (out.empty())
-      return -ENOENT;
-    bl.append(out[key]);
-
-    return 0;
+    bufferlist outbl;
+    int r = db->get(prefix, key, &outbl);
+    if (!r) {
+      bl.append(outbl);
+    }
+    return r;
   }
 
   int get(const string& prefix, const version_t ver, bufferlist& bl) {


### PR DESCRIPTION
Mon, in general, was assuming that db store doesn't return errors when key
is not found, and when 66b7b920cf5a0a9c71212573ef47fb2c7ea9b5ff was
introduced, an assert was being triggered in AuthMonitor which turned out
to be wrong. This changeset fixes that and the following issues stemming
from that change:

 - assert() being triggered prematurely in sync_obtain_latest_monmap
 - no user-readable error message is outputted when load_metadata() fails
 - unnecessary key existence checks in ConfigKeyService::store_get and
   Monitor::check_fsid
 - attempts to decode keyring from empty bufferlist when store->get()
   doesn't find the key
 - Monitor::read_features_off_disk uses extra bufferlist, when the other one
   is already empty

This changeset also reverts d548b5fbb42c72b6430cc7eec2ca6500a693d720 which
is a revert of 66b7b920cf5a0a9c71212573ef47fb2c7ea9b5ff.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>