### PR TITLE
mon: osdmonitor: add a guard for prepare_remove_snaps()

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2345,6 +2345,12 @@ bool OSDMonitor::prepare_remove_snaps(MonOpRequestRef op)
   for (map<int, vector<snapid_t> >::iterator p = m->snaps.begin();
        p != m->snaps.end();
        ++p) {
+
+    if (!osdmap.have_pg_pool(p->first)) {
+      dout(10) << " ignoring removed_snaps " << p->second << " on non-existent pool " << p->first << dendl;
+      continue;
+    }
+
     pg_pool_t& pi = osdmap.pools[p->first];
     for (vector<snapid_t>::iterator q = p->second.begin();
 	 q != p->second.end();


### PR DESCRIPTION
Method preprocess_remove_snaps() is designed to fast check whether
we can safely handle a remove-snaps-request without changing the osdmap.
The original design is to be able to handle snaps from multiple pools,
including those snaps even from a non-existent pool by simply skipping
over them. However, this method will quit on successfully detecting
any vaild snap which is truly needed to be removed and forward this
request to prepare_remove_snaps() for further processing.

From the above analysis, the prepare_remove_snaps() method will
theoretically also encounter some snaps which possibly belong to
non-existent pools.

This pr solves the above problem by adding a sanity check against
pool existense associated with the specified snap to be removed, which
shall be considered as a defensive move and makes prepare_remove_snaps()
stronger.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>