### PR TITLE
ceph_detect_init/__init__.py: remove shebang

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 <contact@redhat.com>
 #
 # Author: Alfredo Deza <adeza@redhat.com>


### PR DESCRIPTION
This file is installed with permissions 644, making the shebang
redundant and causing RPMLINT to complain.

Signed-off-by: Nathan Cutler <ncutler@suse.com>