### PR TITLE
tests: Delete temporary files created by ceph_objectstore_tool.py

### DIFF
--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -461,6 +461,14 @@ def set_osd_weight(CFSD_PREFIX, osd_ids, osd_path, weight):
     cmd = CFSD_PREFIX + "--op set-osdmap --file {osdmap_file} --epoch {epoch} --force"
     cmd = cmd.format(osd=osd_path, osdmap_file=osdmap_file.name, epoch=epoch)
     ret = call(cmd, stdout=subprocess.DEVNULL, shell=True)
+
+    try:
+        os.unlink(osdmap_file.name)
+        os.unlink(new_crush_file.name)
+        os.unlink(old_crush_file.name)
+    except:
+        pass
+
     return ret == 0
 
 def get_osd_weights(CFSD_PREFIX, osd_ids, osd_path):
@@ -487,6 +495,13 @@ def get_osd_weights(CFSD_PREFIX, osd_ids, osd_path):
     for line in output.strip().split('\n'):
         osd_id, weight, osd_name = re.split('\s+', line)
         weights.append(float(weight))
+
+    try:
+        os.unlink(osdmap_file.name)
+        os.unlink(crush_file.name)
+    except:
+        pass
+
     return weights
 
 
@@ -556,6 +571,14 @@ def test_get_set_inc_osdmap(CFSD_PREFIX, osd_path):
         if ret:
             logging.error("Failed to revert the changed inc-osdmap")
             errors += 1
+
+    try:
+        os.unlink(file_e2.name)
+        os.unlink(file_e1_read.name)
+        os.unlink(file_e1_backup.name)
+    except:
+        pass
+
     return errors
 
 


### PR DESCRIPTION
ceph_objectstore_tool was creating 'tempfile' objects but never delete
them making 13 remaining files at each run.

That represent a short leak of 6.8k of raw data but 52k while
considering the allocated sectors. That's not a big thing but better
remove them to get a clean /tmp

Signed-off-by: Erwan Velu <erwan@redhat.com>