### PR TITLE
osd/ReplicatedPG: be more careful about calling publish_stats_to_osd()

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3010,8 +3010,6 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
 	log_op_stats(
 	  ctx);
 
-      publish_stats_to_osd();
-
       if (m && m->wants_ondisk() && !ctx->sent_disk) {
 	// send commit.
 	MOSDOpReply *reply = ctx->reply;
@@ -8355,6 +8353,7 @@ void ReplicatedPG::eval_repop(RepGather *repop)
   if (repop->all_applied && repop->all_committed) {
     repop->rep_done = true;
 
+    publish_stats_to_osd();
     calc_min_last_complete_ondisk();
 
     for (auto p = repop->on_success.begin();


### PR DESCRIPTION
We had moved the call out of eval_repop into a lambda, but that left out
a few other code paths and is fragile. So just call it unconditionally in
eval_repop() instead.

Fixes: #14962

Signed-off-by: Greg Farnum <gfarnum@redhat.com>