### PR TITLE
rgw: do not validate bucket name if request does not specify it

### DIFF
--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -544,6 +544,10 @@ static inline int valid_s3_bucket_name(const string& name, bool relaxed=false)
   // (The requirements, not the recommendations.)
   int len = name.size();
   if (len < 3) {
+    if (len == 0) {
+      // This request doesn't specify a bucket at all
+      return 0;
+    }
     // Name too short
     return -ERR_INVALID_BUCKET_NAME;
   } else if (len > 255) {


### PR DESCRIPTION
The issue is introduced by commit 2f706ef

Fixes: #14816

Signed-off-by: Dunrong Huang <riegamaths@gmail.com>