### PR TITLE
rgw/rgw_orphan: check the return value of save_state

### DIFF
--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -578,7 +578,11 @@ int RGWOrphanSearch::build_linked_oids_index()
     return ret;
   }
 
-  save_state();
+  ret = save_state();
+  if (ret < 0) {
+    cerr << __func__ << ": ERROR: failed to write state ret=" << ret << std::endl;
+    return ret;
+  }
 
   return 0;
 }


### PR DESCRIPTION
It was discovered by covscan that we do not check the return value of
save_state in this one case.

Signed-off-by: Boris Ranto <branto@redhat.com>