### PR TITLE
rgw: return -EACCESS for system requests also

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3600,7 +3600,7 @@ int RGW_Auth_S3::authorize_v4(RGWRados *store, struct req_state *s)
       int ret = rgw_get_user_info_by_uid(store, effective_uid, effective_user);
       if (ret < 0) {
         ldout(s->cct, 0) << "User lookup failed!" << dendl;
-        return -ENOENT;
+        return -EACCES;
       }
       *(s->user) = effective_user;
     }
@@ -3808,7 +3808,7 @@ int RGW_Auth_S3::authorize_v2(RGWRados *store, struct req_state *s)
         ret = rgw_get_user_info_by_uid(store, euid, effective_user);
         if (ret < 0) {
           ldout(s->cct, 0) << "User lookup failed!" << dendl;
-          return -ENOENT;
+          return -EACCES;
         }
         *(s->user) = effective_user;
       }


### PR DESCRIPTION
In a multisite scenario, if a user created in a secondary zone tries to
create a bucket, fail with AccessDenied instead of a NoSuchKey, which
doesn't make sense for a create Bucket request for eg.

Fixes: #15234
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>