### PR TITLE
rbd: specify pool name for rbd admin socket commands

### DIFF
--- a/qa/workunits/rbd/test_admin_socket.sh
+++ b/qa/workunits/rbd/test_admin_socket.sh
@@ -114,15 +114,19 @@ function rbd_watch_end()
 
 wait_for_clean
 
+pool="rbd"
 image=testimg$$
 ceph_admin="ceph --admin-daemon $(rbd_watch_asok ${image})"
 
-rbd create --size 128 ${image}
+rbd create --size 128 ${pool}/${image}
 
 # check rbd cache commands are present in help output
+rbd_cache_flush="rbd cache flush ${pool}/${image}"
+rbd_cache_invalidate="rbd cache invalidate ${pool}/${image}"
+
 rbd_watch_start ${image}
-${ceph_admin} help | fgrep "rbd cache flush ${image}"
-${ceph_admin} help | fgrep "rbd cache invalidate ${image}"
+${ceph_admin} help | fgrep "${rbd_cache_flush}"
+${ceph_admin} help | fgrep "${rbd_cache_invalidate}"
 rbd_watch_end ${image}
 
 # test rbd cache commands with disabled and enabled cache
@@ -133,12 +137,12 @@ for conf_rbd_cache in false true; do
     rbd_watch_start ${image}
 
     rbd_check_perfcounter ${image} flush 0
-    ${ceph_admin} rbd cache flush ${image}
+    ${ceph_admin} ${rbd_cache_flush}
     # 'flush' counter should increase regardless if cache is enabled
     rbd_check_perfcounter ${image} flush 1
 
     rbd_check_perfcounter ${image} invalidate_cache 0
-    ${ceph_admin} rbd cache invalidate ${image}
+    ${ceph_admin} ${rbd_cache_invalidate}
     # 'invalidate_cache' counter should increase regardless if cache is enabled
     rbd_check_perfcounter ${image} invalidate_cache 1
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -163,13 +163,14 @@ struct C_InvalidateCache : public Context {
       readahead(),
       total_bytes_read(0), copyup_finisher(NULL),
       state(new ImageState<>(this)), exclusive_lock(nullptr),
-      object_map(nullptr), aio_work_queue(NULL), op_work_queue(NULL),
-      asok_hook(new LibrbdAdminSocketHook(this))
+      object_map(nullptr), aio_work_queue(NULL), op_work_queue(NULL)
   {
     md_ctx.dup(p);
     data_ctx.dup(p);
     if (snap)
       snap_name = snap;
+
+    asok_hook = new LibrbdAdminSocketHook(this);
 
     memset(&header, 0, sizeof(header));
     memset(&layout, 0, sizeof(layout));

--- a/src/librbd/LibrbdAdminSocketHook.cc
+++ b/src/librbd/LibrbdAdminSocketHook.cc
@@ -57,19 +57,22 @@ LibrbdAdminSocketHook::LibrbdAdminSocketHook(ImageCtx *ictx) :
   admin_socket(ictx->cct->get_admin_socket()) {
 
   std::string command;
+  std::string imagename;
   int r;
 
-  command = "rbd cache flush " + ictx->name;
+  imagename = ictx->md_ctx.get_pool_name() + "/" + ictx->name;
+  command = "rbd cache flush " + imagename;
+
   r = admin_socket->register_command(command, command, this,
-				     "flush rbd image " + ictx->name +
+				     "flush rbd image " + imagename +
 				     " cache");
   if (r == 0) {
     commands[command] = new FlushCacheCommand(ictx);
   }
 
-  command = "rbd cache invalidate " + ictx->name;
+  command = "rbd cache invalidate " + imagename;
   r = admin_socket->register_command(command, command, this,
-				     "invalidate rbd image " + ictx->name +
+				     "invalidate rbd image " + imagename + 
 				     " cache");
   if (r == 0) {
     commands[command] = new InvalidateCacheCommand(ictx);


### PR DESCRIPTION
Add the pool name for a given rbd imgae when executing rbd admin socket
commands in case there are more than one images with the same name in
different pools.

Signed-off-by: Xiangwei Wu <wuxiangwei@h3c.com>