### PR TITLE
cmake: bump up cmake_minimum_required() to 3.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(Ceph)
 set(VERSION "0.90")


### PR DESCRIPTION
we are using add_dependencies() to add dependencies to interface
libraries. and this feature was introduced in cmake 3.3.0.
see https://cmake.org/pipermail/cmake-developers/2015-June/025381.html

Reported-by: John Spray <john.spray@redhat.com>
Signed-off-by: Kefu Chai <kchai@redhat.com>