### PR TITLE
doc:adding "--allow-shrink" in decreasing the size of the rbd block to distinguish from the increasing option

### DIFF
--- a/doc/rbd/rados-rbd-cmds.rst
+++ b/doc/rbd/rados-rbd-cmds.rst
@@ -85,7 +85,8 @@ a maximum capacity  that you set with the ``--size`` option. If you want to
 increase (or decrease) the maximum size of a Ceph Block Device image, execute
 the following:: 
 
-	rbd resize --size 2048 foo
+	rbd resize --size 2048 foo (to increase)
+	rbd resize --size 2048 foo --allow-shrink (to decrease)
 
 
 Removing a Block Device Image


### PR DESCRIPTION
  In the original file, the increasing and decreaing of the size of the rbd block shares the same option:
    "rbd resize --size 2048 foo".
  However, it is not proper, as the "--allow-shrink" needs to be added while decreasing the size of the rbd block.
  As a result, it is necessary to make a distinguish between these two options as follows:
    "rbd resize --size 2048 foo (to increase)"
    "rbd resize --size 2048 foo --allow-shrink (to decrease)"

Signed-off-by: Yehua Chen <chen.yehua@h3c.com>