### PR TITLE
tests: osd-scrub-snaps.sh to display full osd logs on error

### DIFF
--- a/src/test/osd/osd-scrub-snaps.sh
+++ b/src/test/osd/osd-scrub-snaps.sh
@@ -151,7 +151,10 @@ function TEST_scrub_snaps() {
     wait_for_clean || return 1
 
     local pgid="${poolid}.0"
-    pg_scrub "$pgid" || return 1
+    if ! pg_scrub "$pgid" ; then
+        cat $dir/osd.0.log
+        return 1
+    fi
     grep 'log_channel' $dir/osd.0.log
 
     for i in `seq 1 7`


### PR DESCRIPTION
This generates a large output but is the only way to get more
information about race conditions that turn out to show up frequently.

http://tracker.ceph.com/issues/13986 Refs: #13986

Signed-off-by: Loic Dachary <loic@dachary.org>