### PR TITLE
mon: degrade a log message to level 2

### DIFF
--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -207,7 +207,7 @@ void Paxos::handle_collect(MonOpRequestRef op)
   state = STATE_RECOVERING;
 
   if (collect->first_committed > last_committed+1) {
-    dout(5) << __func__
+    dout(2) << __func__
             << " leader's lowest version is too high for our last committed"
             << " (theirs: " << collect->first_committed
             << "; ours: " << last_committed << ") -- bootstrap!" << dendl;


### PR DESCRIPTION
FIX #14083

When leader election was done successfully, it will ask peon to collect info. When failed, it will cause monitor to do reelection, which makes relevant log message so important.
So It would be better if reducing the log level to a default value.

Signed-off-by: Kongming Wu <wu.kongming@h3c.com>