### PR TITLE
cls_rbd: enable object map checksums for object_map_save

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -2203,6 +2203,8 @@ int object_map_save(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     return -EINVAL;
   }
 
+  object_map.set_crc_enabled(true);
+
   bufferlist bl;
   ::encode(object_map, bl);
   CLS_LOG(20, "object_map_save: object size=%" PRIu64 ", byte size=%u",


### PR DESCRIPTION
object_map_save disables CRCs when an object map footer isn't provided.
Unconditionally re-enable object map CRCs before re-encoding the new object
map.

Fixes: #14280
Signed-off-by: Douglas Fuller <dfuller@redhat.com>