### PR TITLE
cmake: Build cython modules and change paths to bin/, lib/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,11 @@ include(CheckIncludeFiles)
 include(CheckIncludeFileCXX)
 include(CheckFunctionExists)
 
+#put all the libs and binaries in one place
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 CHECK_FUNCTION_EXISTS(fallocate CEPH_HAVE_FALLOCATE)
 CHECK_FUNCTION_EXISTS(posix_fadvise HAVE_POSIX_FADVISE)
 CHECK_FUNCTION_EXISTS(posix_fallocate HAVE_POSIX_FALLOCATE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -524,6 +524,8 @@ install(TARGETS rados librados-config DESTINATION bin)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/
   DESTINATION ${PYTHON_INSTDIR})
 
+add_subdirectory(pybind)
+
 ## dencoder
 set(dencoder_srcs
   test/encoding/ceph_dencoder.cc
@@ -883,25 +885,25 @@ target_link_libraries(ceph-authtool global ${EXTRALIBS} ${CRYPTO_LIBS})
 install(TARGETS ceph-authtool DESTINATION bin)
 
 configure_file(${CMAKE_SOURCE_DIR}/src/ceph-coverage.in
-  ${CMAKE_BINARY_DIR}/ceph-coverage @ONLY)
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-coverage @ONLY)
 
 configure_file(${CMAKE_SOURCE_DIR}/src/ceph-debugpack.in
-  ${CMAKE_BINARY_DIR}/ceph-debugpack @ONLY)
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-debugpack @ONLY)
 
 configure_file(${CMAKE_SOURCE_DIR}/src/ceph.in
-  ${CMAKE_BINARY_DIR}/ceph @ONLY)
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph @ONLY)
 
 configure_file(${CMAKE_SOURCE_DIR}/src/ceph-crush-location.in
-  ${CMAKE_BINARY_DIR}/ceph-crush-location @ONLY)
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-crush-location @ONLY)
 
 configure_file(${CMAKE_SOURCE_DIR}/src/init-ceph.in
-  ${CMAKE_BINARY_DIR}/init-ceph @ONLY)
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/init-ceph @ONLY)
 
 install(PROGRAMS
-  ${CMAKE_BINARY_DIR}/ceph
-  ${CMAKE_BINARY_DIR}/ceph-debugpack
-  ${CMAKE_BINARY_DIR}/ceph-coverage
-  ${CMAKE_BINARY_DIR}/init-ceph
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-debugpack
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-coverage
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/init-ceph
   ${CMAKE_SOURCE_DIR}/src/ceph-run
   ${CMAKE_SOURCE_DIR}/src/vstart.sh
   ${CMAKE_SOURCE_DIR}/src/ceph-clsinfo
@@ -1313,6 +1315,7 @@ add_custom_target(vstart DEPENDS
 add_custom_target(cephfs_testing DEPENDS
     vstart
     rados
+    cython_modules
     cephfs
     cls_cephfs
     ceph-fuse

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -72,41 +72,45 @@ def get_pythonlib_dir():
     f = "lib.{platform}-{version[0]}.{version[1]}"
     name = f.format(platform=sysconfig.get_platform(),
                     version=sys.version_info)
-    return os.path.join('build', name)
+    return name
 
 if MYDIR.endswith('src') and \
    os.path.exists(os.path.join(MYDIR, '.libs')) and \
    os.path.exists(os.path.join(MYDIR, 'pybind')) and \
    os.path.exists(os.path.join(MYDIR, 'build')):
 
-    pythonlib_path = get_pythonlib_dir()
-    respawn_in_path(os.path.join(MYDIR, '.libs'), "pybind", pythonlib_path)
+    respawn_in_path(os.path.join(MYDIR, '.libs'), "pybind/build",
+                                 get_pythonlib_dir())
     if os.environ.has_key('PATH') and MYDIR not in os.environ['PATH']:
         os.environ['PATH'] += ':' + MYDIR
 
 elif os.path.exists(os.path.join(os.getcwd(), "CMakeCache.txt")) \
-     and os.path.exists(os.path.join(os.getcwd(), "init-ceph")):
+     and os.path.exists(os.path.join(os.getcwd(), "bin/init-ceph")):
     src_path = None
     for l in open("./CMakeCache.txt").readlines():
         if l.startswith("Ceph_SOURCE_DIR:STATIC="):
             src_path = l.split("=")[1].strip()
+
 
     if src_path is None:
         # Huh, maybe we're not really in a cmake environment?
         pass
     else:
         # Developer mode, but in a cmake build dir instead of the src dir
-        lib_path = os.path.join(os.getcwd(), "src")
+        lib_path = os.path.join(os.getcwd(), "lib")
+        bin_path = os.path.join(os.getcwd(), "bin")
         pybind_path = os.path.join(src_path, "src", "pybind")
-        pythonlib_path = os.path.join(os.getcwd(), "../src/pybind", get_pythonlib_dir())
+
+        import sysconfig
+        f = "lib.{platform}-{version[0]}.{version[1]}"
+        name = f.format(platform=sysconfig.get_platform(),
+                        version=sys.version_info)
+        pythonlib_path = os.path.join(os.getcwd(), "lib/cython_modules", name)
+
         respawn_in_path(lib_path, pybind_path, pythonlib_path)
 
-        sys.path.insert(0, os.path.join(MYDIR, pybind_path))
-        sys.path.insert(0, os.path.join(MYDIR, pythonlib_path))
-
-    # Add src/ to path for e.g. ceph-conf
-    if os.environ.has_key('PATH') and lib_path not in os.environ['PATH']:
-        os.environ['PATH'] += ':' + lib_path
+        if os.environ.has_key('PATH') and bin_path not in os.environ['PATH']:
+            os.environ['PATH'] += ':' + bin_path
 
 import argparse
 import errno

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -98,7 +98,7 @@ elif os.path.exists(os.path.join(os.getcwd(), "CMakeCache.txt")) \
         # Developer mode, but in a cmake build dir instead of the src dir
         lib_path = os.path.join(os.getcwd(), "src")
         pybind_path = os.path.join(src_path, "src", "pybind")
-        pythonlib_path = os.path.join(src_path, "src", get_pythonlib_dir())
+        pythonlib_path = os.path.join(os.getcwd(), "../src/pybind", get_pythonlib_dir())
         respawn_in_path(lib_path, pybind_path, pythonlib_path)
 
         sys.path.insert(0, os.path.join(MYDIR, pybind_path))

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(CYTHON_MODULE_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules)
+
+add_subdirectory(rados)
+add_subdirectory(rbd)
+add_subdirectory(cephfs)
+
+add_custom_target(cython_modules ALL
+    DEPENDS cython_rados cython_cephfs cython_rbd)

--- a/src/pybind/cephfs/CMakeLists.txt
+++ b/src/pybind/cephfs/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_custom_target(cython_cephfs
+  COMMAND
+  LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+  CYTHON_BUILD_DIR=${CMAKE_BINARY_DIR}/src/pybind/cephfs
+  CFLAGS=\"-I${CMAKE_SOURCE_DIR}/src -I${CMAKE_BINARY_DIR}/include -I${CMAKE_SOURCE_DIR}/src/include -std=c++11\"
+  python ${CMAKE_SOURCE_DIR}/src/pybind/cephfs/setup.py build --build-base ${CYTHON_MODULE_DIR} --verbose 
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/cephfs
+  DEPENDS rados cephfs)
+

--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -42,7 +42,8 @@ setup(
     ext_modules = cythonize([
         Extension("cephfs",
             ["cephfs.pyx"],
-            libraries=["cephfs"]
+            libraries=["cephfs"],
+            language="c++"
             )
     ], build_dir=os.environ.get("CYTHON_BUILD_DIR", None), include_path=[
         os.path.join(os.path.dirname(__file__), "..", "rados")]

--- a/src/pybind/rados/CMakeLists.txt
+++ b/src/pybind/rados/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_custom_target(cython_rados
+  COMMAND
+  LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+  CYTHON_BUILD_DIR=${CMAKE_BINARY_DIR}/src/pybind/rados
+  CFLAGS=\"-I${CMAKE_SOURCE_DIR}/src/include -std=c++11\"
+  python ${CMAKE_SOURCE_DIR}/src/pybind/rados/setup.py build --build-base ${CYTHON_MODULE_DIR} --verbose 
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/rados
+  DEPENDS rados)
+

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -42,7 +42,8 @@ setup(
     ext_modules = cythonize([
         Extension("rados",
             ["rados.pyx"],
-            libraries=["rados"]
+            libraries=["rados"],
+            language="c++"
             )
     ], build_dir=os.environ.get("CYTHON_BUILD_DIR", None)),
     cmdclass={

--- a/src/pybind/rbd/CMakeLists.txt
+++ b/src/pybind/rbd/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_custom_target(cython_rbd
+  COMMAND
+  LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+  CYTHON_BUILD_DIR=${CMAKE_BINARY_DIR}/src/pybind/rbd
+  CFLAGS=\"-I${CMAKE_SOURCE_DIR}/src/include -std=c++11\"
+  python ${CMAKE_SOURCE_DIR}/src/pybind/rbd/setup.py build --build-base ${CYTHON_MODULE_DIR} --verbose
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/rbd
+  DEPENDS rbd)
+

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -42,7 +42,8 @@ setup(
     ext_modules = cythonize([
         Extension("rbd",
             ["rbd.pyx"],
-            libraries=["rbd"]
+            libraries=["rbd"],
+            language="c++"
             )
     ], build_dir=os.environ.get("CYTHON_BUILD_DIR", None), include_path=[
         os.path.join(os.path.dirname(__file__), "..", "rados")]

--- a/src/stop.sh
+++ b/src/stop.sh
@@ -21,7 +21,7 @@ test -d dev/osd0/. && test -e dev/sudo && SUDO="sudo"
 if [ -e CMakeCache.txt ]; then
   [ -z "$CEPH_BIN" ] && CEPH_BIN=src
 else
-  [ -z "$CEPH_BIN" ] && CEPH_BIN=.
+  [ -z "$CEPH_BIN" ] && CEPH_BIN=bin
 fi
 
 MYUID=$(id -u)


### PR DESCRIPTION
This is derived from https://github.com/ceph/ceph/pull/7908 and https://github.com/ceph/ceph/pull/7912

Ali's original change included changing build paths for other binaries, so this branch includes the changes elsewhere to accomodate that.  There is also a change in ceph-qa-suite for the paths https://github.com/ceph/ceph-qa-suite/pull/916