### PR TITLE
OSD: project_pg_history may not return the latest same_interval_since.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3519,23 +3519,21 @@ bool OSD::project_pg_history(spg_t pgid, pg_history_t& h, epoch_t from,
       &acting,
       &actingprimary);
 
-    // acting set change?
+    // acting set change or split?
     if ((actingprimary != currentactingprimary ||
 	 upprimary != currentupprimary ||
 	 acting != currentacting ||
-	 up != currentup) && e > h.same_interval_since) {
+	 up != currentup ||
+         pgid.is_split(oldmap->get_pg_num(pgid.pool()),
+                       osdmap->get_pg_num(pgid.pool()),
+                       0)) && 
+         e > h.same_interval_since) {
       dout(15) << "project_pg_history " << pgid << " acting|up changed in " << e
 	       << " from " << acting << "/" << up
 	       << " " << actingprimary << "/" << upprimary
 	       << " -> " << currentacting << "/" << currentup
 	       << " " << currentactingprimary << "/" << currentupprimary
 	       << dendl;
-      h.same_interval_since = e;
-    }
-    // split?
-    if (pgid.is_split(oldmap->get_pg_num(pgid.pool()),
-		      osdmap->get_pg_num(pgid.pool()),
-		      0)) {
       h.same_interval_since = e;
     }
     // up set change?


### PR DESCRIPTION
The project_pg_history method is designed to calculate the latest same_interval_since, same_up_since and same_primary_since between the current epoch and the input epoch. However, if pg split multiple times during this interval, project_pg_history may not return the latest same_interval_since and misleads caller.

Fixes: #13902
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>