### PR TITLE
osd: adjust default snap trim sleep interval to avoid client IO being blocked

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -640,7 +640,7 @@ OPTION(osd_op_thread_suicide_timeout, OPT_INT, 150)
 OPTION(osd_recovery_thread_timeout, OPT_INT, 30)
 OPTION(osd_recovery_thread_suicide_timeout, OPT_INT, 300)
 OPTION(osd_recovery_sleep, OPT_FLOAT, 0)         // seconds to sleep between recovery ops
-OPTION(osd_snap_trim_sleep, OPT_FLOAT, 0)
+OPTION(osd_snap_trim_sleep, OPT_FLOAT, 0.1)
 OPTION(osd_scrub_invalid_stats, OPT_BOOL, true)
 OPTION(osd_remove_thread_timeout, OPT_INT, 60*60)
 OPTION(osd_remove_thread_suicide_timeout, OPT_INT, 10*60*60)


### PR DESCRIPTION
Bug # 14052

This modification updates the third parameter of OPTION(osd_snap_trim_sleep, OPT_FLOAT, 0) from 0 to 0.1. So when dealing with client io and other multiple ios, client io will not be blocked.

Signed-off-by: Kongming Wu <wu.kongming@h3c.com>