### PR TITLE
Modifications to rdb-openstack.rst

### DIFF
--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -283,9 +283,8 @@ On your Cinder Backup node, edit ``/etc/cinder/cinder.conf`` and add::
     [DEFAULT]
     ...
     enabled_backends = ceph-ssd
-
-    [ceph-ssd]
     ...
+    [ceph-ssd]
     backup_driver = cinder.backup.drivers.ceph
     backup_ceph_conf = /etc/ceph/ceph.conf
     backup_ceph_user = cinder-backup

--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -280,6 +280,12 @@ Configuring Cinder Backup
 OpenStack Cinder Backup requires a specific daemon so don't forget to install it.
 On your Cinder Backup node, edit ``/etc/cinder/cinder.conf`` and add::
 
+    [DEFAULT]
+    ...
+    enabled_backends = ceph-ssd
+
+    [ceph-ssd]
+    ...
     backup_driver = cinder.backup.drivers.ceph
     backup_ceph_conf = /etc/ceph/ceph.conf
     backup_ceph_user = cinder-backup
@@ -297,7 +303,9 @@ In order to attach Cinder devices (either normal block or by issuing a boot
 from volume), you must tell Nova (and libvirt) which user and UUID to refer to
 when attaching the device. libvirt will refer to this user when connecting and
 authenticating with the Ceph cluster. ::
-
+    
+    [ceph-ssd]
+    ...
     rbd_user = cinder
     rbd_secret_uuid = 457eb676-33da-42ec-9a8c-9293d545c337
 


### PR DESCRIPTION
the default value of 'enabled_backends' is 'lvm' in cinder.conf.

the documentation about cinder configuration doesn't cover changing it to ceph-ssd.

I think modifications about it should be made.

otherwise OpenStack will still use lvm as storage backend.