### PR TITLE
test/cli-integration/rbd: disable progress output

### DIFF
--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -20,12 +20,8 @@ create
 snapshot
 ========
   $ rbd snap create bar@snap
-  $ rbd resize -s 1024 bar
-  
-  Resizing image: 100% complete...done.
-  $ rbd resize -s 2G  quuy
-  
-  Resizing image: 100% complete...done.
+  $ rbd resize -s 1024 --no-progress bar
+  $ rbd resize -s 2G --no-progress quuy
   $ rbd snap create bar@snap2
   $ rbd snap create foo@snap
 


### PR DESCRIPTION
This test is intended to check machine-readable output and usage, not
human-readable output.

Fixes: #14931
Signed-off-by: Josh Durgin <jdurgin@redhat.com>