### PR TITLE
rbd: fix static initialization ordering issues

### DIFF
--- a/src/tools/rbd/Shell.h
+++ b/src/tools/rbd/Shell.h
@@ -36,22 +36,22 @@ public:
         : command_spec(command_spec), alias_command_spec(alias_command_spec),
           description(description), help(help), get_arguments(args),
           execute(execute) {
-      Shell::s_actions.push_back(this);
+      Shell::get_actions().push_back(this);
     }
 
   };
 
   struct SwitchArguments {
     SwitchArguments(const std::initializer_list<std::string> &arguments) {
-      Shell::s_switch_arguments.insert(arguments.begin(), arguments.end());
+      Shell::get_switch_arguments().insert(arguments.begin(), arguments.end());
     }
   };
 
   int execute(int arg_count, const char **arg_values);
 
 private:
-  static std::vector<Action *> s_actions;
-  static std::set<std::string> s_switch_arguments;
+  static std::vector<Action *>& get_actions();
+  static std::set<std::string>& get_switch_arguments();
 
   void get_command_spec(const std::vector<std::string> &arguments,
                         std::vector<std::string> *command_spec);


### PR DESCRIPTION
The order in which static objects in different compilation units are
initialized is undefined. Use static functions as a workaround.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>