### PR TITLE
test: create pools for rbd tests with different prefix

### DIFF
--- a/src/test/librados/test.cc
+++ b/src/test/librados/test.cc
@@ -20,7 +20,7 @@
 
 using namespace librados;
 
-std::string get_temp_pool_name()
+std::string get_temp_pool_name(const std::string &prefix)
 {
   char hostname[80];
   char out[80];
@@ -30,9 +30,7 @@ std::string get_temp_pool_name()
   static int num = 1;
   sprintf(out, "%s-%d-%d", hostname, getpid(), num);
   num++;
-  std::string prefix("test-rados-api-");
-  prefix += out;
-  return prefix;
+  return prefix + out;
 }
 
 int wait_for_healthy(rados_t *cluster)

--- a/src/test/librados/test.h
+++ b/src/test/librados/test.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <unistd.h>
 
-std::string get_temp_pool_name();
+std::string get_temp_pool_name(const std::string &prefix = "test-rados-api-");
 
 std::string create_one_pool(const std::string &pool_name, rados_t *cluster,
     uint32_t pg_num=0);

--- a/src/test/librbd/test_fixture.cc
+++ b/src/test/librbd/test_fixture.cc
@@ -24,7 +24,7 @@ TestFixture::TestFixture() : m_image_size(0) {
 }
 
 void TestFixture::SetUpTestCase() {
-  _pool_name = get_temp_pool_name();
+  _pool_name = get_temp_pool_name("test-librbd-");
   ASSERT_EQ("", create_one_pool_pp(_pool_name, _rados));
 }
 

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -209,13 +209,13 @@ public:
     librados::Rados rados;
     std::string pool_name;
     if (unique) {
-      pool_name = get_temp_pool_name();
+      pool_name = get_temp_pool_name("test-librbd-");
       EXPECT_EQ("", create_one_pool_pp(pool_name, rados));
       _unique_pool_names.push_back(pool_name);
     } else if (m_pool_number < _pool_names.size()) {
       pool_name = _pool_names[m_pool_number];
     } else {
-      pool_name = get_temp_pool_name();
+      pool_name = get_temp_pool_name("test-librbd-");
       EXPECT_EQ("", create_one_pool_pp(pool_name, rados));
       _pool_names.push_back(pool_name);
     }

--- a/src/test/rbd_mirror/test_ClusterWatcher.cc
+++ b/src/test/rbd_mirror/test_ClusterWatcher.cc
@@ -44,7 +44,7 @@ public:
 
   void create_pool(bool enable_mirroring, const peer_t &peer,
                    string *uuid = nullptr, string *name=nullptr) {
-    string pool_name = get_temp_pool_name();
+    string pool_name = get_temp_pool_name("test-rbd-mirror-");
     ASSERT_EQ("", create_one_pool_pp(pool_name, *m_cluster));
     int64_t pool_id = m_cluster->pool_lookup(pool_name.c_str());
     ASSERT_GE(pool_id, 0);
@@ -83,7 +83,7 @@ public:
 
   void create_cache_pool(const string &base_pool, string *cache_pool_name) {
     bufferlist inbl;
-    *cache_pool_name = get_temp_pool_name();
+    *cache_pool_name = get_temp_pool_name("test-rbd-mirror-");
     ASSERT_EQ("", create_one_pool_pp(*cache_pool_name, *m_cluster));
     ASSERT_EQ(0, m_cluster->mon_command(
       "{\"prefix\": \"osd tier add\", \"pool\": \"" + base_pool +

--- a/src/test/rbd_mirror/test_PoolWatcher.cc
+++ b/src/test/rbd_mirror/test_PoolWatcher.cc
@@ -53,7 +53,7 @@ TestPoolWatcher() : m_lock("TestPoolWatcherLock"),
   }
 
   void create_pool(bool enable_mirroring, const peer_t &peer, string *name=nullptr) {
-    string pool_name = get_temp_pool_name();
+    string pool_name = get_temp_pool_name("test-rbd-mirror-");
     ASSERT_EQ("", create_one_pool_pp(pool_name, *m_cluster));
     int64_t pool_id = m_cluster->pool_lookup(pool_name.c_str());
     ASSERT_GE(pool_id, 0);
@@ -82,7 +82,7 @@ TestPoolWatcher() : m_lock("TestPoolWatcherLock"),
 
   void create_cache_pool(const string &base_pool, string *cache_pool_name) {
     bufferlist inbl;
-    *cache_pool_name = get_temp_pool_name();
+    *cache_pool_name = get_temp_pool_name("test-rbd-mirror-");
     ASSERT_EQ("", create_one_pool_pp(*cache_pool_name, *m_cluster));
     ASSERT_EQ(0, m_cluster->mon_command(
       "{\"prefix\": \"osd tier add\", \"pool\": \"" + base_pool +


### PR DESCRIPTION
This makes easier to find out what test fails to cleanup.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>