### PR TITLE
mailmap updates

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -120,6 +120,8 @@ James Page <james.page@ubuntu.com> <jamespage@ubuntu.com>
 Jason Dillaman <dillaman@redhat.com> <jdillaman@redhat.com>
 Jean-Charles Lopez <jelopez@redhat.com>
 Jeff Epstein <jepst79@gmail.com>
+Jeffrey Lu <lzhng2000@aliyun.com>
+Jeffrey Lu <lzhng2000@aliyun.com> <lzhng2000@hotmail.com>
 Jenkins <jenkins@ceph.com> <jenkins-build@jenkins-slave-wheezy.localdomain>
 Jenkins <jenkins@ceph.com> Jenkins <jenkins@inktank.com>
 Jiang Heng <jiangheng0511@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -233,6 +233,8 @@ Sage Weil <sage@inktank.com> <sage.weil@dreamhost.com>
 Sage Weil <sweil@redhat.com>
 Sage Weil <sweil@redhat.com> <sage@redhat.com>
 Sahid Orentino Ferdjaoui <sahid.ferdjaoui@cloudwatt.com> <sahid.ferdjaoui@gmail.com>
+Sahithi R V <tansy.rv@gmail.com>
+Sahithi R V <tansy.rv@gmail.com> <sahithi.rv1@gmail.com>
 Sam Lang <sam.lang@inktank.com> <samlang@gmail.com>
 Samuel Just <sam.just@inktank.com>
 Samuel Just <sam.just@inktank.com> <sam.just@dreamhost.com>

--- a/.mailmap
+++ b/.mailmap
@@ -154,6 +154,7 @@ Kongming Wu <wu.kongming@h3c.com>
 Laszlo Boszormenyi <gcs@debian.hu>
 Li Wang <li.wang@kylin-cloud.com> <liwang@ubuntukylin.com>
 Liu Peiyan <liu.peiyang@h3c.com>
+Li Tianqing <tianqing@unitedstack.com>
 Lluis Pamies-Juarez <lluis.pamies-juarez@hgst.com> <lluis@pamies.cat>
 Loic Dachary <ldachary@redhat.com> <dachary@users.noreply.github.com>
 Loic Dachary <ldachary@redhat.com> <ldachary@dachary.org>

--- a/.mailmap
+++ b/.mailmap
@@ -29,6 +29,8 @@ Aristoteles Neto <aristoteles.neto@webdrive.co.nz> <wdneto@users.noreply.github.
 Aron Gunn <ritz_303@yahoo.com>
 Ashish Chandra <ashish.a.chandra@ril.com> <mail.ashishchandra@gmail.com>
 Baptiste Veuillez <baptiste.veuillez--mainard@telecom-bretagne.eu> <baptiste@UbuntuBVM.lan>
+Barbora Ančincová <bara@redhat.com>
+Barbora Ančincová <bara@redhat.com> <bancinco@redhat.com>
 Billy Olsen <billy.olsen@canonical.com> <billy.olsen@gmail.com>
 Bo Cai <cai.bo@h3c.com>
 Boris Ranto <branto@redhat.com>

--- a/.mailmap
+++ b/.mailmap
@@ -181,6 +181,7 @@ Marcel Lauhoff <lauhoff@uni-mainz.de> <ml@irq0.org>
 Marco Garcês <marco.garces@bci.co.mz> <marco@garces.cc>
 Mark Nelson <mnelson@redhat.com> <mark.a.nelson@gmail.com>
 Matt Benjamin <matt@cohortfs.com> <matt@linuxbox.com>
+Matt Benjamin <mbenjamin@redhat.com> <mbenjami@redhat.com>
 Matthew Roy <matthew@royhousehold.net> <matthew@matthew-ubuntu.(none)>
 Matthew Roy <matthew@royhousehold.net> <mroy@sandbox-ed.com>
 Matthew Wodrich <matthew.wodrich@dreamhost.com> <mattheww@Mattsbox.(none)>

--- a/.mailmap
+++ b/.mailmap
@@ -260,6 +260,7 @@ Takeshi Miyamae <miyamae.takeshi@jp.fujitsu.com>
 Tamil Muthamizhan <tamil.muthamizhan@inktank.com>
 Tamil Muthamizhan <tamil.muthamizhan@inktank.com> <tamil@tamil-VirtualBox.(none)>
 Tamil Muthamizhan <tamil.muthamizhan@inktank.com> <tamil@ubuntu.(none)>
+Tao Chang <changtao@hihuron.com>
 Thomas Bechtold <t.bechtold@telekom.de> <thomasbechtold@jpberlin.de>
 Thomas Cantin <thomas.cantin@telecom-bretagne.eu>
 Thomas Johnson <NTmatter@gmail.com> <thomas.johnson@180amsterdam.com>

--- a/.mailmap
+++ b/.mailmap
@@ -282,6 +282,7 @@ Xiaowei Chen <chen.xiaowei@h3c.com>
 Xiaowei Chen <chen.xiaowei@h3c.com> <cxwshawn@gmail.com>
 Xie Rui <875016668@qq.com>
 Xie Rui <875016668@qq.com> <jerry.xr86@gmail.com>
+Xie Xingguo <xie.xingguo@zte.com.cn>
 Xie Xingguo <xie.xingguo@zte.com.cn> <258156334@qq.com>
 Xie Xingguo <xie.xingguo@zte.com.cn> <xie.xiexingguo@zte.com.cn>
 Xingyi Wu <wuxingyi2015@outlook.com>

--- a/.mailmap
+++ b/.mailmap
@@ -171,6 +171,8 @@ Lu Shi <shi.lu@h3c.com>
 Luo Kexue <luo.kexue@zte.com.cn> <scienceluo@qq.com>
 Ma Jianpeng <jianpeng.ma@intel.com>
 Ma Jianpeng <jianpeng.ma@intel.com> <majianpeng@gmail.com>
+Marcel Lauhoff <lauhoff@uni-mainz.de>
+Marcel Lauhoff <lauhoff@uni-mainz.de> <ml@irq0.org>
 Marco Garcês <marco.garces@bci.co.mz> <marco@garces.cc>
 Mark Nelson <mnelson@redhat.com> <mark.a.nelson@gmail.com>
 Matt Benjamin <matt@cohortfs.com> <matt@linuxbox.com>

--- a/.mailmap
+++ b/.mailmap
@@ -6,25 +6,25 @@
 # See .peoplemap for unique list of people
 #
 #
-Abhishek Lekshmanan <abhishek.lekshmanan@ril.com> <abhishek.lekshmanan@gmail.com> 
-Ahoussi Armand <ahoussi.say@telecom-bretagne.eu> delco225 <delco225>
+Abhishek Lekshmanan <abhishek.lekshmanan@ril.com> <abhishek.lekshmanan@gmail.com>
+Ahoussi Armand <ahoussi.say@telecom-bretagne.eu> <delco225>
 Ailing Zhang <zhangal1992@gmail.com> <ailzhang@users.noreply.github.com>
 Alexander Chuzhoy <achuzhoy@redhat.com> <schuzhoy@users.noreply.github.com>
-Alexandre Marangone <alexandre.marangone@inktank.com> Alexandre Maragone <alexandre.marangone@inktank.com>
+Alexandre Marangone <alexandre.marangone@inktank.com>
 Alexandre Marangone <alexandre.marangone@inktank.com> <a.marangone@gmail.com>
 Alexandre Oliva <oliva@gnu.org> <lxoliva@fsfla.org>
 Alexandre Oliva <oliva@gnu.org> <oliva@lsd.ic.unicamp.br>
 Alex Elder <elder@inktank.com> <elder@doink.(none)>
 Alex Elder <elder@inktank.com> <elder@dreamhost.com>
 Alex Elder <elder@inktank.com> <elder@speedy.(none)>
-Alexis Normand <n.al3xis@gmail.com> smagtony@gmail.com <smagtony>
+Alexis Normand <n.al3xis@gmail.com> <smagtony>
 Alfredo Deza <adeza@redhat.com> <alfredo@deza.pe>
 Andreas Peters <andreas.joachim.peters@cern.ch> <Andreas.Joachim.Peters@cern.ch>
-Andrew Bartlett <abartlet@catalyst.net.nz> Andrew Bartlett <abartlet@samba.org>
-Andrew Leung <aleung@cs.ucsc.edu> anwleung <anwleung@29311d96-e01e-0410-9327-a35deaab8ce9>
+Andrew Bartlett <abartlet@catalyst.net.nz> <abartlet@samba.org>
+Andrew Leung <aleung@cs.ucsc.edu> <anwleung@29311d96-e01e-0410-9327-a35deaab8ce9>
 Andy Allan <andy@gravitystorm.co.uk> <github@gravitystorm.co.uk>
 Anis Ayari <ayari_anis@live.fr> Anols
-Aristoteles Neto <aristoteles.neto@webdrive.co.nz>  <wdneto@users.noreply.github.com>
+Aristoteles Neto <aristoteles.neto@webdrive.co.nz> <wdneto@users.noreply.github.com>
 Ashish Chandra <ashish.a.chandra@ril.com> <mail.ashishchandra@gmail.com>
 Baptiste Veuillez <baptiste.veuillez--mainard@telecom-bretagne.eu> <baptiste@UbuntuBVM.lan>
 Billy Olsen <billy.olsen@canonical.com> <billy.olsen@gmail.com>
@@ -34,18 +34,17 @@ Brian Andrus <bandrus@redhat.com> <bandrus+github@gmail.com>
 Brian Felton <bjfelton@gmail.com> <bjfelton@gmail.com>
 Brian Rak <dn@devicenull.org> devicenull <dn@devicenull.org>
 Burkhard Linke <Burkhard.Linke@computational.bio.uni-giessen.de> <Burkhard.Linke@computational.bio.uni-giessen.de>
-Caleb Miles <caleb.miles@inktank.com> caleb miles <caleb.miles@inktank.com>
-Caleb Miles <caleb.miles@inktank.com> caleb miles <caselim@gmail.com>
-Caleb Miles <caleb.miles@inktank.com> Caleb Miles <caselim@gmail.com>
-Carlos Maltzahn <carlosm@cs.ucsc.edu> carlosm <carlosm@29311d96-e01e-0410-9327-a35deaab8ce9>
+Caleb Miles <caleb.miles@inktank.com>
+Caleb Miles <caleb.miles@inktank.com> <caselim@gmail.com>
+Carlos Maltzahn <carlosm@cs.ucsc.edu> <carlosm@29311d96-e01e-0410-9327-a35deaab8ce9>
 Casey Marshall <csm@soe.ucsc.edu> rsdio <rsdio@29311d96-e01e-0410-9327-a35deaab8ce9>
 Ce Gu <guce@h3c.com> <guce@h3c.com>
-Chen Dihao <tobeg3oogle@gmail.com> tobe <tobeg3oogle@gmail.com>
-Chendi Xue <chendi.xue@intel.com> Chendi.Xue <chendi.xue@intel.com>
-Chendi Xue <chendi.xue@intel.com> Chendi Xue <xuechendi@gmail.com>
-Cheng Cheng <ccheng.leo@gmail.com> cchengleo <ccheng.leo@gmail.com>
+Chen Dihao <tobeg3oogle@gmail.com> <tobeg3oogle@gmail.com>
+Chendi Xue <chendi.xue@intel.com>
+Chendi Xue <chendi.xue@intel.com> <xuechendi@gmail.com>
+Cheng Cheng <ccheng.leo@gmail.com> <ccheng.leo@gmail.com>
 Chris Holcombe <chris.holcombe@nebula.com> <xfactor973@gmail.com>
-Christian Brunner <christian@brunner-muc.de> <chb@muc.de> 
+Christian Brunner <christian@brunner-muc.de> <chb@muc.de>
 Christian Marie <pingu@anchor.net.au> <christian@ponies.io>
 Christophe Courtaut <christophe.courtaut@gmail.com> Kri5 <christophe.courtaut@gmail.com>
 Chuanhong Wang <wang.chuanhong@zte.com.cn> wangchaunhong <root@A22832429.(none)>
@@ -63,38 +62,37 @@ David Moreau Simard <dmsimard@iweb.com> <moi@dmsimard.com>
 Dennis Schafroth <dennis@schafroth.com> <dennis@schafroth.dk>
 Dmitry Smirnov <onlyjob@member.fsf.org> <onlyjob@debian.org>
 Dmitry Yatsushkevich <dyatsushkevich@mirantis.com> <dmitry.yatsushkevich@gmail.com>
-Dominik Hannen <cantares1+github@gmail.com> Dominik Hannen <dhxgit@users.noreply.github.com>
+Dominik Hannen <cantares1+github@gmail.com> <dhxgit@users.noreply.github.com>
 Donghai Xu <xu.donghai@h3c.com> <xu.donghai@h3c.com>
 Dongmao Zhang <deanraccoon@gmail.com> <deanraccoon@gmail.com>
 Eric Mourgaya <eric.mourgaya@arkea.com> <eric.mourgaya@gmail.com>
 Erwin, Brock A <Brock.Erwin@pnl.gov> <Brock.Erwin@pnl.govgit>
