### PR TITLE
cmake: Add common/PluginRegistry.cc to CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -281,6 +281,7 @@ set(libcommon_files
   common/Thread.cc
   common/Formatter.cc
   common/HeartbeatMap.cc
+  common/PluginRegistry.cc
   common/ceph_fs.cc
   common/ceph_hash.cc
   common/ceph_strings.cc


### PR DESCRIPTION
The issue is like this:

libcommon.a(ceph_context.cc.o): In function `CephContext::CephContext(unsigned int, int)':
  ceph_context.cc:(.text+0x2620): undefined reference to `ceph::PluginRegistry::PluginRegistry(CephContext*)'
