### PR TITLE
Wip rgw swift versioning disabled

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1359,6 +1359,8 @@ OPTION(rgw_realm_reconfigure_delay, OPT_DOUBLE, 2) // seconds to wait before rel
 OPTION(rgw_period_push_interval, OPT_DOUBLE, 2) // seconds to wait before retrying "period push"
 OPTION(rgw_period_push_interval_max, OPT_DOUBLE, 30) // maximum interval after exponential backoff
 
+OPTION(rgw_swift_versioning_enabled, OPT_BOOL, false) // whether swift object versioning feature is enabled
+
 OPTION(mutex_perf_counter, OPT_BOOL, false) // enable/disable mutex perf counter
 OPTION(throttler_perf_counter, OPT_BOOL, true) // enable/disable throttler perf counter
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -892,8 +892,12 @@ struct RGWBucketInfo
 
   RGWBucketIndexType index_type;
 
+  bool swift_versioning;
+  string swift_ver_location;
+
+
   void encode(bufferlist& bl) const {
-     ENCODE_START(15, 4, bl);
+     ENCODE_START(16, 4, bl);
      ::encode(bucket, bl);
      ::encode(owner.id, bl);
      ::encode(flags, bl);
@@ -912,10 +916,14 @@ struct RGWBucketInfo
        ::encode(website_conf, bl);
      }
      ::encode((uint32_t)index_type, bl);
+     ::encode(swift_versioning, bl);
+     if (swift_versioning) {
+       ::encode(swift_ver_location, bl);
+     }
      ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN_32(14, 4, 4, bl);
+    DECODE_START_LEGACY_COMPAT_LEN_32(16, 4, 4, bl);
      ::decode(bucket, bl);
      if (struct_v >= 2) {
        string s;
@@ -960,6 +968,14 @@ struct RGWBucketInfo
      } else {
        index_type = RGWBIType_Normal;
      }
+     swift_versioning = false;
+     swift_ver_location.clear();
+     if (struct_v >= 16) {
+       ::decode(swift_versioning, bl);
+       if (swift_versioning) {
+         ::decode(swift_ver_location, bl);
+       }
+     }
      DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
@@ -971,8 +987,10 @@ struct RGWBucketInfo
   int versioning_status() { return flags & (BUCKET_VERSIONED | BUCKET_VERSIONS_SUSPENDED); }
   bool versioning_enabled() { return versioning_status() == BUCKET_VERSIONED; }
 
+  bool has_swift_versioning() { return swift_versioning; }
+
   RGWBucketInfo() : flags(0), creation_time(0), has_instance_obj(false), num_shards(0), bucket_index_shard_hash_type(MOD), requester_pays(false),
-                    has_website(false) {}
+                    has_website(false), swift_versioning(false) {}
 };
 WRITE_CLASS_ENCODER(RGWBucketInfo)
 

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -637,6 +637,8 @@ void RGWBucketInfo::dump(Formatter *f) const
   if (has_website) {
     encode_json("website_conf", website_conf, f);
   }
