### PR TITLE
rbd-mirror: remote to local cluster image sync

### DIFF
--- a/src/librados/snap_set_diff.h
+++ b/src/librados/snap_set_diff.h
@@ -11,7 +11,7 @@ class CephContext;
 void calc_snap_set_diff(CephContext *cct,
 			const librados::snap_set_t& snap_set,
 			librados::snap_t start, librados::snap_t end,
-			interval_set<uint64_t> *diff,
+			interval_set<uint64_t> *diff, uint64_t *end_size,
 			bool *end_exists);
 
 #endif

--- a/src/librbd/DiffIterate.cc
+++ b/src/librbd/DiffIterate.cc
@@ -125,9 +125,11 @@ private:
 
     // calc diff from from_snap_id -> to_snap_id
     interval_set<uint64_t> diff;
+    uint64_t end_size;
     bool end_exists;
     calc_snap_set_diff(cct, m_snap_set, m_diff_context.from_snap_id,
-                       m_diff_context.end_snap_id, &diff, &end_exists);
+                       m_diff_context.end_snap_id, &diff, &end_size,
+                       &end_exists);
     ldout(cct, 20) << "  diff " << diff << " end_exists=" << end_exists
                    << dendl;
     if (diff.empty()) {

--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -113,7 +113,7 @@ template <typename I>
 void ExclusiveLock<I>::try_lock(Context *on_tried_lock) {
   {
     Mutex::Locker locker(m_lock);
-    assert(m_image_ctx.owner_lock.is_wlocked());
+    assert(m_image_ctx.owner_lock.is_locked());
     assert(!is_shutdown());
 
     if (m_state != STATE_LOCKED || !m_actions_contexts.empty()) {

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -26,6 +26,7 @@
 #include "librbd/operation/ResizeRequest.h"
 #include "librbd/Utils.h"
 
+#include "osdc/Striper.h"
 #include <boost/bind.hpp>
 
 #define dout_subsys ceph_subsys_rbd
@@ -539,6 +540,12 @@ struct C_InvalidateCache : public Context {
       return info->size;
     }
     return 0;
+  }
+
+  uint64_t ImageCtx::get_object_count(snap_t in_snap_id) const {
+    assert(snap_lock.is_locked());
+    uint64_t image_size = get_image_size(in_snap_id);
+    return Striper::get_num_objects(layout, image_size);
   }
 
   bool ImageCtx::test_features(uint64_t features) const

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -228,6 +228,7 @@ namespace librbd {
                   uint8_t protection_status, uint64_t flags);
     void rm_snap(std::string in_snap_name, librados::snap_t id);
     uint64_t get_image_size(librados::snap_t in_snap_id) const;
+    uint64_t get_object_count(librados::snap_t in_snap_id) const;
     bool test_features(uint64_t test_features) const;
     bool test_features(uint64_t test_features,
                        const RWLock &in_snap_lock) const;

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -656,7 +656,7 @@ bool ImageWatcher::handle_payload(const FlattenPayload &payload,
     if (new_request) {
       ldout(m_image_ctx.cct, 10) << this << " remote flatten request: "
 				 << payload.async_request_id << dendl;
-      m_image_ctx.operations->flatten(*prog_ctx, ctx);
+      m_image_ctx.operations->execute_flatten(*prog_ctx, ctx);
     }
 
     ::encode(ResponseMessage(r), ack_ctx->out);
@@ -678,7 +678,7 @@ bool ImageWatcher::handle_payload(const ResizePayload &payload,
       ldout(m_image_ctx.cct, 10) << this << " remote resize request: "
 				 << payload.async_request_id << " "
 				 << payload.size << dendl;
-      m_image_ctx.operations->resize(payload.size, *prog_ctx, ctx, 0);
+      m_image_ctx.operations->execute_resize(payload.size, *prog_ctx, ctx, 0);
     }
 
     ::encode(ResponseMessage(r), ack_ctx->out);
@@ -694,8 +694,9 @@ bool ImageWatcher::handle_payload(const SnapCreatePayload &payload,
     ldout(m_image_ctx.cct, 10) << this << " remote snap_create request: "
 			       << payload.snap_name << dendl;
 
-    m_image_ctx.operations->snap_create(payload.snap_name.c_str(),
-                                        new C_ResponseMessage(ack_ctx), 0);
+    m_image_ctx.operations->execute_snap_create(payload.snap_name.c_str(),
+                                                new C_ResponseMessage(ack_ctx),
+                                                0);
     return false;
   }
   return true;
@@ -710,9 +711,9 @@ bool ImageWatcher::handle_payload(const SnapRenamePayload &payload,
 			       << payload.snap_id << " to "
 			       << payload.snap_name << dendl;
 
-    m_image_ctx.operations->snap_rename(payload.snap_id,
-                                        payload.snap_name.c_str(),
-                                        new C_ResponseMessage(ack_ctx));
+    m_image_ctx.operations->execute_snap_rename(payload.snap_id,
+                                                payload.snap_name.c_str(),
+                                                new C_ResponseMessage(ack_ctx));
     return false;
   }
   return true;
@@ -726,8 +727,8 @@ bool ImageWatcher::handle_payload(const SnapRemovePayload &payload,
     ldout(m_image_ctx.cct, 10) << this << " remote snap_remove request: "
 			       << payload.snap_name << dendl;
 
-    m_image_ctx.operations->snap_remove(payload.snap_name.c_str(),
-                                        new C_ResponseMessage(ack_ctx));
+    m_image_ctx.operations->execute_snap_remove(payload.snap_name.c_str(),
+                                                new C_ResponseMessage(ack_ctx));
     return false;
   }
   return true;
@@ -741,8 +742,8 @@ bool ImageWatcher::handle_payload(const SnapProtectPayload& payload,
     ldout(m_image_ctx.cct, 10) << this << " remote snap_protect request: "
                                << payload.snap_name << dendl;
 
-    m_image_ctx.operations->snap_protect(payload.snap_name.c_str(),
-                                         new C_ResponseMessage(ack_ctx));
+    m_image_ctx.operations->execute_snap_protect(payload.snap_name.c_str(),
+                                                 new C_ResponseMessage(ack_ctx));
     return false;
   }
   return true;
@@ -756,8 +757,8 @@ bool ImageWatcher::handle_payload(const SnapUnprotectPayload& payload,
     ldout(m_image_ctx.cct, 10) << this << " remote snap_unprotect request: "
                                << payload.snap_name << dendl;
 
-    m_image_ctx.operations->snap_unprotect(payload.snap_name.c_str(),
-                                           new C_ResponseMessage(ack_ctx));
+    m_image_ctx.operations->execute_snap_unprotect(payload.snap_name.c_str(),
+                                                   new C_ResponseMessage(ack_ctx));
     return false;
   }
   return true;
@@ -777,7 +778,7 @@ bool ImageWatcher::handle_payload(const RebuildObjectMapPayload& payload,
       ldout(m_image_ctx.cct, 10) << this
                                  << " remote rebuild object map request: "
                                  << payload.async_request_id << dendl;
-      m_image_ctx.operations->rebuild_object_map(*prog_ctx, ctx);
+      m_image_ctx.operations->execute_rebuild_object_map(*prog_ctx, ctx);
     }
 
     ::encode(ResponseMessage(r), ack_ctx->out);
@@ -793,7 +794,7 @@ bool ImageWatcher::handle_payload(const RenamePayload& payload,
     ldout(m_image_ctx.cct, 10) << this << " remote rename request: "
                                << payload.image_name << dendl;
 
-    m_image_ctx.operations->rename(payload.image_name.c_str(),
+    m_image_ctx.operations->execute_rename(payload.image_name.c_str(),
                                    new C_ResponseMessage(ack_ctx));
     return false;
   }

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -16,6 +16,7 @@
 #include "include/encoding.h"
 #include "include/stringify.h"
 #include "common/errno.h"
+#include "common/WorkQueue.h"
 #include <sstream>
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
@@ -191,7 +192,9 @@ void ImageWatcher::handle_async_complete(const AsyncRequestId &request, int r,
   }
 }
 
-int ImageWatcher::notify_flatten(uint64_t request_id, ProgressContext &prog_ctx) {
+void ImageWatcher::notify_flatten(uint64_t request_id,
+                                  ProgressContext &prog_ctx,
+                                  Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.exclusive_lock &&
          !m_image_ctx.exclusive_lock->is_lock_owner());
@@ -200,11 +203,12 @@ int ImageWatcher::notify_flatten(uint64_t request_id, ProgressContext &prog_ctx)
 
   bufferlist bl;
   ::encode(NotifyMessage(FlattenPayload(async_request_id)), bl);
-  return notify_async_request(async_request_id, std::move(bl), prog_ctx);
+  notify_async_request(async_request_id, std::move(bl), prog_ctx, on_finish);
 }
 
-int ImageWatcher::notify_resize(uint64_t request_id, uint64_t size,
-				ProgressContext &prog_ctx) {
+void ImageWatcher::notify_resize(uint64_t request_id, uint64_t size,
+				 ProgressContext &prog_ctx,
+                                 Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.exclusive_lock &&
          !m_image_ctx.exclusive_lock->is_lock_owner());
@@ -213,61 +217,68 @@ int ImageWatcher::notify_resize(uint64_t request_id, uint64_t size,
 
   bufferlist bl;
   ::encode(NotifyMessage(ResizePayload(size, async_request_id)), bl);
-  return notify_async_request(async_request_id, std::move(bl), prog_ctx);
+  notify_async_request(async_request_id, std::move(bl), prog_ctx, on_finish);
 }
 
-int ImageWatcher::notify_snap_create(const std::string &snap_name) {
+void ImageWatcher::notify_snap_create(const std::string &snap_name,
+                                      Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.exclusive_lock &&
          !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(SnapCreatePayload(snap_name)), bl);
-  return notify_lock_owner(std::move(bl));
+  notify_lock_owner(std::move(bl), on_finish);
 }
 
-int ImageWatcher::notify_snap_rename(const snapid_t &src_snap_id,
-				     const std::string &dst_snap_name) {
+void ImageWatcher::notify_snap_rename(const snapid_t &src_snap_id,
+				      const std::string &dst_snap_name,
+                                      Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.exclusive_lock &&
          !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(SnapRenamePayload(src_snap_id, dst_snap_name)), bl);
-  return notify_lock_owner(std::move(bl));
+  notify_lock_owner(std::move(bl), on_finish);
 }
-int ImageWatcher::notify_snap_remove(const std::string &snap_name) {
+
+void ImageWatcher::notify_snap_remove(const std::string &snap_name,
+                                      Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.exclusive_lock &&
          !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(SnapRemovePayload(snap_name)), bl);
-  return notify_lock_owner(std::move(bl));
+  notify_lock_owner(std::move(bl), on_finish);
 }
 
-int ImageWatcher::notify_snap_protect(const std::string &snap_name) {
+void ImageWatcher::notify_snap_protect(const std::string &snap_name,
+                                       Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.exclusive_lock &&
          !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(SnapProtectPayload(snap_name)), bl);
-  return notify_lock_owner(std::move(bl));
+  notify_lock_owner(std::move(bl), on_finish);
 }
 
-int ImageWatcher::notify_snap_unprotect(const std::string &snap_name) {
+void ImageWatcher::notify_snap_unprotect(const std::string &snap_name,
+                                         Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.exclusive_lock &&
          !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(SnapUnprotectPayload(snap_name)), bl);
-  return notify_lock_owner(std::move(bl));
+  notify_lock_owner(std::move(bl), on_finish);
 }
 
-int ImageWatcher::notify_rebuild_object_map(uint64_t request_id,
-                                            ProgressContext &prog_ctx) {
+void ImageWatcher::notify_rebuild_object_map(uint64_t request_id,
+                                             ProgressContext &prog_ctx,
+                                             Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.exclusive_lock &&
          !m_image_ctx.exclusive_lock->is_lock_owner());
@@ -276,17 +287,18 @@ int ImageWatcher::notify_rebuild_object_map(uint64_t request_id,
 
   bufferlist bl;
   ::encode(NotifyMessage(RebuildObjectMapPayload(async_request_id)), bl);
-  return notify_async_request(async_request_id, std::move(bl), prog_ctx);
+  notify_async_request(async_request_id, std::move(bl), prog_ctx, on_finish);
 }
 
-int ImageWatcher::notify_rename(const std::string &image_name) {
+void ImageWatcher::notify_rename(const std::string &image_name,
+                                 Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.exclusive_lock &&
          !m_image_ctx.exclusive_lock->is_lock_owner());
 
   bufferlist bl;
   ::encode(NotifyMessage(RenamePayload(image_name)), bl);
-  return notify_lock_owner(std::move(bl));
+  notify_lock_owner(std::move(bl), on_finish);
 }
 
 void ImageWatcher::notify_header_update(Context *on_finish) {
@@ -420,17 +432,23 @@ void ImageWatcher::handle_request_lock(int r) {
   }
 }
 
-int ImageWatcher::notify_lock_owner(bufferlist &&bl) {
-  C_SaferCond ctx;
-  notify_lock_owner(std::move(bl), &ctx);
-  return ctx.wait();
-}
-
 void ImageWatcher::notify_lock_owner(bufferlist &&bl, Context *on_finish) {
+  assert(on_finish != nullptr);
   assert(m_image_ctx.owner_lock.is_locked());
   NotifyLockOwner *notify_lock_owner = NotifyLockOwner::create(
     m_image_ctx, m_notifier, std::move(bl), on_finish);
   notify_lock_owner->send();
+}
+
+Context *ImageWatcher::remove_async_request(const AsyncRequestId &id) {
+  RWLock::WLocker async_request_locker(m_async_request_lock);
+  auto it = m_async_requests.find(id);
+  if (it != m_async_requests.end()) {
+    Context *on_complete = it->second.first;
+    m_async_requests.erase(it);
+    return on_complete;
+  }
+  return nullptr;
 }
 
 void ImageWatcher::schedule_async_request_timed_out(const AsyncRequestId &id) {
@@ -444,44 +462,45 @@ void ImageWatcher::schedule_async_request_timed_out(const AsyncRequestId &id) {
 }
 
 void ImageWatcher::async_request_timed_out(const AsyncRequestId &id) {
-  RWLock::RLocker l(m_async_request_lock);
-  std::map<AsyncRequestId, AsyncRequest>::iterator it =
-    m_async_requests.find(id);
-  if (it != m_async_requests.end()) {
-    ldout(m_image_ctx.cct, 10) << this << " request timed-out: " << id << dendl;
-    it->second.first->complete(-ERESTART);
+  Context *on_complete = remove_async_request(id);
+  if (on_complete != nullptr) {
+    ldout(m_image_ctx.cct, 5) << "async request timed out: " << id << dendl;
+    m_image_ctx.op_work_queue->queue(on_complete, -ETIMEDOUT);
   }
 }
 
-int ImageWatcher::notify_async_request(const AsyncRequestId &async_request_id,
-				       bufferlist &&in,
-				       ProgressContext& prog_ctx) {
+void ImageWatcher::notify_async_request(const AsyncRequestId &async_request_id,
+				        bufferlist &&in,
+				        ProgressContext& prog_ctx,
+                                        Context *on_finish) {
+  assert(on_finish != nullptr);
   assert(m_image_ctx.owner_lock.is_locked());
 
   ldout(m_image_ctx.cct, 10) << this << " async request: " << async_request_id
                              << dendl;
 
-  C_SaferCond ctx;
+  Context *on_notify = new FunctionContext([this, async_request_id](int r) {
+    if (r < 0) {
+      // notification failed -- don't expect updates
+      Context *on_complete = remove_async_request(async_request_id);
+      if (on_complete != nullptr) {
+        on_complete->complete(r);
+      }
+    }
+  });
+  Context *on_complete = new FunctionContext(
+    [this, async_request_id, on_finish](int r) {
+      m_task_finisher->cancel(Task(TASK_CODE_ASYNC_REQUEST, async_request_id));
+      on_finish->complete(r);
+    });
 
   {
-    RWLock::WLocker l(m_async_request_lock);
-    m_async_requests[async_request_id] = AsyncRequest(&ctx, &prog_ctx);
+    RWLock::WLocker async_request_locker(m_async_request_lock);
+    m_async_requests[async_request_id] = AsyncRequest(on_complete, &prog_ctx);
   }
-
-  BOOST_SCOPE_EXIT( (&ctx)(async_request_id)(&m_task_finisher)
-                    (&m_async_requests)(&m_async_request_lock) ) {
-    m_task_finisher->cancel(Task(TASK_CODE_ASYNC_REQUEST, async_request_id));
-
-    RWLock::WLocker l(m_async_request_lock);
-    m_async_requests.erase(async_request_id);
-  } BOOST_SCOPE_EXIT_END
 
   schedule_async_request_timed_out(async_request_id);
-  int r = notify_lock_owner(std::move(in));
-  if (r < 0) {
-    return r;
-  }
-  return ctx.wait();
+  notify_lock_owner(std::move(in), on_notify);
 }
 
 int ImageWatcher::prepare_async_request(const AsyncRequestId& async_request_id,
@@ -613,14 +632,12 @@ bool ImageWatcher::handle_payload(const AsyncProgressPayload &payload,
 
 bool ImageWatcher::handle_payload(const AsyncCompletePayload &payload,
                                   C_NotifyAck *ack_ctx) {
-  RWLock::RLocker l(m_async_request_lock);
-  std::map<AsyncRequestId, AsyncRequest>::iterator req_it =
-    m_async_requests.find(payload.async_request_id);
-  if (req_it != m_async_requests.end()) {
+  Context *on_complete = remove_async_request(payload.async_request_id);
+  if (on_complete != nullptr) {
     ldout(m_image_ctx.cct, 10) << this << " request finished: "
                                << payload.async_request_id << "="
 			       << payload.result << dendl;
-    req_it->second.first->complete(payload.result);
+    on_complete->complete(payload.result);
   }
   return true;
 }

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -34,18 +34,20 @@ public:
   void unregister_watch(Context *on_finish);
   void flush(Context *on_finish);
 
-  int notify_flatten(uint64_t request_id, ProgressContext &prog_ctx);
-  int notify_resize(uint64_t request_id, uint64_t size,
-                    ProgressContext &prog_ctx);
-  int notify_snap_create(const std::string &snap_name);
-  int notify_snap_rename(const snapid_t &src_snap_id,
-                         const std::string &dst_snap_name);
-  int notify_snap_remove(const std::string &snap_name);
-  int notify_snap_protect(const std::string &snap_name);
-  int notify_snap_unprotect(const std::string &snap_name);
-  int notify_rebuild_object_map(uint64_t request_id,
-                                ProgressContext &prog_ctx);
-  int notify_rename(const std::string &image_name);
+  void notify_flatten(uint64_t request_id, ProgressContext &prog_ctx,
+                      Context *on_finish);
+  void notify_resize(uint64_t request_id, uint64_t size,
+                     ProgressContext &prog_ctx, Context *on_finish);
+  void notify_snap_create(const std::string &snap_name, Context *on_finish);
+  void notify_snap_rename(const snapid_t &src_snap_id,
+                          const std::string &dst_snap_name,
+                          Context *on_finish);
+  void notify_snap_remove(const std::string &snap_name, Context *on_finish);
+  void notify_snap_protect(const std::string &snap_name, Context *on_finish);
+  void notify_snap_unprotect(const std::string &snap_name, Context *on_finish);
+  void notify_rebuild_object_map(uint64_t request_id,
+                                 ProgressContext &prog_ctx, Context *on_finish);
+  void notify_rename(const std::string &image_name, Context *on_finish);
 
   void notify_acquired_lock();
   void notify_released_lock();
@@ -247,13 +249,14 @@ private:
   void handle_request_lock(int r);
   void schedule_request_lock(bool use_timer, int timer_delay = -1);
 
-  int notify_lock_owner(bufferlist &&bl);
   void notify_lock_owner(bufferlist &&bl, Context *on_finish);
 
+  Context *remove_async_request(const watch_notify::AsyncRequestId &id);
   void schedule_async_request_timed_out(const watch_notify::AsyncRequestId &id);
   void async_request_timed_out(const watch_notify::AsyncRequestId &id);
-  int notify_async_request(const watch_notify::AsyncRequestId &id,
-                           bufferlist &&in, ProgressContext& prog_ctx);
+  void notify_async_request(const watch_notify::AsyncRequestId &id,
+                            bufferlist &&in, ProgressContext& prog_ctx,
+                            Context *on_finish);
 
   void schedule_async_progress(const watch_notify::AsyncRequestId &id,
                                uint64_t offset, uint64_t total);

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -22,38 +22,39 @@ public:
   Operations(ImageCtxT &image_ctx);
 
   int flatten(ProgressContext &prog_ctx);
-  void flatten(ProgressContext &prog_ctx, Context *on_finish);
+  void execute_flatten(ProgressContext &prog_ctx, Context *on_finish);
 
   int rebuild_object_map(ProgressContext &prog_ctx);
-  void rebuild_object_map(ProgressContext &prog_ctx, Context *on_finish);
+  void execute_rebuild_object_map(ProgressContext &prog_ctx,
+                                  Context *on_finish);
 
   int rename(const char *dstname);
-  void rename(const char *dstname, Context *on_finish);
+  void execute_rename(const char *dstname, Context *on_finish);
 
   int resize(uint64_t size, ProgressContext& prog_ctx);
-  void resize(uint64_t size, ProgressContext &prog_ctx, Context *on_finish,
-              uint64_t journal_op_tid);
+  void execute_resize(uint64_t size, ProgressContext &prog_ctx,
+                      Context *on_finish, uint64_t journal_op_tid);
 
   int snap_create(const char *snap_name);
-  void snap_create(const char *snap_name, Context *on_finish,
-                   uint64_t journal_op_tid);
+  void execute_snap_create(const char *snap_name, Context *on_finish,
+                           uint64_t journal_op_tid);
 
   int snap_rollback(const char *snap_name, ProgressContext& prog_ctx);
-  void snap_rollback(const char *snap_name, ProgressContext& prog_ctx,
-                     Context *on_finish);
+  void execute_snap_rollback(const char *snap_name, ProgressContext& prog_ctx,
+                             Context *on_finish);
 
   int snap_remove(const char *snap_name);
-  void snap_remove(const char *snap_name, Context *on_finish);
+  void execute_snap_remove(const char *snap_name, Context *on_finish);
 
   int snap_rename(const char *srcname, const char *dstname);
-  void snap_rename(const uint64_t src_snap_id, const char *dst_name,
-                   Context *on_finish);
+  void execute_snap_rename(const uint64_t src_snap_id, const char *dst_name,
+                           Context *on_finish);
 
   int snap_protect(const char *snap_name);
-  void snap_protect(const char *snap_name, Context *on_finish);
+  void execute_snap_protect(const char *snap_name, Context *on_finish);
 
   int snap_unprotect(const char *snap_name);
-  void snap_unprotect(const char *snap_name, Context *on_finish);
+  void execute_snap_unprotect(const char *snap_name, Context *on_finish);
 
   int prepare_image_update();
 

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -63,8 +63,8 @@ private:
 
   int invoke_async_request(const std::string& request_type,
                            bool permit_snapshot,
-                           const boost::function<void(Context*)>& local_request,
-                           const boost::function<int()>& remote_request);
+                           const boost::function<void(Context*)>& local,
+                           const boost::function<void(Context*)>& remote);
 };
 
 } // namespace librbd

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -36,6 +36,7 @@ public:
                       Context *on_finish, uint64_t journal_op_tid);
 
   int snap_create(const char *snap_name);
+  void snap_create(const char *snap_name, Context *on_finish);
   void execute_snap_create(const char *snap_name, Context *on_finish,
                            uint64_t journal_op_tid);
 
@@ -44,6 +45,7 @@ public:
                              Context *on_finish);
 
   int snap_remove(const char *snap_name);
+  void snap_remove(const char *snap_name, Context *on_finish);
   void execute_snap_remove(const char *snap_name, Context *on_finish);
 
   int snap_rename(const char *srcname, const char *dstname);

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -124,6 +124,12 @@ librados::AioCompletion *create_rados_safe_callback(T *obj) {
     obj, nullptr, &detail::rados_callback<T>);
 }
 
+template <typename T, void(T::*MF)(int)>
+librados::AioCompletion *create_rados_safe_callback(T *obj) {
+  return librados::Rados::aio_create_completion(
+    obj, nullptr, &detail::rados_callback<T, MF>);
+}
+
 template <typename T, Context*(T::*MF)(int*), bool destroy=true>
 librados::AioCompletion *create_rados_safe_callback(T *obj) {
   return librados::Rados::aio_create_completion(

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -39,45 +39,51 @@ struct ExecuteOp : public Context {
   }
 
   void execute(const journal::SnapCreateEvent &_) {
-    image_ctx.operations->snap_create(event.snap_name.c_str(), on_op_complete,
-                                      event.op_tid);
+    image_ctx.operations->execute_snap_create(event.snap_name.c_str(),
+                                              on_op_complete,
+                                              event.op_tid);
   }
 
   void execute(const journal::SnapRemoveEvent &_) {
-    image_ctx.operations->snap_remove(event.snap_name.c_str(), on_op_complete);
+    image_ctx.operations->execute_snap_remove(event.snap_name.c_str(),
+                                              on_op_complete);
   }
 
   void execute(const journal::SnapRenameEvent &_) {
-    image_ctx.operations->snap_rename(event.snap_id, event.snap_name.c_str(),
-                                      on_op_complete);
+    image_ctx.operations->execute_snap_rename(event.snap_id,
+                                              event.snap_name.c_str(),
+                                              on_op_complete);
   }
 
   void execute(const journal::SnapProtectEvent &_) {
-    image_ctx.operations->snap_protect(event.snap_name.c_str(), on_op_complete);
+    image_ctx.operations->execute_snap_protect(event.snap_name.c_str(),
+                                               on_op_complete);
   }
 
   void execute(const journal::SnapUnprotectEvent &_) {
-    image_ctx.operations->snap_unprotect(event.snap_name.c_str(),
-                                         on_op_complete);
+    image_ctx.operations->execute_snap_unprotect(event.snap_name.c_str(),
+                                                 on_op_complete);
   }
 
   void execute(const journal::SnapRollbackEvent &_) {
-    image_ctx.operations->snap_rollback(event.snap_name.c_str(),
-                                        no_op_progress_callback,
-                                        on_op_complete);
+    image_ctx.operations->execute_snap_rollback(event.snap_name.c_str(),
+                                                no_op_progress_callback,
+                                                on_op_complete);
   }
 
   void execute(const journal::RenameEvent &_) {
-    image_ctx.operations->rename(event.image_name.c_str(), on_op_complete);
+    image_ctx.operations->execute_rename(event.image_name.c_str(),
+                                         on_op_complete);
   }
 
   void execute(const journal::ResizeEvent &_) {
-    image_ctx.operations->resize(event.size, no_op_progress_callback,
-                                 on_op_complete, event.op_tid);
+    image_ctx.operations->execute_resize(event.size, no_op_progress_callback,
+                                         on_op_complete, event.op_tid);
   }
 
   void execute(const journal::FlattenEvent &_) {
-    image_ctx.operations->flatten(no_op_progress_callback, on_op_complete);
+    image_ctx.operations->execute_flatten(no_op_progress_callback,
+                                          on_op_complete);
   }
 
   virtual void finish(int r) override {

--- a/src/librbd/journal/Types.cc
+++ b/src/librbd/journal/Types.cc
@@ -356,6 +356,7 @@ void MirrorPeerSyncPoint::dump(Formatter *f) const {
 
 void MirrorPeerClientMeta::encode(bufferlist& bl) const {
   ::encode(image_id, bl);
+  ::encode(sync_object_count, bl);
   ::encode(static_cast<uint32_t>(sync_points.size()), bl);
   for (auto &sync_point : sync_points) {
     sync_point.encode(bl);
@@ -365,6 +366,7 @@ void MirrorPeerClientMeta::encode(bufferlist& bl) const {
 
 void MirrorPeerClientMeta::decode(__u8 version, bufferlist::iterator& it) {
   ::decode(image_id, it);
+  ::decode(sync_object_count, it);
 
   uint32_t sync_point_count;
   ::decode(sync_point_count, it);
@@ -378,6 +380,7 @@ void MirrorPeerClientMeta::decode(__u8 version, bufferlist::iterator& it) {
 
 void MirrorPeerClientMeta::dump(Formatter *f) const {
   f->dump_string("image_id", image_id);
+  f->dump_unsigned("sync_object_count", sync_object_count);
   f->open_array_section("sync_points");
   for (auto &sync_point : sync_points) {
     f->open_object_section("sync_point");
@@ -584,6 +587,7 @@ std::ostream &operator<<(std::ostream &out, const MirrorPeerSyncPoint &sync) {
 
 std::ostream &operator<<(std::ostream &out, const MirrorPeerClientMeta &meta) {
   out << "[image_id=" << meta.image_id << ", "
+      << "sync_object_count=" << meta.sync_object_count << ", "
       << "sync_points=[";
   std::string delimiter;
   for (auto &sync_point : meta.sync_points) {

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -357,8 +357,9 @@ struct MirrorPeerClientMeta {
   static const ClientMetaType TYPE = MIRROR_PEER_CLIENT_META_TYPE;
 
   std::string image_id;
-  SyncPoints sync_points; ///< max two in-use snapshots for sync
-  SnapSeqs snap_seqs;     ///< local to peer snap seq mapping
+  uint64_t sync_object_count = 0; ///< maximum number of objects ever sync'ed
+  SyncPoints sync_points;         ///< max two in-use snapshots for sync
+  SnapSeqs snap_seqs;             ///< local to peer snap seq mapping
 
   MirrorPeerClientMeta() {
   }
@@ -370,6 +371,7 @@ struct MirrorPeerClientMeta {
 
   inline bool operator==(const MirrorPeerClientMeta &meta) const {
     return (image_id == meta.image_id &&
+            sync_object_count == meta.sync_object_count &&
             sync_points == meta.sync_points &&
             snap_seqs == meta.snap_seqs);
   }

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -323,13 +323,20 @@ struct MirrorPeerSyncPoint {
   typedef boost::optional<uint64_t> ObjectNumber;
 
   std::string snap_name;
+  std::string from_snap_name;
   ObjectNumber object_number;
 
-  MirrorPeerSyncPoint() : object_number(boost::none) {
+  MirrorPeerSyncPoint() : MirrorPeerSyncPoint("", "", boost::none) {
   }
   MirrorPeerSyncPoint(const std::string &snap_name,
                       const ObjectNumber &object_number)
-    : snap_name(snap_name), object_number(object_number) {
+    : MirrorPeerSyncPoint(snap_name, "", object_number) {
+  }
+  MirrorPeerSyncPoint(const std::string &snap_name,
+                      const std::string &from_snap_name,
+                      const ObjectNumber &object_number)
+    : snap_name(snap_name), from_snap_name(from_snap_name),
+      object_number(object_number) {
   }
 
   void encode(bufferlist& bl) const;
@@ -435,6 +442,8 @@ struct TagData {
 std::ostream &operator<<(std::ostream &out, const EventType &type);
 std::ostream &operator<<(std::ostream &out, const ClientMetaType &type);
 std::ostream &operator<<(std::ostream &out, const ImageClientMeta &meta);
+std::ostream &operator<<(std::ostream &out, const MirrorPeerSyncPoint &sync);
+std::ostream &operator<<(std::ostream &out, const MirrorPeerClientMeta &meta);
 std::ostream &operator<<(std::ostream &out, const TagData &tag_data);
 
 } // namespace journal

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -339,6 +339,12 @@ struct MirrorPeerSyncPoint {
       object_number(object_number) {
   }
 
+  inline bool operator==(const MirrorPeerSyncPoint &sync) const {
+    return (snap_name == sync.snap_name &&
+            from_snap_name == sync.from_snap_name &&
+            object_number == sync.object_number);
+  }
+
   void encode(bufferlist& bl) const;
   void decode(__u8 version, bufferlist::iterator& it);
   void dump(Formatter *f) const;
@@ -360,6 +366,12 @@ struct MirrorPeerClientMeta {
                        const SyncPoints &sync_points = SyncPoints(),
                        const SnapSeqs &snap_seqs = SnapSeqs())
     : image_id(image_id), sync_points(sync_points), snap_seqs(snap_seqs) {
+  }
+
+  inline bool operator==(const MirrorPeerClientMeta &meta) const {
+    return (image_id == meta.image_id &&
+            sync_points == meta.sync_points &&
+            snap_seqs == meta.snap_seqs);
   }
 
   void encode(bufferlist& bl) const;

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -339,17 +339,20 @@ struct MirrorPeerSyncPoint {
 
 struct MirrorPeerClientMeta {
   typedef std::list<MirrorPeerSyncPoint> SyncPoints;
+  typedef std::map<uint64_t, uint64_t> SnapSeqs;
 
   static const ClientMetaType TYPE = MIRROR_PEER_CLIENT_META_TYPE;
 
   std::string image_id;
-  SyncPoints sync_points;
+  SyncPoints sync_points; ///< max two in-use snapshots for sync
+  SnapSeqs snap_seqs;     ///< local to peer snap seq mapping
 
   MirrorPeerClientMeta() {
   }
   MirrorPeerClientMeta(const std::string &image_id,
-                       const SyncPoints &sync_points = SyncPoints())
-    : image_id(image_id), sync_points(sync_points) {
+                       const SyncPoints &sync_points = SyncPoints(),
+                       const SnapSeqs &snap_seqs = SnapSeqs())
+    : image_id(image_id), sync_points(sync_points), snap_seqs(snap_seqs) {
   }
 
   void encode(bufferlist& bl) const;

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -442,6 +442,7 @@ librbd_mirror_test_la_SOURCES = \
 	test/rbd_mirror/test_ClusterWatcher.cc \
 	test/rbd_mirror/test_PoolWatcher.cc \
 	test/rbd_mirror/test_ImageReplayer.cc \
+	test/rbd_mirror/test_ImageSync.cc \
 	test/rbd_mirror/test_fixture.cc
 
 noinst_HEADERS += \
@@ -455,6 +456,7 @@ noinst_LTLIBRARIES += librbd_mirror_test.la
 unittest_rbd_mirror_SOURCES = \
 	test/rbd_mirror/test_main.cc \
 	test/rbd_mirror/test_mock_fixture.cc \
+	test/rbd_mirror/test_mock_ImageSync.cc \
 	test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc \
 	test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc \
 	test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc \

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -441,12 +441,20 @@ noinst_HEADERS += \
 librbd_mirror_test_la_SOURCES = \
 	test/rbd_mirror/test_ClusterWatcher.cc \
 	test/rbd_mirror/test_PoolWatcher.cc \
-	test/rbd_mirror/test_ImageReplayer.cc
+	test/rbd_mirror/test_ImageReplayer.cc \
+	test/rbd_mirror/test_fixture.cc \
+	test/rbd_mirror/test_mock_fixture.cc
+
+noinst_HEADERS += \
+	test/rbd_mirror/test_fixture.h \
+	test/rbd_mirror/test_mock_fixture.h
+
 librbd_mirror_test_la_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 noinst_LTLIBRARIES += librbd_mirror_test.la
 
 unittest_rbd_mirror_SOURCES = \
-	test/rbd_mirror/test_main.cc
+	test/rbd_mirror/test_main.cc \
+	test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
 unittest_rbd_mirror_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_rbd_mirror_LDADD = \
 	librbd_mirror_test.la \

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -442,20 +442,24 @@ librbd_mirror_test_la_SOURCES = \
 	test/rbd_mirror/test_ClusterWatcher.cc \
 	test/rbd_mirror/test_PoolWatcher.cc \
 	test/rbd_mirror/test_ImageReplayer.cc \
-	test/rbd_mirror/test_fixture.cc \
-	test/rbd_mirror/test_mock_fixture.cc
+	test/rbd_mirror/test_fixture.cc
 
 noinst_HEADERS += \
 	test/rbd_mirror/test_fixture.h \
-	test/rbd_mirror/test_mock_fixture.h
+	test/rbd_mirror/test_mock_fixture.h \
+	test/rbd_mirror/mock/MockJournaler.h
 
 librbd_mirror_test_la_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 noinst_LTLIBRARIES += librbd_mirror_test.la
 
 unittest_rbd_mirror_SOURCES = \
 	test/rbd_mirror/test_main.cc \
+	test/rbd_mirror/test_mock_fixture.cc \
 	test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc \
-	test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
+	test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc \
+	test/rbd_mirror/image_sync/test_mock_SyncPointCreateRequest.cc \
+	test/rbd_mirror/image_sync/test_mock_SyncPointPruneRequest.cc \
+	test/rbd_mirror/mock/MockJournaler.cc
 unittest_rbd_mirror_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_rbd_mirror_LDADD = \
 	librbd_mirror_test.la \

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -454,7 +454,8 @@ noinst_LTLIBRARIES += librbd_mirror_test.la
 
 unittest_rbd_mirror_SOURCES = \
 	test/rbd_mirror/test_main.cc \
-	test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
+	test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc \
+	test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
 unittest_rbd_mirror_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_rbd_mirror_LDADD = \
 	librbd_mirror_test.la \

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -455,6 +455,7 @@ noinst_LTLIBRARIES += librbd_mirror_test.la
 unittest_rbd_mirror_SOURCES = \
 	test/rbd_mirror/test_main.cc \
 	test/rbd_mirror/test_mock_fixture.cc \
+	test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc \
 	test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc \
 	test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc \
 	test/rbd_mirror/image_sync/test_mock_SyncPointCreateRequest.cc \

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -66,6 +66,16 @@ void do_out_buffer(string& outbl, char **outbuf, size_t *outbuflen) {
 
 } // anonymous namespace
 
+namespace librados {
+
+MockTestMemIoCtxImpl &get_mock_io_ctx(IoCtx &ioctx) {
+  MockTestMemIoCtxImpl **mock =
+    reinterpret_cast<MockTestMemIoCtxImpl **>(&ioctx);
+  return **mock;
+}
+
+}
+
 namespace librados_test_stub {
 
 TestRadosClientPtr *rados_client() {

--- a/src/test/librados_test_stub/LibradosTestStub.h
+++ b/src/test/librados_test_stub/LibradosTestStub.h
@@ -7,7 +7,11 @@
 #include <boost/shared_ptr.hpp>
 
 namespace librados {
+class IoCtx;
 class TestRadosClient;
+class MockTestMemIoCtxImpl;
+
+MockTestMemIoCtxImpl &get_mock_io_ctx(IoCtx &ioctx);
 }
 
 namespace librados_test_stub {

--- a/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
@@ -48,6 +48,11 @@ public:
                                   snapc);
   }
 
+  MOCK_METHOD2(list_snaps, int(const std::string& o, snap_set_t *out_snaps));
+  int do_list_snaps(const std::string& o, snap_set_t *out_snaps) {
+    return TestMemIoCtxImpl::list_snaps(o, out_snaps);
+  }
+
   MOCK_METHOD2(list_watchers, int(const std::string& o,
                                   std::list<obj_watch_t> *out_watchers));
   int do_list_watchers(const std::string& o,
@@ -64,9 +69,9 @@ public:
     return TestMemIoCtxImpl::read(oid, len, off, bl);
   }
 
-  MOCK_METHOD1(remove, int(const std::string& oid));
-  int do_remove(const std::string& oid) {
-    return TestMemIoCtxImpl::remove(oid);
+  MOCK_METHOD2(remove, int(const std::string& oid, const SnapContext &snapc));
+  int do_remove(const std::string& oid, const SnapContext &snapc) {
+    return TestMemIoCtxImpl::remove(oid, snapc);
   }
 
   MOCK_METHOD1(selfmanaged_snap_create, int(uint64_t *snap_id));
@@ -112,9 +117,10 @@ public:
     using namespace ::testing;
 
     ON_CALL(*this, exec(_, _, _, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_exec));
+    ON_CALL(*this, list_snaps(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_list_snaps));
     ON_CALL(*this, list_watchers(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_list_watchers));
     ON_CALL(*this, read(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_read));
-    ON_CALL(*this, remove(_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_remove));
+    ON_CALL(*this, remove(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_remove));
     ON_CALL(*this, selfmanaged_snap_create(_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_selfmanaged_snap_create));
     ON_CALL(*this, selfmanaged_snap_remove(_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_selfmanaged_snap_remove));
     ON_CALL(*this, selfmanaged_snap_rollback(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_selfmanaged_snap_rollback));

--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -114,7 +114,7 @@ public:
                            bufferlist *pbl);
   virtual int read(const std::string& oid, size_t len, uint64_t off,
                    bufferlist *bl) = 0;
-  virtual int remove(const std::string& oid) = 0;
+  virtual int remove(const std::string& oid, const SnapContext &snapc) = 0;
   virtual int selfmanaged_snap_create(uint64_t *snapid) = 0;
   virtual int selfmanaged_snap_remove(uint64_t snapid) = 0;
   virtual int selfmanaged_snap_rollback(const std::string& oid,

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.h
@@ -38,7 +38,7 @@ public:
                        bufferlist> &map);
   virtual int read(const std::string& oid, size_t len, uint64_t off,
                    bufferlist *bl);
-  virtual int remove(const std::string& oid);
+  virtual int remove(const std::string& oid, const SnapContext &snapc);
   virtual int selfmanaged_snap_create(uint64_t *snapid);
   virtual int selfmanaged_snap_remove(uint64_t snapid);
   virtual int selfmanaged_snap_rollback(const std::string& oid,

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -124,21 +124,21 @@ public:
   }
 
   void expect_flatten(MockReplayImageCtx &mock_image_ctx, Context **on_finish) {
-    EXPECT_CALL(*mock_image_ctx.operations, flatten(_, _))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_flatten(_, _))
                   .WillOnce(DoAll(SaveArg<1>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }
 
   void expect_rename(MockReplayImageCtx &mock_image_ctx, Context **on_finish,
                      const char *image_name) {
-    EXPECT_CALL(*mock_image_ctx.operations, rename(CStrEq(image_name), _))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_rename(CStrEq(image_name), _))
                   .WillOnce(DoAll(SaveArg<1>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }
 
   void expect_resize(MockReplayImageCtx &mock_image_ctx, Context **on_finish,
                      uint64_t size, uint64_t op_tid) {
-    EXPECT_CALL(*mock_image_ctx.operations, resize(size, _, _, op_tid))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_resize(size, _, _, op_tid))
                   .WillOnce(DoAll(SaveArg<2>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }
@@ -146,15 +146,15 @@ public:
   void expect_snap_create(MockReplayImageCtx &mock_image_ctx,
                           Context **on_finish, const char *snap_name,
                           uint64_t op_tid) {
-    EXPECT_CALL(*mock_image_ctx.operations, snap_create(CStrEq(snap_name), _,
-                                                        op_tid))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_create(CStrEq(snap_name), _,
+                                                                op_tid))
                   .WillOnce(DoAll(SaveArg<1>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }
 
   void expect_snap_remove(MockReplayImageCtx &mock_image_ctx,
                           Context **on_finish, const char *snap_name) {
-    EXPECT_CALL(*mock_image_ctx.operations, snap_remove(CStrEq(snap_name), _))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_remove(CStrEq(snap_name), _))
                   .WillOnce(DoAll(SaveArg<1>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }
@@ -162,28 +162,28 @@ public:
   void expect_snap_rename(MockReplayImageCtx &mock_image_ctx,
                           Context **on_finish, uint64_t snap_id,
                           const char *snap_name) {
-    EXPECT_CALL(*mock_image_ctx.operations, snap_rename(snap_id, CStrEq(snap_name), _))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_rename(snap_id, CStrEq(snap_name), _))
                   .WillOnce(DoAll(SaveArg<2>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }
 
   void expect_snap_protect(MockReplayImageCtx &mock_image_ctx,
                            Context **on_finish, const char *snap_name) {
-    EXPECT_CALL(*mock_image_ctx.operations, snap_protect(CStrEq(snap_name), _))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_protect(CStrEq(snap_name), _))
                   .WillOnce(DoAll(SaveArg<1>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }
 
   void expect_snap_unprotect(MockReplayImageCtx &mock_image_ctx,
                              Context **on_finish, const char *snap_name) {
-    EXPECT_CALL(*mock_image_ctx.operations, snap_unprotect(CStrEq(snap_name), _))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_unprotect(CStrEq(snap_name), _))
                   .WillOnce(DoAll(SaveArg<1>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }
 
   void expect_snap_rollback(MockReplayImageCtx &mock_image_ctx,
                             Context **on_finish, const char *snap_name) {
-    EXPECT_CALL(*mock_image_ctx.operations, snap_rollback(CStrEq(snap_name), _, _))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_rollback(CStrEq(snap_name), _, _))
                   .WillOnce(DoAll(SaveArg<2>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }

--- a/src/test/librbd/mock/MockAioImageRequestWQ.h
+++ b/src/test/librbd/mock/MockAioImageRequestWQ.h
@@ -6,6 +6,8 @@
 
 #include "gmock/gmock.h"
 
+class Context;
+
 namespace librbd {
 
 struct MockAioImageRequestWQ {

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -113,6 +113,7 @@ struct MockImageCtx {
   MOCK_CONST_METHOD1(get_object_name, std::string(uint64_t));
   MOCK_CONST_METHOD0(get_current_size, uint64_t());
   MOCK_CONST_METHOD1(get_image_size, uint64_t(librados::snap_t));
+  MOCK_CONST_METHOD1(get_object_count, uint64_t(librados::snap_t));
   MOCK_CONST_METHOD1(get_snap_id, librados::snap_t(std::string in_snap_name));
   MOCK_CONST_METHOD1(get_snap_info, const SnapInfo*(librados::snap_t));
   MOCK_CONST_METHOD2(get_parent_spec, int(librados::snap_t in_snap_id,

--- a/src/test/librbd/mock/MockObjectMap.h
+++ b/src/test/librbd/mock/MockObjectMap.h
@@ -17,7 +17,10 @@ struct MockObjectMap {
 
   MOCK_METHOD3(aio_resize, void(uint64_t new_size, uint8_t default_object_state,
                                 Context *on_finish));
-
+  MOCK_METHOD6(aio_update, void(uint64_t snap_id, uint64_t start_object_no,
+                                uint64_t end_object_no, uint8_t new_state,
+                                const boost::optional<uint8_t> &current_state,
+                                Context *on_finish));
   MOCK_METHOD2(snapshot_add, void(uint64_t snap_id, Context *on_finish));
   MOCK_METHOD2(snapshot_remove, void(uint64_t snap_id, Context *on_finish));
   MOCK_METHOD2(rollback, void(uint64_t snap_id, Context *on_finish));

--- a/src/test/librbd/mock/MockObjectMap.h
+++ b/src/test/librbd/mock/MockObjectMap.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_TEST_LIBRBD_MOCK_OBJECT_MAP_H
 #define CEPH_TEST_LIBRBD_MOCK_OBJECT_MAP_H
 
+#include "common/RWLock.h"
 #include "gmock/gmock.h"
 
 namespace librbd {

--- a/src/test/librbd/mock/MockOperations.h
+++ b/src/test/librbd/mock/MockOperations.h
@@ -12,22 +12,29 @@ class Context;
 namespace librbd {
 
 struct MockOperations {
-  MOCK_METHOD2(flatten, void(ProgressContext &prog_ctx, Context *on_finish));
-  MOCK_METHOD2(rebuild_object_map, void(ProgressContext &prog_ctx,
-                                        Context *on_finish));
-  MOCK_METHOD2(rename, void(const char *dstname, Context *on_finish));
-  MOCK_METHOD4(resize, void(uint64_t size, ProgressContext &prog_ctx,
-                            Context *on_finish, uint64_t journal_op_tid));
-  MOCK_METHOD3(snap_create, void(const char *snap_name, Context *on_finish,
-                                 uint64_t journal_op_tid));
-  MOCK_METHOD2(snap_remove, void(const char *snap_name, Context *on_finish));
-  MOCK_METHOD3(snap_rename, void(uint64_t src_snap_id, const char *snap_name,
-                                 Context *on_finish));
-  MOCK_METHOD3(snap_rollback, void(const char *snap_name,
-                                   ProgressContext &prog_ctx,
-                                   Context *on_finish));
-  MOCK_METHOD2(snap_protect, void(const char *snap_name, Context *on_finish));
-  MOCK_METHOD2(snap_unprotect, void(const char *snap_name, Context *on_finish));
+  MOCK_METHOD2(execute_flatten, void(ProgressContext &prog_ctx,
+                                     Context *on_finish));
+  MOCK_METHOD2(execute_rebuild_object_map, void(ProgressContext &prog_ctx,
+                                                Context *on_finish));
+  MOCK_METHOD2(execute_rename, void(const char *dstname, Context *on_finish));
+  MOCK_METHOD4(execute_resize, void(uint64_t size, ProgressContext &prog_ctx,
+                                    Context *on_finish,
+                                    uint64_t journal_op_tid));
+  MOCK_METHOD3(execute_snap_create, void(const char *snap_name,
+                                         Context *on_finish,
+                                         uint64_t journal_op_tid));
+  MOCK_METHOD2(execute_snap_remove, void(const char *snap_name,
+                                         Context *on_finish));
+  MOCK_METHOD3(execute_snap_rename, void(uint64_t src_snap_id,
+                                         const char *snap_name,
+                                         Context *on_finish));
+  MOCK_METHOD3(execute_snap_rollback, void(const char *snap_name,
+                                           ProgressContext &prog_ctx,
+                                           Context *on_finish));
+  MOCK_METHOD2(execute_snap_protect, void(const char *snap_name,
+                                          Context *on_finish));
+  MOCK_METHOD2(execute_snap_unprotect, void(const char *snap_name,
+                                            Context *on_finish));
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockOperations.h
+++ b/src/test/librbd/mock/MockOperations.h
@@ -20,9 +20,11 @@ struct MockOperations {
   MOCK_METHOD4(execute_resize, void(uint64_t size, ProgressContext &prog_ctx,
                                     Context *on_finish,
                                     uint64_t journal_op_tid));
+  MOCK_METHOD2(snap_create, void(const char *snap_name, Context *on_finish));
   MOCK_METHOD3(execute_snap_create, void(const char *snap_name,
                                          Context *on_finish,
                                          uint64_t journal_op_tid));
+  MOCK_METHOD2(snap_remove, void(const char *snap_name, Context *on_finish));
   MOCK_METHOD2(execute_snap_remove, void(const char *snap_name,
                                          Context *on_finish));
   MOCK_METHOD3(execute_snap_rename, void(uint64_t src_snap_id,

--- a/src/test/librbd/object_map/test_mock_SnapshotRemoveRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotRemoveRequest.cc
@@ -54,10 +54,10 @@ public:
   void expect_remove_map(librbd::ImageCtx *ictx, uint64_t snap_id, int r) {
     std::string snap_oid(ObjectMap::object_map_name(ictx->id, snap_id));
     if (r < 0) {
-      EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx), remove(snap_oid))
+      EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx), remove(snap_oid, _))
                     .WillOnce(Return(r));
     } else {
-      EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx), remove(snap_oid))
+      EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx), remove(snap_oid, _))
                     .WillOnce(DoDefault());
     }
   }

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -257,7 +257,9 @@ struct FlattenTask {
 
   void operator()() {
     RWLock::RLocker l(ictx->owner_lock);
-    result = ictx->image_watcher->notify_flatten(0, *progress_context);
+    C_SaferCond ctx;
+    ictx->image_watcher->notify_flatten(0, *progress_context, &ctx);
+    result = ctx.wait();
   }
 };
 
@@ -271,7 +273,9 @@ struct ResizeTask {
 
   void operator()() {
     RWLock::RLocker l(ictx->owner_lock);
-    result = ictx->image_watcher->notify_resize(0, 0, *progress_context);
+    C_SaferCond ctx;
+    ictx->image_watcher->notify_resize(0, 0, *progress_context, &ctx);
+    result = ctx.wait();
   }
 };
 
@@ -285,7 +289,9 @@ struct RebuildObjectMapTask {
 
   void operator()() {
     RWLock::RLocker l(ictx->owner_lock);
-    result = ictx->image_watcher->notify_rebuild_object_map(0, *progress_context);
+    C_SaferCond ctx;
+    ictx->image_watcher->notify_rebuild_object_map(0, *progress_context, &ctx);
+    result = ctx.wait();
   }
 };
 
@@ -481,7 +487,9 @@ TEST_F(TestImageWatcher, NotifySnapCreate) {
   m_notify_acks = {{NOTIFY_OP_SNAP_CREATE, create_response_message(0)}};
 
   RWLock::RLocker l(ictx->owner_lock);
-  ASSERT_EQ(0, ictx->image_watcher->notify_snap_create("snap"));
+  C_SaferCond notify_ctx;
+  ictx->image_watcher->notify_snap_create("snap", &notify_ctx);
+  ASSERT_EQ(0, notify_ctx.wait());
 
   NotifyOps expected_notify_ops;
   expected_notify_ops += NOTIFY_OP_SNAP_CREATE;
@@ -501,7 +509,9 @@ TEST_F(TestImageWatcher, NotifySnapCreateError) {
   m_notify_acks = {{NOTIFY_OP_SNAP_CREATE, create_response_message(-EEXIST)}};
 
   RWLock::RLocker l(ictx->owner_lock);
-  ASSERT_EQ(-EEXIST, ictx->image_watcher->notify_snap_create("snap"));
+  C_SaferCond notify_ctx;
+  ictx->image_watcher->notify_snap_create("snap", &notify_ctx);
+  ASSERT_EQ(-EEXIST, notify_ctx.wait());
 
   NotifyOps expected_notify_ops;
   expected_notify_ops += NOTIFY_OP_SNAP_CREATE;
@@ -521,7 +531,9 @@ TEST_F(TestImageWatcher, NotifySnapRename) {
   m_notify_acks = {{NOTIFY_OP_SNAP_RENAME, create_response_message(0)}};
 
   RWLock::RLocker l(ictx->owner_lock);
-  ASSERT_EQ(0, ictx->image_watcher->notify_snap_rename(1, "snap-rename"));
+  C_SaferCond notify_ctx;
+  ictx->image_watcher->notify_snap_rename(1, "snap-rename", &notify_ctx);
+  ASSERT_EQ(0, notify_ctx.wait());
 
   NotifyOps expected_notify_ops;
   expected_notify_ops += NOTIFY_OP_SNAP_RENAME;
@@ -541,7 +553,9 @@ TEST_F(TestImageWatcher, NotifySnapRenameError) {
   m_notify_acks = {{NOTIFY_OP_SNAP_RENAME, create_response_message(-EEXIST)}};
 
   RWLock::RLocker l(ictx->owner_lock);
-  ASSERT_EQ(-EEXIST, ictx->image_watcher->notify_snap_rename(1, "snap-rename"));
+  C_SaferCond notify_ctx;
+  ictx->image_watcher->notify_snap_rename(1, "snap-rename", &notify_ctx);
+  ASSERT_EQ(-EEXIST, notify_ctx.wait());
 
   NotifyOps expected_notify_ops;
   expected_notify_ops += NOTIFY_OP_SNAP_RENAME;
@@ -561,7 +575,9 @@ TEST_F(TestImageWatcher, NotifySnapRemove) {
   m_notify_acks = {{NOTIFY_OP_SNAP_REMOVE, create_response_message(0)}};
 
   RWLock::RLocker l(ictx->owner_lock);
-  ASSERT_EQ(0, ictx->image_watcher->notify_snap_remove("snap"));
+  C_SaferCond notify_ctx;
+  ictx->image_watcher->notify_snap_remove("snap", &notify_ctx);
+  ASSERT_EQ(0, notify_ctx.wait());
 
   NotifyOps expected_notify_ops;
   expected_notify_ops += NOTIFY_OP_SNAP_REMOVE;
@@ -581,7 +597,9 @@ TEST_F(TestImageWatcher, NotifySnapProtect) {
   m_notify_acks = {{NOTIFY_OP_SNAP_PROTECT, create_response_message(0)}};
 
   RWLock::RLocker l(ictx->owner_lock);
-  ASSERT_EQ(0, ictx->image_watcher->notify_snap_protect("snap"));
+  C_SaferCond notify_ctx;
+  ictx->image_watcher->notify_snap_protect("snap", &notify_ctx);
+  ASSERT_EQ(0, notify_ctx.wait());
 
   NotifyOps expected_notify_ops;
   expected_notify_ops += NOTIFY_OP_SNAP_PROTECT;
@@ -601,7 +619,9 @@ TEST_F(TestImageWatcher, NotifySnapUnprotect) {
   m_notify_acks = {{NOTIFY_OP_SNAP_UNPROTECT, create_response_message(0)}};
 
   RWLock::RLocker l(ictx->owner_lock);
-  ASSERT_EQ(0, ictx->image_watcher->notify_snap_unprotect("snap"));
+  C_SaferCond notify_ctx;
+  ictx->image_watcher->notify_snap_unprotect("snap", &notify_ctx);
+  ASSERT_EQ(0, notify_ctx.wait());
 
   NotifyOps expected_notify_ops;
   expected_notify_ops += NOTIFY_OP_SNAP_UNPROTECT;
@@ -621,7 +641,9 @@ TEST_F(TestImageWatcher, NotifyRename) {
   m_notify_acks = {{NOTIFY_OP_RENAME, create_response_message(0)}};
 
   RWLock::RLocker l(ictx->owner_lock);
-  ASSERT_EQ(0, ictx->image_watcher->notify_rename("new_name"));
+  C_SaferCond notify_ctx;
+  ictx->image_watcher->notify_rename("new_name", &notify_ctx);
+  ASSERT_EQ(0, notify_ctx.wait());
 
   NotifyOps expected_notify_ops;
   expected_notify_ops += NOTIFY_OP_RENAME;
@@ -720,6 +742,6 @@ TEST_F(TestImageWatcher, NotifyAsyncRequestTimedOut) {
   ASSERT_TRUE(wait_for_notifies(*ictx));
 
   ASSERT_TRUE(thread.timed_join(boost::posix_time::seconds(10)));
-  ASSERT_EQ(-ERESTART, flatten_task.result);
+  ASSERT_EQ(-ETIMEDOUT, flatten_task.result);
 }
 

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -336,7 +336,7 @@ TEST_F(TestInternal, CancelAsyncResize) {
     size -= MIN(size, 1<<18);
     {
       RWLock::RLocker l(ictx->owner_lock);
-      ictx->operations->resize(size, prog_ctx, &ctx, 0);
+      ictx->operations->execute_resize(size, prog_ctx, &ctx, 0);
     }
 
     // try to interrupt the in-progress resize
@@ -384,7 +384,7 @@ TEST_F(TestInternal, MultipleResize) {
 
     RWLock::RLocker l(ictx->owner_lock);
     contexts.push_back(new C_SaferCond());
-    ictx->operations->resize(new_size, prog_ctx, contexts.back(), 0);
+    ictx->operations->execute_resize(new_size, prog_ctx, contexts.back(), 0);
   }
 
   for (uint32_t i = 0; i < contexts.size(); ++i) {

--- a/src/test/librbd/test_mock_fixture.cc
+++ b/src/test/librbd/test_mock_fixture.cc
@@ -68,14 +68,6 @@ void TestMockFixture::expect_op_work_queue(librbd::MockImageCtx &mock_image_ctx)
                   mock_image_ctx.image_ctx->op_work_queue));
 }
 
-librados::MockTestMemIoCtxImpl &TestMockFixture::get_mock_io_ctx(
-    librados::IoCtx &ioctx) {
-  // TODO become friend of IoCtx so that we can cleanly extract io_ctx_impl
-  librados::MockTestMemIoCtxImpl **mock =
-    reinterpret_cast<librados::MockTestMemIoCtxImpl **>(&ioctx);
-  return **mock;
-}
-
 void TestMockFixture::initialize_features(librbd::ImageCtx *ictx,
                                           librbd::MockImageCtx &mock_image_ctx,
                                           librbd::MockExclusiveLock &mock_exclusive_lock,

--- a/src/test/librbd/test_mock_fixture.h
+++ b/src/test/librbd/test_mock_fixture.h
@@ -6,6 +6,7 @@
 
 #include "test/librbd/test_fixture.h"
 #include "test/librbd/mock/MockImageCtx.h"
+#include "test/librados_test_stub/LibradosTestStub.h"
 #include "common/WorkQueue.h"
 #include <boost/shared_ptr.hpp>
 #include <gmock/gmock.h>
@@ -69,7 +70,6 @@ public:
   ::testing::NiceMock<librados::MockTestMemRadosClient> &get_mock_rados_client() {
     return *s_mock_rados_client;
   }
-  librados::MockTestMemIoCtxImpl &get_mock_io_ctx(librados::IoCtx &ioctx);
 
   void expect_op_work_queue(librbd::MockImageCtx &mock_image_ctx);
   void expect_unlock_exclusive_lock(librbd::ImageCtx &ictx);

--- a/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
@@ -152,25 +152,7 @@ public:
                                     &sync_point, ctx);
   }
 
-  int create_snap(librbd::ImageCtx *image_ctx, const char* snap_name,
-                  librados::snap_t *snap_id) {
-    int r = image_ctx->operations->snap_create(snap_name);
-    if (r < 0) {
-      return r;
-    }
-
-    r = image_ctx->state->refresh();
-    if (r < 0) {
-      return r;
-    }
-
-    if (image_ctx->snap_ids.count(snap_name) == 0) {
-      return -ENOENT;
-    }
-    *snap_id = image_ctx->snap_ids[snap_name];
-    return 0;
-  }
-
+  using TestFixture::create_snap;
   int create_snap(const char* snap_name) {
     librados::snap_t remote_snap_id;
     int r = create_snap(m_remote_image_ctx, snap_name, &remote_snap_id);
@@ -344,7 +326,7 @@ TEST_F(TestMockImageSyncImageCopyRequest, RestartCatchup) {
 
 TEST_F(TestMockImageSyncImageCopyRequest, RestartPartialSync) {
   ASSERT_EQ(0, create_snap("snap1"));
-  m_client_meta.sync_points = {{"snap1", 0}};
+  m_client_meta.sync_points = {{"snap1", librbd::journal::MirrorPeerSyncPoint::ObjectNumber{0U}}};
 
   librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
   librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);

--- a/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
@@ -80,14 +80,6 @@ public:
 
     ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
     ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
-
-    m_threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
-      m_local_io_ctx.cct()));
-  }
-
-  virtual void TearDown() {
-    delete m_threads;
-    TestMockFixture::TearDown();
   }
 
   void expect_get_snap_id(librbd::MockImageCtx &mock_image_ctx) {
@@ -182,8 +174,6 @@ public:
   librbd::ImageCtx *m_local_image_ctx;
   librbd::journal::MirrorPeerClientMeta m_client_meta;
   MockImageCopyRequest::SnapMap m_snap_map;
-
-  rbd::mirror::Threads *m_threads = nullptr;
 };
 
 TEST_F(TestMockImageSyncImageCopyRequest, SimpleImage) {

--- a/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
@@ -1,0 +1,479 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "include/rbd/librbd.hpp"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Operations.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/rbd_mirror/mock/MockJournaler.h"
+#include "tools/rbd_mirror/image_sync/ImageCopyRequest.h"
+#include "tools/rbd_mirror/image_sync/ObjectCopyRequest.h"
+#include "tools/rbd_mirror/Threads.h"
+#include <boost/scope_exit.hpp>
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+template <>
+struct ObjectCopyRequest<librbd::MockImageCtx> {
+  static ObjectCopyRequest* s_instance;
+  static ObjectCopyRequest* create(librbd::MockImageCtx *local_image_ctx,
+                                   librbd::MockImageCtx *remote_image_ctx,
+                                   const ImageCopyRequest<librbd::MockImageCtx>::SnapMap *snap_map,
+                                   uint64_t object_number, Context *on_finish) {
+    assert(s_instance != nullptr);
+    Mutex::Locker locker(s_instance->lock);
+    s_instance->snap_map = snap_map;
+    s_instance->object_contexts[object_number] = on_finish;
+    s_instance->cond.Signal();
+    return s_instance;
+  }
+
+  MOCK_METHOD0(send, void());
+
+  Mutex lock;
+  Cond cond;
+
+  const ImageCopyRequest<librbd::MockImageCtx>::SnapMap *snap_map;
+  std::map<uint64_t, Context *> object_contexts;
+
+  ObjectCopyRequest() : lock("lock") {
+    s_instance = this;
+  }
+};
+
+ObjectCopyRequest<librbd::MockImageCtx>* ObjectCopyRequest<librbd::MockImageCtx>::s_instance = nullptr;
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+// template definitions
+#include "tools/rbd_mirror/image_sync/ImageCopyRequest.cc"
+template class rbd::mirror::image_sync::ImageCopyRequest<librbd::MockImageCtx>;
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::WithArg;
+
+class TestMockImageSyncImageCopyRequest : public TestMockFixture {
+public:
+  typedef ImageCopyRequest<librbd::MockImageCtx> MockImageCopyRequest;
+  typedef ObjectCopyRequest<librbd::MockImageCtx> MockObjectCopyRequest;
+
+  virtual void SetUp() {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+
+    ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+
+    m_threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
+      m_local_io_ctx.cct()));
+  }
+
+  virtual void TearDown() {
+    delete m_threads;
+    TestMockFixture::TearDown();
+  }
+
+  void expect_get_snap_id(librbd::MockImageCtx &mock_image_ctx) {
+    EXPECT_CALL(mock_image_ctx, get_snap_id(_))
+      .WillRepeatedly(Invoke([&mock_image_ctx](std::string snap_name) {
+        RWLock::RLocker snap_locker(mock_image_ctx.image_ctx->snap_lock);
+        return mock_image_ctx.image_ctx->get_snap_id(snap_name);
+      }));
+  }
+
+  void expect_get_object_count(librbd::MockImageCtx &mock_image_ctx,
+                               uint64_t count) {
+    EXPECT_CALL(mock_image_ctx, get_object_count(_))
+      .WillOnce(Return(count)).RetiresOnSaturation();
+  }
+
+  void expect_update_client(journal::MockJournaler &mock_journaler, int r) {
+    EXPECT_CALL(mock_journaler, update_client(_, _))
+      .WillOnce(WithArg<1>(CompleteContext(r)));
+  }
+
+  void expect_object_copy_send(MockObjectCopyRequest &mock_object_copy_request) {
+    EXPECT_CALL(mock_object_copy_request, send());
+  }
+
+  bool complete_object_copy(MockObjectCopyRequest &mock_object_copy_request,
+                            uint64_t object_num, int r) {
+    Mutex::Locker locker(mock_object_copy_request.lock);
+    while (mock_object_copy_request.object_contexts.count(object_num) == 0) {
+      if (mock_object_copy_request.cond.WaitInterval(m_local_image_ctx->cct,
+                                                     mock_object_copy_request.lock,
+                                                     utime_t(10, 0)) != 0) {
+        return false;
+      }
+    }
+
+    m_threads->work_queue->queue(mock_object_copy_request.object_contexts[object_num], r);
+    return true;
+  }
+
+  MockImageCopyRequest::SnapMap wait_for_snap_map(MockObjectCopyRequest &mock_object_copy_request) {
+    Mutex::Locker locker(mock_object_copy_request.lock);
+    while (mock_object_copy_request.snap_map == nullptr) {
+      if (mock_object_copy_request.cond.WaitInterval(m_local_image_ctx->cct,
+                                                     mock_object_copy_request.lock,
+                                                     utime_t(10, 0)) != 0) {
+        return MockImageCopyRequest::SnapMap();
+      }
+    }
+    return *mock_object_copy_request.snap_map;
+  }
+
+  MockImageCopyRequest *create_request(librbd::MockImageCtx &mock_remote_image_ctx,
+                                       librbd::MockImageCtx &mock_local_image_ctx,
+                                       journal::MockJournaler &mock_journaler,
+                                       librbd::journal::MirrorPeerSyncPoint &sync_point,
+                                       Context *ctx) {
+    return new MockImageCopyRequest(&mock_local_image_ctx,
+                                    &mock_remote_image_ctx,
+                                    m_threads->timer, &m_threads->timer_lock,
+                                    &mock_journaler, &m_client_meta,
+                                    &sync_point, ctx);
+  }
+
+  int create_snap(librbd::ImageCtx *image_ctx, const char* snap_name,
+                  librados::snap_t *snap_id) {
+    int r = image_ctx->operations->snap_create(snap_name);
+    if (r < 0) {
+      return r;
+    }
+
+    r = image_ctx->state->refresh();
+    if (r < 0) {
+      return r;
+    }
+
+    if (image_ctx->snap_ids.count(snap_name) == 0) {
+      return -ENOENT;
+    }
+    *snap_id = image_ctx->snap_ids[snap_name];
+    return 0;
+  }
+
+  int create_snap(const char* snap_name) {
+    librados::snap_t remote_snap_id;
+    int r = create_snap(m_remote_image_ctx, snap_name, &remote_snap_id);
+    if (r < 0) {
+      return r;
+    }
+
+    librados::snap_t local_snap_id;
+    r = create_snap(m_local_image_ctx, snap_name, &local_snap_id);
+    if (r < 0) {
+      return r;
+    }
+
+    // collection of all existing snaps in local image
+    MockImageCopyRequest::SnapIds local_snap_ids({local_snap_id});
+    if (!m_snap_map.empty()) {
+      local_snap_ids.insert(local_snap_ids.end(),
+                            m_snap_map.rbegin()->second.begin(),
+                            m_snap_map.rbegin()->second.end());
+    }
+    m_snap_map[remote_snap_id] = local_snap_ids;
+    m_client_meta.snap_seqs[remote_snap_id] = local_snap_id;
+    return 0;
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::ImageCtx *m_local_image_ctx;
+  librbd::journal::MirrorPeerClientMeta m_client_meta;
+  MockImageCopyRequest::SnapMap m_snap_map;
+
+  rbd::mirror::Threads *m_threads = nullptr;
+};
+
+TEST_F(TestMockImageSyncImageCopyRequest, SimpleImage) {
+  ASSERT_EQ(0, create_snap("snap1"));
+  m_client_meta.sync_points = {{"snap1", boost::none}};
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+  MockObjectCopyRequest mock_object_copy_request;
+
+  expect_get_snap_id(mock_remote_image_ctx);
+
+  InSequence seq;
+  expect_get_object_count(mock_remote_image_ctx, 1);
+  expect_get_object_count(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+  expect_object_copy_send(mock_object_copy_request);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                 mock_local_image_ctx,
+                                                 mock_journaler,
+                                                 m_client_meta.sync_points.front(),
+                                                 &ctx);
+  request->send();
+
+  ASSERT_EQ(m_snap_map, wait_for_snap_map(mock_object_copy_request));
+  ASSERT_TRUE(complete_object_copy(mock_object_copy_request, 0, 0));
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncImageCopyRequest, Throttled) {
+  ASSERT_EQ(0, create_snap("snap1"));
+  m_client_meta.sync_points = {{"snap1", boost::none}};
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+  MockObjectCopyRequest mock_object_copy_request;
+
+  expect_get_snap_id(mock_remote_image_ctx);
+
+  InSequence seq;
+  expect_get_object_count(mock_remote_image_ctx, 50);
+  expect_get_object_count(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+  for (int i = 0; i < 50; ++i) {
+    expect_object_copy_send(mock_object_copy_request);
+  }
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                 mock_local_image_ctx,
+                                                 mock_journaler,
+                                                 m_client_meta.sync_points.front(),
+                                                 &ctx);
+  request->send();
+
+  ASSERT_EQ(m_snap_map, wait_for_snap_map(mock_object_copy_request));
+  for (uint64_t i = 0; i < 50; ++i) {
+    ASSERT_TRUE(complete_object_copy(mock_object_copy_request, i, 0));
+  }
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncImageCopyRequest, SnapshotSubset) {
+  ASSERT_EQ(0, create_snap("snap1"));
+  ASSERT_EQ(0, create_snap("snap2"));
+  ASSERT_EQ(0, create_snap("snap3"));
+  m_client_meta.sync_points = {{"snap3", "snap2", boost::none}};
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+  MockObjectCopyRequest mock_object_copy_request;
+
+  expect_get_snap_id(mock_remote_image_ctx);
+
+  InSequence seq;
+  expect_get_object_count(mock_remote_image_ctx, 1);
+  expect_get_object_count(mock_remote_image_ctx, 0);
+  expect_get_object_count(mock_remote_image_ctx, 1);
+  expect_get_object_count(mock_remote_image_ctx, 1);
+  expect_update_client(mock_journaler, 0);
+  expect_object_copy_send(mock_object_copy_request);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                 mock_local_image_ctx,
+                                                 mock_journaler,
+                                                 m_client_meta.sync_points.front(),
+                                                 &ctx);
+  request->send();
+
+  MockImageCopyRequest::SnapMap snap_map(m_snap_map);
+  snap_map.erase(snap_map.begin());
+  ASSERT_EQ(snap_map, wait_for_snap_map(mock_object_copy_request));
+
+  ASSERT_TRUE(complete_object_copy(mock_object_copy_request, 0, 0));
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncImageCopyRequest, RestartCatchup) {
+  ASSERT_EQ(0, create_snap("snap1"));
+  ASSERT_EQ(0, create_snap("snap2"));
+  m_client_meta.sync_points = {{"snap1", boost::none},
+                               {"snap2", "snap1", boost::none}};
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+  MockObjectCopyRequest mock_object_copy_request;
+
+  expect_get_snap_id(mock_remote_image_ctx);
+
+  InSequence seq;
+  expect_get_object_count(mock_remote_image_ctx, 1);
+  expect_get_object_count(mock_remote_image_ctx, 0);
+  expect_get_object_count(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+  expect_object_copy_send(mock_object_copy_request);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                 mock_local_image_ctx,
+                                                 mock_journaler,
+                                                 m_client_meta.sync_points.back(),
+                                                 &ctx);
+  request->send();
+
+  ASSERT_EQ(m_snap_map, wait_for_snap_map(mock_object_copy_request));
+  ASSERT_TRUE(complete_object_copy(mock_object_copy_request, 0, 0));
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncImageCopyRequest, RestartPartialSync) {
+  ASSERT_EQ(0, create_snap("snap1"));
+  m_client_meta.sync_points = {{"snap1", 0}};
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+  MockObjectCopyRequest mock_object_copy_request;
+
+  expect_get_snap_id(mock_remote_image_ctx);
+
+  InSequence seq;
+  expect_get_object_count(mock_remote_image_ctx, 1);
+  expect_get_object_count(mock_remote_image_ctx, 2);
+  expect_update_client(mock_journaler, 0);
+  expect_object_copy_send(mock_object_copy_request);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                 mock_local_image_ctx,
+                                                 mock_journaler,
+                                                 m_client_meta.sync_points.front(),
+                                                 &ctx);
+  request->send();
+
+  ASSERT_TRUE(complete_object_copy(mock_object_copy_request, 1, 0));
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncImageCopyRequest, Cancel) {
+  std::string max_ops_str;
+  ASSERT_EQ(0, _rados.conf_get("rbd_concurrent_management_ops", max_ops_str));
+  ASSERT_EQ(0, _rados.conf_set("rbd_concurrent_management_ops", "1"));
+  BOOST_SCOPE_EXIT( (max_ops_str) ) {
+    ASSERT_EQ(0, _rados.conf_set("rbd_concurrent_management_ops", max_ops_str.c_str()));
+  } BOOST_SCOPE_EXIT_END;
+
+  ASSERT_EQ(0, create_snap("snap1"));
+  m_client_meta.sync_points = {{"snap1", boost::none}};
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+  MockObjectCopyRequest mock_object_copy_request;
+
+  expect_get_snap_id(mock_remote_image_ctx);
+
+  InSequence seq;
+  expect_get_object_count(mock_remote_image_ctx, 2);
+  expect_get_object_count(mock_remote_image_ctx, 2);
+  expect_update_client(mock_journaler, 0);
+  expect_object_copy_send(mock_object_copy_request);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                 mock_local_image_ctx,
+                                                 mock_journaler,
+                                                 m_client_meta.sync_points.front(),
+                                                 &ctx);
+  request->send();
+
+  ASSERT_EQ(m_snap_map, wait_for_snap_map(mock_object_copy_request));
+  request->cancel();
+
+  ASSERT_TRUE(complete_object_copy(mock_object_copy_request, 0, 0));
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncImageCopyRequest, MissingSnap) {
+  ASSERT_EQ(0, create_snap("snap1"));
+  m_client_meta.sync_points = {{"missing-snap", boost::none}};
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  expect_get_snap_id(mock_remote_image_ctx);
+
+  C_SaferCond ctx;
+  MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                 mock_local_image_ctx,
+                                                 mock_journaler,
+                                                 m_client_meta.sync_points.front(),
+                                                 &ctx);
+  request->send();
+  ASSERT_EQ(-ENOENT, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncImageCopyRequest, MissingFromSnap) {
+  ASSERT_EQ(0, create_snap("snap1"));
+  m_client_meta.sync_points = {{"snap1", "missing-snap", boost::none}};
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  expect_get_snap_id(mock_remote_image_ctx);
+
+  C_SaferCond ctx;
+  MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                 mock_local_image_ctx,
+                                                 mock_journaler,
+                                                 m_client_meta.sync_points.front(),
+                                                 &ctx);
+  request->send();
+  ASSERT_EQ(-ENOENT, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncImageCopyRequest, EmptySnapMap) {
+  ASSERT_EQ(0, create_snap("snap1"));
+  ASSERT_EQ(0, create_snap("snap2"));
+  m_client_meta.snap_seqs = {{0, 0}};
+  m_client_meta.sync_points = {{"snap2", "snap1", boost::none}};
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  expect_get_snap_id(mock_remote_image_ctx);
+
+  C_SaferCond ctx;
+  MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                 mock_local_image_ctx,
+                                                 mock_journaler,
+                                                 m_client_meta.sync_points.front(),
+                                                 &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
@@ -152,25 +152,7 @@ public:
     }
   }
 
-  int create_snap(librbd::ImageCtx *image_ctx, const char* snap_name,
-                  librados::snap_t *snap_id) {
-    int r = image_ctx->operations->snap_create(snap_name);
-    if (r < 0) {
-      return r;
-    }
-
-    r = image_ctx->state->refresh();
-    if (r < 0) {
-      return r;
-    }
-
-    if (image_ctx->snap_ids.count(snap_name) == 0) {
-      return -ENOENT;
-    }
-    *snap_id = image_ctx->snap_ids[snap_name];
-    return 0;
-  }
-
+  using TestFixture::create_snap;
   int create_snap(const char* snap_name) {
     librados::snap_t remote_snap_id;
     int r = create_snap(m_remote_image_ctx, snap_name, &remote_snap_id);

--- a/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
@@ -1,0 +1,459 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "include/interval_set.h"
+#include "include/rbd/librbd.hpp"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Operations.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "tools/rbd_mirror/image_sync/ObjectCopyRequest.h"
+
+// template definitions
+#include "tools/rbd_mirror/image_sync/ObjectCopyRequest.cc"
+template class rbd::mirror::image_sync::ObjectCopyRequest<librbd::MockImageCtx>;
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+using ::testing::_;
+using ::testing::DoDefault;
+using ::testing::InSequence;
+using ::testing::Return;
+
+namespace {
+
+void scribble(librados::IoCtx &io_ctx, const std::string &oid, int num_ops,
+              size_t max_size, interval_set<uint64_t> *what)
+{
+  uint64_t object_size = 1 << 22;
+  librados::ObjectWriteOperation op;
+  for (int i=0; i<num_ops; i++) {
+    uint64_t off = rand() % (object_size - max_size + 1);
+    uint64_t len = 1 + rand() % max_size;
+
+    bufferlist bl;
+    bl.append(std::string(len, '1'));
+
+    op.write(off, bl);
+
+    interval_set<uint64_t> w;
+    w.insert(off, len);
+    what->union_of(w);
+  }
+
+  ASSERT_EQ(0, io_ctx.operate(oid, &op));
+  std::cout << " wrote " << *what << std::endl;
+}
+
+} // anonymous namespace
+
+class TestMockImageSyncObjectCopyRequest : public TestMockFixture {
+public:
+  typedef ObjectCopyRequest<librbd::MockImageCtx> MockObjectCopyRequest;
+
+  virtual void SetUp() {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+
+    ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+  }
+
+  void expect_list_snaps(librbd::MockImageCtx &mock_image_ctx,
+                         librados::MockTestMemIoCtxImpl &mock_io_ctx, int r) {
+    auto &expect = EXPECT_CALL(mock_io_ctx,
+                               list_snaps(mock_image_ctx.image_ctx->get_object_name(0),
+                                          _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
+  }
+
+  void expect_get_object_name(librbd::MockImageCtx &mock_image_ctx) {
+    EXPECT_CALL(mock_image_ctx, get_object_name(0))
+                  .WillOnce(Return(mock_image_ctx.image_ctx->get_object_name(0)));
+  }
+
+  MockObjectCopyRequest *create_request(librbd::MockImageCtx &mock_remote_image_ctx,
+                                        librbd::MockImageCtx &mock_local_image_ctx,
+                                        Context *on_finish) {
+    expect_get_object_name(mock_local_image_ctx);
+    expect_get_object_name(mock_remote_image_ctx);
+    return new MockObjectCopyRequest(&mock_local_image_ctx,
+                                     &mock_remote_image_ctx, &m_snap_map,
+                                     0, on_finish);
+  }
+
+  void expect_read(librados::MockTestMemIoCtxImpl &mock_io_ctx, uint64_t offset,
+                   uint64_t length, int r) {
+    auto &expect = EXPECT_CALL(mock_io_ctx, read(_, length, offset, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
+  }
+
+  void expect_read(librados::MockTestMemIoCtxImpl &mock_io_ctx,
+                   const interval_set<uint64_t> &extents, int r) {
+    for (auto extent : extents) {
+      expect_read(mock_io_ctx, extent.first, extent.second, r);
+      if (r < 0) {
+        break;
+      }
+    }
+  }
+
+  void expect_write(librados::MockTestMemIoCtxImpl &mock_io_ctx,
+                    uint64_t offset, uint64_t length, int r) {
+    auto &expect = EXPECT_CALL(mock_io_ctx, write(_, _, length, offset, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
+  }
+
+  void expect_write(librados::MockTestMemIoCtxImpl &mock_io_ctx,
+                    const interval_set<uint64_t> &extents, int r) {
+    for (auto extent : extents) {
+      expect_write(mock_io_ctx, extent.first, extent.second, r);
+      if (r < 0) {
+        break;
+      }
+    }
+  }
+
+  void expect_truncate(librados::MockTestMemIoCtxImpl &mock_io_ctx,
+                       uint64_t offset, int r) {
+    auto &expect = EXPECT_CALL(mock_io_ctx, truncate(_, offset, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
+  }
+
+  void expect_remove(librados::MockTestMemIoCtxImpl &mock_io_ctx, int r) {
+    auto &expect = EXPECT_CALL(mock_io_ctx, remove(_, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
+  }
+
+  int create_snap(librbd::ImageCtx *image_ctx, const char* snap_name,
+                  librados::snap_t *snap_id) {
+    int r = image_ctx->operations->snap_create(snap_name);
+    if (r < 0) {
+      return r;
+    }
+
+    r = image_ctx->state->refresh();
+    if (r < 0) {
+      return r;
+    }
+
+    if (image_ctx->snap_ids.count(snap_name) == 0) {
+      return -ENOENT;
+    }
+    *snap_id = image_ctx->snap_ids[snap_name];
+    return 0;
+  }
+
+  int create_snap(const char* snap_name) {
+    librados::snap_t remote_snap_id;
+    int r = create_snap(m_remote_image_ctx, snap_name, &remote_snap_id);
+    if (r < 0) {
+      return r;
+    }
+
+    librados::snap_t local_snap_id;
+    r = create_snap(m_local_image_ctx, snap_name, &local_snap_id);
+    if (r < 0) {
+      return r;
+    }
+
+    // collection of all existing snaps in local image
+    MockObjectCopyRequest::SnapIds local_snap_ids({local_snap_id});
+    if (!m_snap_map.empty()) {
+      local_snap_ids.insert(local_snap_ids.end(),
+                            m_snap_map.rbegin()->second.begin(),
+                            m_snap_map.rbegin()->second.end());
+    }
+    m_snap_map[remote_snap_id] = local_snap_ids;
+    return 0;
+  }
+
+  int compare_objects() {
+    MockObjectCopyRequest::SnapMap snap_map(m_snap_map);
+    if (snap_map.empty()) {
+      return -ENOENT;
+    }
+
+    std::string remote_oid(m_remote_image_ctx->get_object_name(0));
+    std::string local_oid(m_local_image_ctx->get_object_name(0));
+
+    librados::IoCtx remote_io_ctx;
+    remote_io_ctx.dup(m_remote_image_ctx->data_ctx);
+
+    librados::IoCtx local_io_ctx;
+    local_io_ctx.dup(m_local_image_ctx->data_ctx);
+
+    while (!snap_map.empty()) {
+      librados::snap_t remote_snap_id = snap_map.begin()->first;
+      librados::snap_t local_snap_id = *snap_map.begin()->second.begin();
+      snap_map.erase(snap_map.begin());
+      std::cout << "comparing " << remote_snap_id << " to " << local_snap_id
+                << std::endl;
+
+      remote_io_ctx.snap_set_read(remote_snap_id);
+      bufferlist remote_bl;
+      int remote_r = remote_io_ctx.read(remote_oid, remote_bl, 1<<22, 0);
+
+      local_io_ctx.snap_set_read(local_snap_id);
+      bufferlist local_bl;
+      int local_r = local_io_ctx.read(local_oid, local_bl, 1<<22, 0);
+
+      if (remote_r != local_r) {
+        return remote_r < 0 ? remote_r : local_r;
+      }
+
+      if (!remote_bl.contents_equal(local_bl)) {
+        return -EBADMSG;
+      }
+    }
+    return 0;
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::ImageCtx *m_local_image_ctx;
+
+  MockObjectCopyRequest::SnapMap m_snap_map;
+
+};
+
+TEST_F(TestMockImageSyncObjectCopyRequest, DNE) {
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, -ENOENT);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, Write) {
+  // scribble some data
+  std::string remote_oid(m_remote_image_ctx->get_object_name(0));
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx->data_ctx, remote_oid, 10, 102400, &one);
+
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_write(mock_local_io_ctx, 0, one.range_end(), 0);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(0, compare_objects());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, ReadError) {
+  // scribble some data
+  std::string remote_oid(m_remote_image_ctx->get_object_name(0));
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx->data_ctx, remote_oid, 10, 102400, &one);
+
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_read(mock_remote_io_ctx, 0, one.range_end(), -EINVAL);
+
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, WriteError) {
+  // scribble some data
+  std::string remote_oid(m_remote_image_ctx->get_object_name(0));
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx->data_ctx, remote_oid, 10, 102400, &one);
+
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_write(mock_local_io_ctx, 0, one.range_end(), -EINVAL);
+
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, WriteSnaps) {
+  // scribble some data
+  std::string remote_oid(m_remote_image_ctx->get_object_name(0));
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx->data_ctx, remote_oid, 10, 1024, &one);
+  ASSERT_EQ(0, create_snap("one"));
+
+  interval_set<uint64_t> two;
+  scribble(m_remote_image_ctx->data_ctx, remote_oid, 10, 1024, &two);
+  ASSERT_EQ(0, create_snap("two"));
+
+  if (one.range_end() < two.range_end()) {
+    interval_set<uint64_t> resize_diff;
+    resize_diff.insert(one.range_end(), two.range_end() - one.range_end());
+    two.union_of(resize_diff);
+  }
+
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_write(mock_local_io_ctx, 0, one.range_end(), 0);
+  expect_read(mock_remote_io_ctx, two, 0);
+  expect_write(mock_local_io_ctx, two, 0);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(0, compare_objects());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, Trim) {
+  // scribble some data
+  std::string remote_oid(m_remote_image_ctx->get_object_name(0));
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx->data_ctx, remote_oid, 10, 1024, &one);
+  ASSERT_EQ(0, create_snap("one"));
+
+  // trim the object
+  uint64_t trim_offset = rand() % one.range_end();
+  ASSERT_EQ(0, m_remote_image_ctx->data_ctx.trunc(remote_oid, trim_offset));
+  ASSERT_EQ(0, create_snap("sync"));
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_write(mock_local_io_ctx, 0, one.range_end(), 0);
+  expect_truncate(mock_local_io_ctx, trim_offset, 0);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(0, compare_objects());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, Remove) {
+  // scribble some data
+  std::string remote_oid(m_remote_image_ctx->get_object_name(0));
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx->data_ctx, remote_oid, 10, 1024, &one);
+  ASSERT_EQ(0, create_snap("one"));
+
+  // remove the object
+  ASSERT_EQ(0, m_remote_image_ctx->data_ctx.remove(remote_oid));
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_write(mock_local_io_ctx, 0, one.range_end(), 0);
+  expect_remove(mock_local_io_ctx, 0);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(0, compare_objects());
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
@@ -43,14 +43,6 @@ public:
 
     ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
     ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
-
-    m_threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
-      m_local_io_ctx.cct()));
-  }
-
-  virtual void TearDown() {
-    delete m_threads;
-    TestMockFixture::TearDown();
   }
 
   void expect_snap_create(librbd::MockImageCtx &mock_image_ctx,
@@ -118,8 +110,6 @@ public:
 
   MockSnapshotCopyRequest::SnapMap m_snap_map;
   librbd::journal::MirrorPeerClientMeta m_client_meta;
-
-  rbd::mirror::Threads *m_threads = nullptr;
 };
 
 TEST_F(TestMockImageSyncSnapshotCopyRequest, Empty) {

--- a/src/test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
@@ -8,39 +8,9 @@
 #include "librbd/Operations.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "test/librbd/mock/MockImageCtx.h"
+#include "test/rbd_mirror/mock/MockJournaler.h"
 #include "tools/rbd_mirror/image_sync/SnapshotCopyRequest.h"
 #include "tools/rbd_mirror/Threads.h"
-
-namespace journal {
-
-struct MockJournaler {
-  static MockJournaler *s_instance;
-  static MockJournaler &get_instance() {
-    assert(s_instance != nullptr);
-    return *s_instance;
-  }
-
-  MockJournaler() {
-    s_instance = this;
-  }
-
-  MOCK_METHOD2(update_client, void(const bufferlist&, Context *on_safe));
-};
-
-MockJournaler *MockJournaler::s_instance = nullptr;
-
-} // namespace journal
-
-namespace librbd {
-namespace journal {
-
-template <>
-struct TypeTraits<MockImageCtx> {
-  typedef ::journal::MockJournaler Journaler;
-};
-
-} // namespace journal
-} // namespace librbd
 
 // template definitions
 #include "tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc"

--- a/src/test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
@@ -85,7 +85,7 @@ public:
 
   void expect_snap_create(librbd::MockImageCtx &mock_image_ctx,
                           const std::string &snap_name, uint64_t snap_id, int r) {
-    EXPECT_CALL(*mock_image_ctx.operations, snap_create(StrEq(snap_name), _, 0))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_create(StrEq(snap_name), _, 0))
                   .WillOnce(DoAll(InvokeWithoutArgs([&mock_image_ctx, snap_id, snap_name]() {
                                     inject_snap(mock_image_ctx, snap_id, snap_name);
                                   }),
@@ -96,7 +96,7 @@ public:
 
   void expect_snap_remove(librbd::MockImageCtx &mock_image_ctx,
                           const std::string &snap_name, int r) {
-    EXPECT_CALL(*mock_image_ctx.operations, snap_remove(StrEq(snap_name), _))
+    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_remove(StrEq(snap_name), _))
                   .WillOnce(WithArg<1>(Invoke([this, r](Context *ctx) {
                               m_threads->work_queue->queue(ctx, r);
                             })));

--- a/src/test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
@@ -1,0 +1,279 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "include/rbd/librbd.hpp"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Operations.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "tools/rbd_mirror/image_sync/SnapshotCopyRequest.h"
+#include "tools/rbd_mirror/Threads.h"
+
+namespace journal {
+
+struct MockJournaler {
+  static MockJournaler *s_instance;
+  static MockJournaler &get_instance() {
+    assert(s_instance != nullptr);
+    return *s_instance;
+  }
+
+  MockJournaler() {
+    s_instance = this;
+  }
+
+  MOCK_METHOD2(update_client, void(const bufferlist&, Context *on_safe));
+};
+
+MockJournaler *MockJournaler::s_instance = nullptr;
+
+} // namespace journal
+
+namespace librbd {
+namespace journal {
+
+template <>
+struct TypeTraits<MockImageCtx> {
+  typedef ::journal::MockJournaler Journaler;
+};
+
+} // namespace journal
+} // namespace librbd
+
+// template definitions
+#include "tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc"
+template class rbd::mirror::image_sync::SnapshotCopyRequest<librbd::MockImageCtx>;
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::DoDefault;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::InvokeWithoutArgs;
+using ::testing::Return;
+using ::testing::StrEq;
+using ::testing::WithArg;
+
+class TestMockImageSyncSnapshotCopyRequest : public TestMockFixture {
+public:
+  typedef SnapshotCopyRequest<librbd::MockImageCtx> MockSnapshotCopyRequest;
+
+  virtual void SetUp() {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+
+    ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+
+    m_threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
+      m_local_io_ctx.cct()));
+  }
+
+  virtual void TearDown() {
+    delete m_threads;
+    TestMockFixture::TearDown();
+  }
+
+  void expect_snap_create(librbd::MockImageCtx &mock_image_ctx,
+                          const std::string &snap_name, uint64_t snap_id, int r) {
+    EXPECT_CALL(*mock_image_ctx.operations, snap_create(StrEq(snap_name), _, 0))
+                  .WillOnce(DoAll(InvokeWithoutArgs([&mock_image_ctx, snap_id, snap_name]() {
+                                    inject_snap(mock_image_ctx, snap_id, snap_name);
+                                  }),
+                                  WithArg<1>(Invoke([this, r](Context *ctx) {
+                                    m_threads->work_queue->queue(ctx, r);
+                                  }))));
+  }
+
+  void expect_snap_remove(librbd::MockImageCtx &mock_image_ctx,
+                          const std::string &snap_name, int r) {
+    EXPECT_CALL(*mock_image_ctx.operations, snap_remove(StrEq(snap_name), _))
+                  .WillOnce(WithArg<1>(Invoke([this, r](Context *ctx) {
+                              m_threads->work_queue->queue(ctx, r);
+                            })));
+  }
+
+  void expect_update_client(journal::MockJournaler &mock_journaler, int r) {
+    EXPECT_CALL(mock_journaler, update_client(_, _))
+                  .WillOnce(WithArg<1>(CompleteContext(r)));
+  }
+
+  static void inject_snap(librbd::MockImageCtx &mock_image_ctx,
+                   uint64_t snap_id, const std::string &snap_name) {
+    mock_image_ctx.snap_ids[snap_name] = snap_id;
+  }
+
+  MockSnapshotCopyRequest *create_request(librbd::MockImageCtx &mock_remote_image_ctx,
+                                          librbd::MockImageCtx &mock_local_image_ctx,
+                                          journal::MockJournaler &mock_journaler,
+                                          Context *on_finish) {
+    return new MockSnapshotCopyRequest(&mock_local_image_ctx,
+                                       &mock_remote_image_ctx, &m_snap_map,
+                                       &mock_journaler, &m_client_meta,
+                                       on_finish);
+  }
+
+  int create_snap(librbd::ImageCtx *image_ctx, const std::string &snap_name) {
+    int r = image_ctx->operations->snap_create(snap_name.c_str());
+    if (r < 0) {
+      return r;
+    }
+
+    r = image_ctx->state->refresh();
+    if (r < 0) {
+      return r;
+    }
+    return 0;
+  }
+
+  void validate_snap_seqs(const librbd::journal::MirrorPeerClientMeta::SnapSeqs &snap_seqs) {
+    ASSERT_EQ(snap_seqs, m_client_meta.snap_seqs);
+  }
+
+  void validate_snap_map(const MockSnapshotCopyRequest::SnapMap &snap_map) {
+    ASSERT_EQ(snap_map, m_snap_map);
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::ImageCtx *m_local_image_ctx;
+
+  MockSnapshotCopyRequest::SnapMap m_snap_map;
+  librbd::journal::MirrorPeerClientMeta m_client_meta;
+
+  rbd::mirror::Threads *m_threads = nullptr;
+};
+
+TEST_F(TestMockImageSyncSnapshotCopyRequest, Empty) {
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSnapshotCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                    mock_local_image_ctx,
+                                                    mock_journaler, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  validate_snap_map({});
+  validate_snap_seqs({});
+}
+
+TEST_F(TestMockImageSyncSnapshotCopyRequest, UpdateClientError) {
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_update_client(mock_journaler, -EINVAL);
+
+  C_SaferCond ctx;
+  MockSnapshotCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                    mock_local_image_ctx,
+                                                    mock_journaler, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapCreate) {
+  ASSERT_EQ(0, create_snap(m_remote_image_ctx, "snap1"));
+  ASSERT_EQ(0, create_snap(m_remote_image_ctx, "snap2"));
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_snap_create(mock_local_image_ctx, "snap1", 12, 0);
+  expect_snap_create(mock_local_image_ctx, "snap2", 14, 0);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSnapshotCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                    mock_local_image_ctx,
+                                                    mock_journaler, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  uint64_t snap_id1 = m_remote_image_ctx->snap_ids["snap1"];
+  uint64_t snap_id2 = m_remote_image_ctx->snap_ids["snap2"];
+  validate_snap_map({{snap_id1, {12}}, {snap_id2, {14, 12}}});
+  validate_snap_seqs({{snap_id1, 12}, {snap_id2, 14}});
+}
+
+TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapCreateError) {
+  ASSERT_EQ(0, create_snap(m_remote_image_ctx, "snap1"));
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_snap_create(mock_local_image_ctx, "snap1", 12, -EINVAL);
+
+  C_SaferCond ctx;
+  MockSnapshotCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                    mock_local_image_ctx,
+                                                    mock_journaler, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapRemove) {
+  ASSERT_EQ(0, create_snap(m_remote_image_ctx, "snap1"));
+  ASSERT_EQ(0, create_snap(m_local_image_ctx, "snap1"));
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_snap_remove(mock_local_image_ctx, "snap1", 0);
+  expect_snap_create(mock_local_image_ctx, "snap1", 12, 0);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSnapshotCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                    mock_local_image_ctx,
+                                                    mock_journaler, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  uint64_t snap_id1 = m_remote_image_ctx->snap_ids["snap1"];
+  validate_snap_map({{snap_id1, {12}}});
+  validate_snap_seqs({{snap_id1, 12}});
+}
+
+TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapRemoveError) {
+  ASSERT_EQ(0, create_snap(m_local_image_ctx, "snap1"));
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_snap_remove(mock_local_image_ctx, "snap1", -EINVAL);
+
+  C_SaferCond ctx;
+  MockSnapshotCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                    mock_local_image_ctx,
+                                                    mock_journaler, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/image_sync/test_mock_SyncPointCreateRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SyncPointCreateRequest.cc
@@ -1,0 +1,142 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "include/rbd/librbd.hpp"
+#include "librbd/journal/Types.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/rbd_mirror/mock/MockJournaler.h"
+#include "tools/rbd_mirror/image_sync/SyncPointCreateRequest.h"
+
+// template definitions
+#include "tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc"
+template class rbd::mirror::image_sync::SyncPointCreateRequest<librbd::MockImageCtx>;
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::WithArg;
+
+class TestMockImageSyncSyncPointCreateRequest : public TestMockFixture {
+public:
+  typedef SyncPointCreateRequest<librbd::MockImageCtx> MockSyncPointCreateRequest;
+
+  virtual void SetUp() {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+  }
+
+  void expect_update_client(journal::MockJournaler &mock_journaler, int r) {
+    EXPECT_CALL(mock_journaler, update_client(_, _))
+      .WillOnce(WithArg<1>(CompleteContext(r)));
+  }
+
+  void expect_image_refresh(librbd::MockImageCtx &mock_remote_image_ctx, int r) {
+    EXPECT_CALL(*mock_remote_image_ctx.state, refresh(_))
+      .WillOnce(CompleteContext(r));
+  }
+
+  void expect_snap_create(librbd::MockImageCtx &mock_remote_image_ctx, int r) {
+    EXPECT_CALL(*mock_remote_image_ctx.operations, snap_create(_, _))
+      .WillOnce(WithArg<1>(CompleteContext(r)));
+  }
+
+  MockSyncPointCreateRequest *create_request(librbd::MockImageCtx &mock_remote_image_ctx,
+                                             journal::MockJournaler &mock_journaler,
+                                             Context *ctx) {
+    return new MockSyncPointCreateRequest(&mock_remote_image_ctx, "uuid",
+                                          &mock_journaler, &m_client_meta, ctx);
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::journal::MirrorPeerClientMeta m_client_meta;
+};
+
+TEST_F(TestMockImageSyncSyncPointCreateRequest, Success) {
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_update_client(mock_journaler, 0);
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_snap_create(mock_remote_image_ctx, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointCreateRequest *req = create_request(mock_remote_image_ctx,
+                                                   mock_journaler, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  ASSERT_EQ(1U, m_client_meta.sync_points.size());
+}
+
+TEST_F(TestMockImageSyncSyncPointCreateRequest, ResyncSuccess) {
+  m_client_meta.sync_points.emplace_front("start snap", "", boost::none);
+  auto sync_point = m_client_meta.sync_points.front();
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_update_client(mock_journaler, 0);
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_snap_create(mock_remote_image_ctx, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointCreateRequest *req = create_request(mock_remote_image_ctx,
+                                                   mock_journaler, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  ASSERT_EQ(2U, m_client_meta.sync_points.size());
+  ASSERT_EQ(sync_point, m_client_meta.sync_points.front());
+  ASSERT_EQ("start snap", m_client_meta.sync_points.back().from_snap_name);
+}
+
+TEST_F(TestMockImageSyncSyncPointCreateRequest, SnapshotExists) {
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_update_client(mock_journaler, 0);
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_snap_create(mock_remote_image_ctx, -EEXIST);
+  expect_update_client(mock_journaler, 0);
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_snap_create(mock_remote_image_ctx, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointCreateRequest *req = create_request(mock_remote_image_ctx,
+                                                   mock_journaler, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  ASSERT_EQ(1U, m_client_meta.sync_points.size());
+}
+
+TEST_F(TestMockImageSyncSyncPointCreateRequest, ClientUpdateError) {
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_update_client(mock_journaler, -EINVAL);
+
+  C_SaferCond ctx;
+  MockSyncPointCreateRequest *req = create_request(mock_remote_image_ctx,
+                                                   mock_journaler, &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+
+  ASSERT_TRUE(m_client_meta.sync_points.empty());
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/image_sync/test_mock_SyncPointPruneRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SyncPointPruneRequest.cc
@@ -1,0 +1,219 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "include/rbd/librbd.hpp"
+#include "librbd/journal/Types.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/rbd_mirror/mock/MockJournaler.h"
+#include "tools/rbd_mirror/image_sync/SyncPointPruneRequest.h"
+
+// template definitions
+#include "tools/rbd_mirror/image_sync/SyncPointPruneRequest.cc"
+template class rbd::mirror::image_sync::SyncPointPruneRequest<librbd::MockImageCtx>;
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::StrEq;
+using ::testing::WithArg;
+
+class TestMockImageSyncSyncPointPruneRequest : public TestMockFixture {
+public:
+  typedef SyncPointPruneRequest<librbd::MockImageCtx> MockSyncPointPruneRequest;
+
+  virtual void SetUp() {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+  }
+
+  void expect_update_client(journal::MockJournaler &mock_journaler, int r) {
+    EXPECT_CALL(mock_journaler, update_client(_, _))
+      .WillOnce(WithArg<1>(CompleteContext(r)));
+  }
+
+  void expect_image_refresh(librbd::MockImageCtx &mock_remote_image_ctx, int r) {
+    EXPECT_CALL(*mock_remote_image_ctx.state, refresh(_))
+      .WillOnce(CompleteContext(r));
+  }
+
+  void expect_snap_remove(librbd::MockImageCtx &mock_remote_image_ctx,
+                          const std::string &snap_name, int r) {
+    EXPECT_CALL(*mock_remote_image_ctx.operations, snap_remove(StrEq(snap_name), _))
+      .WillOnce(WithArg<1>(CompleteContext(r)));
+  }
+
+  MockSyncPointPruneRequest *create_request(librbd::MockImageCtx &mock_remote_image_ctx,
+                                            journal::MockJournaler &mock_journaler,
+                                            bool sync_complete, Context *ctx) {
+    return new MockSyncPointPruneRequest(&mock_remote_image_ctx, sync_complete,
+                                         &mock_journaler, &m_client_meta, ctx);
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::journal::MirrorPeerClientMeta m_client_meta;
+};
+
+TEST_F(TestMockImageSyncSyncPointPruneRequest, SyncInProgressSuccess) {
+  librbd::journal::MirrorPeerClientMeta client_meta;
+  client_meta.sync_points.emplace_front("snap1", boost::none);
+  m_client_meta = client_meta;
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointPruneRequest *req = create_request(mock_remote_image_ctx,
+                                                  mock_journaler, false, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(client_meta, m_client_meta);
+}
+
+TEST_F(TestMockImageSyncSyncPointPruneRequest, RestartedSyncInProgressSuccess) {
+  librbd::journal::MirrorPeerClientMeta client_meta;
+  client_meta.sync_points.emplace_front("snap2", "snap1", boost::none);
+  client_meta.sync_points.emplace_front("snap1", boost::none);
+  m_client_meta = client_meta;
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_snap_remove(mock_remote_image_ctx, "snap2", 0);
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointPruneRequest *req = create_request(mock_remote_image_ctx,
+                                                  mock_journaler, false, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  client_meta.sync_points.pop_back();
+  ASSERT_EQ(client_meta, m_client_meta);
+}
+
+TEST_F(TestMockImageSyncSyncPointPruneRequest, SyncCompleteSuccess) {
+  librbd::journal::MirrorPeerClientMeta client_meta;
+  client_meta.sync_points.emplace_front("snap1", boost::none);
+  m_client_meta = client_meta;
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_snap_remove(mock_remote_image_ctx, "snap1", 0);
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointPruneRequest *req = create_request(mock_remote_image_ctx,
+                                                  mock_journaler, true, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_TRUE(m_client_meta.sync_points.empty());
+}
+
+TEST_F(TestMockImageSyncSyncPointPruneRequest, RestartedSyncCompleteSuccess) {
+  librbd::journal::MirrorPeerClientMeta client_meta;
+  client_meta.sync_points.emplace_front("snap2", "snap1", boost::none);
+  client_meta.sync_points.emplace_front("snap1", boost::none);
+  m_client_meta = client_meta;
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointPruneRequest *req = create_request(mock_remote_image_ctx,
+                                                  mock_journaler, true, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+  client_meta.sync_points.pop_front();
+  ASSERT_EQ(client_meta, m_client_meta);
+}
+
+TEST_F(TestMockImageSyncSyncPointPruneRequest, RestartedCatchUpSyncCompleteSuccess) {
+  librbd::journal::MirrorPeerClientMeta client_meta;
+  client_meta.sync_points.emplace_front("snap3", "snap2", boost::none);
+  client_meta.sync_points.emplace_front("snap2", "snap1", boost::none);
+  m_client_meta = client_meta;
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_snap_remove(mock_remote_image_ctx, "snap1", 0);
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointPruneRequest *req = create_request(mock_remote_image_ctx,
+                                                  mock_journaler, true, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+  client_meta.sync_points.pop_front();
+  ASSERT_EQ(client_meta, m_client_meta);
+}
+
+TEST_F(TestMockImageSyncSyncPointPruneRequest, SnapshotDNE) {
+  librbd::journal::MirrorPeerClientMeta client_meta;
+  client_meta.sync_points.emplace_front("snap1", boost::none);
+  m_client_meta = client_meta;
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_snap_remove(mock_remote_image_ctx, "snap1", -ENOENT);
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointPruneRequest *req = create_request(mock_remote_image_ctx,
+                                                  mock_journaler, true, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_TRUE(m_client_meta.sync_points.empty());
+}
+
+TEST_F(TestMockImageSyncSyncPointPruneRequest, ClientUpdateError) {
+  librbd::journal::MirrorPeerClientMeta client_meta;
+  client_meta.sync_points.emplace_front("snap2", "snap1", boost::none);
+  client_meta.sync_points.emplace_front("snap1", boost::none);
+  m_client_meta = client_meta;
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, -EINVAL);
+
+  C_SaferCond ctx;
+  MockSyncPointPruneRequest *req = create_request(mock_remote_image_ctx,
+                                                  mock_journaler, true, &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+
+  ASSERT_EQ(client_meta, m_client_meta);
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/mock/MockJournaler.cc
+++ b/src/test/rbd_mirror/mock/MockJournaler.cc
@@ -1,0 +1,10 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "MockJournaler.h"
+
+namespace journal {
+
+MockJournaler *MockJournaler::s_instance = nullptr;
+
+} // namespace journal

--- a/src/test/rbd_mirror/mock/MockJournaler.h
+++ b/src/test/rbd_mirror/mock/MockJournaler.h
@@ -1,0 +1,42 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef TEST_RBD_MIRROR_MOCK_JOURNALER_H
+#define TEST_RBD_MIRROR_MOCK_JOURNALER_H
+
+#include <gmock/gmock.h>
+#include "librbd/Journal.h"
+
+namespace journal {
+
+struct MockJournaler {
+  static MockJournaler *s_instance;
+  static MockJournaler &get_instance() {
+    assert(s_instance != nullptr);
+    return *s_instance;
+  }
+
+  MockJournaler() {
+    s_instance = this;
+  }
+
+  MOCK_METHOD2(update_client, void(const bufferlist&, Context *on_safe));
+};
+
+} // namespace journal
+
+namespace librbd {
+
+struct MockImageCtx;
+
+namespace journal {
+
+template <>
+struct TypeTraits<MockImageCtx> {
+  typedef ::journal::MockJournaler Journaler;
+};
+
+} // namespace journal
+} // namespace librbd
+
+#endif // TEST_RBD_MIRROR_MOCK_JOURNALER_H

--- a/src/test/rbd_mirror/test_ImageSync.cc
+++ b/src/test/rbd_mirror/test_ImageSync.cc
@@ -1,0 +1,140 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_fixture.h"
+#include "include/rbd/librbd.hpp"
+#include "journal/Journaler.h"
+#include "librbd/AioImageRequestWQ.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "tools/rbd_mirror/ImageSync.h"
+#include "tools/rbd_mirror/Threads.h"
+
+void register_test_image_sync() {
+}
+
+namespace rbd {
+namespace mirror {
+
+namespace {
+
+void scribble(librbd::ImageCtx *image_ctx, int num_ops, size_t max_size)
+{
+  for (int i=0; i<num_ops; i++) {
+    uint64_t off = rand() % (image_ctx->size - max_size + 1);
+    uint64_t len = 1 + rand() % max_size;
+
+    if (rand() % 4 == 0) {
+      ASSERT_EQ((int)len, image_ctx->aio_work_queue->discard(off, len));
+    } else {
+      std::string str(len, '1');
+      ASSERT_EQ((int)len, image_ctx->aio_work_queue->write(off, len,
+                                                           str.c_str(), 0));
+    }
+  }
+}
+
+} // anonymous namespace
+class TestImageSync : public TestFixture {
+public:
+
+  virtual void SetUp() {
+    TestFixture::SetUp();
+    create_and_open(m_local_io_ctx, &m_local_image_ctx);
+    create_and_open(m_remote_io_ctx, &m_remote_image_ctx);
+
+    m_threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
+      m_local_io_ctx.cct()));
+
+    m_remote_journaler = new ::journal::Journaler(
+      m_threads->work_queue, m_threads->timer, &m_threads->timer_lock,
+      m_remote_io_ctx, m_remote_image_ctx->id, "mirror-uuid", 5);
+
+    m_client_meta = {"image-id"};
+
+    librbd::journal::ClientData client_data(m_client_meta);
+    bufferlist client_data_bl;
+    ::encode(client_data, client_data_bl);
+
+    ASSERT_EQ(0, m_remote_journaler->register_client(client_data_bl));
+  }
+
+  virtual void TearDown() {
+    delete m_threads;
+    TestFixture::TearDown();
+  }
+
+  void create_and_open(librados::IoCtx &io_ctx, librbd::ImageCtx **image_ctx) {
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(io_ctx, m_image_name, image_ctx));
+
+    C_SaferCond ctx;
+    {
+      RWLock::RLocker owner_locker((*image_ctx)->owner_lock);
+      (*image_ctx)->exclusive_lock->try_lock(&ctx);
+    }
+    ASSERT_EQ(0, ctx.wait());
+    ASSERT_TRUE((*image_ctx)->exclusive_lock->is_lock_owner());
+  }
+
+  ImageSync<> *create_request(Context *ctx) {
+    return new ImageSync<>(m_local_image_ctx, m_remote_image_ctx,
+                           m_threads->timer, &m_threads->timer_lock,
+                           "mirror-uuid", m_remote_journaler, &m_client_meta,
+                           ctx);
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::ImageCtx *m_local_image_ctx;
+  ::journal::Journaler *m_remote_journaler;
+  librbd::journal::MirrorPeerClientMeta m_client_meta;
+
+  rbd::mirror::Threads *m_threads = nullptr;
+};
+
+TEST_F(TestImageSync, Empty) {
+  C_SaferCond ctx;
+  ImageSync<> *request = create_request(&ctx);
+  request->start();
+  ASSERT_EQ(0, ctx.wait());
+
+  ASSERT_EQ(0U, m_client_meta.sync_points.size());
+  ASSERT_EQ(0, m_remote_image_ctx->state->refresh());
+  ASSERT_EQ(0U, m_remote_image_ctx->snap_ids.size());
+  ASSERT_EQ(0, m_local_image_ctx->state->refresh());
+  ASSERT_EQ(1U, m_local_image_ctx->snap_ids.size()); // deleted on journal replay
+}
+
+TEST_F(TestImageSync, Simple) {
+  scribble(m_remote_image_ctx, 10, 102400);
+  {
+    RWLock::RLocker owner_locker(m_remote_image_ctx->owner_lock);
+    ASSERT_EQ(0, m_remote_image_ctx->flush());
+  }
+
+  C_SaferCond ctx;
+  ImageSync<> *request = create_request(&ctx);
+  request->start();
+  ASSERT_EQ(0, ctx.wait());
+
+  int64_t object_size = std::min<int64_t>(
+    m_remote_image_ctx->size, 1 << m_remote_image_ctx->order);
+  bufferlist read_remote_bl;
+  read_remote_bl.append(std::string(object_size, '1'));
+  bufferlist read_local_bl;
+  read_local_bl.append(std::string(object_size, '1'));
+
+  for (uint64_t offset = 0; offset < m_remote_image_ctx->size;
+       offset += object_size) {
+    ASSERT_LE(0, m_remote_image_ctx->aio_work_queue->read(
+                   offset, object_size, read_remote_bl.c_str(), 0));
+    ASSERT_LE(0, m_local_image_ctx->aio_work_queue->read(
+                   offset, object_size, read_local_bl.c_str(), 0));
+    ASSERT_TRUE(read_remote_bl.contents_equal(read_local_bl));
+  }
+}
+
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/test_ImageSync.cc
+++ b/src/test/rbd_mirror/test_ImageSync.cc
@@ -44,9 +44,6 @@ public:
     create_and_open(m_local_io_ctx, &m_local_image_ctx);
     create_and_open(m_remote_io_ctx, &m_remote_image_ctx);
 
-    m_threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
-      m_local_io_ctx.cct()));
-
     m_remote_journaler = new ::journal::Journaler(
       m_threads->work_queue, m_threads->timer, &m_threads->timer_lock,
       m_remote_io_ctx, m_remote_image_ctx->id, "mirror-uuid", 5);
@@ -58,11 +55,6 @@ public:
     ::encode(client_data, client_data_bl);
 
     ASSERT_EQ(0, m_remote_journaler->register_client(client_data_bl));
-  }
-
-  virtual void TearDown() {
-    delete m_threads;
-    TestFixture::TearDown();
   }
 
   void create_and_open(librados::IoCtx &io_ctx, librbd::ImageCtx **image_ctx) {
@@ -90,8 +82,6 @@ public:
   librbd::ImageCtx *m_local_image_ctx;
   ::journal::Journaler *m_remote_journaler;
   librbd::journal::MirrorPeerClientMeta m_client_meta;
-
-  rbd::mirror::Threads *m_threads = nullptr;
 };
 
 TEST_F(TestImageSync, Empty) {

--- a/src/test/rbd_mirror/test_fixture.cc
+++ b/src/test/rbd_mirror/test_fixture.cc
@@ -1,0 +1,72 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_fixture.h"
+#include "include/stringify.h"
+#include "include/rbd/librbd.hpp"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "test/librados/test.h"
+
+namespace rbd {
+namespace mirror {
+
+std::string TestFixture::_local_pool_name;
+std::string TestFixture::_remote_pool_name;
+librados::Rados TestFixture::_rados;
+uint64_t TestFixture::_image_number = 0;
+
+TestFixture::TestFixture() {
+}
+
+void TestFixture::SetUpTestCase() {
+  _local_pool_name = get_temp_pool_name("test-rbd-mirror-");
+  ASSERT_EQ("", create_one_pool_pp(_local_pool_name, _rados));
+
+  _remote_pool_name = get_temp_pool_name("test-rbd-mirror-");
+  ASSERT_EQ("", create_one_pool_pp(_remote_pool_name, _rados));
+}
+
+void TestFixture::TearDownTestCase() {
+  ASSERT_EQ(0, _rados.pool_delete(_remote_pool_name.c_str()));
+  ASSERT_EQ(0, _rados.pool_delete(_local_pool_name.c_str()));
+  _rados.shutdown();
+}
+
+void TestFixture::SetUp() {
+  ASSERT_EQ(0, _rados.ioctx_create(_local_pool_name.c_str(), m_local_io_ctx));
+  ASSERT_EQ(0, _rados.ioctx_create(_remote_pool_name.c_str(), m_remote_io_ctx));
+  m_image_name = get_temp_image_name();
+}
+
+void TestFixture::TearDown() {
+  for (auto image_ctx : m_image_ctxs) {
+    image_ctx->state->close();
+  }
+
+  m_remote_io_ctx.close();
+  m_local_io_ctx.close();
+}
+
+int TestFixture::create_image(librbd::RBD &rbd, librados::IoCtx &ioctx,
+                              const std::string &name, uint64_t size) {
+  int order = 0;
+  return rbd.create2(ioctx, name.c_str(), size, RBD_FEATURES_ALL, &order);
+}
+
+int TestFixture::open_image(librados::IoCtx &io_ctx,
+                            const std::string &image_name,
+                            librbd::ImageCtx **image_ctx) {
+  *image_ctx = new librbd::ImageCtx(image_name.c_str(), "", NULL, io_ctx,
+                                    false);
+  m_image_ctxs.insert(*image_ctx);
+  return (*image_ctx)->state->open();
+}
+
+std::string TestFixture::get_temp_image_name() {
+  ++_image_number;
+  return "image" + stringify(_image_number);
+}
+
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/test_fixture.cc
+++ b/src/test/rbd_mirror/test_fixture.cc
@@ -8,6 +8,7 @@
 #include "librbd/ImageState.h"
 #include "librbd/Operations.h"
 #include "test/librados/test.h"
+#include "tools/rbd_mirror/Threads.h"
 
 namespace rbd {
 namespace mirror {
@@ -38,6 +39,9 @@ void TestFixture::SetUp() {
   ASSERT_EQ(0, _rados.ioctx_create(_local_pool_name.c_str(), m_local_io_ctx));
   ASSERT_EQ(0, _rados.ioctx_create(_remote_pool_name.c_str(), m_remote_io_ctx));
   m_image_name = get_temp_image_name();
+
+  m_threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
+    m_local_io_ctx.cct()));
 }
 
 void TestFixture::TearDown() {
@@ -47,6 +51,8 @@ void TestFixture::TearDown() {
 
   m_remote_io_ctx.close();
   m_local_io_ctx.close();
+
+  delete m_threads;
 }
 
 int TestFixture::create_image(librbd::RBD &rbd, librados::IoCtx &ioctx,

--- a/src/test/rbd_mirror/test_fixture.h
+++ b/src/test/rbd_mirror/test_fixture.h
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_RBD_MIRROR_TEST_FIXTURE_H
+#define CEPH_TEST_RBD_MIRROR_TEST_FIXTURE_H
+
+#include "include/int_types.h"
+#include "include/rados/librados.hpp"
+#include <gtest/gtest.h>
+#include <set>
+
+namespace librbd {
+class ImageCtx;
+class RBD;
+}
+
+namespace rbd {
+namespace mirror {
+
+class TestFixture : public ::testing::Test {
+public:
+  TestFixture();
+
+  static void SetUpTestCase();
+  static void TearDownTestCase();
+
+  virtual void SetUp();
+  virtual void TearDown();
+
+  librados::IoCtx m_local_io_ctx;
+  librados::IoCtx m_remote_io_ctx;
+
+  std::string m_image_name;
+  uint64_t m_image_size = 2 << 20;
+
+  std::set<librbd::ImageCtx *> m_image_ctxs;
+
+  int create_image(librbd::RBD &rbd, librados::IoCtx &ioctx,
+                   const std::string &name, uint64_t size);
+  int open_image(librados::IoCtx &io_ctx, const std::string &image_name,
+                 librbd::ImageCtx **image_ctx);
+
+  static std::string get_temp_image_name();
+
+  static std::string _local_pool_name;
+  static std::string _remote_pool_name;
+  static librados::Rados _rados;
+  static uint64_t _image_number;
+};
+
+} // namespace mirror
+} // namespace rbd
+
+#endif // CEPH_TEST_RBD_MIRROR_TEST_FIXTURE_H

--- a/src/test/rbd_mirror/test_fixture.h
+++ b/src/test/rbd_mirror/test_fixture.h
@@ -31,7 +31,7 @@ public:
   librados::IoCtx m_remote_io_ctx;
 
   std::string m_image_name;
-  uint64_t m_image_size = 2 << 20;
+  uint64_t m_image_size = 1 << 24;
 
   std::set<librbd::ImageCtx *> m_image_ctxs;
 
@@ -39,6 +39,9 @@ public:
                    const std::string &name, uint64_t size);
   int open_image(librados::IoCtx &io_ctx, const std::string &image_name,
                  librbd::ImageCtx **image_ctx);
+
+  int create_snap(librbd::ImageCtx *image_ctx, const char* snap_name,
+                  librados::snap_t *snap_id = nullptr);
 
   static std::string get_temp_image_name();
 

--- a/src/test/rbd_mirror/test_fixture.h
+++ b/src/test/rbd_mirror/test_fixture.h
@@ -17,6 +17,8 @@ class RBD;
 namespace rbd {
 namespace mirror {
 
+class Threads;
+
 class TestFixture : public ::testing::Test {
 public:
   TestFixture();
@@ -34,6 +36,8 @@ public:
   uint64_t m_image_size = 1 << 24;
 
   std::set<librbd::ImageCtx *> m_image_ctxs;
+
+  Threads *m_threads = nullptr;
 
   int create_image(librbd::RBD &rbd, librados::IoCtx &ioctx,
                    const std::string &name, uint64_t size);

--- a/src/test/rbd_mirror/test_main.cc
+++ b/src/test/rbd_mirror/test_main.cc
@@ -11,12 +11,14 @@
 extern void register_test_cluster_watcher();
 extern void register_test_pool_watcher();
 extern void register_test_rbd_mirror();
+extern void register_test_image_sync();
 
 int main(int argc, char **argv)
 {
   register_test_cluster_watcher();
   register_test_pool_watcher();
   register_test_rbd_mirror();
+  register_test_image_sync();
 
   ::testing::InitGoogleTest(&argc, argv);
 

--- a/src/test/rbd_mirror/test_mock_ImageSync.cc
+++ b/src/test/rbd_mirror/test_mock_ImageSync.cc
@@ -1,0 +1,303 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "include/rbd/librbd.hpp"
+#include "librbd/journal/Types.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/rbd_mirror/mock/MockJournaler.h"
+#include "tools/rbd_mirror/ImageSync.h"
+#include "tools/rbd_mirror/Threads.h"
+#include "tools/rbd_mirror/image_sync/ImageCopyRequest.h"
+#include "tools/rbd_mirror/image_sync/SnapshotCopyRequest.h"
+#include "tools/rbd_mirror/image_sync/SyncPointCreateRequest.h"
+#include "tools/rbd_mirror/image_sync/SyncPointPruneRequest.h"
+
+// template definitions
+#include "tools/rbd_mirror/ImageSync.cc"
+template class rbd::mirror::ImageSync<librbd::MockImageCtx>;
+
+namespace rbd {
+namespace mirror {
+
+namespace image_sync {
+
+template <>
+class ImageCopyRequest<librbd::MockImageCtx> {
+public:
+  static ImageCopyRequest* s_instance;
+  Context *on_finish;
+
+  static ImageCopyRequest* create(librbd::MockImageCtx *local_image_ctx,
+                                  librbd::MockImageCtx *remote_image_ctx,
+                                  SafeTimer *timer, Mutex *timer_lock,
+                                  journal::MockJournaler *journaler,
+                                  librbd::journal::MirrorPeerClientMeta *client_meta,
+                                  librbd::journal::MirrorPeerSyncPoint *sync_point,
+                                  Context *on_finish) {
+    assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  ImageCopyRequest() {
+    s_instance = this;
+  }
+  MOCK_METHOD0(cancel, void());
+  MOCK_METHOD0(send, void());
+};
+
+template <>
+class SnapshotCopyRequest<librbd::MockImageCtx> {
+public:
+  static SnapshotCopyRequest* s_instance;
+  Context *on_finish;
+
+  static SnapshotCopyRequest* create(librbd::MockImageCtx *local_image_ctx,
+                                     librbd::MockImageCtx *remote_image_ctx,
+                                     SnapshotCopyRequest<librbd::ImageCtx>::SnapMap *snap_map,
+                                     journal::MockJournaler *journaler,
+                                     librbd::journal::MirrorPeerClientMeta *client_meta,
+                                     Context *on_finish) {
+    assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  SnapshotCopyRequest() {
+    s_instance = this;
+  }
+  MOCK_METHOD0(send, void());
+};
+
+template <>
+class SyncPointCreateRequest<librbd::MockImageCtx> {
+public:
+  static SyncPointCreateRequest *s_instance;
+  Context *on_finish;
+
+  static SyncPointCreateRequest* create(librbd::MockImageCtx *remote_image_ctx,
+                                        const std::string &mirror_uuid,
+                                        journal::MockJournaler *journaler,
+                                        librbd::journal::MirrorPeerClientMeta *client_meta,
+                                        Context *on_finish) {
+    assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  SyncPointCreateRequest() {
+    s_instance = this;
+  }
+  MOCK_METHOD0(send, void());
+};
+
+template <>
+class SyncPointPruneRequest<librbd::MockImageCtx> {
+public:
+  static SyncPointPruneRequest *s_instance;
+  Context *on_finish;
+  bool sync_complete;
+
+  static SyncPointPruneRequest* create(librbd::MockImageCtx *remote_image_ctx,
+                                       bool sync_complete,
+                                       journal::MockJournaler *journaler,
+                                       librbd::journal::MirrorPeerClientMeta *client_meta,
+                                       Context *on_finish) {
+    assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    s_instance->sync_complete = sync_complete;
+    return s_instance;
+  }
+
+  SyncPointPruneRequest() {
+    s_instance = this;
+  }
+  MOCK_METHOD0(send, void());
+};
+
+ImageCopyRequest<librbd::MockImageCtx>* ImageCopyRequest<librbd::MockImageCtx>::s_instance = nullptr;
+SnapshotCopyRequest<librbd::MockImageCtx>* SnapshotCopyRequest<librbd::MockImageCtx>::s_instance = nullptr;
+SyncPointCreateRequest<librbd::MockImageCtx>* SyncPointCreateRequest<librbd::MockImageCtx>::s_instance = nullptr;
+SyncPointPruneRequest<librbd::MockImageCtx>* SyncPointPruneRequest<librbd::MockImageCtx>::s_instance = nullptr;
+
+} // namespace image_sync
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Invoke;
+
+class TestMockImageSync : public TestMockFixture {
+public:
+  typedef ImageSync<librbd::MockImageCtx> MockImageSync;
+  typedef image_sync::ImageCopyRequest<librbd::MockImageCtx> MockImageCopyRequest;
+  typedef image_sync::SnapshotCopyRequest<librbd::MockImageCtx> MockSnapshotCopyRequest;
+  typedef image_sync::SyncPointCreateRequest<librbd::MockImageCtx> MockSyncPointCreateRequest;
+  typedef image_sync::SyncPointPruneRequest<librbd::MockImageCtx> MockSyncPointPruneRequest;
+
+  virtual void SetUp() {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+
+    ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+
+    m_threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
+      m_local_io_ctx.cct()));
+  }
+
+  virtual void TearDown() {
+    delete m_threads;
+    TestMockFixture::TearDown();
+  }
+
+  void expect_create_sync_point(MockSyncPointCreateRequest &mock_sync_point_create_request,
+                                int r) {
+    EXPECT_CALL(mock_sync_point_create_request, send())
+      .WillOnce(Invoke([this, &mock_sync_point_create_request, r]() {
+          if (r == 0) {
+            m_client_meta.sync_points.emplace_back("snap1", boost::none);
+          }
+          m_threads->work_queue->queue(mock_sync_point_create_request.on_finish, r);
+        }));
+  }
+
+  void expect_copy_snapshots(MockSnapshotCopyRequest &mock_snapshot_copy_request, int r) {
+    EXPECT_CALL(mock_snapshot_copy_request, send())
+      .WillOnce(Invoke([this, &mock_snapshot_copy_request, r]() {
+          m_threads->work_queue->queue(mock_snapshot_copy_request.on_finish, r);
+        }));
+  }
+
+  void expect_copy_image(MockImageCopyRequest &mock_image_copy_request, int r) {
+    EXPECT_CALL(mock_image_copy_request, send())
+      .WillOnce(Invoke([this, &mock_image_copy_request, r]() {
+          m_threads->work_queue->queue(mock_image_copy_request.on_finish, r);
+        }));
+  }
+
+  void expect_prune_sync_point(MockSyncPointPruneRequest &mock_sync_point_prune_request,
+                               bool sync_complete, int r) {
+    EXPECT_CALL(mock_sync_point_prune_request, send())
+      .WillOnce(Invoke([this, &mock_sync_point_prune_request, sync_complete, r]() {
+          ASSERT_EQ(sync_complete, mock_sync_point_prune_request.sync_complete);
+          if (r == 0 && !m_client_meta.sync_points.empty()) {
+            if (sync_complete) {
+              m_client_meta.sync_points.pop_front();
+            } else {
+              while (m_client_meta.sync_points.size() > 1) {
+                m_client_meta.sync_points.pop_back();
+              }
+            }
+          }
+          m_threads->work_queue->queue(mock_sync_point_prune_request.on_finish, r);
+        }));
+  }
+
+  MockImageSync *create_request(librbd::MockImageCtx &mock_remote_image_ctx,
+                                librbd::MockImageCtx &mock_local_image_ctx,
+                                journal::MockJournaler &mock_journaler,
+                                Context *ctx) {
+    return new MockImageSync(&mock_local_image_ctx, &mock_remote_image_ctx,
+                             m_threads->timer, &m_threads->timer_lock,
+                             "mirror-uuid", &mock_journaler, &m_client_meta,
+                             ctx);
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::ImageCtx *m_local_image_ctx;
+  librbd::journal::MirrorPeerClientMeta m_client_meta;
+
+  rbd::mirror::Threads *m_threads = nullptr;
+};
+
+TEST_F(TestMockImageSync, SimpleSync) {
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+  MockImageCopyRequest mock_image_copy_request;
+  MockSnapshotCopyRequest mock_snapshot_copy_request;
+  MockSyncPointCreateRequest mock_sync_point_create_request;
+  MockSyncPointPruneRequest mock_sync_point_prune_request;
+
+  InSequence seq;
+  expect_create_sync_point(mock_sync_point_create_request, 0);
+  expect_copy_snapshots(mock_snapshot_copy_request, 0);
+  expect_copy_image(mock_image_copy_request, 0);
+  expect_prune_sync_point(mock_sync_point_prune_request, true, 0);
+
+  C_SaferCond ctx;
+  MockImageSync *request = create_request(mock_remote_image_ctx,
+                                          mock_local_image_ctx,
+                                          mock_journaler, &ctx);
+  request->start();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSync, RestartSync) {
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+  MockImageCopyRequest mock_image_copy_request;
+  MockSnapshotCopyRequest mock_snapshot_copy_request;
+  MockSyncPointCreateRequest mock_sync_point_create_request;
+  MockSyncPointPruneRequest mock_sync_point_prune_request;
+
+  m_client_meta.sync_points = {{"snap1", boost::none},
+                               {"snap2", "snap1", boost::none}};
+
+  InSequence seq;
+  expect_prune_sync_point(mock_sync_point_prune_request, false, 0);
+  expect_copy_snapshots(mock_snapshot_copy_request, 0);
+  expect_copy_image(mock_image_copy_request, 0);
+  expect_prune_sync_point(mock_sync_point_prune_request, true, 0);
+
+  C_SaferCond ctx;
+  MockImageSync *request = create_request(mock_remote_image_ctx,
+                                          mock_local_image_ctx,
+                                          mock_journaler, &ctx);
+  request->start();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSync, CancelImageCopy) {
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+  MockImageCopyRequest mock_image_copy_request;
+  MockSnapshotCopyRequest mock_snapshot_copy_request;
+  MockSyncPointCreateRequest mock_sync_point_create_request;
+  MockSyncPointPruneRequest mock_sync_point_prune_request;
+
+  m_client_meta.sync_points = {{"snap1", boost::none}};
+
+  InSequence seq;
+  expect_copy_snapshots(mock_snapshot_copy_request, 0);
+
+  C_SaferCond image_copy_ctx;
+  EXPECT_CALL(mock_image_copy_request, send())
+    .WillOnce(Invoke([&image_copy_ctx]() {
+        image_copy_ctx.complete(0);
+      }));
+  EXPECT_CALL(mock_image_copy_request, cancel());
+
+  C_SaferCond ctx;
+  MockImageSync *request = create_request(mock_remote_image_ctx,
+                                          mock_local_image_ctx,
+                                          mock_journaler, &ctx);
+  request->start();
+
+  // cancel the image copy once it starts
+  ASSERT_EQ(0, image_copy_ctx.wait());
+  request->cancel();
+  m_threads->work_queue->queue(mock_image_copy_request.on_finish, 0);
+
+  ASSERT_EQ(-ECANCELED, ctx.wait());
+}
+
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/test_mock_fixture.cc
+++ b/src/test/rbd_mirror/test_mock_fixture.cc
@@ -1,0 +1,53 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "test/librados_test_stub/LibradosTestStub.h"
+#include "test/librados_test_stub/MockTestMemRadosClient.h"
+
+namespace rbd {
+namespace mirror {
+
+TestMockFixture::TestRadosClientPtr TestMockFixture::s_test_rados_client;
+::testing::NiceMock<librados::MockTestMemRadosClient> *
+  TestMockFixture::s_mock_rados_client = NULL;
+
+void TestMockFixture::SetUpTestCase() {
+  s_test_rados_client = librados_test_stub::get_rados_client();
+
+  // use a mock version of the in-memory rados client
+  s_mock_rados_client = new ::testing::NiceMock<librados::MockTestMemRadosClient>(
+      s_test_rados_client->cct());
+  librados_test_stub::set_rados_client(TestRadosClientPtr(s_mock_rados_client));
+  TestFixture::SetUpTestCase();
+}
+
+void TestMockFixture::TearDownTestCase() {
+  TestFixture::TearDownTestCase();
+  librados_test_stub::set_rados_client(s_test_rados_client);
+  s_test_rados_client->put();
+  s_test_rados_client.reset();
+}
+
+void TestMockFixture::SetUp() {
+  TestFixture::SetUp();
+}
+
+void TestMockFixture::TearDown() {
+  TestFixture::TearDown();
+
+  // Mock rados client lives across tests -- reset it to initial state
+  ::testing::Mock::VerifyAndClear(s_mock_rados_client);
+  s_mock_rados_client->default_to_dispatch();
+}
+
+librados::MockTestMemIoCtxImpl &TestMockFixture::get_mock_io_ctx(
+    librados::IoCtx &ioctx) {
+  librados::MockTestMemIoCtxImpl **mock =
+    reinterpret_cast<librados::MockTestMemIoCtxImpl **>(&ioctx);
+  return **mock;
+}
+
+} // namespace mirror
+} // namespace rbd
+

--- a/src/test/rbd_mirror/test_mock_fixture.cc
+++ b/src/test/rbd_mirror/test_mock_fixture.cc
@@ -41,13 +41,6 @@ void TestMockFixture::TearDown() {
   s_mock_rados_client->default_to_dispatch();
 }
 
-librados::MockTestMemIoCtxImpl &TestMockFixture::get_mock_io_ctx(
-    librados::IoCtx &ioctx) {
-  librados::MockTestMemIoCtxImpl **mock =
-    reinterpret_cast<librados::MockTestMemIoCtxImpl **>(&ioctx);
-  return **mock;
-}
-
 } // namespace mirror
 } // namespace rbd
 

--- a/src/test/rbd_mirror/test_mock_fixture.cc
+++ b/src/test/rbd_mirror/test_mock_fixture.cc
@@ -2,11 +2,17 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "test/rbd_mirror/test_mock_fixture.h"
+#include "include/rbd/librbd.hpp"
 #include "test/librados_test_stub/LibradosTestStub.h"
 #include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "test/librbd/mock/MockImageCtx.h"
 
 namespace rbd {
 namespace mirror {
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::WithArg;
 
 TestMockFixture::TestRadosClientPtr TestMockFixture::s_test_rados_client;
 ::testing::NiceMock<librados::MockTestMemRadosClient> *
@@ -39,6 +45,13 @@ void TestMockFixture::TearDown() {
   // Mock rados client lives across tests -- reset it to initial state
   ::testing::Mock::VerifyAndClear(s_mock_rados_client);
   s_mock_rados_client->default_to_dispatch();
+}
+
+void TestMockFixture::expect_test_features(librbd::MockImageCtx &mock_image_ctx) {
+  EXPECT_CALL(mock_image_ctx, test_features(_, _))
+    .WillRepeatedly(WithArg<0>(Invoke([&mock_image_ctx](uint64_t features) {
+        return (mock_image_ctx.features & features) != 0;
+      })));
 }
 
 } // namespace mirror

--- a/src/test/rbd_mirror/test_mock_fixture.h
+++ b/src/test/rbd_mirror/test_mock_fixture.h
@@ -15,6 +15,10 @@ class MockTestMemIoCtxImpl;
 class MockTestMemRadosClient;
 }
 
+namespace librbd {
+class MockImageCtx;
+}
+
 ACTION_P(CompleteContext, r) {
   arg0->complete(r);
 }
@@ -31,6 +35,8 @@ public:
 
   virtual void SetUp();
   virtual void TearDown();
+
+  void expect_test_features(librbd::MockImageCtx &mock_image_ctx);
 
   ::testing::NiceMock<librados::MockTestMemRadosClient> &get_mock_rados_client() {
     return *s_mock_rados_client;

--- a/src/test/rbd_mirror/test_mock_fixture.h
+++ b/src/test/rbd_mirror/test_mock_fixture.h
@@ -1,0 +1,43 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_RBD_MIRROR_TEST_MOCK_FIXTURE_H
+#define CEPH_TEST_RBD_MIRROR_TEST_MOCK_FIXTURE_H
+
+#include "test/rbd_mirror/test_fixture.h"
+#include <boost/shared_ptr.hpp>
+#include <gmock/gmock.h>
+
+namespace librados {
+class TestRadosClient;
+class MockTestMemIoCtxImpl;
+class MockTestMemRadosClient;
+}
+
+namespace rbd {
+namespace mirror {
+
+class TestMockFixture : public TestFixture {
+public:
+  typedef boost::shared_ptr<librados::TestRadosClient> TestRadosClientPtr;
+
+  static void SetUpTestCase();
+  static void TearDownTestCase();
+
+  virtual void SetUp();
+  virtual void TearDown();
+
+  ::testing::NiceMock<librados::MockTestMemRadosClient> &get_mock_rados_client() {
+    return *s_mock_rados_client;
+  }
+  librados::MockTestMemIoCtxImpl &get_mock_io_ctx(librados::IoCtx &ioctx);
+
+private:
+  static TestRadosClientPtr s_test_rados_client;
+  static ::testing::NiceMock<librados::MockTestMemRadosClient> *s_mock_rados_client;
+};
+
+} // namespace mirror
+} // namespace rbd
+
+#endif // CEPH_TEST_RBD_MIRROR_TEST_MOCK_FIXTURE_H

--- a/src/test/rbd_mirror/test_mock_fixture.h
+++ b/src/test/rbd_mirror/test_mock_fixture.h
@@ -5,6 +5,7 @@
 #define CEPH_TEST_RBD_MIRROR_TEST_MOCK_FIXTURE_H
 
 #include "test/rbd_mirror/test_fixture.h"
+#include "test/librados_test_stub/LibradosTestStub.h"
 #include <boost/shared_ptr.hpp>
 #include <gmock/gmock.h>
 
@@ -34,7 +35,6 @@ public:
   ::testing::NiceMock<librados::MockTestMemRadosClient> &get_mock_rados_client() {
     return *s_mock_rados_client;
   }
-  librados::MockTestMemIoCtxImpl &get_mock_io_ctx(librados::IoCtx &ioctx);
 
 private:
   static TestRadosClientPtr s_test_rados_client;

--- a/src/test/rbd_mirror/test_mock_fixture.h
+++ b/src/test/rbd_mirror/test_mock_fixture.h
@@ -14,6 +14,10 @@ class MockTestMemIoCtxImpl;
 class MockTestMemRadosClient;
 }
 
+ACTION_P(CompleteContext, r) {
+  arg0->complete(r);
+}
+
 namespace rbd {
 namespace mirror {
 

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -88,6 +88,7 @@ librbd_mirror_internal_la_SOURCES = \
 	tools/rbd_mirror/Replayer.cc \
 	tools/rbd_mirror/Threads.cc \
 	tools/rbd_mirror/types.cc \
+	tools/rbd_mirror/image_sync/ImageCopyRequest.cc \
 	tools/rbd_mirror/image_sync/ObjectCopyRequest.cc \
 	tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc \
 	tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc \
@@ -101,6 +102,7 @@ noinst_HEADERS += \
 	tools/rbd_mirror/Replayer.h \
 	tools/rbd_mirror/Threads.h \
 	tools/rbd_mirror/types.h \
+	tools/rbd_mirror/image_sync/ImageCopyRequest.h \
 	tools/rbd_mirror/image_sync/ObjectCopyRequest.h \
 	tools/rbd_mirror/image_sync/SnapshotCopyRequest.h \
 	tools/rbd_mirror/image_sync/SyncPointCreateRequest.h \

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -83,6 +83,7 @@ endif # LINUX
 librbd_mirror_internal_la_SOURCES = \
 	tools/rbd_mirror/ClusterWatcher.cc \
 	tools/rbd_mirror/ImageReplayer.cc \
+	tools/rbd_mirror/ImageSync.cc \
 	tools/rbd_mirror/Mirror.cc \
 	tools/rbd_mirror/PoolWatcher.cc \
 	tools/rbd_mirror/Replayer.cc \
@@ -97,6 +98,7 @@ noinst_LTLIBRARIES += librbd_mirror_internal.la
 noinst_HEADERS += \
 	tools/rbd_mirror/ClusterWatcher.h \
 	tools/rbd_mirror/ImageReplayer.h \
+	tools/rbd_mirror/ImageSync.h \
 	tools/rbd_mirror/Mirror.h \
 	tools/rbd_mirror/PoolWatcher.h \
 	tools/rbd_mirror/Replayer.h \

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -89,7 +89,9 @@ librbd_mirror_internal_la_SOURCES = \
 	tools/rbd_mirror/Threads.cc \
 	tools/rbd_mirror/types.cc \
 	tools/rbd_mirror/image_sync/ObjectCopyRequest.cc \
-	tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc
+	tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc \
+	tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc \
+	tools/rbd_mirror/image_sync/SyncPointPruneRequest.cc
 noinst_LTLIBRARIES += librbd_mirror_internal.la
 noinst_HEADERS += \
 	tools/rbd_mirror/ClusterWatcher.h \
@@ -100,7 +102,9 @@ noinst_HEADERS += \
 	tools/rbd_mirror/Threads.h \
 	tools/rbd_mirror/types.h \
 	tools/rbd_mirror/image_sync/ObjectCopyRequest.h \
-	tools/rbd_mirror/image_sync/SnapshotCopyRequest.h
+	tools/rbd_mirror/image_sync/SnapshotCopyRequest.h \
+	tools/rbd_mirror/image_sync/SyncPointCreateRequest.h \
+	tools/rbd_mirror/image_sync/SyncPointPruneRequest.h
 
 rbd_mirror_SOURCES = \
 	tools/rbd_mirror/main.cc

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -87,7 +87,8 @@ librbd_mirror_internal_la_SOURCES = \
 	tools/rbd_mirror/PoolWatcher.cc \
 	tools/rbd_mirror/Replayer.cc \
 	tools/rbd_mirror/Threads.cc \
-	tools/rbd_mirror/types.cc
+	tools/rbd_mirror/types.cc \
+	tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
 noinst_LTLIBRARIES += librbd_mirror_internal.la
 noinst_HEADERS += \
 	tools/rbd_mirror/ClusterWatcher.h \
@@ -96,7 +97,8 @@ noinst_HEADERS += \
 	tools/rbd_mirror/PoolWatcher.h \
 	tools/rbd_mirror/Replayer.h \
 	tools/rbd_mirror/Threads.h \
-	tools/rbd_mirror/types.h
+	tools/rbd_mirror/types.h \
+	tools/rbd_mirror/image_sync/ObjectCopyRequest.h
 
 rbd_mirror_SOURCES = \
 	tools/rbd_mirror/main.cc

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -88,7 +88,8 @@ librbd_mirror_internal_la_SOURCES = \
 	tools/rbd_mirror/Replayer.cc \
 	tools/rbd_mirror/Threads.cc \
 	tools/rbd_mirror/types.cc \
-	tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
+	tools/rbd_mirror/image_sync/ObjectCopyRequest.cc \
+	tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc
 noinst_LTLIBRARIES += librbd_mirror_internal.la
 noinst_HEADERS += \
 	tools/rbd_mirror/ClusterWatcher.h \
@@ -98,7 +99,8 @@ noinst_HEADERS += \
 	tools/rbd_mirror/Replayer.h \
 	tools/rbd_mirror/Threads.h \
 	tools/rbd_mirror/types.h \
-	tools/rbd_mirror/image_sync/ObjectCopyRequest.h
+	tools/rbd_mirror/image_sync/ObjectCopyRequest.h \
+	tools/rbd_mirror/image_sync/SnapshotCopyRequest.h
 
 rbd_mirror_SOURCES = \
 	tools/rbd_mirror/main.cc

--- a/src/tools/rbd_mirror/ImageSync.cc
+++ b/src/tools/rbd_mirror/ImageSync.cc
@@ -1,0 +1,243 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "ImageSync.h"
+#include "common/errno.h"
+#include "journal/Journaler.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "librbd/journal/Types.h"
+#include "tools/rbd_mirror/image_sync/ImageCopyRequest.h"
+#include "tools/rbd_mirror/image_sync/SnapshotCopyRequest.h"
+#include "tools/rbd_mirror/image_sync/SyncPointCreateRequest.h"
+#include "tools/rbd_mirror/image_sync/SyncPointPruneRequest.h"
+
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::ImageSync: " \
+                           << this << " " << __func__
+
+namespace rbd {
+namespace mirror {
+
+using namespace image_sync;
+using librbd::util::create_context_callback;
+using librbd::util::unique_lock_name;
+
+template <typename I>
+ImageSync<I>::ImageSync(I *local_image_ctx, I *remote_image_ctx,
+                        SafeTimer *timer, Mutex *timer_lock,
+                        const std::string &mirror_uuid, Journaler *journaler,
+                        MirrorPeerClientMeta *client_meta, Context *on_finish)
+  : m_local_image_ctx(local_image_ctx), m_remote_image_ctx(remote_image_ctx),
+    m_timer(timer), m_timer_lock(timer_lock), m_mirror_uuid(mirror_uuid),
+    m_journaler(journaler), m_client_meta(client_meta), m_on_finish(on_finish),
+    m_lock(unique_lock_name("ImageSync::m_lock", this)) {
+}
+
+template <typename I>
+void ImageSync<I>::start() {
+  send_prune_catch_up_sync_point();
+}
+
+template <typename I>
+void ImageSync<I>::cancel() {
+  Mutex::Locker locker(m_lock);
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  m_canceled = true;
+  if (m_image_copy_request != nullptr) {
+    m_image_copy_request->cancel();
+  }
+}
+
+template <typename I>
+void ImageSync<I>::send_prune_catch_up_sync_point() {
+  if (m_client_meta->sync_points.size() <= 1) {
+    send_create_sync_point();
+    return;
+  }
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  Context *ctx = create_context_callback<
+    ImageSync<I>, &ImageSync<I>::handle_prune_catch_up_sync_point>(this);
+  SyncPointPruneRequest<I> *request = SyncPointPruneRequest<I>::create(
+    m_remote_image_ctx, false, m_journaler, m_client_meta, ctx);
+  request->send();
+}
+
+template <typename I>
+void ImageSync<I>::handle_prune_catch_up_sync_point(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to prune catch-up sync point: "
+               << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  send_create_sync_point();
+}
+
+template <typename I>
+void ImageSync<I>::send_create_sync_point() {
+  // TODO: when support for disconnecting laggy clients is added,
+  //       re-connect and create catch-up sync point
+  if (m_client_meta->sync_points.size() > 0) {
+    send_copy_snapshots();
+    return;
+  }
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  Context *ctx = create_context_callback<
+    ImageSync<I>, &ImageSync<I>::handle_create_sync_point>(this);
+  SyncPointCreateRequest<I> *request = SyncPointCreateRequest<I>::create(
+    m_remote_image_ctx, m_mirror_uuid, m_journaler, m_client_meta, ctx);
+  request->send();
+}
+
+template <typename I>
+void ImageSync<I>::handle_create_sync_point(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to create sync point: " << cpp_strerror(r)
+               << dendl;
+    finish(r);
+    return;
+  }
+
+  send_copy_snapshots();
+}
+
+template <typename I>
+void ImageSync<I>::send_copy_snapshots() {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  Context *ctx = create_context_callback<
+    ImageSync<I>, &ImageSync<I>::handle_copy_snapshots>(this);
+  SnapshotCopyRequest<I> *request = SnapshotCopyRequest<I>::create(
+    m_local_image_ctx, m_remote_image_ctx, &m_snap_map, m_journaler,
+    m_client_meta, ctx);
+  request->send();
+}
+
+template <typename I>
+void ImageSync<I>::handle_copy_snapshots(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to copy snapshot metadata: "
+               << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  send_copy_image();
+}
+
+template <typename I>
+void ImageSync<I>::send_copy_image() {
+  m_lock.Lock();
+  if (m_canceled) {
+    m_lock.Unlock();
+    finish(-ECANCELED);
+    return;
+  }
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  Context *ctx = create_context_callback<
+    ImageSync<I>, &ImageSync<I>::handle_copy_image>(this);
+  m_image_copy_request = ImageCopyRequest<I>::create(
+    m_local_image_ctx, m_remote_image_ctx, m_timer, m_timer_lock,
+    m_journaler, m_client_meta, &m_client_meta->sync_points.front(),
+    ctx);
+  m_lock.Unlock();
+
+  m_image_copy_request->send();
+}
+
+template <typename I>
+void ImageSync<I>::handle_copy_image(int r) {
+  {
+    Mutex::Locker locker(m_lock);
+    m_image_copy_request = nullptr;
+    if (r == 0 && m_canceled) {
+      r = -ECANCELED;
+    }
+  }
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r == -ECANCELED) {
+    ldout(cct, 10) << "image copy canceled" << dendl;
+    finish(r);
+    return;
+  } else if (r < 0) {
+    lderr(cct) << "failed to copy image: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  send_prune_sync_points();
+}
+
+template <typename I>
+void ImageSync<I>::send_prune_sync_points() {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  Context *ctx = create_context_callback<
+    ImageSync<I>, &ImageSync<I>::handle_prune_sync_points>(this);
+  SyncPointPruneRequest<I> *request = SyncPointPruneRequest<I>::create(
+    m_remote_image_ctx, true, m_journaler, m_client_meta, ctx);
+  request->send();
+}
+
+template <typename I>
+void ImageSync<I>::handle_prune_sync_points(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to prune sync point: "
+               << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  if (!m_client_meta->sync_points.empty()) {
+    send_copy_image();
+    return;
+  }
+
+  finish(0);
+}
+
+template <typename I>
+void ImageSync<I>::finish(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::ImageSync<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/ImageSync.h
+++ b/src/tools/rbd_mirror/ImageSync.h
@@ -1,0 +1,109 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_SYNC_H
+#define RBD_MIRROR_IMAGE_SYNC_H
+
+#include "include/int_types.h"
+#include "librbd/Journal.h"
+#include "common/Mutex.h"
+#include <map>
+#include <vector>
+
+class Context;
+class Mutex;
+class SafeTimer;
+namespace journal { class Journaler; }
+namespace librbd { class ImageCtx; }
+namespace librbd { namespace journal { struct MirrorPeerClientMeta; } }
+
+namespace rbd {
+namespace mirror {
+
+namespace image_sync { template <typename> class ImageCopyRequest; }
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class ImageSync {
+public:
+  typedef librbd::journal::TypeTraits<ImageCtxT> TypeTraits;
+  typedef typename TypeTraits::Journaler Journaler;
+  typedef librbd::journal::MirrorPeerClientMeta MirrorPeerClientMeta;
+
+  ImageSync(ImageCtxT *local_image_ctx, ImageCtxT *remote_image_ctx,
+            SafeTimer *timer, Mutex *timer_lock, const std::string &mirror_uuid,
+            Journaler *journaler, MirrorPeerClientMeta *client_meta,
+            Context *on_finish);
+
+  void start();
+  void cancel();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * PRUNE_CATCH_UP_SYNC_POINT
+   *    |
+   *    v
+   * CREATE_SYNC_POINT (skip if already exists and
+   *    |               not disconnected)
+   *    v
+   * COPY_SNAPSHOTS
+   *    |
+   *    v
+   * COPY_IMAGE . . . . . .
+   *    |                 .
+   *    v                 .
+   * PRUNE_SYNC_POINTS    . (image sync canceled)
+   *    |                 .
+   *    v                 .
+   * <finish> < . . . . . .
+   *
+   * @endverbatim
+   */
+
+  typedef std::vector<librados::snap_t> SnapIds;
+  typedef std::map<librados::snap_t, SnapIds> SnapMap;
+
+  ImageCtxT *m_local_image_ctx;
+  ImageCtxT *m_remote_image_ctx;
+  SafeTimer *m_timer;
+  Mutex *m_timer_lock;
+  std::string m_mirror_uuid;
+  Journaler *m_journaler;
+  MirrorPeerClientMeta *m_client_meta;
+  Context *m_on_finish;
+
+  SnapMap m_snap_map;
+
+  Mutex m_lock;
+  bool m_canceled = false;
+
+  image_sync::ImageCopyRequest<ImageCtxT> *m_image_copy_request;
+
+  void send_prune_catch_up_sync_point();
+  void handle_prune_catch_up_sync_point(int r);
+
+  void send_create_sync_point();
+  void handle_create_sync_point(int r);
+
+  void send_copy_snapshots();
+  void handle_copy_snapshots(int r);
+
+  void send_copy_image();
+  void handle_copy_image(int r);
+
+  void send_prune_sync_points();
+  void handle_prune_sync_points(int r);
+
+  void finish(int r);
+};
+
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::ImageSync<librbd::ImageCtx>;
+
+#endif // RBD_MIRROR_IMAGE_SYNC_H

--- a/src/tools/rbd_mirror/image_sync/ImageCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/ImageCopyRequest.cc
@@ -1,0 +1,287 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "ImageCopyRequest.h"
+#include "ObjectCopyRequest.h"
+#include "common/errno.h"
+#include "journal/Journaler.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_sync::ImageCopyRequest: " \
+                           << this << " " << __func__
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+using librbd::util::create_context_callback;
+using librbd::util::unique_lock_name;
+
+template <typename I>
+ImageCopyRequest<I>::ImageCopyRequest(I *local_image_ctx, I *remote_image_ctx,
+                                      SafeTimer *timer, Mutex *timer_lock,
+                                      Journaler *journaler,
+                                      MirrorPeerClientMeta *client_meta,
+                                      MirrorPeerSyncPoint *sync_point,
+                                      Context *on_finish)
+  : m_local_image_ctx(local_image_ctx), m_remote_image_ctx(remote_image_ctx),
+    m_timer(timer), m_timer_lock(timer_lock), m_journaler(journaler),
+    m_client_meta(client_meta), m_sync_point(sync_point),
+    m_on_finish(on_finish),
+    m_lock(unique_lock_name("ImageCopyRequest::m_lock", this)),
+    m_client_meta_copy(*client_meta) {
+  assert(!m_client_meta_copy.sync_points.empty());
+  assert(!m_client_meta_copy.snap_seqs.empty());
+}
+
+template <typename I>
+void ImageCopyRequest<I>::send() {
+  int r = compute_snap_map();
+  if (r < 0) {
+    finish(r);
+    return;
+  }
+
+  send_update_max_object_count();
+}
+
+template <typename I>
+void ImageCopyRequest<I>::cancel() {
+  Mutex::Locker locker(m_lock);
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+  m_canceled = true;
+}
+
+template <typename I>
+void ImageCopyRequest<I>::send_update_max_object_count() {
+  uint64_t max_objects = m_client_meta->sync_object_count;
+  {
+    RWLock::RLocker snap_locker(m_remote_image_ctx->snap_lock);
+    max_objects = std::max(max_objects,
+                           m_remote_image_ctx->get_object_count(CEPH_NOSNAP));
+    for (auto snap_id : m_remote_image_ctx->snaps) {
+      max_objects = std::max(max_objects,
+                             m_remote_image_ctx->get_object_count(snap_id));
+    }
+  }
+
+  if (max_objects == m_client_meta->sync_object_count) {
+    send_object_copies();
+    return;
+  }
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": sync_object_count=" << max_objects << dendl;
+
+  m_client_meta_copy = *m_client_meta;
+  m_client_meta_copy.sync_object_count = max_objects;
+
+  bufferlist client_data_bl;
+  librbd::journal::ClientData client_data(m_client_meta_copy);
+  ::encode(client_data, client_data_bl);
+
+  Context *ctx = create_context_callback<
+    ImageCopyRequest<I>, &ImageCopyRequest<I>::handle_update_max_object_count>(
+      this);
+  m_journaler->update_client(client_data_bl, ctx);
+}
+
+template <typename I>
+void ImageCopyRequest<I>::handle_update_max_object_count(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to update client data: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  // update provided meta structure to reflect reality
+  m_client_meta->sync_object_count = m_client_meta_copy.sync_object_count;
+  m_object_no = 0;
+  if (m_sync_point->object_number) {
+    m_object_no = *m_sync_point->object_number + 1;
+  }
+  m_end_object_no = m_client_meta_copy.sync_object_count;
+
+  send_object_copies();
+}
+
+template <typename I>
+void ImageCopyRequest<I>::send_object_copies() {
+  CephContext *cct = m_local_image_ctx->cct;
+  bool complete;
+  {
+    Mutex::Locker locker(m_lock);
+    for (int i = 0; i < cct->_conf->rbd_concurrent_management_ops; ++i) {
+      send_next_object_copy();
+      if (m_ret_val < 0 && m_current_ops == 0) {
+        break;
+      }
+    }
+    complete = (m_current_ops == 0);
+  }
+  if (complete) {
+    send_flush_sync_point();
+  }
+}
+
+template <typename I>
+void ImageCopyRequest<I>::send_next_object_copy() {
+  assert(m_lock.is_locked());
+  if (m_canceled) {
+    return;
+  } else if (m_ret_val < 0 || m_object_no >= m_end_object_no) {
+    return;
+  }
+
+  uint64_t ono = m_object_no++;
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": object_num=" << ono << dendl;
+
+  ++m_current_ops;
+
+  Context *ctx = create_context_callback<
+    ImageCopyRequest<I>, &ImageCopyRequest<I>::handle_object_copy>(this);
+  ObjectCopyRequest<I> *req = ObjectCopyRequest<I>::create(
+    m_local_image_ctx, m_remote_image_ctx, &m_snap_map, ono, ctx);
+  req->send();
+}
+
+template <typename I>
+void ImageCopyRequest<I>::handle_object_copy(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  bool complete;
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_current_ops > 0);
+    --m_current_ops;
+
+    if (r < 0) {
+      lderr(cct) << "object copy failed: " << cpp_strerror(r) << dendl;
+      if (m_ret_val == 0) {
+        m_ret_val = r;
+      }
+    }
+
+    send_next_object_copy();
+    complete = (m_current_ops == 0);
+  }
+
+  if (complete) {
+    send_flush_sync_point();
+  }
+}
+
+template <typename I>
+void ImageCopyRequest<I>::send_flush_sync_point() {
+  if (m_ret_val < 0) {
+    finish(m_ret_val);
+    return;
+  }
+
+  m_client_meta_copy = *m_client_meta;
+  if (m_object_no > 0) {
+    m_sync_point->object_number = m_object_no - 1;
+  } else {
+    m_sync_point->object_number = boost::none;
+  }
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": sync_point=" << *m_sync_point << dendl;
+
+  bufferlist client_data_bl;
+  librbd::journal::ClientData client_data(m_client_meta_copy);
+  ::encode(client_data, client_data_bl);
+
+  Context *ctx = create_context_callback<
+    ImageCopyRequest<I>, &ImageCopyRequest<I>::handle_flush_sync_point>(
+      this);
+  m_journaler->update_client(client_data_bl, ctx);
+}
+
+template <typename I>
+void ImageCopyRequest<I>::handle_flush_sync_point(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    *m_client_meta = m_client_meta_copy;
+
+    lderr(cct) << "failed to update client data: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  finish(0);
+}
+
+template <typename I>
+void ImageCopyRequest<I>::finish(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+template <typename I>
+int ImageCopyRequest<I>::compute_snap_map() {
+  CephContext *cct = m_local_image_ctx->cct;
+
+  librados::snap_t snap_id_start = 0;
+  librados::snap_t snap_id_end;
+  {
+    RWLock::RLocker snap_locker(m_remote_image_ctx->snap_lock);
+    snap_id_end = m_remote_image_ctx->get_snap_id(m_sync_point->snap_name);
+    if (snap_id_end == CEPH_NOSNAP) {
+      lderr(cct) << "failed to locate snapshot: "
+                 << m_sync_point->snap_name << dendl;
+      return -ENOENT;
+    }
+
+    if (!m_sync_point->from_snap_name.empty()) {
+      snap_id_start = m_remote_image_ctx->get_snap_id(
+        m_sync_point->from_snap_name);
+      if (snap_id_start == CEPH_NOSNAP) {
+        lderr(cct) << "failed to locate from snapshot: "
+                   << m_sync_point->from_snap_name << dendl;
+        return -ENOENT;
+      }
+    }
+  }
+
+  SnapIds snap_ids;
+  for (auto it = m_client_meta->snap_seqs.begin();
+       it != m_client_meta->snap_seqs.end(); ++it) {
+    snap_ids.insert(snap_ids.begin(), it->second);
+    if (it->first < snap_id_start) {
+      continue;
+    } else if (it->first > snap_id_end) {
+      break;
+    }
+
+    m_snap_map[it->first] = snap_ids;
+  }
+
+  if (m_snap_map.empty()) {
+    lderr(cct) << "failed to map snapshots within boundary" << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_sync::ImageCopyRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_sync/ImageCopyRequest.h
+++ b/src/tools/rbd_mirror/image_sync/ImageCopyRequest.h
@@ -1,0 +1,119 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_SYNC_IMAGE_COPY_REQUEST_H
+#define RBD_MIRROR_IMAGE_SYNC_IMAGE_COPY_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/rados/librados.hpp"
+#include "common/Mutex.h"
+#include "librbd/Journal.h"
+#include "librbd/journal/Types.h"
+#include <map>
+#include <vector>
+
+class Context;
+namespace journal { class Journaler; }
+namespace librbd { struct ImageCtx; }
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class ImageCopyRequest {
+public:
+  typedef std::vector<librados::snap_t> SnapIds;
+  typedef std::map<librados::snap_t, SnapIds> SnapMap;
+  typedef librbd::journal::TypeTraits<ImageCtxT> TypeTraits;
+  typedef typename TypeTraits::Journaler Journaler;
+  typedef librbd::journal::MirrorPeerSyncPoint MirrorPeerSyncPoint;
+  typedef librbd::journal::MirrorPeerClientMeta MirrorPeerClientMeta;
+
+  static ImageCopyRequest* create(ImageCtxT *local_image_ctx,
+                                  ImageCtxT *remote_image_ctx,
+                                  SafeTimer *timer, Mutex *timer_lock,
+                                  Journaler *journaler,
+                                  MirrorPeerClientMeta *client_meta,
+                                  MirrorPeerSyncPoint *sync_point,
+                                  Context *on_finish) {
+    return new ImageCopyRequest(local_image_ctx, remote_image_ctx, timer,
+                                timer_lock, journaler, client_meta, sync_point,
+                                on_finish);
+  }
+
+  ImageCopyRequest(ImageCtxT *local_image_ctx, ImageCtxT *remote_image_ctx,
+                   SafeTimer *timer, Mutex *timer_lock, Journaler *journaler,
+                   MirrorPeerClientMeta *client_meta,
+                   MirrorPeerSyncPoint *sync_point, Context *on_finish);
+
+  void send();
+  void cancel();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * UPDATE_MAX_OBJECT_COUNT
+   *    |
+   *    |   . . . . .
+   *    |   .       .  (parallel execution of
+   *    v   v       .   multiple objects at once)
+   * COPY_OBJECT  . .
+   *    |
+   *    v
+   * FLUSH_SYNC_POINT
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  ImageCtxT *m_local_image_ctx;
+  ImageCtxT *m_remote_image_ctx;
+  SafeTimer *m_timer;
+  Mutex *m_timer_lock;
+  Journaler *m_journaler;
+  MirrorPeerClientMeta *m_client_meta;
+  MirrorPeerSyncPoint *m_sync_point;
+  Context *m_on_finish;
+
+  SnapMap m_snap_map;
+
+  Mutex m_lock;
+  bool m_canceled = false;
+
+  uint64_t m_object_no = 0;
+  uint64_t m_end_object_no;
+  uint64_t m_current_ops = 0;
+  int m_ret_val = 0;
+
+  MirrorPeerClientMeta m_client_meta_copy;
+
+  void send_update_max_object_count();
+  void handle_update_max_object_count(int r);
+
+  void send_object_copies();
+  void send_next_object_copy();
+  void handle_object_copy(int r);
+
+  void send_flush_sync_point();
+  void handle_flush_sync_point(int r);
+
+  void finish(int r);
+
+  int compute_snap_map();
+
+};
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_sync::ImageCopyRequest<librbd::ImageCtx>;
+
+#endif // RBD_MIRROR_IMAGE_SYNC_IMAGE_COPY_REQUEST_H

--- a/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
@@ -1,0 +1,299 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "ObjectCopyRequest.h"
+#include "librados/snap_set_diff.h"
+#include "librbd/Utils.h"
+#include "common/errno.h"
+
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_sync::ObjectCopyRequest: " \
+                           << this << " " << __func__
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_safe_callback;
+
+template <typename I>
+ObjectCopyRequest<I>::ObjectCopyRequest(I *local_image_ctx, I *remote_image_ctx,
+                                        const SnapMap *snap_map,
+                                        uint64_t object_number,
+                                        Context *on_finish)
+  : m_local_image_ctx(local_image_ctx), m_remote_image_ctx(remote_image_ctx),
+    m_snap_map(snap_map), m_object_number(object_number),
+    m_on_finish(on_finish) {
+  assert(!snap_map->empty());
+
+  m_local_io_ctx.dup(m_local_image_ctx->data_ctx);
+  m_local_oid = m_local_image_ctx->get_object_name(object_number);
+
+  m_remote_io_ctx.dup(m_remote_image_ctx->data_ctx);
+  m_remote_oid = m_remote_image_ctx->get_object_name(object_number);
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::send() {
+  send_list_snaps();
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::send_list_snaps() {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  librados::AioCompletion *rados_completion = create_rados_ack_callback<
+    ObjectCopyRequest<I>, &ObjectCopyRequest<I>::handle_list_snaps>(this);
+
+  librados::ObjectReadOperation op;
+  op.list_snaps(&m_snap_set, &m_snap_ret);
+
+  m_remote_io_ctx.snap_set_read(CEPH_SNAPDIR);
+  int r = m_remote_io_ctx.aio_operate(m_remote_oid, rados_completion, &op,
+                                      nullptr);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::handle_list_snaps(int r) {
+  if (r == 0 && m_snap_ret < 0) {
+    r = m_snap_ret;
+  }
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r == -ENOENT) {
+    finish(0);
+    return;
+  }
+  if (r < 0) {
+    lderr(cct) << "failed to list snaps: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  compute_diffs();
+  send_read_object();
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::send_read_object() {
+  CephContext *cct = m_local_image_ctx->cct;
+  if (m_snap_sync_ops.empty()) {
+    // no more snapshot diffs to read from remote
+    finish(0);
+    return;
+  }
+
+  // build the read request
+  auto &sync_ops = m_snap_sync_ops.begin()->second;
+  assert(!sync_ops.empty());
+
+  // map the sync op start snap id back to the necessary read snap id
+  auto snap_map_it = m_snap_map->upper_bound(
+    m_snap_sync_ops.begin()->first);
+  assert(snap_map_it != m_snap_map->end());
+  librados::snap_t snap_seq = snap_map_it->first;
+  m_remote_io_ctx.snap_set_read(snap_seq);
+
+  bool read_required = false;
+  librados::ObjectReadOperation op;
+  for (auto &sync_op : sync_ops) {
+    switch (std::get<0>(sync_op)) {
+    case SYNC_OP_TYPE_WRITE:
+      if (!read_required) {
+        ldout(cct, 20) << ": snap_seq=" << snap_seq << dendl;
+        read_required = true;
+      }
+
+      ldout(cct, 20) << ": read op: " << std::get<1>(sync_op) << "~"
+                     << std::get<2>(sync_op) << dendl;
+      op.read(std::get<1>(sync_op), std::get<2>(sync_op),
+              &std::get<3>(sync_op), nullptr);
+      break;
+    default:
+      break;
+    }
+  }
+
+  if (!read_required) {
+    // nothing written to this object for this snapshot (must be trunc/remove)
+    send_write_object();
+    return;
+  }
+
+  librados::AioCompletion *comp = create_rados_safe_callback<
+    ObjectCopyRequest<I>, &ObjectCopyRequest<I>::handle_read_object>(this);
+  int r = m_remote_io_ctx.aio_operate(m_remote_oid, comp, &op, nullptr);
+  assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::handle_read_object(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to read from remote object: " << cpp_strerror(r)
+               << dendl;
+    finish(r);
+    return;
+  }
+
+  send_write_object();
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::send_write_object() {
+  // retrieve the local snap context for the op
+  SnapIds snap_ids;
+  librados::snap_t snap_seq = m_snap_sync_ops.begin()->first;
+  if (snap_seq != 0) {
+    auto snap_map_it = m_snap_map->find(snap_seq);
+    assert(snap_map_it != m_snap_map->end());
+    snap_ids = snap_map_it->second;
+  }
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": "
+                 << "snap_seq=" << snap_seq << ", "
+                 << "snaps=" << snap_ids << dendl;
+
+  auto &sync_ops = m_snap_sync_ops.begin()->second;
+  assert(!sync_ops.empty());
+
+  librados::ObjectWriteOperation op;
+  for (auto &sync_op : sync_ops) {
+    switch (std::get<0>(sync_op)) {
+    case SYNC_OP_TYPE_WRITE:
+      ldout(cct, 20) << ": write op: " << std::get<1>(sync_op) << "~"
+                     << std::get<3>(sync_op).length() << dendl;
+      op.write(std::get<1>(sync_op), std::get<3>(sync_op));
+      break;
+    case SYNC_OP_TYPE_TRUNC:
+      ldout(cct, 20) << ": trunc op: " << std::get<1>(sync_op) << dendl;
+      op.truncate(std::get<1>(sync_op));
+      break;
+    case SYNC_OP_TYPE_REMOVE:
+      ldout(cct, 20) << ": remove op" << dendl;
+      op.remove();
+      break;
+    default:
+      assert(false);
+    }
+  }
+
+  librados::AioCompletion *comp = create_rados_safe_callback<
+    ObjectCopyRequest<I>, &ObjectCopyRequest<I>::handle_write_object>(this);
+  int r = m_local_io_ctx.aio_operate(m_local_oid, comp, &op, snap_seq,
+                                     snap_ids);
+  assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::handle_write_object(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r == -ENOENT) {
+    r = 0;
+  }
+  if (r < 0) {
+    lderr(cct) << "failed to write to local object: " << cpp_strerror(r)
+               << dendl;
+    finish(r);
+    return;
+  }
+
+  m_snap_sync_ops.erase(m_snap_sync_ops.begin());
+  if (!m_snap_sync_ops.empty()) {
+    send_read_object();
+    return;
+  }
+
+  finish(r);
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::compute_diffs() {
+  CephContext *cct = m_local_image_ctx->cct;
+
+  uint64_t prev_end_size = 0;
+  bool prev_exists = false;
+  librados::snap_t start_snap_id = 0;
+  librados::snap_t end_snap_id;
+  for (auto &pair : *m_snap_map) {
+    assert(!pair.second.empty());
+    end_snap_id = pair.second.front();
+
+    interval_set<uint64_t> diff;
+    uint64_t end_size;
+    bool exists;
+    calc_snap_set_diff(cct, m_snap_set, start_snap_id, end_snap_id, &diff,
+                       &end_size, &exists);
+
+    ldout(cct, 20) << ": "
+                   << "start_snap=" << start_snap_id << ", "
+                   << "end_snap_id=" << end_snap_id << ", "
+                   << "diff=" << diff << ", "
+                   << "end_size=" << end_size << ", "
+                   << "exists=" << exists << dendl;
+
+    if (exists) {
+      // clip diff to size of object (in case it was truncated)
+      if (end_size < prev_end_size) {
+        interval_set<uint64_t> trunc;
+        trunc.insert(end_size, prev_end_size);
+        trunc.intersection_of(diff);
+        diff.subtract(trunc);
+        ldout(cct, 20) << ": clearing truncate diff: " << trunc << dendl;
+      }
+
+      // object write/zero, or truncate
+      for (auto it = diff.begin(); it != diff.end(); ++it) {
+        ldout(cct, 20) << ": read/write op: " << it.get_start() << "~"
+                       << it.get_len() << dendl;
+        m_snap_sync_ops[start_snap_id].emplace_back(SYNC_OP_TYPE_WRITE,
+                                                    it.get_start(),
+                                                    it.get_len(),
+                                                    bufferlist());
+      }
+      if (end_size < prev_end_size) {
+        ldout(cct, 20) << ": trunc op: " << end_size << dendl;
+        m_snap_sync_ops[start_snap_id].emplace_back(SYNC_OP_TYPE_TRUNC,
+                                                    end_size, 0U, bufferlist());
+      }
+    } else if (prev_exists) {
+      // object remove
+      ldout(cct, 20) << ": remove op" << dendl;
+      m_snap_sync_ops[start_snap_id].emplace_back(SYNC_OP_TYPE_REMOVE, 0U, 0U,
+                                                  bufferlist());
+    }
+
+    prev_end_size = end_size;
+    prev_exists = exists;
+    start_snap_id = end_snap_id;
+  }
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::finish(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_sync::ObjectCopyRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.h
+++ b/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.h
@@ -1,0 +1,118 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_SYNC_OBJECT_COPY_REQUEST_H
+#define RBD_MIRROR_IMAGE_SYNC_OBJECT_COPY_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/rados/librados.hpp"
+#include "common/snap_types.h"
+#include "librbd/ImageCtx.h"
+#include <list>
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+class Context;
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class ObjectCopyRequest {
+public:
+  typedef std::vector<librados::snap_t> SnapIds;
+  typedef std::map<librados::snap_t, SnapIds> SnapMap;
+
+  static ObjectCopyRequest* create(ImageCtxT *local_image_ctx,
+                                   ImageCtxT *remote_image_ctx,
+                                   const SnapMap *snap_map,
+                                   uint64_t object_number, Context *on_finish) {
+    return new ObjectCopyRequest(local_image_ctx, remote_image_ctx, snap_map,
+                                 object_number, on_finish);
+  }
+
+  ObjectCopyRequest(ImageCtxT *local_image_ctx, ImageCtxT *remote_image_ctx,
+                    const SnapMap *snap_map, uint64_t object_number,
+                    Context *on_finish);
+
+  void send();
+
+  // testing support
+  inline librados::IoCtx &get_local_io_ctx() {
+    return m_local_io_ctx;
+  }
+  inline librados::IoCtx &get_remote_io_ctx() {
+    return m_remote_io_ctx;
+  }
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * LIST_SNAPS
+   *    |
+   *    v
+   * READ_OBJECT <----\
+   *    |             | (repeat for each snapshot)
+   *    v             |
+   * WRITE_OBJECT ----/
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  enum SyncOpType {
+    SYNC_OP_TYPE_WRITE,
+    SYNC_OP_TYPE_TRUNC,
+    SYNC_OP_TYPE_REMOVE
+  };
+
+  typedef std::tuple<SyncOpType, uint64_t, uint64_t, bufferlist> SyncOp;
+  typedef std::list<SyncOp> SyncOps;
+  typedef std::map<librados::snap_t, SyncOps> SnapSyncOps;
+
+  ImageCtxT *m_local_image_ctx;
+  ImageCtxT *m_remote_image_ctx;
+  const SnapMap *m_snap_map;
+  uint64_t m_object_number;
+  Context *m_on_finish;
+
+  decltype(m_local_image_ctx->data_ctx) m_local_io_ctx;
+  decltype(m_remote_image_ctx->data_ctx) m_remote_io_ctx;
+  std::string m_local_oid;
+  std::string m_remote_oid;
+
+  librados::snap_set_t m_snap_set;
+  int m_snap_ret;
+
+  SnapSyncOps m_snap_sync_ops;
+
+  void send_list_snaps();
+  void handle_list_snaps(int r);
+
+  void send_read_object();
+  void handle_read_object(int r);
+
+  void send_write_object();
+  void handle_write_object(int r);
+
+  void compute_diffs();
+  void finish(int r);
+
+};
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_sync::ObjectCopyRequest<librbd::ImageCtx>;
+
+#endif // RBD_MIRROR_IMAGE_SYNC_OBJECT_COPY_REQUEST_H

--- a/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.h
+++ b/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.h
@@ -58,10 +58,16 @@ private:
    * LIST_SNAPS
    *    |
    *    v
-   * READ_OBJECT <----\
-   *    |             | (repeat for each snapshot)
-   *    v             |
-   * WRITE_OBJECT ----/
+   * READ_OBJECT <--------\
+   *    |                 | (repeat for each snapshot)
+   *    v                 |
+   * WRITE_OBJECT --------/
+   *    |
+   *    |     /-----------\
+   *    |     |           | (repeat for each snapshot)
+   *    v     v           |
+   * UPDATE_OBJECT_MAP ---/ (skip if object
+   *    |                    map disabled)
    *    |
    *    v
    * <finish>
@@ -78,6 +84,7 @@ private:
   typedef std::tuple<SyncOpType, uint64_t, uint64_t, bufferlist> SyncOp;
   typedef std::list<SyncOp> SyncOps;
   typedef std::map<librados::snap_t, SyncOps> SnapSyncOps;
+  typedef std::map<librados::snap_t, uint8_t> SnapObjectStates;
 
   ImageCtxT *m_local_image_ctx;
   ImageCtxT *m_remote_image_ctx;
@@ -94,6 +101,7 @@ private:
   int m_snap_ret;
 
   SnapSyncOps m_snap_sync_ops;
+  SnapObjectStates m_snap_object_states;
 
   void send_list_snaps();
   void handle_list_snaps(int r);
@@ -103,6 +111,9 @@ private:
 
   void send_write_object();
   void handle_write_object(int r);
+
+  void send_update_object_map();
+  void handle_update_object_map(int r);
 
   void compute_diffs();
   void finish(int r);

--- a/src/tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc
@@ -1,0 +1,239 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "SnapshotCopyRequest.h"
+#include "common/errno.h"
+#include "journal/Journaler.h"
+#include "librbd/Operations.h"
+#include "librbd/Utils.h"
+#include "librbd/journal/Types.h"
+
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_sync::SnapshotCopyRequest: " \
+                           << this << " " << __func__
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+namespace {
+
+template <typename I>
+const std::string &get_snapshot_name(I *image_ctx, librados::snap_t snap_id) {
+  auto snap_it = std::find_if(image_ctx->snap_ids.begin(),
+                              image_ctx->snap_ids.end(),
+                              [snap_id](
+      const std::pair<std::string, librados::snap_t> &pair) {
+    return pair.second == snap_id;
+  });
+  assert(snap_it != image_ctx->snap_ids.end());
+  return snap_it->first;
+}
+
+} // anonymous namespace
+
+using librbd::util::create_context_callback;
+
+
+
+template <typename I>
+SnapshotCopyRequest<I>::SnapshotCopyRequest(I *local_image_ctx,
+                                            I *remote_image_ctx,
+                                            SnapMap *snap_map,
+                                            Journaler *journaler,
+                                            librbd::journal::MirrorPeerClientMeta *meta,
+                                            Context *on_finish)
+  : m_local_image_ctx(local_image_ctx), m_remote_image_ctx(remote_image_ctx),
+    m_snap_map(snap_map), m_journaler(journaler), m_client_meta(meta),
+    m_on_finish(on_finish), m_snap_seqs(meta->snap_seqs) {
+  m_snap_map->clear();
+
+  // snap ids ordered from oldest to newest
+  m_remote_snap_ids.insert(remote_image_ctx->snaps.begin(),
+                           remote_image_ctx->snaps.end());
+  m_local_snap_ids.insert(local_image_ctx->snaps.begin(),
+                          local_image_ctx->snaps.end());
+}
+
+template <typename I>
+void SnapshotCopyRequest<I>::send() {
+  send_snap_remove();
+}
+
+template <typename I>
+void SnapshotCopyRequest<I>::send_snap_remove() {
+  librados::snap_t local_snap_id = CEPH_NOSNAP;
+  while (local_snap_id == CEPH_NOSNAP && !m_local_snap_ids.empty()) {
+    librados::snap_t snap_id = *m_local_snap_ids.begin();
+
+    // if local snapshot id isn't in our mapping table, delete it
+    // we match by id since snapshots can be renamed
+    if (std::find_if(m_snap_seqs.begin(), m_snap_seqs.end(),
+                     [snap_id](const SnapSeqs::value_type& pair) {
+        return pair.second == snap_id; }) == m_snap_seqs.end()) {
+      local_snap_id = snap_id;
+      m_local_snap_ids.erase(m_local_snap_ids.begin());
+    }
+  }
+
+  if (local_snap_id == CEPH_NOSNAP && m_local_snap_ids.empty()) {
+    // no local snapshots to delete
+    send_snap_create();
+    return;
+  }
+
+  m_snap_name = get_snapshot_name(m_local_image_ctx, local_snap_id);
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": "
+                 << "snap_name=" << m_snap_name << ", "
+                 << "snap_id=" << local_snap_id << dendl;
+
+  Context *ctx = create_context_callback<
+    SnapshotCopyRequest<I>, &SnapshotCopyRequest<I>::handle_snap_remove>(
+      this);
+  RWLock::RLocker owner_locker(m_local_image_ctx->owner_lock);
+  m_local_image_ctx->operations->snap_remove(m_snap_name.c_str(), ctx);
+}
+
+template <typename I>
+void SnapshotCopyRequest<I>::handle_snap_remove(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to remove snapshot '" << m_snap_name << "': "
+               << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  send_snap_remove();
+}
+
+template <typename I>
+void SnapshotCopyRequest<I>::send_snap_create() {
+  librados::snap_t remote_snap_id = CEPH_NOSNAP;
+  while (remote_snap_id == CEPH_NOSNAP && !m_remote_snap_ids.empty()) {
+    librados::snap_t snap_id = *m_remote_snap_ids.begin();
+    if (m_snap_seqs.find(snap_id) == m_snap_seqs.end()) {
+      // missing remote -> local mapping
+      remote_snap_id = snap_id;
+    } else {
+      // already have remote -> local mapping
+      m_remote_snap_ids.erase(m_remote_snap_ids.begin());
+    }
+  }
+
+  if (remote_snap_id == CEPH_NOSNAP && m_remote_snap_ids.empty()) {
+    // no local snapshots to create
+    send_update_client();
+    return;
+  }
+
+  m_snap_name = get_snapshot_name(m_remote_image_ctx, remote_snap_id);
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": "
+                 << "snap_name=" << m_snap_name << ", "
+                 << "snap_id=" << remote_snap_id << dendl;
+
+  Context *ctx = create_context_callback<
+    SnapshotCopyRequest<I>, &SnapshotCopyRequest<I>::handle_snap_create>(
+      this);
+  RWLock::RLocker owner_locker(m_local_image_ctx->owner_lock);
+  m_local_image_ctx->operations->snap_create(m_snap_name.c_str(), ctx, 0U);
+}
+
+template <typename I>
+void SnapshotCopyRequest<I>::handle_snap_create(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to create snapshot '" << m_snap_name << "': "
+               << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  assert(!m_remote_snap_ids.empty());
+  librados::snap_t remote_snap_id = *m_remote_snap_ids.begin();
+  m_remote_snap_ids.erase(m_remote_snap_ids.begin());
+
+  auto snap_it = m_local_image_ctx->snap_ids.find(m_snap_name);
+  assert(snap_it != m_local_image_ctx->snap_ids.end());
+  librados::snap_t local_snap_id = snap_it->second;
+
+  ldout(cct, 20) << ": mapping remote snap id " << remote_snap_id << " to "
+                 << local_snap_id << dendl;
+  m_snap_seqs[remote_snap_id] = local_snap_id;
+
+  send_snap_create();
+}
+
+template <typename I>
+void SnapshotCopyRequest<I>::send_update_client() {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  compute_snap_map();
+
+  librbd::journal::MirrorPeerClientMeta client_meta(*m_client_meta);
+  client_meta.snap_seqs = m_snap_seqs;
+
+  librbd::journal::ClientData client_data(client_meta);
+  bufferlist data_bl;
+  ::encode(client_data, data_bl);
+
+  Context *ctx = create_context_callback<
+    SnapshotCopyRequest<I>, &SnapshotCopyRequest<I>::handle_update_client>(
+      this);
+  m_journaler->update_client(data_bl, ctx);
+}
+
+template <typename I>
+void SnapshotCopyRequest<I>::handle_update_client(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to update client data: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  m_client_meta->snap_seqs = m_snap_seqs;
+
+  finish(0);
+}
+
+template <typename I>
+void SnapshotCopyRequest<I>::finish(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r >= 0) {
+    m_client_meta->snap_seqs = m_snap_seqs;
+  }
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+template <typename I>
+void SnapshotCopyRequest<I>::compute_snap_map() {
+  SnapIds local_snap_ids;
+  for (auto &pair : m_snap_seqs) {
+    local_snap_ids.reserve(1 + local_snap_ids.size());
+    local_snap_ids.insert(local_snap_ids.begin(), pair.second);
+    m_snap_map->insert(std::make_pair(pair.first, local_snap_ids));
+  }
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_sync::SnapshotCopyRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc
@@ -94,7 +94,7 @@ void SnapshotCopyRequest<I>::send_snap_remove() {
     SnapshotCopyRequest<I>, &SnapshotCopyRequest<I>::handle_snap_remove>(
       this);
   RWLock::RLocker owner_locker(m_local_image_ctx->owner_lock);
-  m_local_image_ctx->operations->snap_remove(m_snap_name.c_str(), ctx);
+  m_local_image_ctx->operations->execute_snap_remove(m_snap_name.c_str(), ctx);
 }
 
 template <typename I>
@@ -143,7 +143,8 @@ void SnapshotCopyRequest<I>::send_snap_create() {
     SnapshotCopyRequest<I>, &SnapshotCopyRequest<I>::handle_snap_create>(
       this);
   RWLock::RLocker owner_locker(m_local_image_ctx->owner_lock);
-  m_local_image_ctx->operations->snap_create(m_snap_name.c_str(), ctx, 0U);
+  m_local_image_ctx->operations->execute_snap_create(m_snap_name.c_str(), ctx,
+                                                     0U);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_sync/SnapshotCopyRequest.h
+++ b/src/tools/rbd_mirror/image_sync/SnapshotCopyRequest.h
@@ -1,0 +1,112 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_SYNC_SNAPSHOT_COPY_REQUEST_H
+#define RBD_MIRROR_IMAGE_SYNC_SNAPSHOT_COPY_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/rados/librados.hpp"
+#include "common/snap_types.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Journal.h"
+#include <map>
+#include <set>
+#include <string>
+#include <tuple>
+
+class Context;
+namespace journal { class Journaler; }
+namespace librbd { namespace journal { struct MirrorPeerClientMeta; } }
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class SnapshotCopyRequest {
+public:
+  typedef librbd::journal::TypeTraits<ImageCtxT> TypeTraits;
+  typedef typename TypeTraits::Journaler Journaler;
+
+  typedef std::vector<librados::snap_t> SnapIds;
+  typedef std::map<librados::snap_t, SnapIds> SnapMap;
+
+  static SnapshotCopyRequest* create(ImageCtxT *local_image_ctx,
+                                     ImageCtxT *remote_image_ctx,
+                                     SnapMap *snap_map, Journaler *journaler,
+                                     librbd::journal::MirrorPeerClientMeta *client_meta,
+                                     Context *on_finish) {
+    return new SnapshotCopyRequest(local_image_ctx, remote_image_ctx,
+                                   snap_map, journaler, client_meta, on_finish);
+  }
+
+  SnapshotCopyRequest(ImageCtxT *local_image_ctx, ImageCtxT *remote_image_ctx,
+                      SnapMap *snap_map, Journaler *journaler,
+                      librbd::journal::MirrorPeerClientMeta *client_meta,
+                      Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    |   /-------\
+   *    |   |       |
+   *    v   v       | (repeat as needed)
+   * REMOVE_SNAP <--/
+   *    |
+   *    |   /-------\
+   *    |   |       |
+   *    v   v       | (repeat as needed)
+   * CREATE_SNAP <--/
+   *    |
+   *    v
+   * UPDATE_CLIENT
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  typedef std::set<librados::snap_t> SnapIdSet;
+  typedef std::map<librados::snap_t, librados::snap_t> SnapSeqs;
+
+  ImageCtxT *m_local_image_ctx;
+  ImageCtxT *m_remote_image_ctx;
+  SnapMap *m_snap_map;
+  Journaler *m_journaler;
+  librbd::journal::MirrorPeerClientMeta *m_client_meta;
+  Context *m_on_finish;
+
+  SnapIdSet m_local_snap_ids;
+  SnapIdSet m_remote_snap_ids;
+  SnapSeqs m_snap_seqs;
+
+  std::string m_snap_name;
+
+  void send_snap_remove();
+  void handle_snap_remove(int r);
+
+  void send_snap_create();
+  void handle_snap_create(int r);
+
+  void send_update_client();
+  void handle_update_client(int r);
+
+  void finish(int r);
+
+  void compute_snap_map();
+
+};
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_sync::SnapshotCopyRequest<librbd::ImageCtx>;
+
+#endif // RBD_MIRROR_IMAGE_SYNC_SNAPSHOT_COPY_REQUEST_H

--- a/src/tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc
@@ -1,0 +1,162 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "SyncPointCreateRequest.h"
+#include "include/uuid.h"
+#include "common/errno.h"
+#include "journal/Journaler.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Operations.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_sync::SyncPointCreateRequest: " \
+                           << this << " " << __func__
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+namespace {
+
+static const std::string SNAP_NAME_PREFIX(".rbd-mirror");
+
+} // anonymous namespace
+
+using librbd::util::create_context_callback;
+
+template <typename I>
+SyncPointCreateRequest<I>::SyncPointCreateRequest(I *remote_image_ctx,
+                                                  const std::string &mirror_uuid,
+                                                  Journaler *journaler,
+                                                  MirrorPeerClientMeta *client_meta,
+                                                  Context *on_finish)
+  : m_remote_image_ctx(remote_image_ctx), m_mirror_uuid(mirror_uuid),
+    m_journaler(journaler), m_client_meta(client_meta), m_on_finish(on_finish),
+    m_client_meta_copy(*client_meta) {
+  assert(m_client_meta->sync_points.size() < 2);
+
+  // initialize the updated client meta with the new sync point
+  m_client_meta_copy.sync_points.emplace_back();
+  if (m_client_meta_copy.sync_points.size() > 1) {
+    m_client_meta_copy.sync_points.back().from_snap_name =
+      m_client_meta_copy.sync_points.front().snap_name;
+  }
+}
+
+template <typename I>
+void SyncPointCreateRequest<I>::send() {
+  send_update_client();
+}
+
+template <typename I>
+void SyncPointCreateRequest<I>::send_update_client() {
+  uuid_d uuid_gen;
+  uuid_gen.generate_random();
+
+  MirrorPeerSyncPoint &sync_point = m_client_meta_copy.sync_points.back();
+  sync_point.snap_name = SNAP_NAME_PREFIX + "." + m_mirror_uuid + "." +
+                         uuid_gen.to_string();
+
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << ": sync_point=" << sync_point << dendl;
+
+  bufferlist client_data_bl;
+  librbd::journal::ClientData client_data(m_client_meta_copy);
+  ::encode(client_data, client_data_bl);
+
+  Context *ctx = create_context_callback<
+    SyncPointCreateRequest<I>, &SyncPointCreateRequest<I>::handle_update_client>(
+      this);
+  m_journaler->update_client(client_data_bl, ctx);
+}
+
+template <typename I>
+void SyncPointCreateRequest<I>::handle_update_client(int r) {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to update client data: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  // update provided meta structure to reflect reality
+  *m_client_meta = m_client_meta_copy;
+
+  send_refresh_image();
+}
+
+template <typename I>
+void SyncPointCreateRequest<I>::send_refresh_image() {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  Context *ctx = create_context_callback<
+    SyncPointCreateRequest<I>, &SyncPointCreateRequest<I>::handle_refresh_image>(
+      this);
+  m_remote_image_ctx->state->refresh(ctx);
+}
+
+template <typename I>
+void SyncPointCreateRequest<I>::handle_refresh_image(int r) {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "remote image refresh failed: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  send_create_snap();
+}
+
+template <typename I>
+void SyncPointCreateRequest<I>::send_create_snap() {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  MirrorPeerSyncPoint &sync_point = m_client_meta_copy.sync_points.back();
+
+  Context *ctx = create_context_callback<
+    SyncPointCreateRequest<I>, &SyncPointCreateRequest<I>::handle_create_snap>(
+      this);
+  m_remote_image_ctx->operations->snap_create(
+    sync_point.snap_name.c_str(), ctx);
+}
+
+template <typename I>
+void SyncPointCreateRequest<I>::handle_create_snap(int r) {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r == -EEXIST) {
+    send_update_client();
+    return;
+  } else if (r < 0) {
+    lderr(cct) << "failed to create snapshot: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  finish(0);
+}
+
+template <typename I>
+void SyncPointCreateRequest<I>::finish(int r) {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_sync::SyncPointCreateRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_sync/SyncPointCreateRequest.h
+++ b/src/tools/rbd_mirror/image_sync/SyncPointCreateRequest.h
@@ -1,0 +1,90 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_SYNC_SYNC_POINT_CREATE_REQUEST_H
+#define RBD_MIRROR_IMAGE_SYNC_SYNC_POINT_CREATE_REQUEST_H
+
+#include "librbd/Journal.h"
+#include "librbd/journal/Types.h"
+#include <string>
+
+class Context;
+namespace journal { class Journaler; }
+namespace librbd { class ImageCtx; }
+namespace librbd { namespace journal { struct MirrorPeerClientMeta; } }
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class SyncPointCreateRequest {
+public:
+  typedef librbd::journal::TypeTraits<ImageCtxT> TypeTraits;
+  typedef typename TypeTraits::Journaler Journaler;
+  typedef librbd::journal::MirrorPeerClientMeta MirrorPeerClientMeta;
+  typedef librbd::journal::MirrorPeerSyncPoint MirrorPeerSyncPoint;
+
+  static SyncPointCreateRequest* create(ImageCtxT *remote_image_ctx,
+                                        const std::string &mirror_uuid,
+                                        Journaler *journaler,
+                                        MirrorPeerClientMeta *client_meta,
+                                        Context *on_finish) {
+    return new SyncPointCreateRequest(remote_image_ctx, mirror_uuid, journaler,
+                                      client_meta, on_finish);
+  }
+
+  SyncPointCreateRequest(ImageCtxT *remote_image_ctx,
+                         const std::string &mirror_uuid, Journaler *journaler,
+                         MirrorPeerClientMeta *client_meta, Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * UPDATE_CLIENT < . .
+   *    |              .
+   *    v              .
+   * REFRESH_IMAGE     .
+   *    |              . (repeat on EEXIST)
+   *    v              .
+   * CREATE_SNAP . . . .
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  ImageCtxT *m_remote_image_ctx;
+  std::string m_mirror_uuid;
+  Journaler *m_journaler;
+  MirrorPeerClientMeta *m_client_meta;
+  Context *m_on_finish;
+
+  MirrorPeerClientMeta m_client_meta_copy;
+
+  void send_update_client();
+  void handle_update_client(int r);
+
+  void send_refresh_image();
+  void handle_refresh_image(int r);
+
+  void send_create_snap();
+  void handle_create_snap(int r);
+
+  void finish(int r);
+};
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_sync::SyncPointCreateRequest<librbd::ImageCtx>;
+
+#endif // RBD_MIRROR_IMAGE_SYNC_SYNC_POINT_CREATE_REQUEST_H

--- a/src/tools/rbd_mirror/image_sync/SyncPointPruneRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/SyncPointPruneRequest.cc
@@ -1,0 +1,202 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "SyncPointPruneRequest.h"
+#include "common/errno.h"
+#include "journal/Journaler.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Operations.h"
+#include "librbd/Utils.h"
+#include <set>
+
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_sync::SyncPointPruneRequest: " \
+                           << this << " " << __func__
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+using librbd::util::create_context_callback;
+
+template <typename I>
+SyncPointPruneRequest<I>::SyncPointPruneRequest(I *remote_image_ctx,
+                                                bool sync_complete,
+                                                Journaler *journaler,
+                                                MirrorPeerClientMeta *client_meta,
+                                                Context *on_finish)
+  : m_remote_image_ctx(remote_image_ctx), m_sync_complete(sync_complete),
+    m_journaler(journaler), m_client_meta(client_meta), m_on_finish(on_finish),
+    m_client_meta_copy(*client_meta) {
+}
+
+template <typename I>
+void SyncPointPruneRequest<I>::send() {
+  if (m_client_meta->sync_points.empty()) {
+    send_remove_snap();
+    return;
+  }
+
+  if (m_sync_complete) {
+    // if sync is complete, we can remove the master sync point
+    auto it = m_client_meta_copy.sync_points.begin();
+    MirrorPeerSyncPoint &sync_point = *it;
+
+    ++it;
+    if (it == m_client_meta_copy.sync_points.end() ||
+        it->from_snap_name != sync_point.snap_name) {
+      m_snap_names.push_back(sync_point.snap_name);
+    }
+
+    if (!sync_point.from_snap_name.empty()) {
+      m_snap_names.push_back(sync_point.from_snap_name);
+    }
+  } else {
+    // if we have more than one sync point, trim the extras off
+    std::set<std::string> snap_names;
+    for (auto it = m_client_meta_copy.sync_points.rbegin();
+         it != m_client_meta_copy.sync_points.rend(); ++it) {
+      MirrorPeerSyncPoint &sync_point =
+        m_client_meta_copy.sync_points.back();
+      if (&sync_point == &m_client_meta_copy.sync_points.front()) {
+        break;
+      }
+
+      if (snap_names.count(sync_point.snap_name) == 0) {
+        snap_names.insert(sync_point.snap_name);
+        m_snap_names.push_back(sync_point.snap_name);
+      }
+
+      MirrorPeerSyncPoint &front_sync_point =
+        m_client_meta_copy.sync_points.front();
+      if (!sync_point.from_snap_name.empty() &&
+          snap_names.count(sync_point.from_snap_name) == 0 &&
+          sync_point.from_snap_name != front_sync_point.snap_name) {
+        snap_names.insert(sync_point.from_snap_name);
+        m_snap_names.push_back(sync_point.from_snap_name);
+      }
+    }
+  }
+
+  send_remove_snap();
+}
+
+template <typename I>
+void SyncPointPruneRequest<I>::send_remove_snap() {
+  if (m_snap_names.empty()) {
+    send_refresh_image();
+    return;
+  }
+
+  std::string snap_name = m_snap_names.front();
+
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << ": snap_name=" << snap_name << dendl;
+
+  Context *ctx = create_context_callback<
+    SyncPointPruneRequest<I>, &SyncPointPruneRequest<I>::handle_remove_snap>(
+      this);
+  m_remote_image_ctx->operations->snap_remove(snap_name.c_str(), ctx);
+}
+
+template <typename I>
+void SyncPointPruneRequest<I>::handle_remove_snap(int r) {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  assert(!m_snap_names.empty());
+  std::string snap_name = m_snap_names.front();
+  m_snap_names.pop_front();
+
+  if (r == -ENOENT) {
+    r = 0;
+  }
+  if (r < 0) {
+    lderr(cct) << "failed to remove snapshot '" << snap_name << "': "
+               << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  send_remove_snap();
+}
+
+template <typename I>
+void SyncPointPruneRequest<I>::send_refresh_image() {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  Context *ctx = create_context_callback<
+    SyncPointPruneRequest<I>, &SyncPointPruneRequest<I>::handle_refresh_image>(
+      this);
+  m_remote_image_ctx->state->refresh(ctx);
+}
+
+template <typename I>
+void SyncPointPruneRequest<I>::handle_refresh_image(int r) {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "remote image refresh failed: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  send_update_client();
+}
+
+template <typename I>
+void SyncPointPruneRequest<I>::send_update_client() {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  if (m_sync_complete) {
+    m_client_meta_copy.sync_points.pop_front();
+  } else {
+    while (m_client_meta_copy.sync_points.size() > 1) {
+      m_client_meta_copy.sync_points.pop_back();
+    }
+  }
+
+  bufferlist client_data_bl;
+  librbd::journal::ClientData client_data(m_client_meta_copy);
+  ::encode(client_data, client_data_bl);
+
+  Context *ctx = create_context_callback<
+    SyncPointPruneRequest<I>, &SyncPointPruneRequest<I>::handle_update_client>(
+      this);
+  m_journaler->update_client(client_data_bl, ctx);
+}
+
+template <typename I>
+void SyncPointPruneRequest<I>::handle_update_client(int r) {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to update client data: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  // update provided meta structure to reflect reality
+  *m_client_meta = m_client_meta_copy;
+  finish(0);
+}
+
+template <typename I>
+void SyncPointPruneRequest<I>::finish(int r) {
+  CephContext *cct = m_remote_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_sync::SyncPointPruneRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_sync/SyncPointPruneRequest.h
+++ b/src/tools/rbd_mirror/image_sync/SyncPointPruneRequest.h
@@ -1,0 +1,94 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_SYNC_SYNC_POINT_PRUNE_REQUEST_H
+#define RBD_MIRROR_IMAGE_SYNC_SYNC_POINT_PRUNE_REQUEST_H
+
+#include "librbd/Journal.h"
+#include "librbd/journal/Types.h"
+#include <list>
+#include <string>
+
+class Context;
+namespace journal { class Journaler; }
+namespace librbd { class ImageCtx; }
+namespace librbd { namespace journal { struct MirrorPeerClientMeta; } }
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class SyncPointPruneRequest {
+public:
+  typedef librbd::journal::TypeTraits<ImageCtxT> TypeTraits;
+  typedef typename TypeTraits::Journaler Journaler;
+  typedef librbd::journal::MirrorPeerClientMeta MirrorPeerClientMeta;
+  typedef librbd::journal::MirrorPeerSyncPoint MirrorPeerSyncPoint;
+
+  static SyncPointPruneRequest* create(ImageCtxT *remote_image_ctx,
+                                       bool sync_complete,
+                                       Journaler *journaler,
+                                       MirrorPeerClientMeta *client_meta,
+                                       Context *on_finish) {
+    return new SyncPointPruneRequest(remote_image_ctx, sync_complete, journaler,
+                                      client_meta, on_finish);
+  }
+
+  SyncPointPruneRequest(ImageCtxT *remote_image_ctx, bool sync_complete,
+                        Journaler *journaler, MirrorPeerClientMeta *client_meta,
+                        Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    |    . . . . .
+   *    |    .       .
+   *    v    v       . (repeat if from snap
+   * REMOVE_SNAP . . .  unused by other sync)
+   *    |
+   *    v
+   * REFRESH_IMAGE
+   *    |
+   *    v
+   * UPDATE_CLIENT
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  ImageCtxT *m_remote_image_ctx;
+  bool m_sync_complete;
+  Journaler *m_journaler;
+  MirrorPeerClientMeta *m_client_meta;
+  Context *m_on_finish;
+
+  MirrorPeerClientMeta m_client_meta_copy;
+  std::list<std::string> m_snap_names;
+
+  void send_remove_snap();
+  void handle_remove_snap(int r);
+
+  void send_refresh_image();
+  void handle_refresh_image(int r);
+
+  void send_update_client();
+  void handle_update_client(int r);
+
+  void finish(int r);
+};
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_sync::SyncPointPruneRequest<librbd::ImageCtx>;
+
+#endif // RBD_MIRROR_IMAGE_SYNC_SYNC_POINT_PRUNE_REQUEST_H


### PR DESCRIPTION
This PR currently includes commits from several dependent in-review PRs.  The following functionality is still required:

- [x] create snapshot and register sync point in journal
- [x] invoke snapshot copy state machine
- [x] loop over all object numbers (calculate max from snapshots and HEAD version) and invoke object copy state machine
- [x] sync snapshot object maps
- [ ] periodically update sync point in journal