### PR TITLE
mon: show the pg count in df output

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -886,7 +886,7 @@ void PGMap::dump_pg_sum_stats(ostream& ss, bool header) const
 
 void PGMap::dump_osd_stats(ostream& ss) const
 {
-  ss << "osdstat\tkbused\tkbavail\tkb\thb in\thb out" << std::endl;
+  ss << "osdstat\tkbused\tkbavail\tkb\thb in\thb out\tpg sum" << std::endl;
   for (ceph::unordered_map<int32_t,osd_stat_t>::const_iterator p = osd_stat.begin();
        p != osd_stat.end();
        ++p) {
@@ -896,6 +896,7 @@ void PGMap::dump_osd_stats(ostream& ss) const
        << "\t" << p->second.kb
        << "\t" << p->second.hb_in
        << "\t" << p->second.hb_out
+       << "\t" << get_num_pg_by_osd(p->first)
        << std::endl;
   }
   ss << " sum\t" << osd_sum.kb_used


### PR DESCRIPTION
Mon: show the total pg on each osd
ceph pg dump osds
dumped osds in format plain
osdstat kbused  kbavail kb      hb in   hb out  pg sum
0       143304204       79623420        234882056       [1,2]   []      330
1       143304204       79623420        234882056       [0,2]   []      295
2       143304148       79623476        234882056       [0,1]   []      303
 sum    429912556       238870316       704646168

Fixes: #14183
Signed-off-by: song baisen <song.baisen@zte.com.cn>