### PR TITLE
Wip systemd paths

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -943,11 +943,11 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man8/rbd-replay.8*
 %{_mandir}/man8/rbd-replay-many.8*
 %{_mandir}/man8/rbd-replay-prep.8*
+%dir %{_datadir}/ceph/
 %{_datadir}/ceph/known_hosts_drop.ceph.com
 %{_datadir}/ceph/id_dsa_drop.ceph.com
 %{_datadir}/ceph/id_dsa_drop.ceph.com.pub
 %dir %{_sysconfdir}/ceph/
-%dir %{_datarootdir}/ceph/
 %dir %{_libexecdir}/ceph/
 %config %{_sysconfdir}/bash_completion.d/rados
 %config %{_sysconfdir}/bash_completion.d/rbd

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -617,13 +617,9 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--with-librocksdb-static=check \
 %if 0%{?rhel} || 0%{?fedora}
 		--with-systemd-libexec-dir=/usr/libexec/ceph \
-		--with-rgw-user=root \
-		--with-rgw-group=root \
 %endif
 %if 0%{?suse_version}
 		--with-systemd-libexec-dir=/usr/lib/ceph/ \
-		--with-rgw-user=wwwrun \
-		--with-rgw-group=www \
 %endif
 		--with-radosgw \
 		$CEPH_EXTRA_CONFIGURE_ARGS \

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -66,6 +66,10 @@ restorecon -R /var/log/ceph > /dev/null 2>&1;
 %global _with_lttng 1
 %endif
 
+# unify libexec for all targets
+%global _libexecdir %{_exec_prefix}/lib
+
+
 #################################################################################
 # common
 #################################################################################
@@ -597,6 +601,7 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 
 %{configure}	CPPFLAGS="$java_inc" \
 		--prefix=/usr \
+                --libexecdir=%{_libexecdir} \
 		--localstatedir=/var \
 		--sysconfdir=/etc \
 %if 0%{?_with_systemd}
@@ -838,8 +843,8 @@ rm -rf $RPM_BUILD_ROOT
 %else
 /sbin/mount.ceph
 %endif
-%dir %{_libdir}/ceph
-%{_libdir}/ceph/ceph_common.sh
+%dir %{_libexecdir}/ceph
+%{_libexecdir}/ceph/ceph_common.sh
 %{_libexecdir}/ceph/ceph-osd-prestart.sh
 %dir %{_libdir}/rados-classes
 %{_libdir}/rados-classes/libcls_cephfs.so*
@@ -857,6 +862,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/rados-classes/libcls_user.so*
 %{_libdir}/rados-classes/libcls_version.so*
 %{_libdir}/rados-classes/libcls_journal.so*
+%dir %{_libdir}/ceph
 %dir %{_libdir}/ceph/erasure-code
 %{_libdir}/ceph/erasure-code/libec_*.so*
 %dir %{_libdir}/ceph/compressor
@@ -948,7 +954,6 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/ceph/id_dsa_drop.ceph.com
 %{_datadir}/ceph/id_dsa_drop.ceph.com.pub
 %dir %{_sysconfdir}/ceph/
-%dir %{_libexecdir}/ceph/
 %config %{_sysconfdir}/bash_completion.d/rados
 %config %{_sysconfdir}/bash_completion.d/rbd
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -615,12 +615,6 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--with-selinux \
 %endif
 		--with-librocksdb-static=check \
-%if 0%{?rhel} || 0%{?fedora}
-		--with-systemd-libexec-dir=/usr/libexec/ceph \
-%endif
-%if 0%{?suse_version}
-		--with-systemd-libexec-dir=/usr/lib/ceph/ \
-%endif
 		--with-radosgw \
 		$CEPH_EXTRA_CONFIGURE_ARGS \
 		%{?_with_ocf} \

--- a/configure.ac
+++ b/configure.ac
@@ -1275,50 +1275,6 @@ AC_ARG_WITH(
     ]
 )
 
