### PR TITLE
rgw: remove unused variable in RGWPutMetadataBucket::execute

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2330,7 +2330,6 @@ void RGWPutMetadataBucket::pre_exec()
 
 void RGWPutMetadataBucket::execute()
 {
-  rgw_obj obj(s->bucket, s->object);
   map<string, bufferlist> attrs, orig_attrs, rmattrs;
 
   ret = get_params();


### PR DESCRIPTION
Very similar to PR #6668.