### PR TITLE
hammer: Protect against excessively large object map sizes

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -104,6 +104,7 @@ cls_method_handle_t h_old_snapshot_remove;
 #define RBD_SNAP_KEY_PREFIX "snapshot_"
 #define RBD_DIR_ID_KEY_PREFIX "id_"
 #define RBD_DIR_NAME_KEY_PREFIX "name_"
+#define RBD_MAX_OBJECT_MAP_OBJECT_COUNT 256000000
 
 static int snap_read_header(cls_method_context_t hctx, bufferlist& bl)
 {
@@ -1993,6 +1994,12 @@ int object_map_resize(cls_method_context_t hctx, bufferlist *in, bufferlist *out
     ::decode(object_count, iter);
     ::decode(default_state, iter);
   } catch (const buffer::error &err) {
+    return -EINVAL;
+  }
+
+  // protect against excessive memory requirements
+  if (object_count > RBD_MAX_OBJECT_MAP_OBJECT_COUNT) {
+    CLS_ERR("object map too large: %" PRIu64, object_count);
     return -EINVAL;
   }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/15129