### PR TITLE
Remove unused SnapContext member snapc from MOSDSubOp message.

### DIFF
--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -72,6 +72,7 @@
 #define CEPH_FEATURE_NEW_OSDOP_ENCODING   (1ULL<<56) /* New, v7 encoding */
 #define CEPH_FEATURE_MON_STATEFUL_SUB (1ULL<<57) /* stateful mon subscription */
 #define CEPH_FEATURE_MON_ROUTE_OSDMAP (1ULL<<57) /* peon sends osdmaps */
+#define CEPH_FEATURE_OSDSUBOP_NO_SNAPCONTEXT (1ULL<<57) /* overlap, drop unused SnapContext in v12 */
 #define CEPH_FEATURE_CRUSH_TUNABLES5	(1ULL<<58) /* chooseleaf stable mode */
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */

--- a/src/messages/MOSDSubOp.h
+++ b/src/messages/MOSDSubOp.h
@@ -19,13 +19,15 @@
 #include "msg/Message.h"
 #include "osd/osd_types.h"
 
+#include "include/ceph_features.h"
+
 /*
  * OSD sub op - for internal ops on pobjects between primary and replicas(/stripes/whatever)
  */
 
 class MOSDSubOp : public Message {
 
-  static const int HEAD_VERSION = 11;
+  static const int HEAD_VERSION = 12;
   static const int COMPAT_VERSION = 7;
 
 public:
@@ -51,7 +53,6 @@ public:
   eversion_t old_version;
 
   SnapSet snapset;
-  SnapContext snapc;
 
   // transaction to exec
   bufferlist logbl;
@@ -128,7 +129,12 @@ public:
     ::decode(old_size, p);
     ::decode(old_version, p);
     ::decode(snapset, p);
-    ::decode(snapc, p);
+
+    if (header.version <= 11) {
+      SnapContext snapc_dont_need;
+      ::decode(snapc_dont_need, p);
+    }
+
     ::decode(logbl, p);
     ::decode(pg_stats, p);
     ::decode(pg_trim_to, p);
@@ -196,7 +202,13 @@ public:
     ::encode(old_size, payload);
     ::encode(old_version, payload);
     ::encode(snapset, payload);
-    ::encode(snapc, payload);
+
+    if ((features & CEPH_FEATURE_OSDSUBOP_NO_SNAPCONTEXT) == 0) {
+      header.version = 11;
+      SnapContext dummy_snapc;
+      ::encode(dummy_snapc, payload);
+    }
+
     ::encode(logbl, payload);
     ::encode(pg_stats, payload);
     ::encode(pg_trim_to, payload);
@@ -258,7 +270,7 @@ public:
     if (complete)
       out << " complete";
     out << " v " << version
-	<< " snapset=" << snapset << " snapc=" << snapc;    
+	<< " snapset=" << snapset;
     if (!data_subset.empty()) out << " subset " << data_subset;
     if (updated_hit_set_history)
       out << ", has_updated_hit_set_history";


### PR DESCRIPTION
per new-dev issue at http://tracker.ceph.com/issues/6634

I think I got the message version backwards compatibility change right?
