### PR TITLE
osd/ReplicatedPG: clear watches on change after applying repops

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -10032,8 +10032,6 @@ void ReplicatedPG::on_change(ObjectStore::Transaction *t)
   // requeues waiting_for_active
   scrub_clear_state();
 
-  context_registry_on_change();
-
   cancel_copy_ops(is_primary());
   cancel_flush_ops(is_primary());
   cancel_proxy_ops(is_primary());
@@ -10091,6 +10089,10 @@ void ReplicatedPG::on_change(ObjectStore::Transaction *t)
   // this will requeue ops we were working on but didn't finish, and
   // any dups
   apply_and_flush_repops(is_primary());
+
+  // do this *after* apply_and_flush_repops so that we catch any newly
+  // registered watches.
+  context_registry_on_change();
 
   pgbackend->on_change_cleanup(t);
   scrubber.cleanup_store(t);


### PR DESCRIPTION
apply_and_flush_repops does any in-flight request side-effects,
including setting up new watches.  Clear out watches after that
so we don't leave any behind.

Fixes: #15151
Signed-off-by: Sage Weil <sage@redhat.com>