### PR TITLE
client: properly trim unlinked inode

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4658,7 +4658,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, MClient
     in->gid = m->head.gid;
   }
   bool deleted_inode = false;
-  if ((issued & CEPH_CAP_LINK_EXCL) == 0 && in->nlink != (int32_t)m->head.nlink) {
+  if ((issued & CEPH_CAP_LINK_EXCL) == 0) {
     in->nlink = m->head.nlink;
     if (in->nlink == 0 &&
 	(new_caps & (CEPH_CAP_LINK_SHARED | CEPH_CAP_LINK_EXCL)))


### PR DESCRIPTION
Client should trim inode from its cache when receiving a cap message
with nlink == 0. But the corresponding code has a bug, it does nothing
when inode's nlink is already 0.

Fixes: #13903
Signed-off-by: Yan, Zheng <zyan@redhat.com>