### PR TITLE
update for python3

### DIFF
--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -84,12 +84,12 @@ def get_key(cluster, mon_id):
     pathdir = os.path.dirname(path)
     if not os.path.exists(pathdir):
         os.makedirs(pathdir)
-        os.chmod(pathdir, 0770)
+        os.chmod(pathdir, 0o770)
         os.chown(pathdir, get_ceph_uid(), get_ceph_gid())
     while True:
         try:
             with file(tmp, 'w') as f:
-                os.fchmod(f.fileno(), 0600)
+                os.fchmod(f.fileno(), 0o600)
                 os.fchown(f.fileno(), get_ceph_uid(), get_ceph_gid())
                 LOG.info('Talking to monitor...')
                 returncode = subprocess.call(
@@ -156,13 +156,13 @@ def bootstrap_key(cluster, type_):
     pathdir = os.path.dirname(path)
     if not os.path.exists(pathdir):
         os.makedirs(pathdir)
-        os.chmod(pathdir, 0770)
+        os.chmod(pathdir, 0o770)
         os.chown(pathdir, get_ceph_uid(), get_ceph_gid())
 
     while True:
         try:
             with file(tmp, 'w') as f:
-                os.fchmod(f.fileno(), 0600)
+                os.fchmod(f.fileno(), 0o600)
                 os.fchown(f.fileno(), get_ceph_uid(), get_ceph_gid())
                 LOG.info('Talking to monitor...')
                 returncode = subprocess.call(

--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -84,12 +84,12 @@ def get_key(cluster, mon_id):
     pathdir = os.path.dirname(path)
     if not os.path.exists(pathdir):
         os.makedirs(pathdir)
-        os.chmod(pathdir, 0o770)
+        os.chmod(pathdir, 0o770 | 0770)
         os.chown(pathdir, get_ceph_uid(), get_ceph_gid())
     while True:
         try:
             with file(tmp, 'w') as f:
-                os.fchmod(f.fileno(), 0o600)
+                os.fchmod(f.fileno(), 0o600 | 0600)
                 os.fchown(f.fileno(), get_ceph_uid(), get_ceph_gid())
                 LOG.info('Talking to monitor...')
                 returncode = subprocess.call(
@@ -156,13 +156,13 @@ def bootstrap_key(cluster, type_):
     pathdir = os.path.dirname(path)
     if not os.path.exists(pathdir):
         os.makedirs(pathdir)
-        os.chmod(pathdir, 0o770)
+        os.chmod(pathdir, 0o770 | 0700)
         os.chown(pathdir, get_ceph_uid(), get_ceph_gid())
 
     while True:
         try:
             with file(tmp, 'w') as f:
-                os.fchmod(f.fileno(), 0o600)
+                os.fchmod(f.fileno(), 0o600 | 0600)
                 os.fchown(f.fileno(), get_ceph_uid(), get_ceph_gid())
                 LOG.info('Talking to monitor...')
                 returncode = subprocess.call(


### PR DESCRIPTION
ceph-create-keys: update for python3

see https://www.python.org/dev/peps/pep-3127/#removal-of-old-octal-syntax
octal literals must now be specified with a leading "0o" or "0O" instead of "0"
so start octals with "0o" instead.

Signed-off-by: Smit Patel <indiakafgm@gmail.com>