### PR TITLE
osd: WeightedPriorityQueue: move to intrusive containers

### DIFF
--- a/src/common/WeightedPriorityQueue.h
+++ b/src/common/WeightedPriorityQueue.h
@@ -15,345 +15,277 @@
 #ifndef WP_QUEUE_H
 #define WP_QUEUE_H
 
-#include "common/Formatter.h"
-#include "common/OpQueue.h"
+#include "OpQueue.h"
 
-#include <map>
-#include <list>
+#include <boost/intrusive/list.hpp>
+#include <boost/intrusive/rbtree.hpp>
+#include <boost/intrusive/avl_set.hpp>
 
-/**
- * Weighted Priority queue with strict priority queue
- *
- * This queue attempts to be fair to all classes of
- * operations but is also weighted so that higher classes
- * get more share of the operations.
- */
+namespace bi = boost::intrusive;
+
+template <typename T>
+class MapKey
+{
+  public:
+  bool operator()(const unsigned i, const T &k) const
+  {
+    return i < k.key;
+  }
+  bool operator()(const T &k, const unsigned i) const
+  {
+    return k.key < i;
+  }
+};
+
+template <typename T>
+class DelItem
+{
+  public:
+  void operator()(T* delete_this)
+    { delete delete_this; }
+};
 
 template <typename T, typename K>
