### PR TITLE
rbd/run_cli_tests.sh: Reflect test failures

### DIFF
--- a/qa/workunits/rbd/run_cli_tests.sh
+++ b/qa/workunits/rbd/run_cli_tests.sh
@@ -1,7 +1,5 @@
-#!/bin/bash 
+#!/bin/bash -ex
 
 wget -q http://download.ceph.com/qa/rbd_cli_tests.pls
 wget -q http://download.ceph.com/qa/RbdLib.pm
 perl rbd_cli_tests.pls --pool test
-exit 0
-


### PR DESCRIPTION
This is related to http://tracker.ceph.com/issues/14825

It won't actually fix the test scripts since those are stored at http://download.ceph.com/qa/ for some reason.