### PR TITLE
global/global_init: do not apply_changes until after dropping privs

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -286,6 +286,17 @@ void* AdminSocket::entry()
   ldout(m_cct, 5) << "entry exit" << dendl;
 }
 
+void AdminSocket::chown(uid_t uid, gid_t gid)
+{
+  if (m_sock_fd >= 0) {
+    int r = ::fchown(m_sock_fd, uid, gid);
+    if (r < 0) {
+      r = -errno;
+      lderr(m_cct) << "AdminSocket: failed to chown socket: "
+		   << cpp_strerror(r) << dendl;
+    }
+  }
+}
 
 bool AdminSocket::do_accept()
 {

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -71,7 +71,9 @@ public:
   int unregister_command(std::string command);
 
   bool init(const std::string &path);
-  
+
+  void chown(uid_t uid, gid_t gid);
+
 private:
   AdminSocket(const AdminSocket& rhs);
   AdminSocket& operator=(const AdminSocket &rhs);

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -438,6 +438,8 @@ CephContext::CephContext(uint32_t module_type_, int init_flags_)
     _log(NULL),
     _module_type(module_type_),
     _init_flags(init_flags_),
+    _set_uid(0),
+    _set_gid(0),
     _crypto_inited(false),
     _service_thread(NULL),
     _log_obs(NULL),

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -153,6 +153,17 @@ public:
     return _plugin_registry;
   }
 
