### PR TITLE
test/time: no need to abs(uint64_t) for comparing

### DIFF
--- a/src/test/common/test_time.cc
+++ b/src/test/common/test_time.cc
@@ -122,7 +122,7 @@ static void system_clock_conversions() {
 
   ASSERT_EQ(Clock::to_double(brt), bd);
   // Fudge factor
-  ASSERT_LT(abs((Clock::from_double(bd) - brt).count()), 30);
+  ASSERT_LT((Clock::from_double(bd) - brt).count(), 30U);
 }
 
 TEST(RealClock, Sanity) {


### PR DESCRIPTION
fixes
```
/home/kefu/dev/ceph/src/test/common/test_time.cc: In instantiation of
‘void system_clock_conversions() [with Clock =
ceph::time_detail::real_clock]’:
/home/kefu/dev/ceph/src/test/common/test_time.cc:134:40:   required from
here
/home/kefu/dev/ceph/src/test/common/test_time.cc:125:169: error: call of
overloaded ‘abs(std::chrono::duration<long unsigned int, std::ratio<1l,
1000000000l> >::rep)’ is ambiguous
   ASSERT_LT(abs((Clock::from_double(bd) - brt).count()), 30);
```

as std::abs() in libstdc++ shipped with gcc 6 does not have a specialization for unsigned types, and we
are using uint64_t as the `typename duration<>::rep`.

Signed-off-by: Kefu Chai <kchai@redhat.com>