### PR TITLE
hammer: Ceph daemon failed to start, because the service name was already used.

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -304,7 +304,8 @@ for name in $what; do
 	    [ -n "$max_open_files" ] && files="ulimit -n $max_open_files;"
 
 	    if [ -n "$SYSTEMD_RUN" ]; then
-		cmd="$SYSTEMD_RUN -r bash -c '$files $cmd --cluster $cluster -f'"
+                time=`date +%s.%N` 
+		cmd="$SYSTEMD_RUN --unit=ceph-$name.$time -r bash -c '$files $cmd --cluster $cluster -f'"
 	    else
 		cmd="$files $wrap $cmd --cluster $cluster $runmode"
 	    fi


### PR DESCRIPTION
http://tracker.ceph.com/issues/13936