### PR TITLE
Async Read for PG and FileStore

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -872,6 +872,7 @@ OPTION(osd_recovery_op_warn_multiple, OPT_U32, 16)
 OPTION(osd_mon_shutdown_timeout, OPT_DOUBLE, 5)
 
 OPTION(osd_max_object_size, OPT_U64, 100*1024L*1024L*1024L) // OSD's maximum object size
+OPTION(osd_min_async_read_size, OPT_U64, 100*1024L*1024L*1024L) // OSD's maximum object size
 OPTION(osd_max_object_name_len, OPT_U32, 2048) // max rados object name len
 OPTION(osd_max_object_namespace_len, OPT_U32, 256) // max rados object namespace len
 OPTION(osd_max_attr_name_len, OPT_U32, 100)    // max rados attr name len; cannot go higher than 100 chars for file system backends

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1047,6 +1047,7 @@ OPTION(filestore_sloppy_crc, OPT_BOOL, false)         // track sloppy crcs
 OPTION(filestore_sloppy_crc_block_size, OPT_INT, 65536)
 
 OPTION(filestore_max_alloc_hint_size, OPT_U64, 1ULL << 20) // bytes
+OPTION(filestore_async_threads, OPT_INT, 0)
 
 OPTION(filestore_max_sync_interval, OPT_DOUBLE, 5)    // seconds
 OPTION(filestore_min_sync_interval, OPT_DOUBLE, .01)  // seconds

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -2074,6 +2074,23 @@ public:
      return read(c->get_cid(), oid, offset, len, bl, op_flags, allow_eio);
    }
 
+   virtual int async_read_dispatch(
+     Sequencer *osr,
+     Context *ctx,
+     const coll_t& cid,
+     const ghobject_t& oid,
+     uint64_t offset,
+     size_t len,
+     bufferlist* bl,
+     uint32_t op_flags,
+     Context *blessed_context) {
+     return -EWOULDBLOCK;
+   }
+
+  virtual bool async_read_capable() {
+    return false;
+  }
+
   /**
    * fiemap -- get extent map of data of an object
    *

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -362,6 +362,7 @@ private:
   friend ostream& operator<<(ostream& out, const OpSequencer& s);
 
   FDCache fdcache;
+  FDCache fdcache_direct;
   WBThrottle wbthrottle;
 
   atomic_t next_osr_id;
@@ -529,7 +530,8 @@ public:
     const ghobject_t& oid,
     bool create,
     FDRef *outfd,
-    Index *index = 0);
+    Index *index = 0,
+    bool directio = false);
 
   void lfn_close(FDRef fd);
   int lfn_link(const coll_t& c, const coll_t& newcid, const ghobject_t& o, const ghobject_t& newoid) ;

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1925,6 +1925,7 @@ out:
 };
 
 void ECBackend::objects_read_async(
+  ObjectStore::Sequencer *osr,
   const hobject_t &hoid,
   const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
 		  pair<bufferlist*, Context*> > > &to_read,

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -142,11 +142,16 @@ public:
   };
   list<ClientAsyncReadStatus> in_progress_client_reads;
   void objects_read_async(
+    ObjectStore::Sequencer *osr,
     const hobject_t &hoid,
     const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
 		    pair<bufferlist*, Context*> > > &to_read,
     Context *on_complete,
     bool fast_read = false);
+
+  bool allows_async_read() override {
+    return true;
+  }
 
 private:
   friend struct ECRecoveryHandle;

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -572,10 +572,15 @@ struct shard_info_wrapper;
      bufferlist *bl) = 0;
 
    virtual void objects_read_async(
+     ObjectStore::Sequencer *osr,
      const hobject_t &hoid,
      const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
 		pair<bufferlist*, Context*> > > &to_read,
      Context *on_complete, bool fast_read = false) = 0;
+
+   virtual bool allows_async_read() {
+     return false;
+   }
 
    virtual bool scrub_supported() = 0;
    virtual bool auto_repair_supported() const = 0;

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -157,11 +157,16 @@ public:
     bufferlist *bl);
 
   void objects_read_async(
+    ObjectStore::Sequencer *osr,
     const hobject_t &hoid,
     const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
 	       pair<bufferlist*, Context*> > > &to_read,
                Context *on_complete,
                bool fast_read = false);
+
+  bool allows_async_read() override {
+    return store->async_read_capable();
+  }
 
 private:
   // push


### PR DESCRIPTION
This is a rebase of the PR in https://github.com/ceph/ceph/pull/7783.
I have also made some of the changes from the initial comments, specifically about removing the class library modifications to support Async Reads, and the whitespace/indentation problems.

The following text is copied from the earlier PR:

I had a prior PR (#6776) on the same topic but too many changes since then so that is marked closed now.

The purpose of this is to enable an asynchronous, callback-based interface and functionality for sending Reads to Objectstore, and then to implement an Asynchronous (Linux AIO) mechanism within FileStore that can be used to serve the incoming Async requests from the PG layer. This type of functionality is probably most beneficial to fast storage such as SSDs.

A brief description of the implementation is as follows.

Existing Sync interfaces are unchanged. ObjectStores that do not implement Async Read functionality are not affected.

In do_osd_ops() and related routines, a callback mechanism is enabled by passing in a callback argument. Then if the PGBackend reports that Async is available, Async processing will occur and invoke the callback as expected. Otherwise do_osd_ops() executes the callback itself (in Sync mode). The interface to the caller is the same in either case. Further, for small IO small IO (currently set to less than 256 bytes) the Async mechanism is not invoked. If there is only one callback expected, then additional locking overhead is avoided.

The existing ObjectStore interface for doing synchronous Reads is unchanged. Async operation is disabled by default in ceph.conf. For each instance of ObjectStore, Async may be enabled/disabled individually.

In FileStore, Async completion threads are created on mount(), if functionality is enabled. If filestore_async_threads=0 then the FileStore will not operate in Async mode (or create any Async completion threads). The Async completion threads just wait for AIO completions using io_getevents() and complete processing directly themselves (i.e. without going back to the sharding thread).

I found that unless Direct IO (O_DIRECT) is used the performance gains due to Async functionality are not realized. This is consistent with what one finds about the Linux kernel implementation of AIO. So this code enables the use of O_DIRECT for Async Reads, by maintaining a separate FDCache ("fdcache_direct") in additional to the usual FileStore::fdcache, in which file descriptors are created by opening files with O_DIRECT. Again, this is avoided if Async functionality is not enabled.

Comments and feedback appreciated.
Thanks,
Vikas
