### PR TITLE
rgw: fix problem deleting objects begining with double underscores

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2994,7 +2994,8 @@ void RGWDeleteObj::execute()
     return;
   }
 
-  rgw_obj obj(s->bucket, s->object);
+  rgw_obj obj(s->bucket, s->object.name);
+  obj.set_instance(s->object.instance);
   map<string, bufferlist> attrs;
 
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/15318

Signed-off-by: Orit Wasserman <owasserm@redhat.com>