### PR TITLE
Updated scripts and documentation for mirrors

### DIFF
--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -92,28 +92,6 @@ To install the ``autobuild.asc`` key, execute the following
 	sudo rpm --import 'https://download.ceph.com/keys/autobuild.asc'
 
 
-.. _mirrors:
-
-Mirrors
-=======
-
-For improved user experience multiple mirrors for Ceph are available around the
-world.
-
-These mirrors are available on the following locations:
-
-- **EU**: http://eu.ceph.com/
-- **AU**: http://au.ceph.com/
-
-You can replace all ceph.com URLs with any of the mirrors, for example:
-
-  http://download.ceph.com/debian-hammer
-
-Change this to:
-
-  http://eu.ceph.com/debian-hammer
-
-
 Add Ceph
 ========
 
@@ -154,7 +132,7 @@ The major releases of Ceph include:
   was retired in May 2015), so we recommend that users upgrade to a more
   recent version.
 
-.. tip:: For international users, there are various mirrors globally. See :ref:`mirrors`.
+.. tip:: For international users: There might be a mirror close to you where download Ceph from. For more information see: `Ceph Mirrors`_.
 
 Debian Packages
 ---------------
@@ -194,8 +172,7 @@ of Debian and Ubuntu releases supported. ::
 
 	echo deb http://download.ceph.com/debian-testing/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
-.. tip:: For international users, there are various mirrors globally. See the
-   information at the start of this page.
+.. tip:: For international users: There might be a mirror close to you where download Ceph from. For more information see: `Ceph Mirrors`_.
 
 RPM Packages
 ------------
@@ -284,8 +261,8 @@ You can download the RPMs directly from::
 
      http://download.ceph.com/rpm-testing
 
-.. tip:: For international users, there are various mirrors globally. See :ref:`mirrors`.
-Add Ceph Development
+.. tip:: For international users: There might be a mirror close to you where download Ceph from. For more information see: `Ceph Mirrors`_.
+
 ====================
 
 Development repositories use the ``autobuild.asc`` key to verify packages.
@@ -485,3 +462,4 @@ line to get the short codename. ::
 .. _Install Ceph Object Storage: ../install-storage-cluster
 .. _the testing Debian repository: http://download.ceph.com/debian-testing/dists
 .. _the gitbuilder page: http://gitbuilder.ceph.com
+.. _Ceph Mirrors: ../mirrors

--- a/doc/install/get-tarballs.rst
+++ b/doc/install/get-tarballs.rst
@@ -7,8 +7,8 @@ source code. You may download source code tarballs for Ceph releases here:
 
 `Ceph Release Tarballs`_
 
-`Ceph Release Tarballs (EU mirror)`_
+.. tip:: For international users: There might be a mirror close to you where download Ceph from. For more information see: `Ceph Mirrors`_.
 
 
 .. _Ceph Release Tarballs: http://ceph.com/download/
-.. _Ceph Release Tarballs (EU mirror): http://eu.ceph.com/download/
+.. _Ceph Mirrors: ../mirrors

--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -15,12 +15,13 @@ repository and build Ceph yourself.
 
 
 .. toctree::
-   :maxdepth: 1 
+   :maxdepth: 1
 
 	Get Packages <get-packages>
 	Get Tarballs <get-tarballs>
 	Clone Source <clone-source>
 	Build Ceph <build-ceph>
+    Ceph Mirrors <mirrors>
 
 
 Install Software
@@ -33,27 +34,27 @@ management tools. You should install Yum Priorities for RHEL/CentOS and other
 distributions that use Yum if you intend to install the Ceph Object Gateway or
 QEMU.
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 1
 
 	Install ceph-deploy <install-ceph-deploy>
    Install Ceph Storage Cluster <install-storage-cluster>
 	Install Ceph Object Gateway <install-ceph-gateway>
-	Install Virtualization for Block <install-vm-cloud>	
+	Install Virtualization for Block <install-vm-cloud>
 
 
 Deploy a Cluster Manually
 =========================
 
