### PR TITLE
AsyncConnection: Make standby client reconnect if calling keepalive

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2506,7 +2506,7 @@ void AsyncConnection::handle_write()
     write_lock.Unlock();
     lock.Lock();
     write_lock.Lock();
-    if (state == STATE_STANDBY && !policy.server && is_queued()) {
+    if (state == STATE_STANDBY && !policy.server && (is_queued() || keepalive)) {
       ldout(async_msgr->cct, 10) << __func__ << " state is " << get_state_name(state)
                                  << " policy.server is false" << dendl;
       _connect();


### PR DESCRIPTION
If connection is standby state and call send keepalive, we should reconnect
this connection.

Fix #13797
Signed-off-by: Haomai Wang haomai@xsky.com