### PR TITLE
unittest_erasure_code_plugin: fix deadlock (Alpine)

### DIFF
--- a/src/test/erasure-code/TestErasureCodePlugin.cc
+++ b/src/test/erasure-code/TestErasureCodePlugin.cc
@@ -30,13 +30,21 @@ protected:
 
   class Thread_factory : public Thread {
   public:
+    static void cleanup(void *arg) {
+      ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
+      if (instance.lock.is_locked())
+        instance.lock.Unlock();
+    }
+
     virtual void *entry() {
       ErasureCodeProfile profile;
       ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
       ErasureCodeInterfaceRef erasure_code;
+      pthread_cleanup_push(cleanup, NULL);
       instance.factory("hangs",
 		       g_conf->erasure_code_dir,
 		       profile, &erasure_code, &cerr);
+      pthread_cleanup_pop(0);
       return NULL;
     }
   };


### PR DESCRIPTION
./unittest_erasure_code_plugin
2016-03-25 22:59:03.970835 6e8e4acfbc50 -1 did not load config file, using default settings.
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from ErasureCodePluginRegistryTest
[ RUN      ] ErasureCodePluginRegistryTest.factory_mutex
Trying (1) with delay 0us
Trying (1) with delay 2us
[       OK ] ErasureCodePluginRegistryTest.factory_mutex (0 ms)
[ RUN      ] ErasureCodePluginRegistryTest.all