### PR TITLE
mon: have mon-specific features

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -319,6 +319,7 @@ set(libcommon_files
   common/linux_version.c
   common/TracepointProvider.cc
   common/Cycles.cc
+  common/bit_str.cc
   osdc/Striper.cc
   osdc/Objecter.cc
   common/Graylog.cc

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -74,7 +74,8 @@ libcommon_internal_la_SOURCES = \
 	common/Cycles.cc \
 	common/ContextCompletion.cc \
 	common/TracepointProvider.cc \
-	common/PluginRegistry.cc
+	common/PluginRegistry.cc \
+	common/bit_str.cc
 
 common/PluginRegistry.cc: ./ceph_ver.h
 
@@ -282,6 +283,7 @@ noinst_HEADERS += \
 	common/ceph_time.h \
 	common/ceph_timer.h \
 	common/align.h \
+	common/bit_str.h \
 	common/mutex_debug.h \
 	common/shunique_lock.h
 

--- a/src/common/bit_str.cc
+++ b/src/common/bit_str.cc
@@ -1,0 +1,61 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH 
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#include "common/bit_str.h"
+#include "common/Formatter.h"
+#include "include/assert.h"
+
+static void _dump_bit_str(
+    uint64_t bits,
+    std::ostream *out,
+    ceph::Formatter *f,
+    std::function<const char*(uint64_t)> func)
+{
+  uint64_t b = bits;
+  int cnt = 0;
+  bool outted = false;
+
+  while (b && cnt < 64) {
+    uint64_t r = bits & (1ULL << cnt++);
+    if (r) {
+      if (out) {
+        if (outted)
+          *out << ",";
+        *out << func(r);
+      } else {
+        assert(f != NULL);
+        f->dump_stream("bit_flag") << func(r);
+      }
+      outted = true;
+    }
+    b >>= 1;
+  }
+  if (!outted && out)
+      *out << "none";
+}
+
+void print_bit_str(
+    uint64_t bits,
+    std::ostream &out,
+    std::function<const char*(uint64_t)> func)
+{
+  _dump_bit_str(bits, &out, NULL, func);
+}
+
+void dump_bit_str(
+    uint64_t bits,
+    ceph::Formatter *f,
+    std::function<const char*(uint64_t)> func)
+{
+  _dump_bit_str(bits, NULL, f, func);
+}

--- a/src/common/bit_str.h
+++ b/src/common/bit_str.h
@@ -1,0 +1,36 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH 
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#ifndef CEPH_COMMON_BIT_STR_H
+#define CEPH_COMMON_BIT_STR_H
+
+#include <ostream>
+#include <functional>
+#include <stdint.h>
+//#include "common/Formatter.h"
+
+namespace ceph {
+  class Formatter;
+}
+
+extern void print_bit_str(
+    uint64_t bits,
+    std::ostream &out,
+    std::function<const char*(uint64_t)> func);
+
+extern void dump_bit_str(
+    uint64_t bits,
+    ceph::Formatter *f,
+    std::function<const char*(uint64_t)> func);
+
+#endif /* CEPH_COMMON_BIT_STR_H */

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -73,6 +73,7 @@
 #define CEPH_FEATURE_MON_STATEFUL_SUB (1ULL<<57) /* stateful mon subscription */
 #define CEPH_FEATURE_MON_ROUTE_OSDMAP (1ULL<<57) /* peon sends osdmaps */
 #define CEPH_FEATURE_OSDSUBOP_NO_SNAPCONTEXT (1ULL<<57) /* overlap, drop unused SnapContext in v12 */
+#define CEPH_FEATURE_JEWEL (1ULL<<57) /* jewel */
 #define CEPH_FEATURE_CRUSH_TUNABLES5	(1ULL<<58) /* chooseleaf stable mode */
 // duplicated since it was introduced at the same time as CEPH_FEATURE_CRUSH_TUNABLES5
 #define CEPH_FEATURE_NEW_OSDOPREPLY_ENCODING   (1ULL<<58) /* New, v7 encoding */
@@ -172,6 +173,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_MON_STATEFUL_SUB |	 \
 	 CEPH_FEATURE_MON_ROUTE_OSDMAP |	 \
 	 CEPH_FEATURE_CRUSH_TUNABLES5 |	    \
+         CEPH_FEATURE_JEWEL | \
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -243,7 +243,7 @@ void AuthMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   ::encode(v, bl);
   vector<Incremental>::iterator p;
   for (p = pending_auth.begin(); p != pending_auth.end(); ++p)
-    p->encode(bl, mon->get_quorum_features());
+    p->encode(bl, mon->get_quorum_con_features());
 
   version_t version = get_last_committed() + 1;
   put_version(t, version, bl);

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -89,13 +89,16 @@ void Elector::start()
   }
   start_stamp = ceph_clock_now(g_ceph_context);
   electing_me = true;
