### PR TITLE
ceph: bash auto complete for CLI based on mon command descriptions

### DIFF
--- a/src/bash_completion/ceph
+++ b/src/bash_completion/ceph
@@ -1,73 +1,50 @@
 #
 # Ceph - scalable distributed file system
 #
-# Copyright (C) 2011 Wido den Hollander <wido@widodh.nl>
-#
 # This is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License version 2.1, as published by the Free Software
-# Foundation.  See file COPYING.
+# Foundation.
 #
 
 _ceph()
 {
-        local cur prev
+    local options_noarg="-h --help -s --status -w --watch --watch-debug --watch-info --watch-sec --watch-warn --watch-error --version -v --verbose --concise"
+    local options_arg="-c --conf -i --in-file -o --out-file --id --user -n --name --cluster --admin-daemon --admin-socket -f --format --connect-timeout"
+    local cnt=${#COMP_WORDS[@]}
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    local prev=${COMP_WORDS[COMP_CWORD-1]}
 
-        COMPREPLY=()
-        cur="${COMP_WORDS[COMP_CWORD]}"
-        prev="${COMP_WORDS[COMP_CWORD-1]}"
-        prevprev="${COMP_WORDS[COMP_CWORD-2]}"
+    if [[ " -c --conf -i --in-file -o --out-file " =~ " ${prev} " ]]
+    then
+	#default autocomplete for options (file autocomplete)
+	compopt -o default
+	COMPREPLY=()
+	return 0
+    fi
+    if [[ "${cur:0:1}" == "-" ]] ;
+    then
+	COMPREPLY=( $(compgen -W "${options_noarg} ${options_arg}" -- $cur) )
+	return 0
+    fi
+    declare -A hint_args
+    for (( i=1 ; i<cnt ; i++ ))
+    do
+	#skip this word if it is option
+	if [[ " ${options_noarg} " =~ " ${COMP_WORDS[i]} " ]]
+	then 
+	    continue 
+	fi
+	#skip this word and next if it is option with arg
+	if [[ " ${options_arg} " =~ " ${COMP_WORDS[i]} " ]]
+	then 
+	    ((i++)); 
+	    continue
+	fi
+	hint_args[$((i-1))]="${COMP_WORDS[i]}"
+    done
 
-        if [[ ${cur} == -* ]] ; then
-            COMPREPLY=( $(compgen -W "--conf -c --name --id -m --version -s --status -w --watch -o --out-file -i --in-file" -- ${cur}) )
-            return 0
-        fi
-
-        case "${prev}" in
-            -o | --out-file | -i | --in-file | --conf | -c)
-                COMPREPLY=( $(compgen -f ${cur}) )
-                return 0
-                ;;
-            -m)
-                COMPREPLY=( $(compgen -A hostname ${cur}) )
-                return 0
-                ;;
-            auth)
-                COMPREPLY=( $(compgen -W "list add del print_key print-key export get get-key import get-or-create get-or-create-key" -- ${cur}) )
-                return 0
-                ;;
-            pg)
-                COMPREPLY=( $(compgen -W "stat dump dump_json dump_stuck force_create_pg getmap map send_pg_creates scrub deep-scrub repair" -- ${cur}) )
-                return 0
-                ;;
-            osd)
-                COMPREPLY=( $(compgen -W "stat pool dump getmaxosd tree getmap getcrushmap lspools reweight-by-utilization trash tier" -- ${cur}) )
-                return 0
-                ;;
-            mon)
-                COMPREPLY=( $(compgen -W "stat getmap add remove dump" -- ${cur}) )
-                return 0
-                ;;
-            mds)
-                COMPREPLY=( $(compgen -W "stat stat getmap dump compat" -- ${cur}) )
-                return 0
-                ;;
-            pool)
-                COMPREPLY=( $(compgen -W "create delete rename stats set set-quota get rmsnap mksnap" -- ${cur}) )
-                return 0
-                ;;
-            health)
-                COMPREPLY=( $(compgen -W "detail" -- ${cur}) )
-                return 0
-                ;;
-            tier)
-                COMPREPLY=( $(compgen -W "remove cache-mode" -- ${cur}) )
-                return 0
-                ;;
-            ceph)
-                COMPREPLY=( $(compgen -W "osd mon mds pg auth health df" -- ${cur}) )
-                return 0
-                ;;
-        esac
+    local IFS=$'\n'
+    COMPREPLY=( $(${COMP_WORDS[0]} --completion "${hint_args[@]}" 2>/dev/null) )
 }
 complete -F _ceph ceph

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -474,6 +474,7 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
     return json_command(cluster_handle, target=target, argdict=valid_dict,
                         inbuf=inbuf)
 
