### PR TITLE
test/bufferlist: Avoid false-positive tests

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -478,7 +478,7 @@ TEST(BufferPtr, constructors) {
     bufferptr ptr(std::move(original));
     EXPECT_TRUE(ptr.have_raw());
     EXPECT_FALSE(original.have_raw());
-    EXPECT_EQ(str.compare(0, str.size(), ptr.c_str(), ptr.length()), 0);
+    EXPECT_EQ(0, ::memcmp(str.c_str(), ptr.c_str(), len));
     EXPECT_EQ(1, ptr.raw_nref());
   }
 }


### PR DESCRIPTION
The current code is using the length of ptr to determine if the string is
correct.

As 'ptr' is a copy of the original 'str', it sounds safer to compare against the
original string size of the consider the actual size of the string : if 'ptr' is
shorter than 'str', the actual code will PASS while 'ptr' is broken.

This patch offer to use the same testing logic as per "ptr(const ptr& p,
unsigned o, unsigned l)" test by using a memcmp against the original string
length.

Signed-off-by: Erwan Velu <erwan@redhat.com>