### PR TITLE
rgw: do not include "expat.h" in heade file

### DIFF
--- a/src/rgw/rgw_acl_s3.h
+++ b/src/rgw/rgw_acl_s3.h
@@ -9,8 +9,6 @@
 #include <iosfwd>
 #include <include/types.h>
 
-#include <expat.h>
-
 #include "include/str_list.h"
 #include "rgw_xml.h"
 #include "rgw_acl.h"

--- a/src/rgw/rgw_xml.cc
+++ b/src/rgw/rgw_xml.cc
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <map>
 
+#include <expat.h>
+
 #include "include/types.h"
 
 #include "rgw_common.h"

--- a/src/rgw/rgw_xml.h
+++ b/src/rgw/rgw_xml.h
@@ -10,8 +10,6 @@
 #include <include/types.h>
 #include <common/Formatter.h>
 
-#include <expat.h>
-
 using namespace std;
 
 
@@ -61,9 +59,10 @@ public:
   friend ostream& operator<<(ostream& out, XMLObj& obj);
 };
 
+struct XML_ParserStruct;
 class RGWXMLParser : public XMLObj
 {
-  XML_Parser p;
+  XML_ParserStruct *p;
   char *buf;
   int buf_len;
   XMLObj *cur_obj;


### PR DESCRIPTION
this is a follow-up of #6772.

Building Ceph without the Expat development library currently results in
the following build error:

~/ceph> ./configure --without-fuse --without-tcmalloc --without-radosgw
...
~/ceph> make
...
CXX ceph_dencoder-rgw_dencoder.o
In file included from rgw/rgw_dencoder.cc:6:0:
rgw/rgw_acl_s3.h:9:19: fatal error: expat.h: No such file or directory

The ceph-dencoder binary is built with rgw_dencoder.cc, which includes
rgw_acl_s3.h, which in turn includes expat.h. However, configure.ac
currently only checks for Expat as part of radosgw.

but we don't need expat.h for testing the encoding of rgw structs, so
move "#include <expat.h>" into the source file to avoid this dependency.
and as a side effect, this also speed up the compilation.

Signed-off-by: Kefu Chai <kchai@redhat.com>