### PR TITLE
rgw: add support for Keystone v3

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1188,7 +1188,7 @@ OPTION(rgw_keystone_admin_password, OPT_STR, "")  // keystone admin user passwor
 OPTION(rgw_keystone_admin_tenant, OPT_STR, "")  // keystone admin user tenant (for keystone v2.0)
 OPTION(rgw_keystone_admin_project, OPT_STR, "")  // keystone admin user project (for keystone v3)
 OPTION(rgw_keystone_admin_domain, OPT_STR, "")  // keystone admin user domain
-OPTION(rgw_keystone_api_version, OPT_STR, "2.0") // Version of Keystone API to use ("2.0" or "3")
+OPTION(rgw_keystone_api_version, OPT_INT, 2) // Version of Keystone API to use (2 or 3)
 OPTION(rgw_keystone_accepted_roles, OPT_STR, "Member, admin")  // roles required to serve requests
 OPTION(rgw_keystone_token_cache_size, OPT_INT, 10000)  // max number of entries in keystone token cache
 OPTION(rgw_keystone_revocation_interval, OPT_INT, 15 * 60)  // seconds between tokens revocation check

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1185,7 +1185,10 @@ OPTION(rgw_keystone_url, OPT_STR, "")  // url for keystone server
 OPTION(rgw_keystone_admin_token, OPT_STR, "")  // keystone admin token (shared secret)
 OPTION(rgw_keystone_admin_user, OPT_STR, "")  // keystone admin user name
 OPTION(rgw_keystone_admin_password, OPT_STR, "")  // keystone admin user password
-OPTION(rgw_keystone_admin_tenant, OPT_STR, "")  // keystone admin user tenant
+OPTION(rgw_keystone_admin_tenant, OPT_STR, "")  // keystone admin user tenant (for keystone v2.0)
+OPTION(rgw_keystone_admin_project, OPT_STR, "")  // keystone admin user project (for keystone v3)
+OPTION(rgw_keystone_admin_domain, OPT_STR, "")  // keystone admin user domain
+OPTION(rgw_keystone_api_version, OPT_STR, "2.0") // Version of Keystone API to use ("2.0" or "3")
 OPTION(rgw_keystone_accepted_roles, OPT_STR, "Member, admin")  // roles required to serve requests
 OPTION(rgw_keystone_token_cache_size, OPT_INT, 10000)  // max number of entries in keystone token cache
 OPTION(rgw_keystone_revocation_interval, OPT_INT, 15 * 60)  // seconds between tokens revocation check

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -7,7 +7,8 @@ DENCODER_SOURCES += \
 	rgw/rgw_basic_types.cc \
 	rgw/rgw_common.cc \
 	rgw/rgw_env.cc \
