### PR TITLE
common: Fix ObjBencher clean_up when no prefix specified

### DIFF
--- a/qa/workunits/rados/test_rados_tool.sh
+++ b/qa/workunits/rados/test_rados_tool.sh
@@ -418,6 +418,11 @@ test_cleanup() {
         die "Different objects found after cleanup"
     fi
 
+    set +e
+    run_expect_fail $RADOS_TOOL -p $p cleanup --prefix illegal_prefix
+    run_expect_succ $RADOS_TOOL -p $p cleanup --prefix benchmark_data_otherhost
+    set -e
+
     $RADOS_TOOL rmpool $p $p --yes-i-really-really-mean-it
 }
 

--- a/qa/workunits/rados/test_rados_tool.sh
+++ b/qa/workunits/rados/test_rados_tool.sh
@@ -55,6 +55,10 @@ RADOS_TOOL="`readlink -f \"$DNAME/../rados\"`"
 if ! test -f $RADOS_TOOL ; then
     RADOS_TOOL=$(which rados)
 fi
+CEPH_TOOL="`readlink -f \"$DNAME/../ceph\"`"
+if ! test -f $CEPH_TOOL ; then
+    RADOS_TOOL=$(which ceph)
+fi
 KEEP_TEMP_FILES=0
 POOL=trs_pool
 POOL_CP_TARGET=trs_pool.2
