### PR TITLE
FileStore:Use pwritev instead of writev

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -530,6 +530,7 @@ public:
     int read_fd_zero_copy(int fd, size_t len);
     int write_file(const char *fn, int mode=0644);
     int write_fd(int fd) const;
+    int write_fd(int fd, uint64_t offset) const;
     int write_fd_zero_copy(int fd) const;
     void prepare_iov(std::vector<iovec> *piov) const;
     uint32_t crc32c(uint32_t crc) const;

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -3217,7 +3217,7 @@ int FileStore::_write(coll_t cid, const ghobject_t& oid,
   }
     
   // write
-  r = bl.write_fd(**fd,offset);
+  r = bl.write_fd(**fd, offset);
   if (r == 0)
     r = bl.length();
 

--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -3207,8 +3207,6 @@ int FileStore::_write(coll_t cid, const ghobject_t& oid,
   dout(15) << "write " << cid << "/" << oid << " " << offset << "~" << len << dendl;
   int r;
 
-  int64_t actual;
-
   FDRef fd;
   r = lfn_open(cid, oid, true, &fd);
   if (r < 0) {
@@ -3218,23 +3216,8 @@ int FileStore::_write(coll_t cid, const ghobject_t& oid,
     goto out;
   }
     
-  // seek
-  actual = ::lseek64(**fd, offset, SEEK_SET);
-  if (actual < 0) {
-    r = -errno;
-    dout(0) << "write lseek64 to " << offset << " failed: " << cpp_strerror(r) << dendl;
-    lfn_close(fd);
-    goto out;
-  }
-  if (actual != (int64_t)offset) {
-    dout(0) << "write lseek64 to " << offset << " gave bad offset " << actual << dendl;
-    r = -EIO;
-    lfn_close(fd);
-    goto out;
-  }
-
   // write
-  r = bl.write_fd(**fd);
+  r = bl.write_fd(**fd,offset);
   if (r == 0)
     r = bl.length();
 

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2083,6 +2083,24 @@ TEST(BufferList, write_fd) {
   ::unlink(FILENAME);
 }
 
+TEST(BufferList, write_fd_offset) {
+  ::unlink(FILENAME);
+  int fd = ::open(FILENAME, O_WRONLY|O_CREAT|O_TRUNC, 0600);
+  bufferlist bl;
+  for (unsigned i = 0; i < IOV_MAX * 2; i++) {
+    bufferptr ptr("A", 1);
+    bl.push_back(ptr);
+  }
+  uint64_t offset = 200;
+  EXPECT_EQ(0, bl.write_fd(fd, offset));
+  ::close(fd);
+  struct stat st;
+  memset(&st, 0, sizeof(st));
+  ::stat(FILENAME, &st);
+  EXPECT_EQ(IOV_MAX * 2 + offset, st.st_size);
+  ::unlink(FILENAME);
+}
+
 TEST(BufferList, crc32c) {
   bufferlist bl;
   __u32 crc = 0;


### PR DESCRIPTION
FileStore: Use pwritev instread of  writev, avoiding call lseek system call
Signed-off-by: Tao Chang <changtao@hihuron.com>