### PR TITLE
os/bluestore: minor cleanup in BlueStore::_do_allocate

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5049,10 +5049,9 @@ int BlueStore::_do_allocate(
     if (length >= head)
       length -= head;
   }
-  if ((offset + length) % min_alloc_size) {
-    tail = (offset + length) % min_alloc_size;
-    if (length >= tail)
-      length -= tail;
+  if (length % min_alloc_size) {
+    tail = length % min_alloc_size;
+    length -= tail;
   }
 
   map<uint64_t, bluestore_extent_t>::iterator bp;


### PR DESCRIPTION
(offset % min_alloc_size) identically equals to zero in this case.

Signed-off-by: Mingxin Liu <mingxin@xsky.com>