### PR TITLE
journal: improve commit position tracking

### DIFF
--- a/src/cls/journal/cls_journal_types.cc
+++ b/src/cls/journal/cls_journal_types.cc
@@ -7,51 +7,50 @@
 namespace cls {
 namespace journal {
 
-void EntryPosition::encode(bufferlist& bl) const {
+void ObjectPosition::encode(bufferlist& bl) const {
   ENCODE_START(1, 1, bl);
+  ::encode(object_number, bl);
   ::encode(tag_tid, bl);
   ::encode(entry_tid, bl);
   ENCODE_FINISH(bl);
 }
 
-void EntryPosition::decode(bufferlist::iterator& iter) {
+void ObjectPosition::decode(bufferlist::iterator& iter) {
   DECODE_START(1, iter);
+  ::decode(object_number, iter);
   ::decode(tag_tid, iter);
   ::decode(entry_tid, iter);
   DECODE_FINISH(iter);
 }
 
-void EntryPosition::dump(Formatter *f) const {
+void ObjectPosition::dump(Formatter *f) const {
+  f->dump_unsigned("object_number", object_number);
   f->dump_unsigned("tag_tid", tag_tid);
   f->dump_unsigned("entry_tid", entry_tid);
 }
 
-void EntryPosition::generate_test_instances(std::list<EntryPosition *> &o) {
-  o.push_back(new EntryPosition());
-  o.push_back(new EntryPosition(1, 2));
+void ObjectPosition::generate_test_instances(std::list<ObjectPosition *> &o) {
+  o.push_back(new ObjectPosition());
+  o.push_back(new ObjectPosition(1, 2, 3));
 }
 
 void ObjectSetPosition::encode(bufferlist& bl) const {
   ENCODE_START(1, 1, bl);
-  ::encode(object_number, bl);
-  ::encode(entry_positions, bl);
+  ::encode(object_positions, bl);
   ENCODE_FINISH(bl);
 }
 
 void ObjectSetPosition::decode(bufferlist::iterator& iter) {
   DECODE_START(1, iter);
-  ::decode(object_number, iter);
-  ::decode(entry_positions, iter);
+  ::decode(object_positions, iter);
   DECODE_FINISH(iter);
 }
 
 void ObjectSetPosition::dump(Formatter *f) const {
-  f->dump_unsigned("object_number", object_number);
-  f->open_array_section("entry_positions");
-  for (EntryPositions::const_iterator it = entry_positions.begin();
-       it != entry_positions.end(); ++it) {
-    f->open_object_section("entry_position");
-    it->dump(f);
+  f->open_array_section("object_positions");
+  for (auto &pos : object_positions) {
+    f->open_object_section("object_position");
+    pos.dump(f);
     f->close_section();
   }
   f->close_section();
@@ -60,7 +59,7 @@ void ObjectSetPosition::dump(Formatter *f) const {
 void ObjectSetPosition::generate_test_instances(
     std::list<ObjectSetPosition *> &o) {
   o.push_back(new ObjectSetPosition());
-  o.push_back(new ObjectSetPosition(1, {{1, 120}, {2, 121}}));
+  o.push_back(new ObjectSetPosition({{0, 1, 120}, {121, 2, 121}}));
 }
 
 void Client::encode(bufferlist& bl) const {
@@ -97,7 +96,7 @@ void Client::generate_test_instances(std::list<Client *> &o) {
 
   o.push_back(new Client());
   o.push_back(new Client("id", data));
-  o.push_back(new Client("id", data, {1, {{1, 120}, {2, 121}}}));
+  o.push_back(new Client("id", data, {{{1, 2, 120}, {2, 3, 121}}}));
 }
 
 void Tag::encode(bufferlist& bl) const {
@@ -134,19 +133,20 @@ void Tag::generate_test_instances(std::list<Tag *> &o) {
 }
 
 std::ostream &operator<<(std::ostream &os,
-                         const EntryPosition &entry_position) {
-  os << "[tag_tid=" << entry_position.tag_tid << ", entry_tid="
-     << entry_position.entry_tid << "]";
+                         const ObjectPosition &object_position) {
+  os << "["
+     << "object_number=" << object_position.object_number << ", "
+     << "tag_tid=" << object_position.tag_tid << ", "
+     << "entry_tid=" << object_position.entry_tid << "]";
   return os;
 }
 
 std::ostream &operator<<(std::ostream &os,
                          const ObjectSetPosition &object_set_position) {
-  os << "[object_number=" << object_set_position.object_number << ", "
-     << "positions=[";
+  os << "[positions=[";
   std::string delim;
-  for (auto &entry_position : object_set_position.entry_positions) {
-    os << entry_position << delim;
+  for (auto &object_position : object_set_position.object_positions) {
+    os << object_position << delim;
     delim = ", ";
   }
   os << "]]";

--- a/src/cls/journal/cls_journal_types.cc
+++ b/src/cls/journal/cls_journal_types.cc
@@ -146,7 +146,7 @@ std::ostream &operator<<(std::ostream &os,
   os << "[positions=[";
   std::string delim;
   for (auto &object_position : object_set_position.object_positions) {
-    os << object_position << delim;
+    os << delim << object_position;
     delim = ", ";
   }
   os << "]]";

--- a/src/cls/journal/cls_journal_types.h
+++ b/src/cls/journal/cls_journal_types.h
@@ -19,50 +19,54 @@ class Formatter;
 namespace cls {
 namespace journal {
 
-struct EntryPosition {
+struct ObjectPosition {
+  uint64_t object_number;
   uint64_t tag_tid;
   uint64_t entry_tid;
 
-  EntryPosition() : tag_tid(0), entry_tid(0) {}
-  EntryPosition(uint64_t _tag_tid, uint64_t _entry_tid)
-    : tag_tid(_tag_tid), entry_tid(_entry_tid) {}
+  ObjectPosition() : object_number(0), tag_tid(0), entry_tid(0) {}
+  ObjectPosition(uint64_t _object_number, uint64_t _tag_tid,
+                 uint64_t _entry_tid)
+    : object_number(_object_number), tag_tid(_tag_tid), entry_tid(_entry_tid) {}
 
-  inline bool operator==(const EntryPosition& rhs) const {
-    return (tag_tid == rhs.tag_tid && entry_tid == rhs.entry_tid);
+  inline bool operator==(const ObjectPosition& rhs) const {
+    return (object_number == rhs.object_number &&
+            tag_tid == rhs.tag_tid &&
+            entry_tid == rhs.entry_tid);
   }
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& iter);
   void dump(Formatter *f) const;
 
-  inline bool operator<(const EntryPosition &rhs) const {
-    if (tag_tid != rhs.tag_tid) {
+  inline bool operator<(const ObjectPosition &rhs) const {
+    if (object_number != rhs.object_number) {
+      return object_number < rhs.object_number;
+    } else if (tag_tid != rhs.tag_tid) {
       return tag_tid < rhs.tag_tid;
     }
     return entry_tid < rhs.entry_tid;
   }
 
-  static void generate_test_instances(std::list<EntryPosition *> &o);
+  static void generate_test_instances(std::list<ObjectPosition *> &o);
 };
 
-typedef std::list<EntryPosition> EntryPositions;
+typedef std::list<ObjectPosition> ObjectPositions;
 
 struct ObjectSetPosition {
-  uint64_t object_number;
-  EntryPositions entry_positions;
+  // stored in most-recent -> least recent committed entry order
+  ObjectPositions object_positions;
 
-  ObjectSetPosition() : object_number(0) {}
-  ObjectSetPosition(uint64_t _object_number,
-                    const EntryPositions &_entry_positions)
-    : object_number(_object_number), entry_positions(_entry_positions) {}
+  ObjectSetPosition() {}
+  ObjectSetPosition(const ObjectPositions &_object_positions)
+    : object_positions(_object_positions) {}
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& iter);
   void dump(Formatter *f) const;
 
   inline bool operator==(const ObjectSetPosition &rhs) const {
-    return (object_number == rhs.object_number &&
-            entry_positions == rhs.entry_positions);
+    return (object_positions == rhs.object_positions);
   }
 
   static void generate_test_instances(std::list<ObjectSetPosition *> &o);
@@ -121,13 +125,13 @@ struct Tag {
   static void generate_test_instances(std::list<Tag *> &o);
 };
 
-WRITE_CLASS_ENCODER(EntryPosition);
+WRITE_CLASS_ENCODER(ObjectPosition);
 WRITE_CLASS_ENCODER(ObjectSetPosition);
 WRITE_CLASS_ENCODER(Client);
 WRITE_CLASS_ENCODER(Tag);
 
 std::ostream &operator<<(std::ostream &os,
-                         const EntryPosition &entry_position);
+                         const ObjectPosition &object_position);
 std::ostream &operator<<(std::ostream &os,
                          const ObjectSetPosition &object_set_position);
 std::ostream &operator<<(std::ostream &os,

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -20,33 +20,6 @@ using namespace cls::journal;
 
 namespace {
 
-// does not compare object number
-inline bool object_positions_less_equal(const ObjectSetPosition &lhs,
-                                       const ObjectSetPosition &rhs) {
-  if (lhs.object_positions == rhs.object_positions) {
-    return true;
-  }
-
-  if (lhs.object_positions.size() != rhs.object_positions.size()) {
-    return lhs.object_positions.size() < rhs.object_positions.size();
-  }
-
-  std::map<uint64_t, uint64_t> rhs_tids;
-  for (ObjectPositions::const_iterator it = rhs.object_positions.begin();
-       it != rhs.object_positions.end(); ++it) {
-    rhs_tids[it->tag_tid] = it->entry_tid;
-  }
-
-  for (ObjectPositions::const_iterator it = lhs.object_positions.begin();
-       it != lhs.object_positions.end(); ++it) {
-    const ObjectPosition &object_position = *it;
-    if (object_position.entry_tid < rhs_tids[object_position.tag_tid]) {
-      return true;
-    }
-  }
-  return false;
-}
-
 struct C_AllocateTag : public Context {
   CephContext *cct;
   librados::IoCtx &ioctx;
@@ -491,34 +464,6 @@ void JournalMetadata::flush_commit_position(Context *on_safe) {
   handle_commit_position_task();
 }
 
-void JournalMetadata::set_commit_position(
-    const ObjectSetPosition &commit_position, Context *on_safe) {
-  assert(on_safe != NULL);
-
-  Context *stale_ctx = nullptr;
-  {
-    Mutex::Locker timer_locker(m_timer_lock);
-    Mutex::Locker locker(m_lock);
-    ldout(m_cct, 20) << __func__ << ": current=" << m_client.commit_position
-                     << ", new=" << commit_position << dendl;
-    if (object_positions_less_equal(commit_position, m_client.commit_position) ||
-        object_positions_less_equal(commit_position, m_commit_position)) {
-      stale_ctx = on_safe;
-    } else {
-      stale_ctx = m_commit_position_ctx;
-
-      m_client.commit_position = commit_position;
-      m_commit_position = commit_position;
-      m_commit_position_ctx = on_safe;
-      schedule_commit_task();
-    }
-  }
-
-  if (stale_ctx != nullptr) {
-    stale_ctx->complete(-ESTALE);
-  }
-}
-
 void JournalMetadata::reserve_entry_tid(uint64_t tag_tid, uint64_t entry_tid) {
   Mutex::Locker locker(m_lock);
   uint64_t &allocated_entry_tid = m_allocated_entry_tids[tag_tid];
@@ -696,58 +641,84 @@ uint64_t JournalMetadata::allocate_commit_tid(uint64_t object_num,
 
   ldout(m_cct, 20) << "allocated commit tid: commit_tid=" << commit_tid << " ["
                    << "object_num=" << object_num << ", "
-                   << "tag_tid=" << tag_tid << ", entry_tid=" << entry_tid << "]"
+                   << "tag_tid=" << tag_tid << ", "
+                   << "entry_tid=" << entry_tid << "]"
                    << dendl;
   return commit_tid;
 }
 
-bool JournalMetadata::committed(uint64_t commit_tid,
-                                ObjectSetPosition *object_set_position) {
+void JournalMetadata::committed(uint64_t commit_tid,
+                                const CreateContext &create_context) {
   ldout(m_cct, 20) << "committed tid=" << commit_tid << dendl;
 
-  Mutex::Locker locker(m_lock);
+  ObjectSetPosition commit_position;
+  Context *stale_ctx = nullptr;
   {
+    Mutex::Locker timer_locker(m_timer_lock);
+    Mutex::Locker locker(m_lock);
+    assert(commit_tid > m_commit_position_tid);
+
+    if (!m_commit_position.object_positions.empty()) {
+      // in-flight commit position update
+      commit_position = m_commit_position;
+    } else {
+      // safe commit position
+      commit_position = m_client.commit_position;
+    }
+
     CommitTids::iterator it = m_pending_commit_tids.find(commit_tid);
     assert(it != m_pending_commit_tids.end());
 
     CommitEntry &commit_entry = it->second;
     commit_entry.committed = true;
-  }
 
-  if (!m_commit_position.object_positions.empty()) {
-    *object_set_position = m_commit_position;
-  } else {
-    *object_set_position = m_client.commit_position;
-  }
+    bool update_commit_position = false;
+    while (!m_pending_commit_tids.empty()) {
+      CommitTids::iterator it = m_pending_commit_tids.begin();
+      CommitEntry &commit_entry = it->second;
+      if (!commit_entry.committed) {
+        break;
+      }
 
-  bool update_commit_position = false;
-  while (!m_pending_commit_tids.empty()) {
-    CommitTids::iterator it = m_pending_commit_tids.begin();
-    CommitEntry &commit_entry = it->second;
-    if (!commit_entry.committed) {
-      break;
+      commit_position.object_positions.emplace_front(
+        commit_entry.object_num, commit_entry.tag_tid,
+        commit_entry.entry_tid);
+      m_pending_commit_tids.erase(it);
+      update_commit_position = true;
     }
 
-    // TODO
-    update_commit_position = true;
-  }
+    if (!update_commit_position) {
+      return;
+    }
 
-  if (update_commit_position) {
-    // prune the position to have unique tags in commit-order
-    std::set<uint64_t> in_use_tag_tids;
-    ObjectPositions::iterator it = object_set_position->object_positions.begin();
-    while (it != object_set_position->object_positions.end()) {
-      if (!in_use_tag_tids.insert(it->tag_tid).second) {
-        it = object_set_position->object_positions.erase(it);
+    // prune the position to have one position per splay offset
+    std::set<uint8_t> in_use_splay_offsets;
+    ObjectPositions::iterator ob_it = commit_position.object_positions.begin();
+    while (ob_it != commit_position.object_positions.end()) {
+      uint8_t splay_offset = ob_it->object_number % m_splay_width;
+      if (!in_use_splay_offsets.insert(splay_offset).second) {
+        ob_it = commit_position.object_positions.erase(ob_it);
       } else {
-        ++it;
+        ++ob_it;
       }
     }
 
-    ldout(m_cct, 20) << "updated object set position: " << *object_set_position
-                     << dendl;
+    stale_ctx = m_commit_position_ctx;
+    m_commit_position_ctx = create_context();
+    m_commit_position = commit_position;
+    m_commit_position_tid = commit_tid;
+
+    ldout(m_cct, 20) << "updated commit position: " << commit_position << ", "
+                     << "on_safe=" << m_commit_position_ctx << dendl;
+    schedule_commit_task();
   }
-  return update_commit_position;
+
+
+  if (stale_ctx != nullptr) {
+    ldout(m_cct, 20) << "canceling stale commit: on_safe=" << stale_ctx
+                     << dendl;
+    stale_ctx->complete(-ESTALE);
+  }
 }
 
 void JournalMetadata::notify_update() {

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -513,8 +513,8 @@ void JournalMetadata::handle_refresh_complete(C_Refresh *refresh, int r) {
     Client client(m_client_id, bufferlist());
     RegisteredClients::iterator it = refresh->registered_clients.find(client);
     if (it != refresh->registered_clients.end()) {
-      m_minimum_set = refresh->minimum_set;
-      m_active_set = refresh->active_set;
+      m_minimum_set = MAX(m_minimum_set, refresh->minimum_set);
+      m_active_set = MAX(m_active_set, refresh->active_set);
       m_registered_clients = refresh->registered_clients;
       m_client = *it;
 

--- a/src/journal/JournalMetadata.h
+++ b/src/journal/JournalMetadata.h
@@ -30,8 +30,8 @@ typedef boost::intrusive_ptr<JournalMetadata> JournalMetadataPtr;
 
 class JournalMetadata : public RefCountedObject, boost::noncopyable {
 public:
-  typedef cls::journal::EntryPosition EntryPosition;
-  typedef cls::journal::EntryPositions EntryPositions;
+  typedef cls::journal::ObjectPosition ObjectPosition;
+  typedef cls::journal::ObjectPositions ObjectPositions;
   typedef cls::journal::ObjectSetPosition ObjectSetPosition;
   typedef cls::journal::Client Client;
   typedef cls::journal::Tag Tag;

--- a/src/journal/JournalPlayer.cc
+++ b/src/journal/JournalPlayer.cc
@@ -164,7 +164,7 @@ bool JournalPlayer::try_pop_front(Entry *entry, uint64_t *commit_tid) {
 
     m_state = STATE_ERROR;
     m_journal_metadata->get_finisher().queue(new C_HandleComplete(
-      m_replay_handler), -EINVAL);
+      m_replay_handler), -ENOMSG);
     return false;
   }
 

--- a/src/journal/JournalPlayer.cc
+++ b/src/journal/JournalPlayer.cc
@@ -55,7 +55,7 @@ JournalPlayer::JournalPlayer(librados::IoCtx &ioctx,
     m_journal_metadata(journal_metadata), m_replay_handler(replay_handler),
     m_lock("JournalPlayer::m_lock"), m_state(STATE_INIT), m_splay_offset(0),
     m_watch_enabled(false), m_watch_scheduled(false), m_watch_interval(0),
-    m_commit_object(0), m_commit_tag_tid(0) {
+    m_commit_object(0) {
   m_replay_handler->get();
   m_ioctx.dup(ioctx);
   m_cct = reinterpret_cast<CephContext *>(m_ioctx.cct());
@@ -63,22 +63,18 @@ JournalPlayer::JournalPlayer(librados::IoCtx &ioctx,
   ObjectSetPosition commit_position;
   m_journal_metadata->get_commit_position(&commit_position);
 
-  // TODO
-  /*
   if (!commit_position.object_positions.empty()) {
-    uint8_t splay_width = m_journal_metadata->get_splay_width();
-    m_splay_offset = commit_position.object_number % splay_width;
-    m_commit_object = commit_position.object_number;
-    m_commit_tag_tid = commit_position.object_positions.front().tag_tid;
+    ldout(m_cct, 5) << "commit position: " << commit_position << dendl;
 
-    for (ObjectPositions::const_iterator it =
-           commit_position.object_positions.begin();
-         it != commit_position.object_positions.end(); ++it) {
-      const ObjectPosition &object_position = *it;
-      m_commit_tids[object_position.tag_tid] = object_position.entry_tid;
+    // start replay after the last committed entry's object
+    uint8_t splay_width = m_journal_metadata->get_splay_width();
+    m_commit_object = commit_position.object_positions.front().object_number;
+    m_splay_offset = m_commit_object % splay_width;
+    for (auto &position : commit_position.object_positions) {
+      uint8_t splay_offset = position.object_number % splay_width;
+      m_commit_positions[splay_offset] = position;
     }
   }
-  */
 }
 
 JournalPlayer::~JournalPlayer() {
@@ -92,22 +88,38 @@ void JournalPlayer::prefetch() {
   m_state = STATE_PREFETCH;
 
   uint8_t splay_width = m_journal_metadata->get_splay_width();
-  for (uint8_t splay_index = 0; splay_index < splay_width; ++splay_index) {
-    m_prefetch_splay_offsets.insert(splay_index);
+  for (uint8_t splay_offset = 0; splay_offset < splay_width; ++splay_offset) {
+    m_prefetch_splay_offsets.insert(splay_offset);
   }
 
-  uint64_t object_set = m_commit_object / splay_width;
+  // compute active object for each splay offset (might be before
+  // active set)
+  std::map<uint8_t, uint64_t> splay_offset_to_objects;
+  for (auto &position : m_commit_positions) {
+    assert(splay_offset_to_objects.count(position.first) == 0);
+    splay_offset_to_objects[position.first] = position.second.object_number;
+  }
+
+  // prefetch the active object for each splay offset (and the following object)
   uint64_t active_set = m_journal_metadata->get_active_set();
+  uint64_t max_object_number = (splay_width * (active_set + 1)) - 1;
+  std::set<uint64_t> prefetch_object_numbers;
+  for (uint8_t splay_offset = 0; splay_offset < splay_width; ++splay_offset) {
+    uint64_t object_number = splay_offset;
+    if (splay_offset_to_objects.count(splay_offset) != 0) {
+      object_number = splay_offset_to_objects[splay_offset];
+    }
 
-  uint32_t object_count = splay_width *
-                          std::min<uint64_t>(2, active_set - object_set + 1);
-  ldout(m_cct, 10) << __func__ << ": prefetching " << object_count << " "
-                   << "objects" << dendl;
+    prefetch_object_numbers.insert(object_number);
+    if (object_number + splay_width <= max_object_number) {
+      prefetch_object_numbers.insert(object_number + splay_width);
+    }
+  }
 
-  // prefetch starting from the last known commit set
-  uint64_t start_object = object_set * splay_width;
-  for (uint64_t object_number = start_object;
-       object_number < start_object + object_count; ++object_number) {
+  ldout(m_cct, 10) << __func__ << ": prefetching "
+                   << prefetch_object_numbers.size() << " " << "objects"
+                   << dendl;
+  for (auto object_number : prefetch_object_numbers) {
     fetch(object_number);
   }
 }
@@ -248,15 +260,25 @@ int JournalPlayer::process_prefetch(uint64_t object_number) {
   // prefetch in-order since a newer splay object could prefetch first
   while (!object_players.begin()->second->is_fetch_in_progress()) {
     ObjectPlayerPtr object_player = object_players.begin()->second;
+    uint64_t player_object_number = object_player->get_object_number();
 
     // skip past known committed records
-    if (!m_commit_tids.empty() && !object_player->empty()) {
-      ldout(m_cct, 15) << "seeking known commit position in "
+    if (m_commit_positions.count(splay_offset) != 0 &&
+        !object_player->empty()) {
+      ObjectPosition &position = m_commit_positions[splay_offset];
+
+      ldout(m_cct, 15) << "seeking known commit position " << position << " in "
                        << object_player->get_oid() << dendl;
+
+      bool found_commit = false;
       Entry entry;
-      while (!m_commit_tids.empty() && !object_player->empty()) {
+      while (!object_player->empty()) {
         object_player->front(&entry);
-        if (entry.get_entry_tid() > m_commit_tids[entry.get_tag_tid()]) {
+
+        if (entry.get_tag_tid() == position.tag_tid &&
+            entry.get_entry_tid() == position.entry_tid) {
+          found_commit = true;
+        } else if (found_commit) {
           ldout(m_cct, 10) << "located next uncommitted entry: " << entry
                            << dendl;
           break;
@@ -270,17 +292,22 @@ int JournalPlayer::process_prefetch(uint64_t object_number) {
 
       // if this object contains the commit position, our read should start with
       // the next consistent journal entry in the sequence
-      if (!m_commit_tids.empty() &&
-          object_player->get_object_number() == m_commit_object) {
+      if (player_object_number == m_commit_object) {
         if (object_player->empty()) {
           advance_splay_object();
         } else {
           Entry entry;
           object_player->front(&entry);
-          if (entry.get_tag_tid() == m_commit_tag_tid) {
+          if (entry.get_tag_tid() == position.tag_tid) {
             advance_splay_object();
           }
         }
+      }
+
+      // do not search for commit position for this object
+      // if we've already seen it
+      if (found_commit) {
+        m_commit_positions.erase(splay_offset);
       }
     }
 

--- a/src/journal/JournalPlayer.cc
+++ b/src/journal/JournalPlayer.cc
@@ -62,19 +62,23 @@ JournalPlayer::JournalPlayer(librados::IoCtx &ioctx,
 
   ObjectSetPosition commit_position;
   m_journal_metadata->get_commit_position(&commit_position);
-  if (!commit_position.entry_positions.empty()) {
+
+  // TODO
+  /*
+  if (!commit_position.object_positions.empty()) {
     uint8_t splay_width = m_journal_metadata->get_splay_width();
     m_splay_offset = commit_position.object_number % splay_width;
     m_commit_object = commit_position.object_number;
-    m_commit_tag_tid = commit_position.entry_positions.front().tag_tid;
+    m_commit_tag_tid = commit_position.object_positions.front().tag_tid;
 
-    for (EntryPositions::const_iterator it =
-           commit_position.entry_positions.begin();
-         it != commit_position.entry_positions.end(); ++it) {
-      const EntryPosition &entry_position = *it;
-      m_commit_tids[entry_position.tag_tid] = entry_position.entry_tid;
+    for (ObjectPositions::const_iterator it =
+           commit_position.object_positions.begin();
+         it != commit_position.object_positions.end(); ++it) {
+      const ObjectPosition &object_position = *it;
+      m_commit_tids[object_position.tag_tid] = object_position.entry_tid;
     }
   }
+  */
 }
 
 JournalPlayer::~JournalPlayer() {

--- a/src/journal/JournalPlayer.h
+++ b/src/journal/JournalPlayer.h
@@ -40,9 +40,9 @@ public:
 
 private:
   typedef std::set<uint8_t> PrefetchSplayOffsets;
-  typedef std::map<uint64_t, uint64_t> AllocatedEntryTids;
   typedef std::map<uint64_t, ObjectPlayerPtr> ObjectPlayers;
   typedef std::map<uint8_t, ObjectPlayers> SplayedObjectPlayers;
+  typedef std::map<uint8_t, ObjectPosition> SplayedObjectPositions;
 
   enum State {
     STATE_INIT,
@@ -96,8 +96,7 @@ private:
   PrefetchSplayOffsets m_prefetch_splay_offsets;
   SplayedObjectPlayers m_object_players;
   uint64_t m_commit_object;
-  uint64_t m_commit_tag_tid;
-  AllocatedEntryTids m_commit_tids;
+  SplayedObjectPositions m_commit_positions;
 
   void advance_splay_object();
 

--- a/src/journal/JournalPlayer.h
+++ b/src/journal/JournalPlayer.h
@@ -23,8 +23,8 @@ class ReplayHandler;
 
 class JournalPlayer {
 public:
-  typedef cls::journal::EntryPosition EntryPosition;
-  typedef cls::journal::EntryPositions EntryPositions;
+  typedef cls::journal::ObjectPosition ObjectPosition;
+  typedef cls::journal::ObjectPositions ObjectPositions;
   typedef cls::journal::ObjectSetPosition ObjectSetPosition;
 
   JournalPlayer(librados::IoCtx &ioctx, const std::string &object_oid_prefix,

--- a/src/journal/JournalTrimmer.cc
+++ b/src/journal/JournalTrimmer.cc
@@ -18,13 +18,18 @@ JournalTrimmer::JournalTrimmer(librados::IoCtx &ioctx,
                                const std::string &object_oid_prefix,
                                const JournalMetadataPtr &journal_metadata)
     : m_cct(NULL), m_object_oid_prefix(object_oid_prefix),
-      m_journal_metadata(journal_metadata), m_lock("JournalTrimmer::m_lock"),
-      m_remove_set_pending(false), m_remove_set(0), m_remove_set_ctx(NULL) {
+      m_journal_metadata(journal_metadata), m_metadata_listener(this),
+      m_lock("JournalTrimmer::m_lock"), m_remove_set_pending(false),
+      m_remove_set(0), m_remove_set_ctx(NULL) {
   m_ioctx.dup(ioctx);
   m_cct = reinterpret_cast<CephContext *>(m_ioctx.cct());
+
+  m_journal_metadata->add_listener(&m_metadata_listener);
 }
 
 JournalTrimmer::~JournalTrimmer() {
+  m_journal_metadata->remove_listener(&m_metadata_listener);
+
   m_journal_metadata->flush_commit_position();
   m_async_op_tracker.wait_for_ops();
 }
@@ -110,39 +115,43 @@ void JournalTrimmer::remove_set(uint64_t object_set) {
   }
 }
 
-void JournalTrimmer::handle_commit_position_safe(int r) {
-  ldout(m_cct, 20) << __func__ << ": r=" << r << dendl;
+void JournalTrimmer::handle_metadata_updated() {
+  ldout(m_cct, 20) << __func__ << dendl;
 
   Mutex::Locker locker(m_lock);
-  if (r == 0) {
-    // TODO
-    /*
-    uint8_t splay_width = m_journal_metadata->get_splay_width();
-    uint64_t object_set = object_set_position.object_number / splay_width;
 
-    JournalMetadata::RegisteredClients registered_clients;
-    m_journal_metadata->get_registered_clients(&registered_clients);
+  JournalMetadata::RegisteredClients registered_clients;
+  m_journal_metadata->get_registered_clients(&registered_clients);
 
-    bool trim_permitted = true;
-    for (JournalMetadata::RegisteredClients::iterator it =
-           registered_clients.begin();
-         it != registered_clients.end(); ++it) {
-      const JournalMetadata::Client &client = *it;
-      uint64_t client_object_set = client.commit_position.object_number /
-                                   splay_width;
-      if (client.id != m_journal_metadata->get_client_id() &&
-          client_object_set < object_set) {
-        ldout(m_cct, 20) << "object set " << client_object_set << " still "
-                         << "in-use by client " << client.id << dendl;
-        trim_permitted = false;
-        break;
+  uint8_t splay_width = m_journal_metadata->get_splay_width();
+  uint64_t minimum_set = m_journal_metadata->get_minimum_set();
+  uint64_t active_set = m_journal_metadata->get_active_set();
+  uint64_t minimum_commit_set = active_set;
+  std::string minimum_client_id;
+
+  // TODO: add support for trimming past "laggy" clients
+  for (auto &client : registered_clients) {
+    if (client.commit_position.object_positions.empty()) {
+      // client hasn't recorded any commits
+      minimum_commit_set = minimum_set;
+      minimum_client_id = client.id;
+      break;
+    }
+
+    for (auto &position : client.commit_position.object_positions) {
+      uint64_t object_set = position.object_number / splay_width;
+      if (object_set < minimum_commit_set) {
+        minimum_client_id = client.id;
+        minimum_commit_set = object_set;
       }
     }
+  }
 
-    if (trim_permitted) {
-      trim_objects(object_set_position.object_number / splay_width);
-    }
-    */
+  if (minimum_commit_set > minimum_set) {
+    trim_objects(minimum_commit_set);
+  } else {
+    ldout(m_cct, 20) << "object set " << minimum_commit_set << " still "
+                     << "in-use by client " << minimum_client_id << dendl;
   }
 }
 
@@ -153,23 +162,26 @@ void JournalTrimmer::handle_set_removed(int r, uint64_t object_set) {
   Mutex::Locker locker(m_lock);
   m_remove_set_pending = false;
 
-  if (r == 0 || (r == -ENOENT && m_remove_set_ctx == NULL)) {
-    // advance the minimum set to the next set
-    m_journal_metadata->set_minimum_set(object_set + 1);
-    uint64_t minimum_set = m_journal_metadata->get_minimum_set();
-
-    if (m_remove_set > minimum_set) {
-      m_remove_set_pending = true;
-      remove_set(minimum_set);
-    }
-  } else if (r == -ENOENT) {
+  if (r == -ENOENT) {
     // no objects within the set existed
     r = 0;
   }
+  if (r == 0) {
+    // advance the minimum set to the next set
+    m_journal_metadata->set_minimum_set(object_set + 1);
+    uint64_t active_set = m_journal_metadata->get_active_set();
+    uint64_t minimum_set = m_journal_metadata->get_minimum_set();
 
-  if (m_remove_set_ctx != NULL && !m_remove_set_pending) {
+    if (m_remove_set > minimum_set && minimum_set <= active_set) {
+      m_remove_set_pending = true;
+      remove_set(minimum_set);
+    }
+  }
+
+  if (m_remove_set_ctx != nullptr && !m_remove_set_pending) {
     ldout(m_cct, 20) << "completing remove set context" << dendl;
     m_remove_set_ctx->complete(r);
+    m_remove_set_ctx = nullptr;
   }
 }
 

--- a/src/journal/JournalTrimmer.cc
+++ b/src/journal/JournalTrimmer.cc
@@ -128,6 +128,8 @@ void JournalTrimmer::handle_commit_position_safe(
 
   Mutex::Locker locker(m_lock);
   if (r == 0) {
+    // TODO
+    /*
     uint8_t splay_width = m_journal_metadata->get_splay_width();
     uint64_t object_set = object_set_position.object_number / splay_width;
 
@@ -153,6 +155,7 @@ void JournalTrimmer::handle_commit_position_safe(
     if (trim_permitted) {
       trim_objects(object_set_position.object_number / splay_width);
     }
+    */
   }
 }
 

--- a/src/journal/JournalTrimmer.h
+++ b/src/journal/JournalTrimmer.h
@@ -11,6 +11,7 @@
 #include "journal/AsyncOpTracker.h"
 #include "journal/JournalMetadata.h"
 #include "cls/journal/cls_journal_types.h"
+#include <functional>
 
 namespace journal {
 
@@ -26,18 +27,22 @@ public:
   void committed(uint64_t commit_tid);
 
 private:
+  typedef std::function<Context*()> CreateContext;
+
   struct C_CommitPositionSafe : public Context {
     JournalTrimmer *journal_trimmer;
-    ObjectSetPosition object_set_position;
 
-    C_CommitPositionSafe(JournalTrimmer *_journal_trimmer,
-                         const ObjectSetPosition &_object_set_position)
-      : journal_trimmer(_journal_trimmer),
-        object_set_position(_object_set_position) {}
+    C_CommitPositionSafe(JournalTrimmer *_journal_trimmer)
+      : journal_trimmer(_journal_trimmer) {
+      Mutex::Locker locker(journal_trimmer->m_lock);
+      journal_trimmer->m_async_op_tracker.start_op();
+    }
+    virtual ~C_CommitPositionSafe() {
+      journal_trimmer->m_async_op_tracker.finish_op();
+    }
 
     virtual void finish(int r) {
-      journal_trimmer->handle_commit_position_safe(r, object_set_position);
-      journal_trimmer->m_async_op_tracker.finish_op();
+      journal_trimmer->handle_commit_position_safe(r);
     }
   };
   struct C_RemoveSet : public Context {
@@ -70,10 +75,14 @@ private:
   uint64_t m_remove_set;
   Context *m_remove_set_ctx;
 
+  CreateContext m_create_commit_position_safe_context = [this]() {
+      return new C_CommitPositionSafe(this);
+    };
+
   void trim_objects(uint64_t minimum_set);
   void remove_set(uint64_t object_set);
 
-  void handle_commit_position_safe(int r, const ObjectSetPosition &position);
+  void handle_commit_position_safe(int r);
 
   void handle_set_removed(int r, uint64_t object_set);
 };

--- a/src/journal/ObjectPlayer.cc
+++ b/src/journal/ObjectPlayer.cc
@@ -161,7 +161,7 @@ int ObjectPlayer::handle_fetch_complete(int r, const bufferlist &bl) {
   }
 
   if (!m_invalid_ranges.empty()) {
-    r = -EINVAL;
+    r = -EBADMSG;
   }
   return r;
 }

--- a/src/test/cls_journal/test_cls_journal.cc
+++ b/src/test/cls_journal/test_cls_journal.cc
@@ -293,7 +293,7 @@ TEST_F(TestClsJournal, ClientUnregisterPruneTags) {
   ASSERT_EQ(0, client::tag_create(ioctx, oid, 2, 1, bufferlist()));
 
   librados::ObjectWriteOperation op1;
-  client::client_commit(&op1, "id1", {1, {{2, 120}}});
+  client::client_commit(&op1, "id1", {{{1, 2, 120}}});
   ASSERT_EQ(0, ioctx.operate(oid, &op1));
 
   ASSERT_EQ(0, client::client_unregister(ioctx, oid, "id2"));
@@ -314,12 +314,12 @@ TEST_F(TestClsJournal, ClientCommit) {
   ASSERT_EQ(0, client::create(ioctx, oid, 2, 2, ioctx.get_id()));
   ASSERT_EQ(0, client::client_register(ioctx, oid, "id1", bufferlist()));
 
-  cls::journal::EntryPositions entry_positions;
-  entry_positions = {
-    cls::journal::EntryPosition(234, 120),
-    cls::journal::EntryPosition(235, 121)};
+  cls::journal::ObjectPositions object_positions;
+  object_positions = {
+    cls::journal::ObjectPosition(0, 234, 120),
+    cls::journal::ObjectPosition(3, 235, 121)};
   cls::journal::ObjectSetPosition object_set_position(
-    1, entry_positions);
+    object_positions);
 
   librados::ObjectWriteOperation op2;
   client::client_commit(&op2, "id1", object_set_position);
@@ -342,13 +342,13 @@ TEST_F(TestClsJournal, ClientCommitInvalid) {
   ASSERT_EQ(0, client::create(ioctx, oid, 2, 2, ioctx.get_id()));
   ASSERT_EQ(0, client::client_register(ioctx, oid, "id1", bufferlist()));
 
-  cls::journal::EntryPositions entry_positions;
-  entry_positions = {
-    cls::journal::EntryPosition(234, 120),
-    cls::journal::EntryPosition(234, 121),
-    cls::journal::EntryPosition(235, 121)};
+  cls::journal::ObjectPositions object_positions;
+  object_positions = {
+    cls::journal::ObjectPosition(0, 234, 120),
+    cls::journal::ObjectPosition(4, 234, 121),
+    cls::journal::ObjectPosition(5, 235, 121)};
   cls::journal::ObjectSetPosition object_set_position(
-    1, entry_positions);
+    object_positions);
 
   librados::ObjectWriteOperation op2;
   client::client_commit(&op2, "id1", object_set_position);
@@ -468,7 +468,7 @@ TEST_F(TestClsJournal, TagCreatePrunesTags) {
   ASSERT_EQ(0, client::tag_create(ioctx, oid, 2, 1, bufferlist()));
 
   librados::ObjectWriteOperation op1;
-  client::client_commit(&op1, "id1", {1, {{2, 120}}});
+  client::client_commit(&op1, "id1", {{{1, 2, 120}}});
   ASSERT_EQ(0, ioctx.operate(oid, &op1));
 
   ASSERT_EQ(0, client::tag_create(ioctx, oid, 3, 0, bufferlist()));

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -330,7 +330,7 @@ TYPE(cls_user_get_header_ret)
 TYPE(cls_user_complete_stats_sync_op)
 
 #include "cls/journal/cls_journal_types.h"
-TYPE(cls::journal::EntryPosition)
+TYPE(cls::journal::ObjectPosition)
 TYPE(cls::journal::ObjectSetPosition)
 TYPE(cls::journal::Client)
 

--- a/src/test/journal/test_JournalMetadata.cc
+++ b/src/test/journal/test_JournalMetadata.cc
@@ -18,9 +18,10 @@ public:
   }
 
   journal::JournalMetadataPtr create_metadata(const std::string &oid,
-                                              const std::string &client_id) {
+                                              const std::string &client_id,
+                                              double commit_internal = 0.1) {
     journal::JournalMetadataPtr metadata(new journal::JournalMetadata(
-      m_ioctx, oid, client_id, 0.1));
+      m_ioctx, oid, client_id, commit_internal));
     m_metadata_list.push_back(metadata);
     metadata->add_listener(&m_listener);
     return metadata;
@@ -50,36 +51,49 @@ TEST_F(TestJournalMetadata, ClientDNE) {
   ASSERT_EQ(-ENOENT, init_metadata(metadata2));
 }
 
-TEST_F(TestJournalMetadata, SetCommitPositions) {
+TEST_F(TestJournalMetadata, Committed) {
   std::string oid = get_temp_oid();
 
   ASSERT_EQ(0, create(oid, 14, 2));
   ASSERT_EQ(0, client_register(oid, "client1", ""));
 
-  journal::JournalMetadataPtr metadata1 = create_metadata(oid, "client1");
+  journal::JournalMetadataPtr metadata1 = create_metadata(oid, "client1", 600);
   ASSERT_EQ(0, init_metadata(metadata1));
 
   journal::JournalMetadataPtr metadata2 = create_metadata(oid, "client1");
   ASSERT_EQ(0, init_metadata(metadata2));
   ASSERT_TRUE(wait_for_update(metadata2));
 
-  journal::JournalMetadata::ObjectSetPosition commit_position;
+  journal::JournalMetadata::ObjectSetPosition expect_commit_position;
   journal::JournalMetadata::ObjectSetPosition read_commit_position;
   metadata1->get_commit_position(&read_commit_position);
-  ASSERT_EQ(commit_position, read_commit_position);
+  ASSERT_EQ(expect_commit_position, read_commit_position);
 
-  journal::JournalMetadata::ObjectPositions object_positions;
-  object_positions = {
-    cls::journal::ObjectPosition(1, 123, 122)};
-  commit_position = journal::JournalMetadata::ObjectSetPosition(object_positions);
+  uint64_t commit_tid1 = metadata1->allocate_commit_tid(0, 0, 0);
+  uint64_t commit_tid2 = metadata1->allocate_commit_tid(0, 1, 0);
+  uint64_t commit_tid3 = metadata1->allocate_commit_tid(1, 0, 1);
+  uint64_t commit_tid4 = metadata1->allocate_commit_tid(0, 0, 2);
 
-  C_SaferCond cond;
-  metadata1->set_commit_position(commit_position, &cond);
-  ASSERT_EQ(0, cond.wait());
+  // cannot commit until tid1 + 2 committed
+  metadata1->committed(commit_tid2, []() { return nullptr; });
+  metadata1->committed(commit_tid3, []() { return nullptr; });
+
+  C_SaferCond cond1;
+  metadata1->committed(commit_tid1, [&cond1]() { return &cond1; });
+
+  // given our 10 minute commit internal, this should override the
+  // in-flight commit
+  C_SaferCond cond2;
+  metadata1->committed(commit_tid4, [&cond2]() { return &cond2; });
+
+  ASSERT_EQ(-ESTALE, cond1.wait());
+  metadata1->flush_commit_position();
+  ASSERT_EQ(0, cond2.wait());
+
   ASSERT_TRUE(wait_for_update(metadata2));
-
   metadata2->get_commit_position(&read_commit_position);
-  ASSERT_EQ(commit_position, read_commit_position);
+  expect_commit_position = {{{0, 0, 2}, {1, 0, 1}}};
+  ASSERT_EQ(expect_commit_position, read_commit_position);
 }
 
 TEST_F(TestJournalMetadata, UpdateActiveObject) {

--- a/src/test/journal/test_JournalMetadata.cc
+++ b/src/test/journal/test_JournalMetadata.cc
@@ -68,10 +68,10 @@ TEST_F(TestJournalMetadata, SetCommitPositions) {
   metadata1->get_commit_position(&read_commit_position);
   ASSERT_EQ(commit_position, read_commit_position);
 
-  journal::JournalMetadata::EntryPositions entry_positions;
-  entry_positions = {
-    cls::journal::EntryPosition(123, 122)};
-  commit_position = journal::JournalMetadata::ObjectSetPosition(1, entry_positions);
+  journal::JournalMetadata::ObjectPositions object_positions;
+  object_positions = {
+    cls::journal::ObjectPosition(1, 123, 122)};
+  commit_position = journal::JournalMetadata::ObjectSetPosition(object_positions);
 
   C_SaferCond cond;
   metadata1->set_commit_position(commit_position, &cond);

--- a/src/test/journal/test_JournalPlayer.cc
+++ b/src/test/journal/test_JournalPlayer.cc
@@ -310,7 +310,7 @@ TEST_F(TestJournalPlayer, PrefetchCorruptSequence) {
   uint64_t commit_tid;
   ASSERT_FALSE(player->try_pop_front(&entry, &commit_tid));
   ASSERT_TRUE(wait_for_complete(player));
-  ASSERT_NE(0, m_replay_hander.complete_result);
+  ASSERT_EQ(-ENOMSG, m_replay_hander.complete_result);
 }
 
 TEST_F(TestJournalPlayer, PrefetchAndWatch) {

--- a/src/test/journal/test_JournalPlayer.cc
+++ b/src/test/journal/test_JournalPlayer.cc
@@ -143,10 +143,10 @@ public:
 TEST_F(TestJournalPlayer, Prefetch) {
   std::string oid = get_temp_oid();
 
-  journal::JournalPlayer::EntryPositions positions;
+  journal::JournalPlayer::ObjectPositions positions;
   positions = {
-    cls::journal::EntryPosition(234, 122) };
-  cls::journal::ObjectSetPosition commit_position(0, positions);
+    cls::journal::ObjectPosition(0, 234, 122) };
+  cls::journal::ObjectSetPosition commit_position(positions);
 
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
@@ -183,10 +183,10 @@ TEST_F(TestJournalPlayer, Prefetch) {
 TEST_F(TestJournalPlayer, PrefetchSkip) {
   std::string oid = get_temp_oid();
 
-  journal::JournalPlayer::EntryPositions positions;
+  journal::JournalPlayer::ObjectPositions positions;
   positions = {
-    cls::journal::EntryPosition(234, 125) };
-  cls::journal::ObjectSetPosition commit_position(0, positions);
+    cls::journal::ObjectPosition(0, 234, 125) };
+  cls::journal::ObjectSetPosition commit_position(positions);
 
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
@@ -246,11 +246,11 @@ TEST_F(TestJournalPlayer, PrefetchWithoutCommit) {
 TEST_F(TestJournalPlayer, PrefetchMultipleTags) {
   std::string oid = get_temp_oid();
 
-  journal::JournalPlayer::EntryPositions positions;
+  journal::JournalPlayer::ObjectPositions positions;
   positions = {
-    cls::journal::EntryPosition(234, 122),
-    cls::journal::EntryPosition(345, 1)};
-  cls::journal::ObjectSetPosition commit_position(0, positions);
+    cls::journal::ObjectPosition(0, 234, 122),
+    cls::journal::ObjectPosition(1, 345, 1)};
+  cls::journal::ObjectSetPosition commit_position(positions);
 
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
@@ -316,10 +316,10 @@ TEST_F(TestJournalPlayer, PrefetchCorruptSequence) {
 TEST_F(TestJournalPlayer, PrefetchAndWatch) {
   std::string oid = get_temp_oid();
 
-  journal::JournalPlayer::EntryPositions positions;
+  journal::JournalPlayer::ObjectPositions positions;
   positions = {
-    cls::journal::EntryPosition(234, 122)};
-  cls::journal::ObjectSetPosition commit_position(0, positions);
+    cls::journal::ObjectPosition(0, 234, 122)};
+  cls::journal::ObjectSetPosition commit_position(positions);
 
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));

--- a/src/test/journal/test_JournalPlayer.cc
+++ b/src/test/journal/test_JournalPlayer.cc
@@ -185,7 +185,8 @@ TEST_F(TestJournalPlayer, PrefetchSkip) {
 
   journal::JournalPlayer::ObjectPositions positions;
   positions = {
-    cls::journal::ObjectPosition(0, 234, 125) };
+    cls::journal::ObjectPosition(0, 234, 125),
+    cls::journal::ObjectPosition(1, 234, 124) };
   cls::journal::ObjectSetPosition commit_position(positions);
 
   ASSERT_EQ(0, create(oid));

--- a/src/test/journal/test_JournalTrimmer.cc
+++ b/src/test/journal/test_JournalTrimmer.cc
@@ -85,10 +85,10 @@ TEST_F(TestJournalTrimmer, Committed) {
   uint64_t commit_tid5;
   uint64_t commit_tid6;
   ASSERT_EQ(0, append_payload(metadata, oid, 0, "payload", &commit_tid1));
-  ASSERT_EQ(0, append_payload(metadata, oid, 2, "payload", &commit_tid2));
+  ASSERT_EQ(0, append_payload(metadata, oid, 4, "payload", &commit_tid2));
   ASSERT_EQ(0, append_payload(metadata, oid, 5, "payload", &commit_tid3));
   ASSERT_EQ(0, append_payload(metadata, oid, 0, "payload", &commit_tid4));
-  ASSERT_EQ(0, append_payload(metadata, oid, 2, "payload", &commit_tid5));
+  ASSERT_EQ(0, append_payload(metadata, oid, 4, "payload", &commit_tid5));
   ASSERT_EQ(0, append_payload(metadata, oid, 5, "payload", &commit_tid6));
 
   journal::JournalTrimmer *trimmer = create_trimmer(oid, metadata);

--- a/src/test/journal/test_ObjectPlayer.cc
+++ b/src/test/journal/test_ObjectPlayer.cc
@@ -141,7 +141,7 @@ TEST_F(TestObjectPlayer, FetchCorrupt) {
 
   C_SaferCond cond;
   object->fetch(&cond);
-  ASSERT_EQ(-EINVAL, cond.wait());
+  ASSERT_EQ(-EBADMSG, cond.wait());
 
   journal::ObjectPlayer::Entries entries;
   object->get_entries(&entries);

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -73,15 +73,15 @@ public:
       *tid = -1;
       return;
     }
-    cls::journal::EntryPositions entry_positions =
-	c->commit_position.entry_positions;
-    cls::journal::EntryPositions::const_iterator p;
-    for (p = entry_positions.begin(); p != entry_positions.end(); ++p) {
+    cls::journal::ObjectPositions object_positions =
+	c->commit_position.object_positions;
+    cls::journal::ObjectPositions::const_iterator p;
+    for (p = object_positions.begin(); p != object_positions.end(); p++) {
       if (p->tag_tid == 0) {
 	break;
       }
     }
-    *tid = p == entry_positions.end() ? -1 : p->entry_tid;
+    *tid = p == object_positions.end() ? -1 : p->entry_tid;
 
     C_SaferCond open_cond;
     ictx->journal = new librbd::Journal<>(*ictx);
@@ -599,7 +599,7 @@ TEST_F(TestJournalReplay, Flatten) {
   ASSERT_EQ(-EINVAL, ictx2->operations->flatten(no_op));
 }
 
-TEST_F(TestJournalReplay, EntryPosition) {
+TEST_F(TestJournalReplay, ObjectPosition) {
   REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
 
   librbd::ImageCtx *ictx;

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -204,10 +204,10 @@ public:
     std::set<cls::journal::Client>::const_iterator c;
     for (c = registered_clients.begin(); c != registered_clients.end(); c++) {
       std::cout << __func__ << ": client: " << *c << std::endl;
-      cls::journal::EntryPositions entry_positions =
-	c->commit_position.entry_positions;
-      cls::journal::EntryPositions::const_iterator p;
-      for (p = entry_positions.begin(); p != entry_positions.end(); p++) {
+      cls::journal::ObjectPositions object_positions =
+	c->commit_position.object_positions;
+      cls::journal::ObjectPositions::const_iterator p;
+      for (p = object_positions.begin(); p != object_positions.end(); p++) {
 	if (c->id == master_client_id) {
 	  ASSERT_EQ(-1, master_tid);
 	  master_tid = p->entry_tid;

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -211,9 +211,11 @@ public:
 	if (c->id == master_client_id) {
 	  ASSERT_EQ(-1, master_tid);
 	  master_tid = p->entry_tid;
+          break;
 	} else if (c->id == mirror_client_id) {
 	  ASSERT_EQ(-1, mirror_tid);
 	  mirror_tid = p->entry_tid;
+          break;
 	}
       }
     }


### PR DESCRIPTION
Previously, if batched appends were enabled, it was possible for uncommitted entries to not be replayed because the prefetch started in a later object set.