### PR TITLE
ceph.in: correct dev python path for automake builds

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -79,7 +79,7 @@ if MYDIR.endswith('src') and \
    os.path.exists(os.path.join(MYDIR, 'pybind')) and \
    os.path.exists(os.path.join(MYDIR, 'build')):
 
-    respawn_in_path(os.path.join(MYDIR, '.libs'), "pybind/build",
+    respawn_in_path(os.path.join(MYDIR, '.libs'), "pybind",
                                  get_pythonlib_dir())
     if os.environ.has_key('PATH') and MYDIR not in os.environ['PATH']:
         os.environ['PATH'] += ':' + MYDIR


### PR DESCRIPTION
Accidentally broken by ad2e6f442df0fe302c09fc751fc9e12237789511

Signed-off-by: Josh Durgin <jdurgin@redhat.com>