### PR TITLE
rgw: don't use s->bucket for metadata api path entry

### DIFF
--- a/src/rgw/rgw_rest_metadata.cc
+++ b/src/rgw/rgw_rest_metadata.cc
@@ -32,8 +32,8 @@ static inline void frame_metadata_key(req_state *s, string& out) {
   string key = s->info.args.get("key", &exists);
 
   string section;
-  if (!s->bucket_name.empty()) {
-    section = s->bucket_name;
+  if (!s->init_state.url_bucket.empty()) {
+    section = s->init_state.url_bucket;
   } else {
     section = key;
     key.clear();


### PR DESCRIPTION
Fixes #14549

s->bucket is only initialized at the object store handler (post auth
callback). We don't want to initialize it for other cases because
it's not a real bucket, and initializing it will require going through
the authorization path for this 'bucket'.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>