### PR TITLE
Cephfs will crash if enabling async msg because of an assertion

### DIFF
--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -179,7 +179,7 @@ int EventCenter::create_file_event(int fd, int mask, EventCallbackRef ctxt)
 
 void EventCenter::delete_file_event(int fd, int mask)
 {
-  assert(fd > 0);
+  assert(fd >= 0);
   Mutex::Locker l(file_lock);
   if (fd > nevent) {
     ldout(cct, 1) << __func__ << " delete event fd=" << fd << " exceed nevent=" << nevent


### PR DESCRIPTION
This crash happened when using cephfs with async msg. *0* is an valid value of socket descriptor as shown in below log, so this assertion fails.

2015-11-18 14:44:15.516884 7f4f4a7fc700 20 -- xxx:0/38557 >> xxx:6800/59220 conn(0x7f4f34002300 sd=0 :-1 s=STATE_OPEN pgs=10 cs=1 l=1)._try_send sent bytes 1866 remaining bytes 0
2015-11-18 14:44:15.518071 7f4f4a7fc700 -1 msg/async/Event.cc: In function 'void EventCenter::delete_file_event(int, int)' thread 7f4f4a7fc700 time 2015-11-18 14:44:15.516904
msg/async/Event.cc: 173: FAILED assert(fd > 0)

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>