### PR TITLE
vstart: use ip instead of ifconfig utility

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -390,7 +390,7 @@ if [ -n "$ip" ]; then
 else
     echo hostname $HOSTNAME
     # filter out IPv6 and localhost addresses
-    IP="$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -n1)"
+    IP="$(ip a | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -n1)"
     # if nothing left, try using localhost address, it might work
     if [ -z "$IP" ]; then IP="127.0.0.1"; fi
     echo ip $IP


### PR DESCRIPTION
Making vstart not use ifconfig which may not be supported in all
distributions

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>