### PR TITLE
tests: Fixing broken test/cephtool-test-mon.sh test

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1007,7 +1007,7 @@ function test_mon_mds_metadata()
 function test_mon_mon()
 {
   # print help message
-  ceph mon
+  ceph --help mon
   # no mon add/remove
   ceph mon dump
   ceph mon getmap -o $TMPDIR/monmap.$$
@@ -1145,7 +1145,7 @@ function test_mon_osd()
   [ "$id" = "$id2" ]
   ceph osd rm $id
 
-  ceph osd
+  ceph --help osd
 
   # reset max_osd.
   ceph osd setmaxosd $id


### PR DESCRIPTION
Since the merge of pr #7693, 'ceph command' to get the help is invalid.
As a result, 'test/cephtool-test-mon.sh' test was broken

This patch simply change the 'ceph command' by a 'ceph --help command'

Since this change the test is passing again.

Signed-off-by: Erwan Velu <erwan@redhat.com>