### PR TITLE
async: don't use shared_ptr to manage EventCallback

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -147,6 +147,7 @@ class C_clean_handler : public EventCallback {
   C_clean_handler(AsyncConnectionRef c): conn(c) {}
   void do_request(int id) {
     conn->cleanup_handler();
+    delete this;
   }
 };
 
@@ -183,13 +184,13 @@ AsyncConnection::AsyncConnection(CephContext *cct, AsyncMessenger *m, EventCente
     recv_start(0), recv_end(0), got_bad_auth(false), authorizer(NULL), replacing(false),
     is_reset_from_peer(false), once_ready(false), state_buffer(NULL), state_offset(0), net(cct), center(c)
 {
-  read_handler.reset(new C_handle_read(this));
-  write_handler.reset(new C_handle_write(this));
-  reset_handler.reset(new C_handle_reset(async_msgr, this));
-  remote_reset_handler.reset(new C_handle_remote_reset(async_msgr, this));
-  connect_handler.reset(new C_deliver_connect(async_msgr, this));
-  local_deliver_handler.reset(new C_local_deliver(this));
-  wakeup_handler.reset(new C_time_wakeup(this));
+  read_handler = new C_handle_read(this);
+  write_handler = new C_handle_write(this);
+  reset_handler = new C_handle_reset(async_msgr, this);
+  remote_reset_handler = new C_handle_remote_reset(async_msgr, this);
+  connect_handler = new C_deliver_connect(async_msgr, this);
+  local_deliver_handler = new C_local_deliver(this);
+  wakeup_handler = new C_time_wakeup(this);
   memset(msgvec, 0, sizeof(msgvec));
   // double recv_max_prefetch see "read_until"
   recv_buf = new char[2*recv_max_prefetch];

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -316,13 +316,13 @@ class AsyncConnection : public Connection {
     mark_down();
   }
   void cleanup_handler() {
-    read_handler.reset();
-    write_handler.reset();
-    reset_handler.reset();
-    remote_reset_handler.reset();
-    connect_handler.reset();
-    local_deliver_handler.reset();
-    wakeup_handler.reset();
+    delete read_handler;
+    delete write_handler;
+    delete reset_handler;
+    delete remote_reset_handler;
+    delete connect_handler;
+    delete local_deliver_handler;
+    delete wakeup_handler;
   }
   PerfCounters *get_perf_counter() {
     return logger;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -50,16 +50,6 @@ static ostream& _prefix(std::ostream *_dout, WorkerPool *p) {
 }
 
 
-class C_processor_accept : public EventCallback {
-  Processor *pro;
-
- public:
-  C_processor_accept(Processor *p): pro(p) {}
-  void do_request(int id) {
-    pro->accept();
-  }
-};
-
 
 /*******************
  * Processor
@@ -232,8 +222,7 @@ int Processor::start(Worker *w)
   // start thread
   if (listen_sd >= 0) {
     worker = w;
-    w->center.create_file_event(listen_sd, EVENT_READABLE,
-                                EventCallbackRef(new C_processor_accept(this)));
+    w->center.create_file_event(listen_sd, EVENT_READABLE, listen_handler);
   }
 
   return 0;

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -103,9 +103,22 @@ class Processor {
   Worker *worker;
   int listen_sd;
   uint64_t nonce;
+  EventCallbackRef listen_handler;
+
+  class C_processor_accept : public EventCallback {
+    Processor *pro;
+
+   public:
+    C_processor_accept(Processor *p): pro(p) {}
+    void do_request(int id) {
+      pro->accept();
+    }
+  };
 
  public:
-  Processor(AsyncMessenger *r, CephContext *c, uint64_t n): msgr(r), net(c), worker(NULL), listen_sd(-1), nonce(n) {}
+  Processor(AsyncMessenger *r, CephContext *c, uint64_t n)
+          : msgr(r), net(c), worker(NULL), listen_sd(-1), nonce(n), listen_handler(new C_processor_accept(this)) {}
+  ~Processor() { delete listen_handler; };
 
   void stop();
   int bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports);
@@ -135,6 +148,7 @@ class WorkerPool {
       Mutex::Locker l(pool->barrier_lock);
       pool->barrier_count.dec();
       pool->barrier_cond.Signal();
+      delete this;
     }
   };
   friend class C_barrier;

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -199,10 +199,10 @@ void EventCenter::delete_file_event(int fd, int mask)
   }
 
   if (mask & EVENT_READABLE && event->read_cb) {
-    event->read_cb.reset();
+    event->read_cb = nullptr;
   }
   if (mask & EVENT_WRITABLE && event->write_cb) {
-    event->write_cb.reset();
+    event->write_cb = nullptr;
   }
 
   event->mask = event->mask & (~mask);

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -58,7 +58,7 @@ class EventCallback {
   virtual ~EventCallback() {}       // we want a virtual destructor!!!
 };
 
-typedef ceph::shared_ptr<EventCallback> EventCallbackRef;
+typedef EventCallback* EventCallbackRef;
 
 struct FiredFileEvent {
   int fd;


### PR DESCRIPTION
Reduce all shared_ptr overhead for each message

Signed-off-by: Haomai Wang <haomai@xsky.com>