### PR TITLE
build/ops: systemd ceph-disk unit must not assume /bin/flock

### DIFF
--- a/systemd/ceph-disk@.service
+++ b/systemd/ceph-disk@.service
@@ -4,5 +4,5 @@ Description=Ceph disk activation: %f
 [Service]
 Type=oneshot
 KillMode=none
-ExecStart=/bin/flock /var/lock/ceph-disk -c '/usr/sbin/ceph-disk --verbose --log-stdout trigger --sync %f'
+ExecStart=/bin/sh -c 'flock /var/lock/ceph-disk /usr/sbin/ceph-disk --verbose --log-stdout trigger --sync %f'
 TimeoutSec=0


### PR DESCRIPTION
The flock command may be installed elsewhere, depending on the
system. Let the PATH search figure that out.

http://tracker.ceph.com/issues/13975 Fixes: #13975

Signed-off-by: Loic Dachary <loic@dachary.org>