### PR TITLE
[rgw multisite] realm epoch and period history

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1060,6 +1060,7 @@ if(${WITH_RADOSGW})
     rgw/rgw_sync.cc
     rgw/rgw_data_sync.cc
     rgw/rgw_dencoder.cc
+    rgw/rgw_period_history.cc
     rgw/rgw_period_pusher.cc
     rgw/rgw_realm_reloader.cc
     rgw/rgw_realm_watcher.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1061,6 +1061,7 @@ if(${WITH_RADOSGW})
     rgw/rgw_data_sync.cc
     rgw/rgw_dencoder.cc
     rgw/rgw_period_history.cc
+    rgw/rgw_period_puller.cc
     rgw/rgw_period_pusher.cc
     rgw/rgw_realm_reloader.cc
     rgw/rgw_realm_watcher.cc

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -58,6 +58,7 @@ librgw_la_SOURCES =  \
 	rgw/rgw_keystone.cc \
 	rgw/rgw_quota.cc \
 	rgw/rgw_dencoder.cc \
+	rgw/rgw_period_history.cc \
 	rgw/rgw_period_pusher.cc \
 	rgw/rgw_realm_reloader.cc \
 	rgw/rgw_realm_watcher.cc \
@@ -200,6 +201,7 @@ noinst_HEADERS += \
 	rgw/rgw_user.h \
 	rgw/rgw_bucket.h \
 	rgw/rgw_keystone.h \
+	rgw/rgw_period_history.h \
 	rgw/rgw_period_pusher.h \
 	rgw/rgw_realm_reloader.h \
 	rgw/rgw_realm_watcher.h \

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -59,6 +59,7 @@ librgw_la_SOURCES =  \
 	rgw/rgw_quota.cc \
 	rgw/rgw_dencoder.cc \
 	rgw/rgw_period_history.cc \
+	rgw/rgw_period_puller.cc \
 	rgw/rgw_period_pusher.cc \
 	rgw/rgw_realm_reloader.cc \
 	rgw/rgw_realm_watcher.cc \
@@ -203,6 +204,7 @@ noinst_HEADERS += \
 	rgw/rgw_keystone.h \
 	rgw/rgw_period_history.h \
 	rgw/rgw_period_pusher.h \
+	rgw/rgw_period_puller.h \
 	rgw/rgw_realm_reloader.h \
 	rgw/rgw_realm_watcher.h \
 	rgw/rgw_civetweb.h \

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2395,12 +2395,14 @@ int main(int argc, char **argv)
           return -EINVAL;
         }
         RGWPeriod period;
-        if (!realm.get_current_period().empty()) {
+        auto& current_period = realm.get_current_period();
+        if (!current_period.empty()) {
+          // pull the latest epoch of the realm's current period
           ret = do_period_pull(remote, url, access_key, secret_key,
-                               realm_id, realm_name, period_id, period_epoch,
+                               realm_id, realm_name, current_period, "",
                                &period);
           if (ret < 0) {
-            cerr << "could not fetch period " << realm.get_current_period() << std::endl;
+            cerr << "could not fetch period " << current_period << std::endl;
             return -ret;
           }
         }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1424,6 +1424,11 @@ static int commit_period(RGWRealm& realm, RGWPeriod& period,
     cerr << "Error updating period epoch: " << cpp_strerror(ret) << std::endl;
     return ret;
   }
+  ret = period.reflect();
+  if (ret < 0) {
+    cerr << "Error updating local objects: " << cpp_strerror(ret) << std::endl;
+    return ret;
+  }
   realm.notify_new_period(period);
   return ret;
 }

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -676,6 +676,7 @@ void RGWPeriod::dump(Formatter *f) const
   encode_json("period_config", period_config, f);
   encode_json("realm_id", realm_id, f);
   encode_json("realm_name", realm_name, f);
+  encode_json("realm_epoch", realm_epoch, f);
 }
 
 void RGWPeriod::decode_json(JSONObj *obj)
@@ -690,6 +691,7 @@ void RGWPeriod::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("period_config", period_config, obj);
   JSONDecoder::decode_json("realm_id", realm_id, obj);
   JSONDecoder::decode_json("realm_name", realm_name, obj);
+  JSONDecoder::decode_json("realm_epoch", realm_epoch, obj);
 }
 
 void RGWZoneParams::dump(Formatter *f) const
@@ -950,6 +952,7 @@ void RGWRealm::dump(Formatter *f) const
 {
   RGWSystemMetaObj::dump(f);
   encode_json("current_period", current_period, f);
+  encode_json("epoch", epoch, f);
 }
 
 
@@ -957,6 +960,7 @@ void RGWRealm::decode_json(JSONObj *obj)
 {
   RGWSystemMetaObj::decode_json(obj);
   JSONDecoder::decode_json("current_period", current_period, obj);
+  JSONDecoder::decode_json("epoch", epoch, obj);
 }
 
 void KeystoneToken::Metadata::decode_json(JSONObj *obj)

