### PR TITLE
client: mount non-default filesystem by name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,6 +296,7 @@ set(mds_files)
 list(APPEND mds_files
   mds/MDSMap.cc
   mds/FSMap.cc
+  mds/FSMapUser.cc
   mds/inode_backtrace.cc
   mds/mdstypes.cc)
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -49,6 +49,7 @@ using std::fstream;
 #include "UserGroups.h"
 
 class FSMap;
+class FSMapUser;
 class MonClient;
 
 class CephContext;
@@ -289,10 +290,12 @@ protected:
   // FSMap, for when using mds_command
   list<Cond*> waiting_for_fsmap;
   FSMap *fsmap;
+  FSMapUser *fsmap_user;
 
   // MDS command state
   std::map<ceph_tid_t, CommandOp> commands;
   void handle_command_reply(MCommandReply *m);
+  int fetch_fsmap(bool user);
   int resolve_mds(
       const std::string &mds_spec,
       std::vector<mds_gid_t> *targets);
@@ -569,6 +572,7 @@ protected:
   // messaging
   void handle_mds_map(class MMDSMap *m);
   void handle_fs_map(class MFSMap *m);
+  void handle_fs_map_user(class MFSMapUser *m);
   void handle_osd_map(class MOSDMap *m);
 
   void handle_lease(MClientLease *m);

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -121,6 +121,7 @@ libcommon_internal_la_SOURCES += \
 	osd/HitSet.cc \
 	mds/MDSMap.cc \
 	mds/FSMap.cc \
+	mds/FSMapUser.cc \
 	mds/inode_backtrace.cc \
 	mds/mdstypes.cc \
 	mds/flock.cc

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -416,7 +416,7 @@ OPTION(client_try_dentry_invalidate, OPT_BOOL, true) // the client should try to
 OPTION(client_die_on_failed_remount, OPT_BOOL, true)
 OPTION(client_check_pool_perm, OPT_BOOL, true)
 OPTION(client_use_faked_inos, OPT_BOOL, false)
