### PR TITLE
rgw: approximate AmazonS3 HostId error field.

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1141,6 +1141,8 @@ struct req_state {
 
    string trans_id;
 
+   string host_id;
+
    req_info info;
    req_init_state init_state;
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -557,6 +557,7 @@ static int process_request(RGWRados *store, RGWREST *rest, RGWRequest *req, RGWC
 
   s->req_id = store->unique_id(req->id);
   s->trans_id = store->unique_trans_id(req->id);
+  s->host_id = store->host_id;
 
   req->log_format(s, "initializing for trans_id = %s", s->trans_id.c_str());
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1358,6 +1358,19 @@ public:
     zone_name = name;
   }
 
+  /**
+   * AmazonS3 errors contain a HostId string, but is an opaque base64 blob; we
+   * try to be more transparent. This has a wrapper so we can update it when region/zone are changed.
+   */
+  void init_host_id() {
+    /* uint64_t needs 16, two '-' separators and a trailing null */
+    char charbuf[16 + zone.name.size() + region.name.size() + 2 + 1];
+    snprintf(charbuf, sizeof(charbuf), "%llx-%s-%s", (unsigned long long)instance_id(), zone.name.c_str(), region.name.c_str());
+    string s(charbuf);
+    host_id = s;
+  }
+
+  string host_id;
   RGWRegion region;
   RGWZoneParams zone; /* internal zone params, e.g., rados pools */
   RGWZone zone_public_config; /* external zone params, e.g., entrypoints, log flags, etc. */

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -174,6 +174,8 @@ static set<string> hostnames_s3website_set;
 
 void rgw_rest_init(CephContext *cct, RGWRegion& region)
 {
+  region.store->init_host_id();
+
   for (const auto& rgw2http : base_rgw_to_http_attrs)  {
     rgw_to_http_attrs[rgw2http.rgw_attr] = rgw2http.http_attr;
   }
@@ -624,7 +626,7 @@ void end_header(struct req_state *s, RGWOp *op, const char *content_type, const 
       s->formatter->dump_string("BucketName", s->bucket_name);
     if (!s->trans_id.empty()) // TODO: connect to expose_bucket or another toggle
       s->formatter->dump_string("RequestId", s->trans_id);
-    s->formatter->dump_string("HostId", "FIXME-TODO-How-does-amazon-generate-HostId"); // TODO, FIXME
+    s->formatter->dump_string("HostId", s->host_id);
     if (s->format != RGW_FORMAT_HTML) {
       s->formatter->close_section();
     }


### PR DESCRIPTION
S3Website mode has a HostId error field, it was left as a placeholder during development, but now contains a useful value (includes region & zone & instance id).

Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>