### PR TITLE
osd:shutdown OSD after certain times of reboot

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -608,6 +608,10 @@ OPTION(osd_map_message_max, OPT_INT, 100)  // max maps per MOSDMap message
 OPTION(osd_map_share_max_epochs, OPT_INT, 100)  // cap on # of inc maps we send to peers, clients
 OPTION(osd_inject_bad_map_crc_probability, OPT_FLOAT, 0)
 OPTION(osd_inject_failure_on_pg_removal, OPT_BOOL, false)
+// shutdown the OSD if stuatus flipping more than max_flipping_threshold times in recent flipping_log_period seconds
+OPTION(osd_flipping_log_period, OPT_INT, 600)
+OPTION(osd_max_flipping_threshold, OPT_INT, 5)
+
 OPTION(osd_op_threads, OPT_INT, 2)    // 0 == no threading
 OPTION(osd_peering_wq_batch_size, OPT_U64, 20)
 OPTION(osd_op_pq_max_tokens_per_priority, OPT_U64, 4194304)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6576,13 +6576,14 @@ void OSD::handle_osd_map(MOSDMap *m)
     else
       start_boot();
   }
+  else if (do_shutdown) {
+    osd_lock.Unlock();
+    shutdown();
+    osd_lock.Lock();
+  }
   else if (do_restart)
     start_boot();
 
-  osd_lock.Unlock();
-  if (do_shutdown)
-    shutdown();
-  osd_lock.Lock();
 
   m->put();
 }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1814,6 +1814,7 @@ private:
   utime_t         had_map_since;
   RWLock          map_lock;
   list<OpRequestRef>  waiting_for_osdmap;
+  deque<utime_t> osd_reboot_log;
 
   friend struct send_map_on_destruct;
 


### PR DESCRIPTION
We do observe the OSD status flipping when
1. with slow disk that under high load the op_thread timeout and marked down by other peers due to heartbeat check timeout. Right after the OSD is marked down, the load decrease then it reboot and mark it self up, but soon it will be exhausted again.

2.Network partition,  say we have three racks A,B,C, the aggregate port of B is broken. So OSDs in B will be marked out by OSDs from A and C. But OSDs in B will reboot and mark itself up again because they can meet the 1/3 heartbeat check (as they still have heartbeat inside B).

It will be hard for us to solve all kinds of network partition/HW issue, so as the final guard I think we could make the OSD shutdown itself after rebooting more than {osd_max_flipping_threshold} times in the past {osd_flipping_log_period} seconds. 

By doing this we can speed up the convergence of OSD status, and also usually trigger some external monitor system that warning the admin something goes wrong.

