### PR TITLE
rados: Add a parameter validation for the tail of some rados command

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1529,6 +1529,9 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
   // list pools?
   if (strcmp(nargs[0], "lspools") == 0) {
+    if (nargs.size() >= 2)
+      usage_exit();
+
     list<string> vec;
     ret = rados.pool_list(vec);
     if (ret < 0) {
@@ -1539,6 +1542,9 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       cout << *i << std::endl;
   }
   else if (strcmp(nargs[0], "df") == 0) {
+    if (nargs.size() >= 2)
+      usage_exit();    
+
     // pools
     list<string> vec;
 


### PR DESCRIPTION
This check makes sure invalid arguments in the tail of rados command (df, lspools) seen as illegal inputs. Now command like 'rados df 123' will not show a result correctly.

Signed-off-by: Kongming Wu wu.kongming@h3c.com
