### PR TITLE
WBThrottle: fix incorrect throttle

### DIFF
--- a/src/os/WBThrottle.cc
+++ b/src/os/WBThrottle.cc
@@ -262,7 +262,10 @@ void WBThrottle::clear_object(const ghobject_t &hoid)
 void WBThrottle::throttle()
 {
   Mutex::Locker l(lock);
-  while (!stopping && beyond_limit()) {
+  while (!stopping && !(
+	   cur_ios < io_limits.second &&
+	   pending_wbs.size() < fd_limits.second &&
+	   cur_size < size_limits.second)) {
     cond.Wait(lock);
   }
 }


### PR DESCRIPTION
This bug is introduced in commit 573d2cc, that throttle()
incorrectly use the "start flusher" throttle value to block new
write requests. Fix this issue by reverting changes on throttle().

On a test environment of 2 storage nodes with 7 HDD each, the
overall write performance measured by iozone is doubled with this
patch (boosted from 160MB/s to 300MB/s).

Signed-off-by: Zhang Huan <zhanghuan@ict.ac.cn>