### PR TITLE
os/ObjectStore: make device uuid probe output something friendly

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -189,7 +189,8 @@ int main(int argc, const char **argv)
   }
   if (get_device_fsid) {
     uuid_d uuid;
-    int r = ObjectStore::probe_block_device_fsid(device_path, &uuid);
+    int r = ObjectStore::probe_block_device_fsid(g_ceph_context, device_path,
+						 &uuid);
     if (r < 0) {
       cerr << "failed to get device fsid for " << device_path
 	   << ": " << cpp_strerror(r) << std::endl;

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -86,6 +86,7 @@ ObjectStore *ObjectStore::create(CephContext *cct,
 }
 
 int ObjectStore::probe_block_device_fsid(
+  CephContext *cct,
   const string& path,
   uuid_d *fsid)
 {
@@ -95,14 +96,20 @@ int ObjectStore::probe_block_device_fsid(
   // first try bluestore -- it has a crc on its header and will fail
   // reliably.
   r = BlueStore::get_block_device_fsid(path, fsid);
-  if (r == 0)
+  if (r == 0) {
+    lgeneric_dout(cct, 0) << __func__ << " " << path << " is bluestore, "
+			  << *fsid << dendl;
     return r;
+  }
 #endif
 
   // okay, try FileStore (journal).
   r = FileStore::get_block_device_fsid(path, fsid);
-  if (r == 0)
+  if (r == 0) {
+    lgeneric_dout(cct, 0) << __func__ << " " << path << " is filestore, "
+			  << *fsid << dendl;
     return r;
+  }
 
   return -EINVAL;
 }

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -119,8 +119,10 @@ public:
    * @param path path to device
    * @param fsid [out] osd uuid
    */
-  static int probe_block_device_fsid(const string& path,
-				     uuid_d *fsid);
+  static int probe_block_device_fsid(
+    CephContext *cct,
+    const string& path,
+    uuid_d *fsid);
 
   Logger *logger;
 


### PR DESCRIPTION
Otherwise, all you see is errors about the probes that failed (e.g., a
failure to decode a non-bluestore superblock as bluestore).

Signed-off-by: Sage Weil <sage@redhat.com>