+  encode_json("swift_versioning", swift_versioning, f);
+  encode_json("swift_ver_location", swift_ver_location, f);
 }
 
 void RGWBucketInfo::decode_json(JSONObj *obj) {
@@ -661,6 +663,8 @@ void RGWBucketInfo::decode_json(JSONObj *obj) {
   if (has_website) {
     JSONDecoder::decode_json("website_conf", website_conf, obj);
   }
+  JSONDecoder::decode_json("swift_versioning", swift_versioning, obj);
+  JSONDecoder::decode_json("swift_ver_location", swift_ver_location, obj);
 }
 
 void rgw_obj_key::dump(Formatter *f) const

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1921,6 +1921,7 @@ void RGWCreateBucket::execute()
   s->bucket.tenant = s->bucket_tenant; /* ignored if bucket exists */
   s->bucket.name = s->bucket_name;
   op_ret = store->create_bucket(*(s->user), s->bucket, zonegroup_id, placement_rule,
+                                swift_ver_location,
 				attrs, info, pobjv, &ep_objv, creation_time,
 				pmaster_bucket, true);
   /* continue if EEXIST and create_bucket will fail below.  this way we can
@@ -2807,6 +2808,9 @@ void RGWPutMetadataBucket::execute()
     cors_config.encode(bl);
     attrs[RGW_ATTR_CORS] = bl;
   }
+
+  s->bucket_info.swift_ver_location = swift_ver_location;
+  s->bucket_info.swift_versioning = (!swift_ver_location.empty());
 
   op_ret = rgw_bucket_set_attrs(store, s->bucket_info, attrs, &s->bucket_info.objv_tracker);
 }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -537,6 +537,7 @@ protected:
   obj_version ep_objv;
   bool has_cors;
   RGWCORSConfiguration cors_config;
+  string swift_ver_location;
 
   bufferlist in_data;
 
@@ -767,6 +768,7 @@ protected:
   RGWAccessControlPolicy policy;
   RGWCORSConfiguration cors_config;
   string placement_rule;
+  string swift_ver_location;
 
 public:
   RGWPutMetadataBucket()

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4944,6 +4944,7 @@ int RGWRados::init_bucket_index(rgw_bucket& bucket, int num_shards)
 int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
                             const string& zonegroup_id,
                             const string& placement_rule,
+                            const string& swift_ver_location,
 			    map<std::string, bufferlist>& attrs,
                             RGWBucketInfo& info,
                             obj_version *pobjv,
@@ -5004,6 +5005,8 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     info.zonegroup = zonegroup_id;
     info.placement_rule = selected_placement_rule_name;
     info.index_type = rule_info.index_type;
+    info.swift_ver_location = swift_ver_location;
+    info.swift_versioning = (!swift_ver_location.empty());
     info.num_shards = bucket_index_max_shards;
     info.bucket_index_shard_hash_type = RGWBucketInfo::MOD;
     info.requester_pays = false;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5668,7 +5668,8 @@ int RGWRados::swift_versioning_copy(RGWBucketInfo& bucket_info, RGWRados::Object
   rgw_obj& obj = source->get_obj();
   const string& src_name = obj.get_object();
   char buf[src_name.size() + 32];
-  snprintf(buf, sizeof(buf), "%03d%s%lld.%06d", (int)src_name.size(), src_name.c_str(), (long long)state->mtime, 0);
+  snprintf(buf, sizeof(buf), "%03d%s/%lld.%06d", (int)src_name.size(),
+           src_name.c_str(), (long long)state->mtime, 0);
 
   RGWBucketInfo dest_bucket_info;
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2448,6 +2448,8 @@ public:
                        struct rgw_err *err,
                        void (*progress_cb)(off_t, void *),
                        void *progress_data);
+  int swift_versioning_copy(RGWBucketInfo& bucket_info, RGWRados::Object *source, RGWObjState *state,
+                            rgw_user& user);
   int copy_obj_to_remote_dest(RGWObjState *astate,
                               map<string, bufferlist>& src_attrs,
                               RGWRados::Object::Read& read_op,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2032,6 +2032,7 @@ public:
   virtual int create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
                             const string& zonegroup_id,
                             const string& placement_rule,
+                            const string& swift_ver_location,
                             map<std::string,bufferlist>& attrs,
                             RGWBucketInfo& bucket_info,
                             obj_version *pobjv,

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -483,7 +483,9 @@ int RGWCreateBucket_ObjStore_SWIFT::get_params()
   location_constraint = store->get_zonegroup().api_name;
   placement_rule = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
 
-  swift_ver_location = s->info.env->get("HTTP_X_VERSIONS_LOCATION", "");
+  if (s->cct->_conf->rgw_swift_versioning_enabled) {
+    swift_ver_location = s->info.env->get("HTTP_X_VERSIONS_LOCATION", "");
+  }
 
   return 0;
 }
@@ -735,7 +737,9 @@ int RGWPutMetadataBucket_ObjStore_SWIFT::get_params()
 			   rmattr_names);
   placement_rule = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
 
-  swift_ver_location = s->info.env->get("HTTP_X_VERSIONS_LOCATION", "");
+  if (s->cct->_conf->rgw_swift_versioning_enabled) {
+    swift_ver_location = s->info.env->get("HTTP_X_VERSIONS_LOCATION", "");
+  }
   return 0;
 }
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -371,6 +371,14 @@ static void dump_container_metadata(struct req_state *s, RGWBucketEnt& bucket)
       }
     }
   }
+
+  /* Dump container versioning info. */
+  if (!s->bucket_info.swift_ver_location.empty()) {
+    string encoded_loc;
+    url_encode(s->bucket_info.swift_ver_location, encoded_loc);
+    STREAM_IO(s)->print("X-Versions-Location: %s\r\n", encoded_loc.c_str());
+  }
+
 }
 
 void RGWStatAccount_ObjStore_SWIFT::execute()

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -475,6 +475,8 @@ int RGWCreateBucket_ObjStore_SWIFT::get_params()
   location_constraint = store->get_zonegroup().api_name;
   placement_rule = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
 
+  swift_ver_location = s->info.env->get("HTTP_X_VERSIONS_LOCATION", "");
+
   return 0;
 }
 
@@ -724,6 +726,8 @@ int RGWPutMetadataBucket_ObjStore_SWIFT::get_params()
   get_rmattrs_from_headers(s, CONT_PUT_ATTR_PREFIX, CONT_REMOVE_ATTR_PREFIX,
 			   rmattr_names);
   placement_rule = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
+
+  swift_ver_location = s->info.env->get("HTTP_X_VERSIONS_LOCATION", "");
   return 0;
 }
 


### PR DESCRIPTION
(partial) support for swift object versioning. The feature is disabled by default. The idea is to have to data structure changes in now, so that it make feature backport feasible later.