### PR TITLE
mds: fix FSMap upgrade with daemons in the map

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -326,8 +326,14 @@ void FSMap::decode(bufferlist::iterator& p)
     }
 
     // We're upgrading, populate filesystems from the legacy fields
-    assert(filesystems.empty());
+    filesystems.clear();
+    standby_daemons.clear();
+    standby_epochs.clear();
+    mds_roles.clear();
+    compat = legacy_mds_map.compat;
+    enable_multiple = false;
 
+    // Synthesise a Filesystem from legacy_mds_map, if enabled
     if (legacy_mds_map.enabled) {
       // Construct a Filesystem from the legacy MDSMap
       auto migrate_fs = std::make_shared<Filesystem>(); 
@@ -355,9 +361,6 @@ void FSMap::decode(bufferlist::iterator& p)
     } else {
       legacy_client_fscid = FS_CLUSTER_ID_NONE;
     }
-
-    compat = legacy_mds_map.compat;
-    enable_multiple = false;
   } else {
     ::decode(epoch, p);
     ::decode(next_filesystem_id, p);

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1568,14 +1568,6 @@ int MDSMonitor::management_command(
         return -EINVAL;
     }
 
-    if (pending_fsmap.any_filesystems()
-        && !pending_fsmap.get_enable_multiple()) {
-      ss << "Creation of multiple filesystems is disabled.  To enable "
-            "this experimental feature, use 'ceph fs flag set enable_multiple "
-            "true'";
-      return -EINVAL;
-    }
-
     if (pending_fsmap.get_filesystem(fs_name)) {
       auto fs = pending_fsmap.get_filesystem(fs_name);
       if (*(fs->mds_map.data_pools.begin()) == data
@@ -1587,6 +1579,14 @@ int MDSMonitor::management_command(
         ss << "filesystem already exists with name '" << fs_name << "'";
         return -EINVAL;
       }
+    }
+
+    if (pending_fsmap.any_filesystems()
+        && !pending_fsmap.get_enable_multiple()) {
+      ss << "Creation of multiple filesystems is disabled.  To enable "
+            "this experimental feature, use 'ceph fs flag set enable_multiple "
+            "true'";
+      return -EINVAL;
     }
 
     pg_pool_t const *data_pool = mon->osdmon()->osdmap.get_pg_pool(data);


### PR DESCRIPTION
This would trigger a sanity() assertion because
you'd have standbys in a Filesystem::mds_map, instead
of in standby_daemons.

Also, fix handling the enabled flag.

Signed-off-by: John Spray <john.spray@redhat.com>