### PR TITLE
os/bluestore/bluestore: For truncate, no need zero(old_size, ROUND_UP_TO(old_size, block_size))

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5821,6 +5821,7 @@ int BlueStore::_do_truncate(
     if (bp != o->onode.block_map.begin())
       --bp;
     uint64_t x_end = bp->first + bp->second.length;
+    old_size = ROUND_UP_TO(old_size, block_size); //_do_write make sure this area already zero.
     if (bp != o->onode.block_map.end() &&
 	x_end > old_size) {
       // we need to zero from old_size to (end of extent or offset)


### PR DESCRIPTION
…_TO(old_size, block_size))

In _do_write, we can make sure (old_size, ROUND_UP_TO(old_size,block_size)) must padded by zero.
So when truncate, we can skip this area. This can reduce one RMW op.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>