### PR TITLE
msg/async: smarter MSG_MORE

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -398,8 +398,8 @@ ssize_t AsyncConnection::_try_send(bufferlist &send_bl, bool send, bool more)
 
   // trim already sent for outcoming_bl
   if (sent_bytes) {
-    bufferlist bl;
     if (sent_bytes < outcoming_bl.length()) {
+      bufferlist bl;
       outcoming_bl.splice(sent_bytes, outcoming_bl.length()-sent_bytes, &bl);
       bl.swap(outcoming_bl);
     } else {

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -53,11 +53,12 @@ class AsyncConnection : public Connection {
   ssize_t do_sendmsg(struct msghdr &msg, unsigned len, bool more);
   ssize_t try_send(bufferlist &bl, bool send=true, bool more=false) {
     Mutex::Locker l(write_lock);
-    return _try_send(bl, send, more);
+    outcoming_bl.claim_append(bl);
+    return _try_send(send, more);
   }
   // if "send" is false, it will only append bl to send buffer
   // the main usage is avoid error happen outside messenger threads
-  ssize_t _try_send(bufferlist &bl, bool send=true, bool more=false);
+  ssize_t _try_send(bool send=true, bool more=false);
   ssize_t _send(Message *m);
   void prepare_send_message(uint64_t features, Message *m, bufferlist &bl);
   ssize_t read_until(unsigned needed, char *p);

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -74,7 +74,7 @@ class AsyncConnection : public Connection {
   int randomize_out_seq();
   void handle_ack(uint64_t seq);
   void _send_keepalive_or_ack(bool ack=false, utime_t *t=NULL);
-  ssize_t write_message(Message *m, bufferlist& bl);
+  ssize_t write_message(Message *m, bufferlist& bl, bool more);
   ssize_t _reply_accept(char tag, ceph_msg_connect &connect, ceph_msg_connect_reply &reply,
                     bufferlist &authorizer_reply) {
     bufferlist reply_bl;
@@ -116,6 +116,10 @@ class AsyncConnection : public Connection {
         out_q.erase(it->first);
     }
     return m;
+  }
+  bool _has_next_outgoing() {
+    assert(write_lock.is_locked());
+    return !out_q.empty();
   }
 
  public:


### PR DESCRIPTION
In write_message, set "more" flag according to ack queue, if there are
messages to acknowledge, set it. Unset it otherwise. Same goes for queued
messages.This keeps packet count low, while improving throughput.
To reduce kernel-side buffer coalescing and number of sendmsg() calls,
remove complete_bl and let messenger write directly to outcoming_bl of
a connection. Also, if message bufferlist is small enough, append its
contents to outcoming_bl directly, so we'll use less iovecs and in best
case, pack entire message (together with header and footer added in
write_message()) in single bufferptr.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>