### PR TITLE
mon:some cleanup in MonmapMonitor.cc

### DIFF
--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -240,10 +240,6 @@ bool MonmapMonitor::preprocess_command(MonOpRequestRef op)
     if (p != mon->monmap)
        delete p;
   }
-  else if (prefix == "mon add")
-    return false;
-  else if (prefix == "mon remove")
-    return false;
 
 reply:
   if (r != -1) {
@@ -580,18 +576,5 @@ int MonmapMonitor::get_monmap(bufferlist &bl)
             << cpp_strerror(err) << dendl;
     return err;
   }
-  return 0;
-}
-
-int MonmapMonitor::get_monmap(MonMap &m)
-{
-  dout(10) << __func__ << dendl;
-  bufferlist monmap_bl;
-
-  int err = get_monmap(monmap_bl);
-  if (err < 0) {
-    return err;
-  }
-  m.decode(monmap_bl);
   return 0;
 }

--- a/src/mon/MonmapMonitor.h
+++ b/src/mon/MonmapMonitor.h
@@ -71,7 +71,6 @@ class MonmapMonitor : public PaxosService {
 		  list<pair<health_status_t,string> > *detail) const;
 
   int get_monmap(bufferlist &bl);
-  int get_monmap(MonMap &m);
 
   /*
    * Since monitors are pretty


### PR DESCRIPTION
remove the processing of  ”mon add“ && “mon remove” in the preprocess_command;
delete unused "get_monmap(MonMap &m)" 

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>