### PR TITLE
vstart.sh: osds get ids from 'osd create'

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -564,13 +564,15 @@ EOF
 	    fi
 
 	    uuid=`uuidgen`
-	    echo "add osd$osd $uuid"
-	    $SUDO $CEPH_ADM osd create $uuid
+            echo "create osd with uuid ${uuid}"
+            osd=`$SUDO $CEPH_ADM osd create $uuid`
+            echo "added osd.${osd} uuid ${uuid}"
+
 	    $SUDO $CEPH_ADM osd crush add osd.$osd 1.0 host=$HOSTNAME root=default
 	    $SUDO $CEPH_BIN/ceph-osd -i $osd $ARGS --mkfs --mkkey --osd-uuid $uuid
 
 	    key_fn=$CEPH_DEV_DIR/osd$osd/keyring
-	    echo adding osd$osd key to auth repository
+	    echo adding osd.$osd key to auth repository
 	    $SUDO $CEPH_ADM -i $key_fn auth add osd.$osd osd "allow *" mon "allow profile osd"
 	fi
 	echo start osd$osd


### PR DESCRIPTION
Avoids nasty things like running vstart multiple times ending up trying
to add the same set of osds.

Signed-off-by: Joao Eduardo Luis <joao@suse.de>