### PR TITLE
os/FileStore: make fallocate work.

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -3271,22 +3271,30 @@ int FileStore::_zero(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t 
   if (ret < 0) {
     goto out;
   }
-
-  // first try fallocate
-  ret = fallocate(**fd, FALLOC_FL_PUNCH_HOLE, offset, len);
-  if (ret < 0)
+  struct stat st;
+  ret = fstat(**fd, &st);
+  if (ret < 0) {
     ret = -errno;
-  lfn_close(fd);
-
-  if (ret >= 0 && m_filestore_sloppy_crc) {
-    int rc = backend->_crc_update_zero(**fd, offset, len);
-    assert(rc >= 0);
+    lfn_close(fd);
+    goto out;
   }
+  // first try fallocate
+  if (offset + len <= (uint64_t)st.st_size) {
+    ret = fallocate(**fd, FALLOC_FL_PUNCH_HOLE|FALLOC_FL_KEEP_SIZE, offset, len);
+    if (ret < 0)
+      ret = -errno;
+    lfn_close(fd);
 
-  if (ret == 0)
-    goto out;  // yay!
-  if (ret != -EOPNOTSUPP)
-    goto out;  // some other error
+    if (ret >= 0 && m_filestore_sloppy_crc) {
+      int rc = backend->_crc_update_zero(**fd, offset, len);
+      assert(rc >= 0);
+    }
+
+    if (ret == 0)
+      goto out;  // yay!
+    if (ret != -EOPNOTSUPP)
+      goto out;  // some other error
+  }
 # endif
 #endif
 

--- a/src/os/FileStore.h
+++ b/src/os/FileStore.h
@@ -46,10 +46,12 @@ using namespace std;
 
 
 // from include/linux/falloc.h:
+#ifndef FALLOC_FL_KEEP_SIZE
+# define FALLOC_FL_KEEP_SIZE 0x1
+#endif
 #ifndef FALLOC_FL_PUNCH_HOLE
 # define FALLOC_FL_PUNCH_HOLE 0x2
 #endif
-
 #if defined(__linux__)
 # ifndef BTRFS_SUPER_MAGIC
 #define BTRFS_SUPER_MAGIC 0x9123683E


### PR DESCRIPTION
From 'man 2 fallocate", The FALLOC_FL_PUNCH_HOLE flag must be ORed with
FALLOC_FL_KEEP_SIZE in mode.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>