### PR TITLE
crushtool: set type 0 name "device" for --build option

### DIFF
--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -213,7 +213,7 @@ int CrushCompiler::decompile(ostream &out)
   for (int i=0; n; i++) {
     const char *name = crush.get_type_name(i);
     if (!name) {
-      if (i == 0) out << "type 0 device\n";
+      if (i == 0) out << "type 0 osd\n";
       continue;
     }
     n--;

--- a/src/test/cli/crushtool/arg-order-checks.t
+++ b/src/test/cli/crushtool/arg-order-checks.t
@@ -79,7 +79,7 @@
   device 24 osd.24
   
   # types
-  type 0 device
+  type 0 osd
   type 1 node
   type 2 rack
   type 3 root

--- a/src/test/cli/crushtool/build.t
+++ b/src/test/cli/crushtool/build.t
@@ -36,7 +36,7 @@
   device 0 osd.0
   
   # types
-  type 0 device
+  type 0 osd
   type 1 root
   
   # buckets

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -617,6 +617,7 @@ int main(int argc, const char **argv)
       crush.set_item_name(i, "osd." + stringify(i));
     }
 
+    crush.set_type_name(0, "osd");
     int type = 1;
     for (vector<layer_t>::iterator p = layers.begin(); p != layers.end(); ++p, type++) {
       layer_t &l = *p;


### PR DESCRIPTION
The crushmap built by crushtool cannot be used directly as the name of type 0 is not specified.
We may decompile the crushmap(it will automatically add type 0) and then recompile it to make it usable, but that's extra effort.

Signed-off-by: Sangdi Xu <xu.sangdi@h3c.com>