### PR TITLE
log: Log.cc: Assign LOG_DEBUG priority to syslog calls

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -241,7 +241,7 @@ void Log::_flush(EntryQueue *t, EntryQueue *requeue, bool crash)
       }
 
       if (do_syslog) {
-	syslog(LOG_USER, "%s%s", buf, s.c_str());
+	syslog(LOG_USER|LOG_DEBUG, "%s%s", buf, s.c_str());
       }
 
       if (do_stderr) {
@@ -263,7 +263,7 @@ void Log::_log_message(const char *s, bool crash)
       cerr << "problem writing to " << m_log_file << ": " << cpp_strerror(r) << std::endl;
   }
   if ((crash ? m_syslog_crash : m_syslog_log) >= 0) {
-    syslog(LOG_USER, "%s", s);
+    syslog(LOG_USER|LOG_DEBUG, "%s", s);
   }
   
   if ((crash ? m_stderr_crash : m_stderr_log) >= 0) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/14137