### PR TITLE
rgw: multisite tests don't change working directory

### DIFF
--- a/src/mrgw.sh
+++ b/src/mrgw.sh
@@ -11,7 +11,7 @@ port=$2
 
 shift 2
 
-run_root=$script_root/run/$name
+run_root=run/$name
 pidfile=$run_root/out/radosgw.${port}.pid
 asokfile=$run_root/out/radosgw.${port}.asok
 logfile=$run_root/out/radosgw.${port}.log

--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -54,7 +54,7 @@ x() {
 
 
 script_dir=`dirname $0`
-root_path=`(cd $script_dir/../..; pwd)`
+root_path=$script_dir/../..
 
 mstart=$root_path/mstart.sh
 mstop=$root_path/mstop.sh


### PR DESCRIPTION
this allows the multisite tests (src/test/rgw/test_multi.py) to be invoked from the cmake build directory, and use pwd to find the `run` directory used by mstart.sh and friends