### PR TITLE
read cluster_name.conf for multi-cluster

### DIFF
--- a/systemd/ceph-create-keys@.service
+++ b/systemd/ceph-create-keys@.service
@@ -7,4 +7,4 @@ ConditionPathExists=!/var/lib/ceph/bootstrap-mds/ceph.keyring
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-ExecStart=/usr/sbin/ceph-create-keys --cluster ${CLUSTER} --id %i
+ExecStart=/usr/sbin/ceph-create-keys --cluster ${CLUSTER} -c ${CLUSTER}.conf --id %i

--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -9,7 +9,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} -c ${CLUSTER}.conf --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 PrivateDevices=yes
 ProtectHome=true

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -15,7 +15,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} -c ${CLUSTER}.conf --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 PrivateDevices=yes
 ProtectHome=true

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -9,7 +9,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} -c ${CLUSTER}.conf --id %i --setuser ceph --setgroup ceph
 ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 ProtectHome=true

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -9,7 +9,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} -c ${CLUSTER}.conf --name client.%i --setuser ceph --setgroup ceph
 PrivateDevices=yes
 ProtectHome=true
 ProtectSystem=full


### PR DESCRIPTION
Right now, the unit service  will find the ceph.conf by default.
So add -c to read cluster_name.conf.