### PR TITLE
rbd: fix build with "--without-rbd"

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -97,11 +97,10 @@ libcommon_internal_la_SOURCES += \
         common/aix_errno.cc
 endif
 
-if WITH_RBD
+# used by RBD and FileStore
 if LINUX
 libcommon_internal_la_SOURCES += \
 	common/blkdev.cc
-endif
 endif
 
 if ENABLE_XIO

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -433,9 +433,11 @@ bin_DEBUGPROGRAMS += ceph_test_objectcacher_stress
 ceph_test_cfuse_cache_invalidate_SOURCES = test/test_cfuse_cache_invalidate.cc
 bin_DEBUGPROGRAMS += ceph_test_cfuse_cache_invalidate
 
+if LINUX
 ceph_test_get_blkdev_size_SOURCES = test/test_get_blkdev_size.cc
 ceph_test_get_blkdev_size_LDADD = $(LIBCOMMON)
 bin_DEBUGPROGRAMS += ceph_test_get_blkdev_size
+endif
 
 noinst_HEADERS += \
 	test/bench/backend.h \

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -226,6 +226,7 @@ TYPE(ETableServer)
 #include "mds/events/EUpdate.h"
 TYPE(EUpdate)
 
+#ifdef WITH_RBD
 #include "librbd/JournalTypes.h"
 TYPE(librbd::journal::EventEntry)
 #include "librbd/WatchNotifyTypes.h"
@@ -235,6 +236,7 @@ TYPE(librbd::watch_notify::ResponseMessage)
 #include "rbd_replay/ActionTypes.h"
 TYPE(rbd_replay::action::Dependency)
 TYPE(rbd_replay::action::ActionEntry);
+#endif
 
 #ifdef WITH_RADOSGW
 
@@ -331,12 +333,14 @@ TYPE(rgw_obj)
 #include "rgw/rgw_log.h"
 TYPE(rgw_log_entry)
 
+#ifdef WITH_RBD
 #include "cls/rbd/cls_rbd.h"
 TYPE(cls_rbd_parent)
 TYPE(cls_rbd_snap)
 
 #include "cls/rbd/cls_rbd_types.h"
 TYPE(cls::rbd::MirrorPeer)
+#endif
 
 #endif
 


### PR DESCRIPTION
It's not possible to build Ceph configured with "--without-rbd", as
tests and FileStore depends on components provided by RBD. This changeset
fixes this.

Fixes: #14058
Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>