### PR TITLE
os/bluestore: fix block device file creation

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -896,10 +896,13 @@ OPTION(bluestore_bluefs_reclaim_ratio, OPT_FLOAT, .20) // how much to reclaim at
 // bluestore_block_path = spdk:55cd2e404bd73932
 OPTION(bluestore_block_path, OPT_STR, "")
 OPTION(bluestore_block_size, OPT_U64, 10 * 1024*1024*1024)  // 10gb for testing
+OPTION(bluestore_block_create, OPT_BOOL, true)
 OPTION(bluestore_block_db_path, OPT_STR, "")
 OPTION(bluestore_block_db_size, OPT_U64, 0)   // rocksdb ssts (hot/warm)
+OPTION(bluestore_block_db_create, OPT_BOOL, false)
 OPTION(bluestore_block_wal_path, OPT_STR, "")
 OPTION(bluestore_block_wal_size, OPT_U64, 96 * 1024*1024) // rocksdb wal
+OPTION(bluestore_block_wal_create, OPT_BOOL, false)
 OPTION(bluestore_max_dir_size, OPT_U32, 1000000)
 OPTION(bluestore_min_alloc_size, OPT_U32, 64*1024)
 OPTION(bluestore_onode_map_size, OPT_U32, 1024)   // onodes per collection

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -563,7 +563,8 @@ private:
   int _open_collections(int *errors=0);
   void _close_collections();
 
-  int _setup_block_symlink_or_file(string name, string path, uint64_t size);
+  int _setup_block_symlink_or_file(string name, string path, uint64_t size,
+				   bool create);
 
   int _write_bdev_label(string path, bluestore_bdev_label_t label);
   static int _read_bdev_label(string path, bluestore_bdev_label_t *label);

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -495,8 +495,11 @@ $DAEMONOPTS
         filestore wbthrottle btrfs ios hard limit = 20
         filestore wbthrottle btrfs inodes hard limit = 30
 	bluestore fsck on mount = true
+	bluestore block create = true
 	bluestore block db size = 67108864
+	bluestore block db create = true
 	bluestore block wal size = 134217728
+	bluestore block wal create = true
 $COSDDEBUG
 $COSDMEMSTORE
 $extra_conf
@@ -592,11 +595,6 @@ EOF
 	    rm -rf $CEPH_DEV_DIR/osd$osd || true
 	    for f in $CEPH_DEV_DIR/osd$osd/* ; do btrfs sub delete $f || true ; done || true
 	    mkdir -p $CEPH_DEV_DIR/osd$osd
-
-	    # for bluestore
-	    touch $CEPH_DEV_DIR/osd$osd/block
-	    touch $CEPH_DEV_DIR/osd$osd/block.db
-	    touch $CEPH_DEV_DIR/osd$osd/block.wal
 
 	    uuid=`uuidgen`
 	    echo "add osd$osd $uuid"


### PR DESCRIPTION
Just make a separate flag to indicate whether we create a block
file.  This lets us drop the weird touch in vstart.sh, and default
to creating a token 'block' file on --mkfs.

Signed-off-by: Sage Weil <sage@redhat.com>