### PR TITLE
tests: --osd-scrub-load-threshold=2000 for more consistency

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -491,6 +491,7 @@ function activate_osd() {
     ceph_args+=" --osd-backfill-full-ratio=.99"
     ceph_args+=" --osd-failsafe-full-ratio=.99"
     ceph_args+=" --osd-journal-size=100"
+    ceph_args+=" --osd-scrub-load-threshold=2000"
     ceph_args+=" --osd-data=$osd_data"
     ceph_args+=" --chdir="
     ceph_args+=" --erasure-code-dir=.libs"

--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -1037,7 +1037,9 @@ function test_repair() {
 
     setup $dir || return 1
     run_mon $dir a --osd_pool_default_size=1 || return 1
-    run_osd $dir 0 || return 1
+    run_osd $dir 0 \
+            --osd-scrub-min-interval=1 \
+            --osd-scrub-interval-randomize-ratio=0 || return 1
     wait_for_clean || return 1
     repair 1.0 || return 1
     kill_daemons $dir KILL osd || return 1
@@ -1068,7 +1070,9 @@ function test_pg_scrub() {
 
     setup $dir || return 1
     run_mon $dir a --osd_pool_default_size=1 || return 1
-    run_osd $dir 0 || return 1
+    run_osd $dir 0 \
+            --osd-scrub-min-interval=1 \
+            --osd-scrub-interval-randomize-ratio=0 || return 1
     wait_for_clean || return 1
     pg_scrub 1.0 || return 1
     kill_daemons $dir KILL osd || return 1
@@ -1157,7 +1161,9 @@ function test_wait_for_scrub() {
 
     setup $dir || return 1
     run_mon $dir a --osd_pool_default_size=1 || return 1
-    run_osd $dir 0 || return 1
+    run_osd $dir 0 \
+            --osd-scrub-min-interval=1 \
+            --osd-scrub-interval-randomize-ratio=0 || return 1
     wait_for_clean || return 1
     local pgid=1.0
     ceph pg repair $pgid

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6183,7 +6183,7 @@ void OSD::sched_scrub()
 
       if (scrub.sched_time > now) {
 	// save ourselves some effort
-	dout(10) << "sched_scrub " << scrub.pgid << " schedued at " << scrub.sched_time
+	dout(10) << "sched_scrub " << scrub.pgid << " scheduled at " << scrub.sched_time
 		 << " > " << now << dendl;
 	break;
       }

--- a/src/test/osd/osd-scrub-repair.sh
+++ b/src/test/osd/osd-scrub-repair.sh
@@ -24,6 +24,8 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--osd-scrub-min-interval=1 "
+    CEPH_ARGS+="--osd-scrub-interval-randomize-ratio=0 "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do

--- a/src/test/osd/osd-scrub-snaps.sh
+++ b/src/test/osd/osd-scrub-snaps.sh
@@ -154,7 +154,11 @@ function TEST_scrub_snaps() {
 
     local pgid="${poolid}.0"
     if ! pg_scrub "$pgid" ; then
+        echo ====================================
         cat $dir/osd.0.log
+        echo ====================================
+        cat $dir/mon.a.log
+        echo ====================================
         return 1
     fi
     grep 'log_channel' $dir/osd.0.log

--- a/src/test/osd/osd-scrub-snaps.sh
+++ b/src/test/osd/osd-scrub-snaps.sh
@@ -39,7 +39,9 @@ function TEST_scrub_snaps() {
 
     setup $dir || return 1
     run_mon $dir a --osd_pool_default_size=1 || return 1
-    run_osd $dir 0 || return 1
+    run_osd $dir 0 \
+            --osd-scrub-min-interval=1 \
+            --osd-scrub-interval-randomize-ratio=0 || return 1
 
     wait_for_clean || return 1
 

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -460,7 +460,7 @@ $DAEMONOPTS
         osd journal size = 100
         osd class tmp = out
         osd class dir = $OBJCLASS_PATH
-        osd scrub load threshold = 5.0
+        osd scrub load threshold = 2000.0
         osd debug op order = true
         filestore wbthrottle xfs ios start flusher = 10
         filestore wbthrottle xfs ios hard limit = 20


### PR DESCRIPTION
In a test environment, consistency is more important than
performances. Effectively disable the test that would postpone a scrub
depending on the load average. It is assumed that a machine with a load
average higher than 2000 won't be useable anyway.

http://tracker.ceph.com/issues/13986 Fixes: #13986

Signed-off-by: Loic Dachary <loic@dachary.org>