### PR TITLE
Gentoo support for ceph-disk / ceph-detect-init; pip speedup

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -19,13 +19,16 @@ from ceph_detect_init import exc
 from ceph_detect_init import fedora
 from ceph_detect_init import rhel
 from ceph_detect_init import suse
+from ceph_detect_init import gentoo
 import logging
 import platform
 
 
 def get(use_rhceph=False):
     distro_name, release, codename = platform_information()
-    if not codename or not _get_distro(distro_name):
+    # Not all distributions have a concept that maps to codenames
+    # (or even releases really)
+    if not codename and not _get_distro(distro_name):
         raise exc.UnsupportedPlatform(
             distro=distro_name,
             codename=codename,
@@ -57,6 +60,9 @@ def _get_distro(distro, use_rhceph=False):
         'redhat': centos,
         'fedora': fedora,
         'suse': suse,
+        'gentoo': gentoo,
+        'funtoo': gentoo,
+        'exherbo': gentoo,
     }
 
     if distro == 'redhat' and use_rhceph:
@@ -75,6 +81,8 @@ def _normalized_distro_name(distro):
         return 'suse'
     elif distro.startswith('centos'):
         return 'centos'
+    elif distro.startswith(('gentoo', 'funtoo', 'exherbo')):
+        return 'gentoo'
     return distro
 
 

--- a/src/ceph-detect-init/ceph_detect_init/gentoo/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/gentoo/__init__.py
@@ -1,0 +1,37 @@
+import os
+distro = None
+release = None
+codename = None
+
+
+# From ceph-disk, but there is no way to access it since it's not in a module
+def is_systemd():
+    """
+    Detect whether systemd is running;
+    WARNING: not mutually exclusive with openrc
+    """
+    with open('/proc/1/comm', 'rb') as i:
+        for line in i:
+            if 'systemd' in line:
+                return True
+    return False
+
+
+def is_openrc():
+    """
+    Detect whether openrc is running.
+    """
+    OPENRC_CGROUP = '/sys/fs/cgroup/openrc'
+    return os.path.isdir(OPENRC_CGROUP)
+
+
+def choose_init():
+    """Select a init system
+
+    Returns the name of a init system (upstart, sysvinit ...).
+    """
+    if is_openrc():
+        return 'openrc'
+    if is_systemd():
+        return 'systemd'
+    return 'unknown'

--- a/src/ceph-detect-init/requirements.txt
+++ b/src/ceph-detect-init/requirements.txt
@@ -1,1 +1,0 @@
-argparse

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -211,6 +211,7 @@ INIT_SYSTEMS = [
     'upstart',
     'sysvinit',
     'systemd',
+    'openrc',
     'auto',
     'none',
 ]
@@ -2844,6 +2845,20 @@ def start_daemon(
                     'ceph-osd@{osd_id}'.format(osd_id=osd_id),
                 ],
             )
+        elif os.path.exists(os.path.join(path, 'openrc')):
+            base_script = '/etc/init.d/ceph-osd'
+            osd_script = '{base}.{osd_id}'.format(
+                base=base_script,
+                osd_id=osd_id
+            )
+            if not os.path.exists(osd_script):
+                os.symlink(base_script, osd_script)
+            command_check_call(
+                [
+                    osd_script,
+                    'start',
+                ],
+            )
         else:
             raise Error('{cluster} osd.{osd_id} is not tagged '
                         'with an init system'.format(
@@ -2899,6 +2914,13 @@ def stop_daemon(
                     'systemctl',
                     'stop',
                     'ceph-osd@{osd_id}'.format(osd_id=osd_id),
+                ],
+            )
+        elif os.path.exists(os.path.join(path, 'openrc')):
+            command_check_call(
+                [
+                    '/etc/init.d/ceph-osd.{osd_id}'.format(osd_id=osd_id),
+                    'stop',
                 ],
             )
         else:

--- a/src/ceph-disk/requirements.txt
+++ b/src/ceph-disk/requirements.txt
@@ -1,1 +1,0 @@
-argparse


### PR DESCRIPTION
Done because this was very useful while testing static-sites.