### PR TITLE
mon: remove unnecessary comment for update_from_paxos

### DIFF
--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -343,8 +343,6 @@ public:
   /**
    * Query the Paxos system for the latest state and apply it if it's newer
    * than the current Monitor state.
-   *
-   * @returns 'true' on success; 'false' otherwise.
    */
   virtual void update_from_paxos(bool *need_bootstrap) = 0;
 


### PR DESCRIPTION
The return value comment for update_from_paxos is unnecessary.

Signed-off-by: Qinghua Jin <qhjin_dev@163.com>