### PR TITLE
 ceph.spec.in: do not install Ceph RA on systemd platforms

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1181,13 +1181,27 @@ fi
 
 #################################################################################
 %if %{with ocf}
+
 %files resource-agents
 %defattr(0755,root,root,-)
 # N.B. src/ocf/Makefile.am uses $(prefix)/lib
 %dir %{_prefix}/lib/ocf
 %dir %{_prefix}/lib/ocf/resource.d
 %dir %{_prefix}/lib/ocf/resource.d/ceph
-%{_prefix}/lib/ocf/resource.d/%{name}/*
+%if 0%{_with_systemd}
+%exclude %{_prefix}/lib/ocf/resource.d/ceph/ceph
+%exclude %{_prefix}/lib/ocf/resource.d/ceph/mds
+%exclude %{_prefix}/lib/ocf/resource.d/ceph/mon
+%exclude %{_prefix}/lib/ocf/resource.d/ceph/osd
+%endif
+%if ! 0%{_with_systemd}
+%{_prefix}/lib/ocf/resource.d/ceph/ceph
+%{_prefix}/lib/ocf/resource.d/ceph/mds
+%{_prefix}/lib/ocf/resource.d/ceph/mon
+%{_prefix}/lib/ocf/resource.d/ceph/osd
+%endif
+%{_prefix}/lib/ocf/resource.d/ceph/rbd
+
 %endif
 
 #################################################################################

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1183,10 +1183,11 @@ fi
 %if %{with ocf}
 %files resource-agents
 %defattr(0755,root,root,-)
-%dir /usr/lib/ocf
-%dir /usr/lib/ocf/resource.d
-%dir /usr/lib/ocf/resource.d/ceph
-/usr/lib/ocf/resource.d/%{name}/*
+# N.B. src/ocf/Makefile.am uses $(prefix)/lib
+%dir %{_prefix}/lib/ocf
+%dir %{_prefix}/lib/ocf/resource.d
+%dir %{_prefix}/lib/ocf/resource.d/ceph
+%{_prefix}/lib/ocf/resource.d/%{name}/*
 %endif
 
 #################################################################################


### PR DESCRIPTION
The ceph-resource-agents package consists of two RAs: the "Ceph RA" (which includes RAs for OSD, MON, and MDS) and the "RBD RA". Since the Ceph RA wraps the Ceph sysvinit script, it cannot be used on systemd-based platforms. The RBD RA is OK on systemd.

http://tracker.ceph.com/issues/14828 Fixes: #14828