### PR TITLE
script: subscription-manager support (part 3)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1190,6 +1190,8 @@ fi
 %{_mandir}/man8/ceph-disk.8*
 %{_mandir}/man8/ceph-osd.8*
 %if 0%{?rhel} && ! 0%{?centos}
+%exclude /etc/cron.hourly/subman.pyc
+%exclude /etc/cron.hourly/subman.pyo
 /etc/cron.hourly/subman
 %endif
 %if 0%{?_with_systemd}


### PR DESCRIPTION
Renaming subman.py in subman is cute but does not prevent the generation
of the py[co]. Exclude them explicitly from packaging instead.

Signed-off-by: Loic Dachary <loic@dachary.org>