### PR TITLE
osd/OSDMap: fix typo in summarize_mapping_stats

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -140,7 +140,7 @@ void Log::reopen_log_file()
     VOID_TEMP_FAILURE_RETRY(::close(m_fd));
   if (m_log_file.length()) {
     m_fd = ::open(m_log_file.c_str(), O_CREAT|O_WRONLY|O_APPEND, 0644);
-    if (m_uid || m_gid) {
+    if (m_fd >= 0 && (m_uid || m_gid)) {
       int r = ::fchown(m_fd, m_uid, m_gid);
       if (r < 0) {
 	r = -errno;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3018,7 +3018,7 @@ int OSDMap::summarize_mapping_stats(
       if (newmap)
 	f->dump_unsigned("new_max_osd_pgs", max_new_pg);
     } else {
-      ss << "max osd." << min << " with " << max_base_pg;
+      ss << "max osd." << max << " with " << max_base_pg;
       if (newmap)
 	ss << " -> " << max_new_pg;
       ss << " pgs (" << (float)max_base_pg / avg_pg;

--- a/src/test/librados/list.cc
+++ b/src/test/librados/list.cc
@@ -941,7 +941,7 @@ TEST_F(LibRadosListPP, EnumerateObjectsFilterPP) {
     std::vector<ObjectItem> result;
     int r = ioctx.object_list(c, end, 12, filter_bl, &result, &c);
     ASSERT_GE(r, 0);
-    ASSERT_EQ(r, result.size());
+    ASSERT_EQ(r, (int)result.size());
     for (int i = 0; i < r; ++i) {
       auto oid = result[i].oid;
       // We should only see the object that matches the filter

--- a/src/test/librados/tmap_migrate.cc
+++ b/src/test/librados/tmap_migrate.cc
@@ -53,7 +53,7 @@ TEST_F(TmapMigratePP, DataScan) {
   // Check that the TMAP object is now an omap object
   std::map<std::string, bufferlist> read_vals;
   ASSERT_EQ(0, ioctx.omap_get_vals("10000000000.00000000", "", 1, &read_vals));
-  ASSERT_EQ(read_vals.size(), 1);
+  ASSERT_EQ(read_vals.size(), 1u);
   bufferlist tmap_expect_val;
   tmap_expect_val.append("custard");
   ASSERT_EQ(read_vals.at("rhubarb"), tmap_expect_val);
@@ -62,7 +62,7 @@ TEST_F(TmapMigratePP, DataScan) {
   // Check that the OMAP object is still readable
   read_vals.clear();
   ASSERT_EQ(0, ioctx.omap_get_vals("10000000001.00000000", "", 1, &read_vals));
-  ASSERT_EQ(read_vals.size(), 1);
+  ASSERT_EQ(read_vals.size(), 1u);
   bufferlist expect_omap_val;
   expect_omap_val.append("waffles");
   ASSERT_EQ(read_vals.at("tasty"), expect_omap_val);


### PR DESCRIPTION
From ea9abe53d0e777b7dc3b22af71639f77c4de08c8

Signed-off-by: Sage Weil <sage@redhat.com>