### PR TITLE
doc/dev/index.rst: fix headings

### DIFF
--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -107,7 +107,11 @@ There are also `other Ceph-related mailing lists`_.
 IRC
 ---
 
-See https://ceph.com/resources/mailing-list-irc/
+In addition to mailing lists, the Ceph community also communicates in real
+time using `Internet Relay Chat`_.  
+
+See https://ceph.com/resources/mailing-list-irc/ for how to set up your IRC
+client and a list of channels.
 
 
 High-level structure

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -42,7 +42,7 @@ Leads
 
 The Ceph project is led by Sage Weil. In addition, each major project
 component has its own lead. The following table shows all the leads and
-their nicks on `github`:
+their nicks on `GitHub`_:
 
 .. _github: https://github.com/ceph/ceph
 
@@ -63,7 +63,7 @@ structure`_, below.
 History
 -------
 
-See the `History chapter of the Wikipedia article`.
+See the `History chapter of the Wikipedia article`_.
 
 .. _`History chapter of the Wikipedia article`: https://en.wikipedia.org/wiki/Ceph_%28software%29#History
 
@@ -73,9 +73,11 @@ Licensing
 Ceph is free software.
 
 Unless stated otherwise, the Ceph source code is distributed under the terms of
-the LGPL2.1. For full details, see the file COPYING in the top-level directory
-of the source-code distribution:
-https://github.com/ceph/ceph/blob/master/COPYING
+the LGPL2.1. For full details, see `the file COPYING in the top-level
+directory of the source-code tree`_.
+
+.. _`the file COPYING in the top-level directory of the source-code tree`: 
+  https://github.com/ceph/ceph/blob/master/COPYING
 
 Source code repositories
 ------------------------
@@ -176,4 +178,59 @@ You can start a development mode Ceph cluster, after compiling the source, with:
 	./vstart.sh -n -x -l
 	# check that it's there
 	./ceph health
+
+Bugfixing
+=========
+
+Without bugs, there would be no software, and without software, there would
+be no software developers. This chapter explains the Ceph-specific aspects
+of bugfixing workflows.
+
+Issue tracker
+-------------
+
+The Ceph project has its own issue tracker, `http://tracker.ceph.com`_,
+powered by `Redmine`_.
+
+.. _`http://tracker.ceph.com`: http://tracker.ceph.com
+.. _Redmine: http://www.redmine.org
+
+The tracker has a Ceph project with a number of subprojects loosely
+corresponding to the project components listed in `High-level overview`.
+
+Mere `registration`_ automatically grants tracker permissions sufficient to
+open new issues and comment on existing ones.
+
+.. _registration: http://tracker.ceph.com/account/register
+
+To report a bug, `jump to the Ceph project`_ and click on `New issue`_
+
+.. _`jump to the Ceph project`: http://tracker.ceph.com/projects/ceph
+.. _`New issue`: http://tracker.ceph.com/projects/ceph/issues/new
+
+If you start working on a bug, let the other developers know by adding an
+update to the issue.
+
+If your tracker permissions have been escalated, you can change the issue
+status as appropriate:
+
+================ ===========================================
+Status           Meaning
+================ ===========================================
+New              Initial status
+In Progress      Somebody is working on it
+Need Review      Pull request is open with a fix
+Pending Backport Fix has been merged, backport(s) pending
+Resolved         Fix and backports (if any) have been merged
+================ ===========================================
+
+There are other statuses, but these are the most common.
+
+If you do not have permission to change the status yourself, don't worry:
+someone will probably change it for you, even without asking. You can ask
+on IRC for another developer to change the status for you.
+
+Documentation bugs
+------------------
+
 

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -1,9 +1,6 @@
-====================
-Contributing to Ceph
-====================
-----------------------
-A Guide for Developers
-----------------------
+============================================
+Contributing to Ceph: A Guide for Developers
+============================================
 
 :Author: Loic Dachary
 :Author: Nathan Cutler
@@ -12,7 +9,7 @@ A Guide for Developers
 .. note:: The old (pre-2016) developer documentation has been moved to :doc:`/dev/index-old`.
 
 .. contents::
-   :depth: 4
+   :depth: 3
 
 Introduction
 ============

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -14,7 +14,11 @@ Contributing to Ceph: A Guide for Developers
 Introduction
 ============
 
