### PR TITLE
mount/mtab.cc: memory leaks

### DIFF
--- a/src/mount/mtab.c
+++ b/src/mount/mtab.c
@@ -289,4 +289,6 @@ update_mtab_entry(const char *spec, const char *node, const char *type,
 
 	free(mnt.mnt_fsname);
 	free(mnt.mnt_dir);
+	free(mnt.mnt_type);
+	free(mnt.mnt_opts);
 }


### PR DESCRIPTION
the free() should be called to free resources, in order to avoid memory leaks

Fixes:#14066
Signed-off-by: Qiankun Zheng <zheng.qiankun@h3c.com>