### PR TITLE
rgw: add drain_all() after collect() in sync crs

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -342,6 +342,7 @@ public:
 	}
         yield;
       }
+      drain_all();
       return set_cr_done();
     }
     return 0;
@@ -556,6 +557,7 @@ public:
 	}
         yield;
       }
+      drain_all();
       yield return set_cr_done();
     }
     return 0;

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -566,6 +566,7 @@ public:
 	}
         yield;
       }
+      drain_all();
       return set_cr_done();
     }
     return 0;
@@ -770,6 +771,7 @@ public:
 	}
         yield;
       }
+      drain_all();
       if (failed) {
         yield return set_cr_error(-EIO);
       }


### PR DESCRIPTION
this fixes a segfault caused by parent stacks completing while there are
child stacks outstanding

Signed-off-by: Casey Bodley <cbodley@redhat.com>