### PR TITLE
configure: Add -D_LARGEFILE64_SOURCE to Linux build.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,7 @@ darwin*)
 	;;
 linux*)
 	linux="yes"
+	CFLAGS="-D_LARGEFILE64_SOURCE ${CFLAGS}"
 	;;
 freebsd*)
 	freebsd="yes"


### PR DESCRIPTION
Without -D_LARGEFILE64_SOURCE we can't build against libxfs,
because off64_t must be defined.

Builds on Fedora 23 are broken without this fix.

"mock" builds now pass with this patch in place.