### PR TITLE
mon: osd [test-]reweight-by-{pg,utilization} command updates

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -982,6 +982,7 @@ Subcommand ``reweight-by-pg`` reweight OSDs by PG distribution
 Usage::
 
 	ceph osd reweight-by-pg {<int[100-]>} {<poolname> [<poolname...]}
+	{--no-increasing} {--yes-i-really-mean-it}
 
 Subcommand ``reweight-by-utilization`` reweight OSDs by utilization
 [overload-percentage-for-consideration, default 120].
@@ -989,6 +990,7 @@ Subcommand ``reweight-by-utilization`` reweight OSDs by utilization
 Usage::
 
 	ceph osd reweight-by-utilization {<int[100-]>}
+	{--no-increasing} {--yes-i-really-mean-it}
 
 Subcommand ``rm`` removes osd(s) <id> [<id>...] in the cluster.
 

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1587,7 +1587,7 @@ function test_mon_osd_misc()
   ceph pg set_full_ratio 95 2>$TMPFILE; check_response 'not in range' $? 22
 
   # expect "not in range" for invalid overload percentage
-  ceph osd reweight-by-utilization 80 2>$TMPFILE; check_response 'not in range' $? 22
+  ceph osd reweight-by-utilization 80 2>$TMPFILE; check_response 'higher than 100' $? 22
 
   set -e
 

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1592,8 +1592,12 @@ function test_mon_osd_misc()
   set -e
 
   ceph osd reweight-by-utilization 110
+  ceph osd reweight-by-utilization 110 .5
+  ceph osd test-reweight-by-utilization 110 .5 --no-increasing
   ceph osd reweight-by-pg 110
+  ceph osd test-reweight-by-pg 110 .5
   ceph osd reweight-by-pg 110 rbd
+  ceph osd reweight-by-pg 110 .5 rbd
   expect_false ceph osd reweight-by-pg 110 boguspoolasdfasdfasdf
 }
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -281,6 +281,7 @@ OPTION(mon_daemon_bytes, OPT_U64, 400ul << 20)  // mds, osd message memory cap (
 OPTION(mon_max_log_entries_per_event, OPT_INT, 4096)
 OPTION(mon_reweight_min_pgs_per_osd, OPT_U64, 10)   // min pgs per osd for reweight-by-pg command
 OPTION(mon_reweight_min_bytes_per_osd, OPT_U64, 100*1024*1024)   // min bytes per osd for reweight-by-utilization command
+OPTION(mon_reweight_max_change, OPT_FLOAT, 0.05)   // max change to each osd per reweight-by-* command
 OPTION(mon_health_data_update_interval, OPT_FLOAT, 60.0)
 OPTION(mon_health_to_clog, OPT_BOOL, true)
 OPTION(mon_health_to_clog_interval, OPT_INT, 3600)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -281,6 +281,7 @@ OPTION(mon_daemon_bytes, OPT_U64, 400ul << 20)  // mds, osd message memory cap (
 OPTION(mon_max_log_entries_per_event, OPT_INT, 4096)
 OPTION(mon_reweight_min_pgs_per_osd, OPT_U64, 10)   // min pgs per osd for reweight-by-pg command
 OPTION(mon_reweight_min_bytes_per_osd, OPT_U64, 100*1024*1024)   // min bytes per osd for reweight-by-utilization command
+OPTION(mon_reweight_max_osds, OPT_INT, 4)   // max osds to change per reweight-by-* command
 OPTION(mon_reweight_max_change, OPT_FLOAT, 0.05)   // max change to each osd per reweight-by-* command
 OPTION(mon_health_data_update_interval, OPT_FLOAT, 60.0)
 OPTION(mon_health_to_clog, OPT_BOOL, true)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -282,7 +282,6 @@ OPTION(mon_max_log_entries_per_event, OPT_INT, 4096)
 OPTION(mon_reweight_min_pgs_per_osd, OPT_U64, 10)   // min pgs per osd for reweight-by-pg command
 OPTION(mon_reweight_min_bytes_per_osd, OPT_U64, 100*1024*1024)   // min bytes per osd for reweight-by-utilization command
 OPTION(mon_reweight_max_osds, OPT_INT, 4)   // max osds to change per reweight-by-* command
