### PR TITLE
mds: tear down connections from `tell` commands

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -571,6 +571,21 @@ void MDSDaemon::handle_command(MCommand *m)
     r = _handle_command(cmdmap, m->get_data(), &outbl, &outs, &run_after);
   }
 
+  // If someone is using a closed session for sending commands (e.g.
+  // the ceph CLI) then we should feel free to clean up this connection
+  // as soon as we've sent them a response.
+  const bool live_session = mds_rank &&
+    mds_rank->sessionmap.get_session(session->info.inst.name) != nullptr
+    && session->get_state_seq() > 0;
+
+  if (!live_session) {
+    // This session only existed to issue commands, so terminate it
+    // as soon as we can.
+    assert(session->is_closed());
+    session->connection->mark_disposable();
+    session->put();
+  }
+
   MCommandReply *reply = new MCommandReply(r, outs);
   reply->set_tid(m->get_tid());
   reply->set_data(outbl);


### PR DESCRIPTION
We can identify sessions that were never really
opened, just created when a client sent in
a 'tell' message.  When we see one of those, mark
the associated connection disposable when responding
to the command.

Fixes: #14048
Signed-off-by: John Spray <john.spray@redhat.com>