### PR TITLE
Cache Tier: agent should continue try other level PG

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -526,6 +526,7 @@ void OSDService::agent_entry()
     }
     uint64_t level = agent_queue.rbegin()->first;
     set<PGRef>& top = agent_queue.rbegin()->second;
+    assert(!top.empty());
     dout(10) << __func__
 	     << " tiers " << agent_queue.size()
 	     << ", top is " << level
@@ -535,7 +536,7 @@ void OSDService::agent_entry()
 	     << (agent_active ? " active" : " NOT ACTIVE")
 	     << dendl;
     dout(20) << __func__ << " oids " << agent_oids << dendl;
-    if (agent_ops >= g_conf->osd_agent_max_ops || top.empty() ||
+    if (agent_ops >= g_conf->osd_agent_max_ops ||
 	!agent_active) {
       agent_cond.Wait(agent_lock);
       continue;


### PR DESCRIPTION
when top level PG set is empty, it should continue to  try other level PG sets, rather than waiting.

Signed-off-by: Tao Chang <changtao@hihuron.com>