### PR TITLE
OSD/PGBackend interface cleanup

### DIFF
--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -104,7 +104,6 @@ public:
   /// Write
   void touch(
     const hobject_t &hoid) {
-    bufferlist bl;
     ops.push_back(TouchOp(hoid));
   }
   void append(

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -555,8 +555,8 @@
 		pair<bufferlist*, Context*> > > &to_read,
      Context *on_complete, bool fast_read = false) = 0;
 
-   virtual bool scrub_supported() { return false; }
-   virtual bool auto_repair_supported() const { return false; }
+   virtual bool scrub_supported() = 0;
+   virtual bool auto_repair_supported() const = 0;
    void be_scan_list(
      ScrubMap &map, const vector<hobject_t> &ls, bool deep, uint32_t seed,
      ThreadPool::TPHandle &handle);
@@ -585,12 +585,12 @@
      const vector<int> &acting,
      ostream &errorstream);
    virtual uint64_t be_get_ondisk_size(
-     uint64_t logical_size) { assert(0); return 0; }
+     uint64_t logical_size) = 0;
    virtual void be_deep_scrub(
      const hobject_t &poid,
      uint32_t seed,
      ScrubMap::object &o,
-     ThreadPool::TPHandle &handle) { assert(0); }
+     ThreadPool::TPHandle &handle) = 0;
 
    static PGBackend *build_pg_backend(
      const pg_pool_t &pool,

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -434,6 +434,8 @@ private:
   void sub_op_modify_applied(RepModifyRef rm);
   void sub_op_modify_commit(RepModifyRef rm);
   bool scrub_supported() { return true; }
+  bool auto_repair_supported() const { return false; }
+
 
   void be_deep_scrub(
     const hobject_t &obj,


### PR DESCRIPTION
The patch uniforms abstract methods declaration for PGBackend and moves method implementation correctness check from run-time to a compiler.