### PR TITLE
MDSMonitor: introduce command 'fs set_default <fs_name>'

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1740,6 +1740,17 @@ int MDSMonitor::management_command(
     // Persist the new FSMap
     pending_fsmap.filesystems[new_fs->fscid] = new_fs;
     return 0;
+  } else if (prefix == "fs set_default") {
+    string fs_name;
+    cmd_getval(g_ceph_context, cmdmap, "fs_name", fs_name);
+    auto fs = pending_fsmap.get_filesystem(fs_name);
+    if (fs == nullptr) {
+        ss << "filesystem '" << fs_name << "' does not exist";
+        return -ENOENT;
+    }
+
+    pending_fsmap.legacy_client_fscid = fs->fscid;
+    return 0;
   } else {
     return -ENOSYS;
   }

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -411,6 +411,9 @@ COMMAND("fs add_data_pool name=fs_name,type=CephString " \
 COMMAND("fs rm_data_pool name=fs_name,type=CephString " \
 	"name=pool,type=CephString", \
 	"remove data pool <pool>", "mds", "rw", "cli,rest")
+COMMAND("fs set_default name=fs_name,type=CephString", \
+	"set the default to the named filesystem", \
+	"fs", "rw", "cli,rest")
 
 /*
  * Monmap commands

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -491,6 +491,11 @@ class TestFS(TestArgparse):
         self.assert_valid_command(['fs', 'ls'])
         assert_equal({}, validate_command(sigdict, ['fs', 'ls', 'toomany']))
 
+    def test_fs_set_default(self):
+        self.assert_valid_command(['fs', 'set_default', 'cephfs'])
+        assert_equal({}, validate_command(sigdict, ['fs', 'set_default']))
+        assert_equal({}, validate_command(sigdict, ['fs', 'set_default', 'cephfs', 'toomany']))
+
 class TestMon(TestArgparse):
 
     def test_dump(self):


### PR DESCRIPTION
set default filesystem for legacy client

Signed-off-by: Yan, Zheng <zyan@redhat.com>