### PR TITLE
os/filestore/FileJournal: set block size via config option

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1050,6 +1050,7 @@ OPTION(filestore_debug_verify_split, OPT_BOOL, false)
 OPTION(journal_dio, OPT_BOOL, true)
 OPTION(journal_aio, OPT_BOOL, true)
 OPTION(journal_force_aio, OPT_BOOL, false)
+OPTION(journal_block_size, OPT_INT, 4096)
 
 // max bytes to search ahead in journal searching for corruption
 OPTION(journal_max_corrupt_search, OPT_U64, 10<<20)

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1042,12 +1042,9 @@ void FileJournal::align_bl(off64_t pos, bufferlist& bl)
   // make sure list segments are page aligned
   if (directio && (!bl.is_aligned(block_size) ||
 		   !bl.is_n_align_sized(CEPH_DIRECTIO_ALIGNMENT))) {
-    assert(0 == "bl should be align");
-    if ((bl.length() & (CEPH_DIRECTIO_ALIGNMENT - 1)) != 0 ||
-	(pos & (CEPH_DIRECTIO_ALIGNMENT - 1)) != 0)
-      dout(0) << "rebuild_page_aligned failed, " << bl << dendl;
     assert((bl.length() & (CEPH_DIRECTIO_ALIGNMENT - 1)) == 0);
     assert((pos & (CEPH_DIRECTIO_ALIGNMENT - 1)) == 0);
+    assert(0 == "bl was not aligned");
   }
 }
 


### PR DESCRIPTION
We were setting the block_size as the MIN of the min size (4096) and the
block size reported for the journal file/device.  In reality, file systmes
report all kinds of crazy block sizes.  Usually it's the page size, but
sometimes it is larger (e.g., 128KB for ZFS), and that's not actually what
we want.  Using a size smaller than the file systems block size is not
optimal for performance, but it doesn't affect how the IO happens--as long
as it is larger than the hardware sector size, which is either 512 or
4096 bytes.  And our min was hard-coded at 4096.

So, instead, just set a config option to specify teh block size, and
default that to 4096.

The other uses of this constant we about *alignment* of memory buffers
for the purposes of direct IO.  Rename the option but do not change
the logic.  That means we continue to use 4k alignment for direct io even
if the device has 512 byte sectors, but that's fine--no reason to use
a smaller alignment.

Signed-off-by: Sage Weil <sage@redhat.com>