### PR TITLE
systemd: drop --set{user,group} options from ceph-osd-prestart.sh call

### DIFF
--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -10,7 +10,7 @@ LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
 ExecReload=/bin/kill -HUP $MAINPID
 ProtectHome=true
 ProtectSystem=full


### PR DESCRIPTION
The --setuser and --setgroup options were added to the
ceph-osd-prestart.sh call in 7c9fdf44f2c18659a0bcc03f7b98dafdf9f54448
but that script does not support these options.

I peeked at how ceph-osd-prestart.sh is being called in
upstart/ceph-osd.conf and these options are not being provided there.
I don't think they are necessary, but if they are they would need to be
implemented in the script somehow.

http://tracker.ceph.com/issues/13955 Fixes: #13955

Signed-off-by: Nathan Cutler <ncutler@suse.com>