### PR TITLE
osd: Allow repair of history.last_epoch_started using config

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -293,7 +293,8 @@ void PG::proc_master_log(
   if (oinfo.last_epoch_started > info.last_epoch_started)
     info.last_epoch_started = oinfo.last_epoch_started;
   info.history.merge(oinfo.history);
-  assert(info.last_epoch_started >= info.history.last_epoch_started);
+  assert(cct->_conf->osd_find_best_info_ignore_history_les ||
+	 info.last_epoch_started >= info.history.last_epoch_started);
 
   peer_missing[from].swap(omissing);
 }


### PR DESCRIPTION
Check for osd_find_best_info_ignore_history_les config

Signed-off-by: David Zafman <dzafman@redhat.com>