### PR TITLE
qa/workunits/rest/test.py: don't use newfs

### DIFF
--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -166,8 +166,9 @@ if __name__ == '__main__':
     r = expect('mds/dump.xml', 'GET', 200, 'xml')
     assert(r.tree.find('output/mdsmap/created') is not None)
 
-    expect('mds/newfs?metadata=0&data=1&sure=--yes-i-really-mean-it', 'PUT',
-           200, '')
+    expect('osd/pool/create?pg_num=1&pool=fsmetadata', 'PUT', 200, '')
+    expect('osd/pool/create?pg_num=1&pool=fsdata', 'PUT', 200, '')
+    expect('fs/new?fs_name=default&metadata=fsmetadata&data=fsdata', 'PUT', 200, '')
     expect('osd/pool/create?pool=data2&pg_num=10', 'PUT', 200, '')
     r = expect('osd/dump', 'GET', 200, 'json', JSONHDR)
     pools = r.myjson['output']['pools']


### PR DESCRIPTION
It doesn't work anymore.

Signed-off-by: Sage Weil <sage@redhat.com>