### PR TITLE
osd: bluestore: fix check for write falling within the same extent

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5059,7 +5059,7 @@ int BlueStore::_do_allocate(
   bool shared_head = false;
   bool shared_tail = false;
   uint64_t orig_end = orig_offset + orig_length;
-  if (orig_offset / min_alloc_size == orig_end / min_alloc_size) {
+  if (orig_offset / min_alloc_size == (orig_end - 1)/ min_alloc_size) {
     // we fall within the same block
     offset = orig_offset - orig_offset % min_alloc_size;
     length = 0;


### PR DESCRIPTION
… in the a extent.

Suppose: bluestore_overlay_max_length == bluestore_min_alloc_size
The orignal code which calc content of written whether locate in a
extent:
(offset / min_alloc_size) == (offset + length) /min_alloc_size
This will make the case which offset=0 & length =min_alloc_size locate
in the different extent.
In fact, this content is in the same extent.

Change end = offset + length - 1 make work.

Fixes: #14954

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>