### PR TITLE
python: avoid long paths

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -299,3 +299,5 @@ DENCODER_DEPS =
 
 
 radoslibdir = $(libdir)/rados-classes
+
+CEPH_BUILD_VIRTUALENV = .

--- a/src/ceph-detect-init/Makefile.am
+++ b/src/ceph-detect-init/Makefile.am
@@ -53,13 +53,15 @@ EXTRA_DIST += \
 	ceph-detect-init/tests/test_all.py \
 	ceph-detect-init/tox.ini
 
-ceph-detect-init-all: ceph-detect-init/virtualenv
+export CEPH_DETECT_INIT_VIRTUALENV = ${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-virtualenv
 
-ceph-detect-init/virtualenv:
-	cd $(srcdir)/ceph-detect-init ; ../tools/setup-virtualenv.sh ; test -d wheelhouse && export NO_INDEX=--no-index ; virtualenv/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
+ceph-detect-init-all: ${CEPH_DETECT_INIT_VIRTUALENV}
+
+${CEPH_DETECT_INIT_VIRTUALENV}:
+	cd $(srcdir)/ceph-detect-init ; ../tools/setup-virtualenv.sh ${CEPH_DETECT_INIT_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
 
 ceph-detect-init-clean:
-	cd $(srcdir)/ceph-detect-init ; python setup.py clean ; rm -fr wheelhouse .tox build virtualenv .coverage *.egg-info
+	cd $(srcdir)/ceph-detect-init ; python setup.py clean ; rm -fr wheelhouse .tox build ${CEPH_DETECT_INIT_VIRTUALENV} .coverage *.egg-info
 
 ceph-detect-init-install-data:
 	cd $(srcdir)/ceph-detect-init ; \

--- a/src/ceph-detect-init/run-tox.sh
+++ b/src/ceph-detect-init/run-tox.sh
@@ -18,9 +18,10 @@
 #
 
 # run from the ceph-detect-init directory or from its parent
+: ${CEPH_DETECT_INIT_VIRTUALENV:=ceph-detect-init-virtualenv}
 test -d ceph-detect-init && cd ceph-detect-init
-source virtualenv/bin/activate
-tox > virtualenv/tox.out 2>&1
+source ${CEPH_DETECT_INIT_VIRTUALENV}/bin/activate
+tox > ${CEPH_DETECT_INIT_VIRTUALENV}/tox.out 2>&1
 status=$?
-grep -v InterpreterNotFound < virtualenv/tox.out
+grep -v InterpreterNotFound < ${CEPH_DETECT_INIT_VIRTUALENV}/tox.out
 exit $status

--- a/src/ceph-disk/Makefile.am
+++ b/src/ceph-disk/Makefile.am
@@ -29,13 +29,15 @@ EXTRA_DIST += \
 	ceph-disk/tests/test_main.py \
 	ceph-disk/tox.ini
 
-ceph-disk-all: ceph-disk/virtualenv
+export CEPH_DISK_VIRTUALENV = ${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv
 
-ceph-disk/virtualenv:
-	cd $(srcdir)/ceph-disk ; ../tools/setup-virtualenv.sh ; test -d wheelhouse && export NO_INDEX=--no-index ; virtualenv/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
+ceph-disk-all: ${CEPH_DISK_VIRTUALENV}
+
+${CEPH_DISK_VIRTUALENV}:
+	cd $(srcdir)/ceph-disk ; ../tools/setup-virtualenv.sh ${CEPH_DISK_VIRTUALENV} ; test -d wheelhouse && export NO_INDEX=--no-index ; ${CEPH_DISK_VIRTUALENV}/bin/pip install $$NO_INDEX --use-wheel --find-links=file://$$(pwd)/wheelhouse -e .
 
 ceph-disk-clean:
-	cd $(srcdir)/ceph-disk ; python setup.py clean ; rm -fr wheelhouse .tox build virtualenv .coverage *.egg-info
+	cd $(srcdir)/ceph-disk ; python setup.py clean ; rm -fr wheelhouse .tox build ${CEPH_DISK_VIRTUALENV} .coverage *.egg-info
 
 ceph-disk-install-data:
 	cd $(srcdir)/ceph-disk ; \

--- a/src/ceph-disk/run-tox.sh
+++ b/src/ceph-disk/run-tox.sh
@@ -16,9 +16,10 @@
 #
 
 # run from the ceph-disk directory or from its parent
+: ${CEPH_DISK_VIRTUALENV:=ceph-disk-virtualenv}
 test -d ceph-disk && cd ceph-disk
-source virtualenv/bin/activate
-tox > virtualenv/tox.out 2>&1
+source ${CEPH_DISK_VIRTUALENV}/bin/activate
+tox > ${CEPH_DISK_VIRTUALENV}/tox.out 2>&1
 status=$?
-grep -v InterpreterNotFound < virtualenv/tox.out
+grep -v InterpreterNotFound < ${CEPH_DISK_VIRTUALENV}/tox.out
 exit $status

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -15,17 +15,19 @@
 # GNU Library Public License for more details.
 #
 
-rm -fr virtualenv
-virtualenv virtualenv
-. virtualenv/bin/activate
+DIR=$1
+rm -fr $DIR
+mkdir -p $DIR
+virtualenv $DIR
+. $DIR/bin/activate
 # older versions of pip will not install wrap_console scripts
 # when using wheel packages
-pip --log virtualenv/log.txt install --upgrade 'pip >= 6.1'
+pip --log $DIR/log.txt install --upgrade 'pip >= 6.1'
 if test -d wheelhouse ; then
     export NO_INDEX=--no-index
 fi
-pip --log virtualenv/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse --upgrade distribute
-pip --log virtualenv/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9' 
+pip --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse --upgrade distribute
+pip --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9'
 if test -f requirements.txt ; then
-    pip --log virtualenv/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse -r requirements.txt
+    pip --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse -r requirements.txt
 fi


### PR DESCRIPTION
As a temporary measure because it overflows when jenkins tries to build
in a deep path. Run make with:

make CEPH_BUILD_VIRTUALENV=/tmp

and it will use these directories instead of the default.

Signed-off-by: Loic Dachary <loic@dachary.org>