### PR TITLE
Reduce CPU usage by replacing coll_t by const coll_t&

### DIFF
--- a/src/os/CollectionIndex.h
+++ b/src/os/CollectionIndex.h
@@ -57,14 +57,14 @@ protected:
     /// Debugging Constructor
     Path(
       string path,                              ///< [in] Path to return.
-      coll_t coll)                              ///< [in] collection
+      const coll_t& coll)                              ///< [in] collection
       : full_path(path), parent_coll(coll) {}
       
     /// Getter for the stored path.
     const char *path() const { return full_path.c_str(); }
 
     /// Getter for collection
-    coll_t coll() const { return parent_coll; }
+    const coll_t& coll() const { return parent_coll; }
 
     /// Getter for parent
     CollectionIndex* get_index() const {
@@ -78,7 +78,7 @@ protected:
   /// Type of returned paths
   typedef ceph::shared_ptr<Path> IndexedPath;
 
-  static IndexedPath get_testing_path(string path, coll_t collection) {
+  static IndexedPath get_testing_path(string path, const coll_t& collection) {
     return IndexedPath(new Path(path, collection));
   }
 

--- a/src/os/FileStore.h
+++ b/src/os/FileStore.h
@@ -137,9 +137,15 @@ private:
 
   // Indexed Collections
   IndexManager index_manager;
-  int get_index(coll_t c, Index *index);
-  int init_index(coll_t c);
+  int get_index(const coll_t& c, Index *index);
+  int init_index(const coll_t& c);
 
+  bool _need_temp_object_collection(const coll_t& cid, const ghobject_t& oid) {
+    // - normal temp case: cid is pg, object is temp (pool < -1)
+    // - hammer temp case: cid is pg (or already temp), object pool is -1
+    return (cid.is_pg() && (oid.hobj.pool < -1 ||
+			oid.hobj.pool == -1));
+  }
   void _kludge_temp_object_collection(coll_t& cid, const ghobject_t& oid) {
     // - normal temp case: cid is pg, object is temp (pool < -1)
     // - hammer temp case: cid is pg (or already temp), object pool is -1
@@ -153,7 +159,7 @@ private:
   boost::scoped_ptr<ObjectMap> object_map;
   
   // helper fns
-  int get_cdir(coll_t cid, char *s, int len);
+  int get_cdir(const coll_t& cid, char *s, int len);
   
   /// read a uuid from fd
   int read_fsid(int fd, uuid_d *uuid);
@@ -394,18 +400,18 @@ private:
 public:
   int lfn_find(const ghobject_t& oid, const Index& index, 
                                   IndexedPath *path = NULL);
-  int lfn_truncate(coll_t cid, const ghobject_t& oid, off_t length);
-  int lfn_stat(coll_t cid, const ghobject_t& oid, struct stat *buf);
+  int lfn_truncate(const coll_t& cid, const ghobject_t& oid, off_t length);
+  int lfn_stat(const coll_t& cid, const ghobject_t& oid, struct stat *buf);
   int lfn_open(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     bool create,
     FDRef *outfd,
     Index *index = 0);
 
   void lfn_close(FDRef fd);
-  int lfn_link(coll_t c, coll_t newcid, const ghobject_t& o, const ghobject_t& newoid) ;
-  int lfn_unlink(coll_t cid, const ghobject_t& o, const SequencerPosition &spos,
+  int lfn_link(const coll_t& c, const coll_t& newcid, const ghobject_t& o, const ghobject_t& newoid) ;
+  int lfn_unlink(const coll_t& cid, const ghobject_t& o, const SequencerPosition &spos,
 		 bool force_clear_omap=false);
 
 public:
@@ -499,15 +505,15 @@ public:
 			 const SequencerPosition& spos,
 			 const ghobject_t *oid=0,
 			 bool in_progress=false);
-  void _set_replay_guard(coll_t cid,
+  void _set_replay_guard(const coll_t& cid,
                          const SequencerPosition& spos,
                          bool in_progress);
-  void _set_global_replay_guard(coll_t cid,
+  void _set_global_replay_guard(const coll_t& cid,
 				const SequencerPosition &spos);
 
   /// close a replay guard opened with in_progress=true
   void _close_replay_guard(int fd, const SequencerPosition& spos);
-  void _close_replay_guard(coll_t cid, const SequencerPosition& spos);
+  void _close_replay_guard(const coll_t& cid, const SequencerPosition& spos);
 
   /**
    * check replay guard xattr on given file
@@ -526,23 +532,23 @@ public:
    * @return 1 if we can apply (maybe replay) this operation, -1 if spos has already been applied, 0 if it was in progress
    */
   int _check_replay_guard(int fd, const SequencerPosition& spos);
-  int _check_replay_guard(coll_t cid, const SequencerPosition& spos);
-  int _check_replay_guard(coll_t cid, ghobject_t oid, const SequencerPosition& pos);
-  int _check_global_replay_guard(coll_t cid, const SequencerPosition& spos);
+  int _check_replay_guard(const coll_t& cid, const SequencerPosition& spos);
+  int _check_replay_guard(const coll_t& cid, ghobject_t oid, const SequencerPosition& pos);
+  int _check_global_replay_guard(const coll_t& cid, const SequencerPosition& spos);
 
   // ------------------
   // objects
   int pick_object_revision_lt(ghobject_t& oid) {
     return 0;
   }
-  bool exists(coll_t cid, const ghobject_t& oid);
+  bool exists(const coll_t& cid, const ghobject_t& oid);
   int stat(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     struct stat *st,
     bool allow_eio = false);
   int read(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
@@ -553,22 +559,22 @@ public:
                  map<uint64_t, uint64_t> *m);
   int _do_seek_hole_data(int fd, uint64_t offset, size_t len,
                          map<uint64_t, uint64_t> *m);
-  int fiemap(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl);
+  int fiemap(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl);
 
-  int _touch(coll_t cid, const ghobject_t& oid);
-  int _write(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len,
+  int _touch(const coll_t& cid, const ghobject_t& oid);
+  int _write(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len,
 	      const bufferlist& bl, uint32_t fadvise_flags = 0);
-  int _zero(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len);
-  int _truncate(coll_t cid, const ghobject_t& oid, uint64_t size);
-  int _clone(coll_t cid, const ghobject_t& oldoid, const ghobject_t& newoid,
+  int _zero(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len);
+  int _truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size);
+  int _clone(const coll_t& cid, const ghobject_t& oldoid, const ghobject_t& newoid,
 	     const SequencerPosition& spos);
-  int _clone_range(coll_t cid, const ghobject_t& oldoid, const ghobject_t& newoid,
+  int _clone_range(const coll_t& cid, const ghobject_t& oldoid, const ghobject_t& newoid,
 		   uint64_t srcoff, uint64_t len, uint64_t dstoff,
 		   const SequencerPosition& spos);
   int _do_clone_range(int from, int to, uint64_t srcoff, uint64_t len, uint64_t dstoff);
   int _do_sparse_copy_range(int from, int to, uint64_t srcoff, uint64_t len, uint64_t dstoff);
   int _do_copy_range(int from, int to, uint64_t srcoff, uint64_t len, uint64_t dstoff, bool skip_sloppycrc=false);
-  int _remove(coll_t cid, const ghobject_t& oid, const SequencerPosition &spos);
+  int _remove(const coll_t& cid, const ghobject_t& oid, const SequencerPosition &spos);
 
   int _fgetattr(int fd, const char *name, bufferptr& bp);
   int _fgetattrs(int fd, map<string,bufferptr>& aset);
@@ -604,54 +610,54 @@ public:
   int snapshot(const string& name);
 
   // attrs
-  int getattr(coll_t cid, const ghobject_t& oid, const char *name, bufferptr &bp);
-  int getattrs(coll_t cid, const ghobject_t& oid, map<string,bufferptr>& aset);
+  int getattr(const coll_t& cid, const ghobject_t& oid, const char *name, bufferptr &bp);
+  int getattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset);
 
-  int _setattrs(coll_t cid, const ghobject_t& oid, map<string,bufferptr>& aset,
+  int _setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset,
 		const SequencerPosition &spos);
-  int _rmattr(coll_t cid, const ghobject_t& oid, const char *name,
+  int _rmattr(const coll_t& cid, const ghobject_t& oid, const char *name,
 	      const SequencerPosition &spos);
-  int _rmattrs(coll_t cid, const ghobject_t& oid,
+  int _rmattrs(const coll_t& cid, const ghobject_t& oid,
 	       const SequencerPosition &spos);
 
-  int collection_getattr(coll_t c, const char *name, void *value, size_t size);
-  int collection_getattr(coll_t c, const char *name, bufferlist& bl);
-  int collection_getattrs(coll_t cid, map<string,bufferptr> &aset);
+  int collection_getattr(const coll_t& c, const char *name, void *value, size_t size);
+  int collection_getattr(const coll_t& c, const char *name, bufferlist& bl);
+  int collection_getattrs(const coll_t& cid, map<string,bufferptr> &aset);
 
-  int _collection_setattr(coll_t c, const char *name, const void *value, size_t size);
-  int _collection_rmattr(coll_t c, const char *name);
-  int _collection_setattrs(coll_t cid, map<string,bufferptr> &aset);
+  int _collection_setattr(const coll_t& c, const char *name, const void *value, size_t size);
+  int _collection_rmattr(const coll_t& c, const char *name);
+  int _collection_setattrs(const coll_t& cid, map<string,bufferptr> &aset);
   int _collection_remove_recursive(const coll_t &cid,
 				   const SequencerPosition &spos);
 
   // collections
-  int collection_list(coll_t c, ghobject_t start, ghobject_t end,
+  int collection_list(const coll_t& c, ghobject_t start, ghobject_t end,
 		      bool sort_bitwise, int max,
 		      vector<ghobject_t> *ls, ghobject_t *next);
   int list_collections(vector<coll_t>& ls);
   int list_collections(vector<coll_t>& ls, bool include_temp);
-  int collection_version_current(coll_t c, uint32_t *version);
-  int collection_stat(coll_t c, struct stat *st);
-  bool collection_exists(coll_t c);
-  bool collection_empty(coll_t c);
+  int collection_version_current(const coll_t& c, uint32_t *version);
+  int collection_stat(const coll_t& c, struct stat *st);
+  bool collection_exists(const coll_t& c);
+  bool collection_empty(const coll_t& c);
 
   // omap (see ObjectStore.h for documentation)
-  int omap_get(coll_t c, const ghobject_t &oid, bufferlist *header,
+  int omap_get(const coll_t& c, const ghobject_t &oid, bufferlist *header,
 	       map<string, bufferlist> *out);
   int omap_get_header(
-    coll_t c,
+    const coll_t& c,
     const ghobject_t &oid,
     bufferlist *out,
     bool allow_eio = false);
-  int omap_get_keys(coll_t c, const ghobject_t &oid, set<string> *keys);
-  int omap_get_values(coll_t c, const ghobject_t &oid, const set<string> &keys,
+  int omap_get_keys(const coll_t& c, const ghobject_t &oid, set<string> *keys);
+  int omap_get_values(const coll_t& c, const ghobject_t &oid, const set<string> &keys,
 		      map<string, bufferlist> *out);
-  int omap_check_keys(coll_t c, const ghobject_t &oid, const set<string> &keys,
+  int omap_check_keys(const coll_t& c, const ghobject_t &oid, const set<string> &keys,
 		      set<string> *out);
-  ObjectMap::ObjectMapIterator get_omap_iterator(coll_t c, const ghobject_t &oid);
+  ObjectMap::ObjectMapIterator get_omap_iterator(const coll_t& c, const ghobject_t &oid);
 
-  int _create_collection(coll_t c, const SequencerPosition &spos);
-  int _destroy_collection(coll_t c);
+  int _create_collection(const coll_t& c, const SequencerPosition &spos);
+  int _destroy_collection(const coll_t& c);
   /**
    * Give an expected number of objects hint to the collection.
    *
@@ -662,16 +668,16 @@ public:
    *
    * @return 0 on success, an error code otherwise
    */
-  int _collection_hint_expected_num_objs(coll_t c, uint32_t pg_num,
+  int _collection_hint_expected_num_objs(const coll_t& c, uint32_t pg_num,
       uint64_t expected_num_objs,
       const SequencerPosition &spos);
-  int _collection_add(coll_t c, coll_t ocid, const ghobject_t& oid,
+  int _collection_add(const coll_t& c, const coll_t& ocid, const ghobject_t& oid,
 		      const SequencerPosition& spos);
-  int _collection_move_rename(coll_t oldcid, const ghobject_t& oldoid,
+  int _collection_move_rename(const coll_t& oldcid, const ghobject_t& oldoid,
 			      coll_t c, const ghobject_t& o,
 			      const SequencerPosition& spos);
 
-  int _set_alloc_hint(coll_t cid, const ghobject_t& oid,
+  int _set_alloc_hint(const coll_t& cid, const ghobject_t& oid,
                       uint64_t expected_object_size,
                       uint64_t expected_write_size);
 
@@ -683,21 +689,21 @@ private:
   void _inject_failure();
 
   // omap
-  int _omap_clear(coll_t cid, const ghobject_t &oid,
+  int _omap_clear(const coll_t& cid, const ghobject_t &oid,
 		  const SequencerPosition &spos);
-  int _omap_setkeys(coll_t cid, const ghobject_t &oid,
+  int _omap_setkeys(const coll_t& cid, const ghobject_t &oid,
 		    const map<string, bufferlist> &aset,
 		    const SequencerPosition &spos);
-  int _omap_rmkeys(coll_t cid, const ghobject_t &oid, const set<string> &keys,
+  int _omap_rmkeys(const coll_t& cid, const ghobject_t &oid, const set<string> &keys,
 		   const SequencerPosition &spos);
-  int _omap_rmkeyrange(coll_t cid, const ghobject_t &oid,
+  int _omap_rmkeyrange(const coll_t& cid, const ghobject_t &oid,
 		       const string& first, const string& last,
 		       const SequencerPosition &spos);
-  int _omap_setheader(coll_t cid, const ghobject_t &oid, const bufferlist &bl,
+  int _omap_setheader(const coll_t& cid, const ghobject_t &oid, const bufferlist &bl,
 		      const SequencerPosition &spos);
-  int _split_collection(coll_t cid, uint32_t bits, uint32_t rem, coll_t dest,
+  int _split_collection(const coll_t& cid, uint32_t bits, uint32_t rem, coll_t dest,
                         const SequencerPosition &spos);
-  int _split_collection_create(coll_t cid, uint32_t bits, uint32_t rem,
+  int _split_collection_create(const coll_t& cid, uint32_t bits, uint32_t rem,
 			       coll_t dest,
 			       const SequencerPosition &spos);
 

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -1611,7 +1611,7 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
 // =========== KeyValueStore Op Implementation ==============
 // objects
 
-bool KeyValueStore::exists(coll_t cid, const ghobject_t& oid)
+bool KeyValueStore::exists(const coll_t& cid, const ghobject_t& oid)
 {
   dout(10) << __func__ << "collection: " << cid << " object: " << oid
            << dendl;
@@ -1626,7 +1626,7 @@ bool KeyValueStore::exists(coll_t cid, const ghobject_t& oid)
   return true;
 }
 
-int KeyValueStore::stat(coll_t cid, const ghobject_t& oid,
+int KeyValueStore::stat(const coll_t& cid, const ghobject_t& oid,
                         struct stat *st, bool allow_eio)
 {
   dout(10) << "stat " << cid << "/" << oid << dendl;
@@ -1719,7 +1719,7 @@ int KeyValueStore::_generic_read(StripObjectMap::StripObjectHeaderRef header,
 }
 
 
-int KeyValueStore::read(coll_t cid, const ghobject_t& oid, uint64_t offset,
+int KeyValueStore::read(const coll_t& cid, const ghobject_t& oid, uint64_t offset,
                         size_t len, bufferlist& bl, uint32_t op_flags,
 			bool allow_eio)
 {
@@ -1739,7 +1739,7 @@ int KeyValueStore::read(coll_t cid, const ghobject_t& oid, uint64_t offset,
   return _generic_read(header, offset, len, bl, allow_eio);
 }
 
-int KeyValueStore::fiemap(coll_t cid, const ghobject_t& oid,
+int KeyValueStore::fiemap(const coll_t& cid, const ghobject_t& oid,
                           uint64_t offset, size_t len, bufferlist& bl)
 {
   dout(10) << __func__ << " " << cid << " " << oid << " " << offset << "~"
@@ -1770,7 +1770,7 @@ int KeyValueStore::fiemap(coll_t cid, const ghobject_t& oid,
   return 0;
 }
 
-int KeyValueStore::_remove(coll_t cid, const ghobject_t& oid,
+int KeyValueStore::_remove(const coll_t& cid, const ghobject_t& oid,
                            BufferTransaction &t)
 {
   dout(15) << __func__ << " " << cid << "/" << oid << dendl;
@@ -1794,7 +1794,7 @@ int KeyValueStore::_remove(coll_t cid, const ghobject_t& oid,
   return r;
 }
 
-int KeyValueStore::_truncate(coll_t cid, const ghobject_t& oid, uint64_t size,
+int KeyValueStore::_truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size,
                              BufferTransaction &t)
 {
   dout(15) << __func__ << " " << cid << "/" << oid << " size " << size
@@ -1866,7 +1866,7 @@ int KeyValueStore::_truncate(coll_t cid, const ghobject_t& oid, uint64_t size,
   return r;
 }
 
-int KeyValueStore::_touch(coll_t cid, const ghobject_t& oid,
+int KeyValueStore::_touch(const coll_t& cid, const ghobject_t& oid,
                           BufferTransaction &t)
 {
   dout(15) << __func__ << " " << cid << "/" << oid << dendl;
@@ -1963,7 +1963,7 @@ int KeyValueStore::_generic_write(StripObjectMap::StripObjectHeaderRef header,
   return r;
 }
 
-int KeyValueStore::_write(coll_t cid, const ghobject_t& oid,
+int KeyValueStore::_write(const coll_t& cid, const ghobject_t& oid,
                           uint64_t offset, size_t len, const bufferlist& bl,
                           BufferTransaction &t, uint32_t fadvise_flags)
 {
@@ -1983,7 +1983,7 @@ int KeyValueStore::_write(coll_t cid, const ghobject_t& oid,
   return _generic_write(header, offset, len, bl, t, fadvise_flags);
 }
 
-int KeyValueStore::_zero(coll_t cid, const ghobject_t& oid, uint64_t offset,
+int KeyValueStore::_zero(const coll_t& cid, const ghobject_t& oid, uint64_t offset,
                          size_t len, BufferTransaction &t)
 {
   dout(15) << __func__ << " " << cid << "/" << oid << " " << offset << "~" << len << dendl;
@@ -2041,7 +2041,7 @@ int KeyValueStore::_zero(coll_t cid, const ghobject_t& oid, uint64_t offset,
   return r;
 }
 
-int KeyValueStore::_clone(coll_t cid, const ghobject_t& oldoid,
+int KeyValueStore::_clone(const coll_t& cid, const ghobject_t& oldoid,
                           const ghobject_t& newoid, BufferTransaction &t)
 {
   dout(15) << __func__ << " " << cid << "/" << oldoid << " -> " << cid << "/"
@@ -2067,7 +2067,7 @@ int KeyValueStore::_clone(coll_t cid, const ghobject_t& oldoid,
   return r;
 }
 
-int KeyValueStore::_clone_range(coll_t cid, const ghobject_t& oldoid,
+int KeyValueStore::_clone_range(const coll_t& cid, const ghobject_t& oldoid,
                                 const ghobject_t& newoid, uint64_t srcoff,
                                 uint64_t len, uint64_t dstoff,
                                 BufferTransaction &t)
@@ -2112,7 +2112,7 @@ int KeyValueStore::_clone_range(coll_t cid, const ghobject_t& oldoid,
 
 // attrs
 
-int KeyValueStore::getattr(coll_t cid, const ghobject_t& oid, const char *name,
+int KeyValueStore::getattr(const coll_t& cid, const ghobject_t& oid, const char *name,
                            bufferptr &bp)
 {
   dout(15) << __func__ << " " << cid << "/" << oid << " '" << name << "'"
@@ -2150,7 +2150,7 @@ int KeyValueStore::getattr(coll_t cid, const ghobject_t& oid, const char *name,
   return r;
 }
 
-int KeyValueStore::getattrs(coll_t cid, const ghobject_t& oid,
+int KeyValueStore::getattrs(const coll_t& cid, const ghobject_t& oid,
                            map<string,bufferptr>& aset)
 {
   map<string, bufferlist> attr_aset;
@@ -2183,7 +2183,7 @@ int KeyValueStore::getattrs(coll_t cid, const ghobject_t& oid,
   return r;
 }
 
-int KeyValueStore::_setattrs(coll_t cid, const ghobject_t& oid,
+int KeyValueStore::_setattrs(const coll_t& cid, const ghobject_t& oid,
                              map<string, bufferptr>& aset,
                              BufferTransaction &t)
 {
@@ -2211,7 +2211,7 @@ out:
 }
 
 
-int KeyValueStore::_rmattr(coll_t cid, const ghobject_t& oid, const char *name,
+int KeyValueStore::_rmattr(const coll_t& cid, const ghobject_t& oid, const char *name,
                            BufferTransaction &t)
 {
   dout(15) << __func__ << " " << cid << "/" << oid << " '" << name << "'"
@@ -2236,7 +2236,7 @@ int KeyValueStore::_rmattr(coll_t cid, const ghobject_t& oid, const char *name,
   return r;
 }
 
-int KeyValueStore::_rmattrs(coll_t cid, const ghobject_t& oid,
+int KeyValueStore::_rmattrs(const coll_t& cid, const ghobject_t& oid,
                             BufferTransaction &t)
 {
   dout(15) << __func__ << " " << cid << "/" << oid << dendl;
@@ -2269,7 +2269,7 @@ int KeyValueStore::_rmattrs(coll_t cid, const ghobject_t& oid,
 
 // collections
 
-int KeyValueStore::_create_collection(coll_t c, BufferTransaction &t)
+int KeyValueStore::_create_collection(const coll_t& c, BufferTransaction &t)
 {
   dout(15) << __func__ << " " << c << dendl;
   int r = 0;
@@ -2289,7 +2289,7 @@ int KeyValueStore::_create_collection(coll_t c, BufferTransaction &t)
   return r;
 }
 
-int KeyValueStore::_destroy_collection(coll_t c, BufferTransaction &t)
+int KeyValueStore::_destroy_collection(const coll_t& c, BufferTransaction &t)
 {
   dout(15) << __func__ << " " << c << dendl;
 
@@ -2349,7 +2349,7 @@ out:
 }
 
 
-int KeyValueStore::_collection_add(coll_t c, coll_t oldcid,
+int KeyValueStore::_collection_add(const coll_t& c, const coll_t& oldcid,
                                    const ghobject_t& o,
                                    BufferTransaction &t)
 {
@@ -2389,7 +2389,7 @@ out:
   return r;
 }
 
-int KeyValueStore::_collection_move_rename(coll_t oldcid,
+int KeyValueStore::_collection_move_rename(const coll_t& oldcid,
                                            const ghobject_t& oldoid,
                                            coll_t c, const ghobject_t& o,
                                            BufferTransaction &t)
@@ -2469,14 +2469,14 @@ int KeyValueStore::list_collections(vector<coll_t>& ls)
   return 0;
 }
 
-bool KeyValueStore::collection_exists(coll_t c)
+bool KeyValueStore::collection_exists(const coll_t& c)
 {
   dout(10) << __func__ << " " << dendl;
   RWLock::RLocker l(collections_lock);
   return collections.count(c);
 }
 
-bool KeyValueStore::collection_empty(coll_t c)
+bool KeyValueStore::collection_empty(const coll_t& c)
 {
   dout(10) << __func__ << " " << dendl;
 
@@ -2486,7 +2486,7 @@ bool KeyValueStore::collection_empty(coll_t c)
   return oids.empty();
 }
 
-int KeyValueStore::collection_list(coll_t c, ghobject_t start,
+int KeyValueStore::collection_list(const coll_t& c, ghobject_t start,
 				   ghobject_t end, bool sort_bitwise, int max,
 				   vector<ghobject_t> *ls, ghobject_t *next)
 {
@@ -2503,7 +2503,7 @@ int KeyValueStore::collection_list(coll_t c, ghobject_t start,
   return r;
 }
 
-int KeyValueStore::collection_version_current(coll_t c, uint32_t *version)
+int KeyValueStore::collection_version_current(const coll_t& c, uint32_t *version)
 {
   *version = COLLECTION_VERSION;
   if (*version == target_version)
@@ -2514,7 +2514,7 @@ int KeyValueStore::collection_version_current(coll_t c, uint32_t *version)
 
 // omap
 
-int KeyValueStore::omap_get(coll_t c, const ghobject_t &hoid,
+int KeyValueStore::omap_get(const coll_t& c, const ghobject_t &hoid,
                             bufferlist *bl, map<string, bufferlist> *out)
 {
   dout(15) << __func__ << " " << c << "/" << hoid << dendl;
@@ -2551,7 +2551,7 @@ int KeyValueStore::omap_get(coll_t c, const ghobject_t &hoid,
   return 0;
 }
 
-int KeyValueStore::omap_get_header(coll_t c, const ghobject_t &hoid,
+int KeyValueStore::omap_get_header(const coll_t& c, const ghobject_t &hoid,
                                    bufferlist *bl, bool allow_eio)
 {
   dout(15) << __func__ << " " << c << "/" << hoid << dendl;
@@ -2581,7 +2581,7 @@ int KeyValueStore::omap_get_header(coll_t c, const ghobject_t &hoid,
   return 0;
 }
 
-int KeyValueStore::omap_get_keys(coll_t c, const ghobject_t &hoid, set<string> *keys)
+int KeyValueStore::omap_get_keys(const coll_t& c, const ghobject_t &hoid, set<string> *keys)
 {
   dout(15) << __func__ << " " << c << "/" << hoid << dendl;
 
@@ -2599,7 +2599,7 @@ int KeyValueStore::omap_get_keys(coll_t c, const ghobject_t &hoid, set<string> *
   return 0;
 }
 
-int KeyValueStore::omap_get_values(coll_t c, const ghobject_t &hoid,
+int KeyValueStore::omap_get_values(const coll_t& c, const ghobject_t &hoid,
                                    const set<string> &keys,
                                    map<string, bufferlist> *out)
 {
@@ -2619,7 +2619,7 @@ int KeyValueStore::omap_get_values(coll_t c, const ghobject_t &hoid,
   return 0;
 }
 
-int KeyValueStore::omap_check_keys(coll_t c, const ghobject_t &hoid,
+int KeyValueStore::omap_check_keys(const coll_t& c, const ghobject_t &hoid,
                                    const set<string> &keys, set<string> *out)
 {
   dout(15) << __func__ << " " << c << "/" << hoid << dendl;
@@ -2632,13 +2632,13 @@ int KeyValueStore::omap_check_keys(coll_t c, const ghobject_t &hoid,
 }
 
 ObjectMap::ObjectMapIterator KeyValueStore::get_omap_iterator(
-    coll_t c, const ghobject_t &hoid)
+    const coll_t& c, const ghobject_t &hoid)
 {
   dout(15) << __func__ << " " << c << "/" << hoid << dendl;
   return backend->get_iterator(c, hoid, OBJECT_OMAP);
 }
 
-int KeyValueStore::_omap_clear(coll_t cid, const ghobject_t &hoid,
+int KeyValueStore::_omap_clear(const coll_t& cid, const ghobject_t &hoid,
                                BufferTransaction &t)
 {
   dout(15) << __func__ << " " << cid << "/" << hoid << dendl;
@@ -2679,7 +2679,7 @@ int KeyValueStore::_omap_clear(coll_t cid, const ghobject_t &hoid,
   return 0;
 }
 
-int KeyValueStore::_omap_setkeys(coll_t cid, const ghobject_t &hoid,
+int KeyValueStore::_omap_setkeys(const coll_t& cid, const ghobject_t &hoid,
                                  map<string, bufferlist> &aset,
                                  BufferTransaction &t)
 {
@@ -2699,7 +2699,7 @@ int KeyValueStore::_omap_setkeys(coll_t cid, const ghobject_t &hoid,
   return 0;
 }
 
-int KeyValueStore::_omap_rmkeys(coll_t cid, const ghobject_t &hoid,
+int KeyValueStore::_omap_rmkeys(const coll_t& cid, const ghobject_t &hoid,
                                 const set<string> &keys,
                                 BufferTransaction &t)
 {
@@ -2720,7 +2720,7 @@ int KeyValueStore::_omap_rmkeys(coll_t cid, const ghobject_t &hoid,
   return r;
 }
 
-int KeyValueStore::_omap_rmkeyrange(coll_t cid, const ghobject_t &hoid,
+int KeyValueStore::_omap_rmkeyrange(const coll_t& cid, const ghobject_t &hoid,
                                     const string& first, const string& last,
                                     BufferTransaction &t)
 {
@@ -2741,7 +2741,7 @@ int KeyValueStore::_omap_rmkeyrange(coll_t cid, const ghobject_t &hoid,
   return _omap_rmkeys(cid, hoid, keys, t);
 }
 
-int KeyValueStore::_omap_setheader(coll_t cid, const ghobject_t &hoid,
+int KeyValueStore::_omap_setheader(const coll_t& cid, const ghobject_t &hoid,
                                    const bufferlist &bl,
                                    BufferTransaction &t)
 {
@@ -2762,7 +2762,7 @@ int KeyValueStore::_omap_setheader(coll_t cid, const ghobject_t &hoid,
   return 0;
 }
 
-int KeyValueStore::_split_collection(coll_t cid, uint32_t bits, uint32_t rem,
+int KeyValueStore::_split_collection(const coll_t& cid, uint32_t bits, uint32_t rem,
                                      coll_t dest, BufferTransaction &t)
 {
   {
@@ -2846,7 +2846,7 @@ int KeyValueStore::_split_collection(coll_t cid, uint32_t bits, uint32_t rem,
   return 0;
 }
 
-int KeyValueStore::_set_alloc_hint(coll_t cid, const ghobject_t& oid,
+int KeyValueStore::_set_alloc_hint(const coll_t& cid, const ghobject_t& oid,
                                    uint64_t expected_object_size,
                                    uint64_t expected_write_size,
                                    BufferTransaction &t)
@@ -2926,7 +2926,7 @@ void KeyValueStore::handle_conf_change(const struct md_config_t *conf,
   }
 }
 
-int KeyValueStore::check_get_rc(const coll_t cid, const ghobject_t& oid, int r, bool is_equal_size)
+int KeyValueStore::check_get_rc(const coll_t& cid, const ghobject_t& oid, int r, bool is_equal_size)
 {
   if (r < 0) {
     dout(10) << __func__ << " " << cid << "/" << oid << " "

--- a/src/os/KeyValueStore.h
+++ b/src/os/KeyValueStore.h
@@ -559,28 +559,28 @@ class KeyValueStore : public ObjectStore,
                      uint64_t offset, size_t len, const bufferlist& bl,
                      BufferTransaction &t, uint32_t fadvise_flags = 0);
 
-  bool exists(coll_t cid, const ghobject_t& oid);
-  int stat(coll_t cid, const ghobject_t& oid, struct stat *st,
+  bool exists(const coll_t& cid, const ghobject_t& oid);
+  int stat(const coll_t& cid, const ghobject_t& oid, struct stat *st,
            bool allow_eio = false);
-  int read(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len,
+  int read(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len,
            bufferlist& bl, uint32_t op_flags = 0, bool allow_eio = false);
-  int fiemap(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len,
+  int fiemap(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len,
              bufferlist& bl);
 
-  int _touch(coll_t cid, const ghobject_t& oid, BufferTransaction &t);
-  int _write(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len,
+  int _touch(const coll_t& cid, const ghobject_t& oid, BufferTransaction &t);
+  int _write(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len,
              const bufferlist& bl, BufferTransaction &t, uint32_t fadvise_flags = 0);
-  int _zero(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len,
+  int _zero(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len,
             BufferTransaction &t);
-  int _truncate(coll_t cid, const ghobject_t& oid, uint64_t size,
+  int _truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size,
                 BufferTransaction &t);
-  int _clone(coll_t cid, const ghobject_t& oldoid, const ghobject_t& newoid,
+  int _clone(const coll_t& cid, const ghobject_t& oldoid, const ghobject_t& newoid,
              BufferTransaction &t);
-  int _clone_range(coll_t cid, const ghobject_t& oldoid,
+  int _clone_range(const coll_t& cid, const ghobject_t& oldoid,
                    const ghobject_t& newoid, uint64_t srcoff,
                    uint64_t len, uint64_t dstoff, BufferTransaction &t);
-  int _remove(coll_t cid, const ghobject_t& oid, BufferTransaction &t);
-  int _set_alloc_hint(coll_t cid, const ghobject_t& oid,
+  int _remove(const coll_t& cid, const ghobject_t& oid, BufferTransaction &t);
+  int _set_alloc_hint(const coll_t& cid, const ghobject_t& oid,
                       uint64_t expected_object_size,
                       uint64_t expected_write_size,
                       BufferTransaction &t);
@@ -591,53 +591,53 @@ class KeyValueStore : public ObjectStore,
   uuid_d get_fsid() { return fsid; }
 
   // attrs
-  int getattr(coll_t cid, const ghobject_t& oid, const char *name,
+  int getattr(const coll_t& cid, const ghobject_t& oid, const char *name,
               bufferptr &bp);
-  int getattrs(coll_t cid, const ghobject_t& oid, map<string,bufferptr>& aset);
+  int getattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset);
 
-  int _setattrs(coll_t cid, const ghobject_t& oid,
+  int _setattrs(const coll_t& cid, const ghobject_t& oid,
                 map<string, bufferptr>& aset, BufferTransaction &t);
-  int _rmattr(coll_t cid, const ghobject_t& oid, const char *name,
+  int _rmattr(const coll_t& cid, const ghobject_t& oid, const char *name,
               BufferTransaction &t);
-  int _rmattrs(coll_t cid, const ghobject_t& oid, BufferTransaction &t);
+  int _rmattrs(const coll_t& cid, const ghobject_t& oid, BufferTransaction &t);
 
   // collections
-  int _collection_hint_expected_num_objs(coll_t cid, uint32_t pg_num,
+  int _collection_hint_expected_num_objs(const coll_t& cid, uint32_t pg_num,
       uint64_t num_objs) const { return 0; }
-  int _create_collection(coll_t c, BufferTransaction &t);
-  int _destroy_collection(coll_t c, BufferTransaction &t);
-  int _collection_add(coll_t c, coll_t ocid, const ghobject_t& oid,
+  int _create_collection(const coll_t& c, BufferTransaction &t);
+  int _destroy_collection(const coll_t& c, BufferTransaction &t);
+  int _collection_add(const coll_t& c, const coll_t& ocid, const ghobject_t& oid,
                       BufferTransaction &t);
-  int _collection_move_rename(coll_t oldcid, const ghobject_t& oldoid,
+  int _collection_move_rename(const coll_t& oldcid, const ghobject_t& oldoid,
                               coll_t c, const ghobject_t& o,
                               BufferTransaction &t);
   int _collection_remove_recursive(const coll_t &cid,
                                    BufferTransaction &t);
   int list_collections(vector<coll_t>& ls);
-  bool collection_exists(coll_t c);
-  bool collection_empty(coll_t c);
-  int collection_list(coll_t c, ghobject_t start, ghobject_t end,
+  bool collection_exists(const coll_t& c);
+  bool collection_empty(const coll_t& c);
+  int collection_list(const coll_t& c, ghobject_t start, ghobject_t end,
 		      bool sort_bitwise, int max,
 		      vector<ghobject_t> *ls, ghobject_t *next);
-  int collection_version_current(coll_t c, uint32_t *version);
+  int collection_version_current(const coll_t& c, uint32_t *version);
 
   // omap (see ObjectStore.h for documentation)
-  int omap_get(coll_t c, const ghobject_t &oid, bufferlist *header,
+  int omap_get(const coll_t& c, const ghobject_t &oid, bufferlist *header,
                map<string, bufferlist> *out);
   int omap_get_header(
-    coll_t c,
+    const coll_t& c,
     const ghobject_t &oid,
     bufferlist *out,
     bool allow_eio = false);
-  int omap_get_keys(coll_t c, const ghobject_t &oid, set<string> *keys);
-  int omap_get_values(coll_t c, const ghobject_t &oid, const set<string> &keys,
+  int omap_get_keys(const coll_t& c, const ghobject_t &oid, set<string> *keys);
+  int omap_get_values(const coll_t& c, const ghobject_t &oid, const set<string> &keys,
                       map<string, bufferlist> *out);
-  int omap_check_keys(coll_t c, const ghobject_t &oid, const set<string> &keys,
+  int omap_check_keys(const coll_t& c, const ghobject_t &oid, const set<string> &keys,
                       set<string> *out);
-  ObjectMap::ObjectMapIterator get_omap_iterator(coll_t c,
+  ObjectMap::ObjectMapIterator get_omap_iterator(const coll_t& c,
                                                  const ghobject_t &oid);
 
-  int check_get_rc(const coll_t cid, const ghobject_t& oid, int r, bool is_equal_size);
+  int check_get_rc(const coll_t& cid, const ghobject_t& oid, int r, bool is_equal_size);
   void dump_start(const std::string &file);
   void dump_stop();
   void dump_transactions(list<ObjectStore::Transaction*>& ls, uint64_t seq,
@@ -647,21 +647,21 @@ class KeyValueStore : public ObjectStore,
   void _inject_failure() {}
 
   // omap
-  int _omap_clear(coll_t cid, const ghobject_t &oid,
+  int _omap_clear(const coll_t& cid, const ghobject_t &oid,
                   BufferTransaction &t);
-  int _omap_setkeys(coll_t cid, const ghobject_t &oid,
+  int _omap_setkeys(const coll_t& cid, const ghobject_t &oid,
                     map<string, bufferlist> &aset,
                     BufferTransaction &t);
-  int _omap_rmkeys(coll_t cid, const ghobject_t &oid, const set<string> &keys,
+  int _omap_rmkeys(const coll_t& cid, const ghobject_t &oid, const set<string> &keys,
                    BufferTransaction &t);
-  int _omap_rmkeyrange(coll_t cid, const ghobject_t &oid,
+  int _omap_rmkeyrange(const coll_t& cid, const ghobject_t &oid,
                        const string& first, const string& last,
                        BufferTransaction &t);
-  int _omap_setheader(coll_t cid, const ghobject_t &oid, const bufferlist &bl,
+  int _omap_setheader(const coll_t& cid, const ghobject_t &oid, const bufferlist &bl,
                       BufferTransaction &t);
-  int _split_collection(coll_t cid, uint32_t bits, uint32_t rem, coll_t dest,
+  int _split_collection(const coll_t& cid, uint32_t bits, uint32_t rem, coll_t dest,
                         BufferTransaction &t);
-  int _split_collection_create(coll_t cid, uint32_t bits, uint32_t rem,
+  int _split_collection_create(const coll_t& cid, uint32_t bits, uint32_t rem,
                                coll_t dest, BufferTransaction &t){
     return 0;
   }

--- a/src/os/MemStore.cc
+++ b/src/os/MemStore.cc
@@ -251,7 +251,7 @@ objectstore_perf_stat_t MemStore::get_cur_stats()
   return objectstore_perf_stat_t();
 }
 
-MemStore::CollectionRef MemStore::get_collection(coll_t cid)
+MemStore::CollectionRef MemStore::get_collection(const coll_t& cid)
 {
   RWLock::RLocker l(coll_lock);
   ceph::unordered_map<coll_t,CollectionRef>::iterator cp = coll_map.find(cid);
@@ -264,7 +264,7 @@ MemStore::CollectionRef MemStore::get_collection(coll_t cid)
 // ---------------
 // read operations
 
-bool MemStore::exists(coll_t cid, const ghobject_t& oid)
+bool MemStore::exists(const coll_t& cid, const ghobject_t& oid)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
   CollectionRef c = get_collection(cid);
@@ -277,7 +277,7 @@ bool MemStore::exists(coll_t cid, const ghobject_t& oid)
 }
 
 int MemStore::stat(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     struct stat *st,
     bool allow_eio)
@@ -298,7 +298,7 @@ int MemStore::stat(
 }
 
 int MemStore::read(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
@@ -326,7 +326,7 @@ int MemStore::read(
   return o->read(offset, l, bl);
 }
 
-int MemStore::fiemap(coll_t cid, const ghobject_t& oid,
+int MemStore::fiemap(const coll_t& cid, const ghobject_t& oid,
 		     uint64_t offset, size_t len, bufferlist& bl)
 {
   dout(10) << __func__ << " " << cid << " " << oid << " " << offset << "~"
@@ -349,7 +349,7 @@ int MemStore::fiemap(coll_t cid, const ghobject_t& oid,
   return 0;  
 }
 
-int MemStore::getattr(coll_t cid, const ghobject_t& oid,
+int MemStore::getattr(const coll_t& cid, const ghobject_t& oid,
 		      const char *name, bufferptr& value)
 {
   dout(10) << __func__ << " " << cid << " " << oid << " " << name << dendl;
@@ -369,7 +369,7 @@ int MemStore::getattr(coll_t cid, const ghobject_t& oid,
   return 0;
 }
 
-int MemStore::getattrs(coll_t cid, const ghobject_t& oid,
+int MemStore::getattrs(const coll_t& cid, const ghobject_t& oid,
 		       map<string,bufferptr>& aset)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
@@ -397,14 +397,14 @@ int MemStore::list_collections(vector<coll_t>& ls)
   return 0;
 }
 
-bool MemStore::collection_exists(coll_t cid)
+bool MemStore::collection_exists(const coll_t& cid)
 {
   dout(10) << __func__ << " " << cid << dendl;
   RWLock::RLocker l(coll_lock);
   return coll_map.count(cid);
 }
 
-bool MemStore::collection_empty(coll_t cid)
+bool MemStore::collection_empty(const coll_t& cid)
 {
   dout(10) << __func__ << " " << cid << dendl;
   CollectionRef c = get_collection(cid);
@@ -415,7 +415,7 @@ bool MemStore::collection_empty(coll_t cid)
   return c->object_map.empty();
 }
 
-int MemStore::collection_list(coll_t cid, ghobject_t start, ghobject_t end,
+int MemStore::collection_list(const coll_t& cid, ghobject_t start, ghobject_t end,
 			      bool sort_bitwise, int max,
 			      vector<ghobject_t> *ls, ghobject_t *next)
 {
@@ -443,7 +443,7 @@ int MemStore::collection_list(coll_t cid, ghobject_t start, ghobject_t end,
 }
 
 int MemStore::omap_get(
-    coll_t cid,                ///< [in] Collection containing oid
+    const coll_t& cid,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     map<string, bufferlist> *out /// < [out] Key to value map
@@ -464,7 +464,7 @@ int MemStore::omap_get(
 }
 
 int MemStore::omap_get_header(
-    coll_t cid,                ///< [in] Collection containing oid
+    const coll_t& cid,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     bool allow_eio ///< [in] don't assert on eio
@@ -484,7 +484,7 @@ int MemStore::omap_get_header(
 }
 
 int MemStore::omap_get_keys(
-    coll_t cid,              ///< [in] Collection containing oid
+    const coll_t& cid,              ///< [in] Collection containing oid
     const ghobject_t &oid, ///< [in] Object containing omap
     set<string> *keys      ///< [out] Keys defined on oid
     )
@@ -506,7 +506,7 @@ int MemStore::omap_get_keys(
 }
 
 int MemStore::omap_get_values(
-    coll_t cid,                    ///< [in] Collection containing oid
+    const coll_t& cid,                    ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const set<string> &keys,     ///< [in] Keys to get
     map<string, bufferlist> *out ///< [out] Returned keys and values
@@ -532,7 +532,7 @@ int MemStore::omap_get_values(
 }
 
 int MemStore::omap_check_keys(
-    coll_t cid,                ///< [in] Collection containing oid
+    const coll_t& cid,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     const set<string> &keys, ///< [in] Keys to check
     set<string> *out         ///< [out] Subset of keys defined on oid
@@ -557,7 +557,7 @@ int MemStore::omap_check_keys(
   return 0;
 }
 
-ObjectMap::ObjectMapIterator MemStore::get_omap_iterator(coll_t cid,
+ObjectMap::ObjectMapIterator MemStore::get_omap_iterator(const coll_t& cid,
 							 const ghobject_t& oid)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
@@ -954,7 +954,7 @@ void MemStore::_do_transaction(Transaction& t)
   }
 }
 
-int MemStore::_touch(coll_t cid, const ghobject_t& oid)
+int MemStore::_touch(const coll_t& cid, const ghobject_t& oid)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
   CollectionRef c = get_collection(cid);
@@ -965,7 +965,7 @@ int MemStore::_touch(coll_t cid, const ghobject_t& oid)
   return 0;
 }
 
-int MemStore::_write(coll_t cid, const ghobject_t& oid,
+int MemStore::_write(const coll_t& cid, const ghobject_t& oid,
 		     uint64_t offset, size_t len, const bufferlist& bl,
 		     uint32_t fadvise_flags)
 {
@@ -985,7 +985,7 @@ int MemStore::_write(coll_t cid, const ghobject_t& oid,
   return 0;
 }
 
-int MemStore::_zero(coll_t cid, const ghobject_t& oid,
+int MemStore::_zero(const coll_t& cid, const ghobject_t& oid,
 		    uint64_t offset, size_t len)
 {
   dout(10) << __func__ << " " << cid << " " << oid << " " << offset << "~"
@@ -997,7 +997,7 @@ int MemStore::_zero(coll_t cid, const ghobject_t& oid,
   return _write(cid, oid, offset, len, bl);
 }
 
-int MemStore::_truncate(coll_t cid, const ghobject_t& oid, uint64_t size)
+int MemStore::_truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size)
 {
   dout(10) << __func__ << " " << cid << " " << oid << " " << size << dendl;
   CollectionRef c = get_collection(cid);
@@ -1013,7 +1013,7 @@ int MemStore::_truncate(coll_t cid, const ghobject_t& oid, uint64_t size)
   return r;
 }
 
-int MemStore::_remove(coll_t cid, const ghobject_t& oid)
+int MemStore::_remove(const coll_t& cid, const ghobject_t& oid)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
   CollectionRef c = get_collection(cid);
@@ -1031,7 +1031,7 @@ int MemStore::_remove(coll_t cid, const ghobject_t& oid)
   return 0;
 }
 
-int MemStore::_setattrs(coll_t cid, const ghobject_t& oid,
+int MemStore::_setattrs(const coll_t& cid, const ghobject_t& oid,
 			map<string,bufferptr>& aset)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
@@ -1048,7 +1048,7 @@ int MemStore::_setattrs(coll_t cid, const ghobject_t& oid,
   return 0;
 }
 
-int MemStore::_rmattr(coll_t cid, const ghobject_t& oid, const char *name)
+int MemStore::_rmattr(const coll_t& cid, const ghobject_t& oid, const char *name)
 {
   dout(10) << __func__ << " " << cid << " " << oid << " " << name << dendl;
   CollectionRef c = get_collection(cid);
@@ -1066,7 +1066,7 @@ int MemStore::_rmattr(coll_t cid, const ghobject_t& oid, const char *name)
   return 0;
 }
 
-int MemStore::_rmattrs(coll_t cid, const ghobject_t& oid)
+int MemStore::_rmattrs(const coll_t& cid, const ghobject_t& oid)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
   CollectionRef c = get_collection(cid);
@@ -1081,7 +1081,7 @@ int MemStore::_rmattrs(coll_t cid, const ghobject_t& oid)
   return 0;
 }
 
-int MemStore::_clone(coll_t cid, const ghobject_t& oldoid,
+int MemStore::_clone(const coll_t& cid, const ghobject_t& oldoid,
 		     const ghobject_t& newoid)
 {
   dout(10) << __func__ << " " << cid << " " << oldoid
@@ -1111,7 +1111,7 @@ int MemStore::_clone(coll_t cid, const ghobject_t& oldoid,
   return 0;
 }
 
-int MemStore::_clone_range(coll_t cid, const ghobject_t& oldoid,
+int MemStore::_clone_range(const coll_t& cid, const ghobject_t& oldoid,
 			   const ghobject_t& newoid,
 			   uint64_t srcoff, uint64_t len, uint64_t dstoff)
 {
@@ -1139,7 +1139,7 @@ int MemStore::_clone_range(coll_t cid, const ghobject_t& oldoid,
   return len;
 }
 
-int MemStore::_omap_clear(coll_t cid, const ghobject_t &oid)
+int MemStore::_omap_clear(const coll_t& cid, const ghobject_t &oid)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
   CollectionRef c = get_collection(cid);
@@ -1155,7 +1155,7 @@ int MemStore::_omap_clear(coll_t cid, const ghobject_t &oid)
   return 0;
 }
 
-int MemStore::_omap_setkeys(coll_t cid, const ghobject_t &oid,
+int MemStore::_omap_setkeys(const coll_t& cid, const ghobject_t &oid,
 			    bufferlist& aset_bl)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
@@ -1178,7 +1178,7 @@ int MemStore::_omap_setkeys(coll_t cid, const ghobject_t &oid,
   return 0;
 }
 
-int MemStore::_omap_rmkeys(coll_t cid, const ghobject_t &oid,
+int MemStore::_omap_rmkeys(const coll_t& cid, const ghobject_t &oid,
 			   bufferlist& keys_bl)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
@@ -1201,7 +1201,7 @@ int MemStore::_omap_rmkeys(coll_t cid, const ghobject_t &oid,
   return 0;
 }
 
-int MemStore::_omap_rmkeyrange(coll_t cid, const ghobject_t &oid,
+int MemStore::_omap_rmkeyrange(const coll_t& cid, const ghobject_t &oid,
 			       const string& first, const string& last)
 {
   dout(10) << __func__ << " " << cid << " " << oid << " " << first
@@ -1220,7 +1220,7 @@ int MemStore::_omap_rmkeyrange(coll_t cid, const ghobject_t &oid,
   return 0;
 }
 
-int MemStore::_omap_setheader(coll_t cid, const ghobject_t &oid,
+int MemStore::_omap_setheader(const coll_t& cid, const ghobject_t &oid,
 			      const bufferlist &bl)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
@@ -1236,7 +1236,7 @@ int MemStore::_omap_setheader(coll_t cid, const ghobject_t &oid,
   return 0;
 }
 
-int MemStore::_create_collection(coll_t cid)
+int MemStore::_create_collection(const coll_t& cid)
 {
   dout(10) << __func__ << " " << cid << dendl;
   RWLock::WLocker l(coll_lock);
@@ -1247,7 +1247,7 @@ int MemStore::_create_collection(coll_t cid)
   return 0;
 }
 
-int MemStore::_destroy_collection(coll_t cid)
+int MemStore::_destroy_collection(const coll_t& cid)
 {
   dout(10) << __func__ << " " << cid << dendl;
   RWLock::WLocker l(coll_lock);
@@ -1264,7 +1264,7 @@ int MemStore::_destroy_collection(coll_t cid)
   return 0;
 }
 
-int MemStore::_collection_add(coll_t cid, coll_t ocid, const ghobject_t& oid)
+int MemStore::_collection_add(const coll_t& cid, const coll_t& ocid, const ghobject_t& oid)
 {
   dout(10) << __func__ << " " << cid << " " << ocid << " " << oid << dendl;
   CollectionRef c = get_collection(cid);
@@ -1286,7 +1286,7 @@ int MemStore::_collection_add(coll_t cid, coll_t ocid, const ghobject_t& oid)
   return 0;
 }
 
-int MemStore::_collection_move_rename(coll_t oldcid, const ghobject_t& oldoid,
+int MemStore::_collection_move_rename(const coll_t& oldcid, const ghobject_t& oldoid,
 				      coll_t cid, const ghobject_t& oid)
 {
   dout(10) << __func__ << " " << oldcid << " " << oldoid << " -> "
@@ -1330,7 +1330,7 @@ int MemStore::_collection_move_rename(coll_t oldcid, const ghobject_t& oldoid,
   return r;
 }
 
-int MemStore::_split_collection(coll_t cid, uint32_t bits, uint32_t match,
+int MemStore::_split_collection(const coll_t& cid, uint32_t bits, uint32_t match,
 				coll_t dest)
 {
   dout(10) << __func__ << " " << cid << " " << bits << " " << match << " "

--- a/src/os/MemStore.h
+++ b/src/os/MemStore.h
@@ -294,7 +294,7 @@ private:
   RWLock coll_lock;    ///< rwlock to protect coll_map
   Mutex apply_lock;    ///< serialize all updates
 
-  CollectionRef get_collection(coll_t cid);
+  CollectionRef get_collection(const coll_t& cid);
 
   Finisher finisher;
 
@@ -302,34 +302,34 @@ private:
 
   void _do_transaction(Transaction& t);
 
-  int _touch(coll_t cid, const ghobject_t& oid);
-  int _write(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len,
+  int _touch(const coll_t& cid, const ghobject_t& oid);
+  int _write(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len,
 	      const bufferlist& bl, uint32_t fadvsie_flags = 0);
-  int _zero(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len);
-  int _truncate(coll_t cid, const ghobject_t& oid, uint64_t size);
-  int _remove(coll_t cid, const ghobject_t& oid);
-  int _setattrs(coll_t cid, const ghobject_t& oid, map<string,bufferptr>& aset);
-  int _rmattr(coll_t cid, const ghobject_t& oid, const char *name);
-  int _rmattrs(coll_t cid, const ghobject_t& oid);
-  int _clone(coll_t cid, const ghobject_t& oldoid, const ghobject_t& newoid);
-  int _clone_range(coll_t cid, const ghobject_t& oldoid,
+  int _zero(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len);
+  int _truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size);
+  int _remove(const coll_t& cid, const ghobject_t& oid);
+  int _setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset);
+  int _rmattr(const coll_t& cid, const ghobject_t& oid, const char *name);
+  int _rmattrs(const coll_t& cid, const ghobject_t& oid);
+  int _clone(const coll_t& cid, const ghobject_t& oldoid, const ghobject_t& newoid);
+  int _clone_range(const coll_t& cid, const ghobject_t& oldoid,
 		   const ghobject_t& newoid,
 		   uint64_t srcoff, uint64_t len, uint64_t dstoff);
-  int _omap_clear(coll_t cid, const ghobject_t &oid);
-  int _omap_setkeys(coll_t cid, const ghobject_t &oid, bufferlist& aset_bl);
-  int _omap_rmkeys(coll_t cid, const ghobject_t &oid, bufferlist& keys_bl);
-  int _omap_rmkeyrange(coll_t cid, const ghobject_t &oid,
+  int _omap_clear(const coll_t& cid, const ghobject_t &oid);
+  int _omap_setkeys(const coll_t& cid, const ghobject_t &oid, bufferlist& aset_bl);
+  int _omap_rmkeys(const coll_t& cid, const ghobject_t &oid, bufferlist& keys_bl);
+  int _omap_rmkeyrange(const coll_t& cid, const ghobject_t &oid,
 		       const string& first, const string& last);
-  int _omap_setheader(coll_t cid, const ghobject_t &oid, const bufferlist &bl);
+  int _omap_setheader(const coll_t& cid, const ghobject_t &oid, const bufferlist &bl);
 
-  int _collection_hint_expected_num_objs(coll_t cid, uint32_t pg_num,
+  int _collection_hint_expected_num_objs(const coll_t& cid, uint32_t pg_num,
       uint64_t num_objs) const { return 0; }
-  int _create_collection(coll_t c);
-  int _destroy_collection(coll_t c);
-  int _collection_add(coll_t cid, coll_t ocid, const ghobject_t& oid);
-  int _collection_move_rename(coll_t oldcid, const ghobject_t& oldoid,
+  int _create_collection(const coll_t& c);
+  int _destroy_collection(const coll_t& c);
+  int _collection_add(const coll_t& cid, const coll_t& ocid, const ghobject_t& oid);
+  int _collection_move_rename(const coll_t& oldcid, const ghobject_t& oldoid,
 			      coll_t cid, const ghobject_t& o);
-  int _split_collection(coll_t cid, uint32_t bits, uint32_t rem, coll_t dest);
+  int _split_collection(const coll_t& cid, uint32_t bits, uint32_t rem, coll_t dest);
 
   int _save();
   int _load();
@@ -386,33 +386,33 @@ public:
 
   int statfs(struct statfs *buf);
 
-  bool exists(coll_t cid, const ghobject_t& oid);
+  bool exists(const coll_t& cid, const ghobject_t& oid);
   int stat(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     struct stat *st,
     bool allow_eio = false); // struct stat?
   int read(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
     bufferlist& bl,
     uint32_t op_flags = 0,
     bool allow_eio = false);
-  int fiemap(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl);
-  int getattr(coll_t cid, const ghobject_t& oid, const char *name, bufferptr& value);
-  int getattrs(coll_t cid, const ghobject_t& oid, map<string,bufferptr>& aset);
+  int fiemap(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl);
+  int getattr(const coll_t& cid, const ghobject_t& oid, const char *name, bufferptr& value);
+  int getattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset);
 
   int list_collections(vector<coll_t>& ls);
-  bool collection_exists(coll_t c);
-  bool collection_empty(coll_t c);
-  int collection_list(coll_t cid, ghobject_t start, ghobject_t end,
+  bool collection_exists(const coll_t& c);
+  bool collection_empty(const coll_t& c);
+  int collection_list(const coll_t& cid, ghobject_t start, ghobject_t end,
 		      bool sort_bitwise, int max,
 		      vector<ghobject_t> *ls, ghobject_t *next);
 
   int omap_get(
-    coll_t cid,                ///< [in] Collection containing oid
+    const coll_t& cid,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     map<string, bufferlist> *out /// < [out] Key to value map
@@ -420,7 +420,7 @@ public:
 
   /// Get omap header
   int omap_get_header(
-    coll_t cid,                ///< [in] Collection containing oid
+    const coll_t& cid,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     bool allow_eio = false ///< [in] don't assert on eio
@@ -428,14 +428,14 @@ public:
 
   /// Get keys defined on oid
   int omap_get_keys(
-    coll_t cid,              ///< [in] Collection containing oid
+    const coll_t& cid,              ///< [in] Collection containing oid
     const ghobject_t &oid, ///< [in] Object containing omap
     set<string> *keys      ///< [out] Keys defined on oid
     );
 
   /// Get key values
   int omap_get_values(
-    coll_t cid,                    ///< [in] Collection containing oid
+    const coll_t& cid,                    ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const set<string> &keys,     ///< [in] Keys to get
     map<string, bufferlist> *out ///< [out] Returned keys and values
@@ -443,14 +443,14 @@ public:
 
   /// Filters keys into out which are defined on oid
   int omap_check_keys(
-    coll_t cid,                ///< [in] Collection containing oid
+    const coll_t& cid,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     const set<string> &keys, ///< [in] Keys to check
     set<string> *out         ///< [out] Subset of keys defined on oid
     );
 
   ObjectMap::ObjectMapIterator get_omap_iterator(
-    coll_t cid,              ///< [in] collection
+    const coll_t& cid,              ///< [in] collection
     const ghobject_t &oid  ///< [in] object
     );
 

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -952,7 +952,7 @@ public:
      * Ensure the existance of an object in a collection. Create an
      * empty object if necessary
      */
-    void touch(coll_t cid, const ghobject_t& oid) {
+    void touch(const coll_t& cid, const ghobject_t& oid) {
       if (use_tbl) {
         __u32 op = OP_TOUCH;
         ::encode(op, tbl);
@@ -976,7 +976,7 @@ public:
      * ObjectStore will omit the untouched data and store it as a
      * "hole" in the file.
      */
-    void write(coll_t cid, const ghobject_t& oid, uint64_t off, uint64_t len,
+    void write(const coll_t& cid, const ghobject_t& oid, uint64_t off, uint64_t len,
 	       const bufferlist& write_data, uint32_t flags = 0) {
       if (use_tbl) {
         __u32 op = OP_WRITE;
@@ -1009,7 +1009,7 @@ public:
      * ObjectStore instances may optimize this to release the
      * underlying storage space.
      */
-    void zero(coll_t cid, const ghobject_t& oid, uint64_t off, uint64_t len) {
+    void zero(const coll_t& cid, const ghobject_t& oid, uint64_t off, uint64_t len) {
       if (use_tbl) {
         __u32 op = OP_ZERO;
         ::encode(op, tbl);
@@ -1028,7 +1028,7 @@ public:
       data.ops++;
     }
     /// Discard all data in the object beyond the specified size.
-    void truncate(coll_t cid, const ghobject_t& oid, uint64_t off) {
+    void truncate(const coll_t& cid, const ghobject_t& oid, uint64_t off) {
       if (use_tbl) {
         __u32 op = OP_TRUNCATE;
         ::encode(op, tbl);
@@ -1045,7 +1045,7 @@ public:
       data.ops++;
     }
     /// Remove an object. All four parts of the object are removed.
-    void remove(coll_t cid, const ghobject_t& oid) {
+    void remove(const coll_t& cid, const ghobject_t& oid) {
       if (use_tbl) {
         __u32 op = OP_REMOVE;
         ::encode(op, tbl);
@@ -1060,12 +1060,12 @@ public:
       data.ops++;
     }
     /// Set an xattr of an object
-    void setattr(coll_t cid, const ghobject_t& oid, const char* name, bufferlist& val) {
+    void setattr(const coll_t& cid, const ghobject_t& oid, const char* name, bufferlist& val) {
       string n(name);
       setattr(cid, oid, n, val);
     }
     /// Set an xattr of an object
-    void setattr(coll_t cid, const ghobject_t& oid, const string& s, bufferlist& val) {
+    void setattr(const coll_t& cid, const ghobject_t& oid, const string& s, bufferlist& val) {
       if (use_tbl) {
         __u32 op = OP_SETATTR;
         ::encode(op, tbl);
@@ -1084,7 +1084,7 @@ public:
       data.ops++;
     }
     /// Set multiple xattrs of an object
-    void setattrs(coll_t cid, const ghobject_t& oid, map<string,bufferptr>& attrset) {
+    void setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& attrset) {
       if (use_tbl) {
         __u32 op = OP_SETATTRS;
         ::encode(op, tbl);
@@ -1101,7 +1101,7 @@ public:
       data.ops++;
     }
     /// Set multiple xattrs of an object
-    void setattrs(coll_t cid, const ghobject_t& oid, map<string,bufferlist>& attrset) {
+    void setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferlist>& attrset) {
       if (use_tbl) {
         __u32 op = OP_SETATTRS;
         ::encode(op, tbl);
@@ -1118,12 +1118,12 @@ public:
       data.ops++;
     }
     /// remove an xattr from an object
-    void rmattr(coll_t cid, const ghobject_t& oid, const char *name) {
+    void rmattr(const coll_t& cid, const ghobject_t& oid, const char *name) {
       string n(name);
       rmattr(cid, oid, n);
     }
     /// remove an xattr from an object
-    void rmattr(coll_t cid, const ghobject_t& oid, const string& s) {
+    void rmattr(const coll_t& cid, const ghobject_t& oid, const string& s) {
       if (use_tbl) {
         __u32 op = OP_RMATTR;
         ::encode(op, tbl);
@@ -1140,7 +1140,7 @@ public:
       data.ops++;
     }
     /// remove all xattrs from an object
-    void rmattrs(coll_t cid, const ghobject_t& oid) {
+    void rmattrs(const coll_t& cid, const ghobject_t& oid) {
       if (use_tbl) {
         __u32 op = OP_RMATTRS;
         ::encode(op, tbl);
@@ -1165,7 +1165,7 @@ public:
      * The destination named object may already exist, in
      * which case its previous contents are discarded.
      */
-    void clone(coll_t cid, const ghobject_t& oid, ghobject_t noid) {
+    void clone(const coll_t& cid, const ghobject_t& oid, ghobject_t noid) {
       if (use_tbl) {
         __u32 op = OP_CLONE;
         ::encode(op, tbl);
@@ -1188,7 +1188,7 @@ public:
      * portion of the data from the source object. None of the other
      * three parts of an object is copied from the source.
      */
-    void clone_range(coll_t cid, const ghobject_t& oid, ghobject_t noid,
+    void clone_range(const coll_t& cid, const ghobject_t& oid, ghobject_t noid,
 		     uint64_t srcoff, uint64_t srclen, uint64_t dstoff) {
       if (use_tbl) {
         __u32 op = OP_CLONERANGE2;
@@ -1212,7 +1212,7 @@ public:
       data.ops++;
     }
     /// Create the collection
-    void create_collection(coll_t cid, int bits) {
+    void create_collection(const coll_t& cid, int bits) {
       if (use_tbl) {
         __u32 op = OP_MKCOLL;
         ::encode(op, tbl);
@@ -1234,7 +1234,7 @@ public:
      * @param hint - the hint payload, which contains the customized
      *               data along with the hint type.
      */
-    void collection_hint(coll_t cid, uint32_t type, const bufferlist& hint) {
+    void collection_hint(const coll_t& cid, uint32_t type, const bufferlist& hint) {
       if (use_tbl) {
         __u32 op = OP_COLL_HINT;
         ::encode(op, tbl);
@@ -1252,7 +1252,7 @@ public:
     }
 
     /// remove the collection, the collection must be empty
-    void remove_collection(coll_t cid) {
+    void remove_collection(const coll_t& cid) {
       if (use_tbl) {
         __u32 op = OP_RMCOLL;
         ::encode(op, tbl);
@@ -1264,7 +1264,7 @@ public:
       }
       data.ops++;
     }
-    void collection_move(coll_t cid, coll_t oldcid, const ghobject_t& oid)
+    void collection_move(const coll_t& cid, coll_t oldcid, const ghobject_t& oid)
       __attribute__ ((deprecated)) {
       // NOTE: we encode this as a fixed combo of ADD + REMOVE.  they
       // always appear together, so this is effectively a single MOVE.
@@ -1296,7 +1296,7 @@ public:
       }
       data.ops++;
     }
-    void collection_move_rename(coll_t oldcid, const ghobject_t& oldoid,
+    void collection_move_rename(const coll_t& oldcid, const ghobject_t& oldoid,
 				coll_t cid, const ghobject_t& oid) {
       if (use_tbl) {
         __u32 op = OP_COLL_MOVE_RENAME;
@@ -1320,7 +1320,7 @@ public:
     // backends need not implement these at all.
 
     /// Set an xattr on a collection
-    void collection_setattr(coll_t cid, const string& name, bufferlist& val)
+    void collection_setattr(const coll_t& cid, const string& name, bufferlist& val)
       __attribute__ ((deprecated)) {
       if (use_tbl) {
         __u32 op = OP_COLL_SETATTR;
@@ -1339,7 +1339,7 @@ public:
     }
 
     /// Remove an xattr from a collection
-    void collection_rmattr(coll_t cid, const string& name)
+    void collection_rmattr(const coll_t& cid, const string& name)
       __attribute__ ((deprecated)) {
       if (use_tbl) {
         __u32 op = OP_COLL_RMATTR;
@@ -1355,7 +1355,7 @@ public:
       data.ops++;
     }
     /// Set multiple xattrs on a collection
-    void collection_setattrs(coll_t cid, map<string,bufferptr>& aset)
+    void collection_setattrs(const coll_t& cid, map<string,bufferptr>& aset)
       __attribute__ ((deprecated)) {
       if (use_tbl) {
         __u32 op = OP_COLL_SETATTRS;
@@ -1371,7 +1371,7 @@ public:
       data.ops++;
     }
     /// Set multiple xattrs on a collection
-    void collection_setattrs(coll_t cid, map<string,bufferlist>& aset)
+    void collection_setattrs(const coll_t& cid, map<string,bufferlist>& aset)
       __attribute__ ((deprecated)) {
       if (use_tbl) {
         __u32 op = OP_COLL_SETATTRS;
@@ -1406,7 +1406,7 @@ public:
     }
     /// Set keys on oid omap.  Replaces duplicate keys.
     void omap_setkeys(
-      coll_t cid,                           ///< [in] Collection containing oid
+      const coll_t& cid,                           ///< [in] Collection containing oid
       const ghobject_t &oid,                ///< [in] Object to update
       const map<string, bufferlist> &attrset ///< [in] Replacement keys and values
       ) {
@@ -1886,7 +1886,7 @@ public:
    * @param oid oid of object
    * @returns true if object exists, false otherwise
    */
-  virtual bool exists(coll_t cid, const ghobject_t& oid) = 0;                   // useful?
+  virtual bool exists(const coll_t& cid, const ghobject_t& oid) = 0;                   // useful?
 
   /**
    * stat -- get information for an object
@@ -1898,7 +1898,7 @@ public:
    * @returns 0 on success, negative error code on failure.
    */
   virtual int stat(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     struct stat *st,
     bool allow_eio = false) = 0; // struct stat?
@@ -1919,7 +1919,7 @@ public:
    * @returns number of bytes read on success, or negative error code on failure.
    */
    virtual int read(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
@@ -1943,7 +1943,7 @@ public:
    * @param bl output bufferlist for extent map information.
    * @returns 0 on success, negative error code on failure.
    */
-  virtual int fiemap(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl) = 0;
+  virtual int fiemap(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl) = 0;
 
   /**
    * getattr -- get an xattr of an object
@@ -1954,7 +1954,7 @@ public:
    * @param value place to put output result.
    * @returns 0 on success, negative error code on failure.
    */
-  virtual int getattr(coll_t cid, const ghobject_t& oid, const char *name, bufferptr& value) = 0;
+  virtual int getattr(const coll_t& cid, const ghobject_t& oid, const char *name, bufferptr& value) = 0;
 
   /**
    * getattr -- get an xattr of an object
@@ -1965,7 +1965,7 @@ public:
    * @param value place to put output result.
    * @returns 0 on success, negative error code on failure.
    */
-  int getattr(coll_t cid, const ghobject_t& oid, const char *name, bufferlist& value) {
+  int getattr(const coll_t& cid, const ghobject_t& oid, const char *name, bufferlist& value) {
     bufferptr bp;
     int r = getattr(cid, oid, name, bp);
     if (bp.length())
@@ -1989,7 +1989,7 @@ public:
    * @param aset place to put output result.
    * @returns 0 on success, negative error code on failure.
    */
-  virtual int getattrs(coll_t cid, const ghobject_t& oid, map<string,bufferptr>& aset) = 0;
+  virtual int getattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset) = 0;
 
   /**
    * getattrs -- get all of the xattrs of an object
@@ -1999,7 +1999,7 @@ public:
    * @param aset place to put output result.
    * @returns 0 on success, negative error code on failure.
    */
-  int getattrs(coll_t cid, const ghobject_t& oid, map<string,bufferlist>& aset) {
+  int getattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferlist>& aset) {
     map<string,bufferptr> bmap;
     int r = getattrs(cid, oid, bmap);
     for (map<string,bufferptr>::iterator i = bmap.begin();
@@ -2021,7 +2021,7 @@ public:
    */
   virtual int list_collections(vector<coll_t>& ls) = 0;
 
-  virtual int collection_version_current(coll_t c, uint32_t *version) {
+  virtual int collection_version_current(const coll_t& c, uint32_t *version) {
     *version = 0;
     return 1;
   }
@@ -2031,7 +2031,7 @@ public:
    * @param c collection
    * @returns true if it exists, false otherwise
    */
-  virtual bool collection_exists(coll_t c) = 0;
+  virtual bool collection_exists(const coll_t& c) = 0;
   /**
    * collection_getattr - get an xattr of a collection
    *
@@ -2041,7 +2041,7 @@ public:
    * @param size size of buffer to receive value
    * @returns 0 on success, negative error code on failure
    */
-  virtual int collection_getattr(coll_t cid, const char *name,
+  virtual int collection_getattr(const coll_t& cid, const char *name,
 	                         void *value, size_t size)
     __attribute__ ((deprecated)) {
     return -EOPNOTSUPP;
@@ -2055,7 +2055,7 @@ public:
    * @param bl buffer to receive value
    * @returns 0 on success, negative error code on failure
    */
-  virtual int collection_getattr(coll_t cid, const char *name, bufferlist& bl)
+  virtual int collection_getattr(const coll_t& cid, const char *name, bufferlist& bl)
     __attribute__ ((deprecated)) {
     return -EOPNOTSUPP;
   }
@@ -2067,7 +2067,7 @@ public:
    * @param aset map of keys and buffers that contain the values
    * @returns 0 on success, negative error code on failure
    */
-  virtual int collection_getattrs(coll_t cid, map<string,bufferptr> &aset)
+  virtual int collection_getattrs(const coll_t& cid, map<string,bufferptr> &aset)
     __attribute__ ((deprecated)) {
     return -EOPNOTSUPP;
   }
@@ -2078,7 +2078,7 @@ public:
    * @param c collection
    * @returns true if empty, false otherwise
    */
-  virtual bool collection_empty(coll_t c) = 0;
+  virtual bool collection_empty(const coll_t& c) = 0;
 
   /**
    * list contents of a collection that fall in the range [start, end) and no more than a specified many result
@@ -2093,14 +2093,14 @@ public:
    * @param next [out] next item sorts >= this value
    * @return zero on success, or negative error
    */
-  virtual int collection_list(coll_t c, ghobject_t start, ghobject_t end,
+  virtual int collection_list(const coll_t& c, ghobject_t start, ghobject_t end,
 			      bool sort_bitwise, int max,
 			      vector<ghobject_t> *ls, ghobject_t *next) = 0;
 
   /// OMAP
   /// Get omap contents
   virtual int omap_get(
-    coll_t c,                ///< [in] Collection containing oid
+    const coll_t& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     map<string, bufferlist> *out /// < [out] Key to value map
@@ -2108,7 +2108,7 @@ public:
 
   /// Get omap header
   virtual int omap_get_header(
-    coll_t c,                ///< [in] Collection containing oid
+    const coll_t& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     bool allow_eio = false ///< [in] don't assert on eio
@@ -2116,14 +2116,14 @@ public:
 
   /// Get keys defined on oid
   virtual int omap_get_keys(
-    coll_t c,              ///< [in] Collection containing oid
+    const coll_t& c,              ///< [in] Collection containing oid
     const ghobject_t &oid, ///< [in] Object containing omap
     set<string> *keys      ///< [out] Keys defined on oid
     ) = 0;
 
   /// Get key values
   virtual int omap_get_values(
-    coll_t c,                    ///< [in] Collection containing oid
+    const coll_t& c,                    ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const set<string> &keys,     ///< [in] Keys to get
     map<string, bufferlist> *out ///< [out] Returned keys and values
@@ -2131,7 +2131,7 @@ public:
 
   /// Filters keys into out which are defined on oid
   virtual int omap_check_keys(
-    coll_t c,                ///< [in] Collection containing oid
+    const coll_t& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     const set<string> &keys, ///< [in] Keys to check
     set<string> *out         ///< [out] Subset of keys defined on oid
@@ -2147,7 +2147,7 @@ public:
    * @return iterator, null on error
    */
   virtual ObjectMap::ObjectMapIterator get_omap_iterator(
-    coll_t c,              ///< [in] collection
+    const coll_t& c,              ///< [in] collection
     const ghobject_t &oid  ///< [in] object
     ) = 0;
 

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -1087,7 +1087,7 @@ int NewStore::statfs(struct statfs *buf)
 // ---------------
 // cache
 
-NewStore::CollectionRef NewStore::_get_collection(coll_t cid)
+NewStore::CollectionRef NewStore::_get_collection(const coll_t& cid)
 {
   RWLock::RLocker l(coll_lock);
   ceph::unordered_map<coll_t,CollectionRef>::iterator cp = coll_map.find(cid);
@@ -1138,7 +1138,7 @@ void NewStore::_reap_collections()
 // ---------------
 // read operations
 
-bool NewStore::exists(coll_t cid, const ghobject_t& oid)
+bool NewStore::exists(const coll_t& cid, const ghobject_t& oid)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
   CollectionRef c = _get_collection(cid);
@@ -1152,7 +1152,7 @@ bool NewStore::exists(coll_t cid, const ghobject_t& oid)
 }
 
 int NewStore::stat(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     struct stat *st,
     bool allow_eio)
@@ -1173,7 +1173,7 @@ int NewStore::stat(
 }
 
 int NewStore::read(
-  coll_t cid,
+  const coll_t& cid,
   const ghobject_t& oid,
   uint64_t offset,
   size_t length,
@@ -1354,7 +1354,7 @@ int NewStore::_do_read(
 }
 
 int NewStore::fiemap(
-  coll_t cid,
+  const coll_t& cid,
   const ghobject_t& oid,
   uint64_t offset,
   size_t len,
@@ -1459,7 +1459,7 @@ int NewStore::fiemap(
 }
 
 int NewStore::getattr(
-  coll_t cid,
+  const coll_t& cid,
   const ghobject_t& oid,
   const char *name,
   bufferptr& value)
@@ -1491,7 +1491,7 @@ int NewStore::getattr(
 }
 
 int NewStore::getattrs(
-  coll_t cid,
+  const coll_t& cid,
   const ghobject_t& oid,
   map<string,bufferptr>& aset)
 {
@@ -1525,13 +1525,13 @@ int NewStore::list_collections(vector<coll_t>& ls)
   return 0;
 }
 
-bool NewStore::collection_exists(coll_t c)
+bool NewStore::collection_exists(const coll_t& c)
 {
   RWLock::RLocker l(coll_lock);
   return coll_map.count(c);
 }
 
-bool NewStore::collection_empty(coll_t cid)
+bool NewStore::collection_empty(const coll_t& cid)
 {
   dout(15) << __func__ << " " << cid << dendl;
   vector<ghobject_t> ls;
@@ -1546,7 +1546,7 @@ bool NewStore::collection_empty(coll_t cid)
 }
 
 int NewStore::collection_list(
-  coll_t cid, ghobject_t start, ghobject_t end,
+  const coll_t& cid, ghobject_t start, ghobject_t end,
   bool sort_bitwise, int max,
   vector<ghobject_t> *ls, ghobject_t *pnext)
 {
@@ -1738,7 +1738,7 @@ bufferlist NewStore::OmapIteratorImpl::value()
 }
 
 int NewStore::omap_get(
-  coll_t cid,                ///< [in] Collection containing oid
+  const coll_t& cid,                ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
   bufferlist *header,      ///< [out] omap header
   map<string, bufferlist> *out /// < [out] Key to value map
@@ -1787,7 +1787,7 @@ int NewStore::omap_get(
 }
 
 int NewStore::omap_get_header(
-  coll_t cid,                ///< [in] Collection containing oid
+  const coll_t& cid,                ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
   bufferlist *header,      ///< [out] omap header
   bool allow_eio ///< [in] don't assert on eio
@@ -1822,7 +1822,7 @@ int NewStore::omap_get_header(
 }
 
 int NewStore::omap_get_keys(
-  coll_t cid,              ///< [in] Collection containing oid
+  const coll_t& cid,              ///< [in] Collection containing oid
   const ghobject_t &oid, ///< [in] Object containing omap
   set<string> *keys      ///< [out] Keys defined on oid
   )
@@ -1871,7 +1871,7 @@ int NewStore::omap_get_keys(
 }
 
 int NewStore::omap_get_values(
-  coll_t cid,                    ///< [in] Collection containing oid
+  const coll_t& cid,                    ///< [in] Collection containing oid
   const ghobject_t &oid,       ///< [in] Object containing omap
   const set<string> &keys,     ///< [in] Keys to get
   map<string, bufferlist> *out ///< [out] Returned keys and values
@@ -1906,7 +1906,7 @@ int NewStore::omap_get_values(
 }
 
 int NewStore::omap_check_keys(
-  coll_t cid,                ///< [in] Collection containing oid
+  const coll_t& cid,                ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
   const set<string> &keys, ///< [in] Keys to check
   set<string> *out         ///< [out] Subset of keys defined on oid
@@ -1943,7 +1943,7 @@ int NewStore::omap_check_keys(
 }
 
 ObjectMap::ObjectMapIterator NewStore::get_omap_iterator(
-  coll_t cid,              ///< [in] collection
+  const coll_t& cid,              ///< [in] collection
   const ghobject_t &oid  ///< [in] object
   )
 {

--- a/src/os/newstore/NewStore.h
+++ b/src/os/newstore/NewStore.h
@@ -531,7 +531,7 @@ private:
   int _open_collections();
   void _close_collections();
 
-  CollectionRef _get_collection(coll_t cid);
+  CollectionRef _get_collection(const coll_t& cid);
   void _queue_reap_collection(CollectionRef& c);
   void _reap_collections();
 
@@ -621,14 +621,14 @@ public:
 
   int statfs(struct statfs *buf);
 
-  bool exists(coll_t cid, const ghobject_t& oid);
+  bool exists(const coll_t& cid, const ghobject_t& oid);
   int stat(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     struct stat *st,
     bool allow_eio = false); // struct stat?
   int read(
-    coll_t cid,
+    const coll_t& cid,
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
@@ -642,20 +642,20 @@ public:
     bufferlist& bl,
     uint32_t op_flags = 0);
 
-  int fiemap(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl);
-  int getattr(coll_t cid, const ghobject_t& oid, const char *name, bufferptr& value);
-  int getattrs(coll_t cid, const ghobject_t& oid, map<string,bufferptr>& aset);
+  int fiemap(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl);
+  int getattr(const coll_t& cid, const ghobject_t& oid, const char *name, bufferptr& value);
+  int getattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset);
 
   int list_collections(vector<coll_t>& ls);
-  bool collection_exists(coll_t c);
-  bool collection_empty(coll_t c);
+  bool collection_exists(const coll_t& c);
+  bool collection_empty(const coll_t& c);
 
-  int collection_list(coll_t cid, ghobject_t start, ghobject_t end,
+  int collection_list(const coll_t& cid, ghobject_t start, ghobject_t end,
 		      bool sort_bitwise, int max,
 		      vector<ghobject_t> *ls, ghobject_t *next);
 
   int omap_get(
-    coll_t cid,                ///< [in] Collection containing oid
+    const coll_t& cid,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     map<string, bufferlist> *out /// < [out] Key to value map
@@ -663,7 +663,7 @@ public:
 
   /// Get omap header
   int omap_get_header(
-    coll_t cid,                ///< [in] Collection containing oid
+    const coll_t& cid,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     bool allow_eio = false ///< [in] don't assert on eio
@@ -671,14 +671,14 @@ public:
 
   /// Get keys defined on oid
   int omap_get_keys(
-    coll_t cid,              ///< [in] Collection containing oid
+    const coll_t& cid,              ///< [in] Collection containing oid
     const ghobject_t &oid, ///< [in] Object containing omap
     set<string> *keys      ///< [out] Keys defined on oid
     );
 
   /// Get key values
   int omap_get_values(
-    coll_t cid,                    ///< [in] Collection containing oid
+    const coll_t& cid,                    ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const set<string> &keys,     ///< [in] Keys to get
     map<string, bufferlist> *out ///< [out] Returned keys and values
@@ -686,14 +686,14 @@ public:
 
   /// Filters keys into out which are defined on oid
   int omap_check_keys(
-    coll_t cid,                ///< [in] Collection containing oid
+    const coll_t& cid,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     const set<string> &keys, ///< [in] Keys to check
     set<string> *out         ///< [out] Subset of keys defined on oid
     );
 
   ObjectMap::ObjectMapIterator get_omap_iterator(
-    coll_t cid,              ///< [in] collection
+    const coll_t& cid,              ///< [in] collection
     const ghobject_t &oid  ///< [in] object
     );
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -540,8 +540,27 @@ public:
   }
 
   coll_t(const coll_t& other)
-    : type(other.type), pgid(other.pgid), removal_seq(other.removal_seq) {
-    calc_str();
+    : type(other.type), pgid(other.pgid), removal_seq(other.removal_seq), _str(other._str) {
+  }
+
+  coll_t(coll_t&& other)
+    : type(other.type), pgid(other.pgid), removal_seq(other.removal_seq), _str(std::move(other._str)) {
+  }
+
+  coll_t& operator=(const coll_t& other) {
+    type = other.type;
+    pgid = other.pgid;
+    removal_seq = other.removal_seq;
+    _str = other._str;
+    return *this;
+  }
+
+  coll_t& operator=(coll_t&& other) {
+    type = other.type;
+    pgid = other.pgid;
+    removal_seq = other.removal_seq;
+    _str = std::move(other._str);
+    return *this;
   }
 
   explicit coll_t(spg_t pgid)

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -543,6 +543,12 @@ public:
     : type(other.type), pgid(other.pgid), removal_seq(other.removal_seq), _str(other._str) {
   }
 
+  coll_t(const coll_t& other, bool temp)
+    : type(TYPE_PG_TEMP), pgid(other.pgid), removal_seq(0) {
+      (void)temp;
+      calc_str();
+  }
+
   coll_t(coll_t&& other)
     : type(other.type), pgid(other.pgid), removal_seq(other.removal_seq), _str(std::move(other._str)) {
   }


### PR DESCRIPTION
About 9% performance improvement above filestore.

The change is almost trivial replacement of coll_t by const coll_t&, except replacement of call to _kludge_temp_object_collection.

Comparable, but somewhat worse, improvement could be achieved by just adding move constructor to the coll_t, so leaving it as a part of the change as good to have.