### PR TITLE
Wip mstart

### DIFF
--- a/src/mrgw.sh
+++ b/src/mrgw.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+script_root=`dirname $0`
+
+[ "$#" -lt 2 ] && echo "usage: $0 <name> <port> [params...]" && exit 1
+
+name=$1
+port=$2
+
+shift 2
+
+run_root=$script_root/run/$name
+pidfile=$run_root/out/radosgw.${port}.pid
+
+$script_root/mstop.sh $name radosgw $port
+
+$script_root/mrun $name radosgw --rgw-frontends="civetweb port=$port" --pid-file=$pidfile "$@"

--- a/src/mrun
+++ b/src/mrun
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+[ $# -lt 2 ] && echo "usage: $0 <name> <command> [params...]" && exit 1
+
+root=`dirname $0`
+run_name=$1
+command=$2
+
+shift 2
+
+$root/$command -c $root/run/$run_name/ceph.conf "$@"

--- a/src/mstart.sh
+++ b/src/mstart.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+usage="usage: $0 <name> [vstart options]..\n"
+
+usage_exit() {
+	printf "$usage"
+	exit
+}
+
+[ $# -lt 1 ] && usage_exit
+
+
+instance=$1
+shift
+
+root_path=`dirname $0`
+root_path=`(cd $root_path; pwd)`
+RUN_ROOT_PATH=${root_path}/run
+CLUSTERS_LIST=$RUN_ROOT_PATH/.clusters.list
+
+mkdir -p $RUN_ROOT_PATH
+
+
+if [ ! -f $CLUSTERS_LIST ]; then
+touch $CLUSTERS_LIST
+fi
+
+pos=`grep -n -w $instance $CLUSTERS_LIST`
+if [ $? -ne 0 ]; then
+  echo $instance >> $CLUSTERS_LIST
+  pos=`grep -n -w $instance $CLUSTERS_LIST`
+fi
+
+pos=`echo $pos | cut -d: -f1`
+base_port=$((6800+pos*10))
+
+export VSTART_DEST=$RUN_ROOT_PATH/$instance
+export CEPH_PORT=$base_port
+
+mkdir -p $VSTART_DEST
+
+echo "Cluster dest path: $VSTART_DEST"
+echo "monitors base port: $CEPH_PORT"
+
+$root_path/vstart.sh "$@"

--- a/src/mstop.sh
+++ b/src/mstop.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+script_root=`dirname $0`
+
+[ "$#" -lt 1 ] && echo "usage: $0 <name> [entity [id]]" && exit 1
+
+name=$1
+entity=$2
+id=$3
+
+run_root=$script_root/run/$name
+pidpath=$run_root/out
+
+if [ "$entity" == "" ]; then
+  pfiles=`ls $pidpath/*.pid` || true
+elif [ "$id" == "" ]; then
+  pfiles=`ls $pidpath/$entity.*.pid` || true
+else
+  pfiles=`ls $pidpath/$entity.$id.pid` || true
+fi
+
+for pidfile in $pfiles; do
+  pid=`cat $pidfile`
+  fname=`echo $pidfile | sed 's/.*\///g'`
+  echo $pid
+  [ "$pid" == "" ] && exit
+  [ $pid -eq 0 ] && exit
+  echo pid=$pid
+  extra_check=""
+  entity=`echo $fname | sed 's/\..*//g'`
+  [ "$entity" == "radosgw" ] && extra_check="-e lt-radosgw"
+  echo entity=$entity pid=$pid
+  while ps -p $pid -o args= | grep -q -e $entity $extracheck ; do
+    cmd="kill $signal $pid"
+    printf "$cmd..."
+    $cmd
+    sleep 1
+    continue
+  done
+done
+

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -3,6 +3,18 @@
 # abort on failure
 set -e
 
+if [ -n "$VSTART_DEST" ]; then
+  SRC_PATH=`dirname $0`
+  SRC_PATH=`(cd $SRC_PATH; pwd)`
+
+  CEPH_DIR=$SRC_PATH
+  CEPH_BIN=$SRC_PATH
+  CEPH_LIB=$SRC_PATH/.libs
+  CEPH_CONF_PATH=$VSTART_DEST
+  CEPH_DEV_DIR=$VSTART_DEST/dev
+  CEPH_OUT_DIR=$VSTART_DEST/out
+fi
+
 if [ -e CMakeCache.txt ]; then
   # Out of tree build, learn source location from CMakeCache.txt
   SRC_ROOT=`grep Ceph_SOURCE_DIR CMakeCache.txt | cut -d "=" -f 2`
@@ -59,6 +71,7 @@ export DYLD_LIBRARY_PATH=$CEPH_LIB:$DYLD_LIBRARY_PATH
 [ -z "$CEPH_DEV_DIR" ] && CEPH_DEV_DIR="$CEPH_DIR/dev"
 [ -z "$CEPH_OUT_DIR" ] && CEPH_OUT_DIR="$CEPH_DIR/out"
 [ -z "$CEPH_RGW_PORT" ] && CEPH_RGW_PORT=8000
+[ -z "$CEPH_CONF_PATH" ] && CEPH_CONF_PATH=$CEPH_DIR
 
 extra_conf=""
 new=0
@@ -83,8 +96,8 @@ journal=1
 
 MON_ADDR=""
 
-conf_fn="$CEPH_DIR/ceph.conf"
-keyring_fn="$CEPH_DIR/keyring"
+conf_fn="$CEPH_CONF_PATH/ceph.conf"
+keyring_fn="$CEPH_CONF_PATH/keyring"
 osdmap_fn="/tmp/ceph_osdmap.$$"
 monmap_fn="/tmp/ceph_monmap.$$"
 


### PR DESCRIPTION
Set of scripts that allow setting multiple separate ce[h clusters (through vstart) on a single dev tree.

mstart.sh is used to start a new cluster
mstop.sh is used to stop a specific cluster
mrgw.sh is used to spawn rgw instance on a specific cluster
mrun is used to run a command (e.g., ceph, rados) on a specific cluster

Usage example:

$ ./mstart.sh c1 -n
$ ./mstart.sh c2 -n

$ ./mrgw c1 80 --debug-rgw=20
$ ./mrgw c2 88 --debug-rgw=20

$ ./mrun c1 ceph -s

$ ./mstop.sh c2

etc.