### PR TITLE
tiering: allow multiple tiering

### DIFF
--- a/doc/rados/operations/cache-tiering.rst
+++ b/doc/rados/operations/cache-tiering.rst
@@ -400,6 +400,25 @@ disable and remove it.
 	ceph osd tier remove cold-storage hot-storage
 
 
+Setting mutiple cache tiering
+-----------------------------
+
+If there are more than two pools with different performance,
+e.g. pool A < pool B < pool C, we can set B as a cache of
+A, then set C as a cache of B. To prevent cyclic tiering,
+the multiple tiering must be specified in the bottom-up order,
+cold_pool as base of warm_pool, warm_pool as base of hot_pool.
+Instead, if one pool (warm_pool) have tiers (hot_pool) already,
+setting it as cache pool for another (cold_pool) is invalid. ::
+
+	ceph osd tier add {storagepool} {slowcachepool}
+	ceph osd tier add {slowcachepool} {fastcachepool}
+
+   For example (these two commands must in following order)::
+
+	ceph osd tier add cold-storage warm-storage
+	ceph osd tier add warm-storage hot-storage
+
 .. _Create a Pool: ../pools#create-a-pool
 .. _Pools - Set Pool Values: ../pools#set-pool-values
 .. _Placing Different Pools on Different OSDs: ../crush-map/#placing-different-pools-on-different-osds

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7771,14 +7771,6 @@ bool OSDMonitor::_check_become_tier(
     return false;
   }
 
-  if (base_pool->is_tier()) {
-    *ss << "pool '" << base_pool_name << "' is already a tier of '"
-      << osdmap.get_pool_name(base_pool->tier_of) << "', "
-      << "multiple tiers are not yet supported.";
-    *err = -EINVAL;
-    return false;
-  }
-
   if (tier_pool->is_tier()) {
     *ss << "tier pool '" << tier_pool_name << "' is already a tier of '"
        << osdmap.get_pool_name(tier_pool->tier_of) << "'";

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7763,6 +7763,16 @@ bool OSDMonitor::_check_become_tier(
     return false;
   }
 
+  if (tier_pool->has_tiers()) {
+    *ss << "may cause cyclic tiering, always set multiple tiering in the order of cold, warm, hot ...";
+    *ss << "pool '" << tier_pool_name << "' has following tier(s) already:";
+    for (set<uint64_t>::const_iterator it = tier_pool->tiers.begin();
+         it != tier_pool->tiers.end(); it++)
+      *ss << " '" << osdmap.get_pool_name(*it) << "'";
+    *err = -EINVAL;
+    return false;
+  }
+
   if (base_pool->tiers.count(tier_pool_id)) {
     assert(tier_pool->tier_of == base_pool_id);
     *err = 0;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2381,7 +2381,7 @@ void ReplicatedPG::do_proxy_read(OpRequestRef op)
 		 m->get_pg().ps(),
 		 m->get_object_locator().get_pool(),
 		 m->get_object_locator().nspace);
-  unsigned flags = CEPH_OSD_FLAG_IGNORE_CACHE | CEPH_OSD_FLAG_IGNORE_OVERLAY;
+  unsigned flags = CEPH_OSD_FLAG_IGNORE_OVERLAY;
 
   // pass through some original flags that make sense.
   //  - leave out redirection and balancing flags since we are
@@ -2576,7 +2576,7 @@ void ReplicatedPG::do_proxy_write(OpRequestRef op, const hobject_t& missing_oid)
 		 m->get_pg().ps(),
 		 m->get_object_locator().get_pool(),
 		 m->get_object_locator().nspace);
-  unsigned flags = CEPH_OSD_FLAG_IGNORE_CACHE | CEPH_OSD_FLAG_IGNORE_OVERLAY;
+  unsigned flags = CEPH_OSD_FLAG_IGNORE_OVERLAY;
   dout(10) << __func__ << " Start proxy write for " << *m << dendl;
 
   ProxyWriteOpRef pwop(new ProxyWriteOp(op, soid, m->ops, m->get_reqid()));
@@ -2747,7 +2747,6 @@ void ReplicatedPG::promote_object(ObjectContextRef obc,
   my_oloc.pool = pool.info.tier_of;
 
   unsigned flags = CEPH_OSD_COPY_FROM_FLAG_IGNORE_OVERLAY |
-                   CEPH_OSD_COPY_FROM_FLAG_IGNORE_CACHE |
                    CEPH_OSD_COPY_FROM_FLAG_MAP_SNAP_CLONE |
                    CEPH_OSD_COPY_FROM_FLAG_RWORDERED;
   start_copy(cb, obc, obc->obs.oi.soid, my_oloc, 0, flags,

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1213,6 +1213,7 @@ void Objecter::handle_osd_map(MOSDMap *m)
 	monc->renew_subs();
       }
     }
+    tier_map_setup();
   }
 
   bool pauserd = osdmap->test_flag(CEPH_OSDMAP_PAUSERD);

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2641,10 +2641,10 @@ int Objecter::_calc_target(op_target_t *t, epoch_t *last_force_resend,
 
   if (need_check_tiering &&
       (t->flags & CEPH_OSD_FLAG_IGNORE_OVERLAY) == 0) {
-    if (is_read && pi->has_read_tier())
-      t->target_oloc.pool = pi->read_tier;
-    if (is_write && pi->has_write_tier())
-      t->target_oloc.pool = pi->write_tier;
+    if (is_read)
+      t->target_oloc.pool = get_read_tier(t->target_oloc.pool);
+    if (is_write)
+      t->target_oloc.pool = get_write_tier(t->target_oloc.pool);
   }
 
   pg_t pgid;


### PR DESCRIPTION
This patch enables multiple tiering for cache tiering. For example, there are three pools 
1, 2 and 3 with different performance, among which 1 is the fastest, and 3 is the slowest. 
It allows to set 1 as the cache of 2, and 2 as the cache of 3