### PR TITLE
WBThrottle: fix incorrect throttle

### DIFF
--- a/src/os/WBThrottle.cc
+++ b/src/os/WBThrottle.cc
@@ -262,7 +262,6 @@ void WBThrottle::clear_object(const ghobject_t &hoid)
 void WBThrottle::throttle()
 {
   Mutex::Locker l(lock);
-  while (!stopping && beyond_limit()) {
+  while (!stopping && need_flush())
     cond.Wait(lock);
-  }
 }

--- a/src/os/WBThrottle.h
+++ b/src/os/WBThrottle.h
@@ -137,6 +137,14 @@ private:
     else
       return true;
   }
+  bool need_flush() const {
+    if (cur_ios < io_limits.second &&
+	pending_wbs.size() < fd_limits.second &&
+	cur_size < size_limits.second)
+      return false;
+    else
+      return true;
+  }
 
 public:
   WBThrottle(CephContext *cct);


### PR DESCRIPTION
This bug is introduced in commit 573d2cc, that throttle()
incorrectly use the "start flusher" throttle value to block new
write requests.

On a test environment of 2 storage nodes with 7 HDD each, the
overall write performance measured by iozone is doubled with this
patch (boosted from 160MB/s to 300MB/s).

Signed-off-by: Zhang Huan <zhanghuan@ict.ac.cn>