### PR TITLE
librbd: retrieve image name when opening by id

### DIFF
--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -152,6 +152,9 @@ namespace librbd {
     // operations on rbd_directory objects
     int dir_get_id(librados::IoCtx *ioctx, const std::string &oid,
 		   const std::string &name, std::string *id);
+    void dir_get_name_start(librados::ObjectReadOperation *op,
+			    const std::string &id);
+    int dir_get_name_finish(bufferlist::iterator *it, std::string *name);
     int dir_get_name(librados::IoCtx *ioctx, const std::string &oid,
 		     const std::string &id, std::string *name);
     int dir_list(librados::IoCtx *ioctx, const std::string &oid,

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -197,6 +197,7 @@ namespace librbd {
 	     const char *snap, IoCtx& p, bool read_only);
     ~ImageCtx();
     void init();
+    void shutdown();
     void init_layout();
     void perf_start(std::string name);
     void perf_stop();

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -248,10 +248,7 @@ void CloseRequest<I>::handle_flush_image_watcher(int r) {
 
 template <typename I>
 void CloseRequest<I>::finish() {
-  if (m_image_ctx->image_watcher != nullptr) {
-    m_image_ctx->unregister_watch();
-  }
-
+  m_image_ctx->shutdown();
   m_on_finish->complete(m_error_result);
   delete this;
 }

--- a/src/librbd/image/OpenRequest.h
+++ b/src/librbd/image/OpenRequest.h
@@ -38,7 +38,7 @@ private:
    *    \-----> V2_DETECT_HEADER                    |             .
    *                |                               |             .
    *                v                               |             .
-   *            V2_GET_ID                           |             .
+   *            V2_GET_ID|NAME                      |             .
    *                |                               |             .
    *                v                               |             .
    *            V2_GET_IMMUTABLE_METADATA           |             .
@@ -77,6 +77,9 @@ private:
 
   void send_v2_get_id();
   Context *handle_v2_get_id(int *result);
+
+  void send_v2_get_name();
+  Context *handle_v2_get_name(int *result);
 
   void send_v2_get_immutable_metadata();
   Context *handle_v2_get_immutable_metadata(int *result);

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -6,6 +6,7 @@
 #include "librbd/AioImageRequest.h"
 #include "librbd/AioImageRequestWQ.h"
 #include "librbd/ExclusiveLock.h"
+#include "librbd/ImageState.h"
 #include "librbd/ImageWatcher.h"
 #include "librbd/internal.h"
 #include "librbd/ObjectMap.h"
@@ -70,6 +71,20 @@ public:
   virtual void finish(int r) {
   }
 };
+
+TEST_F(TestInternal, OpenByID) {
+   REQUIRE_FORMAT_V2();
+
+   librbd::ImageCtx *ictx;
+   ASSERT_EQ(0, open_image(m_image_name, &ictx));
+   std::string id = ictx->id;
+   close_image(ictx);
+
+   ictx = new librbd::ImageCtx("", id, nullptr, m_ioctx, true);
+   ASSERT_EQ(0, ictx->state->open());
+   ASSERT_EQ(ictx->name, m_image_name);
+   close_image(ictx);
+}
 
 TEST_F(TestInternal, IsExclusiveLockOwner) {
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);


### PR DESCRIPTION
name is empty when the image is opened by its id.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>