### PR TITLE
ceph-detect-init: add missing test case

### DIFF
--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -50,6 +50,10 @@ class TestCephDetectInit(testtools.TestCase):
             self.assertEqual('sysvinit', debian.choose_init())
         with mock.patch.multiple('ceph_detect_init.debian',
                                  distro='debian',
+                                 codename='squeeze'):
+            self.assertEqual('sysvinit', debian.choose_init())
+        with mock.patch.multiple('ceph_detect_init.debian',
+                                 distro='debian',
                                  codename='jessie'):
             self.assertEqual('systemd', debian.choose_init())
         with mock.patch.multiple('ceph_detect_init.debian',


### PR DESCRIPTION
Since we return 'sysvinit' for wheezy and squeeze only, make sure we are
testing both of these.