### PR TITLE
mon/OSDMonitor: _have_pending_crush of return value should be bool

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -83,7 +83,7 @@ OSDMonitor::OSDMonitor(CephContext *cct, Monitor *mn, Paxos *p, const string& se
 
 bool OSDMonitor::_have_pending_crush()
 {
-  return pending_inc.crush.length();
+  return pending_inc.crush.length() > 0;
 }
 
 CrushWrapper &OSDMonitor::_get_stable_crush()


### PR DESCRIPTION
 “_have_pending_crush” of  return value should be bool, fix it.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>