### PR TITLE
Snappy decompressor may assert when handling segmented input bufferlist

### DIFF
--- a/src/compressor/Compressor.h
+++ b/src/compressor/Compressor.h
@@ -25,8 +25,8 @@ typedef shared_ptr<Compressor> CompressorRef;
 class Compressor {
  public:
   virtual ~Compressor() {}
-  virtual int compress(bufferlist &in, bufferlist &out) = 0;
-  virtual int decompress(bufferlist &in, bufferlist &out) = 0;
+  virtual int compress(const bufferlist &in, bufferlist &out) = 0;
+  virtual int decompress(const bufferlist &in, bufferlist &out) = 0;
 
   static CompressorRef create(CephContext *cct, const string &type);
 };

--- a/src/test/compressor/compressor_example.h
+++ b/src/test/compressor/compressor_example.h
@@ -31,13 +31,13 @@ class CompressorExample : public Compressor {
 public:
   virtual ~CompressorExample() {}
 
-  virtual int compress(bufferlist &in, bufferlist &out)
+  virtual int compress(const bufferlist &in, bufferlist &out)
   {
     out = in;
     return 0;
   }
 
-  virtual int decompress(bufferlist &in, bufferlist &out)
+  virtual int decompress(const bufferlist &in, bufferlist &out)
   {
     out = in;
     return 0;

--- a/src/test/compressor/test_compression_snappy.cc
+++ b/src/test/compressor/test_compression_snappy.cc
@@ -27,7 +27,7 @@ TEST(SnappyCompressor, compress_decompress)
 {
   SnappyCompressor sp;
   EXPECT_EQ(sp.get_method_name(), "snappy");
-  char* test = "This is test text";
+  const char* test = "This is test text";
   int len = strlen(test);
   bufferlist in, out;
   in.append(test, len);
@@ -35,6 +35,38 @@ TEST(SnappyCompressor, compress_decompress)
   EXPECT_EQ(res, 0);
   bufferlist after;
   res = sp.decompress(out, after);
+  EXPECT_EQ(res, 0);
+}
+
+TEST(SnappyCompressor, sharded_input_decompress)
+{
+  const size_t small_prefix_size=3;
+
+  SnappyCompressor sp;
+  EXPECT_EQ(sp.get_method_name(), "snappy");
+  string test(128*1024,0);
+  int len = test.size();
+  bufferlist in, out;
+  in.append(test.c_str(), len);
+  int res = sp.compress(in, out);
+  EXPECT_EQ(res, 0);
+  EXPECT_GT(out.length(), small_prefix_size);
+  
+  bufferlist out2, tmp;
+  tmp.substr_of(out, 0, small_prefix_size );
+  out2.append( tmp );
+  size_t left = out.length()-small_prefix_size;
+  size_t offs = small_prefix_size;
+  while( left > 0 ){
+    size_t shard_size = MIN( 2048, left ); 
+    tmp.substr_of(out, offs, shard_size );
+    out2.append( tmp );
+    left -= shard_size;
+    offs += shard_size;
+  }
+
+  bufferlist after;
+  res = sp.decompress(out2, after);
   EXPECT_EQ(res, 0);
 }
 


### PR DESCRIPTION
Fixes #14400
Additionally Introduces some compressor interface refactoring to avoid input buffer modification in future and eliminate similar issues.

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>