### PR TITLE
common/buffer.cc: allocate iov on demand in write_fd

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1919,7 +1919,8 @@ int buffer::list::write_fd(int fd) const
     return write_fd_zero_copy(fd);
 
   // use writev!
-  iovec iov[IOV_MAX];
+  int max = MIN(_buffers.size(), IOV_MAX);
+  iovec iov[max];
   int iovlen = 0;
   ssize_t bytes = 0;
 


### PR DESCRIPTION
Current `write_fd` implementation allocates iov arrary in fixed
size(`IOV_MAX`),that's memory inefficient for writev syscall.

Cause `writev` syscall's behavior depends on iov arrary's size.
If the iov arrary's size is smaller than `UIO_FASTIOV`(defined in
`include/uapi/linux/uio.h`),kernel allocates segments on its
stack,vectored-IO occurs in a very memory-efficient manner.

This commit allows allocating iov array size on demand,and let the
kernel optimize `writev` syscall.

Signed-off-by: Jiaying Ren <mikulely@gmail.com>