### PR TITLE
rgw: fix build failure, reference member correctly

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2428,7 +2428,7 @@ void RGWListMultipart_ObjStore_S3::send_response()
       dump_time(s, "LastModified", &info.modified);
 
       s->formatter->dump_unsigned("PartNumber", info.num);
-      s->formatter->dump_format("ETag", "\"%s\"", info->etag.c_str());
+      s->formatter->dump_format("ETag", "\"%s\"", info.etag.c_str());
       s->formatter->dump_unsigned("Size", info.size);
       s->formatter->close_section();
     }


### PR DESCRIPTION
fixing referring to a non pointer member via -> operator
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>