### PR TITLE
ceph-detect-init: add debian/jessie test

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
@@ -14,9 +14,8 @@ def choose_init():
             return 'systemd'
         else:
             return 'upstart'
-    if distro.lower() in ('debian'):
+    if distro.lower() == 'debian':
         if codename in ('squeeze', 'wheezy'):
             return 'sysvinit'
         else:
             return 'systemd'
-    return 'sysvinit'

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -49,6 +49,10 @@ class TestCephDetectInit(testtools.TestCase):
                                  codename='wheezy'):
             self.assertEqual('sysvinit', debian.choose_init())
         with mock.patch.multiple('ceph_detect_init.debian',
+                                 distro='debian',
+                                 codename='jessie'):
+            self.assertEqual('systemd', debian.choose_init())
+        with mock.patch.multiple('ceph_detect_init.debian',
                                  distro='ubuntu',
                                  codename='trusty'):
             self.assertEqual('upstart', debian.choose_init())
@@ -56,6 +60,10 @@ class TestCephDetectInit(testtools.TestCase):
                                  distro='ubuntu',
                                  codename='vivid'):
             self.assertEqual('systemd', debian.choose_init())
+        with mock.patch.multiple('ceph_detect_init.debian',
+                                 distro='not-debian',
+                                 codename='andy'):
+            self.assertIs(None, debian.choose_init())
 
     def test_fedora(self):
         with mock.patch('ceph_detect_init.fedora.release',


### PR DESCRIPTION
the test coverage is under 100%, and `make test` fails
```
ERROR: InvocationError: '/home/jenkins-build/build/workspace/ceph-pull-requests/src/ceph-detect-init/.tox/py27/bin/coverage report --omit=*test*,*tox* --show-missing --fail-under=100'
py3 create: /home/jenkins-build/build/workspace/ceph-pull-requests/src/ceph-detect-init/.tox/py3
___________________________________ summary ____________________________________
  pep8: commands succeeded
ERROR:   py27: commands failed
```

see https://jenkins.ceph.com/job/ceph-pull-requests/2996/console