### PR TITLE
osd: update crush_location from ceph-osd on startup

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -10,3 +10,14 @@
   New monitors will now use rocksdb by default, but if that file is
   not present, existing monitors will use leveldb.  The ``mon keyvaluedb`` option
   now only affects the backend chosen when a monitor is created.
+
+* The 'osd crush initial weight' option allows you to specify a CRUSH
+  weight for a newly added OSD.  Previously a value of 0 (the default)
+  meant that we should use the size of the OSD's store to weight the
+  new OSD.  Now, a value of 0 means it should have a weight of 0, and
+  a negative value (the new default) means we should automatically
+  weight the OSD based on its size.  If your configuration file
+  explicitly specifies a value of 0 for this option you will need to
+  change it to a negative value (e.g., -1) to preserve the current
+  behavior.
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,7 +184,8 @@ set(crush_srcs
   crush/hash.c
   crush/CrushWrapper.cc
   crush/CrushCompiler.cc
-  crush/CrushTester.cc)
+  crush/CrushTester.cc
+  crush/CrushLocation.cc)
 
 add_library(crush STATIC ${crush_srcs})
 

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -25,6 +25,7 @@
 #include "include/atomic.h"
 #include "common/cmdparse.h"
 #include "include/Spinlock.h"
+#include "crush/CrushLocation.h"
 #include <boost/noncopyable.hpp>
 
 class AdminSocket;
@@ -246,6 +247,10 @@ private:
   PluginRegistry *_plugin_registry;
 
   md_config_obs_t *_lockdep_obs;
