### PR TITLE
osd: clear pg_stat_queue after stopping pgs

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2371,6 +2371,7 @@ int OSD::shutdown()
       p->second->osr->flush();
     }
   }
+  clear_pg_stat_queue();
   
   // finish ops
   op_shardedwq.drain(); // should already be empty except for lagard PGs


### PR DESCRIPTION
Fixes: #14212
Signed-off-by: Sage Weil <sage@redhat.com>