### PR TITLE
rgw: Fixes after WIP 5073 Multi-Tenancy

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -69,15 +69,22 @@ string rgw_make_bucket_entry_name(const string& tenant_name, const string& bucke
  * Tenants are separated from buckets in URLs by a colon in S3.
  * This function is not to be used on Swift URLs, not even for COPY arguments.
  */
-void rgw_parse_url_bucket(const string &bucket,
+void rgw_parse_url_bucket(const string &bucket, const string& auth_tenant,
                           string &tenant_name, string &bucket_name) {
+
   int pos = bucket.find(':');
   if (pos >= 0) {
+    /*
+     * N.B.: We allow ":bucket" syntax with explicit empty tenant in order
+     * to refer to the legacy tenant, in case users in new named tenants
+     * want to access old global buckets.
+     */
     tenant_name = bucket.substr(0, pos);
+    bucket_name = bucket.substr(pos + 1);
   } else {
-    tenant_name.clear();
+    tenant_name = auth_tenant;
+    bucket_name = bucket;
   }
-  bucket_name = bucket.substr(pos + 1);
 }
 
 /**

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -49,7 +49,8 @@ extern void rgw_make_bucket_entry_name(const string& tenant_name,
                                        string& bucket_entry);
 extern string rgw_make_bucket_entry_name(const string& tenant_name,
                                        const string& bucket_name);
-extern void rgw_parse_url_bucket(const string &bucket,
+extern void rgw_parse_url_bucket(const string& bucket,
+                                 const string& auth_tenant,
                                  string &tenant_name, string &bucket_name);
 
 /**

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -175,6 +175,8 @@ req_state::req_state(CephContext *_cct, class RGWEnv *e) : cct(_cct), cio(NULL),
   local_source = false;
 
   obj_ctx = NULL;
+
+  init_state.s = this;
 }
 
 req_state::~req_state() {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1052,7 +1052,9 @@ struct req_state {
    uint32_t perm_mask;
    utime_t header_time;
 
-   /* Set once when req_state is initialized and not violated thereafter */
+   /* Keeps [[tenant]:]bucket until we parse the token. Don't use elsewhere. */
+   string url_bucket;
+   /* Set once when url_bucket is parsed and not violated thereafter. */
    string bucket_tenant;
    string bucket_name;
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1029,6 +1029,14 @@ inline ostream& operator<<(ostream& out, const rgw_obj_key &o) {
   }
 }
 
+struct req_init_state {
+  struct req_state *s;
+
+  /* Keeps [[tenant]:]bucket until we parse the token. */
+  string url_bucket;
+  string src_bucket;
+};
+
 /** Store all the state necessary to complete and respond to an HTTP request*/
 struct req_state {
    CephContext *cct;
@@ -1052,8 +1060,6 @@ struct req_state {
    uint32_t perm_mask;
    utime_t header_time;
 
-   /* Keeps [[tenant]:]bucket until we parse the token. Don't use elsewhere. */
-   string url_bucket;
    /* Set once when url_bucket is parsed and not violated thereafter. */
    string bucket_tenant;
    string bucket_name;
@@ -1103,6 +1109,7 @@ struct req_state {
    string trans_id;
 
    req_info info;
+   req_init_state init_state; /* don't access this as s->init_state ever */
 
    req_state(CephContext *_cct, class RGWEnv *e);
    ~req_state();

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -552,6 +552,7 @@ static int process_request(RGWRados *store, RGWREST *rest, RGWRequest *req, RGWC
   struct req_state rstate(g_ceph_context, &rgw_env);
 
   struct req_state *s = &rstate;
+  struct req_init_state *t = &rstate.init_state;
 
   RGWObjectCtx rados_ctx(store, s);
   s->obj_ctx = &rados_ctx;
@@ -565,7 +566,7 @@ static int process_request(RGWRados *store, RGWREST *rest, RGWRequest *req, RGWC
   int init_error = 0;
   bool should_log = false;
   RGWRESTMgr *mgr;
-  RGWHandler *handler = rest->get_handler(store, s, client_io, &mgr, &init_error);
+  RGWHandler *handler = rest->get_handler(store, t, client_io, &mgr, &init_error);
   if (init_error != 0) {
     abort_early(s, NULL, init_error);
     goto done;
@@ -590,7 +591,7 @@ static int process_request(RGWRados *store, RGWREST *rest, RGWRequest *req, RGWC
   }
 
   req->log(s, "normalizing buckets and tenants");
-  ret = handler->postauth_init();
+  ret = handler->postauth_init(t);
   if (ret < 0) {
     dout(10) << "failed to run post-auth init" << dendl;
     abort_early(s, op, ret);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4275,10 +4275,10 @@ RGWHandler::~RGWHandler()
 {
 }
 
-int RGWHandler::init(RGWRados *_store, struct req_state *_s, RGWClientIO *cio)
+int RGWHandler::init(RGWRados *_store, struct req_init_state *t, RGWClientIO *cio)
 {
   store = _store;
-  s = _s;
+  s = t->s; /* XXX need to get rid of this, too implicit in get_op() */
 
   return 0;
 }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1303,6 +1303,7 @@ public:
   virtual void put_op(RGWOp *op);
   virtual int read_permissions(RGWOp *op) = 0;
   virtual int authorize() = 0;
+  virtual int postauth_init() = 0;
 };
 
 #endif

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1297,13 +1297,13 @@ protected:
 public:
   RGWHandler() : store(NULL), s(NULL) {}
   virtual ~RGWHandler();
-  virtual int init(RGWRados *store, struct req_state *_s, RGWClientIO *cio);
+  virtual int init(RGWRados *store, struct req_init_state *t, RGWClientIO *cio);
 
   virtual RGWOp *get_op(RGWRados *store);
   virtual void put_op(RGWOp *op);
   virtual int read_permissions(RGWOp *op) = 0;
   virtual int authorize() = 0;
-  virtual int postauth_init() = 0;
+  virtual int postauth_init(struct req_init_state *t) = 0;
 };
 
 #endif

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1546,9 +1546,10 @@ int RGWREST::preprocess(struct req_state *s, RGWClientIO *cio)
   return 0;
 }
 
-RGWHandler *RGWREST::get_handler(RGWRados *store, struct req_state *s, RGWClientIO *cio,
+RGWHandler *RGWREST::get_handler(RGWRados *store, struct req_init_state *t, RGWClientIO *cio,
 				 RGWRESTMgr **pmgr, int *init_error)
 {
+  struct req_state *s = t->s;
   RGWHandler *handler;
 
   *init_error = preprocess(s, cio);
@@ -1564,12 +1565,12 @@ RGWHandler *RGWREST::get_handler(RGWRados *store, struct req_state *s, RGWClient
   if (pmgr)
     *pmgr = m;
 
-  handler = m->get_handler(s);
+  handler = m->get_handler(t);
   if (!handler) {
     *init_error = -ERR_METHOD_NOT_ALLOWED;
     return NULL;
   }
-  *init_error = handler->init(store, s, cio);
+  *init_error = handler->init(store, t, cio);
   if (*init_error < 0) {
     m->put_handler(handler);
     return NULL;

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -350,6 +350,7 @@ public:
   int read_permissions(RGWOp *op);
 
   virtual int authorize() = 0;
+  // virtual int postauth_init(struct req_init_state *t) = 0;
 };
 
 class RGWHandler_ObjStore_SWIFT;
@@ -371,7 +372,7 @@ public:
   void register_default_mgr(RGWRESTMgr *mgr);
 
   virtual RGWRESTMgr *get_resource_mgr(struct req_state *s, const string& uri, string *out_uri);
-  virtual RGWHandler *get_handler(struct req_state *s) { return NULL; }
+  virtual RGWHandler *get_handler(struct req_init_state *t) { return NULL; }
   virtual void put_handler(RGWHandler *handler) { delete handler; }
 
   void set_logging(bool _should_log) { should_log = _should_log; }
@@ -384,7 +385,7 @@ class RGWREST {
   static int preprocess(struct req_state *s, RGWClientIO *cio);
 public:
   RGWREST() {}
-  RGWHandler *get_handler(RGWRados *store, struct req_state *s, RGWClientIO *cio,
+  RGWHandler *get_handler(RGWRados *store, struct req_init_state *t, RGWClientIO *cio,
 			  RGWRESTMgr **pmgr, int *init_error);
   void put_handler(RGWHandler *handler) {
     mgr.put_handler(handler);

--- a/src/rgw/rgw_rest_bucket.h
+++ b/src/rgw/rgw_rest_bucket.h
@@ -28,7 +28,7 @@ public:
   RGWRESTMgr_Bucket() {}
   virtual ~RGWRESTMgr_Bucket() {}
 
-  RGWHandler *get_handler(struct req_state *s) {
+  RGWHandler *get_handler(struct req_init_state *t) {
     return new RGWHandler_Bucket;
   }
 };

--- a/src/rgw/rgw_rest_config.h
+++ b/src/rgw/rgw_rest_config.h
@@ -47,7 +47,7 @@ public:
   RGWRESTMgr_Config() {}
   virtual ~RGWRESTMgr_Config() {}
 
-  virtual RGWHandler *get_handler(struct req_state *s){
+  virtual RGWHandler *get_handler(struct req_init_state *t){
     return new RGWHandler_Config;
   }
 };

--- a/src/rgw/rgw_rest_log.h
+++ b/src/rgw/rgw_rest_log.h
@@ -293,7 +293,7 @@ public:
   RGWRESTMgr_Log() {}
   virtual ~RGWRESTMgr_Log() {}
 
-  virtual RGWHandler *get_handler(struct req_state *s){
+  virtual RGWHandler *get_handler(struct req_init_state *t){
     return new RGWHandler_Log;
   }
 };

--- a/src/rgw/rgw_rest_metadata.h
+++ b/src/rgw/rgw_rest_metadata.h
@@ -114,7 +114,7 @@ public:
   RGWRESTMgr_Metadata() {}
   virtual ~RGWRESTMgr_Metadata() {}
 
-  virtual RGWHandler *get_handler(struct req_state *s){
+  virtual RGWHandler *get_handler(struct req_init_state *t){
     return new RGWHandler_Metadata;
   }
 };

--- a/src/rgw/rgw_rest_opstate.h
+++ b/src/rgw/rgw_rest_opstate.h
@@ -100,7 +100,7 @@ public:
   RGWRESTMgr_Opstate() {}
   virtual ~RGWRESTMgr_Opstate() {}
 
-  virtual RGWHandler *get_handler(struct req_state *s){
+  virtual RGWHandler *get_handler(struct req_init_state *t){
     return new RGWHandler_Opstate;
   }
 };

--- a/src/rgw/rgw_rest_replica_log.h
+++ b/src/rgw/rgw_rest_replica_log.h
@@ -146,7 +146,7 @@ public:
   RGWRESTMgr_ReplicaLog() {}
   virtual ~RGWRESTMgr_ReplicaLog() {}
 
-  virtual RGWHandler *get_handler(struct req_state *s){
+  virtual RGWHandler *get_handler(struct req_init_state *t){
     return new RGWHandler_ReplicaLog;
   }
 };

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2206,7 +2206,7 @@ RGWOp *RGWHandler_ObjStore_Obj_S3::op_put()
   if (is_acl_op()) {
     return new RGWPutACLs_ObjStore_S3;
   }
-  if (s->src_bucket_name.empty())
+  if (s->init_state.src_bucket.empty())  /* XXX aaaargh */
     return new RGWPutObj_ObjStore_S3;
   else
     return new RGWCopyObj_ObjStore_S3;
@@ -2238,8 +2238,10 @@ RGWOp *RGWHandler_ObjStore_Obj_S3::op_options()
   return new RGWOptionsCORS_ObjStore_S3;
 }
 
-int RGWHandler_ObjStore_S3::init_from_header(struct req_state *s, int default_formatter, bool configurable_format)
+int RGWHandler_ObjStore_S3::init_from_header(struct req_init_state *t, int default_formatter, bool configurable_format)
 {
+  struct req_state *s = t->s;
+
   string req;
   string first;
 
@@ -2286,8 +2288,8 @@ int RGWHandler_ObjStore_S3::init_from_header(struct req_state *s, int default_fo
    * the bucket (and its tenant) from DNS and Host: header (HTTP_HOST)
    * into req_status.bucket_name directly.
    */
-  if (s->url_bucket.empty()) {
-    s->url_bucket = first;  /* Save bucket to tide us over until token is parsed. */
+  if (t->url_bucket.empty()) {
+    t->url_bucket = first;  /* Save bucket to tide us over until token is parsed. */
 
     if (pos >= 0) {
       string encoded_obj_str = req.substr(pos+1);
@@ -2299,11 +2301,12 @@ int RGWHandler_ObjStore_S3::init_from_header(struct req_state *s, int default_fo
   return 0;
 }
 
-int RGWHandler_ObjStore_S3::postauth_init()
+int RGWHandler_ObjStore_S3::postauth_init(struct req_init_state *t)
 {
+  struct req_state *s = t->s;
+  bool relaxed_names = s->cct->_conf->rgw_relaxed_s3_bucket_names;
 
-  rgw_parse_url_bucket(s->url_bucket, s->user.user_id.tenant, s->bucket_tenant, s->bucket_name);
-  /* please don't use url_bucket after this point no matter how tempting */
+  rgw_parse_url_bucket(t->url_bucket, s->user.user_id.tenant, s->bucket_tenant, s->bucket_name);
 
   dout(10) << "s->object=" << (!s->object.empty() ? s->object : rgw_obj_key("<NULL>"))
            << " s->bucket=" << rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name) << dendl;
@@ -2312,13 +2315,22 @@ int RGWHandler_ObjStore_S3::postauth_init()
   ret = validate_tenant_name(s->bucket_tenant);
   if (ret)
     return ret;
-  bool relaxed_names = s->cct->_conf->rgw_relaxed_s3_bucket_names;
   ret = validate_bucket_name(s->bucket_name, relaxed_names);
   if (ret)
     return ret;
   ret = validate_object_name(s->object.name);
   if (ret)
     return ret;
+
+  if (!t->src_bucket.empty()) {
+    rgw_parse_url_bucket(t->src_bucket, s->user.user_id.tenant, s->src_tenant_name, s->src_bucket_name);
+    ret = validate_tenant_name(s->src_tenant_name);
+    if (ret)
+      return ret;
+    ret = validate_bucket_name(s->src_bucket_name, relaxed_names);
+    if (ret)
+      return ret;
+  }
   return 0;
 }
 
@@ -2380,9 +2392,12 @@ int RGWHandler_ObjStore_S3::validate_bucket_name(const string& bucket, bool rela
   return 0;
 }
 
-int RGWHandler_ObjStore_S3::init(RGWRados *store, struct req_state *s, RGWClientIO *cio)
+int RGWHandler_ObjStore_S3::init(RGWRados *store, struct req_init_state *t, RGWClientIO *cio)
 {
+  struct req_state *s = t->s;
   int ret;
+
+  s->dialect = "s3";
 
   const char *cacl = s->info.env->get("HTTP_X_AMZ_ACL");
   if (cacl)
@@ -2392,19 +2407,14 @@ int RGWHandler_ObjStore_S3::init(RGWRados *store, struct req_state *s, RGWClient
 
   const char *copy_source = s->info.env->get("HTTP_X_AMZ_COPY_SOURCE");
   if (copy_source) {
-    string src_bucket_str;
-    ret = RGWCopyObj::parse_copy_location(copy_source, src_bucket_str, s->src_object);
+    ret = RGWCopyObj::parse_copy_location(copy_source, t->src_bucket, s->src_object);
     if (!ret) {
       ldout(s->cct, 0) << "failed to parse copy location" << dendl;
       return -EINVAL; // XXX why not -ERR_INVALID_BUCKET_NAME or -ERR_BAD_URL?
     }
-    rgw_parse_url_bucket(src_bucket_str, s->user.user_id.tenant, s->src_tenant_name, s->src_bucket_name);
-    /* XXX oops, we use user_id prematurely here too */
   }
 
-  s->dialect = "s3";
-
-  return RGWHandler_ObjStore::init(store, s, cio);
+  return RGWHandler_ObjStore::init(store, t, cio);
 }
 
 
@@ -2662,22 +2672,24 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
   return  0;
 }
 
-int RGWHandler_Auth_S3::init(RGWRados *store, struct req_state *state, RGWClientIO *cio)
+int RGWHandler_Auth_S3::init(RGWRados *store, struct req_init_state *t, RGWClientIO *cio)
 {
-  int ret = RGWHandler_ObjStore_S3::init_from_header(state, RGW_FORMAT_JSON, true);
+  int ret = RGWHandler_ObjStore_S3::init_from_header(t, RGW_FORMAT_JSON, true);
   if (ret < 0)
     return ret;
 
-  return RGWHandler_ObjStore::init(store, state, cio);
+  return RGWHandler_ObjStore::init(store, t, cio);
 }
 
-RGWHandler *RGWRESTMgr_S3::get_handler(struct req_state *s)
+RGWHandler *RGWRESTMgr_S3::get_handler(struct req_init_state *t)
 {
-  int ret = RGWHandler_ObjStore_S3::init_from_header(s, RGW_FORMAT_XML, false);
+  struct req_state *s = t->s;
+
+  int ret = RGWHandler_ObjStore_S3::init_from_header(t, RGW_FORMAT_XML, false);
   if (ret < 0)
     return NULL;
 
-  if (s->url_bucket.empty())
+  if (t->url_bucket.empty())
     return new RGWHandler_ObjStore_Service_S3;
 
   if (s->object.empty())

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -375,17 +375,17 @@ public:
 
   virtual int validate_object_name(const string& bucket) { return 0; }
 
-  virtual int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
+  virtual int init(RGWRados *store, struct req_init_state *t, RGWClientIO *cio);
   virtual int authorize() {
     return RGW_Auth_S3::authorize(store, s);
   }
-  int postauth_init() { return 0; }
+  int postauth_init(struct req_init_state *t) { return 0; }
 };
 
 class RGWHandler_ObjStore_S3 : public RGWHandler_ObjStore {
   friend class RGWRESTMgr_S3;
 public:
-  static int init_from_header(struct req_state *s, int default_formatter, bool configurable_format);
+  static int init_from_header(struct req_init_state *t, int default_formatter, bool configurable_format);
 
   RGWHandler_ObjStore_S3() : RGWHandler_ObjStore() {}
   virtual ~RGWHandler_ObjStore_S3() {}
@@ -393,11 +393,11 @@ public:
   int validate_bucket_name(const string& bucket, bool relaxed_names);
   using RGWHandler_ObjStore::validate_bucket_name;
   
-  virtual int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
+  virtual int init(RGWRados *store, struct req_init_state *t, RGWClientIO *cio);
   virtual int authorize() {
     return RGW_Auth_S3::authorize(store, s);
   }
-  int postauth_init();
+  int postauth_init(struct req_init_state *t);
 };
 
 class RGWHandler_ObjStore_Service_S3 : public RGWHandler_ObjStore_S3 {
@@ -465,7 +465,7 @@ public:
   RGWRESTMgr_S3() {}
   virtual ~RGWRESTMgr_S3() {}
 
-  virtual RGWHandler *get_handler(struct req_state *s);
+  virtual RGWHandler *get_handler(struct req_init_state *t);
 };
 
 

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -379,6 +379,7 @@ public:
   virtual int authorize() {
     return RGW_Auth_S3::authorize(store, s);
   }
+  int postauth_init() { return 0; }
 };
 
 class RGWHandler_ObjStore_S3 : public RGWHandler_ObjStore {
@@ -396,6 +397,7 @@ public:
   virtual int authorize() {
     return RGW_Auth_S3::authorize(store, s);
   }
+  int postauth_init();
 };
 
 class RGWHandler_ObjStore_Service_S3 : public RGWHandler_ObjStore_S3 {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -892,7 +892,6 @@ int RGWCopyObj_ObjStore_SWIFT::get_params()
   if_match = s->info.env->get("HTTP_COPY_IF_MATCH");
   if_nomatch = s->info.env->get("HTTP_COPY_IF_NONE_MATCH");
 
-  /* XXX why copy this? just use req_state in rgw_op.cc:verify_permission */
   src_tenant_name = s->src_tenant_name;
   src_bucket_name = s->src_bucket_name;
   src_object = s->src_object;
@@ -1230,7 +1229,7 @@ RGWOp *RGWHandler_ObjStore_Obj_SWIFT::op_put()
   if (is_acl_op()) {
     return new RGWPutACLs_ObjStore_SWIFT;
   }
-  if (s->src_bucket_name.empty())
+  if (s->init_state.src_bucket.empty()) /* XXX aargh, using init_state */
     return new RGWPutObj_ObjStore_SWIFT;
   else
     return new RGWCopyObj_ObjStore_SWIFT;
@@ -1273,12 +1272,13 @@ int RGWHandler_ObjStore_SWIFT::authorize()
   return 0;
 }
 
-int RGWHandler_ObjStore_SWIFT::postauth_init()
+int RGWHandler_ObjStore_SWIFT::postauth_init(struct req_init_state *t)
 {
+  struct req_state *s = t->s;
 
   /* XXX Stub this until Swift Auth sets account into URL. */
   s->bucket_tenant = s->user.user_id.tenant;
-  s->bucket_name = s->url_bucket;
+  s->bucket_name = t->url_bucket;
 
   dout(10) << "s->object=" << (!s->object.empty() ? s->object : rgw_obj_key("<NULL>"))
            << " s->bucket=" << rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name) << dendl;
@@ -1293,6 +1293,24 @@ int RGWHandler_ObjStore_SWIFT::postauth_init()
   ret = validate_object_name(s->object.name);
   if (ret)
     return ret;
+
+  if (!t->src_bucket.empty()) {
+    /*
+     * We don't allow cross-tenant copy at present. It requires account
+     * names in the URL for Swift.
+     */
+    s->src_tenant_name = s->user.user_id.tenant;
+    s->src_bucket_name = t->src_bucket;
+
+    ret = validate_bucket_name(s->src_bucket_name);
+    if (ret < 0) {
+      return ret;
+    }
+    ret = validate_object_name(s->src_object.name);
+    if (ret < 0) {
+      return ret;
+    }
+  }
 
   return 0;
 }
@@ -1340,8 +1358,9 @@ static void next_tok(string& str, string& tok, char delim)
   }
 }
 
-int RGWHandler_ObjStore_SWIFT::init_from_header(struct req_state *s)
+int RGWHandler_ObjStore_SWIFT::init_from_header(struct req_init_state *t)
 {
+  struct req_state *s = t->s;
   string req;
   string first;
 
@@ -1422,7 +1441,7 @@ int RGWHandler_ObjStore_SWIFT::init_from_header(struct req_state *s)
 
   s->info.effective_uri = "/" + first;
 
-  s->url_bucket = first;  /* Save bucket to tide us over until token is parsed. */
+  t->url_bucket = first;  /* Save bucket to tide us over until token is parsed. */
 
   if (req.size()) {
     s->object = rgw_obj_key(req, s->info.env->get("HTTP_X_OBJECT_VERSION_ID", "")); /* rgw swift extension */
@@ -1432,65 +1451,53 @@ int RGWHandler_ObjStore_SWIFT::init_from_header(struct req_state *s)
   return 0;
 }
 
-int RGWHandler_ObjStore_SWIFT::init(RGWRados *store, struct req_state *s, RGWClientIO *cio)
+int RGWHandler_ObjStore_SWIFT::init(RGWRados *store, struct req_init_state *t, RGWClientIO *cio)
 {
-  int ret;
+  struct req_state *s = t->s;
+
+  s->dialect = "swift";
 
   const char *copy_source = s->info.env->get("HTTP_X_COPY_FROM");
   if (copy_source) {
-    bool result = RGWCopyObj::parse_copy_location(copy_source, s->src_bucket_name, s->src_object);
+    bool result = RGWCopyObj::parse_copy_location(copy_source, t->src_bucket, s->src_object);
     if (!result)
        return -ERR_BAD_URL;
-    s->src_tenant_name = s->user.user_id.tenant;
-    /* XXX oops, we use user_id prematurely here too */
   }
-
-  s->dialect = "swift";
 
   if (s->op == OP_COPY) {
     const char *req_dest = s->info.env->get("HTTP_DESTINATION");
     if (!req_dest)
       return -ERR_BAD_URL;
 
-    string dest_tenant_name, dest_bucket_name;
+    string dest_bucket_name;
     rgw_obj_key dest_obj_key;
     bool result = RGWCopyObj::parse_copy_location(req_dest, dest_bucket_name, dest_obj_key);
     if (!result)
        return -ERR_BAD_URL;
-    dest_tenant_name = s->user.user_id.tenant; /* XXX not available yet */
 
     string dest_object = dest_obj_key.name;
-    if (dest_bucket_name != s->bucket_name) {
-      ret = validate_bucket_name(dest_bucket_name);
-      if (ret < 0)
-        return ret;
-    }
-
-    ret = validate_tenant_name(dest_tenant_name);
-    if (ret < 0)
-      return ret;
 
     /* convert COPY operation into PUT */
-    s->src_tenant_name = s->bucket_tenant;
-    s->src_bucket_name = s->bucket_name;
+    t->src_bucket = t->url_bucket;
     s->src_object = s->object;
-    s->bucket_tenant = dest_tenant_name;
-    s->bucket_name = dest_bucket_name;
+    t->url_bucket = dest_bucket_name;
     s->object = rgw_obj_key(dest_object);
     s->op = OP_PUT;
   }
 
-  return RGWHandler_ObjStore::init(store, s, cio);
+  return RGWHandler_ObjStore::init(store, t, cio);
 }
 
 
-RGWHandler *RGWRESTMgr_SWIFT::get_handler(struct req_state *s)
+RGWHandler *RGWRESTMgr_SWIFT::get_handler(struct req_init_state *t)
 {
-  int ret = RGWHandler_ObjStore_SWIFT::init_from_header(s);
+  struct req_state *s = t->s;
+
+  int ret = RGWHandler_ObjStore_SWIFT::init_from_header(t);
   if (ret < 0)
     return NULL;
 
-  if (s->url_bucket.empty())
+  if (t->url_bucket.empty())
     return new RGWHandler_ObjStore_Service_SWIFT;
 
   if (s->object.empty())

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -194,6 +194,7 @@ public:
 
   int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
   int authorize();
+  int postauth_init();
 
   RGWAccessControlPolicy *alloc_policy() { return NULL; /* return new RGWAccessControlPolicy_SWIFT; */ }
   void free_policy(RGWAccessControlPolicy *policy) { delete policy; }

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -185,16 +185,16 @@ protected:
     return false;
   }
 
-  static int init_from_header(struct req_state *s);
+  static int init_from_header(struct req_init_state *t);
 public:
   RGWHandler_ObjStore_SWIFT() {}
   virtual ~RGWHandler_ObjStore_SWIFT() {}
 
   int validate_bucket_name(const string& bucket);
 
-  int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
+  int init(RGWRados *store, struct req_init_state *t, RGWClientIO *cio);
   int authorize();
-  int postauth_init();
+  int postauth_init(struct req_init_state *t);
 
   RGWAccessControlPolicy *alloc_policy() { return NULL; /* return new RGWAccessControlPolicy_SWIFT; */ }
   void free_policy(RGWAccessControlPolicy *policy) { delete policy; }
@@ -253,7 +253,7 @@ public:
   RGWRESTMgr_SWIFT() {}
   virtual ~RGWRESTMgr_SWIFT() {}
 
-  virtual RGWHandler *get_handler(struct req_state *s);
+  virtual RGWHandler *get_handler(struct req_init_state *t);
 };
 
 #endif

--- a/src/rgw/rgw_rest_usage.h
+++ b/src/rgw/rgw_rest_usage.h
@@ -26,7 +26,7 @@ public:
   RGWRESTMgr_Usage() {}
   virtual ~RGWRESTMgr_Usage() {}
 
-  RGWHandler *get_handler(struct req_state *s) {
+  RGWHandler *get_handler(struct req_init_state *t) {
     return new RGWHandler_Usage;
   }
 };

--- a/src/rgw/rgw_rest_user.h
+++ b/src/rgw/rgw_rest_user.h
@@ -28,7 +28,7 @@ public:
   RGWRESTMgr_User() {}
   virtual ~RGWRESTMgr_User() {}
 
-  RGWHandler *get_handler(struct req_state *s) {
+  RGWHandler *get_handler(struct req_init_state *t) {
     return new RGWHandler_User;
   }
 };

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -231,13 +231,14 @@ done:
   end_header(s);
 }
 
-int RGWHandler_SWIFT_Auth::init(RGWRados *store, struct req_state *state, RGWClientIO *cio)
+int RGWHandler_SWIFT_Auth::init(RGWRados *store, struct req_init_state *t, RGWClientIO *cio)
 {
+  struct req_state *state = t->s;
   state->dialect = "swift-auth";
   state->formatter = new JSONFormatter;
   state->format = RGW_FORMAT_JSON;
 
-  return RGWHandler::init(store, state, cio);
+  return RGWHandler::init(store, t, cio);
 }
 
 int RGWHandler_SWIFT_Auth::authorize()

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -29,6 +29,7 @@ public:
 
   int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
   int authorize();
+  int postauth_init() { return 0; }
   int read_permissions(RGWOp *op) { return 0; }
 
   virtual RGWAccessControlPolicy *alloc_policy() { return NULL; }

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -27,9 +27,9 @@ public:
   ~RGWHandler_SWIFT_Auth() {}
   RGWOp *op_get();
 
-  int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
+  int init(RGWRados *store, struct req_init_state *t, RGWClientIO *cio);
   int authorize();
-  int postauth_init() { return 0; }
+  int postauth_init(struct req_init_state *t) { return 0; }
   int read_permissions(RGWOp *op) { return 0; }
 
   virtual RGWAccessControlPolicy *alloc_policy() { return NULL; }
@@ -44,7 +44,7 @@ public:
   virtual RGWRESTMgr *get_resource_mgr(struct req_state *s, const string& uri, string *out_uri) {
     return this;
   }
-  virtual RGWHandler *get_handler(struct req_state *s) {
+  virtual RGWHandler *get_handler(struct req_init_state *t) {
     return new RGWHandler_SWIFT_Auth;
   }
 };


### PR DESCRIPTION
The initial merge for the Multi-Tenancy feature did work as well as it should. In particular, attempts to delete buckets with explicit tenants ended with code 405. This pull request contains two commits, which 1) fixes the basic operation with explicit tenants, and 2) supports for COPY operation on buckets under different tenant. Thus far explicit tenants are only available through S3 interface.