### PR TITLE
librbd: image refresh code paths converted to async state machines

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -890,11 +890,14 @@ if(${WITH_RBD})
     librbd/ObjectMap.cc
     librbd/Utils.cc
     librbd/object_map/InvalidateRequest.cc
+    librbd/object_map/LockRequest.cc
     librbd/object_map/Request.cc
+    librbd/object_map/RefreshRequest.cc
     librbd/object_map/ResizeRequest.cc
     librbd/object_map/SnapshotCreateRequest.cc
     librbd/object_map/SnapshotRemoveRequest.cc
     librbd/object_map/SnapshotRollbackRequest.cc
+    librbd/object_map/UnlockRequest.cc
     librbd/object_map/UpdateRequest.cc
     librbd/operation/FlattenRequest.cc
     librbd/operation/RebuildObjectMapRequest.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -888,6 +888,7 @@ if(${WITH_RBD})
     librbd/LibrbdAdminSocketHook.cc
     librbd/LibrbdWriteback.cc
     librbd/ObjectMap.cc
+    librbd/Utils.cc
     librbd/object_map/InvalidateRequest.cc
     librbd/object_map/Request.cc
     librbd/object_map/ResizeRequest.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -880,7 +880,7 @@ if(${WITH_RBD})
     librbd/DiffIterate.cc
     librbd/ExclusiveLock.cc
     librbd/ImageCtx.cc
-    librbd/ImageRefresh.cc
+    librbd/ImageState.cc
     librbd/ImageWatcher.cc
     librbd/internal.cc
     librbd/Journal.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -880,6 +880,7 @@ if(${WITH_RBD})
     librbd/DiffIterate.cc
     librbd/ExclusiveLock.cc
     librbd/ImageCtx.cc
+    librbd/ImageRefresh.cc
     librbd/ImageWatcher.cc
     librbd/internal.cc
     librbd/Journal.cc
@@ -892,6 +893,11 @@ if(${WITH_RBD})
     librbd/Utils.cc
     librbd/exclusive_lock/AcquireRequest.cc
     librbd/exclusive_lock/ReleaseRequest.cc
+    librbd/image/CloseRequest.cc
+    librbd/image/OpenRequest.cc
+    librbd/image/RefreshParentRequest.cc
+    librbd/image/RefreshRequest.cc
+    librbd/image/SetSnapRequest.cc
     librbd/object_map/InvalidateRequest.cc
     librbd/object_map/LockRequest.cc
     librbd/object_map/Request.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -878,6 +878,7 @@ if(${WITH_RBD})
     librbd/AsyncRequest.cc
     librbd/CopyupRequest.cc
     librbd/DiffIterate.cc
+    librbd/ExclusiveLock.cc
     librbd/ImageCtx.cc
     librbd/ImageWatcher.cc
     librbd/internal.cc
@@ -889,6 +890,8 @@ if(${WITH_RBD})
     librbd/LibrbdWriteback.cc
     librbd/ObjectMap.cc
     librbd/Utils.cc
+    librbd/exclusive_lock/AcquireRequest.cc
+    librbd/exclusive_lock/ReleaseRequest.cc
     librbd/object_map/InvalidateRequest.cc
     librbd/object_map/LockRequest.cc
     librbd/object_map/Request.cc

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "cls/rbd/cls_rbd_client.h"
 #include "cls/lock/cls_lock_client.h"
 #include "include/buffer.h"
 #include "include/Context.h"
@@ -8,135 +9,117 @@
 #include "include/rbd_types.h"
 #include "common/Cond.h"
 
-#include "cls_rbd_client.h"
-
 #include <errno.h>
 
 namespace librbd {
   namespace cls_client {
 
-namespace {
-
-void rados_callback(rados_completion_t c, void *arg) {
-  Context *ctx = reinterpret_cast<Context *>(arg);
-  ctx->complete(rados_aio_get_return_value(c));
-}
-
-struct C_GetChildren : public Context {
-  librados::IoCtx *ioctx;
-  std::string oid;
-  parent_spec pspec;
-  std::set<std::string> *children;
-  Context *on_finish;
-  bufferlist out_bl;
-
-  C_GetChildren(librados::IoCtx *_ioctx, const std::string &_oid,
-                const parent_spec &_pspec, std::set<std::string> *_children,
-                Context *_on_finish)
-  : ioctx(_ioctx), oid(_oid), pspec(_pspec), children(_children),
-    on_finish(_on_finish) {
-  }
-
-  void send() {
-    bufferlist in_bl;
-    ::encode(pspec.pool_id, in_bl);
-    ::encode(pspec.image_id, in_bl);
-    ::encode(pspec.snap_id, in_bl);
-
-    librados::ObjectReadOperation op;
-    op.exec("rbd", "get_children", in_bl);
-
-    librados::AioCompletion *rados_completion =
-       librados::Rados::aio_create_completion(this, rados_callback, NULL);
-    int r = ioctx->aio_operate(oid, rados_completion, &op, &out_bl);
-    assert(r == 0);
-    rados_completion->release();
-  }
-
-  virtual void finish(int r) {
-    if (r == 0) {
-      try {
-        bufferlist::iterator it = out_bl.begin();
-        ::decode(*children, it);
-      } catch (const buffer::error &err) {
-        r = -EBADMSG;
-      }
+    void get_immutable_metadata_start(librados::ObjectReadOperation *op) {
+      bufferlist bl, empty_bl;
+      snapid_t snap = CEPH_NOSNAP;
+      ::encode(snap, bl);
+      op->exec("rbd", "get_size", bl);
+      op->exec("rbd", "get_object_prefix", empty_bl);
     }
-    on_finish->complete(r);
-  }
-};
 
-struct C_ObjectMapLoad : public Context {
-  librados::IoCtx *ioctx;
-  std::string oid;
-  ceph::BitVector<2> *object_map;
-  Context *on_finish;
-  bufferlist out_bl;
-
-  C_ObjectMapLoad(librados::IoCtx *_ioctx, const std::string &_oid,
-                  ceph::BitVector<2> *_object_map, Context *_on_finish)
-    : ioctx(_ioctx), oid(_oid), object_map(_object_map), on_finish(_on_finish) {
-  }
-
-  void send() {
-    bufferlist in_bl;
-    librados::ObjectReadOperation op;
-    op.exec("rbd", "object_map_load", in_bl);
-
-    librados::AioCompletion *rados_completion =
-       librados::Rados::aio_create_completion(this, rados_callback, NULL);
-    int r = ioctx->aio_operate(oid, rados_completion, &op, &out_bl);
-    assert(r == 0);
-    rados_completion->release();
-  }
-
-  virtual void finish(int r) {
-    if (r == 0) {
+    int get_immutable_metadata_finish(bufferlist::iterator *it,
+                                      std::string *object_prefix,
+                                      uint8_t *order) {
       try {
-        bufferlist::iterator it = out_bl.begin();
-        ::decode(*object_map, it);
+	uint64_t size;
+	// get_size
+	::decode(*order, *it);
+	::decode(size, *it);
+	// get_object_prefix
+	::decode(*object_prefix, *it);
       } catch (const buffer::error &err) {
-        r = -EBADMSG;
+	return -EBADMSG;
       }
+      return 0;
+
     }
-    on_finish->complete(r);
-  }
-};
-
-
-} // anonymous namespace
 
     int get_immutable_metadata(librados::IoCtx *ioctx, const std::string &oid,
 			       std::string *object_prefix, uint8_t *order)
     {
-      assert(object_prefix);
-      assert(order);
-
       librados::ObjectReadOperation op;
-      bufferlist bl, empty;
-      snapid_t snap = CEPH_NOSNAP;
-      ::encode(snap, bl);
-      op.exec("rbd", "get_size", bl);
-      op.exec("rbd", "get_object_prefix", empty);
-      
+      get_immutable_metadata_start(&op);
 
-      bufferlist outbl;
-      int r = ioctx->operate(oid, &op, &outbl);
-      if (r < 0)
-	return r;
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+        return r;
+      }
+
+      bufferlist::iterator it = out_bl.begin();
+      return get_immutable_metadata_finish(&it, object_prefix, order);
+    }
+
+    void get_mutable_metadata_start(librados::ObjectReadOperation *op,
+                                    bool read_only) {
+      snapid_t snap = CEPH_NOSNAP;
+      bufferlist size_bl;
+      ::encode(snap, size_bl);
+      op->exec("rbd", "get_size", size_bl);
+
+      bufferlist features_bl;
+      ::encode(snap, features_bl);
+      ::encode(read_only, features_bl);
+      op->exec("rbd", "get_features", features_bl);
+
+      bufferlist empty_bl;
+      op->exec("rbd", "get_snapcontext", empty_bl);
+
+      bufferlist parent_bl;
+      ::encode(snap, parent_bl);
+      op->exec("rbd", "get_parent", parent_bl);
+      rados::cls::lock::get_lock_info_start(op, RBD_LOCK_NAME);
+    }
+
+    int get_mutable_metadata_finish(bufferlist::iterator *it,
+                                    uint64_t *size, uint64_t *features,
+                                    uint64_t *incompatible_features,
+                                    std::map<rados::cls::lock::locker_id_t,
+                                             rados::cls::lock::locker_info_t> *lockers,
+                                    bool *exclusive_lock, std::string *lock_tag,
+                                    ::SnapContext *snapc, parent_info *parent) {
+      assert(size);
+      assert(features);
+      assert(incompatible_features);
+      assert(lockers);
+      assert(exclusive_lock);
+      assert(snapc);
+      assert(parent);
 
       try {
-	bufferlist::iterator iter = outbl.begin();
-	uint64_t size;
+	uint8_t order;
 	// get_size
-	::decode(*order, iter);
-	::decode(size, iter);
-	// get_object_prefix
-	::decode(*object_prefix, iter);
+	::decode(order, *it);
+	::decode(*size, *it);
+	// get_features
+	::decode(*features, *it);
+	::decode(*incompatible_features, *it);
+	// get_snapcontext
+	::decode(*snapc, *it);
+	// get_parent
+	::decode(parent->spec.pool_id, *it);
+	::decode(parent->spec.image_id, *it);
+	::decode(parent->spec.snap_id, *it);
+	::decode(parent->overlap, *it);
+
+	// get_lock_info
+	ClsLockType lock_type = LOCK_NONE;
+	int r = rados::cls::lock::get_lock_info_finish(it, lockers, &lock_type,
+						       lock_tag);
+        if (r == -EOPNOTSUPP) {
+          r = 0;
+        }
+        if (r == 0) {
+	  *exclusive_lock = (lock_type == LOCK_EXCLUSIVE);
+        }
       } catch (const buffer::error &err) {
 	return -EBADMSG;
       }
-
       return 0;
     }
 
@@ -150,69 +133,20 @@ struct C_ObjectMapLoad : public Context {
 			     ::SnapContext *snapc,
 			     parent_info *parent)
     {
-      assert(size);
-      assert(features);
-      assert(incompatible_features);
-      assert(lockers);
-      assert(exclusive_lock);
-      assert(snapc);
-      assert(parent);
-
       librados::ObjectReadOperation op;
-      bufferlist sizebl, featuresbl, parentbl, empty;
-      snapid_t snap = CEPH_NOSNAP;
-      ::encode(snap, sizebl);
-      op.exec("rbd", "get_size", sizebl);
+      get_mutable_metadata_start(&op, read_only);
 
-      ::encode(snap, featuresbl);
-      ::encode(read_only, featuresbl);
-      op.exec("rbd", "get_features", featuresbl);
-
-      op.exec("rbd", "get_snapcontext", empty);
-
-      ::encode(snap, parentbl);
-      op.exec("rbd", "get_parent", parentbl);
-      rados::cls::lock::get_lock_info_start(&op, RBD_LOCK_NAME);
-
-      bufferlist outbl;
-      int r = ioctx->operate(oid, &op, &outbl);
-      if (r < 0)
-	return r;
-
-      try {
-	bufferlist::iterator iter = outbl.begin();
-	uint8_t order;
-	// get_size
-	::decode(order, iter);
-	::decode(*size, iter);
-	// get_features
-	::decode(*features, iter);
-	::decode(*incompatible_features, iter);
-	// get_snapcontext
-	::decode(*snapc, iter);
-	// get_parent
-	::decode(parent->spec.pool_id, iter);
-	::decode(parent->spec.image_id, iter);
-	::decode(parent->spec.snap_id, iter);
-	::decode(parent->overlap, iter);
-
-	// get_lock_info
-	ClsLockType lock_type = LOCK_NONE;
-	r = rados::cls::lock::get_lock_info_finish(&iter, lockers, &lock_type,
-						   lock_tag);
-
-	// see comment in ictx_refresh().  Ugly conflation of
-	// EOPNOTSUPP and EIO.
-
-	if (r < 0 && ((r != -EOPNOTSUPP) && (r != -EIO)))
-	  return r;
-
-	*exclusive_lock = (lock_type == LOCK_EXCLUSIVE);
-      } catch (const buffer::error &err) {
-	return -EBADMSG;
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+        return r;
       }
 
-      return 0;
+      bufferlist::iterator it = out_bl.begin();
+      return get_mutable_metadata_finish(&it, size, features,
+                                         incompatible_features, lockers,
+                                         exclusive_lock, lock_tag, snapc,
+                                         parent);
     }
 
     int create_image(librados::IoCtx *ioctx, const std::string &oid,
@@ -350,40 +284,50 @@ struct C_ObjectMapLoad : public Context {
       return ioctx->exec(oid, "rbd", "set_parent", inbl, outbl);
     }
 
-    int get_flags(librados::IoCtx *ioctx, const std::string &oid,
-		  uint64_t *flags, const std::vector<snapid_t> &snap_ids,
-		  vector<uint64_t> *snap_flags)
-    {
-      bufferlist inbl;
-      ::encode(static_cast<snapid_t>(CEPH_NOSNAP), inbl);
+    void get_flags_start(librados::ObjectReadOperation *op,
+                         const std::vector<snapid_t> &snap_ids) {
+      bufferlist in_bl;
+      ::encode(static_cast<snapid_t>(CEPH_NOSNAP), in_bl);
 
-      librados::ObjectReadOperation op;
-      op.exec("rbd", "get_flags", inbl);
+      op->exec("rbd", "get_flags", in_bl);
       for (size_t i = 0; i < snap_ids.size(); ++i) {
-	bufferlist snapbl;
-	::encode(snap_ids[i], snapbl);
-	op.exec("rbd", "get_flags", snapbl);
+        bufferlist snap_bl;
+        ::encode(snap_ids[i], snap_bl);
+        op->exec("rbd", "get_flags", snap_bl);
       }
 
-      snap_flags->clear();
+    }
+
+    int get_flags_finish(bufferlist::iterator *it, uint64_t *flags,
+                         const std::vector<snapid_t> &snap_ids,
+                         std::vector<uint64_t> *snap_flags) {
       snap_flags->resize(snap_ids.size());
-
-      bufferlist outbl;
-      int r = ioctx->operate(oid, &op, &outbl);
-      if (r < 0) {
-        return r;
-      }
-
       try {
-        bufferlist::iterator iter = outbl.begin();
-        ::decode(*flags, iter);
-	for (size_t i = 0; i < snap_ids.size(); ++i) {
-	  ::decode((*snap_flags)[i], iter);
+        ::decode(*flags, *it);
+	for (size_t i = 0; i < snap_flags->size(); ++i) {
+	  ::decode((*snap_flags)[i], *it);
 	}
       } catch (const buffer::error &err) {
         return -EBADMSG;
       }
       return 0;
+    }
+
+    int get_flags(librados::IoCtx *ioctx, const std::string &oid,
+		  uint64_t *flags, const std::vector<snapid_t> &snap_ids,
+		  vector<uint64_t> *snap_flags)
+    {
+      librados::ObjectReadOperation op;
+      get_flags_start(&op, snap_ids);
+
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+        return r;
+      }
+
+      bufferlist::iterator it = out_bl.begin();
+      return get_flags_finish(&it, flags, snap_ids, snap_flags);
     }
 
     void set_flags(librados::ObjectWriteOperation *op, snapid_t snap_id,
@@ -440,20 +384,39 @@ struct C_ObjectMapLoad : public Context {
       return ioctx->operate(oid, &op);
     }
 
+    void get_children_start(librados::ObjectReadOperation *op,
+                            const parent_spec &pspec) {
+      bufferlist in_bl;
+      ::encode(pspec.pool_id, in_bl);
+      ::encode(pspec.image_id, in_bl);
+      ::encode(pspec.snap_id, in_bl);
+      op->exec("rbd", "get_children", in_bl);
+    }
+
+    int get_children_finish(bufferlist::iterator *it,
+                            std::set<std::string>* children) {
+      try {
+        ::decode(*children, *it);
+      } catch (const buffer::error &err) {
+        return -EBADMSG;
+      }
+      return 0;
+    }
+
     int get_children(librados::IoCtx *ioctx, const std::string &oid,
 		     parent_spec pspec, set<string>& children)
     {
-      C_SaferCond cond_ctx;
-      get_children(ioctx, oid, pspec, &children, &cond_ctx);
-      return cond_ctx.wait();
-    }
+      librados::ObjectReadOperation op;
+      get_children_start(&op, pspec);
 
-    void get_children(librados::IoCtx *ioctx, const std::string &oid,
-                      const parent_spec &pspec, std::set<string> *children,
-                      Context *on_finish) {
-      C_GetChildren *req = new C_GetChildren(ioctx, oid, pspec, children,
-                                             on_finish);
-      req->send();
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+        return r;
+      }
+
+      bufferlist::iterator it = out_bl.begin();
+      return get_children_finish(&it, &children);
     }
 
     void snapshot_add(librados::ObjectWriteOperation *op, snapid_t snap_id,
@@ -504,6 +467,55 @@ struct C_ObjectMapLoad : public Context {
       return 0;
     }
 
+    void snapshot_list_start(librados::ObjectReadOperation *op,
+                             const std::vector<snapid_t> &ids) {
+      for (vector<snapid_t>::const_iterator it = ids.begin();
+           it != ids.end(); ++it) {
+        snapid_t snap_id = it->val;
+        bufferlist bl1, bl2, bl3, bl4;
+        ::encode(snap_id, bl1);
+        op->exec("rbd", "get_snapshot_name", bl1);
+        ::encode(snap_id, bl2);
+        op->exec("rbd", "get_size", bl2);
+        ::encode(snap_id, bl3);
+        op->exec("rbd", "get_parent", bl3);
+        ::encode(snap_id, bl4);
+        op->exec("rbd", "get_protection_status", bl4);
+      }
+    }
+
+    int snapshot_list_finish(bufferlist::iterator *it,
+                             const std::vector<snapid_t> &ids,
+                             std::vector<string> *names,
+                             std::vector<uint64_t> *sizes,
+                             std::vector<parent_info> *parents,
+                             std::vector<uint8_t> *protection_statuses) {
+      names->resize(ids.size());
+      sizes->resize(ids.size());
+      parents->resize(ids.size());
+      protection_statuses->resize(ids.size());
+      try {
+	for (size_t i = 0; i < names->size(); ++i) {
+	  uint8_t order;
+	  // get_snapshot_name
+	  ::decode((*names)[i], *it);
+	  // get_size
+	  ::decode(order, *it);
+	  ::decode((*sizes)[i], *it);
+	  // get_parent
+	  ::decode((*parents)[i].spec.pool_id, *it);
+	  ::decode((*parents)[i].spec.image_id, *it);
+	  ::decode((*parents)[i].spec.snap_id, *it);
+	  ::decode((*parents)[i].overlap, *it);
+	  // get_protection_status
+	  ::decode((*protection_statuses)[i], *it);
+	}
+      } catch (const buffer::error &err) {
+        return -EBADMSG;
+      }
+      return 0;
+    }
+
     int snapshot_list(librados::IoCtx *ioctx, const std::string &oid,
 		      const std::vector<snapid_t> &ids,
 		      std::vector<string> *names,
@@ -511,57 +523,18 @@ struct C_ObjectMapLoad : public Context {
 		      std::vector<parent_info> *parents,
 		      std::vector<uint8_t> *protection_statuses)
     {
-      names->clear();
-      names->resize(ids.size());
-      sizes->clear();
-      sizes->resize(ids.size());
-      parents->clear();
-      parents->resize(ids.size());
-      protection_statuses->clear();
-      protection_statuses->resize(ids.size());
-
       librados::ObjectReadOperation op;
-      for (vector<snapid_t>::const_iterator it = ids.begin();
-	   it != ids.end(); ++it) {
-	snapid_t snap_id = it->val;
-	bufferlist bl1, bl2, bl3, bl4;
-	::encode(snap_id, bl1);
-	op.exec("rbd", "get_snapshot_name", bl1);
-	::encode(snap_id, bl2);
-	op.exec("rbd", "get_size", bl2);
-	::encode(snap_id, bl3);
-	op.exec("rbd", "get_parent", bl3);
-	::encode(snap_id, bl4);
-	op.exec("rbd", "get_protection_status", bl4);
+      snapshot_list_start(&op, ids);
+
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+        return r;
       }
 
-      bufferlist outbl;
-      int r = ioctx->operate(oid, &op, &outbl);
-      if (r < 0)
-	return r;
-
-      try {
-	bufferlist::iterator iter = outbl.begin();
-	for (size_t i = 0; i < ids.size(); ++i) {
-	  uint8_t order;
-	  // get_snapshot_name
-	  ::decode((*names)[i], iter);
-	  // get_size
-	  ::decode(order, iter);
-	  ::decode((*sizes)[i], iter);
-	  // get_parent
-	  ::decode((*parents)[i].spec.pool_id, iter);
-	  ::decode((*parents)[i].spec.image_id, iter);
-	  ::decode((*parents)[i].spec.snap_id, iter);
-	  ::decode((*parents)[i].overlap, iter);
-	  // get_protection_status
-	  ::decode((*protection_statuses)[i], iter);
-	}
-      } catch (const buffer::error &err) {
-	return -EBADMSG;
-      }
-
-      return 0;
+      bufferlist::iterator it = out_bl.begin();
+      return snapshot_list_finish(&it, ids, names, sizes, parents,
+                                  protection_statuses);
     }
 
     void old_snapshot_add(librados::ObjectWriteOperation *op,
@@ -590,36 +563,50 @@ struct C_ObjectMapLoad : public Context {
       op->exec("rbd", "snap_rename", bl);
     }
 
+    void old_snapshot_list_start(librados::ObjectReadOperation *op) {
+      bufferlist in_bl;
+      op->exec("rbd", "snap_list", in_bl);
+    }
+
+    int old_snapshot_list_finish(bufferlist::iterator *it,
+                                 std::vector<string> *names,
+                                 std::vector<uint64_t> *sizes,
+                                 ::SnapContext *snapc) {
+      try {
+	uint32_t num_snaps;
+	::decode(snapc->seq, *it);
+	::decode(num_snaps, *it);
+
+	names->resize(num_snaps);
+	sizes->resize(num_snaps);
+	snapc->snaps.resize(num_snaps);
+	for (uint32_t i = 0; i < num_snaps; ++i) {
+	  ::decode(snapc->snaps[i], *it);
+	  ::decode((*sizes)[i], *it);
+	  ::decode((*names)[i], *it);
+	}
+      } catch (const buffer::error &err) {
+        return -EBADMSG;
+      }
+      return 0;
+    }
+
     int old_snapshot_list(librados::IoCtx *ioctx, const std::string &oid,
 			  std::vector<string> *names,
 			  std::vector<uint64_t> *sizes,
 			  ::SnapContext *snapc)
     {
-      bufferlist bl, outbl;
-      int r = ioctx->exec(oid, "rbd", "snap_list", bl, outbl);
-      if (r < 0)
-	return r;
+      librados::ObjectReadOperation op;
+      old_snapshot_list_start(&op);
 
-      bufferlist::iterator iter = outbl.begin();
-      try {
-	uint32_t num_snaps;
-	::decode(snapc->seq, iter);
-	::decode(num_snaps, iter);
-
-	names->resize(num_snaps);
-	sizes->resize(num_snaps);
-	snapc->snaps.resize(num_snaps);
-
-	for (uint32_t i = 0; i < num_snaps; ++i) {
-	  ::decode(snapc->snaps[i], iter);
-	  ::decode((*sizes)[i], iter);
-	  ::decode((*names)[i], iter);
-	}
-      } catch (const buffer::error &err) {
-	return -EBADMSG;
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+        return r;
       }
 
-      return 0;
+      bufferlist::iterator it = out_bl.begin();
+      return old_snapshot_list_finish(&it, names, sizes, snapc);
     }
 
     int copyup(librados::IoCtx *ioctx, const std::string &oid,
@@ -666,30 +653,40 @@ struct C_ObjectMapLoad : public Context {
       op->exec("rbd", "set_protection_status", in);
     }
 
-    int get_stripe_unit_count(librados::IoCtx *ioctx, const std::string &oid,
-			      uint64_t *stripe_unit, uint64_t *stripe_count)
-    {
+    void get_stripe_unit_count_start(librados::ObjectReadOperation *op) {
+      bufferlist empty_bl;
+      op->exec("rbd", "get_stripe_unit_count", empty_bl);
+    }
+
+    int get_stripe_unit_count_finish(bufferlist::iterator *it,
+                                     uint64_t *stripe_unit,
+                                     uint64_t *stripe_count) {
       assert(stripe_unit);
       assert(stripe_count);
 
-      librados::ObjectReadOperation op;
-      bufferlist empty;
-      op.exec("rbd", "get_stripe_unit_count", empty);
-
-      bufferlist outbl;
-      int r = ioctx->operate(oid, &op, &outbl);
-      if (r < 0)
-	return r;
-
       try {
-	bufferlist::iterator iter = outbl.begin();
-	::decode(*stripe_unit, iter);
-	::decode(*stripe_count, iter);
+	::decode(*stripe_unit, *it);
+	::decode(*stripe_count, *it);
       } catch (const buffer::error &err) {
 	return -EBADMSG;
       }
-
       return 0;
+    }
+
+    int get_stripe_unit_count(librados::IoCtx *ioctx, const std::string &oid,
+			      uint64_t *stripe_unit, uint64_t *stripe_count)
+    {
+      librados::ObjectReadOperation op;
+      get_stripe_unit_count_start(&op);
+
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+        return r;
+      }
+
+      bufferlist::iterator it = out_bl.begin();
+      return get_stripe_unit_count_finish(&it, stripe_unit, stripe_count);
     }
 
     int set_stripe_unit_count(librados::IoCtx *ioctx, const std::string &oid,
@@ -704,21 +701,33 @@ struct C_ObjectMapLoad : public Context {
 
     /************************ rbd_id object methods ************************/
 
-    int get_id(librados::IoCtx *ioctx, const std::string &oid, std::string *id)
-    {
-      bufferlist in, out;
-      int r = ioctx->exec(oid, "rbd", "get_id", in, out);
-      if (r < 0)
-	return r;
+    void get_id_start(librados::ObjectReadOperation *op) {
+      bufferlist empty_bl;
+      op->exec("rbd", "get_id", empty_bl);
+    }
 
-      bufferlist::iterator iter = out.begin();
+    int get_id_finish(bufferlist::iterator *it, std::string *id) {
       try {
-	::decode(*id, iter);
+	::decode(*id, *it);
       } catch (const buffer::error &err) {
 	return -EBADMSG;
       }
-
       return 0;
+    }
+
+    int get_id(librados::IoCtx *ioctx, const std::string &oid, std::string *id)
+    {
+      librados::ObjectReadOperation op;
+      get_id_start(&op);
+
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+        return r;
+      }
+
+      bufferlist::iterator it = out_bl.begin();
+      return get_id_finish(&it, id);
     }
 
     int set_id(librados::IoCtx *ioctx, const std::string &oid, std::string id)
@@ -818,32 +827,35 @@ struct C_ObjectMapLoad : public Context {
       op->exec("rbd", "dir_rename_image", in);
     }
 
-    int object_map_load(librados::IoCtx *ioctx, const std::string &oid,
-			ceph::BitVector<2> *object_map)
-    {
-      // TODO eliminate sync version
-      bufferlist in;
-      bufferlist out;
-      int r = ioctx->exec(oid, "rbd", "object_map_load", in, out);
-      if (r < 0) {
-	return r;
-      }
+    void object_map_load_start(librados::ObjectReadOperation *op) {
+      bufferlist in_bl;
+      op->exec("rbd", "object_map_load", in_bl);
+    }
 
+    int object_map_load_finish(bufferlist::iterator *it,
+                               ceph::BitVector<2> *object_map) {
       try {
-        bufferlist::iterator iter = out.begin();
-        ::decode(*object_map, iter);
+        ::decode(*object_map, *it);
       } catch (const buffer::error &err) {
         return -EBADMSG;
       }
       return 0;
     }
 
-    void object_map_load(librados::IoCtx *ioctx, const std::string &oid,
-                         ceph::BitVector<2> *object_map, Context *on_finish)
+    int object_map_load(librados::IoCtx *ioctx, const std::string &oid,
+			ceph::BitVector<2> *object_map)
     {
-      C_ObjectMapLoad *req = new C_ObjectMapLoad(ioctx, oid, object_map,
-                                                 on_finish);
-      req->send();
+      librados::ObjectReadOperation op;
+      object_map_load_start(&op);
+
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+	return r;
+      }
+
+      bufferlist::iterator it = out_bl.begin();
+      return object_map_load_finish(&it, object_map);
     }
 
     void object_map_save(librados::ObjectWriteOperation *rados_op,

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -20,8 +20,22 @@ class Context;
 namespace librbd {
   namespace cls_client {
     // high-level interface to the header
+    void get_immutable_metadata_start(librados::ObjectReadOperation *op);
+    int get_immutable_metadata_finish(bufferlist::iterator *it,
+                                      std::string *object_prefix,
+                                      uint8_t *order);
     int get_immutable_metadata(librados::IoCtx *ioctx, const std::string &oid,
 			       std::string *object_prefix, uint8_t *order);
+
+    void get_mutable_metadata_start(librados::ObjectReadOperation *op,
+                                    bool read_only);
+    int get_mutable_metadata_finish(bufferlist::iterator *it,
+                                    uint64_t *size, uint64_t *features,
+                                    uint64_t *incompatible_features,
+                                    std::map<rados::cls::lock::locker_id_t,
+                                             rados::cls::lock::locker_info_t> *lockers,
+                                    bool *exclusive_lock, std::string *lock_tag,
+                                    ::SnapContext *snapc, parent_info *parent);
     int get_mutable_metadata(librados::IoCtx *ioctx, const std::string &oid,
 			     bool read_only, uint64_t *size, uint64_t *features,
 			     uint64_t *incompatible_features,
@@ -52,6 +66,11 @@ namespace librbd {
 		   uint64_t *parent_overlap);
     int set_parent(librados::IoCtx *ioctx, const std::string &oid,
 		   parent_spec pspec, uint64_t parent_overlap);
+    void get_flags_start(librados::ObjectReadOperation *op,
+                         const std::vector<snapid_t> &snap_ids);
+    int get_flags_finish(bufferlist::iterator *it, uint64_t *flags,
+                         const std::vector<snapid_t> &snap_ids,
+                         std::vector<uint64_t> *snap_flags);
     int get_flags(librados::IoCtx *ioctx, const std::string &oid,
 		  uint64_t *flags, const std::vector<snapid_t> &snap_ids,
 		  vector<uint64_t> *snap_flags);
@@ -65,11 +84,12 @@ namespace librbd {
 		      parent_spec pspec, const std::string &c_imageid);
     int remove_child(librados::IoCtx *ioctx, const std::string &oid,
 		     parent_spec pspec, const std::string &c_imageid);
+    void get_children_start(librados::ObjectReadOperation *op,
+                            const parent_spec &pspec);
+    int get_children_finish(bufferlist::iterator *it,
+                            std::set<string> *children);
     int get_children(librados::IoCtx *ioctx, const std::string &oid,
                       parent_spec pspec, set<string>& children);
-    void get_children(librados::IoCtx *ioctx, const std::string &oid,
-                      const parent_spec &pspec, std::set<string> *children,
-                      Context *on_finish);
     void snapshot_add(librados::ObjectWriteOperation *op, snapid_t snap_id,
 		      const std::string &snap_name);
     void snapshot_remove(librados::ObjectWriteOperation *op, snapid_t snap_id);
@@ -78,12 +98,22 @@ namespace librbd {
 			const std::string &dst_name);
     int get_snapcontext(librados::IoCtx *ioctx, const std::string &oid,
 			::SnapContext *snapc);
+
+    void snapshot_list_start(librados::ObjectReadOperation *op,
+                             const std::vector<snapid_t> &ids);
+    int snapshot_list_finish(bufferlist::iterator *it,
+                             const std::vector<snapid_t> &ids,
+                             std::vector<string> *names,
+                             std::vector<uint64_t> *sizes,
+                             std::vector<parent_info> *parents,
+                             std::vector<uint8_t> *protection_statuses);
     int snapshot_list(librados::IoCtx *ioctx, const std::string &oid,
 		      const std::vector<snapid_t> &ids,
 		      std::vector<string> *names,
 		      std::vector<uint64_t> *sizes,
 		      std::vector<parent_info> *parents,
 		      std::vector<uint8_t> *protection_statuses);
+
     int copyup(librados::IoCtx *ioctx, const std::string &oid,
 	       bufferlist data);
     int get_protection_status(librados::IoCtx *ioctx, const std::string &oid,
@@ -92,8 +122,14 @@ namespace librbd {
 			      snapid_t snap_id, uint8_t protection_status);
     void set_protection_status(librados::ObjectWriteOperation *op,
                                snapid_t snap_id, uint8_t protection_status);
+
+    void get_stripe_unit_count_start(librados::ObjectReadOperation *op);
+    int get_stripe_unit_count_finish(bufferlist::iterator *it,
+                                     uint64_t *stripe_unit,
+                                     uint64_t *stripe_count);
     int get_stripe_unit_count(librados::IoCtx *ioctx, const std::string &oid,
 			      uint64_t *stripe_unit, uint64_t *stripe_count);
+
     int set_stripe_unit_count(librados::IoCtx *ioctx, const std::string &oid,
 			      uint64_t stripe_unit, uint64_t stripe_count);
     int metadata_list(librados::IoCtx *ioctx, const std::string &oid,
@@ -107,7 +143,10 @@ namespace librbd {
                      const std::string &key, string *v);
 
     // operations on rbd_id objects
+    void get_id_start(librados::ObjectReadOperation *op);
+    int get_id_finish(bufferlist::iterator *it, std::string *id);
     int get_id(librados::IoCtx *ioctx, const std::string &oid, std::string *id);
+
     int set_id(librados::IoCtx *ioctx, const std::string &oid, std::string id);
 
     // operations on rbd_directory objects
@@ -128,10 +167,11 @@ namespace librbd {
 			  const std::string &id);
 
     // operations on the rbd_object_map.$image_id object
+    void object_map_load_start(librados::ObjectReadOperation *op);
+    int object_map_load_finish(bufferlist::iterator *it,
+                               ceph::BitVector<2> *object_map);
     int object_map_load(librados::IoCtx *ioctx, const std::string &oid,
 		        ceph::BitVector<2> *object_map);
-    void object_map_load(librados::IoCtx *ioctx, const std::string &oid,
-                         ceph::BitVector<2> *object_map, Context *on_finish);
     void object_map_save(librados::ObjectWriteOperation *rados_op,
                          const ceph::BitVector<2> &object_map);
     void object_map_resize(librados::ObjectWriteOperation *rados_op,
@@ -152,6 +192,12 @@ namespace librbd {
 			    const std::string &snap_name);
     void old_snapshot_rename(librados::ObjectWriteOperation *rados_op,
 			     snapid_t src_snap_id, const std::string &dst_name);
+
+    void old_snapshot_list_start(librados::ObjectReadOperation *op);
+    int old_snapshot_list_finish(bufferlist::iterator *it,
+                                 std::vector<string> *names,
+                                 std::vector<uint64_t> *sizes,
+                                 ::SnapContext *snapc);
     int old_snapshot_list(librados::IoCtx *ioctx, const std::string &oid,
 			  std::vector<string> *names,
 			  std::vector<uint64_t> *sizes,

--- a/src/common/Readahead.h
+++ b/src/common/Readahead.h
@@ -6,6 +6,7 @@
 
 #include "Mutex.h"
 #include "Cond.h"
+#include <list>
 
 /**
    This class provides common state and logic for code that needs to perform readahead
@@ -70,6 +71,7 @@ public:
      Waits until the pending count reaches 0.
    */
   void wait_for_pending();
+  void wait_for_pending(Context *ctx);
 
   /**
      Sets the number of sequential requests necessary to trigger readahead.
@@ -146,8 +148,8 @@ private:
   /// Lock for m_pending
   Mutex m_pending_lock;
 
-  /// Signalled when m_pending reaches 0
-  Cond m_pending_cond;
+  /// Waiters for pending readahead
+  std::list<Context *> m_pending_waiting;
 };
 
 #endif

--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -411,6 +411,10 @@ public:
     }
 
     virtual void process(T *item) = 0;
+    void process_finish() {
+      Mutex::Locker locker(m_pool->_lock);
+      _void_process_finish(nullptr);
+    }
 
     T *front() {
       assert(m_pool->_lock.is_locked());
@@ -422,6 +426,9 @@ public:
     void signal() {
       Mutex::Locker pool_locker(m_pool->_lock);
       m_pool->_cond.SignalOne();
+    }
+    Mutex &get_pool_lock() {
+      return m_pool->_lock;
     }
   private:
     ThreadPool *m_pool;

--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -117,13 +117,12 @@ void AioImageRequest::send() {
                  << "completion=" << m_aio_comp <<  dendl;
 
   m_aio_comp->get();
-  int r = m_image_ctx.state->refresh_if_required(m_image_ctx.owner_lock);
-  if (r < 0) {
-    m_aio_comp->fail(cct, r);
-    return;
-  }
-
   send_request();
+}
+
+void AioImageRequest::fail(int r) {
+  m_aio_comp->get();
+  m_aio_comp->fail(m_image_ctx.cct, r);
 }
 
 void AioImageRead::send_request() {

--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -4,6 +4,7 @@
 #include "librbd/AioImageRequest.h"
 #include "librbd/AioCompletion.h"
 #include "librbd/AioObjectRequest.h"
+#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageWatcher.h"
 #include "librbd/internal.h"
@@ -247,8 +248,8 @@ void AbstractAioImageWrite::send_request() {
                   !m_image_ctx.journal->is_journal_replaying());
   }
 
-  assert(!m_image_ctx.image_watcher->is_lock_supported() ||
-          m_image_ctx.image_watcher->is_lock_owner());
+  assert(m_image_ctx.exclusive_lock == nullptr ||
+         m_image_ctx.exclusive_lock->is_lock_owner());
 
   m_aio_comp->set_request_count(
     m_image_ctx.cct, object_extents.size() +

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -40,6 +40,7 @@ public:
   }
 
   void send();
+  void fail(int r);
 
 protected:
   typedef std::list<AioObjectRequest *> AioObjectRequests;

--- a/src/librbd/AioImageRequestWQ.cc
+++ b/src/librbd/AioImageRequestWQ.cc
@@ -34,7 +34,7 @@ ssize_t AioImageRequestWQ::read(uint64_t off, uint64_t len, char *buf,
   image_extents.push_back(make_pair(off, len));
 
   C_SaferCond cond;
-  AioCompletion *c = aio_create_completion_internal(&cond, rbd_ctx_cb);
+  AioCompletion *c = AioCompletion::create(&cond);
   aio_read(c, off, len, buf, NULL, op_flags, false);
   return cond.wait();
 }
@@ -53,7 +53,7 @@ ssize_t AioImageRequestWQ::write(uint64_t off, uint64_t len, const char *buf,
   }
 
   C_SaferCond cond;
-  AioCompletion *c = aio_create_completion_internal(&cond, rbd_ctx_cb);
+  AioCompletion *c = AioCompletion::create(&cond);
   aio_write(c, off, len, buf, op_flags, false);
 
   r = cond.wait();
@@ -76,7 +76,7 @@ int AioImageRequestWQ::discard(uint64_t off, uint64_t len) {
   }
 
   C_SaferCond cond;
-  AioCompletion *c = aio_create_completion_internal(&cond, rbd_ctx_cb);
+  AioCompletion *c = AioCompletion::create(&cond);
   aio_discard(c, off, len, false);
 
   r = cond.wait();

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -9,6 +9,7 @@
 
 #include "librbd/AioCompletion.h"
 #include "librbd/AioImageRequest.h"
+#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageWatcher.h"
 #include "librbd/internal.h"
@@ -387,7 +388,7 @@ namespace librbd {
         write = true;
       } else {
         // should have been flushed prior to releasing lock
-        assert(m_ictx->image_watcher->is_lock_owner());
+        assert(m_ictx->exclusive_lock->is_lock_owner());
 
         ldout(m_ictx->cct, 20) << "send_pre " << this << " " << m_oid << " "
           		       << m_object_off << "~" << m_object_len << dendl;
@@ -424,7 +425,7 @@ namespace librbd {
     }
 
     // should have been flushed prior to releasing lock
-    assert(m_ictx->image_watcher->is_lock_owner());
+    assert(m_ictx->exclusive_lock->is_lock_owner());
 
     ldout(m_ictx->cct, 20) << "send_post " << this << " " << m_oid << " "
 			   << m_object_off << "~" << m_object_len << dendl;

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -103,14 +103,6 @@ namespace librbd {
     guard_read();
   }
 
-  AioObjectRead::~AioObjectRead()
-  {
-    if (m_parent_completion) {
-      m_parent_completion->release();
-      m_parent_completion = NULL;
-    }
-  }
-
   void AioObjectRead::guard_read()
   {
     RWLock::RLocker snap_locker(m_ictx->snap_lock);
@@ -262,7 +254,7 @@ namespace librbd {
   void AioObjectRead::read_from_parent(const vector<pair<uint64_t,uint64_t> >& parent_extents)
   {
     assert(!m_parent_completion);
-    m_parent_completion = aio_create_completion_internal(this, rbd_req_cb);
+    m_parent_completion = AioCompletion::create<AioObjectRequest>(this);
 
     // prevent the parent image from being deleted while this
     // request is still in-progress

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -11,6 +11,7 @@
 #include "include/buffer.h"
 #include "include/Context.h"
 #include "include/rados/librados.hpp"
+#include "include/rbd/librbd.hpp"
 #include "librbd/ObjectMap.h"
 
 namespace librbd {
@@ -63,7 +64,6 @@ namespace librbd {
 	          vector<pair<uint64_t,uint64_t> >& be,
 	          librados::snap_t snap_id, bool sparse,
 	          Context *completion, int op_flags);
-    virtual ~AioObjectRead();
 
     virtual bool should_complete(int r);
     virtual void send();
@@ -110,6 +110,7 @@ namespace librbd {
     read_state_d m_state;
 
     void send_copyup();
+
     void read_from_parent(const vector<pair<uint64_t,uint64_t> >& image_extents);
   };
 

--- a/src/librbd/AsyncObjectThrottle.cc
+++ b/src/librbd/AsyncObjectThrottle.cc
@@ -7,6 +7,7 @@
 #include "librbd/AsyncRequest.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/internal.h"
+#include "librbd/Utils.h"
 
 namespace librbd
 {
@@ -16,7 +17,7 @@ AsyncObjectThrottle<T>::AsyncObjectThrottle(
     const AsyncRequest<T>* async_request, T &image_ctx,
     const ContextFactory& context_factory, Context *ctx,
     ProgressContext *prog_ctx, uint64_t object_no, uint64_t end_object_no)
-  : m_lock(unique_lock_name("librbd::AsyncThrottle::m_lock", this)),
+  : m_lock(util::unique_lock_name("librbd::AsyncThrottle::m_lock", this)),
     m_async_request(async_request), m_image_ctx(image_ctx),
     m_context_factory(context_factory), m_ctx(ctx), m_prog_ctx(prog_ctx),
     m_object_no(object_no), m_end_object_no(end_object_no), m_current_ops(0),

--- a/src/librbd/AsyncOperation.cc
+++ b/src/librbd/AsyncOperation.cc
@@ -46,6 +46,7 @@ void AsyncOperation::start_op(ImageCtx &image_ctx) {
 
 void AsyncOperation::finish_op() {
   ldout(m_image_ctx->cct, 20) << this << " " << __func__ << dendl;
+
   {
     Mutex::Locker l(m_image_ctx->async_ops_lock);
     xlist<AsyncOperation *>::iterator iter(&m_xlist_item);

--- a/src/librbd/AsyncRequest.cc
+++ b/src/librbd/AsyncRequest.cc
@@ -3,6 +3,7 @@
 #include "librbd/AsyncRequest.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/internal.h"
+#include "librbd/Utils.h"
 #include "common/WorkQueue.h"
 #include <boost/bind.hpp>
 
@@ -28,19 +29,18 @@ void AsyncRequest<T>::async_complete(int r) {
 
 template <typename T>
 librados::AioCompletion *AsyncRequest<T>::create_callback_completion() {
-  return librados::Rados::aio_create_completion(create_callback_context(),
-						NULL, rados_ctx_cb);
+  return util::create_rados_safe_callback(this);
 }
 
 template <typename T>
 Context *AsyncRequest<T>::create_callback_context() {
-  return new FunctionContext(boost::bind(&AsyncRequest<T>::complete, this, _1));
+  return util::create_context_callback(this);
 }
 
 template <typename T>
 Context *AsyncRequest<T>::create_async_callback_context() {
-  return new FunctionContext(boost::bind(&AsyncRequest<T>::async_complete, this,
-                                         _1));;
+  return util::create_context_callback<AsyncRequest<T>,
+                                       &AsyncRequest<T>::async_complete>(this);
 }
 
 template <typename T>

--- a/src/librbd/CopyupRequest.cc
+++ b/src/librbd/CopyupRequest.cc
@@ -177,8 +177,7 @@ private:
   void CopyupRequest::send()
   {
     m_state = STATE_READ_FROM_PARENT;
-    AioCompletion *comp = aio_create_completion_internal(
-      util::create_context_callback(this), rbd_ctx_cb);
+    AioCompletion *comp = AioCompletion::create(this);
 
     ldout(m_ictx->cct, 20) << __func__ << " " << this
                            << ": completion " << comp

--- a/src/librbd/CopyupRequest.h
+++ b/src/librbd/CopyupRequest.h
@@ -25,6 +25,8 @@ namespace librbd {
     void send();
     void queue_send();
 
+    void complete(int r);
+
   private:
     /**
      * Copyup requests go through the following state machine to read from the
@@ -74,15 +76,12 @@ namespace librbd {
 
     void complete_requests(int r);
 
-    void complete(int r);
     bool should_complete(int r);
 
     void remove_from_list();
 
     bool send_object_map();
     bool send_copyup();
-
-    Context *create_callback_context();
   };
 }
 

--- a/src/librbd/DiffIterate.cc
+++ b/src/librbd/DiffIterate.cc
@@ -4,6 +4,7 @@
 #include "librbd/DiffIterate.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/internal.h"
+#include "librbd/Utils.h"
 #include "include/rados/librados.hpp"
 #include "include/interval_set.h"
 #include "common/errno.h"
@@ -61,7 +62,7 @@ public:
   void send() {
     C_OrderedThrottle *ctx = m_diff_context.throttle.start_op(this);
     librados::AioCompletion *rados_completion =
-      librados::Rados::aio_create_completion(ctx, NULL, rados_ctx_cb);
+      util::create_rados_safe_callback(ctx);
 
     librados::ObjectReadOperation op;
     op.list_snaps(&m_snap_set, &m_snap_ret);

--- a/src/librbd/DiffIterate.cc
+++ b/src/librbd/DiffIterate.cc
@@ -4,6 +4,7 @@
 #include "librbd/DiffIterate.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/internal.h"
+#include "librbd/ObjectMap.h"
 #include "librbd/Utils.h"
 #include "include/rados/librados.hpp"
 #include "include/interval_set.h"

--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -1,0 +1,417 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/ExclusiveLock.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/AioImageRequestWQ.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageWatcher.h"
+#include "librbd/Utils.h"
+#include "librbd/exclusive_lock/AcquireRequest.h"
+#include "librbd/exclusive_lock/ReleaseRequest.h"
+#include <sstream>
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::ExclusiveLock: "
+
+namespace librbd {
+
+using namespace exclusive_lock;
+
+namespace {
+
+const std::string WATCHER_LOCK_COOKIE_PREFIX = "auto";
+
+} // anonymous namespace
+
+template <typename I>
+const std::string ExclusiveLock<I>::WATCHER_LOCK_TAG("internal");
+
+template <typename I>
+ExclusiveLock<I>::ExclusiveLock(I &image_ctx)
+  : m_image_ctx(image_ctx),
+    m_lock(util::unique_lock_name("librbd::ExclusiveLock::m_lock", this)),
+    m_state(STATE_UNINITIALIZED), m_watch_handle(0) {
+}
+
+template <typename I>
+ExclusiveLock<I>::~ExclusiveLock() {
+  assert(m_state == STATE_UNINITIALIZED || m_state == STATE_SHUTDOWN);
+}
+
+template <typename I>
+bool ExclusiveLock<I>::is_lock_owner() const {
+  ldout(m_image_ctx.cct, 20) << __func__ << dendl;
+  assert(m_image_ctx.owner_lock.is_locked());
+
+  Mutex::Locker locker(m_lock);
+  return (m_state == STATE_LOCKED);
+}
+
+template <typename I>
+void ExclusiveLock<I>::init(Context *on_init) {
+  ldout(m_image_ctx.cct, 10) << __func__ << dendl;
+
+  assert(m_image_ctx.owner_lock.is_wlocked());
+
+  Mutex::Locker locker(m_lock);
+  assert(m_state == STATE_UNINITIALIZED);
+  m_state = STATE_INITIALIZING;
+
+  m_image_ctx.aio_work_queue->block_writes(new C_InitComplete(this, on_init));
+}
+
+template <typename I>
+void ExclusiveLock<I>::shut_down(Context *on_shut_down) {
+  ldout(m_image_ctx.cct, 10) << __func__ << dendl;
+  assert(m_image_ctx.owner_lock.is_wlocked());
+
+  Mutex::Locker locker(m_lock);
+  assert(!is_shutdown());
+  execute_action(ACTION_SHUT_DOWN, on_shut_down);
+}
+
+template <typename I>
+void ExclusiveLock<I>::try_lock(Context *on_tried_lock) {
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_image_ctx.owner_lock.is_wlocked());
+    assert(!is_shutdown());
+
+    if (m_state != STATE_LOCKED || !m_actions_contexts.empty()) {
+      ldout(m_image_ctx.cct, 10) << __func__ << dendl;
+      execute_action(ACTION_TRY_LOCK, on_tried_lock);
+      return;
+    }
+  }
+
+  on_tried_lock->complete(0);
+}
+
+template <typename I>
+void ExclusiveLock<I>::request_lock(Context *on_locked) {
+  {
+    Mutex::Locker locker(m_lock);
+    assert(!is_shutdown());
+    assert(m_image_ctx.owner_lock.is_wlocked());
+
+    if (m_state != STATE_LOCKED || !m_actions_contexts.empty()) {
+      ldout(m_image_ctx.cct, 10) << __func__ << dendl;
+      execute_action(ACTION_REQUEST_LOCK, on_locked);
+      return;
+    }
+  }
+
+  if (on_locked != nullptr) {
+    on_locked->complete(0);
+  }
+}
+
+template <typename I>
+void ExclusiveLock<I>::release_lock(Context *on_released) {
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_image_ctx.owner_lock.is_wlocked());
+    assert(!is_shutdown());
+
+    if (m_state != STATE_UNLOCKED || !m_actions_contexts.empty()) {
+      ldout(m_image_ctx.cct, 10) << __func__ << dendl;
+      execute_action(ACTION_RELEASE_LOCK, on_released);
+      return;
+    }
+  }
+
+  on_released->complete(0);
+}
+
+template <typename I>
+void ExclusiveLock<I>::handle_lock_released() {
+  Mutex::Locker locker(m_lock);
+  if (m_state != STATE_WAITING_FOR_PEER) {
+    return;
+  }
+
+  ldout(m_image_ctx.cct, 10) << __func__ << dendl;
+  assert(get_active_action() == ACTION_REQUEST_LOCK);
+  execute_next_action();
+}
+
+template <typename I>
+void ExclusiveLock<I>::set_watch_handle(uint64_t watch_handle) {
+  Mutex::Locker locker(m_lock);
+  assert(m_watch_handle == 0 || watch_handle == 0);
+  m_watch_handle = watch_handle;
+}
+
+template <typename I>
+std::string ExclusiveLock<I>::encode_lock_cookie() const {
+  assert(m_lock.is_locked());
+
+  assert(m_watch_handle != 0);
+  std::ostringstream ss;
+  ss << WATCHER_LOCK_COOKIE_PREFIX << " " << m_watch_handle;
+  return ss.str();
+}
+
+template <typename I>
+bool ExclusiveLock<I>::decode_lock_cookie(const std::string &tag,
+                                          uint64_t *handle) {
+  std::string prefix;
+  std::istringstream ss(tag);
+  if (!(ss >> prefix >> *handle) || prefix != WATCHER_LOCK_COOKIE_PREFIX) {
+    return false;
+  }
+  return true;
+}
+
+template <typename I>
+bool ExclusiveLock<I>::is_transition_state() const {
+  switch (m_state) {
+  case STATE_INITIALIZING:
+  case STATE_ACQUIRING:
+  case STATE_WAITING_FOR_PEER:
+  case STATE_RELEASING:
+  case STATE_SHUTTING_DOWN:
+    return true;
+  case STATE_UNINITIALIZED:
+  case STATE_UNLOCKED:
+  case STATE_LOCKED:
+  case STATE_SHUTDOWN:
+    break;
+  }
+  return false;
+}
+
+template <typename I>
+void ExclusiveLock<I>::append_context(Action action, Context *ctx) {
+  assert(m_lock.is_locked());
+
+  for (auto &action_ctxs : m_actions_contexts) {
+    if (action == action_ctxs.first) {
+      if (ctx != nullptr) {
+        action_ctxs.second.push_back(ctx);
+      }
+      return;
+    }
+  }
+
+  Contexts contexts;
+  if (ctx != nullptr) {
+    contexts.push_back(ctx);
+  }
+  m_actions_contexts.push_back({action, std::move(contexts)});
+}
+
+template <typename I>
+void ExclusiveLock<I>::execute_action(Action action, Context *ctx) {
+  assert(m_lock.is_locked());
+
+  append_context(action, ctx);
+  if (!is_transition_state()) {
+    execute_next_action();
+  }
+}
+
+template <typename I>
+void ExclusiveLock<I>::execute_next_action() {
+  assert(m_lock.is_locked());
+  assert(!m_actions_contexts.empty());
+  switch (get_active_action()) {
+  case ACTION_TRY_LOCK:
+  case ACTION_REQUEST_LOCK:
+    send_acquire_lock();
+    break;
+  case ACTION_RELEASE_LOCK:
+    send_release_lock();
+    break;
+  case ACTION_SHUT_DOWN:
+    send_shutdown();
+    break;
+  default:
+    assert(false);
+    break;
+  }
+}
+
+template <typename I>
+typename ExclusiveLock<I>::Action ExclusiveLock<I>::get_active_action() const {
+  assert(m_lock.is_locked());
+  assert(!m_actions_contexts.empty());
+  return m_actions_contexts.front().first;
+}
+
+template <typename I>
+void ExclusiveLock<I>::complete_active_action(State next_state, int r) {
+  assert(m_lock.is_locked());
+  assert(!m_actions_contexts.empty());
+
+  ActionContexts action_contexts(std::move(m_actions_contexts.front()));
+  m_actions_contexts.pop_front();
+  m_state = next_state;
+
+  m_lock.Unlock();
+  for (auto ctx : action_contexts.second) {
+    ctx->complete(r);
+  }
+  m_lock.Lock();
+
+  if (!m_actions_contexts.empty()) {
+    execute_next_action();
+  }
+}
+
+template <typename I>
+bool ExclusiveLock<I>::is_shutdown() const {
+  assert(m_lock.is_locked());
+
+  return ((m_state == STATE_SHUTDOWN) ||
+          (!m_actions_contexts.empty() &&
+           m_actions_contexts.back().first == ACTION_SHUT_DOWN));
+}
+
+template <typename I>
+void ExclusiveLock<I>::handle_init_complete() {
+  ldout(m_image_ctx.cct, 10) << __func__ << dendl;
+
+  Mutex::Locker locker(m_lock);
+  m_state = STATE_UNLOCKED;
+}
+
+template <typename I>
+void ExclusiveLock<I>::send_acquire_lock() {
+  assert(m_lock.is_locked());
+  if (m_state == STATE_LOCKED) {
+    complete_active_action(STATE_LOCKED, 0);
+    return;
+  }
+
+  ldout(m_image_ctx.cct, 10) << __func__ << dendl;
+  m_state = STATE_ACQUIRING;
+
+  using el = ExclusiveLock<I>;
+  AcquireRequest<I>* req = AcquireRequest<I>::create(
+    m_image_ctx, encode_lock_cookie(),
+    util::create_context_callback<el, &el::handle_acquire_lock>(this));
+  req->send();
+}
+
+template <typename I>
+void ExclusiveLock<I>::handle_acquire_lock(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << r << dendl;
+
+  if (r == -EBUSY) {
+    ldout(cct, 5) << "unable to acquire exclusive lock" << dendl;
+  } else if (r < 0) {
+    lderr(cct) << "failed to acquire exclusive lock:" << cpp_strerror(r)
+               << dendl;
+  } else {
+    ldout(cct, 5) << "successfully acquired exclusive lock" << dendl;
+  }
+
+  {
+    m_lock.Lock();
+    Action action = get_active_action();
+    assert(action == ACTION_TRY_LOCK || action == ACTION_REQUEST_LOCK);
+    if (action == ACTION_REQUEST_LOCK && r < 0 && r != -EBLACKLISTED) {
+      m_state = STATE_WAITING_FOR_PEER;
+      m_lock.Unlock();
+
+      // request the lock from a peer
+      m_image_ctx.image_watcher->notify_request_lock();
+      return;
+    }
+    m_lock.Unlock();
+  }
+
+  State next_state = (r < 0 ? STATE_UNLOCKED : STATE_LOCKED);
+  if (r == -EAGAIN) {
+    r = 0;
+  }
+
+  Mutex::Locker locker(m_lock);
+  if (next_state == STATE_LOCKED) {
+    m_image_ctx.aio_work_queue->unblock_writes();
+  }
+  complete_active_action(next_state, r);
+}
+
+template <typename I>
+void ExclusiveLock<I>::send_release_lock() {
+  assert(m_lock.is_locked());
+  if (m_state == STATE_UNLOCKED) {
+    complete_active_action(STATE_UNLOCKED, 0);
+    return;
+  }
+
+  ldout(m_image_ctx.cct, 10) << __func__ << dendl;
+  m_state = STATE_RELEASING;
+
+  m_image_ctx.op_work_queue->queue(
+    new C_BlockWrites(m_image_ctx, new C_ReleaseBlockWrites(this)), 0);
+}
+
+template <typename I>
+void ExclusiveLock<I>::handle_release_blocked_writes(int r) {
+  if (r < 0) {
+    handle_release_lock(r);
+    return;
+  }
+
+  ldout(m_image_ctx.cct, 10) << __func__ << ": r=" << r << dendl;
+
+  Mutex::Locker locker(m_lock);
+  assert(m_state == STATE_RELEASING);
+
+  using el = ExclusiveLock<I>;
+  ReleaseRequest<I>* req = ReleaseRequest<I>::create(
+    m_image_ctx, encode_lock_cookie(),
+    util::create_context_callback<el, &el::handle_release_lock>(this));
+  req->send();
+}
+
+template <typename I>
+void ExclusiveLock<I>::handle_release_lock(int r) {
+  Mutex::Locker locker(m_lock);
+
+  ldout(m_image_ctx.cct, 10) << __func__ << ": r=" << r << dendl;
+
+  if (r < 0) {
+    m_image_ctx.aio_work_queue->unblock_writes();
+  }
+  complete_active_action(r < 0 ? STATE_LOCKED : STATE_UNLOCKED, r);
+}
+
+template <typename I>
+void ExclusiveLock<I>::send_shutdown() {
+  assert(m_lock.is_locked());
+  if (m_state == STATE_UNLOCKED) {
+    m_image_ctx.aio_work_queue->unblock_writes();
+    complete_active_action(STATE_SHUTDOWN, 0);
+    return;
+  }
+
+  ldout(m_image_ctx.cct, 10) << __func__ << dendl;
+  assert(m_state == STATE_LOCKED);
+  m_state = STATE_SHUTTING_DOWN;
+
+  using el = ExclusiveLock<I>;
+  ReleaseRequest<I>* req = ReleaseRequest<I>::create(
+    m_image_ctx, encode_lock_cookie(),
+    util::create_context_callback<el, &el::handle_shutdown>(this));
+  req->send();
+}
+
+template <typename I>
+void ExclusiveLock<I>::handle_shutdown(int r) {
+  Mutex::Locker locker(m_lock);
+  ldout(m_image_ctx.cct, 10) << __func__ << ": r=" << r << dendl;
+
+  complete_active_action(r == 0 ? STATE_SHUTDOWN : STATE_LOCKED, r);
+}
+
+} // namespace librbd
+
+template class librbd::ExclusiveLock<librbd::ImageCtx>;

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -21,6 +21,10 @@ class ExclusiveLock {
 public:
   static const std::string WATCHER_LOCK_TAG;
 
+  static ExclusiveLock *create(ImageCtxT &image_ctx) {
+    return new ExclusiveLock<ImageCtxT>(image_ctx);
+  }
+
   ExclusiveLock(ImageCtxT &image_ctx);
   ~ExclusiveLock();
 

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -1,0 +1,159 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_EXCLUSIVE_LOCK_H
+#define CEPH_LIBRBD_EXCLUSIVE_LOCK_H
+
+#include "include/int_types.h"
+#include "include/Context.h"
+#include "common/Mutex.h"
+#include "common/RWLock.h"
+#include <list>
+#include <string>
+#include <utility>
+
+namespace librbd {
+
+class ImageCtx;
+
+template <typename ImageCtxT = ImageCtx>
+class ExclusiveLock {
+public:
+  static const std::string WATCHER_LOCK_TAG;
+
+  ExclusiveLock(ImageCtxT &image_ctx);
+  ~ExclusiveLock();
+
+  bool is_lock_owner() const;
+
+  void init(Context *on_init);
+  void shut_down(Context *on_shutdown);
+
+  void try_lock(Context *on_tried_lock);
+  void request_lock(Context *on_locked);
+  void release_lock(Context *on_released);
+
+  void handle_lock_released();
+
+  void set_watch_handle(uint64_t watch_handle);
+  static bool decode_lock_cookie(const std::string &cookie, uint64_t *handle);
+
+private:
+
+  /**
+   * <start>                               WAITING_FOR_PEER -----------------\
+   *    |                                     ^                              |
+   *    |                                     *  (request_lock busy)         |
+   *    |                                     * * * * * * * * * * * *        |
+   *    |                                                           *        |
+   *    v            (init)            (try_lock/request_lock)      *        |
+   * UNINITIALIZED  -------> UNLOCKED ------------------------> ACQUIRING <--/
+   *                            ^                                   |
+   *                            |                                   |
+   *                            |          (release_lock)           v
+   *                         RELEASING <------------------------- LOCKED
+   *
+   * <UNLOCKED/LOCKED states>
+   *    |
+   *    |
+   *    v
+   * SHUTTING_DOWN ---> SHUTDOWN ---> <finish>
+   */
+  enum State {
+    STATE_UNINITIALIZED,
+    STATE_UNLOCKED,
+    STATE_LOCKED,
+    STATE_INITIALIZING,
+    STATE_ACQUIRING,
+    STATE_WAITING_FOR_PEER,
+    STATE_RELEASING,
+    STATE_SHUTTING_DOWN,
+    STATE_SHUTDOWN,
+  };
+
+  enum Action {
+    ACTION_TRY_LOCK,
+    ACTION_REQUEST_LOCK,
+    ACTION_RELEASE_LOCK,
+    ACTION_SHUT_DOWN
+  };
+
+  typedef std::list<Context *> Contexts;
+  typedef std::pair<Action, Contexts> ActionContexts;
+  typedef std::list<ActionContexts> ActionsContexts;
+
+  struct C_InitComplete : public Context {
+    ExclusiveLock *exclusive_lock;
+    Context *on_init;
+    C_InitComplete(ExclusiveLock *exclusive_lock, Context *on_init)
+      : exclusive_lock(exclusive_lock), on_init(on_init) {
+    }
+    virtual void finish(int r) override {
+      if (r == 0) {
+        exclusive_lock->handle_init_complete();
+      }
+      on_init->complete(r);
+    }
+  };
+
+  struct C_BlockWrites : public Context {
+    ImageCtxT &image_ctx;
+    Context *on_finish;
+    C_BlockWrites(ImageCtxT &image_ctx, Context *on_finish)
+      : image_ctx(image_ctx), on_finish(on_finish) {
+    }
+    virtual void finish(int r) override {
+      RWLock::RLocker owner_locker(image_ctx.owner_lock);
+      image_ctx.aio_work_queue->block_writes(on_finish);
+    }
+  };
+
+  struct C_ReleaseBlockWrites : public Context {
+    ExclusiveLock *exclusive_lock;
+    C_ReleaseBlockWrites(ExclusiveLock *exclusive_lock)
+      : exclusive_lock(exclusive_lock) {
+    }
+    virtual void finish(int r) override {
+      exclusive_lock->handle_release_blocked_writes(r);
+    }
+  };
+
+  ImageCtxT &m_image_ctx;
+
+  mutable Mutex m_lock;
+  State m_state;
+  uint64_t m_watch_handle;
+
+  ActionsContexts m_actions_contexts;
+
+  std::string encode_lock_cookie() const;
+
+  bool is_transition_state() const;
+
+  void append_context(Action action, Context *ctx);
+  void execute_action(Action action, Context *ctx);
+  void execute_next_action();
+
+  Action get_active_action() const;
+  void complete_active_action(State next_state, int r);
+
+  bool is_shutdown() const;
+
+  void handle_init_complete();
+
+  void send_acquire_lock();
+  void handle_acquire_lock(int r);
+
+  void send_release_lock();
+  void handle_release_blocked_writes(int r);
+  void handle_release_lock(int r);
+
+  void send_shutdown();
+  void handle_shutdown(int r);
+};
+
+} // namespace librbd
+
+extern template class librbd::ExclusiveLock<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_EXCLUSIVE_LOCK_H

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -886,7 +886,6 @@ struct C_InvalidateCache : public Context {
   int ImageCtx::register_watch() {
     assert(image_watcher == NULL);
     image_watcher = new ImageWatcher(*this);
-    aio_work_queue->register_lock_listener();
     return image_watcher->register_watch();
   }
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -165,7 +165,7 @@ struct C_InvalidateCache : public Context {
       readahead(),
       total_bytes_read(0), copyup_finisher(NULL),
       exclusive_lock(nullptr),
-      object_map(*this), object_map_ptr(nullptr), aio_work_queue(NULL), op_work_queue(NULL),
+      object_map(nullptr), aio_work_queue(NULL), op_work_queue(NULL),
       refresh_in_progress(false), asok_hook(new LibrbdAdminSocketHook(this))
   {
     md_ctx.dup(p);
@@ -483,7 +483,6 @@ struct C_InvalidateCache : public Context {
       snap_name = in_snap_name;
       snap_exists = true;
       data_ctx.snap_set_read(snap_id);
-      object_map.refresh(in_snap_id);
       return 0;
     }
     return -ENOENT;
@@ -496,7 +495,6 @@ struct C_InvalidateCache : public Context {
     snap_name = "";
     snap_exists = true;
     data_ctx.snap_set_read(snap_id);
-    object_map.refresh(CEPH_NOSNAP);
   }
 
   snap_t ImageCtx::get_snap_id(string in_snap_name) const

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -1024,24 +1024,4 @@ struct C_InvalidateCache : public Context {
   Journal *ImageCtx::create_journal() {
     return new Journal(*this);
   }
-
-  void ImageCtx::open_journal() {
-    assert(journal == NULL);
-    journal = new Journal(*this);
-  }
-
-  int ImageCtx::close_journal(bool force) {
-    assert(journal != NULL);
-    int r = journal->close();
-    if (r < 0) {
-      lderr(cct) << "failed to flush journal: " << cpp_strerror(r) << dendl;
-      if (!force) {
-        return r;
-      }
-    }
-
-    delete journal;
-    journal = NULL;
-    return r;
-  }
 }

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -21,6 +21,7 @@
 #include "librbd/LibrbdAdminSocketHook.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/operation/ResizeRequest.h"
+#include "librbd/Utils.h"
 
 #include <boost/bind.hpp>
 
@@ -131,16 +132,16 @@ struct C_InvalidateCache : public Context {
       journal(NULL),
       refresh_seq(0),
       last_refresh(0),
-      owner_lock(unique_lock_name("librbd::ImageCtx::owner_lock", this)),
-      md_lock(unique_lock_name("librbd::ImageCtx::md_lock", this)),
-      cache_lock(unique_lock_name("librbd::ImageCtx::cache_lock", this)),
-      snap_lock(unique_lock_name("librbd::ImageCtx::snap_lock", this)),
-      parent_lock(unique_lock_name("librbd::ImageCtx::parent_lock", this)),
-      refresh_lock(unique_lock_name("librbd::ImageCtx::refresh_lock", this)),
-      object_map_lock(unique_lock_name("librbd::ImageCtx::object_map_lock", this)),
-      async_ops_lock(unique_lock_name("librbd::ImageCtx::async_ops_lock", this)),
-      copyup_list_lock(unique_lock_name("librbd::ImageCtx::copyup_list_lock", this)),
-      completed_reqs_lock(unique_lock_name("librbd::ImageCtx::completed_reqs_lock", this)),
+      owner_lock(util::unique_lock_name("librbd::ImageCtx::owner_lock", this)),
+      md_lock(util::unique_lock_name("librbd::ImageCtx::md_lock", this)),
+      cache_lock(util::unique_lock_name("librbd::ImageCtx::cache_lock", this)),
+      snap_lock(util::unique_lock_name("librbd::ImageCtx::snap_lock", this)),
+      parent_lock(util::unique_lock_name("librbd::ImageCtx::parent_lock", this)),
+      refresh_lock(util::unique_lock_name("librbd::ImageCtx::refresh_lock", this)),
+      object_map_lock(util::unique_lock_name("librbd::ImageCtx::object_map_lock", this)),
+      async_ops_lock(util::unique_lock_name("librbd::ImageCtx::async_ops_lock", this)),
+      copyup_list_lock(util::unique_lock_name("librbd::ImageCtx::copyup_list_lock", this)),
+      completed_reqs_lock(util::unique_lock_name("librbd::ImageCtx::completed_reqs_lock", this)),
       extra_read_flags(0),
       old_format(true),
       order(0), size(0), features(0),
@@ -216,7 +217,7 @@ struct C_InvalidateCache : public Context {
 
     if (!old_format) {
       if (!id.length()) {
-	r = cls_client::get_id(&md_ctx, id_obj_name(name), &id);
+	r = cls_client::get_id(&md_ctx, util::id_obj_name(name), &id);
 	if (r < 0) {
 	  lderr(cct) << "error reading image id: " << cpp_strerror(r)
 		     << dendl;
@@ -224,7 +225,7 @@ struct C_InvalidateCache : public Context {
 	}
       }
 
-      header_oid = header_name(id);
+      header_oid = util::header_name(id);
       apply_metadata_confs();
       r = cls_client::get_immutable_metadata(&md_ctx, header_oid,
 					     &object_prefix, &order);
@@ -245,7 +246,7 @@ struct C_InvalidateCache : public Context {
       init_layout();
     } else {
       apply_metadata_confs();
-      header_oid = old_header_name(name);
+      header_oid = util::old_header_name(name);
     }
 
     string pname = string("librbd-") + id + string("-") +

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -29,7 +29,6 @@
 #include "cls/rbd/cls_rbd_client.h"
 #include "librbd/AsyncRequest.h"
 #include "librbd/LibrbdWriteback.h"
-#include "librbd/ObjectMap.h"
 #include "librbd/SnapInfo.h"
 #include "librbd/parent_types.h"
 
@@ -49,6 +48,7 @@ namespace librbd {
   class ImageWatcher;
   class Journal;
   class LibrbdAdminSocketHook;
+  class ObjectMap;
 
   namespace operation {
   template <typename> class ResizeRequest;
@@ -99,7 +99,8 @@ namespace librbd {
                    // lock_tag
                    // lockers
     Mutex cache_lock; // used as client_lock for the ObjectCacher
-    RWLock snap_lock; // protects snapshot-related member variables, features, and flags
+    RWLock snap_lock; // protects snapshot-related member variables,
+                      // features (and associated helper classes), and flags
     RWLock parent_lock; // protects parent_md and parent
     Mutex refresh_lock; // protects refresh_seq and last_refresh
     RWLock object_map_lock; // protects object map updates and object_map itself
@@ -140,8 +141,7 @@ namespace librbd {
 
     ExclusiveLock<ImageCtx> *exclusive_lock;
 
-    ObjectMap object_map;         // TODO
-    ObjectMap *object_map_ptr;
+    ObjectMap *object_map;
 
     atomic_t async_request_seq;
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -273,10 +273,7 @@ namespace librbd {
     void apply_metadata_confs();
 
     ObjectMap *create_object_map(uint64_t snap_id);
-
     Journal *create_journal();
-    void open_journal();            // TODO remove
-    int close_journal(bool force);  // TODO remove
 
     void clear_pending_completions();
   };

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -228,8 +228,11 @@ namespace librbd {
     void rm_snap(std::string in_snap_name, librados::snap_t id);
     uint64_t get_image_size(librados::snap_t in_snap_id) const;
     bool test_features(uint64_t test_features) const;
+    bool test_features(uint64_t test_features,
+                       const RWLock &in_snap_lock) const;
     int get_flags(librados::snap_t in_snap_id, uint64_t *flags) const;
     bool test_flags(uint64_t test_flags) const;
+    bool test_flags(uint64_t test_flags, const RWLock &in_snap_lock) const;
     int update_flags(librados::snap_t in_snap_id, uint64_t flag, bool enabled);
 
     const parent_info* get_parent_info(librados::snap_t in_snap_id) const;
@@ -269,7 +272,7 @@ namespace librbd {
 
     void apply_metadata_confs();
 
-    ObjectMap *create_object_map();
+    ObjectMap *create_object_map(uint64_t snap_id);
 
     Journal *create_journal();
     void open_journal();            // TODO remove

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -41,13 +41,14 @@ class PerfCounters;
 namespace librbd {
 
   struct ImageCtx;
+  class AioCompletion;
   class AioImageRequestWQ;
   class AsyncOperation;
   class CopyupRequest;
-  class LibrbdAdminSocketHook;
+  template <typename> class ExclusiveLock;
   class ImageWatcher;
   class Journal;
-  class AioCompletion;
+  class LibrbdAdminSocketHook;
 
   namespace operation {
   template <typename> class ResizeRequest;
@@ -137,6 +138,8 @@ namespace librbd {
     xlist<AsyncRequest<>*> async_requests;
     std::list<Context*> async_requests_waiters;
 
+    ExclusiveLock<ImageCtx> *exclusive_lock;
+
     ObjectMap object_map;         // TODO
     ObjectMap *object_map_ptr;
 
@@ -198,7 +201,8 @@ namespace librbd {
     ImageCtx(const std::string &image_name, const std::string &image_id,
 	     const char *snap, IoCtx& p, bool read_only);
     ~ImageCtx();
-    int init();
+    int init_legacy();   // TODO
+    void init();
     void init_layout();
     void perf_start(std::string name);
     void perf_stop();
@@ -250,7 +254,8 @@ namespace librbd {
     void user_flushed();
     int flush_cache();
     void flush_cache(Context *onfinish);
-    int shutdown_cache();
+    int shutdown_cache(); // TODO
+    void shut_down_cache(Context *on_finish);
     int invalidate_cache(bool purge_on_error=false);
     void invalidate_cache(Context *on_finish);
     void clear_nonexistence_cache();
@@ -267,6 +272,9 @@ namespace librbd {
 
     void cancel_async_requests();
     void cancel_async_requests(Context *on_finish);
+
+    void flush_copyup(Context *on_finish);
+
     void apply_metadata_confs();
 
     ObjectMap *create_object_map();

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -5,6 +5,7 @@
 
 #include "include/int_types.h"
 
+#include <list>
 #include <map>
 #include <set>
 #include <string>
@@ -134,9 +135,10 @@ namespace librbd {
 
     xlist<AsyncOperation*> async_ops;
     xlist<AsyncRequest<>*> async_requests;
-    Cond async_requests_cond;
+    std::list<Context*> async_requests_waiters;
 
-    ObjectMap object_map;
+    ObjectMap object_map;         // TODO
+    ObjectMap *object_map_ptr;
 
     atomic_t async_request_seq;
 
@@ -264,10 +266,15 @@ namespace librbd {
     void flush(Context *on_safe);
 
     void cancel_async_requests();
+    void cancel_async_requests(Context *on_finish);
     void apply_metadata_confs();
 
-    void open_journal();
-    int close_journal(bool force);
+    ObjectMap *create_object_map();
+
+    Journal *create_journal();
+    void open_journal();            // TODO remove
+    int close_journal(bool force);  // TODO remove
+
     void clear_pending_completions();
   };
 }

--- a/src/librbd/ImageRefresh.cc
+++ b/src/librbd/ImageRefresh.cc
@@ -1,0 +1,35 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/ImageRefresh.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/image/RefreshRequest.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::ImageRefresh: "
+
+namespace librbd {
+
+template <typename I>
+ImageRefresh<I>::ImageRefresh(I &image_ctx) : m_image_ctx(image_ctx) {
+}
+
+template <typename I>
+bool ImageRefresh<I>::is_refresh_required() const {
+  // TODO future entry point for AIO ops -- to replace ictx_check call
+  return false;
+}
+
+template <typename I>
+void ImageRefresh<I>::refresh(Context *on_finish) {
+  // TODO simple state machine to restrict to a single in-progress refresh / snap set
+  image::RefreshRequest<I> *req = image::RefreshRequest<I>::create(
+    m_image_ctx, on_finish);
+  req->send();
+}
+
+} // namespace librbd
+
+template class librbd::ImageRefresh<librbd::ImageCtx>;

--- a/src/librbd/ImageRefresh.h
+++ b/src/librbd/ImageRefresh.h
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IMAGE_REFRESH_H
+#define CEPH_LIBRBD_IMAGE_REFRESH_H
+
+#include "include/int_types.h"
+
+class Context;
+
+namespace librbd {
+
+class ImageCtx;
+
+template <typename ImageCtxT = ImageCtx>
+class ImageRefresh {
+public:
+  ImageRefresh(ImageCtxT &image_ctx);
+
+  bool is_refresh_required() const;
+
+  void refresh(Context *on_finish);
+
+private:
+  ImageCtxT &m_image_ctx;
+
+};
+
+} // namespace librbd
+
+extern template class librbd::ImageRefresh<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_IMAGE_REFRESH_H

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -4,7 +4,13 @@
 #include "librbd/ImageState.h"
 #include "common/dout.h"
 #include "common/errno.h"
-#include "librbd/image/StateRequest.h"
+#include "common/Cond.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "librbd/image/CloseRequest.h"
+#include "librbd/image/OpenRequest.h"
+#include "librbd/image/RefreshRequest.h"
+#include "librbd/image/SetSnapRequest.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -12,22 +18,373 @@
 
 namespace librbd {
 
+using util::create_context_callback;
+
 template <typename I>
-ImageState<I>::ImageState(I &image_ctx) : m_image_ctx(image_ctx) {
+ImageState<I>::ImageState(I *image_ctx)
+  : m_image_ctx(image_ctx), m_state(STATE_UNINITIALIZED),
+    m_lock(util::unique_lock_name("librbd::ImageState::m_lock", this)),
+    m_last_refresh(0), m_refresh_seq(0) {
+}
+
+template <typename I>
+ImageState<I>::~ImageState() {
+  assert(m_state == STATE_UNINITIALIZED || m_state == STATE_CLOSED);
+}
+
+template <typename I>
+int ImageState<I>::open() {
+  C_SaferCond ctx;
+  open(&ctx);
+  return ctx.wait();
+}
+
+template <typename I>
+void ImageState<I>::open(Context *on_finish) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 20) << __func__ << dendl;
+
+  Mutex::Locker locker(m_lock);
+  assert(m_state == STATE_UNINITIALIZED);
+
+  Action action(ACTION_TYPE_OPEN);
+  action.refresh_seq = m_refresh_seq;
+  execute_action(action, on_finish);
+}
+
+template <typename I>
+int ImageState<I>::close() {
+  C_SaferCond ctx;
+  close(&ctx);
+
+  int r = ctx.wait();
+  delete m_image_ctx;
+  return r;
+}
+
+template <typename I>
+void ImageState<I>::close(Context *on_finish) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 20) << __func__ << dendl;
+
+  Mutex::Locker locker(m_lock);
+  assert(!is_closed());
+
+  Action action(ACTION_TYPE_CLOSE);
+  action.refresh_seq = m_refresh_seq;
+  execute_action(action, on_finish);
+}
+
+template <typename I>
+void ImageState<I>::handle_update_notification() {
+  Mutex::Locker locker(m_lock);
+  ++m_refresh_seq;
+
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 20) << "refresh_seq = " << m_refresh_seq << ", "
+		 << "last_refresh = " << m_last_refresh << dendl;
 }
 
 template <typename I>
 bool ImageState<I>::is_refresh_required() const {
-  // TODO future entry point for AIO ops -- to replace ictx_check call
-  return false;
+  Mutex::Locker locker(m_lock);
+  return (m_last_refresh != m_refresh_seq);
+}
+
+template <typename I>
+int ImageState<I>::refresh() {
+  C_SaferCond refresh_ctx;
+  {
+    RWLock::RLocker owner_lock(m_image_ctx->owner_lock);
+    refresh(&refresh_ctx);
+  }
+  return refresh_ctx.wait();
 }
 
 template <typename I>
 void ImageState<I>::refresh(Context *on_finish) {
-  // TODO simple state machine to restrict to a single in-progress refresh / snap set
-  image::StateRequest<I> *req = image::StateRequest<I>::create(
-    m_image_ctx, on_finish);
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 20) << __func__ << dendl;
+
+  m_lock.Lock();
+  if (is_closed()) {
+    m_lock.Unlock();
+    on_finish->complete(0);
+    return;
+  }
+
+  Action action(ACTION_TYPE_REFRESH);
+  action.refresh_seq = m_refresh_seq;
+  execute_action(action, on_finish);
+  m_lock.Unlock();
+}
+
+template <typename I>
+int ImageState<I>::refresh_if_required() {
+  RWLock::RLocker owner_locker(m_image_ctx->owner_lock);
+  return refresh_if_required(m_image_ctx->owner_lock);
+}
+
+template <typename I>
+int ImageState<I>::refresh_if_required(const RWLock &) {
+  assert(m_image_ctx->owner_lock.is_locked());
+
+  C_SaferCond ctx;
+  {
+    Mutex::Locker locker(m_lock);
+    if (m_last_refresh == m_refresh_seq || is_closed()) {
+      return 0;
+    }
+
+    Action action(ACTION_TYPE_REFRESH);
+    action.refresh_seq = m_refresh_seq;
+    execute_action(action, &ctx);
+  }
+
+  return ctx.wait();
+}
+
+template <typename I>
+void ImageState<I>::snap_set(const std::string &snap_name, Context *on_finish) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 20) << __func__ << ": snap_name=" << snap_name << dendl;
+
+  Mutex::Locker locker(m_lock);
+  Action action(ACTION_TYPE_SET_SNAP);
+  action.snap_name = snap_name;
+  execute_action(action, on_finish);
+}
+
+template <typename I>
+bool ImageState<I>::is_transition_state() const {
+  switch (m_state) {
+  case STATE_UNINITIALIZED:
+  case STATE_OPEN:
+  case STATE_CLOSED:
+    return false;
+  case STATE_OPENING:
+  case STATE_CLOSING:
+  case STATE_REFRESHING:
+  case STATE_SETTING_SNAP:
+    break;
+  }
+  return true;
+}
+
+template <typename I>
+bool ImageState<I>::is_closed() const {
+  assert(m_lock.is_locked());
+
+  return ((m_state == STATE_CLOSED) ||
+          (!m_actions_contexts.empty() &&
+           m_actions_contexts.back().first.action_type == ACTION_TYPE_CLOSE));
+}
+
+template <typename I>
+void ImageState<I>::append_context(const Action &action, Context *context) {
+  assert(m_lock.is_locked());
+
+  ActionContexts *action_contexts = nullptr;
+  for (auto &action_ctxs : m_actions_contexts) {
+    if (action == action_ctxs.first) {
+      action_contexts = &action_ctxs;
+      break;
+    }
+  }
+
+  if (action_contexts == nullptr) {
+    m_actions_contexts.push_back({action, {}});
+    action_contexts = &m_actions_contexts.back();
+  }
+
+  if (context != nullptr) {
+    action_contexts->second.push_back(context);
+  }
+}
+
+template <typename I>
+void ImageState<I>::execute_next_action() {
+  assert(m_lock.is_locked());
+  assert(!m_actions_contexts.empty());
+  switch (m_actions_contexts.front().first.action_type) {
+  case ACTION_TYPE_OPEN:
+    send_open();
+    return;
+  case ACTION_TYPE_CLOSE:
+    send_close();
+    return;
+  case ACTION_TYPE_REFRESH:
+    send_refresh();
+    return;
+  case ACTION_TYPE_SET_SNAP:
+    send_set_snap();
+    return;
+  }
+  assert(false);
+}
+
+template <typename I>
+void ImageState<I>::execute_action(const Action &action, Context *on_finish) {
+  assert(m_lock.is_locked());
+
+  append_context(action, on_finish);
+  if (!is_transition_state()) {
+    execute_next_action();
+  }
+}
+
+template <typename I>
+void ImageState<I>::complete_action(State next_state, int r) {
+  assert(m_lock.is_locked());
+  assert(!m_actions_contexts.empty());
+
+  ActionContexts action_contexts(std::move(m_actions_contexts.front()));
+  m_actions_contexts.pop_front();
+  m_state = next_state;
+
+  m_lock.Unlock();
+  for (auto ctx : action_contexts.second) {
+    ctx->complete(r);
+  }
+  m_lock.Lock();
+
+  if (!is_transition_state() && !m_actions_contexts.empty()) {
+    execute_next_action();
+  }
+}
+
+template <typename I>
+void ImageState<I>::send_open() {
+  assert(m_lock.is_locked());
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_state = STATE_OPENING;
+
+  Context *ctx = create_context_callback<
+    ImageState<I>, &ImageState<I>::handle_open>(this);
+  image::OpenRequest<I> *req = image::OpenRequest<I>::create(
+    m_image_ctx, ctx);
+
+  m_lock.Unlock();
   req->send();
+  m_lock.Lock();
+}
+
+template <typename I>
+void ImageState<I>::handle_open(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to open image: " << cpp_strerror(r) << dendl;
+  }
+
+  Mutex::Locker locker(m_lock);
+  complete_action(r < 0 ? STATE_UNINITIALIZED : STATE_OPEN, r);
+}
+
+template <typename I>
+void ImageState<I>::send_close() {
+  assert(m_lock.is_locked());
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_state = STATE_CLOSING;
+
+  Context *ctx = create_context_callback<
+    ImageState<I>, &ImageState<I>::handle_close>(this);
+  image::CloseRequest<I> *req = image::CloseRequest<I>::create(
+    m_image_ctx, ctx);
+
+  m_lock.Unlock();
+  req->send();
+  m_lock.Lock();
+}
+
+template <typename I>
+void ImageState<I>::handle_close(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "error occurred while closing image: " << cpp_strerror(r)
+               << dendl;
+  }
+
+  Mutex::Locker locker(m_lock);
+  complete_action(STATE_CLOSED, r);
+}
+
+template <typename I>
+void ImageState<I>::send_refresh() {
+  assert(m_lock.is_locked());
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_state = STATE_REFRESHING;
+
+  Context *ctx = create_context_callback<
+    ImageState<I>, &ImageState<I>::handle_refresh>(this);
+  image::RefreshRequest<I> *req = image::RefreshRequest<I>::create(
+    *m_image_ctx, ctx);
+
+  m_lock.Unlock();
+  req->send();
+  m_lock.Lock();
+}
+
+template <typename I>
+void ImageState<I>::handle_refresh(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  Mutex::Locker locker(m_lock);
+  assert(!m_actions_contexts.empty());
+
+  ActionContexts &action_contexts(m_actions_contexts.front());
+  assert(action_contexts.first.action_type == ACTION_TYPE_REFRESH);
+  assert(m_last_refresh <= action_contexts.first.refresh_seq);
+  m_last_refresh = action_contexts.first.refresh_seq;
+
+  complete_action(STATE_OPEN, r);
+}
+
+template <typename I>
+void ImageState<I>::send_set_snap() {
+  assert(m_lock.is_locked());
+
+  m_state = STATE_SETTING_SNAP;
+
+  assert(!m_actions_contexts.empty());
+  ActionContexts &action_contexts(m_actions_contexts.front());
+  assert(action_contexts.first.action_type == ACTION_TYPE_SET_SNAP);
+
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": "
+                 << "snap_name=" << action_contexts.first.snap_name << dendl;
+
+  Context *ctx = create_context_callback<
+    ImageState<I>, &ImageState<I>::handle_set_snap>(this);
+  image::SetSnapRequest<I> *req = image::SetSnapRequest<I>::create(
+    *m_image_ctx, action_contexts.first.snap_name, ctx);
+
+  m_lock.Unlock();
+  req->send();
+  m_lock.Lock();
+}
+
+template <typename I>
+void ImageState<I>::handle_set_snap(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << " r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to set snapshot: " << cpp_strerror(r) << dendl;
+  }
+
+  Mutex::Locker locker(m_lock);
+  complete_action(STATE_OPEN, r);
 }
 
 } // namespace librbd

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -94,10 +94,7 @@ bool ImageState<I>::is_refresh_required() const {
 template <typename I>
 int ImageState<I>::refresh() {
   C_SaferCond refresh_ctx;
-  {
-    RWLock::RLocker owner_lock(m_image_ctx->owner_lock);
-    refresh(&refresh_ctx);
-  }
+  refresh(&refresh_ctx);
   return refresh_ctx.wait();
 }
 

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -1,35 +1,35 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "librbd/ImageRefresh.h"
+#include "librbd/ImageState.h"
 #include "common/dout.h"
 #include "common/errno.h"
-#include "librbd/image/RefreshRequest.h"
+#include "librbd/image/StateRequest.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
-#define dout_prefix *_dout << "librbd::ImageRefresh: "
+#define dout_prefix *_dout << "librbd::ImageState: "
 
 namespace librbd {
 
 template <typename I>
-ImageRefresh<I>::ImageRefresh(I &image_ctx) : m_image_ctx(image_ctx) {
+ImageState<I>::ImageState(I &image_ctx) : m_image_ctx(image_ctx) {
 }
 
 template <typename I>
-bool ImageRefresh<I>::is_refresh_required() const {
+bool ImageState<I>::is_refresh_required() const {
   // TODO future entry point for AIO ops -- to replace ictx_check call
   return false;
 }
 
 template <typename I>
-void ImageRefresh<I>::refresh(Context *on_finish) {
+void ImageState<I>::refresh(Context *on_finish) {
   // TODO simple state machine to restrict to a single in-progress refresh / snap set
-  image::RefreshRequest<I> *req = image::RefreshRequest<I>::create(
+  image::StateRequest<I> *req = image::StateRequest<I>::create(
     m_image_ctx, on_finish);
   req->send();
 }
 
 } // namespace librbd
 
-template class librbd::ImageRefresh<librbd::ImageCtx>;
+template class librbd::ImageState<librbd::ImageCtx>;

--- a/src/librbd/ImageState.h
+++ b/src/librbd/ImageState.h
@@ -1,8 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#ifndef CEPH_LIBRBD_IMAGE_REFRESH_H
-#define CEPH_LIBRBD_IMAGE_REFRESH_H
+#ifndef CEPH_LIBRBD_IMAGE_STATE_H
+#define CEPH_LIBRBD_IMAGE_STATE_H
 
 #include "include/int_types.h"
 
@@ -13,9 +13,9 @@ namespace librbd {
 class ImageCtx;
 
 template <typename ImageCtxT = ImageCtx>
-class ImageRefresh {
+class ImageState {
 public:
-  ImageRefresh(ImageCtxT &image_ctx);
+  ImageState(ImageCtxT &image_ctx);
 
   bool is_refresh_required() const;
 
@@ -28,6 +28,6 @@ private:
 
 } // namespace librbd
 
-extern template class librbd::ImageRefresh<librbd::ImageCtx>;
+extern template class librbd::ImageState<librbd::ImageCtx>;
 
-#endif // CEPH_LIBRBD_IMAGE_REFRESH_H
+#endif // CEPH_LIBRBD_IMAGE_STATE_H

--- a/src/librbd/ImageState.h
+++ b/src/librbd/ImageState.h
@@ -5,8 +5,13 @@
 #define CEPH_LIBRBD_IMAGE_STATE_H
 
 #include "include/int_types.h"
+#include "common/Mutex.h"
+#include <list>
+#include <string>
+#include <utility>
 
 class Context;
+class RWLock;
 
 namespace librbd {
 
@@ -15,14 +20,98 @@ class ImageCtx;
 template <typename ImageCtxT = ImageCtx>
 class ImageState {
 public:
-  ImageState(ImageCtxT &image_ctx);
+  ImageState(ImageCtxT *image_ctx);
+  ~ImageState();
+
+  int open();
+  void open(Context *on_finish);
+
+  int close();
+  void close(Context *on_finish);
+
+  void handle_update_notification();
 
   bool is_refresh_required() const;
 
+  int refresh();
   void refresh(Context *on_finish);
+  int refresh_if_required();
+  int refresh_if_required(const RWLock &owner_lock);
+
+  void snap_set(const std::string &snap_name, Context *on_finish);
 
 private:
-  ImageCtxT &m_image_ctx;
+  enum State {
+    STATE_UNINITIALIZED,
+    STATE_OPEN,
+    STATE_CLOSED,
+    STATE_OPENING,
+    STATE_CLOSING,
+    STATE_REFRESHING,
+    STATE_SETTING_SNAP
+  };
+
+  enum ActionType {
+    ACTION_TYPE_OPEN,
+    ACTION_TYPE_CLOSE,
+    ACTION_TYPE_REFRESH,
+    ACTION_TYPE_SET_SNAP
+  };
+
+  struct Action {
+    ActionType action_type;
+    uint64_t refresh_seq;
+    std::string snap_name;
+
+    Action(ActionType action_type) : action_type(action_type), refresh_seq(0) {
+    }
+    inline bool operator==(const Action &action) const {
+      if (action_type != action.action_type) {
+        return false;
+      }
+      switch (action_type) {
+      case ACTION_TYPE_REFRESH:
+        return refresh_seq == action.refresh_seq;
+      case ACTION_TYPE_SET_SNAP:
+        return snap_name == action.snap_name;
+      default:
+        return true;
+      }
+    }
+  };
+
+  typedef std::list<Context *> Contexts;
+  typedef std::pair<Action, Contexts> ActionContexts;
+  typedef std::list<ActionContexts> ActionsContexts;
+
+  ImageCtxT *m_image_ctx;
+  State m_state;
+
+  mutable Mutex m_lock;
+  ActionsContexts m_actions_contexts;
+
+  uint64_t m_last_refresh;
+  uint64_t m_refresh_seq;
+
+  bool is_transition_state() const;
+  bool is_closed() const;
+
+  void append_context(const Action &action, Context *context);
+  void execute_next_action();
+  void execute_action(const Action &action, Context *context);
+  void complete_action(State next_state, int r);
+
+  void send_open();
+  void handle_open(int r);
+
+  void send_close();
+  void handle_close(int r);
+
+  void send_refresh();
+  void handle_refresh(int r);
+
+  void send_set_snap();
+  void handle_set_snap(int r);
 
 };
 

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -6,6 +6,7 @@
 #include "librbd/internal.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/TaskFinisher.h"
+#include "librbd/Utils.h"
 #include "cls/lock/cls_lock_client.h"
 #include "cls/lock/cls_lock_types.h"
 #include "include/encoding.h"
@@ -32,17 +33,16 @@ static const double	RETRY_DELAY_SECONDS = 1.0;
 
 ImageWatcher::ImageWatcher(ImageCtx &image_ctx)
   : m_image_ctx(image_ctx),
-    m_watch_lock(unique_lock_name("librbd::ImageWatcher::m_watch_lock", this)),
+    m_watch_lock(util::unique_lock_name("librbd::ImageWatcher::m_watch_lock", this)),
     m_watch_ctx(*this), m_watch_handle(0),
     m_watch_state(WATCH_STATE_UNREGISTERED),
-    m_refresh_lock(unique_lock_name("librbd::ImageWatcher::m_refresh_lock",
-                                    this)),
+    m_refresh_lock(util::unique_lock_name("librbd::ImageWatcher::m_refresh_lock", this)),
     m_lock_supported(false), m_lock_owner_state(LOCK_OWNER_STATE_NOT_LOCKED),
-    m_listeners_lock(unique_lock_name("librbd::ImageWatcher::m_listeners_lock", this)),
+    m_listeners_lock(util::unique_lock_name("librbd::ImageWatcher::m_listeners_lock", this)),
     m_listeners_in_use(false),
     m_task_finisher(new TaskFinisher<Task>(*m_image_ctx.cct)),
-    m_async_request_lock(unique_lock_name("librbd::ImageWatcher::m_async_request_lock", this)),
-    m_owner_client_id_lock(unique_lock_name("librbd::ImageWatcher::m_owner_client_id_lock", this))
+    m_async_request_lock(util::unique_lock_name("librbd::ImageWatcher::m_async_request_lock", this)),
+    m_owner_client_id_lock(util::unique_lock_name("librbd::ImageWatcher::m_owner_client_id_lock", this))
 {
 }
 

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -2,13 +2,12 @@
 // vim: ts=8 sw=2 smarttab
 #include "librbd/ImageWatcher.h"
 #include "librbd/AioCompletion.h"
+#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/internal.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/TaskFinisher.h"
 #include "librbd/Utils.h"
-#include "cls/lock/cls_lock_client.h"
-#include "cls/lock/cls_lock_types.h"
 #include "include/encoding.h"
 #include "include/stringify.h"
 #include "common/errno.h"
@@ -25,9 +24,6 @@ namespace librbd {
 
 using namespace watch_notify;
 
-static const std::string WATCHER_LOCK_TAG = "internal";
-static const std::string WATCHER_LOCK_COOKIE_PREFIX = "auto";
-
 static const uint64_t	NOTIFY_TIMEOUT = 5000;
 static const double	RETRY_DELAY_SECONDS = 1.0;
 
@@ -36,10 +32,6 @@ ImageWatcher::ImageWatcher(ImageCtx &image_ctx)
     m_watch_lock(util::unique_lock_name("librbd::ImageWatcher::m_watch_lock", this)),
     m_watch_ctx(*this), m_watch_handle(0),
     m_watch_state(WATCH_STATE_UNREGISTERED),
-    m_refresh_lock(util::unique_lock_name("librbd::ImageWatcher::m_refresh_lock", this)),
-    m_lock_supported(false), m_lock_owner_state(LOCK_OWNER_STATE_NOT_LOCKED),
-    m_listeners_lock(util::unique_lock_name("librbd::ImageWatcher::m_listeners_lock", this)),
-    m_listeners_in_use(false),
     m_task_finisher(new TaskFinisher<Task>(*m_image_ctx.cct)),
     m_async_request_lock(util::unique_lock_name("librbd::ImageWatcher::m_async_request_lock", this)),
     m_owner_client_id_lock(util::unique_lock_name("librbd::ImageWatcher::m_owner_client_id_lock", this))
@@ -53,42 +45,6 @@ ImageWatcher::~ImageWatcher()
     RWLock::RLocker l(m_watch_lock);
     assert(m_watch_state != WATCH_STATE_REGISTERED);
   }
-  {
-    RWLock::RLocker l(m_image_ctx.owner_lock);
-    assert(m_lock_owner_state == LOCK_OWNER_STATE_NOT_LOCKED);
-  }
-}
-
-bool ImageWatcher::is_lock_supported() const {
-  RWLock::RLocker l(m_image_ctx.snap_lock);
-  return is_lock_supported(m_image_ctx.snap_lock);
-}
-
-bool ImageWatcher::is_lock_supported(const RWLock &) const {
-  assert(m_image_ctx.owner_lock.is_locked());
-  assert(m_image_ctx.snap_lock.is_locked());
-  return ((m_image_ctx.features & RBD_FEATURE_EXCLUSIVE_LOCK) != 0 &&
-	  !m_image_ctx.read_only && m_image_ctx.snap_id == CEPH_NOSNAP);
-}
-
-bool ImageWatcher::is_lock_owner() const {
-  assert(m_image_ctx.owner_lock.is_locked());
-  return (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED ||
-          m_lock_owner_state == LOCK_OWNER_STATE_RELEASING);
-}
-
-void ImageWatcher::register_listener(Listener *listener) {
-  Mutex::Locker listeners_locker(m_listeners_lock);
-  m_listeners.push_back(listener);
-}
-
-void ImageWatcher::unregister_listener(Listener *listener) {
-  // TODO CoW listener list
-  Mutex::Locker listeners_locker(m_listeners_lock);
-  while (m_listeners_in_use) {
-    m_listeners_cond.Wait(m_listeners_lock);
-  }
-  m_listeners.remove(listener);
 }
 
 int ImageWatcher::register_watch() {
@@ -125,325 +81,6 @@ int ImageWatcher::unregister_watch() {
   librados::Rados rados(m_image_ctx.md_ctx);
   rados.watch_flush();
   return r;
-}
-
-int ImageWatcher::refresh() {
-  assert(m_image_ctx.owner_lock.is_locked());
-
-  bool lock_support_changed = false;
-  {
-    Mutex::Locker refresh_locker(m_refresh_lock);
-    if (m_lock_supported != is_lock_supported()) {
-      m_lock_supported = is_lock_supported();
-      lock_support_changed = true;
-    }
-  }
-
-  int r = 0;
-  if (lock_support_changed) {
-    if (is_lock_supported()) {
-      // image opened, exclusive lock dynamically enabled, or now HEAD
-      notify_listeners_updated_lock(LOCK_UPDATE_STATE_RELEASING);
-      notify_listeners_updated_lock(LOCK_UPDATE_STATE_UNLOCKED);
-    } else if (!is_lock_supported()) {
-      if (is_lock_owner()) {
-        // exclusive lock dynamically disabled or now snapshot
-        m_image_ctx.owner_lock.put_read();
-        {
-          RWLock::WLocker owner_locker(m_image_ctx.owner_lock);
-          r = release_lock();
-        }
-        m_image_ctx.owner_lock.get_read();
-      }
-      notify_listeners_updated_lock(LOCK_UPDATE_STATE_NOT_SUPPORTED);
-    }
-  }
-  return r;
-}
-
-int ImageWatcher::try_lock() {
-  assert(m_image_ctx.owner_lock.is_wlocked());
-  assert(m_lock_owner_state == LOCK_OWNER_STATE_NOT_LOCKED);
-  assert(is_lock_supported());
-
-  while (true) {
-    int r = lock();
-    if (r != -EBUSY) {
-      return r;
-    }
-
-    // determine if the current lock holder is still alive
-    entity_name_t locker;
-    std::string locker_cookie;
-    std::string locker_address;
-    uint64_t locker_handle;
-    r = get_lock_owner_info(&locker, &locker_cookie, &locker_address,
-			    &locker_handle);
-    if (r < 0) {
-      return r;
-    }
-    if (locker_cookie.empty() || locker_address.empty()) {
-      // lock is now unlocked ... try again
-      continue;
-    }
-
-    std::list<obj_watch_t> watchers;
-    r = m_image_ctx.md_ctx.list_watchers(m_image_ctx.header_oid, &watchers);
-    if (r < 0) {
-      return r;
-    }
-
-    for (std::list<obj_watch_t>::iterator iter = watchers.begin();
-	 iter != watchers.end(); ++iter) {
-      if ((strncmp(locker_address.c_str(),
-                   iter->addr, sizeof(iter->addr)) == 0) &&
-	  (locker_handle == iter->cookie)) {
-	Mutex::Locker l(m_owner_client_id_lock);
-        set_owner_client_id(ClientId(iter->watcher_id, locker_handle));
-	return 0;
-      }
-    }
-
-    if (m_image_ctx.blacklist_on_break_lock) {
-      ldout(m_image_ctx.cct, 1) << this << " blacklisting client: " << locker
-                                << "@" << locker_address << dendl;
-      librados::Rados rados(m_image_ctx.md_ctx);
-      r = rados.blacklist_add(locker_address,
-			      m_image_ctx.blacklist_expire_seconds);
-      if (r < 0) {
-        lderr(m_image_ctx.cct) << this << " unable to blacklist client: "
-			       << cpp_strerror(r) << dendl;
-        return r;
-      }
-    }
-
-    ldout(m_image_ctx.cct, 5) << this << " breaking exclusive lock: " << locker
-                              << dendl;
-    r = rados::cls::lock::break_lock(&m_image_ctx.md_ctx,
-                                     m_image_ctx.header_oid, RBD_LOCK_NAME,
-                                     locker_cookie, locker);
-    if (r < 0 && r != -ENOENT) {
-      return r;
-    }
-  }
-  return 0;
-}
-
-void ImageWatcher::request_lock() {
-  schedule_request_lock(false);
-}
-
-bool ImageWatcher::try_request_lock() {
-  assert(m_image_ctx.owner_lock.is_locked());
-  if (is_lock_owner()) {
-    return true;
-  }
-
-  int r = 0;
-  m_image_ctx.owner_lock.put_read();
-  {
-    RWLock::WLocker l(m_image_ctx.owner_lock);
-    if (!is_lock_owner()) {
-      r = try_lock();
-    }
-  }
-  m_image_ctx.owner_lock.get_read();
-
-  if (r < 0) {
-    ldout(m_image_ctx.cct, 5) << this << " failed to acquire exclusive lock:"
-			      << cpp_strerror(r) << dendl;
-    return false;
-  }
-
-  if (is_lock_owner()) {
-    ldout(m_image_ctx.cct, 15) << this << " successfully acquired exclusive lock"
-			       << dendl;
-  } else {
-    ldout(m_image_ctx.cct, 15) << this
-                               << " unable to acquire exclusive lock, retrying"
-                               << dendl;
-  }
-  return is_lock_owner();
-}
-
-int ImageWatcher::get_lock_owner_info(entity_name_t *locker, std::string *cookie,
-				      std::string *address, uint64_t *handle) {
-  std::map<rados::cls::lock::locker_id_t,
-	   rados::cls::lock::locker_info_t> lockers;
-  ClsLockType lock_type;
-  std::string lock_tag;
-  int r = rados::cls::lock::get_lock_info(&m_image_ctx.md_ctx,
-					  m_image_ctx.header_oid,
-					  RBD_LOCK_NAME, &lockers, &lock_type,
-					  &lock_tag);
-  if (r < 0) {
-    return r;
-  }
-
-  if (lockers.empty()) {
-    ldout(m_image_ctx.cct, 20) << this << " no lockers detected" << dendl;
-    return 0;
-  }
-
-  if (lock_tag != WATCHER_LOCK_TAG) {
-    ldout(m_image_ctx.cct, 5) << this << " locked by external mechanism: tag="
-			      << lock_tag << dendl;
-    return -EBUSY;
-  }
-
-  if (lock_type == LOCK_SHARED) {
-    ldout(m_image_ctx.cct, 5) << this << " shared lock type detected" << dendl;
-    return -EBUSY;
-  }
-
-  std::map<rados::cls::lock::locker_id_t,
-           rados::cls::lock::locker_info_t>::iterator iter = lockers.begin();
-  if (!decode_lock_cookie(iter->first.cookie, handle)) {
-    ldout(m_image_ctx.cct, 5) << this << " locked by external mechanism: "
-                              << "cookie=" << iter->first.cookie << dendl;
-    return -EBUSY;
-  }
-
-  *locker = iter->first.locker;
-  *cookie = iter->first.cookie;
-  *address = stringify(iter->second.addr);
-  ldout(m_image_ctx.cct, 10) << this << " retrieved exclusive locker: "
-                             << *locker << "@" << *address << dendl;
-  return 0;
-}
-
-int ImageWatcher::lock() {
-  assert(m_image_ctx.owner_lock.is_wlocked());
-  assert(m_lock_owner_state == LOCK_OWNER_STATE_NOT_LOCKED);
-
-  int r = rados::cls::lock::lock(&m_image_ctx.md_ctx, m_image_ctx.header_oid,
-				 RBD_LOCK_NAME, LOCK_EXCLUSIVE,
-				 encode_lock_cookie(), WATCHER_LOCK_TAG, "",
-				 utime_t(), 0);
-  if (r < 0) {
-    return r;
-  }
-
-  ldout(m_image_ctx.cct, 10) << this << " acquired exclusive lock" << dendl;
-  m_lock_owner_state = LOCK_OWNER_STATE_LOCKED;
-
-  ClientId owner_client_id = get_client_id();
-  {
-    Mutex::Locker l(m_owner_client_id_lock);
-    set_owner_client_id(owner_client_id);
-  }
-
-  if (m_image_ctx.object_map.enabled()) {
-    r = m_image_ctx.object_map.lock();
-    if (r < 0 && r != -ENOENT) {
-      unlock();
-      return r;
-    }
-    RWLock::WLocker l2(m_image_ctx.snap_lock);
-    m_image_ctx.object_map.refresh(CEPH_NOSNAP);
-  }
-
-  // send the notification when we aren't holding locks
-  FunctionContext *ctx = new FunctionContext(
-    boost::bind(&ImageWatcher::notify_acquired_lock, this));
-  m_task_finisher->queue(TASK_CODE_ACQUIRED_LOCK, ctx);
-  return 0;
-}
-
-int ImageWatcher::unlock()
-{
-  assert(m_image_ctx.owner_lock.is_wlocked());
-
-  ldout(m_image_ctx.cct, 10) << this << " releasing exclusive lock" << dendl;
-  m_lock_owner_state = LOCK_OWNER_STATE_NOT_LOCKED;
-  int r = rados::cls::lock::unlock(&m_image_ctx.md_ctx, m_image_ctx.header_oid,
-				   RBD_LOCK_NAME, encode_lock_cookie());
-  if (r < 0 && r != -ENOENT) {
-    lderr(m_image_ctx.cct) << this << " failed to release exclusive lock: "
-			   << cpp_strerror(r) << dendl;
-    return r;
-  }
-
-  if (m_image_ctx.object_map.enabled()) {
-    m_image_ctx.object_map.unlock();
-  }
-
-  {
-    Mutex::Locker l(m_owner_client_id_lock);
-    set_owner_client_id(ClientId());
-  }
-
-  FunctionContext *ctx = new FunctionContext(
-    boost::bind(&ImageWatcher::notify_released_lock, this));
-  m_task_finisher->queue(TASK_CODE_RELEASED_LOCK, ctx);
-  return 0;
-}
-
-int ImageWatcher::release_lock()
-{
-  assert(m_image_ctx.owner_lock.is_wlocked());
-
-  CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 10) << this << " releasing exclusive lock by request" << dendl;
-  if (m_lock_owner_state != LOCK_OWNER_STATE_LOCKED) {
-    return 0;
-  }
-
-  m_lock_owner_state = LOCK_OWNER_STATE_RELEASING;
-  m_image_ctx.owner_lock.put_write();
-
-  // ensure all maint operations are canceled
-  m_image_ctx.cancel_async_requests();
-  m_image_ctx.flush_async_operations();
-
-  int r;
-  {
-    RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-
-    // alert listeners that all incoming IO needs to be stopped since the
-    // lock is being released
-    notify_listeners_updated_lock(LOCK_UPDATE_STATE_RELEASING);
-
-    RWLock::WLocker md_locker(m_image_ctx.md_lock);
-    r = m_image_ctx.flush();
-    if (r < 0) {
-      lderr(cct) << this << " failed to flush: " << cpp_strerror(r) << dendl;
-      goto err_cancel_unlock;
-    }
-  }
-
-  m_image_ctx.owner_lock.get_write();
-  assert(m_lock_owner_state == LOCK_OWNER_STATE_RELEASING);
-  r = unlock();
-
-  // notify listeners of the change w/ owner read locked
-  m_image_ctx.owner_lock.put_write();
-  {
-    RWLock::RLocker owner_lock(m_image_ctx.owner_lock);
-    if (m_lock_owner_state == LOCK_OWNER_STATE_NOT_LOCKED) {
-      notify_listeners_updated_lock(LOCK_UPDATE_STATE_UNLOCKED);
-    }
-  }
-  m_image_ctx.owner_lock.get_write();
-
-  if (r < 0) {
-    lderr(cct) << this << " failed to unlock: " << cpp_strerror(r) << dendl;
-    return r;
-  }
-
-  return 0;
-
-err_cancel_unlock:
-  m_image_ctx.owner_lock.get_write();
-  if (m_lock_owner_state == LOCK_OWNER_STATE_RELEASING) {
-    m_lock_owner_state = LOCK_OWNER_STATE_LOCKED;
-  }
-  return r;
-}
-
-void ImageWatcher::assert_header_locked(librados::ObjectWriteOperation *op) {
-  rados::cls::lock::assert_locked(op, RBD_LOCK_NAME, LOCK_EXCLUSIVE,
-                                  encode_lock_cookie(), WATCHER_LOCK_TAG);
 }
 
 void ImageWatcher::schedule_async_progress(const AsyncRequestId &request,
@@ -503,7 +140,8 @@ int ImageWatcher::notify_async_complete(const AsyncRequestId &request,
 
 int ImageWatcher::notify_flatten(uint64_t request_id, ProgressContext &prog_ctx) {
   assert(m_image_ctx.owner_lock.is_locked());
-  assert(!is_lock_owner());
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
 
   AsyncRequestId async_request_id(get_client_id(), request_id);
 
@@ -516,7 +154,8 @@ int ImageWatcher::notify_flatten(uint64_t request_id, ProgressContext &prog_ctx)
 int ImageWatcher::notify_resize(uint64_t request_id, uint64_t size,
 				ProgressContext &prog_ctx) {
   assert(m_image_ctx.owner_lock.is_locked());
-  assert(!is_lock_owner());
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
 
   AsyncRequestId async_request_id(get_client_id(), request_id);
 
@@ -528,7 +167,8 @@ int ImageWatcher::notify_resize(uint64_t request_id, uint64_t size,
 
 int ImageWatcher::notify_snap_create(const std::string &snap_name) {
   assert(m_image_ctx.owner_lock.is_locked());
-  assert(!is_lock_owner());
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(SnapCreatePayload(snap_name)), bl);
@@ -539,7 +179,8 @@ int ImageWatcher::notify_snap_create(const std::string &snap_name) {
 int ImageWatcher::notify_snap_rename(const snapid_t &src_snap_id,
 				     const std::string &dst_snap_name) {
   assert(m_image_ctx.owner_lock.is_locked());
-  assert(!is_lock_owner());
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(SnapRenamePayload(src_snap_id, dst_snap_name)), bl);
@@ -548,7 +189,8 @@ int ImageWatcher::notify_snap_rename(const snapid_t &src_snap_id,
 }
 int ImageWatcher::notify_snap_remove(const std::string &snap_name) {
   assert(m_image_ctx.owner_lock.is_locked());
-  assert(!is_lock_owner());
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(SnapRemovePayload(snap_name)), bl);
@@ -558,7 +200,8 @@ int ImageWatcher::notify_snap_remove(const std::string &snap_name) {
 
 int ImageWatcher::notify_snap_protect(const std::string &snap_name) {
   assert(m_image_ctx.owner_lock.is_locked());
-  assert(!is_lock_owner());
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(SnapProtectPayload(snap_name)), bl);
@@ -567,7 +210,8 @@ int ImageWatcher::notify_snap_protect(const std::string &snap_name) {
 
 int ImageWatcher::notify_snap_unprotect(const std::string &snap_name) {
   assert(m_image_ctx.owner_lock.is_locked());
-  assert(!is_lock_owner());
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(SnapUnprotectPayload(snap_name)), bl);
@@ -577,7 +221,8 @@ int ImageWatcher::notify_snap_unprotect(const std::string &snap_name) {
 int ImageWatcher::notify_rebuild_object_map(uint64_t request_id,
                                             ProgressContext &prog_ctx) {
   assert(m_image_ctx.owner_lock.is_locked());
-  assert(!is_lock_owner());
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
 
   AsyncRequestId async_request_id(get_client_id(), request_id);
 
@@ -589,26 +234,12 @@ int ImageWatcher::notify_rebuild_object_map(uint64_t request_id,
 
 int ImageWatcher::notify_rename(const std::string &image_name) {
   assert(m_image_ctx.owner_lock.is_locked());
-  assert(!is_lock_owner());
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(RenamePayload(image_name)), bl);
   return notify_lock_owner(bl);
-}
-
-void ImageWatcher::notify_lock_state() {
-  RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
-    // re-send the acquired lock notification so that peers know they can now
-    // request the lock
-    ldout(m_image_ctx.cct, 10) << this << " notify lock state" << dendl;
-
-    bufferlist bl;
-    ::encode(NotifyMessage(AcquiredLockPayload(get_client_id())), bl);
-
-    m_image_ctx.md_ctx.notify2(m_image_ctx.header_oid, bl, NOTIFY_TIMEOUT,
-                               NULL);
-  }
 }
 
 void ImageWatcher::notify_header_update(librados::IoCtx &io_ctx,
@@ -619,23 +250,6 @@ void ImageWatcher::notify_header_update(librados::IoCtx &io_ctx,
   ::encode(NotifyMessage(HeaderUpdatePayload()), bl);
 
   io_ctx.notify2(oid, bl, NOTIFY_TIMEOUT, NULL);
-}
-
-std::string ImageWatcher::encode_lock_cookie() const {
-  RWLock::RLocker l(m_watch_lock);
-  std::ostringstream ss;
-  ss << WATCHER_LOCK_COOKIE_PREFIX << " " << m_watch_handle;
-  return ss.str();
-}
-
-bool ImageWatcher::decode_lock_cookie(const std::string &tag,
-				      uint64_t *handle) {
-  std::string prefix;
-  std::istringstream ss(tag);
-  if (!(ss >> prefix >> *handle) || prefix != WATCHER_LOCK_COOKIE_PREFIX) {
-    return false;
-  }
-  return true;
 }
 
 void ImageWatcher::schedule_cancel_async_requests() {
@@ -669,25 +283,25 @@ ClientId ImageWatcher::get_client_id() {
 void ImageWatcher::notify_acquired_lock() {
   ldout(m_image_ctx.cct, 10) << this << " notify acquired lock" << dendl;
 
-  RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-  if (m_lock_owner_state != LOCK_OWNER_STATE_LOCKED) {
-    return;
+  ClientId client_id = get_client_id();
+  {
+    Mutex::Locker owner_client_id_locker(m_owner_client_id_lock);
+    set_owner_client_id(client_id);
   }
 
-  notify_listeners_updated_lock(LOCK_UPDATE_STATE_LOCKED);
-
   bufferlist bl;
-  ::encode(NotifyMessage(AcquiredLockPayload(get_client_id())), bl);
+  ::encode(NotifyMessage(AcquiredLockPayload(client_id)), bl);
   m_image_ctx.md_ctx.notify2(m_image_ctx.header_oid, bl, NOTIFY_TIMEOUT, NULL);
-}
-
-void ImageWatcher::notify_release_lock() {
-  RWLock::WLocker owner_locker(m_image_ctx.owner_lock);
-  release_lock();
 }
 
 void ImageWatcher::notify_released_lock() {
   ldout(m_image_ctx.cct, 10) << this << " notify released lock" << dendl;
+
+  {
+    Mutex::Locker owner_client_id_locker(m_owner_client_id_lock);
+    set_owner_client_id(ClientId());
+  }
+
   bufferlist bl;
   ::encode(NotifyMessage(ReleasedLockPayload(get_client_id())), bl);
   m_image_ctx.md_ctx.notify2(m_image_ctx.header_oid, bl, NOTIFY_TIMEOUT, NULL);
@@ -695,7 +309,13 @@ void ImageWatcher::notify_released_lock() {
 
 void ImageWatcher::schedule_request_lock(bool use_timer, int timer_delay) {
   assert(m_image_ctx.owner_lock.is_locked());
-  assert(m_lock_owner_state == LOCK_OWNER_STATE_NOT_LOCKED);
+
+  if (m_image_ctx.exclusive_lock == nullptr) {
+    // exclusive lock dynamically disabled via image refresh
+    return;
+  }
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
 
   RWLock::RLocker watch_locker(m_watch_lock);
   if (m_watch_state == WATCH_STATE_REGISTERED) {
@@ -716,12 +336,8 @@ void ImageWatcher::schedule_request_lock(bool use_timer, int timer_delay) {
 }
 
 void ImageWatcher::notify_request_lock() {
-  ldout(m_image_ctx.cct, 10) << this << " notify request lock" << dendl;
-
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-  if (try_request_lock()) {
-    return;
-  }
+  ldout(m_image_ctx.cct, 10) << this << " notify request lock" << dendl;
 
   bufferlist bl;
   ::encode(NotifyMessage(RequestLockPayload(get_client_id())), bl);
@@ -730,7 +346,9 @@ void ImageWatcher::notify_request_lock() {
   if (r == -ETIMEDOUT) {
     ldout(m_image_ctx.cct, 5) << this << " timed out requesting lock: retrying"
                               << dendl;
-    schedule_request_lock(false);
+
+    // treat this is a dead client -- so retest acquiring the lock
+    m_image_ctx.exclusive_lock->handle_lock_released();
   } else if (r < 0) {
     lderr(m_image_ctx.cct) << this << " error requesting lock: "
                            << cpp_strerror(r) << dendl;
@@ -754,6 +372,7 @@ int ImageWatcher::notify_lock_owner(bufferlist &bl) {
   int r = m_image_ctx.md_ctx.notify2(m_image_ctx.header_oid, bl, NOTIFY_TIMEOUT,
 				     &response_bl);
   m_image_ctx.owner_lock.get_read();
+
   if (r < 0 && r != -ETIMEDOUT) {
     lderr(m_image_ctx.cct) << this << " lock owner notification failed: "
 			   << cpp_strerror(r) << dendl;
@@ -891,7 +510,7 @@ bool ImageWatcher::handle_payload(const AcquiredLockPayload &payload,
 
   bool cancel_async_requests = true;
   if (payload.client_id.is_valid()) {
-    Mutex::Locker l(m_owner_client_id_lock);
+    Mutex::Locker owner_client_id_locker(m_owner_client_id_lock);
     if (payload.client_id == m_owner_client_id) {
       cancel_async_requests = false;
     }
@@ -899,11 +518,10 @@ bool ImageWatcher::handle_payload(const AcquiredLockPayload &payload,
   }
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_NOT_LOCKED) {
-    if (cancel_async_requests) {
-      schedule_cancel_async_requests();
-    }
-    notify_listeners_updated_lock(LOCK_UPDATE_STATE_NOTIFICATION);
+  if (cancel_async_requests &&
+      (m_image_ctx.exclusive_lock == nullptr ||
+       !m_image_ctx.exclusive_lock->is_lock_owner())) {
+    schedule_cancel_async_requests();
   }
   return true;
 }
@@ -926,11 +544,17 @@ bool ImageWatcher::handle_payload(const ReleasedLockPayload &payload,
   }
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_NOT_LOCKED) {
-    if (cancel_async_requests) {
-      schedule_cancel_async_requests();
-    }
-    notify_listeners_updated_lock(LOCK_UPDATE_STATE_NOTIFICATION);
+  if (cancel_async_requests &&
+      (m_image_ctx.exclusive_lock == nullptr ||
+       !m_image_ctx.exclusive_lock->is_lock_owner())) {
+    schedule_cancel_async_requests();
+  }
+
+  // alert the exclusive lock state machine that the lock is available
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      !m_image_ctx.exclusive_lock->is_lock_owner()) {
+    m_task_finisher->cancel(TASK_CODE_REQUEST_LOCK);
+    m_image_ctx.exclusive_lock->handle_lock_released();
   }
   return true;
 }
@@ -943,36 +567,23 @@ bool ImageWatcher::handle_payload(const RequestLockPayload &payload,
   }
 
   RWLock::RLocker l(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     // need to send something back so the client can detect a missing leader
     ::encode(ResponseMessage(0), ack_ctx->out);
 
     {
-      Mutex::Locker l(m_owner_client_id_lock);
+      Mutex::Locker owner_client_id_locker(m_owner_client_id_lock);
       if (!m_owner_client_id.is_valid()) {
 	return true;
       }
     }
 
-    bool release_permitted = true;
-    {
-      Mutex::Locker listeners_locker(m_listeners_lock);
-      for (Listeners::iterator it = m_listeners.begin();
-           it != m_listeners.end(); ++it) {
-        if (!(*it)->handle_requested_lock()) {
-          release_permitted = false;
-          break;
-        }
-      }
-    }
-
-    if (release_permitted) {
-      ldout(m_image_ctx.cct, 10) << this << " queuing release of exclusive lock"
-                                 << dendl;
-      FunctionContext *ctx = new FunctionContext(
-        boost::bind(&ImageWatcher::notify_release_lock, this));
-      m_task_finisher->queue(TASK_CODE_RELEASING_LOCK, ctx);
-    }
+    ldout(m_image_ctx.cct, 10) << this << " queuing release of exclusive lock"
+                               << dendl;
+    FunctionContext *ctx = new FunctionContext(
+      boost::bind(&ImageWatcher::notify_release_lock, this));
+    m_task_finisher->queue(TASK_CODE_RELEASING_LOCK, ctx);
   }
   return true;
 }
@@ -1011,7 +622,8 @@ bool ImageWatcher::handle_payload(const FlattenPayload &payload,
 				  C_NotifyAck *ack_ctx) {
 
   RWLock::RLocker l(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     bool new_request;
     Context *ctx;
     ProgressContext *prog_ctx;
@@ -1031,7 +643,8 @@ bool ImageWatcher::handle_payload(const FlattenPayload &payload,
 bool ImageWatcher::handle_payload(const ResizePayload &payload,
 				  C_NotifyAck *ack_ctx) {
   RWLock::RLocker l(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     bool new_request;
     Context *ctx;
     ProgressContext *prog_ctx;
@@ -1052,7 +665,8 @@ bool ImageWatcher::handle_payload(const ResizePayload &payload,
 bool ImageWatcher::handle_payload(const SnapCreatePayload &payload,
 				  C_NotifyAck *ack_ctx) {
   RWLock::RLocker l(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     ldout(m_image_ctx.cct, 10) << this << " remote snap_create request: "
 			       << payload.snap_name << dendl;
 
@@ -1066,7 +680,8 @@ bool ImageWatcher::handle_payload(const SnapCreatePayload &payload,
 bool ImageWatcher::handle_payload(const SnapRenamePayload &payload,
 				  C_NotifyAck *ack_ctx) {
   RWLock::RLocker l(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     ldout(m_image_ctx.cct, 10) << this << " remote snap_rename request: "
 			       << payload.snap_id << " to "
 			       << payload.snap_name << dendl;
@@ -1081,7 +696,8 @@ bool ImageWatcher::handle_payload(const SnapRenamePayload &payload,
 bool ImageWatcher::handle_payload(const SnapRemovePayload &payload,
 				  C_NotifyAck *ack_ctx) {
   RWLock::RLocker l(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     ldout(m_image_ctx.cct, 10) << this << " remote snap_remove request: "
 			       << payload.snap_name << dendl;
 
@@ -1095,7 +711,8 @@ bool ImageWatcher::handle_payload(const SnapRemovePayload &payload,
 bool ImageWatcher::handle_payload(const SnapProtectPayload& payload,
                                   C_NotifyAck *ack_ctx) {
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     ldout(m_image_ctx.cct, 10) << this << " remote snap_protect request: "
                                << payload.snap_name << dendl;
 
@@ -1109,7 +726,8 @@ bool ImageWatcher::handle_payload(const SnapProtectPayload& payload,
 bool ImageWatcher::handle_payload(const SnapUnprotectPayload& payload,
                                   C_NotifyAck *ack_ctx) {
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     ldout(m_image_ctx.cct, 10) << this << " remote snap_unprotect request: "
                                << payload.snap_name << dendl;
 
@@ -1123,7 +741,8 @@ bool ImageWatcher::handle_payload(const SnapUnprotectPayload& payload,
 bool ImageWatcher::handle_payload(const RebuildObjectMapPayload& payload,
                                   C_NotifyAck *ack_ctx) {
   RWLock::RLocker l(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     bool new_request;
     Context *ctx;
     ProgressContext *prog_ctx;
@@ -1144,7 +763,8 @@ bool ImageWatcher::handle_payload(const RebuildObjectMapPayload& payload,
 bool ImageWatcher::handle_payload(const RenamePayload& payload,
                                   C_NotifyAck *ack_ctx) {
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     ldout(m_image_ctx.cct, 10) << this << " remote rename request: "
                                << payload.image_name << dendl;
 
@@ -1158,7 +778,8 @@ bool ImageWatcher::handle_payload(const RenamePayload& payload,
 bool ImageWatcher::handle_payload(const UnknownPayload &payload,
 				  C_NotifyAck *ack_ctx) {
   RWLock::RLocker l(m_image_ctx.owner_lock);
-  if (is_lock_owner()) {
+  if (m_image_ctx.exclusive_lock != nullptr &&
+      m_image_ctx.exclusive_lock->is_lock_owner()) {
     ::encode(ResponseMessage(-EOPNOTSUPP), ack_ctx->out);
   }
   return true;
@@ -1213,14 +834,23 @@ void ImageWatcher::acknowledge_notify(uint64_t notify_id, uint64_t handle,
 void ImageWatcher::reregister_watch() {
   ldout(m_image_ctx.cct, 10) << this << " re-registering image watch" << dendl;
 
-  RWLock::WLocker l(m_image_ctx.owner_lock);
   bool was_lock_owner = false;
-  if (m_lock_owner_state == LOCK_OWNER_STATE_LOCKED) {
-    // ensure all async requests are canceled and IO is flushed
-    was_lock_owner = release_lock();
+  C_SaferCond release_lock_ctx;
+  {
+    RWLock::WLocker l(m_image_ctx.owner_lock);
+    if (m_image_ctx.exclusive_lock != nullptr &&
+        m_image_ctx.exclusive_lock->is_lock_owner()) {
+      was_lock_owner = true;
+      m_image_ctx.exclusive_lock->release_lock(&release_lock_ctx);
+    }
   }
 
   int r;
+  if (was_lock_owner) {
+    r = release_lock_ctx.wait();
+    assert(r == 0);
+  }
+
   {
     RWLock::WLocker l(m_watch_lock);
     if (m_watch_state != WATCH_STATE_ERROR) {
@@ -1244,18 +874,6 @@ void ImageWatcher::reregister_watch() {
     m_watch_state = WATCH_STATE_REGISTERED;
   }
   handle_payload(HeaderUpdatePayload(), NULL);
-
-  if (was_lock_owner) {
-    r = try_lock();
-    if (r == -EBUSY) {
-      ldout(m_image_ctx.cct, 5) << this << "lost image lock while "
-                                << "re-registering image watch" << dendl;
-    } else if (r < 0) {
-      lderr(m_image_ctx.cct) << this
-                             << "failed to lock image while re-registering "
-                             << "image watch" << cpp_strerror(r) << dendl;
-    }
-  }
 }
 
 void ImageWatcher::WatchCtx::handle_notify(uint64_t notify_id,
@@ -1271,27 +889,6 @@ void ImageWatcher::WatchCtx::handle_error(uint64_t handle, int err) {
 
 void ImageWatcher::RemoteContext::finish(int r) {
   m_image_watcher.schedule_async_complete(m_async_request_id, r);
-}
-
-void ImageWatcher::notify_listeners_updated_lock(
-    LockUpdateState lock_update_state) {
-  assert(m_image_ctx.owner_lock.is_locked());
-
-  Listeners listeners;
-  {
-    Mutex::Locker listeners_locker(m_listeners_lock);
-    m_listeners_in_use = true;
-    listeners = m_listeners;
-  }
-
-  for (Listeners::iterator it = listeners.begin();
-       it != listeners.end(); ++it) {
-    (*it)->handle_lock_updated(lock_update_state);
-  }
-
-  Mutex::Locker listeners_locker(m_listeners_lock);
-  m_listeners_in_use = false;
-  m_listeners_cond.Signal();
 }
 
 ImageWatcher::C_NotifyAck::C_NotifyAck(ImageWatcher *image_watcher,
@@ -1320,28 +917,3 @@ void ImageWatcher::C_ResponseMessage::finish(int r) {
 }
 
 } // namespace librbd
-
-std::ostream &operator<<(std::ostream &os,
-			 const librbd::ImageWatcher::LockUpdateState &state) {
-  switch (state) {
-  case librbd::ImageWatcher::LOCK_UPDATE_STATE_NOT_SUPPORTED:
-    os << "NotSupported";
-    break;
-  case librbd::ImageWatcher::LOCK_UPDATE_STATE_LOCKED:
-    os << "Locked";
-    break;
-  case librbd::ImageWatcher::LOCK_UPDATE_STATE_RELEASING:
-    os << "Releasing";
-    break;
-  case librbd::ImageWatcher::LOCK_UPDATE_STATE_UNLOCKED:
-    os << "Unlocked";
-    break;
-  case librbd::ImageWatcher::LOCK_UPDATE_STATE_NOTIFICATION:
-    os << "Notification";
-    break;
-  default:
-    os << "Unknown (" << static_cast<uint32_t>(state) << ")";
-    break;
-  }
-  return os;
-}

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -581,9 +581,7 @@ bool ImageWatcher::handle_payload(const RequestLockPayload &payload,
 
     ldout(m_image_ctx.cct, 10) << this << " queuing release of exclusive lock"
                                << dendl;
-    FunctionContext *ctx = new FunctionContext(
-      boost::bind(&ImageWatcher::notify_release_lock, this));
-    m_task_finisher->queue(TASK_CODE_RELEASING_LOCK, ctx);
+    m_image_ctx.exclusive_lock->release_lock(nullptr);
   }
   return true;
 }

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -4,6 +4,7 @@
 #include "librbd/AioCompletion.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
 #include "librbd/internal.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/TaskFinisher.h"
@@ -497,8 +498,7 @@ bool ImageWatcher::handle_payload(const HeaderUpdatePayload &payload,
 				  C_NotifyAck *ack_ctx) {
   ldout(m_image_ctx.cct, 10) << this << " image header updated" << dendl;
 
-  Mutex::Locker lictx(m_image_ctx.refresh_lock);
-  ++m_image_ctx.refresh_seq;
+  m_image_ctx.state->handle_update_notification();
   m_image_ctx.perfcounter->inc(l_librbd_notify);
   return true;
 }

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -46,7 +46,6 @@ public:
   int notify_rename(const std::string &image_name);
 
   void notify_acquired_lock();
-  void notify_release_lock();
   void notify_released_lock();
   void notify_request_lock();
 
@@ -68,7 +67,6 @@ private:
   enum TaskCode {
     TASK_CODE_ACQUIRED_LOCK,
     TASK_CODE_REQUEST_LOCK,
-    TASK_CODE_RELEASING_LOCK,
     TASK_CODE_RELEASED_LOCK,
     TASK_CODE_CANCEL_ASYNC_REQUESTS,
     TASK_CODE_REREGISTER_WATCH,

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -75,6 +75,8 @@ public:
                                 ProgressContext &prog_ctx);
   int notify_rename(const std::string &image_name);
 
+  void notify_request_lock();
+
   void notify_lock_state();
   static void notify_header_update(librados::IoCtx &io_ctx,
                                    const std::string &oid);
@@ -267,7 +269,6 @@ private:
   void notify_released_lock();
 
   void schedule_request_lock(bool use_timer, int timer_delay = -1);
-  void notify_request_lock();
 
   int notify_lock_owner(bufferlist &bl);
 

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -169,6 +169,23 @@ private:
     virtual void finish(int r);
   };
 
+  struct C_ProcessPayload : public Context {
+    ImageWatcher *image_watcher;
+    uint64_t notify_id;
+    uint64_t handle;
+    watch_notify::Payload payload;
+
+    C_ProcessPayload(ImageWatcher *image_watcher_, uint64_t notify_id_,
+                     uint64_t handle_, const watch_notify::Payload &payload)
+      : image_watcher(image_watcher_), notify_id(notify_id_), handle(handle_),
+        payload(payload) {
+    }
+
+    virtual void finish(int r) override {
+      image_watcher->process_payload(notify_id, handle, payload, r);
+    }
+  };
+
   struct HandlePayloadVisitor : public boost::static_visitor<void> {
     ImageWatcher *image_watcher;
     uint64_t notify_id;
@@ -265,6 +282,8 @@ private:
                       C_NotifyAck *ctx);
   bool handle_payload(const watch_notify::UnknownPayload& payload,
                       C_NotifyAck *ctx);
+  void process_payload(uint64_t notify_id, uint64_t handle,
+                       const watch_notify::Payload &payload, int r);
 
   void handle_notify(uint64_t notify_id, uint64_t handle, bufferlist &bl);
   void handle_error(uint64_t cookie, int err);

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -248,6 +248,11 @@ void Journal::open() {
   create_journaler();
 }
 
+void Journal::open(Context *on_finish) {
+  open();
+  wait_for_journal_ready(on_finish);
+}
+
 int Journal::close() {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << this << " " << __func__ << ": state=" << m_state << dendl;
@@ -286,6 +291,11 @@ int Journal::close() {
 
   destroy_journaler();
   return 0;
+}
+
+void Journal::close(Context *on_finish) {
+  // TODO
+  assert(false);
 }
 
 uint64_t Journal::append_io_event(AioCompletion *aio_comp,

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -13,7 +13,6 @@
 #include "common/Cond.h"
 #include "journal/Future.h"
 #include "journal/ReplayHandler.h"
-#include "librbd/ImageWatcher.h"
 #include <algorithm>
 #include <list>
 #include <string>
@@ -108,19 +107,6 @@ private:
   };
   typedef ceph::unordered_map<uint64_t, Event> Events;
 
-  struct LockListener : public ImageWatcher::Listener {
-    Journal *journal;
-    LockListener(Journal *_journal) : journal(_journal) {
-    }
-
-    virtual bool handle_requested_lock() {
-      return journal->handle_requested_lock();
-    }
-    virtual void handle_lock_updated(ImageWatcher::LockUpdateState state) {
-      journal->handle_lock_updated(state);
-    }
-  };
-
   struct C_InitJournal : public Context {
     Journal *journal;
 
@@ -186,7 +172,6 @@ private:
   State m_state;
 
   Contexts m_wait_for_state_contexts;
-  LockListener m_lock_listener;
 
   ReplayHandler m_replay_handler;
   bool m_close_pending;
@@ -212,9 +197,6 @@ private:
   void handle_replay_complete(int r);
 
   void handle_event_safe(int r, uint64_t tid);
-
-  bool handle_requested_lock();
-  void handle_lock_updated(ImageWatcher::LockUpdateState state);
 
   int stop_recording();
 

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -54,8 +54,10 @@ public:
   void wait_for_journal_ready(Context *on_ready);
   void wait_for_journal_ready();
 
-  void open();
-  int close();
+  void open();  // TODO remove
+  void open(Context *on_finish);
+  int close();  // TODO remove
+  void close(Context *on_finish);
 
   uint64_t append_io_event(AioCompletion *aio_comp,
                            const journal::EventEntry &event_entry,

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -10,7 +10,6 @@
 #include "include/unordered_map.h"
 #include "include/rados/librados.hpp"
 #include "common/Mutex.h"
-#include "common/Cond.h"
 #include "journal/Future.h"
 #include "journal/ReplayHandler.h"
 #include <algorithm>
@@ -51,11 +50,8 @@ public:
   bool is_journal_replaying() const;
 
   void wait_for_journal_ready(Context *on_ready);
-  void wait_for_journal_ready();
 
-  void open();  // TODO remove
   void open(Context *on_finish);
-  int close();  // TODO remove
   void close(Context *on_finish);
 
   uint64_t append_io_event(AioCompletion *aio_comp,
@@ -77,12 +73,42 @@ private:
   typedef std::list<Context *> Contexts;
   typedef interval_set<uint64_t> ExtentInterval;
 
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * UNINITIALIZED ---> INITIALIZING ---> REPLAYING ------> READY
+   *    |                 *  .  ^             *  .            |
+   *    |                 *  .  |             *  .            |
+   *    |                 *  .  |    (error)  *  . . . .      |
+   *    |                 *  .  |             *        .      |
+   *    |                 *  .  |             v        .      v
+   *    |                 *  .  |         RESTARTING   .    STOPPING
+   *    |                 *  .  |             |        .      |
+   *    |                 *  .  |             |        .      |
+   *    |       * * * * * *  .  \-------------/        .      |
+   *    |       * (error)    .                         .      |
+   *    |       *            .   . . . . . . . . . . . .      |
+   *    |       *            .   .                            |
+   *    |       v            v   v                            |
+   *    |     CLOSED <----- CLOSING <-------------------------/
+   *    |       |
+   *    |       v
+   *    \---> <finish>
+   *
+   * @endverbatim
+   */
   enum State {
     STATE_UNINITIALIZED,
     STATE_INITIALIZING,
     STATE_REPLAYING,
-    STATE_RECORDING,
-    STATE_STOPPING_RECORDING
+    STATE_RESTARTING_REPLAY,
+    STATE_READY,
+    STATE_STOPPING,
+    STATE_CLOSING,
+    STATE_CLOSED
   };
 
   struct Event {
@@ -118,6 +144,28 @@ private:
     }
   };
 
+  struct C_StopRecording : public Context {
+    Journal *journal;
+
+    C_StopRecording(Journal *_journal) : journal(_journal) {
+    }
+
+    virtual void finish(int r) {
+      journal->handle_recording_stopped(r);
+    }
+  };
+
+  struct C_DestroyJournaler : public Context {
+    Journal *journal;
+
+    C_DestroyJournaler(Journal *_journal) : journal(_journal) {
+    }
+
+    virtual void finish(int r) {
+      journal->handle_journal_destroyed(r);
+    }
+  };
+
   struct C_EventSafe : public Context {
     Journal *journal;
     uint64_t tid;
@@ -128,19 +176,6 @@ private:
 
     virtual void finish(int r) {
       journal->handle_event_safe(r, tid);
-    }
-  };
-
-  struct C_WaitForReady : public Context {
-    Journal *journal;
-    Context *on_ready;
-
-    C_WaitForReady(Journal *_journal, Context *_on_ready)
-      : journal(_journal), on_ready(_on_ready) {
-    }
-
-    virtual void finish(int r) {
-      journal->handle_wait_for_ready(on_ready);
     }
   };
 
@@ -168,9 +203,9 @@ private:
 
   ::journal::Journaler *m_journaler;
   mutable Mutex m_lock;
-  Cond m_cond;
   State m_state;
 
+  int m_error_result;
   Contexts m_wait_for_state_contexts;
 
   ReplayHandler m_replay_handler;
@@ -187,7 +222,8 @@ private:
   ::journal::Future wait_event(Mutex &lock, uint64_t tid, Context *on_safe);
 
   void create_journaler();
-  void destroy_journaler();
+  void destroy_journaler(int r);
+  void recreate_journaler(int r);
 
   void complete_event(Events::iterator it, int r);
 
@@ -196,18 +232,21 @@ private:
   void handle_replay_ready();
   void handle_replay_complete(int r);
 
+  void handle_recording_stopped(int r);
+
+  void handle_journal_destroyed(int r);
+
   void handle_event_safe(int r, uint64_t tid);
 
-  int stop_recording();
+  void stop_recording();
 
   void block_writes();
   void unblock_writes();
 
-  void flush_journal();
-  void transition_state(State state);
-  void wait_for_state_transition();
-  void schedule_wait_for_ready(Context *on_ready);
-  void handle_wait_for_ready(Context *on_ready);
+  void transition_state(State state, int r);
+
+  bool is_steady_state() const;
+  void wait_for_steady_state(Context *on_state);
 
   friend std::ostream &operator<<(std::ostream &os, const State &state);
 };

--- a/src/librbd/JournalReplay.cc
+++ b/src/librbd/JournalReplay.cc
@@ -150,8 +150,8 @@ void JournalReplay::handle_event(const journal::UnknownEvent &event,
 
 AioCompletion *JournalReplay::create_aio_completion(Context *on_safe) {
   Mutex::Locker locker(m_lock);
-  AioCompletion *aio_comp = aio_create_completion_internal(
-    this, &aio_completion_callback);
+  AioCompletion *aio_comp = AioCompletion::create(this, aio_completion_callback,
+                                                  nullptr);
   m_aio_completions.insert(std::pair<AioCompletion*,Context*>(
 			     aio_comp, on_safe));
   return aio_comp;

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -12,6 +12,7 @@
 #include "include/rbd/librbd.hpp"
 
 #include "librbd/AioObjectRequest.h"
+#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/internal.h"
 #include "librbd/LibrbdWriteback.h"
@@ -157,7 +158,7 @@ namespace librbd {
                      << "journal committed: sending write request" << dendl;
 
       RWLock::RLocker owner_locker(image_ctx->owner_lock);
-      assert(image_ctx->image_watcher->is_lock_owner());
+      assert(image_ctx->exclusive_lock->is_lock_owner());
 
       request_sent = true;
       AioObjectWrite *req = new AioObjectWrite(image_ctx, oid, object_no, off,

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -18,6 +18,7 @@
 #include "librbd/AioCompletion.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/Journal.h"
+#include "librbd/Utils.h"
 
 #include "include/assert.h"
 
@@ -193,12 +194,13 @@ namespace librbd {
       }
     }
 
-    librados::AioCompletion *rados_completion =
-      librados::Rados::aio_create_completion(req, context_cb, NULL);
     librados::ObjectReadOperation op;
     op.read(off, len, pbl, NULL);
     op.set_op_flags2(op_flags);
     int flags = m_ictx->get_read_flags(snapid);
+
+    librados::AioCompletion *rados_completion =
+      util::create_rados_ack_callback(req);
     int r = m_ictx->data_ctx.aio_operate(oid.name, rados_completion, &op,
 					 flags, NULL);
     rados_completion->release();

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -189,7 +189,9 @@ namespace librbd {
                                      &m_lock);
 
     {
-      if (!m_ictx->object_map.object_may_exist(object_no)) {
+      RWLock::RLocker snap_locker(m_ictx->snap_lock);
+      if (m_ictx->object_map != nullptr &&
+          !m_ictx->object_map->object_may_exist(object_no)) {
 	m_finisher->queue(req, -ENOENT);
 	return;
       }

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -19,7 +19,7 @@ librbd_internal_la_SOURCES = \
 	librbd/DiffIterate.cc \
 	librbd/ExclusiveLock.cc \
 	librbd/ImageCtx.cc \
-	librbd/ImageRefresh.cc \
+	librbd/ImageState.cc \
 	librbd/ImageWatcher.cc \
 	librbd/internal.cc \
 	librbd/Journal.cc \
@@ -93,7 +93,7 @@ noinst_HEADERS += \
 	librbd/DiffIterate.h \
 	librbd/ExclusiveLock.h \
 	librbd/ImageCtx.h \
-	librbd/ImageRefresh.h \
+	librbd/ImageState.h \
 	librbd/ImageWatcher.h \
 	librbd/internal.h \
 	librbd/Journal.h \

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -90,6 +90,7 @@ noinst_HEADERS += \
 	librbd/parent_types.h \
 	librbd/SnapInfo.h \
 	librbd/TaskFinisher.h \
+	librbd/Utils.h \
 	librbd/WatchNotifyTypes.h \
 	librbd/object_map/InvalidateRequest.h \
 	librbd/object_map/Request.h \

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -19,6 +19,7 @@ librbd_internal_la_SOURCES = \
 	librbd/DiffIterate.cc \
 	librbd/ExclusiveLock.cc \
 	librbd/ImageCtx.cc \
+	librbd/ImageRefresh.cc \
 	librbd/ImageWatcher.cc \
 	librbd/internal.cc \
 	librbd/Journal.cc \
@@ -29,6 +30,11 @@ librbd_internal_la_SOURCES = \
 	librbd/Utils.cc \
 	librbd/exclusive_lock/AcquireRequest.cc \
 	librbd/exclusive_lock/ReleaseRequest.cc \
+	librbd/image/CloseRequest.cc \
+	librbd/image/OpenRequest.cc \
+	librbd/image/RefreshParentRequest.cc \
+	librbd/image/RefreshRequest.cc \
+	librbd/image/SetSnapRequest.cc \
 	librbd/object_map/InvalidateRequest.cc \
 	librbd/object_map/LockRequest.cc \
 	librbd/object_map/Request.cc \
@@ -87,6 +93,7 @@ noinst_HEADERS += \
 	librbd/DiffIterate.h \
 	librbd/ExclusiveLock.h \
 	librbd/ImageCtx.h \
+	librbd/ImageRefresh.h \
 	librbd/ImageWatcher.h \
 	librbd/internal.h \
 	librbd/Journal.h \
@@ -102,6 +109,11 @@ noinst_HEADERS += \
 	librbd/WatchNotifyTypes.h \
 	librbd/exclusive_lock/AcquireRequest.h \
 	librbd/exclusive_lock/ReleaseRequest.h \
+	librbd/image/CloseRequest.h \
+	librbd/image/OpenRequest.h \
+	librbd/image/RefreshParentRequest.h \
+	librbd/image/RefreshRequest.h \
+	librbd/image/SetSnapRequest.h \
 	librbd/object_map/InvalidateRequest.h \
 	librbd/object_map/LockRequest.h \
 	librbd/object_map/Request.h \

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -25,6 +25,7 @@ librbd_internal_la_SOURCES = \
 	librbd/LibrbdAdminSocketHook.cc \
 	librbd/LibrbdWriteback.cc \
 	librbd/ObjectMap.cc \
+	librbd/Utils.cc \
 	librbd/object_map/InvalidateRequest.cc \
 	librbd/object_map/Request.cc \
 	librbd/object_map/ResizeRequest.cc \

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -27,11 +27,14 @@ librbd_internal_la_SOURCES = \
 	librbd/ObjectMap.cc \
 	librbd/Utils.cc \
 	librbd/object_map/InvalidateRequest.cc \
+	librbd/object_map/LockRequest.cc \
 	librbd/object_map/Request.cc \
+	librbd/object_map/RefreshRequest.cc \
 	librbd/object_map/ResizeRequest.cc \
 	librbd/object_map/SnapshotCreateRequest.cc \
 	librbd/object_map/SnapshotRemoveRequest.cc \
 	librbd/object_map/SnapshotRollbackRequest.cc \
+	librbd/object_map/UnlockRequest.cc \
 	librbd/object_map/UpdateRequest.cc \
 	librbd/operation/FlattenRequest.cc \
 	librbd/operation/RebuildObjectMapRequest.cc \
@@ -94,11 +97,14 @@ noinst_HEADERS += \
 	librbd/Utils.h \
 	librbd/WatchNotifyTypes.h \
 	librbd/object_map/InvalidateRequest.h \
+	librbd/object_map/LockRequest.h \
 	librbd/object_map/Request.h \
+	librbd/object_map/RefreshRequest.h \
 	librbd/object_map/ResizeRequest.h \
 	librbd/object_map/SnapshotCreateRequest.h \
 	librbd/object_map/SnapshotRemoveRequest.h \
 	librbd/object_map/SnapshotRollbackRequest.h \
+	librbd/object_map/UnlockRequest.h \
 	librbd/object_map/UpdateRequest.h \
 	librbd/operation/FlattenRequest.h \
 	librbd/operation/RebuildObjectMapRequest.h \

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -17,6 +17,7 @@ librbd_internal_la_SOURCES = \
 	librbd/AsyncRequest.cc \
 	librbd/CopyupRequest.cc \
 	librbd/DiffIterate.cc \
+	librbd/ExclusiveLock.cc \
 	librbd/ImageCtx.cc \
 	librbd/ImageWatcher.cc \
 	librbd/internal.cc \
@@ -26,6 +27,8 @@ librbd_internal_la_SOURCES = \
 	librbd/LibrbdWriteback.cc \
 	librbd/ObjectMap.cc \
 	librbd/Utils.cc \
+	librbd/exclusive_lock/AcquireRequest.cc \
+	librbd/exclusive_lock/ReleaseRequest.cc \
 	librbd/object_map/InvalidateRequest.cc \
 	librbd/object_map/LockRequest.cc \
 	librbd/object_map/Request.cc \
@@ -82,6 +85,7 @@ noinst_HEADERS += \
 	librbd/AsyncRequest.h \
 	librbd/CopyupRequest.h \
 	librbd/DiffIterate.h \
+	librbd/ExclusiveLock.h \
 	librbd/ImageCtx.h \
 	librbd/ImageWatcher.h \
 	librbd/internal.h \
@@ -96,6 +100,8 @@ noinst_HEADERS += \
 	librbd/TaskFinisher.h \
 	librbd/Utils.h \
 	librbd/WatchNotifyTypes.h \
+	librbd/exclusive_lock/AcquireRequest.h \
+	librbd/exclusive_lock/ReleaseRequest.h \
 	librbd/object_map/InvalidateRequest.h \
 	librbd/object_map/LockRequest.h \
 	librbd/object_map/Request.h \

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 #include "librbd/ObjectMap.h"
+#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageWatcher.h"
 #include "librbd/internal.h"
@@ -349,8 +350,8 @@ void ObjectMap::aio_resize(uint64_t new_size, uint8_t default_object_state,
   assert(m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP));
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.image_watcher != NULL);
-  assert(!m_image_ctx.image_watcher->is_lock_supported() ||
-         m_image_ctx.image_watcher->is_lock_owner());
+  assert(m_image_ctx.exclusive_lock == nullptr ||
+         m_image_ctx.exclusive_lock->is_lock_owner());
 
   object_map::ResizeRequest *req = new object_map::ResizeRequest(
     m_image_ctx, &m_object_map, m_snap_id, new_size, default_object_state,
@@ -375,8 +376,8 @@ bool ObjectMap::aio_update(uint64_t start_object_no, uint64_t end_object_no,
   assert((m_image_ctx.features & RBD_FEATURE_OBJECT_MAP) != 0);
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.image_watcher != NULL);
-  assert(!m_image_ctx.image_watcher->is_lock_supported(m_image_ctx.snap_lock) ||
-         m_image_ctx.image_watcher->is_lock_owner());
+  assert(m_image_ctx.exclusive_lock == nullptr ||
+         m_image_ctx.exclusive_lock->is_lock_owner());
   assert(m_image_ctx.object_map_lock.is_wlocked());
   assert(start_object_no < end_object_no);
 

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -387,7 +387,7 @@ void ObjectMap::invalidate(uint64_t snap_id, bool force) {
 
   // TODO remove once all methods are async
   C_SaferCond cond_ctx;
-  object_map::InvalidateRequest *req = new object_map::InvalidateRequest(
+  object_map::InvalidateRequest<> *req = new object_map::InvalidateRequest<>(
     m_image_ctx, m_snap_id, force, &cond_ctx);
   req->send();
 

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -27,25 +27,8 @@
 
 namespace librbd {
 
-namespace {
-
-struct C_ApplyRefresh : public Context {
-  object_map::RefreshRequest<> *request;
-  C_ApplyRefresh(object_map::RefreshRequest<> *request) : request(request) {
-  }
-  virtual void finish(int r) {
-    if (r < 0) {
-      request->apply();
-    } else {
-      request->discard();
-    }
-  }
-};
-
-} // anonymous namespace
-
-ObjectMap::ObjectMap(ImageCtx &image_ctx)
-  : m_image_ctx(image_ctx), m_snap_id(CEPH_NOSNAP)
+ObjectMap::ObjectMap(ImageCtx &image_ctx, uint64_t snap_id)
+  : m_image_ctx(image_ctx), m_snap_id(snap_id)
 {
 }
 
@@ -79,101 +62,15 @@ uint8_t ObjectMap::operator[](uint64_t object_no) const
   return m_object_map[object_no];
 }
 
-int ObjectMap::lock()
-{
-  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP)) {
-    return 0;
-  }
-
-  bool broke_lock = false;
-  CephContext *cct = m_image_ctx.cct;
-  std::string oid(object_map_name(m_image_ctx.id, CEPH_NOSNAP));
-  while (true) {
-    int r;
-    ldout(cct, 10) << &m_image_ctx << " locking object map: "
-                   << oid << dendl;
-    r = rados::cls::lock::lock(&m_image_ctx.md_ctx, oid,
-			       RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "", "",
-			       utime_t(), 0);
-    if (r == 0) {
-      break;
-    } else if (broke_lock || r != -EBUSY) {
-      lderr(cct) << "failed to lock object map: " << cpp_strerror(r) << dendl;
-      return r;
-    }
-
-    typedef std::map<rados::cls::lock::locker_id_t,
-                     rados::cls::lock::locker_info_t> lockers_t;
-    lockers_t lockers;
-    ClsLockType lock_type;
-    std::string lock_tag;
-    r = rados::cls::lock::get_lock_info(&m_image_ctx.md_ctx, oid,
-                                        RBD_LOCK_NAME, &lockers,
-                                        &lock_type, &lock_tag);
-    if (r == -ENOENT) {
-      continue;
-    } else if (r < 0) {
-      lderr(cct) << "failed to list object map locks: " << cpp_strerror(r)
-                 << dendl;
-      return r;
-    }
-
-    ldout(cct, 10) << "breaking current object map lock" << dendl;
-    for (lockers_t::iterator it = lockers.begin();
-         it != lockers.end(); ++it) {
-      const rados::cls::lock::locker_id_t &locker = it->first;
-      r = rados::cls::lock::break_lock(&m_image_ctx.md_ctx, oid,
-                                       RBD_LOCK_NAME, locker.cookie,
-                                       locker.locker);
-      if (r < 0 && r != -ENOENT) {
-        lderr(cct) << "failed to break object map lock: " << cpp_strerror(r)
-                   << dendl;
-        return r;
-      }
-    }
-
-
-
-    broke_lock = true;
-  }
-  return 0;
-}
-
-void ObjectMap::lock(Context *on_finish) {
-  object_map::LockRequest<> *req = new object_map::LockRequest<>(
-    m_image_ctx, on_finish);
-  req->send();
-}
-
-int ObjectMap::unlock()
-{
-  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP)) {
-    return 0;
-  }
-
-  std::string oid = object_map_name(m_image_ctx.id, CEPH_NOSNAP);
-  ldout(m_image_ctx.cct, 10) << &m_image_ctx << " unlocking object map: "
-			     << oid << dendl;
-  int r = rados::cls::lock::unlock(&m_image_ctx.md_ctx, oid,
-                                   RBD_LOCK_NAME, "");
-  if (r < 0 && r != -ENOENT) {
-    lderr(m_image_ctx.cct) << "failed to release object map lock: "
-			   << cpp_strerror(r) << dendl;
-  }
-  return r;
-}
-
-void ObjectMap::unlock(Context *on_finish) {
-  object_map::UnlockRequest<> *req = new object_map::UnlockRequest<>(
-    m_image_ctx, on_finish);
-  req->send();
-}
-
 bool ObjectMap::object_may_exist(uint64_t object_no) const
 {
+  assert(m_image_ctx.snap_lock.is_locked());
+
   // Fall back to default logic if object map is disabled or invalid
-  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP) ||
-      m_image_ctx.test_flags(RBD_FLAG_OBJECT_MAP_INVALID)) {
+  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,
+                                 m_image_ctx.snap_lock) ||
+      m_image_ctx.test_flags(RBD_FLAG_OBJECT_MAP_INVALID,
+                             m_image_ctx.snap_lock)) {
     return true;
   }
 
@@ -186,83 +83,24 @@ bool ObjectMap::object_may_exist(uint64_t object_no) const
   return exists;
 }
 
-void ObjectMap::refresh(uint64_t snap_id)
-{
-  assert(m_image_ctx.snap_lock.is_wlocked());
-  RWLock::WLocker l(m_image_ctx.object_map_lock);
-  m_snap_id = snap_id;
-
-  CephContext *cct = m_image_ctx.cct;
-  std::string oid(object_map_name(m_image_ctx.id, snap_id));
-  ldout(cct, 10) << &m_image_ctx << " refreshing object map: "
-                 << oid << dendl;
-
-  uint64_t num_objs = Striper::get_num_objects(
-    m_image_ctx.layout, m_image_ctx.get_image_size(snap_id));
-
-  int r = cls_client::object_map_load(&m_image_ctx.md_ctx, oid,
-                                      &m_object_map);
-  if (r == -EINVAL) {
-    // object map is corrupt on-disk -- clear it and properly size it
-    // so future IO can keep the object map in sync
-    invalidate(snap_id, false);
-
-    librados::ObjectWriteOperation op;
-    if (snap_id == CEPH_NOSNAP) {
-      rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "",
-                                      "");
-    }
-    op.truncate(0);
-    cls_client::object_map_resize(&op, num_objs, OBJECT_NONEXISTENT);
-
-    r = m_image_ctx.md_ctx.operate(oid, &op);
-    if (r == 0) {
-      m_object_map.clear();
-      object_map::ResizeRequest::resize(&m_object_map, num_objs,
-                                        OBJECT_NONEXISTENT);
-    }
-  }
-  if (r < 0) {
-    lderr(cct) << "error refreshing object map: " << cpp_strerror(r)
-               << dendl;
-    invalidate(snap_id, false);
-    m_object_map.clear();
-    return;
-  }
-
-  ldout(cct, 20) << "refreshed object map: num_objs=" << m_object_map.size()
-                 << dendl;
-
-  if (m_object_map.size() < num_objs) {
-    lderr(cct) << "object map smaller than current object count: "
-               << m_object_map.size() << " != " << num_objs << dendl;
-    invalidate(snap_id, false);
-
-    // correct the size issue so future IO can keep the object map in sync
-    librados::ObjectWriteOperation op;
-    if (snap_id == CEPH_NOSNAP) {
-      rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "",
-                                      "");
-    }
-    cls_client::object_map_resize(&op, num_objs, OBJECT_NONEXISTENT);
-
-    r = m_image_ctx.md_ctx.operate(oid, &op);
-    if (r == 0) {
-      object_map::ResizeRequest::resize(&m_object_map, num_objs,
-                                        OBJECT_NONEXISTENT);
-    }
-  } else if (m_object_map.size() > num_objs) {
-    // resize op might have been interrupted
-    ldout(cct, 1) << "object map larger than current object count: "
-                  << m_object_map.size() << " != " << num_objs << dendl;
-  }
+void ObjectMap::open(Context *on_finish) {
+  object_map::RefreshRequest<> *req = new object_map::RefreshRequest<>(
+    m_image_ctx, &m_object_map, m_snap_id, on_finish);
+  req->send();
 }
 
-Context* ObjectMap::refresh(uint64_t snap_id, Context *on_finish) {
-  object_map::RefreshRequest<> *req = new object_map::RefreshRequest<>(
-    m_image_ctx, &m_object_map, snap_id, on_finish);
+void ObjectMap::lock(Context *on_finish) {
+  assert(m_snap_id == CEPH_NOSNAP);
+  object_map::LockRequest<> *req = new object_map::LockRequest<>(
+    m_image_ctx, on_finish);
   req->send();
-  return new C_ApplyRefresh(req);
+}
+
+void ObjectMap::unlock(Context *on_finish) {
+  assert(m_snap_id == CEPH_NOSNAP);
+  object_map::UnlockRequest<> *req = new object_map::UnlockRequest<>(
+    m_image_ctx, on_finish);
+  req->send();
 }
 
 void ObjectMap::rollback(uint64_t snap_id, Context *on_finish) {
@@ -277,6 +115,7 @@ void ObjectMap::rollback(uint64_t snap_id, Context *on_finish) {
 void ObjectMap::snapshot_add(uint64_t snap_id, Context *on_finish) {
   assert(m_image_ctx.snap_lock.is_locked());
   assert((m_image_ctx.features & RBD_FEATURE_OBJECT_MAP) != 0);
+  assert(snap_id != CEPH_NOSNAP);
 
   object_map::SnapshotCreateRequest *req =
     new object_map::SnapshotCreateRequest(m_image_ctx, &m_object_map, snap_id,
@@ -295,10 +134,11 @@ void ObjectMap::snapshot_remove(uint64_t snap_id, Context *on_finish) {
   req->send();
 }
 
-void ObjectMap::aio_save(Context *on_finish)
-{
-  assert(m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP));
+void ObjectMap::aio_save(Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
+  assert(m_image_ctx.snap_lock.is_locked());
+  assert(m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,
+                                   m_image_ctx.snap_lock));
   RWLock::RLocker object_map_locker(m_image_ctx.object_map_lock);
 
   librados::ObjectWriteOperation op;
@@ -317,8 +157,10 @@ void ObjectMap::aio_save(Context *on_finish)
 
 void ObjectMap::aio_resize(uint64_t new_size, uint8_t default_object_state,
 			   Context *on_finish) {
-  assert(m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP));
   assert(m_image_ctx.owner_lock.is_locked());
+  assert(m_image_ctx.snap_lock.is_locked());
+  assert(m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,
+                                   m_image_ctx.snap_lock));
   assert(m_image_ctx.image_watcher != NULL);
   assert(m_image_ctx.exclusive_lock == nullptr ||
          m_image_ctx.exclusive_lock->is_lock_owner());
@@ -384,24 +226,6 @@ void ObjectMap::aio_update(uint64_t snap_id, uint64_t start_object_no,
     m_image_ctx, &m_object_map, snap_id, start_object_no, end_object_no,
     new_state, current_state, on_finish);
   req->send();
-}
-
-void ObjectMap::invalidate(uint64_t snap_id, bool force) {
-  assert(m_image_ctx.snap_lock.is_wlocked());
-  assert(m_image_ctx.object_map_lock.is_wlocked());
-  uint64_t flags;
-  m_image_ctx.get_flags(snap_id, &flags);
-  if ((flags & RBD_FLAG_OBJECT_MAP_INVALID) != 0) {
-    return;
-  }
-
-  // TODO remove once all methods are async
-  C_SaferCond cond_ctx;
-  object_map::InvalidateRequest<> *req = new object_map::InvalidateRequest<>(
-    m_image_ctx, m_snap_id, force, &cond_ctx);
-  req->send();
-
-  cond_ctx.wait();
 }
 
 } // namespace librbd

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -10,6 +10,7 @@
 #include "librbd/object_map/SnapshotRemoveRequest.h"
 #include "librbd/object_map/SnapshotRollbackRequest.h"
 #include "librbd/object_map/UpdateRequest.h"
+#include "librbd/Utils.h"
 #include "common/dout.h"
 #include "common/errno.h"
 #include "include/stringify.h"
@@ -297,8 +298,7 @@ void ObjectMap::aio_save(Context *on_finish)
   cls_client::object_map_save(&op, m_object_map);
 
   std::string oid(object_map_name(m_image_ctx.id, m_snap_id));
-  librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-    on_finish, NULL, rados_ctx_cb);
+  librados::AioCompletion *comp = util::create_rados_safe_callback(on_finish);
 
   int r = m_image_ctx.md_ctx.aio_operate(oid, comp, &op);
   assert(r == 0);

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -60,14 +60,10 @@ public:
   void snapshot_add(uint64_t snap_id, Context *on_finish);
   void snapshot_remove(uint64_t snap_id, Context *on_finish);
 
-  bool enabled() const;
-  bool enabled(const RWLock &object_map_lock) const;
-
 private:
   ImageCtx &m_image_ctx;
   ceph::BitVector<2> m_object_map;
   uint64_t m_snap_id;
-  bool m_enabled;
 
   void invalidate(uint64_t snap_id, bool force);
 };

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -31,8 +31,10 @@ public:
     return m_object_map.size();
   }
 
-  int lock();
-  int unlock();
+  int lock();   // TODO remove
+  void lock(Context *on_finish);
+  int unlock(); // TODO remove
+  void unlock(Context *on_finish);
 
   bool object_may_exist(uint64_t object_no) const;
 
@@ -52,7 +54,8 @@ public:
                   const boost::optional<uint8_t> &current_state,
                   Context *on_finish);
 
-  void refresh(uint64_t snap_id);
+  void refresh(uint64_t snap_id); // TODO remove
+  Context *refresh(uint64_t snap_id, Context *on_finish);
   void rollback(uint64_t snap_id, Context *on_finish);
   void snapshot_add(uint64_t snap_id, Context *on_finish);
   void snapshot_remove(uint64_t snap_id, Context *on_finish);

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -18,8 +18,7 @@ class ImageCtx;
 
 class ObjectMap {
 public:
-
-  ObjectMap(ImageCtx &image_ctx);
+  ObjectMap(ImageCtx &image_ctx, uint64_t snap_id);
 
   static int remove(librados::IoCtx &io_ctx, const std::string &image_id);
   static std::string object_map_name(const std::string &image_id,
@@ -31,9 +30,8 @@ public:
     return m_object_map.size();
   }
 
-  int lock();   // TODO remove
+  void open(Context *on_finish);
   void lock(Context *on_finish);
-  int unlock(); // TODO remove
   void unlock(Context *on_finish);
 
   bool object_may_exist(uint64_t object_no) const;
@@ -54,8 +52,6 @@ public:
                   const boost::optional<uint8_t> &current_state,
                   Context *on_finish);
 
-  void refresh(uint64_t snap_id); // TODO remove
-  Context *refresh(uint64_t snap_id, Context *on_finish);
   void rollback(uint64_t snap_id, Context *on_finish);
   void snapshot_add(uint64_t snap_id, Context *on_finish);
   void snapshot_remove(uint64_t snap_id, Context *on_finish);
@@ -65,7 +61,6 @@ private:
   ceph::BitVector<2> m_object_map;
   uint64_t m_snap_id;
 
-  void invalidate(uint64_t snap_id, bool force);
 };
 
 } // namespace librbd

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -1,0 +1,31 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/Utils.h"
+#include "include/rbd_types.h"
+#include "include/stringify.h"
+
+namespace librbd {
+namespace util {
+
+const std::string id_obj_name(const std::string &name)
+{
+  return RBD_ID_PREFIX + name;
+}
+
+const std::string header_name(const std::string &image_id)
+{
+  return RBD_HEADER_PREFIX + image_id;
+}
+
+const std::string old_header_name(const std::string &image_name)
+{
+  return image_name + RBD_SUFFIX;
+}
+
+std::string unique_lock_name(const std::string &name, void *address) {
+  return name + " (" + stringify(address) + ")";
+}
+
+} // namespace util
+} // namespace librbd

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -1,0 +1,134 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_UTILS_H
+#define CEPH_LIBRBD_UTILS_H
+
+#include "include/rados/librados.hpp"
+#include "include/Context.h"
+#include <type_traits>
+
+class Context;
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace util {
+
+namespace detail {
+
+template <typename T>
+void rados_callback(rados_completion_t c, void *arg) {
+  reinterpret_cast<T*>(arg)->complete(rados_aio_get_return_value(c));
+}
+
+template <typename T, Context*(T::*MF)(int*), bool destroy>
+void rados_state_callback(rados_completion_t c, void *arg) {
+  T *obj = reinterpret_cast<T*>(arg);
+  int r = rados_aio_get_return_value(c);
+  Context *on_finish = (obj->*MF)(&r);
+  if (on_finish != nullptr) {
+    on_finish->complete(r);
+    if (destroy) {
+      delete obj;
+    }
+  }
+}
+
+template <typename T, void (T::*MF)(int)>
+class C_CallbackAdapter : public Context {
+  T *obj;
+public:
+  C_CallbackAdapter(T *obj) : obj(obj) {
+  }
+
+protected:
+  virtual void finish(int r) {
+    (obj->*MF)(r);
+  }
+};
+
+template <typename T, Context*(T::*MF)(int*), bool destroy>
+class C_StateCallbackAdapter : public Context {
+  T *obj;
+public:
+  C_StateCallbackAdapter(T *obj) : obj(obj){
+  }
+
+protected:
+  virtual void complete(int r) override {
+    Context *on_finish = (obj->*MF)(&r);
+    if (on_finish != nullptr) {
+      on_finish->complete(r);
+      if (destroy) {
+        delete obj;
+      }
+    }
+    Context::complete(r);
+  }
+  virtual void finish(int r) override {
+  }
+};
+
+template <typename WQ>
+struct C_AsyncCallback : public Context {
+  WQ *op_work_queue;
+  Context *on_finish;
+
+  C_AsyncCallback(WQ *op_work_queue, Context *on_finish)
+    : op_work_queue(op_work_queue), on_finish(on_finish) {
+  }
+  virtual void finish(int r) {
+    op_work_queue->queue(on_finish, r);
+  }
+};
+
+} // namespace detail
+
+template <typename T>
+librados::AioCompletion *create_rados_ack_callback(T *obj) {
+  return librados::Rados::aio_create_completion(
+    obj, &detail::rados_callback<T>, nullptr);
+}
+
+template <typename T, Context*(T::*MF)(int*), bool destroy=true>
+librados::AioCompletion *create_rados_ack_callback(T *obj) {
+  return librados::Rados::aio_create_completion(
+    obj, &detail::rados_state_callback<T, MF, destroy>, nullptr);
+}
+
+template <typename T>
+librados::AioCompletion *create_rados_safe_callback(T *obj) {
+  return librados::Rados::aio_create_completion(
+    obj, nullptr, &detail::rados_callback<T>);
+}
+
+template <typename T, Context*(T::*MF)(int*), bool destroy=true>
+librados::AioCompletion *create_rados_safe_callback(T *obj) {
+  return librados::Rados::aio_create_completion(
+    obj, nullptr, &detail::rados_state_callback<T, MF, destroy>);
+}
+
+template <typename T, void(T::*MF)(int) = &T::complete>
+Context *create_context_callback(T *obj) {
+  return new detail::C_CallbackAdapter<T, MF>(obj);
+}
+
+template <typename T, Context*(T::*MF)(int*), bool destroy=true>
+Context *create_context_callback(T *obj) {
+  return new detail::C_StateCallbackAdapter<T, MF, destroy>(obj);
+}
+
+template <typename I>
+Context *create_async_context_callback(I &image_ctx, Context *on_finish) {
+  // use async callback to acquire a clean lock context
+  return new detail::C_AsyncCallback<
+    typename std::decay<decltype(*image_ctx.op_work_queue)>::type>(
+      image_ctx.op_work_queue, on_finish);
+}
+
+} // namespace util
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_UTILS_H

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -86,6 +86,11 @@ struct C_AsyncCallback : public Context {
 
 } // namespace detail
 
+const std::string id_obj_name(const std::string &name);
+const std::string header_name(const std::string &image_id);
+const std::string old_header_name(const std::string &image_name);
+std::string unique_lock_name(const std::string &name, void *address);
+
 template <typename T>
 librados::AioCompletion *create_rados_ack_callback(T *obj) {
   return librados::Rados::aio_create_completion(

--- a/src/librbd/exclusive_lock/AcquireRequest.cc
+++ b/src/librbd/exclusive_lock/AcquireRequest.cc
@@ -1,0 +1,403 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/exclusive_lock/AcquireRequest.h"
+#include "cls/lock/cls_lock_client.h"
+#include "cls/lock/cls_lock_types.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "common/WorkQueue.h"
+#include "include/stringify.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Journal.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::exclusive_lock::AcquireRequest: "
+
+namespace librbd {
+namespace exclusive_lock {
+
+using util::create_async_context_callback;
+using util::create_context_callback;
+using util::create_rados_ack_callback;
+using util::create_rados_safe_callback;
+
+namespace {
+
+template <typename I>
+struct C_BlacklistClient : public Context {
+  I &image_ctx;
+  std::string locker_address;
+  Context *on_finish;
+
+  C_BlacklistClient(I &image_ctx, const std::string &locker_address,
+                    Context *on_finish)
+    : image_ctx(image_ctx), locker_address(locker_address),
+      on_finish(on_finish) {
+  }
+
+  virtual void finish(int r) override {
+    librados::Rados rados(image_ctx.md_ctx);
+    r = rados.blacklist_add(locker_address,
+                            image_ctx.blacklist_expire_seconds);
+    on_finish->complete(r);
+  }
+};
+
+} // anonymous namespace
+
+template <typename I>
+AcquireRequest<I>* AcquireRequest<I>::create(I &image_ctx,
+                                             const std::string &cookie,
+                                             Context *on_finish) {
+  return new AcquireRequest(image_ctx, cookie, on_finish);
+}
+
+template <typename I>
+AcquireRequest<I>::AcquireRequest(I &image_ctx, const std::string &cookie,
+                                  Context *on_finish)
+  : m_image_ctx(image_ctx), m_cookie(cookie),
+    m_on_finish(create_async_context_callback(image_ctx, on_finish)),
+    m_object_map(nullptr), m_journal(nullptr) {
+}
+
+template <typename I>
+void AcquireRequest<I>::send() {
+  send_lock();
+}
+
+template <typename I>
+void AcquireRequest<I>::send_lock() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  librados::ObjectWriteOperation op;
+  rados::cls::lock::lock(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, m_cookie,
+                         ExclusiveLock<I>::WATCHER_LOCK_TAG, "", utime_t(), 0);
+
+  using klass = AcquireRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_safe_callback<klass, &klass::handle_lock>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid,
+                                         rados_completion, &op);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *AcquireRequest<I>::handle_lock(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val == 0) {
+    return send_open_journal();
+  } else if (*ret_val != -EBUSY) {
+    lderr(cct) << "failed to lock: " << cpp_strerror(*ret_val) << dendl;
+    return m_on_finish;
+  }
+
+  send_get_lockers();
+  return nullptr;
+}
+
+template <typename I>
+Context *AcquireRequest<I>::send_open_journal() {
+  if (!m_image_ctx.test_features(RBD_FEATURE_JOURNALING)) {
+    return send_open_object_map();
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  using klass = AcquireRequest<I>;
+  Context *ctx = create_context_callback<klass, &klass::handle_open_journal>(
+    this);
+  m_journal = m_image_ctx.create_journal();
+  m_journal->open(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *AcquireRequest<I>::handle_open_journal(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val < 0) {
+    lderr(cct) << "failed to open journal: " << cpp_strerror(*ret_val) << dendl;
+
+    delete m_journal;
+    return m_on_finish;
+  }
+
+  assert(m_image_ctx.journal == nullptr);
+  return send_open_object_map();
+}
+
+template <typename I>
+Context *AcquireRequest<I>::send_open_object_map() {
+  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP)) {
+    apply();
+    return m_on_finish;
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  using klass = AcquireRequest<I>;
+  Context *ctx = create_context_callback<klass, &klass::handle_open_object_map>(
+    this);
+  m_object_map = m_image_ctx.create_object_map(CEPH_NOSNAP);
+  m_object_map->open(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *AcquireRequest<I>::handle_open_object_map(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  // object map should never result in an error
+  assert(*ret_val == 0);
+  return send_lock_object_map();
+}
+
+template <typename I>
+Context *AcquireRequest<I>::send_lock_object_map() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  assert(m_object_map != nullptr);
+
+  using klass = AcquireRequest<I>;
+  Context *ctx = create_context_callback<klass, &klass::handle_lock_object_map>(
+    this);
+  m_object_map->lock(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *AcquireRequest<I>::handle_lock_object_map(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  // object map should never result in an error
+  assert(*ret_val == 0);
+
+  apply();
+  return m_on_finish;
+}
+
+template <typename I>
+void AcquireRequest<I>::send_get_lockers() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  librados::ObjectReadOperation op;
+  rados::cls::lock::get_lock_info_start(&op, RBD_LOCK_NAME);
+
+  using klass = AcquireRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_ack_callback<klass, &klass::handle_get_lockers>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid,
+                                         rados_completion, &op, &m_out_bl);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *AcquireRequest<I>::handle_get_lockers(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  std::map<rados::cls::lock::locker_id_t,
+           rados::cls::lock::locker_info_t> lockers;
+  ClsLockType lock_type;
+  std::string lock_tag;
+  if (*ret_val == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    *ret_val = rados::cls::lock::get_lock_info_finish(&it, &lockers,
+                                                      &lock_type, &lock_tag);
+  }
+
+  if (*ret_val < 0) {
+    lderr(cct) << "failed to retrieve lockers: " << cpp_strerror(*ret_val)
+               << dendl;
+    return m_on_finish;
+  }
+
+  if (lockers.empty()) {
+    ldout(cct, 20) << "no lockers detected" << dendl;
+    send_lock();
+    return nullptr;
+  }
+
+  if (lock_tag != ExclusiveLock<I>::WATCHER_LOCK_TAG) {
+    ldout(cct, 5) <<"locked by external mechanism: tag=" << lock_tag << dendl;
+    *ret_val = -EBUSY;
+    return m_on_finish;
+  }
+
+  if (lock_type == LOCK_SHARED) {
+    ldout(cct, 5) << "shared lock type detected" << dendl;
+    *ret_val = -EBUSY;
+    return m_on_finish;
+  }
+
+  std::map<rados::cls::lock::locker_id_t,
+           rados::cls::lock::locker_info_t>::iterator iter = lockers.begin();
+  if (!ExclusiveLock<I>::decode_lock_cookie(iter->first.cookie,
+                                            &m_locker_handle)) {
+    ldout(cct, 5) << "locked by external mechanism: "
+                  << "cookie=" << iter->first.cookie << dendl;
+    *ret_val = -EBUSY;
+    return m_on_finish;
+  }
+
+  m_locker_entity = iter->first.locker;
+  m_locker_cookie = iter->first.cookie;
+  m_locker_address = stringify(iter->second.addr);
+  if (m_locker_cookie.empty() || m_locker_address.empty()) {
+    ldout(cct, 20) << "no valid lockers detected" << dendl;
+    send_lock();
+    return nullptr;
+  }
+
+  ldout(cct, 10) << "retrieved exclusive locker: "
+                 << m_locker_entity << "@" << m_locker_address << dendl;
+  send_get_watchers();
+  return nullptr;
+}
+
+template <typename I>
+void AcquireRequest<I>::send_get_watchers() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  librados::ObjectReadOperation op;
+  op.list_watchers(&m_watchers, &m_watchers_ret_val);
+
+  using klass = AcquireRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_ack_callback<klass, &klass::handle_get_watchers>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid,
+                                         rados_completion, &op, &m_out_bl);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *AcquireRequest<I>::handle_get_watchers(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val == 0) {
+    *ret_val = m_watchers_ret_val;
+  }
+  if (*ret_val < 0) {
+    lderr(cct) << "failed to retrieve watchers: " << cpp_strerror(*ret_val)
+               << dendl;
+    return m_on_finish;
+  }
+
+  for (auto &watcher : m_watchers) {
+    if ((strncmp(m_locker_address.c_str(),
+                 watcher.addr, sizeof(watcher.addr)) == 0) &&
+        (m_locker_handle == watcher.cookie)) {
+      ldout(cct, 10) << "lock owner is still alive" << dendl;
+
+      *ret_val = -EAGAIN;
+      return m_on_finish;
+    }
+  }
+
+  send_blacklist();
+  return nullptr;
+}
+
+template <typename I>
+void AcquireRequest<I>::send_blacklist() {
+  if (!m_image_ctx.blacklist_on_break_lock) {
+    send_break_lock();
+    return;
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  // TODO: need async version of RadosClient::blacklist_add
+  using klass = AcquireRequest<I>;
+  Context *ctx = create_context_callback<klass, &klass::handle_blacklist>(
+    this);
+  m_image_ctx.op_work_queue->queue(new C_BlacklistClient<I>(m_image_ctx,
+                                                            m_locker_address,
+                                                            ctx), 0);
+}
+
+template <typename I>
+Context *AcquireRequest<I>::handle_blacklist(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val < 0) {
+    lderr(cct) << "failed to blacklist lock owner: " << cpp_strerror(*ret_val)
+               << dendl;
+    return m_on_finish;
+  }
+  send_break_lock();
+  return nullptr;
+}
+
+template <typename I>
+void AcquireRequest<I>::send_break_lock() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  librados::ObjectWriteOperation op;
+  rados::cls::lock::break_lock(&op, RBD_LOCK_NAME, m_locker_cookie,
+                               m_locker_entity);
+
+  using klass = AcquireRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_safe_callback<klass, &klass::handle_break_lock>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid,
+                                         rados_completion, &op);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *AcquireRequest<I>::handle_break_lock(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val == -ENOENT) {
+    *ret_val = 0;
+  } else if (*ret_val < 0) {
+    lderr(cct) << "failed to break lock: " << cpp_strerror(*ret_val) << dendl;
+    return m_on_finish;
+  }
+
+  send_lock();
+  return nullptr;
+}
+
+template <typename I>
+void AcquireRequest<I>::apply() {
+  RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
+  assert(m_image_ctx.object_map == nullptr);
+  m_image_ctx.object_map = m_object_map;
+
+  assert(m_image_ctx.journal == nullptr);
+  m_image_ctx.journal = m_journal;
+}
+
+} // namespace exclusive_lock
+} // namespace librbd
+
+template class librbd::exclusive_lock::AcquireRequest<librbd::ImageCtx>;

--- a/src/librbd/exclusive_lock/AcquireRequest.h
+++ b/src/librbd/exclusive_lock/AcquireRequest.h
@@ -1,0 +1,114 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_EXCLUSIVE_LOCK_ACQUIRE_REQUEST_H
+#define CEPH_LIBRBD_EXCLUSIVE_LOCK_ACQUIRE_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+#include "include/rados/librados.hpp"
+#include "librbd/ImageCtx.h"
+#include "msg/msg_types.h"
+#include <map>
+#include <string>
+
+class Context;
+
+namespace librbd {
+
+class Journal;
+
+namespace exclusive_lock {
+
+template <typename ImageCtxT = ImageCtx>
+class AcquireRequest {
+public:
+  static AcquireRequest* create(ImageCtxT &image_ctx, const std::string &cookie,
+                                Context *on_finish);
+
+  void send();
+
+private:
+
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |     /---------------------------------------------------------\
+   *    |     |                                                         |
+   *    |     |             (no lockers)                                |
+   *    |     |   . . . . . . . . . . . . . . . . . . . . .             |
+   *    |     |   .                                       .             |
+   *    |     v   v      (EBUSY)                          .             |
+   *    \--> LOCK_IMAGE * * * * * * * > GET_LOCKERS . . . .             |
+   *          .   |                       |                             |
+   *    . . . .   |                       |                             |
+   *    .         v                       v                             |
+   *    .     OPEN_JOURNAL  . . .       GET_WATCHERS . . .              |
+   *    .         |             .         |              .              |
+   *    .         v             .         v              .              |
+   *    . . > OPEN_OBJECT_MAP   .       BLACKLIST        . (blacklist   |
+   *    .         |             .         |              .  disabled)   |
+   *    .         v             .         v              .              |
+   *    .     LOCK_OBJECT_MAP   .       BREAK_LOCK < . . .              |
+   *    .         |             .         |                             |
+   *    .         v             .         |                             |
+   *    . . > <finish>  < . . . .         |                             |
+   *                                      \-----------------------------/
+   *
+   * @endverbatim
+   */
+
+  AcquireRequest(ImageCtxT &image_ctx, const std::string &cookie,
+                 Context *on_finish);
+
+  ImageCtxT &m_image_ctx;
+  std::string m_cookie;
+  Context *m_on_finish;
+
+  bufferlist m_out_bl;
+
+  std::list<obj_watch_t> m_watchers;
+  int m_watchers_ret_val;
+
+  decltype(m_image_ctx.object_map) m_object_map;
+  decltype(m_image_ctx.journal) m_journal;
+
+  entity_name_t m_locker_entity;
+  std::string m_locker_cookie;
+  std::string m_locker_address;
+  uint64_t m_locker_handle;
+
+  void send_lock();
+  Context *handle_lock(int *ret_val);
+
+  Context *send_open_journal();
+  Context *handle_open_journal(int *ret_val);
+
+  Context *send_open_object_map();
+  Context *handle_open_object_map(int *ret_val);
+
+  Context *send_lock_object_map();
+  Context *handle_lock_object_map(int *ret_val);
+
+  void send_get_lockers();
+  Context *handle_get_lockers(int *ret_val);
+
+  void send_get_watchers();
+  Context *handle_get_watchers(int *ret_val);
+
+  void send_blacklist();
+  Context *handle_blacklist(int *ret_val);
+
+  void send_break_lock();
+  Context *handle_break_lock(int *ret_val);
+
+  void apply();
+};
+
+} // namespace exclusive_lock
+} // namespace librbd
+
+extern template class librbd::exclusive_lock::AcquireRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_EXCLUSIVE_LOCK_ACQUIRE_REQUEST_H

--- a/src/librbd/exclusive_lock/ReleaseRequest.cc
+++ b/src/librbd/exclusive_lock/ReleaseRequest.cc
@@ -108,7 +108,7 @@ template <typename I>
 void ReleaseRequest<I>::send_unlock_object_map() {
   {
     RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
-    std::swap(m_object_map, m_image_ctx.object_map_ptr);
+    std::swap(m_object_map, m_image_ctx.object_map);
   }
 
   if (m_object_map == nullptr) {

--- a/src/librbd/exclusive_lock/ReleaseRequest.cc
+++ b/src/librbd/exclusive_lock/ReleaseRequest.cc
@@ -1,0 +1,175 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/exclusive_lock/ReleaseRequest.h"
+#include "cls/lock/cls_lock_client.h"
+#include "cls/lock/cls_lock_types.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "common/WorkQueue.h"
+#include "include/stringify.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Journal.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::exclusive_lock::ReleaseRequest: "
+
+namespace librbd {
+namespace exclusive_lock {
+
+using util::create_async_context_callback;
+using util::create_context_callback;
+using util::create_rados_safe_callback;
+
+template <typename I>
+ReleaseRequest<I>* ReleaseRequest<I>::create(I &image_ctx,
+                                             const std::string &cookie,
+                                             Context *on_finish) {
+  return new ReleaseRequest(image_ctx, cookie, on_finish);
+}
+
+template <typename I>
+ReleaseRequest<I>::ReleaseRequest(I &image_ctx, const std::string &cookie,
+                                  Context *on_finish)
+  : m_image_ctx(image_ctx), m_cookie(cookie),
+    m_on_finish(create_async_context_callback(image_ctx, on_finish)),
+    m_object_map(nullptr), m_journal(nullptr) {
+}
+
+template <typename I>
+void ReleaseRequest<I>::send() {
+  send_cancel_op_requests();
+}
+
+template <typename I>
+void ReleaseRequest<I>::send_cancel_op_requests() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  using klass = ReleaseRequest<I>;
+  Context *ctx = create_context_callback<klass,
+                                         &klass::handle_cancel_op_requests>(this);
+  m_image_ctx.cancel_async_requests(ctx);
+}
+
+template <typename I>
+Context *ReleaseRequest<I>::handle_cancel_op_requests(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  assert(*ret_val == 0);
+  send_close_journal();
+  return nullptr;
+}
+
+template <typename I>
+void ReleaseRequest<I>::send_close_journal() {
+  {
+    RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
+    std::swap(m_journal, m_image_ctx.journal);
+  }
+
+  if (m_journal == nullptr) {
+    send_unlock_object_map();
+    return;
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  using klass = ReleaseRequest<I>;
+  Context *ctx = create_context_callback<klass, &klass::handle_close_journal>(
+    this);
+  m_journal->close(ctx);
+}
+
+template <typename I>
+Context *ReleaseRequest<I>::handle_close_journal(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val < 0) {
+    // error implies some journal events were not flushed -- continue
+    lderr(cct) << "failed to close journal: " << cpp_strerror(*ret_val)
+               << dendl;
+  }
+
+  delete m_journal;
+
+  send_unlock_object_map();
+  return nullptr;
+}
+
+template <typename I>
+void ReleaseRequest<I>::send_unlock_object_map() {
+  {
+    RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
+    std::swap(m_object_map, m_image_ctx.object_map_ptr);
+  }
+
+  if (m_object_map == nullptr) {
+    send_unlock();
+    return;
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  using klass = ReleaseRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_unlock_object_map>(this);
+  m_object_map->unlock(ctx);
+}
+
+template <typename I>
+Context *ReleaseRequest<I>::handle_unlock_object_map(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  // object map shouldn't return errors
+  assert(*ret_val == 0);
+  delete m_object_map;
+
+  send_unlock();
+  return nullptr;
+}
+
+template <typename I>
+void ReleaseRequest<I>::send_unlock() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  librados::ObjectWriteOperation op;
+  rados::cls::lock::unlock(&op, RBD_LOCK_NAME, m_cookie);
+
+  using klass = ReleaseRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_safe_callback<klass, &klass::handle_unlock>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid,
+                                         rados_completion, &op);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *ReleaseRequest<I>::handle_unlock(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val < 0 && *ret_val != -ENOENT) {
+    lderr(cct) << "failed to unlock: " << cpp_strerror(*ret_val) << dendl;
+  }
+
+  // treat errors as the image is unlocked
+  *ret_val = 0;
+  return m_on_finish;
+}
+
+} // namespace exclusive_lock
+} // namespace librbd
+
+template class librbd::exclusive_lock::ReleaseRequest<librbd::ImageCtx>;

--- a/src/librbd/exclusive_lock/ReleaseRequest.h
+++ b/src/librbd/exclusive_lock/ReleaseRequest.h
@@ -56,7 +56,7 @@ private:
   std::string m_cookie;
   Context *m_on_finish;
 
-  decltype(m_image_ctx.object_map_ptr) m_object_map;
+  decltype(m_image_ctx.object_map) m_object_map;
   decltype(m_image_ctx.journal) m_journal;
 
   void send_cancel_op_requests();

--- a/src/librbd/exclusive_lock/ReleaseRequest.h
+++ b/src/librbd/exclusive_lock/ReleaseRequest.h
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_EXCLUSIVE_LOCK_RELEASE_REQUEST_H
+#define CEPH_LIBRBD_EXCLUSIVE_LOCK_RELEASE_REQUEST_H
+
+#include "include/int_types.h"
+#include "librbd/ImageCtx.h"
+#include <string>
+
+class Context;
+
+namespace librbd {
+
+class ImageCtx;
+class Journal;
+
+namespace exclusive_lock {
+
+template <typename ImageCtxT = ImageCtx>
+class ReleaseRequest {
+public:
+  static ReleaseRequest* create(ImageCtxT &image_ctx, const std::string &cookie,
+                                Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * CANCEL_OP_REQUESTS . . . . . . . . . . . .
+   *    |                                     .
+   *    v                                     .
+   * CLOSE_JOURNAL                            .
+   *    |                (journal disabled,   .
+   *    v                 object map enabled) .
+   * UNLOCK_OBJECT_MAP  < . . . . . . . . . . .
+   *    |                                     .
+   *    v               (object map disabled) .
+   * UNLOCK < . . . . . . . . . . . . . . . . .
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  ReleaseRequest(ImageCtxT &image_ctx, const std::string &cookie,
+                 Context *on_finish);
+
+  ImageCtxT &m_image_ctx;
+  std::string m_cookie;
+  Context *m_on_finish;
+
+  decltype(m_image_ctx.object_map_ptr) m_object_map;
+  decltype(m_image_ctx.journal) m_journal;
+
+  void send_cancel_op_requests();
+  Context *handle_cancel_op_requests(int *ret_val);
+
+  void send_close_journal();
+  Context *handle_close_journal(int *ret_val);
+
+  void send_unlock_object_map();
+  Context *handle_unlock_object_map(int *ret_val);
+
+  void send_unlock();
+  Context *handle_unlock(int *ret_val);
+
+};
+
+} // namespace exclusive_lock
+} // namespace librbd
+
+extern template class librbd::exclusive_lock::ReleaseRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_EXCLUSIVE_LOCK_RELEASE_REQUEST_H

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -7,6 +7,7 @@
 #include "common/WorkQueue.h"
 #include "librbd/AioImageRequestWQ.h"
 #include "librbd/ExclusiveLock.h"
+#include "librbd/ImageWatcher.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "librbd/ImageWatcher.h"

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -1,0 +1,258 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/image/CloseRequest.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "common/WorkQueue.h"
+#include "librbd/AioImageRequestWQ.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/ImageWatcher.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::image::CloseRequest: "
+
+namespace librbd {
+namespace image {
+
+
+using util::create_async_context_callback;
+using util::create_context_callback;
+
+template <typename I>
+CloseRequest<I>::CloseRequest(I *image_ctx, Context *on_finish)
+  : m_image_ctx(image_ctx), m_on_finish(on_finish), m_error_result(0),
+    m_exclusive_lock(nullptr) {
+  assert(image_ctx != nullptr);
+}
+
+template <typename I>
+void CloseRequest<I>::send() {
+  // TODO
+  send_shut_down_aio_queue();
+  //send_unregister_image_watcher();
+}
+
+template <typename I>
+void CloseRequest<I>::send_unregister_image_watcher() {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  // prevent incoming requests from our peers
+
+}
+
+template <typename I>
+void CloseRequest<I>::handle_unregister_image_watcher(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  save_result(r);
+  if (r < 0) {
+    lderr(cct) << "failed to unregister image watcher: " << cpp_strerror(r)
+               << dendl;
+  }
+
+  send_shut_down_aio_queue();
+}
+
+template <typename I>
+void CloseRequest<I>::send_shut_down_aio_queue() {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  RWLock::RLocker owner_locker(m_image_ctx->owner_lock);
+  m_image_ctx->aio_work_queue->shut_down(create_context_callback<
+    CloseRequest<I>, &CloseRequest<I>::handle_shut_down_aio_queue>(this));
+}
+
+template <typename I>
+void CloseRequest<I>::handle_shut_down_aio_queue(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  send_shut_down_exclusive_lock();
+}
+
+template <typename I>
+void CloseRequest<I>::send_shut_down_exclusive_lock() {
+  {
+    RWLock::WLocker owner_locker(m_image_ctx->owner_lock);
+    RWLock::WLocker snap_locker(m_image_ctx->snap_lock);
+    std::swap(m_exclusive_lock, m_image_ctx->exclusive_lock);
+
+    if (m_exclusive_lock == nullptr) {
+      delete m_image_ctx->object_map;
+      m_image_ctx->object_map = nullptr;
+    }
+  }
+
+  if (m_exclusive_lock == nullptr) {
+    send_flush();
+    return;
+  }
+
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_exclusive_lock->shut_down(create_context_callback<
+    CloseRequest<I>, &CloseRequest<I>::handle_shut_down_exclusive_lock>(this));
+}
+
+template <typename I>
+void CloseRequest<I>::handle_shut_down_exclusive_lock(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  // object map and journal closed during exclusive lock shutdown
+  assert(m_image_ctx->journal == nullptr);
+  assert(m_image_ctx->object_map == nullptr);
+  delete m_exclusive_lock;
+
+  save_result(r);
+  if (r < 0) {
+    lderr(cct) << "failed to shut down exclusive lock: " << cpp_strerror(r)
+               << dendl;
+  }
+  send_flush_readahead();
+}
+
+template <typename I>
+void CloseRequest<I>::send_flush() {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  RWLock::RLocker owner_locker(m_image_ctx->owner_lock);
+  m_image_ctx->flush(create_async_context_callback(
+    *m_image_ctx, create_context_callback<
+      CloseRequest<I>, &CloseRequest<I>::handle_flush>(this)));
+}
+
+template <typename I>
+void CloseRequest<I>::handle_flush(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to flush IO: " << cpp_strerror(r) << dendl;
+  }
+  send_flush_readahead();
+}
+
+template <typename I>
+void CloseRequest<I>::send_flush_readahead() {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_image_ctx->readahead.wait_for_pending(create_context_callback<
+    CloseRequest<I>, &CloseRequest<I>::handle_flush_readahead>(this));
+}
+
+template <typename I>
+void CloseRequest<I>::handle_flush_readahead(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  send_shut_down_cache();
+}
+
+template <typename I>
+void CloseRequest<I>::send_shut_down_cache() {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_image_ctx->shut_down_cache(create_context_callback<
+    CloseRequest<I>, &CloseRequest<I>::handle_shut_down_cache>(this));
+}
+
+template <typename I>
+void CloseRequest<I>::handle_shut_down_cache(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  save_result(r);
+  if (r < 0) {
+    lderr(cct) << "failed to shut down cache: " << cpp_strerror(r) << dendl;
+  }
+  send_flush_copyup();
+}
+
+template <typename I>
+void CloseRequest<I>::send_flush_copyup() {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_image_ctx->flush_copyup(create_context_callback<
+    CloseRequest<I>, &CloseRequest<I>::handle_flush_copyup>(this));
+}
+
+template <typename I>
+void CloseRequest<I>::handle_flush_copyup(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+  send_flush_op_work_queue();
+}
+
+template <typename I>
+void CloseRequest<I>::send_flush_op_work_queue() {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_image_ctx->op_work_queue->queue(create_context_callback<
+    CloseRequest<I>, &CloseRequest<I>::handle_flush_op_work_queue>(this), 0);
+}
+
+template <typename I>
+void CloseRequest<I>::handle_flush_op_work_queue(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+  send_close_parent();
+}
+
+template <typename I>
+void CloseRequest<I>::send_close_parent() {
+  if (m_image_ctx->parent == nullptr) {
+    finish();
+    return;
+  }
+
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_image_ctx->parent->state->close(create_async_context_callback(
+    *m_image_ctx, create_context_callback<
+      CloseRequest<I>, &CloseRequest<I>::handle_close_parent>(this)));
+}
+
+template <typename I>
+void CloseRequest<I>::handle_close_parent(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  delete m_image_ctx->parent;
+  save_result(r);
+  if (r < 0) {
+    lderr(cct) << "error closing parent image: " << cpp_strerror(r) << dendl;
+  }
+  finish();
+}
+
+template <typename I>
+void CloseRequest<I>::finish() {
+  if (m_image_ctx->image_watcher) {
+    m_image_ctx->unregister_watch();
+  }
+
+  m_on_finish->complete(m_error_result);
+  delete this;
+}
+
+} // namespace image
+} // namespace librbd
+
+template class librbd::image::CloseRequest<librbd::ImageCtx>;

--- a/src/librbd/image/CloseRequest.h
+++ b/src/librbd/image/CloseRequest.h
@@ -1,0 +1,116 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IMAGE_CLOSE_REQUEST_H
+#define CEPH_LIBRBD_IMAGE_CLOSE_REQUEST_H
+
+#include "include/int_types.h"
+#include "librbd/ImageCtx.h"
+
+class Context;
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace image {
+
+template <typename ImageCtxT = ImageCtx>
+class CloseRequest {
+public:
+  static CloseRequest *create(ImageCtxT *image_ctx, Context *on_finish) {
+    return new CloseRequest(image_ctx, on_finish);
+  }
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * UNREGISTER_IMAGE_WATCHER
+   *    |
+   *    v
+   * SHUT_DOWN_AIO_WORK_QUEUE . . .
+   *    |                         .
+   *    v                         .
+   * SHUT_DOWN_EXCLUSIVE_LOCK     . (exclusive lock
+   *    |                         .  disabled)
+   *    v                         v
+   * FLUSH  < . . . . . . . . . . .
+   *    |
+   *    v
+   * FLUSH_READAHEAD
+   *    |
+   *    v
+   * SHUTDOWN_CACHE
+   *    |
+   *    v
+   * FLUSH_COPYUP
+   *    |
+   *    v
+   * FLUSH_OP_WORK_QUEUE  . . . . .
+   *    |                         .
+   *    v                         .
+   * CLOSE_PARENT                 . (no parent)
+   *    |                         .
+   *    v                         .
+   * <finish> < . . . . . . . . . .
+   *
+   * @endverbatim
+   */
+
+  CloseRequest(ImageCtxT *image_ctx, Context *on_finish);
+
+  ImageCtxT *m_image_ctx;
+  Context *m_on_finish;
+
+  int m_error_result;
+
+  decltype(m_image_ctx->exclusive_lock) m_exclusive_lock;
+
+  void send_unregister_image_watcher();
+  void handle_unregister_image_watcher(int r);
+
+  void send_shut_down_aio_queue();
+  void handle_shut_down_aio_queue(int r);
+
+  void send_shut_down_exclusive_lock();
+  void handle_shut_down_exclusive_lock(int r);
+
+  void send_flush();
+  void handle_flush(int r);
+
+  void send_flush_readahead();
+  void handle_flush_readahead(int r);
+
+  void send_shut_down_cache();
+  void handle_shut_down_cache(int r);
+
+  void send_flush_copyup();
+  void handle_flush_copyup(int r);
+
+  void send_flush_op_work_queue();
+  void handle_flush_op_work_queue(int r);
+
+  void send_close_parent();
+  void handle_close_parent(int r);
+
+  void finish();
+
+  void save_result(int result) {
+    if (m_error_result == 0 && result < 0) {
+      m_error_result = result;
+    }
+  }
+};
+
+} // namespace image
+} // namespace librbd
+
+extern template class librbd::image::CloseRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_IMAGE_CLOSE_REQUEST_H

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -1,0 +1,373 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/image/OpenRequest.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "common/WorkQueue.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "librbd/image/CloseRequest.h"
+#include "librbd/image/RefreshRequest.h"
+#include "librbd/image/SetSnapRequest.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::image::OpenRequest: "
+
+namespace librbd {
+namespace image {
+
+namespace {
+
+template <typename I>
+class C_RegisterWatch : public Context {
+public:
+  I &image_ctx;
+  Context *on_finish;
+
+  C_RegisterWatch(I &image_ctx, Context *on_finish)
+    : image_ctx(image_ctx), on_finish(on_finish) {
+  }
+
+  virtual void finish(int r) {
+    assert(r == 0);
+    on_finish->complete(image_ctx.register_watch());
+  }
+};
+
+} // anonymous namespace
+
+using util::create_context_callback;
+using util::create_rados_ack_callback;
+
+template <typename I>
+OpenRequest<I>::OpenRequest(I *image_ctx, Context *on_finish)
+  : m_image_ctx(image_ctx), m_on_finish(on_finish), m_error_result(0) {
+}
+
+template <typename I>
+void OpenRequest<I>::send() {
+  send_v2_detect_header();
+}
+
+template <typename I>
+void OpenRequest<I>::send_v1_detect_header() {
+  librados::ObjectReadOperation op;
+  op.stat(NULL, NULL, NULL);
+
+  using klass = OpenRequest<I>;
+  librados::AioCompletion *comp =
+    create_rados_ack_callback<klass, &klass::handle_v1_detect_header>(this);
+  m_out_bl.clear();
+  m_image_ctx->md_ctx.aio_operate(util::old_header_name(m_image_ctx->name),
+                                 comp, &op, &m_out_bl);
+  comp->release();
+}
+
+template <typename I>
+Context *OpenRequest<I>::handle_v1_detect_header(int *result) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to stat image header: " << cpp_strerror(*result)
+               << dendl;
+    send_close_image(*result);
+  } else {
+    m_image_ctx->old_format = true;
+    m_image_ctx->header_oid = util::old_header_name(m_image_ctx->name);
+    send_register_watch();
+  }
+  return nullptr;
+}
+
+template <typename I>
+void OpenRequest<I>::send_v2_detect_header() {
+  if (m_image_ctx->id.empty()) {
+    CephContext *cct = m_image_ctx->cct;
+    ldout(cct, 10) << this << " " << __func__ << dendl;
+
+    librados::ObjectReadOperation op;
+    op.stat(NULL, NULL, NULL);
+
+    using klass = OpenRequest<I>;
+    librados::AioCompletion *comp =
+      create_rados_ack_callback<klass, &klass::handle_v2_detect_header>(this);
+    m_out_bl.clear();
+    m_image_ctx->md_ctx.aio_operate(util::id_obj_name(m_image_ctx->name),
+                                   comp, &op, &m_out_bl);
+    comp->release();
+  } else {
+    send_v2_get_immutable_metadata();
+  }
+}
+
+template <typename I>
+Context *OpenRequest<I>::handle_v2_detect_header(int *result) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result == -ENOENT) {
+    send_v1_detect_header();
+  } else if (*result < 0) {
+    lderr(cct) << "failed to stat v2 image header: " << cpp_strerror(*result)
+               << dendl;
+    send_close_image(*result);
+  } else {
+    m_image_ctx->old_format = false;
+    send_v2_get_id();
+  }
+  return nullptr;
+}
+
+template <typename I>
+void OpenRequest<I>::send_v2_get_id() {
+  if (m_image_ctx->id.empty()) {
+    CephContext *cct = m_image_ctx->cct;
+    ldout(cct, 10) << this << " " << __func__ << dendl;
+
+    librados::ObjectReadOperation op;
+    cls_client::get_id_start(&op);
+
+    using klass = OpenRequest<I>;
+    librados::AioCompletion *comp =
+      create_rados_ack_callback<klass, &klass::handle_v2_get_id>(this);
+    m_out_bl.clear();
+    m_image_ctx->md_ctx.aio_operate(util::id_obj_name(m_image_ctx->name),
+                                    comp, &op, &m_out_bl);
+    comp->release();
+  } else {
+    send_v2_get_immutable_metadata();
+  }
+}
+
+template <typename I>
+Context *OpenRequest<I>::handle_v2_get_id(int *result) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    *result = cls_client::get_id_finish(&it, &m_image_ctx->id);
+  }
+  if (*result < 0) {
+    lderr(cct) << "failed to retrieve image id: " << cpp_strerror(*result)
+               << dendl;
+    send_close_image(*result);
+  } else {
+    send_v2_get_immutable_metadata();
+  }
+  return nullptr;
+}
+
+template <typename I>
+void OpenRequest<I>::send_v2_get_immutable_metadata() {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_image_ctx->old_format = false;
+  m_image_ctx->header_oid = util::header_name(m_image_ctx->id);
+
+  librados::ObjectReadOperation op;
+  cls_client::get_immutable_metadata_start(&op);
+
+  using klass = OpenRequest<I>;
+  librados::AioCompletion *comp = create_rados_ack_callback<
+    klass, &klass::handle_v2_get_immutable_metadata>(this);
+  m_out_bl.clear();
+  m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op,
+                                  &m_out_bl);
+  comp->release();
+}
+
+template <typename I>
+Context *OpenRequest<I>::handle_v2_get_immutable_metadata(int *result) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    *result = cls_client::get_immutable_metadata_finish(
+      &it, &m_image_ctx->object_prefix, &m_image_ctx->order);
+  }
+  if (*result < 0) {
+    lderr(cct) << "failed to retreive immutable metadata: "
+               << cpp_strerror(*result) << dendl;
+    send_close_image(*result);
+  } else {
+    send_v2_get_stripe_unit_count();
+  }
+
+  return nullptr;
+}
+
+template <typename I>
+void OpenRequest<I>::send_v2_get_stripe_unit_count() {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  librados::ObjectReadOperation op;
+  cls_client::get_stripe_unit_count_start(&op);
+
+  using klass = OpenRequest<I>;
+  librados::AioCompletion *comp = create_rados_ack_callback<
+    klass, &klass::handle_v2_get_stripe_unit_count>(this);
+  m_out_bl.clear();
+  m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op,
+                                  &m_out_bl);
+  comp->release();
+}
+
+template <typename I>
+Context *OpenRequest<I>::handle_v2_get_stripe_unit_count(int *result) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    *result = cls_client::get_stripe_unit_count_finish(
+      &it, &m_image_ctx->stripe_unit, &m_image_ctx->stripe_count);
+  }
+
+  if (*result == -ENOEXEC || *result == -EINVAL) {
+    *result = 0;
+  }
+
+  if (*result < 0) {
+    lderr(cct) << "failed to read striping metadata: " << cpp_strerror(*result)
+               << dendl;
+    send_close_image(*result);
+  } else {
+    send_register_watch();
+  }
+  return nullptr;
+}
+
+template <typename I>
+void OpenRequest<I>::send_register_watch() {
+  m_image_ctx->init();
+
+  if (!m_image_ctx->read_only) {
+    CephContext *cct = m_image_ctx->cct;
+    ldout(cct, 10) << this << " " << __func__ << dendl;
+
+    // no librados async version of watch
+    using klass = OpenRequest<I>;
+    Context *ctx = new C_RegisterWatch<I>(
+      *m_image_ctx,
+      create_context_callback<klass, &klass::handle_register_watch>(this));
+    m_image_ctx->op_work_queue->queue(ctx);
+  } else {
+    send_refresh();
+  }
+}
+
+template <typename I>
+Context *OpenRequest<I>::handle_register_watch(int *result) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to register watch: " << cpp_strerror(*result)
+               << dendl;
+    send_close_image(*result);
+  } else {
+    send_refresh();
+  }
+  return nullptr;
+}
+
+template <typename I>
+void OpenRequest<I>::send_refresh() {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  using klass = OpenRequest<I>;
+  RefreshRequest<I> *ctx = RefreshRequest<I>::create(
+    *m_image_ctx,
+    create_context_callback<klass, &klass::handle_refresh>(this));
+  ctx->send();
+}
+
+template <typename I>
+Context *OpenRequest<I>::handle_refresh(int *result) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to refresh image: " << cpp_strerror(*result)
+               << dendl;
+    send_close_image(*result);
+    return nullptr;
+  } else {
+    return send_set_snap(result);
+  }
+}
+
+template <typename I>
+Context *OpenRequest<I>::send_set_snap(int *result) {
+  if (m_image_ctx->snap_name.empty()) {
+    *result = 0;
+    return m_on_finish;
+  }
+
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  using klass = OpenRequest<I>;
+  SetSnapRequest<I> *ctx = SetSnapRequest<I>::create(
+    *m_image_ctx, m_image_ctx->snap_name,
+    create_context_callback<klass, &klass::handle_set_snap>(this));
+  ctx->send();
+  return nullptr;
+}
+
+template <typename I>
+Context *OpenRequest<I>::handle_set_snap(int *result) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to set image snapshot: " << cpp_strerror(*result)
+               << dendl;
+    send_close_image(*result);
+    return nullptr;
+  }
+
+  return m_on_finish;
+}
+
+template <typename I>
+void OpenRequest<I>::send_close_image(int error_result) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_error_result = error_result;
+
+  using klass = OpenRequest<I>;
+  Context *ctx = create_context_callback<klass, &klass::handle_close_image>(
+    this);
+  CloseRequest<I> *req = CloseRequest<I>::create(m_image_ctx, ctx);
+  req->send();
+}
+
+template <typename I>
+Context *OpenRequest<I>::handle_close_image(int *result) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to close image: " << cpp_strerror(*result) << dendl;
+  }
+  if (m_error_result < 0) {
+    *result = m_error_result;
+  }
+  return m_on_finish;
+}
+
+} // namespace image
+} // namespace librbd
+
+template class librbd::image::OpenRequest<librbd::ImageCtx>;

--- a/src/librbd/image/OpenRequest.h
+++ b/src/librbd/image/OpenRequest.h
@@ -1,0 +1,106 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IMAGE_OPEN_REQUEST_H
+#define CEPH_LIBRBD_IMAGE_OPEN_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+
+class Context;
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace image {
+
+template <typename ImageCtxT = ImageCtx>
+class OpenRequest {
+public:
+  static OpenRequest *create(ImageCtxT *image_ctx, Context *on_finish) {
+    return new OpenRequest(image_ctx, on_finish);
+  }
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    | (v1)                          (read only)
+   *    |-----> V1_DETECT_HEADER  . . . . . . . . . . . . . . . . .
+   *    |           |                                             .
+   *    |           \-------------------------------\             .
+   *    | (v2)                                      |             .
+   *    \-----> V2_DETECT_HEADER                    |             .
+   *                |                               |             .
+   *                v                               |             .
+   *            V2_GET_ID                           |             .
+   *                |                               |             .
+   *                v                               |             .
+   *            V2_GET_IMMUTABLE_METADATA           |             .
+   *                |                               |             .
+   *                v                               v             .
+   *            V2_GET_STRIPE_UNIT_COUNT  ----> REGISTER_WATCH    .
+   *                .                               |             .
+   *                .  (read only)                  v             .
+   *                . . . . . . . . . . . . . > REFRESH < . . . . .
+   *                                             .   |
+   *                                             .   |
+   *                                             .   \--> SET_SNAP
+   *                                   (no snap) .          |
+   *                                             .          v
+   *                                             . . . > <finish>
+   *                                                        ^
+   *     (on error)                                         |
+   *    * * * * * * > CLOSE --------------------------------/
+   *
+   * @endverbatim
+   */
+
+  OpenRequest(ImageCtxT *image_ctx, Context *on_finish);
+
+  ImageCtxT *m_image_ctx;
+  Context *m_on_finish;
+
+  bufferlist m_out_bl;
+  int m_error_result;
+
+  void send_v1_detect_header();
+  Context *handle_v1_detect_header(int *result);
+
+  void send_v2_detect_header();
+  Context *handle_v2_detect_header(int *result);
+
+  void send_v2_get_id();
+  Context *handle_v2_get_id(int *result);
+
+  void send_v2_get_immutable_metadata();
+  Context *handle_v2_get_immutable_metadata(int *result);
+
+  void send_v2_get_stripe_unit_count();
+  Context *handle_v2_get_stripe_unit_count(int *result);
+
+  void send_register_watch();
+  Context *handle_register_watch(int *result);
+
+  void send_refresh();
+  Context *handle_refresh(int *result);
+
+  Context *send_set_snap(int *result);
+  Context *handle_set_snap(int *result);
+
+  void send_close_image(int error_result);
+  Context *handle_close_image(int *result);
+
+};
+
+} // namespace image
+} // namespace librbd
+
+extern template class librbd::image::OpenRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_IMAGE_OPEN_REQUEST_H

--- a/src/librbd/image/RefreshParentRequest.cc
+++ b/src/librbd/image/RefreshParentRequest.cc
@@ -1,0 +1,235 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/image/RefreshParentRequest.h"
+#include "include/rados/librados.hpp"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "common/WorkQueue.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "librbd/image/CloseRequest.h"
+#include "librbd/image/OpenRequest.h"
+#include "librbd/image/SetSnapRequest.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::image::RefreshParentRequest: "
+
+namespace librbd {
+namespace image {
+
+using util::create_async_context_callback;
+using util::create_context_callback;
+
+template <typename I>
+RefreshParentRequest<I>::RefreshParentRequest(I &child_image_ctx,
+                                              const parent_info &parent_md,
+                                              Context *on_finish)
+  : m_child_image_ctx(child_image_ctx), m_parent_md(parent_md),
+    m_on_finish(on_finish), m_parent_image_ctx(nullptr),
+    m_parent_snap_id(CEPH_NOSNAP), m_error_result(0) {
+}
+
+template <typename I>
+bool RefreshParentRequest<I>::is_refresh_required(I &child_image_ctx,
+                                                  const parent_info &parent_md) {
+  assert(child_image_ctx.snap_lock.is_locked());
+  assert(child_image_ctx.parent_lock.is_locked());
+  return (is_open_required(child_image_ctx, parent_md) ||
+          is_close_required(child_image_ctx, parent_md));
+}
+
+template <typename I>
+bool RefreshParentRequest<I>::is_close_required(I &child_image_ctx,
+                                                const parent_info &parent_md) {
+  return (child_image_ctx.parent != nullptr &&
+          (parent_md.spec.pool_id == -1 || parent_md.overlap == 0));
+}
+
+template <typename I>
+bool RefreshParentRequest<I>::is_open_required(I &child_image_ctx,
+                                               const parent_info &parent_md) {
+  return (parent_md.spec.pool_id > -1 && parent_md.overlap > 0 &&
+          (child_image_ctx.parent == nullptr ||
+           child_image_ctx.parent->md_ctx.get_id() != parent_md.spec.pool_id ||
+           child_image_ctx.parent->id != parent_md.spec.image_id ||
+           child_image_ctx.parent->snap_id != parent_md.spec.snap_id));
+}
+
+template <typename I>
+void RefreshParentRequest<I>::send() {
+  if (is_open_required(m_child_image_ctx, m_parent_md)) {
+    send_open_parent();
+  } else {
+    // parent will be closed (if necessary) during finalize
+    send_complete(0);
+  }
+}
+
+template <typename I>
+void RefreshParentRequest<I>::apply() {
+  if (m_child_image_ctx.parent != nullptr) {
+    // closing parent image
+    m_child_image_ctx.clear_nonexistence_cache();
+  }
+  assert(m_child_image_ctx.snap_lock.is_wlocked());
+  assert(m_child_image_ctx.parent_lock.is_wlocked());
+  std::swap(m_child_image_ctx.parent, m_parent_image_ctx);
+}
+
+template <typename I>
+void RefreshParentRequest<I>::finalize(Context *on_finish) {
+  CephContext *cct = m_child_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_on_finish = on_finish;
+  if (m_parent_image_ctx != nullptr) {
+    send_close_parent();
+  } else {
+    send_complete(0);
+  }
+}
+
+template <typename I>
+void RefreshParentRequest<I>::send_open_parent() {
+  assert(m_parent_md.spec.pool_id >= 0);
+
+  CephContext *cct = m_child_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  librados::Rados rados(m_child_image_ctx.md_ctx);
+
+  librados::IoCtx parent_io_ctx;
+  int r = rados.ioctx_create2(m_parent_md.spec.pool_id, parent_io_ctx);
+  assert(r == 0);
+
+  // since we don't know the image and snapshot name, set their ids and
+  // reset the snap_name and snap_exists fields after we read the header
+  m_parent_image_ctx = new I("", m_parent_md.spec.image_id, NULL, parent_io_ctx,
+                             true);
+
+  // set rados flags for reading the parent image
+  if (m_child_image_ctx.balance_parent_reads) {
+    m_parent_image_ctx->set_read_flag(librados::OPERATION_BALANCE_READS);
+  } else if (m_child_image_ctx.localize_parent_reads) {
+    m_parent_image_ctx->set_read_flag(librados::OPERATION_LOCALIZE_READS);
+  }
+
+  using klass = RefreshParentRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_open_parent, false>(this);
+  OpenRequest<I> *req = OpenRequest<I>::create(m_parent_image_ctx, ctx);
+  req->send();
+}
+
+template <typename I>
+Context *RefreshParentRequest<I>::handle_open_parent(int *result) {
+  CephContext *cct = m_child_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << " r=" << *result << dendl;
+
+  save_result(result);
+  if (*result < 0) {
+    lderr(cct) << "failed to open parent image: " << cpp_strerror(*result)
+               << dendl;
+    send_close_parent();
+    return nullptr;
+  }
+
+  send_set_parent_snap();
+  return nullptr;
+}
+
+template <typename I>
+void RefreshParentRequest<I>::send_set_parent_snap() {
+  assert(m_parent_md.spec.snap_id != CEPH_NOSNAP);
+
+  CephContext *cct = m_child_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  int r;
+  std::string snap_name;
+  {
+    RWLock::RLocker snap_locker(m_parent_image_ctx->snap_lock);
+    r = m_parent_image_ctx->get_snap_name(m_parent_md.spec.snap_id, &snap_name);
+  }
+
+  if (r < 0) {
+    lderr(cct) << "failed to located snapshot: " << cpp_strerror(r) << dendl;
+    send_complete(r);
+    return;
+  }
+
+  using klass = RefreshParentRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_set_parent_snap, false>(this);
+  SetSnapRequest<I> *req = SetSnapRequest<I>::create(
+    *m_parent_image_ctx, snap_name, ctx);
+  req->send();
+}
+
+template <typename I>
+Context *RefreshParentRequest<I>::handle_set_parent_snap(int *result) {
+  CephContext *cct = m_child_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << " r=" << *result << dendl;
+
+  save_result(result);
+  if (*result < 0) {
+    lderr(cct) << "failed to set parent snapshot: " << cpp_strerror(*result)
+               << dendl;
+    send_close_parent();
+    return nullptr;
+  }
+
+  return m_on_finish;
+}
+
+template <typename I>
+void RefreshParentRequest<I>::send_close_parent() {
+  assert(m_parent_image_ctx != nullptr);
+
+  CephContext *cct = m_child_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  using klass = RefreshParentRequest<I>;
+  Context *ctx = create_async_context_callback(
+    m_child_image_ctx, create_context_callback<
+      klass, &klass::handle_close_parent, false>(this));
+  CloseRequest<I> *req = CloseRequest<I>::create(m_parent_image_ctx, ctx);
+  req->send();
+}
+
+template <typename I>
+Context *RefreshParentRequest<I>::handle_close_parent(int *result) {
+  CephContext *cct = m_child_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << " r=" << *result << dendl;
+
+  delete m_parent_image_ctx;
+  if (*result < 0) {
+    lderr(cct) << "failed to close parent image: " << cpp_strerror(*result)
+               << dendl;
+  }
+
+  if (m_error_result < 0) {
+    // propagate errors from opening the image
+    *result = m_error_result;
+  } else {
+    // ignore errors from closing the image
+    *result = 0;
+  }
+
+  return m_on_finish;
+}
+
+template <typename I>
+void RefreshParentRequest<I>::send_complete(int r) {
+  CephContext *cct = m_child_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_on_finish->complete(r);
+}
+
+} // namespace image
+} // namespace librbd
+
+template class librbd::image::RefreshParentRequest<librbd::ImageCtx>;

--- a/src/librbd/image/RefreshParentRequest.h
+++ b/src/librbd/image/RefreshParentRequest.h
@@ -1,0 +1,99 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IMAGE_REFRESH_PARENT_REQUEST_H
+#define CEPH_LIBRBD_IMAGE_REFRESH_PARENT_REQUEST_H
+
+#include "include/int_types.h"
+#include "librbd/parent_types.h"
+
+class Context;
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace image {
+
+template <typename ImageCtxT = ImageCtx>
+class RefreshParentRequest {
+public:
+  static RefreshParentRequest *create(ImageCtxT &child_image_ctx,
+                                      const parent_info &parent_md,
+                                      Context *on_finish) {
+    return new RefreshParentRequest(child_image_ctx, parent_md, on_finish);
+  }
+
+  static bool is_refresh_required(ImageCtxT &child_image_ctx,
+                                  const parent_info &parent_md);
+
+  void send();
+  void apply();
+  void finalize(Context *on_finish);
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    | (open required)
+   *    |----------------> OPEN_PARENT * * * * * * * *
+   *    |                     |                      *
+   *    |                     v                      * (on error)
+   *    |                  SET_PARENT_SNAP * * * * * *
+   *    |                     |                      *
+   *    |                     v                      *
+   *    \----------------> <apply>                   *
+   *                          |                      *
+   *                          | (close required)     v
+   *                          |-----------------> CLOSE_PARENT
+   *                          |                      |
+   *                          |                      v
+   *                          \-----------------> <finish>
+   *
+   * @endverbatim
+   */
+
+  RefreshParentRequest(ImageCtxT &child_image_ctx, const parent_info &parent_md,
+                       Context *on_finish);
+
+  ImageCtxT &m_child_image_ctx;
+  parent_info m_parent_md;
+  Context *m_on_finish;
+
+  ImageCtxT *m_parent_image_ctx;
+  uint64_t m_parent_snap_id;
+
+  int m_error_result;
+
+  static bool is_close_required(ImageCtxT &child_image_ctx,
+                                const parent_info &parent_md);
+  static bool is_open_required(ImageCtxT &child_image_ctx,
+                               const parent_info &parent_md);
+
+  void send_open_parent();
+  Context *handle_open_parent(int *result);
+
+  void send_set_parent_snap();
+  Context *handle_set_parent_snap(int *result);
+
+  void send_close_parent();
+  Context *handle_close_parent(int *result);
+
+  void send_complete(int r);
+
+  void save_result(int *result) {
+    if (m_error_result == 0 && *result < 0) {
+      m_error_result = *result;
+    }
+  }
+
+};
+
+} // namespace image
+} // namespace librbd
+
+extern template class librbd::image::RefreshParentRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_IMAGE_REFRESH_PARENT_REQUEST_H

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -1,0 +1,762 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/image/RefreshRequest.h"
+#include "include/stringify.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "cls/lock/cls_lock_client.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Journal.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/Utils.h"
+#include "librbd/image/RefreshParentRequest.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::image::RefreshRequest: "
+
+namespace librbd {
+namespace image {
+
+using util::create_rados_ack_callback;
+using util::create_context_callback;
+
+template <typename I>
+RefreshRequest<I>::RefreshRequest(I &image_ctx, Context *on_finish)
+  : m_image_ctx(image_ctx), m_on_finish(on_finish), m_error_result(0),
+    m_flush_aio(false), m_exclusive_lock(nullptr), m_object_map(nullptr),
+    m_journal(nullptr), m_refresh_parent(nullptr) {
+}
+
+template <typename I>
+RefreshRequest<I>::~RefreshRequest() {
+  delete m_object_map;
+
+  // these require state machine to close
+  assert(m_exclusive_lock == nullptr);
+  assert(m_journal == nullptr);
+  assert(m_refresh_parent == nullptr);
+}
+
+template <typename I>
+void RefreshRequest<I>::send() {
+  if (m_image_ctx.old_format) {
+    send_v1_read_header();
+  } else {
+    send_v2_get_mutable_metadata();
+  }
+}
+
+template <typename I>
+void RefreshRequest<I>::send_v1_read_header() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  librados::ObjectReadOperation op;
+  op.read(0, 0, nullptr, nullptr);
+
+  using klass = RefreshRequest<I>;
+  librados::AioCompletion *comp = create_rados_ack_callback<
+    klass, &klass::handle_v1_read_header>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
+                                         &m_out_bl);
+  assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v1_read_header(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": " << "r=" << *result << dendl;
+
+  rbd_obj_header_ondisk v1_header;
+  if (*result < 0) {
+    return m_on_finish;
+  } else if (m_out_bl.length() < sizeof(v1_header)) {
+    lderr(cct) << "v1 header too small" << dendl;
+    *result = -EIO;
+    return m_on_finish;
+  } else if (memcmp(RBD_HEADER_TEXT, m_out_bl.c_str(),
+                    sizeof(RBD_HEADER_TEXT)) != 0) {
+    lderr(cct) << "unrecognized v1 header" << dendl;
+    *result = -ENXIO;
+    return m_on_finish;
+  }
+
+  memcpy(&v1_header, m_out_bl.c_str(), sizeof(v1_header));
+  m_order = v1_header.options.order;
+  m_size = v1_header.image_size;
+  m_object_prefix = v1_header.block_name;
+  send_v1_get_snapshots();
+  return nullptr;
+}
+
+template <typename I>
+void RefreshRequest<I>::send_v1_get_snapshots() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  librados::ObjectReadOperation op;
+  cls_client::old_snapshot_list_start(&op);
+
+  using klass = RefreshRequest<I>;
+  librados::AioCompletion *comp = create_rados_ack_callback<
+    klass, &klass::handle_v1_get_snapshots>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
+                                         &m_out_bl);
+  assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v1_get_snapshots(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": " << "r=" << *result << dendl;
+
+  if (*result == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    *result = cls_client::old_snapshot_list_finish(
+      &it, &m_snap_names, &m_snap_sizes, &m_snapc);
+  }
+
+  if (*result < 0) {
+    lderr(cct) << "failed to retrieve v1 snapshots: " << cpp_strerror(*result)
+               << dendl;
+    return m_on_finish;
+  }
+
+  if (!m_snapc.is_valid()) {
+    lderr(cct) << "v1 image snap context is invalid" << dendl;
+    *result = -EIO;
+    return m_on_finish;
+  }
+
+  send_v1_get_locks();
+  return nullptr;
+}
+
+template <typename I>
+void RefreshRequest<I>::send_v1_get_locks() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  librados::ObjectReadOperation op;
+  rados::cls::lock::get_lock_info_start(&op, RBD_LOCK_NAME);
+
+  using klass = RefreshRequest<I>;
+  librados::AioCompletion *comp = create_rados_ack_callback<
+    klass, &klass::handle_v1_get_locks>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
+                                         &m_out_bl);
+  assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v1_get_locks(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": "
+                 << "r=" << *result << dendl;
+
+  // If EOPNOTSUPP, treat image as if there are no locks (we can't
+  // query them).
+  if (*result == -EOPNOTSUPP) {
+    *result = 0;
+  } else if (*result == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    ClsLockType lock_type;
+    *result = rados::cls::lock::get_lock_info_finish(&it, &m_lockers,
+                                                     &lock_type, &m_lock_tag);
+    if (*result == 0) {
+      m_exclusive_locked = (lock_type == LOCK_EXCLUSIVE);
+    }
+  }
+  if (*result < 0) {
+    lderr(cct) << "failed to retrieve locks: " << cpp_strerror(*result)
+               << dendl;
+    return m_on_finish;
+  }
+
+  apply();
+
+  return send_flush_aio();
+}
+
+template <typename I>
+void RefreshRequest<I>::send_v2_get_mutable_metadata() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  uint64_t snap_id;
+  {
+    RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
+    snap_id = m_image_ctx.snap_id;
+  }
+
+  bool read_only = m_image_ctx.read_only || snap_id != CEPH_NOSNAP;
+  librados::ObjectReadOperation op;
+  cls_client::get_mutable_metadata_start(&op, read_only);
+
+  using klass = RefreshRequest<I>;
+  librados::AioCompletion *comp = create_rados_ack_callback<
+    klass, &klass::handle_v2_get_mutable_metadata>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
+                                         &m_out_bl);
+  assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_get_mutable_metadata(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": "
+                 << "r=" << *result << dendl;
+
+  if (*result == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    *result = cls_client::get_mutable_metadata_finish(&it, &m_size, &m_features,
+                                                      &m_incompatible_features,
+                                                      &m_lockers,
+                                                      &m_exclusive_locked,
+                                                      &m_lock_tag, &m_snapc,
+                                                      &m_parent_md);
+  }
+  if (*result < 0) {
+    lderr(cct) << "failed to retrieve mutable metadata: "
+               << cpp_strerror(*result) << dendl;
+    return m_on_finish;
+  }
+
+  uint64_t unsupported = m_incompatible_features & ~RBD_FEATURES_ALL;
+  if (unsupported != 0ULL) {
+    lderr(cct) << "Image uses unsupported features: " << unsupported << dendl;
+    *result = -ENOSYS;
+    return m_on_finish;
+  }
+
+  send_v2_get_flags();
+  return nullptr;
+}
+
+template <typename I>
+void RefreshRequest<I>::send_v2_get_flags() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  librados::ObjectReadOperation op;
+  cls_client::get_flags_start(&op, m_snapc.snaps);
+
+  using klass = RefreshRequest<I>;
+  librados::AioCompletion *comp = create_rados_ack_callback<
+    klass, &klass::handle_v2_get_flags>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
+                                         &m_out_bl);
+  assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_get_flags(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": "
+                 << "r=" << *result << dendl;
+
+  if (*result == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    cls_client::get_flags_finish(&it, &m_flags, m_snapc.snaps, &m_snap_flags);
+  }
+  if (*result == -EOPNOTSUPP) {
+    // Older OSD doesn't support RBD flags, need to assume the worst
+    ldout(cct, 10) << "OSD does not support RBD flags, disabling object map "
+                   << "optimizations" << dendl;
+    m_flags = RBD_FLAG_OBJECT_MAP_INVALID;
+    if ((m_features & RBD_FEATURE_FAST_DIFF) != 0) {
+      m_flags |= RBD_FLAG_FAST_DIFF_INVALID;
+    }
+
+    std::vector<uint64_t> default_flags(m_snapc.snaps.size(), m_flags);
+    m_snap_flags = std::move(default_flags);
+  } else if (*result == -ENOENT) {
+    ldout(cct, 10) << "out-of-sync snapshot state detected" << dendl;
+    send_v2_get_mutable_metadata();
+    return nullptr;
+  } else if (*result < 0) {
+    lderr(cct) << "failed to retrieve flags: " << cpp_strerror(*result)
+               << dendl;
+    return m_on_finish;
+  }
+
+  return send_v2_get_snapshots();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::send_v2_get_snapshots() {
+  if (m_snapc.snaps.empty()) {
+    m_snap_names.clear();
+    m_snap_sizes.clear();
+    m_snap_parents.clear();
+    m_snap_protection.clear();
+    return send_v2_refresh_parent();
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  librados::ObjectReadOperation op;
+  cls_client::snapshot_list_start(&op, m_snapc.snaps);
+
+  using klass = RefreshRequest<I>;
+  librados::AioCompletion *comp = create_rados_ack_callback<
+    klass, &klass::handle_v2_get_snapshots>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
+                                         &m_out_bl);
+  assert(r == 0);
+  comp->release();
+  return nullptr;
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_get_snapshots(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": "
+                 << "r=" << *result << dendl;
+
+  if (*result == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    *result = cls_client::snapshot_list_finish(&it, m_snapc.snaps,
+                                               &m_snap_names, &m_snap_sizes,
+                                               &m_snap_parents,
+                                               &m_snap_protection);
+  }
+  if (*result == -ENOENT) {
+    ldout(cct, 10) << "out-of-sync snapshot state detected" << dendl;
+    send_v2_get_mutable_metadata();
+    return nullptr;
+  } else if (*result < 0) {
+    lderr(cct) << "failed to retrieve snapshots: " << cpp_strerror(*result)
+               << dendl;
+    return m_on_finish;
+  }
+
+  if (!m_snapc.is_valid()) {
+    lderr(cct) << "image snap context is invalid!" << dendl;
+    *result = -EIO;
+    return m_on_finish;
+  }
+
+  return send_v2_refresh_parent();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::send_v2_refresh_parent() {
+  {
+    RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
+    RWLock::RLocker parent_locker(m_image_ctx.parent_lock);
+
+    parent_info parent_md;
+    int r = get_parent_info(m_image_ctx.snap_id, &parent_md);
+    if (r < 0 ||
+        RefreshParentRequest<I>::is_refresh_required(m_image_ctx, parent_md)) {
+      CephContext *cct = m_image_ctx.cct;
+      ldout(cct, 10) << this << " " << __func__ << dendl;
+
+      using klass = RefreshRequest<I>;
+      Context *ctx = create_context_callback<
+        klass, &klass::handle_v2_refresh_parent>(this);
+      m_refresh_parent = RefreshParentRequest<I>::create(
+        m_image_ctx, parent_md, ctx);
+    }
+  }
+
+  if (m_refresh_parent != nullptr) {
+    m_refresh_parent->send();
+    return nullptr;
+  } else {
+    return send_v2_init_exclusive_lock();
+  }
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_refresh_parent(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to refresh parent image: " << cpp_strerror(*result)
+               << dendl;
+    save_result(result);
+    return send_v2_finalize_refresh_parent();
+  }
+
+  return send_v2_init_exclusive_lock();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::send_v2_init_exclusive_lock() {
+  if ((m_features & RBD_FEATURE_EXCLUSIVE_LOCK) == 0 ||
+      !m_image_ctx.snap_name.empty() ||
+      m_image_ctx.exclusive_lock != nullptr) {
+    return send_v2_open_journal();
+  }
+
+  // implies exclusive lock dynamically enabled or image open in-progress
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  // TODO need safe shut down
+  m_exclusive_lock = ExclusiveLock<I>::create(m_image_ctx);
+
+  using klass = RefreshRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_v2_init_exclusive_lock>(this);
+
+  RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
+  m_exclusive_lock->init(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_init_exclusive_lock(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to initialize exclusive lock: "
+               << cpp_strerror(*result) << dendl;
+    save_result(result);
+    return send_v2_finalize_refresh_parent();
+  }
+
+  return send_v2_open_journal();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::send_v2_open_journal() {
+  if ((m_features & RBD_FEATURE_JOURNALING) == 0 ||
+      m_image_ctx.read_only ||
+      m_image_ctx.journal != nullptr ||
+      m_image_ctx.exclusive_lock == nullptr ||
+      !m_image_ctx.exclusive_lock->is_lock_owner()) {
+    return send_v2_open_object_map();
+  }
+
+  // implies journal dynamically enabled since ExclusiveLock will init
+  // the journal upon acquiring the lock
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  using klass = RefreshRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_v2_open_journal>(this);
+
+  // TODO need safe close
+  m_journal = new Journal(m_image_ctx);
+  m_journal->open(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_open_journal(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to initialize journal: " << cpp_strerror(*result)
+               << dendl;
+    save_result(result);
+    return send_v2_finalize_refresh_parent();
+  }
+
+  return send_v2_shut_down_exclusive_lock();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::send_v2_open_object_map() {
+  if ((m_features & RBD_FEATURE_OBJECT_MAP) == 0 ||
+      m_image_ctx.object_map != nullptr || m_image_ctx.snap_name.empty()) {
+    return send_v2_finalize_refresh_parent();
+  }
+
+  // implies object map dynamically enabled or image open in-progress
+  // since SetSnapRequest loads the object map for a snapshot and
+  // ExclusiveLock loads the object map for HEAD
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  for (size_t snap_idx = 0; snap_idx < m_snap_names.size(); ++snap_idx) {
+    if (m_snap_names[snap_idx] == m_image_ctx.snap_name) {
+      using klass = RefreshRequest<I>;
+      Context *ctx = create_context_callback<
+        klass, &klass::handle_v2_open_object_map>(this);
+
+      m_object_map = m_image_ctx.create_object_map(m_snapc.snaps[snap_idx].val);
+      m_object_map->open(ctx);
+      return nullptr;
+    }
+  }
+
+  lderr(cct) << "failed to locate snapshot: " << m_image_ctx.snap_name
+             << dendl;
+  return send_v2_finalize_refresh_parent();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_open_object_map(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  assert(*result == 0);
+  return send_v2_finalize_refresh_parent();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::send_v2_finalize_refresh_parent() {
+  apply();
+
+  if (m_refresh_parent == nullptr) {
+    return send_v2_shut_down_exclusive_lock();
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  using klass = RefreshRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_v2_finalize_refresh_parent>(this);
+  m_refresh_parent->finalize(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_finalize_refresh_parent(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  assert(m_refresh_parent != nullptr);
+  delete m_refresh_parent;
+  m_refresh_parent = nullptr;
+
+  return send_v2_shut_down_exclusive_lock();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::send_v2_shut_down_exclusive_lock() {
+  if (m_exclusive_lock == nullptr) {
+    return send_v2_close_journal();
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  // exclusive lock feature was dynamically disabled
+  using klass = RefreshRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_v2_shut_down_exclusive_lock>(this);
+  m_exclusive_lock->shut_down(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_shut_down_exclusive_lock(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to shut down exclusive lock: "
+               << cpp_strerror(*result) << dendl;
+    save_result(result);
+  }
+
+  assert(m_exclusive_lock != nullptr);
+  delete m_exclusive_lock;
+  m_exclusive_lock = nullptr;
+
+  return send_v2_close_journal();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::send_v2_close_journal() {
+  if (m_journal == nullptr) {
+    return send_flush_aio();
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  // journal feature was dynamically disabled
+  using klass = RefreshRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_v2_close_journal>(this);
+  m_journal->close(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_close_journal(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    save_result(result);
+    lderr(cct) << "failed to close journal: " << cpp_strerror(*result)
+               << dendl;
+  }
+
+  return send_flush_aio();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::send_flush_aio() {
+  if (m_flush_aio) {
+    CephContext *cct = m_image_ctx.cct;
+    ldout(cct, 10) << this << " " << __func__ << dendl;
+
+    RWLock::RLocker owner_lock(m_image_ctx.owner_lock);
+    using klass = RefreshRequest<I>;
+    Context *ctx = create_context_callback<
+      klass, &klass::handle_flush_aio>(this);
+    m_image_ctx.flush(ctx);
+    return nullptr;
+  }
+  return m_on_finish;
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_flush_aio(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to flush pending AIO: " << cpp_strerror(*result)
+               << dendl;
+  }
+
+  if (m_error_result < 0) {
+    *result = m_error_result;
+  }
+  return m_on_finish;
+}
+
+template <typename I>
+void RefreshRequest<I>::apply() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << this << " " << __func__ << dendl;
+
+  RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
+  RWLock::WLocker md_locker(m_image_ctx.md_lock);
+
+  {
+    Mutex::Locker cache_locker(m_image_ctx.cache_lock);
+    RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
+    RWLock::WLocker parent_locker(m_image_ctx.parent_lock);
+
+    m_image_ctx.size = m_size;
+    m_image_ctx.lockers = m_lockers;
+    m_image_ctx.lock_tag = m_lock_tag;
+    m_image_ctx.exclusive_locked = m_exclusive_locked;
+
+    if (m_image_ctx.old_format) {
+      m_image_ctx.order = m_order;
+      m_image_ctx.features = 0;
+      m_image_ctx.flags = 0;
+      m_image_ctx.object_prefix = std::move(m_object_prefix);
+      m_image_ctx.init_layout();
+    } else {
+      m_image_ctx.features = m_features;
+      m_image_ctx.flags = m_flags;
+      m_image_ctx.parent_md = m_parent_md;
+    }
+
+    for (size_t i = 0; i < m_snapc.snaps.size(); ++i) {
+      std::vector<librados::snap_t>::const_iterator it = std::find(
+        m_image_ctx.snaps.begin(), m_image_ctx.snaps.end(),
+        m_snapc.snaps[i].val);
+      if (it == m_image_ctx.snaps.end()) {
+        m_flush_aio = true;
+        ldout(cct, 20) << "new snapshot id=" << m_snapc.snaps[i].val
+                       << " name=" << m_snap_names[i]
+                       << " size=" << m_snap_sizes[i]
+                       << dendl;
+      }
+    }
+
+    m_image_ctx.snaps.clear();
+    m_image_ctx.snap_info.clear();
+    m_image_ctx.snap_ids.clear();
+    for (size_t i = 0; i < m_snapc.snaps.size(); ++i) {
+      uint64_t flags = m_image_ctx.old_format ? 0 : m_snap_flags[i];
+      uint8_t protection_status = m_image_ctx.old_format ?
+        static_cast<uint8_t>(RBD_PROTECTION_STATUS_UNPROTECTED) :
+        m_snap_protection[i];
+      parent_info parent;
+      if (!m_image_ctx.old_format) {
+        parent = m_snap_parents[i];
+      }
+
+      m_image_ctx.add_snap(m_snap_names[i], m_snapc.snaps[i].val,
+                           m_snap_sizes[i], parent, protection_status, flags);
+    }
+    m_image_ctx.snapc = m_snapc;
+
+    if (m_image_ctx.snap_id != CEPH_NOSNAP &&
+        m_image_ctx.get_snap_id(m_image_ctx.snap_name) != m_image_ctx.snap_id) {
+      lderr(cct) << "tried to read from a snapshot that no longer exists: "
+                 << m_image_ctx.snap_name << dendl;
+      m_image_ctx.snap_exists = false;
+    }
+
+    if (m_refresh_parent != nullptr) {
+      m_refresh_parent->apply();
+    }
+    m_image_ctx.data_ctx.selfmanaged_snap_set_write_ctx(m_image_ctx.snapc.seq,
+                                                        m_image_ctx.snaps);
+
+    // handle dynamically enabled / disabled features
+    if (!m_image_ctx.test_features(RBD_FEATURE_EXCLUSIVE_LOCK,
+                                   m_image_ctx.snap_lock) ||
+        m_exclusive_lock != nullptr) {
+      std::swap(m_exclusive_lock, m_image_ctx.exclusive_lock);
+    }
+    if (!m_image_ctx.test_features(RBD_FEATURE_JOURNALING,
+                                   m_image_ctx.snap_lock) ||
+        m_journal != nullptr) {
+      std::swap(m_journal, m_image_ctx.journal);
+    }
+    if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,
+                                   m_image_ctx.snap_lock) ||
+        m_object_map != nullptr) {
+      std::swap(m_object_map, m_image_ctx.object_map);
+    }
+  }
+}
+
+template <typename I>
+int RefreshRequest<I>::get_parent_info(uint64_t snap_id,
+                                       parent_info *parent_md) {
+  if (snap_id == CEPH_NOSNAP) {
+    *parent_md = m_parent_md;
+    return 0;
+  } else {
+    for (size_t i = 0; i < m_snapc.snaps.size(); ++i) {
+      if (m_snapc.snaps[i].val == snap_id) {
+        *parent_md = m_snap_parents[i];
+        return 0;
+      }
+    }
+  }
+  return -ENOENT;
+}
+
+} // namespace image
+} // namespace librbd
+
+template class librbd::image::RefreshRequest<librbd::ImageCtx>;

--- a/src/librbd/image/RefreshRequest.h
+++ b/src/librbd/image/RefreshRequest.h
@@ -1,0 +1,189 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IMAGE_REFRESH_REQUEST_H
+#define CEPH_LIBRBD_IMAGE_REFRESH_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+#include "include/rbd_types.h"
+#include "common/snap_types.h"
+#include "cls/lock/cls_lock_types.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/parent_types.h"
+#include <string>
+#include <vector>
+
+class Context;
+
+namespace librbd {
+
+template <typename> class ExclusiveLock;
+class ImageCtx;
+class Journal;
+class ObjectMap;
+
+namespace image {
+
+template<typename> class RefreshParentRequest;
+
+template<typename ImageCtxT = ImageCtx>
+class RefreshRequest {
+public:
+  static  RefreshRequest *create(ImageCtxT &image_ctx, Context *on_finish) {
+    return new RefreshRequest(image_ctx, on_finish);
+  }
+
+  ~RefreshRequest();
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    | (v1)
+   *    |-----> V1_READ_HEADER ---> V1_GET_SNAPSHOTS ---> V1_GET_LOCKS
+   *    |                                                     |
+   *    | (v2)                                                v
+   *    \-----> V2_GET_MUTABLE_METADATA                    <apply>
+   *                |                                         |
+   *                v                                         |
+   *            V2_GET_FLAGS                                  |
+   *                |                                         |
+   *                v                                         |
+   *            V2_GET_SNAPSHOTS (skip if no snaps)           |
+   *                |                                         |
+   *                v                                         |
+   *            V2_REFRESH_PARENT (skip if no parent or       |
+   *                |              refresh not needed)        |
+   *                v                                         |
+   *            V2_INIT_EXCLUSIVE_LOCK (skip if lock          |
+   *                |                   active or disabled)   |
+   *                v                                         |
+   *            V2_OPEN_JOURNAL (skip if journal              |
+   *                |            active or disabled)          |
+   *                v                                         |
+   *            V2_OPEN_OBJECT_MAP (skip if map               |
+   *                |               active or disabled)       |
+   *                v                                         |
+   *             <apply>                                      |
+   *                |                                         |
+   *                v                                         |
+   *            V2_FINALIZE_REFRESH_PARENT (skip if refresh   |
+   *                |                       not needed)       |
+   *  (error)       v                                         |
+   *  * * * * > V2_SHUT_DOWN_EXCLUSIVE_LOCK (skip if lock     |
+   *                |                      active or enabled) |
+   *                v                                         |
+   *            V2_CLOSE_JOURNAL (skip if journal inactive    |
+   *                |             or enabled)                 |
+   *                v                                         |
+   *            V2_CLOSE_OBJECT_MAP (skip if map inactive     |
+   *                |                or enabled)              |
+   *                |                                         |
+   *                \-------------------\/--------------------/
+   *                                    |
+   *                                    v
+   *                                  FLUSH (skip if no new
+   *                                    |    snapshots)
+   *                                    v
+   *                                 <finish>
+   *
+   * @endverbatim
+   */
+
+  ImageCtxT &m_image_ctx;
+  Context *m_on_finish;
+
+  int m_error_result;
+  bool m_flush_aio;
+  decltype(m_image_ctx.exclusive_lock) m_exclusive_lock;
+  decltype(m_image_ctx.object_map) m_object_map;
+  decltype(m_image_ctx.journal) m_journal;
+  RefreshParentRequest<ImageCtxT> *m_refresh_parent;
+
+  bufferlist m_out_bl;
+
+  uint8_t m_order;
+  uint64_t m_size;
+  uint64_t m_features;
+  uint64_t m_incompatible_features;
+  uint64_t m_flags;
+  std::string m_object_prefix;
+  parent_info m_parent_md;
+
+  ::SnapContext m_snapc;
+  std::vector<std::string> m_snap_names;
+  std::vector<uint64_t> m_snap_sizes;
+  std::vector<parent_info> m_snap_parents;
+  std::vector<uint8_t> m_snap_protection;
+  std::vector<uint64_t> m_snap_flags;
+
+  std::map<rados::cls::lock::locker_id_t,
+           rados::cls::lock::locker_info_t> m_lockers;
+  std::string m_lock_tag;
+  bool m_exclusive_locked;
+
+  RefreshRequest(ImageCtxT &image_ctx, Context *on_finish);
+
+  void send_v1_read_header();
+  Context *handle_v1_read_header(int *result);
+
+  void send_v1_get_snapshots();
+  Context *handle_v1_get_snapshots(int *result);
+
+  void send_v1_get_locks();
+  Context *handle_v1_get_locks(int *result);
+
+  void send_v2_get_mutable_metadata();
+  Context *handle_v2_get_mutable_metadata(int *result);
+
+  void send_v2_get_flags();
+  Context *handle_v2_get_flags(int *result);
+
+  Context *send_v2_get_snapshots();
+  Context *handle_v2_get_snapshots(int *result);
+
+  Context *send_v2_refresh_parent();
+  Context *handle_v2_refresh_parent(int *result);
+
+  Context *send_v2_init_exclusive_lock();
+  Context *handle_v2_init_exclusive_lock(int *result);
+
+  Context *send_v2_open_journal();
+  Context *handle_v2_open_journal(int *result);
+
+  Context *send_v2_open_object_map();
+  Context *handle_v2_open_object_map(int *result);
+
+  Context *send_v2_finalize_refresh_parent();
+  Context *handle_v2_finalize_refresh_parent(int *result);
+
+  Context *send_v2_shut_down_exclusive_lock();
+  Context *handle_v2_shut_down_exclusive_lock(int *result);
+
+  Context *send_v2_close_journal();
+  Context *handle_v2_close_journal(int *result);
+
+  Context *send_flush_aio();
+  Context *handle_flush_aio(int *result);
+
+  void save_result(int *result) {
+    if (m_error_result == 0 && *result < 0) {
+      m_error_result = *result;
+    }
+  }
+
+  void apply();
+  int get_parent_info(uint64_t snap_id, parent_info *parent_md);
+};
+
+} // namespace image
+} // namespace librbd
+
+extern template class librbd::image::RefreshRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_IMAGE_REFRESH_REQUEST_H

--- a/src/librbd/image/SetSnapRequest.cc
+++ b/src/librbd/image/SetSnapRequest.cc
@@ -326,7 +326,7 @@ int SetSnapRequest<I>::apply() {
   }
 
   std::swap(m_exclusive_lock, m_image_ctx.exclusive_lock);
-  std::swap(m_object_map, m_image_ctx.object_map_ptr);
+  std::swap(m_object_map, m_image_ctx.object_map);
   return 0;
 }
 

--- a/src/librbd/image/SetSnapRequest.cc
+++ b/src/librbd/image/SetSnapRequest.cc
@@ -1,0 +1,342 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/image/SetSnapRequest.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/AioImageRequestWQ.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/Utils.h"
+#include "librbd/image/RefreshParentRequest.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::image::SetSnapRequest: "
+
+namespace librbd {
+namespace image {
+
+using util::create_context_callback;
+
+template <typename I>
+SetSnapRequest<I>::SetSnapRequest(I &image_ctx, const std::string &snap_name,
+                                  Context *on_finish)
+  : m_image_ctx(image_ctx), m_snap_name(snap_name), m_on_finish(on_finish),
+    m_snap_id(CEPH_NOSNAP), m_exclusive_lock(nullptr), m_object_map(nullptr),
+    m_refresh_parent(nullptr), m_writes_blocked(false) {
+}
+
+template <typename I>
+SetSnapRequest<I>::~SetSnapRequest() {
+  delete m_refresh_parent;
+  delete m_object_map;
+  delete m_exclusive_lock;
+  if (m_writes_blocked) {
+    m_image_ctx.aio_work_queue->unblock_writes();
+  }
+}
+
+template <typename I>
+void SetSnapRequest<I>::send() {
+  if (m_snap_name.empty()) {
+    send_init_exclusive_lock();
+  } else {
+    send_block_writes();
+  }
+}
+
+template <typename I>
+void SetSnapRequest<I>::send_init_exclusive_lock() {
+  {
+    RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
+    if (m_image_ctx.exclusive_lock != nullptr) {
+      assert(m_image_ctx.snap_id == CEPH_NOSNAP);
+      send_complete();
+      return;
+    }
+  }
+
+  if (!m_image_ctx.test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
+    int r = 0;
+    if (send_refresh_parent(&r) != nullptr) {
+      send_complete();
+      return;
+    }
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  m_exclusive_lock = ExclusiveLock<I>::create(m_image_ctx);
+
+  using klass = SetSnapRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_init_exclusive_lock>(this);
+
+  RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
+  m_exclusive_lock->init(ctx);
+}
+
+template <typename I>
+Context *SetSnapRequest<I>::handle_init_exclusive_lock(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to initialize exclusive lock: "
+               << cpp_strerror(*result) << dendl;
+    return m_on_finish;
+  }
+  return send_refresh_parent(result);
+}
+
+template <typename I>
+void SetSnapRequest<I>::send_block_writes() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  m_writes_blocked = true;
+
+  using klass = SetSnapRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_block_writes>(this);
+
+  RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
+  m_image_ctx.aio_work_queue->block_writes(ctx);
+}
+
+template <typename I>
+Context *SetSnapRequest<I>::handle_block_writes(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to block writes: " << cpp_strerror(*result)
+               << dendl;
+    return m_on_finish;
+  }
+
+  {
+    RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
+    m_snap_id = m_image_ctx.get_snap_id(m_snap_name);
+    if (m_snap_id == CEPH_NOSNAP) {
+      lderr(cct) << "failed to locate snapshot '" << m_snap_name << "'"
+                 << dendl;
+
+      *result = -ENOENT;
+      return m_on_finish;
+    }
+  }
+
+  return send_shut_down_exclusive_lock(result);
+}
+
+template <typename I>
+Context *SetSnapRequest<I>::send_shut_down_exclusive_lock(int *result) {
+  ExclusiveLock<I> *exclusive_lock;
+  {
+    RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
+    exclusive_lock = m_image_ctx.exclusive_lock;
+  }
+
+  if (exclusive_lock == nullptr) {
+    return send_refresh_parent(result);
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  using klass = SetSnapRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_shut_down_exclusive_lock>(this);
+  exclusive_lock->shut_down(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *SetSnapRequest<I>::handle_shut_down_exclusive_lock(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to shut down exclusive lock: "
+               << cpp_strerror(*result) << dendl;
+    return m_on_finish;
+  }
+
+  return send_refresh_parent(result);
+}
+
+template <typename I>
+Context *SetSnapRequest<I>::send_refresh_parent(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+
+  parent_info parent_md;
+  bool refresh_parent;
+  {
+    RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
+    RWLock::RLocker parent_locker(m_image_ctx.parent_lock);
+
+    const parent_info *parent_info = m_image_ctx.get_parent_info(m_snap_id);
+    if (parent_info == nullptr) {
+      *result = -ENOENT;
+      lderr(cct) << "failed to retrieve snapshot parent info" << dendl;
+      return m_on_finish;
+    }
+
+    parent_md = *parent_info;
+    refresh_parent = RefreshParentRequest<I>::is_refresh_required(m_image_ctx,
+                                                                  parent_md);
+  }
+
+  if (!refresh_parent) {
+    if (m_snap_id == CEPH_NOSNAP) {
+      // object map is loaded when exclusive lock is acquired
+      *result = apply();
+      return m_on_finish;
+    } else {
+      // load snapshot object map
+      return send_open_object_map(result);
+    }
+  }
+
+  ldout(cct, 10) << __func__ << dendl;
+
+  using klass = SetSnapRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_refresh_parent>(this);
+  m_refresh_parent = RefreshParentRequest<I>::create(m_image_ctx, parent_md,
+                                                     ctx);
+  m_refresh_parent->send();
+  return nullptr;
+}
+
+template <typename I>
+Context *SetSnapRequest<I>::handle_refresh_parent(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to refresh snapshot parent: " << cpp_strerror(*result)
+               << dendl;
+    return m_on_finish;
+  }
+
+  if (m_snap_id == CEPH_NOSNAP) {
+    // object map is loaded when exclusive lock is acquired
+    *result = apply();
+    if (*result < 0) {
+      return m_on_finish;
+    }
+
+    return send_finalize_refresh_parent(result);
+  } else {
+    // load snapshot object map
+    return send_open_object_map(result);
+  }
+}
+
+template <typename I>
+Context *SetSnapRequest<I>::send_open_object_map(int *result) {
+  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP)) {
+    *result = apply();
+    if (*result < 0) {
+      return m_on_finish;
+    }
+
+    return send_finalize_refresh_parent(result);
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  using klass = SetSnapRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_open_object_map>(this);
+  m_object_map = new ObjectMap(m_image_ctx, m_snap_id);
+  m_object_map->open(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *SetSnapRequest<I>::handle_open_object_map(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << ": r=" << *result << dendl;
+
+  // object map should never report errors
+  assert(*result == 0);
+
+  *result = apply();
+  if (*result < 0) {
+    return m_on_finish;
+  }
+
+  return send_finalize_refresh_parent(result);
+}
+
+template <typename I>
+Context *SetSnapRequest<I>::send_finalize_refresh_parent(int *result) {
+  if (m_refresh_parent == nullptr) {
+    return m_on_finish;
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  using klass = SetSnapRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_finalize_refresh_parent>(this);
+  m_refresh_parent->finalize(ctx);
+  return nullptr;
+}
+
+template <typename I>
+Context *SetSnapRequest<I>::handle_finalize_refresh_parent(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to close parent image: " << cpp_strerror(*result)
+               << dendl;
+  }
+  return m_on_finish;
+}
+
+template <typename I>
+int SetSnapRequest<I>::apply() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << __func__ << dendl;
+
+  RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
+  RWLock::WLocker parent_locker(m_image_ctx.parent_lock);
+
+  if (m_snap_id != CEPH_NOSNAP) {
+    int r = m_image_ctx.snap_set(m_snap_name);
+    if (r < 0) {
+      return r;
+    }
+  } else {
+    m_image_ctx.snap_unset();
+  }
+
+  if (m_refresh_parent != nullptr) {
+    m_refresh_parent->apply();
+  }
+
+  std::swap(m_exclusive_lock, m_image_ctx.exclusive_lock);
+  std::swap(m_object_map, m_image_ctx.object_map_ptr);
+  return 0;
+}
+
+template <typename I>
+void SetSnapRequest<I>::send_complete() {
+  m_on_finish->complete(0);
+  delete this;
+}
+
+} // namespace image
+} // namespace librbd
+
+template class librbd::image::SetSnapRequest<librbd::ImageCtx>;

--- a/src/librbd/image/SetSnapRequest.h
+++ b/src/librbd/image/SetSnapRequest.h
@@ -1,0 +1,121 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IMAGE_SNAP_SET_REQUEST_H
+#define CEPH_LIBRBD_IMAGE_SNAP_SET_REQUEST_H
+
+#include "include/int_types.h"
+#include "librbd/parent_types.h"
+#include <string>
+
+class Context;
+
+namespace librbd {
+
+template <typename> class ExclusiveLock;
+class ImageCtx;
+class ObjectMap;
+
+namespace image {
+
+template <typename> class RefreshParentRequest;
+
+template <typename ImageCtxT = ImageCtx>
+class SetSnapRequest {
+public:
+  static SetSnapRequest *create(ImageCtxT &image_ctx,
+                                const std::string &snap_name,
+                                Context *on_finish) {
+    return new SetSnapRequest(image_ctx, snap_name, on_finish);
+  }
+
+  ~SetSnapRequest();
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    | (set snap)
+   *    |-----------> BLOCK_WRITES
+   *    |                 |
+   *    |                 v
+   *    |             SHUTDOWN_EXCLUSIVE_LOCK (skip if lock inactive
+   *    |                 |                    or disabled)
+   *    |                 v
+   *    |             REFRESH_PARENT (skip if no parent
+   *    |                 |           or refresh not needed)
+   *    |                 v
+   *    |             OPEN_OBJECT_MAP (skip if map disabled)
+   *    |                 |
+   *    |                 v
+   *    |              <apply>
+   *    |                 |
+   *    |                 v
+   *    |             FINALIZE_REFRESH_PARENT (skip if no parent
+   *    |                 |                    or refresh not needed)
+   *    |                 v
+   *    |             <finish>
+   *    |
+   *    \-----------> INIT_EXCLUSIVE_LOCK (skip if active or
+   *                      |                disabled)
+   *                      v
+   *                  REFRESH_PARENT (skip if no parent
+   *                      |           or refresh not needed)
+   *                      v
+   *                   <apply>
+   *                      |
+   *                      v
+   *                  FINALIZE_REFRESH_PARENT (skip if no parent
+   *                      |                    or refresh not needed)
+   *                      v
+   *                  <finish>
+   *
+   * @endverbatim
+   */
+
+  SetSnapRequest(ImageCtxT &image_ctx, const std::string &snap_name,
+                Context *on_finish);
+
+  ImageCtxT &m_image_ctx;
+  std::string m_snap_name;
+  Context *m_on_finish;
+
+  uint64_t m_snap_id;
+  ExclusiveLock<ImageCtxT> *m_exclusive_lock;
+  ObjectMap *m_object_map;
+  RefreshParentRequest<ImageCtxT> *m_refresh_parent;
+
+  bool m_writes_blocked;
+
+  void send_block_writes();
+  Context *handle_block_writes(int *result);
+
+  void send_init_exclusive_lock();
+  Context *handle_init_exclusive_lock(int *result);
+
+  Context *send_shut_down_exclusive_lock(int *result);
+  Context *handle_shut_down_exclusive_lock(int *result);
+
+  Context *send_refresh_parent(int *result);
+  Context *handle_refresh_parent(int *result);
+
+  Context *send_open_object_map(int *result);
+  Context *handle_open_object_map(int *result);
+
+  Context *send_finalize_refresh_parent(int *result);
+  Context *handle_finalize_refresh_parent(int *result);
+
+  int apply();
+  void send_complete();
+};
+
+} // namespace image
+} // namespace librbd
+
+extern template class librbd::image::SetSnapRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_IMAGE_SNAP_SET_REQUEST_H

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -42,6 +42,7 @@
 #include "librbd/operation/SnapshotRollbackRequest.h"
 #include "librbd/operation/SnapshotUnprotectRequest.h"
 #include "librbd/operation/TrimRequest.h"
+#include "librbd/Utils.h"
 #include "include/util.h"
 
 #include <boost/bind.hpp>
@@ -3501,18 +3502,6 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
                         whole_object, cb, arg);
     r = command.execute();
     return r;
-  }
-
-  void rados_req_cb(rados_completion_t c, void *arg)
-  {
-    AioObjectRequest *req = reinterpret_cast<AioObjectRequest *>(arg);
-    req->complete(rados_aio_get_return_value(c));
-  }
-
-  void rados_ctx_cb(rados_completion_t c, void *arg)
-  {
-    Context *comp = reinterpret_cast<Context *>(arg);
-    comp->complete(rados_aio_get_return_value(c));
   }
 
   // validate extent against image size; clip to image size if necessary

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2605,7 +2605,8 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
 	ictx->snap_exists = false;
       }
 
-      ictx->object_map.refresh(ictx->snap_id);
+      // TODO handle by new async refresh state machine
+      //ictx->object_map.refresh(ictx->snap_id);
 
       ictx->data_ctx.selfmanaged_snap_set_write_ctx(ictx->snapc.seq, ictx->snaps);
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -31,6 +31,12 @@
 #include "librbd/Journal.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/parent_types.h"
+#include "librbd/Utils.h"
+#include "librbd/image/CloseRequest.h"
+#include "librbd/image/OpenRequest.h"
+#include "librbd/image/RefreshParentRequest.h"
+#include "librbd/image/RefreshRequest.h"
+#include "librbd/image/SetSnapRequest.h"
 #include "librbd/operation/FlattenRequest.h"
 #include "librbd/operation/RebuildObjectMapRequest.h"
 #include "librbd/operation/RenameRequest.h"
@@ -42,7 +48,6 @@
 #include "librbd/operation/SnapshotRollbackRequest.h"
 #include "librbd/operation/SnapshotUnprotectRequest.h"
 #include "librbd/operation/TrimRequest.h"
-#include "librbd/Utils.h"
 #include "include/util.h"
 
 #include <boost/bind.hpp>
@@ -2959,7 +2964,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
 			 << "' id = '" << ictx->id
 			 << "' snap_name = '"
 			 << ictx->snap_name << "'" << dendl;
-    int r = ictx->init();
+    int r = ictx->init_legacy();
     if (r < 0)
       goto err_close;
 

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -141,18 +141,9 @@ namespace librbd {
                              const char *snap_name);
   int snap_is_protected(ImageCtx *ictx, const char *snap_name,
 			bool *is_protected);
-  int refresh_parent(ImageCtx *ictx);
-  int ictx_check(ImageCtx *ictx);
-  int ictx_check(ImageCtx *ictx, const RWLock &owner_lock);
-  int ictx_refresh(ImageCtx *ictx);
   int copy(ImageCtx *ictx, IoCtx& dest_md_ctx, const char *destname,
 	   ImageOptions& opts, ProgressContext &prog_ctx);
   int copy(ImageCtx *src, ImageCtx *dest, ProgressContext &prog_ctx);
-
-  int open_parent(ImageCtx *ictx);
-  int open_image(ImageCtx *ictx);
-  int close_image(ImageCtx *ictx);
-  int close_parent(ImageCtx *ictx);
 
   int flatten(ImageCtx *ictx, ProgressContext &prog_ctx);
 

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -68,11 +68,6 @@ namespace librbd {
     }
   };
 
-  const std::string id_obj_name(const std::string &name);
-  const std::string header_name(const std::string &image_id);
-  const std::string old_header_name(const std::string &image_name);
-  std::string unique_lock_name(const std::string &name, void *address);
-
   int detect_format(librados::IoCtx &io_ctx, const std::string &name,
 		    bool *old_format, uint64_t *size);
 

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -235,8 +235,6 @@ namespace librbd {
 						callback_t cb_complete);
 
   // raw callbacks
-  void rados_req_cb(rados_completion_t cb, void *arg);
-  void rados_ctx_cb(rados_completion_t cb, void *arg);
   void rbd_req_cb(completion_t cb, void *arg);
   void rbd_ctx_cb(completion_t cb, void *arg);
 }

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -229,14 +229,6 @@ namespace librbd {
   int mirror_peer_set_cluster(IoCtx& io_ctx, const std::string &cluster_uuid,
                               const std::string &cluster_name);
 
-  AioCompletion *aio_create_completion();
-  AioCompletion *aio_create_completion(void *cb_arg, callback_t cb_complete);
-  AioCompletion *aio_create_completion_internal(void *cb_arg,
-						callback_t cb_complete);
-
-  // raw callbacks
-  void rbd_req_cb(completion_t cb, void *arg);
-  void rbd_ctx_cb(completion_t cb, void *arg);
 }
 
 #endif

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -314,10 +314,8 @@ namespace librbd {
 
   RBD::AioCompletion::AioCompletion(void *cb_arg, callback_t complete_cb)
   {
-    librbd::AioCompletion *c = librbd::aio_create_completion(cb_arg,
-							     complete_cb);
-    pc = (void *)c;
-    c->rbd_comp = this;
+    pc = reinterpret_cast<void*>(librbd::AioCompletion::create(
+      cb_arg, complete_cb, this));
   }
 
   bool RBD::AioCompletion::is_complete()

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -28,6 +28,7 @@
 #include "librbd/AioImageRequestWQ.h"
 #include "cls/rbd/cls_rbd_client.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
 #include "librbd/internal.h"
 #include "librbd/LibrbdWriteback.h"
 
@@ -120,12 +121,13 @@ namespace librbd {
     tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
     if (image.ctx != NULL) {
-      close_image(reinterpret_cast<ImageCtx*>(image.ctx));
+      reinterpret_cast<ImageCtx*>(image.ctx)->state->close();
       image.ctx = NULL;
     }
 
-    int r = librbd::open_image(ictx);
+    int r = ictx->state->open();
     if (r < 0) {
+      delete ictx;
       tracepoint(librbd, open_image_exit, r);
       return r;
     }
@@ -143,12 +145,13 @@ namespace librbd {
     tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
     if (image.ctx != NULL) {
-      close_image(reinterpret_cast<ImageCtx*>(image.ctx));
+      reinterpret_cast<ImageCtx*>(image.ctx)->state->close();
       image.ctx = NULL;
     }
 
-    int r = librbd::open_image(ictx);
+    int r = ictx->state->open();
     if (r < 0) {
+      delete ictx;
       tracepoint(librbd, open_image_exit, r);
       return r;
     }
@@ -422,8 +425,10 @@ namespace librbd {
     if (ctx) {
       ImageCtx *ictx = (ImageCtx *)ctx;
       tracepoint(librbd, close_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str());
-      r = close_image(ictx);
+
+      r = ictx->state->close();
       ctx = NULL;
+
       tracepoint(librbd, close_image_exit, r);
     }
     return r;
@@ -1539,9 +1544,13 @@ extern "C" int rbd_open(rados_ioctx_t p, const char *name, rbd_image_t *image,
   librbd::ImageCtx *ictx = new librbd::ImageCtx(name, "", snap_name, io_ctx,
 						false);
   tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
-  int r = librbd::open_image(ictx);
-  if (r >= 0)
+
+  int r = ictx->state->open();
+  if (r < 0) {
+    delete ictx;
+  } else {
     *image = (rbd_image_t)ictx;
+  }
   tracepoint(librbd, open_image_exit, r);
   return r;
 }
@@ -1555,18 +1564,24 @@ extern "C" int rbd_open_read_only(rados_ioctx_t p, const char *name,
   librbd::ImageCtx *ictx = new librbd::ImageCtx(name, "", snap_name, io_ctx,
 						true);
   tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
-  int r = librbd::open_image(ictx);
-  if (r >= 0)
+
+  int r = ictx->state->open();
+  if (r < 0) {
+    delete ictx;
+  } else {
     *image = (rbd_image_t)ictx;
+  }
   tracepoint(librbd, open_image_exit, r);
   return r;
 }
 
 extern "C" int rbd_close(rbd_image_t image)
 {
-  librbd::ImageCtx *ctx = (librbd::ImageCtx *)image;
-  tracepoint(librbd, close_image_enter, ctx, ctx->name.c_str(), ctx->id.c_str());
-  int r = librbd::close_image(ctx);
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  tracepoint(librbd, close_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str());
+
+  int r = ictx->state->close();
+
   tracepoint(librbd, close_image_exit, r);
   return r;
 }

--- a/src/librbd/object_map/InvalidateRequest.cc
+++ b/src/librbd/object_map/InvalidateRequest.cc
@@ -14,58 +14,72 @@
 namespace librbd {
 namespace object_map {
 
-void InvalidateRequest::send() {
-  assert(m_image_ctx.owner_lock.is_locked());
-  assert(m_image_ctx.snap_lock.is_wlocked());
+template <typename I>
+InvalidateRequest<I>* InvalidateRequest<I>::create(I &image_ctx,
+                                                   uint64_t snap_id, bool force,
+                                                   Context *on_finish) {
+  return new InvalidateRequest<I>(image_ctx, snap_id, force, on_finish);
+}
+
+template <typename I>
+void InvalidateRequest<I>::send() {
+  I &image_ctx = this->m_image_ctx;
+  assert(image_ctx.owner_lock.is_locked());
+  assert(image_ctx.snap_lock.is_wlocked());
 
   uint64_t snap_flags;
-  int r = m_image_ctx.get_flags(m_snap_id, &snap_flags);
+  int r = image_ctx.get_flags(m_snap_id, &snap_flags);
   if (r < 0 || ((snap_flags & RBD_FLAG_OBJECT_MAP_INVALID) != 0)) {
-    async_complete(r);
+    this->async_complete(r);
     return;
   }
 
-  CephContext *cct = m_image_ctx.cct;
+  CephContext *cct = image_ctx.cct;
   lderr(cct) << this << " invalidating object map in-memory" << dendl;
 
   // update in-memory flags
   uint64_t flags = RBD_FLAG_OBJECT_MAP_INVALID;
-  if ((m_image_ctx.features & RBD_FEATURE_FAST_DIFF) != 0) {
+  if ((image_ctx.features & RBD_FEATURE_FAST_DIFF) != 0) {
     flags |= RBD_FLAG_FAST_DIFF_INVALID;
   }
 
-  r = m_image_ctx.update_flags(m_snap_id, flags, true);
+  r = image_ctx.update_flags(m_snap_id, flags, true);
   if (r < 0) {
-    async_complete(r);
+    this->async_complete(r);
   }
 
   // do not update on-disk flags if not image owner
-  if (m_image_ctx.image_watcher == NULL ||
-      (m_image_ctx.image_watcher->is_lock_supported(m_image_ctx.snap_lock) &&
-       !m_image_ctx.image_watcher->is_lock_owner() && !m_force)) {
-    async_complete(0);
+  if (image_ctx.image_watcher == NULL ||
+      (image_ctx.image_watcher->is_lock_supported(image_ctx.snap_lock) &&
+       !image_ctx.image_watcher->is_lock_owner() && !m_force)) {
+    this->async_complete(0);
     return;
   }
 
   lderr(cct) << this << " invalidating object map on-disk" << dendl;
   librados::ObjectWriteOperation op;
   if (m_snap_id == CEPH_NOSNAP && !m_force) {
-    m_image_ctx.image_watcher->assert_header_locked(&op);
+    image_ctx.image_watcher->assert_header_locked(&op);
   }
   cls_client::set_flags(&op, m_snap_id, flags, flags);
 
-  librados::AioCompletion *rados_completion = create_callback_completion();
-  r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, rados_completion,
+  librados::AioCompletion *rados_completion =
+    this->create_callback_completion();
+  r = image_ctx.md_ctx.aio_operate(image_ctx.header_oid, rados_completion,
                                      &op);
   assert(r == 0);
   rados_completion->release();
 }
 
-bool InvalidateRequest::should_complete(int r) {
-  CephContext *cct = m_image_ctx.cct;
+template <typename I>
+bool InvalidateRequest<I>::should_complete(int r) {
+  I &image_ctx = this->m_image_ctx;
+  CephContext *cct = image_ctx.cct;
   lderr(cct) << this << " " << __func__ << ": r=" << r << dendl;
   return true;
 }
 
 } // namespace object_map
 } // namespace librbd
+
+template class librbd::object_map::InvalidateRequest<librbd::ImageCtx>;

--- a/src/librbd/object_map/InvalidateRequest.h
+++ b/src/librbd/object_map/InvalidateRequest.h
@@ -15,18 +15,23 @@ class ImageCtx;
 
 namespace object_map {
 
-class InvalidateRequest : public AsyncRequest<> {
+template <typename ImageCtxT = ImageCtx>
+class InvalidateRequest : public AsyncRequest<ImageCtxT> {
 public:
-  InvalidateRequest(ImageCtx &image_ctx, uint64_t snap_id, bool force,
+  static InvalidateRequest* create(ImageCtxT &image_ctx, uint64_t snap_id,
+                                   bool force, Context *on_finish);
+
+  InvalidateRequest(ImageCtxT &image_ctx, uint64_t snap_id, bool force,
                     Context *on_finish)
-    : AsyncRequest(image_ctx, on_finish), m_snap_id(snap_id), m_force(force) {
+    : AsyncRequest<ImageCtxT>(image_ctx, on_finish),
+      m_snap_id(snap_id), m_force(force) {
   }
 
   virtual void send();
 
 protected:
-  virtual bool should_complete(int r);
-  virtual int filter_return_code(int r) const {
+  virtual bool should_complete(int r) override;
+  virtual int filter_return_code(int r) const override{
     // never propagate an error back to the caller
     return 0;
   }
@@ -34,10 +39,11 @@ protected:
 private:
   uint64_t m_snap_id;
   bool m_force;
-
 };
 
 } // namespace object_map
 } // namespace librbd
+
+extern template class librbd::object_map::InvalidateRequest<librbd::ImageCtx>;
 
 #endif // CEPH_LIBRBD_OBJECT_MAP_INVALIDATE_REQUEST_H

--- a/src/librbd/object_map/LockRequest.cc
+++ b/src/librbd/object_map/LockRequest.cc
@@ -1,0 +1,154 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/object_map/LockRequest.h"
+#include "cls/lock/cls_lock_client.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::object_map::LockRequest: "
+
+namespace librbd {
+namespace object_map {
+
+using util::create_rados_ack_callback;
+using util::create_rados_safe_callback;
+
+template <typename I>
+LockRequest<I>::LockRequest(I &image_ctx, Context *on_finish)
+  : m_image_ctx(image_ctx), m_on_finish(on_finish), m_broke_lock(false) {
+}
+
+template <typename I>
+void LockRequest<I>::send() {
+  send_lock();
+}
+
+template <typename I>
+void LockRequest<I>::send_lock() {
+  CephContext *cct = m_image_ctx.cct;
+  std::string oid(ObjectMap::object_map_name(m_image_ctx.id, CEPH_NOSNAP));
+  ldout(cct, 10) << this << " " << __func__ << ": oid=" << oid << dendl;
+
+  librados::ObjectWriteOperation op;
+  rados::cls::lock::lock(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "", "",
+                           utime_t(), 0);
+
+  using klass = LockRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_safe_callback<klass, &klass::handle_lock>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *LockRequest<I>::handle_lock(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val == 0) {
+    return m_on_finish;
+  } else if (m_broke_lock || *ret_val != -EBUSY) {
+    lderr(cct) << "failed to lock object map: " << cpp_strerror(*ret_val)
+               << dendl;
+    *ret_val = 0;
+    return m_on_finish;
+  }
+
+  send_get_lock_info();
+  return nullptr;
+}
+
+template <typename I>
+void LockRequest<I>::send_get_lock_info() {
+  CephContext *cct = m_image_ctx.cct;
+  std::string oid(ObjectMap::object_map_name(m_image_ctx.id, CEPH_NOSNAP));
+  ldout(cct, 10) << this << " " << __func__ << ": oid=" << oid << dendl;
+
+  librados::ObjectReadOperation op;
+  rados::cls::lock::get_lock_info_start(&op, RBD_LOCK_NAME);
+
+  using klass = LockRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_ack_callback<klass, &klass::handle_get_lock_info>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op, &m_out_bl);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *LockRequest<I>::handle_get_lock_info(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val == -ENOENT) {
+    send_lock();
+    return nullptr;
+  }
+
+  ClsLockType lock_type;
+  std::string lock_tag;
+  if (*ret_val == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    *ret_val = rados::cls::lock::get_lock_info_finish(&it, &m_lockers,
+                                                      &lock_type, &lock_tag);
+  }
+  if (*ret_val < 0) {
+    lderr(cct) << "failed to list object map locks: " << cpp_strerror(*ret_val)
+               << dendl;
+    *ret_val = 0;
+    return m_on_finish;
+  }
+
+  send_break_locks();
+  return nullptr;
+}
+
+template <typename I>
+void LockRequest<I>::send_break_locks() {
+  CephContext *cct = m_image_ctx.cct;
+  std::string oid(ObjectMap::object_map_name(m_image_ctx.id, CEPH_NOSNAP));
+  ldout(cct, 10) << this << " " << __func__ << ": oid=" << oid << ", "
+                 << "num_lockers=" << m_lockers.size() << dendl;
+
+  librados::ObjectWriteOperation op;
+  for (auto &locker : m_lockers) {
+    rados::cls::lock::break_lock(&op, RBD_LOCK_NAME, locker.first.cookie,
+                                 locker.first.locker);
+  }
+
+  using klass = LockRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_safe_callback<klass, &klass::handle_break_locks>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *LockRequest<I>::handle_break_locks(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *ret_val << dendl;
+
+  m_broke_lock = true;
+  if (*ret_val == 0 || *ret_val == -ENOENT) {
+    send_lock();
+    return nullptr;
+  }
+
+  lderr(cct) << "failed to break object map lock: " << cpp_strerror(*ret_val)
+             << dendl;
+  *ret_val = 0;
+  return m_on_finish;
+}
+
+} // namespace object_map
+} // namespace librbd
+
+template class librbd::object_map::LockRequest<librbd::ImageCtx>;

--- a/src/librbd/object_map/LockRequest.h
+++ b/src/librbd/object_map/LockRequest.h
@@ -1,0 +1,72 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_OBJECT_MAP_LOCK_REQUEST_H
+#define CEPH_LIBRBD_OBJECT_MAP_LOCK_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+#include "include/Context.h"
+#include "cls/lock/cls_lock_types.h"
+#include <map>
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace object_map {
+
+template <typename ImageCtxT = ImageCtx>
+class LockRequest {
+public:
+  LockRequest(ImageCtxT &image_ctx, Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>         /------------------------------------- BREAK_LOCKS * * *
+   *    |            |                                        ^             *
+   *    |            |                                        |             *
+   *    |            |                                        |             *
+   *    |            v   (EBUSY && !broke_lock)               |             *
+   *    \---------> LOCK_OBJECT_MAP * * * * * * * * * * * > GET_LOCK_INFO * *
+   *                 |  *       ^                             *             *
+   *                 |  *       *                             *             *
+   *                 |  *       *  (ENOENT)                   *             *
+   *                 |  *       * * * * * * * * * * * * * * * *             *
+   *                 |  *                                                   *
+   *                 |  * (other errors)                                    *
+   *                 |  *                                                   *
+   *                 v  v                         (other errors)            *
+   *               <finish> < * * * * * * * * * * * * * * * * * * * * * * * *
+   *
+   * @endverbatim
+   */
+
+  ImageCtxT &m_image_ctx;
+  Context *m_on_finish;
+
+  bool m_broke_lock;
+  std::map<rados::cls::lock::locker_id_t,
+           rados::cls::lock::locker_info_t> m_lockers;
+  bufferlist m_out_bl;
+
+  void send_lock();
+  Context *handle_lock(int *ret_val);
+
+  void send_get_lock_info();
+  Context *handle_get_lock_info(int *ret_val);
+
+  void send_break_locks();
+  Context *handle_break_locks(int *ret_val);
+};
+
+} // namespace object_map
+} // namespace librbd
+
+extern template class librbd::object_map::LockRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_OBJECT_MAP_LOCK_REQUEST_H

--- a/src/librbd/object_map/RefreshRequest.cc
+++ b/src/librbd/object_map/RefreshRequest.cc
@@ -1,0 +1,224 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/object_map/RefreshRequest.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "cls/lock/cls_lock_client.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/object_map/InvalidateRequest.h"
+#include "librbd/object_map/ResizeRequest.h"
+#include "librbd/Utils.h"
+#include "osdc/Striper.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::object_map::RefreshRequest: "
+
+namespace librbd {
+
+using util::create_context_callback;
+using util::create_rados_ack_callback;
+using util::create_rados_safe_callback;
+
+namespace object_map {
+
+template <typename I>
+RefreshRequest<I>::RefreshRequest(I &image_ctx, ceph::BitVector<2> *object_map,
+                                  uint64_t snap_id, Context *on_finish)
+  : m_image_ctx(image_ctx), m_object_map(object_map), m_snap_id(snap_id),
+    m_on_finish(on_finish), m_object_count(0),
+    m_truncate_on_disk_object_map(false) {
+}
+
+template <typename I>
+void RefreshRequest<I>::send() {
+  {
+    RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
+    m_object_count = Striper::get_num_objects(
+      m_image_ctx.layout, m_image_ctx.get_image_size(m_snap_id));
+  }
+
+  send_load();
+}
+
+template <typename I>
+void RefreshRequest<I>::apply() {
+  uint64_t num_objs;
+  {
+    RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
+    num_objs = Striper::get_num_objects(
+      m_image_ctx.layout, m_image_ctx.get_image_size(m_snap_id));
+  }
+  assert(m_on_disk_object_map.size() >= num_objs);
+
+  *m_object_map = m_on_disk_object_map;
+}
+
+template <typename I>
+void RefreshRequest<I>::send_load() {
+  CephContext *cct = m_image_ctx.cct;
+  std::string oid(ObjectMap::object_map_name(m_image_ctx.id, m_snap_id));
+  ldout(cct, 10) << this << " " << __func__ << ": oid=" << oid << dendl;
+
+  librados::ObjectReadOperation op;
+  cls_client::object_map_load_start(&op);
+
+  using klass = RefreshRequest<I>;
+  m_out_bl.clear();
+  librados::AioCompletion *rados_completion =
+    create_rados_ack_callback<klass, &klass::handle_load>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op, &m_out_bl);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_load(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val == 0) {
+    bufferlist::iterator bl_it = m_out_bl.begin();
+    *ret_val = cls_client::object_map_load_finish(&bl_it,
+                                                  &m_on_disk_object_map);
+  }
+
+  std::string oid(ObjectMap::object_map_name(m_image_ctx.id, m_snap_id));
+  if (*ret_val == -EINVAL) {
+     // object map is corrupt on-disk -- clear it and properly size it
+     // so future IO can keep the object map in sync
+    lderr(cct) << "object map corrupt on-disk: " << oid << dendl;
+    m_truncate_on_disk_object_map = true;
+    send_resize_invalidate();
+    return nullptr;
+  } else if (*ret_val < 0) {
+    lderr(cct) << "failed to load object map: " << oid << dendl;
+    send_invalidate();
+    return nullptr;
+  }
+
+  if (m_on_disk_object_map.size() < m_object_count) {
+    lderr(cct) << "object map smaller than current object count: "
+               << m_on_disk_object_map.size() << " != "
+               << m_object_count << dendl;
+    send_resize_invalidate();
+    return nullptr;
+  }
+
+  ldout(cct, 20) << "refreshed object map: num_objs="
+                 << m_on_disk_object_map.size() << dendl;
+  if (m_on_disk_object_map.size() > m_object_count) {
+    // resize op might have been interrupted
+    ldout(cct, 1) << "object map larger than current object count: "
+                  << m_on_disk_object_map.size() << " != "
+                  << m_object_count << dendl;
+  }
+
+  apply();
+  return m_on_finish;
+}
+
+template <typename I>
+void RefreshRequest<I>::send_invalidate() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_on_disk_object_map.clear();
+  object_map::ResizeRequest::resize(&m_on_disk_object_map, m_object_count,
+                                    OBJECT_EXISTS);
+
+  using klass = RefreshRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_invalidate>(this);
+  InvalidateRequest<I> *req = InvalidateRequest<I>::create(
+    m_image_ctx, m_snap_id, false, ctx);
+
+  RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
+  RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
+  req->send();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_invalidate(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *ret_val << dendl;
+
+  assert(*ret_val == 0);
+  apply();
+  return m_on_finish;
+}
+
+template <typename I>
+void RefreshRequest<I>::send_resize_invalidate() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_on_disk_object_map.clear();
+  object_map::ResizeRequest::resize(&m_on_disk_object_map, m_object_count,
+                                    OBJECT_EXISTS);
+
+  using klass = RefreshRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_resize_invalidate>(this);
+  InvalidateRequest<I> *req = InvalidateRequest<I>::create(
+    m_image_ctx, m_snap_id, false, ctx);
+
+  RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
+  RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
+  req->send();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_resize_invalidate(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *ret_val << dendl;
+
+  assert(*ret_val == 0);
+  send_resize();
+  return nullptr;
+}
+
+template <typename I>
+void RefreshRequest<I>::send_resize() {
+  CephContext *cct = m_image_ctx.cct;
+  std::string oid(ObjectMap::object_map_name(m_image_ctx.id, m_snap_id));
+  ldout(cct, 10) << this << " " << __func__ << ": oid=" << oid << dendl;
+
+  librados::ObjectWriteOperation op;
+  if (m_snap_id == CEPH_NOSNAP) {
+    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "");
+  }
+  if (m_truncate_on_disk_object_map) {
+    op.truncate(0);
+  }
+  cls_client::object_map_resize(&op, m_object_count, OBJECT_NONEXISTENT);
+
+  using klass = RefreshRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_safe_callback<klass, &klass::handle_resize>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_resize(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val < 0) {
+    lderr(cct) << "failed to adjust object map size: " << cpp_strerror(*ret_val)
+               << dendl;
+    *ret_val = 0;
+  }
+  apply();
+  return m_on_finish;
+}
+
+} // namespace object_map
+} // namespace librbd
+
+template class librbd::object_map::RefreshRequest<librbd::ImageCtx>;

--- a/src/librbd/object_map/RefreshRequest.h
+++ b/src/librbd/object_map/RefreshRequest.h
@@ -1,0 +1,76 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_OBJECT_MAP_REFRESH_REQUEST_H
+#define CEPH_LIBRBD_OBJECT_MAP_REFRESH_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+#include "include/Context.h"
+#include "common/bit_vector.hpp"
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace object_map {
+
+template <typename ImageCtxT = ImageCtx>
+class RefreshRequest {
+public:
+  RefreshRequest(ImageCtxT &image_ctx, ceph::BitVector<2> *object_map,
+                 uint64_t snap_id, Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *                         (other errors)
+   * <start> -----> LOAD * * * * * * * > INVALIDATE ------------\
+   *                  |    *                                    |
+   *                  |    * (-EINVAL or too small)             |
+   *                  |    * * * * * * > INVALIDATE_AND_RESIZE  |
+   *                  |                      |              *   |
+   *                  |                      |              *   |
+   *                  |                      v              *   |
+   *                  |                    RESIZE           *   |
+   *                  |                      |              *   |
+   *                  |                      |  * * * * * * *   |
+   *                  |                      |  *               |
+   *                  |                      v  v               |
+   *                  \-----------------> <finish> <------------/
+   * @endverbatim
+   */
+
+  ImageCtxT &m_image_ctx;
+  ceph::BitVector<2> *m_object_map;
+  uint64_t m_snap_id;
+  Context *m_on_finish;
+
+  uint64_t m_object_count;
+  ceph::BitVector<2> m_on_disk_object_map;
+  bool m_truncate_on_disk_object_map;
+  bufferlist m_out_bl;
+
+  void send_load();
+  Context *handle_load(int *ret_val);
+
+  void send_invalidate();
+  Context *handle_invalidate(int *ret_val);
+
+  void send_resize_invalidate();
+  Context *handle_resize_invalidate(int *ret_val);
+
+  void send_resize();
+  Context *handle_resize(int *ret_val);
+
+  void apply();
+};
+
+} // namespace object_map
+} // namespace librbd
+
+extern template class librbd::object_map::RefreshRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_OBJECT_MAP_REFRESH_REQUEST_H

--- a/src/librbd/object_map/Request.cc
+++ b/src/librbd/object_map/Request.cc
@@ -62,8 +62,9 @@ bool Request::invalidate() {
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
-  InvalidateRequest *req = new InvalidateRequest(m_image_ctx, m_snap_id, true,
-                                                 create_callback_context());
+  InvalidateRequest<> *req = new InvalidateRequest<>(m_image_ctx, m_snap_id,
+                                                     true,
+                                                     create_callback_context());
   req->send();
   return false;
 }

--- a/src/librbd/object_map/SnapshotRemoveRequest.cc
+++ b/src/librbd/object_map/SnapshotRemoveRequest.cc
@@ -72,6 +72,10 @@ bool SnapshotRemoveRequest::should_complete(int r) {
   bool finished = false;
   switch (m_state) {
   case STATE_LOAD_MAP:
+    if (r == 0) {
+      bufferlist::iterator it = m_out_bl.begin();
+      r = cls_client::object_map_load_finish(&it, &m_snap_object_map);
+    }
     if (r < 0) {
       RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
       send_invalidate_next_map();
@@ -108,8 +112,14 @@ void SnapshotRemoveRequest::send_load_map() {
                 << dendl;
   m_state = STATE_LOAD_MAP;
 
-  cls_client::object_map_load(&m_image_ctx.md_ctx, snap_oid,
-                              &m_snap_object_map, create_callback_context());
+  librados::ObjectReadOperation op;
+  cls_client::object_map_load_start(&op);
+
+  librados::AioCompletion *rados_completion = create_callback_completion();
+  int r = m_image_ctx.md_ctx.aio_operate(snap_oid, rados_completion, &op,
+                                         &m_out_bl);
+  assert(r == 0);
+  rados_completion->release();
 }
 
 void SnapshotRemoveRequest::send_remove_snapshot() {

--- a/src/librbd/object_map/SnapshotRemoveRequest.cc
+++ b/src/librbd/object_map/SnapshotRemoveRequest.cc
@@ -148,9 +148,9 @@ void SnapshotRemoveRequest::send_invalidate_next_map() {
   ldout(cct, 5) << this << " " << __func__ << dendl;
   m_state = STATE_INVALIDATE_NEXT_MAP;
 
-  InvalidateRequest *req = new InvalidateRequest(m_image_ctx, m_next_snap_id,
-                                                 true,
-                                                 create_callback_context());
+  InvalidateRequest<> *req = new InvalidateRequest<>(m_image_ctx,
+                                                     m_next_snap_id, true,
+                                                     create_callback_context());
   req->send();
 }
 

--- a/src/librbd/object_map/SnapshotRemoveRequest.h
+++ b/src/librbd/object_map/SnapshotRemoveRequest.h
@@ -5,6 +5,7 @@
 #define CEPH_LIBRBD_OBJECT_MAP_SNAPSHOT_REMOVE_REQUEST_H
 
 #include "include/int_types.h"
+#include "include/buffer.h"
 #include "common/bit_vector.hpp"
 #include "librbd/AsyncRequest.h"
 
@@ -73,6 +74,7 @@ private:
   uint64_t m_next_snap_id;
 
   ceph::BitVector<2> m_snap_object_map;
+  bufferlist m_out_bl;
 
   void send_load_map();
   void send_remove_snapshot();

--- a/src/librbd/object_map/SnapshotRollbackRequest.cc
+++ b/src/librbd/object_map/SnapshotRollbackRequest.cc
@@ -121,8 +121,9 @@ void SnapshotRollbackRequest::send_invalidate_map() {
   ldout(cct, 5) << this << " " << __func__ << dendl;
   m_state = STATE_INVALIDATE_MAP;
 
-  InvalidateRequest *req = new InvalidateRequest(m_image_ctx, m_snap_id, false,
-                                                 create_callback_context());
+  InvalidateRequest<> *req = new InvalidateRequest<>(m_image_ctx, m_snap_id,
+                                                     false,
+                                                     create_callback_context());
   req->send();
 }
 

--- a/src/librbd/object_map/UnlockRequest.cc
+++ b/src/librbd/object_map/UnlockRequest.cc
@@ -1,0 +1,66 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/object_map/UnlockRequest.h"
+#include "cls/lock/cls_lock_client.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::object_map::UnlockRequest: "
+
+namespace librbd {
+namespace object_map {
+
+using util::create_rados_safe_callback;
+
+template <typename I>
+UnlockRequest<I>::UnlockRequest(I &image_ctx, Context *on_finish)
+  : m_image_ctx(image_ctx), m_on_finish(on_finish) {
+}
+
+template <typename I>
+void UnlockRequest<I>::send() {
+  send_unlock();
+}
+
+template <typename I>
+void UnlockRequest<I>::send_unlock() {
+  CephContext *cct = m_image_ctx.cct;
+  std::string oid(ObjectMap::object_map_name(m_image_ctx.id, CEPH_NOSNAP));
+  ldout(cct, 10) << this << " " << __func__ << ": oid=" << oid << dendl;
+
+  librados::ObjectWriteOperation op;
+  rados::cls::lock::unlock(&op, RBD_LOCK_NAME, "");
+
+  using klass = UnlockRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_safe_callback<klass, &klass::handle_unlock>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+Context *UnlockRequest<I>::handle_unlock(int *ret_val) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *ret_val << dendl;
+
+  if (*ret_val < 0 && *ret_val != -ENOENT) {
+    lderr(m_image_ctx.cct) << "failed to release object map lock: "
+                           << cpp_strerror(*ret_val) << dendl;
+
+  }
+
+  *ret_val = 0;
+  return m_on_finish;
+}
+
+} // namespace object_map
+} // namespace librbd
+
+template class librbd::object_map::UnlockRequest<librbd::ImageCtx>;

--- a/src/librbd/object_map/UnlockRequest.h
+++ b/src/librbd/object_map/UnlockRequest.h
@@ -1,0 +1,46 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_OBJECT_MAP_UNLOCK_REQUEST_H
+#define CEPH_LIBRBD_OBJECT_MAP_UNLOCK_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+#include "include/Context.h"
+#include <map>
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace object_map {
+
+template <typename ImageCtxT = ImageCtx>
+class UnlockRequest {
+public:
+  UnlockRequest(ImageCtxT &image_ctx, Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start> ----> UNLOCK ----> <finish>
+   *
+   * @endverbatim
+   */
+
+  ImageCtxT &m_image_ctx;
+  Context *m_on_finish;
+
+  void send_unlock();
+  Context* handle_unlock(int *ret_val);
+};
+
+} // namespace object_map
+} // namespace librbd
+
+extern template class librbd::object_map::UnlockRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_OBJECT_MAP_UNLOCK_REQUEST_H

--- a/src/librbd/operation/RebuildObjectMapRequest.cc
+++ b/src/librbd/operation/RebuildObjectMapRequest.cc
@@ -145,8 +145,11 @@ private:
     assert(image_ctx.exclusive_lock == nullptr ||
            image_ctx.exclusive_lock->is_lock_owner());
 
+    RWLock::RLocker snap_locker(image_ctx.snap_lock);
+    assert(image_ctx.object_map != nullptr);
+
     RWLock::WLocker l(image_ctx.object_map_lock);
-    uint8_t state = image_ctx.object_map[m_object_no];
+    uint8_t state = (*image_ctx.object_map)[m_object_no];
     if (state == OBJECT_EXISTS && new_state == OBJECT_NONEXISTENT &&
         m_snap_id == CEPH_NOSNAP) {
       // might be writing object to OSD concurrently
@@ -157,7 +160,7 @@ private:
       ldout(cct, 15) << m_oid << " C_VerifyObject::update_object_map "
                      << static_cast<uint32_t>(state) << "->"
                      << static_cast<uint32_t>(new_state) << dendl;
-      image_ctx.object_map[m_object_no] = new_state;
+      (*image_ctx.object_map)[m_object_no] = new_state;
     }
     return true;
   }
@@ -234,15 +237,14 @@ void RebuildObjectMapRequest<I>::send_resize_object_map() {
   assert(m_image_ctx.owner_lock.is_locked());
   CephContext *cct = m_image_ctx.cct;
 
-  uint64_t num_objects;
-  uint64_t size;
-  {
-    RWLock::RLocker l(m_image_ctx.snap_lock);
-    size = get_image_size();
-    num_objects = Striper::get_num_objects(m_image_ctx.layout, size);
-  }
+  m_image_ctx.snap_lock.get_read();
+  assert(m_image_ctx.object_map != nullptr);
 
-  if (m_image_ctx.object_map.size() == num_objects) {
+  uint64_t size = get_image_size();
+  uint64_t num_objects = Striper::get_num_objects(m_image_ctx.layout, size);
+
+  if (m_image_ctx.object_map->size() == num_objects) {
+    m_image_ctx.snap_lock.put_read();
     send_verify_objects();
     return;
   }
@@ -253,8 +255,10 @@ void RebuildObjectMapRequest<I>::send_resize_object_map() {
   // should have been canceled prior to releasing lock
   assert(m_image_ctx.exclusive_lock == nullptr ||
          m_image_ctx.exclusive_lock->is_lock_owner());
-  m_image_ctx.object_map.aio_resize(size, OBJECT_NONEXISTENT,
-                                    this->create_callback_context());
+
+  m_image_ctx.object_map->aio_resize(size, OBJECT_NONEXISTENT,
+                                     this->create_callback_context());
+  m_image_ctx.snap_lock.put_read();
 }
 
 template <typename I>
@@ -273,9 +277,11 @@ void RebuildObjectMapRequest<I>::send_trim_image() {
   uint64_t orig_size;
   {
     RWLock::RLocker l(m_image_ctx.snap_lock);
+    assert(m_image_ctx.object_map != nullptr);
+
     new_size = get_image_size();
     orig_size = m_image_ctx.get_object_size() *
-                m_image_ctx.object_map.size();
+                m_image_ctx.object_map->size();
   }
   TrimRequest<I> *req = new TrimRequest<I>(m_image_ctx,
                                            this->create_callback_context(),
@@ -325,7 +331,10 @@ void RebuildObjectMapRequest<I>::send_save_object_map() {
   // should have been canceled prior to releasing lock
   assert(m_image_ctx.exclusive_lock == nullptr ||
          m_image_ctx.exclusive_lock->is_lock_owner());
-  m_image_ctx.object_map.aio_save(this->create_callback_context());
+
+  RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
+  assert(m_image_ctx.object_map != nullptr);
+  m_image_ctx.object_map->aio_save(this->create_callback_context());
 }
 
 template <typename I>

--- a/src/librbd/operation/RebuildObjectMapRequest.cc
+++ b/src/librbd/operation/RebuildObjectMapRequest.cc
@@ -11,6 +11,7 @@
 #include "librbd/ObjectMap.h"
 #include "librbd/operation/ResizeRequest.h"
 #include "librbd/operation/TrimRequest.h"
+#include "librbd/Utils.h"
 #include <boost/lambda/bind.hpp>
 #include <boost/lambda/construct.hpp>
 
@@ -83,12 +84,10 @@ private:
     ldout(image_ctx.cct, 5) << m_oid << " C_VerifyObject::send_list_snaps"
                             << dendl;
 
-    librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-      this, NULL, rados_ctx_cb);
-
     librados::ObjectReadOperation op;
     op.list_snaps(&m_snap_set, &m_snap_list_ret);
 
+    librados::AioCompletion *comp = util::create_rados_safe_callback(this);
     int r = m_io_ctx.aio_operate(m_oid, comp, &op, NULL);
     assert(r == 0);
     comp->release();

--- a/src/librbd/operation/RenameRequest.cc
+++ b/src/librbd/operation/RenameRequest.cc
@@ -7,6 +7,7 @@
 #include "include/rados/librados.hpp"
 #include "librbd/ImageCtx.h"
 #include "librbd/internal.h"
+#include "librbd/Utils.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -46,10 +47,10 @@ template <typename I>
 RenameRequest<I>::RenameRequest(I &image_ctx, Context *on_finish,
 				const std::string &dest_name)
   : Request<I>(image_ctx, on_finish), m_dest_name(dest_name),
-    m_source_oid(image_ctx.old_format ? old_header_name(image_ctx.name) :
-                                        id_obj_name(image_ctx.name)),
-    m_dest_oid(image_ctx.old_format ? old_header_name(dest_name) :
-                                      id_obj_name(dest_name)) {
+    m_source_oid(image_ctx.old_format ? util::old_header_name(image_ctx.name) :
+                                        util::id_obj_name(image_ctx.name)),
+    m_dest_oid(image_ctx.old_format ? util::old_header_name(dest_name) :
+                                      util::id_obj_name(dest_name)) {
 }
 
 template <typename I>

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -222,13 +222,13 @@ bool SnapshotCreateRequest<I>::send_create_object_map() {
   {
     RWLock::RLocker snap_locker(image_ctx.snap_lock);
     RWLock::RLocker object_map_lock(image_ctx.object_map_lock);
-    if (image_ctx.object_map.enabled(image_ctx.object_map_lock)) {
+    if (image_ctx.object_map != nullptr) {
       CephContext *cct = image_ctx.cct;
       ldout(cct, 5) << this << " " << __func__ << dendl;
       m_state = STATE_CREATE_OBJECT_MAP;
 
-      image_ctx.object_map.snapshot_add(m_snap_id,
-                                        this->create_callback_context());
+      image_ctx.object_map->snapshot_add(m_snap_id,
+                                         this->create_callback_context());
       return false;
     }
   }

--- a/src/librbd/operation/SnapshotRemoveRequest.cc
+++ b/src/librbd/operation/SnapshotRemoveRequest.cc
@@ -4,6 +4,7 @@
 #include "librbd/operation/SnapshotRemoveRequest.h"
 #include "common/dout.h"
 #include "common/errno.h"
+#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageWatcher.h"
 #include "librbd/ObjectMap.h"
@@ -164,8 +165,9 @@ void SnapshotRemoveRequest<I>::send_remove_snap() {
   if (image_ctx.old_format) {
     cls_client::old_snapshot_remove(&op, m_snap_name);
   } else {
-    if (image_ctx.image_watcher->is_lock_owner()) {
-      image_ctx.image_watcher->assert_header_locked(&op);
+    if (image_ctx.exclusive_lock != nullptr &&
+        image_ctx.exclusive_lock->is_lock_owner()) {
+      image_ctx.exclusive_lock->assert_header_locked(&op);
     }
     cls_client::snapshot_remove(&op, m_snap_id);
   }

--- a/src/librbd/operation/SnapshotRemoveRequest.cc
+++ b/src/librbd/operation/SnapshotRemoveRequest.cc
@@ -100,12 +100,12 @@ void SnapshotRemoveRequest<I>::send_remove_object_map() {
   {
     RWLock::WLocker snap_locker(image_ctx.snap_lock);
     RWLock::RLocker object_map_locker(image_ctx.object_map_lock);
-    if (image_ctx.object_map.enabled(image_ctx.object_map_lock)) {
+    if (image_ctx.object_map != nullptr) {
       CephContext *cct = image_ctx.cct;
       ldout(cct, 5) << this << " " << __func__ << dendl;
       m_state = STATE_REMOVE_OBJECT_MAP;
 
-      image_ctx.object_map.snapshot_remove(
+      image_ctx.object_map->snapshot_remove(
         m_snap_id, this->create_callback_context());
       return;
     }

--- a/src/librbd/operation/SnapshotRollbackRequest.cc
+++ b/src/librbd/operation/SnapshotRollbackRequest.cc
@@ -8,6 +8,7 @@
 #include "librbd/AsyncObjectThrottle.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ObjectMap.h"
+#include "librbd/Utils.h"
 #include "librbd/operation/ResizeRequest.h"
 #include "osdc/Striper.h"
 #include <boost/lambda/bind.hpp>
@@ -62,10 +63,11 @@ public:
 
     std::string oid = image_ctx.get_object_name(m_object_num);
 
-    librados::AioCompletion *rados_completion =
-      librados::Rados::aio_create_completion(this, NULL, rados_ctx_cb);
     librados::ObjectWriteOperation op;
     op.selfmanaged_snap_rollback(m_snap_id);
+
+    librados::AioCompletion *rados_completion =
+      util::create_rados_safe_callback(this);
     image_ctx.data_ctx.aio_operate(oid, rados_completion, &op);
     rados_completion->release();
     return 0;

--- a/src/librbd/operation/SnapshotRollbackRequest.cc
+++ b/src/librbd/operation/SnapshotRollbackRequest.cc
@@ -163,12 +163,13 @@ void SnapshotRollbackRequest<I>::send_rollback_object_map() {
   {
     RWLock::RLocker snap_locker(image_ctx.snap_lock);
     RWLock::WLocker object_map_lock(image_ctx.object_map_lock);
-    if (image_ctx.object_map.enabled(image_ctx.object_map_lock)) {
+    if (image_ctx.object_map != nullptr) {
       CephContext *cct = image_ctx.cct;
       ldout(cct, 5) << this << " " << __func__ << dendl;
       m_state = STATE_ROLLBACK_OBJECT_MAP;
 
-      image_ctx.object_map.rollback(m_snap_id, this->create_callback_context());
+      image_ctx.object_map->rollback(m_snap_id,
+                                     this->create_callback_context());
       return;
     }
   }

--- a/src/librbd/operation/TrimRequest.cc
+++ b/src/librbd/operation/TrimRequest.cc
@@ -8,6 +8,7 @@
 #include "librbd/ImageWatcher.h"
 #include "librbd/internal.h"
 #include "librbd/ObjectMap.h"
+#include "librbd/Utils.h"
 #include "common/ContextCompletion.h"
 #include "common/dout.h"
 #include "common/errno.h"
@@ -76,7 +77,7 @@ public:
     ldout(image_ctx.cct, 10) << "removing " << oid << dendl;
 
     librados::AioCompletion *rados_completion =
-      librados::Rados::aio_create_completion(this, NULL, rados_ctx_cb);
+      util::create_rados_safe_callback(this);
     int r = image_ctx.data_ctx.aio_remove(oid, rados_completion);
     assert(r == 0);
     rados_completion->release();

--- a/src/librbd/operation/TrimRequest.cc
+++ b/src/librbd/operation/TrimRequest.cc
@@ -4,6 +4,7 @@
 #include "librbd/operation/TrimRequest.h"
 #include "librbd/AsyncObjectThrottle.h"
 #include "librbd/AioObjectRequest.h"
+#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageWatcher.h"
 #include "librbd/internal.h"
@@ -39,8 +40,8 @@ public:
   virtual int send() {
     I &image_ctx = this->m_image_ctx;
     assert(image_ctx.owner_lock.is_locked());
-    assert(!image_ctx.image_watcher->is_lock_supported() ||
-           image_ctx.image_watcher->is_lock_owner());
+    assert(image_ctx.exclusive_lock == nullptr ||
+           image_ctx.exclusive_lock->is_lock_owner());
 
     string oid = image_ctx.get_object_name(m_object_no);
     ldout(image_ctx.cct, 10) << "removing (with copyup) " << oid << dendl;
@@ -67,8 +68,8 @@ public:
   virtual int send() {
     I &image_ctx = this->m_image_ctx;
     assert(image_ctx.owner_lock.is_locked());
-    assert(!image_ctx.image_watcher->is_lock_supported() ||
-           image_ctx.image_watcher->is_lock_owner());
+    assert(image_ctx.exclusive_lock == nullptr ||
+           image_ctx.exclusive_lock->is_lock_owner());
     if (!image_ctx.object_map.object_may_exist(m_object_no)) {
       return 1;
     }
@@ -169,8 +170,8 @@ template <typename I>
 void TrimRequest<I>::send_copyup_objects() {
   I &image_ctx = this->m_image_ctx;
   assert(image_ctx.owner_lock.is_locked());
-  assert(!image_ctx.image_watcher->is_lock_supported() ||
-         image_ctx.image_watcher->is_lock_owner());
+  assert(image_ctx.exclusive_lock == nullptr ||
+         image_ctx.exclusive_lock->is_lock_owner());
 
   if (m_delete_start >= m_num_objects) {
     send_clean_boundary();
@@ -258,7 +259,7 @@ void TrimRequest<I>::send_pre_remove() {
 				<< " num_objects=" << m_num_objects << dendl;
       m_state = STATE_PRE_REMOVE;
 
-      assert(image_ctx.image_watcher->is_lock_owner());
+      assert(image_ctx.exclusive_lock->is_lock_owner());
 
       // flag the objects as pending deletion
       Context *ctx = this->create_callback_context();
@@ -295,7 +296,7 @@ void TrimRequest<I>::send_post_remove() {
           		        << " num_objects=" << m_num_objects << dendl;
       m_state = STATE_POST_REMOVE;
 
-      assert(image_ctx.image_watcher->is_lock_owner());
+      assert(image_ctx.exclusive_lock->is_lock_owner());
 
       // flag the pending objects as removed
       Context *ctx = this->create_callback_context();
@@ -327,8 +328,8 @@ void TrimRequest<I>::send_clean_boundary() {
   }
 
   // should have been canceled prior to releasing lock
-  assert(!image_ctx.image_watcher->is_lock_supported() ||
-         image_ctx.image_watcher->is_lock_owner());
+  assert(image_ctx.exclusive_lock == nullptr ||
+         image_ctx.exclusive_lock->is_lock_owner());
   uint64_t delete_len = m_delete_off - m_new_size;
   ldout(image_ctx.cct, 5) << this << " send_clean_boundary: "
 			    << " delete_off=" << m_delete_off

--- a/src/librbd/parent_types.h
+++ b/src/librbd/parent_types.h
@@ -3,16 +3,20 @@
 #ifndef CEPH_LIBRBD_PARENT_TYPES_H
 #define CEPH_LIBRBD_PARENT_TYPES_H
 
+#include "include/int_types.h"
+#include "include/types.h"
+#include <string>
+
 namespace librbd {
   /** @brief Unique identification of a parent in clone relationship.
    * Cloning an image creates a child image that keeps a reference
    * to its parent. This allows copy-on-write images. */
   struct parent_spec {
     int64_t pool_id;
-    string image_id;
+    std::string image_id;
     snapid_t snap_id;
     parent_spec() : pool_id(-1), snap_id(CEPH_NOSNAP) {}
-    parent_spec(uint64_t pool_id, string image_id, snapid_t snap_id) :
+    parent_spec(uint64_t pool_id, std::string image_id, snapid_t snap_id) :
       pool_id(pool_id), image_id(image_id), snap_id(snap_id) {}
     bool operator==(const parent_spec &other) {
       return ((this->pool_id == other.pool_id) &&

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -406,10 +406,12 @@ noinst_HEADERS += \
 	test/librbd/test_support.h \
 	test/librbd/mock/MockAioImageRequestWQ.h \
 	test/librbd/mock/MockContextWQ.h \
+	test/librbd/mock/MockExclusiveLock.h \
 	test/librbd/mock/MockImageCtx.h \
 	test/librbd/mock/MockImageWatcher.h \
 	test/librbd/mock/MockJournal.h \
 	test/librbd/mock/MockObjectMap.h \
+	test/librbd/mock/MockReadahead.h \
 	test/librbd/object_map/mock/MockInvalidateRequest.h
 
 if LINUX

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -353,6 +353,9 @@ noinst_LTLIBRARIES += librbd_test.la
 unittest_librbd_SOURCES = \
         test/librbd/test_main.cc \
 	test/librbd/test_mock_fixture.cc \
+	test/librbd/test_mock_ExclusiveLock.cc \
+	test/librbd/exclusive_lock/test_mock_AcquireRequest.cc \
+	test/librbd/exclusive_lock/test_mock_ReleaseRequest.cc \
 	test/librbd/object_map/test_mock_InvalidateRequest.cc \
 	test/librbd/object_map/test_mock_LockRequest.cc \
 	test/librbd/object_map/test_mock_RefreshRequest.cc \

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -354,10 +354,13 @@ unittest_librbd_SOURCES = \
         test/librbd/test_main.cc \
 	test/librbd/test_mock_fixture.cc \
 	test/librbd/object_map/test_mock_InvalidateRequest.cc \
+	test/librbd/object_map/test_mock_LockRequest.cc \
+	test/librbd/object_map/test_mock_RefreshRequest.cc \
 	test/librbd/object_map/test_mock_ResizeRequest.cc \
 	test/librbd/object_map/test_mock_SnapshotCreateRequest.cc \
 	test/librbd/object_map/test_mock_SnapshotRemoveRequest.cc \
 	test/librbd/object_map/test_mock_SnapshotRollbackRequest.cc \
+	test/librbd/object_map/test_mock_UnlockRequest.cc \
 	test/librbd/object_map/test_mock_UpdateRequest.cc \
 	test/librbd/operation/test_mock_SnapshotCreateRequest.cc \
 	test/librbd/operation/test_mock_SnapshotProtectRequest.cc \

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -403,7 +403,8 @@ noinst_HEADERS += \
 	test/librbd/mock/MockImageCtx.h \
 	test/librbd/mock/MockImageWatcher.h \
 	test/librbd/mock/MockJournal.h \
-	test/librbd/mock/MockObjectMap.h
+	test/librbd/mock/MockObjectMap.h \
+	test/librbd/object_map/mock/MockInvalidateRequest.h
 
 if LINUX
 ceph_test_librbd_fsx_SOURCES = test/librbd/fsx.cc

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -661,6 +661,19 @@ void ObjectReadOperation::list_snaps(snap_set_t *out_snaps, int *prval) {
   o->ops.push_back(op);
 }
 
+void ObjectReadOperation::list_watchers(std::list<obj_watch_t> *out_watchers,
+                                        int *prval) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+
+  ObjectOperationTestImpl op = boost::bind(&TestIoCtxImpl::list_watchers, _1,
+                                           _2, out_watchers);
+  if (prval != NULL) {
+    op = boost::bind(save_operation_result,
+                     boost::bind(op, _1, _2, _3, _4), prval);
+  }
+  o->ops.push_back(op);
+}
+
 void ObjectReadOperation::read(size_t off, uint64_t len, bufferlist *pbl,
                                int *prval) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -698,6 +698,19 @@ void ObjectReadOperation::sparse_read(uint64_t off, uint64_t len,
   o->ops.push_back(op);
 }
 
+void ObjectReadOperation::stat(uint64_t *psize, time_t *pmtime, int *prval) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+
+  ObjectOperationTestImpl op = boost::bind(&TestIoCtxImpl::stat, _1, _2,
+                                           psize, pmtime);
+
+  if (prval != NULL) {
+    op = boost::bind(save_operation_result,
+                     boost::bind(op, _1, _2, _3, _4), prval);
+  }
+  o->ops.push_back(op);
+}
+
 void ObjectWriteOperation::append(const bufferlist &bl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
   o->ops.push_back(boost::bind(&TestIoCtxImpl::append, _1, _2, bl, _4));

--- a/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
@@ -48,6 +48,13 @@ public:
                                   snapc);
   }
 
+  MOCK_METHOD2(list_watchers, int(const std::string& o,
+                                  std::list<obj_watch_t> *out_watchers));
+  int do_list_watchers(const std::string& o,
+                       std::list<obj_watch_t> *out_watchers) {
+    return TestMemIoCtxImpl::list_watchers(o, out_watchers);
+  }
+
   MOCK_METHOD4(read, int(const std::string& oid,
                          size_t len,
                          uint64_t off,
@@ -92,6 +99,7 @@ public:
     using namespace ::testing;
 
     ON_CALL(*this, exec(_, _, _, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_exec));
+    ON_CALL(*this, list_watchers(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_list_watchers));
     ON_CALL(*this, read(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_read));
     ON_CALL(*this, remove(_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_remove));
     ON_CALL(*this, selfmanaged_snap_create(_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_selfmanaged_snap_create));

--- a/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
@@ -72,6 +72,14 @@ public:
     return TestMemIoCtxImpl::selfmanaged_snap_remove(snap_id);
   }
 
+  MOCK_METHOD3(truncate, int(const std::string& oid,
+                             uint64_t size,
+                             const SnapContext &snapc));
+  int do_truncate(const std::string& oid, uint64_t size,
+                  const SnapContext &snapc) {
+    return TestMemIoCtxImpl::truncate(oid, size, snapc);
+  }
+
   MOCK_METHOD3(write_full, int(const std::string& oid,
                                bufferlist& bl,
                                const SnapContext &snapc));
@@ -88,6 +96,7 @@ public:
     ON_CALL(*this, remove(_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_remove));
     ON_CALL(*this, selfmanaged_snap_create(_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_selfmanaged_snap_create));
     ON_CALL(*this, selfmanaged_snap_remove(_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_selfmanaged_snap_remove));
+    ON_CALL(*this, truncate(_,_,_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_truncate));
     ON_CALL(*this, write_full(_, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_write_full));
   }
 

--- a/src/test/librados_test_stub/MockTestMemRadosClient.h
+++ b/src/test/librados_test_stub/MockTestMemRadosClient.h
@@ -24,10 +24,18 @@ public:
       this, this, pool_id, pool_name, get_pool(pool_name));
   }
 
+  MOCK_METHOD2(blacklist_add, int(const std::string& client_address,
+                                  uint32_t expire_seconds));
+  int do_blacklist_add(const std::string& client_address,
+                       uint32_t expire_seconds) {
+    return TestMemRadosClient::blacklist_add(client_address, expire_seconds);
+  }
+
   void default_to_dispatch() {
     using namespace ::testing;
 
     ON_CALL(*this, create_ioctx(_, _)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_create_ioctx));
+    ON_CALL(*this, blacklist_add(_, _)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_blacklist_add));
   }
 };
 

--- a/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
@@ -149,9 +149,10 @@ TEST_F(TestMockExclusiveLockAcquireRequest, Success) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, 0);
 
   MockJournal mock_journal;
@@ -179,9 +180,10 @@ TEST_F(TestMockExclusiveLockAcquireRequest, SuccessJournalDisabled) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, 0);
 
   expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING, false);
@@ -206,9 +208,10 @@ TEST_F(TestMockExclusiveLockAcquireRequest, SuccessObjectMapDisabled) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, 0);
 
   MockJournal mock_journal;
@@ -232,15 +235,15 @@ TEST_F(TestMockExclusiveLockAcquireRequest, LockBusy) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
                        LOCK_EXCLUSIVE);
   expect_list_watchers(mock_image_ctx, 0, "dead client", 123);
-  expect_op_work_queue(mock_image_ctx);
   expect_blacklist_add(mock_image_ctx, 0);
   expect_break_lock(mock_image_ctx, 0);
   expect_lock(mock_image_ctx, -ENOENT);
@@ -259,9 +262,10 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, -EINVAL, entity_name_t::CLIENT(1), "",
                        "", "", LOCK_EXCLUSIVE);
@@ -280,9 +284,10 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoEmpty) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, -ENOENT, entity_name_t::CLIENT(1), "",
                        "", "", LOCK_EXCLUSIVE);
@@ -302,9 +307,10 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoExternalTag) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", "external tag", LOCK_EXCLUSIVE);
@@ -323,9 +329,10 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoShared) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -345,9 +352,10 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoExternalCookie) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "external cookie", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -367,9 +375,10 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetWatchersError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -390,9 +399,10 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetWatchersAlive) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -413,16 +423,16 @@ TEST_F(TestMockExclusiveLockAcquireRequest, BlacklistDisabled) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
   mock_image_ctx.blacklist_on_break_lock = false;
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
                        LOCK_EXCLUSIVE);
   expect_list_watchers(mock_image_ctx, 0, "dead client", 123);
-  expect_op_work_queue(mock_image_ctx);
   expect_break_lock(mock_image_ctx, 0);
   expect_lock(mock_image_ctx, -ENOENT);
 
@@ -440,15 +450,15 @@ TEST_F(TestMockExclusiveLockAcquireRequest, BlacklistError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
                        LOCK_EXCLUSIVE);
   expect_list_watchers(mock_image_ctx, 0, "dead client", 123);
-  expect_op_work_queue(mock_image_ctx);
   expect_blacklist_add(mock_image_ctx, -EINVAL);
 
   C_SaferCond ctx;
@@ -465,15 +475,15 @@ TEST_F(TestMockExclusiveLockAcquireRequest, BreakLockMissing) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
                        LOCK_EXCLUSIVE);
   expect_list_watchers(mock_image_ctx, 0, "dead client", 123);
-  expect_op_work_queue(mock_image_ctx);
   expect_blacklist_add(mock_image_ctx, 0);
   expect_break_lock(mock_image_ctx, -ENOENT);
   expect_lock(mock_image_ctx, -EINVAL);
@@ -492,15 +502,15 @@ TEST_F(TestMockExclusiveLockAcquireRequest, BreakLockError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
                        LOCK_EXCLUSIVE);
   expect_list_watchers(mock_image_ctx, 0, "dead client", 123);
-  expect_op_work_queue(mock_image_ctx);
   expect_blacklist_add(mock_image_ctx, 0);
   expect_break_lock(mock_image_ctx, -EINVAL);
 

--- a/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
@@ -1,0 +1,516 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/MockJournal.h"
+#include "test/librbd/mock/MockObjectMap.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "cls/lock/cls_lock_ops.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/exclusive_lock/AcquireRequest.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <arpa/inet.h>
+#include <list>
+
+// template definitions
+#include "librbd/exclusive_lock/AcquireRequest.cc"
+template class librbd::exclusive_lock::AcquireRequest<librbd::MockImageCtx>;
+
+namespace librbd {
+namespace exclusive_lock {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+using ::testing::WithArg;
+
+static const std::string TEST_COOKIE("auto 123");
+
+class TestMockExclusiveLockAcquireRequest : public TestMockFixture {
+public:
+  typedef AcquireRequest<MockImageCtx> MockAcquireRequest;
+  typedef ExclusiveLock<MockImageCtx> MockExclusiveLock;
+
+  void expect_test_features(MockImageCtx &mock_image_ctx, uint64_t features,
+                            bool enabled) {
+    EXPECT_CALL(mock_image_ctx, test_features(features))
+                  .WillOnce(Return(enabled));
+  }
+
+  void expect_lock(MockImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(mock_image_ctx.header_oid, _, "lock", "lock", _, _, _))
+                  .WillOnce(Return(r));
+  }
+
+  void expect_create_object_map(MockImageCtx &mock_image_ctx,
+                                MockObjectMap *mock_object_map) {
+    EXPECT_CALL(mock_image_ctx, create_object_map(_))
+                  .WillOnce(Return(mock_object_map));
+  }
+
+  void expect_open_object_map(MockImageCtx &mock_image_ctx,
+                              MockObjectMap &mock_object_map) {
+    EXPECT_CALL(mock_object_map, open(_))
+                  .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
+  }
+
+  void expect_lock_object_map(MockImageCtx &mock_image_ctx,
+                              MockObjectMap &mock_object_map) {
+    EXPECT_CALL(mock_object_map, lock(_))
+                  .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
+  }
+
+  void expect_create_journal(MockImageCtx &mock_image_ctx,
+                             MockJournal *mock_journal) {
+    EXPECT_CALL(mock_image_ctx, create_journal())
+                  .WillOnce(Return(mock_journal));
+  }
+
+  void expect_open_journal(MockImageCtx &mock_image_ctx,
+                           MockJournal &mock_journal, int r) {
+    EXPECT_CALL(mock_journal, open(_))
+                  .WillOnce(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue));
+  }
+
+  void expect_get_lock_info(MockImageCtx &mock_image_ctx, int r,
+                            const entity_name_t &locker_entity,
+                            const std::string &locker_address,
+                            const std::string &locker_cookie,
+                            const std::string &lock_tag,
+                            ClsLockType lock_type) {
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                               exec(mock_image_ctx.header_oid, _, "lock",
+                               "get_info", _, _, _));
+    if (r < 0 && r != -ENOENT) {
+      expect.WillOnce(Return(r));
+    } else {
+      entity_name_t entity(locker_entity);
+      entity_addr_t entity_addr;
+      entity_addr.addr.ss_family = AF_INET;
+      inet_pton(AF_INET, locker_address.c_str(), &entity_addr.addr4.sin_addr);
+
+      cls_lock_get_info_reply reply;
+      if (r != -ENOENT) {
+        reply.lockers = decltype(reply.lockers){
+          {rados::cls::lock::locker_id_t(entity, locker_cookie),
+           rados::cls::lock::locker_info_t(utime_t(), entity_addr, "")}};
+        reply.tag = lock_tag;
+        reply.lock_type = lock_type;
+      }
+
+      bufferlist bl;
+      ::encode(reply, bl);
+
+      std::string str(bl.c_str(), bl.length());
+      expect.WillOnce(DoAll(WithArg<5>(CopyInBufferlist(str)), Return(0)));
+    }
+  }
+
+  void expect_list_watchers(MockImageCtx &mock_image_ctx, int r,
+                            const std::string &address, uint64_t watch_handle) {
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                               list_watchers(mock_image_ctx.header_oid, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      obj_watch_t watcher;
+      strcpy(watcher.addr, (address + ":0/0").c_str());
+      watcher.cookie = watch_handle;
+
+      std::list<obj_watch_t> watchers;
+      watchers.push_back(watcher);
+
+      expect.WillOnce(DoAll(SetArgPointee<1>(watchers), Return(0)));
+    }
+  }
+
+  void expect_blacklist_add(MockImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(get_mock_rados_client(), blacklist_add(_, _))
+                  .WillOnce(Return(r));
+  }
+
+  void expect_break_lock(MockImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(mock_image_ctx.header_oid, _, "lock", "break_lock", _, _, _))
+                  .WillOnce(Return(r));
+  }
+};
+
+TEST_F(TestMockExclusiveLockAcquireRequest, Success) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, 0);
+
+  MockJournal mock_journal;
+  expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING, true);
+  expect_create_journal(mock_image_ctx, &mock_journal);
+  expect_open_journal(mock_image_ctx, mock_journal, 0);
+
+  MockObjectMap mock_object_map;
+  expect_test_features(mock_image_ctx, RBD_FEATURE_OBJECT_MAP, true);
+  expect_create_object_map(mock_image_ctx, &mock_object_map);
+  expect_open_object_map(mock_image_ctx, mock_object_map);
+  expect_lock_object_map(mock_image_ctx, mock_object_map);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, SuccessJournalDisabled) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, 0);
+
+  expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING, false);
+
+  MockObjectMap mock_object_map;
+  expect_test_features(mock_image_ctx, RBD_FEATURE_OBJECT_MAP, true);
+  expect_create_object_map(mock_image_ctx, &mock_object_map);
+  expect_open_object_map(mock_image_ctx, mock_object_map);
+  expect_lock_object_map(mock_image_ctx, mock_object_map);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, SuccessObjectMapDisabled) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, 0);
+
+  MockJournal mock_journal;
+  expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING, true);
+  expect_create_journal(mock_image_ctx, &mock_journal);
+  expect_open_journal(mock_image_ctx, mock_journal, 0);
+
+  expect_test_features(mock_image_ctx, RBD_FEATURE_OBJECT_MAP, false);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, LockBusy) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
+                       "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
+                       LOCK_EXCLUSIVE);
+  expect_list_watchers(mock_image_ctx, 0, "dead client", 123);
+  expect_op_work_queue(mock_image_ctx);
+  expect_blacklist_add(mock_image_ctx, 0);
+  expect_break_lock(mock_image_ctx, 0);
+  expect_lock(mock_image_ctx, -ENOENT);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-ENOENT, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoError) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, -EINVAL, entity_name_t::CLIENT(1), "",
+                       "", "", LOCK_EXCLUSIVE);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoEmpty) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, -ENOENT, entity_name_t::CLIENT(1), "",
+                       "", "", LOCK_EXCLUSIVE);
+  expect_lock(mock_image_ctx, -EINVAL);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoExternalTag) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
+                       "auto 123", "external tag", LOCK_EXCLUSIVE);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-EBUSY, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoShared) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
+                       "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
+                       LOCK_SHARED);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-EBUSY, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoExternalCookie) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
+                       "external cookie", MockExclusiveLock::WATCHER_LOCK_TAG,
+                       LOCK_EXCLUSIVE);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-EBUSY, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, GetWatchersError) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
+                       "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
+                       LOCK_EXCLUSIVE);
+  expect_list_watchers(mock_image_ctx, -EINVAL, "dead client", 123);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, GetWatchersAlive) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
+                       "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
+                       LOCK_EXCLUSIVE);
+  expect_list_watchers(mock_image_ctx, 0, "1.2.3.4", 123);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-EAGAIN, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, BlacklistDisabled) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+  mock_image_ctx.blacklist_on_break_lock = false;
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
+                       "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
+                       LOCK_EXCLUSIVE);
+  expect_list_watchers(mock_image_ctx, 0, "dead client", 123);
+  expect_op_work_queue(mock_image_ctx);
+  expect_break_lock(mock_image_ctx, 0);
+  expect_lock(mock_image_ctx, -ENOENT);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-ENOENT, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, BlacklistError) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
+                       "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
+                       LOCK_EXCLUSIVE);
+  expect_list_watchers(mock_image_ctx, 0, "dead client", 123);
+  expect_op_work_queue(mock_image_ctx);
+  expect_blacklist_add(mock_image_ctx, -EINVAL);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, BreakLockMissing) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
+                       "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
+                       LOCK_EXCLUSIVE);
+  expect_list_watchers(mock_image_ctx, 0, "dead client", 123);
+  expect_op_work_queue(mock_image_ctx);
+  expect_blacklist_add(mock_image_ctx, 0);
+  expect_break_lock(mock_image_ctx, -ENOENT);
+  expect_lock(mock_image_ctx, -EINVAL);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, BreakLockError) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
+                       "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
+                       LOCK_EXCLUSIVE);
+  expect_list_watchers(mock_image_ctx, 0, "dead client", 123);
+  expect_op_work_queue(mock_image_ctx);
+  expect_blacklist_add(mock_image_ctx, 0);
+  expect_break_lock(mock_image_ctx, -EINVAL);
+
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+} // namespace exclusive_lock
+} // namespace librbd

--- a/src/test/librbd/exclusive_lock/test_mock_ReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_ReleaseRequest.cc
@@ -1,0 +1,153 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/MockJournal.h"
+#include "test/librbd/mock/MockObjectMap.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "librbd/exclusive_lock/ReleaseRequest.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <list>
+
+// template definitions
+#include "librbd/exclusive_lock/ReleaseRequest.cc"
+template class librbd::exclusive_lock::ReleaseRequest<librbd::MockImageCtx>;
+
+namespace librbd {
+namespace exclusive_lock {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Return;
+
+static const std::string TEST_COOKIE("auto 123");
+
+class TestMockExclusiveLockReleaseRequest : public TestMockFixture {
+public:
+  typedef ReleaseRequest<MockImageCtx> MockReleaseRequest;
+
+  void expect_cancel_op_requests(MockImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(mock_image_ctx, cancel_async_requests(_))
+                  .WillOnce(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue));
+  }
+
+  void expect_unlock(MockImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(mock_image_ctx.header_oid, _, "lock", "unlock", _, _, _))
+                  .WillOnce(Return(r));
+  }
+
+  void expect_close_journal(MockImageCtx &mock_image_ctx,
+                           MockJournal &mock_journal, int r) {
+    EXPECT_CALL(mock_journal, close(_))
+                  .WillOnce(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue));
+  }
+
+  void expect_unlock_object_map(MockImageCtx &mock_image_ctx,
+                                MockObjectMap &mock_object_map) {
+    EXPECT_CALL(mock_object_map, unlock(_))
+                  .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
+  }
+};
+
+TEST_F(TestMockExclusiveLockReleaseRequest, Success) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_cancel_op_requests(mock_image_ctx, 0);
+
+  MockJournal *mock_journal = new MockJournal();
+  mock_image_ctx.journal = mock_journal;
+  expect_close_journal(mock_image_ctx, *mock_journal, -EINVAL);
+
+  MockObjectMap *mock_object_map = new MockObjectMap();
+  mock_image_ctx.object_map_ptr = mock_object_map;
+  expect_unlock_object_map(mock_image_ctx, *mock_object_map);
+
+  expect_unlock(mock_image_ctx, 0);
+
+  C_SaferCond ctx;
+  MockReleaseRequest *req = MockReleaseRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockReleaseRequest, SuccessJournalDisabled) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_cancel_op_requests(mock_image_ctx, 0);
+
+  MockObjectMap *mock_object_map = new MockObjectMap();
+  mock_image_ctx.object_map_ptr = mock_object_map;
+  expect_unlock_object_map(mock_image_ctx, *mock_object_map);
+
+  expect_unlock(mock_image_ctx, 0);
+
+  C_SaferCond ctx;
+  MockReleaseRequest *req = MockReleaseRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockReleaseRequest, SuccessObjectMapDisabled) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_cancel_op_requests(mock_image_ctx, 0);
+
+  expect_unlock(mock_image_ctx, 0);
+
+  C_SaferCond ctx;
+  MockReleaseRequest *req = MockReleaseRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockReleaseRequest, UnlockError) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_cancel_op_requests(mock_image_ctx, 0);
+
+  expect_unlock(mock_image_ctx, -EINVAL);
+
+  C_SaferCond ctx;
+  MockReleaseRequest *req = MockReleaseRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+} // namespace exclusive_lock
+} // namespace librbd

--- a/src/test/librbd/exclusive_lock/test_mock_ReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_ReleaseRequest.cc
@@ -59,9 +59,10 @@ TEST_F(TestMockExclusiveLockReleaseRequest, Success) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_cancel_op_requests(mock_image_ctx, 0);
 
   MockJournal *mock_journal = new MockJournal();
@@ -69,7 +70,7 @@ TEST_F(TestMockExclusiveLockReleaseRequest, Success) {
   expect_close_journal(mock_image_ctx, *mock_journal, -EINVAL);
 
   MockObjectMap *mock_object_map = new MockObjectMap();
-  mock_image_ctx.object_map_ptr = mock_object_map;
+  mock_image_ctx.object_map = mock_object_map;
   expect_unlock_object_map(mock_image_ctx, *mock_object_map);
 
   expect_unlock(mock_image_ctx, 0);
@@ -88,13 +89,14 @@ TEST_F(TestMockExclusiveLockReleaseRequest, SuccessJournalDisabled) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_cancel_op_requests(mock_image_ctx, 0);
 
   MockObjectMap *mock_object_map = new MockObjectMap();
-  mock_image_ctx.object_map_ptr = mock_object_map;
+  mock_image_ctx.object_map = mock_object_map;
   expect_unlock_object_map(mock_image_ctx, *mock_object_map);
 
   expect_unlock(mock_image_ctx, 0);
@@ -113,9 +115,10 @@ TEST_F(TestMockExclusiveLockReleaseRequest, SuccessObjectMapDisabled) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_cancel_op_requests(mock_image_ctx, 0);
 
   expect_unlock(mock_image_ctx, 0);
@@ -134,9 +137,10 @@ TEST_F(TestMockExclusiveLockReleaseRequest, UnlockError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  InSequence seq;
   MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
 
+  InSequence seq;
   expect_cancel_op_requests(mock_image_ctx, 0);
 
   expect_unlock(mock_image_ctx, -EINVAL);

--- a/src/test/librbd/mock/MockAioImageRequestWQ.h
+++ b/src/test/librbd/mock/MockAioImageRequestWQ.h
@@ -11,6 +11,8 @@ namespace librbd {
 struct MockAioImageRequestWQ {
   MOCK_METHOD1(block_writes, void(Context *));
   MOCK_METHOD0(unblock_writes, void());
+
+  MOCK_CONST_METHOD0(writes_empty, bool());
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockExclusiveLock.h
+++ b/src/test/librbd/mock/MockExclusiveLock.h
@@ -1,0 +1,25 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_LIBRBD_MOCK_EXCLUSIVE_LOCK_H
+#define CEPH_TEST_LIBRBD_MOCK_EXCLUSIVE_LOCK_H
+
+#include "include/int_types.h"
+#include "include/rados/librados.hpp"
+#include "gmock/gmock.h"
+
+class Context;
+
+namespace librbd {
+
+struct MockExclusiveLock {
+  MOCK_CONST_METHOD0(is_lock_owner, bool());
+
+  MOCK_METHOD1(assert_header_locked, void(librados::ObjectWriteOperation *));
+
+  MOCK_METHOD1(shut_down, void(Context*));
+};
+
+} // namespace librbd
+
+#endif // CEPH_TEST_LIBRBD_MOCK_EXCLUSIVE_LOCK_H

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -35,6 +35,7 @@ struct MockImageCtx {
       header_oid(image_ctx.header_oid),
       id(image_ctx.id),
       parent_md(image_ctx.parent_md),
+      layout(image_ctx.layout),
       aio_work_queue(new MockAioImageRequestWQ()),
       op_work_queue(new MockContextWQ()),
       image_watcher(NULL), journal(NULL),
@@ -62,6 +63,7 @@ struct MockImageCtx {
     }
   }
 
+  MOCK_CONST_METHOD1(get_image_size, uint64_t(librados::snap_t));
   MOCK_CONST_METHOD1(get_snap_id, librados::snap_t(std::string in_snap_name));
   MOCK_CONST_METHOD1(get_snap_info, const SnapInfo*(librados::snap_t));
   MOCK_CONST_METHOD2(get_parent_spec, int(librados::snap_t in_snap_id,
@@ -104,6 +106,8 @@ struct MockImageCtx {
   std::string header_oid;
   std::string id;
   parent_info parent_md;
+
+  ceph_file_layout layout;
 
   xlist<AsyncRequest<MockImageCtx>*> async_requests;
   Cond async_requests_cond;

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -38,8 +38,10 @@ struct MockImageCtx {
       layout(image_ctx.layout),
       aio_work_queue(new MockAioImageRequestWQ()),
       op_work_queue(new MockContextWQ()),
-      image_watcher(NULL), journal(NULL),
-      concurrent_management_ops(image_ctx.concurrent_management_ops)
+      image_watcher(NULL), object_map_ptr(NULL), journal(NULL),
+      concurrent_management_ops(image_ctx.concurrent_management_ops),
+      blacklist_on_break_lock(image_ctx.blacklist_on_break_lock),
+      blacklist_expire_seconds(image_ctx.blacklist_expire_seconds)
   {
     md_ctx.dup(image_ctx.md_ctx);
     data_ctx.dup(image_ctx.data_ctx);
@@ -57,10 +59,17 @@ struct MockImageCtx {
   }
 
   void wait_for_async_requests() {
-    Mutex::Locker async_ops_locker(async_ops_lock);
-    while (!async_requests.empty()) {
-      async_requests_cond.Wait(async_ops_lock);
+    async_ops_lock.Lock();
+    if (async_requests.empty()) {
+      async_ops_lock.Unlock();
+      return;
     }
+
+    C_SaferCond ctx;
+    async_requests_waiters.push_back(&ctx);
+    async_ops_lock.Unlock();
+
+    ctx.wait();
   }
 
   MOCK_CONST_METHOD1(get_image_size, uint64_t(librados::snap_t));
@@ -79,6 +88,13 @@ struct MockImageCtx {
                               uint8_t protection_status, uint64_t flags));
   MOCK_METHOD2(rm_snap, void(std::string in_snap_name, librados::snap_t id));
   MOCK_METHOD1(flush, void(Context *));
+
+  MOCK_CONST_METHOD1(test_features, bool(uint64_t test_features));
+
+  MOCK_METHOD1(cancel_async_requests, void(Context*));
+
+  MOCK_METHOD0(create_object_map, MockObjectMap*());
+  MOCK_METHOD0(create_journal, MockJournal*());
 
   ImageCtx *image_ctx;
   CephContext *cct;
@@ -110,17 +126,20 @@ struct MockImageCtx {
   ceph_file_layout layout;
 
   xlist<AsyncRequest<MockImageCtx>*> async_requests;
-  Cond async_requests_cond;
+  std::list<Context*> async_requests_waiters;
 
   MockAioImageRequestWQ *aio_work_queue;
   MockContextWQ *op_work_queue;
 
   MockImageWatcher *image_watcher;
-  MockObjectMap object_map;
+  MockObjectMap object_map;       // TODO replace with ptr
+  MockObjectMap *object_map_ptr;  // TODO
 
   MockJournal *journal;
 
   int concurrent_management_ops;
+  bool blacklist_on_break_lock;
+  uint32_t blacklist_expire_seconds;
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockImageWatcher.h
+++ b/src/test/librbd/mock/MockImageWatcher.h
@@ -12,6 +12,8 @@ struct MockImageWatcher {
   MOCK_CONST_METHOD0(is_lock_owner, bool());
   MOCK_CONST_METHOD1(is_lock_supported, bool(const RWLock &));
   MOCK_METHOD1(assert_header_locked, void (librados::ObjectWriteOperation *));
+
+  MOCK_METHOD0(notify_request_lock, void());
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockImageWatcher.h
+++ b/src/test/librbd/mock/MockImageWatcher.h
@@ -9,10 +9,12 @@
 namespace librbd {
 
 struct MockImageWatcher {
-  MOCK_CONST_METHOD0(is_lock_owner, bool());
-  MOCK_CONST_METHOD1(is_lock_supported, bool(const RWLock &));
-  MOCK_METHOD1(assert_header_locked, void (librados::ObjectWriteOperation *));
+  MOCK_METHOD0(unregister_watch, void());
 
+  MOCK_CONST_METHOD0(get_watch_handle, uint64_t());
+
+  MOCK_METHOD0(notify_acquired_lock, void());
+  MOCK_METHOD0(notify_released_lock, void());
   MOCK_METHOD0(notify_request_lock, void());
 };
 

--- a/src/test/librbd/mock/MockJournal.h
+++ b/src/test/librbd/mock/MockJournal.h
@@ -5,6 +5,7 @@
 #define CEPH_TEST_LIBRBD_MOCK_JOURNAL_H
 
 #include "gmock/gmock.h"
+#include "librbd/JournalTypes.h"
 #include "librbd/Journal.h"
 
 namespace librbd {
@@ -14,6 +15,9 @@ struct MockJournal {
   MOCK_CONST_METHOD0(is_journal_replaying, bool());
 
   MOCK_METHOD1(wait_for_journal_ready, void(Context *));
+
+  MOCK_METHOD1(open, void(Context *));
+  MOCK_METHOD1(close, void(Context *));
 
   MOCK_METHOD1(append_op_event, uint64_t(journal::EventEntry&));
   MOCK_METHOD2(commit_op_event, void(uint64_t, int));

--- a/src/test/librbd/mock/MockObjectMap.h
+++ b/src/test/librbd/mock/MockObjectMap.h
@@ -11,6 +11,10 @@ namespace librbd {
 struct MockObjectMap {
   MOCK_CONST_METHOD1(enabled, bool(const RWLock &object_map_lock));
 
+  MOCK_METHOD1(lock, void(Context *on_finish));
+  MOCK_METHOD1(unlock, void(Context *on_finish));
+  MOCK_METHOD2(refresh, void(uint64_t snap_id, Context *on_finish));
+
   MOCK_METHOD2(snapshot_add, void(uint64_t snap_id, Context *on_finish));
   MOCK_METHOD2(snapshot_remove, void(uint64_t snap_id, Context *on_finish));
 };

--- a/src/test/librbd/mock/MockObjectMap.h
+++ b/src/test/librbd/mock/MockObjectMap.h
@@ -11,9 +11,10 @@ namespace librbd {
 struct MockObjectMap {
   MOCK_CONST_METHOD1(enabled, bool(const RWLock &object_map_lock));
 
+  MOCK_METHOD1(open, void(Context *on_finish));
+
   MOCK_METHOD1(lock, void(Context *on_finish));
   MOCK_METHOD1(unlock, void(Context *on_finish));
-  MOCK_METHOD2(refresh, void(uint64_t snap_id, Context *on_finish));
 
   MOCK_METHOD2(snapshot_add, void(uint64_t snap_id, Context *on_finish));
   MOCK_METHOD2(snapshot_remove, void(uint64_t snap_id, Context *on_finish));

--- a/src/test/librbd/mock/MockReadahead.h
+++ b/src/test/librbd/mock/MockReadahead.h
@@ -1,0 +1,21 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_LIBRBD_MOCK_READAHEAD_H
+#define CEPH_TEST_LIBRBD_MOCK_READAHEAD_H
+
+#include "include/int_types.h"
+#include "gmock/gmock.h"
+
+class Context;
+
+namespace librbd {
+
+struct MockReadahead {
+  MOCK_METHOD1(set_max_readahead_size, void(uint64_t));
+  MOCK_METHOD1(wait_for_pending, void(Context *));
+};
+
+} // namespace librbd
+
+#endif // CEPH_TEST_LIBRBD_MOCK_READAHEAD_H

--- a/src/test/librbd/object_map/mock/MockInvalidateRequest.h
+++ b/src/test/librbd/object_map/mock/MockInvalidateRequest.h
@@ -1,0 +1,42 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/object_map/InvalidateRequest.h"
+
+// template definitions
+#include "librbd/object_map/InvalidateRequest.cc"
+
+namespace librbd {
+namespace object_map {
+
+template <>
+struct InvalidateRequest<MockImageCtx> {
+  static std::list<InvalidateRequest *> s_requests;
+  uint64_t snap_id;
+  bool force;
+  Context *on_finish;
+
+  static InvalidateRequest* create(MockImageCtx &image_ctx, uint64_t snap_id,
+                                   bool force, Context *on_finish) {
+    assert(!s_requests.empty());
+    InvalidateRequest* req = s_requests.front();
+    req->snap_id = snap_id;
+    req->force = force;
+    req->on_finish = on_finish;
+    s_requests.pop_front();
+    return req;
+  }
+
+  InvalidateRequest() {
+    s_requests.push_back(this);
+  }
+
+  MOCK_METHOD0(send, void());
+};
+
+typedef InvalidateRequest<MockImageCtx> MockInvalidateRequest;
+
+std::list<InvalidateRequest<MockImageCtx>*> InvalidateRequest<MockImageCtx>::s_requests;
+
+} // namespace object_map
+} // namespace librbd

--- a/src/test/librbd/object_map/test_mock_InvalidateRequest.cc
+++ b/src/test/librbd/object_map/test_mock_InvalidateRequest.cc
@@ -28,7 +28,7 @@ TEST_F(TestMockObjectMapInvalidateRequest, UpdatesInMemoryFlag) {
   ASSERT_FALSE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
 
   C_SaferCond cond_ctx;
-  AsyncRequest<> *request = new InvalidateRequest(*ictx, CEPH_NOSNAP, false, &cond_ctx);
+  AsyncRequest<> *request = new InvalidateRequest<>(*ictx, CEPH_NOSNAP, false, &cond_ctx);
 
   EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
               exec(ictx->header_oid, _, "rbd", "set_flags", _, _, _))
@@ -52,7 +52,7 @@ TEST_F(TestMockObjectMapInvalidateRequest, UpdatesHeadOnDiskFlag) {
   ASSERT_EQ(0, acquire_exclusive_lock(*ictx));
 
   C_SaferCond cond_ctx;
-  AsyncRequest<> *request = new InvalidateRequest(*ictx, CEPH_NOSNAP, false, &cond_ctx);
+  AsyncRequest<> *request = new InvalidateRequest<>(*ictx, CEPH_NOSNAP, false, &cond_ctx);
 
   EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
               exec(ictx->header_oid, _, "lock", "assert_locked", _, _, _))
@@ -81,7 +81,7 @@ TEST_F(TestMockObjectMapInvalidateRequest, UpdatesSnapOnDiskFlag) {
   ASSERT_EQ(0, librbd::snap_set(ictx, "snap1"));
 
   C_SaferCond cond_ctx;
-  AsyncRequest<> *request = new InvalidateRequest(*ictx, ictx->snap_id, false,
+  AsyncRequest<> *request = new InvalidateRequest<>(*ictx, ictx->snap_id, false,
                                                 &cond_ctx);
 
   EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
@@ -106,7 +106,7 @@ TEST_F(TestMockObjectMapInvalidateRequest, SkipOnDiskUpdateWithoutLock) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   C_SaferCond cond_ctx;
-  AsyncRequest<> *request = new InvalidateRequest(*ictx, CEPH_NOSNAP, false, &cond_ctx);
+  AsyncRequest<> *request = new InvalidateRequest<>(*ictx, CEPH_NOSNAP, false, &cond_ctx);
 
   EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
               exec(ictx->header_oid, _, "rbd", "set_flags", _, _, _))
@@ -130,7 +130,7 @@ TEST_F(TestMockObjectMapInvalidateRequest, IgnoresOnDiskUpdateFailure) {
   ASSERT_EQ(0, acquire_exclusive_lock(*ictx));
 
   C_SaferCond cond_ctx;
-  AsyncRequest<> *request = new InvalidateRequest(*ictx, CEPH_NOSNAP, false, &cond_ctx);
+  AsyncRequest<> *request = new InvalidateRequest<>(*ictx, CEPH_NOSNAP, false, &cond_ctx);
 
   EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
               exec(ictx->header_oid, _, "lock", "assert_locked", _, _, _))

--- a/src/test/librbd/object_map/test_mock_LockRequest.cc
+++ b/src/test/librbd/object_map/test_mock_LockRequest.cc
@@ -1,0 +1,215 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "cls/lock/cls_lock_ops.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/object_map/LockRequest.h"
+
+// template definitions
+#include "librbd/object_map/LockRequest.cc"
+
+namespace librbd {
+namespace object_map {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Return;
+using ::testing::WithArg;
+
+class TestMockObjectMapLockRequest : public TestMockFixture {
+public:
+  typedef LockRequest<MockImageCtx> MockLockRequest;
+
+  void expect_lock(MockImageCtx &mock_image_ctx, int r) {
+    std::string oid(ObjectMap::object_map_name(mock_image_ctx.id, CEPH_NOSNAP));
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(oid, _, "lock", "lock", _, _, _))
+                  .WillOnce(Return(r));
+  }
+
+  void expect_get_lock_info(MockImageCtx &mock_image_ctx, int r) {
+    std::string oid(ObjectMap::object_map_name(mock_image_ctx.id, CEPH_NOSNAP));
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                               exec(oid, _, "lock", "get_info", _, _, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      entity_name_t entity1(entity_name_t::CLIENT(1));
+      entity_name_t entity2(entity_name_t::CLIENT(2));
+
+      cls_lock_get_info_reply reply;
+      reply.lockers = decltype(reply.lockers){
+        {rados::cls::lock::locker_id_t(entity1, "cookie1"),
+         rados::cls::lock::locker_info_t()},
+        {rados::cls::lock::locker_id_t(entity2, "cookie2"),
+         rados::cls::lock::locker_info_t()}};
+
+      bufferlist bl;
+      ::encode(reply, bl);
+
+      std::string str(bl.c_str(), bl.length());
+      expect.WillOnce(DoAll(WithArg<5>(CopyInBufferlist(str)), Return(r)));
+    }
+  }
+
+  void expect_break_lock(MockImageCtx &mock_image_ctx, int r) {
+    std::string oid(ObjectMap::object_map_name(mock_image_ctx.id, CEPH_NOSNAP));
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                               exec(oid, _, "lock", "break_lock", _, _, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.Times(2).WillRepeatedly(Return(0));
+    }
+  }
+};
+
+TEST_F(TestMockObjectMapLockRequest, Success) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  MockLockRequest *req = new MockLockRequest(mock_image_ctx, &ctx);
+
+  InSequence seq;
+  expect_lock(mock_image_ctx, 0);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockObjectMapLockRequest, LockBusy) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  MockLockRequest *req = new MockLockRequest(mock_image_ctx, &ctx);
+
+  InSequence seq;
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0);
+  expect_break_lock(mock_image_ctx, 0);
+  expect_lock(mock_image_ctx, 0);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockObjectMapLockRequest, LockError) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  MockLockRequest *req = new MockLockRequest(mock_image_ctx, &ctx);
+
+  InSequence seq;
+  expect_lock(mock_image_ctx, -ENOENT);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockObjectMapLockRequest, GetLockInfoMissing) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  MockLockRequest *req = new MockLockRequest(mock_image_ctx, &ctx);
+
+  InSequence seq;
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, -ENOENT);
+  expect_lock(mock_image_ctx, 0);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockObjectMapLockRequest, GetLockInfoError) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  MockLockRequest *req = new MockLockRequest(mock_image_ctx, &ctx);
+
+  InSequence seq;
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, -EINVAL);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockObjectMapLockRequest, BreakLockMissing) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  MockLockRequest *req = new MockLockRequest(mock_image_ctx, &ctx);
+
+  InSequence seq;
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0);
+  expect_break_lock(mock_image_ctx, -ENOENT);
+  expect_lock(mock_image_ctx, 0);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockObjectMapLockRequest, BreakLockError) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  MockLockRequest *req = new MockLockRequest(mock_image_ctx, &ctx);
+
+  InSequence seq;
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0);
+  expect_break_lock(mock_image_ctx, -EINVAL);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockObjectMapLockRequest, LockErrorAfterBrokeLock) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  MockLockRequest *req = new MockLockRequest(mock_image_ctx, &ctx);
+
+  InSequence seq;
+  expect_lock(mock_image_ctx, -EBUSY);
+  expect_get_lock_info(mock_image_ctx, 0);
+  expect_break_lock(mock_image_ctx, 0);
+  expect_lock(mock_image_ctx, -EBUSY);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+} // namespace object_map
+} // namespace librbd

--- a/src/test/librbd/object_map/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/object_map/test_mock_RefreshRequest.cc
@@ -1,0 +1,291 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/object_map/mock/MockInvalidateRequest.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "common/bit_vector.hpp"
+#include "librbd/ObjectMap.h"
+#include "librbd/object_map/RefreshRequest.h"
+
+// template definitions
+#include "librbd/object_map/RefreshRequest.cc"
+
+namespace librbd {
+namespace object_map {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::DoDefault;
+using ::testing::InSequence;
+using ::testing::Return;
+using ::testing::WithArg;
+
+class TestMockObjectMapRefreshRequest : public TestMockFixture {
+public:
+  static const uint64_t TEST_SNAP_ID = 123;
+
+  typedef RefreshRequest<MockImageCtx> MockRefreshRequest;
+
+  void expect_object_map_load(MockImageCtx &mock_image_ctx,
+                              ceph::BitVector<2> *object_map, int r) {
+    std::string oid(ObjectMap::object_map_name(mock_image_ctx.id, TEST_SNAP_ID));
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                               exec(oid, _, "rbd", "object_map_load", _, _, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      assert(object_map);
+      object_map->set_crc_enabled(false);
+
+      bufferlist bl;
+      ::encode(*object_map, bl);
+
+      std::string str(bl.c_str(), bl.length());
+      expect.WillOnce(DoAll(WithArg<5>(CopyInBufferlist(str)), Return(0)));
+    }
+  }
+
+  void expect_get_image_size(MockImageCtx &mock_image_ctx, uint64_t size) {
+    EXPECT_CALL(mock_image_ctx, get_image_size(TEST_SNAP_ID))
+                  .WillOnce(Return(size));
+  }
+
+  void expect_invalidate_request(MockImageCtx &mock_image_ctx,
+                                 MockInvalidateRequest &invalidate_request) {
+    EXPECT_CALL(invalidate_request, send())
+                  .WillOnce(FinishRequest(&invalidate_request, 0,
+                                          &mock_image_ctx));
+  }
+
+  void expect_truncate_request(MockImageCtx &mock_image_ctx) {
+    std::string oid(ObjectMap::object_map_name(mock_image_ctx.id, TEST_SNAP_ID));
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx), truncate(oid, 0, _))
+                  .WillOnce(Return(0));
+  }
+
+  void expect_object_map_resize(MockImageCtx &mock_image_ctx,
+                                uint64_t num_objects, int r) {
+    std::string oid(ObjectMap::object_map_name(mock_image_ctx.id, TEST_SNAP_ID));
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                               exec(oid, _, "rbd", "object_map_resize", _, _, _));
+    expect.WillOnce(Return(r));
+  }
+
+  void init_object_map(MockImageCtx &mock_image_ctx,
+                       ceph::BitVector<2> *object_map) {
+    uint64_t num_objs = Striper::get_num_objects(
+      mock_image_ctx.layout, mock_image_ctx.image_ctx->size);
+    object_map->resize(num_objs);
+    for (uint64_t i = 0; i < num_objs; ++i) {
+      (*object_map)[i] = rand() % 3;
+    }
+  }
+
+  void when_apply_refresh_request(MockImageCtx &mock_image_ctx,
+                                 MockRefreshRequest *req) {
+    RWLock::WLocker snap_locker(mock_image_ctx.snap_lock);
+    RWLock::WLocker object_map_locker(mock_image_ctx.object_map_lock);
+    expect_get_image_size(mock_image_ctx, mock_image_ctx.image_ctx->size);
+    req->apply();
+  }
+};
+
+TEST_F(TestMockObjectMapRefreshRequest, Success) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  ceph::BitVector<2> on_disk_object_map;
+  init_object_map(mock_image_ctx, &on_disk_object_map);
+
+  C_SaferCond ctx;
+  ceph::BitVector<2> object_map;
+  MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, &object_map,
+                                                   TEST_SNAP_ID, &ctx);
+
+  InSequence seq;
+  expect_get_image_size(mock_image_ctx, mock_image_ctx.image_ctx->size);
+  expect_object_map_load(mock_image_ctx, &on_disk_object_map, 0);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  when_apply_refresh_request(mock_image_ctx, req);
+  ASSERT_EQ(on_disk_object_map, object_map);
+}
+
+TEST_F(TestMockObjectMapRefreshRequest, LoadError) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  ceph::BitVector<2> on_disk_object_map;
+  init_object_map(mock_image_ctx, &on_disk_object_map);
+
+  C_SaferCond ctx;
+  ceph::BitVector<2> object_map;
+  MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, &object_map,
+                                                   TEST_SNAP_ID, &ctx);
+
+  InSequence seq;
+  expect_get_image_size(mock_image_ctx, mock_image_ctx.image_ctx->size);
+  expect_object_map_load(mock_image_ctx, nullptr, -ENOENT);
+
+  MockInvalidateRequest invalidate_request;
+  expect_invalidate_request(mock_image_ctx, invalidate_request);
+
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  when_apply_refresh_request(mock_image_ctx, req);
+}
+
+TEST_F(TestMockObjectMapRefreshRequest, LoadCorrupt) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  ceph::BitVector<2> on_disk_object_map;
+  init_object_map(mock_image_ctx, &on_disk_object_map);
+
+  C_SaferCond ctx;
+  ceph::BitVector<2> object_map;
+  MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, &object_map,
+                                                   TEST_SNAP_ID, &ctx);
+
+  InSequence seq;
+  expect_get_image_size(mock_image_ctx, mock_image_ctx.image_ctx->size);
+  expect_object_map_load(mock_image_ctx, nullptr, -EINVAL);
+
+  MockInvalidateRequest invalidate_request;
+  expect_invalidate_request(mock_image_ctx, invalidate_request);
+  expect_truncate_request(mock_image_ctx);
+  expect_object_map_resize(mock_image_ctx, on_disk_object_map.size(), 0);
+
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  when_apply_refresh_request(mock_image_ctx, req);
+}
+
+TEST_F(TestMockObjectMapRefreshRequest, TooSmall) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  ceph::BitVector<2> on_disk_object_map;
+  init_object_map(mock_image_ctx, &on_disk_object_map);
+
+  ceph::BitVector<2> small_object_map;
+
+  C_SaferCond ctx;
+  ceph::BitVector<2> object_map;
+  MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, &object_map,
+                                                   TEST_SNAP_ID, &ctx);
+
+  InSequence seq;
+  expect_get_image_size(mock_image_ctx, mock_image_ctx.image_ctx->size);
+  expect_object_map_load(mock_image_ctx, &small_object_map, 0);
+
+  MockInvalidateRequest invalidate_request;
+  expect_invalidate_request(mock_image_ctx, invalidate_request);
+  expect_object_map_resize(mock_image_ctx, on_disk_object_map.size(), 0);
+
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  when_apply_refresh_request(mock_image_ctx, req);
+}
+
+TEST_F(TestMockObjectMapRefreshRequest, TooLarge) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  ceph::BitVector<2> on_disk_object_map;
+  init_object_map(mock_image_ctx, &on_disk_object_map);
+
+  ceph::BitVector<2> large_object_map;
+  large_object_map.resize(on_disk_object_map.size() * 2);
+
+  C_SaferCond ctx;
+  ceph::BitVector<2> object_map;
+  MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, &object_map,
+                                                   TEST_SNAP_ID, &ctx);
+
+  InSequence seq;
+  expect_get_image_size(mock_image_ctx, mock_image_ctx.image_ctx->size);
+  expect_object_map_load(mock_image_ctx, &large_object_map, 0);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  when_apply_refresh_request(mock_image_ctx, req);
+}
+
+TEST_F(TestMockObjectMapRefreshRequest, ResizeError) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  ceph::BitVector<2> on_disk_object_map;
+  init_object_map(mock_image_ctx, &on_disk_object_map);
+
+  ceph::BitVector<2> small_object_map;
+
+  C_SaferCond ctx;
+  ceph::BitVector<2> object_map;
+  MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, &object_map,
+                                                   TEST_SNAP_ID, &ctx);
+
+  InSequence seq;
+  expect_get_image_size(mock_image_ctx, mock_image_ctx.image_ctx->size);
+  expect_object_map_load(mock_image_ctx, &small_object_map, 0);
+
+  MockInvalidateRequest invalidate_request;
+  expect_invalidate_request(mock_image_ctx, invalidate_request);
+  expect_object_map_resize(mock_image_ctx, on_disk_object_map.size(), -ESTALE);
+
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  when_apply_refresh_request(mock_image_ctx, req);
+}
+
+TEST_F(TestMockObjectMapRefreshRequest, StaleRefresh) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  ceph::BitVector<2> object_map;
+  MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, &object_map,
+                                                   TEST_SNAP_ID, &ctx);
+  ASSERT_THROW(when_apply_refresh_request(mock_image_ctx, req),
+               ceph::FailedAssertion);
+}
+
+TEST_F(TestMockObjectMapRefreshRequest, Discard) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  ceph::BitVector<2> object_map;
+  MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, &object_map,
+                                                   TEST_SNAP_ID, &ctx);
+  req->discard();
+}
+
+} // namespace object_map
+} // namespace librbd
+

--- a/src/test/librbd/object_map/test_mock_ResizeRequest.cc
+++ b/src/test/librbd/object_map/test_mock_ResizeRequest.cc
@@ -6,6 +6,7 @@
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "common/bit_vector.hpp"
 #include "librbd/internal.h"
+#include "librbd/ObjectMap.h"
 #include "librbd/object_map/ResizeRequest.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/src/test/librbd/object_map/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotCreateRequest.cc
@@ -6,6 +6,7 @@
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "common/bit_vector.hpp"
 #include "librbd/internal.h"
+#include "librbd/ObjectMap.h"
 #include "librbd/object_map/SnapshotCreateRequest.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/src/test/librbd/object_map/test_mock_SnapshotRemoveRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotRemoveRequest.cc
@@ -5,7 +5,9 @@
 #include "test/librbd/test_support.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "common/bit_vector.hpp"
+#include "librbd/ImageState.h"
 #include "librbd/internal.h"
+#include "librbd/ObjectMap.h"
 #include "librbd/object_map/SnapshotRemoveRequest.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -75,7 +77,7 @@ TEST_F(TestMockObjectMapSnapshotRemoveRequest, Success) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;
   if (ictx->test_features(RBD_FEATURE_FAST_DIFF)) {
@@ -104,7 +106,7 @@ TEST_F(TestMockObjectMapSnapshotRemoveRequest, LoadMapError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;
   expect_load_map(ictx, snap_id, -EINVAL);
@@ -131,7 +133,7 @@ TEST_F(TestMockObjectMapSnapshotRemoveRequest, RemoveSnapshotMissing) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;
   expect_load_map(ictx, snap_id, 0);
@@ -158,7 +160,7 @@ TEST_F(TestMockObjectMapSnapshotRemoveRequest, RemoveSnapshotError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;
   expect_load_map(ictx, snap_id, 0);
@@ -186,7 +188,7 @@ TEST_F(TestMockObjectMapSnapshotRemoveRequest, RemoveMapMissing) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;
   if (ictx->test_features(RBD_FEATURE_FAST_DIFF)) {
@@ -215,7 +217,7 @@ TEST_F(TestMockObjectMapSnapshotRemoveRequest, RemoveMapError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;
   if (ictx->test_features(RBD_FEATURE_FAST_DIFF)) {
@@ -244,7 +246,7 @@ TEST_F(TestMockObjectMapSnapshotRemoveRequest, ScrubCleanObjects) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;
 

--- a/src/test/librbd/object_map/test_mock_SnapshotRollbackRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotRollbackRequest.cc
@@ -4,6 +4,7 @@
 #include "test/librbd/test_mock_fixture.h"
 #include "test/librbd/test_support.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "librbd/ImageState.h"
 #include "librbd/internal.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/object_map/SnapshotRollbackRequest.h"
@@ -66,7 +67,7 @@ TEST_F(TestMockObjectMapSnapshotRollbackRequest, Success) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;
   expect_read_map(ictx, snap_id, 0);
@@ -87,7 +88,7 @@ TEST_F(TestMockObjectMapSnapshotRollbackRequest, ReadMapError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;
   expect_read_map(ictx, snap_id, -ENOENT);
@@ -115,7 +116,7 @@ TEST_F(TestMockObjectMapSnapshotRollbackRequest, WriteMapError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;
   expect_read_map(ictx, snap_id, 0);

--- a/src/test/librbd/object_map/test_mock_UnlockRequest.cc
+++ b/src/test/librbd/object_map/test_mock_UnlockRequest.cc
@@ -1,0 +1,67 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "cls/lock/cls_lock_ops.h"
+#include "librbd/ObjectMap.h"
+#include "librbd/object_map/UnlockRequest.h"
+
+// template definitions
+#include "librbd/object_map/UnlockRequest.cc"
+
+namespace librbd {
+namespace object_map {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Return;
+
+class TestMockObjectMapUnlockRequest : public TestMockFixture {
+public:
+  typedef UnlockRequest<MockImageCtx> MockUnlockRequest;
+
+  void expect_unlock(MockImageCtx &mock_image_ctx, int r) {
+    std::string oid(ObjectMap::object_map_name(mock_image_ctx.id, CEPH_NOSNAP));
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(oid, _, "lock", "unlock", _, _, _))
+                  .WillOnce(Return(r));
+  }
+};
+
+TEST_F(TestMockObjectMapUnlockRequest, Success) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  MockUnlockRequest *req = new MockUnlockRequest(mock_image_ctx, &ctx);
+
+  InSequence seq;
+  expect_unlock(mock_image_ctx, 0);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockObjectMapUnlockRequest, UnlockError) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  C_SaferCond ctx;
+  MockUnlockRequest *req = new MockUnlockRequest(mock_image_ctx, &ctx);
+
+  InSequence seq;
+  expect_unlock(mock_image_ctx, -ENOENT);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+} // namespace object_map
+} // namespace librbd

--- a/src/test/librbd/object_map/test_mock_UpdateRequest.cc
+++ b/src/test/librbd/object_map/test_mock_UpdateRequest.cc
@@ -5,7 +5,9 @@
 #include "test/librbd/test_support.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "common/bit_vector.hpp"
+#include "librbd/ImageState.h"
 #include "librbd/internal.h"
+#include "librbd/ObjectMap.h"
 #include "librbd/object_map/UpdateRequest.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -168,7 +170,7 @@ TEST_F(TestMockObjectMapUpdateRequest, RebuildSnapOnDisk) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
   ASSERT_EQ(CEPH_NOSNAP, ictx->snap_id);
 
   uint64_t snap_id = ictx->snap_info.rbegin()->first;

--- a/src/test/librbd/operation/test_mock_SnapshotProtectRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotProtectRequest.cc
@@ -6,6 +6,7 @@
 #include "test/librbd/mock/MockImageCtx.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "common/bit_vector.hpp"
+#include "librbd/ImageState.h"
 #include "librbd/internal.h"
 #include "librbd/operation/SnapshotProtectRequest.h"
 #include "gmock/gmock.h"
@@ -61,7 +62,7 @@ TEST_F(TestMockOperationSnapshotProtectRequest, Success) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 
@@ -88,7 +89,7 @@ TEST_F(TestMockOperationSnapshotProtectRequest, GetSnapIdMissing) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 
@@ -113,7 +114,7 @@ TEST_F(TestMockOperationSnapshotProtectRequest, IsSnapProtectedError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 
@@ -139,7 +140,7 @@ TEST_F(TestMockOperationSnapshotProtectRequest, SnapAlreadyProtected) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 
@@ -165,7 +166,7 @@ TEST_F(TestMockOperationSnapshotProtectRequest, SetProtectionStateError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 

--- a/src/test/librbd/operation/test_mock_SnapshotUnprotectRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotUnprotectRequest.cc
@@ -8,6 +8,7 @@
 #include "test/librados_test_stub/MockTestMemRadosClient.h"
 #include "include/rados/librados.hpp"
 #include "common/bit_vector.hpp"
+#include "librbd/ImageState.h"
 #include "librbd/internal.h"
 #include "librbd/operation/SnapshotUnprotectRequest.h"
 #include "gmock/gmock.h"
@@ -105,7 +106,7 @@ TEST_F(TestMockOperationSnapshotUnprotectRequest, Success) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 
@@ -138,7 +139,7 @@ TEST_F(TestMockOperationSnapshotUnprotectRequest, GetSnapIdMissing) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 
@@ -163,7 +164,7 @@ TEST_F(TestMockOperationSnapshotUnprotectRequest, IsSnapUnprotectedError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 
@@ -189,7 +190,7 @@ TEST_F(TestMockOperationSnapshotUnprotectRequest, SnapAlreadyUnprotected) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 
@@ -215,7 +216,7 @@ TEST_F(TestMockOperationSnapshotUnprotectRequest, SetProtectionStatusError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 
@@ -244,7 +245,7 @@ TEST_F(TestMockOperationSnapshotUnprotectRequest, ChildrenExist) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, librbd::snap_create(ictx, "snap1"));
-  ASSERT_EQ(0, librbd::ictx_check(ictx));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);
 

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -45,44 +45,6 @@ public:
   {
   }
 
-  struct LockListener : public librbd::ImageWatcher::Listener {
-    Mutex lock;
-    Cond cond;
-    size_t releasing_lock_count;
-    size_t lock_updated_count;
-    bool lock_owner;
-
-    LockListener()
-      : lock("lock"), releasing_lock_count(0), lock_updated_count(0),
-        lock_owner(false) {
-    }
-
-    virtual bool handle_requested_lock() {
-      return true;
-    }
-    virtual void handle_lock_updated(
-        librbd::ImageWatcher::LockUpdateState state) {
-      Mutex::Locker locker(lock);
-      ++lock_updated_count;
-
-      switch (state) {
-      case librbd::ImageWatcher::LOCK_UPDATE_STATE_NOT_SUPPORTED:
-      case librbd::ImageWatcher::LOCK_UPDATE_STATE_UNLOCKED:
-      case librbd::ImageWatcher::LOCK_UPDATE_STATE_NOTIFICATION:
-        lock_owner = false;
-        break;
-      case librbd::ImageWatcher::LOCK_UPDATE_STATE_RELEASING:
-        lock_owner = false;
-        ++releasing_lock_count;
-        break;
-      case librbd::ImageWatcher::LOCK_UPDATE_STATE_LOCKED:
-        lock_owner = true;
-        break;
-      }
-      cond.Signal();
-    }
-  };
-
   class WatchCtx : public librados::WatchCtx2 {
   public:
     WatchCtx(TestImageWatcher &parent) : m_parent(parent), m_handle(0) {}
@@ -165,37 +127,9 @@ public:
     return 0;
   }
 
-  void register_lock_listener(librbd::ImageCtx &ictx) {
-    ictx.image_watcher->register_listener(&m_lock_listener);
-  }
-
   int register_image_watch(librbd::ImageCtx &ictx) {
     m_watch_ctx = new WatchCtx(*this);
     return m_watch_ctx->watch(ictx);
-  }
-
-  bool wait_for_releasing_lock(librbd::ImageCtx &ictx) {
-    Mutex::Locker locker(m_lock_listener.lock);
-    while (m_lock_listener.releasing_lock_count == 0) {
-      if (m_lock_listener.cond.WaitInterval(ictx.cct, m_lock_listener.lock,
-                                            utime_t(10, 0)) != 0) {
-        return false;
-      }
-    }
-    m_lock_listener.releasing_lock_count = 0;
-    return true;
-  }
-
-  bool wait_for_lock_updated(librbd::ImageCtx &ictx) {
-    Mutex::Locker locker(m_lock_listener.lock);
-    while (m_lock_listener.lock_updated_count == 0) {
-      if (m_lock_listener.cond.WaitInterval(ictx.cct, m_lock_listener.lock,
-                                            utime_t(10, 0)) != 0) {
-        return false;
-      }
-    }
-    m_lock_listener.lock_updated_count = 0;
-    return true;
   }
 
   bool wait_for_notifies(librbd::ImageCtx &ictx) {
@@ -270,8 +204,6 @@ public:
   typedef std::set<NotifyOp> NotifyOps;
 
   WatchCtx *m_watch_ctx;
-
-  LockListener m_lock_listener;
 
   NotifyOps m_notifies;
   NotifyOpPayloads m_notify_payloads;
@@ -357,487 +289,58 @@ struct RebuildObjectMapTask {
   }
 };
 
-TEST_F(TestImageWatcher, IsLockSupported) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  RWLock::WLocker l(ictx->owner_lock);
-  ASSERT_TRUE(ictx->image_watcher);
-  ASSERT_TRUE(ictx->image_watcher->is_lock_supported());
-
-  ictx->read_only = true;
-  ASSERT_FALSE(ictx->image_watcher->is_lock_supported());
-  ictx->read_only = false;
-
-  ictx->features &= ~RBD_FEATURE_EXCLUSIVE_LOCK;
-  ASSERT_FALSE(ictx->image_watcher->is_lock_supported());
-  ictx->features |= RBD_FEATURE_EXCLUSIVE_LOCK;
-
-  ictx->snap_id = 1234;
-  ASSERT_FALSE(ictx->image_watcher->is_lock_supported());
-  ictx->snap_id = CEPH_NOSNAP;
-}
-
-TEST_F(TestImageWatcher, TryLock) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_TRUE(ictx->image_watcher);
-
-  {
-    RWLock::WLocker l(ictx->owner_lock);
-    ASSERT_EQ(0, ictx->image_watcher->try_lock());
-    ASSERT_TRUE(ictx->image_watcher->is_lock_owner());
-  }
-
-  std::map<rados::cls::lock::locker_id_t,
-           rados::cls::lock::locker_info_t> lockers;
-  ClsLockType lock_type;
-  ASSERT_EQ(0, rados::cls::lock::get_lock_info(&m_ioctx, ictx->header_oid,
-					       RBD_LOCK_NAME, &lockers,
-					       &lock_type, NULL));
-  ASSERT_EQ(LOCK_EXCLUSIVE, lock_type);
-  ASSERT_EQ(1U, lockers.size());
-}
-
-TEST_F(TestImageWatcher, TryLockNotifyAnnounceLocked) {
+TEST_F(TestImageWatcher, NotifyRequestLock) {
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  m_notify_acks = {{NOTIFY_OP_ACQUIRED_LOCK, {}}};
 
-  {
-    RWLock::WLocker l(ictx->owner_lock);
-    ASSERT_EQ(0, ictx->image_watcher->try_lock());
-  }
-
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-
-  NotifyOps expected_notify_ops;
-  expected_notify_ops += NOTIFY_OP_ACQUIRED_LOCK;
-  ASSERT_EQ(expected_notify_ops, m_notifies);
-}
-
-TEST_F(TestImageWatcher, TryLockWithTimedOutOwner) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  // use new Rados connection due to blacklisting
-  librados::Rados rados;
-  ASSERT_EQ("", connect_cluster_pp(rados));
-
-  librados::IoCtx io_ctx;
-  ASSERT_EQ(0, rados.ioctx_create(_pool_name.c_str(), io_ctx));
-  librbd::ImageCtx *ictx = new librbd::ImageCtx(m_image_name.c_str(), "", NULL,
-					        io_ctx, false);
-  ASSERT_EQ(0, librbd::open_image(ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE, "auto 1234"));
-  librbd::close_image(ictx);
-  io_ctx.close();
-
-  // no watcher on the locked image means we can break the lock
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  RWLock::WLocker l(ictx->owner_lock);
-  ASSERT_EQ(0, ictx->image_watcher->try_lock());
-  ASSERT_TRUE(ictx->image_watcher->is_lock_owner());
-
-  rados.test_blacklist_self(false);
-}
-
-TEST_F(TestImageWatcher, TryLockWithUserExclusiveLock) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE, "manually locked"));
-
-  RWLock::WLocker l(ictx->owner_lock);
-  ASSERT_EQ(-EBUSY, ictx->image_watcher->try_lock());
-  ASSERT_FALSE(ictx->image_watcher->is_lock_owner());
-
-  ASSERT_EQ(0, unlock_image());
-  ASSERT_EQ(0, ictx->image_watcher->try_lock());
-  ASSERT_TRUE(ictx->image_watcher->is_lock_owner());
-}
-
-TEST_F(TestImageWatcher, TryLockWithUserSharedLocked) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_SHARED, "manually locked"));
-
-  RWLock::WLocker l(ictx->owner_lock);
-  ASSERT_EQ(-EBUSY, ictx->image_watcher->try_lock());
-  ASSERT_FALSE(ictx->image_watcher->is_lock_owner());
-
-  ASSERT_EQ(0, unlock_image());
-  ASSERT_EQ(0, ictx->image_watcher->try_lock());
-  ASSERT_TRUE(ictx->image_watcher->is_lock_owner());
-}
-
-TEST_F(TestImageWatcher, ReleaseLockNotLocked) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-
-  RWLock::WLocker l(ictx->owner_lock);
-  ASSERT_EQ(0, ictx->image_watcher->release_lock());
-}
-
-TEST_F(TestImageWatcher, ReleaseLockNotifies) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-
-  ASSERT_EQ(0, register_image_watch(*ictx));
-  m_notify_acks = {{NOTIFY_OP_ACQUIRED_LOCK, {}}};
-
-  {
-    RWLock::WLocker l(ictx->owner_lock);
-    ASSERT_EQ(0, ictx->image_watcher->try_lock());
-  }
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-
-  m_notify_acks += std::make_pair(NOTIFY_OP_RELEASED_LOCK, bufferlist());
-  {
-    RWLock::WLocker l(ictx->owner_lock);
-    ASSERT_EQ(0, ictx->image_watcher->release_lock());
-  }
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-
-  NotifyOps expected_notify_ops;
-  expected_notify_ops += NOTIFY_OP_ACQUIRED_LOCK, NOTIFY_OP_RELEASED_LOCK;
-  ASSERT_EQ(expected_notify_ops, m_notifies);
-}
-
-TEST_F(TestImageWatcher, ReleaseLockBrokenLock) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-
-  RWLock::WLocker l(ictx->owner_lock);
-  ASSERT_EQ(0, ictx->image_watcher->try_lock());
-
-  std::map<rados::cls::lock::locker_id_t,
-           rados::cls::lock::locker_info_t> lockers;
-  ClsLockType lock_type;
-  ASSERT_EQ(0, rados::cls::lock::get_lock_info(&m_ioctx, ictx->header_oid,
-                                               RBD_LOCK_NAME, &lockers,
-                                               &lock_type, NULL));
-  ASSERT_EQ(1U, lockers.size());
-  ASSERT_EQ(0, rados::cls::lock::break_lock(&m_ioctx, ictx->header_oid,
-					    RBD_LOCK_NAME,
-					    lockers.begin()->first.cookie,
-					    lockers.begin()->first.locker));
-
-  ASSERT_EQ(0, ictx->image_watcher->release_lock());
-}
-
-TEST_F(TestImageWatcher, RequestLock) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, register_image_watch(*ictx));
-
-  register_lock_listener(*ictx);
-  m_notify_acks = {{NOTIFY_OP_ACQUIRED_LOCK, {}}};
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ictx->image_watcher->request_lock();
-  }
-
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-  NotifyOps expected_notify_ops;
-  expected_notify_ops += NOTIFY_OP_ACQUIRED_LOCK;
-  ASSERT_EQ(expected_notify_ops, m_notifies);
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ASSERT_TRUE(ictx->image_watcher->is_lock_owner());
-  }
-}
-
-TEST_F(TestImageWatcher, RequestLockFromPeer) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
-			  "auto " + stringify(m_watch_ctx->get_handle())));
-
-  register_lock_listener(*ictx);
-  m_notify_acks = {{NOTIFY_OP_REQUEST_LOCK, create_response_message(0)}};
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ictx->image_watcher->request_lock();
-  }
-
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-  NotifyOps expected_notify_ops;
-  expected_notify_ops += NOTIFY_OP_REQUEST_LOCK;
-  ASSERT_EQ(expected_notify_ops, m_notifies);
-
-  ASSERT_EQ(0, unlock_image());
-
-  {
-    Mutex::Locker l(m_callback_lock);
-    m_notifies.clear();
-    m_notify_acks = {{NOTIFY_OP_RELEASED_LOCK,{}}};
-  }
-
-  bufferlist bl;
-  {
-    ENCODE_START(1, 1, bl);
-    ::encode(NOTIFY_OP_RELEASED_LOCK, bl);
-    ENCODE_FINISH(bl);
-  }
-  ASSERT_EQ(0, m_ioctx.notify2(ictx->header_oid, bl, 5000, NULL));
-  ASSERT_TRUE(wait_for_lock_updated(*ictx));
-
-  {
-    Mutex::Locker l(m_callback_lock);
-    m_notifies.clear();
-    m_notify_acks = {{NOTIFY_OP_ACQUIRED_LOCK, {}}};
-  }
-
-  {
-    RWLock::RLocker owner_lock(ictx->owner_lock);
-    ictx->image_watcher->request_lock();
-  }
-
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-  expected_notify_ops.clear();
-  expected_notify_ops += NOTIFY_OP_ACQUIRED_LOCK;
-  ASSERT_EQ(expected_notify_ops, m_notifies);
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ASSERT_TRUE(ictx->image_watcher->is_lock_owner());
-  }
-}
-
-TEST_F(TestImageWatcher, RequestLockTimedOut) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
-			  "auto " + stringify(m_watch_ctx->get_handle())));
-
-  register_lock_listener(*ictx);
   m_notify_acks = {{NOTIFY_OP_REQUEST_LOCK, {}}};
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ictx->image_watcher->request_lock();
-  }
+  ictx->image_watcher->notify_request_lock();
 
   ASSERT_TRUE(wait_for_notifies(*ictx));
+
   NotifyOps expected_notify_ops;
   expected_notify_ops += NOTIFY_OP_REQUEST_LOCK;
   ASSERT_EQ(expected_notify_ops, m_notifies);
-
-  // should resend when empty ack returned
-  {
-    Mutex::Locker l(m_callback_lock);
-    m_notifies.clear();
-  }
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-
-  {
-    Mutex::Locker l(m_callback_lock);
-    ASSERT_EQ(0, unlock_image());
-    m_notifies.clear();
-    m_notify_acks = {{NOTIFY_OP_ACQUIRED_LOCK, {}}};
-  }
-
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-  ASSERT_TRUE(wait_for_lock_updated(*ictx));
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ASSERT_TRUE(ictx->image_watcher->is_lock_owner());
-  }
 }
 
-TEST_F(TestImageWatcher, RequestLockIgnored) {
+TEST_F(TestImageWatcher, NotifyReleasedLock) {
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
-			  "auto " + stringify(m_watch_ctx->get_handle())));
 
-  register_lock_listener(*ictx);
-  m_notify_acks = {{NOTIFY_OP_REQUEST_LOCK, create_response_message(0)}};
-
-  int orig_notify_timeout = ictx->cct->_conf->client_notify_timeout;
-  ictx->cct->_conf->set_val("client_notify_timeout", "0");
-  BOOST_SCOPE_EXIT( (ictx)(orig_notify_timeout) ) {
-    ictx->cct->_conf->set_val("client_notify_timeout",
-                              stringify(orig_notify_timeout));
-  } BOOST_SCOPE_EXIT_END;
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ictx->image_watcher->request_lock();
-  }
+  m_notify_acks = {{NOTIFY_OP_RELEASED_LOCK, {}}};
+  ictx->image_watcher->notify_released_lock();
 
   ASSERT_TRUE(wait_for_notifies(*ictx));
+
   NotifyOps expected_notify_ops;
-  expected_notify_ops += NOTIFY_OP_REQUEST_LOCK;
+  expected_notify_ops += NOTIFY_OP_RELEASED_LOCK;
   ASSERT_EQ(expected_notify_ops, m_notifies);
-
-  // after the request times out -- it will be resent
-  {
-    Mutex::Locker l(m_callback_lock);
-    m_notifies.clear();
-  }
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-  ASSERT_EQ(expected_notify_ops, m_notifies);
-
-  {
-    Mutex::Locker l(m_callback_lock);
-    ASSERT_EQ(0, unlock_image());
-    m_notifies.clear();
-    m_notify_acks = {{NOTIFY_OP_ACQUIRED_LOCK, {}}};
-  }
-
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-  ASSERT_TRUE(wait_for_lock_updated(*ictx));
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ASSERT_TRUE(ictx->image_watcher->is_lock_owner());
-  }
 }
 
-TEST_F(TestImageWatcher, RequestLockTryLockRace) {
+TEST_F(TestImageWatcher, NotifyAcquiredLock) {
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
-                          "auto " + stringify(m_watch_ctx->get_handle())));
 
-  register_lock_listener(*ictx);
-  m_notify_acks = {{NOTIFY_OP_REQUEST_LOCK, create_response_message(0)}};
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ictx->image_watcher->request_lock();
-  }
+  m_notify_acks = {{NOTIFY_OP_ACQUIRED_LOCK, {}}};
+  ictx->image_watcher->notify_acquired_lock();
 
   ASSERT_TRUE(wait_for_notifies(*ictx));
+
   NotifyOps expected_notify_ops;
-  expected_notify_ops += NOTIFY_OP_REQUEST_LOCK;
+  expected_notify_ops += NOTIFY_OP_ACQUIRED_LOCK;
   ASSERT_EQ(expected_notify_ops, m_notifies);
-
-  {
-    Mutex::Locker l(m_callback_lock);
-    m_notifies.clear();
-    m_notify_acks = {{NOTIFY_OP_RELEASED_LOCK, {}}};
-  }
-
-  bufferlist bl;
-  {
-    ENCODE_START(1, 1, bl);
-    ::encode(NOTIFY_OP_RELEASED_LOCK, bl);
-    ENCODE_FINISH(bl);
-  }
-  ASSERT_EQ(0, m_ioctx.notify2(ictx->header_oid, bl, 5000, NULL));
-
-  // after losing race -- it will re-request
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ASSERT_FALSE(ictx->image_watcher->is_lock_owner());
-  }
-
-  {
-    Mutex::Locker l(m_callback_lock);
-    ASSERT_EQ(0, unlock_image());
-    m_notifies.clear();
-    m_notify_acks = {{NOTIFY_OP_RELEASED_LOCK, {}}};
-  }
-
-  ASSERT_EQ(0, m_ioctx.notify2(ictx->header_oid, bl, 5000, NULL));
-  ASSERT_TRUE(wait_for_lock_updated(*ictx));
-
-  {
-    Mutex::Locker l(m_callback_lock);
-    m_notifies.clear();
-    m_notify_acks = {{NOTIFY_OP_ACQUIRED_LOCK, {}}};
-  }
-
-  {
-    RWLock::RLocker owner_lock(ictx->owner_lock);
-    ictx->image_watcher->request_lock();
-  }
-
-  ASSERT_TRUE(wait_for_lock_updated(*ictx));
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ASSERT_TRUE(ictx->image_watcher->is_lock_owner());
-  }
-}
-
-TEST_F(TestImageWatcher, RequestLockTryLockFailed) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_SHARED, "manually 1234"));
-
-  register_lock_listener(*ictx);
-  m_notify_acks = {{NOTIFY_OP_REQUEST_LOCK, {}}};
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ictx->image_watcher->request_lock();
-  }
-
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-  NotifyOps expected_notify_ops;
-  expected_notify_ops += NOTIFY_OP_REQUEST_LOCK;
-  ASSERT_EQ(expected_notify_ops, m_notifies);
-
-  // should resend when error encountered
-  {
-    Mutex::Locker l(m_callback_lock);
-    m_notifies.clear();
-  }
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-
-  {
-    Mutex::Locker l(m_callback_lock);
-    ASSERT_EQ(0, unlock_image());
-    m_notifies.clear();
-    m_notify_acks = {{NOTIFY_OP_ACQUIRED_LOCK, {}}};
-  }
-
-  ASSERT_TRUE(wait_for_notifies(*ictx));
 }
 
 TEST_F(TestImageWatcher, NotifyHeaderUpdate) {
@@ -1216,47 +719,3 @@ TEST_F(TestImageWatcher, NotifyAsyncRequestTimedOut) {
   ASSERT_EQ(-ERESTART, flatten_task.result);
 }
 
-TEST_F(TestImageWatcher, PeerRequestsLock) {
-  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
-
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, register_image_watch(*ictx));
-
-  register_lock_listener(*ictx);
-  m_notify_acks = {{NOTIFY_OP_ACQUIRED_LOCK, {}}};
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ictx->image_watcher->request_lock();
-  }
-
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-
-  {
-    RWLock::RLocker owner_locker(ictx->owner_lock);
-    ASSERT_TRUE(ictx->image_watcher->is_lock_owner());
-  }
-
-  // if journaling is enabled, ensure we wait for it to replay since
-  // it will block our peer request
-  std::string buffer(256, '1');
-  ictx->aio_work_queue->write(0, buffer.size(), buffer.c_str(), 0);
-
-  {
-    Mutex::Locker l(m_callback_lock);
-    m_notifies.clear();
-    m_notify_acks = {{NOTIFY_OP_RELEASED_LOCK, {}}};
-  }
-
-  bufferlist bl;
-  {
-    ENCODE_START(1, 1, bl);
-    ::encode(NOTIFY_OP_REQUEST_LOCK, bl);
-    ENCODE_FINISH(bl);
-  }
-  ASSERT_EQ(0, m_ioctx.notify2(ictx->header_oid, bl, 5000, NULL));
-
-  ASSERT_TRUE(wait_for_releasing_lock(*ictx));
-  ASSERT_TRUE(wait_for_notifies(*ictx));
-}

--- a/src/test/librbd/test_JournalEntries.cc
+++ b/src/test/librbd/test_JournalEntries.cc
@@ -125,8 +125,7 @@ TEST_F(TestJournalEntries, AioWrite) {
 
   std::string buffer(512, '1');
   C_SaferCond cond_ctx;
-  librbd::AioCompletion *c =
-    librbd::aio_create_completion_internal(&cond_ctx, librbd::rbd_ctx_cb);
+  librbd::AioCompletion *c = librbd::AioCompletion::create(&cond_ctx);
   c->get();
   ictx->aio_work_queue->aio_write(c, 123, buffer.size(), buffer.c_str(), 0);
   ASSERT_EQ(0, c->wait_for_complete());
@@ -163,8 +162,7 @@ TEST_F(TestJournalEntries, AioDiscard) {
   ASSERT_TRUE(journaler != NULL);
 
   C_SaferCond cond_ctx;
-  librbd::AioCompletion *c =
-    librbd::aio_create_completion_internal(&cond_ctx, librbd::rbd_ctx_cb);
+  librbd::AioCompletion *c = librbd::AioCompletion::create(&cond_ctx);
   c->get();
   ictx->aio_work_queue->aio_discard(c, 123, 234);
   ASSERT_EQ(0, c->wait_for_complete());
@@ -197,8 +195,7 @@ TEST_F(TestJournalEntries, AioFlush) {
   ASSERT_TRUE(journaler != NULL);
 
   C_SaferCond cond_ctx;
-  librbd::AioCompletion *c =
-    librbd::aio_create_completion_internal(&cond_ctx, librbd::rbd_ctx_cb);
+  librbd::AioCompletion *c = librbd::AioCompletion::create(&cond_ctx);
   c->get();
   ictx->aio_work_queue->aio_flush(c);
   ASSERT_EQ(0, c->wait_for_complete());

--- a/src/test/librbd/test_fixture.cc
+++ b/src/test/librbd/test_fixture.cc
@@ -4,6 +4,8 @@
 #include "test/librbd/test_support.h"
 #include "include/stringify.h"
 #include "librbd/AioImageRequestWQ.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageState.h"
 #include "librbd/ImageWatcher.h"
 #include "cls/lock/cls_lock_client.h"
 #include "cls/lock/cls_lock_types.h"
@@ -46,7 +48,7 @@ void TestFixture::TearDown() {
   unlock_image();
   for (std::set<librbd::ImageCtx *>::iterator iter = m_ictxs.begin();
        iter != m_ictxs.end(); ++iter) {
-    librbd::close_image(*iter);
+    (*iter)->state->close();
   }
 
   m_ioctx.close();
@@ -56,12 +58,14 @@ int TestFixture::open_image(const std::string &image_name,
 			    librbd::ImageCtx **ictx) {
   *ictx = new librbd::ImageCtx(image_name.c_str(), "", NULL, m_ioctx, false);
   m_ictxs.insert(*ictx);
-  return librbd::open_image(*ictx);
+
+  return (*ictx)->state->open();
 }
 
 void TestFixture::close_image(librbd::ImageCtx *ictx) {
   m_ictxs.erase(ictx);
-  librbd::close_image(ictx);
+
+  ictx->state->close();
 }
 
 int TestFixture::lock_image(librbd::ImageCtx &ictx, ClsLockType lock_type,
@@ -93,5 +97,6 @@ int TestFixture::acquire_exclusive_lock(librbd::ImageCtx &ictx) {
   }
 
   RWLock::RLocker owner_locker(ictx.owner_lock);
-  return ictx.image_watcher->is_lock_owner() ? 0 : -EINVAL;
+  assert(ictx.exclusive_lock != nullptr);
+  return ictx.exclusive_lock->is_lock_owner() ? 0 : -EINVAL;
 }

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -252,9 +252,8 @@ TEST_F(TestInternal, AioWriteRequestsLock) {
   ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE, "manually locked"));
 
   std::string buffer(256, '1');
-  DummyContext *ctx = new DummyContext();
-  librbd::AioCompletion *c =
-    librbd::aio_create_completion_internal(ctx, librbd::rbd_ctx_cb);
+  Context *ctx = new DummyContext();
+  librbd::AioCompletion *c = librbd::AioCompletion::create(ctx);
   c->get();
   ictx->aio_work_queue->aio_write(c, 0, buffer.size(), buffer.c_str(), 0);
 
@@ -275,9 +274,8 @@ TEST_F(TestInternal, AioDiscardRequestsLock) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE, "manually locked"));
 
-  DummyContext *ctx = new DummyContext();
-  librbd::AioCompletion *c =
-    librbd::aio_create_completion_internal(ctx, librbd::rbd_ctx_cb);
+  Context *ctx = new DummyContext();
+  librbd::AioCompletion *c = librbd::AioCompletion::create(ctx);
   c->get();
   ictx->aio_work_queue->aio_discard(c, 0, 256);
 
@@ -661,8 +659,7 @@ TEST_F(TestInternal, ShrinkFlushesCache) {
   ictx->aio_work_queue->write(0, buffer.size(), buffer.c_str(), 0);
 
   C_SaferCond cond_ctx;
-  librbd::AioCompletion *c =
-    librbd::aio_create_completion_internal(&cond_ctx, librbd::rbd_ctx_cb);
+  librbd::AioCompletion *c = librbd::AioCompletion::create(&cond_ctx);
   c->get();
   ictx->aio_work_queue->aio_write(c, 0, buffer.size(), buffer.c_str(), 0);
 

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -3429,7 +3429,7 @@ TEST_F(TestLibRBD, RebuildObjectMap)
 
 TEST_F(TestLibRBD, RebuildNewObjectMap)
 {
-  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+  REQUIRE_FEATURE(RBD_FEATURE_OBJECT_MAP);
 
   rados_ioctx_t ioctx;
   rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2826,15 +2826,15 @@ TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
   librbd::Image image1;
   ASSERT_EQ(0, rbd.open(ioctx, image1, name.c_str(), NULL));
 
-  uint64_t flags;
-  ASSERT_EQ(0, image1.get_flags(&flags));
-  ASSERT_TRUE((flags & RBD_FLAG_OBJECT_MAP_INVALID) != 0);
-
   bool lock_owner;
   bl.clear();
   ASSERT_EQ(0, image1.write(0, 0, bl));
   ASSERT_EQ(0, image1.is_exclusive_lock_owner(&lock_owner));
   ASSERT_TRUE(lock_owner);
+
+  uint64_t flags;
+  ASSERT_EQ(0, image1.get_flags(&flags));
+  ASSERT_TRUE((flags & RBD_FLAG_OBJECT_MAP_INVALID) != 0);
 
   librbd::Image image2;
   ASSERT_EQ(0, rbd.open(ioctx, image2, name.c_str(), NULL));
@@ -3405,6 +3405,12 @@ TEST_F(TestLibRBD, RebuildObjectMap)
 
   librbd::Image image1;
   ASSERT_EQ(0, rbd.open(ioctx, image1, name.c_str(), NULL));
+
+  bool lock_owner;
+  bl.clear();
+  ASSERT_EQ(0, image1.write(0, 0, bl));
+  ASSERT_EQ(0, image1.is_exclusive_lock_owner(&lock_owner));
+  ASSERT_TRUE(lock_owner);
 
   uint64_t flags;
   ASSERT_EQ(0, image1.get_flags(&flags));

--- a/src/test/librbd/test_mock_ExclusiveLock.cc
+++ b/src/test/librbd/test_mock_ExclusiveLock.cc
@@ -1,0 +1,522 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/exclusive_lock/AcquireRequest.h"
+#include "librbd/exclusive_lock/ReleaseRequest.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <list>
+
+namespace librbd {
+namespace exclusive_lock {
+
+template<typename T>
+struct BaseRequest {
+  static std::list<T *> s_requests;
+  Context *on_finish;
+
+  static T* create(MockImageCtx &image_ctx, const std::string &cookie,
+                   Context *on_finish) {
+    assert(!s_requests.empty());
+    T* req = s_requests.front();
+    req->on_finish = on_finish;
+    s_requests.pop_front();
+    return req;
+  }
+
+  BaseRequest() {
+    s_requests.push_back(reinterpret_cast<T*>(this));
+  }
+};
+
+template<typename T>
+std::list<T *> BaseRequest<T>::s_requests;
+
+template <>
+struct AcquireRequest<MockImageCtx> : public BaseRequest<AcquireRequest<MockImageCtx> > {
+  MOCK_METHOD0(send, void());
+};
+
+template <>
+struct ReleaseRequest<MockImageCtx> : public BaseRequest<ReleaseRequest<MockImageCtx> > {
+  MOCK_METHOD0(send, void());
+};
+
+} // namespace exclusive_lock
+} // namespace librbd
+
+// template definitions
+#include "librbd/ExclusiveLock.cc"
+template class librbd::ExclusiveLock<librbd::MockImageCtx>;
+
+namespace librbd {
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::InSequence;
+
+class TestMockExclusiveLock : public TestMockFixture {
+public:
+  typedef ExclusiveLock<MockImageCtx> MockExclusiveLock;
+  typedef exclusive_lock::AcquireRequest<MockImageCtx> MockAcquireRequest;
+  typedef exclusive_lock::ReleaseRequest<MockImageCtx> MockReleaseRequest;
+
+  void expect_block_writes(MockImageCtx &mock_image_ctx) {
+    EXPECT_CALL(*mock_image_ctx.aio_work_queue, block_writes(_))
+                  .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
+  }
+
+  void expect_unblock_writes(MockImageCtx &mock_image_ctx) {
+    EXPECT_CALL(*mock_image_ctx.aio_work_queue, unblock_writes());
+  }
+
+  void expect_acquire_lock(MockImageCtx &mock_image_ctx,
+                           MockAcquireRequest &acquire_request, int r) {
+    EXPECT_CALL(acquire_request, send())
+                  .WillOnce(FinishRequest(&acquire_request, r, &mock_image_ctx));
+    if (r == 0) {
+      expect_unblock_writes(mock_image_ctx);
+    }
+  }
+
+  void expect_release_lock(MockImageCtx &mock_image_ctx,
+                           MockReleaseRequest &release_request, int r,
+                           bool shutting_down = false) {
+    if (!shutting_down) {
+      expect_block_writes(mock_image_ctx);
+    }
+    EXPECT_CALL(release_request, send())
+                  .WillOnce(FinishRequest(&release_request, r, &mock_image_ctx));
+    if (!shutting_down && r < 0) {
+      expect_unblock_writes(mock_image_ctx);
+    }
+  }
+
+  void expect_notify_request_lock(MockImageCtx &mock_image_ctx,
+                                  MockExclusiveLock &mock_exclusive_lock) {
+    EXPECT_CALL(*mock_image_ctx.image_watcher, notify_request_lock())
+                  .WillRepeatedly(Invoke(&mock_exclusive_lock,
+                                         &MockExclusiveLock::handle_lock_released));
+  }
+
+  int when_init(MockImageCtx &mock_image_ctx,
+                MockExclusiveLock &exclusive_lock) {
+    C_SaferCond ctx;
+    {
+      RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
+      exclusive_lock.init(&ctx);
+    }
+    exclusive_lock.set_watch_handle(123);
+    return ctx.wait();
+  }
+
+  int when_try_lock(MockImageCtx &mock_image_ctx,
+                     MockExclusiveLock &exclusive_lock) {
+    C_SaferCond ctx;
+    {
+      RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
+      exclusive_lock.try_lock(&ctx);
+    }
+    return ctx.wait();
+  }
+  int when_request_lock(MockImageCtx &mock_image_ctx,
+                     MockExclusiveLock &exclusive_lock) {
+    C_SaferCond ctx;
+    {
+      RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
+      exclusive_lock.request_lock(&ctx);
+    }
+    return ctx.wait();
+  }
+  int when_release_lock(MockImageCtx &mock_image_ctx,
+                     MockExclusiveLock &exclusive_lock) {
+    C_SaferCond ctx;
+    {
+      RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
+      exclusive_lock.release_lock(&ctx);
+    }
+    return ctx.wait();
+  }
+  int when_shut_down(MockImageCtx &mock_image_ctx,
+                     MockExclusiveLock &exclusive_lock) {
+    C_SaferCond ctx;
+    {
+      RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
+      exclusive_lock.shut_down(&ctx);
+    }
+    return ctx.wait();
+  }
+
+  bool is_lock_owner(MockImageCtx &mock_image_ctx,
+                     MockExclusiveLock &exclusive_lock) {
+    RWLock::RLocker owner_locker(mock_image_ctx.owner_lock);
+    return exclusive_lock.is_lock_owner();
+  }
+};
+
+TEST_F(TestMockExclusiveLock, StateTransitions) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  MockAcquireRequest try_lock_acquire;
+  expect_acquire_lock(mock_image_ctx, try_lock_acquire, 0);
+  ASSERT_EQ(0, when_try_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_TRUE(is_lock_owner(mock_image_ctx, exclusive_lock));
+
+  MockReleaseRequest request_release;
+  expect_release_lock(mock_image_ctx, request_release, 0);
+  ASSERT_EQ(0, when_release_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
+
+  MockAcquireRequest request_lock_acquire;
+  expect_acquire_lock(mock_image_ctx, request_lock_acquire, 0);
+  ASSERT_EQ(0, when_request_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_TRUE(is_lock_owner(mock_image_ctx, exclusive_lock));
+
+  MockReleaseRequest shutdown_release;
+  expect_release_lock(mock_image_ctx, shutdown_release, 0, true);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+  ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, TryLockLockedState) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  MockAcquireRequest try_lock_acquire;
+  expect_acquire_lock(mock_image_ctx, try_lock_acquire, 0);
+  ASSERT_EQ(0, when_try_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_EQ(0, when_try_lock(mock_image_ctx, exclusive_lock));
+
+  MockReleaseRequest shutdown_release;
+  expect_release_lock(mock_image_ctx, shutdown_release, 0, true);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, TryLockAlreadyLocked) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  MockAcquireRequest try_lock_acquire;
+  expect_acquire_lock(mock_image_ctx, try_lock_acquire, -EAGAIN);
+  ASSERT_EQ(0, when_try_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
+
+  expect_unblock_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, TryLockBusy) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  MockAcquireRequest try_lock_acquire;
+  expect_acquire_lock(mock_image_ctx, try_lock_acquire, -EBUSY);
+  ASSERT_EQ(-EBUSY, when_try_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
+
+  expect_unblock_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, TryLockError) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+
+  MockAcquireRequest try_lock_acquire;
+  expect_acquire_lock(mock_image_ctx, try_lock_acquire, -EINVAL);
+
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+  ASSERT_EQ(-EINVAL, when_try_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
+
+  expect_unblock_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, RequestLockLockedState) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  MockAcquireRequest try_lock_acquire;
+  expect_acquire_lock(mock_image_ctx, try_lock_acquire, 0);
+  ASSERT_EQ(0, when_try_lock(mock_image_ctx, exclusive_lock));
+
+  MockReleaseRequest shutdown_release;
+  expect_release_lock(mock_image_ctx, shutdown_release, 0, true);
+  ASSERT_EQ(0, when_request_lock(mock_image_ctx, exclusive_lock));
+
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, RequestLockBlacklist) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  // will abort after seeing blacklist error (avoid infinite request loop)
+  MockAcquireRequest request_lock_acquire;
+  expect_acquire_lock(mock_image_ctx, request_lock_acquire, -EBLACKLISTED);
+  expect_notify_request_lock(mock_image_ctx, exclusive_lock);
+  ASSERT_EQ(-EBLACKLISTED, when_request_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
+
+  expect_unblock_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, RequestLockBusy) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  // will repeat until successfully acquires the lock
+  MockAcquireRequest request_lock_acquire1;
+  expect_acquire_lock(mock_image_ctx, request_lock_acquire1, -EBUSY);
+  expect_notify_request_lock(mock_image_ctx, exclusive_lock);
+
+  MockAcquireRequest request_lock_acquire2;
+  expect_acquire_lock(mock_image_ctx, request_lock_acquire2, 0);
+  ASSERT_EQ(0, when_request_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_TRUE(is_lock_owner(mock_image_ctx, exclusive_lock));
+
+  MockReleaseRequest shutdown_release;
+  expect_release_lock(mock_image_ctx, shutdown_release, 0, true);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, RequestLockError) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  // will repeat until successfully acquires the lock
+  MockAcquireRequest request_lock_acquire1;
+  expect_acquire_lock(mock_image_ctx, request_lock_acquire1, -EINVAL);
+  expect_notify_request_lock(mock_image_ctx, exclusive_lock);
+
+  MockAcquireRequest request_lock_acquire2;
+  expect_acquire_lock(mock_image_ctx, request_lock_acquire2, 0);
+  ASSERT_EQ(0, when_request_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_TRUE(is_lock_owner(mock_image_ctx, exclusive_lock));
+
+  MockReleaseRequest shutdown_release;
+  expect_release_lock(mock_image_ctx, shutdown_release, 0, true);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, ReleaseLockUnlockedState) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  ASSERT_EQ(0, when_release_lock(mock_image_ctx, exclusive_lock));
+
+  expect_unblock_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, ReleaseLockError) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  MockAcquireRequest try_lock_acquire;
+  expect_acquire_lock(mock_image_ctx, try_lock_acquire, 0);
+  ASSERT_EQ(0, when_try_lock(mock_image_ctx, exclusive_lock));
+
+  MockReleaseRequest release;
+  expect_release_lock(mock_image_ctx, release, -EINVAL);
+
+  ASSERT_EQ(-EINVAL, when_release_lock(mock_image_ctx, exclusive_lock));
+  ASSERT_TRUE(is_lock_owner(mock_image_ctx, exclusive_lock));
+
+  MockReleaseRequest shutdown_release;
+  expect_release_lock(mock_image_ctx, shutdown_release, 0, true);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+  ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
+}
+
+TEST_F(TestMockExclusiveLock, ConcurrentRequests) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_block_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_init(mock_image_ctx, exclusive_lock));
+
+  MockAcquireRequest try_lock_acquire;
+  C_SaferCond wait_for_send_ctx1;
+  EXPECT_CALL(try_lock_acquire, send())
+                .WillOnce(Notify(&wait_for_send_ctx1));
+
+  MockAcquireRequest request_acquire;
+  expect_acquire_lock(mock_image_ctx, request_acquire, 0);
+
+  MockReleaseRequest release;
+  C_SaferCond wait_for_send_ctx2;
+  expect_block_writes(mock_image_ctx);
+  EXPECT_CALL(release, send())
+                .WillOnce(Notify(&wait_for_send_ctx2));
+
+  C_SaferCond try_request_ctx1;
+  {
+    RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
+    exclusive_lock.try_lock(&try_request_ctx1);
+  }
+
+  C_SaferCond request_lock_ctx1;
+  C_SaferCond request_lock_ctx2;
+  {
+    RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
+    exclusive_lock.request_lock(&request_lock_ctx1);
+    exclusive_lock.request_lock(&request_lock_ctx2);
+  }
+
+  C_SaferCond release_lock_ctx1;
+  {
+    RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
+    exclusive_lock.release_lock(&release_lock_ctx1);
+  }
+
+  C_SaferCond request_lock_ctx3;
+  {
+    RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
+    exclusive_lock.request_lock(&request_lock_ctx3);
+  }
+
+  // fail the try_lock
+  ASSERT_EQ(0, wait_for_send_ctx1.wait());
+  try_lock_acquire.on_finish->complete(-EINVAL);
+  ASSERT_EQ(-EINVAL, try_request_ctx1.wait());
+
+  // all three pending request locks should complete
+  ASSERT_EQ(0, request_lock_ctx1.wait());
+  ASSERT_EQ(0, request_lock_ctx2.wait());
+  ASSERT_EQ(0, request_lock_ctx3.wait());
+
+  // proceed with the release
+  ASSERT_EQ(0, wait_for_send_ctx2.wait());
+  release.on_finish->complete(0);
+  ASSERT_EQ(0, release_lock_ctx1.wait());
+
+  expect_unblock_writes(mock_image_ctx);
+  ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
+}
+
+} // namespace librbd
+

--- a/src/test/librbd/test_mock_fixture.h
+++ b/src/test/librbd/test_mock_fixture.h
@@ -46,6 +46,10 @@ ACTION_P(GetReference, ref_object) {
   ref_object->get();
 }
 
+ACTION_P(Notify, ctx) {
+  ctx->complete(0);
+}
+
 MATCHER_P(ContentsEqual, bl, "") {
   // TODO fix const-correctness of bufferlist
   return const_cast<bufferlist &>(arg).contents_equal(
@@ -62,6 +66,9 @@ public:
   virtual void SetUp();
   virtual void TearDown();
 
+  ::testing::NiceMock<librados::MockTestMemRadosClient> &get_mock_rados_client() {
+    return *s_mock_rados_client;
+  }
   librados::MockTestMemIoCtxImpl &get_mock_io_ctx(librados::IoCtx &ioctx);
 
   void expect_op_work_queue(librbd::MockImageCtx &mock_image_ctx);

--- a/src/test/librbd/test_mock_fixture.h
+++ b/src/test/librbd/test_mock_fixture.h
@@ -5,6 +5,7 @@
 #define CEPH_TEST_LIBRBD_TEST_MOCK_FIXTURE_H
 
 #include "test/librbd/test_fixture.h"
+#include "test/librbd/mock/MockImageCtx.h"
 #include "common/WorkQueue.h"
 #include <boost/shared_ptr.hpp>
 #include <gmock/gmock.h>
@@ -18,6 +19,10 @@ namespace librbd {
 class MockImageCtx;
 }
 
+ACTION_P(CopyInBufferlist, str) {
+  arg0->append(str);
+}
+
 ACTION_P2(CompleteContext, r, wq) {
   ContextWQ *context_wq = reinterpret_cast<ContextWQ *>(wq);
   if (context_wq != NULL) {
@@ -29,6 +34,12 @@ ACTION_P2(CompleteContext, r, wq) {
 
 ACTION_P(DispatchContext, wq) {
   wq->queue(arg0, arg1);
+}
+
+ACTION_P3(FinishRequest, request, r, mock) {
+  librbd::MockImageCtx *mock_image_ctx =
+    reinterpret_cast<librbd::MockImageCtx *>(mock);
+  mock_image_ctx->image_ctx->op_work_queue->queue(request->on_finish, r);
 }
 
 ACTION_P(GetReference, ref_object) {


### PR DESCRIPTION
The goal is to eliminate all possible deadlock potential between mixing synchronous and asynchronous workloads. 