### PR TITLE
mon/OSDMonitor: block 'ceph osd pg-temp ...' if update is pending

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6179,6 +6179,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       err = -ENOENT;
       goto reply;
     }
+    if (pending_inc.new_pg_temp.count(pgid)) {
+      dout(10) << __func__ << " waiting for pending update on " << pgid << dendl;
+      wait_for_finished_proposal(op, new C_RetryMessage(this, op));
+      return true;
+    }
 
     vector<string> id_vec;
     vector<int32_t> new_pg_temp;


### PR DESCRIPTION
The OSD expects it's pg_temp update requests to succeed.  If it
races with an ill-timed admin request, it can get stuck in
WaitActingChange indefinitely.

This is only a real problem now that the OSD/mon interaction has
been updated with wip-bigbang; previously we would retry (although
it would take a while).  Backporting is optional.

Signed-off-by: Sage Weil <sage@redhat.com>