### PR TITLE
src/yasm-wrapper: ignore parameters starting with ggc-min

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,20 @@
 include Makefile-env.am
 
+# a workaround for http://debbugs.gnu.org/cgi/bugreport.cgi?bug=18744, this
+# bug was fixed in automake 1.15, but automake 1.13 is supported by us.  so
+# we can not just require 1.15 using `AM_INIT_AUTOMAKE`
+am__is_gnu_make = { \
+  if test -z '$(MAKELEVEL)'; then \
+    false; \
+  elif test -n '$(MAKE_HOST)'; then \
+    true; \
+  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
+    true; \
+  else \
+    false; \
+  fi; \
+}
+
 SUBDIRS += ocf java
 DIST_SUBDIRS += gmock ocf java
 

--- a/src/yasm-wrapper
+++ b/src/yasm-wrapper
@@ -12,7 +12,7 @@ while [ -n "$*" ]; do
 	    new="$new -f $1"
 	    shift
 	    ;;
-	-g* | -f* | -W* | -MD | -MP | -fPIC | -c | -D* | --param* | -O* | -m* | -pipe )
+	-g* | -f* | -W* | -MD | -MP | -fPIC | -c | -D* | --param* | -O* | -m* | -pipe | ggc-min* )
 	    shift
 	    ;;
 	-I )


### PR DESCRIPTION
When the "with lowmem_builder" bcond is active, the string "--param
ggc-min-expand=20 --param ggc-min-heapsize=32768" is added to
RPM_OPT_FLAGS. In the course of the build, these parameters get passed on
to yasm-wrapper, making it unhappy.

http://tracker.ceph.com/issues/14811 Fixes: #14811

Signed-off-by: Nathan Cutler <ncutler@suse.com>