### PR TITLE
doc: Fixes a CRUSH map step take argument

### DIFF
--- a/doc/rados/operations/crush-map.rst
+++ b/doc/rados/operations/crush-map.rst
@@ -502,7 +502,7 @@ A rule takes the following form::
 		type [ replicated | erasure ]
 		min_size <min-size>
 		max_size <max-size>
-		step take <bucket-type>
+		step take <bucket-name>
 		step [choose|chooseleaf] [firstn|indep] <N> <bucket-type>
 		step emit
 	}


### PR DESCRIPTION
CRUSH map step take argument is really a bucket-name, not a bucket-type

Signed-off-by: Ivan Grcic <igrcic@gmail.com>