### PR TITLE
fix set 128MB tcmalloc cache size by bytes

### DIFF
--- a/etc/sysconfig/ceph
+++ b/etc/sysconfig/ceph
@@ -4,7 +4,7 @@
 #
 
 # Increase tcmalloc cache size
-TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=128MB
+TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728
 
 ## use jemalloc instead of tcmalloc
 #


### PR DESCRIPTION
Setting TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES value by bytes.