### PR TITLE
rgw: add missing error code for admin op API

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -497,7 +497,7 @@ Special Error Responses
 :Description: Provided email address exists.
 :Code: 409 Conflict
 
-``InvalidCap``
+``InvalidCapability``
 
 :Description: Attempt to grant invalid admin capability.
 :Code: 400 Bad Request
@@ -685,7 +685,7 @@ Special Error Responses
 :Description: Provided email address exists.
 :Code: 409 Conflict
 
-``InvalidCap``
+``InvalidCapability``
 
 :Description: Attempt to grant invalid admin capability.
 :Code: 400 Bad Request
@@ -1719,7 +1719,7 @@ If successful, the response contains the user's capabilities.
 Special Error Responses
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-``InvalidCap``
+``InvalidCapability``
 
 :Description: Attempt to grant invalid admin capability.
 :Code: 400 Bad Request
@@ -1796,7 +1796,7 @@ If successful, the response contains the user's capabilities.
 Special Error Responses
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-``InvalidCap``
+``InvalidCapability``
 
 :Description: Attempt to remove an invalid admin capability.
 :Code: 400 Bad Request

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1010,7 +1010,7 @@ int RGWUserCaps::get_cap(const string& cap, string& type, uint32_t *pperm)
   }
 
   if (!is_valid_cap_type(type))
-    return -EINVAL;
+    return -ERR_INVALID_CAP;
 
   string cap_perm;
   uint32_t perm = 0;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -158,6 +158,7 @@ using ceph::crypto::MD5;
 #define ERR_NOT_SLO_MANIFEST     2031
 #define ERR_EMAIL_EXIST          2032
 #define ERR_KEY_EXIST            2033
+#define ERR_INVALID_SECRET_KEY   2034
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
 #define ERR_NOT_IMPLEMENTED      2201

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -160,6 +160,7 @@ using ceph::crypto::MD5;
 #define ERR_KEY_EXIST            2033
 #define ERR_INVALID_SECRET_KEY   2034
 #define ERR_INVALID_KEY_TYPE     2035
+#define ERR_INVALID_CAP          2036
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
 #define ERR_NOT_IMPLEMENTED      2201

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -156,6 +156,7 @@ using ceph::crypto::MD5;
 #define ERR_MALFORMED_XML        2029
 #define ERR_USER_EXIST           2030
 #define ERR_NOT_SLO_MANIFEST     2031
+#define ERR_EMAIL_EXIST          2032
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
 #define ERR_NOT_IMPLEMENTED      2201

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -159,6 +159,7 @@ using ceph::crypto::MD5;
 #define ERR_EMAIL_EXIST          2032
 #define ERR_KEY_EXIST            2033
 #define ERR_INVALID_SECRET_KEY   2034
+#define ERR_INVALID_KEY_TYPE     2035
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
 #define ERR_NOT_IMPLEMENTED      2201

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -157,6 +157,7 @@ using ceph::crypto::MD5;
 #define ERR_USER_EXIST           2030
 #define ERR_NOT_SLO_MANIFEST     2031
 #define ERR_EMAIL_EXIST          2032
+#define ERR_KEY_EXIST            2033
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
 #define ERR_NOT_IMPLEMENTED      2201

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -53,6 +53,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ERR_USER_EXIST, 409, "UserAlreadyExists" },
     { ERR_EMAIL_EXIST, 409, "EmailExists" },
     { ERR_KEY_EXIST, 409, "KeyExists"},
+    { ERR_INVALID_SECRET_KEY, 400, "InvalidSecretKey"},
     { ENOTEMPTY, 409, "BucketNotEmpty" },
     { ERR_PRECONDITION_FAILED, 412, "PreconditionFailed" },
     { ERANGE, 416, "InvalidRange" },

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -55,6 +55,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ERR_KEY_EXIST, 409, "KeyExists"},
     { ERR_INVALID_SECRET_KEY, 400, "InvalidSecretKey"},
     { ERR_INVALID_KEY_TYPE, 400, "InvalidKeyType"},
+    { ERR_INVALID_CAP, 400, "InvalidCapability"},
     { ENOTEMPTY, 409, "BucketNotEmpty" },
     { ERR_PRECONDITION_FAILED, 412, "PreconditionFailed" },
     { ERANGE, 416, "InvalidRange" },

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -54,6 +54,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ERR_EMAIL_EXIST, 409, "EmailExists" },
     { ERR_KEY_EXIST, 409, "KeyExists"},
     { ERR_INVALID_SECRET_KEY, 400, "InvalidSecretKey"},