-Esteban Molina-Estolano <eestolan@lanl.gov> eestolan <eestolan@29311d96-e01e-0410-9327-a35deaab8ce9>
-Federico Gimenez <fgimenez@coit.es> fgimenez <federico.gimenez@hola-internet.com>
-Feng Wang <cyclonew@cs.ucsc.edu> cyclonew <cyclonew@29311d96-e01e-0410-9327-a35deaab8ce9>
-Florent Bautista <florent@coppint.com> FlorentCoppint <florent@coppint.com>
+Esteban Molina-Estolano <eestolan@lanl.gov> <eestolan@29311d96-e01e-0410-9327-a35deaab8ce9>
+Federico Gimenez <fgimenez@coit.es> <federico.gimenez@hola-internet.com>
+Feng Wang <cyclonew@cs.ucsc.edu> <cyclonew@29311d96-e01e-0410-9327-a35deaab8ce9>
+Florent Bautista <florent@coppint.com> <florent@coppint.com>
 Florent Flament <florent.flament@cloudwatt.com> <florent.flament-ext@cloudwatt.com>
-Florent Manens <florent@beezim.fr> Florent Manens <florent@manens.org>
+Florent Manens <florent@beezim.fr> <florent@manens.org>
 Florian Coste <fcoste21@gmail.com> nairolf21
 Florian Marsylle <florian.marsylle@hotmail.fr> <floleblanc@hotmail.fr>
 François Lafont <flafdivers@free.fr> <francois.lafont@crdp.ac-versailles.fr>
 Gabriel Sentucq <perso@kazhord.fr> <perso@kazhord.fr>
-Gary Lowell <gary.lowell@inktank.com> Gary Lowelll <gary.lowell@inktank.com>
+Gary Lowell <gary.lowell@inktank.com>
 Gary Lowell <gary.lowell@inktank.com> <glowell@flab.ops.newdream.net>
 Gary Lowell <gary.lowell@inktank.com> <glowell@inktank.com>
 Gaurav Kumar Garg <garg.gaurav52@gmail.com> <ggarg@redhat.com>
 Gerben Meijer <gerben@daybyday.nl> <infernix@gmail.com>
 Germain Chipaux <germain.chipaux@gmail.com> <germain.chipaux@gmail.com>
+Greg Farnum <gfarnum@redhat.com>
 Greg Farnum <gfarnum@redhat.com> <gfarnum@GF-Macbook.local>
 Greg Farnum <gfarnum@redhat.com> <gfarnum@rehdat.com>
 Greg Farnum <gfarnum@redhat.com> <greg@gregs42.com>
-Greg Farnum <greg@inktank.com> Greg Farnu <greg@inktank.com>
+Greg Farnum <greg@inktank.com>
 Greg Farnum <greg@inktank.com> <greg.farnum@dreamhost.com>
 Greg Farnum <greg@inktank.com> <gregf@hq.newdream.net>
 Greg Farnum <greg@inktank.com> <gregf@skinny.ops.newdream.net>
 Greg Farnum <greg@inktank.com> <gregory.farnum@dreamhost.com>
-Greg Farnum <greg@inktank.com> Gregory Farnum <greg@inktank.com> 
-Greg Farnum <greg@inktank.com> Reviewed-by: Greg Farnum <greg@inktank.com>
-Guang Yang <yguang@yahoo-inc.com> Guang Yang <yguang@caughtrealize-dl-vm0.peking.corp.yahoo.com>
+Guang Yang <yguang@yahoo-inc.com> <yguang@caughtrealize-dl-vm0.peking.corp.yahoo.com>
 Guang Yang <yguang@yahoo-inc.com> <guangyy@gmail.com>
 Guang Yang <yguang@yahoo-inc.com> <yguang@renownedground.corp.gq1.yahoo.com>
 Guang Yang <yguang@yahoo-inc.com> <yguang@yahoo-inc>
@@ -107,34 +105,33 @@ Henry C Chang <henry_c_chang@tcloudcomputing.com> <henry.cy.chang@gmail.com>
 Hervé Rousseau <hroussea@cern.ch> <hroussea@cern.ch>
 Holger Macht <hmacht@suse.de> <holger@homac.de>
 Huamin Chen <hchen@redhat.com> rootfs <hchen@redhat.com>
-Huang Jun <hjwsm1989@gmail.com> huang jun <hjwsm1989@gmail.com>
-Huang Jun <hjwsm1989@gmail.com> huangjun <hjwsm1989@gmail.com>
+Huang Jun <hjwsm1989@gmail.com>
 Ilja Slepnev <islepnev@gmail.com>
 Ilya Dryomov <idryomov@redhat.com> <idryomov@gmail.com>
 Ismael Serrano <ismael.serrano@gmail.com> <ismaels@qti.qualcomm.com>
 Jacek J. Łakis <jacek.lakis@intel.com> <jlakis@gklab-126-033.igk.intel.com>
 James Page <james.page@ubuntu.com> <jamespage@ubuntu.com>
 Jason Dillaman <dillaman@redhat.com> <jdillaman@redhat.com>
-Jean-Charles Lopez <jelopez@redhat.com> jeanchlopez <jelopez@redhat.com>
-Jeff Epstein <jepst79@gmail.com> <jepst79@gmail.com>
+Jean-Charles Lopez <jelopez@redhat.com>
+Jeff Epstein <jepst79@gmail.com>
 Jenkins <jenkins@ceph.com> <jenkins-build@jenkins-slave-wheezy.localdomain>
 Jenkins <jenkins@ceph.com> Jenkins <jenkins@inktank.com>
-Jiang Heng <jiangheng0511@gmail.com> jiangheng <jiangheng0511@gmail.com>
-Jiantao He <hejiantao5@gmail.com> hejiantao5 <hejiantao5@gmail.com>
+Jiang Heng <jiangheng0511@gmail.com>
+Jiantao He <hejiantao5@gmail.com>
 Jian Wen <wenjian@letv.com> <wenjianhn@gmail.com>
-Ji Chen <insomnia@139.com> <insomnia@139.com>
-João Eduardo Luís <joao.luis@inktank.com> Joao Eduardo Luis <joao.luis@inktank.com>
+Ji Chen <insomnia@139.com>
+João Eduardo Luís <joao.luis@inktank.com>
 João Eduardo Luís <joao.luis@inktank.com> <joao@inktank.com>
-João Eduardo Luís <joao.luis@inktank.com> Joao Luis <joao.luis@inktank.com>
+João Eduardo Luís <joao@redhat.com>
 João Eduardo Luís <joao@redhat.com> <jecluis@gmail.com>
 João Eduardo Luís <joao@redhat.com> <jluis@redhat.com>
-João Eduardo Luís <joao@redhat.com> Joao Eduardo Luis <jeclui@gmail.com>
-João Eduardo Luís <joao@redhat.com> Joao Eduardo Luis <joao@redhat.com>
-Joao Eduardo Luis <joao@suse.de> <jluis@suse.com>
-Joao Eduardo Luis <joao@suse.de> <joao@suse.com>
+João Eduardo Luís <joao@redhat.com> <jeclui@gmail.com>
+João Eduardo Luís <joao@suse.de>
+João Eduardo Luís <joao@suse.de> <jluis@suse.com>
+João Eduardo Luís <joao@suse.de> <joao@suse.com>
 Joe Buck <jbbuck@gmail.com> <buck@soe.ucsc.edu>
 John Spray <jspray@redhat.com> <jcspray@gmail.com>
-John Spray <jspray@redhat.com> john <jspray@redhat.com>
+John Spray <jspray@redhat.com> <jspray@redhat.com>
 John Spray <jspray@redhat.com> <john.spray@redhat.com>
 Johnu George <johnugeo@cisco.com> <johnugeorge109@gmail.com>
 John Wilkins <john.wilkins@inktank.com> <john@admin-host.(none)>
@@ -144,71 +141,72 @@ John Wilkins <jwilkins@redhat.com> <jowilkin@redhat.com>
 John Wilkins <jwilkins@redhat.com> <jowilki@redhat.com>
 John Wilkins <jwilkins@redhat.com> <jowilk@redhat.com>
 Jordan Dorne <jordan.dorne@gmail.com> <jordan.dorne@gmail.com>
-Josh Durgin <jdurgin@redhat.com> Josh During <jdurgin@redhat.com>
+Josh Durgin <jdurgin@redhat.com>
 Josh Durgin <josh.durgin@inktank.com> <joshd@hq.newdream.net>
 Josh Durgin <josh.durgin@inktank.com> <josh.durgin@dreamhost.com>
-Kacper Kowalik <xarthisius@gentoo.org> Kacper Kowalik (Xarthisius) <xarthisius@gentoo.org> 
+Kacper Kowalik <xarthisius@gentoo.org>
 Kefu Chai <kchai@redhat.com> <tchaikov@gmail.com>
-Ken Dreyer <kdreyer@redhat.com>  <kdreyer@redhat.com>
+Ken Dreyer <kdreyer@redhat.com> <kdreyer@redhat.com>
 Kévin Caradant <kevin.caradant@gmail.com> <kevin.caradant@gmail.com>
 Kiseleva Alyona <akiselyova@mirantis.com> Ved-vampir
-Kongming Wu <wu.kongming@h3c.com> clever215 <wu.kongming@h3c.com>
-Laszlo Boszormenyi <gcs@debian.hu> Laszlo Boszormenyi (GCS) <gcs@debian.hu>
+Kongming Wu <wu.kongming@h3c.com>
+Laszlo Boszormenyi <gcs@debian.hu>
 Li Wang <li.wang@kylin-cloud.com> <liwang@ubuntukylin.com>
 Lluis Pamies-Juarez <lluis.pamies-juarez@hgst.com> <lluis@pamies.cat>
 Loic Dachary <ldachary@redhat.com> <dachary@users.noreply.github.com>
 Loic Dachary <ldachary@redhat.com> <ldachary@dachary.org>
+Loic Dachary <loic@dachary.org>
 Loic Dachary <loic@dachary.org> <loic@dachary.com>
-Loic Dachary <loic@dachary.org> Loïc Dachary <loic@dachary.org>
-Lucas Fantinel <lucas.fantinel@gmail.com> <lucas.fantinel@gmail.com>
-Lu Shi <shi.lu@h3c.com> <shi.lu@h3c.com>
-Ma Jianpeng <jianpeng.ma@intel.com> Jianpeng Ma <jianpeng.ma@intel.com>
+Lucas Fantinel <lucas.fantinel@gmail.com>
+Lu Shi <shi.lu@h3c.com>
+Ma Jianpeng <jianpeng.ma@intel.com>
 Ma Jianpeng <jianpeng.ma@intel.com> <majianpeng@gmail.com>
-Ma Jianpeng <jianpeng.ma@intel.com> Ma, Jianpeng <jianpeng.ma@intel.com>
-Marco Garcês <marco.garces@bci.co.mz> Marco Garcês <marco@garces.cc>
+Marco Garcês <marco.garces@bci.co.mz> <marco@garces.cc>
 Mark Nelson <mnelson@redhat.com> <mark.a.nelson@gmail.com>
 Matt Benjamin <matt@cohortfs.com> <matt@linuxbox.com>
 Matthew Roy <matthew@royhousehold.net> <matthew@matthew-ubuntu.(none)>
 Matthew Roy <matthew@royhousehold.net> <mroy@sandbox-ed.com>
 Matthew Wodrich <matthew.wodrich@dreamhost.com> <mattheww@Mattsbox.(none)>
-Maxime Robert <maxime.robert1992@gmail.com> <maxime.robert1992@gmail.com>
-Michael Riederer <michael@riederer.org> dynamike67 <michael@riederer.org>
-Michael Rodriguez <michael@newdream.net> <michael@newdream.net>
+Maxime Robert <maxime.robert1992@gmail.com>
+Michael Riederer <michael@riederer.org>
+Michael Rodriguez <michael@newdream.net>
 Michael Rodriguez <michael@newdream.net> <michael@squid.newdream.net>
-Min Chen <minchen@ubuntukylin.com> <minchen@ubuntukylin.com>
+Min Chen <minchen@ubuntukylin.com>
 MingXin Liu <mingxin.liu@kylin-cloud.com> <mingxinliu@ubuntukylin.com>
-Mingyue Zhao <zhao.mingyue@h3c.com> <zhao.mingyue@h3c.com>
-Mykola Golub <mgolub@mirantis.com> Mykola Golub <mgolub@zhuzha.mirantis.lviv.net>
+Mingyue Zhao <zhao.mingyue@h3c.com>
+Mykola Golub <mgolub@mirantis.com> <mgolub@zhuzha.mirantis.lviv.net>
 Nathan Cutler <ncutler@suse.com> <ncutler@suse.cz>
-Na Xie <xie.na@h3c.com> <xie.na@h3c.com>
-Neha Ummareddy <nehaummareddy@gmail.com> nehaummareddy <nehaummareddy@gmail.com>
+Na Xie <xie.na@h3c.com>
+Neha Ummareddy <nehaummareddy@gmail.com>
 Neil Levine <neil.levine@inktank.com> <levine@yoyo.org>
-Nicolas Yong <nicolas.yong93@gmail.com> <nicolas.yong93@gmail.com>
+Nicolas Yong <nicolas.yong93@gmail.com>
 Ning Yao <yaoning@ruijie.com.cn> <zay11022@gmail.com>
 Noah Watkins <nwatkins@redhat.com> <jayhawk@cs.ucsc.edu>
 Noah Watkins <nwatkins@redhat.com> <noahwatkins@gmail.com>
-Pascal de Bruijn <pascal@unilogicnetworks.net> Pascal de Bruijn | Unilogic Networks B.V <pascal@unilogicnetworks.net>
+Pascal de Bruijn <pascal@unilogicnetworks.net>
 Patience Warnick <patience@cranium.pelton.net> <patiencew@29311d96-e01e-0410-9327-a35deaab8ce9>
