### PR TITLE
cls/cls_rbd.cc: fix misused metadata_name_from_key

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -2506,8 +2506,6 @@ int metadata_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
       break;
 
     map<string, bufferlist>::iterator it = raw_data.begin();
-    if (metadata_name_from_key(it->first) == last_read)
-        ++it;
     for (; it != raw_data.end(); ++it)
       data[metadata_name_from_key(it->first)].swap(it->second);
 


### PR DESCRIPTION
The string last_read is already prefixed with RBD_METADATA_KEY_PREFIX,
also it->first. So compare them directly.

This bug was hide because in both LevelDBWholeSpaceIteratorImpl::upper_bound
and RocksDBWholeSpaceIteratorImpl::upper_bound we already skip the pair where key=after.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>