### PR TITLE
mon: warn if 'sortbitwise' flag is not set and no legacy OSDs are present

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -312,6 +312,14 @@ Upgrading from Infernalis
 * The rbd legacy image format (version 1) is deprecated with the Jewel
   release.
 
+* After upgrading, users should set the 'sortbitwise' flag to enable the new
+  internal object sort order::
+
+    ceph osd set sortbitwise
+
+  This flag is important for the new object enumeration API and for
+  new backends like BlueStore.
+
 Notable Changes since v10.0.4
 -----------------------------
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -271,6 +271,7 @@ OPTION(mon_crush_min_required_version, OPT_STR, "firefly")
 OPTION(mon_warn_on_crush_straw_calc_version_zero, OPT_BOOL, true) // warn if crush straw_calc_version==0
 OPTION(mon_warn_on_osd_down_out_interval_zero, OPT_BOOL, true) // warn if 'mon_osd_down_out_interval == 0'
 OPTION(mon_warn_on_cache_pools_without_hit_sets, OPT_BOOL, true)
+OPTION(mon_warn_on_no_sortbitwise, OPT_BOOL, true)  // warn when sortbitwise not set
 OPTION(mon_min_osdmap_epochs, OPT_INT, 500)
 OPTION(mon_max_pgmap_epochs, OPT_INT, 500)
 OPTION(mon_max_log_epochs, OPT_INT, 500)

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2955,6 +2955,16 @@ void OSDMonitor::get_health(list<pair<health_status_t,string> >& summary,
       }
     }
 
+    // Not using 'sortbitwise' and should be?
+    if (g_conf->mon_warn_on_no_sortbitwise &&
+	!osdmap.test_flag(CEPH_OSDMAP_SORTBITWISE) &&
+	(osdmap.get_features(CEPH_ENTITY_TYPE_OSD, NULL) &
+	 CEPH_FEATURE_OSD_BITWISE_HOBJ_SORT)) {
+      ostringstream ss;
+      ss << "no legacy OSD present but 'sortbitwise' flag is not set";
+      summary.push_back(make_pair(HEALTH_WARN, ss.str()));
+    }
+
     // Warn if 'mon_osd_down_out_interval' is set to zero.
     // Having this option set to zero on the leader acts much like the
     // 'noout' flag.  It's hard to figure out what's going wrong with clusters


### PR DESCRIPTION
If the user has upgraded, they should set sortbitwise.

Signed-off-by: Sage Weil <sage@redhat.com>