### PR TITLE
Clean osd from down_pending_out at monitor peon when osd is up.

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -275,6 +275,9 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
 	dout(10) << " adding osd." << o << " to down_pending_out map" << dendl;
 	down_pending_out[o] = ceph_clock_now(g_ceph_context);
       }
+    } else if (osdmap.is_up(o) && down_pending_out.count(o) != 0 ) {
+      dout(10) << "clean osd." << o << " from down_pending_out map" << dendl;
+      down_pending_out.erase(o);
     }
   }
   // blow away any osd_epoch items beyond max_osd


### PR DESCRIPTION
The bug may  ahead of time to let osd out .    One example  
1. mon.a  down
2. osd.0  down, then mon.b record osd.0 in down_pending_out map
3. mon.a up, then become leader, mon.b  is peon 
4. osd.0 up.   mon.b still record osd.0 in down_pending_out map.
5. after 5min,  mon.a down and osd.0 down, mon.b become leader
6 . mon.b find the osd.0 down more than 5min in down_pending_out map ,  let osd.0 out,  but the osd.0  down just 1min actually.