### PR TITLE
tests: ignore test-suite.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ release
 stamp-h1
 systemd/Makefile
 vgcore.*
+test-suite.log
 
 # specific local dir files
 /build-doc


### PR DESCRIPTION
Now that the tests at the top level directory are run via TESTS and not
check-local:, the test-suite.log file is created and must bit
gitignored.

Signed-off-by: Loic Dachary <loic@dachary.org>