### PR TITLE
rgw: Do not send a Content-Type on a '304 Not Modified' response

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -53,8 +53,15 @@ int RGWMongoose::complete_request()
       /*
        * Status 204 should not include a content-length header
        * RFC7230 says so
+       *
+       * Same goes for status 304: Not Modified
+       *
+       * 'If a cache uses a received 304 response to update a cache entry,'
+       * 'the cache MUST update the entry to reflect any new field values'
+       * 'given in the response.'
+       *
        */
-      if (status_num == 204) {
+      if (status_num == 204 || status_num == 304) {
         has_content_length = true;
       } else if (0 && data.length() == 0) {
         has_content_length = true;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -257,10 +257,14 @@ done:
 			riter->second.c_str());
   }
 
-  if (!content_type)
-    content_type = "binary/octet-stream";
+  if (op_ret == ERR_NOT_MODIFIED) {
+      end_header(s, this);
+  } else {
+      if (!content_type)
+          content_type = "binary/octet-stream";
 
-  end_header(s, this, content_type);
+      end_header(s, this, content_type);
+  }
 
   if (metadata_bl.length()) {
     STREAM_IO(s)->write(metadata_bl.c_str(), metadata_bl.length());


### PR DESCRIPTION
When we say the Content has not changed we should not respond
with a content type which defaults to binary/octet stream.

Fixes: #15119

Signed-off-by: Wido den Hollander <wido@42on.com>

This should fix issue http://tracker.ceph.com/issues/15119