### PR TITLE
man: document listwatchers cmd in "rados" manpage

### DIFF
--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -81,6 +81,9 @@ Pool specific commands
 :command:`rm` *name*
   Remove object name.
 
+:command:`listwatchers` *name*
+  List the watchers of object name.
+
 :command:`ls` *outfile*
   List objects in given pool and write to outfile.
 

--- a/man/rados.8
+++ b/man/rados.8
@@ -132,6 +132,9 @@ Write object name to the cluster with contents from infile.
 .B \fBrm\fP \fIname\fP
 Remove object name.
 .TP
+.B \fBlistwatchers\fP \fIname\fP
+List the watchers of object name.
+.TP
 .B \fBls\fP \fIoutfile\fP
 List objects in given pool and write to outfile.
 .TP


### PR DESCRIPTION
http://tracker.ceph.com/issues/14441

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit c2e391301efc43f0b431e89737246b2c43bf10a9)

man/rados.8: also added the rendered man.8 man page, as we don't
             put the generated man pages in master anymore. but
             they are still in the hammer's source repo.