-OPTION(client_mds_namespace, OPT_INT, -1)
+OPTION(client_mds_namespace, OPT_STR, "")
 
 OPTION(crush_location, OPT_STR, "")       // whitespace-separated list of key=value pairs describing crush location
 OPTION(crush_location_hook, OPT_STR, "")

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -133,6 +133,8 @@ struct ceph_dir_layout {
 
 /* FSMap subscribers (see all MDS clusters at once) */
 #define CEPH_MSG_FS_MAP                 45
+/* FSMapUser subscribers (get MDS clusters name->ID mapping) */
+#define CEPH_MSG_FS_MAP_USER		103
 
 
 /* watch-notify operations */

--- a/src/mds/FSMapUser.cc
+++ b/src/mds/FSMapUser.cc
@@ -1,0 +1,81 @@
+#include "FSMapUser.h"
+
+void FSMapUser::encode(bufferlist& bl, uint64_t features) const
+{
+  ENCODE_START(1, 1, bl);
+  ::encode(epoch, bl);
+  ::encode(legacy_client_fscid, bl);
+  std::vector<fs_info_t> fs_list;
+  for (auto p = filesystems.begin(); p != filesystems.end(); ++p)
+    fs_list.push_back(p->second);
+  ::encode(fs_list, bl, features);
+  ENCODE_FINISH(bl);
+}
+
+void FSMapUser::decode(bufferlist::iterator& p)
+{
+  DECODE_START(1, p);
+  ::decode(epoch, p);
+  ::decode(legacy_client_fscid, p);
+  std::vector<fs_info_t> fs_list;
+  ::decode(fs_list, p);
+  filesystems.clear();
+  for (auto p = fs_list.begin(); p != fs_list.end(); ++p)
+    filesystems[p->cid] = *p;
+  DECODE_FINISH(p);
+}
+
+void FSMapUser::fs_info_t::encode(bufferlist& bl, uint64_t features) const
+{
+  ENCODE_START(1, 1, bl);
+  ::encode(cid, bl);
+  ::encode(name, bl);
+  ENCODE_FINISH(bl);
+}
+
+void FSMapUser::fs_info_t::decode(bufferlist::iterator& p)
+{
+  DECODE_START(1, p);
+  ::decode(cid, p);
+  ::decode(name, p);
+  DECODE_FINISH(p);
+}
+
+void FSMapUser::generate_test_instances(list<FSMapUser*>& ls)
+{
+  FSMapUser *m = new FSMapUser();
+  m->epoch = 2;
+  m->legacy_client_fscid = 1;
+  m->filesystems[1].cid = 1;
+  m->filesystems[2].name = "cephfs2";
+  m->filesystems[2].cid = 2;
+  m->filesystems[1].name = "cephfs1";
+  ls.push_back(m);
+}
+
+
+void FSMapUser::print(ostream& out) const
+{
+  out << "e" << epoch << std::endl;
+  out << "legacy_client_fscid: " << legacy_client_fscid << std::endl;
+  for (auto &p : filesystems)
+    out << " id " <<  p.second.cid << " name " << p.second.name << std::endl;
+}
+
+void FSMapUser::print_summary(Formatter *f, ostream *out)
+{
+  map<mds_role_t,string> by_rank;
+  map<string,int> by_state;
+
+  if (f) {
+    f->dump_unsigned("epoch", get_epoch());
+    for (auto &p : filesystems) {
+      f->dump_unsigned("id", p.second.cid);
+      f->dump_string("name", p.second.name);
+    }
+  } else {
+    *out << "e" << get_epoch() << ":";
+    for (auto &p : filesystems)
+      *out << " " << p.second.name << "(" << p.second.cid << ")";
+  }
+}

--- a/src/mds/FSMapUser.h
+++ b/src/mds/FSMapUser.h
@@ -1,0 +1,75 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#ifndef CEPH_FSMAPCOMPACT_H
+#define CEPH_FSMAPCOMPACT_H
+
+#include "mds/mdstypes.h"
+#include <map>
+#include <string>
+
+class FSMapUser {
+public:
+  struct fs_info_t {
+    fs_cluster_id_t cid;
+    std::string name;
+    fs_info_t() : cid(FS_CLUSTER_ID_NONE) {}
+    void encode(bufferlist& bl, uint64_t features) const;
+    void decode(bufferlist::iterator &bl);
+  };
+
+  epoch_t epoch;
+  fs_cluster_id_t legacy_client_fscid;
+  std::map<fs_cluster_id_t, fs_info_t> filesystems;
+
+  FSMapUser()
+    : epoch(0), legacy_client_fscid(FS_CLUSTER_ID_NONE) { }
+
+  FSMapUser(const FSMapUser &o)
+    : epoch(o.epoch), legacy_client_fscid(o.legacy_client_fscid),
+      filesystems(o.filesystems) { }
+
+  FSMapUser &operator=(const FSMapUser &o)
+  {
+    epoch = o.epoch;
+    legacy_client_fscid = o.legacy_client_fscid;
+    filesystems = o.filesystems;
+    return *this;
+  }
+
+  epoch_t get_epoch() const { return epoch; }
+
+  fs_cluster_id_t get_fs_cid(const std::string &name) const {
+    for (auto &p : filesystems) {
+      if (p.second.name == name)
+	return p.first;
+    }
+    return FS_CLUSTER_ID_NONE;
+  }
+
+  void encode(bufferlist& bl, uint64_t features) const;
+  void decode(bufferlist::iterator& bl);
+
+  void print(ostream& out) const;
+  void print_summary(Formatter *f, ostream *out);
+
+  static void generate_test_instances(list<FSMapUser*>& ls);
+};
+WRITE_CLASS_ENCODER_FEATURES(FSMapUser::fs_info_t)
+WRITE_CLASS_ENCODER_FEATURES(FSMapUser)
+
+inline ostream& operator<<(ostream& out, FSMapUser& m) {
+  m.print_summary(NULL, &out);
+  return out;
+}
+#endif

--- a/src/mds/Makefile-server.am
+++ b/src/mds/Makefile-server.am
@@ -32,6 +32,7 @@ noinst_HEADERS += \
 	mds/MDSAuthCaps.h \
 	mds/MDSMap.h \
 	mds/FSMap.h \
+	mds/FSMapUser.h \
 	mds/MDSTable.h \
 	mds/MDSTableServer.h \
 	mds/MDSTableClient.h \

--- a/src/messages/MFSMap.h
+++ b/src/messages/MFSMap.h
@@ -41,7 +41,7 @@ private:
   ~MFSMap() {}
 
 public:
-  const char *get_type_name() const { return "mdsmap"; }
+  const char *get_type_name() const { return "fsmap"; }
   void print(ostream& out) const {
     out << "fsmap(e " << epoch << ")";
   }

--- a/src/messages/MFSMapUser.h
+++ b/src/messages/MFSMapUser.h
@@ -1,0 +1,59 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+
+#ifndef CEPH_MFSMAPCOMPACT_H
+#define CEPH_MFSMAPCOMPACT_H
+
+#include "msg/Message.h"
+#include "mds/FSMapUser.h"
+#include "include/ceph_features.h"
+
+class MFSMapUser : public Message {
+ public:
+  epoch_t epoch;
+
+  version_t get_epoch() const { return epoch; }
+  const FSMapUser & get_fsmap() { return fsmap; }
+
+  MFSMapUser() :
+    Message(CEPH_MSG_FS_MAP_USER), epoch(0) {}
+  MFSMapUser(const uuid_d &f, const FSMapUser &fsmap_) :
+    Message(CEPH_MSG_FS_MAP_USER), epoch(fsmap_.epoch)
+  {
+    fsmap = fsmap_;
+  }
+private:
+  FSMapUser fsmap;
+
+  ~MFSMapUser() {}
+
+public:
+  const char *get_type_name() const { return "fsmap.user"; }
+  void print(ostream& out) const {
+    out << "fsmap.user(e " << epoch << ")";
+  }
+
+  // marshalling
+  void decode_payload() {
+    bufferlist::iterator p = payload.begin();
+    ::decode(epoch, p);
+    ::decode(fsmap, p);
+  }
+  void encode_payload(uint64_t features) {
+    ::encode(epoch, payload);
+    ::encode(fsmap, payload, features);
+  }
+};
+
+#endif

--- a/src/messages/Makefile.am
+++ b/src/messages/Makefile.am
@@ -49,6 +49,7 @@ noinst_HEADERS += \
 	messages/MMDSFragmentNotify.h \
 	messages/MMDSMap.h \
 	messages/MFSMap.h \
+	messages/MFSMapUser.h \
 	messages/MMDSOpenIno.h \
 	messages/MMDSOpenInoReply.h \
 	messages/MMDSResolve.h \

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4271,7 +4271,7 @@ void Monitor::handle_subscribe(MonOpRequestRef op)
 			       p->second.flags & CEPH_SUBSCRIBE_ONETIME,
 			       m->get_connection()->has_feature(CEPH_FEATURE_INCSUBOSDMAP));
 
