### PR TITLE
fix OSD utilization is abnormal after data disk lost

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -668,7 +668,11 @@ void OSDService::update_osd_stat(vector<int>& hb_peers)
 
   // fill in osd stats too
   struct statfs stbuf;
-  osd->store->statfs(&stbuf);
+  int r = osd->store->statfs(&stbuf);
+  if (r < 0) {
+    derr << "statfs() failed: " << cpp_strerror(r) << dendl; 
+    return;
+  }
 
   uint64_t bytes = stbuf.f_blocks * stbuf.f_bsize;
   uint64_t used = (stbuf.f_blocks - stbuf.f_bfree) * stbuf.f_bsize;


### PR DESCRIPTION
in function "OSDService::update_osd_stat", local variable "stbuf"" isn't initialized and it's still used to
update the utilization of OSD.

Fixes: #14026 
Signed-off-by: Chuanhong Wang <wang.chuanhong@zte.com.cn>