### PR TITLE
qa/workunits/rbd: do not use object map during read flag testing

### DIFF
--- a/qa/workunits/rbd/read-flags.sh
+++ b/qa/workunits/rbd/read-flags.sh
@@ -42,7 +42,7 @@ clean_up
 
 trap clean_up INT TERM EXIT
 
-rbd create -s 10 test
+rbd create --image-feature layering -s 10 test
 rbd snap create test@snap
 
 # export from non snapshot with or without settings should not have flags


### PR DESCRIPTION
Signed-off-by: Jason Dillaman <dillaman@redhat.com>