### PR TITLE
qa/workunits: remove 'mds setmap' from workunits

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -751,8 +751,6 @@ function test_mon_mds()
   mdsmapfile=$TMPDIR/mdsmap.$$
   current_epoch=$(ceph mds getmap -o $mdsmapfile --no-log-to-stderr 2>&1 | grep epoch | sed 's/.*epoch //')
   [ -s $mdsmapfile ]
-  ((epoch = current_epoch + 1))
-  ceph mds setmap -i $mdsmapfile $epoch
   rm $mdsmapfile
 
   ceph osd pool create data2 10

--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -166,26 +166,6 @@ if __name__ == '__main__':
     r = expect('mds/dump.xml', 'GET', 200, 'xml')
     assert(r.tree.find('output/mdsmap/created') is not None)
 
-    failresps = []
-    while len(failresps) < 10:
-        r = expect('mds/dump.json', 'GET', 200, 'json')
-        assert('created' in r.myjson['output'])
-        current_epoch = r.myjson['output']['epoch']
-
-        map = expect('mds/getmap', 'GET', 200, '')
-        assert(len(map.content) != 0)
-        msg, r = expect_nofail(
-            'mds/setmap?epoch={0}'.format(current_epoch + 1), 'PUT', 200,
-            'plain', {'Content-Type':'text/plain'}, data=map.content
-            )
-        if msg:
-            failresps.append(msg + r.content)
-        else:
-            break
-
-    if len(failresps) == 10:
-        fail(r, 'Could not mds setmap in 10 tries; responses:' +
-             '\n'.join(failresps))
     expect('mds/newfs?metadata=0&data=1&sure=--yes-i-really-mean-it', 'PUT',
            200, '')
     expect('osd/pool/create?pool=data2&pg_num=10', 'PUT', 200, '')


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 6a80e2df8b31802a39ef6f89136ed357dce50c20)