### PR TITLE
tests: restore run-cli-tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,11 @@ check-local:: all
 		exit 1 ; \
 	fi
 
+# display the output of failed check_SCRIPTS after a failed make check
+export VERBOSE = true
+
+TESTS = $(check_SCRIPTS)
+
 check_SCRIPTS = \
 	src/test/run-cli-tests
 

--- a/src/test/cli/crushtool/check-names.empty.t
+++ b/src/test/cli/crushtool/check-names.empty.t
@@ -1,4 +1,5 @@
   $ crushtool -c "$TESTDIR/check-names.empty.crushmap.txt" -o "$TESTDIR/check-names.empty.crushmap"
-  $ crushtool -i "$TESTDIR/check-names.empty.crushmap" --check-names
+  $ crushtool -i "$TESTDIR/check-names.empty.crushmap" --check 0
   unknown type name: item#0
+  [1]
   $ rm -f "$TESTDIR/check-names.empty.crushmap"

--- a/src/test/cli/crushtool/check-names.max-id.t
+++ b/src/test/cli/crushtool/check-names.max-id.t
@@ -4,4 +4,5 @@
   $ crushtool -i check-names.crushmap       --add-item 2 1.0 device2 --loc host host0 --loc cluster cluster0 -o check-names.crushmap > /dev/null
   $ crushtool -i check-names.crushmap --check 2
   item id too large: item#2
+  [1]
   $ crushtool -i check-names.crushmap --check

--- a/src/test/cli/crushtool/help.t
+++ b/src/test/cli/crushtool/help.t
@@ -64,7 +64,7 @@
                            show location for given device id
      -i mapfn --test       test a range of inputs on the map
         [--min-x x] [--max-x x] [--x x]
-        [--min-rule r] [--max-rule r] [--rule r]
+        [--min-rule r] [--max-rule r] [--rule r] [--ruleset rs]
         [--num-rep n]
         [--batches b]      split the CRUSH mapping into b > 1 rounds
         [--weight|-w devno weight]

--- a/src/test/cli/osdmaptool/pool.t
+++ b/src/test/cli/osdmaptool/pool.t
@@ -7,6 +7,7 @@
 #
   $ osdmaptool myosdmap --test-map-object foo --pool
   Option --pool requires an argument.
+  
   [1]
 
   $ osdmaptool myosdmap --test-map-object foo --pool bar
@@ -32,6 +33,7 @@
 #
   $ osdmaptool myosdmap --test-map-pgs --pool
   Option --pool requires an argument.
+  
   [1]
 
   $ osdmaptool myosdmap --test-map-pgs --pool baz

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -57,7 +57,7 @@
     metadata rm                remove metadata info
     metadata list              list metadata info
     mdlog list                 list metadata log