-	rgw/rgw_json_enc.cc
+	rgw/rgw_json_enc.cc \
+	rgw/rgw_keystone.cc
 
 DENCODER_DEPS += -lcurl -lexpat \
 	libcls_version_client.la \

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1219,34 +1219,33 @@ void KeystoneAdminTokenRequestVer2::dump(Formatter * const f) const
 void KeystoneAdminTokenRequestVer3::dump(Formatter * const f) const
 {
   f->open_object_section("token_request");
-  f->open_object_section("auth");
-    f->open_object_section("identity");
-      f->open_array_section("methods");
-        f->dump_string("", "password");
+    f->open_object_section("auth");
+      f->open_object_section("identity");
+        f->open_array_section("methods");
+          f->dump_string("", "password");
+        f->close_section();
+        f->open_object_section("password");
+          f->open_object_section("user");
+            f->open_object_section("domain");
+              encode_json("name", cct->_conf->rgw_keystone_admin_domain, f);
+            f->close_section();
+            encode_json("name", cct->_conf->rgw_keystone_admin_user, f);
+            encode_json("password", cct->_conf->rgw_keystone_admin_password, f);
+          f->close_section();
+        f->close_section();
       f->close_section();
-      f->open_object_section("password");
-        f->open_object_section("user");
+      f->open_object_section("scope");
+        f->open_object_section("project");
+          if (!cct->_conf->rgw_keystone_admin_project.empty()) {
+            encode_json("name", cct->_conf->rgw_keystone_admin_project, f);
+          } else {
+            encode_json("name", cct->_conf->rgw_keystone_admin_tenant, f);
+          }
           f->open_object_section("domain");
             encode_json("name", cct->_conf->rgw_keystone_admin_domain, f);
           f->close_section();
-          encode_json("name", cct->_conf->rgw_keystone_admin_user, f);
-          encode_json("password", cct->_conf->rgw_keystone_admin_password, f);
         f->close_section();
       f->close_section();
     f->close_section();
-    f->open_object_section("scope");
-      f->open_object_section("project");
-        if (!cct->_conf->rgw_keystone_admin_project.empty()) {
-          encode_json("name", cct->_conf->rgw_keystone_admin_project, f);
-        }
-        else {
-          encode_json("name", cct->_conf->rgw_keystone_admin_tenant, f);
-        }
-        f->open_object_section("domain");
-          encode_json("name", cct->_conf->rgw_keystone_admin_domain, f);
-        f->close_section();
-      f->close_section();
-    f->close_section();
-  f->close_section();
   f->close_section();
 }

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1220,6 +1220,7 @@ void KeystoneAdminTokenRequestVer2::dump(Formatter * const f) const
 
 void KeystoneAdminTokenRequestVer3::dump(Formatter * const f) const
 {
+  f->open_object_section("token_request");
   f->open_object_section("auth");
     f->open_object_section("identity");
       f->open_array_section("methods");
@@ -1248,5 +1249,6 @@ void KeystoneAdminTokenRequestVer3::dump(Formatter * const f) const
         f->close_section();
       f->close_section();
     f->close_section();
+  f->close_section();
   f->close_section();
 }

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1048,42 +1048,13 @@ void RGWRealm::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("epoch", epoch, obj);
 }
 
-void KeystoneToken::Metadata::decode_json(JSONObj *obj)
-{
-  JSONDecoder::decode_json("is_admin", is_admin, obj);
-}
-
-void KeystoneToken::Service::Endpoint::decode_json(JSONObj *obj)
-{
-  JSONDecoder::decode_json("id", id, obj);
-  JSONDecoder::decode_json("adminURL", admin_url, obj);
-  JSONDecoder::decode_json("publicURL", public_url, obj);
-  JSONDecoder::decode_json("internalURL", internal_url, obj);
-  JSONDecoder::decode_json("region", region, obj);
-}
-
-void KeystoneToken::Service::decode_json(JSONObj *obj)
-{
-  JSONDecoder::decode_json("type", type, obj, true);
-  JSONDecoder::decode_json("name", name, obj, true);
-  JSONDecoder::decode_json("endpoints", endpoints, obj);
-}
-
-void KeystoneToken::Token::Tenant::decode_json(JSONObj *obj)
-{
-  JSONDecoder::decode_json("id", id, obj, true);
-  JSONDecoder::decode_json("name", name, obj, true);
-  JSONDecoder::decode_json("description", description, obj);
-  JSONDecoder::decode_json("enabled", enabled, obj);
-}
-
 void KeystoneToken::Token::decode_json(JSONObj *obj)
 {
   string expires_iso8601;
   struct tm t;
 
   JSONDecoder::decode_json("id", id, obj, true);
-  JSONDecoder::decode_json("tenant", tenant, obj, true);
+  JSONDecoder::decode_json("tenant", tenant_v2, obj, true);
   JSONDecoder::decode_json("expires", expires_iso8601, obj, true);
 
   if (parse_iso8601(expires_iso8601.c_str(), &t)) {
@@ -1094,26 +1065,59 @@ void KeystoneToken::Token::decode_json(JSONObj *obj)
   }
 }
 
