### PR TITLE
mon: standardize Ceph removal commands

### DIFF
--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -39,7 +39,7 @@ creation of multiple filesystems use ``ceph fs flag set enable_multiple true``.
 
 ::
 
-    fs remove_data_pool <filesystem name> <pool name/id>
+    fs rm_data_pool <filesystem name> <pool name/id>
 
 
 Daemons

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -537,6 +537,7 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
   cmd_getval(g_ceph_context, cmdmap, "prefix", prefix);
   if (prefix == "auth add" ||
       prefix == "auth del" ||
+      prefix == "auth rm" ||
       prefix == "auth get-or-create" ||
       prefix == "auth get-or-create-key" ||
       prefix == "auth import" ||
@@ -990,7 +991,8 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
 					      get_last_committed() + 1));
     return true;
-  } else if (prefix == "auth del" && !entity_name.empty()) {
+  } else if ((prefix == "auth del" || prefix == "auto rm") &&
+             !entity_name.empty()) {
     KeyServerData::Incremental auth_inc;
     auth_inc.name = entity;
     if (!mon->key_server.contains(auth_inc.name)) {

--- a/src/mon/ConfigKeyService.cc
+++ b/src/mon/ConfigKeyService.cc
@@ -160,7 +160,8 @@ bool ConfigKeyService::service_dispatch(MonOpRequestRef op)
     // return for now; we'll put the message once it's done.
     return true;
 
-  } else if (prefix == "config-key del") {
+  } else if (prefix == "config-key del" ||
+             prefix == "config-key rm") {
     if (!mon->is_leader()) {
       mon->forward_request_leader(op);
       return true;

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2926,5 +2926,7 @@ MDSMonitor::MDSMonitor(Monitor *mn, Paxos *p, string service_name)
   handlers.push_back(std::make_shared<RemoveDataPoolHandler>());
   handlers.push_back(std::make_shared<LegacyHandler<RemoveDataPoolHandler> >(
         "mds remove_data_pool"));
+  handlers.push_back(std::make_shared<LegacyHandler<RemoveDataPoolHandler> >(
+        "mds rm_data_pool"));
 }
 

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1979,7 +1979,7 @@ class RemoveDataPoolHandler : public FileSystemCommandHandler
 {
   public:
   RemoveDataPoolHandler()
-    : FileSystemCommandHandler("fs remove_data_pool")
+    : FileSystemCommandHandler("fs rm_data_pool")
   {}
 
   int handle(

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -412,7 +412,7 @@ COMMAND("fs flag set name=flag_name,type=CephChoices,strings=enable_multiple "
 COMMAND("fs add_data_pool name=fs_name,type=CephString " \
 	"name=pool,type=CephString", \
 	"add data pool <pool>", "mds", "rw", "cli,rest")
-COMMAND("fs remove_data_pool name=fs_name,type=CephString " \
+COMMAND("fs rm_data_pool name=fs_name,type=CephString " \
 	"name=pool,type=CephString", \
 	"remove data pool <pool>", "mds", "rw", "cli,rest")
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -833,6 +833,9 @@ COMMAND("config-key put " \
 COMMAND("config-key del " \
 	"name=key,type=CephString", \
 	"delete <key>", "config-key", "rw", "cli,rest")
+COMMAND("config-key rm " \
+	"name=key,type=CephString", \
+	"rm <key>", "config-key", "rw", "cli,rest")
 COMMAND("config-key exists " \
 	"name=key,type=CephString", \
 	"check for <key>'s existence", "config-key", "r", "cli,rest")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -219,6 +219,10 @@ COMMAND("auth del " \
 	"name=entity,type=CephString", \
 	"delete all caps for <name>", \
 	"auth", "rwx", "cli,rest")
+COMMAND("auth rm " \
+	"name=entity,type=CephString", \
+	"remove all caps for <name>", \
+	"auth", "rwx", "cli,rest")
 
 /*
  * Monitor commands (Monitor.cc)

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -808,6 +808,9 @@ COMMAND("osd tier set-overlay " \
 COMMAND("osd tier remove-overlay " \
 	"name=pool,type=CephPoolname ", \
 	"remove the overlay pool for base pool <pool>", "osd", "rw", "cli,rest")
+COMMAND("osd tier rm-overlay " \
+	"name=pool,type=CephPoolname ", \
+	"remove the overlay pool for base pool <pool>", "osd", "rw", "cli,rest")
 
 COMMAND("osd tier add-cache " \
 	"name=pool,type=CephPoolname " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -367,6 +367,9 @@ COMMAND("mds add_data_pool " \
 COMMAND("mds remove_data_pool " \
 	"name=pool,type=CephString", \
 	"remove data pool <pool>", "mds", "rw", "cli,rest")
+COMMAND("mds rm_data_pool " \
+	"name=pool,type=CephString", \
+	"remove data pool <pool>", "mds", "rw", "cli,rest")
 COMMAND("mds newfs " \
 	"name=metadata,type=CephInt,range=0 " \
 	"name=data,type=CephInt,range=0 " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -792,6 +792,11 @@ COMMAND("osd tier remove " \
 	"name=tierpool,type=CephPoolname",
 	"remove the tier <tierpool> (the second one) from base pool <pool> (the first one)", \
 	"osd", "rw", "cli,rest")
+COMMAND("osd tier rm " \
+	"name=pool,type=CephPoolname " \
+	"name=tierpool,type=CephPoolname",
+	"remove the tier <tierpool> (the second one) from base pool <pool> (the first one)", \
+	"osd", "rw", "cli,rest")
 COMMAND("osd tier cache-mode " \
 	"name=pool,type=CephPoolname " \
 	"name=mode,type=CephChoices,strings=none|writeback|forward|readonly|readforward|readproxy", \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -434,6 +434,9 @@ COMMAND("mon add " \
 COMMAND("mon remove " \
 	"name=name,type=CephString", \
 	"remove monitor named <name>", "mon", "rw", "cli,rest")
+COMMAND("mon rm " \
+	"name=name,type=CephString", \
+	"remove monitor named <name>", "mon", "rw", "cli,rest")
 
 /*
  * OSD commands

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -706,6 +706,12 @@ COMMAND("osd pool delete " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-really-mean-it,req=false", \
 	"delete pool", \
 	"osd", "rw", "cli,rest")
+COMMAND("osd pool rm " \
+	"name=pool,type=CephPoolname " \
+	"name=pool2,type=CephPoolname,req=false " \
+	"name=sure,type=CephChoices,strings=--yes-i-really-really-mean-it,req=false", \
+	"remove pool", \
+	"osd", "rw", "cli,rest")
 COMMAND("osd pool rename " \
 	"name=srcpool,type=CephPoolname " \
 	"name=destpool,type=CephPoolname", \

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -414,7 +414,8 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
     dout(0) << __func__ << " proposing new mon." << name << dendl;
     goto reply;
 
-  } else if (prefix == "mon remove") {
+  } else if (prefix == "mon remove" ||
+             prefix == "mon rm") {
     string name;
     cmd_getval(g_ceph_context, cmdmap, "name", name);
     if (!monmap.contains(name)) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6943,8 +6943,9 @@ done:
 					      get_last_committed() + 1));
     return true;
 
-  } else if (prefix == "osd pool delete") {
-    // osd pool delete <poolname> <poolname again> --yes-i-really-really-mean-it
+  } else if (prefix == "osd pool delete" ||
+             prefix == "osd pool rm") {
+    // osd pool delete/rm <poolname> <poolname again> --yes-i-really-really-mean-it
     string poolstr, poolstr2, sure;
     cmd_getval(g_ceph_context, cmdmap, "pool", poolstr);
     cmd_getval(g_ceph_context, cmdmap, "pool2", poolstr2);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7094,7 +7094,8 @@ done:
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, ss.str(),
 					      get_last_committed() + 1));
     return true;
-  } else if (prefix == "osd tier remove") {
+  } else if (prefix == "osd tier remove" ||
+             prefix == "osd tier rm") {
     string poolstr;
     cmd_getval(g_ceph_context, cmdmap, "pool", poolstr);
     int64_t pool_id = osdmap.lookup_pg_pool_name(poolstr);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7209,7 +7209,8 @@ done:
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, ss.str(),
 					      get_last_committed() + 1));
     return true;
-  } else if (prefix == "osd tier remove-overlay") {
+  } else if (prefix == "osd tier remove-overlay" ||
+             prefix == "osd tier rm-overlay") {
     string poolstr;
     cmd_getval(g_ceph_context, cmdmap, "pool", poolstr);
     int64_t pool_id = osdmap.lookup_pg_pool_name(poolstr);


### PR DESCRIPTION
Many commands do remove/rm/del/delete, and we're sort of random about which verb applies to which command.  This PR make the all behaviour works in "remove" subcommand. For the backforward compatibility, I am keeping the all other subcommands here, just adding a "remove" subcommand as an alias for them.

Fix 14363 & 11385