### PR TITLE
mon: fix OSDMonitor::_check_become_tier

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7738,6 +7738,16 @@ bool OSDMonitor::_check_become_tier(
     return false;
   }
 
+  if (tier_pool->has_tiers()) {
+    *ss << "pool '" << tier_pool_name << "' has following tier(s) already:";
+    for (set<uint64_t>::iterator it = tier_pool->tiers.begin();
+         it != tier_pool->tiers.end(); it++)
+      *ss << "'" << osdmap.get_pool_name(*it) << "',";
+    *ss << " multiple tiers are not yet supported.";
+    *err = -EINVAL;
+    return false;
+  }
+
   if (tier_pool->is_tier()) {
     *ss << "tier pool '" << tier_pool_name << "' is already a tier of '"
        << osdmap.get_pool_name(tier_pool->tier_of) << "'";


### PR DESCRIPTION
_check_become_tier cannot prevent client from setting multiple tiers in a particular way.
suppose there are three pools,A B C.
if we add B to A as a tier,then add C to B as a tier,
the current implement will return with EINVAL to prevent setting multiple tiers.
but we can success setting multiple tiers in reverse order,that is,add C to B first,then add B to A as a tier,_checkout_become_tier will not prevent it, and it might cause many serious problems, like risk of correctness.

Signed-off-by: Mingxin Liu <mingxin.liu@kylin-cloud.com>
issues:13950#