### PR TITLE
Filestore:: avoid apply threadpool pause when sync journal 

### DIFF
--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1791,6 +1791,12 @@ void FileJournal::do_discard(int64_t offset, int64_t end)
 	dout(1) << __func__ << "ioctl(BLKDISCARD) error:" << cpp_strerror(errno) << dendl;
 }
 
+uint64_t FileJournal::get_journaled_seq()
+{
+  Mutex::Locker locker(finisher_lock);
+  return journaled_seq;
+}
+
 void FileJournal::committed_thru(uint64_t seq)
 {
   Mutex::Locker locker(write_lock);

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -464,6 +464,7 @@ private:
   // writes
   void commit_start(uint64_t seq);
   void committed_thru(uint64_t seq);
+  uint64_t get_journaled_seq();
   bool should_commit_now() {
     return full_state != FULL_NOTFULL && !write_stop;
   }

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -1850,7 +1850,6 @@ void FileStore::_do_op(OpSequencer *osr, ThreadPool::TPHandle &handle)
 
   osr->apply_lock.Lock();
   Op *o = osr->peek_queue();
-  apply_manager.op_apply_start(o->op);
   dout(5) << "_do_op " << o << " seq " << o->op << " " << *osr << "/" << osr->parent << " start" << dendl;
   int r = _do_transactions(o->tls, o->op, &handle);
   apply_manager.op_apply_finish(o->op);

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3630,7 +3630,6 @@ void FileStore::sync_entry()
     fin.swap(sync_waiters);
     lock.Unlock();
 
-    op_tp.pause();
     if (apply_manager.commit_start()) {
       utime_t start = ceph_clock_now(g_ceph_context);
       uint64_t cp = apply_manager.get_committing_seq();
@@ -3669,7 +3668,6 @@ void FileStore::sync_entry()
 
 	snaps.push_back(cp);
 	apply_manager.commit_started();
-	op_tp.unpause();
 
 	if (cid > 0) {
 	  dout(20) << " waiting for checkpoint " << cid << " to complete" << dendl;
@@ -3683,7 +3681,6 @@ void FileStore::sync_entry()
       } else
       {
 	apply_manager.commit_started();
-	op_tp.unpause();
 
 	int err = object_map->sync();
 	if (err < 0) {
@@ -3743,8 +3740,6 @@ void FileStore::sync_entry()
       sync_entry_timeo_lock.Lock();
       timer.cancel_event(sync_entry_timeo);
       sync_entry_timeo_lock.Unlock();
-    } else {
-      op_tp.unpause();
     }
 
     lock.Lock();

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -255,14 +255,18 @@ private:
 	to_queue->push_back(i->second);
       }
     }
-
+    uint64_t dequeue_seq() {
+      Mutex::Locker l(qlock);
+      uint64_t seq =  jq.front();
+      jq.pop_front();
+      return seq;
+    }
     void queue_journal(uint64_t s) {
       Mutex::Locker l(qlock);
       jq.push_back(s);
     }
     void dequeue_journal(list<Context*> *to_queue) {
       Mutex::Locker l(qlock);
-      jq.pop_front();
       cond.Signal();
       _wake_flush_waiters(to_queue);
     }

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -372,6 +372,7 @@ private:
 	return NULL;
       OpSequencer *osr = store->op_queue.front();
       store->op_queue.pop_front();
+      store->apply_manager.op_apply_start(osr->dequeue_seq());
       return osr;
     }
     void _process(OpSequencer *osr, ThreadPool::TPHandle &handle) override {

--- a/src/os/filestore/Journal.h
+++ b/src/os/filestore/Journal.h
@@ -71,6 +71,7 @@ public:
   virtual void commit_start(uint64_t seq) = 0;
   virtual void committed_thru(uint64_t seq) = 0;
 
+  virtual uint64_t get_journaled_seq() = 0;
   /// Read next journal entry - asserts on invalid journal
   virtual bool read_entry(
     bufferlist &bl, ///< [out] payload on successful read

--- a/src/os/filestore/JournalingObjectStore.cc
+++ b/src/os/filestore/JournalingObjectStore.cc
@@ -118,13 +118,7 @@ int JournalingObjectStore::journal_replay(uint64_t fs_op_seq)
 uint64_t JournalingObjectStore::ApplyManager::op_apply_start(uint64_t op)
 {
   Mutex::Locker l(apply_lock);
-  while (blocked) {
-    // note: this only happens during journal replay
-    dout(10) << "op_apply_start blocked, waiting" << dendl;
-    blocked_cond.Wait(apply_lock);
-  }
   dout(10) << "op_apply_start " << op << " open_ops " << open_ops << " -> " << (open_ops+1) << dendl;
-  assert(!blocked);
   assert(op > committed_seq);
   open_ops++;
   return op;
@@ -140,10 +134,6 @@ void JournalingObjectStore::ApplyManager::op_apply_finish(uint64_t op)
   --open_ops;
   assert(open_ops >= 0);
 
-  // signal a blocked commit_start (only needed during journal replay)
-  if (blocked) {
-    blocked_cond.Signal();
-  }
 
   // there can be multiple applies in flight; track the max value we
   // note.  note that we can't _read_ this value and learn anything
@@ -227,8 +217,6 @@ void JournalingObjectStore::ApplyManager::commit_started()
   Mutex::Locker l(apply_lock);
   // allow new ops. (underlying fs should now be committing all prior ops)
   dout(10) << "commit_started committing " << committing_seq << ", unblocking" << dendl;
-  blocked = false;
-  blocked_cond.Signal();
 }
 
 void JournalingObjectStore::ApplyManager::commit_finish()

--- a/src/os/filestore/JournalingObjectStore.cc
+++ b/src/os/filestore/JournalingObjectStore.cc
@@ -205,6 +205,11 @@ bool JournalingObjectStore::ApplyManager::commit_start()
 
       assert( (int)applying_seq.size() == open_ops );
     }
+    if (g_conf->filestore_journal_parallel) {
+       uint64_t journaled_seq = journal->get_journaled_seq();
+       if (journaled_seq < _committing_seq )
+          _committing_seq = journaled_seq;
+    }
   }
   Mutex::Locker l(com_lock);
   {

--- a/src/os/filestore/JournalingObjectStore.h
+++ b/src/os/filestore/JournalingObjectStore.h
@@ -57,6 +57,7 @@ protected:
     Mutex com_lock;
     map<version_t, vector<Context*> > commit_waiters;
     uint64_t committing_seq, committed_seq;
+    map<pthread_t,atomic64_t> applying_seq;
 
   public:
     ApplyManager(Journal *&j, Finisher &f) :

--- a/src/os/filestore/JournalingObjectStore.h
+++ b/src/os/filestore/JournalingObjectStore.h
@@ -51,8 +51,6 @@ protected:
     Finisher &finisher;
 
     Mutex apply_lock;
-    bool blocked;
-    Cond blocked_cond;
     int open_ops;
     uint64_t max_applied_seq;
 
@@ -64,14 +62,12 @@ protected:
     ApplyManager(Journal *&j, Finisher &f) :
       journal(j), finisher(f),
       apply_lock("JOS::ApplyManager::apply_lock", false, true, false, g_ceph_context),
-      blocked(false),
       open_ops(0),
       max_applied_seq(0),
       com_lock("JOS::ApplyManager::com_lock", false, true, false, g_ceph_context),
       committing_seq(0), committed_seq(0) {}
     void reset() {
       assert(open_ops == 0);
-      assert(blocked == false);
       max_applied_seq = 0;
       committing_seq = 0;
       committed_seq = 0;


### PR DESCRIPTION

1) add a map<pthread_t,atomic64_t> applying_seq  to record the seq applying in a thread

2) when sync journal, if applying_seq map is empty, use max_applied_seq as current sync_seq, else
use  min_seq-1 of current applying thread as  current sync_seq

3) For parallel journal, journal commit and journal apply operations are executed in parallel. Journal commit operation may leg behind of journal applied operation,so when journal sync,  get min of journaled_seq and applyed_seq as sync_seq 