### PR TITLE
test: Adding bzip2 for linkage on ceph_objectstore_bench

### DIFF
--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -79,7 +79,7 @@ ceph_omapbench_LDADD = $(LIBRADOS) $(CEPH_GLOBAL)
 bin_DEBUGPROGRAMS += ceph_omapbench
 
 ceph_objectstore_bench_SOURCES = test/objectstore_bench.cc
-ceph_objectstore_bench_LDADD = $(LIBOS) $(CEPH_GLOBAL)
+ceph_objectstore_bench_LDADD = $(LIBOS) $(CEPH_GLOBAL) -lbz2
 bin_DEBUGPROGRAMS += ceph_objectstore_bench
 
 if LINUX


### PR DESCRIPTION
The build process always ends up with the following trace :

./make_version -g ./.git_version
if [ -n "$NO_VERSION" ] ; then \
    ./make_version -g ./.git_version -c ./ceph_ver.h -n ; \
else \
    ./make_version -g ./.git_version -c ./ceph_ver.h ; \
fi
/bin/sh ../libtool  --tag=CXX   --mode=link g++ -Wall -Wtype-limits -Wignored-qualifiers -Winit-self -Wpointer-arith  -fno-strict-aliasing -fsigned-char -rdynamic -ftemplate-depth-1024 -Wnon-virtual-dtor -Wno-invalid-offsetof -O2 -g -pipe -Wall -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 -fPIE -fstack-protector-strong    -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free  -Wstrict-null-sentinel -g -O2 -std=gnu++11 -Wl,--as-needed -pie -Wl,-z,relro -Wl,-z,now  -latomic_ops  -o ceph_objectstore_bench test/objectstore_bench.o libos.a -laio   libos_types.a libkv.a rocksdb/librocksdb.a   -lz -lleveldb -lsnappy -lfuse -pthread  libglobal.la libcommon.la -luuid -lpthread -lm -lcryptopp -lm  -lrt   -lboost_iostreams -lboost_system
libtool: link: g++ -Wall -Wtype-limits -Wignored-qualifiers -Winit-self -Wpointer-arith -fno-strict-aliasing -fsigned-char -rdynamic -ftemplate-depth-1024 -Wnon-virtual-dtor -Wno-invalid-offsetof -O2 -g -pipe -Wall -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 -fPIE -fstack-protector-strong -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -Wstrict-null-sentinel -g -O2 -std=gnu++11 -Wl,--as-needed -pie -Wl,-z -Wl,relro -Wl,-z -Wl,now -o ceph_objectstore_bench test/objectstore_bench.o -pthread  libos.a -laio libos_types.a libkv.a rocksdb/librocksdb.a -lz -lleveldb -lsnappy -lfuse ./.libs/libglobal.a ./.libs/libcommon.a -ldl -lboost_thread -latomic_ops -lboost_random -lblkid -luuid -lpthread -lcryptopp -lm -lrt -lboost_iostreams -lboost_system -pthread
/usr/bin/ld: rocksdb/librocksdb.a(format.o): undefined reference to symbol 'BZ2_bzDecompressEnd'
/usr/lib64/libbz2.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:15213: recipe for target 'ceph_objectstore_bench' failed
make[2]: *** [ceph_objectstore_bench] Error 1
make[2]: Leaving directory '/build/erwan/ceph/src'
Makefile:29326: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/build/erwan/ceph/src'
Makefile:12041: recipe for target 'all' failed
make: *** [all] Error 2

ceph_objectstore_bench is linked to rocksdb/librocksdb.a which requires BZ2_bzDecompressEnd defined in bzip2.
The bz2 lib is not provided at link time making this error occuring.

This patch simply adds a -lbz2 on the ceph_objectstore_bench_LDADD.