### PR TITLE
os/kstore: insert new onode to the front position of onode LRU

### DIFF
--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -439,7 +439,7 @@ void KStore::OnodeHashLRU::add(const ghobject_t& oid, OnodeRef o)
   dout(30) << __func__ << " " << oid << " " << o << dendl;
   assert(onode_map.count(oid) == 0);
   onode_map[oid] = o;
-  lru.push_back(*o);
+  lru.push_front(*o);
 }
 
 KStore::OnodeRef KStore::OnodeHashLRU::lookup(const ghobject_t& oid)


### PR DESCRIPTION
See https://github.com/jjhuo/ceph/commit/caed88264d77f860376d4213cc98309a5daf3af2 for detail information.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>