### PR TITLE
rgw: remove a useless write op when bl is empty

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1077,8 +1077,13 @@ int RGWPutObjProcessor_Atomic::handle_data(bufferlist& bl, off_t ofs, MD5 *hash,
   uint64_t max_write_size = MIN(max_chunk_size, (uint64_t)next_part_ofs - data_ofs);
 
   pending_data_bl.claim_append(bl);
-  if (pending_data_bl.length() < max_write_size)
+  if (0 == max_write_size) {
+    prepare_next_part(data_ofs);
     return 0;
+  }
+  else if (pending_data_bl.length() < max_write_size) {
+    return 0;
+  }
 
   pending_data_bl.splice(0, max_write_size, &bl);
 


### PR DESCRIPTION
if max_write_size is zero,the next bl to be writen is empty.if we not
return here,next full write is verbose.

Signed-off-by: Zengran Zhang <zhangzengran@h3c.com>