### PR TITLE
qa: update rest test cephfs calls (part 2)

### DIFF
--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -196,9 +196,9 @@ if __name__ == '__main__':
     r = expect('mds/stat.json', 'GET', 200, 'json')
     expect('mds/set?var=max_mds&val=2', 'PUT', 200, '')
     r = expect('mds/stat.json', 'GET', 200, 'json')
-    assert('info' in r.myjson['output']['mdsmap'])
+    assert('epoch' in r.myjson['output']['fsmap'])
     r = expect('mds/stat.xml', 'GET', 200, 'xml')
-    assert(r.tree.find('output/mds_stat/mdsmap/info') is not None)
+    assert(r.tree.find('output/mds_stat/fsmap/epoch') is not None)
 
     # more content tests below, just check format here
     expect('mon/dump.json', 'GET', 200, 'json')


### PR DESCRIPTION
"mds stat" now gives fsmap output rather than
mdsmap.  Update the rest api test's expectations.

Fixes: http://tracker.ceph.com/issues/15309
Signed-off-by: John Spray <john.spray@redhat.com>