### PR TITLE
rgw: fix the build failure

### DIFF
--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -140,7 +140,6 @@ std::ostream& RGWFormatter_Plain::dump_stream(const char *name)
 void RGWFormatter_Plain::dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
-  const char *format;
 
   struct plain_stack_entry& entry = stack.back();
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -819,7 +819,7 @@ void RGWDeleteObj_ObjStore_SWIFT::send_response()
       bulkdelete_respond(0, 1, {}, s->prot_flags, *s->formatter);
     } else {
       RGWBulkDelete::acct_path_t path;
-      path.bucket_name = s->bucket_name_str;
+      path.bucket_name = s->bucket_name;
       path.obj_key = s->object;
 
       RGWBulkDelete::fail_desc_t fail_desc;


### PR DESCRIPTION
* s/bucket_name_str/bucket_name/
* the member variable name of `req_state` was changed to `bucket_name`
  in f7ca00a. but some commits was still using the old name before the
  commit got merged.
* also fixes a typo

Signed-off-by: Kefu Chai <kchai@redhat.com>