### PR TITLE
cls/rgw: fix FTBFS

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1391,7 +1391,7 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   }
 
   if (existed && !real_clock::is_zero(op.unmod_since)) {
-    struct timespec mtime = ceph::real_clock::to_timespec(obj.mtime);
+    struct timespec mtime = ceph::real_clock::to_timespec(obj.mtime());
     struct timespec unmod = ceph::real_clock::to_timespec(op.unmod_since);
     if (!op.high_precision_time) {
       mtime.tv_nsec = 0;


### PR DESCRIPTION
BIVerObjEntry::mtime() is a method not a member variable

Signed-off-by: Kefu Chai <kchai@redhat.com>