### PR TITLE
script: subscription-manager support (part 3)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -155,7 +155,7 @@ ceph_libexec_SCRIPTS = ceph_common.sh ceph-osd-prestart.sh
 
 if ENABLE_SUBMAN
 submandir = /etc/cron.hourly
-subman_SCRIPTS = script/subman
+subman_DATA = script/subman
 endif
 
 # tests to actually run on "make check"; if you need extra, non-test,

--- a/src/script/subman
+++ b/src/script/subman
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python -B
 
 import json
 import re


### PR DESCRIPTION
Renaming subman.py in subman is cute but does not prevent the generation
of the py[co]. Exclude them explicitly from packaging instead.

Signed-off-by: Loic Dachary <loic@dachary.org>