### PR TITLE
configure.ac: macro fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1315,8 +1315,8 @@ AC_ARG_WITH([eventfd],
             ,
             [with_eventfd=yes])
 AS_IF([test "x$with_eventfd" != xno],
-    AC_CHECK_HEADERS(sys/eventfd.h,
-                     [AC_DEFINE(HAVE_EVENTFD, 1, [Have eventfd extension.])]))
+    [AC_CHECK_HEADERS(sys/eventfd.h,
+                     [AC_DEFINE(HAVE_EVENTFD, 1, [Have eventfd extension.])])])
 AM_CONDITIONAL(WITH_EVENTFD, [ test "$with_eventfd" = "yes" ])
 
 # Checks for typedefs, structures, and compiler characteristics.


### PR DESCRIPTION
Configure fails with autoconf 2.63 on Centos 6.6 with:

`./configure: line 34026: syntax error near unexpected token ``newline'`
`./configure: line 34026: ``  yes:no:'`

Signed-off-by: Igor Podoski <igor.podoski@ts.fujitsu.com>