### PR TITLE
os: fix newstore: unused buffer in Onode attrs during recovery

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1906,6 +1906,15 @@ void ReplicatedBackend::handle_push(
   bool complete = pop.after_progress.data_complete &&
     pop.after_progress.omap_complete;
 
+  if (first) {
+    // attrs only reference the origin bufferlist (decode from MOSDPGPush message)
+    // whose size is much greater than attrs in recovery. Onode in BlueStore will cache it
+    for (map<string, bufferlist>::iterator it = pop.attrset.begin();
+         it != pop.attrset.end();
+         ++it) {
+      it->second.rebuild();
+    }    
+  }
   response->soid = pop.recovery_info.soid;
   submit_push_data(pop.recovery_info,
 		   first,


### PR DESCRIPTION
Please refer to https://github.com/ceph/ceph/pull/5451
Onode in (BlueStore)Newstore would be the same situation
Onode caches attrs during recovery, which also caches data bufferlist

The issue may just related to BlueStore, the alternative is to fix it in BlueStore::transaction SETATTRS. Which one is preferable. I think the current one is more generic.

@liewegas , It would be really hard for us to find out those kind of memory leak when dealing with the issue  https://github.com/ceph/ceph/pull/5451. In order to prevent those kind of bugs, is any approaches, like adding some unittest case, to prevent this?

Signed-off-by: Ning Yao <zay11022@gmail.com>