### PR TITLE
osd: fix scrub start hobject

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3994,9 +3994,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  scrubber.reserved_peers.clear();
 	}
 
-        scrubber.start = hobject_t();
         // Don't include temporary objects when scrubbing
-        scrubber.start.pool = info.pgid.pool();
+        scrubber.start = info.pgid.pgid.get_hobj_start();
         scrubber.state = PG::Scrubber::NEW_CHUNK;
 
 	{


### PR DESCRIPTION
This avoids tripping over bluestore's assert that the object start be either MIN or fall within
the PG interval.