### PR TITLE
mon: allow mds profile to OSD write

### DIFF
--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -133,7 +133,8 @@ void MonCapGrant::expand_profile(EntityName name) const
   if (profile == "mds") {
     profile_grants.push_back(MonCapGrant("mds", MON_CAP_ALL));
     profile_grants.push_back(MonCapGrant("mon", MON_CAP_R));
-    profile_grants.push_back(MonCapGrant("osd", MON_CAP_R));
+    // MDS requires OSD write cap to delete snapshots
+    profile_grants.push_back(MonCapGrant("osd", MON_CAP_R | MON_CAP_W));
     profile_grants.push_back(MonCapGrant("log", MON_CAP_W));
   }
   if (profile == "osd" || profile == "mds" || profile == "mon") {


### PR DESCRIPTION
So that MDSs can remove snapshots.

Signed-off-by: John Spray <john.spray@redhat.com>