### PR TITLE
Implement asynchronous execution of OSD Read commands

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -562,7 +562,14 @@ int main(int argc, const char **argv)
                 g_conf->osd_data,
                 g_conf->osd_journal);
 
-  int err = osd->pre_init();
+  int err = store->create_read_completion_threads();
+  if (err < 0) {
+    derr << TEXT_RED << " ** ERROR: store create read completion threads failed: " << cpp_strerror(-err)
+	 << TEXT_NORMAL << dendl;
+    return 1;
+  }
+
+  err = osd->pre_init();
   if (err < 0) {
     derr << TEXT_RED << " ** ERROR: osd pre_init failed: " << cpp_strerror(-err)
 	 << TEXT_NORMAL << dendl;

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -1732,6 +1732,50 @@ int copyup(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
  * @param id the id stored in the object
  * @returns 0 on success, negative error code on failure
  */
+
+void get_id_async_callback(cls_method_context_t hctx, OSDOp *osd_op, bool asyncmode, int read_status)
+{
+  OSDOp *parent = osd_op->parent_op;
+  int retval = read_status;
+  string id;
+
+  assert(parent);
+  if (retval >= 0) {
+    try {
+      bufferlist::iterator iter = osd_op->outdata.begin();
+      ::decode(id, iter);
+    } catch (const buffer::error &err) {
+      retval = -EIO;
+    }
+  }
+
+  if (retval >= 0)
+    ::encode(id, parent->outdata);
+
+  osd_op->parent_op_callback(hctx, parent, asyncmode, retval);
+  delete osd_op;
+}
+
+int get_id_async(cls_method_context_t hctx, OSDOp& parent, cls_method_cxx_cb_t cb)
+{
+  uint64_t size;
+  int r = cls_cxx_stat(hctx, &size, NULL);
+  if (r < 0)
+    return r;
+
+  if (size == 0)
+    return -ENOENT;
+
+  OSDOp *osd_op = new OSDOp(&parent, cb);
+  r = cls_cxx_read_async(hctx, 0, size, &osd_op->outdata, *osd_op, get_id_async_callback);
+  if (r < 0) {
+    CLS_ERR("get_id: could not read id: %d", r);
+    return r;
+  }
+
+  return 0;
+}
+
 int get_id(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
   uint64_t size;
@@ -3005,7 +3049,7 @@ void __cls_init()
   /* methods for the rbd_id.$image_name objects */
   cls_register_cxx_method(h_class, "get_id",
 			  CLS_METHOD_RD,
-			  get_id, &h_get_id);
+			  get_id, &h_get_id, get_id_async);
   cls_register_cxx_method(h_class, "set_id",
 			  CLS_METHOD_RD | CLS_METHOD_WR,
 			  set_id, &h_set_id);

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -884,6 +884,7 @@ OPTION(filestore_sloppy_crc, OPT_BOOL, false)         // track sloppy crcs
 OPTION(filestore_sloppy_crc_block_size, OPT_INT, 65536)
 
 OPTION(filestore_max_alloc_hint_size, OPT_U64, 1ULL << 20) // bytes
+OPTION(filestore_async_threads, OPT_INT, 0)
 
 OPTION(filestore_max_sync_interval, OPT_DOUBLE, 5)    // seconds
 OPTION(filestore_min_sync_interval, OPT_DOUBLE, .01)  // seconds

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -9,6 +9,7 @@
 #include "../include/types.h"
 #include "msg/msg_types.h"
 #include "common/hobject.h"
+#include "osd/osd_types.h"
 
 extern "C" {
 #endif
@@ -26,6 +27,7 @@ const char *__cls_name = #name;
 #define CLS_METHOD_WR       0x2 /// method executes write operations
 #define CLS_METHOD_PUBLIC   0x4 /// unused
 #define CLS_METHOD_PROMOTE  0x8 /// method cannot be proxied to base tier
+#define CLS_METHOD_ASYNC    0x10
 
 
 #define CLS_LOG(level, fmt, ...)					\
@@ -41,6 +43,7 @@ typedef void *cls_method_context_t;
 typedef int (*cls_method_call_t)(cls_method_context_t ctx,
 				 char *indata, int datalen,
 				 char **outdata, int *outdatalen);
+
 typedef struct {
 	const char *name;
 	const char *ver;
@@ -95,6 +98,9 @@ extern void class_fini(void);
 #ifdef __cplusplus
 }
 
+typedef void (*cls_method_cxx_cb_t)(cls_method_context_t ctx, OSDOp *osd_op, bool async_mode, int result);
+typedef int (*cls_method_cxx_async_call_t)(cls_method_context_t ctx, 
+                                           OSDOp& osd_op, cls_method_cxx_cb_t callback);
 typedef int (*cls_method_cxx_call_t)(cls_method_context_t ctx,
 				     class buffer::list *inbl, class buffer::list *outbl);
 
@@ -132,17 +138,20 @@ typedef PGLSFilter* (*cls_cxx_filter_factory_t)();
 
 
 extern int cls_register_cxx_method(cls_handle_t hclass, const char *method, int flags,
-				   cls_method_cxx_call_t class_call, cls_method_handle_t *handle);
+                                   cls_method_cxx_call_t class_call, cls_method_handle_t *handle,
+                                   cls_method_cxx_async_call_t async_class_call=NULL);
 
 extern int cls_register_cxx_filter(cls_handle_t hclass,
                                    const std::string &filter_name,
-				   cls_cxx_filter_factory_t fn,
+                                   cls_cxx_filter_factory_t fn,
                                    cls_filter_handle_t *handle=NULL);
 
 extern int cls_cxx_create(cls_method_context_t hctx, bool exclusive);
 extern int cls_cxx_remove(cls_method_context_t hctx);
 extern int cls_cxx_stat(cls_method_context_t hctx, uint64_t *size, time_t *mtime);
 extern int cls_cxx_read(cls_method_context_t hctx, int ofs, int len, bufferlist *bl);
+extern int cls_cxx_read_async(cls_method_context_t hctx, int ofs, int len, bufferlist *bl,
+                              OSDOp& osd_op, cls_method_cxx_cb_t callback);
 extern int cls_cxx_write(cls_method_context_t hctx, int ofs, int len, bufferlist *bl);
 extern int cls_cxx_write_full(cls_method_context_t hctx, bufferlist *bl);
 extern int cls_cxx_getxattr(cls_method_context_t hctx, const char *name,

--- a/src/os/FileStore.h
+++ b/src/os/FileStore.h
@@ -44,6 +44,10 @@ using namespace std;
 
 #include "include/uuid.h"
 
+#ifdef HAVE_LIBAIO
+#include <libaio.h>
+#endif
+#include "common/errno.h"
 
 // from include/linux/falloc.h:
 #ifndef FALLOC_FL_PUNCH_HOLE
@@ -182,6 +186,7 @@ private:
       return 0;
     }
   } sync_thread;
+  bool async_read_avail;
 
   // -- op workqueue --
   struct Op {
@@ -372,6 +377,70 @@ private:
     }
   } op_wq;
 
