### PR TITLE
IO block reduction

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -68,6 +68,13 @@ void handle_osd_signal(int signum)
     osd->handle_signal(signum);
 }
 
+void handle_osd_signal_info(int signum, siginfo_t *info)
+{
+  if (osd)
+    osd->handle_signal(signum, info);
+}
+
+
 void usage() 
 {
   cout << "usage: ceph-osd -i <osdid>\n"
@@ -617,6 +624,7 @@ int main(int argc, const char **argv)
   // install signal handlers
   init_async_signal_handler();
   register_async_signal_handler(SIGHUP, sighup_handler);
+  register_async_signal_handler(SIGUSR1, handle_osd_signal_info);
   register_async_signal_handler_oneshot(SIGINT, handle_osd_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_osd_signal);
 
@@ -633,6 +641,7 @@ int main(int argc, const char **argv)
   ms_objecter->wait();
 
   unregister_async_signal_handler(SIGHUP, sighup_handler);
+  unregister_async_signal_handler(SIGUSR1, handle_osd_signal_info);
   unregister_async_signal_handler(SIGINT, handle_osd_signal);
   unregister_async_signal_handler(SIGTERM, handle_osd_signal);
   shutdown_async_signal_handler();

--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -54,7 +54,8 @@ Thread::Thread()
     pid(0),
     ioprio_class(-1),
     ioprio_priority(-1),
-    cpuid(-1)
+    cpuid(-1),
+    thread_name(NULL)
 {
 }
 
@@ -81,6 +82,8 @@ void *Thread::entry_wrapper()
   }
   if (pid && cpuid >= 0)
     _set_affinity(cpuid);
+
+  pthread_setname_np(pthread_self(), thread_name);
   return entry();
 }
 
@@ -145,6 +148,9 @@ int Thread::try_create(size_t stacksize)
 
 void Thread::create(const char *name, size_t stacksize)
 {
+  assert(strlen(name) < 16);
+  thread_name = name;
+
   int ret = try_create(stacksize);
   if (ret != 0) {
     char buf[256];
@@ -152,9 +158,6 @@ void Thread::create(const char *name, size_t stacksize)
 	     "failed with error %d", ret);
     dout_emergency(buf);
     assert(ret == 0);
-  } else if (thread_id > 0) {
-      assert(strlen(name) < 16);
-      pthread_setname_np(thread_id, name);
   }
 }
 

--- a/src/common/Thread.h
+++ b/src/common/Thread.h
@@ -25,6 +25,7 @@ class Thread {
   pid_t pid;
   int ioprio_class, ioprio_priority;
   int cpuid;
+  const char *thread_name;
 
   void *entry_wrapper();
 

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -60,7 +60,7 @@ void install_sighandler(int signum, signal_handler_t handler, int flags)
   }
 }
 
-void sighup_handler(int signum)
+void sighup_handler(int signum, siginfo_t *info)
 {
   g_ceph_context->reopen_logs();
 }
