### PR TITLE
rados: add ceph:: namespace to bufferlist type

### DIFF
--- a/src/include/rados/rados_types.hpp
+++ b/src/include/rados/rados_types.hpp
@@ -100,7 +100,7 @@ struct err_t {
 };
 
 struct shard_info_t : err_t {
-  std::map<std::string, bufferlist> attrs;
+  std::map<std::string, ceph::bufferlist> attrs;
   uint64_t size = -1;
   bool omap_digest_present = false;
   uint32_t omap_digest = 0;


### PR DESCRIPTION
After a fresh install, applications that had been including rados.hpp cannot resolve bufferlist, which is in ceph:: scope.

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>