-Once you have Ceph installed on your nodes, you can deploy a cluster manually. 
+Once you have Ceph installed on your nodes, you can deploy a cluster manually.
 The manual procedure is primarily for exemplary purposes for those developing
 deployment scripts with Chef, Juju, Puppet, etc.
 
-.. toctree:: 
-   
+.. toctree::
+
    Manual Deployment <manual-deployment>
 
-Upgrade Software	
+Upgrade Software
 ================
 
 As new versions of Ceph become available, you may upgrade your cluster to take
@@ -65,5 +66,5 @@ sequence.
    :maxdepth: 2
 
    Upgrading Ceph <upgrading-ceph>
-   
+
 .. _get packages: ../install/get-packages

--- a/doc/install/mirrors.rst
+++ b/doc/install/mirrors.rst
@@ -1,0 +1,64 @@
+=============
+ Ceph Mirrors
+=============
+
+For improved user experience multiple mirrors for Ceph are available around the
+world.
+
+These mirrors are kindly sponsored by various companies who want to support the
+Ceph project.
+
+
+Locations
+=========
+
+These mirrors are available on the following locations:
+
+- **EU: Netherlands**: http://eu.ceph.com/
+- **AU: Australia**: http://au.ceph.com/
+- **CZ: Czech Republic**: http://cz.ceph.com/
+- **SE: Sweden**: http://se.ceph.com/
+- **DE: Germany**: http://de.ceph.com/
+- **HK: Hong Kong**: http://hk.ceph.com/
+- **US-East: US East Coast**: http://us-east.ceph.com/
+- **US-West: US West Coast**: http://us-west.ceph.com/
+
+You can replace all download.ceph.com URLs with any of the mirrors, for example:
+
+  http://download.ceph.com/tarballs/
+  http://download.ceph.com/debian-hammer/
+  http://download.ceph.com/rpm-hammer/
+
+Change this to:
+
+  http://eu.ceph.com/tarballs/
+  http://eu.ceph.com/debian-hammer/
+  http://eu.ceph.com/rpm-hammer/
+
+
+Mirroring
+=========
+
+You can easily mirror Ceph yourself using a Bash script and rsync. A easy to use
+script can be found at `Github`_.
+
+When mirroring Ceph, please keep the following guidelines in mind:
+
+- Choose a mirror close to you
+- Do not sync in a interval shorter than 3 hours
+- Avoid syncing at minute 0 of the hour, use something between 0 and 59
+
+
+Becoming a mirror
+=================
+
+If you want to provide a public mirror for other users of Ceph you can opt to
+become a official mirror.
+
+To make sure all mirrors meet the same standards some requirements have been
+set for all mirrors. These can be found on `Github`_.
+
+If you want to apply for an official mirror, please contact the ceph-users mailinglist.
+
+
+.. _Github: https://github.com/ceph/ceph/tree/master/mirroring

--- a/mirroring/MIRRORS
+++ b/mirroring/MIRRORS
@@ -1,4 +1,9 @@
 download.ceph.com: Red Hat <ceph-users@lists.ceph.com>
 eu.ceph.com: Wido den Hollander <wido@42on.com>
 au.ceph.com: Matthew Taylor <matthew.taylor@digitalpacific.com.au>
-
+de.ceph.com: Oliver Dzombic <info@ip-interactive.de>
+se.ceph.com: Josef Johansson <josef86@gmail.com>
+cz.ceph.com: Tomáš Kukrál <kukratom@fit.cvut.cz>
+us-east.ceph.com: Tyler Bishop <tyler.bishop@beyondhosting.net>
+hk.ceph.com: Mart van Santen <mart@greenhost.nl>
+fr.ceph.com: Adrien Gillard <gillard.adrien@gmail.com>

--- a/mirroring/mirror-ceph.sh
+++ b/mirroring/mirror-ceph.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 #
 # Script to mirror Ceph locally
 #
@@ -10,8 +11,15 @@ SILENT=0
 # All available source mirrors
 declare -A SOURCES
 SOURCES[eu]="eu.ceph.com"
