### PR TITLE
librbd: ensure librados callbacks are flushed prior to destroying image

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -212,6 +212,8 @@ struct C_InvalidateCache : public Context {
     }
     delete[] format_string;
 
+    md_ctx.aio_flush();
+    data_ctx.aio_flush();
     op_work_queue->drain();
     aio_work_queue->drain();
 

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -57,6 +57,8 @@ struct MockImageCtx {
 
   ~MockImageCtx() {
     wait_for_async_requests();
+    image_ctx->md_ctx.aio_flush();
+    image_ctx->data_ctx.aio_flush();
     image_ctx->op_work_queue->drain();
     delete image_watcher;
     delete op_work_queue;


### PR DESCRIPTION
It's possible for a librados async callback to complete a state machine while still holding an ImageCtx lock.

Fixes: #14092
Signed-off-by: Jason Dillaman <dillaman@redhat.com>