### PR TITLE
assert: abort() rather than throw

### DIFF
--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -43,7 +43,8 @@ namespace ceph {
     g_assert_context = cct;
   }
 
-  void __ceph_assert_fail(const char *assertion, const char *file, int line, const char *func)
+  void __ceph_assert_fail(const char *assertion, const char *file, int line,
+			  const char *func)
   {
     ostringstream tss;
     tss << ceph_clock_now(g_assert_context);
@@ -74,10 +75,11 @@ namespace ceph {
       g_assert_context->_log->dump_recent();
     }
 
-    throw FailedAssertion(bt);
+    abort();
   }
 
-  void __ceph_assertf_fail(const char *assertion, const char *file, int line, const char *func, const char* msg, ...)
+  void __ceph_assertf_fail(const char *assertion, const char *file, int line,
+			   const char *func, const char* msg, ...)
   {
     ostringstream tss;
     tss << ceph_clock_now(g_assert_context);
@@ -143,7 +145,7 @@ namespace ceph {
       g_assert_context->_log->dump_recent();
     }
 
-    throw FailedAssertion(bt);
+    abort();
   }
 
   void __ceph_assert_warn(const char *assertion, const char *file,

--- a/src/include/assert.h
+++ b/src/include/assert.h
@@ -26,12 +26,6 @@ class CephContext;
 namespace ceph {
 
 struct BackTrace;
-
-struct FailedAssertion {
-  BackTrace *backtrace;
-  FailedAssertion(BackTrace *bt) : backtrace(bt) {}
-};
-
 #endif
 
 

--- a/src/librados-config.cc
+++ b/src/librados-config.cc
@@ -42,14 +42,9 @@ int main(int argc, const char **argv)
   bool opt_version = false;
   bool opt_vernum = false;
 
-  try {
-    global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
-		CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
-    common_init_finish(g_ceph_context);
-  } catch (ceph::FailedAssertion &a) {
-    cout << "ceph::FailedAssertion thrown, exit." << std::endl;
-    exit(1);
-  }
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+	      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
   for (std::vector<const char*>::iterator i = args.begin();
        i != args.end(); ) {
     if (strcmp(*i, "--") == 0) {

--- a/src/test/bench_log.cc
+++ b/src/test/bench_log.cc
@@ -53,15 +53,8 @@ int main(int argc, const char **argv)
   for (int i=0; i<threads; i++) {
     T *t = ls.front();
     ls.pop_front();
-    try {
-      t->join();
-    }
-    catch (ceph::FailedAssertion &a) {
-      cout << "Failed assert in join(), exit." << std::endl;
-      delete t;
-      return -1;
-    }
-    delete t;    
+    t->join();
+    delete t;
   }
 
   utime_t t = ceph_clock_now(NULL);

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -445,8 +445,8 @@ TEST(BufferPtr, constructors) {
     EXPECT_EQ(original.get_raw(), ptr.get_raw());
     EXPECT_EQ(2, ptr.raw_nref());
     EXPECT_EQ(0, ::memcmp(original.c_str(), ptr.c_str(), len));
-    EXPECT_THROW(bufferptr(original, 0, original.length() + 1), FailedAssertion);
-    EXPECT_THROW(bufferptr(bufferptr(), 0, 0), FailedAssertion);
+    EXPECT_DEATH(bufferptr(original, 0, original.length() + 1), "");
+    EXPECT_DEATH(bufferptr(bufferptr(), 0, 0), "");
   }
 }
 
@@ -592,14 +592,14 @@ TEST(BufferPtr, accessors) {
   EXPECT_EQ('X', ptr.c_str()[0]);
   {
     bufferptr ptr;
-    EXPECT_THROW(ptr.c_str(), FailedAssertion);
-    EXPECT_THROW(ptr[0], FailedAssertion);
+    EXPECT_DEATH(ptr.c_str(), "");
+    EXPECT_DEATH(ptr[0], "");
   }
   EXPECT_EQ('X', const_ptr.c_str()[0]);
   {
     const bufferptr const_ptr;
-    EXPECT_THROW(const_ptr.c_str(), FailedAssertion);
-    EXPECT_THROW(const_ptr[0], FailedAssertion);
+    EXPECT_DEATH(const_ptr.c_str(), "");
+    EXPECT_DEATH(const_ptr[0], "");
   }
   EXPECT_EQ(len, const_ptr.length());
   EXPECT_EQ((unsigned)0, const_ptr.offset());
@@ -616,13 +616,13 @@ TEST(BufferPtr, accessors) {
     bufferptr ptr;
     EXPECT_EQ((unsigned)0, ptr.unused_tail_length());
   }
-  EXPECT_THROW(ptr[len], FailedAssertion);
-  EXPECT_THROW(const_ptr[len], FailedAssertion);
+  EXPECT_DEATH(ptr[len], "");
+  EXPECT_DEATH(const_ptr[len], "");
   {
     const bufferptr const_ptr;
-    EXPECT_THROW(const_ptr.raw_c_str(), FailedAssertion);
-    EXPECT_THROW(const_ptr.raw_length(), FailedAssertion);
-    EXPECT_THROW(const_ptr.raw_nref(), FailedAssertion);
+    EXPECT_DEATH(const_ptr.raw_c_str(), "");
+    EXPECT_DEATH(const_ptr.raw_length(), "");
+    EXPECT_DEATH(const_ptr.raw_nref(), "");
   }
   EXPECT_NE((const char *)NULL, const_ptr.raw_c_str());
   EXPECT_EQ(len, const_ptr.raw_length());
@@ -668,7 +668,7 @@ TEST(BufferPtr, is_zero) {
 TEST(BufferPtr, copy_out) {
   {
     const bufferptr ptr;
-    EXPECT_THROW(ptr.copy_out((unsigned)0, (unsigned)0, NULL), FailedAssertion);
+    EXPECT_DEATH(ptr.copy_out((unsigned)0, (unsigned)0, NULL), "");
   }
   {
     char in[] = "ABC";
@@ -703,13 +703,13 @@ TEST(BufferPtr, copy_out_bench) {
 TEST(BufferPtr, copy_in) {
   {
     bufferptr ptr;
-    EXPECT_THROW(ptr.copy_in((unsigned)0, (unsigned)0, NULL), FailedAssertion);
+    EXPECT_DEATH(ptr.copy_in((unsigned)0, (unsigned)0, NULL), "");
   }
   {
     char in[] = "ABCD";
     bufferptr ptr(2);
-    EXPECT_THROW(ptr.copy_in((unsigned)0, strlen(in) + 1, NULL), FailedAssertion);
-    EXPECT_THROW(ptr.copy_in(strlen(in) + 1, (unsigned)0, NULL), FailedAssertion);
+    EXPECT_DEATH(ptr.copy_in((unsigned)0, strlen(in) + 1, NULL), "");
+    EXPECT_DEATH(ptr.copy_in(strlen(in) + 1, (unsigned)0, NULL), "");
     ptr.copy_in((unsigned)0, (unsigned)2, in);
     EXPECT_EQ(in[0], ptr[0]);
     EXPECT_EQ(in[1], ptr[1]);
@@ -737,13 +737,13 @@ TEST(BufferPtr, copy_in_bench) {
 TEST(BufferPtr, append) {
   {
     bufferptr ptr;
-    EXPECT_THROW(ptr.append('A'), FailedAssertion);
-    EXPECT_THROW(ptr.append("B", (unsigned)1), FailedAssertion);
+    EXPECT_DEATH(ptr.append('A'), "");
+    EXPECT_DEATH(ptr.append("B", (unsigned)1), "");
   }
   {
     bufferptr ptr(2);
-    EXPECT_THROW(ptr.append('A'), FailedAssertion);
-    EXPECT_THROW(ptr.append("B", (unsigned)1), FailedAssertion);
+    EXPECT_DEATH(ptr.append('A'), "");
+    EXPECT_DEATH(ptr.append("B", (unsigned)1), "");
     ptr.set_length(0);
     ptr.append('A');
     EXPECT_EQ((unsigned)1, ptr.length());
@@ -776,7 +776,7 @@ TEST(BufferPtr, append_bench) {
 TEST(BufferPtr, zero) {
   char str[] = "XXXX";
   bufferptr ptr(buffer::create_static(strlen(str), str));
-  EXPECT_THROW(ptr.zero(ptr.length() + 1, 0), FailedAssertion);
+  EXPECT_DEATH(ptr.zero(ptr.length() + 1, 0), "");
   ptr.zero(1, 1);
   EXPECT_EQ('X', ptr[0]);
   EXPECT_EQ('\0', ptr[1]);
@@ -1882,7 +1882,7 @@ TEST(BufferList, append) {
     bufferptr in(back);
     EXPECT_EQ((unsigned)1, bl.buffers().size());
     EXPECT_EQ((unsigned)1, bl.length());
-    EXPECT_THROW(bl.append(in, (unsigned)100, (unsigned)100), FailedAssertion);
+    EXPECT_DEATH(bl.append(in, (unsigned)100, (unsigned)100), "");
     EXPECT_LT((unsigned)0, in.unused_tail_length());
     in.append('B');
     bl.append(in, back.end(), 1);
@@ -2398,7 +2398,7 @@ TEST(BufferList, zero) {
       bufferptr ptr(s[i], strlen(s[i]));
       bl.push_back(ptr);
     }
-    EXPECT_THROW(bl.zero((unsigned)0, (unsigned)2000), FailedAssertion);
+    EXPECT_DEATH(bl.zero((unsigned)0, (unsigned)2000), "");
     bl.zero((unsigned)2, (unsigned)5);
     EXPECT_EQ(0, ::memcmp("AB\0\0\0\0\0HIKLM", bl.c_str(), 9));
   }

--- a/src/test/ceph_compatset.cc
+++ b/src/test/ceph_compatset.cc
@@ -37,8 +37,8 @@ TEST(CephCompatSet, AllSet) {
   CompatSet::FeatureSet ro;
   CompatSet::FeatureSet incompat;
 
-  EXPECT_THROW(compat.insert(CompatSet::Feature(0, "test")), FailedAssertion);
-  EXPECT_THROW(compat.insert(CompatSet::Feature(64, "test")), FailedAssertion);
+  EXPECT_DEATH(compat.insert(CompatSet::Feature(0, "test")), "");
+  EXPECT_DEATH(compat.insert(CompatSet::Feature(64, "test")), "");
 
   for (int i = 1; i < 64; i++) {
     stringstream cname;

--- a/src/test/common/Throttle.cc
+++ b/src/test/common/Throttle.cc
@@ -37,13 +37,13 @@ protected:
     int64_t count;
     bool waited;
 
-    Thread_get(Throttle& _throttle, int64_t _count) : 
+    Thread_get(Throttle& _throttle, int64_t _count) :
       throttle(_throttle),
       count(_count),
       waited(false)
     {
     }
-    
+
     virtual void *entry() {
       waited = throttle.get(count);
       throttle.put(count);
@@ -54,9 +54,9 @@ protected:
 };
 
 TEST_F(ThrottleTest, Throttle) {
-  ASSERT_THROW({
+  ASSERT_DEATH({
       Throttle throttle(g_ceph_context, "throttle", -1);
-    }, FailedAssertion);
+    }, "");
 
   int64_t throttle_max = 10;
   Throttle throttle(g_ceph_context, "throttle", throttle_max);
@@ -67,7 +67,7 @@ TEST_F(ThrottleTest, Throttle) {
 TEST_F(ThrottleTest, take) {
   int64_t throttle_max = 10;
   Throttle throttle(g_ceph_context, "throttle", throttle_max);
-  ASSERT_THROW(throttle.take(-1), FailedAssertion);
+  ASSERT_DEATH(throttle.take(-1), "");
   ASSERT_EQ(throttle.take(throttle_max), throttle_max);
   ASSERT_EQ(throttle.take(throttle_max), throttle_max * 2);
 }
@@ -83,18 +83,18 @@ TEST_F(ThrottleTest, get) {
     ASSERT_EQ(throttle.put(throttle_max), 0);
   }
 
-  ASSERT_THROW(throttle.get(-1), FailedAssertion);
-  ASSERT_FALSE(throttle.get(5)); 
-  ASSERT_EQ(throttle.put(5), 0); 
+  ASSERT_DEATH(throttle.get(-1), "");
+  ASSERT_FALSE(throttle.get(5));
+  ASSERT_EQ(throttle.put(5), 0);
 
-  ASSERT_FALSE(throttle.get(throttle_max)); 
-  ASSERT_FALSE(throttle.get_or_fail(1)); 
-  ASSERT_FALSE(throttle.get(1, throttle_max + 1)); 
-  ASSERT_EQ(throttle.put(throttle_max + 1), 0); 
-  ASSERT_FALSE(throttle.get(0, throttle_max)); 
-  ASSERT_FALSE(throttle.get(throttle_max)); 
-  ASSERT_FALSE(throttle.get_or_fail(1)); 
-  ASSERT_EQ(throttle.put(throttle_max), 0); 
+  ASSERT_FALSE(throttle.get(throttle_max));
+  ASSERT_FALSE(throttle.get_or_fail(1));
+  ASSERT_FALSE(throttle.get(1, throttle_max + 1));
+  ASSERT_EQ(throttle.put(throttle_max + 1), 0);
+  ASSERT_FALSE(throttle.get(0, throttle_max));
+  ASSERT_FALSE(throttle.get(throttle_max));
+  ASSERT_FALSE(throttle.get_or_fail(1));
+  ASSERT_EQ(throttle.put(throttle_max), 0);
 
   useconds_t delay = 1;
 
@@ -103,24 +103,24 @@ TEST_F(ThrottleTest, get) {
   do {
     cout << "Trying (1) with delay " << delay << "us\n";
 
-    ASSERT_FALSE(throttle.get(throttle_max)); 
-    ASSERT_FALSE(throttle.get_or_fail(throttle_max));  
+    ASSERT_FALSE(throttle.get(throttle_max));
+    ASSERT_FALSE(throttle.get_or_fail(throttle_max));
 
     Thread_get t(throttle, 7);
     t.create();
     usleep(delay);
-    ASSERT_EQ(throttle.put(throttle_max), 0); 
+    ASSERT_EQ(throttle.put(throttle_max), 0);
     t.join();
 
     if (!(waited = t.waited))
       delay *= 2;
   } while(!waited);
-	  
+
   do {
     cout << "Trying (2) with delay " << delay << "us\n";
 
     ASSERT_FALSE(throttle.get(throttle_max / 2));
-    ASSERT_FALSE(throttle.get_or_fail(throttle_max));  
+    ASSERT_FALSE(throttle.get_or_fail(throttle_max));
 
     Thread_get t(throttle, throttle_max);
     t.create();
@@ -138,13 +138,13 @@ TEST_F(ThrottleTest, get) {
     if (!(waited = t.waited && u.waited))
       delay *= 2;
   } while(!waited);
-	  
+
 }
 
 TEST_F(ThrottleTest, get_or_fail) {
   {
     Throttle throttle(g_ceph_context, "throttle");
-    
+
     ASSERT_TRUE(throttle.get_or_fail(5));
     ASSERT_TRUE(throttle.get_or_fail(5));
   }
@@ -161,8 +161,8 @@ TEST_F(ThrottleTest, get_or_fail) {
     ASSERT_FALSE(throttle.get_or_fail(throttle_max * 2));
     ASSERT_EQ(throttle.put(throttle_max * 2), 0);
 
-    ASSERT_TRUE(throttle.get_or_fail(throttle_max));  
-    ASSERT_FALSE(throttle.get_or_fail(1));  
+    ASSERT_TRUE(throttle.get_or_fail(throttle_max));
+    ASSERT_FALSE(throttle.get_or_fail(1));
     ASSERT_EQ(throttle.put(throttle_max), 0);
   }
 }
@@ -185,7 +185,7 @@ TEST_F(ThrottleTest, wait) {
     cout << "Trying (3) with delay " << delay << "us\n";
 
     ASSERT_FALSE(throttle.get(throttle_max / 2));
-    ASSERT_FALSE(throttle.get_or_fail(throttle_max));  
+    ASSERT_FALSE(throttle.get_or_fail(throttle_max));
 
     Thread_get t(throttle, throttle_max);
     t.create();
@@ -193,8 +193,8 @@ TEST_F(ThrottleTest, wait) {
 
     //
     // Throttle::_reset_max(int64_t m) used to contain a test
-    // that blocked the following statement, only if 
-    // the argument was greater than throttle_max. 
+    // that blocked the following statement, only if
+    // the argument was greater than throttle_max.
     // Although a value lower than throttle_max would cover
     // the same code in _reset_max, the throttle_max * 100
     // value is left here to demonstrate that the problem
@@ -220,7 +220,7 @@ TEST_F(ThrottleTest, destructor) {
     int64_t throttle_max = 10;
     Throttle *throttle = new Throttle(g_ceph_context, "throttle", throttle_max);
 
-    ASSERT_FALSE(throttle->get(5)); 
+    ASSERT_FALSE(throttle->get(5));
 
     t = new Thread_get(*throttle, 7);
     t->create();
@@ -238,8 +238,8 @@ TEST_F(ThrottleTest, destructor) {
     } while(!blocked);
     delete throttle;
   }
-  
-  { // 
+
+  { //
     // The thread is left hanging, otherwise it will abort().
     // Deleting the Throttle on which it is waiting creates a
     // inconsistency that will be detected: the Throttle object that
@@ -265,8 +265,8 @@ int main(int argc, char **argv) {
 
 /*
  * Local Variables:
- * compile-command: "cd ../.. ; 
- *   make unittest_throttle ; 
+ * compile-command: "cd ../.. ;
+ *   make unittest_throttle ;
  *   ./unittest_throttle # --gtest_filter=ThrottleTest.destructor \
  *       --log-to-stderr=true --debug-filestore=20
  * "

--- a/src/test/objectstore/chain_xattr.cc
+++ b/src/test/objectstore/chain_xattr.cc
@@ -120,8 +120,8 @@ TEST(chain_xattr, get_and_set) {
   {
     int x;
     const string name = user + string(CHAIN_XATTR_MAX_NAME_LEN * 2, '@');
-    ASSERT_THROW(chain_setxattr(file, name.c_str(), &x, sizeof(x)), FailedAssertion);
-    ASSERT_THROW(chain_fsetxattr(fd, name.c_str(), &x, sizeof(x)), FailedAssertion);
+    ASSERT_DEATH(chain_setxattr(file, name.c_str(), &x, sizeof(x)), "");
+    ASSERT_DEATH(chain_fsetxattr(fd, name.c_str(), &x, sizeof(x)), "");
   }
 
   {
@@ -229,7 +229,7 @@ TEST(chain_xattr, listxattr) {
   const string name2 = user + string(CHAIN_XATTR_MAX_NAME_LEN - user.size(), '@');
   const string x(LARGE_BLOCK_LEN, 'X');
   const int y = 1234;
-  
+
   ASSERT_EQ(LARGE_BLOCK_LEN, chain_setxattr(file, name1.c_str(), x.c_str(), LARGE_BLOCK_LEN));
   ASSERT_EQ((int)sizeof(y), chain_setxattr(file, name2.c_str(), &y, sizeof(y)));
 

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -291,9 +291,8 @@ TEST_F(PGLogTest, rewind_divergent_log) {
 
     log.tail = eversion_t(2, 1);
     TestHandler h(remove_snap);
-    EXPECT_THROW(rewind_divergent_log(t, eversion_t(1, 1), info, &h,
-				      dirty_info, dirty_big_info),
-		 FailedAssertion);
+    EXPECT_DEATH(rewind_divergent_log(t, eversion_t(1, 1), info, &h,
+				      dirty_info, dirty_big_info), "");
   }
 
   /*        +----------------+
@@ -1200,8 +1199,8 @@ TEST_F(PGLogTest, merge_log) {
     olog.tail = eversion_t(1, 1);
 
     TestHandler h(remove_snap);
-    ASSERT_THROW(merge_log(t, oinfo, olog, fromosd, info, &h,
-                           dirty_info, dirty_big_info), FailedAssertion);
+    ASSERT_DEATH(merge_log(t, oinfo, olog, fromosd, info, &h,
+			   dirty_info, dirty_big_info), "");
   }
 
   /*        +--------------------------+
@@ -1264,8 +1263,8 @@ TEST_F(PGLogTest, merge_log) {
     }
 
     TestHandler h(remove_snap);
-    EXPECT_THROW(merge_log(t, oinfo, olog, fromosd, info, &h,
-                           dirty_info, dirty_big_info), FailedAssertion);
+    EXPECT_DEATH(merge_log(t, oinfo, olog, fromosd, info, &h,
+			   dirty_info, dirty_big_info), "");
   }
 }
 

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -907,7 +907,7 @@ TEST(pg_missing_t, add_next_event)
     e.op = pg_log_entry_t::BACKLOG;
     EXPECT_TRUE(e.is_backlog());
     EXPECT_FALSE(missing.is_missing(oid));
-    EXPECT_THROW(missing.add_next_event(e), FailedAssertion);
+    EXPECT_DEATH(missing.add_next_event(e), "");
   }
 
   // adding a DELETE matching an existing event
@@ -1020,14 +1020,14 @@ TEST(pg_missing_t, got)
     hobject_t oid(object_t("objname"), "key", 123, 456, 0, "");
     pg_missing_t missing;
     // assert if the oid does not exist
-    EXPECT_THROW(missing.got(oid, eversion_t()), FailedAssertion);
+    EXPECT_DEATH(missing.got(oid, eversion_t()), "");
     EXPECT_FALSE(missing.is_missing(oid));
     epoch_t epoch = 10;
     eversion_t need(epoch,10);
     missing.add(oid, need, eversion_t());
     EXPECT_TRUE(missing.is_missing(oid));
     // assert if that the version to be removed is lower than the version of the object
-    EXPECT_THROW(missing.got(oid, eversion_t(epoch / 2,20)), FailedAssertion);
+    EXPECT_DEATH(missing.got(oid, eversion_t(epoch / 2,20)), "");
     // remove of a later version removes the object
     missing.got(oid, eversion_t(epoch * 2,20));
     EXPECT_FALSE(missing.is_missing(oid));
@@ -1390,7 +1390,7 @@ TEST(ghobject_t, cmp) {
 
 TEST(pool_opts_t, invalid_opt) {
   EXPECT_FALSE(pool_opts_t::is_opt_name("INVALID_OPT"));
-  EXPECT_THROW(pool_opts_t::get_opt_desc("INVALID_OPT"), FailedAssertion);
+  EXPECT_DEATH(pool_opts_t::get_opt_desc("INVALID_OPT"), "");
 }
 
 TEST(pool_opts_t, scrub_min_interval) {
@@ -1401,7 +1401,7 @@ TEST(pool_opts_t, scrub_min_interval) {
 
   pool_opts_t opts;
   EXPECT_FALSE(opts.is_set(pool_opts_t::SCRUB_MIN_INTERVAL));
-  EXPECT_THROW(opts.get(pool_opts_t::SCRUB_MIN_INTERVAL), FailedAssertion);
+  EXPECT_DEATH(opts.get(pool_opts_t::SCRUB_MIN_INTERVAL), "");
   double val;
   EXPECT_FALSE(opts.get(pool_opts_t::SCRUB_MIN_INTERVAL, &val));
   opts.set(pool_opts_t::SCRUB_MIN_INTERVAL, static_cast<double>(2015));
@@ -1419,7 +1419,7 @@ TEST(pool_opts_t, scrub_max_interval) {
 
   pool_opts_t opts;
   EXPECT_FALSE(opts.is_set(pool_opts_t::SCRUB_MAX_INTERVAL));
-  EXPECT_THROW(opts.get(pool_opts_t::SCRUB_MAX_INTERVAL), FailedAssertion);
+  EXPECT_DEATH(opts.get(pool_opts_t::SCRUB_MAX_INTERVAL), "");
   double val;
   EXPECT_FALSE(opts.get(pool_opts_t::SCRUB_MAX_INTERVAL, &val));
   opts.set(pool_opts_t::SCRUB_MAX_INTERVAL, static_cast<double>(2015));
@@ -1437,7 +1437,7 @@ TEST(pool_opts_t, deep_scrub_interval) {
 
   pool_opts_t opts;
   EXPECT_FALSE(opts.is_set(pool_opts_t::DEEP_SCRUB_INTERVAL));
-  EXPECT_THROW(opts.get(pool_opts_t::DEEP_SCRUB_INTERVAL), FailedAssertion);
+  EXPECT_DEATH(opts.get(pool_opts_t::DEEP_SCRUB_INTERVAL), "");
   double val;
   EXPECT_FALSE(opts.get(pool_opts_t::DEEP_SCRUB_INTERVAL, &val));
   opts.set(pool_opts_t::DEEP_SCRUB_INTERVAL, static_cast<double>(2015));

--- a/src/test/test_texttable.cc
+++ b/src/test/test_texttable.cc
@@ -72,6 +72,5 @@ TEST(TextTable, TooManyItems) {
   t.define_column("3", TextTable::LEFT, TextTable::LEFT);
 
   // expect assertion failure on this, which throws FailedAssertion
-  ASSERT_THROW((t << "1" << "2" << "3" << "4" << TextTable::endrow),
-	       FailedAssertion);
+  ASSERT_DEATH((t << "1" << "2" << "3" << "4" << TextTable::endrow), "");
 }

--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -62,226 +62,221 @@ int main(int argc, const char **argv)
   map<string,bufferlist> caps;
   std::string fn;
 
-  try {
-    global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
-  	      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+	      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
 
-    bool gen_key = false;
-    bool gen_print_key = false;
-    bool list = false;
-    bool print_key = false;
-    bool create_keyring = false;
-    bool set_auid = false;
-    std::vector<const char*>::iterator i;
+  bool gen_key = false;
+  bool gen_print_key = false;
+  bool list = false;
+  bool print_key = false;
+  bool create_keyring = false;
+  bool set_auid = false;
+  std::vector<const char*>::iterator i;
 
-    for (i = args.begin(); i != args.end(); ) {
-      std::string val;
-      if (ceph_argparse_double_dash(args, i)) {
-        break;
-      } else if (ceph_argparse_flag(args, i, "-g", "--gen-key", (char*)NULL)) {
-        gen_key = true;
-      } else if (ceph_argparse_flag(args, i, "--gen-print-key", (char*)NULL)) {
-        gen_print_key = true;
-      } else if (ceph_argparse_witharg(args, i, &val, "-a", "--add-key", (char*)NULL)) {
-        add_key = val;
-      } else if (ceph_argparse_flag(args, i, "-l", "--list", (char*)NULL)) {
-        list = true;
-      } else if (ceph_argparse_witharg(args, i, &val, "--caps", (char*)NULL)) {
-        caps_fn = val;
-      } else if (ceph_argparse_witharg(args, i, &val, "--cap", (char*)NULL)) {
-        std::string my_key = val;
-        if (i == args.end()) {
-  	cerr << "must give two arguments to --cap: key and val." << std::endl;
-  	exit(1);
-        }
-        std::string my_val = *i;
-        ++i;
-        ::encode(my_val, caps[my_key]);
-      } else if (ceph_argparse_flag(args, i, "-p", "--print-key", (char*)NULL)) {
-        print_key = true;
-      } else if (ceph_argparse_flag(args, i, "-C", "--create-keyring", (char*)NULL)) {
-        create_keyring = true;
-      } else if (ceph_argparse_witharg(args, i, &val, "--import-keyring", (char*)NULL)) {
-        import_keyring = val;
-      } else if (ceph_argparse_witharg(args, i, &val, "-u", "--set-uid", (char*)NULL)) {
-        std::string err;
-        auid = strict_strtoll(val.c_str(), 10, &err);
-        if (!err.empty()) {
-  	cerr << "error parsing UID: " << err << std::endl;
-  	exit(1);
-        }
-        set_auid = true;
-      } else if (fn.empty()) {
-        fn = *i++;
-      } else {
-        cerr << argv[0] << ": unexpected '" << *i << "'" << std::endl;
-        usage();
+  for (i = args.begin(); i != args.end(); ) {
+    std::string val;
+    if (ceph_argparse_double_dash(args, i)) {
+      break;
+    } else if (ceph_argparse_flag(args, i, "-g", "--gen-key", (char*)NULL)) {
+      gen_key = true;
+    } else if (ceph_argparse_flag(args, i, "--gen-print-key", (char*)NULL)) {
+      gen_print_key = true;
+    } else if (ceph_argparse_witharg(args, i, &val, "-a", "--add-key", (char*)NULL)) {
+      add_key = val;
+    } else if (ceph_argparse_flag(args, i, "-l", "--list", (char*)NULL)) {
+      list = true;
+    } else if (ceph_argparse_witharg(args, i, &val, "--caps", (char*)NULL)) {
+      caps_fn = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--cap", (char*)NULL)) {
+      std::string my_key = val;
+      if (i == args.end()) {
+	cerr << "must give two arguments to --cap: key and val." << std::endl;
+	exit(1);
       }
-    }
-    if (fn.empty() && !gen_print_key) {
-      cerr << argv[0] << ": must specify filename" << std::endl;
+      std::string my_val = *i;
+      ++i;
+      ::encode(my_val, caps[my_key]);
+    } else if (ceph_argparse_flag(args, i, "-p", "--print-key", (char*)NULL)) {
+      print_key = true;
+    } else if (ceph_argparse_flag(args, i, "-C", "--create-keyring", (char*)NULL)) {
+      create_keyring = true;
+    } else if (ceph_argparse_witharg(args, i, &val, "--import-keyring", (char*)NULL)) {
+      import_keyring = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "-u", "--set-uid", (char*)NULL)) {
+      std::string err;
+      auid = strict_strtoll(val.c_str(), 10, &err);
+      if (!err.empty()) {
+	cerr << "error parsing UID: " << err << std::endl;
+	exit(1);
+      }
+      set_auid = true;
+    } else if (fn.empty()) {
+      fn = *i++;
+    } else {
+      cerr << argv[0] << ": unexpected '" << *i << "'" << std::endl;
       usage();
     }
-    if (!(gen_key ||
-  	gen_print_key ||
-  	!add_key.empty() ||
-  	list ||
-  	!caps_fn.empty() ||
-  	!caps.empty() ||
-  	set_auid ||
-  	print_key ||
-  	create_keyring ||
-  	!import_keyring.empty())) {
-      cerr << "no command specified" << std::endl;
-      usage();
+  }
+  if (fn.empty() && !gen_print_key) {
+    cerr << argv[0] << ": must specify filename" << std::endl;
+    usage();
+  }
+  if (!(gen_key ||
+	gen_print_key ||
+	!add_key.empty() ||
+	list ||
+	!caps_fn.empty() ||
+	!caps.empty() ||
+	set_auid ||
+	print_key ||
+	create_keyring ||
+	!import_keyring.empty())) {
+    cerr << "no command specified" << std::endl;
+    usage();
+  }
+  if (gen_key && (!add_key.empty())) {
+    cerr << "can't both gen_key and add_key" << std::endl;
+    usage();
+  }
+
+  common_init_finish(g_ceph_context);
+  EntityName ename(g_conf->name);
+
+  if (gen_print_key) {
+    CryptoKey key;
+    key.create(g_ceph_context, CEPH_CRYPTO_AES);
+    cout << key << std::endl;
+    return 0;
+  }
+
+  // keyring --------
+  bool modified = false;
+  KeyRing keyring;
+
+  bufferlist bl;
+  int r = 0;
+  if (create_keyring) {
+    cout << "creating " << fn << std::endl;
+    modified = true;
+  } else {
+    std::string err;
+    r = bl.read_file(fn.c_str(), &err);
+    if (r >= 0) {
+      try {
+	bufferlist::iterator iter = bl.begin();
+	::decode(keyring, iter);
+      } catch (const buffer::error &err) {
+	cerr << "error reading file " << fn << std::endl;
+	exit(1);
+      }
+    } else {
+      cerr << "can't open " << fn << ": " << err << std::endl;
+      exit(1);
     }
-    if (gen_key && (!add_key.empty())) {
-      cerr << "can't both gen_key and add_key" << std::endl;
-      usage();
-    }	
-  
-    common_init_finish(g_ceph_context);
-    EntityName ename(g_conf->name);
-  
-    if (gen_print_key) {
-      CryptoKey key;
-      key.create(g_ceph_context, CEPH_CRYPTO_AES);
-      cout << key << std::endl;    
-      return 0;
-    }
-  
-    // keyring --------
-    bool modified = false;
-    KeyRing keyring;
-  
-    bufferlist bl;
-    int r = 0;
-    if (create_keyring) {
-      cout << "creating " << fn << std::endl;
+  }
+
+  // write commands
+  if (!import_keyring.empty()) {
+    KeyRing other;
+    bufferlist obl;
+    std::string err;
+    int r = obl.read_file(import_keyring.c_str(), &err);
+    if (r >= 0) {
+      try {
+	bufferlist::iterator iter = obl.begin();
+	::decode(other, iter);
+      } catch (const buffer::error &err) {
+	cerr << "error reading file " << import_keyring << std::endl;
+	exit(1);
+      }
+
+      cout << "importing contents of " << import_keyring << " into " << fn << std::endl;
+      //other.print(cout);
+      keyring.import(g_ceph_context, other);
       modified = true;
     } else {
-      std::string err;
-      r = bl.read_file(fn.c_str(), &err);
-      if (r >= 0) {
-        try {
-  	bufferlist::iterator iter = bl.begin();
-  	::decode(keyring, iter);
-        } catch (const buffer::error &err) {
-  	cerr << "error reading file " << fn << std::endl;
-  	exit(1);
-        }
-      } else {
-        cerr << "can't open " << fn << ": " << err << std::endl;
-        exit(1);
+      cerr << "can't open " << import_keyring << ": " << err << std::endl;
+      exit(1);
+    }
+  }
+  if (gen_key) {
+    EntityAuth eauth;
+    eauth.key.create(g_ceph_context, CEPH_CRYPTO_AES);
+    keyring.add(ename, eauth);
+    modified = true;
+  }
+  if (!add_key.empty()) {
+    EntityAuth eauth;
+    try {
+      eauth.key.decode_base64(add_key);
+    } catch (const buffer::error &err) {
+      cerr << "can't decode key '" << add_key << "'" << std::endl;
+      exit(1);
+    }
+    keyring.add(ename, eauth);
+    modified = true;
+    cout << "added entity " << ename << " auth " << eauth << std::endl;
+  }
+  if (!caps_fn.empty()) {
+    ConfFile cf;
+    std::deque<std::string> parse_errors;
+    if (cf.parse_file(caps_fn, &parse_errors, &cerr) != 0) {
+      cerr << "could not parse caps file " << caps_fn << std::endl;
+      exit(1);
+    }
+    complain_about_parse_errors(g_ceph_context, &parse_errors);
+    map<string, bufferlist> caps;
+    const char *key_names[] = { "mon", "osd", "mds", NULL };
+    for (int i=0; key_names[i]; i++) {
+      std::string val;
+      if (cf.read("global", key_names[i], val) == 0) {
+	bufferlist bl;
+	::encode(val, bl);
+	string s(key_names[i]);
+	caps[s] = bl;
       }
     }
-  
-    // write commands
-    if (!import_keyring.empty()) {
-      KeyRing other;
-      bufferlist obl;
-      std::string err;
-      int r = obl.read_file(import_keyring.c_str(), &err);
-      if (r >= 0) {
-        try {
-  	bufferlist::iterator iter = obl.begin();
-  	::decode(other, iter);
-        } catch (const buffer::error &err) {
-  	cerr << "error reading file " << import_keyring << std::endl;
-  	exit(1);
-        }
-        
-        cout << "importing contents of " << import_keyring << " into " << fn << std::endl;
-        //other.print(cout);
-        keyring.import(g_ceph_context, other);
-        modified = true;
-      } else {
-        cerr << "can't open " << import_keyring << ": " << err << std::endl;
-        exit(1);
-      }
+    keyring.set_caps(ename, caps);
+    modified = true;
+  }
+  if (!caps.empty()) {
+    keyring.set_caps(ename, caps);
+    modified = true;
+  }
+  if (set_auid) {
+    keyring.set_uid(ename, auid);
+    modified = true;
+  }
+
+  // read commands
+  if (list) {
+    try {
+      keyring.print(cout);
+    } catch (ceph::buffer::end_of_buffer &eob) {
+      cout << "Exception (end_of_buffer) in print(), exit." << std::endl;
+      exit(1);
     }
-    if (gen_key) {
-      EntityAuth eauth;
-      eauth.key.create(g_ceph_context, CEPH_CRYPTO_AES);
-      keyring.add(ename, eauth);
-      modified = true;
+  }
+  if (print_key) {
+    CryptoKey key;
+    if (keyring.get_secret(ename, key)) {
+      cout << key << std::endl;
+    } else {
+      cerr << "entity " << ename << " not found" << std::endl;
+      exit(1);
     }
-    if (!add_key.empty()) {
-      EntityAuth eauth;
-      try {
-        eauth.key.decode_base64(add_key);
-      } catch (const buffer::error &err) {
-        cerr << "can't decode key '" << add_key << "'" << std::endl;
-        exit(1);
-      }
-      keyring.add(ename, eauth);
-      modified = true;
-      cout << "added entity " << ename << " auth " << eauth << std::endl;
+  }
+
+  // write result?
+  if (modified) {
+    bufferlist bl;
+    keyring.encode_plaintext(bl);
+    r = bl.write_file(fn.c_str(), 0600);
+    if (r < 0) {
+      cerr << "could not write " << fn << std::endl;
+      exit(1);
     }
-    if (!caps_fn.empty()) {
-      ConfFile cf;
-      std::deque<std::string> parse_errors;
-      if (cf.parse_file(caps_fn, &parse_errors, &cerr) != 0) {
-        cerr << "could not parse caps file " << caps_fn << std::endl;
-        exit(1);
-      }
-      complain_about_parse_errors(g_ceph_context, &parse_errors);
-      map<string, bufferlist> caps;
-      const char *key_names[] = { "mon", "osd", "mds", NULL };
-      for (int i=0; key_names[i]; i++) {
-        std::string val;
-        if (cf.read("global", key_names[i], val) == 0) {
-          bufferlist bl;
-          ::encode(val, bl);
-          string s(key_names[i]);
-          caps[s] = bl; 
-        }
-      }
-      keyring.set_caps(ename, caps);
-      modified = true;
-    }
-    if (!caps.empty()) {
-      keyring.set_caps(ename, caps);
-      modified = true;
-    }
-    if (set_auid) {
-      keyring.set_uid(ename, auid);
-      modified = true;
-    }
-  
-    // read commands
-    if (list) {
-      try {
-        keyring.print(cout);
-      } catch (ceph::buffer::end_of_buffer &eob) {
-        cout << "Exception (end_of_buffer) in print(), exit." << std::endl;
-        exit(1);
-      }
-    }
-    if (print_key) {
-      CryptoKey key;
-      if (keyring.get_secret(ename, key)) {
-        cout << key << std::endl;
-      } else {
-        cerr << "entity " << ename << " not found" << std::endl;
-        exit(1);
-      }
-    }
-  
-    // write result?
-    if (modified) {
-      bufferlist bl;
-      keyring.encode_plaintext(bl);
-      r = bl.write_file(fn.c_str(), 0600);
-      if (r < 0) {
-        cerr << "could not write " << fn << std::endl;
-        exit(1);
-      }
-      //cout << "wrote " << bl.length() << " bytes to " << fn << std::endl;
-    }
-  } catch (ceph::FailedAssertion &a) {
-    cout << "Failed assert, exit." << std::endl;
-    exit(1); 
-  } 
+    //cout << "wrote " << bl.length() << " bytes to " << fn << std::endl;
+  }
   return 0;
 }


### PR DESCRIPTION
Assertion failure should be big. It should be catastrophic. It should
make an impression!

It should also not throw exceptions. This change does exactly that.

More specifically it calls abort() so we don't throw out stack frames or
otherwise mess up debugging.

Signed-off-by: Adam C. Emerson <aemerson@redhat.com>