### PR TITLE
common: various fixes from SCA runs

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4816,6 +4816,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, MClient
 
 int Client::_getgrouplist(gid_t** sgids, int uid, int gid)
 {
+  // cppcheck-suppress variableScope
   int sgid_count;
   gid_t *sgid_buf;
 
@@ -4875,9 +4876,8 @@ int Client::inode_permission(Inode *in, uid_t uid, UserGroups& groups, unsigned 
   if (uid == 0)
     return 0;
 
-  int ret;
   if (uid != in->uid && (in->mode & S_IRWXG)) {
-    ret = _posix_acl_permission(in, uid, groups, want);
+    int ret = _posix_acl_permission(in, uid, groups, want);
     if (ret != -EAGAIN)
       return ret;
   }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -171,8 +171,8 @@ bool Client::CommandHook::call(std::string command, cmdmap_t& cmdmap,
 // -------------
 
 dir_result_t::dir_result_t(Inode *in)
-  : inode(in), offset(0), this_offset(2), next_offset(2),
-    release_count(0), ordered_count(0), start_shared_gen(0),
+  : inode(in), owner_uid(-1), owner_gid(-1), offset(0), this_offset(2),
+    next_offset(2), release_count(0), ordered_count(0), start_shared_gen(0),
     buffer(0) {
 }
 

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -2401,13 +2401,8 @@ int SyntheticClient::object_rw(int nobj, int osize, int wrpc,
 int SyntheticClient::read_random(string& fn, int size, int rdsize)   // size is in MB, wrsize in bytes
 {
   uint64_t chunks = (uint64_t)size * (uint64_t)(1024*1024) / (uint64_t)rdsize;
-
   int fd = client->open(fn.c_str(), O_RDWR);
   dout(5) << "reading from " << fn << " fd " << fd << dendl;
-   
- // dout(0) << "READING FROM  " << fn << " fd " << fd << dendl;
-
- // dout(0) << "filename " << fn << " size:" << size  << " read size|" << rdsize << "|" <<  "\ chunks: |" << chunks <<"|" <<  dendl;
 
   if (fd < 0) return fd;
   int offset = 0;
@@ -2425,97 +2420,71 @@ int SyntheticClient::read_random(string& fn, int size, int rdsize)   // size is 
     // use rand instead ??
     double x = drand48();
 
-    //dout(0) << "RANDOM NUMBER RETURN |" << x << "|" << dendl;
-
     // cleanup before call 'new'
     if (buf != NULL) {
 	delete[] buf;
 	buf = NULL;
     }
-    if ( x < 0.5) 
-    {
-        //dout(0) << "DECIDED TO READ " << x << dendl;
+    if (x < 0.5) {
         buf = new char[rdsize]; 
         memset(buf, 1, rdsize);
         read=true;
-    }
-    else
-    {
-       // dout(0) << "DECIDED TO WRITE " << x << dendl;
+    } else {
         buf = new char[rdsize+100];   // 1 MB
         memset(buf, 7, rdsize);
     }
-
-    //double  y  = drand48() ;
-
-    //dout(0) << "OFFSET is |" << offset << "| chunks |" << chunks<<  dendl;
     
-    if ( read)
-    {
+    if (read) {
         offset=(rand())%(chunks+1);
         dout(2) << "reading block " << offset << "/" << chunks << dendl;
 
-        int r = client->read(fd, buf, rdsize,
-                        offset*rdsize);
+        int r = client->read(fd, buf, rdsize, offset*rdsize);
         if (r < rdsize) {
-                  dout(1) << "read_file got r = " << r << ", probably end of file" << dendl;
-    }
-    }
-    else
-    {
-        dout(2) << "writing block " << offset << "/" << chunks << dendl;
+	  dout(1) << "read_file got r = " << r << ", probably end of file" << dendl;
+	}
+    } else {
+      dout(2) << "writing block " << offset << "/" << chunks << dendl;
 
-    // fill buf with a 16 byte fingerprint
-    // 64 bits : file offset
-    // 64 bits : client id
-    // = 128 bits (16 bytes)
-
-      //if (true )
-      //{
-      //int count = rand()%10;
-
-      //for ( int j=0;j<count; j++ )
-      //{
+      // fill buf with a 16 byte fingerprint
+      // 64 bits : file offset
+      // 64 bits : client id
+      // = 128 bits (16 bytes)
 
       offset=(rand())%(chunks+1);
-    uint64_t *p = (uint64_t*)buf;
-    while ((char*)p < buf + rdsize) {
-      *p = offset*rdsize + (char*)p - buf;      
-      p++;
-      *p = client->get_nodeid().v;
-      p++;
-    }
+      uint64_t *p = (uint64_t*)buf;
+      while ((char*)p < buf + rdsize) {
+	*p = offset*rdsize + (char*)p - buf;      
+	p++;
+	*p = client->get_nodeid().v;
+	p++;
+      }
 
       client->write(fd, buf, rdsize,
                         offset*rdsize);
-      //}
-      //}
     }
 
     // verify fingerprint
-    if ( read )
-    {
-    int bad = 0;
-    int64_t *p = (int64_t*)buf;
-    int64_t readoff, readclient;
-    while ((char*)p + 32 < buf + rdsize) {
-      readoff = *p;
-      int64_t wantoff = offset*rdsize + (int64_t)((char*)p - buf);
-      p++;
-      readclient = *p;
-      p++;
-      if (readoff != wantoff ||
-	  readclient != client->get_nodeid()) {
-        if (!bad)
-          dout(0) << "WARNING: wrong data from OSD, block says fileoffset=" << readoff << " client=" << readclient
-		  << ", should be offset " << wantoff << " clietn " << client->get_nodeid()
-		  << dendl;
-        bad++;
+    if (read) {
+      int bad = 0;
+      int64_t *p = (int64_t*)buf;
+      int64_t readoff, readclient;
+      while ((char*)p + 32 < buf + rdsize) {
+	readoff = *p;
+	int64_t wantoff = offset*rdsize + (int64_t)((char*)p - buf);
+	p++;
+	readclient = *p;
+	p++;
+	if (readoff != wantoff || readclient != client->get_nodeid()) {
+	  if (!bad)
+	    dout(0) << "WARNING: wrong data from OSD, block says fileoffset=" << readoff << " client=" << readclient
+		    << ", should be offset " << wantoff << " clietn " << client->get_nodeid()
+		    << dendl;
+	  bad++;
+	}
       }
+      if (bad) 
+	dout(0) << " + " << (bad-1) << " other bad 16-byte bits in this block" << dendl;
     }
-    if (bad) 
-      dout(0) << " + " << (bad-1) << " other bad 16-byte bits in this block" << dendl;
-  }
   }
   
   client->close(fd);
@@ -2523,19 +2492,6 @@ int SyntheticClient::read_random(string& fn, int size, int rdsize)   // size is 
 
   return 0;
 }
-
-
-//#include<stdio.h>
-//#include<stdlib.h>
-
-int normdist(int min, int max, int stdev) /* specifies input values */;
-//main()
-//{
- // for ( int i=0; i < 10; i++ )
- //  normdist ( 0 , 10, 1 );
-   
-//}
-
 
 int normdist(int min, int max, int stdev) /* specifies input values */
 {
@@ -2574,13 +2530,8 @@ int normdist(int min, int max, int stdev) /* specifies input values */
 int SyntheticClient::read_random_ex(string& fn, int size, int rdsize)   // size is in MB, wrsize in bytes
 {
   uint64_t chunks = (uint64_t)size * (uint64_t)(1024*1024) / (uint64_t)rdsize;
-  
   int fd = client->open(fn.c_str(), O_RDWR);
   dout(5) << "reading from " << fn << " fd " << fd << dendl;
-  
-  // dout(0) << "READING FROM  " << fn << " fd " << fd << dendl;
-  
-  // dout(0) << "filename " << fn << " size:" << size  << " read size|" << rdsize << "|" <<  "\ chunks: |" << chunks <<"|" <<  dendl;
   
   if (fd < 0) return fd;
   int offset = 0;
@@ -2598,53 +2549,29 @@ int SyntheticClient::read_random_ex(string& fn, int size, int rdsize)   // size 
     // use rand instead ??
     double x = drand48();
     
-    //dout(0) << "RANDOM NUMBER RETURN |" << x << "|" << dendl;
-    
     // cleanup before call 'new'
     if (buf != NULL) {
-	delete[] buf;
-	buf = NULL;
+      delete[] buf;
+      buf = NULL;
     }
-    if ( x < 0.5) 
-      {
-        //dout(0) << "DECIDED TO READ " << x << dendl;
-        buf = new char[rdsize]; 
-        memset(buf, 1, rdsize);
-        read=true;
-      }
-    else
-      {
-	// dout(0) << "DECIDED TO WRITE " << x << dendl;
-        buf = new char[rdsize+100];   // 1 MB
-        memset(buf, 7, rdsize);
-      }
+    if (x < 0.5) {
+      buf = new char[rdsize]; 
+      memset(buf, 1, rdsize);
+      read=true;
+    } else {
+      buf = new char[rdsize+100];   // 1 MB
+      memset(buf, 7, rdsize);
+    }
     
-    //double  y  = drand48() ;
-    
-    //dout(0) << "OFFSET is |" << offset << "| chunks |" << chunks<<  dendl;
-    
-    if ( read)
-      {
-        //offset=(rand())%(chunks+1);
+    if (read) {
+      dout(2) << "reading block " << offset << "/" << chunks << dendl;
 	
-	/*    if ( chunks > 10000 ) 
-	      offset= normdist( 0 , chunks/1000 , 5  )*1000;
-	      else if ( chunks > 1000 )
-	      offset= normdist( 0 , chunks/100 , 5  )*100;
-	      else if ( chunks > 100 )
-	      offset= normdist( 0 , chunks/20 , 5  )*20;*/
-	
-	
-        dout(2) << "reading block " << offset << "/" << chunks << dendl;
-	
-        int r = client->read(fd, buf, rdsize,
+      int r = client->read(fd, buf, rdsize,
 			     offset*rdsize);
-        if (r < rdsize) {
-	  dout(1) << "read_file got r = " << r << ", probably end of file" << dendl;
-	}
+      if (r < rdsize) {
+	dout(1) << "read_file got r = " << r << ", probably end of file" << dendl;
       }
-    else
-      {
+    } else {
         dout(2) << "writing block " << offset << "/" << chunks << dendl;
 	
 	// fill buf with a 16 byte fingerprint
@@ -2652,52 +2579,44 @@ int SyntheticClient::read_random_ex(string& fn, int size, int rdsize)   // size 
 	// 64 bits : client id
 	// = 128 bits (16 bytes)
 	
-	//if (true )
-	//{
 	int count = rand()%10;
 	
-	for ( int j=0;j<count; j++ )
-	  {
-	    
-	    offset=(rand())%(chunks+1);
-	    uint64_t *p = (uint64_t*)buf;
-	    while ((char*)p < buf + rdsize) {
-	      *p = offset*rdsize + (char*)p - buf;      
-	      p++;
-	      *p = client->get_nodeid().v;
-	      p++;
-	    }
-	    
-	    client->write(fd, buf, rdsize,
-			  offset*rdsize);
+	for ( int j=0;j<count; j++ ) {
+	  offset=(rand())%(chunks+1);
+	  uint64_t *p = (uint64_t*)buf;
+	  while ((char*)p < buf + rdsize) {
+	    *p = offset*rdsize + (char*)p - buf;      
+	    p++;
+	    *p = client->get_nodeid().v;
+	    p++;
 	  }
-	//}
-      }
+	    
+	  client->write(fd, buf, rdsize, offset*rdsize);
+	}
+    }
     
     // verify fingerprint
-    if ( read )
-      {
-	int bad = 0;
-	int64_t *p = (int64_t*)buf;
-	int64_t readoff, readclient;
-	while ((char*)p + 32 < buf + rdsize) {
-	  readoff = *p;
-	  int64_t wantoff = offset*rdsize + (int64_t)((char*)p - buf);
-	  p++;
-	  readclient = *p;
-	  p++;
-	  if (readoff != wantoff ||
-	      readclient != client->get_nodeid()) {
-	    if (!bad)
-	      dout(0) << "WARNING: wrong data from OSD, block says fileoffset=" << readoff << " client=" << readclient
-		      << ", should be offset " << wantoff << " clietn " << client->get_nodeid()
-		      << dendl;
-	    bad++;
-	  }
+    if (read) {
+      int bad = 0;
+      int64_t *p = (int64_t*)buf;
+      int64_t readoff, readclient;
+      while ((char*)p + 32 < buf + rdsize) {
+	readoff = *p;
+	int64_t wantoff = offset*rdsize + (int64_t)((char*)p - buf);
+	p++;
+	readclient = *p;
+	p++;
+	if (readoff != wantoff || readclient != client->get_nodeid()) { 
+	  if (!bad)
+	    dout(0) << "WARNING: wrong data from OSD, block says fileoffset=" << readoff << " client=" << readclient
+		    << ", should be offset " << wantoff << " clietn " << client->get_nodeid()
+		    << dendl;
+	  bad++;
 	}
-	if (bad) 
-	  dout(0) << " + " << (bad-1) << " other bad 16-byte bits in this block" << dendl;
       }
+      if (bad) 
+	dout(0) << " + " << (bad-1) << " other bad 16-byte bits in this block" << dendl;
+    }
   }
   
   client->close(fd);

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -2467,12 +2467,11 @@ int SyntheticClient::read_random(string& fn, int size, int rdsize)   // size is 
     if (read) {
       int bad = 0;
       int64_t *p = (int64_t*)buf;
-      int64_t readoff, readclient;
       while ((char*)p + 32 < buf + rdsize) {
-	readoff = *p;
+	int64_t readoff = *p;
 	int64_t wantoff = offset*rdsize + (int64_t)((char*)p - buf);
 	p++;
-	readclient = *p;
+	int64_t readclient = *p;
 	p++;
 	if (readoff != wantoff || readclient != client->get_nodeid()) {
 	  if (!bad)
@@ -2599,12 +2598,11 @@ int SyntheticClient::read_random_ex(string& fn, int size, int rdsize)   // size 
     if (read) {
       int bad = 0;
       int64_t *p = (int64_t*)buf;
-      int64_t readoff, readclient;
       while ((char*)p + 32 < buf + rdsize) {
-	readoff = *p;
+	int64_t readoff = *p;
 	int64_t wantoff = offset*rdsize + (int64_t)((char*)p - buf);
 	p++;
-	readclient = *p;
+	int64_t readclient = *p;
 	p++;
 	if (readoff != wantoff || readclient != client->get_nodeid()) { 
 	  if (!bad)

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -3068,7 +3068,7 @@ int mirror_set_enabled(cls_method_context_t hctx, bufferlist *in,
     }
   } else {
     std::vector<cls::rbd::MirrorPeer> peers;
-    int r = mirror::read_peers(hctx, &peers);
+    r = mirror::read_peers(hctx, &peers);
     if (r < 0 && r != -ENOENT) {
       return r;
     }

--- a/src/common/Graylog.h
+++ b/src/common/Graylog.h
@@ -47,7 +47,7 @@ class Graylog
    * until set_destination is called
    * @param logger Value for key "_logger" in GELF
    */
-  Graylog(std::string logger);
+  explicit Graylog(std::string logger);
   virtual ~Graylog();
 
   void set_hostname(const std::string& host);

--- a/src/common/HTMLFormatter.cc
+++ b/src/common/HTMLFormatter.cc
@@ -35,7 +35,7 @@
 namespace ceph {
 
 HTMLFormatter::HTMLFormatter(bool pretty)
-: XMLFormatter(pretty), m_header_done(false), m_status(0), m_status_name(NULL)
+: XMLFormatter(pretty), m_status(0), m_status_name(NULL)
 {
 }
 

--- a/src/common/HTMLFormatter.h
+++ b/src/common/HTMLFormatter.h
@@ -37,9 +37,7 @@ namespace ceph {
     /* with attrs */
     void dump_string_with_attrs(const char *name, const std::string& s, const FormatterAttrs& attrs);
   private:
-	template <typename T> void dump_template(const char *name, T arg);
-
-    bool m_header_done;
+    template <typename T> void dump_template(const char *name, T arg);
 
     int m_status;
     const char* m_status_name;

--- a/src/common/PluginRegistry.h
+++ b/src/common/PluginRegistry.h
@@ -39,7 +39,7 @@ namespace ceph {
     void *library;
     CephContext *cct;
 
-    explicit Plugin(CephContext *cct) : cct(cct) {}
+    explicit Plugin(CephContext *cct) : library(NULL), cct(cct) {}
     virtual ~Plugin() {}
   };
 

--- a/src/compressor/zlib/CompressionPluginZlib.cc
+++ b/src/compressor/zlib/CompressionPluginZlib.cc
@@ -25,7 +25,7 @@
 class CompressionPluginZlib : public CompressionPlugin {
 public:
 
-  CompressionPluginZlib(CephContext *cct) : CompressionPlugin(cct)
+  explicit CompressionPluginZlib(CephContext *cct) : CompressionPlugin(cct)
   {}
 
   virtual int factory(CompressorRef *cs,

--- a/src/compressor/zlib/CompressionZlib.cc
+++ b/src/compressor/zlib/CompressionZlib.cc
@@ -44,7 +44,7 @@ const char* CompressionZlib::get_method_name()
 
 int CompressionZlib::compress(const bufferlist &in, bufferlist &out)
 {
-  int ret, flush;
+  int ret;
   unsigned have;
   z_stream strm;
   unsigned char* c_in;
@@ -71,7 +71,7 @@ int CompressionZlib::compress(const bufferlist &in, bufferlist &out)
     ++i;
 
     strm.avail_in = len;
-    flush = i != in.buffers().end() ? Z_NO_FLUSH : Z_FINISH;
+    int flush = i != in.buffers().end() ? Z_NO_FLUSH : Z_FINISH;
 
     strm.next_in = c_in;
 

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -158,7 +158,8 @@ public:
   explicit ErasureCodeJerasureCauchy(const char *technique) :
     ErasureCodeJerasure(technique),
     bitmatrix(0),
-    schedule(0)
+    schedule(0),
+    packetsize(0)
   {
     DEFAULT_K = "7";
     DEFAULT_M = "3";
@@ -211,7 +212,8 @@ public:
   explicit ErasureCodeJerasureLiberation(const char *technique = "liberation") :
     ErasureCodeJerasure(technique),
     bitmatrix(0),
-    schedule(0)
+    schedule(0),
+    packetsize(0)
   {
     DEFAULT_K = "2";
     DEFAULT_M = "2";

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -29,7 +29,7 @@ inline bool entry_positions_less_equal(const ObjectSetPosition &lhs,
 
   if (lhs.entry_positions.size() < rhs.entry_positions.size()) {
     return true;
-  } else if (rhs.entry_positions.size() > rhs.entry_positions.size()) {
+  } else if (lhs.entry_positions.size() > rhs.entry_positions.size()) {
     return false;
   }
 

--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -222,7 +222,6 @@ void AbstractAioImageWrite::send_request() {
   RWLock::RLocker md_locker(m_image_ctx.md_lock);
 
   bool journaling = false;
-  uint64_t journal_tid = 0;
 
   uint64_t clip_len = m_len;
   ObjectExtents object_extents;
@@ -257,6 +256,7 @@ void AbstractAioImageWrite::send_request() {
   }
 
   if (!object_extents.empty()) {
+    uint64_t journal_tid = 0;
     m_aio_comp->set_request_count(
       cct, object_extents.size() + get_cache_request_count(journaling));
 

--- a/src/librbd/DiffIterate.cc
+++ b/src/librbd/DiffIterate.cc
@@ -349,7 +349,6 @@ int DiffIterate::diff_object_map(uint64_t from_snap_id, uint64_t to_snap_id,
   }
 
   object_diff_state->clear();
-  int r;
   uint64_t current_snap_id = from_snap_id;
   uint64_t next_snap_id = to_snap_id;
   BitVector<2> prev_object_map;
@@ -371,7 +370,7 @@ int DiffIterate::diff_object_map(uint64_t from_snap_id, uint64_t to_snap_id,
     }
 
     uint64_t flags;
-    r = m_image_ctx.get_flags(from_snap_id, &flags);
+    int r = m_image_ctx.get_flags(from_snap_id, &flags);
     if (r < 0) {
       lderr(cct) << "diff_object_map: failed to retrieve image flags" << dendl;
       return r;

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -930,13 +930,12 @@ struct C_InvalidateCache : public Context {
         "rbd_journal_pool", false);
 
     string start = METADATA_CONF_PREFIX;
-    int r = 0, j = 0;
     md_config_t local_config_t;
 
     bool retrieve_metadata = !old_format;
     while (retrieve_metadata) {
       map<string, bufferlist> pairs, res;
-      r = cls_client::metadata_list(&md_ctx, header_oid, start, max_conf_items,
+      int r = cls_client::metadata_list(&md_ctx, header_oid, start, max_conf_items,
                                     &pairs);
       if (r == -EOPNOTSUPP || r == -EIO) {
         ldout(cct, 10) << "config metadata not supported by OSD" << dendl;
@@ -955,7 +954,7 @@ struct C_InvalidateCache : public Context {
       for (map<string, bufferlist>::iterator it = res.begin();
            it != res.end(); ++it) {
         string val(it->second.c_str(), it->second.length());
-        j = local_config_t.set_val(it->first.c_str(), val);
+        int j = local_config_t.set_val(it->first.c_str(), val);
         if (j < 0) {
           lderr(cct) << __func__ << " failed to set config " << it->first
                      << " with value " << it->second.c_str() << ": " << j

--- a/src/librbd/operation/RebuildObjectMapRequest.cc
+++ b/src/librbd/operation/RebuildObjectMapRequest.cc
@@ -32,7 +32,8 @@ public:
                  uint64_t snap_id, uint64_t object_no)
     : C_AsyncObjectThrottle<I>(throttle, *image_ctx), m_snap_id(snap_id),
       m_object_no(object_no),
-      m_oid(image_ctx->get_object_name(m_object_no))
+      m_oid(image_ctx->get_object_name(m_object_no)),
+      m_snap_list_ret(0)
   {
     m_io_ctx.dup(image_ctx->md_ctx);
     m_io_ctx.snap_set_read(CEPH_SNAPDIR);

--- a/src/log/Graylog.h
+++ b/src/log/Graylog.h
@@ -22,7 +22,7 @@ class Graylog
 {
  public:
 
-  Graylog(const SubsystemMap * const s);
+  explicit Graylog(const SubsystemMap * const s);
   virtual ~Graylog();
 
   void set_hostname(const std::string& host);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4316,7 +4316,7 @@ void Server::handle_client_setxattr(MDRequestRef& mdr)
   CInode *cur;
 
   ceph_file_layout *dir_layout = NULL;
-  if (name.find("ceph.dir.layout") == 0)
+  if (name.compare(0, 15, "ceph.dir.layout") == 0)
     cur = rdlock_path_pin_ref(mdr, 0, rdlocks, true, false, &dir_layout);
   else
     cur = rdlock_path_pin_ref(mdr, 0, rdlocks, true);
@@ -4331,7 +4331,7 @@ void Server::handle_client_setxattr(MDRequestRef& mdr)
   int flags = req->head.args.setxattr.flags;
 
   // magic ceph.* namespace?
-  if (name.find("ceph.") == 0) {
+  if (name.compare(0, 5, "ceph.") == 0) {
     handle_set_vxattr(mdr, cur, dir_layout, rdlocks, wrlocks, xlocks);
     return;
   }
@@ -4401,7 +4401,7 @@ void Server::handle_client_removexattr(MDRequestRef& mdr)
     return;
   }
 
-  if (name.find("ceph.") == 0) {
+  if (name.compare(0, 5, "ceph.") == 0) {
     handle_remove_vxattr(mdr, cur, rdlocks, wrlocks, xlocks);
     return;
   }

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -625,7 +625,7 @@ struct fnode_t {
   void decode(bufferlist::iterator& bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<fnode_t*>& ls);
-  fnode_t() : version(0),
+  fnode_t() : version(0), damage_flags(0),
 	      recursive_scrub_version(0), localized_scrub_version(0) {}
 };
 WRITE_CLASS_ENCODER(fnode_t)

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -41,10 +41,9 @@ class C_handle_notify : public EventCallback {
   C_handle_notify(EventCenter *c, CephContext *cc): center(c), cct(cc) {}
   void do_request(int fd_or_id) {
     char c[256];
-    int r;
     do {
       center->already_wakeup.set(0);
-      r = read(fd_or_id, c, sizeof(c));
+      int r = read(fd_or_id, c, sizeof(c));
       if (r < 0) {
         ldout(cct, 1) << __func__ << " read notify pipe failed: " << cpp_strerror(errno) << dendl;
         break;

--- a/src/msg/async/EventKqueue.cc
+++ b/src/msg/async/EventKqueue.cc
@@ -71,11 +71,11 @@ int KqueueDriver::del_event(int fd, int cur_mask, int delmask)
                  << " delmask=" << delmask << dendl;
   struct kevent ke;
   int filter = 0;
-  int r = 0;
   filter |= (delmask & EVENT_READABLE) ? EVFILT_READ : 0;
   filter |= (delmask & EVENT_WRITABLE) ? EVFILT_WRITE : 0;
 
   if (filter) {
+    int r = 0;
     EV_SET(&ke, fd, filter, EV_DELETE, 0, 0, NULL);
     if ((r = kevent(kqfd, &ke, 1, NULL, 0, NULL)) < 0) {
       lderr(cct) << __func__ << " kevent: delete fd=" << fd << " mask=" << filter

--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -96,7 +96,9 @@ private:
     uint32_t in_seq, out_seq_acked; // atomic<uint64_t>, got receipt
     atomic_t out_seq; // atomic<uint32_t>
 
-    lifecycle() : state(lifecycle::INIT), in_seq(0), out_seq(0) {}
+    lifecycle() : state(lifecycle::INIT), reconnects(0), connect_seq(0),
+		  peer_global_seq(0), in_seq(0), out_seq_acked(0), 
+		  out_seq(0) {}
 
     void set_in_seq(uint32_t seq) {
       in_seq = seq;
@@ -143,11 +145,18 @@ private:
     uint32_t flags;
 
     explicit CState(XioConnection* _xcon)
-      : xcon(_xcon),
+      : features(0),
+	authorizer(NULL),
+	xcon(_xcon),
 	protocol_version(0),
 	session_state(INIT),
 	startup_state(IDLE),
+	reconnects(0),
+	connect_seq(0),
+	global_seq(0),
+	peer_global_seq(0),
 	in_seq(0),
+	out_seq_acked(0),
 	out_seq(0),
 	flags(FLAG_NONE) {}
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -990,9 +990,6 @@ int check_obj_tail_locator_underscore(RGWBucketInfo& bucket_info, rgw_obj& obj, 
   f->dump_string("instance", key.instance);
   f->close_section();
 
-  string oid;
-  string locator;
-
   bool needs_fixing;
   string status;
 
@@ -1064,7 +1061,6 @@ int do_check_object_locator(const string& tenant_name, const string& bucket_name
 
     count += result.size();
 
-    list<rgw_obj> objs;
     for (vector<RGWObjEnt>::iterator iter = result.begin(); iter != result.end(); ++iter) {
       rgw_obj_key key = iter->key;
       rgw_obj obj(bucket, key);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -802,13 +802,10 @@ static int iterate_slo_parts(CephContext *cct,
                              void *cb_param)
 {
   bool found_start = false, found_end = false;
-  string delim;
-  vector<RGWObjEnt> objs;
 
   if (slo_parts.empty()) {
     return 0;
   }
-
 
   utime_t start_time = ceph_clock_now(cct);
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3386,8 +3386,6 @@ done_err:
  */
 int RGWRados::fix_tail_obj_locator(rgw_bucket& bucket, rgw_obj_key& key, bool fix, bool *need_fix)
 {
-  string locator;
-
   rgw_obj obj(bucket, key);
 
   if (need_fix) {

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -64,7 +64,7 @@ public:
 	&active_set, &registered_clients, &cond);
     ASSERT_EQ(0, cond.wait());
     std::set<cls::journal::Client>::const_iterator c;
-    for (c = registered_clients.begin(); c != registered_clients.end(); c++) {
+    for (c = registered_clients.begin(); c != registered_clients.end(); ++c) {
       if (c->id == client_id) {
 	break;
       }
@@ -76,7 +76,7 @@ public:
     cls::journal::EntryPositions entry_positions =
 	c->commit_position.entry_positions;
     cls::journal::EntryPositions::const_iterator p;
-    for (p = entry_positions.begin(); p != entry_positions.end(); p++) {
+    for (p = entry_positions.begin(); p != entry_positions.end(); ++p) {
       if (p->tag_tid == 0) {
 	break;
       }


### PR DESCRIPTION
Several type of fixes:
- remove unused variables
- prefer ++operator for non-primitive iterators
- fix compare same variables with itself
- change some ctors to explicit
- fix same variable names in parent and derived class
- init member variables in constructor
- remove unused code
- replace inefficient string::find() w/ compare()
- reduce scope of variables
- update .gitignore