### PR TITLE
mon/MonClient: avoid null pointer error when configured incorrectly

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -117,6 +117,9 @@ int MonClient::get_monmap_privately()
   Messenger* smessenger = NULL;
   if (!messenger) {
     messenger = smessenger = Messenger::create_client_messenger(cct, "temp_mon_client");
+    if (NULL == messenger) {
+        return -1;
+    }
     messenger->add_dispatcher_head(this);
     smessenger->start();
     temp_msgr = true;


### PR DESCRIPTION
http://tracker.ceph.com/issues/14405

fix: #14405
Signed-off-by: Bo Cai <cai.bo@h3c.com>