### PR TITLE
journal: re-use common threads between journalers

### DIFF
--- a/src/journal/FutureImpl.cc
+++ b/src/journal/FutureImpl.cc
@@ -3,14 +3,15 @@
 
 #include "journal/FutureImpl.h"
 #include "common/Finisher.h"
+#include "journal/JournalMetadata.h"
 #include "journal/Utils.h"
 
 namespace journal {
 
-FutureImpl::FutureImpl(Finisher &finisher, uint64_t tag_tid, uint64_t entry_tid,
-                       uint64_t commit_tid)
-  : RefCountedObject(NULL, 0), m_finisher(finisher), m_tag_tid(tag_tid),
-    m_entry_tid(entry_tid), m_commit_tid(commit_tid),
+FutureImpl::FutureImpl(JournalMetadataPtr journal_metadata, uint64_t tag_tid,
+                       uint64_t entry_tid, uint64_t commit_tid)
+  : RefCountedObject(NULL, 0), m_journal_metadata(journal_metadata),
+    m_tag_tid(tag_tid), m_entry_tid(entry_tid), m_commit_tid(commit_tid),
     m_lock(utils::unique_lock_name("FutureImpl::m_lock", this)), m_safe(false),
     m_consistent(false), m_return_value(0), m_flush_state(FLUSH_STATE_NONE),
     m_consistent_ack(this) {
@@ -51,7 +52,7 @@ void FutureImpl::flush(Context *on_safe) {
   }
 
   if (complete && on_safe != NULL) {
-    m_finisher.queue(on_safe, m_return_value);
+    m_journal_metadata->get_finisher().queue(on_safe, m_return_value);
   } else if (flush_handler) {
     // attached to journal object -- instruct it to flush all entries through
     // this one.  possible to become detached while lock is released, so flush
@@ -69,7 +70,7 @@ void FutureImpl::wait(Context *on_safe) {
       return;
     }
   }
-  m_finisher.queue(on_safe, m_return_value);
+  m_journal_metadata->get_finisher().queue(on_safe, m_return_value);
 }
 
 bool FutureImpl::is_complete() const {

--- a/src/journal/FutureImpl.cc
+++ b/src/journal/FutureImpl.cc
@@ -2,7 +2,6 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "journal/FutureImpl.h"
-#include "common/Finisher.h"
 #include "journal/JournalMetadata.h"
 #include "journal/Utils.h"
 
@@ -52,7 +51,7 @@ void FutureImpl::flush(Context *on_safe) {
   }
 
   if (complete && on_safe != NULL) {
-    m_journal_metadata->get_finisher().queue(on_safe, m_return_value);
+    m_journal_metadata->queue(on_safe, m_return_value);
   } else if (flush_handler) {
     // attached to journal object -- instruct it to flush all entries through
     // this one.  possible to become detached while lock is released, so flush
@@ -70,7 +69,7 @@ void FutureImpl::wait(Context *on_safe) {
       return;
     }
   }
-  m_journal_metadata->get_finisher().queue(on_safe, m_return_value);
+  m_journal_metadata->queue(on_safe, m_return_value);
 }
 
 bool FutureImpl::is_complete() const {

--- a/src/journal/FutureImpl.h
+++ b/src/journal/FutureImpl.h
@@ -14,11 +14,11 @@
 #include "include/assert.h"
 
 class Context;
-class Finisher;
 
 namespace journal {
 
 class FutureImpl;
+class JournalMetadata;
 typedef boost::intrusive_ptr<FutureImpl> FutureImplPtr;
 
 class FutureImpl : public RefCountedObject, boost::noncopyable {
@@ -29,10 +29,11 @@ public:
     virtual void get() = 0;
     virtual void put() = 0;
   };
+  typedef boost::intrusive_ptr<JournalMetadata> JournalMetadataPtr;
   typedef boost::intrusive_ptr<FlushHandler> FlushHandlerPtr;
 
-  FutureImpl(Finisher &finisher, uint64_t tag_tid, uint64_t entry_tid,
-             uint64_t commit_tid);
+  FutureImpl(JournalMetadataPtr journal_metadata, uint64_t tag_tid,
+             uint64_t entry_tid, uint64_t commit_tid);
 
   void init(const FutureImplPtr &prev_future);
 
@@ -95,7 +96,7 @@ private:
     virtual void finish(int r) {}
   };
 
-  Finisher &m_finisher;
+  JournalMetadataPtr m_journal_metadata;
   uint64_t m_tag_tid;
   uint64_t m_entry_tid;
   uint64_t m_commit_tid;

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -4,7 +4,6 @@
 #include "journal/JournalMetadata.h"
 #include "journal/Utils.h"
 #include "common/errno.h"
-#include "common/Finisher.h"
 #include "common/Timer.h"
 #include "cls/journal/cls_journal_client.h"
 #include <functional>
@@ -231,14 +230,15 @@ struct C_FlushCommitPosition : public Context {
 
 } // anonymous namespace
 
-JournalMetadata::JournalMetadata(librados::IoCtx &ioctx,
+JournalMetadata::JournalMetadata(ContextWQ *work_queue, SafeTimer *timer,
+                                 Mutex *timer_lock, librados::IoCtx &ioctx,
                                  const std::string &oid,
                                  const std::string &client_id,
                                  double commit_interval)
     : RefCountedObject(NULL, 0), m_cct(NULL), m_oid(oid),
       m_client_id(client_id), m_commit_interval(commit_interval), m_order(0),
-      m_splay_width(0), m_pool_id(-1), m_initialized(false), m_finisher(NULL),
-      m_timer(NULL), m_timer_lock("JournalMetadata::m_timer_lock"),
+      m_splay_width(0), m_pool_id(-1), m_initialized(false),
+      m_work_queue(work_queue), m_timer(timer), m_timer_lock(timer_lock),
       m_lock("JournalMetadata::m_lock"), m_commit_tid(0), m_watch_ctx(this),
       m_watch_handle(0), m_minimum_set(0), m_active_set(0),
       m_update_notifications(0), m_commit_position_ctx(NULL),
@@ -249,19 +249,13 @@ JournalMetadata::JournalMetadata(librados::IoCtx &ioctx,
 
 JournalMetadata::~JournalMetadata() {
   if (m_initialized) {
-    shutdown();
+    shut_down();
   }
 }
 
 void JournalMetadata::init(Context *on_init) {
   assert(!m_initialized);
   m_initialized = true;
-
-  m_finisher = new Finisher(m_cct);
-  m_finisher->start();
-
-  m_timer = new SafeTimer(m_cct, m_timer_lock, true);
-  m_timer->init();
 
   int r = m_ioctx.watch2(m_oid, &m_watch_handle, &m_watch_ctx);
   if (r < 0) {
@@ -275,7 +269,7 @@ void JournalMetadata::init(Context *on_init) {
   get_immutable_metadata(&m_order, &m_splay_width, &m_pool_id, ctx);
 }
 
-void JournalMetadata::shutdown() {
+void JournalMetadata::shut_down() {
 
   ldout(m_cct, 20) << __func__ << dendl;
 
@@ -292,24 +286,10 @@ void JournalMetadata::shutdown() {
 
   flush_commit_position();
 
-  if (m_timer != NULL) {
-    Mutex::Locker locker(m_timer_lock);
-    m_timer->shutdown();
-    delete m_timer;
-    m_timer = NULL;
-  }
-
-  if (m_finisher != NULL) {
-    m_finisher->stop();
-    delete m_finisher;
-    m_finisher = NULL;
-  }
-
   librados::Rados rados(m_ioctx);
   rados.watch_flush();
 
   m_async_op_tracker.wait_for_ops();
-  m_ioctx.aio_flush();
 }
 
 void JournalMetadata::get_immutable_metadata(uint8_t *order,
@@ -458,7 +438,7 @@ void JournalMetadata::set_active_set(uint64_t object_set) {
 void JournalMetadata::flush_commit_position() {
   ldout(m_cct, 20) << __func__ << dendl;
 
-  Mutex::Locker timer_locker(m_timer_lock);
+  Mutex::Locker timer_locker(*m_timer_lock);
   Mutex::Locker locker(m_lock);
   if (m_commit_position_ctx == nullptr) {
     return;
@@ -471,12 +451,12 @@ void JournalMetadata::flush_commit_position() {
 void JournalMetadata::flush_commit_position(Context *on_safe) {
   ldout(m_cct, 20) << __func__ << dendl;
 
-  Mutex::Locker timer_locker(m_timer_lock);
+  Mutex::Locker timer_locker(*m_timer_lock);
   Mutex::Locker locker(m_lock);
   if (m_commit_position_ctx == nullptr) {
     // nothing to flush
     if (on_safe != nullptr) {
-      m_finisher->queue(on_safe, 0);
+      m_work_queue->queue(on_safe, 0);
     }
     return;
   }
@@ -567,7 +547,7 @@ void JournalMetadata::handle_refresh_complete(C_Refresh *refresh, int r) {
 void JournalMetadata::cancel_commit_task() {
   ldout(m_cct, 20) << __func__ << dendl;
 
-  assert(m_timer_lock.is_locked());
+  assert(m_timer_lock->is_locked());
   assert(m_lock.is_locked());
   assert(m_commit_position_ctx != nullptr);
   assert(m_commit_position_task_ctx != nullptr);
@@ -579,7 +559,7 @@ void JournalMetadata::cancel_commit_task() {
 void JournalMetadata::schedule_commit_task() {
   ldout(m_cct, 20) << __func__ << dendl;
 
-  assert(m_timer_lock.is_locked());
+  assert(m_timer_lock->is_locked());
   assert(m_lock.is_locked());
   assert(m_commit_position_ctx != nullptr);
   if (m_commit_position_task_ctx == NULL) {
@@ -589,7 +569,7 @@ void JournalMetadata::schedule_commit_task() {
 }
 
 void JournalMetadata::handle_commit_position_task() {
-  assert(m_timer_lock.is_locked());
+  assert(m_timer_lock->is_locked());
   assert(m_lock.is_locked());
   ldout(m_cct, 20) << __func__ << dendl;
 
@@ -610,12 +590,12 @@ void JournalMetadata::handle_commit_position_task() {
 }
 
 void JournalMetadata::schedule_watch_reset() {
-  assert(m_timer_lock.is_locked());
+  assert(m_timer_lock->is_locked());
   m_timer->add_event_after(0.1, new C_WatchReset(this));
 }
 
 void JournalMetadata::handle_watch_reset() {
-  assert(m_timer_lock.is_locked());
+  assert(m_timer_lock->is_locked());
   if (!m_initialized) {
     return;
   }
@@ -642,7 +622,7 @@ void JournalMetadata::handle_watch_notify(uint64_t notify_id, uint64_t cookie) {
 
 void JournalMetadata::handle_watch_error(int err) {
   lderr(m_cct) << "journal watch error: " << cpp_strerror(err) << dendl;
-  Mutex::Locker timer_locker(m_timer_lock);
+  Mutex::Locker timer_locker(*m_timer_lock);
   Mutex::Locker locker(m_lock);
 
   // release old watch on error
@@ -679,7 +659,7 @@ void JournalMetadata::committed(uint64_t commit_tid,
   ObjectSetPosition commit_position;
   Context *stale_ctx = nullptr;
   {
-    Mutex::Locker timer_locker(m_timer_lock);
+    Mutex::Locker timer_locker(*m_timer_lock);
     Mutex::Locker locker(m_lock);
     assert(commit_tid > m_commit_position_tid);
 

--- a/src/journal/JournalMetadata.h
+++ b/src/journal/JournalMetadata.h
@@ -10,6 +10,7 @@
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/RefCountedObj.h"
+#include "common/WorkQueue.h"
 #include "cls/journal/cls_journal_types.h"
 #include "journal/AsyncOpTracker.h"
 #include <boost/intrusive_ptr.hpp>
@@ -21,7 +22,6 @@
 #include <string>
 #include "include/assert.h"
 
-class Finisher;
 class SafeTimer;
 
 namespace journal {
@@ -46,12 +46,13 @@ public:
     virtual void handle_update(JournalMetadata *) = 0;
   };
 
-  JournalMetadata(librados::IoCtx &ioctx, const std::string &oid,
+  JournalMetadata(ContextWQ *work_queue, SafeTimer *timer, Mutex *timer_lock,
+                  librados::IoCtx &ioctx, const std::string &oid,
                   const std::string &client_id, double commit_interval);
   ~JournalMetadata();
 
   void init(Context *on_init);
-  void shutdown();
+  void shut_down();
 
   void get_immutable_metadata(uint8_t *order, uint8_t *splay_width,
 			      int64_t *pool_id, Context *on_finish);
@@ -84,15 +85,15 @@ public:
     return m_pool_id;
   }
 
-  inline Finisher &get_finisher() {
-    return *m_finisher;
+  inline void queue(Context *on_finish, int r) {
+    m_work_queue->queue(on_finish, r);
   }
 
   inline SafeTimer &get_timer() {
     return *m_timer;
   }
   inline Mutex &get_timer_lock() {
-    return m_timer_lock;
+    return *m_timer_lock;
   }
 
   void set_minimum_set(uint64_t object_set);
@@ -283,9 +284,9 @@ private:
   int64_t m_pool_id;
   bool m_initialized;
 
-  Finisher *m_finisher;
+  ContextWQ *m_work_queue;
   SafeTimer *m_timer;
-  Mutex m_timer_lock;
+  Mutex *m_timer_lock;
 
   mutable Mutex m_lock;
 

--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -2,7 +2,6 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "journal/JournalRecorder.h"
-#include "common/Finisher.h"
 #include "journal/Entry.h"
 #include "journal/Utils.h"
 
@@ -32,7 +31,7 @@ struct C_Flush : public Context {
     }
     if (pending_flushes.dec() == 0) {
       // ensure all prior callback have been flushed as well
-      journal_metadata->get_finisher().queue(on_finish, ret_val);
+      journal_metadata->queue(on_finish, ret_val);
       delete this;
     }
   }

--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -81,8 +81,8 @@ Future JournalRecorder::append(uint64_t tag_tid,
   ObjectRecorderPtr object_ptr = get_object(splay_offset);
   uint64_t commit_tid = m_journal_metadata->allocate_commit_tid(
     object_ptr->get_object_number(), tag_tid, entry_tid);
-  FutureImplPtr future(new FutureImpl(m_journal_metadata->get_finisher(),
-                                      tag_tid, entry_tid, commit_tid));
+  FutureImplPtr future(new FutureImpl(m_journal_metadata, tag_tid, entry_tid,
+                                      commit_tid));
   future->init(m_prev_future);
   m_prev_future = future;
 

--- a/src/journal/JournalTrimmer.cc
+++ b/src/journal/JournalTrimmer.cc
@@ -5,7 +5,6 @@
 #include "journal/Utils.h"
 #include "common/Cond.h"
 #include "common/errno.h"
-#include "common/Finisher.h"
 #include <limits>
 
 #define dout_subsys ceph_subsys_journaler

--- a/src/journal/Journaler.cc
+++ b/src/journal/Journaler.cc
@@ -4,6 +4,8 @@
 #include "journal/Journaler.h"
 #include "include/stringify.h"
 #include "common/errno.h"
+#include "common/Timer.h"
+#include "common/WorkQueue.h"
 #include "journal/Entry.h"
 #include "journal/FutureImpl.h"
 #include "journal/JournalMetadata.h"
@@ -51,31 +53,74 @@ std::string Journaler::object_oid_prefix(int pool_id,
   return JOURNAL_OBJECT_PREFIX + stringify(pool_id) + "." + journal_id + ".";
 }
 
+Journaler::Threads::Threads(CephContext *cct)
+    : timer_lock("Journaler::timer_lock") {
+  thread_pool = new ThreadPool(cct, "Journaler::thread_pool", "tp_journal", 1);
+  thread_pool->start();
+
+  work_queue = new ContextWQ("Journaler::work_queue", 60, thread_pool);
+
+  timer = new SafeTimer(cct, timer_lock, true);
+  timer->init();
+}
+
+Journaler::Threads::~Threads() {
+  {
+    Mutex::Locker timer_locker(timer_lock);
+    timer->shutdown();
+  }
+  delete timer;
+
+  work_queue->drain();
+  delete work_queue;
+
+  thread_pool->stop();
+  delete thread_pool;
+}
+
 Journaler::Journaler(librados::IoCtx &header_ioctx,
+                     const std::string &journal_id,
+                     const std::string &client_id, double commit_interval)
+    : m_threads(new Threads(reinterpret_cast<CephContext*>(header_ioctx.cct()))),
+      m_client_id(client_id) {
+  set_up(m_threads->work_queue, m_threads->timer, &m_threads->timer_lock,
+         header_ioctx, journal_id, commit_interval);
+}
+
+Journaler::Journaler(ContextWQ *work_queue, SafeTimer *timer,
+                     Mutex *timer_lock, librados::IoCtx &header_ioctx,
 		     const std::string &journal_id,
 		     const std::string &client_id, double commit_interval)
-  : m_client_id(client_id), m_metadata(NULL), m_player(NULL), m_recorder(NULL),
-    m_trimmer(NULL)
-{
+    : m_client_id(client_id) {
+  set_up(work_queue, timer, timer_lock, header_ioctx, journal_id,
+         commit_interval);
+}
+
+void Journaler::set_up(ContextWQ *work_queue, SafeTimer *timer,
+                       Mutex *timer_lock, librados::IoCtx &header_ioctx,
+                       const std::string &journal_id, double commit_interval) {
   m_header_ioctx.dup(header_ioctx);
   m_cct = reinterpret_cast<CephContext *>(m_header_ioctx.cct());
 
   m_header_oid = header_oid(journal_id);
   m_object_oid_prefix = object_oid_prefix(m_header_ioctx.get_id(), journal_id);
 
-  m_metadata = new JournalMetadata(m_header_ioctx, m_header_oid, m_client_id,
+  m_metadata = new JournalMetadata(work_queue, timer, timer_lock,
+                                   m_header_ioctx, m_header_oid, m_client_id,
                                    commit_interval);
   m_metadata->get();
 }
 
 Journaler::~Journaler() {
-  if (m_metadata != NULL) {
+  if (m_metadata != nullptr) {
     m_metadata->put();
-    m_metadata = NULL;
+    m_metadata = nullptr;
   }
   delete m_trimmer;
-  assert(m_player == NULL);
-  assert(m_recorder == NULL);
+  assert(m_player == nullptr);
+  assert(m_recorder == nullptr);
+
+  delete m_threads;
 }
 
 int Journaler::exists(bool *header_exists) const {
@@ -116,8 +161,8 @@ int Journaler::init_complete() {
   return 0;
 }
 
-void Journaler::shutdown() {
-  m_metadata->shutdown();
+void Journaler::shut_down() {
+  m_metadata->shut_down();
 }
 
 void Journaler::get_immutable_metadata(uint8_t *order, uint8_t *splay_width,
@@ -152,7 +197,7 @@ int Journaler::create(uint8_t order, uint8_t splay_width, int64_t pool_id) {
 }
 
 int Journaler::remove(bool force) {
-  m_metadata->shutdown();
+  m_metadata->shut_down();
 
   ldout(m_cct, 5) << "removing journal: " << m_header_oid << dendl;
   int r = m_trimmer->remove_objects(force);

--- a/src/journal/Journaler.h
+++ b/src/journal/Journaler.h
@@ -15,7 +15,9 @@
 #include <string>
 #include "include/assert.h"
 
+class ContextWQ;
 class SafeTimer;
+class ThreadPool;
 
 namespace journal {
 
@@ -28,6 +30,17 @@ class ReplayHandler;
 
 class Journaler {
 public:
+  struct Threads {
+    Threads(CephContext *cct);
+    ~Threads();
+
+    ThreadPool *thread_pool = nullptr;
+    ContextWQ *work_queue = nullptr;
+
+    SafeTimer *timer = nullptr;
+    Mutex timer_lock;
+  };
+
   typedef std::list<cls::journal::Tag> Tags;
   typedef std::set<cls::journal::Client> RegisteredClients;
 
@@ -37,6 +50,9 @@ public:
 
   Journaler(librados::IoCtx &header_ioctx, const std::string &journal_id,
 	    const std::string &client_id, double commit_interval);
+  Journaler(ContextWQ *work_queue, SafeTimer *timer, Mutex *timer_lock,
+            librados::IoCtx &header_ioctx, const std::string &journal_id,
+	    const std::string &client_id, double commit_interval);
   ~Journaler();
 
   int exists(bool *header_exists) const;
@@ -44,7 +60,7 @@ public:
   int remove(bool force);
 
   void init(Context *on_init);
-  void shutdown();
+  void shut_down();
 
   void get_immutable_metadata(uint8_t *order, uint8_t *splay_width,
 			      int64_t *pool_id, Context *on_finish);
@@ -95,6 +111,8 @@ private:
     }
   };
 
+  Threads *m_threads = nullptr;
+
   mutable librados::IoCtx m_header_ioctx;
   librados::IoCtx m_data_ioctx;
   CephContext *m_cct;
@@ -103,10 +121,14 @@ private:
   std::string m_header_oid;
   std::string m_object_oid_prefix;
 
-  JournalMetadata *m_metadata;
-  JournalPlayer *m_player;
-  JournalRecorder *m_recorder;
-  JournalTrimmer *m_trimmer;
+  JournalMetadata *m_metadata = nullptr;
+  JournalPlayer *m_player = nullptr;
+  JournalRecorder *m_recorder = nullptr;
+  JournalTrimmer *m_trimmer = nullptr;
+
+  void set_up(ContextWQ *work_queue, SafeTimer *timer, Mutex *timer_lock,
+              librados::IoCtx &header_ioctx, const std::string &journal_id,
+              double commit_interval);
 
   int init_complete();
   void create_player(ReplayHandler *replay_handler);

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -13,12 +13,46 @@
 #include "journal/Journaler.h"
 #include "journal/ReplayEntry.h"
 #include "common/errno.h"
+#include "common/Timer.h"
+#include "common/WorkQueue.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
 #define dout_prefix *_dout << "librbd::Journal: "
 
 namespace librbd {
+
+namespace {
+
+// TODO: once journaler is 100% async, remove separate threads and
+// reuse ImageCtx's thread pool
+class ThreadPoolSingleton : public ThreadPool {
+public:
+  explicit ThreadPoolSingleton(CephContext *cct)
+    : ThreadPool(cct, "librbd::Journal", "tp_librbd_journ", 1) {
+    start();
+  }
+  virtual ~ThreadPoolSingleton() {
+    stop();
+  }
+};
+
+class SafeTimerSingleton : public SafeTimer {
+public:
+  Mutex lock;
+
+  explicit SafeTimerSingleton(CephContext *cct)
+      : SafeTimer(cct, lock, true),
+        lock("librbd::Journal::SafeTimerSingleton::lock") {
+    init();
+  }
+  virtual ~SafeTimerSingleton() {
+    Mutex::Locker locker(lock);
+    shutdown();
+  }
+};
+
+} // anonymous namespace
 
 using util::create_async_context_callback;
 using util::create_context_callback;
@@ -72,11 +106,30 @@ Journal<I>::Journal(I &image_ctx)
     m_event_lock("Journal<I>::m_event_lock"), m_event_tid(0),
     m_blocking_writes(false), m_journal_replay(NULL) {
 
-  ldout(m_image_ctx.cct, 5) << this << ": ictx=" << &m_image_ctx << dendl;
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 5) << this << ": ictx=" << &m_image_ctx << dendl;
+
+  ThreadPoolSingleton *thread_pool_singleton;
+  cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
+    thread_pool_singleton, "librbd::journal::thread_pool");
+  m_work_queue = new ContextWQ("librbd::journal::work_queue",
+                               cct->_conf->rbd_op_thread_timeout,
+                               thread_pool_singleton);
+
+  SafeTimerSingleton *safe_timer_singleton;
+  cct->lookup_or_create_singleton_object<SafeTimerSingleton>(
+    safe_timer_singleton, "librbd::journal::safe_timer");
+  m_timer = safe_timer_singleton;
+  m_timer_lock = &safe_timer_singleton->lock;
 }
 
 template <typename I>
 Journal<I>::~Journal() {
+  if (m_work_queue != nullptr) {
+    m_work_queue->drain();
+    delete m_work_queue;
+  }
+
   assert(m_state == STATE_UNINITIALIZED || m_state == STATE_CLOSED);
   assert(m_journaler == NULL);
   assert(m_journal_replay == NULL);
@@ -560,7 +613,8 @@ void Journal<I>::create_journaler() {
   assert(m_journaler == NULL);
 
   transition_state(STATE_INITIALIZING, 0);
-  m_journaler = new Journaler(m_image_ctx.md_ctx, m_image_ctx.id, "",
+  m_journaler = new Journaler(m_work_queue, m_timer, m_timer_lock,
+                              m_image_ctx.md_ctx, m_image_ctx.id, "",
                               m_image_ctx.journal_commit_age);
   m_journaler->init(create_async_context_callback(
     m_image_ctx, create_context_callback<

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -20,6 +20,8 @@
 #include <unordered_map>
 
 class Context;
+class ContextWQ;
+class SafeTimer;
 namespace journal {
 class Journaler;
 }
@@ -237,6 +239,10 @@ private:
       journal->handle_replay_complete(r);
     }
   };
+
+  ContextWQ *m_work_queue = nullptr;
+  SafeTimer *m_timer = nullptr;
+  Mutex *m_timer_lock = nullptr;
 
   Journaler *m_journaler;
   mutable Mutex m_lock;

--- a/src/test/journal/RadosTestFixture.cc
+++ b/src/test/journal/RadosTestFixture.cc
@@ -43,6 +43,14 @@ int RadosTestFixture::create(const std::string &oid, uint8_t order,
   return cls::journal::client::create(m_ioctx, oid, order, splay_width, -1);
 }
 
+journal::JournalMetadataPtr RadosTestFixture::create_metadata(
+    const std::string &oid, const std::string &client_id,
+    double commit_internal) {
+  journal::JournalMetadataPtr metadata(new journal::JournalMetadata(
+    m_ioctx, oid, client_id, commit_internal));
+  return metadata;
+}
+
 int RadosTestFixture::append(const std::string &oid, const bufferlist &bl) {
   librados::ObjectWriteOperation op;
   op.append(bl);

--- a/src/test/journal/RadosTestFixture.cc
+++ b/src/test/journal/RadosTestFixture.cc
@@ -4,6 +4,7 @@
 #include "test/journal/RadosTestFixture.h"
 #include "cls/journal/cls_journal_client.h"
 #include "include/stringify.h"
+#include "common/WorkQueue.h"
 
 RadosTestFixture::RadosTestFixture()
   : m_timer_lock("m_timer_lock"), m_timer(NULL), m_listener(this) {
@@ -12,10 +13,18 @@ RadosTestFixture::RadosTestFixture()
 void RadosTestFixture::SetUpTestCase() {
   _pool_name = get_temp_pool_name();
   ASSERT_EQ("", create_one_pool_pp(_pool_name, _rados));
+
+  CephContext* cct = reinterpret_cast<CephContext*>(_rados.cct());
+  _thread_pool = new ThreadPool(cct, "RadosTestFixture::_thread_pool",
+                                 "tp_test", 1);
+  _thread_pool->start();
 }
 
 void RadosTestFixture::TearDownTestCase() {
   ASSERT_EQ(0, destroy_one_pool_pp(_pool_name, _rados));
+
+  _thread_pool->stop();
+  delete _thread_pool;
 }
 
 std::string RadosTestFixture::get_temp_oid() {
@@ -25,8 +34,12 @@ std::string RadosTestFixture::get_temp_oid() {
 
 void RadosTestFixture::SetUp() {
   ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), m_ioctx));
-  m_timer = new SafeTimer(reinterpret_cast<CephContext*>(m_ioctx.cct()),
-                          m_timer_lock, true);
+
+  CephContext* cct = reinterpret_cast<CephContext*>(m_ioctx.cct());
+  m_work_queue = new ContextWQ("RadosTestFixture::m_work_queue", 60,
+                               _thread_pool);
+
+  m_timer = new SafeTimer(cct, m_timer_lock, true);
   m_timer->init();
 }
 
@@ -36,6 +49,9 @@ void RadosTestFixture::TearDown() {
     m_timer->shutdown();
   }
   delete m_timer;
+
+  m_work_queue->drain();
+  delete m_work_queue;
 }
 
 int RadosTestFixture::create(const std::string &oid, uint8_t order,
@@ -47,7 +63,8 @@ journal::JournalMetadataPtr RadosTestFixture::create_metadata(
     const std::string &oid, const std::string &client_id,
     double commit_internal) {
   journal::JournalMetadataPtr metadata(new journal::JournalMetadata(
-    m_ioctx, oid, client_id, commit_internal));
+    m_work_queue, m_timer, &m_timer_lock, m_ioctx, oid, client_id,
+    commit_internal));
   return metadata;
 }
 
@@ -101,3 +118,4 @@ bool RadosTestFixture::wait_for_update(journal::JournalMetadataPtr metadata) {
 std::string RadosTestFixture::_pool_name;
 librados::Rados RadosTestFixture::_rados;
 uint64_t RadosTestFixture::_oid_number = 0;
+ThreadPool *RadosTestFixture::_thread_pool = nullptr;

--- a/src/test/journal/RadosTestFixture.h
+++ b/src/test/journal/RadosTestFixture.h
@@ -19,11 +19,15 @@ public:
   virtual void SetUp();
   virtual void TearDown();
 
-  int create(const std::string &oid, uint8_t order, uint8_t splay_width);
+  int create(const std::string &oid, uint8_t order = 14,
+             uint8_t splay_width = 2);
+  journal::JournalMetadataPtr create_metadata(const std::string &oid,
+                                              const std::string &client_id = "client",
+                                              double commit_internal = 0.1);
   int append(const std::string &oid, const bufferlist &bl);
 
-  int client_register(const std::string &oid, const std::string &id,
-                      const std::string &description);
+  int client_register(const std::string &oid, const std::string &id = "client",
+                      const std::string &description = "");
   int client_commit(const std::string &oid, const std::string &id,
                     const cls::journal::ObjectSetPosition &commit_position);
 

--- a/src/test/journal/RadosTestFixture.h
+++ b/src/test/journal/RadosTestFixture.h
@@ -8,6 +8,8 @@
 #include "cls/journal/cls_journal_types.h"
 #include "gtest/gtest.h"
 
+class ThreadPool;
+
 class RadosTestFixture : public ::testing::Test {
 public:
   static void SetUpTestCase();
@@ -56,8 +58,11 @@ public:
   static std::string _pool_name;
   static librados::Rados _rados;
   static uint64_t _oid_number;
+  static ThreadPool *_thread_pool;
 
   librados::IoCtx m_ioctx;
+
+  ContextWQ *m_work_queue;
 
   Mutex m_timer_lock;
   SafeTimer *m_timer;

--- a/src/test/journal/test_JournalMetadata.cc
+++ b/src/test/journal/test_JournalMetadata.cc
@@ -14,6 +14,8 @@ public:
          it != m_metadata_list.end(); ++it) {
       (*it)->remove_listener(&m_listener);
     }
+    m_metadata_list.clear();
+
     RadosTestFixture::TearDown();
   }
 

--- a/src/test/journal/test_JournalMetadata.cc
+++ b/src/test/journal/test_JournalMetadata.cc
@@ -20,8 +20,8 @@ public:
   journal::JournalMetadataPtr create_metadata(const std::string &oid,
                                               const std::string &client_id,
                                               double commit_internal = 0.1) {
-    journal::JournalMetadataPtr metadata(new journal::JournalMetadata(
-      m_ioctx, oid, client_id, commit_internal));
+    journal::JournalMetadataPtr metadata = RadosTestFixture::create_metadata(
+      oid, client_id, commit_internal);
     m_metadata_list.push_back(metadata);
     metadata->add_listener(&m_listener);
     return metadata;

--- a/src/test/journal/test_JournalPlayer.cc
+++ b/src/test/journal/test_JournalPlayer.cc
@@ -53,14 +53,6 @@ public:
     RadosTestFixture::TearDown();
   }
 
-  int create(const std::string &oid, uint8_t splay_width = 2) {
-    return RadosTestFixture::create(oid, 14, splay_width);
-  }
-
-  int client_register(const std::string &oid) {
-    return RadosTestFixture::client_register(oid, "client", "");
-  }
-
   int client_commit(const std::string &oid,
                     journal::JournalPlayer::ObjectSetPosition position) {
     return RadosTestFixture::client_commit(oid, "client", position);
@@ -70,12 +62,6 @@ public:
     bufferlist payload_bl;
     payload_bl.append("playload");
     return journal::Entry(tag_tid, entry_tid, payload_bl);
-  }
-
-  journal::JournalMetadataPtr create_metadata(const std::string &oid) {
-    journal::JournalMetadataPtr metadata(new journal::JournalMetadata(
-      m_ioctx, oid, "client", 0.1));
-    return metadata;
   }
 
   journal::JournalPlayer *create_player(const std::string &oid,
@@ -355,7 +341,7 @@ TEST_F(TestJournalPlayer, PrefetchSkippedObject) {
 
   cls::journal::ObjectSetPosition commit_position;
 
-  ASSERT_EQ(0, create(oid, 3));
+  ASSERT_EQ(0, create(oid, 14, 3));
   ASSERT_EQ(0, client_register(oid));
   ASSERT_EQ(0, client_commit(oid, commit_position));
 

--- a/src/test/journal/test_JournalRecorder.cc
+++ b/src/test/journal/test_JournalRecorder.cc
@@ -18,16 +18,6 @@ public:
     RadosTestFixture::TearDown();
   }
 
-  int client_register(const std::string &oid) {
-    return RadosTestFixture::client_register(oid, "client", "");
-  }
-
-  journal::JournalMetadataPtr create_metadata(const std::string &oid) {
-    journal::JournalMetadataPtr metadata(new journal::JournalMetadata(
-      m_ioctx, oid, "client", 0.1));
-    return metadata;
-  }
-
   journal::JournalRecorder *create_recorder(const std::string &oid,
                                             const journal::JournalMetadataPtr &metadata) {
     journal::JournalRecorder *recorder(new journal::JournalRecorder(

--- a/src/test/journal/test_JournalTrimmer.cc
+++ b/src/test/journal/test_JournalTrimmer.cc
@@ -34,14 +34,9 @@ public:
     return r;
   }
 
-  using RadosTestFixture::client_register;
-  int client_register(const std::string &oid) {
-    return RadosTestFixture::client_register(oid, "client", "");
-  }
-
   journal::JournalMetadataPtr create_metadata(const std::string &oid) {
-    journal::JournalMetadataPtr metadata(new journal::JournalMetadata(
-      m_ioctx, oid, "client", 0.1));
+    journal::JournalMetadataPtr metadata = RadosTestFixture::create_metadata(
+      oid);
     m_metadata_list.push_back(metadata);
     metadata->add_listener(&m_listener);
     return metadata;

--- a/src/test/journal/test_JournalTrimmer.cc
+++ b/src/test/journal/test_JournalTrimmer.cc
@@ -16,6 +16,8 @@ public:
          it != m_metadata_list.end(); ++it) {
       (*it)->remove_listener(&m_listener);
     }
+    m_metadata_list.clear();
+
     for (std::list<journal::JournalTrimmer*>::iterator it = m_trimmers.begin();
          it != m_trimmers.end(); ++it) {
       delete *it;

--- a/src/test/journal/test_Journaler.cc
+++ b/src/test/journal/test_Journaler.cc
@@ -20,7 +20,8 @@ public:
   virtual void SetUp() {
     RadosTestFixture::SetUp();
     m_journal_id = get_temp_journal_id();
-    m_journaler = new journal::Journaler(m_ioctx, m_journal_id, CLIENT_ID, 5);
+    m_journaler = new journal::Journaler(m_work_queue, m_timer, &m_timer_lock,
+                                         m_ioctx, m_journal_id, CLIENT_ID, 5);
   }
 
   virtual void TearDown() {
@@ -39,7 +40,8 @@ public:
   }
 
   int register_client(const std::string &client_id, const std::string &desc) {
-    journal::Journaler journaler(m_ioctx, m_journal_id, client_id, 5);
+    journal::Journaler journaler(m_work_queue, m_timer, &m_timer_lock,
+                                 m_ioctx, m_journal_id, client_id, 5);
     bufferlist data;
     data.append(desc);
     C_SaferCond cond;
@@ -48,7 +50,8 @@ public:
   }
 
   int update_client(const std::string &client_id, const std::string &desc) {
-    journal::Journaler journaler(m_ioctx, m_journal_id, client_id, 5);
+    journal::Journaler journaler(m_work_queue, m_timer, &m_timer_lock,
+                                 m_ioctx, m_journal_id, client_id, 5);
     bufferlist data;
     data.append(desc);
     C_SaferCond cond;
@@ -57,7 +60,8 @@ public:
   }
 
   int unregister_client(const std::string &client_id) {
-    journal::Journaler journaler(m_ioctx, m_journal_id, client_id, 5);
+    journal::Journaler journaler(m_work_queue, m_timer, &m_timer_lock,
+                                 m_ioctx, m_journal_id, client_id, 5);
     C_SaferCond cond;
     journaler.unregister_client(&cond);
     return cond.wait();

--- a/src/test/journal/test_ObjectRecorder.cc
+++ b/src/test/journal/test_ObjectRecorder.cc
@@ -52,6 +52,8 @@ public:
       (*it)->flush(&cond);
       cond.wait();
     }
+    m_object_recorders.clear();
+
     RadosTestFixture::TearDown();
   }
 

--- a/src/test/journal/test_ObjectRecorder.cc
+++ b/src/test/journal/test_ObjectRecorder.cc
@@ -3,7 +3,6 @@
 
 #include "journal/ObjectRecorder.h"
 #include "common/Cond.h"
-#include "common/Finisher.h"
 #include "common/Mutex.h"
 #include "common/Timer.h"
 #include "gtest/gtest.h"
@@ -16,14 +15,8 @@ public:
   TestObjectRecorder()
     : m_flush_interval(std::numeric_limits<uint32_t>::max()),
       m_flush_bytes(std::numeric_limits<uint64_t>::max()),
-      m_flush_age(600),
-      m_finisher(NULL)
+      m_flush_age(600)
   {
-  }
-
-  ~TestObjectRecorder() {
-    m_finisher->stop();
-    delete m_finisher;
   }
 
   struct OverflowHandler : public journal::ObjectRecorder::OverflowHandler {
@@ -52,14 +45,6 @@ public:
   double m_flush_age;
   OverflowHandler m_overflow_handler;
 
-  Finisher *m_finisher;
-
-  void SetUp() {
-    RadosTestFixture::SetUp();
-    m_finisher = new Finisher(reinterpret_cast<CephContext*>(m_ioctx.cct()));
-    m_finisher->start();
-  }
-
   void TearDown() {
     for (ObjectRecorders::iterator it = m_object_recorders.begin();
          it != m_object_recorders.end(); ++it) {
@@ -80,10 +65,11 @@ public:
     m_flush_age = i;
   }
 
-  journal::AppendBuffer create_append_buffer(uint64_t tag_tid, uint64_t entry_tid,
+  journal::AppendBuffer create_append_buffer(journal::JournalMetadataPtr metadata,
+                                             uint64_t tag_tid, uint64_t entry_tid,
                                              const std::string &payload) {
-    journal::FutureImplPtr future(new journal::FutureImpl(*m_finisher,
-                                                          tag_tid, entry_tid, 456));
+    journal::FutureImplPtr future(new journal::FutureImpl(metadata, tag_tid,
+                                                          entry_tid, 456));
     future->init(journal::FutureImplPtr());
 
     bufferlist bl;
@@ -103,18 +89,24 @@ public:
 
 TEST_F(TestObjectRecorder, Append) {
   std::string oid = get_temp_oid();
+  ASSERT_EQ(0, create(oid));
+  ASSERT_EQ(0, client_register(oid));
+  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  ASSERT_EQ(0, init_metadata(metadata));
 
   journal::ObjectRecorderPtr object = create_object(oid, 24);
 
-  journal::AppendBuffer append_buffer1 = create_append_buffer(234, 123,
-                                                             "payload");
+  journal::AppendBuffer append_buffer1 = create_append_buffer(metadata,
+                                                              234, 123,
+                                                              "payload");
   journal::AppendBuffers append_buffers;
   append_buffers = {append_buffer1};
   ASSERT_FALSE(object->append(append_buffers));
   ASSERT_EQ(1U, object->get_pending_appends());
 
-  journal::AppendBuffer append_buffer2 = create_append_buffer(234, 124,
-                                                             "payload");
+  journal::AppendBuffer append_buffer2 = create_append_buffer(metadata,
+                                                              234, 124,
+                                                              "payload");
   append_buffers = {append_buffer2};
   ASSERT_FALSE(object->append(append_buffers));
   ASSERT_EQ(2U, object->get_pending_appends());
@@ -127,19 +119,25 @@ TEST_F(TestObjectRecorder, Append) {
 
 TEST_F(TestObjectRecorder, AppendFlushByCount) {
   std::string oid = get_temp_oid();
+  ASSERT_EQ(0, create(oid));
+  ASSERT_EQ(0, client_register(oid));
+  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  ASSERT_EQ(0, init_metadata(metadata));
 
   set_flush_interval(2);
   journal::ObjectRecorderPtr object = create_object(oid, 24);
 
-  journal::AppendBuffer append_buffer1 = create_append_buffer(234, 123,
-                                                             "payload");
+  journal::AppendBuffer append_buffer1 = create_append_buffer(metadata,
+                                                              234, 123,
+                                                              "payload");
   journal::AppendBuffers append_buffers;
   append_buffers = {append_buffer1};
   ASSERT_FALSE(object->append(append_buffers));
   ASSERT_EQ(1U, object->get_pending_appends());
 
-  journal::AppendBuffer append_buffer2 = create_append_buffer(234, 124,
-                                                             "payload");
+  journal::AppendBuffer append_buffer2 = create_append_buffer(metadata,
+                                                              234, 124,
+                                                              "payload");
   append_buffers = {append_buffer2};
   ASSERT_FALSE(object->append(append_buffers));
   ASSERT_EQ(0U, object->get_pending_appends());
@@ -151,19 +149,25 @@ TEST_F(TestObjectRecorder, AppendFlushByCount) {
 
 TEST_F(TestObjectRecorder, AppendFlushByBytes) {
   std::string oid = get_temp_oid();
+  ASSERT_EQ(0, create(oid));
+  ASSERT_EQ(0, client_register(oid));
+  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  ASSERT_EQ(0, init_metadata(metadata));
 
   set_flush_bytes(10);
   journal::ObjectRecorderPtr object = create_object(oid, 24);
 
-  journal::AppendBuffer append_buffer1 = create_append_buffer(234, 123,
-                                                             "payload");
+  journal::AppendBuffer append_buffer1 = create_append_buffer(metadata,
+                                                              234, 123,
+                                                              "payload");
   journal::AppendBuffers append_buffers;
   append_buffers = {append_buffer1};
   ASSERT_FALSE(object->append(append_buffers));
   ASSERT_EQ(1U, object->get_pending_appends());
 
-  journal::AppendBuffer append_buffer2 = create_append_buffer(234, 124,
-                                                             "payload");
+  journal::AppendBuffer append_buffer2 = create_append_buffer(metadata,
+                                                              234, 124,
+                                                              "payload");
   append_buffers = {append_buffer2};
   ASSERT_FALSE(object->append(append_buffers));
   ASSERT_EQ(0U, object->get_pending_appends());
@@ -175,18 +179,24 @@ TEST_F(TestObjectRecorder, AppendFlushByBytes) {
 
 TEST_F(TestObjectRecorder, AppendFlushByAge) {
   std::string oid = get_temp_oid();
+  ASSERT_EQ(0, create(oid));
+  ASSERT_EQ(0, client_register(oid));
+  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  ASSERT_EQ(0, init_metadata(metadata));
 
   set_flush_age(0.1);
   journal::ObjectRecorderPtr object = create_object(oid, 24);
 
-  journal::AppendBuffer append_buffer1 = create_append_buffer(234, 123,
-                                                             "payload");
+  journal::AppendBuffer append_buffer1 = create_append_buffer(metadata,
+                                                              234, 123,
+                                                              "payload");
   journal::AppendBuffers append_buffers;
   append_buffers = {append_buffer1};
   ASSERT_FALSE(object->append(append_buffers));
 
-  journal::AppendBuffer append_buffer2 = create_append_buffer(234, 124,
-                                                             "payload");
+  journal::AppendBuffer append_buffer2 = create_append_buffer(metadata,
+                                                              234, 124,
+                                                              "payload");
   append_buffers = {append_buffer2};
   ASSERT_FALSE(object->append(append_buffers));
 
@@ -198,17 +208,23 @@ TEST_F(TestObjectRecorder, AppendFlushByAge) {
 
 TEST_F(TestObjectRecorder, AppendFilledObject) {
   std::string oid = get_temp_oid();
+  ASSERT_EQ(0, create(oid));
+  ASSERT_EQ(0, client_register(oid));
+  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  ASSERT_EQ(0, init_metadata(metadata));
 
   journal::ObjectRecorderPtr object = create_object(oid, 12);
 
   std::string payload(2048, '1');
-  journal::AppendBuffer append_buffer1 = create_append_buffer(234, 123,
+  journal::AppendBuffer append_buffer1 = create_append_buffer(metadata,
+                                                              234, 123,
                                                               payload);
   journal::AppendBuffers append_buffers;
   append_buffers = {append_buffer1};
   ASSERT_FALSE(object->append(append_buffers));
 
-  journal::AppendBuffer append_buffer2 = create_append_buffer(234, 124,
+  journal::AppendBuffer append_buffer2 = create_append_buffer(metadata,
+                                                              234, 124,
                                                               payload);
   append_buffers = {append_buffer2};
   ASSERT_TRUE(object->append(append_buffers));
@@ -221,11 +237,16 @@ TEST_F(TestObjectRecorder, AppendFilledObject) {
 
 TEST_F(TestObjectRecorder, Flush) {
   std::string oid = get_temp_oid();
+  ASSERT_EQ(0, create(oid));
+  ASSERT_EQ(0, client_register(oid));
+  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  ASSERT_EQ(0, init_metadata(metadata));
 
   journal::ObjectRecorderPtr object = create_object(oid, 24);
 
-  journal::AppendBuffer append_buffer1 = create_append_buffer(234, 123,
-                                                             "payload");
+  journal::AppendBuffer append_buffer1 = create_append_buffer(metadata,
+                                                              234, 123,
+                                                              "payload");
   journal::AppendBuffers append_buffers;
   append_buffers = {append_buffer1};
   ASSERT_FALSE(object->append(append_buffers));
@@ -243,10 +264,15 @@ TEST_F(TestObjectRecorder, Flush) {
 
 TEST_F(TestObjectRecorder, FlushFuture) {
   std::string oid = get_temp_oid();
+  ASSERT_EQ(0, create(oid));
+  ASSERT_EQ(0, client_register(oid));
+  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  ASSERT_EQ(0, init_metadata(metadata));
 
   journal::ObjectRecorderPtr object = create_object(oid, 24);
 
-  journal::AppendBuffer append_buffer = create_append_buffer(234, 123,
+  journal::AppendBuffer append_buffer = create_append_buffer(metadata,
+                                                             234, 123,
                                                              "payload");
   journal::AppendBuffers append_buffers;
   append_buffers = {append_buffer};
@@ -263,10 +289,15 @@ TEST_F(TestObjectRecorder, FlushFuture) {
 
 TEST_F(TestObjectRecorder, FlushDetachedFuture) {
   std::string oid = get_temp_oid();
+  ASSERT_EQ(0, create(oid));
+  ASSERT_EQ(0, client_register(oid));
+  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  ASSERT_EQ(0, init_metadata(metadata));
 
   journal::ObjectRecorderPtr object = create_object(oid, 24);
 
-  journal::AppendBuffer append_buffer = create_append_buffer(234, 123,
+  journal::AppendBuffer append_buffer = create_append_buffer(metadata,
+                                                             234, 123,
                                                              "payload");
 
   journal::AppendBuffers append_buffers;
@@ -284,14 +315,20 @@ TEST_F(TestObjectRecorder, FlushDetachedFuture) {
 
 TEST_F(TestObjectRecorder, Overflow) {
   std::string oid = get_temp_oid();
+  ASSERT_EQ(0, create(oid));
+  ASSERT_EQ(0, client_register(oid));
+  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  ASSERT_EQ(0, init_metadata(metadata));
 
   journal::ObjectRecorderPtr object1 = create_object(oid, 12);
   journal::ObjectRecorderPtr object2 = create_object(oid, 12);
 
   std::string payload(2048, '1');
-  journal::AppendBuffer append_buffer1 = create_append_buffer(234, 123,
+  journal::AppendBuffer append_buffer1 = create_append_buffer(metadata,
+                                                              234, 123,
                                                               payload);
-  journal::AppendBuffer append_buffer2 = create_append_buffer(234, 124,
+  journal::AppendBuffer append_buffer2 = create_append_buffer(metadata,
+                                                              234, 124,
                                                               payload);
   journal::AppendBuffers append_buffers;
   append_buffers = {append_buffer1, append_buffer2};
@@ -302,7 +339,8 @@ TEST_F(TestObjectRecorder, Overflow) {
   ASSERT_EQ(0, cond.wait());
   ASSERT_EQ(0U, object1->get_pending_appends());
 
-  journal::AppendBuffer append_buffer3 = create_append_buffer(456, 123,
+  journal::AppendBuffer append_buffer3 = create_append_buffer(metadata,
+                                                              456, 123,
                                                               payload);
   append_buffers = {append_buffer3};
 

--- a/src/test/librbd/test_mock_Journal.cc
+++ b/src/test/librbd/test_mock_Journal.cc
@@ -109,6 +109,13 @@ struct MockJournalerProxy {
     MockJournaler::get_instance().construct();
   }
 
+  template <typename IoCtxT>
+  MockJournalerProxy(ContextWQ *work_queue, SafeTimer *safe_timer,
+                     Mutex *timer_lock, IoCtxT &header_ioctx,
+                     const std::string &, const std::string &, double) {
+    MockJournaler::get_instance().construct();
+  }
+
   int exists(bool *header_exists) const {
     return -EINVAL;
   }

--- a/src/test/rbd_mirror/image_replay.cc
+++ b/src/test/rbd_mirror/image_replay.cc
@@ -10,6 +10,7 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "tools/rbd_mirror/ImageReplayer.h"
+#include "tools/rbd_mirror/Threads.h"
 
 #include <string>
 #include <vector>
@@ -128,6 +129,7 @@ int main(int argc, const char **argv)
 
   rbd::mirror::RadosRef local(new librados::Rados());
   rbd::mirror::RadosRef remote(new librados::Rados());
+  rbd::mirror::Threads *threads = nullptr;
 
   int r = local->init_with_context(g_ceph_context);
   if (r < 0) {
@@ -170,7 +172,9 @@ int main(int argc, const char **argv)
 
   dout(5) << "starting replay" << dendl;
 
-  replayer = new rbd::mirror::ImageReplayer(local, remote, client_id,
+  threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
+    local->cct()));
+  replayer = new rbd::mirror::ImageReplayer(threads, local, remote, client_id,
 					    remote_pool_id, remote_image_id);
 
   r = replayer->start(&bootstap_params);
@@ -198,6 +202,7 @@ int main(int argc, const char **argv)
   shutdown_async_signal_handler();
 
   delete replayer;
+  delete threads;
   g_ceph_context->put();
 
   return r < 0 ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -30,6 +30,7 @@
 #include "librbd/internal.h"
 #include "tools/rbd_mirror/types.h"
 #include "tools/rbd_mirror/ImageReplayer.h"
+#include "tools/rbd_mirror/Threads.h"
 
 #include "test/librados/test.h"
 #include "gtest/gtest.h"
@@ -98,7 +99,11 @@ public:
 				false, features, &order, 0, 0));
     m_remote_image_id = get_image_id(m_remote_ioctx, m_image_name);
 
+    m_threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
+      m_local_ioctx.cct()));
+
     m_replayer = new rbd::mirror::ImageReplayer(
+      m_threads,
       rbd::mirror::RadosRef(new librados::Rados(m_local_ioctx)),
       rbd::mirror::RadosRef(new librados::Rados(m_remote_ioctx)),
       m_client_id, remote_pool_id, m_remote_image_id);
@@ -109,6 +114,7 @@ public:
   ~TestImageReplayer()
   {
     delete m_replayer;
+    delete m_threads;
 
     EXPECT_EQ(0, m_remote_cluster.pool_delete(m_remote_pool_name.c_str()));
     EXPECT_EQ(0, m_local_cluster.pool_delete(m_local_pool_name.c_str()));
@@ -311,6 +317,7 @@ public:
 
   static int _image_number;
 
+  rbd::mirror::Threads *m_threads = nullptr;
   librados::Rados m_local_cluster, m_remote_cluster;
   std::string m_client_id;
   std::string m_local_pool_name, m_remote_pool_name;

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -86,6 +86,7 @@ librbd_mirror_internal_la_SOURCES = \
 	tools/rbd_mirror/Mirror.cc \
 	tools/rbd_mirror/PoolWatcher.cc \
 	tools/rbd_mirror/Replayer.cc \
+	tools/rbd_mirror/Threads.cc \
 	tools/rbd_mirror/types.cc
 noinst_LTLIBRARIES += librbd_mirror_internal.la
 noinst_HEADERS += \
@@ -94,6 +95,7 @@ noinst_HEADERS += \
 	tools/rbd_mirror/Mirror.h \
 	tools/rbd_mirror/PoolWatcher.h \
 	tools/rbd_mirror/Replayer.h \
+	tools/rbd_mirror/Threads.h \
 	tools/rbd_mirror/types.h
 
 rbd_mirror_SOURCES = \

--- a/src/tools/rbd/action/Journal.cc
+++ b/src/tools/rbd/action/Journal.cc
@@ -205,8 +205,8 @@ public:
     return 0;
   }
 
-  int shutdown() {
-    ::journal::Journaler::shutdown();
+  int shut_down() {
+    ::journal::Journaler::shut_down();
 
     int r = unregister_client();
     if (r < 0) {
@@ -250,7 +250,7 @@ public:
       }
     }
 
-    r = m_journaler.shutdown();
+    r = m_journaler.shut_down();
     if (r < 0 && m_r == 0) {
       m_r = r;
     }
@@ -679,7 +679,7 @@ public:
     if (r1 < 0 && r == 0) {
       r = r1;
     }
-    r1 = m_journaler.shutdown();
+    r1 = m_journaler.shut_down();
     if (r1 < 0 && r == 0) {
       r = r1;
     }

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -6,6 +6,8 @@
 #include "common/errno.h"
 #include "include/stringify.h"
 #include "cls/rbd/cls_rbd_client.h"
+#include "common/Timer.h"
+#include "common/WorkQueue.h"
 #include "journal/Journaler.h"
 #include "journal/ReplayEntry.h"
 #include "journal/ReplayHandler.h"
@@ -18,6 +20,7 @@
 #include "librbd/internal.h"
 #include "librbd/journal/Replay.h"
 #include "ImageReplayer.h"
+#include "Threads.h"
 
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
@@ -158,10 +161,11 @@ private:
   Commands commands;
 };
 
-ImageReplayer::ImageReplayer(RadosRef local, RadosRef remote,
+ImageReplayer::ImageReplayer(Threads *threads, RadosRef local, RadosRef remote,
 			     const std::string &client_id,
 			     int64_t remote_pool_id,
 			     const std::string &remote_image_id) :
+  m_threads(threads),
   m_local(local),
   m_remote(remote),
   m_client_id(client_id),
@@ -183,6 +187,8 @@ ImageReplayer::ImageReplayer(RadosRef local, RadosRef remote,
 
 ImageReplayer::~ImageReplayer()
 {
+  m_threads->work_queue->drain();
+
   assert(m_local_image_ctx == nullptr);
   assert(m_local_replay == nullptr);
   assert(m_remote_journaler == nullptr);
@@ -219,9 +225,13 @@ int ImageReplayer::start(const BootstrapParams *bootstrap_params)
   }
 
   CephContext *cct = static_cast<CephContext *>(m_local->cct());
+
   commit_interval = cct->_conf->rbd_journal_commit_age;
   bool remote_journaler_initialized = false;
-  m_remote_journaler = new ::journal::Journaler(m_remote_ioctx,
+  m_remote_journaler = new ::journal::Journaler(m_threads->work_queue,
+                                                m_threads->timer,
+                                                &m_threads->timer_lock,
+                                                m_remote_ioctx,
 						remote_journal_id,
 						m_client_id, commit_interval);
   r = get_registered_client_status(&registered);
@@ -315,7 +325,7 @@ fail:
   if (m_remote_journaler) {
     if (remote_journaler_initialized) {
       m_remote_journaler->stop_replay();
-      m_remote_journaler->shutdown();
+      m_remote_journaler->shut_down();
     }
     delete m_remote_journaler;
     m_remote_journaler = nullptr;
@@ -378,7 +388,7 @@ void ImageReplayer::stop()
   m_local_ioctx.close();
 
   m_remote_journaler->stop_replay();
-  m_remote_journaler->shutdown();
+  m_remote_journaler->shut_down();
   delete m_remote_journaler;
   m_remote_journaler = nullptr;
 

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -13,6 +13,8 @@
 #include "include/rados/librados.hpp"
 #include "types.h"
 
+class ContextWQ;
+
 namespace journal {
 
 class Journaler;
@@ -37,6 +39,7 @@ namespace rbd {
 namespace mirror {
 
 class ImageReplayerAdminSocketHook;
+struct Threads;
 
 /**
  * Replays changes from a remote cluster for a single image.
@@ -64,8 +67,9 @@ public:
   };
 
 public:
-  ImageReplayer(RadosRef local, RadosRef remote, const std::string &client_id,
-		int64_t remote_pool_id, const std::string &remote_image_id);
+  ImageReplayer(Threads *threads, RadosRef local, RadosRef remote,
+                const std::string &client_id, int64_t remote_pool_id,
+                const std::string &remote_image_id);
   virtual ~ImageReplayer();
   ImageReplayer(const ImageReplayer&) = delete;
   ImageReplayer& operator=(const ImageReplayer&) = delete;
@@ -98,6 +102,7 @@ private:
   friend std::ostream &operator<<(std::ostream &os,
 				  const ImageReplayer &replayer);
 private:
+  Threads *m_threads;
   RadosRef m_local, m_remote;
   std::string m_client_id;
   int64_t m_remote_pool_id, m_local_pool_id;

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -6,6 +6,7 @@
 #include "common/debug.h"
 #include "common/errno.h"
 #include "Mirror.h"
+#include "Threads.h"
 
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
@@ -31,6 +32,8 @@ Mirror::Mirror(CephContext *cct) :
   m_lock("rbd::mirror::Mirror"),
   m_local(new librados::Rados())
 {
+  cct->lookup_or_create_singleton_object<Threads>(m_threads,
+                                                  "rbd_mirror::threads");
 }
 
 void Mirror::handle_signal(int signum)
@@ -76,7 +79,7 @@ void Mirror::update_replayers(const map<peer_t, set<int64_t> > &peer_configs)
   for (auto &kv : peer_configs) {
     const peer_t &peer = kv.first;
     if (m_replayers.find(peer) == m_replayers.end()) {
-      unique_ptr<Replayer> replayer(new Replayer(m_local, peer));
+      unique_ptr<Replayer> replayer(new Replayer(m_threads, m_local, peer));
       // TODO: make async, and retry connecting within replayer
       int r = replayer->init();
       if (r < 0) {

--- a/src/tools/rbd_mirror/Mirror.h
+++ b/src/tools/rbd_mirror/Mirror.h
@@ -19,6 +19,8 @@
 namespace rbd {
 namespace mirror {
 
+struct Threads;
+
 /**
  * Contains the main loop and overall state for rbd-mirror.
  *
@@ -40,6 +42,7 @@ private:
   void update_replayers(const map<peer_t, set<int64_t> > &peer_configs);
 
   CephContext *m_cct;
+  Threads *m_threads = nullptr;
   Mutex m_lock;
   Cond m_cond;
   RadosRef m_local;

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -21,7 +21,9 @@ using std::vector;
 namespace rbd {
 namespace mirror {
 
-Replayer::Replayer(RadosRef local_cluster, const peer_t &peer) :
+Replayer::Replayer(Threads *threads, RadosRef local_cluster,
+                   const peer_t &peer) :
+  m_threads(threads),
   m_lock(stringify("rbd::mirror::Replayer ") + stringify(peer)),
   m_peer(peer),
   m_local(local_cluster),
@@ -122,7 +124,8 @@ void Replayer::set_sources(const map<int64_t, set<string> > &images)
     auto &pool_replayers = m_images[pool_id];
     for (const auto &image_id : kv.second) {
       if (pool_replayers.find(image_id) == pool_replayers.end()) {
-	unique_ptr<ImageReplayer> image_replayer(new ImageReplayer(m_local,
+	unique_ptr<ImageReplayer> image_replayer(new ImageReplayer(m_threads,
+                                                                   m_local,
 								   m_remote,
 								   m_client_id,
 								   pool_id,

--- a/src/tools/rbd_mirror/Replayer.h
+++ b/src/tools/rbd_mirror/Replayer.h
@@ -23,12 +23,14 @@
 namespace rbd {
 namespace mirror {
 
+struct Threads;
+
 /**
  * Controls mirroring for a single remote cluster.
  */
 class Replayer {
 public:
-  Replayer(RadosRef local_cluster, const peer_t &peer);
+  Replayer(Threads *threads, RadosRef local_cluster, const peer_t &peer);
   ~Replayer();
   Replayer(const Replayer&) = delete;
   Replayer& operator=(const Replayer&) = delete;
@@ -40,6 +42,7 @@ public:
 private:
   void set_sources(const std::map<int64_t, std::set<std::string> > &images);
 
+  Threads *m_threads;
   Mutex m_lock;
   Cond m_cond;
   atomic_t m_stopping;

--- a/src/tools/rbd_mirror/Threads.cc
+++ b/src/tools/rbd_mirror/Threads.cc
@@ -1,0 +1,38 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "tools/rbd_mirror/Threads.h"
+#include "common/Timer.h"
+#include "common/WorkQueue.h"
+
+namespace rbd {
+namespace mirror {
+
+Threads::Threads(CephContext *cct) : timer_lock("Threads::timer_lock") {
+  thread_pool = new ThreadPool(cct, "Journaler::thread_pool", "tp_journal",
+                               cct->_conf->rbd_op_threads, "rbd_op_threads");
+  thread_pool->start();
+
+  work_queue = new ContextWQ("Journaler::work_queue",
+                             cct->_conf->rbd_op_thread_timeout, thread_pool);
+
+  timer = new SafeTimer(cct, timer_lock, true);
+  timer->init();
+}
+
+Threads::~Threads() {
+  {
+    Mutex::Locker timer_locker(timer_lock);
+    timer->shutdown();
+  }
+  delete timer;
+
+  work_queue->drain();
+  delete work_queue;
+
+  thread_pool->stop();
+  delete thread_pool;
+}
+
+} // namespace mirror
+} // namespace rbd

--- a/src/tools/rbd_mirror/Threads.h
+++ b/src/tools/rbd_mirror/Threads.h
@@ -1,0 +1,34 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_RBD_MIRROR_THREADS_H
+#define CEPH_RBD_MIRROR_THREADS_H
+
+#include "common/Mutex.h"
+
+class CephContext;
+class ContextWQ;
+class SafeTimer;
+class ThreadPool;
+
+namespace rbd {
+namespace mirror {
+
+struct Threads {
+  ThreadPool *thread_pool = nullptr;
+  ContextWQ *work_queue = nullptr;
+
+  SafeTimer *timer = nullptr;
+  Mutex timer_lock;
+
+  explicit Threads(CephContext *cct);
+  Threads(const Threads&) = delete;
+  Threads& operator=(const Threads&) = delete;
+
+  ~Threads();
+};
+
+} // namespace mirror
+} // namespace rbd
+
+#endif // CEPH_RBD_MIRROR_THREADS_H


### PR DESCRIPTION
The rbd-mirror daemon will instantiate potentially thousands of journalers.  To avoid spawning two threads per journaler, now rbd-mirror can reuse the same threads between journalers.