### PR TITLE
osd: try to flush/evict object from cache tier based on time period

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -573,6 +573,7 @@ OPTION(osd_agent_max_low_ops, OPT_INT, 2)
 OPTION(osd_agent_min_evict_effort, OPT_FLOAT, .1)
 OPTION(osd_agent_quantize_effort, OPT_FLOAT, .1)
 OPTION(osd_agent_delay_time, OPT_FLOAT, 5.0)
+OPTION(osd_agent_flush_evict_interval, OPT_U64, 0)
 
 // osd ignore history.last_epoch_started in find_best_info
 OPTION(osd_find_best_info_ignore_history_les, OPT_BOOL, false)

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2657,7 +2657,7 @@ void pool_stat_t::generate_test_instances(list<pool_stat_t*>& o)
 
 void pg_history_t::encode(bufferlist &bl) const
 {
-  ENCODE_START(7, 4, bl);
+  ENCODE_START(8, 4, bl);
   ::encode(epoch_created, bl);
   ::encode(last_epoch_started, bl);
   ::encode(last_epoch_clean, bl);
@@ -2671,12 +2671,13 @@ void pg_history_t::encode(bufferlist &bl) const
   ::encode(last_deep_scrub_stamp, bl);
   ::encode(last_clean_scrub_stamp, bl);
   ::encode(last_epoch_marked_full, bl);
+  ::encode(last_flush_evict_stamp, bl);
   ENCODE_FINISH(bl);
 }
 
 void pg_history_t::decode(bufferlist::iterator &bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(7, 4, 4, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(8, 4, 4, bl);
   ::decode(epoch_created, bl);
   ::decode(last_epoch_started, bl);
   if (struct_v >= 3)
@@ -2701,6 +2702,13 @@ void pg_history_t::decode(bufferlist::iterator &bl)
   if (struct_v >= 7) {
     ::decode(last_epoch_marked_full, bl);
   }
+  if (struct_v >= 8) {
+    ::decode(last_flush_evict_stamp, bl);
+  }
+  else {
+    last_flush_evict_stamp = utime_t();
+  }
+
   DECODE_FINISH(bl);
 }
 
@@ -2719,6 +2727,7 @@ void pg_history_t::dump(Formatter *f) const
   f->dump_stream("last_deep_scrub") << last_deep_scrub;
   f->dump_stream("last_deep_scrub_stamp") << last_deep_scrub_stamp;
   f->dump_stream("last_clean_scrub_stamp") << last_clean_scrub_stamp;
+  f->dump_stream("last_flush_evict_stamp") << last_flush_evict_stamp;
 }
 
 void pg_history_t::generate_test_instances(list<pg_history_t*>& o)

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2011,12 +2011,14 @@ struct pg_history_t {
   utime_t last_scrub_stamp;
   utime_t last_deep_scrub_stamp;
   utime_t last_clean_scrub_stamp;
+  utime_t last_flush_evict_stamp; // last cache tier flush/evict timestamp
 
   pg_history_t()
     : epoch_created(0),
       last_epoch_started(0), last_epoch_clean(0), last_epoch_split(0),
       last_epoch_marked_full(0),
-      same_up_since(0), same_interval_since(0), same_primary_since(0) {}
+      same_up_since(0), same_interval_since(0), same_primary_since(0),
+      last_flush_evict_stamp(utime_t()) {}
   
   bool merge(const pg_history_t &other) {
     // Here, we only update the fields which cannot be calculated from the OSDmap.
@@ -2059,6 +2061,10 @@ struct pg_history_t {
     }
     if (other.last_clean_scrub_stamp > last_clean_scrub_stamp) {
       last_clean_scrub_stamp = other.last_clean_scrub_stamp;
+      modified = true;
+    }
+    if (other.last_flush_evict_stamp > last_flush_evict_stamp) {
+      last_flush_evict_stamp = other.last_flush_evict_stamp;
       modified = true;
     }
     return modified;


### PR DESCRIPTION
Currently cache tier's flushing/evicting triggering mechanism is based on dirty ratio and full dirty ratio. This is useful to control cache tier pool's space utilization. 

However one user case that we encountered is that customer doesn't care too much on such ratio towards their requirement. Customers want to move cold data to cheap base pool from upper expensive but small cache tier pool. They want to see only hot data staying at cache tier pool.

So we add such feature on cache tier with a configurable option, together with cache_min_flush_age, osd agent can flush objects which meet cache_min_flush_age to base pool periodically and then evict them.

Fixes: #15157

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>
