### PR TITLE
librados: fix pool alignment API overflow issue and tests

### DIFF
--- a/src/test/librados/TestCase.cc
+++ b/src/test/librados/TestCase.cc
@@ -25,7 +25,9 @@ void RadosTestNS::SetUp()
 {
   cluster = RadosTestNS::s_cluster;
   ASSERT_EQ(0, rados_ioctx_create(cluster, pool_name.c_str(), &ioctx));
-  ASSERT_FALSE(rados_ioctx_pool_requires_alignment(ioctx));
+  int requires;
+  ASSERT_EQ(0, rados_ioctx_pool_requires_alignment2(ioctx, &requires));
+  ASSERT_EQ(0, requires);
 }
 
 void RadosTestNS::TearDown()
@@ -71,7 +73,9 @@ void RadosTestPPNS::TearDownTestCase()
 void RadosTestPPNS::SetUp()
 {
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
-  ASSERT_FALSE(ioctx.pool_requires_alignment());
+  bool requires;
+  ASSERT_EQ(0, ioctx.pool_requires_alignment2(&requires));
+  ASSERT_FALSE(requires);
 }
 
 void RadosTestPPNS::TearDown()
@@ -151,7 +155,9 @@ void RadosTestParamPPNS::SetUp()
   }
 
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
-  ASSERT_FALSE(ioctx.pool_requires_alignment());
+  bool requires;
+  ASSERT_EQ(0, ioctx.pool_requires_alignment2(&requires));
+  ASSERT_FALSE(requires);
 }
 
 void RadosTestParamPPNS::TearDown()
@@ -191,8 +197,10 @@ void RadosTestECNS::SetUp()
 {
   cluster = RadosTestECNS::s_cluster;
   ASSERT_EQ(0, rados_ioctx_create(cluster, pool_name.c_str(), &ioctx));
-  ASSERT_TRUE(rados_ioctx_pool_requires_alignment(ioctx));
-  alignment = rados_ioctx_pool_required_alignment(ioctx);
+  int requires;
+  ASSERT_EQ(0, rados_ioctx_pool_requires_alignment2(ioctx, &requires));
+  ASSERT_NE(0, requires);
+  ASSERT_EQ(0, rados_ioctx_pool_required_alignment2(ioctx, &alignment));
   ASSERT_NE((unsigned)0, alignment);
 }
 
@@ -219,8 +227,10 @@ void RadosTestECPPNS::TearDownTestCase()
 void RadosTestECPPNS::SetUp()
 {
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
-  ASSERT_TRUE(ioctx.pool_requires_alignment());
-  alignment = ioctx.pool_required_alignment();
+  bool requires;
+  ASSERT_EQ(0, ioctx.pool_requires_alignment2(&requires));
+  ASSERT_TRUE(requires);
+  ASSERT_EQ(0, ioctx.pool_required_alignment2(&alignment));
   ASSERT_NE((unsigned)0, alignment);
 }
 
@@ -250,7 +260,9 @@ void RadosTest::SetUp()
   ASSERT_EQ(0, rados_ioctx_create(cluster, pool_name.c_str(), &ioctx));
   nspace = get_temp_pool_name();
   rados_ioctx_set_namespace(ioctx, nspace.c_str());
-  ASSERT_FALSE(rados_ioctx_pool_requires_alignment(ioctx));
+  int requires; 
+  ASSERT_EQ(0, rados_ioctx_pool_requires_alignment2(ioctx, &requires));
+  ASSERT_EQ(0, requires);
 }
 
 void RadosTest::TearDown()
@@ -303,7 +315,9 @@ void RadosTestPP::SetUp()
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
   nspace = get_temp_pool_name();
   ioctx.set_namespace(nspace);
-  ASSERT_FALSE(ioctx.pool_requires_alignment());
+  bool requires;
+  ASSERT_EQ(0, ioctx.pool_requires_alignment2(&requires));
+  ASSERT_FALSE(requires);
 }
 
 void RadosTestPP::TearDown()
@@ -398,7 +412,9 @@ void RadosTestParamPP::SetUp()
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
   nspace = get_temp_pool_name();
   ioctx.set_namespace(nspace);
-  ASSERT_FALSE(ioctx.pool_requires_alignment());
+  bool requires;
+  ASSERT_EQ(0, ioctx.pool_requires_alignment2(&requires));
+  ASSERT_FALSE(requires);
 }
 
 void RadosTestParamPP::TearDown()
@@ -446,8 +462,10 @@ void RadosTestEC::SetUp()
   ASSERT_EQ(0, rados_ioctx_create(cluster, pool_name.c_str(), &ioctx));
   nspace = get_temp_pool_name();
   rados_ioctx_set_namespace(ioctx, nspace.c_str());
