### PR TITLE
osd/osd_types.h: use optimized is_zero in object_stat_sum_t.is_zero()

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -30,26 +30,6 @@
 #include <sys/mount.h>
 #endif
 
-// test if an entire buf is zero in 8-byte chunks
-bool buf_is_zero(const char *buf, size_t len)
-{
-  size_t ofs;
-  int chunk = sizeof(uint64_t);
-
-  for (ofs = 0; ofs < len; ofs += sizeof(uint64_t)) {
-    if (*(uint64_t *)(buf + ofs) != 0) {
-      return false;
-    }
-  }
-  for (ofs = (len / chunk) * chunk; ofs < len; ofs++) {
-    if (buf[ofs] != '\0') {
-      return false;
-    }
-  }
-  return true;
-}
-
-
 int64_t unit_to_bytesize(string val, ostream *pss)
 {
   if (val.empty()) {

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -14,12 +14,8 @@
 #ifndef CEPH_UTIL_H
 #define CEPH_UTIL_H
 
-// is buf~len completely zero (in 8-byte chunks)
-
 #include "common/Formatter.h"
 #include "include/types.h"
-
-bool buf_is_zero(const char *buf, size_t len);
 
 int64_t unit_to_bytesize(string val, ostream *pss);
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -33,6 +33,7 @@
 #include "include/CompatSet.h"
 #include "common/histogram.h"
 #include "include/interval_set.h"
+#include "include/inline_memory.h"
 #include "common/Formatter.h"
 #include "common/bloom_filter.hpp"
 #include "common/hobject.h"
@@ -1624,8 +1625,7 @@ struct object_stat_sum_t {
   }
 
   bool is_zero() const {
-    object_stat_sum_t zero;
-    return memcmp(this, &zero, sizeof(zero)) == 0;
+    return mem_is_zero((char*)this, sizeof(*this));
   }
 
   void add(const object_stat_sum_t& o);


### PR DESCRIPTION
We already have a fast implementation of is_zero(memory), we should use
it instead of using memcmp with temp struct on stack. This change reduces
object_stat_sum_t.is_zero() CPU usage by 35-50%.
Remove unused buf_is_zero() while we're at it.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>