-OPTION(mon_reweight_max_change, OPT_FLOAT, 0.05)   // max change to each osd per reweight-by-* command
 OPTION(mon_health_data_update_interval, OPT_FLOAT, 60.0)
 OPTION(mon_health_to_clog, OPT_BOOL, true)
 OPTION(mon_health_to_clog_interval, OPT_INT, 3600)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -282,6 +282,7 @@ OPTION(mon_max_log_entries_per_event, OPT_INT, 4096)
 OPTION(mon_reweight_min_pgs_per_osd, OPT_U64, 10)   // min pgs per osd for reweight-by-pg command
 OPTION(mon_reweight_min_bytes_per_osd, OPT_U64, 100*1024*1024)   // min bytes per osd for reweight-by-utilization command
 OPTION(mon_reweight_max_osds, OPT_INT, 4)   // max osds to change per reweight-by-* command
+OPTION(mon_reweight_max_change, OPT_DOUBLE, 0.05)
 OPTION(mon_health_data_update_interval, OPT_FLOAT, 60.0)
 OPTION(mon_health_to_clog, OPT_BOOL, true)
 OPTION(mon_health_to_clog_interval, OPT_INT, 3600)

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -705,28 +705,28 @@ COMMAND("osd utilization",
 	"get basic pg distribution stats",
 	"osd", "r", "cli,rest")
 COMMAND("osd reweight-by-utilization " \
-	"name=oload,type=CephInt,range=100,req=false " \
+	"name=oload,type=CephInt,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
 	"name=max_osds,type=CephInt,req=false "			\
 	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false",\
 	"reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd test-reweight-by-utilization " \
-	"name=oload,type=CephInt,range=100,req=false " \
+	"name=oload,type=CephInt,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
 	"name=max_osds,type=CephInt,req=false "			\
 	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false",\
 	"dry run of reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd reweight-by-pg " \
-	"name=oload,type=CephInt,range=100,req=false " \
+	"name=oload,type=CephInt,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
 	"name=max_osds,type=CephInt,req=false "			\
 	"name=pools,type=CephPoolname,n=N,req=false",			\
 	"reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd test-reweight-by-pg " \
-	"name=oload,type=CephInt,range=100,req=false " \
+	"name=oload,type=CephInt,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
 	"name=max_osds,type=CephInt,req=false "			\
 	"name=pools,type=CephPoolname,n=N,req=false",			\

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -702,12 +702,16 @@ COMMAND("osd pool stats " \
         "obtain stats from all pools, or from specified pool",
         "osd", "r", "cli,rest")
 COMMAND("osd reweight-by-utilization " \
-	"name=oload,type=CephInt,range=100,req=false", \
+	"name=oload,type=CephInt,range=100,req=false " \
+	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false " \
+	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd reweight-by-pg " \
-	"name=oload,type=CephInt,range=100 " \
-	"name=pools,type=CephPoolname,n=N,req=false", \
+	"name=oload,type=CephInt,range=100,req=false " \
+	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false " \
+	"name=pools,type=CephPoolname,n=N,req=false " \
+	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd thrash " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -701,6 +701,9 @@ COMMAND("osd pool stats " \
         "name=name,type=CephString,req=false",
         "obtain stats from all pools, or from specified pool",
         "osd", "r", "cli,rest")
+COMMAND("osd utilization",
+	"get basic pg distribution stats",
+	"osd", "r", "cli,rest")
 COMMAND("osd reweight-by-utilization " \
 	"name=oload,type=CephInt,range=100,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -703,12 +703,14 @@ COMMAND("osd pool stats " \
         "osd", "r", "cli,rest")
 COMMAND("osd reweight-by-utilization " \
 	"name=oload,type=CephInt,range=100,req=false " \
+	"name=max_change,type=CephFloat,req=false "			\
 	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd reweight-by-pg " \
 	"name=oload,type=CephInt,range=100,req=false " \
+	"name=max_change,type=CephFloat,req=false "			\
 	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false " \
 	"name=pools,type=CephPoolname,n=N,req=false " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -707,17 +707,26 @@ COMMAND("osd utilization",
 COMMAND("osd reweight-by-utilization " \
 	"name=oload,type=CephInt,range=100,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
-	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false",\
 	"reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
+	"osd", "rw", "cli,rest")
+COMMAND("osd test-reweight-by-utilization " \
+	"name=oload,type=CephInt,range=100,req=false " \
+	"name=max_change,type=CephFloat,req=false "			\
+	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false",\
+	"dry run of reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd reweight-by-pg " \
 	"name=oload,type=CephInt,range=100,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
-	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false " \
-	"name=pools,type=CephPoolname,n=N,req=false " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=pools,type=CephPoolname,n=N,req=false",			\
 	"reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]", \
+	"osd", "rw", "cli,rest")
+COMMAND("osd test-reweight-by-pg " \
+	"name=oload,type=CephInt,range=100,req=false " \
+	"name=max_change,type=CephFloat,req=false "			\
+	"name=pools,type=CephPoolname,n=N,req=false",			\
+	"dry run of reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd thrash " \
 	"name=num_epochs,type=CephInt,range=0", \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -707,24 +707,28 @@ COMMAND("osd utilization",
 COMMAND("osd reweight-by-utilization " \
 	"name=oload,type=CephInt,range=100,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
+	"name=max_osds,type=CephInt,req=false "			\
 	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false",\
 	"reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd test-reweight-by-utilization " \
 	"name=oload,type=CephInt,range=100,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
+	"name=max_osds,type=CephInt,req=false "			\
 	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false",\
 	"dry run of reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd reweight-by-pg " \
 	"name=oload,type=CephInt,range=100,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
+	"name=max_osds,type=CephInt,req=false "			\
 	"name=pools,type=CephPoolname,n=N,req=false",			\
 	"reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd test-reweight-by-pg " \
 	"name=oload,type=CephInt,range=100,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
+	"name=max_osds,type=CephInt,req=false "			\
 	"name=pools,type=CephPoolname,n=N,req=false",			\
 	"dry run of reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw", "cli,rest")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -479,7 +479,8 @@ void OSDMonitor::update_logger()
  * percentage 'oload' percent greater than the average utilization.
  */
 int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
-					bool by_pg, const set<int64_t> *pools)
+					bool by_pg, const set<int64_t> *pools,
+					bool no_increasing, bool sure)
 {
   if (oload <= 100) {
     ostringstream oss;
@@ -585,15 +586,17 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
       // to represent e.g. differing storage capacities
       unsigned weight = osdmap.get_weight(p->first);
       unsigned new_weight = (unsigned)((average_util / util) * (float)weight);
-      pending_inc.new_weight[p->first] = new_weight;
+      if (sure) {
+	pending_inc.new_weight[p->first] = new_weight;
+	changed = true;
+      }
       char buf[128];
       snprintf(buf, sizeof(buf), "osd.%d [%04f -> %04f]", p->first,
 	       (float)weight / (float)0x10000,
 	       (float)new_weight / (float)0x10000);
       oss << buf << sep;
-      changed = true;
     }
-    if (util <= underload_util) {
+    if (!no_increasing && util <= underload_util) {
       // assign a higher weight.. if we can.
       unsigned weight = osdmap.get_weight(p->first);
       unsigned new_weight = (unsigned)((average_util / util) * (float)weight);
@@ -601,13 +604,15 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
 	new_weight = 0x10000;
       if (new_weight > weight) {
 	sep = ", ";
-	pending_inc.new_weight[p->first] = new_weight;
+	if (sure) {
+	  pending_inc.new_weight[p->first] = new_weight;
+	  changed = true;
+	}
 	char buf[128];
 	snprintf(buf, sizeof(buf), "osd.%d [%04f -> %04f]", p->first,
 		 (float)weight / (float)0x10000,
 		 (float)new_weight / (float)0x10000);
 	oss << buf << sep;
-	changed = true;
       }
     }
   }
@@ -7421,8 +7426,13 @@ done:
   } else if (prefix == "osd reweight-by-utilization") {
     int64_t oload;
     cmd_getval(g_ceph_context, cmdmap, "oload", oload, int64_t(120));
+    string no_increasing, sure;
+    cmd_getval(g_ceph_context, cmdmap, "no_increasing", no_increasing);
+    cmd_getval(g_ceph_context, cmdmap, "sure", sure);
     string out_str;
-    err = reweight_by_utilization(oload, out_str, false, NULL);
+    err = reweight_by_utilization(oload, out_str, false, NULL,
+				  no_increasing == "--no-increasing",
+				  sure == "--yes-i-really-mean-it");
     if (err < 0) {
       ss << "FAILED reweight-by-utilization: " << out_str;
     } else if (err == 0) {
@@ -7449,9 +7459,14 @@ done:
       }
       pools.insert(pool);
     }
+    string no_increasing, sure;
+    cmd_getval(g_ceph_context, cmdmap, "no_increasing", no_increasing);
+    cmd_getval(g_ceph_context, cmdmap, "sure", sure);
     string out_str;
     err = reweight_by_utilization(oload, out_str, true,
-				  pools.empty() ? NULL : &pools);
+				  pools.empty() ? NULL : &pools,
+				  no_increasing == "--no-increasing",
+				  sure == "--yes-i-really-mean-it");
     if (err < 0) {
       ss << "FAILED reweight-by-pg: " << out_str;
     } else if (err == 0) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -586,6 +586,7 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
       // to represent e.g. differing storage capacities
       unsigned weight = osdmap.get_weight(p->first);
       unsigned new_weight = (unsigned)((average_util / util) * (float)weight);
+      new_weight = MAX(new_weight, weight - g_conf->mon_reweight_max_change);
       if (sure) {
 	pending_inc.new_weight[p->first] = new_weight;
 	changed = true;
@@ -600,8 +601,9 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
       // assign a higher weight.. if we can.
       unsigned weight = osdmap.get_weight(p->first);
       unsigned new_weight = (unsigned)((average_util / util) * (float)weight);
+      new_weight = MIN(new_weight, weight + g_conf->mon_reweight_max_change);
       if (new_weight > 0x10000)
-	new_weight = 0x10000;
+          new_weight = 0x10000;
       if (new_weight > weight) {
 	sep = ", ";
 	if (sure) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -569,16 +569,35 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
   std::string sep;
   oss << "reweighted: ";
   bool changed = false;
+  int num_changed = 0;
+
+  // precompute util for each OSD
+  std::vector<std::pair<int, float> > util_by_osd;
   for (ceph::unordered_map<int,osd_stat_t>::const_iterator p =
-	 pgm.osd_stat.begin();
+       pgm.osd_stat.begin();
        p != pgm.osd_stat.end();
        ++p) {
-    float util;
+    std::pair<int, float> osd_util;
+    osd_util.first = p->first;
     if (by_pg) {
-      util = pgs_by_osd[p->first] / osdmap.crush->get_item_weightf(p->first);
+      osd_util.second = pgs_by_osd[p->first] / osdmap.crush->get_item_weightf(p->first);
     } else {
-      util = (double)p->second.kb_used / (double)p->second.kb;
+      osd_util.second = (double)p->second.kb_used / (double)p->second.kb;
     }
+    util_by_osd.push_back(osd_util);
+  }
+
+  // sort and iterate from most to least utilized
+  std::sort(util_by_osd.begin(), util_by_osd.end(), [](std::pair<int, float> l, std::pair<int, float> r) {
+    return l.second > r.second;
+  });
+
+  for (std::vector<std::pair<int, float> >::const_iterator p =
+	 util_by_osd.begin();
+       p != util_by_osd.end();
+       ++p) {
+    float util = p->second;
+
     if (util >= overload_util) {
       sep = ", ";
       // Assign a lower weight to overloaded OSDs. The current weight
@@ -596,6 +615,8 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
 	       (float)weight / (float)0x10000,
 	       (float)new_weight / (float)0x10000);
       oss << buf << sep;
+      if (++num_changed >= g_conf->mon_reweight_max_osds)
+	break;
     }
     if (!no_increasing && util <= underload_util) {
       // assign a higher weight.. if we can.
@@ -615,6 +636,8 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
 		 (float)weight / (float)0x10000,
 		 (float)new_weight / (float)0x10000);
 	oss << buf << sep;
+	if (++num_changed >= g_conf->mon_reweight_max_osds)
+	  break;
       }
     }
   }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -646,7 +646,7 @@ int OSDMonitor::reweight_by_utilization(int oload,
       unsigned new_weight = (unsigned)((average_util / util) * (float)weight);
       new_weight = MIN(new_weight, weight + max_change);
       if (new_weight > 0x10000)
-          new_weight = 0x10000;
+	new_weight = 0x10000;
       if (new_weight > weight) {
 	newinc.new_weight[p->first] = new_weight;
 	if (!dry_run) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -478,18 +478,20 @@ void OSDMonitor::update_logger()
  * The osds that will get a lower weight are those with with a utilization
  * percentage 'oload' percent greater than the average utilization.
  */
-int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
+int OSDMonitor::reweight_by_utilization(int oload,
+					double max_changef,
 					bool by_pg, const set<int64_t> *pools,
-					float max_change,
-					bool no_increasing, bool sure)
+					bool no_increasing,
+					bool dry_run,
+					std::stringstream *ss,
+					std::string *out_str,
+					Formatter *f)
 {
   if (oload <= 100) {
-    ostringstream oss;
-    oss << "You must give a percentage higher than 100. "
+    *ss << "You must give a percentage higher than 100. "
       "The reweighting threshold will be calculated as <average-utilization> "
       "times <input-percentage>. For example, an argument of 200 would "
       "reweight OSDs which are twice as utilized as the average OSD.\n";
-    out_str = oss.str();
     return -EINVAL;
   }
 
@@ -525,10 +527,8 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
     }
 
     if (!num_osds || (num_pg_copies / num_osds < g_conf->mon_reweight_min_pgs_per_osd)) {
-      ostringstream oss;
-      oss << "Refusing to reweight: we only have " << num_pg_copies
+      *ss << "Refusing to reweight: we only have " << num_pg_copies
 	  << " PGs across " << num_osds << " osds!\n";
-      out_str = oss.str();
       return -EDOM;
     }
 
@@ -539,17 +539,15 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
     if ((uint64_t)pgm.osd_sum.kb * 1024 / num_osd
 	< g_conf->mon_reweight_min_bytes_per_osd) {
       ostringstream oss;
-      oss << "Refusing to reweight: we only have " << pgm.osd_sum.kb
+      *ss << "Refusing to reweight: we only have " << pgm.osd_sum.kb
 	  << " kb across all osds!\n";
-      out_str = oss.str();
       return -EDOM;
     }
     if ((uint64_t)pgm.osd_sum.kb_used * 1024 / num_osd
 	< g_conf->mon_reweight_min_bytes_per_osd) {
       ostringstream oss;
-      oss << "Refusing to reweight: we only have " << pgm.osd_sum.kb_used
+      *ss << "Refusing to reweight: we only have " << pgm.osd_sum.kb_used
 	  << " kb used across all osds!\n";
-      out_str = oss.str();
       return -EDOM;
     }
 
@@ -562,13 +560,23 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
   // but aggressively adjust weights up whenever possible.
   double underload_util = average_util;
 
+  unsigned max_change = (unsigned)(max_changef * (double)0x10000);
+
   ostringstream oss;
-  char buf[128];
-  snprintf(buf, sizeof(buf), "average %04f, overload %04f. ",
-	   average_util, overload_util);
-  oss << buf;
-  std::string sep;
-  oss << "reweighted: ";
+  if (f) {
+    f->open_object_section("reweight_by_utilization");
+    f->dump_unsigned("overload_min", oload);
+    f->dump_float("max_change", max_changef);
+    f->dump_float("average_utilization", average_util);
+    f->dump_float("overload_utilization", overload_util);
+  } else {
+    oss << "oload " << oload << "\n";
+    oss << "max_change " << max_changef << "\n";
+    char buf[128];
+    snprintf(buf, sizeof(buf), "average %04f\noverload %04f\n",
+	     average_util, overload_util);
+    oss << buf;
+  }
   bool changed = false;
   int num_changed = 0;
 
@@ -593,6 +601,11 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
     return l.second > r.second;
   });
 
+  OSDMap::Incremental newinc;
+
+  if (f)
+    f->open_array_section("reweights");
+
   for (std::vector<std::pair<int, float> >::const_iterator p =
 	 util_by_osd.begin();
        p != util_by_osd.end();
@@ -600,22 +613,30 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
     float util = p->second;
 
     if (util >= overload_util) {
-      sep = ", ";
       // Assign a lower weight to overloaded OSDs. The current weight
       // is a factor to take into account the original weights,
       // to represent e.g. differing storage capacities
       unsigned weight = osdmap.get_weight(p->first);
       unsigned new_weight = (unsigned)((average_util / util) * (float)weight);
       new_weight = MAX(new_weight, weight - max_change);
-      if (sure) {
+      newinc.new_weight[p->first] = new_weight;
+      if (!dry_run) {
 	pending_inc.new_weight[p->first] = new_weight;
 	changed = true;
       }
-      char buf[128];
-      snprintf(buf, sizeof(buf), "osd.%d [%04f -> %04f]", p->first,
-	       (float)weight / (float)0x10000,
-	       (float)new_weight / (float)0x10000);
-      oss << buf << sep;
+      if (f) {
+	f->open_object_section("osd");
+	f->dump_unsigned("osd", p->first);
+	f->dump_float("weight", (float)weight / (float)0x10000);
+	f->dump_float("new_weight", (float)new_weight / (float)0x10000);
+	f->close_section();
+      } else {
+	char buf[128];
+	snprintf(buf, sizeof(buf), "osd.%d weight %04f -> %04f\n", p->first,
+		 (float)weight / (float)0x10000,
+		 (float)new_weight / (float)0x10000);
+	oss << buf;
+      }
       if (++num_changed >= g_conf->mon_reweight_max_osds)
 	break;
     }
@@ -627,25 +648,39 @@ int OSDMonitor::reweight_by_utilization(int oload, std::string& out_str,
       if (new_weight > 0x10000)
           new_weight = 0x10000;
       if (new_weight > weight) {
-	sep = ", ";
-	if (sure) {
+	newinc.new_weight[p->first] = new_weight;
+	if (!dry_run) {
 	  pending_inc.new_weight[p->first] = new_weight;
 	  changed = true;
 	}
 	char buf[128];
-	snprintf(buf, sizeof(buf), "osd.%d [%04f -> %04f]", p->first,
+	snprintf(buf, sizeof(buf), "osd.%d weight %04f -> %04f\n", p->first,
 		 (float)weight / (float)0x10000,
 		 (float)new_weight / (float)0x10000);
-	oss << buf << sep;
+	oss << buf;
 	if (++num_changed >= g_conf->mon_reweight_max_osds)
 	  break;
       }
     }
   }
-  if (sep.empty()) {
-    oss << "(none)";
+  if (f) {
+    f->close_section();
   }
-  out_str = oss.str();
+
+  OSDMap newmap;
+  newmap.deepish_copy_from(osdmap);
+  newinc.fsid = newmap.fsid;
+  newinc.epoch = newmap.get_epoch() + 1;
+  newmap.apply_incremental(newinc);
+
+  osdmap.summarize_mapping_stats(&newmap, pools, out_str, f);
+
+  if (f) {
+    f->close_section();
+  } else {
+    *out_str += "\n";
+    *out_str += oss.str();
+  }
   dout(10) << "reweight_by_utilization: finished with " << out_str << dendl;
   return changed;
 }
@@ -7458,31 +7493,15 @@ done:
 					      get_last_committed() + 1));
     return true;
 
-  } else if (prefix == "osd reweight-by-utilization") {
-    int64_t oload;
-    cmd_getval(g_ceph_context, cmdmap, "oload", oload, int64_t(120));
-    float max_change;
-    cmd_getval(g_ceph_context, cmdmap, "max_change", max_change);
-    string no_increasing, sure;
-    cmd_getval(g_ceph_context, cmdmap, "no_increasing", no_increasing);
-    cmd_getval(g_ceph_context, cmdmap, "sure", sure);
-    string out_str;
-    err = reweight_by_utilization(oload, out_str, false, NULL,
-				  max_change,
-				  no_increasing == "--no-increasing",
-				  sure == "--yes-i-really-mean-it");
-    if (err < 0) {
-      ss << "FAILED reweight-by-utilization: " << out_str;
-    } else if (err == 0) {
-      ss << "no change: " << out_str;
-    } else {
-      ss << "SUCCESSFUL reweight-by-utilization: " << out_str;
-      getline(ss, rs);
-      wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
-						get_last_committed() + 1));
-      return true;
-    }
-  } else if (prefix == "osd reweight-by-pg") {
+  } else if (prefix == "osd reweight-by-pg" ||
+	     prefix == "osd reweight-by-utilization" ||
+	     prefix == "osd test-reweight-by-pg" ||
+	     prefix == "osd test-reweight-by-utilization") {
+    bool by_pg =
+      prefix == "osd reweight-by-pg" || prefix == "osd test-reweight-by-pg";
+    bool dry_run =
+      prefix == "osd test-reweight-by-pg" ||
+      prefix == "osd test-reweight-by-utilization";
     int64_t oload;
     cmd_getval(g_ceph_context, cmdmap, "oload", oload, int64_t(120));
     set<int64_t> pools;
@@ -7497,26 +7516,36 @@ done:
       }
       pools.insert(pool);
     }
