### PR TITLE
mon: reset lease_timeout_event when handling 'begin' message

### DIFF
--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -716,6 +716,8 @@ void Paxos::handle_begin(MonOpRequestRef op)
   // set state.
   state = STATE_UPDATING;
   lease_expire = utime_t();  // cancel lease
+  // leader won't renew lease until commit, we need some extra time
+  reset_lease_timeout();
 
   // yes.
   version_t v = last_committed+1;


### PR DESCRIPTION
Give Peons a bit more time to wait for Paxos updating finished

Signed-off-by: Sangdi Xu xu.sangdi@h3c.com
