### PR TITLE
rgw: Parse --subuser better

### DIFF
--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -267,9 +267,8 @@ struct RGWUserAdminOpState {
       return;
 
     size_t pos = _subuser.find(":");
-
     if (pos != string::npos) {
-      user_id.id = _subuser.substr(0, pos);
+      user_id.from_str(_subuser.substr(0, pos));
       subuser = _subuser.substr(pos+1);
     } else {
       subuser = _subuser;


### PR DESCRIPTION
Woops. I meant to allow a conflict-less setting of user alongside
the --tenant option. However, since we allow --subuser="user:subuser",
it makes sense to allow --subuser="tenant$user:subuser" too. Even if
we don't we ought to guard against it, least the separator leaks into
the user name and triggers exceedingly strange error messages.

Signed-off-by: Pete Zaitcev <zaitcev@redhat.com>