-    float max_change;
+    double max_change = .05;
     cmd_getval(g_ceph_context, cmdmap, "max_change", max_change);
-    string no_increasing, sure;
+    if (max_change <= 0.0) {
+      ss << "max_change " << max_change << " must be positive";
+      err = -EINVAL;
+      goto reply;
+    }
+    string no_increasing;
     cmd_getval(g_ceph_context, cmdmap, "no_increasing", no_increasing);
-    cmd_getval(g_ceph_context, cmdmap, "sure", sure);
     string out_str;
-    err = reweight_by_utilization(oload, out_str, true,
-				  pools.empty() ? NULL : &pools,
+    err = reweight_by_utilization(oload,
 				  max_change,
+				  by_pg,
+				  pools.empty() ? NULL : &pools,
 				  no_increasing == "--no-increasing",
-				  sure == "--yes-i-really-mean-it");
+				  dry_run,
+				  &ss, &out_str, f.get());
+    if (f)
+      f->flush(rdata);
+    else
+      rdata.append(out_str);
     if (err < 0) {
-      ss << "FAILED reweight-by-pg: " << out_str;
+      ss << "FAILED reweight-by-pg";
     } else if (err == 0) {
-      ss << "no change: " << out_str;
+      ss << "no change";
     } else {
-      ss << "SUCCESSFUL reweight-by-pg: " << out_str;
-      getline(ss, rs);
-      wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
-						get_last_committed() + 1));
+      ss << "SUCCESSFUL reweight-by-pg";
+      wait_for_finished_proposal(
+	op,
+	new Monitor::C_Command(mon, op, 0, rs, rdata, get_last_committed() + 1));
       return true;
     }
   } else if (prefix == "osd thrash") {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7516,7 +7516,7 @@ done:
       }
       pools.insert(pool);
     }