-  ASSERT_TRUE(rados_ioctx_pool_requires_alignment(ioctx));
-  alignment = rados_ioctx_pool_required_alignment(ioctx);
+  int requires;
+  ASSERT_EQ(0, rados_ioctx_pool_requires_alignment2(ioctx, &requires));
+  ASSERT_NE(0, requires);
+  ASSERT_EQ(0, rados_ioctx_pool_required_alignment2(ioctx, &alignment));
   ASSERT_NE((unsigned)0, alignment);
 }
 
@@ -477,8 +495,10 @@ void RadosTestECPP::SetUp()
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
   nspace = get_temp_pool_name();
   ioctx.set_namespace(nspace);
-  ASSERT_TRUE(ioctx.pool_requires_alignment());
-  alignment = ioctx.pool_required_alignment();
+  bool requires;
+  ASSERT_EQ(0, ioctx.pool_requires_alignment2(&requires));
+  ASSERT_TRUE(requires);
+  ASSERT_EQ(0, ioctx.pool_required_alignment2(&alignment));
   ASSERT_NE((unsigned)0, alignment);
 }
 

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -2208,9 +2208,12 @@ TEST(LibRadosAioEC, RoundTripAppend) {
   ASSERT_EQ("", test_data.init());
   ASSERT_EQ(0, rados_aio_create_completion((void*)&test_data,
 	      set_completion_completeEC, set_completion_safeEC, &my_completion));
-  ASSERT_TRUE(rados_ioctx_pool_requires_alignment(test_data.m_ioctx));
-  uint64_t alignment = rados_ioctx_pool_required_alignment(test_data.m_ioctx);
-  ASSERT_NE((unsigned)0, alignment);
+  int requires;
+  ASSERT_EQ(0, rados_ioctx_pool_requires_alignment2(test_data.m_ioctx, &requires));
+  ASSERT_NE(0, requires);
+  uint64_t alignment;
+  ASSERT_EQ(0, rados_ioctx_pool_required_alignment2(test_data.m_ioctx, &alignment));
+  ASSERT_NE((unsigned)0, alignment); 
 
   int bsize = alignment;
   char *buf = (char *)new char[bsize];
@@ -2276,8 +2279,11 @@ TEST(LibRadosAioEC, RoundTripAppendPP) {
 	  (void*)&test_data, set_completion_completeEC, set_completion_safeEC);
   AioCompletion *my_completion_null = NULL;
   ASSERT_NE(my_completion, my_completion_null);
-  ASSERT_TRUE(test_data.m_ioctx.pool_requires_alignment());
-  uint64_t alignment = test_data.m_ioctx.pool_required_alignment();
+  bool requires;
+  ASSERT_EQ(0, test_data.m_ioctx.pool_requires_alignment2(&requires));
+  ASSERT_TRUE(requires);
+  uint64_t alignment;
+  ASSERT_EQ(0, test_data.m_ioctx.pool_required_alignment2(&alignment));
   ASSERT_NE((unsigned)0, alignment);
   int bsize = alignment;
   char *buf = (char *)new char[bsize];

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -756,10 +756,18 @@ public:
       uint64_t prev_length = found && old_value.has_contents() ?
 	old_value.most_recent_gen()->get_length(old_value.most_recent()) :
 	0;
+      bool requires;
+      int r = context->io_ctx.pool_requires_alignment2(&requires);
+      assert(r == 0);
+      uint64_t alignment = 0;
+      if (requires) {
+        r = context->io_ctx.pool_required_alignment2(&alignment);
+        assert(r == 0);
+        assert(alignment != 0);
+      }
       cont_gen = new AppendGenerator(
 	prev_length,
-	(context->io_ctx.pool_requires_alignment() ?
-	 context->io_ctx.pool_required_alignment() : 0),
+	alignment,
 	context->min_stride_size,
 	context->max_stride_size,
 	3);

--- a/src/tools/rados/RadosImport.cc
+++ b/src/tools/rados/RadosImport.cc
@@ -243,8 +243,22 @@ int RadosImport::get_object_rados(librados::IoCtx &ioctx, bufferlist &bl, bool n
     need_align = true;
     alignment = align;
   } else {
-    if ((need_align = ioctx.pool_requires_alignment()))
-      alignment = ioctx.pool_required_alignment();
+    int ret = ioctx.pool_requires_alignment2(&need_align);
+    if (ret < 0) {
+      cerr << "pool_requires_alignment2 failed: " << cpp_strerror(ret)
+        << std::endl;
+      return ret;	
+    }
+	
+    if (need_align) {
+      ret = ioctx.pool_required_alignment2(&alignment);
+      if (ret < 0) {
+        cerr << "pool_required_alignment2 failed: " << cpp_strerror(ret)
+	  << std::endl;
+	return ret;
+      }
+      assert(alignment != 0);
+    }
   }
 
   if (need_align) {


### PR DESCRIPTION
The original APIs may overflow and are replaced by 1f855456cae96c91a67c169d2333e333c3b59671.
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>