### PR TITLE
tiering: aggressively flushing at (user specified) idle time

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -604,6 +604,8 @@ OPTION(osd_tier_default_cache_min_read_recency_for_promote, OPT_INT, 1) // numbe
 OPTION(osd_tier_default_cache_min_write_recency_for_promote, OPT_INT, 1) // number of recent HitSets the object must appear in to be promoted (on write)
 OPTION(osd_tier_default_cache_hit_set_grade_decay_rate, OPT_INT, 20)
 OPTION(osd_tier_default_cache_hit_set_search_last_n, OPT_INT, 1)
+OPTION(osd_tier_schedule_flush_start, OPT_STR, "0:0") //hour:munite, user defined schedule_flush start time
+OPTION(osd_tier_schedule_flush_end, OPT_STR, "0:0") //schedule_flush end time
 
 OPTION(osd_map_dedup, OPT_BOOL, true)
 OPTION(osd_map_max_advance, OPT_INT, 150) // make this < cache_size!

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -611,6 +611,18 @@ public:
   }
 };
 
+void OSDService::agent_schedule_flush_start()
+{
+  agent_in_schedule_time = true;
+  dout(10) << "start user specified flushing" << dendl;
+  RWLock::RLocker rl(osd->pg_map_lock);
+  for (ceph::unordered_map<spg_t, PG*>::iterator p = osd->pg_map.begin();
+        p != osd->pg_map.end(); ++p) {
+    p->second->agent_choose_mode_restart(true);
+    dout(10) << p->first.pgid << " agent_state reset" << dendl;
+  }
+}
+
 void OSDService::agent_schedule_flush_setup()
 {
   dout(10) << __func__ << " start" << dendl;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8666,6 +8666,9 @@ const char** OSD::get_tracked_conf_keys() const
     "clog_to_syslog",
     "clog_to_syslog_facility",
     "clog_to_syslog_level",
+    //schedule_flush function on cache tiering
+    "osd_tier_schedule_flush_start",
+    "osd_tier_schedule_flush_end",
     NULL
   };
   return KEYS;
@@ -8709,6 +8712,14 @@ void OSD::handle_conf_change(const struct md_config_t *conf,
       changed.count("clog_to_syslog_level") ||
       changed.count("clog_to_syslog_facility")) {
     update_log_config();
+  }
+  if (changed.count("osd_tier_schedule_flush_start") ||
+      changed.count("osd_tier_schedule_flush_end")) {
+    if (!service.agent_stop_flag) {
+      Mutex::Locker l(service.agent_timer_lock);
+      service.agent_schedule_flush_version++;
+      service.agent_schedule_flush_setup();
+    }
   }
 
   check_config();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -228,6 +228,8 @@ OSDService::OSDService(OSD *osd) :
   agent_active(true),
   agent_thread(this),
   agent_stop_flag(false),
+  agent_in_schedule_time(false),
+  agent_schedule_flush_version(0),
   agent_timer_lock("OSD::agent_timer_lock"),
   agent_timer(osd->client_messenger->cct, agent_timer_lock),
   objecter(new Objecter(osd->client_messenger->cct, osd->objecter_messenger, osd->monc, NULL, 0, 0)),
@@ -586,6 +588,85 @@ void OSDService::agent_stop()
     agent_cond.Signal();
   }
   agent_thread.join();
