### PR TITLE
os/ObjectStore: implement more efficient get_encoded_bytes() 

### DIFF
--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -442,6 +442,7 @@ public:
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& bl);
   void decode(json_spirit::Value& v);
+  size_t encoded_size() const;
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ghobject_t*>& o);
   friend int cmp_nibblewise(const ghobject_t& l, const ghobject_t& r);

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -808,15 +808,27 @@ public:
         return 1 + 8 + 8 + 4 + 4 + 4 + 4 + 4 + tbl.length();
       else {
         //layout: data_bl + op_bl + coll_index + object_index + data
-        //TODO: maybe we need better way to get encoded bytes;
-        bufferlist bl;
-        ::encode(coll_index, bl);
-        ::encode(object_index, bl);
 
+        // coll_index size, object_index size and sizeof(transaction_data)
+        // all here, so they may be computed at compile-time
+        size_t final_size = sizeof(__u32) * 2 + sizeof(data);
+
+        // coll_index second and object_index second
+        final_size += (coll_index.size() + object_index.size()) * sizeof(__le32);
+
+        // coll_index first
+        for (auto p = coll_index.begin(); p != coll_index.end(); ++p) {
+          final_size += p->first.encoded_size();
+        }
+
+        // object_index first
+        for (auto p = object_index.begin(); p != object_index.end(); ++p) {
+          final_size += p->first.encoded_size();
+        }
+        
         return data_bl.length() +
           op_bl.length() +
-          bl.length() +
-          sizeof(data);
+          final_size;
       }
     }
 

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -832,6 +832,24 @@ public:
       }
     }
 
+    /// Retain old version for regression testing purposes
+    uint64_t get_encoded_bytes_test() {
+      if (use_tbl)
+        return 1 + 8 + 8 + 4 + 4 + 4 + 4 + 4 + tbl.length();
+      else {
+        //layout: data_bl + op_bl + coll_index + object_index + data
+
+        bufferlist bl;
+        ::encode(coll_index, bl);
+        ::encode(object_index, bl);
+
+        return data_bl.length() +
+          op_bl.length() +
+          bl.length() +
+          sizeof(data);
+      }
+    }
+
     uint64_t get_num_bytes() {
       return get_encoded_bytes();
     }

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -4038,7 +4038,6 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	}
 
 	// read into a buffer
-	bufferlist bl;
 	bool async = false;
 	if (trimmed_read && op.extent.length == 0) {
 	  // read size was trimmed to zero and it is expected to do nothing

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -624,6 +624,7 @@ public:
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& bl);
+  size_t encoded_size() const;
 
   inline bool operator==(const coll_t& rhs) const {
     // only compare type if meta

--- a/src/test/objectstore/test_transaction.cc
+++ b/src/test/objectstore/test_transaction.cc
@@ -14,6 +14,8 @@
 
 #include "os/ObjectStore.h"
 #include <gtest/gtest.h>
+#include "common/Clock.h"
+#include "include/utime.h"
 
 TEST(Transaction, MoveConstruct)
 {
@@ -72,4 +74,116 @@ TEST(Transaction, Swap)
   std::swap(a, b); // swap a and b
   ASSERT_TRUE(a.empty());
   ASSERT_FALSE(b.empty());
+}
+
+ObjectStore::Transaction generate_transaction()
+{
+  auto a = ObjectStore::Transaction{};
+  a.set_use_tbl(false);
+  a.nop();
+
+  coll_t cid;
+  object_t obj("test_name");
+  snapid_t snap(0);
+  hobject_t hoid(obj, "key", snap, 0, 0, "nspace");
+  ghobject_t oid(hoid);
+
+  coll_t acid;
+  object_t aobj("another_test_name");
+  snapid_t asnap(0);
+  hobject_t ahoid(obj, "another_key", snap, 0, 0, "another_nspace");
+  ghobject_t aoid(hoid);
+  std::set<string> keys;
+  keys.insert("any_1");
+  keys.insert("any_2");
+  keys.insert("any_3");
+
+  bufferlist bl;
+  bl.append_zero(4096);
+
+  a.write(cid, oid, 1, 4096, bl, 0);
+
+  a.omap_setkeys(acid, aoid, bl);
+
+  a.omap_rmkeys(cid, aoid, keys);
+
+  a.touch(acid, oid);
+
+  return a;
+}
+
+TEST(Transaction, GetNumBytes)
+{
+  auto a = ObjectStore::Transaction{};
+  a.set_use_tbl(false);
+  a.nop();
+  ASSERT_TRUE(a.get_encoded_bytes() == a.get_encoded_bytes_test());
+
+  coll_t cid;
+  object_t obj("test_name");
+  snapid_t snap(0);
+  hobject_t hoid(obj, "key", snap, 0, 0, "nspace");
+  ghobject_t oid(hoid);
+
+  coll_t acid;
+  object_t aobj("another_test_name");
+  snapid_t asnap(0);
+  hobject_t ahoid(obj, "another_key", snap, 0, 0, "another_nspace");
+  ghobject_t aoid(hoid);
+  std::set<string> keys;
+  keys.insert("any_1");
+  keys.insert("any_2");
+  keys.insert("any_3");
+
+  bufferlist bl;
+  bl.append_zero(4096);
+
+  a.write(cid, oid, 1, 4096, bl, 0);
+  ASSERT_TRUE(a.get_encoded_bytes() == a.get_encoded_bytes_test());
+
+  a.omap_setkeys(acid, aoid, bl);
+  ASSERT_TRUE(a.get_encoded_bytes() == a.get_encoded_bytes_test());
+
+  a.omap_rmkeys(cid, aoid, keys);
+  ASSERT_TRUE(a.get_encoded_bytes() == a.get_encoded_bytes_test());
+
+  a.touch(acid, oid);
+  ASSERT_TRUE(a.get_encoded_bytes() == a.get_encoded_bytes_test());
+}
+
+void bench_num_bytes(bool legacy)
+{
+  const int max = 2500000;
+  auto a = generate_transaction();
+
+  if (legacy) {
+    cout << "get_encoded_bytes_test: ";
+  } else {
+    cout << "get_encoded_bytes: ";
+  }
+
+  utime_t start = ceph_clock_now(NULL);
+  if (legacy) {
+    for (int i = 0; i < max; ++i) {
+      a.get_encoded_bytes_test();
+    }
+  } else {
+    for (int i = 0; i < max; ++i) {
+      a.get_encoded_bytes();
+    }
+  }
+
+  utime_t end = ceph_clock_now(NULL);
+  cout << max << " encodes in " << (end - start) << std::endl;
+
+}
+
+TEST(Transaction, GetNumBytesBenchLegacy)
+{
+   bench_num_bytes(true);
+}
+
+TEST(Transaction, GetNumBytesBenchCurrent)
+{
+   bench_num_bytes(false);
 }


### PR DESCRIPTION
Previous version explicitly encoded entire transaction just to get
its length, which resulted in encoding it twice. New method adds
encoded_size() methods to ghobject_t and coll_t, which return their
encoded size without explicit encoding, and in turn, reducing memory
manager pressure and CPU time spent. Added a test so a change
to ghobject_t and/or coll_t encoding should trigger test failure.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>