### PR TITLE
hammer: mon: Enable Pg_prime By Default

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -843,6 +843,24 @@ Miscellaneous
 :Default: ``4096``
 
 
+``mon osd prime pg temp``
+
+:Description: Enables or disable priming the PGMap with the previous OSDs when an out
+              OSD comes back into the cluster. With the ``true`` setting the clients
+              will continue to use the previous OSDs until the newly in OSDs as that
+              PG peered.
+:Type: Boolean
+:Default: ``true``
+
+
+``mon osd prime pg temp max time``
+
+:Description: How much time in seconds the monitor should spend trying to prime the
+              PGMap when an out OSD comes back into the cluster.
+:Type: Float
+:Default: ``0.5``
+
+
 
 .. _Paxos: http://en.wikipedia.org/wiki/Paxos_(computer_science)
 .. _Monitor Keyrings: ../../operations/authentication#monitor-keyrings

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -196,6 +196,7 @@ OPTION(mon_osd_max_op_age, OPT_DOUBLE, 32)     // max op age before we get conce
 OPTION(mon_osd_max_split_count, OPT_INT, 32) // largest number of PGs per "involved" OSD to let split create
 OPTION(mon_osd_allow_primary_temp, OPT_BOOL, false)  // allow primary_temp to be set in the osdmap
 OPTION(mon_osd_allow_primary_affinity, OPT_BOOL, false)  // allow primary_affinity to be set in the osdmap
+OPTION(mon_osd_prime_pg_temp, OPT_BOOL, false)  // prime osdmap with pg mapping changes
 OPTION(mon_stat_smooth_intervals, OPT_INT, 2)  // smooth stats over last N PGMap maps
 OPTION(mon_lease, OPT_FLOAT, 5)       // lease interval
 OPTION(mon_lease_renew_interval, OPT_FLOAT, 3) // on leader, to renew the lease

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -196,7 +196,7 @@ OPTION(mon_osd_max_op_age, OPT_DOUBLE, 32)     // max op age before we get conce
 OPTION(mon_osd_max_split_count, OPT_INT, 32) // largest number of PGs per "involved" OSD to let split create
 OPTION(mon_osd_allow_primary_temp, OPT_BOOL, false)  // allow primary_temp to be set in the osdmap
 OPTION(mon_osd_allow_primary_affinity, OPT_BOOL, false)  // allow primary_affinity to be set in the osdmap
-OPTION(mon_osd_prime_pg_temp, OPT_BOOL, false)  // prime osdmap with pg mapping changes
+OPTION(mon_osd_prime_pg_temp, OPT_BOOL, true)  // prime osdmap with pg mapping changes
 OPTION(mon_osd_prime_pg_temp_max_time, OPT_FLOAT, .5)  // max time to spend priming
 OPTION(mon_stat_smooth_intervals, OPT_INT, 2)  // smooth stats over last N PGMap maps
 OPTION(mon_lease, OPT_FLOAT, 5)       // lease interval

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -197,6 +197,7 @@ OPTION(mon_osd_max_split_count, OPT_INT, 32) // largest number of PGs per "invol
 OPTION(mon_osd_allow_primary_temp, OPT_BOOL, false)  // allow primary_temp to be set in the osdmap
 OPTION(mon_osd_allow_primary_affinity, OPT_BOOL, false)  // allow primary_affinity to be set in the osdmap
 OPTION(mon_osd_prime_pg_temp, OPT_BOOL, false)  // prime osdmap with pg mapping changes
+OPTION(mon_osd_prime_pg_temp_max_time, OPT_FLOAT, .5)  // max time to spend priming
 OPTION(mon_stat_smooth_intervals, OPT_INT, 2)  // smooth stats over last N PGMap maps
 OPTION(mon_lease, OPT_FLOAT, 5)       // lease interval
 OPTION(mon_lease_renew_interval, OPT_FLOAT, 3) // on leader, to renew the lease

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -988,6 +988,11 @@ void OSDMonitor::prime_pg_temp(OSDMap& next,
 			      &cur_acting, &acting_primary);
   if (cur_acting == acting)
     return;  // no change this epoch; must be stale pg_stat
