### PR TITLE
test/encoding/readable.sh fix

### DIFF
--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -12,85 +12,84 @@ numtests=0
 
 myversion=`./ceph-dencoder version`
 
-for arversion in `ls -v $dir/archive`
-do
-    vdir="$dir/archive/$arversion"
-#    echo $vdir
+for arversion in `ls -v $dir/archive`; do
+  vdir="$dir/archive/$arversion"
+  #echo $vdir
 
-    if [ ! -d "$vdir/objects" ]; then
-	continue;
+  if [ ! -d "$vdir/objects" ]; then
+    continue;
+  fi
+
+  for type in `ls $vdir/objects`; do
+    if ./ceph-dencoder type $type 2>/dev/null; then
+      #echo "type $type";
+      echo "        $vdir/objects/$type"
+
+      # is there a fwd incompat change between $arversion and $version?
+      incompat=""
+      sawarversion=0
+      for iv in `ls -v $dir/archive`; do
+        if [ "$iv" = "$arversion" ]; then
+          sawarversion=1
+        fi
+
+        if [ $sawarversion -eq 1 ] && [ -e "$dir/archive/$iv/forward_incompat/$type" ]; then
+          incompat="$iv"
+        fi
+
+        if [ "$iv" = "$version" ]; then
+          break
+        fi
+      done
+
+      if [ -n "$incompat" ]; then
+        echo "skipping incompat $type version $arversion, changed at $incompat < code $myversion"
+        continue
+      fi
+
+      for f in `ls $vdir/objects/$type`; do
+        #echo "\t$vdir/$type/$f"
+        if ! ./ceph-dencoder type $type import $vdir/objects/$type/$f decode dump_json > $tmp1; then
+          echo "**** failed to decode $vdir/objects/$type/$f ****"
+          failed=$(($failed + 1))
+          continue      
+        fi
+        if ! ./ceph-dencoder type $type import $vdir/objects/$type/$f decode encode decode dump_json > $tmp2; then
+          echo "**** failed to decode+encode+decode $vdir/objects/$type/$f ****"
+          failed=$(($failed + 1))
+          continue
+        fi
+
+        # nondeterministic classes may dump
+        # nondeterministically.  compare the sorted json
+        # output.  this is a weaker test, but is better than
+        # nothing.
+        if ! ./ceph-dencoder type $type is_deterministic; then
+          echo "  sorting json output for nondeterministic object"
+          for f in $tmp1 $tmp2; do
+            sort $f | sed 's/,$//' > $f.new
+            mv $f.new $f
+          done
+        fi
+
+        if ! cmp $tmp1 $tmp2; then
+          echo "**** reencode of $vdir/objects/$type/$f resulted in a different dump ****"
+          diff $tmp1 $tmp2
+          failed=$(($failed + 1))
+        fi
+        numtests=$(($numtests + 1))
+      done
+    else
+      echo "skipping unrecognized type $type"
     fi
-
-    for type in `ls $vdir/objects`
-    do
-	if ./ceph-dencoder type $type 2>/dev/null; then
-#	    echo "type $type";
-	    echo "        $vdir/objects/$type"
-
-	    # is there a fwd incompat change between $arversion and $version?
-	    incompat=""
-	    sawarversion=0
-	    for iv in `ls -v $dir/archive`
-	    do
-		if [ "$iv" = "$arversion" ]; then
-		    sawarversion=1
-		fi
-		if [ $sawarversion -eq 1 ] && [ -e "$dir/archive/$iv/forward_incompat/$type" ]; then
-		    incompat="$iv"
-		fi
-		if [ "$iv" = "$version" ]; then
-		    break
-		fi
-	    done
-	    if [ -n "$incompat" ]; then
-		echo "skipping incompat $type version $arversion, changed at $iv < code $myversion"
-		continue
-	    fi
-
-	    for f in `ls $vdir/objects/$type`; do
-#		echo "\t$vdir/$type/$f"
-		if ! ./ceph-dencoder type $type import $vdir/objects/$type/$f decode dump_json > $tmp1; then
-		    echo "**** failed to decode $vdir/objects/$type/$f ****"
-		    failed=$(($failed + 1))
-		    continue	    
-		fi
-		if ! ./ceph-dencoder type $type import $vdir/objects/$type/$f decode encode decode dump_json > $tmp2; then
-		    echo "**** failed to decode+encode+decode $vdir/objects/$type/$f ****"
-		    failed=$(($failed + 1))
-		    continue
-		fi
-
-		# nondeterministic classes may dump
-		# nondeterministically.  compare the sorted json
-		# output.  this is a weaker test, but is better than
-		# nothing.
-		if ! ./ceph-dencoder type $type is_deterministic
-		then
-		    echo "  sorting json output for nondeterministic object"
-		    for f in $tmp1 $tmp2; do
-			sort $f | sed 's/,$//' > $f.new
-			mv $f.new $f
-		    done
-		fi
-
-		if ! cmp $tmp1 $tmp2; then
-		    echo "**** reencode of $vdir/objects/$type/$f resulted in a different dump ****"
-		    diff $tmp1 $tmp2
-		    failed=$(($failed + 1))
-	    	fi
-		numtests=$(($numtests + 1))
-	    done
-	else
-            echo "skipping unrecognized type $type"
-	fi
-    done
+  done
 done
 
 rm -f $tmp1 $tmp2
 
 if [ $failed -gt 0 ]; then
-    echo "FAILED $failed / $numtests tests."
-    exit 1
+  echo "FAILED $failed / $numtests tests."
+  exit 1
 fi
 echo "passed $numtests tests."
 


### PR DESCRIPTION
1. Fix formatting (mixed tabs and spaces)
2. Status of skipped types was showing always last version in directory

Signed-off-by: Igor Podoski <igor.podoski@ts.fujitsu.com>