### PR TITLE
tests: ceph-disk.sh: use "readlink -f" instead for fullpath

### DIFF
--- a/src/ceph-disk/tests/ceph-disk.sh
+++ b/src/ceph-disk/tests/ceph-disk.sh
@@ -132,8 +132,8 @@ function kill_daemons() {
 
 function command_fixture() {
     local command=$1
-
-    [ $(which $command) = `readlink -f ../$command` ] || [ $(which $command) = `readlink -f $(pwd)/$command` ] || return 1
+    local fpath=`readlink -f $(which $command)`
+    [ "$fpath" = `readlink -f ../$command` ] || [ "$fpath" = `readlink -f $(pwd)/$command` ] || return 1
 
     cat > $DIR/$command <<EOF
 #!/bin/bash


### PR DESCRIPTION
if $PATH has ".." in it, and the program happen to be located in
"..", `which program` will print `../program` instead of its fullpath,
so we should always use `readlink -f` for the fullpath.

Signed-off-by: Kefu Chai <kchai@redhat.com>