### PR TITLE
CMake: For CMake version <= 2.8.11, use LINK_PRIVATE and LINK_PUBLIC 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -411,11 +411,12 @@ add_library(librados ${CEPH_SHARED} ${librados_srcs}
   $<TARGET_OBJECTS:heap_profiler_objs>
   $<TARGET_OBJECTS:common_util_obj>)
 add_dependencies(librados osdc)
-target_link_libraries(librados PRIVATE osdc osd os global common cls_lock_client
+# LINK_PRIVATE instead of PRIVATE is used to backward compatibility with cmake 2.8.11
+target_link_libraries(librados LINK_PRIVATE osdc osd os global common cls_lock_client
   ${BLKID_LIBRARIES}
   ${CRYPTO_LIBS} ${EXTRALIBS} ${ALLOC_LIBS})
 if(${WITH_LTTNG})
-  target_link_libraries(librados PUBLIC librados_tp)
+  target_link_libraries(librados librados_tp)
 endif(${WITH_LTTNG})
 if(${ENABLE_SHARED})
   set_target_properties(librados PROPERTIES OUTPUT_NAME rados VERSION 2.0.0
@@ -910,7 +911,7 @@ if(WITH_LIBCEPHFS)
     $<TARGET_OBJECTS:cls_references_objs>
     $<TARGET_OBJECTS:heap_profiler_objs>
     $<TARGET_OBJECTS:common_util_obj>)
-  target_link_libraries(cephfs PRIVATE client osdc osd os global common cls_lock_client
+  target_link_libraries(cephfs LINK_PRIVATE client osdc osd os global common cls_lock_client
     ${BLKID_LIBRARIES}
     ${CRYPTO_LIBS} ${EXTRALIBS} ${ALLOC_LIBS})
 if(${ENABLE_SHARED})
@@ -1023,11 +1024,11 @@ if(${WITH_RBD})
   add_library(librbd ${CEPH_SHARED} ${librbd_srcs}
     $<TARGET_OBJECTS:osdc_rbd_objs>
     $<TARGET_OBJECTS:common_util_obj>)
-  target_link_libraries(librbd PRIVATE librados common journal
+  target_link_libraries(librbd LINK_PRIVATE librados common journal
     cls_lock_client cls_rbd_client cls_journal_client udev
     ${CMAKE_DL_LIBS})
   if(${WITH_LTTNG})
-    target_link_libraries(librbd PUBLIC librbd_tp)
+    target_link_libraries(librbd librbd_tp)
   endif(${WITH_LTTNG})
   if(${ENABLE_SHARED})
     set_target_properties(librbd PROPERTIES VERSION "1.0.0" SOVERSION "1"

--- a/src/rbd_replay/CMakeLists.txt
+++ b/src/rbd_replay/CMakeLists.txt
@@ -10,7 +10,7 @@ set(librbd_replay_srcs
     rbd_loc.cc
     Replayer.cc)
 add_library(rbd_replay STATIC ${librbd_replay_srcs})
-target_link_libraries(rbd_replay PRIVATE librbd librados global)
+target_link_libraries(rbd_replay LINK_PRIVATE librbd librados global)
 
 add_executable(rbd-replay
   rbd-replay.cc


### PR DESCRIPTION
For CMake version <=2.8.11 ,it has no PUBLIC and PRIVATE keywords. It should use LINK_PRIVATE and LINK_PUBLIC instread to compile

Signed-off-by: changtao <changtao@hihuron.com>