### PR TITLE
mon: add an independent option for max election time

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -7,3 +7,7 @@ v10.0.0
 
 * The 'send_pg_creates' and 'map_pg_creates' mon CLI commands are
   obsolete and no longer supported.
+
+* A new configure option 'mon_election_timeout' is added to specifically
+  limit max waiting time of monitor election process, which was previously
+  restricted by 'mon_lease'.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -225,6 +225,7 @@ OPTION(mon_osd_prime_pg_temp, OPT_BOOL, false)  // prime osdmap with pg mapping 
 OPTION(mon_osd_prime_pg_temp_max_time, OPT_FLOAT, .5)  // max time to spend priming
 OPTION(mon_osd_pool_ec_fast_read, OPT_BOOL, false) // whether turn on fast read on the pool or not
 OPTION(mon_stat_smooth_intervals, OPT_INT, 2)  // smooth stats over last N PGMap maps
+OPTION(mon_election_timeout, OPT_FLOAT, 5)  // on election proposer, max waiting time for all ACKs
 OPTION(mon_lease, OPT_FLOAT, 5)       // lease interval
 OPTION(mon_lease_renew_interval_factor, OPT_FLOAT, .6) // on leader, to renew the lease
 OPTION(mon_lease_ack_timeout_factor, OPT_FLOAT, 2.0) // on leader, if lease isn't acked by all peons

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -130,7 +130,7 @@ void Elector::reset_timer(double plus)
   // set the timer
   cancel_timer();
   expire_event = new C_ElectionExpire(this);
-  mon->timer.add_event_after(g_conf->mon_lease + plus,
+  mon->timer.add_event_after(g_conf->mon_election_timeout + plus,
 			     expire_event);
 }
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -451,6 +451,7 @@ const char** Monitor::get_tracked_conf_keys() const
 {
   static const char* KEYS[] = {
     "crushtool", // helpful for testing
+    "mon_election_timeout",
     "mon_lease",
     "mon_lease_renew_interval_factor",
     "mon_lease_ack_timeout_factor",


### PR DESCRIPTION
add a new configure option mon_election_timeout, which is not dependent on mon_lease

Signed-off-by: Sangdi Xu <xu.sangdi@h3c.com>