### PR TITLE
qa/workunits/rest/test.py: add confirmation to 'mds setmap'

### DIFF
--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -175,7 +175,7 @@ if __name__ == '__main__':
         map = expect('mds/getmap', 'GET', 200, '')
         assert(len(map.content) != 0)
         msg, r = expect_nofail(
-            'mds/setmap?epoch={0}'.format(current_epoch + 1), 'PUT', 200,
+            'mds/setmap?epoch={0}&confirm=--yes-i-really-mean-it'.format(current_epoch + 1), 'PUT', 200,
             'plain', {'Content-Type':'text/plain'}, data=map.content
             )
         if msg:


### PR DESCRIPTION
Broken when we added the confirmation in
fc3554e36af439ef1cec0be3d98ca0fabe15ba73

Fixes: #14606
Signed-off-by: Sage Weil <sage@redhat.com>