### PR TITLE
Wip 13862

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2571,7 +2571,8 @@ void OSD::clear_temp_objects()
 	break;
       vector<ghobject_t>::iterator q;
       for (q = objects.begin(); q != objects.end(); ++q) {
-	if (q->hobj.is_temp()) {
+	// Hammer set pool for temps to -1, so check for clean-up
+	if (q->hobj.is_temp() || (q->hobj.pool == -1)) {
 	  temps.push_back(*q);
 	} else {
 	  break;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3994,6 +3994,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	}
 
         scrubber.start = hobject_t();
+        // Don't include temporary objects when scrubbing
+        scrubber.start.pool = info.pgid.pool();
         scrubber.state = PG::Scrubber::NEW_CHUNK;
 
 	{

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -571,10 +571,9 @@ void PGBackend::be_compare_scrubmaps(
       be_select_auth_object(*k, maps, okseed, &auth_oi);
     list<pg_shard_t> auth_list;
     if (auth == maps.end()) {
-      dout(10) << __func__ << ": unable to find any auth object" << dendl;
       ++shallow_errors;
-      errorstream << pgid << " shard " << j->first
-		  << ": soid failed to pick suitable auth object\n";
+      errorstream << pgid.pgid << " soid " << *k
+		  << ": failed to pick suitable auth object\n";
       continue;
     }
     auth_list.push_back(auth->first);


### PR DESCRIPTION
Various scrub fixes:
    Fix 13862 by removing old Hammer temp objects.
   Clean up a log message.
   Skip temporary objects on both primary and replicas.