### PR TITLE
AsyncConnection: avoid debug log in cleanup_handler

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2567,16 +2567,3 @@ void AsyncConnection::local_deliver()
     write_lock.Lock();
   }
 }
-
-void AsyncConnection::cleanup_handler()
-{
-  ldout(async_msgr->cct, 1) << __func__ << dendl;
-
-  delete read_handler;
-  delete write_handler;
-  delete reset_handler;
-  delete remote_reset_handler;
-  delete connect_handler;
-  delete local_deliver_handler;
-  delete wakeup_handler;
-}

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -315,7 +315,15 @@ class AsyncConnection : public Connection {
     lock.Unlock();
     mark_down();
   }
-  void cleanup_handler();
+  void cleanup_handler() {
+    delete read_handler;
+    delete write_handler;
+    delete reset_handler;
+    delete remote_reset_handler;
+    delete connect_handler;
+    delete local_deliver_handler;
+    delete wakeup_handler;
+  }
   PerfCounters *get_perf_counter() {
     return logger;
   }


### PR DESCRIPTION
local connection will be stop and call cleanup_handler after messenger
is down
introduced in
commit(https://github.com/ceph/ceph/commit/9da2fffd31562ed5d0b795d7862b3ebec66aba40)

Fix #14679

Signed-off-by: Haomai Wang <haomai@xsky.com>