### PR TITLE
osd: avoid FORCE updating digest been overwritten by MAYBE when comparing scrub map

### DIFF
--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -635,6 +635,18 @@ void PGBackend::be_compare_scrubmaps(
 	FORCE = 2,
       } update = NO;
 
+      if (auth_object.digest_present && auth_object.omap_digest_present &&
+	  (!auth_oi.is_data_digest() || !auth_oi.is_omap_digest())) {
+	dout(20) << __func__ << " missing digest on " << *k << dendl;
+	update = MAYBE;
+      }
+      if (g_conf->osd_debug_scrub_chance_rewrite_digest &&
+	  (((unsigned)rand() % 100) >
+	   g_conf->osd_debug_scrub_chance_rewrite_digest)) {
+	dout(20) << __func__ << " randomly updating digest on " << *k << dendl;
+	update = MAYBE;
+      }
+
       // recorded digest != actual digest?
       if (auth_oi.is_data_digest() && auth_object.digest_present &&
 	  auth_oi.data_digest != auth_object.digest) {
@@ -657,17 +669,6 @@ void PGBackend::be_compare_scrubmaps(
 	  update = FORCE;
       }
 
-      if (auth_object.digest_present && auth_object.omap_digest_present &&
-	  (!auth_oi.is_data_digest() || !auth_oi.is_omap_digest())) {
-	dout(20) << __func__ << " missing digest on " << *k << dendl;
-	update = MAYBE;
-      }
-      if (g_conf->osd_debug_scrub_chance_rewrite_digest &&
-	  (((unsigned)rand() % 100) >
-	   g_conf->osd_debug_scrub_chance_rewrite_digest)) {
-	dout(20) << __func__ << " randomly updating digest on " << *k << dendl;
-	update = MAYBE;
-      }
       if (update != NO) {
 	utime_t age = now - auth_oi.local_mtime;
 	if (update == FORCE ||

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -640,7 +640,8 @@ void PGBackend::be_compare_scrubmaps(
 	dout(20) << __func__ << " missing digest on " << *k << dendl;
 	update = MAYBE;
       }
-      if (g_conf->osd_debug_scrub_chance_rewrite_digest &&
+      if (auth_object.digest_present && auth_object.omap_digest_present &&
+	  g_conf->osd_debug_scrub_chance_rewrite_digest &&
 	  (((unsigned)rand() % 100) >
 	   g_conf->osd_debug_scrub_chance_rewrite_digest)) {
 	dout(20) << __func__ << " randomly updating digest on " << *k << dendl;


### PR DESCRIPTION
Should set update to FORCE after MAYBE, to avoid it been overwritten.