### PR TITLE
osd/PGLog: fix warning

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1467,8 +1467,8 @@ public:
     // backends need not implement these at all.
 
     /// Set an xattr on a collection
-    void collection_setattr(const coll_t& cid, const string& name, bufferlist& val)
-      __attribute__ ((deprecated)) {
+    void collection_setattr(const coll_t& cid, const string& name,
+			    bufferlist& val) {
       if (use_tbl) {
         __u32 op = OP_COLL_SETATTR;
         ::encode(op, tbl);
@@ -1486,8 +1486,7 @@ public:
     }
 
     /// Remove an xattr from a collection
-    void collection_rmattr(const coll_t& cid, const string& name)
-      __attribute__ ((deprecated)) {
+    void collection_rmattr(const coll_t& cid, const string& name) {
       if (use_tbl) {
         __u32 op = OP_COLL_RMATTR;
         ::encode(op, tbl);
@@ -1502,8 +1501,7 @@ public:
       data.ops++;
     }
     /// Set multiple xattrs on a collection
-    void collection_setattrs(const coll_t& cid, map<string,bufferptr>& aset)
-      __attribute__ ((deprecated)) {
+    void collection_setattrs(const coll_t& cid, map<string,bufferptr>& aset) {
       if (use_tbl) {
         __u32 op = OP_COLL_SETATTRS;
         ::encode(op, tbl);
@@ -1518,8 +1516,7 @@ public:
       data.ops++;
     }
     /// Set multiple xattrs on a collection
-    void collection_setattrs(const coll_t& cid, map<string,bufferlist>& aset)
-      __attribute__ ((deprecated)) {
+    void collection_setattrs(const coll_t& cid, map<string,bufferlist>& aset) {
       if (use_tbl) {
         __u32 op = OP_COLL_SETATTRS;
         ::encode(op, tbl);
@@ -2208,8 +2205,7 @@ public:
    * @returns 0 on success, negative error code on failure
    */
   virtual int collection_getattr(const coll_t& cid, const char *name,
-	                         void *value, size_t size)
-    __attribute__ ((deprecated)) {
+	                         void *value, size_t size) {
     return -EOPNOTSUPP;
   }
 
@@ -2221,8 +2217,8 @@ public:
    * @param bl buffer to receive value
    * @returns 0 on success, negative error code on failure
    */
-  virtual int collection_getattr(const coll_t& cid, const char *name, bufferlist& bl)
-    __attribute__ ((deprecated)) {
+  virtual int collection_getattr(const coll_t& cid, const char *name,
+				 bufferlist& bl) {
     return -EOPNOTSUPP;
   }
 
@@ -2233,8 +2229,8 @@ public:
    * @param aset map of keys and buffers that contain the values
    * @returns 0 on success, negative error code on failure
    */
-  virtual int collection_getattrs(const coll_t& cid, map<string,bufferptr> &aset)
-    __attribute__ ((deprecated)) {
+  virtual int collection_getattrs(const coll_t& cid,
+				  map<string,bufferptr> &aset) {
     return -EOPNOTSUPP;
   }
 

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -125,7 +125,7 @@ int KernelDevice::open(string p)
   // require a read/modify/write if we write something smaller than
   // it.
   block_size = g_conf->bdev_block_size;
-  if (block_size != st.st_blksize) {
+  if (block_size != (unsigned)st.st_blksize) {
     dout(1) << __func__ << " backing device/file reports st_blksize "
 	    << st.st_blksize << ", using bdev_block_size "
 	    << block_size << " anyway" << dendl;

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -36,7 +36,8 @@ struct PGLog : DoutPrefixProvider {
     return prefix_provider ? prefix_provider->gen_prefix() : "";
   }
   unsigned get_subsys() const {
-    return prefix_provider ? prefix_provider->get_subsys() : ceph_subsys_osd;
+    return prefix_provider ? prefix_provider->get_subsys() :
+      (unsigned)ceph_subsys_osd;
   }
   CephContext *get_cct() const {
     return cct;


### PR DESCRIPTION
osd/PGLog.h: In member function 'virtual unsigned int PGLog::get_subsys() const':
osd/PGLog.h:39:28: warning: enumeral and non-enumeral type in conditional expression [-Wextra]
     return prefix_provider ? prefix_provider->get_subsys() : ceph_subsys_osd;
                            ^


Signed-off-by: Sage Weil <sage@redhat.com>