### PR TITLE
rgw_file: set owner uid, gid, and Unix mode on new objects

### DIFF
--- a/src/include/rados/rgw_file.h
+++ b/src/include/rados/rgw_file.h
@@ -128,15 +128,23 @@ int rgw_statfs(struct rgw_fs *rgw_fs,
 	       uint32_t flags);
 
 
+/* XXX (get|set)attr mask bits */
+#define RGW_SETATTR_MODE   1
+#define RGW_SETATTR_UID    2
+#define RGW_SETATTR_GID    4
+#define RGW_SETATTR_MTIME  8
+#define RGW_SETATTR_ATIME 16
+#define RGW_SETATTR_SIZE  32
+#define RGW_SETATTR_CTIME 64
+
 /*
   create file
 */
 #define RGW_CREATE_FLAG_NONE     0x0000
 
-int rgw_create(struct rgw_fs *rgw_fs,
-	       struct rgw_file_handle *parent_fh,
-	       const char *name, mode_t mode, struct stat *st,
-	       struct rgw_file_handle **fh, uint32_t flags);
+int rgw_create(struct rgw_fs *rgw_fs, struct rgw_file_handle *parent_fh,
+	      const char *name, struct stat *st, uint32_t mask,
+	      struct rgw_file_handle **fh, uint32_t flags);
 
 /*
   create a new directory
@@ -145,7 +153,7 @@ int rgw_create(struct rgw_fs *rgw_fs,
 
 int rgw_mkdir(struct rgw_fs *rgw_fs,
 	      struct rgw_file_handle *parent_fh,
-	      const char *name, mode_t mode, struct stat *st,
+	      const char *name, struct stat *st, uint32_t mask,
 	      struct rgw_file_handle **fh, uint32_t flags);
 
 /*
@@ -179,15 +187,6 @@ int rgw_readdir(struct rgw_fs *rgw_fs,
 		struct rgw_file_handle *parent_fh, uint64_t *offset,
 		rgw_readdir_cb rcb, void *cb_arg, bool *eof,
 		uint32_t flags);
-
-/* XXX (get|set)attr mask bits */
-#define RGW_SETATTR_MODE   1
-#define RGW_SETATTR_UID    2
-#define RGW_SETATTR_GID    4
-#define RGW_SETATTR_MTIME  8
-#define RGW_SETATTR_ATIME 16
-#define RGW_SETATTR_SIZE  32
-#define RGW_SETATTR_CTIME 64
 
 /*
    get unix attributes for object

--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -37,6 +37,10 @@ namespace {
   string secret_key("");
   struct rgw_fs *fs = nullptr;
 
+  uint32_t owner_uid = 867;
+  uint32_t owner_gid = 5309;
+  uint32_t create_mask = RGW_SETATTR_UID | RGW_SETATTR_GID | RGW_SETATTR_MODE;
+
   bool do_create = false;
   bool do_delete = false;
   bool do_verify = false;
@@ -179,8 +183,13 @@ TEST(LibRGW, CREATE_BUCKET) {
   if (do_create) {
     struct stat st;
     struct rgw_file_handle *fh;
-    int ret = rgw_mkdir(fs, fs->root_fh, bucket_name.c_str(), 755, &st, &fh,
-			RGW_MKDIR_FLAG_NONE);
+
+    st.st_uid = owner_uid;
+    st.st_gid = owner_gid;
+    st.st_mode = 755;
+
+    int ret = rgw_mkdir(fs, fs->root_fh, bucket_name.c_str(), &st, create_mask,
+			&fh, RGW_MKDIR_FLAG_NONE);
     ASSERT_EQ(ret, 0);
   }
 }

--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -32,7 +32,7 @@
 
 namespace {
   librgw_t rgw = nullptr;
-  string uid("testuser");
+  string userid("testuser");
   string access_key("");
   string secret_key("");
   struct rgw_fs *fs = nullptr;
@@ -173,8 +173,8 @@ TEST(LibRGW, INIT) {
 }
 
 TEST(LibRGW, MOUNT) {
-  int ret = rgw_mount(rgw, uid.c_str(), access_key.c_str(), secret_key.c_str(),
-		      &fs, RGW_MOUNT_FLAG_NONE);
+  int ret = rgw_mount(rgw, userid.c_str(), access_key.c_str(),
+		      secret_key.c_str(), &fs, RGW_MOUNT_FLAG_NONE);
   ASSERT_EQ(ret, 0);
   ASSERT_NE(fs, nullptr);
 }
@@ -323,12 +323,18 @@ int main(int argc, char *argv[])
     } else if (ceph_argparse_witharg(args, arg_iter, &val, "--secret",
 				     (char*) nullptr)) {
       secret_key = val;
-    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--uid",
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--userid",
 				     (char*) nullptr)) {
-      uid = val;
+      userid = val;
     } else if (ceph_argparse_witharg(args, arg_iter, &val, "--bn",
 				     (char*) nullptr)) {
       bucket_name = val;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--uid",
+				     (char*) nullptr)) {
+      owner_uid = std::stoi(val);
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--gid",
+				     (char*) nullptr)) {
+      owner_gid = std::stoi(val);
     } else if (ceph_argparse_flag(args, arg_iter, "--verify",
 					    (char*) nullptr)) {
       do_verify = true;

--- a/src/test/librgw_file_cd.cc
+++ b/src/test/librgw_file_cd.cc
@@ -28,7 +28,7 @@
 
 namespace {
   librgw_t rgw = nullptr;
-  string uid("testuser");
+  string userid("testuser");
   string access_key("");
   string secret_key("");
   struct rgw_fs *fs = nullptr;
@@ -57,8 +57,8 @@ TEST(LibRGW, INIT) {
 }
 
 TEST(LibRGW, MOUNT) {
-  int ret = rgw_mount(rgw, uid.c_str(), access_key.c_str(), secret_key.c_str(),
-		      &fs, RGW_MOUNT_FLAG_NONE);
+  int ret = rgw_mount(rgw, userid.c_str(), access_key.c_str(),
+		      secret_key.c_str(), &fs, RGW_MOUNT_FLAG_NONE);
   ASSERT_EQ(ret, 0);
   ASSERT_NE(fs, nullptr);
 }
@@ -161,12 +161,18 @@ int main(int argc, char *argv[])
     } else if (ceph_argparse_witharg(args, arg_iter, &val, "--secret",
 				     (char*) nullptr)) {
       secret_key = val;
-    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--uid",
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--userid",
 				     (char*) nullptr)) {
-      uid = val;
+      userid = val;
     } else if (ceph_argparse_witharg(args, arg_iter, &val, "--bn",
 				     (char*) nullptr)) {
       bucket_name = val;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--uid",
+				     (char*) nullptr)) {
+      owner_uid = std::stoi(val);
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--gid",
+				     (char*) nullptr)) {
+      owner_gid = std::stoi(val);
     } else if (ceph_argparse_flag(args, arg_iter, "--create",
 					    (char*) nullptr)) {
       do_create = true;

--- a/src/test/librgw_file_cd.cc
+++ b/src/test/librgw_file_cd.cc
@@ -33,6 +33,10 @@ namespace {
   string secret_key("");
   struct rgw_fs *fs = nullptr;
 
+  uint32_t owner_uid = 867;
+  uint32_t owner_gid = 5309;
+  uint32_t create_mask = RGW_SETATTR_UID | RGW_SETATTR_GID | RGW_SETATTR_MODE;
+
   bool do_create = false;
   bool do_delete = false;
   bool do_multi = false;
@@ -63,8 +67,13 @@ TEST(LibRGW, CREATE_BUCKET) {
   if (do_create) {
     struct stat st;
     struct rgw_file_handle *fh;
-    int ret = rgw_mkdir(fs, fs->root_fh, bucket_name.c_str(), 755, &st, &fh,
-			RGW_MKDIR_FLAG_NONE);
+
+    st.st_uid = owner_uid;
+    st.st_gid = owner_gid;
+    st.st_mode = 755;
+
+    int ret = rgw_mkdir(fs, fs->root_fh, bucket_name.c_str(), &st, create_mask,
+			&fh, RGW_MKDIR_FLAG_NONE);
     ASSERT_EQ(ret, 0);
   }
 }
@@ -82,10 +91,15 @@ TEST(LibRGW, CREATE_BUCKET_MULTI) {
     int ret;
     struct stat st;
     struct rgw_file_handle *fh;
+
+    st.st_uid = owner_uid;
+    st.st_gid = owner_gid;
+    st.st_mode = 755;
+
     for (int ix = 0; ix < multi_cnt; ++ix) {
       string bn = bucket_name;
       bn += to_string(ix);
-      ret = rgw_mkdir(fs, fs->root_fh, bn.c_str(), 755, &st, &fh,
+      ret = rgw_mkdir(fs, fs->root_fh, bn.c_str(), &st, create_mask, &fh,
 		      RGW_MKDIR_FLAG_NONE);
       ASSERT_EQ(ret, 0);
       std::cout << "created: " << bn << std::endl;

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -38,7 +38,7 @@ namespace {
   using std::string;
 
   librgw_t rgw_h = nullptr;
-  string uid("testuser");
+  string userid("testuser");
   string access_key("");
   string secret_key("");
   struct rgw_fs *fs = nullptr;
@@ -179,7 +179,7 @@ TEST(LibRGW, INIT) {
 }
 
 TEST(LibRGW, MOUNT) {
-  int ret = rgw_mount(rgw_h, uid.c_str(), access_key.c_str(),
+  int ret = rgw_mount(rgw_h, userid.c_str(), access_key.c_str(),
 		      secret_key.c_str(), &fs, RGW_MOUNT_FLAG_NONE);
   ASSERT_EQ(ret, 0);
   ASSERT_NE(fs, nullptr);
@@ -996,12 +996,18 @@ int main(int argc, char *argv[])
     } else if (ceph_argparse_witharg(args, arg_iter, &val, "--secret",
 				     (char*) nullptr)) {
       secret_key = val;
-    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--uid",
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--userid",
 				     (char*) nullptr)) {
-      uid = val;
+      userid = val;
     } else if (ceph_argparse_witharg(args, arg_iter, &val, "--bn",
 				     (char*) nullptr)) {
       bucket_name = val;
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--uid",
+				     (char*) nullptr)) {
+      owner_uid = std::stoi(val);
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--gid",
+				     (char*) nullptr)) {
+      owner_gid = std::stoi(val);
     } else if (ceph_argparse_flag(args, arg_iter, "--hier1",
 					    (char*) nullptr)) {
       do_hier1 = true;

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -44,6 +44,10 @@ namespace {
   struct rgw_fs *fs = nullptr;
   CephContext* cct = nullptr;
 
+  uint32_t owner_uid = 867;
+  uint32_t owner_gid = 5309;
+  uint32_t create_mask = RGW_SETATTR_UID | RGW_SETATTR_GID | RGW_SETATTR_MODE;
+
   string bucket_name("nfsroot");
   string dirs1_bucket_name("bdirs1");
   string readf_name("toyland");
@@ -191,8 +195,13 @@ TEST(LibRGW, SETUP_HIER1)
     if (! bucket_fh) {
       if (do_create) {
 	struct stat st;
-	int rc = rgw_mkdir(fs, fs->root_fh, bucket_name.c_str(), 755, &st,
-			   &bucket_fh, RGW_MKDIR_FLAG_NONE);
+
+	st.st_uid = owner_uid;
+	st.st_gid = owner_gid;
+	st.st_mode = 755;
+
+	int rc = rgw_mkdir(fs, fs->root_fh, bucket_name.c_str(), &st,
+			  create_mask, &bucket_fh, RGW_MKDIR_FLAG_NONE);
 	ASSERT_EQ(rc, 0);
       }
     }
@@ -239,6 +248,10 @@ TEST(LibRGW, SETUP_DIRS1) {
     int rc;
     struct stat st;
 
+    st.st_uid = owner_uid;
+    st.st_gid = owner_gid;
+    st.st_mode = 755;
+
     dirs1_b.parent_fh = fs->root_fh;
 
     (void) rgw_lookup(fs, dirs1_b.parent_fh, dirs1_bucket_name.c_str(),
@@ -246,8 +259,8 @@ TEST(LibRGW, SETUP_DIRS1) {
 
     if (! dirs1_b.fh) {
       if (do_create) {
-	rc = rgw_mkdir(fs, dirs1_b.parent_fh, dirs1_b.name.c_str(), 755, &st,
-		       &dirs1_b.fh, RGW_MKDIR_FLAG_NONE);
+	rc = rgw_mkdir(fs, dirs1_b.parent_fh, dirs1_b.name.c_str(), &st,
+		      create_mask, &dirs1_b.fh, RGW_MKDIR_FLAG_NONE);
 	ASSERT_EQ(rc, 0);
       }
     }
@@ -266,7 +279,7 @@ TEST(LibRGW, SETUP_DIRS1) {
 			RGW_LOOKUP_FLAG_NONE);
       if (! dir.fh) {
 	if (do_create) {
-	  rc = rgw_mkdir(fs, dir.parent_fh, dir.name.c_str(), 755, &st,
+	  rc = rgw_mkdir(fs, dir.parent_fh, dir.name.c_str(), &st, create_mask,
 			 &dir.fh, RGW_MKDIR_FLAG_NONE);
 	  ASSERT_EQ(rc, 0);
 	}
@@ -289,8 +302,8 @@ TEST(LibRGW, SETUP_DIRS1) {
 
 	if (! sdir.fh) {
 	  if (do_create) {
-	    rc = rgw_mkdir(fs, sdir.parent_fh, sdir.name.c_str(), 755,
-			   &st, &sdir.fh, RGW_MKDIR_FLAG_NONE);
+	    rc = rgw_mkdir(fs, sdir.parent_fh, sdir.name.c_str(), &st,
+			  create_mask, &sdir.fh, RGW_MKDIR_FLAG_NONE);
 	    ASSERT_EQ(rc, 0);
 	  }
 	}
@@ -352,6 +365,11 @@ TEST(LibRGW, RGW_CREATE_DIRS1) {
     if (do_create) {
       int rc;
       struct stat st;
+
+      st.st_uid = owner_uid;
+      st.st_gid = owner_gid;
+      st.st_mode = 644;
+
       for (auto& dirs_rec : dirs_vec) {
 	/* create 1 more file in each sdir */
 	obj_rec& dir = get<0>(dirs_rec);
