### PR TITLE
doc: add ceph-detect-init(8) source to dist tarball

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -6,6 +6,7 @@ EXTRA_DIST = \
 	man/8/ceph-debugpack.rst	\
 	man/8/ceph-dencoder.rst	\
 	man/8/ceph-deploy.rst	\
+	man/8/ceph-detect-init.rst	\
 	man/8/ceph-disk.rst	\
 	man/8/cephfs.rst	\
 	man/8/ceph-fuse.rst	\


### PR DESCRIPTION
Prior to this commit, the tarball from `make dist` did not include the ceph-detect-init(8) man page rST source.