### PR TITLE
bluestore/KernelDevice.cc: fix inject crash rate

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -185,7 +185,8 @@ int KernelDevice::flush()
   }
   dout(10) << __func__ << " start" << dendl;
   io_since_flush.set(0);
-  if (g_conf->bdev_inject_crash) {
+  if (g_conf->bdev_inject_crash &&
+      rand() % g_conf->bdev_inject_crash == 0) {
     ++injecting_crash;
     // sleep for a moment to give other threads a chance to submit or
     // wait on io that races with a flush.
@@ -267,7 +268,8 @@ void KernelDevice::_aio_thread()
       }
     }
     reap_ioc();
-    if (g_conf->bdev_inject_crash) {
+    if (g_conf->bdev_inject_crash &&
+        rand() % g_conf->bdev_inject_crash == 0) {
       ++inject_crash_count;
       if (inject_crash_count * g_conf->bdev_aio_poll_ms / 1000 >
 	  g_conf->bdev_inject_crash + g_conf->bdev_inject_crash_flush_delay) {


### PR DESCRIPTION
’bdev_inject_crash‘ means 1/N IOs will complete before we crash(definition in common/config_opts.h), so we should keep the same inject crash rate. It will be helpful for debug.
Signed-off-by: haodong tang haodong.tang@intel.com