### PR TITLE
tools/rados: fix wrong op/object sizes in rand/seq bench

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -230,6 +230,8 @@ int ObjBencher::aio_bench(
         cerr << "Must write data before running a read benchmark!" << std::endl;
       return r;
     }
+    object_size = prev_object_size;   
+    op_size = prev_op_size;           
   }
 
   char* contentsChars = new char[op_size];


### PR DESCRIPTION
Metadata contain correct information about last bench write run, yet
these are ignored in subsequent bench rand/seq runs, resulting in
wrong perf numbers and failures when not using --no-verify.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>