### PR TITLE
Fix unittest for chain_xattr.

### DIFF
--- a/src/test/objectstore/chain_xattr.cc
+++ b/src/test/objectstore/chain_xattr.cc
@@ -220,6 +220,35 @@ TEST(chain_xattr, chunk_aligned) {
   ::unlink(file);
 }
 
+void get_vector_from_xattr(vector<string> &xattrs, char* xattr, int size) {
+  char *end = xattr + size;
+  while (xattr < end) {
+    if (*xattr == '\0' )
+      break;
+    xattrs.push_back(xattr);
+    xattr += strlen(xattr) + 1;
+  }
+}
+
+bool listxattr_cmp(char* xattr1, char* xattr2, int size) {
+  vector<string> xattrs1;
+  vector<string> xattrs2;
+  get_vector_from_xattr(xattrs1, xattr1, size);
+  get_vector_from_xattr(xattrs2, xattr2, size);
+
+  if (xattrs1.size() != xattrs2.size())
+    return false;
+
+  std::sort(xattrs1.begin(), xattrs1.end());
+  std::sort(xattrs2.begin(), xattrs2.end());
+  std::vector<string> diff;
+  std::set_difference(xattrs1.begin(), xattrs1.end(),
+			  xattrs2.begin(), xattrs2.end(),
+			  diff.begin());
+
+  return diff.empty();
+}
+
 TEST(chain_xattr, listxattr) {
   const char* file = FILENAME;
   ::unlink(file);
@@ -230,20 +259,41 @@ TEST(chain_xattr, listxattr) {
   const string x(LARGE_BLOCK_LEN, 'X');
   const int y = 1234;
 
+  int orig_size = chain_listxattr(file, NULL, 0);
+  char *orig_buffer = NULL;
+  string orig_str;
+  if (orig_size) {
+    orig_buffer = (char*)malloc(orig_size);
+    chain_flistxattr(fd, orig_buffer, orig_size);
+    orig_str = string(orig_buffer);
+    orig_size = orig_str.size();
+  }
+
   ASSERT_EQ(LARGE_BLOCK_LEN, chain_setxattr(file, name1.c_str(), x.c_str(), LARGE_BLOCK_LEN));
   ASSERT_EQ((int)sizeof(y), chain_setxattr(file, name2.c_str(), &y, sizeof(y)));
 
-  int buffer_size = name1.size() + sizeof(char) + name2.size() + sizeof(char);
+  int buffer_size = 0;
+  if (orig_size)
+    buffer_size += orig_size + sizeof(char);
+  buffer_size += name1.size() + sizeof(char) + name2.size() + sizeof(char);
+
+  int index = 0;
   char* expected = (char*)malloc(buffer_size);
-  ::strcpy(expected, name1.c_str());
-  ::strcpy(expected + name1.size() + 1, name2.c_str());
-  char* actual = (char*)calloc(1, buffer_size);
+  ::memset(expected, '\0', buffer_size);
+  if (orig_size) {
+    ::strcpy(expected, orig_str.c_str());
+    index = orig_size + 1;
+  }
+  ::strcpy(expected + index, name1.c_str());
+  ::strcpy(expected + index + name1.size() + 1, name2.c_str());
+  char* actual = (char*)malloc(buffer_size);
+  ::memset(actual, '\0', buffer_size);
   ASSERT_LT(buffer_size, chain_listxattr(file, NULL, 0)); // size evaluation is conservative
   chain_listxattr(file, actual, buffer_size);
-  ASSERT_EQ(0, ::memcmp(expected, actual, buffer_size));
+  ASSERT_TRUE(listxattr_cmp(expected, actual, buffer_size));
   ::memset(actual, '\0', buffer_size);
   chain_flistxattr(fd, actual, buffer_size);
-  ASSERT_EQ(0, ::memcmp(expected, actual, buffer_size));
+  ASSERT_TRUE(listxattr_cmp(expected, actual, buffer_size));
 
   int unlikely_to_be_a_valid_fd = 400;
   ASSERT_GT(0, chain_listxattr("UNLIKELY_TO_EXIST", actual, 0));
@@ -256,6 +306,7 @@ TEST(chain_xattr, listxattr) {
   ASSERT_EQ(0, chain_removexattr(file, name1.c_str()));
   ASSERT_EQ(0, chain_removexattr(file, name2.c_str()));
 
+  free(orig_buffer);
   free(actual);
   free(expected);
   ::unlink(file);

--- a/src/test/objectstore/chain_xattr.cc
+++ b/src/test/objectstore/chain_xattr.cc
@@ -240,6 +240,7 @@ TEST(chain_xattr, listxattr) {
   char* actual = (char*)calloc(1, buffer_size);
   ASSERT_LT(buffer_size, chain_listxattr(file, NULL, 0)); // size evaluation is conservative
   chain_listxattr(file, actual, buffer_size);
+  ASSERT_EQ(0, ::memcmp(expected, actual, buffer_size));
   ::memset(actual, '\0', buffer_size);
   chain_flistxattr(fd, actual, buffer_size);
   ASSERT_EQ(0, ::memcmp(expected, actual, buffer_size));

--- a/src/test/objectstore/chain_xattr.cc
+++ b/src/test/objectstore/chain_xattr.cc
@@ -255,6 +255,7 @@ TEST(chain_xattr, listxattr) {
   ASSERT_EQ(0, chain_removexattr(file, name1.c_str()));
   ASSERT_EQ(0, chain_removexattr(file, name2.c_str()));
 
+  free(actual);
   free(expected);
   ::unlink(file);
 }


### PR DESCRIPTION
When we run unittest_chain_xattr, if there is a default xattr enabled, such as security.selinux, this test would fail.
```
  attr security.selinux
  attr user.foo
  attr user.foo@1
[       OK ] chain_xattr.chunk_aligned (2 ms)
[ RUN      ] chain_xattr.listxattr
test/objectstore/chain_xattr.cc:251: Failure
Value of: ::memcmp(expected, actual, buffer_size)
  Actual: 117
Expected: 0
[  FAILED  ] chain_xattr.listxattr (1 ms)
[----------] 3 tests from chain_xattr (333 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (333 ms total)
[  PASSED  ] 2 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] chain_xattr.listxattr

 1 FAILED TEST
FAIL unittest_chain_xattr (exit status: 1)
```

This patch record the original xattr in the expected buffer, then unittest_chain_xattr works well now. 