### PR TITLE
ceph-detect-init: fix py3 test

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
@@ -8,6 +8,7 @@ def choose_init():
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
+    assert(distro and codename)
     if distro.lower() in ('ubuntu', 'linuxmint'):
         if codename >= 'vivid':
             return 'systemd'

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -44,15 +44,18 @@ class TestCephDetectInit(testtools.TestCase):
         self.assertEqual('sysvinit', centos.choose_init())
 
     def test_debian(self):
-        with mock.patch('ceph_detect_init.debian.distro',
-                        'debian'):
+        with mock.patch.multiple('ceph_detect_init.debian',
+                                 distro='debian',
+                                 codename='wheezy'):
             self.assertEqual('sysvinit', debian.choose_init())
-        with mock.patch('ceph_detect_init.debian.distro',
-                        'ubuntu'):
+        with mock.patch.multiple('ceph_detect_init.debian',
+                                 distro='ubuntu',
+                                 codename='trusty'):
             self.assertEqual('upstart', debian.choose_init())
-            with mock.patch('ceph_detect_init.debian.codename',
-                            'vivid'):
-                self.assertEqual('systemd', debian.choose_init())
+        with mock.patch.multiple('ceph_detect_init.debian',
+                                 distro='ubuntu',
+                                 codename='vivid'):
+            self.assertEqual('systemd', debian.choose_init())
 
     def test_fedora(self):
         with mock.patch('ceph_detect_init.fedora.release',


### PR DESCRIPTION
* in python3, None can not be compared with a str. and
  we should always set codename with a non empty str, so update
  TestCephDetectInit.test_debian so it always set a code name.
  and assert(codename and distroname) in choose_init().
* and debian switched its default init system to systemd in
  jessie, see
  https://lists.debian.org/debian-ctte/2014/02/msg00405.html
* and add a test for unsupported debian distro

Signed-off-by: Kefu Chai <kchai@redhat.com>