### PR TITLE
rbd: support for enabling/disabling mirroring on specific images

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1092,6 +1092,7 @@ if(${WITH_RBD})
     tools/rbd/action/Lock.cc
     tools/rbd/action/MergeDiff.cc
     tools/rbd/action/MirrorPool.cc
+    tools/rbd/action/MirrorImage.cc
     tools/rbd/action/Nbd.cc
     tools/rbd/action/ObjectMap.cc
     tools/rbd/action/Remove.cc

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -101,6 +101,17 @@ typedef struct {
   char *client_name;
 } rbd_mirror_peer_t;
 
+typedef enum {
+  RBD_MIRROR_IMAGE_DISABLING = 0,
+  RBD_MIRROR_IMAGE_ENABLED = 1,
+  RBD_MIRROR_IMAGE_DISABLED = 2
+} rbd_mirror_image_state_t;
+
+typedef struct {
+  char *global_id;
+  rbd_mirror_image_state_t state;
+} rbd_mirror_image_t;
+
 CEPH_RBD_API void rbd_version(int *major, int *minor, int *extra);
 
 /* image options */
@@ -589,6 +600,8 @@ CEPH_RBD_API int rbd_metadata_list(rbd_image_t image, const char *start, uint64_
 
 CEPH_RBD_API int rbd_mirror_image_enable(rbd_image_t image);
 CEPH_RBD_API int rbd_mirror_image_disable(rbd_image_t image, bool force);
+CEPH_RBD_API int rbd_mirror_image_get(rbd_image_t image,
+    rbd_mirror_image_t *mirror_image);
 
 #ifdef __cplusplus
 }

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -587,6 +587,8 @@ CEPH_RBD_API int rbd_metadata_list(rbd_image_t image, const char *start, uint64_
     char *keys, size_t *key_len, char *values, size_t *vals_len);
 
 
+CEPH_RBD_API int rbd_mirror_image_enable(rbd_image_t image);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -588,6 +588,7 @@ CEPH_RBD_API int rbd_metadata_list(rbd_image_t image, const char *start, uint64_
 
 
 CEPH_RBD_API int rbd_mirror_image_enable(rbd_image_t image);
+CEPH_RBD_API int rbd_mirror_image_disable(rbd_image_t image, bool force);
 
 #ifdef __cplusplus
 }

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -322,6 +322,7 @@ public:
   int metadata_list(const std::string &start, uint64_t max, std::map<std::string, ceph::bufferlist> *pairs);
 
   int mirror_image_enable();
+  int mirror_image_disable(bool force);
 
 private:
   friend class RBD;

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -321,6 +321,8 @@ public:
    */
   int metadata_list(const std::string &start, uint64_t max, std::map<std::string, ceph::bufferlist> *pairs);
 
+  int mirror_image_enable();
+
 private:
   friend class RBD;
 

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -52,6 +52,13 @@ namespace librbd {
     std::string client_name;
   } mirror_peer_t;
 
+  typedef rbd_mirror_image_state_t mirror_image_state_t;
+
+  typedef struct {
+    std::string global_id;
+    mirror_image_state_t state;
+  } mirror_image_t;
+
   typedef rbd_image_info_t image_info_t;
 
   class CEPH_RBD_API ProgressContext
@@ -323,6 +330,7 @@ public:
 
   int mirror_image_enable();
   int mirror_image_disable(bool force);
+  int mirror_image_get(mirror_image_t *mirror_image);
 
 private:
   friend class RBD;

--- a/src/json_spirit/CMakeLists.txt
+++ b/src/json_spirit/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(json_spirit
   json_spirit_reader.cpp
   json_spirit_writer.cpp)
+target_link_libraries(json_spirit ${Boost_LIBRARIES})

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -109,6 +109,8 @@ public:
   static int remove(librados::IoCtx &io_ctx, const std::string &image_id);
   static int reset(librados::IoCtx &io_ctx, const std::string &image_id);
 