+    { ERR_INVALID_KEY_TYPE, 400, "InvalidKeyType"},
     { ENOTEMPTY, 409, "BucketNotEmpty" },
     { ERR_PRECONDITION_FAILED, 412, "PreconditionFailed" },
     { ERANGE, 416, "InvalidRange" },

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -51,6 +51,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ETIMEDOUT, 408, "RequestTimeout" },
     { EEXIST, 409, "BucketAlreadyExists" },
     { ERR_USER_EXIST, 409, "UserAlreadyExists" },
+    { ERR_EMAIL_EXIST, 409, "EmailExists" },
     { ENOTEMPTY, 409, "BucketNotEmpty" },
     { ERR_PRECONDITION_FAILED, 412, "PreconditionFailed" },
     { ERANGE, 416, "InvalidRange" },

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -52,6 +52,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { EEXIST, 409, "BucketAlreadyExists" },
     { ERR_USER_EXIST, 409, "UserAlreadyExists" },
     { ERR_EMAIL_EXIST, 409, "EmailExists" },
+    { ERR_KEY_EXIST, 409, "KeyExists"},
     { ENOTEMPTY, 409, "BucketNotEmpty" },
     { ERR_PRECONDITION_FAILED, 412, "PreconditionFailed" },
     { ERANGE, 416, "InvalidRange" },

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1836,12 +1836,15 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
 
     if (op_state.found_by_email) {
       set_err_msg(err_msg, "email: " + user_email + " exists");
+      ret = -ERR_EMAIL_EXIST;
     } else if (op_state.found_by_key) {
       set_err_msg(err_msg, "duplicate key provided");
+      ret = -EEXIST;
     } else {
       set_err_msg(err_msg, "user: " + op_state.user_id.to_str() + " exists");
+      ret = -EEXIST;
     }
-    return -EEXIST;
+    return ret;
   }
 
   // fail if the user_info has already been populated
