### PR TITLE
Wip rgw sync status

### DIFF
--- a/src/mstart.sh
+++ b/src/mstart.sh
@@ -38,7 +38,7 @@ if [ $? -ne 0 ]; then
 fi
 
 pos=`echo $pos | cut -d: -f1`
-base_port=$((6800+pos*10))
+base_port=$((6800+pos*20))
 
 export VSTART_DEST=$RUN_ROOT_PATH/$instance
 export CEPH_PORT=$base_port

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1874,11 +1874,13 @@ static void tab_dump(const string& header, int width, const list<string>& entrie
 
 static void sync_status(Formatter *formatter)
 {
-  RGWZoneGroup zonegroup = store->get_zonegroup();
+  RGWRealm& realm = store->realm;
+  RGWZoneGroup& zonegroup = store->get_zonegroup();
   RGWZone& zone = store->get_zone();
 
   int width = 15;
 
+  cout << std::setw(width) << "realm" << std::setw(1) << " " << realm.get_id() << " (" << realm.get_name() << ")" << std::endl;
   cout << std::setw(width) << "zonegroup" << std::setw(1) << " " << zonegroup.get_id() << " (" << zonegroup.get_name() << ")" << std::endl;
   cout << std::setw(width) << "zone" << std::setw(1) << " " << zone.id << " (" << zone.name << ")" << std::endl;
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1719,7 +1719,7 @@ static void get_md_sync_status(list<string>& status)
       }
 
       if (!oldest.is_zero()) {
-        push_ss(ss, status) << "oldest change not applied: " << oldest;
+        push_ss(ss, status) << "oldest incremental change not applied: " << oldest;
       }
     }
   }
