### PR TITLE
os/kv, os/bluestore: Enable SingleDelete with RocksDB and Bluestore

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -88,6 +88,16 @@ public:
       const std::string &k	      ///< [in] Key to remove
       ) = 0;
 
+    /// Remove Single Key which exists and was not overwritten.
+    /// This API is only related to performance optimization, and should only be 
+    /// re-implemented by log-insert-merge tree based keyvalue stores(such as RocksDB). 
+    /// If a key is overwritten (by calling set multiple times), then the result
+    /// of calling rm_single_key on this key is undefined.
+    virtual void rm_single_key(
+      const std::string &prefix,   ///< [in] Prefix to search for
+      const std::string &k	      ///< [in] Key to remove
+      ) { return rmkey(prefix, k);}
+
     /// Removes keys beginning with prefix
     virtual void rmkeys_by_prefix(
       const std::string &prefix ///< [in] Prefix by which to remove keys

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -437,6 +437,12 @@ void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
   bat->Delete(combine_strings(prefix, k));
 }
 
+void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
+					                 const string &k)
+{
+  bat->SingleDelete(combine_strings(prefix, k));
+}
+
 void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
 {
   KeyValueDB::Iterator it = db->get_iterator(prefix);

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -147,17 +147,20 @@ public:
     void set(
       const string &prefix,
       const string &k,
-      const bufferlist &bl);
+      const bufferlist &bl) override;
     void rmkey(
       const string &prefix,
-      const string &k);
+      const string &k) override;
+    void rm_single_key(
+      const string &prefix,
+      const string &k) override;
     void rmkeys_by_prefix(
       const string &prefix
-      );
+      ) override;
     void merge(
       const string& prefix,
       const string& k,
-      const bufferlist &bl);
+      const bufferlist &bl) override;
   };
 
   KeyValueDB::Transaction get_transaction() {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3993,7 +3993,7 @@ void BlueStore::_kv_sync_thread()
 	// cleanup the wal
 	string key;
 	get_wal_key(wt.seq, &key);
-	t->rmkey(PREFIX_WAL, key);
+	t->rm_single_key(PREFIX_WAL, key);
       }
       db->submit_transaction_sync(t);
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3987,7 +3987,7 @@ void BlueStore::_kv_sync_thread()
 	       ++q) {
             string key;
             get_overlay_key(p->nid, *q, &key);
-	    t->rmkey(PREFIX_OVERLAY, key);
+	    t->rm_single_key(PREFIX_OVERLAY, key);
 	  }
 	}
 	// cleanup the wal
@@ -4726,7 +4726,7 @@ int BlueStore::_do_overlay_trim(TransContext *txc,
       if (o->onode.put_overlay_ref(p->second.key)) {
 	string key;
 	get_overlay_key(o->onode.nid, p->second.key, &key);
-	txc->t->rmkey(PREFIX_OVERLAY, key);
+	txc->t->rm_single_key(PREFIX_OVERLAY, key);
       }
       o->onode.overlay_map.erase(p++);
       ++changed;
@@ -4826,7 +4826,7 @@ int BlueStore::_do_write_overlays(TransContext *txc,
 	if (o->onode.put_overlay_ref(p->second.key)) {
 	  string key;
 	  get_overlay_key(o->onode.nid, p->second.key, &key);
-	  txc->t->rmkey(PREFIX_OVERLAY, key);
+	  txc->t->rm_single_key(PREFIX_OVERLAY, key);
 	}
 	o->onode.overlay_map.erase(p++);
 	continue;
@@ -4844,7 +4844,7 @@ int BlueStore::_do_write_overlays(TransContext *txc,
 	if (o->onode.put_overlay_ref(p->second.key)) {
 	  string key;
 	  get_overlay_key(o->onode.nid, p->second.key, &key);
-	  txc->t->rmkey(PREFIX_OVERLAY, key);
+	  txc->t->rm_single_key(PREFIX_OVERLAY, key);
 	}
 	o->onode.overlay_map.erase(p++);
 	continue;
@@ -6013,7 +6013,7 @@ int BlueStore::_do_truncate(
 		 << op->second << dendl;
 	string key;
 	get_overlay_key(o->onode.nid, op->second.key, &key);
-	txc->t->rmkey(PREFIX_OVERLAY, key);
+	txc->t->rm_single_key(PREFIX_OVERLAY, key);
       } else {
 	dout(20) << __func__ << " rm overlay " << op->first << " "
 		 << op->second << " (put ref)" << dendl;


### PR DESCRIPTION
SingleDelete is useful for log-insert-merge tree based key value store, such as RocksDB, to avoid more LSM compactions for already deleted key value pairs.

By use of single delete, RocksDB should be able to remove deleted wal/overlay entries with only one compaction in theory, when they land on level0. This should reduce RocksDB WAF.
