### PR TITLE
tests: Improving 'make check' execution time

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -940,7 +940,7 @@ function get_num_active_clean() {
     # grep -v '^$' 
     ceph --format xml pg dump pgs 2>/dev/null | \
         $XMLSTARLET sel -t -m "//pg_stat/state[$expression]" -v . -n | \
-        grep -v '^$' | wc -l
+        grep -cv '^$'
 }
 
 function test_get_num_active_clean() {

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1814,7 +1814,10 @@ function test_mon_cephdf_commands()
   rados put cephdf_for_test cephdf_for_test -p cephdf_for_test
 
   #wait for update
-  sleep 10
+  for i in `seq 1 10`; do
+    rados -p cephdf_for_test ls - | grep -q cephdf_for_test && break
+    sleep 1
+  done
 
   cal_raw_used_size=`ceph df detail | grep cephdf_for_test | awk -F ' ' '{printf "%d\n", 2 * $4}'`
   raw_used_size=`ceph df detail | grep cephdf_for_test | awk -F ' '  '{print $11}'`

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -248,24 +248,24 @@ function test_tiering_agent()
   # wait for the object to be evicted from the cache
   local evicted
   evicted=false
-  for i in 1 2 4 8 16 32 64 128 256 ; do
+  for i in `seq 1 300` ; do
       if ! rados -p $fast ls | grep obj1 ; then
           evicted=true
           break
       fi
-      sleep $i
+      sleep 1
   done
   $evicted # assert
   # the object is proxy read and promoted to the cache
   rados -p $slow get obj1 - >/dev/null
   # wait for the promoted object to be evicted again
   evicted=false
-  for i in 1 2 4 8 16 32 64 128 256 ; do
+  for i in `seq 1 300` ; do
       if ! rados -p $fast ls | grep obj1 ; then
           evicted=true
           break
       fi
-      sleep $i
+      sleep 1
   done
   $evicted # assert
   ceph osd tier remove-overlay $slow

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1084,10 +1084,10 @@ function test_mon_osd()
   ceph osd down 0
   ceph osd dump | grep 'osd.0 down'
   ceph osd unset noup
-  for ((i=0; i < 100; i++)); do
+  for ((i=0; i < 1000; i++)); do
     if ! ceph osd dump | grep 'osd.0 up'; then
       echo "waiting for osd.0 to come back up"
-      sleep 10
+      sleep 1
     else
       break
     fi

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -170,8 +170,8 @@ function ceph_watch_wait()
     fi
 
     for i in `seq ${timeout}`; do
-	sleep 1
 	grep -q "$regexp" $CEPH_WATCH_FILE && break
+	sleep 1
     done
 
     kill $CEPH_WATCH_PID

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -44,7 +44,8 @@ def wait_for_health():
     print "Wait for health_ok...",
     tries = 0
     while call("./ceph health 2> /dev/null | grep -v 'HEALTH_OK\|HEALTH_WARN' > /dev/null", shell=True) == 0:
-        if ++tries == 150:
+        tries += 1
+        if tries == 150:
             raise Exception("Time exceeded to go to health")
         time.sleep(1)
     print "DONE"

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -44,9 +44,9 @@ def wait_for_health():
     print "Wait for health_ok...",
     tries = 0
     while call("./ceph health 2> /dev/null | grep -v 'HEALTH_OK\|HEALTH_WARN' > /dev/null", shell=True) == 0:
-        if ++tries == 30:
+        if ++tries == 150:
             raise Exception("Time exceeded to go to health")
-        time.sleep(5)
+        time.sleep(1)
     print "DONE"
 
 
@@ -1799,15 +1799,11 @@ def main(argv):
         vstart(new=False)
         wait_for_health()
 
-        time.sleep(20)
-
         cmd = "./ceph osd pool set {pool} pg_num 2".format(pool=SPLIT_POOL)
         logging.debug(cmd)
         ret = call(cmd, shell=True, stdout=nullfd, stderr=nullfd)
         time.sleep(5)
         wait_for_health()
-
-        time.sleep(15)
 
         kill_daemons()
 

--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -86,14 +86,18 @@ test_object() {
           continue
         fi;
 
+        ./ceph-dencoder type $type import $vdir/objects/$type/$f decode dump_json > $tmp1 &
+        pid1="$!"
+        ./ceph-dencoder type $type import $vdir/objects/$type/$f decode encode decode dump_json > $tmp2 &
+        pid2="$!"
         #echo "\t$vdir/$type/$f"
-        if ! ./ceph-dencoder type $type import $vdir/objects/$type/$f decode dump_json > $tmp1; then
+        if ! wait $pid1; then
           echo "**** failed to decode $vdir/objects/$type/$f ****"
           failed=$(($failed + 1))
           rm -f $tmp1 $tmp2
           continue      
         fi
-        if ! ./ceph-dencoder type $type import $vdir/objects/$type/$f decode encode decode dump_json > $tmp2; then
+        if ! wait $pid2; then
           echo "**** failed to decode+encode+decode $vdir/objects/$type/$f ****"
           failed=$(($failed + 1))
           rm -f $tmp1 $tmp2

--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -4,23 +4,25 @@ dir=../ceph-object-corpus
 
 set -e
 
-tmp1=`mktemp /tmp/typ-XXXXXXXXX`
-tmp2=`mktemp /tmp/typ-XXXXXXXXX`
-
 failed=0
 numtests=0
+pids=""
 
 myversion=`./ceph-dencoder version`
+DEBUG=0
+WAITALL_DELAY=.1
+debug() { if [ "$DEBUG" -gt 0 ]; then echo "DEBUG: $*" >&2; fi }
 
-for arversion in `ls -v $dir/archive`; do
-  vdir="$dir/archive/$arversion"
-  #echo $vdir
+test_object() {
+    local type=$1
+    local output_file=$2
+    local failed=0
+    local numtests=0
 
-  if [ ! -d "$vdir/objects" ]; then
-    continue;
-  fi
+    tmp1=`mktemp /tmp/typ-XXXXXXXXX`
+    tmp2=`mktemp /tmp/typ-XXXXXXXXX`
 
-  for type in `ls $vdir/objects`; do
+    rm -f $output_file
     if ./ceph-dencoder type $type 2>/dev/null; then
       #echo "type $type";
       echo "        $vdir/objects/$type"
@@ -88,11 +90,13 @@ for arversion in `ls -v $dir/archive`; do
         if ! ./ceph-dencoder type $type import $vdir/objects/$type/$f decode dump_json > $tmp1; then
           echo "**** failed to decode $vdir/objects/$type/$f ****"
           failed=$(($failed + 1))
+          rm -f $tmp1 $tmp2
           continue      
         fi
         if ! ./ceph-dencoder type $type import $vdir/objects/$type/$f decode encode decode dump_json > $tmp2; then
           echo "**** failed to decode+encode+decode $vdir/objects/$type/$f ****"
           failed=$(($failed + 1))
+          rm -f $tmp1 $tmp2
           continue
         fi
 
@@ -114,14 +118,85 @@ for arversion in `ls -v $dir/archive`; do
           failed=$(($failed + 1))
         fi
         numtests=$(($numtests + 1))
+        echo "failed=$failed" > $output_file
+        echo "numtests=$numtests" >> $output_file
       done
     else
       echo "skipping unrecognized type $type"
     fi
+
+    rm -f $tmp1 $tmp2
+}
+
+waitall() { # PID...
+   ## Wait for children to exit and indicate whether all exited with 0 status.
+   local errors=0
+   while :; do
+     debug "Processes remaining: $*"
+     for pid in "$@"; do
+       shift
+       if kill -0 "$pid" 2>/dev/null; then
+         debug "$pid is still alive."
+         set -- "$@" "$pid"
+       elif wait "$pid"; then
+         debug "$pid exited with zero exit status."
+       else
+         debug "$pid exited with non-zero exit status."
+         errors=$(($errors + 1))
+       fi
+     done
+     (("$#" > 0)) || break
+     sleep ${WAITALL_DELAY:-1}
+    done
+   [ $errors -eq 0 ]
+}
+
+######
+# MAIN
+######
+
+# Using $MAX_PARALLEL_JOBS jobs if defined, unless the number of logical
+# processors
+max_parallel_jobs=${MAX_PARALLEL_JOBS:-$(nproc)}
+
+for arversion in `ls -v $dir/archive`; do
+  vdir="$dir/archive/$arversion"
+  #echo $vdir
+
+  if [ ! -d "$vdir/objects" ]; then
+    continue;
+  fi
+
+  output_file=`mktemp /tmp/typ-XXXXXXXXX`
+  running_jobs=0
+  for type in `ls $vdir/objects`; do
+    test_object $type $output_file.$running_jobs &
+    pids="$pids $!"
+    running_jobs=$(($running_jobs + 1))
+
+    # Once we spawned enough jobs, let's wait them to complete
+    # Every spawned job have almost the same execution time so
+    # it's not a big deal having them not ending at the same time
+    if [ "$running_jobs" -eq "$max_parallel_jobs" ]; then
+        waitall $pids
+        pids=""
+        # Reading the output of jobs to compute failed & numtests
+        # Tests are run in parallel but sum should be done sequentialy to avoid
+        # races between threads
+        while [ "$running_jobs" -ge 0 ]; do
+            if [ -f $output_file.$running_jobs ]; then
+                read_failed=$(grep "^failed=" $output_file.$running_jobs | cut -d "=" -f 2)
+                read_numtests=$(grep "^numtests=" $output_file.$running_jobs | cut -d "=" -f 2)
+                rm -f $output_file.$running_jobs
+                failed=$(($failed + $read_failed))
+                numtests=$(($numtests + $read_numtests))
+            fi
+            running_jobs=$(($running_jobs - 1))
+        done
+        running_jobs=0
+    fi
   done
 done
-
-rm -f $tmp1 $tmp2
 
 if [ $failed -gt 0 ]; then
   echo "FAILED $failed / $numtests tests."


### PR DESCRIPTION
When running make -j x check, we face a weird situation where the makefile
targets are spawn in parallel up to "x" but some targets is very very
long and sequential.

This pull request aims at removing this bottlenecks to make a faster build process.

The initial running time was 30mn on a recent laptop and dropped to 14mn.

Signed-off-by: Erwan Velu <erwan@redhat.com>