### PR TITLE
msg/async: AF_UNIX socket support

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -205,6 +205,10 @@ OPTION(ms_async_set_affinity, OPT_BOOL, true)
 OPTION(ms_async_affinity_cores, OPT_STR, "")
 OPTION(ms_async_send_inline, OPT_BOOL, true)
 
+OPTION(ms_async_use_local_socket, OPT_BOOL, false) // should async msgr use AF_UNIX sockets for communication on localhost?
+OPTION(ms_async_require_local_socket, OPT_BOOL, false) // should local socket bind error be fatal?
+OPTION(ms_async_sndbuf, OPT_INT, 0) // local socket send buffer size
+
 OPTION(inject_early_sigterm, OPT_BOOL, false)
 
 OPTION(mon_data, OPT_STR, "/var/lib/ceph/mon/$cluster-$id")

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -21,6 +21,7 @@
 #include "uuid.h"
 
 #include <netinet/in.h>
+#include <sys/un.h>
 #include <fcntl.h>
 #include <string.h>
 

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -32,7 +32,7 @@
 #undef dout_prefix
 #define dout_prefix _conn_prefix(_dout)
 ostream& AsyncConnection::_conn_prefix(std::ostream *_dout) {
-  return *_dout << "-- " << async_msgr->get_myinst().addr << " >> " << peer_addr << " conn(" << this
+  return *_dout << "-- " << async_msgr->get_myinst().addr << " >> " << established_peer_addr << " conn(" << this
                 << " sd=" << sd << " :" << port
                 << " s=" << get_state_name(state)
                 << " pgs=" << peer_global_seq
@@ -1036,8 +1036,9 @@ ssize_t AsyncConnection::_process_connection()
           center->delete_file_event(sd, EVENT_READABLE|EVENT_WRITABLE);
           ::close(sd);
         }
+        established_peer_addr = async_msgr->try_unixify(get_peer_addr(), peer_type);
+        sd = net.nonblock_connect(established_peer_addr);
 
-        sd = net.nonblock_connect(get_peer_addr());
         if (sd < 0) {
           goto fail;
         }
@@ -1049,7 +1050,9 @@ ssize_t AsyncConnection::_process_connection()
 
     case STATE_CONNECTING_RE:
       {
-        r = net.reconnect(get_peer_addr(), sd);
+        // this works because established_peer_addr is either actually an unix addr
+        // or clone of addr.
+        r = net.reconnect(established_peer_addr, sd);
         if (r < 0) {
           ldout(async_msgr->cct, 1) << __func__ << " reconnect failed " << dendl;
           goto fail;
@@ -1153,6 +1156,26 @@ ssize_t AsyncConnection::_process_connection()
           ldout(async_msgr->cct, 1) << __func__ << " state changed while learned_addr, mark_down or "
                                     << " replacing must be happened just now" << dendl;
           return 0;
+        }
+
+        // are we connected through TCP? can we connect through AF_UNIX?
+        // if so, drop existing TCP conenction and reconnect to UNIX socket
+        if (established_peer_addr.addr.ss_family != AF_UNIX) {
+          established_peer_addr = async_msgr->try_unixify(get_peer_addr(), peer_type);
+          if (established_peer_addr.addr.ss_family == AF_UNIX) {
+              // there is an unix socket for this peer, check if we're connected
+              // using TCP.
+              sockaddr_storage other;
+              socklen_t len = sizeof(other);
+              // Failure of getpeername is not fatal here.
+              r = ::getpeername(sd, (sockaddr*)&other, &len);
+              if ((r >= 0) && (other.ss_family != AF_UNIX)) {
+                ldout(async_msgr->cct, 10) << __func__ << " attempting to switch to " << string(&established_peer_addr.addrun.sun_path[0]) << dendl;
+                // everything will be handled in STATE_CONNECTING
+                state = STATE_CONNECTING;
+                break;
+              }
+          }
         }
 
         ::encode(async_msgr->get_myaddr(), myaddrbl);
@@ -1366,8 +1389,6 @@ ssize_t AsyncConnection::_process_connection()
         if (net.set_nonblock(sd) < 0)
           goto fail;
 
-        net.set_socket_options(sd);
-
         bl.append(CEPH_BANNER, strlen(CEPH_BANNER));
 
         ::encode(async_msgr->get_myaddr(), bl);
@@ -1380,7 +1401,21 @@ ssize_t AsyncConnection::_process_connection()
                               << cpp_strerror(errno) << dendl;
           goto fail;
         }