@@ -360,8 +378,8 @@ TEST(LibRGW, RGW_CREATE_DIRS1) {
 	(void) rgw_lookup(fs, sf.parent_fh, sf.name.c_str(), &sf.fh,
 			  RGW_LOOKUP_FLAG_NONE);
 	if (! sf.fh) {
-	  rc = rgw_create(fs, sf.parent_fh, sf.name.c_str(), 644, &st, &sf.fh,
-			  RGW_CREATE_FLAG_NONE);
+	  rc = rgw_create(fs, sf.parent_fh, sf.name.c_str(), &st, create_mask,
+			  &sf.fh, RGW_CREATE_FLAG_NONE);
 	  ASSERT_EQ(rc, 0);
 	}
 	sf.sync();
@@ -377,6 +395,11 @@ TEST(LibRGW, RGW_SETUP_RENAME1) {
     int rc;
     struct stat st;
     obj_vec ovec;
+
+    st.st_uid = owner_uid;
+    st.st_gid = owner_gid;
+    st.st_mode = 755;
+
     for (int b_ix : {0, 1}) {
       std::string bname{"brename_" + to_string(b_ix)};
       obj_rec brec{bname, nullptr, nullptr, nullptr};
@@ -385,13 +408,16 @@ TEST(LibRGW, RGW_SETUP_RENAME1) {
       if (! brec.fh) {
 	if (do_create) {
 	  struct stat st;
-	  int rc = rgw_mkdir(fs, fs->root_fh, brec.name.c_str(), 755, &st,
-			     &brec.fh, RGW_MKDIR_FLAG_NONE);
+	  int rc = rgw_mkdir(fs, fs->root_fh, brec.name.c_str(), &st,
+			    create_mask, &brec.fh, RGW_MKDIR_FLAG_NONE);
 	  ASSERT_EQ(rc, 0);
 	}
       }
       ASSERT_NE(brec.fh, nullptr);
       brec.sync();
+
+      st.st_mode = 644; /* file mask */
+
       for (int f_ix : {0, 1}) {
 	std::string rfname{"rfile_"};
 	rfname += to_string(f_ix);
@@ -399,8 +425,8 @@ TEST(LibRGW, RGW_SETUP_RENAME1) {
 	(void) rgw_lookup(fs, rf.parent_fh, rf.name.c_str(), &rf.fh,
 			  RGW_LOOKUP_FLAG_NONE);
 	if (! rf.fh) {
-	  rc = rgw_create(fs, rf.parent_fh, rf.name.c_str(), 644, &st, &rf.fh,
-			  RGW_CREATE_FLAG_NONE);
+	  rc = rgw_create(fs, rf.parent_fh, rf.name.c_str(), &st, create_mask,
+			  &rf.fh, RGW_CREATE_FLAG_NONE);
 	  ASSERT_EQ(rc, 0);
 	}
 	rf.sync();
@@ -796,9 +822,13 @@ TEST(LibRGW, MARKER1_SETUP_BUCKET) {
     struct stat st;
     int ret;
 
+    st.st_uid = owner_uid;
+    st.st_gid = owner_gid;
+    st.st_mode = 755;
+
     if (do_create) {
-      ret = rgw_mkdir(fs, bucket_fh, marker_dir.c_str(), 755, &st, &marker_fh,
-		      RGW_MKDIR_FLAG_NONE);
+      ret = rgw_mkdir(fs, bucket_fh, marker_dir.c_str(), &st, create_mask,
+		      &marker_fh, RGW_MKDIR_FLAG_NONE);
     } else {
       ret = rgw_lookup(fs, bucket_fh, marker_dir.c_str(), &marker_fh,
 		       RGW_LOOKUP_FLAG_NONE);


### PR DESCRIPTION
Unix attributes aren't current materialized, but a future change
will serialize them in a new object attribute.

Also moves create and mkdir into operations on RGWLibFS, which
better encapsulates the behavior.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>