### PR TITLE
Makefile-env.am: set a default for CEPH_BUILD_VIRTUALENV (part 2)

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -19,6 +19,7 @@
 #
 TIMEOUT=300
 PG_NUM=4
+: ${CEPH_BUILD_VIRTUALENV:=/tmp}
 
 if type xmlstarlet > /dev/null 2>&1; then
     XMLSTARLET=xmlstarlet
@@ -1313,7 +1314,7 @@ function main() {
     shopt -s -o xtrace
     PS4='${BASH_SOURCE[0]}:$LINENO: ${FUNCNAME[0]}:  '
 
-    export PATH=ceph-disk/ceph-disk-virtualenv/bin:ceph-detect-init/ceph-detect-init-virtualenv/bin:.:$PATH # make sure program from sources are prefered
+    export PATH=${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv/bin:${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-virtualenv/bin:.:$PATH # make sure program from sources are prefered
 
     export CEPH_CONF=/dev/null
     unset CEPH_ARGS
@@ -1335,7 +1336,7 @@ function run_tests() {
     shopt -s -o xtrace
     PS4='${BASH_SOURCE[0]}:$LINENO: ${FUNCNAME[0]}:  '
 
-    export PATH=ceph-disk/ceph-disk-virtualenv/bin:ceph-detect-init/ceph-detect-init-virtualenv/bin:.:$PATH # make sure program from sources are prefered
+    export PATH=${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv/bin:${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-virtualenv/bin:.:$PATH # make sure program from sources are prefered
 
     export CEPH_MON="127.0.0.1:7109" # git grep '\<7109\>' : there must be only one
     export CEPH_ARGS

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -297,7 +297,8 @@ LIBCIVETWEB_DEPS =
 DENCODER_SOURCES =
 DENCODER_DEPS =
 
-# put virtualenvs in this directory for build
-CEPH_BUILD_VIRTUALENV="/tmp/"
+# put virtualenvs in this directory
+# otherwise it may overflow #! 80 kernel limit
+export CEPH_BUILD_VIRTUALENV = /tmp
 
 radoslibdir = $(libdir)/rados-classes

--- a/src/ceph-detect-init/Makefile.am
+++ b/src/ceph-detect-init/Makefile.am
@@ -53,7 +53,7 @@ EXTRA_DIST += \
 	ceph-detect-init/tests/test_all.py \
 	ceph-detect-init/tox.ini
 
-export CEPH_DETECT_INIT_VIRTUALENV = ${CEPH_BUILD_VIRTUALENV}ceph-detect-init-virtualenv
+export CEPH_DETECT_INIT_VIRTUALENV = ${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-virtualenv
 
 ceph-detect-init-all: ${CEPH_DETECT_INIT_VIRTUALENV}
 

--- a/src/ceph-disk/Makefile.am
+++ b/src/ceph-disk/Makefile.am
@@ -29,7 +29,7 @@ EXTRA_DIST += \
 	ceph-disk/tests/test_main.py \
 	ceph-disk/tox.ini
 
-export CEPH_DISK_VIRTUALENV = ${CEPH_BUILD_VIRTUALENV}ceph-disk-virtualenv
+export CEPH_DISK_VIRTUALENV = ${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv
 
 ceph-disk-all: ${CEPH_DISK_VIRTUALENV}
 


### PR DESCRIPTION
The new default must be taken into account by make check scripts
otherwise they fail.

Signed-off-by: Loic Dachary <loic@dachary.org>