### PR TITLE
rgw:Use count fn in RGWUserBuckets for quota check

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1779,8 +1779,7 @@ int RGWCreateBucket::verify_permission()
     if (op_ret < 0)
       return op_ret;
 
-    map<string, RGWBucketEnt>& m = buckets.get_buckets();
-    if (m.size() >= s->user->max_buckets) {
+    if (buckets.count() >= s->user->max_buckets) {
       return -ERR_TOO_MANY_BUCKETS;
     }
   }


### PR DESCRIPTION
We already have a count function from RGWUserBuckets class which gives
the total size of the map, use that instead of getting the map and doing
a count.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>