### PR TITLE
journal: possible race condition during live replay

### DIFF
--- a/src/journal/JournalPlayer.cc
+++ b/src/journal/JournalPlayer.cc
@@ -552,9 +552,14 @@ void JournalPlayer::schedule_watch() {
 
 void JournalPlayer::handle_watch(int r) {
   ldout(m_cct, 10) << __func__ << ": r=" << r << dendl;
+  if (r == -ECANCELED) {
+    // unwatch of object player(s)
+    return;
+  }
 
   Mutex::Locker locker(m_lock);
   m_watch_scheduled = false;
+
   std::set<uint64_t> object_numbers;
   for (auto &players : m_object_players) {
     object_numbers.insert(

--- a/src/journal/JournalPlayer.cc
+++ b/src/journal/JournalPlayer.cc
@@ -535,16 +535,18 @@ void JournalPlayer::schedule_watch() {
   // poll first splay offset and active splay offset since
   // new records should only appear in those two objects
   C_Watch *ctx = new C_Watch(this);
-  ObjectPlayerPtr object_player = get_object_player();
-  object_player->watch(ctx, m_watch_interval);
 
+  ObjectPlayerPtr object_player = get_object_player();
   uint8_t splay_width = m_journal_metadata->get_splay_width();
   if (object_player->get_object_number() % splay_width != 0) {
     ++ctx->pending_fetches;
 
-    object_player = m_object_players.begin()->second.begin()->second;
-    object_player->watch(ctx, m_watch_interval);
+    ObjectPlayerPtr first_object_player =
+      m_object_players.begin()->second.begin()->second;
+    first_object_player->watch(ctx, m_watch_interval);
   }
+
+  object_player->watch(ctx, m_watch_interval);
   m_watch_scheduled = true;
 }
 

--- a/src/journal/JournalPlayer.h
+++ b/src/journal/JournalPlayer.h
@@ -70,24 +70,26 @@ private:
 
   struct C_Watch : public Context {
     JournalPlayer *player;
+    Mutex lock;
     uint8_t pending_fetches = 1;
     int ret_val = 0;
 
-    C_Watch(JournalPlayer *player) : player(player) {
+    C_Watch(JournalPlayer *player)
+      : player(player), lock("JournalPlayer::C_Watch::lock") {
     }
 
     virtual void complete(int r) override {
-      player->m_lock.Lock();
+      lock.Lock();
       if (ret_val == 0 && r < 0) {
         ret_val = r;
       }
 
       assert(pending_fetches > 0);
       if (--pending_fetches == 0) {
-        player->m_lock.Unlock();
+        lock.Unlock();
         Context::complete(ret_val);
       } else {
-        player->m_lock.Unlock();
+        lock.Unlock();
       }
     }
 

--- a/src/journal/ObjectPlayer.cc
+++ b/src/journal/ObjectPlayer.cc
@@ -32,6 +32,7 @@ ObjectPlayer::~ObjectPlayer() {
     Mutex::Locker timer_locker(m_timer_lock);
     Mutex::Locker locker(m_lock);
     assert(!m_fetch_in_progress);
+    assert(!m_watch_in_progress);
     assert(m_watch_ctx == NULL);
   }
 }


### PR DESCRIPTION
When two objects are being actively watched, it was possible for
the watch context to complete before the second watch was
associated.

Fixes: http://tracker.ceph.com/issues/15352
Signed-off-by: Jason Dillaman <dillaman@redhat.com>