### PR TITLE
librbd: disallow unsafe rbd_op_threads values

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -52,7 +52,7 @@ namespace {
 class ThreadPoolSingleton : public ThreadPool {
 public:
   explicit ThreadPoolSingleton(CephContext *cct)
-    : ThreadPool(cct, "librbd::thread_pool", "tp_librbd", cct->_conf->rbd_op_threads,
+    : ThreadPool(cct, "librbd::thread_pool", "tp_librbd", 1,
                  "rbd_op_threads") {
     start();
   }


### PR DESCRIPTION
Don't use this config option in librbd until
http://tracker.ceph.com/issues/15034 is avoided.

The option itself is still useful for mirroring threads, where
ordering is unimportant.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>