### PR TITLE
osd: bail out of _committed_osd_maps if we are shutting down

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6756,6 +6756,10 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 {
   dout(10) << __func__ << " " << first << ".." << last << dendl;
   Mutex::Locker l(osd_lock);
+  if (is_stopping()) {
+    dout(10) << __func__ << " bailing, we are shutting down" << dendl;
+    return;
+  }
   map_lock.get_write();
 
   bool do_shutdown = false;


### PR DESCRIPTION
Introduced in b839a06c1aba24ecf0780387a605192ff929f158
Fixes: 14309
Signed-off-by: Samuel Just <sjust@redhat.com>