### PR TITLE
messages/MOSDOp: clear reqid inc for v6 encoding

### DIFF
--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -315,7 +315,13 @@ struct ceph_osd_request_head {
 
       ::encode(retry_attempt, payload);
       ::encode(features, payload);
-      ::encode(reqid, payload);
+      if (reqid.name != entity_name_t() || reqid.tid != 0) {
+	::encode(reqid, payload);
+      } else {
+	// don't include client_inc in the reqid for the legacy v6
+	// encoding or else we'll confuse older peers.
+	::encode(osd_reqid_t(), payload);
+      }
     } else {
       // new, reordered, v7 message encoding
       header.version = HEAD_VERSION;


### PR DESCRIPTION
For the new v7 encoding, we put the client incarnation in the reqid so that
we can have it at the beginning of the encoding.  However, we do *not*
want to do this for the v6 encoding, as that version of get_reqid() will
return reqid if it is not == osd_reqid_t().  Previously we were setting
the field in the constructor, but since it's specific to the v7 encoding,
put it there (in encode_payload()) instead.

Fixes: #15230
Signed-off-by: Sage Weil <sage@redhat.com>