### PR TITLE
rbd: hardcode application name into help

### DIFF
--- a/src/tools/rbd/Shell.cc
+++ b/src/tools/rbd/Shell.cc
@@ -19,6 +19,7 @@ namespace po = boost::program_options;
 
 namespace {
 
+static const std::string APP_NAME("rbd");
 static const std::string HELP_SPEC("help");
 static const std::string BASH_COMPLETION_SPEC("bash-completion");
 
@@ -32,11 +33,6 @@ void validate(boost::any& v, const std::vector<std::string>& values,
   const std::string &s = po::validators::get_single_string(values);
   g_conf->set_val_or_die("keyfile", s.c_str());
   v = boost::any(s);
-}
-
-std::string base_name(const std::string &path,
-                      const std::string &delims = "/\\") {
-  return path.substr(path.find_last_of(delims) + 1);
 }
 
 std::string format_command_spec(const Shell::CommandSpec &spec) {
@@ -74,7 +70,6 @@ std::vector<Shell::Action *> Shell::s_actions;
 std::set<std::string> Shell::s_switch_arguments;
 
 int Shell::execute(int arg_count, const char **arg_values) {
-  std::string app_name(base_name(arg_values[0]));
 
   std::vector<std::string> arguments;
   prune_command_line_arguments(arg_count, arg_values, &arguments);
@@ -84,17 +79,17 @@ int Shell::execute(int arg_count, const char **arg_values) {
 
   if (command_spec.empty() || command_spec == CommandSpec({"help"})) {
     // list all available actions
-    print_help(app_name);
+    print_help();
     return 0;
   } else if (command_spec[0] == HELP_SPEC) {
     // list help for specific action
     command_spec.erase(command_spec.begin());
     Action *action = find_action(command_spec, NULL);
     if (action == NULL) {
-      print_unknown_action(app_name, command_spec);
+      print_unknown_action(command_spec);
       return EXIT_FAILURE;
     } else {
-      print_action_help(app_name, action);
+      print_action_help(action);
       return 0;
     }
   } else if (command_spec[0] == BASH_COMPLETION_SPEC) {
@@ -106,7 +101,7 @@ int Shell::execute(int arg_count, const char **arg_values) {
   CommandSpec *matching_spec;
   Action *action = find_action(command_spec, &matching_spec);
   if (action == NULL) {
-    print_unknown_action(app_name, command_spec);
+    print_unknown_action(command_spec);
     return EXIT_FAILURE;
   }
 
@@ -272,8 +267,8 @@ void Shell::prune_command_line_arguments(int arg_count, const char **arg_values,
   }
 }
 
-void Shell::print_help(const std::string &app_name) {
-  std::cout << "usage: " << app_name << " <command> ..."
+void Shell::print_help() {
+  std::cout << "usage: " << APP_NAME << " <command> ..."
             << std::endl << std::endl
             << "Command-line interface for managing Ceph RBD images."
             << std::endl << std::endl;
@@ -318,14 +313,14 @@ void Shell::print_help(const std::string &app_name) {
   po::options_description global_opts(OptionPrinter::OPTIONAL_ARGUMENTS);
   get_global_options(&global_opts);
   std::cout << std::endl << global_opts << std::endl
-            << "See '" << app_name << " help <command>' for help on a specific "
+            << "See '" << APP_NAME << " help <command>' for help on a specific "
             << "command." << std::endl;
 }
 
-void Shell::print_action_help(const std::string &app_name, Action *action) {
+void Shell::print_action_help(Action *action) {
 
   std::stringstream ss;
-  ss << "usage: " << app_name << " "
+  ss << "usage: " << APP_NAME << " "
      << format_command_spec(action->command_spec);
   std::cout << ss.str();
 
@@ -348,13 +343,12 @@ void Shell::print_action_help(const std::string &app_name, Action *action) {
   }
 }
 
-void Shell::print_unknown_action(const std::string &app_name,
-                                 const std::vector<std::string> &command_spec) {
+void Shell::print_unknown_action(const std::vector<std::string> &command_spec) {
   std::cerr << "error: unknown option '"
             << joinify<std::string>(command_spec.begin(),
                                     command_spec.end(), " ") << "'"
             << std::endl << std::endl;
-  print_help(app_name);
+  print_help();
 }
 
 void Shell::print_bash_completion(const CommandSpec &command_spec) {

--- a/src/tools/rbd/Shell.h
+++ b/src/tools/rbd/Shell.h
@@ -62,10 +62,9 @@ private:
   void prune_command_line_arguments(int arg_count, const char **arg_values,
                                     std::vector<std::string> *args);
 
-  void print_help(const std::string &app_name);
-  void print_action_help(const std::string &app_name, Action *action);
-  void print_unknown_action(const std::string &app_name,
-                            const CommandSpec &command_spec);
+  void print_help();
+  void print_action_help(Action *action);
+  void print_unknown_action(const CommandSpec &command_spec);
 
   void print_bash_completion(const CommandSpec &command_spec);
   void print_bash_completion_options(


### PR DESCRIPTION
Avoid dynamically detecting the application name and instead hardcode
the rbd CLI name into the help output.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>