### PR TITLE
mon: support min_down_reporter conuted by host

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -276,7 +276,8 @@ OPTION(mon_sync_debug_leader, OPT_INT, -1) // monitor to be used as the sync lea
 OPTION(mon_sync_debug_provider, OPT_INT, -1) // monitor to be used as the sync provider
 OPTION(mon_sync_debug_provider_fallback, OPT_INT, -1) // monitor to be used as fallback if sync provider fails
 OPTION(mon_inject_sync_get_chunk_delay, OPT_DOUBLE, 0)  // inject N second delay on each get_chunk request
-OPTION(mon_osd_min_down_reporters, OPT_INT, 2)   // number of OSDs who need to report a down OSD for it to count
+OPTION(mon_osd_min_down_reporters, OPT_INT, 2)   // number of OSDs from different subtrees who need to report a down OSD for it to count
+OPTION(mon_osd_reporter_subtree_level , OPT_STR, "host")   // in which level of parent bucket the reporters are counted
 OPTION(mon_osd_force_trim_to, OPT_INT, 0)   // force mon to trim maps to this point, regardless of min_last_epoch_clean (dangerous, use with care)
 OPTION(mon_mds_force_trim_to, OPT_INT, 0)   // force mon to trim mdsmaps to this point (dangerous, use with care)
 


### PR DESCRIPTION
In many case OSDs in an isolated(public/cluster connection lost but osd<->mon is good) node
will report other OSD down to monitor,which usually wrongly mark someone down.

Nowaday the "osd_min_down_reporters", we would like to extend the semantic to
allow it counted by host or rack, thus user could require failure reports from at
least two nodes to mark an OSD down, which shoudl prevent an isoloated host make trouble
to the cluster.

Signed-off-by: Xiaoxi Chen <xiaoxi.chen@intel.com>