### PR TITLE
DNM: CephFS Lockouts

### DIFF
--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -79,9 +79,13 @@ Global settings
 
 ::
 
-    fs flag set <flag name> <flag val>
+    fs flag set <flag name> <flag val> [<confirmation string>]
 
     flag name must be one of ['enable_multiple']
+
+    some flags require you to confirm your intentions with "--yes-i-really-mean-it"
+    or a similar string they will prompt you with. Consider these actions carefully
+    before proceeding; they are placed on especially dangerous activities.
 
 Advanced
 --------

--- a/doc/cephfs/experimental-features.rst
+++ b/doc/cephfs/experimental-features.rst
@@ -1,0 +1,81 @@
+
+Experimental Features
+=====================
+
+CephFS includes a number of experimental features which are not fully stabilized
+or qualified for users to turn on in real deployments. We generally do our best
+to clearly demarcate these and fence them off so they can't be used by mistake.
+
+Some of these features are closer to being done than others, though. We describe
+each of them with an approximation of how risky they are and briefly describe
+what is required to enable them. Note that doing so will *irrevocably* flag maps
+in the monitor as having once enabled this flag to improve debugging and
+support processes.
+
+
+Directory Fragmentation
+-----------------------
+CephFS directories are generally stored within a single RADOS object. But this has
+certain negative results once they become large enough. The filesystem is capable
+of "fragmenting" these directories into multiple objects. There are no known bugs
+with doing so but it is not sufficiently tested to support at this time.
+
+Directory fragmentation has always been off by default and required setting
+```mds bal frag = true`` in the MDS' config file. It has been further protected
+by requiring the user to set the "allow_dirfrags" flag for Jewel.
+
+Inline data
+-----------
+By default, all CephFS file data is stored in RADOS objects. The inline data
+feature enables small files (generally <2KB) to be stored in the inode
+and served out of the MDS. This may improve small-file performance but increases
+load on the MDS. It is not sufficiently tested to support at this time, although
+failures within it are unlikely to make non-inlined data inaccessible
+
+Inline data has always been off by default and requires setting
+the "inline_data" flag.
+
+Multi-MDS filesystem clusters
+-----------------------------
+CephFS has been designed from the ground up to support fragmenting the metadata
+hierarchy across multiple active metadata servers, to allow horizontal scaling
+to arbitrary throughput requirements. Unfortunately, doing so requires a lot
+more working code than having a single MDS which is authoritative over the
+entire filesystem namespace.
+
+Multiple active MDSes are generally stable under trivial workloads, but often
+break in the presence of any failure, and do not have enough testing to offer
+any stability guarantees. If a filesystem with multiple active MDSes does
+experience failure, it will require (generally extensive) manual intervention.
+There are serious known bugs.
+
+Multi-MDS filesystems have always required explicitly increasing the "max_mds"
+value and have been further protected with the "allow_multimds" flag for Jewel.
+
+Snapshots
+---------
+Like multiple active MDSes, CephFS is designed from the ground up to support
+snapshotting of arbitrary directories. There are no known bugs at the time of
+writing, but there is insufficient testing to provide stability guarantees and
+every expansion of testing has generally revealed new issues. If you do enable
+snapshots and experience failure, manual intervention will be needed.
+
+Snapshotting was blocked off with the "allow_new_snaps" flag prior to Firefly.
+
+Multiple filesystems within a Ceph cluster
+------------------------------------------
+Code was merged prior to the Jewel release which enables administrators
+to create multiple independent CephFS filesystems within a single Ceph cluster.
+These independent filesystems have their own set of active MDSes, cluster maps,
+and data. But the feature required extensive changes to data structures which
+are not yet fully qualified, and has security implications which are not all
+apparent nor resolved.
+
+There are no known bugs, but any failures which do result from having multiple
+active filesystems in your cluster will require manual intervention and, so far,
+will not have been experienced by anybody else -- knowledgeable help will be
+extremely limited. You also probably do not have the security or isolation
+guarantees you want or think you have upon doing so.
+
+Multiple filesystems were available starting in the Jewel release candidates
+but were protected behind the "enable_multiple" flag before the final release.

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -814,6 +814,8 @@ function test_mon_mds()
   ceph mds remove_data_pool $data3_pool
   ceph osd pool delete data2 data2 --yes-i-really-really-mean-it
   ceph osd pool delete data3 data3 --yes-i-really-really-mean-it
+  expect_false ceph mds set_max_mds 4
+  ceph mds set allow_multimds true --yes-i-really-mean-it
   ceph mds set_max_mds 4
   ceph mds set_max_mds 3
   ceph mds set_max_mds 256
@@ -875,7 +877,7 @@ function test_mon_mds()
   set -e
 
   # Check that setting enable_multiple enables creation of second fs
-  ceph fs flag set enable_multiple true
+  ceph fs flag set enable_multiple true --yes-i-really-mean-it
   ceph fs new cephfs2 fs_metadata2 fs_data2
 
   # Clean up multi-fs stuff

--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -183,6 +183,7 @@ if __name__ == '__main__':
     expect('mds/remove_data_pool?pool={0}'.format(poolnum), 'PUT', 200, '')
     expect('osd/pool/delete?pool=data2&pool2=data2'
            '&sure=--yes-i-really-really-mean-it', 'PUT', 200, '')
+    expect('mds/set?var=allow_multimds&val=true&confirm=--yes-i-really-mean-it', 'PUT', 200, '')
     expect('mds/set_max_mds?maxmds=4', 'PUT', 200, '')
     expect('mds/set?var=max_mds&val=4', 'PUT', 200, '')
     expect('mds/set?var=max_file_size&val=1048576', 'PUT', 200, '')

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -234,6 +234,11 @@ struct ceph_mon_subscribe_ack {
  */
 #define CEPH_MDSMAP_DOWN    (1<<0)  /* cluster deliberately down */
 #define CEPH_MDSMAP_ALLOW_SNAPS   (1<<1)  /* cluster allowed to create snapshots */
+#define CEPH_MDSMAP_ALLOW_MULTIMDS (1<<2) /* cluster allowed to have >1 active MDS */
+#define CEPH_MDSMAP_ALLOW_DIRFRAGS (1<<3) /* cluster allowed to fragment directories */
+
+#define CEPH_MDSMAP_ALLOW_CLASSICS (CEPH_MDSMAP_ALLOW_SNAPS | CEPH_MDSMAP_ALLOW_MULTIMDS | \
+				    CEPH_MDSMAP_ALLOW_DIRFRAGS)
 
 /*
  * mds states

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -77,7 +77,7 @@ void FSMap::print(ostream& out) const
 {
   out << "e" << epoch << std::endl;
   out << "enable_multiple: " << enable_multiple << std::endl;
-  out << "compat: " << enable_multiple << std::endl;
+  out << "compat: " << compat << std::endl;
   out << " " << std::endl;
 
   if (filesystems.empty()) {

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -35,6 +35,11 @@ void FSMap::dump(Formatter *f) const
   compat.dump(f);
   f->close_section();
 
+  f->open_object_section("feature flags");
+  f->dump_bool("enable_multiple", enable_multiple);
+  f->dump_bool("ever_enabled_multiple", ever_enabled_multiple);
+  f->close_section();
+
   f->open_array_section("standbys");
   for (const auto &i : standby_daemons) {
     f->open_object_section("info");
@@ -76,7 +81,8 @@ void FSMap::generate_test_instances(list<FSMap*>& ls)
 void FSMap::print(ostream& out) const
 {
   out << "e" << epoch << std::endl;
-  out << "enable_multiple: " << enable_multiple << std::endl;
+  out << "enable_multiple, ever_enabled_multiple: " << enable_multiple << ","
+      << ever_enabled_multiple << std::endl;
   out << "compat: " << compat << std::endl;
   out << " " << std::endl;
 

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -231,7 +231,7 @@ void FSMap::get_health(list<pair<health_status_t,string> >& summary,
 void FSMap::encode(bufferlist& bl, uint64_t features) const
 {
   if (features & CEPH_FEATURE_SERVER_JEWEL) {
-    ENCODE_START(6, 6, bl);
+    ENCODE_START(7, 6, bl);
     ::encode(epoch, bl);
     ::encode(next_filesystem_id, bl);
     ::encode(legacy_client_fscid, bl);
@@ -245,6 +245,7 @@ void FSMap::encode(bufferlist& bl, uint64_t features) const
     ::encode(mds_roles, bl);
     ::encode(standby_daemons, bl, features);
     ::encode(standby_epochs, bl);
+    ::encode(ever_enabled_multiple, bl);
     ENCODE_FINISH(bl);
   } else {
     if (filesystems.empty()) {
@@ -280,7 +281,7 @@ void FSMap::decode(bufferlist::iterator& p)
   // MDSMonitor to store an FSMap instead of an MDSMap was
   // 5, so anything older than 6 is decoded as an MDSMap,
   // and anything newer is decoded as an FSMap.
-  DECODE_START_LEGACY_COMPAT_LEN_16(6, 4, 4, p);
+  DECODE_START_LEGACY_COMPAT_LEN_16(7, 4, 4, p);
   if (struct_v < 6) {
     // Decoding an MDSMap (upgrade)
     ::decode(epoch, p);
@@ -416,6 +417,7 @@ void FSMap::decode(bufferlist::iterator& p)
     ::decode(mds_roles, p);
     ::decode(standby_daemons, p);
     ::decode(standby_epochs, p);
+    ::decode(ever_enabled_multiple, p);
   }
 
   DECODE_FINISH(p);

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -345,16 +345,24 @@ void FSMap::decode(bufferlist::iterator& p)
 	// previously this was a bool about snaps, not a flag map
 	bool flag;
 	::decode(flag, p);
-	legacy_mds_map.ever_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+	legacy_mds_map.ever_allowed_features = flag ?
+	  CEPH_MDSMAP_ALLOW_SNAPS : 0;
 	::decode(flag, p);
-	legacy_mds_map.explicitly_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+	legacy_mds_map.explicitly_allowed_features = flag ?
+	  CEPH_MDSMAP_ALLOW_SNAPS : 0;
+	if (legacy_mds_map.max_mds > 1) {
+	  legacy_mds_map.set_multimds_allowed();
+	}
       } else {
 	::decode(legacy_mds_map.ever_allowed_features, p);
 	::decode(legacy_mds_map.explicitly_allowed_features, p);
       }
     } else {
-      legacy_mds_map.ever_allowed_features = CEPH_MDSMAP_ALLOW_SNAPS;
+      legacy_mds_map.ever_allowed_features = CEPH_MDSMAP_ALLOW_CLASSICS;
       legacy_mds_map.explicitly_allowed_features = 0;
+      if (legacy_mds_map.max_mds > 1) {
+	legacy_mds_map.set_multimds_allowed();
+      }
     }
     if (ev >= 7)
       ::decode(legacy_mds_map.inline_data_enabled, p);

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -341,11 +341,20 @@ void FSMap::decode(bufferlist::iterator& p)
     if (ev >= 4)
       ::decode(legacy_mds_map.last_failure_osd_epoch, p);
     if (ev >= 6) {
-      ::decode(legacy_mds_map.ever_allowed_snaps, p);
-      ::decode(legacy_mds_map.explicitly_allowed_snaps, p);
+      if (ev < 10) {
+	// previously this was a bool about snaps, not a flag map
+	bool flag;
+	::decode(flag, p);
+	legacy_mds_map.ever_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+	::decode(flag, p);
+	legacy_mds_map.explicitly_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+      } else {
+	::decode(legacy_mds_map.ever_allowed_features, p);
+	::decode(legacy_mds_map.explicitly_allowed_features, p);
+      }
     } else {
-      legacy_mds_map.ever_allowed_snaps = true;
-      legacy_mds_map.explicitly_allowed_snaps = false;
+      legacy_mds_map.ever_allowed_features = CEPH_MDSMAP_ALLOW_SNAPS;
+      legacy_mds_map.explicitly_allowed_features = 0;
     }
     if (ev >= 7)
       ::decode(legacy_mds_map.inline_data_enabled, p);

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -95,6 +95,7 @@ protected:
   fs_cluster_id_t legacy_client_fscid;
   CompatSet compat;
   bool enable_multiple;
+  bool ever_enabled_multiple; // < the cluster had multiple MDSes enabled once
 
   std::map<fs_cluster_id_t, std::shared_ptr<Filesystem> > filesystems;
 
@@ -115,7 +116,7 @@ public:
       next_filesystem_id(FS_CLUSTER_ID_ANONYMOUS + 1),
       legacy_client_fscid(FS_CLUSTER_ID_NONE),
       compat(get_mdsmap_compat_set_default()),
-      enable_multiple(false)
+      enable_multiple(false), ever_enabled_multiple(false)
   { }
 
   FSMap(const FSMap &rhs)
@@ -125,6 +126,7 @@ public:
       legacy_client_fscid(rhs.legacy_client_fscid),
       compat(rhs.compat),
       enable_multiple(rhs.enable_multiple),
+      ever_enabled_multiple(rhs.ever_enabled_multiple),
       mds_roles(rhs.mds_roles),
       standby_daemons(rhs.standby_daemons),
       standby_epochs(rhs.standby_epochs)
@@ -159,6 +161,9 @@ public:
   void set_enable_multiple(const bool v)
   {
     enable_multiple = v;
+    if (true == v) {
+      ever_enabled_multiple = true;
+    }
   }
 
   bool get_enable_multiple() const

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -333,6 +333,7 @@ double MDBalancer::try_match(mds_rank_t ex, double& maxex,
 
 void MDBalancer::queue_split(CDir *dir)
 {
+  assert(mds->mdsmap->allows_dirfrags());
   split_queue.insert(dir->dirfrag());
 }
 
@@ -984,6 +985,7 @@ void MDBalancer::hit_dir(utime_t now, CDir *dir, int type, int who, double amoun
 
     // split
     if (g_conf->mds_bal_split_size > 0 &&
+	mds->mdsmap->allows_dirfrags() &&
 	(dir->should_split() ||
 	 (v > g_conf->mds_bal_split_rd && type == META_POP_IRD) ||
 	 (v > g_conf->mds_bal_split_wr && type == META_POP_IWR)) &&

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -630,16 +630,23 @@ void MDSMap::decode(bufferlist::iterator& p)
       // previously this was a bool about snaps, not a flag map
       bool flag;
       ::decode(flag, p);
-      legacy_mds_map.ever_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+      ever_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+      ever_allowed_features |= CEPH_MDSMAP_ALLOW_MULTIMDS|CEPH_MDSMAP_ALLOW_DIRFRAGS;
       ::decode(flag, p);
-      legacy_mds_map.explicitly_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+      explicitly_allowed_features = flag ? CEPH_MDSMAP_ALLOW_SNAPS : 0;
+      if (max_mds > 1) {
+	set_multimds_allowed();
+      }
     } else {
       ::decode(ever_allowed_features, p);
       ::decode(explicitly_allowed_features, p);
     }
   } else {
-    ever_allowed_features = CEPH_MDSMAP_ALLOW_SNAPS;
+    ever_allowed_features = CEPH_MDSMAP_ALLOW_CLASSICS;
     explicitly_allowed_features = 0;
+    if (max_mds > 1) {
+      set_multimds_allowed();
+    }
   }
   if (ev >= 7)
     ::decode(inline_data_enabled, p);

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -262,8 +262,24 @@ public:
     ever_allowed_features |= CEPH_MDSMAP_ALLOW_SNAPS;
     explicitly_allowed_features |= CEPH_MDSMAP_ALLOW_SNAPS;
   }
-  bool allows_snaps() { return test_flag(CEPH_MDSMAP_ALLOW_SNAPS); }
   void clear_snaps_allowed() { clear_flag(CEPH_MDSMAP_ALLOW_SNAPS); }
+  bool allows_snaps() const { return test_flag(CEPH_MDSMAP_ALLOW_SNAPS); }
+
+  void set_multimds_allowed() {
+    set_flag(CEPH_MDSMAP_ALLOW_MULTIMDS);
+    ever_allowed_features |= CEPH_MDSMAP_ALLOW_MULTIMDS;
+    explicitly_allowed_features |= CEPH_MDSMAP_ALLOW_MULTIMDS;
+  }
+  void clear_multimds_allowed() { clear_flag(CEPH_MDSMAP_ALLOW_MULTIMDS); }
+  bool allows_multimds() const { return test_flag(CEPH_MDSMAP_ALLOW_MULTIMDS); }
+
+  void set_dirfrags_allowed() {
+    set_flag(CEPH_MDSMAP_ALLOW_DIRFRAGS);
+    ever_allowed_features |= CEPH_MDSMAP_ALLOW_DIRFRAGS;
+    explicitly_allowed_features |= CEPH_MDSMAP_ALLOW_DIRFRAGS;
+  }
+  void clear_dirfrags_allowed() { clear_flag(CEPH_MDSMAP_ALLOW_DIRFRAGS); }
+  bool allows_dirfrags() const { return test_flag(CEPH_MDSMAP_ALLOW_DIRFRAGS); }
 
   epoch_t get_epoch() const { return epoch; }
   void inc_epoch() { epoch++; }

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -209,8 +209,8 @@ protected:
   std::map<mds_rank_t, mds_gid_t> up;        // who is in those roles
   std::map<mds_gid_t, mds_info_t> mds_info;
 
-  bool ever_allowed_snaps; //< the cluster has ever allowed snap creation
-  bool explicitly_allowed_snaps; //< the user has explicitly enabled snap creation
+  uint8_t ever_allowed_features; //< bitmap of features the cluster has allowed
+  uint8_t explicitly_allowed_features; //< bitmap of features explicitly enabled 
 
   bool inline_data_enabled;
 
@@ -235,8 +235,8 @@ public:
       cas_pool(-1),
       metadata_pool(0),
       max_mds(0),
-      ever_allowed_snaps(false),
-      explicitly_allowed_snaps(false),
+      ever_allowed_features(0),
+      explicitly_allowed_features(0),
       inline_data_enabled(false),
       cached_up_features(0)
   { }
@@ -259,8 +259,8 @@ public:
 
   void set_snaps_allowed() {
     set_flag(CEPH_MDSMAP_ALLOW_SNAPS);
-    ever_allowed_snaps = true;
-    explicitly_allowed_snaps = true;
+    ever_allowed_features |= CEPH_MDSMAP_ALLOW_SNAPS;
+    explicitly_allowed_features |= CEPH_MDSMAP_ALLOW_SNAPS;
   }
   bool allows_snaps() { return test_flag(CEPH_MDSMAP_ALLOW_SNAPS); }
   void clear_snaps_allowed() { clear_flag(CEPH_MDSMAP_ALLOW_SNAPS); }

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -70,6 +70,11 @@ template<> bool cmd_getval(CephContext *cct, const cmdmap_t& cmdmap,
   return cmd_getval(cct, cmdmap, k, (int64_t&)val);
 }
 
+static const string EXPERIMENTAL_WARNING("Warning! This feature is experimental."
+"It may cause problems up to and including data loss."
+"Consult the documentation at ceph.com, and if unsure, do not proceed."
+"Add --yes-i-really-mean-it if you are certain.");
+
 static const string MDS_METADATA_PREFIX("mds_metadata");
 
 
@@ -1525,10 +1530,7 @@ class FlagSetHandler : public FileSystemCommandHandler
         return -EINVAL;
       }
       if (confirm != "--yes-i-really-mean-it") {
-	ss << "Multiple filesystems is an EXPERIMENTAL and BARELY-TESTED configuration"
-	  " that may break your entire cluster, probably prevent serious"
-	  " support, and irrevocably marks your cluster."
-	  " Add --yes-i-really-mean-it if you are sure you wish to continue.";
+	ss << EXPERIMENTAL_WARNING;
       }
       fsmap.set_enable_multiple(flag_bool);
       return 0;
@@ -1846,7 +1848,7 @@ public:
 	string confirm;
 	if (!cmd_getval(g_ceph_context, cmdmap, "confirm", confirm) ||
 	    confirm != "--yes-i-really-mean-it") {
-	  ss << "inline data is new and experimental; you must specify --yes-i-really-mean-it";
+	  ss << EXPERIMENTAL_WARNING;
 	  return -EPERM;
 	}
 	ss << "inline data enabled";
@@ -1905,7 +1907,7 @@ public:
 	string confirm;
 	if (!cmd_getval(g_ceph_context, cmdmap, "confirm", confirm) ||
 	    confirm != "--yes-i-really-mean-it") {
-	  ss << "Snapshots are unstable and will probably break your FS! Set to --yes-i-really-mean-it if you are sure you want to enable them";
+	  ss << EXPERIMENTAL_WARNING;
 	  return -EPERM;
 	}
         fsmap.modify_filesystem(
@@ -1934,7 +1936,7 @@ public:
 	string confirm;
 	if (!cmd_getval(g_ceph_context, cmdmap, "confirm", confirm) ||
 	    confirm != "--yes-i-really-mean-it") {
-	  ss << "Multi-MDS clusters are unstable and will probably break your FS! Set to --yes-i-really-mean-it if you are sure you want to enable this";
+	  ss << EXPERIMENTAL_WARNING;
 	  return -EPERM;
 	}
         fsmap.modify_filesystem(
@@ -1963,7 +1965,7 @@ public:
 	string confirm;
 	if (!cmd_getval(g_ceph_context, cmdmap, "confirm", confirm) ||
 	    confirm != "--yes-i-really-mean-it") {
-	  ss << "directory fragmentation is unstable and may break your FS! Set to --yes-i-really-mean-it if you are sure you want to enable this";
+	  ss << EXPERIMENTAL_WARNING;
 	  return -EPERM;
 	}
         fsmap.modify_filesystem(

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1820,6 +1820,11 @@ public:
       if (interr.length()) {
 	return -EINVAL;
       }
+      if (!fs->mds_map.allows_multimds() && n > fs->mds_map.get_max_mds() &&
+	  n > 1) {
+	ss << "multi-MDS clusters are not enabled; set 'allow_multimds' to enable";
+	return -EINVAL;
+      }
       if (n > MAX_MDS) {
         ss << "may not have more than " << MAX_MDS << " MDS ranks";
         return -EINVAL;
@@ -1910,6 +1915,64 @@ public:
           fs->mds_map.set_snaps_allowed();
         });
 	ss << "enabled new snapshots";
+      }
+    } else if (var == "allow_multimds") {
+      bool enable_multimds = false;
+      int r = parse_bool(val, &enable_multimds, ss);
+      if (r != 0) {
+	return r;
+      }
+
+      if (!enable_multimds) {
+	fsmap.modify_filesystem(fs->fscid,
+	     [](std::shared_ptr<Filesystem> fs)
+		{
+		  fs->mds_map.clear_multimds_allowed();
+		});
+	ss << "disallowed increasing the cluster size past 1";
+      } else {
+	string confirm;
+	if (!cmd_getval(g_ceph_context, cmdmap, "confirm", confirm) ||
+	    confirm != "--yes-i-really-mean-it") {
+	  ss << "Multi-MDS clusters are unstable and will probably break your FS! Set to --yes-i-really-mean-it if you are sure you want to enable this";
+	  return -EPERM;
+	}
+        fsmap.modify_filesystem(
+            fs->fscid,
+            [](std::shared_ptr<Filesystem> fs)
+        {
+          fs->mds_map.set_multimds_allowed();
+        });
+	ss << "enabled creation of more than 1 active MDS";
+      }
+    } else if (var == "allow_dirfrags") {
+      bool enable_dirfrags = false;
+      int r = parse_bool(val, &enable_dirfrags, ss);
+      if (r != 0) {
+	return r;
+      }
+
+      if (!enable_dirfrags) {
+	fsmap.modify_filesystem(fs->fscid,
+	     [](std::shared_ptr<Filesystem> fs)
+		{
+		  fs->mds_map.clear_dirfrags_allowed();
+		});
+	ss << "disallowed new directory fragmentation";
+      } else {
+	string confirm;
+	if (!cmd_getval(g_ceph_context, cmdmap, "confirm", confirm) ||
+	    confirm != "--yes-i-really-mean-it") {
+	  ss << "directory fragmentation is unstable and may break your FS! Set to --yes-i-really-mean-it if you are sure you want to enable this";
+	  return -EPERM;
+	}
+        fsmap.modify_filesystem(
+            fs->fscid,
+            [](std::shared_ptr<Filesystem> fs)
+        {
+          fs->mds_map.set_dirfrags_allowed();
+        });
+	ss << "enabled directory fragmentation";
       }
     } else if (var == "cluster_down") {
       bool is_down = false;
@@ -2337,6 +2400,17 @@ int MDSMonitor::legacy_filesystem_command(
     if (!cmd_getval(g_ceph_context, cmdmap, "maxmds", maxmds) || maxmds < 0) {
       return -EINVAL;
     }
+
+    const MDSMap& mdsmap =
+      pending_fsmap.filesystems.at(pending_fsmap.legacy_client_fscid)->mds_map;
+      
+    if (!mdsmap.allows_multimds() &&
+	maxmds > mdsmap.get_max_mds() &&
+	maxmds > 1) {
+      ss << "multi-MDS clusters are not enabled; set 'allow_multimds' to enable";
+      return -EINVAL;
+    }
+
     if (maxmds > MAX_MDS) {
       ss << "may not have more than " << MAX_MDS << " MDS ranks";
       return -EINVAL;

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1508,6 +1508,9 @@ class FlagSetHandler : public FileSystemCommandHandler
     string flag_val;
     cmd_getval(g_ceph_context, cmdmap, "val", flag_val);
 
+    string confirm;
+    cmd_getval(g_ceph_context, cmdmap, "confirm", confirm);
+
     if (flag_name == "enable_multiple") {
       bool flag_bool = false;
       int r = parse_bool(flag_val, &flag_bool, ss);
@@ -1521,7 +1524,12 @@ class FlagSetHandler : public FileSystemCommandHandler
         ss << "Multiple-filesystems are forbidden until all mons are updated";
         return -EINVAL;
       }
-
+      if (confirm != "--yes-i-really-mean-it") {
+	ss << "Multiple filesystems is an EXPERIMENTAL and BARELY-TESTED configuration"
+	  " that may break your entire cluster, probably prevent serious"
+	  " support, and irrevocably marks your cluster."
+	  " Add --yes-i-really-mean-it if you are sure you wish to continue.";
+      }
       fsmap.set_enable_multiple(flag_bool);
       return 0;
     } else {

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -329,7 +329,8 @@ COMMAND("mds set_max_mds " \
 	"name=maxmds,type=CephInt,range=0", \
 	"set max MDS index", "mds", "rw", "cli,rest")
 COMMAND("mds set " \
-	"name=var,type=CephChoices,strings=max_mds|max_file_size|allow_new_snaps|inline_data " \
+	"name=var,type=CephChoices,strings=max_mds|max_file_size"
+	"|allow_new_snaps|inline_data|allow_multimds|allow_dirfrags " \
 	"name=val,type=CephString "					\
 	"name=confirm,type=CephString,req=false",			\
 	"set mds parameter <var> to <val>", "mds", "rw", "cli,rest")
@@ -397,7 +398,7 @@ COMMAND("fs get name=fs_name,type=CephString", \
 COMMAND("fs set " \
 	"name=fs_name,type=CephString " \
 	"name=var,type=CephChoices,strings=max_mds|max_file_size"
-        "|allow_new_snaps|inline_data|cluster_down " \
+        "|allow_new_snaps|inline_data|cluster_down|allow_multimds|allow_dirfrags " \
 	"name=val,type=CephString "					\
 	"name=confirm,type=CephString,req=false",			\
 	"set mds parameter <var> to <val>", "mds", "rw", "cli,rest")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -402,7 +402,8 @@ COMMAND("fs set " \
 	"name=confirm,type=CephString,req=false",			\
 	"set mds parameter <var> to <val>", "mds", "rw", "cli,rest")
 COMMAND("fs flag set name=flag_name,type=CephChoices,strings=enable_multiple "
-        "name=val,type=CephString", \
+        "name=val,type=CephString " \
+	"name=confirm,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"Set a global CephFS flag", \
 	"fs", "rw", "cli,rest")
 COMMAND("fs add_data_pool name=fs_name,type=CephString " \

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -192,6 +192,10 @@ TYPE_FEATUREFUL(InodeStore)
 TYPE_FEATUREFUL(MDSMap)
 TYPE_FEATUREFUL(MDSMap::mds_info_t)
 
+#include "mds/FSMap.h"
+//TYPE_FEATUREFUL(Filesystem)
+TYPE_FEATUREFUL(FSMap)
+
 #include "mds/Capability.h"
 TYPE_NOCOPY(Capability)
 

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -625,7 +625,7 @@ fi
 
 if [ "$start_mds" -eq 1 -a "$CEPH_NUM_MDS" -gt 0 ]; then
     if [ "$CEPH_NUM_FS" -gt "1" ] ; then
-        $CEPH_ADM fs flag set enable_multiple true
+        $CEPH_ADM fs flag set enable_multiple true --yes-i-really-mean-it
     fi
 
     fs=0


### PR DESCRIPTION
This PR disables the CephFS features we don't consider stable in time for Jewel.

Specifically, it strengthens the multi-FS warning and adds a lockout on multi-MDS clusters and
directory fragmentation.

Currently untested.