+  static int is_tag_owner(ImageCtx *image_ctx, bool *is_tag_owner);
+
   bool is_journal_ready() const;
   bool is_journal_replaying() const;
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -19,6 +19,8 @@
 
 #include "cls/rbd/cls_rbd.h"
 #include "cls/rbd/cls_rbd_client.h"
+#include "cls/journal/cls_journal_types.h"
+#include "cls/journal/cls_journal_client.h"
 
 #include "librbd/AioCompletion.h"
 #include "librbd/AioImageRequest.h"
@@ -32,12 +34,15 @@
 #include "librbd/ImageWatcher.h"
 #include "librbd/internal.h"
 #include "librbd/Journal.h"
+#include "librbd/journal/Types.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/Operations.h"
 #include "librbd/parent_types.h"
 #include "librbd/Utils.h"
 #include "librbd/operation/TrimRequest.h"
 #include "include/util.h"
+
+#include "journal/Journaler.h"
 
 #include <boost/bind.hpp>
 #include <boost/scope_exit.hpp>
@@ -2361,6 +2366,119 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
 
     ldout(cct, 20) << "image mirroring is enabled: global_id=" <<
       mirror_image_internal.global_image_id << dendl;
+
+    return 0;
+  }
+
+  int mirror_image_disable(ImageCtx *ictx, bool force) {
+    CephContext *cct = ictx->cct;
+    ldout(cct, 20) << "mirror_image_disable " << ictx << dendl;
+
+    cls::rbd::MirrorImage mirror_image_internal;
+    std::vector<snap_info_t> snaps;
+    std::set<cls::journal::Client> clients;
+    std::string header_oid;
+
+    bool is_primary;
+    int r = Journal<>::is_tag_owner(ictx, &is_primary);
+    if (r < 0) {
+      lderr(cct) << "cannot disable mirroring: failed to check tag ownership: "
+        << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    if (!is_primary) {
+      if (!force) {
+        lderr(cct) << "Mirrored image is not the primary, add force option to"
+          " disable mirroring" << dendl;
+        return -EINVAL;
+      }
+      goto remove_mirroring_image;
+    }
+
+    r = cls_client::mirror_image_get(&ictx->md_ctx, ictx->id,
+                                     &mirror_image_internal);
+    if (r < 0 && r != -ENOENT) {
+      lderr(cct) << "cannot disable mirroring: " << cpp_strerror(r) << dendl;
+      return r;
+    }
+    else if (r == -ENOENT) {
+      // mirroring is not enabled for this image
+      ldout(cct, 20) << "ignoring disable command: mirroring is not enabled "
+        "for this image" << dendl;
+      return 0;
+    }
+
+    mirror_image_internal.state =
+      cls::rbd::MirrorImageState::MIRROR_IMAGE_STATE_DISABLING;
+    r = cls_client::mirror_image_set(&ictx->md_ctx, ictx->id,
+                                     mirror_image_internal);
+    if (r < 0) {
+      lderr(cct) << "cannot disable mirroring: " << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    header_oid = ::journal::Journaler::header_oid(ictx->id);
+
+    while(true) {
+      r = cls::journal::client::client_list(ictx->md_ctx, header_oid, &clients);
+      if (r < 0) {
+        lderr(cct) << "cannot disable mirroring: " << cpp_strerror(r) << dendl;
+        return r;
+      }
+
+      assert(clients.size() >= 1);
+
+      if (clients.size() == 1) {
+        // only local journal client remains
+        break;
+      }
+
+      for (auto client : clients) {
+        journal::ClientData client_data;
+        bufferlist::iterator bl = client.data.begin();
+        ::decode(client_data, bl);
+        journal::ClientMetaType type = client_data.get_client_meta_type();
+
+        if (type != journal::ClientMetaType::MIRROR_PEER_CLIENT_META_TYPE) {
+          continue;
+        }
+
+        journal::MirrorPeerClientMeta client_meta =
+          boost::get<journal::MirrorPeerClientMeta>(client_data.client_meta);
+
+        for (const auto& sync : client_meta.sync_points) {
+          r = ictx->operations->snap_remove(sync.snap_name.c_str());
+          if (r < 0 && r != -ENOENT) {
+            lderr(cct) << "cannot disable mirroring: failed to remove temporary"
+              " snapshot created by remote peer: " << cpp_strerror(r) << dendl;
+            return r;
+          }
+        }
+
+        r = cls::journal::client::client_unregister(ictx->md_ctx, header_oid,
+                                                    client.id);
+        if (r < 0 && r != -ENOENT) {
+          lderr(cct) << "cannot disable mirroring: failed to unregister remote"
+            " journal client: " << cpp_strerror(r) << dendl;
+          return r;
+        }
+      }
+    }
+
+  remove_mirroring_image:
+    r = cls_client::mirror_image_remove(&ictx->md_ctx, ictx->id);
+    if (r < 0) {
+      lderr(cct) << "failed to remove image from mirroring directory: "
+        << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    ldout(cct, 20) << "removed image state from rbd_mirroring object" << dendl;
+
+    if (is_primary) {
+      // TODO: send notification to mirroring object about update
+    }
 
     return 0;
   }

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -185,6 +185,7 @@ namespace librbd {
 
   int mirror_image_enable(ImageCtx *ictx);
   int mirror_image_disable(ImageCtx *ictx, bool force);
+  int mirror_image_get(ImageCtx *ictx, mirror_image_t *mirror_image);
 }
 
 #endif

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -184,6 +184,7 @@ namespace librbd {
                               const std::string &cluster_name);
 
   int mirror_image_enable(ImageCtx *ictx);
+  int mirror_image_disable(ImageCtx *ictx, bool force);
 }
 
 #endif

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -183,6 +183,7 @@ namespace librbd {
   int mirror_peer_set_cluster(IoCtx& io_ctx, const std::string &uuid,
                               const std::string &cluster_name);
 
+  int mirror_image_enable(ImageCtx *ictx);
 }
 
 #endif

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1231,6 +1231,11 @@ namespace librbd {
     return librbd::mirror_image_enable(ictx);
   }
 
+  int Image::mirror_image_disable(bool force) {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    return librbd::mirror_image_disable(ictx, force);
+  }
+
 } // namespace librbd
 
 extern "C" void rbd_version(int *major, int *minor, int *extra)
@@ -2562,6 +2567,12 @@ extern "C" int rbd_mirror_image_enable(rbd_image_t image)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   return librbd::mirror_image_enable(ictx);
+}
+
+extern "C" int rbd_mirror_image_disable(rbd_image_t image, bool force)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  return librbd::mirror_image_disable(ictx, force);
 }
 
 extern "C" int rbd_aio_is_complete(rbd_completion_t c)

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1236,6 +1236,11 @@ namespace librbd {
     return librbd::mirror_image_disable(ictx, force);
   }
 
