### PR TITLE
tests:delete the default order of RBD in test_rbd.py

### DIFF
--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -138,8 +138,6 @@ def check_default_params(format, order=None, features=None, stripe_count=None,
                     eq(format == 1, image.old_format())
 
                     expected_order = order
-                    if not order:
-                        expected_order = 22
                     actual_order = image.stat()['order']
                     eq(expected_order, actual_order)
 
@@ -171,9 +169,6 @@ def test_create_defaults():
     # basic format 1 and 2
     check_default_params(1)
     check_default_params(2)
-    # default order still works
-    check_default_params(1, 0)
-    check_default_params(2, 0)
     # invalid order
     check_default_params(1, 11, exception=ArgumentOutOfRange)
     check_default_params(2, 11, exception=ArgumentOutOfRange)


### PR DESCRIPTION
delete rbd'order = RBD_DEFAULT_OBJ_ORDER process, when rbd'order is set to zero
so,delete the default order of RBD in test_rbd.py

Fixes: #14139
Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>