### PR TITLE
rgw: warn on suspicious civetweb frontend parameters

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -1168,6 +1168,16 @@ int main(int argc, const char **argv)
   for (list<string>::iterator iter = frontends.begin(); iter != frontends.end(); ++iter) {
     string& f = *iter;
 
+    if (f.find("civetweb") != string::npos) {
+      if (f.find("port") != string::npos) {
+	// check for the most common ws problems
+	if ((f.find("port=") == string::npos) ||
+	    (f.find("port= ") != string::npos)) {
+	  derr << "WARNING: civetweb frontend config found unexpected spacing around 'port' (ensure civetweb port parameter has the form 'port=80' with no spaces before or after '=')" << dendl;
+	}
+      }
+    }
+
     RGWFrontendConfig *config = new RGWFrontendConfig(f);
     int r = config->init();
     if (r < 0) {


### PR DESCRIPTION
Warns when civetweb port is not specified, and about incorrect
spacing near 'port' (e.g., 'port = 80').

Fixes BZ 1228845.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>