### PR TITLE
cppcheck complains on double free

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -48,7 +48,6 @@ static void fuse_usage()
   if (fuse_parse_cmdline(&args, NULL, NULL, NULL) == -1) {
     derr << "fuse_parse_cmdline failed." << dendl;
     fuse_opt_free_args(&args);
-    free(argv);
   }
 
   assert(args.allocated);  // Checking fuse has realloc'd args so we can free newargv


### PR DESCRIPTION
Checking src/ceph_fuse.cc...
[src/ceph_fuse.cc:55]: (error) Memory pointed to by 'argv' is freed twice.
[src/ceph_fuse.cc:55]: (error) Deallocating a deallocated pointer: argv