### PR TITLE
rgw: do not abort radowgw server when using admin op API with bad parameters 

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1605,7 +1605,11 @@ public:
   int put(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker,
           time_t mtime, JSONObj *obj, sync_type_t sync_type) {
     RGWBucketEntryPoint be, old_be;
-    decode_json_obj(be, obj);
+    try {
+      decode_json_obj(be, obj);
+    } catch (JSONDecoder::err& e) {
+      return -EINVAL;
+    }
 
     time_t orig_mtime;
     map<string, bufferlist> attrs;
@@ -1756,7 +1760,11 @@ public:
   int put(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker,
           time_t mtime, JSONObj *obj, sync_type_t sync_type) {
     RGWBucketCompleteInfo bci, old_bci;
-    decode_json_obj(bci, obj);
+    try {
+      decode_json_obj(bci, obj);
+    } catch (JSONDecoder::err& e) {
+      return -EINVAL;
+    }
 
     time_t orig_mtime;
     RGWObjectCtx obj_ctx(store);

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -355,9 +355,13 @@ int RGWMetadataManager::put(string& metadata_key, bufferlist& bl,
 
   time_t mtime = 0;
 
-  JSONDecoder::decode_json("key", metadata_key, &parser);
-  JSONDecoder::decode_json("ver", *objv, &parser);
-  JSONDecoder::decode_json("mtime", mtime, &parser);
+  try {
+    JSONDecoder::decode_json("key", metadata_key, &parser);
+    JSONDecoder::decode_json("ver", *objv, &parser);
+    JSONDecoder::decode_json("mtime", mtime, &parser);
+  } catch (JSONDecoder::err& e) {
+    return -EINVAL;
+  }
 
   JSONObj *jo = parser.find_obj("data");
   if (!jo) {

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -53,9 +53,14 @@ int rgw_rest_get_json_input(CephContext *cct, req_state *s, T& out, int max_len,
     return -EINVAL;
   }
 
-  decode_json_obj(out, &parser);
-
   free(data);
+
+  try {
+      decode_json_obj(out, &parser);
+  } catch (JSONDecoder::err& e) {
+      return -EINVAL;
+  }
+
   return 0;
 }
 
@@ -82,7 +87,11 @@ int rgw_rest_get_json_input_keep_data(CephContext *cct, req_state *s, T& out, in
     return -EINVAL;
   }
 
-  decode_json_obj(out, &parser);
+  try {
+      decode_json_obj(out, &parser);
+  } catch (JSONDecoder::err& e) {
+      return -EINVAL;
+  }
 
   *pdata = data;
   return 0;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2552,7 +2552,11 @@ public:
           time_t mtime, JSONObj *obj, sync_type_t sync_mode) {
     RGWUserCompleteInfo uci;
 
-    decode_json_obj(uci, obj);
+    try {
+      decode_json_obj(uci, obj);
+    } catch (JSONDecoder::err& e) {
+      return -EINVAL;
+    }
 
     map<string, bufferlist> *pattrs = NULL;
     if (uci.has_attrs) {


### PR DESCRIPTION
when admin user passes bad parameter(e.g. pass "null" to bool parameter) to radowgw server, the ceph_json.cc::decode_json_obj() will raise a exception with type of JSONDecoder::err(). If we do not catch this exception, the radosgw server will abort.

Fixes: #14190, #14191

Reported-by: Coffee Chou <coffee.zyr@gmail.com>
Signed-off-by: Dunrong Huang <riegamaths@gmail.com>