### PR TITLE
newstore/NewStore.cc: FAILED assert(k >= start_key && k < end_key)

### DIFF
--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -1612,7 +1612,7 @@ int NewStore::collection_list(
       if (!it->valid())
 	dout(20) << __func__ << " iterator not valid (end of db?)" << dendl;
       else
-	dout(20) << __func__ << " key " << it->key() << " > " << end << dendl;
+	dout(20) << __func__ << " key " << it->key() << " > " << pend << dendl;
       if (temp) {
 	if (end.hobj.is_temp()) {
 	  break;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3812,8 +3812,10 @@ void PG::replica_scrub(
   // compensate for hobject_t's with wrong pool from sloppy hammer OSDs
   hobject_t start = msg->start;
   hobject_t end = msg->end;
-  start.pool = info.pgid.pool();
-  end.pool = info.pgid.pool();
+  if(start != hobject_t())
+    start.pool = info.pgid.pool();
+  if(!end.is_max())
+    end.pool = info.pgid.pool();
 
   build_scrub_map_chunk(
     map, start, end, msg->deep, msg->seed,


### PR DESCRIPTION
fix bug: http://tracker.ceph.com/issues/14101

InPG::replica_scrub ,start.pool is  assigned info.pgid.pool(),but  start may be a MIN object,and its hash is 0.Change it may hit assert in NewStore::collection_list.



Signed-off-by: YiQiang Chen <cyqsign@163.com>