### PR TITLE
os/filestore: fix result handling logic of destroy_collection

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4340,8 +4340,10 @@ int FileStore::_rmattrs(const coll_t& cid, const ghobject_t& oid,
       char n[CHAIN_XATTR_MAX_NAME_LEN];
       get_attrname(p->first.c_str(), n, CHAIN_XATTR_MAX_NAME_LEN);
       r = chain_fremovexattr(**fd, n);
-      if (r < 0)
-	break;
+      if (r < 0) {
+        dout(10) << __func__ << " could not remove xattr r = " << r << dendl;
+	goto out_close;
+      }
     }
   }
 

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4119,7 +4119,6 @@ int FileStore::getattrs(const coll_t& _cid, const ghobject_t& oid, map<string,bu
   if (r < 0) {
     goto out;
   }
-  lfn_close(fd);
 
   if (!spill_out) {
     dout(10) << __func__ << " no xattr exists in object_map r = " << r << dendl;

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2988,7 +2988,7 @@ int FileStore::read(
   if (m_filestore_sloppy_crc && (!replaying || backend->can_checkpoint())) {
     ostringstream ss;
     int errors = backend->_crc_verify_read(**fd, offset, got, bl, &ss);
-    if (errors > 0) {
+    if (errors != 0) {
       dout(0) << "FileStore::read " << cid << "/" << oid << " " << offset << "~"
 	      << got << " ... BAD CRC:\n" << ss.str() << dendl;
       assert(0 == "bad crc on read");

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3385,7 +3385,11 @@ int FileStore::_do_sparse_copy_range(int from, int to, uint64_t srcoff, uint64_t
     r = _do_fiemap(from, srcoff, len, &exomap);
   }
 
-  int64_t written = 0;
+ 
+ int64_t written = 0;
+ if (r < 0)
+    goto out;
+
   for (map<uint64_t, uint64_t>::iterator miter = exomap.begin(); miter != exomap.end(); ++miter) {
     uint64_t it_off = miter->first - srcoff + dstoff;
     r = _do_copy_range(from, to, miter->first, miter->second, it_off, true);

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -1332,7 +1332,6 @@ int FileStore::mount()
 
   ret = read_superblock();
   if (ret < 0) {
-    ret = -EINVAL;
     goto close_fsid_fd;
   }
 

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3907,7 +3907,6 @@ int FileStore::snapshot(const string& name)
 
   int r = backend->create_checkpoint(s, NULL);
   if (r) {
-    r = -errno;
     derr << "snapshot " << name << " failed: " << cpp_strerror(r) << dendl;
   }
 


### PR DESCRIPTION
The problem here is if we fail to remove the original collection,
we may go on to removing the temp collection(if there is any) and
succeed(although the probability can be really small), then the
result code for the former operation can be overwritten, which is
unsafe and can be misleading.

This pr solves the above problem by starting the process of
parallelly removing a temp collection only if we succeed in
removing the original collection.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>