### PR TITLE
debian: package librgw_file* tests

### DIFF
--- a/debian/ceph-test.install
+++ b/debian/ceph-test.install
@@ -25,5 +25,6 @@ usr/bin/ceph_xattr_bench
 usr/bin/ceph-monstore-tool
 usr/bin/ceph-osdomap-tool
 usr/bin/ceph-kvstore-tool
+usr/bin/librgw_file*
 usr/share/java/libcephfs-test.jar
 usr/lib/ceph/ceph-monstore-update-crush.sh


### PR DESCRIPTION
The `make install` command installs these files, but the Debian packaging did not include them.