### PR TITLE
rgw: fix partial read issue in rgw_admin and rgw_tools

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -16,6 +16,7 @@ using namespace std;
 #include "common/ceph_argparse.h"
 #include "common/Formatter.h"
 #include "common/errno.h"
+#include "common/safe_io.h"
 
 #include "global/global_init.h"
 
@@ -668,7 +669,7 @@ static int read_input(const string& infile, bufferlist& bl)
   do {
     char buf[READ_CHUNK];
 
-    r = read(fd, buf, READ_CHUNK);
+    r = safe_read(fd, buf, READ_CHUNK);
     if (r < 0) {
       err = -errno;
       cerr << "error while reading input" << std::endl;

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -4,6 +4,7 @@
 #include <errno.h>
 
 #include "common/errno.h"
+#include "common/safe_io.h"
 
 #include "include/types.h"
 
@@ -141,9 +142,9 @@ static int ext_mime_map_init(CephContext *cct, const char *ext_map)
     goto done;
   }
 
-  ret = read(fd, buf, st.st_size + 1);
+  ret = safe_read(fd, buf, st.st_size + 1);
   if (ret != st.st_size) {
-    // huh? file size has changed, what are the odds?
+    // huh? file size has changed?
     ldout(cct, 0) << "ext_mime_map_init(): raced! will retry.." << dendl;
     free(buf);
     close(fd);


### PR DESCRIPTION
In order to avoid partial read issue,we need to replace invoking raw `read` call by `safe_read` .