### PR TITLE
osd: more accurate disk space usage calculation when considering 'whiteout'/empty/small objects.

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -2388,6 +2388,12 @@ public:
   virtual void set_fsid(uuid_d u) = 0;
   virtual uuid_d get_fsid() = 0;
 
+  /**
+  * Estimates additional disk space used by the specified amount of objects and caused by file allocation granularity and metadata store
+  * - num objects - total (including witeouts) object count to measure used space for.
+  */
+  virtual uint64_t estimate_objects_overhead(uint64_t num_objects) = 0;
+
   // DEBUG
   virtual void inject_data_error(const ghobject_t &oid) {}
   virtual void inject_mdata_error(const ghobject_t &oid) {}

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -799,6 +799,10 @@ public:
     return fsid;
   }
 
+  uint64_t estimate_objects_overhead(uint64_t num_objects) override { 
+    return num_objects * 300; //assuming per-object overhead is 300 bytes
+  }
+
   objectstore_perf_stat_t get_cur_stats() override {
     return objectstore_perf_stat_t();
   }

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -5685,6 +5685,12 @@ void FileStore::set_xattr_limits_via_conf()
     m_filestore_max_inline_xattrs = fs_xattrs;
 }
 
+uint64_t FileStore::estimate_objects_overhead(uint64_t num_objects)
+{
+  uint64_t res = num_objects * blk_size / 2; //assumes that each object uses ( in average ) additional 1/2 block due to FS allocation granularity.
+  return res;
+}
+
 // -- FSSuperblock --
 
 void FSSuperblock::encode(bufferlist &bl) const

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -588,6 +588,8 @@ public:
     fsid = u;
   }
   uuid_d get_fsid() { return fsid; }
+  
+  uint64_t estimate_objects_overhead(uint64_t num_objects);
 
   // DEBUG read error injection, an object is removed from both on delete()
   Mutex read_error_lock;

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -521,6 +521,10 @@ public:
     return fsid;
   }
 
+  uint64_t estimate_objects_overhead(uint64_t num_objects) override {
+    return num_objects * 300; //assuming per-object overhead is 300 bytes
+  }
+
   objectstore_perf_stat_t get_cur_stats() {
     return objectstore_perf_stat_t();
   }

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -485,6 +485,10 @@ public:
   void set_fsid(uuid_d u);
   uuid_d get_fsid();
 
+  uint64_t estimate_objects_overhead(uint64_t num_objects) override {
+    return 0; //do not care
+  }
+
   objectstore_perf_stat_t get_cur_stats();
 
   int queue_transactions(

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -12211,6 +12211,8 @@ bool ReplicatedPG::agent_choose_mode(bool restart, OpRequestRef op)
   uint64_t num_user_bytes = info.stats.stats.sum.num_bytes;
   uint64_t unflushable_bytes = info.stats.stats.sum.num_bytes_hit_set_archive;
   num_user_bytes -= unflushable_bytes;
+  uint64_t num_overhead_bytes = osd->store->estimate_objects_overhead(num_user_objects);
+  num_user_bytes += num_overhead_bytes;
 
   // also reduce the num_dirty by num_objects_omap
   int64_t num_dirty = info.stats.stats.sum.num_objects_dirty;
@@ -12233,6 +12235,7 @@ bool ReplicatedPG::agent_choose_mode(bool restart, OpRequestRef op)
 	   << " num_dirty: " << num_dirty
 	   << " num_user_objects: " << num_user_objects
 	   << " num_user_bytes: " << num_user_bytes
+	   << " num_overhead_bytes: " << num_overhead_bytes
 	   << " pool.info.target_max_bytes: " << pool.info.target_max_bytes
 	   << " pool.info.target_max_objects: " << pool.info.target_max_objects
 	   << dendl;


### PR DESCRIPTION
Fixes 
http://tracker.ceph.com/issues/13848

Evidently the case is rather a corner one. And in real
life additional user traffic may trigger cache flush. But probably it's
worth to handle such case given the fact that it's pretty easy.
In the patch below for the sake of simplicity I assumed that minimum
object size is always 4K. Despite the fact that it probably depends on
the underlying File System I think that's good enough to use this
constant.  And of cause that's just a simple correction in used space
calculation to trigger cache flush - it doesn't ensure 100% correct
calculation. 