### PR TITLE
config_opts: disable filestore throttle soft backoff by default

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1058,18 +1058,18 @@ OPTION(filestore_queue_max_bytes, OPT_U64, 100 << 20)
 OPTION(filestore_caller_concurrency, OPT_INT, 10)
 
 /// Expected filestore throughput in B/s
-OPTION(filestore_expected_throughput_bytes, OPT_DOUBLE, 100 << 20)
+OPTION(filestore_expected_throughput_bytes, OPT_DOUBLE, 200 << 20)
 /// Expected filestore throughput in ops/s
-OPTION(filestore_expected_throughput_ops, OPT_DOUBLE, 100)
+OPTION(filestore_expected_throughput_ops, OPT_DOUBLE, 200)
 
-/// Filestore max delay multiple (probably don't need to change)
-OPTION(filestore_queue_max_delay_multiple, OPT_DOUBLE, 10)
-/// Filestore max delay multiple (probably don't need to change)
-OPTION(filestore_queue_high_delay_multiple, OPT_DOUBLE, 2)
+/// Filestore max delay multiple.  Defaults to 0 (disabled)
+OPTION(filestore_queue_max_delay_multiple, OPT_DOUBLE, 0)
+/// Filestore high delay multiple.  Defaults to 0 (disabled)
+OPTION(filestore_queue_high_delay_multiple, OPT_DOUBLE, 0)
 
 /// Use above to inject delays intended to keep the op queue between low and high
-OPTION(filestore_queue_low_threshhold, OPT_DOUBLE, 0.2)
-OPTION(filestore_queue_high_threshhold, OPT_DOUBLE, 0.8)
+OPTION(filestore_queue_low_threshhold, OPT_DOUBLE, 0.3)
+OPTION(filestore_queue_high_threshhold, OPT_DOUBLE, 0.9)
 
 OPTION(filestore_op_threads, OPT_INT, 2)
 OPTION(filestore_op_thread_timeout, OPT_INT, 60)
@@ -1102,13 +1102,13 @@ OPTION(journal_max_write_bytes, OPT_INT, 10 << 20)
 OPTION(journal_max_write_entries, OPT_INT, 100)
 
 /// Target range for journal fullness
-OPTION(journal_throttle_low_threshhold, OPT_DOUBLE, 0.5)
-OPTION(journal_throttle_high_threshhold, OPT_DOUBLE, 0.8)
+OPTION(journal_throttle_low_threshhold, OPT_DOUBLE, 0.6)
+OPTION(journal_throttle_high_threshhold, OPT_DOUBLE, 0.9)
 
-/// Multiple over expected at high_threshhold (probably don't need to change)
-OPTION(journal_throttle_high_multiple, OPT_DOUBLE, 2)
-/// Multiple over expected at max (probably don't need to change)
-OPTION(journal_throttle_max_multiple, OPT_DOUBLE, 10)
+/// Multiple over expected at high_threshhold. Defaults to 0 (disabled).
+OPTION(journal_throttle_high_multiple, OPT_DOUBLE, 0)
+/// Multiple over expected at max.  Defaults to 0 (disabled).
+OPTION(journal_throttle_max_multiple, OPT_DOUBLE, 0)
 
 OPTION(journal_align_min_size, OPT_INT, 64 << 10)  // align data payloads >= this.
 OPTION(journal_replay_from, OPT_INT, 0)


### PR DESCRIPTION
Performance testing suggests that HDD osds don't benefit and
in some cases are slowed down.

Also, adjust the other defaults to make more sense.

Signed-off-by: Samuel Just <sjust@redhat.com>