@@ -2066,7 +2069,7 @@ int RGWUser::execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg)
       ret = rgw_get_user_info_by_email(store, op_email, duplicate_check);
       if (ret >= 0 && duplicate_check.user_id.compare(user_id) != 0) {
         set_err_msg(err_msg, "cannot add duplicate email");
-        return -EEXIST;
+        return -ERR_EMAIL_EXIST;
       }
     }
     user_info.user_email = op_email;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1013,7 +1013,7 @@ int RGWAccessKeyPool::modify_key(RGWUserAdminOpState& op_state, std::string *err
     break;
   default:
     set_err_msg(err_msg, "invalid key type");
-    return -EINVAL;
+    return -ERR_INVALID_KEY_TYPE;
   }
 
   if (!op_state.has_existing_key()) {

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -917,7 +917,7 @@ int RGWAccessKeyPool::generate_key(RGWUserAdminOpState& op_state, std::string *e
   if (!gen_secret) {
     if (op_state.get_secret_key().empty()) {
       set_err_msg(err_msg, "empty secret key");
-      return -EINVAL; 
+      return -ERR_INVALID_SECRET_KEY;
     }
   
     key = op_state.get_secret_key();
@@ -1049,7 +1049,7 @@ int RGWAccessKeyPool::modify_key(RGWUserAdminOpState& op_state, std::string *err
 
   if (key.empty()) {
       set_err_msg(err_msg, "empty secret key");
-      return  -EINVAL;
+      return -ERR_INVALID_SECRET_KEY;
   }
 
   // update the access key with the new secret key

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1521,7 +1521,7 @@ int RGWUserCapPool::init(RGWUserAdminOpState& op_state)
   caps = op_state.get_caps_obj();
   if (!caps) {
     caps_allowed = false;
-    return -EINVAL;
+    return -ERR_INVALID_CAP;
   }
 
   caps_allowed = true;
@@ -1551,7 +1551,7 @@ int RGWUserCapPool::add(RGWUserAdminOpState& op_state, std::string *err_msg, boo
 
   if (caps_str.empty()) {
     set_err_msg(err_msg, "empty user caps");
-    return -EINVAL;
+    return -ERR_INVALID_CAP;
   }
 
   int r = caps->add_from_string(caps_str);
@@ -1592,7 +1592,7 @@ int RGWUserCapPool::remove(RGWUserAdminOpState& op_state, std::string *err_msg, 
 
   if (caps_str.empty()) {
     set_err_msg(err_msg, "empty user caps");
-    return -EINVAL;
+    return -ERR_INVALID_CAP;
   }
 
   int r = caps->remove_from_string(caps_str);

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -882,7 +882,7 @@ int RGWAccessKeyPool::generate_key(RGWUserAdminOpState& op_state, std::string *e
 
   if (op_state.has_existing_key()) {
     set_err_msg(err_msg, "cannot create existing key");
-    return -EEXIST;
+    return -ERR_KEY_EXIST;
   }
 
   if (!gen_access) {
@@ -894,13 +894,13 @@ int RGWAccessKeyPool::generate_key(RGWUserAdminOpState& op_state, std::string *e
     case KEY_TYPE_SWIFT:
       if (rgw_get_user_info_by_swift(store, id, duplicate_check) >= 0) {
         set_err_msg(err_msg, "existing swift key in RGW system:" + id);
-        return -EEXIST;
+        return -ERR_KEY_EXIST;
       }
       break;
     case KEY_TYPE_S3:
       if (rgw_get_user_info_by_access_key(store, id, duplicate_check) >= 0) {
         set_err_msg(err_msg, "existing S3 key in RGW system:" + id);
-        return -EEXIST;
+        return -ERR_KEY_EXIST;
       }
     }
   }
@@ -964,7 +964,7 @@ int RGWAccessKeyPool::generate_key(RGWUserAdminOpState& op_state, std::string *e
     // check that the access key doesn't exist
     if (rgw_get_user_info_by_swift(store, id, duplicate_check) >= 0) {
       set_err_msg(err_msg, "cannot create existing swift key");
-      return -EEXIST;
+      return -ERR_KEY_EXIST;
     }
   }
 
@@ -1839,7 +1839,7 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
       ret = -ERR_EMAIL_EXIST;
     } else if (op_state.found_by_key) {
       set_err_msg(err_msg, "duplicate key provided");
-      ret = -EEXIST;
+      ret = -ERR_KEY_EXIST;
     } else {
       set_err_msg(err_msg, "user: " + op_state.user_id.to_str() + " exists");
       ret = -EEXIST;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -850,7 +850,7 @@ int RGWAccessKeyPool::check_op(RGWUserAdminOpState& op_state,
   if (key_type == KEY_TYPE_S3 && !op_state.will_gen_access() && 
       op_state.get_access_key().empty()) {
     set_err_msg(err_msg, "empty access key");
-    return -EINVAL;
+    return -ERR_INVALID_ACCESS_KEY;
   }
 
   // don't check for secret key because we may be doing a removal
@@ -958,7 +958,7 @@ int RGWAccessKeyPool::generate_key(RGWUserAdminOpState& op_state, std::string *e
     id = op_state.build_default_swift_kid();
     if (id.empty()) {
       set_err_msg(err_msg, "empty swift access key");
-      return -EINVAL;
+      return -ERR_INVALID_ACCESS_KEY;
     }
 
     // check that the access key doesn't exist
@@ -1001,7 +1001,7 @@ int RGWAccessKeyPool::modify_key(RGWUserAdminOpState& op_state, std::string *err
     id = op_state.get_access_key();
     if (id.empty()) {
       set_err_msg(err_msg, "no access key specified");
-      return -EINVAL;
+      return -ERR_INVALID_ACCESS_KEY;
     }
     break;
   case KEY_TYPE_SWIFT:
@@ -1018,7 +1018,7 @@ int RGWAccessKeyPool::modify_key(RGWUserAdminOpState& op_state, std::string *err
 
   if (!op_state.has_existing_key()) {
     set_err_msg(err_msg, "key does not exist");
-    return -EINVAL;
+    return -ERR_INVALID_ACCESS_KEY;
   }
 
   key_pair.first = id;
@@ -1139,7 +1139,7 @@ int RGWAccessKeyPool::execute_remove(RGWUserAdminOpState& op_state, std::string 
 
   if (!op_state.has_existing_key()) {
     set_err_msg(err_msg, "unable to find access key");
-    return -EINVAL;
+    return -ERR_INVALID_ACCESS_KEY;
   }
 
   if (key_type == KEY_TYPE_S3) {
@@ -1149,13 +1149,13 @@ int RGWAccessKeyPool::execute_remove(RGWUserAdminOpState& op_state, std::string 
   } else {
     keys_map = NULL;
     set_err_msg(err_msg, "invalid access key");
-    return -EINVAL;
+    return -ERR_INVALID_ACCESS_KEY;
   }
 
   kiter = keys_map->find(id);
   if (kiter == keys_map->end()) {
     set_err_msg(err_msg, "key not found");
-    return -EINVAL;
+    return -ERR_INVALID_ACCESS_KEY;
   }
 
   rgw_remove_key_index(store, kiter->second);


### PR DESCRIPTION
From http://docs.ceph.com/docs/master/radosgw/adminops/, corresponding error code should be returned  for bad request
