### PR TITLE
cmake: fix the build of tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,15 @@ if (NOT (CMAKE_MAJOR_VERSION LESS 3))
   # Tweak policies (this one disables "missing" dependency warning)
   cmake_policy(SET CMP0046 OLD)
 endif(NOT (CMAKE_MAJOR_VERSION LESS 3))
+# we use LINK_PRIVATE keyword instead of PRIVATE, but do not specify the LINK_PUBLIC
+# for target_link_libraries() command when PUBLIC should be used instead, it's just
+# for backward compatibility with cmake 2.8.11.
+if (POLICY CMP0022)
+cmake_policy(SET CMP0022 OLD)
+endif (POLICY CMP0022)
+if (POLICY CMP0023)
+cmake_policy(SET CMP0023 OLD)
+endif (POLICY CMP0023)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,8 +76,7 @@ else()
 endif()
 
 
-set(EXTRALIBS uuid rt dl
-  ${Boost_LIBRARIES} ${Boost_SYSTEM_LIBRARY} ${ATOMIC_OPS_LIBRARIES})
+set(EXTRALIBS uuid rt dl ${Boost_LIBS} ${ATOMIC_OPS_LIBRARIES})
 
 if(${WITH_PROFILER})
   list(APPEND EXTRALIBS profiler)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,7 +76,7 @@ else()
 endif()
 
 
-set(EXTRALIBS uuid rt dl ${Boost_LIBS} ${ATOMIC_OPS_LIBRARIES})
+set(EXTRALIBS uuid rt dl ${ATOMIC_OPS_LIBRARIES})
 
 if(${WITH_PROFILER})
   list(APPEND EXTRALIBS profiler)

--- a/src/common/Graylog.cc
+++ b/src/common/Graylog.cc
@@ -5,16 +5,15 @@
 
 #include <iostream>
 #include <sstream>
-#include <memory>
 
 #include <arpa/inet.h>
 
-#include <boost/asio.hpp>
-#include <boost/iostreams/filtering_stream.hpp>
-#include <boost/iostreams/filter/zlib.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include "common/Formatter.h"
+#include "common/LogEntry.h"
+#include "log/Entry.h"
+#include "log/SubsystemMap.h"
 #include "include/uuid.h"
 
 namespace ceph {
@@ -71,7 +70,7 @@ void Graylog::set_hostname(const std::string& host)
   m_hostname = host;
 }
 
