### PR TITLE
rgw: fix up the use of tenant before it's available

### DIFF
--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -49,7 +49,8 @@ extern void rgw_make_bucket_entry_name(const string& tenant_name,
                                        string& bucket_entry);
 extern string rgw_make_bucket_entry_name(const string& tenant_name,
                                        const string& bucket_name);
-extern void rgw_parse_url_bucket(const string &bucket,
+extern void rgw_parse_url_bucket(const string& bucket,
+                                 const string& auth_tenant,
                                  string &tenant_name, string &bucket_name);
 
 /**

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -161,6 +161,7 @@ using ceph::crypto::MD5;
 #define ERR_INVALID_SECRET_KEY   2034
 #define ERR_INVALID_KEY_TYPE     2035
 #define ERR_INVALID_CAP          2036
+#define ERR_INVALID_TENANT_NAME  2037
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
 #define ERR_NOT_IMPLEMENTED      2201
@@ -1034,6 +1035,12 @@ inline ostream& operator<<(ostream& out, const rgw_obj_key &o) {
   }
 }
 
+struct req_init_state {
+  /* Keeps [[tenant]:]bucket until we parse the token. */
+  string url_bucket;
+  string src_bucket;
+};
+
 /** Store all the state necessary to complete and respond to an HTTP request*/
 struct req_state {
    CephContext *cct;
@@ -1057,7 +1064,7 @@ struct req_state {
    uint32_t perm_mask;
    utime_t header_time;
 
-   /* Set once when req_state is initialized and not violated thereafter */
+   /* Set once when url_bucket is parsed and not violated thereafter. */
    string bucket_tenant;
    string bucket_name;
 
@@ -1106,6 +1113,7 @@ struct req_state {
    string trans_id;
 
    req_info info;
+   req_init_state init_state;
 
    req_state(CephContext *_cct, class RGWEnv *e);
    ~req_state();

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -56,6 +56,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ERR_INVALID_SECRET_KEY, 400, "InvalidSecretKey"},
     { ERR_INVALID_KEY_TYPE, 400, "InvalidKeyType"},
     { ERR_INVALID_CAP, 400, "InvalidCapability"},
+    { ERR_INVALID_TENANT_NAME, 400, "InvalidTenantName" },
     { ENOTEMPTY, 409, "BucketNotEmpty" },
     { ERR_PRECONDITION_FAILED, 412, "PreconditionFailed" },
     { ERANGE, 416, "InvalidRange" },

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1304,6 +1304,7 @@ public:
   virtual void put_op(RGWOp *op);
   virtual int read_permissions(RGWOp *op) = 0;
   virtual int authorize() = 0;
+  virtual int postauth_init() = 0;
 };
 
 #endif

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1203,13 +1203,13 @@ int RGWHandler_ObjStore::allocate_formatter(struct req_state *s, int default_typ
 
 int RGWHandler_ObjStore::validate_tenant_name(string const& t)
 {
-  struct tench {
-    static bool is_good(char ch) {
-      return isalnum(ch) || ch == '_';
-    }
-  };
-  std::string::const_iterator it = std::find_if(t.begin(), t.end(), tench::is_good);
-  return (it == t.end())? 0: -ERR_INVALID_BUCKET_NAME;
+  const char *p = t.c_str();
+  for (int i = 0; i < t.size(); i++) {
+    char ch = p[i];
+    if (!(isalnum(ch) || ch == '_'))
+      return -ERR_INVALID_TENANT_NAME;
+  }
+  return 0;
 }
 
 // This function enforces Amazon's spec for bucket names.

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -359,6 +359,7 @@ public:
   int read_permissions(RGWOp *op);
 
   virtual int authorize() = 0;
+  // virtual int postauth_init(struct req_init_state *t) = 0;
 };
 
 class RGWHandler_ObjStore_SWIFT;

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -375,10 +375,11 @@ public:
 
   virtual int validate_object_name(const string& bucket) { return 0; }
 
-  virtual int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
+  virtual int init(RGWRados *store, struct req_state *s, RGWClientIO *cio);
   virtual int authorize() {
     return RGW_Auth_S3::authorize(store, s);
   }
+  int postauth_init() { return 0; }
 };
 
 class RGWHandler_ObjStore_S3 : public RGWHandler_ObjStore {
@@ -392,10 +393,11 @@ public:
   int validate_bucket_name(const string& bucket, bool relaxed_names);
   using RGWHandler_ObjStore::validate_bucket_name;
   
-  virtual int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
+  virtual int init(RGWRados *store, struct req_state *s, RGWClientIO *cio);
   virtual int authorize() {
     return RGW_Auth_S3::authorize(store, s);
   }
+  int postauth_init();
 };
 
 class RGWHandler_ObjStore_Service_S3 : public RGWHandler_ObjStore_S3 {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -893,7 +893,6 @@ int RGWCopyObj_ObjStore_SWIFT::get_params()
   if_match = s->info.env->get("HTTP_COPY_IF_MATCH");
   if_nomatch = s->info.env->get("HTTP_COPY_IF_NONE_MATCH");
 
-  /* XXX why copy this? just use req_state in rgw_op.cc:verify_permission */
   src_tenant_name = s->src_tenant_name;
   src_bucket_name = s->src_bucket_name;
   src_object = s->src_object;
@@ -1231,7 +1230,7 @@ RGWOp *RGWHandler_ObjStore_Obj_SWIFT::op_put()
   if (is_acl_op()) {
     return new RGWPutACLs_ObjStore_SWIFT;
   }
-  if (s->src_bucket_name.empty())
+  if (s->init_state.src_bucket.empty())
     return new RGWPutObj_ObjStore_SWIFT;
   else
     return new RGWCopyObj_ObjStore_SWIFT;
@@ -1270,6 +1269,49 @@ int RGWHandler_ObjStore_SWIFT::authorize()
   bool authorized = rgw_swift->verify_swift_token(store, s);
   if (!authorized)
     return -EPERM;
+
+  return 0;
+}
+
+int RGWHandler_ObjStore_SWIFT::postauth_init()
+{
+  struct req_init_state *t = &s->init_state;
+
+  /* XXX Stub this until Swift Auth sets account into URL. */
+  s->bucket_tenant = s->user.user_id.tenant;
+  s->bucket_name = t->url_bucket;
+
+  dout(10) << "s->object=" << (!s->object.empty() ? s->object : rgw_obj_key("<NULL>"))
+           << " s->bucket=" << rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name) << dendl;
+
+  int ret;
+  ret = validate_tenant_name(s->bucket_tenant);
+  if (ret)
+    return ret;
+  ret = validate_bucket_name(s->bucket_name);
+  if (ret)
+    return ret;
+  ret = validate_object_name(s->object.name);
+  if (ret)
+    return ret;
+
+  if (!t->src_bucket.empty()) {
+    /*
+     * We don't allow cross-tenant copy at present. It requires account
+     * names in the URL for Swift.
+     */
+    s->src_tenant_name = s->user.user_id.tenant;
+    s->src_bucket_name = t->src_bucket;
+
+    ret = validate_bucket_name(s->src_bucket_name);
+    if (ret < 0) {
+      return ret;
+    }
+    ret = validate_object_name(s->src_object.name);
+    if (ret < 0) {
+      return ret;
+    }
+  }
 
   return 0;
 }
