### PR TITLE
ceph.spec.in: make --with lowmem_builder limit _smp_mflags

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -590,6 +590,11 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		%{?_with_tcmalloc} \
 		CFLAGS="$RPM_OPT_FLAGS" CXXFLAGS="$RPM_OPT_FLAGS"
 
+%if %{with lowmem_builder}
+%if 0%{?jobs} > 8
+%define _smp_mflags -j8
+%endif
+%endif
 
 make %{?_smp_mflags}
 


### PR DESCRIPTION
The limit, -j8, may seem arbitrary but works nicely in the openSUSE Build
Service.

http://tracker.ceph.com/issues/13858 Fixes: #13858

Signed-off-by: Nathan Cutler <ncutler@suse.com>