### PR TITLE
OSD: race condition detected during send_failures

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4709,11 +4709,9 @@ void OSD::got_full_map(epoch_t e)
 void OSD::send_failures()
 {
   assert(osd_lock.is_locked());
-  bool locked = false;
-  if (!failure_queue.empty()) {
-    heartbeat_lock.Lock();
-    locked = true;
-  }
+  if (failure_queue.empty())
+    return;
+  heartbeat_lock.Lock();
   utime_t now = ceph_clock_now(cct);
   while (!failure_queue.empty()) {
     int osd = failure_queue.begin()->first;
@@ -4723,7 +4721,7 @@ void OSD::send_failures()
     failure_pending[osd] = i;
     failure_queue.erase(osd);
   }
-  if (locked) heartbeat_lock.Unlock();
+  heartbeat_lock.Unlock();
 }
 
 void OSD::send_still_alive(epoch_t epoch, const entity_inst_t &i)


### PR DESCRIPTION
In OSD::send_failures(), we are risking of changing failure_queue possibly without protection of heartbeat_lock, and thus race may happen.
Fixes: #13821
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>