### PR TITLE
mrun: update path to cmake binaries

### DIFF
--- a/src/mrun
+++ b/src/mrun
@@ -9,7 +9,7 @@ CEPH_BIN=$root
 CEPH_CONF_PATH=$root/run/$run_name
 
 if [ -e CMakeCache.txt ]; then
-    CEPH_BIN=$PWD/src
+    CEPH_BIN=$PWD/bin
     CEPH_CONF_PATH=$PWD/run/$run_name
 fi
 


### PR DESCRIPTION
cmake now puts its built binaries under \<cmake-build-dir\>/bin - update mrun to look there when it detects a CMakeCache.txt