### PR TITLE
tests: configure with rocksdb by default

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -66,7 +66,7 @@ function run() {
 	$DRY_RUN ./install-deps.sh || return 1
     fi
     $DRY_RUN ./autogen.sh || return 1
-    $DRY_RUN ./configure "$@" --disable-static --with-radosgw --with-debug --without-lttng \
+    $DRY_RUN ./configure "$@"  --with-librocksdb-static --disable-static --with-radosgw --with-debug --without-lttng \
         CC="ccache gcc" CXX="ccache g++" CFLAGS="-Wall -g" CXXFLAGS="-Wall -g" || return 1
     $DRY_RUN make $BUILD_MAKEOPTS || return 1
     $DRY_RUN make $CHECK_MAKEOPTS check || return 1


### PR DESCRIPTION
Otherwise bluestore won't compile and run-make-check.sh will fail.

http://tracker.ceph.com/issues/14220 Fixes: #14220

Signed-off-by: Loic Dachary <loic@dachary.org>