### PR TITLE
ceph-disk activate fallback for old mon caps

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -2024,7 +2024,7 @@ def auth_key(
                 ],
             )
     except subprocess.CalledProcessError as err:
-        if err.returncode == errno.EACCES:
+        if err.returncode == errno.EINVAL:
             # try old cap scheme
             command_check_call(
                 [


### PR DESCRIPTION
While activating osd with "ceph-disk" it fails with the following error:
Error EINVAL: entity osd.0 exists but cap mon does not match

This is because old caps where:
osd "allow rwx"
while there is a new caps format:
osd "allow profile osd"

ceph-disk should normally rescue this type of error, but i matches the wrong error code.