### PR TITLE
msg: add thread safety for "random" Messenger + fix wrong usage of random functions

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -160,6 +160,8 @@ int main(int argc, const char **argv)
   Messenger *msgr = Messenger::create(g_ceph_context, g_conf->ms_type,
 				      entity_name_t::MDS(-1), "mds",
 				      getpid());
+  if (!msgr)
+    exit(1);
   msgr->set_cluster_protocol(CEPH_MDS_PROTOCOL);
 
   cout << "starting " << g_conf->name << " at " << msgr->get_myaddr()

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -666,6 +666,8 @@ int main(int argc, const char **argv)
 				      entity_name_t::MON(rank),
 				      "mon",
 				      0);
+  if (!msgr)
+    exit(1);
   msgr->set_cluster_protocol(CEPH_MON_PROTOCOL);
   msgr->set_default_send_priority(CEPH_MSG_PRIO_HIGH);
 

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -461,6 +461,8 @@ int main(int argc, const char **argv)
   Messenger *ms_objecter = Messenger::create(g_ceph_context, g_conf->ms_type,
 					     entity_name_t::OSD(whoami), "ms_objecter",
 					     getpid());
+  if (!ms_public || !ms_cluster || !ms_hbclient || !ms_hb_back_server || !ms_hb_front_server || !ms_objecter)
+    exit(1);
   ms_cluster->set_cluster_protocol(CEPH_OSD_PROTOCOL);
   ms_hbclient->set_cluster_protocol(CEPH_OSD_PROTOCOL);
   ms_hb_back_server->set_cluster_protocol(CEPH_OSD_PROTOCOL);

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <thread>
 #include "include/types.h"
 #include "Messenger.h"
 
@@ -23,9 +24,11 @@ Messenger *Messenger::create(CephContext *cct, const string &type,
 			     uint64_t nonce, uint64_t features)
 {
   int r = -1;
-  srand(time(NULL));
-  if (type == "random")
-    r = rand() % 2; // random does not include xio
+  if (type == "random") {
+    thread_local unsigned seed = (unsigned) time(nullptr) +
+      (unsigned) std::hash<std::thread::id>()(std::this_thread::get_id());
+    r = rand_r(&seed) % 2; // random does not include xio
+  }
   if (r == 0 || type == "simple")
     return new SimpleMessenger(cct, name, lname, nonce, features);
   else if ((r == 1 || type == "async") &&
@@ -37,7 +40,7 @@ Messenger *Messenger::create(CephContext *cct, const string &type,
     return new XioMessenger(cct, name, lname, nonce, features);
 #endif
   lderr(cct) << "unrecognized ms_type '" << type << "'" << dendl;
-  return NULL;
+  return nullptr;
 }
 
 /*


### PR DESCRIPTION
msg: add thread safety for "random" Messenger + fix wrong usage of random functions

1. srand() and rand() functions are not thread safe => for extra robustness: use rand_r with a thread_local variable
2. At any case, it is inappropriate to call srand() again with any call to rand()!

Even with single thread, the current code is not only with redundant calls to srand(), but it is actually with a bug:
 In the common case that subsequent calls from ceph_osd to "Messanger::create"
 happens to occur in same 1 second in time, then the current code will feed all
 calls to "srand" with the very same "seed" argument.
 This is true because - during same 1 second - repeated calls to "time(NULL)"
 will return same value.  Hence, with the current code, during that 1 second,
 all calls to "rand" will return identical values (since, there is just one
 call to "rand" after any call to "srand").

Signed-off-by: Avner BenHanoch <avnerb@mellanox.com>