### PR TITLE
correct radosgw-admin command

### DIFF
--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -343,7 +343,7 @@ Once you set a user quota, you may enable it. For example::
 
 You may disable an enabled user quota. For example:: 
 
-	radosgw-admin quota-disable --quota-scope=user --uid=<uid>
+	radosgw-admin quota disable --quota-scope=user --uid=<uid>
 
 
 Set Bucket Quota
@@ -367,7 +367,7 @@ Once you set a bucket quota, you may enable it. For example::
 
 You may disable an enabled bucket quota. For example:: 
 
-	radosgw-admin quota-disable --quota-scope=bucket --uid=<uid>
+	radosgw-admin quota disable --quota-scope=bucket --uid=<uid>
 
 
 Get Quota Settings


### PR DESCRIPTION
The command to disable users quota should be 'radosgw-admin quota disable --quota-scope=<user | bucket> --uid=<uid>'