### PR TITLE
OSD/ReplicatedPG: Fixes unneccessary object promotion when deleting f…

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2147,7 +2147,7 @@ ReplicatedPG::cache_result_t ReplicatedPG::maybe_handle_cache_detail(
       return cache_result_t::BLOCKED_FULL;
     }
 
-    if (!hit_set) {
+    if (!hit_set && (must_promote || !op->need_skip_promote()) ) {
       promote_object(obc, missing_oid, oloc, op, promote_obc);
       return cache_result_t::BLOCKED_PROMOTE;
     } else if (op->may_write() || op->may_cache()) {


### PR DESCRIPTION
…rom the cache that lacks hit_set configured.

Minor cleanup nearby too.

This issue was mentioned at http://tracker.ceph.com/issues/13894 ( comment #12 and beyond ) but it's probably not the root cause of 13894.

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>