### PR TITLE
common/buffer.cc: allocate iov on demand in write_fd

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1945,7 +1945,11 @@ int buffer::list::write_fd(int fd) const
     return write_fd_zero_copy(fd);
 
   // use writev!
-  iovec iov[IOV_MAX];
+  int max = _buffers.size();
+  if (max == 0) {
+    return 0;
+  }
+  iovec iov[max];
   int iovlen = 0;
   ssize_t bytes = 0;
 


### PR DESCRIPTION
Current `write_fd` implementation allocates iov arrary in fixed
size(`IOV_MAX`),that's memory inefficient for writev syscall.

Cause `writev` syscall's behavior depends on iov arrary's size.
If the iov arrary's size is smaller than `UIO_FASTIOV`(defined in
`include/uapi/linux/uio.h`),kernel allocates segments on its
stack,vectored-IO occurs in a very memory-efficient manner.

This commit allows allocating iov array size on demand,and let the
kernel optimize `writev` syscall. 

 Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>