### PR TITLE
build: Respect TMPDIR for virtualenv.

### DIFF
--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -299,6 +299,8 @@ DENCODER_DEPS =
 
 # put virtualenvs in this directory
 # otherwise it may overflow #! 80 kernel limit
-export CEPH_BUILD_VIRTUALENV = /tmp
+# beware that some build environments might not be able to write to /tmp
+export TMPDIR ?= /tmp
+export CEPH_BUILD_VIRTUALENV = $(TMPDIR)
 
 radoslibdir = $(libdir)/rados-classes


### PR DESCRIPTION
Gentoo's normal build process uses a sandbox to catch writes outside the
build environment; this includes providing a value other than /tmp for
TMPDIR. Use TMPDIR by default for CEPH_BUILD_VIRTUALENV.

Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>