### PR TITLE
mon/OSDMonitor.cc:pool create doesn't need pg_num

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -658,7 +658,7 @@ COMMAND("osd pool ls " \
 	"list pools", "osd", "r", "cli,rest")
 COMMAND("osd pool create " \
 	"name=pool,type=CephPoolname " \
-	"name=pg_num,type=CephInt,range=0 " \
+	"name=pg_num,type=CephInt,range=0,req=false " \
 	"name=pgp_num,type=CephInt,range=0,req=false " \
         "name=pool_type,type=CephChoices,strings=replicated|erasure,req=false " \
 	"name=erasure_code_profile,type=CephString,req=false,goodchars=[A-Za-z0-9-_.] " \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6704,7 +6704,8 @@ done:
   } else if (prefix == "osd pool create") {
     int64_t  pg_num;
     int64_t pgp_num;
-    cmd_getval(g_ceph_context, cmdmap, "pg_num", pg_num, int64_t(0));
+    const int64_t default_pg_num = g_conf->osd_pool_default_pg_num;
+    cmd_getval(g_ceph_context, cmdmap, "pg_num", pg_num, default_pg_num);
     cmd_getval(g_ceph_context, cmdmap, "pgp_num", pgp_num, pg_num);
 
     string pool_type_str;

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -988,11 +988,11 @@ class TestOSD(TestArgparse):
         self.assert_valid_command(['osd', 'pool', 'create',
                                    'poolname', '128', '128',
                                    'erasure', 'A-Za-z0-9-_.', 'ruleset^^'])
+        self.assert_valid_command(['osd', 'pool', 'create',
+                                   'poolname'])
+        self.assert_valid_command(['osd', 'pool', 'create',
+                                   'poolname', '-1'])
         assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create']))
-        assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
-                                                    'poolname']))
-        assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
-                                                    'poolname', '-1']))
         assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
                                                     'poolname',
                                                     '128', '128',


### PR DESCRIPTION
When invoking ceph osd pool create, pg_num is now not required
argument. If the argument is not supplied the default is taken
from the config option:
osd pool default pg num

Fixes: #13702

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>