### PR TITLE
Monitor: modify a dout level in OSDMonitor.cc

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1564,7 +1564,7 @@ bool OSDMonitor::can_mark_down(int i)
   int up = osdmap.get_num_up_osds() - pending_inc.get_net_marked_down(&osdmap);
   float up_ratio = (float)up / (float)num_osds;
   if (up_ratio < g_conf->mon_osd_min_up_ratio) {
-    dout(5) << "can_mark_down current up_ratio " << up_ratio << " < min "
+    dout(2) << "can_mark_down current up_ratio " << up_ratio << " < min "
 	    << g_conf->mon_osd_min_up_ratio
 	    << ", will not mark osd." << i << " down" << dendl;
     return false;


### PR DESCRIPTION
This modification changed a log level from 5 to 0
Before:/*   dout(5) << "can_mark_down current up_ratio " << up_ratio << " < min "
		    << g_conf->mon_osd_min_up_ratio
		    << ", will not mark osd." << i << " down" << dendl; */

After:/*   dout(0) << "can_mark_down current up_ratio " << up_ratio << " < min "
                    << g_conf->mon_osd_min_up_ratio
                    << ", will not mark osd." << i << " down" << dendl; */

we think this log is very important to help us find the reason why the markdown request of osd be rejected by monitor,
and it helps us to know there is a parameter "mon_osd_min_up_ratio";

Signed-off-by: Yongqiang He <he.yongqiang@h3c.com>