### PR TITLE
common: fix RWLock

### DIFF
--- a/src/common/RWLock.h
+++ b/src/common/RWLock.h
@@ -142,8 +142,8 @@ public:
     }
     void unlock() {
       assert(locked);
-      m_lock.unlock();
       locked = false;
+      m_lock.unlock();
     }
     ~RLocker() {
       if (locked) {
@@ -164,8 +164,8 @@ public:
     }
     void unlock() {
       assert(locked);
-      m_lock.unlock();
       locked = false;
+      m_lock.unlock();
     }
     ~WLocker() {
       if (locked) {


### PR DESCRIPTION
we should reset locked to false before unlock

Signed-off-by: Xinze Chi <xinze@xsky.com>