### PR TITLE
cmake: avoid false-positive LDAP header detect

### DIFF
--- a/cmake/modules/FindOpenLdap.cmake
+++ b/cmake/modules/FindOpenLdap.cmake
@@ -3,13 +3,13 @@
 # OPENLDAP_PREFIX - where to find ldap.h and libraries
 # OPENLDAP_FOUND - True if found.
 
-set(OPENLDAP_INCLUDE_DIR "${OPENLDAP_PREFIX}/include")
 set(OPENLDAP_LIB_DIR "${OPENLDAP_PREFIX}/lib")
 
 find_path(OPENLDAP_INCLUDE_DIR ldap.h NO_DEFAULT_PATH PATHS
   /usr/include
   /opt/local/include
   /usr/local/include
+  "${OPENLDAP_PREFIX}/include"
   )
 
 find_library(LIBLDAP NAMES ldap)
@@ -23,12 +23,13 @@ endif (OPENLDAP_INCLUDE_DIR AND LIBLDAP AND LIBLBER)
 
 if (OPENLDAP_FOUND)
   message(STATUS "Found ldap: ${OPENLDAP_INCLUDE_DIR}")
-else ()
-  message(STATUS "Failed to find ldap.h")
-  if (OPENLDAP_FIND_REQUIRED)
-    message(FATAL_ERROR "Missing required ldap.h")
-  endif ()
-endif ()
+else (OPENLDAP_FOUND)
+  if (NOT OPENLDAP_INCLUDE_DIR)
+    message(FATAL_ERROR "Missing required ldap.h (openldap-devel)")
+  else (NOT OPENLDAP_INCLUDE_DIR)
+    message (FATAL_ERROR "Missing required LDAP libraries (openldap)")
+  endif (NOT OPENLDAP_INCLUDE_DIR)
+endif (OPENLDAP_FOUND)
 
 set(OPENLDAP_LIBS ${LIBLDAP} ${LIBLBER})
 


### PR DESCRIPTION
Pre-setting a value in OPENLDAP_INCLUDE_DIR broke the subsequent
test.

@oritwas look ok?

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>