-Patrick McGarry <patrick@inktank.com> scuttlemonkey <patrick@inktank.com>
+Patrick McGarry <patrick@inktank.com>
 Patrick McGarry <pmcgarry@redhat.com> <pmcgarry@gmail.com>
-Pavan Rallabhandi <pavan.rallabhandi@sandisk.com> Pavan Rallabhandi <pavanrallabhandis@gmail.com>
+Pavan Rallabhandi <pavan.rallabhandi@sandisk.com> <pavanrallabhandis@gmail.com>
 Pete Zaitcev <zaitcev@redhat.com> <zaitcev@kotori.zaitcev.us>
-Pierre Chaumont <pierre.chaumont31@gmail.com> <pierre.chaumont31@gmail.com>
-Qiankun Zheng <zheng.qiankun@h3c.com> <zheng.qiankun@h3c.com>
+Pierre Chaumont <pierre.chaumont31@gmail.com>
+Qiankun Zheng <zheng.qiankun@h3c.com>
 Radoslaw Zarzynski <rzarzynski@mirantis.com> <rzarzynski@github.com>
-Rahul Aggarwal <rahul.1aggarwal@gmail.com> <rahul.1aggarwal@gmail.com>
-Ren Huanwen <ren.huanwen@zte.com.cn> renhwztetecs <rhwlyw@163.com>
-Riccardo Ferretti <rferrett@soe.ucsc.edu> rferrett <rferrett@29311d96-e01e-0410-9327-a35deaab8ce9>
+Rahul Aggarwal <rahul.1aggarwal@gmail.com>
+Ren Huanwen <ren.huanwen@zte.com.cn> <rhwlyw@163.com>
+Riccardo Ferretti <rferrett@soe.ucsc.edu> <rferrett@29311d96-e01e-0410-9327-a35deaab8ce9>
 Roald J. van Loon <roald@roaldvanloon.nl> <roaldvanloon@gmail.com>
 Robert Jansen <r.jansen@fairbanks.nl> <r.jansen86@gmail.com>
 Robin Dehu <robindehu@gmail.com> <rdehu@prune>
-Robin H. Johnson <robin.johnson@dreamhost.com> <robin.johnson@dreamhost.com>
-Robin Tang <robintang974@gmail.com> <robintang974@gmail.com>
-Ron Allred <rallred@itrefined.com> rallred <ron-github@neversleep.net>
-Ross Turk <ross.turk@inktank.com> <ross@inktank.com> 
+Robin H. Johnson <robin.johnson@dreamhost.com>
+Robin Tang <robintang974@gmail.com>
+Ron Allred <rallred@itrefined.com> <ron-github@neversleep.net>
+Ross Turk <ross.turk@inktank.com> <ross@inktank.com>
 Ross Turk <ross.turk@inktank.com> <ross.turk@dreamhost.com>
+Ruifeng Yang <yangruifeng.09209@h3c.com>
 Ruifeng Yang <yangruifeng.09209@h3c.com> <149233652@qq.com>
-Ruifeng Yang <yangruifeng.09209@h3c.com> <yangruifeng.09209@h3c.com> 
+Sage Weil <sage@inktank.com>
+Sage Weil <sage@inktank.com> <sage.weil@inktank.com>
 Sage Weil <sage@inktank.com> <sage@29311d96-e01e-0410-9327-a35deaab8ce9>
 Sage Weil <sage@inktank.com> <sage@ceph0.dreamhost.com>
 Sage Weil <sage@inktank.com> <sage@foil.westwood.newdream.net>
@@ -219,39 +217,35 @@ Sage Weil <sage@inktank.com> <sage@skinny.ops.newdream.net>
 Sage Weil <sage@inktank.com> <sage@vapre.localdomain>
 Sage Weil <sage@inktank.com> <sageweil@29311d96-e01e-0410-9327-a35deaab8ce9>
 Sage Weil <sage@inktank.com> <sage.weil@dreamhost.com>
-Sage Weil <sage@inktank.com> <sage.weil@inktank.com>
-Sage Weil <sweil@redhat.com> Reviewed-by: Sage Weil <sage@redhat.com>
-Sage Weil <sweil@redhat.com> Sage Weil <sage@redhat.com>
+Sage Weil <sweil@redhat.com>
+Sage Weil <sweil@redhat.com> <sage@redhat.com>
 Sahid Orentino Ferdjaoui <sahid.ferdjaoui@cloudwatt.com> <sahid.ferdjaoui@gmail.com>
 Sam Lang <sam.lang@inktank.com> <samlang@gmail.com>
+Samuel Just <sam.just@inktank.com>
 Samuel Just <sam.just@inktank.com> <sam.just@dreamhost.com>
-Samuel Just <sam.just@inktank.com> <sam.just@inktank.com>
 Samuel Just <sam.just@inktank.com> <sam.just@inktnak.com>
-Samuel Just <sam.just@inktank.com> Sam Just <sam.just@inktank.com>
 Samuel Just <sam.just@inktank.com> <sam@Pondermatic.(none)>
 Samuel Just <sam.just@inktank.com> <samuelj@hq.newdream.net>
 Samuel Just <sam.just@inktank.com> <samuel.just@dreamhost.com>
 Samuel Just <sam.just@inktank.com> <samuel.just@inktank.com>
+Samuel Just <sjust@redhat.com>
 Samuel Just <sjust@redhat.com> <rexludorum@gmail.com>
-Sandon Van Ness <sandon@inktank.com> SandonV <sandon@inktank.com>
+Sandon Van Ness <sandon@inktank.com>
 Sandon Van Ness <svanness@redhat.com> <sandon@redhat.com>
 Sangdi Xu <xu.sangdi@h3c.com> <xu.sangdi@h3c>
-Sangdi Xu <xu.sangdi@h3c.com> <xu.sangdi@h3c.com>
-Scott A. Brandt <scott@cs.ucsc.edu> sbrandt <sbrandt@29311d96-e01e-0410-9327-a35deaab8ce9>
+Scott A. Brandt <scott@cs.ucsc.edu> <sbrandt@29311d96-e01e-0410-9327-a35deaab8ce9>
 Sébastien Han <shan@redhat.com> <sebastien.han@enovance.com>
-Sebastien Ponce <sebastien.ponce@cern.ch> Sebastien Ponce <Sebastien.Ponce@cern.ch>
-Sergey Arkhipov <nineseconds@yandex.ru> 9seconds <nineseconds@yandex.ru>
+Sebastien Ponce <sebastien.ponce@cern.ch> <Sebastien.Ponce@cern.ch>
+Sergey Arkhipov <nineseconds@yandex.ru>
 Shanggao Qiu <qiushanggao@qq.com> qiushanggao
-Shawn Chen <cxwshawn@gmail.com> <cxwshawn@gmail.com>
-Shu, Xinxin <xinxin.shu@intel.com> xinxin shu <xinxin.shu@intel.com>
-Shu, Xinxin <xinxin.shu@intel.com> xinxinsh <xinxin.shu@intel.com>
+Shawn Chen <cxwshawn@gmail.com>
+Shu, Xinxin <xinxin.shu@intel.com>
 Stephen F Taylor <steveftaylor@gmail.com> <steve@DES-U1404-STETAY.stc.local>
-Sushma Gurram <sushma.gurram@sandisk.com> sushma <sushma.gurram@sandisk.com>
-Swami Reddy <swami.reddy@ril.com> M Ranga Swami Reddy <swamireddy@gmail.com>
+Sushma Gurram <sushma.gurram@sandisk.com>
 Swami Reddy <swami.reddy@ril.com> <swamireddy@gmail.com>
 Sylvain Munaut <s.munaut@whatever-company.com> <tnt@246tNt.com>
 Takeshi Miyamae <miyamae.takeshi@jp.fujitsu.com> t-miyamae
-Tamil Muthamizhan <tamil.muthamizhan@inktank.com> tamil <tamil.muthamizhan@inktank.com>
+Tamil Muthamizhan <tamil.muthamizhan@inktank.com>
 Tamil Muthamizhan <tamil.muthamizhan@inktank.com> <tamil@tamil-VirtualBox.(none)>
 Tamil Muthamizhan <tamil.muthamizhan@inktank.com> <tamil@ubuntu.(none)>
 Thomas Bechtold <t.bechtold@telekom.de> <thomasbechtold@jpberlin.de>
@@ -259,43 +253,42 @@ Thomas Cantin <thomas.cantin@telecom-bretagne.eu> ThomasCantin
 Thomas Johnson <NTmatter@gmail.com> <thomas.johnson@180amsterdam.com>
 Thomas Laumondais <thomas.laumondais@gmail.com> <LSWS0275@EB-OR6251090.toulouse.francetelecom.fr>
 Tianshan Qu <tianshan@xsky.com> <qutianshan@gmail.com>
-Tobias Suckow <tobias@suckow.biz> <tobias@suckow.biz>
+Tobias Suckow <tobias@suckow.biz>
 Tommi Virtanen <tv@inktank.com> <tommi.virtanen@dreamhost.com>
 Tommi Virtanen <tv@inktank.com> <tv@eagain.net>
 Tommi Virtanen <tv@inktank.com> <tv@hq.newdream.net>
 Travis Rhoden <trhoden@redhat.com> <trhoden@gmail.com>
-Tyler Brekke <tyler.brekke@inktank.com> Concubidated <tyler.brekke@inktank.com>
-Valentin Arshanes Thomas <valentin.arshanes.thomas@gmail.com> <valentin.arshanes.thomas@gmail.com>
+Tyler Brekke <tyler.brekke@inktank.com>
+Valentin Arshanes Thomas <valentin.arshanes.thomas@gmail.com>
 Varada Kari <varada.kari@sandisk.com> <kariraja@yahoo.com>
-Vasu Kulkarni <vasu.kulkarni@gmail.com> <vasu.kulkarni@gmail.com>
+Vasu Kulkarni <vasu.kulkarni@gmail.com>
 Volker Assmann <volker@twisted-nerve.de> <volker@36-135.mops.RWTH-Aachen.DE>
 Volker Assmann <volker@twisted-nerve.de> <volker@stan.local>
-Walter Huf <hufman@gmail.com> Walter J. Huf <hufman@gmail.com>
-Wang, Yaguang <yaguang.wang@intel.com> ywang19 <yaguang.wang@intel.com>
-Warren Usui <warren.usui@inktank.com> wusui <warren.usui@inktank.com>
-Weijun Duan <duanweijun@h3c.com> <duanweijun@h3c.com>
-Wei Luo <luowei@yahoo-inc.com> luowei <luowei@yahoo-inc.com>
-Wei Luo <weilluo@tencent.com> <weilluo@tencent.com>
-Wei Qian <weiq@dtdream.com> <weiq@dtdream.com>
-Wenjun Huang <wenjunhuang@tencent.com> <wenjunhuang@tencent.com>
+Walter Huf <hufman@gmail.com>
+Wang, Yaguang <yaguang.wang@intel.com>
+Warren Usui <warren.usui@inktank.com>
+Weijun Duan <duanweijun@h3c.com>
+Wei Luo <luowei@yahoo-inc.com>
+Wei Luo <weilluo@tencent.com>
+Wei Qian <weiq@dtdream.com>
+Wenjun Huang <wenjunhuang@tencent.com>
 Wido den Hollander <wido@42on.com> <wido@widodh.nl>
-Wu Xingyi <wuxingyi@letv.com> <wuxingyi@letv.com>
-Xan Peng <xanpeng@gmail.com> xan <xanpeng@gmail.com>
+Wu Xingyi <wuxingyi@letv.com>
+Xan Peng <xanpeng@gmail.com>
 Xavier Roche <roche+git@exalead.com> <roche@httrack.com>
-Xiaowei Chen <chen.xiaowei@h3c.com> <chen.xiaowei@h3c.com>
+Xiaowei Chen <chen.xiaowei@h3c.com>
 Xiaowei Chen <chen.xiaowei@h3c.com> <cxwshawn@gmail.com>
-Xie Rui <875016668@qq.com> Jerry7X <875016668@qq.com>
-Xie Rui <875016668@qq.com> Xie Rui <jerry.xr86@gmail.com>
+Xie Rui <875016668@qq.com>
+Xie Rui <875016668@qq.com> <jerry.xr86@gmail.com>
 Xie Xingguo <xie.xingguo@zte.com.cn> <258156334@qq.com>
 Xie Xingguo <xie.xingguo@zte.com.cn> <xie.xiexingguo@zte.com.cn>
 Xingyi Wu <wuxingyi2015@outlook.com>
-Xinze Chi <xinze@xsky.com> <xinze@xksy.com>
+Xinze Chi <xinze@xsky.com>
 Xinze Chi <xinze@xsky.com> <xmdxcxz@gmail.com>
-Xuan Liu <liu.xuan@h3c.com> <liu.xuan@h3c.com>
-Yannick Atchy Dalama <yannick.atchy.dalama@gmail.com> <yannick.atchy.dalama@gmail.com>
+Xuan Liu <liu.xuan@h3c.com>
+Yannick Atchy Dalama <yannick.atchy.dalama@gmail.com>
+Yan, Zheng <zheng.z.yan@intel.com>
 Yan, Zheng <zheng.z.yan@intel.com> <ukernel@gmail.com>
