### PR TITLE
mon: cleanup set-quota error msg

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7354,7 +7354,7 @@ done:
     string field;
     cmd_getval(g_ceph_context, cmdmap, "field", field);
     if (field != "max_objects" && field != "max_bytes") {
-      ss << "unrecognized field '" << field << "'; max_bytes of max_objects";
+      ss << "unrecognized field '" << field << "'; should be 'max_bytes' or 'max_objects'";
       err = -EINVAL;
       goto reply;
     }


### PR DESCRIPTION
When we send in an unrecognized field for set-quota, specify that the
options should be `max_bytes` or `max_objects`. This doesn't affect the
ceph-cli as the choices are caught at an earlier stage, however the
error message is seen while reaching the cluster via rados api for eg.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>