### PR TITLE
librbd: remove canceled tasks from timer thread

### DIFF
--- a/src/librbd/TaskFinisher.h
+++ b/src/librbd/TaskFinisher.h
@@ -45,6 +45,7 @@ public:
     typename TaskContexts::iterator it = m_task_contexts.find(task);
     if (it != m_task_contexts.end()) {
       delete it->second.first;
+      m_safe_timer->cancel_event(it->second.second);
       m_task_contexts.erase(it);
     }
   }


### PR DESCRIPTION
When canceling scheduled tasks using the timer thread, TaskFinisher::cancel
does not call SafeTimer::cancel_event, so events fire anyway. Add this call.

Fixes: #14476
Signed-off-by: Douglas Fuller <dfuller@redhat.com>