### PR TITLE
WIP:  common: parse according to code_env and alias format for rados-cli

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -356,7 +356,7 @@ void md_config_t::_show_config(std::ostream *out, Formatter *f)
   }
 }
 
-int md_config_t::parse_argv(std::vector<const char*>& args)
+int md_config_t::parse_argv(std::vector<const char*>& args, enum code_environment_t code_env)
 {
   Mutex::Locker l(lock);
   if (internal_safe_to_start_threads) {
@@ -378,7 +378,22 @@ int md_config_t::parse_argv(std::vector<const char*>& args)
        * argument parses will still need to see it. */
       break;
     }
-    else if (ceph_argparse_flag(args, i, "--show_conf", (char*)NULL)) {
+
+    /* Parse for daemonize flags only if we are a daemon, they are not needed
+       for libraries or clients */
+    if (code_env == CODE_ENVIRONMENT_DAEMON) {
+      if (ceph_argparse_flag(args, i, "--foreground", "-f", (char*)NULL)) {
+      set_val_or_die("daemonize", "false");
+      } else if (ceph_argparse_flag(args, i, "-d", (char*)NULL)) {
+      set_val_or_die("daemonize", "false");
+      set_val_or_die("log_file", "");
+      set_val_or_die("log_to_stderr", "true");
+      set_val_or_die("err_to_stderr", "true");
+      set_val_or_die("log_to_syslog", "false");
+      }
+    }
+
+    if (ceph_argparse_flag(args, i, "--show_conf", (char*)NULL)) {
       cerr << cf << std::endl;
       _exit(0);
     }
@@ -388,16 +403,6 @@ int md_config_t::parse_argv(std::vector<const char*>& args)
     else if (ceph_argparse_witharg(args, i, &val, "--show_config_value", (char*)NULL)) {
       show_config_value = true;
       show_config_value_arg = val;
-    }
-    else if (ceph_argparse_flag(args, i, "--foreground", "-f", (char*)NULL)) {
-      set_val_or_die("daemonize", "false");
-    }
-    else if (ceph_argparse_flag(args, i, "-d", (char*)NULL)) {
-      set_val_or_die("daemonize", "false");
-      set_val_or_die("log_file", "");
-      set_val_or_die("log_to_stderr", "true");
-      set_val_or_die("err_to_stderr", "true");
-      set_val_or_die("log_to_syslog", "false");
     }
     // Some stuff that we wanted to give universal single-character options for
     // Careful: you can burn through the alphabet pretty quickly by adding

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -22,6 +22,7 @@ extern struct ceph_file_layout g_default_file_layout;
 #include <map>
 #include <set>
 
+#include "common/code_environment.h"
 #include "common/ConfUtils.h"
 #include "common/entity_name.h"
 #include "common/Mutex.h"
@@ -113,7 +114,7 @@ public:
   void parse_env();
 
   // Absorb config settings from argv
-  int parse_argv(std::vector<const char*>& args);
+  int parse_argv(std::vector<const char*>& args, enum code_environment_t code_env);
 
   // Expand all metavariables. Make any pending observer callbacks.
   void apply_changes(std::ostream *oss);

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -76,7 +76,7 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
   md_config_t *conf = cct->_conf;
 
   if (alt_def_args)
-    conf->parse_argv(*alt_def_args);  // alternative default args
+    conf->parse_argv(*alt_def_args, code_env);  // alternative default args
 
   std::deque<std::string> parse_errors;
   int ret = conf->parse_config_files(c_str_or_null(conf_file_list), &parse_errors, &cerr, flags);
@@ -104,7 +104,7 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
 
   conf->parse_env(); // environment variables override
 
-  conf->parse_argv(args); // argv override
+  conf->parse_argv(args, code_env); // argv override
 
   // Expand metavariables. Invoke configuration observers.
   conf->apply_changes(NULL);

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -187,7 +187,7 @@ public:
     int ret;
     vector<const char*> args;
     argv_to_vec(argc, argv, args);
-    ret = cct->_conf->parse_argv(args);
+    ret = cct->_conf->parse_argv(args,CODE_ENVIRONMENT_LIBRARY);
     if (ret)
 	return ret;
     cct->_conf->apply_changes(NULL);
@@ -199,7 +199,7 @@ public:
     md_config_t *conf = cct->_conf;
     vector<const char*> args;
     env_to_vec(args, name);
-    int ret = conf->parse_argv(args);
+    int ret = conf->parse_argv(args, CODE_ENVIRONMENT_LIBRARY);
     if (ret)
       return ret;
     conf->apply_changes(NULL);

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2461,7 +2461,7 @@ extern "C" int rados_conf_parse_argv(rados_t cluster, int argc, const char **arg
   md_config_t *conf = client->cct->_conf;
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
-  int ret = conf->parse_argv(args);
+  int ret = conf->parse_argv(args, CODE_ENVIRONMENT_LIBRARY);
   if (ret) {
     tracepoint(librados, rados_conf_parse_argv_exit, ret);
     return ret;
@@ -2490,7 +2490,7 @@ extern "C" int rados_conf_parse_argv_remainder(rados_t cluster, int argc,
   vector<const char*> args;
   for (int i=0; i<argc; i++)
     args.push_back(argv[i]);
-  int ret = conf->parse_argv(args);
+  int ret = conf->parse_argv(args, CODE_ENVIRONMENT_LIBRARY);
   if (ret) {
     tracepoint(librados, rados_conf_parse_argv_remainder_exit, ret);
     return ret;
@@ -2515,7 +2515,7 @@ extern "C" int rados_conf_parse_env(rados_t cluster, const char *env)
   md_config_t *conf = client->cct->_conf;
   vector<const char*> args;
   env_to_vec(args, env);
-  int ret = conf->parse_argv(args);
+  int ret = conf->parse_argv(args, CODE_ENVIRONMENT_LIBRARY);
   if (ret) {
     tracepoint(librados, rados_conf_parse_env_exit, ret);
     return ret;

--- a/src/test/daemon_config.cc
+++ b/src/test/daemon_config.cc
@@ -135,7 +135,7 @@ TEST(DaemonConfig, ArgV) {
   size_t argc = (sizeof(argv) / sizeof(argv[0])) - 1;
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
-  g_ceph_context->_conf->parse_argv(args);
+  g_ceph_context->_conf->parse_argv(args, CODE_ENVIRONMENT_DAEMON);
   g_ceph_context->_conf->apply_changes(NULL);
 
   char buf[128];

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -142,7 +142,7 @@ extern "C" int rados_conf_parse_env(rados_t cluster, const char *var) {
   md_config_t *conf = client->cct()->_conf;
   std::vector<const char*> args;
   env_to_vec(args, var);
-  int ret = conf->parse_argv(args);
+  int ret = conf->parse_argv(args, CODE_ENVIRONMENT_LIBRARY);
   if (ret == 0) {
     conf->apply_changes(NULL);
   }

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2957,8 +2957,6 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
       usage(cout);
       exit(0);
-    } else if (ceph_argparse_flag(args, i, "-f", "--force", (char*)NULL)) {
-      opts["force"] = "true";
     } else if (ceph_argparse_flag(args, i, "--force-full", (char*)NULL)) {
       opts["force-full"] = "true";
     } else if (ceph_argparse_flag(args, i, "-d", "--delete-after", (char*)NULL)) {

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2948,6 +2948,9 @@ int main(int argc, const char **argv)
   argv_to_vec(argc, argv, args);
   env_to_vec(args);
 
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+
   std::map < std::string, std::string > opts;
   std::vector<const char*>::iterator i;
   std::string val;
@@ -3057,8 +3060,6 @@ int main(int argc, const char **argv)
     cerr << "rados: you must give an action. Try --help" << std::endl;
     return 1;
   }
-  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
-  common_init_finish(g_ceph_context);
 
   return rados_tool_common(opts, args);
 }

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -182,6 +182,9 @@ void usage(ostream& out)
 "        Use radostriper interface rather than pure rados\n"
 "        Available for stat, get, put, truncate, rm, ls and \n"
 "        all xattr related operations\n"
+"   -f format\n"
+"   --format=format\n"
+"       Use the specified output format, valid options are xml and json"
 "\n"
 "BENCH OPTIONS:\n"
 "   -t N\n"
@@ -3020,7 +3023,7 @@ int main(int argc, const char **argv)
       opts["run-length"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--workers", (char*)NULL)) {
       opts["workers"] = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "--format", (char*)NULL)) {
+    } else if (ceph_argparse_witharg(args, i, &val, "-f", "--format", (char*)NULL)) {
       opts["format"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--lock-tag", (char*)NULL)) {
       opts["lock-tag"] = val;

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2948,9 +2948,6 @@ int main(int argc, const char **argv)
   argv_to_vec(argc, argv, args);
   env_to_vec(args);
 
-  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
-  common_init_finish(g_ceph_context);
-
   std::map < std::string, std::string > opts;
   std::vector<const char*>::iterator i;
   std::string val;
@@ -3060,6 +3057,8 @@ int main(int argc, const char **argv)
     cerr << "rados: you must give an action. Try --help" << std::endl;
     return 1;
   }
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
 
   return rados_tool_common(opts, args);
 }


### PR DESCRIPTION
Not completely sure whether this is the way yet.. here for review

The force option seems to be unused at the moment, removing it, also
this allows us to use the short flag alias `-f` for format, however since `-f` was already used by `foreground` by global_init this could be honored by moving global init after we parse arguments?

_EDIT_ Make description less confusing than it already is
