### PR TITLE
pybind/ceph_argparse: remove the invalid test

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -982,7 +982,7 @@ Subcommand ``reweight-by-pg`` reweight OSDs by PG distribution
 Usage::
 
 	ceph osd reweight-by-pg {<int[100-]>} {<poolname> [<poolname...]}
-	{--no-increasing} {--yes-i-really-mean-it}
+	{--no-increasing}
 
 Subcommand ``reweight-by-utilization`` reweight OSDs by utilization
 [overload-percentage-for-consideration, default 120].
@@ -990,7 +990,7 @@ Subcommand ``reweight-by-utilization`` reweight OSDs by utilization
 Usage::
 
 	ceph osd reweight-by-utilization {<int[100-]>}
-	{--no-increasing} {--yes-i-really-mean-it}
+	{--no-increasing}
 
 Subcommand ``rm`` removes osd(s) <id> [<id>...] in the cluster.
 

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -1112,7 +1112,6 @@ class TestOSD(TestArgparse):
         self.assert_valid_command(['osd', 'reweight-by-utilization'])
         self.assert_valid_command(['osd', 'reweight-by-utilization', '100'])
         self.assert_valid_command(['osd', 'reweight-by-utilization', '--no-increasing'])
-        self.assert_valid_command(['osd', 'reweight-by-utilization', '--yes-i-really-mean-it'])
         assert_equal({}, validate_command(sigdict, ['osd',
                                                     'reweight-by-utilization',
                                                     '50']))


### PR DESCRIPTION
remove the invalid test in
test_ceph_argparse.TestOSD.test_reweight_by_utilization
introduced in 1a6ad50

Fixes: #15037
Signed-off-by: Kefu Chai <kchai@redhat.com>