### PR TITLE
buffer: make usable outside of ceph source again

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -403,6 +403,7 @@ install(FILES include/rados/librados.h
   include/rados/rados_types.hpp
   include/rados/librados.hpp
   include/buffer.h
+  include/buffer_fwd.h
   include/page.h
   include/crc32c.h
   DESTINATION include/rados)

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -104,6 +104,7 @@ noinst_HEADERS += \
 	include/rados/page.h \
 	include/rados/crc32c.h \
 	include/rados/buffer.h \
+	include/rados/buffer_fwd.h \
 	include/radosstriper/libradosstriper.h \
 	include/radosstriper/libradosstriper.hpp \
 	include/rbd/features.h \

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -47,7 +47,7 @@
 
 #include "page.h"
 #include "crc32c.h"
-#include "include/buffer_fwd.h"
+#include "buffer_fwd.h"
 
 #ifdef __CEPH__
 # include "include/assert.h"

--- a/src/include/rados/buffer_fwd.h
+++ b/src/include/rados/buffer_fwd.h
@@ -1,0 +1,1 @@
+../buffer_fwd.h


### PR DESCRIPTION
Add a rados/buffer_fwd.h symlink and remove the "include/" prefix from
buffer.h.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>