### PR TITLE
Objecter: improve watch ping message priority to avoid watch timeout

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -658,6 +658,7 @@ void Objecter::_send_linger_ping(LingerOp *info)
   o->oncommit_sync = onack;
   o->target = info->target;
   o->should_resend = false;
+  o->priority = CEPH_MSG_PRIO_HIGHEST;
   _send_op_account(o);
   MOSDOp *m = _prepare_osd_op(o);
   o->tid = last_tid.inc();


### PR DESCRIPTION
In heavy benchmark case, osd will easily make watched client timeout because of lots of messages.
We burst watch ping op priority here and want to avoid this case.

Signed-off-by: Haomai Wang <haomai@xsky.com>