### PR TITLE
memstore: fix alignment of Page for test_pageset

### DIFF
--- a/src/os/memstore/PageSet.h
+++ b/src/os/memstore/PageSet.h
@@ -63,6 +63,9 @@ struct Page {
   }
 
   static Ref create(size_t page_size, uint64_t offset = 0) {
+    // ensure proper alignment of the Page
+    const auto align = alignof(Page);
+    page_size = (page_size + align - 1) & ~(align - 1);
     // allocate the Page and its data in a single buffer
     auto buffer = new char[page_size + sizeof(Page)];
     // place the Page structure at the end of the buffer

--- a/src/test/test_pageset.cc
+++ b/src/test/test_pageset.cc
@@ -4,6 +4,12 @@
 
 #include "os/memstore/PageSet.h"
 
+template <typename T>
+bool is_aligned(T* ptr) {
+  const auto align_mask = alignof(T) - 1;
+  return (reinterpret_cast<uintptr_t>(ptr) & align_mask) == 0;
+}
+
 TEST(PageSet, AllocAligned)
 {
   PageSet pages(1);
@@ -15,6 +21,12 @@ TEST(PageSet, AllocAligned)
   ASSERT_EQ(1u, range[1]->offset);
   ASSERT_EQ(2u, range[2]->offset);
   ASSERT_EQ(3u, range[3]->offset);
+
+  // verify that the Page pointers are properly aligned
+  ASSERT_TRUE(is_aligned(range[0].get()));
+  ASSERT_TRUE(is_aligned(range[1].get()));
+  ASSERT_TRUE(is_aligned(range[2].get()));
+  ASSERT_TRUE(is_aligned(range[3].get()));
 }
 
 TEST(PageSet, AllocUnaligned)


### PR DESCRIPTION
test_pageset creates Pages with size=1, which messes up alignment of the
Page contents and leads to a bus error on arm64

Page::create() now adds padding to make sure Page is properly aligned,
and test_pageset verifies that alignment

Reported-by: Dan Mick <dmick@redhat.com>
Signed-off-by: Casey Bodley <cbodley@redhat.com>