### PR TITLE
mon: compact full epochs also

### DIFF
--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -383,6 +383,9 @@ void PaxosService::trim(MonitorDBStore::TransactionRef t,
   if (g_conf->mon_compact_on_trim) {
     dout(20) << " compacting prefix " << get_service_name() << dendl;
     t->compact_range(get_service_name(), stringify(from - 1), stringify(to));
+    t->compact_range(get_service_name(),
+		     mon->store->combine_strings(full_prefix_name, from - 1),
+		     mon->store->combine_strings(full_prefix_name, to));
   }
 }
 


### PR DESCRIPTION
by compacting the ${prefix}.${start}..${prefix}..${end} does not
necessary compact the range of ${prefix}."full_"${start}..
${prefix}."full_"${end}. so when more and more epochs get trimmed
with out a full range compaction, the size of monitor store could
be very large.

Fixes: #14537
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 93d633a25ad8c36c972bb766c38187e2612041e1)