### PR TITLE
librados: ObjectWriteOperation::snap_rollback is unnecessary

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -383,15 +383,6 @@ namespace librados
     void selfmanaged_snap_rollback(uint64_t snapid);
 
     /**
-     * Rollback an object to the specified snapshot id
-     *
-     * Used with pool snapshots
-     *
-     * @param snapid [in] snopshot id specified
-     */
-    void snap_rollback(uint64_t snapid);
-
-    /**
      * set keys and values according to map
      *
      * @param map [in] keys and values to set

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -533,13 +533,6 @@ void librados::ObjectWriteOperation::selfmanaged_snap_rollback(snap_t snapid)
   o->rollback(snapid);
 }
 
-// You must specify the snapid not the name normally used with pool snapshots
-void librados::ObjectWriteOperation::snap_rollback(snap_t snapid)
-{
-  ::ObjectOperation *o = &impl->o;
-  o->rollback(snapid);
-}
-
 void librados::ObjectWriteOperation::set_alloc_hint(
                                             uint64_t expected_object_size,
                                             uint64_t expected_write_size)

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -1536,11 +1536,7 @@ public:
     zero_write_op1.append(bl);
     zero_write_op2.append(bl2);
 
-    if (context->pool_snaps) {
-      op.snap_rollback(snap);
-    } else {
-      op.selfmanaged_snap_rollback(snap);
-    }
+    op.selfmanaged_snap_rollback(snap);
 
     if (existed_before) {
       pair<TestOp*, TestOp::CallbackInfo*> *cb_arg =


### PR DESCRIPTION
The function of ObjectWriteOperation::snap_rollback and ObjectWriteOperation::selfmanaged_snap_rollback are the same,
and in the TestOp::RollbackOp::_begin to distinguish is redundant

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>