### PR TITLE
rgw: drop permissions of rgw/civetweb after startup

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -441,6 +441,8 @@ CephContext::CephContext(uint32_t module_type_, int init_flags_)
     _init_flags(init_flags_),
     _set_uid(0),
     _set_gid(0),
+    _set_uid_string(),
+    _set_gid_string(),
     _crypto_inited(false),
     _service_thread(NULL),
     _log_obs(NULL),

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -164,6 +164,17 @@ public:
     return _set_gid;
   }
 
+  void set_uid_gid_strings(std::string u, std::string g) {
+    _set_uid_string = u;
+    _set_gid_string = g;
+  }
+  std::string get_set_uid_string() const {
+    return _set_uid_string;
+  }
+  std::string get_set_gid_string() const {
+    return _set_gid_string;
+  }
+
 private:
   struct SingletonWrapper : boost::noncopyable {
     virtual ~SingletonWrapper() {}
@@ -192,6 +203,8 @@ private:
 
   uid_t _set_uid; ///< uid to drop privs to
   gid_t _set_gid; ///< gid to drop privs to
+  std::string _set_uid_string;
+  std::string _set_gid_string;
 
   bool _crypto_inited;
 

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -151,6 +151,8 @@ void global_init(std::vector < const char * > *alt_def_args,
       g_conf->setuser.length()) {
     uid_t uid = 0;  // zero means no change; we can only drop privs here.
     gid_t gid = 0;
+    std::string uid_string;
+    std::string gid_string;
     if (g_conf->setuser.length()) {
       uid = atoi(g_conf->setuser.c_str());
       if (!uid) {
@@ -165,6 +167,7 @@ void global_init(std::vector < const char * > *alt_def_args,
 	}
 	uid = p->pw_uid;
 	gid = p->pw_gid;
+	uid_string = g_conf->setuser;
       }
     }
     if (g_conf->setgroup.length() > 0) {
@@ -180,6 +183,7 @@ void global_init(std::vector < const char * > *alt_def_args,
 	  exit(1);
 	}
 	gid = g->gr_gid;
+	gid_string = g_conf->setgroup;
       }
     }
     if ((uid || gid) &&
@@ -201,6 +205,8 @@ void global_init(std::vector < const char * > *alt_def_args,
 	     << std::endl;
 	uid = 0;
 	gid = 0;
+	uid_string.erase();
+	gid_string.erase();
       } else {
 	priv_ss << "setuser_match_path "
 		<< g_conf->setuser_match_path << " owned by "
@@ -208,6 +214,7 @@ void global_init(std::vector < const char * > *alt_def_args,
       }
     }
     g_ceph_context->set_uid_gid(uid, gid);
+    g_ceph_context->set_uid_gid_strings(uid_string, gid_string);
     if ((flags & CINIT_FLAG_DEFER_DROP_PRIVILEGES) == 0) {
       if (setgid(gid) != 0) {
 	int r = errno;
@@ -221,9 +228,9 @@ void global_init(std::vector < const char * > *alt_def_args,
 	     << std::endl;
 	exit(1);
       }
-      priv_ss << "set uid:gid to " << uid << ":" << gid;
+      priv_ss << "set uid:gid to " << uid << ":" << gid << " (" << uid_string << ":" << gid_string << ")";
     } else {
-      priv_ss << "deferred set uid:gid to " << uid << ":" << gid;
+      priv_ss << "deferred set uid:gid to " << uid << ":" << gid << " (" << uid_string << ":" << gid_string << ")";
     }
   }
 

--- a/src/global/global_init.h
+++ b/src/global/global_init.h
@@ -35,7 +35,8 @@ void global_init(std::vector < const char * > *alt_def_args,
 		 uint32_t module_type,
 		 code_environment_t code_env,
 		 int flags,
-		 const char *data_dir_option = 0);
+		 const char *data_dir_option = 0,
+		 bool run_pre_init = true);
 
 // just the first half; enough to get config parsed but doesn't start up the
 // cct or log.

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -43,6 +43,14 @@ int RGWMongooseFrontend::run() {
   set_conf_default(conf_map, "num_threads", thread_pool_buf);
   set_conf_default(conf_map, "decode_url", "no");
 
+  // Set run_as_user. This will cause civetweb to invoke setuid() and setgid()
+  // based on pw_uid and pw_gid obtained from pw_name.
+  string uid_string = g_ceph_context->get_set_uid_string();
+  if (!uid_string.empty()) {
+    conf_map.erase("run_as_user");
+    conf_map["run_as_user"] = uid_string;
+  }
+
   const char *options[conf_map.size() * 2 + 1];
   int i = 0;
   for (map<string, string>::iterator iter = conf_map.begin();


### PR DESCRIPTION
An alternative to https://github.com/ceph/ceph/pull/7313

Differs in that it stores --setuser/--setgroup strings in CephContext to be used by civetweb directly when dropping permissions.

Fixes: http://tracker.ceph.com/issues/13600
