### PR TITLE
configure.ac: check for libedit when client is enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -719,7 +719,7 @@ fi
 #
 # FreeBSD has it in base.
 #
-if test x"$freebsd" != x"yes" -a x"$with_radosgw" = x"yes"; then
+if test x"$freebsd" != x"yes" -a x"$enable_client" = x"yes"; then
 PKG_CHECK_MODULES([LIBEDIT], [libedit >= 2.11],
                 [], AC_MSG_FAILURE([No usable version of libedit found.]))
 else


### PR DESCRIPTION
In src/client/Makefile.am, libclient.la depends on -ledit. However, configure
only checks for libedit when radosgw is enabled. Linking can fail during
the build when libedit is missing:

    CXXLD    libcephfs.la
    /usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../x86_64-slackware-linux/bin/ld:
    cannot find -ledit
    collect2: error: ld returned 1 exit status
    Makefile:10567: recipe for target 'libcephfs.la' failed

Simply check for libedit whenever --enable-client is there.