### PR TITLE
config: increase default async op threads

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -195,7 +195,7 @@ OPTION(ms_inject_delay_probability, OPT_DOUBLE, 0) // range [0, 1]
 OPTION(ms_inject_internal_delays, OPT_DOUBLE, 0)   // seconds
 OPTION(ms_dump_on_send, OPT_BOOL, false)           // hexdump msg to log on send
 OPTION(ms_dump_corrupt_message_level, OPT_INT, 1)  // debug level to hexdump undecodeable messages at
-OPTION(ms_async_op_threads, OPT_INT, 2)
+OPTION(ms_async_op_threads, OPT_INT, 3)
 OPTION(ms_async_set_affinity, OPT_BOOL, true)
 // example: ms_async_affinity_cores = 0,1
 // The number of coreset is expected to equal to ms_async_op_threads, otherwise


### PR DESCRIPTION
Default value of two async threads is enough for light workloads,
but is insufficient for heavy ones, reducing maximum throughput on
slower CPUs that have plenty of logical cores. Three async threads
give noticeable perf jump (finally being on par or even exceeding
simple messenger) without any noticeable downsides.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>