### PR TITLE
XIO: Isolate the frequently accessed atomic variable 'connected' on a separate cache line

### DIFF
--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -65,7 +65,8 @@ public:
 private:
   XioConnection::type xio_conn_type;
   XioPortal *portal;
-  atomic_t connected;
+  atomic_t connected __attribute__((align(64)));
+  char pad_after[56]; 	//Padding to isolate the frequently accessed atomic variable 'connected' on a separate cache line
   entity_inst_t peer;
   struct xio_session *session;
   struct xio_connection	*conn;

--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -63,10 +63,10 @@ public:
   };
 
 private:
-  XioConnection::type xio_conn_type;
-  XioPortal *portal;
   atomic_t connected __attribute__((align(64)));
   char pad_after[56]; 	//Padding to isolate the frequently accessed atomic variable 'connected' on a separate cache line
+  XioConnection::type xio_conn_type;
+  XioPortal *portal;
   entity_inst_t peer;
   struct xio_session *session;
   struct xio_connection	*conn;


### PR DESCRIPTION
@tchaikov  I am re-submitting the changes to isolate the 'connected' variable on a cache line. Since the last discussion, you had one remaining comment - you wanted to remove the 'pad' and instead align the next data item ( entitiy_inst_t peer) in the structure. We want to stick to the pad because we dont want to tie this to whatever be the next data item. The comment conveys the idea to whoever is going through the code. If we align the next data item and a new item is introduced again in between, it may introduce more data items into the same cache line..