### PR TITLE
librados: Revert "rados: Add new field flags for ceph_osd_op.copy_get."

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -446,10 +446,6 @@ enum {
 };
 
 enum {
-	CEPH_OSD_COPY_GET_FLAG_NOTSUPP_OMAP = 1, /* mean dest pool don't support omap*/
-};
-
-enum {
 	CEPH_OSD_TMAP2OMAP_NULLOK = 1,
 };
 
@@ -516,7 +512,6 @@ struct ceph_osd_op {
 		} __attribute__ ((packed)) clonerange;
 		struct {
 			__le64 max;     /* max data in reply */
-			__le32 flags;
 		} __attribute__ ((packed)) copy_get;
 		struct {
 			__le64 snapid;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -6919,10 +6919,6 @@ int ReplicatedPG::fill_in_copy_get(
     return result;
   }
 
-  if ((osd_op.op.copy_get.flags & CEPH_OSD_COPY_GET_FLAG_NOTSUPP_OMAP) &&
-      oi.is_omap())
-      return -EOPNOTSUPP;
-
   MOSDOp *op = reinterpret_cast<MOSDOp*>(ctx->op->get_req());
   uint64_t features = op->get_features();
 
@@ -7162,12 +7158,7 @@ void ReplicatedPG::_copy_some(ObjectContextRef obc, CopyOpRef cop)
     // it already!
     assert(cop->cursor.is_initial());
   }
-
-  uint32_t copyget_flags = 0;
-  if (!pool.info.supports_omap())
-   copyget_flags |= CEPH_OSD_COPY_GET_FLAG_NOTSUPP_OMAP;
-
-  op.copy_get(&cop->cursor, get_copy_chunk_size(), copyget_flags,
+  op.copy_get(&cop->cursor, get_copy_chunk_size(),
 	      &cop->results.object_size, &cop->results.mtime,
 	      &cop->attrs, &cop->data, &cop->omap_header, &cop->omap_data,
 	      &cop->results.snaps, &cop->results.snap_seq,

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -747,7 +747,6 @@ struct ObjectOperation {
 
   void copy_get(object_copy_cursor_t *cursor,
 		uint64_t max,
-		uint32_t copyget_flags,
 		uint64_t *out_size,
 		ceph::real_time *out_mtime,
 		std::map<std::string,bufferlist> *out_attrs,
@@ -765,7 +764,6 @@ struct ObjectOperation {
 		int *prval) {
     OSDOp& osd_op = add_op(CEPH_OSD_OP_COPY_GET);
     osd_op.op.copy_get.max = max;
-    osd_op.op.copy_get.flags = copyget_flags;
     ::encode(*cursor, osd_op.indata);
     ::encode(max, osd_op.indata);
     unsigned p = ops.size() - 1;


### PR DESCRIPTION
This reverts commit 2b4acfb1b808b98132a771cf1089063c0f7a75b5.

We fixed this on the receiving end in
fc51ce2a837e8e878d46d8ca54531aa7bd5d01b2 a few weeks after this commit
was added.  It's ugly and no longer needed.

This *does* mean that we'll start to copy some data and then abort
partway through, but that's better than an kludgey protocol/interface.

Signed-off-by: Sage Weil <sage@redhat.com>