### PR TITLE
unittest_blkdev: fix test when /sys/block permission denied

### DIFF
--- a/src/test/common/test_blkdev.cc
+++ b/src/test/common/test_blkdev.cc
@@ -27,6 +27,8 @@ TEST(blkdev, get_block_device_base) {
     // work backwards
     sprintf(buf, "%s/sys/block", root);
     DIR *dir = opendir(buf);
+    if (*root == '\0' && errno == EACCES)
+      continue;
     ASSERT_TRUE(dir);
     while (!::readdir_r(dir, reinterpret_cast<struct dirent*>(buf), &de)) {
       if (!de)


### PR DESCRIPTION
./unittest_blkdev
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from blkdev
[ RUN      ] blkdev.get_block_device_base
base /dev/cciss!c0d1 (cciss!c0d1)
  got 'cciss!c0d1' expected 'cciss!c0d1'
  discard granularity = 512 .. supported = 1
base /dev/sda (sda)
  got 'sda' expected 'sda'
  discard granularity = 512 .. supported = 1
test/common/test_blkdev.cc:30: Failure
Value of: dir
  Actual: false
Expected: true
opendir(/sys/block) failed with: Permission denied
[  FAILED  ] blkdev.get_block_device_base (0 ms)
[----------] 1 test from blkdev (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (0 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] blkdev.get_block_device_base

 1 FAILED TEST