### PR TITLE
ceph.spec.in: add license declaration

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -10,6 +10,8 @@
 # remain the property of their copyright owners, unless otherwise agreed
 # upon.
 #
+# This file is under the GNU Lesser General Public License, version 2.1
+#
 # Please submit bugfixes or comments via http://tracker.ceph.com/
 # 
 %bcond_with ocf


### PR DESCRIPTION
Another openSUSE spec file requirement

Signed-off-by: Nathan Cutler <ncutler@suse.com>