### PR TITLE
hammer: doc: regenerate man pages, add orphans commands to radosgw-admin(8)

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -83,6 +83,12 @@ Commands
 :command:`usage trim`
   Trim usage information (with optional user and date range)
 
+:command:`orphans find`
+  Init and run search for leaked rados objects
+
+:command:`orphans finish`
+  Clean up search for leaked rados objects
+
 
 Options
 =======
@@ -149,6 +155,18 @@ Options
 
    Defer removal of object tail
    
+
+Orphans Search Options
+======================
+
+.. option:: --pool
+
+	Data pool to scan for leaked rados objects
+
+.. option:: --num-shards
+
+	Number of shards to use for keeping the temporary scan info
+
 
 Examples
 ========

--- a/man/ceph-authtool.8
+++ b/man/ceph-authtool.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-AUTHTOOL" "8" "November 30, 2014" "dev" "Ceph"
+.TH "CEPH-AUTHTOOL" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-authtool \- ceph keyring manipulation tool
 .
@@ -287,7 +287,7 @@ mount \-t ceph serverhost:/ mountpoint \-o name=foo,secret=\(gaceph\-authtool \-
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-authtool\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please
+\fBceph\-authtool\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please
 refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/ceph-clsinfo.8
+++ b/man/ceph-clsinfo.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-CLSINFO" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-CLSINFO" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-clsinfo \- show class object information
 .
@@ -84,7 +84,7 @@ Shows the class architecture
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-clsinfo\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please
+\fBceph\-clsinfo\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please
 refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/ceph-conf.8
+++ b/man/ceph-conf.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-CONF" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-CONF" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-conf \- ceph conf file tool
 .
@@ -147,7 +147,7 @@ ceph\-conf \-c foo.conf \-L
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-conf\fP is part of Ceph, a massively scalable, open-source, distributed storage system.  Please refer
+\fBceph\-conf\fP is part of Ceph, a massively scalable, open\-source, distributed storage system.  Please refer
 to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/ceph-create-keys.8
+++ b/man/ceph-create-keys.8
@@ -1,8 +1,35 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-CREATE-KEYS" "8" "June 02, 2015" "dev" "Ceph"
+.TH "CEPH-CREATE-KEYS" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-create-keys \- ceph keyring generate tool
+.
+.nr rst2man-indent-level 0
+.
+.de1 rstReportMargin
+\\$1 \\n[an-margin]
+level \\n[rst2man-indent-level]
+level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
+-
+\\n[rst2man-indent0]
+\\n[rst2man-indent1]
+\\n[rst2man-indent2]
+..
+.de1 INDENT
+.\" .rstReportMargin pre:
+. RS \\$1
+. nr rst2man-indent\\n[rst2man-indent-level] \\n[an-margin]
+. nr rst2man-indent-level +1
+.\" .rstReportMargin post:
+..
+.de UNINDENT
+. RE
+.\" indent \\n[an-margin]
+.\" old: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.nr rst2man-indent-level -1
+.\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.in \\n[rst2man-indent\\n[rst2man-indent-level]]u
+..
 .
 .nr rst2man-indent-level 0
 .
@@ -40,7 +67,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 \fBceph\-create\-keys\fP is a utility to generate bootstrap keyrings using
 the given monitor when it is ready.
 .sp
-it creates following auth entities (or users)
+It creates following auth entities (or users)
 .sp
 \fBclient.admin\fP
 .INDENT 0.0
@@ -56,7 +83,7 @@ and their keys for bootstrapping corresponding services
 .UNINDENT
 .UNINDENT
 .sp
-To list all users in cluster:
+To list all users in the cluster:
 .INDENT 0.0
 .INDENT 3.5
 .sp

--- a/man/ceph-debugpack.8
+++ b/man/ceph-debugpack.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-DEBUGPACK" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-DEBUGPACK" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-debugpack \- ceph debug packer utility
 .
@@ -82,7 +82,7 @@ startup.
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-debugpack\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please
+\fBceph\-debugpack\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please
 refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/ceph-dencoder.8
+++ b/man/ceph-dencoder.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-DENCODER" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-DENCODER" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-dencoder \- ceph encoder/decoder utility
 .
@@ -100,6 +100,12 @@ Select the given type for future \fBencode\fP or \fBdecode\fP operations.
 .UNINDENT
 .INDENT 0.0
 .TP
+.B skip <bytes>
+Seek <bytes> into the imported file before reading data structure, use
+this with objects that have a preamble/header before the object of interest.
+.UNINDENT
+.INDENT 0.0
+.TP
 .B decode
 Decode the contents of the in\-memory buffer into an instance of the
 previously selected type.  If there is an error, report it.
@@ -143,7 +149,7 @@ versions of the software (for those types that support it).
 .UNINDENT
 .SH EXAMPLE
 .sp
-Say you want to examine an attribute on an object stored by \fBceph\-osd\fP\&.  You can do:
+Say you want to examine an attribute on an object stored by \fBceph\-osd\fP\&.  You can do this:
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -179,9 +185,29 @@ $ ceph\-dencoder type object_info_t import /tmp/a decode dump_json
 .fi
 .UNINDENT
 .UNINDENT
+.sp
+Alternatively, perhaps you wish to dump an internal CephFS metadata object, you might
+do that like this:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ rados \-p metadata get mds_snaptable mds_snaptable.bin
+$ ceph\-dencoder type SnapServer skip 8 import mds_snaptable.bin decode dump_json
+{ "snapserver": { "last_snap": 1,
+   "pending_noop": [],
+   "snaps": [],
+   "need_to_purge": {},
+   "pending_create": [],
+   "pending_destroy": []}}
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-dencoder\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please
+\fBceph\-dencoder\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please
 refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/ceph-deploy.8
+++ b/man/ceph-deploy.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-DEPLOY" "8" "December 20, 2014" "dev" "Ceph"
+.TH "CEPH-DEPLOY" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-deploy \- Ceph deployment tool
 .
@@ -827,7 +827,7 @@ The domain for the Calamari master server.
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-deploy\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBceph\-deploy\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the documentation at \fI\%http://ceph.com/ceph-deploy/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/ceph-disk.8
+++ b/man/ceph-disk.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-DISK" "8" "December 18, 2014" "dev" "Ceph"
+.TH "CEPH-DISK" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-disk \- Ceph disk preparation and activation utility for OSD
 .
@@ -388,7 +388,7 @@ Provide init system to manage the OSD directory.
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-disk\fP is a part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBceph\-disk\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/ceph-fuse.8
+++ b/man/ceph-fuse.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-FUSE" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-FUSE" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-fuse \- FUSE-based client for ceph
 .
@@ -108,7 +108,7 @@ Use root_directory as the mounted root, rather than the full Ceph tree.
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-fuse\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBceph\-fuse\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/ceph-mds.8
+++ b/man/ceph-mds.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-MDS" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-MDS" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-mds \- ceph metadata server daemon
 .
@@ -106,9 +106,19 @@ startup.
 Connect to specified monitor (instead of looking through
 \fBceph.conf\fP).
 .UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-journal\-check <rank>
+Attempt to replay the journal for MDS <rank>, then exit.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-hot\-standby <rank>
+Start as a hot standby for MDS <rank>.
+.UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-mon\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to the Ceph documentation at
+\fBceph\-mds\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to the Ceph documentation at
 \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/ceph-mon.8
+++ b/man/ceph-mon.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-MON" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-MON" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-mon \- ceph monitor daemon
 .
@@ -123,7 +123,7 @@ Specify a keyring for use with \fB\-\-mkfs\fP\&.
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-mon\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer
+\fBceph\-mon\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer
 to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/ceph-osd.8
+++ b/man/ceph-osd.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-OSD" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-OSD" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-osd \- ceph object storage daemon
 .
@@ -155,7 +155,7 @@ Connect to specified monitor (instead of looking through
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-osd\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBceph\-osd\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/ceph-post-file.8
+++ b/man/ceph-post-file.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-POST-FILE" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-POST-FILE" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-post-file \- post files for ceph developers
 .
@@ -118,7 +118,7 @@ ceph\-post\-file \-d \(aqmon data directories\(aq /var/log/ceph/mon/*
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-post\-file\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBceph\-post\-file\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/ceph-rbdnamer.8
+++ b/man/ceph-rbdnamer.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-RBDNAMER" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-RBDNAMER" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-rbdnamer \- udev helper to name RBD devices
 .
@@ -79,7 +79,7 @@ KERNEL=="rbd[0\-9]*", PROGRAM="/usr/bin/ceph\-rbdnamer %n", SYMLINK+="rbd/%c{1}/
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-rbdnamer\fP is part of Ceph, a massively scalable, open-source, distributed storage system.  Please
+\fBceph\-rbdnamer\fP is part of Ceph, a massively scalable, open\-source, distributed storage system.  Please
 refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/ceph-rest-api.8
+++ b/man/ceph-rest-api.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-REST-API" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-REST-API" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-rest-api \- ceph RESTlike administration server
 .
@@ -197,7 +197,7 @@ exception to be raised; see your WSGI server documentation for how to
 see those messages in case of problem.
 .SH AVAILABILITY
 .sp
-\fBceph\-rest\-api\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to the Ceph documentation at
+\fBceph\-rest\-api\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to the Ceph documentation at
 \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/ceph-run.8
+++ b/man/ceph-run.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-RUN" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-RUN" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-run \- restart daemon on core dump
 .
@@ -75,7 +75,7 @@ that means the \fB\-f\fP option.
 None
 .SH AVAILABILITY
 .sp
-\fBceph\-run\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBceph\-run\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/ceph-syn.8
+++ b/man/ceph-syn.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH-SYN" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPH-SYN" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph-syn \- ceph synthetic workload generator
 .
@@ -136,7 +136,7 @@ Recursively walk the file system (like find).
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBceph\-syn\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBceph\-syn\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/ceph.8
+++ b/man/ceph.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPH" "8" "March 22, 2015" "dev" "Ceph"
+.TH "CEPH" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 ceph \- ceph administration tool
 .
@@ -1390,6 +1390,20 @@ Usage:
 .nf
 .ft C
 ceph osd crush show\-tunables
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Subcommand \fBtree\fP shows the crush buckets and items in a tree view.
+.sp
+Usage:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+ceph osd crush tree
 .ft P
 .fi
 .UNINDENT

--- a/man/cephfs.8
+++ b/man/cephfs.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CEPHFS" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CEPHFS" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 cephfs \- ceph file system options utility
 .
@@ -109,7 +109,7 @@ Set the pool (by numeric value, not name!) to use
 .INDENT 0.0
 .TP
 .B \-o \-\-osd
-Set the preferred OSD to use as the primary (deprecated and ignored)
+Set the preferred OSD to use as the primary
 .UNINDENT
 .SH LIMITATIONS
 .sp
@@ -132,7 +132,7 @@ preferred OSD for placement. This feature is unsupported and ignored
 in modern versions of the Ceph servers; do not use it.
 .SH AVAILABILITY
 .sp
-\fBcephfs\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer
+\fBcephfs\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer
 to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/crushtool.8
+++ b/man/crushtool.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "CRUSHTOOL" "8" "January 12, 2014" "dev" "Ceph"
+.TH "CRUSHTOOL" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 crushtool \- CRUSH map manipulation tool
 .
@@ -417,7 +417,7 @@ crushtool \-c map.txt \-o crushmap
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBcrushtool\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please
+\fBcrushtool\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please
 refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/librados-config.8
+++ b/man/librados-config.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "LIBRADOS-CONFIG" "8" "January 12, 2014" "dev" "Ceph"
+.TH "LIBRADOS-CONFIG" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 librados-config \- display information about librados
 .
@@ -81,7 +81,7 @@ Display the \fBlibrados\fP version code
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBlibrados\-config\fP is part of Ceph, a massively scalable, open-source, distributed storage system.
+\fBlibrados\-config\fP is part of Ceph, a massively scalable, open\-source, distributed storage system.
 Please refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for
 more information.
 .SH SEE ALSO

--- a/man/monmaptool.8
+++ b/man/monmaptool.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "MONMAPTOOL" "8" "January 12, 2014" "dev" "Ceph"
+.TH "MONMAPTOOL" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 monmaptool \- ceph monitor cluster map manipulation tool
 .
@@ -175,7 +175,7 @@ monmaptool \-\-rm mon.a \-\-add mon.a 192.168.0.9:6789 \-\-clobber monmap
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBmonmaptool\fP is part of Ceph, a massively scalable, open-source, distributed storage system.  Please
+\fBmonmaptool\fP is part of Ceph, a massively scalable, open\-source, distributed storage system.  Please
 refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/mount.ceph.8
+++ b/man/mount.ceph.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "MOUNT.CEPH" "8" "January 12, 2014" "dev" "Ceph"
+.TH "MOUNT.CEPH" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 mount.ceph \- mount a ceph file system
 .
@@ -244,7 +244,7 @@ mount \-t ceph monhost:/ /mnt/foo
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBmount.ceph\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please
+\fBmount.ceph\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please
 refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/osdmaptool.8
+++ b/man/osdmaptool.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "OSDMAPTOOL" "8" "January 12, 2014" "dev" "Ceph"
+.TH "OSDMAPTOOL" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 osdmaptool \- ceph osd cluster map manipulation tool
 .
@@ -126,7 +126,7 @@ osdmaptool \-\-print osdmap
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBosdmaptool\fP is part of Ceph, a massively scalable, open-source, distributed storage system.  Please
+\fBosdmaptool\fP is part of Ceph, a massively scalable, open\-source, distributed storage system.  Please
 refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/rados.8
+++ b/man/rados.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "RADOS" "8" "May 29, 2014" "dev" "Ceph"
+.TH "RADOS" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 rados \- rados object storage utility
 .
@@ -259,7 +259,7 @@ rados \-p foo \-s mysnap get myobject blah.txt.old
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBrados\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBrados\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/radosgw-admin.8
+++ b/man/radosgw-admin.8
@@ -131,6 +131,12 @@ Show the usage information (with optional user and date range)
 .TP
 .B \fBusage trim\fP
 Trim usage information (with optional user and date range)
+.TP
+.B \fBorphans find\fP
+Init and run search for leaked rados objects
+.TP
+.B \fBorphans finish\fP
+Clean up search for leaked rados objects
 .UNINDENT
 .SH OPTIONS
 .INDENT 0.0
@@ -209,6 +215,17 @@ Remove all objects before bucket removal
 .TP
 .B \-\-lazy\-remove
 Defer removal of object tail
+.UNINDENT
+.SH ORPHANS SEARCH OPTIONS
+.INDENT 0.0
+.TP
+.B \-\-pool
+Data pool to scan for leaked rados objects
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-num\-shards
+Number of shards to use for keeping the temporary scan info
 .UNINDENT
 .SH EXAMPLES
 .sp

--- a/man/radosgw-admin.8
+++ b/man/radosgw-admin.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "RADOSGW-ADMIN" "8" "January 12, 2014" "dev" "Ceph"
+.TH "RADOSGW-ADMIN" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 radosgw-admin \- rados REST gateway user administration utility
 .
@@ -277,7 +277,7 @@ Show the logs of a bucket from April 1st, 2012:
 .sp
 .nf
 .ft C
-$ radosgw\-admin log show \-\-bucket=foo \-\-date=2012=04\-01
+$ radosgw\-admin log show \-\-bucket=foo \-\-date=2012\-04\-01
 .ft P
 .fi
 .UNINDENT
@@ -321,7 +321,7 @@ $ radosgw\-admin usage trim \-\-uid=johnny \-\-end\-date=2012\-04\-01
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBradosgw\-admin\fP is part of Ceph, a massively scalable, open-source, distributed storage system.  Please
+\fBradosgw\-admin\fP is part of Ceph, a massively scalable, open\-source, distributed storage system.  Please
 refer to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/radosgw.8
+++ b/man/radosgw.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "RADOSGW" "8" "January 12, 2014" "dev" "Ceph"
+.TH "RADOSGW" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 radosgw \- rados REST gateway
 .
@@ -83,8 +83,43 @@ Connect to specified monitor (instead of looking through
 .UNINDENT
 .INDENT 0.0
 .TP
+.B \-i ID, \-\-id ID
+Set the ID portion of name for radosgw
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-n TYPE.ID, \-\-name TYPE.ID
+Set the rados user name for the gateway (eg. client.radosgw.gateway)
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cluster NAME
+Set the cluster name (default: ceph)
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-d
+Run in foreground, log to stderr
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-f
+Run in foreground, log to usual location
+.UNINDENT
+.INDENT 0.0
+.TP
 .B \-\-rgw\-socket\-path=path
 Specify a unix domain socket path.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-rgw\-region=region
+The region where radosgw runs
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-rgw\-zone=zone
+The zone where radosgw runs
 .UNINDENT
 .SH CONFIGURATION
 .sp
@@ -229,7 +264,7 @@ threshold specify how many entries can be kept before resorting to
 synchronous flush.
 .SH AVAILABILITY
 .sp
-\fBradosgw\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer
+\fBradosgw\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer
 to the Ceph documentation at \fI\%http://ceph.com/docs\fP for more
 information.
 .SH SEE ALSO

--- a/man/rbd-fuse.8
+++ b/man/rbd-fuse.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "RBD-FUSE" "8" "January 12, 2014" "dev" "Ceph"
+.TH "RBD-FUSE" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 rbd-fuse \- expose rbd images as files
 .
@@ -98,7 +98,7 @@ Use \fIpool\fP as the pool to search for rbd images.  Default is \fBrbd\fP\&.
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBrbd\-fuse\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBrbd\-fuse\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/rbd-replay-many.8
+++ b/man/rbd-replay-many.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "RBD-REPLAY-MANY" "8" "September 04, 2014" "dev" "Ceph"
+.TH "RBD-REPLAY-MANY" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 rbd-replay-many \- replay a rados block device (RBD) workload on several clients
 .
@@ -122,7 +122,7 @@ ssh host\-1 \(aqrbd\-replay\(aq \-\-map\-image \(aqimage=image\-1\(aq \-c ceph.c
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBrbd\-replay\-many\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBrbd\-replay\-many\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/rbd-replay-prep.8
+++ b/man/rbd-replay-prep.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "RBD-REPLAY-PREP" "8" "August 21, 2014" "dev" "Ceph"
+.TH "RBD-REPLAY-PREP" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 rbd-replay-prep \- prepare captured rados block device (RBD) workloads for replay
 .
@@ -76,6 +76,11 @@ Requests further apart than \(aqseconds\(aq seconds are assumed to be independen
 .B \-\-anonymize
 Anonymizes image and snap names.
 .UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-verbose
+Print all processed events to console
+.UNINDENT
 .SH EXAMPLES
 .sp
 To prepare workload1\-trace for replay:
@@ -91,7 +96,7 @@ rbd\-replay\-prep workload1\-trace/ust/uid/1000/64\-bit workload1
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBrbd\-replay\-prep\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBrbd\-replay\-prep\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/rbd-replay.8
+++ b/man/rbd-replay.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "RBD-REPLAY" "8" "September 10, 2014" "dev" "Ceph"
+.TH "RBD-REPLAY" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 rbd-replay \- replay rados block device (RBD) workloads
 .
@@ -129,7 +129,7 @@ rbd\-replay \-\-map\-image=prod_image=test_image workload1
 .UNINDENT
 .SH AVAILABILITY
 .sp
-\fBrbd\-replay\fP is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+\fBrbd\-replay\fP is part of Ceph, a massively scalable, open\-source, distributed storage system. Please refer to
 the Ceph documentation at \fI\%http://ceph.com/docs\fP for more information.
 .SH SEE ALSO
 .sp

--- a/man/rbd.8
+++ b/man/rbd.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "RBD" "8" "March 12, 2015" "dev" "Ceph"
+.TH "RBD" "8" "February 04, 2016" "dev" "Ceph"
 .SH NAME
 rbd \- manage rados block device (RBD) images
 .
@@ -395,21 +395,28 @@ The striping is controlled by three parameters:
 .INDENT 0.0
 .TP
 .B order
-The size of objects we stripe over is a power of two, specifically 2^[\fIorder\fP] bytes.  The default
-is 22, or 4 MB.
+.TP
+.B The size of objects we stripe over is a power of two, specifically 2^[*order*] bytes.  The default
+.TP
+.B is 22, or 4 MB.
 .UNINDENT
 .INDENT 0.0
 .TP
 .B stripe_unit
-Each [\fIstripe_unit\fP] contiguous bytes are stored adjacently in the same object, before we move on
-to the next object.
+.TP
+.B Each [*stripe_unit*] contiguous bytes are stored adjacently in the same object, before we move on
+.TP
+.B to the next object.
 .UNINDENT
 .INDENT 0.0
 .TP
 .B stripe_count
-After we write [\fIstripe_unit\fP] bytes to [\fIstripe_count\fP] objects, we loop back to the initial object
-and write another stripe, until the object reaches its maximum size (as specified by [\fIorder\fP].  At that
-point, we move on to the next [\fIstripe_count\fP] objects.
+.TP
+.B After we write [*stripe_unit*] bytes to [*stripe_count*] objects, we loop back to the initial object
+.TP
+.B and write another stripe, until the object reaches its maximum size (as specified by [*order*].  At that
+.TP
+.B point, we move on to the next [*stripe_count*] objects.
 .UNINDENT
 .sp
 By default, [\fIstripe_unit\fP] is the same as the object size and [\fIstripe_count\fP] is 1.  Specifying a different


### PR DESCRIPTION
The first commit rebuilds the in-tree nroff sources for the manpages, following the procedure in `admin/manpage-howto.txt`. (I was unable to get this to work using asphyxiate, so I cherry-picked cd69ded7affcdd754e229f94989a62c46f0a117b to my local hammer branch... not sure what we want to do about that long-term.) This synchronizes the hammer man page files with the canonical rST sources.

The second commit adds the orphans commands to `radosgw-admin(8)`, fixing http://tracker.ceph.com/issues/14643