### PR TITLE
common/WeightedPriorityQueue: Add new Weighted priority queue

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -177,7 +177,9 @@ noinst_HEADERS += \
 	common/Preforker.h \
 	common/SloppyCRCMap.h \
 	common/WorkQueue.h \
+	common/OpQueue.h \
 	common/PrioritizedQueue.h \
+	common/WeightedPriorityQueue.h \
 	common/ceph_argparse.h \
 	common/ceph_context.h \
 	common/xattr.h \

--- a/src/common/OpQueue.h
+++ b/src/common/OpQueue.h
@@ -1,0 +1,63 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef OP_QUEUE_H
+#define OP_QUEUE_H
+
+#include "include/msgr.h"
+
+#include <list>
+#include <functional>
+
+namespace ceph {
+  class Formatter;
+}
+
+/**
+ * Abstract class for all Op Queues
+ *
+ * In order to provide optimized code, be sure to declare all
+ * virutal functions as final in the derived class.
+ */
+
+template <typename T, typename K>
+class OpQueue {
+
+  public:
+    // How many Ops are in the queue
+    virtual unsigned length() const = 0;
+    // Ops will be removed and placed in *removed if f is true
+    virtual void remove_by_filter(
+	std::function<bool (T)> f, std::list<T> *removed) = 0;
+    // Ops of this priority should be deleted immediately
+    virtual void remove_by_class(K k, std::list<T> *out) = 0;
+    // Enqueue op in the back of the strict queue
+    virtual void enqueue_strict(K cl, unsigned priority, T item) = 0;
+    // Enqueue op in the front of the strict queue
+    virtual void enqueue_strict_front(K cl, unsigned priority, T item) = 0;
+    // Enqueue op in the back of the regular queue
+    virtual void enqueue(K cl, unsigned priority, unsigned cost, T item) = 0;
+    // Enqueue the op in the front of the regular queue
+    virtual void enqueue_front(K cl, unsigned priority, unsigned cost, T item) = 0;
+    // Returns if the queue is empty
+    virtual bool empty() const = 0;
+    // Return an op to be dispatch
+    virtual T dequeue() = 0;
+    // Formatted output of the queue
+    virtual void dump(ceph::Formatter *f) const = 0;
+    // Don't leak resources on destruction
+    virtual ~OpQueue() {}; 
+};
+
+#endif

--- a/src/common/PrioritizedQueue.h
+++ b/src/common/PrioritizedQueue.h
@@ -15,13 +15,10 @@
 #ifndef PRIORITY_QUEUE_H
 #define PRIORITY_QUEUE_H
 
-#include "common/Mutex.h"
 #include "common/Formatter.h"
 
 #include <map>
-#include <utility>
 #include <list>
