### PR TITLE
man/8/ceph-disk: fix formatting issue

### DIFF
--- a/doc/man/8/ceph-disk.rst
+++ b/doc/man/8/ceph-disk.rst
@@ -27,20 +27,19 @@ Synopsis
 
 | subcommands:
 
-    prepare             Prepare a directory or disk for a Ceph OSD
-    activate            Activate a Ceph OSD
-    activate-lockbox    Activate a Ceph lockbox
-    activate-block      Activate an OSD via its block device
-    activate-journal    Activate an OSD via its journal device
-    activate-all        Activate all tagged OSD partitions
-    list                List disks, partitions, and Ceph OSDs
-    suppress-activate   Suppress activate on a device (prefix)
-    unsuppress-activate
-                        Stop suppressing activate on a device (prefix)
-    deactivate          Deactivate a Ceph OSD
-    destroy             Destroy a Ceph OSD
-    zap                 Zap/erase/destroy a device's partition table (and contents)
-    trigger             Trigger an event (caled by udev)
+    prepare              Prepare a directory or disk for a Ceph OSD
+    activate             Activate a Ceph OSD
+    activate-lockbox     Activate a Ceph lockbox
+    activate-block       Activate an OSD via its block device
+    activate-journal     Activate an OSD via its journal device
+    activate-all         Activate all tagged OSD partitions
+    list                 List disks, partitions, and Ceph OSDs
+    suppress-activate    Suppress activate on a device (prefix)
+    unsuppress-activate  Stop suppressing activate on a device (prefix)
+    deactivate           Deactivate a Ceph OSD
+    destroy              Destroy a Ceph OSD
+    zap                  Zap/erase/destroy a device's partition table (and contents)
+    trigger              Trigger an event (caled by udev)
 
 Description
 ===========


### PR DESCRIPTION
ERROR: /srv/autobuild-ceph/gitbuilder.git/build/doc/man/8/ceph-disk.rst:39: Unexpected indentation.
WARNING: /srv/autobuild-ceph/gitbuilder.git/build/doc/man/8/ceph-disk.rst:40: Block quote ends without a blank line; unexpected unindent.

Signed-off-by: Sage Weil <sage@redhat.com>