+  int Image::mirror_image_get(mirror_image_t *mirror_image) {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    return librbd::mirror_image_get(ictx, mirror_image);
+  }
+
 } // namespace librbd
 
 extern "C" void rbd_version(int *major, int *minor, int *extra)
@@ -2573,6 +2578,23 @@ extern "C" int rbd_mirror_image_disable(rbd_image_t image, bool force)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   return librbd::mirror_image_disable(ictx, force);
+}
+
+extern "C" int rbd_mirror_image_get(rbd_image_t image,
+    rbd_mirror_image_t *mirror_image)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+
+  librbd::mirror_image_t cpp_mirror_image;
+  int r = librbd::mirror_image_get(ictx, &cpp_mirror_image);
+  if (r < 0) {
+    return r;
+  }
+
+  mirror_image->global_id = strdup(cpp_mirror_image.global_id.c_str());
+  mirror_image->state = cpp_mirror_image.state;
+
+  return 0;
 }
 
 extern "C" int rbd_aio_is_complete(rbd_completion_t c)

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1226,6 +1226,11 @@ namespace librbd {
     return r;
   }
 
+  int Image::mirror_image_enable() {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    return librbd::mirror_image_enable(ictx);
+  }
+
 } // namespace librbd
 
 extern "C" void rbd_version(int *major, int *minor, int *extra)
