### PR TITLE
time: Have skewing-now call non-skewing now

### DIFF
--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -22,13 +22,10 @@
 namespace ceph {
   namespace time_detail {
     real_clock::time_point real_clock::now(const CephContext* cct) noexcept {
-      struct timespec ts;
-      clock_gettime(CLOCK_REALTIME, &ts);
-      // TODO: After we get the time-literal configuration patch in,
-      // just add the configured duration.
+      auto t = now();
       if (cct)
-	ts.tv_sec += cct->_conf->clock_offset;
-      return from_timespec(ts);
+	t += make_timespan(cct->_conf->clock_offset);
+      return t;
     }
 
     void real_clock::to_ceph_timespec(const time_point& t,
@@ -48,13 +45,10 @@ namespace ceph {
 
     coarse_real_clock::time_point coarse_real_clock::now(
       const CephContext* cct) noexcept {
-      struct timespec ts;
-      clock_gettime(CLOCK_REALTIME_COARSE, &ts);
-      // TODO: After we get the time-literal configuration patch in,
-      // just add the configured duration.
+      auto t = now();
       if (cct)
-	ts.tv_sec += cct->_conf->clock_offset;
-      return from_timespec(ts);
+	t += make_timespan(cct->_conf->clock_offset);
+      return t;
     }
 
     void coarse_real_clock::to_ceph_timespec(const time_point& t,

--- a/src/test/common/test_time.cc
+++ b/src/test/common/test_time.cc
@@ -56,8 +56,7 @@ static constexpr double bd = bs + ((double)bns / 1000000000.);
 
 template<typename Clock>
 static void system_clock_sanity() {
-  static constexpr typename Clock::time_point brt(seconds(bs)
-						  + nanoseconds(bns));
+  static const typename Clock::time_point brt(seconds(bs) + nanoseconds(bns));
   const typename Clock::time_point now(Clock::now());
 
   ASSERT_GT(now, brt);


### PR DESCRIPTION
For the real-time clocks, Ceph's testing infrastructure likes to be able to
inject a skew. To avoid pulling CephContext into ceph_time.h these are moved to
ceph_time.cc. The original way this was done called clock_gettime in both
places.

This is an unnecessary duplication and apparently error-prone. So only call
clock_gettime from one place.

Signed-off-by: Adam C. Emerson <aemerson@redhat.com>