### PR TITLE
cmake: check for libsnappy in default path also

### DIFF
--- a/cmake/modules/Findsnappy.cmake
+++ b/cmake/modules/Findsnappy.cmake
@@ -23,38 +23,13 @@
 # SNAPPY_LIBRARIES - List of libraries when using snappy.
 # SNAPPY_FOUND - True if snappy found.
 
-find_path(SNAPPY_INCLUDE_DIR snappy.h NO_DEFAULT_PATH PATHS
-  ${HT_DEPENDENCY_INCLUDE_DIR}
-  /usr/include
-  /opt/local/include
-  /usr/local/include
-)
+find_path(SNAPPY_INCLUDE_DIR
+  NAMES snappy.h
+  HINTS ${SNAPPY_ROOT_DIR}/include)
 
-set(SNAPPY_NAMES ${SNAPPY_NAMES} snappy)
-find_library(SNAPPY_LIBRARY NAMES ${SNAPPY_NAMES} NO_DEFAULT_PATH PATHS
-    ${HT_DEPENDENCY_LIB_DIR}
-    /usr/local/lib
-    /opt/local/lib
-    /usr/lib
-    )
-
-if (SNAPPY_INCLUDE_DIR AND SNAPPY_LIBRARY)
-  set(SNAPPY_FOUND TRUE)
-  set( SNAPPY_LIBRARIES ${SNAPPY_LIBRARY} )
-else ()
-  set(SNAPPY_FOUND FALSE)
-  set( SNAPPY_LIBRARIES )
-endif ()
-
-if (SNAPPY_FOUND)
-  message(STATUS "Found Snappy: ${SNAPPY_LIBRARY}")
-else ()
-  message(STATUS "Not Found Snappy: ${SNAPPY_LIBRARY}")
-  if (SNAPPY_FIND_REQUIRED)
-    message(STATUS "Looked for Snappy libraries named ${SNAPPY_NAMES}.")
-    message(FATAL_ERROR "Could NOT find Snappy library")
-  endif ()
-endif ()
+find_library(SNAPPY_LIBRARIES
+  NAMES snappy
+  HINTS ${SNAPPY_ROOT_DIR}/lib)
 
 # handle the QUIETLY and REQUIRED arguments and set UUID_FOUND to TRUE if
 # all listed variables are TRUE
@@ -62,6 +37,5 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(snappy DEFAULT_MSG SNAPPY_LIBRARIES SNAPPY_INCLUDE_DIR)
 
 mark_as_advanced(
-  SNAPPY_LIBRARY
-  SNAPPY_I
-)
+  SNAPPY_LIBRARIES
+  SNAPPY_INCLUDE_DIR)


### PR DESCRIPTION
* some distros install libsnappy into /usr/lib/x86_64-linux-gnu
  which is completely resonable. but this directory is not listed
  in the Findsnappy.cmake.
* also add SNAPPY_ROOT_DIR, in case user install snappy in some
  other directory.

Signed-off-by: Kefu Chai <kchai@redhat.com>