### PR TITLE
Modifications to rbd-openstack.rst

### DIFF
--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -255,6 +255,11 @@ OpenStack requires a driver to interact with Ceph block devices. You must also
 specify the pool name for the block device. On your OpenStack node, edit
 ``/etc/cinder/cinder.conf`` by adding::
 
+    [DEFAULT]
+    ...
+    enabled_backends = ceph
+    ...
+    [ceph]
     volume_driver = cinder.volume.drivers.rbd.RBDDriver
     rbd_pool = volumes
     rbd_ceph_conf = /etc/ceph/ceph.conf
@@ -267,6 +272,8 @@ specify the pool name for the block device. On your OpenStack node, edit
 If you're using `cephx authentication`_, also configure the user and uuid of
 the secret you added to ``libvirt`` as documented earlier::
 
+    [ceph]
+    ...
     rbd_user = cinder
     rbd_secret_uuid = 457eb676-33da-42ec-9a8c-9293d545c337
 


### PR DESCRIPTION
Original configuration is not working 

'enabled_backends' should be changed according to openstack configuration guide.

''A list of backend names to use. These backend names should
''be backed by a unique [CONFIG] group with its options (list
''value)
''enabled_backends=<None>
 

Signed-off-by: RustShen <rustinpeace@163.com>