### PR TITLE
cmake: fix the build of test_rados_api_list

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1850,7 +1850,7 @@ add_executable(test_rados_api_list
 set_target_properties(test_rados_api_list PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rados_api_list
-  librados ${UNITTEST_LIBS} radostest)
+  librados global ${UNITTEST_LIBS} radostest)
 
 add_executable(test_rados_api_nlist
   librados/nlist.cc


### PR DESCRIPTION
the libglobal linkage was added in 769c0af, so add it to cmake
accordingly.

Signed-off-by: Kefu Chai <kchai@redhat.com>