### PR TITLE
selinux: Allow log files to be located in /var/log/radosgw

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -46,7 +46,8 @@ restorecon -R /etc/rc\.d/init\.d/ceph > /dev/null 2>&1; \
 restorecon -R /etc/rc\.d/init\.d/radosgw > /dev/null 2>&1; \
 restorecon -R /var/run/ceph > /dev/null 2>&1; \
 restorecon -R /var/lib/ceph > /dev/null 2>&1; \
-restorecon -R /var/log/ceph > /dev/null 2>&1;
+restorecon -R /var/log/ceph > /dev/null 2>&1; \
+restorecon -R /var/log/radosgw > /dev/null 2>&1;
 %endif
 
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}

--- a/man/ceph_selinux.8
+++ b/man/ceph_selinux.8
@@ -1,4 +1,4 @@
-.TH  "ceph_selinux"  "8"  "15-08-10" "ceph" "SELinux Policy ceph"
+.TH  "ceph_selinux"  "8"  "16-02-11" "ceph" "SELinux Policy ceph"
 .SH "NAME"
 ceph_selinux \- Security Enhanced Linux Policy for the ceph processes
 .SH "DESCRIPTION"
@@ -170,6 +170,8 @@ The SELinux process type ceph_t can manage files labeled with the following file
 
 	/var/log/ceph(/.*)?
 .br
+	/var/log/radosgw(/.*)?
+.br
 
 .br
 .B ceph_var_lib_t
@@ -238,11 +240,59 @@ The SELinux process type ceph_t can manage files labeled with the following file
 .br
 
 .br
+.B initrc_tmp_t
+
+
+.br
+.B mnt_t
+
+	/mnt(/[^/]*)?
+.br
+	/mnt(/[^/]*)?
+.br
+	/rhev(/[^/]*)?
+.br
+	/media(/[^/]*)?
+.br
+	/media(/[^/]*)?
+.br
+	/media/\.hal-.*
+.br
+	/var/run/media(/[^/]*)?
+.br
+	/net
+.br
+	/afs
+.br
+	/rhev
+.br
+	/misc
+.br
+
+.br
 .B root_t
 
 	/
 .br
 	/initrd
+.br
+
+.br
+.B tmp_t
+
+	/sandbox(/.*)?
+.br
+	/tmp
+.br
+	/usr/tmp
+.br
+	/var/tmp
+.br
+	/tmp-inst
+.br
+	/var/tmp-inst
+.br
+	/var/tmp/vi\.recover
 .br
 
 .br
@@ -319,7 +369,7 @@ Paths:
 .br
 .TP 5
 Paths:
-/var/log/ceph(/.*)?
+/var/log/ceph(/.*)?, /var/log/radosgw(/.*)?
 
 .EX
 .PP

--- a/selinux/ceph.fc
+++ b/selinux/ceph.fc
@@ -9,5 +9,6 @@
 /var/lib/ceph(/.*)?		gen_context(system_u:object_r:ceph_var_lib_t,s0)
 
 /var/log/ceph(/.*)?		gen_context(system_u:object_r:ceph_log_t,s0)
+/var/log/radosgw(/.*)?		gen_context(system_u:object_r:ceph_log_t,s0)
 
 /var/run/ceph(/.*)?		gen_context(system_u:object_r:ceph_var_run_t,s0)

--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -1,4 +1,4 @@
-policy_module(ceph, 1.1.0)
+policy_module(ceph, 1.1.1)
 
 require {
 	type sysfs_t;


### PR DESCRIPTION
We do suggest users to put their logs in /var/log/radosgw in the
documentation at times. We should also label that directory with
ceph_var_log_t so that ceph daemons can also write there.

The commit also updates the man page for this policy. This man page is
automatically generated by

* sepolicy manpage -p . -d ceph_t

and have not been reloaded in a while. Hence, it contains few more
changes than the new radosgw directory.

Signed-off-by: Boris Ranto <branto@redhat.com>