@@ -171,6 +171,7 @@ struct SignalHandler : public Thread {
   struct safe_handler {
     int pipefd[2];  // write to [1], read from [0]
     signal_handler_t handler;
+    signal_handler_info_t handler_info;
   };
 
   /// all handlers
@@ -238,6 +239,7 @@ struct SignalHandler : public Thread {
 	break;
       if (r > 0) {
 	char v;
+        siginfo_t s;
 
 	// consume byte from signal socket, if any.
 	r = read(pipefd[0], &v, 1);
@@ -245,10 +247,14 @@ struct SignalHandler : public Thread {
 	lock.Lock();
 	for (unsigned signum=0; signum<32; signum++) {
 	  if (handlers[signum]) {
-	    r = read(handlers[signum]->pipefd[0], &v, 1);
-	    if (r == 1) {
-	      handlers[signum]->handler(signum);
-	    }
+	    r = read(handlers[signum]->pipefd[0], (siginfo_t *) &s, sizeof(siginfo_t));
+            // TODO use of read siginfo_t is unlcear, once it sends siginfo_t other " "
+            // got to remember about it
+	    if (r == sizeof(siginfo_t)) {
+	      handlers[signum]->handler_info(signum, &s);
+	    } else if (r == 1) {
+              handlers[signum]->handler(signum);
+            }
 	  }
 	}
 	lock.Unlock();
@@ -257,6 +263,18 @@ struct SignalHandler : public Thread {
       }
     }
     return NULL;
+  }
+
+
+  // TODO change functions below, they only differ in two places
+  void queue_signal(int signum, siginfo_t *info) {
+    // If this signal handler is registered, the callback must be
+    // defined.  We can do this without the lock because we will never
+    // have the signal handler defined without the handlers entry also
+    // being filled in.
+    assert(handlers[signum]);
+    int r = write(handlers[signum]->pipefd[1], info, sizeof(siginfo_t));
+    assert(r == sizeof(siginfo_t));
   }
 
   void queue_signal(int signum) {
@@ -271,13 +289,58 @@ struct SignalHandler : public Thread {
 
   void register_handler(int signum, signal_handler_t handler, bool oneshot);
   void unregister_handler(int signum, signal_handler_t handler);
+
+  void register_handler(int signum, signal_handler_info_t handler, bool oneshot);
+  void unregister_handler(int signum, signal_handler_info_t handler);
 };
 
 static SignalHandler *g_signal_handler = NULL;
 
+static void handler_hook(int signum, siginfo_t *info, void *ignored_ucontext_t)
+{
+  g_signal_handler->queue_signal(signum, info);
+}
+
 static void handler_hook(int signum)
 {
   g_signal_handler->queue_signal(signum);
+}
+
+// TODO change functions below, it only differ in two places looking on 
+// one without siginfo_t
+void SignalHandler::register_handler(int signum, signal_handler_info_t handler, bool oneshot)
+{
+  int r;
+
+  assert(signum >= 0 && signum < 32);
+
+  safe_handler *h = new safe_handler;
+
+  r = pipe(h->pipefd);
+  assert(r == 0);
+  r = fcntl(h->pipefd[0], F_SETFL, O_NONBLOCK);
+  assert(r == 0);
+
+  h->handler_info = handler;
+  lock.Lock();
+  handlers[signum] = h;
+  lock.Unlock();
+
+  // signal thread so that it sees our new handler
+  signal_thread();
+  
+  // install our handler
+  struct sigaction oldact;
+  struct sigaction act;
+  memset(&act, 0, sizeof(act));
+
+  act.sa_sigaction = handler_hook;
+  sigfillset(&act.sa_mask);  // mask all signals in the handler
+  act.sa_flags = oneshot ? SA_RESETHAND : 0;
+  act.sa_flags|=SA_SIGINFO;
+
+  int ret = sigaction(signum, &act, &oldact);
+  assert(ret == 0);
 }
 
 void SignalHandler::register_handler(int signum, signal_handler_t handler, bool oneshot)
@@ -312,6 +375,29 @@ void SignalHandler::register_handler(int signum, signal_handler_t handler, bool 
 
   int ret = sigaction(signum, &act, &oldact);
   assert(ret == 0);
+}
+
+// TODO change functions below, it only differ in two places looking on 
+// one without siginfo_t
+void SignalHandler::unregister_handler(int signum, signal_handler_info_t handler)
+{
+  assert(signum >= 0 && signum < 32);
+  safe_handler *h = handlers[signum];
+  assert(h);
+  assert(h->handler_info == handler);
+
+  // restore to default
+  signal(signum, SIG_DFL);
+
+  // _then_ remove our handlers entry
+  lock.Lock();
+  handlers[signum] = NULL;
+  lock.Unlock();
+
+  // this will wake up select() so that worker thread sees our handler is gone
+  close(h->pipefd[0]);
+  close(h->pipefd[1]);
+  delete h;
 }
 
 void SignalHandler::unregister_handler(int signum, signal_handler_t handler)
@@ -351,10 +437,22 @@ void shutdown_async_signal_handler()
   g_signal_handler = NULL;
 }
 
+void queue_async_signal(int signum, siginfo_t *info)
+{
+  assert(g_signal_handler);
+  g_signal_handler->queue_signal(signum, info);
+}
+
 void queue_async_signal(int signum)
 {
   assert(g_signal_handler);
   g_signal_handler->queue_signal(signum);
+}
+
+void register_async_signal_handler(int signum, signal_handler_info_t handler)
+{
+  assert(g_signal_handler);
+  g_signal_handler->register_handler(signum, handler, false);
 }
 
 void register_async_signal_handler(int signum, signal_handler_t handler)
@@ -363,10 +461,22 @@ void register_async_signal_handler(int signum, signal_handler_t handler)
   g_signal_handler->register_handler(signum, handler, false);
 }
 
+void register_async_signal_handler_oneshot(int signum, signal_handler_info_t handler)
+{
+  assert(g_signal_handler);
+  g_signal_handler->register_handler(signum, handler, true);
+}
+
 void register_async_signal_handler_oneshot(int signum, signal_handler_t handler)
 {
   assert(g_signal_handler);
   g_signal_handler->register_handler(signum, handler, true);
+}
+
+void unregister_async_signal_handler(int signum, signal_handler_info_t handler)
+{
+  assert(g_signal_handler);
+  g_signal_handler->unregister_handler(signum, handler);
 }
 
 void unregister_async_signal_handler(int signum, signal_handler_t handler)
@@ -374,6 +484,4 @@ void unregister_async_signal_handler(int signum, signal_handler_t handler)
   assert(g_signal_handler);
   g_signal_handler->unregister_handler(signum, handler);
 }
