### PR TITLE
rbd: add --object-size option

### DIFF
--- a/src/test/cli-integration/rbd/defaults.t
+++ b/src/test/cli-integration/rbd/defaults.t
@@ -12,7 +12,7 @@ Plain create with various options specified via usual cli arguments
       "size": 1048576
   }
   $ rbd rm test --no-progress
-  $ rbd create -s 1 --order 20 test
+  $ rbd create -s 1 --object-size 1M test
   $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "block_name_prefix": "rb.0.*",  (glob)
@@ -22,6 +22,18 @@ Plain create with various options specified via usual cli arguments
       "objects": 1, 
       "order": 20, 
       "size": 1048576
+  }
+  $ rbd rm test --no-progress
+  $ rbd create -s 1G --object-size 4K test
+  $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
+  {
+      "block_name_prefix": "rb.0.*",  (glob)
+      "format": 1, 
+      "name": "test", 
+      "object_size": 4096, 
+      "objects": 262144, 
+      "order": 12, 
+      "size": 1073741824
   }
   $ rbd rm test --no-progress
   $ rbd create -s 1 test --image-format 2
@@ -58,7 +70,7 @@ Plain create with various options specified via usual cli arguments
       "size": 1073741824
   }
   $ rbd rm test --no-progress
-  $ rbd create -s 1 test --image-format 2 --order 20
+  $ rbd create -s 1 test --image-format 2 --object-size 1M
   $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "block_name_prefix": "rbd_data.*",  (glob)
@@ -173,7 +185,7 @@ Format 2 Usual arguments with custom rbd_default_* params
       "stripe_unit": 1048576
   }
   $ rbd rm test --no-progress
-  $ rbd create -s 1 test --image-format 2 --stripe-unit 1048576 --stripe-count 8 --order 23 --rbd-default-order 20
+  $ rbd create -s 1 test --image-format 2 --stripe-unit 1048576 --stripe-count 8 --object-size 8M --rbd-default-order 20
   $ rbd info test --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "block_name_prefix": "rbd_data.*",  (glob)

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -123,6 +123,7 @@
   rbd help clone
   usage: rbd clone [--pool <pool>] [--image <image>] [--snap <snap>] 
                    [--dest-pool <dest-pool>] [--dest <dest>] [--order <order>] 
+                   [--object-size <object-size>] 
                    [--image-feature <image-feature>] [--image-shared] 
                    [--stripe-unit <stripe-unit>] [--stripe-count <stripe-count>] 
                    [--journal-splay-width <journal-splay-width>] 
@@ -146,6 +147,7 @@
     --dest-pool arg           destination pool name
     --dest arg                destination image name
     --order arg               object order [12 <= order <= 25]
+    --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), striping(+), exclusive-lock(*),
                               object-map(*), fast-diff(*), deep-flatten,
@@ -164,6 +166,7 @@
   rbd help copy
   usage: rbd copy [--pool <pool>] [--image <image>] [--snap <snap>] 
                   [--dest-pool <dest-pool>] [--dest <dest>] [--order <order>] 
+                  [--object-size <object-size>] 
                   [--image-feature <image-feature>] [--image-shared] 
                   [--stripe-unit <stripe-unit>] [--stripe-count <stripe-count>] 
                   [--journal-splay-width <journal-splay-width>] 
@@ -187,6 +190,7 @@
     --dest-pool arg              destination pool name
     --dest arg                   destination image name
     --order arg                  object order [12 <= order <= 25]
+    --object-size arg            object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg          image features
                                  [layering(+), striping(+), exclusive-lock(*),
                                  object-map(*), fast-diff(*), deep-flatten,
@@ -206,8 +210,9 @@
   rbd help create
   usage: rbd create [--pool <pool>] [--image <image>] 
                     [--image-format <image-format>] [--new-format] 
-                    [--order <order>] [--image-feature <image-feature>] 
-                    [--image-shared] [--stripe-unit <stripe-unit>] 
+                    [--order <order>] [--object-size <object-size>] 
+                    [--image-feature <image-feature>] [--image-shared] 
+                    [--stripe-unit <stripe-unit>] 
                     [--stripe-count <stripe-count>] 
                     [--journal-splay-width <journal-splay-width>] 
                     [--journal-object-size <journal-object-size>] 
@@ -227,6 +232,7 @@
     --new-format              use image format 2
                               (deprecated)
     --order arg               object order [12 <= order <= 25]
+    --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), striping(+), exclusive-lock(*),
                               object-map(*), fast-diff(*), deep-flatten,
@@ -446,8 +452,9 @@
   rbd help import
   usage: rbd import [--path <path>] [--dest-pool <dest-pool>] [--dest <dest>] 
                     [--image-format <image-format>] [--new-format] 