-Yan, Zheng <zheng.z.yan@intel.com> Zheng Yan <zheng.z.yan@intel.com>
-Yan, Zheng <zheng.z.yan@intel.com> Zheng, Yan <zheng.z.yan@intel.com>
 Yehua Chen <chen.yehua@h3c.com> <root@ubuntu1.com>
 Yehuda Sadeh <yehuda@inktank.com> <yehdua@inktank.com>
 Yehuda Sadeh <yehuda@inktank.com> <yehuda@hq.newdream.net>
@@ -309,16 +302,15 @@ Yehuda Sadeh <yehuda@inktank.com> <yehuda@yehuda.infit.com>
 Yehuda Sadeh <ysadehwe@redhat.com> <yehuda@redhat.com>
 Yehuda Sadeh <ysadehwe@redhat.com> <yehuda@rehat.com>
 Yehuda Sadeh <ysadehwe@redhat.com> <ysadeh@redhat.com>
-Yongyue Sun <abioy.sun@gmail.com> Abioy <abioy.sun@gmail.com>
-You Ji <youji@ebay.com> <youji@ebay.com>
+Yongyue Sun <abioy.sun@gmail.com>
+You Ji <youji@ebay.com>
 Yuan Zhou <yuan.zhou@intel.com> <dunk007@gmail.com>
 Yunchuan Wen <yunchuan.wen@kylin-cloud.com> <yunchuanwen@ubuntukylin.com>
-Zengran Zhang <zhangzengran@h3c.com> <zhangzengran@h3c.com>
-Zeqiang Zhuang <zhuang.zeqiang@h3c.com> <zhuang.zeqiang@h3c.com>
+Zengran Zhang <zhangzengran@h3c.com>
+Zeqiang Zhuang <zhuang.zeqiang@h3c.com>
+Zhi (David) Zhang <zhangz@yahoo-inc.com>
 Zhi (David) Zhang <zhangz@yahoo-inc.com> <david.z1003@yahoo.com>
-Zhi (David) Zhang <zhangz@yahoo-inc.com> Zhi Z Zhang <zhangz@yahoo-inc.com>
-Zhiqiang Wang <zhiqiang.wang@intel.com> Signed-off-by: Zhiqiang Wang <wonzhq@hotmail.com>
-Zhiqiang Wang <zhiqiang.wang@intel.com> Wang, Zhiqiang <zhiqiang.wang@intel.com>
-Zhiqiang Wang <zhiqiang.wang@intel.com> Zhiqiang Wang <wonzhq@hotmail.com>
-Zhiqiang Wang <zhiqiang.wang@intel.com> Zhiqiang Wang <zhiqiang.wang@intel.com>
+Zhiqiang Wang <zhiqiang.wang@intel.com>
+Zhiqiang Wang <zhiqiang.wang@intel.com> <wonzhq@hotmail.com>
+Zhi Zhang <willzzhang@tencent.com>
 Zhi Zhang <zhangz.david@outlook.com> <zhangzhi@localhost.localdomain>

--- a/.mailmap
+++ b/.mailmap
@@ -318,4 +318,5 @@ Zhi (David) Zhang <zhangz@yahoo-inc.com> <david.z1003@yahoo.com>
 Zhiqiang Wang <zhiqiang.wang@intel.com>
 Zhiqiang Wang <zhiqiang.wang@intel.com> <wonzhq@hotmail.com>
 Zhi Zhang <willzzhang@tencent.com>
-Zhi Zhang <zhangz.david@outlook.com> <zhangzhi@localhost.localdomain>
+Zhi Zhang <willzzhang@tencent.com> <zhangz.david@outlook.com>
+Zhi Zhang <willzzhang@tencent.com> <zhangzhi@localhost.localdomain>

--- a/.mailmap
+++ b/.mailmap
@@ -51,6 +51,8 @@ Chris Holcombe <chris.holcombe@nebula.com> <xfactor973@gmail.com>
 Christian Brunner <christian@brunner-muc.de> <chb@muc.de>
 Christian Marie <pingu@anchor.net.au> <christian@ponies.io>
 Christophe Courtaut <christophe.courtaut@gmail.com>
+Chuanhong Wang <wang.chuanhong@zte.com.cn>
+Chuanhong Wang <wang.chuanhong@zte.com.cn> <chuanhong.wang@163.com>
 Chuanhong Wang <wang.chuanhong@zte.com.cn> <root@A22832429.(none)>
 Claire Massot <claire.massot93@gmail.com> <claire12.93@hotmail.fr>
 Clement Lebrun <clement.lebrun.31@gmail.com> <clem_noob@hotmail.fr>

--- a/.mailmap
+++ b/.mailmap
@@ -25,6 +25,7 @@ Andrew Leung <aleung@cs.ucsc.edu> <anwleung@29311d96-e01e-0410-9327-a35deaab8ce9
 Andy Allan <andy@gravitystorm.co.uk> <github@gravitystorm.co.uk>
 Anis Ayari <ayari_anis@live.fr>
 Aristoteles Neto <aristoteles.neto@webdrive.co.nz> <wdneto@users.noreply.github.com>
+Aron Gunn <ritz_303@yahoo.com>
 Ashish Chandra <ashish.a.chandra@ril.com> <mail.ashishchandra@gmail.com>
 Baptiste Veuillez <baptiste.veuillez--mainard@telecom-bretagne.eu> <baptiste@UbuntuBVM.lan>
 Billy Olsen <billy.olsen@canonical.com> <billy.olsen@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -195,6 +195,7 @@ Pierre Chaumont <pierre.chaumont31@gmail.com>
 Qiankun Zheng <zheng.qiankun@h3c.com>
 Radoslaw Zarzynski <rzarzynski@mirantis.com> <rzarzynski@github.com>
 Rahul Aggarwal <rahul.1aggarwal@gmail.com>
+Ren Huanwen <ren.huanwen@zte.com.cn>
 Ren Huanwen <ren.huanwen@zte.com.cn> <rhwlyw@163.com>
 Riccardo Ferretti <rferrett@soe.ucsc.edu> <rferrett@29311d96-e01e-0410-9327-a35deaab8ce9>
 Roald J. van Loon <roald@roaldvanloon.nl> <roaldvanloon@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -276,6 +276,7 @@ Wido den Hollander <wido@42on.com> <wido@widodh.nl>
 Wu Xingyi <wuxingyi@letv.com>
 Xan Peng <xanpeng@gmail.com>
 Xavier Roche <roche+git@exalead.com> <roche@httrack.com>
+Xiangwei Wu <wuxiangwei@h3c.com>
 Xiaowei Chen <chen.xiaowei@h3c.com>
 Xiaowei Chen <chen.xiaowei@h3c.com> <cxwshawn@gmail.com>
 Xie Rui <875016668@qq.com>

--- a/.mailmap
+++ b/.mailmap
@@ -103,6 +103,7 @@ Guilhem Lettron <guilhem@lettron.fr> <guilhem+github@lettron.fr>
 Haomai Wang <haomai@xsky.com> <haomaiwang@gmail.com>
 Haomai Wang <haomai@xsky.com> <haomai@xsky.io>
 Haomai Wang <haomai@xsky.com> <yuyuyu101@163.com>
+Harry Harrington <git-harry@live.co.uk>
 Hazem Amara <hazem.amara@telecom-bretagne.eu> <hazem@hazem-Inspiron-3537.(none)>
 Henry C Chang <henry_c_chang@tcloudcomputing.com> <henry.cy.chang@gmail.com>
 Hervé Rousseau <hroussea@cern.ch>

--- a/.mailmap
+++ b/.mailmap
@@ -7,6 +7,7 @@
 #
 #
 Abhishek Lekshmanan <abhishek.lekshmanan@ril.com> <abhishek.lekshmanan@gmail.com>
+Adam Twardowski <adam.twardowski@gmail.com>
 Ahoussi Armand <ahoussi.say@telecom-bretagne.eu> <delco225>
 Ailing Zhang <zhangal1992@gmail.com> <ailzhang@users.noreply.github.com>
 Alexander Chuzhoy <achuzhoy@redhat.com> <schuzhoy@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -76,6 +76,7 @@ Florent Manens <florent@beezim.fr> <florent@manens.org>
 Florian Coste <fcoste21@gmail.com> nairolf21
 Florian Marsylle <florian.marsylle@hotmail.fr> <floleblanc@hotmail.fr>
 François Lafont <flafdivers@free.fr> <francois.lafont@crdp.ac-versailles.fr>
+François Lafont <flafdivers@free.fr> <francois.lafont@ac-versailles.fr>
 Gabriel Sentucq <perso@kazhord.fr> <perso@kazhord.fr>
 Gary Lowell <gary.lowell@inktank.com>
 Gary Lowell <gary.lowell@inktank.com> <glowell@flab.ops.newdream.net>

--- a/.mailmap
+++ b/.mailmap
@@ -295,6 +295,7 @@ Xuan Liu <liu.xuan@h3c.com>
 Yannick Atchy Dalama <yannick.atchy.dalama@gmail.com>
 Yan, Zheng <zheng.z.yan@intel.com>
 Yan, Zheng <zheng.z.yan@intel.com> <ukernel@gmail.com>
+Yehua Chen <chen.yehua@h3c.com>
 Yehua Chen <chen.yehua@h3c.com> <root@ubuntu1.com>
 Yehuda Sadeh <yehuda@inktank.com> <yehdua@inktank.com>
 Yehuda Sadeh <yehuda@inktank.com> <yehuda@hq.newdream.net>

--- a/.mailmap
+++ b/.mailmap
@@ -240,6 +240,7 @@ Sergey Arkhipov <nineseconds@yandex.ru>
 Shanggao Qiu <qiushanggao@qq.com> qiushanggao
 Shawn Chen <cxwshawn@gmail.com>
 Shu, Xinxin <xinxin.shu@intel.com>
+Song Baisen <song.baisen@zte.com.cn>
 Stephen F Taylor <steveftaylor@gmail.com> <steve@DES-U1404-STETAY.stc.local>
 Sushma Gurram <sushma.gurram@sandisk.com>
 Swami Reddy <swami.reddy@ril.com> <swamireddy@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -163,6 +163,7 @@ Loic Dachary <loic@dachary.org>
 Loic Dachary <loic@dachary.org> <loic@dachary.com>
 Lucas Fantinel <lucas.fantinel@gmail.com>
 Lu Shi <shi.lu@h3c.com>
+Luo Kexue <luo.kexue@zte.com.cn> <scienceluo@qq.com>
 Ma Jianpeng <jianpeng.ma@intel.com>
 Ma Jianpeng <jianpeng.ma@intel.com> <majianpeng@gmail.com>
 Marco Garcês <marco.garces@bci.co.mz> <marco@garces.cc>

--- a/.mailmap
+++ b/.mailmap
@@ -151,6 +151,7 @@ John Wilkins <john.wilkins@inktank.com> <johnw@johnw7664.(none)>
 John Wilkins <jwilkins@redhat.com> <jowilkin@redhat.com>
 John Wilkins <jwilkins@redhat.com> <jowilki@redhat.com>
 John Wilkins <jwilkins@redhat.com> <jowilk@redhat.com>
+Jonas Keidel <jonas@jonas-keidel.de>
 Jordan Dorne <jordan.dorne@gmail.com>
 Josh Durgin <jdurgin@redhat.com>
 Josh Durgin <josh.durgin@inktank.com> <joshd@hq.newdream.net>

--- a/.mailmap
+++ b/.mailmap
@@ -246,6 +246,7 @@ Sebastien Ponce <sebastien.ponce@cern.ch> <Sebastien.Ponce@cern.ch>
 Sergey Arkhipov <nineseconds@yandex.ru>
 Shanggao Qiu <qiushanggao@qq.com>
 Shawn Chen <cxwshawn@gmail.com>
+Shishir Gowda <shishir.gowda@sandisk.com>
 Shu, Xinxin <xinxin.shu@intel.com>
 Shun Song <song.shun3@zte.com.cn>
 Shun Song <song.shun3@zte.com.cn> <songshun134@126.com>

--- a/.mailmap
+++ b/.mailmap
@@ -246,6 +246,9 @@ Sergey Arkhipov <nineseconds@yandex.ru>
 Shanggao Qiu <qiushanggao@qq.com>
 Shawn Chen <cxwshawn@gmail.com>
 Shu, Xinxin <xinxin.shu@intel.com>
+Shun Song <song.shun3@zte.com.cn>
+Shun Song <song.shun3@zte.com.cn> <songshun134@126.com>
+Shun Song <song.shun3@zte.com.cn> <root@clove83.zte.com.cn>
 Song Baisen <song.baisen@zte.com.cn>
 Stephen F Taylor <steveftaylor@gmail.com> <steve@DES-U1404-STETAY.stc.local>
 Sushma Gurram <sushma.gurram@sandisk.com>

--- a/.mailmap
+++ b/.mailmap
@@ -152,6 +152,7 @@ Kiseleva Alyona <akiselyova@mirantis.com> Ved-vampir
 Kongming Wu <wu.kongming@h3c.com>
 Laszlo Boszormenyi <gcs@debian.hu>
 Li Wang <li.wang@kylin-cloud.com> <liwang@ubuntukylin.com>
+Liu Peiyan <liu.peiyang@h3c.com>
 Lluis Pamies-Juarez <lluis.pamies-juarez@hgst.com> <lluis@pamies.cat>
 Loic Dachary <ldachary@redhat.com> <dachary@users.noreply.github.com>
 Loic Dachary <ldachary@redhat.com> <ldachary@dachary.org>