@@ -306,11 +310,11 @@ test_xattr() {
 }
 test_rmobj() {
     p=`uuidgen`
-    ceph osd pool create $p 1
-    ceph osd pool set-quota $p max_objects 1
+    $CEPH_TOOL osd pool create $p 1
+    $CEPH_TOOL osd pool set-quota $p max_objects 1
     V1=`mktemp fooattrXXXXXXX`
     rados put $OBJ $V1 -p $p
-    while ! ceph osd dump | grep 'full max_objects'
+    while ! $CEPH_TOOL osd dump | grep 'full max_objects'
     do
 	sleep 2
     done

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -45,11 +45,10 @@ static std::string generate_object_prefix_nopid() {
 }
 
 static std::string generate_object_prefix(int pid = 0) {
-  if (!cached_pid) {
-    if (!pid)
-      pid = getpid();
+  if (pid)
     cached_pid = pid;
-  }
+  else if (!cached_pid)
+    cached_pid = getpid();
 
   std::ostringstream oss;
   oss << generate_object_prefix_nopid() << "_" << cached_pid;
@@ -58,19 +57,9 @@ static std::string generate_object_prefix(int pid = 0) {
 
 static std::string generate_object_name(int objnum, int pid = 0)
 {
-  if (cached_hostname[0] == 0) {
-    gethostname(cached_hostname, sizeof(cached_hostname)-1);
-    cached_hostname[sizeof(cached_hostname)-1] = 0;
-  }
-  if (!cached_pid) {
-    if (!pid)
-      pid = getpid();
-    cached_pid = pid;
-  }
-
-  char name[1024];
-  size_t l = sprintf(&name[0], "%s_%s_%d_object%d", BENCH_PREFIX.c_str(), cached_hostname, cached_pid, objnum);
-  return string(&name[0], l);
+  std::ostringstream oss;
+  oss << generate_object_prefix(pid) << "_object" << objnum;
+  return oss.str();
 }
 
 static void sanitize_object_contents (bench_data *data, size_t length) {
@@ -1095,29 +1084,57 @@ int ObjBencher::clean_up(const std::string& orig_prefix, int concurrentios, cons
   size_t op_size, object_size;
   int num_objects;
   int prevPid;
-  std::string prefix = orig_prefix;
 
   // default meta object if user does not specify one
   const std::string run_name_meta = (run_name.empty() ? BENCH_LASTRUN_METADATA : run_name);
+  const std::string prefix = (orig_prefix.empty() ? generate_object_prefix_nopid() : orig_prefix);
 
-  r = fetch_bench_metadata(run_name_meta, &op_size, &object_size, &num_objects, &prevPid);
-  if (r < 0) {
-    // if the metadata file is not found we should try to do a linear search on the prefix
-    if (r == -ENOENT) {
-      if (prefix == "")
-	prefix = generate_object_prefix_nopid();
-      return clean_up_slow(prefix, concurrentios);
-    }
-    else {
-      return r;
+  std::list<Object> unfiltered_objects;
+  std::set<std::string> meta_namespaces, all_namespaces;
+
+  // If caller set all_nspaces this will be searching
+  // across multiple namespaces.
+  while (true) {
+    bool objects_remain = get_objects(&unfiltered_objects, 20);
+    if (!objects_remain)
+      break;
+
+    std::list<Object>::const_iterator i = unfiltered_objects.begin();
+    for ( ; i != unfiltered_objects.end(); ++i) {
+      if (i->first == run_name_meta) {
+        meta_namespaces.insert(i->second);
+      }
+      if (i->first.substr(0, prefix.length()) == prefix) {
+        all_namespaces.insert(i->second);
+      }
     }
   }
 
-  r = clean_up(num_objects, prevPid, concurrentios);
-  if (r != 0) return r;
+  std::set<std::string>::const_iterator i = all_namespaces.begin();
+  for ( ; i != all_namespaces.end(); ++i) {
+    set_namespace(*i);
 
-  r = sync_remove(run_name_meta);
-  if (r != 0) return r;
+    // if no metadata file found we should try to do a linear search on the prefix
+    if (meta_namespaces.find(*i) == meta_namespaces.end()) {
+      int r = clean_up_slow(prefix, concurrentios);
+      if (r < 0) {
+        cerr << "clean_up_slow error r= " << r << std::endl;
+        return r;
+      }
+      continue;
+    }
+
+    r = fetch_bench_metadata(run_name_meta, &op_size, &object_size, &num_objects, &prevPid);
+    if (r < 0) {
+      return r;
+    }
+
+    r = clean_up(num_objects, prevPid, concurrentios);
+    if (r != 0) return r;
+
+    r = sync_remove(run_name_meta);
+    if (r != 0) return r;
+  }
 
   return 0;
 }
@@ -1240,6 +1257,8 @@ int ObjBencher::clean_up(int num_objects, int prevPid, int concurrentios) {
   lock.Unlock();
 
   completions_done();
+
+  out(cout) << "Removed " << data.finished << " object" << (data.finished != 1 ? "s" : "") << std::endl;
 
   return 0;
 

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -1089,6 +1089,11 @@ int ObjBencher::clean_up(const std::string& orig_prefix, int concurrentios, cons
   const std::string run_name_meta = (run_name.empty() ? BENCH_LASTRUN_METADATA : run_name);
   const std::string prefix = (orig_prefix.empty() ? generate_object_prefix_nopid() : orig_prefix);
 
+  if (prefix.substr(0, BENCH_PREFIX.length()) != BENCH_PREFIX) {
+    cerr << "Specified --prefix invalid, it must begin with \"" << BENCH_PREFIX << "\"" << std::endl;
+    return -EINVAL;
+  }
+
   std::list<Object> unfiltered_objects;
   std::set<std::string> meta_namespaces, all_namespaces;
 

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2769,6 +2769,8 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   else if (strcmp(nargs[0], "cleanup") == 0) {
     if (!pool_name)
       usage_exit();
+    if (wildcard)
+      io_ctx.set_namespace(all_nspaces);
     RadosBencher bencher(g_ceph_context, rados, io_ctx);
     ret = bencher.clean_up(prefix, concurrent_ios, run_name);
     if (ret != 0)


### PR DESCRIPTION

Fix rados cleanup when there is no benchmark_last_metadata available
Support --all option with rados cleanup
Prevent rados cleanup from being used to remove non rados bench objects

Fixes: http://tracker.ceph.com/issues/15338