### PR TITLE
osd: MOSDRepOp and pg_log_entry_t optimization

### DIFF
--- a/src/messages/MOSDRepOp.h
+++ b/src/messages/MOSDRepOp.h
@@ -25,7 +25,7 @@
 
 class MOSDRepOp : public Message {
 
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -64,6 +64,8 @@ public:
   /// non-empty if this transaction involves a hit_set history update
   boost::optional<pg_hit_set_history_t> updated_hit_set_history;
 
+  map<string, bufferlist> pglog_encode_checksum;
+
   int get_cost() const {
     return data.length();
   }
@@ -94,6 +96,8 @@ public:
     ::decode(from, p);
     ::decode(updated_hit_set_history, p);
     ::decode(pg_trim_rollback_to, p);
+    if (header.version >= 2)
+      ::decode(pglog_encode_checksum, p);
     final_decode_needed = false;
   }
 
@@ -113,6 +117,7 @@ public:
     ::encode(from, payload);
     ::encode(updated_hit_set_history, payload);
     ::encode(pg_trim_rollback_to, payload);
+    ::encode(pglog_encode_checksum, payload);
   }
 
   MOSDRepOp()

--- a/src/messages/MOSDSubOp.h
+++ b/src/messages/MOSDSubOp.h
@@ -92,6 +92,8 @@ public:
   /// non-empty if this transaction involves a hit_set history update
   boost::optional<pg_hit_set_history_t> updated_hit_set_history;
 
+  map<string, bufferlist> pglog_encode_checksum;
+
   int get_cost() const {
     if (ops.size() == 1 && ops[0].op.op == CEPH_OSD_OP_PULL)
       return ops[0].op.extent.length;

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -358,6 +358,10 @@ public:
       byte_throttler->take(payload.length());
   }
 
+  void fillin_payload(bufferlist bl) {
+    payload.claim(bl);
+  }
+
   void set_middle(bufferlist& bl) {
     if (byte_throttler)
       byte_throttler->put(payload.length());

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2176,7 +2176,7 @@ public:
     ghobject_t &pgmeta_oid,
     bool dirty_big_info,
     bool dirty_epoch);
