### PR TITLE
FileJournal::_open: return the correct error code

### DIFF
--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -103,9 +103,16 @@ int FileJournal::_open(bool forwrite, bool create)
     aio_ctx = 0;
     ret = io_setup(128, &aio_ctx);
     if (ret < 0) {
-      ret = errno;
-      derr << "FileJournal::_open: unable to setup io_context " << cpp_strerror(ret) << dendl;
-      ret = -ret;
+      switch (ret) {
+	// Contrary to naive expectations -EAGIAN means ...
+	case -EAGAIN:
+	  derr << "FileJournal::_open: user's limit of aio events exceeded. "
+	       << "Try increasing /proc/sys/fs/aio-max-nr" << dendl;
+	  break;
+	default:
+	  derr << "FileJournal::_open: unable to setup io_context " << cpp_strerror(-ret) << dendl;
+	  break;
+      }
       goto out_fd;
     }
   }


### PR DESCRIPTION
.. and print a more helpful error message. Unlike most of IO routines
(open, creat, write*, read, close) io_setup does NOT set the errno,
instead it returns the negated error code. Also -EAGAIN indicates
the limit of available events has been exceeded.