### PR TITLE
osd: kstore: fix a race condition in _txc_finish()

### DIFF
--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -2280,8 +2280,10 @@ void KStore::_txc_finish(TransContext *txc)
   }
 
   OpSequencerRef osr = txc->osr;
-  std::lock_guard<std::mutex> l(osr->qlock);
-  txc->state = TransContext::STATE_DONE;
+  {
+    std::lock_guard<std::mutex> l(osr->qlock);
+    txc->state = TransContext::STATE_DONE;
+  }
 
   _osr_reap_done(osr.get());
 }


### PR DESCRIPTION
Among previous kstore updates changes, this {} was missed in _txc_finish() accidentally, which would cause a race condition.