### PR TITLE
mon: drop useless rank init assignment

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -196,8 +196,6 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   routed_request_tid(0),
   op_tracker(cct, true, 1)
 {
-  rank = -1;
-
   clog = log_client.create_channel(CLOG_CHANNEL_CLUSTER);
   audit_clog = log_client.create_channel(CLOG_CHANNEL_AUDIT);
 


### PR DESCRIPTION
Monitor initialization bug fixes
rank is initialization assignment, do not need the assignment again;
&& preinit has not unlock before reture.

Fixes: #14508
Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>