### PR TITLE
signal_handler: added support for using reentrant strsignal() implementations vs. sys_siglist[]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,11 @@ if(WITH_THREAD_SAFE_RES_QUERY)
     set(HAVE_THREAD_SAFE_RES_QUERY 1 CACHE INTERNAL "Thread safe res_query supported.")
 endif(WITH_THREAD_SAFE_RES_QUERY)
 
+option(WITH_REENTRANT_STRSIGNAL "strsignal is reentrant" OFF)
+if(WITH_REENTRANT_STRSIGNAL)
+    set(HAVE_REENTRANT_STRSIGNAL 1 CACHE INTERNAL "Reentrant strsignal is supported.")
+endif(WITH_REENTRANT_STRSIGNAL)
+
 # Now create a useable config.h
 configure_file(
   ${PROJECT_SOURCE_DIR}/src/include/config-h.in.cmake

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -30,7 +30,6 @@
 extern char *sys_siglist[]; 
 #endif 
 
-
 void install_sighandler(int signum, signal_handler_t handler, int flags)
 {
   int ret;
@@ -54,7 +53,7 @@ void install_sighandler(int signum, signal_handler_t handler, int flags)
 #else
     snprintf(buf, sizeof(buf), "install_sighandler: sigaction returned "
 	    "%d when trying to install a signal handler for %s\n",
-	     ret, sys_siglist[signum]);
+	     ret, sig_str(signum));
 #endif
     dout_emergency(buf);
     exit(1);
@@ -99,7 +98,7 @@ static void handle_fatal_signal(int signum)
 	    "in thread %llx\n", message, (unsigned long long)pthread_self());
 #else
   snprintf(buf, sizeof(buf), "*** Caught signal (%s) **\n "
-	    "in thread %llx\n", sys_siglist[signum], (unsigned long long)pthread_self());
+	    "in thread %llx\n", sig_str(signum), (unsigned long long)pthread_self());
 #endif
   dout_emergency(buf);
   pidfile_remove();

--- a/src/global/signal_handler.h
+++ b/src/global/signal_handler.h
@@ -18,7 +18,15 @@
 #include <signal.h>
 #include <string>
 
+#include "acconfig.h"
+
 typedef void (*signal_handler_t)(int);
+
+#ifndef HAVE_REENTRANT_STRSIGNAL
+# define sig_str(signum) sys_siglist[signum]
+#else
+# define sig_str(signum) strsignal(signum)
+#endif
 
 void install_sighandler(int signum, signal_handler_t handler, int flags);
 

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -246,4 +246,7 @@
 /* res_query is thread safe */
 #cmakedefine HAVE_THREAD_SAFE_RES_QUERY
 
+/* Define if HAVE_REENTRANT_STRSIGNAL */
+#cmakedefine HAVE_REENTRANT_STRSIGNAL
+
 #endif /* CONFIG_H */

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -993,7 +993,7 @@ void MDSDaemon::_handle_mds_map(MDSMap *oldmap)
 void MDSDaemon::handle_signal(int signum)
 {
   assert(signum == SIGINT || signum == SIGTERM);
-  derr << "*** got signal " << sys_siglist[signum] << " ***" << dendl;
+  derr << "*** got signal " << sig_str(signum) << " ***" << dendl;
   {
     Mutex::Locker l(mds_lock);
     if (stopping) {

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -62,6 +62,8 @@
 #include "common/perf_counters.h"
 #include "common/admin_socket.h"
 
+#include "global/signal_handler.h"
+
 #include "include/color.h"
 #include "include/ceph_fs.h"
 #include "include/str_list.h"
@@ -356,7 +358,7 @@ abort:
 void Monitor::handle_signal(int signum)
 {
   assert(signum == SIGINT || signum == SIGTERM);
-  derr << "*** Got Signal " << sys_siglist[signum] << " ***" << dendl;
+  derr << "*** Got Signal " << sig_str(signum) << " ***" << dendl;
   shutdown();
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1648,7 +1648,7 @@ void cls_initialize(ClassHandler *ch);
 void OSD::handle_signal(int signum)
 {
   assert(signum == SIGINT || signum == SIGTERM);
-  derr << "*** Got signal " << sys_siglist[signum] << " ***" << dendl;
+  derr << "*** Got signal " << sig_str(signum) << " ***" << dendl;
   shutdown();
 }
 

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -935,7 +935,7 @@ void handle_test_signal(int signum)
   if ((signum != SIGINT) && (signum != SIGTERM))
     return;
 
-  std::cerr << "*** Got signal " << sys_siglist[signum] << " ***" << std::endl;
+  std::cerr << "*** Got signal " << sig_str(signum) << " ***" << std::endl;
   Mutex::Locker l(shutdown_lock);
   if (shutdown_timer) {
     shutdown_timer->cancel_all_events();


### PR DESCRIPTION
Hey @liewegas, I've rebased https://github.com/ceph/ceph/pull/6223. Not sure if I was suppose to open a new PR. Cheers