### PR TITLE
[patch]print file name before osd assert if read file failed

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2959,7 +2959,10 @@ int FileStore::read(
   if (got < 0) {
     dout(10) << "FileStore::read(" << cid << "/" << oid << ") pread error: " << cpp_strerror(got) << dendl;
     lfn_close(fd);
-    assert(allow_eio || !m_filestore_fail_eio || got != -EIO);
+    if (!(allow_eio || !m_filestore_fail_eio || got != -EIO)) {
+      derr << "FileStore::read(" << cid << "/" << oid << ") pread error: " << cpp_strerror(got) << dendl;
+      assert(0 == "eio on pread");
+    }
     return got;
   }
   bptr.set_length(got);   // properly size the buffer


### PR DESCRIPTION
when osd do backfillings, once read one file failed
osd will assert failed, and never up again.
so we need locate this file from log at level-0,
delete it manully,start osd and let backfill go again.