### PR TITLE
crushtool: add ability of precise testing of placement group calculation.

### DIFF
--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -640,7 +640,11 @@ int CrushTester::test()
           if (use_crush) {
             if (output_mappings)
 	      err << "CRUSH"; // prepend CRUSH to placement output
-            crush.do_rule(r, x, out, nr, weight);
+            uint32_t real_x = x;
+            if (pool_id != -1) {
+              real_x = crush_hash32_2(CRUSH_HASH_RJENKINS1, x, (uint32_t)pool_id);
+            }
+            crush.do_rule(r, real_x, out, nr, weight);
           } else {
             if (output_mappings)
 	      err << "RNG"; // prepend RNG to placement output to denote simulation

--- a/src/crush/CrushTester.h
+++ b/src/crush/CrushTester.h
@@ -18,6 +18,7 @@ class CrushTester {
   int ruleset;
   int min_x, max_x;
   int min_rep, max_rep;
+  int64_t pool_id;
 
   int num_batches;
   bool use_crush;
@@ -172,6 +173,7 @@ public:
       ruleset(-1),
       min_x(-1), max_x(-1),
       min_rep(-1), max_rep(-1),
+      pool_id(-1),
       num_batches(1),
       use_crush(true),
       mark_down_device_ratio(0.0),
@@ -302,6 +304,11 @@ public:
   void set_min_x(int x) {
     min_x = x;
   }
+
+  void set_pool_id(int64_t x){
+    pool_id = x;
+  }
+
   int get_min_x() const {
     return min_x;
   }

--- a/src/test/cli/crushtool/help.t
+++ b/src/test/cli/crushtool/help.t
@@ -69,6 +69,7 @@
         [--min-x x] [--max-x x] [--x x]
         [--min-rule r] [--max-rule r] [--rule r] [--ruleset rs]
         [--num-rep n]
+        [--pool-id n]      specifies pool id
         [--batches b]      split the CRUSH mapping into b > 1 rounds
         [--weight|-w devno weight]
                            where weight is 0 to 1.0

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -175,6 +175,7 @@ void usage()
   cout << "      [--min-x x] [--max-x x] [--x x]\n";
   cout << "      [--min-rule r] [--max-rule r] [--rule r] [--ruleset rs]\n";
   cout << "      [--num-rep n]\n";
+  cout << "      [--pool-id n]      specifies pool id\n";
   cout << "      [--batches b]      split the CRUSH mapping into b > 1 rounds\n";
   cout << "      [--weight|-w devno weight]\n";
   cout << "                         where weight is 0 to 1.0\n";
@@ -276,6 +277,7 @@ int main(int argc, const char **argv)
 
   int x;
   float y;
+  long long z;
 
   std::string val;
   std::ostringstream err;
@@ -448,6 +450,12 @@ int main(int argc, const char **argv)
 	exit(EXIT_FAILURE);
       }
       tester.set_min_x(x);
+    } else if (ceph_argparse_witharg(args, i, &z, err, "--pool_id", (char*)NULL)) {
+      if (!err.str().empty()) {
+  cerr << err.str() << std::endl;
+  exit(EXIT_FAILURE);
+      }
+      tester.set_pool_id(z);
     } else if (ceph_argparse_witharg(args, i, &x, err, "--x", (char*)NULL)) {
       if (!err.str().empty()) {
 	cerr << err.str() << std::endl;


### PR DESCRIPTION
Now pool id can be passed and proper JENKINS hash is used.
Signed-off-by: Adam Kupczyk akupczyk@mirantis.com