### PR TITLE
rbd-mirror: don't link dynamically with librados

### DIFF
--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -507,8 +507,8 @@ ceph_test_rbd_mirror_image_replay_LDADD = \
 	librbd_api.la \
 	$(LIBRBD_TYPES) \
 	libjournal.la \
-	$(LIBRADOS) $(LIBOSDC) \
-	librados_internal.la \
+	librados_api.la \
+	$(LIBRADOS_DEPS) \
 	libcls_rbd_client.la \
 	libcls_lock_client.la \
 	libcls_journal_client.la \

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -131,8 +131,8 @@ rbd_mirror_LDADD = \
 	librbd_api.la \
 	$(LIBRBD_TYPES) \
 	libjournal.la \
-	$(LIBRADOS) $(LIBOSDC) \
-	librados_internal.la \
+	librados_api.la \
+	$(LIBRADOS_DEPS) \
 	libcls_rbd_client.la \
 	libcls_lock_client.la \
 	libcls_journal_client.la \


### PR DESCRIPTION
It fixes the issue with multiple instances of lockdep static
variables, which led to lockdep assert violations due to locks
registered in one variables and unregistered in another.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>