### PR TITLE
[RFC]osd: If osd full, reply -ENOSPC.

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1554,11 +1554,13 @@ void ReplicatedPG::do_op(OpRequestRef& op)
       info.history.last_epoch_marked_full > m->get_map_epoch()) {
     dout(10) << __func__ << " discarding op sent before full " << m << " "
 	     << *m << dendl;
+    osd->reply_op_error(op, -ENOSPC);
     return;
   }
   if (!m->get_source().is_mds() && osd->check_failsafe_full()) {
     dout(10) << __func__ << " fail-safe full check failed, dropping request"
 	     << dendl;
+    osd->reply_op_error(op, -ENOSPC);
     return;
   }
   int64_t poolid = get_pgid().pool();


### PR DESCRIPTION
Now if osd full, the client op will discard. If client set timeout of
op, the op will end with -ETIMEDOUT. If client don't set timeout of op,
the op don't end for ever.
Further, if op can bypass osd-full and maybe met the no-space error.
So for this situation, reply w/ -ENOSPC is better than discard op.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>