### PR TITLE
KeyValueStore: fix return code of mkfs

### DIFF
--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -649,7 +649,7 @@ int KeyValueStore::mkfs()
       goto close_fsid_fd;
     }
     if (::fsync(fsid_fd) < 0) {
-      ret = errno;
+      ret = -errno;
       derr << "mkfs: close failed: can't write fsid: "
            << cpp_strerror(ret) << dendl;
       goto close_fsid_fd;


### PR DESCRIPTION
It shall return a negative result code instead, otherwise the main(from ceph_osd.cc)->OSD::mkfs()->KeyValueStore::mkfs() shall be problematic.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>