### PR TITLE
RPM: fix openldap and openssl build dependencies for SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -119,8 +119,6 @@ BuildRequires:	libblkid-devel >= 2.17
 BuildRequires:	libudev-devel
 BuildRequires:	libtool
 BuildRequires:	make
-BuildRequires:  openldap-devel
-BuildRequires:  openssl-devel
 BuildRequires:	parted
 BuildRequires:	perl
 BuildRequires:	pkgconfig
@@ -159,7 +157,9 @@ BuildRequires:  btrfsprogs
 BuildRequires:	mozilla-nss-devel
 BuildRequires:	keyutils-devel
 BuildRequires:	libatomic-ops-devel
+BuildRequires:  libopenssl-devel
 BuildRequires:  lsb-release
+BuildRequires:  openldap2-devel
 BuildRequires:	python-Cython
 %endif
 %if 0%{?fedora} || 0%{?rhel} 
@@ -176,6 +176,8 @@ Requires(post):	chkconfig
 Requires(preun):	chkconfig
 Requires(preun):	initscripts
 BuildRequires:	gperftools-devel
+BuildRequires:  openldap-devel
+BuildRequires:  openssl-devel
 BuildRequires:  redhat-lsb-core
 BuildRequires:	Cython
 %endif


### PR DESCRIPTION
http://tracker.ceph.com/issues/15138 Fixes: #15138

Signed-off-by: Nathan Cutler <ncutler@suse.com>