### PR TITLE
Use --cluster instead of -c so metavariables are substituted correctly (pedantic)

### DIFF
--- a/systemd/ceph-radosgw-prestart.sh
+++ b/systemd/ceph-radosgw-prestart.sh
@@ -6,6 +6,7 @@ while true ; do
   case "$1" in
     -n|--name) name=$2; shift 2 ;;
     --cluster) cluster=$2; shift 2 ;;
+    -c|--conf) conf=$2; shift 2 ;;
     --) shift ; break ;;
   esac
 done
@@ -43,7 +44,11 @@ if [ -z "$cluster"  ]; then
   cluster="ceph"
 fi
 
-ceph_conf_file="/etc/ceph/${cluster}.conf"
+if [ -z "$conf"  ]; then
+  ceph_conf_file="/etc/ceph/${cluster}.conf"
+else
+  ceph_conf_file=$conf
+fi
 
 if [ ! -f "${ceph_conf_file}" ] ; then
   echo "ceph config file not found: $ceph_conf_file"
@@ -51,35 +56,35 @@ if [ ! -f "${ceph_conf_file}" ] ; then
 fi
 
 longname=${PREFIX}${name}
-testname=$(${CEPHCONF} -c ${ceph_conf_file} --list-sections $PREFIX | grep $longname )
+testname=$(${CEPHCONF} --cluster ${cluster} -c ${ceph_conf_file} --list-sections $PREFIX | grep $longname )
 
 if [ -z "$testname"  ]; then
-  echo "error parsing '$name' : valid types are: $(echo $(${CEPHCONF} -c ${ceph_conf_file} --list-sections $PREFIX | sed s/$PREFIX//))"
+  echo "error parsing '$name' : valid types are: $(echo $(${CEPHCONF} --cluster ${cluster} -c ${ceph_conf_file} --list-sections $PREFIX | sed s/$PREFIX//))"
   exit 1
 fi
 
-auto_start=`${CEPHCONF} -c ${ceph_conf_file} -n $longname 'auto start'`
+auto_start=`${CEPHCONF} --cluster ${cluster} -c ${ceph_conf_file} -n $longname 'auto start'`
 if [ "$auto_start" = "no" ] || [ "$auto_start" = "false" ] || [ "$auto_start" = "0" ]; then
-  echo "ceph.conf:[$longname], says not to start."
+  echo "${ceph_conf_file}:[$longname], says not to start."
   exit 1
 fi
 
 # is the socket defined?  if it's not, this instance shouldn't run as a daemon.
-rgw_socket=`$RADOSGW -c ${ceph_conf_file} -n $longname --show-config-value rgw_socket_path`
+rgw_socket=`$RADOSGW --cluster ${cluster} -c ${ceph_conf_file} -n $longname --show-config-value rgw_socket_path`
 if [ -z "$rgw_socket" ]; then
-  echo "socket $rgw_socket could not be found in ceph.conf:[$longname], not starting."
+  echo "socket $rgw_socket could not be found in ${ceph_conf_file}:[$longname], not starting."
   exit 1
 fi
 
 # mapped to this host?
-host=`${CEPHCONF} -c ${ceph_conf_file} -n $longname host`
+host=`${CEPHCONF} --cluster ${cluster} -c ${ceph_conf_file} -n $longname host`
 hostname=`hostname -s`
 if [ "$host" != "$hostname" ]; then
   echo "hostname $hostname could not be found in ceph.conf:[$longname], not starting."
   exit 1
 fi
 
-user=`${CEPHCONF} -c ${ceph_conf_file} -n $longname user`
+user=`${CEPHCONF} --cluster ${cluster} -c ${ceph_conf_file} -n $longname user`
 if [ -n "$user" ]; then
   if [ "$USER" != "$user" ]; then
     echo "enviroment \$USER '$USER' does not match '$longname' user '$user'"
@@ -88,7 +93,7 @@ if [ -n "$user" ]; then
 fi
 
 
-log_file=`$RADOSGW -c ${ceph_conf_file} -n $longname --show-config-value log_file`
+log_file=`$RADOSGW --cluster ${cluster} -c ${ceph_conf_file} -n $longname --show-config-value log_file`
 if [ -n "$log_file" ]; then
   if [ ! -f "$log_file" ]; then
     touch "$log_file"


### PR DESCRIPTION
1. $cluster is not substituted correctly if  -c ${ceph_conf_file} is used. The cluster name is still ceph
2. Use  --cluster ${cluster} instead; this ensures that metavars in /etc/ceph/${cluster}.conf are substituted correctly.
3. For this use case (ExecStartPre), this pull request may be pedantic as we don't really need the correct values just some value
E.g.  it's ok if rgw socket path returns /var/run/ceph/ceph-client.radosgw.gateway.asok instead of /var/run/ceph/CUSTOMCLUSTERNAME-client.radosgw.gateway.asok. Please ignore if this is the thinking.