### PR TITLE
journal: flush commit position on metadata shutdown

### DIFF
--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -74,6 +74,8 @@ void JournalMetadata::shutdown() {
     }
   }
 
+  flush_commit_position();
+
   if (m_timer != NULL) {
     Mutex::Locker locker(m_timer_lock);
     m_timer->shutdown();


### PR DESCRIPTION
A crash was observed on JournalTrimmer destroy, which was called
by the Journaler after metadata shutdown. JournalTrimmer destructor
also calls flush_commit_position, but at that time metadata m_timer
is already null and it crushed there.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>