### PR TITLE
ceph-mds:add --help/-h

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -105,6 +105,10 @@ int main(int argc, const char **argv)
     if (ceph_argparse_double_dash(args, i)) {
       break;
     }
+    else if (ceph_argparse_flag(args, i, "--help", "-h", (char*)NULL)) {
+      usage();
+      break;
+    }
     else if (ceph_argparse_witharg(args, i, &val, "--journal-check", (char*)NULL)) {
       int r = parse_rank("journal-check", val);
       if (shadow != MDSMap::STATE_NULL) {


### PR DESCRIPTION
When use ceph-mds --hlep/-h, the usage will be showed

Signed-off-by: Cilang Zhao <zhao.cilang@h3c.com>