+
 def complete(sigdict, args, target):
     """
     Command completion.  Match as much of [args] as possible,
@@ -491,45 +492,37 @@ def complete(sigdict, args, target):
         args = args[2:]
     # look for best match, accumulate possibles in bestcmds
     # (so we can maybe give a more-useful error message)
-    best_match_cnt = 0
-    bestcmds = []
+
+    match_count = 0
+    comps = []
     for cmdtag, cmd in sigdict.iteritems():
         sig = cmd['sig']
-        matched = matchnum(args, sig, partial=True)
-        if (matched > best_match_cnt):
-            if complete_verbose:
-                print("better match: {0} > {1}: {2}:{3} ".format(matched,
-                        best_match_cnt, cmdtag, concise_sig(sig)),  file=sys.stderr)
-            best_match_cnt = matched
-            bestcmds = [{cmdtag:cmd}]
-        elif matched == best_match_cnt:
-            if complete_verbose:
-                print("equal match: {0} > {1}: {2}:{3} ".format(matched,
-                        best_match_cnt, cmdtag, concise_sig(sig)), file=sys.stderr)
-            bestcmds.append({cmdtag:cmd})
+        j = 0
+        # iterate over all arguments, except last one
+        for arg in args[0:-1]:
+            if j > len(sig)-1:
+                # an out of argument definitions
+                break
+            found_match = arg in sig[j].complete(arg)
+            if not found_match and sig[j].req:
+                # no elements that match
+                break
+            if not sig[j].N:
+                j += 1
+        else:
+            # successfully matched all - except last one - arguments
+            if j < len(sig) and len(args) > 0:
+                comps += sig[j].complete(args[-1])
 
-    # look through all matching sigs
-    comps = []
-    for cmddict in bestcmds:
-        for cmd in cmddict.itervalues():
-            sig = cmd['sig']
-            # either:
-            #   we match everything fully, so we want the next desc, or
-            #   we match more partially, so we want the partial match
-            fullindex = matchnum(args, sig, partial=False) - 1
-            partindex = matchnum(args, sig, partial=True) - 1
-            if complete_verbose:
-                print('{}: f {} p {} len {}'.format(sig, fullindex, partindex, len(sig)), file=sys.stderr)
-            if fullindex == partindex and fullindex + 1 < len(sig):
-                d = sig[fullindex + 1]
-            else:
-                d = sig[partindex]
-            comps.append(str(d))
-    if complete_verbose:
-        print('\n'.join(comps), file=sys.stderr)
-    print('\n'.join(comps))
+            match_count += 1
+            match_cmd = cmd
 
+    if match_count == 1 and len(comps) == 0:
+        # only one command matched and no hints yet => add help
+        comps = comps + [' ', '#'+match_cmd['help']]
+    print('\n'.join(sorted(set(comps))))
     return 0
+
 
 ###
 # ping a monitor
@@ -712,9 +705,6 @@ def main():
             file=sys.stderr)
         return 1
 
-    if childargs in [['mon'], ['osd']]:
-        parsed_args.help = True
-
     if parsed_args.help:
         # short default timeout for -h
         if not timeout:
@@ -727,7 +717,9 @@ def main():
         if len(childargs) < 2:
             print('"ping" requires a monitor name as argument: "ping mon.<id>"', file=sys.stderr)
             return 1
-
+    if parsed_args.completion:
+        #for completion let timeout be really small
+        timeout = 3
     try:
         if childargs and childargs[0] == 'ping':
             return ping_monitor(cluster_handle, childargs[1], timeout)

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -120,6 +120,9 @@ class CephArgtype(object):
         """
         return '<{0}>'.format(self.__class__.__name__)
 
+    def complete(self, s):
+        return []
+
 
 class CephInt(CephArgtype):
     """
@@ -218,6 +221,12 @@ class CephString(CephArgtype):
         if self.goodchars:
             b += '(goodchars {0})'.format(self.goodchars)
         return '<string{0}>'.format(b)
+
+    def complete(self, s):
+        if s == '':
+            return []
+        else:
+            return [s]
 
 
 class CephSocketpath(CephArgtype):
@@ -450,6 +459,10 @@ class CephChoices(CephArgtype):
         else:
             return '{0}'.format('|'.join(self.strings))
 
+    def complete(self, s):
+        all_elems = [token for token in self.strings if token.startswith(s)]
+        return all_elems
+
 
 class CephFilepath(CephArgtype):
     """
@@ -536,6 +549,12 @@ class CephPrefix(CephArgtype):
     def __str__(self):
         return self.prefix
 
+    def complete(self, s):
+        if self.prefix.startswith(s):
+            return [self.prefix.rstrip(' ')]
+        else:
+            return []
+
 
 class argdesc(object):
     """
@@ -617,6 +636,9 @@ class argdesc(object):
         if not self.req:
             s = '{' + s + '}'
         return s
+
+    def complete(self, s):
+        return self.instance.complete(s)
 
 
 def concise_sig(sig):


### PR DESCRIPTION
This is not bind to bash yet. Use as 'ceph --comp osd ls'.
Able to fulfill commands as well as print command line help, when matching is complete.
This is required step before adding hinting of string values, eg. pool names.
Signed-off-by: Adam Kupczyk(a.kupczyk@mirantis.com)