### PR TITLE
mon: default ec min_size to k+1

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4519,7 +4519,7 @@ int OSDMonitor::prepare_pool_size(const unsigned pool_type,
       err = get_erasure_code(erasure_code_profile, &erasure_code, ss);
       if (err == 0) {
 	*size = erasure_code->get_chunk_count();
-	*min_size = erasure_code->get_data_chunk_count();
+	*min_size = MIN(erasure_code->get_data_chunk_count() + 1, *size);
       }
     }
     break;


### PR DESCRIPTION
If m OSDs are down and we allow writes to the remaining k, the
PG could suffer split brain problems if one of these k goes down
during subsequent recovery. Default min_size to k+1 to be a bit
safer.

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>