### PR TITLE
doc/rados/operations/crush: fix the formatting

### DIFF
--- a/doc/rados/operations/crush-map.rst
+++ b/doc/rados/operations/crush-map.rst
@@ -957,8 +957,8 @@ algorithm is used.
 
 In order to use newer tunables, both clients and servers must support
 the new version of CRUSH.  For this reason, we have created
-``profiles'' that are named after the Ceph version in which they were
-introduced.  For example, the ``firefly'' tunables are first supported
+``profiles`` that are named after the Ceph version in which they were
+introduced.  For example, the ``firefly`` tunables are first supported
 in the firefly release, and will not work with older (e.g., dumpling)
 clients.  Once a given set of tunables are changed from the legacy
 default behavior, the ``ceph-mon`` and ``ceph-osd`` will prevent older


### PR DESCRIPTION
unlike in LaTeX, we should use "\`\`foo\`\`" instead of "``bar''" in the
sphinx markdown for the double quote.

it's now rendered like http://docs.ceph.com/docs/master/rados/operations/crush-map/#tunables which puts the line following "``" in monospace.

Signed-off-by: Kefu Chai <kchai@redhat.com>