### PR TITLE
script: subscription-manager support

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -692,6 +692,9 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
                 --libexecdir=%{_libexecdir} \
 		--localstatedir=/var \
 		--sysconfdir=/etc \
+%if 0%{?rhel}
+                --enable-subman \
+%endif
 %if 0%{?_with_systemd}
 		--with-systemdsystemunitdir=%_unitdir \
 %endif
@@ -1183,6 +1186,9 @@ fi
 %{_mandir}/man8/ceph-clsinfo.8*
 %{_mandir}/man8/ceph-disk.8*
 %{_mandir}/man8/ceph-osd.8*
+%if 0%{?rhel}
+/etc/cron.hourly/subman.py
+%endif
 %if 0%{?_with_systemd}
 %{_unitdir}/ceph-osd@.service
 %{_unitdir}/ceph-osd.target

--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,13 @@ AC_ARG_ENABLE([server],
 AM_CONDITIONAL(ENABLE_SERVER, test "$enable_server" = "yes")
 #AS_IF([test "$enable_server" = "yes"], [AC_DEFINE([WITH_MON, WITH_OSD, WITH_MDS, ENABLE_SERVER])])
 
+# subscription manager?
+AC_ARG_ENABLE([subman],
+	[AS_HELP_STRING([--enable-subman], [enable subman])],
+	[],
+	[enable_subman=yes])
+AM_CONDITIONAL([ENABLE_SUBMAN], test "$enable_subman" = "yes")
+
 # cython is required to build python bindings for libraries
 if test x"$with_cython" = xyes; then
     AC_CHECK_PROG(CYTHON_CHECK, cython, yes)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -107,6 +107,7 @@ EXTRA_DIST += \
 	$(srcdir)/.git_version \
 	$(srcdir)/ceph-rbdnamer \
 	$(srcdir)/tools/ceph-monstore-update-crush.sh \
+	$(srcdir)/script/subman.py \
 	$(srcdir)/upstart/ceph-all.conf \
 	$(srcdir)/upstart/ceph-disk.conf \
 	$(srcdir)/upstart/ceph-mon.conf \
@@ -149,6 +150,10 @@ doc_DATA = $(srcdir)/sample.ceph.conf sample.fetch_config
 ceph_libexecdir = $(libexecdir)/ceph
 ceph_libexec_SCRIPTS = ceph_common.sh ceph-osd-prestart.sh
 
+if ENABLE_SUBMAN
+submandir = /etc/cron.hourly
+subman_SCRIPTS = script/subman.py
+endif
 
 # tests to actually run on "make check"; if you need extra, non-test,
 # executables built, you need to replace this with manual assignments

--- a/src/script/subman.py
+++ b/src/script/subman.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import json
+import re
+import subprocess
+
+disks = json.loads(subprocess.check_output("ceph-disk list --format json", shell=True))
+used = 0
+
+for disk in disks:
+    for partition in disk.get('partition', []):
+        if partition.get('type') == 'data':
+            df = subprocess.check_output("df --output=used " + partition['path'], shell=True)
+            used += int(re.findall('\d+', df)[0])
+
+open("/etc/rhsm/facts/ceph_usage.facts", 'w').write("""
+{
+"band.storage.usage": {used}
+}
+""".format(used=used/(1024*1024*1024)))


### PR DESCRIPTION
The script is designed to create a fact file for subscription-manager to
consume. It can be run hourly if placed in /etc/cron.hourly.

http://tracker.ceph.com/issues/14972 Fixes: #14972

Signed-off-by: Loic Dachary <loic@dachary.org>