### PR TITLE
rgw: user quota may not adjust on bucket removal

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -499,6 +499,11 @@ int rgw_remove_bucket(RGWRados *store, rgw_bucket& bucket, bool delete_children)
     }
   }
 
+  ret = rgw_bucket_sync_user_stats(store, bucket.tenant, bucket.name);
+  if ( ret < 0) {
+     dout(1) << "WARNING: failed sync user stats before bucket delete. ret=" <<  ret << dendl;
+  }
+
   RGWObjVersionTracker objv_tracker;
 
   ret = store->delete_bucket(bucket, objv_tracker);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1878,6 +1878,11 @@ void RGWDeleteBucket::execute()
     }
   }
 
+  op_ret = rgw_bucket_sync_user_stats(store, s->user.user_id, s->bucket);
+  if ( op_ret < 0) {
+     ldout(s->cct, 1) << "WARNING: failed to sync user stats before bucket delete: op_ret= " << op_ret << dendl;
+  }
+
   op_ret = store->delete_bucket(s->bucket, ot);
   if (op_ret == 0) {
     op_ret = rgw_unlink_bucket(store, s->user.user_id, s->bucket.tenant,


### PR DESCRIPTION
Description:
If the user/admin removes a bucket using --force/--purge-objects options with s3cmd/radosgw-admin respectively, the user stats will continue to reflect the deleted objects for quota purposes, and there seems to be no way to reset them. User stats need to be sync'ed prior to bucket removal.

Solution:
Sync user stats before removing a bucket.

Fixes: #14507
Signed-off-by: Edward Yang eyang@us.fujitsu.com