### PR TITLE
mon: OSDMonitor: improve pool creation logic

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1374,6 +1374,7 @@ function test_mon_pg()
 
   ceph osd primary-affinity osd.0 .9
   expect_false ceph osd primary-affinity osd.0 -2
+  expect_false ceph osd primary-affinity osd.9999 .5
   ceph osd primary-affinity osd.0 1
 
   ceph osd pg-temp 0.0 0 1 2

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1235,6 +1235,7 @@ function test_mon_osd_pool()
   ceph osd pool mksnap data datasnap
   rados -p data lssnap | grep datasnap
   ceph osd pool rmsnap data datasnap
+  expect_false ceph osd pool rmsnap pool_fake snapshot
   ceph osd pool delete data data --yes-i-really-really-mean-it
 
   ceph osd pool create data2 10

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1041,6 +1041,9 @@ function test_mon_osd()
   expect_false "ceph osd blacklist $bl/-1"
   expect_false "ceph osd blacklist $bl/foo"
 
+  # test with wrong address
+  expect_false "ceph osd blacklist 1234.56.78.90/100"
+
   # Test `clear`
   ceph osd blacklist add $bl
   ceph osd blacklist ls | grep $bl

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1694,15 +1694,17 @@ bool OSDMonitor::can_mark_in(int i)
   return true;
 }
 
-void OSDMonitor::check_failures(utime_t now)
+bool OSDMonitor::check_failures(utime_t now)
 {
+  bool found_failure = false;
   for (map<int,failure_info_t>::iterator p = failure_info.begin();
        p != failure_info.end();
        ++p) {
     if (can_mark_down(p->first)) {
-      check_failure(now, p->first, p->second);
+      found_failure |= check_failure(now, p->first, p->second);
     }
   }
+  return found_failure;
 }
 
 bool OSDMonitor::check_failure(utime_t now, int target_osd, failure_info_t& fi)
@@ -2666,7 +2668,8 @@ void OSDMonitor::tick()
   utime_t now = ceph_clock_now(g_ceph_context);
 
   // mark osds down?
