### PR TITLE
Add --setuser and --setgroup options for ceph-disk

### DIFF
--- a/doc/man/8/ceph-disk.rst
+++ b/doc/man/8/ceph-disk.rst
@@ -277,6 +277,14 @@ Options
 
    Directory in which ceph configuration files are found (default ``/etc/ceph``).
 
+.. option:: --setuser USER
+
+   Specify a user for ceph-disk to use when dropping privileges (default ``ceph``, or ``root`` if ``ceph`` does not exist)
+
+.. option:: --setgroup GROUP
+
+   Specify a group for ceph-disk to use when dropping privileges (default ``ceph``, or ``root`` if ``ceph`` does not exist)
+
 .. option:: --cluster
 
    Provide name of the ceph cluster in which the OSD is being prepared.

--- a/doc/man/8/ceph-disk.rst
+++ b/doc/man/8/ceph-disk.rst
@@ -11,10 +11,12 @@ Synopsis
 
 | **ceph-disk** **prepare** [--cluster *clustername*] [--cluster-uuid *uuid*]
 	[--fs-type *xfs|ext4|btrfs*] [*data-path*] [*journal-path*]
+	[--setuser *user*] [--setgroup *group*]
 
 | **ceph-disk** **activate** [*data-path*] [--activate-key *path*]
         [--mark-init *sysvinit|upstart|systemd|auto|none*]
         [--no-start-daemon] [--reactivate]
+        [--setuser *user*] [--setgroup *group*]
 
 | **ceph-disk** **activate-all**
 
@@ -322,6 +324,14 @@ Options
 .. option:: --dmcrypt-key-dir
 
 	Directory where ``dm-crypt`` keys are stored.
+
+.. option:: --setuser
+
+    Define the user for ceph-disk's child processes (default ``ceph``, or ``root``)
+
+.. option:: --setgroup
+
+    Define the group for ceph-disk's child processes (default ``ceph``, or ``root``)
 
 Availability
 ============


### PR DESCRIPTION
In some contexts, ceph-disk's child processes (particularly those creating the journal) may need special user or group permissions.  This PR adds the options to ceph-disk, and updates the man page accordingly.