-
-
 

--- a/src/global/signal_handler.h
+++ b/src/global/signal_handler.h
@@ -21,6 +21,7 @@
 #include "acconfig.h"
 
 typedef void (*signal_handler_t)(int);
+typedef void (*signal_handler_info_t)(int, siginfo_t *);
 
 #ifndef HAVE_REENTRANT_STRSIGNAL
 # define sig_str(signum) sys_siglist[signum]
@@ -31,7 +32,7 @@ typedef void (*signal_handler_t)(int);
 void install_sighandler(int signum, signal_handler_t handler, int flags);
 
 // handles SIGHUP
-void sighup_handler(int signum);
+void sighup_handler(int signum, siginfo_t *info);
 
 // Install the standard Ceph signal handlers
 void install_standard_sighandlers(void);
@@ -44,13 +45,22 @@ void init_async_signal_handler();
 void shutdown_async_signal_handler();
 
 /// queue an async signal
+void queue_async_signal(int signum, siginfo_t *info);
 void queue_async_signal(int signum);
 
 /// install a safe, async, callback for the given signal
+void register_async_signal_handler(int signum, signal_handler_info_t handler);
 void register_async_signal_handler(int signum, signal_handler_t handler);
+void register_async_signal_handler_oneshot(int signum, signal_handler_info_t handler);
 void register_async_signal_handler_oneshot(int signum, signal_handler_t handler);
 
 /// uninstall a safe async signal callback
+void unregister_async_signal_handler(int signum, signal_handler_info_t handler);
 void unregister_async_signal_handler(int signum, signal_handler_t handler);
+
+struct sig_pthread_info {
+  pthread_t p_id;
+  char name[16];
+};
 
 #endif

