### PR TITLE
variable offset may be equal to variable start,so m[start] value is 0.

### DIFF
--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -1419,7 +1419,7 @@ int NewStore::fiemap(
       continue;
     }
 
-    unsigned x_len = len;
+    uint64_t x_len = len;
     if (op != oend &&
 	op->first > offset &&
 	op->first - offset < x_len) {
@@ -1439,8 +1439,10 @@ int NewStore::fiemap(
       continue;
     }
     // we are seeing a hole, time to add an entry to fiemap.
-    m[start] = offset - start;
-    dout(20) << __func__ << " get fiemap entry, off =  " << start << " len=" << m[start] << dendl;
+    if (offset - start != 0) {
+      m[start] = offset - start;
+      dout(20) << __func__ << " get fiemap entry, off =  " << start << " len=" << m[start] << dendl;
+    }
     offset += x_len;
     start = offset;
     len -= x_len;


### PR DESCRIPTION
In function NewStore::fiemap ,variable offset may be equal to variable start,so m[start] value is 0.
the problem was recorded in the osd log:
2015-12-10 18:41:43.914146 7f85584ed700 20 newstore(/var/lib/ceph/osd/ceph-11) fiemap 0~4194304 size 4194304
2015-12-10 18:41:43.914148 7f85584ed700 20 newstore(/var/lib/ceph/osd/ceph-11) fiemap get fiemap entry, off = 0 len=0
2015-12-10 18:41:43.914149 7f85584ed700 30 newstore(/var/lib/ceph/osd/ceph-11) fiemap get overlay, off = 4128768 len=65536
2015-12-10 18:41:43.914151 7f85584ed700 20 newstore(/var/lib/ceph/osd/ceph-11) fiemap get fiemap entry, off = 4128768 len=65536
2015-12-10 18:41:43.914155 7f85584ed700 20 newstore(/var/lib/ceph/osd/ceph-11) fiemap 4194304~0 size = 0 ({0=0,4128768=65536})
2015-12-10 18:41:43.937608 7f8561d00700 30 osd.11 22593 heartbeat_dispatch 0x7f859c51c800
2015-12-10 18:41:43.937614 7f8563503700 30 osd.11 22593 heartbeat_dispatch 0x7f859c51fc00
2015-12-10 18:41:44.021043 7f8563503700 30 osd.11 22593 heartbeat_dispatch 0x7f8596f03400
2015-12-10 18:41:44.021045 7f8561d00700 30 osd.11 22593 heartbeat_dispatch 0x7f8596f01400
2015-12-10 18:41:44.069612 7f85584ed700 -1 ./include/interval_set.h: In function 'void interval_set::insert(T, T) [with T = long unsigned int]' thread 7f85584ed700 time 2015-12-10 18:41:43.914870
./include/interval_set.h: 338: FAILED assert(len > 0)

ceph version 9.2.0 (bb2ecea)
1: (ceph::__ceph_assert_fail(char const, char const, int, char const)+0x85) [0x7f8580b9ebe5]
2: (interval_set<unsigned long>::insert(unsigned long, unsigned long)+0x27c) [0x7f858080fc1c]
3: (ReplicatedBackend::build_push_op(ObjectRecoveryInfo const&, ObjectRecoveryProgress const&, ObjectRecoveryProgress, PushOp, object_stat_sum_t, bool)+0x1122) [0x7f85809bd372]
4: (ReplicatedBackend::prep_push(std::shared_ptr<ObjectContext>, hobject_t const&, pg_shard_t, eversion_t, interval_set<unsigned long>&, std::map<hobject_t, interval_set<unsigned long>, hobject_t::BitwiseComparator, std::allocator<std::pair<hobject_t const, interval_set<unsigned long> > > >&, PushOp, bool)+0x486) [0x7f85809c2716]
5: (ReplicatedBackend::prep_push_to_replica(std::shared_ptr<ObjectContext>, hobject_t const&, pg_shard_t, PushOp, bool)+0x1a4) [0x7f85809c2bb4]
6: (ReplicatedBackend::start_pushes(hobject_t const&, std::shared_ptr<ObjectContext>, ReplicatedBackend::RPGHandle)+0x1c1) [0x7f85809c37f1]
7: (ReplicatedBackend::recover_object(hobject_t const&, eversion_t, std::shared_ptr<ObjectContext>, std::shared_ptr<ObjectContext>, PGBackend::RecoveryHandle)+0xf8) [0x7f85809c39b8]
8: (ReplicatedPG::prep_backfill_object_push(hobject_t, eversion_t, std::shared_ptr<ObjectContext>, std::vector<pg_shard_t, std::allocator<pg_shard_t> >, PGBackend::RecoveryHandle)+0x45d) [0x7f858079157d]
9: (ReplicatedPG::recover_backfill(int, ThreadPool::TPHandle&, bool)+0x19d9) [0x7f85807d3959]
10: (ReplicatedPG::start_recovery_ops(int, ThreadPool::TPHandle&, int)+0x8bc) [0x7f85807d672c]
11: (OSD::do_recovery(PG, ThreadPool::TPHandle&)+0x356) [0x7f8580605e76]
12: (OSD::RecoveryWQ::_process(PG, ThreadPool::TPHandle&)+0x27) [0x7f858064e827]
13: (ThreadPool::worker(ThreadPool::WorkThread)+0xa76) [0x7f8580b901a6]
14: (ThreadPool::WorkThread::entry()+0x10) [0x7f8580b91070]
15: (()+0x7df5) [0x7f857ec34df5]
16: (clone()+0x6d) [0x7f857d4dd1ad]
NOTE: a copy of the executable, or objdump -rdS &lt;executable&gt; is needed to interpret this.

Signed-off-by: YiQiang Chen <cyqsign@163.com>