### PR TITLE
Add error check for object_map->sync()

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3692,8 +3692,13 @@ void FileStore::sync_entry()
 	apply_manager.commit_started();
 	op_tp.unpause();
 
-	object_map->sync();
-	int err = backend->syncfs();
+	int err = object_map->sync();
+	if (err < 0) {
+	  derr << "object_map sync got " << cpp_strerror(err) << dendl;
+	  assert(0 == "object_map sync returned error");
+	}
+
+	err = backend->syncfs();
 	if (err < 0) {
 	  derr << "syncfs got " << cpp_strerror(err) << dendl;
 	  assert(0 == "syncfs returned error");


### PR DESCRIPTION
There lacks error check after doing object_map->sync under
sync_entry, which is OK when omap deployed in the same device
with object data, but it is better to add error check in case
object_map->sync failed.

Signed-off-by: Chendi Xue <chendi.xue@intel.com>