### PR TITLE
kv: implement value_as_ptr() and use it in .get()

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -163,6 +163,14 @@ public:
     virtual std::pair<std::string,std::string> raw_key() = 0;
     virtual bool raw_key_is_prefixed(const std::string &prefix) = 0;
     virtual bufferlist value() = 0;
+    virtual bufferptr value_as_ptr() {
+      bufferlist bl = value();
+      if (bl.length()) {
+        return *bl.buffers().begin();
+      } else {
+        return bufferptr();
+      }
+    }
     virtual int status() = 0;
     virtual ~WholeSpaceIteratorImpl() { }
   };
@@ -222,6 +230,9 @@ public:
     }
     bufferlist value() {
       return generic_iter->value();
+    }
+    bufferptr value_as_ptr() {
+      return generic_iter->value_as_ptr();
     }
     int status() {
       return generic_iter->status();

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -267,6 +267,7 @@ int LevelDBStore::get(const string &prefix,
 		  const string &key,
 		  bufferlist *value)
 {
+  assert(value && (value->length() == 0));
   utime_t start = ceph_clock_now(g_ceph_context);
   int r = 0;
   KeyValueDB::Iterator it = get_iterator(prefix);

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -272,7 +272,7 @@ int LevelDBStore::get(const string &prefix,
   KeyValueDB::Iterator it = get_iterator(prefix);
   it->lower_bound(key);
   if (it->valid() && it->key() == key) {
-    *value = it->value();
+    value->append(it->value_as_ptr());
   } else {
     r = -ENOENT;
   }

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -298,6 +298,12 @@ public:
     bufferlist value() {
       return to_bufferlist(dbiter->value());
     }
+
+    bufferptr value_as_ptr() {
+      leveldb::Slice data = dbiter->value();
+      return bufferptr(data.data(), data.size());
+    }
+
     int status() {
       return dbiter->status().ok() ? 0 : -1;
     }

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -366,6 +366,7 @@ int RocksDBStore::get(
     const string &key,
     bufferlist *out)
 {
+  assert(out && (out->length() == 0));
   utime_t start = ceph_clock_now(g_ceph_context);
   int r = 0;
   KeyValueDB::Iterator it = get_iterator(prefix);

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -371,7 +371,7 @@ int RocksDBStore::get(
   KeyValueDB::Iterator it = get_iterator(prefix);
   it->lower_bound(key);
   if (it->valid() && it->key() == key) {
-    *out = it->value();
+    out->append(it->value_as_ptr());
   } else {
     r = -ENOENT;
   }
@@ -589,6 +589,13 @@ bufferlist RocksDBStore::RocksDBWholeSpaceIteratorImpl::value()
 {
   return to_bufferlist(dbiter->value());
 }
+
+bufferptr RocksDBStore::RocksDBWholeSpaceIteratorImpl::value_as_ptr()
+{
+  rocksdb::Slice val = dbiter->value();
+  return bufferptr(val.data(), val.size());
+}
+
 int RocksDBStore::RocksDBWholeSpaceIteratorImpl::status()
 {
   return dbiter->status().ok() ? 0 : -1;
@@ -600,7 +607,6 @@ string RocksDBStore::past_prefix(const string &prefix)
   limit.push_back(1);
   return limit;
 }
-
 
 RocksDBStore::WholeSpaceIterator RocksDBStore::_get_iterator()
 {

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -192,6 +192,7 @@ public:
     pair<string,string> raw_key();
     bool raw_key_is_prefixed(const string &prefix);
     bufferlist value();
+    bufferptr value_as_ptr();
     int status();
   };
 

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -507,6 +507,7 @@ class MonitorDBStore
   }
 
   int get(const string& prefix, const string& key, bufferlist& bl) {
+    assert(bl.length() == 0);
     return db->get(prefix, key, &bl);
   }
 

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -507,12 +507,7 @@ class MonitorDBStore
   }
 
   int get(const string& prefix, const string& key, bufferlist& bl) {
-    bufferlist outbl;
-    int r = db->get(prefix, key, &outbl);
-    if (!r) {
-      bl.append(outbl);
-    }
-    return r;
+    return db->get(prefix, key, &bl);
   }
 
   int get(const string& prefix, const version_t ver, bufferlist& bl) {


### PR DESCRIPTION
Current .get() methods return values as bufferlists, which are replacing
bufferlists provided by caller. This is particularly inefficient with
MonitorDBStore, because its get() method uses its own temporary bufferlist
which is then appended to bufferlist provided by MonitorDBStore user.
This changeset:
 - adds value_as_ptr() which returns just a bufferptr
 - modifies *DBStore.get() methods to append returned bufferptr to provided
   bufferlist instead of replacing it
 - modifies mondbstore to pass provided bufferlist as target for underlying
   .get() method, instead of providing its own and appending it to one given
   by caller.

This reduces CPU usage of *DBStore.get() methods by up to 5% (particularly
visible with MonitorDBStore, which doesn't use two temporary bufferlists
anymore, and for some reason queries mon db store every few seconds).

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>