### PR TITLE
[rgw multisite] add realm epoch for period ordering

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2382,12 +2382,14 @@ int main(int argc, char **argv)
           return -EINVAL;
         }
         RGWPeriod period;
-        if (!realm.get_current_period().empty()) {
+        auto& current_period = realm.get_current_period();
+        if (!current_period.empty()) {
+          // pull the latest epoch of the realm's current period
           ret = do_period_pull(remote, url, access_key, secret_key,
-                               realm_id, realm_name, period_id, period_epoch,
+                               realm_id, realm_name, current_period, 0,
                                &period);
           if (ret < 0) {
-            cerr << "could not fetch period " << realm.get_current_period() << std::endl;
+            cerr << "could not fetch period " << current_period << std::endl;
             return -ret;
           }
         }

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -675,6 +675,7 @@ void RGWPeriod::dump(Formatter *f) const
   encode_json("period_config", period_config, f);
   encode_json("realm_id", realm_id, f);
   encode_json("realm_name", realm_name, f);
+  encode_json("realm_epoch", realm_epoch, f);
 }
 
 void RGWPeriod::decode_json(JSONObj *obj)
@@ -689,6 +690,7 @@ void RGWPeriod::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("period_config", period_config, obj);
   JSONDecoder::decode_json("realm_id", realm_id, obj);
   JSONDecoder::decode_json("realm_name", realm_name, obj);
+  JSONDecoder::decode_json("realm_epoch", realm_epoch, obj);
 }
 
 void RGWZoneParams::dump(Formatter *f) const
@@ -946,6 +948,7 @@ void RGWRealm::dump(Formatter *f) const
   encode_json("master_zonegroup", master_zonegroup, f);
   encode_json_map("zonegroups", zonegroups, f);
   encode_json("current_period", current_period, f);
+  encode_json("epoch", epoch, f);
 }
 
 
@@ -955,6 +958,7 @@ void RGWRealm::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("master_zonegroup", master_zonegroup, obj);
   JSONDecoder::decode_json("zonegroups", zonegroups, decode_zonegroups, obj);
   JSONDecoder::decode_json("current_period", current_period, obj);
+  JSONDecoder::decode_json("epoch", epoch, obj);
 }
 
 void KeystoneToken::Metadata::decode_json(JSONObj *obj)

--- a/src/rgw/rgw_period_pusher.h
+++ b/src/rgw/rgw_period_pusher.h
@@ -43,8 +43,8 @@ class RGWPeriodPusher final : public RGWRealmWatcher::Watcher,
   RGWRados* store;
 
   std::mutex mutex;
-  std::string period_id; //< the current period id being sent
-  epoch_t period_epoch; //< the current period epoch being sent
+  epoch_t realm_epoch{0}; //< the current realm epoch being sent
+  epoch_t period_epoch{0}; //< the current period epoch being sent
 
   /// while paused for reconfiguration, we need to queue up notifications
   std::vector<RGWZonesNeedPeriod> pending_periods;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1257,17 +1257,17 @@ int RGWPeriod::commit(RGWRealm& realm, const RGWPeriod& current_period)
   }
   // did the master zone change?
   if (master_zone != current_period.get_master_zone()) {
-    // create with a new period id
-    int r = create(true);
-    if (r < 0) {
-      lderr(cct) << "failed to create new period: " << cpp_strerror(-r) << dendl;
-      return r;
-    }
     // store the current metadata sync status in the period
-    r = update_sync_status();
+    int r = update_sync_status();
     if (r < 0) {
       lderr(cct) << "failed to update metadata sync status: "
           << cpp_strerror(-r) << dendl;
+      return r;
+    }
+    // create an object with a new period id
+    r = create(true);
+    if (r < 0) {
+      lderr(cct) << "failed to create new period: " << cpp_strerror(-r) << dendl;
       return r;
     }
     // set as current period

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -692,7 +692,7 @@ int RGWRealm::create(bool exclusive)
       return ret;
     }
   }
-  ret = set_current_period(period.get_id());
+  ret = set_current_period(period);
   if (ret < 0) {
     return ret;
   }
@@ -759,28 +759,18 @@ const string& RGWRealm::get_info_oid_prefix(bool old_format)
   return realm_info_oid_prefix;
 }
 
