### PR TITLE
rbd: striping parameters should support 64bit integers

### DIFF
--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -223,8 +223,8 @@ void add_create_image_options(po::options_description *opt,
     (IMAGE_FEATURES.c_str(), po::value<ImageFeatures>()->composing(),
      ("image features\n" + get_short_features_help(true)).c_str())
     (IMAGE_SHARED.c_str(), po::bool_switch(), "shared image")
-    (IMAGE_STRIPE_UNIT.c_str(), po::value<uint32_t>(), "stripe unit")
-    (IMAGE_STRIPE_COUNT.c_str(), po::value<uint32_t>(), "stripe count");
+    (IMAGE_STRIPE_UNIT.c_str(), po::value<uint64_t>(), "stripe unit")
+    (IMAGE_STRIPE_COUNT.c_str(), po::value<uint64_t>(), "stripe count");
 
   add_create_journal_options(opt);
 }


### PR DESCRIPTION
 the type of striping parameter is confusioned，uint32 as defined and uint64 as parse

Signed-off-by: Na Xie <xie.na@h3c.com>