### PR TITLE
Makefile-env.am: set a default for CEPH_BUILD_VIRTUALENV

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -297,5 +297,7 @@ LIBCIVETWEB_DEPS =
 DENCODER_SOURCES =
 DENCODER_DEPS =
 
+# put virtualenvs in this directory for build
+CEPH_BUILD_VIRTUALENV="/tmp/"
 
 radoslibdir = $(libdir)/rados-classes


### PR DESCRIPTION
We need to shorten the virtualenv path for non-Jenkins builds
too; gitbuilders were also overflowing the interpreter path limit

Signed-off-by: Dan Mick <dan.mick@redhat.com>