### PR TITLE
rgw: allow authentication keystone with self signed certs 

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1192,6 +1192,7 @@ OPTION(rgw_keystone_api_version, OPT_INT, 2) // Version of Keystone API to use (
 OPTION(rgw_keystone_accepted_roles, OPT_STR, "Member, admin")  // roles required to serve requests
 OPTION(rgw_keystone_token_cache_size, OPT_INT, 10000)  // max number of entries in keystone token cache
 OPTION(rgw_keystone_revocation_interval, OPT_INT, 15 * 60)  // seconds between tokens revocation check
+OPTION(rgw_keystone_verify_ssl, OPT_BOOL, true) // should we try to verify keystone's ssl
 OPTION(rgw_s3_auth_use_rados, OPT_BOOL, true)  // should we try to use the internal credentials for s3?
 OPTION(rgw_s3_auth_use_keystone, OPT_BOOL, false)  // should we try to use keystone for s3?
 OPTION(rgw_admin_entry, OPT_STR, "admin")  // entry point for which a url is considered an admin request

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -113,6 +113,12 @@ int RGWHTTPClient::process(const char *method, const char *url)
   if (has_send_len) {
     curl_easy_setopt(curl_handle, CURLOPT_INFILESIZE, (void *)send_len); 
   }
+  if (!verify_ssl) {
+    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYHOST, 0L);
+    dout(20) << "ssl verification is set to off" << dendl;
+  }
+
   CURLcode status = curl_easy_perform(curl_handle);
   if (status) {
     dout(0) << "curl_easy_perform returned error: " << error_buf << dendl;

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -27,6 +27,7 @@ class RGWHTTPClient
 
   string last_method;
   string last_url;
+  bool verify_ssl; // Do not validate self signed certificates, default to false
 
 protected:
   CephContext *cct;
@@ -34,6 +35,7 @@ protected:
   list<pair<string, string> > headers;
   int init_request(const char *method, const char *url, rgw_http_req_data *req_data);
 public:
+
   static const long HTTP_STATUS_NOSTATUS     = 0;
   static const long HTTP_STATUS_UNAUTHORIZED = 401;
 
@@ -44,6 +46,7 @@ public:
       http_status(HTTP_STATUS_NOSTATUS),
       req_data(nullptr),
       user_info(nullptr),
+      verify_ssl(true),
       cct(_cct) {
   }
 
@@ -68,8 +71,13 @@ public:
     has_send_len = true;
   }
 
+
   long get_http_status() const {
     return http_status;
+  }
+
+  void set_verify_ssl(bool flag) {
+    verify_ssl = flag;
   }
 
   int process(const char *method, const char *url);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2773,6 +2773,9 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(
   append_header("X-Auth-Token", admin_token_id);
   append_header("Content-Type", "application/json");
 
+  /* check if we want to verify keystone's ssl certs */
+  set_verify_ssl(cct->_conf->rgw_keystone_verify_ssl);
+
   /* encode token */
   bufferlist token_buff;
   bufferlist token_encoded;

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -114,6 +114,9 @@ class RGWPostHTTPData : public RGWHTTPClient {
   std::string subject_token;
 public:
   RGWPostHTTPData(CephContext *_cct, bufferlist *_bl) : RGWHTTPClient(_cct), bl(_bl), post_data_index(0) {}
+  RGWPostHTTPData(CephContext *_cct, bufferlist *_bl, bool verify_ssl) : RGWHTTPClient(_cct), bl(_bl), post_data_index(0){
+    set_verify_ssl(verify_ssl);
+  }
 
   void set_post_data(const std::string& _post_data) {
     this->post_data = _post_data;
@@ -253,7 +256,7 @@ int RGWSwift::get_keystone_url(CephContext * const cct,
                                std::string& url)
 {
   bufferlist bl;
-  RGWGetRevokedTokens req(cct, &bl);
+  RGWGetRevokedTokens req(cct, &bl, cct->_conf->rgw_keystone_verify_ssl);
 
   url = cct->_conf->rgw_keystone_url;
   if (url.empty()) {
@@ -287,7 +290,7 @@ int RGWSwift::get_keystone_admin_token(CephContext * const cct,
     return 0;
   }
   bufferlist token_bl;
-  RGWGetKeystoneAdminToken token_req(cct, &token_bl);
+  RGWGetKeystoneAdminToken token_req(cct, &token_bl, cct->_conf->rgw_keystone_verify_ssl);
   token_req.append_header("Content-Type", "application/json");
   JSONFormatter jf;
 
@@ -548,7 +551,7 @@ int RGWSwift::validate_keystone_token(RGWRados *store, const string& token, stru
 
     /* can't decode, just go to the keystone server for validation */
 
-    RGWValidateKeystoneToken validate(cct, &bl);
+    RGWValidateKeystoneToken validate(cct, &bl, cct->_conf->rgw_keystone_verify_ssl);
 
     string url = g_conf->rgw_keystone_url;
     if (url.empty()) {


### PR DESCRIPTION
This pr makes deployments that use keystone terminated with a self signed certificate to be used for authentication for radosgw, this is similiar to many openstack clients which allow for a `--insecure` switch to the option. Here based on the configurable `rgw keystone verify ssl` (which is true by default) we can allow for rgw to post requests with a keystone with self signed cert.

Fixes: #14853