### PR TITLE
cmake: no need to run configure from run-cmake-check.sh

### DIFF
--- a/run-cmake-check.sh
+++ b/run-cmake-check.sh
@@ -48,8 +48,6 @@ function run() {
 	$DRY_RUN ./install-deps.sh || return 1
     fi
     $DRY_RUN ./autogen.sh || return 1
-    $DRY_RUN ./configure "$@" --disable-static --with-radosgw --with-debug --without-lttng \
-             CC="ccache gcc" CXX="ccache g++" CFLAGS="-Wall -g" CXXFLAGS="-Wall -g" || return 1
     $DRY_RUN mkdir build
     $DRY_RUN cd build
     $DRY_RUN cmake ../    


### PR DESCRIPTION
Signed-off-by: Orit Wasserman <owasserm@redhat.com>