+
+public:
+  CrushLocation crush_location;
+private:
 
   enum {
     l_cct_first,

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -614,7 +614,7 @@ OPTION(osd_pgp_bits, OPT_INT, 6)  // bits per osd
 OPTION(osd_crush_chooseleaf_type, OPT_INT, 1) // 1 = host
 OPTION(osd_pool_use_gmt_hitset, OPT_BOOL, true) // try to use gmt for hitset archive names if all osds in cluster support it.
 OPTION(osd_crush_update_on_start, OPT_BOOL, true)
-OPTION(osd_crush_initial_weight, OPT_DOUBLE, 0) // the initial weight is for newly added osds.
+OPTION(osd_crush_initial_weight, OPT_DOUBLE, -1) // if >=0, the initial weight is for newly added osds.
 OPTION(osd_pool_default_crush_rule, OPT_INT, -1) // deprecated for osd_pool_default_crush_replicated_ruleset
 OPTION(osd_pool_default_crush_replicated_ruleset, OPT_INT, CEPH_DEFAULT_CRUSH_REPLICATED_RULESET)
 OPTION(osd_pool_erasure_code_stripe_width, OPT_U32, OSD_POOL_ERASURE_CODE_STRIPE_WIDTH) // in bytes

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -417,6 +417,8 @@ OPTION(client_use_faked_inos, OPT_BOOL, false)
 OPTION(client_mds_namespace, OPT_INT, -1)
 
 OPTION(crush_location, OPT_STR, "")       // whitespace-separated list of key=value pairs describing crush location
+OPTION(crush_location_hook, OPT_STR, "")
+OPTION(crush_location_hook_timeout, OPT_INT, 10)
 
 OPTION(objecter_tick_interval, OPT_DOUBLE, 5.0)
 OPTION(objecter_timeout, OPT_DOUBLE, 10.0)    // before we ask for a map

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -612,9 +612,9 @@ OPTION(osd_pg_op_threshold_ratio, OPT_U64, 2)             // the expected maximu
 OPTION(osd_pg_bits, OPT_INT, 6)  // bits per osd
 OPTION(osd_pgp_bits, OPT_INT, 6)  // bits per osd
 OPTION(osd_crush_chooseleaf_type, OPT_INT, 1) // 1 = host
-// This parameter is not consumed by ceph C code but the upstart scripts.
-// OPTION(osd_crush_initial_weight, OPT_DOUBLE, 0) // the initial weight is for newly added osds.
 OPTION(osd_pool_use_gmt_hitset, OPT_BOOL, true) // try to use gmt for hitset archive names if all osds in cluster support it.
+OPTION(osd_crush_update_on_start, OPT_BOOL, true)
+OPTION(osd_crush_initial_weight, OPT_DOUBLE, 0) // the initial weight is for newly added osds.
 OPTION(osd_pool_default_crush_rule, OPT_INT, -1) // deprecated for osd_pool_default_crush_replicated_ruleset
 OPTION(osd_pool_default_crush_replicated_ruleset, OPT_INT, CEPH_DEFAULT_CRUSH_REPLICATED_RULESET)
 OPTION(osd_pool_erasure_code_stripe_width, OPT_U32, OSD_POOL_ERASURE_CODE_STRIPE_WIDTH) // in bytes

--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -1,0 +1,105 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "CrushLocation.h"
+#include "CrushWrapper.h"
+#include "common/config.h"
+#include "include/str_list.h"
+#include "common/debug.h"
+
+#include <common/SubProcess.h>
+
+#include <vector>
+
+int CrushLocation::update_from_conf()
+{
+  if (cct->_conf->crush_location.length())
+    return _parse(cct->_conf->crush_location);
+  return 0;
+}
+
+int CrushLocation::_parse(const std::string& s)
+{
+  std::multimap<std::string,std::string> new_crush_location;
+  std::vector<std::string> lvec;
+  get_str_vec(s, ";, \t", lvec);
+  int r = CrushWrapper::parse_loc_multimap(lvec, &new_crush_location);
+  if (r < 0) {
+    lderr(cct) << "warning: crush_location '" << cct->_conf->crush_location
+	       << "' does not parse, keeping original crush_location "
+	       << loc << dendl;
+    return -EINVAL;
+  }
+  std::lock_guard<std::mutex> l(lock);
+  loc.swap(new_crush_location);
+  lgeneric_dout(cct, 10) << "crush_location is " << loc << dendl;
+  return 0;
+}
+
+int CrushLocation::update_from_hook()
+{
+  if (cct->_conf->crush_location_hook.length() == 0)
+    return 0;
+
+  SubProcessTimed hook(
+    cct->_conf->crush_location_hook.c_str(),
+    SubProcess::CLOSE, SubProcess::PIPE, SubProcess::PIPE,
+    cct->_conf->crush_location_hook_timeout);
+  hook.add_cmd_args(
+    "--cluster", cct->_conf->cluster.c_str(),
+    "--id", cct->_conf->name.get_id().c_str(),
+    "--type", cct->_conf->name.get_type_str(),
+    NULL);
+  int ret = hook.spawn();
+  if (ret != 0) {
+    lderr(cct) << "error: failed run " << cct->_conf->crush_location_hook << ": "
+	       << hook.err() << dendl;
+    return ret;
+  }
+
+  bufferlist bl;
+  ret = bl.read_fd(hook.get_stdout(), 100 * 1024);
+  if (ret < 0) {
+    lderr(cct) << "error: failed read stdout from "
+	       << cct->_conf->crush_location_hook
+	       << ": " << cpp_strerror(-ret) << dendl;
+    bufferlist err;
+    err.read_fd(hook.get_stderr(), 100 * 1024);
+    lderr(cct) << "stderr:\n";
+    err.hexdump(*_dout);
+    *_dout << dendl;
+    return ret;
+  }
+
+  if (hook.join() != 0) {
+    lderr(cct) << "error: failed to join: " << hook.err() << dendl;
+    return -EINVAL;
+  }
+
+  std::string out;
+  bl.copy(0, bl.length(), out);
+  out.erase(out.find_last_not_of(" \n\r\t")+1);
+  return _parse(out);
+}
+
+int CrushLocation::init_on_startup()
+{
+  if (cct->_conf->crush_location.length()) {
+    return update_from_conf();
+  }
+  if (cct->_conf->crush_location_hook.length()) {
+    return update_from_hook();
+  }
+
+  // start with a sane default
+  char hostname[HOST_NAME_MAX + 1];
+  int r = gethostname(hostname, sizeof(hostname)-1);
+  if (r < 0)
+    strcpy(hostname, "unknown_host");
+  std::lock_guard<std::mutex> l(lock);
+  loc.clear();
+  loc.insert(make_pair<std::string,std::string>("host", hostname));
+  loc.insert(make_pair<std::string,std::string>("root", "default"));
+  lgeneric_dout(cct, 10) << "crush_location is (default) " << loc << dendl;
+  return 0;
+}

--- a/src/crush/CrushLocation.h
+++ b/src/crush/CrushLocation.h
@@ -1,0 +1,35 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_CRUSH_LOCATION_H
+#define CEPH_CRUSH_LOCATION_H
+
+#include <map>
+#include <mutex>
+#include <string>
+
+class CephContext;
+
+class CrushLocation {
+  CephContext *cct;
+  std::multimap<std::string,std::string> loc;
+  std::mutex lock;
+
+  int _parse(const std::string& s);
+
+public:
+  CrushLocation(CephContext *c) : cct(c) {
+    update_from_conf();
+  }
+
+  int update_from_conf();  ///< refresh from config
+  int update_from_hook();  ///< call hook, if present
+  int init_on_startup();
+
+  std::multimap<std::string,std::string> get_location() {
+    std::lock_guard<std::mutex> l(lock);
+    return loc;
+  }
+};
+
+#endif

--- a/src/crush/Makefile.am
+++ b/src/crush/Makefile.am
@@ -5,11 +5,13 @@ libcrush_la_SOURCES = \
 	crush/hash.c \
 	crush/CrushWrapper.cc \
 	crush/CrushCompiler.cc \
-	crush/CrushTester.cc
+	crush/CrushTester.cc \
+	crush/CrushLocation.cc
 noinst_LTLIBRARIES += libcrush.la
 
 noinst_HEADERS += \
 	crush/CrushCompiler.h \
+	crush/CrushLocation.h \
 	crush/CrushTester.h \
 	crush/CrushTreeDumper.h \
 	crush/CrushWrapper.h \

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -321,6 +321,8 @@ void global_init(std::vector < const char * > *alt_def_args,
 
   if (code_env == CODE_ENVIRONMENT_DAEMON && !(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))
     output_ceph_version();
+
+  g_ceph_context->crush_location.init_on_startup();
 }
 
 void global_print_banner(void)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2766,7 +2766,7 @@ int OSD::update_crush_location()
   }
 
   char weight[32];
