### PR TITLE
mon/MonClient: make authenticate timeout more reliable

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -461,7 +461,11 @@ int MonClient::authenticate(double timeout)
     ldout(cct, 10) << "authenticate will time out at " << until << dendl;
   while (state != MC_STATE_HAVE_SESSION && !authenticate_err) {
     if (timeout > 0.0) {
-      int r = auth_cond.WaitUntil(monc_lock, until);
+      utime_t now = ceph_clock_now(cct);
+      int r = ETIMEDOUT;
+      if (now < until) {
+	r = auth_cond.WaitUntil(monc_lock, until);
+      }
       if (r == ETIMEDOUT) {
 	ldout(cct, 0) << "authenticate timed out after " << timeout << dendl;
 	authenticate_err = -r;


### PR DESCRIPTION
The LibRadosMiscConnectFailure.ConnectFailure test occasionally
fails with a .000001 timeout.  I'm pretty sure it's because this
cond always manages a signal queued by the time it goes to wait,
or gets a signal before the deadline.

Fix by adding an outter check as well so that we'll error out
regardless of the queued signal vs timeout check order in the
cond.

This is my best theory as to what is going on, at least... I don't
see any other way we'd get a success with the timeout set.

Fixes: #13392
Signed-off-by: Sage Weil <sage@redhat.com>