-void Graylog::set_fsid(uuid_d fsid)
+void Graylog::set_fsid(const uuid_d& fsid)
 {
   std::vector<char> buf(40);
   fsid.print(&buf[0]);

--- a/src/common/Graylog.h
+++ b/src/common/Graylog.h
@@ -7,18 +7,23 @@
 
 #include <memory>
 
-#include <boost/thread/mutex.hpp>
 #include <boost/asio.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/filter/zlib.hpp>
 
-#include "log/Entry.h"
-#include "log/SubsystemMap.h"
-#include "common/LogEntry.h"
 #include "include/memory.h"
 
+struct uuid_d;
+class LogEntry;
+
 namespace ceph {
+
+class Formatter;
+
 namespace log {
+
+struct Entry;
+class SubsystemMap;
 
 // Graylog logging backend: Convert log datastructures (LogEntry, Entry) to
 // GELF (http://www.graylog2.org/resources/gelf/specification) and send it
@@ -45,7 +50,7 @@ class Graylog
   virtual ~Graylog();
 
   void set_hostname(const std::string& host);
-  void set_fsid(uuid_d fsid);
+  void set_fsid(const uuid_d& fsid);
 
   void set_destination(const std::string& host, int port);
 

--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -16,6 +16,7 @@
 
 #include "include/types.h"
 #include "include/str_map.h"
+#include "include/uuid.h"
 
 #include "msg/Messenger.h"
 #include "msg/Message.h"
@@ -34,6 +35,9 @@
 #include <sys/mount.h>
 #endif // DARWIN
 
+#include "common/Graylog.h"
+// wipe the assert() introduced by boost headers included by Graylog.h
+#include "include/assert.h"
 #include "common/LogClient.h"
 
 #include "common/config.h"

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -17,8 +17,6 @@
 
 #include "common/LogEntry.h"
 #include "common/Mutex.h"
-#include "include/uuid.h"
-#include "common/Graylog.h"
 
 #include <iosfwd>
 #include <sstream>
@@ -29,9 +27,16 @@ class MLogAck;
 class Messenger;
 class MonMap;
 class Message;
+struct uuid_d;
 struct Connection;
 
 class LogChannel;
+
+namespace ceph {
+namespace log {
+  class Graylog;
+}
+}
 
 int parse_log_client_options(CephContext *cct,
 			     map<string,string> &log_to_monitors,
@@ -177,7 +182,7 @@ private:
   std::string syslog_facility;
   bool log_to_syslog;
   bool log_to_monitors;
-  ceph::log::Graylog::Ref graylog;
+  shared_ptr<ceph::log::Graylog> graylog;
 
 
   friend class LogClientTemp;

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -27,6 +27,7 @@
 #include "common/errno.h"
 #include "common/lockdep.h"
 #include "common/Formatter.h"
+#include "common/Graylog.h"
 #include "log/Log.h"
 #include "auth/Crypto.h"
 #include "include/str_list.h"

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -17,6 +17,7 @@
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "common/Clock.h"
+#include "common/Graylog.h"
 #include "common/valgrind.h"
 #include "common/Formatter.h"
 #include "include/assert.h"

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -6,17 +6,16 @@
 
 #include "common/Thread.h"
 
-#include <assert.h>
 #include <pthread.h>
-#include <boost/asio.hpp>
 
 #include "Entry.h"
 #include "EntryQueue.h"
 #include "SubsystemMap.h"
-#include "common/Graylog.h"
 
 namespace ceph {
 namespace log {
+
+class Graylog;
 
 class Log : private Thread
 {
@@ -42,7 +41,7 @@ class Log : private Thread
   int m_stderr_log, m_stderr_crash;
   int m_graylog_log, m_graylog_crash;
 
-  Graylog::Ref m_graylog;
+  shared_ptr<Graylog> m_graylog;
 
   bool m_stop;
 
@@ -78,7 +77,7 @@ public:
   void start_graylog();
   void stop_graylog();
 
-  Graylog::Ref graylog() { return m_graylog; }
+  shared_ptr<Graylog> graylog() { return m_graylog; }
 
   Entry *create_entry(int level, int subsys);
   Entry *create_entry(int level, int subsys, size_t* expected_size);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2129,7 +2129,7 @@ add_executable(test_rados_api_tier
 set_target_properties(test_rados_api_tier PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_tier
-  global librados ${UNITTEST_LIBS} ${ALLOC_LIBS} ${Boost_SYSTEM_LIBRARY} radostest)
+  global librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_snapshots
   librados/snapshots.cc

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2020,7 +2020,7 @@ add_executable(test_rados_api_io
 set_target_properties(test_rados_api_io PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_io
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_c_write_operations
   librados/c_write_operations.cc
@@ -2029,7 +2029,7 @@ add_executable(test_rados_api_c_write_operations
 set_target_properties(test_rados_api_c_write_operations PROPERTIES
   COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_c_write_operations
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_c_read_operations
   librados/c_read_operations.cc
@@ -2038,7 +2038,7 @@ add_executable(test_rados_api_c_read_operations
 set_target_properties(test_rados_api_c_read_operations PROPERTIES COMPILE_FLAGS 
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_c_read_operations
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_aio
   librados/aio.cc
@@ -2047,9 +2047,7 @@ add_executable(test_rados_api_aio
 set_target_properties(test_rados_api_aio PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_aio
-  librados ${UNITTEST_LIBS}
-  ${EXTRALIBS}
-  ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_list
   librados/list.cc
@@ -2058,7 +2056,7 @@ add_executable(test_rados_api_list
 set_target_properties(test_rados_api_list PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_list
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_nlist
   librados/nlist.cc
@@ -2067,7 +2065,7 @@ add_executable(test_rados_api_nlist
 set_target_properties(test_rados_api_nlist PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_nlist
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_pool
   librados/pool.cc
@@ -2077,7 +2075,7 @@ set_target_properties(test_rados_api_pool PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS}
   )
 target_link_libraries(test_rados_api_pool
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_stat
   librados/stat.cc
@@ -2086,7 +2084,7 @@ add_executable(test_rados_api_stat
 set_target_properties(test_rados_api_stat PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_stat
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_watch_notify
   librados/watch_notify.cc
@@ -2095,7 +2093,7 @@ add_executable(test_rados_api_watch_notify
 set_target_properties(test_rados_api_watch_notify PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_watch_notify
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_cls
   librados/cls.cc
@@ -2104,7 +2102,7 @@ add_executable(test_rados_api_cls
 set_target_properties(test_rados_api_cls PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_cls
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_misc
   librados/misc.cc
@@ -2122,7 +2120,7 @@ add_executable(test_rados_api_lock
 set_target_properties(test_rados_api_lock PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_lock
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_executable(test_rados_api_tier
   librados/tier.cc
@@ -2140,7 +2138,7 @@ add_executable(test_rados_api_snapshots
 set_target_properties(test_rados_api_snapshots PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_snapshots
-  librados ${UNITTEST_LIBS} ${EXTRALIBS} ${ALLOC_LIBS} radostest)
+  librados ${UNITTEST_LIBS} ${ALLOC_LIBS} radostest)
 
 add_library(rados_striper_test STATIC libradosstriper/TestCase.cc)
 target_link_libraries(rados_striper_test radostest)


### PR DESCRIPTION
perfglue/heap_profiler.cc is referncing boost-system somehow, and
this file is compiled when we are using tcmalloc, so added it to
ALLOC_LIBS along with tcmalloc.

Signed-off-by: Kefu Chai <kchai@redhat.com>