### PR TITLE
OSD: fix null pointer access and race condition

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6633,16 +6633,17 @@ void OSD::handle_osd_map(MOSDMap *m)
     osdmap_subscribe(osdmap->get_epoch()+1, false);
   }
   else if (do_shutdown) {
-    osd_lock.Unlock();
-    shutdown();
     if (network_error) {
+      Mutex::Locker l(heartbeat_lock);	
       map<int,pair<utime_t,entity_inst_t>>::iterator it = failure_pending.begin();
       while (it != failure_pending.end()) {
         dout(10) << "handle_osd_ping canceling in-flight failure report for osd." << it->first << dendl;
         send_still_alive(osdmap->get_epoch(), it->second.second);
         failure_pending.erase(it++);
       }
-    }
+    }	
+    osd_lock.Unlock();
+    shutdown();
     osd_lock.Lock();
   }
   else if (is_preboot()) {


### PR DESCRIPTION
We are risking of accessing a null osdmap pointer when we failed to handle an osdmap message due to network error.
Also, it is not safe to change failure_pending without protection of hearbeat_lock.
Fixes:#14072
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>