-void KeystoneToken::User::Role::decode_json(JSONObj *obj)
+void KeystoneToken::Role::decode_json(JSONObj *obj)
 {
-  JSONDecoder::decode_json("id", id, obj);
-  JSONDecoder::decode_json("name", name, obj);
+  JSONDecoder::decode_json("id", id, obj, true);
+  JSONDecoder::decode_json("name", name, obj, true);
+}
+
+void KeystoneToken::Domain::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("id", id, obj, true);
+  JSONDecoder::decode_json("name", name, obj, true);
+}
+
+void KeystoneToken::Project::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("id", id, obj, true);
+  JSONDecoder::decode_json("name", name, obj, true);
+  JSONDecoder::decode_json("domain", domain, obj);
 }
 
 void KeystoneToken::User::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("id", id, obj, true);
-  JSONDecoder::decode_json("name", name, obj);
-  JSONDecoder::decode_json("username", user_name, obj, true);
-  JSONDecoder::decode_json("roles", roles, obj);
+  JSONDecoder::decode_json("name", name, obj, true);
+  JSONDecoder::decode_json("domain", domain, obj);
+  JSONDecoder::decode_json("roles", roles_v2, obj);
 }
 
-void KeystoneToken::decode_json(JSONObj *access_obj)
+void KeystoneToken::decode_json(JSONObj *root_obj)
 {
-  JSONDecoder::decode_json("metadata", metadata, access_obj);
-  JSONDecoder::decode_json("token", token, access_obj, true);
-  JSONDecoder::decode_json("user", user, access_obj, true);
-  JSONDecoder::decode_json("serviceCatalog", service_catalog, access_obj);
+  if (version == "2.0") {
+    JSONDecoder::decode_json("token", token, root_obj, true);
+  }
+  if (version == "3") {
+    string expires_iso8601;
+    struct tm t;
+
+    JSONDecoder::decode_json("expires_at", expires_iso8601, root_obj, true);
+
+    if (parse_iso8601(expires_iso8601.c_str(), &t)) {
+      token.expires = timegm(&t);
+    } else {
+      token.expires = 0;
+      throw JSONDecoder::err("Failed to parse ISO8601 expiration date from Keystone response.");
+    }
+    JSONDecoder::decode_json("roles", roles, root_obj, true);
+    JSONDecoder::decode_json("project", project, root_obj, true);
+  }
+
+  JSONDecoder::decode_json("user", user, root_obj, true);
+  if (version == "2.0") {
+    roles = user.roles_v2;
+    project = token.tenant_v2;
+  }
 }
 
 void rgw_slo_entry::decode_json(JSONObj *obj)

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1204,3 +1204,49 @@ void rgw_sync_error_info::dump(Formatter *f) const {
   encode_json("error_code", error_code, f);
   encode_json("message", message, f);
 }
