### PR TITLE
osd: filestore: fast abort if statfs encounters ENOENT

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -692,6 +692,7 @@ int FileStore::statfs(struct statfs *buf)
   if (::statfs(basedir.c_str(), buf) < 0) {
     int r = -errno;
     assert(!m_filestore_fail_eio || r != -EIO);
+    assert(r != -ENOENT);
     return r;
   }
   return 0;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -668,6 +668,11 @@ void OSDService::update_osd_stat(vector<int>& hb_peers)
 {
   Mutex::Locker lock(stat_lock);
 
+  osd_stat.hb_in.swap(hb_peers);
+  osd_stat.hb_out.clear();
+
+  osd->op_tracker.get_age_ms_histogram(&osd_stat.op_queue_age_hist);
+
   // fill in osd stats too
   struct statfs stbuf;
   int r = osd->store->statfs(&stbuf);
@@ -688,12 +693,7 @@ void OSDService::update_osd_stat(vector<int>& hb_peers)
   osd->logger->set(l_osd_stat_bytes_used, used);
   osd->logger->set(l_osd_stat_bytes_avail, avail);
 
-  osd_stat.hb_in.swap(hb_peers);
-  osd_stat.hb_out.clear();
-
   check_nearfull_warning(osd_stat);
-
-  osd->op_tracker.get_age_ms_histogram(&osd_stat.op_queue_age_hist);
 
   dout(20) << "update_osd_stat " << osd_stat << dendl;
 }


### PR DESCRIPTION
This is a supplement patch for https://github.com/ceph/ceph/pull/6869.

The original case is that if we remove the root directory of an OSD by accident or something alike, and the OSD is currently idle, the OSD process will be able to survive a long time before it does have some consumers to take it down, which may confuse  other OSDs and decrease the reliability of the cluster. 

This patch try to find out the above case as soon as possible, that is: if __statfs__ to the basedir returned ENOENT, which means the file referred to by path does not exist any more,  we abort quickly.
And also for other forgivable errors such as EINTR, we want update heartbeat peers normally. 

Verified locally, and below is part of the result:
```
    -1> 2016-02-19 19:47:57.640730 7f69bebd7700  0 filestore(/home/xxg/ceph-0.94.5/src/dev/osd0)  path(/home/xxg/ceph-0.94.5/src/dev
/osd0) no longer exists, aborting...
     0> 2016-02-19 19:47:57.645429 7f69bebd7700 -1 os/FileStore.cc: In function 'virtual int FileStore::statfs(statfs*)' thread 7f69
bebd7700 time 2016-02-19 19:47:57.640781
os/FileStore.cc: 660: FAILED assert(0)
```