### PR TITLE
os/bluestore/KernelDevice: force block size

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -869,6 +869,7 @@ OPTION(bdev_inject_crash_flush_delay, OPT_INT, 2) // wait N more seconds on flus
 OPTION(bdev_aio, OPT_BOOL, true)
 OPTION(bdev_aio_poll_ms, OPT_INT, 250)  // milliseconds
 OPTION(bdev_aio_max_queue_depth, OPT_INT, 32)
+OPTION(bdev_block_size, OPT_INT, 4096)
 
 // if yes, osd will unbind all NVMe devices from kernel driver and bind them
 // to the uio_pci_generic driver. The purpose is to prevent the case where

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -119,7 +119,17 @@ int KernelDevice::open(string p)
   } else {
     size = st.st_size;
   }
-  block_size = st.st_blksize;
+
+  // Operate as though the block size is 4 KB.  The backing file
+  // blksize doesn't strictly matter except that some file systems may
+  // require a read/modify/write if we write something smaller than
+  // it.
+  block_size = g_conf->bdev_block_size;
+  if (block_size != st.st_blksize) {
+    dout(1) << __func__ << " backing device/file reports st_blksize "
+	    << st.st_blksize << ", using bdev_block_size "
+	    << block_size << " anyway" << dendl;
+  }
 
   fs = FS::create_by_fd(fd_direct);
   assert(fs);


### PR DESCRIPTION
Ignore what the file or block device IO Block is.

Signed-off-by: Sage Weil <sage@redhat.com>