### PR TITLE
hammer: rgw-admin: document orphans commands in usage

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -112,6 +112,8 @@ void _usage()
   cerr << "  replicalog get             get replica metadata log entry\n";
   cerr << "  replicalog update          update replica metadata log entry\n";
   cerr << "  replicalog delete          delete replica metadata log entry\n";
+  cout << "  orphans find               init and run search for leaked rados objects\n";
+  cout << "  orphans finish             clean up search for leaked rados objects\n";
   cerr << "options:\n";
   cerr << "   --uid=<id>                user id\n";
   cerr << "   --subuser=<name>          subuser name\n";
@@ -174,6 +176,9 @@ void _usage()
   cerr << "   --max-objects             specify max objects (negative value to disable)\n";
   cerr << "   --max-size                specify max size (in bytes, negative value to disable)\n";
   cerr << "   --quota-scope             scope of quota (bucket, user)\n";
+  cout << "\nOrphans search options:\n";
+  cout << "   --pool                    data pool to scan for leaked rados objects in\n";
+  cout << "   --num-shards              num of shards to use for keeping the temporary scan info\n";
   cerr << "\n";
   generic_client_usage();
 }

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -69,6 +69,8 @@
     replicalog get             get replica metadata log entry
     replicalog update          update replica metadata log entry
     replicalog delete          delete replica metadata log entry
+    orphans find               init and run search for leaked rados objects
+    orphans finish             clean up search for leaked rados objects
   options:
      --uid=<id>                user id
      --subuser=<name>          subuser name
@@ -131,6 +133,10 @@
      --max-objects             specify max objects (negative value to disable)
      --max-size                specify max size (in bytes, negative value to disable)
      --quota-scope             scope of quota (bucket, user)
+  
+  Orphans search options:
+     --pool                    data pool to scan for leaked rados objects in
+     --num-shards              num of shards to use for keeping the temporary scan info
   
     --conf/-c FILE    read configuration from the given configuration file
     --id/-i ID        set ID portion of my name


### PR DESCRIPTION
Fixes http://tracker.ceph.com/issues/14516 for hammer.

(cherry picked from commit 105a76bf542e05b739d5a03ca8ae55432350f107)

```
Conflicts:
	src/rgw/rgw_admin.cc (trivial resolution)
```