### PR TITLE
rgw: fix error message for zone delete

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -323,7 +323,7 @@ int RGWZoneGroup::remove_zone(const RGWZoneParams& zone_params)
   map<string, RGWZone>::iterator iter = zones.find(zone_params.get_id());
 
   if (iter == zones.end()) {
-    ldout(cct, 0) << "zone " << zone_params.get_name() << " " << zone_params.get_id() << " doesn't exists "<< dendl;
+    ldout(cct, 0) << "zone " << zone_params.get_name() << " " << zone_params.get_id() << "is not a part of zonegroup "<< name << dendl;
     return -ENOENT;
   }
 


### PR DESCRIPTION
Currently if a zone is not a part of a zonegroup, an error message
is printed that zone doesn't exist, and the zone gets deleted anyway.
Since this is exhibited only if the zone isn't a part of a zonegroup
and we allow creation of such zones, clarify that the zone wasn't a
part of zonegroup instead

Fixes: #14951
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>

EDIT: added fixes http://tracker.eph.com/issues/14951 