### PR TITLE
osd: filestore: fix wrong scope of result code for error cases during mkfs

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -877,16 +877,17 @@ int FileStore::mkfs()
     uint64_t initial_seq = 0;
     int fd = read_op_seq(&initial_seq);
     if (fd < 0) {
+      ret = fd;
       derr << "mkfs: failed to create " << current_op_seq_fn << ": "
-	   << cpp_strerror(fd) << dendl;
+	   << cpp_strerror(ret) << dendl;
       goto close_fsid_fd;
     }
     if (initial_seq == 0) {
-      int err = write_op_seq(fd, 1);
-      if (err < 0) {
+      ret = write_op_seq(fd, 1);
+      if (ret < 0) {
 	VOID_TEMP_FAILURE_RETRY(::close(fd));
 	derr << "mkfs: failed to write to " << current_op_seq_fn << ": "
-	     << cpp_strerror(err) << dendl;
+	     << cpp_strerror(ret) << dendl;
 	goto close_fsid_fd;
       }
 


### PR DESCRIPTION
During the __mkfs__ process, if we fail to read and sometimes rewrite the
op_seq, the __mkfs__ process is abnormally terminated but we may
still return a positive answer to the caller, which is confusing and misleading.

This patch is provided to solve the above problems by correctly setting
'ret' correspondingly under these two cases, which is the final answer to
be passed out to caller.

Fixes: #14814
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>