### PR TITLE
common: set thread name from correct thread

### DIFF
--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -54,7 +54,8 @@ Thread::Thread()
     pid(0),
     ioprio_class(-1),
     ioprio_priority(-1),
-    cpuid(-1)
+    cpuid(-1),
+    thread_name(NULL)
 {
 }
 
@@ -81,6 +82,8 @@ void *Thread::entry_wrapper()
   }
   if (pid && cpuid >= 0)
     _set_affinity(cpuid);
+
+  pthread_setname_np(pthread_self(), thread_name);
   return entry();
 }
 
@@ -145,6 +148,9 @@ int Thread::try_create(size_t stacksize)
 
 void Thread::create(const char *name, size_t stacksize)
 {
+  assert(strlen(name) < 16);
+  thread_name = name;
+
   int ret = try_create(stacksize);
   if (ret != 0) {
     char buf[256];
@@ -152,9 +158,6 @@ void Thread::create(const char *name, size_t stacksize)
 	     "failed with error %d", ret);
     dout_emergency(buf);
     assert(ret == 0);
-  } else if (thread_id > 0) {
-      assert(strlen(name) < 16);
-      pthread_setname_np(thread_id, name);
   }
 }
 

--- a/src/common/Thread.h
+++ b/src/common/Thread.h
@@ -25,6 +25,7 @@ class Thread {
   pid_t pid;
   int ioprio_class, ioprio_priority;
   int cpuid;
+  const char *thread_name;
 
   void *entry_wrapper();
 


### PR DESCRIPTION
When using setuid/setgid, main thread don't have access to
/proc/self/task/[tid]/comm, which is owned by newly created
thread (root).

To fix this, pthread_setname_np() was moved to newly created
thread, and now it changes name for itself.

Signed-off-by: Igor Podoski <igor.podoski@ts.fujitsu.com>