### PR TITLE
admin/build-doc: add lxml dependencies on debian

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -7,7 +7,7 @@ TOPDIR=`pwd`
 install -d -m0755 build-doc
 
 if command -v dpkg >/dev/null; then
-    for package in python-dev python-pip python-virtualenv doxygen ditaa ant; do
+    for package in python-dev python-pip python-virtualenv doxygen ditaa ant libxml2-dev libxslt1-dev; do
 	if [ "$(dpkg --status -- $package|sed -n 's/^Status: //p')" != "install ok installed" ]; then
             # add a space after old values
 	    missing="${missing:+$missing }$package"


### PR DESCRIPTION
Some parts of the docs require libxml2 in order to build. We were already checking for these lxml dependencies on Fedora; check for the dependencies on Ubuntu as well.