### PR TITLE
Check for full before changing the cached obc

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2288,10 +2288,8 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
     return;
   }
 
-  // check for full
-  if (ctx->delta_stats.num_bytes > 0 &&
-      pool.info.has_flag(pg_pool_t::FLAG_FULL)) {
-    reply_ctx(ctx, -ENOSPC);
+  if (result == -ENOSPC) {
+    reply_ctx(ctx, result);
     return;
   }
 
@@ -5672,6 +5670,15 @@ int ReplicatedPG::prepare_transaction(OpContext *ctx)
   if (ctx->op_t->empty() && !ctx->modify) {
     unstable_stats.add(ctx->delta_stats);
     return result;
+  }
+
+  // check for full
+  if ((ctx->delta_stats.num_bytes > 0 ||
+       ctx->delta_stats.num_objects > 0) &&
+      (pool.info.has_flag(pg_pool_t::FLAG_FULL) ||
+       get_osdmap()->test_flag(CEPH_OSDMAP_FULL))) {
+    dout(20) << __func__ << ": full, returning -ENOSPC";
+    return -ENOSPC;
   }
 
   // clone, if necessary


### PR DESCRIPTION
ReplicatedPG::prepare_transaction(): check if the pool is full before
updating the cached ObjectContext to avoid the discrepancy between
the cached and the actual object size (and other metadata).
While at it improve the check itself: consider cluster full flag,
not just the pool full flag, also consider object count changes too,
not just bytes.

Fixes: #13335 (partially backport #6052 to hammer)

Signed-off-by: Alexey Sheplyakov asheplyakov@mirantis.com