### PR TITLE
mon/MonClient: fix shutdown race

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -426,6 +426,11 @@ void MonClient::shutdown()
     waiting_for_session.pop_front();
   }
 
+  if (cur_con)
+    cur_con->mark_down();
+  cur_con.reset(NULL);
+  cur_mon.clear();
+
   monc_lock.Unlock();
 
   if (initialized) {
@@ -433,11 +438,6 @@ void MonClient::shutdown()
   }
   monc_lock.Lock();
   timer.shutdown();
-
-  if (cur_con)
-    cur_con->mark_down();
-  cur_con.reset(NULL);
-  cur_mon.clear();
 
   monc_lock.Unlock();
 }


### PR DESCRIPTION
While we are shutting down, we should drop all subsequent mon
messages.  Currently it is possible to finish the authentication
sequence *while* we are shutting down, such that a subsequent
attempt to authenticate succeeds.

Fix this by resetting cur_con early in the sequence, as this
makes us drop all incoming messages.

Fixes: http://tracker.ceph.com/issues/13992
Signed-off-by: Sage Weil <sage@redhat.com>