### PR TITLE
os/bluestore/BlueStore: fix bug for using cache_tail.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5520,6 +5520,7 @@ int BlueStore::_do_write(
 
     // use cached tail block?
     uint64_t tail_start = o->onode.size - o->onode.size % block_size;
+    bool partly_overwrite_tail = false;
     if (offset >= bp->first &&
 	offset > tail_start &&
 	offset + length >= o->onode.size &&
@@ -5545,6 +5546,9 @@ int BlueStore::_do_write(
 	bl.swap(t);
       } else {
 	bufferlist t;
+	//partly overwrite cache tail. Block size don't equal sector size
+	//so block update isn't a atomic op.
+	partly_overwrite_tail = true;
 	t.substr_of(o->tail_bl, 0, tail_off);
 	offset -= t.length();
 	length += t.length();
@@ -5555,15 +5559,17 @@ int BlueStore::_do_write(
       assert(!bp->second.has_flag(bluestore_extent_t::FLAG_UNWRITTEN) ||
 	     bp->second.has_flag(bluestore_extent_t::FLAG_COW_HEAD) ||
 	     offset == bp->first);
-      bp->second.clear_flag(bluestore_extent_t::FLAG_COW_HEAD);
-      bp->second.clear_flag(bluestore_extent_t::FLAG_UNWRITTEN);
-      _pad_zeros(txc, o, &bl, &offset, &length, block_size);
-      uint64_t x_off = offset - bp->first;
-      dout(20) << __func__ << " write " << offset << "~" << length
-	       << " x_off " << x_off << dendl;
-      bdev->aio_write(bp->second.offset + x_off, bl, &txc->ioc, buffered);
-      ++bp;
-      continue;
+      if (!partly_overwrite_tail) {
+	bp->second.clear_flag(bluestore_extent_t::FLAG_COW_HEAD);
+	bp->second.clear_flag(bluestore_extent_t::FLAG_UNWRITTEN);
+	_pad_zeros(txc, o, &bl, &offset, &length, block_size);
+	uint64_t x_off = offset - bp->first;
+	dout(20) << __func__ << " write " << offset << "~" << length
+	  << " x_off " << x_off << dendl;
+	bdev->aio_write(bp->second.offset + x_off, bl, &txc->ioc, buffered);
+	++bp;
+	continue;
+      }
     }
 
     if (offset + length > (o->onode.size & block_mask) &&
@@ -5573,7 +5579,7 @@ int BlueStore::_do_write(
     }
 
     if (offset % min_alloc_size == 0 &&
-	length % min_alloc_size == 0) {
+	length % min_alloc_size == 0 && !partly_overwrite_tail) {
       assert(bp->second.has_flag(bluestore_extent_t::FLAG_UNWRITTEN));
     }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5562,7 +5562,8 @@ int BlueStore::_do_write(
       if (!partly_overwrite_tail) {
 	bp->second.clear_flag(bluestore_extent_t::FLAG_COW_HEAD);
 	bp->second.clear_flag(bluestore_extent_t::FLAG_UNWRITTEN);
-	_pad_zeros(txc, o, &bl, &offset, &length, block_size);
+	if ((offset % block_size) || ((offset + length) % block_size))
+	  _pad_zeros(txc, o, &bl, &offset, &length, block_size);
 	uint64_t x_off = offset - bp->first;
 	dout(20) << __func__ << " write " << offset << "~" << length
 	  << " x_off " << x_off << dendl;


### PR DESCRIPTION
If using cache tail and the extent isn't unwritten, this mean overwrite
the existed tail-data(all or part). It must using wal rather than
directly write.
For example:
write(0-2K)-->cache tail 2k, offset=0
write(2k, 60K)-->using cache tail
   write(0, 64K)-->overwrite the exsited data (0, 2k)
Because overwrite existed data, for data integrity, it must use
wal-mode.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>