### PR TITLE
os/bluestore/KernelDevice: For buffer mode no need do bufferlist::rebuid

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -375,7 +375,7 @@ int KernelDevice::aio_write(
   assert(off < size);
   assert(off + len <= size);
 
-  if (!bl.is_n_align_sized(block_size) || !bl.is_aligned(block_size)) {
+  if (!buffered && (!bl.is_n_align_sized(block_size) || !bl.is_aligned(block_size))) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
     bl.rebuild_aligned(block_size);
   }


### PR DESCRIPTION

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>