### PR TITLE
os: fix fd leak

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -202,6 +202,7 @@ int FileStore::lfn_truncate(coll_t cid, const ghobject_t& oid, off_t length)
     int rc = backend->_crc_update_truncate(**fd, length);
     assert(rc >= 0);
   }
+  lfn_close(fd);
   assert(!m_filestore_fail_eio || r != -EIO);
   return r;
 }
@@ -3134,11 +3135,13 @@ int FileStore::fiemap(coll_t cid, const ghobject_t& oid,
     r = _do_fiemap(**fd, offset, len, &exomap);
   }
 
-done:
+  lfn_close(fd);
+
   if (r >= 0) {
-    lfn_close(fd);
     ::encode(exomap, bl);
   }
+
+done:
 
   dout(10) << "fiemap " << cid << "/" << oid << " " << offset << "~" << len << " = " << r << " num_extents=" << exomap.size() << " " << exomap << dendl;
   assert(!m_filestore_fail_eio || r != -EIO);
@@ -4102,6 +4105,8 @@ int FileStore::getattrs(coll_t cid, const ghobject_t& oid, map<string,bufferptr>
     spill_out = false;
 
   r = _fgetattrs(**fd, aset);
+  lfn_close(fd);
+  fd = FDRef(); // defensive
   if (r < 0) {
     goto out;
   }
@@ -5143,10 +5148,10 @@ int FileStore::_collection_move_rename(coll_t oldcid, const ghobject_t& oldoid,
       r = lfn_open(c, o, 0, &fd);
 
     // close guard on object so we don't do this again
-    if (r == 0)
+    if (r == 0) {
       _close_replay_guard(**fd, spos);
-
-    lfn_close(fd);
+      lfn_close(fd);
+    }
   }
 
   dout(10) << __func__ << " " << c << "/" << o << " from " << oldcid << "/" << oldoid


### PR DESCRIPTION
Although currently lfn_close() is a noop, but these cases will be problematic if someday
we want to do some real tidy up work.

Fixes: 14192
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>