+  if (cur_acting.empty())
+    return;  // if previously empty now we can be no worse off
+  const pg_pool_t *pool = next.get_pg_pool(pp->first.pool());
+  if (pool && cur_acting.size() < pool->min_size)
+    return;  // can be no worse off than before
 
   dout(20) << __func__ << " " << pp->first << " " << cur_up << "/" << cur_acting
 	   << " -> " << up << "/" << acting

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -887,6 +887,93 @@ void OSDMonitor::create_pending()
   OSDMap::remove_down_temps(g_ceph_context, osdmap, &pending_inc);
 }
 
+void OSDMonitor::maybe_prime_pg_temp()
+{
+  if (pending_inc.crush.length()) {
+    dout(10) << __func__ << " new crush map" << dendl;
+    OSDMap next;
+    next.deepish_copy_from(osdmap);
+    next.apply_incremental(pending_inc);
+    prime_pg_temp(next, &mon->pgmon()->pg_map);
+    return;
+  }
+
+  // check for interesting OSDs
+  set<int> osds;
+  for (map<int32_t,uint8_t>::iterator p = pending_inc.new_state.begin();
+       p != pending_inc.new_state.end();
+       ++p) {
+    if (p->second & CEPH_OSD_UP) {
+      osds.insert(p->first);
+    }
+  }
+  for (map<int32_t,uint32_t>::iterator p = pending_inc.new_weight.begin();
+       p != pending_inc.new_weight.end();
+       ++p) {
+    osds.insert(p->first);
+  }
+  if (!osds.empty()) {
+    dout(10) << __func__ << " " << osds.size() << " interesting osds" << dendl;
+    OSDMap next;
+    next.deepish_copy_from(osdmap);
+    next.apply_incremental(pending_inc);
+    for (set<int>::iterator p = osds.begin(); p != osds.end(); ++p) {
+      prime_pg_temp(next, &mon->pgmon()->pg_map, *p);
+    }
+  }
+}
+
+void OSDMonitor::prime_pg_temp(OSDMap& next,
+			       ceph::unordered_map<pg_t, pg_stat_t>::iterator pp)
+{
+  // do not touch a mapping if a change is pending
+  if (pending_inc.new_pg_temp.count(pp->first))
+    return;
+  vector<int> up, acting;
+  int up_primary, acting_primary;
+  next.pg_to_up_acting_osds(pp->first, &up, &up_primary, &acting, &acting_primary);
+  if (acting == pp->second.acting)
+    return;  // no change since last pg update, skip
+  vector<int> cur_up, cur_acting;
+  osdmap.pg_to_up_acting_osds(pp->first, &cur_up, &up_primary,
+			      &cur_acting, &acting_primary);
+  if (cur_acting == acting)
+    return;  // no change this epoch; must be stale pg_stat
+
+  dout(20) << __func__ << " " << pp->first << " " << cur_up << "/" << cur_acting
+	   << " -> " << up << "/" << acting
+	   << ", priming " << cur_acting
+	   << dendl;
+  pending_inc.new_pg_temp[pp->first] = cur_acting;
+}
+
+void OSDMonitor::prime_pg_temp(OSDMap& next, PGMap *pg_map, int osd)
+{
+  dout(10) << __func__ << " osd." << osd << dendl;
+  ceph::unordered_map<int, set<pg_t> >::iterator po = pg_map->pg_by_osd.find(osd);
+  if (po != pg_map->pg_by_osd.end()) {
+    for (set<pg_t>::iterator p = po->second.begin();
+	 p != po->second.end();
+	 ++p) {
+      ceph::unordered_map<pg_t, pg_stat_t>::iterator pp = pg_map->pg_stat.find(*p);
+      if (pp == pg_map->pg_stat.end())
+	continue;
+      prime_pg_temp(next, pp);
+    }
+  }
+}
+
+void OSDMonitor::prime_pg_temp(OSDMap& next, PGMap *pg_map)
+{
+  dout(10) << __func__ << dendl;
+  for (ceph::unordered_map<pg_t, pg_stat_t>::iterator pp = pg_map->pg_stat.begin();
+       pp != pg_map->pg_stat.end();
+       ++pp) {
+    prime_pg_temp(next, pp);
+  }
+}
+
+
 /**
  * @note receiving a transaction in this function gives a fair amount of
  * freedom to the service implementation if it does need it. It shouldn't.
@@ -901,6 +988,9 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 
   int r = pending_inc.propagate_snaps_to_tiers(g_ceph_context, osdmap);
   assert(r == 0);
+
+  if (g_conf->mon_osd_prime_pg_temp)
+    maybe_prime_pg_temp();
 
   bufferlist bl;
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -889,44 +889,84 @@ void OSDMonitor::create_pending()
 
 void OSDMonitor::maybe_prime_pg_temp()
 {
+  bool all = false;
   if (pending_inc.crush.length()) {
-    dout(10) << __func__ << " new crush map" << dendl;
-    OSDMap next;
-    next.deepish_copy_from(osdmap);
-    next.apply_incremental(pending_inc);
-    prime_pg_temp(next, &mon->pgmon()->pg_map);
-    return;
+    dout(10) << __func__ << " new crush map, all" << dendl;
+    all = true;
+  }
+
+  if (!pending_inc.new_up_client.empty()) {
+    dout(10) << __func__ << " new up osds, all" << dendl;
+    all = true;
   }
 
   // check for interesting OSDs
   set<int> osds;
   for (map<int32_t,uint8_t>::iterator p = pending_inc.new_state.begin();
-       p != pending_inc.new_state.end();
+       !all && p != pending_inc.new_state.end();
        ++p) {
-    if (p->second & CEPH_OSD_UP) {
+    if ((p->second & CEPH_OSD_UP) &&
+	osdmap.is_up(p->first)) {
       osds.insert(p->first);
     }
   }
   for (map<int32_t,uint32_t>::iterator p = pending_inc.new_weight.begin();
-       p != pending_inc.new_weight.end();
+       !all && p != pending_inc.new_weight.end();
        ++p) {
-    osds.insert(p->first);
+    if (p->second < osdmap.get_weight(p->first)) {
+      // weight reduction
+      osds.insert(p->first);
+    } else {
+      dout(10) << __func__ << " osd." << p->first << " weight increase, all"
+	       << dendl;
+      all = true;
+    }
   }
-  if (!osds.empty()) {
+
+  if (!all && osds.empty())
+    return;
+
+  OSDMap next;
+  next.deepish_copy_from(osdmap);
+  next.apply_incremental(pending_inc);
+
+  PGMap *pg_map = &mon->pgmon()->pg_map;
+
+  utime_t stop = ceph_clock_now(NULL);
+  stop += g_conf->mon_osd_prime_pg_temp_max_time;
+  int chunk = 1000;
+  int n = chunk;
+
+  if (all) {
+    for (ceph::unordered_map<pg_t, pg_stat_t>::iterator pp =
+	   pg_map->pg_stat.begin();
+	 pp != pg_map->pg_stat.end();
+	 ++pp) {
+      prime_pg_temp(next, pp);
+      if (--n <= 0) {
+	n = chunk;
+	if (ceph_clock_now(NULL) > stop) {
+	  dout(10) << __func__ << " consumed more than "
+		   << g_conf->mon_osd_prime_pg_temp_max_time
+		   << " seconds, stopping"
+		   << dendl;
+	  break;
+	}
+      }
+    }
+  } else {
     dout(10) << __func__ << " " << osds.size() << " interesting osds" << dendl;
-    OSDMap next;
-    next.deepish_copy_from(osdmap);
-    next.apply_incremental(pending_inc);
-    utime_t stop = ceph_clock_now(NULL);
-    stop += g_conf->mon_osd_prime_pg_temp_max_time;
     for (set<int>::iterator p = osds.begin(); p != osds.end(); ++p) {
-      prime_pg_temp(next, &mon->pgmon()->pg_map, *p);
-      if (ceph_clock_now(NULL) > stop) {
-	dout(10) << __func__ << " consumed more than "
-		 << g_conf->mon_osd_prime_pg_temp_max_time
-		 << " seconds, stopping"
-		 << dendl;
-	break;
+      n -= prime_pg_temp(next, pg_map, *p);
+      if (--n <= 0) {
+	n = chunk;
+	if (ceph_clock_now(NULL) > stop) {
+	  dout(10) << __func__ << " consumed more than "
+		   << g_conf->mon_osd_prime_pg_temp_max_time
+		   << " seconds, stopping"
+		   << dendl;
+	  break;
+	}
       }
     }
   }
@@ -956,43 +996,22 @@ void OSDMonitor::prime_pg_temp(OSDMap& next,
   pending_inc.new_pg_temp[pp->first] = cur_acting;
 }
 
-void OSDMonitor::prime_pg_temp(OSDMap& next, PGMap *pg_map, int osd)
+int OSDMonitor::prime_pg_temp(OSDMap& next, PGMap *pg_map, int osd)
 {
   dout(10) << __func__ << " osd." << osd << dendl;
+  int num = 0;
   ceph::unordered_map<int, set<pg_t> >::iterator po = pg_map->pg_by_osd.find(osd);
   if (po != pg_map->pg_by_osd.end()) {
     for (set<pg_t>::iterator p = po->second.begin();
 	 p != po->second.end();
-	 ++p) {
+	 ++p, ++num) {
       ceph::unordered_map<pg_t, pg_stat_t>::iterator pp = pg_map->pg_stat.find(*p);
       if (pp == pg_map->pg_stat.end())
 	continue;
       prime_pg_temp(next, pp);
     }
   }
-}
-
-void OSDMonitor::prime_pg_temp(OSDMap& next, PGMap *pg_map)
-{
-  dout(10) << __func__ << dendl;
-  utime_t stop = ceph_clock_now(NULL);
-  stop += g_conf->mon_osd_prime_pg_temp_max_time;
-  int n = 0;
-  for (ceph::unordered_map<pg_t, pg_stat_t>::iterator pp = pg_map->pg_stat.begin();
-       pp != pg_map->pg_stat.end();
-       ++pp) {
-    prime_pg_temp(next, pp);
-    if (++n == 1000) {
-      n = 0;
-      if (ceph_clock_now(NULL) > stop) {
-	dout(10) << __func__ << " consumed more than "
-		 << g_conf->mon_osd_prime_pg_temp_max_time
-		 << " seconds, stopping"
-		 << dendl;
-	break;
-      }
-    }
-  }
+  return num;
 }
 
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -917,8 +917,17 @@ void OSDMonitor::maybe_prime_pg_temp()
     OSDMap next;
     next.deepish_copy_from(osdmap);
     next.apply_incremental(pending_inc);
+    utime_t stop = ceph_clock_now(NULL);
+    stop += g_conf->mon_osd_prime_pg_temp_max_time;
     for (set<int>::iterator p = osds.begin(); p != osds.end(); ++p) {
       prime_pg_temp(next, &mon->pgmon()->pg_map, *p);
+      if (ceph_clock_now(NULL) > stop) {
+	dout(10) << __func__ << " consumed more than "
+		 << g_conf->mon_osd_prime_pg_temp_max_time
+		 << " seconds, stopping"
+		 << dendl;
+	break;
+      }
     }
   }
 }
@@ -966,10 +975,23 @@ void OSDMonitor::prime_pg_temp(OSDMap& next, PGMap *pg_map, int osd)
 void OSDMonitor::prime_pg_temp(OSDMap& next, PGMap *pg_map)
 {
   dout(10) << __func__ << dendl;
+  utime_t stop = ceph_clock_now(NULL);
+  stop += g_conf->mon_osd_prime_pg_temp_max_time;
+  int n = 0;
   for (ceph::unordered_map<pg_t, pg_stat_t>::iterator pp = pg_map->pg_stat.begin();
        pp != pg_map->pg_stat.end();
        ++pp) {
     prime_pg_temp(next, pp);
+    if (++n == 1000) {
+      n = 0;
+      if (ceph_clock_now(NULL) > stop) {
+	dout(10) << __func__ << " consumed more than "
+		 << g_conf->mon_osd_prime_pg_temp_max_time
+		 << " seconds, stopping"
+		 << dendl;
+	break;
+      }
+    }
   }
 }
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -35,6 +35,8 @@ using namespace std;
 #include "Session.h"
 
 class Monitor;
+class PGMap;
+
 #include "messages/MOSDBoot.h"
 #include "messages/MMonCommand.h"
 #include "messages/MOSDMap.h"
@@ -195,6 +197,12 @@ private:
                                       stringstream &ss);
 
   void share_map_with_random_osd();
+
+  void maybe_prime_pg_temp();
+  void prime_pg_temp(OSDMap& next,
+		     ceph::unordered_map<pg_t, pg_stat_t>::iterator pp);
+  void prime_pg_temp(OSDMap& next, PGMap *pg_map, int osd);
+  void prime_pg_temp(OSDMap& next, PGMap *pg_map);
 
   void update_logger();
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -201,8 +201,7 @@ private:
   void maybe_prime_pg_temp();
   void prime_pg_temp(OSDMap& next,
 		     ceph::unordered_map<pg_t, pg_stat_t>::iterator pp);
-  void prime_pg_temp(OSDMap& next, PGMap *pg_map, int osd);
-  void prime_pg_temp(OSDMap& next, PGMap *pg_map);
+  int prime_pg_temp(OSDMap& next, PGMap *pg_map, int osd);
 
   void update_logger();
 

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -121,6 +121,7 @@ public:
   osd_stat_t osd_sum;
   mutable epoch_t min_last_epoch_clean;
   ceph::unordered_map<int,int> blocked_by_sum;
+  ceph::unordered_map<int,set<pg_t> > pg_by_osd;
 
   utime_t stamp;
 
@@ -249,8 +250,11 @@ public:
   void redo_full_sets();
   void register_nearfull_status(int osd, const osd_stat_t& s);
   void calc_stats();
-  void stat_pg_add(const pg_t &pgid, const pg_stat_t &s, bool sumonly=false);
-  void stat_pg_sub(const pg_t &pgid, const pg_stat_t &s, bool sumonly=false);
+  void stat_pg_add(const pg_t &pgid, const pg_stat_t &s, bool sumonly=false,
+		   bool sameosds=false);
+  void stat_pg_sub(const pg_t &pgid, const pg_stat_t &s, bool sumonly=false,
+		   bool sameosds=false);
+  void stat_pg_update(const pg_t pgid, pg_stat_t &prev, bufferlist::iterator& blp);
   void stat_osd_add(const osd_stat_t &s);
   void stat_osd_sub(const osd_stat_t &s);
   

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -420,6 +420,7 @@ $extra_conf
         mon pg warn min per osd = 3
         mon osd allow primary affinity = true
         mon reweight min pgs per osd = 4
+        mon osd prime pg temp = true
 $DAEMONOPTS
 $CMONDEBUG
 $extra_conf


### PR DESCRIPTION
http://tracker.ceph.com/issues/14948

The pg_temp mapping helps reduce the memory of an OSD when it is restarted.

Signed-off-by: Robert LeBlanc <robert.leblanc@endurance.com>