### PR TITLE
OSD:memory leak in ReplicatedPG.cc

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3267,6 +3267,7 @@ ReplicatedPG::RepGather *ReplicatedPG::trim_object(const hobject_t &coid)
 	break;
     if (p == snapset.clones.end()) {
       osd->clog->error() << __func__ << " Snap " << coid.snap << " not in clones" << "\n";
+      remove_repop(repop);
       return NULL;
     }
 


### PR DESCRIPTION
"return NULL" in "if (p == snapset.clones.end())" can not free the
memory of "*repop"

Signed-off-by: Bin Zheng <zhengbin.08747@h3c.com>