### PR TITLE
Clarify usage on starting single osd/mds/mon.

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -120,7 +120,7 @@ keyring_fn="$CEPH_CONF_PATH/keyring"
 osdmap_fn="/tmp/ceph_osdmap.$$"
 monmap_fn="/tmp/ceph_monmap.$$"
 
-usage="usage: $0 [option]... [mon] [mds] [osd]\n"
+usage="usage: $0 [option]... [\"mon\"] [\"mds\"] [\"osd\"]\n"
 usage=$usage"options:\n"
 usage=$usage"\t-d, --debug\n"
 usage=$usage"\t-s, --standby_mds: Generate standby-replay MDS for each active\n"


### PR DESCRIPTION
vstart.sh expects the literal string "osd"/"mds"/"mon". To me, it was confusing
as I interpreted the usage hint as an optional count for each daemon.

Signed-off-by: Patrick Donnelly <batrick@batbytes.com>