### PR TITLE
buffer: fix iterator_impl visibility through typedef

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -57,10 +57,8 @@
 
 #if __GNUC__ >= 4
   #define CEPH_BUFFER_API  __attribute__ ((visibility ("default")))
-  #define CEPH_BUFFER_DETAILS __attribute__ ((visibility ("hidden")))
 #else
   #define CEPH_BUFFER_API
-  #define CEPH_BUFFER_DETAILS
 #endif
 
 #if defined(HAVE_XIO)
@@ -270,7 +268,7 @@ namespace buffer CEPH_BUFFER_API {
 
   private:
     template <bool is_const>
-    class CEPH_BUFFER_DETAILS iterator_impl
+    class CEPH_BUFFER_API iterator_impl
       : public std::iterator<std::forward_iterator_tag, char> {
     protected:
       typedef typename std::conditional<is_const,


### PR DESCRIPTION
The following program doesn't compile because of symbol visibility issues.
While bufferlist::iterator is a class implementation with visibility specified,
it is unclear after google-fu how to do the same through typedef.
```c++
int main()
{
 ceph::bufferlist bl;
 ceph::bufferlist::const_iterator it = bl.begin();
 (void)it;
 return 0;
}
```
[nwatkins@bender ~]$ g++ -Wall -std=c++11 -Iinstall/include -Linstall/lib -o test test.cc -lrados
/tmp/cciR9MUj.o: In function `main':
test.cc:(.text+0x43): undefined reference to `ceph::buffer::list::iterator_impl<true>::iterator_impl(ceph::buffer::list::iterator const&)'
/usr/bin/ld: test: hidden symbol `_ZN4ceph6buffer4list13iterator_implILb1EEC1ERKNS1_8iteratorE' isn't defined
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>