### PR TITLE
librados examples: link and include from current source tree by default.

### DIFF
--- a/examples/librados/Makefile
+++ b/examples/librados/Makefile
@@ -1,15 +1,35 @@
-CXXFLAGS=-std=c++0x -I../../src/include
-CFLAGS=-I../../src/include
-all: librados_hello_world librados_hello_world_c
 
-librados_hello_world: hello_world.cc
-	g++ -g -c hello_world.cc -o hello_world.o $(CXXFLAGS)
-	g++ -g hello_world.o -lrados -o librados_hello_world $(LDFLAGS)
+CXX?=g++
+CXX_FLAGS?=-std=c++11 -Wall -Wextra -Werror -g
+CXX_LIBS?=-lboost_system -lrados
+CXX_INC?=$(LOCAL_LIBRADOS_INC)
+CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS) $(CXX_LIBS)
 
-librados_hello_world_c: hello_world_c.c
-	cc -g -c hello_world_c.c -o hello_world_c.o $(CFLAGS)
-	cc -g hello_world_c.o -lrados -o librados_hello_world_c $(LDFLAGS)
+CC?=gcc
+CC_FLAGS=-Wall -Wextra -Werror -g
+CC_INC=$(LOCAL_LIBRADOS_INC)
+CC_LIBS?=-lrados
+CC_CC=$(CC) $(CC_FLAGS) $(CC_INC) $(LOCAL_LIBRADOS) $(CC_LIBS)
+
+# Relative path to the Ceph source:
+CEPH_SRC_HOME?=../../src
+
+LOCAL_LIBRADOS?=-L$(CEPH_SRC_HOME)/.libs/ -Wl,-rpath,$(CEPH_SRC_HOME)/.libs
+LOCAL_LIBRADOS_INC?=-I$(CEPH_SRC_HOME)/include
+
+all: hello_world_cpp hello_world_c
+
+# Build against the system librados instead of the one in the build tree:
+all-system: LOCAL_LIBRADOS=
+all-system: LOCAL_LIBRADOS_INC=
+all-system: all
+
+hello_world_cpp: hello_world.cc
+	$(CXX_CC) -o hello_world_cpp hello_world.cc
+
+hello_world_c: hello_world_c.c
+	$(CC_CC) -o hello_world_c hello_world_c.c
 
 clean:
-	rm hello_world.o librados_hello_world
-	rm hello_world_c.o librados_hello_world_c
+	rm -f hello_world_cpp hello_world_c
+

--- a/examples/librados/hello_world.readme
+++ b/examples/librados/hello_world.readme
@@ -1,6 +1,10 @@
 This simple librados program can be built by running "make" (and cleaned up
 with "make clean"), assuming you have librados-dev already installed.
 
+By default, the makefile will build against the librados headers and library in your
+build tree (ie. using relative paths). If you would like to build the examples against
+your system librados and headers, use "make all-system".
+
 And executed using
 ./librados_hello_world -c ../../src/ceph.conf
 (or whatever path to a ceph.conf is appropriate to you, or


### PR DESCRIPTION
Fixes #15100. The Makefile now by default links and includes from the
current source tree's librados and offers another option for building
examples against the system's.

Signed-off-by: Jesse Williamson <nerd.cpp@gmail.com>