### PR TITLE
OSD: remove wrongly placed assert

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3329,7 +3329,6 @@ void OSD::handle_pg_peering_evt(
 
       dout(10) << *parent << " is new" << dendl;
 
-      assert(service.splitting(pgid));
       peering_wait_for_split[pgid].push_back(evt);
 
       //parent->queue_peering_event(evt);


### PR DESCRIPTION
It will definitely fire in this case.
Fixes:#14075
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>