### PR TITLE
common/lockdep: increase max lock names

### DIFF
--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -34,7 +34,7 @@ namespace std {
 
 /******* Constants **********/
 #define lockdep_dout(v) lsubdout(g_lockdep_ceph_ctx, lockdep, v)
-#define MAX_LOCKS  2000   // increase me as needed
+#define MAX_LOCKS  4096   // increase me as needed
 #define BACKTRACE_SKIP 2
 
 /******* Globals **********/


### PR DESCRIPTION
Recently hit this limit with

 /a/sage-2015-12-16_21:46:23-rados-wip-sage-testing---basic-openstack/40275

Signed-off-by: Sage Weil <sage@redhat.com>