### PR TITLE
Makefile-env.am: set a default for CEPH_BUILD_VIRTUALENV (part 3)

### DIFF
--- a/src/ceph-detect-init/run-tox.sh
+++ b/src/ceph-detect-init/run-tox.sh
@@ -23,7 +23,7 @@ if [ x"`uname`"x = xFreeBSDx ]; then
 fi
 
 # run from the ceph-detect-init directory or from its parent
-: ${CEPH_DETECT_INIT_VIRTUALENV:=ceph-detect-init-virtualenv}
+: ${CEPH_DETECT_INIT_VIRTUALENV:=/tmp/ceph-detect-init-virtualenv}
 test -d ceph-detect-init && cd ceph-detect-init
 source ${CEPH_DETECT_INIT_VIRTUALENV}/bin/activate
 tox > ${CEPH_DETECT_INIT_VIRTUALENV}/tox.out 2>&1

--- a/src/ceph-disk/run-tox.sh
+++ b/src/ceph-disk/run-tox.sh
@@ -16,7 +16,7 @@
 #
 
 # run from the ceph-disk directory or from its parent
-: ${CEPH_DISK_VIRTUALENV:=ceph-disk-virtualenv}
+: ${CEPH_DISK_VIRTUALENV:=/tmp/ceph-disk-virtualenv}
 test -d ceph-disk && cd ceph-disk
 source ${CEPH_DISK_VIRTUALENV}/bin/activate
 tox > ${CEPH_DISK_VIRTUALENV}/tox.out 2>&1


### PR DESCRIPTION
The default values in the run-tox.sh scripts must be updated as well, so
that it is possible to run them from the command line for debug
purposes. Otherwise it is mandatory to run them from

  make TESTS=ceph-detect-init/run-tox.sh check

which introduces a significant delay. The alternative is to run with

  CEPH_DETECT_INIT_VIRTUALENV:=/tmp/ceph-detect-init-virtualenv \
    ceph-detect-init/run-tox.sh

but it's difficult to figure out.

Followup of fa450896ace454dbd140b2d4c71535ab015fc407

Signed-off-by: Loic Dachary <loic@dachary.org>