### PR TITLE
rgw: add a missing cap type

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1158,7 +1158,8 @@ int RGWUserCaps::check_cap(const string& cap, uint32_t perm)
 
 bool RGWUserCaps::is_valid_cap_type(const string& tp)
 {
-  static const char *cap_type[] = { "users",
+  static const char *cap_type[] = { "user",
+                                    "users",
                                     "buckets",
                                     "metadata",
                                     "usage",


### PR DESCRIPTION
Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>