### PR TITLE
Running systemd-run within containers fails. 

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -348,13 +348,13 @@ for name in $what; do
 	    if [ -n "$SYSTEMD_RUN" ]; then
                 detectDocker
                 if [ -z "$DOCKER_RUN" ]; then
-		    cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
+                    cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
                 else
                     time=`date +%s.%N` 
 		    cmd="$SYSTEMD_RUN --unit=ceph-$name.$time -r bash -c '$files $tcmalloc $cmd --cluster $cluster --setuser ceph --setgroup ceph -f'"
                 fi
 	    else
-		cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
+                cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
 	    fi
 
 	    if [ $dofsmount -eq 1 ] && [ -n "$fs_devs" ]; then

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -21,6 +21,11 @@ fi
 SYSTEMD_RUN=$(which systemd-run 2>/dev/null)
 grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
 
+# Detect if this is inside docker, systemd-run fails inside containers.
+function detectDocker {
+readonly DOCKER_RUN=$(grep -q docker /proc/1/cgroup)
+}
+
 # if we start up as ./init-ceph, assume everything else is in the
 # current directory too.
 if [ `dirname $0` = "." ] && [ $PWD != "/etc/init.d" ]; then
@@ -341,8 +346,13 @@ for name in $what; do
 	    [ -n "$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES" ] && tcmalloc="TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES"
 
 	    if [ -n "$SYSTEMD_RUN" ]; then
-                time=`date +%s.%N` 
-		cmd="$SYSTEMD_RUN --unit=ceph-$name.$time -r bash -c '$files $tcmalloc $cmd --cluster $cluster --setuser ceph --setgroup ceph -f'"
+                detectDocker
+                if [ -z "$DOCKER_RUN" ]; then
+		    cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
+                else
+                    time=`date +%s.%N` 
+		    cmd="$SYSTEMD_RUN --unit=ceph-$name.$time -r bash -c '$files $tcmalloc $cmd --cluster $cluster --setuser ceph --setgroup ceph -f'"
+                fi
 	    else
 		cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
 	    fi

--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -23,6 +23,11 @@ else
     grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
 fi
 
+# Detect Docker, if we run systemd-run within docker the process will fail.
+function detectDocker {
+readonly DOCKER_RUN=$(grep -q docker /proc/1/cgroup)
+}
+
 daemon_is_running() {
     daemon=$1
     if pidof $daemon >/dev/null; then
@@ -102,6 +107,15 @@ case "$1" in
 	    if [ $DEBIAN -eq 1 ]; then
 		start-stop-daemon --start -u $user -x $RADOSGW -p /var/run/ceph/client-$name.pid -- -n $name
 	    elif [ -n "$SYSTEMD_RUN" ]; then
+	    detectDocker
+	        if [ -z "$DOCKER_RUN" ]; then
+	            ulimit -n 32768
+                    core_limit=`ceph-conf -n $name 'core file limit'`
+                    if [ -z $core_limit ]; then
+                        DAEMON_COREFILE_LIMIT=$core_limit
+                    fi
+                    daemon --user="$user" "$RADOSGW -n $name"	        
+	        else
                 $SYSTEMD_RUN -r su "$user" -c "ulimit -n 32768; $RADOSGW -n $name"
             else
                 ulimit -n 32768

--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -109,13 +109,13 @@ case "$1" in
 	    elif [ -n "$SYSTEMD_RUN" ]; then
 	    detectDocker
 	        if [ -z "$DOCKER_RUN" ]; then
-	            ulimit -n 32768
+                    ulimit -n 32768
                     core_limit=`ceph-conf -n $name 'core file limit'`
                     if [ -z $core_limit ]; then
                         DAEMON_COREFILE_LIMIT=$core_limit
                     fi
                     daemon --user="$user" "$RADOSGW -n $name"	        
-	        else
+                else
                 $SYSTEMD_RUN -r su "$user" -c "ulimit -n 32768; $RADOSGW -n $name"
             else
                 ulimit -n 32768


### PR DESCRIPTION
When you run a container with ceph it will fail with the error: 
```
failed: '/bin/systemd-run -r bash -c 'ulimit -n 32768; /usr/bin/ceph-osd -i 2 --pid-file /var/run/ceph/osd.2.pid -c /etc/ceph/ceph.conf --cluster ceph -f''
Failed to create bus connection: No such file or directory
```

It's unlikely that people are running systemd within containers and thus i added a check if the processes is running in a container when systemd-run is triggered, if docker is detected the usual startup process is executed. 

I chose to use grep -q to detect docker because it works on every system (even tested it on privileged containers). 