+#define MAX_READ_EVENTS (1024)
+  // See struct aio_info
+  struct read_aio {
+    struct iocb iocb;
+    FDRef fd;
+    bufferlist *bl;
+    bufferptr bptr;
+    bool done;
+    uint32_t op_flags;
+
+    uint64_t off, len;
+    const ghobject_t& oid;
+    Context *context;
+    int status;
+
+    read_aio(FDRef fd_arg, bufferlist *b, uint64_t o, uint64_t s,
+             uint32_t opflags, const ghobject_t& oid_arg,
+             Context *context_arg)
+      : fd(fd_arg), bl(b), done(false),
+        op_flags(opflags), off(o), len(b->length()), oid(oid_arg),
+        context(context_arg), status(0)
+    {
+      memset((void*)&iocb, 0, sizeof(iocb));
+    }
+    ~read_aio() {
+    }
+  };
+
+  class ReadCompletionThread : public Thread {
+    unsigned magic;
+    FileStore *fs;
+  public:
+    io_context_t read_aio_ctx;
+    bool active;
+    ReadCompletionThread(FileStore *fs_arg) :
+      magic(0xdeadbeac), fs(fs_arg), active(true)
+    {
+      read_aio_ctx = 0;
+      int r = io_setup(MAX_READ_EVENTS, &read_aio_ctx);
+      if (r < 0) {
+        derr << "ReadCompletionThread: unable to set up io_context for " << this << " " <<
+          cpp_strerror(r) << dendl;
+      }
+    }
+
+    void * entry() {
+      fs->read_finish_thread_entry(this);
+      magic = ~(0xdeadbeac);
+      derr << "ReadCompletionThread: " << this << "  exit " << dendl;
+      return 0;
+    };
+  };
+
+  list<ReadCompletionThread*> read_completion_threads;
+  list<ReadCompletionThread *>::iterator next_read_submit_thread;
+  Mutex read_completion_threads_lock;
+
+  void read_finish_thread_entry(ReadCompletionThread *rct);
+  void async_read_finish(read_aio *rio);
+  void read_aio_bl(FDRef fdref, bufferlist* bl, bufferptr* bptr,
+                   off64_t& pos, size_t len, Context *ctx, uint32_t op_flags,
+                   const ghobject_t &oid);
+  int rio_num, rio_bytes;
+
   void _do_op(OpSequencer *o, ThreadPool::TPHandle &handle);
   void _finish_op(OpSequencer *o);
   Op *build_op(list<Transaction*>& tls,
@@ -388,6 +457,17 @@ private:
   PerfCounters *logger;
 
 public:
+  int create_read_completion_threads();
+  int async_read_dispatch(
+    Context *ctx,
+    const coll_t *cid,
+    const ghobject_t& oid,
+    uint64_t offset,
+    size_t len,
+    bufferlist* bl,
+    uint32_t op_flags,
+    bool allow_eio);
+
   int lfn_find(const ghobject_t& oid, const Index& index, 
                                   IndexedPath *path = NULL);
   int lfn_truncate(coll_t cid, const ghobject_t& oid, off_t length);
@@ -545,6 +625,10 @@ public:
     bufferlist& bl,
     uint32_t op_flags = 0,
     bool allow_eio = false);