+
+void KeystoneAdminTokenRequestVer2::dump(Formatter * const f) const
+{
+  f->open_object_section("token_request");
+    f->open_object_section("auth");
+      f->open_object_section("passwordCredentials");
+        encode_json("username", cct->_conf->rgw_keystone_admin_user, f);
+        encode_json("password", cct->_conf->rgw_keystone_admin_password, f);
+      f->close_section();
+      encode_json("tenantName", cct->_conf->rgw_keystone_admin_tenant, f);
+    f->close_section();
+  f->close_section();
+}
+
+void KeystoneAdminTokenRequestVer3::dump(Formatter * const f) const
+{
+  f->open_object_section("auth");
+    f->open_object_section("identity");
+      f->open_array_section("methods");
+        f->dump_string("", "password");
+      f->close_section();
+      f->open_object_section("password");
+        f->open_object_section("user");
+          f->open_object_section("domain");
+            encode_json("name", cct->_conf->rgw_keystone_admin_domain, f);
+          f->close_section();
+          encode_json("name", cct->_conf->rgw_keystone_admin_user, f);
+          encode_json("password", cct->_conf->rgw_keystone_admin_password, f);
+        f->close_section();
+      f->close_section();
+    f->close_section();
+    f->open_object_section("scope");
+      f->open_object_section("project");
+        if (!cct->_conf->rgw_keystone_admin_project.empty()) {
+          encode_json("name", cct->_conf->rgw_keystone_admin_project, f);
+        }
+        else {
+          encode_json("name", cct->_conf->rgw_keystone_admin_tenant, f);
+        }
+        f->open_object_section("domain");
+          encode_json("name", cct->_conf->rgw_keystone_admin_domain, f);
+        f->close_section();
+      f->close_section();
+    f->close_section();
+  f->close_section();
+}

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1094,10 +1094,14 @@ void KeystoneToken::User::decode_json(JSONObj *obj)
 
 void KeystoneToken::decode_json(JSONObj *root_obj)
 {
-  if (version == "2.0") {
+  JSONDecoder::decode_json("user", user, root_obj, true);
+
+  if (version == KeystoneApiVersion::VER_2) {
     JSONDecoder::decode_json("token", token, root_obj, true);
-  }
-  if (version == "3") {
+
+    roles = user.roles_v2;
+    project = token.tenant_v2;
+  } else if (version == KeystoneApiVersion::VER_3) {
     string expires_iso8601;
     struct tm t;
 
@@ -1111,12 +1115,6 @@ void KeystoneToken::decode_json(JSONObj *root_obj)
     }
     JSONDecoder::decode_json("roles", roles, root_obj, true);
     JSONDecoder::decode_json("project", project, root_obj, true);
-  }
-
-  JSONDecoder::decode_json("user", user, root_obj, true);
-  if (version == "2.0") {
-    roles = user.roles_v2;
-    project = token.tenant_v2;
   }
 }
 

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1067,7 +1067,7 @@ void KeystoneToken::Token::decode_json(JSONObj *obj)
 
 void KeystoneToken::Role::decode_json(JSONObj *obj)
 {
-  JSONDecoder::decode_json("id", id, obj, true);
+  JSONDecoder::decode_json("id", id, obj);
   JSONDecoder::decode_json("name", name, obj, true);
 }
 

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -14,7 +14,7 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-bool KeystoneToken::User::has_role(const string& r) {
+bool KeystoneToken::has_role(const string& r) {
   list<Role>::iterator iter;
   for (iter = roles.begin(); iter != roles.end(); ++iter) {
       if (fnmatch(r.c_str(), ((*iter).name.c_str()), 0) == 0) {
@@ -33,7 +33,12 @@ int KeystoneToken::parse(CephContext *cct, bufferlist& bl)
   }
 
   try {
-    JSONDecoder::decode_json("access", *this, &parser);
+    if (version == "2.0") {
+      JSONDecoder::decode_json("access", *this, &parser);
+    }
+    if (version == "3") {
+      JSONDecoder::decode_json("token", *this, &parser);
+    }
   } catch (JSONDecoder::err& err) {
     ldout(cct, 0) << "Keystone token parse error: " << err.message << dendl;
     return -EINVAL;

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -50,9 +50,9 @@ int KeystoneToken::parse(CephContext *cct, bufferlist& bl)
 
   try {
     if (version == KeystoneApiVersion::VER_2) {
-      JSONDecoder::decode_json("access", *this, &parser);
+      JSONDecoder::decode_json("access", *this, &parser, true);
     } else if (version == KeystoneApiVersion::VER_3) {
-      JSONDecoder::decode_json("token", *this, &parser);
+      JSONDecoder::decode_json("token", *this, &parser, true);
     }
   } catch (JSONDecoder::err& err) {
     ldout(cct, 0) << "Keystone token parse error: " << err.message << dendl;

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -6,9 +6,19 @@
 
 #include "rgw_common.h"
 
+enum class KeystoneApiVersion {
+  VER_2,
+  VER_3
+};
+
+class KeystoneService {
+public:
+  static KeystoneApiVersion get_api_version();
+};
+
 class KeystoneToken {
 protected:
-  string version;
+  KeystoneApiVersion version;
 
 public:
   class Domain {
@@ -56,8 +66,9 @@ public:
   list<Role> roles;
 
 public:
-  KeystoneToken() : version("") {};
-  KeystoneToken(string _version) : version(_version) {};
+  // FIXME: default ctor needs to be eradicated here
+  KeystoneToken() : version(KeystoneApiVersion::VER_2) {};
+  KeystoneToken(KeystoneApiVersion _version) : version(_version) {};
   time_t get_expires() { return token.expires; }
   string get_domain_id() {return project.domain.id;};
   string get_domain_name()  {return project.domain.name;};

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -17,9 +17,6 @@ public:
 };
 
 class KeystoneToken {
-protected:
-  KeystoneApiVersion version;
-
 public:
   class Domain {
   public:
@@ -67,8 +64,7 @@ public:
 
 public:
   // FIXME: default ctor needs to be eradicated here
-  KeystoneToken() : version(KeystoneApiVersion::VER_2) {};
-  KeystoneToken(KeystoneApiVersion _version) : version(_version) {};
+  KeystoneToken() = default;
   time_t get_expires() { return token.expires; }
   string get_domain_id() {return project.domain.id;};
   string get_domain_name()  {return project.domain.name;};

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -97,5 +97,30 @@ public:
   void invalidate(const string& token_id);
 };
 
+class KeystoneAdminTokenRequest {
+public:
+  virtual ~KeystoneAdminTokenRequest() = default;
+  virtual void dump(Formatter *f) const = 0;
+};
+
+class KeystoneAdminTokenRequestVer2 : public KeystoneAdminTokenRequest {
+  CephContext *cct;
+
+public:
+  KeystoneAdminTokenRequestVer2(CephContext * const _cct)
+    : cct(_cct) {
+  }
+  void dump(Formatter *f) const;
+};
+
+class KeystoneAdminTokenRequestVer3 : public KeystoneAdminTokenRequest {
+  CephContext *cct;
+
+public:
+  KeystoneAdminTokenRequestVer3(CephContext * const _cct)
+    : cct(_cct) {
+  }
+  void dump(Formatter *f) const;
+};
 
 #endif

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2673,7 +2673,7 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(
   string keystone_version = cct->_conf->rgw_keystone_api_version;
   if (keystone_url[keystone_url.size() - 1] != '/')
     keystone_url.append("/");
-  if (keystone_version == "3") {
+  if (KeystoneService::get_api_version() == KeystoneApiVersion::VER_3) {
     keystone_url.append("v3/s3tokens");
   }
   else {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2670,13 +2670,13 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(
   const string& auth_id, const string& auth_token, const string& auth_sign) {
   /* prepare keystone url */
   string keystone_url = cct->_conf->rgw_keystone_url;
-  string keystone_version = cct->_conf->rgw_keystone_api_version;
-  if (keystone_url[keystone_url.size() - 1] != '/')
+  if (keystone_url[keystone_url.size() - 1] != '/') {
     keystone_url.append("/");
+  }
+
   if (KeystoneService::get_api_version() == KeystoneApiVersion::VER_3) {
     keystone_url.append("v3/s3tokens");
-  }
-  else {
+  } else {
     keystone_url.append("v2.0/s3tokens");
   }
 
@@ -2742,7 +2742,9 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(
   }
 
   /* everything seems fine, continue with this user */
-  ldout(cct, 5) << "s3 keystone: validated token: " << response.get_project_name() << ":" << response.get_user_name() << " expires: " << response.get_expires() << dendl;
+  ldout(cct, 5) << "s3 keystone: validated token: " << response.get_project_name()
+                << ":" << response.get_user_name()
+                << " expires: " << response.get_expires() << dendl;
   return 0;
 }
 

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -356,11 +356,7 @@ private:
 
 public:
   explicit RGW_Auth_S3_Keystone_ValidateToken(CephContext *_cct)
-      : RGWHTTPClient(_cct),
-        /* This is really crazy but S3Extension in Keystone always
-         * returns token conforming to v2 - regardless whether you
-         * have requested v3 or not. */
-        response(KeystoneToken(KeystoneApiVersion::VER_2)) {
+      : RGWHTTPClient(_cct) {
     get_str_list(cct->_conf->rgw_keystone_accepted_roles, roles_list);
   }
 

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -357,7 +357,10 @@ private:
 public:
   explicit RGW_Auth_S3_Keystone_ValidateToken(CephContext *_cct)
       : RGWHTTPClient(_cct),
-        response(KeystoneToken(KeystoneService::get_api_version())) {
+        /* This is really crazy but S3Extension in Keystone always
+         * returns token conforming to v2 - regardless whether you
+         * have requested v3 or not. */
+        response(KeystoneToken(KeystoneApiVersion::VER_2)) {
     get_str_list(cct->_conf->rgw_keystone_accepted_roles, roles_list);
   }
 

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -356,7 +356,8 @@ private:
 
 public:
   explicit RGW_Auth_S3_Keystone_ValidateToken(CephContext *_cct)
-      : RGWHTTPClient(_cct) {
+      : RGWHTTPClient(_cct),
+        response(KeystoneToken(_cct->_conf->rgw_keystone_api_version)) {
     get_str_list(cct->_conf->rgw_keystone_accepted_roles, roles_list);
   }
 

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -357,7 +357,7 @@ private:
 public:
   explicit RGW_Auth_S3_Keystone_ValidateToken(CephContext *_cct)
       : RGWHTTPClient(_cct),
-        response(KeystoneToken(_cct->_conf->rgw_keystone_api_version)) {
+        response(KeystoneToken(KeystoneService::get_api_version())) {
     get_str_list(cct->_conf->rgw_keystone_accepted_roles, roles_list);
   }
 

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -304,7 +304,7 @@ int RGWSwift::get_keystone_admin_token(CephContext * const cct,
     int ret = token_req.process("POST", token_url.c_str());
     if (ret < 0)
       return ret;
-    KeystoneToken t = KeystoneToken(keystone_version);
+    KeystoneToken t;
     if (t.parse(cct, token_bl) != 0)
       return -EINVAL;
     token = t.token.id;
@@ -521,7 +521,7 @@ static bool decode_pki_token(CephContext *cct, const string& token, bufferlist& 
 int RGWSwift::validate_keystone_token(RGWRados *store, const string& token, struct rgw_swift_auth_info *info,
 				      RGWUserInfo& rgw_user)
 {
-  KeystoneToken t(KeystoneService::get_api_version());
+  KeystoneToken t;
 
   string token_id;
   get_token_id(token, token_id);

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -139,7 +139,7 @@ public:
 
     char *s = (char *)ptr, *end = (char *)ptr + len;
     char *p = line;
-    ldout(cct, 10) << "read_http_header" << dendl;
+    ldout(cct, 20) << "RGWPostHTTPData::receive_header parsing HTTP headers" << dendl;
 
     while (s != end) {
       if (*s == '\r') {
@@ -148,7 +148,8 @@ public:
       }
       if (*s == '\n') {
         *p = '\0';
-        ldout(cct, 10) << "os_auth:" << line << dendl;
+        ldout(cct, 20) << "RGWPostHTTPData::receive_header: line="
+                       << line << dendl;
         // TODO: fill whatever data required here
         char *l = line;
         char *tok = strsep(&l, " \t:");

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -172,26 +172,9 @@ public:
   }
 };
 
+typedef RGWPostHTTPData RGWValidateKeystoneToken;
 typedef RGWPostHTTPData RGWGetKeystoneAdminToken;
 typedef RGWPostHTTPData RGWGetRevokedTokens;
-
-class RGWValidateKeystoneToken : public RGWHTTPClient {
-  bufferlist *bl;
-public:
-  RGWValidateKeystoneToken(CephContext *_cct, bufferlist *_bl) : RGWHTTPClient(_cct), bl(_bl) {}
-
-  int receive_data(void *ptr, size_t len) {
-    bl->append((char *)ptr, len);
-    return 0;
-  }
-  int receive_header(void *ptr, size_t len) {
-    return 0;
-  }
-  int send_data(void *ptr, size_t len) {
-    return 0;
-  }
-
-};
 
 static RGWKeystoneTokenCache *keystone_token_cache = NULL;
 

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -153,16 +153,18 @@ public:
         char *l = line;
         char *tok = strsep(&l, " \t:");
         if (tok) {
-          while (l && *l == ' ')
+          while (l && *l == ' ') {
             l++;
+          }
 
           if (strcasecmp(tok, "X-Subject-Token") == 0) {
             subject_token = l;
           }
         }
       }
-      if (s != end)
+      if (s != end) {
         *p++ = *s++;
+      }
     }
     return 0;
   }
@@ -333,10 +335,12 @@ int RGWSwift::check_revoked()
   bufferlist bl;
   RGWGetRevokedTokens req(cct, &bl);
 
-  if (get_keystone_admin_token(token) < 0)
+  if (get_keystone_admin_token(token) < 0) {
     return -EINVAL;
-  if (get_keystone_url(url) < 0)
+  }
+  if (get_keystone_url(url) < 0) {
     return -EINVAL;
+  }
   req.append_header("X-Auth-Token", token);
 
   const auto keystone_version = KeystoneService::get_api_version();
@@ -345,10 +349,12 @@ int RGWSwift::check_revoked()
   } else if (keystone_version == KeystoneApiVersion::VER_3) {
     url.append("v3/auth/tokens/OS-PKI/revoked");
   }
+
   req.set_send_length(0);
   int ret = req.process(url.c_str());
-  if (ret < 0)
+  if (ret < 0) {
     return ret;
+  }
 
   bl.append((char)0); // NULL terminate for debug output
 
@@ -441,11 +447,14 @@ int RGWSwift::parse_keystone_token_response(const string& token, bufferlist& bl,
   }
 
   if (!found) {
-    ldout(cct, 0) << "user does not hold a matching role; required roles: " << g_conf->rgw_keystone_accepted_roles << dendl;
+    ldout(cct, 0) << "user does not hold a matching role; required roles: "
+                  << g_conf->rgw_keystone_accepted_roles << dendl;
     return -EPERM;
   }
 
-  ldout(cct, 0) << "validated token: " << t.get_project_name() << ":" << t.get_user_name() << " expires: " << t.get_expires() << dendl;
+  ldout(cct, 0) << "validated token: " << t.get_project_name()
+                << ":" << t.get_user_name()
+                << " expires: " << t.get_expires() << dendl;
 
   rgw_set_keystone_token_auth_info(t, info);
 
@@ -581,7 +590,9 @@ int RGWSwift::validate_keystone_token(RGWRados *store, const string& token, stru
     return ret;
 
   if (t.expired()) {
-    ldout(cct, 0) << "got expired token: " << t.get_project_name() << ":" << t.get_user_name() << " expired: " << t.get_expires() << dendl;
+    ldout(cct, 0) << "got expired token: " << t.get_project_name()
+                  << ":" << t.get_user_name()
+                  << " expired: " << t.get_expires() << dendl;
     return -EPERM;
   }
 


### PR DESCRIPTION
This PR is basing on #6337 by Mark Barnes which seems to be abandoned by the original author. The reworked version addresses some issues and avoids extensive code shuffling (number of affected lines has been significantly reduced).

@yehudasa Although commit messages mention about the authorship, I think this is not enough. What is the practice for handling cases like this one? Can we add ```Signed-off-by``` from the original commit there?

TODO:
* ~~rework parsing in ```KeystoneToken``` to be proof for fixes in ```S3Extension``` of Keystone~~ (done).