### PR TITLE
ceph-fuse: double decreased the count to trim caps

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3778,11 +3778,13 @@ void Client::_invalidate_kernel_dcache()
 void Client::trim_caps(MetaSession *s, int max)
 {
   mds_rank_t mds = s->mds_num;
-  ldout(cct, 10) << "trim_caps mds." << mds << " max " << max << dendl;
+  int caps_size = s->caps.size();
+  ldout(cct, 10) << "trim_caps mds." << mds << " max " << max 
+    << " caps " << caps_size << dendl;
 
   int trimmed = 0;
   xlist<Cap*>::iterator p = s->caps.begin();
-  while ((s->caps.size() - trimmed) > max && !p.end()) {
+  while ((caps_size - trimmed) > max && !p.end()) {
     Cap *cap = *p;
     s->s_cap_iterator = cap;
     Inode *in = cap->inode;


### PR DESCRIPTION
Ceph-fuse will recalculate current caps size for each loop, so it double decreases the loop counts. Hence at most time, ceph-fuse client only trims half of expected caps number. MDS often reports the warning of failing to respond to cache pressure.

Both master and hammer branch have this issue and this fix has been tested locally on both branches, so it can be backported to hammer.

Fixes: #14319

Signed-off-by: Zhi Zhang zhangz.david@outlook.com