### PR TITLE
rbd-mirror: replayers async create/destroy

### DIFF
--- a/src/tools/rbd_mirror/Mirror.h
+++ b/src/tools/rbd_mirror/Mirror.h
@@ -52,6 +52,21 @@ private:
   Mutex m_replayers_lock;
   std::map<peer_t, std::unique_ptr<Replayer> > m_replayers;
   atomic_t m_stopping;
+
+  struct C_ShutdownReplayer : public Context {
+    std::map<peer_t, std::unique_ptr<Replayer> > *m_replayers;
+    Mutex *m_replayers_lock;
+    peer_t peer;
+
+    C_ShutdownReplayer(
+        std::map<peer_t, std::unique_ptr<Replayer> > *m_replayers,
+        Mutex *m_replayers_lock, peer_t peer)
+      : m_replayers(m_replayers), m_replayers_lock(m_replayers_lock),
+        peer(peer) {
+    }
+
+    virtual void finish(int r);
+  };
 };
 
 } // namespace mirror

--- a/src/tools/rbd_mirror/Mirror.h
+++ b/src/tools/rbd_mirror/Mirror.h
@@ -49,6 +49,7 @@ private:
 
   // monitor local cluster for config changes in peers
   std::unique_ptr<ClusterWatcher> m_local_cluster_watcher;
+  Mutex m_replayers_lock;
   std::map<peer_t, std::unique_ptr<Replayer> > m_replayers;
   atomic_t m_stopping;
 };

--- a/src/tools/rbd_mirror/Replayer.h
+++ b/src/tools/rbd_mirror/Replayer.h
@@ -35,7 +35,7 @@ public:
   Replayer(const Replayer&) = delete;
   Replayer& operator=(const Replayer&) = delete;
 
-  int init();
+  void init(Context *on_finish);
   void run();
   void shutdown();
 
@@ -68,6 +68,17 @@ private:
       return 0;
     }
   } m_replayer_thread;
+
+  struct C_InitReplayer : public Context {
+    Replayer *replayer;
+    Context *on_finish;
+
+    C_InitReplayer(Replayer *replayer, Context *on_finish) :
+      replayer(replayer), on_finish(on_finish) {
+    }
+
+    virtual void finish(int r);
+  };
 };
 
 } // namespace mirror


### PR DESCRIPTION
Implemented the TODOs left in Mirror.cc regarding the creation and destruction of Replayer objects in an asynchronous way.