### PR TITLE
os/bluestore: fix bluestore_wal_transaction_t encoding test

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -258,7 +258,7 @@ struct bluestore_wal_op_t {
     OP_COPY = 2,
     OP_ZERO = 4,
   } type_t;
-  __u8 op;
+  __u8 op = 0;
   bluestore_extent_t extent;
   bluestore_extent_t src_extent;
   uint64_t src_rmw_head, src_rmw_tail;


### PR DESCRIPTION
bluestore_wal_op_t::op is encoded/dumped but it is not
initialized in its ctor. so set it to 0 in its ctor. 0 is not an
valid op though, but it helps with debugging and testing.

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 4d30e7cf2174e11fc8b19bda8f4034ff212d06d3)
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>

Need to backport this for tests to pass on Jewel