### PR TITLE
rgw: fixes for per-period metadata logs

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -439,7 +439,7 @@ int RGWCoroutinesManager::run(list<RGWCoroutinesStack *>& stacks)
     RGWCoroutinesStack *stack = *iter;
     env.stack = stack;
 
-    int ret = stack->operate(&env);
+    ret = stack->operate(&env);
     stack->set_is_scheduled(false);
     if (ret < 0) {
       ldout(cct, 0) << "ERROR: stack->operate() returned ret=" << ret << dendl;
@@ -531,6 +531,9 @@ int RGWCoroutinesManager::run(list<RGWCoroutinesStack *>& stacks)
       }
       handle_unblocked_stack(context_stacks, scheduled_stacks, blocked_stack, &blocked_count);
       iter = scheduled_stacks.begin();
+    }
+    if (ret == -ECANCELED) {
+      break;
     }
 
     if (iter == scheduled_stacks.end()) {

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -887,5 +887,42 @@ public:
   int request_complete();
 };
 
+class RGWAsyncStatObj : public RGWAsyncRadosRequest {
+  RGWRados *store;
+  rgw_obj obj;
+  uint64_t *psize;
+  time_t *pmtime;
+  uint64_t *pepoch;
+  RGWObjVersionTracker *objv_tracker;
+protected:
+  int _send_request() override;
+public:
+  RGWAsyncStatObj(RGWAioCompletionNotifier *cn, RGWRados *store,
+                  const rgw_obj& obj, uint64_t *psize = nullptr,
+                  time_t *pmtime = nullptr, uint64_t *pepoch = nullptr,
+                  RGWObjVersionTracker *objv_tracker = nullptr)
+    : RGWAsyncRadosRequest(cn), store(store), obj(obj), psize(psize),
+      pmtime(pmtime), pepoch(pepoch), objv_tracker(objv_tracker) {}
+};
+
+class RGWStatObjCR : public RGWSimpleCoroutine {
+  RGWRados *store;
+  RGWAsyncRadosProcessor *async_rados;
+  rgw_obj obj;
+  uint64_t *psize;
+  time_t *pmtime;
+  uint64_t *pepoch;
+  RGWObjVersionTracker *objv_tracker;
+  RGWAsyncStatObj *req = nullptr;
+ public:
+  RGWStatObjCR(RGWAsyncRadosProcessor *async_rados, RGWRados *store,
+               const rgw_obj& obj, uint64_t *psize = nullptr,
+               time_t *pmtime = nullptr, uint64_t *pepoch = nullptr,
+               RGWObjVersionTracker *objv_tracker = nullptr);
+  ~RGWStatObjCR();
+
+  int send_request() override;
+  int request_complete() override;
+};
 
 #endif

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -150,12 +150,6 @@ class RGWMetadataLog {
     return META_LOG_OBJ_PREFIX + period + ".";
   }
 
-  void get_shard_oid(int id, string& oid) {
-    char buf[16];
-    snprintf(buf, sizeof(buf), "%d", id);
-    oid = prefix + buf;
-  }
-
   RWLock lock;
   set<int> modified_shards;
 
@@ -165,6 +159,12 @@ public:
     : cct(_cct), store(_store),
       prefix(make_prefix(period)),
       lock("RGWMetaLog::lock") {}
+
+  void get_shard_oid(int id, string& oid) const {
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%d", id);
+    oid = prefix + buf;
+  }
 
   int add_entry(RGWMetadataHandler *handler, const string& section, const string& key, bufferlist& bl);
   int store_entries_in_shard(list<cls_log_entry>& entries, int shard_id, librados::AioCompletion *completion);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3680,10 +3680,10 @@ int RGWRados::init_complete()
         << cpp_strerror(-ret) << dendl;
     return ret;
   }
-  auto md_log = meta_mgr->get_log(current_period.get_id());
 
-  meta_notifier = new RGWMetaNotifier(this, md_log);
   if (is_meta_master()) {
+    auto md_log = meta_mgr->get_log(current_period.get_id());
+    meta_notifier = new RGWMetaNotifier(this, md_log);
     meta_notifier->start();
   }
 

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -81,13 +81,13 @@ void RGWOp_MDLog_List::execute() {
     http_ret = -EINVAL;
     return;
   }
