### PR TITLE
os/FileStore:: optimize lfn_unlink.

### DIFF
--- a/src/os/CollectionIndex.h
+++ b/src/os/CollectionIndex.h
@@ -146,7 +146,7 @@ protected:
   virtual int lookup(
     const ghobject_t &oid, ///< [in] Object to lookup
     IndexedPath *path,	   ///< [out] Path to object
-    int *exist	           ///< [out] True if the object exists, else false
+    int *hardlink          ///< [out] number of hard links of this object. *hardlink=0 mean object no-exist.
     ) = 0;
 
   /**

--- a/src/os/HashIndex.cc
+++ b/src/os/HashIndex.cc
@@ -361,7 +361,7 @@ int HashIndex::_remove(const vector<string> &path,
 int HashIndex::_lookup(const ghobject_t &oid,
 		       vector<string> *path,
 		       string *mangled_name,
-		       int *exists_out) {
+		       int *hardlink) {
   vector<string> path_comp;
   get_path_components(oid, &path_comp);
   vector<string>::iterator next = path_comp.begin();
@@ -380,7 +380,7 @@ int HashIndex::_lookup(const ghobject_t &oid,
       break;
     path->push_back(*(next++));
   }
-  return get_mangled_name(*path, oid, mangled_name, exists_out);
+  return get_mangled_name(*path, oid, mangled_name, hardlink);
 }
 
 int HashIndex::_collection_list_partial(const ghobject_t &start,

--- a/src/os/HashIndex.h
+++ b/src/os/HashIndex.h
@@ -177,7 +177,7 @@ protected:
     const ghobject_t &oid,
     vector<string> *path,
     string *mangled_name,
-    int *exists
+    int *hardlink
     );
 
   /**

--- a/src/os/LFNIndex.cc
+++ b/src/os/LFNIndex.cc
@@ -115,12 +115,12 @@ int LFNIndex::unlink(const ghobject_t &oid)
 
 int LFNIndex::lookup(const ghobject_t &oid,
 		     IndexedPath *out_path,
-		     int *exist)
+		     int *hardlink)
 {
   WRAP_RETRY(
   vector<string> path;
   string short_name;
-  r = _lookup(oid, &path, &short_name, exist);
+  r = _lookup(oid, &path, &short_name, hardlink);
   if (r < 0)
     goto out;
   string full_path = get_full_path(path, short_name);
@@ -304,9 +304,9 @@ int LFNIndex::remove_object(const vector<string> &from,
 
 int LFNIndex::get_mangled_name(const vector<string> &from,
 			       const ghobject_t &oid,
-			       string *mangled_name, int *exists)
+			       string *mangled_name, int *hardlink)
 {
-  return lfn_get_name(from, oid, mangled_name, 0, exists);
+  return lfn_get_name(from, oid, mangled_name, 0, hardlink);
 }
 
 int LFNIndex::move_subdir(
@@ -710,7 +710,7 @@ string LFNIndex::lfn_generate_object_name_poolless(const ghobject_t &oid)
 int LFNIndex::lfn_get_name(const vector<string> &path, 
 			   const ghobject_t &oid,
 			   string *mangled_name, string *out_path,
-			   int *exists)
+			   int *hardlink)
 {
   string subdir_path = get_full_path_subdir(path);
   string full_name = lfn_generate_object_name(oid);
@@ -721,18 +721,18 @@ int LFNIndex::lfn_get_name(const vector<string> &path,
       *mangled_name = full_name;
     if (out_path)
       *out_path = get_full_path(path, full_name);
-    if (exists) {
+    if (hardlink) {
       struct stat buf;
       string full_path = get_full_path(path, full_name);
       maybe_inject_failure();
       r = ::stat(full_path.c_str(), &buf);
       if (r < 0) {
 	if (errno == ENOENT)
-	  *exists = 0;
+	  *hardlink = 0;
 	else
 	  return -errno;
       } else {
-	*exists = 1;
+	*hardlink = buf.st_nlink;
       }
     }
     return 0;
@@ -762,8 +762,8 @@ int LFNIndex::lfn_get_name(const vector<string> &path,
 	*mangled_name = candidate;
       if (out_path)
 	*out_path = candidate_path;
-      if (exists)
-	*exists = 0;
+      if (hardlink)
+	*hardlink = 0;
       return 0;
     }
     assert(r > 0);
@@ -773,8 +773,11 @@ int LFNIndex::lfn_get_name(const vector<string> &path,
 	*mangled_name = candidate;
       if (out_path)
 	*out_path = candidate_path;
-      if (exists)
-	*exists = 1;
+      if (hardlink) {
+	struct stat st;
+	r = ::stat(candidate_path.c_str(), &st);
+	*hardlink = st.st_nlink;
+      }
       return 0;
     }
     r = chain_getxattr(candidate_path.c_str(), get_alt_lfn_attr().c_str(),
@@ -804,8 +807,8 @@ int LFNIndex::lfn_get_name(const vector<string> &path,
 	  *mangled_name = candidate;
 	if (out_path)
 	  *out_path = candidate_path;
-	if (exists)
-	  *exists = 1;
+	if (hardlink)
+	  *hardlink = st.st_nlink;
 	return 0;
       }
     }

--- a/src/os/LFNIndex.cc
+++ b/src/os/LFNIndex.cc
@@ -299,6 +299,8 @@ int LFNIndex::remove_object(const vector<string> &from,
   maybe_inject_failure();
   if (r < 0)
     return r;
+  if (exist == 0)
+    return -ENOENT;
   return lfn_unlink(from, oid, short_name);
 }
 

--- a/src/os/LFNIndex.cc
+++ b/src/os/LFNIndex.cc
@@ -124,20 +124,6 @@ int LFNIndex::lookup(const ghobject_t &oid,
   if (r < 0)
     goto out;
   string full_path = get_full_path(path, short_name);
-  struct stat buf;
-  maybe_inject_failure();
-  r = ::stat(full_path.c_str(), &buf);
-  maybe_inject_failure();
-  if (r < 0) {
-    if (errno == ENOENT) {
-      *exist = 0;
-    } else {
-      r = -errno;
-      goto out;
-    }
-  } else {
-    *exist = 1;
-  }
   *out_path = IndexedPath(new Path(full_path, this));
   r = 0;
   );

--- a/src/os/LFNIndex.h
+++ b/src/os/LFNIndex.h
@@ -175,7 +175,7 @@ public:
   int lookup(
     const ghobject_t &oid,
     IndexedPath *path,
-    int *exist
+    int *hardlink
     );
 
   /// @see CollectionIndex;
@@ -326,7 +326,7 @@ protected:
     const vector<string> &from, ///< [in] Subdirectory
     const ghobject_t &oid,	///< [in] Object
     string *mangled_name,	///< [out] Filename
-    int *exists			///< [out] 1 if the file exists, else 0
+    int *hardlink		///< [out] hardlink for this file, hardlink=0 mean no-exist
     );
 
   /// do move subdir from from to dest
@@ -424,7 +424,7 @@ private:
    * @param [in] oid Object for which to get filename.
    * @param [out] mangled_name Filename for oid, pass NULL if not needed.
    * @param [out] full_path Fullpath for oid, pass NULL if not needed.
-   * @param [out] exists 1 if the file exists, 0 otherwise, pass NULL if 
+   * @param [out] hardlink of this file, 0 mean no-exist, pass NULL if
    * not needed
    * @return Error Code, 0 on success.
    */
@@ -433,7 +433,7 @@ private:
     const ghobject_t &oid,
     string *mangled_name,
     string *full_path,
-    int *exists
+    int *hardlink
     );
 
   /// Adjusts path contents when oid is created at name mangled_name.


### PR DESCRIPTION
If object didn't exist, the Index::lookup return 0 and set exist to
zero. So we should first check exist.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>