### PR TITLE
rgw:response information is error when geting token of swift account

### DIFF
--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -145,6 +145,8 @@ void RGW_SWIFT_Auth_Get::execute()
   const char *key = s->info.env->get("HTTP_X_AUTH_KEY");
   const char *user = s->info.env->get("HTTP_X_AUTH_USER");
 
+  s->prot_flags |= RGW_REST_SWIFT;
+
   string user_str;
   RGWUserInfo info;
   bufferlist bl;


### PR DESCRIPTION
The header is X-Trans-Id instead of x-amz-request-id in the response header

Fixes:#15195
Signed-off-by: Qiankun Zheng <zheng.qiankun@h3c.com>