### PR TITLE
crushtool: Don't crash when called on a file that isn't a crushmap

### DIFF
--- a/src/test/cli/crushtool/check-invalid-map.t
+++ b/src/test/cli/crushtool/check-invalid-map.t
@@ -1,0 +1,3 @@
+  $ crushtool -d /etc/hosts
+  crushtool: unable to decode /etc/hosts
+  [1]

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -583,7 +583,12 @@ int main(int argc, const char **argv)
       }
     }
     bufferlist::iterator p = bl.begin();
-    crush.decode(p);
+    try {
+      crush.decode(p);
+    } catch(...) {
+      cerr << me << ": unable to decode " << infn << std::endl;
+      exit(EXIT_FAILURE);
+    }
   }
 
   if (compile) {


### PR DESCRIPTION
Currently we crash due to an uncaught exception when we fail to decode a crushmap.

Catch the exception and exit gracefully.

Fixes: #8286
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>