-  RGWMetadataLog *meta_log = store->meta_mgr->get_log(period);
+  RGWMetadataLog meta_log{s->cct, store, period};
 
-  meta_log->init_list_entries(shard_id, ut_st, ut_et, marker, &handle);
+  meta_log.init_list_entries(shard_id, ut_st, ut_et, marker, &handle);
 
   do {
-    http_ret = meta_log->list_entries(handle, max_entries, entries,
-				      &last_marker, &truncated);
+    http_ret = meta_log.list_entries(handle, max_entries, entries,
+				     &last_marker, &truncated);
     if (http_ret < 0) 
       break;
 
@@ -95,7 +95,7 @@ void RGWOp_MDLog_List::execute() {
       max_entries -= entries.size();
   } while (truncated && (max_entries > 0));
 
-  meta_log->complete_list_entries(handle);
+  meta_log.complete_list_entries(handle);
 }
 
 void RGWOp_MDLog_List::send_response() {
@@ -161,9 +161,9 @@ void RGWOp_MDLog_ShardInfo::execute() {
     http_ret = -EINVAL;
     return;
   }
-  RGWMetadataLog *meta_log = store->meta_mgr->get_log(period);
+  RGWMetadataLog meta_log{s->cct, store, period};
 
-  http_ret = meta_log->get_info(shard_id, &info);
+  http_ret = meta_log.get_info(shard_id, &info);
 }
 
 void RGWOp_MDLog_ShardInfo::send_response() {
@@ -215,9 +215,9 @@ void RGWOp_MDLog_Delete::execute() {
     http_ret = -EINVAL;
     return;
   }
-  RGWMetadataLog *meta_log = store->meta_mgr->get_log(period);
+  RGWMetadataLog meta_log{s->cct, store, period};
 
-  http_ret = meta_log->trim(shard_id, ut_st, ut_et, start_marker, end_marker);
+  http_ret = meta_log.trim(shard_id, ut_st, ut_et, start_marker, end_marker);
 }
 
 void RGWOp_MDLog_Lock::execute() {
@@ -250,7 +250,7 @@ void RGWOp_MDLog_Lock::execute() {
     return;
   }
 
-  RGWMetadataLog *meta_log = store->meta_mgr->get_log(period);
+  RGWMetadataLog meta_log{s->cct, store, period};
   unsigned dur;
   dur = (unsigned)strict_strtol(duration_str.c_str(), 10, &err);
   if (!err.empty() || dur <= 0) {
@@ -259,7 +259,7 @@ void RGWOp_MDLog_Lock::execute() {
     return;
   }
   utime_t time(dur, 0);
-  http_ret = meta_log->lock_exclusive(shard_id, time, zone_id, locker_id);
+  http_ret = meta_log.lock_exclusive(shard_id, time, zone_id, locker_id);
   if (http_ret == -EBUSY)
     http_ret = -ERR_LOCKED;
 }
@@ -292,8 +292,8 @@ void RGWOp_MDLog_Unlock::execute() {
     return;
   }
 
-  RGWMetadataLog *meta_log = store->meta_mgr->get_log(period);
-  http_ret = meta_log->unlock(shard_id, zone_id, locker_id);
+  RGWMetadataLog meta_log{s->cct, store, period};
+  http_ret = meta_log.unlock(shard_id, zone_id, locker_id);
 }
 
 void RGWOp_MDLog_Notify::execute() {

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1676,9 +1676,9 @@ static RGWPeriodHistory::Cursor get_period_at(RGWRados* store,
     return cursor;
   }
 
-  // read the period from rados
-  RGWPeriod period(info.period);
-  int r = period.init(store->ctx(), store, store->realm.get_id());
+  // read the period from rados or pull it from the master
+  RGWPeriod period;
+  int r = store->period_puller->pull(info.period, period);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed to read period id "
         << info.period << ": " << cpp_strerror(r) << dendl;


### PR DESCRIPTION
This change set addresses the pending comments from the previously merged https://github.com/ceph/ceph/pull/7699. It also finishes implementing `find_oldest_log_period()` on the metadata master, and fixes the way the remote side was using it.