### PR TITLE
librbd: include missing header for bool type

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -25,6 +25,7 @@ extern "C" {
 #elif defined(__FreeBSD__)
 #include <sys/types.h>
 #endif
+#include <stdbool.h>
 #include <string.h>
 #include "../rados/librados.h"
 #include "features.h"


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@mirantis.com>