-    double max_change = .05;
+    double max_change = g_conf->mon_reweight_max_change;
     cmd_getval(g_ceph_context, cmdmap, "max_change", max_change);
     if (max_change <= 0.0) {
       ss << "max_change " << max_change << " must be positive";

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3147,6 +3147,15 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       ds << "max_osd = " << osdmap.get_max_osd() << " in epoch " << osdmap.get_epoch();
       rdata.append(ds);
     }
+  } else if (prefix == "osd utilization") {
+    string out;
+    osdmap.summarize_mapping_stats(NULL, NULL, &out, f.get());
+    if (f)
+      f->flush(rdata);
+    else
+      rdata.append(out);
+    r = 0;
+    goto reply;
   } else if (prefix  == "osd find") {
     int64_t osd;
     if (!cmd_getval(g_ceph_context, cmdmap, "id", osd)) {

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -228,8 +228,8 @@ public:
 			MonOpRequestRef req = MonOpRequestRef());
 private:
   int reweight_by_utilization(int oload, std::string& out_str, bool by_pg,
-			      const set<int64_t> *pools);
-
+			      const set<int64_t> *pools, bool no_increasing,
+			      bool sure);
   void print_utilization(ostream &out, Formatter *f, bool tree) const;
 
   bool check_source(PaxosServiceMessage *m, uuid_d fsid);

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -226,12 +226,17 @@ public:
   //            @c Monitor::send_reply() can mark_event with it.
   void send_incremental(epoch_t first, MonSession *session, bool onetime,
 			MonOpRequestRef req = MonOpRequestRef());
