### PR TITLE
infernalis: PK11_DestroyContext() is called twice if PK11_DigestFinal() fails

### DIFF
--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -243,7 +243,6 @@ static int nss_aes_operation(CK_ATTRIBUTE_TYPE op,
 			 out_tmp.length()-written);
   PK11_DestroyContext(ectx, PR_TRUE);
   if (ret != SECSuccess) {
-    PK11_DestroyContext(ectx, PR_TRUE);
     if (error) {
       ostringstream oss;
       oss << "NSS AES final round failed: " << PR_GetError();

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -419,6 +419,8 @@ int CryptoKey::_set_secret(int t, const bufferptr& s)
     if (error.length()) {
       return -EIO;
     }
+  } else {
+      return -EOPNOTSUPP;
   }
   type = t;
   secret = s;


### PR DESCRIPTION
http://tracker.ceph.com/issues/14960
This patch set resolves multiple crashes in infernalis including tracker 13826 and 13527