### PR TITLE
rbd-nbd: network block device (NBD) support for RBD 

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -253,6 +253,15 @@ Requires:	librbd1 = %{epoch}:%{version}-%{release}
 %description -n rbd-fuse
 FUSE based client to map Ceph rbd images to files
 
+%package -n rbd-nbd
+Summary:	Ceph RBD client base on NBD
+Group:		System Environment/Base
+Requires:	%{name}
+Requires:	librados2 = %{epoch}:%{version}-%{release}
+Requires:	librbd1 = %{epoch}:%{version}-%{release}
+%description -n rbd-nbd
+NBD based client to map Ceph rbd images to local device
+
 %package radosgw
 Summary:	Rados REST gateway
 Group:		Development/Libraries
@@ -960,6 +969,12 @@ fi
 %defattr(-,root,root,-)
 %{_bindir}/rbd-fuse
 %{_mandir}/man8/rbd-fuse.8*
+
+#################################################################################
+%files -n rbd-nbd
+%defattr(-,root,root,-)
+%{_bindir}/rbd-nbd
+%{_mandir}/man8/rbd-nbd.8*
 
 #################################################################################
 %files radosgw

--- a/debian/control
+++ b/debian/control
@@ -190,6 +190,33 @@ Description: debugging symbols for rbd-fuse
  .
  This package contains the debugging symbols for rbd-fuse.
 
+Package: rbd-nbd
+Architecture: linux-any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: NBD-based rbd client for the Ceph distributed file system
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.  This is a
+ NBD-based client that allows one to map Ceph rbd images as local
+ block device.
+ .
+ NBD base client that allows one to map Ceph rbd images as local
+ block device.
+
+Package: rbd-nbd-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: rbd-nbd (= ${binary:Version}), ${misc:Depends}
+Description: debugging symbols for rbd-nbd
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.  This is a
+ NBD-based client that allows one to map Ceph rbd images as local
+ block device.
+ .
+ This package contains the debugging symbols for rbd-nbd.
+
 Package: ceph-common
 Architecture: linux-any
 Depends: librbd1 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends},

--- a/debian/rbd-nbd.install
+++ b/debian/rbd-nbd.install
@@ -1,0 +1,2 @@
+usr/bin/rbd-nbd
+usr/share/man/man8/rbd-nbd.8

--- a/debian/rules
+++ b/debian/rules
@@ -161,6 +161,7 @@ binary-arch: build install
 	dh_strip -pceph-mds --dbg-package=ceph-mds-dbg
 	dh_strip -pceph-fuse --dbg-package=ceph-fuse-dbg
 	dh_strip -prbd-fuse --dbg-package=rbd-fuse-dbg
+	dh_strip -prbd-nbd --dbg-package=rbd-nbd-dbg
 	dh_strip -pceph-common --dbg-package=ceph-common-dbg
 	dh_strip -pceph-fs-common --dbg-package=ceph-fs-common-dbg
 	dh_strip -plibrados2 --dbg-package=librados2-dbg

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST = \
 	man/8/radosgw.rst	\
 	man/8/rados.rst	\
 	man/8/rbd-fuse.rst	\
+	man/8/rbd-nbd.rst	\
 	man/8/rbd-replay-many.rst	\
 	man/8/rbd-replay-prep.rst	\
 	man/8/rbd-replay.rst	\

