### PR TITLE
qa: update rest test cephfs calls

### DIFF
--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -166,9 +166,9 @@ if __name__ == '__main__':
     r = expect('mds/dump.xml', 'GET', 200, 'xml')
     assert(r.tree.find('output/mdsmap/created') is not None)
 
-    expect('osd/pool/create?pg_num=1&pool=fsmetadata', 'PUT', 200, '')
-    expect('osd/pool/create?pg_num=1&pool=fsdata', 'PUT', 200, '')
-    expect('fs/new?fs_name=default&metadata=fsmetadata&data=fsdata', 'PUT', 200, '')
+    expect('osd/pool/create?pg_num=1&pool=cephfs_metadata', 'PUT', 200, '')
+    expect('osd/pool/create?pg_num=1&pool=cephfs_data', 'PUT', 200, '')
+    expect('fs/new?fs_name=cephfs&metadata=cephfs_metadata&data=cephfs_data', 'PUT', 200, '')
     expect('osd/pool/create?pool=data2&pg_num=10', 'PUT', 200, '')
     r = expect('osd/dump', 'GET', 200, 'json', JSONHDR)
     pools = r.myjson['output']['pools']


### PR DESCRIPTION
Since the ceph task was already creating filesystems
during setup, I presume that these calls only ever
worked when they were using the same names as
the existing filesystem.

Fixes: http://tracker.ceph.com/issues/15309
Signed-off-by: John Spray <john.spray@redhat.com>