### PR TITLE
rgw: Remote the new rgw_swift_account_in_url option

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1221,7 +1221,6 @@ OPTION(rgw_swift_url_prefix, OPT_STR, "swift") // entry point for which a url is
 OPTION(rgw_swift_auth_url, OPT_STR, "")        // default URL to go and verify tokens for v1 auth (if not using internal swift auth)
 OPTION(rgw_swift_auth_entry, OPT_STR, "auth")  // entry point for which a url is considered a swift auth url
 OPTION(rgw_swift_tenant_name, OPT_STR, "")  // tenant name to use for swift access
-OPTION(rgw_swift_account_in_url, OPT_BOOL, false)  // assume that URL always contain the account (aka tenant) part
 OPTION(rgw_swift_enforce_content_length, OPT_BOOL, false)  // enforce generation of Content-Length even in cost of performance or scalability
 OPTION(rgw_keystone_url, OPT_STR, "")  // url for keystone server
 OPTION(rgw_keystone_admin_token, OPT_STR, "")  // keystone admin token (shared secret)

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1468,6 +1468,14 @@ static void next_tok(string& str, string& tok, char delim)
   }
 }
 
+bool is_account_in_url(const char *token)
+{
+  if (strncmp(token, "AUTH_rgwts", 10) == 0) {
+    return true;
+  }
+  return false;
+}
+
 int RGWHandler_REST_SWIFT::init_from_header(struct req_state *s)
 {
   string req;
@@ -1533,11 +1541,13 @@ int RGWHandler_REST_SWIFT::init_from_header(struct req_state *s)
   if (ret < 0)
     return ret;
 
+  s->os_auth_token = s->info.env->get("HTTP_X_AUTH_TOKEN");
+
   string ver;
 
   next_tok(req, ver, '/');
 
-  if (!tenant_path.empty() || g_conf->rgw_swift_account_in_url) {
+  if (!tenant_path.empty() || is_account_in_url(s->os_auth_token)) {
     string account_name;
     next_tok(req, account_name, '/');
 
@@ -1560,7 +1570,6 @@ int RGWHandler_REST_SWIFT::init_from_header(struct req_state *s)
     }
   }
 
-  s->os_auth_token = s->info.env->get("HTTP_X_AUTH_TOKEN");
   next_tok(req, first, '/');
 
   dout(10) << "ver=" << ver << " first=" << first << " req=" << req << dendl;

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -723,13 +723,11 @@ bool RGWSwift::do_verify_swift_token(RGWRados *store, req_state *s)
     return (ret >= 0);
   }
 
-  if (strncmp(s->os_auth_token, "AUTH_rgwtk", 10) == 0) {
+  if (strncmp(s->os_auth_token, "AUTH_rgwtk", 10) == 0 ||
+      strncmp(s->os_auth_token, "AUTH_rgwts", 10) == 0) {
     int ret = rgw_swift_verify_signed_token(s->cct, store, s->os_auth_token,
 					    *(s->user), &s->swift_user);
-    if (ret < 0)
-      return false;
-
-    return  true;
+    return (ret >= 0);
   }
 
   struct rgw_swift_auth_info info;


### PR DESCRIPTION
A recent commit introduced rgw_swift_account_in_url, which appears
to be not necessary. This patch uses token format to pass the
information that current code extracts from the option. This way
a smooth upgrades without undue configuration are possible, and
the administrative load is not raised. No need to document what
software can do automatically either.

When I presented this originally in one of community BJ meetings,
it may be that Radoslaw pointed out that adjustments to TempURL
were needed. But I cannot recall if it were true and if yes, what was
the problem. I may be missing something though. This commit permits
to find it out and document the issue, if any.