### PR TITLE
systemd: drop any systemd imposed process/thread limits

### DIFF
--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -15,6 +15,7 @@ PrivateDevices=yes
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-mds.target

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -21,6 +21,7 @@ PrivateDevices=yes
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-mon.target

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -15,6 +15,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-osd.target

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -14,6 +14,7 @@ PrivateDevices=yes
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-radosgw.target

--- a/systemd/ceph-rbd-mirror@.service
+++ b/systemd/ceph-rbd-mirror@.service
@@ -17,6 +17,7 @@ PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-rbd-mirror.target


### PR DESCRIPTION
If systemd has task accounting enabled, a default of 512 tasks
will be applied to all systemd units.

For ceph, this is way to low even for a modest cluster, so stop
this restriction being applied and allow administrators to apply
limits using sysctl.

Signed-off-by: James Page <james.page@ubuntu.com>