### PR TITLE
add -f flag for btrfs mkfs

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -134,6 +134,8 @@ MOUNT_OPTIONS = dict(
 
 MKFS_ARGS = dict(
     btrfs=[
+        # btrfs requires -f, for the same reason as xfs (see comment below)
+        '-f',
         '-m', 'single',
         '-l', '32768',
         '-n', '32768',


### PR DESCRIPTION
The -f flag is needed for btrfs mkfs in ceph-disk. Without -f, mkfs refuses to overwrite existing btrfs partitions. This causes ceph-disk to fail when remains of previous btrfs partitions exist on the disk. The -f flag was already added to xfs for exactly the same reason.