-  acked_me[mon->rank] = CEPH_FEATURES_ALL;
+  acked_me[mon->rank].cluster_features = CEPH_FEATURES_ALL;
+  acked_me[mon->rank].mon_features = ceph::features::mon::get_supported();
   leader_acked = -1;
 
   // bcast to everyone else
   for (unsigned i=0; i<mon->monmap->size(); ++i) {
     if ((int)i == mon->rank) continue;
-    Message *m = new MMonElection(MMonElection::OP_PROPOSE, epoch, mon->monmap);
+    MMonElection *m =
+      new MMonElection(MMonElection::OP_PROPOSE, epoch, mon->monmap);
+    m->mon_features = ceph::features::mon::get_supported();
     mon->messenger->send_message(m, mon->monmap->get_inst(i));
   }
   
@@ -117,6 +120,7 @@ void Elector::defer(int who)
   leader_acked = who;
   ack_stamp = ceph_clock_now(g_ceph_context);
   MMonElection *m = new MMonElection(MMonElection::OP_ACK, epoch, mon->monmap);
+  m->mon_features = ceph::features::mon::get_supported();
   m->sharing_bl = mon->get_supported_commands_bl();
   mon->messenger->send_message(m, mon->monmap->get_inst(who));
   
@@ -167,12 +171,15 @@ void Elector::victory()
   leader_acked = -1;
   electing_me = false;
 
-  uint64_t features = CEPH_FEATURES_ALL;
+  uint64_t cluster_features = CEPH_FEATURES_ALL;
+  mon_feature_t mon_features = ceph::features::mon::get_supported();
   set<int> quorum;
-  for (map<int, uint64_t>::iterator p = acked_me.begin(); p != acked_me.end();
+  for (map<int, elector_features_t>::iterator p = acked_me.begin();
+       p != acked_me.end();
        ++p) {
     quorum.insert(p->first);
-    features &= p->second;
+    cluster_features &= p->second.cluster_features;
+    mon_features &= p->second.mon_features;
   }
 
   // decide what command set we're supporting
@@ -204,13 +211,16 @@ void Elector::victory()
     if (*p == mon->rank) continue;
     MMonElection *m = new MMonElection(MMonElection::OP_VICTORY, epoch, mon->monmap);
     m->quorum = quorum;
-    m->quorum_features = features;
+    m->quorum_features = cluster_features;
+    m->mon_features = mon_features;
     m->sharing_bl = *cmds_bl;
     mon->messenger->send_message(m, mon->monmap->get_inst(*p));
   }
     
   // tell monitor
-  mon->win_election(epoch, quorum, features, cmds, cmdsize, &copy_classic_mons);
+  mon->win_election(epoch, quorum,
+                    cluster_features, mon_features,
+                    cmds, cmdsize, &copy_classic_mons);
 }
 
 
@@ -295,13 +305,24 @@ void Elector::handle_ack(MonOpRequestRef op)
 	    << " without required features" << dendl;
     return;
   }
-  
+
   if (electing_me) {
     // thanks
-    acked_me[from] = m->get_connection()->get_features();
+    acked_me[from].cluster_features = m->get_connection()->get_features();
+    acked_me[from].mon_features = m->mon_features;
     if (!m->sharing_bl.length())
       classic_mons.insert(from);
-    dout(5) << " so far i have " << acked_me << dendl;
+    dout(5) << " so far i have {";
+    for (map<int, elector_features_t>::const_iterator p = acked_me.begin();
+         p != acked_me.end();
+         ++p) {
+      if (p != acked_me.begin())
+        *_dout << ",";
+      *_dout << " mon." << p->first << ":"
+             << " features " << p->second.cluster_features
+             << " " << p->second.mon_features;
+    }
+    *_dout << " }" << dendl;
     
     // is that _everyone_?
     if (acked_me.size() == mon->monmap->size()) {
@@ -319,7 +340,10 @@ void Elector::handle_victory(MonOpRequestRef op)
 {
   op->mark_event("elector:handle_victory");
   MMonElection *m = static_cast<MMonElection*>(op->get_req());
-  dout(5) << "handle_victory from " << m->get_source() << " quorum_features " << m->quorum_features << dendl;
+  dout(5) << "handle_victory from " << m->get_source()
+          << " quorum_features " << m->quorum_features
+          << " " << m->mon_features
+          << dendl;
   int from = m->get_source().num();
 
   assert(from < mon->rank);
@@ -336,10 +360,11 @@ void Elector::handle_victory(MonOpRequestRef op)
   }
 
   bump_epoch(m->epoch);
-  
+
   // they win
-  mon->lose_election(epoch, m->quorum, from, m->quorum_features);
-  
+  mon->lose_election(epoch, m->quorum, from,
+                     m->quorum_features, m->mon_features);
+
   // cancel my timer
   cancel_timer();
 

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -233,15 +233,26 @@ void Elector::handle_propose(MonOpRequestRef op)
 
   assert(m->epoch % 2 == 1); // election
   uint64_t required_features = mon->get_required_features();
+  mon_feature_t required_mon_features = mon->get_required_mon_features();
+
   dout(10) << __func__ << " required features " << required_features
+           << " " << required_mon_features
            << ", peer features " << m->get_connection()->get_features()
+           << " " << m->mon_features
            << dendl;
+
   if ((required_features ^ m->get_connection()->get_features()) &
       required_features) {
     dout(5) << " ignoring propose from mon" << from
 	    << " without required features" << dendl;
     nak_old_peer(op);
     return;
+  } else if (!m->mon_features.contains_all(required_mon_features)) {
+    mon_feature_t missing = m->mon_features.diff(required_mon_features);
+    dout(5) << " ignoring propose from mon." << from
+            << " without required mon_features " << missing
+            << dendl;
+    nak_old_peer(op);
   } else if (m->epoch > epoch) {
     bump_epoch(m->epoch);
   } else if (m->epoch < epoch) {
@@ -282,7 +293,7 @@ void Elector::handle_propose(MonOpRequestRef op)
     }
   }
 }
