### PR TITLE
OSD/ReplicatedPG: Fixing lack of object unblock when flush fails.

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -7870,6 +7870,11 @@ void ReplicatedPG::finish_flush(hobject_t oid, ceph_tid_t tid, int r)
   if (r < 0 && !(r == -ENOENT && fop->removal)) {
     if (fop->op)
       osd->reply_op_error(fop->op, -EBUSY);
+    if (fop->blocking) {
+      obc->stop_block();
+      kick_object_context_blocked(obc);
+    }
+
     if (!fop->dup_ops.empty()) {
       dout(20) << __func__ << " requeueing dups" << dendl;
       requeue_ops(fop->dup_ops);


### PR DESCRIPTION
See: http://tracker.ceph.com/issues/14511

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>