### PR TITLE
OSDMap: reset osd_primary_affinity shared_ptr when deepish_copy_from

### DIFF
--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -296,6 +296,9 @@ public:
     pg_temp.reset(new map<pg_t,vector<int32_t> >(*o.pg_temp));
     osd_uuid.reset(new vector<uuid_d>(*o.osd_uuid));
 
+    if (o.osd_primary_affinity)
+      osd_primary_affinity.reset(new vector<__u32>(*o.osd_primary_affinity));
+
     // NOTE: this still references shared entity_addr_t's.
     osd_addrs.reset(new addrs_s(*o.osd_addrs));
 


### PR DESCRIPTION
Base on current logic, OSDMonitor may call create_pending and
encode_pending twice for the some epoch.

In encode_pending:

tmp.deepish_copy_from(osdmap);
tmp.apply_incremental(pending_inc);

These Ops would change the tmp osd_primary_affinity, but the osd_primary_affinity
is declared as ceph::shared_ptr, so this would change the osdmap too. When this
round encode_pending is proposed fail. We may call encode_pending again, but the
osdmap is changed last round, so the pending_inc would be wrong.

Signed-off-by: Xinze Chi <xinze@xsky.com>

I am not very sure whether It is right or not.