### PR TITLE
test/cls ：clean useless pools

### DIFF
--- a/src/test/cls_log/test_cls_log.cc
+++ b/src/test/cls_log/test_cls_log.cc
@@ -187,6 +187,9 @@ TEST(cls_rgw, test_log_add_same_time)
   ASSERT_EQ(1, (int)truncated);
 
   delete rop;
+
+  /* destroy pool */
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, rados));
 }
 
 TEST(cls_rgw, test_log_add_different_time)
@@ -280,6 +283,9 @@ TEST(cls_rgw, test_log_add_different_time)
 
   ASSERT_EQ(10, i);
   delete rop;
+
+  /* destroy pool */
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, rados));
 }
 
 TEST(cls_rgw, test_log_trim)
@@ -331,4 +337,7 @@ TEST(cls_rgw, test_log_trim)
     ASSERT_EQ(0, (int)truncated);
   }
   delete rop;
+
+  /* destroy pool */
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, rados));
 }


### PR DESCRIPTION
After do ./ceph_test_cls_log ,pools remains
need be destroyed.

Signed-off-by: Ji Chen <insomnia@139.com>