### PR TITLE
osd: duplicated clear for peer_missing

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4995,7 +4995,6 @@ void PG::start_peering_interval(
   state_clear(PG_STATE_RECOVERY_WAIT);
   state_clear(PG_STATE_RECOVERING);
 
-  peer_missing.clear();
   peer_purged.clear();
   actingbackfill.clear();
   snap_trim_queued = false;


### PR DESCRIPTION
peering_missing is also cleared in clear_primary_state

Signed-off-by: Ning Yao <yaoning@unitedstack.com>