### PR TITLE
rgw: update data_log only when completing the op

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -632,9 +632,12 @@ void *RGWHTTPManager::reqs_thread_entry()
   }
 
   RWLock::WLocker rl(reqs_lock);
-  map<uint64_t, rgw_http_req_data *>::iterator iter = reqs.begin();
-  for (; iter != reqs.end(); ++iter) {
-    _finish_request(iter->second, -ECANCELED);
+  set<rgw_http_req_data *> all_reqs;
+  for (auto iter : reqs) {
+    all_reqs.insert(iter.second); /* can't call _finish_request() on iter.second, it will modify reqs */
+  }
+  for (auto iter : all_reqs) {
+    _finish_request(iter, -ECANCELED);
   }
 
   reqs.clear();

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -536,8 +536,11 @@ protected:
   bool has_cors;
   RGWCORSConfiguration cors_config;
   string swift_ver_location;
+  set<string> rmattr_names;
 
   bufferlist in_data;
+
+  virtual bool need_metadata_upload() const { return false; }
 
 public:
   RGWCreateBucket() : has_cors(false) {}

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -467,6 +467,42 @@ static int get_swift_container_settings(req_state *s, RGWRados *store, RGWAccess
   return 0;
 }
 
+#define ACCT_REMOVE_ATTR_PREFIX     "HTTP_X_REMOVE_ACCOUNT_META_"
+#define ACCT_PUT_ATTR_PREFIX        "HTTP_X_ACCOUNT_META_"
+#define CONT_REMOVE_ATTR_PREFIX     "HTTP_X_REMOVE_CONTAINER_META_"
+#define CONT_PUT_ATTR_PREFIX        "HTTP_X_CONTAINER_META_"
+
+static void get_rmattrs_from_headers(const req_state * const s,
+				     const char * const put_prefix,
+				     const char * const del_prefix,
+				     set<string>& rmattr_names)
+{
+  map<string, string, ltstr_nocase>& m = s->info.env->get_map();
+  map<string, string, ltstr_nocase>::const_iterator iter;
+  const size_t put_prefix_len = strlen(put_prefix);
+  const size_t del_prefix_len = strlen(del_prefix);
+
+  for (iter = m.begin(); iter != m.end(); ++iter) {
+    size_t prefix_len = 0;
+    const char * const p = iter->first.c_str();
+
+    if (strncasecmp(p, del_prefix, del_prefix_len) == 0) {
+      /* Explicitly requested removal. */
+      prefix_len = del_prefix_len;
+    } else if ((strncasecmp(p, put_prefix, put_prefix_len) == 0)
+	       && iter->second.empty()) {
+      /* Removal requested by putting an empty value. */
+      prefix_len = put_prefix_len;
+    }
+
+    if (prefix_len > 0) {
+      string name(RGW_ATTR_META_PREFIX);
+      name.append(lowercase_dash_http_attr(p + prefix_len));
+      rmattr_names.insert(name);
+    }
+  }
+}
+
 int RGWCreateBucket_ObjStore_SWIFT::get_params()
 {
   bool has_policy;
@@ -481,6 +517,8 @@ int RGWCreateBucket_ObjStore_SWIFT::get_params()
   }
 
   location_constraint = store->get_zonegroup().api_name;
+  get_rmattrs_from_headers(s, CONT_PUT_ATTR_PREFIX,
+                           CONT_REMOVE_ATTR_PREFIX, rmattr_names);
   placement_rule = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
 
   if (s->cct->_conf->rgw_swift_versioning_enabled) {
@@ -661,42 +699,6 @@ void RGWPutObj_ObjStore_SWIFT::send_response()
   dump_errno(s);
   end_header(s, this);
   rgw_flush_formatter_and_reset(s, s->formatter);
-}
-
-#define ACCT_REMOVE_ATTR_PREFIX     "HTTP_X_REMOVE_ACCOUNT_META_"
-#define ACCT_PUT_ATTR_PREFIX        "HTTP_X_ACCOUNT_META_"
-#define CONT_REMOVE_ATTR_PREFIX     "HTTP_X_REMOVE_CONTAINER_META_"
-#define CONT_PUT_ATTR_PREFIX        "HTTP_X_CONTAINER_META_"
-
-static void get_rmattrs_from_headers(const req_state * const s,
-				     const char * const put_prefix,
-				     const char * const del_prefix,
-				     set<string>& rmattr_names)
-{
-  map<string, string, ltstr_nocase>& m = s->info.env->get_map();
-  map<string, string, ltstr_nocase>::const_iterator iter;
-  const size_t put_prefix_len = strlen(put_prefix);
-  const size_t del_prefix_len = strlen(del_prefix);
-
-  for (iter = m.begin(); iter != m.end(); ++iter) {
-    size_t prefix_len = 0;
-    const char * const p = iter->first.c_str();
-
-    if (strncasecmp(p, del_prefix, del_prefix_len) == 0) {
-      /* Explicitly requested removal. */
-      prefix_len = del_prefix_len;
-    } else if ((strncasecmp(p, put_prefix, put_prefix_len) == 0)
-	       && iter->second.empty()) {
-      /* Removal requested by putting an empty value. */
-      prefix_len = put_prefix_len;
-    }
-
-    if (prefix_len > 0) {
-      string name(RGW_ATTR_META_PREFIX);
-      name.append(lowercase_dash_http_attr(p + prefix_len));
-      rmattr_names.insert(name);
-    }
-  }
 }
 
 int RGWPutMetadataAccount_ObjStore_SWIFT::get_params()

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -71,6 +71,8 @@ public:
 };
 
 class RGWCreateBucket_ObjStore_SWIFT : public RGWCreateBucket_ObjStore {
+protected:
+  bool need_metadata_upload() const override { return true; }
 public:
   RGWCreateBucket_ObjStore_SWIFT() {}
   ~RGWCreateBucket_ObjStore_SWIFT() {}


### PR DESCRIPTION
It doesn't make sense to update it earlier, the zone that follows will not sync before
it sees the completion.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>