-    if (p->first.find("mdsmap") == 0 || p->first == "fsmap") {
+    if (p->first.compare(0, 6, "mdsmap") == 0 || p->first.compare(0, 5, "fsmap") == 0) {
       dout(10) << __func__ << ": MDS sub '" << p->first << "'" << dendl;
       if ((int)s->is_capable("mds", MON_CAP_R)) {
         Subscription *sub = s->sub_map[p->first];

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -112,6 +112,7 @@ using namespace std;
 
 #include "messages/MMDSMap.h"
 #include "messages/MFSMap.h"
+#include "messages/MFSMapUser.h"
 #include "messages/MMDSBeacon.h"
 #include "messages/MMDSLoadTargets.h"
 #include "messages/MMDSResolve.h"
@@ -577,6 +578,9 @@ Message *decode_message(CephContext *cct, int crcflags,
     break;
   case CEPH_MSG_FS_MAP:
     m = new MFSMap;
+    break;
+  case CEPH_MSG_FS_MAP_USER:
+    m = new MFSMapUser;
     break;
   case MSG_MDS_BEACON:
     m = new MMDSBeacon;


### PR DESCRIPTION
To mount non-default filesytem, user needs to provide mds namespace ID.
This is inconvenience.

This patch makes user be able to mount filesystem by name. To do this,
client first subscribes to FSMap. Subscribe to mdsmap.<ID> after knowning
ID of the filesystem.

Signed-off-by: Yan, Zheng <zyan@redhat.com>