### PR TITLE
systemd: Add systemd sandboxing to services.

### DIFF
--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -11,6 +11,10 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
+PrivateDevices=yes
+ProtectHome=true
+ProtectSystem=full
+PrivateTmp=true
 
 [Install]
 WantedBy=ceph-mds.target

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -17,6 +17,10 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
+PrivateDevices=yes
+ProtectHome=true
+ProtectSystem=full
+PrivateTmp=true
 
 [Install]
 WantedBy=ceph-mon.target

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -12,6 +12,9 @@ Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecStartPre=/usr/libexec/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
+ProtectHome=true
+ProtectSystem=full
+PrivateTmp=true
 
 [Install]
 WantedBy=ceph-osd.target

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -10,6 +10,10 @@ LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
+PrivateDevices=yes
+ProtectHome=true
+ProtectSystem=full
+PrivateTmp=true
 
 [Install]
 WantedBy=ceph-radosgw.target


### PR DESCRIPTION
This change makes it so the mon/osd/mds/radosgw daemons:
    o Cannot write to /usr, /etc, and /boot.
    o Cannot access /home, /root, or /run/user.
    o Each daemon gets its own private /tmp and /var/tmp.
    o All daemons get a private /dev without physical devices (exception: osd)

I'm not sure if the osd daemon needs access to a full /dev so I left
ProtectDevices out for ceph-osd@.service.

Signed-off-by: Patrick Donnelly <batrick@batbytes.com>