### PR TITLE
[cephfs] fix free fds being exhausted eventually because freed fds are never put back

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7664,6 +7664,7 @@ int Client::close(int fd)
     return -EBADF;
   int err = _release_fh(fh);
   fd_map.erase(fd);
+  put_fd(fd);
   ldout(cct, 3) << "close exit(" << fd << ")" << dendl;
   return err;
 }


### PR DESCRIPTION
The open and create operation in libcephfs will get a free fd from the free_fd_set. This free fd will be erased from the free_fd_set. But in close operation, it just erases this free fd from fd_map and never put it back to free_fd_set. So free_fd_set will exhaust all the free fds initialized at beginning eventually. I think we should put freed fd back to free_fd_set for reusing.

Fixes: #14798

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>