### PR TITLE
time: should use signed type for time_point::duration::rep

### DIFF
--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -63,7 +63,7 @@ namespace ceph {
       typedef duration::period period;
       // The second template parameter defaults to the clock's duration
       // type.
-      typedef std::chrono::time_point<real_clock> time_point;
+      typedef std::chrono::time_point<real_clock, signedspan> time_point;
       static constexpr const bool is_steady = false;
 
       static time_point now() noexcept {
@@ -146,7 +146,7 @@ namespace ceph {
       typedef duration::period period;
       // The second template parameter defaults to the clock's duration
       // type.
-      typedef std::chrono::time_point<real_clock> time_point;
+      typedef std::chrono::time_point<real_clock, signedspan> time_point;
       static constexpr const bool is_steady = false;
 
       static time_point now() noexcept {
@@ -220,7 +220,7 @@ namespace ceph {
       typedef timespan duration;
       typedef duration::rep rep;
       typedef duration::period period;
-      typedef std::chrono::time_point<mono_clock> time_point;
+      typedef std::chrono::time_point<mono_clock, signedspan> time_point;
       static constexpr const bool is_steady = true;
 
       static time_point now() noexcept {
@@ -239,7 +239,7 @@ namespace ceph {
       typedef timespan duration;
       typedef duration::rep rep;
       typedef duration::period period;
-      typedef std::chrono::time_point<mono_clock> time_point;
+      typedef std::chrono::time_point<mono_clock, signedspan> time_point;
       static constexpr const bool is_steady = true;
 
       static time_point now() noexcept {

--- a/src/test/common/test_time.cc
+++ b/src/test/common/test_time.cc
@@ -122,7 +122,7 @@ static void system_clock_conversions() {
 
   ASSERT_EQ(Clock::to_double(brt), bd);
   // Fudge factor
-  ASSERT_LT(abs((Clock::from_double(bd) - brt).count()), 30);
+  ASSERT_LT(std::abs((Clock::from_double(bd) - brt).count()), 30);
 }
 
 TEST(RealClock, Sanity) {


### PR DESCRIPTION
otherwise the timespan between two `Clock::time_point`s could be
incredibly large due to unsigned integer overflow. and da0f660
covered this bug up in a wrong way.

Signed-off-by: Kefu Chai <kchai@redhat.com>