### PR TITLE
Increase verbosity level on RGWObjManifest line

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -636,7 +636,7 @@ void RGWObjManifest::obj_iterator::operator++()
     stripe_size = 0;
   }
 
-  dout(0) << "RGWObjManifest::operator++(): result: ofs=" << ofs << " stripe_ofs=" << stripe_ofs << " part_ofs=" << part_ofs << " rule->part_size=" << rule->part_size << dendl;
+  dout(20) << "RGWObjManifest::operator++(): result: ofs=" << ofs << " stripe_ofs=" << stripe_ofs << " part_ofs=" << part_ofs << " rule->part_size=" << rule->part_size << dendl;
   update_location();
 }
 


### PR DESCRIPTION
My RadosGW log is filling with lines starting with `RGWObjManifest::operator++() result:` with debug at 0. I believe this line should be at debug level 20 like the others just before it. 

Signed-off-by: Aaron Bassett magicrobotmonkey@gmail.com