### PR TITLE
pybind: decode empty string in conf_parse_argv() correctly

### DIFF
--- a/src/pybind/rados.py
+++ b/src/pybind/rados.py
@@ -429,8 +429,7 @@ Rados object in state %s." % self.state)
 
         # cretargs was allocated with fixed length; collapse return
         # list to eliminate any missing args
-
-        retargs = [decode_cstr(a) for a in cretargs if a is not None]
+        retargs = [a.decode('utf-8') for a in cretargs if a is not None]
         self.parsed_args = args
         return retargs
 

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -33,6 +33,11 @@ def test_ioctx_context_manager():
         with conn.open_ioctx('rbd') as ioctx:
             pass
 
+def test_parse_argv_empty_str():
+    args = ['']
+    r = Rados()
+    eq(args, r.conf_parse_argv(args))
+
 class TestRequires(object):
     @requires(('foo', str), ('bar', int), ('baz', int))
     def _method_plain(self, foo, bar, baz):


### PR DESCRIPTION
cretargs is a array of c_char_p, which means ctypes has already
converted it to python byte strings. decode_cstr() would misinterpret
the empty string as a NULL c_char_p(), and convert it to None by
accident, resulting in errors when running commands like
'ceph config-key put foo ""'.

Since this is the only place we use arrays of c_char_p, just decode
it directly in conf_parse_argv(). Tested with python 2 and 3.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>