### PR TITLE
rgw: typo fix for zone delete message

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3261,7 +3261,7 @@ int main(int argc, char **argv)
 
 	ret = zone.delete_obj();
 	if (ret < 0) {
-	  cerr << "failed to create zone " << zone_name << ": " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to delete zone " << zone_name << ": " << cpp_strerror(-ret) << std::endl;
 	  return ret;
 	}
       }


### PR DESCRIPTION
Though this error message is hard to reach, it is still wrongly printed
as failed to create instead of failed to delete.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>