### PR TITLE
rgw/rgw_common.h: fix the RGWBucketInfo decoding

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -935,9 +935,9 @@ struct RGWBucketInfo
        ::decode(flags, bl);
      if (struct_v >= 5)
        ::decode(zonegroup, bl);
-     uint64_t ct;
-     ::decode(ct, bl);
      if (struct_v >= 6 && struct_v < 17) {
+       uint64_t ct;
+       ::decode(ct, bl);
        creation_time = ceph::real_clock::from_time_t((time_t)ct);
      }
      if (struct_v >= 7)


### PR DESCRIPTION
```
        ../ceph-object-corpus/archive/0.61.4-60-g24c59be/objects/RGWBucketInfo
error: buffer::end_of_buffer
**** failed to decode ../ceph-object-corpus/archive/0.61.4-60-g24c59be/objects/RGWBucketInfo/25f5ff183bba6da708243a0bbbe40a2e ****
error: buffer::end_of_buffer
**** failed to decode ../ceph-object-corpus/archive/0.61.4-60-g24c59be/objects/RGWBucketInfo/54f53e3e301071f48247d59272b27b53 ****
```
see https://jenkins.ceph.com/job/ceph-pull-requests/3178/console

introduced by 416234b

Signed-off-by: Kefu Chai <kchai@redhat.com>