### PR TITLE
doc: amend Fixes instructions in SubmittingPatches

### DIFF
--- a/SubmittingPatches.rst
+++ b/SubmittingPatches.rst
@@ -405,7 +405,7 @@ feature.
    tracked by http://tracker.ceph.com, consider adding a ``Fixes:`` tag to
    connect this change to addressed issue(s). So a line saying ::
 
-     Fixes: #12345
+     Fixes: http://tracker.ceph.com/issues/12345
 
    is added before the ``Signed-off-by:`` line stating that this commit
    addresses http://tracker.ceph.com/issues/12345. It helps the reviewer to
@@ -419,7 +419,7 @@ feature.
      * update the man page for bar with the newly added "--foo" option.
      * fix a typo
 
-     Fixes: #12345
+     Fixes: http://tracker.ceph.com/issues/12345
      Signed-off-by: Random J Developer <random@developer.example.org>
 
 4. Separate your changes.


### PR DESCRIPTION
Since the "Fixes: #..." line is interpreted by GitHub as referring to a
pull request, yet the intention is for it to refer to the tracker issue,
change our instructions to use the full tracker issue URL.

Now that github pull request numbers are in the 8000s, there are cases when
a PR is wrongly closed by a "Fixes: #..." line in a commit message. See

https://github.com/ceph/ceph/pull/8286#event-603120191

for one such case.

Signed-off-by: Nathan Cutler <ncutler@suse.com>