### PR TITLE
os/bluestore/BlueFS: Before reap ioct, it should wait io complete.

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1307,6 +1307,7 @@ void BlueFS::_close_writer(FileWriter *h)
 {
   dout(10) << __func__ << " " << h << dendl;
   for (unsigned i=0; i<bdev.size(); ++i) {
+    h->iocv[i]->aio_wait();
     bdev[i]->queue_reap_ioc(h->iocv[i]);
   }
   h->iocv.clear();


### PR DESCRIPTION
When change write mode of FileWrite(in _flush_range) from buffer to
direct. osd met segment fault.
This because call _close_writer don't check related ios whether
complete.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>