### PR TITLE
client: modify a word in log

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7700,7 +7700,7 @@ void Client::sync_write_commit(InodeRef& in)
 
   ldout(cct, 15) << "sync_write_commit unsafe_sync_write = " << unsafe_sync_write << dendl;
   if (unsafe_sync_write == 0 && unmounting) {
-    ldout(cct, 10) << "sync_write_comit -- no more unsafe writes, unmount can proceed" << dendl;
+    ldout(cct, 10) << "sync_write_commit -- no more unsafe writes, unmount can proceed" << dendl;
     mount_cond.Signal();
   }
 


### PR DESCRIPTION
This modification changed the word "comit" in line 7704
/* ldout(cct, 10) << "sync_write_comit -- no more unsafe writes, unmount can proceed" << dendl; */
by the word "commit";

Signed-off-by: YongQiang He<he.yongqiang@h3c.com>