### PR TITLE
common: re-enable backtrace support

### DIFF
--- a/src/common/BackTrace.h
+++ b/src/common/BackTrace.h
@@ -1,6 +1,7 @@
 #ifndef CEPH_BACKTRACE_H
 #define CEPH_BACKTRACE_H
 
+#include "acconfig.h"
 #include <iosfwd>
 #ifdef HAVE_EXECINFO_H
 #include <execinfo.h>
@@ -24,6 +25,7 @@ struct BackTrace {
 #else
     skip = 0;
     size = 0;
+    strings = nullptr;
 #endif
   }
   ~BackTrace() {


### PR DESCRIPTION
A recent porting effort disabled support for backtrace creation.  It
also didn't initialize all variables, which would lead to a crash when
deleting a backtrace instance.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>