### PR TITLE
msg/Message.h:remove unneeded inline

### DIFF
--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -301,7 +301,7 @@ protected:
       completion_hook->complete(0);
   }
 public:
-  inline const ConnectionRef& get_connection() const { return connection; }
+  const ConnectionRef& get_connection() const { return connection; }
   void set_connection(const ConnectionRef& c) {
     connection = c;
   }


### PR DESCRIPTION
Member functions defined within class are implicitly inline.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>