### PR TITLE
tools/rados: reduce "rados put" memory usage by op_size

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -429,7 +429,7 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
       }
       continue;
     }
-    indata.append(buf, count);
+    indata.append(buffer::ptr(buffer::create_static(count, buf)));
     if (use_striper) {
       if (offset == 0)
 	ret = striper.write_full(oid, indata);


### PR DESCRIPTION
indata.append(char*, len) causes buffer "buf" to be physically copied
to new memory block. Make static buffer pointing to buf so we don't need
any intermediate copies. This reduces memory usage by op_size, and also
cpu usage by a bit (no memmove necessary).

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>