### PR TITLE
osd: make os_flags an option

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -257,7 +257,8 @@ int main(int argc, const char **argv)
   ObjectStore *store = ObjectStore::create(g_ceph_context,
 					   store_type,
 					   g_conf->osd_data,
-					   g_conf->osd_journal);
+					   g_conf->osd_journal,
+                                           g_conf->osd_os_flags);
   if (!store) {
     derr << "unable to create object store" << dendl;
     return -ENODEV;

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -578,6 +578,12 @@ OPTION(osd_uuid, OPT_UUID, uuid_d())
 OPTION(osd_data, OPT_STR, "/var/lib/ceph/osd/$cluster-$id")
 OPTION(osd_journal, OPT_STR, "/var/lib/ceph/osd/$cluster-$id/journal")
 OPTION(osd_journal_size, OPT_INT, 5120)         // in mb
+// flags for specific control purpose during osd mount() process. 
+// e.g., can be 1 to skip over replaying journal
+// or 2 to skip over mounting omap or 3 to skip over both.
+// This might be helpful in case the journal is totally corrupted
+// and we still want to bring the osd daemon back normally, etc.
+OPTION(osd_os_flags, OPT_U32, 0)
 OPTION(osd_max_write_size, OPT_INT, 90)
 OPTION(osd_max_pgls, OPT_U64, 1024) // max number of pgls entries to return
 OPTION(osd_client_message_size_cap, OPT_U64, 500*1024L*1024L) // client data allowed in-memory (in bytes)


### PR DESCRIPTION
In one of our test environments an osd is unable to back to work
due to the journal is totally unrecoverable. The os_flags field
is introduced to handle such a case but never be made an option
and visible to normal user.

This pr tries to make os_flags field a configurable option and
no flags is enabled by default and thus shall cause no compatibility
relevant issues.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>