### PR TITLE
packaging: align radosgw package description

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -361,9 +361,10 @@ Requires:	python-flask
 Requires:      python-Flask
 %endif
 %description radosgw
-This package is an S3 HTTP REST gateway for the RADOS object store. It
-is implemented as a FastCGI module using libfcgi, and can be used in
-conjunction with any FastCGI capable web server.
+RADOS is a distributed object store used by the Ceph distributed
+storage system.  This package provides a REST gateway to the
+object store that aims to implement a superset of Amazon's S3
+service as well as the OpenStack Object Storage ("Swift") API.
 
 %if %{with ocf}
 %package resource-agents

--- a/debian/control
+++ b/debian/control
@@ -604,7 +604,7 @@ Description: REST gateway for RADOS distributed object store
  RADOS is a distributed object store used by the Ceph distributed
  storage system.  This package provides a REST gateway to the
  object store that aims to implement a superset of Amazon's S3
- service.
+ service as well as the OpenStack Object Storage ("Swift") API.
  .
  This package contains the proxy daemon and related tools only.
 
@@ -617,7 +617,7 @@ Description: debugging symbols for radosgw
  RADOS is a distributed object store used by the Ceph distributed
  storage system.  This package provides a REST gateway to the
  object store that aims to implement a superset of Amazon's S3
- service.
+ service as well as the OpenStack Object Storage ("Swift") API.
  .
  This package contains debugging symbols for radosgw.
 


### PR DESCRIPTION
First, make the Debian package description mention that RGW aims to
implement the Swift API.

Second, replace the RPM package description with the Debian one, both for
consistency and because the Debian one is better.

Signed-off-by: Nathan Cutler <ncutler@suse.com>