+SOURCES[de]="de.ceph.com"
+SOURCES[se]="se.ceph.com"
+SOURCES[cz]="cz.ceph.com"
 SOURCES[au]="au.ceph.com"
 SOURCES[us]="download.ceph.com"
+SOURCES[hk]="hk.ceph.com"
+SOURCES[fr]="fr.ceph.com"
+SOURCES[us-east]="us-east.ceph.com"
+SOURCES[us-west]="us-west.ceph.com"
 SOURCES[global]="download.ceph.com"
 
 function print_usage() {
@@ -77,8 +85,6 @@ fi
 #
 
 # Exclude all metadata files
-RET=0
-
 rsync ${RSYNC_OPTS} ${SOURCE_HOST}::ceph --recursive --times --links \
                                          --hard-links \
                                          --exclude Packages* \
@@ -90,17 +96,7 @@ rsync ${RSYNC_OPTS} ${SOURCE_HOST}::ceph --recursive --times --links \
                                          --exclude repodata/* \
                                          ${TARGET}
 
-if [ "$?" -ne 0 ]; then
-    RET=$?
-fi
-
 # Now also transfer the metadata and delete afterwards
 rsync ${RSYNC_OPTS} ${SOURCE_HOST}::ceph --recursive --times --links \
                                          --hard-links --delete-after \
-                                        ${TARGET}
-
-if [ "$?" -ne 0 ]; then
-    RET=$?
-fi
-
-exit $RET
+                                         ${TARGET}

--- a/mirroring/rsyncd.conf
+++ b/mirroring/rsyncd.conf
@@ -1,0 +1,9 @@
+uid = nobody
+gid = nogroup
+max connections = 15
+socket options = SO_KEEPALIVE
+
+[ceph]
+  path = /path/to/ceph/mirror/data
+  comment = Ceph mirror
+  read only = true

--- a/mirroring/test-mirrors.sh
+++ b/mirroring/test-mirrors.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Simple script which performs a HTTP and rsync check on
+# all Ceph mirrors over IPv4 and IPv6 to see if they are online
+#
+# Requires IPv4, IPv6, rsync and curl
+#
+# Example usage:
+# - ./test-mirrors.sh eu.ceph.com,de.ceph.com,hk.ceph.com
+# - cat MIRRORS |cut -d ':' -f 1|xargs -n 1 ./test-mirrors.sh
+#
+
+function print_usage {
+    echo "Usage: $0 mirror1,mirror2,mirror3,mirror4,etc"
+}
+
+function test_http {
+    HOST=$1
+
+    echo -n "$HOST HTTP IPv4: "
+    curl -s -I -4 -o /dev/null http://$HOST
+    if [ "$?" -ne 0 ]; then
+        echo "FAIL"
+    else
+        echo "OK"
+    fi
+
+    echo -n "$HOST HTTP IPv6: "
+    curl -s -I -6 -o /dev/null http://$HOST
+    if [ "$?" -ne 0 ]; then
+        echo "FAIL"
+    else
+        echo "OK"
+    fi
+}
+
+function test_rsync {
+    HOST=$1
+
+    echo -n "$HOST RSYNC IPv4: "
+    rsync -4 -avrqn ${HOST}::ceph /tmp 2>/dev/null
+    if [ "$?" -ne 0 ]; then
+        echo "FAIL"
+    else
+        echo "OK"
+    fi
+
+    echo -n "$HOST RSYNC IPv6: "
+    rsync -6 -avrqn ${HOST}::ceph /tmp 2>/dev/null
+    if [ "$?" -ne 0 ]; then
+        echo "FAIL"
+    else
+        echo "OK"
+    fi
+}
+
+MIRRORS=$1
+
+if [ -z "$MIRRORS" ]; then
+    print_usage
+    exit 1
+fi
+
+IFS=', ' read -r -a array <<< "$MIRRORS"
+
+for MIRROR in "${array[@]}"; do
+    test_http $MIRROR
+    test_rsync $MIRROR
+done


### PR DESCRIPTION
This PR is to add documentation about the newly set up mirrors for Ceph.

This should allow users to use a local mirror instead of download.ceph.com for getting the latest and greatest Ceph.