### PR TITLE
tests: be more generous with test timeout

### DIFF
--- a/src/test/librados/test.h
+++ b/src/test/librados/test.h
@@ -48,7 +48,7 @@ class TestAlarm
 {
 public:
   TestAlarm() {
-    alarm(360);
+    alarm(1200);
   }
   ~TestAlarm() {
     alarm(0);


### PR DESCRIPTION
When the thrasher is in action together with a validater (lockdep or
valgrind), a single test may hang for more than 360 seconds. Increase to
1200: it does not matter if the value is large, only that it prevents
the test from hanging forever.

Fixes: http://tracker.ceph.com/issues/15403

Signed-off-by: Loic Dachary <loic@dachary.org>