### PR TITLE
osd: filestore: fix wrong scope of result code for error cases during mount

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -1466,6 +1466,7 @@ int FileStore::mount()
 
   op_fd = read_op_seq(&initial_op_seq);
   if (op_fd < 0) {
+    ret = op_fd;
     derr << "FileStore::mount: read_op_seq failed" << dendl;
     goto close_current_fd;
   }
@@ -1482,6 +1483,7 @@ int FileStore::mount()
     // from it.
     int r = ::creat(nosnapfn, 0644);
     if (r < 0) {
+      ret = -errno;
       derr << "FileStore::mount: failed to create current/nosnap" << dendl;
       goto close_current_fd;
     }


### PR DESCRIPTION
…ount

This pr is similar to https://github.com/ceph/ceph/pull/7704
but I feel like making a new one in case they need to be treated separately,
such as one needs to be backported while the other does not, and vice versa.

During the mount process, if we fail to read op_seq or create a no-snap-fn,
the mount process is abnormally terminated but we may
still return a positive answer to the caller, which is misleading.

This patch is provided to solve the above problems by correctly setting
'ret' correspondingly under these cases, which is the final answer to
be passed out for caller.

Fixes: #14815
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>