### PR TITLE
admin/build-doc: make paths absolute

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -49,38 +49,38 @@ fi
 # for availability of commands
 set -e
 
-cat src/osd/PG.h src/osd/PG.cc | doc/scripts/gen_state_diagram.py > doc/dev/peering_graph.generated.dot
+cat $TOPDIR/src/osd/PG.h $TOPDIR/src/osd/PG.cc | $TOPDIR/doc/scripts/gen_state_diagram.py > $TOPDIR/doc/dev/peering_graph.generated.dot
 
 cd build-doc
 
-[ -z "$vdir" ] && vdir="./virtualenv"
+[ -z "$vdir" ] && vdir="$TOPDIR/build-doc/virtualenv"
 
 if [ ! -e $vdir ]; then
     virtualenv --system-site-packages $vdir
 fi
-$vdir/bin/pip install --quiet -r ../admin/doc-requirements.txt
+$vdir/bin/pip install --quiet -r $TOPDIR/admin/doc-requirements.txt
 
 install -d -m0755 \
-    output/html \
-    output/man
+    $TOPDIR/build-doc/output/html \
+    $TOPDIR/build-doc/output/man
 
 # To avoid having to build librbd to build the Python bindings to build the docs,
 # create a dummy librbd.so that allows the module to be imported by sphinx.
 mkdir -p $vdir/lib
 export LD_LIBRARY_PATH="$vdir/lib"
-export PYTHONPATH=`pwd`/../src/pybind
+export PYTHONPATH=$TOPDIR/src/pybind
 ln -sf librbd.so.1 $vdir/lib/librbd.so
 gcc -shared -o $vdir/lib/librbd.so.1 -xc /dev/null
-CFLAGS="-iquote `pwd`/../src/include" \
-    CPPFLAGS="-iquote `pwd`/../src/include" \
+CFLAGS="-iquote $TOPDIR/src/include" \
+    CPPFLAGS="-iquote $TOPDIR/src/include" \
     LDFLAGS="-L$vdir/lib -Wl,--no-as-needed" \
-    $vdir/bin/pip install `pwd`/../src/pybind
+    $vdir/bin/pip install $TOPDIR/src/pybind
 nm $vdir/lib/python*/*-packages/rbd.so | grep 'U rbd_' | \
     awk '{ print "void "$2"(void) {}" }' | \
     gcc -shared -o $vdir/lib/librbd.so.1 -xc -
 
-$vdir/bin/sphinx-build -a -n -b dirhtml -d doctrees ../doc output/html
-$vdir/bin/sphinx-build -a -b man -d doctrees ../doc output/man
+$vdir/bin/sphinx-build -a -n -b dirhtml -d doctrees $TOPDIR/doc $TOPDIR/build-doc/output/html
+$vdir/bin/sphinx-build -a -b man -d doctrees $TOPDIR/doc $TOPDIR/build-doc/output/man
 
 #
 # Build and install JavaDocs
@@ -92,7 +92,7 @@ rm -rf $JAVADIR/doc
 ant -buildfile $JAVADIR/build.xml docs
 
 # Create clean target directory
-JAVA_OUTDIR=output/html/api/libcephfs-java/javadoc
+JAVA_OUTDIR=$TOPDIR/build-doc/output/html/api/libcephfs-java/javadoc
 rm -rf $JAVA_OUTDIR
 mkdir $JAVA_OUTDIR
 


### PR DESCRIPTION
Build failure on docs.dhc because pip apparently was changing directory
before building rbd with cython, causing the relative library path
references to fail.  Bite the bullet and make everything absolute (since
we already have TOPDIR to use).

Signed-off-by: Dan Mick <dan.mick@redhat.com>