### PR TITLE
cmake: let ceph-client-debug link with tcmalloc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -806,7 +806,7 @@ add_library(compressor STATIC ${compressor_srcs})
 target_link_libraries(compressor common snappy)
 
 add_executable(ceph-client-debug tools/ceph-client-debug.cc)
-target_link_libraries(ceph-client-debug cephfs librados global common)
+target_link_libraries(ceph-client-debug cephfs librados global common ${ALLOC_LIBS})
 install(TARGETS ceph-client-debug DESTINATION bin/debug)
 
 add_executable(ceph-kvstore-tool tools/ceph_kvstore_tool.cc)


### PR DESCRIPTION
to fix the link problem of
libcephfs.so.1.0.0: undefined reference to `IsHeapProfilerRunning'
when tcmalloc is used and profiler header is detected.

Signed-off-by: Kefu Chai <kchai@redhat.com>