### PR TITLE
ghobject_t: use ! instead of @ as a separator

### DIFF
--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -499,7 +499,7 @@ ostream& operator<<(ostream& out, const ghobject_t& o)
     return out << "GHMAX";
   if (o.shard_id != shard_id_t::NO_SHARD)
     out << std::hex << o.shard_id << std::dec;
-  out << '@' << o.hobj << '@';
+  out << '!' << o.hobj << '!';
   if (o.generation != ghobject_t::NO_GEN)
     out << std::hex << (unsigned long long)(o.generation) << std::dec;
   return out;
@@ -516,12 +516,12 @@ bool ghobject_t::parse(const string& s)
     return true;
   }
 
-  // look for shard@ prefix
+  // look for shard! prefix
   const char *start = s.c_str();
   const char *p;
   int sh = shard_id_t::NO_SHARD;
   for (p = start; *p && isxdigit(*p); ++p) ;
-  if (!*p && *p != '@')
+  if (!*p && *p != '!')
     return false;
   if (p > start) {
     int r = sscanf(s.c_str(), "%x", &sh);
@@ -532,13 +532,13 @@ bool ghobject_t::parse(const string& s)
     ++start;
   }
 
-  // look for @generation suffix
+  // look for !generation suffix
   long long unsigned g = NO_GEN;
   const char *last = start + strlen(start) - 1;
   p = last;
   while (isxdigit(*p))
     p--;
-  if (*p != '@')
+  if (*p != '!')
     return false;
   if (p < last) {
     sscanf(p + 1, "%llx", &g);

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -1442,15 +1442,15 @@ TEST(ghobject_t, parse) {
   const char *v[] = {
     "GHMIN",
     "GHMAX",
-    "13@0:00000000::::head@",
-    "13@0:00000000::::head@deadbeef",
-    "@-1:60c2fa6d:::inc_osdmap.1:333@deadbeef",
-    "@-1:60c2fa6d:::inc%02osdmap.1:333@deadbeef",
-    "@-1:60c2fa6d:::inc_osdmap.1:333@",
-    "1@MIN@deadbeefff",
-    "1@MAX@",
-    "@MAX@123",
-    "@-40:00000000:nspace::obj:head@",
+    "13!0:00000000::::head!",
+    "13!0:00000000::::head!deadbeef",
+    "!-1:60c2fa6d:::inc_osdmap.1:333!deadbeef",
+    "!-1:60c2fa6d:::inc%02osdmap.1:333!deadbeef",
+    "!-1:60c2fa6d:::inc_osdmap.1:333!",
+    "1!MIN!deadbeefff",
+    "1!MAX!",
+    "!MAX!123",
+    "!-40:00000000:nspace::obj:head!",
     NULL
   };
 


### PR DESCRIPTION
@ confuses less's search (/ then @ does not do what you want).  !
behaves as expected.

Signed-off-by: Sage Weil <sage@redhat.com>