### PR TITLE
mds: Variable 'mds' is assigned a value that is never used.

### DIFF
--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -301,8 +301,6 @@ EMetaBlob::EMetaBlob(MDLog *mdlog) : opened_ino(0), renamed_dirino(0),
 
 void EMetaBlob::add_dir_context(CDir *dir, int mode)
 {
-  MDSRank *mds = dir->cache->mds;
-
   list<CDentry*> parents;
 
   // it may be okay not to include the maybe items, if


### PR DESCRIPTION
Signed-off-by: Wei Feng <feng.wei@h3c.com>