### PR TITLE
rbd-mirror: fix long termination due to 30sec wait in Mirror::run loop

### DIFF
--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -40,6 +40,10 @@ Mirror::Mirror(CephContext *cct, const std::vector<const char*> &args) :
 void Mirror::handle_signal(int signum)
 {
   m_stopping.set(1);
+  {
+    Mutex::Locker l(m_lock);
+    m_cond.Signal();
+  }
 }
 
 int Mirror::init()


### PR DESCRIPTION

Signed-off-by: Mykola Golub <mgolub@mirantis.com>