--- a/src/rgw/rgw_period_history.cc
+++ b/src/rgw/rgw_period_history.cc
@@ -1,0 +1,249 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "rgw_period_history.h"
+#include "rgw_rados.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+#undef dout_prefix
+#define dout_prefix (*_dout << "rgw period history: ")
+
+/// value comparison for avl_set
+bool operator<(const RGWPeriodHistory::History& lhs,
+               const RGWPeriodHistory::History& rhs)
+{
+  return lhs.get_newest_epoch() < rhs.get_newest_epoch();
+}
+
+/// key-value comparison for avl_set
+struct NewestEpochLess {
+  bool operator()(const RGWPeriodHistory::History& value, epoch_t key) const {
+    return value.get_newest_epoch() < key;
+  }
+};
+
+
+RGWPeriodHistory::RGWPeriodHistory(CephContext* cct, Puller* puller,
+                                   const RGWPeriod& current_period)
+  : cct(cct),
+    puller(puller),
+    current_epoch(current_period.get_realm_epoch())
+{
+  // copy the current period into a new history
+  auto history = new History;
+  history->periods.push_back(current_period);
+
+  // insert as our current history
+  current_history = histories.insert(*history).first;
+}
+
+RGWPeriodHistory::~RGWPeriodHistory()
+{
+  // clear the histories and delete each entry
+  histories.clear_and_dispose(std::default_delete<History>{});
+}
+
+using Cursor = RGWPeriodHistory::Cursor;
+
+Cursor RGWPeriodHistory::get_current() const
+{
+  return Cursor{current_history, &mutex, current_epoch};
+}
+
+Cursor RGWPeriodHistory::attach(RGWPeriod&& period)
+{
+  const auto epoch = period.get_realm_epoch();
+
+  std::string predecessor_id;
+  for (;;) {
+    {
+      // hold the lock over insert, and while accessing the unsafe cursor
+      std::lock_guard<std::mutex> lock(mutex);
+
+      auto cursor = insert_locked(std::move(period));
+      if (!cursor) {
+        return cursor;
+      }
+      if (current_history->contains(epoch)) {
+        break; // the history is complete
+      }
+
+      // take the predecessor id of the most recent history
+      if (cursor.get_epoch() > current_epoch) {
+        predecessor_id = cursor.history->get_predecessor_id();
+      } else {
+        predecessor_id = current_history->get_predecessor_id();
+      }
+    }
+
+    if (predecessor_id.empty()) {
+      lderr(cct) << "reached a period with an empty predecessor id" << dendl;
+      return Cursor{-EINVAL};
+    }
+
+    // pull the period outside of the lock
+    int r = puller->pull(predecessor_id, period);
+    if (r < 0) {
+      return Cursor{r};
+    }
+  }
+
+  // return a cursor to the requested period
+  return Cursor{current_history, &mutex, epoch};
+}
+
+Cursor RGWPeriodHistory::insert(RGWPeriod&& period)
+{
+  std::lock_guard<std::mutex> lock(mutex);
+
+  auto cursor = insert_locked(std::move(period));
+
+  if (cursor.get_error()) {
+    return cursor;
+  }
+  // we can only provide cursors that are safe to use outside of the mutex if
+  // they're within the current_history, because other histories can disappear
+  // in a merge. see merge() for the special handling of current_history
+  if (cursor.history == current_history) {
+    return cursor;
+  }
+  return Cursor{};
+}
+
+Cursor RGWPeriodHistory::lookup(epoch_t realm_epoch)
+{
+  if (current_history->contains(realm_epoch)) {
+    return Cursor{current_history, &mutex, realm_epoch};
+  }
+  return Cursor{};
+}
+
+Cursor RGWPeriodHistory::insert_locked(RGWPeriod&& period)
+{
+  auto epoch = period.get_realm_epoch();
+
+  // find the first history whose newest epoch comes at or after this period
+  auto i = histories.lower_bound(epoch, NewestEpochLess{});
+
+  if (i == histories.end()) {
+    // epoch is past the end of our newest history
+    auto last = --Set::iterator{i}; // last = i - 1
+
+    if (epoch == last->get_newest_epoch() + 1) {
+      // insert at the back of the last history
+      last->periods.emplace_back(std::move(period));
+      return Cursor{last, &mutex, epoch};
+    }
+
+    // create a new history for this period
+    auto history = new History;
+    history->periods.emplace_back(std::move(period));
+    histories.insert(last, *history);
+
+    i = Set::s_iterator_to(*history);
+    return Cursor{i, &mutex, epoch};
+  }
+
+  if (i->contains(epoch)) {
+    // already resident in this history
+    auto& existing = i->get(epoch);
+    // verify that the period ids match; otherwise we've forked the history
+    if (period.get_id() != existing.get_id()) {
+      lderr(cct) << "Got two different periods, " << period.get_id()
+          << " and " << existing.get_id() << ", with the same realm epoch "
+          << epoch << "! This indicates a fork in the period history." << dendl;
+      return Cursor{-EEXIST};
+    }
+    // update the existing period if we got a newer period epoch
+    if (period.get_epoch() > existing.get_epoch()) {
+      existing = std::move(period);
+    }
+    return Cursor{i, &mutex, epoch};
+  }
+
+  if (epoch + 1 == i->get_oldest_epoch()) {
+    // insert at the front of this history
+    i->periods.emplace_front(std::move(period));
+
+    // try to merge with the previous history
+    if (i != histories.begin()) {
+      auto prev = --Set::iterator{i};
+      if (epoch == prev->get_newest_epoch() + 1) {
+        i = merge(prev, i);
+      }
+    }
+    return Cursor{i, &mutex, epoch};
+  }
+
+  if (i != histories.begin()) {
+    auto prev = --Set::iterator{i};
+    if (epoch == prev->get_newest_epoch() + 1) {
+      // insert at the back of the previous history
+      prev->periods.emplace_back(std::move(period));
+      return Cursor{prev, &mutex, epoch};
+    }
+  }
+
+  // create a new history for this period
+  auto history = new History;
+  history->periods.emplace_back(std::move(period));
+  histories.insert(i, *history);
+
+  i = Set::s_iterator_to(*history);
+  return Cursor{i, &mutex, epoch};
+}
+
+RGWPeriodHistory::Set::iterator RGWPeriodHistory::merge(Set::iterator dst,
+                                                        Set::iterator src)
+{
+  assert(dst->get_newest_epoch() + 1 == src->get_oldest_epoch());
+
+  // always merge into current_history
+  if (src == current_history) {
+    // move the periods from dst onto the front of src
+    src->periods.insert(src->periods.begin(),
+                        std::make_move_iterator(dst->periods.begin()),
+                        std::make_move_iterator(dst->periods.end()));
+    histories.erase_and_dispose(dst, std::default_delete<History>{});
+    return src;
+  }
+
+  // move the periods from src onto the end of dst
+  dst->periods.insert(dst->periods.end(),
+                      std::make_move_iterator(src->periods.begin()),
+                      std::make_move_iterator(src->periods.end()));
+  histories.erase_and_dispose(src, std::default_delete<History>{});
+  return dst;
+}
+
+
+epoch_t RGWPeriodHistory::History::get_oldest_epoch() const
+{
+  return periods.front().get_realm_epoch();
+}
+
+epoch_t RGWPeriodHistory::History::get_newest_epoch() const
+{
+  return periods.back().get_realm_epoch();
+}
+
+bool RGWPeriodHistory::History::contains(epoch_t epoch) const
+{
+  return get_oldest_epoch() <= epoch && epoch <= get_newest_epoch();
+}
+
+RGWPeriod& RGWPeriodHistory::History::get(epoch_t epoch)
+{
+  return periods[epoch - get_oldest_epoch()];
+}
+
+const RGWPeriod& RGWPeriodHistory::History::get(epoch_t epoch) const
+{
+  return periods[epoch - get_oldest_epoch()];
+}
+
+const std::string& RGWPeriodHistory::History::get_predecessor_id() const
+{
+  return periods.front().get_predecessor();
+}

