### PR TITLE
MOSDOp/MOSDOpReply: Move MOSDOp and MOSDOpReply newest version to the front of the decoding function.

### DIFF
--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -344,7 +344,14 @@ struct ceph_osd_request_head {
     assert(partial_decode_needed && final_decode_needed);
     p = payload.begin();
 
-    if (header.version < 2) {
+    // Always keep here the newest version of decoding order/rule
+    if (header.version == HEAD_VERSION) {
+	  ::decode(pgid, p);
+	  ::decode(osdmap_epoch, p);
+	  ::decode(flags, p);
+	  ::decode(reassert_version, p);
+	  ::decode(reqid, p);
+    } else if (header.version < 2) {
       // old decode
       ::decode(client_inc, p);
 
@@ -446,13 +453,6 @@ struct ceph_osd_request_head {
       // put client_inc in reqid.inc for get_reqid()'s benefit
       if (reqid.name == entity_name_t() && reqid.tid == 0)
 	reqid.inc = client_inc;
-    } else {
-      // new, v7 decode, splitted to partial and final
-      ::decode(pgid, p);
-      ::decode(osdmap_epoch, p);
-      ::decode(flags, p);
-      ::decode(reassert_version, p);
-      ::decode(reqid, p);
     }
 
     partial_decode_needed = false;

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -194,7 +194,32 @@ public:
   }
   virtual void decode_payload() {
     bufferlist::iterator p = payload.begin();
-    if (header.version < 2) {
+
+    // Always keep here the newest version of decoding order/rule
+    if (header.version == HEAD_VERSION) {
+	::decode(oid, p);
+	::decode(pgid, p);
+	::decode(flags, p);
+	::decode(result, p);
+	::decode(bad_replay_version, p);
+	::decode(osdmap_epoch, p);
+
+	__u32 num_ops = ops.size();
+	::decode(num_ops, p);
+	ops.resize(num_ops);
+	for (unsigned i = 0; i < num_ops; i++)
+	::decode(ops[i].op, p);
+	::decode(retry_attempt, p);
+
+	for (unsigned i = 0; i < num_ops; ++i)
+	::decode(ops[i].rval, p);
+
+	OSDOp::split_osd_op_vector_out_data(ops, data);
+
+	::decode(replay_version, p);
+	::decode(user_version, p);
+	::decode(redirect, p);
+    } else if (header.version < 2) {
       ceph_osd_reply_head head;
       ::decode(head, p);
       ops.resize(head.num_ops);


### PR DESCRIPTION
  Since we have a consistent versions - we can decode message without couple of version checks and decode message in known order/rule. In case of difference between client and server - we're still going through the all of checks that ensures backward compatibility. 
  Not so much improvement expected (will be tested on SSDs soon - more ops, more omitted checks), but still it is + easier to see whole decoding block.
  Good to consider doing this for the other decoded messages

Here's the comparison for reads and writes in SSD cluster. I also included charts for object_stat_sum_t class optimized in the same way (not commited). This last change didn't affected results so much. If there's any test you're curious about, or you think we need to repeat, let me know.

There's no visible improvement for reads (it's possible that we don't attain hardware's capabilities):
![image](https://cloud.githubusercontent.com/assets/12859079/11299875/b45e5960-8f8a-11e5-9ae7-2ec24ffd5f99.png)

For writes, we observed performance improvement for higher QD:
![image](https://cloud.githubusercontent.com/assets/12859079/11300008/cf33299a-8f8b-11e5-90a6-6d724c2b3506.png)


Signed-off-by: Jacek J. Łakis <jacek.lakis@intel.com>