### PR TITLE
test/system/rados_list_parallel: print oid if rados_write fails

### DIFF
--- a/src/test/system/st_rados_create_pool.cc
+++ b/src/test/system/st_rados_create_pool.cc
@@ -93,7 +93,8 @@ run()
     std::string buf(get_random_buf(256));
     int ret = rados_write(io_ctx, oid, buf.c_str(), buf.size(), 0);
     if (ret != 0) {
-      printf("%s: rados_write error %d\n", get_id_str(), ret);
+      printf("%s: rados_write(%s) failed with error: %d\n",
+	     get_id_str(), oid, ret);
       ret_val = ret;
       goto out;
     }


### PR DESCRIPTION
trying to get the oid of the rados_write() failure in http://tracker.ceph.com/issues/15240

Signed-off-by: Kefu Chai <kchai@redhat.com>