### PR TITLE
ceph-fuse:print usage information when no parameter specified

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -47,6 +47,10 @@ int main(int argc, const char **argv, const char *envp[]) {
   //cerr << "ceph-fuse starting " << myrank << "/" << world << std::endl;
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    usage();
+    return 0;
+  }
   env_to_vec(args);
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_DAEMON,


### PR DESCRIPTION
when input ceph-fuse without parameter, it should call usage()
Signed-off-by: Bo Cai <cai.bo@h3c.com>