### PR TITLE
ceph-detect-init: Ubuntu >= 15.04 uses systemd

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
@@ -9,5 +9,8 @@ def choose_init():
     Returns the name of a init system (upstart, sysvinit ...).
     """
     if distro.lower() in ('ubuntu', 'linuxmint'):
-        return 'upstart'
+        if codename >= 'vivid':
+            return 'systemd'
+        else:
+            return 'upstart'
     return 'sysvinit'

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -50,6 +50,9 @@ class TestCephDetectInit(testtools.TestCase):
         with mock.patch('ceph_detect_init.debian.distro',
                         'ubuntu'):
             self.assertEqual('upstart', debian.choose_init())
+            with mock.patch('ceph_detect_init.debian.codename',
+                            'vivid'):
+                self.assertEqual('systemd', debian.choose_init())
 
     def test_fedora(self):
         with mock.patch('ceph_detect_init.fedora.release',


### PR DESCRIPTION
Ubuntu releases since Ubuntu 15.04 use systemd instead of upstart;
teach ceph-detect-init that this is the case, thus avoiding OSD
devices on systemd based installs being marked as managed by
upstart by ceph-disk.

Signed-off-by: James Page <james.page@ubuntu.com>