### PR TITLE
systemd: Use the same restart limits as upstart

### DIFF
--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -16,6 +16,9 @@ ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
 TasksMax=infinity
+Restart=on-failure
+StartLimitInterval=30min
+StartLimitBurst=3
 
 [Install]
 WantedBy=ceph-mds.target

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -22,6 +22,9 @@ ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
 TasksMax=infinity
+Restart=on-failure
+StartLimitInterval=30min
+StartLimitBurst=3
 
 [Install]
 WantedBy=ceph-mon.target

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -16,6 +16,9 @@ ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
 TasksMax=infinity
+Restart=on-failure
+StartLimitInterval=30min
+StartLimitBurst=3
 
 [Install]
 WantedBy=ceph-osd.target

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -15,6 +15,9 @@ ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
 TasksMax=infinity
+Restart=on-failure
+StartLimitInterval=30s
+StartLimitBurst=5
 
 [Install]
 WantedBy=ceph-radosgw.target


### PR DESCRIPTION
Currently, the systemd daemons are not restarted on failure. This patch
adds this functionality and sets the defaults to those defined in
upstart. This resolves to 3 fails per 30 minutes for osd, mon and mds
and 5 fails per 30 seconds for radosgw.

Signed-off-by: Boris Ranto <branto@redhat.com>