### PR TITLE
throttle: fix unit test on Alpine

### DIFF
--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -35,28 +35,28 @@ class Throttle {
   const bool use_perf;
 
 public:
-  Throttle(CephContext *cct, const std::string& n, int64_t m = 0, bool _use_perf = true);
+  Throttle(CephContext *cct, const std::string& n, uint64_t m = 0, bool _use_perf = true);
   ~Throttle();
 
 private:
-  void _reset_max(int64_t m);
-  bool _should_wait(int64_t c) const {
-    int64_t m = max.read();
-    int64_t cur = count.read();
+  void _reset_max(uint64_t m);
+  bool _should_wait(uint64_t c) const {
+    uint64_t m = max.read();
+    uint64_t cur = count.read();
     return
       m &&
       ((c <= m && cur + c > m) || // normally stay under max
        (c >= m && cur > m));     // except for large c
   }
 
-  bool _wait(int64_t c);
+  bool _wait(uint64_t c);
 
 public:
   /**
    * gets the number of currently taken slots
    * @returns the number of taken slots
    */
-  int64_t get_current() const {
+  uint64_t get_current() const {
     return count.read();
   }
 
@@ -64,7 +64,7 @@ public:
    * get the max number of slots
    * @returns the max number of slots
    */
-  int64_t get_max() const { return max.read(); }
+  uint64_t get_max() const { return max.read(); }
 
   /**
    * set the new max number, and wait until the number of taken slots drains
@@ -73,14 +73,14 @@ public:
    * @param m the new max number
    * @returns true if this method is blocked, false it it returns immediately
    */
-  bool wait(int64_t m = 0);
+  bool wait(uint64_t m = 0);
 
   /**
    * take the specified number of slots from the stock regardless the throttling
    * @param c number of slots to take
    * @returns the total number of taken slots
    */
-  int64_t take(int64_t c = 1);
+  uint64_t take(uint64_t c = 1);
 
   /**
    * get the specified amount of slots from the stock, but will wait if the
@@ -90,25 +90,25 @@ public:
    * @returns true if this request is blocked due to the throttling, false 
    * otherwise
    */
-  bool get(int64_t c = 1, int64_t m = 0);
+  bool get(uint64_t c = 1, uint64_t m = 0);
 
   /**
    * the unblocked version of @p get()
    * @returns true if it successfully got the requested amount,
    * or false if it would block.
    */
-  bool get_or_fail(int64_t c = 1);
+  bool get_or_fail(uint64_t c = 1);
 
   /**
    * put slots back to the stock
    * @param c number of slots to return
    * @returns number of requests being hold after this
    */
-  int64_t put(int64_t c = 1);
-  bool should_wait(int64_t c) const {
+  uint64_t put(uint64_t c = 1);
+  bool should_wait(uint64_t c) const {
     return _should_wait(c);
   }
-  void reset_max(int64_t m) {
+  void reset_max(uint64_t m) {
     Mutex::Locker l(lock);
     _reset_max(m);
   }

--- a/src/test/common/Throttle.cc
+++ b/src/test/common/Throttle.cc
@@ -61,47 +61,41 @@ protected:
 };
 
 TEST_F(ThrottleTest, Throttle) {
-  ASSERT_DEATH({
-      Throttle throttle(g_ceph_context, "throttle", -1);
-    }, "");
-
-  int64_t throttle_max = 10;
+  uint64_t throttle_max = 10;
   Throttle throttle(g_ceph_context, "throttle", throttle_max);
   ASSERT_EQ(throttle.get_max(), throttle_max);
-  ASSERT_EQ(throttle.get_current(), 0);
+  ASSERT_EQ(throttle.get_current(), (uint64_t)0);
 }
 
 TEST_F(ThrottleTest, take) {
-  int64_t throttle_max = 10;
+  uint64_t throttle_max = 10;
   Throttle throttle(g_ceph_context, "throttle", throttle_max);
-  ASSERT_DEATH(throttle.take(-1), "");
   ASSERT_EQ(throttle.take(throttle_max), throttle_max);
   ASSERT_EQ(throttle.take(throttle_max), throttle_max * 2);
 }
 
 TEST_F(ThrottleTest, get) {
-  int64_t throttle_max = 10;
+  uint64_t throttle_max = 10;
   Throttle throttle(g_ceph_context, "throttle");
 
   // test increasing max from 0 to throttle_max
   {
     ASSERT_FALSE(throttle.get(throttle_max, throttle_max));
     ASSERT_EQ(throttle.get_max(), throttle_max);
-    ASSERT_EQ(throttle.put(throttle_max), 0);
+    ASSERT_EQ(throttle.put(throttle_max), (uint64_t)0);
   }
 
-  ASSERT_DEATH(throttle.get(-1), "");
   ASSERT_FALSE(throttle.get(5));
-  ASSERT_EQ(throttle.put(5), 0);
+  ASSERT_EQ(throttle.put(5), (uint64_t)0);
 
   ASSERT_FALSE(throttle.get(throttle_max));
   ASSERT_FALSE(throttle.get_or_fail(1));
   ASSERT_FALSE(throttle.get(1, throttle_max + 1));
-  ASSERT_EQ(throttle.put(throttle_max + 1), 0);
+  ASSERT_EQ(throttle.put(throttle_max + 1), (uint64_t)0);
   ASSERT_FALSE(throttle.get(0, throttle_max));
   ASSERT_FALSE(throttle.get(throttle_max));
   ASSERT_FALSE(throttle.get_or_fail(1));
-  ASSERT_EQ(throttle.put(throttle_max), 0);
+  ASSERT_EQ(throttle.put(throttle_max), (uint64_t)0);
 
   useconds_t delay = 1;
 
@@ -116,7 +110,7 @@ TEST_F(ThrottleTest, get) {
     Thread_get t(throttle, 7);
     t.create("t_throttle_1");
     usleep(delay);
-    ASSERT_EQ(throttle.put(throttle_max), 0);
+    ASSERT_EQ(throttle.put(throttle_max), (uint64_t)0);
     t.join();
 
     if (!(waited = t.waited))
@@ -157,25 +151,25 @@ TEST_F(ThrottleTest, get_or_fail) {
   }
 
   {
-    int64_t throttle_max = 10;
+    uint64_t throttle_max = 10;
     Throttle throttle(g_ceph_context, "throttle", throttle_max);
 
     ASSERT_TRUE(throttle.get_or_fail(throttle_max));
-    ASSERT_EQ(throttle.put(throttle_max), 0);
+    ASSERT_EQ(throttle.put(throttle_max), (uint64_t)0);
 
     ASSERT_TRUE(throttle.get_or_fail(throttle_max * 2));
     ASSERT_FALSE(throttle.get_or_fail(1));
     ASSERT_FALSE(throttle.get_or_fail(throttle_max * 2));
-    ASSERT_EQ(throttle.put(throttle_max * 2), 0);
+    ASSERT_EQ(throttle.put(throttle_max * 2), (uint64_t)0);
 
     ASSERT_TRUE(throttle.get_or_fail(throttle_max));
     ASSERT_FALSE(throttle.get_or_fail(1));
-    ASSERT_EQ(throttle.put(throttle_max), 0);
+    ASSERT_EQ(throttle.put(throttle_max), (uint64_t)0);
   }
 }
 
 TEST_F(ThrottleTest, wait) {
-  int64_t throttle_max = 10;
+  uint64_t throttle_max = 10;
   Throttle throttle(g_ceph_context, "throttle");
 
   // test increasing max from 0 to throttle_max
@@ -224,7 +218,7 @@ TEST_F(ThrottleTest, wait) {
 TEST_F(ThrottleTest, destructor) {
   Thread_get *t;
   {
-    int64_t throttle_max = 10;
+    uint64_t throttle_max = 10;
     Throttle *throttle = new Throttle(g_ceph_context, "throttle", throttle_max);
 
     ASSERT_FALSE(throttle->get(5));


### PR DESCRIPTION
./unittest_throttle
2016-03-23 11:37:30.179899 6bd13c053c50 -1 did not load config file, using default settings.
[==========] Running 9 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 6 tests from ThrottleTest
[ RUN      ] ThrottleTest.Throttle

[WARNING] ./src/gtest-death-test.cc:825:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test couldn't detect the number of threads.
[       OK ] ThrottleTest.Throttle (1 ms)
[ RUN      ] ThrottleTest.take

[WARNING] ./src/gtest-death-test.cc:825:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test couldn't detect the number of threads.
[       OK ] ThrottleTest.take (30002 ms)
[ RUN      ] ThrottleTest.get

[WARNING] ./src/gtest-death-test.cc:825:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test couldn't detect the number of threads.
Trying (1) with delay 1us
Trying (1) with delay 2us
Trying (2) with delay 2us
[       OK ] ThrottleTest.get (150017 ms)
[ RUN      ] ThrottleTest.get_or_fail
[       OK ] ThrottleTest.get_or_fail (0 ms)
[ RUN      ] ThrottleTest.wait
Trying (3) with delay 1us
[       OK ] ThrottleTest.wait (30003 ms)
[ RUN      ] ThrottleTest.destructor
[       OK ] ThrottleTest.destructor (30003 ms)
[----------] 6 tests from ThrottleTest (240026 ms total)

[----------] 3 tests from BackoffThrottle
[ RUN      ] BackoffThrottle.undersaturated
test/common/Throttle.cc:375: Failure
Expected: (results.second.count()) < (0.0002), actual: 0.000310413 vs 0.0002
[  FAILED  ] BackoffThrottle.undersaturated (275034 ms)
[ RUN      ] BackoffThrottle.balanced
test/common/Throttle.cc:393: Failure
Expected: (results.second.count()) < (0.002), actual: 0.0123898 vs 0.002
[  FAILED  ] BackoffThrottle.balanced (275147 ms)
[ RUN      ] BackoffThrottle.oversaturated
test/common/Throttle.cc:411: Failure
Expected: (results.second.count()) < (0.002), actual: 0.00273208 vs 0.002
[  FAILED  ] BackoffThrottle.oversaturated (125037 ms)
[----------] 3 tests from BackoffThrottle (675218 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 2 test cases ran. (915244 ms total)
[  PASSED  ] 6 tests.
[  FAILED  ] 3 tests, listed below:
[  FAILED  ] BackoffThrottle.undersaturated
[  FAILED  ] BackoffThrottle.balanced
[  FAILED  ] BackoffThrottle.oversaturated

 3 FAILED TESTS