### PR TITLE
msg: remove duplicated code - local_delivery will now call 'enqueue'

### DIFF
--- a/src/msg/simple/DispatchQueue.cc
+++ b/src/msg/simple/DispatchQueue.cc
@@ -123,16 +123,7 @@ void DispatchQueue::run_local_delivery()
     if (can_fast_dispatch(m)) {
       fast_dispatch(m);
     } else {
-      Mutex::Locker l(lock);
-      add_arrival(m);
-      if (priority >= CEPH_MSG_PRIO_LOW) {
-        mqueue.enqueue_strict(
-            0, priority, QueueItem(m));
-      } else {
-        mqueue.enqueue(
-            0, priority, m->get_cost(), QueueItem(m));
-      }
-      cond.Signal();
+      enqueue(m, priority, 0);
     }
     local_delivery_lock.Lock();
   }


### PR DESCRIPTION
This simplify the code and clarify that for each local message,
 'local_delivery_thread' simply tries to 'fast_dispatch' it,
 or it will 'enqueue' it for the dispatch_thread (like any standard message)

Signed-off-by: Avner BenHanoch <avnerb@mellanox.com>