### PR TITLE
cls_rbd: mirror_image_list should return global image id

### DIFF
--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -1132,8 +1132,12 @@ namespace librbd {
     }
 
     int mirror_image_list(librados::IoCtx *ioctx,
-			  std::vector<std::string> *image_ids) {
+		          const std::string &start, uint64_t max_return,
+			  std::map<std::string, std::string> *mirror_image_ids) {
       bufferlist in_bl;
+      ::encode(start, in_bl);
+      ::encode(max_return, in_bl);
+
       bufferlist out_bl;
       int r = ioctx->exec(RBD_MIRRORING, "rbd", "mirror_image_list", in_bl,
 			  out_bl);
@@ -1141,10 +1145,9 @@ namespace librbd {
         return r;
       }
 
-      image_ids->clear();
       try {
         bufferlist::iterator bl_it = out_bl.begin();
-        ::decode(*image_ids, bl_it);
+        ::decode(*mirror_image_ids, bl_it);
       } catch (const buffer::error &err) {
         return -EBADMSG;
       }

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -228,7 +228,8 @@ namespace librbd {
                                 const std::string &uuid,
                                 const std::string &cluster_name);
     int mirror_image_list(librados::IoCtx *ioctx,
-			  std::vector<std::string> *image_ids);
+		          const std::string &start, uint64_t max_return,
+                          std::map<std::string, std::string> *mirror_image_ids);
     int mirror_image_get(librados::IoCtx *ioctx, const std::string &image_id,
 			 cls::rbd::MirrorImage *mirror_image);
     int mirror_image_set(librados::IoCtx *ioctx, const std::string &image_id,


### PR DESCRIPTION
The global image id is needed to crosslink images when an image is
replicated between multiple clusters.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>