--- a/doc/man/8/rbd-nbd.rst
+++ b/doc/man/8/rbd-nbd.rst
@@ -1,0 +1,55 @@
+:orphan:
+
+=========================================
+ rbd-nbd -- map rbd images to nbd device
+=========================================
+
+.. program:: rbd-nbd
+
+Synopsis
+========
+
+| **rbd-nbd** [-c conf] [--nbds_max *limit*] [--read-only] [--device *nbd device*] map *image-spec* | *snap-spec*
+| **rbd-nbd** unmap *nbd device*
+| **rbd-nbd** list-mapped
+
+Description
+===========
+
+**rbd-nbd** is a client for RADOS block device (rbd) images like rbd kernel module.
+It will map a rbd image to a nbd (Network Block Device) device, allowing access it
+as regular local block device.
+
+Options
+=======
+
+.. option:: -c ceph.conf
+
+   Use *ceph.conf* configuration file instead of the default
+   ``/etc/ceph/ceph.conf`` to determine monitor addresses during startup.
+
+.. option:: --nbds_max *limit*
+
+   Override the parameter of NBD kernel module when modprobe, used to
+   limit the count of nbd device.
+
+Image and snap specs
+====================
+
+| *image-spec* is [*pool-name*]/*image-name*
+| *snap-spec*  is [*pool-name*]/*image-name*\ @\ *snap-name*
+
+The default for *pool-name* is "rbd".  If an image name contains a slash
+character ('/'), *pool-name* is required.
+
+Availability
+============
+
+**rbd-nbd** is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+the Ceph documentation at http://ceph.com/docs for more information.
+
+
+See also
+========
+
+:doc:`rbd <rbd>`\(8)

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -321,6 +321,15 @@ Commands
 :command:`showmapped`
   Show the rbd images that are mapped via the rbd kernel module.
 
+:command:`nbd map` [--device *device-path*] [--read-only] *image-spec* | *snap-spec*
+  Maps the specified image to a block device via the rbd-nbd tool.
+
+:command:`nbd unmap` *device-path*
+  Unmaps the block device that was mapped via the rbd-nbd tool.
+
+:command:`nbd list`
+  Show the list of used nbd devices via the rbd-nbd tool.
+
 :command:`status` *image-spec*
   Show the status of the image, including which clients have it open.
 

--- a/doc/rbd/rbd.rst
+++ b/doc/rbd/rbd.rst
@@ -51,6 +51,7 @@ devices simultaneously.
 	CloudStack <rbd-cloudstack>
 	Manpage rbd <../../man/8/rbd>
 	Manpage rbd-fuse <../../man/8/rbd-fuse>
+	Manpage rbd-nbd <../../man/8/rbd-nbd>
 	Manpage ceph-rbdnamer <../../man/8/ceph-rbdnamer>
 	RBD Replay <rbd-replay>
 	Manpage rbd-replay-prep <../../man/8/rbd-replay-prep>

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -26,6 +26,7 @@ install(FILES
 	ceph-rbdnamer.8
 	ceph-post-file.8
 	rbd-fuse.8
+	rbd-nbd.8
 	rbd-replay.8
 	rbd-replay-prep.8
   DESTINATION ${CEPH_MAN_DIR}/man8)

--- a/man/Makefile-client.am
+++ b/man/Makefile-client.am
@@ -16,6 +16,7 @@ endif
 if WITH_RBD
 dist_man_MANS += \
 	ceph-rbdnamer.8 \
+	rbd-nbd.8 \
 	rbd-replay.8 \
 	rbd-replay-many.8 \
 	rbd-replay-prep.8

--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -ex
+
+pool=rbd
+gen=$pool/gen
+data=testfile
+size=64
+dev=/dev/nbd0
+
+mkdir -p rbd_nbd_test
+pushd rbd_nbd_test
+
+function expect_false()
+{
+  if "$@"; then return 1; else return 0; fi
+}
+
+rbd remove $gen || true
+rbd-nbd unmap $dev || true
+
+#read test
+dd if=/dev/urandom of=$data bs=1M count=$size
+rbd --no-progress import $data $gen
+rbd-nbd --device $dev map $gen
+[ "`dd if=$data bs=1M | md5sum`" != "`dd if=$dev bs=1M | md5sum`" ] && false
+
+#write test
+dd if=/dev/urandom of=$data bs=1M count=$size
+dd if=$data of=$dev bs=1M
+sync
+[ "`dd if=$data bs=1M | md5sum`" != "`rbd --no-progress export $gen - | md5sum`" ] && false
+
+#trim test
+mkfs.ext4 $dev # better idea?
+sync
+info=`rbd du $gen | tail -n 1`
+[ "`echo $info | awk '{print $2}'`" == "`echo $info | awk '{print $3}'`" ] && false
+
+rbd-nbd unmap $dev
+popd
+rm -rf rbd_nbd_test
+
+echo OK

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -74,6 +74,7 @@ Makefile
 /radosgw-admin
 /radosgw-object-expirer
 /rbd
+/rbd-nbd
 /rbd-fuse
 /rbd-replay
 /rbd-replay-prep

--- a/src/common/SubProcess.h
+++ b/src/common/SubProcess.h
@@ -30,6 +30,7 @@
 
 #include <sstream>
 #include <vector>
+#include <iostream>
 
 #include <include/assert.h>
 #include <common/errno.h>

--- a/src/common/SubProcess.h
+++ b/src/common/SubProcess.h
@@ -40,7 +40,7 @@
  *
  * Example:
  *
- *   SubProcess cat("cat", true, true);
+ *   SubProcess cat("cat", SubProcess::PIPE, SubProcess::PIPE);
  *   if (cat.spawn() != 0) {
  *     std::cerr << "cat failed: " << cat.err() << std::endl;
  *     return false;
@@ -56,8 +56,16 @@
 
 class SubProcess {
 public:
-  SubProcess(const char *cmd, bool pipe_stdin = false, bool pipe_stdout = false,
-	     bool pipe_stderr = false);
+  enum std_fd_op{
+    KEEP,
+    CLOSE,
+    PIPE
+  };
+public:
+  SubProcess(const char *cmd,
+             std_fd_op stdin_op = CLOSE,
+             std_fd_op stdout_op = CLOSE,
+             std_fd_op stderr_op = CLOSE);
   virtual ~SubProcess();
 
   void add_cmd_args(const char *arg, ...);
@@ -90,9 +98,9 @@ private:
 protected:
   std::string cmd;
   std::vector<std::string> cmd_args;
-  bool pipe_stdin;
-  bool pipe_stdout;
-  bool pipe_stderr;
+  std_fd_op stdin_op;
+  std_fd_op stdout_op;
+  std_fd_op stderr_op;
   int stdin_pipe_out_fd;
   int stdout_pipe_in_fd;
   int stderr_pipe_in_fd;
@@ -102,8 +110,8 @@ protected:
 
 class SubProcessTimed : public SubProcess {
 public:
-  SubProcessTimed(const char *cmd, bool pipe_stdin = false,
-		  bool pipe_stdout = false, bool pipe_stderr = false,
+  SubProcessTimed(const char *cmd, std_fd_op stdin_op = CLOSE,
+		  std_fd_op stdout_op = CLOSE, std_fd_op stderr_op = CLOSE,
 		  int timeout = 0, int sigkill = SIGKILL);
 
 protected:
@@ -114,12 +122,12 @@ private:
   int sigkill;
 };
 
-SubProcess::SubProcess(const char *cmd_, bool use_stdin, bool use_stdout, bool use_stderr) :
+SubProcess::SubProcess(const char *cmd_, std_fd_op stdin_op_, std_fd_op stdout_op_, std_fd_op stderr_op_) :
   cmd(cmd_),
   cmd_args(),
-  pipe_stdin(use_stdin),
-  pipe_stdout(use_stdout),
-  pipe_stderr(use_stderr),
+  stdin_op(stdin_op_),
+  stdout_op(stdout_op_),
+  stderr_op(stderr_op_),
   stdin_pipe_out_fd(-1),
   stdout_pipe_in_fd(-1),
   stderr_pipe_in_fd(-1),
@@ -155,21 +163,21 @@ void SubProcess::add_cmd_arg(const char *arg) {
 
 int SubProcess::get_stdin() const {
   assert(is_spawned());
-  assert(pipe_stdin);
+  assert(stdin_op == PIPE);
 
   return stdin_pipe_out_fd;
 }
 
 int SubProcess::get_stdout() const {
   assert(is_spawned());
-  assert(pipe_stdout);
+  assert(stdout_op == PIPE);
 
   return stdout_pipe_in_fd;
 }
 
 int SubProcess::get_stderr() const {
   assert(is_spawned());
-  assert(pipe_stderr);
+  assert(stderr_op == PIPE);
 
   return stderr_pipe_in_fd;
 }
@@ -184,21 +192,21 @@ void SubProcess::close(int &fd) {
 
 void SubProcess::close_stdin() {
   assert(is_spawned());
-  assert(pipe_stdin);
+  assert(stdin_op == PIPE);
 
   close(stdin_pipe_out_fd);
 }
 
 void SubProcess::close_stdout() {
   assert(is_spawned());
-  assert(pipe_stdout);
+  assert(stdout_op == PIPE);
 
   close(stdout_pipe_in_fd);
 }
 
 void SubProcess::close_stderr() {
   assert(is_spawned());
-  assert(pipe_stderr);
+  assert(stderr_op == PIPE);
 
   close(stderr_pipe_in_fd);
 }
@@ -247,9 +255,9 @@ int SubProcess::spawn() {
 
   int ret = 0;
 
-  if ((pipe_stdin  && ::pipe(ipipe) == -1) ||
-      (pipe_stdout && ::pipe(opipe) == -1) ||
-      (pipe_stderr && ::pipe(epipe) == -1)) {
+  if ((stdin_op == PIPE  && ::pipe(ipipe) == -1) ||
+      (stdout_op == PIPE && ::pipe(opipe) == -1) ||
+      (stderr_op == PIPE && ::pipe(epipe) == -1)) {
     ret = -errno;
     errstr << "pipe failed: " << cpp_strerror(errno);
     goto fail;
@@ -290,11 +298,11 @@ int SubProcess::spawn() {
     if (maxfd == -1)
       maxfd = 16384;
     for (int fd = 0; fd <= maxfd; fd++) {
-      if (fd == STDIN_FILENO && pipe_stdin)
+      if (fd == STDIN_FILENO && stdin_op != CLOSE)
 	continue;
-      if (fd == STDOUT_FILENO && pipe_stdout)
+      if (fd == STDOUT_FILENO && stdout_op != CLOSE)
 	continue;
-      if (fd == STDERR_FILENO && pipe_stderr)
+      if (fd == STDERR_FILENO && stderr_op != CLOSE)
 	continue;
       ::close(fd);
     }
@@ -363,10 +371,10 @@ int SubProcess::join() {
   return EXIT_FAILURE;
 }
 
-SubProcessTimed::SubProcessTimed(const char *cmd, bool pipe_stdin,
-				 bool pipe_stdout, bool pipe_stderr,
+SubProcessTimed::SubProcessTimed(const char *cmd, std_fd_op stdin_op,
+				 std_fd_op stdout_op, std_fd_op stderr_op,
 				 int timeout_, int sigkill_) :
-  SubProcess(cmd, pipe_stdin, pipe_stdout, pipe_stderr),
+  SubProcess(cmd, stdin_op, stdout_op, stderr_op),
   timeout(timeout_),
   sigkill(sigkill_) {
 }

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -359,7 +359,7 @@ int CrushTester::test_with_crushtool(const char *crushtool_cmd,
 				     int max_id, int timeout,
 				     int ruleset)
 {
-  SubProcessTimed crushtool(crushtool_cmd, true, false, true, timeout);
+  SubProcessTimed crushtool(crushtool_cmd, SubProcess::PIPE, SubProcess::CLOSE, SubProcess::PIPE, timeout);
   string opt_max_id = boost::lexical_cast<string>(max_id);
   crushtool.add_cmd_args(
     "-i", "-",

--- a/src/ps-ceph.pl
+++ b/src/ps-ceph.pl
@@ -18,6 +18,7 @@ sub is_ceph_proc {
 
         return 1 if $cmdline =~ /\bceph\b/;
         return 1 if $cmdline =~ /\bceph-fuse\b/;
+        return 1 if $cmdline =~ /\brbd-nbd\b/;
         return 1 if $cmdline =~ /\brbd-fuse\b/;
         return 1 if $cmdline =~ /\bceph-mds\b/;
         return 1 if $cmdline =~ /\bceph-mon\b/;

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -36,6 +36,9 @@
       lock remove (lock rm)       Release a lock on an image.
       map                         Map image to a block device using the kernel.
       merge-diff                  Merge two diff exports together.
+      nbd list (nbd ls)           List the nbd devices already used.
+      nbd map                     Map image to a nbd device.
+      nbd unmap                   Unmap a nbd device.
       object-map rebuild          Rebuild an invalid object map.
       remove (rm)                 Delete an image.
       rename (mv)                 Rename image within pool.
@@ -556,6 +559,38 @@
   Optional arguments
     --path arg           path to merged diff (or '-' for stdout)
     --no-progress        disable progress output
+  
+  rbd help nbd list
+  usage: rbd nbd list 
+  
+  List the nbd devices already used.
+  
+  rbd help nbd map
+  usage: rbd nbd map [--pool <pool>] [--image <image>] [--snap <snap>] 
+                     [--read-only] [--device <device>] 
+                     <image-or-snap-spec> 
+  
+  Map image to a nbd device.
+  
+  Positional arguments
+    <image-or-snap-spec>  image or snapshot specification
+                          (example: [<pool-name>/]<image-name>[@<snap-name>])
+  
+  Optional arguments
+    -p [ --pool ] arg     pool name
+    --image arg           image name
+    --snap arg            snapshot name
+    --read-only           mount read-only
+    --device arg          specify nbd device
+  
+  rbd help nbd unmap
+  usage: rbd nbd unmap 
+                       <device-spec> 
+  
+  Unmap a nbd device.
+  
+  Positional arguments
+    <device-spec>        specify nbd device
   
   rbd help object-map rebuild
   usage: rbd object-map rebuild [--pool <pool>] [--image <image>] 

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -43,6 +43,9 @@
 #include "include/rados/librados.h"
 #include "include/rbd/librbd.h"
 
+#include "common/SubProcess.h"
+#include "common/safe_io.h"
+
 #define NUMPRINTCOLUMNS 32	/* # columns of data to print on each line */
 
 /*
@@ -255,8 +258,8 @@ get_random(void)
 struct rbd_ctx {
 	const char *name;	/* image name */
 	rbd_image_t image;	/* image handle */
