### PR TITLE
mds: fix setvxattr (broken in a536d114)

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4157,6 +4157,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur,
 	return;
       }
 
+      xlocks.insert(&cur->filelock);
       if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))
 	return;
 
@@ -4166,7 +4167,6 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur,
         }
       }
 
-      xlocks.insert(&cur->filelock);
       pi = cur->project_inode();
       int64_t old_pool = pi->layout.fl_pg_pool;
       pi->add_old_pool(old_pool);


### PR DESCRIPTION
There was an accidental move of this line
when adding the MAY_SET_POOL check, which
was causing setxattr to proceed before
it had the right locks, and thereby apply
its checks on bad data (symptom was failing
to detect that the file had data written to it).

Fixes: #14029
Signed-off-by: John Spray <john.spray@redhat.com>