### PR TITLE
osd: drop unnecessary transaction cleanup

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2008,12 +2008,7 @@ void PG::_activate_committed(epoch_t epoch, epoch_t activation_epoch)
     }
   }
 
-  if (dirty_info) {
-    ObjectStore::Transaction t;
-    write_if_dirty(t);
-    int tr = osd->store->queue_transaction(osr.get(), std::move(t), NULL);
-    assert(tr == 0);
-  }
+  assert(!dirty_info);
 
   unlock();
 }


### PR DESCRIPTION
The lock() method will ensure 'dirty_info' will be false,
and within this function's scope I see no possibility to
set 'dirty_info' true. Thus I guess the transaction cleanup
logic before exit is never reachable and therefore shall be
considered as redundant and can be safely removed.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>