### PR TITLE
vstart: support independent configuration and startup of rgw instances

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -377,7 +377,11 @@ $SUDO rm -f core*
 
 test -d $CEPH_OUT_DIR || mkdir $CEPH_OUT_DIR
 test -d $CEPH_DEV_DIR || mkdir $CEPH_DEV_DIR
-$SUDO rm -rf $CEPH_OUT_DIR/*
+
+# Only clear out pidfiles/heartbeats/logs/etc on a $new run.
+if [ "$new" -eq 1 ]; then
+    $SUDO rm -rf $CEPH_OUT_DIR/*
+fi
 test -d gmon && $SUDO rm -rf gmon/*
 
 [ "$cephx" -eq 1 ] && [ "$new" -eq 1 ] && test -e $keyring_fn && rm $keyring_fn

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -141,6 +141,7 @@ usage=$usage"\t-o config\t\t add extra config parameters to all sections\n"
 usage=$usage"\t--mon_num specify ceph monitor count\n"
 usage=$usage"\t--osd_num specify ceph osd count\n"
 usage=$usage"\t--mds_num specify ceph mds count\n"
+usage=$usage"\t--rgw_num specify ceph rgw count\n"
 usage=$usage"\t--rgw_port specify ceph rgw http listen port\n"
 usage=$usage"\t--bluestore use bluestore as the osd objectstore backend\n"
 usage=$usage"\t--memstore use memstore as the osd objectstore backend\n"
@@ -213,6 +214,10 @@ case $1 in
             ;;
     --mds_num )
             CEPH_NUM_MDS=$2
+            shift
+            ;;
+    --rgw_num )
+            CEPH_NUM_RGW=$2
             shift
             ;;
     --rgw_port )

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -732,28 +732,40 @@ do_rgw()
     # Create S3 user
     local akey='0555b35654ad1656d804'
     local skey='h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=='
-    echo "setting up user testid"
-    $CEPH_BIN/radosgw-admin user create --uid testid --access-key $akey --secret $skey --display-name 'M. Tester' --email tester@ceph.com -c $conf_fn > /dev/null
+    if [ "$new" -eq 1 ]; then
+        echo "setting up user testid"
+        $CEPH_BIN/radosgw-admin user create --uid testid --access-key $akey --secret $skey --display-name 'M. Tester' --email tester@ceph.com -c $conf_fn > /dev/null
+    else
+        echo "re-using user testid"
+    fi
 
     # Create S3-test users
     # See: https://github.com/ceph/s3-tests
-    echo "setting up s3-test users"
-    $CEPH_BIN/radosgw-admin user create \
-        --uid 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
-        --access-key ABCDEFGHIJKLMNOPQRST \
-        --secret abcdefghijklmnopqrstuvwxyzabcdefghijklmn \
-        --display-name youruseridhere \
-        --email s3@example.com -c $conf_fn > /dev/null
-    $CEPH_BIN/radosgw-admin user create \
-        --uid 56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234 \
-        --access-key NOPQRSTUVWXYZABCDEFG \
-        --secret nopqrstuvwxyzabcdefghijklmnabcdefghijklm \
-        --display-name john.doe \
-        --email john.doe@example.com -c $conf_fn > /dev/null
+    if [ "$new" -eq 1 ]; then
+        echo "setting up s3-test users"
+        $CEPH_BIN/radosgw-admin user create \
+            --uid 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+            --access-key ABCDEFGHIJKLMNOPQRST \
+            --secret abcdefghijklmnopqrstuvwxyzabcdefghijklmn \
+            --display-name youruseridhere \
+            --email s3@example.com -c $conf_fn > /dev/null
+        $CEPH_BIN/radosgw-admin user create \
+            --uid 56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234 \
+            --access-key NOPQRSTUVWXYZABCDEFG \
+            --secret nopqrstuvwxyzabcdefghijklmnabcdefghijklm \
+            --display-name john.doe \
+            --email john.doe@example.com -c $conf_fn > /dev/null
+    else
+        echo "re-using s3-test users"
+    fi
 
     # Create Swift user
-    echo "setting up user tester"
-    $CEPH_BIN/radosgw-admin user create -c $conf_fn --subuser=test:tester --display-name=Tester-Subuser --key-type=swift --secret=testing --access=full > /dev/null
+    if [ "$new" -eq 1 ]; then
+        echo "setting up user tester"
+        $CEPH_BIN/radosgw-admin user create -c $conf_fn --subuser=test:tester --display-name=Tester-Subuser --key-type=swift --secret=testing --access=full > /dev/null
+    else
+        echo "re-using user tester"
+    fi
 
     echo ""
     echo "S3 User Info:"


### PR DESCRIPTION
RGW was a bit neglected in some of our scripting. Trying to remedy this.

This PR:
1. Allows restarting rgw independently of the cluster.
2. Tries to provide better support for multiple rgw instances (same
   cluster, or multi-cluster via mstart.sh) by providing independent config
   sections, etc.
3. Allows setting base port number on which to listen (instances will
   increment base port by instance number).
4. Changing base port number when re-starting overrides rgw_frontends
   allowing new instance to run on changed port.
5. Generates proper pid/log/asok/etc files in out/client.rgw.\* (needed to properly stop rgw instances via mstop.sh)

Fixes: http://tracker.ceph.com/issues/15226
