### PR TITLE
qa/workunits/cephtool/test.sh: false positive fail on /tmp/obj1.

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -247,7 +247,7 @@ function test_tiering_agent()
   done
   $evicted # assert
   # the object is proxy read and promoted to the cache
-  rados -p $slow get obj1 /tmp/obj1
+  rados -p $slow get obj1 - >/dev/null
   # wait for the promoted object to be evicted again
   evicted=false
   for i in 1 2 4 8 16 32 64 128 256 ; do


### PR DESCRIPTION
If /tmp/obj1 happened to exist already, and was not writable by the
testing user, then this test failed!

Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>