### PR TITLE
osd: disable filestore_xfs_extsize by default

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -979,7 +979,10 @@ OPTION(filestore_collect_device_partition_information, OPT_BOOL, true)
 // data corruption in xfs prior to kernel 3.5.  filestore will
 // implicity disable this if it cannot confirm the kernel is newer
 // than that.
-OPTION(filestore_xfs_extsize, OPT_BOOL, true)
+// NOTE: This option involves a tradeoff: When disabled, fragmentation is
+// worse, but large sequential writes are faster. When enabled, large
+// sequential writes are slower, but fragmentation is reduced.
+OPTION(filestore_xfs_extsize, OPT_BOOL, false)
 
 OPTION(filestore_journal_parallel, OPT_BOOL, false)
 OPTION(filestore_journal_writeahead, OPT_BOOL, false)


### PR DESCRIPTION
This option involves a tradeoff: When disabled, fragmentation is worse, but large sequential writes are faster. When enabled, large sequential writes are slower, but fragmentation is reduced.

The reason for setting it off by default is to make performance comparable to that in Firefly and not introduce a perceived large sequential write perf regression.

Fixes: #14397 http://tracker.ceph.com/issues/14397

CC @markhpc @liewegas @idryomov