### PR TITLE
rgw: Drop unused usage_exit from rgw_admin.cc

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -195,12 +195,6 @@ int usage()
   return 1;
 }
 
-void usage_exit()
-{
-  _usage();
-  exit(1);
-}
-
 enum {
   OPT_NO_CMD = 0,
   OPT_USER_CREATE,


### PR DESCRIPTION
Somewhat of a worthless cleanup, but what the deuce, let's tighten it.

Signed-off-by: Pete Zaitcev <zaitcev@redhat.com>