@@ -2551,6 +2556,12 @@ extern "C" int rbd_metadata_list(rbd_image_t image, const char *start, uint64_t 
   }
   tracepoint(librbd, metadata_list_exit, r);
   return r;
+}
+
+extern "C" int rbd_mirror_image_enable(rbd_image_t image)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  return librbd::mirror_image_enable(ictx);
 }
 
 extern "C" int rbd_aio_is_complete(rbd_completion_t c)

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -42,6 +42,8 @@
       lock remove (lock rm)       Release a lock on an image.
       map                         Map image to a block device using the kernel.
       merge-diff                  Merge two diff exports together.
+      mirror image disable        Disable RBD mirroring for an image.
+      mirror image enable         Enable RBD mirroring for an image.
       mirror pool disable         Disable RBD mirroring by default within a pool.
       mirror pool enable          Enable RBD mirroring by default within a pool.
       mirror pool info            Show information about the pool mirroring
@@ -745,6 +747,35 @@
   Optional arguments
     --path arg           path to merged diff (or '-' for stdout)
     --no-progress        disable progress output
+  
+  rbd help mirror image disable
+  usage: rbd mirror image disable [--force] [--pool <pool>] [--image <image>] 
+                                  <image-spec> 
+  
+  Disable RBD mirroring for an image.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/]<image-name>)
+  
+  Optional arguments
+    --force              disable even if not primary
+    -p [ --pool ] arg    pool name
+    --image arg          image name
+  
+  rbd help mirror image enable
+  usage: rbd mirror image enable [--pool <pool>] [--image <image>] 
+                                 <image-spec> 
+  
+  Enable RBD mirroring for an image.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --image arg          image name
   
   rbd help mirror pool disable
   usage: rbd mirror pool disable [--pool <pool>] 

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -50,6 +50,7 @@ rbd_SOURCES = \
 	tools/rbd/action/Lock.cc \
 	tools/rbd/action/MergeDiff.cc \
 	tools/rbd/action/MirrorPool.cc \
+	tools/rbd/action/MirrorImage.cc \
 	tools/rbd/action/ObjectMap.cc \
 	tools/rbd/action/Remove.cc \
 	tools/rbd/action/Rename.cc \

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -619,5 +619,18 @@ std::string image_id(librbd::Image& image) {
   return string(prefix + strlen(RBD_DATA_PREFIX));
 }
 
+std::string mirror_image_state(rbd_mirror_image_state_t mirror_image_state) {
+  switch (mirror_image_state) {
+    case RBD_MIRROR_IMAGE_DISABLING:
+      return "disabling";
+    case RBD_MIRROR_IMAGE_ENABLED:
+      return "enabled";
+    case RBD_MIRROR_IMAGE_DISABLED:
+      return "disabled";
+    default:
+      return "unknown";
+  }
+}
+
 } // namespace utils
 } // namespace rbd

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -100,6 +100,8 @@ int snap_set(librbd::Image &image, const std::string &snap_name);
 
 std::string image_id(librbd::Image& image);
 
+std::string mirror_image_state(rbd_mirror_image_state_t mirror_image_state);
+
 } // namespace utils
 } // namespace rbd
 

