### PR TITLE
pybind/test_rbd: fix test_create_defaults

### DIFF
--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -137,7 +137,7 @@ def check_default_params(format, order=None, features=None, stripe_count=None,
                 with Image(ioctx, image_name) as image:
                     eq(format == 1, image.old_format())
 
-                    expected_order = order
+                    expected_order = int(rados.conf_get('rbd_default_order'))
                     actual_order = image.stat()['order']
                     eq(expected_order, actual_order)
 
@@ -170,6 +170,8 @@ def test_create_defaults():
     check_default_params(1)
     check_default_params(2)
     # invalid order
+    check_default_params(1, 0, exception=ArgumentOutOfRange)
+    check_default_params(2, 0, exception=ArgumentOutOfRange)
     check_default_params(1, 11, exception=ArgumentOutOfRange)
     check_default_params(2, 11, exception=ArgumentOutOfRange)
     check_default_params(1, 65, exception=ArgumentOutOfRange)


### PR DESCRIPTION
Adjust for default order only being applied via ceph conf since
16d50459c4996cd3b188bc5da100d1ce069f05cd

Fixes: #14279
Signed-off-by: Josh Durgin <jdurgin@redhat.com>