### PR TITLE
DNM: osd: fix epoch check in handle_pg_create

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7096,7 +7096,17 @@ void OSD::handle_pg_create(OpRequestRef op)
      * cannot be on the other side of a map gap
      */
     assert(valid_history);
-    
+
+    // The mon won't resend unless the primary changed, so
+    // we ignore same_interval_since.
+    if (history.same_primary_since > m->epoch) {
+      dout(10) << __func__ << ": got obsolete pg create on pgid "
+               << pgid << " from epoch " << m->epoch
+               << ", primary changed in " << history.same_primary_since
+               << dendl;
+      continue;
+    }
+
     // register.
     creating_pgs[pgid].history = history;
     creating_pgs[pgid].parent = parent;


### PR DESCRIPTION
Rather than add a flag to handle_pg_peering_evt, check
same_primary_since here and pass the create event to
handle_pg_peering_evt as if it originated at the current epoch (the
project_pg_history checks in handle_pg_peering_evt will be noops).

Fixes: tracker.ceph.com/issues/15241
Signed-off-by: Samuel Just <sjust@redhat.com>
(cherry picked from commit 7e58045f0e3226882f7b608300e70fd0c97dd6bf)

Conflicts:
	- the original change also passes the osdmap->get_epoch() to
handle_pg_peering_evt(), but that relies on the commit of 53f2c7f
and 439bdbe. so we do the cherry-pick the hard way.
    - and also remove the comment no longer applies