### PR TITLE
client: fix deadlock related to async pagecache invalidation

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -610,11 +610,11 @@ protected:
   void _async_dentry_invalidate(vinodeno_t dirino, vinodeno_t ino, string& name);
   void _try_to_trim_inode(Inode *in);
 
-  void _schedule_invalidate_callback(Inode *in, int64_t off, int64_t len, bool keep_caps);
+  void _schedule_invalidate_callback(Inode *in, int64_t off, int64_t len);
   void _invalidate_inode_cache(Inode *in);
   void _invalidate_inode_cache(Inode *in, int64_t off, int64_t len);
-  void _async_invalidate(InodeRef& in, int64_t off, int64_t len, bool keep_caps);
-  void _release(Inode *in);
+  void _async_invalidate(InodeRef& in, int64_t off, int64_t len);
+  bool _release(Inode *in);
   
   /**
    * Initiate a flush of the data associated with the given inode.


### PR DESCRIPTION
When mds reovkes Fc capability, client code first invalidates kernel
pagecache, then calls check_caps() to release Fc capability to MDS.
invalidating kernel pagecache can block if there is writer holding
i_mutex. Deadlock happens if the writer needs to wait Fw capability.
(MDS can't finish revoking Fc capability because client doesn't call
 check_caps(). So mds can't issue Fw to the client)

The fix is call check_caps() after invalidating the objectcacher.

Fixes: #13800
Signed-off-by: Yan, Zheng <zyan@redhat.com>