### PR TITLE
rgw: Allow to serve Swift off the URL root

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -749,10 +749,14 @@ Swift Settings
 
 ``rgw swift url prefix``
 
-:Description: The URL prefix for the Swift API. 
+:Description: The URL prefix for the Swift StorageURL that goes in front of
+              the "/v1" part. This allows to run several Gateway instances
+              on the same host. For compatibility, setting this configuration
+              variable to empty causes the default "/swift" to be used.
+              Use explicit prefix "/" to start StorageURL at the root.
 :Default: ``swift``
-:Example: http://fqdn.com/swift
-	
+:Example: "/swift-testing"
+
 
 ``rgw swift auth url``
 

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -13,7 +13,7 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-#define DEFAULT_SWIFT_PREFIX "swift"
+#define DEFAULT_SWIFT_PREFIX "/swift"
 
 using namespace ceph::crypto;
 
@@ -141,6 +141,7 @@ int rgw_swift_verify_signed_token(CephContext *cct, RGWRados *store,
 void RGW_SWIFT_Auth_Get::execute()
 {
   int ret = -EPERM;
+  const char *token_tag = "rgwtk";
 
   const char *key = s->info.env->get("HTTP_X_AUTH_KEY");
   const char *user = s->info.env->get("HTTP_X_AUTH_USER");
@@ -155,8 +156,20 @@ void RGW_SWIFT_Auth_Get::execute()
   string swift_prefix = g_conf->rgw_swift_url_prefix;
   string tenant_path;
 
+  /*
+   * We did not allow an empty Swift prefix before, but we want it now.
+   * So, we take rgw_swift_url_prefix = "/" to yield the empty prefix.
+   * The rgw_swift_url_prefix = "" is the default and yields "/swift"
+   * in a backwards-compatible way.
+   */
   if (swift_prefix.size() == 0) {
     swift_prefix = DEFAULT_SWIFT_PREFIX;
+  } else if (swift_prefix == "/") {
+    swift_prefix.clear();
+  } else {
+    if (swift_prefix[0] != '/') {
+      swift_prefix.insert(0, "/");
+    }
   }
 
   if (swift_url.size() == 0) {
@@ -218,8 +231,8 @@ void RGW_SWIFT_Auth_Get::execute()
     tenant_path.append(user_str);
   }
 
-  STREAM_IO(s)->print("X-Storage-Url: %s/%s/v1%s\r\n", swift_url.c_str(),
-		swift_prefix.c_str(), tenant_path.c_str());
+  STREAM_IO(s)->print("X-Storage-Url: %s%s/v1%s\r\n", swift_url.c_str(),
+	        swift_prefix.c_str(), tenant_path.c_str());
 
   if ((ret = encode_token(s->cct, swift_key->id, swift_key->key, bl)) < 0)
     goto done;


### PR DESCRIPTION
In most public clouds OpenStack Swift URL is based on the tree
root, like:
  https://swift.domain.com/v1/AUTH_tenant

Our convention is to have a path, like:
  https://domain.com/swift/v1/AUTH_tenant

The path is configurable, but even if someone manages to set
an empty prefix, we print headers with %s/%s/v1 where the extra
slash is baked in. In addition, the empty prefix means "use the
/swift default".

To provide compatibility, this patch uses a trick. The empty
prefix remains to mean "/swift", but then we use "/" (one slash)
to create the needed empty prefix.

Signed-off-by: Pete Zaitcev <zaitcev@redhat.com>