### PR TITLE
common: update config parsing error for clarity

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -814,6 +814,8 @@ function test_mon_mds()
   ceph mds remove_data_pool $data3_pool
   ceph osd pool delete data2 data2 --yes-i-really-really-mean-it
   ceph osd pool delete data3 data3 --yes-i-really-really-mean-it
+  expect_false ceph mds set_max_mds 4
+  ceph mds set allow_multimds true --yes-i-really-mean-it
   ceph mds set_max_mds 4
   ceph mds set_max_mds 3
   ceph mds set_max_mds 256
@@ -875,7 +877,7 @@ function test_mon_mds()
   set -e
 
   # Check that setting enable_multiple enables creation of second fs
-  ceph fs flag set enable_multiple true
+  ceph fs flag set enable_multiple true --yes-i-really-mean-it
   ceph fs new cephfs2 fs_metadata2 fs_data2
 
   # Clean up multi-fs stuff

--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -183,6 +183,7 @@ if __name__ == '__main__':
     expect('mds/remove_data_pool?pool={0}'.format(poolnum), 'PUT', 200, '')
     expect('osd/pool/delete?pool=data2&pool2=data2'
            '&sure=--yes-i-really-really-mean-it', 'PUT', 200, '')
+    expect('mds/set?var=allow_multimds&val=true&confirm=--yes-i-really-mean-it', 'PUT', 200, '')
     expect('mds/set_max_mds?maxmds=4', 'PUT', 200, '')
     expect('mds/set?var=max_mds&val=4', 'PUT', 200, '')
     expect('mds/set?var=max_file_size&val=1048576', 'PUT', 200, '')

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -234,6 +234,11 @@ struct ceph_mon_subscribe_ack {
  */
 #define CEPH_MDSMAP_DOWN    (1<<0)  /* cluster deliberately down */
 #define CEPH_MDSMAP_ALLOW_SNAPS   (1<<1)  /* cluster allowed to create snapshots */
+#define CEPH_MDSMAP_ALLOW_MULTIMDS (1<<2) /* cluster allowed to have >1 active MDS */
+#define CEPH_MDSMAP_ALLOW_DIRFRAGS (1<<3) /* cluster allowed to fragment directories */
+
+#define CEPH_MDSMAP_ALLOW_CLASSICS (CEPH_MDSMAP_ALLOW_SNAPS | CEPH_MDSMAP_ALLOW_MULTIMDS | \
+				    CEPH_MDSMAP_ALLOW_DIRFRAGS)
 
 /*
  * mds states

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -77,7 +77,7 @@ void FSMap::print(ostream& out) const
 {
   out << "e" << epoch << std::endl;
   out << "enable_multiple: " << enable_multiple << std::endl;
-  out << "compat: " << enable_multiple << std::endl;
+  out << "compat: " << compat << std::endl;
   out << " " << std::endl;
 
   if (filesystems.empty()) {

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -35,6 +35,11 @@ void FSMap::dump(Formatter *f) const
   compat.dump(f);
   f->close_section();
 
+  f->open_object_section("feature flags");
+  f->dump_bool("enable_multiple", enable_multiple);
+  f->dump_bool("ever_enabled_multiple", ever_enabled_multiple);
+  f->close_section();
+
   f->open_array_section("standbys");
   for (const auto &i : standby_daemons) {
     f->open_object_section("info");
@@ -76,7 +81,8 @@ void FSMap::generate_test_instances(list<FSMap*>& ls)
 void FSMap::print(ostream& out) const
 {
   out << "e" << epoch << std::endl;
-  out << "enable_multiple: " << enable_multiple << std::endl;
+  out << "enable_multiple, ever_enabled_multiple: " << enable_multiple << ","
+      << ever_enabled_multiple << std::endl;
   out << "compat: " << compat << std::endl;
   out << " " << std::endl;
 

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -231,7 +231,7 @@ void FSMap::get_health(list<pair<health_status_t,string> >& summary,
 void FSMap::encode(bufferlist& bl, uint64_t features) const
 {
   if (features & CEPH_FEATURE_SERVER_JEWEL) {
-    ENCODE_START(6, 6, bl);
+    ENCODE_START(7, 6, bl);
     ::encode(epoch, bl);
     ::encode(next_filesystem_id, bl);
     ::encode(legacy_client_fscid, bl);
@@ -245,6 +245,7 @@ void FSMap::encode(bufferlist& bl, uint64_t features) const
     ::encode(mds_roles, bl);
     ::encode(standby_daemons, bl, features);
     ::encode(standby_epochs, bl);
+    ::encode(ever_enabled_multiple, bl);
     ENCODE_FINISH(bl);
   } else {
     if (filesystems.empty()) {
@@ -406,6 +407,7 @@ void FSMap::decode(bufferlist::iterator& p)
     ::decode(legacy_client_fscid, p);
     ::decode(compat, p);
     ::decode(enable_multiple, p);
+    ::decode(ever_enabled_multiple, p);
     std::vector<Filesystem> fs_list;
     ::decode(fs_list, p);
     filesystems.clear();

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -345,16 +345,24 @@ void FSMap::decode(bufferlist::iterator& p)
 	// previously this was a bool about snaps, not a flag map
 	bool flag;
 	::decode(flag, p);
-	legacy_mds_map.ever_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+	legacy_mds_map.ever_allowed_features = flag ?
+	  CEPH_MDSMAP_ALLOW_SNAPS : 0;
 	::decode(flag, p);
-	legacy_mds_map.explicitly_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+	legacy_mds_map.explicitly_allowed_features = flag ?
+	  CEPH_MDSMAP_ALLOW_SNAPS : 0;
+	if (legacy_mds_map.max_mds > 1) {
+	  legacy_mds_map.set_multimds_allowed();
+	}
       } else {
 	::decode(legacy_mds_map.ever_allowed_features, p);
 	::decode(legacy_mds_map.explicitly_allowed_features, p);
       }
     } else {
-      legacy_mds_map.ever_allowed_features = CEPH_MDSMAP_ALLOW_SNAPS;
+      legacy_mds_map.ever_allowed_features = CEPH_MDSMAP_ALLOW_CLASSICS;
       legacy_mds_map.explicitly_allowed_features = 0;
+      if (legacy_mds_map.max_mds > 1) {
+	legacy_mds_map.set_multimds_allowed();
+      }
     }
     if (ev >= 7)
       ::decode(legacy_mds_map.inline_data_enabled, p);

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -341,11 +341,20 @@ void FSMap::decode(bufferlist::iterator& p)
     if (ev >= 4)
       ::decode(legacy_mds_map.last_failure_osd_epoch, p);
     if (ev >= 6) {
-      ::decode(legacy_mds_map.ever_allowed_snaps, p);
-      ::decode(legacy_mds_map.explicitly_allowed_snaps, p);
+      if (ev < 10) {
+	// previously this was a bool about snaps, not a flag map
+	bool flag;
+	::decode(flag, p);
+	legacy_mds_map.ever_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+	::decode(flag, p);
+	legacy_mds_map.explicitly_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+      } else {
+	::decode(legacy_mds_map.ever_allowed_features, p);
+	::decode(legacy_mds_map.explicitly_allowed_features, p);
+      }
     } else {
-      legacy_mds_map.ever_allowed_snaps = true;
-      legacy_mds_map.explicitly_allowed_snaps = false;
+      legacy_mds_map.ever_allowed_features = CEPH_MDSMAP_ALLOW_SNAPS;
+      legacy_mds_map.explicitly_allowed_features = 0;
     }
     if (ev >= 7)
       ::decode(legacy_mds_map.inline_data_enabled, p);

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -95,6 +95,7 @@ protected:
   fs_cluster_id_t legacy_client_fscid;
   CompatSet compat;
   bool enable_multiple;
+  bool ever_enabled_multiple; // < the cluster had multiple MDSes enabled once
 
   std::map<fs_cluster_id_t, std::shared_ptr<Filesystem> > filesystems;
 
@@ -115,7 +116,7 @@ public:
       next_filesystem_id(FS_CLUSTER_ID_ANONYMOUS + 1),
       legacy_client_fscid(FS_CLUSTER_ID_NONE),
       compat(get_mdsmap_compat_set_default()),
-      enable_multiple(false)
+      enable_multiple(false), ever_enabled_multiple(false)
   { }
 
   FSMap(const FSMap &rhs)
@@ -125,6 +126,7 @@ public:
       legacy_client_fscid(rhs.legacy_client_fscid),
       compat(rhs.compat),
       enable_multiple(rhs.enable_multiple),
+      ever_enabled_multiple(rhs.ever_enabled_multiple),
       mds_roles(rhs.mds_roles),
       standby_daemons(rhs.standby_daemons),
       standby_epochs(rhs.standby_epochs)
@@ -159,6 +161,9 @@ public:
   void set_enable_multiple(const bool v)
   {
     enable_multiple = v;
+    if (true == v) {
+      ever_enabled_multiple = true;
+    }
   }
 
   bool get_enable_multiple() const

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -333,6 +333,7 @@ double MDBalancer::try_match(mds_rank_t ex, double& maxex,
 
 void MDBalancer::queue_split(CDir *dir)
 {
+  assert(mds->mdsmap->allows_dirfrags());
   split_queue.insert(dir->dirfrag());
 }
 
@@ -984,6 +985,7 @@ void MDBalancer::hit_dir(utime_t now, CDir *dir, int type, int who, double amoun
 
     // split
     if (g_conf->mds_bal_split_size > 0 &&
+	mds->mdsmap->allows_dirfrags() &&
 	(dir->should_split() ||
 	 (v > g_conf->mds_bal_split_rd && type == META_POP_IRD) ||
 	 (v > g_conf->mds_bal_split_wr && type == META_POP_IWR)) &&

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -630,16 +630,23 @@ void MDSMap::decode(bufferlist::iterator& p)
       // previously this was a bool about snaps, not a flag map
       bool flag;
       ::decode(flag, p);
-      legacy_mds_map.ever_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+      ever_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+      ever_allowed_features |= CEPH_MDSMAP_ALLOW_MULTIMDS|CEPH_MDSMAP_ALLOW_DIRFRAGS;
       ::decode(flag, p);
-      legacy_mds_map.explicitly_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+      explicitly_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+      if (max_mds > 1) {
+	set_multimds_allowed();
+      }
     } else {
       ::decode(ever_allowed_features, p);
       ::decode(explicitly_allowed_features, p);
     }
   } else {
-    ever_allowed_features = CEPH_MDSMAP_ALLOW_SNAPS;
+    ever_allowed_features = CEPH_MDSMAP_ALLOW_CLASSICS;
     explicitly_allowed_features = 0;
+    if (max_mds > 1) {
+      set_multimds_allowed();
+    }
   }
   if (ev >= 7)
     ::decode(inline_data_enabled, p);

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -262,8 +262,24 @@ public:
     ever_allowed_features &= CEPH_MDSMAP_ALLOW_SNAPS;
     explicitly_allowed_features &= CEPH_MDSMAP_ALLOW_SNAPS;
   }
-  bool allows_snaps() { return test_flag(CEPH_MDSMAP_ALLOW_SNAPS); }
   void clear_snaps_allowed() { clear_flag(CEPH_MDSMAP_ALLOW_SNAPS); }
+  bool allows_snaps() const { return test_flag(CEPH_MDSMAP_ALLOW_SNAPS); }
+
+  void set_multimds_allowed() {
+    set_flag(CEPH_MDSMAP_ALLOW_MULTIMDS);
+    ever_allowed_features &= CEPH_MDSMAP_ALLOW_MULTIMDS;
+    explicitly_allowed_features &= CEPH_MDSMAP_ALLOW_MULTIMDS;
+  }
+  void clear_multimds_allowed() { clear_flag(CEPH_MDSMAP_ALLOW_MULTIMDS); }
+  bool allows_multimds() const { return test_flag(CEPH_MDSMAP_ALLOW_MULTIMDS); }
+
+  void set_dirfrags_allowed() {
+    set_flag(CEPH_MDSMAP_ALLOW_DIRFRAGS);
+    ever_allowed_features &= CEPH_MDSMAP_ALLOW_DIRFRAGS;
+    explicitly_allowed_features &= CEPH_MDSMAP_ALLOW_DIRFRAGS;
+  }
+  void clear_dirfrags_allowed() { clear_flag(CEPH_MDSMAP_ALLOW_DIRFRAGS); }
+  bool allows_dirfrags() const { return test_flag(CEPH_MDSMAP_ALLOW_DIRFRAGS); }
 
   epoch_t get_epoch() const { return epoch; }
   void inc_epoch() { epoch++; }

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -209,8 +209,8 @@ protected:
   std::map<mds_rank_t, mds_gid_t> up;        // who is in those roles
   std::map<mds_gid_t, mds_info_t> mds_info;
 
-  bool ever_allowed_snaps; //< the cluster has ever allowed snap creation
-  bool explicitly_allowed_snaps; //< the user has explicitly enabled snap creation
+  uint8_t ever_allowed_features; //< bitmap of features the cluster has allowed
+  uint8_t explicitly_allowed_features; //< bitmap of features explicitly enabled 
 
   bool inline_data_enabled;
 
@@ -235,8 +235,8 @@ public:
       cas_pool(-1),
       metadata_pool(0),
       max_mds(0),
-      ever_allowed_snaps(false),
-      explicitly_allowed_snaps(false),
+      ever_allowed_features(0),
+      explicitly_allowed_features(0),
       inline_data_enabled(false),
       cached_up_features(0)
   { }
@@ -259,8 +259,8 @@ public:
 
   void set_snaps_allowed() {
     set_flag(CEPH_MDSMAP_ALLOW_SNAPS);
-    ever_allowed_snaps = true;
-    explicitly_allowed_snaps = true;
+    ever_allowed_features &= CEPH_MDSMAP_ALLOW_SNAPS;
+    explicitly_allowed_features &= CEPH_MDSMAP_ALLOW_SNAPS;
   }
   bool allows_snaps() { return test_flag(CEPH_MDSMAP_ALLOW_SNAPS); }
   void clear_snaps_allowed() { clear_flag(CEPH_MDSMAP_ALLOW_SNAPS); }

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1508,6 +1508,9 @@ class FlagSetHandler : public FileSystemCommandHandler
     string flag_val;
     cmd_getval(g_ceph_context, cmdmap, "val", flag_val);
 
+    string confirm;
+    cmd_getval(g_ceph_context, cmdmap, "confirm", confirm);
+
     if (flag_name == "enable_multiple") {
       bool flag_bool = false;
       int r = parse_bool(flag_val, &flag_bool, ss);
@@ -1521,7 +1524,12 @@ class FlagSetHandler : public FileSystemCommandHandler
         ss << "Multiple-filesystems are forbidden until all mons are updated";
         return -EINVAL;
       }
-
+      if (confirm != "--yes-i-really-mean-it") {
+	ss << "Multiple FSes is an EXPERIMENTAL and BARELY-TESTED configuration"
+	  " that may break your entire cluster, probably prevent serious"
+	  " support, and irrevocably marks your cluster."
+	  " Add --yes-i-really-mean-it if you are sure you wish to continue.";
+      }
       fsmap.set_enable_multiple(flag_bool);
       return 0;
     } else {

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -402,7 +402,8 @@ COMMAND("fs set " \
 	"name=confirm,type=CephString,req=false",			\
 	"set mds parameter <var> to <val>", "mds", "rw", "cli,rest")
 COMMAND("fs flag set name=flag_name,type=CephChoices,strings=enable_multiple "
-        "name=val,type=CephString", \
+        "name=val,type=CephString " \
+	"name=confirm,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"Set a global CephFS flag", \
 	"fs", "rw", "cli,rest")
 COMMAND("fs add_data_pool name=fs_name,type=CephString " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -397,7 +397,7 @@ COMMAND("fs get name=fs_name,type=CephString", \
 COMMAND("fs set " \
 	"name=fs_name,type=CephString " \
 	"name=var,type=CephChoices,strings=max_mds|max_file_size"
-        "|allow_new_snaps|inline_data|cluster_down " \
+        "|allow_new_snaps|inline_data|cluster_down|allow_multimds|allow_dirfrags " \
 	"name=val,type=CephString "					\
 	"name=confirm,type=CephString,req=false",			\
 	"set mds parameter <var> to <val>", "mds", "rw", "cli,rest")

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -625,7 +625,7 @@ fi
 
 if [ "$start_mds" -eq 1 -a "$CEPH_NUM_MDS" -gt 0 ]; then
     if [ "$CEPH_NUM_FS" -gt "1" ] ; then
-        $CEPH_ADM fs flag set enable_multiple true
+        $CEPH_ADM fs flag set enable_multiple true --yes-i-really-mean-it
     fi
 
     fs=0


### PR DESCRIPTION
http://tracker.ceph.com/issues/15235 describes a user getting this
message despite not trying to open the config file. And indeed, it's
what gets spat out if internal_safe_to_start_threads is false. Update
the output to reflect that being the most likely error.message

Signed-off-by: Greg Farnum <gfarnum@redhat.com>