+
 private:
-  int reweight_by_utilization(int oload, std::string& out_str, bool by_pg,
+  int reweight_by_utilization(int oload,
+			      double max_change,
+			      bool by_pg,
 			      const set<int64_t> *pools,
-			      float max_change,
 			      bool no_increasing,
-			      bool sure);
+			      bool dry_run,
+			      std::stringstream *ss,
+			      std::string *out_str,
+			      Formatter *f);
   void print_utilization(ostream &out, Formatter *f, bool tree) const;
 
   bool check_source(PaxosServiceMessage *m, uuid_d fsid);

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -228,7 +228,9 @@ public:
 			MonOpRequestRef req = MonOpRequestRef());
 private:
   int reweight_by_utilization(int oload, std::string& out_str, bool by_pg,
-			      const set<int64_t> *pools, bool no_increasing,
+			      const set<int64_t> *pools,
+			      float max_change,
+			      bool no_increasing,
 			      bool sure);
   void print_utilization(ostream &out, Formatter *f, bool tree) const;
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -230,6 +230,7 @@ public:
 private:
   int reweight_by_utilization(int oload,
 			      double max_change,
+			      int max_osds,
 			      bool by_pg,
 			      const set<int64_t> *pools,
 			      bool no_increasing,

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -867,6 +867,12 @@ public:
   void print_oneline_summary(ostream& out) const;
   void print_tree(Formatter *f, ostream *out) const;
 
+  int summarize_mapping_stats(
+    OSDMap *newmap,
+    const set<int64_t> *pools,
+    std::string *out,
+    Formatter *f) const;
+
   string get_flag_string() const;
   static string get_flag_string(unsigned flags);
   static void dump_erasure_code_profiles(const map<string,map<string,string> > &profiles,

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -1111,6 +1111,8 @@ class TestOSD(TestArgparse):
     def test_reweight_by_utilization(self):
         self.assert_valid_command(['osd', 'reweight-by-utilization'])
         self.assert_valid_command(['osd', 'reweight-by-utilization', '100'])
+        self.assert_valid_command(['osd', 'reweight-by-utilization', '--no-increasing'])
+        self.assert_valid_command(['osd', 'reweight-by-utilization', '--yes-i-really-mean-it'])
         assert_equal({}, validate_command(sigdict, ['osd',
                                                     'reweight-by-utilization',
                                                     '50']))


### PR DESCRIPTION
- 'osd utilization' command to show current pg distribution stats
- show before/after stats
- test-* variants
- --no-increasing option for the -utilization ones