### PR TITLE
mon/MDSMonitor: fix warning

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2112,7 +2112,6 @@ int MDSMonitor::filesystem_command(
 {
   dout(4) << __func__ << " prefix='" << prefix << "'" << dendl;
   op->mark_mdsmon_event(__func__);
-  MMonCommand *m = static_cast<MMonCommand*>(op->get_req());
   int r = 0;
   string whostr;
   cmd_getval(g_ceph_context, cmdmap, "who", whostr);


### PR DESCRIPTION
mon/MDSMonitor.cc: In member function ‘int MDSMonitor::filesystem_command(MonOpRequestRef, const string&, std::map<std::basic_string<char>, boost::variant<std::basic_string<char>, bool, long int, double, std::vector<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > >&, std::stringstream&)’:
mon/MDSMonitor.cc:2115:16: warning: unused variable ‘m’ [-Wunused-variable]
   MMonCommand *m = static_cast<MMonCommand*>(op->get_req());
                ^

Signed-off-by: Sage Weil <sage@redhat.com>