### PR TITLE
hammer: tests: be more generous with test timeout

### DIFF
--- a/src/test/librados/test.h
+++ b/src/test/librados/test.h
@@ -44,7 +44,7 @@ class TestAlarm
 {
 public:
   TestAlarm() {
-    alarm(360);
+    alarm(1200);
   }
   ~TestAlarm() {
     alarm(0);


### PR DESCRIPTION
http://tracker.ceph.com/issues/15699

When the thrasher is in action together with a validater (lockdep or
valgrind), a single test may hang for more than 360 seconds. Increase to
1200: it does not matter if the value is large, only that it prevents
the test from hanging forever.

Fixes: http://tracker.ceph.com/issues/15403

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit af89474b3fb2c4aa63680aa6b30d71fad2fdd373)