### PR TITLE
Correctly escape block device paths for systemd

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3854,7 +3854,7 @@ def main_trigger(args):
     LOG.debug("main_trigger: " + str(args))
     if is_systemd() and not args.sync:
         # http://www.freedesktop.org/software/systemd/man/systemd-escape.html
-        escaped_dev = args.dev.replace('-', '\\x2d')
+        escaped_dev = args.dev[1:].replace('-', '\\x2d')
         service = 'ceph-disk@{dev}.service'.format(dev=escaped_dev)
         LOG.info('systemd detected, triggering %s' % service)
         command(


### PR DESCRIPTION
Ensure that the leading / is stripped from block device
paths before escaping for using in systemd unit names.

Fixes: #14706

Signed-off-by: James Page <james.page@ubuntu.com>