### PR TITLE
osdc: removed unnecessary op budget calculation

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2056,11 +2056,11 @@ ceph_tid_t Objecter::_op_submit_with_budget(Op *op, RWLock::Context& lc, int *ct
 
   // throttle.  before we look at any state, because
   // _take_op_budget() may drop our lock while it blocks.
-  if (!op->ctx_budgeted || (ctx_budget && (*ctx_budget == -1))) {
-    int op_budget = _take_op_budget(op);
-    // take and pass out the budget for the first OP
-    // in the context session
-    if (ctx_budget && (*ctx_budget == -1)) {
+  if (NULL != ctx_budget) {
+    if (!op->ctx_budgeted && (*ctx_budget == -1)) {
+      int op_budget = _take_op_budget(op);
+      // take and pass out the budget for the first OP
+      // in the context session
       *ctx_budget = op_budget;
     }
   }


### PR DESCRIPTION
Most of the scene is ctx_budget = NULL && op - > ctx_budgeted = false conditions to invoke Objecter::_op_submit_with_budget, but this situation is to call "int op_budget = _take_op_budget (op)" is meaningless, and the influence on the performance function call
So，Need to optimize the *ctx_budget get op_budget way

Fixes: #14084
Signed-off-by: huanwen ren ren.huanwen@zte.com.cn