### PR TITLE
rgw: fix a glaring syntax error

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -106,7 +106,7 @@ case "$1" in
             else
                 ulimit -n 32768
                 core_limit=`ceph-conf -n $name 'core file limit'`
-                if [ -z $core_limit ]
+                if [ -z $core_limit ]; then
                     DAEMON_COREFILE_LIMIT=$core_limit
                 fi
                 daemon --user="$user" "$RADOSGW -n $name"


### PR DESCRIPTION
syntactical error is causing rgw not to start

Signed-off-by: Pavan Rallabhandi <pavan.rallabhandi@sandisk.com>