--- a/.mailmap
+++ b/.mailmap
@@ -123,6 +123,7 @@ Jenkins <jenkins@ceph.com> Jenkins <jenkins@inktank.com>
 Jiang Heng <jiangheng0511@gmail.com>
 Jiantao He <hejiantao5@gmail.com>
 Jian Wen <wenjian@letv.com> <wenjianhn@gmail.com>
+Jingkai Yuan <jingkai.yuan@intel.com>
 Ji Chen <insomnia@139.com>
 João Eduardo Luís <joao.luis@inktank.com>
 João Eduardo Luís <joao.luis@inktank.com> <joao@inktank.com>

--- a/.mailmap
+++ b/.mailmap
@@ -23,37 +23,37 @@ Andreas Peters <andreas.joachim.peters@cern.ch> <Andreas.Joachim.Peters@cern.ch>
 Andrew Bartlett <abartlet@catalyst.net.nz> <abartlet@samba.org>
 Andrew Leung <aleung@cs.ucsc.edu> <anwleung@29311d96-e01e-0410-9327-a35deaab8ce9>
 Andy Allan <andy@gravitystorm.co.uk> <github@gravitystorm.co.uk>
-Anis Ayari <ayari_anis@live.fr> Anols
+Anis Ayari <ayari_anis@live.fr>
 Aristoteles Neto <aristoteles.neto@webdrive.co.nz> <wdneto@users.noreply.github.com>
 Ashish Chandra <ashish.a.chandra@ril.com> <mail.ashishchandra@gmail.com>
 Baptiste Veuillez <baptiste.veuillez--mainard@telecom-bretagne.eu> <baptiste@UbuntuBVM.lan>
 Billy Olsen <billy.olsen@canonical.com> <billy.olsen@gmail.com>
-Bo Cai <cai.bo@h3c.com> caibo <cai.bo@h3c.com>
-Boris Ranto <branto@redhat.com> branto1 <branto@redhat.com>
+Bo Cai <cai.bo@h3c.com>
+Boris Ranto <branto@redhat.com>
 Brian Andrus <bandrus@redhat.com> <bandrus+github@gmail.com>
-Brian Felton <bjfelton@gmail.com> <bjfelton@gmail.com>
-Brian Rak <dn@devicenull.org> devicenull <dn@devicenull.org>
-Burkhard Linke <Burkhard.Linke@computational.bio.uni-giessen.de> <Burkhard.Linke@computational.bio.uni-giessen.de>
+Brian Felton <bjfelton@gmail.com>
+Brian Rak <dn@devicenull.org>
+Burkhard Linke <Burkhard.Linke@computational.bio.uni-giessen.de>
 Caleb Miles <caleb.miles@inktank.com>
 Caleb Miles <caleb.miles@inktank.com> <caselim@gmail.com>
 Carlos Maltzahn <carlosm@cs.ucsc.edu> <carlosm@29311d96-e01e-0410-9327-a35deaab8ce9>
-Casey Marshall <csm@soe.ucsc.edu> rsdio <rsdio@29311d96-e01e-0410-9327-a35deaab8ce9>
-Ce Gu <guce@h3c.com> <guce@h3c.com>
-Chen Dihao <tobeg3oogle@gmail.com> <tobeg3oogle@gmail.com>
+Casey Marshall <csm@soe.ucsc.edu> <rsdio@29311d96-e01e-0410-9327-a35deaab8ce9>
+Ce Gu <guce@h3c.com>
+Chen Dihao <tobeg3oogle@gmail.com>
 Chendi Xue <chendi.xue@intel.com>
 Chendi Xue <chendi.xue@intel.com> <xuechendi@gmail.com>
-Cheng Cheng <ccheng.leo@gmail.com> <ccheng.leo@gmail.com>
+Cheng Cheng <ccheng.leo@gmail.com>
 Chris Holcombe <chris.holcombe@nebula.com> <xfactor973@gmail.com>
 Christian Brunner <christian@brunner-muc.de> <chb@muc.de>
 Christian Marie <pingu@anchor.net.au> <christian@ponies.io>
-Christophe Courtaut <christophe.courtaut@gmail.com> Kri5 <christophe.courtaut@gmail.com>
-Chuanhong Wang <wang.chuanhong@zte.com.cn> wangchaunhong <root@A22832429.(none)>
+Christophe Courtaut <christophe.courtaut@gmail.com>
+Chuanhong Wang <wang.chuanhong@zte.com.cn> <root@A22832429.(none)>
 Claire Massot <claire.massot93@gmail.com> <claire12.93@hotmail.fr>
 Clement Lebrun <clement.lebrun.31@gmail.com> <clem_noob@hotmail.fr>
 Colin P. McCabe <colinm@hq.newdream.net> <cmccabe@alumni.cmu.edu>
 Colin P. McCabe <colinm@hq.newdream.net> <cmccabe@fatty.ops.newdream.net>
-Dan Chai <tengweicai@gmail.com> danchai <tengweicai@gmail.com>
-Daniel Gryniewicz <dang@redhat.com>  <dang@fprintf.net>
+Dan Chai <tengweicai@gmail.com> <tengweicai@gmail.com>
+Daniel Gryniewicz <dang@redhat.com> <dang@fprintf.net>
 Dan Mick <dan.mick@inktank.com> <dan.mick@dreamhost.com>
 Dan Mick <dmick@redhat.com> <dan.mick@redhat.com>
 Dan Mick <dmick@redhat.com> <dmick@danceorelse.org>
@@ -63,27 +63,27 @@ Dennis Schafroth <dennis@schafroth.com> <dennis@schafroth.dk>
 Dmitry Smirnov <onlyjob@member.fsf.org> <onlyjob@debian.org>
 Dmitry Yatsushkevich <dyatsushkevich@mirantis.com> <dmitry.yatsushkevich@gmail.com>
 Dominik Hannen <cantares1+github@gmail.com> <dhxgit@users.noreply.github.com>
-Donghai Xu <xu.donghai@h3c.com> <xu.donghai@h3c.com>
-Dongmao Zhang <deanraccoon@gmail.com> <deanraccoon@gmail.com>
+Donghai Xu <xu.donghai@h3c.com>
+Dongmao Zhang <deanraccoon@gmail.com>
 Eric Mourgaya <eric.mourgaya@arkea.com> <eric.mourgaya@gmail.com>
 Erwin, Brock A <Brock.Erwin@pnl.gov> <Brock.Erwin@pnl.govgit>
 Esteban Molina-Estolano <eestolan@lanl.gov> <eestolan@29311d96-e01e-0410-9327-a35deaab8ce9>
 Federico Gimenez <fgimenez@coit.es> <federico.gimenez@hola-internet.com>
 Feng Wang <cyclonew@cs.ucsc.edu> <cyclonew@29311d96-e01e-0410-9327-a35deaab8ce9>
-Florent Bautista <florent@coppint.com> <florent@coppint.com>
+Florent Bautista <florent@coppint.com>
 Florent Flament <florent.flament@cloudwatt.com> <florent.flament-ext@cloudwatt.com>
 Florent Manens <florent@beezim.fr> <florent@manens.org>
-Florian Coste <fcoste21@gmail.com> nairolf21
+Florian Coste <fcoste21@gmail.com>
 Florian Marsylle <florian.marsylle@hotmail.fr> <floleblanc@hotmail.fr>
 François Lafont <flafdivers@free.fr> <francois.lafont@crdp.ac-versailles.fr>
 François Lafont <flafdivers@free.fr> <francois.lafont@ac-versailles.fr>
-Gabriel Sentucq <perso@kazhord.fr> <perso@kazhord.fr>
+Gabriel Sentucq <perso@kazhord.fr>
 Gary Lowell <gary.lowell@inktank.com>
 Gary Lowell <gary.lowell@inktank.com> <glowell@flab.ops.newdream.net>
 Gary Lowell <gary.lowell@inktank.com> <glowell@inktank.com>
 Gaurav Kumar Garg <garg.gaurav52@gmail.com> <ggarg@redhat.com>
 Gerben Meijer <gerben@daybyday.nl> <infernix@gmail.com>
-Germain Chipaux <germain.chipaux@gmail.com> <germain.chipaux@gmail.com>
+Germain Chipaux <germain.chipaux@gmail.com>
 Greg Farnum <gfarnum@redhat.com>
 Greg Farnum <gfarnum@redhat.com> <gfarnum@GF-Macbook.local>
 Greg Farnum <gfarnum@redhat.com> <gfarnum@rehdat.com>
@@ -103,9 +103,9 @@ Haomai Wang <haomai@xsky.com> <haomai@xsky.io>
 Haomai Wang <haomai@xsky.com> <yuyuyu101@163.com>
 Hazem Amara <hazem.amara@telecom-bretagne.eu> <hazem@hazem-Inspiron-3537.(none)>
 Henry C Chang <henry_c_chang@tcloudcomputing.com> <henry.cy.chang@gmail.com>
-Hervé Rousseau <hroussea@cern.ch> <hroussea@cern.ch>
+Hervé Rousseau <hroussea@cern.ch>
 Holger Macht <hmacht@suse.de> <holger@homac.de>
-Huamin Chen <hchen@redhat.com> rootfs <hchen@redhat.com>
+Huamin Chen <hchen@redhat.com>
 Huang Jun <hjwsm1989@gmail.com>
 Ilja Slepnev <islepnev@gmail.com>
 Ilya Dryomov <idryomov@redhat.com> <idryomov@gmail.com>
@@ -131,8 +131,8 @@ João Eduardo Luís <joao@suse.de>
 João Eduardo Luís <joao@suse.de> <jluis@suse.com>
 João Eduardo Luís <joao@suse.de> <joao@suse.com>
 Joe Buck <jbbuck@gmail.com> <buck@soe.ucsc.edu>
+John Spray <jspray@redhat.com>
 John Spray <jspray@redhat.com> <jcspray@gmail.com>
-John Spray <jspray@redhat.com> <jspray@redhat.com>
 John Spray <jspray@redhat.com> <john.spray@redhat.com>
 Johnu George <johnugeo@cisco.com> <johnugeorge109@gmail.com>
 John Wilkins <john.wilkins@inktank.com> <john@admin-host.(none)>
@@ -141,15 +141,15 @@ John Wilkins <john.wilkins@inktank.com> <johnw@johnw7664.(none)>
 John Wilkins <jwilkins@redhat.com> <jowilkin@redhat.com>
 John Wilkins <jwilkins@redhat.com> <jowilki@redhat.com>
 John Wilkins <jwilkins@redhat.com> <jowilk@redhat.com>
-Jordan Dorne <jordan.dorne@gmail.com> <jordan.dorne@gmail.com>
+Jordan Dorne <jordan.dorne@gmail.com>
 Josh Durgin <jdurgin@redhat.com>
 Josh Durgin <josh.durgin@inktank.com> <joshd@hq.newdream.net>
 Josh Durgin <josh.durgin@inktank.com> <josh.durgin@dreamhost.com>
 Kacper Kowalik <xarthisius@gentoo.org>
 Kefu Chai <kchai@redhat.com> <tchaikov@gmail.com>
-Ken Dreyer <kdreyer@redhat.com> <kdreyer@redhat.com>
-Kévin Caradant <kevin.caradant@gmail.com> <kevin.caradant@gmail.com>
-Kiseleva Alyona <akiselyova@mirantis.com> Ved-vampir
+Ken Dreyer <kdreyer@redhat.com>
+Kévin Caradant <kevin.caradant@gmail.com>
+Kiseleva Alyona <akiselyova@mirantis.com>
 Kongming Wu <wu.kongming@h3c.com>
 Laszlo Boszormenyi <gcs@debian.hu>
 Li Wang <li.wang@kylin-cloud.com> <liwang@ubuntukylin.com>
@@ -241,7 +241,7 @@ Scott A. Brandt <scott@cs.ucsc.edu> <sbrandt@29311d96-e01e-0410-9327-a35deaab8ce
 Sébastien Han <shan@redhat.com> <sebastien.han@enovance.com>
 Sebastien Ponce <sebastien.ponce@cern.ch> <Sebastien.Ponce@cern.ch>
 Sergey Arkhipov <nineseconds@yandex.ru>
-Shanggao Qiu <qiushanggao@qq.com> qiushanggao
+Shanggao Qiu <qiushanggao@qq.com>
 Shawn Chen <cxwshawn@gmail.com>
 Shu, Xinxin <xinxin.shu@intel.com>
 Song Baisen <song.baisen@zte.com.cn>
@@ -249,12 +249,12 @@ Stephen F Taylor <steveftaylor@gmail.com> <steve@DES-U1404-STETAY.stc.local>
 Sushma Gurram <sushma.gurram@sandisk.com>
 Swami Reddy <swami.reddy@ril.com> <swamireddy@gmail.com>
 Sylvain Munaut <s.munaut@whatever-company.com> <tnt@246tNt.com>
-Takeshi Miyamae <miyamae.takeshi@jp.fujitsu.com> t-miyamae
+Takeshi Miyamae <miyamae.takeshi@jp.fujitsu.com>
 Tamil Muthamizhan <tamil.muthamizhan@inktank.com>
 Tamil Muthamizhan <tamil.muthamizhan@inktank.com> <tamil@tamil-VirtualBox.(none)>
 Tamil Muthamizhan <tamil.muthamizhan@inktank.com> <tamil@ubuntu.(none)>
 Thomas Bechtold <t.bechtold@telekom.de> <thomasbechtold@jpberlin.de>
