### PR TITLE
rgw: Allow an implicit tenant in case of Keystone

### DIFF
--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -16,6 +16,7 @@ The following configuration options are available for Keystone integration::
 	rgw keystone accepted roles = {accepted user roles}
 	rgw keystone token cache size = {number of tokens to cache}
 	rgw keystone revocation interval = {number of seconds before checking revoked tickets}
+	rgw keystone make new tenants = {true for private tenant for each new user}
 	rgw s3 auth use keystone = true
 	nss db path = {path to nss db}
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1240,6 +1240,7 @@ OPTION(rgw_keystone_accepted_roles, OPT_STR, "Member, admin")  // roles required
 OPTION(rgw_keystone_token_cache_size, OPT_INT, 10000)  // max number of entries in keystone token cache
 OPTION(rgw_keystone_revocation_interval, OPT_INT, 15 * 60)  // seconds between tokens revocation check
 OPTION(rgw_keystone_verify_ssl, OPT_BOOL, true) // should we try to verify keystone's ssl
+OPTION(rgw_keystone_implicit_tenants, OPT_BOOL, false)  // create new users in their own tenants of the same name
 OPTION(rgw_s3_auth_use_rados, OPT_BOOL, true)  // should we try to use the internal credentials for s3?
 OPTION(rgw_s3_auth_use_keystone, OPT_BOOL, false)  // should we try to use keystone for s3?
 

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -14,13 +14,12 @@ class RGWRados;
 class KeystoneToken;
 
 struct rgw_swift_auth_info {
-  int status;
   string auth_groups;
   rgw_user user;
   string display_name;
   long long ttl;
 
-  rgw_swift_auth_info() : status(0), ttl(0) {}
+  rgw_swift_auth_info() : ttl(0) {}
 };
 
 class RGWSwift {
@@ -28,7 +27,7 @@ class RGWSwift {
   atomic_t down_flag;
 
   int validate_token(const char *token, struct rgw_swift_auth_info *info);
-  int validate_keystone_token(RGWRados *store, const string& token, struct rgw_swift_auth_info *info,
+  int validate_keystone_token(RGWRados *store, const string& token,
 			      RGWUserInfo& rgw_user);
 
   int parse_keystone_token_response(const string& token,


### PR DESCRIPTION
This, unfortunately, introduces possible double lookups, but
they should be cached. Also, the logic appears somewhat convoluted,
although the intent is quite simple: if you're an OpenStack user
with a Keystone authentication, we allow an implicit tenant of
the same name as the user.

Signed-off-by: Pete Zaitcev <zaitcev@redhat.com>

Conflicts:
	src/rgw/rgw_swift.cc