### PR TITLE
Bdev zero with discard

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -139,7 +139,7 @@ int64_t get_block_device_int_property(const char *devname, const char *property)
     return r;
 
   snprintf(filename, sizeof(filename),
-	   "%s/sys/block/%s/queue/discard_granularity", sandbox_dir, basename);
+	   "%s/sys/block/%s/queue/%s", sandbox_dir, basename, property);
 
   FILE *fp = fopen(filename, "r");
   if (fp == NULL) {

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -967,6 +967,7 @@ OPTION(bluestore_debug_freelist, OPT_BOOL, false)
 OPTION(bluestore_debug_prefill, OPT_FLOAT, 0)
 OPTION(bluestore_debug_prefragment_max, OPT_INT, 1048576)
 OPTION(bluestore_inject_wal_apply_delay, OPT_FLOAT, 0)
+OPTION(bluestore_discard_on_release, OPT_BOOL, false) //when free block do discard
 
 OPTION(kstore_max_ops, OPT_U64, 512)
 OPTION(kstore_max_bytes, OPT_U64, 64*1024*1024)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -901,6 +901,7 @@ OPTION(bdev_aio, OPT_BOOL, true)
 OPTION(bdev_aio_poll_ms, OPT_INT, 250)  // milliseconds
 OPTION(bdev_aio_max_queue_depth, OPT_INT, 32)
 OPTION(bdev_block_size, OPT_INT, 4096)
+OPTION(bdev_discard_on_zero, OPT_BOOL, false) //if true mean using discard instead of write-zero
 
 // if yes, osd will unbind all NVMe devices from kernel driver and bind them
 // to the uio_pci_generic driver. The purpose is to prevent the case where

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -103,6 +103,9 @@ public:
   virtual int invalidate_cache(uint64_t off, uint64_t len) = 0;
   virtual int open(string path) = 0;
   virtual void close() = 0;
+
+  virtual bool supports_discard() = 0;
+  virtual int discard(uint64_t off, uint64_t len) = 0;
 };
 
 #endif //CEPH_OS_BLUESTORE_BLOCKDEVICE_H

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3892,7 +3892,7 @@ void BlueStore::_txc_update_fm(TransContext *txc)
 	alloc->release(p.get_start(), p.get_len());
     }
 
-    if (bdev->supports_discard()) {
+    if (g_conf->bluestore_discard_on_release && bdev->supports_discard()) {
       uint64_t block_size = bdev->get_block_size();
       for (interval_set<uint64_t>::iterator p = txc->released.begin();
 	  p != txc->released.end() && (p.get_len() >= block_size);
@@ -3988,7 +3988,7 @@ void BlueStore::_kv_sync_thread()
 	      alloc->release(p.get_start(), p.get_len());
 	  }
 
-	  if (bdev->supports_discard()) {
+	  if (g_conf->bluestore_discard_on_release && bdev->supports_discard()) {
 	    uint64_t block_size = bdev->get_block_size();
 	    for (interval_set<uint64_t>::iterator p = txc->wal_txn->released.begin();
 		p != txc->wal_txn->released.end() && (p.get_len() >= block_size);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -555,6 +555,8 @@ private:
 
   PerfCounters *logger;
 
+  bufferptr zeros;
+
   std::mutex reap_lock;
   list<CollectionRef> removed_collections;
 

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -477,7 +477,7 @@ int KernelDevice::aio_zero(
   bufferlist bl;
 
   //discard bypass page cache, so we must invalidate the related page cache.
-  if (discard_zeroes_data) {
+  if (g_conf->bdev_discard_on_zero && discard_zeroes_data) {
     int r = invalidate_cache(off, len);
     //if met error, use aio_write
     if (r < 0) {

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -570,5 +570,7 @@ bool KernelDevice::supports_discard()
 
 int KernelDevice::discard(uint64_t off, uint64_t len)
 {
+  assert(off % block_size == 0);
+  assert(len % block_size == 0);
   return block_device_discard(fd_direct, off, len);
 }

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -54,6 +54,7 @@ class KernelDevice : public BlockDevice {
   std::atomic_int injecting_crash;
 
   bool can_discard; //whether support discard
+  bool discard_zeroes_data; //whether after discard, read data are zero.
 
   void _aio_thread();
   int _aio_start();

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -53,6 +53,8 @@ class KernelDevice : public BlockDevice {
 
   std::atomic_int injecting_crash;
 
+  bool can_discard; //whether support discard
+
   void _aio_thread();
   int _aio_start();
   void _aio_stop();
@@ -90,6 +92,9 @@ public:
   int invalidate_cache(uint64_t off, uint64_t len) override;
   int open(string path) override;
   void close() override;
+
+  bool supports_discard() override;
+  int discard(uint64_t off, uint64_t len) override;
 };
 
 #endif

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -1035,3 +1035,8 @@ int NVMEDevice::invalidate_cache(uint64_t off, uint64_t len)
   dout(5) << __func__ << " " << off << "~" << len << dendl;
   return 0;
 }
+
+bool supports_discard()
+{
+  return false;
+}

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -237,6 +237,8 @@ class NVMEDevice : public BlockDevice {
   int invalidate_cache(uint64_t off, uint64_t len) override;
   int open(string path) override;
   void close() override;
+
+  bool supports_discard() override;
 };
 
 #endif


### PR DESCRIPTION
add function make bluestore support discard. If block device support discard-zeroes-data which after discard the data are zero, we use discard instead of write-zero.