### PR TITLE
hammer: osd/OSD.cc: 2469: FAILED assert(pg_stat_queue.empty()) on shutdown

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2289,6 +2289,7 @@ int OSD::shutdown()
       p->second->osr->flush();
     }
   }
+  clear_pg_stat_queue();
   
   // finish ops
   op_shardedwq.drain(); // should already be empty except for lagard PGs


### PR DESCRIPTION
http://tracker.ceph.com/issues/14285