### PR TITLE
Master fixes

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -154,7 +154,7 @@ namespace buffer CEPH_BUFFER_API {
   raw* create_unshareable(unsigned len);
 
 #if defined(HAVE_XIO)
-  static raw* create_msg(unsigned len, char *buf, XioDispatchHook *m_hook);
+  raw* create_msg(unsigned len, char *buf, XioDispatchHook *m_hook);
 #endif
 
   /*

--- a/src/msg/Dispatcher.h
+++ b/src/msg/Dispatcher.h
@@ -17,6 +17,7 @@
 #define CEPH_DISPATCHER_H
 
 #include "include/buffer_fwd.h"
+#include "include/assert.h"
 
 class Messenger;
 class Message;

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -319,12 +319,13 @@ XioMessenger::XioMessenger(CephContext *cct, entity_name_t name,
       xio_set_opt(NULL, XIO_OPTLEVEL_ACCELIO, XIO_OPTNAME_MAX_INLINE_XIO_HEADER,
                  &xopt, sizeof(xopt));
 
+      size_t queue_depth = cct->_conf->xio_queue_depth;
       struct xio_mempool_config mempool_config = {
         6,
         {
-          {1024,  0,  cct->_conf->xio_queue_depth,  262144},
-          {4096,  0,  cct->_conf->xio_queue_depth,  262144},
-          {16384, 0,  cct->_conf->xio_queue_depth,  262144},
+          {1024,  0,  queue_depth,  262144},
+          {4096,  0,  queue_depth,  262144},
+          {16384, 0,  queue_depth,  262144},
           {65536, 0,  128,  65536},
           {262144, 0,  32,  16384},
           {1048576, 0, 8,  8192}


### PR DESCRIPTION
Fixes some small issues on master (12/20):

1. an xio-specific buffer.h fix
2. a new narrowing conversion compile warning in XioMessenger.cc
3. a change to include assert.h in Dispatcher.h, as it is now used in the interface

As noted in the commit message, possibly this suggests a need for a FastDispatcher interface, which could declare ms_fast_dispatch pure virtual.