### PR TITLE
mon: mark_down_pgs in lockstep with pg_map's osdmap epoch

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1285,7 +1285,7 @@ epoch_t PGMonitor::send_pg_creates(int osd, Connection *con, epoch_t next)
 }
 
 void PGMonitor::_try_mark_pg_stale(
-  OSDMap *osdmap,
+  const OSDMap *osdmap,
   pg_t pgid,
   const pg_stat_t& cur_stat)
 {

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -125,18 +125,6 @@ void PGMonitor::tick()
 
   handle_osd_timeouts();
 
-  if (mon->is_leader()) {
-    bool propose = false;
-
-    if ((need_check_down_pgs || !need_check_down_pg_osds.empty()) &&
-        check_down_pgs())
-      propose = true;
-
-    if (propose) {
-      propose_pending();
-    }
-  }
-
   if (!pg_map.pg_sum_deltas.empty()) {
     utime_t age = ceph_clock_now(g_ceph_context) - pg_map.stamp;
     if (age > 2 * g_conf->mon_delta_reset_interval) {

--- a/src/mon/PGMonitor.h
+++ b/src/mon/PGMonitor.h
@@ -141,7 +141,8 @@ private:
    * @return true if we updated pending_inc (and should propose)
    */
   bool check_down_pgs();
-  void _try_mark_pg_stale(OSDMap *osdmap, pg_t pgid, const pg_stat_t& cur_stat);
+  void _try_mark_pg_stale(const OSDMap *osdmap, pg_t pgid,
+			  const pg_stat_t& cur_stat);
 
 
   /**

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6907,6 +6907,12 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 	       osd_markdown_log.front() + grace < now)
 	  osd_markdown_log.pop_front();
 	if ((int)osd_markdown_log.size() > g_conf->osd_max_markdown_count) {
+	  dout(10) << __func__ << " marked down "
+		   << osd_markdown_log.size()
+		   << " > osd_max_markdown_count "
+		   << g_conf->osd_max_markdown_count
+		   << " in last " << grace << " seconds, shutting down"
+		   << dendl;
 	  do_restart = false;
 	  do_shutdown = true;
 	}


### PR DESCRIPTION
This fixes the stale PGs we've been seeing.  And probably
several corner cases that are hard to see.