### PR TITLE
rados: Add a parameter validation for the tail of command

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -3060,5 +3060,10 @@ int main(int argc, const char **argv)
     return 1;
   }
 
+  if (args.begin() != args.end()) {
+    cerr << "rados: unknown command: " << *args.begin() << std::endl;
+    return 1;
+  }
+
   return rados_tool_common(opts, args);
 }


### PR DESCRIPTION
This check makes sure invalid arguments in the tail of rados command seen as illegal inputs. Now command like 'rados df 123' will not show a result correctly.

Signed-off-by: Kongming Wu <wu.kongming@h3c.com>