### PR TITLE
build/ops: rbd-replay moved from ceph-test-dbg to ceph-common-dbg

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -218,7 +218,9 @@ Package: ceph-common-dbg
 Architecture: linux-any
 Depends: ceph-common (= ${binary:Version}), ${misc:Depends}
 Conflicts: ceph-client-tools-dbg
-Replaces: ceph-client-tools-dbg
+Replaces: ceph-client-tools-dbg,
+	  ceph-test-dbg (<< 9.0.3-1646)
+Breaks: ceph-test-dbg (<< 9.0.3-1646)
 Section: debug
 Priority: extra
 Description: debugging symbols for ceph-common


### PR DESCRIPTION
http://tracker.ceph.com/issues/13785 Fixes: #13785

Signed-off-by: Loic Dachary <loic@dachary.org>