### PR TITLE
cmake: add missing check for HAVE_EXECINFO_H

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ CHECK_INCLUDE_FILES("fcgios.h" FASTCGI_FASTCGIOS_DIR)
 CHECK_INCLUDE_FILES("fcgi_stdio.h" HAVE_FASTCGI_STDIO_H)
 CHECK_INCLUDE_FILES("openssl/ssl.h" HAVE_SSL_H)
 CHECK_INCLUDE_FILES("keyutils.h" HAVE_KEYUTILS_H)
+CHECK_INCLUDE_FILES("execinfo.h" HAVE_EXECINFO_H)
 
 include(CheckSymbolExists)
 CHECK_SYMBOL_EXISTS(__u8 "sys/types.h;linux/types.h" HAVE___U8)

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -273,4 +273,7 @@
 /* Defined if curl headers define curl_multi_wait() */
 #cmakedefine HAVE_CURL_MULTI_WAIT 1
 
+/* Define to 1 if you have the <execinfo.h> header file. */
+#cmakedefine HAVE_EXECINFO_H 1
+
 #endif /* CONFIG_H */


### PR DESCRIPTION
cmake builds were failing to include stack traces in logs due to missing HAVE_EXECINFO_H