### PR TITLE
mds: Add cmapv to ESessions default constructor initializer list

### DIFF
--- a/src/mds/events/ESessions.h
+++ b/src/mds/events/ESessions.h
@@ -28,7 +28,7 @@ public:
   map<client_t,entity_inst_t> client_map;
   bool old_style_encode;
 
-  ESessions() : LogEvent(EVENT_SESSIONS), old_style_encode(false) { }
+  ESessions() : LogEvent(EVENT_SESSIONS), cmapv(0), old_style_encode(false) { }
   ESessions(version_t pv, map<client_t,entity_inst_t>& cm) :
     LogEvent(EVENT_SESSIONS),
     cmapv(pv),


### PR DESCRIPTION
2 EOpen
1 EResetJournal
1 ESession
1 ESessions
/tmp/typ-0xkIaUoD0 /tmp/typ-BGoHeqaPh differ: char 31, line 2
**** ESessions test 1 dump_json check failed ****
   ./ceph-dencoder type ESessions select_test 1 dump_json > /tmp/typ-0xkIaUoD0
   ./ceph-dencoder type ESessions select_test 1 encode decode dump_json > /tmp/typ-BGoHeqaPh
   diff /tmp/typ-0xkIaUoD0 /tmp/typ-BGoHeqaPh
/tmp/typ-0xkIaUoD0 /tmp/typ-tiU63rZX2 differ: char 30, line 2
**** ESessions test 1 copy dump_json check failed ****
   ./ceph-dencoder type ESessions select_test 1 dump_json > /tmp/typ-0xkIaUoD0
   ./ceph-dencoder type ESessions select_test 1 copy dump_json > /tmp/typ-BGoHeqaPh
   diff /tmp/typ-0xkIaUoD0 /tmp/typ-BGoHeqaPh
/tmp/typ-0xkIaUoD0 /tmp/typ-UQHZ1V5Cl differ: char 31, line 2
**** ESessions test 1 copy_ctor dump_json check failed ****
   ./ceph-dencoder type ESessions select_test 1 dump_json > /tmp/typ-0xkIaUoD0
   ./ceph-dencoder type ESessions select_test 1 copy_ctor dump_json > /tmp/typ-BGoHeqaPh
   diff /tmp/typ-0xkIaUoD0 /tmp/typ-BGoHeqaPh
/tmp/typ-0xkIaUoD0 /tmp/typ-BGoHeqaPh differ: char 11, line 1
**** ESessions test 1 binary reencode check failed ****
   ./ceph-dencoder type ESessions select_test 1 encode export /tmp/typ-0xkIaUoD0
   ./ceph-dencoder type ESessions select_test 1 encode decode encode export /tmp/typ-BGoHeqaPh
   cmp /tmp/typ-0xkIaUoD0 /tmp/typ-BGoHeqaPh
1 ESlaveUpdate
1 ESubtreeMap
1 ETableClient
1 ETableServer
1 EUpdate

rkb:~/ceph/src$ cat /tmp/typ-n8fovLxy5
{
    "client map version": 138185855205184,
    "client map": []
}

rkb:~/ceph/src$ cat /tmp/typ-PPFrpu8uR
{
    "client map version": 124927316901915,
    "client map": []
}