### PR TITLE
Osd shutdown fix

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6629,7 +6629,7 @@ void OSD::handle_osd_map(MOSDMap *m)
   // yay!
   consume_map();
 
-  if (is_active() || is_waiting_for_healthy())
+  if (!do_shutdown && (is_active() || is_waiting_for_healthy()))
     maybe_update_heartbeat_peers();
 
   if (!is_active()) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6645,7 +6645,6 @@ void OSD::handle_osd_map(MOSDMap *m)
   }
   else if (do_shutdown) {
     osd_lock.Unlock();
-    shutdown();
     if (network_error) {
       map<int,pair<utime_t,entity_inst_t>>::iterator it = failure_pending.begin();
       while (it != failure_pending.end()) {
@@ -6654,6 +6653,7 @@ void OSD::handle_osd_map(MOSDMap *m)
         failure_pending.erase(it++);
       }
     }
+    shutdown();
     osd_lock.Lock();
   }
   else if (is_preboot()) {


### PR DESCRIPTION
c760789eee62011fd3d1e2aa4a00a3b252604476 is a cleanup that skip hb_peers update when we plan to shutdown.

4e33bf58e6efc5a6649878d8ca67ab582d0e5f90 is a bug fix for bug #14150