### PR TITLE
Fix for rgw: user quota may not adjust on bucket removal. BUG#14507

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -488,6 +488,11 @@ int rgw_remove_bucket(RGWRados *store, rgw_bucket& bucket, bool delete_children)
     }
   }
 
+  ret = rgw_bucket_sync_user_stats(store, bucket.name);
+  if ( ret < 0) {
+     dout(1) << "WARNING: failed sync user stats before bucket delete. ret=" << ret << dendl;
+  }
+
   RGWObjVersionTracker objv_tracker;
 
   ret = store->delete_bucket(bucket, objv_tracker);

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -488,7 +488,7 @@ int rgw_remove_bucket(RGWRados *store, rgw_bucket& bucket, bool delete_children)
     }
   }
 
-  ret = rgw_bucket_sync_user_stats(store, bucket.name);
+  ret = rgw_bucket_sync_user_stats(store, bucket.tenant, bucket.name);
   if ( ret < 0) {
      dout(1) << "WARNING: failed sync user stats before bucket delete. ret=" << ret << dendl;
   }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -490,7 +490,7 @@ int rgw_remove_bucket(RGWRados *store, rgw_bucket& bucket, bool delete_children)
 
   ret = rgw_bucket_sync_user_stats(store, bucket.tenant, bucket.name);
   if ( ret < 0) {
-     dout(1) << "WARNING: failed sync user stats before bucket delete. ret=" << ret << dendl;
+     dout(1) << "WARNING: failed sync user stats before bucket delete. ret=" <<  ret << dendl;
   }
 
   RGWObjVersionTracker objv_tracker;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1790,6 +1790,11 @@ void RGWDeleteBucket::execute()
     }
   }
 
+  ret = rgw_bucket_sync_user_stats(store, s->user.user_id, s->bucket);
+  if ( ret < 0) {
+     dout(1) << "WARNING: failed to sync user stats before bucket delete: ret=" << ret << dendl;
+  }
+  
   ret = store->delete_bucket(s->bucket, ot);
 
   if (ret == 0) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1792,7 +1792,7 @@ void RGWDeleteBucket::execute()
 
   ret = rgw_bucket_sync_user_stats(store, s->user.user_id, s->bucket);
   if ( ret < 0) {
-     dout(1) << "WARNING: failed to sync user stats before bucket delete: ret=" << ret << dendl;
+     dout(1) << "WARNING: failed to sync user stats before bucket delete: ret= " << ret << dendl;
   }
   
   ret = store->delete_bucket(s->bucket, ot);


### PR DESCRIPTION
I modified the two files to sync user stats before removing bucket.

Problem Description:
If the user/admin removes a bucket using --force/--purge-objects options with s3cmd/radosgw-admin respectively, the user stats will  continue to reflect the deleted objects for quota purposes, and  there seems to be no way to reset them. User stats need to be sync'ed prior to bucket removal. 
Setting "rgw_user_quota_bucket_sync_interval = 0" avoids the problem, but adds overhead to puts and deletes.
