### PR TITLE
DNM: refrain from packaging libec test plugins (using check_LTLIBRARIES)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -868,7 +868,15 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/rados-classes/libcls_version.so*
 %{_libdir}/rados-classes/libcls_journal.so*
 %dir %{_libdir}/ceph/erasure-code
-%{_libdir}/ceph/erasure-code/libec_*.so*
+%{_libdir}/ceph/erasure-code/libec_jerasure.so
+%{_libdir}/ceph/erasure-code/libec_jerasure_generic.so
+%{_libdir}/ceph/erasure-code/libec_jerasure_sse3.so
+%{_libdir}/ceph/erasure-code/libec_jerasure_sse4.so
+%{_libdir}/ceph/erasure-code/libec_lrc.so
+%{_libdir}/ceph/erasure-code/libec_shec.so
+%{_libdir}/ceph/erasure-code/libec_shec_generic.so
+%{_libdir}/ceph/erasure-code/libec_shec_sse3.so
+%{_libdir}/ceph/erasure-code/libec_shec_sse4.so
 %dir %{_libdir}/ceph/compressor
 %{_libdir}/ceph/compressor/libceph_*.so*
 %if 0%{?_with_lttng}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,20 @@
 include Makefile-env.am
 
+# a workaround for http://debbugs.gnu.org/cgi/bugreport.cgi?bug=18744, this
+# bug was fixed in automake 1.15, but automake 1.13 is supported by us.  so
+# we can not just require 1.15 using `AM_INIT_AUTOMAKE`
+am__is_gnu_make = { \
+  if test -z '$(MAKELEVEL)'; then \
+    false; \
+  elif test -n '$(MAKE_HOST)'; then \
+    true; \
+  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
+    true; \
+  else \
+    false; \
+  fi; \
+}
+
 SUBDIRS += ocf java
 DIST_SUBDIRS += gmock ocf java
 

--- a/src/erasure-code/Makefile.am
+++ b/src/erasure-code/Makefile.am
@@ -2,6 +2,7 @@
 
 erasure_codelibdir = $(pkglibdir)/erasure-code
 erasure_codelib_LTLIBRARIES =  
+check_LTLIBRARIES =
 
 include erasure-code/jerasure/Makefile.am
 include erasure-code/lrc/Makefile.am

--- a/src/test/erasure-code/Makefile.am
+++ b/src/test/erasure-code/Makefile.am
@@ -42,7 +42,10 @@ test/erasure-code/ErasureCodePluginExample.cc: ./ceph_ver.h
 libec_example_la_CFLAGS = ${AM_CFLAGS}
 libec_example_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_example_la_LIBADD = $(LIBCRUSH) $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_example_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_example_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_example_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_example.la
 
 libec_missing_entry_point_la_SOURCES = test/erasure-code/ErasureCodePluginMissingEntryPoint.cc
@@ -50,14 +53,20 @@ test/erasure-code/ErasureCodePluginMissingEntryPoint.cc: ./ceph_ver.h
 libec_missing_entry_point_la_CFLAGS = ${AM_CFLAGS}
 libec_missing_entry_point_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_missing_entry_point_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_missing_entry_point_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_missing_entry_point_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_missing_entry_point_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_missing_entry_point.la
 
 libec_missing_version_la_SOURCES = test/erasure-code/ErasureCodePluginMissingVersion.cc
 libec_missing_version_la_CFLAGS = ${AM_CFLAGS}
 libec_missing_version_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_missing_version_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_missing_version_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_missing_version_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_missing_version_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_missing_version.la
 
 libec_hangs_la_SOURCES = test/erasure-code/ErasureCodePluginHangs.cc
@@ -65,7 +74,10 @@ test/erasure-code/ErasureCodePluginHangs.cc: ./ceph_ver.h
 libec_hangs_la_CFLAGS = ${AM_CFLAGS}
 libec_hangs_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_hangs_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_hangs_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_hangs_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_hangs_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_hangs.la
 
 libec_fail_to_initialize_la_SOURCES = test/erasure-code/ErasureCodePluginFailToInitialize.cc
@@ -73,7 +85,10 @@ test/erasure-code/ErasureCodePluginFailToInitialize.cc: ./ceph_ver.h
 libec_fail_to_initialize_la_CFLAGS = ${AM_CFLAGS}
 libec_fail_to_initialize_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_fail_to_initialize_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_fail_to_initialize_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_fail_to_initialize_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_fail_to_initialize_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_fail_to_initialize.la
 
 libec_fail_to_register_la_SOURCES = test/erasure-code/ErasureCodePluginFailToRegister.cc
@@ -81,7 +96,10 @@ test/erasure-code/ErasureCodePluginFailToRegister.cc: ./ceph_ver.h
 libec_fail_to_register_la_CFLAGS = ${AM_CFLAGS}
 libec_fail_to_register_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_fail_to_register_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_fail_to_register_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_fail_to_register_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_fail_to_register_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_fail_to_register.la
 
 libec_test_jerasure_neon_la_SOURCES = test/erasure-code/TestJerasurePluginNEON.cc
