### PR TITLE
rbd: allow librados to prune the command-line for config overrides

### DIFF
--- a/src/tools/rbd/Shell.h
+++ b/src/tools/rbd/Shell.h
@@ -14,6 +14,7 @@ namespace rbd {
 
 class Shell {
 public:
+  typedef std::vector<const char *> Arguments;
   typedef std::vector<std::string> CommandSpec;
 
   struct Action {
@@ -47,7 +48,7 @@ public:
     }
   };
 
-  int execute(int arg_count, const char **arg_values);
+  int execute(const Arguments &argument);
 
 private:
   static std::vector<Action *>& get_actions();
@@ -59,8 +60,6 @@ private:
                       CommandSpec **matching_spec);
 
   void get_global_options(boost::program_options::options_description *opts);
-  void prune_command_line_arguments(int arg_count, const char **arg_values,
-                                    std::vector<std::string> *args);
 
   void print_help();
   void print_action_help(Action *action);

--- a/src/tools/rbd/rbd.cc
+++ b/src/tools/rbd/rbd.cc
@@ -16,5 +16,5 @@ int main(int argc, const char **argv)
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
 
   rbd::Shell shell;
-  return shell.execute(argc, argv);
+  return shell.execute(args);
 }


### PR DESCRIPTION
The "global_init" method will already prune all Ceph configuration overrides, so avoid reimplementing this within the RBD CLI.

Fixes: #15250

Signed-off-by: Jason Dillaman <dillaman@redhat.com>