@@ -1399,9 +1441,8 @@ int RGWHandler_ObjStore_SWIFT::init_from_header(struct req_state *s)
 
   s->info.effective_uri = "/" + first;
 
-  /* XXX Temporarily not parsing URL until Auth puts something in there. */
-  s->bucket_tenant = s->user.user_id.tenant;
-  s->bucket_name = first;
+  // Save bucket to tide us over until token is parsed.
+  s->init_state.url_bucket = first;
 
   if (req.size()) {
     s->object = rgw_obj_key(req, s->info.env->get("HTTP_X_OBJECT_VERSION_ID", "")); /* rgw swift extension */
@@ -1413,59 +1454,34 @@ int RGWHandler_ObjStore_SWIFT::init_from_header(struct req_state *s)
 
 int RGWHandler_ObjStore_SWIFT::init(RGWRados *store, struct req_state *s, RGWClientIO *cio)
 {
-  dout(10) << "s->object=" << (!s->object.empty() ? s->object : rgw_obj_key("<NULL>"))
-           << " s->bucket=" << rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name) << dendl;
+  struct req_init_state *t = &s->init_state;
 
-  int ret;
-  ret = validate_tenant_name(s->bucket_tenant);
-  if (ret)
-    return ret;
-  ret = validate_bucket_name(s->bucket_name);
-  if (ret)
-    return ret;
-  ret = validate_object_name(s->object.name);
-  if (ret)
-    return ret;
+  s->dialect = "swift";
 
   const char *copy_source = s->info.env->get("HTTP_X_COPY_FROM");
   if (copy_source) {
-    bool result = RGWCopyObj::parse_copy_location(copy_source, s->src_bucket_name, s->src_object);
+    bool result = RGWCopyObj::parse_copy_location(copy_source, t->src_bucket, s->src_object);
     if (!result)
        return -ERR_BAD_URL;
-    s->src_tenant_name = s->user.user_id.tenant;
   }
-
-  s->dialect = "swift";
 
   if (s->op == OP_COPY) {
     const char *req_dest = s->info.env->get("HTTP_DESTINATION");
     if (!req_dest)
       return -ERR_BAD_URL;
 
-    string dest_tenant_name, dest_bucket_name;
+    string dest_bucket_name;
     rgw_obj_key dest_obj_key;
     bool result = RGWCopyObj::parse_copy_location(req_dest, dest_bucket_name, dest_obj_key);
     if (!result)
        return -ERR_BAD_URL;
-    dest_tenant_name = s->user.user_id.tenant;
 
     string dest_object = dest_obj_key.name;
-    if (dest_bucket_name != s->bucket_name) {
-      ret = validate_bucket_name(dest_bucket_name);
-      if (ret < 0)
-        return ret;
-    }
-
-    ret = validate_tenant_name(dest_tenant_name);
-    if (ret < 0)
-      return ret;
 
     /* convert COPY operation into PUT */
-    s->src_tenant_name = s->bucket_tenant;
-    s->src_bucket_name = s->bucket_name;
+    t->src_bucket = t->url_bucket;
     s->src_object = s->object;
-    s->bucket_tenant = dest_tenant_name;
-    s->bucket_name = dest_bucket_name;
+    t->url_bucket = dest_bucket_name;
     s->object = rgw_obj_key(dest_object);
     s->op = OP_PUT;
   }
@@ -1480,8 +1496,9 @@ RGWHandler *RGWRESTMgr_SWIFT::get_handler(struct req_state *s)
   if (ret < 0)
     return NULL;
 
-  if (s->bucket_name.empty())
+  if (s->init_state.url_bucket.empty())
     return new RGWHandler_ObjStore_Service_SWIFT;
+
   if (s->object.empty())
     return new RGWHandler_ObjStore_Bucket_SWIFT;
 

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -192,8 +192,9 @@ public:
 
   int validate_bucket_name(const string& bucket);
 
-  int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
+  int init(RGWRados *store, struct req_state *s, RGWClientIO *cio);
   int authorize();
+  int postauth_init();
 
   RGWAccessControlPolicy *alloc_policy() { return NULL; /* return new RGWAccessControlPolicy_SWIFT; */ }
   void free_policy(RGWAccessControlPolicy *policy) { delete policy; }

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -29,6 +29,7 @@ public:
 
   int init(RGWRados *store, struct req_state *state, RGWClientIO *cio);
   int authorize();
+  int postauth_init() { return 0; }
   int read_permissions(RGWOp *op) { return 0; }
 
   virtual RGWAccessControlPolicy *alloc_policy() { return NULL; }


### PR DESCRIPTION
A big problem that cropped up with the multi-tenancy as it
went in was that it used tenant to initialize bucket names
before tenant was actually available by parsing a token.
Thus, although multi-tenancy worked, accessing anything across
tenants was actually impossible. This patch fixes that oversight.
Unfortunately, a new method postauth_init() was needed for it.

We also fix small bugs:

 - validate_tenant_name() used a proper-looking C++ but was
   incorrect. We simply use C for now, which may be not as
   pretty but is correct.

 - We now make a distinction between empty tenant syntax that
   means "the logged-in tenant" ("bucket") and the syntax
   that means "the legacy compatibility tenant with no name
   (":bucket").

 - We make rgw_make_bucket_entry_name() more robust against
   empty inputs. It's not used for work, but produces odd-looking
   debugging logs.

Signed-off-by: Pete Zaitcev <zaitcev@redhat.com>