### PR TITLE
rbd: abort if we are unable to open imagectx during remove()

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1566,6 +1566,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     if (r < 0) {
       ldout(cct, 2) << "error opening image: " << cpp_strerror(-r) << dendl;
       delete ictx;
+      return r;
     } else {
       string header_oid = ictx->header_oid;
       old_format = ictx->old_format;


### PR DESCRIPTION
Otherwise the real error number will be overwritten and mislead caller.

Signed-off-by: xiexingguo <xie.xingguo@zte.com.cn>