--- a/src/rgw/rgw_period_history.h
+++ b/src/rgw/rgw_period_history.h
@@ -1,0 +1,160 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RGW_PERIOD_HISTORY_H
+#define RGW_PERIOD_HISTORY_H
+
+#include <deque>
+#include <mutex>
+#include <system_error>
+#include <boost/intrusive/avl_set.hpp>
+#include "include/assert.h"
+#include "include/types.h"
+
+namespace bi = boost::intrusive;
+
+class RGWPeriod;
+
+/**
+ * RGWPeriodHistory tracks the relative history of all inserted periods,
+ * coordinates the pulling of missing intermediate periods, and provides a
+ * Cursor object for traversing through the connected history.
+ */
+class RGWPeriodHistory final {
+  /// an ordered history of consecutive periods
+  struct History : public bi::avl_set_base_hook<> {
+    std::deque<RGWPeriod> periods;
+
+    epoch_t get_oldest_epoch() const;
+    epoch_t get_newest_epoch() const;
+    bool contains(epoch_t epoch) const;
+    RGWPeriod& get(epoch_t epoch);
+    const RGWPeriod& get(epoch_t epoch) const;
+    const std::string& get_predecessor_id() const;
+  };
+
+  // comparisons for avl_set ordering
+  friend bool operator<(const History& lhs, const History& rhs);
+  friend struct NewestEpochLess;
+
+  /// an intrusive set of histories, ordered by their newest epoch. although
+  /// the newest epoch of each history is mutable, the ordering cannot change
+  /// because we prevent the histories from overlapping
+  using Set = bi::avl_set<History>;
+
+ public:
+  /**
+   * Puller is a synchronous interface for pulling periods from the master
+   * zone. The abstraction exists mainly to support unit testing.
+   */
+  class Puller {
+   public:
+    virtual ~Puller() = default;
+
+    virtual int pull(const std::string& period_id, RGWPeriod& period) = 0;
+  };
+
+  RGWPeriodHistory(CephContext* cct, Puller* puller,
+                   const RGWPeriod& current_period);
+  ~RGWPeriodHistory();
+
+  /**
+   * Cursor tracks a position in the period history and allows forward and
+   * backward traversal. Only periods that are fully connected to the
+   * current_period are reachable via a Cursor, because other histories are
+   * temporary and can be merged away. Cursors to periods in disjoint
+   * histories, as provided by insert() or lookup(), are therefore invalid and
+   * their operator bool() will return false.
+   */
+  class Cursor final {
+   public:
+    Cursor() = default;
+
+    int get_error() const { return error; }
+
+    /// return false for a default-constructed Cursor
+    operator bool() const { return history != Set::const_iterator{}; }
+
+    epoch_t get_epoch() const { return epoch; }
+    const RGWPeriod& get_period() const;
+
+    bool has_prev() const;
+    bool has_next() const;
+
+    void prev() { epoch--; }
+    void next() { epoch++; }
+
+   private:
+    // private constructors for RGWPeriodHistory
+    friend class RGWPeriodHistory;
+
+    explicit Cursor(int error) : error(error) {}
+    Cursor(Set::const_iterator history, std::mutex* mutex, epoch_t epoch)
+      : history(history), mutex(mutex), epoch(epoch) {}
+
+    int error{0};
+    Set::const_iterator history;
+    std::mutex* mutex{nullptr};
+    epoch_t epoch{0}; //< realm epoch of cursor position
+  };
+
+  /// return a cursor to the current period
+  Cursor get_current() const;
+
+  /// build up a connected period history that covers the span between
+  /// current_period and the given period, reading predecessor periods or
+  /// fetching them from the master as necessary. returns a cursor at the
+  /// given period that can be used to traverse the current_history
+  Cursor attach(RGWPeriod&& period);
+
+  /// insert the given period into an existing history, or create a new
+  /// unconnected history. similar to attach(), but it doesn't try to fetch
+  /// missing periods. returns a cursor to the inserted period iff it's in
+  /// the current_history
+  Cursor insert(RGWPeriod&& period);
+
+  /// search for a period by realm epoch, returning a valid Cursor iff it's in
+  /// the current_history
+  Cursor lookup(epoch_t realm_epoch);
+
+ private:
+  /// insert the given period into the period history, creating new unconnected
+  /// histories or merging existing histories as necessary. expects the caller
+  /// to hold a lock on mutex. returns a valid cursor regardless of whether it
+  /// ends up in current_history, though cursors in other histories are only
+  /// valid within the context of the lock
+  Cursor insert_locked(RGWPeriod&& period);
+
+  /// merge the periods from the src history onto the end of the dst history,
+  /// and return an iterator to the merged history
+  Set::iterator merge(Set::iterator dst, Set::iterator src);
+
+
+  CephContext *const cct;
+  Puller *const puller; //< interface for pulling missing periods
+  const epoch_t current_epoch; //< realm_epoch of realm's current period
+
+  mutable std::mutex mutex; //< protects the histories
+
+  /// set of disjoint histories that are missing intermediate periods needed to
+  /// connect them together
+  Set histories;
+
+  /// iterator to the history that contains the realm's current period
+  Set::const_iterator current_history;
+};
+
+inline const RGWPeriod& RGWPeriodHistory::Cursor::get_period() const {
+  std::lock_guard<std::mutex> lock(*mutex);
+  return history->get(epoch);
+}
+inline bool RGWPeriodHistory::Cursor::has_prev() const {
+  std::lock_guard<std::mutex> lock(*mutex);
+  return epoch > history->get_oldest_epoch();
+}
+inline bool RGWPeriodHistory::Cursor::has_next() const {
+  std::lock_guard<std::mutex> lock(*mutex);
+  return epoch < history->get_newest_epoch();
+}
+
+#endif // RGW_PERIOD_HISTORY_H

