### PR TITLE
rgw: fix a typo in init-radosgw

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -106,7 +106,7 @@ case "$1" in
             else
                 ulimit -n 32768
                 core_limit=`ceph-conf -n $name 'core file limit'`
-                if [ -z $core_limit ]
+                if [ -z $core_limit ]; then
                     DAEMON_COREFILE_LIMIT=$core_limit
                 fi
                 daemon --user="$user" "$RADOSGW -n $name"


### PR DESCRIPTION
Fix an accidental typo in init-radosgw, which causes rgw not working.

Function test, like start/restart/stop rgw, has been run on my local cluster.
  
Signed-off-by: Zhi Zhang zhangz.david@outlook.com