### PR TITLE
librbd: block maintenance ops until after journal is ready

### DIFF
--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -739,7 +739,8 @@ int Operations<I>::prepare_image_update() {
   {
     RWLock::WLocker owner_locker(m_image_ctx.owner_lock);
     if (m_image_ctx.exclusive_lock != nullptr &&
-        !m_image_ctx.exclusive_lock->is_lock_owner()) {
+        (!m_image_ctx.exclusive_lock->is_lock_owner() ||
+         !m_image_ctx.exclusive_lock->accept_requests())) {
       m_image_ctx.exclusive_lock->try_lock(&ctx);
       trying_lock = true;
     }


### PR DESCRIPTION
Ops were already blocked when the requests were received via
watch/notify.  Requests are now blocked for local requests as
well.

Fixes: #14510
Signed-off-by: Jason Dillaman <dillaman@redhat.com>