### PR TITLE
log: segv in a portable way

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -190,7 +190,7 @@ void Log::submit_entry(Entry *e)
   m_queue_mutex_holder = pthread_self();
 
   if (m_inject_segv)
-    *(int *)(0) = 0xdead;
+    *(volatile int *)(0) = 0xdead;
 
   // wait for flush to catch up
   while (m_new.m_len > m_max_new)


### PR DESCRIPTION
this piece of code creates a SEGV from logging code to verify a
bug fix at e3fe18a.

clang will delete the null-referencing code. so we need to either
- pass -Wnonull-dereference to $(CC)
- or use  __builtin_trap() offered by GCC/clang
- or use `volatile`
seems volatile is easier and probably more portable.

Fixes: #14856
Signed-off-by: Kefu Chai <kchai@redhat.com>