-#include <algorithm>
 
 /**
  * Manages queue for normal and strict priority items
@@ -106,14 +103,16 @@ class PrioritizedQueue {
     }
     void put_tokens(unsigned t) {
       tokens += t;
-      if (tokens > max_tokens)
+      if (tokens > max_tokens) {
 	tokens = max_tokens;
+      }
     }
     void take_tokens(unsigned t) {
-      if (tokens > t)
+      if (tokens > t) {
 	tokens -= t;
-      else
+      } else {
 	tokens = 0;
+      }
     }
     void enqueue(K cl, unsigned cost, T item) {
       q[cl].push_back(std::make_pair(cost, item));
@@ -136,12 +135,14 @@ class PrioritizedQueue {
       assert(!(q.empty()));
       assert(cur != q.end());
       cur->second.pop_front();
-      if (cur->second.empty())
+      if (cur->second.empty()) {
 	q.erase(cur++);
-      else
+      } else {
 	++cur;
-      if (cur == q.end())
+      }
+      if (cur == q.end()) {
 	cur = q.begin();
+      }
       size--;
     }
     unsigned length() const {
@@ -158,8 +159,9 @@ class PrioritizedQueue {
 	   ) {
 	size -= filter_list_pairs(&(i->second), f, out);
 	if (i->second.empty()) {
-	  if (cur == i)
+	  if (cur == i) {
 	    ++cur;
+	  }
 	  q.erase(i++);
 	} else {
 	  ++i;
@@ -170,11 +172,13 @@ class PrioritizedQueue {
     }
     void remove_by_class(K k, std::list<T> *out) {
       typename Classes::iterator i = q.find(k);
-      if (i == q.end())
+      if (i == q.end()) {
 	return;
+      }
       size -= i->second.size();
-      if (i == cur)
+      if (i == cur) {
 	++cur;
+      }
       if (out) {
 	for (typename ListPairs::reverse_iterator j =
 	       i->second.rbegin();
@@ -184,8 +188,9 @@ class PrioritizedQueue {
 	}
       }
       q.erase(i);
-      if (cur == q.end())
+      if (cur == q.end()) {
 	cur = q.begin();
+      }
     }
 
     void dump(Formatter *f) const {
@@ -193,8 +198,9 @@ class PrioritizedQueue {
       f->dump_int("max_tokens", max_tokens);
       f->dump_int("size", size);
       f->dump_int("num_keys", q.size());
-      if (!empty())
+      if (!empty()) {
 	f->dump_int("first_item_cost", front().first);
+      }
     }
   };
 
@@ -204,8 +210,9 @@ class PrioritizedQueue {
 
   SubQueue *create_queue(unsigned priority) {
     typename SubQueues::iterator p = queue.find(priority);
-    if (p != queue.end())
+    if (p != queue.end()) {
       return &p->second;
+    }
     total_priority += priority;
     SubQueue *sq = &queue[priority];
     sq->set_max_tokens(max_tokens_per_subqueue);
@@ -220,8 +227,9 @@ class PrioritizedQueue {
   }
 
   void distribute_tokens(unsigned cost) {
-    if (total_priority == 0)
+    if (total_priority == 0) {
       return;
+    }
     for (typename SubQueues::iterator i = queue.begin();
 	 i != queue.end();
 	 ++i) {
@@ -341,8 +349,9 @@ public:
     if (!(high_queue.empty())) {
       T ret = high_queue.rbegin()->second.front().second;
       high_queue.rbegin()->second.pop_front();
-      if (high_queue.rbegin()->second.empty())
+      if (high_queue.rbegin()->second.empty()) {
 	high_queue.erase(high_queue.rbegin()->first);
+      }
       return ret;
     }
 
@@ -358,8 +367,9 @@ public:
 	unsigned cost = i->second.front().first;
 	i->second.take_tokens(cost);
 	i->second.pop_front();
-	if (i->second.empty())
+	if (i->second.empty()) {
 	  remove_queue(i->first);
+	}
 	distribute_tokens(cost);
 	return ret;
       }
@@ -370,8 +380,9 @@ public:
     T ret = queue.rbegin()->second.front().second;
     unsigned cost = queue.rbegin()->second.front().first;
     queue.rbegin()->second.pop_front();
-    if (queue.rbegin()->second.empty())
+    if (queue.rbegin()->second.empty()) {
       remove_queue(queue.rbegin()->first);
+    }
     distribute_tokens(cost);
     return ret;
   }

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -624,6 +624,8 @@ OPTION(osd_recovery_threads, OPT_INT, 1)
 OPTION(osd_recover_clone_overlap, OPT_BOOL, true)   // preserve clone_overlap during recovery/migration
 OPTION(osd_op_num_threads_per_shard, OPT_INT, 2)
 OPTION(osd_op_num_shards, OPT_INT, 5)
+OPTION(osd_op_queue, OPT_STR, "prio") // PrioritzedQueue (prio), Weighted Priority Queue (wpq), or debug_random
+OPTION(osd_op_queue_cut_off, OPT_STR, "low") // Min priority to go to strict queue. (low, high, debug_random)
 
 // Set to true for testing.  Users should NOT set this.
 // If set to true even after reading enough shards to

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -52,7 +52,9 @@ using namespace std;
 #include "common/shared_cache.hpp"
 #include "common/simple_cache.hpp"
 #include "common/sharedptr_registry.hpp"
+#include "common/WeightedPriorityQueue.h"
 #include "common/PrioritizedQueue.h"
+#include "common/OpQueue.h"
 #include "messages/MOSDOp.h"
 #include "include/Spinlock.h"
 
@@ -1617,6 +1619,11 @@ private:
   friend struct C_CompleteSplits;
 
   // -- op queue --
+  enum io_queue {
+    prioritized,
+    weightedpriority};
+  const io_queue op_queue;
+  const unsigned int op_prio_cutoff;
 
   friend class PGQueueable;
   class ShardedOpWQ: public ShardedThreadPool::ShardedWQ < pair <PGRef, PGQueueable> > {
@@ -1626,13 +1633,25 @@ private:
       Cond sdata_cond;
       Mutex sdata_op_ordering_lock;
       map<PG*, list<PGQueueable> > pg_for_processing;
-      PrioritizedQueue< pair<PGRef, PGQueueable>, entity_inst_t> pqueue;
+      std::unique_ptr<OpQueue< pair<PGRef, PGQueueable>, entity_inst_t>> pqueue;
       ShardData(
 	string lock_name, string ordering_lock,
-	uint64_t max_tok_per_prio, uint64_t min_cost, CephContext *cct)
+	uint64_t max_tok_per_prio, uint64_t min_cost, CephContext *cct,
+	io_queue opqueue)
 	: sdata_lock(lock_name.c_str(), false, true, false, cct),
-	  sdata_op_ordering_lock(ordering_lock.c_str(), false, true, false, cct),
-	  pqueue(max_tok_per_prio, min_cost) {}
+	  sdata_op_ordering_lock(ordering_lock.c_str(), false, true, false, cct) {
+	    if (opqueue == weightedpriority) {
+	      pqueue = std::unique_ptr
+		<WeightedPriorityQueue< pair<PGRef, PGQueueable>, entity_inst_t>>(
+		  new WeightedPriorityQueue< pair<PGRef, PGQueueable>, entity_inst_t>(
+		    max_tok_per_prio, min_cost));
+	    } else if (opqueue == prioritized) {
+	      pqueue = std::unique_ptr
+		<PrioritizedQueue< pair<PGRef, PGQueueable>, entity_inst_t>>(
+		  new PrioritizedQueue< pair<PGRef, PGQueueable>, entity_inst_t>(
+		    max_tok_per_prio, min_cost));
+	    }
+	  }
     };
     
     vector<ShardData*> shard_list;
@@ -1653,7 +1672,7 @@ private:
 	ShardData* one_shard = new ShardData(
 	  lock_name, order_lock,
 	  osd->cct->_conf->osd_op_pq_max_tokens_per_priority, 
-	  osd->cct->_conf->osd_op_pq_min_cost, osd->cct);
+	  osd->cct->_conf->osd_op_pq_min_cost, osd->cct, osd->op_queue);
 	shard_list.push_back(one_shard);
       }
     }
@@ -1687,7 +1706,7 @@ private:
 	assert (NULL != sdata);
 	sdata->sdata_op_ordering_lock.Lock();
 	f->open_object_section(lock_name);
-	sdata->pqueue.dump(f);
+	sdata->pqueue->dump(f);
 	f->close_section();
 	sdata->sdata_op_ordering_lock.Unlock();
       }
@@ -1708,7 +1727,7 @@ private:
       sdata = shard_list[shard_index];
       assert(sdata != NULL);
       sdata->sdata_op_ordering_lock.Lock();
-      sdata->pqueue.remove_by_filter(Pred(pg));
+      sdata->pqueue->remove_by_filter(Pred(pg), 0);
       sdata->pg_for_processing.erase(pg);
       sdata->sdata_op_ordering_lock.Unlock();
     }
@@ -1722,7 +1741,7 @@ private:
       assert(dequeued);
       list<pair<PGRef, PGQueueable> > _dequeued;
       sdata->sdata_op_ordering_lock.Lock();
-      sdata->pqueue.remove_by_filter(Pred(pg), &_dequeued);
+      sdata->pqueue->remove_by_filter(Pred(pg), &_dequeued);
       for (list<pair<PGRef, PGQueueable> >::iterator i = _dequeued.begin();
 	   i != _dequeued.end(); ++i) {
 	boost::optional<OpRequestRef> mop = i->second.maybe_get_op();
@@ -1749,7 +1768,7 @@ private:
       ShardData* sdata = shard_list[shard_index];
       assert(NULL != sdata);
       Mutex::Locker l(sdata->sdata_op_ordering_lock);
-      return sdata->pqueue.empty();
+      return sdata->pqueue->empty();
     }
   } op_shardedwq;
 
@@ -2309,6 +2328,28 @@ protected:
   void ms_handle_fast_accept(Connection *con);
   bool ms_handle_reset(Connection *con);
   void ms_handle_remote_reset(Connection *con) {}
+
+  io_queue get_io_queue() const {
+    if (cct->_conf->osd_op_queue == "debug_random") {
+      srand(time(NULL));
+      return (rand() % 2 < 1) ? prioritized : weightedpriority;
+    } else if (cct->_conf->osd_op_queue == "wpq") {
+      return weightedpriority;
+    } else {
+      return prioritized;
+    }
+  }
+
+  unsigned int get_io_prio_cut() const {
+    if (cct->_conf->osd_op_queue_cut_off == "debug_random") {
+      srand(time(NULL));
+      return (rand() % 2 < 1) ? CEPH_MSG_PRIO_HIGH : CEPH_MSG_PRIO_LOW;
+    } else if (cct->_conf->osd_op_queue_cut_off == "low") {
+      return CEPH_MSG_PRIO_LOW;
+    } else {
+      return CEPH_MSG_PRIO_HIGH;
+    }
+  }
 
  public:
   /* internal and external can point to the same messenger, they will still

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -488,6 +488,18 @@ target_link_libraries(unittest_prioritized_queue global
 set_target_properties(unittest_prioritized_queue
   PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 
+# unittest_weighted_priority_queue
+add_executable(unittest_weighted_priority_queue EXCLUDE_FROM_ALL
+  common/test_weighted_priority_queue.cc
+  $<TARGET_OBJECTS:heap_profiler_objs>
+  )
+add_test(unittest_weighted_priority_queue unittest_weighted_priority_queue)
+add_dependencies(check unittest_weighted_priority_queue)
+target_link_libraries(unittest_weighted_priority_queue global
+  ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} ${TCMALLOC_LIBS} ${UNITTEST_LIBS})
+set_target_properties(unittest_weighted_priority_queue
+  PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
+
 # unittest_str_map
 add_executable(unittest_str_map EXCLUDE_FROM_ALL
   common/test_str_map.cc

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -168,6 +168,10 @@ unittest_prioritized_queue_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_prioritized_queue_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 check_TESTPROGRAMS += unittest_prioritized_queue
 
+unittest_weighted_priority_queue_SOURCES = test/common/test_weighted_priority_queue.cc
+unittest_weighted_priority_queue_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+unittest_weighted_priority_queue_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
+check_TESTPROGRAMS += unittest_weighted_priority_queue
 
 unittest_str_map_SOURCES = test/common/test_str_map.cc
 unittest_str_map_CXXFLAGS = $(UNITTEST_CXXFLAGS)

--- a/src/test/common/test_prioritized_queue.cc
+++ b/src/test/common/test_prioritized_queue.cc
@@ -6,7 +6,7 @@
 
 #include <numeric>
 #include <vector>
-
+#include <algorithm>
 
 using std::vector;
 
@@ -23,7 +23,7 @@ protected:
     for (int i = 0; i < item_size; i++) {
       items.push_back(Item(i));
     }
-    random_shuffle(items.begin(), items.end());
+    std::random_shuffle(items.begin(), items.end());
   }
   virtual void TearDown() {
     items.clear();

--- a/src/test/common/test_weighted_priority_queue.cc
+++ b/src/test/common/test_weighted_priority_queue.cc
@@ -1,0 +1,287 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "gtest/gtest.h"
+#include "common/Formatter.h"
+#include "common/WeightedPriorityQueue.h"
+
+#include <numeric>
+#include <vector>
+#include <map>
+#include <list>
+#include <tuple>
+
+#define CEPH_OP_CLASS_STRICT	0
+#define CEPH_OP_CLASS_NORMAL	0
+#define CEPH_OP_QUEUE_BACK	0
+#define CEPH_OP_QUEUE_FRONT	0
+
+class WeightedPriorityQueueTest : public testing::Test
+{
+protected:
+  typedef unsigned Klass;
+  // tuple<Prio, Klass, OpID> so that we can verfiy the op
+  typedef std::tuple<unsigned, unsigned, unsigned> Item;
+  typedef unsigned Prio;
+  typedef unsigned Kost;
+  typedef WeightedPriorityQueue<Item, Klass> WQ;
+  // Simulate queue structure
+  typedef std::list<std::pair<Kost, Item> > ItemList;
+  typedef std::map<Klass, ItemList> KlassItem;
+  typedef std::map<Prio, KlassItem> LQ;
+  typedef std::list<Item> Removed;
+  const unsigned max_prios = 5; // (0-4) * 64
+  const unsigned klasses = 37;  // Make prime to help get good coverage
+
+  void fill_queue(WQ &wq, LQ &strictq, LQ &normq,
+      unsigned item_size, bool randomize = false) {
+    unsigned p, k, c, o, op_queue, fob;
+    for (unsigned i = 1; i <= item_size; ++i) {
+      // Choose priority, class, cost and 'op' for this op.
+      if (randomize) {
+        p = (rand() % max_prios) * 64;
+        k = rand() % klasses;
+        c = rand() % (1<<22);  // 4M cost
+        // Make some of the costs 0, but make sure small costs
+        // still work ok.
+        if (c > (1<<19) && c < (1<<20)) {
+          c = 0;
+	}
+        op_queue = rand() % 10;
+        fob = rand() % 10;
+      } else {
+        p = (i % max_prios) * 64;
+        k = i % klasses;
+        c = (i % 8 == 0 || i % 16 == 0) ? 0 : 1 << (i % 23);
+        op_queue = i % 7; // Use prime numbers to
+        fob = i % 11;     // get better coverage
+      }
+      o = rand() % (1<<16);
+      // Choose how to enqueue this op.
+      switch (op_queue) {
+      case 6 :
+        // Strict Queue
+        if (fob == 4) {
+	  // Queue to the front.
+	  strictq[p][k].push_front(std::make_pair(
+  	    c, std::make_tuple(p, k, o)));
+	  wq.enqueue_strict_front(Klass(k), p, std::make_tuple(p, k, o));
+        } else {
+	  //Queue to the back.
+	  strictq[p][k].push_back(std::make_pair(
+	    c, std::make_tuple(p, k, o)));
+	  wq.enqueue_strict(Klass(k), p, std::make_tuple(p, k, o));
+        }
+        break;
+      default:
+        // Normal queue
+        if (fob == 4) {
+	  // Queue to the front.
+	  normq[p][k].push_front(std::make_pair(
+	    c, std::make_tuple(p, k, o)));
+	  wq.enqueue_front(Klass(k), p, c, std::make_tuple(p, k, o));
+        } else {
+	  //Queue to the back.
+	  normq[p][k].push_back(std::make_pair(
+	    c, std::make_tuple(p, k, o)));
+	  wq.enqueue(Klass(k), p, c, std::make_tuple(p, k, o));
+        }
+        break;
+      }
+    }
+  }
+  void test_queue(unsigned item_size, bool randomize = false) {
+    // Due to the WRR queue having a lot of probabilistic logic
+    // we can't determine the exact order OPs will be dequeued.
+    // However, the queue should not dequeue a priority out of
+    // order. It should also dequeue the strict priority queue
+    // first and in order. In both the strict and normal queues
+    // push front and back should be respected. Here we keep
+    // track of the ops queued and make sure they dequeue
+    // correctly.
+  
+    // Set up local tracking queues
+    WQ wq(0, 0);
+    LQ strictq, normq;
+    fill_queue(wq, strictq, normq, item_size, randomize);
+    // Test that the queue is dequeuing properly.
+    typedef std::map<unsigned, unsigned> LastKlass;
+    LastKlass last_strict, last_norm;
+    while (!(wq.empty())) {
+      Item r = wq.dequeue();
+      if (!(strictq.empty())) {
+        // Check that there are no higher priorities
+        // in the strict queue.
+        LQ::reverse_iterator ri = strictq.rbegin();
+        EXPECT_EQ(std::get<0>(r), ri->first);
+        // Check that if there are multiple classes in a priority
+        // that it is not dequeueing the same class each time.
+        LastKlass::iterator si = last_strict.find(std::get<0>(r));
+        if (strictq[std::get<0>(r)].size() > 1 && si != last_strict.end()) {
+	  EXPECT_NE(std::get<1>(r), si->second);
+	}
+        last_strict[std::get<0>(r)] = std::get<1>(r);
+
+	Item t = strictq[std::get<0>(r)][std::get<1>(r)].front().second;
+        EXPECT_EQ(std::get<2>(r), std::get<2>(t));
+        strictq[std::get<0>(r)][std::get<1>(r)].pop_front();
+        if (strictq[std::get<0>(r)][std::get<1>(r)].empty()) {
+	  strictq[std::get<0>(r)].erase(std::get<1>(r));
+	}
+        if (strictq[std::get<0>(r)].empty()) {
+	  strictq.erase(std::get<0>(r));
+	}
+      } else {
+        // Check that if there are multiple classes in a priority
+        // that it is not dequeueing the same class each time.
+        LastKlass::iterator si = last_norm.find(std::get<0>(r));
+        if (normq[std::get<0>(r)].size() > 1 && si != last_norm.end()) {
+	  EXPECT_NE(std::get<1>(r), si->second);
+	}
+        last_norm[std::get<0>(r)] = std::get<1>(r);
+
+	Item t = normq[std::get<0>(r)][std::get<1>(r)].front().second;
+        EXPECT_EQ(std::get<2>(r), std::get<2>(t));
+        normq[std::get<0>(r)][std::get<1>(r)].pop_front();
+        if (normq[std::get<0>(r)][std::get<1>(r)].empty()) {
+	  normq[std::get<0>(r)].erase(std::get<1>(r));
+	}
+        if (normq[std::get<0>(r)].empty()) {
+	  normq.erase(std::get<0>(r));
+	}
+      }
+    }
+  }
+
+  virtual void SetUp() {
+    srand(time(0));
+  }
+  virtual void TearDown() {
+  }
+};
+
+TEST_F(WeightedPriorityQueueTest, wpq_size){
+  WQ wq(0, 0);
+  EXPECT_TRUE(wq.empty());
+  EXPECT_EQ(0u, wq.length());
+
+  // Test the strict queue size.
+  for (unsigned i = 1; i < 5; ++i) {
+    wq.enqueue_strict(Klass(i),i, std::make_tuple(i, i, i));
+    EXPECT_FALSE(wq.empty());
+    EXPECT_EQ(i, wq.length());
+  }
+  // Test the normal queue size.
+  for (unsigned i = 5; i < 10; ++i) {
+    wq.enqueue(Klass(i), i, i, std::make_tuple(i, i, i));
+    EXPECT_FALSE(wq.empty());
+    EXPECT_EQ(i, wq.length());
+  }
+  // Test that as both queues are emptied
+  // the size is correct.
+  for (unsigned i = 8; i >0; --i) {
+    wq.dequeue();
+    EXPECT_FALSE(wq.empty());
+    EXPECT_EQ(i, wq.length());
+  }
+  wq.dequeue();
+  EXPECT_TRUE(wq.empty());
+  EXPECT_EQ(0u, wq.length());
+}
+
+TEST_F(WeightedPriorityQueueTest, wpq_test_static) {
+  test_queue(1000);
+} 
+
+TEST_F(WeightedPriorityQueueTest, wpq_test_random) {
+  test_queue(rand() % 500 + 500, true);
+} 
+
+template <typename T>
+struct Greater {
+  const T rhs;
+  Greater(const T &v) : rhs(v) {}
+  bool operator()(const T &lhs) const {
+    return std::get<2>(lhs) > std::get<2>(rhs);
+  }
+};
+
+TEST_F(WeightedPriorityQueueTest, wpq_test_remove_by_filter) {
+  WQ wq(0, 0);
+  LQ strictq, normq;
+  unsigned num_items = 1000;
+  fill_queue(wq, strictq, normq, num_items);
+  const Greater<Item> pred(std::make_tuple(0, 0, (1 << 16) - (1 << 16)/10));
+  Removed r_strictq, r_normq;
+  unsigned num_to_remove = 0;
+  // Figure out from what has been queued what we
+  // expect to be removed
+  for (LQ::iterator pi = strictq.begin();
+       pi != strictq.end(); ++pi) {
+    for (KlassItem::iterator ki = pi->second.begin();
+	 ki != pi->second.end(); ++ki) {
+      for (ItemList::iterator li = ki->second.begin();
+	   li != ki->second.end(); ++li) {
+	if (pred(li->second)) {
+	  ++num_to_remove;
+	}
+      }
+    }
+  }
+  for (LQ::iterator pi = normq.begin();
+       pi != normq.end(); ++pi) {
+    for (KlassItem::iterator ki = pi->second.begin();
+	 ki != pi->second.end(); ++ki) {
+      for (ItemList::iterator li = ki->second.begin();
+	   li != ki->second.end(); ++li) {
+	if (pred(li->second)) {
+	  ++num_to_remove;
+	}
+      }
+    }
+  }
+  Removed wq_removed;
+  wq.remove_by_filter(pred, &wq_removed);
+  // Check that what was removed was correct
+  for (Removed::iterator it = wq_removed.begin();
+       it != wq_removed.end(); ++it) {
+    EXPECT_TRUE(pred(*it));
+  }
+  EXPECT_EQ(num_to_remove, wq_removed.size());
+  EXPECT_EQ(num_items - num_to_remove, wq.length());
+  // Make sure that none were missed
+  while (!(wq.empty())) {
+    EXPECT_FALSE(pred(wq.dequeue()));
+  }
+}
+
+TEST_F(WeightedPriorityQueueTest, wpq_test_remove_by_class) {
+  WQ wq(0, 0);
+  LQ strictq, normq;
+  unsigned num_items = 1000;
+  fill_queue(wq, strictq, normq, num_items);
+  unsigned num_to_remove = 0;
+  const Klass k = 5;
+  // Find how many ops are in the class
+  for (LQ::iterator it = strictq.begin();
+       it != strictq.end(); ++it) {
+    num_to_remove += it->second[k].size();
+  }
+  for (LQ::iterator it = normq.begin();
+       it != normq.end(); ++it) {
+    num_to_remove += it->second[k].size();
+  }
+  Removed wq_removed;
+  wq.remove_by_class(k, &wq_removed);
+  // Check that the right ops were removed.
+  EXPECT_EQ(num_to_remove, wq_removed.size());
+  EXPECT_EQ(num_items - num_to_remove, wq.length());
+  for (Removed::iterator it = wq_removed.begin();
+       it != wq_removed.end(); ++it) {
+    EXPECT_EQ(k, std::get<1>(*it));
+  }
+  // Check that none were missed
+  while (!(wq.empty())) {
+    EXPECT_NE(k, std::get<1>(wq.dequeue()));
+  }
+}


### PR DESCRIPTION
This is an update from https://github.com/ceph/ceph/pull/6781 which resolves the issue with the performance degradation with SSDs. Now this queue is showing 3-17% performance improvement across [SSD,HDD] x [4K,4M] tests. The new algorithm is showing very similar enqueue/dequeue times as PrioritizedQueue or a little better. The OP distribution of Weighted Priority stays true in all cases; steady state, contention (more enqueue than dequeue), and relief (more dequeue than enqueue) where the PrioritizedQueue would favor high priority ops and starve all low priority ops during contention. The Weighted Priority Queue also responds well to skewed ops (high priority ops have low costs and low priority ops have high costs). Although, the number of Op deviate from the target dequeue, the costs lines up closely to the target distribution which I believe is one of the primary goals.

It may be possible to increase the performance of this queue by using intrusive containers, but since it performs with the same latency as the current queue and has tangible benefits, I want to get this in sooner than later.

Signed-off-by: Robert LeBlanc <robert.leblanc@endurance.com>