### PR TITLE
FileJournal: Should add item in writeq before signaling writeq_cond

### DIFF
--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1664,9 +1664,9 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
     completions.push_back(
       completion_item(
 	seq, oncommit, ceph_clock_now(g_ceph_context), osd_op));
-    if (writeq.empty())
-      writeq_cond.Signal();
     writeq.push_back(write_item(seq, e, orig_len, osd_op));
+    if (!writeq.empty())
+      writeq_cond.Signal();
   }
 }
 


### PR DESCRIPTION
Calling writeq.push_back() before signaling writeq_cond could reduce the potential lock contention on writeq_lock and make the code abide by the typical multi-thread pattern.

Signed-off-by: Jevon Qiao <scaleqiao@gmail.com>