### PR TITLE
optimize FileStore::Index lock

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -261,13 +261,19 @@ int FileStore::lfn_open(coll_t cid,
   int fd, exist;
   assert(NULL != (*index).index);
   if (need_lock) {
+    if (create)
     ((*index).index)->access_lock.get_write();
+    else
+    ((*index).index)->access_lock.get_read();
   }
   if (!replaying) {
     *outfd = fdcache.lookup(oid);
     if (*outfd) {
       if (need_lock) {
-        ((*index).index)->access_lock.put_write();
+	if (create)
+	  ((*index).index)->access_lock.put_write();
+	else
+	  ((*index).index)->access_lock.put_read();
       }
       return 0;
     }
@@ -320,16 +326,14 @@ int FileStore::lfn_open(coll_t cid,
     *outfd = FDRef(new FDCache::FD(fd));
   }
 
+  r = 0;
+
+fail:
   if (need_lock) {
-    ((*index).index)->access_lock.put_write();
-  }
-
-  return 0;
-
- fail:
-
-  if (need_lock) {
-    ((*index).index)->access_lock.put_write();
+    if (create)
+      ((*index).index)->access_lock.put_write();
+    else
+      ((*index).index)->access_lock.put_read();
   }
 
   assert(!m_filestore_fail_eio || r != -EIO);


### PR DESCRIPTION
For read object, in the following steps we call lfn_open
a)get OI_ATTR: 
b)get SS_ATTR
c)for ec object, get all xattr
d)read read
Suppose FDCache is too larger which make sure b/c/d don't miss FD. So we only need one create and the left only get from fdcache.
