### PR TITLE
init-ceph.in: skip ceph-disk if it is not present

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -533,7 +533,9 @@ done
 # activate latent osds?
 if [ "$command" = "start" -a "$BINDIR" != "." ]; then
     if [ "$*" = "" ] || echo $* | grep -q ^osd\$ ; then
-	ceph-disk activate-all
+       if [ -x $SBINDIR/ceph-disk ]; then
+           ceph-disk activate-all
+       fi
     fi
 fi
 


### PR DESCRIPTION
With the ceph-mon vs ceph-osd split packaging, users are expected to have the ceph-mon package installed and not ceph-osd (and vice versa).  However, the init script (`/etc/init.d/ceph`) has a call to `ceph-disk`, which may not be present on the machine.

Given that our packaging is not yet split upstream, this bug does not manifest itself currently, because both ceph-mon and ceph-disk are currently in the same "ceph" package. Once we split the packaging, though, this will become an issue.

(This relates to http://tracker.ceph.com/issues/10587 , although it does not implement any actual split in the packaging.)