### PR TITLE
ceph-osd-prestart.sh: drop --setuser/--setgroup

### DIFF
--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -10,7 +10,7 @@ LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
 ExecReload=/bin/kill -HUP $MAINPID
 ProtectHome=true
 ProtectSystem=full


### PR DESCRIPTION
These are not supported by /usr/lib/ceph/ceph-osd-prestart.sh,
resulting in warnings:

 ceph-osd-prestart.sh[23367]: getopt: unrecognized option '--setuser'
 ceph-osd-prestart.sh[23367]: getopt: unrecognized option '--setgroup'

--setuser and --setgroup are only needed for the ceph-osd process.

Signed-off-by: James Page <james.page@ubuntu.com>