### PR TITLE
osd: remove unnecessary transaction cleanup

### DIFF
--- a/src/include/object.h
+++ b/src/include/object.h
@@ -89,7 +89,7 @@ namespace std {
 
 struct file_object_t {
   uint64_t ino, bno;
-  mutable char buf[33];
+  mutable char buf[34];
 
   file_object_t(uint64_t i=0, uint64_t b=0) : ino(i), bno(b) {
     buf[0] = 0;
@@ -97,7 +97,7 @@ struct file_object_t {
   
   const char *c_str() const {
     if (!buf[0])
-      sprintf(buf, "%llx.%08llx", (long long unsigned)ino, (long long unsigned)bno);
+      snprintf(buf, sizeof(buf), "%llx.%08llx", (long long unsigned)ino, (long long unsigned)bno);
     return buf;
   }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2008,13 +2008,6 @@ void PG::_activate_committed(epoch_t epoch, epoch_t activation_epoch)
     }
   }
 
-  if (dirty_info) {
-    ObjectStore::Transaction t;
-    write_if_dirty(t);
-    int tr = osd->store->queue_transaction(osr.get(), std::move(t), NULL);
-    assert(tr == 0);
-  }
-
   unlock();
 }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -267,9 +267,6 @@ public:
     _lock.Unlock();
   }
 
-  void assert_locked() {
-    assert(_lock.is_locked());
-  }
   bool is_locked() const {
     return _lock.is_locked();
   }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1087,7 +1087,7 @@ public:
   void proc_primary_info(ObjectStore::Transaction &t, const pg_info_t &info);
 
   bool have_unfound() const { 
-    return missing_loc.num_unfound();
+    return missing_loc.num_unfound() > 0;
   }
   int get_num_unfound() const {
     return missing_loc.num_unfound();


### PR DESCRIPTION
The lock() method will ensure 'dirty_info' will be false,
and within this function's scope I see no possibility to
set 'dirty_info' true. Thus I guess the transaction cleanup
logic before exit is never reachable and therefore shall be
considered as redundant and can be safely removed.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>