- 
+
 void Elector::handle_ack(MonOpRequestRef op)
 {
   op->mark_event("elector:handle_ack");
@@ -306,6 +317,15 @@ void Elector::handle_ack(MonOpRequestRef op)
     return;
   }
 
+  mon_feature_t required_mon_features = mon->get_required_mon_features();
+  if (!m->mon_features.contains_all(required_mon_features)) {
+    mon_feature_t missing = m->mon_features.diff(required_mon_features);
+    dout(5) << " ignoring ack from mon." << from
+            << " without required mon_features " << missing
+            << dendl;
+    return;
+  }
+
   if (electing_me) {
     // thanks
     acked_me[from].cluster_features = m->get_connection()->get_features();
@@ -323,7 +343,7 @@ void Elector::handle_ack(MonOpRequestRef op)
              << " " << p->second.mon_features;
     }
     *_dout << " }" << dendl;
-    
+
     // is that _everyone_?
     if (acked_me.size() == mon->monmap->size()) {
       // if yes, shortcut to election finish
@@ -391,13 +411,18 @@ void Elector::nak_old_peer(MonOpRequestRef op)
 
   if (supported_features & CEPH_FEATURE_OSDMAP_ENC) {
     uint64_t required_features = mon->get_required_features();
+    mon_feature_t required_mon_features = mon->get_required_mon_features();
     dout(10) << "sending nak to peer " << m->get_source()
 	     << " that only supports " << supported_features
-	     << " of the required " << required_features << dendl;
+             << " " << m->mon_features
+	     << " of the required " << required_features
+             << " " << required_mon_features
+             << dendl;
     
     MMonElection *reply = new MMonElection(MMonElection::OP_NAK, m->epoch,
 					   mon->monmap);
     reply->quorum_features = required_features;
+    reply->mon_features = required_mon_features;
     mon->features.encode(reply->sharing_bl);
     m->get_connection()->send_message(reply);
   }
@@ -408,16 +433,21 @@ void Elector::handle_nak(MonOpRequestRef op)
   op->mark_event("elector:handle_nak");
   MMonElection *m = static_cast<MMonElection*>(op->get_req());
   dout(1) << "handle_nak from " << m->get_source()
-	  << " quorum_features " << m->quorum_features << dendl;
+	  << " quorum_features " << m->quorum_features
+          << " " << m->mon_features
+          << dendl;
 
   CompatSet other;
   bufferlist::iterator bi = m->sharing_bl.begin();
   other.decode(bi);
   CompatSet diff = Monitor::get_supported_features().unsupported(other);
-  
+
+  mon_feature_t mon_supported = ceph::features::mon::get_supported();
+  mon_feature_t mon_diff = mon_supported.diff(m->mon_features);
+
   derr << "Shutting down because I do not support required monitor features: { "
-       << diff << " }" << dendl;
-  
+       << diff << " } " << mon_diff << dendl;
+
   exit(0);
   // the end!
 }

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -26,6 +26,7 @@ using namespace std;
 
 #include "common/Timer.h"
 #include "mon/MonOpRequest.h"
+#include "mon/mon_types.h"
 
 class Monitor;
 
