### PR TITLE
rbd: deprecate image format 1

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -12,6 +12,10 @@ v10.0.0
   limit max waiting time of monitor election process, which was previously
   restricted by 'mon_lease'.
 
+* The rbd legacy image format (version 1) is deprecated with the Jewel release.
+  Attempting to create a new version 1 RBD image will result in a warning.
+  Future releases of Ceph will remove support for version 1 RBD images.
+
 v9.3.0
 ======
 * Some symbols wrongly exposed by librados in v9.1.0 and v9.2.0 were removed.

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -56,9 +56,9 @@ Parameters
 
    Specifies which object layout to use. The default is 1.
 
-   * format 1 - Use the original format for a new rbd image. This format is
-     understood by all versions of librbd and the kernel rbd module, but
-     does not support newer features like cloning.
+   * format 1 - (deprecated) Use the original format for a new rbd image. This
+     format is understood by all versions of librbd and the kernel rbd module,
+     but does not support newer features like cloning.
 
    * format 2 - Use the second rbd format, which is supported by
      librbd and kernel since version 3.11 (except for striping). This adds

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -78,6 +78,9 @@ Context *OpenRequest<I>::handle_v1_detect_header(int *result) {
     }
     send_close_image(*result);
   } else {
+    lderr(cct) << "RBD image format 1 is deprecated. "
+               << "Please copy this image to image format 2." << dendl;
+
     m_image_ctx->old_format = true;
     m_image_ctx->header_oid = util::old_header_name(m_image_ctx->name);
     send_register_watch();

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -228,7 +228,7 @@
   Optional arguments
     -p [ --pool ] arg         pool name
     --image arg               image name
-    --image-format arg        image format [1 or 2]
+    --image-format arg        image format [1 (deprecated) or 2]
     --new-format              use image format 2
                               (deprecated)
     --order arg               object order [12 <= order <= 25]
@@ -473,7 +473,7 @@
     --path arg                import file (or '-' for stdin)
     --dest-pool arg           destination pool name
     --dest arg                destination image name
-    --image-format arg        image format [1 or 2]
+    --image-format arg        image format [1 (deprecated) or 2]
     --new-format              use image format 2
                               (deprecated)
     --order arg               object order [12 <= order <= 25]

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -209,7 +209,8 @@ void add_create_image_options(po::options_description *opt,
   // TODO get default image format from conf
   if (include_format) {
     opt->add_options()
-      (IMAGE_FORMAT.c_str(), po::value<ImageFormat>(), "image format [1 or 2]")
+      (IMAGE_FORMAT.c_str(), po::value<ImageFormat>(),
+       "image format [1 (deprecated) or 2]")
       (IMAGE_NEW_FORMAT.c_str(),
        po::value<ImageNewFormat>()->zero_tokens(),
        "use image format 2\n(deprecated)");

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -390,6 +390,9 @@ int get_image_options(const boost::program_options::variables_map &vm,
     } else {
       format = g_conf->rbd_default_format;
     }
+    if (format == 1) {
+      std::cerr << "rbd: image format 1 is deprecated" << std::endl;
+    }
 
     if (features_specified && features != 0) {
       if (format_specified && format == 1) {


### PR DESCRIPTION
The rbd cli will warn about the deprecation when attempting to create
image format 1 images.  librbd will log an error message when opening
a format 1 RBD image.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>