### PR TITLE
test/system/*: use dynamically generated pool name

### DIFF
--- a/src/test/system/rados_delete_pools_parallel.cc
+++ b/src/test/system/rados_delete_pools_parallel.cc
@@ -57,7 +57,7 @@ const char *get_id_str()
 int main(int argc, const char **argv)
 {
   const char *num_objects = getenv("NUM_OBJECTS");
-  std::string pool = "foo";
+  const std::string pool = get_temp_pool_name(argv[0]);
   if (num_objects) {
     g_num_objects = atoi(num_objects); 
     if (g_num_objects == 0)

--- a/src/test/system/rados_list_parallel.cc
+++ b/src/test/system/rados_list_parallel.cc
@@ -221,7 +221,7 @@ const char *get_id_str()
 int main(int argc, const char **argv)
 {
   const char *num_objects = getenv("NUM_OBJECTS");
-  std::string pool = "foo." + stringify(getpid());
+  const std::string pool = get_temp_pool_name(argv[0]);
   if (num_objects) {
     g_num_objects = atoi(num_objects); 
     if (g_num_objects == 0)

--- a/src/test/system/rados_open_pools_parallel.cc
+++ b/src/test/system/rados_open_pools_parallel.cc
@@ -49,9 +49,13 @@ class StRadosOpenPool : public SysTestRunnable
 {
 public:
   StRadosOpenPool(int argc, const char **argv,
-		  CrossProcessSem *pool_setup_sem, CrossProcessSem *open_pool_sem)
+                  CrossProcessSem *pool_setup_sem,
+                  CrossProcessSem *open_pool_sem,
+                  const std::string& pool_name)
     : SysTestRunnable(argc, argv),
-      m_pool_setup_sem(pool_setup_sem), m_open_pool_sem(open_pool_sem)
+      m_pool_setup_sem(pool_setup_sem),
+      m_open_pool_sem(open_pool_sem),
+      m_pool_name(pool_name)
   {
   }
 
@@ -74,10 +78,10 @@ public:
       m_pool_setup_sem->wait();
 
     printf("%s: rados_pool_create.\n", get_id_str());
-    rados_pool_create(cl, "foo");
+    rados_pool_create(cl, m_pool_name.c_str());
     rados_ioctx_t io_ctx;
     printf("%s: rados_ioctx_create.\n", get_id_str());
-    RETURN1_IF_NOT_VAL(0, rados_ioctx_create(cl, "foo", &io_ctx));
+    RETURN1_IF_NOT_VAL(0, rados_ioctx_create(cl, m_pool_name.c_str(), &io_ctx));
     if (m_open_pool_sem)
       m_open_pool_sem->post();
     rados_ioctx_destroy(io_ctx);
@@ -88,6 +92,7 @@ public:
 private:
   CrossProcessSem *m_pool_setup_sem;
   CrossProcessSem *m_open_pool_sem;
+  std::string m_pool_name;
 };
 
 const char *get_id_str()
@@ -97,13 +102,14 @@ const char *get_id_str()
 
 int main(int argc, const char **argv)
 {
+  const std::string pool = get_temp_pool_name(argv[0]);
   // first test: create a pool, shut down the client, access that 
   // pool in a different process.
   CrossProcessSem *pool_setup_sem = NULL;
   RETURN1_IF_NONZERO(CrossProcessSem::create(0, &pool_setup_sem));
   StRadosCreatePool r1(argc, argv, NULL, pool_setup_sem, NULL,
-					   "foo", 50, ".obj");
-  StRadosOpenPool r2(argc, argv, pool_setup_sem, NULL);
+					   pool, 50, ".obj");
+  StRadosOpenPool r2(argc, argv, pool_setup_sem, NULL, pool);
   vector < SysTestRunnable* > vec;
   vec.push_back(&r1);
   vec.push_back(&r2);
@@ -120,8 +126,8 @@ int main(int argc, const char **argv)
   CrossProcessSem *open_pool_sem2 = NULL;
   RETURN1_IF_NONZERO(CrossProcessSem::create(0, &open_pool_sem2));
   StRadosCreatePool r3(argc, argv, NULL, pool_setup_sem2, open_pool_sem2,
-					   "foo", 50, ".obj");
-  StRadosOpenPool r4(argc, argv, pool_setup_sem2, open_pool_sem2);
+					   pool, 50, ".obj");
+  StRadosOpenPool r4(argc, argv, pool_setup_sem2, open_pool_sem2, pool);
   vector < SysTestRunnable* > vec2;
   vec2.push_back(&r3);
   vec2.push_back(&r4);

--- a/src/test/system/st_rados_create_pool.cc
+++ b/src/test/system/st_rados_create_pool.cc
@@ -22,6 +22,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <sstream>
 #include <string>
 
@@ -112,4 +113,18 @@ out:
   rados_ioctx_destroy(io_ctx);
   rados_shutdown(cl);
   return ret_val;
+}
+
+std::string get_temp_pool_name(const char* prefix)
+{
+  assert(prefix);
+  char hostname[80];
+  int ret = 0;
+  ret = gethostname(hostname, sizeof(hostname));
+  assert(!ret);
+  char poolname[256];
+  ret = snprintf(poolname, sizeof(poolname),
+                 "%s.%s-%d", prefix, hostname, getpid());
+  assert(ret < sizeof(poolname));
+  return poolname;
 }

--- a/src/test/system/st_rados_create_pool.h
+++ b/src/test/system/st_rados_create_pool.h
@@ -48,4 +48,6 @@ private:
   std::string m_suffix;
 };
 
+std::string get_temp_pool_name(const char* prefix);
+
 #endif

--- a/src/test/system/st_rados_list_objects.cc
+++ b/src/test/system/st_rados_list_objects.cc
@@ -36,6 +36,7 @@ StRadosListObjects(int argc, const char **argv,
 		   CrossProcessSem *midway_sem_wait,
 		   CrossProcessSem *midway_sem_post)
   : SysTestRunnable(argc, argv),
+    m_pool_name(pool_name),
     m_accept_list_errors(accept_list_errors),
     m_midway_cnt(midway_cnt),
     m_pool_setup_sem(pool_setup_sem),
@@ -63,8 +64,8 @@ run()
   m_pool_setup_sem->post();
 
   rados_ioctx_t io_ctx;
-  rados_pool_create(cl, "foo");
-  RETURN1_IF_NONZERO(rados_ioctx_create(cl, "foo", &io_ctx));
+  rados_pool_create(cl, m_pool_name.c_str());
+  RETURN1_IF_NONZERO(rados_ioctx_create(cl, m_pool_name.c_str(), &io_ctx));
 
   int saw = 0;
   const char *obj_name;

--- a/src/test/system/systest_runnable.h
+++ b/src/test/system/systest_runnable.h
@@ -36,7 +36,7 @@
   RETURN1_IF_NOT_VAL(0, expr)
 
 extern void* systest_runnable_pthread_helper(void *arg);
-
+std::string get_temp_pool_name(const char* prefix);
 /* Represents a single test thread / process.
  *
  * Inherit from this class and implement the test body in run().


### PR DESCRIPTION
was using "foo" for the pool name. this works if we are performing
tests in serial. but if we do it in parallel, the tests interfere
with each other.

Fixes: #15240
Signed-off-by: Kefu Chai <kchai@redhat.com>