### PR TITLE
osd: call on_new_interval on newly split child PG

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2273,6 +2273,8 @@ void PG::split_into(pg_t child_pgid, PG *child, unsigned split_bits)
   split_ops(child, split_bits);
   _split_into(child_pgid, child, split_bits);
 
+  child->on_new_interval();
+
   child->dirty_info = true;
   child->dirty_big_info = true;
   dirty_info = true;


### PR DESCRIPTION
We must call on_new_interval() on any interval change *and* on the
creation of the PG.  Currently we call it from PG::init() and
PG::start_peering_interval().  However, PG::split_into() did not
do so for the child PG, which meant that the new child feature
bits were not properly initialized and the bitwise/nibblewise
debug bit was not correctly set.  That, in turn, could lead to
various misbehaviors, the most obvious of which is scrub errors
due to the sort order mismatch.

Fixes: #13962
Signed-off-by: Sage Weil <sage@redhat.com>