-
-dnl rgw-user
-AC_SUBST(user_rgw)
-AC_ARG_WITH(
-    rgw-user,
-    AS_HELP_STRING(
-        [--with-rgw-user=USER],
-        [systemd unit directory @<:@USER_RGW@:>@
-        Defaults to "www-data"]
-    ),
-    [
-        user_rgw="$withval"
-    ],
-    [
-        if test "x$USER_RGW" = "x"; then
-            user_rgw=www-data
-        else
-            user_rgw="$USER_RGW"
-        fi
-    ]
-)
-
-dnl rgw-group
-AC_SUBST(group_rgw)
-AC_ARG_WITH(
-    rgw-group,
-    AS_HELP_STRING(
-        [--with-rgw-group=GROUP],
-        [systemd unit directory @<:@GROUP_RGW@:>@
-        Defaults to "www-data"]
-    ),
-    [
-        group_rgw="$withval"
-    ],
-    [
-        if test "x$GROUP_RGW" = "x"; then
-            group_rgw=www-data
-        else
-            group_rgw="$GROUP_RGW"
-        fi
-    ]
-)
-
-
 AC_SUBST(systemd_unit_dir)
 AC_ARG_WITH(
     systemd-unit-dir,

--- a/configure.ac
+++ b/configure.ac
@@ -1234,47 +1234,6 @@ if test "x$enable_valgrind" = "xyes"; then
   AC_CHECK_HEADERS([valgrind/helgrind.h])
 fi
 
-dnl systemd-libexec-dir
-AC_SUBST(systemd_libexec_dir)
-AC_ARG_WITH(
-    systemd-libexec-dir,
-    AS_HELP_STRING(
-	    [--with-systemd-libexec-dir=DIR],
-	    [systemd libexec directory @<:@SYSTEMD_LIBEXEC_DIR@:>@
-        defaults to --libexecdir=DIR]
-    ),
-    [
-	    systemd_libexec_dir="$withval"
-    ],
-    [
-        if test "x$SYSTEMD_LIBEXEC_DIR" = "x"; then
-            dnl store old values
-
-            prefix_save=$prefix
-            exec_prefix_save=$exec_prefix
-
-            dnl if no prefix given, then use /usr/local, the default prefix
-            if test "x$prefix" = "xNONE"; then
-                prefix="$ac_default_prefix"
-            fi
-            dnl if no exec_prefix given, then use prefix
-            if test "x$exec_prefix" = "xNONE"; then
-                exec_prefix=$prefix
-            fi
-
-            dnl now get the expanded default
-            systemd_libexec_dir="`eval exec_prefix=$exec_prefix prefix=$prefix echo $libexecdir`"
-
-            dnl now cleanup prefix and exec_prefix
-
-            prefix=$prefix_save
-            exec_prefix=$exec_prefix_save
-        else
-            systemd_libexec_dir="$SYSTEMD_LIBEXEC_DIR"
-        fi
-    ]
-)
-
 AC_SUBST(systemd_unit_dir)
 AC_ARG_WITH(
     systemd-unit-dir,

--- a/debian/ceph.install
+++ b/debian/ceph.install
@@ -21,9 +21,9 @@ usr/bin/osdmaptool
 usr/lib/libos_tp.so.*
 usr/lib/libosd_tp.so.*
 usr/lib/ceph/ceph_common.sh
+usr/lib/ceph/ceph-osd-prestart.sh
 usr/lib/ceph/erasure-code/*
 usr/lib/rados-classes/*
-usr/libexec/ceph/ceph-osd-prestart.sh
 usr/share/doc/ceph/sample.ceph.conf
 usr/share/doc/ceph/sample.fetch_config
 usr/share/man/man8/ceph-clsinfo.8

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,20 @@
 include Makefile-env.am
 
+# a workaround for http://debbugs.gnu.org/cgi/bugreport.cgi?bug=18744, this
+# bug was fixed in automake 1.15, but automake 1.13 is supported by us.  so
+# we can not just require 1.15 using `AM_INIT_AUTOMAKE`
+am__is_gnu_make = { \
+  if test -z '$(MAKELEVEL)'; then \
+    false; \
+  elif test -n '$(MAKE_HOST)'; then \
+    true; \
+  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
+    true; \
+  else \
+    false; \
+  fi; \
+}
+
 SUBDIRS += ocf java
 DIST_SUBDIRS += gmock ocf java
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,6 +62,7 @@ editpaths = sed \
 	-e 's|@sysconfdir[@]|$(sysconfdir)|g' \
 	-e 's|@datadir[@]|$(pkgdatadir)|g' \
 	-e 's|@prefix[@]|$(prefix)|g' \
+	-e 's|@libexecdir[@]|$(libexecdir)|g' \
 	-e 's|@@GCOV_PREFIX_STRIP[@][@]|$(GCOV_PREFIX_STRIP)|g'
 shell_scripts = ceph-debugpack ceph-post-file ceph-crush-location
 $(shell_scripts): Makefile
@@ -128,13 +129,10 @@ docdir ?= ${datadir}/doc/ceph
 doc_DATA = $(srcdir)/sample.ceph.conf sample.fetch_config
 
 
-# various scripts
-
-shell_commondir = $(libdir)/ceph
-shell_common_SCRIPTS = ceph_common.sh
+# various scripts in $(libexecdir)
 
 ceph_libexecdir = $(libexecdir)/ceph
-ceph_libexec_SCRIPTS = ceph-osd-prestart.sh
+ceph_libexec_SCRIPTS = ceph_common.sh ceph-osd-prestart.sh
 
 
 # tests to actually run on "make check"; if you need extra, non-test,

--- a/src/ceph-debugpack.in
+++ b/src/ceph-debugpack.in
@@ -4,11 +4,11 @@
 # current directory too.
 if [ `dirname $0` = "." ] && [ $PWD != "/etc/init.d" ]; then
     BINDIR=.
-    LIBDIR=.
+    LIBEXECDIR=.
     ETCDIR=.
 else
     BINDIR=@bindir@
-    LIBDIR=@libdir@/ceph
+    LIBEXECDIR=@libexecdir@/ceph
     ETCDIR=@sysconfdir@/ceph
 fi
 
@@ -32,7 +32,7 @@ wait_pid_exit() {
 	fi
 }
 
-. $LIBDIR/ceph_common.sh
+. $LIBEXECDIR/ceph_common.sh
 
 dest_tar=''
 while [ $# -ge 1 ]; do

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -26,14 +26,14 @@ grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
 if [ `dirname $0` = "." ] && [ $PWD != "/etc/init.d" ]; then
     BINDIR=.
     SBINDIR=.
-    LIBDIR=.
+    LIBEXECDIR=.
     ETCDIR=.
     SYSTEMD_RUN=""
     ASSUME_DEV=1
 else
     BINDIR=@bindir@
     SBINDIR=@prefix@/sbin
-    LIBDIR=@libdir@/ceph
+    LIBEXECDIR=@libexecdir@/ceph
     ETCDIR=@sysconfdir@/ceph
     ASSUME_DEV=0
 fi
@@ -65,9 +65,9 @@ usage_exit() {
 
 # behave if we are not completely installed (e.g., Debian "removed,
 # config remains" state)
-test -f $LIBDIR/ceph_common.sh || exit 0
+test -f $LIBEXECDIR/ceph_common.sh || exit 0
 
-. $LIBDIR/ceph_common.sh
+. $LIBEXECDIR/ceph_common.sh
 
 EXIT_STATUS=0
 

--- a/src/upstart/ceph-osd.conf
+++ b/src/upstart/ceph-osd.conf
@@ -15,7 +15,7 @@ pre-start script
 
     install -d -m0770 -o ceph -g ceph /var/run/ceph
 
-    /usr/libexec/ceph/ceph-osd-prestart.sh --cluster="${cluster:-ceph}" -i "$id"
+    /usr/lib/ceph/ceph-osd-prestart.sh --cluster="${cluster:-ceph}" -i "$id"
 end script
 
 instance ${cluster:-ceph}/$id

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -10,7 +10,7 @@ LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecStartPre=/usr/libexec/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 ProtectHome=true
 ProtectSystem=full


### PR DESCRIPTION
This PR fixes http://tracker.ceph.com/issues/14705 and drops the autotools code for handling the user_rgw and group_rgw template variables which are no longer used.

This should be OK for Jewel because autotools is not going away that fast.