### PR TITLE
ceph-detect-init: return correct value on recent SUSE distros

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/suse/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/suse/__init__.py
@@ -8,10 +8,6 @@ def choose_init():
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
-    init_mapping = {
-        '11': 'sysvinit',   # SLE_11
-        '12': 'systemd',    # SLE_12
-        '13.1': 'systemd',  # openSUSE_13.1
-        '13.2': 'systemd',  # openSUSE_13.2
-    }
-    return init_mapping.get(release, 'sysvinit')
+    if release and int(release.split('.')[0]) >= 12:
+        return 'systemd'
+    return 'sysvinit'


### PR DESCRIPTION
http://tracker.ceph.com/issues/14770 Fixes: #14770

Signed-off-by: Nathan Cutler <ncutler@suse.com>