### PR TITLE
cmake: made rocksdb an imported library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -660,11 +660,11 @@ add_custom_target(build_rocksdb
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/rocksdb
     COMMENT "rocksdb building")
 
-# add a dummy target to attach librocksdb.a and it's include_directories
-add_library(rocksdb INTERFACE)
-set_target_properties(rocksdb PROPERTIES INTERFACE_LINK_LIBRARIES "${CMAKE_SOURCE_DIR}/src/rocksdb/librocksdb.a") 
+# add a imported library for librocksdb.a 
+add_library(rocksdb STATIC IMPORTED)
+set_property(TARGET rocksdb PROPERTY IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/src/rocksdb/librocksdb.a") 
 add_dependencies(rocksdb build_rocksdb)
-target_include_directories(rocksdb INTERFACE "${CMAKE_SOURCE_DIR}/src/rocksdb/include")
+set(ROCKSDB_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/rocksdb/include)
 
 add_subdirectory(kv)
 

--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -3,6 +3,7 @@ set(kv_srcs
   LevelDBStore.cc
   RocksDBStore.cc)
 add_library(kv_objs OBJECT ${kv_srcs})
-add_library(kv STATIC ${kv_srcs})
-target_include_directories(kv_objs PUBLIC ${CMAKE_SOURCE_DIR}/src/rocksdb/include)
+add_library(kv STATIC $<TARGET_OBJECTS:kv_objs>)
+target_include_directories(kv_objs PUBLIC ${ROCKSDB_INCLUDE_DIR})
+target_include_directories(kv PUBLIC ${ROCKSDB_INCLUDE_DIR})
 target_link_libraries(kv bz2 z leveldb snappy rocksdb)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1414,9 +1414,8 @@ add_executable(unittest_rocksdb_option EXCLUDE_FROM_ALL
   )
 add_test(unittest_rocksdb_option unittest_rocksdb_option)
 add_dependencies(check unittest_rocksdb_option)
-target_link_libraries(unittest_rocksdb_option global os rocksdb ${CMAKE_DL_LIBS}
+target_link_libraries(unittest_rocksdb_option global os ${CMAKE_DL_LIBS}
   ${BLKID_LIBRARIES} ${ALLOC_LIBS} ${UNITTEST_LIBS})
-target_include_directories(unittest_rocksdb_option PUBLIC ${CMAKE_SOURCE_DIR}/src/rocksdb/include)
 set_target_properties(unittest_rocksdb_option PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 
 # unittest_bluefs


### PR DESCRIPTION
Systems with the minimum required version of CMake
such as Ubuntu Trusty Tahr don't support
INTERFACE_LINK_LIBRARIES, so rocksdb was made into
an IMPORTED library.

Signed-off-by: Ali Maredia <amaredia@redhat.com>