### PR TITLE
journal: prevent race injecting new records into overflowed object

### DIFF
--- a/src/journal/ObjectRecorder.cc
+++ b/src/journal/ObjectRecorder.cc
@@ -47,6 +47,12 @@ bool ObjectRecorder::append(const AppendBuffers &append_buffers) {
   bool schedule_append = false;
   {
     Mutex::Locker locker(m_lock);
+    if (m_overflowed) {
+      m_append_buffers.insert(m_append_buffers.end(),
+                              append_buffers.begin(), append_buffers.end());
+      return false;
+    }
+
     for (AppendBuffers::const_iterator iter = append_buffers.begin();
          iter != append_buffers.end(); ++iter) {
       if (append(*iter, &schedule_append)) {


### PR DESCRIPTION
The recorded added after the overflow will not have been detached
from the object recorder.

Fixes: #15202

Signed-off-by: Jason Dillaman <dillaman@redhat.com>