### PR TITLE
doc: rgw explain keystone's verify ssl switch

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -975,6 +975,11 @@ Keystone Settings
 :Default: ``15 * 60``
 
 
+``rgw keystone verify ssl`
+
+:Description: Verify SSL certificates while making token requests to keystone.
+:Type: Boolean
+:Default: ``true``
 
 .. _Architecture: ../../architecture#data-striping
 .. _Pool Configuration: ../../rados/configuration/pool-pg-config-ref/

--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -109,3 +109,11 @@ requests to the nss db format, for example::
 		certutil -d /var/ceph/nss -A -n ca -t "TCu,Cu,Tuw"
 	openssl x509 -in /etc/keystone/ssl/certs/signing_cert.pem -pubkey | \
 		certutil -A -d /var/ceph/nss -n signing_cert -t "P,P,P"
+
+
+Openstack keystone may also be terminated with a self signed ssl certificate, in
+order for radosgw to interact with keystone in such a case, you could either
+install keystone's ssl certificate in the node running radosgw. Alternatively
+radosgw could be made to not verify the ssl certificate at all (similar to
+openstack clients with a ``--insecure`` switch) by setting the value of the
+configurable ``rgw keystone verify ssl`` to false.


### PR DESCRIPTION
As an addendum to #7777 adding info about `rgw keystone verify ssl` to configuration reference,
also adding a note in keystone page to explain the usage.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>