### PR TITLE
ceph_test_rados_misc: shorten mount timeout

### DIFF
--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -59,7 +59,7 @@ TEST(LibRadosMiscConnectFailure, ConnectFailure) {
   ASSERT_EQ(0, rados_conf_read_file(cluster, NULL));
   ASSERT_EQ(0, rados_conf_parse_env(cluster, NULL));
 
-  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "0.000001"));
+  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "0.000000001"));
 
   ASSERT_EQ(-ENOTCONN, rados_monitor_log(cluster, "error",
                                          test_rados_log_cb, NULL));


### PR DESCRIPTION
This might fix #13992.

Signed-off-by: Sage Weil <sage@redhat.com>