### PR TITLE
hammer: auth: use libnss more safely

### DIFF
--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -62,7 +62,20 @@ uint64_t get_random(uint64_t min_val, uint64_t max_val)
   return r;
 }
 
+
 // ---------------------------------------------------
+
+class CryptoNoneKeyHandler : public CryptoKeyHandler {
+public:
+  void encrypt(const bufferlist& in,
+	       bufferlist& out, std::string &error) const {
+    out = in;
+  }
+  void decrypt(const bufferlist& in,
+	       bufferlist& out, std::string &error) const {
+    out = in;
+  }
+};
 
 class CryptoNone : public CryptoHandler {
 public:
@@ -71,38 +84,20 @@ public:
   int get_type() const {
     return CEPH_CRYPTO_NONE;
   }
-  int create(bufferptr& secret);
-  int validate_secret(bufferptr& secret);
-  void encrypt(const bufferptr& secret, const bufferlist& in,
-	      bufferlist& out, std::string &error) const;
-  void decrypt(const bufferptr& secret, const bufferlist& in,
-	      bufferlist& out, std::string &error) const;
+  int create(bufferptr& secret) {
+    return 0;
+  }
+  int validate_secret(const bufferptr& secret) {
+    return 0;
+  }
+  CryptoKeyHandler *get_key_handler(const bufferptr& secret, string& error) {
+    return new CryptoNoneKeyHandler;
+  }
 };
-
-int CryptoNone::create(bufferptr& secret)
-{
-  return 0;
-}
-
-int CryptoNone::validate_secret(bufferptr& secret)
-{
-  return 0;
-}
-
-void CryptoNone::encrypt(const bufferptr& secret, const bufferlist& in,
-			 bufferlist& out, std::string &error) const
-{
-  out = in;
-}
-
-void CryptoNone::decrypt(const bufferptr& secret, const bufferlist& in,
-			 bufferlist& out, std::string &error) const
-{
-  out = in;
-}
 
 
 // ---------------------------------------------------
+
 
 class CryptoAES : public CryptoHandler {
 public:
@@ -112,172 +107,29 @@ public:
     return CEPH_CRYPTO_AES;
   }
   int create(bufferptr& secret);
-  int validate_secret(bufferptr& secret);
-  void encrypt(const bufferptr& secret, const bufferlist& in,
-	       bufferlist& out, std::string &error) const;
-  void decrypt(const bufferptr& secret, const bufferlist& in,
-	      bufferlist& out, std::string &error) const;
+  int validate_secret(const bufferptr& secret);
+  CryptoKeyHandler *get_key_handler(const bufferptr& secret, string& error);
 };
-
 
 #ifdef USE_CRYPTOPP
 # define AES_KEY_LEN     ((size_t)CryptoPP::AES::DEFAULT_KEYLENGTH)
 # define AES_BLOCK_LEN   ((size_t)CryptoPP::AES::BLOCKSIZE)
-#elif USE_NSS
-// when we say AES, we mean AES-128
-# define AES_KEY_LEN	16
-# define AES_BLOCK_LEN   16
 
