### PR TITLE
test/bufferlist: Fixing corruption on ptr(ptr&& p)

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -457,7 +457,7 @@ TEST(BufferPtr, constructors) {
     bufferptr ptr(std::move(original));
     EXPECT_TRUE(ptr.have_raw());
     EXPECT_FALSE(original.have_raw());
-    EXPECT_EQ(str.compare(0, str.size(), ptr.c_str()), 0);
+    EXPECT_EQ(0, ::memcmp(str.c_str(), ptr.c_str(), len));
     EXPECT_EQ(1, ptr.raw_nref());
   }
 }


### PR DESCRIPTION
The bufferlist is trying to compare two strings by doing :
    str.compare(0, str.size(), ptr.c_str())

This have been introduced recently in commit 41c3dc2e734a6f57c3636db5a937edd8f8b66b39.

The issue in that test is not providing the amount of char to compare but only
the size of 'str'.

As a result, it does compare a null-terminated string (str) with a
non-terminated buffer (ptr).

The issue was discoverd by having on a test where
 - str="XXXXXXXXXXXXXXXXX"
but
 - ptr="XXXXXXXXXXXXXXXXXriptor".

The associated assertion failed and broke the test.

This patch is fixing the issue by using the memcmp() call as per 'ptr(const
ptr& p, unsigned o, unsigned l)' test.

The simple solution is to test the buffer at the byte level and only for the
n-bytes of the initial string.

That change makes the test passing.

Regarding the initial code, that's pretty a big chance that no-one hit that
before.

Signed-off-by: Erwan Velu <erwan@redhat.com>