### PR TITLE
Gentoo: _FORTIFY_SOURCE fix.

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -57,6 +57,7 @@ HARDENING_CFLAGS = \
                    -g \
                    -pipe \
                    -Wall \
+                   -Wp,-U_FORTIFY_SOURCE \
                    -Wp,-D_FORTIFY_SOURCE=2 \
                    -fexceptions \
                    --param=ssp-buffer-size=4 \


### PR DESCRIPTION
GCC under Gentoo has a patch that has a built-in define for
_FORTIFY_SOURCE if -O2 or higher are used. This causes warnings about
_FORTIFY_SOURCE redefined for every single object compiled.

Work around the issue by explicitly undefining _FORTIFY_SOURCE before we
define it again.

http://tracker.ceph.com/issues/13920 Fixes: #13920
Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>