### PR TITLE
cmake: define STRERROR_R_CHAR_P for GNU-specific strerror_r

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,12 @@ CHECK_SYMBOL_EXISTS(__s64 "sys/types.h;linux/types.h" HAVE___S64)
 
 CHECK_SYMBOL_EXISTS(res_nquery "resolv.h" HAVE_RES_NQUERY)
 
+include(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES("
+  #include <string.h>
+  int main() { char x = *strerror_r(0, &x, sizeof(x)); return 0; }
+  " STRERROR_R_CHAR_P)
+
 set(CEPH_MAN_DIR "share/man" CACHE STRING "Install location for man pages (relative to prefix).")
 
 option(ENABLE_SHARED "build shared libraries" ON)

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -176,6 +176,9 @@
 /* Define to 1 if you have the <utime.h> header file. */
 #cmakedefine HAVE_UTIME_H
 
+/* Define to 1 if strerror_r returns char *. */
+#cmakedefine STRERROR_R_CHAR_P 1
+
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */
 #cmakedefine LT_OBJDIR


### PR DESCRIPTION
This is what autotools does with AC_FUNC_STRERROR_R bit.  It takes us
from

    $ monmaptool --print nonexistant
    monmaptool: monmap file nonexistant
    monmaptool: couldn't open nonexistant: (2)

to

    $ monmaptool --print nonexistant
    monmaptool: monmap file nonexistant
    monmaptool: couldn't open nonexistant: (2) No such file or directory

on cmake - otherwise we end up using GNU-specific version as if it was
the POSIX version.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>