### PR TITLE
rgw: multiple improvements for Swift API's account-related operations

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1187,6 +1187,7 @@ OPTION(rgw_keystone_admin_user, OPT_STR, "")  // keystone admin user name
 OPTION(rgw_keystone_admin_password, OPT_STR, "")  // keystone admin user password
 OPTION(rgw_keystone_admin_tenant, OPT_STR, "")  // keystone admin user tenant
 OPTION(rgw_keystone_accepted_roles, OPT_STR, "Member, admin")  // roles required to serve requests
+OPTION(rgw_keystone_accepted_admin_roles, OPT_STR, "") // list of roles allowing an user to gain admin privileges
 OPTION(rgw_keystone_token_cache_size, OPT_INT, 10000)  // max number of entries in keystone token cache
 OPTION(rgw_keystone_revocation_interval, OPT_INT, 15 * 60)  // seconds between tokens revocation check
 OPTION(rgw_s3_auth_use_rados, OPT_BOOL, true)  // should we try to use the internal credentials for s3?

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1179,6 +1179,7 @@ OPTION(rgw_swift_url_prefix, OPT_STR, "swift") // entry point for which a url is
 OPTION(rgw_swift_auth_url, OPT_STR, "")        // default URL to go and verify tokens for v1 auth (if not using internal swift auth)
 OPTION(rgw_swift_auth_entry, OPT_STR, "auth")  // entry point for which a url is considered a swift auth url
 OPTION(rgw_swift_tenant_name, OPT_STR, "")  // tenant name to use for swift access
+OPTION(rgw_swift_account_in_url, OPT_BOOL, false)  // assume that URL always contain the account (aka tenant) part
 OPTION(rgw_swift_enforce_content_length, OPT_BOOL, false)  // enforce generation of Content-Length even in cost of performance or scalability
 OPTION(rgw_keystone_url, OPT_STR, "")  // url for keystone server
 OPTION(rgw_keystone_admin_token, OPT_STR, "")  // keystone admin token (shared secret)

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -709,7 +709,7 @@ bool verify_requester_payer_permission(struct req_state *s)
   if (!s->bucket_info.requester_pays)
     return true;
 
-  if (s->bucket_info.owner == s->user->user_id)
+  if (s->bucket_info.owner == s->auth_user)
     return true;
 
   const char *request_payer = s->info.env->get("HTTP_X_AMZ_REQUEST_PAYER");
@@ -741,7 +741,7 @@ bool verify_bucket_permission(struct req_state * const s,
   if (!verify_requester_payer_permission(s))
     return false;
 
-  return bucket_acl->verify_permission(s->user->user_id, perm, perm);
+  return bucket_acl->verify_permission(s->auth_user, perm, perm);
 }
 
 bool verify_bucket_permission(struct req_state * const s, const int perm)
@@ -771,13 +771,14 @@ bool verify_object_permission(struct req_state * const s,
     return true;
   }
 
-  if (!object_acl)
+  if (!object_acl) {
     return false;
+  }
 
-  bool ret = object_acl->verify_permission(s->user->user_id, s->perm_mask,
-					  perm);
-  if (ret)
+  bool ret = object_acl->verify_permission(s->auth_user, s->perm_mask, perm);
+  if (ret) {
     return true;
+  }
 
   if (!s->cct->_conf->rgw_enforce_swift_acls)
     return ret;
