### PR TITLE
hammer: mds: fix out-of-order messages

### DIFF
--- a/src/mds/MDS.h
+++ b/src/mds/MDS.h
@@ -454,7 +454,7 @@ private:
   void dec_dispatch_depth() { --dispatch_depth; }
 
   // messages
-  bool _dispatch(Message *m);
+  bool _dispatch(Message *m, bool new_msg);
 
   protected:
   bool is_stale_message(Message *m);
@@ -488,7 +488,7 @@ public:
   }
   virtual void finish(int r) {
     mds->inc_dispatch_depth();
-    mds->_dispatch(m);
+    mds->_dispatch(m, false);
     mds->dec_dispatch_depth();
   }
 };


### PR DESCRIPTION
http://tracker.ceph.com/issues/13927

When MDS is no longer laggy, it should process deferred messages
first, then process newly received messages.

Fix: #11258
Signed-off-by: Yan, Zheng <zyan@redhat.com>
(cherry picked from commit ccdeaf87df8b66e09f6b20950b57ac61bf213086)