### PR TITLE
qa/workunits/rbd: use POSIX function definition

### DIFF
--- a/qa/workunits/rbd/verify_pool.sh
+++ b/qa/workunits/rbd/verify_pool.sh
@@ -3,11 +3,11 @@
 POOL_NAME=rbd_test_validate_pool
 PG_NUM=100
 
-function tear_down() {
+tear_down () {
   ceph osd pool delete $POOL_NAME $POOL_NAME --yes-i-really-really-mean-it || true
 }
 
-function set_up() {
+set_up () {
   tear_down
   ceph osd pool create $POOL_NAME $PG_NUM
   ceph osd pool mksnap $POOL_NAME snap


### PR DESCRIPTION
In scripts with /bin/sh shebang, we must use POSIX function definitions to
avoid syntax errors on platforms that link /bin/sh to something other than
/bin/bash.

See https://wiki.ubuntu.com/DashAsBinSh#function for more information.

http://tracker.ceph.com/issues/15104 Fixes: #15104

Signed-off-by: Nathan Cutler <ncutler@suse.com>