-  check_failures(now);
+  if (check_failures(now))
+    do_propose = true;
 
   // mark down osds out?
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2414,6 +2414,12 @@ bool OSDMonitor::prepare_remove_snaps(MonOpRequestRef op)
   for (map<int, vector<snapid_t> >::iterator p = m->snaps.begin();
        p != m->snaps.end();
        ++p) {
+
+    if (!osdmap.have_pg_pool(p->first)) {
+      dout(10) << " ignoring removed_snaps " << p->second << " on non-existent pool " << p->first << dendl;
+      continue;
+    }
+
     pg_pool_t& pi = osdmap.pools[p->first];
     for (vector<snapid_t>::iterator q = p->second.begin();
 	 q != p->second.end();

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5702,6 +5702,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     if (!newcrush.name_exists(name)) {
       err = -ENOENT;
       ss << "item " << name << " does not exist";
+      goto reply;
     } else {
       int id = newcrush.get_item_id(name);
       if (!newcrush.check_item_loc(g_ceph_context, id, loc, (int *)NULL)) {
@@ -5714,6 +5715,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 	} else {
 	  ss << "cannot link item id " << id << " name '" << name
              << "' to location " << loc;
+          goto reply;
 	}
       } else {
 	ss << "no need to move item id " << id << " name '" << name

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5268,14 +5268,17 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
     }
     p.min_write_recency_for_promote = n;
   } else if (var == "fast_read") {
-    if (val == "true" || (interr.empty() && n == 1)) {
-      if (p.is_replicated()) {
+    if (p.is_replicated()) {
         ss << "fast read is not supported in replication pool";
         return -EINVAL;
-      }
+    }
+    if (val == "true" || (interr.empty() && n == 1)) {
       p.fast_read = true;
     } else if (val == "false" || (interr.empty() && n == 0)) {
       p.fast_read = false;
+    } else {
+      ss << "expecting value 'true', 'false', '0', or '1'";
+      return -EINVAL;
     }
   } else if (pool_opts_t::is_opt_name(var)) {
     pool_opts_t::opt_desc_t desc = pool_opts_t::get_opt_desc(var);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6732,8 +6732,11 @@ done:
     string addrstr;
     cmd_getval(g_ceph_context, cmdmap, "addr", addrstr);
     entity_addr_t addr;
-    if (!addr.parse(addrstr.c_str(), 0))
+    if (!addr.parse(addrstr.c_str(), 0)) {
       ss << "unable to parse address " << addrstr;
+      err = -EINVAL;
+      goto reply;
+    }
     else {
       string blacklistop;
       cmd_getval(g_ceph_context, cmdmap, "blacklistop", blacklistop);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -708,7 +708,7 @@ public:
 
 protected:
   void dump_stray(F *f) {
-    for (int i = 0; i <= osdmap->get_max_osd(); i++) {
+    for (int i = 0; i < osdmap->get_max_osd(); i++) {
       if (osdmap->exists(i) && !this->is_touched(i))
 	dump_item(CrushTreeDumper::Item(i, 0, 0), f);
     }
@@ -760,7 +760,7 @@ protected:
 
   double average_utilization() {
     int64_t kb = 0, kb_used = 0;
-    for (int i = 0; i <= osdmap->get_max_osd(); i++) {
+    for (int i = 0; i < osdmap->get_max_osd(); i++) {
       if (!osdmap->exists(i) || osdmap->get_weight(i) == 0)
 	continue;
       int64_t kb_i, kb_used_i, kb_avail_i;
@@ -1263,7 +1263,7 @@ void OSDMonitor::print_nodes(Formatter *f)
 {
   // group OSDs by their hosts
   map<string, list<int> > osds; // hostname => osd
-  for (int osd = 0; osd <= osdmap.get_max_osd(); osd++) {
+  for (int osd = 0; osd < osdmap.get_max_osd(); osd++) {
     map<string, string> m;
     if (load_metadata(osd, m, NULL)) {
       continue;
@@ -6227,7 +6227,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       // Check if the OSDs exist between current max and new value.
       // If there are any OSDs exist, then don't allow shrinking number
       // of OSDs.
-      for (int i = newmax; i <= osdmap.get_max_osd(); i++) {
+      for (int i = newmax; i < osdmap.get_max_osd(); i++) {
         if (osdmap.exists(i)) {
           err = -EBUSY;
           ss << "cannot shrink max_osd to " << newmax

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4999,7 +4999,7 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
 	 k = erasure_code->get_data_chunk_count();
        } else {
 	 ss << __func__ << " get_erasure_code failed: " << tmp.rdbuf();
-	 return err;;
+	 return err;
        }
 
        if (n < k || n > p.size) {
@@ -7653,12 +7653,12 @@ bool OSDMonitor::preprocess_pool_op(MonOpRequestRef op)
     return preprocess_pool_op_create(op);
 
   if (!osdmap.get_pg_pool(m->pool)) {
-    dout(10) << "attempt to delete non-existent pool id " << m->pool << dendl;
+    dout(10) << "attempt to operate on non-existent pool id " << m->pool << dendl;
     _pool_op_reply(op, 0, osdmap.get_epoch());
     return true;
   }
 
-  // check if the snap and snapname exists
+  // check if the snap and snapname exist
   bool snap_exists = false;
   const pg_pool_t *p = osdmap.get_pg_pool(m->pool);
   if (p->snap_exists(m->name.c_str()))

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5180,6 +5180,11 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
   } else if (var == "debug_fake_ec_pool") {
     if (val == "true" || (interr.empty() && n == 1)) {
       p.flags |= pg_pool_t::FLAG_DEBUG_FAKE_EC_POOL;
+    } else if (val == "false" || (interr.empty() && n == 0)) {
+      p.flags &= ~pg_pool_t::FLAG_DEBUG_FAKE_EC_POOL;
+    } else {
+      ss << "expecting value 'true', 'false', '0', or '1'";
+      return -EINVAL;
     }
   } else if (var == "target_max_objects") {
     if (interr.length()) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3054,7 +3054,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 
   MonSession *session = m->get_session();
   if (!session) {
-    mon->reply_command(op, -EACCES, "access denied", rdata, get_last_committed());
+    mon->reply_command(op, -EACCES, "access denied", get_last_committed());
     return true;
   }
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7643,6 +7643,8 @@ done:
     ss << "will thrash map for " << thrash_map << " epochs";
     ret = thrash();
     err = 0;
+    if (ret)
+      goto update;
   } else {
     err = -EINVAL;
   }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6546,6 +6546,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
                                                 get_last_committed() + 1));
       return true;
+    } else {
+      ss << "osd." << id << " does not exist";
+      err = -ENOENT;
+      goto reply;
     }
   } else if (prefix == "osd reweight") {
     int64_t id;
@@ -6575,8 +6579,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
 						get_last_committed() + 1));
       return true;
+    } else {
+      ss << "osd." << id << " does not exist";
+      err = -ENOENT;
+      goto reply;
     }
-
   } else if (prefix == "osd lost") {
     int64_t id;
     if (!cmd_getval(g_ceph_context, cmdmap, "id", id)) {

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -134,7 +134,7 @@ private:
   SimpleLRU<version_t, bufferlist> inc_osd_cache;
   SimpleLRU<version_t, bufferlist> full_osd_cache;
 
-  void check_failures(utime_t now);
+  bool check_failures(utime_t now);
   bool check_failure(utime_t now, int target_osd, failure_info_t& fi);
 
   // map thrashing

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2494,7 +2494,7 @@ public:
 
     Parent::dump(tbl);
 
-    for (int i = 0; i <= osdmap->get_max_osd(); i++) {
+    for (int i = 0; i < osdmap->get_max_osd(); i++) {
       if (osdmap->exists(i) && !is_touched(i))
 	dump_item(CrushTreeDumper::Item(i, 0, 0), tbl);
     }
@@ -2546,7 +2546,7 @@ public:
     Parent::dump(f);
     f->close_section();
     f->open_array_section("stray");
-    for (int i = 0; i <= osdmap->get_max_osd(); i++) {
+    for (int i = 0; i < osdmap->get_max_osd(); i++) {
       if (osdmap->exists(i) && !is_touched(i))
 	dump_item(CrushTreeDumper::Item(i, 0, 0), f);
     }


### PR DESCRIPTION
This pr consists of two changes:

    The first one is that we move sanity-check for fast_read option of erasure coding
    pool ahead, so we don't dirty pending_inc map and thus can make a clean exit 
    on failure.

    The second one is that we move sanity-check for duplicated request of pool-create
    ahead,  this is safe because we only update new_pool_names[] field of penging_inc
    map at the end of creation, which undoubtedly reflects that the creation is a success.

    The first one shall be considered as a bug-fix while the second one is a cleanup, 
    which is proposed for the sake of efficiency.