-Thomas Cantin <thomas.cantin@telecom-bretagne.eu> ThomasCantin
+Thomas Cantin <thomas.cantin@telecom-bretagne.eu>
 Thomas Johnson <NTmatter@gmail.com> <thomas.johnson@180amsterdam.com>
 Thomas Laumondais <thomas.laumondais@gmail.com> <LSWS0275@EB-OR6251090.toulouse.francetelecom.fr>
 Tianshan Qu <tianshan@xsky.com> <qutianshan@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -407,6 +407,7 @@ Unaffiliated <no@organization.net> Hector Martin <marcan@marcan.st>
 Unaffiliated <no@organization.net> Gaël Fenet-Garde <gael.fenet.garde@gmail.com>
 Unaffiliated <no@organization.net> Gaurav Kumar Garg <garg.gaurav52@gmail.com>
 Unaffiliated <no@organization.net> Germain Chipaux <germain.chipaux@gmail.com>
+Unaffiliated <no@organization.net> Gu Zhongyan <guzhongyan@360.cn>
 Unaffiliated <no@organization.net> Harry Harrington <git-harry@live.co.uk>
 Unaffiliated <no@organization.net> Henry Chang <henry@bigtera.com>
 Unaffiliated <no@organization.net> Huang Jun <hjwsm1989@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -399,6 +399,7 @@ Unaffiliated <no@organization.net> Hector Martin <marcan@marcan.st>
 Unaffiliated <no@organization.net> Gaël Fenet-Garde <gael.fenet.garde@gmail.com>
 Unaffiliated <no@organization.net> Gaurav Kumar Garg <garg.gaurav52@gmail.com>
 Unaffiliated <no@organization.net> Germain Chipaux <germain.chipaux@gmail.com>
+Unaffiliated <no@organization.net> Harry Harrington <git-harry@live.co.uk>
 Unaffiliated <no@organization.net> Henry Chang <henry@bigtera.com>
 Unaffiliated <no@organization.net> Huang Jun <hjwsm1989@gmail.com>
 Unaffiliated <no@organization.net> Ian Kelling <ian@iankelling.org>

--- a/.organizationmap
+++ b/.organizationmap
@@ -227,6 +227,7 @@ Los Alamos National Laboratory <contact@lanl.gov> Esteban Molina-Estolano <eesto
 Mellanox <contact@mellanox.com> Vu Pham <vu@mellanox.com>
 Mellanox <contact@mellanox.com> Roi Dayan <roid@mellanox.com>
 Mirantis <contact@mirantis.com> Adam Kupczyk <akupczyk@mirantis.com>
+Mirantis <contact@mirantis.com> Alexey Sheplyakov <asheplyakov@mirantis.com>
 Mirantis <contact@mirantis.com> Andrew Woodward <awoodward@mirantis.com>
 Mirantis <contact@mirantis.com> Dmitry Yatsushkevich <dyatsushkevich@mirantis.com>
 Mirantis <contact@mirantis.com> Dmytro Iurchenko <diurchenko@mirantis.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -423,6 +423,7 @@ Unaffiliated <no@organization.net> Jiang Heng <jiangheng0511@gmail.com>
 Unaffiliated <no@organization.net> Jianhui Yuan <zuiwanyuan@gmail.com>
 Unaffiliated <no@organization.net> Jiantao He <hejiantao5@gmail.com>
 Unaffiliated <no@organization.net> Jian Wen <wenjian@letv.com>
+Unaffiliated <no@organization.net> Jianjian Huo <samuel.huo@gmail.com>
 Unaffiliated <no@organization.net> Jiaying Ren <mikulely@gmail.com>
 Unaffiliated <no@organization.net> John Coyle <dx9err@gmail.com>
 Unaffiliated <no@organization.net> Jon Bernard <jbernard@tuxion.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -326,6 +326,7 @@ SAP <contact@sap.com> Marc Koderer <marc@koderer.com>
 Science & Technology Facilities Council <contact@stfc.ac.uk> George Ryall <george.ryall@stfc.ac.uk>
 SendFaster <contact@sendfaster.com> Christopher O'Connell <jwriteclub@gmail.com>
 Spectra Logic <contact@spectralogic.com> Alan Somers <asomers@gmail.com>
+SUSE <contact@suse.com> Abhishek Lekshmanan <abhishek@suse.com>
 SUSE <contact@suse.com> Adam Spiers <aspiers@suse.com>
 SUSE <contact@suse.com> David Disseldorp <ddiss@suse.de>
 SUSE <contact@suse.com> Hannes Reinecke <hare@suse.de>

--- a/.organizationmap
+++ b/.organizationmap
@@ -452,6 +452,7 @@ Unaffiliated <no@organization.net> Nicolas Yong <nicolas.yong93@gmail.com>
 Unaffiliated <no@organization.net> Nishtha Rai <nishtha3rai@gmail.com>
 Unaffiliated <no@organization.net> (no author) <(no author)@29311d96-e01e-0410-9327-a35deaab8ce9>
 Unaffiliated <no@organization.net> oddomatik <bandrus+github@gmail.com>
+Unaffiliated <no@organization.net> Patrick Donnelly <batrick@batbytes.com>
 Unaffiliated <no@organization.net> Pierre Chaumont <pierre.chaumont31@gmail.com>
 Unaffiliated <no@organization.net> Rachana Patel <rachana83.patel@gmail.com>
 Unaffiliated <no@organization.net> Rahul Aggarwal <rahul.1aggarwal@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -436,6 +436,7 @@ Unaffiliated <no@organization.net> Kernel Neophyte <neophyte.hacker001@gmail.com
 Unaffiliated <no@organization.net> Ketor Meng <d.ketor@gmail.com>
 Unaffiliated <no@organization.net> Kévin Caradant <kevin.caradant@gmail.com>
 Unaffiliated <no@organization.net> Kevin Cox <kevincox@kevincox.ca>
+Unaffiliated <no@organization.net> Kevin Jones <k.j.jonez@gmail.com>
 Unaffiliated <no@organization.net> Kim Vandry <vandry@TZoNE.ORG>
 Unaffiliated <no@organization.net> koleosfuscus <koleosfuscus@yahoo.com>
 Unaffiliated <no@organization.net> Laurent Guerby <laurent@guerby.net>

--- a/.organizationmap
+++ b/.organizationmap
@@ -223,6 +223,7 @@ Linaro <contact@linaro.org> Steve Capper <steve.capper@linaro.org>
 Linaro <contact@linaro.org> Yazen Ghannam <yazen.ghannam@linaro.org>
 Los Alamos National Laboratory <contact@lanl.gov> Esteban Molina-Estolano <eestolan@lanl.gov>
 Mellanox <contact@mellanox.com> Vu Pham <vu@mellanox.com>
+Mellanox <contact@mellanox.com> Roi Dayan <roid@mellanox.com>
 Mirantis <contact@mirantis.com> Adam Kupczyk <akupczyk@mirantis.com>
 Mirantis <contact@mirantis.com> Andrew Woodward <awoodward@mirantis.com>
 Mirantis <contact@mirantis.com> Dmitry Yatsushkevich <dyatsushkevich@mirantis.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -81,6 +81,7 @@ DreamHost <contact@dreamhost.com> Wesley Spikes <wesley.spikes@dreamhost.com>
 Dtdream <contact@dtdream.com> Li Peng <lip@dtdream.com>
 Dtdream <contact@dtdream.com> weiqian <weiq@dtdream.com>
 Dtdream <contact@dtdream.com> Wei Qian <weiq@dtdream.com>
+Eayun <contact@eayun.com> Dunrong Huang <dunrong.huang@eayun.com>
 Ebay <contact@ebay.com> Chengyuan Li <chengyli@ebay.com>
 Ebay <contact@ebay.com> You Ji <youji@ebay.com>
 École polytechnique fédérale de Lausanne <contact@epfl.ch> Stefan Eilemann <Stefan.Eilemann@epfl.ch>

--- a/.organizationmap
+++ b/.organizationmap
@@ -453,6 +453,7 @@ Unaffiliated <no@organization.net> Nishtha Rai <nishtha3rai@gmail.com>
 Unaffiliated <no@organization.net> (no author) <(no author)@29311d96-e01e-0410-9327-a35deaab8ce9>
 Unaffiliated <no@organization.net> oddomatik <bandrus+github@gmail.com>
 Unaffiliated <no@organization.net> Pierre Chaumont <pierre.chaumont31@gmail.com>
+Unaffiliated <no@organization.net> Rachana Patel <rachana83.patel@gmail.com>
 Unaffiliated <no@organization.net> Rahul Aggarwal <rahul.1aggarwal@gmail.com>
 Unaffiliated <no@organization.net> Robin Dehu <robindehu@gmail.com>
 Unaffiliated <no@organization.net> Robin Tang <robintang974@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -377,6 +377,7 @@ Unaffiliated <no@organization.net> Clement Lebrun <clement.lebrun.31@gmail.com>
 Unaffiliated <no@organization.net> Colin Mattson <colinmattson@gmail.com>
 Unaffiliated <no@organization.net> Dan Chai <tengweicai@gmail.com>
 Unaffiliated <no@organization.net> Daniel Schepler <dschepler@gmail.com>
+Unaffiliated <no@organization.net> Darrell Enns <darrell@darrellenns.com>
 Unaffiliated <no@organization.net> David Anderson <dave@natulte.net>
 Unaffiliated <no@organization.net> Dennis Schafroth <dennis@schafroth.com>
 Unaffiliated <no@organization.net> Ding Dinghua <dingdinghua85@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -327,7 +327,7 @@ SUSE <contact@suse.com> Adam Spiers <aspiers@suse.com>
 SUSE <contact@suse.com> David Disseldorp <ddiss@suse.de>
 SUSE <contact@suse.com> Hannes Reinecke <hare@suse.de>
 SUSE <contact@suse.com> Holger Macht <hmacht@suse.de>
-SUSE <contact@suse.com> Joao Eduardo Luis <joao@suse.de>
+SUSE <contact@suse.com> João Eduardo Luís <joao@suse.de>
 SUSE <contact@suse.com> Karl Eichwalder <ke@suse.de>
 SUSE <contact@suse.com> Nathan Cutler <ncutler@suse.com>
 SUSE <contact@suse.com> Owen Synge <osynge@suse.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -507,6 +507,7 @@ XSky <contact@xsky.com> Haomai Wang <haomai@xsky.com>
 XSky <contact@xsky.com> Min Chen <chenmin@xsky.com>
 XSky <contact@xsky.com> Tianshan Qu <tianshan@xsky.com>
 XSky <contact@xsky.com> Xinze Chi <xinze@xsky.com>
+XSky <contact@xsky.com> Zhiqiang Wang <zhiqiang@xsky.com>
 Yahoo! <contact@yahoo-inc.com> Guang Yang <yguang@yahoo-inc.com>
 Yahoo! <contact@yahoo-inc.com> Haifeng Liu <haifeng@yahoo-inc.com>
 Yahoo! <contact@yahoo-inc.com> Lei Dong <leidong@yahoo-inc.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -148,7 +148,7 @@ H3C <contact@h3c.com> Zhanyang Chen <Chen.zhanyang@h3c.com>
 Hastexo <contact@hastexo.com> Florian Haas <florian@hastexo.com>
 HGST <contact@hgst.com> Kevin Dalley <kevin@kelphead.org>
 HGST <contact@hgst.com> Lluis Pamies-Juarez <lluis.pamies-juarez@hgst.com>
-Hihuron <contact@huron.com> Changtao <changtao@hihuron.com>
+Hihuron <contact@huron.com> Tao Chang <changtao@hihuron.com>
 Hostplex Hosting <contact@hostplex.net> Andras Elso <elso.andras@gmail.com>
 HP <contact@hp.com> Blaine Gardner <blaine.gardner@hp.com>
 HP <contact@hp.com> Joe Handzik <joseph.t.handzik@hp.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -518,7 +518,7 @@ Yahoo! <contact@yahoo-inc.com> Zhi (David) Zhang <zhangz@yahoo-inc.com>
 YouScribe <contact@youscribe.fr> Guilhem Lettron <guilhem@lettron.fr>
 ZTE <contact@zte.com.cn> Chuanhong Wang <wang.chuanhong@zte.com.cn>
 ZTE <contact@zte.com.cn> Ren Huanwen <ren.huanwen@zte.com.cn>
-ZTE <contact@zte.com.cn> <xie.xingguo@zte.com.cn>
+ZTE <contact@zte.com.cn> Xie Xingguo <xie.xingguo@zte.com.cn>
 ZTE <contact@zte.com.cn> Song Baisen <song.baisen@zte.com.cn>
 #
 # Local Variables:

--- a/.organizationmap
+++ b/.organizationmap
@@ -208,6 +208,7 @@ IO <contact@io.com> Joe Julian <jjulian@io.com>
 Iron Systems Inc. <info@ironsystems.com> Harpreet Dhillon <harpreet@ironsystems.com>
 IT Refined <contact@itrefined.com> Ron Allred <rallred@itrefined.com>
 IWeb <contact@iweb.com> David Moreau Simard <dmsimard@iweb.com>
+Johannes Gutenberg-Universität Mainz <contact@uni-mainz.de> Marcel Lauhoff <lauhoff@uni-mainz.de>
 Karlsruhe Institute of Technology <ceph@lists.kit.edu> Daniel J. Hofmann <daniel@trvx.org>
 Keeper Technology <contact@keepertech.com> Wyllys Ingersoll <wyllys.ingersoll@keepertech.com>
 Kylin Cloud <contact@kylin-cloud.com> Jie Wang <jie.wang@kylin-cloud.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -255,6 +255,7 @@ Red Hat <contact@redhat.com> Daniel Gryniewicz <dang@redhat.com>
 Red Hat <contact@redhat.com> Dan Mick <dmick@redhat.com>
 Red Hat <contact@redhat.com> David Zafman <dzafman@redhat.com>
 Red Hat <contact@redhat.com> Douglas Fuller <dfuller@redhat.com>
