### PR TITLE
rgw: avoid 2 override hidden/invalid deleted warnings

### DIFF
--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -152,6 +152,8 @@ namespace rgw {
 
     virtual int read_permissions(RGWOp *op);
 
+  private:
+    int init(RGWRados*, struct req_state*, RGWClientIO*) /* = delete */;
   }; /* RGWLibRequest */
 
   class RGWLibContinuedReq : public RGWLibRequest {

--- a/src/rgw/rgw_os_lib.cc
+++ b/src/rgw/rgw_os_lib.cc
@@ -59,4 +59,9 @@ namespace rgw {
     return 0;
   } /* init_from_header */
 
+  int RGWLibRequest::init(RGWRados*, struct req_state*, RGWClientIO*)
+  {
+    assert(false);
+  }
+
 } /* namespace rgw */

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1371,7 +1371,7 @@ int RGWHandler_REST::validate_tenant_name(string const& t)
 
 // This function enforces Amazon's spec for bucket names.
 // (The requirements, not the recommendations.)
-int RGWHandler_REST::validate_bucket_name(const string& bucket)
+int RGWHandler_REST::validate_bucket_name(const string& bucket, bool relaxed)
 {
   int len = bucket.size();
   if (len < 3) {

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -371,7 +371,7 @@ protected:
   virtual RGWOp *op_options() { return NULL; }
 
   virtual int validate_tenant_name(const string& bucket);
-  virtual int validate_bucket_name(const string& bucket);
+  virtual int validate_bucket_name(const string& bucket, bool relaxed=false);
   virtual int validate_object_name(const string& object);
 
   static int allocate_formatter(struct req_state *s, int default_formatter,

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -395,7 +395,7 @@ public:
   RGWHandler_Auth_S3() : RGWHandler_REST() {}
   virtual ~RGWHandler_Auth_S3() {}
 
-  virtual int validate_bucket_name(const string& bucket) {
+  virtual int validate_bucket_name(const string& bucket, bool relaxed=false) {
     return 0;
   }
 
@@ -416,7 +416,6 @@ public:
   RGWHandler_REST_S3() : RGWHandler_REST() {}
   virtual ~RGWHandler_REST_S3() {}
 
-  int validate_bucket_name(const string& bucket, bool relaxed_names) = delete;
   int get_errordoc(const string& errordoc_key, string* error_content);  
 
   virtual int init(RGWRados *store, struct req_state *s, RGWClientIO *cio);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1366,7 +1366,8 @@ int RGWHandler_REST_SWIFT::postauth_init()
   return 0;
 }
 
-int RGWHandler_REST_SWIFT::validate_bucket_name(const string& bucket)
+int RGWHandler_REST_SWIFT::validate_bucket_name(const string& bucket,
+						bool relaxed)
 {
   int ret = RGWHandler_REST::validate_bucket_name(bucket);
   if (ret < 0)

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -190,7 +190,7 @@ public:
   RGWHandler_REST_SWIFT() {}
   virtual ~RGWHandler_REST_SWIFT() {}
 
-  int validate_bucket_name(const string& bucket);
+  int validate_bucket_name(const string& bucket, bool relaxed=false);
 
   int init(RGWRados *store, struct req_state *s, RGWClientIO *cio);
   int authorize();


### PR DESCRIPTION
* a virtual function should not be deleted in a descendant (misuse)
* avoid override hidden warnings for validate_bucket_name and init

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>