### PR TITLE
global/signal_handler: print thread name in signal handler

### DIFF
--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -91,14 +91,18 @@ static void handle_fatal_signal(int signum)
   // case, SA_RESETHAND specifies that the default signal handler--
   // presumably dump core-- will handle it.
   char buf[1024];
+  char pthread_name[16] = {0}; //limited by 16B include terminating null byte.
+  int r = pthread_getname_np(pthread_self(), pthread_name, sizeof(pthread_name));
 #if defined(__sun)
   char message[SIG2STR_MAX];
   sig2str(signum,message);
   snprintf(buf, sizeof(buf), "*** Caught signal (%s) **\n "
-	    "in thread %llx\n", message, (unsigned long long)pthread_self());
+	    "in thread %llx thread_name:%s\n", message, (unsigned long long)pthread_self(),
+	    pthread_name);
 #else
   snprintf(buf, sizeof(buf), "*** Caught signal (%s) **\n "
-	    "in thread %llx\n", sig_str(signum), (unsigned long long)pthread_self());
+	    "in thread %llx thread_name:%s\n", sig_str(signum), (unsigned long long)pthread_self(),
+	    pthread_name);
 #endif
   dout_emergency(buf);
   pidfile_remove();


### PR DESCRIPTION
Now most thread has own thread name. So print thread name in signal
handle.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>