### PR TITLE
common: fix race during optracker switches between enabled/disabled mode

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -164,6 +164,7 @@ void OpTracker::unregister_inflight_op(TrackedOp *i)
   }
   i->_unregistered();
 
+  RWLock::RLocker l(lock);
   if (!tracking_enabled)
     delete i;
   else {


### PR DESCRIPTION
The RWLock lock is made private to protect tracking_enabled changing
but we are reading tracking_enabled beyond its protection during
unregister_inflight_op(). So this is a slight race conditon.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>