### PR TITLE
common: default cluster name to config file prefix

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -676,7 +676,7 @@ def main():
     else:
         injectargs = None
 
-    clustername = 'ceph'
+    clustername = None
     if parsed_args.cluster:
         clustername = parsed_args.cluster
 

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -68,7 +68,7 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
   // You can only call global_init once.
   assert(!g_ceph_context);
   std::string conf_file_list;
-  std::string cluster = "ceph";
+  std::string cluster = "";
   CephInitParameters iparams = ceph_argparse_early_args(args, module_type, flags,
 							&cluster, &conf_file_list);
   CephContext *cct = common_preinit(iparams, code_env, flags, data_dir_option);

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2348,7 +2348,7 @@ extern "C" int rados_create(rados_t *pcluster, const char * const id)
   if (id) {
     iparams.name.set(CEPH_ENTITY_TYPE_CLIENT, id);
   }
-  CephContext *cct = rados_create_cct("ceph", &iparams);
+  CephContext *cct = rados_create_cct("", &iparams);
 
   tracepoint(librados, rados_create_enter, id);
   *pcluster = reinterpret_cast<rados_t>(new librados::RadosClient(cct));

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -542,7 +542,7 @@ cdef class Rados(object):
         elif name is None:
             name = 'client.admin'
         if clustername is None:
-            clustername = 'ceph'
+            clustername = ''
 
         name = cstr(name, 'name')
         clustername = cstr(clustername, 'clustername')

--- a/src/test/common/test_context.cc
+++ b/src/test/common/test_context.cc
@@ -30,6 +30,8 @@ TEST(CephContext, do_command)
 {
   CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_CLIENT))->get();
 
+  cct->_conf->cluster = "ceph";
+
   string key("key");
   string value("value");
   cct->_conf->set_val(key.c_str(), value.c_str(), false);
@@ -56,6 +58,8 @@ TEST(CephContext, do_command)
 TEST(CephContext, experimental_features)
 {
   CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_CLIENT))->get();
+
+  cct->_conf->cluster = "ceph";
 
   ASSERT_FALSE(cct->check_experimental_feature_enabled("foo"));
   ASSERT_FALSE(cct->check_experimental_feature_enabled("bar"));


### PR DESCRIPTION
The goal of the fixing.
1. When only configuration file is given, cluster name would be the 
prefix of the basename of conf file.
2. When both configuration file and cluster name are given, both 
arguments are respected.
3. When neither configuration file nor cluster name are given, the
cluster name would be 'ceph'.
4. When only cluster name is given, configuration file would be
/etc/ceph/$cluster.conf.

With the fixing, Consumers of 
1.librados
2. rados python binding
3. rados_create()
4. libvirt
would be able to support the CEPH clusters not being named 'ceph'
without any change as long as configure file following $cluster.conf
convention.

ceph(8), rados(8) benefit from the changes when only config file of
'non-ceph' cluster is given.

Tests run:
ceph(8) tests
rados(8) tests
rbd(8) tests
libvirt tests by 'nova image-create'
