### PR TITLE
pybind/rados: fix object lifetime issues and other bugs in aio

### DIFF
--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -1802,13 +1802,13 @@ cdef class Ioctx(object):
             uint64_t _offset = offset
 
         completion = self.__get_completion(oncomplete, onsafe)
-
+        self.__track_completion(completion)
         with nogil:
             ret = rados_aio_write(self.io, _object_name, completion.rados_comp,
                                 _to_write, size, _offset)
         if ret < 0:
+            completion._cleanup()
             raise make_ex(ret, "error writing object %s" % object_name)
-        self.__track_completion(completion)
         return completion
 
     def aio_write_full(self, object_name, to_write,
@@ -1844,13 +1844,14 @@ cdef class Ioctx(object):
             size_t size = len(to_write)
 
         completion = self.__get_completion(oncomplete, onsafe)
+        self.__track_completion(completion)
         with nogil:
             ret = rados_aio_write_full(self.io, _object_name,
                                     completion.rados_comp,
                                     _to_write, size)
         if ret < 0:
+            completion._cleanup()
             raise make_ex(ret, "error writing object %s" % object_name)
-        self.__track_completion(completion)
         return completion
 
     def aio_append(self, object_name, to_append, oncomplete=None, onsafe=None):
@@ -1884,13 +1885,14 @@ cdef class Ioctx(object):
             size_t size = len(to_append)
 
         completion = self.__get_completion(oncomplete, onsafe)
+        self.__track_completion(completion)
         with nogil:
             ret = rados_aio_append(self.io, _object_name,
                                 completion.rados_comp,
                                 _to_append, size)
         if ret < 0:
+            completion._cleanup()
             raise make_ex(ret, "error appending object %s" % object_name)
-        self.__track_completion(completion)
         return completion
 
     def aio_flush(self):
@@ -1946,12 +1948,13 @@ cdef class Ioctx(object):
         completion = self.__get_completion(oncomplete_, None)
         completion.buf = PyBytes_FromStringAndSize(NULL, length)
         ret_buf = PyBytes_AsString(completion.buf)
+        self.__track_completion(completion)
         with nogil:
             ret = rados_aio_read(self.io, _object_name, completion.rados_comp,
                                 ret_buf, _length, _offset)
         if ret < 0:
+            completion._cleanup()
             raise make_ex(ret, "error reading %s" % object_name)
-        self.__track_completion(completion)
         return completion
 
     def aio_remove(self, object_name, oncomplete=None, onsafe=None):
@@ -1977,12 +1980,13 @@ cdef class Ioctx(object):
             char* _object_name = object_name
 
         completion = self.__get_completion(oncomplete, onsafe)
+        self.__track_completion(completion)
         with nogil:
             ret = rados_aio_remove(self.io, _object_name,
                                 completion.rados_comp)
         if ret < 0:
+            completion._cleanup()
             raise make_ex(ret, "error removing %s" % object_name)
-        self.__track_completion(completion)
         return completion
 
     def require_ioctx_open(self):


### PR DESCRIPTION
This fixes some subtle and some not so subtle object lifetime issues in the aio completion implementation in rados.pyx.

WRT the comment at the end of the second commit, where we still have a case of completion objects living longer than they should if an exception arrives at the wrong time (not likely to be a problem in practice, but worth fixing): I'm working on aio support for the rbd bindings, and am trying out a different approach to keeping the completion objects alive. If that works out I'll switch the rados bindings to the same approach and that should fix the problem.

cc @jdurgin @sileht
