### PR TITLE
os/bluestore: fix bluestore_wal_transaction_t encoding test

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -279,7 +279,7 @@ WRITE_CLASS_ENCODER(bluestore_wal_op_t)
 
 /// writeahead-logged transaction
 struct bluestore_wal_transaction_t {
-  uint64_t seq;
+  uint64_t seq = 0;
   list<bluestore_wal_op_t> ops;
   interval_set<uint64_t> released;  ///< allocations to release after wal
 


### PR DESCRIPTION
bluestore_wal_transaction_t::seq is encoded/dumped but it is not
initialized in its ctor. so set it to 0 in its ctor.

Signed-off-by: Kefu Chai <kchai@redhat.com>