+
+        if (socket_addr.addr.ss_family == AF_UNIX) {
+          net.set_unix_socket_options(sd);
+          // this prevents assert in socket_addr.encode();
+          socket_addr.addr.ss_family = AF_INET;
+        } else {
+          // we'll get really bad performance if we'll forget to set IP socket options...
+          net.set_socket_options(sd);
+        }
+
+        // at this point, when peer is using UNIX scket, socket_addr will be invalid.
+        // this is not a problem as such peer already knows its IP and won't use 
+        // provided socket_addr anyway.
         ::encode(socket_addr, bl);
+
         ldout(async_msgr->cct, 1) << __func__ << " sd=" << sd << " " << socket_addr << dendl;
 
         r = try_send(bl);
@@ -1478,7 +1513,8 @@ ssize_t AsyncConnection::_process_connection()
         ldout(async_msgr->cct, 10) << __func__ << " accept of host_type " << connect_msg.host_type
                                    << ", policy.lossy=" << policy.lossy << " policy.server="
                                    << policy.server << " policy.standby=" << policy.standby
-                                   << " policy.resetcheck=" << policy.resetcheck << dendl;
+                                   << " policy.resetcheck=" << policy.resetcheck
+                                   << dendl;
 
         r = handle_connect_msg(connect_msg, authorizer_bl, authorizer_reply);
         if (r < 0)

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -285,6 +285,7 @@ class AsyncConnection : public Connection {
   ceph_msg_connect_reply connect_reply;
   // Accepting state
   entity_addr_t socket_addr;
+  entity_addr_t established_peer_addr;
   CryptoKey session_key;
   bool replacing;    // when replacing process happened, we will reply connect
                      // side with RETRY tag and accept side will clear replaced

--- a/src/msg/async/net_handler.h
+++ b/src/msg/async/net_handler.h
@@ -25,10 +25,14 @@ namespace ceph {
     int generic_connect(const entity_addr_t& addr, bool nonblock);
 
     CephContext *cct;
+#ifdef SO_NOSIGPIPE
+    void set_nosigpipe(int sd)
+#endif
    public:
     explicit NetHandler(CephContext *c): cct(c) {}
     int set_nonblock(int sd);
     void set_socket_options(int sd);
+    void set_unix_socket_options(int sd);
     int connect(const entity_addr_t &addr);
     
     /**
@@ -40,6 +44,7 @@ namespace ceph {
      */
     int reconnect(const entity_addr_t &addr, int sd);
     int nonblock_connect(const entity_addr_t &addr);
+    static entity_addr_t ip_to_unix(const entity_addr_t &addr, int type, const string& path, bool catch_all);
   };
 }
 

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -205,6 +205,7 @@ struct entity_addr_t {
     sockaddr_storage addr;
     sockaddr_in addr4;
     sockaddr_in6 addr6;
+    sockaddr_un addrun;
   };
 
   unsigned int addr_size() const {
@@ -215,11 +216,14 @@ struct entity_addr_t {
     case AF_INET6:
       return sizeof(addr6);
       break;
+    case AF_UNIX:
+      return sizeof(addrun);
+      break;
     }
     return sizeof(addr);
   }
 
-  entity_addr_t() : type(0), nonce(0) { 
+  entity_addr_t() : type(0), nonce(0) {
     memset(&addr, 0, sizeof(addr));
   }
   explicit entity_addr_t(const ceph_entity_addr &o) {


### PR DESCRIPTION
This changeset adds AF_UNIX sockets to Async Messenger for improved
performance and reduction of IP network stack load (which include
any firewall rules, if necessary) of communication between daemons
and clients on same host. Since it's quite common to have multiple
OSDs on single host, there's no reason to have them talk through IP
protocol even if Linux kernel is smart enough to not pipe data
through complete network stack in that case.
Improves max throughput of Async messenger.
New config knobs added:

  - ms async use local socket (bool, default = false)
    Enable or disable AF_UNIX sockets usage
  - ms async require local socket (bool, default = false)
    If true, any failure to set up listening local socket is considered
    fatal.
  - ms async sndbuf (integer, default = 0/system default)
    Allows setting the size of send buffer of AF_UNIX socket, on Linux
    3.10.42 it defaults to around 208KB.

Signed-off-by: Piotr Dałek <piotr.dalek@ts.fujitsu.com>