-                    [--order <order>] [--image-feature <image-feature>] 
-                    [--image-shared] [--stripe-unit <stripe-unit>] 
+                    [--order <order>] [--object-size <object-size>] 
+                    [--image-feature <image-feature>] [--image-shared] 
+                    [--stripe-unit <stripe-unit>] 
                     [--stripe-count <stripe-count>] 
                     [--journal-splay-width <journal-splay-width>] 
                     [--journal-object-size <journal-object-size>] 
@@ -470,6 +477,7 @@
     --new-format              use image format 2
                               (deprecated)
     --order arg               object order [12 <= order <= 25]
+    --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), striping(+), exclusive-lock(*),
                               object-map(*), fast-diff(*), deep-flatten,

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -218,6 +218,8 @@ void add_create_image_options(po::options_description *opt,
   opt->add_options()
     (IMAGE_ORDER.c_str(), po::value<ImageOrder>(),
      "object order [12 <= order <= 25]")
+    (IMAGE_OBJECT_SIZE.c_str(), po::value<ImageObjectSize>(),
+     "object size in B/K/M [4K <= object size <= 32M]")
     (IMAGE_FEATURES.c_str(), po::value<ImageFeatures>()->composing(),
      ("image features\n" + get_short_features_help(true)).c_str())
     (IMAGE_SHARED.c_str(), po::bool_switch(), "shared image")
@@ -335,7 +337,7 @@ void validate(boost::any& v, const std::vector<std::string>& values,
   po::validators::check_first_occurrence(v);
   const std::string &s = po::validators::get_single_string(values);
   try {
-    uint32_t order = boost::lexical_cast<uint32_t>(s);
+    uint64_t order = boost::lexical_cast<uint64_t>(s);
     if (order >= 12 && order <= 25) {
       v = boost::any(order);
       return;
@@ -343,6 +345,19 @@ void validate(boost::any& v, const std::vector<std::string>& values,
   } catch (const boost::bad_lexical_cast &) {
   }
   throw po::validation_error(po::validation_error::invalid_option_value);
+}
+
+void validate(boost::any& v, const std::vector<std::string>& values,
+              ImageObjectSize *target_type, int dummy) {
+  po::validators::check_first_occurrence(v);
+  const std::string &s = po::validators::get_single_string(values);
+  
+  std::string parse_error;
+  uint64_t objectsize = strict_sistrtoll(s.c_str(), &parse_error);
+  if (!parse_error.empty()) {
+    throw po::validation_error(po::validation_error::invalid_option_value);
+  }
+  v = boost::any(objectsize);
 }
 
 void validate(boost::any& v, const std::vector<std::string>& values,

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -59,6 +59,7 @@ static const std::string WHOLE_OBJECT("whole-object");
 static const std::string IMAGE_FORMAT("image-format");
 static const std::string IMAGE_NEW_FORMAT("new-format");
 static const std::string IMAGE_ORDER("order");
+static const std::string IMAGE_OBJECT_SIZE("object-size");
 static const std::string IMAGE_FEATURES("image-feature");
 static const std::string IMAGE_SHARED("image-shared");
 static const std::string IMAGE_SIZE("size");
@@ -80,6 +81,7 @@ static const std::set<std::string> SWITCH_ARGUMENTS = {
 
 struct ImageSize {};
 struct ImageOrder {};
+struct ImageObjectSize {};
 struct ImageFormat {};
 struct ImageNewFormat {};
 
@@ -171,6 +173,8 @@ void validate(boost::any& v, const std::vector<std::string>& values,
               ImageSize *target_type, int);
 void validate(boost::any& v, const std::vector<std::string>& values,
               ImageOrder *target_type, int);
+void validate(boost::any& v, const std::vector<std::string>& values,
+              ImageObjectSize *target_type, int);
 void validate(boost::any& v, const std::vector<std::string>& values,
               ImageFormat *target_type, int);
 void validate(boost::any& v, const std::vector<std::string>& values,

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -317,11 +317,16 @@ int validate_snapshot_name(at::ArgumentModifier mod,
 
 int get_image_options(const boost::program_options::variables_map &vm,
 		      bool get_format, librbd::ImageOptions *opts) {
-  uint64_t order, features, stripe_unit, stripe_count;
+  uint64_t order, features, stripe_unit, stripe_count, object_size;
   bool features_specified = false;
 
   if (vm.count(at::IMAGE_ORDER)) {
     order = vm[at::IMAGE_ORDER].as<uint64_t>();
+    std::cerr << "rbd: --order is deprecated, use --object-size"
+	      << std::endl;
+  } else if (vm.count(at::IMAGE_OBJECT_SIZE)) {
+    object_size = vm[at::IMAGE_OBJECT_SIZE].as<uint64_t>();
+    order = std::round(std::log2(object_size)); 
   } else {
     order = 22;
   }


### PR DESCRIPTION
Object size can be specified when creating an image with the --order option,
as a number of bits in the size.

This patch is adding new option --object-size. This new option will specify
object size directly for example --object-size 2M.

It would be easier to use. --order is still present for backwards compatibility.
For simplicity, we are rounding up the object size to the nearest power of 2.

Fixes #12112

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>