### PR TITLE
qa/krbd: Expunge generic/247

### DIFF
--- a/qa/run_xfstests_krbd.sh
+++ b/qa/run_xfstests_krbd.sh
@@ -45,6 +45,8 @@ cat > "${EXPUNGE}" <<-!
 	generic/204	# stripe size throws off test's math for when to
 			#  expect ENOSPC
 	generic/231 # broken for disk and rbd by xfs kernel commit 4162bb
+	generic/247 # race between DIO and mmap writes
+               # see (https://lists.01.org/pipermail/lkp/2015-March/002459.html)
 
 	shared/272	# not for xfs
 	shared/289	# not for xfs


### PR DESCRIPTION
xfstests generic/247 exercises XFS DIO and AIO to detect races. Some
races apparently exist in the XFS code as this is a known issue within
XFS. Expunge this test because it is not specifically relevant to krbd
and not a specific krbd issue.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>