### PR TITLE
mon:Re join the Monitor alone to form a cluster when it's rank=0

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -956,7 +956,7 @@ void Monitor::bootstrap()
   }
 
   // singleton monitor?
-  if (monmap->size() == 1 && rank == 0) {
+  if (monmap->size() == 1 && rank == 0 && extra_probe_peers.empty()) {
     win_standalone_election();
     return;
   }

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -465,6 +465,7 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
     entity_addr_t addr = pending_map.get_addr(name);
     pending_map.remove(name);
     pending_map.last_changed = ceph_clock_now(g_ceph_context);
+    mon->extra_probe_peers.erase(addr);
     ss << "removing mon." << name << " at " << addr
        << ", there will be " << pending_map.size() << " monitors" ;
     propose = true;


### PR DESCRIPTION
Increase whether there is Monitor extra judgment. when there is Monitor information in the extra_probe_peers, it does not enter the win_standalone_election() process

Fixes: #14263
Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>