@@ -89,7 +107,10 @@ test/erasure-code/TestJerasurePluginNEON.cc: ./ceph_ver.h
 libec_test_jerasure_neon_la_CFLAGS = ${AM_CFLAGS}
 libec_test_jerasure_neon_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_jerasure_neon_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_jerasure_neon_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_test_jerasure_neon_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_test_jerasure_neon_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_test_jerasure_neon.la
 
 libec_test_jerasure_sse4_la_SOURCES = test/erasure-code/TestJerasurePluginSSE4.cc
@@ -97,7 +118,10 @@ test/erasure-code/TestJerasurePluginSSE4.cc: ./ceph_ver.h
 libec_test_jerasure_sse4_la_CFLAGS = ${AM_CFLAGS}
 libec_test_jerasure_sse4_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_jerasure_sse4_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_jerasure_sse4_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_test_jerasure_sse4_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_test_jerasure_sse4_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_test_jerasure_sse4.la
 
 libec_test_jerasure_sse3_la_SOURCES = test/erasure-code/TestJerasurePluginSSE3.cc
@@ -105,7 +129,10 @@ test/erasure-code/TestJerasurePluginSSE3.cc: ./ceph_ver.h
 libec_test_jerasure_sse3_la_CFLAGS = ${AM_CFLAGS}
 libec_test_jerasure_sse3_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_jerasure_sse3_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_jerasure_sse3_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_test_jerasure_sse3_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_test_jerasure_sse3_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_test_jerasure_sse3.la
 
 libec_test_jerasure_generic_la_SOURCES = test/erasure-code/TestJerasurePluginGeneric.cc
@@ -113,7 +140,10 @@ test/erasure-code/TestJerasurePluginGeneric.cc: ./ceph_ver.h
 libec_test_jerasure_generic_la_CFLAGS = ${AM_CFLAGS}
 libec_test_jerasure_generic_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_jerasure_generic_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_jerasure_generic_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_test_jerasure_generic_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_test_jerasure_generic_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_test_jerasure_generic.la
 
 unittest_erasure_code_plugin_SOURCES = \
@@ -288,7 +318,10 @@ test/erasure-code/TestShecPluginNEON.cc: ./ceph_ver.h
 libec_test_shec_neon_la_CFLAGS = ${AM_CFLAGS}
 libec_test_shec_neon_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_shec_neon_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_shec_neon_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_test_shec_neon_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_test_shec_neon_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_test_shec_neon.la
 
 libec_test_shec_sse4_la_SOURCES = test/erasure-code/TestShecPluginSSE4.cc
@@ -296,7 +329,10 @@ test/erasure-code/TestShecPluginSSE4.cc: ./ceph_ver.h
 libec_test_shec_sse4_la_CFLAGS = ${AM_CFLAGS}
 libec_test_shec_sse4_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_shec_sse4_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_shec_sse4_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_test_shec_sse4_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_test_shec_sse4_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_test_shec_sse4.la
 
 libec_test_shec_sse3_la_SOURCES = test/erasure-code/TestShecPluginSSE3.cc
@@ -304,7 +340,10 @@ test/erasure-code/TestShecPluginSSE3.cc: ./ceph_ver.h
 libec_test_shec_sse3_la_CFLAGS = ${AM_CFLAGS}
 libec_test_shec_sse3_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_shec_sse3_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_shec_sse3_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_test_shec_sse3_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_test_shec_sse3_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_test_shec_sse3.la
 
 libec_test_shec_generic_la_SOURCES = test/erasure-code/TestShecPluginGeneric.cc
@@ -312,7 +351,10 @@ test/erasure-code/TestShecPluginGeneric.cc: ./ceph_ver.h
 libec_test_shec_generic_la_CFLAGS = ${AM_CFLAGS}
 libec_test_shec_generic_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_shec_generic_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_shec_generic_la_LDFLAGS = ${AM_LDFLAGS} -export-symbols-regex '.*__erasure_code_.*'
+libec_test_shec_generic_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+if LINUX
+libec_test_shec_generic_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
+endif
 erasure_codelib_LTLIBRARIES += libec_test_shec_generic.la
 
 unittest_erasure_code_example_SOURCES = \

--- a/src/test/erasure-code/Makefile.am
+++ b/src/test/erasure-code/Makefile.am
@@ -46,7 +46,7 @@ libec_example_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
 if LINUX
 libec_example_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_example.la
+check_LTLIBRARIES += libec_example.la
 
 libec_missing_entry_point_la_SOURCES = test/erasure-code/ErasureCodePluginMissingEntryPoint.cc
 test/erasure-code/ErasureCodePluginMissingEntryPoint.cc: ./ceph_ver.h
@@ -57,7 +57,7 @@ libec_missing_entry_point_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -sha
 if LINUX
 libec_missing_entry_point_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_missing_entry_point.la
+check_LTLIBRARIES += libec_missing_entry_point.la
 
 libec_missing_version_la_SOURCES = test/erasure-code/ErasureCodePluginMissingVersion.cc
 libec_missing_version_la_CFLAGS = ${AM_CFLAGS}