@@ -795,8 +796,7 @@ bool verify_object_permission(struct req_state * const s,
     return false;
   /* we already verified the user mask above, so we pass swift_perm as the mask here,
      otherwise the mask might not cover the swift permissions bits */
-  return bucket_acl->verify_permission(s->user->user_id, swift_perm,
-				      swift_perm);
+  return bucket_acl->verify_permission(s->auth_user, swift_perm, swift_perm);
 }
 
 bool verify_object_permission(struct req_state *s, int perm)

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1131,6 +1131,12 @@ struct req_state {
 
   bool has_bad_meta;
 
+  /* Identity used to authorize given RGWOp (used in verify_permission()
+   * method). It might be different than owner of the account (represented
+   * in radosgw by RGWUserInfo structure) we are operating on. */
+  rgw_user auth_user;
+
+  /* Account we are performing operations on. */
   RGWUserInfo *user;
 
   RGWAccessControlPolicy *bucket_acl;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1107,6 +1107,8 @@ struct req_state {
   utime_t header_time;
 
   /* Set once when url_bucket is parsed and not violated thereafter. */
+  string account_name;
+
   string bucket_tenant;
   string bucket_name;
 

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -14,9 +14,9 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-bool KeystoneToken::User::has_role(const string& r) {
-  list<Role>::iterator iter;
-  for (iter = roles.begin(); iter != roles.end(); ++iter) {
+bool KeystoneToken::User::has_role(const string& r) const {
+  list<Role>::const_iterator iter;
+  for (iter = roles.cbegin(); iter != roles.cend(); ++iter) {
       if (fnmatch(r.c_str(), ((*iter).name.c_str()), 0) == 0) {
         return true;
       }

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -63,7 +63,7 @@ public:
     string user_name;
     list<Role> roles;
     void decode_json(JSONObj *obj);
-    bool has_role(const string& r);
+    bool has_role(const string& r) const;
   };
 
   Metadata metadata;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1613,7 +1613,7 @@ int RGWGetBucketLocation::verify_permission()
 
 int RGWCreateBucket::verify_permission()
 {
-  if (!rgw_user_is_authenticated(*(s->user))) {
+  if (!rgw_user_is_authenticated(s->auth_user)) {
     return -EACCES;
   }
 
@@ -2508,7 +2508,7 @@ int RGWPutMetadataAccount::handle_temp_url_update(
 
 int RGWPutMetadataAccount::verify_permission()
 {
-  if (!rgw_user_is_authenticated(*(s->user))) {
+  if (!rgw_user_is_authenticated(s->auth_user)) {
     return -EACCES;
   }
   // if ((s->perm_mask & RGW_PERM_WRITE) == 0) {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1289,7 +1289,7 @@ int RGWHandler_REST_SWIFT::authorize()
   if ((!s->os_auth_token && s->info.args.get("temp_url_sig").empty()) ||
       (s->op == OP_OPTIONS)) {
     /* anonymous access */
-    rgw_get_anon_user(*(s->user), s->auth_user);
+    rgw_get_anon_user(*(s->user), s->auth_user, store, s->account_name);
     s->perm_mask = RGW_PERM_FULL_CONTROL;
     return 0;
   }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1459,9 +1459,28 @@ int RGWHandler_REST_SWIFT::init_from_header(struct req_state *s)
 
   next_tok(req, ver, '/');
 
-  string tenant;
-  if (!tenant_path.empty()) {
-    next_tok(req, tenant, '/');
+  if (!tenant_path.empty() || g_conf->rgw_swift_account_in_url) {
+    string account_name;
+    next_tok(req, account_name, '/');
+
+    /* Erase all pre-defined prefixes like "AUTH_" or "KEY_". */
+    list<string> skipped_prefixes;
+    get_str_list("AUTH_,KEY_", skipped_prefixes);
+
+    for (const auto pfx : skipped_prefixes) {
+      const size_t comp_len = min(account_name.length(), pfx.length());
+      if (account_name.compare(0, comp_len, pfx) == 0) {
+        /* Prefix is present. Drop it. */
+        account_name = account_name.substr(comp_len);
+        break;
+      }
+    }
+
+    if (account_name.empty()) {
+      return -ERR_PRECONDITION_FAILED;
+    } else {
+      s->account_name = account_name;
+    }
   }
 
   s->os_auth_token = s->info.env->get("HTTP_X_AUTH_TOKEN");

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1289,14 +1289,19 @@ int RGWHandler_REST_SWIFT::authorize()
   if ((!s->os_auth_token && s->info.args.get("temp_url_sig").empty()) ||
       (s->op == OP_OPTIONS)) {
     /* anonymous access */
-    rgw_get_anon_user(*(s->user));
+    rgw_get_anon_user(*(s->user), s->auth_user);
     s->perm_mask = RGW_PERM_FULL_CONTROL;
     return 0;
   }
 
-  bool authorized = rgw_swift->verify_swift_token(store, s);
-  if (!authorized)
+  const bool authorized = rgw_swift->verify_swift_token(store, s);
+  if (!authorized) {
     return -EPERM;
+  }
+
+  if (s->auth_user.empty()) {
+    s->auth_user = s->user->user_id;
+  }
 
   return 0;
 }

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -21,6 +21,7 @@
 #define dout_subsys ceph_subsys_rgw
 
 static list<string> roles_list;
+static list<string> admin_roles_list;
 
 class RGWValidateSwiftToken : public RGWHTTPClient {
   struct rgw_swift_auth_info *info;
@@ -383,25 +384,42 @@ int RGWSwift::check_revoked()
   return 0;
 }
 
-static void rgw_set_keystone_token_auth_info(KeystoneToken& token, struct rgw_swift_auth_info *info)
+static void rgw_set_keystone_token_auth_info(const KeystoneToken& token,
+                                             struct rgw_swift_auth_info * const info)
 {
   info->user = token.token.tenant.id;
   info->display_name = token.token.tenant.name;
   info->status = 200;
+
+  /* Check whether the user has an admin status. */
+  bool is_admin = false;
+  for (const auto admin_role : admin_roles_list) {
+    if (token.user.has_role(admin_role)) {
+      is_admin = true;
+      break;
+    }
+  }
+  info->is_admin = is_admin;
 }
 
-int RGWSwift::parse_keystone_token_response(const string& token, bufferlist& bl, struct rgw_swift_auth_info *info, KeystoneToken& t)
+int RGWSwift::parse_keystone_token_response(const string& token,
+                                            bufferlist& bl,
+                                            struct rgw_swift_auth_info * const info,
+                                            KeystoneToken& t)
 {
   int ret = t.parse(cct, bl);
-  if (ret < 0)
+  if (ret < 0) {
     return ret;
+  }
 
   bool found = false;
   list<string>::iterator iter;
   for (iter = roles_list.begin(); iter != roles_list.end(); ++iter) {
     const string& role = *iter;
-    if ((found=t.user.has_role(role))==true)
+    if (t.user.has_role(role) == true) {
+      found = true;
       break;
+    }
   }
 
   if (!found) {
@@ -723,9 +741,11 @@ bool RGWSwift::do_verify_swift_token(RGWRados *store, req_state *s)
       return false;
     }
 
-    if (!s->account_name.empty() && info.user.to_str() != s->account_name) {
+    if (!s->account_name.empty() && info.user.to_str() != s->account_name
+        && !info.is_admin) {
       /* Authentication succeeded but completely different account (tenant
-       * in Keystone terminology) has been requested. */
+       * in Keystone terminology) has been requested and the user is not
+       * a reseller admin. */
       return false;
     }
 
@@ -761,8 +781,14 @@ bool RGWSwift::do_verify_swift_token(RGWRados *store, req_state *s)
 void RGWSwift::init()
 {
   get_str_list(cct->_conf->rgw_keystone_accepted_roles, roles_list);
-  if (supports_keystone())
-      init_keystone();
+  get_str_list(cct->_conf->rgw_keystone_accepted_admin_roles, admin_roles_list);
+
+  roles_list.insert(roles_list.end(), admin_roles_list.begin(),
+          admin_roles_list.end());
+
+  if (supports_keystone()) {
+    init_keystone();
+  }
 }
 
 

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -416,10 +416,21 @@ int RGWSwift::parse_keystone_token_response(const string& token, bufferlist& bl,
   return 0;
 }
 
-int RGWSwift::update_user_info(RGWRados *store, struct rgw_swift_auth_info *info, RGWUserInfo& user_info)
+int RGWSwift::update_user_info(RGWRados *const store,
+                               const string& account_name,
+                               const struct rgw_swift_auth_info * const info,
+                               RGWUserInfo& user_info)
 {
-  if (rgw_get_user_info_by_uid(store, info->user, user_info) < 0) {
+  const rgw_user ui_owner = !account_name.empty() ? account_name : info->user;
+
+  if (rgw_get_user_info_by_uid(store, ui_owner, user_info) < 0) {
     ldout(cct, 0) << "NOTICE: couldn't map swift user" << dendl;
+
+    if (ui_owner != info->user) {
+      ldout(cct, 0) << "ERROR: only owner may create the account" << dendl;
+      return -EPERM;
+    }
+
     user_info.user_id = info->user;
     user_info.display_name = info->display_name;
 
@@ -472,8 +483,11 @@ static bool decode_pki_token(CephContext *cct, const string& token, bufferlist& 
   return true;
 }
 
-int RGWSwift::validate_keystone_token(RGWRados *store, const string& token, struct rgw_swift_auth_info *info,
-				      RGWUserInfo& rgw_user)
+int RGWSwift::validate_keystone_token(RGWRados * const store,
+                                      const string& account_name,
+                                      const string& token,
+                                      struct rgw_swift_auth_info *info,
+                                      RGWUserInfo& rgw_user)
 {
   KeystoneToken t;
 
@@ -488,7 +502,7 @@ int RGWSwift::validate_keystone_token(RGWRados *store, const string& token, stru
 
     ldout(cct, 20) << "cached token.tenant.id=" << t.token.tenant.id << dendl;
 
-    int ret = update_user_info(store, info, rgw_user);
+    int ret = update_user_info(store, account_name, info, rgw_user);
     if (ret < 0)
       return ret;
 
@@ -544,7 +558,7 @@ int RGWSwift::validate_keystone_token(RGWRados *store, const string& token, stru
 
   keystone_token_cache->add(token_id, t);
 
-  ret = update_user_info(store, info, rgw_user);
+  ret = update_user_info(store, account_name, info, rgw_user);
   if (ret < 0)
     return ret;
 
@@ -702,8 +716,20 @@ bool RGWSwift::do_verify_swift_token(RGWRados *store, req_state *s)
   int ret;
 
   if (supports_keystone()) {
-    ret = validate_keystone_token(store, s->os_auth_token, &info, *(s->user));
-    return (ret >= 0);
+    ret = validate_keystone_token(store, s->account_name, s->os_auth_token,
+            &info, *(s->user));
+    if (ret < 0) {
+      /* Authentication failed. */
+      return false;
+    }
+
+    if (!s->account_name.empty() && info.user.to_str() != s->account_name) {
+      /* Authentication succeeded but completely different account (tenant
+       * in Keystone terminology) has been requested. */
+      return false;
+    }
+
+    return true;
   }
 
   ret = validate_token(s->os_auth_token, &info);

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -28,12 +28,18 @@ class RGWSwift {
   atomic_t down_flag;
 
   int validate_token(const char *token, struct rgw_swift_auth_info *info);
-  int validate_keystone_token(RGWRados *store, const string& token, struct rgw_swift_auth_info *info,
-			      RGWUserInfo& rgw_user);
+  int validate_keystone_token(RGWRados *store,
+                              const string& account_name,
+                              const string& token,
+                              struct rgw_swift_auth_info *info,
+                              RGWUserInfo& rgw_user);
 
   int parse_keystone_token_response(const string& token, bufferlist& bl, struct rgw_swift_auth_info *info,
 		                    KeystoneToken& t);
-  int update_user_info(RGWRados *store, struct rgw_swift_auth_info *info, RGWUserInfo& user_info);
+  int update_user_info(RGWRados *store,
+                       const string& account_name,
+                       const struct rgw_swift_auth_info *info,
+                       RGWUserInfo& user_info);
   int get_keystone_url(std::string& url);
   int get_keystone_admin_token(std::string& token);
 

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -19,8 +19,13 @@ struct rgw_swift_auth_info {
   rgw_user user;
   string display_name;
   long long ttl;
+  bool is_admin;
 
-  rgw_swift_auth_info() : status(0), ttl(0) {}
+  rgw_swift_auth_info()
+    : status(0),
+      ttl(0),
+      is_admin(false) {
+  }
 };
 
 class RGWSwift {

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -213,6 +213,9 @@ void RGW_SWIFT_Auth_Get::execute()
   if (!g_conf->rgw_swift_tenant_name.empty()) {
     tenant_path = "/AUTH_";
     tenant_path.append(g_conf->rgw_swift_tenant_name);
+  } else if (g_conf->rgw_swift_account_in_url) {
+    tenant_path = "/AUTH_";
+    tenant_path.append(user_str);
   }
 
   STREAM_IO(s)->print("X-Storage-Url: %s/%s/v1%s\r\n", swift_url.c_str(),

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -33,18 +33,32 @@ static RGWMetadataHandler *user_meta_handler = NULL;
 /**
  * Get the anonymous (ie, unauthenticated) user info.
  */
-void rgw_get_anon_user(RGWUserInfo& info, rgw_user& auth_user)
+void rgw_get_anon_user(RGWUserInfo& info,
+                       rgw_user& auth_user,
+                       RGWRados * const store,
+                       const string& account_name)
 {
-  info.user_id = RGW_USER_ANON_ID;
-  info.display_name.clear();
-  info.access_keys.clear();
+  int ret = 0;
+  if (!account_name.empty()) {
+    const rgw_user ui_owner(account_name);
+    ret = rgw_get_user_info_by_uid(store, ui_owner, info);
+    if (ret < 0) {
+      dout(0) << "NOTICE: couldn't map swift user" << dendl;
+    }
+  }
+
+  if (account_name.empty() || ret < 0) {
+    info.user_id = RGW_USER_ANON_ID;
+    info.display_name.clear();
+    info.access_keys.clear();
+  }
 
   auth_user = RGW_USER_ANON_ID;
 }
 
-bool rgw_user_is_authenticated(RGWUserInfo& info)
+bool rgw_user_is_authenticated(const rgw_user& auth_user)
 {
-  return (info.user_id.id != RGW_USER_ANON_ID);
+  return (auth_user.id != RGW_USER_ANON_ID);
 }
 
 int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id)

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -33,11 +33,13 @@ static RGWMetadataHandler *user_meta_handler = NULL;
 /**
  * Get the anonymous (ie, unauthenticated) user info.
  */
-void rgw_get_anon_user(RGWUserInfo& info)
+void rgw_get_anon_user(RGWUserInfo& info, rgw_user& auth_user)
 {
   info.user_id = RGW_USER_ANON_ID;
   info.display_name.clear();
   info.access_keys.clear();
+
+  auth_user = RGW_USER_ANON_ID;
 }
 
 bool rgw_user_is_authenticated(RGWUserInfo& info)
@@ -1696,8 +1698,7 @@ RGWUser::~RGWUser()
 void RGWUser::init_default()
 {
   // use anonymous user info as a placeholder
-  rgw_get_anon_user(old_info);
-  user_id = RGW_USER_ANON_ID;
+  rgw_get_anon_user(old_info, user_id);
 
   clear_populated();
 }

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -298,10 +298,10 @@ int rgw_get_user_info_from_index(RGWRados *store, string& key, rgw_bucket& bucke
 int rgw_get_user_info_by_uid(RGWRados *store,
                              const rgw_user& uid,
                              RGWUserInfo& info,
-                             RGWObjVersionTracker *objv_tracker,
-                             time_t *pmtime,
-                             rgw_cache_entry_info *cache_info,
-                             map<string, bufferlist> *pattrs)
+                             RGWObjVersionTracker * const objv_tracker,
+                             time_t * const pmtime,
+                             rgw_cache_entry_info * const cache_info,
+                             map<string, bufferlist> * const pattrs)
 {
   bufferlist bl;
   RGWUID user_id;

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -49,7 +49,7 @@ extern int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id);
 /**
  * Get the anonymous (ie, unauthenticated) user info.
  */
-extern void rgw_get_anon_user(RGWUserInfo& info);
+extern void rgw_get_anon_user(RGWUserInfo& info, rgw_user& auth_user);
 
 /**
  * verify that user is an actual user, and not the anonymous user

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -49,12 +49,15 @@ extern int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id);
 /**
  * Get the anonymous (ie, unauthenticated) user info.
  */
-extern void rgw_get_anon_user(RGWUserInfo& info, rgw_user& auth_user);
+extern void rgw_get_anon_user(RGWUserInfo& info,
+                              rgw_user& auth_user,
+                              RGWRados * store = NULL,
+                              const std::string& account_name = std::string());
 
 /**
  * verify that user is an actual user, and not the anonymous user
  */
-extern bool rgw_user_is_authenticated(RGWUserInfo& info);
+extern bool rgw_user_is_authenticated(const rgw_user& auth_user);
 /**
  * Save the given user information to storage.
  * Returns: 0 on success, -ERR# on failure.


### PR DESCRIPTION
This PR provides following improvements:
* Support for full Swift URL schema  - account name is extracted from URL and may be used to load proper tenant identifier. This provides good basics  for i.a. account ACLs and TempURL requests on buckets in the non-empty namespace.
* Split user identity used for authentication/authorization purposes (```req_state::auth_user```) from account owner. Enables account ACL support.
* Swift's reseller admin feature (admin accounts).

The PR bases on #5872.