### PR TITLE
client: pass 'newly issued caps' to Client::check_cap_issue()

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4807,7 +4807,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, MClient
   if (m->get_op() == CEPH_CAP_OP_IMPORT && m->get_wanted() != wanted)
     check = true;
 
-  check_cap_issue(in, cap, issued);
+  check_cap_issue(in, cap, new_caps);
 
   // update caps
   if (old_caps & ~new_caps) { 


### PR DESCRIPTION
Client::check_cap_issue() expects caller to pass 'newly issued caps'
to it. But in Client::check_cap_issue(), varible 'issued' is caps
client alread has.

Fixes: http://tracker.ceph.com/issues/15303
Signed-off-by: Yan, Zheng <zyan@redhat.com>