### PR TITLE
osd/PG: release related sources when interrupt scrub.

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -9594,6 +9594,8 @@ void ReplicatedPG::on_shutdown()
   deleting = true;
 
   clear_scrub_reserved();
+  scrub_clear_state();
+
   unreg_next_scrub();
   cancel_copy_ops(false);
   cancel_flush_ops(false);


### PR DESCRIPTION
Now scrub is chunky scrub. For a pg, it maybe need more chunky_scrub.
If interrupt scrub, it should free the related sources.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>