### PR TITLE
os/bluestore: small fixes in bluestore StupidAllocator

### DIFF
--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -85,15 +85,15 @@ static uint64_t aligned_len(btree_interval_set<uint64_t>::iterator p,
 }
 
 int StupidAllocator::allocate(
-  uint64_t need_size, uint64_t alloc_unit, int64_t hint,
+  uint64_t want_size, uint64_t alloc_unit, int64_t hint,
   uint64_t *offset, uint32_t *length)
 {
   std::lock_guard<std::mutex> l(lock);
-  dout(10) << __func__ << " need_size " << need_size
+  dout(10) << __func__ << " want_size " << want_size
 	   << " alloc_unit " << alloc_unit
 	   << " hint " << hint
 	   << dendl;
-  uint64_t want = MAX(alloc_unit, need_size);
+  uint64_t want = MAX(alloc_unit, want_size);
   int bin = _choose_bin(want);
   int orig_bin = bin;
 
@@ -107,7 +107,7 @@ int StupidAllocator::allocate(
     for (bin = orig_bin; bin < (int)free.size(); ++bin) {
       p = free[bin].lower_bound(hint);
       while (p != free[bin].end()) {
-	if (aligned_len(p, alloc_unit) >= need_size) {
+	if (aligned_len(p, alloc_unit) >= want_size) {
 	  goto found;
 	}
 	++p;
@@ -120,7 +120,7 @@ int StupidAllocator::allocate(
     p = free[bin].begin();
     auto end = hint ? free[bin].lower_bound(hint) : free[bin].end();
     while (p != end) {
-      if (aligned_len(p, alloc_unit) >= need_size) {
+      if (aligned_len(p, alloc_unit) >= want_size) {
 	goto found;
       }
       ++p;
@@ -160,7 +160,7 @@ int StupidAllocator::allocate(
   if (skew)
     skew = alloc_unit - skew;
   *offset = p.get_start() + skew;
-  *length = MIN(MAX(alloc_unit, need_size), p.get_len() - skew);
+  *length = MIN(MAX(alloc_unit, want_size), p.get_len() - skew);
   if (g_conf->bluestore_debug_small_allocations) {
     uint64_t max =
       alloc_unit * (rand() % g_conf->bluestore_debug_small_allocations);

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -115,10 +115,11 @@ int StupidAllocator::allocate(
     }
   }
 
-  // search up (from origin)
+  // search up (from origin, and skip searched extents by hint)
   for (bin = orig_bin; bin < (int)free.size(); ++bin) {
     p = free[bin].begin();
-    while (p != free[bin].end()) {
+    auto end = hint ? free[bin].lower_bound(hint) : free[bin].end();
+    while (p != end) {
       if (aligned_len(p, alloc_unit) >= need_size) {
 	goto found;
       }
@@ -139,10 +140,11 @@ int StupidAllocator::allocate(
     }
   }
 
-  // search down (origin)
+  // search down (from origin, and skip searched extents by hint)
   for (bin = orig_bin; bin >= 0; --bin) {
     p = free[bin].begin();
-    while (p != free[bin].end()) {
+    auto end = hint ? free[bin].lower_bound(hint) : free[bin].end();
+    while (p != end) {
       if (aligned_len(p, alloc_unit) >= alloc_unit) {
 	goto found;
       }

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -34,7 +34,7 @@ public:
   void unreserve(uint64_t unused);
 
   int allocate(
-    uint64_t need_size, uint64_t alloc_unit, int64_t hint,
+    uint64_t want_size, uint64_t alloc_unit, int64_t hint,
     uint64_t *offset, uint32_t *length);
 
   int release(


### PR DESCRIPTION
Main change is to avoid duplicated searches during allocating free extents.