### PR TITLE
tests: ceph-disk.sh: should use "readlink -f" instead

### DIFF
--- a/src/ceph-disk/tests/ceph-disk.sh
+++ b/src/ceph-disk/tests/ceph-disk.sh
@@ -133,7 +133,7 @@ function kill_daemons() {
 function command_fixture() {
     local command=$1
 
-    [ $(which $command) = `realpath ../$command` ] || [ $(which $command) = `realpath $(pwd)/$command` ] || return 1
+    [ $(which $command) = `readlink -f ../$command` ] || [ $(which $command) = `readlink -f $(pwd)/$command` ] || return 1
 
     cat > $DIR/$command <<EOF
 #!/bin/bash


### PR DESCRIPTION
turns out trusty does not have `realpath` unless the package named
`realpath` is installed.

Reported-by: Joao Eduardo Luis <joao@suse.de>
Signed-off-by: Kefu Chai <kchai@redhat.com>