-static void nss_aes_operation(CK_ATTRIBUTE_TYPE op, const bufferptr& secret,
-			     const bufferlist& in, bufferlist& out, std::string &error)
-{
-  const CK_MECHANISM_TYPE mechanism = CKM_AES_CBC_PAD;
-
-  // sample source said this has to be at least size of input + 8,
-  // but i see 15 still fail with SEC_ERROR_OUTPUT_LEN
-  bufferptr out_tmp(in.length()+16);
-
-  bufferlist incopy;
-
-  PK11SlotInfo *slot;
-
-  slot = PK11_GetBestSlot(mechanism, NULL);
-  if (!slot) {
-    ostringstream oss;
-    oss << "cannot find NSS slot to use: " << PR_GetError();
-    error = oss.str();
-    goto err;
+class CryptoAESKeyHandler : public CryptoKeyHandler {
+public:
+  int init(const bufferptr& s, ostringstream& err) {
+    secret = s;
+    return 0;
   }
 
-  SECItem keyItem;
-
-  keyItem.type = siBuffer;
-  keyItem.data = (unsigned char*)secret.c_str();
-  keyItem.len = secret.length();
-
-  PK11SymKey *key;
-
-  key = PK11_ImportSymKey(slot, mechanism, PK11_OriginUnwrap, CKA_ENCRYPT,
-			  &keyItem, NULL);
-  if (!key) {
-    ostringstream oss;
-    oss << "cannot convert AES key for NSS: " << PR_GetError();
-    error = oss.str();
-    goto err_slot;
-  }
-
-  SECItem ivItem;
-
-  ivItem.type = siBuffer;
-  // losing constness due to SECItem.data; IV should never be
-  // modified, regardless
-  ivItem.data = (unsigned char*)CEPH_AES_IV;
-  ivItem.len = sizeof(CEPH_AES_IV);
-
-  SECItem *param;
-
-  param = PK11_ParamFromIV(mechanism, &ivItem);
-  if (!param) {
-    ostringstream oss;
-    oss << "cannot set NSS IV param: " << PR_GetError();
-    error = oss.str();
-    goto err_key;
-  }
-
-  PK11Context *ctx;
-
-  ctx = PK11_CreateContextBySymKey(mechanism, op, key, param);
-  if (!ctx) {
-    ostringstream oss;
-    oss << "cannot create NSS context: " << PR_GetError();
-    error = oss.str();
-    goto err_param;
-  }
-
-  SECStatus ret;
-  int written;
-  unsigned char *in_buf;
-
-  incopy = in;  // it's a shallow copy!
-  in_buf = (unsigned char*)incopy.c_str();
-  ret = PK11_CipherOp(ctx,
-		      (unsigned char*)out_tmp.c_str(), &written, out_tmp.length(),
-		      in_buf, in.length());
-  if (ret != SECSuccess) {
-    ostringstream oss;
-    oss << "NSS AES failed: " << PR_GetError();
-    error = oss.str();
-    goto err_op;
-  }
-
-  unsigned int written2;
-  ret = PK11_DigestFinal(ctx, (unsigned char*)out_tmp.c_str()+written, &written2,
-			 out_tmp.length()-written);
-  if (ret != SECSuccess) {
-    ostringstream oss;
-    oss << "NSS AES final round failed: " << PR_GetError();
-    error = oss.str();
-    goto err_op;
-  }
-
-  out_tmp.set_length(written + written2);
-  out.append(out_tmp);
-
-  PK11_DestroyContext(ctx, PR_TRUE);
-  SECITEM_FreeItem(param, PR_TRUE);
-  PK11_FreeSymKey(key);
-  PK11_FreeSlot(slot);
-  return;
-
- err_op:
-  PK11_DestroyContext(ctx, PR_TRUE);
- err_param:
-  SECITEM_FreeItem(param, PR_TRUE);
- err_key:
-  PK11_FreeSymKey(key);
- err_slot:
-  PK11_FreeSlot(slot);
- err:
-  ;
-}
-
-#else
-# error "No supported crypto implementation found."
-#endif
-
-int CryptoAES::create(bufferptr& secret)
-{
-  bufferlist bl;
-  int r = get_random_bytes(AES_KEY_LEN, bl);
-  if (r < 0)
-    return r;
-  secret = buffer::ptr(bl.c_str(), bl.length());
-  return 0;
-}
-
-int CryptoAES::validate_secret(bufferptr& secret)
-{
-  if (secret.length() < (size_t)AES_KEY_LEN) {
-    return -EINVAL;
-  }
-
-  return 0;
-}
-
-void CryptoAES::encrypt(const bufferptr& secret, const bufferlist& in, bufferlist& out,
-			std::string &error) const
-{
-  if (secret.length() < AES_KEY_LEN) {
-    error = "key is too short";
-    return;
-  }
-#ifdef USE_CRYPTOPP
-  {
+  void encrypt(const bufferlist& in,
+	       bufferlist& out, std::string &error) const {
     const unsigned char *key = (const unsigned char *)secret.c_str();
 
     string ciphertext;
     CryptoPP::AES::Encryption aesEncryption(key, CryptoPP::AES::DEFAULT_KEYLENGTH);
-    CryptoPP::CBC_Mode_ExternalCipher::Encryption cbcEncryption( aesEncryption, (const byte*)CEPH_AES_IV );
+    CryptoPP::CBC_Mode_ExternalCipher::Encryption cbcEncryption(
+      aesEncryption, (const byte*)CEPH_AES_IV);
     CryptoPP::StringSink *sink = new CryptoPP::StringSink(ciphertext);
     CryptoPP::StreamTransformationFilter stfEncryptor(cbcEncryption, sink);
 
@@ -296,108 +148,274 @@ void CryptoAES::encrypt(const bufferptr& secret, const bufferlist& in, bufferlis
     }
     out.append((const char *)ciphertext.c_str(), ciphertext.length());
   }
-#elif USE_NSS
-  nss_aes_operation(CKA_ENCRYPT, secret, in, out, error);
-#else
-# error "No supported crypto implementation found."
-#endif
-}
 
-void CryptoAES::decrypt(const bufferptr& secret, const bufferlist& in, 
-			bufferlist& out, std::string &error) const
-{
-#ifdef USE_CRYPTOPP
-  const unsigned char *key = (const unsigned char *)secret.c_str();
+  void decrypt(const bufferlist& in,
+	       bufferlist& out, std::string &error) const {
+    const unsigned char *key = (const unsigned char *)secret.c_str();
 
-  CryptoPP::AES::Decryption aesDecryption(key, CryptoPP::AES::DEFAULT_KEYLENGTH);
-  CryptoPP::CBC_Mode_ExternalCipher::Decryption cbcDecryption( aesDecryption, (const byte*)CEPH_AES_IV );
+    CryptoPP::AES::Decryption aesDecryption(key, CryptoPP::AES::DEFAULT_KEYLENGTH);
+    CryptoPP::CBC_Mode_ExternalCipher::Decryption cbcDecryption(
+      aesDecryption, (const byte*)CEPH_AES_IV );
 
-  string decryptedtext;
-  CryptoPP::StringSink *sink = new CryptoPP::StringSink(decryptedtext);
-  CryptoPP::StreamTransformationFilter stfDecryptor(cbcDecryption, sink);
-  for (std::list<bufferptr>::const_iterator it = in.buffers().begin(); 
-       it != in.buffers().end(); ++it) {
+    string decryptedtext;
+    CryptoPP::StringSink *sink = new CryptoPP::StringSink(decryptedtext);
+    CryptoPP::StreamTransformationFilter stfDecryptor(cbcDecryption, sink);
+    for (std::list<bufferptr>::const_iterator it = in.buffers().begin();
+	 it != in.buffers().end(); ++it) {
       const unsigned char *in_buf = (const unsigned char *)it->c_str();
       stfDecryptor.Put(in_buf, it->length());
+    }
+
+    try {
+      stfDecryptor.MessageEnd();
+    } catch (CryptoPP::Exception& e) {
+      ostringstream oss;
+      oss << "decryptor.MessageEnd::Exception: " << e.GetWhat();
+      error = oss.str();
+      return;
+    }
+
+    out.append((const char *)decryptedtext.c_str(), decryptedtext.length());
+  }
+};
+
+#elif USE_NSS
+// when we say AES, we mean AES-128
+# define AES_KEY_LEN	16
+# define AES_BLOCK_LEN   16
+
+static void nss_aes_operation(CK_ATTRIBUTE_TYPE op,
+			      const bufferptr& secret,
+			      const bufferlist& in, bufferlist& out,
+			      std::string& error)
+{
+  CK_MECHANISM_TYPE mechanism = CKM_AES_CBC_PAD;
+  PK11SlotInfo *slot;
+  PK11SymKey *key;
+  SECItem *param;
+
+  slot = PK11_GetBestSlot(mechanism, NULL);
+  if (!slot) {
+    ostringstream err;
+    err << "cannot find NSS slot to use: " << PR_GetError();
+    error = err.str();
+    return;
   }
 
-  try {
-    stfDecryptor.MessageEnd();
-  } catch (CryptoPP::Exception& e) {
+  SECItem keyItem;
+  keyItem.type = siBuffer;
+  keyItem.data = (unsigned char*)secret.c_str();
+  keyItem.len = secret.length();
+  key = PK11_ImportSymKey(slot, mechanism, PK11_OriginUnwrap, CKA_ENCRYPT,
+			  &keyItem, NULL);
+  if (!key) {
+    ostringstream err;
+    err << "cannot convert AES key for NSS: " << PR_GetError();
+    error = err.str();
+    return;
+  }
+
+  SECItem ivItem;
+  ivItem.type = siBuffer;
+  // losing constness due to SECItem.data; IV should never be
+  // modified, regardless
+  ivItem.data = (unsigned char*)CEPH_AES_IV;
+  ivItem.len = sizeof(CEPH_AES_IV);
+
+  param = PK11_ParamFromIV(mechanism, &ivItem);
+  if (!param) {
+    ostringstream err;
+    err << "cannot set NSS IV param: " << PR_GetError();
+    error = err.str();
+    return;
+  }
+
+  // sample source said this has to be at least size of input + 8,
+  // but i see 15 still fail with SEC_ERROR_OUTPUT_LEN
+  bufferptr out_tmp(in.length()+16);
+  bufferlist incopy;
+
+  SECStatus ret;
+  int written;
+  unsigned char *in_buf;
+
+  PK11Context *ectx;
+  ectx = PK11_CreateContextBySymKey(mechanism, op, key, param);
+  assert(ectx);
+
+  incopy = in;  // it's a shallow copy!
+  in_buf = (unsigned char*)incopy.c_str();
+  ret = PK11_CipherOp(ectx,
+		      (unsigned char*)out_tmp.c_str(), &written, out_tmp.length(),
+		      in_buf, in.length());
+  if (ret != SECSuccess) {
     ostringstream oss;
-    oss << "decryptor.MessageEnd::Exception: " << e.GetWhat();
+    oss << "NSS AES failed: " << PR_GetError();
     error = oss.str();
     return;
   }
 
-  out.append((const char *)decryptedtext.c_str(), decryptedtext.length());
-#elif USE_NSS
-  nss_aes_operation(CKA_DECRYPT, secret, in, out, error);
+  unsigned int written2;
+  ret = PK11_DigestFinal(ectx,
+			 (unsigned char*)out_tmp.c_str()+written, &written2,
+			 out_tmp.length()-written);
+  if (ret != SECSuccess) {
+    ostringstream oss;
+    oss << "NSS AES final round failed: " << PR_GetError();
+    error = oss.str();
+    return;
+  }
+
+  PK11_DestroyContext(ectx, PR_TRUE);
+  SECITEM_FreeItem(param, PR_TRUE);
+  PK11_FreeSymKey(key);
+  PK11_FreeSlot(slot);
+
+  out_tmp.set_length(written + written2);
+  out.append(out_tmp);
+}
+
+class CryptoAESKeyHandler : public CryptoKeyHandler {
+public:
+  int init(const bufferptr& s, ostringstream& err) {
+    secret = s;
+    return 0;
+  }
+
+  void encrypt(const bufferlist& in,
+	       bufferlist& out, std::string &error) const {
+    nss_aes_operation(CKA_ENCRYPT, secret, in, out, error);
+  }
+  void decrypt(const bufferlist& in,
+	       bufferlist& out, std::string &error) const {
+    nss_aes_operation(CKA_DECRYPT, secret, in, out, error);
+  }
+};
+
 #else
 # error "No supported crypto implementation found."
 #endif
+
+
+
+// ------------------------------------------------------------
+
+int CryptoAES::create(bufferptr& secret)
+{
+  bufferlist bl;
+  int r = get_random_bytes(AES_KEY_LEN, bl);
+  if (r < 0)
+    return r;
+  secret = buffer::ptr(bl.c_str(), bl.length());
+  return 0;
 }
+
+int CryptoAES::validate_secret(const bufferptr& secret)
+{
+  if (secret.length() < (size_t)AES_KEY_LEN) {
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+CryptoKeyHandler *CryptoAES::get_key_handler(const bufferptr& secret,
+					     string& error)
+{
+  CryptoAESKeyHandler *ckh = new CryptoAESKeyHandler;
+  ostringstream oss;
+  if (ckh->init(secret, oss) < 0) {
+    error = oss.str();
+    return NULL;
+  }
+  return ckh;
+}
+
+
+
+
+// --
 
 
 // ---------------------------------------------------
 
-int CryptoKey::set_secret(CephContext *cct, int type, bufferptr& s)
+
+void CryptoKey::encode(bufferlist& bl) const
 {
-  this->type = type;
-  created = ceph_clock_now(cct);
+  ::encode(type, bl);
+  ::encode(created, bl);
+  __u16 len = secret.length();
+  ::encode(len, bl);
+  bl.append(secret);
+}
 
-  CryptoHandler *h = cct->get_crypto_handler(type);
-  if (!h) {
-    lderr(cct) << "ERROR: cct->get_crypto_handler(type=" << type << ") returned NULL" << dendl;
-    return -EOPNOTSUPP;
+void CryptoKey::decode(bufferlist::iterator& bl)
+{
+  ::decode(type, bl);
+  ::decode(created, bl);
+  __u16 len;
+  ::decode(len, bl);
+  bufferptr tmp;
+  bl.copy(len, tmp);
+  if (_set_secret(type, tmp) < 0)
+    throw buffer::malformed_input("malformed secret");
+}
+
+int CryptoKey::set_secret(int type, const bufferptr& s, utime_t c)
+{
+  int r = _set_secret(type, s);
+  if (r < 0)
+    return r;
+  this->created = c;
+  return 0;
+}
+
+int CryptoKey::_set_secret(int t, const bufferptr& s)
+{
+  if (s.length() == 0) {
+    secret = s;
+    ckh.reset();
+    return 0;
   }
-  int ret = h->validate_secret(s);
 
-  if (ret < 0)
-    return ret;
-
+  CryptoHandler *ch = CryptoHandler::create(t);
+  if (ch) {
+    int ret = ch->validate_secret(s);
+    if (ret < 0) {
+      delete ch;
+      return ret;
+    }
+    string error;
+    ckh.reset(ch->get_key_handler(s, error));
+    delete ch;
+    if (error.length()) {
+      return -EIO;
+    }
+  }
+  type = t;
   secret = s;
-
   return 0;
 }
 
 int CryptoKey::create(CephContext *cct, int t)
 {
-  type = t;
-  created = ceph_clock_now(cct);
-
-  CryptoHandler *h = cct->get_crypto_handler(type);
-  if (!h) {
-    lderr(cct) << "ERROR: cct->get_crypto_handler(type=" << type << ") returned NULL" << dendl;
+  CryptoHandler *ch = CryptoHandler::create(t);
+  if (!ch) {
+    if (cct)
+      lderr(cct) << "ERROR: cct->get_crypto_handler(type=" << t << ") returned NULL" << dendl;
     return -EOPNOTSUPP;
   }
-  return h->create(secret);
-}
+  bufferptr s;
+  int r = ch->create(s);
+  delete ch;
+  if (r < 0)
+    return r;
 
-void CryptoKey::encrypt(CephContext *cct, const bufferlist& in, bufferlist& out, std::string &error) const
-{
-  if (!ch || ch->get_type() != type) {
-    ch = cct->get_crypto_handler(type);
-    if (!ch) {
-      ostringstream oss;
-      oss << "CryptoKey::encrypt: key type " << type << " not supported.";
-      return;
-    }
-  }
-  ch->encrypt(this->secret, in, out, error);
-}
-
-void CryptoKey::decrypt(CephContext *cct, const bufferlist& in, bufferlist& out, std::string &error) const
-{
-  if (!ch || ch->get_type() != type) {
-    ch = cct->get_crypto_handler(type);
-    if (!ch) {
-      ostringstream oss;
-      oss << "CryptoKey::decrypt: key type " << type << " not supported.";
-      return;
-    }
-  }
-  ch->decrypt(this->secret, in, out, error);
+  r = _set_secret(t, s);
+  if (r < 0)
+    return r;
+  created = ceph_clock_now(cct);
+  return r;
 }
 
 void CryptoKey::print(std::ostream &out) const

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -185,51 +185,12 @@ public:
 # define AES_BLOCK_LEN   16
 
 static void nss_aes_operation(CK_ATTRIBUTE_TYPE op,
-			      const bufferptr& secret,
+			      CK_MECHANISM_TYPE mechanism,
+			      PK11SymKey *key,
+			      SECItem *param,
 			      const bufferlist& in, bufferlist& out,
-			      std::string& error)
+			      std::string &error)
 {
-  CK_MECHANISM_TYPE mechanism = CKM_AES_CBC_PAD;
-  PK11SlotInfo *slot;
-  PK11SymKey *key;
-  SECItem *param;
-
-  slot = PK11_GetBestSlot(mechanism, NULL);
-  if (!slot) {
-    ostringstream err;
-    err << "cannot find NSS slot to use: " << PR_GetError();
-    error = err.str();
-    return;
-  }
-
-  SECItem keyItem;
-  keyItem.type = siBuffer;
-  keyItem.data = (unsigned char*)secret.c_str();
-  keyItem.len = secret.length();
-  key = PK11_ImportSymKey(slot, mechanism, PK11_OriginUnwrap, CKA_ENCRYPT,
-			  &keyItem, NULL);
-  if (!key) {
-    ostringstream err;
-    err << "cannot convert AES key for NSS: " << PR_GetError();
-    error = err.str();
-    return;
-  }
-
-  SECItem ivItem;
-  ivItem.type = siBuffer;
-  // losing constness due to SECItem.data; IV should never be
-  // modified, regardless
-  ivItem.data = (unsigned char*)CEPH_AES_IV;
-  ivItem.len = sizeof(CEPH_AES_IV);
-
-  param = PK11_ParamFromIV(mechanism, &ivItem);
-  if (!param) {
-    ostringstream err;
-    err << "cannot set NSS IV param: " << PR_GetError();
-    error = err.str();
-    return;
-  }
-
   // sample source said this has to be at least size of input + 8,
   // but i see 15 still fail with SEC_ERROR_OUTPUT_LEN
   bufferptr out_tmp(in.length()+16);
@@ -249,6 +210,7 @@ static void nss_aes_operation(CK_ATTRIBUTE_TYPE op,
 		      (unsigned char*)out_tmp.c_str(), &written, out_tmp.length(),
 		      in_buf, in.length());
   if (ret != SECSuccess) {
+    PK11_DestroyContext(ectx, PR_TRUE);
     ostringstream oss;
     oss << "NSS AES failed: " << PR_GetError();
     error = oss.str();
@@ -259,36 +221,80 @@ static void nss_aes_operation(CK_ATTRIBUTE_TYPE op,
   ret = PK11_DigestFinal(ectx,
 			 (unsigned char*)out_tmp.c_str()+written, &written2,
 			 out_tmp.length()-written);
+  PK11_DestroyContext(ectx, PR_TRUE);
   if (ret != SECSuccess) {
+    PK11_DestroyContext(ectx, PR_TRUE);
     ostringstream oss;
     oss << "NSS AES final round failed: " << PR_GetError();
     error = oss.str();
     return;
   }
 
-  PK11_DestroyContext(ectx, PR_TRUE);
-  SECITEM_FreeItem(param, PR_TRUE);
-  PK11_FreeSymKey(key);
-  PK11_FreeSlot(slot);
-
   out_tmp.set_length(written + written2);
   out.append(out_tmp);
 }
 
 class CryptoAESKeyHandler : public CryptoKeyHandler {
+  CK_MECHANISM_TYPE mechanism;
+  PK11SlotInfo *slot;
+  PK11SymKey *key;
+  SECItem *param;
+
 public:
+  CryptoAESKeyHandler()
+    : mechanism(CKM_AES_CBC_PAD),
+      slot(NULL),
+      key(NULL),
+      param(NULL) {}
+  ~CryptoAESKeyHandler() {
+    SECITEM_FreeItem(param, PR_TRUE);
+    PK11_FreeSymKey(key);
+    PK11_FreeSlot(slot);
+  }
+
   int init(const bufferptr& s, ostringstream& err) {
     secret = s;
+
+    slot = PK11_GetBestSlot(mechanism, NULL);
+    if (!slot) {
+      err << "cannot find NSS slot to use: " << PR_GetError();
+      return -1;
+    }
+
+    SECItem keyItem;
+    keyItem.type = siBuffer;
+    keyItem.data = (unsigned char*)secret.c_str();
+    keyItem.len = secret.length();
+    key = PK11_ImportSymKey(slot, mechanism, PK11_OriginUnwrap, CKA_ENCRYPT,
+			    &keyItem, NULL);
+    if (!key) {
+      err << "cannot convert AES key for NSS: " << PR_GetError();
+      return -1;
+    }
+
+    SECItem ivItem;
+    ivItem.type = siBuffer;
+    // losing constness due to SECItem.data; IV should never be
+    // modified, regardless
+    ivItem.data = (unsigned char*)CEPH_AES_IV;
+    ivItem.len = sizeof(CEPH_AES_IV);
+
+    param = PK11_ParamFromIV(mechanism, &ivItem);
+    if (!param) {
+      err << "cannot set NSS IV param: " << PR_GetError();
+      return -1;
+    }
+
     return 0;
   }
 
   void encrypt(const bufferlist& in,
 	       bufferlist& out, std::string &error) const {
-    nss_aes_operation(CKA_ENCRYPT, secret, in, out, error);
+    nss_aes_operation(CKA_ENCRYPT, mechanism, key, param, in, out, error);
   }
   void decrypt(const bufferlist& in,
 	       bufferlist& out, std::string &error) const {
-    nss_aes_operation(CKA_DECRYPT, secret, in, out, error);
+    nss_aes_operation(CKA_DECRYPT, mechanism, key, param, in, out, error);
   }
 };
 

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -67,13 +67,15 @@ uint64_t get_random(uint64_t min_val, uint64_t max_val)
 
 class CryptoNoneKeyHandler : public CryptoKeyHandler {
 public:
-  void encrypt(const bufferlist& in,
-	       bufferlist& out, std::string &error) const {
+  int encrypt(const bufferlist& in,
+	       bufferlist& out, std::string *error) const {
     out = in;
+    return 0;
   }
-  void decrypt(const bufferlist& in,
-	       bufferlist& out, std::string &error) const {
+  int decrypt(const bufferlist& in,
+	      bufferlist& out, std::string *error) const {
     out = in;
+    return 0;
   }
 };
 
@@ -139,8 +141,8 @@ public:
     return 0;
   }
 
-  void encrypt(const bufferlist& in,
-	       bufferlist& out, std::string &error) const {
+  int encrypt(const bufferlist& in,
+	      bufferlist& out, std::string *error) const {
     string ciphertext;
     CryptoPP::StringSink *sink = new CryptoPP::StringSink(ciphertext);
     CryptoPP::CBC_Mode_ExternalCipher::Encryption cbc(
@@ -155,16 +157,19 @@ public:
     try {
       stfEncryptor.MessageEnd();
     } catch (CryptoPP::Exception& e) {
-      ostringstream oss;
-      oss << "encryptor.MessageEnd::Exception: " << e.GetWhat();
-      error = oss.str();
-      return;
+      if (error) {
+	ostringstream oss;
+	oss << "encryptor.MessageEnd::Exception: " << e.GetWhat();
+	*error = oss.str();
+      }
+      return -1;
     }
     out.append((const char *)ciphertext.c_str(), ciphertext.length());
+    return 0;
   }
 
-  void decrypt(const bufferlist& in,
-	       bufferlist& out, std::string &error) const {
+  int decrypt(const bufferlist& in,
+	      bufferlist& out, std::string *error) const {
     string decryptedtext;
     CryptoPP::StringSink *sink = new CryptoPP::StringSink(decryptedtext);
     CryptoPP::CBC_Mode_ExternalCipher::Decryption cbc(
@@ -179,13 +184,16 @@ public:
     try {
       stfDecryptor.MessageEnd();
     } catch (CryptoPP::Exception& e) {
-      ostringstream oss;
-      oss << "decryptor.MessageEnd::Exception: " << e.GetWhat();
-      error = oss.str();
-      return;
+      if (error) {
+	ostringstream oss;
+	oss << "decryptor.MessageEnd::Exception: " << e.GetWhat();
+	*error = oss.str();
+      }
+      return -1;
     }
 
     out.append((const char *)decryptedtext.c_str(), decryptedtext.length());
+    return 0;
   }
 };
 
@@ -194,12 +202,12 @@ public:
 # define AES_KEY_LEN	16
 # define AES_BLOCK_LEN   16
 
-static void nss_aes_operation(CK_ATTRIBUTE_TYPE op,
-			      CK_MECHANISM_TYPE mechanism,
-			      PK11SymKey *key,
-			      SECItem *param,
-			      const bufferlist& in, bufferlist& out,
-			      std::string &error)
+static int nss_aes_operation(CK_ATTRIBUTE_TYPE op,
+			     CK_MECHANISM_TYPE mechanism,
+			     PK11SymKey *key,
+			     SECItem *param,
+			     const bufferlist& in, bufferlist& out,
+			     std::string *error)
 {
   // sample source said this has to be at least size of input + 8,
   // but i see 15 still fail with SEC_ERROR_OUTPUT_LEN
@@ -221,10 +229,12 @@ static void nss_aes_operation(CK_ATTRIBUTE_TYPE op,
 		      in_buf, in.length());
   if (ret != SECSuccess) {
     PK11_DestroyContext(ectx, PR_TRUE);
-    ostringstream oss;
-    oss << "NSS AES failed: " << PR_GetError();
-    error = oss.str();
-    return;
+    if (error) {
+      ostringstream oss;
+      oss << "NSS AES failed: " << PR_GetError();
+      *error = oss.str();
+    }
+    return -1;
   }
 
   unsigned int written2;
@@ -234,14 +244,17 @@ static void nss_aes_operation(CK_ATTRIBUTE_TYPE op,
   PK11_DestroyContext(ectx, PR_TRUE);
   if (ret != SECSuccess) {
     PK11_DestroyContext(ectx, PR_TRUE);
-    ostringstream oss;
-    oss << "NSS AES final round failed: " << PR_GetError();
-    error = oss.str();
-    return;
+    if (error) {
+      ostringstream oss;
+      oss << "NSS AES final round failed: " << PR_GetError();
+      *error = oss.str();
+    }
+    return -1;
   }
 
   out_tmp.set_length(written + written2);
   out.append(out_tmp);
+  return 0;
 }
 
 class CryptoAESKeyHandler : public CryptoKeyHandler {
@@ -298,13 +311,13 @@ public:
     return 0;
   }
 
-  void encrypt(const bufferlist& in,
-	       bufferlist& out, std::string &error) const {
-    nss_aes_operation(CKA_ENCRYPT, mechanism, key, param, in, out, error);
+  int encrypt(const bufferlist& in,
+	      bufferlist& out, std::string *error) const {
+    return nss_aes_operation(CKA_ENCRYPT, mechanism, key, param, in, out, error);
   }
-  void decrypt(const bufferlist& in,
-	       bufferlist& out, std::string &error) const {
-    nss_aes_operation(CKA_DECRYPT, mechanism, key, param, in, out, error);
+  int decrypt(const bufferlist& in,
+	       bufferlist& out, std::string *error) const {
+    return nss_aes_operation(CKA_DECRYPT, mechanism, key, param, in, out, error);
   }
 };
 

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -17,6 +17,7 @@
 
 #include "include/types.h"
 #include "include/utime.h"
+#include "include/memory.h"
 
 #include "common/Formatter.h"
 #include "include/buffer.h"
@@ -25,6 +26,22 @@
 
 class CephContext;
 class CryptoHandler;
+class CryptoKeyContext;
+
+/*
+ * some per-key context that is specific to a particular crypto backend
+ */
+class CryptoKeyHandler {
+public:
+  bufferptr secret;
+
+  virtual ~CryptoKeyHandler() {}
+
+  virtual void encrypt(const bufferlist& in,
+		       bufferlist& out, std::string &error) const = 0;
+  virtual void decrypt(const bufferlist& in,
+		       bufferlist& out, std::string &error) const = 0;
+};
 
 /*
  * match encoding of struct ceph_secret
@@ -33,38 +50,32 @@ class CryptoKey {
 protected:
   __u16 type;
   utime_t created;
-  bufferptr secret;
+  bufferptr secret;   // must set this via set_secret()!
 
-  // cache a pointer to the handler, so we don't have to look it up
-  // for each crypto operation
-  mutable CryptoHandler *ch;
+  // cache a pointer to the implementation-specific key handler, so we
+  // don't have to create it for every crypto operation.
+  mutable ceph::shared_ptr<CryptoKeyHandler> ckh;
+
+  int _set_secret(int type, const bufferptr& s);
 
 public:
-  CryptoKey() : type(0), ch(NULL) { }
-  CryptoKey(int t, utime_t c, bufferptr& s) : type(t), created(c), secret(s), ch(NULL) { }
+  CryptoKey() : type(0) { }
+  CryptoKey(int t, utime_t c, bufferptr& s)
+    : created(c) {
+    _set_secret(t, s);
+  }
+  ~CryptoKey() {
+  }
 
-  void encode(bufferlist& bl) const {
-    ::encode(type, bl);
-    ::encode(created, bl);
-    __u16 len = secret.length();
-    ::encode(len, bl);
-    bl.append(secret);
-  }
-  void decode(bufferlist::iterator& bl) {
-    ::decode(type, bl);
-    ::decode(created, bl);
-    __u16 len;
-    ::decode(len, bl);
-    bl.copy(len, secret);
-    secret.c_str();   // make sure it's a single buffer!
-  }
+  void encode(bufferlist& bl) const;
+  void decode(bufferlist::iterator& bl);
 
   int get_type() const { return type; }
   utime_t get_created() const { return created; }
   void print(std::ostream& out) const;
 
-  int set_secret(CephContext *cct, int type, bufferptr& s);
-  bufferptr& get_secret() { return secret; }
+  int set_secret(int type, const bufferptr& s, utime_t created);
+  const bufferptr& get_secret() { return secret; }
   const bufferptr& get_secret() const { return secret; }
 
   void encode_base64(string& s) const {
@@ -94,8 +105,14 @@ public:
 
   // --
   int create(CephContext *cct, int type);
-  void encrypt(CephContext *cct, const bufferlist& in, bufferlist& out, std::string &error) const;
-  void decrypt(CephContext *cct, const bufferlist& in, bufferlist& out, std::string &error) const;
+  void encrypt(CephContext *cct, const bufferlist& in, bufferlist& out,
+	       std::string &error) const {
+    ckh->encrypt(in, out, error);
+  }
+  void decrypt(CephContext *cct, const bufferlist& in, bufferlist& out,
+	       std::string &error) const {
+    ckh->decrypt(in, out, error);
+  }
 
   void to_str(std::string& s) const;
 };
@@ -119,11 +136,9 @@ public:
   virtual ~CryptoHandler() {}
   virtual int get_type() const = 0;
   virtual int create(bufferptr& secret) = 0;
-  virtual int validate_secret(bufferptr& secret) = 0;
-  virtual void encrypt(const bufferptr& secret, const bufferlist& in,
-		      bufferlist& out, std::string &error) const = 0;
-  virtual void decrypt(const bufferptr& secret, const bufferlist& in,
-		      bufferlist& out, std::string &error) const = 0;
+  virtual int validate_secret(const bufferptr& secret) = 0;
+  virtual CryptoKeyHandler *get_key_handler(const bufferptr& secret,
+					    string& error) = 0;
 
   static CryptoHandler *create(int type);
 };

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -124,39 +124,11 @@ public:
 		      bufferlist& out, std::string &error) const = 0;
   virtual void decrypt(const bufferptr& secret, const bufferlist& in,
 		      bufferlist& out, std::string &error) const = 0;
+
+  static CryptoHandler *create(int type);
 };
 
 extern int get_random_bytes(char *buf, int len);
 extern uint64_t get_random(uint64_t min_val, uint64_t max_val);
-
-class CryptoNone : public CryptoHandler {
-public:
-  CryptoNone() { }
-  ~CryptoNone() {}
-  int get_type() const {
-    return CEPH_CRYPTO_NONE;
-  }
-  int create(bufferptr& secret);
-  int validate_secret(bufferptr& secret);
-  void encrypt(const bufferptr& secret, const bufferlist& in,
-	      bufferlist& out, std::string &error) const;
-  void decrypt(const bufferptr& secret, const bufferlist& in,
-	      bufferlist& out, std::string &error) const;
-};
-
-class CryptoAES : public CryptoHandler {
-public:
-  CryptoAES() { }
-  ~CryptoAES() {}
-  int get_type() const {
-    return CEPH_CRYPTO_AES;
-  }
-  int create(bufferptr& secret);
-  int validate_secret(bufferptr& secret);
-  void encrypt(const bufferptr& secret, const bufferlist& in,
-	       bufferlist& out, std::string &error) const;
-  void decrypt(const bufferptr& secret, const bufferlist& in, 
-	      bufferlist& out, std::string &error) const;
-};
 
 #endif

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -37,10 +37,10 @@ public:
 
   virtual ~CryptoKeyHandler() {}
 
-  virtual void encrypt(const bufferlist& in,
-		       bufferlist& out, std::string &error) const = 0;
-  virtual void decrypt(const bufferlist& in,
-		       bufferlist& out, std::string &error) const = 0;
+  virtual int encrypt(const bufferlist& in,
+		       bufferlist& out, std::string *error) const = 0;
+  virtual int decrypt(const bufferlist& in,
+		       bufferlist& out, std::string *error) const = 0;
 };
 
 /*
@@ -105,13 +105,13 @@ public:
 
   // --
   int create(CephContext *cct, int type);
-  void encrypt(CephContext *cct, const bufferlist& in, bufferlist& out,
-	       std::string &error) const {
-    ckh->encrypt(in, out, error);
+  int encrypt(CephContext *cct, const bufferlist& in, bufferlist& out,
+	       std::string *error) const {
+    return ckh->encrypt(in, out, error);
   }
-  void decrypt(CephContext *cct, const bufferlist& in, bufferlist& out,
-	       std::string &error) const {
-    ckh->decrypt(in, out, error);
+  int decrypt(CephContext *cct, const bufferlist& in, bufferlist& out,
+	       std::string *error) const {
+    return ckh->decrypt(in, out, error);
   }
 
   void to_str(std::string& s) const;

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -268,7 +268,7 @@ bool KeyServer::generate_secret(CryptoKey& secret)
   if (crypto->create(bp) < 0)
     return false;
 
-  secret.set_secret(cct, CEPH_CRYPTO_AES, bp);
+  secret.set_secret(CEPH_CRYPTO_AES, bp, ceph_clock_now(NULL));
 
   return true;
 }

--- a/src/auth/cephx/CephxProtocol.h
+++ b/src/auth/cephx/CephxProtocol.h
@@ -433,8 +433,7 @@ void decode_decrypt_enc_bl(CephContext *cct, T& t, CryptoKey key, bufferlist& bl
   uint64_t magic;
   bufferlist bl;
 
-  key.decrypt(cct, bl_enc, bl, error);
-  if (!error.empty())
+  if (key.decrypt(cct, bl_enc, bl, &error) < 0)
     return;
 
   bufferlist::iterator iter2 = bl.begin();
@@ -462,7 +461,7 @@ void encode_encrypt_enc_bl(CephContext *cct, const T& t, const CryptoKey& key,
   ::encode(magic, bl);
   ::encode(t, bl);
 
-  key.encrypt(cct, bl, out, error);
+  key.encrypt(cct, bl, out, &error);
 }
 
 template <typename T>

--- a/src/auth/cephx/CephxSessionHandler.cc
+++ b/src/auth/cephx/CephxSessionHandler.cc
@@ -28,7 +28,6 @@ int CephxSessionHandler::_calc_signature(Message *m, uint64_t *psig)
 {
   const ceph_msg_header& header = m->get_header();
   const ceph_msg_footer& footer = m->get_footer();
-  std::string error;
 
   // optimized signature calculation
   // - avoid temporary allocated buffers from encode_encrypt[_enc_bl]
@@ -49,7 +48,10 @@ int CephxSessionHandler::_calc_signature(Message *m, uint64_t *psig)
   bl_plaintext.append(buffer::create_static(sizeof(sigblock), (char*)&sigblock));
 
   bufferlist bl_ciphertext;
-  key.encrypt(cct, bl_plaintext, bl_ciphertext, error);
+  if (key.encrypt(cct, bl_plaintext, bl_ciphertext, NULL) < 0) {
+    lderr(cct) << __func__ << " failed to encrypt signature block" << dendl;
+    return -1;
+  }
 
   bufferlist::iterator ci = bl_ciphertext.begin();
   ::decode(*psig, ci);

--- a/src/auth/cephx/CephxSessionHandler.cc
+++ b/src/auth/cephx/CephxSessionHandler.cc
@@ -24,47 +24,56 @@
 
 #define dout_subsys ceph_subsys_auth
 
+int CephxSessionHandler::_calc_signature(Message *m, uint64_t *psig)
+{
+  const ceph_msg_header& header = m->get_header();
+  const ceph_msg_footer& footer = m->get_footer();
+
+  bufferlist bl_plaintext;
+  ::encode(header.crc, bl_plaintext);
+  ::encode(footer.front_crc, bl_plaintext);
+  ::encode(footer.middle_crc, bl_plaintext);
+  ::encode(footer.data_crc, bl_plaintext);
+
+  bufferlist bl_encrypted;
+  std::string error;
+  if (encode_encrypt(cct, bl_plaintext, key, bl_encrypted, error)) {
+    ldout(cct, 0) << "error encrypting message signature: " << error << dendl;
+    ldout(cct, 0) << "no signature put on message" << dendl;
+    return SESSION_SIGNATURE_FAILURE;
+  }
+
+  bufferlist::iterator ci = bl_encrypted.begin();
+  // Skip the magic number up front. PLR
+  ci.advance(4);
+  ::decode(*psig, ci);
+  ldout(cct, 10) << __func__ << " seq " << m->get_seq()
+		 << " front_crc_ = " << footer.front_crc
+		 << " middle_crc = " << footer.middle_crc
+		 << " data_crc = " << footer.data_crc
+		 << " sig = " << *psig
+		 << dendl;
+  return 0;
+}
+
 int CephxSessionHandler::sign_message(Message *m)
 {
   // If runtime signing option is off, just return success without signing.
   if (!cct->_conf->cephx_sign_messages) {
     return 0;
   }
-  bufferlist bl_plaintext, bl_encrypted;
-  ceph_msg_header header = m->get_header();
-  std::string error;
 
-  ceph_msg_footer& en_footer = m->get_footer();
+  uint64_t sig;
+  int r = _calc_signature(m, &sig);
+  if (r < 0)
+    return r;
 
-  ::encode(header.crc, bl_plaintext);
-  ::encode(en_footer.front_crc, bl_plaintext);
-  ::encode(en_footer.middle_crc, bl_plaintext);
-  ::encode(en_footer.data_crc, bl_plaintext);
-
-  ldout(cct, 10) <<  "sign_message: seq # " << header.seq << " CRCs are: header " << header.crc
-		 << " front " << en_footer.front_crc << " middle " << en_footer.middle_crc
-		 << " data " << en_footer.data_crc << dendl;
-
-  if (encode_encrypt(cct, bl_plaintext, key, bl_encrypted, error)) {
-    ldout(cct, 0) << "error encrypting message signature: " << error << dendl;
-    ldout(cct, 0) << "no signature put on message" << dendl;
-    return SESSION_SIGNATURE_FAILURE;
-  } 
-
-  bufferlist::iterator ci = bl_encrypted.begin();
-  // Skip the magic number up front. PLR
-  ci.advance(4);
-  ::decode(en_footer.sig, ci);
-
-  // There's potentially an issue with whether the encoding and decoding done here will work
-  // properly when a big endian and little endian machine are talking.  We think it's OK,
-  // but it should be tested to be sure.  PLR
-
-  // Receiver won't trust this flag to decide if msg should have been signed.  It's primarily
-  // to debug problems where sender and receiver disagree on need to sign msg.  PLR
-  en_footer.flags = (unsigned)en_footer.flags | CEPH_MSG_FOOTER_SIGNED;
+  ceph_msg_footer& f = m->get_footer();
+  f.sig = sig;
+  f.flags = (unsigned)f.flags | CEPH_MSG_FOOTER_SIGNED;
   messages_signed++;
-  ldout(cct, 20) << "Putting signature in client message(seq # " << header.seq << "): sig = " << en_footer.sig << dendl;
+  ldout(cct, 20) << "Putting signature in client message(seq # " << m->get_seq()
+		 << "): sig = " << sig << dendl;
   return 0;
 }
 
@@ -74,57 +83,34 @@ int CephxSessionHandler::check_message_signature(Message *m)
   if (!cct->_conf->cephx_sign_messages) {
     return 0;
   }
-
-  bufferlist bl_plaintext, bl_ciphertext;
-  std::string sig_error;
-  ceph_msg_header& header = m->get_header();
-  ceph_msg_footer& footer = m->get_footer();
-
   if ((features & CEPH_FEATURE_MSG_AUTH) == 0) {
     // it's fine, we didn't negotiate this feature.
     return 0;
   }
 
+  uint64_t sig;
+  int r = _calc_signature(m, &sig);
+  if (r < 0)
+    return r;
+
   signatures_checked++;
 
-  ldout(cct, 10) << "check_message_signature: seq # = " << m->get_seq() << " front_crc_ = " << footer.front_crc
-		 << " middle_crc = " << footer.middle_crc << " data_crc = " << footer.data_crc << dendl;
-  ::encode(header.crc, bl_plaintext);
-  ::encode(footer.front_crc, bl_plaintext);
-  ::encode(footer.middle_crc, bl_plaintext);
-  ::encode(footer.data_crc, bl_plaintext);
-
-  // Encrypt the buffer containing the checksums to calculate the signature. PLR
-  if (encode_encrypt(cct, bl_plaintext, key, bl_ciphertext, sig_error)) {
-    ldout(cct, 0) << "error in encryption for checking message signature: " << sig_error << dendl;
-    return (SESSION_SIGNATURE_FAILURE);
-  } 
-
-  bufferlist::iterator ci = bl_ciphertext.begin();
-  // Skip the magic number at the front. PLR
-  ci.advance(4);
-  uint64_t sig_check;
-  ::decode(sig_check, ci);
-
-  // There's potentially an issue with whether the encoding and decoding done here will work
-  // properly when a big endian and little endian machine are talking.  We think it's OK,
-  // but it should be tested to be sure.  PLR
-
-  if (sig_check != footer.sig) {
+  if (sig != m->get_footer().sig) {
     // Should have been signed, but signature check failed.  PLR
-    if (!(footer.flags & CEPH_MSG_FOOTER_SIGNED)) {
-      ldout(cct, 0) << "SIGN: MSG " << header.seq << " Sender did not set CEPH_MSG_FOOTER_SIGNED." << dendl;
+    if (!(m->get_footer().flags & CEPH_MSG_FOOTER_SIGNED)) {
+      ldout(cct, 0) << "SIGN: MSG " << m->get_seq() << " Sender did not set CEPH_MSG_FOOTER_SIGNED." << dendl;
     }
-    ldout(cct, 0) << "SIGN: MSG " << header.seq << " Message signature does not match contents." << dendl;
-    ldout(cct, 0) << "SIGN: MSG " << header.seq << "Signature on message:" << dendl;
-    ldout(cct, 0) << "SIGN: MSG " << header.seq << "    sig: " << footer.sig << dendl;
-    ldout(cct, 0) << "SIGN: MSG " << header.seq << "Locally calculated signature:" << dendl;
-    ldout(cct, 0) << "SIGN: MSG " << header.seq << "    sig_check:" << sig_check << dendl;
+    ldout(cct, 0) << "SIGN: MSG " << m->get_seq() << " Message signature does not match contents." << dendl;
+    ldout(cct, 0) << "SIGN: MSG " << m->get_seq() << "Signature on message:" << dendl;
+    ldout(cct, 0) << "SIGN: MSG " << m->get_seq() << "    sig: " << m->get_footer().sig << dendl;
+    ldout(cct, 0) << "SIGN: MSG " << m->get_seq() << "Locally calculated signature:" << dendl;
+    ldout(cct, 0) << "SIGN: MSG " << m->get_seq() << "    sig_check:" << sig << dendl;
 
-    // For the moment, printing an error message to the log and returning failure is sufficient.
-    // In the long term, we should probably have code parsing the log looking for this kind
-    // of security failure, particularly when there are large numbers of them, since the latter
-    // is a potential sign of an attack.  PLR
+    // For the moment, printing an error message to the log and
+    // returning failure is sufficient.  In the long term, we should
+    // probably have code parsing the log looking for this kind of
+    // security failure, particularly when there are large numbers of
+    // them, since the latter is a potential sign of an attack.  PLR
 
     signatures_failed++;
     ldout(cct, 0) << "Signature failed." << dendl;

--- a/src/auth/cephx/CephxSessionHandler.cc
+++ b/src/auth/cephx/CephxSessionHandler.cc
@@ -28,25 +28,32 @@ int CephxSessionHandler::_calc_signature(Message *m, uint64_t *psig)
 {
   const ceph_msg_header& header = m->get_header();
   const ceph_msg_footer& footer = m->get_footer();
-
-  bufferlist bl_plaintext;
-  ::encode(header.crc, bl_plaintext);
-  ::encode(footer.front_crc, bl_plaintext);
-  ::encode(footer.middle_crc, bl_plaintext);
-  ::encode(footer.data_crc, bl_plaintext);
-
-  bufferlist bl_encrypted;
   std::string error;
-  if (encode_encrypt(cct, bl_plaintext, key, bl_encrypted, error)) {
-    ldout(cct, 0) << "error encrypting message signature: " << error << dendl;
-    ldout(cct, 0) << "no signature put on message" << dendl;
-    return SESSION_SIGNATURE_FAILURE;
-  }
 
-  bufferlist::iterator ci = bl_encrypted.begin();
-  // Skip the magic number up front. PLR
-  ci.advance(4);
+  // optimized signature calculation
+  // - avoid temporary allocated buffers from encode_encrypt[_enc_bl]
+  // - skip the leading 4 byte wrapper from encode_encrypt
+  struct {
+    __u8 v;
+    __le64 magic;
+    __le32 len;
+    __le32 header_crc;
+    __le32 front_crc;
+    __le32 middle_crc;
+    __le32 data_crc;
+  } __attribute__ ((packed)) sigblock = {
+    1, AUTH_ENC_MAGIC, 4*4,
+    header.crc, footer.front_crc, footer.middle_crc, footer.data_crc
+  };
+  bufferlist bl_plaintext;
+  bl_plaintext.append(buffer::create_static(sizeof(sigblock), (char*)&sigblock));
+
+  bufferlist bl_ciphertext;
+  key.encrypt(cct, bl_plaintext, bl_ciphertext, error);
+
+  bufferlist::iterator ci = bl_ciphertext.begin();
   ::decode(*psig, ci);
+
   ldout(cct, 10) << __func__ << " seq " << m->get_seq()
 		 << " front_crc_ = " << footer.front_crc
 		 << " middle_crc = " << footer.middle_crc

--- a/src/auth/cephx/CephxSessionHandler.h
+++ b/src/auth/cephx/CephxSessionHandler.h
@@ -31,8 +31,9 @@ public:
     return false;
   }
 
-  int sign_message(Message *m);
+  int _calc_signature(Message *m, uint64_t *psig);
 
+  int sign_message(Message *m);
   int check_message_signature(Message *m) ;
 
   // Cephx does not currently encrypt messages, so just return 0 if called.  PLR

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -448,8 +448,8 @@ CephContext::CephContext(uint32_t module_type_)
   _admin_socket->register_command("log dump", "log dump", _admin_hook, "dump recent log entries to log file");
   _admin_socket->register_command("log reopen", "log reopen", _admin_hook, "reopen log file");
 
-  _crypto_none = new CryptoNone;
-  _crypto_aes = new CryptoAES;
+  _crypto_none = CryptoHandler::create(CEPH_CRYPTO_NONE);
+  _crypto_aes = CryptoHandler::create(CEPH_CRYPTO_AES);
 }
 
 CephContext::~CephContext()

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -32,8 +32,6 @@ class md_config_obs_t;
 struct md_config_t;
 class CephContextHook;
 class CephContextObs;
-class CryptoNone;
-class CryptoAES;
 class CryptoHandler;
 
 namespace ceph {
@@ -170,8 +168,8 @@ private:
   std::map<std::string, AssociatedSingletonObject*> _associated_objs;
 
   // crypto
-  CryptoNone *_crypto_none;
-  CryptoAES *_crypto_aes;
+  CryptoHandler *_crypto_none;
+  CryptoHandler *_crypto_aes;
 
   // experimental
   CephContextObs *_cct_obs;

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -52,7 +52,8 @@ TEST(AES, Encrypt) {
 
   bufferlist cipher;
   std::string error;
-  h->encrypt(secret, plaintext, cipher, error);
+  CryptoKeyHandler *kh = h->get_key_handler(secret, error);
+  kh->encrypt(plaintext, cipher, error);
   ASSERT_EQ(error, "");
 
   unsigned char want_cipher[] = {
@@ -96,7 +97,8 @@ TEST(AES, Decrypt) {
 
   std::string error;
   bufferlist plaintext;
-  h->decrypt(secret, cipher, plaintext, error);
+  CryptoKeyHandler *kh = h->get_key_handler(secret, error);
+  kh->decrypt(cipher, plaintext, error);
   ASSERT_EQ(error, "");
 
   ASSERT_EQ(sizeof(plaintext_s), plaintext.length());
@@ -128,7 +130,8 @@ TEST(AES, Loop) {
       CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES);
 
       std::string error;
-      h->encrypt(secret, plaintext, cipher, error);
+      CryptoKeyHandler *kh = h->get_key_handler(secret, error);
+      kh->encrypt(plaintext, cipher, error);
       ASSERT_EQ(error, "");
     }
     plaintext.clear();
@@ -136,7 +139,8 @@ TEST(AES, Loop) {
     {
       CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES);
       std::string error;
-      h->decrypt(secret, cipher, plaintext, error);
+      CryptoKeyHandler *ckh = h->get_key_handler(secret, error);
+      ckh->decrypt(cipher, plaintext, error);
       ASSERT_EQ(error, "");
     }
   }

--- a/src/test/testcrypto.cc
+++ b/src/test/testcrypto.cc
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
   bufferlist enc_out;
   std::string error;
   if (key.encrypt(g_ceph_context, enc_in, enc_out, &error) < 0) {
-    ASSERT_TRUE(!error.empty());
+    assert(!error.empty());
     dout(0) << "couldn't encode! error " << error << dendl;
     exit(1);
   }
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   dec_in = enc_out;
 
   if (key.decrypt(g_ceph_context, dec_in, dec_out, &error) < 0) {
-    ASSERT_TRUE(!error.empty());
+    assert(!error.empty());
     dout(0) << "couldn't decode! error " << error << dendl;
     exit(1);
   }

--- a/src/test/testcrypto.cc
+++ b/src/test/testcrypto.cc
@@ -25,8 +25,8 @@ int main(int argc, char *argv[])
 
   bufferlist enc_out;
   std::string error;
-  key.encrypt(g_ceph_context, enc_in, enc_out, error);
-  if (!error.empty()) {
+  if (key.encrypt(g_ceph_context, enc_in, enc_out, &error) < 0) {
+    ASSERT_TRUE(!error.empty());
     dout(0) << "couldn't encode! error " << error << dendl;
     exit(1);
   }
@@ -42,8 +42,8 @@ int main(int argc, char *argv[])
 
   dec_in = enc_out;
 
-  key.decrypt(g_ceph_context, dec_in, dec_out, error);
-  if (!error.empty()) {
+  if (key.decrypt(g_ceph_context, dec_in, dec_out, &error) < 0) {
+    ASSERT_TRUE(!error.empty());
     dout(0) << "couldn't decode! error " << error << dendl;
     exit(1);
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/14620

PK11_GetBestSlot() does not appear to be threadsafe, and can be called from multiple threads, leading to a crash similar to that in #6480. This backports a later refactoring of the auth code to avoid calling it from more than one thread, and only call it once per key. As a nice side effect, this decreases the overhead of authentication.