### PR TITLE
osd: delete useless bytes_written defined in RepModify

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1208,8 +1208,6 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
     update_snaps,
     &(rm->localt));
 
-  rm->bytes_written = rm->opt.get_encoded_bytes();
-
   rm->opt.register_on_commit(
     parent->bless_context(
       new C_OSD_RepModifyCommit(this, rm)));

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -403,12 +403,10 @@ private:
     eversion_t last_complete;
     epoch_t epoch_started;
 
-    uint64_t bytes_written;
-
     ObjectStore::Transaction opt, localt;
     
     RepModify() : applied(false), committed(false), ackerosd(-1),
-		  epoch_started(0), bytes_written(0) {}
+		  epoch_started(0) {}
   };
   typedef ceph::shared_ptr<RepModify> RepModifyRef;
 


### PR DESCRIPTION
this would avoid calling encode function.

Signed-off-by: Xinze Chi <xinze@xsky.com>