### PR TITLE
rgw: rest and http client code to use param vectors

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1345,7 +1345,7 @@ static int send_to_url(const string& url, const string& access,
   key.id = access;
   key.key = secret;
 
-  list<pair<string, string> > params;
+  param_vec_t params;
   RGWRESTSimpleRequest req(g_ceph_context, url, NULL, &params);
 
   bufferlist response;

--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -12,7 +12,7 @@ class RGWReadRESTResourceCR : public RGWSimpleCoroutine {
   RGWRESTConn *conn;
   RGWHTTPManager *http_manager;
   string path;
-  param_list_t params;
+  param_vec_t params;
   T *result;
 
   boost::intrusive_ptr<RGWRESTReadResource> http_op;
@@ -64,7 +64,7 @@ class RGWPostRESTResourceCR : public RGWSimpleCoroutine {
   RGWRESTConn *conn;
   RGWHTTPManager *http_manager;
   string path;
-  param_list_t params;
+  param_vec_t params;
   T *result;
   S input;
 

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -49,11 +49,11 @@ static size_t send_http_data(void *ptr, size_t size, size_t nmemb, void *_info)
   return ret;
 }
 
-static curl_slist *headers_to_slist(list<pair<string, string> >& headers)
+static curl_slist *headers_to_slist(param_vec_t& headers)
 {
   curl_slist *h = NULL;
 
-  list<pair<string, string> >::iterator iter;
+  param_vec_t::iterator iter;
   for (iter = headers.begin(); iter != headers.end(); ++iter) {
     pair<string, string>& p = *iter;
     string val = p.first;

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -9,6 +9,9 @@
 #include "include/atomic.h"
 #include "rgw_common.h"
 
+using param_pair_t = pair<string, string>;
+using param_vec_t = vector<param_pair_t>;
+
 struct rgw_http_req_data;
 
 class RGWHTTPClient
@@ -32,7 +35,7 @@ class RGWHTTPClient
 protected:
   CephContext *cct;
 
-  list<pair<string, string> > headers;
+  param_vec_t headers;
   int init_request(const char *method, const char *url, rgw_http_req_data *req_data);
 public:
 

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -200,7 +200,7 @@ void RGWRESTSimpleRequest::get_params_str(map<string, string>& extra_args, strin
   for (miter = extra_args.begin(); miter != extra_args.end(); ++miter) {
     append_param(dest, miter->first, miter->second);
   }
-  list<pair<string, string> >::iterator iter;
+  param_vec_t::iterator iter;
   for (iter = params.begin(); iter != params.end(); ++iter) {
     append_param(dest, iter->first, iter->second);
   }
@@ -631,7 +631,7 @@ int RGWRESTStreamRWRequest::get_resource(RGWAccessKey& key, map<string, string>&
   get_params_str(args, params_str);
 
   /* merge params with extra args so that we can sign correctly */
-  for (list<pair<string, string> >::iterator iter = params.begin(); iter != params.end(); ++iter) {
+  for (param_vec_t::iterator iter = params.begin(); iter != params.end(); ++iter) {
     new_info.args.append(iter->first, iter->second);
   }
 

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -4,8 +4,6 @@
 #ifndef CEPH_RGW_REST_CLIENT_H
 #define CEPH_RGW_REST_CLIENT_H
 
-#include <list>
-
 #include "rgw_http_client.h"
 
 class RGWGetDataCB;
@@ -18,7 +16,7 @@ protected:
   string url;
 
   map<string, string> out_headers;
-  list<pair<string, string> > params;
+  param_vec_t params;
 
   bufferlist::iterator *send_iter;
 
@@ -31,20 +29,20 @@ protected:
 
   int sign_request(RGWAccessKey& key, RGWEnv& env, req_info& info);
 public:
-  RGWRESTSimpleRequest(CephContext *_cct, const string& _url, list<pair<string, string> > *_headers,
-                list<pair<string, string> > *_params) : RGWHTTPClient(_cct), http_status(0), status(0),
+  RGWRESTSimpleRequest(CephContext *_cct, const string& _url, param_vec_t *_headers,
+		param_vec_t *_params) : RGWHTTPClient(_cct), http_status(0), status(0),
                 url(_url), send_iter(NULL),
                 max_response(0) {
     set_headers(_headers);
     set_params(_params);
   }
 
-  void set_headers(list<pair<string, string> > *_headers) {
+  void set_headers(param_vec_t *_headers) {
     if (_headers)
       headers = *_headers;
   }
 
-  void set_params(list<pair<string, string> > *_params) {
+  void set_params(param_vec_t *_params) {
     if (_params)
       params = *_params;
   }
@@ -74,8 +72,8 @@ public:
   int add_output_data(bufferlist& bl);
   int send_data(void *ptr, size_t len);
 
-  RGWRESTStreamWriteRequest(CephContext *_cct, const string& _url, list<pair<string, string> > *_headers,
-                list<pair<string, string> > *_params) : RGWRESTSimpleRequest(_cct, _url, _headers, _params),
+  RGWRESTStreamWriteRequest(CephContext *_cct, const string& _url, param_vec_t *_headers,
+		param_vec_t *_params) : RGWRESTSimpleRequest(_cct, _url, _headers, _params),
                 lock("RGWRESTStreamWriteRequest"), cb(NULL), http_manager(_cct) {}
   ~RGWRESTStreamWriteRequest();
   int put_obj_init(RGWAccessKey& key, rgw_obj& obj, uint64_t obj_size, map<string, bufferlist>& attrs);
@@ -101,8 +99,7 @@ public:
   int receive_data(void *ptr, size_t len);
 
   RGWRESTStreamRWRequest(CephContext *_cct, const char *_method, const string& _url, RGWGetDataCB *_cb,
-	        list<pair<string, string> > *_headers,
-                list<pair<string, string> > *_params) : RGWRESTSimpleRequest(_cct, _url, _headers, _params),
+		param_vec_t *_headers, param_vec_t *_params) : RGWRESTSimpleRequest(_cct, _url, _headers, _params),
                 lock("RGWRESTStreamReadRequest"), cb(_cb),
                 chunk_ofs(0), ofs(0), http_manager(_cct), method(_method), write_ofs(0) {
   }
@@ -120,8 +117,8 @@ public:
 
 class RGWRESTStreamReadRequest : public RGWRESTStreamRWRequest {
 public:
-  RGWRESTStreamReadRequest(CephContext *_cct, const string& _url, RGWGetDataCB *_cb, list<pair<string, string> > *_headers,
-                list<pair<string, string> > *_params) : RGWRESTStreamRWRequest(_cct, "GET", _url, _cb, _headers, _params) {}
+  RGWRESTStreamReadRequest(CephContext *_cct, const string& _url, RGWGetDataCB *_cb, param_vec_t *_headers,
+		param_vec_t *_params) : RGWRESTStreamRWRequest(_cct, "GET", _url, _cb, _headers, _params) {}
 };
 
 #endif

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -51,7 +51,7 @@ int RGWRESTConn::forward(const rgw_user& uid, req_info& info, obj_version *objv,
   if (ret < 0)
     return ret;
   string uid_str = uid.to_str();
-  param_list_t params;
+  param_vec_t params;
   if (!uid.empty())
     params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "uid", uid_str));
   params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "zonegroup", self_zone_group));
@@ -80,7 +80,7 @@ int RGWRESTConn::put_obj_init(const rgw_user& uid, rgw_obj& obj, uint64_t obj_si
     return ret;
 
   string uid_str = uid.to_str();
-  param_list_t params;
+  param_vec_t params;
   params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "uid", uid_str));
   params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "zonegroup", self_zone_group));
   *req = new RGWRESTStreamWriteRequest(cct, url, NULL, &params);
@@ -125,7 +125,7 @@ int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, rgw
   if (ret < 0)
     return ret;
 
-  param_list_t params;
+  param_vec_t params;
   if (!uid.empty()) {
     params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "uid", uid.to_str()));
   }
