### PR TITLE
os/bluestore/BlueStore: preallocate space when use file instead of blockdevice

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -938,6 +938,7 @@ OPTION(bluestore_block_db_create, OPT_BOOL, false)
 OPTION(bluestore_block_wal_path, OPT_STR, "")
 OPTION(bluestore_block_wal_size, OPT_U64, 96 * 1024*1024) // rocksdb wal
 OPTION(bluestore_block_wal_create, OPT_BOOL, false)
+OPTION(bluestore_block_preallocate_file, OPT_BOOL, false) //whether preallocate space if block/db_path/wal_path is file rather that block device.
 OPTION(bluestore_min_alloc_size, OPT_U32, 64*1024)
 OPTION(bluestore_onode_map_size, OPT_U32, 1024)   // onodes per collection
 OPTION(bluestore_cache_tails, OPT_BOOL, true)   // cache tail blocks in Onode

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1639,6 +1639,31 @@ int BlueStore::_setup_block_symlink_or_file(
 	  VOID_TEMP_FAILURE_RETRY(::close(fd));
 	  return r;
 	}
+#ifdef HAVE_POSIX_FALLOCATE
+	r = ::posix_fallocate(fd, 0, size);
+	if (r < 0) {
+	  r = -errno;
+	  derr << __func__ << " failed to prefallocate " << name << " file to "
+	       << size << ": " << cpp_strerror(r) << dendl;
+	  VOID_TEMP_FAILURE_RETRY(::close(fd));
+	  return r;
+	}
+#else
+	char data[1024*128];
+	for (uint64_t off = 0; off < size; off += sizeof(data)) {
+	  if (off + sizeof(data) > size)
+	    r = ::write(fd, data, size - off);
+	  else
+	    r = ::write(fd, data, sizeof(data));
+	  if (r < 0) {
+	    r = -errno;
+	    derr << __func__ << " failed to prefallocate w/ write " << name << " file to "
+	      << size << ": " << cpp_strerror(r) << dendl;
+	    VOID_TEMP_FAILURE_RETRY(::close(fd));
+	    return r;
+	  }
+	}
+#endif
 	dout(1) << __func__ << " resized " << name << " file to "
 		<< pretty_si_t(size) << "B" << dendl;
       }


### PR DESCRIPTION

Avoid failure because lack of space.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>