### PR TITLE
Sync up kstore with recent bluestore updates

### DIFF
--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -474,7 +474,6 @@ void KStore::OnodeHashLRU::rename(const ghobject_t& old_oid,
 
   // install a non-existent onode it its place
   po->second.reset(new Onode(old_oid, o->key));
-  po->second->exists = false;
   lru.push_back(*po->second);
 
   // fix oid, key
@@ -607,6 +606,7 @@ KStore::OnodeRef KStore::Collection::get_onode(
     // loaded
     assert(r >=0);
     on = new Onode(oid, key);
+    on->exists = true;
     bufferlist::iterator p = v.begin();
     ::decode(on->onode, p);
   }
@@ -2952,6 +2952,8 @@ int KStore::_zero(TransContext *txc,
 	   << " " << offset << "~" << length
 	   << dendl;
   int r = 0;
+  o->exists = true;
+
   _dump_onode(o);
   _assign_nid(txc, o);
 

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -403,15 +403,6 @@ static void get_omap_tail(uint64_t id, string *out)
 #undef dout_prefix
 #define dout_prefix *_dout << "kstore.onode(" << this << ") "
 
-KStore::Onode::Onode(const ghobject_t& o, const string& k)
-  : nref(0),
-    oid(o),
-    key(k),
-    dirty(false),
-    exists(true),
-    flush_lock("KStore::Onode::flush_lock") {
-}
-
 void KStore::Onode::flush()
 {
   Mutex::Locker l(flush_lock);
@@ -552,7 +543,7 @@ int KStore::OnodeHashLRU::trim(int max)
     --p;
   while (num > 0) {
     Onode *o = &*p;
-    int refs = o->nref.read();
+    int refs = o->nref.load();
     if (refs > 1) {
       dout(20) << __func__ << "  " << o->oid << " has " << refs
 	       << " refs; stopping with " << num << " left to trim" << dendl;

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -455,20 +455,6 @@ void KStore::OnodeHashLRU::clear()
   onode_map.clear();
 }
 
-void KStore::OnodeHashLRU::remove(const ghobject_t& oid)
-{
-  std::lock_guard<std::mutex> l(lock);
-  ceph::unordered_map<ghobject_t,OnodeRef>::iterator p = onode_map.find(oid);
-  if (p == onode_map.end()) {
-    dout(30) << __func__ << " " << oid << " miss" << dendl;
-    return;
-  }
-  dout(30) << __func__ << " " << oid << " hit " << p->second << dendl;
-  lru_list_t::iterator pi = lru.iterator_to(*p->second);
-  lru.erase(pi);
-  onode_map.erase(p);
-}
-
 void KStore::OnodeHashLRU::rename(const ghobject_t& old_oid,
 				    const ghobject_t& new_oid)
 {

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -722,6 +722,7 @@ int KStore::_open_fsid(bool create)
 int KStore::_read_fsid(uuid_d *uuid)
 {
   char fsid_str[40];
+  memset(fsid_str, 0, sizeof(fsid_str));
   int ret = safe_read(fsid_fd, fsid_str, sizeof(fsid_str));
   if (ret < 0) {
     derr << __func__ << " failed: " << cpp_strerror(ret) << dendl;

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -2440,6 +2440,14 @@ int KStore::_txc_add_transaction(TransContext *txc, Transaction *t)
 {
   Transaction::iterator i = t->begin();
 
+  dout(30) << __func__ << " transaction dump:\n";
+  JSONFormatter f(true);
+  f.open_object_section("transaction");
+  t->dump(&f);
+  f.close_section();
+  f.flush(*_dout);
+  *_dout << dendl;
+
   vector<CollectionRef> cvec(i.colls.size());
   unsigned j = 0;
   for (vector<coll_t>::iterator p = i.colls.begin(); p != i.colls.end();

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -3125,8 +3125,12 @@ int KStore::_setattrs(TransContext *txc,
 	   << dendl;
   int r = 0;
   for (map<string,bufferptr>::const_iterator p = aset.begin();
-       p != aset.end(); ++p)
-    o->onode.attrs[p->first] = p->second;
+       p != aset.end(); ++p) {
+    if (p->second.is_partial())
+      o->onode.attrs[p->first] = bufferptr(p->second.c_str(), p->second.length());
+    else
+      o->onode.attrs[p->first] = p->second;
+  }
   txc->write_onode(o);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << aset.size() << " keys"

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -70,7 +70,7 @@ public:
 	oid(o),
 	key(k),
 	dirty(false),
-	exists(true) {
+	exists(false) {
     }
 
     void flush();

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -196,9 +196,6 @@ public:
     list<Context*> oncommits;  ///< more commit completions
     list<CollectionRef> removed_collections; ///< colls we removed
 
-    Mutex lock;
-    Cond cond;
-
     CollectionRef first_collection;  ///< first referenced collection
 
     explicit TransContext(OpSequencer *o)
@@ -208,8 +205,7 @@ public:
 	bytes(0),
 	oncommit(NULL),
 	onreadable(NULL),
-	onreadable_sync(NULL),
-	lock("KStore::TransContext::lock") {
+	onreadable_sync(NULL) {
       //cout << "txc new " << this << std::endl;
     }
     ~TransContext() {

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -514,7 +514,7 @@ private:
 
   int _write(TransContext *txc,
 	     CollectionRef& c,
-	     const ghobject_t& oid,
+	     OnodeRef& o,
 	     uint64_t offset, size_t len,
 	     bufferlist& bl,
 	     uint32_t fadvise_flags);
@@ -525,76 +525,77 @@ private:
 		uint32_t fadvise_flags);
   int _touch(TransContext *txc,
 	     CollectionRef& c,
-	     const ghobject_t& oid);
+	     OnodeRef& o);
   int _zero(TransContext *txc,
 	    CollectionRef& c,
-	    const ghobject_t& oid,
+	    OnodeRef& o,
 	    uint64_t offset, size_t len);
   int _do_truncate(TransContext *txc,
 		   OnodeRef o,
 		   uint64_t offset);
   int _truncate(TransContext *txc,
 		CollectionRef& c,
-		const ghobject_t& oid,
+		OnodeRef& o,
 		uint64_t offset);
   int _remove(TransContext *txc,
 	      CollectionRef& c,
-	      const ghobject_t& oid);
+	      OnodeRef& o);
   int _do_remove(TransContext *txc,
 		 OnodeRef o);
   int _setattr(TransContext *txc,
 	       CollectionRef& c,
-	       const ghobject_t& oid,
+	       OnodeRef& o,
 	       const string& name,
 	       bufferptr& val);
   int _setattrs(TransContext *txc,
 		CollectionRef& c,
-		const ghobject_t& oid,
+		OnodeRef& o,
 		const map<string,bufferptr>& aset);
   int _rmattr(TransContext *txc,
 	      CollectionRef& c,
-	      const ghobject_t& oid,
+	      OnodeRef& o,
 	      const string& name);
   int _rmattrs(TransContext *txc,
 	       CollectionRef& c,
-	       const ghobject_t& oid);
+	       OnodeRef& o);
   void _do_omap_clear(TransContext *txc, uint64_t id);
   int _omap_clear(TransContext *txc,
 		  CollectionRef& c,
-		  const ghobject_t& oid);
+		  OnodeRef& o);
   int _omap_setkeys(TransContext *txc,
 		    CollectionRef& c,
-		    const ghobject_t& oid,
+		    OnodeRef& o,
 		    bufferlist& bl);
   int _omap_setheader(TransContext *txc,
 		      CollectionRef& c,
-		      const ghobject_t& oid,
+		      OnodeRef& o,
 		      bufferlist& header);
   int _omap_rmkeys(TransContext *txc,
 		   CollectionRef& c,
-		   const ghobject_t& oid,
+		   OnodeRef& o,
 		   bufferlist& bl);
   int _omap_rmkey_range(TransContext *txc,
 			CollectionRef& c,
-			const ghobject_t& oid,
+			OnodeRef& o,
 			const string& first, const string& last);
   int _setallochint(TransContext *txc,
 		    CollectionRef& c,
-		    const ghobject_t& oid,
+		    OnodeRef& o,
 		    uint64_t expected_object_size,
 		    uint64_t expected_write_size);
   int _clone(TransContext *txc,
 	     CollectionRef& c,
-	     const ghobject_t& old_oid,
-	     const ghobject_t& new_oid);
+	     OnodeRef& oldo,
+	     OnodeRef& newo);
   int _clone_range(TransContext *txc,
 		   CollectionRef& c,
-		   const ghobject_t& old_oid,
-		   const ghobject_t& new_oid,
+		   OnodeRef& oldo,
+		   OnodeRef& newo,
 		   uint64_t srcoff, uint64_t length, uint64_t dstoff);
   int _rename(TransContext *txc,
 	      CollectionRef& c,
-	      const ghobject_t& old_oid,
+	      OnodeRef& oldo,
+	      OnodeRef& newo,
 	      const ghobject_t& new_oid);
   int _create_collection(TransContext *txc, coll_t cid, unsigned bits,
 			 CollectionRef *c);

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -109,7 +109,6 @@ public:
     void add(const ghobject_t& oid, OnodeRef o);
     void _touch(OnodeRef o);
     OnodeRef lookup(const ghobject_t& o);
-    void remove(const ghobject_t& o);
     void rename(const ghobject_t& old_oid, const ghobject_t& new_oid);
     void clear();
     bool get_next(const ghobject_t& after, pair<ghobject_t,OnodeRef> *next);


### PR DESCRIPTION
Recently, Sage made a lot of changes to optimize/refactor some parts of bluestore, but those changes didn't make it to kstore. This will prevent future bug fixes going to kstore from bluestore, since common shared code look very different now.
This PR feeds all those Sage's changes into kstore, by scanning and applying recently changes manually. The order of those changes into kstore may be different, but end results should be same.