### PR TITLE
cmake: Add ENABLE_GIT_VERSION to avoid rebuilding

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,8 +92,14 @@ endif(USE_NSS)
 
 set(GCOV_PREFIX_STRIP 4)
 
-get_git_head_revision(GIT_REFSPEC CEPH_GIT_VER)
-git_describe(CEPH_GIT_NICE_VER --always)
+option(ENABLE_GIT_VERSION "build Ceph with git version string" ON)
+if(${ENABLE_GIT_VERSION})
+  get_git_head_revision(GIT_REFSPEC CEPH_GIT_VER)
+  git_describe(CEPH_GIT_NICE_VER --always)
+else(${ENABLE_GIT_VERSION})
+  set(CEPH_GIT_VER "no_version")
+  set(CEPH_GIT_NICE_VER "Development")
+endif(${ENABLE_GIT_VERSION})
 
 # Python stuff
 find_package(PythonInterp 2 QUIET)


### PR DESCRIPTION
it is a pain to see something like
"expected plugin ./ec_plugins/libec_jerasure.so version
 v10.0.1-1239-g73c5763 but it claims to be v10.0.1-1241-gdb83f12
 instead" from time to time. so this is a cmake port of b227426 by @dmick .
the option ENABLE_GIT_VERSION is ON by default. if it is set OFF,
ceph_ver.h will not be recreated.

Signed-off-by: Kefu Chai <kchai@redhat.com>