### PR TITLE
tests: fix failure for osd-scrub-snap.sh

### DIFF
--- a/src/test/osd/osd-scrub-snaps.sh
+++ b/src/test/osd/osd-scrub-snaps.sh
@@ -92,8 +92,7 @@ function TEST_scrub_snaps() {
     rados -p $poolname rm obj4
     rados -p $poolname rm obj2
 
-    kill_daemons $dir KILL osd || return 1
-    sleep 5
+    kill_daemons $dir TERM osd || return 1
 
     # Don't need to ceph_objectstore_tool function because osd stopped
 


### PR DESCRIPTION
Reason to get a false negative
only one osd, when calling kill_daemons $dir KILL osd, which means kill -9
shutdown() would not be called to notify monitor so that it remain active+clean and osd up until monitor got a mon_report timeout.
Thus wait_for_clean lose it function and when we call ceph pg scrub, we got an EAGAIN error and monitor will ignore the scrub message because of osd not up

Signed-off-by: Ning Yao <zay11022@gmail.com>