### PR TITLE
os/OSD.cc: Skip report failure when OSD is isolated.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3854,6 +3854,14 @@ void OSD::heartbeat_check()
       }
     }
   }
+  //am I failed to receive heartbeat from everyone?
+  if (heartbeat_peers.size() == failure_queue.size()) {
+    //I cannot hear from anyone, suppose something wrong on my side.
+    failure_queue.clear();
+    clog->warn() << "failed to hear all the peers(cutoff " << cutoff << "), is that something wrong "
+	 << "on my side? ";
+    derr << "Skip report failure peers to monitor as I cannot hear any of my peers." <<dendl;
+  }
 }
 
 void OSD::heartbeat()


### PR DESCRIPTION
Skip reporting failure to monitor when I cannot hear no heartbeat from
all peers. Usually in this case there is something wrong on my side, likely
to be network issue.

Also warn to monitor and local log to alarm the administrator to jump in.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>