### PR TITLE
common/page.cc: _page_mask has too many bits

### DIFF
--- a/src/common/page.cc
+++ b/src/common/page.cc
@@ -14,6 +14,6 @@ namespace ceph {
 
   unsigned _page_size = sysconf(_SC_PAGESIZE);
   unsigned long _page_mask = ~(unsigned long)(_page_size - 1);
-  unsigned _page_shift = _get_bits_of(_page_size);
+  unsigned _page_shift = _get_bits_of(_page_size - 1);
 
 }


### PR DESCRIPTION
It's not used anywhere, but in case it is one day...

Signed-off-by: Dan Mick <dan.mick@redhat.com>