--- a/src/rgw/rgw_period_puller.cc
+++ b/src/rgw/rgw_period_puller.cc
@@ -1,0 +1,97 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "rgw_rados.h"
+#include "rgw_rest_conn.h"
+#include "common/ceph_json.h"
+#include "common/errno.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+#undef dout_prefix
+#define dout_prefix (*_dout << "rgw period puller: ")
+
+namespace {
+
+// pull the given period over the connection
+int pull_period(RGWRESTConn* conn, const std::string& period_id,
+                const std::string& realm_id, RGWPeriod& period)
+{
+  rgw_user user;
+  RGWEnv env;
+  req_info info(conn->get_ctx(), &env);
+  info.method = "GET";
+  info.request_uri = "/admin/realm/period";
+
+  auto& params = info.args.get_params();
+  params["realm_id"] = realm_id;
+  params["period_id"] = period_id;
+
+  bufferlist data;
+#define MAX_REST_RESPONSE (128 * 1024)
+  int r = conn->forward(user, info, nullptr, MAX_REST_RESPONSE, nullptr, &data);
+  if (r < 0) {
+    return r;
+  }
+
+  JSONParser parser;
+  r = parser.parse(data.c_str(), data.length());
+  if (r < 0) {
+    lderr(conn->get_ctx()) << "request failed: " << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  try {
+    decode_json_obj(period, &parser);
+  } catch (JSONDecoder::err& e) {
+    lderr(conn->get_ctx()) << "failed to decode JSON input: "
+        << e.message << dendl;
+    return -EINVAL;
+  }
+  return 0;
+}
+
+} // anonymous namespace
+
+int RGWPeriodPuller::pull(const std::string& period_id, RGWPeriod& period)
+{
+  // try to read the period from rados
+  period.set_id(period_id);
+  int r = period.init(store->ctx(), store);
+  if (r < 0) {
+    ldout(store->ctx(), 14) << "pulling period " << period_id
+        << " from master" << dendl;
+    // request the period from the master zone
+    r = pull_period(store->rest_master_conn, period_id,
+                    store->realm.get_id(), period);
+    if (r < 0) {
+      lderr(store->ctx()) << "failed to pull period " << period_id << dendl;
+      return r;
+    }
+    // write the period to rados
+    r = period.store_info(true);
+    if (r == -EEXIST) {
+      r = 0;
+    } else if (r < 0) {
+      lderr(store->ctx()) << "failed to store period " << period_id << dendl;
+      return r;
+    }
+    // XXX: if this is a newer epoch, we should overwrite the existing
+    // latest_epoch. but there's no way to do that atomically
+    bool exclusive = true;
+    r = period.set_latest_epoch(period.get_epoch(), exclusive);
+    if (r == -EEXIST) {
+      r = 0;
+    } else if (r < 0) {
+      lderr(store->ctx()) << "failed to update latest_epoch for period "
+          << period_id << dendl;
+      return r;
+    }
+    ldout(store->ctx(), 14) << "period " << period_id
+        << " pulled and written to local storage" << dendl;
+  } else {
+    ldout(store->ctx(), 14) << "found period " << period_id
+        << " in local storage" << dendl;
+  }
+  return 0;
+}

--- a/src/rgw/rgw_period_puller.h
+++ b/src/rgw/rgw_period_puller.h
@@ -1,0 +1,20 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_RGW_PERIOD_PULLER_H
+#define CEPH_RGW_PERIOD_PULLER_H
+
+#include "rgw_period_history.h"
+
+class RGWRados;
+class RGWPeriod;
+
+class RGWPeriodPuller : public RGWPeriodHistory::Puller {
+  RGWRados *const store;
+ public:
+  RGWPeriodPuller(RGWRados* store) : store(store) {}
+
+  int pull(const std::string& period_id, RGWPeriod& period) override;
+};
+
+#endif // CEPH_RGW_PERIOD_PULLER_H

--- a/src/rgw/rgw_period_pusher.h
+++ b/src/rgw/rgw_period_pusher.h
@@ -43,8 +43,8 @@ class RGWPeriodPusher final : public RGWRealmWatcher::Watcher,
   RGWRados* store;
 
   std::mutex mutex;
-  std::string period_id; //< the current period id being sent
-  epoch_t period_epoch; //< the current period epoch being sent
+  epoch_t realm_epoch{0}; //< the current realm epoch being sent
+  epoch_t period_epoch{0}; //< the current period epoch being sent
 
   /// while paused for reconfiguration, we need to queue up notifications
   std::vector<RGWZonesNeedPeriod> pending_periods;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -995,7 +995,7 @@ int RGWPeriod::use_latest_epoch()
   return 0;
 }
 