-	const char *krbd_name;	/* image /dev/rbd<id> name */
-	int krbd_fd;		/* image /dev/rbd<id> fd */
+	const char *krbd_name;	/* image /dev/rbd<id> name */ /* reused for nbd test */
+	int krbd_fd;		/* image /dev/rbd<id> fd */ /* reused for nbd test */
 };
 
 #define RBD_CTX_INIT	(struct rbd_ctx) { NULL, NULL, NULL, -1 }
@@ -788,6 +791,127 @@ const struct rbd_operations krbd_operations = {
 	krbd_get_size,
 	krbd_resize,
 	krbd_clone,
+	krbd_flatten,
+};
+
+int
+nbd_open(const char *name, struct rbd_ctx *ctx)
+{
+	int r;
+	int fd;
+	char dev[4096];
+	char *devnode;
+
+	SubProcess process("rbd-nbd", SubProcess::KEEP, SubProcess::PIPE);
+	process.add_cmd_arg("map");
+	std::string img;
+	img.append(pool);
+	img.append("/");
+	img.append(name);
+	process.add_cmd_arg(img.c_str());
+
+	r = __librbd_open(name, ctx);
+	if (r < 0)
+		return r;
+
+        r = process.spawn();
+        if (r < 0) {
+		prt("nbd_open failed to run rbd-nbd error: %s\n", process.err());
+		return r;
+        }
+	r = safe_read(process.get_stdout(), dev, sizeof(dev));
+	if (r < 0) {
+		prt("nbd_open failed to get nbd device path\n");
+		return r;
+	}
+	for (int i = 0; i < r; ++i)
+	  if (dev[i] == 10 || dev[i] == 13)
+	    dev[i] = 0;
+	dev[r] = 0;
+	r = process.join();
+	if (r) {
+		prt("rbd-nbd failed with error: %s", process.err());
+		return -EINVAL;
+	}
+
+	devnode = strdup(dev);
+	if (!devnode)
+		return -ENOMEM;
+
+	fd = open(devnode, O_RDWR | o_direct);
+	if (fd < 0) {
+		r = -errno;
+		prt("open(%s) failed\n", devnode);
+		return r;
+	}
+
+	ctx->krbd_name = devnode;
+	ctx->krbd_fd = fd;
+
+	return 0;
+}
+
+int
+nbd_close(struct rbd_ctx *ctx)
+{
+	int r;
+
+	assert(ctx->krbd_name && ctx->krbd_fd >= 0);
+
+	if (close(ctx->krbd_fd) < 0) {
+		r = -errno;
+		prt("close(%s) failed\n", ctx->krbd_name);
+		return r;
+	}
+
+	SubProcess process("rbd-nbd");
+	process.add_cmd_arg("unmap");
+	process.add_cmd_arg(ctx->krbd_name);
+
+        r = process.spawn();
+        if (r < 0) {
+		prt("nbd_close failed to run rbd-nbd error: %s\n", process.err());
+		return r;
+        }
+	r = process.join();
+	if (r) {
+		prt("rbd-nbd failed with error: %d", process.err());
+		return -EINVAL;
+	}
+
+	free((void *)ctx->krbd_name);
+
+	ctx->krbd_name = NULL;
+	ctx->krbd_fd = -1;
+
+	return __librbd_close(ctx);
+}
+
+int
+nbd_clone(struct rbd_ctx *ctx, const char *src_snapname,
+	  const char *dst_imagename, int *order, int stripe_unit,
+	  int stripe_count)
+{
+	int ret;
+
+	ret = __krbd_flush(ctx, false);
+	if (ret < 0)
+		return ret;
+
+	return __librbd_clone(ctx, src_snapname, dst_imagename, order,
+			      stripe_unit, stripe_count, false);
+}
+
+const struct rbd_operations nbd_operations = {
+	nbd_open,
+	nbd_close,
+	krbd_read,
+	krbd_write,
+	krbd_flush,
+	krbd_discard,
+	krbd_get_size,
+	krbd_resize,
+	nbd_clone,
 	krbd_flatten,
 };
 
