### PR TITLE
filestore: disable lockdep on collectionindex rwlock

### DIFF
--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -138,7 +138,14 @@ int lockdep_register(const char *name)
   pthread_mutex_lock(&lockdep_mutex);
   ceph::unordered_map<std::string, int>::iterator p = lock_ids.find(name);
   if (p == lock_ids.end()) {
-    assert(!free_ids.empty());
+    if (free_ids.empty()) {
+      lockdep_dout(0) << "ERROR OUT OF IDS .. have " << free_ids.size()
+		      << " max " << MAX_LOCKS << dendl;
+      for (auto& p : lock_names) {
+	lockdep_dout(0) << "  lock " << p.first << " " << p.second << dendl;
+      }
+      assert(free_ids.empty());
+    }
     id = free_ids.front();
     free_ids.pop_front();
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -627,7 +627,7 @@ int BlueStore::OnodeHashLRU::trim(int max)
 BlueStore::Collection::Collection(BlueStore *ns, coll_t c)
   : store(ns),
     cid(c),
-    lock("BlueStore::Collection::lock"),
+    lock("BlueStore::Collection::lock", true, false),
     exists(true),
     onode_map(),
     enode_set(g_conf->bluestore_onode_map_size)

--- a/src/os/filestore/CollectionIndex.h
+++ b/src/os/filestore/CollectionIndex.h
@@ -73,7 +73,6 @@ protected:
   };
  public:
 
-  string access_lock_name;
   RWLock access_lock;
   /// Type of returned paths
   typedef ceph::shared_ptr<Path> IndexedPath;
@@ -177,8 +176,7 @@ protected:
   virtual int prep_delete() { return 0; }
 
   CollectionIndex(const coll_t& collection):
-    access_lock_name ("CollectionIndex::access_lock::" + collection.to_str()),
-    access_lock(access_lock_name.c_str()) {}
+    access_lock("CollectionIndex::access_lock", true, false) {}
 
   /*
    * Pre-hash the collection, this collection should map to a PG folder.

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -584,7 +584,7 @@ int KStore::OnodeHashLRU::trim(int max)
 KStore::Collection::Collection(KStore *ns, coll_t c)
   : store(ns),
     cid(c),
-    lock("KStore::Collection::lock"),
+    lock("KStore::Collection::lock", true, false),
     onode_map()
 {
 }

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -245,7 +245,8 @@ public:
 
     Collection(CephContext *cct)
       : cct(cct), use_page_set(cct->_conf->memstore_page_set),
-        lock("MemStore::Collection::lock"), exists(true) {}
+        lock("MemStore::Collection::lock", true, false),
+	exists(true) {}
   };
   typedef Collection::Ref CollectionRef;
 


### PR DESCRIPTION
This routinely overflows the lockdep table in my vstart tests.