### PR TITLE
Namespace buffer

### DIFF
--- a/src/cls/journal/cls_journal_types.h
+++ b/src/cls/journal/cls_journal_types.h
@@ -5,7 +5,7 @@
 #define CEPH_CLS_JOURNAL_TYPES_H
 
 #include "include/int_types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/encoding.h"
 #include <iosfwd>
 #include <list>

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -4,7 +4,7 @@
 #define __CEPH_CLS_RBD_H
 
 #include "include/types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "common/Formatter.h"
 #include "librbd/parent_types.h"
 

--- a/src/common/ConfUtils.h
+++ b/src/common/ConfUtils.h
@@ -20,7 +20,7 @@
 #include <set>
 #include <string>
 
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 
 /*
  * Ceph configuration file support.

--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -19,6 +19,7 @@
 #include "assert.h"
 #include "Formatter.h"
 #include "common/escape.h"
+#include "include/buffer.h"
 
 #include <iostream>
 #include <sstream>
@@ -87,6 +88,14 @@ Formatter *Formatter::create(const std::string &type,
     return create(fallback, "", "");
   else
     return (Formatter *) NULL;
+}
+
+
+void Formatter::flush(bufferlist &bl)
+{
+  std::stringstream os;
+  flush(os);
+  bl.append(os.str());
 }
 
 void Formatter::dump_format(const char *name, const char *fmt, ...)

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <map>
 
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 
 namespace ceph {
 
@@ -41,12 +41,7 @@ namespace ceph {
     virtual ~Formatter();
 
     virtual void flush(std::ostream& os) = 0;
-    void flush(bufferlist &bl)
-    {
-      std::stringstream os;
-      flush(os);
-      bl.append(os.str());
-    }
+    void flush(bufferlist &bl);
     virtual void reset() = 0;
 
     virtual void open_array_section(const char *name) = 0;

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -20,7 +20,7 @@
 
 #include <string>
 #include <map>
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "common/cmdparse.h"
 
 class AdminSocket;

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -52,20 +52,26 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
   static atomic64_t buffer_history_alloc_num;
   const bool buffer_track_alloc = get_env_bool("CEPH_BUFFER_TRACK");
 
-  void buffer::inc_total_alloc(unsigned len) {
+  namespace {
+  void inc_total_alloc(unsigned len) {
     if (buffer_track_alloc)
       buffer_total_alloc.add(len);
   }
-  void buffer::dec_total_alloc(unsigned len) {
+
+  void dec_total_alloc(unsigned len) {
     if (buffer_track_alloc)
       buffer_total_alloc.sub(len);
   }
-  void buffer::inc_history_alloc(uint64_t len) {
+
+  void inc_history_alloc(uint64_t len) {
     if (buffer_track_alloc) {
       buffer_history_alloc_bytes.add(len);
       buffer_history_alloc_num.inc();
     }
   }
+  }
+
+
   int buffer::get_total_alloc() {
     return buffer_total_alloc.read();
   }
@@ -2118,11 +2124,11 @@ void buffer::list::hexdump(std::ostream &out) const
   out.flags(original_flags);
 }
 
-std::ostream& operator<<(std::ostream& out, const buffer::raw &r) {
+std::ostream& buffer::operator<<(std::ostream& out, const buffer::raw &r) {
   return out << "buffer::raw(" << (void*)r.data << " len " << r.len << " nref " << r.nref.read() << ")";
 }
 
-std::ostream& operator<<(std::ostream& out, const buffer::ptr& bp) {
+std::ostream& buffer::operator<<(std::ostream& out, const buffer::ptr& bp) {
   if (bp.have_raw())
     out << "buffer::ptr(" << bp.offset() << "~" << bp.length()
 	<< " " << (void*)bp.c_str()
@@ -2134,7 +2140,7 @@ std::ostream& operator<<(std::ostream& out, const buffer::ptr& bp) {
   return out;
 }
 
-std::ostream& operator<<(std::ostream& out, const buffer::list& bl) {
+std::ostream& buffer::operator<<(std::ostream& out, const buffer::list& bl) {
   out << "buffer::list(len=" << bl.length() << "," << std::endl;
 
   std::list<buffer::ptr>::const_iterator it = bl.buffers().begin();
@@ -2147,9 +2153,8 @@ std::ostream& operator<<(std::ostream& out, const buffer::list& bl) {
   return out;
 }
 
-std::ostream& operator<<(std::ostream& out, const buffer::error& e)
+std::ostream& buffer::operator<<(std::ostream& out, const buffer::error& e)
 {
   return out << e.what();
 }
-
 }

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -21,7 +21,7 @@
 #include <set>
 
 #include "include/assert.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/atomic.h"
 #include "common/cmdparse.h"
 #include "include/Spinlock.h"

--- a/src/common/ceph_crypto_cms.h
+++ b/src/common/ceph_crypto_cms.h
@@ -1,7 +1,7 @@
 #ifndef CEPH_CRYPTO_CMS_H
 #define CEPH_CRYPTO_CMS_H
 
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 
 class CephContext;
 

--- a/src/common/entity_name.h
+++ b/src/common/entity_name.h
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "include/encoding.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "msg/msg_types.h"
 
 /* Represents a Ceph entity name.

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -18,7 +18,6 @@
 
 #include "common/config_obs.h"
 #include "common/Mutex.h"
-#include "include/buffer.h"
 #include "include/utime.h"
 
 #include <stdint.h>

--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -22,6 +22,7 @@
 
 #include "common/strtol.h"
 #include "ErasureCode.h"
+#include "include/buffer.h"
 
 const unsigned ErasureCode::SIMD_ALIGN = 32;
 

--- a/src/erasure-code/ErasureCodeInterface.h
+++ b/src/erasure-code/ErasureCodeInterface.h
@@ -145,7 +145,7 @@
 #include <vector>
 #include <iostream>
 #include "include/memory.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 
 class CrushWrapper;
 

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -9,6 +9,7 @@ rados_include_DATA = \
 	$(srcdir)/include/rados/rados_types.hpp \
 	$(srcdir)/include/rados/librados.hpp \
 	$(srcdir)/include/buffer.h \
+	$(srcdir)/include/buffer_fwd.h \
 	$(srcdir)/include/page.h \
 	$(srcdir)/include/crc32c.h \
 	$(srcdir)/include/memory.h
@@ -52,6 +53,7 @@ noinst_HEADERS += \
 	include/bitmapper.h \
 	include/blobhash.h \
 	include/buffer.h \
+	include/buffer_fwd.h \
 	include/byteorder.h \
 	include/cephfs/libcephfs.h \
 	include/ceph_features.h \

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -47,6 +47,7 @@
 
 #include "page.h"
 #include "crc32c.h"
+#include "include/buffer_fwd.h"
 
 #ifdef __CEPH__
 # include "include/assert.h"
@@ -69,12 +70,11 @@ namespace ceph {
 
 const static int CEPH_BUFFER_APPEND_SIZE(4096);
 
-class CEPH_BUFFER_API buffer {
+namespace buffer CEPH_BUFFER_API {
   /*
    * exceptions
    */
 
