### PR TITLE
DNM rgw: WIP 5073 11

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -749,10 +749,14 @@ Swift Settings
 
 ``rgw swift url prefix``
 
-:Description: The URL prefix for the Swift API. 
+:Description: The URL prefix for the Swift StorageURL that goes in front of
+              the "/v1" part. This allows to run several Gateway instances
+              on the same host. For compatibility, setting this configuration
+              variable to empty causes the default "/swift" to be used.
+              Use explicit prefix "/" to start StorageURL at the root.
 :Default: ``swift``
-:Example: http://fqdn.com/swift
-	
+:Example: "/swift-testing"
+
 
 ``rgw swift auth url``
 

--- a/src/rgw/rgw_acl_s3.cc
+++ b/src/rgw/rgw_acl_s3.cc
@@ -516,7 +516,7 @@ int RGWAccessControlPolicy_S3::rebuild(RGWRados *store, ACLOwner *owner, RGWAcce
           ldout(cct, 0) << "ERROR: src_grant.get_id() failed" << dendl;
           return -EINVAL;
         }
-        email = u.id;
+        email = u.id;  // XXX none of that .to_str() stuff here, but why?
         ldout(cct, 10) << "grant user email=" << email << dendl;
         if (rgw_get_user_info_by_email(store, email, grant_user) < 0) {
           ldout(cct, 10) << "grant user email not found or other error" << dendl;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1797,6 +1797,7 @@ public:
 
     if (!exists || old_bci.info.bucket.bucket_id != bci.info.bucket.bucket_id) {
       /* a new bucket, we need to select a new bucket placement for it */
+      // XXX not sure if this is correct -- stolen from Radoslaw; what about get()?
       string tenant_name;
       string bucket_name;
       parse_bucket(entry, tenant_name, bucket_name);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1095,6 +1095,8 @@ struct req_state {
    string bucket_tenant;
    string bucket_name;
 
+   string account_name;
+
    rgw_bucket bucket;
    rgw_obj_key object;
    string src_tenant_name;

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -670,7 +670,8 @@ bool RGWSwift::do_verify_swift_token(RGWRados *store, req_state *s)
     return (ret >= 0);
   }
 
-  if (strncmp(s->os_auth_token, "AUTH_rgwtk", 10) == 0) {
+  if (strncmp(s->os_auth_token, "AUTH_rgwtk", 10) == 0 ||
+      strncmp(s->os_auth_token, "AUTH_rgwts", 10) == 0) {
     int ret = rgw_swift_verify_signed_token(s->cct, store, s->os_auth_token, s->user, &s->swift_user);
     if (ret < 0)
       return false;

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -13,7 +13,7 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-#define DEFAULT_SWIFT_PREFIX "swift"
+#define DEFAULT_SWIFT_PREFIX "/swift"
 
 using namespace ceph::crypto;
 
@@ -61,10 +61,13 @@ static int encode_token(CephContext *cct, string& swift_user, string& key, buffe
 
 int rgw_swift_verify_signed_token(CephContext *cct, RGWRados *store, const char *token, RGWUserInfo& info, string *pswift_user)
 {
-  if (strncmp(token, "AUTH_rgwtk", 10) != 0)
+  if (strncmp(token, "AUTH_rgwtk", 10) == 0) {
+    token += 10;
+  } else if (strncmp(token, "AUTH_rgwts", 10) == 0) {
+    token += 10;
+  } else {
     return -EINVAL;
-
-  token += 10;
+  }
 
   int len = strlen(token);
   if (len & 1) {
@@ -134,6 +137,7 @@ int rgw_swift_verify_signed_token(CephContext *cct, RGWRados *store, const char 
 void RGW_SWIFT_Auth_Get::execute()
 {
   int ret = -EPERM;
+  const char *token_tag = "rgwtk";
 
   const char *key = s->info.env->get("HTTP_X_AUTH_KEY");
   const char *user = s->info.env->get("HTTP_X_AUTH_USER");
@@ -148,8 +152,20 @@ void RGW_SWIFT_Auth_Get::execute()
   string swift_prefix = g_conf->rgw_swift_url_prefix;
   string tenant_path;
 
+  /*
+   * We did not allow an empty Swift prefix before, but we want it now.
+   * So, we take rgw_swift_url_prefix = "/" to yield the empty prefix.
+   * The rgw_swift_url_prefix = "" is the default and yields "/swift"
+   * in a backwards-compatible way.
+   */
   if (swift_prefix.size() == 0) {
     swift_prefix = DEFAULT_SWIFT_PREFIX;
+  } else if (swift_prefix == "/") {
+    swift_prefix.clear();
+  } else {
+    if (swift_prefix[0] != '/') {
+      swift_prefix.insert(0, "/");
+    }
   }
 
   if (swift_url.size() == 0) {
@@ -179,7 +195,6 @@ void RGW_SWIFT_Auth_Get::execute()
     }
   }
 
-
   if (!key || !user)
     goto done;
 
@@ -207,9 +222,13 @@ void RGW_SWIFT_Auth_Get::execute()
   if (!g_conf->rgw_swift_tenant_name.empty()) {
     tenant_path = "/AUTH_";
     tenant_path.append(g_conf->rgw_swift_tenant_name);
+  } else {
+    tenant_path = "/AUTH_";
+    tenant_path.append(info.user_id.to_str());
+    token_tag = "rgwts";
   }
 
-  s->cio->print("X-Storage-Url: %s/%s/v1%s\r\n", swift_url.c_str(),
+  s->cio->print("X-Storage-Url: %s%s/v1%s\r\n", swift_url.c_str(),
 	        swift_prefix.c_str(), tenant_path.c_str());
 
   if ((ret = encode_token(s->cct, swift_key->id, swift_key->key, bl)) < 0)
@@ -219,8 +238,8 @@ void RGW_SWIFT_Auth_Get::execute()
     char buf[bl.length() * 2 + 1];
     buf_to_hex((const unsigned char *)bl.c_str(), bl.length(), buf);
 
-    s->cio->print("X-Storage-Token: AUTH_rgwtk%s\r\n", buf);
-    s->cio->print("X-Auth-Token: AUTH_rgwtk%s\r\n", buf);
+    s->cio->print("X-Storage-Token: AUTH_%s%s\r\n", token_tag, buf);
+    s->cio->print("X-Auth-Token: AUTH_%s%s\r\n", token_tag, buf);
   }
 
   ret = STATUS_NO_CONTENT;


### PR DESCRIPTION
WIP 5073 continuing

(DNM because this does not incorporate the changes Radoslaw made over Christmas.)
(This includes the exact commit from PR 7120 as a prerequisite.)

 - Import Radoslaw's "account name in URL"
 - Use the AUTH_rgwtsXXXX token to signify that account is in URL
 - fix up Radoslaw with user_str replaced with info.user_id
 - allow solitary "/" to specify empty swift prefix

Signed-off-by: Pete Zaitcev <zaitcev@redhat.com>