### PR TITLE
common/hobject.h: don't reverse bits in zero

### DIFF
--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -176,6 +176,8 @@ public:
   }
 
   static uint32_t _reverse_bits(uint32_t v) {
+    if (v == 0)
+      return v;
     // reverse bits
     // swap odd and even bits
     v = ((v >> 1) & 0x55555555) | ((v & 0x55555555) << 1);


### PR DESCRIPTION
Zero is passed in around 30% of all calls to _reverse_bits (and most of
them during daemon startup). Optimize this by not doing anything in
that special case and returning 0.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>