### PR TITLE
rgw: fcgi should include acconfig

### DIFF
--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_RGW_FCGI_H
 #define CEPH_RGW_FCGI_H
 
+#include "acconfig.h"
 #ifdef FASTCGI_INCLUDE_DIR
 # include "fastcgi/fcgiapp.h"
 #else


### PR DESCRIPTION
As it references FASTCGI_INCLUDE_DIR which is referenced from it

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>