### PR TITLE
rgw: move signal.h dependency from rgw_front.h

### DIFF
--- a/src/rgw/rgw_frontend.cc
+++ b/src/rgw/rgw_frontend.cc
@@ -1,8 +1,9 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "rgw_frontend.h"
+#include <signal.h>
 
+#include "rgw_frontend.h"
 #include "include/str_list.h"
 
 #include "include/assert.h"
@@ -76,4 +77,10 @@ bool RGWFrontendConfig::get_val(const string& key, int def_val, int *out)
     return -EINVAL;
   }
   return 0;
+}
+
+void RGWProcessFrontend::stop()
+{
+  pprocess->close_fd();
+  thread->kill(SIGUSR1);
 }

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -102,10 +102,7 @@ public:
     return 0;
   }
 
-  void stop() {
-    pprocess->close_fd();
-    thread->kill(SIGUSR1);
-  }
+  void stop();
 
   void join() {
     thread->join();


### PR DESCRIPTION
Missed in refactoring of rgw_main.cc.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>