### PR TITLE
librados: check connection state in rados_monitor_log

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -823,6 +823,10 @@ int librados::RadosClient::monitor_log(const string& level, rados_log_callback_t
 {
   Mutex::Locker l(lock);
 
+  if (state != CONNECTED) {
+    return -ENOTCONN;
+  }
+
   if (cb == NULL) {
     // stop watch
     ldout(cct, 10) << __func__ << " removing cb " << (void*)log_cb << dendl;

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -38,6 +38,16 @@ TEST(LibRadosMiscVersion, VersionPP) {
   Rados::version(&major, &minor, &extra);
 }
 
+static void test_rados_log_cb(void *arg,
+                              const char *line,
+                              const char *who,
+                              uint64_t sec, uint64_t nsec,
+                              uint64_t seq, const char *level,
+                              const char *msg)
+{
+    std::cerr << "monitor log callback invoked" << std::endl;
+}
+
 TEST(LibRadosMiscConnectFailure, ConnectFailure) {
   rados_t cluster;
 
@@ -50,6 +60,9 @@ TEST(LibRadosMiscConnectFailure, ConnectFailure) {
   ASSERT_EQ(0, rados_conf_parse_env(cluster, NULL));
 
   ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "0.000001"));
+
+  ASSERT_EQ(-ENOTCONN, rados_monitor_log(cluster, "error",
+                                         test_rados_log_cb, NULL));
 
   ASSERT_NE(0, rados_connect(cluster));
   ASSERT_NE(0, rados_connect(cluster));


### PR DESCRIPTION
rados_monitor_log() may abort the calling process if called with a
disconnected rados cluster context. Return -ENOTCONN up to the caller,
rather than aborting in such cases.

Fixes: #14499
Signed-off-by: David Disseldorp <ddiss@suse.de>