### PR TITLE
[rgw] RGWLib::env is not used so remove it

### DIFF
--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -25,7 +25,6 @@ namespace rgw {
     RGWLibFrontend* fe;
     OpsLogSocket* olog;
     RGWREST rest; // XXX needed for RGWProcessEnv
-    RGWProcessEnv env;
     RGWRados* store;
 
   public:


### PR DESCRIPTION
Coverity complains about RGWLib::env.port being uninitialised but
RGWLib::env is not used at all so just remove it.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>