### PR TITLE
build: change ccache invocation to path style

### DIFF
--- a/make-debs.sh
+++ b/make-debs.sh
@@ -84,7 +84,12 @@ fi
 if test $NPROC -gt 1 ; then
     j=-j${NPROC}
 fi
-PATH=/usr/lib/ccache:$PATH dpkg-buildpackage $j -uc -us
+CCACHE_PATH=$PATH
+for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+    test -d $d && test -x $d/g++ && CCACHE_PATH=$d:$PATH && break
+done
+
+PATH=${CCACHE_PATH} dpkg-buildpackage $j -uc -us
 cd ../..
 mkdir -p $codename/conf
 cat > $codename/conf/distributions <<EOF

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -65,9 +65,13 @@ function run() {
     if test -f ./install-deps.sh ; then
 	$DRY_RUN ./install-deps.sh || return 1
     fi
-    $DRY_RUN ./autogen.sh || return 1
+    CCACHE_PATH=$PATH
+    for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+        test -d $d && test -x $d/g++ && CCACHE_PATH=$d:$PATH && break
+    done
+    $DRY_RUN ./autogen.sh PATH=$CCACHE_PATH || return 1
     $DRY_RUN ./configure "$@"  --with-librocksdb-static --disable-static --with-radosgw --with-debug --without-lttng \
-        CC="ccache gcc" CXX="ccache g++" CFLAGS="-Wall -g" CXXFLAGS="-Wall -g" || return 1
+        PATH=$CCACHE_PATH CFLAGS="-Wall -g" CXXFLAGS="-Wall -g" || return 1
     $DRY_RUN make $BUILD_MAKEOPTS || return 1
     $DRY_RUN make $CHECK_MAKEOPTS check || return 1
     $DRY_RUN make dist || return 1


### PR DESCRIPTION
If ccache is invoked as two arguments eg CXX='ccache g++', then pybind
linking can fail because of long-standing distutils bug 8027. Some
distributions patch distutils for this, but it's not consistent.

The alternative way to use ccache is by altering PATH, but it needs
slight care because the actual directory for the ccache symlinks is not
consistent between distributions.

X-Distutils-Bug-URL: https://bugs.python.org/issue8027
Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>