### PR TITLE
Silence a harmless msg where btrfs is not found.

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -599,7 +599,7 @@ EOF
 	    fi
 
 	    rm -rf $CEPH_DEV_DIR/osd$osd || true
-	    for f in $CEPH_DEV_DIR/osd$osd/* ; do btrfs sub delete $f || true ; done || true
+	    for f in $CEPH_DEV_DIR/osd$osd/*; do btrfs sub delete $f &> /dev/null || true; done
 	    mkdir -p $CEPH_DEV_DIR/osd$osd
 
 	    uuid=`uuidgen`


### PR DESCRIPTION
The error was:

./vstart.sh: line 603: btrfs: command not found

Signed-off-by: Patrick Donnelly <batrick@batbytes.com>