### PR TITLE
selinux: Update policy to grant additional access

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -43,7 +43,7 @@ files_pid_file(ceph_var_run_t)
 allow ceph_t self:process { signal_perms };
 allow ceph_t self:fifo_file rw_fifo_file_perms;
 allow ceph_t self:unix_stream_socket create_stream_socket_perms;
-allow ceph_t self:capability { setuid setgid };
+allow ceph_t self:capability { setuid setgid dac_override };
 
 manage_dirs_pattern(ceph_t, ceph_log_t, ceph_log_t)
 manage_files_pattern(ceph_t, ceph_log_t, ceph_log_t)

--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -94,6 +94,7 @@ files_list_tmp(ceph_t)
 fstools_exec(ceph_t)
 nis_use_ypbind_uncond(ceph_t)
 storage_raw_rw_fixed_disk(ceph_t)
+files_manage_generic_locks(ceph_t)
 
 allow ceph_t sysfs_t:dir read;
 allow ceph_t sysfs_t:file { read getattr open };


### PR DESCRIPTION
This adds dac_override capability and ability to manage var_lock_t labelled locks.

EDIT: No need to bump the version and relabel the files as we do not change any context of the files, we just allow additional access.