### PR TITLE
fsx: checkout old version until it compiles properly on miras

### DIFF
--- a/qa/workunits/suites/fsx.sh
+++ b/qa/workunits/suites/fsx.sh
@@ -3,7 +3,10 @@
 set -e
 
 git clone git://git.ceph.com/xfstests.git
-make -C xfstests
+cd xfstests
+git checkout b7fd3f05d6a7a320d13ff507eda2e5b183cae180
+make
+cd ..
 cp xfstests/ltp/fsx .
 
 OPTIONS="-z"  # don't use zero range calls; not supported by cephfs


### PR DESCRIPTION
I sent a patch to xfstests upstream at
http://article.gmane.org/gmane.comp.file-systems.fstests/1665, but
until that's fixed we need a version that works in our test lab.

Signed-off-by: Greg Farnum <gfarnum@redhat.com>
(cherry picked from commit 7d52372ae74878ebd001036ff0a7aad525eb15b6)