### PR TITLE
rbd-fuse: display image extended attributes when listing xattrs

### DIFF
--- a/src/rbd_fuse/rbd-fuse.cc
+++ b/src/rbd_fuse/rbd-fuse.cc
@@ -655,7 +655,7 @@ rbdfs_listxattr(const char *path, char *list, size_t len)
 	struct rbdfuse_attr *ap;
 	size_t required_len = 0;
 
-	if (strcmp(path, "/") != 0)
+	if (strcmp(path, "/") == 0)
 		return -EINVAL;
 
 	for (ap = attrs; ap->attrname != NULL; ap++)


### PR DESCRIPTION
… command to list xattrs.

fix the rbd-fuse error when execute xattr command to list the image xattrs.

Signed-off-by: Xiangwei Wu <wuxiangwei@h3c.com>