### PR TITLE
Bug #14348 fix

### DIFF
--- a/src/Makefile-server.am
+++ b/src/Makefile-server.am
@@ -1,4 +1,4 @@
-ceph_sbin_SCRIPTS = ceph-create-keys
+ceph_sbin_SCRIPTS = ceph-create-keys ceph-custom-daemon
 
 bin_SCRIPTS += \
 	ceph-run \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -120,6 +120,8 @@ EXTRA_DIST += \
 EXTRA_DIST += \
 	unittest_bufferlist.sh
 
+EXTRA_DIST += \
+	ceph-custom-daemon
 
 # work around old versions of automake that don't define $docdir
 # NOTE: this won't work on suse, where docdir is /usr/share/doc/packages/$package.

--- a/src/ceph-custom-daemon
+++ b/src/ceph-custom-daemon
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Wrapping script to call CEPH daemons with %clustername.%daemonid
+# i.e. mycluster.mon1, joecluster.2 or maryclustername.mds3
+#
+usage() {
+	echo "Usage: ceph-custom-daemon <daemon> [<cluster>.]<id> [ <daemon-options> ]"
+	echo "	<daemon> ::= mon | mds | osd | create-keys | radosgw"
+	exit 1
+}
+
+if [ "$1" != "mon" -a "$1" != "osd" -a "$1" != "mds" -a "$1" != "create-keys" -a "$1" != "radosgw" -o -z "$2" ] ; then
+	usage
+	exit 1
+fi
+
+case "$1" in
+	mon) binary=ceph-mon ;;
+	mds) binary=ceph-mds ;;
+	osd) binary=ceph-osd ;;
+	create-keys) binary=ceph-create-keys ;;
+	radosgw) binary=radosgw ;;
+esac
+
+if echo "$2" | grep -q "\." ; then
+	cluster=`echo $2 | cut -f 1 -d .`
+	objid=`echo $2 | cut -f 2 -d .`
+else
+	cluster=ceph
+	objid="$2"
+fi
+shift 2
+
+if [ "$binary" = "ceph-create-keys" ] ; then
+	if [ -f /var/lib/ceph/bootstrap-mds/$cluster.keyring ] ; then
+		echo "Keys for cluster $cluster already exists, won't rewrite"
+		exit 0
+	fi
+fi
+
+exec $binary --cluster ${cluster} --id $objid $@

--- a/src/ceph-custom-daemon
+++ b/src/ceph-custom-daemon
@@ -3,6 +3,8 @@
 # Wrapping script to call CEPH daemons with %clustername.%daemonid
 # i.e. mycluster.mon1, joecluster.2 or maryclustername.mds3
 #
+# If cluster name is omitted "ceph" suggested
+#
 usage() {
 	echo "Usage: ceph-custom-daemon <daemon> [<cluster>.]<id> [ <daemon-options> ]"
 	echo "	<daemon> ::= mon | mds | osd | create-keys | radosgw"

--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -2132,18 +2132,22 @@ def start_daemon(
                     ],
                 )
         elif os.path.exists(os.path.join(path, 'systemd')):
-            command_check_call(
-                [
-                    'systemctl',
-                    'enable',
-                    'ceph-osd@{osd_id}'.format(osd_id=osd_id),
-                    ],
-                )
+#
+#            We don't need to enable because systemd will use ceph-osd@.service file
+#
+#            command_check_call(
+#                [
+#                    'systemctl',
+#                    'enable',
+#                    'ceph-osd@{cluster}.{osd_id}'.format(cluster=cluster,osd_id=osd_id),
+#                    ],
+#                )
+#
             command_check_call(
                 [
                     'systemctl',
                     'start',
-                    'ceph-osd@{osd_id}'.format(osd_id=osd_id),
+                    'ceph-osd@{cluster}.{osd_id}'.format(cluster=cluster,osd_id=osd_id),
                     ],
                 )
         else:

--- a/src/ceph-osd-prestart.sh
+++ b/src/ceph-osd-prestart.sh
@@ -1,14 +1,25 @@
 #!/bin/sh
 
-eval set -- "$(getopt -o i: --long id:,cluster: -- $@)"
+eval set -- "$(getopt -o i: --long id:,cluster:,node:,setuser:,setgroup: -- $@)"
 
-while true ; do
+while [ "$1" != "" ] ; do
 	case "$1" in
-		-i|--id) id=$2; shift 2 ;;
-		--cluster) cluster=$2; shift 2 ;;
-		--) shift ; break ;;
+		-i|--id) id=$2; shift ;;
+		--cluster) cluster=$2; shift ;;
+		--node) node=$2 ; shift ;;
 	esac
+	shift
 done
+
+if [ "$id" = "" ] ; then
+	if echo "$node" | grep -q "\." ; then
+		cluster=`echo "$node" | cut -f 1 -d "."`
+		id=`echo "$node" | cut -f 2 -d "."`
+	else
+		id="$node"
+		cluster="ceph"
+	fi
+fi
 
 if [ -z "$id"  ]; then
     echo "Usage: $0 [OPTIONS]"

--- a/systemd/ceph-create-keys@.service
+++ b/systemd/ceph-create-keys@.service
@@ -7,4 +7,4 @@ ConditionPathExists=!/var/lib/ceph/bootstrap-mds/ceph.keyring
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-ExecStart=/usr/sbin/ceph-create-keys --cluster ${CLUSTER} --id %i
+ExecStart=/usr/sbin/ceph-custom-daemon create-keys %i

--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -9,7 +9,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/sbin/ceph-custom-daemon mds %i -f --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -14,8 +14,7 @@ PartOf=ceph-mon.target
 LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
-Environment=CLUSTER=ceph
-ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/sbin/ceph-custom-daemon mon %i -f --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -9,8 +9,8 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecStartPre=/usr/libexec/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/sbin/ceph-custom-daemon osd %i -f --setuser ceph --setgroup ceph
+ExecStartPre=/usr/libexec/ceph/ceph-osd-prestart.sh --node %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
Fix for http://tracker.ceph.com/issues/14348
The old naming schema is stile supported:
service start ceph-mon@mon0.service does exactly what did before