--- a/src/tools/rbd/action/Info.cc
+++ b/src/tools/rbd/action/Info.cc
@@ -71,6 +71,7 @@ static int do_show_info(const char *imgname, librbd::Image& image,
   uint8_t old_format;
   uint64_t overlap, features, flags;
   bool snap_protected = false;
+  librbd::mirror_image_t mirror_image;
   int r;
 
   r = image.stat(info, sizeof(info));
@@ -98,6 +99,13 @@ static int do_show_info(const char *imgname, librbd::Image& image,
     r = image.snap_is_protected(snapname, &snap_protected);
     if (r < 0)
       return r;
+  }
+
+  if (features & RBD_FEATURE_JOURNALING) {
+    r = image.mirror_image_get(&mirror_image);
+    if (r < 0) {
+      return r;
+    }
   }
 
   char prefix[RBD_MAX_BLOCK_NAME_SIZE + 1];
@@ -176,6 +184,23 @@ static int do_show_info(const char *imgname, librbd::Image& image,
       f->dump_string("journal", utils::image_id(image));
     } else {
       std::cout << "\tjournal: " << utils::image_id(image) << std::endl;
+    }
+  }
+
+  if (features & RBD_FEATURE_JOURNALING) {
+    if (f) {
+      f->dump_string("mirroring_state",
+          utils::mirror_image_state(mirror_image.state));
+      if (mirror_image.state != RBD_MIRROR_IMAGE_DISABLED) {
+        f->dump_string("mirroring_global_id", mirror_image.global_id);
+      }
+    } else {
+      std::cout << "\tmirroring state: "
+        << utils::mirror_image_state(mirror_image.state) << std::endl;
+      if (mirror_image.state != RBD_MIRROR_IMAGE_DISABLED) {
+        std::cout << "\tmirroring global id: " << mirror_image.global_id
+          << std::endl;
+      }
     }
   }
 

--- a/src/tools/rbd/action/MirrorImage.cc
+++ b/src/tools/rbd/action/MirrorImage.cc
@@ -1,0 +1,99 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#include "tools/rbd/ArgumentTypes.h"
+#include "tools/rbd/Shell.h"
+#include "tools/rbd/Utils.h"
+#include "include/stringify.h"
+#include "common/config.h"
+#include "common/errno.h"
+#include "common/Formatter.h"
+#include "common/TextTable.h"
+#include "global/global_context.h"
+#include <iostream>
+#include <boost/program_options.hpp>
+#include <boost/regex.hpp>
+
+namespace rbd {
+namespace action {
+namespace mirror_image {
+
+namespace at = argument_types;
+namespace po = boost::program_options;
+
+
+void get_arguments(po::options_description *positional,
+                           po::options_description *options) {
+  at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+}
+
+void get_arguments_disable(po::options_description *positional,
+                           po::options_description *options) {
+  options->add_options()
+    ("force", po::bool_switch(), "disable even if not primary");
+  at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+}
+
+int execute_enable_disable(const po::variables_map &vm, bool enable,
+                           bool force) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string image_name;
+  std::string snap_name;
+  int r = utils::get_pool_image_snapshot_names(
+      vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &image_name,
+      &snap_name, utils::SNAPSHOT_PRESENCE_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  librbd::Image image;
+  r = utils::init_and_open_image(pool_name, image_name, "", false,
+                                 &rados, &io_ctx, &image);
+  if (r < 0) {
+    return r;
+  }
+
+  r = enable ? image.mirror_image_enable() : image.mirror_image_disable(force);
+  if (r < 0) {
+    return r;
+  }
+
+  std::cout << (enable ? "Mirroring enabled" : "Mirroring disabled")
+    << std::endl;
+
+  return 0;
+}
+
+int execute_disable(const po::variables_map &vm) {
+  return execute_enable_disable(vm, false, vm["force"].as<bool>());
+}
+
+int execute_enable(const po::variables_map &vm) {
+  return execute_enable_disable(vm, true, false);
+}
+
+Shell::Action action_enable(
+  {"mirror", "image", "enable"}, {},
+  "Enable RBD mirroring for an image.", "",
+  &get_arguments, &execute_enable);
+Shell::Action action_disable(
+  {"mirror", "image", "disable"}, {},
+  "Disable RBD mirroring for an image.", "",
+  &get_arguments_disable, &execute_disable);
+
+} // namespace mirror_image
+} // namespace action
+} // namespace rbd


### PR DESCRIPTION
Added the RBD CLI commands "mirror image enable|disable" to enable/disable the mirroring of an RBD image.

Ticket url: http://tracker.ceph.com/issues/13296