### PR TITLE
OSD/OSDService: make osdmap load error more human-understandable

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1333,7 +1333,8 @@ OSDMapRef OSDService::try_get_map(epoch_t epoch)
   if (epoch > 0) {
     dout(20) << "get_map " << epoch << " - loading and decoding " << map << dendl;
     bufferlist bl;
-    if (!_get_map_bl(epoch, bl)) {
+    if (!_get_map_bl(epoch, bl) || bl.length() == 0) {
+      derr << "failed to load OSD map for epoch " << epoch << ", got " << bl.length() << " bytes" << dendl;
       delete map;
       return OSDMapRef();
     }


### PR DESCRIPTION
In case when OSD crashed leaving empty OSD maps in its store, subsequent
OSD boots will fail with exception end_of_buffer thrown in map->decode.
This occurs because _get_map_bl returns TRUE and empty bufferlist.
In that case, inform user of actual issue instead of crashing in odd place
and requiring them to strace ceph-osd to find out what actually happened.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>