### PR TITLE
hammer: rbd-replay does not check for EOF and goes to endless loop

### DIFF
--- a/src/rbd_replay/BufferReader.cc
+++ b/src/rbd_replay/BufferReader.cc
@@ -10,7 +10,7 @@ namespace rbd_replay {
 
 BufferReader::BufferReader(int fd, size_t min_bytes, size_t max_bytes)
   : m_fd(fd), m_min_bytes(min_bytes), m_max_bytes(max_bytes),
-    m_bl_it(m_bl.begin()) {
+    m_bl_it(m_bl.begin()), m_eof_reached(false) {
   assert(m_min_bytes <= m_max_bytes);
 }
 
@@ -18,10 +18,13 @@ int BufferReader::fetch(bufferlist::iterator **it) {
   if (m_bl_it.get_remaining() < m_min_bytes) {
     ssize_t bytes_to_read = ROUND_UP_TO(m_max_bytes - m_bl_it.get_remaining(),
                                         CEPH_PAGE_SIZE);
-    while (bytes_to_read > 0) {
+    while (!m_eof_reached && bytes_to_read > 0) {
       int r = m_bl.read_fd(m_fd, CEPH_PAGE_SIZE);
       if (r < 0) {
         return r;
+      }
+      if (r == 0) {
+	m_eof_reached = true;
       }
       assert(r <= bytes_to_read);
       bytes_to_read -= r;

--- a/src/rbd_replay/BufferReader.h
+++ b/src/rbd_replay/BufferReader.h
@@ -25,6 +25,7 @@ private:
   size_t m_max_bytes;
   bufferlist m_bl;
   bufferlist::iterator m_bl_it;
+  bool m_eof_reached;
 
 };
 

--- a/src/rbd_replay/Replayer.cc
+++ b/src/rbd_replay/Replayer.cc
@@ -222,6 +222,9 @@ void Replayer::run(const std::string& replay_file) {
                       << std::endl;
             exit(-r);
           }
+	  if (it->get_remaining() == 0) {
+	    break;
+	  }
 
           if (versioned) {
             action_entry.decode(*it);
@@ -229,7 +232,7 @@ void Replayer::run(const std::string& replay_file) {
             action_entry.decode_unversioned(*it);
           }
         } catch (const buffer::error &err) {
-          std::cerr << "Failed to decode trace action" << std::endl;
+          std::cerr << "Failed to decode trace action: " << err.what() << std::endl;
           exit(1);
         }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/14466