### PR TITLE
journal: fire replay complete event after reading last object

### DIFF
--- a/src/journal/JournalPlayer.h
+++ b/src/journal/JournalPlayer.h
@@ -108,7 +108,7 @@ private:
 
   void process_state(uint64_t object_number, int r);
   int process_prefetch(uint64_t object_number);
-  int process_playback();
+  int process_playback(uint64_t object_number);
 
   void fetch(uint64_t object_num);
   void handle_fetched(uint64_t object_num, int r);


### PR DESCRIPTION
Results in sporadic failures in journal unit test case.

Fixes: #13924
Signed-off-by: Jason Dillaman <dillaman@redhat.com>