### PR TITLE
librbd: uninitialized state in snap remove state machine

### DIFF
--- a/src/librbd/operation/SnapshotRemoveRequest.cc
+++ b/src/librbd/operation/SnapshotRemoveRequest.cc
@@ -34,6 +34,9 @@ std::ostream& operator<<(std::ostream& os,
   case SnapshotRemoveRequest<I>::STATE_RELEASE_SNAP_ID:
     os << "RELEASE_SNAP_ID";
     break;
+  case SnapshotRemoveRequest<I>::STATE_ERROR:
+    os << "STATE_ERROR";
+    break;
   default:
     os << "UNKNOWN (" << static_cast<uint32_t>(state) << ")";
     break;
@@ -127,6 +130,8 @@ void SnapshotRemoveRequest<I>::send_remove_child() {
     int r = image_ctx.get_parent_spec(m_snap_id, &our_pspec);
     if (r < 0) {
       lderr(cct) << "failed to retrieve parent spec" << dendl;
+      m_state = STATE_ERROR;
+
       this->async_complete(r);
       return;
     }

--- a/src/librbd/operation/SnapshotRemoveRequest.h
+++ b/src/librbd/operation/SnapshotRemoveRequest.h
@@ -52,7 +52,8 @@ public:
     STATE_REMOVE_OBJECT_MAP,
     STATE_REMOVE_CHILD,
     STATE_REMOVE_SNAP,
-    STATE_RELEASE_SNAP_ID
+    STATE_RELEASE_SNAP_ID,
+    STATE_ERROR
   };
 
   SnapshotRemoveRequest(ImageCtxT &image_ctx, Context *on_finish,


### PR DESCRIPTION
Signed-off-by: Jason Dillaman <dillaman@redhat.com>