### PR TITLE
DNM: mon: MonMap: hold mon info (addr,etc) in dedicated class

### DIFF
--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -113,6 +113,30 @@ void MonMap::generate_test_instances(list<MonMap*>& o)
   o.back()->last_changed = utime_t(123, 456);
   o.back()->created = utime_t(789, 101112);
   o.back()->add("one", entity_addr_t());
+
+  MonMap *m = new MonMap;
+  {
+    m->epoch = 1;
+    m->last_changed = utime_t(123, 456);
+
+    entity_addr_t empty_addr_one;
+    empty_addr_one.set_nonce(1);
+    m->add("empty_addr_one", empty_addr_one);
+    entity_addr_t empty_addr_two;
+    empty_addr_two.set_nonce(2);
+    m->add("empty_adrr_two", empty_addr_two);
+
+    const char *local_pub_addr_s = "127.0.1.2";
+
+    const char *end_p = local_pub_addr_s + strlen(local_pub_addr_s);
+    entity_addr_t local_pub_addr;
+    local_pub_addr.parse(local_pub_addr_s, &end_p);
+
+    m->add("filled_pub_addr", local_pub_addr);
+
+    m->add("empty_addr_zero", entity_addr_t());
+  }
+  o.push_back(m);
 }
 
 // read from/write to a file


### PR DESCRIPTION
I'm pushing this branch, as it is, solely for discussion; should it get the okay to merge, that will happen as part of a broader pull request.

Even if this change seems unwarranted, it's meant as a basis for a having multiple networks on the monitors (i.e., instead of just having a public network). Keeping any given monitor's info on a dedicated struct/class allows us to more easily access it's information and extend the number of, say, addresses. The alternative would be to add clutter to the monmap in ways that make me feel all sorts of wrong.

Reviews will be most welcome.

`Signed-off-by: Joao Eduardo Luis <joao@suse.de>`