### PR TITLE
xio: xio_init needs to be called before any other xio function

### DIFF
--- a/src/msg/xio/XioMessenger.h
+++ b/src/msg/xio/XioMessenger.h
@@ -28,7 +28,17 @@ extern "C" {
 #include "common/Mutex.h"
 #include "include/Spinlock.h"
 
-class XioMessenger : public SimplePolicyMessenger
+class XioInit {
+  /* safe to be called multiple times */
+  void package_init(CephContext *cct);
+
+protected:
+  XioInit(CephContext *cct) {
+    this->package_init(cct);
+  }
+};
+
+class XioMessenger : public SimplePolicyMessenger, XioInit
 {
 private:
   static atomic_t nInstances;


### PR DESCRIPTION
Latest accelio code removes the attribute to call xio_init on load
and XioMessenger will first try to initialize portals and create xio context.
This commit will fix this behavior and call xio_init first.

Signed-off-by: Roi Dayan <roid@mellanox.com>