### PR TITLE
librbd: use async librados notifications

### DIFF
--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -462,8 +462,8 @@ void ExclusiveLock<I>::send_shutdown() {
   if (m_state == STATE_UNLOCKED) {
     m_state = STATE_SHUTTING_DOWN;
     m_image_ctx.aio_work_queue->unblock_writes();
-    m_image_ctx.op_work_queue->queue(util::create_context_callback<
-      ExclusiveLock<I>, &ExclusiveLock<I>::complete_shutdown>(this), 0);
+    m_image_ctx.image_watcher->flush(util::create_context_callback<
+      ExclusiveLock<I>, &ExclusiveLock<I>::complete_shutdown>(this));
     return;
   }
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -1018,6 +1018,16 @@ struct C_InvalidateCache : public Context {
     return new Journal<ImageCtx>(*this);
   }
 
+  void ImageCtx::set_image_name(const std::string &image_name) {
+    // update the name so rename can be invoked repeatedly
+    RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
+    RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
+    name = image_name;
+    if (old_format) {
+      header_oid = util::old_header_name(image_name);
+    }
+  }
+
   void ImageCtx::notify_update() {
     state->handle_update_notification();
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -1017,4 +1017,17 @@ struct C_InvalidateCache : public Context {
   Journal<ImageCtx> *ImageCtx::create_journal() {
     return new Journal<ImageCtx>(*this);
   }
+
+  void ImageCtx::notify_update() {
+    state->handle_update_notification();
+
+    C_SaferCond ctx;
+    image_watcher->notify_header_update(&ctx);
+    ctx.wait();
+  }
+
+  void ImageCtx::notify_update(Context *on_finish) {
+    state->handle_update_notification();
+    image_watcher->notify_header_update(on_finish);
+  }
 }

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -1020,8 +1020,8 @@ struct C_InvalidateCache : public Context {
 
   void ImageCtx::set_image_name(const std::string &image_name) {
     // update the name so rename can be invoked repeatedly
-    RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-    RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
+    RWLock::RLocker owner_locker(owner_lock);
+    RWLock::WLocker snap_locker(snap_lock);
     name = image_name;
     if (old_format) {
       header_oid = util::old_header_name(image_name);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -275,6 +275,9 @@ namespace librbd {
     Journal<ImageCtx> *create_journal();
 
     void clear_pending_completions();
+
+    void notify_update();
+    void notify_update(Context *on_finish);
   };
 }
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -276,6 +276,8 @@ namespace librbd {
 
     void clear_pending_completions();
 
+    void set_image_name(const std::string &name);
+
     void notify_update();
     void notify_update(Context *on_finish);
   };

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -118,14 +118,6 @@ void ImageState<I>::refresh(Context *on_finish) {
 
 template <typename I>
 int ImageState<I>::refresh_if_required() {
-  RWLock::RLocker owner_locker(m_image_ctx->owner_lock);
-  return refresh_if_required(m_image_ctx->owner_lock);
-}
-
-template <typename I>
-int ImageState<I>::refresh_if_required(const RWLock &) {
-  assert(m_image_ctx->owner_lock.is_locked());
-
   C_SaferCond ctx;
   {
     Mutex::Locker locker(m_lock);

--- a/src/librbd/ImageState.h
+++ b/src/librbd/ImageState.h
@@ -36,7 +36,6 @@ public:
   int refresh();
   void refresh(Context *on_finish);
   int refresh_if_required();
-  int refresh_if_required(const RWLock &owner_lock);
 
   void snap_set(const std::string &snap_name, Context *on_finish);
 

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -290,13 +290,6 @@ ClientId ImageWatcher::get_client_id() {
 }
 
 void ImageWatcher::notify_acquired_lock() {
-  // might be invoked from librados AIO thread
-  FunctionContext *ctx = new FunctionContext(
-      boost::bind(&ImageWatcher::execute_acquired_lock, this));
-  m_task_finisher->queue(TASK_CODE_ACQUIRED_LOCK, ctx);
-}
-
-void ImageWatcher::execute_acquired_lock() {
   ldout(m_image_ctx.cct, 10) << this << " notify acquired lock" << dendl;
 
   ClientId client_id = get_client_id();
@@ -311,13 +304,6 @@ void ImageWatcher::execute_acquired_lock() {
 }
 
 void ImageWatcher::notify_released_lock() {
-  // might be invoked from librados AIO thread
-  FunctionContext *ctx = new FunctionContext(
-      boost::bind(&ImageWatcher::execute_released_lock, this));
-  m_task_finisher->queue(TASK_CODE_RELEASED_LOCK, ctx);
-}
-
-void ImageWatcher::execute_released_lock() {
   ldout(m_image_ctx.cct, 10) << this << " notify released lock" << dendl;
 
   {
@@ -345,7 +331,7 @@ void ImageWatcher::schedule_request_lock(bool use_timer, int timer_delay) {
     ldout(m_image_ctx.cct, 15) << this << " requesting exclusive lock" << dendl;
 
     FunctionContext *ctx = new FunctionContext(
-      boost::bind(&ImageWatcher::execute_request_lock, this));
+      boost::bind(&ImageWatcher::notify_request_lock, this));
     if (use_timer) {
       if (timer_delay < 0) {
         timer_delay = RETRY_DELAY_SECONDS;
@@ -359,13 +345,6 @@ void ImageWatcher::schedule_request_lock(bool use_timer, int timer_delay) {
 }
 
 void ImageWatcher::notify_request_lock() {
-  // might be invoked from librados AIO thread
-  FunctionContext *ctx = new FunctionContext(
-      boost::bind(&ImageWatcher::execute_request_lock, this));
-  m_task_finisher->queue(TASK_CODE_REQUEST_LOCK, ctx);
-}
-
-void ImageWatcher::execute_request_lock() {
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   ldout(m_image_ctx.cct, 10) << this << " notify request lock" << dendl;
 

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -230,22 +230,25 @@ private:
   void set_owner_client_id(const watch_notify::ClientId &client_id);
   watch_notify::ClientId get_client_id();
 
+  void handle_request_lock(int r);
   void schedule_request_lock(bool use_timer, int timer_delay = -1);
 
-  int notify_lock_owner(bufferlist &bl);
+  int notify_lock_owner(bufferlist &&bl);
+  void notify_lock_owner(bufferlist &&bl, Context *on_finish);
 
   void schedule_async_request_timed_out(const watch_notify::AsyncRequestId &id);
   void async_request_timed_out(const watch_notify::AsyncRequestId &id);
   int notify_async_request(const watch_notify::AsyncRequestId &id,
-                           bufferlist &in, ProgressContext& prog_ctx);
-  void notify_request_leadership();
+                           bufferlist &&in, ProgressContext& prog_ctx);
 
   void schedule_async_progress(const watch_notify::AsyncRequestId &id,
                                uint64_t offset, uint64_t total);
   int notify_async_progress(const watch_notify::AsyncRequestId &id,
                             uint64_t offset, uint64_t total);
   void schedule_async_complete(const watch_notify::AsyncRequestId &id, int r);
-  int notify_async_complete(const watch_notify::AsyncRequestId &id, int r);
+  void notify_async_complete(const watch_notify::AsyncRequestId &id, int r);
+  void handle_async_complete(const watch_notify::AsyncRequestId &request, int r,
+                             int ret_val);
 
   int prepare_async_request(const watch_notify::AsyncRequestId& id,
                             bool* new_request, Context** ctx,

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -3,12 +3,12 @@
 #ifndef CEPH_LIBRBD_IMAGE_WATCHER_H
 #define CEPH_LIBRBD_IMAGE_WATCHER_H
 
-#include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/RWLock.h"
 #include "include/Context.h"
 #include "include/rados/librados.hpp"
 #include "include/rbd/librbd.hpp"
+#include "librbd/image_watcher/Notifier.h"
 #include "librbd/WatchNotifyTypes.h"
 #include <set>
 #include <string>
@@ -31,6 +31,7 @@ public:
 
   int register_watch();
   int unregister_watch();
+  void flush(Context *on_finish);
 
   int notify_flatten(uint64_t request_id, ProgressContext &prog_ctx);
   int notify_resize(uint64_t request_id, uint64_t size,
@@ -65,9 +66,7 @@ private:
   };
 
   enum TaskCode {
-    TASK_CODE_ACQUIRED_LOCK,
     TASK_CODE_REQUEST_LOCK,
-    TASK_CODE_RELEASED_LOCK,
     TASK_CODE_CANCEL_ASYNC_REQUESTS,
     TASK_CODE_REREGISTER_WATCH,
     TASK_CODE_ASYNC_REQUEST,
@@ -222,6 +221,8 @@ private:
 
   Mutex m_owner_client_id_lock;
   watch_notify::ClientId m_owner_client_id;
+
+  image_watcher::Notifier m_notifier;
 
   void schedule_cancel_async_requests();
   void cancel_async_requests();

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -230,9 +230,6 @@ private:
   void set_owner_client_id(const watch_notify::ClientId &client_id);
   watch_notify::ClientId get_client_id();
 
-  void execute_acquired_lock();
-  void execute_released_lock();
-  void execute_request_lock();
   void schedule_request_lock(bool use_timer, int timer_delay = -1);
 
   int notify_lock_owner(bufferlist &bl);

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -1,5 +1,6 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_LIBRBD_IMAGE_WATCHER_H
 #define CEPH_LIBRBD_IMAGE_WATCHER_H
 
@@ -50,8 +51,7 @@ public:
   void notify_released_lock();
   void notify_request_lock();
 
-  static void notify_header_update(librados::IoCtx &io_ctx,
-                                   const std::string &oid);
+  void notify_header_update(Context *on_finish);
 
   uint64_t get_watch_handle() const {
     RWLock::RLocker watch_locker(m_watch_lock);

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -35,6 +35,7 @@ librbd_internal_la_SOURCES = \
 	librbd/image/RefreshParentRequest.cc \
 	librbd/image/RefreshRequest.cc \
 	librbd/image/SetSnapRequest.cc \
+	librbd/image_watcher/Notifier.cc \
 	librbd/journal/Replay.cc \
 	librbd/object_map/InvalidateRequest.cc \
 	librbd/object_map/LockRequest.cc \
@@ -114,6 +115,7 @@ noinst_HEADERS += \
 	librbd/image/RefreshParentRequest.h \
 	librbd/image/RefreshRequest.h \
 	librbd/image/SetSnapRequest.h \
+	librbd/image_watcher/Notifier.h \
 	librbd/journal/Replay.h \
 	librbd/journal/Types.h \
 	librbd/object_map/InvalidateRequest.h \

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -36,6 +36,7 @@ librbd_internal_la_SOURCES = \
 	librbd/image/RefreshRequest.cc \
 	librbd/image/SetSnapRequest.cc \
 	librbd/image_watcher/Notifier.cc \
+	librbd/image_watcher/NotifyLockOwner.cc \
 	librbd/journal/Replay.cc \
 	librbd/object_map/InvalidateRequest.cc \
 	librbd/object_map/LockRequest.cc \
@@ -116,6 +117,7 @@ noinst_HEADERS += \
 	librbd/image/RefreshRequest.h \
 	librbd/image/SetSnapRequest.h \
 	librbd/image_watcher/Notifier.h \
+	librbd/image_watcher/NotifyLockOwner.h \
 	librbd/journal/Replay.h \
 	librbd/journal/Types.h \
 	librbd/object_map/InvalidateRequest.h \

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -231,6 +231,8 @@ int Operations<I>::rename(const char *dstname) {
       return r;
     }
   }
+
+  m_image_ctx.set_image_name(dstname);
   return 0;
 }
 

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -65,7 +65,6 @@ private:
                            bool permit_snapshot,
                            const boost::function<void(Context*)>& local_request,
                            const boost::function<int()>& remote_request);
-  void notify_change();
 };
 
 } // namespace librbd

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -27,5 +27,9 @@ std::string unique_lock_name(const std::string &name, void *address) {
   return name + " (" + stringify(address) + ")";
 }
 
+librados::AioCompletion *create_rados_ack_callback(Context *on_finish) {
+  return create_rados_ack_callback<Context, &Context::complete>(on_finish);
+}
+
 } // namespace util
 } // namespace librbd

--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -11,6 +11,14 @@ namespace watch_notify {
 
 namespace {
 
+class CheckForRefreshVisitor  : public boost::static_visitor<bool> {
+public:
+  template <typename Payload>
+  inline bool operator()(const Payload &payload) const {
+    return Payload::CHECK_FOR_REFRESH;
+  }
+};
+
 class EncodePayloadVisitor : public boost::static_visitor<void> {
 public:
   explicit EncodePayloadVisitor(bufferlist &bl) : m_bl(bl) {}
@@ -255,6 +263,10 @@ void UnknownPayload::decode(__u8 version, bufferlist::iterator &iter) {
 }
 
 void UnknownPayload::dump(Formatter *f) const {
+}
+
+bool NotifyMessage::check_for_refresh() const {
+  return boost::apply_visitor(CheckForRefreshVisitor(), payload);
 }
 
 void NotifyMessage::encode(bufferlist& bl) const {

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -92,6 +92,7 @@ enum NotifyOp {
 
 struct AcquiredLockPayload {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_ACQUIRED_LOCK;
+  static const bool CHECK_FOR_REFRESH = true;
 
   ClientId client_id;
 
@@ -105,6 +106,7 @@ struct AcquiredLockPayload {
 
 struct ReleasedLockPayload {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_RELEASED_LOCK;
+  static const bool CHECK_FOR_REFRESH = true;
 
   ClientId client_id;
 
@@ -118,6 +120,7 @@ struct ReleasedLockPayload {
 
 struct RequestLockPayload {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_REQUEST_LOCK;
+  static const bool CHECK_FOR_REFRESH = true;
 
   ClientId client_id;
 
@@ -131,6 +134,7 @@ struct RequestLockPayload {
 
 struct HeaderUpdatePayload {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_HEADER_UPDATE;
+  static const bool CHECK_FOR_REFRESH = false;
 
   void encode(bufferlist &bl) const;
   void decode(__u8 version, bufferlist::iterator &iter);
@@ -152,6 +156,7 @@ protected:
 
 struct AsyncProgressPayload : public AsyncRequestPayloadBase {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_ASYNC_PROGRESS;
+  static const bool CHECK_FOR_REFRESH = false;
 
   AsyncProgressPayload() : offset(0), total(0) {}
   AsyncProgressPayload(const AsyncRequestId &id, uint64_t offset_, uint64_t total_)
@@ -167,6 +172,7 @@ struct AsyncProgressPayload : public AsyncRequestPayloadBase {
 
 struct AsyncCompletePayload : public AsyncRequestPayloadBase {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_ASYNC_COMPLETE;
+  static const bool CHECK_FOR_REFRESH = false;
 
   AsyncCompletePayload() {}
   AsyncCompletePayload(const AsyncRequestId &id, int r)
@@ -181,6 +187,7 @@ struct AsyncCompletePayload : public AsyncRequestPayloadBase {
 
 struct FlattenPayload : public AsyncRequestPayloadBase {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_FLATTEN;
+  static const bool CHECK_FOR_REFRESH = true;
 
   FlattenPayload() {}
   FlattenPayload(const AsyncRequestId &id) : AsyncRequestPayloadBase(id) {}
@@ -188,6 +195,7 @@ struct FlattenPayload : public AsyncRequestPayloadBase {
 
 struct ResizePayload : public AsyncRequestPayloadBase {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_RESIZE;
+  static const bool CHECK_FOR_REFRESH = true;
 
   ResizePayload() : size(0) {}
   ResizePayload(uint64_t size_, const AsyncRequestId &id)
@@ -202,6 +210,8 @@ struct ResizePayload : public AsyncRequestPayloadBase {
 
 struct SnapPayloadBase {
 public:
+  static const bool CHECK_FOR_REFRESH = true;
+
   std::string snap_name;
 
   void encode(bufferlist &bl) const;
@@ -257,6 +267,7 @@ struct SnapUnprotectPayload : public SnapPayloadBase {
 
 struct RebuildObjectMapPayload : public AsyncRequestPayloadBase {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_REBUILD_OBJECT_MAP;
+  static const bool CHECK_FOR_REFRESH = true;
 
   RebuildObjectMapPayload() {}
   RebuildObjectMapPayload(const AsyncRequestId &id)
@@ -265,6 +276,7 @@ struct RebuildObjectMapPayload : public AsyncRequestPayloadBase {
 
 struct RenamePayload {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_RENAME;
+  static const bool CHECK_FOR_REFRESH = true;
 
   RenamePayload() {}
   RenamePayload(const std::string _image_name) : image_name(_image_name) {}
@@ -278,6 +290,7 @@ struct RenamePayload {
 
 struct UnknownPayload {
   static const NotifyOp NOTIFY_OP = static_cast<NotifyOp>(-1);
+  static const bool CHECK_FOR_REFRESH = false;
 
   void encode(bufferlist &bl) const;
   void decode(__u8 version, bufferlist::iterator &iter);
@@ -306,6 +319,8 @@ struct NotifyMessage {
   NotifyMessage(const Payload &payload_) : payload(payload_) {}
 
   Payload payload;
+
+  bool check_for_refresh() const;
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& it);

--- a/src/librbd/exclusive_lock/AcquireRequest.h
+++ b/src/librbd/exclusive_lock/AcquireRequest.h
@@ -35,6 +35,10 @@ private:
    * @verbatim
    *
    * <start>
+   *    |
+   *    v
+   * FLUSH_NOTIFIES
+   *    |
    *    |     /---------------------------------------------------------\
    *    |     |                                                         |
    *    |     |             (no lockers)                                |
@@ -80,6 +84,9 @@ private:
   uint64_t m_locker_handle;
 
   int m_error_result;
+
+  void send_flush_notifies();
+  Context *handle_flush_notifies(int *ret_val);
 
   void send_lock();
   Context *handle_lock(int *ret_val);

--- a/src/librbd/exclusive_lock/ReleaseRequest.h
+++ b/src/librbd/exclusive_lock/ReleaseRequest.h
@@ -36,7 +36,10 @@ private:
    * BLOCK_WRITES
    *    |
    *    v
-   * CANCEL_OP_REQUESTS . . . . . . . . . . . .
+   * CANCEL_OP_REQUESTS
+   *    |
+   *    v
+   * FLUSH_NOTIFIES . . . . . . . . . . . . . .
    *    |                                     .
    *    v                                     .
    * CLOSE_JOURNAL                            .
@@ -69,6 +72,9 @@ private:
 
   void send_cancel_op_requests();
   Context *handle_cancel_op_requests(int *ret_val);
+
+  void send_flush_notifies();
+  Context *handle_flush_notifies(int *ret_val);
 
   void send_close_journal();
   Context *handle_close_journal(int *ret_val);

--- a/src/librbd/image/CloseRequest.h
+++ b/src/librbd/image/CloseRequest.h
@@ -49,13 +49,16 @@ private:
    * SHUTDOWN_CACHE
    *    |
    *    v
-   * FLUSH_OP_WORK_QUEUE  . . . . .
-   *    |                         .
-   *    v                         .
-   * CLOSE_PARENT                 . (no parent)
-   *    |                         .
-   *    v                         .
-   * <finish> < . . . . . . . . . .
+   * FLUSH_OP_WORK_QUEUE . . . . .
+   *    |                        .
+   *    v                        .
+   * CLOSE_PARENT                . (no parent)
+   *    |                        .
+   *    v                        .
+   * FLUSH_IMAGE_WATCHER < . . . .
+   *    |
+   *    v
+   * <finish>
    *
    * @endverbatim
    */
@@ -92,6 +95,9 @@ private:
 
   void send_close_parent();
   void handle_close_parent(int r);
+
+  void send_flush_image_watcher();
+  void handle_flush_image_watcher(int r);
 
   void finish();
 

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -701,7 +701,7 @@ void RefreshRequest<I>::apply() {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << this << " " << __func__ << dendl;
 
-  RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
+  RWLock::WLocker owner_locker(m_image_ctx.owner_lock);
   RWLock::WLocker md_locker(m_image_ctx.md_lock);
 
   {

--- a/src/librbd/image/SetSnapRequest.cc
+++ b/src/librbd/image/SetSnapRequest.cc
@@ -309,9 +309,9 @@ int SetSnapRequest<I>::apply() {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 10) << __func__ << dendl;
 
+  RWLock::WLocker owner_locker(m_image_ctx.owner_lock);
   RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
   RWLock::WLocker parent_locker(m_image_ctx.parent_lock);
-
   if (m_snap_id != CEPH_NOSNAP) {
     int r = m_image_ctx.snap_set(m_snap_name);
     if (r < 0) {

--- a/src/librbd/image_watcher/Notifier.cc
+++ b/src/librbd/image_watcher/Notifier.cc
@@ -50,7 +50,7 @@ void Notifier::notify(bufferlist &bl, bufferlist *out_bl, Context *on_finish) {
   C_AioNotify *ctx = new C_AioNotify(this, on_finish);
   librados::AioCompletion *comp = util::create_rados_ack_callback(ctx);
   int r = m_image_ctx.md_ctx.aio_notify(m_image_ctx.header_oid, comp, bl,
-                                        NOTIFY_TIMEOUT, nullptr);
+                                        NOTIFY_TIMEOUT, out_bl);
   assert(r == 0);
   comp->release();
 }

--- a/src/librbd/image_watcher/Notifier.cc
+++ b/src/librbd/image_watcher/Notifier.cc
@@ -1,0 +1,76 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/image_watcher/Notifier.h"
+#include "common/WorkQueue.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::image_watcher::Notifier: "
+
+namespace librbd {
+namespace image_watcher {
+
+const uint64_t Notifier::NOTIFY_TIMEOUT = 5000;
+
+Notifier::Notifier(ImageCtx &image_ctx)
+  : m_image_ctx(image_ctx),
+    m_aio_notify_lock(util::unique_lock_name(
+      "librbd::image_watcher::Notifier::m_aio_notify_lock", this)) {
+}
+
+Notifier::~Notifier() {
+  Mutex::Locker aio_notify_locker(m_aio_notify_lock);
+  assert(m_pending_aio_notifies == 0);
+}
+
+void Notifier::flush(Context *on_finish) {
+  Mutex::Locker aio_notify_locker(m_aio_notify_lock);
+  if (m_pending_aio_notifies == 0) {
+    m_image_ctx.op_work_queue->queue(on_finish, 0);
+    return;
+  }
+
+  assert(m_aio_notify_flush == nullptr);
+  m_aio_notify_flush = on_finish;
+}
+
+void Notifier::notify(bufferlist &bl, bufferlist *out_bl, Context *on_finish) {
+  {
+    Mutex::Locker aio_notify_locker(m_aio_notify_lock);
+    ++m_pending_aio_notifies;
+
+    CephContext *cct = m_image_ctx.cct;
+    ldout(cct, 20) << __func__ << ": pending=" << m_pending_aio_notifies
+                   << dendl;
+  }
+
+  C_AioNotify *ctx = new C_AioNotify(this, on_finish);
+  librados::AioCompletion *comp = util::create_rados_ack_callback(ctx);
+  int r = m_image_ctx.md_ctx.aio_notify(m_image_ctx.header_oid, comp, bl,
+                                        NOTIFY_TIMEOUT, nullptr);
+  assert(r == 0);
+  comp->release();
+}
+
+void Notifier::handle_notify(int r, Context *on_finish) {
+  if (on_finish != nullptr) {
+    m_image_ctx.op_work_queue->queue(on_finish, r);
+  }
+
+  Mutex::Locker aio_notify_locker(m_aio_notify_lock);
+  assert(m_pending_aio_notifies > 0);
+  --m_pending_aio_notifies;
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << __func__ << ": pending=" << m_pending_aio_notifies
+                 << dendl;
+  if (m_pending_aio_notifies == 0 && m_aio_notify_flush != nullptr) {
+    m_image_ctx.op_work_queue->queue(m_aio_notify_flush, 0);
+  }
+}
+
+} // namespace image_watcher
+} // namespace librbd

--- a/src/librbd/image_watcher/Notifier.h
+++ b/src/librbd/image_watcher/Notifier.h
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IMAGE_WATCHER_NOTIFIER_H
+#define CEPH_LIBRBD_IMAGE_WATCHER_NOTIFIER_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+#include "include/Context.h"
+#include "common/Mutex.h"
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace image_watcher {
+
+class Notifier {
+public:
+  static const uint64_t NOTIFY_TIMEOUT;
+
+  Notifier(ImageCtx &image_ctx);
+  ~Notifier();
+
+  void flush(Context *on_finish);
+  void notify(bufferlist &bl, bufferlist *out_bl, Context *on_finish);
+
+private:
+  struct C_AioNotify : public Context {
+    Notifier *notifier;
+    Context *on_finish;
+
+    C_AioNotify(Notifier *notifier, Context *on_finish)
+      : notifier(notifier), on_finish(on_finish) {
+    }
+    virtual void finish(int r) override {
+      notifier->handle_notify(r, on_finish);
+    }
+  };
+
+  ImageCtx &m_image_ctx;
+
+  Mutex m_aio_notify_lock;
+  size_t m_pending_aio_notifies = 0;
+  Context *m_aio_notify_flush = nullptr;
+
+  void handle_notify(int r, Context *on_finish);
+
+};
+
+} // namespace image_watcher
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_IMAGE_WATCHER_NOTIFIER_H

--- a/src/librbd/image_watcher/Notifier.h
+++ b/src/librbd/image_watcher/Notifier.h
@@ -8,6 +8,7 @@
 #include "include/buffer.h"
 #include "include/Context.h"
 #include "common/Mutex.h"
+#include <list>
 
 namespace librbd {
 
@@ -26,6 +27,8 @@ public:
   void notify(bufferlist &bl, bufferlist *out_bl, Context *on_finish);
 
 private:
+  typedef std::list<Context*> Contexts;
+
   struct C_AioNotify : public Context {
     Notifier *notifier;
     Context *on_finish;
@@ -42,7 +45,7 @@ private:
 
   Mutex m_aio_notify_lock;
   size_t m_pending_aio_notifies = 0;
-  Context *m_aio_notify_flush = nullptr;
+  Contexts m_aio_notify_flush_ctxs;
 
   void handle_notify(int r, Context *on_finish);
 

--- a/src/librbd/image_watcher/NotifyLockOwner.cc
+++ b/src/librbd/image_watcher/NotifyLockOwner.cc
@@ -1,0 +1,105 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/image_watcher/NotifyLockOwner.h"
+#include "common/errno.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "librbd/WatchNotifyTypes.h"
+#include "librbd/image_watcher/Notifier.h"
+#include <map>
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::image_watcher::NotifyLockOwner: " \
+                           << this << " " << __func__
+
+namespace librbd {
+namespace image_watcher {
+
+using namespace watch_notify;
+using util::create_context_callback;
+
+NotifyLockOwner::NotifyLockOwner(ImageCtx &image_ctx, Notifier &notifier,
+                                 bufferlist &&bl, Context *on_finish)
+  : m_image_ctx(image_ctx), m_notifier(notifier), m_bl(std::move(bl)),
+    m_on_finish(on_finish) {
+}
+
+void NotifyLockOwner::send() {
+  send_notify();
+}
+
+void NotifyLockOwner::send_notify() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << dendl;
+
+  assert(m_image_ctx.owner_lock.is_locked());
+  m_notifier.notify(m_bl, &m_out_bl, create_context_callback<
+    NotifyLockOwner, &NotifyLockOwner::handle_notify>(this));
+}
+
+void NotifyLockOwner::handle_notify(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0 && r != -ETIMEDOUT) {
+    lderr(cct) << ": lock owner notification failed: " << cpp_strerror(r)
+               << dendl;
+    finish(r);
+    return;
+  }
+
+  typedef std::map<std::pair<uint64_t, uint64_t>, bufferlist> responses_t;
+  responses_t responses;
+  if (m_out_bl.length() > 0) {
+    try {
+      bufferlist::iterator iter = m_out_bl.begin();
+      ::decode(responses, iter);
+    } catch (const buffer::error &err) {
+      lderr(cct) << ": failed to decode response" << dendl;
+      finish(-EINVAL);
+      return;
+    }
+  }
+
+  bufferlist response;
+  bool lock_owner_responded = false;
+  for (responses_t::iterator i = responses.begin(); i != responses.end(); ++i) {
+    if (i->second.length() > 0) {
+      if (lock_owner_responded) {
+        lderr(cct) << ": duplicate lock owners detected" << dendl;
+        finish(-EINVAL);
+        return;
+      }
+      lock_owner_responded = true;
+      response.claim(i->second);
+    }
+  }
+
+  if (!lock_owner_responded) {
+    lderr(cct) << ": no lock owners detected" << dendl;
+    finish(-ETIMEDOUT);
+    return;
+  }
+
+  try {
+    bufferlist::iterator iter = response.begin();
+
+    ResponseMessage response_message;
+    ::decode(response_message, iter);
+
+    r = response_message.result;
+  } catch (const buffer::error &err) {
+    r = -EINVAL;
+  }
+  finish(r);
+}
+
+void NotifyLockOwner::finish(int r) {
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image_watcher
+} // namespace librbd

--- a/src/librbd/image_watcher/NotifyLockOwner.h
+++ b/src/librbd/image_watcher/NotifyLockOwner.h
@@ -1,0 +1,49 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IMAGE_WATCHER_NOTIFY_LOCK_OWNER_H
+#define CEPH_LIBRBD_IMAGE_WATCHER_NOTIFY_LOCK_OWNER_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+
+class Context;
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace image_watcher {
+
+class Notifier;
+
+class NotifyLockOwner {
+public:
+  static NotifyLockOwner *create(ImageCtx &image_ctx, Notifier &notifier,
+                                 bufferlist &&bl, Context *on_finish) {
+    return new NotifyLockOwner(image_ctx, notifier, std::move(bl), on_finish);
+  }
+
+  NotifyLockOwner(ImageCtx &image_ctx, Notifier &notifier, bufferlist &&bl,
+                  Context *on_finish);
+
+  void send();
+
+private:
+  ImageCtx &m_image_ctx;
+  Notifier &m_notifier;
+
+  bufferlist m_bl;
+  bufferlist m_out_bl;
+  Context *m_on_finish;
+
+  void send_notify();
+  void handle_notify(int r);
+
+  void finish(int r);
+};
+
+} // namespace image_watcher
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_IMAGE_WATCHER_NOTIFY_LOCK_OWNER_H

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -307,16 +307,6 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     return 0;
   }
 
-  int notify_change(IoCtx& io_ctx, const string& oid, ImageCtx *ictx)
-  {
-    if (ictx) {
-      ictx->state->handle_update_notification();
-    }
-
-    ImageWatcher::notify_header_update(io_ctx, oid);
-    return 0;
-  }
-
   int read_header(IoCtx& io_ctx, const string& header_oid,
 		  struct rbd_obj_header_ondisk *header, uint64_t *ver)
   {
@@ -1453,7 +1443,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       }
     }
 
-    notify_change(ictx->md_ctx, ictx->header_oid, ictx);
+    ictx->notify_update();
     return 0;
   }
 
@@ -1988,7 +1978,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       }
     }
 
-    notify_change(ictx->md_ctx, ictx->header_oid, ictx);
+    ictx->notify_update();
     return 0;
   }
 
@@ -2010,7 +2000,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       }
     }
 
-    notify_change(ictx->md_ctx, ictx->header_oid, ictx);
+    ictx->notify_update();
     return 0;
   }
 
@@ -2073,7 +2063,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
 				     RBD_LOCK_NAME, cookie, lock_client);
     if (r < 0)
       return r;
-    notify_change(ictx->md_ctx, ictx->header_oid, ictx);
+    ictx->notify_update();
     return 0;
   }
 

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -142,8 +142,6 @@ namespace librbd {
 
   int read_header_bl(librados::IoCtx& io_ctx, const std::string& md_oid,
 		     ceph::bufferlist& header, uint64_t *ver);
-  int notify_change(librados::IoCtx& io_ctx, const std::string& oid,
-		    ImageCtx *ictx);
   int read_header(librados::IoCtx& io_ctx, const std::string& md_oid,
 		  struct rbd_obj_header_ondisk *header, uint64_t *ver);
   int tmap_set(librados::IoCtx& io_ctx, const std::string& imgname);

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -8,6 +8,8 @@
 #include "librbd/AioCompletion.h"
 #include "librbd/AioImageRequest.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/ImageWatcher.h"
 #include "librbd/internal.h"
 #include "librbd/Operations.h"
 #include "librbd/Utils.h"
@@ -25,6 +27,32 @@ static const uint64_t IN_FLIGHT_IO_LOW_WATER_MARK(32);
 static const uint64_t IN_FLIGHT_IO_HIGH_WATER_MARK(64);
 
 static NoOpProgressContext no_op_progress_callback;
+
+template <typename I, typename E>
+struct ExecuteOp : public Context {
+  I &image_ctx;
+  E event;
+  Context *on_op_complete;
+
+  ExecuteOp(I &image_ctx, const E &event, Context *on_op_complete)
+    : image_ctx(image_ctx), event(event), on_op_complete(on_op_complete) {
+  }
+
+  void execute(const journal::SnapCreateEvent &_) {
+    image_ctx.operations->snap_create(event.snap_name.c_str(), on_op_complete,
+                                      event.op_tid);
+  }
+
+  void execute(const journal::ResizeEvent &_) {
+    image_ctx.operations->resize(event.size, no_op_progress_callback,
+                                 on_op_complete, event.op_tid);
+  }
+
+  virtual void finish(int r) override {
+    RWLock::RLocker owner_locker(image_ctx.owner_lock);
+    execute(event);
+  }
+};
 
 } // anonymous namespace
 
@@ -254,8 +282,10 @@ void Replay<I>::handle_event(const journal::SnapCreateEvent &event,
   Context *on_op_complete = create_op_context_callback(event.op_tid, on_safe,
                                                        &op_event);
 
-  m_image_ctx.operations->snap_create(event.snap_name.c_str(), on_op_complete,
-                                      event.op_tid);
+  // avoid lock cycles
+  m_image_ctx.op_work_queue->queue(
+    new ExecuteOp<I, journal::SnapCreateEvent>(m_image_ctx, event,
+                                               on_op_complete), 0);
 
   // do not process more events until the state machine is ready
   // since it will affect IO
@@ -391,8 +421,10 @@ void Replay<I>::handle_event(const journal::ResizeEvent &event,
   Context *on_op_complete = create_op_context_callback(event.op_tid, on_safe,
                                                        &op_event);
 
-  m_image_ctx.operations->resize(event.size, no_op_progress_callback,
-                                 on_op_complete, event.op_tid);
+  // avoid lock cycles
+  m_image_ctx.op_work_queue->queue(
+    new ExecuteOp<I, journal::ResizeEvent>(m_image_ctx, event,
+                                               on_op_complete), 0);
 
   // do not process more events until the state machine is ready
   // since it will affect IO

--- a/src/librbd/journal/Replay.h
+++ b/src/librbd/journal/Replay.h
@@ -46,6 +46,7 @@ private:
     Context *on_start_safe = nullptr;
     Context *on_finish_ready = nullptr;
     Context *on_finish_safe = nullptr;
+    Context *on_op_complete = nullptr;
   };
 
   typedef std::list<uint64_t> OpTids;

--- a/src/librbd/operation/RenameRequest.h
+++ b/src/librbd/operation/RenameRequest.h
@@ -80,6 +80,7 @@ private:
   void send_update_directory();
   void send_remove_source_header();
 
+  void apply();
 };
 
 } // namespace operation

--- a/src/librbd/operation/Request.h
+++ b/src/librbd/operation/Request.h
@@ -44,9 +44,7 @@ protected:
     if (image_ctx.journal != NULL) {
       Context *ctx = util::create_context_callback<T, MF>(request);
       if (image_ctx.journal->is_journal_replaying()) {
-        assert(m_op_tid != 0);
-        m_appended_op_event = true;
-        image_ctx.journal->replay_op_ready(m_op_tid, ctx);
+        replay_op_ready(ctx);
       } else {
         append_op_event(ctx);
       }
@@ -83,6 +81,7 @@ private:
   bool m_appended_op_event = false;
   bool m_committed_op_event = false;
 
+  void replay_op_ready(Context *on_safe);
   void append_op_event(Context *on_safe);
   void handle_op_event_safe(int r);
 

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -170,7 +170,8 @@ template <typename I>
 Context *SnapshotCreateRequest<I>::handle_allocate_snap_id(int *result) {
   I &image_ctx = this->m_image_ctx;
   CephContext *cct = image_ctx.cct;
-  ldout(cct, 5) << this << " " << __func__ << ": r=" << *result << dendl;
+  ldout(cct, 5) << this << " " << __func__ << ": r=" << *result << ", "
+                << "snap_id=" << m_snap_id << dendl;
 
   if (*result < 0) {
     save_result(result);

--- a/src/librbd/operation/SnapshotRollbackRequest.cc
+++ b/src/librbd/operation/SnapshotRollbackRequest.cc
@@ -279,6 +279,7 @@ Context *SnapshotRollbackRequest<I>::send_invalidate_cache() {
   CephContext *cct = image_ctx.cct;
   ldout(cct, 5) << this << " " << __func__ << dendl;
 
+  RWLock::RLocker owner_lock(image_ctx.owner_lock);
   Context *ctx = create_context_callback<
     SnapshotRollbackRequest<I>,
     &SnapshotRollbackRequest<I>::handle_invalidate_cache>(this);

--- a/src/test/librados_test_stub/TestWatchNotify.cc
+++ b/src/test/librados_test_stub/TestWatchNotify.cc
@@ -7,6 +7,8 @@
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 
+#define dout_subsys ceph_subsys_rados
+
 namespace librados {
 
 TestWatchNotify::TestWatchNotify(CephContext *cct, Finisher *finisher)
@@ -81,6 +83,9 @@ int TestWatchNotify::notify(const std::string& oid, bufferlist& bl,
 void TestWatchNotify::notify_ack(const std::string& o, uint64_t notify_id,
                                  uint64_t handle, uint64_t gid,
                                  bufferlist& bl) {
+  ldout(m_cct, 20) << __func__ << ": notify_id=" << notify_id << ", "
+                   << "handle=" << handle << ", "
+                   << "gid=" << gid << dendl;
   Mutex::Locker lock(m_lock);
   WatcherID watcher_id = std::make_pair(gid, handle);
   ack_notify(o, notify_id, watcher_id, bl);

--- a/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
@@ -141,6 +141,11 @@ public:
                 exec(mock_image_ctx.header_oid, _, "lock", "break_lock", _, _, _))
                   .WillOnce(Return(r));
   }
+
+  void expect_flush_notifies(MockImageCtx &mock_image_ctx) {
+    EXPECT_CALL(*mock_image_ctx.image_watcher, flush(_))
+                  .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
+  }
 };
 
 TEST_F(TestMockExclusiveLockAcquireRequest, Success) {
@@ -153,6 +158,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, Success) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, 0);
 
   MockObjectMap mock_object_map;
@@ -185,6 +191,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, SuccessJournalDisabled) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, 0);
 
   MockObjectMap mock_object_map;
@@ -214,6 +221,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, SuccessObjectMapDisabled) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, 0);
 
   expect_test_features(mock_image_ctx, RBD_FEATURE_OBJECT_MAP, false);
@@ -243,6 +251,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, JournalError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, 0);
 
   MockObjectMap *mock_object_map = new MockObjectMap();
@@ -275,6 +284,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, LockBusy) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -302,6 +312,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, -EINVAL, entity_name_t::CLIENT(1), "",
                        "", "", LOCK_EXCLUSIVE);
@@ -324,6 +335,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoEmpty) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, -ENOENT, entity_name_t::CLIENT(1), "",
                        "", "", LOCK_EXCLUSIVE);
@@ -347,6 +359,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoExternalTag) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", "external tag", LOCK_EXCLUSIVE);
@@ -369,6 +382,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoShared) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -392,6 +406,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetLockInfoExternalCookie) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "external cookie", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -415,6 +430,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetWatchersError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -439,6 +455,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, GetWatchersAlive) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -464,6 +481,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, BlacklistDisabled) {
   mock_image_ctx.blacklist_on_break_lock = false;
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -490,6 +508,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, BlacklistError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -515,6 +534,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, BreakLockMissing) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,
@@ -542,6 +562,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, BreakLockError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
   expect_lock(mock_image_ctx, -EBUSY);
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", MockExclusiveLock::WATCHER_LOCK_TAG,

--- a/src/test/librbd/exclusive_lock/test_mock_ReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_ReleaseRequest.cc
@@ -60,6 +60,11 @@ public:
     EXPECT_CALL(mock_object_map, close(_))
                   .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
   }
+
+  void expect_flush_notifies(MockImageCtx &mock_image_ctx) {
+    EXPECT_CALL(*mock_image_ctx.image_watcher, flush(_))
+                  .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
+  }
 };
 
 TEST_F(TestMockExclusiveLockReleaseRequest, Success) {
@@ -74,6 +79,7 @@ TEST_F(TestMockExclusiveLockReleaseRequest, Success) {
   InSequence seq;
   expect_block_writes(mock_image_ctx, 0);
   expect_cancel_op_requests(mock_image_ctx, 0);
+  expect_flush_notifies(mock_image_ctx);
 
   MockJournal *mock_journal = new MockJournal();
   mock_image_ctx.journal = mock_journal;
@@ -107,6 +113,7 @@ TEST_F(TestMockExclusiveLockReleaseRequest, SuccessJournalDisabled) {
 
   InSequence seq;
   expect_cancel_op_requests(mock_image_ctx, 0);
+  expect_flush_notifies(mock_image_ctx);
 
   MockObjectMap *mock_object_map = new MockObjectMap();
   mock_image_ctx.object_map = mock_object_map;
@@ -136,6 +143,7 @@ TEST_F(TestMockExclusiveLockReleaseRequest, SuccessObjectMapDisabled) {
 
   InSequence seq;
   expect_cancel_op_requests(mock_image_ctx, 0);
+  expect_flush_notifies(mock_image_ctx);
 
   expect_unlock(mock_image_ctx, 0);
 
@@ -182,6 +190,7 @@ TEST_F(TestMockExclusiveLockReleaseRequest, UnlockError) {
   InSequence seq;
   expect_block_writes(mock_image_ctx, 0);
   expect_cancel_op_requests(mock_image_ctx, 0);
+  expect_flush_notifies(mock_image_ctx);
 
   expect_unlock(mock_image_ctx, -EINVAL);
 

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -8,6 +8,7 @@
 #include "test/librbd/mock/MockObjectMap.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "librbd/ImageState.h"
 #include "librbd/internal.h"
 #include "librbd/Operations.h"
 #include "librbd/image/RefreshRequest.h"
@@ -287,6 +288,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessSnapshotV1) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, snap_create(*ictx, "snap"));
+  ASSERT_EQ(0, ictx->state->refresh());
 
   MockImageCtx mock_image_ctx(*ictx);
   expect_op_work_queue(mock_image_ctx);

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -141,6 +141,9 @@ struct MockImageCtx {
   MOCK_METHOD1(create_object_map, MockObjectMap*(uint64_t));
   MOCK_METHOD0(create_journal, MockJournal*());
 
+  MOCK_METHOD0(notify_update, void());
+  MOCK_METHOD1(notify_update, void(Context *));
+
   ImageCtx *image_ctx;
   CephContext *cct;
 

--- a/src/test/librbd/mock/MockImageWatcher.h
+++ b/src/test/librbd/mock/MockImageWatcher.h
@@ -6,10 +6,13 @@
 
 #include "gmock/gmock.h"
 
+class Context;
+
 namespace librbd {
 
 struct MockImageWatcher {
   MOCK_METHOD0(unregister_watch, void());
+  MOCK_METHOD1(flush, void(Context *));
 
   MOCK_CONST_METHOD0(get_watch_handle, uint64_t());
 

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -352,7 +352,7 @@ TEST_F(TestImageWatcher, NotifyHeaderUpdate) {
   ASSERT_EQ(0, register_image_watch(*ictx));
 
   m_notify_acks = {{NOTIFY_OP_HEADER_UPDATE, {}}};
-  librbd::ImageWatcher::notify_header_update(m_ioctx, ictx->header_oid);
+  ictx->notify_update();
 
   ASSERT_TRUE(wait_for_notifies(*ictx));
 

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -300,6 +300,10 @@ TEST_F(TestImageWatcher, NotifyRequestLock) {
   m_notify_acks = {{NOTIFY_OP_REQUEST_LOCK, {}}};
   ictx->image_watcher->notify_request_lock();
 
+  C_SaferCond ctx;
+  ictx->image_watcher->flush(&ctx);
+  ctx.wait();
+
   ASSERT_TRUE(wait_for_notifies(*ictx));
 
   NotifyOps expected_notify_ops;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -3761,6 +3761,7 @@ TEST_F(TestLibRBD, ExclusiveLockTransition)
     comps.pop_front();
     ASSERT_EQ(0, comp->wait_for_complete());
     ASSERT_EQ(1, comp->is_complete());
+    comp->release();
   }
 
   librbd::Image image3;

--- a/src/test/librbd/test_mock_ExclusiveLock.cc
+++ b/src/test/librbd/test_mock_ExclusiveLock.cc
@@ -129,6 +129,11 @@ public:
                   .WillRepeatedly(Return(true));
   }
 
+  void expect_flush_notifies(MockImageCtx &mock_image_ctx) {
+    EXPECT_CALL(*mock_image_ctx.image_watcher, flush(_))
+                  .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
+  }
+
   int when_init(MockImageCtx &mock_image_ctx,
                 MockExclusiveLock &exclusive_lock) {
     C_SaferCond ctx;
@@ -262,6 +267,7 @@ TEST_F(TestMockExclusiveLock, TryLockAlreadyLocked) {
   ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
 
   expect_unblock_writes(mock_image_ctx);
+  expect_flush_notifies(mock_image_ctx);
   ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
 }
 
@@ -285,6 +291,7 @@ TEST_F(TestMockExclusiveLock, TryLockBusy) {
   ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
 
   expect_unblock_writes(mock_image_ctx);
+  expect_flush_notifies(mock_image_ctx);
   ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
 }
 
@@ -309,6 +316,7 @@ TEST_F(TestMockExclusiveLock, TryLockError) {
   ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
 
   expect_unblock_writes(mock_image_ctx);
+  expect_flush_notifies(mock_image_ctx);
   ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
 }
 
@@ -359,6 +367,7 @@ TEST_F(TestMockExclusiveLock, RequestLockBlacklist) {
   ASSERT_FALSE(is_lock_owner(mock_image_ctx, exclusive_lock));
 
   expect_unblock_writes(mock_image_ctx);
+  expect_flush_notifies(mock_image_ctx);
   ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
 }
 
@@ -437,6 +446,7 @@ TEST_F(TestMockExclusiveLock, ReleaseLockUnlockedState) {
   ASSERT_EQ(0, when_release_lock(mock_image_ctx, exclusive_lock));
 
   expect_unblock_writes(mock_image_ctx);
+  expect_flush_notifies(mock_image_ctx);
   ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
 }
 
@@ -542,7 +552,7 @@ TEST_F(TestMockExclusiveLock, ConcurrentRequests) {
   ASSERT_EQ(0, release_lock_ctx1.wait());
 
   expect_unblock_writes(mock_image_ctx);
-  expect_op_work_queue(mock_image_ctx);
+  expect_flush_notifies(mock_image_ctx);
   ASSERT_EQ(0, when_shut_down(mock_image_ctx, exclusive_lock));
 }
 

--- a/src/test/librbd/test_mock_fixture.cc
+++ b/src/test/librbd/test_mock_fixture.cc
@@ -37,6 +37,8 @@ void TestMockFixture::SetUpTestCase() {
 void TestMockFixture::TearDownTestCase() {
   TestFixture::TearDownTestCase();
   librados_test_stub::set_rados_client(s_test_rados_client);
+  s_test_rados_client->put();
+  s_test_rados_client.reset();
 }
 
 void TestMockFixture::SetUp() {


### PR DESCRIPTION
There is a possible edge condition when multiple images are opened and a refresh is required.  The WorkQueue will be blocked waiting for the notification to be ACKed, but it cannot be ACKed until the (blocked) refresh is complete.

This also includes minor modifications (and associated tests) to ensure librbd and properly replay uncommitted events followed by resuming live ops without upsetting lockdep.