### PR TITLE
cls_journal: fix -EEXIST checking

### DIFF
--- a/src/cls/journal/cls_journal.cc
+++ b/src/cls/journal/cls_journal.cc
@@ -250,9 +250,11 @@ int journal_create(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
 
   bufferlist stored_orderbl;
   int r = cls_cxx_map_get_val(hctx, HEADER_KEY_ORDER, &stored_orderbl);
-  if (r != -ENOENT) {
+  if (r >= 0) {
     CLS_ERR("journal already exists");
     return -EEXIST;
+  } else if (r != -ENOENT) {
+    return r;
   }
 
   r = write_key(hctx, HEADER_KEY_ORDER, order);
@@ -556,9 +558,11 @@ int journal_client_register(cls_method_context_t hctx, bufferlist *in,
   std::string key(key_from_client_id(id));
   bufferlist stored_clientbl;
   r = cls_cxx_map_get_val(hctx, key, &stored_clientbl);
-  if (r != -ENOENT) {
+  if (r >= 0) {
     CLS_ERR("duplicate client id: %s", id.c_str());
     return -EEXIST;
+  } else if (r != -ENOENT) {
+    return r;
   }
 
   cls::journal::Client client(id, data);
@@ -866,9 +870,11 @@ int journal_tag_create(cls_method_context_t hctx, bufferlist *in,
   std::string key(key_from_tag_tid(tag_tid));
   bufferlist stored_tag_bl;
   int r = cls_cxx_map_get_val(hctx, key, &stored_tag_bl);
-  if (r != -ENOENT) {
+  if (r >= 0) {
     CLS_ERR("duplicate tag id: %" PRIu64, tag_tid);
     return -EEXIST;
+  } else if (r != -ENOENT) {
+    return r;
   }
 
   // verify tag tid ordering


### PR DESCRIPTION
the interface `cls_cxx_map_get_val` may return error code other than `-ENOENT`, so we'd better not to translate error code other than `-ENOENT` into `-EEXIST`.

Signed-off-by: runsisi <runsisi@zte.com.cn>