### PR TITLE
tools/rados: add parameter "--obj-offset" for put cmd.

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -82,7 +82,7 @@ void usage(ostream& out)
 "\n"
 "OBJECT COMMANDS\n"
 "   get <obj-name> [outfile]         fetch object\n"
-"   put <obj-name> [infile]          write object\n"
+"   put <obj-name> [infile]  [--offset offset]  write object start offset(default 0)\n"
 "   truncate <obj-name> length       truncate object\n"
 "   create <obj-name>                create object\n"
 "   rm <obj-name> ...[--force-full]  [force no matter full or not]remove object(s)\n"
@@ -389,7 +389,7 @@ static int do_copy_pool(Rados& rados, const char *src_pool, const char *target_p
 }
 
 static int do_put(IoCtx& io_ctx, RadosStriper& striper,
-		  const char *objname, const char *infile, int op_size,
+		  const char *objname, const char *infile, int op_size, uint64_t obj_offset,
 		  bool use_striper)
 {
   string oid(objname);
@@ -408,7 +408,7 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
   }
   char *buf = new char[op_size];
   int count = op_size;
-  uint64_t offset = 0;
+  uint64_t offset = obj_offset;
   while (count != 0) {
     count = read(fd, buf, op_size);
     if (count < 0) {
@@ -417,7 +417,7 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
       goto out;
     }
     if (count == 0) {
-      if (!offset) { // in case we have to create an empty object
+      if (offset == obj_offset) { // in case we have to create an empty object & if obj_offset > 0 do a hole
 	if (use_striper) {
 	  ret = striper.write_full(oid, indata); // indata is empty
 	} else {
@@ -425,6 +425,16 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
 	}
 	if (ret < 0) {
 	  goto out;
+	}
+	if (offset) {
+	  if (use_striper) {
+	    ret = striper.trunc(oid, offset); //before truncate, object must be existed.
+	  } else {
+	    ret = io_ctx.trunc(oid, offset); //before truncate, object must be existed
+	  }
+	  if (ret < 0) {
+	    goto out;
+	  }
 	}
       }
       continue;
@@ -1442,6 +1452,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   unsigned op_size = default_op_size;
   unsigned object_size = 0;
   unsigned max_objects = 0;
+  uint64_t obj_offset = 0;
   bool block_size_specified = false;
   int bench_write_dest = 0;
   bool cleanup = true;
@@ -1532,6 +1543,12 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       return -EINVAL;
     }
     block_size_specified = true;
+  }
+  i = opts.find("offset");
+  if (i != opts.end()) {
+    if (rados_sistrtoll(i, &obj_offset)) {
+      return -EINVAL;
+    }
   }
   i = opts.find("max-objects");
   if (i != opts.end()) {
@@ -2011,7 +2028,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   else if (strcmp(nargs[0], "put") == 0) {
     if (!pool_name || nargs.size() < 3)
       usage_exit();
-    ret = do_put(io_ctx, striper, nargs[1], nargs[2], op_size, use_striper);
+    ret = do_put(io_ctx, striper, nargs[1], nargs[2], op_size, obj_offset,  use_striper);
     if (ret < 0) {
       cerr << "error putting " << pool_name << "/" << nargs[1] << ": " << cpp_strerror(ret) << std::endl;
       goto out;
@@ -3255,6 +3272,8 @@ int main(int argc, const char **argv)
       opts["object-size"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--max-objects", (char*)NULL)) {
       opts["max-objects"] = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--offset", (char*)NULL)) {
+      opts["offset"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-o", (char*)NULL)) {
       opts["object-size"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-s", "--snap", (char*)NULL)) {


### PR DESCRIPTION
In development, we need write object at options offset. But 'rados put'
don't support this. So add write command w/ options offset.

Signed-off-by: Jianpeng Ma jianpeng.ma@intel.com
