### PR TITLE
OpRequest: release the message throttle when unregistered

### DIFF
--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -294,8 +294,7 @@ protected:
   virtual ~Message() {
     if (byte_throttler)
       byte_throttler->put(payload.length() + middle.length() + data.length());
-    if (msg_throttler)
-      msg_throttler->put();
+    release_message_throttle();
     /* call completion hooks (if any) */
     if (completion_hook)
       completion_hook->complete(0);
@@ -346,6 +345,11 @@ public:
       byte_throttler->put(data.length());
     data.clear();
     clear_buffers(); // let subclass drop buffers as well
+  }
+  void release_message_throttle() {
+    if (msg_throttler)
+      msg_throttler->put();
+    msg_throttler = nullptr;
   }
 
   bool empty_payload() const { return payload.length() == 0; }

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -81,6 +81,7 @@ void OpRequest::_dump_op_descriptor_unlocked(ostream& stream) const
 void OpRequest::_unregistered() {
   request->clear_data();
   request->clear_payload();
+  request->release_message_throttle();
 }
 
 bool OpRequest::check_rmw(int flag) {


### PR DESCRIPTION
We don't want messages in the OpTracker history hanging on to
message throttle.

Fixes: #14248
Backport: hammer, firefly
Signed-off-by: Samuel Just <sjust@redhat.com>