### PR TITLE
ceph.in:avoid a broken pipe error when use ceph command

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -917,10 +917,14 @@ def main():
             if suffix != '':
                 outbuf = outbuf.rstrip()
             if outbuf != '':
-                # Write directly to binary stdout
-                raw_stdout.write(prefix)
-                raw_stdout.write(outbuf)
-                raw_stdout.write(suffix)
+                try:
+                    # Write directly to binary stdout
+                    raw_stdout.write(prefix)
+                    raw_stdout.write(outbuf)
+                    raw_stdout.write(suffix)
+                except IOError as e:
+                    if e.errno != errno.EPIPE:
+                        raise e
 
         sys.stdout.flush()
 


### PR DESCRIPTION
when use command like 'ceph report | less' and press q, the following error occurs:
Traceback (most recent call last):
File "./ceph", line 936, in <module>
retval = main()
File "./ceph", line 922, in main
raw_stdout.write(outbuf)
IOError: [Errno 32] Broken pipe

http://tracker.ceph.com/issues/14354

Signed-off-by: Bo Cai <cai.bo@h3c.com>