-public:
   struct error : public std::exception{
     const char *what() const throw ();
   };
@@ -99,35 +99,28 @@ public:
 
 
   /// total bytes allocated
-  static int get_total_alloc();
+  int get_total_alloc();
 
   /// history total bytes allocated
-  static uint64_t get_history_alloc_bytes();
+  uint64_t get_history_alloc_bytes();
 
   /// total num allocated
-  static uint64_t get_history_alloc_num();
+  uint64_t get_history_alloc_num();
 
   /// enable/disable alloc tracking
-  static void track_alloc(bool b);
+  void track_alloc(bool b);
 
   /// count of cached crc hits (matching input)
-  static int get_cached_crc();
+  int get_cached_crc();
   /// count of cached crc hits (mismatching input, required adjustment)
-  static int get_cached_crc_adjusted();
+  int get_cached_crc_adjusted();
   /// enable/disable tracking of cached crcs
-  static void track_cached_crc(bool b);
+  void track_cached_crc(bool b);
 
   /// count of calls to buffer::ptr::c_str()
-  static int get_c_str_accesses();
+  int get_c_str_accesses();
   /// enable/disable tracking of buffer::ptr::c_str() calls
-  static void track_c_str(bool b);
-
-private:
- 
-  /* hack for memory utilization debugging. */
-  static void inc_total_alloc(unsigned len);
-  static void inc_history_alloc(uint64_t len);
-  static void dec_total_alloc(unsigned len);
+  void track_c_str(bool b);
 
   /*
    * an abstract raw buffer.  with a reference count.
@@ -142,25 +135,23 @@ private:
   class raw_pipe;
   class raw_unshareable; // diagnostic, unshareable char buffer
 
-  friend std::ostream& operator<<(std::ostream& out, const raw &r);
 
-public:
   class xio_mempool;
   class xio_msg_buffer;
 
   /*
    * named constructors 
    */
