### PR TITLE
Improving 'make check' for ceph-disk

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1211,10 +1211,16 @@ def mount(
     if options is None:
         options = MOUNT_OPTIONS.get(fstype, '')
 
+    myTemp = STATEDIR + '/tmp'
+    # mkdtemp expect 'dir' to be existing on the system
+    # Let's be sure it's always the case
+    if not os.path.exists(myTemp):
+        os.makedirs(myTemp)
+
     # mount
     path = tempfile.mkdtemp(
         prefix='mnt.',
-        dir=STATEDIR + '/tmp',
+        dir=myTemp,
     )
     try:
         LOG.debug('Mounting %s on %s with options %s', dev, path, options)

--- a/src/ceph-disk/tests/ceph-disk.sh
+++ b/src/ceph-disk/tests/ceph-disk.sh
@@ -233,8 +233,6 @@ function test_mark_init() {
 
     ! test -f $osd_data/$(ceph-detect-init) || return 1
     test -f $osd_data/$expected || return 1
-
-    $rm -fr $osd_data
 }
 
 function test_zap() {
@@ -315,7 +313,6 @@ function test_activate_dir() {
     local osd_data=$DIR/dir
     $mkdir -p $osd_data
     test_activate $osd_data $osd_data || return 1
-    $rm -fr $osd_data
 }
 
 function test_activate_dir_bluestore() {

--- a/src/ceph-disk/tests/test_main.py
+++ b/src/ceph-disk/tests/test_main.py
@@ -315,7 +315,7 @@ class TestCephDisk(object):
             partition_uuid = "56244cf5-83ef-4984-888a-2d8b8e0e04b2"
             disk = "Xda"
             partition = "Xda1"
-            holders = ["dm-0"]
+            holders = ["dm-dummy"]
             with patch.multiple(
                     main,
                     is_held=lambda dev: holders,
@@ -346,7 +346,7 @@ class TestCephDisk(object):
             partition_uuid = "56244cf5-83ef-4984-888a-2d8b8e0e04b2"
             disk = "Xda"
             partition = "Xda1"
-            holders = ["dm-0", "dm-1"]
+            holders = ["dm-dummy", "dm-dummy1"]
             with patch.multiple(
                     main,
                     is_held=lambda dev: holders,
@@ -451,9 +451,9 @@ class TestCephDisk(object):
         data_uuid = "56244cf5-83ef-4984-888a-2d8b8e0e04b2"
         disk = "Xda"
         data = "Xda1"
-        data_holder = "dm-0"
+        data_holder = "dm-dummy"
         space = "Xda2"
-        space_holder = "dm-0"
+        space_holder = "dm-dummy"
         mount_path = '/mount/path'
         fs_type = 'ext4'
         space_uuid = "7ad5e65a-0ca5-40e4-a896-62a74ca61c55"


### PR DESCRIPTION
This PR is the first of a series that aims at improving the build process and especially the make check.

This PR makes a few changes on the ceph-disk target while taking care of 
- not conflicting with local device mappers
- avoiding permissions issues
- creating the missing directories

Enjoy,