### PR TITLE
MDSMap -> FSMap decoding fixes

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -332,8 +332,10 @@ void FSMap::decode(bufferlist::iterator& p)
     *migrate_fs = legacy_fs;
     migrate_fs->fscid = FS_CLUSTER_ID_ANONYMOUS;
     migrate_fs->mds_map.fs_name = "default";
-    legacy_client_fscid = migrate_fs->fscid;
-    filesystems[migrate_fs->fscid] = migrate_fs;
+    if (migrate_fs->mds_map.enabled) {
+      legacy_client_fscid = migrate_fs->fscid;
+      filesystems[migrate_fs->fscid] = migrate_fs;
+    }
     compat = migrate_fs->mds_map.compat;
     enable_multiple = false;
   } else {

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1568,14 +1568,6 @@ int MDSMonitor::management_command(
         return -EINVAL;
     }
 
-    if (pending_fsmap.any_filesystems()
-        && !pending_fsmap.get_enable_multiple()) {
-      ss << "Creation of multiple filesystems is disabled.  To enable "
-            "this experimental feature, use 'ceph fs flag set enable_multiple "
-            "true'";
-      return -EINVAL;
-    }
-
     if (pending_fsmap.get_filesystem(fs_name)) {
       auto fs = pending_fsmap.get_filesystem(fs_name);
       if (*(fs->mds_map.data_pools.begin()) == data
@@ -1587,6 +1579,14 @@ int MDSMonitor::management_command(
         ss << "filesystem already exists with name '" << fs_name << "'";
         return -EINVAL;
       }
+    }
+
+    if (pending_fsmap.any_filesystems()
+        && !pending_fsmap.get_enable_multiple()) {
+      ss << "Creation of multiple filesystems is disabled.  To enable "
+            "this experimental feature, use 'ceph fs flag set enable_multiple "
+            "true'";
+      return -EINVAL;
     }
 
     pg_pool_t const *data_pool = mon->osdmon()->osdmap.get_pg_pool(data);


### PR DESCRIPTION
Fix a failure when upgrading monitor clusters that have *no* filesystem, not just those which do have an FS. And make "fs new" idempotent again.