### PR TITLE
librbd:add an option to limit the number of snapshots an image can have

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1007,6 +1007,7 @@ OPTION(rbd_skip_partial_discard, OPT_BOOL, false) // when trying to discard a ra
 OPTION(rbd_enable_alloc_hint, OPT_BOOL, true) // when writing a object, it will issue a hint to osd backend to indicate the expected size object need
 OPTION(rbd_tracing, OPT_BOOL, false) // true if LTTng-UST tracepoints should be enabled
 OPTION(rbd_validate_pool, OPT_BOOL, true) // true if empty pools should be validated for RBD compatibility
+OPTION(rbd_snap_max_nums, OPT_U64, 255) // the number snap of image
 
 /*
  * The following options change the behavior for librbd's image creation methods that

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -126,6 +126,7 @@ namespace librbd {
   int snap_create(ImageCtx *ictx, const char *snap_name);
   void snap_create_helper(ImageCtx *ictx, Context* ctx, const char *snap_name);
   int snap_list(ImageCtx *ictx, std::vector<snap_info_t>& snaps);
+  int snap_list_nums(ImageCtx *ictx, uint64_t *snap_nums);
   int snap_exists(ImageCtx *ictx, const char *snap_name, bool *exists);
   int snap_rollback(ImageCtx *ictx, const char *snap_name,
 		    ProgressContext& prog_ctx);


### PR DESCRIPTION
Get the number of the Snap in the Image
snap_create_helper add rule "determine whether more than the maximum number of snap Settings"

Fixes: #12892
Signed-off-by: ren.huanwen@zte.com.cn
