### PR TITLE
ceph-detect-init: fix py3 test

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
@@ -8,6 +8,7 @@ def choose_init():
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
+    assert(distro and codename)
     if distro.lower() in ('ubuntu', 'linuxmint'):
         if codename >= 'vivid':
             return 'systemd'

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -44,15 +44,18 @@ class TestCephDetectInit(testtools.TestCase):
         self.assertEqual('sysvinit', centos.choose_init())
 
     def test_debian(self):
-        with mock.patch('ceph_detect_init.debian.distro',
-                        'debian'):
+        with mock.patch.multiple('ceph_detect_init.debian',
+                                 distro='debian',
+                                 codename='wheezy'):
             self.assertEqual('sysvinit', debian.choose_init())
-        with mock.patch('ceph_detect_init.debian.distro',
-                        'ubuntu'):
+        with mock.patch.multiple('ceph_detect_init.debian',
+                                 distro='ubuntu',
+                                 codename='trusty'):
             self.assertEqual('upstart', debian.choose_init())
-            with mock.patch('ceph_detect_init.debian.codename',
-                            'vivid'):
-                self.assertEqual('systemd', debian.choose_init())
+        with mock.patch.multiple('ceph_detect_init.debian',
+                                 distro='ubuntu',
+                                 codename='vivid'):
+            self.assertEqual('systemd', debian.choose_init())
 
     def test_fedora(self):
         with mock.patch('ceph_detect_init.fedora.release',


### PR DESCRIPTION
* in python3, None can not be compared with a str. and
  we should always set codename with a non empty str, so update
  TestCephDetectInit.test_debian so it always set a code name.
  and assert(codename and distroname) in choose_init().

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 80c770e1151464000a963113147e5e42ec0aa224)

it fixes the test failure spotted at http://gitbuilder.sepia.ceph.com/gitbuilder-ceph-tarball-trusty-amd64-basic/log.cgi?log=2697b302bd5e28f172c6d87966a48c77665cde53

```
tests/test_all.py::TestCephDetectInit::test_debian FAILED
...
testtools.testresult.real._StringException: Traceback (most recent call last):
File "/srv/autobuild-ceph/gitbuilder.git/build/src/ceph-detect-init/tests/test_all.py", line 52, in test_debian
self.assertEqual('upstart', debian.choose_init())
File "/srv/autobuild-ceph/gitbuilder.git/build/src/ceph-detect-init/ceph_detect_init/debian/__init__.py", line 12, in choose_init
if codename >= 'vivid':
Error: Type unorderable types: NoneType() >= str()
====================== 1 failed, 9 passed in 0.49 seconds ======================
ERROR: InvocationError: '/srv/autobuild-ceph/gitbuilder.git/build/src/ceph-detect-init/.tox/py3/bin/coverage run --source=ceph_detect_init /srv/autobuild-ceph/gitbuilder.git/build/src/ceph-detect-init/.tox/py3/bin/py.test -v tests'
___________________________________ summary ____________________________________
pep8: commands succeeded
py27: commands succeeded
ERROR: py3: commands failed

```