+  void set_uid_gid(uid_t u, gid_t g) {
+    _set_uid = u;
+    _set_gid = g;
+  }
+  uid_t get_set_uid() const {
+    return _set_uid;
+  }
+  gid_t get_set_gid() const {
+    return _set_gid;
+  }
+
 private:
   struct SingletonWrapper : boost::noncopyable {
     virtual ~SingletonWrapper() {}
@@ -178,6 +189,9 @@ private:
   uint32_t _module_type;
 
   int _init_flags;
+
+  uid_t _set_uid; ///< uid to drop privs to
+  gid_t _set_gid; ///< gid to drop privs to
 
   bool _crypto_inited;
 

--- a/src/common/common_init.h
+++ b/src/common/common_init.h
@@ -37,6 +37,9 @@ enum common_init_flags_t {
 
   // don't do anything daemonish, like create /var/run/ceph, or print a banner
   CINIT_FLAG_NO_DAEMON_ACTIONS = 0x8,
+
+  // don't drop privileges
+  CINIT_FLAG_DEFER_DROP_PRIVILEGES = 0x16,
 };
 
 /*

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -106,7 +106,6 @@ public:
 
   // Parse a config file
   int parse_config_files(const char *conf_files,
-			 std::deque<std::string> *parse_errors,
 			 std::ostream *warnings, int flags);
 
   // Absorb config settings from the environment
@@ -162,6 +161,9 @@ public:
   void diff(const md_config_t *other,
             map<string,pair<string,string> > *diff, set<string> *unknown);
 
+  /// print/log warnings/errors from parsing the config
+  void complain_about_parse_errors(CephContext *cct);
+
 private:
   void _show_config(std::ostream *out, Formatter *f);
 
@@ -176,7 +178,6 @@ private:
   int parse_injectargs(std::vector<const char*>& args,
 		      std::ostream *oss);
   int parse_config_files_impl(const std::list<std::string> &conf_files,
-			      std::deque<std::string> *parse_errors,
 			      std::ostream *warnings);
 
   int set_val_impl(const char *val, const config_option *opt);
@@ -197,6 +198,9 @@ private:
 
   // The configuration file we read, or NULL if we haven't read one.
   ConfFile cf;
+public:
+  std::deque<std::string> parse_errors;
+private:
 
   obs_map_t observers;
   changed_set_t changed;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -106,9 +106,6 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
 
   conf->parse_argv(args); // argv override
 
-  // Expand metavariables. Invoke configuration observers.
-  conf->apply_changes(NULL);
-
   // Now we're ready to complain about config file parse errors
   complain_about_parse_errors(cct, &parse_errors);
 }
@@ -219,6 +216,9 @@ void global_init(std::vector < const char * > *alt_def_args,
     }
     dout(0) << "set uid:gid to " << uid << ":" << gid << dendl;
   }
+
+  // Expand metavariables. Invoke configuration observers. Open log file.
+  g_conf->apply_changes(NULL);
 
   if (g_conf->run_dir.length() &&
       code_env == CODE_ENVIRONMENT_DAEMON &&

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -256,6 +256,9 @@ void global_init(std::vector < const char * > *alt_def_args,
     }
   }
 
+  // Now we're ready to complain about config file parse errors
+  g_conf->complain_about_parse_errors(g_ceph_context);
+
   // test leak checking
   if (g_conf->debug_deliberately_leak_memory) {
     derr << "deliberately leaking some memory" << dendl;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -79,8 +79,8 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
   if (alt_def_args)
     conf->parse_argv(*alt_def_args);  // alternative default args
 
-  std::deque<std::string> parse_errors;
-  int ret = conf->parse_config_files(c_str_or_null(conf_file_list), &parse_errors, &cerr, flags);
+  int ret = conf->parse_config_files(c_str_or_null(conf_file_list),
+				     &cerr, flags);
   if (ret == -EDOM) {
     dout_emergency("global_init: error parsing config file.\n");
     _exit(1);
@@ -108,7 +108,7 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
   conf->parse_argv(args); // argv override
 
   // Now we're ready to complain about config file parse errors
-  complain_about_parse_errors(cct, &parse_errors);
+  g_conf->complain_about_parse_errors(g_ceph_context);
 }
 
 void global_init(std::vector < const char * > *alt_def_args,

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -22,6 +22,7 @@
 #include "common/safe_io.h"
 #include "common/signal.h"
 #include "common/version.h"
+#include "common/admin_socket.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
 #include "global/pidfile.h"
@@ -243,6 +244,16 @@ void global_init(std::vector < const char * > *alt_def_args,
 
   if (priv_ss.str().length()) {
     dout(0) << priv_ss.str() << dendl;
+
+    if (g_ceph_context->get_set_uid() || g_ceph_context->get_set_gid()) {
+      // fix ownership on log, asok files.  this is sadly a bit of a hack :(
+      g_ceph_context->_log->chown_log_file(
+	g_ceph_context->get_set_uid(),
+	g_ceph_context->get_set_gid());
+      g_ceph_context->get_admin_socket()->chown(
+	g_ceph_context->get_set_uid(),
+	g_ceph_context->get_set_gid());
+    }
   }
 
   // test leak checking

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -202,6 +202,7 @@ void global_init(std::vector < const char * > *alt_def_args,
 		<< st.st_uid << ":" << st.st_gid << ". ";
       }
     }
+    g_ceph_context->set_uid_gid(uid, gid);
     if (setgid(gid) != 0) {
       int r = errno;
       cerr << "unable to setgid " << gid << ": " << cpp_strerror(r)

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -173,12 +173,11 @@ public:
 
   int conf_read_file(const char *path_list)
   {
-    std::deque<std::string> parse_errors;
-    int ret = cct->_conf->parse_config_files(path_list, &parse_errors, NULL, 0);
+    int ret = cct->_conf->parse_config_files(path_list, NULL, 0);
     if (ret)
       return ret;
     cct->_conf->apply_changes(NULL);
-    complain_about_parse_errors(cct, &parse_errors);
+    cct->_conf->complain_about_parse_errors(cct);
     return 0;
   }
 

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2456,8 +2456,7 @@ extern "C" int rados_conf_read_file(rados_t cluster, const char *path_list)
   tracepoint(librados, rados_conf_read_file_enter, cluster, path_list);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
   md_config_t *conf = client->cct->_conf;
-  std::deque<std::string> parse_errors;
-  int ret = conf->parse_config_files(path_list, &parse_errors, NULL, 0);
+  int ret = conf->parse_config_files(path_list, NULL, 0);
   if (ret) {
     tracepoint(librados, rados_conf_read_file_exit, ret);
     return ret;
@@ -2465,7 +2464,7 @@ extern "C" int rados_conf_read_file(rados_t cluster, const char *path_list)
   conf->parse_env(); // environment variables override
 
   conf->apply_changes(NULL);
-  complain_about_parse_errors(client->cct, &parse_errors);
+  client->cct->_conf->complain_about_parse_errors(client->cct);
   tracepoint(librados, rados_conf_read_file_exit, 0);
   return 0;
 }

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -50,6 +50,8 @@ Log::Log(SubsystemMap *s)
     m_flush_mutex_holder(0),
     m_new(), m_recent(),
     m_fd(-1),
+    m_uid(0),
+    m_gid(0),
     m_syslog_log(-2), m_syslog_crash(-2),
     m_stderr_log(1), m_stderr_crash(-1),
     m_graylog_log(-3), m_graylog_crash(-3),
@@ -136,10 +138,32 @@ void Log::reopen_log_file()
     VOID_TEMP_FAILURE_RETRY(::close(m_fd));
   if (m_log_file.length()) {
     m_fd = ::open(m_log_file.c_str(), O_CREAT|O_WRONLY|O_APPEND, 0644);
+    if (m_uid || m_gid) {
+      int r = ::fchown(m_fd, m_uid, m_gid);
+      if (r < 0) {
+	r = -errno;
+	cerr << "failed to chown " << m_log_file << ": " << cpp_strerror(r)
+	     << std::endl;
+      }
+    }
   } else {
     m_fd = -1;
   }
   m_flush_mutex_holder = 0;
+  pthread_mutex_unlock(&m_flush_mutex);
+}
+
+void Log::chown_log_file(uid_t uid, gid_t gid)
+{
+  pthread_mutex_lock(&m_flush_mutex);
+  if (m_fd >= 0) {
+    int r = ::fchown(m_fd, uid, gid);
+    if (r < 0) {
+      r = -errno;
+      cerr << "failed to chown " << m_log_file << ": " << cpp_strerror(r)
+	   << std::endl;
+    }
+  }
   pthread_mutex_unlock(&m_flush_mutex);
 }
 

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -37,6 +37,8 @@ class Log : private Thread
 
   std::string m_log_file;
   int m_fd;
+  uid_t m_uid;
+  gid_t m_gid;
 
   int m_syslog_log, m_syslog_crash;
   int m_stderr_log, m_stderr_crash;
@@ -66,6 +68,7 @@ public:
   void set_max_recent(int n);
   void set_log_file(std::string fn);
   void reopen_log_file();
+  void chown_log_file(uid_t uid, gid_t gid);
 
   void flush();
 

--- a/src/test/confutils.cc
+++ b/src/test/confutils.cc
@@ -471,35 +471,33 @@ TEST(ConfUtils, EscapingFiles) {
 
 TEST(ConfUtils, Overrides) {
   md_config_t conf;
-  std::deque<std::string> err;
   std::ostringstream warn;
   std::string override_conf_1_f(next_tempfile(override_config_1));
 
   conf.name.set(CEPH_ENTITY_TYPE_MON, "0");
-  conf.parse_config_files(override_conf_1_f.c_str(), &err, &warn, 0);
-  ASSERT_EQ(err.size(), 0U);
+  conf.parse_config_files(override_conf_1_f.c_str(), &warn, 0);
+  ASSERT_EQ(conf.parse_errors.size(), 0U);
   ASSERT_EQ(conf.log_file, "global_log");
 
   conf.name.set(CEPH_ENTITY_TYPE_MDS, "a");
-  conf.parse_config_files(override_conf_1_f.c_str(), &err, &warn, 0);
-  ASSERT_EQ(err.size(), 0U);
+  conf.parse_config_files(override_conf_1_f.c_str(), &warn, 0);
+  ASSERT_EQ(conf.parse_errors.size(), 0U);
   ASSERT_EQ(conf.log_file, "mds_log");
 
   conf.name.set(CEPH_ENTITY_TYPE_OSD, "0");
-  conf.parse_config_files(override_conf_1_f.c_str(), &err, &warn, 0);
-  ASSERT_EQ(err.size(), 0U);
+  conf.parse_config_files(override_conf_1_f.c_str(), &warn, 0);
+  ASSERT_EQ(conf.parse_errors.size(), 0U);
   ASSERT_EQ(conf.log_file, "osd0_log");
 }
 
 TEST(ConfUtils, DupKey) {
   md_config_t conf;
-  std::deque<std::string> err;
   std::ostringstream warn;
   std::string dup_key_config_f(next_tempfile(dup_key_config_1));
 
   conf.name.set(CEPH_ENTITY_TYPE_MDS, "a");
-  conf.parse_config_files(dup_key_config_f.c_str(), &err, &warn, 0);
-  ASSERT_EQ(err.size(), 0U);
+  conf.parse_config_files(dup_key_config_f.c_str(), &warn, 0);
+  ASSERT_EQ(conf.parse_errors.size(), 0U);
   ASSERT_EQ(conf.log_file, string("3"));
 }
 

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -153,12 +153,11 @@ extern "C" int rados_conf_read_file(rados_t cluster, const char *path) {
   librados::TestRadosClient *client =
     reinterpret_cast<librados::TestRadosClient*>(cluster);
   md_config_t *conf = client->cct()->_conf;
-  std::deque<std::string> parse_errors;
-  int ret = conf->parse_config_files(path, &parse_errors, NULL, 0);
+  int ret = conf->parse_config_files(path, NULL, 0);
   if (ret == 0) {
     conf->parse_env();
     conf->apply_changes(NULL);
-    complain_about_parse_errors(client->cct(), &parse_errors);
+    conf->complain_about_parse_errors(client->cct());
   } else if (ret == -EINVAL) {
     // ignore missing client config
     return 0;

--- a/src/tools/ceph_conf.cc
+++ b/src/tools/ceph_conf.cc
@@ -153,6 +153,7 @@ int main(int argc, const char **argv)
 
   global_pre_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_DAEMON,
 		  CINIT_FLAG_NO_DAEMON_ACTIONS);
+  g_conf->apply_changes(NULL);
 
   // do not common_init_finish(); do not start threads; do not do any of thing
   // wonky things the daemon whose conf we are examining would do (like initialize

--- a/src/tools/ceph_conf.cc
+++ b/src/tools/ceph_conf.cc
@@ -154,6 +154,7 @@ int main(int argc, const char **argv)
   global_pre_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_DAEMON,
 		  CINIT_FLAG_NO_DAEMON_ACTIONS);
   g_conf->apply_changes(NULL);
+  g_conf->complain_about_parse_errors(g_ceph_context);
 
   // do not common_init_finish(); do not start threads; do not do any of thing
   // wonky things the daemon whose conf we are examining would do (like initialize


### PR DESCRIPTION
This ensures we open the log file a the final user, not as root.

Signed-off-by: Sage Weil <sage@redhat.com>