### PR TITLE
os/newstore: cleanup inconsistent cpp_strerror usage

### DIFF
--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -772,11 +772,11 @@ int NewStore::_lock_fsid()
   l.l_len = 0;
   int r = ::fcntl(fsid_fd, F_SETLK, &l);
   if (r < 0) {
-    int err = errno;
+    int err = -errno;
     derr << __func__ << " failed to lock " << path << "/fsid"
 	 << " (is another ceph-osd still running?)"
 	 << cpp_strerror(err) << dendl;
-    return -err;
+    return err;
   }
   return 0;
 }


### PR DESCRIPTION
`cpp_strerror` can handle the negative errno,this commit cleans 
up inconsistent `cpp_strerror` usage in NewStore.cc file.

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>