### PR TITLE
rgw: add zone delete to rgw-admin help

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -108,6 +108,7 @@ void _usage()
   cout << "  zonegroup-map get          show zonegroup-map\n";
   cout << "  zonegroup-map set          set zonegroup-map (requires infile)\n";
   cout << "  zone create                create a new zone\n";
+  cout << "  zone delete                delete a zone\n";
   cout << "  zone get                   show zone cluster params\n";
   cout << "  zone modify                set/clear zone master status\n";
   cout << "  zone set                   set zone cluster params (requires infile)\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -60,6 +60,7 @@
     zonegroup-map get          show zonegroup-map
     zonegroup-map set          set zonegroup-map (requires infile)
     zone create                create a new zone
+    zone delete                delete a zone
     zone get                   show zone cluster params
     zone modify                set/clear zone master status
     zone set                   set zone cluster params (requires infile)


### PR DESCRIPTION
This operation is already implemented (OPT_ZONE_DELETE), however not
mentioned in the help, just adding to the help options

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>