@@ -40,6 +41,25 @@ class Elector {
    * @{
    */
  private:
+   /**
+   * @defgroup Elector_h_internal_types Internal Types
+   * @{
+   */
+  /**
+   * This struct will hold the features from a given peer.
+   * Features may both be the cluster's (in the form of a uint64_t), or
+   * mon-specific features. Instead of keeping maps to hold them both, or
+   * a pair, which would be weird, a struct to keep them seems appropriate.
+   */
+  struct elector_features_t {
+    uint64_t cluster_features;
+    mon_feature_t mon_features;
+  };
+
+  /**
+   * @}
+   */
+
   /**
    * The Monitor instance associated with this class.
    */
@@ -114,7 +134,7 @@ class Elector {
    * If we are acked by everyone in the MonMap, we will declare
    * victory.  Also note each peer's feature set.
    */
-  map<int, uint64_t> acked_me;
+  map<int, elector_features_t> acked_me;
   set<int> classic_mons;
   /**
    * @}

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -162,7 +162,7 @@ void MDSMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   // apply to paxos
   assert(get_last_committed() + 1 == pending_mdsmap.epoch);
   bufferlist mdsmap_bl;
-  pending_mdsmap.encode(mdsmap_bl, mon->get_quorum_features());
+  pending_mdsmap.encode(mdsmap_bl, mon->get_quorum_con_features());
 
   /* put everything in the transaction */
   put_version(t, pending_mdsmap.epoch, mdsmap_bl);

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -19,6 +19,7 @@
 
 #include "msg/Message.h"
 #include "include/types.h"
+#include "mon/mon_types.h"
 //#include "common/config.h"
 
 namespace ceph {
@@ -36,6 +37,13 @@ class MonMap {
   map<entity_addr_t,string> addr_name;
   vector<string> rank_name;
   vector<entity_addr_t> rank_addr;
+
+  mon_feature_t persistent_features;
+  mon_feature_t optional_features;
+
+  mon_feature_t get_required_features() {
+    return (persistent_features | optional_features);
+  }
 
   void calc_ranks() {
     rank_name.resize(mon_addr.size());
@@ -56,7 +64,7 @@ class MonMap {
     }
   }
 
-  MonMap() 
+  MonMap()
     : epoch(0) {
     memset(&fsid, 0, sizeof(fsid));
   }
@@ -83,7 +91,7 @@ class MonMap {
     mon_addr[name] = addr;
     calc_ranks();
   }
-  
+
   void remove(const string &name) {
     assert(mon_addr.count(name));
     mon_addr.erase(name);
@@ -173,7 +181,7 @@ class MonMap {
     return i;
   }
 
-  void encode(bufferlist& blist, uint64_t features) const;
+  void encode(bufferlist& blist, uint64_t con_features) const;
   void decode(bufferlist& blist) {
     bufferlist::iterator p = blist.begin();
     decode(p);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1910,6 +1910,7 @@ void Monitor::win_election(epoch_t epoch, set<int>& active, uint64_t features,
   finish_election();
   if (monmap->size() > 1 &&
       monmap->get_epoch() > 0) {
+    monmon()->apply_mon_features(quorum_mon_features);
     timecheck_start();
     health_tick_start();
     do_health_to_clog_interval();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -169,7 +169,7 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   elector(this),
   required_features(0),
   leader(0),
-  quorum_features(0),
+  quorum_con_features(0),
   // scrub
   scrub_version(0),
   scrub_event(NULL),
@@ -1880,7 +1880,7 @@ void Monitor::win_election(epoch_t epoch, set<int>& active, uint64_t features,
   leader_since = ceph_clock_now(g_ceph_context);
   leader = rank;
   quorum = active;
-  quorum_features = features;
+  quorum_con_features = features;
   quorum_mon_features = mon_features;
   outside_quorum.clear();
 
@@ -1927,10 +1927,10 @@ void Monitor::lose_election(epoch_t epoch, set<int> &q, int l,
   leader = l;
   quorum = q;
   outside_quorum.clear();
-  quorum_features = features;
+  quorum_con_features = features;
   quorum_mon_features = mon_features;
   dout(10) << "lose_election, epoch " << epoch << " leader is mon" << leader
-	   << " quorum is " << quorum << " features are " << quorum_features
+	   << " quorum is " << quorum << " features are " << quorum_con_features
            << " mon_features are " << quorum_mon_features
            << dendl;
 
@@ -1943,7 +1943,7 @@ void Monitor::lose_election(epoch_t epoch, set<int> &q, int l,
 
   finish_election();
 
-  if (quorum_features & CEPH_FEATURE_MON_METADATA) {
+  if (quorum_con_features & CEPH_FEATURE_MON_METADATA) {
     Metadata sys_info;
     collect_sys_info(&sys_info, g_ceph_context);
     messenger->send_message(new MMonMetadata(sys_info),
@@ -1974,16 +1974,16 @@ void Monitor::finish_election()
 void Monitor::apply_quorum_to_compatset_features()
 {
   CompatSet new_features(features);
-  if (quorum_features & CEPH_FEATURE_OSD_ERASURE_CODES) {
+  if (quorum_con_features & CEPH_FEATURE_OSD_ERASURE_CODES) {
     new_features.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_OSD_ERASURE_CODES);
   }
-  if (quorum_features & CEPH_FEATURE_OSDMAP_ENC) {
+  if (quorum_con_features & CEPH_FEATURE_OSDMAP_ENC) {
     new_features.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_OSDMAP_ENC);
   }
-  if (quorum_features & CEPH_FEATURE_ERASURE_CODE_PLUGINS_V2) {
+  if (quorum_con_features & CEPH_FEATURE_ERASURE_CODE_PLUGINS_V2) {
     new_features.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V2);
   }
-  if (quorum_features & CEPH_FEATURE_ERASURE_CODE_PLUGINS_V3) {
+  if (quorum_con_features & CEPH_FEATURE_ERASURE_CODE_PLUGINS_V3) {
     new_features.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V3);
   }
   if (new_features.compare(features) != 0) {
@@ -3208,7 +3208,7 @@ void Monitor::try_send_message(Message *m, const entity_inst_t& to)
   dout(10) << "try_send_message " << *m << " to " << to << dendl;
 
   bufferlist bl;
-  encode_message(m, quorum_features, bl);
+  encode_message(m, quorum_con_features, bl);
 
   messenger->send_message(m, to);
 
@@ -3264,7 +3264,7 @@ void Monitor::no_reply(MonOpRequestRef op)
   Message *req = op->get_req();
 
   if (session->proxy_con) {
-    if (get_quorum_features() & CEPH_FEATURE_MON_NULLROUTE) {
+    if (get_quorum_con_features() & CEPH_FEATURE_MON_NULLROUTE) {
       dout(10) << "no_reply to " << req->get_source_inst()
 	       << " via " << session->proxy_con->get_peer_addr()
 	       << " for request " << *req << dendl;
@@ -4433,7 +4433,7 @@ int Monitor::scrub_start()
   dout(10) << __func__ << dendl;
   assert(is_leader());
 
-  if ((get_quorum_features() & CEPH_FEATURE_MON_SCRUB) == 0) {
+  if ((get_quorum_con_features() & CEPH_FEATURE_MON_SCRUB) == 0) {
     clog->warn() << "scrub not supported by entire quorum\n";
     return -EOPNOTSUPP;
   }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2100,6 +2100,18 @@ void Monitor::get_mon_status(Formatter *f, ostream& ss)
 
   f->close_section(); // quorum
 
+  f->open_object_section("features");
+  f->dump_stream("required_con") << required_features;
+  f->open_array_section("required_mon");
+  mon_feature_t req_mon_features = get_required_mon_features();
+  req_mon_features.dump(f);
+  f->close_section(); // required_mon
+  f->dump_stream("quorum_con") << quorum_con_features;
+  f->open_array_section("quorum_mon");
+  quorum_mon_features.dump(f);
+  f->close_section(); // quorum_mon
+  f->close_section(); // features
+
   f->open_array_section("outside_quorum");
   for (set<string>::iterator p = outside_quorum.begin(); p != outside_quorum.end(); ++p)
     f->dump_string("mon", *p);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -378,6 +378,7 @@ CompatSet Monitor::get_supported_features()
   compat.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_OSDMAP_ENC);
   compat.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V2);
   compat.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V3);
+  compat.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_JEWEL);
   return compat;
 }
 
@@ -1987,6 +1988,9 @@ void Monitor::apply_quorum_to_compatset_features()
   if (quorum_con_features & CEPH_FEATURE_ERASURE_CODE_PLUGINS_V3) {
     new_features.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V3);
   }
+  if (quorum_con_features & CEPH_FEATURE_JEWEL) {
+    new_features.incompat.insert(CEPH_MON_FEATURE_INCOMPAT_JEWEL);
+  }
   if (new_features.compare(features) != 0) {
     CompatSet diff = features.unsupported(new_features);
     dout(1) << __func__ << " enabling new quorum features: " << diff << dendl;
@@ -2014,6 +2018,9 @@ void Monitor::apply_compatset_features_to_quorum_requirements()
   }
   if (features.incompat.contains(CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V3)) {
     required_features |= CEPH_FEATURE_ERASURE_CODE_PLUGINS_V3;
+  }
+  if (features.incompat.contains(CEPH_MON_FEATURE_INCOMPAT_JEWEL)) {
+    required_features |= CEPH_FEATURE_JEWEL;
   }
   dout(10) << __func__ << " required_features " << required_features << dendl;
 }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1609,9 +1609,6 @@ void Monitor::handle_probe(MonOpRequestRef op)
   }
 }
 
-/**
- * @todo fix this. This is going to cause trouble.
- */
 void Monitor::handle_probe_probe(MonOpRequestRef op)
 {
   MMonProbe *m = static_cast<MMonProbe*>(op->get_req());

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1602,8 +1602,8 @@ void Monitor::handle_probe(MonOpRequestRef op)
 
   case MMonProbe::OP_MISSING_FEATURES:
     derr << __func__ << " missing features, have " << CEPH_FEATURES_ALL
-	 << ", required " << required_features
-	 << ", missing " << (required_features & ~CEPH_FEATURES_ALL)
+	 << ", required " << m->required_features
+	 << ", missing " << (m->required_features & ~CEPH_FEATURES_ALL)
 	 << dendl;
     break;
   }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -788,7 +788,6 @@ int Monitor::init()
   // i'm ready!
   messenger->add_dispatcher_tail(this);
 
-
   bootstrap();
 
   // encode command sets
@@ -1850,7 +1849,10 @@ void Monitor::win_standalone_election()
   const MonCommand *my_cmds;
   int cmdsize;
   get_locally_supported_monitor_commands(&my_cmds, &cmdsize);
-  win_election(elector.get_epoch(), q, CEPH_FEATURES_ALL, my_cmds, cmdsize, NULL);
+  win_election(elector.get_epoch(), q,
+               CEPH_FEATURES_ALL,
+               ceph::features::mon::get_supported(),
+               my_cmds, cmdsize, NULL);
 }
 
 const utime_t& Monitor::get_leader_since() const
@@ -1865,17 +1867,21 @@ epoch_t Monitor::get_epoch()
 }
 
 void Monitor::win_election(epoch_t epoch, set<int>& active, uint64_t features,
+                           const mon_feature_t& mon_features,
                            const MonCommand *cmdset, int cmdsize,
                            const set<int> *classic_monitors)
 {
   dout(10) << __func__ << " epoch " << epoch << " quorum " << active
-	   << " features " << features << dendl;
+	   << " features " << features
+           << " mon_features " << mon_features
+           << dendl;
   assert(is_electing());
   state = STATE_LEADER;
   leader_since = ceph_clock_now(g_ceph_context);
   leader = rank;
   quorum = active;
   quorum_features = features;
+  quorum_mon_features = mon_features;
   outside_quorum.clear();
 
   clog->info() << "mon." << name << "@" << rank
@@ -1912,7 +1918,9 @@ void Monitor::win_election(epoch_t epoch, set<int>& active, uint64_t features,
   collect_sys_info(&metadata[rank], g_ceph_context);
 }
 
-void Monitor::lose_election(epoch_t epoch, set<int> &q, int l, uint64_t features) 
+void Monitor::lose_election(epoch_t epoch, set<int> &q, int l,
+                            uint64_t features,
+                            const mon_feature_t& mon_features)
 {
   state = STATE_PEON;
   leader_since = utime_t();
@@ -1920,8 +1928,11 @@ void Monitor::lose_election(epoch_t epoch, set<int> &q, int l, uint64_t features
   quorum = q;
   outside_quorum.clear();
   quorum_features = features;
+  quorum_mon_features = mon_features;
   dout(10) << "lose_election, epoch " << epoch << " leader is mon" << leader
-	   << " quorum is " << quorum << " features are " << quorum_features << dendl;
+	   << " quorum is " << quorum << " features are " << quorum_features
+           << " mon_features are " << quorum_mon_features
+           << dendl;
 
   paxos->peon_init();
   for (vector<PaxosService*>::iterator p = paxos_service.begin(); p != paxos_service.end(); ++p)

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -227,7 +227,7 @@ private:
   set<int> quorum;       // current active set of monitors (if !starting)
   utime_t leader_since;  // when this monitor became the leader, if it is the leader
   utime_t exited_quorum; // time detected as not in quorum; 0 if in
-  uint64_t quorum_features;  ///< intersection of quorum member feature bits
+  uint64_t quorum_con_features;  ///< intersection of quorum member feature bits
   /// intersection of quorum members mon-specific feature bits
   mon_feature_t quorum_mon_features;
   bufferlist supported_commands_bl; // encoded MonCommands we support
@@ -587,8 +587,8 @@ public:
       q.push_back(monmap->get_name(*p));
     return q;
   }
-  uint64_t get_quorum_features() const {
-    return quorum_features;
+  uint64_t get_quorum_con_features() const {
+    return quorum_con_features;
   }
   uint64_t get_required_features() const {
     return required_features;

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -985,6 +985,7 @@ public:
 #define CEPH_MON_FEATURE_INCOMPAT_OSDMAP_ENC CompatSet::Feature(5, "new-style osdmap encoding")
 #define CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V2 CompatSet::Feature(6, "support isa/lrc erasure code")
 #define CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V3 CompatSet::Feature(7, "support shec erasure code")
+#define CEPH_MON_FEATURE_INCOMPAT_JEWEL CompatSet::Feature(8, "support monmap features")
 // make sure you add your feature to Monitor::get_supported_features
 
 long parse_pos_long(const char *s, ostream *pss = NULL);

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -593,6 +593,9 @@ public:
   uint64_t get_required_features() const {
     return required_features;
   }
+  mon_feature_t get_required_mon_features() const {
+    return monmap->get_required_features();
+  }
   void apply_quorum_to_compatset_features();
   void apply_compatset_features_to_quorum_requirements();
 

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -228,6 +228,8 @@ private:
   utime_t leader_since;  // when this monitor became the leader, if it is the leader
   utime_t exited_quorum; // time detected as not in quorum; 0 if in
   uint64_t quorum_features;  ///< intersection of quorum member feature bits
+  /// intersection of quorum members mon-specific feature bits
+  mon_feature_t quorum_mon_features;
   bufferlist supported_commands_bl; // encoded MonCommands we support
   bufferlist classic_commands_bl; // encoded MonCommands supported by Dumpling
   set<int> classic_mons; // set of "classic" monitors; only valid on leader
@@ -605,10 +607,13 @@ public:
   // end election (called by Elector)
   void win_election(epoch_t epoch, set<int>& q,
 		    uint64_t features,
+                    const mon_feature_t& mon_features,
 		    const MonCommand *cmdset, int cmdsize,
 		    const set<int> *classic_monitors);
   void lose_election(epoch_t epoch, set<int>& q, int l,
-		     uint64_t features); // end election (called by Elector)
+		     uint64_t features,
+                     const mon_feature_t& mon_features);
+  // end election (called by Elector)
   void finish_election();
 
   const bufferlist& get_supported_commands_bl() {

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -93,7 +93,7 @@ void MonmapMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   assert(mon->monmap->epoch + 1 == pending_map.epoch ||
 	 pending_map.epoch == 1);  // special case mkfs!
   bufferlist bl;
-  pending_map.encode(bl, mon->get_quorum_features());
+  pending_map.encode(bl, mon->get_quorum_con_features());
 
   put_version(t, pending_map.epoch, bl);
   put_last_committed(t, pending_map.epoch);

--- a/src/mon/MonmapMonitor.h
+++ b/src/mon/MonmapMonitor.h
@@ -55,6 +55,7 @@ class MonmapMonitor : public PaxosService {
   virtual void encode_full(MonitorDBStore::TransactionRef t) { }
 
   void on_active();
+  void apply_mon_features(const mon_feature_t& features);
 
   void dump_info(Formatter *f);
 
@@ -83,6 +84,26 @@ class MonmapMonitor : public PaxosService {
 
  private:
   bufferlist monmap_bl;
+
+  class C_ApplyFeatures : public Context {
+    MonmapMonitor *svc;
+    mon_feature_t features;
+  public:
+    C_ApplyFeatures(MonmapMonitor *s, const mon_feature_t& f) :
+      svc(s), features(f) { }
+    void finish(int r) {
+      if (r >= 0) {
+        svc->apply_mon_features(features);
+      } else if (r == -EAGAIN || r == -ECANCELED) {
+        // discard features if we're no longer on the quorum that
+        // established them in the first place.
+        return;
+      } else {
+        assert(0 == "bad C_ApplyFeatures return value");
+      }
+    }
+  };
+
 };
 
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -126,7 +126,8 @@ void OSDMonitor::create_initial()
   newmap.set_flag(CEPH_OSDMAP_SORTBITWISE);
 
   // encode into pending incremental
-  newmap.encode(pending_inc.fullmap, mon->quorum_features | CEPH_FEATURE_RESERVED);
+  newmap.encode(pending_inc.fullmap,
+                mon->get_quorum_con_features() | CEPH_FEATURE_RESERVED);
   pending_inc.full_crc = newmap.get_crc();
   dout(20) << " full crc " << pending_inc.full_crc << dendl;
 }
@@ -232,7 +233,7 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
     // encode with all features.
     uint64_t f = inc.encode_features;
     if (!f)
-      f = mon->quorum_features;
+      f = mon->get_quorum_con_features();
     if (!f)
       f = -1;
     bufferlist full_bl;
@@ -1126,7 +1127,8 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
     tmp.deepish_copy_from(osdmap);
     tmp.apply_incremental(pending_inc);
     bufferlist fullbl;
-    ::encode(tmp, fullbl, mon->quorum_features | CEPH_FEATURE_RESERVED);
+    ::encode(tmp, fullbl,
+             mon->get_quorum_con_features() | CEPH_FEATURE_RESERVED);
     pending_inc.full_crc = tmp.get_crc();
 
     // include full map in the txn.  note that old monitors will
@@ -1137,7 +1139,8 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 
   // encode
   assert(get_last_committed() + 1 == pending_inc.epoch);
-  ::encode(pending_inc, bl, mon->quorum_features | CEPH_FEATURE_RESERVED);
+  ::encode(pending_inc, bl,
+           mon->get_quorum_con_features() | CEPH_FEATURE_RESERVED);
 
   dout(20) << " full_crc " << tmp.get_crc()
 	   << " inc_crc " << pending_inc.inc_crc << dendl;
@@ -4297,7 +4300,7 @@ int OSDMonitor::check_cluster_features(uint64_t features,
 {
   stringstream unsupported_ss;
   int unsupported_count = 0;
-  if ((mon->get_quorum_features() & features) != features) {
+  if ((mon->get_quorum_con_features() & features) != features) {
     unsupported_ss << "the monitor cluster";
     ++unsupported_count;
   }

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -494,7 +494,7 @@ void PGMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   assert(get_last_committed() + 1 == version);
   pending_inc.stamp = ceph_clock_now(g_ceph_context);
 
-  uint64_t features = mon->get_quorum_features();
+  uint64_t features = mon->get_quorum_con_features();
 
   string prefix = pgmap_meta_prefix;
 

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -18,7 +18,9 @@
 #include "include/utime.h"
 #include "include/util.h"
 #include "common/Formatter.h"
+#include "common/bit_str.h"
 #include "include/Context.h"
+#include "include/stringify.h"
 #include "mon/MonOpRequest.h"
 
 #define PAXOS_PGMAP      0  // before osd, for pg kick to behave
@@ -233,5 +235,179 @@ struct C_MonOp : public Context
 
   virtual void _finish(int r) = 0;
 };
+
+namespace ceph {
+  namespace features {
+    namespace mon {
+      static inline const char *get_feature_name(uint64_t b);
+    }
+  }
+}
+
+
+inline const char *ceph_mon_feature_name(uint64_t b)
+{
+  return ceph::features::mon::get_feature_name(b);
+};
+
+class mon_feature_t {
+
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+
+  // mon-specific features
+  uint64_t features;
+
+public:
+
+  explicit constexpr
+  mon_feature_t(const uint64_t f) : features(f) { }
+
+  mon_feature_t() :
+    features(0) { }
+
+  constexpr
+  mon_feature_t(const mon_feature_t &o) :
+    features(o.features) { }
+
+  mon_feature_t& operator&=(const mon_feature_t other) {
+    features &= other.features;
+    return (*this);
+  }
+
+  constexpr
+  friend mon_feature_t operator&(const mon_feature_t a,
+                                 const mon_feature_t b) {
+    return mon_feature_t(a.features & b.features);
+  }
+
+  mon_feature_t& operator|=(const mon_feature_t other) {
+    features |= other.features;
+    return (*this);
+  }
+
+  constexpr
+  friend mon_feature_t operator|(const mon_feature_t a,
+                                 const mon_feature_t b) {
+    return mon_feature_t(a.features | b.features);
+  }
+
+  constexpr
+  friend mon_feature_t operator^(const mon_feature_t a,
+                                 const mon_feature_t b) {
+    return mon_feature_t(a.features ^ b.features);
+  }
+
+  mon_feature_t& operator^=(const mon_feature_t other) {
+    features ^= other.features;
+    return (*this);
+  }
+
+  bool operator==(const mon_feature_t other) const {
+    return (features == other.features);
+  }
+
+  bool operator!=(const mon_feature_t other) const {
+    return (features != other.features);
+  }
+
+  mon_feature_t diff(const mon_feature_t other) const {
+    return mon_feature_t((other.features ^ features) & other.features);
+  }
+
+  bool contains_all(const mon_feature_t other) const {
+    return !((other.features ^ features) & other.features);
+  }
+
+  bool contains_any(const mon_feature_t f) const {
+    return (features & f.features);
+  }
+
+  void set_feature(const mon_feature_t f) {
+    features |= f.features;
+  }
+
+  void print(ostream& out) const {
+    out << "[";
+    print_bit_str(features, out, ceph::features::mon::get_feature_name);
+    out << "]";
+  }
+
+  void dump(Formatter *f, const char *sec_name = NULL) const {
+    f->open_array_section((sec_name ? sec_name : "features"));
+    dump_bit_str(features, f, ceph::features::mon::get_feature_name);
+    f->close_section();
+  }
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(HEAD_VERSION, COMPAT_VERSION, bl);
+    ::encode(features, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::iterator& p) {
+    DECODE_START(COMPAT_VERSION, p);
+    ::decode(features, p);
+    DECODE_FINISH(p);
+  }
+};
+WRITE_CLASS_ENCODER(mon_feature_t)
+
+namespace ceph {
+  namespace features {
+    namespace mon {
+      constexpr mon_feature_t FEATURE_JEWEL(      (1ULL << 0));
+      constexpr mon_feature_t FEATURE_RESERVED(   (1ULL << 63));
+      constexpr mon_feature_t FEATURE_NONE(       (0ULL));
+
+      /**
+       * All the features this monitor supports
+       *
+       * If there's a feature above, it should be OR'ed to this list.
+       */
+      constexpr mon_feature_t get_supported() {
+        return (
+            FEATURE_JEWEL |
+            FEATURE_NONE
+            );
+      }
+      /**
+       * All the features that, once set, cannot be removed.
+       *
+       * Features should only be added to this list if you want to make
+       * sure downgrades are not possible after a quorum supporting all
+       * these features has been formed.
+       *
+       * Any feature in this list will be automatically set on the monmap's
+       * features once all the monitors in the quorum support it.
+       */
+      constexpr mon_feature_t get_persistent() {
+        return (
+            FEATURE_JEWEL |
+            FEATURE_NONE
+            );
+      }
+    }
+  }
+}
+
+static inline const char *ceph::features::mon::get_feature_name(uint64_t b) {
+  mon_feature_t f(b);
+
+  if (f == FEATURE_JEWEL) {
+    return "jewel";
+  } else if (f == FEATURE_RESERVED) {
+    return "reserved";
+  }
+  return "unknown";
+}
+
+//constexpr mon_feature_t mon_feature_t::FEATURE_JEWEL(10);
+
+static inline ostream& operator<<(ostream& out, const mon_feature_t& f) {
+  out << "mon_feature_t(";
+  f.print(out);
+  out << ")";
+  return out;
+}
 
 #endif

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -386,6 +386,8 @@ namespace ceph {
             FEATURE_NONE
             );
       }
+
+      constexpr mon_feature_t FLAG_NONE(          (0ULL));
     }
   }
 }


### PR DESCRIPTION
UPDATE: fixed patch set according to @liewegas review. See below for highlights.

This patch set adds the following functionality to the monitors:

1. have a 'features' field in the MonMap, holding the bare minimum features required
by ALL the monitors in the cluster.

2. we now have 'sticky' features, which will be automatically activated - and set on
monmap - once all the quorum members support them. These can not be disabled
or reverted. To be used sparingly.

3. have a 'flags' field in the MonMap, holding (possibly) transient features that are
required by all monitors in the quorum.

4. monitors require a given set of features to join a quorum; these will be assessed
relying on `monmap.features` and `monmap.flags`.

5. any given flag can be set in `monmap.flags` once all the monitors in a quorum
are able to understand said flag. These can also be unset. Setting/unsetting flags
will likely require user intervention (or some action that triggers a flag to be set/unset).

`Signed-off-by: Joao Eduardo Luis <joao@suse.de>`