### PR TITLE
crush: add safe judgment for get parent hierarchy method.

### DIFF
--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -175,12 +175,7 @@ bool Filer::_probed(Probe *probe, const object_t& oid, uint64_t size, utime_t mt
 
   if (!probe->fwd) {
     // reverse
-    vector<ObjectExtent> r;
-    for (vector<ObjectExtent>::reverse_iterator p = probe->probing.rbegin();
-	 p != probe->probing.rend();
-	 ++p)
-      r.push_back(*p);
-    probe->probing.swap(r);
+    std::reverse(probe->probing.begin(),probe->probing.end());
   }
 
   for (vector<ObjectExtent>::iterator p = probe->probing.begin();


### PR DESCRIPTION
Crush: add safe judgment for get parent hierarchy method.

Fixes: #14623
Signed-off-by: song baisen <song.baisen@zte.com.cn>