-class WeightedPriorityQueue : public OpQueue <T, K> {
-  int64_t total_priority;
-
-  typedef std::list<std::pair<unsigned, T>> ListPairs;
-  static unsigned filter_list_pairs(
-    ListPairs *l, std::function<bool (T)> f,
-    std::list<T> *out) {
-    unsigned ret = 0;
-    if (out) {
-      for (typename ListPairs::reverse_iterator i = l->rbegin();
-	   i != l->rend();
-	   ++i) {
-	if (f(i->second)) {
-	  out->push_front(i->second);
-	}
-      }
-    }
-    for (typename ListPairs::iterator i = l->begin();
-	 i != l->end(); ) {
-      if (f(i->second)) {
-	l->erase(i++);
-	++ret;
-      } else {
-	++i;
-      }
-    }
-    return ret;
-  }
-
-  struct SubQueue {
+class WeightedPriorityQueue :  public OpQueue <T, K>
+{
   private:
-    typedef std::map<K, ListPairs> Classes;
-    Classes q;
-    typename Classes::iterator cur;
-    unsigned q_size;
-  public:
-    SubQueue(const SubQueue &other)
-      : q(other.q),
-	cur(q.begin()),
-	q_size(0) {}
-    SubQueue()
-      :	cur(q.begin()),
-	q_size(0) {}
-    void enqueue_front(K cl, unsigned cost, T item) {
-      q[cl].push_front(std::make_pair(cost, item));
-      if (cur == q.end()) {
-	cur = q.begin();
+    class ListPair : public bi::list_base_hook<>
+    {
+      public:
+	K klass;
+        unsigned cost;
+        T item;
+        ListPair(K& k, unsigned c, T& i) :
+	  klass(k),
+          cost(c),
+          item(i)
+          {}
+    };
+    class SubQueue : public bi::set_base_hook<>
+    {
+      typedef bi::list<ListPair> QueueItems;
+      typedef typename QueueItems::iterator QI;
+      public:
+	unsigned key;	// priority
+	QueueItems qitems;
+	SubQueue(unsigned& p) :
+	  key(p)
+	  {}
+      bool empty() const {
+        return qitems.empty();
       }
-      ++q_size;
-    }
-    void enqueue(K cl, unsigned cost, T item) {
-      q[cl].push_back(std::make_pair(cost, item));
-      if (cur == q.end()) {
-	cur = q.begin();
-      }
-      ++q_size;
-    }
-    std::pair<unsigned, T> front() const {
-      assert(!q.empty());
-      assert(cur != q.end());
-      assert(!cur->second.empty());
-      return cur->second.front();
-    }
-    void pop_front() {
-      assert(!q.empty());
-      assert(cur != q.end());
-      assert(!cur->second.empty());
-      cur->second.pop_front();
-      if (cur->second.empty()) {
-	cur = q.erase(cur);
-      } else {
-	++cur;
-      }
-      if (cur == q.end()) {
-	cur = q.begin();
-      }
-      --q_size;
-    }
-    unsigned size() const {
-      return q_size;
-    }
-    bool empty() const {
-      return (q_size == 0);
-    }
-    unsigned remove_by_filter(std::function<bool (T)> f, std::list<T> *out) {
-      unsigned count = 0;
-      for (typename Classes::iterator i = q.begin();
-	   i != q.end(); ) {
-	count += filter_list_pairs(&(i->second), f, out);
-	if (i->second.empty()) {
-	  if (cur == i) {
-	    ++cur;
-	  }
-	  q.erase(i++);
+      void insert(K& cl, unsigned cost, T& item, bool front = false) {
+	if (front) {
+	  qitems.push_front(*new ListPair(cl, cost, item));
 	} else {
-	  ++i;
+	  qitems.push_back(*new ListPair(cl, cost, item));
 	}
       }
-      if (cur == q.end()) {
-	cur = q.begin();
+      unsigned get_cost() const {
+	return qitems.begin()->cost;
       }
-      q_size -= count;
-      return count;
-    }
-    unsigned remove_by_class(K k, std::list<T> *out) {
-      typename Classes::iterator i = q.find(k);
-      if (i == q.end()) {
-	return 0;
+      T pop() {
+	T ret = qitems.begin()->item;
+	qitems.erase_and_dispose(qitems.begin(), DelItem<ListPair>());
+	return ret;
       }
-      unsigned count = i->second.size();
-      q_size -= count;
-      if (out) {
-	for (typename ListPairs::reverse_iterator j =
-	       i->second.rbegin();
-	     j != i->second.rend();
-	     ++j) {
-	  out->push_front(j->second);
+      unsigned filter_list_pairs(std::function<bool (T)>& f, std::list<T>* out) {
+	unsigned count = 0;
+        // intrusive containers can't erase with a reverse_iterator
+        // so we have to walk backwards on our own. Since there is
+        // no iterator before begin, we have to test at the end.
+        for (QI i = --qitems.end();; --i) {
+          if (f(i->item)) {
+            if (out) {
+              out->push_front(i->item);
+            }
+            i = qitems.erase_and_dispose(i, DelItem<ListPair>());
+            ++count;
+          }
+          if (i == qitems.begin()) {
+            break;
+          }
+        }
+	return count;
+      }
+      unsigned filter_class(K& cl, std::list<T>* out) {
+	unsigned count = 0;
+        for (QI i = --qitems.end();; --i) {
+	  if (i->klass == cl) {
+	    if (out) {
+	      out->push_front(i->item);
+	    }
+	    i = qitems.erase_and_dispose(i, DelItem<ListPair>());
+	    ++count;
+	  }
+	  if (i == qitems.begin()) {
+	    break;
+	  }
+        }
+	return count;
+      }
+      void dump(ceph::Formatter *f) const {
+	f->dump_int("num_keys", qitems.size());
+	f->dump_int("first_item_cost", qitems.begin()->cost);
+      }
+    };
+    class Queue {
+      typedef bi::rbtree<SubQueue> SubQueues;
+      typedef typename SubQueues::iterator Sit;
+      SubQueues queues;
+      unsigned total_prio;
+      unsigned max_cost;
+      public:
+	unsigned size;
+	Queue() :
+	  total_prio(0),
+	  max_cost(0),
+	  size(0)
+	  {}
+	bool empty() const {
+	  return !size;
 	}
-      }
-      if (i == cur) {
-	++cur;
-      }
-      q.erase(i);
-      if (cur == q.end()) {
-	cur = q.begin();
-      }
-      return count;
-    }
+	void insert(unsigned p, K& cl, unsigned cost, T& item, bool front = false) {
+	  typename SubQueues::insert_commit_data insert_data;
+      	  std::pair<typename SubQueues::iterator, bool> ret =
+      	    queues.insert_unique_check(p, MapKey<SubQueue>(), insert_data);
+      	  if (ret.second) {
+      	    ret.first = queues.insert_unique_commit(*new SubQueue(p), insert_data);
+	    total_prio += p;
+      	  }
+      	  ret.first->insert(cl, cost, item, front);
+	  if (cost > max_cost) {
+	    max_cost = cost;
+	  }
+	  ++size;
+	}
+	T pop(bool strict = false) {
+	  --size;
+	  Sit i = --queues.end();
+	  if (strict) {
+	    T ret = i->pop();
+	    if (i->empty()) {
+	      queues.erase_and_dispose(i, DelItem<SubQueue>());
+	    }
+	    return ret;
+	  }
+	  if (queues.size() > 1) {
+	    while (true) {
+	      // Pick a new priority out of the total priority.
+	      unsigned prio = rand() % total_prio + 1;
+	      unsigned tp = total_prio - i->key;
+	      // Find the priority coresponding to the picked number.
+	      // Subtract high priorities to low priorities until the picked number
+	      // is more than the total and try to dequeue that priority.
+	      // Reverse the direction from previous implementation because there is a higher
+	      // chance of dequeuing a high priority op so spend less time spinning.
+	      while (prio <= tp) {
+		--i;
+		tp -= i->key;
+	      }
+	      // Flip a coin to see if this priority gets to run based on cost.
+	      // The next op's cost is multiplied by .9 and subtracted from the
+	      // max cost seen. Ops with lower costs will have a larger value
+	      // and allow them to be selected easier than ops with high costs.
+	      if (max_cost == 0 || rand() % max_cost <=
+		  (max_cost - ((i->get_cost() * 9) / 10))) {
+		break;
+	      }
+	      i = --queues.end();
+	    }
+	  }
+	  T ret = i->pop();
+	  if (i->empty()) {
+	    total_prio -= i->key;
+	    queues.erase_and_dispose(i, DelItem<SubQueue>());
+	  }
+	  return ret;
+	}
+	void filter_list_pairs(std::function<bool (T)>& f, std::list<T>* out) {
+	  for (Sit i = queues.begin(); i != queues.end();) {
+      	    size -= i->filter_list_pairs(f, out);
+	    if (i->empty()) {
+	      total_prio -= i->key;
+	      i = queues.erase_and_dispose(i, DelItem<SubQueue>());
+	    } else {
+	      ++i;
+	    }
+      	  }
+	}
+	void filter_class(K& cl, std::list<T>* out) {
+	  for (Sit i = queues.begin(); i != queues.end();) {
+	    size -= i->filter_class(cl, out);
+	    if (i->empty()) {
+	      total_prio -= i->key;
+	      i = queues.erase_and_dispose(i, DelItem<SubQueue>());
+	    } else {
+	      ++i;
+	    }
+	  }
+	}
+	void dump(ceph::Formatter *f) const {
+	  for (typename SubQueues::const_iterator i = queues.begin();
+	        i != queues.end(); ++i) {
+	    f->dump_int("total_priority", total_prio);
+	    f->dump_int("max_cost", max_cost);
+	    f->open_object_section("subqueue");
+	    f->dump_int("priority", i->key);
+	    i->dump(f);
+	    f->close_section();
+	  }
+	}
+    };
 
+    Queue strict;
+    Queue normal;
+  public:
+    WeightedPriorityQueue(unsigned max_per, unsigned min_c) :
+      strict(),
+      normal()
+      {
+	std::srand(time(0));
+      }
+    unsigned length() const override final {
+      return strict.size + normal.size;
+    }
+    void remove_by_filter(std::function<bool (T)> f, std::list<T>* removed = 0) override final {
+      strict.filter_list_pairs(f, removed);
+      normal.filter_list_pairs(f, removed);
+    }
+    void remove_by_class(K cl, std::list<T>* removed = 0) override final {
+      strict.filter_class(cl, removed);
+      normal.filter_class(cl, removed);
+    }
+    bool empty() const override final {
+      return !(strict.size + normal.size);
+    }
+    void enqueue_strict(K cl, unsigned p, T item) override final {
+      strict.insert(p, cl, 0, item);
+    }
+    void enqueue_strict_front(K cl, unsigned p, T item) override final {
+      strict.insert(p, cl, 0, item, true);
+    }
+    void enqueue(K cl, unsigned p, unsigned cost, T item) override final {
+      normal.insert(p, cl, cost, item);
+    }
+    void enqueue_front(K cl, unsigned p, unsigned cost, T item) override final {
+      normal.insert(p, cl, cost, item, true);
+    }
+    T dequeue() {
+      assert(strict.size + normal.size > 0);
+      if (!strict.empty()) {
+	return strict.pop(true);
+      }
+      return normal.pop();
+    }
     void dump(ceph::Formatter *f) const {
-      f->dump_int("num_keys", q.size());
-      if (!empty()) {
-	f->dump_int("first_item_cost", front().first);
-      }
-    }
-  };
-
-  unsigned high_size, wrr_size;
-  unsigned max_cost;
-
-  typedef std::map<unsigned, SubQueue> SubQueues;
-  SubQueues high_queue;
-  SubQueues queue;
-  typename SubQueues::reverse_iterator dq;
-
-  SubQueue *create_queue(unsigned priority) {
-    typename SubQueues::iterator p = queue.find(priority);
-    if (p != queue.end()) {
-      return &p->second;
-    }
-    total_priority += priority;
-    SubQueue *sq = &queue[priority];
-    return sq;
-  }
-
-  void remove_queue(unsigned priority) {
-    assert(queue.count(priority));
-    dq = (typename SubQueues::reverse_iterator) queue.erase(queue.find(priority));
-    if (dq == queue.rend()) {
-      dq = queue.rbegin();
-    }
-    total_priority -= priority;
-    assert(total_priority >= 0);
-  }
-
-public:
-  WeightedPriorityQueue(unsigned max_per, unsigned min_c)
-    : total_priority(0),
-      high_size(0),
-      wrr_size(0),
-      max_cost(0),
-      dq(queue.rbegin())
-  {
-    srand(time(0));
-  }
-
-  unsigned length() const override final {
-    return high_size + wrr_size;
-  }
-
-  void remove_by_filter(
-      std::function<bool (T)> f, std::list<T> *removed = 0) override final {
-    for (typename SubQueues::iterator i = queue.begin();
-	 i != queue.end(); ++i) {
-      wrr_size -= i->second.remove_by_filter(f, removed);
-      unsigned priority = i->first;
-      if (i->second.empty()) {
-	remove_queue(priority);
-      }
-    }
-    for (typename SubQueues::iterator i = high_queue.begin();
-	 i != high_queue.end();
-	 ) {
-      high_size -= i->second.remove_by_filter(f, removed);
-      if (i->second.empty()) {
-	high_queue.erase(i++);
-      } else {
-	++i;
-      }
-    }
-  }
-
-  void remove_by_class(K k, std::list<T> *out = 0) override final {
-    for (typename SubQueues::iterator i = queue.begin();
-	 i != queue.end(); ++i) {
-      wrr_size -= i->second.remove_by_class(k, out);
-      unsigned priority = i->first;
-      if (i->second.empty()) {
-	remove_queue(priority);
-      }
-    }
-    for (typename SubQueues::iterator i = high_queue.begin();
-	 i != high_queue.end();
-	 ) {
-      high_size -= i->second.remove_by_class(k, out);
-      if (i->second.empty()) {
-	high_queue.erase(i++);
-      } else {
-	++i;
-      }
-    }
-  }
-
-  void enqueue_strict(K cl, unsigned priority, T item) override final {
-    high_queue[priority].enqueue(cl, 0, item);
-    ++high_size;
-  }
-
-  void enqueue_strict_front(K cl, unsigned priority, T item) override final {
-    high_queue[priority].enqueue_front(cl, 0, item);
-    ++high_size;
-  }
-
-  void enqueue(K cl, unsigned priority, unsigned cost, T item) override final {
-    if (cost > max_cost) {
-      max_cost = cost;
-    }
-    create_queue(priority)->enqueue(cl, cost, item);
-    ++wrr_size;
-  }
-
-  void enqueue_front(K cl, unsigned priority, unsigned cost, T item) override final {
-    if (cost > max_cost) {
-      max_cost = cost;
-    }
-    create_queue(priority)->enqueue_front(cl, cost, item);
-    ++wrr_size;
-  }
-
-  bool empty() const override final {
-    assert(total_priority >= 0);
-    assert((total_priority == 0) || !queue.empty());
-    return (high_size + wrr_size  == 0) ? true : false;
-  }
-
-  T dequeue() override final {
-    assert(!empty());
-
-    if (!high_queue.empty()) {
-      T ret = high_queue.rbegin()->second.front().second;
-      high_queue.rbegin()->second.pop_front();
-      if (high_queue.rbegin()->second.empty()) {
-	high_queue.erase(high_queue.rbegin()->first);
-      }
-      --high_size;
-      return ret;
-    }
-    // If there is more than one priority, choose one to run.
-    if (dq->second.size() != wrr_size) {
-      while (true) {
-	// Pick a new priority out of the total priority.
-	unsigned prio = rand() % total_priority;
-	typename SubQueues::iterator i = queue.begin();
-	unsigned tp = i->first;
-	// Find the priority coresponding to the picked number.
-	// Add low priorities to high priorities until the picked number
-	// is less than the total and try to dequeue that priority.
-	while (prio > tp) {
-	  ++i;
-	  tp += i->first;
-	}
-	dq = (typename SubQueues::reverse_iterator) ++i;
-	// Flip a coin to see if this priority gets to run based on cost.
-	// The next op's cost is multiplied by .9 and subtracted from the
-	// max cost seen. Ops with lower costs will have a larger value
-	// and allow them to be selected easier than ops with high costs.
-	if (max_cost == 0 || rand() % max_cost <=
-	    (max_cost - ((dq->second.front().first * 9) / 10))){
-	  break;
-	}
-      }
-    }
-    T ret = dq->second.front().second;
-    dq->second.pop_front();
-    if (dq->second.empty()) {
-      remove_queue(dq->first);
-    }
-    --wrr_size;
-    return ret;
-  }
-
-  void dump(ceph::Formatter *f) const {
-    f->dump_int("total_priority", total_priority);
-    f->open_array_section("high_queues");
-    for (typename SubQueues::const_iterator p = high_queue.begin();
-	 p != high_queue.end();
-	 ++p) {
-      f->open_object_section("subqueue");
-      f->dump_int("priority", p->first);
-      p->second.dump(f);
+      f->open_array_section("high_queues");
+      strict.dump(f);
+      f->close_section();
+      f->open_array_section("queues");
+      normal.dump(f);
       f->close_section();
     }
-    f->close_section();
-    f->open_array_section("queues");
-    for (typename SubQueues::const_iterator p = queue.begin();
-	 p != queue.end();
-	 ++p) {
-      f->open_object_section("subqueue");
-      f->dump_int("priority", p->first);
-      p->second.dump(f);
-      f->close_section();
-    }
-    f->close_section();
-  }
 };
 
 #endif

--- a/src/test/common/test_weighted_priority_queue.cc
+++ b/src/test/common/test_weighted_priority_queue.cc
@@ -114,13 +114,6 @@ protected:
         // in the strict queue.
         LQ::reverse_iterator ri = strictq.rbegin();
         EXPECT_EQ(std::get<0>(r), ri->first);
-        // Check that if there are multiple classes in a priority
-        // that it is not dequeueing the same class each time.
-        LastKlass::iterator si = last_strict.find(std::get<0>(r));
-        if (strictq[std::get<0>(r)].size() > 1 && si != last_strict.end()) {
-	  EXPECT_NE(std::get<1>(r), si->second);
-	}
-        last_strict[std::get<0>(r)] = std::get<1>(r);
 
 	Item t = strictq[std::get<0>(r)][std::get<1>(r)].front().second;
         EXPECT_EQ(std::get<2>(r), std::get<2>(t));
@@ -132,14 +125,6 @@ protected:
 	  strictq.erase(std::get<0>(r));
 	}
       } else {
-        // Check that if there are multiple classes in a priority
-        // that it is not dequeueing the same class each time.
-        LastKlass::iterator si = last_norm.find(std::get<0>(r));
-        if (normq[std::get<0>(r)].size() > 1 && si != last_norm.end()) {
-	  EXPECT_NE(std::get<1>(r), si->second);
-	}
-        last_norm[std::get<0>(r)] = std::get<1>(r);
-
 	Item t = normq[std::get<0>(r)][std::get<1>(r)].front().second;
         EXPECT_EQ(std::get<2>(r), std::get<2>(t));
         normq[std::get<0>(r)][std::get<1>(r)].pop_front();


### PR DESCRIPTION
My microbenchmarks is showing a 60-70% execution time compared to the previous version and PrioritizedQueue. Unittests also complete without issues.

However, I'm stuck with an issue that I could use some help on. The OSDs will start up and recover just fine, but as soon as client traffic happens, it gets an assert (i.e. rbd -p rbd ls). I've looked at it through gdb and r has a value of 22 which I believes means EINVAL which means that the mutex does not refer to an initialized mutex object. However dumping the mutex object looks initialized to me. So I'm not really sure what is going on and could use some help. Don't forget to set "osd_op_queue = wpq" so the error shows up.

     0> 2016-02-15 18:21:28.448629 7f94e7a6b700 -1 *** Caught signal (Aborted) **
 in thread 7f94e7a6b700

 ceph version 10.0.3-1037-g91339ad (91339ade26f26b41af9d950190b1c7793289c0af)
 1: (()+0x91ab55) [0x55b481344b55]
 2: (()+0xf8d0) [0x7f9504c0b8d0]
 3: (gsignal()+0x37) [0x7f9502c31107]
 4: (abort()+0x148) [0x7f9502c324e8]
 5: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x256) [0x55b48144b9f6]
 6: (Mutex::Lock(bool)+0x194) [0x55b4813fa5c4]
 7: (TrackedOp::mark_event(std::string const&)+0x74) [0x55b481346124]
 8: (OpRequest::mark_flag_point(unsigned char, std::string const&)+0x14) [0x55b480e10714]
 9: (OSD::dequeue_op(boost::intrusive_ptr<PG>, std::shared_ptr<OpRequest>, ThreadPool::TPHandle&)+0x3ec) [0x55b480d86b6c]
 10: (PGQueueable::RunVis::operator()(std::shared_ptr<OpRequest>&)+0x6a) [0x55b480d86dfa]
 11: (OSD::ShardedOpWQ::_process(unsigned int, ceph::heartbeat_handle_d*)+0x769) [0x55b480da1e59]
 12: (ShardedThreadPool::shardedthreadpool_worker(unsigned int)+0x8b6) [0x55b48143b5d6]
 13: (ShardedThreadPool::WorkThreadSharded::entry()+0x10) [0x55b48143d590]
 14: (()+0x80a4) [0x7f9504c040a4]
 15: (clone()+0x6d) [0x7f9502ce204d]
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is needed to interpret this.

Aborted

(gdb) frame 3
#3  0x0000555555f245c4 in Mutex::Lock (this=this@entry=0x55555fdf9448, no_lockdep=no_lockdep@entry=false) at common/Mutex.cc:113
113       assert(r == 0);
(gdb) list
108                      ceph_clock_now(cct) - start);
109       } else {
110         r = pthread_mutex_lock(&_m);
111       }
112
113       assert(r == 0);
114       if (lockdep && g_lockdep) _locked();
115       _post_lock();
116
117     out:
(gdb) print _m
$1 = {__data = {__lock = 0, __count = 0, __owner = 0, __nusers = 0, __kind = -1, __spins = 0, __elision = 0, __list = {__prev = 0x0, __next = 0x0}}, 
  __size = '\000' <repeats 16 times>, "\377\377\377\377", '\000' <repeats 19 times>, __align = 0}
(gdb) p r
$2 = 22
(gdb) 

Thanks