### PR TITLE
fix wrong checking for parse() return

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1504,16 +1504,16 @@ int OSD::peek_meta(ObjectStore *store, std::string& magic,
   if (r < 0)
     return r;
   r = cluster_fsid.parse(val.c_str());
-  if (r < 0)
-    return r;
+  if (!r)
+    return -EINVAL;
 
   r = store->read_meta("fsid", &val);
   if (r < 0) {
     osd_fsid = uuid_d();
   } else {
     r = osd_fsid.parse(val.c_str());
-    if (r < 0)
-      return r;
+    if (!r)
+      return -EINVAL;
   }
 
   return 0;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -695,10 +695,9 @@ static int read_decode_json(const string& infile, T& t)
     return ret;
   }
   JSONParser p;
-  ret = p.parse(bl.c_str(), bl.length());
-  if (ret < 0) {
+  if (!p.parse(bl.c_str(), bl.length())) {
     cout << "failed to parse JSON" << std::endl;
-    return ret;
+    return -EINVAL;
   }
 
   try {
@@ -720,10 +719,9 @@ static int read_decode_json(const string& infile, T& t, K *k)
     return ret;
   }
   JSONParser p;
-  ret = p.parse(bl.c_str(), bl.length());
-  if (ret < 0) {
+  if (!p.parse(bl.c_str(), bl.length())) {
     cout << "failed to parse JSON" << std::endl;
-    return ret;
+    return -EINVAL;
   }
 
   try {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1374,10 +1374,9 @@ static int forward_request_to_master(struct req_state *s, obj_version *objv, RGW
     return ret;
 
   ldout(s->cct, 20) << "response: " << response.c_str() << dendl;
-  ret = jp->parse(response.c_str(), response.length());
-  if (ret < 0) {
+  if (!jp->parse(response.c_str(), response.length())) {
     ldout(s->cct, 0) << "failed parsing response from master region" << dendl;
-    return ret;
+    return -EINVAL;
   }
 
   return 0;


### PR DESCRIPTION
The type of return value from JSONParser::parse() is bool, it never returns
a negative value.

Signed-off-by: Dunrong Huang <dunrong.huang@eayun.com>
