### PR TITLE
cmake: Remove duplicate find_package libcurl line.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,6 @@ find_package(libuuid REQUIRED)
 
 find_package(libcurl REQUIRED)
 
-find_package(libcurl REQUIRED)
-
 option(USE_CRYPTOPP "Cryptopp is ON" ON)
 find_package(cryptopp)
 if(CRYPTOPP_FOUND)


### PR DESCRIPTION
Can't think of a reason why we would have two identical lines one directly after the other although I claim amateur status where cmake is concerned so please verify.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>