### PR TITLE
osd/OSD.cc: finish full_map_request every MOSDMap message.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4933,6 +4933,17 @@ void OSD::request_full_map(epoch_t first, epoch_t last)
   monc->send_mon_message(req);
 }
 
+void OSD::finish_full_map_request()
+{
+  if (requested_full_first == 0 && requested_full_last == 0)
+    return;
+  //Had requested some map but didn't receive in this message,
+  //This might because monitor capping the message to osd_map_message_max
+  dout(10) << __func__ << "still missing " << requested_full_first
+	   << ".." << requested_full_last << ", but now give up." << dendl;
+  requested_full_first = requested_full_last = 0;
+}
+
 void OSD::got_full_map(epoch_t e)
 {
   assert(requested_full_first <= requested_full_last);
@@ -6705,6 +6716,9 @@ void OSD::handle_osd_map(MOSDMap *m)
 
   // even if this map isn't from a mon, we may have satisfied our subscription
   monc->sub_got("osdmap", last);
+
+  if (!m->maps.empty())
+    finish_full_map_request();
 
   if (last <= superblock.newest_map) {
     dout(10) << " no new maps here, dropping" << dendl;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2052,6 +2052,7 @@ protected:
   epoch_t requested_full_first, requested_full_last;
 
   void request_full_map(epoch_t first, epoch_t last);
+  void finish_full_map_request();
   void got_full_map(epoch_t e);
 
   // -- failures --


### PR DESCRIPTION
We remember the range of requested full map in requested_full_first/last
and prevent sending duplicate requests.

But monitor will cap the reply to osd_map_message_max number of maps, for example,
OSD request [100, 200] while monitor only return [100,149], previous code think
[150, 200] is dup and prevent the OSD to send out the request, which is wrong.

Fix this by clear the requested_full_first/last field at the end of handle_osd_map.

Fixes: #15130

Signed-off-by: Xiaoxi Chen <xiaoxchen@ebay.com>