### PR TITLE
vstart.sh: If use '-n' delete related source rather than consider '-k'.

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -593,11 +593,11 @@ if [ "$start_osd" -eq 1 ]; then
 [osd.$osd]
         host = $HOSTNAME
 EOF
-		    rm -rf $CEPH_DEV_DIR/osd$osd || true
-		    for f in $CEPH_DEV_DIR/osd$osd/* ; do btrfs sub delete $f || true ; done || true
-		    mkdir -p $CEPH_DEV_DIR/osd$osd
-
 	    fi
+
+	    rm -rf $CEPH_DEV_DIR/osd$osd || true
+	    for f in $CEPH_DEV_DIR/osd$osd/* ; do btrfs sub delete $f || true ; done || true
+	    mkdir -p $CEPH_DEV_DIR/osd$osd
 
 	    uuid=`uuidgen`
 	    echo "add osd$osd $uuid"


### PR DESCRIPTION
Exec './vstart.sh -k -n' will meet error. The messages:
2016-01-20 19:55:22.998169 7f8acea1c8c0 -1 bluestore(/mnt/ceph/src/dev/osd0) mkfs on-disk fsid
b4db5bc2-e333-4ad7-aab9-9ffc7e79c70d != provided d6ba1d96-b2d4-408e-a901-05db1cfd06f5
2016-01-20 19:55:22.998189 7f8acea1c8c0 -1 OSD::mkfs: ObjectStore::mkfs failed with error -22
2016-01-20 19:55:22.998241 7f8acea1c8c0 -1  ** ERROR: error creating empty object store in /mnt/ceph/src/dev/osd0: (22) Invalid argument

This is because vstart.sh don't remove the existing dir.
It only remove dir for command w/ '-n' and w/o '-k'.

But '-n' is mean create new cluster. So don't '-k', only '-n' it should
remove dirs.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>