### PR TITLE
rbd: correct an output string for merge-diff

### DIFF
--- a/src/tools/rbd/action/MergeDiff.cc
+++ b/src/tools/rbd/action/MergeDiff.cc
@@ -290,9 +290,9 @@ static int do_merge_diff(const char *first, const char *second,
       uint64_t last_off = s_off;
 
       r = parse_diff_body(sd, &s_tag, &s_off, &s_len);
-      dout(2) << "second diff data chunk: tag=" << f_tag << ", "
-              << "off=" << f_off << ", "
-              << "len=" << f_len << dendl;
+      dout(2) << "second diff data chunk: tag=" << s_tag << ", "
+              << "off=" << s_off << ", "
+              << "len=" << s_len << dendl;
       if (r < 0) {
         std::cerr << "rbd: failed to read second diff data chunk header"
                   << std::endl;


### PR DESCRIPTION
This modification correct an output string for rbd merge-diff, in which mistakenly output variables of first diff header rather than second diff header.

Signed-off-by: Kongming Wu <wu.kongming@h3c.com>