### PR TITLE
python: avoid long paths

### DIFF
--- a/src/ceph-detect-init/Makefile.am
+++ b/src/ceph-detect-init/Makefile.am
@@ -55,11 +55,13 @@ EXTRA_DIST += \
 
 ceph-detect-init-all: ceph-detect-init/virtualenv
 
+CEPH_DETECT_INIT_VIRTUALENV := .
+
 ceph-detect-init/virtualenv:
-	cd $(srcdir)/ceph-detect-init ; ../tools/setup-virtualenv.sh ; test -d wheelhouse && export NO_INDEX=--no-index ; virtualenv/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
+	cd $(srcdir)/ceph-detect-init ; ../tools/setup-virtualenv.sh ${CEPH_DETECT_INIT_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DETECT_INIT_VIRTUALENV}/virtualenv/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
 
 ceph-detect-init-clean:
-	cd $(srcdir)/ceph-detect-init ; python setup.py clean ; rm -fr wheelhouse .tox build virtualenv .coverage *.egg-info
+	cd $(srcdir)/ceph-detect-init ; python setup.py clean ; rm -fr wheelhouse .tox build ${CEPH_DETECT_INIT_VIRTUALENV}/virtualenv .coverage *.egg-info
 
 ceph-detect-init-install-data:
 	cd $(srcdir)/ceph-detect-init ; \

--- a/src/ceph-disk/Makefile.am
+++ b/src/ceph-disk/Makefile.am
@@ -31,11 +31,13 @@ EXTRA_DIST += \
 
 ceph-disk-all: ceph-disk/virtualenv
 
+CEPH_DISK_VIRTUALENV := .
+
 ceph-disk/virtualenv:
-	cd $(srcdir)/ceph-disk ; ../tools/setup-virtualenv.sh ; test -d wheelhouse && export NO_INDEX=--no-index ; virtualenv/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
+	cd $(srcdir)/ceph-disk ; ../tools/setup-virtualenv.sh ${CEPH_DISK_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DISK_VIRTUALENV}/virtualenv/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
 
 ceph-disk-clean:
-	cd $(srcdir)/ceph-disk ; python setup.py clean ; rm -fr wheelhouse .tox build virtualenv .coverage *.egg-info
+	cd $(srcdir)/ceph-disk ; python setup.py clean ; rm -fr wheelhouse .tox build ${CEPH_DISK_VIRTUALENV}/virtualenv .coverage *.egg-info
 
 ceph-disk-install-data:
 	cd $(srcdir)/ceph-disk ; \

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -15,17 +15,19 @@
 # GNU Library Public License for more details.
 #
 
-rm -fr virtualenv
-virtualenv virtualenv
-. virtualenv/bin/activate
+DIR=$1
+mkdir -p $DIR
+rm -fr $DIR/virtualenv
+virtualenv $DIR/virtualenv
+. $DIR/virtualenv/bin/activate
 # older versions of pip will not install wrap_console scripts
 # when using wheel packages
-pip --log virtualenv/log.txt install --upgrade 'pip >= 6.1'
+pip --log $DIR/virtualenv/log.txt install --upgrade 'pip >= 6.1'
 if test -d wheelhouse ; then
     export NO_INDEX=--no-index
 fi
-pip --log virtualenv/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse --upgrade distribute
-pip --log virtualenv/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9' 
+pip --log $DIR/virtualenv/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse --upgrade distribute
+pip --log $DIR/virtualenv/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9' 
 if test -f requirements.txt ; then
-    pip --log virtualenv/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse -r requirements.txt
+    pip --log $DIR/virtualenv/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse -r requirements.txt
 fi


### PR DESCRIPTION
As a temporary measure because it overflows when jenkins tries to build
in a deep path. Run make with:

make CEPH_DETECT_INIT_VIRTUALENV=/tmp/ceph-detect-init \
     CEPH_DISK_VIRTUALENV=/tmp/ceph-disk

and it will use these directories instead of the default.

Signed-off-by: Loic Dachary <loic@dachary.org>