### PR TITLE
cmake: add KernelDevice.cc to libos_srcs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -652,6 +652,7 @@ set(libos_srcs
   os/bluestore/BlueStore.cc
   os/bluestore/bluestore_types.cc
   os/bluestore/FreelistManager.cc
+  os/bluestore/KernelDevice.cc
   os/bluestore/StupidAllocator.cc
   os/fs/FS.cc
   ${libos_xfs_srcs})


### PR DESCRIPTION
which fixes the build

Signed-off-by: Kefu Chai <kchai@redhat.com>