### PR TITLE
cache-tier: Allow to config eviction check max size

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -596,6 +596,7 @@ OPTION(osd_pool_default_cache_target_dirty_high_ratio, OPT_FLOAT, .6)
 OPTION(osd_pool_default_cache_target_full_ratio, OPT_FLOAT, .8)
 OPTION(osd_pool_default_cache_min_flush_age, OPT_INT, 0)  // seconds
 OPTION(osd_pool_default_cache_min_evict_age, OPT_INT, 0)  // seconds
+OPTION(osd_pool_default_cache_max_evict_check_size, OPT_INT, 10)  // max size to check for eviction
 OPTION(osd_hit_set_min_size, OPT_INT, 1000)  // min target size for a HitSet
 OPTION(osd_hit_set_max_size, OPT_INT, 100000)  // max target size for a HitSet
 OPTION(osd_hit_set_namespace, OPT_STR, ".ceph-internal") // rados namespace for hit_set tracking

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -11474,7 +11474,7 @@ bool ReplicatedPG::agent_work(int start_max, int agent_flush_quota)
   assert(base_pool);
 
   int ls_min = 1;
-  int ls_max = 10; // FIXME?
+  int ls_max = cct->_conf->osd_pool_default_cache_max_evict_check_size;
 
   // list some objects.  this conveniently lists clones (oldest to
   // newest) before heads... the same order we want to flush in.


### PR DESCRIPTION
This patch adds the option for eviction check size in cache-tier.
On a busy setup, it's better to check bigger number of objects so
the eviction is faster.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>