### PR TITLE
os: skip checking pg_meta object existance in FileStore

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -5225,7 +5225,12 @@ int FileStore::_omap_setkeys(coll_t cid, const ghobject_t &hoid,
 			     const SequencerPosition &spos) {
   dout(15) << __func__ << " " << cid << "/" << hoid << dendl;
   Index index;
-  int r = get_index(cid, &index);
+  int r;
+  //treat pgmeta as a logical object, skip to check exist
+  if (hoid.is_pgmeta())
+    goto skip;
+
+  r = get_index(cid, &index);
   if (r < 0) {
     dout(20) << __func__ << " get_index got " << cpp_strerror(r) << dendl;
     return r;
@@ -5239,6 +5244,7 @@ int FileStore::_omap_setkeys(coll_t cid, const ghobject_t &hoid,
       return r;
     }
   }
+skip:
   r = object_map->set_keys(hoid, aset, &spos);
   dout(20) << __func__ << " " << cid << "/" << hoid << " = " << r << dendl;
   return r;
@@ -5249,7 +5255,12 @@ int FileStore::_omap_rmkeys(coll_t cid, const ghobject_t &hoid,
 			    const SequencerPosition &spos) {
   dout(15) << __func__ << " " << cid << "/" << hoid << dendl;
   Index index;
-  int r = get_index(cid, &index);
+  int r;
+  //treat pgmeta as a logical object, skip to check exist
+  if (hoid.is_pgmeta())
+    goto skip;
+
+  r = get_index(cid, &index);
   if (r < 0)
     return r;
   {
@@ -5259,6 +5270,7 @@ int FileStore::_omap_rmkeys(coll_t cid, const ghobject_t &hoid,
     if (r < 0)
       return r;
   }
+skip:
   r = object_map->rm_keys(hoid, keys, &spos);
   if (r < 0 && r != -ENOENT)
     return r;


### PR DESCRIPTION
pg_meta object in FileStore is actually a logical object without any significant information.
All it data writes to omap (leveldb), and actually no competition condition for the real object in FileStore
Based on the optimazation, we further reduce _omap_setkeys() execution time (123.784us to 108.444us, about 15%), and save cpu usage 0.5% globally

Signed-off-by: Ning Yao <zay11022@gmail.com>