### PR TITLE
infernalis: rbd: TaskFinisher::cancel should remove event from SafeTimer

### DIFF
--- a/src/librbd/TaskFinisher.h
+++ b/src/librbd/TaskFinisher.h
@@ -45,6 +45,7 @@ public:
     typename TaskContexts::iterator it = m_task_contexts.find(task);
     if (it != m_task_contexts.end()) {
       delete it->second.first;
+      m_safe_timer->cancel_event(it->second.second);
       m_task_contexts.erase(it);
     }
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/14552