### PR TITLE
[rgw] Check return code in RGWFileHandle::write

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -417,6 +417,8 @@ namespace rgw {
 	new RGWWriteRequest(fs->get_context(), fs->get_user(), this,
 			    bucket_name(), object_name);
       rc = rgwlib.get_fe()->start_req(f->write_req);
+      if (rc < 0)
+        return -EIO;
     }
 
     buffer::list bl;


### PR DESCRIPTION
Coverity complains about rc being unused so check rc accordinly
to silence the error.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>