### PR TITLE
rbd: add "--dest-snap" optional for snap rename

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -1019,6 +1019,7 @@
   rbd help snap rename
   usage: rbd snap rename [--pool <pool>] [--image <image>] [--snap <snap>] 
                          [--dest-pool <dest-pool>] [--dest <dest>] 
+                         [--dest-snap <dest-snap>] 
                          <source-snap-spec> <dest-snap-spec> 
   
   Rename a snapshot.
@@ -1035,6 +1036,7 @@
     --snap arg           source snapshot name
     --dest-pool arg      destination pool name
     --dest arg           destination image name
+    --dest-snap arg      destination snapshot name
   
   rbd help snap rollback
   usage: rbd snap rollback [--pool <pool>] [--image <image>] [--snap <snap>] 

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -104,15 +104,15 @@ void add_image_option(po::options_description *opt,
 
 void add_snap_option(po::options_description *opt,
                       ArgumentModifier modifier) {
-  if (modifier == ARGUMENT_MODIFIER_DEST) {
-    return;
-  }
 
   std::string name = SNAPSHOT_NAME;
   std::string description = "snapshot name";
   switch (modifier) {
   case ARGUMENT_MODIFIER_NONE:
+    break;
   case ARGUMENT_MODIFIER_DEST:
+    name = DEST_SNAPSHOT_NAME;
+    description = "destination " + description;
     break;
   case ARGUMENT_MODIFIER_SOURCE:
     description = "source " + description;

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -50,6 +50,7 @@ static const std::string DEST_POOL_NAME("dest-pool");
 static const std::string IMAGE_NAME("image");
 static const std::string DEST_IMAGE_NAME("dest");
 static const std::string SNAPSHOT_NAME("snap");
+static const std::string DEST_SNAPSHOT_NAME("dest-snap");
 static const std::string JOURNAL_NAME("journal");
 static const std::string DEST_JOURNAL_NAME("dest-journal");
 static const std::string PATH("path");

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -144,6 +144,8 @@ int get_pool_image_snapshot_names(const po::variables_map &vm,
     at::DEST_POOL_NAME : at::POOL_NAME);
   std::string image_key = (mod == at::ARGUMENT_MODIFIER_DEST ?
     at::DEST_IMAGE_NAME : at::IMAGE_NAME);
+  std::string snap_key = (mod == at::ARGUMENT_MODIFIER_DEST ?
+	at::DEST_SNAPSHOT_NAME : at::SNAPSHOT_NAME);
 
   if (vm.count(pool_key) && pool_name != nullptr) {
     *pool_name = vm[pool_key].as<std::string>();
@@ -151,11 +153,10 @@ int get_pool_image_snapshot_names(const po::variables_map &vm,
   if (vm.count(image_key) && image_name != nullptr) {
     *image_name = vm[image_key].as<std::string>();
   }
-  if (vm.count(at::SNAPSHOT_NAME) && snap_name != nullptr &&
-      mod != at::ARGUMENT_MODIFIER_DEST) {
-    *snap_name = vm[at::SNAPSHOT_NAME].as<std::string>();
-  }
-
+  if (vm.count(snap_key) && snap_name != nullptr) {
+     *snap_name = vm[snap_key].as<std::string>();
+   }
+  
   if (image_name != nullptr && !image_name->empty()) {
     // despite the separate pool and snapshot name options,
     // we can also specify them via the image option

--- a/src/tools/rbd/action/Snap.cc
+++ b/src/tools/rbd/action/Snap.cc
@@ -446,7 +446,7 @@ int execute_rename(const po::variables_map &vm) {
               << std::endl;
     return -EINVAL;
   }
-
+  
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;


### PR DESCRIPTION
rbd snap rename failure.
snap rename command does not have a parameters to accept  the destination snapshot name will lead to rename failure

```
root@vm01:~# rbd help snap rename
usage: rbd snap rename [--pool <pool>] [--image <image>] [--snap <snap>] 
                       [--dest-pool <dest-pool>] [--dest <dest>] 
                       <source-snap-spec> <dest-snap-spec> 

Rename a snapshot.

Positional arguments
  <source-snap-spec> source snapshot specification
                       (example: [<pool-name>/]<image-name>@<snapshot-name>)
  <dest-snap-spec> destination snapshot specification
                       (example: [<pool-name>/]<image-name>@<snapshot-name>)

Optional arguments
  -p [ --pool ] arg source pool name
  --image arg source image name
  --snap arg source snapshot name
  --dest-pool arg destination pool name
  --dest arg destination image name
```

Signed-off-by: Na Xie <xie.na@h3c.com>