### PR TITLE
FileStore: Trust cached fd for existed file

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -171,6 +171,8 @@ int FileStore::init_index(coll_t cid)
 
 int FileStore::lfn_find(const ghobject_t& oid, const Index& index, IndexedPath *path)
 {
+  if (fdcache.lookup(oid) && !path)
+    return 0;
   IndexedPath path2;
   if (!path)
     path = &path2;


### PR DESCRIPTION
lookup() will cost a lots to retrieve the real objectname, may trust fdcache if the object is existed. This can reduce the omap_setkeys latency from 360us to 320us

Signed-off-by: Ning Yao <zay11022@gmail.com>