### PR TITLE
build/ops: enable CR in CentOS 7

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -62,12 +62,15 @@ CentOS|Fedora|RedHatEnterpriseServer)
             CentOS|RedHatEnterpriseServer)
                 $SUDO yum install -y yum-utils
                 MAJOR_VERSION=$(lsb_release -rs | cut -f1 -d.)
-                if test $(lsb_release -si) == RedHatEnterpriseServer ; then
+                if test $(lsb_release -si) = RedHatEnterpriseServer ; then
                     $SUDO yum install subscription-manager
                     $SUDO subscription-manager repos --enable=rhel-$MAJOR_VERSION-server-optional-rpms
                 fi
                 $SUDO yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/$MAJOR_VERSION/x86_64/ 
                 $SUDO yum install --nogpgcheck -y epel-release
+                if test $(lsb_release -si) = CentOS -a $MAJOR_VERSION = 7 ; then
+                    yum-config-manager --enable cr
+                fi
                 $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
                 ;;


### PR DESCRIPTION
To get libunwind from the CR repositories until CentOS 7.2.1511 is released.

http://tracker.ceph.com/issues/13997 Fixes: #13997

Signed-off-by: Loic Dachary <loic@dachary.org>