-int RGWPeriod::set_latest_epoch(epoch_t epoch)
+int RGWPeriod::set_latest_epoch(epoch_t epoch, bool exclusive)
 {
   string pool_name = get_pool_name(cct);
   string oid = get_period_oid_prefix() + get_latest_epoch_oid();
@@ -1008,7 +1008,8 @@ int RGWPeriod::set_latest_epoch(epoch_t epoch)
 
   ::encode(info, bl);
 
-  return rgw_put_system_obj(store, pool, oid, bl.c_str(), bl.length(), false, NULL, 0, NULL);
+  return rgw_put_system_obj(store, pool, oid, bl.c_str(), bl.length(),
+                            exclusive, NULL, 0, NULL);
 }
 
 int RGWPeriod::delete_obj()

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1285,17 +1285,17 @@ int RGWPeriod::commit(RGWRealm& realm, const RGWPeriod& current_period)
   }
   // did the master zone change?
   if (master_zone != current_period.get_master_zone()) {
-    // create with a new period id
-    int r = create(true);
-    if (r < 0) {
-      lderr(cct) << "failed to create new period: " << cpp_strerror(-r) << dendl;
-      return r;
-    }
     // store the current metadata sync status in the period
-    r = update_sync_status();
+    int r = update_sync_status();
     if (r < 0) {
       lderr(cct) << "failed to update metadata sync status: "
           << cpp_strerror(-r) << dendl;
+      return r;
+    }
+    // create an object with a new period id
+    r = create(true);
+    if (r < 0) {
+      lderr(cct) << "failed to create new period: " << cpp_strerror(-r) << dendl;
       return r;
     }
     // set as current period

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1008,17 +1008,7 @@ int RGWPeriod::set_latest_epoch(epoch_t epoch)
 
   ::encode(info, bl);
 
-  int ret = rgw_put_system_obj(store, pool, oid, bl.c_str(), bl.length(), false, NULL, 0, NULL);
-  if (ret < 0)
-    return ret;
-
-  ret = reflect();
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: period.reflect(): " << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
-
-  return 0;
+  return rgw_put_system_obj(store, pool, oid, bl.c_str(), bl.length(), false, NULL, 0, NULL);
 }
 
 int RGWPeriod::delete_obj()
@@ -1342,6 +1332,11 @@ int RGWPeriod::commit(RGWRealm& realm, const RGWPeriod& current_period)
   r = set_latest_epoch(epoch);
   if (r < 0) {
     lderr(cct) << "failed to set latest epoch: " << cpp_strerror(-r) << dendl;
+    return r;
+  }
+  r = reflect();
+  if (r < 0) {
+    lderr(cct) << "failed to update local objects: " << cpp_strerror(-r) << dendl;
     return r;
   }
   ldout(cct, 4) << "Committed new epoch " << epoch

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -785,7 +785,20 @@ const string& RGWRealm::get_info_oid_prefix(bool old_format)
 
 int RGWRealm::set_current_period(RGWPeriod& period)
 {
+  // update realm epoch to match the period's
+  if (epoch > period.get_realm_epoch()) {
+    lderr(cct) << "ERROR: set_current_period with old realm epoch "
+        << period.get_realm_epoch() << ", current epoch=" << epoch << dendl;
+    return -EINVAL;
+  }
+  if (epoch == period.get_realm_epoch() && current_period != period.get_id()) {
+    lderr(cct) << "ERROR: set_current_period with same realm epoch "
+        << period.get_realm_epoch() << ", but different period id "
+        << period.get_id() << " != " << current_period << dendl;
+    return -EINVAL;
+  }
 
+  epoch = period.get_realm_epoch();
   current_period = period.get_id();
 
   int ret = update();
@@ -1208,6 +1221,7 @@ void RGWPeriod::fork()
   predecessor_uuid = id;
   id = get_staging_id(realm_id);
   period_map.reset();
+  realm_epoch++;
 }
 
 void RGWPeriod::update(const RGWZoneGroupMap& map)
@@ -1273,6 +1287,13 @@ int RGWPeriod::commit(RGWRealm& realm, const RGWPeriod& current_period)
         << dendl;
     return -EINVAL;
   }
