### PR TITLE
include/rados/librados.h: fix typo

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -145,7 +145,7 @@ enum {
 typedef void *rados_t;
 
 /**
- * @tyepdef rados_config_t
+ * @typedef rados_config_t
  *
  * A handle for the ceph configuration context for the rados_t cluster
  * instance.  This can be used to share configuration context/state


### PR DESCRIPTION
This typo causes a warning when building the docs.

Signed-off-by: Nathan Cutler <ncutler@suse.com>