### PR TITLE
use 4 decimal places for default weight

### DIFF
--- a/src/upstart/ceph-osd.conf
+++ b/src/upstart/ceph-osd.conf
@@ -24,7 +24,7 @@ pre-start script
 	fi
 	location="$($hook --cluster ${cluster:-ceph} --id $id --type osd)"
 	weight="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_initial_weight || :)"
-	defaultweight=`df -P -k /var/lib/ceph/osd/${cluster:-ceph}-$id/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }'`
+	defaultweight=`df -P -k /var/lib/ceph/osd/${cluster:-ceph}-$id/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.4f", d); print r }'`
 	ceph \
             --cluster="${cluster:-ceph}" \
             --name="osd.$id" \


### PR DESCRIPTION
using 2 places means that when deploying a test cluster on tiny OSDs does not work

Signed-off-by: Chris MacNaughton <chris.macnaughton@canonical.com>