### PR TITLE
common/Mutex.cc: initialize the variable to be asserted on.

### DIFF
--- a/src/common/Mutex.cc
+++ b/src/common/Mutex.cc
@@ -92,6 +92,8 @@ Mutex::~Mutex() {
 void Mutex::Lock(bool no_lockdep) {
   int r;
 
+  r = 0;
+  
   if (lockdep && g_lockdep && !no_lockdep) _will_lock();
 
   if (logger && cct && cct->_conf->mutex_perf_counter) {


### PR DESCRIPTION
int r is not initialized, and could be left unitialised at the point the assert is tested.
Stack variables have an undefined value upon entry into the functions.

I have run into tests (on Linux) where the assert was called