+  // realm epoch must be 1 greater than current period
+  if (realm_epoch != current_period.get_realm_epoch() + 1) {
+    lderr(cct) << "period's realm epoch " << realm_epoch
+        << " does not come directly after current realm epoch "
+        << current_period.get_realm_epoch() << dendl;
+    return -EINVAL;
+  }
   // did the master zone change?
   if (master_zone != current_period.get_master_zone()) {
     // store the current metadata sync status in the period
@@ -1310,6 +1331,7 @@ int RGWPeriod::commit(RGWRealm& realm, const RGWPeriod& current_period)
   set_id(current_period.get_id());
   set_epoch(current_period.get_epoch() + 1);
   set_predecessor(current_period.get_predecessor());
+  realm_epoch = current_period.get_realm_epoch();
   // write the period to rados
   int r = store_info(false);
   if (r < 0) {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1305,7 +1305,7 @@ public:
   const string& get_current_period() const {
     return current_period;
   }
-  int set_current_period(const string& period_id);
+  int set_current_period(RGWPeriod& period);
 
   string get_control_oid();
   /// send a notify on the realm control object

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1268,6 +1268,7 @@ class RGWPeriod;
 class RGWRealm : public RGWSystemMetaObj
 {
   string current_period;
+  epoch_t epoch{0}; //< realm epoch, incremented for each new period
 
   int create_control();
   int delete_control();
@@ -1281,6 +1282,7 @@ public:
     ENCODE_START(1, 1, bl);
     RGWSystemMetaObj::encode(bl);
     ::encode(current_period, bl);
+    ::encode(epoch, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -1288,6 +1290,7 @@ public:
     DECODE_START(1, bl);
     RGWSystemMetaObj::decode(bl);
     ::decode(current_period, bl);
+    ::decode(epoch, bl);
     DECODE_FINISH(bl);
   }
 
@@ -1306,6 +1309,8 @@ public:
     return current_period;
   }
   int set_current_period(RGWPeriod& period);
+
+  epoch_t get_epoch() const { return epoch; }
 
   string get_control_oid();
   /// send a notify on the realm control object
@@ -1348,6 +1353,7 @@ class RGWPeriod
 
   string realm_id;
   string realm_name;
+  epoch_t realm_epoch{1}; //< realm epoch when period was made current
 
   CephContext *cct;
   RGWRados *store;
@@ -1371,6 +1377,7 @@ public:
 
   const string& get_id() const { return id; }
   epoch_t get_epoch() const { return epoch; }
+  epoch_t get_realm_epoch() const { return realm_epoch; }
   const string& get_predecessor() const { return predecessor_uuid; }
   const string& get_master_zone() const { return master_zone; }
   const string& get_master_zonegroup() const { return master_zonegroup; }
@@ -1425,9 +1432,10 @@ public:
   int commit(RGWRealm& realm, const RGWPeriod &current_period);
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);    
+    ENCODE_START(1, 1, bl);
     ::encode(id, bl);
     ::encode(epoch, bl);
+    ::encode(realm_epoch, bl);
     ::encode(predecessor_uuid, bl);
     ::encode(sync_status, bl);
     ::encode(period_map, bl);
@@ -1443,6 +1451,7 @@ public:
     DECODE_START(1, bl);
     ::decode(id, bl);
     ::decode(epoch, bl);
+    ::decode(realm_epoch, bl);
     ::decode(predecessor_uuid, bl);
     ::decode(sync_status, bl);
     ::decode(period_map, bl);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1414,7 +1414,7 @@ public:
   bool is_single_zonegroup(CephContext *cct, RGWRados *store);
 
   int get_latest_epoch(epoch_t& epoch);
-  int set_latest_epoch(epoch_t epoch);
+  int set_latest_epoch(epoch_t epoch, bool exclusive = false);
 
   int init(CephContext *_cct, RGWRados *_store, const string &period_realm_id, const string &period_realm_name = "",
 	   bool setup_obj = true);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -17,6 +17,7 @@
 #include "rgw_log.h"
 #include "rgw_metadata.h"
 #include "rgw_meta_sync_status.h"
+#include "rgw_period_puller.h"
 
 class RGWWatcher;
 class SafeTimer;
@@ -1868,6 +1869,11 @@ public:
   const RGWQuotaInfo& get_user_quota() {
     return current_period.get_config().user_quota;
   }
+
+  // pulls missing periods for period_history
+  std::unique_ptr<RGWPeriodPuller> period_puller;
+  // maintains a connected history of periods
+  std::unique_ptr<RGWPeriodHistory> period_history;
 
   RGWMetadataManager *meta_mgr;
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1394,6 +1394,7 @@ public:
     period_map.id = id;
   }
   void set_epoch(epoch_t epoch) { this->epoch = epoch; }