@@ -67,7 +67,7 @@ libec_missing_version_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
 if LINUX
 libec_missing_version_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_missing_version.la
+check_LTLIBRARIES += libec_missing_version.la
 
 libec_hangs_la_SOURCES = test/erasure-code/ErasureCodePluginHangs.cc
 test/erasure-code/ErasureCodePluginHangs.cc: ./ceph_ver.h
@@ -78,7 +78,7 @@ libec_hangs_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
 if LINUX
 libec_hangs_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_hangs.la
+check_LTLIBRARIES += libec_hangs.la
 
 libec_fail_to_initialize_la_SOURCES = test/erasure-code/ErasureCodePluginFailToInitialize.cc
 test/erasure-code/ErasureCodePluginFailToInitialize.cc: ./ceph_ver.h
@@ -89,7 +89,7 @@ libec_fail_to_initialize_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shar
 if LINUX
 libec_fail_to_initialize_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_fail_to_initialize.la
+check_LTLIBRARIES += libec_fail_to_initialize.la
 
 libec_fail_to_register_la_SOURCES = test/erasure-code/ErasureCodePluginFailToRegister.cc
 test/erasure-code/ErasureCodePluginFailToRegister.cc: ./ceph_ver.h
@@ -100,7 +100,7 @@ libec_fail_to_register_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
 if LINUX
 libec_fail_to_register_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_fail_to_register.la
+check_LTLIBRARIES += libec_fail_to_register.la
 
 libec_test_jerasure_neon_la_SOURCES = test/erasure-code/TestJerasurePluginNEON.cc
 test/erasure-code/TestJerasurePluginNEON.cc: ./ceph_ver.h
@@ -111,7 +111,7 @@ libec_test_jerasure_neon_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shar
 if LINUX
 libec_test_jerasure_neon_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_jerasure_neon.la
+check_LTLIBRARIES += libec_test_jerasure_neon.la
 
 libec_test_jerasure_sse4_la_SOURCES = test/erasure-code/TestJerasurePluginSSE4.cc
 test/erasure-code/TestJerasurePluginSSE4.cc: ./ceph_ver.h
@@ -122,7 +122,7 @@ libec_test_jerasure_sse4_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shar
 if LINUX
 libec_test_jerasure_sse4_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_jerasure_sse4.la
+check_LTLIBRARIES += libec_test_jerasure_sse4.la
 
 libec_test_jerasure_sse3_la_SOURCES = test/erasure-code/TestJerasurePluginSSE3.cc
 test/erasure-code/TestJerasurePluginSSE3.cc: ./ceph_ver.h
@@ -133,7 +133,7 @@ libec_test_jerasure_sse3_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shar
 if LINUX
 libec_test_jerasure_sse3_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_jerasure_sse3.la
+check_LTLIBRARIES += libec_test_jerasure_sse3.la
 
 libec_test_jerasure_generic_la_SOURCES = test/erasure-code/TestJerasurePluginGeneric.cc
 test/erasure-code/TestJerasurePluginGeneric.cc: ./ceph_ver.h
@@ -144,7 +144,7 @@ libec_test_jerasure_generic_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -s
 if LINUX
 libec_test_jerasure_generic_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_jerasure_generic.la
+check_LTLIBRARIES += libec_test_jerasure_generic.la
 
 unittest_erasure_code_plugin_SOURCES = \
 	erasure-code/ErasureCode.cc \
@@ -322,7 +322,7 @@ libec_test_shec_neon_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
 if LINUX
 libec_test_shec_neon_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_shec_neon.la
+check_LTLIBRARIES += libec_test_shec_neon.la
 
 libec_test_shec_sse4_la_SOURCES = test/erasure-code/TestShecPluginSSE4.cc
 test/erasure-code/TestShecPluginSSE4.cc: ./ceph_ver.h
@@ -333,7 +333,7 @@ libec_test_shec_sse4_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
 if LINUX
 libec_test_shec_sse4_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_shec_sse4.la
+check_LTLIBRARIES += libec_test_shec_sse4.la
 
 libec_test_shec_sse3_la_SOURCES = test/erasure-code/TestShecPluginSSE3.cc
 test/erasure-code/TestShecPluginSSE3.cc: ./ceph_ver.h
@@ -344,7 +344,7 @@ libec_test_shec_sse3_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
 if LINUX
 libec_test_shec_sse3_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_shec_sse3.la
+check_LTLIBRARIES += libec_test_shec_sse3.la
 
 libec_test_shec_generic_la_SOURCES = test/erasure-code/TestShecPluginGeneric.cc
 test/erasure-code/TestShecPluginGeneric.cc: ./ceph_ver.h
@@ -355,7 +355,7 @@ libec_test_shec_generic_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -share
 if LINUX
 libec_test_shec_generic_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_shec_generic.la
+check_LTLIBRARIES += libec_test_shec_generic.la
 
 unittest_erasure_code_example_SOURCES = \
 	erasure-code/ErasureCode.cc \


### PR DESCRIPTION
This fixes the same bug as #7637 but uses `check_LTLIBRARIES`.