### PR TITLE
pybind: Ensure correct python flags are passed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,6 +213,14 @@ if test x"$with_cython" = xyes; then
     if test x"$CYTHON_CHECK" != xyes; then
         AC_MSG_FAILURE([cython not found])
     fi
+    AC_CHECK_PROG(PYTHON_CONFIG_CHECK, python-config, yes)
+    if test x"$PYTHON_CONFIG_CHECK" != xyes; then
+        AC_MSG_FAILURE([python-config not found])
+    fi
+    PYTHON_CFLAGS=`python-config --cflags`
+    AC_SUBST(PYTHON_CFLAGS)
+    PYTHON_LDFLAGS=`python-config --ldflags`
+    AC_SUBST(PYTHON_LDFLAGS)
 fi
 
 # cond-check if snappy-devel is installed, needed by leveldb that is need by server parts of the project

--- a/src/pybind/Makefile.am
+++ b/src/pybind/Makefile.am
@@ -7,8 +7,8 @@ if WITH_CYTHON
 
 PY_DISTUTILS = \
 	CPPFLAGS="-iquote \${abs_srcdir}/include ${AM_CPPFLAGS} ${CPPFLAGS}" \
-	CFLAGS="-iquote \${abs_srcdir}/include ${AM_CFLAGS} ${CFLAGS}" \
-	LDFLAGS="-L\${abs_builddir}/.libs $(subst -pie,,${AM_LDFLAGS}) ${LDFLAGS}" \
+	CFLAGS="-iquote \${abs_srcdir}/include ${AM_CFLAGS} ${PYTHON_CFLAGS}" \
+	LDFLAGS="-L\${abs_builddir}/.libs $(subst -pie,,${AM_LDFLAGS}) ${PYTHON_LDFLAGS}" \
 	CYTHON_BUILD_DIR="$(shell readlink -f $(builddir))/build" \
 	${PYTHON} ./setup.py
 


### PR DESCRIPTION
Cython should use the cflags and ldflags provided by
python-config; add checks, population and use of:

  PYTHON_CFLAGS
  PYTHON_LDFLAGS

resolving linker failures on Ubuntu and Debian.

Signed-off-by: James Page <james.page@ubuntu.com>