+Red Hat <contact@redhat.com> Erwan Velu <erwan@redhat.com>
 Red Hat <contact@redhat.com> Federico Simoncelli <fsimonce@redhat.com>
 Red Hat <contact@redhat.com> Gary Lowell <glowell@redhat.com>
 Red Hat <contact@redhat.com> Greg Farnum <gfarnum@redhat.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -457,6 +457,7 @@ Unaffiliated <no@organization.net> Robin Tang <robintang974@gmail.com>
 Unaffiliated <no@organization.net> Rohan Mars <code@rohanmars.com>
 Unaffiliated <no@organization.net> Roman Haritonov <reclosedev@gmail.com>
 Unaffiliated <no@organization.net> Ruben Kerkhof <ruben@rubenkerkhof.com>
+Unaffiliated <no@organization.net> Sahithi R V <tansy.rv@gmail.com>
 Unaffiliated <no@organization.net> Sergey Arkhipov <nineseconds@yandex.ru>
 Unaffiliated <no@organization.net> Shang Ding <dingshang2013@163.com>
 Unaffiliated <no@organization.net> Shanggao Qiu <qiushanggao@qq.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -91,6 +91,7 @@ eNovance <contact@enovance.com> Sebastien Han <sebastien.han@enovance.com>
 EPAM <contact@epam.com> Andrey Kuznetsov <Andrey_Kuznetsov@epam.com>
 Exalead <contact@exalead.com> <roche+git@exalead.com>
 Fairbanks <contact@fairbanks.nl> Robert Jansen <r.jansen@fairbanks.nl>
+Free Software Foundation Europe <office@fsfeurope.org> Benoît Knecht <benoit.knecht@fsfe.org>
 Fujitsu <contact@fujitsu.com> Igor Podoski <igor.podoski@ts.fujitsu.com>
 Fujitsu <contact@fujitsu.com> Piotr Dałek <piotr.dalek@ts.fujitsu.com>
 Fujitsu <contact@fujitsu.com> Shotaro Kawaguchi <kawaguchi.s@jp.fujitsu.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -84,6 +84,7 @@ Eayun <contact@eayun.com> Dunrong Huang <dunrong.huang@eayun.com>
 Ebay <contact@ebay.com> Chengyuan Li <chengyli@ebay.com>
 Ebay <contact@ebay.com> You Ji <youji@ebay.com>
 École polytechnique fédérale de Lausanne <contact@epfl.ch> Stefan Eilemann <Stefan.Eilemann@epfl.ch>
+Endurance International Group <contact@endurance.com> Robert LeBlanc <robert.leblanc@endurance.com>
 eNovance <contact@enovance.com> Babu Shanmugam <anbu@enovance.com>
 eNovance <contact@enovance.com> Sebastien Han <sebastien.han@enovance.com>
 EPAM <contact@epam.com> Andrey Kuznetsov <Andrey_Kuznetsov@epam.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -519,6 +519,7 @@ YouScribe <contact@youscribe.fr> Guilhem Lettron <guilhem@lettron.fr>
 ZTE <contact@zte.com.cn> Chuanhong Wang <wang.chuanhong@zte.com.cn>
 ZTE <contact@zte.com.cn> Ren Huanwen <ren.huanwen@zte.com.cn>
 ZTE <contact@zte.com.cn> <xie.xingguo@zte.com.cn>
+ZTE <contact@zte.com.cn> Song Baisen <song.baisen@zte.com.cn>
 #
 # Local Variables:
 # compile-command: "git log --pretty='%aN <%aE>' | \

--- a/.organizationmap
+++ b/.organizationmap
@@ -486,6 +486,7 @@ UnitedStack <contact@unitedstack.com> Dong Yuan <yuandong1222@gmail.com>
 UnitedStack <contact@unitedstack.com> Guangliang Zhao <guangliang@unitedstack.com>
 UnitedStack <contact@unitedstack.com> Jevon Qiao <qiaojianfeng@unitedstack.com>
 UnitedStack <contact@unitedstack.com> Kun Huang <academicgareth@gmail.com>
+UnitedStack <contact@unitedstack.com> Li Tianqing <tianqing@unitedstack.com>
 University of California, Santa Cruz <contact@cs.ucsc.edu> Adam Crume <adamcrume@gmail.com>
 University of California, Santa Cruz <contact@cs.ucsc.edu> Andrew Leung <aleung@cs.ucsc.edu>
 University of California, Santa Cruz <contact@cs.ucsc.edu> Carlos Maltzahn <carlosm@cs.ucsc.edu>

--- a/.organizationmap
+++ b/.organizationmap
@@ -358,6 +358,7 @@ UMCloud <contact@umcloud.com> Jiaying Ren <mikulely@gmail.com>
 UMCloud <contact@umcloud.com> Rongze Zhu <zrzhit@gmail.com>
 Unaffiliated <no@organization.net> Abhishek Dixit <dixitabhi@gmail.com>
 Unaffiliated <no@organization.net> Accela Zhao <accelazh@gmail.com>
+Unaffiliated <no@organization.net> Adam Twardowski <adam.twardowski@gmail.com>
 Unaffiliated <no@organization.net> Ailing Zhang <zhangal1992@gmail.com> 
 Unaffiliated <no@organization.net> Alexis Normand <n.al3xis@gmail.com>
 Unaffiliated <no@organization.net> Andy Allan <andy@gravitystorm.co.uk>

--- a/.organizationmap
+++ b/.organizationmap
@@ -369,6 +369,7 @@ Unaffiliated <no@organization.net> Abhishek Dixit <dixitabhi@gmail.com>
 Unaffiliated <no@organization.net> Accela Zhao <accelazh@gmail.com>
 Unaffiliated <no@organization.net> Adam Twardowski <adam.twardowski@gmail.com>
 Unaffiliated <no@organization.net> Ailing Zhang <zhangal1992@gmail.com> 
+Unaffiliated <no@organization.net> Alan Grosskurth <code@alan.grosskurth.ca>
 Unaffiliated <no@organization.net> Alexis Normand <n.al3xis@gmail.com>
 Unaffiliated <no@organization.net> Andy Allan <andy@gravitystorm.co.uk>
 Unaffiliated <no@organization.net> Anis Ayari <ayari_anis@live.fr>

--- a/.organizationmap
+++ b/.organizationmap
@@ -414,6 +414,7 @@ Unaffiliated <no@organization.net> Ian Kelling <ian@iankelling.org>
 Unaffiliated <no@organization.net> Ilya Shipitsin <ilia@localhost.localdomain>
 Unaffiliated <no@organization.net> Ilja Slepnev <islepnev@gmail.com>
 Unaffiliated <no@organization.net> Ismael Serrano <ismael.serrano@gmail.com>
+Unaffiliated <no@organization.net> Ivan Grcic <igrcic@gmail.com>
 Unaffiliated <no@organization.net> Janne Grunau <j@jannau.net>
 Unaffiliated <no@organization.net> Jashan Kamboj <jashank42@gmail.com>
 Unaffiliated <no@organization.net> Javier Guerra <javier@guerrag.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -84,6 +84,7 @@ Dtdream <contact@dtdream.com> Wei Qian <weiq@dtdream.com>
 Eayun <contact@eayun.com> Dunrong Huang <dunrong.huang@eayun.com>
 Ebay <contact@ebay.com> Chengyuan Li <chengyli@ebay.com>
 Ebay <contact@ebay.com> You Ji <youji@ebay.com>
+Ebay <contact@ebay.com> Emile Snyder <emsnyder@ebay.com>
 École polytechnique fédérale de Lausanne <contact@epfl.ch> Stefan Eilemann <Stefan.Eilemann@epfl.ch>
 Endurance International Group <contact@endurance.com> Robert LeBlanc <robert.leblanc@endurance.com>
 eNovance <contact@enovance.com> Babu Shanmugam <anbu@enovance.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -194,6 +194,7 @@ Inktank <contact@inktank.com> Yehuda Sadeh <yehuda@inktank.com>
 Inktank <contact@inktank.com> Yuri Weinstein <yuri.weinstein@inktank.com>
 Intel <contact@intel.com> Chendi Xue <chendi.xue@intel.com>
 Intel <contact@intel.com> Jacek J. Łakis <jacek.lakis@intel.com>
+Intel <contact@intel.com> Jingkai Yuan <jingkai.yuan@intel.com>
 Intel <contact@intel.com> Krzysztof Kosiński <krzysztof.kosinski@intel.com>
 Intel <contact@intel.com> Ma Jianpeng <jianpeng.ma@intel.com>
 Intel <contact@intel.com> Shu, Xinxin <xinxin.shu@intel.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -79,7 +79,6 @@ DreamHost <contact@dreamhost.com> Robin H. Johnson <robin.johnson@dreamhost.com>
 DreamHost <contact@dreamhost.com> Sondra.Menthers <sondra.menthers@dreamhost.com>
 DreamHost <contact@dreamhost.com> Wesley Spikes <wesley.spikes@dreamhost.com>
 Dtdream <contact@dtdream.com> Li Peng <lip@dtdream.com>
-Dtdream <contact@dtdream.com> weiqian <weiq@dtdream.com>
 Dtdream <contact@dtdream.com> Wei Qian <weiq@dtdream.com>
 Eayun <contact@eayun.com> Dunrong Huang <dunrong.huang@eayun.com>
 Ebay <contact@ebay.com> Chengyuan Li <chengyli@ebay.com>
@@ -194,7 +193,6 @@ Inktank <contact@inktank.com> Warren Usui <warren.usui@inktank.com>
 Inktank <contact@inktank.com> Yehuda Sadeh <yehuda@inktank.com>
 Inktank <contact@inktank.com> Yuri Weinstein <yuri.weinstein@inktank.com>
 Intel <contact@intel.com> Chendi Xue <chendi.xue@intel.com>
-Intel <contact@intel.com> Jacek J. Lakis <jacek.lakis@intel.com>
 Intel <contact@intel.com> Jacek J. Łakis <jacek.lakis@intel.com>
 Intel <contact@intel.com> Krzysztof Kosiński <krzysztof.kosinski@intel.com>
 Intel <contact@intel.com> Ma Jianpeng <jianpeng.ma@intel.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -239,6 +239,7 @@ Pacific Northwest National Laboratory <contact@pnl.gov> Evan Felix <evan.felix@p
 Pacific Northwest National Laboratory <contact@pnl.gov> Scott Devoid <devoid@anl.gov>
 Piston Cloud Computing <info@pistoncloud.com> Mike Lundy <mike@fluffypenguin.org>
 Pogoapp <contact@pogoapp.com> Paul Meserve <paul@pogodan.com>
+Red Hat <contact@redhat.com> Adam C. Emerson <aemerson@redhat.com>
 Red Hat <contact@redhat.com> Alexander Chuzhoy <achuzhoy@redhat.com>
 Red Hat <contact@redhat.com> Alexandre Marangone <amarango@redhat.com>
 Red Hat <contact@redhat.com> Alex Elder <aelder@redhat.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -478,6 +478,7 @@ Unaffiliated <no@organization.net> Vicente Cheng <freeze.bilsted@gmail.com>
 Unaffiliated <no@organization.net> Viktor Suprun <popsul1993@gmail.com>
 Unaffiliated <no@organization.net> Volker Voigt <volker.voigt@1und1.de>
 Unaffiliated <no@organization.net> VRan Liu <gliuwr@gmail.com>
+Unaffiliated <no@organization.net> Wei Jin <wjin.cn@gmail.com>
 Unaffiliated <no@organization.net> William A. Kennington III <william@wkennington.com>
 Unaffiliated <no@organization.net> Xan Peng <xanpeng@gmail.com>
 Unaffiliated <no@organization.net> Xie Rui <875016668@qq.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -400,6 +400,7 @@ Unaffiliated <no@organization.net> Germain Chipaux <germain.chipaux@gmail.com>
 Unaffiliated <no@organization.net> Henry Chang <henry@bigtera.com>
 Unaffiliated <no@organization.net> Huang Jun <hjwsm1989@gmail.com>
 Unaffiliated <no@organization.net> Ian Kelling <ian@iankelling.org>
+Unaffiliated <no@organization.net> Ilya Shipitsin <ilia@localhost.localdomain>
 Unaffiliated <no@organization.net> Ilja Slepnev <islepnev@gmail.com>
 Unaffiliated <no@organization.net> Ismael Serrano <ismael.serrano@gmail.com>
 Unaffiliated <no@organization.net> Janne Grunau <j@jannau.net>

--- a/.organizationmap
+++ b/.organizationmap
@@ -25,6 +25,7 @@
 #
 Acaleph <contact@acale.ph> Alistair Israel <aisrael@gmail.com>
 Alcatel Lucent <contact@alcatel-lucent.com> Joseph McDonald <joseph.mcdonald@alcatel-lucent.com>
+Aliyun <contact@aliyun.com> Jeffrey Lu <lzhng2000@aliyun.com>
 Anchor Hosting <contact@anchor.com.au> Christian Marie <pingu@anchor.net.au>
 Anchor Hosting <contact@anchor.com.au> Sharif Olorin <sio@tesser.org>
 ArtiBit <contact@artibit.com> Rutger ter Borg <rutger@terborg.net>

