### PR TITLE
infernalis: RPM packaging puts ceph_daemon.py in ceph-common, Debian packaging puts it in ceph (should be ceph-common) 

### DIFF
--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -30,3 +30,4 @@ etc/ceph/rbdmap
 etc/init.d/rbdmap
 lib/udev/rules.d/50-rbd.rules
 usr/lib/python*/dist-packages/ceph_argparse.py*
+usr/lib/python*/dist-packages/ceph_daemon.py*

--- a/debian/ceph.install
+++ b/debian/ceph.install
@@ -37,4 +37,3 @@ usr/share/man/man8/ceph-rest-api.8
 usr/share/man/man8/crushtool.8
 usr/share/man/man8/monmaptool.8
 usr/share/man/man8/osdmaptool.8
-usr/lib/python*/dist-packages/ceph_daemon.py*


### PR DESCRIPTION
http://tracker.ceph.com/issues/15048