### PR TITLE
test: use sequential journal_tid for object cacher test

### DIFF
--- a/src/test/osdc/object_cacher_stress.cc
+++ b/src/test/osdc/object_cacher_stress.cc
@@ -72,6 +72,7 @@ int stress_test(uint64_t num_ops, uint64_t num_objs,
   SnapContext snapc;
   ceph::buffer::ptr bp(max_op_len);
   ceph::bufferlist bl;
+  uint64_t journal_tid = 0;
   bp.zero();
   bl.append(bp);
 
@@ -110,7 +111,7 @@ int stress_test(uint64_t num_ops, uint64_t num_objs,
 	assert(r == 0);
     } else {
       ObjectCacher::OSDWrite *wr = obc.prepare_write(snapc, bl, utime_t(), 0,
-                                                     random());
+                                                     ++journal_tid);
       wr->extents.push_back(op->extent);
       lock.Lock();
       obc.writex(wr, &object_set, NULL);


### PR DESCRIPTION
This matches the real usage by librbd.

Fixes: #13877
Signed-off-by: Josh Durgin <jdurgin@redhat.com>
(cherry picked from commit 9331e031bd2a719463920581a47c13f0606e9971)