### PR TITLE
tools/cephfs: add tmap_upgrade

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -12,6 +12,10 @@ v10.0.0
   limit max waiting time of monitor election process, which was previously
   restricted by 'mon_lease'.
 
+* CephFS filesystems created using versions older than Firefly (0.80) must
+  use the new "cephfs-data-scan tmap_upgrade" command after upgrading to
+  Jewel.  See 'Upgrading' in the CephFS documentation for more information.
+
 v9.3.0
 ======
 * Some symbols wrongly exposed by librados in v9.1.0 and v9.2.0 were removed.

--- a/doc/cephfs/index.rst
+++ b/doc/cephfs/index.rst
@@ -92,6 +92,7 @@ authentication keyring.
 	Troubleshooting <troubleshooting>
 	Disaster recovery <disaster-recovery>
 	Client authentication <client-auth>
+	Upgrading old filesystems <upgrading>
 
 .. raw:: html
 

--- a/doc/cephfs/upgrading.rst
+++ b/doc/cephfs/upgrading.rst
@@ -1,0 +1,34 @@
+
+Upgrading pre-Firefly filesystems past Jewel
+============================================
+
+.. tip::
+
+    This advice only applies to users with filesystems
+    created using versions of Ceph older than *Firefly* (0.80).
+    Users creating new filesystems may disregard this advice.
+
+Pre-firefly versions of Ceph used a now-deprecated format
+for storing CephFS directory objects, called TMAPs.  Support
+for reading these in RADOS will be removed after the Jewel
+release of Ceph, so for upgrading CephFS users it is important
+to ensure that any old directory objects have been converted.
+
+After installing Jewel on all your MDS and OSD servers, and restarting
+the services, run the following command:
+
+::
+    
+    cephfs-data-scan tmap_upgrade <metadata pool name>
+
+This only needs to be run once, and it is not necessary to
+stop any other services while it runs.  The command may take some
+time to execute, as it iterates overall objects in your metadata
+pool.  It is safe to continue using your filesystem as normal while
+it executes.  If the command aborts for any reason, it is safe
+to simply run it again.
+
+If you are upgrading a pre-Firefly CephFS filesystem to a newer Ceph version
+than Jewel, you must first upgrade to Jewel and run the ``tmap_upgrade``
+command before completing your upgrade to the latest version.
+

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2077,6 +2077,17 @@ set_target_properties(test_rados_api_misc PROPERTIES COMPILE_FLAGS
 target_link_libraries(test_rados_api_misc
   librados global ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
+add_executable(test_rados_api_tmap_migrate
+  ../tools/cephfs/DataScan.cc
+  ../tools/cephfs/MDSUtility.cc
+  librados/tmap_migrate.cc
+  $<TARGET_OBJECTS:heap_profiler_objs>
+  )
+set_target_properties(test_rados_api_tmap_migrate PROPERTIES COMPILE_FLAGS
+  ${UNITTEST_CXX_FLAGS})
+target_link_libraries(test_rados_api_tmap_migrate
+  librados mds osdc global cls_cephfs_client ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
+
 add_executable(test_rados_api_lock
   librados/lock.cc
   $<TARGET_OBJECTS:heap_profiler_objs>

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -285,6 +285,11 @@ ceph_test_rados_api_lock_LDADD = $(LIBRADOS) $(UNITTEST_LDADD) $(RADOS_TEST_LDAD
 ceph_test_rados_api_lock_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_rados_api_lock
 
+ceph_test_rados_api_tmap_migrate_SOURCES = test/librados/tmap_migrate.cc tools/cephfs/DataScan.cc tools/cephfs/MDSUtility.cc
+ceph_test_rados_api_tmap_migrate_LDADD = $(LIBRADOS) $(UNITTEST_LDADD) $(LIBMDS) libcls_cephfs_client.la  $(CEPH_GLOBAL) $(RADOS_TEST_LDADD)
+ceph_test_rados_api_tmap_migrate_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+bin_DEBUGPROGRAMS += ceph_test_rados_api_tmap_migrate
+
 
 ceph_test_stress_watch_SOURCES = test/test_stress_watch.cc
 ceph_test_stress_watch_LDADD = \

--- a/src/test/librados/tmap_migrate.cc
+++ b/src/test/librados/tmap_migrate.cc
@@ -1,0 +1,70 @@
+#include "include/rados/librados.h"
+#include "include/rados/librados.hpp"
+#include "test/librados/test.h"
+#include "test/librados/TestCase.h"
+#include "include/encoding.h"
+#include "tools/cephfs/DataScan.h"
+#include "global/global_init.h"
+
+#include <algorithm>
+#include <errno.h>
+#include "gtest/gtest.h"
+
+
+using namespace librados;
+
+typedef RadosTestPP TmapMigratePP;
+
+TEST_F(TmapMigratePP, DataScan) {
+  std::vector<const char *> args;
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+
+  // DataScan isn't namespace-aware, so override RadosTestPP's default
+  // behaviour of putting everything into a namespace
+  ioctx.set_namespace("");
+
+  bufferlist header;
+  std::map<std::string, bufferlist> kvs;
+  bufferlist val;
+  val.append("custard");
+  kvs.insert({"rhubarb", val});
+
+  bufferlist tmap_trans;
+  ::encode(header, tmap_trans);
+  ::encode(kvs, tmap_trans);
+
+  // Create a TMAP object
+  ASSERT_EQ(0, ioctx.tmap_put("10000000000.00000000", tmap_trans));
+
+  // Create an OMAP object
+  std::map<std::string, bufferlist> omap_kvs;
+  bufferlist omap_val;
+  omap_val.append("waffles");
+  omap_kvs.insert({"tasty", omap_val});
+  ASSERT_EQ(0, ioctx.omap_set("10000000001.00000000", omap_kvs));
+
+  DataScan ds;
+  ASSERT_EQ(0, ds.init());
+  int r = ds.main({"tmap_upgrade", pool_name.c_str()});
+  ASSERT_EQ(r, 0);
+  ds.shutdown();
+
+  // Check that the TMAP object is now an omap object
+  std::map<std::string, bufferlist> read_vals;
+  ASSERT_EQ(0, ioctx.omap_get_vals("10000000000.00000000", "", 1, &read_vals));
+  ASSERT_EQ(read_vals.size(), 1);
+  bufferlist tmap_expect_val;
+  tmap_expect_val.append("custard");
+  ASSERT_EQ(read_vals.at("rhubarb"), tmap_expect_val);
+
+
+  // Check that the OMAP object is still readable
+  read_vals.clear();
+  ASSERT_EQ(0, ioctx.omap_get_vals("10000000001.00000000", "", 1, &read_vals));
+  ASSERT_EQ(read_vals.size(), 1);
+  bufferlist expect_omap_val;
+  expect_omap_val.append("waffles");
+  ASSERT_EQ(read_vals.at("tasty"), expect_omap_val);
+}
+

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -249,6 +249,16 @@ class DataScan : public MDSUtility, public MetadataTool
      */
     int scan_frags();
 
+    /**
+     * Check if an inode number is in the permitted ranges
+     */
+    bool valid_ino(inodeno_t ino) const;
+
+    /**
+     * Invoke tmap_to_omap on all metadata pool objects
+     */
+    int tmap_upgrade();
+
     // Accept pools which are not in the MDSMap
     bool force_pool;
     // Respond to decode errors by overwriting


### PR DESCRIPTION
Because TMAP support will go away in Jewel+1,
we need a way to ensure anyone upgrading
an ancient CephFS filesystem can make sure
all their TMAPs have gone away.

Signed-off-by: John Spray <john.spray@redhat.com>