### PR TITLE
osd: Repair metadata on corrupted PG repair. bugfix#14521

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2917,9 +2917,15 @@ void OSD::load_pgs()
     epoch_t map_epoch = 0;
     int r = PG::peek_map_epoch(store, pgid, &map_epoch, &bl);
     if (r < 0) {
-      derr << __func__ << " unable to peek at " << pgid << " metadata, skipping"
-	   << dendl;
-      continue;
+	derr << __func__ << " unable to peek at " << pgid <<
+	  " metadata, repairing" << dendl;
+      PG::repair_meta(store, pgid);
+      r = PG::peek_map_epoch(store, pgid, &map_epoch, &bl);
+      if (r < 0) {
+	derr << __func__ << " unable to peek at " << pgid <<
+	  " metadata, skipping" << dendl;
+	continue;
+      }
     }
 
     PG *pg = NULL;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2775,6 +2775,37 @@ void PG::_init(ObjectStore::Transaction& t, spg_t pgid, const pg_pool_t *pool)
   t.omap_setkeys(coll, pgmeta_oid, values);
 }
 
+void PG::_repair_meta(ObjectStore *store, const coll_t& coll,
+    const ghobject_t& pgmeta_oid, ObjectStore::Sequencer* osr)
+{
+  ObjectStore::Transaction t;
+
+  if (store->exists(coll, pgmeta_oid))
+    return;
+
+  t.remove(coll, pgmeta_oid); // Removes oid from fdcache
+  t.touch(coll, pgmeta_oid);
+
+  map<string,bufferlist> v;
+  __u8 ver = cur_struct_v;
+  ::encode(ver, v[infover_key]);
+  t.omap_setkeys(coll, pgmeta_oid, v);
+
+  int r = store->apply_transaction(osr, t);
+  assert(r == 0);
+}
+
+void PG::repair_meta(ObjectStore *store, spg_t pgid)
+{
+  coll_t coll(pgid);
+  ghobject_t pgmeta_oid(pgid.make_pgmeta_oid());
+
+  ceph::shared_ptr<ObjectStore::Sequencer> osr(
+    new ObjectStore::Sequencer("repair_meta"));
+
+  _repair_meta(store, coll, pgmeta_oid, osr.get());
+}
+
 void PG::prepare_write_info(map<string,bufferlist> *km)
 {
   info.stats.stats.add(unstable_stats);
@@ -4371,6 +4402,9 @@ void PG::scrub_finish()
 
   // type-specific finish (can tally more errors)
   _scrub_finish();
+
+  if (repair)
+    _repair_meta(osd->store, coll, pgmeta_oid, osr.get());
 
   bool has_error = scrub_process_inconsistent();
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2044,6 +2044,9 @@ public:
      const PGPool &pool, spg_t p);
   virtual ~PG();
 
+  static void _repair_meta(ObjectStore *store, const coll_t& coll,
+      const ghobject_t& oid, ObjectStore::Sequencer* osr);
+
  private:
   // Prevent copying
   explicit PG(const PG& rhs);
@@ -2205,6 +2208,8 @@ public:
   static bool _has_removal_flag(ObjectStore *store, spg_t pgid);
   static int peek_map_epoch(ObjectStore *store, spg_t pgid,
 			    epoch_t *pepoch, bufferlist *bl);
+  static void repair_meta(ObjectStore *store, spg_t pgid);
+
   void update_snap_map(
     const vector<pg_log_entry_t> &log_entries,
     ObjectStore::Transaction& t);


### PR DESCRIPTION
Test case:
1. Start 2 OSDs, 8 PGs, pool size = 2
2. Run write workload for some time.
3. Stop workload
4. rm -rf dev/osd0/current/0.2_head/*
5. ceph osd scrub 0
6. ceph pg repair 0.2
7. Restart OSD.
8. Get "error (17) File exists not handled on operation"

The root cause is that "head" meta file wasn't restored by pg repair. So
all omap_get/setkeys fail for that PG.

On restart load_pgs skips that PG because it can't read metadata, but later when
OSD tries to recreate PG it hit the error from the test case, because
all the data files are in place, restored by repair.

http://tracker.ceph.com/issues/14521
