### PR TITLE
mds: build fix for LIBMDS consumer.

### DIFF
--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -285,10 +285,12 @@ ceph_test_rados_api_lock_LDADD = $(LIBRADOS) $(UNITTEST_LDADD) $(RADOS_TEST_LDAD
 ceph_test_rados_api_lock_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_rados_api_lock
 
+if WITH_MDS
 ceph_test_rados_api_tmap_migrate_SOURCES = test/librados/tmap_migrate.cc tools/cephfs/DataScan.cc tools/cephfs/MDSUtility.cc
 ceph_test_rados_api_tmap_migrate_LDADD = $(LIBRADOS) $(UNITTEST_LDADD) $(LIBMDS) libcls_cephfs_client.la  $(CEPH_GLOBAL) $(RADOS_TEST_LDADD)
 ceph_test_rados_api_tmap_migrate_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_rados_api_tmap_migrate
+endif
 
 
 ceph_test_stress_watch_SOURCES = test/test_stress_watch.cc


### PR DESCRIPTION
If you have --without-mds, then this test case cannot be compiled due to
the lack of libmds.

Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>