### PR TITLE
Handle cluster names with non-alphanumeric chars in upstart.

### DIFF
--- a/src/upstart/ceph-mds-all-starter.conf
+++ b/src/upstart/ceph-mds-all-starter.conf
@@ -6,13 +6,20 @@ task
 
 script
   set -e
-  # TODO what's the valid charset for cluster names and mds ids?
-  find -L /var/lib/ceph/mds/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
+
+  confdir="/etc/ceph"
+  vardir="/var/lib/ceph/mds"
+
+  # find all cluster names
+  find $confdir -mindepth 1 -maxdepth 1 -type f -name '*.conf' -printf '%P\n' \
   | while read f; do
-    if [ -e "/var/lib/ceph/mds/$f/done" ] && [ -e "/var/lib/ceph/mds/$f/upstart" ] && [ ! -e "/var/lib/ceph/mds/$f/sysvinit" ]; then
-        cluster="${f%%-*}"
-        id="${f#*-}"
-        initctl emit ceph-mds cluster="$cluster" id="$id"
-    fi
+    cluster=${f%%.conf}
+    find -L $vardir -mindepth 1 -maxdepth 1 -type d -name "$cluster-*" -printf '%P\n' \
+    | while read d; do
+      if [ -e "$vardir/$d/done" ] && [ -e "$vardir/$d/upstart" ] && [ ! -e "$vardir/$d/sysvinit" ]; then
+          id=${d:$(( ${#cluster} + 1 ))}
+          initctl emit ceph-mon cluster="$cluster" id="$id"
+      fi
+    done
   done
 end script

--- a/src/upstart/ceph-mon-all-starter.conf
+++ b/src/upstart/ceph-mon-all-starter.conf
@@ -6,14 +6,20 @@ task
 
 script
   set -e
-  # TODO what's the valid charset for cluster names and mon ids?
-  find -L /var/lib/ceph/mon/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
-  | while read f; do
-    if [ -e "/var/lib/ceph/mon/$f/done" ] && [ -e "/var/lib/ceph/mon/$f/upstart" ] && [ ! -e "/var/lib/ceph/mon/$f/sysvinit" ]; then
-        cluster="${f%%-*}"
-        id="${f#*-}"
 
-	initctl emit ceph-mon cluster="$cluster" id="$id"
-    fi
+  confdir="/etc/ceph"
+  vardir="/var/lib/ceph/mon"
+
+  # find all cluster names
+  find $confdir -mindepth 1 -maxdepth 1 -type f -name '*.conf' -printf '%P\n' \
+  | while read f; do
+    cluster=${f%%.conf}
+    find -L $vardir -mindepth 1 -maxdepth 1 -type d -name "$cluster-*" -printf '%P\n' \
+    | while read d; do
+      if [ -e "$vardir/$d/done" ] && [ -e "$vardir/$d/upstart" ] && [ ! -e "$vardir/$d/sysvinit" ]; then
+          id=${d:$(( ${#cluster} + 1 ))}
+          initctl emit ceph-mon cluster="$cluster" id="$id"
+      fi
+    done
   done
 end script

--- a/src/upstart/ceph-osd-all-starter.conf
+++ b/src/upstart/ceph-osd-all-starter.conf
@@ -10,13 +10,19 @@ script
   # first activate any partitions
   ceph-disk activate-all
 
-  # TODO what's the valid charset for cluster names and osd ids?
-  find -L /var/lib/ceph/osd/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
+  confdir="/etc/ceph"
+  vardir="/var/lib/ceph/osd"
+
+  # find all cluster names
+  find $confdir -mindepth 1 -maxdepth 1 -type f -name '*.conf' -printf '%P\n' \
   | while read f; do
-    if [ -e "/var/lib/ceph/osd/$f/ready" ] && [ -e "/var/lib/ceph/osd/$f/upstart" ] && [ ! -e "/var/lib/ceph/osd/$f/sysvinit" ]; then
-        cluster="${f%%-*}"
-        id="${f#*-}"
-	initctl emit ceph-osd cluster="$cluster" id="$id"
-    fi
+    cluster=${f%%.conf}
+    find -L $vardir -mindepth 1 -maxdepth 1 -type d -name "$cluster-*" -printf '%P\n' \
+    | while read d; do
+      if [ -e "$vardir/$d/ready" ] && [ -e "$vardir/$d/upstart" ] && [ ! -e "$vardir/$d/sysvinit" ]; then
+          id=${d:$(( ${#cluster} + 1 ))}
+          initctl emit ceph-osd cluster="$cluster" id="$id"
+      fi
+    done
   done
 end script

--- a/src/upstart/radosgw-all-starter.conf
+++ b/src/upstart/radosgw-all-starter.conf
@@ -6,13 +6,20 @@ task
 
 script
   set -e
-  # TODO what's the valid charset for cluster names and daemon ids?
-  find -L /var/lib/ceph/radosgw/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -printf '%P\n' \
+
+  confdir="/etc/ceph"
+  vardir="/var/lib/ceph/radosgw"
+
+  # find all cluster names
+  find $confdir -mindepth 1 -maxdepth 1 -type f -name '*.conf' -printf '%P\n' \
   | while read f; do
-    if [ -e "/var/lib/ceph/radosgw/$f/done" ]; then
-        cluster="${f%%-*}"
-        id="${f#*-}"
-        initctl emit radosgw cluster="$cluster" id="$id"
-    fi
+    cluster=${f%%.conf}
+    find -L $vardir -mindepth 1 -maxdepth 1 -type d -name "$cluster-*" -printf '%P\n' \
+    | while read d; do
+      if [ -e "$vardir/$d/done" ]; then
+          id=${d:$(( ${#cluster} + 1 ))}
+          initctl emit radosgw cluster="$cluster" id="$id"
+      fi
+    done
   done
 end script


### PR DESCRIPTION
Changes scripts to look for cluster names based on the /etc/ceph/*.conf
files, then based on directories named as
/var/lib/ceph/[daemon type]/[cluster]-[id]/

Signed-off-by: Emile Snyder emile.snyder@gmail.com
