### PR TITLE
RPM: move %post(un) ldconfig calls to ceph-base

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -792,75 +792,8 @@ mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/ceph/bootstrap-rgw
 %clean
 rm -rf $RPM_BUILD_ROOT
 
-%pre
-%if 0%{?_with_systemd}
-  %if 0%{?suse_version}
-    # service_add_pre and friends don't work with parameterized systemd service
-    # instances, only with single services or targets, so we always pass
-    # ceph.target to these macros
-    %service_add_pre ceph.target
-  %endif
-%endif
-
-
-%post
-/sbin/ldconfig
-%if 0%{?_with_systemd}
-  %if 0%{?suse_version}
-    %fillup_only
-    %service_add_post ceph.target
-  %endif
-%else
-  /sbin/chkconfig --add ceph
-%endif
-
-%preun
-%if 0%{?_with_systemd}
-  %if 0%{?suse_version}
-    %service_del_preun ceph.target
-  %endif
-  # Disable and stop on removal.
-  if [ $1 = 0 ] ; then
-    SERVICE_LIST=$(systemctl | grep -E '^ceph-mon@|^ceph-create-keys@|^ceph-osd@|^ceph-mds@|^ceph-disk-'  | cut -d' ' -f1)
-    if [ -n "$SERVICE_LIST" ]; then
-      for SERVICE in $SERVICE_LIST; do
-        /usr/bin/systemctl --no-reload disable $SERVICE > /dev/null 2>&1 || :
-        /usr/bin/systemctl stop $SERVICE > /dev/null 2>&1 || :
-      done
-    fi
-  fi
-%else
-  %if 0%{?rhel} || 0%{?fedora}
-    if [ $1 = 0 ] ; then
-      /sbin/service ceph stop >/dev/null 2>&1
-      /sbin/chkconfig --del ceph
-    fi
-  %endif
-%endif
-
-%postun
-/sbin/ldconfig
-%if 0%{?_with_systemd}
-  if [ $1 = 1 ] ; then
-    # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
-    # "yes". In any case: if units are not running, do not touch them.
-    SYSCONF_CEPH=/etc/sysconfig/ceph
-    if [ -f $SYSCONF_CEPH -a -r $SYSCONF_CEPH ] ; then
-      source $SYSCONF_CEPH
-    fi
-    if [ "X$CEPH_AUTO_RESTART_ON_UPGRADE" = "Xyes" ] ; then
-      SERVICE_LIST=$(systemctl | grep -E '^ceph-mon@|^ceph-create-keys@|^ceph-osd@|^ceph-mds@|^ceph-disk-'  | cut -d' ' -f1)
-      if [ -n "$SERVICE_LIST" ]; then
-        for SERVICE in $SERVICE_LIST; do
-          /usr/bin/systemctl try-restart $SERVICE > /dev/null 2>&1 || :
-        done
-      fi
-    fi
-  fi
-%endif
-
 #################################################################################
-# files
+# files and systemd scriptlets
 #################################################################################
 %files
 
@@ -933,8 +866,74 @@ rm -rf $RPM_BUILD_ROOT
 %attr(770,ceph,ceph) %dir %{_localstatedir}/run/ceph
 %endif
 
