### PR TITLE
debian/changelog: Remove stray 'v' in version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ceph (v10.0.4) stable; urgency=low
+ceph (10.0.4) stable; urgency=low
 
   * New upstream release 
 


### PR DESCRIPTION
Signed-off-by: Dan Mick <dan.mick@redhat.com>
(cherry picked from commit 0f7730c8f444657d4aaffa28c12bbcd602a2e3b8)