### PR TITLE
osd: fix ScrubJob compare function

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6073,12 +6073,13 @@ bool OSD::scrub_random_backoff()
   return false;
 }
 
-OSDService::ScrubJob::ScrubJob(const spg_t& pg, const utime_t& timestamp,
+OSDService::ScrubJob::ScrubJob(const spg_t& pg, const utime_t& sched_stamp,
+                               const utime_t& dead_stamp,
 			       double pool_scrub_min_interval,
 			       double pool_scrub_max_interval, bool must)
   : pgid(pg),
-    sched_time(timestamp),
-    deadline(timestamp)
+    sched_time(sched_stamp),
+    deadline(dead_stamp)
 {
   // if not explicitly requested, postpone the scrub with a random delay
   if (!must) {
@@ -6100,6 +6101,10 @@ bool OSDService::ScrubJob::ScrubJob::operator<(const OSDService::ScrubJob& rhs) 
   if (sched_time < rhs.sched_time)
     return true;
   if (sched_time > rhs.sched_time)
+    return false;
+  if (deadline < rhs.deadline)
+    return true;
+  if (deadline > rhs.deadline)
     return false;
   return pgid < rhs.pgid;
 }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -598,7 +598,7 @@ public:
     /// the hard upper bound of scrub time
     utime_t deadline;
     ScrubJob() {}
-    explicit ScrubJob(const spg_t& pg, const utime_t& timestamp,
+    explicit ScrubJob(const spg_t& pg, const utime_t& sched_stamp, const utime_t& dead_stamp,
 		      double pool_scrub_min_interval = 0,
 		      double pool_scrub_max_interval = 0, bool must = true);
     /// order the jobs by sched_time
@@ -606,18 +606,18 @@ public:
   };
   set<ScrubJob> sched_scrub_pg;
 
-  /// @returns the scrub_reg_stamp used for unregister the scrub job
-  utime_t reg_pg_scrub(spg_t pgid, utime_t t, double pool_scrub_min_interval,
+  /// @returns the scrub_reg_stamp and deadline stamp used for unregister the scrub job
+  pair<utime_t, utime_t> reg_pg_scrub(spg_t pgid, utime_t t, double pool_scrub_min_interval,
 		       double pool_scrub_max_interval, bool must) {
-    ScrubJob scrub(pgid, t, pool_scrub_min_interval, pool_scrub_max_interval,
+    ScrubJob scrub(pgid, t, t, pool_scrub_min_interval, pool_scrub_max_interval,
 		   must);
     Mutex::Locker l(sched_scrub_lock);
     sched_scrub_pg.insert(scrub);
-    return scrub.sched_time;
+    return make_pair(scrub.sched_time, scrub.deadline);
   }
-  void unreg_pg_scrub(spg_t pgid, utime_t t) {
+  void unreg_pg_scrub(spg_t pgid, pair<utime_t, utime_t> t) {
     Mutex::Locker l(sched_scrub_lock);
-    size_t removed = sched_scrub_pg.erase(ScrubJob(pgid, t));
+    size_t removed = sched_scrub_pg.erase(ScrubJob(pgid, t.first, t.second));
     assert(removed);
   }
   bool first_scrub_stamp(ScrubJob *out) {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1096,7 +1096,7 @@ public:
     ScrubMap primary_scrubmap;
     map<pg_shard_t, ScrubMap> received_maps;
     OpRequestRef active_rep_scrub;
-    utime_t scrub_reg_stamp;  // stamp we registered for
+    pair<utime_t, utime_t> scrub_reg_stamp;  // stamp we registered for
 
     // flags to indicate explicitly requested scrubs (by admin)
     bool must_scrub, must_deep_scrub, must_repair;


### PR DESCRIPTION
If we not consider the deadline in compare function. Some pgs would not
be scheduled when the deadline arrives.

Such as, there is ScrubJob A in sched_scrub_pg. A.pgid = 1.1, A.sched_time = 0:00,
A.deadline = 23:00. Now we send a command `ceph pg scrub 1.2`, so osd would
add a new ScrubJob B. It is possible that B.pgid = 1.2, A.sched_time = 0:00,
A.deadline = 0:00. Current strategy ScrubJob B would be scheduled after A.
But A.deadline is much later than B.deadline. So it possible that job B is
not scheduled when the job B deadline arrives.

Signed-off-by: Xinze Chi <xinze@xsky.com>