+  void set_realm_epoch(epoch_t epoch) { realm_epoch = epoch; }
 
   void set_predecessor(const string& predecessor)
   {

--- a/src/rgw/rgw_realm_watcher.h
+++ b/src/rgw/rgw_realm_watcher.h
@@ -20,8 +20,7 @@ WRITE_RAW_ENCODER(RGWRealmNotify);
 
 /**
  * RGWRealmWatcher establishes a watch on the current RGWRealm's control object,
- * and responds to notifications by recreating RGWRados with the updated realm
- * configuration.
+ * and forwards notifications to registered observers.
  */
 class RGWRealmWatcher : public librados::WatchCtx2 {
  public:

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -140,7 +140,7 @@ void RGWOp_Period_Post::execute()
       return;
     }
     // set as current period
-    http_ret = realm.set_current_period(period.get_id()); // TODO: add sync status argument
+    http_ret = realm.set_current_period(period);
     if (http_ret < 0) {
       lderr(cct) << "failed to update realm's current period" << dendl;
       return;

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -171,6 +171,13 @@ void RGWOp_Period_Post::execute()
     lderr(cct) << "failed to set latest epoch" << dendl;
     return;
   }
+  // reflect the period into our local objects
+  http_ret  = period.reflect();
+  if (http_ret  < 0) {
+    lderr(cct) << "failed to update local objects: "
+        << cpp_strerror(-http_ret) << dendl;
+    return;
+  }
   ldout(cct, 4) << "period epoch " << period.get_epoch()
       << " is newer than current epoch " << current_period.get_epoch()
       << ", updating latest epoch and notifying zone" << dendl;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1453,6 +1453,7 @@ add_subdirectory(erasure-code EXCLUDE_FROM_ALL)
 #make check ends here
 
 if(${WITH_RADOSGW})
+  add_subdirectory(rgw)
   # test_cors
   set(test_cors_srcs test_cors.cc)
   add_executable(test_cors

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -582,6 +582,13 @@ ceph_test_rgw_manifest_LDADD = \
 ceph_test_rgw_manifest_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_rgw_manifest
 
+ceph_test_rgw_period_history_SOURCES = test/rgw/test_rgw_period_history.cc
+ceph_test_rgw_period_history_LDADD = \
+	$(LIBRADOS) $(LIBRGW) $(LIBRGW_DEPS) $(CEPH_GLOBAL) \
+	$(UNITTEST_LDADD) $(CRYPTO_LIBS) -lcurl -lexpat
+ceph_test_rgw_period_history_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+bin_DEBUGPROGRAMS += ceph_test_rgw_period_history
+
 ceph_test_rgw_obj_SOURCES = test/rgw/test_rgw_obj.cc
 ceph_test_rgw_obj_LDADD = \
 	$(LIBRADOS) $(LIBRGW) $(LIBRGW_DEPS) $(CEPH_GLOBAL) \

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(test_rgw_period_history EXCLUDE_FROM_ALL test_rgw_period_history.cc)
+target_link_libraries(test_rgw_period_history rgw_a ${UNITTEST_LIBS})
+set_target_properties(test_rgw_period_history PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
+add_test(RGWPeriodHistory test_rgw_period_history)
+add_dependencies(check test_rgw_period_history)

--- a/src/test/rgw/test_rgw_period_history.cc
+++ b/src/test/rgw/test_rgw_period_history.cc
@@ -1,0 +1,330 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+#include "rgw/rgw_period_history.h"
+#include "rgw/rgw_rados.h"
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
+#include <boost/lexical_cast.hpp>
+#include <gtest/gtest.h>
+
+namespace {
+
+// construct a period with the given fields
+RGWPeriod make_period(const std::string& id, epoch_t realm_epoch,
+                      const std::string& predecessor)
+{
+  RGWPeriod period(id);
+  period.set_realm_epoch(realm_epoch);
+  period.set_predecessor(predecessor);
+  return period;
+}
+
+const auto current_period = make_period("5", 5, "4");
+
+// mock puller that throws an exception if it's called
+struct ErrorPuller : public RGWPeriodHistory::Puller {
+  int pull(const std::string& id, RGWPeriod& period) override {
+    throw std::runtime_error("unexpected call to pull");
+  }
+};
+ErrorPuller puller; // default puller
+
+// mock puller that records the period ids requested and returns an error
+using Ids = std::vector<std::string>;
+class RecordingPuller : public RGWPeriodHistory::Puller {
+  const int error;
+ public:
+  RecordingPuller(int error) : error(error) {}
+  Ids ids;
+  int pull(const std::string& id, RGWPeriod& period) override {
+    ids.push_back(id);
+    return error;
+  }
+};
+
+// mock puller that returns a fake period by parsing the period id
+struct NumericPuller : public RGWPeriodHistory::Puller {
+  int pull(const std::string& id, RGWPeriod& period) override {
+    // relies on numeric period ids to divine the realm_epoch
+    auto realm_epoch = boost::lexical_cast<epoch_t>(id);
+    auto predecessor = boost::lexical_cast<std::string>(realm_epoch-1);
+    period = make_period(id, realm_epoch, predecessor);
+    return 0;
+  }
+};
+
+} // anonymous namespace
+
+// for ASSERT_EQ()
+bool operator==(const RGWPeriod& lhs, const RGWPeriod& rhs)
+{
+  return lhs.get_id() == rhs.get_id()
+      && lhs.get_realm_epoch() == rhs.get_realm_epoch();
+}
+
+TEST(PeriodHistory, InsertBefore)
+{
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  // inserting right before current_period 5 will attach to history
+  auto c = history.insert(make_period("4", 4, "3"));
+  ASSERT_TRUE(c);
+  ASSERT_FALSE(c.has_prev());
+  ASSERT_TRUE(c.has_next());
+
+  // cursor can traverse forward to current_period
+  c.next();
+  ASSERT_EQ(5u, c.get_epoch());
+  ASSERT_EQ(current_period, c.get_period());
+}
+
+TEST(PeriodHistory, InsertAfter)
+{
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  // inserting right after current_period 5 will attach to history
+  auto c = history.insert(make_period("6", 6, "5"));
+  ASSERT_TRUE(c);
+  ASSERT_TRUE(c.has_prev());
+  ASSERT_FALSE(c.has_next());
+
+  // cursor can traverse back to current_period
+  c.prev();
+  ASSERT_EQ(5u, c.get_epoch());
+  ASSERT_EQ(current_period, c.get_period());
+}
+
+TEST(PeriodHistory, InsertWayBefore)
+{
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  // inserting way before current_period 5 will not attach to history
+  auto c = history.insert(make_period("1", 1, ""));
+  ASSERT_FALSE(c);
+  ASSERT_EQ(0, c.get_error());
+}
+
+TEST(PeriodHistory, InsertWayAfter)
+{
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  // inserting way after current_period 5 will not attach to history
+  auto c = history.insert(make_period("9", 9, "8"));
+  ASSERT_FALSE(c);
+  ASSERT_EQ(0, c.get_error());
+}
+
+TEST(PeriodHistory, PullPredecessorsBeforeCurrent)
+{
+  RecordingPuller puller{-EFAULT};
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  // create a disjoint history at 1 and verify that periods are requested
+  // backwards from current_period
+  auto c1 = history.attach(make_period("1", 1, ""));
+  ASSERT_FALSE(c1);
+  ASSERT_EQ(-EFAULT, c1.get_error());
+  ASSERT_EQ(Ids{"4"}, puller.ids);
+
+  auto c4 = history.insert(make_period("4", 4, "3"));
+  ASSERT_TRUE(c4);
+
+  c1 = history.attach(make_period("1", 1, ""));
+  ASSERT_FALSE(c1);
+  ASSERT_EQ(-EFAULT, c1.get_error());
+  ASSERT_EQ(Ids({"4", "3"}), puller.ids);
+
+  auto c3 = history.insert(make_period("3", 3, "2"));
+  ASSERT_TRUE(c3);
+
+  c1 = history.attach(make_period("1", 1, ""));
+  ASSERT_FALSE(c1);
+  ASSERT_EQ(-EFAULT, c1.get_error());
+  ASSERT_EQ(Ids({"4", "3", "2"}), puller.ids);
+
+  auto c2 = history.insert(make_period("2", 2, "1"));
+  ASSERT_TRUE(c2);
+
+  c1 = history.attach(make_period("1", 1, ""));
+  ASSERT_TRUE(c1);
+  ASSERT_EQ(Ids({"4", "3", "2"}), puller.ids);
+}
+
+TEST(PeriodHistory, PullPredecessorsAfterCurrent)
+{
+  RecordingPuller puller{-EFAULT};
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  // create a disjoint history at 9 and verify that periods are requested
+  // backwards down to current_period
+  auto c9 = history.attach(make_period("9", 9, "8"));
+  ASSERT_FALSE(c9);
+  ASSERT_EQ(-EFAULT, c9.get_error());
+  ASSERT_EQ(Ids{"8"}, puller.ids);
+
+  auto c8 = history.attach(make_period("8", 8, "7"));
+  ASSERT_FALSE(c8);
+  ASSERT_EQ(-EFAULT, c8.get_error());
+  ASSERT_EQ(Ids({"8", "7"}), puller.ids);
+
+  auto c7 = history.attach(make_period("7", 7, "6"));
+  ASSERT_FALSE(c7);
+  ASSERT_EQ(-EFAULT, c7.get_error());
+  ASSERT_EQ(Ids({"8", "7", "6"}), puller.ids);
+
+  auto c6 = history.attach(make_period("6", 6, "5"));
+  ASSERT_TRUE(c6);
+  ASSERT_EQ(Ids({"8", "7", "6"}), puller.ids);
+}
+
+TEST(PeriodHistory, MergeBeforeCurrent)
+{
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  auto c = history.get_current();
+  ASSERT_FALSE(c.has_prev());
+
+  // create a disjoint history at 3
+  auto c3 = history.insert(make_period("3", 3, "2"));
+  ASSERT_FALSE(c3);
+
+  // insert the missing period to merge 3 and 5
+  auto c4 = history.insert(make_period("4", 4, "3"));
+  ASSERT_TRUE(c4);
+  ASSERT_TRUE(c4.has_prev());
+  ASSERT_TRUE(c4.has_next());
+
+  // verify that the merge didn't destroy the original cursor's history
+  ASSERT_EQ(current_period, c.get_period());
+  ASSERT_TRUE(c.has_prev());
+}
+
+TEST(PeriodHistory, MergeAfterCurrent)
+{
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  auto c = history.get_current();
+  ASSERT_FALSE(c.has_next());
+
+  // create a disjoint history at 7
+  auto c7 = history.insert(make_period("7", 7, "6"));
+  ASSERT_FALSE(c7);
+
+  // insert the missing period to merge 5 and 7
+  auto c6 = history.insert(make_period("6", 6, "5"));
+  ASSERT_TRUE(c6);
+  ASSERT_TRUE(c6.has_prev());
+  ASSERT_TRUE(c6.has_next());
+
+  // verify that the merge didn't destroy the original cursor's history
+  ASSERT_EQ(current_period, c.get_period());
+  ASSERT_TRUE(c.has_next());
+}
+
+TEST(PeriodHistory, MergeWithoutCurrent)
+{
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  // create a disjoint history at 7
+  auto c7 = history.insert(make_period("7", 7, "6"));
+  ASSERT_FALSE(c7);
+
+  // create a disjoint history at 9
+  auto c9 = history.insert(make_period("9", 9, "8"));
+  ASSERT_FALSE(c9);
+
+  // insert the missing period to merge 7 and 9
+  auto c8 = history.insert(make_period("8", 8, "7"));
+  ASSERT_FALSE(c8); // not connected to current_period yet
+
+  // insert the missing period to merge 5 and 7-9
+  auto c = history.insert(make_period("6", 6, "5"));
+  ASSERT_TRUE(c);
+  ASSERT_TRUE(c.has_next());
+
+  // verify that we merged all periods from 5-9
+  c.next();
+  ASSERT_EQ(7u, c.get_epoch());
+  ASSERT_TRUE(c.has_next());
+  c.next();
+  ASSERT_EQ(8u, c.get_epoch());
+  ASSERT_TRUE(c.has_next());
+  c.next();
+  ASSERT_EQ(9u, c.get_epoch());
+  ASSERT_FALSE(c.has_next());
+}
+
+TEST(PeriodHistory, AttachBefore)
+{
+  NumericPuller puller;
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  auto c1 = history.attach(make_period("1", 1, ""));
+  ASSERT_TRUE(c1);
+
+  // verify that we pulled and merged all periods from 1-5
+  auto c = history.get_current();
+  ASSERT_TRUE(c);
+  ASSERT_TRUE(c.has_prev());
+  c.prev();
+  ASSERT_EQ(4u, c.get_epoch());
+  ASSERT_TRUE(c.has_prev());
+  c.prev();
+  ASSERT_EQ(3u, c.get_epoch());
+  ASSERT_TRUE(c.has_prev());
+  c.prev();
+  ASSERT_EQ(2u, c.get_epoch());
+  ASSERT_TRUE(c.has_prev());
+  c.prev();
+  ASSERT_EQ(1u, c.get_epoch());
+  ASSERT_FALSE(c.has_prev());
+}
+
+TEST(PeriodHistory, AttachAfter)
+{
+  NumericPuller puller;
+  RGWPeriodHistory history(g_ceph_context, &puller, current_period);
+
+  auto c9 = history.attach(make_period("9", 9, "8"));
+  ASSERT_TRUE(c9);
+
+  // verify that we pulled and merged all periods from 5-9
+  auto c = history.get_current();
+  ASSERT_TRUE(c);
+  ASSERT_TRUE(c.has_next());
+  c.next();
+  ASSERT_EQ(6u, c.get_epoch());
+  ASSERT_TRUE(c.has_next());
+  c.next();
+  ASSERT_EQ(7u, c.get_epoch());
+  ASSERT_TRUE(c.has_next());
+  c.next();
+  ASSERT_EQ(8u, c.get_epoch());
+  ASSERT_TRUE(c.has_next());
+  c.next();
+  ASSERT_EQ(9u, c.get_epoch());
+  ASSERT_FALSE(c.has_next());
+}
+
+int main(int argc, char** argv)
+{
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The first few patches implement the realm epoch, which is a version number on RGWRealm that increments on each new period. Each RGWPeriod stores the realm_epoch when it was created, allowing us to determine whether a given period comes before/after another with a simple comparison.

The RGWPeriod realm_epoch is incremented by RGWPeriod::fork() on 'period update', and 'period commit' uses that to verify that the new period is based on the current period. If the master zone is unchanged (i.e. we don't generate a new period), RGWPeriod::commit() resets the period's realm_epoch back to the current period's. Otherwise, RGWRealm::set_current_period() will update the realm's epoch to match the new period.

The remaining patches add a RGWPeriodHistory class that tracks RGWPeriods in memory and provides a Cursor object to traverse forward and backwards, along with a RGWPeriodPuller class that RGWPeriodHistory uses to fill in the missing periods.

The handler for 'period push' (POST /admin/realm/period) calls RGWPeriodHistory::attach() to fill in any missing periods between current_period and the new period, then checks the Cursor to verify that it's the newest period in the history before switching to it.