### PR TITLE
buffer: hide iterator_impl symbols

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -11,3 +11,10 @@ v10.0.0
 * A new configure option 'mon_election_timeout' is added to specifically
   limit max waiting time of monitor election process, which was previously
   restricted by 'mon_lease'.
+
+v9.3.0
+======
+* Some symbols wrongly exposed by librados in v9.1.0 and v9.2.0 were removed.
+  If you compiled your own application against librados shipped with these
+  releases, it is very likely referencing these removed symbols. So you will
+  need to recompile it.

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -962,6 +962,13 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     }*/
 
   template<bool is_const>
+  buffer::list::iterator_impl<is_const>::iterator_impl(bl_t *l, unsigned o)
+    : bl(l), ls(&bl->_buffers), off(0), p(ls->begin()), p_off(0)
+  {
+    advance(o);
+  }
+
+  template<bool is_const>
   void buffer::list::iterator_impl<is_const>::advance(int o)
   {
     //cout << this << " advance " << o << " from " << off << " (p_off " << p_off << " in " << p->length() << ")" << std::endl;
@@ -1130,6 +1137,14 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
   // dependencies.
   template class buffer::list::iterator_impl<true>;
   template class buffer::list::iterator_impl<false>;
+
+  buffer::list::iterator::iterator(bl_t *l, unsigned o)
+    : iterator_impl(l, o)
+  {}
+
+  buffer::list::iterator::iterator(bl_t *l, unsigned o, list_iter_t ip, unsigned po)
+    : iterator_impl(l, o, ip, po)
+  {}
 
   void buffer::list::iterator::advance(int o)
   {

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -57,8 +57,10 @@
 
 #if __GNUC__ >= 4
   #define CEPH_BUFFER_API  __attribute__ ((visibility ("default")))
+  #define CEPH_BUFFER_DETAILS __attribute__ ((visibility ("hidden")))
 #else
   #define CEPH_BUFFER_API
+  #define CEPH_BUFFER_DETAILS
 #endif
 
 #if defined(HAVE_XIO)
@@ -263,7 +265,8 @@ namespace buffer CEPH_BUFFER_API {
     ptr append_buffer;  // where i put small appends.
 
     template <bool is_const>
-    class iterator_impl: public std::iterator<std::forward_iterator_tag, char> {
+    class CEPH_BUFFER_DETAILS iterator_impl
+      : public std::iterator<std::forward_iterator_tag, char> {
     protected:
       typedef typename std::conditional<is_const,
 					const list,
@@ -284,10 +287,7 @@ namespace buffer CEPH_BUFFER_API {
       // constructor.  position.
       iterator_impl()
 	: bl(0), ls(0), off(0), p_off(0) {}
-      iterator_impl(bl_t *l, unsigned o=0)
-	: bl(l), ls(&bl->_buffers), off(0), p(ls->begin()), p_off(0) {
-	advance(o);
-      }
+      iterator_impl(bl_t *l, unsigned o=0);
       iterator_impl(bl_t *l, unsigned o, list_iter_t ip, unsigned po)
 	: bl(l), ls(&bl->_buffers), off(o), p(ip), p_off(po) {}
 
@@ -326,11 +326,9 @@ namespace buffer CEPH_BUFFER_API {
 
     class CEPH_BUFFER_API iterator : public iterator_impl<false> {
     public:
-      iterator(): iterator_impl() {}
-      iterator(bl_t *l, unsigned o=0) :
-	iterator_impl(l, o) {}
-      iterator(bl_t *l, unsigned o, list_iter_t ip, unsigned po) :
-	iterator_impl(l, o, ip, po) {}
+      iterator() = default;
+      iterator(bl_t *l, unsigned o=0);
+      iterator(bl_t *l, unsigned o, list_iter_t ip, unsigned po);
 
       void advance(int o);
       void seek(unsigned o);


### PR DESCRIPTION
buffer::list::iterator_impl symbols are referenced by const_iterator
and iterator, and are exposed as weak symbols. if a source file is
compiled using the buffer.h, the produced object file will reference
these symbols as well, so we'd better hiding them and avoid using
them in the header file.
as a side-effect, buffer::list::const_iterator is also hidden, but
currently we don't have any librados client using this class, so
we can just leave it as an internal class at this moment.

Fixes: #14788
Signed-off-by: Kefu Chai <kchai@redhat.com>