-  if (g_conf->osd_crush_initial_weight) {
+  if (g_conf->osd_crush_initial_weight >= 0) {
     snprintf(weight, sizeof(weight), "%.4lf", g_conf->osd_crush_initial_weight);
   } else {
     struct statfs st;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2796,18 +2796,39 @@ int OSD::update_crush_location()
   }
   cmd += "]}";
 
-  dout(10) << __func__ << " cmd: " << cmd << dendl;
-  vector<string> vcmd{cmd};
-  bufferlist inbl;
-
-  C_SaferCond w;
-  string outs;
-  int r = monc->start_mon_command(vcmd, inbl, NULL, &outs, &w);
-  if (r == 0)
-    r = w.wait();
-  if (r < 0) {
-    derr << __func__ << " fail: '" << outs << "': " << cpp_strerror(r) << dendl;
-    return r;
+  bool created = false;
+  while (true) {
+    dout(10) << __func__ << " cmd: " << cmd << dendl;
+    vector<string> vcmd{cmd};
+    bufferlist inbl;
+    C_SaferCond w;
+    string outs;
+    int r = monc->start_mon_command(vcmd, inbl, NULL, &outs, &w);
+    if (r == 0)
+      r = w.wait();
+    if (r < 0) {
+      if (r == -ENOENT && !created) {
+	string newcmd = "{\"prefix\": \"osd create\", \"id\": " + stringify(whoami)
+	  + ", \"uuid\": \"" + stringify(superblock.osd_fsid) + "\"}";
+	vector<string> vnewcmd{newcmd};
+	bufferlist inbl;
+	C_SaferCond w;
+	string outs;
+	int r = monc->start_mon_command(vnewcmd, inbl, NULL, &outs, &w);
+	if (r == 0)
+	  r = w.wait();
+	if (r < 0) {
+	  derr << __func__ << " fail: osd does not exist and created failed: "
+	       << cpp_strerror(r) << dendl;
+	  return r;
+	}
+	created = true;
+	continue;
+      }
+      derr << __func__ << " fail: '" << outs << "': " << cpp_strerror(r) << dendl;
+      return r;
+    }
+    break;
   }
 
   return 0;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2404,6 +2404,8 @@ protected:
   }
 
 private:
+  int update_crush_location();
+
   static int write_meta(ObjectStore *store,
 			uuid_d& cluster_fsid, uuid_d& osd_fsid, int whoami);
 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -184,16 +184,7 @@ void Objecter::handle_conf_change(const struct md_config_t *conf,
 void Objecter::update_crush_location()
 {
   unique_lock wl(rwlock);
-  std::multimap<string,string> new_crush_location;
-  vector<string> lvec;
-  get_str_vec(cct->_conf->crush_location, ";, \t", lvec);
-  int r = CrushWrapper::parse_loc_multimap(lvec, &new_crush_location);
-  if (r < 0) {
-    lderr(cct) << "warning: crush_location '" << cct->_conf->crush_location
-	       << "' does not parse, leave origin crush_location untouched." << dendl;
-    return;
-  }
-  crush_location = new_crush_location;
+  crush_location = cct->crush_location.get_location();
 }
 
 // messages ------------------------------


### PR DESCRIPTION
This is (1) just cleaner and better, and (2) it means that the crush weight matches ObjectStore::statfs's value, which means that for bluestore we get an accurate weight (whereas df does not give you the right value)