--- a/.organizationmap
+++ b/.organizationmap
@@ -524,6 +524,7 @@ Yahoo! <contact@yahoo-inc.com> Xihui He <xihuihe@gmail.com>
 Yahoo! <contact@yahoo-inc.com> Zhi (David) Zhang <zhangz@yahoo-inc.com>
 YouScribe <contact@youscribe.fr> Guilhem Lettron <guilhem@lettron.fr>
 ZTE <contact@zte.com.cn> Chuanhong Wang <wang.chuanhong@zte.com.cn>
+ZTE <contact@zte.com.cn> Luo Kexue <luo.kexue@zte.com.cn>
 ZTE <contact@zte.com.cn> Ren Huanwen <ren.huanwen@zte.com.cn>
 ZTE <contact@zte.com.cn> Xie Xingguo <xie.xingguo@zte.com.cn>
 ZTE <contact@zte.com.cn> Song Baisen <song.baisen@zte.com.cn>

--- a/.organizationmap
+++ b/.organizationmap
@@ -429,6 +429,7 @@ Unaffiliated <no@organization.net> Jiaying Ren <mikulely@gmail.com>
 Unaffiliated <no@organization.net> John Coyle <dx9err@gmail.com>
 Unaffiliated <no@organization.net> Jon Bernard <jbernard@tuxion.com>
 Unaffiliated <no@organization.net> Jordan Dorne <jordan.dorne@gmail.com>
+Unaffiliated <no@organization.net> JP François <francoisjp@gmail.com>
 Unaffiliated <no@organization.net> Kadu Ribeiro <mail+github@carlosribeiro.me>
 Unaffiliated <no@organization.net> Karel Striegel <karel.striegel@ipc.be>
 Unaffiliated <no@organization.net> Kefu Chai <tchaikov@gmail.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -525,6 +525,7 @@ ZTE <contact@zte.com.cn> Chuanhong Wang <wang.chuanhong@zte.com.cn>
 ZTE <contact@zte.com.cn> Luo Kexue <luo.kexue@zte.com.cn>
 ZTE <contact@zte.com.cn> Ren Huanwen <ren.huanwen@zte.com.cn>
 ZTE <contact@zte.com.cn> Xie Xingguo <xie.xingguo@zte.com.cn>
+ZTE <contact@zte.com.cn> Shun Song <song.shun3@zte.com.cn>
 ZTE <contact@zte.com.cn> Song Baisen <song.baisen@zte.com.cn>
 #
 # Local Variables:

--- a/.organizationmap
+++ b/.organizationmap
@@ -366,6 +366,7 @@ Unaffiliated <no@organization.net> Andy Allan <andy@gravitystorm.co.uk>
 Unaffiliated <no@organization.net> Anis Ayari <ayari_anis@live.fr>
 Unaffiliated <no@organization.net> Anthony Alba <ascanio.alba7@gmail.com>
 Unaffiliated <no@organization.net> Armando Segnini <armaseg@gmail.com>
+Unaffiliated <no@organization.net> Aron Gunn <ritz_303@yahoo.com>
 Unaffiliated <no@organization.net> Arthur Gorjux <arthurgorjux@gmail.com>
 Unaffiliated <no@organization.net> BJ Lougee <almightybeeij@gmail.com>
 Unaffiliated <no@organization.net> Bosse Klykken <larkly@gmail.com>
@@ -445,7 +446,6 @@ Unaffiliated <no@organization.net> (no author) <(no author)@29311d96-e01e-0410-9
 Unaffiliated <no@organization.net> oddomatik <bandrus+github@gmail.com>
 Unaffiliated <no@organization.net> Pierre Chaumont <pierre.chaumont31@gmail.com>
 Unaffiliated <no@organization.net> Rahul Aggarwal <rahul.1aggarwal@gmail.com>
-Unaffiliated <no@organization.net> ritz303 <ritz_303@yahoo.com>
 Unaffiliated <no@organization.net> Robin Dehu <robindehu@gmail.com>
 Unaffiliated <no@organization.net> Robin Tang <robintang974@gmail.com>
 Unaffiliated <no@organization.net> Rohan Mars <code@rohanmars.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -476,6 +476,7 @@ Unaffiliated <no@organization.net> Xiong Yiliang <xiongyiliang@xunlei.com>
 Unaffiliated <no@organization.net> YankunLi <YankunLi@users.noreply.github.com>
 Unaffiliated <no@organization.net> Yann Dupont <yann@objoo.org>
 Unaffiliated <no@organization.net> Yannick Atchy Dalama <yannick.atchy.dalama@gmail.com>
+Unaffiliated <no@organization.net> YiQiang Chen <cyqsign@163.com>
 Unaffiliated <no@organization.net> Yongyue Sun <abioy.sun@gmail.com>
 Unaffiliated <no@organization.net> Zhe Zhang <zzxuanyuan@gmail.com>
 Unaffiliated <no@organization.net> Zhicheng Wei <zhicheng@opensourceforge.net>

--- a/.organizationmap
+++ b/.organizationmap
@@ -246,6 +246,7 @@ Red Hat <contact@redhat.com> Alexandre Marangone <amarango@redhat.com>
 Red Hat <contact@redhat.com> Alex Elder <aelder@redhat.com>
 Red Hat <contact@redhat.com> Alfredo Deza <adeza@redhat.com>
 Red Hat <contact@redhat.com> Ali Maredia <amaredia@redhat.com>
+Red Hat <contact@redhat.com> Barbora Ančincová <bara@redhat.com>
 Red Hat <contact@redhat.com> Boris Ranto <branto@redhat.com>
 Red Hat <contact@redhat.com> Brad Hubbard <bhubbard@redhat.com>
 Red Hat <contact@redhat.com> Brian Andrus <bandrus@redhat.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -116,6 +116,7 @@ H3C <contact@h3c.com> Fei Wang <wang.fei@h3c.com>
 H3C <contact@h3c.com> Jie Chen <chen.jie@h3c.com>
 H3C <contact@h3c.com> Jie Li <li.jieA@h3c.com>
 H3C <contact@h3c.com> Kongming Wu <wu.kongming@h3c.com>
+H3C <contact@h3c.com> Liu Peiyan <liu.peiyang@h3c.com>
 H3C <contact@h3c.com> Lu Shi <shi.lu@h3c.com>
 H3C <contact@h3c.com> Mingyue Zhao <zhao.mingyue@h3c.com>
 H3C <contact@h3c.com> Ming Zou <zou.ming@h3c.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -348,7 +348,7 @@ Telecom Bretagne <contact@telecom-bretagne.eu> Hazem Amara <hazem.amara@telecom-
 Telecom Bretagne <contact@telecom-bretagne.eu> Thomas Cantin <thomas.cantin@telecom-bretagne.eu>
 Tencent <contact@tencent.com> Wei Luo <weilluo@tencent.com>
 Tencent <contact@tencent.com> Wenjun Huang <wenjunhuang@tencent.com>
-Tencent <contact@tencent.com> Zhi Zhang <zhangz.david@outlook.com>
+Tencent <contact@tencent.com> Zhi Zhang <willzzhang@tencent.com>
 The Linux Box <contact@linuxbox.com> Adam C. Emerson <aemerson@linuxbox.com>
 The Linux Box <contact@linuxbox.com> Ali Maredia <ali@linuxbox.com>
 The Linux Box <contact@linuxbox.com> Casey Bodley <casey@linuxbox.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -388,6 +388,7 @@ Unaffiliated <no@organization.net> Drunkard Zhang <gongfan193@gmail.com>
 Unaffiliated <no@organization.net> Dunrong Huang <riegamaths@gmail.com>
 Unaffiliated <no@organization.net> Erik Logtenberg <erik@logtenberg.eu>
 Unaffiliated <no@organization.net> Fabio Alessandro Locati <fabiolocati@gmail.com>
+Unaffiliated <no@organization.net> fangdong <yp.fangdong@gmail.com>
 Unaffiliated <no@organization.net> Federico Gimenez <fgimenez@coit.es>
 Unaffiliated <no@organization.net> Feng He <fenglife@hotmail.com>
 Unaffiliated <no@organization.net> Florent Bautista <florent@coppint.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -521,6 +521,7 @@ Warpnet B.V. <contact@warpnet.nl> Gerhard Muntingh <gerhard@warpnet.nl>
 Web Drive <contact@webdrive.co.nz> Aristoteles Neto <aristoteles.neto@webdrive.co.nz>
 Whatever <contact@whatever-company.com> Sylvain Munaut <s.munaut@whatever-company.com>
 Wido 42on <contact@42on.com> Wido den Hollander <wido@42on.com>
+Wikia <contact@wikia-inc.com> Lukasz Jagiello <lukasz@wikia-inc.com>
 X-ION <contact@x-ion.de> Mouad Benchchaoui <m.benchchaoui@x-ion.de>
 X-ION <contact@x-ion.de> Stephan Renatus <s.renatus@x-ion.de>
 XSky <contact@xsky.com> Haomai Wang <haomai@xsky.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -442,6 +442,7 @@ Unaffiliated <no@organization.net> Laurent Guerby <laurent@guerby.net>
 Unaffiliated <no@organization.net> Lee Revell <rlrevell@gmail.com>
 Unaffiliated <no@organization.net> Lucas Fantinel <lucas.fantinel@gmail.com>
 Unaffiliated <no@organization.net> Matt Richards <mattjrichards@gmail.com>
+Unaffiliated <no@organization.net> Mauricio Garavaglia <mauriciogaravaglia@gmail.com>
 Unaffiliated <no@organization.net> Maxime Robert <maxime.robert1992@gmail.com>
 Unaffiliated <no@organization.net> Mehdi Abaakouk <sileht@sileht.net>
 Unaffiliated <no@organization.net> Michael Nelson <mikenel@tnld.net>

--- a/.organizationmap
+++ b/.organizationmap
@@ -434,6 +434,7 @@ Unaffiliated <no@organization.net> Jianjian Huo <samuel.huo@gmail.com>
 Unaffiliated <no@organization.net> Jiaying Ren <mikulely@gmail.com>
 Unaffiliated <no@organization.net> John Coyle <dx9err@gmail.com>
 Unaffiliated <no@organization.net> Jon Bernard <jbernard@tuxion.com>
+Unaffiliated <no@organization.net> Jonas Keidel <jonas@jonas-keidel.de>
 Unaffiliated <no@organization.net> Jordan Dorne <jordan.dorne@gmail.com>
 Unaffiliated <no@organization.net> JP François <francoisjp@gmail.com>
 Unaffiliated <no@organization.net> Kadu Ribeiro <mail+github@carlosribeiro.me>

--- a/.peoplemap
+++ b/.peoplemap
@@ -15,6 +15,7 @@
 #
 # git log --pretty='%aN <%aE>' $range | git -c mailmap.file=.peoplemap check-mailmap --stdin | sort | uniq | sed -e 's/\(.*\) \(<.*\)/\2 \1/' | uniq --skip-field=1 --all-repeated | sed -e 's/\(.*>\) \(.*\)/\2 \1/'
 #
+Abhishek Lekshmanan <abhishek@suse.com> Abhishek Lekshmanan <abhishek.lekshmanan@ril.com> 
 Alexandre Marangone <amarango@redhat.com> Alexandre Marangone <alexandre.marangone@inktank.com>
 Alfredo Deza <adeza@redhat.com> Alfredo Deza <alfredo.deza@inktank.com>
 Dan Mick <dmick@redhat.com> Dan Mick <dan.mick@inktank.com>

--- a/.peoplemap
+++ b/.peoplemap
@@ -22,8 +22,8 @@ David Zafman <dzafman@redhat.com> David Zafman <david.zafman@inktank.com>
 Greg Farnum <gfarnum@redhat.com> Greg Farnum <greg@inktank.com>
 Ilya Dryomov <idryomov@redhat.com> Ilya Dryomov <ilya.dryomov@inktank.com>
 Jenkins <jenkins@ceph.com> Jenkins <jenkins@inktank.com>
-Joao Eduardo Luis <joao@suse.de> João Eduardo Luís <joao.luis@inktank.com>
-Joao Eduardo Luis <joao@suse.de> João Eduardo Luís <joao@redhat.com>
+João Eduardo Luís <joao@suse.de> João Eduardo Luís <joao.luis@inktank.com>
+João Eduardo Luís <joao@suse.de> João Eduardo Luís <joao@redhat.com>
 John Spray <jspray@redhat.com> John Spray <john.spray@inktank.com>
 John Wilkins <jwilkins@redhat.com> John Wilkins <john.wilkins@inktank.com>
 Josh Durgin <jdurgin@redhat.com> Josh Durgin <josh.durgin@inktank.com>


### PR DESCRIPTION
I preferred to make another pull request, please disregard previous one.
I based this work on a cleaned up .mailmap.
Somewhat too much cleaned. 

The first patch is probably a bit over optimistic ; It's ok for the current run , but if you run credits.sh on historic releases, you may find again some non canonical names appears. That's because I assumed that a line like Zhiqiang Wang zhiqiang.wang@intel.com wonzhq@hotmail.com catch ALL zhiqiang.wang@intel.com and ALL wonzhq@hotmail.com. That's not the case, it only cath the 2nd one. To be complete you also need a first line like this : Zhiqiang Wang zhiqiang.wang@intel.com

I'll correct this tomorrow.
