### PR TITLE
os/bluestore: fix a typo in SPDK path parsing

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1579,7 +1579,7 @@ int BlueStore::_setup_block_symlink_or_file(
 	   << " size " << size << " create=" << (int)create << dendl;
   int r = 0;
   if (epath.length()) {
-    if (!epath.compare(0, sizeof(SPDK_PREFIX-1), SPDK_PREFIX)) {
+    if (!epath.compare(0, sizeof(SPDK_PREFIX)-1, SPDK_PREFIX)) {
       string symbol_spdk_file = path + "/" + epath;
       r = ::symlinkat(symbol_spdk_file.c_str(), path_fd, name.c_str());
       if (r < 0) {


### PR DESCRIPTION
SPDK block path with bluestore is something like spdk:55cd2e404bd73932.
The size of the prefix to compare should be 5.
sizeof(SPDK_PREFIX)-1 returns 5, while sizeof(SPDK_PREFIX-1) returns 8.

Signed-off-by: Jianjian Huo <samuel.huo@gmail.com>