### PR TITLE
os/fileStore: Replace Mutex with RWLock in IndexManager

### DIFF
--- a/src/os/filestore/IndexManager.cc
+++ b/src/os/filestore/IndexManager.cc
@@ -73,7 +73,7 @@ IndexManager::~IndexManager() {
 
 
 int IndexManager::init_index(coll_t c, const char *path, uint32_t version) {
-  Mutex::Locker l(lock);
+  RWLock::WLocker l(lock);
   int r = set_version(path, version);
   if (r < 0)
     return r;
@@ -116,9 +116,19 @@ int IndexManager::build_index(coll_t c, const char *path, CollectionIndex **inde
   }
 }
 
-int IndexManager::get_index(coll_t c, const string& baseDir, Index *index) {
+bool IndexManager::get_index_optimistic(coll_t c, Index *index) {
+  RWLock::RLocker l(lock);
+  ceph::unordered_map<coll_t, CollectionIndex* > ::iterator it = col_indices.find(c);
+  if (it == col_indices.end()) 
+    return false;
+  index->index = it->second;
+  return true;
+}
 
-  Mutex::Locker l(lock);
+int IndexManager::get_index(coll_t c, const string& baseDir, Index *index) {
+  if (get_index_optimistic(c, index))
+    return 0;
+  RWLock::WLocker l(lock);
   ceph::unordered_map<coll_t, CollectionIndex* > ::iterator it = col_indices.find(c);
   if (it == col_indices.end()) {
     char path[PATH_MAX];

--- a/src/os/filestore/IndexManager.h
+++ b/src/os/filestore/IndexManager.h
@@ -49,7 +49,7 @@ struct Index {
  * This is enforced by using CollectionIndex::access_lock
  */
 class IndexManager {
-  Mutex lock; ///< Lock for Index Manager
+  RWLock lock; ///< Lock for Index Manager
   bool upgrade;
   ceph::unordered_map<coll_t, CollectionIndex* > col_indices;
 
@@ -65,6 +65,7 @@ class IndexManager {
    * @return error code
    */
   int build_index(coll_t c, const char *path, CollectionIndex **index);
+  bool get_index_optimistic(coll_t c, Index *index);
 public:
   /// Constructor
   IndexManager(bool upgrade) : lock("IndexManager lock"),


### PR DESCRIPTION
This mutex was one of the topmost in the fio runs above filestore. This change eliminates it from the profile.