@@ -175,7 +175,7 @@ int RGWRESTConn::complete_request(RGWRESTStreamReadRequest *req, string& etag, r
 }
 
 int RGWRESTConn::get_resource(const string& resource,
-		     param_list_t *extra_params,
+		     param_vec_t *extra_params,
 		     map<string, string> *extra_headers,
 		     bufferlist& bl,
 		     RGWHTTPManager *mgr)
@@ -185,7 +185,7 @@ int RGWRESTConn::get_resource(const string& resource,
   if (ret < 0)
     return ret;
 
-  param_list_t params;
+  param_vec_t params;
 
   if (extra_params) {
     params.insert(params.end(), extra_params->begin(), extra_params->end());
@@ -216,7 +216,7 @@ int RGWRESTConn::get_resource(const string& resource,
 RGWRESTReadResource::RGWRESTReadResource(RGWRESTConn *_conn,
                                          const string& _resource,
 		                         const rgw_http_param_pair *pp,
-                                         param_list_t *extra_headers,
+					 param_vec_t *extra_headers,
                                          RGWHTTPManager *_mgr)
   : cct(_conn->get_ctx()), conn(_conn), resource(_resource),
     params(make_param_list(pp)), cb(bl), mgr(_mgr),
@@ -227,8 +227,8 @@ RGWRESTReadResource::RGWRESTReadResource(RGWRESTConn *_conn,
 
 RGWRESTReadResource::RGWRESTReadResource(RGWRESTConn *_conn,
                                          const string& _resource,
-		                         param_list_t& _params,
-                                         param_list_t *extra_headers,
+					 param_vec_t& _params,
+					 param_vec_t *extra_headers,
                                          RGWHTTPManager *_mgr)
   : cct(_conn->get_ctx()), conn(_conn), resource(_resource), params(_params),
     cb(bl), mgr(_mgr), req(cct, conn->get_url(), &cb, NULL, NULL)
@@ -236,7 +236,7 @@ RGWRESTReadResource::RGWRESTReadResource(RGWRESTConn *_conn,
   init_common(extra_headers);
 }
 
-void RGWRESTReadResource::init_common(param_list_t *extra_headers)
+void RGWRESTReadResource::init_common(param_vec_t *extra_headers)
 {
   params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "zonegroup", conn->get_self_zonegroup()));
 
@@ -276,7 +276,7 @@ int RGWRESTReadResource::aio_read()
 RGWRESTPostResource::RGWRESTPostResource(RGWRESTConn *_conn,
                                          const string& _resource,
 		                         const rgw_http_param_pair *pp,
-                                         param_list_t *extra_headers,
+					 param_vec_t *extra_headers,
                                          RGWHTTPManager *_mgr)
   : cct(_conn->get_ctx()), conn(_conn), resource(_resource),
     params(make_param_list(pp)), cb(bl), mgr(_mgr),
@@ -287,8 +287,8 @@ RGWRESTPostResource::RGWRESTPostResource(RGWRESTConn *_conn,
 
 RGWRESTPostResource::RGWRESTPostResource(RGWRESTConn *_conn,
                                          const string& _resource,
-		                         param_list_t& params,
-                                         param_list_t *extra_headers,
+					 param_vec_t& params,
+					 param_vec_t *extra_headers,
                                          RGWHTTPManager *_mgr)
   : cct(_conn->get_ctx()), conn(_conn), resource(_resource), params(params),
     cb(bl), mgr(_mgr), req(cct, "POST", conn->get_url(), &cb, NULL, NULL)
@@ -296,7 +296,7 @@ RGWRESTPostResource::RGWRESTPostResource(RGWRESTConn *_conn,
   init_common(extra_headers);
 }
 
-void RGWRESTPostResource::init_common(param_list_t *extra_headers)
+void RGWRESTPostResource::init_common(param_vec_t *extra_headers)
 {
   params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "zonegroup", conn->get_self_zonegroup()));
 

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -36,14 +36,10 @@ struct rgw_http_param_pair {
   const char *val;
 };
 
-using param_pair_t = pair<string, string>;
-// TODO: consider vector instead of list
-using param_list_t = std::list<param_pair_t>;
-
 // copy a null-terminated rgw_http_param_pair list into a list of string pairs
-inline param_list_t make_param_list(const rgw_http_param_pair* pp)
+inline param_vec_t make_param_list(const rgw_http_param_pair* pp)
 {
-  param_list_t params;
+  param_vec_t params;
   while (pp && pp->key) {
     string k = pp->key;
     string v = (pp->val ? pp->val : "");
@@ -97,19 +93,19 @@ public:
   int complete_request(RGWRESTStreamReadRequest *req, string& etag, ceph::real_time *mtime, map<string, string>& attrs);
 
   int get_resource(const string& resource,
-                   param_list_t *extra_params,
+		   param_vec_t *extra_params,
                    map<string, string>* extra_headers,
                    bufferlist& bl, RGWHTTPManager *mgr = NULL);
 
   template <class T>
-  int get_json_resource(const string& resource, param_list_t *params, T& t);
+  int get_json_resource(const string& resource, param_vec_t *params, T& t);
   template <class T>
   int get_json_resource(const string& resource, const rgw_http_param_pair *pp, T& t);
 };
 
 
 template<class T>
-int RGWRESTConn::get_json_resource(const string& resource, param_list_t *params, T& t)
+int RGWRESTConn::get_json_resource(const string& resource, param_vec_t *params, T& t)
 {
   bufferlist bl;
   int ret = get_resource(resource, params, NULL, bl);
@@ -128,7 +124,7 @@ int RGWRESTConn::get_json_resource(const string& resource, param_list_t *params,
 template<class T>
 int RGWRESTConn::get_json_resource(const string& resource,  const rgw_http_param_pair *pp, T& t)
 {
-  param_list_t params = make_param_list(pp);
+  param_vec_t params = make_param_list(pp);
   return get_json_resource(resource, &params, t);
 }
 
@@ -146,7 +142,7 @@ class RGWRESTReadResource : public RefCountedObject {
   CephContext *cct;
   RGWRESTConn *conn;
   string resource;
-  param_list_t params;
+  param_vec_t params;
   map<string, string> headers;
   bufferlist bl;
   RGWStreamIntoBufferlist cb;
@@ -154,19 +150,19 @@ class RGWRESTReadResource : public RefCountedObject {
   RGWHTTPManager *mgr;
   RGWRESTStreamReadRequest req;
 
-  void init_common(param_list_t *extra_headers);
+  void init_common(param_vec_t *extra_headers);
 
 public:
   RGWRESTReadResource(RGWRESTConn *_conn,
 		      const string& _resource,
 		      const rgw_http_param_pair *pp,
-		      param_list_t *extra_headers,
+		      param_vec_t *extra_headers,
 		      RGWHTTPManager *_mgr);
 
   RGWRESTReadResource(RGWRESTConn *_conn,
 		      const string& _resource,
-		      param_list_t& _params,
-		      param_list_t *extra_headers,
+		      param_vec_t& _params,
+		      param_vec_t *extra_headers,
 		      RGWHTTPManager *_mgr);
 
   void set_user_info(void *user_info) {
@@ -262,7 +258,7 @@ class RGWRESTPostResource : public RefCountedObject {
   CephContext *cct;
   RGWRESTConn *conn;
   string resource;
-  param_list_t params;
+  param_vec_t params;
   map<string, string> headers;
   bufferlist bl;
   RGWStreamIntoBufferlist cb;
@@ -270,19 +266,19 @@ class RGWRESTPostResource : public RefCountedObject {
   RGWHTTPManager *mgr;
   RGWRESTStreamRWRequest req;
 
-  void init_common(param_list_t *extra_headers);
+  void init_common(param_vec_t *extra_headers);
 
 public:
   RGWRESTPostResource(RGWRESTConn *_conn,
 		      const string& _resource,
 		      const rgw_http_param_pair *pp,
-		      param_list_t *extra_headers,
+		      param_vec_t *extra_headers,
 		      RGWHTTPManager *_mgr);
 
   RGWRESTPostResource(RGWRESTConn *_conn,
 		      const string& _resource,
-		      param_list_t& params,
-		      param_list_t *extra_headers,
+		      param_vec_t& params,
+		      param_vec_t *extra_headers,
 		      RGWHTTPManager *_mgr);
 
   void set_user_info(void *user_info) {


### PR DESCRIPTION
Trying to knock down a //TODO item, in replacing the use of a list for a vector in some rgw REST parameter lists.

Since we're only inserting to the back of the parameter list, a vector should be a more efficient choice for a container structure.