### PR TITLE
 [DNM] hammer: rgw: S3 authentication subsystem should be able to use admin credentials for accessing Keystone

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -20,6 +20,10 @@
 
 #include "rgw_client_io.h"
 
+/* This header consists several Keystone-related primitives
+ * we want to reuse here. */
+#include "rgw_swift.h"
+
 #define dout_subsys ceph_subsys_rgw
 
 using namespace ceph::crypto;
@@ -2243,8 +2247,16 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(const string& auth_id, 
     keystone_url.append("/");
   keystone_url.append("v2.0/s3tokens");
 
+  /* get authentication token for Keystone. */
+  string admin_token_id;
+  int r = RGWSwift::get_keystone_admin_token(cct, admin_token_id);
+  if (r < 0) {
+    ldout(cct, 2) << "s3 keystone: cannot get token for keystone access" << dendl;
+    return r;
+  }
+
   /* set required headers for keystone request */
-  append_header("X-Auth-Token", cct->_conf->rgw_keystone_admin_token);
+  append_header("X-Auth-Token", admin_token_id);
   append_header("Content-Type", "application/json");
 
   /* encode token */

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -229,7 +229,8 @@ static int decode_b64_cms(CephContext *cct, const string& signed_b64, bufferlist
   return 0;
 }
 
-int	RGWSwift::get_keystone_url(std::string& url)
+int RGWSwift::get_keystone_url(CephContext * const cct,
+                               std::string& url)
 {
   bufferlist bl;
   RGWGetRevokedTokens req(cct, &bl);
@@ -244,11 +245,22 @@ int	RGWSwift::get_keystone_url(std::string& url)
   return 0;
 }
 
-int	RGWSwift::get_keystone_admin_token(std::string& token)
+int RGWSwift::get_keystone_url(std::string& url)
+{
+  return RGWSwift::get_keystone_url(cct, url);
+}
+
+int RGWSwift::get_keystone_admin_token(std::string& token)
+{
+  return RGWSwift::get_keystone_admin_token(cct, token);
+}
+
+int RGWSwift::get_keystone_admin_token(CephContext * const cct,
+                                       std::string& token)
 {
   std::string token_url;
 
-  if (get_keystone_url(token_url) < 0)
+  if (get_keystone_url(cct, token_url) < 0)
     return -EINVAL;
   if (cct->_conf->rgw_keystone_admin_token.empty()) {
     token_url.append("v2.0/tokens");

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -70,6 +70,10 @@ public:
 
   bool verify_swift_token(RGWRados *store, req_state *s);
   bool going_down();
+
+  /* Static methods shared between Swift API and S3. */
+  static int get_keystone_url(CephContext *cct, std::string& url);
+  static int get_keystone_admin_token(CephContext *cct, std::string& token);
 };
 
 extern RGWSwift *rgw_swift;


### PR DESCRIPTION
http://tracker.ceph.com/issues/14721