### PR TITLE
osd: Avoid debug std::string initialization in PG::get/put

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -74,7 +74,7 @@ static ostream& _prefix(std::ostream *_dout, T *t)
   return *_dout << t->gen_prefix();
 }
 
-void PG::get(const string &tag) 
+void PG::get(const char* tag)
 {
   ref.inc();
 #ifdef PG_DEBUG_REFS
@@ -86,7 +86,7 @@ void PG::get(const string &tag)
 #endif
 }
 
-void PG::put(const string &tag)
+void PG::put(const char* tag)
 {
 #ifdef PG_DEBUG_REFS
   {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -273,8 +273,8 @@ public:
   void put_with_id(uint64_t);
   void dump_live_ids();
 #endif
-  void get(const string &tag);
-  void put(const string &tag);
+  void get(const char* tag);
+  void put(const char* tag);
 
   bool dirty_info, dirty_big_info;
 


### PR DESCRIPTION
I didn't notice any immediate performance improvement from this change, but it eliminates
intrusive_ptr_add_ref/release(ReplicatedPG*) from the profile top.