-  static raw* copy(const char *c, unsigned len);
-  static raw* create(unsigned len);
-  static raw* claim_char(unsigned len, char *buf);
-  static raw* create_malloc(unsigned len);
-  static raw* claim_malloc(unsigned len, char *buf);
-  static raw* create_static(unsigned len, char *buf);
-  static raw* create_aligned(unsigned len, unsigned align);
-  static raw* create_page_aligned(unsigned len);
-  static raw* create_zero_copy(unsigned len, int fd, int64_t *offset);
-  static raw* create_unshareable(unsigned len);
+  raw* copy(const char *c, unsigned len);
+  raw* create(unsigned len);
+  raw* claim_char(unsigned len, char *buf);
+  raw* create_malloc(unsigned len);
+  raw* claim_malloc(unsigned len, char *buf);
+  raw* create_static(unsigned len, char *buf);
+  raw* create_aligned(unsigned len, unsigned align);
+  raw* create_page_aligned(unsigned len);
+  raw* create_zero_copy(unsigned len, int fd, int64_t *offset);
+  raw* create_unshareable(unsigned len);
 
 #if defined(HAVE_XIO)
   static raw* create_msg(unsigned len, char *buf, XioDispatchHook *m_hook);
@@ -254,7 +245,6 @@ public:
 
   };
 