+%pre base
+%if 0%{?_with_systemd}
+  %if 0%{?suse_version}
+    # service_add_pre and friends don't work with parameterized systemd service
+    # instances, only with single services or targets, so we always pass
+    # ceph.target to these macros
+    %service_add_pre ceph.target
+  %endif
+%endif
+
+%post base
+/sbin/ldconfig
+%if 0%{?_with_systemd}
+  %if 0%{?suse_version}
+    %fillup_only
+    %service_add_post ceph.target
+  %endif
+%else
+  /sbin/chkconfig --add ceph
+%endif
+
+%preun base
+%if 0%{?_with_systemd}
+  %if 0%{?suse_version}
+    %service_del_preun ceph.target
+  %endif
+  # Disable and stop on removal.
+  if [ $1 = 0 ] ; then
+    SERVICE_LIST=$(systemctl | grep -E '^ceph-mon@|^ceph-create-keys@|^ceph-osd@|^ceph-mds@|^ceph-disk-'  | cut -d' ' -f1)
+    if [ -n "$SERVICE_LIST" ]; then
+      for SERVICE in $SERVICE_LIST; do
+        /usr/bin/systemctl --no-reload disable $SERVICE > /dev/null 2>&1 || :
+        /usr/bin/systemctl stop $SERVICE > /dev/null 2>&1 || :
+      done
+    fi
+  fi
+%else
+  %if 0%{?rhel} || 0%{?fedora}
+    if [ $1 = 0 ] ; then
+      /sbin/service ceph stop >/dev/null 2>&1
+      /sbin/chkconfig --del ceph
+    fi
+  %endif
+%endif
+
+%postun base
+/sbin/ldconfig
+%if 0%{?_with_systemd}
+  if [ $1 = 1 ] ; then
+    # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
+    # "yes". In any case: if units are not running, do not touch them.
+    SYSCONF_CEPH=/etc/sysconfig/ceph
+    if [ -f $SYSCONF_CEPH -a -r $SYSCONF_CEPH ] ; then
+      source $SYSCONF_CEPH
+    fi
+    if [ "X$CEPH_AUTO_RESTART_ON_UPGRADE" = "Xyes" ] ; then
+      SERVICE_LIST=$(systemctl | grep -E '^ceph-mon@|^ceph-create-keys@|^ceph-osd@|^ceph-mds@|^ceph-disk-'  | cut -d' ' -f1)
+      if [ -n "$SERVICE_LIST" ]; then
+        for SERVICE in $SERVICE_LIST; do
+          /usr/bin/systemctl try-restart $SERVICE > /dev/null 2>&1 || :
+        done
+      fi
+    fi
+  fi
+%endif
+
 #################################################################################
-%files -n ceph-common
+%files common
 %defattr(-,root,root,-)
 %{_bindir}/ceph
 %{_bindir}/ceph-authtool
@@ -987,7 +986,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(3770,ceph,ceph) %dir %{_localstatedir}/log/ceph/
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/
 
-%pre -n ceph-common
+%pre common
 CEPH_GROUP_ID=""
 CEPH_USER_ID=""
 %if 0%{?rhel} || 0%{?fedora}
@@ -1004,18 +1003,19 @@ getent passwd ceph >/dev/null || useradd -r -g ceph -d %{_localstatedir}/lib/cep
 %endif
 exit 0
 
-%post -n ceph-common
+%post common
 %if 0%{?_with_systemd}
 %tmpfiles_create %{_tmpfilesdir}/ceph-common.conf
 %endif
 
-%postun -n ceph-common
+%postun common
 # Package removal cleanup
 if [ "$1" -eq "0" ] ; then
     rm -rf /var/log/ceph
     rm -rf /etc/ceph
 fi
 
+#################################################################################
 %files mds
 %{_bindir}/ceph-mds
 %{_bindir}/cephfs-journal-tool
@@ -1030,6 +1030,7 @@ fi
 %endif
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/mds
 
+#################################################################################
 %files mon
 %{_bindir}/ceph-mon
 %{_bindir}/ceph-rest-api
@@ -1135,6 +1136,7 @@ fi
   fi
 %endif
 
+#################################################################################
 %files osd
 %{_bindir}/ceph-clsinfo
 %{_bindir}/ceph-bluefs-tool


### PR DESCRIPTION
This addresses the following RPMLINT error:

```
ceph-base.x86_64: E: library-without-ldconfig-postun (Badness: 300) /usr/lib64/libosd_tp.so.1.0.0
ceph-base.x86_64: E: library-without-ldconfig-postun (Badness: 300) /usr/lib64/libos_tp.so.1.0.0
This package contains a library and provides no %postun scriptlet containing a call to ldconfig.

ceph-base.x86_64: E: library-without-ldconfig-postin (Badness: 300) /usr/lib64/libosd_tp.so.1.0.0
ceph-base.x86_64: E: library-without-ldconfig-postin (Badness: 300) /usr/lib64/libos_tp.so.1.0.0
This package contains a library and provides no %post scriptlet containing a call to ldconfig.
```

http://tracker.ceph.com/issues/14940 Fixes: #14940

Signed-off-by: Nathan Cutler <ncutler@suse.com>