### PR TITLE
buffer: increment history alloc as well in raw_combined

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -250,6 +250,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
       : raw(dataptr, l),
 	alignment(align) {
       inc_total_alloc(len);
+      inc_history_alloc(len);
     }
     ~raw_combined() {
       dec_total_alloc(len);


### PR DESCRIPTION
Introduced in 73dcd26fc8798e09d93520c583d63edb28ffc631

Fixes: #14955
Signed-off-by: Samuel Just <sjust@redhat.com>