### PR TITLE
osd: Replace snprintf with faster implementation in eversion_t::get_key_name

### DIFF
--- a/src/common/strtol.h
+++ b/src/common/strtol.h
@@ -48,4 +48,26 @@ Target strict_si_cast(const char *str, std::string *err) {
 template <>
 uint64_t strict_si_cast(const char *str, std::string *err);
 
+/* On enter buf points to the end of the buffer, e.g. where the least
+ * significant digit of the input number will be printed. Returns pointer to
+ * where the most significant digit were printed, including zero padding.
+ * Does NOT add zero at the end of buffer, this is responsibility of the caller.
+ */
+template<typename T, const unsigned base = 10, const unsigned width = 1>
+static inline
+char* ritoa(T u, char *buf)
+{
+  static_assert(std::is_unsigned<T>::value, "signed types are not supported");
+  static_assert(base <= 16, "extend character map below to support higher bases");
+  unsigned digits = 0;
+  while (u) {
+    *--buf = "0123456789abcdef"[u % base];
+    u /= base;
+    digits++;
+  }
+  while (digits++ < width)
+    *--buf = '0';
+  return buf;
+}
+
 #endif

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -121,22 +121,6 @@ string ceph_osd_op_flag_string(unsigned flags)
   return string("-");
 }
 
-const char *num_char_map = "0123456789abcdef";
-template<typename T, const int base>
-static inline
-char* ritoa(T u, char *buf) {
-  if (u < base) {
-    *--buf = num_char_map[u];
-    return buf;
-  }
- 
-  while (u) {
-    *--buf = num_char_map[u % base]; 
-    u /= base;
-  }
-  return buf;
-}
-
 void pg_shard_t::encode(bufferlist &bl) const
 {
   ENCODE_START(1, 1, bl);
@@ -463,7 +447,7 @@ char *spg_t::calc_name(char *buf, const char *suffix_backwords) const
     *--buf = *suffix_backwords++;
 
   if (!is_no_shard()) {
-    buf = ritoa<int8_t, 10>(shard.id, buf);
+    buf = ritoa<uint8_t, 10>((uint8_t)shard.id, buf);
     *--buf = 's';
   }
 
@@ -884,9 +868,12 @@ int pg_string_state(const std::string& state)
 // -- eversion_t --
 string eversion_t::get_key_name() const
 {
-  char key[40];
-  snprintf(
-    key, sizeof(key), "%010u.%020llu", epoch, (long long unsigned)version);
+  char key[32];
+  // Below is equivalent of sprintf("%010u.%020llu");
+  key[31] = 0;
+  ritoa<uint64_t, 10, 20>(version, key + 31);
+  key[10] = '.';
+  ritoa<uint32_t, 10, 10>(epoch, key + 10);
   return string(key);
 }
 


### PR DESCRIPTION
This implementaiton is 5 times faster in synthetic test.
There is some improvement in 4k fio test too, but I can't quantify.