### PR TITLE
rpm,deb: remove conditional BuildRequires for btrfs-progs

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -152,9 +152,7 @@ BuildRequires:	libbz2-devel
 %if 0%{with tcmalloc}
 BuildRequires:	gperftools-devel
 %endif
-%if 0%{with tests}
 BuildRequires:  btrfsprogs
-%endif
 BuildRequires:	mozilla-nss-devel
 BuildRequires:	keyutils-devel
 BuildRequires:	libatomic-ops-devel
@@ -165,9 +163,7 @@ BuildRequires:	python-Cython
 %if 0%{?_with_systemd}
 Requires:	systemd
 %endif
-%if 0%{with tests}
 BuildRequires:	btrfs-progs
-%endif
 BuildRequires:	nss-devel
 BuildRequires:	keyutils-libs-devel
 BuildRequires:	libatomic_ops-devel


### PR DESCRIPTION
By pull request 7742, the btrfs-progs package was considered as a BuildRequires
only when --with tests was engaged like :

    if %{with tests}
    BuildRequires: btrfsprogs
    %endif

That's perfectly valid for a spec file.

The issue we have is the following :
- yum-builddep called by install-deps.sh is used to prepare the build env by
installing the needed BuildRequires.
- %{with test} is defined by using a %bcond_with
- yum-builddep doesn't consider %{with test} as valid
- yum-builddep doesn't install the btrfs package

As per discussions with the yum team, there is no way to engage conditional flags with
yum-builddep.

So this patch, as per discussions with Nathan Cutler & Loic Dachary, is removing
the condition arond the BuildRequires.

Note that all BuildRequires defined with a %bcond_with would be affected by this
issue. The current specfile only have %bcond_without conditional BuildRequires
which is fine.

Fixes: #15042
Signed-off-by: Erwan Velu <erwan@redhat.com>