-    mdlog trim                 trim metadata log (use start-date, end-date or 
+    mdlog trim                 trim metadata log (use start-date, end-date or
                                start-marker, end-marker)
     bilog list                 list bucket index log
     bilog trim                 trim bucket index log (use start-marker, end-marker)
@@ -127,7 +127,6 @@
      --caps=<caps>             list of caps (e.g., "usage=read, write; user=read"
      --yes-i-really-mean-it    required for certain operations
      --reset-regions           reset regionmap when regionmap update
- 
   <date> := "YYYY-MM-DD[ hh:mm:ss]"
   
   Quota options:
@@ -145,3 +144,4 @@
     --version         show version and quit
   
   [1]
+ 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -59,7 +59,7 @@
     -k [ --keyring ] arg  path to keyring
   
   See 'rbd help <command>' for help on a specific command.
-  $ while read -r line; do echo rbd help $line ; rbd help $line; done <<< "$(rbd help | grep '^    [a-z]' | sed 's/^    \([a-z -]*[a-z]\).*/\1/g')"
+  $ rbd help | grep '^    [a-z]' | sed 's/^    \([a-z -]*[a-z]\).*/\1/g' | while read -r line; do echo rbd help $line ; rbd help $line; done
   rbd help bench-write
   usage: rbd bench-write [--pool <pool>] [--image <image>] [--io-size <io-size>] 
                          [--io-threads <io-threads>] [--io-total <io-total>] 

--- a/src/tools/rbd/Shell.cc
+++ b/src/tools/rbd/Shell.cc
@@ -19,6 +19,7 @@ namespace po = boost::program_options;
 
 namespace {
 
+static const std::string APP_NAME("rbd");
 static const std::string HELP_SPEC("help");
 static const std::string BASH_COMPLETION_SPEC("bash-completion");
 
@@ -32,11 +33,6 @@ void validate(boost::any& v, const std::vector<std::string>& values,
   const std::string &s = po::validators::get_single_string(values);
   g_conf->set_val_or_die("keyfile", s.c_str());
   v = boost::any(s);
-}
-
-std::string base_name(const std::string &path,
-                      const std::string &delims = "/\\") {
-  return path.substr(path.find_last_of(delims) + 1);
 }
 
 std::string format_command_spec(const Shell::CommandSpec &spec) {
@@ -74,7 +70,6 @@ std::vector<Shell::Action *> Shell::s_actions;
 std::set<std::string> Shell::s_switch_arguments;
 
 int Shell::execute(int arg_count, const char **arg_values) {
-  std::string app_name(base_name(arg_values[0]));
 
   std::vector<std::string> arguments;
   prune_command_line_arguments(arg_count, arg_values, &arguments);
@@ -84,17 +79,17 @@ int Shell::execute(int arg_count, const char **arg_values) {
 
   if (command_spec.empty() || command_spec == CommandSpec({"help"})) {
     // list all available actions
-    print_help(app_name);
+    print_help();
     return 0;
   } else if (command_spec[0] == HELP_SPEC) {
     // list help for specific action
     command_spec.erase(command_spec.begin());
     Action *action = find_action(command_spec, NULL);
     if (action == NULL) {
-      print_unknown_action(app_name, command_spec);
+      print_unknown_action(command_spec);
       return EXIT_FAILURE;
     } else {
-      print_action_help(app_name, action);
+      print_action_help(action);
       return 0;
     }
   } else if (command_spec[0] == BASH_COMPLETION_SPEC) {
@@ -106,7 +101,7 @@ int Shell::execute(int arg_count, const char **arg_values) {
   CommandSpec *matching_spec;
   Action *action = find_action(command_spec, &matching_spec);
   if (action == NULL) {
-    print_unknown_action(app_name, command_spec);
+    print_unknown_action(command_spec);
     return EXIT_FAILURE;
   }
 
@@ -272,8 +267,8 @@ void Shell::prune_command_line_arguments(int arg_count, const char **arg_values,
   }
 }
 
-void Shell::print_help(const std::string &app_name) {
-  std::cout << "usage: " << app_name << " <command> ..."
+void Shell::print_help() {
+  std::cout << "usage: " << APP_NAME << " <command> ..."
             << std::endl << std::endl
             << "Command-line interface for managing Ceph RBD images."
             << std::endl << std::endl;
@@ -318,14 +313,14 @@ void Shell::print_help(const std::string &app_name) {
   po::options_description global_opts(OptionPrinter::OPTIONAL_ARGUMENTS);
   get_global_options(&global_opts);
   std::cout << std::endl << global_opts << std::endl
-            << "See '" << app_name << " help <command>' for help on a specific "
+            << "See '" << APP_NAME << " help <command>' for help on a specific "
             << "command." << std::endl;
 }
 
-void Shell::print_action_help(const std::string &app_name, Action *action) {
+void Shell::print_action_help(Action *action) {
 
   std::stringstream ss;
-  ss << "usage: " << app_name << " "
+  ss << "usage: " << APP_NAME << " "
      << format_command_spec(action->command_spec);
   std::cout << ss.str();
 
@@ -348,13 +343,12 @@ void Shell::print_action_help(const std::string &app_name, Action *action) {
   }
 }
 
-void Shell::print_unknown_action(const std::string &app_name,
-                                 const std::vector<std::string> &command_spec) {
+void Shell::print_unknown_action(const std::vector<std::string> &command_spec) {
   std::cerr << "error: unknown option '"
             << joinify<std::string>(command_spec.begin(),
                                     command_spec.end(), " ") << "'"
             << std::endl << std::endl;
-  print_help(app_name);
+  print_help();
 }
 
 void Shell::print_bash_completion(const CommandSpec &command_spec) {

--- a/src/tools/rbd/Shell.h
+++ b/src/tools/rbd/Shell.h
@@ -62,10 +62,9 @@ private:
   void prune_command_line_arguments(int arg_count, const char **arg_values,
                                     std::vector<std::string> *args);
 
-  void print_help(const std::string &app_name);
-  void print_action_help(const std::string &app_name, Action *action);
-  void print_unknown_action(const std::string &app_name,
-                            const CommandSpec &command_spec);
+  void print_help();
+  void print_action_help(Action *action);
+  void print_unknown_action(const CommandSpec &command_spec);
 
   void print_bash_completion(const CommandSpec &command_spec);
   void print_bash_completion_options(


### PR DESCRIPTION
e4ca468 moved src/test/run-cli-tests from check-local to check_SCRIPTS
but did not add it to the TESTS variable.

Signed-off-by: Loic Dachary <loic@dachary.org>