-int RGWRealm::set_current_period(const string& period_id) {
-  /* check to see period id is valid */
-  RGWPeriod new_current(period_id);
-  int ret = new_current.init(cct, store, id, name);
-  if (ret < 0) {
-    ldout(cct, 0) << "Error init new period id " << period_id << " : " << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
-  new_current.set_predecessor(current_period);
+int RGWRealm::set_current_period(RGWPeriod& period)
+{
 
-  ret = new_current.store_info(false);
-  if (ret < 0) {
-    return ret;
-  }
-  current_period = period_id;
-  ret = update();
+  current_period = period.get_id();
+
+  int ret = update();
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: period update: " << cpp_strerror(-ret) << dendl;
     return ret;
   }
 
-  ret = new_current.reflect();
+  ret = period.reflect();
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: period.reflect(): " << cpp_strerror(-ret) << dendl;
     return ret;
@@ -1271,7 +1261,7 @@ int RGWPeriod::commit(RGWRealm& realm, const RGWPeriod& current_period)
       return r;
     }
     // set as current period
-    r = realm.set_current_period(id);
+    r = realm.set_current_period(*this);
     if (r < 0) {
       lderr(cct) << "failed to update realm's current period: "
           << cpp_strerror(-r) << dendl;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1266,6 +1266,7 @@ class RGWRealm : public RGWSystemMetaObj
   string master_zonegroup;
   map<string, RGWZoneGroup> zonegroups;
   string current_period;
+  epoch_t epoch{0}; //< realm epoch, incremented for each new period
 
   int create_control();
   int delete_control();
@@ -1281,6 +1282,7 @@ public:
     ::encode(master_zonegroup, bl);
     ::encode(zonegroups, bl);
     ::encode(current_period, bl);
+    ::encode(epoch, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -1290,6 +1292,7 @@ public:
     ::decode(master_zonegroup, bl);
     ::decode(zonegroups, bl);
     ::decode(current_period, bl);
+    ::decode(epoch, bl);
     DECODE_FINISH(bl);
   }
 
@@ -1308,6 +1311,8 @@ public:
     return current_period;
   }
   int set_current_period(RGWPeriod& period);
+
+  epoch_t get_epoch() const { return epoch; }
 
   string get_control_oid();
   /// send a notify on the realm control object
@@ -1350,6 +1355,7 @@ class RGWPeriod
 
   string realm_id;
   string realm_name;
+  epoch_t realm_epoch{1}; //< realm epoch when period was made current
 
   CephContext *cct;
   RGWRados *store;
@@ -1373,6 +1379,7 @@ public:
 
   const string& get_id() const { return id; }
   epoch_t get_epoch() const { return epoch; }
+  epoch_t get_realm_epoch() const { return realm_epoch; }
   const string& get_predecessor() const { return predecessor_uuid; }
   const string& get_master_zone() const { return master_zone; }
   const string& get_master_zonegroup() const { return master_zonegroup; }
@@ -1427,9 +1434,10 @@ public:
   int commit(RGWRealm& realm, const RGWPeriod &current_period);
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);    
+    ENCODE_START(1, 1, bl);
     ::encode(id, bl);
     ::encode(epoch, bl);
+    ::encode(realm_epoch, bl);
     ::encode(predecessor_uuid, bl);
     ::encode(sync_status, bl);
     ::encode(period_map, bl);
@@ -1445,6 +1453,7 @@ public:
     DECODE_START(1, bl);
     ::decode(id, bl);
     ::decode(epoch, bl);
+    ::decode(realm_epoch, bl);
     ::decode(predecessor_uuid, bl);
     ::decode(sync_status, bl);
     ::decode(period_map, bl);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1307,7 +1307,7 @@ public:
   const string& get_current_period() const {
     return current_period;
   }
-  int set_current_period(const string& period_id);
+  int set_current_period(RGWPeriod& period);
 
   string get_control_oid();
   /// send a notify on the realm control object

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -140,7 +140,7 @@ void RGWOp_Period_Post::execute()
       return;
     }
     // set as current period
-    http_ret = realm.set_current_period(period.get_id()); // TODO: add sync status argument
+    http_ret = realm.set_current_period(period);
     if (http_ret < 0) {
       lderr(cct) << "failed to update realm's current period" << dendl;
       return;


### PR DESCRIPTION
The first 3 patches are minor bug fixes. I can split them into a separate pull request if there are any issues with the rest.

The last 3 patches implement the realm epoch, which is a version number on RGWRealm that increments on each new period. Each RGWPeriod stores the realm_epoch when it was created, allowing us to determine whether a given period comes before/after another.

The RGWPeriod realm_epoch is incremented by RGWPeriod::fork() on 'period update', and 'period commit' uses that to verify that the new period is based on the current period. If the master zone is unchanged (i.e. we don't generate a new period), RGWPeriod::commit() resets the period's realm_epoch back to the current period's. Otherwise, RGWRealm::set_current_period() will update the realm's epoch to match the new period.