### PR TITLE
osd: call on_new_interval on newly split child PG

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2273,6 +2273,8 @@ void PG::split_into(pg_t child_pgid, PG *child, unsigned split_bits)
   split_ops(child, split_bits);
   _split_into(child_pgid, child, split_bits);
 
+  child->on_new_interval();
+
   child->dirty_info = true;
   child->dirty_big_info = true;
   dirty_info = true;


### PR DESCRIPTION
http://tracker.ceph.com/issues/13979