### PR TITLE
osd: Avoid osd_op_thread suicide because osd_scrub_sleep >

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3851,7 +3851,9 @@ void PG::scrub(epoch_t queued, ThreadPool::TPHandle &handle)
     unlock();
     utime_t t;
     t.set_from_double(g_conf->osd_scrub_sleep);
+    handle.suspend_tp_timeout();
     t.sleep();
+    handle.reset_tp_timeout();
     lock();
     dout(20) << __func__ << " slept for " << t << dendl;
   }


### PR DESCRIPTION
tp_suicide_timeout.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>