### PR TITLE
os/bluestore: clone overlay data

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6211,23 +6211,27 @@ int BlueStore::_clone(TransContext *txc,
     goto out;
 
   if (g_conf->bluestore_clone_cow) {
-    EnodeRef e = c->get_enode(newo->oid.hobj.get_hash());
-    bool marked = false;
-    for (auto& p : oldo->onode.block_map) {
-      if (p.second.has_flag(bluestore_extent_t::FLAG_SHARED)) {
-	e->ref_map.get(p.second.offset, p.second.length);
-      } else {
-	p.second.set_flag(bluestore_extent_t::FLAG_SHARED);
-	e->ref_map.add(p.second.offset, p.second.length, 2);
-	marked = true;
+    if (!oldo->onode.block_map.empty()) {
+      EnodeRef e = c->get_enode(newo->oid.hobj.get_hash());
+      bool marked = false;
+      for (auto& p : oldo->onode.block_map) {
+	if (p.second.has_flag(bluestore_extent_t::FLAG_SHARED)) {
+	  e->ref_map.get(p.second.offset, p.second.length);
+	} else {
+	  p.second.set_flag(bluestore_extent_t::FLAG_SHARED);
+	  e->ref_map.add(p.second.offset, p.second.length, 2);
+	  marked = true;
+	}
       }
+      dout(20) << __func__ << " hash " << std::hex << e->hash << std::dec << " ref_map now "
+	<< e->ref_map << dendl;
+      newo->onode.block_map = oldo->onode.block_map;
+      newo->enode = e;
+      dout(20) << __func__ << " block_map " << newo->onode.block_map << dendl;
+      txc->write_enode(e);
+      if (marked)
+	txc->write_onode(oldo);
     }
-    dout(20) << __func__ << " hash " << std::hex << e->hash << std::dec << " ref_map now "
-	     << e->ref_map << dendl;
-    newo->onode.block_map = oldo->onode.block_map;
-    newo->enode = e;
-    dout(20) << __func__ << " block_map " << newo->onode.block_map << dendl;
-    txc->write_enode(e);
 
     //don't care _can_overlay_write()
     for (auto& v : oldo->onode.overlay_map) {
@@ -6249,8 +6253,6 @@ int BlueStore::_clone(TransContext *txc,
     }
 
     newo->onode.size = oldo->onode.size;
-    if (marked)
-      txc->write_onode(oldo);
   } else {
     // read + write
     r = _do_read(oldo, 0, oldo->onode.size, bl, 0);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6222,7 +6222,7 @@ int BlueStore::_clone(TransContext *txc,
 	marked = true;
       }
     }
-    dout(20) << __func__ << " hash " << e->hash << " ref_map now "
+    dout(20) << __func__ << " hash " << std::hex << e->hash << std::dec << " ref_map now "
 	     << e->ref_map << dendl;
     newo->onode.block_map = oldo->onode.block_map;
     newo->enode = e;


### PR DESCRIPTION
Make BlueStore::_clone work when source-object has overlay data.