-  void write_if_dirty(ObjectStore::Transaction& t);
+  void write_if_dirty(ObjectStore::Transaction& t, map<string, bufferlist> *pglog_encode_checksum = NULL);
 
   eversion_t get_next_version() const {
     eversion_t at_version(get_osdmap()->get_epoch(),
@@ -2192,6 +2192,7 @@ public:
     eversion_t trim_to,
     eversion_t trim_rollback_to,
     ObjectStore::Transaction &t,
+    map<string, bufferlist> *pglog_encode_checksum,
     bool transaction_applied = true);
   bool check_log_for_corruption(ObjectStore *store);
   void trim_peers();

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -178,7 +178,8 @@
        const eversion_t &trim_to,
        const eversion_t &trim_rollback_to,
        bool transaction_applied,
-       ObjectStore::Transaction *t) = 0;
+       ObjectStore::Transaction *t,
+       map<string, bufferlist> *pglog_encode_checksum = NULL) = 0;
 
      virtual void update_peer_last_complete_ondisk(
        pg_shard_t fromosd,

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -740,7 +740,8 @@ void PGLog::write_log(
   ObjectStore::Transaction& t,
   map<string,bufferlist> *km,
   const coll_t& coll, const ghobject_t &log_oid,
-  bool require_rollback)
+  bool require_rollback,
+  map<string, bufferlist> *pglog_encode_checksum)
 {
   if (is_dirty()) {
     dout(5) << "write_log with: "
@@ -761,7 +762,8 @@ void PGLog::write_log(
       dirty_divergent_priors,
       !touched_log,
       require_rollback,
-      (pg_log_debug ? &log_keys_debug : 0));
+      (pg_log_debug ? &log_keys_debug : 0),
+      pglog_encode_checksum);
     undirty();
   } else {
     dout(10) << "log is not dirty" << dendl;
@@ -780,7 +782,7 @@ void PGLog::write_log(
     t, km, log, coll, log_oid,
     divergent_priors, eversion_t::max(), eversion_t(), eversion_t(),
     set<eversion_t>(),
-    true, true, require_rollback, 0);
+    true, true, require_rollback, 0, NULL);
 }
 
 void PGLog::_write_log(
@@ -796,7 +798,8 @@ void PGLog::_write_log(
   bool dirty_divergent_priors,
   bool touch_log,
   bool require_rollback,
-  set<string> *log_keys_debug
+  set<string> *log_keys_debug,
+  map<string, bufferlist> *pglog_encode_checksum
   )
 {
   set<string> to_remove;
@@ -830,9 +833,15 @@ void PGLog::_write_log(
   for (list<pg_log_entry_t>::iterator p = log.log.begin();
        p != log.log.end() && p->version <= dirty_to;
        ++p) {
-    bufferlist bl(sizeof(*p) * 2);
-    p->encode_with_checksum(bl);
-    (*km)[p->get_key_name()].claim(bl);
+    if (!pglog_encode_checksum || !pglog_encode_checksum->count(p->get_key_name())) {
+      bufferlist bl(sizeof(*p) * 2);
+      p->encode_with_checksum(bl);
+      (*km)[p->get_key_name()].claim(bl);
+      if (pglog_encode_checksum)
+        (*pglog_encode_checksum)[p->get_key_name()] = (*km)[p->get_key_name()];
+    } else {
+      (*km)[p->get_key_name()] = (*pglog_encode_checksum)[p->get_key_name()];
+    }
   }
 
   for (list<pg_log_entry_t>::reverse_iterator p = log.log.rbegin();
@@ -840,9 +849,15 @@ void PGLog::_write_log(
 	 (p->version >= dirty_from || p->version >= writeout_from) &&
 	 p->version >= dirty_to;
        ++p) {
-    bufferlist bl(sizeof(*p) * 2);
-    p->encode_with_checksum(bl);
-    (*km)[p->get_key_name()].claim(bl);
+    if (!pglog_encode_checksum || !pglog_encode_checksum->count(p->get_key_name())) {
+      bufferlist bl(sizeof(*p) * 2);
+      p->encode_with_checksum(bl);
+      (*km)[p->get_key_name()].claim(bl);
+      if (pglog_encode_checksum)
+        (*pglog_encode_checksum)[p->get_key_name()] = (*km)[p->get_key_name()];
+    } else {
+      (*km)[p->get_key_name()] = (*pglog_encode_checksum)[p->get_key_name()];
+    }
   }
 
   if (log_keys_debug) {

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -648,7 +648,8 @@ public:
 		 map<string,bufferlist> *km,
 		 const coll_t& coll,
 		 const ghobject_t &log_oid,
-		 bool require_rollback);
+		 bool require_rollback,
+                 map<string, bufferlist> *pglog_encode_checksum = NULL);
 
   static void write_log(
     ObjectStore::Transaction& t,
@@ -671,7 +672,8 @@ public:
     bool dirty_divergent_priors,
     bool touch_log,
     bool require_rollback,
-    set<string> *log_keys_debug
+    set<string> *log_keys_debug,
+    map<string, bufferlist> *pglog_encode_checksum
     );
 
   void read_log(ObjectStore *store, coll_t pg_coll,

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -375,7 +375,7 @@ private:
     ObjectStore::Transaction *op_t,
     pg_shard_t peer,
     const pg_info_t &pinfo);
-  void issue_op(
+  bool prepare_op(
     const hobject_t &soid,
     const eversion_t &at_version,
     ceph_tid_t tid,
@@ -387,7 +387,11 @@ private:
     const vector<pg_log_entry_t> &log_entries,
     boost::optional<pg_hit_set_history_t> &hset_history,
     InProgressOp *op,
-    ObjectStore::Transaction *op_t);
+    ObjectStore::Transaction *op_t,
+    list<Message*> &msgs);
+  void issue_op(bool repop_same_payload,
+    list<Message*>,
+    map<string, bufferlist> &pglog_encode_checksum);
   void op_applied(InProgressOp *op);
   void op_commit(InProgressOp *op);
   template<typename T, int MSGTYPE>

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -388,12 +388,13 @@ public:
     const eversion_t &trim_to,
     const eversion_t &trim_rollback_to,
     bool transaction_applied,
-    ObjectStore::Transaction *t) {
+    ObjectStore::Transaction *t,
+    map<string, bufferlist> *pglog_encode_checksum = NULL) {
     if (hset_history) {
       info.hit_set = *hset_history;
       dirty_info = true;
     }
-    append_log(logv, trim_to, trim_rollback_to, *t, transaction_applied);
+    append_log(logv, trim_to, trim_rollback_to, *t, pglog_encode_checksum, transaction_applied);
   }
 
   void op_applied(


### PR DESCRIPTION
1. reuse payload in MOSDRepOp if all remote peers have same payload
2. reuse pg log encode and checksum from primary