### PR TITLE
hammer: test_bit_vector.cc uses magic numbers against #defines that vary

### DIFF
--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -35,6 +35,7 @@ private:
   BOOST_STATIC_ASSERT((_bit_count != 0) && !(_bit_count & (_bit_count - 1)));
   BOOST_STATIC_ASSERT(_bit_count <= BITS_PER_BYTE);
 public:
+  static const uint32_t BLOCK_SIZE;
 
   class ConstReference {
   public:
@@ -111,6 +112,9 @@ private:
 };
 
 template <uint8_t _b>
+const uint32_t BitVector<_b>::BLOCK_SIZE = 4096;
+
+template <uint8_t _b>
 BitVector<_b>::BitVector() : m_size(0), m_crc_enabled(true)
 {
 }
@@ -135,7 +139,7 @@ void BitVector<_b>::resize(uint64_t size) {
   }
   m_size = size;
 
-  uint64_t block_count = (buffer_size + CEPH_PAGE_SIZE - 1) / CEPH_PAGE_SIZE;
+  uint64_t block_count = (buffer_size + BLOCK_SIZE - 1) / BLOCK_SIZE;
   m_data_crcs.resize(block_count);
 }
 
@@ -190,26 +194,26 @@ uint64_t BitVector<_b>::get_header_length() const {
 template <uint8_t _b>
 void BitVector<_b>::encode_data(bufferlist& bl, uint64_t byte_offset,
 				uint64_t byte_length) const {
-  assert(byte_offset % CEPH_PAGE_SIZE == 0);
+  assert(byte_offset % BLOCK_SIZE == 0);
   assert(byte_offset + byte_length == m_data.length() ||
-	 byte_length % CEPH_PAGE_SIZE == 0);
+	 byte_length % BLOCK_SIZE == 0);
 
   uint64_t end_offset = byte_offset + byte_length;
   while (byte_offset < end_offset) {
-    uint64_t len = MIN(CEPH_PAGE_SIZE, end_offset - byte_offset);
+    uint64_t len = MIN(BLOCK_SIZE, end_offset - byte_offset);
 
     bufferlist bit;
     bit.substr_of(m_data, byte_offset, len);
-    m_data_crcs[byte_offset / CEPH_PAGE_SIZE] = bit.crc32c(0);
+    m_data_crcs[byte_offset / BLOCK_SIZE] = bit.crc32c(0);
 
     bl.claim_append(bit);
-    byte_offset += CEPH_PAGE_SIZE;
+    byte_offset += BLOCK_SIZE;
   }
 }
 
 template <uint8_t _b>
 void BitVector<_b>::decode_data(bufferlist::iterator& it, uint64_t byte_offset) {
-  assert(byte_offset % CEPH_PAGE_SIZE == 0);
+  assert(byte_offset % BLOCK_SIZE == 0);
   if (it.end()) {
     return;
   }
@@ -225,12 +229,12 @@ void BitVector<_b>::decode_data(bufferlist::iterator& it, uint64_t byte_offset) 
   }
 
   while (byte_offset < end_offset) {
-    uint64_t len = MIN(CEPH_PAGE_SIZE, end_offset - byte_offset);
+    uint64_t len = MIN(BLOCK_SIZE, end_offset - byte_offset);
 
     bufferlist bit;
     it.copy(len, bit);
     if (m_crc_enabled &&
-	m_data_crcs[byte_offset / CEPH_PAGE_SIZE] != bit.crc32c(0)) {
+	m_data_crcs[byte_offset / BLOCK_SIZE] != bit.crc32c(0)) {
       throw buffer::malformed_input("invalid data block CRC");
     }
     data.append(bit);
@@ -250,15 +254,15 @@ template <uint8_t _b>
 void BitVector<_b>::get_data_extents(uint64_t offset, uint64_t length,
 				     uint64_t *byte_offset,
 				     uint64_t *byte_length) const {
-  // read CEPH_PAGE_SIZE-aligned chunks
+  // read BLOCK_SIZE-aligned chunks
   assert(length > 0 && offset + length <= m_size);
   uint64_t shift;
   compute_index(offset, byte_offset, &shift);
-  *byte_offset -= (*byte_offset % CEPH_PAGE_SIZE);
+  *byte_offset -= (*byte_offset % BLOCK_SIZE);
 
   uint64_t end_offset;
   compute_index(offset + length - 1, &end_offset, &shift);
-  end_offset += (CEPH_PAGE_SIZE - (end_offset % CEPH_PAGE_SIZE));
+  end_offset += (BLOCK_SIZE - (end_offset % BLOCK_SIZE));
   assert(*byte_offset <= end_offset);
 
   *byte_length = end_offset - *byte_offset;
@@ -292,7 +296,7 @@ void BitVector<_b>::decode_footer(bufferlist::iterator& it) {
       throw buffer::malformed_input("incorrect header CRC");
     }
 
-    uint64_t block_count = (m_data.length() + CEPH_PAGE_SIZE - 1) / CEPH_PAGE_SIZE;
+    uint64_t block_count = (m_data.length() + BLOCK_SIZE - 1) / BLOCK_SIZE;
     ::decode(m_data_crcs, footer_it);
     if (m_data_crcs.size() != block_count) {
       throw buffer::malformed_input("invalid data block CRCs");

--- a/src/test/common/test_bit_vector.cc
+++ b/src/test/common/test_bit_vector.cc
@@ -88,21 +88,22 @@ TYPED_TEST(BitVectorTest, get_set) {
 TYPED_TEST(BitVectorTest, get_buffer_extents) {
   typename TestFixture::bit_vector_t bit_vector;
 
-  uint64_t element_count = 2 * CEPH_PAGE_SIZE + 51;
+  uint64_t element_count = 2 * bit_vector.BLOCK_SIZE + 51;
   uint64_t elements_per_byte = 8 / bit_vector.BIT_COUNT;
   bit_vector.resize(element_count * elements_per_byte);
 
-  uint64_t offset = (CEPH_PAGE_SIZE + 11) * elements_per_byte;
-  uint64_t length = (CEPH_PAGE_SIZE + 31) * elements_per_byte;
+  uint64_t offset = (bit_vector.BLOCK_SIZE + 11) * elements_per_byte;
+  uint64_t length = (bit_vector.BLOCK_SIZE + 31) * elements_per_byte;
   uint64_t byte_offset;
   uint64_t byte_length;
   bit_vector.get_data_extents(offset, length, &byte_offset, &byte_length);
-  ASSERT_EQ(CEPH_PAGE_SIZE, byte_offset);
-  ASSERT_EQ(CEPH_PAGE_SIZE + (element_count % CEPH_PAGE_SIZE), byte_length);
+  ASSERT_EQ(bit_vector.BLOCK_SIZE, byte_offset);
+  ASSERT_EQ(bit_vector.BLOCK_SIZE + (element_count % bit_vector.BLOCK_SIZE),
+            byte_length);
 
   bit_vector.get_data_extents(1, 1, &byte_offset, &byte_length);
   ASSERT_EQ(0U, byte_offset);
-  ASSERT_EQ(CEPH_PAGE_SIZE, byte_length);
+  ASSERT_EQ(bit_vector.BLOCK_SIZE, byte_length);
 }
 
 TYPED_TEST(BitVectorTest, get_header_length) {
@@ -155,11 +156,11 @@ TYPED_TEST(BitVectorTest, partial_decode_encode) {
 
   Extents extents = boost::assign::list_of(
     std::make_pair(0, 1))(
-    std::make_pair((CEPH_PAGE_SIZE * elements_per_byte) - 2, 4))(
-    std::make_pair((CEPH_PAGE_SIZE * elements_per_byte) + 2, 2))(
-    std::make_pair((2 * CEPH_PAGE_SIZE * elements_per_byte) - 2, 4))(
-    std::make_pair((2 * CEPH_PAGE_SIZE * elements_per_byte) + 2, 2))(
-    std::make_pair(2, 2 * CEPH_PAGE_SIZE));
+    std::make_pair((bit_vector.BLOCK_SIZE * elements_per_byte) - 2, 4))(
+    std::make_pair((bit_vector.BLOCK_SIZE * elements_per_byte) + 2, 2))(
+    std::make_pair((2 * bit_vector.BLOCK_SIZE * elements_per_byte) - 2, 4))(
+    std::make_pair((2 * bit_vector.BLOCK_SIZE * elements_per_byte) + 2, 2))(
+    std::make_pair(2, 2 * bit_vector.BLOCK_SIZE));
   for (Extents::iterator it = extents.begin(); it != extents.end(); ++it) {
     uint64_t element_offset = it->first;
     uint64_t element_length = it->second;
@@ -224,8 +225,8 @@ TYPED_TEST(BitVectorTest, data_crc) {
   typename TestFixture::bit_vector_t bit_vector2;
 
   uint64_t elements_per_byte = 8 / bit_vector1.BIT_COUNT;
-  bit_vector1.resize((CEPH_PAGE_SIZE + 1) * elements_per_byte);
-  bit_vector2.resize((CEPH_PAGE_SIZE + 1) * elements_per_byte);
+  bit_vector1.resize((bit_vector1.BLOCK_SIZE + 1) * elements_per_byte);
+  bit_vector2.resize((bit_vector2.BLOCK_SIZE + 1) * elements_per_byte);
 
   uint64_t byte_offset;
   uint64_t byte_length;
@@ -236,7 +237,7 @@ TYPED_TEST(BitVectorTest, data_crc) {
   bit_vector1.encode_data(data, byte_offset, byte_length);
 
   bufferlist::iterator data_it = data.begin();
-  bit_vector1.decode_data(data_it, byte_offset); 
+  bit_vector1.decode_data(data_it, byte_offset);
 
   bit_vector2[bit_vector2.size() - 1] = 1;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/14783