### PR TITLE
msg/async: don't calculate msg header crc when not needed

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2316,7 +2316,8 @@ ssize_t AsyncConnection::write_message(Message *m, bufferlist& bl)
     m->get();
   }
 
-  m->calc_header_crc();
+  if (msgr->crcflags & MSG_CRC_HEADER)
+    m->calc_header_crc();
 
   ceph_msg_header& header = m->get_header();
   ceph_msg_footer& footer = m->get_footer();


### PR DESCRIPTION
There was a missing condition that caused to calculate outgoing message
header CRC even if CRC checking was disabled in Ceph configuration.
This change fixes that.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>