### PR TITLE
librbd: Truncate of non-existent object results in object map flagged…

### DIFF
--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -575,4 +575,15 @@ namespace librbd {
 			   << m_object_off << "~" << m_object_len << dendl;
     send_write_op(true);
   }
+  void AioObjectTruncate::send_write() {
+    ldout(m_ictx->cct, 20) << "send_write " << this << " " << m_oid
+			   << " truncate " << m_object_off << dendl;
+    if (!m_object_exist && ! has_parent()) {
+      m_state = LIBRBD_AIO_WRITE_FLAT;
+      Context *ctx = util::create_context_callback<AioObjectRequest>(this);
+      m_ictx->op_work_queue->queue(ctx, 0);
+    } else {
+      AbstractAioObjectWrite::send_write();
+    }
+  }
 }

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -323,6 +323,7 @@ namespace librbd {
       else
 	*new_state = OBJECT_EXISTS;
     }
+    virtual void send_write();
   };
 
   class AioObjectZero : public AbstractAioObjectWrite {

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -318,7 +318,10 @@ namespace librbd {
     }
 
     virtual void pre_object_map_update(uint8_t *new_state) {
-      *new_state = OBJECT_EXISTS;
+      if (!m_object_exist && !has_parent())
+        *new_state = OBJECT_NONEXISTENT;
+      else
+	*new_state = OBJECT_EXISTS;
     }
   };
 


### PR DESCRIPTION
… as exists

Fixes: #14789

Signed-off-by: xinxin shu <xinxin.shu@intel.com>