### PR TITLE
cmake: add rgw_basic_types.cc to librgw.a

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1019,6 +1019,7 @@ if(${WITH_RADOSGW})
     rgw/rgw_rest_client.cc
     rgw/rgw_rest_conn.cc
     rgw/rgw_op.cc
+    rgw/rgw_basic_types.cc
     rgw/rgw_common.cc
     rgw/rgw_cache.cc
     rgw/rgw_formats.cc


### PR DESCRIPTION
Signed-off-by: Orit Wasserman <owasserm@redhat.com>