### PR TITLE
rgw: remove duplicated code in RGWRados::get_bucket_info()

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7661,8 +7661,6 @@ int RGWRados::get_bucket_info(RGWObjectCtx& obj_ctx,
 
   ldout(cct, 20) << "rgw_get_bucket_info: bucket instance: " << entry_point.bucket << dendl;
 
-  if (pattrs)
-    pattrs->clear();
 
   /* read bucket instance info */
 


### PR DESCRIPTION
The effect of line 7664-7665 is the same as the line 7658-7660

Signed-off-by: liyankun <lioveni99@gmail.com>