### PR TITLE
rbd:must specify both of stripe-unit and stripe-count when specify striping features

### DIFF
--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -366,6 +366,10 @@ int get_image_options(const boost::program_options::variables_map &vm,
     }
     features |= RBD_FEATURE_STRIPINGV2;
   } else {
+    if (features_specified && ((features & RBD_FEATURE_STRIPINGV2) != 0)) {
+      std::cerr << "must specify both of stripe-unit and stripe-count when specify striping features" << std::endl;
+      return -EINVAL;
+    }
     features &= ~RBD_FEATURE_STRIPINGV2;
   }
 


### PR DESCRIPTION
when specify striping features, Be sure specify both of stirpe-unit and stripe-count too, If not, refuse to excute and give a message

Signed-off-by:Donghai Xu <xu.donghai@h3c.com>