### PR TITLE
unittest_ipaddr: fix segv

### DIFF
--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -29,9 +29,11 @@ TEST(CommonIPAddr, TestNotFound)
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = "eth0";
 
   two.ifa_next = NULL;
   two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = "eth1";
 
   ipv4(&a_one, "10.11.12.13");
   ipv6(&a_two, "2001:1234:5678:90ab::cdef");
@@ -51,9 +53,11 @@ TEST(CommonIPAddr, TestV4_Simple)
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = "eth0";
 
   two.ifa_next = NULL;
   two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = "eth1";
 
   ipv4(&a_one, "10.11.12.13");
   ipv6(&a_two, "2001:1234:5678:90ab::cdef");
@@ -73,9 +77,11 @@ TEST(CommonIPAddr, TestV4_Prefix25)
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = "eth0";
 
   two.ifa_next = NULL;
   two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = "eth1";
 
   ipv4(&a_one, "10.11.12.13");
   ipv4(&a_two, "10.11.12.129");
@@ -95,9 +101,11 @@ TEST(CommonIPAddr, TestV4_Prefix16)
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = "eth0";
 
   two.ifa_next = NULL;
   two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = "eth1";
 
   ipv4(&a_one, "10.1.1.2");
   ipv4(&a_two, "10.2.1.123");
@@ -116,6 +124,7 @@ TEST(CommonIPAddr, TestV4_PrefixTooLong)
 
   one.ifa_next = NULL;
   one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = "eth0";
 
   ipv4(&a_one, "10.11.12.13");
   ipv4(&net, "10.11.12.12");
@@ -134,9 +143,11 @@ TEST(CommonIPAddr, TestV4_PrefixZero)
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = "eth0";
 
   two.ifa_next = NULL;
   two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = "eth1";
 
   ipv6(&a_one, "2001:1234:5678:900F::cdef");
   ipv4(&a_two, "10.1.2.3");
@@ -156,9 +167,11 @@ TEST(CommonIPAddr, TestV6_Simple)
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = "eth0";
 
   two.ifa_next = NULL;
   two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = "eth1";
 
   ipv4(&a_one, "10.11.12.13");
   ipv6(&a_two, "2001:1234:5678:90ab::cdef");
@@ -178,9 +191,11 @@ TEST(CommonIPAddr, TestV6_Prefix57)
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = "eth0";
 
   two.ifa_next = NULL;
   two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = "eth1";
 
   ipv6(&a_one, "2001:1234:5678:900F::cdef");
   ipv6(&a_two, "2001:1234:5678:90ab::cdef");
@@ -199,6 +214,7 @@ TEST(CommonIPAddr, TestV6_PrefixTooLong)
 
   one.ifa_next = NULL;
   one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = "eth0";
 
   ipv6(&a_one, "2001:1234:5678:900F::cdef");
   ipv6(&net, "2001:1234:5678:900F::cdee");
@@ -217,9 +233,11 @@ TEST(CommonIPAddr, TestV6_PrefixZero)
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = "eth0";
 
   two.ifa_next = NULL;
   two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = "eth1";
 
   ipv4(&a_one, "10.2.3.4");
   ipv6(&a_two, "2001:f00b::1");


### PR DESCRIPTION
Since b6d0fc9e0e515e50894c08217d688a8c94db7570 we need ifa_name to
be defined.

Signed-off-by: Sage Weil <sage@redhat.com>