### PR TITLE
tests/{ceph-disk,ceph-detect-init}: use the "python" in virtualenv 

### DIFF
--- a/src/ceph-detect-init/Makefile.am
+++ b/src/ceph-detect-init/Makefile.am
@@ -59,7 +59,7 @@ ceph-detect-init/virtualenv:
 	cd $(srcdir)/ceph-detect-init ; ../tools/setup-virtualenv.sh ; virtualenv/bin/python setup.py develop
 
 ceph-detect-init-clean:
-	cd $(srcdir)/ceph-detect-init ; python setup.py clean ; rm -fr wheelhouse .tox virtualenv .coverage *.egg-info
+	cd $(srcdir)/ceph-detect-init ; virtualenv/bin/python setup.py clean ; rm -fr wheelhouse .tox virtualenv .coverage *.egg-info
 
 ceph-detect-init-install-data:
 	cd $(srcdir)/ceph-detect-init ; \
@@ -71,7 +71,7 @@ ceph-detect-init-install-data:
 		fi ; \
 		root="--root=$(DESTDIR)" ; \
 	fi ; \
-	python setup.py install $$root $$options
+	virtualenv/bin/python setup.py install $$root $$options
 
 LOCAL_ALL += ceph-detect-init-all
 LOCAL_CLEAN += ceph-detect-init-clean

--- a/src/ceph-disk/Makefile.am
+++ b/src/ceph-disk/Makefile.am
@@ -35,7 +35,7 @@ ceph-disk/virtualenv:
 	cd $(srcdir)/ceph-disk ; ../tools/setup-virtualenv.sh ; virtualenv/bin/python setup.py develop
 
 ceph-disk-clean:
-	cd $(srcdir)/ceph-disk ; python setup.py clean ; rm -fr wheelhouse .tox virtualenv .coverage *.egg-info
+	cd $(srcdir)/ceph-disk ; virtualenv/bin/python setup.py clean ; rm -fr wheelhouse .tox virtualenv .coverage *.egg-info
 
 ceph-disk-install-data:
 	cd $(srcdir)/ceph-disk ; \
@@ -47,7 +47,7 @@ ceph-disk-install-data:
 		fi ; \
 		root="--root=$(DESTDIR) --install-script=/usr/sbin" ; \
 	fi ; \
-	python setup.py install $$root $$options
+	virtualenv/bin/python setup.py install $$root $$options
 
 LOCAL_ALL += ceph-disk-all
 LOCAL_CLEAN += ceph-disk-clean


### PR DESCRIPTION
we have some leftovers in the "build" directory otherwise. see http://gitbuilder.sepia.ceph.com/gitbuilder-ceph-tarball-trusty-amd64-basic/log.cgi?log=4056ee298aea9b5deacc833e600c2111b696a88c