### PR TITLE
rgw: store system object meta in cache when creating it

### DIFF
--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -52,7 +52,7 @@ int ObjectCache::get(string& name, ObjectCacheInfo& info, uint32_t mask, rgw_cac
     if(perfcounter) perfcounter->inc(l_rgw_cache_miss);
     return -ENOENT;
   }
-  ldout(cct, 10) << "cache get: name=" << name << " : hit" << dendl;
+  ldout(cct, 10) << "cache get: name=" << name << " : hit (requested=" << mask << ", cached=" << src.flags << ")" << dendl;
 
   info = src;
   if (cache_info) {
@@ -119,7 +119,7 @@ void ObjectCache::put(string& name, ObjectCacheInfo& info, rgw_cache_entry_info 
     return;
   }
 
-  ldout(cct, 10) << "cache put: name=" << name << dendl;
+  ldout(cct, 10) << "cache put: name=" << name << " info.flags=" << info.flags << dendl;
   map<string, ObjectCacheEntry>::iterator iter = cache_map.find(name);
   if (iter == cache_map.end()) {
     ObjectCacheEntry entry;

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -401,13 +401,19 @@ int RGWCache<T>::put_system_obj_impl(rgw_obj& obj, uint64_t size, time_t *mtime,
   info.status = 0;
   info.flags = CACHE_FLAG_XATTRS;
   info.data = data;
-  info.flags |= CACHE_FLAG_DATA;
+  info.flags |= CACHE_FLAG_DATA | CACHE_FLAG_META;
   if (objv_tracker) {
     info.version = objv_tracker->write_version;
     info.flags |= CACHE_FLAG_OBJV;
   }
-  int ret = T::put_system_obj_impl(obj, size, mtime, attrs, flags, data,
+  time_t result_mtime;
+  int ret = T::put_system_obj_impl(obj, size, &result_mtime, attrs, flags, data,
                                    objv_tracker, set_mtime);
+  if (mtime) {
+    *mtime = result_mtime;
+  }
+  info.meta.mtime = result_mtime;
+  info.meta.size = size;
   string name = normal_name(bucket, oid);
   if (ret >= 0) {
     cache.put(name, info, NULL);


### PR DESCRIPTION
Fixes: #14678

When creating the system object we can easily also get the object's meta, so
keep it in the cache.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>