### PR TITLE
ReplicatedBackend : only CEPH_OSD_FLAG_ACK, erase from waiting_for_applied

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -715,13 +715,13 @@ void ReplicatedBackend::sub_op_modify_reply(OpRequestRef op)
       }
     } else {
       assert(ip_op.waiting_for_applied.count(from));
+      ip_op.waiting_for_applied.erase(from);
       if (ip_op.op) {
         ostringstream ss;
         ss << "sub_op_applied_rec from " << from;
 	ip_op.op->mark_event(ss.str());
       }
     }
-    ip_op.waiting_for_applied.erase(from);
 
     parent->update_peer_last_complete_ondisk(
       from,


### PR DESCRIPTION
ip_op.waiting_for_applied.erase(from); out of if/else is really confused,
actually this should happen only when ack from peer.
Signed-off-by: Xiaowei Chen <chen.xiaowei@h3c.com>