+}
+
+class AgentScheduleFlushTimeoutCB : public Context {
+  OSDService *osd;
+  bool start;
+  int version;
+public:
+  AgentScheduleFlushTimeoutCB(OSDService *o, bool s, int v) :
+    osd(o),
+    start(s),
+    version(v) {}
+  void finish(int) {
+    //skip stale schedule events' callback
+    if (version != osd->agent_schedule_flush_version)
+      return;
+    if (start) {
+      osd->agent_schedule_flush_start();
+    } else {
+      osd->agent_schedule_flush_end();
+    }
+  }
+};
+
+void OSDService::agent_schedule_flush_setup()
+{
+  dout(10) << __func__ << " start" << dendl;
+  utime_t now = ceph_clock_now(cct);
+  struct tm tm_t;
+  time_t tt= now.sec();
+  localtime_r(&tt, &tm_t);
+  double start_after;
+  double end_after;
+
+  //transfer config string to struct tm
+  struct tm sche_st;
+  struct tm sche_ed;
+  strptime(cct->_conf->osd_tier_schedule_flush_start.c_str(), "%H:%M", &sche_st);
+  strptime(cct->_conf->osd_tier_schedule_flush_end.c_str(), "%H:%M", &sche_ed);
+  double interval_time = (sche_ed.tm_hour * 60 + sche_ed.tm_min)
+                         - (sche_st.tm_hour * 60 + sche_st.tm_min);
+
+  //no schedule_flush job
+  if (interval_time == 0) {
+    dout(10) << __func__ << " no schedule_flush set" << dendl;
+    agent_in_schedule_time = false;
+    return;
+  } else if (interval_time > 0) {
+    if ((tm_t.tm_hour * 60 + tm_t.tm_min >= sche_st.tm_hour * 60 + sche_st.tm_min)
+        && (tm_t.tm_hour *60 + tm_t.tm_min < sche_ed.tm_hour * 60 + sche_ed.tm_min))
+      agent_in_schedule_time= true;
+  } else {
+    interval_time += 24 * 60;
+
+    if ((tm_t.tm_hour * 60 + tm_t.tm_min >= sche_st.tm_hour * 60 + sche_st.tm_min)
+        || (tm_t.tm_hour *60 + tm_t.tm_min < sche_ed.tm_hour * 60 + sche_ed.tm_min))
+      agent_in_schedule_time= true;
+  }
+
+  //prepare callbacks for schedule flush
+  Context *sf_start_cb = new AgentScheduleFlushTimeoutCB(this, true, agent_schedule_flush_version);
+  Context *sf_end_cb = new AgentScheduleFlushTimeoutCB(this, false, agent_schedule_flush_version);
+
+  //calculate time(seconds) agent_timer thread invoke schedule_flush callbacks from now.
+  if (agent_in_schedule_time)
+    start_after= 5.0;
+  else {
+    start_after = ((sche_st.tm_hour - tm_t.tm_hour) * 3600
+                   + (sche_st.tm_min - tm_t.tm_min) * 60);
+    if (start_after < 0)
+      start_after += 24 * 3600;
+  }
+  end_after = start_after + interval_time * 60;
+
+  //add events in agent_timer to tell agent process schedule_flush
+  dout(10) << __func__ << " queue timer: "
+          << "start schedule_flush after " << start_after
+          << " ,terminate schedule_flush after " << end_after << dendl;
+  agent_timer.add_event_after(start_after, sf_start_cb);
+  agent_timer.add_event_after(end_after, sf_end_cb);
 }
 
 // -------------------------------------

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -517,6 +517,9 @@ void OSDService::agent_entry()
 {
   dout(10) << __func__ << " start" << dendl;
   agent_lock.Lock();
+  agent_timer_lock.Lock();
+  agent_schedule_flush_setup();
+  agent_timer_lock.Unlock();
 
   while (!agent_stop_flag) {
     if (agent_queue.empty()) {
@@ -584,6 +587,7 @@ void OSDService::agent_stop()
       assert(0 == "agent queue not empty");
     }
 
+    agent_in_schedule_time = false;
     agent_stop_flag = true;
     agent_cond.Signal();
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -623,6 +623,14 @@ void OSDService::agent_schedule_flush_start()
   }
 }
 
+//on schedule_flush ending, setup the next period's schedule jobs.
+void OSDService::agent_schedule_flush_end()
+{
+  agent_in_schedule_time = false;
+  dout(10) << "stop user specified flushing" << dendl;
+  agent_schedule_flush_setup();
+}
+
 void OSDService::agent_schedule_flush_setup()
 {
   dout(10) << __func__ << " start" << dendl;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -673,11 +673,16 @@ public:
     }
   } agent_thread;
   bool agent_stop_flag;
-  Mutex agent_timer_lock;
-  SafeTimer agent_timer;
-
   void agent_entry();
   void agent_stop();
+
+  bool agent_in_schedule_time;
+  int agent_schedule_flush_version;
+  Mutex agent_timer_lock;
+  SafeTimer agent_timer;
+  void agent_schedule_flush_setup();
+  void agent_schedule_flush_start();  //start schedule flush work
+  void agent_schedule_flush_end();  //finish schedule flush work
 
   void _enqueue(PG *pg, uint64_t priority) {
     if (!agent_queue.empty() &&

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2333,7 +2333,7 @@ public:
   virtual void agent_stop() = 0;
   virtual void agent_delay() = 0;
   virtual void agent_clear() = 0;
-  virtual void agent_choose_mode_restart() = 0;
+  virtual void agent_choose_mode_restart(bool force = false) = 0;
 };
 
 ostream& operator<<(ostream& out, const PG& pg);

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -953,7 +953,7 @@ protected:
 
   /// choose (new) agent mode(s), returns true if op is requeued
   bool agent_choose_mode(bool restart = false, OpRequestRef op = OpRequestRef());
-  void agent_choose_mode_restart();
+  void agent_choose_mode_restart(bool force = false);
 
   /// true if we can send an ondisk/commit for v
   bool already_complete(eversion_t v) {


### PR DESCRIPTION
This was thrown out several months ago, seems buried in bunch of pull requests. In many use cases, the user traffic is high in only some fixed time, for example, work hour. In those cases, it is desirable that the flushing job for cache tiering could be scheduled at the idle time, and do as much as possible, to reduce the bandwidth contention with user traffic. This patch implements aggressively flushing for cache tiering at user specified time.

Signed-off-by: Mingxin Liu <mingxin.liu@kylin-cloud.com>
Reviewed-by: Li Wang <wang.li@kylin-cloud.com>
Reviewed-by: Yunchuan Wen <yunchuan.wen@kylin-cloud.com>
Suggested-by: Xinze Chi <xmdxcxz@gmail.com>