### PR TITLE
mon: remove remove_legacy_versions()

### DIFF
--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -425,24 +425,7 @@ bool Paxos::store_state(MMonPaxos *m)
     changed = true;
   }
 
-  remove_legacy_versions();
-
   return changed;
-}
-
-void Paxos::remove_legacy_versions()
-{
-  if (get_store()->exists(get_name(), "conversion_first")) {
-    MonitorDBStore::TransactionRef t(new MonitorDBStore::Transaction);
-    version_t v = get_store()->get(get_name(), "conversion_first");
-    dout(10) << __func__ << " removing pre-conversion paxos states from " << v
-	     << " until " << first_committed << dendl;
-    for (; v < first_committed; ++v) {
-      t->erase(get_name(), v);
-    }
-    t->erase(get_name(), "conversion_first");
-    get_store()->apply_transaction(t);
-  }
 }
 
 void Paxos::_sanity_check_store()
@@ -900,8 +883,6 @@ void Paxos::commit_finish()
 
   // get ready for a new round.
   new_value.clear();
-
-  remove_legacy_versions();
 
   // WRITING -> REFRESH
   // among other things, this lets do_refresh() -> mon->bootstrap() know

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -1188,11 +1188,6 @@ public:
   void _sanity_check_store();
 
   /**
-   * remove legacy paxos versions from before conversion
-   */
-  void remove_legacy_versions();
-
-  /**
    * Helper function to decode a bufferlist into a transaction and append it
    * to another transaction.
    *

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -144,26 +144,6 @@ void PaxosService::post_refresh()
   }
 }
 
-void PaxosService::remove_legacy_versions()
-{
-  dout(10) << __func__ << dendl;
-  if (!mon->store->exists(get_service_name(), "conversion_first"))
-    return;
-
-  version_t cf = mon->store->get(get_service_name(), "conversion_first");
-  version_t fc = get_first_committed();
-
-  dout(10) << __func__ << " conversion_first " << cf
-	   << " first committed " << fc << dendl;
-
-  MonitorDBStore::TransactionRef t(new MonitorDBStore::Transaction);
-  if (cf < fc) {
-    trim(t, cf, fc);
-  }
-  t->erase(get_service_name(), "conversion_first");
-  mon->store->apply_transaction(t);
-}
-
 bool PaxosService::should_propose(double& delay)
 {
   // simple default policy: quick startup, then some damping.
@@ -277,8 +257,6 @@ void PaxosService::_active()
     return;
   }
   dout(10) << "_active" << dendl;
-
-  remove_legacy_versions();
 
   // create pending state?
   if (mon->is_leader() && is_active()) {

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -257,11 +257,6 @@ private:
    *	   active
    */
   void _active();
-  /**
-   * Scrub our versions after we convert the store from the old layout to
-   * the new k/v store.
-   */
-  void remove_legacy_versions();
 
 public:
   /**


### PR DESCRIPTION
as it's required to upgrade to hammer before moving to jewel, and
hammer is already using the single-paxos monitor. and we convert
the store.db when starting up from an old monitor (bobtail). we
stopped the conversion since 1d814b7.

Signed-off-by: Kefu Chai <kchai@redhat.com>