### PR TITLE
librbd: allocate new journal tag after acquiring exclusive lock

### DIFF
--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -980,6 +980,37 @@ namespace librbd {
       return 0;
     }
 
+    int mirror_uuid_get(librados::IoCtx *ioctx, std::string *uuid) {
+      bufferlist in_bl;
+      bufferlist out_bl;
+      int r = ioctx->exec(RBD_MIRRORING, "rbd", "mirror_uuid_get", in_bl,
+                          out_bl);
+      if (r < 0) {
+        return r;
+      }
+
+      try {
+        bufferlist::iterator bl_it = out_bl.begin();
+        ::decode(*uuid, bl_it);
+      } catch (const buffer::error &err) {
+        return -EBADMSG;
+      }
+      return 0;
+    }
+
+    int mirror_uuid_set(librados::IoCtx *ioctx, const std::string &uuid) {
+      bufferlist in_bl;
+      ::encode(uuid, in_bl);
+
+      bufferlist out_bl;
+      int r = ioctx->exec(RBD_MIRRORING, "rbd", "mirror_uuid_set", in_bl,
+                          out_bl);
+      if (r < 0) {
+        return r;
+      }
+      return 0;
+    }
+
     int mirror_mode_get(librados::IoCtx *ioctx,
                         cls::rbd::MirrorMode *mirror_mode) {
       bufferlist in_bl;

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -207,6 +207,8 @@ namespace librbd {
 			  ::SnapContext *snapc);
 
     // operations on the rbd_mirroring object
+    int mirror_uuid_get(librados::IoCtx *ioctx, std::string *uuid);
+    int mirror_uuid_set(librados::IoCtx *ioctx, const std::string &uuid);
     int mirror_mode_get(librados::IoCtx *ioctx,
                         cls::rbd::MirrorMode *mirror_mode);
     int mirror_mode_set(librados::IoCtx *ioctx,

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -35,6 +35,10 @@ struct MirrorPeer {
   std::string client_name;
   int64_t pool_id = -1;
 
+  inline bool is_valid() const {
+    return (!uuid.empty() && !cluster_name.empty() && !client_name.empty());
+  }
+
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &it);
   void dump(Formatter *f) const;

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -591,7 +591,9 @@ void JournalMetadata::schedule_commit_task() {
 void JournalMetadata::handle_commit_position_task() {
   assert(m_timer_lock.is_locked());
   assert(m_lock.is_locked());
-  ldout(m_cct, 20) << __func__ << dendl;
+  ldout(m_cct, 20) << __func__ << ": "
+                   << "client_id=" << m_client_id << ", "
+                   << "commit_position=" << m_commit_position << dendl;
 
   librados::ObjectWriteOperation op;
   client::client_commit(&op, m_client_id, m_commit_position);

--- a/src/journal/JournalPlayer.h
+++ b/src/journal/JournalPlayer.h
@@ -45,6 +45,7 @@ private:
   typedef std::map<uint64_t, ObjectPlayerPtr> ObjectPlayers;
   typedef std::map<uint8_t, ObjectPlayers> SplayedObjectPlayers;
   typedef std::map<uint8_t, ObjectPosition> SplayedObjectPositions;
+  typedef std::set<uint64_t> ObjectNumbers;
 
   enum State {
     STATE_INIT,
@@ -113,6 +114,8 @@ private:
   double m_watch_interval;
 
   bool m_handler_notified = false;
+
+  ObjectNumbers m_fetch_object_numbers;
 
   PrefetchSplayOffsets m_prefetch_splay_offsets;
   SplayedObjectPlayers m_object_players;

--- a/src/journal/JournalPlayer.h
+++ b/src/journal/JournalPlayer.h
@@ -112,6 +112,8 @@ private:
   bool m_watch_scheduled;
   double m_watch_interval;
 
+  bool m_handler_notified = false;
+
   PrefetchSplayOffsets m_prefetch_splay_offsets;
   SplayedObjectPlayers m_object_players;
   uint64_t m_commit_object;
@@ -136,6 +138,9 @@ private:
 
   void schedule_watch();
   void handle_watch(int r);
+
+  void notify_entries_available();
+  void notify_complete(int r);
 };
 
 } // namespace journal

--- a/src/journal/Journaler.cc
+++ b/src/journal/Journaler.cc
@@ -199,6 +199,20 @@ void Journaler::unregister_client(Context *on_finish) {
   return m_metadata->unregister_client(on_finish);
 }
 
+int Journaler::get_cached_client(const std::string &client_id,
+                                 cls::journal::Client *client) {
+  RegisteredClients clients;
+  m_metadata->get_registered_clients(&clients);
+
+  auto it = clients.find({client_id, {}});
+  if (it == clients.end()) {
+    return -ENOENT;
+  }
+
+  *client = *it;
+  return 0;
+}
+
 void Journaler::allocate_tag(const bufferlist &data, cls::journal::Tag *tag,
                              Context *on_finish) {
   m_metadata->allocate_tag(cls::journal::Tag::TAG_CLASS_NEW, data, tag,

--- a/src/journal/Journaler.h
+++ b/src/journal/Journaler.h
@@ -52,10 +52,15 @@ public:
 			    RegisteredClients *clients, Context *on_finish);
 
   int register_client(const bufferlist &data);
-  int unregister_client();
   void register_client(const bufferlist &data, Context *on_finish);
-  void update_client(const bufferlist &data, Context *on_finish);
+
+  int unregister_client();
   void unregister_client(Context *on_finish);
+
+  void update_client(const bufferlist &data, Context *on_finish);
+
+  int get_cached_client(const std::string &client_id,
+                        cls::journal::Client *client);
 
   void flush_commit_position(Context *on_safe);
 

--- a/src/journal/ObjectPlayer.cc
+++ b/src/journal/ObjectPlayer.cc
@@ -207,11 +207,10 @@ void ObjectPlayer::handle_watch_fetched(int r) {
     Mutex::Locker timer_locker(m_timer_lock);
     assert(m_watch_in_progress);
     if (r == -ENOENT) {
-      schedule_watch();
-    } else {
-      on_finish = m_watch_ctx;
-      m_watch_ctx = NULL;
+      r = 0;
     }
+    on_finish = m_watch_ctx;
+    m_watch_ctx = NULL;
   }
 
   if (on_finish != NULL) {

--- a/src/journal/ObjectPlayer.h
+++ b/src/journal/ObjectPlayer.h
@@ -46,11 +46,6 @@ public:
   void watch(Context *on_fetch, double interval);
   void unwatch();
 
-  inline bool is_fetch_in_progress() const {
-    Mutex::Locker locker(m_lock);
-    return m_fetch_in_progress;
-  }
-
   void front(Entry *entry) const;
   void pop_front();
   inline bool empty() const {

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -119,16 +119,9 @@ int Journal<I>::create(librados::IoCtx &io_ctx, const std::string &image_id,
     return r;
   }
 
-  std::string cluster_id;
-  r = rados.cluster_fsid(&cluster_id);
-  if (r < 0) {
-    lderr(cct) << "failed to retrieve cluster id: " << cpp_strerror(r) << dendl;
-    return r;
-  }
-
   // create tag class for this image's journal events
   bufferlist tag_data;
-  ::encode(journal::TagData{cluster_id, pool_id, image_id}, tag_data);
+  ::encode(journal::TagData(), tag_data);
 
   C_SaferCond tag_ctx;
   cls::journal::Tag tag;

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -59,6 +59,10 @@ struct C_DecodeTag : public Context {
       lderr(cct) << "failed to decode allocated tag" << dendl;
       return r;
     }
+
+    ldout(cct, 20) << "allocated journal tag: "
+                   << "tid=" << tag.tid << ", "
+                   << "data=" << *tag_data << dendl;
     return 0;
   }
 
@@ -117,6 +121,10 @@ struct C_DecodeTags : public Context {
       lderr(cct) << "failed to decode journal tag" << dendl;
       return r;
     }
+
+    ldout(cct, 20) << "most recent journal tag: "
+                   << "tid=" << *tag_tid << ", "
+                   << "data=" << *tag_data << dendl;
     return 0;
   }
 };
@@ -771,7 +779,7 @@ void Journal<I>::handle_initialized(int r) {
   assert(m_state == STATE_INITIALIZING);
 
   if (r < 0) {
-    lderr(cct) << this << " " << __func__
+    lderr(cct) << this << " " << __func__ << ": "
                << "failed to initialize journal: " << cpp_strerror(r)
                << dendl;
     destroy_journaler(r);
@@ -808,6 +816,9 @@ void Journal<I>::handle_initialized(int r) {
   }
 
   m_tag_class = image_client_meta->tag_class;
+  ldout(cct, 20) << "client: " << client << ", "
+                 << "image meta: " << *image_client_meta << dendl;
+
   C_DecodeTags *tags_ctx = new C_DecodeTags(
     cct, &m_lock, &m_tag_tid, &m_tag_data, create_async_context_callback(
       m_image_ctx, create_context_callback<

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -8,8 +8,8 @@
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/journal/Replay.h"
-#include "librbd/journal/Types.h"
 #include "librbd/Utils.h"
+#include "cls/journal/cls_journal_types.h"
 #include "journal/Journaler.h"
 #include "journal/ReplayEntry.h"
 #include "common/errno.h"
@@ -20,8 +20,119 @@
 
 namespace librbd {
 
+namespace {
+
+struct C_DecodeTag : public Context {
+  CephContext *cct;
+  Mutex *lock;
+  uint64_t *tag_tid;
+  journal::TagData *tag_data;
+  Context *on_finish;
+
+  cls::journal::Tag tag;
+
+  C_DecodeTag(CephContext *cct, Mutex *lock, uint64_t *tag_tid,
+              journal::TagData *tag_data, Context *on_finish)
+    : cct(cct), lock(lock), tag_tid(tag_tid), tag_data(tag_data),
+      on_finish(on_finish) {
+  }
+
+  virtual void complete(int r) override {
+    on_finish->complete(process(r));
+    Context::complete(0);
+  }
+  virtual void finish(int r) override {
+  }
+
+  int process(int r) {
+    if (r < 0) {
+      lderr(cct) << "failed to allocate tag: " << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    Mutex::Locker locker(*lock);
+    *tag_tid = tag.tid;
+
+    bufferlist::iterator data_it = tag.data.begin();
+    r = decode(&data_it, tag_data);
+    if (r < 0) {
+      lderr(cct) << "failed to decode allocated tag" << dendl;
+      return r;
+    }
+    return 0;
+  }
+
+  static int decode(bufferlist::iterator *it,
+                    journal::TagData *tag_data) {
+    try {
+      ::decode(*tag_data, *it);
+    } catch (const buffer::error &err) {
+      return -EBADMSG;
+    }
+    return 0;
+  }
+
+};
+
+struct C_DecodeTags : public Context {
+  CephContext *cct;
+  Mutex *lock;
+  uint64_t *tag_tid;
+  journal::TagData *tag_data;
+  Context *on_finish;
+
+  ::journal::Journaler::Tags tags;
+
+  C_DecodeTags(CephContext *cct, Mutex *lock, uint64_t *tag_tid,
+               journal::TagData *tag_data, Context *on_finish)
+    : cct(cct), lock(lock), tag_tid(tag_tid), tag_data(tag_data),
+      on_finish(on_finish) {
+  }
+
+  virtual void complete(int r) {
+    on_finish->complete(process(r));
+    Context::complete(0);
+  }
+  virtual void finish(int r) override {
+  }
+
+  int process(int r) {
+    if (r < 0) {
+      lderr(cct) << "failed to retrieve journal tags: " << cpp_strerror(r)
+                 << dendl;
+      return r;
+    }
+
+    if (tags.empty()) {
+      lderr(cct) << "no journal tags retrieved" << dendl;
+      return -ENOENT;
+    }
+
+    Mutex::Locker locker(*lock);
+    *tag_tid = tags.back().tid;
+
+    bufferlist::iterator data_it = tags.back().data.begin();
+    r = C_DecodeTag::decode(&data_it, tag_data);
+    if (r < 0) {
+      lderr(cct) << "failed to decode journal tag" << dendl;
+      return r;
+    }
+    return 0;
+  }
+};
+
+} // anonymous namespace
+
 using util::create_async_context_callback;
 using util::create_context_callback;
+
+// client id for local image
+template <typename I>
+const std::string Journal<I>::IMAGE_CLIENT_ID("");
+
+// mirror uuid to use for local images
+template <typename I>
+const std::string Journal<I>::LOCAL_MIRROR_UUID("");
 
 template <typename I>
 std::ostream &operator<<(std::ostream &os,
@@ -111,7 +222,8 @@ int Journal<I>::create(librados::IoCtx &io_ctx, const std::string &image_id,
     pool_id = data_io_ctx.get_id();
   }
 
-  Journaler journaler(io_ctx, image_id, "", cct->_conf->rbd_journal_commit_age);
+  Journaler journaler(io_ctx, image_id, IMAGE_CLIENT_ID,
+                      cct->_conf->rbd_journal_commit_age);
 
   int r = journaler.create(order, splay_width, pool_id);
   if (r < 0) {
@@ -150,7 +262,8 @@ int Journal<I>::remove(librados::IoCtx &io_ctx, const std::string &image_id) {
   CephContext *cct = reinterpret_cast<CephContext *>(io_ctx.cct());
   ldout(cct, 5) << __func__ << ": image=" << image_id << dendl;
 
-  Journaler journaler(io_ctx, image_id, "", cct->_conf->rbd_journal_commit_age);
+  Journaler journaler(io_ctx, image_id, IMAGE_CLIENT_ID,
+                      cct->_conf->rbd_journal_commit_age);
 
   bool journal_exists;
   int r = journaler.exists(&journal_exists);
@@ -185,7 +298,8 @@ int Journal<I>::reset(librados::IoCtx &io_ctx, const std::string &image_id) {
   CephContext *cct = reinterpret_cast<CephContext *>(io_ctx.cct());
   ldout(cct, 5) << __func__ << ": image=" << image_id << dendl;
 
-  Journaler journaler(io_ctx, image_id, "", cct->_conf->rbd_journal_commit_age);
+  Journaler journaler(io_ctx, image_id, IMAGE_CLIENT_ID,
+                      cct->_conf->rbd_journal_commit_age);
 
   C_SaferCond cond;
   journaler.init(&cond);
@@ -282,6 +396,38 @@ void Journal<I>::close(Context *on_finish) {
 }
 
 template <typename I>
+bool Journal<I>::is_tag_owner() const {
+  return (m_tag_data.mirror_uuid == LOCAL_MIRROR_UUID);
+}
+
+template <typename I>
+void Journal<I>::allocate_tag(const std::string &mirror_uuid,
+                              Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << this << " " << __func__ << ":  mirror_uuid=" << mirror_uuid
+                 << dendl;
+
+  Mutex::Locker locker(m_lock);
+  assert(m_journaler != nullptr && is_tag_owner());
+
+  // NOTE: currently responsibility of caller to provide local mirror
+  // uuid constant or remote peer uuid
+  journal::TagData tag_data;
+  tag_data.mirror_uuid = mirror_uuid;
+
+  // TODO: inject current commit position into tag data (need updated journaler PR)
+  tag_data.predecessor_mirror_uuid = m_tag_data.mirror_uuid;
+
+  bufferlist tag_bl;
+  ::encode(tag_data, tag_bl);
+
+  C_DecodeTag *decode_tag_ctx = new C_DecodeTag(cct, &m_lock, &m_tag_tid,
+                                                &m_tag_data, on_finish);
+  m_journaler->allocate_tag(m_tag_class, tag_bl, &decode_tag_ctx->tag,
+                            decode_tag_ctx);
+}
+
+template <typename I>
 void Journal<I>::flush_commit_position(Context *on_finish) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << this << " " << __func__ << dendl;
@@ -312,8 +458,7 @@ uint64_t Journal<I>::append_io_event(AioCompletion *aio_comp,
     tid = ++m_event_tid;
     assert(tid != 0);
 
-    // TODO: use allocated tag_id
-    future = m_journaler->append(0, bl);
+    future = m_journaler->append(m_tag_tid, bl);
     m_events[tid] = Event(future, aio_comp, requests, offset, length);
   }
 
@@ -398,8 +543,7 @@ void Journal<I>::append_op_event(uint64_t op_tid,
     Mutex::Locker locker(m_lock);
     assert(m_state == STATE_READY);
 
-    // TODO: use allocated tag_id
-    future = m_journaler->append(0, bl);
+    future = m_journaler->append(m_tag_tid, bl);
 
     // delay committing op event to ensure consistent replay
     assert(m_op_futures.count(op_tid) == 0);
@@ -438,8 +582,7 @@ void Journal<I>::commit_op_event(uint64_t op_tid, int r) {
     op_start_future = it->second;
     m_op_futures.erase(it);
 
-    // TODO: use allocated tag_id
-    op_finish_future = m_journaler->append(0, bl);
+    op_finish_future = m_journaler->append(m_tag_tid, bl);
   }
 
   op_finish_future.flush(new C_OpEventSafe(this, op_tid, op_start_future,
@@ -553,8 +696,8 @@ void Journal<I>::create_journaler() {
   assert(m_journaler == NULL);
 
   transition_state(STATE_INITIALIZING, 0);
-  m_journaler = new Journaler(m_image_ctx.md_ctx, m_image_ctx.id, "",
-                              m_image_ctx.journal_commit_age);
+  m_journaler = new Journaler(m_image_ctx.md_ctx, m_image_ctx.id,
+                              IMAGE_CLIENT_ID, m_image_ctx.journal_commit_age);
   m_journaler->init(create_async_context_callback(
     m_image_ctx, create_context_callback<
       Journal<I>, &Journal<I>::handle_initialized>(this)));
@@ -625,11 +768,62 @@ void Journal<I>::handle_initialized(int r) {
   ldout(cct, 20) << this << " " << __func__ << ": r=" << r << dendl;
 
   Mutex::Locker locker(m_lock);
+  assert(m_state == STATE_INITIALIZING);
 
   if (r < 0) {
     lderr(cct) << this << " " << __func__
                << "failed to initialize journal: " << cpp_strerror(r)
                << dendl;
+    destroy_journaler(r);
+    return;
+  }
+
+  // locate the master image client record
+  cls::journal::Client client;
+  r = m_journaler->get_cached_client(Journal<ImageCtx>::IMAGE_CLIENT_ID,
+                                     &client);
+  if (r < 0) {
+    lderr(cct) << "failed to locate master image client" << dendl;
+    destroy_journaler(r);
+    return;
+  }
+
+  librbd::journal::ClientData client_data;
+  bufferlist::iterator bl = client.data.begin();
+  try {
+    ::decode(client_data, bl);
+  } catch (const buffer::error &err) {
+    lderr(cct) << "failed to decode client meta data: " << err.what()
+               << dendl;
+    destroy_journaler(-EINVAL);
+    return;
+  }
+
+  librbd::journal::ImageClientMeta *image_client_meta =
+    boost::get<librbd::journal::ImageClientMeta>(&client_data.client_meta);
+  if (image_client_meta == nullptr) {
+    lderr(cct) << "failed to extract client meta data" << dendl;
+    destroy_journaler(-EINVAL);
+    return;
+  }
+
+  m_tag_class = image_client_meta->tag_class;
+  C_DecodeTags *tags_ctx = new C_DecodeTags(
+    cct, &m_lock, &m_tag_tid, &m_tag_data, create_async_context_callback(
+      m_image_ctx, create_context_callback<
+        Journal<I>, &Journal<I>::handle_get_tags>(this)));
+  m_journaler->get_tags(m_tag_class, &tags_ctx->tags, tags_ctx);
+}
+
+template <typename I>
+void Journal<I>::handle_get_tags(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << this << " " << __func__ << ": r=" << r << dendl;
+
+  Mutex::Locker locker(m_lock);
+  assert(m_state == STATE_INITIALIZING);
+
+  if (r < 0) {
     destroy_journaler(r);
     return;
   }

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -13,6 +13,7 @@
 #include "journal/Future.h"
 #include "journal/ReplayEntry.h"
 #include "journal/ReplayHandler.h"
+#include "librbd/journal/Types.h"
 #include <algorithm>
 #include <iosfwd>
 #include <list>
@@ -32,7 +33,6 @@ class ImageCtx;
 
 namespace journal {
 
-class EventEntry;
 template <typename> class Replay;
 
 template <typename ImageCtxT>
@@ -92,6 +92,9 @@ public:
     STATE_CLOSED
   };
 
+  static const std::string IMAGE_CLIENT_ID;
+  static const std::string LOCAL_MIRROR_UUID;
+
   typedef std::list<AioObjectRequest *> AioObjectRequests;
 
   Journal(ImageCtxT &image_ctx);
@@ -111,6 +114,9 @@ public:
 
   void open(Context *on_finish);
   void close(Context *on_finish);
+
+  bool is_tag_owner() const;
+  void allocate_tag(const std::string &mirror_uuid, Context *on_finish);
 
   void flush_commit_position(Context *on_finish);
 
@@ -241,6 +247,9 @@ private:
   Journaler *m_journaler;
   mutable Mutex m_lock;
   State m_state;
+  uint64_t m_tag_class = 0;
+  uint64_t m_tag_tid = 0;
+  journal::TagData m_tag_data;
 
   int m_error_result;
   Contexts m_wait_for_state_contexts;
@@ -268,6 +277,7 @@ private:
   void complete_event(typename Events::iterator it, int r);
 
   void handle_initialized(int r);
+  void handle_get_tags(int r);
 
   void handle_replay_ready();
   void handle_replay_complete(int r);

--- a/src/librbd/exclusive_lock/AcquireRequest.h
+++ b/src/librbd/exclusive_lock/AcquireRequest.h
@@ -39,25 +39,33 @@ private:
    *    v
    * FLUSH_NOTIFIES
    *    |
-   *    |     /---------------------------------------------------------\
-   *    |     |                                                         |
-   *    |     |             (no lockers)                                |
-   *    |     |   . . . . . . . . . . . . . . . . . . . . .             |
-   *    |     |   .                                       .             |
-   *    |     v   v      (EBUSY)                          .             |
-   *    \--> LOCK_IMAGE * * * * * * * > GET_LOCKERS . . . .             |
-   *          .   |                       |                             |
-   *    . . . .   |                       |                             |
-   *    .         v                       v                             |
-   *    .     OPEN_OBJECT_MAP           GET_WATCHERS . . .              |
-   *    .         |                       |              .              |
-   *    .         v                       v              .              |
-   *    . . > OPEN_JOURNAL * *          BLACKLIST        . (blacklist   |
-   *    .         |          *            |              .  disabled)   |
-   *    .         |          v            v              .              |
-   *    .         | CLOSE_OBJECT_MAP    BREAK_LOCK < . . .              |
-   *    .         v          |            |                             |
-   *    . . > <finish> <-----/            \-----------------------------/
+   *    |     /-----------------------------------------------------------\
+   *    |     |                                                           |
+   *    |     |             (no lockers)                                  |
+   *    |     |   . . . . . . . . . . . . . . . . . . . . . .             |
+   *    |     |   .                                         .             |
+   *    |     v   v      (EBUSY)                            .             |
+   *    \--> LOCK_IMAGE * * * * * * * >   GET_LOCKERS . . . .             |
+   *          .   |                         |                             |
+   *    . . . .   |                         |                             |
+   *    .         v                         v                             |
+   *    .     OPEN_OBJECT_MAP             GET_WATCHERS . . .              |
+   *    .         |                         |              .              |
+   *    .         v                         v              .              |
+   *    . . > OPEN_JOURNAL * * * * * *    BLACKLIST        . (blacklist   |
+   *    .         |                  *      |              .  disabled)   |
+   *    .         v                  *      v              .              |
+   *    .     ALLOCATE_JOURNAL_TAG   *    BREAK_LOCK < . . .              |
+   *    .         |            *     *      |                             |
+   *    .         |            *     *      \-----------------------------/
+   *    .         |            v     v
+   *    .         |         CLOSE_JOURNAL
+   *    .         |               |
+   *    .         |               v
+   *    .         |         CLOSE_OBJECT_MAP
+   *    .         |               |
+   *    .         v               |
+   *    . . > <finish> <----------/
    *
    * @endverbatim
    */
@@ -94,10 +102,16 @@ private:
   Context *send_open_journal();
   Context *handle_open_journal(int *ret_val);
 
+  void send_allocate_journal_tag();
+  Context *handle_allocate_journal_tag(int *ret_val);
+
+  void send_close_journal();
+  Context *handle_close_journal(int *ret_val);
+
   Context *send_open_object_map();
   Context *handle_open_object_map(int *ret_val);
 
-  Context *send_close_object_map();
+  Context *send_close_object_map(int *ret_val);
   Context *handle_close_object_map(int *ret_val);
 
   void send_get_lockers();
@@ -113,7 +127,7 @@ private:
   Context *handle_break_lock(int *ret_val);
 
   void apply();
-  void revert();
+  void revert(int *ret_val);
 };
 
 } // namespace exclusive_lock

--- a/src/librbd/journal/Types.cc
+++ b/src/librbd/journal/Types.cc
@@ -333,25 +333,49 @@ void ImageClientMeta::dump(Formatter *f) const {
   f->dump_unsigned("tag_class", tag_class);
 }
 
-void MirrorPeerClientMeta::encode(bufferlist& bl) const {
-  ::encode(cluster_id, bl);
-  ::encode(pool_id, bl);
-  ::encode(image_id, bl);
+void MirrorPeerSyncPoint::encode(bufferlist& bl) const {
   ::encode(snap_name, bl);
+  ::encode(object_number, bl);
+}
+
+void MirrorPeerSyncPoint::decode(__u8 version, bufferlist::iterator& it) {
+  ::decode(snap_name, it);
+  ::decode(object_number, it);
+}
+
+void MirrorPeerSyncPoint::dump(Formatter *f) const {
+  f->dump_string("snap_name", snap_name);
+  if (object_number) {
+    f->dump_unsigned("object_number", *object_number);
+  }
+}
+
+void MirrorPeerClientMeta::encode(bufferlist& bl) const {
+  ::encode(image_id, bl);
+  ::encode(static_cast<uint32_t>(sync_points.size()), bl);
+  for (auto &sync_point : sync_points) {
+    sync_point.encode(bl);
+  }
 }
 
 void MirrorPeerClientMeta::decode(__u8 version, bufferlist::iterator& it) {
-  ::decode(cluster_id, it);
-  ::decode(pool_id, it);
   ::decode(image_id, it);
-  ::decode(snap_name, it);
+
+  uint32_t sync_point_count;
+  ::decode(sync_point_count, it);
+  sync_points.resize(sync_point_count);
+  for (auto &sync_point : sync_points) {
+    sync_point.decode(version, it);
+  }
 }
 
 void MirrorPeerClientMeta::dump(Formatter *f) const {
-  f->dump_string("cluster_id", cluster_id.c_str());
-  f->dump_int("pool_id", pool_id);
-  f->dump_string("image_id", image_id.c_str());
-  f->dump_string("snap_name", snap_name.c_str());
+  f->dump_string("image_id", image_id);
+  f->open_array_section("sync_points");
+  for (auto &sync_point : sync_points) {
+    sync_point.dump(f);
+  }
+  f->close_section();
 }
 
 void CliClientMeta::encode(bufferlist& bl) const {
@@ -417,39 +441,41 @@ void ClientData::generate_test_instances(std::list<ClientData *> &o) {
   o.push_back(new ClientData(ImageClientMeta()));
   o.push_back(new ClientData(ImageClientMeta(123)));
   o.push_back(new ClientData(MirrorPeerClientMeta()));
-  o.push_back(new ClientData(MirrorPeerClientMeta("cluster_id", 123, "image_id")));
+  o.push_back(new ClientData(MirrorPeerClientMeta("image_id", {{"snap 1", 123}})));
   o.push_back(new ClientData(CliClientMeta()));
 }
 
 // Journal Tag
 
 void TagData::encode(bufferlist& bl) const {
-  ::encode(cluster_id, bl);
-  ::encode(pool_id, bl);
-  ::encode(image_id, bl);
+  ::encode(mirror_uuid, bl);
+  ::encode(predecessor_mirror_uuid, bl);
+  ::encode(predecessor_commit_valid, bl);
   ::encode(predecessor_tag_tid, bl);
   ::encode(predecessor_entry_tid, bl);
 }
 
 void TagData::decode(bufferlist::iterator& it) {
-  ::decode(cluster_id, it);
-  ::decode(pool_id, it);
-  ::decode(image_id, it);
+  ::decode(mirror_uuid, it);
+  ::decode(predecessor_mirror_uuid, it);
+  ::decode(predecessor_commit_valid, it);
   ::decode(predecessor_tag_tid, it);
   ::decode(predecessor_entry_tid, it);
 }
 
 void TagData::dump(Formatter *f) const {
-  f->dump_string("cluster_id", cluster_id.c_str());
-  f->dump_int("pool_id", pool_id);
-  f->dump_string("image_id", image_id.c_str());
+  f->dump_string("mirror_uuid", mirror_uuid);
+  f->dump_string("predecessor_mirror_uuid", predecessor_mirror_uuid);
+  f->dump_string("predecessor_commit_valid",
+                 predecessor_commit_valid ? "true" : "false");
   f->dump_unsigned("predecessor_tag_tid", predecessor_tag_tid);
   f->dump_unsigned("predecessor_entry_tid", predecessor_entry_tid);
 }
 
 void TagData::generate_test_instances(std::list<TagData *> &o) {
   o.push_back(new TagData());
-  o.push_back(new TagData("cluster_id", 123, "image_id"));
+  o.push_back(new TagData("mirror-uuid"));
+  o.push_back(new TagData("mirror-uuid", "remote-mirror-uuid", true, 123, 234));
 }
 
 } // namespace journal

--- a/src/librbd/journal/Types.cc
+++ b/src/librbd/journal/Types.cc
@@ -478,11 +478,7 @@ void TagData::generate_test_instances(std::list<TagData *> &o) {
   o.push_back(new TagData("mirror-uuid", "remote-mirror-uuid", true, 123, 234));
 }
 
-} // namespace journal
-} // namespace librbd
-
-std::ostream &operator<<(std::ostream &out,
-                         const librbd::journal::EventType &type) {
+std::ostream &operator<<(std::ostream &out, const EventType &type) {
   using namespace librbd::journal;
 
   switch (type) {
@@ -532,8 +528,7 @@ std::ostream &operator<<(std::ostream &out,
   return out;
 }
 
-std::ostream &operator<<(std::ostream &out,
-                         const librbd::journal::ClientMetaType &type) {
+std::ostream &operator<<(std::ostream &out, const ClientMetaType &type) {
   using namespace librbd::journal;
 
   switch (type) {
@@ -551,5 +546,26 @@ std::ostream &operator<<(std::ostream &out,
     break;
   }
   return out;
-
 }
+
+std::ostream &operator<<(std::ostream &out, const ImageClientMeta &meta) {
+  out << "[tag_class=" << meta.tag_class << "]";
+  return out;
+}
+
+std::ostream &operator<<(std::ostream &out, const TagData &tag_data) {
+  out << "["
+      << "mirror_uuid=" << tag_data.mirror_uuid << ", "
+      << "predecessor_mirror_uuid=" << tag_data.predecessor_mirror_uuid;
+  if (tag_data.predecessor_commit_valid) {
+    out << ", "
+        << "predecessor_tag_tid=" << tag_data.predecessor_tag_tid << ", "
+        << "predecessor_entry_tid=" << tag_data.predecessor_entry_tid;
+  }
+  out << "]";
+  return out;
+}
+
+} // namespace journal
+} // namespace librbd
+

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -429,13 +429,13 @@ struct TagData {
   static void generate_test_instances(std::list<TagData *> &o);
 };
 
+std::ostream &operator<<(std::ostream &out, const EventType &type);
+std::ostream &operator<<(std::ostream &out, const ClientMetaType &type);
+std::ostream &operator<<(std::ostream &out, const ImageClientMeta &meta);
+std::ostream &operator<<(std::ostream &out, const TagData &tag_data);
+
 } // namespace journal
 } // namespace librbd
-
-std::ostream &operator<<(std::ostream &out,
-                         const librbd::journal::EventType &type);
-std::ostream &operator<<(std::ostream &out,
-                         const librbd::journal::ClientMetaType &type);
 
 WRITE_CLASS_ENCODER(librbd::journal::EventEntry);
 WRITE_CLASS_ENCODER(librbd::journal::ClientData);

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -9,6 +9,9 @@
 #include "include/encoding.h"
 #include "include/types.h"
 #include <iosfwd>
+#include <list>
+#include <boost/none.hpp>
+#include <boost/optional.hpp>
 #include <boost/variant.hpp>
 
 namespace ceph {
@@ -316,21 +319,37 @@ struct ImageClientMeta {
   void dump(Formatter *f) const;
 };
 
+struct MirrorPeerSyncPoint {
+  typedef boost::optional<uint64_t> ObjectNumber;
+
+  std::string snap_name;
+  ObjectNumber object_number;
+
+  MirrorPeerSyncPoint() : object_number(boost::none) {
+  }
+  MirrorPeerSyncPoint(const std::string &snap_name,
+                      const ObjectNumber &object_number)
+    : snap_name(snap_name), object_number(object_number) {
+  }
+
+  void encode(bufferlist& bl) const;
+  void decode(__u8 version, bufferlist::iterator& it);
+  void dump(Formatter *f) const;
+};
+
 struct MirrorPeerClientMeta {
+  typedef std::list<MirrorPeerSyncPoint> SyncPoints;
+
   static const ClientMetaType TYPE = MIRROR_PEER_CLIENT_META_TYPE;
 
-  std::string cluster_id;
-  int64_t pool_id = 0;
   std::string image_id;
-  std::string snap_name;
+  SyncPoints sync_points;
 
   MirrorPeerClientMeta() {
   }
-  MirrorPeerClientMeta(const std::string &cluster_id, int64_t pool_id,
-                       const std::string &image_id,
-                       const std::string &snap_name = "")
-    : cluster_id(cluster_id), pool_id(pool_id), image_id(image_id),
-      snap_name(snap_name) {
+  MirrorPeerClientMeta(const std::string &image_id,
+                       const SyncPoints &sync_points = SyncPoints())
+    : image_id(image_id), sync_points(sync_points) {
   }
 
   void encode(bufferlist& bl) const;
@@ -380,19 +399,27 @@ struct ClientData {
 
 struct TagData {
   // owner of the tag (exclusive lock epoch)
-  std::string cluster_id;
-  int64_t pool_id = 0;
-  std::string image_id;
+  std::string mirror_uuid; // empty if local
 
   // mapping to last committed record of previous tag
+  std::string predecessor_mirror_uuid; // empty if local
+  bool predecessor_commit_valid = false;
   uint64_t predecessor_tag_tid = 0;
   uint64_t predecessor_entry_tid = 0;
 
   TagData() {
   }
-  TagData(const std::string &cluster_id, int64_t pool_id,
-          const std::string &image_id)
-    : cluster_id(cluster_id), pool_id(pool_id), image_id(image_id) {
+  TagData(const std::string &mirror_uuid) : mirror_uuid(mirror_uuid) {
+  }
+  TagData(const std::string &mirror_uuid,
+          const std::string &predecessor_mirror_uuid,
+          bool predecessor_commit_valid,
+          uint64_t predecessor_tag_tid, uint64_t predecessor_entry_tid)
+    : mirror_uuid(mirror_uuid),
+      predecessor_mirror_uuid(predecessor_mirror_uuid),
+      predecessor_commit_valid(predecessor_commit_valid),
+      predecessor_tag_tid(predecessor_tag_tid),
+      predecessor_entry_tid(predecessor_entry_tid) {
   }
 
   void encode(bufferlist& bl) const;

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1297,20 +1297,31 @@ TEST_F(TestClsRbd, mirror) {
   std::vector<cls::rbd::MirrorPeer> peers;
   ASSERT_EQ(-ENOENT, mirror_peer_list(&ioctx, &peers));
 
+  std::string uuid;
+  ASSERT_EQ(-ENOENT, mirror_uuid_get(&ioctx, &uuid));
   ASSERT_EQ(-EINVAL, mirror_peer_add(&ioctx, "uuid1", "cluster1", "client"));
 
   cls::rbd::MirrorMode mirror_mode;
   ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode));
   ASSERT_EQ(cls::rbd::MIRROR_MODE_DISABLED, mirror_mode);
 
+  ASSERT_EQ(-EINVAL, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_IMAGE));
+  ASSERT_EQ(-EINVAL, mirror_uuid_set(&ioctx, ""));
+  ASSERT_EQ(0, mirror_uuid_set(&ioctx, "mirror-uuid"));
+  ASSERT_EQ(0, mirror_uuid_get(&ioctx, &uuid));
+  ASSERT_EQ("mirror-uuid", uuid);
+
   ASSERT_EQ(0, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_IMAGE));
   ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode));
   ASSERT_EQ(cls::rbd::MIRROR_MODE_IMAGE, mirror_mode);
+
+  ASSERT_EQ(-EINVAL, mirror_uuid_set(&ioctx, "new-mirror-uuid"));
 
   ASSERT_EQ(0, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_POOL));
   ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode));
   ASSERT_EQ(cls::rbd::MIRROR_MODE_POOL, mirror_mode);
 
+  ASSERT_EQ(-EINVAL, mirror_peer_add(&ioctx, "mirror-uuid", "cluster1", "client"));
   ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid1", "cluster1", "client"));
   ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid2", "cluster2", "admin"));
   ASSERT_EQ(-ESTALE, mirror_peer_add(&ioctx, "uuid2", "cluster3", "foo"));
@@ -1354,6 +1365,7 @@ TEST_F(TestClsRbd, mirror) {
   ASSERT_EQ(0, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_DISABLED));
   ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode));
   ASSERT_EQ(cls::rbd::MIRROR_MODE_DISABLED, mirror_mode);
+  ASSERT_EQ(-ENOENT, mirror_uuid_get(&ioctx, &uuid));
 }
 
 TEST_F(TestClsRbd, mirror_image) {

--- a/src/test/journal/test_ObjectPlayer.cc
+++ b/src/test/journal/test_ObjectPlayer.cc
@@ -267,7 +267,7 @@ TEST_F(TestObjectPlayer, Unwatch) {
   bool done = false;
   int rval = 0;
   C_SafeCond *ctx = new C_SafeCond(&mutex, &cond, &done, &rval);
-  object->watch(ctx, 0.1);
+  object->watch(ctx, 600);
 
   usleep(200000);
   ASSERT_FALSE(done);

--- a/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
@@ -80,6 +80,22 @@ public:
                   .WillOnce(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue));
   }
 
+  void expect_close_journal(MockImageCtx &mock_image_ctx,
+                            MockJournal &mock_journal) {
+    EXPECT_CALL(mock_journal, close(_))
+                  .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
+  }
+
+  void expect_is_journal_tag_owner(MockJournal &mock_journal, bool owner) {
+    EXPECT_CALL(mock_journal, is_tag_owner()).WillOnce(Return(owner));
+  }
+
+  void expect_allocate_journal_tag(MockImageCtx &mock_image_ctx,
+                                   MockJournal &mock_journal, int r) {
+    EXPECT_CALL(mock_journal, allocate_tag("", _))
+                  .WillOnce(WithArg<1>(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue)));
+  }
+
   void expect_get_lock_info(MockImageCtx &mock_image_ctx, int r,
                             const entity_name_t &locker_entity,
                             const std::string &locker_address,
@@ -171,6 +187,8 @@ TEST_F(TestMockExclusiveLockAcquireRequest, Success) {
   expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING, true);
   expect_create_journal(mock_image_ctx, &mock_journal);
   expect_open_journal(mock_image_ctx, mock_journal, 0);
+  expect_is_journal_tag_owner(mock_journal, true);
+  expect_allocate_journal_tag(mock_image_ctx, mock_journal, 0);
 
   C_SaferCond acquire_ctx;
   C_SaferCond ctx;
@@ -231,6 +249,8 @@ TEST_F(TestMockExclusiveLockAcquireRequest, SuccessObjectMapDisabled) {
   expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING, true);
   expect_create_journal(mock_image_ctx, &mock_journal);
   expect_open_journal(mock_image_ctx, mock_journal, 0);
+  expect_is_journal_tag_owner(mock_journal, true);
+  expect_allocate_journal_tag(mock_image_ctx, mock_journal, 0);
 
   C_SaferCond acquire_ctx;
   C_SaferCond ctx;
@@ -264,6 +284,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, JournalError) {
   expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING, true);
   expect_create_journal(mock_image_ctx, mock_journal);
   expect_open_journal(mock_image_ctx, *mock_journal, -EINVAL);
+  expect_close_journal(mock_image_ctx, *mock_journal);
   expect_close_object_map(mock_image_ctx, *mock_object_map);
 
   C_SaferCond acquire_ctx;
@@ -273,6 +294,77 @@ TEST_F(TestMockExclusiveLockAcquireRequest, JournalError) {
                                                        &acquire_ctx, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, NotJournalTagOwner) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
+  expect_lock(mock_image_ctx, 0);
+
+  MockObjectMap *mock_object_map = new MockObjectMap();
+  expect_test_features(mock_image_ctx, RBD_FEATURE_OBJECT_MAP, true);
+  expect_create_object_map(mock_image_ctx, mock_object_map);
+  expect_open_object_map(mock_image_ctx, *mock_object_map);
+
+  MockJournal *mock_journal = new MockJournal();
+  expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING, true);
+  expect_create_journal(mock_image_ctx, mock_journal);
+  expect_open_journal(mock_image_ctx, *mock_journal, 0);
+  expect_is_journal_tag_owner(*mock_journal, false);
+  expect_close_journal(mock_image_ctx, *mock_journal);
+  expect_close_object_map(mock_image_ctx, *mock_object_map);
+
+  C_SaferCond acquire_ctx;
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &acquire_ctx, &ctx);
+  req->send();
+  ASSERT_EQ(-EPERM, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockAcquireRequest, AllocateJournalTagError) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_flush_notifies(mock_image_ctx);
+  expect_lock(mock_image_ctx, 0);
+
+  MockObjectMap *mock_object_map = new MockObjectMap();
+  expect_test_features(mock_image_ctx, RBD_FEATURE_OBJECT_MAP, true);
+  expect_create_object_map(mock_image_ctx, mock_object_map);
+  expect_open_object_map(mock_image_ctx, *mock_object_map);
+
+  MockJournal *mock_journal = new MockJournal();
+  expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING, true);
+  expect_create_journal(mock_image_ctx, mock_journal);
+  expect_open_journal(mock_image_ctx, *mock_journal, 0);
+  expect_is_journal_tag_owner(*mock_journal, true);
+  expect_allocate_journal_tag(mock_image_ctx, *mock_journal, -ESTALE);
+  expect_close_journal(mock_image_ctx, *mock_journal);
+  expect_close_object_map(mock_image_ctx, *mock_object_map);
+
+  C_SaferCond acquire_ctx;
+  C_SaferCond ctx;
+  MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx,
+                                                       TEST_COOKIE,
+                                                       &acquire_ctx, &ctx);
+  req->send();
+  ASSERT_EQ(-ESTALE, ctx.wait());
 }
 
 TEST_F(TestMockExclusiveLockAcquireRequest, LockBusy) {

--- a/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
@@ -17,6 +17,7 @@
 #include <list>
 
 // template definitions
+#include "librbd/Journal.cc"
 #include "librbd/exclusive_lock/AcquireRequest.cc"
 template class librbd::exclusive_lock::AcquireRequest<librbd::MockImageCtx>;
 

--- a/src/test/librbd/mock/MockJournal.h
+++ b/src/test/librbd/mock/MockJournal.h
@@ -16,6 +16,9 @@ struct MockJournal {
 
   MOCK_METHOD1(wait_for_journal_ready, void(Context *));
 
+  MOCK_CONST_METHOD0(is_tag_owner, bool());
+  MOCK_METHOD2(allocate_tag, void(const std::string &, Context *));
+
   MOCK_METHOD1(open, void(Context *));
   MOCK_METHOD1(close, void(Context *));
 

--- a/src/test/librbd/test_mock_Journal.cc
+++ b/src/test/librbd/test_mock_Journal.cc
@@ -586,7 +586,7 @@ TEST_F(TestMockJournal, GetCachedClientError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  MockImageCtx mock_image_ctx(*ictx);
+  MockJournalImageCtx mock_image_ctx(*ictx);
   MockJournal mock_journal(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -605,7 +605,7 @@ TEST_F(TestMockJournal, GetTagsError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  MockImageCtx mock_image_ctx(*ictx);
+  MockJournalImageCtx mock_image_ctx(*ictx);
   MockJournal mock_journal(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 

--- a/src/test/librbd/test_mock_Journal.cc
+++ b/src/test/librbd/test_mock_Journal.cc
@@ -7,6 +7,7 @@
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "cls/journal/cls_journal_types.h"
+#include "journal/Journaler.h"
 #include "librbd/Journal.h"
 #include "librbd/Utils.h"
 #include "librbd/journal/Replay.h"
@@ -87,6 +88,9 @@ struct MockJournaler {
   MOCK_METHOD1(init, void(Context*));
   MOCK_METHOD1(flush_commit_position, void(Context*));
 
+  MOCK_METHOD2(get_cached_client, int(const std::string&, cls::journal::Client*));
+  MOCK_METHOD3(get_tags, void(uint64_t, journal::Journaler::Tags*, Context*));
+
   MOCK_METHOD1(start_replay, void(::journal::ReplayHandler *replay_handler));
   MOCK_METHOD1(try_pop_front, bool(MockReplayEntryProxy *replay_entry));
   MOCK_METHOD0(stop_replay, void());
@@ -132,6 +136,16 @@ struct MockJournalerProxy {
 
   void init(Context *on_finish) {
     MockJournaler::get_instance().init(on_finish);
+  }
+
+  int get_cached_client(const std::string& client_id,
+                        cls::journal::Client* client) {
+    return MockJournaler::get_instance().get_cached_client(client_id, client);
+  }
+
+  void get_tags(uint64_t tag_class, journal::Journaler::Tags *tags,
+                Context *on_finish) {
+    MockJournaler::get_instance().get_tags(tag_class, tags, on_finish);
   }
 
   void flush_commit_position(Context *on_finish) {
@@ -308,7 +322,36 @@ public:
   void expect_init_journaler(::journal::MockJournaler &mock_journaler, int r) {
     EXPECT_CALL(mock_journaler, init(_))
                   .WillOnce(CompleteContext(r, NULL));
+  }
 
+  void expect_get_journaler_cached_client(::journal::MockJournaler &mock_journaler, int r) {
+
+    journal::ImageClientMeta image_client_meta;
+    image_client_meta.tag_class = 0;
+
+    journal::ClientData client_data;
+    client_data.client_meta = image_client_meta;
+
+    cls::journal::Client client;
+    ::encode(client_data, client.data);
+
+    EXPECT_CALL(mock_journaler, get_cached_client("", _))
+                  .WillOnce(DoAll(SetArgPointee<1>(client),
+                                  Return(r)));
+  }
+
+  void expect_get_journaler_tags(MockImageCtx &mock_image_ctx,
+                                 ::journal::MockJournaler &mock_journaler,
+                                 int r) {
+    journal::TagData tag_data;
+
+    bufferlist tag_data_bl;
+    ::encode(tag_data, tag_data_bl);
+
+    ::journal::Journaler::Tags tags = {{0, 0, {}}, {1, 0, tag_data_bl}};
+    EXPECT_CALL(mock_journaler, get_tags(0, _, _))
+                  .WillOnce(DoAll(SetArgPointee<1>(tags),
+                                  WithArg<2>(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue))));
   }
 
   void expect_start_replay(MockJournalImageCtx &mock_image_ctx,
@@ -442,6 +485,8 @@ public:
     InSequence seq;
     expect_construct_journaler(mock_journaler);
     expect_init_journaler(mock_journaler, 0);
+    expect_get_journaler_cached_client(mock_journaler, 0);
+    expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
     expect_start_replay(
       mock_image_ctx, mock_journaler, {
         std::bind(&invoke_replay_complete, _1, 0)
@@ -485,6 +530,8 @@ TEST_F(TestMockJournal, StateTransitions) {
   ::journal::MockJournaler mock_journaler;
   expect_construct_journaler(mock_journaler);
   expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
   expect_start_replay(
     mock_image_ctx, mock_journaler, {
       std::bind(&invoke_replay_ready, _1),
@@ -533,6 +580,45 @@ TEST_F(TestMockJournal, InitError) {
   ASSERT_EQ(-EINVAL, when_open(mock_journal));
 }
 
+TEST_F(TestMockJournal, GetCachedClientError) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockJournal mock_journal(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+
+  ::journal::MockJournaler mock_journaler;
+  expect_construct_journaler(mock_journaler);
+  expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, -ENOENT);
+  ASSERT_EQ(-ENOENT, when_open(mock_journal));
+}
+
+TEST_F(TestMockJournal, GetTagsError) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockJournal mock_journal(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+
+  ::journal::MockJournaler mock_journaler;
+  expect_construct_journaler(mock_journaler);
+  expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, -EBADMSG);
+  ASSERT_EQ(-EBADMSG, when_open(mock_journal));
+}
+
 TEST_F(TestMockJournal, ReplayCompleteError) {
   REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
 
@@ -548,6 +634,8 @@ TEST_F(TestMockJournal, ReplayCompleteError) {
   ::journal::MockJournaler mock_journaler;
   expect_construct_journaler(mock_journaler);
   expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
   expect_start_replay(
     mock_image_ctx, mock_journaler, {
       std::bind(&invoke_replay_complete, _1, -EINVAL)
@@ -560,6 +648,8 @@ TEST_F(TestMockJournal, ReplayCompleteError) {
   // replay failure should result in replay-restart
   expect_construct_journaler(mock_journaler);
   expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
   expect_start_replay(
     mock_image_ctx, mock_journaler, {
       std::bind(&invoke_replay_complete, _1, 0)
@@ -589,6 +679,8 @@ TEST_F(TestMockJournal, FlushReplayError) {
   ::journal::MockJournaler mock_journaler;
   expect_construct_journaler(mock_journaler);
   expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
   expect_start_replay(
     mock_image_ctx, mock_journaler, {
       std::bind(&invoke_replay_ready, _1),
@@ -606,6 +698,8 @@ TEST_F(TestMockJournal, FlushReplayError) {
   // replay flush failure should result in replay-restart
   expect_construct_journaler(mock_journaler);
   expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
   expect_start_replay(
     mock_image_ctx, mock_journaler, {
       std::bind(&invoke_replay_complete, _1, 0)
@@ -635,6 +729,8 @@ TEST_F(TestMockJournal, StopError) {
   ::journal::MockJournaler mock_journaler;
   expect_construct_journaler(mock_journaler);
   expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
   expect_start_replay(
     mock_image_ctx, mock_journaler, {
       std::bind(&invoke_replay_complete, _1, 0)
@@ -664,6 +760,8 @@ TEST_F(TestMockJournal, ReplayOnDiskPreFlushError) {
   ::journal::MockJournaler mock_journaler;
   expect_construct_journaler(mock_journaler);
   expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
 
   ::journal::ReplayHandler *replay_handler = nullptr;
   expect_start_replay(
@@ -688,6 +786,8 @@ TEST_F(TestMockJournal, ReplayOnDiskPreFlushError) {
   // replay write-to-disk failure should result in replay-restart
   expect_construct_journaler(mock_journaler);
   expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
   expect_start_replay(
     mock_image_ctx, mock_journaler, {
       std::bind(&invoke_replay_complete, _1, 0)
@@ -738,6 +838,8 @@ TEST_F(TestMockJournal, ReplayOnDiskPostFlushError) {
   ::journal::MockJournaler mock_journaler;
   expect_construct_journaler(mock_journaler);
   expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
   expect_start_replay(
     mock_image_ctx, mock_journaler, {
       std::bind(&invoke_replay_ready, _1),
@@ -759,6 +861,8 @@ TEST_F(TestMockJournal, ReplayOnDiskPostFlushError) {
   // replay write-to-disk failure should result in replay-restart
   expect_construct_journaler(mock_journaler);
   expect_init_journaler(mock_journaler, 0);
+  expect_get_journaler_cached_client(mock_journaler, 0);
+  expect_get_journaler_tags(mock_image_ctx, mock_journaler, 0);
   expect_start_replay(
     mock_image_ctx, mock_journaler, {
       std::bind(&invoke_replay_complete, _1, 0)

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -101,7 +101,7 @@ public:
     m_replayer = new rbd::mirror::ImageReplayer(
       rbd::mirror::RadosRef(new librados::Rados(m_local_ioctx)),
       rbd::mirror::RadosRef(new librados::Rados(m_remote_ioctx)),
-      m_client_id, remote_pool_id, m_remote_image_id);
+      m_client_id, m_local_ioctx.get_id(), remote_pool_id, m_remote_image_id);
 
     bootstrap();
   }

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -65,7 +65,8 @@ public:
 
 public:
   ImageReplayer(RadosRef local, RadosRef remote, const std::string &client_id,
-		int64_t remote_pool_id, const std::string &remote_image_id);
+		int64_t local_pool_id, int64_t remote_pool_id,
+                const std::string &remote_image_id);
   virtual ~ImageReplayer();
   ImageReplayer(const ImageReplayer&) = delete;
   ImageReplayer& operator=(const ImageReplayer&) = delete;


### PR DESCRIPTION
The journal tags are used to delineate epochs within an image.