### PR TITLE
DNM Client: allow same uid to do async setattr even if gid changes

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5820,7 +5820,8 @@ int Client::_setattr(Inode *in, struct stat *attr, int mask, int uid, int gid,
 
   // make the change locally?
   if ((in->cap_dirtier_uid >= 0 && uid != in->cap_dirtier_uid) ||
-      (in->cap_dirtier_gid >= 0 && gid != in->cap_dirtier_gid)) {
+      (in->cap_dirtier_uid < 0 &&
+       in->cap_dirtier_gid >= 0 && gid != in->cap_dirtier_gid)) {
     ldout(cct, 10) << __func__ << " caller " << uid << ":" << gid
 		   << " != cap dirtier " << in->cap_dirtier_uid << ":"
 		   << in->cap_dirtier_gid << ", forcing sync setattr"


### PR DESCRIPTION
We want to do sync setattrs when the user changes. A change in gid shouldn't matter if the uid stays constant though.