### PR TITLE
os/filestore/FileJournal: set block size via config option

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -916,6 +916,7 @@ OPTION(filestore_debug_verify_split, OPT_BOOL, false)
 OPTION(journal_dio, OPT_BOOL, true)
 OPTION(journal_aio, OPT_BOOL, true)
 OPTION(journal_force_aio, OPT_BOOL, false)
+OPTION(journal_block_size, OPT_INT, 4096)
 
 OPTION(keyvaluestore_queue_max_ops, OPT_INT, 50)
 OPTION(keyvaluestore_queue_max_bytes, OPT_INT, 100 << 20)

--- a/src/os/FileJournal.cc
+++ b/src/os/FileJournal.cc
@@ -44,7 +44,8 @@
 #define dout_prefix *_dout << "journal "
 
 const static int64_t ONE_MEG(1 << 20);
-const static int CEPH_MINIMUM_BLOCK_SIZE(4096);
+const static int CEPH_DIRECTIO_ALIGNMENT(4096);
+
 
 int FileJournal::_open(bool forwrite, bool create)
 {
@@ -148,7 +149,7 @@ int FileJournal::_open_block_device()
 	   << dendl;
   max_size = bdev_sz;
 
-  block_size = CEPH_MINIMUM_BLOCK_SIZE;
+  block_size = g_conf->journal_block_size;
 
   if (g_conf->journal_discard) {
     discard = block_device_support_discard(fn.c_str());
@@ -288,7 +289,7 @@ int FileJournal::_open_file(int64_t oldsize, blksize_t blksize,
   else {
     max_size = oldsize;
   }
-  block_size = MAX(blksize, (blksize_t)CEPH_MINIMUM_BLOCK_SIZE);
+  block_size = g_conf->journal_block_size;
 
   if (create && g_conf->journal_zero_on_create) {
     derr << "FileJournal::_open_file : zeroing journal" << dendl;
@@ -503,9 +504,11 @@ int FileJournal::open(uint64_t fs_op_seq)
 	    << block_size << " (required for direct_io journal mode)" << dendl;
     return -EINVAL;
   }
-  if ((header.alignment % CEPH_MINIMUM_BLOCK_SIZE) && directio) {
-    dout(0) << "open journal alignment " << header.alignment << " is not multiple of minimum block size "
-           << CEPH_MINIMUM_BLOCK_SIZE << " (required for direct_io journal mode)" << dendl;
+  if ((header.alignment % CEPH_DIRECTIO_ALIGNMENT) && directio) {
+    dout(0) << "open journal alignment " << header.alignment
+	    << " is not multiple of minimum directio alignment "
+	    << CEPH_DIRECTIO_ALIGNMENT << " (required for direct_io journal mode)"
+	    << dendl;
     return -EINVAL;
   }
 
@@ -1041,14 +1044,14 @@ void FileJournal::align_bl(off64_t pos, bufferlist& bl)
 {
   // make sure list segments are page aligned
   if (directio && (!bl.is_aligned(block_size) ||
-		   !bl.is_n_align_sized(CEPH_MINIMUM_BLOCK_SIZE))) {
-    bl.rebuild_aligned(CEPH_MINIMUM_BLOCK_SIZE);
+		   !bl.is_n_align_sized(CEPH_DIRECTIO_ALIGNMENT))) {
+    bl.rebuild_aligned(CEPH_DIRECTIO_ALIGNMENT);
     dout(10) << __func__ << " total memcopy: " << bl.get_memcopy_count() << dendl;
-    if ((bl.length() & (CEPH_MINIMUM_BLOCK_SIZE - 1)) != 0 ||
-	(pos & (CEPH_MINIMUM_BLOCK_SIZE - 1)) != 0)
+    if ((bl.length() & (CEPH_DIRECTIO_ALIGNMENT - 1)) != 0 ||
+	(pos & (CEPH_DIRECTIO_ALIGNMENT - 1)) != 0)
       dout(0) << "rebuild_page_aligned failed, " << bl << dendl;
-    assert((bl.length() & (CEPH_MINIMUM_BLOCK_SIZE - 1)) == 0);
-    assert((pos & (CEPH_MINIMUM_BLOCK_SIZE - 1)) == 0);
+    assert((bl.length() & (CEPH_DIRECTIO_ALIGNMENT - 1)) == 0);
+    assert((pos & (CEPH_DIRECTIO_ALIGNMENT - 1)) == 0);
   }
 }
 


### PR DESCRIPTION
We were setting the block_size as the MIN of the min size (4096) and the
block size reported for the journal file/device.  In reality, file systmes
report all kinds of crazy block sizes.  Usually it's the page size, but
sometimes it is larger (e.g., 128KB for ZFS), and that's not actually what
we want.  Using a size smaller than the file systems block size is not
optimal for performance, but it doesn't affect how the IO happens--as long
as it is larger than the hardware sector size, which is either 512 or
4096 bytes.  And our min was hard-coded at 4096.

So, instead, just set a config option to specify teh block size, and
default that to 4096.

The other uses of this constant we about *alignment* of memory buffers
for the purposes of direct IO.  Rename the constant but do not change
the logic.  That means we continue to use 4k alignment for direct io even
if the device has 512 byte sectors, but that's fine--no reason to use
a smaller alignment.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit c8048ce4bedf0d1ba5d448795c46668f2724f29d)