### PR TITLE
rgw/rgw_admin:fix bug about list and stats command

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4068,6 +4068,10 @@ int RGWRados::list_buckets_next(RGWObjEnt& obj, RGWAccessHandle *handle)
     }
 
     obj.key.set((*state)->get_oid());
+    if (obj.key.name[0] == '_') {
+      obj.key.name = obj.key.name.substr(1);
+    }
+
     (*state)++;
   } while (obj.key.name[0] == '.'); /* skip all entries starting with '.' */
 


### PR DESCRIPTION
The results of bucket-list and bucket-stats are incorrect when the first character of bucket name is underline

Fixes:#15197
Signed-off-by: Qiankun Zheng <zheng.qiankun@h3c.com>