### PR TITLE
ceph-detect-init/run-tox.sh: FreeBSD: No init detect

### DIFF
--- a/src/ceph-detect-init/run-tox.sh
+++ b/src/ceph-detect-init/run-tox.sh
@@ -17,6 +17,11 @@
 # GNU Library Public License for more details.
 #
 
+if [ x"`uname`"x = xFreeBSDx ]; then
+    echo FreeBSD init system has not been integrated.
+    exit 0
+fi
+
 # run from the ceph-detect-init directory or from its parent
 : ${CEPH_DETECT_INIT_VIRTUALENV:=ceph-detect-init-virtualenv}
 test -d ceph-detect-init && cd ceph-detect-init


### PR DESCRIPTION
 - Freebsd has /etc/rc.d with scripts to start daemons at boottime. 
   Test for that are currently not integrated with Ceph tests

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>