--- a/src/include/assert.h
+++ b/src/include/assert.h
@@ -74,6 +74,8 @@ extern void __ceph_assertf_fail(const char *assertion, const char *file, int lin
   __attribute__ ((__noreturn__));
 extern void __ceph_assert_warn(const char *assertion, const char *file, int line, const char *function);
 
+extern void assert_release_lock();
+
 #define ceph_assert(expr)							\
   ((expr)								\
    ? __CEPH_ASSERT_VOID_CAST (0)					\

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1642,6 +1642,41 @@ void OSD::handle_signal(int signum)
   shutdown();
 }
 
+void OSD::handle_signal(int signum, siginfo_t *info)
+{
+  assert(signum == SIGUSR1);
+
+  derr << "*** Got signal " << sig_str(signum) << " with info ***" << dendl;
+
+  if (signum == SIGUSR1 && info->si_pid == getpid() && info->si_value.sival_ptr) {
+
+    sig_pthread_info *p;
+
+    p = (sig_pthread_info *) info->si_value.sival_ptr;
+
+    if (pthread_self() == p->p_id) {
+      derr << "*** Loop singal detected, ignoring. ***" << dendl;
+      assert_release_lock();
+      return;
+    }
+
+    derr << "*** Got signal from: " << p->name << ", pthread_t: 0x" << std::hex << p->p_id << dendl;
+
+    if (monc) {
+      OSDMapRef osdmap = get_osdmap();
+      if (osdmap && osdmap->is_up(whoami)) {
+        monc->send_mon_message(
+            new MOSDMarkMeDown(monc->get_fsid(),
+                               osdmap->get_inst(whoami),
+                               osdmap->get_epoch(),
+                               true //wait for ack
+                               )
+        );
+      }
+    }
+  }
+}
+
 int OSD::pre_init()
 {
   Mutex::Locker lock(osd_lock);
@@ -5491,6 +5526,8 @@ bool OSD::heartbeat_dispatch(Message *m)
 bool OSD::ms_dispatch(Message *m)
 {
   if (m->get_type() == MSG_OSD_MARK_ME_DOWN) {
+    assert_release_lock();
+
     service.got_stop_ack();
     m->put();
     return true;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -42,6 +42,7 @@
 
 #include <map>
 #include <memory>
+#include <signal.h>
 #include "include/memory.h"
 using namespace std;
 
@@ -2358,6 +2359,7 @@ public:
   int shutdown();
 
   void handle_signal(int signum);
+  void handle_signal(int signum, siginfo_t *info);
 
   /// check if we can throw out op from a disconnected client
   static bool op_is_discardable(MOSDOp *m);

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -237,7 +237,7 @@ unittest_str_list_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 check_TESTPROGRAMS += unittest_str_list
 
 unittest_log_SOURCES = log/test.cc
-unittest_log_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD)
+unittest_log_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD) $(CRYPTO_LIBS) 
 unittest_log_CXXFLAGS = $(UNITTEST_CXXFLAGS) -O2
 check_TESTPROGRAMS += unittest_log
 
@@ -292,7 +292,7 @@ unittest_bufferlist_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_TESTPROGRAMS += unittest_bufferlist
 
 unittest_xlist_SOURCES = test/test_xlist.cc
-unittest_xlist_LDADD = $(UNITTEST_LDADD) $(LIBCOMMON)
+unittest_xlist_LDADD = $(UNITTEST_LDADD) $(LIBCOMMON) $(CRYPTO_LIBS) 
 unittest_xlist_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_TESTPROGRAMS += unittest_xlist
 
@@ -395,7 +395,7 @@ unittest_ipaddr_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_TESTPROGRAMS += unittest_ipaddr
 
 unittest_texttable_SOURCES = test/test_texttable.cc
-unittest_texttable_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD)
+unittest_texttable_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD) $(CRYPTO_LIBS) 
 unittest_texttable_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_TESTPROGRAMS += unittest_texttable
 
@@ -419,7 +419,7 @@ unittest_bit_vector_LDADD = $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 check_TESTPROGRAMS += unittest_bit_vector
 
 unittest_subprocess_SOURCES = test/test_subprocess.cc
-unittest_subprocess_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD)
+unittest_subprocess_LDADD = $(LIBCOMMON) $(UNITTEST_LDADD) $(CRYPTO_LIBS) 
 unittest_subprocess_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_PROGRAMS += unittest_subprocess
 


### PR DESCRIPTION
Inform monitor that OSD is going down just before abort() in filestore and filestore journal.

Normally when there is an assert/abort in osd, cluster does not know that this osd is down. If this occur on write/read operation, IO will block until monitor realizes that osd is down.

Sending "mark down" just before abort() causes huge IO block reduction (almost to 0) on writes and reads. Tested with rados bench.

Signed-off-by: Igor Podoski <igor.podoski@ts.fujitsu.com>