### PR TITLE
os/bluestore: remove unused intrusive member hook in enode

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -81,8 +81,6 @@ public:
 
     bluestore_extent_ref_map_t ref_map;
 
-    boost::intrusive::unordered_set_member_hook<> map_item;
-
     Enode(uint32_t h, const string& k, EnodeSet *s)
       : nref(0),
 	hash(h),


### PR DESCRIPTION
Enode only uses intrusive unordered_set base hook, member hook is not necessary.
This should save some memory space, when we have tons of enodes.