-This guide assumes that you are already familiar with Ceph (the distributed
+This guide has two aims. First, it should lower the barrier to entry for
+software developers who wish to get involved in the Ceph project. Second,
+it should serve as a reference for Ceph developers.
+
+We assume that readers are already familiar with Ceph (the distributed
 object store and file system designed to provide excellent performance,
 reliability and scalability). If not, please refer to the `project website`_ 
 and especially the `publications list`_.
@@ -22,38 +26,46 @@ and especially the `publications list`_.
 .. _`project website`: http://ceph.com 
 .. _`publications list`: https://ceph.com/resources/publications/
 
-Bare essentials
-===============
+Since this document is to be consumed by developers, who are assumed to
+have Internet access, topics covered elsewhere on the web are treated by
+linking. If you notice that a link is broken or if you know of a better
+link, `open a pull request`.
+
+The bare essentials
+===================
+
+This chapter presents essential information that every Ceph developer needs
+to know.
 
 Leads
 -----
 
-* Project lead: Sage Weil
-* RADOS lead: Samuel Just
-* RGW lead: Yehuda Sadeh
-* RBD lead: Josh Durgin
-* CephFS lead: Gregory Farnum
-* Build/Ops lead: Ken Dreyer
+The Ceph project is led by Sage Weil. In addition, each major project
+component has its own lead. The following table shows all the leads and
+their nicks on `github`:
 
-The Ceph-specific acronyms are explained under `High-level structure`_, below.
+.. _github: https://github.com/ceph/ceph
+
+========= =============== =============
+Scope     Lead            GitHub nick
+========= =============== =============
+Ceph      Sage Weil       liewegas
+RADOS     Samuel Just     athanatos
+RGW       Yehuda Sadeh    yehudasa
+RBD       Josh Durgin     jdurgin
+CephFS    Gregory Farnum  gregsfortytwo
+Build/Ops Ken Dreyer      ktdreyer
+========= =============== =============
+
+The Ceph-specific acronyms in the table are explained under `High-level
+structure`_, below.
 
 History
 -------
 
-The Ceph project grew out of the petabyte-scale storage research at the Storage
-Systems Research Center at the University of California, Santa Cruz. The
-project was funded primarily by a grant from the Lawrence Livermore, Sandia,
-and Los Alamos National Laboratories.
+See the `History chapter of the Wikipedia article`.
 
-Sage Weil, the project lead, published his Ph. D. thesis entitled "Ceph:
-Reliable, Scalable, and High-Performance Distributed Storage" in 2007.
-
-DreamHost https://www.dreamhost.com . . .
-
-Inktank . . .
-
-On April 30, 2014 Red Hat announced its takeover of Inktank:
-http://www.redhat.com/en/about/press-releases/red-hat-acquire-inktank-provider-ceph
+.. _`History chapter of the Wikipedia article`: https://en.wikipedia.org/wiki/Ceph_%28software%29#History
 
 Licensing
 ---------
@@ -78,10 +90,11 @@ knowledge of git_ is essential.
 Mailing list
 ------------
 
-The official development email list is ``ceph-devel@vger.kernel.org``.  Subscribe by sending
-a message to ``majordomo@vger.kernel.org`` with the line::
+Ceph development email discussions take place on
+``ceph-devel@vger.kernel.org``.  Subscribe by sending a message to
+``majordomo@vger.kernel.org`` with the line::
 
- subscribe ceph-devel
+    subscribe ceph-devel
 
 in the body of the message.
 
@@ -101,32 +114,49 @@ High-level structure
 Like any other large software project, Ceph consists of a number of components.
 Viewed from a very high level, the components are:
 
-* **RADOS**
+RADOS
+-----
 
-  RADOS stands for "Reliable, Autonomic Distributed Object Store". In a Ceph
-  cluster, all data are stored in objects, and RADOS is the component responsible
-  for that. 
+RADOS stands for "Reliable, Autonomic Distributed Object Store". In a Ceph
+cluster, all data are stored in objects, and RADOS is the component responsible
+for that. 
 
-  RADOS itself can be further broken down into Monitors, Object Storage Daemons
-  (OSDs), and clients.
+RADOS itself can be further broken down into Monitors, Object Storage Daemons
+(OSDs), and clients (librados). Monitors and OSDs are introduced at
+:doc:`start/intro`. The client library is explained at :doc:`rados/api`.
 
-* **RGW**
+RGW
+---
 
-  RGW stands for RADOS Gateway. Using the embedded HTTP server civetweb_, RGW
-  provides a REST interface to RADOS objects.
+RGW stands for RADOS Gateway. Using the embedded HTTP server civetweb_, RGW
+provides a REST interface to RADOS objects.
 
-  .. _civetweb: https://github.com/civetweb/civetweb
+.. _civetweb: https://github.com/civetweb/civetweb
 
-* **RBD**
+A more thorough introduction to RGW can be found at :doc:`radosgw`.
 
-  RBD stands for RADOS Block Device. It enables a Ceph cluster to store disk
-  images, and includes in-kernel code enabling RBD images to be mounted.
+RBD
+---
 
-* **CephFS**
+RBD stands for RADOS Block Device. It enables a Ceph cluster to store disk
+images, and includes in-kernel code enabling RBD images to be mounted.
 
-  CephFS is a distributed file system that enables a Ceph cluster to be used as a NAS.
+To delve further into RBD, see :doc:`rbd/rbd`.
 
-  File system metadata is managed by Meta Data Server (MDS) daemons.
+CephFS
+------
+
+CephFS is a distributed file system that enables a Ceph cluster to be used as a NAS.
+
+File system metadata is managed by Meta Data Server (MDS) daemons. The Ceph
+file system is explained in more detail at :doc:`cephfs`.
+
+Build/Ops
+---------
+
+Ceph is regularly built and packaged for a number of major Linux
+distributions. At the time of this writing, these included Debian, Ubuntu,
+CentOS, openSUSE, and Fedora.
 
 Building
 ========
@@ -134,7 +164,7 @@ Building
 Building from source
 --------------------
 
-See http://docs.ceph.com/docs/master/install/build-ceph/
+See instructions at :doc:`install/build-ceph`.
 
 Testing
 =======
@@ -146,37 +176,4 @@ You can start a development mode Ceph cluster, after compiling the source, with:
 	./vstart.sh -n -x -l
 	# check that it's there
 	./ceph health
-
-WIP
-===
-
-Monitors
---------
-
-MON stands for "Monitor". Each Ceph cluster has a number of monitor processes.
-See **man ceph-mon** or http://docs.ceph.com/docs/master/man/8/ceph-mon/ for
-some basic information. The monitor source code lives under **src/mon** in the
-tree: https://github.com/ceph/ceph/tree/master/src/mon
-
-OSDs
-----
-
-OSD stands for Object Storage Daemon. Typically, there is one of these for each
-disk in the cluster. See **man ceph-osd** or
-http://docs.ceph.com/docs/master/man/8/ceph-osd/ for basic information. The OSD
-source code can be found here: https://github.com/ceph/ceph/tree/master/src/osd
-
-librados
---------
-
-RADOS also includes an API for writing your own clients that can communicate
-directly with a Ceph cluster's underlying object store. The API includes
-bindings for popular scripting languages such as Python. For more information, 
-see the documents under https://github.com/ceph/ceph/tree/master/doc/rados/api
-
-Build/Ops
----------
-
-Ceph supports a number of major Linux distributions and provides packaging for them.
-
 

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -29,7 +29,9 @@ and especially the `publications list`_.
 Since this document is to be consumed by developers, who are assumed to
 have Internet access, topics covered elsewhere on the web are treated by
 linking. If you notice that a link is broken or if you know of a better
-link, `open a pull request`.
+link, `open a pull request`_.
+
+.. _`open a pull request`: http://tracker.ceph.com/projects/ceph/issues/new
 
 The bare essentials
 ===================
@@ -82,7 +84,8 @@ directory of the source-code tree`_.
 Source code repositories
 ------------------------
 
-The source code of Ceph lives on GitHub in a number of repositories below https://github.com/ceph
+The source code of Ceph lives on GitHub in a number of repositories below
+https://github.com/ceph.
 
 To make a meaningful contribution to the project as a developer, a working
 knowledge of git_ is essential.
@@ -110,6 +113,8 @@ IRC
 In addition to mailing lists, the Ceph community also communicates in real
 time using `Internet Relay Chat`_.  
 
+.. _`Internet Relay Chat`: http://www.irchelp.org/
+
 See https://ceph.com/resources/mailing-list-irc/ for how to set up your IRC
 client and a list of channels.
 
@@ -129,7 +134,8 @@ for that.
 
 RADOS itself can be further broken down into Monitors, Object Storage Daemons
 (OSDs), and clients (librados). Monitors and OSDs are introduced at
-:doc:`start/intro`. The client library is explained at :doc:`rados/api`.
+:doc:`/start/intro`. The client library is explained at
+:doc:`/rados/api/index`.
 
 RGW
 ---
@@ -139,7 +145,7 @@ provides a REST interface to RADOS objects.
 
 .. _civetweb: https://github.com/civetweb/civetweb
 
-A more thorough introduction to RGW can be found at :doc:`radosgw`.
+A more thorough introduction to RGW can be found at :doc:`/radosgw/index`.
 
 RBD
 ---
@@ -147,7 +153,7 @@ RBD
 RBD stands for RADOS Block Device. It enables a Ceph cluster to store disk
 images, and includes in-kernel code enabling RBD images to be mounted.
 
-To delve further into RBD, see :doc:`rbd/rbd`.
+To delve further into RBD, see :doc:`/rbd/rbd`.
 
 CephFS
 ------
@@ -155,7 +161,7 @@ CephFS
 CephFS is a distributed file system that enables a Ceph cluster to be used as a NAS.
 
 File system metadata is managed by Meta Data Server (MDS) daemons. The Ceph
-file system is explained in more detail at :doc:`cephfs`.
+file system is explained in more detail at :doc:`/cephfs/index`.
 
 Build/Ops
 ---------
@@ -170,46 +176,46 @@ Building
 Building from source
 --------------------
 
-See instructions at :doc:`install/build-ceph`.
+See instructions at :doc:`/install/build-ceph`.
 
 Testing
 =======
 
 You can start a development mode Ceph cluster, after compiling the source, with::
 
-	cd src
-	install -d -m0755 out dev/osd0
-	./vstart.sh -n -x -l
-	# check that it's there
-	./ceph health
+    cd src
+    install -d -m0755 out dev/osd0
+    ./vstart.sh -n -x -l
+    # check that it's there
+    ./ceph health
 
 Issue tracker
 =============
 
-The Ceph project has its own issue tracker, `http://tracker.ceph.com`_,
+The Ceph project has its own issue tracker, http://tracker.ceph.com,
 powered by `Redmine`_.
 
-.. _`http://tracker.ceph.com`: http://tracker.ceph.com
 .. _Redmine: http://www.redmine.org
 
 The tracker has a Ceph project with a number of subprojects loosely
-corresponding to the project components listed in `High-level overview`.
+corresponding to the project components listed in `High-level structure`_.
 
 Mere `registration`_ automatically grants tracker permissions sufficient to
 open new issues and comment on existing ones.
 
 .. _registration: http://tracker.ceph.com/account/register
 
-To report a bug, `jump to the Ceph project`_ and click on `New issue`_
+To report a bug or propose a new feature, `jump to the Ceph project`_ and
+click on `New issue`_.
 
 .. _`jump to the Ceph project`: http://tracker.ceph.com/projects/ceph
 .. _`New issue`: http://tracker.ceph.com/projects/ceph/issues/new
 
-If you start working on a bug, let the other developers know by adding an
-update to the issue.
+If you start working on an issue, let the other developers know by adding
+an update to the issue. If your tracker permissions have been escalated,
+you can change the issue status yourself to reflect reality. 
 
-If your tracker permissions have been escalated, you can change the issue
-status as appropriate:
+**Meanings of some commonly used statuses**
 
 ================ ===========================================
 Status           Meaning
@@ -221,11 +227,9 @@ Pending Backport Fix has been merged, backport(s) pending
 Resolved         Fix and backports (if any) have been merged
 ================ ===========================================
 
-There are other statuses, but these are the most common.
-
 If you do not have permission to change the status yourself, don't worry:
-someone will probably change it for you, even without asking. You can ask
-on IRC for another developer to change the status for you.
+someone will probably change it for you, even without asking. You can also
+ask for assistance on IRC.
 
 Bugfixing
 =========

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -179,15 +179,8 @@ You can start a development mode Ceph cluster, after compiling the source, with:
 	# check that it's there
 	./ceph health
 
-Bugfixing
-=========
-
-Without bugs, there would be no software, and without software, there would
-be no software developers. This chapter explains the Ceph-specific aspects
-of bugfixing workflows.
-
 Issue tracker
--------------
+=============
 
 The Ceph project has its own issue tracker, `http://tracker.ceph.com`_,
 powered by `Redmine`_.
@@ -230,7 +223,13 @@ If you do not have permission to change the status yourself, don't worry:
 someone will probably change it for you, even without asking. You can ask
 on IRC for another developer to change the status for you.
 
-Documentation bugs
-------------------
+Bugfixing
+=========
 
+Without bugs, there would be no software, and without software, there would
+be no software developers. This chapter explains the Ceph-specific aspects
+of the project's bugfixing workflows.
+
+A good understanding of the `Issue tracker`_ chapter is necessary before
+you attempt to fix any bugs.
 


### PR DESCRIPTION
This commit fixes the headings so they render properly on http://ceph.com

Signed-off-by: Nathan Cutler <ncutler@suse.com>