### PR TITLE
mds: advance clientreplay when replying

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1236,6 +1236,19 @@ void MDSRank::clientreplay_start()
   queue_one_replay();
 }
 
+bool MDSRank::queue_one_replay()
+{
+  if (replay_queue.empty()) {
+    if (mdcache->get_num_client_requests() == 0) {
+      clientreplay_done();
+    }
+    return false;
+  }
+  queue_waiter(replay_queue.front());
+  replay_queue.pop_front();
+  return true;
+}
+
 void MDSRank::clientreplay_done()
 {
   dout(1) << "clientreplay_done" << dendl;

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -347,13 +347,7 @@ class MDSRank {
       replay_queue.push_back(c);
     }
 
-    bool queue_one_replay() {
-      if (replay_queue.empty())
-        return false;
-      queue_waiter(replay_queue.front());
-      replay_queue.pop_front();
-      return true;
-    }
+    bool queue_one_replay();
 
     void set_osd_epoch_barrier(epoch_t e);
     epoch_t get_osd_epoch_barrier() const {return osd_epoch_barrier;}

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1165,8 +1165,7 @@ void Server::reply_client_request(MDRequestRef& mdr, MClientReply *reply)
     client_con->send_message(reply);
   }
 
-  if (mdr->has_completed && mds->is_clientreplay())
-    mds->queue_one_replay();
+  const bool completed = mdr->has_completed;
 
   // clean up request
   mdcache->request_finish(mdr);
@@ -1176,6 +1175,11 @@ void Server::reply_client_request(MDRequestRef& mdr, MClientReply *reply)
       tracedn &&
       tracedn->get_projected_linkage()->is_remote()) {
     mdcache->eval_remote(tracedn);
+  }
+
+  // Advance clientreplay process if we're in it
+  if (completed && mds->is_clientreplay()) {
+    mds->queue_one_replay();
   }
 }
 


### PR DESCRIPTION
...not just at the end of _dispatch.  Often we reply
to clients (i.e. complete a request) outside of
_dispatch, and currently in these cases we fail
to check for clientreplay completion (only hitting
that next time someone talks to _dispatch)

Fixes: #14357
Signed-off-by: John Spray <john.spray@redhat.com>