### PR TITLE
ceph-detect-init: return systemd on Debian Jessie

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
@@ -14,4 +14,9 @@ def choose_init():
             return 'systemd'
         else:
             return 'upstart'
+    if distro.lower() in ('debian'):
+        if codename in ('squeeze', 'wheezy'):
+            return 'sysvinit'
+        else:
+            return 'systemd'
     return 'sysvinit'


### PR DESCRIPTION
http://tracker.ceph.com/issues/15086 Fixes: #15086

Signed-off-by: Nathan Cutler <ncutler@suse.com>