### PR TITLE
Running ceph inside a container fails due to systemd-run

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -21,6 +21,13 @@ fi
 SYSTEMD_RUN=$(which systemd-run 2>/dev/null)
 grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
 
+# detect if running inside docker container, systemd-run fails then.
+function detectDocker {
+if [[ -e /.dockerinit ]]; then
+    readonly DOCKER_RUN=0
+fi
+}
+
 # if we start up as ./init-ceph, assume everything else is in the
 # current directory too.
 if [ `dirname $0` = "." ] && [ $PWD != "/etc/init.d" ]; then
@@ -340,12 +347,19 @@ for name in $what; do
 
 	    [ -n "$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES" ] && tcmalloc="TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES"
 
+
 	    if [ -n "$SYSTEMD_RUN" ]; then
-                time=`date +%s.%N` 
-		cmd="$SYSTEMD_RUN --unit=ceph-$name.$time -r bash -c '$files $tcmalloc $cmd --cluster $cluster --setuser ceph --setgroup ceph -f'"
+                detectDocker
+                if [ -z "$DOCKER_RUN" ]; then
+                    time=`date +%s.%N` 
+		    cmd="$SYSTEMD_RUN --unit=ceph-$name.$time -r bash -c '$files $tcmalloc $cmd --cluster $cluster --setuser ceph --setgroup ceph -f'"
+                else
+		    cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
+                fi
 	    else
 		cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
 	    fi
+
 
 	    if [ $dofsmount -eq 1 ] && [ -n "$fs_devs" ]; then
 		get_conf pre_mount "true" "pre mount command"

--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -23,6 +23,13 @@ else
     grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
 fi
 
+# detect if running inside docker container, systemd-run fails then.
+function detectDocker {
+if [[ -e /.dockerinit ]]; then
+    readonly DOCKER_RUN=0
+fi
+}
+
 daemon_is_running() {
     daemon=$1
     if pidof $daemon >/dev/null; then
@@ -102,7 +109,17 @@ case "$1" in
 	    if [ $DEBIAN -eq 1 ]; then
 		start-stop-daemon --start -u $user -x $RADOSGW -p /var/run/ceph/client-$name.pid -- -n $name
 	    elif [ -n "$SYSTEMD_RUN" ]; then
-                $SYSTEMD_RUN -r su "$user" -c "ulimit -n 32768; $RADOSGW -n $name"
+	    detectDocker
+	        if [ -z "$DOCKER_RUN" ]; then
+                     $SYSTEMD_RUN -r su "$user" -c "ulimit -n 32768; $RADOSGW -n $name"
+                else
+                    ulimit -n 32768
+                    core_limit=`ceph-conf -n $name 'core file limit'`
+                    if [ -z $core_limit ]; then
+                        DAEMON_COREFILE_LIMIT=$core_limit
+                    fi
+                    daemon --user="$user" "$RADOSGW -n $name"
+                fi
             else
                 ulimit -n 32768
                 core_limit=`ceph-conf -n $name 'core file limit'`


### PR DESCRIPTION
```
failed: '/bin/systemd-run -r bash -c 'ulimit -n 32768; /usr/bin/ceph-osd -i 2 --pid-file /var/run/ceph/osd.2.pid -c /etc/ceph/ceph.conf --cluster ceph -f''
Failed to create bus connection: No such file or directory
```

It's unlikely that people are running systemd within containers and thus i added a check if the processes is running in a container when systemd-run is triggered, if docker is detected the usual startup process is executed.

I messed up PR 7566, sorry for that!

Now checking for /.dockerinit if it exists, if the file does not exist we perform systemd-run

Signed-off-by: Rogier Dikkes <rogier.dikkes@surfsara.nl>