### PR TITLE
mon: PG Monitor should report waiting for backfill

### DIFF
--- a/doc/dev/placement-group.rst
+++ b/doc/dev/placement-group.rst
@@ -127,12 +127,12 @@ User-visible PG States
 *recovery_wait*
   the PG is waiting for the local/remote recovery reservations
 
-*backfill*
+*backfilling*
   a special case of recovery, in which the entire contents of
   the PG are scanned and synchronized, instead of inferring what
   needs to be transferred from the PG logs of recent operations
 
-*backfill-wait*
+*backfill_wait*
   the PG is waiting in line to start backfill
 
 *backfill_toofull*

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -2060,7 +2060,7 @@ void PGMonitor::get_health(list<pair<health_status_t,string> >& summary,
     if (p->first & PG_STATE_INCOMPLETE)
       note["incomplete"] += p->second;
     if (p->first & PG_STATE_BACKFILL_WAIT)
-      note["backfill"] += p->second;
+      note["backfill_wait"] += p->second;
     if (p->first & PG_STATE_BACKFILL)
       note["backfilling"] += p->second;
     if (p->first & PG_STATE_BACKFILL_TOOFULL)


### PR DESCRIPTION
Instead of backfill (as the state is `wait_backfill`)

Fixes: #12744