### PR TITLE
libradosstriper: async rm, truncate

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -923,6 +923,7 @@ namespace librados
      * other than SNAP_HEAD
      */
     int aio_remove(const std::string& oid, AioCompletion *c);
+    int aio_remove(const std::string& oid, AioCompletion *c, int flags);
 
     /**
      * Wait for all currently pending aio writes to be safe.

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -920,7 +920,7 @@ int librados::IoCtxImpl::aio_write_full(const object_t &oid,
   return 0;
 }
 
-int librados::IoCtxImpl::aio_remove(const object_t &oid, AioCompletionImpl *c)
+int librados::IoCtxImpl::aio_remove(const object_t &oid, AioCompletionImpl *c, int flags)
 {
   auto ut = ceph::real_clock::now(client->cct);
 
@@ -935,7 +935,7 @@ int librados::IoCtxImpl::aio_remove(const object_t &oid, AioCompletionImpl *c)
   queue_aio_write(c);
 
   c->tid = objecter->remove(oid, oloc,
-		   snapc, ut, 0,
+		   snapc, ut, flags,
 		   onack, onsafe, &c->objver);
 
   return 0;

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -201,7 +201,7 @@ struct librados::IoCtxImpl {
 		 const bufferlist& bl, size_t len);
   int aio_write_full(const object_t &oid, AioCompletionImpl *c,
 		     const bufferlist& bl);
-  int aio_remove(const object_t &oid, AioCompletionImpl *c);
+  int aio_remove(const object_t &oid, AioCompletionImpl *c, int flags=0);
   int aio_exec(const object_t& oid, AioCompletionImpl *c, const char *cls,
 	       const char *method, bufferlist& inbl, bufferlist *outbl);
   int aio_stat(const object_t& oid, AioCompletionImpl *c, uint64_t *psize, time_t *pmtime);

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -1801,6 +1801,11 @@ int librados::IoCtx::aio_remove(const std::string& oid, librados::AioCompletion 
   return io_ctx_impl->aio_remove(oid, c->pc);
 }
 
+int librados::IoCtx::aio_remove(const std::string& oid, librados::AioCompletion *c, int flags)
+{
+  return io_ctx_impl->aio_remove(oid, c->pc, flags);
+}
+
 int librados::IoCtx::aio_flush_async(librados::AioCompletion *c)
 {
   io_ctx_impl->flush_aio_writes_async(c->pc);


### PR DESCRIPTION
optimized truncation and removal of striped objects in the radosstriper library by using the async API of the rados layer.
The previous implementation was a first, inefficient one.