### PR TITLE
global/global_init: expand metavariables in setuser_match_path

### DIFF
--- a/src/common/config.h
+++ b/src/common/config.h
@@ -185,7 +185,13 @@ private:
 
   bool expand_meta(std::string &val,
 		   std::ostream *oss) const;
-
+public:  // for global_init
+  bool early_expand_meta(std::string &val,
+			 std::ostream *oss) const {
+    Mutex::Locker l(lock);
+    return expand_meta(val, oss);
+  }
+private:
   bool expand_meta(std::string &val,
 		   config_option *opt,
 		   std::list<config_option *> stack,

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -195,8 +195,11 @@ void global_init(std::vector < const char * > *alt_def_args,
     }
     if ((uid || gid) &&
 	g_conf->setuser_match_path.length()) {
+      // induce early expansion of setuser_match_path config option
+      string match_path = g_conf->setuser_match_path;
+      g_conf->early_expand_meta(match_path, &cerr);
       struct stat st;
-      int r = ::stat(g_conf->setuser_match_path.c_str(), &st);
+      int r = ::stat(match_path.c_str(), &st);
       if (r < 0) {
 	r = -errno;
 	cerr << "unable to stat setuser_match_path "
@@ -206,7 +209,7 @@ void global_init(std::vector < const char * > *alt_def_args,
       }
       if ((uid && uid != st.st_uid) ||
 	  (gid && gid != st.st_gid)) {
-	cerr << "WARNING: will not setuid/gid: " << g_conf->setuser_match_path
+	cerr << "WARNING: will not setuid/gid: " << match_path
 	     << " owned by " << st.st_uid << ":" << st.st_gid
 	     << " and not requested " << uid << ":" << gid
 	     << std::endl;
@@ -216,7 +219,7 @@ void global_init(std::vector < const char * > *alt_def_args,
 	gid_string.erase();
       } else {
 	priv_ss << "setuser_match_path "
-		<< g_conf->setuser_match_path << " owned by "
+		<< match_path << " owned by "
 		<< st.st_uid << ":" << st.st_gid << ". ";
       }
     }


### PR DESCRIPTION
Back in 8290536d7d373ea6dddd8cdb55ac71e42b5278e2 we moved the
apply_changse (and, indirectly, config var expansion) to happen
after set do the drop privileges, but we need the metavar
expansion for setuser_match_path (which docs suggest setting to
/var/lib/ceph/$type/$cluster-$id).

Fixes: http://tracker.ceph.com/issues/15365
Signed-off-by: Sage Weil <sage@redhat.com>