### PR TITLE
[backport] rgw: fix wrong etag calculation during POST on S3 bucket.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2025,6 +2025,7 @@ void RGWPostObj::execute()
     goto done;
   }
 
+  processor->complete_hash(&hash);
   hash.Final(m);
   buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
 


### PR DESCRIPTION
Hi all!

I've backported useful thing to hammer, closing http://tracker.ceph.com/issues/14570.
(cherry picked from commit 742906a)

We've tested this patch on hammer together with #7441 in our testing env and it perfectly works.
Any comments or thought are welcome.