@@ -1742,7 +1742,7 @@ static void get_data_sync_status(const string& source_zone, list<string>& status
 
   ret = sync.read_sync_status();
   if (ret < 0) {
-    status.push_back(string("failed to read sync status: ") + cpp_strerror(-ret));
+    push_ss(ss, status, tab) << string("failed read sync status: ") + cpp_strerror(-ret);
     return;
   }
 
@@ -1797,7 +1797,7 @@ static void get_data_sync_status(const string& source_zone, list<string>& status
   rgw_datalog_info log_info;
   ret = sync.read_log_info(&log_info);
   if (ret < 0) {
-    status.push_back(string("failed to fetch local sync status: ") + cpp_strerror(-ret));
+    push_ss(ss, status, tab) << string("failed to fetch local sync status: ") + cpp_strerror(-ret);
     return;
   }
 
@@ -1806,7 +1806,7 @@ static void get_data_sync_status(const string& source_zone, list<string>& status
 
   ret = sync.read_source_log_shards_info(&source_shards_info);
   if (ret < 0) {
-    status.push_back(string("failed to fetch master sync status: ") + cpp_strerror(-ret));
+    push_ss(ss, status, tab) << string("failed to fetch source sync status: ") + cpp_strerror(-ret);
     return;
   }
 
@@ -1829,7 +1829,7 @@ static void get_data_sync_status(const string& source_zone, list<string>& status
 
   int total_behind = shards_behind.size() + (sync_status.sync_info.num_shards - num_inc);
   if (total_behind == 0) {
-    status.push_back("data is caught up with master");
+    push_ss(ss, status, tab) << "data is caught up with source";
   } else {
     push_ss(ss, status, tab) << "data is behind on " << total_behind << " shards";
 
@@ -1853,7 +1853,7 @@ static void get_data_sync_status(const string& source_zone, list<string>& status
       }
 
       if (!oldest.is_zero()) {
-        push_ss(ss, status, tab) << "oldest change not applied: " << oldest;
+        push_ss(ss, status, tab) << "oldest incremental change not applied: " << oldest;
       }
     }
   }

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -161,7 +161,7 @@ int RGWCoroutinesStack::operate(RGWCoroutinesEnv *_env)
   ldout(cct, 20) << *op << ": operate()" << dendl;
   int r = op->operate();
   if (r < 0) {
-    ldout(cct, 0) << "ERROR: op->operate() returned r=" << r << dendl;
+    ldout(cct, 20) << *op << ": operate() returned r=" << r << dendl;
   }
 
   error_flag = op->is_error();
@@ -442,7 +442,7 @@ int RGWCoroutinesManager::run(list<RGWCoroutinesStack *>& stacks)
     ret = stack->operate(&env);
     stack->set_is_scheduled(false);
     if (ret < 0) {
-      ldout(cct, 0) << "ERROR: stack->operate() returned ret=" << ret << dendl;
+      ldout(cct, 20) << "stack->operate() returned ret=" << ret << dendl;
     }
 
     if (stack->is_error()) {
@@ -568,7 +568,7 @@ int RGWCoroutinesManager::run(RGWCoroutine *op)
 
   int r = run(stacks);
   if (r < 0) {
-    ldout(cct, 0) << "ERROR: run(stacks) returned r=" << r << dendl;
+    ldout(cct, 20) << "run(stacks) returned r=" << r << dendl;
   } else {
     r = op->get_ret_status();
   }
@@ -579,7 +579,9 @@ int RGWCoroutinesManager::run(RGWCoroutine *op)
 
 RGWAioCompletionNotifier *RGWCoroutinesManager::create_completion_notifier(RGWCoroutinesStack *stack)
 {
-  return new RGWAioCompletionNotifier(&completion_mgr, (void *)stack);
+  RGWAioCompletionNotifier *cn = new RGWAioCompletionNotifier(completion_mgr, (void *)stack);
+  completion_mgr->register_completion_notifier(cn);
+  return cn;
 }
 
 void RGWCoroutinesManager::dump(Formatter *f) const {
@@ -733,7 +735,7 @@ bool RGWCoroutine::drain_children(int num_cr_left)
       int ret;
       while (collect(&ret)) {
         if (ret < 0) {
-          ldout(cct, 0) << "ERROR: collect() returned error" << dendl;
+          ldout(cct, 10) << "collect() returned ret=" << ret << dendl;
           /* we should have reported this error */
           log_error() << "ERROR: collect() returned error (ret=" << ret << ")";
         }

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -8,6 +8,9 @@
 #define dout_subsys ceph_subsys_rgw
 
 bool RGWAsyncRadosProcessor::RGWWQ::_enqueue(RGWAsyncRadosRequest *req) {
+  if (processor->is_going_down()) {
+    return false;
+  }
   req->get();
   processor->m_req_queue.push_back(req);
   dout(20) << "enqueued request req=" << hex << req << dec << dendl;
@@ -61,6 +64,7 @@ void RGWAsyncRadosProcessor::start() {
 }
 
 void RGWAsyncRadosProcessor::stop() {
+  going_down.set(1);
   m_tp.drain(&req_wq);
   m_tp.stop();
   for (auto iter = m_req_queue.begin(); iter != m_req_queue.end(); ++iter) {

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -45,6 +45,7 @@ public:
 
 class RGWAsyncRadosProcessor {
   deque<RGWAsyncRadosRequest *> m_req_queue;
+  atomic_t going_down;
 protected:
   RGWRados *store;
   ThreadPool m_tp;
@@ -76,6 +77,10 @@ public:
   void stop();
   void handle_request(RGWAsyncRadosRequest *req);
   void queue(RGWAsyncRadosRequest *req);
+
+  bool is_going_down() {
+    return (going_down.read() != 0);
+  }
 };
 
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1359,7 +1359,7 @@ int RGWDataSyncStatusManager::init()
   rgw_datalog_info datalog_info;
   r = source_log.read_log_info(&datalog_info);
   if (r < 0) {
-    lderr(store->ctx()) << "ERROR: master.read_log_info() returned r=" << r << dendl;
+    ldout(store->ctx(), 5) << "ERROR: master.read_log_info() returned r=" << r << dendl;
     return r;
   }
 

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -3,6 +3,7 @@
 
 #include "rgw_coroutine.h"
 #include "rgw_http_client.h"
+#include "rgw_bucket.h"
 
 #include "common/RWLock.h"
 
@@ -191,6 +192,7 @@ public:
   void finish();
 
   int read_log_info(rgw_datalog_info *log_info);
+  int read_source_log_shards_info(map<int, RGWDataChangesLogInfo> *shards_info);
   int get_shard_info(int shard_id);
   int read_sync_status(rgw_data_sync_status *sync_status);
   int init_sync_status(int num_shards);
@@ -235,6 +237,13 @@ public:
 
   int read_sync_status() { return source_log.read_sync_status(&sync_status); }
   int init_sync_status() { return source_log.init_sync_status(num_shards); }
+
+  int read_log_info(rgw_datalog_info *log_info) {
+    return source_log.read_log_info(log_info);
+  }
+  int read_source_log_shards_info(map<int, RGWDataChangesLogInfo> *shards_info) {
+    return source_log.read_source_log_shards_info(shards_info);
+  }
 
   int run() { return source_log.run_sync(num_shards, sync_status); }
 

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -138,6 +138,21 @@ struct rgw_data_sync_status {
 };
 WRITE_CLASS_ENCODER(rgw_data_sync_status)
 
+struct rgw_datalog_entry {
+  string key;
+  utime_t timestamp;
+
+  void decode_json(JSONObj *obj);
+};
+
+struct rgw_datalog_shard_data {
+  string marker;
+  bool truncated;
+  vector<rgw_datalog_entry> entries;
+
+  void decode_json(JSONObj *obj);
+};
+
 class RGWAsyncRadosProcessor;
 class RGWDataSyncStatusManager;
 class RGWDataSyncControlCR;
@@ -193,6 +208,7 @@ public:
 
   int read_log_info(rgw_datalog_info *log_info);
   int read_source_log_shards_info(map<int, RGWDataChangesLogInfo> *shards_info);
+  int read_source_log_shards_next(map<int, string> shard_markers, map<int, rgw_datalog_shard_data> *result);
   int get_shard_info(int shard_id);
   int read_sync_status(rgw_data_sync_status *sync_status);
   int init_sync_status(int num_shards);
@@ -243,6 +259,9 @@ public:
   }
   int read_source_log_shards_info(map<int, RGWDataChangesLogInfo> *shards_info) {
     return source_log.read_source_log_shards_info(shards_info);
+  }
+  int read_source_log_shards_next(map<int, string> shard_markers, map<int, rgw_datalog_shard_data> *result) {
+    return source_log.read_source_log_shards_next(shard_markers, result);
   }
 
   int run() { return source_log.run_sync(num_shards, sync_status); }

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -184,7 +184,7 @@ public:
   RGWRemoteDataLog(RGWRados *_store, RGWAsyncRadosProcessor *async_rados)
     : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()),
       store(_store), async_rados(async_rados),
-      http_manager(store->ctx(), &completion_mgr),
+      http_manager(store->ctx(), completion_mgr),
       lock("RGWRemoteDataLog::lock"), data_sync_cr(NULL),
       initialized(false) {}
   int init(const string& _source_zone, RGWRESTConn *_conn, RGWSyncErrorLogger *_error_logger);

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -385,7 +385,7 @@ void RGWHTTPManager::_complete_request(rgw_http_req_data *req_data)
     reqs.erase(iter);
   }
   if (completion_mgr) {
-    completion_mgr->complete(req_data->client->get_user_info());
+    completion_mgr->complete(NULL, req_data->client->get_user_info());
   }
   req_data->put();
 }

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -558,6 +558,7 @@ void RGWHTTPManager::stop()
 {
   if (is_threaded) {
     going_down.set(1);
+    signal_thread();
     reqs_thread->join();
     delete reqs_thread;
   }

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -203,7 +203,7 @@ public:
       pinfo->marker = header.max_marker;
       pinfo->last_update = header.max_time;
     }
-    completion_manager->complete(user_info);
+    completion_manager->complete(NULL, user_info);
     put();
   }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3381,7 +3381,7 @@ int RGWRados::replace_region_with_zonegroup()
   /* create zonegroups */
   for (iter = regions.begin(); iter != regions.end(); ++iter)
   {
-    derr << "create zonegroup " << *iter << dendl;
+    ldout(cct, 10) << "create zonegroup " << *iter << dendl;
     /* read region info default has no data */
     if (*iter != default_zonegroup_name){
       RGWZoneGroup zonegroup(*iter);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3641,6 +3641,7 @@ int RGWRados::init_complete()
     const string& id = ziter->first;
     RGWZone& z = ziter->second;
     zone_id_by_name[z.name] = id;
+    zone_name_by_id[id] = z.name;
     if (id != zone_id()) {
       if (!z.endpoints.empty()) {
         ldout(cct, 20) << "generating connection object for zone " << z.name << " id " << z.id << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2673,7 +2673,7 @@ class RGWMetaNotifierManager : public RGWCoroutinesManager {
 
 public:
   RGWMetaNotifierManager(RGWRados *_store) : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()), store(_store),
-                                             http_manager(store->ctx(), &completion_mgr) {
+                                             http_manager(store->ctx(), completion_mgr) {
     http_manager.set_threaded();
   }
 
@@ -2700,7 +2700,7 @@ class RGWDataNotifierManager : public RGWCoroutinesManager {
 
 public:
   RGWDataNotifierManager(RGWRados *_store) : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()), store(_store),
-                                             http_manager(store->ctx(), &completion_mgr) {
+                                             http_manager(store->ctx(), completion_mgr) {
     http_manager.set_threaded();
   }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3065,6 +3065,9 @@ int RGWRados::get_max_chunk_size(rgw_bucket& bucket, uint64_t *max_chunk_size)
 
 void RGWRados::finalize()
 {
+  if (async_rados) {
+    async_rados->stop();
+  }
   if (run_sync_thread) {
     Mutex::Locker l(meta_sync_thread_lock);
     meta_sync_processor_thread->stop();
@@ -3104,7 +3107,6 @@ void RGWRados::finalize()
   delete meta_mgr;
   delete data_log;
   if (async_rados) {
-    async_rados->stop();
     delete async_rados;
   }
   if (use_gc_thread) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2421,7 +2421,13 @@ int RGWPutObjProcessor_Atomic::complete_parts()
 int RGWPutObjProcessor_Atomic::complete_writing_data()
 {
   if (!data_ofs && !immutable_head()) {
-    first_chunk.claim(pending_data_bl);
+    /* only claim if pending_data_bl() is not empty. This is needed because we might be called twice
+     * (e.g., when a retry due to race happens). So a second call to first_chunk.claim() would
+     * clobber first_chunk
+     */
+    if (pending_data_bl.length() > 0) {
+      first_chunk.claim(pending_data_bl);
+    }
     obj_len = (uint64_t)first_chunk.length();
   }
   if (pending_data_bl.length()) {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1868,6 +1868,7 @@ public:
   map<string, RGWRESTConn *> zonegroup_conn_map;
 
   map<string, string> zone_id_by_name;
+  map<string, string> zone_name_by_id;
 
   RGWRESTConn *get_zone_conn_by_id(const string& id) {
     auto citer = zone_conn_map.find(id);

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -47,6 +47,11 @@ class RGWRealmReloader::C_Reload : public Context {
 void RGWRealmReloader::handle_notify(RGWRealmNotify type,
                                      bufferlist::iterator& p)
 {
+  if (!store) {
+    /* we're in the middle of reload */
+    return;
+  }
+
   CephContext *const cct = store->ctx();
 
   Mutex::Locker lock(mutex);

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -204,7 +204,7 @@ int RGWRESTConn::get_resource(const string& resource,
 
   ret = req.get_resource(key, headers, resource, mgr);
   if (ret < 0) {
-    ldout(cct, 0) << __func__ << ": get_resource() resource=" << resource << " returned ret=" << ret << dendl;
+    ldout(cct, 5) << __func__ << ": get_resource() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
   }
 
@@ -251,7 +251,7 @@ int RGWRESTReadResource::read()
 {
   int ret = req.get_resource(conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
-    ldout(cct, 0) << __func__ << ": get_resource() resource=" << resource << " returned ret=" << ret << dendl;
+    ldout(cct, 5) << __func__ << ": get_resource() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
   }
 
@@ -266,7 +266,7 @@ int RGWRESTReadResource::aio_read()
   int ret = req.get_resource(conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     put();
-    ldout(cct, 0) << __func__ << ": get_resource() resource=" << resource << " returned ret=" << ret << dendl;
+    ldout(cct, 5) << __func__ << ": get_resource() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
   }
 
@@ -312,7 +312,7 @@ int RGWRESTPostResource::send(bufferlist& outbl)
   req.set_outbl(outbl);
   int ret = req.get_resource(conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
-    ldout(cct, 0) << __func__ << ": get_resource() resource=" << resource << " returned ret=" << ret << dendl;
+    ldout(cct, 5) << __func__ << ": get_resource() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
   }
 
@@ -328,7 +328,7 @@ int RGWRESTPostResource::aio_send(bufferlist& outbl)
   int ret = req.get_resource(conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     put();
-    ldout(cct, 0) << __func__ << ": get_resource() resource=" << resource << " returned ret=" << ret << dendl;
+    ldout(cct, 5) << __func__ << ": get_resource() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
   }
 

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -169,6 +169,81 @@ void rgw_mdlog_shard_data::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("entries", entries, obj);
 };
 
+class RGWShardCollectCR : public RGWCoroutine {
+  CephContext *cct;
+
+  int cur_shard;
+  int current_running;
+  int max_concurrent;
+  int status;
+
+public:
+  RGWShardCollectCR(CephContext *_cct, int _max_concurrent) : RGWCoroutine(_cct),
+                                                             current_running(0),
+                                                             max_concurrent(_max_concurrent),
+                                                             status(0) {}
+
+  virtual bool spawn_next() = 0;
+
+  int operate() {
+    reenter(this) {
+      while (spawn_next()) {
+        current_running++;
+
+        while (current_running >= max_concurrent) {
+          int child_ret;
+          yield wait_for_child();
+          if (collect_next(&child_ret)) {
+            current_running--;
+            if (child_ret < 0 && child_ret != -ENOENT) {
+              ldout(cct, 10) << __func__ << ": failed to fetch log status, ret=" << child_ret << dendl;
+              status = child_ret;
+            }
+          }
+        }
+      }
+      while (current_running > 0) {
+        int child_ret;
+        yield wait_for_child();
+        if (collect_next(&child_ret)) {
+          current_running--;
+          if (child_ret < 0 && child_ret != -ENOENT) {
+            ldout(cct, 10) << __func__ << ": failed to fetch log status, ret=" << child_ret << dendl;
+            status = child_ret;
+          }
+        }
+      }
+      if (status < 0) {
+        return set_cr_error(status);
+      }
+      return set_cr_done();
+    }
+    return 0;
+  }
+
+};
+
+class RGWReadRemoteMDLogInfoCR : public RGWShardCollectCR {
+  RGWMetaSyncEnv *sync_env;
+  RGWMetadataLog *mdlog;
+
+  const std::string& period;
+  int num_shards;
+  map<int, RGWMetadataLogInfo> *mdlog_info;
+
+  int shard_id;
+#define READ_MDLOG_MAX_CONCURRENT 10
+
+public:
+  RGWReadRemoteMDLogInfoCR(RGWMetaSyncEnv *_sync_env, RGWMetadataLog* mdlog,
+                     const std::string& period, int _num_shards,
+                     map<int, RGWMetadataLogInfo> *_mdlog_info) : RGWShardCollectCR(_sync_env->cct, READ_MDLOG_MAX_CONCURRENT),
+                                                                 sync_env(_sync_env), mdlog(mdlog),
+                                                                 period(period), num_shards(_num_shards),
+                                                                 mdlog_info(_mdlog_info), shard_id(0) {}
+  bool spawn_next();
+};
+
 RGWRemoteMetaLog::~RGWRemoteMetaLog()
 {
   delete error_logger;
@@ -188,6 +263,25 @@ int RGWRemoteMetaLog::read_log_info(rgw_mdlog_info *log_info)
   ldout(store->ctx(), 20) << "remote mdlog, num_shards=" << log_info->num_shards << dendl;
 
   return 0;
+}
+
+int RGWRemoteMetaLog::read_master_log_shards_info(string *master_period, map<int, RGWMetadataLogInfo> *shards_info)
+{
+  if (store->is_meta_master()) {
+    return 0;
+  }
+
+  rgw_mdlog_info log_info;
+  int ret = read_log_info(&log_info);
+  if (ret < 0) {
+    return ret;
+  }
+
+  *master_period = log_info.period;
+
+  RGWObjectCtx obj_ctx(store, NULL);
+  auto mdlog = store->meta_mgr->get_log(log_info.period);
+  return run(new RGWReadRemoteMDLogInfoCR(&sync_env, mdlog, log_info.period, log_info.num_shards, shards_info));
 }
 
 int RGWRemoteMetaLog::init()
@@ -423,6 +517,74 @@ public:
     return 0;
   }
 };
+
+class RGWListRemoteMDLogShardCR : public RGWSimpleCoroutine {
+  RGWMetaSyncEnv *sync_env;
+  RGWRESTReadResource *http_op;
+
+  const std::string& period;
+  int shard_id;
+  string marker;
+  uint32_t max_entries;
+  rgw_mdlog_shard_data *result;
+
+public:
+  RGWListRemoteMDLogShardCR(RGWMetaSyncEnv *env, const std::string& period,
+                            int _shard_id, const string& _marker, uint32_t _max_entries,
+                            rgw_mdlog_shard_data *_result)
+    : RGWSimpleCoroutine(env->store->ctx()), sync_env(env), http_op(NULL),
+      period(period), shard_id(_shard_id), marker(_marker), max_entries(_max_entries), result(_result) {}
+
+  int send_request() {
+    RGWRESTConn *conn = sync_env->conn;
+    RGWRados *store = sync_env->store;
+
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%d", shard_id);
+
+    char max_entries_buf[32];
+    snprintf(max_entries_buf, sizeof(max_entries_buf), "%d", (int)max_entries);
+
+    const char *marker_key = (marker.empty() ? "" : "marker");
+
+    rgw_http_param_pair pairs[] = { { "type", "metadata" },
+      { "id", buf },
+      { "period", period.c_str() },
+      { "max-entries", max_entries_buf },
+      { marker_key, marker.c_str() },
+      { NULL, NULL } };
+
+    string p = "/admin/log/";
+
+    http_op = new RGWRESTReadResource(conn, p, pairs, NULL, sync_env->http_manager);
+    http_op->set_user_info((void *)stack);
+
+    int ret = http_op->aio_read();
+    if (ret < 0) {
+      ldout(store->ctx(), 0) << "ERROR: failed to read from " << p << dendl;
+      log_error() << "failed to send http operation: " << http_op->to_str() << " ret=" << ret << std::endl;
+      http_op->put();
+      return ret;
+    }
+
+    return 0;
+  }
+
+  int handle_response() {
+    int ret = http_op->wait(result);
+    if (ret < 0 && ret != -ENOENT) {
+      ldout(sync_env->store->ctx(), 0) << "ERROR: failed to list remote mdlog shard, ret=" << ret << dendl;
+      return ret;
+    }
+    return 0;
+  }
+};
+
+bool RGWReadRemoteMDLogInfoCR::spawn_next() {
+  spawn(new RGWReadRemoteMDLogShardInfoCR(sync_env, period, shard_id, &(*mdlog_info)[shard_id]), false);
+  shard_id++;
+  return (shard_id < num_shards);
+}
 
 class RGWInitSyncStatusCoroutine : public RGWCoroutine {
   RGWMetaSyncEnv *sync_env;

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -418,6 +418,23 @@ public:
   int operate();
 };
 
+class RGWShardCollectCR : public RGWCoroutine {
+  CephContext *cct;
+
+  int cur_shard;
+  int current_running;
+  int max_concurrent;
+  int status;
+
+public:
+  RGWShardCollectCR(CephContext *_cct, int _max_concurrent) : RGWCoroutine(_cct),
+                                                             current_running(0),
+                                                             max_concurrent(_max_concurrent),
+                                                             status(0) {}
+
+  virtual bool spawn_next() = 0;
+  int operate();
+};
 
 
 #endif

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -167,7 +167,7 @@ public:
                    RGWMetaSyncStatusManager *_sm)
     : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()),
       store(_store), conn(NULL), async_rados(async_rados),
-      http_manager(store->ctx(), &completion_mgr),
+      http_manager(store->ctx(), completion_mgr),
       status_manager(_sm), error_logger(NULL), meta_sync_cr(NULL) {}
 
   ~RGWRemoteMetaLog();

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -176,6 +176,7 @@ public:
   void finish();
 
   int read_log_info(rgw_mdlog_info *log_info);
+  int read_master_log_shards_info(string *master_period, map<int, RGWMetadataLogInfo> *shards_info);
   int read_sync_status();
   int init_sync_status();
   int run_sync();
@@ -227,6 +228,12 @@ public:
 
   int read_sync_status() { return master_log.read_sync_status(); }
   int init_sync_status() { return master_log.init_sync_status(); }
+  int read_log_info(rgw_mdlog_info *log_info) {
+    return master_log.read_log_info(log_info);
+  }
+  int read_master_log_shards_info(string *master_period, map<int, RGWMetadataLogInfo> *shards_info) {
+    return master_log.read_master_log_shards_info(master_period, shards_info);
+  }
 
   int run() { return master_log.run_sync(); }
 


### PR DESCRIPTION
based on top of #8013. Also includes some minor noisy debug log fixes.

adds the `radosgw-admin sync status` command that gives a human readable status of the sync process at a specific zone

