### PR TITLE
os/BlueStore: reduce unnecessary memory cost in 'aio_write'

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -757,9 +757,12 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     r->nref.inc();
     bdout << "ptr " << this << " get " << _raw << bendl;
   }
-  buffer::ptr::ptr(unsigned l) : _off(0), _len(l)
+  buffer::ptr::ptr(unsigned l, const bool page_aligned) : _off(0), _len(l)
   {
-    _raw = create(l);
+    if (page_aligned)
+      _raw = create_page_aligned(l);
+    else
+      _raw = create(l);
     _raw->nref.inc();
     bdout << "ptr " << this << " get " << _raw << bendl;
   }
@@ -1751,9 +1754,9 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     }
   }
   
-  void buffer::list::append_zero(unsigned len)
+  void buffer::list::append_zero(unsigned len, const bool page_aligned)
   {
-    ptr bp(len);
+    ptr bp(len, page_aligned);
     bp.zero();
     append(std::move(bp));
   }

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -170,7 +170,7 @@ namespace buffer CEPH_BUFFER_API {
     // cppcheck-suppress noExplicitConstructor
     ptr(raw *r);
     // cppcheck-suppress noExplicitConstructor
-    ptr(unsigned l);
+    ptr(unsigned l, const bool page_aligned = false);
     ptr(const char *d, unsigned l);
     ptr(const ptr& p);
     ptr(ptr&& p);
@@ -551,7 +551,7 @@ namespace buffer CEPH_BUFFER_API {
     void append(const ptr& bp, unsigned off, unsigned len);
     void append(const list& bl);
     void append(std::istream& in);
-    void append_zero(unsigned len);
+    void append_zero(unsigned len, const bool page_aligned = false);
     
     /*
      * get a char

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -44,8 +44,6 @@ KernelDevice::KernelDevice(aio_callback_t cb, void *cbpriv)
     aio_thread(this),
     injecting_crash(0)
 {
-  zeros = buffer::create_page_aligned(1048576);
-  zeros.zero();
 }
 
 int KernelDevice::_lock()
@@ -456,14 +454,7 @@ int KernelDevice::aio_zero(
   assert(off + len <= size);
 
   bufferlist bl;
-  while (len > 0) {
-    bufferlist t;
-    t.append(zeros, 0, MIN(zeros.length(), len));
-    len -= t.length();
-    bl.claim_append(t);
-  }
-  // note: this works with aio only becaues the actual buffer is
-  // this->zeros, which is page-aligned and never freed.
+  bl.append_zero(len, true);
   return aio_write(off, bl, ioc, false);
 }
 

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -29,7 +29,6 @@ class KernelDevice : public BlockDevice {
   string path;
   FS *fs;
   bool aio, dio;
-  bufferptr zeros;
 
   Mutex debug_lock;
   interval_set<uint64_t> debug_inflight;

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -829,10 +829,6 @@ int NVMEDevice::open(string p)
   driver->register_device(this);
   block_size = driver->get_block_size();
   size = driver->get_size();
-  if (!driver->zero_command_support) {
-    zeros = buffer::create_page_aligned(1048576);
-    zeros.zero();
-  }
 
   dout(1) << __func__ << " size " << size << " (" << pretty_si_t(size) << "B)"
           << " block_size " << block_size << " (" << pretty_si_t(block_size)
@@ -944,16 +940,8 @@ int NVMEDevice::aio_zero(
     ioc->nvme_task_last = t;
     ++ioc->num_pending;
   } else {
-    assert(zeros.length());
     bufferlist bl;
-    while (len > 0) {
-      bufferlist t;
-      t.append(zeros, 0, MIN(zeros.length(), len));
-      len -= t.length();
-      bl.claim_append(t);
-    }
-    // note: this works with aio only becaues the actual buffer is
-    // this->zeros, which is page-aligned and never freed.
+    bl.append_zero(len, true);
     return aio_write(off, bl, ioc, false);
   }
 

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -56,7 +56,6 @@ class NVMEDevice : public BlockDevice {
   uint64_t block_size;
 
   bool aio_stop;
-  bufferptr zeros;
 
   struct BufferedExtents {
     struct Extent {


### PR DESCRIPTION
preallocate memory for zero buffer, reducing memory cost repeatly constructing bufferlist object.

Signed-off-by: haodong tang <haodong.tang@intel.com>