### PR TITLE
packaging: move cephfs repair tools to ceph-common

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -974,6 +974,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/ceph-rbdnamer
 %{_bindir}/ceph-syn
 %{_bindir}/ceph-crush-location
+%{_bindir}/cephfs-data-scan
+%{_bindir}/cephfs-journal-tool
+%{_bindir}/cephfs-table-tool
 %{_bindir}/rados
 %{_bindir}/rbd
 %{_bindir}/rbd-replay
@@ -1050,9 +1053,6 @@ fi
 #################################################################################
 %files mds
 %{_bindir}/ceph-mds
-%{_bindir}/cephfs-journal-tool
-%{_bindir}/cephfs-table-tool
-%{_bindir}/cephfs-data-scan
 %{_mandir}/man8/ceph-mds.8*
 %if 0%{?_with_systemd}
 %{_unitdir}/ceph-mds@.service

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -266,6 +266,7 @@ Summary:	Ceph Common
 Group:		System Environment/Base
 Requires:	librbd1 = %{epoch}:%{version}-%{release}
 Requires:	librados2 = %{epoch}:%{version}-%{release}
+Requires:	libcephfs1 = %{epoch}:%{version}-%{release}
 Requires:	python-rados = %{epoch}:%{version}-%{release}
 Requires:	python-rbd = %{epoch}:%{version}-%{release}
 Requires:	python-cephfs = %{epoch}:%{version}-%{release}

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -7,6 +7,9 @@ usr/bin/ceph-dencoder
 usr/bin/ceph-rbdnamer
 usr/bin/ceph-syn
 usr/bin/ceph-crush-location
+usr/bin/cephfs-data-scan
+usr/bin/cephfs-journal-tool
+usr/bin/cephfs-table-tool
 usr/bin/rados
 usr/bin/rbd
 usr/bin/rbdmap

--- a/debian/ceph-mds.install
+++ b/debian/ceph-mds.install
@@ -1,5 +1,2 @@
 usr/bin/ceph-mds
-usr/bin/cephfs-journal-tool
-usr/bin/cephfs-table-tool
-usr/bin/cephfs-data-scan
 usr/share/man/man8/ceph-mds.8


### PR DESCRIPTION
The CephFS repair tools are generally useful to run on any node, not just the MDS nodes themselves.

Move the utilities from the ceph-mds package to the ceph-common package.

Fixes http://tracker.ceph.com/issues/15145