### PR TITLE
erasure: fix up failing to find atexit symbol when make check-coverage

### DIFF
--- a/src/erasure-code/lrc/Makefile.am
+++ b/src/erasure-code/lrc/Makefile.am
@@ -12,7 +12,7 @@ erasure-code/lrc/ErasureCodePluginLrc.cc: ./ceph_ver.h
 libec_lrc_la_SOURCES = ${lrc_sources} common/str_map.cc
 libec_lrc_la_CFLAGS = ${AM_CFLAGS}
 libec_lrc_la_CXXFLAGS= ${AM_CXXFLAGS}
-libec_lrc_la_LIBADD = $(LIBCRUSH) $(PTHREAD_LIBS) $(LIBJSON_SPIRIT)
+libec_lrc_la_LIBADD = $(LIBCRUSH) $(PTHREAD_LIBS) $(LIBJSON_SPIRIT) $(EXTRALIBS)
 libec_lrc_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
 if LINUX
 libec_lrc_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'


### PR DESCRIPTION
fix up failing to find atexit symbol when make check-coverage
Fixes: http://tracker.ceph.com/issues/14149

Signed-off-by: song shun song.shun3@zte.com.cn
