### PR TITLE
Fixes headline different font size and type

### DIFF
--- a/doc/rbd/libvirt.rst
+++ b/doc/rbd/libvirt.rst
@@ -1,5 +1,5 @@
 =================================
- Using ``libvirt`` with Ceph RBD
+ Using libvirt with Ceph RBD
 =================================
 
 .. index:: Ceph Block Device; livirt


### PR DESCRIPTION
Which makes headline of http://docs.ceph.com/docs/master/rbd/libvirt/
looks ugly.