### PR TITLE
mds: use epoch as incarnation counter (#15399)

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -334,7 +334,8 @@ void FSMap::decode(bufferlist::iterator& p)
     ::decode(legacy_mds_map.modified, p);
     ::decode(legacy_mds_map.tableserver, p);
     ::decode(legacy_mds_map.in, p);
-    ::decode(legacy_mds_map.inc, p);
+    std::map<mds_rank_t,int32_t> inc;  // Legacy field, parse and drop
+    ::decode(inc, p);
     ::decode(legacy_mds_map.up, p);
     ::decode(legacy_mds_map.failed, p);
     ::decode(legacy_mds_map.stopped, p);
@@ -663,7 +664,7 @@ void FSMap::promote(
     mds_map.failed.erase(assigned_rank);
   }
   info.rank = assigned_rank;
-  info.inc = ++mds_map.inc[assigned_rank];
+  info.inc = epoch;
   mds_roles[standby_gid] = filesystem->fscid;
 
   // Update the rank state in Filesystem

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -469,6 +469,13 @@ void MDSMap::mds_info_t::decode(bufferlist::iterator& bl)
 
 void MDSMap::encode(bufferlist& bl, uint64_t features) const
 {
+  std::map<mds_rank_t,int32_t> inc;  // Legacy field, fake it so that
+                                     // old-mon peers have something sane
+                                     // during upgrade
+  for (const auto rank : in) {
+    inc.insert(std::make_pair(rank, epoch));
+  }
+
   if ((features & CEPH_FEATURE_PGID64) == 0) {
     __u16 v = 2;
     ::encode(v, bl);
@@ -573,6 +580,8 @@ void MDSMap::encode(bufferlist& bl, uint64_t features) const
 
 void MDSMap::decode(bufferlist::iterator& p)
 {
+  std::map<mds_rank_t,int32_t> inc;  // Legacy field, parse and drop
+
   cached_up_features = 0;
   DECODE_START_LEGACY_COMPAT_LEN_16(5, 4, 4, p);
   ::decode(epoch, p);

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -203,7 +203,7 @@ protected:
   mds_rank_t max_mds; /* The maximum number of active MDSes. Also, the maximum rank. */
 
   std::set<mds_rank_t> in;              // currently defined cluster
-  std::map<mds_rank_t,int32_t> inc;     // most recent incarnation.
+
   // which ranks are failed, stopped, damaged (i.e. not held by a daemon)
   std::set<mds_rank_t> failed, stopped, damaged;
   std::map<mds_rank_t, mds_gid_t> up;        // who is in those roles

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -867,9 +867,6 @@ bool MDSRank::is_daemon_stopping() const
   return stopping;
 }
 
-// FIXME>> this fns are state-machiney, not dispatchy
-// >>>>>
-
 void MDSRank::request_state(MDSMap::DaemonState s)
 {
   dout(3) << "request_state " << ceph_mds_state_name(s) << dendl;
@@ -1375,8 +1372,6 @@ void MDSRank::stopping_done()
   // tell monitor we shut down cleanly.
   request_state(MDSMap::STATE_STOPPED);
 }
-
-// <<<<<<<<
 
 void MDSRankDispatcher::handle_mds_map(
     MMDSMap *m,

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1732,7 +1732,6 @@ int MDSMonitor::management_command(
 
     // Carry forward what makes sense
     new_fs->fscid = fs->fscid;
-    new_fs->mds_map.inc = fs->mds_map.inc;
     new_fs->mds_map.inline_data_enabled = fs->mds_map.inline_data_enabled;
     new_fs->mds_map.max_mds = g_conf->max_mds;
     new_fs->mds_map.data_pools = fs->mds_map.data_pools;


### PR DESCRIPTION

To avoid the need to manage the per-map arrange of rank to incarnation across multiple filesystems.