@@ -1824,6 +1948,7 @@ usage(void)
 #endif
 "	-H: do not use punch hole calls\n\
 	-K: enable krbd mode (use -t and -h too)\n\
+	-M: enable rbd-nbd mode (use -t and -h too)\n\
 	-L: fsxLite - no file creations & no file size changes\n\
 	-N numops: total # operations to do (default infinity)\n\
 	-O: use oplen (see -o flag) for every op (default random)\n\
@@ -2010,7 +2135,7 @@ main(int argc, char **argv)
 
 	setvbuf(stdout, (char *)0, _IOLBF, 0); /* line buffered stdout */
 
-	while ((ch = getopt(argc, argv, "b:c:dfh:l:m:no:p:qr:s:t:w:xyACD:FHKLN:OP:RS:UWZ"))
+	while ((ch = getopt(argc, argv, "b:c:dfh:l:m:no:p:qr:s:t:w:xyACD:FHKMLN:OP:RS:UWZ"))
 	       != EOF)
 		switch (ch) {
 		case 'b':
@@ -2125,6 +2250,10 @@ main(int argc, char **argv)
 		case 'K':
 			prt("krbd mode enabled\n");
 			ops = &krbd_operations;
+			break;
+		case 'M':
+			prt("rbd-nbd mode enabled\n");
+			ops = &nbd_operations;
 			break;
 		case 'L':
 			prt("lite mode not supported for rbd\n");

--- a/src/test/test_subprocess.cc
+++ b/src/test/test_subprocess.cc
@@ -51,7 +51,7 @@ TEST(SubProcess, False)
 
 TEST(SubProcess, NotFound)
 {
-  SubProcess p("NOTEXISTENTBINARY", false, false, true);
+  SubProcess p("NOTEXISTENTBINARY", SubProcess::CLOSE, SubProcess::CLOSE, SubProcess::PIPE);
   ASSERT_EQ(p.spawn(), 0);
   std::string buf;
   ASSERT_TRUE(read_from_fd(p.get_stderr(), buf));
@@ -63,7 +63,7 @@ TEST(SubProcess, NotFound)
 
 TEST(SubProcess, Echo)
 {
-  SubProcess echo("echo", false, true);
+  SubProcess echo("echo", SubProcess::CLOSE, SubProcess::PIPE);
   echo.add_cmd_args("1", "2", "3", NULL);
 
   ASSERT_EQ(echo.spawn(), 0);
@@ -77,7 +77,7 @@ TEST(SubProcess, Echo)
 
 TEST(SubProcess, Cat)
 {
-  SubProcess cat("cat", true, true, true);
+  SubProcess cat("cat", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE);
 
   ASSERT_EQ(cat.spawn(), 0);
   std::string msg("to my, trociny!");
@@ -96,7 +96,7 @@ TEST(SubProcess, Cat)
 
 TEST(SubProcess, CatDevNull)
 {
-  SubProcess cat("cat", true, true, true);
+  SubProcess cat("cat", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE);
   cat.add_cmd_arg("/dev/null");
 
   ASSERT_EQ(cat.spawn(), 0);
@@ -111,7 +111,7 @@ TEST(SubProcess, CatDevNull)
 
 TEST(SubProcess, Killed)
 {
-  SubProcessTimed cat("cat", true, true);
+  SubProcessTimed cat("cat", SubProcess::PIPE, SubProcess::PIPE);
 
   ASSERT_EQ(cat.spawn(), 0);
   cat.kill();
@@ -122,7 +122,7 @@ TEST(SubProcess, Killed)
 
 TEST(SubProcess, CatWithArgs)
 {
-  SubProcess cat("cat", true, true, true);
+  SubProcess cat("cat", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE);
   cat.add_cmd_args("/dev/stdin", "/dev/null", "/NOTEXIST", NULL);
 
   ASSERT_EQ(cat.spawn(), 0);
@@ -144,7 +144,7 @@ TEST(SubProcess, CatWithArgs)
 
 TEST(SubProcess, Subshell)
 {
-  SubProcess sh("/bin/sh", true, true, true);
+  SubProcess sh("/bin/sh", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE);
   sh.add_cmd_args("-c",
       "sleep 0; "
       "cat; "
@@ -169,7 +169,7 @@ TEST(SubProcess, Subshell)
 
 TEST(SubProcessTimed, True)
 {
-  SubProcessTimed p("true", false, false, false, 10);
+  SubProcessTimed p("true", SubProcess::CLOSE, SubProcess::CLOSE, SubProcess::CLOSE, 10);
   ASSERT_EQ(p.spawn(), 0);
   ASSERT_EQ(p.join(), 0);
   ASSERT_TRUE(p.err()[0] == '\0');
@@ -177,7 +177,7 @@ TEST(SubProcessTimed, True)
 
 TEST(SubProcessTimed, SleepNoTimeout)
 {
-  SubProcessTimed sleep("sleep", false, false, false, 0);
+  SubProcessTimed sleep("sleep", SubProcess::CLOSE, SubProcess::CLOSE, SubProcess::CLOSE, 0);
   sleep.add_cmd_arg("1");
 
   ASSERT_EQ(sleep.spawn(), 0);
@@ -187,7 +187,7 @@ TEST(SubProcessTimed, SleepNoTimeout)
 
 TEST(SubProcessTimed, Killed)
 {
-  SubProcessTimed cat("cat", true, true, true, 5);
+  SubProcessTimed cat("cat", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 5);
 
   ASSERT_EQ(cat.spawn(), 0);
   cat.kill();
@@ -203,7 +203,7 @@ TEST(SubProcessTimed, Killed)
 
 TEST(SubProcessTimed, SleepTimedout)
 {
-  SubProcessTimed sleep("sleep", false, false, true, 1);
+  SubProcessTimed sleep("sleep", SubProcess::CLOSE, SubProcess::CLOSE, SubProcess::PIPE, 1);
   sleep.add_cmd_arg("10");
 
   ASSERT_EQ(sleep.spawn(), 0);
@@ -218,7 +218,7 @@ TEST(SubProcessTimed, SleepTimedout)
 
 TEST(SubProcessTimed, SubshellNoTimeout)
 {
-  SubProcessTimed sh("/bin/sh", true, true, true, 0);
+  SubProcessTimed sh("/bin/sh", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 0);
   sh.add_cmd_args("-c", "cat >&2", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string msg("the quick brown fox jumps over the lazy dog");
@@ -238,7 +238,7 @@ TEST(SubProcessTimed, SubshellNoTimeout)
 
 TEST(SubProcessTimed, SubshellKilled)
 {
-  SubProcessTimed sh("/bin/sh", true, true, true, 10);
+  SubProcessTimed sh("/bin/sh", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 10);
   sh.add_cmd_args("-c", "sh -c cat", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string msg("etaoin shrdlu");
@@ -255,7 +255,7 @@ TEST(SubProcessTimed, SubshellKilled)
 
 TEST(SubProcessTimed, SubshellTimedout)
 {
-  SubProcessTimed sh("/bin/sh", true, true, true, 1, SIGTERM);
+  SubProcessTimed sh("/bin/sh", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 1, SIGTERM);
   sh.add_cmd_args("-c", "sleep 1000& cat; NEVER REACHED", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string buf;

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -67,6 +67,12 @@ rbd_LDADD = \
 	$(BOOST_REGEX_LIBS) $(BOOST_PROGRAM_OPTIONS_LIBS)
 if LINUX
 bin_PROGRAMS += rbd
+
+rbd_nbd_SOURCES = tools/rbd_nbd/rbd-nbd.cc
+rbd_nbd_CXXFLAGS = $(AM_CXXFLAGS)
+rbd_nbd_LDADD = $(LIBRBD) $(LIBRADOS) $(CEPH_GLOBAL) $(BOOST_REGEX_LIBS)
+bin_PROGRAMS += rbd-nbd
+
 endif # LINUX
 
 endif # WITH_RBD

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -46,6 +46,7 @@ rbd_SOURCES = \
 	tools/rbd/action/ImportDiff.cc \
 	tools/rbd/action/Info.cc \
 	tools/rbd/action/Kernel.cc \
+	tools/rbd/action/Nbd.cc \
 	tools/rbd/action/List.cc \
 	tools/rbd/action/Lock.cc \
 	tools/rbd/action/MergeDiff.cc \

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -1,0 +1,186 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "tools/rbd/ArgumentTypes.h"
+#include "tools/rbd/Shell.h"
+#include "tools/rbd/Utils.h"
+#include "include/stringify.h"
+#include "common/SubProcess.h"
+#include <iostream>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/scope_exit.hpp>
+#include <boost/program_options.hpp>
+
+namespace rbd {
+namespace action {
+namespace nbd {
+
+namespace at = argument_types;
+namespace po = boost::program_options;
+
+static int call_nbd_cmd(const po::variables_map &vm,
+                        const std::vector<const char*> &args)
+{
+  char exe_path[PATH_MAX];
+  ssize_t exe_path_bytes = readlink("/proc/self/exe", exe_path,
+				    sizeof(exe_path) - 1);
+  if (exe_path_bytes < 0) {
+    strcpy(exe_path, "rbd-nbd");
+  } else {
+    if (snprintf(exe_path + exe_path_bytes,
+                 sizeof(exe_path) - exe_path_bytes,
+                 "-nbd") < 0) {
+      return -EOVERFLOW;
+    }
+  }
+
+  SubProcess process(exe_path, SubProcess::KEEP, SubProcess::KEEP, SubProcess::KEEP);
+
+  if (vm.count("conf")) {
+    process.add_cmd_arg("--conf");
+    process.add_cmd_arg(vm["conf"].as<std::string>().c_str());
+  }
+  if (vm.count("cluster")) {
+    process.add_cmd_arg("--cluster");
+    process.add_cmd_arg(vm["cluster"].as<std::string>().c_str());
+  }
+  if (vm.count("id")) {
+    process.add_cmd_arg("--id");
+    process.add_cmd_arg(vm["id"].as<std::string>().c_str());
+  }
+  if (vm.count("name")) {
+    process.add_cmd_arg("--name");
+    process.add_cmd_arg(vm["name"].as<std::string>().c_str());
+  }
+  if (vm.count("mon_host")) {
+    process.add_cmd_arg("--mon_host");
+    process.add_cmd_arg(vm["mon_host"].as<std::string>().c_str());
+  }
+  if (vm.count("keyfile")) {
+    process.add_cmd_arg("--keyfile");
+    process.add_cmd_arg(vm["keyfile"].as<std::string>().c_str());
+  }
+  if (vm.count("keyring")) {
+    process.add_cmd_arg("--keyring");
+    process.add_cmd_arg(vm["keyring"].as<std::string>().c_str());
+  }
+
+  for (std::vector<const char*>::const_iterator p = args.begin();
+       p != args.end(); p++)
+    process.add_cmd_arg(*p);
+
+  if (process.spawn()) {
+    std::cerr << "rbd: failed to run rbd-nbd: " << process.err() << std::endl;
+    return -EINVAL;
+  } else if (process.join()) {
+    std::cerr << "rbd: rbd-nbd failed with error: " << process.err() << std::endl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+void get_show_arguments(po::options_description *positional,
+                        po::options_description *options)
+{ }
+
+int execute_show(const po::variables_map &vm)
+{
+  std::vector<const char*> args;
+
+  args.push_back("list-mapped");
+
+  return call_nbd_cmd(vm, args);
+}
+
+void get_map_arguments(po::options_description *positional,
+                       po::options_description *options)
+{
+  at::add_image_or_snap_spec_options(positional, options,
+                                     at::ARGUMENT_MODIFIER_NONE);
+  options->add_options()
+    ("read-only", po::bool_switch(), "mount read-only")
+    ("device", po::value<std::string>(), "specify nbd device");
+}
+
+int execute_map(const po::variables_map &vm)
+{
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string image_name;
+  std::string snap_name;
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &image_name,
+    &snap_name, utils::SNAPSHOT_PRESENCE_PERMITTED);
+  if (r < 0) {
+    return r;
+  }
+
+  std::vector<const char*> args;
+
+  args.push_back("map");
+  std::string img;
+  img.append(pool_name);
+  img.append("/");
+  img.append(image_name);
+  if (!snap_name.empty()) {
+    img.append("@");
+    img.append(snap_name);
+  }
+  args.push_back(img.c_str());
+
+  if (vm["read-only"].as<bool>())
+    args.push_back("--read-only");
+
+  if (vm.count("device")) {
+    args.push_back("--device");
+    args.push_back(vm["device"].as<std::string>().c_str());
+  }
+
+  return call_nbd_cmd(vm, args);
+}
+
+void get_unmap_arguments(po::options_description *positional,
+                   po::options_description *options)
+{
+  positional->add_options()
+    ("device-spec", "specify nbd device");
+}
+
+int execute_unmap(const po::variables_map &vm)
+{
+  std::string device_name = utils::get_positional_argument(vm, 0);
+  if (!boost::starts_with(device_name, "/dev/")) {
+    device_name.clear();
+  }
+
+  if (device_name.empty()) {
+    std::cerr << "rbd: nbd unmap requires device path" << std::endl;
+    return -EINVAL;
+  }
+
+  std::vector<const char*> args;
+
+  args.push_back("unmap");
+  args.push_back(device_name.c_str());
+
+  return call_nbd_cmd(vm, args);
+}
+
+Shell::SwitchArguments switched_arguments({"read-only"});
+
+Shell::Action action_show(
+  {"nbd", "list"}, {"nbd", "ls"}, "List the nbd devices already used.", "",
+  &get_show_arguments, &execute_show);
+
+Shell::Action action_map(
+  {"nbd", "map"}, {}, "Map image to a nbd device.", "",
+  &get_map_arguments, &execute_map);
+
+Shell::Action action_unmap(
+  {"nbd", "unmap"}, {}, "Unmap a nbd device.", "",
+  &get_unmap_arguments, &execute_unmap);
+
+} // namespace nbd
+} // namespace action
+} // namespace rbd

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1,0 +1,739 @@
+#include "include/int_types.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include <linux/nbd.h>
+#include <linux/fs.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+
+#include <iostream>
+#include <boost/regex.hpp>
+
+#include "mon/MonClient.h"
+#include "common/config.h"
+
+#include "common/errno.h"
+#include "common/module.h"
+#include "common/safe_io.h"
+#include "common/ceph_argparse.h"
+#include "common/Preforker.h"
+#include "global/global_init.h"
+
+#include "include/rados/librados.hpp"
+#include "include/rbd/librbd.hpp"
+
+static void usage()
+{
+  std::cout << "Usage: rbd-nbd [options] map <image-or-snap-spec>  Map a image to nbd device\n"
+            << "               unmap <device path>                 Unmap nbd device\n"
+            << "               list-mapped                         List mapped nbd devices\n"
+            << "Options: --device <device path>                    Specify nbd device path\n"
+            << "         --read-only                               Map readonly\n"
+            << "         --nbds_max <limit>                        Override for module param\n"
+            << std::endl;
+}
+
+static Preforker forker;
+static std::string devpath, poolname("rbd"), imgname, snapname;
+static bool readonly = false;
+static int nbds_max = 0;
+
+#ifdef CEPH_BIG_ENDIAN
+#define ntohll(a) (a)
+#elif defined(CEPH_LITTLE_ENDIAN)
+#define ntohll(a) swab64(a)
+#else
+#error "Could not determine endianess"
+#endif
+#define htonll(a) ntohll(a)
+
+class NBDServer
+{
+private:
+  int fd;
+  librbd::Image &image;
+
+public:
+  NBDServer(int _fd, librbd::Image& _image)
+    : fd(_fd)
+    , image(_image)
+    , terminated(false)
+    , lock("NBDServer::Locker")
+    , reader_thread(*this, &NBDServer::reader_entry)
+    , writer_thread(*this, &NBDServer::writer_entry)
+    , started(false)
+  {}
+
+private:
+  atomic_t terminated;
+
+  void shutdown()
+  {
+    if (terminated.compare_and_swap(false, true)) {
+      ::shutdown(fd, SHUT_RDWR);
+
+      Mutex::Locker l(lock);
+      cond.Signal();
+    }
+  }
+
+  struct IOContext
+  {
+    xlist<IOContext*>::item item;
+    NBDServer *server;
+    struct nbd_request request;
+    struct nbd_reply reply;
+    bufferlist data;
+    int command;
+
+    IOContext()
+      : item(this)
+    {}
+  };
+
+  Mutex lock;
+  Cond cond;
+  xlist<IOContext*> io_pending;
+  xlist<IOContext*> io_finished;
+
+  void io_start(IOContext *ctx)
+  {
+    Mutex::Locker l(lock);
+    io_pending.push_back(&ctx->item);
+  }
+
+  void io_finish(IOContext *ctx)
+  {
+    Mutex::Locker l(lock);
+    assert(ctx->item.is_on_list());
+    ctx->item.remove_myself();
+    io_finished.push_back(&ctx->item);
+    cond.Signal();
+  }
+
+  IOContext *wait_io_finish()
+  {
+    Mutex::Locker l(lock);
+    while(io_finished.empty() && !terminated.read())
+      cond.Wait(lock);
+
+    if (io_finished.empty())
+      return NULL;
+
+    IOContext *ret = io_finished.front();
+    io_finished.pop_front();
+
+    return ret;
+  }
+
+  void wait_clean()
+  {
+    assert(!reader_thread.is_started());
+    Mutex::Locker l(lock);
+    while(!io_pending.empty())
+      cond.Wait(lock);
+
+    while(!io_finished.empty()) {
+      ceph::unique_ptr<IOContext> free_ctx(io_finished.front());
+      io_finished.pop_front();
+    }
+  }
+
+  static void aio_callback(librbd::completion_t cb, void *arg)
+  {
+    librbd::RBD::AioCompletion *aio_completion =
+    reinterpret_cast<librbd::RBD::AioCompletion*>(cb);
+
+    IOContext *ctx = reinterpret_cast<IOContext *>(arg);
+    int ret = aio_completion->get_return_value();
+    if (ret > 0)
+      ret = 0;
+    ctx->reply.error = htonl(ret);
+    ctx->server->io_finish(ctx);
+
+    aio_completion->release();
+  }
+
+  void reader_entry()
+  {
+    while (!terminated.read()) {
+      ceph::unique_ptr<IOContext> ctx(new IOContext());
+      ctx->server = this;
+      if (safe_read_exact(fd, &ctx->request, sizeof(struct nbd_request)) < 0)
+        return;
+
+      if (ctx->request.magic != htonl(NBD_REQUEST_MAGIC))
+        return;
+
+      ctx->request.from = ntohll(ctx->request.from);
+      ctx->request.type = ntohl(ctx->request.type);
+      ctx->request.len = ntohl(ctx->request.len);
+
+      ctx->reply.magic = htonl(NBD_REPLY_MAGIC);
+      memcpy(ctx->reply.handle, ctx->request.handle, sizeof(ctx->reply.handle));
+
+      ctx->command = ctx->request.type & 0x0000ffff;
+
+      switch (ctx->command)
+      {
+        case NBD_CMD_DISC:
+          return;
+        case NBD_CMD_WRITE:
+          bufferptr ptr(ctx->request.len);
+          if (safe_read_exact(fd, ptr.c_str(), ctx->request.len) < 0)
+            return;
+          ctx->data.push_back(ptr);
+          break;
+      }
+
+      IOContext *pctx = ctx.release();
+      io_start(pctx);
+      librbd::RBD::AioCompletion *c = new librbd::RBD::AioCompletion(pctx, aio_callback);
+      switch (pctx->command)
+      {
+        case NBD_CMD_WRITE:
+          image.aio_write(pctx->request.from, pctx->request.len, pctx->data, c);
+          break;
+        case NBD_CMD_READ:
+          image.aio_read(pctx->request.from, pctx->request.len, pctx->data, c);
+          break;
+        case NBD_CMD_FLUSH:
+          image.aio_flush(c);
+          break;
+        case NBD_CMD_TRIM:
+          image.aio_discard(pctx->request.from, pctx->request.len, c);
+          break;
+        default:
+          return;
+      }
+    }
+  }
+
+  void writer_entry()
+  {
+    while (!terminated.read()) {
+      ceph::unique_ptr<IOContext> ctx(wait_io_finish());
+      if (!ctx)
+        return;
+
+      if (safe_write(fd, &ctx->reply, sizeof(struct nbd_reply)) < 0)
+        return;
+      if (ctx->command == NBD_CMD_READ && ctx->reply.error == htonl(0)) {
+        if (ctx->data.write_fd(fd) < 0)
+          return;
+      }
+    }
+  }
+
+  class ThreadHelper : public Thread
+  {
+  public:
+    typedef void (NBDServer::*entry_func)();
+  private:
+    NBDServer &server;
+    entry_func func;
+  public:
+    ThreadHelper(NBDServer &_server, entry_func _func)
+      :server(_server)
+      ,func(_func)
+    {}
+  protected:
+    virtual void* entry()
+    {
+      (server.*func)();
+      server.shutdown();
+      return NULL;
+    }
+  } reader_thread, writer_thread;
+
+  bool started;
+public:
+  void start()
+  {
+    if (!started) {
+      started = true;
+
+      reader_thread.create();
+      writer_thread.create();
+    }
+  }
+
+  void stop()
+  {
+    if (started) {
+      shutdown();
+
+      reader_thread.join();
+      writer_thread.join();
+
+      wait_clean();
+
+      started = false;
+    }
+  }
+
+  ~NBDServer()
+  {
+    stop();
+  }
+};
+
+
+class NBDWatchCtx : public librados::WatchCtx2
+{
+private:
+  int fd;
+  librados::IoCtx &io_ctx;
+  librbd::Image &image;
+  std::string header_oid;
+  unsigned long size;
+public:
+  NBDWatchCtx(int _fd,
+              librados::IoCtx &_io_ctx,
+              librbd::Image &_image,
+              std::string &_header_oid,
+              unsigned long _size)
+    : fd(_fd)
+    , io_ctx(_io_ctx)
+    , image(_image)
+    , header_oid(_header_oid)
+    , size(_size)
+  { }
+
+  virtual ~NBDWatchCtx() {}
+
+  virtual void handle_notify(uint64_t notify_id,
+                             uint64_t cookie,
+                             uint64_t notifier_id,
+                             bufferlist& bl)
+  {
+    librbd::image_info_t info;
+    if (image.stat(info, sizeof(info)) == 0) {
+      unsigned long new_size = info.size;
+
+      if (new_size != size) {
+        if (ioctl(fd, BLKFLSBUF, NULL) < 0)
+          std::cerr << "rbd-nbd: invalidate page cache failed status: " << cpp_strerror(errno) << std::endl;
+        if (ioctl(fd, NBD_SET_SIZE, new_size) < 0)
+          std::cerr << "rbd-nbd: resize failed status: " << cpp_strerror(errno) << std::endl;
+        if (image.invalidate_cache() < 0)
+          std::cerr << "rbd-nbd: invalidate rbd cache failed" << std::endl;
+        size = new_size;
+      }
+    }
+
+    bufferlist reply;
+    io_ctx.notify_ack(header_oid, notify_id, cookie, reply);
+  }
+
+  virtual void handle_error(uint64_t cookie, int err)
+  {
+    //ignore
+  }
+};
+
+static int open_device(const char* path, bool try_load_moudle = false)
+{
+  int nbd = open(path, O_RDWR);
+  if (nbd < 0 && try_load_moudle && access("/sys/module/nbd", F_OK) != 0) {
+    int r;
+    if (nbds_max) {
+      ostringstream param;
+      param << "nbds_max=" << nbds_max;
+      r = module_load("nbd", param.str().c_str());
+    } else {
+      r = module_load("nbd", NULL);
+    }
+    if (r < 0) {
+      cerr << "rbd-nbd: failed to load nbd kernel module: " << cpp_strerror(-r) << std::endl;
+      return r;
+    }
+    nbd = open(path, O_RDWR);
+  }
+  return nbd;
+}
+
+static int do_map()
+{
+  int r;
+
+  librados::Rados rados;
+  librbd::RBD rbd;
+  librados::IoCtx io_ctx;
+  librbd::Image image;
+
+  int read_only;
+  unsigned long flags;
+  unsigned long size;
+
+  int fd[2];
+  int nbd;
+  int null_fd = -1;
+
+  uint8_t old_format;
+  librbd::image_info_t info;
+
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, fd) == -1) {
+    r = -errno;
+    goto close_ret;
+  }
+
+  if (devpath.empty()) {
+    char dev[64];
+    int index = 0;
+    while (true) {
+      snprintf(dev, sizeof(dev), "/dev/nbd%d", index);
+
+      nbd = open_device(dev, true);
+      if (nbd < 0) {
+        r = nbd;
+        cerr << "rbd-nbd: failed to find unused device" << std::endl;
+        goto close_fd;
+      }
+
+      r = ioctl(nbd, NBD_SET_SOCK, fd[0]);
+      if (r < 0) {
+        close(nbd);
+        ++index;
+        continue;
+      }
+
+      devpath = dev;
+      break;
+    }
+  } else {
+    nbd = open_device(devpath.c_str(), true);
+    if (nbd < 0) {
+      r = nbd;
+      cerr << "rbd-nbd: failed to open device: " << devpath << std::endl;
+      goto close_fd;
+    }
+
+    r = ioctl(nbd, NBD_SET_SOCK, fd[0]);
+    if (r < 0) {
+      r = -errno;
+      cerr << "rbd-nbd: the device " << devpath << " is busy" << std::endl;
+      close(nbd);
+      goto close_fd;
+    }
+  }
+
+  flags = NBD_FLAG_SEND_FLUSH | NBD_FLAG_SEND_TRIM | NBD_FLAG_HAS_FLAGS;
+  if (!snapname.empty() || readonly)
+    flags |= NBD_FLAG_READ_ONLY;
+
+  r = rados.init_with_context(g_ceph_context);
+  if (r < 0)
+    goto close_nbd;
+
+  r = rados.connect();
+  if (r < 0)
+    goto close_nbd;
+
+  r = rados.ioctx_create(poolname.c_str(), io_ctx);
+  if (r < 0)
+    goto close_nbd;
+
+  r = rbd.open(io_ctx, image, imgname.c_str());
+  if (r < 0)
+    goto close_nbd;
+
+  if (!snapname.empty()) {
+    r = image.snap_set(snapname.c_str());
+    if (r < 0)
+      goto close_nbd;
+  }
+
+  r = image.stat(info, sizeof(info));
+  if (r < 0)
+    goto close_nbd;
+
+  r = ioctl(nbd, NBD_SET_BLKSIZE, 512UL);
+  if (r < 0) {
+    r = -errno;
+    goto close_nbd;
+  }
+
+  size = info.size;
+  r = ioctl(nbd, NBD_SET_SIZE, size);
+  if (r < 0) {
+    r = -errno;
+    goto close_nbd;
+  }
+
+  ioctl(nbd, NBD_SET_FLAGS, flags);
+
+  read_only = snapname.empty() ? 0 : 1;
+  r = ioctl(nbd, BLKROSET, (unsigned long) &read_only);
+  if (r < 0) {
+    r = -errno;
+    goto close_nbd;
+  }
+
+  r = image.old_format(&old_format);
+  if (r < 0)
+    goto close_nbd;
+
+  {
+    string header_oid;
+    uint64_t watcher;
+
+    if (old_format != 0) {
+      header_oid = imgname + RBD_SUFFIX;
+    } else {
+      char prefix[RBD_MAX_BLOCK_NAME_SIZE + 1];
+      strncpy(prefix, info.block_name_prefix, RBD_MAX_BLOCK_NAME_SIZE);
+      prefix[RBD_MAX_BLOCK_NAME_SIZE] = '\0';
+
+      std::string image_id(prefix + strlen(RBD_DATA_PREFIX));
+      header_oid = RBD_HEADER_PREFIX + image_id;
+    }
+
+    NBDWatchCtx watch_ctx(nbd, io_ctx, image, header_oid, info.size);
+    r = io_ctx.watch2(header_oid, &watcher, &watch_ctx);
+    if (r < 0)
+      goto close_nbd;
+
+    if (g_conf->daemonize) {
+      r = open("/dev/null", O_RDWR);
+      if (r < 0)
+        goto close_watcher;
+      null_fd = r;
+    }
+
+    cout << devpath << std::endl;
+
+    if (g_conf->daemonize) {
+      forker.daemonize();
+
+      ::dup2(null_fd, STDIN_FILENO);
+      ::dup2(null_fd, STDOUT_FILENO);
+      ::dup2(null_fd, STDERR_FILENO);
+      close(null_fd);
+    }
+
+    {
+      NBDServer server(fd[1], image);
+
+      server.start();
+      ioctl(nbd, NBD_DO_IT);
+      server.stop();
+    }
+
+close_watcher:
+    io_ctx.unwatch2(watcher);
+  }
+
+close_nbd:
+  if (r < 0) {
+    ioctl(nbd, NBD_CLEAR_SOCK);
+    cerr << "rbd-nbd: failed to map, status: " << cpp_strerror(-r) << std::endl;
+  }
+  close(nbd);
+close_fd:
+  close(fd[0]);
+  close(fd[1]);
+close_ret:
+  image.close();
+  io_ctx.close();
+  rados.shutdown();
+  return r;
+}
+
+static int do_unmap()
+{
+  int nbd = open_device(devpath.c_str());
+  if (nbd < 0) {
+    cerr << "rbd-nbd: failed to open device: " << devpath << std::endl;
+    return nbd;
+  }
+
+  if (ioctl(nbd, NBD_DISCONNECT) < 0)
+    cerr << "rbd-nbd: the device is not used" << std::endl;
+  ioctl(nbd, NBD_CLEAR_SOCK);
+  close(nbd);
+
+  return 0;
+}
+
+static int parse_imgpath(const std::string &imgpath)
+{
+  boost::regex pattern("^(?:([^/@]+)/)?([^/@]+)(?:@([^/@]+))?$");
+  boost::smatch match;
+  if (!boost::regex_match(imgpath, match, pattern)) {
+    std::cerr << "rbd-nbd: invalid spec '" << imgpath << "'" << std::endl;
+    return -EINVAL;
+  }
+
+  if (match[1].matched)
+    poolname = match[1];
+
+  imgname = match[2];
+
+  if (match[3].matched)
+    snapname = match[3];
+
+  return 0;
+}
+
+static void list_mapped_devices()
+{
+  char path[64];
+  int m = 0;
+  int fd[2];
+
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, fd) == -1)
+    return;
+
+  while (true) {
+    snprintf(path, sizeof(path), "/dev/nbd%d", m);
+    int nbd = open_device(path);
+    if (nbd < 0)
+      break;
+    if (ioctl(nbd, NBD_SET_SOCK, fd[0]) != 0)
+      cout << path << std::endl;
+    else
+      ioctl(nbd, NBD_CLEAR_SOCK);
+    close(nbd);
+    m++;
+  }
+
+  close(fd[0]);
+  close(fd[1]);
+}
+
+static int rbd_nbd(int argc, const char *argv[])
+{
+  int r;
+  enum {
+    None,
+    Connect,
+    Disconnect,
+    List
+  } cmd = None;
+
+  vector<const char*> args;
+
+  argv_to_vec(argc, argv, args);
+  env_to_vec(args);
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_DAEMON,
+              CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);
+
+  std::vector<const char*>::iterator i;
+
+  for (i = args.begin(); i != args.end(); ) {
+    if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
+      usage();
+      return 0;
+    } else if (ceph_argparse_witharg(args, i, &devpath, "--device", (char *)NULL)) {
+    } else if (ceph_argparse_witharg(args, i, &nbds_max, cerr, "--nbds_max", (char *)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--read-only", (char *)NULL)) {
+      readonly = true;
+    } else {
+      ++i;
+    }
+  }
+
+  if (args.begin() != args.end()) {
+    if (strcmp(*args.begin(), "map") == 0) {
+      cmd = Connect;
+    } else if (strcmp(*args.begin(), "unmap") == 0) {
+      cmd = Disconnect;
+    } else if (strcmp(*args.begin(), "list-mapped") == 0) {
+      cmd = List;
+    } else {
+      cerr << "rbd-nbd: unknown command: " << *args.begin() << std::endl;
+      return EXIT_FAILURE;
+    }
+    args.erase(args.begin());
+  }
+
+  if (cmd == None) {
+    cerr << "rbd-nbd: must specify command" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  switch (cmd) {
+    case Connect:
+      if (args.begin() == args.end()) {
+        cerr << "rbd-nbd: must specify image-or-snap-spec" << std::endl;
+        return EXIT_FAILURE;
+      }
+      if (parse_imgpath(string(*args.begin())) < 0)
+        return EXIT_FAILURE;
+      args.erase(args.begin());
+      break;
+    case Disconnect:
+      if (args.begin() == args.end()) {
+        cerr << "rbd-nbd: must specify nbd device path" << std::endl;
+        return EXIT_FAILURE;
+      }
+      devpath = *args.begin();
+      args.erase(args.begin());
+      break;
+    default:
+      //shut up gcc;
+      break;
+  }
+
+  if (args.begin() != args.end()) {
+    cerr << "rbd-nbd: unknown args: " << *args.begin() << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  switch (cmd) {
+    case Connect:
+      common_init_finish(g_ceph_context);
+
+      if (imgname.empty()) {
+        cerr << "rbd-nbd: image name was not specified" << std::endl;
+        return EXIT_FAILURE;
+      }
+
+      r = do_map();
+      if (r < 0)
+        return EXIT_FAILURE;
+      break;
+    case Disconnect:
+      r = do_unmap();
+      if (r < 0)
+        return EXIT_FAILURE;
+      break;
+    case List:
+      list_mapped_devices();
+      break;
+    default:
+      usage();
+      return EXIT_FAILURE;
+  }
+
+  return 0;
+}
+
+int main(int argc, const char *argv[])
+{
+  std::string err;
+
+  if (forker.prefork(err) < 0) {
+    cerr << err << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (forker.is_child()) {
+    forker.exit(rbd_nbd(argc, argv));
+  } else if (forker.parent_wait(err) < 0) {
+    cerr << err << std::endl;
+    return EXIT_FAILURE;
+  } else {
+    return 0;
+  }
+}


### PR DESCRIPTION
This is rbd client in userspace (refer to rbd-nbd), as an alternative to kernel rbd client
(refer to rbd-ker). The motivation are as follows,
(1) The developement of rbd-ker is behind that of userspace librbd;
(2) The flexibility and portability (dependent on kernel version) of rbd-ker are not very good;
(3) More importantly, according to our experience on ARM64 architecture for container scenario,
there exists stability issue for rbd-ker, easily cause kernel hang or disk-utils 100%;
(4) Rely on powerful librbd, rbd-nbd enjoys extremely simple code, and easy to maintain and
make stable, and will not cause system unusable even if crashed (which we do not meet in our
test);
(5) According to our test, the performance of rbd-nbd is comparable to rbd-ker;
(6) For the container sinaro, rbd-nbd is very practical.
The usage of rbd-nbd is very simple, rbd-nbd map/unmap/list-mapped, the other functions still
leave rbd to do.