### PR TITLE
hammer: unittest_crypto: benchmark 100,000 CryptoKey::encrypt() calls

### DIFF
--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -3,7 +3,10 @@
 
 #include "include/types.h"
 #include "auth/Crypto.h"
+#include "common/Clock.h"
 #include "common/ceph_crypto.h"
+#include "common/ceph_context.h"
+#include "global/global_context.h"
 
 #include "test/unit.h"
 


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit fb4b6c52d8e31e8dedfa8aecc16c389f0e7d86cf)

Conflicts:
	src/test/crypto.cc : complements the incorrect cherry-pick
           df3f971eafda9c54881c13dcf47f996f18e17028 see
           http://tracker.ceph.com/issues/14863 for more information