### PR TITLE
config: fix osd_crush_initial_weight

### DIFF
--- a/doc/rados/configuration/pool-pg-config-ref.rst
+++ b/doc/rados/configuration/pool-pg-config-ref.rst
@@ -66,6 +66,16 @@ Ceph configuration file.
 :Default: ``1``. Typically a host containing one or more Ceph OSD Daemons.
 
 
+``osd crush initial weight``
+
+:Description: The initial crush weight for newly added osds into crushmap.
+
+:Type: Double
+:Default: ``the size of newly added osd in TB``. By default, the initial crush
+          weight for the newly added osd is set to its volume size in TB.
+          See `Weighting Bucket Items`_ for details.
+
+
 ``osd pool default crush replicated ruleset`` 
 
 :Description: The default CRUSH ruleset to use when creating a replicated pool.
@@ -164,3 +174,4 @@ Ceph configuration file.
 
 .. _pool: ../../operations/pools
 .. _Monitoring OSDs and PGs: ../../operations/monitoring-osd-pg#peering
+.. _Weighting Bucket Items: ../../operations/crush-map#weightingbucketitems

--- a/doc/rados/operations/crush-map.rst
+++ b/doc/rados/operations/crush-map.rst
@@ -451,6 +451,8 @@ and one rack bucket. The OSDs are declared as items within the host buckets::
    Enter ``0`` as your hash setting to select ``rjenkins1``.
 
 
+.. _weightingbucketitems:
+
 .. topic:: Weighting Bucket Items
 
    Ceph expresses bucket weights as doubles, which allows for fine

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -550,6 +550,8 @@ OPTION(osd_client_message_cap, OPT_U64, 100)              // num client messages
 OPTION(osd_pg_bits, OPT_INT, 6)  // bits per osd
 OPTION(osd_pgp_bits, OPT_INT, 6)  // bits per osd
 OPTION(osd_crush_chooseleaf_type, OPT_INT, 1) // 1 = host
+// This parameter is not consumed by ceph C code but the upstart scripts.
+// OPTION(osd_crush_initial_weight, OPT_DOUBLE, 0) // the initial weight is for newly added osds.
 OPTION(osd_pool_use_gmt_hitset, OPT_BOOL, true) // try to use gmt for hitset archive names if all osds in cluster support it.
 OPTION(osd_pool_default_crush_rule, OPT_INT, -1) // deprecated for osd_pool_default_crush_replicated_ruleset
 OPTION(osd_pool_default_crush_replicated_ruleset, OPT_INT, CEPH_DEFAULT_CRUSH_REPLICATED_RULESET)


### PR DESCRIPTION
1. Fix missing config osd_crush_initial_weight in config_opts.h.
2. Add related docs for osd_crush_initial_weight.