### PR TITLE
osd: add cache hint when pushing raw clone during recovery

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1571,14 +1571,14 @@ void ReplicatedBackend::prep_push_to_replica(
     // we need the head (and current SnapSet) locally to do that.
     if (get_parent()->get_local_missing().is_missing(head)) {
       dout(15) << "push_to_replica missing head " << head << ", pushing raw clone" << dendl;
-      return prep_push(obc, soid, peer, pop);
+      return prep_push(obc, soid, peer, pop, cache_dont_need);
     }
     hobject_t snapdir = head;
     snapdir.snap = CEPH_SNAPDIR;
     if (get_parent()->get_local_missing().is_missing(snapdir)) {
       dout(15) << "push_to_replica missing snapdir " << snapdir
 	       << ", pushing raw clone" << dendl;
-      return prep_push(obc, soid, peer, pop);
+      return prep_push(obc, soid, peer, pop, cache_dont_need);
     }
 
     SnapSetContext *ssc = obc->ssc;
@@ -1612,7 +1612,7 @@ void ReplicatedBackend::prep_push_to_replica(
 
 void ReplicatedBackend::prep_push(ObjectContextRef obc,
 			     const hobject_t& soid, pg_shard_t peer,
-			     PushOp *pop)
+			     PushOp *pop, bool cache_dont_need)
 {
   interval_set<uint64_t> data_subset;
   if (obc->obs.oi.size)
@@ -1621,7 +1621,7 @@ void ReplicatedBackend::prep_push(ObjectContextRef obc,
 
   prep_push(obc, soid, peer,
 	    obc->obs.oi.version, data_subset, clone_subsets,
-	    pop);
+	    pop, cache_dont_need);
 }
 
 void ReplicatedBackend::prep_push(

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -298,7 +298,8 @@ private:
     PushOp *pop, bool cache_dont_need = true);
   void prep_push(ObjectContextRef obc,
 		 const hobject_t& oid, pg_shard_t dest,
-		 PushOp *op);
+		 PushOp *op,
+		 bool cache_dont_need);
   void prep_push(ObjectContextRef obc,
 		 const hobject_t& soid, pg_shard_t peer,
 		 eversion_t version,


### PR DESCRIPTION
When head or snapdir is missing on the primary, we push raw clone to the
replicas. Set cache hint also in this case.

Signed-off-by: Zhiqiang Wang <wonzhq@hotmail.com>