### PR TITLE
vstart: fix up cmake paths when VSTART_DEST is given

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -12,8 +12,8 @@ if [ -n "$VSTART_DEST" ]; then
   CEPH_LIB=$SRC_PATH/.libs
 
   if [ -e CMakeCache.txt ]; then
-      CEPH_BIN=$VSTART_DEST/../../src
-      CEPH_LIB=$CEPH_BIN
+      CEPH_BIN=$VSTART_DEST/../../bin
+      CEPH_LIB=$VSTART_DEST/../../lib
   fi
 
   CEPH_CONF_PATH=$VSTART_DEST


### PR DESCRIPTION
mstart.sh uses VSTART_DEST to tell vstart.sh where to create the
cluster. in the cmake case, it needs to get a relative path from there
to the built binaries and libraries - update these paths to use the new
'lib' and 'bin' directories

Signed-off-by: Casey Bodley \<cbodley@redhat.com\>