### PR TITLE
cls_rbd: fix the test for ceph-dencoder

### DIFF
--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -60,7 +60,7 @@ struct MirrorImage {
     : global_image_id(global_image_id), state(state) {}
 
   std::string global_image_id;
-  MirrorImageState state;
+  MirrorImageState state = MIRROR_IMAGE_STATE_DISABLING;
 
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &it);


### PR DESCRIPTION
initialize MirrorImage::state to a certain value, otherwise the
generated test instances would be undetermined, and hence fail
the dencoder tests.

Signed-off-by: Kefu Chai <kchai@redhat.com>