### PR TITLE
osd: bluestore: kick out onodes from onode_map as soon as they are removed

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -498,6 +498,16 @@ void BlueStore::OnodeHashLRU::add(const ghobject_t& oid, OnodeRef o)
   lru.push_front(*o);
 }
 
+void BlueStore::OnodeHashLRU::remove(OnodeRef o)
+{
+  std::lock_guard<std::mutex> l(lock);
+  dout(30) << __func__ << " " << o->oid << " " << o << dendl;
+  lru_list_t::iterator p = lru.iterator_to(*o);
+  lru.erase(p);
+  assert(onode_map.count(o->oid));
+  onode_map.erase(o->oid);
+}
+
 BlueStore::OnodeRef BlueStore::OnodeHashLRU::lookup(const ghobject_t& oid)
 {
   std::lock_guard<std::mutex> l(lock);
@@ -5909,6 +5919,7 @@ int BlueStore::_do_remove(
   }
   o->exists = false;
   o->onode = bluestore_onode_t();
+  c->onode_map.remove(o);
   txc->onodes.erase(o);
   txc->t->rmkey(PREFIX_OBJ, o->key);
   return 0;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -186,6 +186,7 @@ public:
 
     void add(const ghobject_t& oid, OnodeRef o);
     void _touch(OnodeRef o);
+    void remove(OnodeRef o);
     OnodeRef lookup(const ghobject_t& o);
     void rename(const ghobject_t& old_oid, const ghobject_t& new_oid);
     void clear();


### PR DESCRIPTION
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>