### PR TITLE
ceph-disk: warn for prepare partitions with bad GUIDs

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1599,6 +1599,11 @@ def prepare_dev(
     if is_partition(data):
         LOG.debug('OSD data device %s is a partition', data)
         rawdev = data
+
+        ptype = get_partition_type(rawdev)
+        if ptype != ptype_osd:
+                LOG.warning('incorrect partition UUID: %s, expected %s'
+                            % (ptype, ptype_osd))
     else:
         LOG.debug('Creating osd partition on %s', data)
         try:


### PR DESCRIPTION
If ceph-disk is a given partition device argument for prepare, it leaves
the GPT GUID as is and doesn't check whether the partition's existing
GUID matches the expected value. Print a warning in such cases.

Fixes: #13943

Signed-off-by: David Disseldorp <ddiss@suse.de>