-  friend std::ostream& operator<<(std::ostream& out, const buffer::ptr& bp);
 
   /*
    * list - the useful bit!
@@ -562,16 +552,6 @@ public:
       return crc;
     }
   };
-};
-
-#if defined(HAVE_XIO)
-xio_reg_mem* get_xio_mp(const buffer::ptr& bp);
-#endif
-
-typedef buffer::ptr bufferptr;
-typedef buffer::list bufferlist;
-typedef buffer::hash bufferhash;
-
 
 inline bool operator>(bufferlist& l, bufferlist& r) {
   for (unsigned p = 0; ; p++) {
@@ -610,6 +590,7 @@ inline bool operator<=(bufferlist& l, bufferlist& r) {
 
 std::ostream& operator<<(std::ostream& out, const buffer::ptr& bp);
 
+std::ostream& operator<<(std::ostream& out, const raw &r);
 
 std::ostream& operator<<(std::ostream& out, const buffer::list& bl);
 
@@ -619,6 +600,12 @@ inline bufferhash& operator<<(bufferhash& l, bufferlist &r) {
   l.update(r);
   return l;
 }
+}
+
+#if defined(HAVE_XIO)
+xio_reg_mem* get_xio_mp(const buffer::ptr& bp);
+#endif
+
 }
 
 #endif

--- a/src/include/buffer_fwd.h
+++ b/src/include/buffer_fwd.h
@@ -1,0 +1,17 @@
+#ifndef BUFFER_FWD_H
+#define BUFFER_FWD_H
+
+namespace ceph {
+  namespace buffer {
+    class ptr;
+    class list;
+    class hash;
+  }
+
+  using bufferptr = buffer::ptr;
+  using bufferlist = buffer::list;
+  using bufferhash = buffer::hash;
+}
+
+#endif
+

--- a/src/journal/Journaler.h
+++ b/src/journal/Journaler.h
@@ -5,7 +5,7 @@
 #define CEPH_JOURNAL_JOURNALER_H
 
 #include "include/int_types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/Context.h"
 #include "include/rados/librados.hpp"
 #include "journal/Future.h"

--- a/src/kv/KineticStore.h
+++ b/src/kv/KineticStore.h
@@ -4,7 +4,7 @@
 #define KINETIC_STORE_H
 
 #include "include/types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "KeyValueDB.h"
 #include <set>
 #include <map>

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -4,7 +4,7 @@
 #define LEVEL_DB_STORE_H
 
 #include "include/types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "KeyValueDB.h"
 #include <set>
 #include <map>

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -4,7 +4,7 @@
 #define ROCKS_DB_STORE_H
 
 #include "include/types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "KeyValueDB.h"
 #include <set>
 #include <map>

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -5,7 +5,7 @@
 #define CEPH_LIBRBD_AIO_IMAGE_REQUEST_H
 
 #include "include/int_types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "common/snap_types.h"
 #include "osd/osd_types.h"
 #include "librbd/AioCompletion.h"

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -17,7 +17,7 @@
 #include "common/RWLock.h"
 #include "common/snap_types.h"
 #include "include/atomic.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/rbd/librbd.hpp"
 #include "include/rbd_types.h"
 #include "include/types.h"

--- a/src/librbd/JournalReplay.h
+++ b/src/librbd/JournalReplay.h
@@ -5,7 +5,7 @@
 #define CEPH_LIBRBD_JOURNAL_REPLAY_H
 
 #include "include/int_types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/rbd/librbd.hpp"
 #include "common/Cond.h"
 #include "common/Mutex.h"

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -4,7 +4,7 @@
 #define LIBRBD_WATCH_NOTIFY_TYPES_H
 
 #include "include/int_types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/encoding.h"
 #include <iosfwd>
 #include <list>

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/rbd/librbd.hpp"
 #include "include/rbd_types.h"
 

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -21,7 +21,7 @@
 #include <set>
 
 #include "include/types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/lru.h"
 #include "include/elist.h"
 #include "include/filepath.h"

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -18,7 +18,7 @@
 #define CEPH_CDIR_H
 
 #include "include/types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "mdstypes.h"
 #include "common/config.h"
 #include "common/DecayCounter.h"

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -16,7 +16,7 @@
 #ifndef CEPH_CAPABILITY_H
 #define CEPH_CAPABILITY_H
 
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/xlist.h"
 
 #include "common/config.h"

--- a/src/mds/LogEvent.h
+++ b/src/mds/LogEvent.h
@@ -42,7 +42,7 @@
 #define EVENT_NOOP        51
 
 
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/Context.h"
 #include "include/utime.h"
 

--- a/src/mds/MDSTable.h
+++ b/src/mds/MDSTable.h
@@ -17,7 +17,7 @@
 
 #include "mdstypes.h"
 #include "mds_table_types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 
 class MDSRank;
 class Context;

--- a/src/os/DBObjectMap.h
+++ b/src/os/DBObjectMap.h
@@ -2,7 +2,7 @@
 #ifndef DBOBJECTMAP_DB_H
 #define DBOBJECTMAP_DB_H
 
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include <set>
 #include <map>
 #include <string>

--- a/src/os/HashIndex.h
+++ b/src/os/HashIndex.h
@@ -15,7 +15,7 @@
 #ifndef CEPH_HASHINDEX_H
 #define CEPH_HASHINDEX_H
 
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/encoding.h"
 #include "LFNIndex.h"
 

--- a/src/os/Journal.h
+++ b/src/os/Journal.h
@@ -18,7 +18,7 @@
 
 #include <errno.h>
 
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/Context.h"
 #include "common/Finisher.h"
 #include "common/TrackedOp.h"

--- a/src/os/WBThrottle.h
+++ b/src/os/WBThrottle.h
@@ -18,7 +18,6 @@
 #include "include/unordered_map.h"
 #include <boost/tuple/tuple.hpp>
 #include "include/memory.h"
-#include "include/buffer.h"
 #include "common/Formatter.h"
 #include "common/hobject.h"
 #include "include/interval_set.h"

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -137,6 +137,22 @@ int ECUtil::encode(
   return 0;
 }
 
+void ECUtil::HashInfo::append(uint64_t old_size,
+			      map<int, bufferlist> &to_append) {
+  assert(to_append.size() == cumulative_shard_hashes.size());
+  assert(old_size == total_chunk_size);
+  uint64_t size_to_append = to_append.begin()->second.length();
+  for (map<int, bufferlist>::iterator i = to_append.begin();
+       i != to_append.end();
+       ++i) {
+    assert(size_to_append == i->second.length());
+    assert((unsigned)i->first < cumulative_shard_hashes.size());
+    uint32_t new_hash = i->second.crc32c(cumulative_shard_hashes[i->first]);
+    cumulative_shard_hashes[i->first] = new_hash;
+  }
+  total_chunk_size += size_to_append;
+}
+
 void ECUtil::HashInfo::encode(bufferlist &bl) const
 {
   ENCODE_START(1, 1, bl);

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -20,7 +20,7 @@
 
 #include "include/memory.h"
 #include "erasure-code/ErasureCodeInterface.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/assert.h"
 #include "include/encoding.h"
 #include "common/Formatter.h"
@@ -112,20 +112,7 @@ public:
   HashInfo(unsigned num_chunks)
   : total_chunk_size(0),
     cumulative_shard_hashes(num_chunks, -1) {}
-  void append(uint64_t old_size, map<int, bufferlist> &to_append) {
-    assert(to_append.size() == cumulative_shard_hashes.size());
-    assert(old_size == total_chunk_size);
-    uint64_t size_to_append = to_append.begin()->second.length();
-    for (map<int, bufferlist>::iterator i = to_append.begin();
-	 i != to_append.end();
-	 ++i) {
-      assert(size_to_append == i->second.length());
-      assert((unsigned)i->first < cumulative_shard_hashes.size());
-      uint32_t new_hash = i->second.crc32c(cumulative_shard_hashes[i->first]);
-      cumulative_shard_hashes[i->first] = new_hash;
-    }
-    total_chunk_size += size_to_append;
-  }
+  void append(uint64_t old_size, map<int, bufferlist> &to_append);
   void clear() {
     total_chunk_size = 0;
     cumulative_shard_hashes = vector<uint32_t>(

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -31,7 +31,7 @@
 #include "include/types.h"
 #include "include/stringify.h"
 #include "osd_types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/xlist.h"
 #include "include/atomic.h"
 #include "SnapMapper.h"

--- a/src/rbd_replay/ActionTypes.h
+++ b/src/rbd_replay/ActionTypes.h
@@ -5,7 +5,7 @@
 #define CEPH_RBD_REPLAY_ACTION_TYPES_H
 
 #include "include/int_types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/encoding.h"
 #include <iosfwd>
 #include <list>

--- a/src/rbd_replay/ios.hpp
+++ b/src/rbd_replay/ios.hpp
@@ -18,7 +18,7 @@
 // This code assumes that IO IDs and timestamps are related monotonically.
 // In other words, (a.id < b.id) == (a.timestamp < b.timestamp) for all IOs a and b.
 
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/shared_ptr.hpp>
 #include <iostream>

--- a/src/test/common/ObjectContents.h
+++ b/src/test/common/ObjectContents.h
@@ -1,6 +1,6 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 #include "include/interval_set.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include <map>
 
 #ifndef COMMON_OBJECT_H

--- a/src/test/common/test_tableformatter.cc
+++ b/src/test/common/test_tableformatter.cc
@@ -5,6 +5,8 @@
 #include <sstream>
 #include <string>
 
+using namespace ceph;
+
 TEST(tableformatter, singleline)
 {
   std::stringstream sout;

--- a/src/test/librados/cls.cc
+++ b/src/test/librados/cls.cc
@@ -9,7 +9,6 @@
 #include <string>
 
 using namespace librados;
-using ceph::buffer;
 using std::map;
 using std::ostringstream;
 using std::string;

--- a/src/test/librados/cmd.cc
+++ b/src/test/librados/cmd.cc
@@ -18,7 +18,6 @@
 #include <string>
 
 using namespace librados;
-using ceph::buffer;
 using std::map;
 using std::ostringstream;
 using std::string;

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -21,7 +21,6 @@
 #include <string>
 
 using namespace librados;
-using ceph::buffer;
 using std::map;
 using std::ostringstream;
 using std::string;

--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -26,7 +26,6 @@
 #include <string>
 
 using namespace librados;
-using ceph::buffer;
 using std::map;
 using std::ostringstream;
 using std::string;

--- a/src/test/librados_test_stub/TestRadosClient.h
+++ b/src/test/librados_test_stub/TestRadosClient.h
@@ -9,7 +9,7 @@
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "include/atomic.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "test/librados_test_stub/TestWatchNotify.h"
 #include <boost/function.hpp>
 #include <boost/functional/hash.hpp>

--- a/src/test/multi_stress_watch.cc
+++ b/src/test/multi_stress_watch.cc
@@ -13,7 +13,6 @@
 #include <unistd.h>
 
 using namespace librados;
-using ceph::buffer;
 using std::map;
 using std::ostringstream;
 using std::string;

--- a/src/test/test_stress_watch.cc
+++ b/src/test/test_stress_watch.cc
@@ -18,7 +18,6 @@
 
 
 using namespace librados;
-using ceph::buffer;
 using std::map;
 using std::ostringstream;
 using std::string;

--- a/src/tools/rados/RadosImport.h
+++ b/src/tools/rados/RadosImport.h
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "include/rados/librados.hpp"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 
 #include "tools/RadosDump.h"
 


### PR DESCRIPTION
common/buffer: changed buffer from class to namespace

Since the buffer only contained static functions it doesn't make sense
for it to be a class. Changing it to a namespace will allow
bufferlist, bufferptr and bufferhash to be forward declared.
This wasn't possible when they were nested classes.

Function declarations for
inc_total_alloc and
dec_total_alloc
were removed from the header file and changed to static, to simulate
the private access specifier, which they were under.

Moved the operators inside the buffer namespace to take advantage of
the Argument Dependent Lookup.

Moved typedefs to  buffer_fwd header file which we can include when
only the forward declarations are needed.

Since the buffer is not a class anymore all the instances of
using ceph::buffer
were removed.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>