### PR TITLE
sysvinit: allow custom cluster names

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -142,6 +142,10 @@ dofsumount=0
 verbose=0
 use_default_conf=1
 
+## set variables like cluster or conf
+[ -e /etc/sysconfig/ceph ] && . /etc/sysconfig/ceph
+[ -e /etc/default/ceph ] && . /etc/default/ceph
+
 
 while echo $1 | grep -q '^-'; do     # FIXME: why not '^-'?
 case $1 in
@@ -313,7 +317,7 @@ for name in $what; do
 	lockfile=""
     fi
 
-    get_conf asok "$run_dir/ceph-$type.$id.asok" "admin socket"
+    get_conf asok "$run_dir/$cluster-$type.$id.asok" "admin socket"
 
     case "$command" in
 	start)
@@ -430,8 +434,8 @@ for name in $what; do
 		# these keys.  it's also true for legacy installs
 		# via mkcephfs, which is fine too; there is no harm
 		# in creating these keys.
-		get_conf mon_data "/var/lib/ceph/mon/ceph-$id" "mon data"
-		if [ "$mon_data" = "/var/lib/ceph/mon/ceph-$id" -a "$asok" = "/var/run/ceph/ceph-mon.$id.asok" ]; then
+		get_conf mon_data "/var/lib/ceph/mon/$cluster-$id" "mon data"
+		if [ "$mon_data" = "/var/lib/ceph/mon/$cluster-$id" -a "$asok" = "/var/run/ceph/$cluster-mon.$id.asok" ]; then
 		    echo Starting ceph-create-keys on $host...
 		    cmd2="$SBINDIR/ceph-create-keys --cluster $cluster -i $id 2> /dev/null &"
 		    do_cmd "$cmd2"


### PR DESCRIPTION
Squashed commit: improves #6726 

Allows custom cluster names during system startup by emulating CLI. 
In Red Hat (/etc/sysconfig/ceph) or Debian (/etc/default/ceph):

    cluster=mycluster

is equivalent to   /etc/init.d/ceph --cluster mycluster

    conf=/etc/ceph/mycluster.conf
    use_default_conf=0

is equivalent to --conf /etc/ceph/mycluster.conf