### PR TITLE
rados: fix bug for write bench

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -508,7 +508,7 @@ int ObjBencher::write_bench(int secondsToRun,
     ++data.started;
     ++data.in_flight;
     if (max_objects &&
-	data.started > (int)((data.object_size * max_objects + data.op_size - 1) /
+	data.started >= (int)((data.object_size * max_objects + data.op_size - 1) /
 			     data.op_size))
       break;
   }


### PR DESCRIPTION
The number of IO is always one more time than designated by --max-objects. The patch will fix this bug

Signed-off-by: James Liu <james.liu@ssi.samsung.com>