### PR TITLE
hammer: When logging to a file fails, ceph logs excessively to stderr

### DIFF
--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -35,6 +35,8 @@ class Log : private Thread
   std::string m_log_file;
   int m_fd;
 
+  int m_fd_last_error;  ///< last error we say writing to fd (if any)
+
   int m_syslog_log, m_syslog_crash;
   int m_stderr_log, m_stderr_crash;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/15081