+
+  bool async_read_capable() {return async_read_avail;}
+  //bool async_read_capable() {return false;}
+
   int _do_fiemap(int fd, uint64_t offset, size_t len,
                  map<uint64_t, uint64_t> *m);
   int _do_seek_hole_data(int fd, uint64_t offset, size_t len,
@@ -725,6 +809,7 @@ private:
   int m_filestore_sloppy_crc_block_size;
   uint64_t m_filestore_max_alloc_hint_size;
   long m_fs_type;
+  int m_filestore_async_threads;
 
   //Determined xattr handling based on fs type
   void set_xattr_limits_via_conf();

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1922,6 +1922,18 @@ public:
     uint32_t op_flags = 0,
     bool allow_eio = false) = 0;
 
+   virtual bool async_read_capable() { return false;}
+   virtual int create_read_completion_threads() {return 0;}
+   virtual int async_read_dispatch(
+    Context *ctx,
+    const coll_t *cid,
+    const ghobject_t& oid,
+    uint64_t offset,
+    size_t len,
+    bufferlist* bl,
+    uint32_t op_flags = 0,
+    bool allow_eio = false) {return -EINVAL;}
+
   /**
    * fiemap -- get extent map of data of an object
    *

--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -23,8 +23,11 @@ public:
     int flags;
     cls_method_call_t func;
     cls_method_cxx_call_t cxx_func;
+    cls_method_cxx_async_call_t cxx_async_func;
 
     int exec(cls_method_context_t ctx, bufferlist& indata, bufferlist& outdata);
+    int exec_async(cls_method_context_t ctx, OSDOp& osd_op,
+                   cls_method_cxx_cb_t cxx_callback);
     void unregister();
 
     int get_flags() {
@@ -32,7 +35,7 @@ public:
       return flags;
     }
 
-    ClassMethod() : cls(0), flags(0), func(0), cxx_func(0) {}
+    ClassMethod() : cls(0), flags(0), func(0), cxx_func(0), cxx_async_func(0) {}
   };
 
   struct ClassFilter {
@@ -73,7 +76,8 @@ public:
     ~ClassData() { }
 
     ClassMethod *register_method(const char *mname, int flags, cls_method_call_t func);
-    ClassMethod *register_cxx_method(const char *mname, int flags, cls_method_cxx_call_t func);
+    ClassMethod *register_cxx_method(const char *mname, int flags, cls_method_cxx_call_t func,
+                                     cls_method_cxx_async_call_t async_func = NULL);
     void unregister_method(ClassMethod *method);
 
     ClassFilter *register_cxx_filter(

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -555,6 +555,12 @@
 		pair<bufferlist*, Context*> > > &to_read,
      Context *on_complete, bool fast_read = false) = 0;
 
+   virtual void objects_read_async_use_aio(
+     const hobject_t &hoid,
+     const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
+		pair<bufferlist*, Context*> > > &to_read,
+     Context *on_complete) { assert(0); }
+
    virtual bool scrub_supported() { return false; }
    virtual bool auto_repair_supported() const { return false; }
    void be_scan_list(

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -162,6 +162,12 @@ public:
                Context *on_complete,
                bool fast_read = false);
 
+  void objects_read_async_use_aio(
+    const hobject_t &hoid,
+    const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
+	       pair<bufferlist*, Context*> > > &to_read,
+    Context *on_complete);
+
 private:
   // push
   struct PushInfo {

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -478,6 +478,8 @@ public:
     osd_reqid_t reqid;
     vector<OSDOp> &ops;
 
+    vector<async_opvec_control *> ctx_opvec_controls;
+
     const ObjectState *obs; // Old objectstate
     const SnapSet *snapset; // Old snapset
 
@@ -627,9 +629,11 @@ public:
 	snapset = &obc->ssc->snapset;
       }
     }
+
     OpContext(OpRequestRef _op, osd_reqid_t _reqid,
               vector<OSDOp>& _ops, ReplicatedPG *_pg) :
-      op(_op), reqid(_reqid), ops(_ops), obs(NULL), snapset(0),
+      op(_op), reqid(_reqid), ops(_ops),
+      obs(NULL), snapset(0),
       modify(false), user_modify(false), undirty(false), cache_evict(false),
       ignore_cache(false), ignore_log_op_stats(false),
       bytes_written(0), bytes_read(0), user_at_version(0),
@@ -651,6 +655,7 @@ public:
 	snapset = &obc->ssc->snapset;
       }
     }
+
     ~OpContext() {
       assert(!op_t);
       assert(lock_to_release == NONE);
@@ -664,7 +669,19 @@ public:
 	delete i->second.second;
       }
       assert(on_finish == NULL);
+
+      // delete the async_opvec_controls
+      while (!ctx_opvec_controls.empty()) {
+        async_opvec_control *opvec_control = ctx_opvec_controls.back();
+        ctx_opvec_controls.pop_back();
+
+        // Here we just free all the opvec_controls since we allocated those;
+        // the OSDOp's are allocated and freed in the same way as for
+        // synchronous operation.
+        delete opvec_control;
+      }
     }
+
     void finish(int r) {
       if (on_finish) {
 	on_finish->complete(r);
@@ -673,6 +690,7 @@ public:
     }
   };
   friend struct OpContext;
+  void execute_ctx_continue(OpContext *ctx, int result);
 
   /*
    * State on the PG primary associated with the replicated mutation
@@ -1477,7 +1495,11 @@ public:
 
   RepGather *trim_object(const hobject_t &coid);
   void snap_trimmer(epoch_t e);
-  int do_osd_ops(OpContext *ctx, vector<OSDOp>& ops);
+
+  int do_osd_ops(OpContext *ctx, vector<OSDOp>& ops,
+                 osd_op_callback_t callback = NULL);
+  void osd_op_call_completion(OpContext *ctx, OSDOp *osd_op, bool asyncmode, int result);
+  int prepare_transaction_continue(OpContext *ctx, int result, bool async_call);
 
   int _get_tmap(OpContext *ctx, bufferlist *header, bufferlist *vals);
   int do_tmap2omap(OpContext *ctx, unsigned flags);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3698,6 +3698,10 @@ struct ScrubMap {
 WRITE_CLASS_ENCODER(ScrubMap::object)
 WRITE_CLASS_ENCODER(ScrubMap)
 
+struct OSDOp;
+struct async_opvec_control;
+// Callback function for OSDOp asynchronous completion.
+typedef void (*osd_op_callback_t)(void *ctx, OSDOp *osd_op, bool async_mode, int result);
 
 struct OSDOp {
   ceph_osd_op op;
@@ -3706,7 +3710,20 @@ struct OSDOp {
   bufferlist indata, outdata;
   int32_t rval;
 
-  OSDOp() : rval(0) {
+  bool async_done;
+  int async_result;
+
+  struct OSDOp *parent_op;
+  osd_op_callback_t parent_op_callback;
+  async_opvec_control *opvec_control;
+
+  OSDOp() : rval(0), async_done(false), parent_op(0), opvec_control(0) {
+    memset(&op, 0, sizeof(ceph_osd_op));
+  }
+
+  OSDOp(OSDOp *parent_op_arg, osd_op_callback_t poc) :
+    rval(0), async_done(false),
+    parent_op(parent_op_arg), parent_op_callback(poc) {
     memset(&op, 0, sizeof(ceph_osd_op));
   }
 
@@ -3747,6 +3764,78 @@ struct OSDOp {
 };
 
 ostream& operator<<(ostream& out, const OSDOp& op);
+
+// Tracks if all OSDOps have completed.
+struct async_opvec_control {
+  bool callbacks_locked;      // whether callbacks are allowed/blocked.
+  osd_op_callback_t callback;
+  vector<OSDOp *> peer_ops;
+  bool lock_used;
+  Mutex *async_lock;
+
+  //
+  // Add the OSDOp to the given opvec_control. This is needed for
+  // the OSDOp's async completion handling.
+  //
+  void add_osd_op(struct OSDOp *osd_op)
+  {
+    peer_ops.push_back(osd_op);
+    osd_op->opvec_control = this;
+  }
+
+  // Check if all ops in an opvec are complete. If so, return the
+  // callback in the opvec_control. Holds a lock over all async
+  // completions for that OpContext.
+  osd_op_callback_t
+  check_completion(bool async_mode, int *result, OSDOp *osd_op = NULL)
+  {
+    if (lock_used)
+      async_lock->Lock();
+    osd_op_callback_t cb = NULL;
+
+    if (osd_op) {
+      osd_op->async_done = true;
+      osd_op->async_result = *result;
+    }
+
+    if (callbacks_locked)
+      goto out;
+
+    *result = 0;
+    for (vector<OSDOp *>::iterator p = peer_ops.begin(); p != peer_ops.end(); ++p) {
+      OSDOp *cur = *p;
+      if (!cur->async_done)
+        goto out;
+
+      if (cur->async_result < 0 && *result == 0)
+        *result = cur->async_result;
+    }
+
+    cb = callback;
+    // Ensure callback executed only once for the vector.
+    callback = NULL;
+
+  out:
+    if (lock_used)
+      async_lock->Unlock();
+    return cb;
+  }
+
+  async_opvec_control(bool use_lock, osd_op_callback_t cb): callback(cb), lock_used(use_lock)
+  {
+    if (lock_used) {
+      async_lock = new Mutex("async_opvec_lock");
+      callbacks_locked = true;
+    } else
+      callbacks_locked = false;
+  }
+
+  ~async_opvec_control()
+  {
+    if (lock_used)
+      delete async_lock;
+  }
+};
 
 struct watch_item_t {
   entity_name_t name;


### PR DESCRIPTION
Work in Progress.
Implement asynchronous execution of Read commands sent to OSD configured with FileStore.
- Class driver and RBD class: allow registering methods which accept an additional
  parameter, a completion callback. For these methods, both normal (sync) mode and
  async mode are supported, caller can check for CLS_METHOD_ASYNC and issue async
  version of command, along with a callback function.
  Currently asynchronous versions of only get_id(), cxx_read() are available.
- ObjectStore interface changed to allow dispatching of asynchronous reads through
  virtual function that returns error in the base class.
- FileStore: Create list of threads for completion processing, using Linux AIO
  (io_getevents()) to process completion. Allow asynchronous Read commands via
  Async dispatch routine, which uses round-robin to spread completion workload
  among threads.
- ReplicatedPG::do_osd_ops() accepts callback argument. If callback is non-null and
  if it determines that command can be serviced using asynchronous methods, then it
  executes the command asynchronously and may return before callback has completed.
  Callers of do_osd_ops() are refactored to reflect this.
- OSDOp modified to include a pointer to an async_opvec_control struct which
  ensures callback completion for all OSDOp in a vector is checked atomically. For this
  a Mutex async_opvec_control::async_lock is defined but used only if number of
  callbacks in a vector of OSDOp are > 1.
- I have received some suggestions on this and working on those improvements.