### PR TITLE
build: set hardening flags conditionally

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,13 @@ AC_PROG_LIBTOOL
 AC_SUBST(AM_CXXFLAGS)
 AM_CXXFLAGS="${AM_CXXFLAGS}"
 
+# Hardened build
+AC_ARG_WITH([hardening],
+	    [AS_HELP_STRING([--without-hardening], [disable setting of hardening cflags (to be used with -O0)])],
+	    [],
+	    [with_hardening=yes])
+AM_CONDITIONAL(WITH_HARDENING, test "$with_hardening" = "yes")
+
 # Find out what to build (default is most of these)
 
 # rados?

--- a/do_autogen.sh
+++ b/do_autogen.sh
@@ -20,6 +20,7 @@ do_autogen.sh: make a ceph build by running autogen, etc.
 -p                               google profiler
 -P                               profiling build
 -R                               without rocksdb
+-S                               --without-hardening
 -T                               --without-tcmalloc
 -v                               verbose output
 
@@ -36,7 +37,7 @@ verbose=0
 profile=0
 rocksdb=1
 CONFIGURE_FLAGS="--disable-static --with-lttng"
-while getopts  "C:cd:e:hjJLO:pPRTv" flag
+while getopts  "C:cd:e:hjJLO:pPRSTv" flag
 do
     case $flag in
     C) CONFIGURE_FLAGS="$CONFIGURE_FLAGS $OPTARG";;
@@ -51,6 +52,7 @@ do
     p) with_profiler="--with-profiler" ;;
     P) profile=1;;
     R) rocksdb=0;;
+    S) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --without-hardening";;
     T) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --without-tcmalloc";;
     v) verbose=1;;
 

--- a/do_autogen.sh
+++ b/do_autogen.sh
@@ -48,7 +48,10 @@ do
     j) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --enable-cephfs-java";;
     J) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-jemalloc";;
     L) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --without-lttng";;
-    O) CFLAGS="${CFLAGS} -O$OPTARG";;
+    O) if [ $OPTARG -lt 2 ]; then
+           CONFIGURE_FLAGS="$CONFIGURE_FLAGS --without-hardening"
+       fi
+       CFLAGS="${CFLAGS} -O$OPTARG";;
     p) with_profiler="--with-profiler" ;;
     P) profile=1;;
     R) rocksdb=0;;

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -127,7 +127,9 @@ endif
 
 AM_CFLAGS = $(AM_COMMON_CFLAGS)
 if LINUX
+if WITH_HARDENING
 AM_CFLAGS += $(HARDENING_CFLAGS)
+endif
 endif
 AM_CPPFLAGS = $(AM_COMMON_CPPFLAGS)
 AM_CXXFLAGS = \
@@ -137,7 +139,9 @@ AM_CXXFLAGS = \
 	-Wnon-virtual-dtor \
 	-Wno-invalid-offsetof 
 if LINUX
-AM_CXXFLAGS += $(HARDENING_CFLAGS) 
+if WITH_HARDENING
+AM_CXXFLAGS += $(HARDENING_CFLAGS)
+endif
 endif
 if !CLANG
 	AM_CXXFLAGS += -Wstrict-null-sentinel
@@ -154,7 +158,9 @@ endif
 # http://sigquit.wordpress.com/2011/02/16/why-asneeded-doesnt-work-as-expected-for-your-libraries-on-your-autotools-project/
 AM_LDFLAGS =
 if LINUX
+if WITH_HARDENING
 AM_LDFLAGS += -Wl,--as-needed $(HARDENING_LDFLAGS)
+endif
 endif
 if AIX
 AM_LDFLAGS += -Wl,-brtl 


### PR DESCRIPTION
Last night I was stepping (actually hopping :D) through radosgw in gdb due to the optimization level set during compilation. I went digging where to set -O0... do_autogen.sh provides a "-O" option, however this broke compilation because FORTIFY_SOURCE=2 (along with a few others) are being set via HARDENING_CFLAGS in src/Makefile-env.am under a "if LINUX" conditional.

This patch _tries_ to fix this by adding a "--without-hardening" option to do_autogen.sh/configure.ac to be used alongside "-d" and "-O".

First pass at fixing: http://tracker.ceph.com/issues/15263