### PR TITLE
os/kstore: we have flush_txns is to make sure read after write for th…

### DIFF
--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -2204,7 +2204,7 @@ void KStore::_txc_state_proc(TransContext *txc)
     case TransContext::STATE_KV_DONE:
       txc->log_state_latency(logger, l_kstore_state_kv_done_lat);
       txc->state = TransContext::STATE_FINISHING;
-      break;
+      // ** fall-thru **
 
     case TransContext::TransContext::STATE_FINISHING:
       txc->log_state_latency(logger, l_kstore_state_finishing_lat);


### PR DESCRIPTION
…e same object. That's the reason why we add _txc_finalize(osr,txc) after we add the

transaction. However, since we did not call STATE_FINISHING at all, The _txf_finish will never be called and flush_txns of object will never be removed.
It will make the read on the same object hanging there forever. We will combine KV_DONE and STATE_FINISHING.

Signed-off-by: James Liu <james.liu@ssi.samsung.com>