### PR TITLE
rgw: the map 'headers' is assigned a wrong value

### DIFF
--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -199,7 +199,7 @@ int RGWRESTConn::get_resource(const string& resource,
 
   map<string, string> headers;
   if (extra_headers) {
-    headers.insert(extra_params->begin(), extra_params->end());
+    headers.insert(extra_headers->begin(), extra_headers->end());
   }
 
   ret = req.get_resource(key, headers, resource, mgr);


### PR DESCRIPTION
Signed-off-by: weiqiaomiao <wei.qiaomiao@zte.com.cn>