### PR TITLE
KeyValueStore: fix wrongly placed assert

### DIFF
--- a/src/os/keyvaluestore/KeyValueStore.cc
+++ b/src/os/keyvaluestore/KeyValueStore.cc
@@ -1213,9 +1213,7 @@ int KeyValueStore::_do_transactions(list<Transaction*> &tls, uint64_t op_seq,
   for (list<Transaction*>::iterator p = tls.begin();
        p != tls.end();
        ++p, trans_num++) {
-    r = _do_transaction(**p, bt, handle);
-    if (r < 0)
-      break;
+    _do_transaction(**p, bt, handle);
     if (handle)
       handle->reset_tp_timeout();
   }
@@ -1228,7 +1226,7 @@ int KeyValueStore::_do_transactions(list<Transaction*> &tls, uint64_t op_seq,
   return r;
 }
 
-unsigned KeyValueStore::_do_transaction(Transaction& transaction,
+void KeyValueStore::_do_transaction(Transaction& transaction,
                                         BufferTransaction &t,
                                         ThreadPool::TPHandle *handle)
 {
@@ -1600,8 +1598,6 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
 
     op_num++;
   }
-
-  return 0;  // FIXME count errors
 }
 
 

--- a/src/os/keyvaluestore/KeyValueStore.cc
+++ b/src/os/keyvaluestore/KeyValueStore.cc
@@ -945,7 +945,7 @@ int KeyValueStore::mount()
       derr << "KeyValueStore::mount backend type "
 	   << superblock.backend << " error" << dendl;
       ret = -1;
-      goto close_fsid_fd;
+      goto close_current_fd;
 
     }
 

--- a/src/os/keyvaluestore/KeyValueStore.cc
+++ b/src/os/keyvaluestore/KeyValueStore.cc
@@ -1589,11 +1589,12 @@ unsigned KeyValueStore::_do_transaction(Transaction& transaction,
         f.close_section();
         f.flush(*_dout);
         *_dout << dendl;
-        assert(0 == "unexpected error");
 
         if (r == -EMFILE) {
           dump_open_fds(g_ceph_context);
-        }
+        }      
+
+        assert(0 == "unexpected error");
       }
     }
 

--- a/src/os/keyvaluestore/KeyValueStore.h
+++ b/src/os/keyvaluestore/KeyValueStore.h
@@ -526,7 +526,7 @@ class KeyValueStore : public ObjectStore,
   int do_transactions(list<Transaction*> &tls, uint64_t op_seq) {
     return _do_transactions(tls, op_seq, 0);
   }
-  unsigned _do_transaction(Transaction& transaction,
+  void _do_transaction(Transaction& transaction,
                            BufferTransaction &bt,
                            ThreadPool::TPHandle *handle);
 


### PR DESCRIPTION
At present it will not be able to dump the current opened fds when an EMFILE error has encountered.

Fixes: #14176
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>