### PR TITLE
os/filestore: force lfn attrs to be written atomically, restructure name length limits

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -869,6 +869,7 @@ OPTION(osd_mon_shutdown_timeout, OPT_DOUBLE, 5)
 
 OPTION(osd_max_object_size, OPT_U64, 100*1024L*1024L*1024L) // OSD's maximum object size
 OPTION(osd_max_object_name_len, OPT_U32, 2048) // max rados object name len
+OPTION(osd_max_object_namespace_len, OPT_U32, 256) // max rados object namespace len
 OPTION(osd_max_attr_name_len, OPT_U32, 100)    // max rados attr name len; cannot go higher than 100 chars for file system backends
 OPTION(osd_max_attr_size, OPT_U64, 0)
 
@@ -1025,6 +1026,18 @@ OPTION(filestore_max_inline_xattrs, OPT_U32, 0)	//Override
 OPTION(filestore_max_inline_xattrs_xfs, OPT_U32, 10)
 OPTION(filestore_max_inline_xattrs_btrfs, OPT_U32, 10)
 OPTION(filestore_max_inline_xattrs_other, OPT_U32, 2)
+
+// max xattr value size
+OPTION(filestore_max_xattr_value_size, OPT_U32, 0)	//Override
+OPTION(filestore_max_xattr_value_size_xfs, OPT_U32, 64<<10)
+OPTION(filestore_max_xattr_value_size_btrfs, OPT_U32, 64<<10)
+// ext4 allows 4k xattrs total including some smallish extra fields and the
+// keys.  We're allowing 2 512 inline attrs in addition some some filestore
+// replay attrs.  After accounting for those, we still need to fit up to
+// two attrs of this value.  That means we need this value to be around 1k
+// to be safe.  This is hacky, but it's not worth complicating the code
+// to work around ext4's total xattr limit.
+OPTION(filestore_max_xattr_value_size_other, OPT_U32, 1<<10)
 
 OPTION(filestore_sloppy_crc, OPT_BOOL, false)         // track sloppy crcs
 OPTION(filestore_sloppy_crc_block_size, OPT_INT, 65536)

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1926,7 +1926,15 @@ public:
   virtual int fsck() {
     return -EOPNOTSUPP;
   }
-  virtual unsigned get_max_object_name_length() = 0;
+
+  /**
+   * Returns 0 if the hobject is valid, -error otherwise
+   *
+   * Errors:
+   * -ENAMETOOLONG: locator/namespace/name too large
+   */
+  virtual int validate_hobject_key(const hobject_t &obj) const = 0;
+
   virtual unsigned get_max_attr_name_length() = 0;
   virtual int mkfs() = 0;  // wipe
   virtual int mkjournal() = 0; // journal only

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -667,8 +667,8 @@ public:
 
   int fsck() override;
 
-  unsigned get_max_object_name_length() override {
-    return 4096;
+  int validate_hobject_key(const hobject_t &obj) const override {
+    return 0;
   }
   unsigned get_max_attr_name_length() override {
     return 256;  // arbitrary; there is no real limit internally

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -5713,6 +5713,18 @@ void FileStore::set_xattr_limits_via_conf()
     m_filestore_max_xattr_value_size = g_conf->filestore_max_xattr_value_size;
   else
     m_filestore_max_xattr_value_size = fs_xattr_max_value_size;
+
+  if (m_filestore_max_xattr_value_size < g_conf->osd_max_object_name_len) {
+    derr << "WARNING: max attr value size ("
+	 << m_filestore_max_xattr_value_size
+	 << ") is smaller than osd_max_object_name_len ("
+	 << g_conf->osd_max_object_name_len
+	 << ").  Your backend filesystem appears to not support attrs large "
+	 << "enough to handle the configured max rados name size.  You may get "
+	 << "unexpected ENAMETOOLONG errors on rados operations or buggy "
+	 << "behavior"
+	 << dendl;
+  }
 }
 
 // -- FSSuperblock --

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -432,10 +432,9 @@ public:
   int write_op_seq(int, uint64_t seq);
   int mount();
   int umount();
-  unsigned get_max_object_name_length() {
-    // not safe for all file systems, btw!  use the tunable to limit this.
-    return 4096;
-  }
+
+  int validate_hobject_key(const hobject_t &obj) const override;
+
   unsigned get_max_attr_name_length() {
     // xattr limit is 128; leave room for our prefixes (user.ceph._),
     // some margin, and cap at 100
@@ -739,6 +738,7 @@ private:
   void set_xattr_limits_via_conf();
   uint32_t m_filestore_max_inline_xattr_size;
   uint32_t m_filestore_max_inline_xattrs;
+  uint32_t m_filestore_max_xattr_value_size;
 
   FSSuperblock superblock;
 

--- a/src/os/filestore/IndexManager.cc
+++ b/src/os/filestore/IndexManager.cc
@@ -36,8 +36,9 @@
 static int set_version(const char *path, uint32_t version) {
   bufferlist bl;
   ::encode(version, bl);
-  return chain_setxattr(path, "user.cephos.collection_version", bl.c_str(),
-		     bl.length(), true);
+  return chain_setxattr<true, true>(
+    path, "user.cephos.collection_version", bl.c_str(),
+    bl.length());
 }
 
 static int get_version(const char *path, uint32_t *version) {

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -430,7 +430,6 @@ int LFNIndex::list_objects(const vector<string> &to_list, int max_objs,
     if (lfn_is_object(short_name)) {
       r = lfn_translate(to_list, short_name, &obj);
       if (r < 0) {
-	r = -errno;
 	goto cleanup;
       } else if (r > 0) {
 	string long_name = lfn_generate_object_name(obj);

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -529,9 +529,10 @@ int LFNIndex::add_attr_path(const vector<string> &path,
 {
   string full_path = get_full_path_subdir(path);
   maybe_inject_failure();
-  return chain_setxattr(full_path.c_str(), mangle_attr_name(attr_name).c_str(),
-		     reinterpret_cast<void *>(attr_value.c_str()),
-		     attr_value.length());
+  return chain_setxattr<false, true>(
+    full_path.c_str(), mangle_attr_name(attr_name).c_str(),
+    reinterpret_cast<void *>(attr_value.c_str()),
+    attr_value.length());
 }
 
 int LFNIndex::get_attr_path(const vector<string> &path,
@@ -853,14 +854,16 @@ int LFNIndex::lfn_created(const vector<string> &path,
 	     << " moving old name to alt attr "
 	     << string(buf, r)
 	     << ", new name is " << full_name << dendl;
-    r = chain_setxattr(full_path.c_str(), get_alt_lfn_attr().c_str(),
-		       buf, r);
+    r = chain_setxattr<false, true>(
+      full_path.c_str(), get_alt_lfn_attr().c_str(),
+      buf, r);
     if (r < 0)
       return r;
   }
 
-  return chain_setxattr(full_path.c_str(), get_lfn_attr().c_str(),
-		     full_name.c_str(), full_name.size());
+  return chain_setxattr<false, true>(
+    full_path.c_str(), get_lfn_attr().c_str(),
+    full_name.c_str(), full_name.size());
 }
 
 int LFNIndex::lfn_unlink(const vector<string> &path,

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -74,6 +74,14 @@ struct FDCloser {
 
 /* Public methods */
 
+uint64_t LFNIndex::get_max_escaped_name_len(const hobject_t &obj)
+{
+  ghobject_t ghobj(obj);
+  ghobj.shard_id = shard_id_t(0);
+  ghobj.generation = 0;
+  ghobj.hobj.snap = 0;
+  return lfn_generate_object_name_current(ghobj).size();
+}
 
 int LFNIndex::init()
 {
@@ -621,13 +629,8 @@ static void append_escaped(string::const_iterator begin,
   }
 }
 
-string LFNIndex::lfn_generate_object_name(const ghobject_t &oid)
+string LFNIndex::lfn_generate_object_name_current(const ghobject_t &oid)
 {
-  if (index_version == HASH_INDEX_TAG)
-    return lfn_generate_object_name_keyless(oid);
-  if (index_version == HASH_INDEX_TAG_2)
-    return lfn_generate_object_name_poolless(oid);
-
   string full_name;
   string::const_iterator i = oid.hobj.oid.name.begin();
   if (oid.hobj.oid.name.substr(0, 4) == "DIR_") {

--- a/src/os/filestore/LFNIndex.h
+++ b/src/os/filestore/LFNIndex.h
@@ -212,6 +212,11 @@ public:
       );
   }
 
+  /**
+   * Returns the length of the longest escaped name which could result
+   * from any clone, shard, or rollback object of this object
+   */
+  static uint64_t get_max_escaped_name_len(const hobject_t &obj);
 
 protected:
   virtual int _init() = 0;
@@ -480,9 +485,21 @@ private:
     ); ///< @return Generated object name.
 
   /// Generate object name
-  string lfn_generate_object_name(
+  static string lfn_generate_object_name_current(
     const ghobject_t &oid ///< [in] Object for which to generate.
     ); ///< @return Generated object name.
+
+  /// Generate object name
+  string lfn_generate_object_name(
+    const ghobject_t &oid ///< [in] Object for which to generate.
+    ) {
+    if (index_version == HASH_INDEX_TAG)
+      return lfn_generate_object_name_keyless(oid);
+    if (index_version == HASH_INDEX_TAG_2)
+      return lfn_generate_object_name_poolless(oid);
+    else
+      return lfn_generate_object_name_current(oid);
+  } ///< @return Generated object name.
 
   /// Parse object name
   bool lfn_parse_object_name_keyless(

--- a/src/os/filestore/LFNIndex.h
+++ b/src/os/filestore/LFNIndex.h
@@ -502,19 +502,19 @@ private:
   } ///< @return Generated object name.
 
   /// Parse object name
-  bool lfn_parse_object_name_keyless(
+  int lfn_parse_object_name_keyless(
     const string &long_name, ///< [in] Name to parse
     ghobject_t *out	     ///< [out] Resulting Object
     ); ///< @return True if successfull, False otherwise.
 
   /// Parse object name
-  bool lfn_parse_object_name_poolless(
+  int lfn_parse_object_name_poolless(
     const string &long_name, ///< [in] Name to parse
     ghobject_t *out	     ///< [out] Resulting Object
     ); ///< @return True if successfull, False otherwise.
 
   /// Parse object name
-  bool lfn_parse_object_name(
+  int lfn_parse_object_name(
     const string &long_name, ///< [in] Name to parse
     ghobject_t *out	     ///< [out] Resulting Object
     ); ///< @return True if successfull, False otherwise.

--- a/src/os/filestore/chain_xattr.cc
+++ b/src/os/filestore/chain_xattr.cc
@@ -135,7 +135,7 @@ int chain_getxattr(const char *fn, const char *name, void *val, size_t size)
     return getxattr_len(fn, name);
 
   do {
-    chunk_size = (size < CHAIN_XATTR_MAX_BLOCK_LEN ? size : CHAIN_XATTR_MAX_BLOCK_LEN);
+    chunk_size = size;
     get_raw_xattr_name(name, i, raw_name, sizeof(raw_name));
 
     r = sys_getxattr(fn, raw_name, (char *)val + pos, chunk_size);
@@ -206,7 +206,7 @@ int chain_fgetxattr(int fd, const char *name, void *val, size_t size)
     return chain_fgetxattr_len(fd, name);
 
   do {
-    chunk_size = (size < CHAIN_XATTR_MAX_BLOCK_LEN ? size : CHAIN_XATTR_MAX_BLOCK_LEN);
+    chunk_size = size;
     get_raw_xattr_name(name, i, raw_name, sizeof(raw_name));
 
     r = sys_fgetxattr(fd, raw_name, (char *)val + pos, chunk_size);

--- a/src/os/filestore/chain_xattr.cc
+++ b/src/os/filestore/chain_xattr.cc
@@ -37,7 +37,7 @@
  * where <id> marks the num of xattr in the chain.
  */
 
-static void get_raw_xattr_name(const char *name, int i, char *raw_name, int raw_len)
+void get_raw_xattr_name(const char *name, int i, char *raw_name, int raw_len)
 {
   int pos = 0;
 
@@ -247,7 +247,7 @@ int chain_fgetxattr(int fd, const char *name, void *val, size_t size)
 
 // setxattr
 
-static int get_xattr_block_size(size_t size)
+int get_xattr_block_size(size_t size)
 {
   if (size <= CHAIN_XATTR_SHORT_LEN_THRESHOLD)
     // this may fit in the inode; stripe over short attrs so that XFS
@@ -255,79 +255,6 @@ static int get_xattr_block_size(size_t size)
     return CHAIN_XATTR_SHORT_BLOCK_LEN;
   return CHAIN_XATTR_MAX_BLOCK_LEN;
 }
-
-int chain_setxattr(const char *fn, const char *name, const void *val, size_t size, bool onechunk)
-{
-  int i = 0, pos = 0;
-  char raw_name[CHAIN_XATTR_MAX_NAME_LEN * 2 + 16];
-  int ret = 0;
-  size_t max_chunk_size = get_xattr_block_size(size);
-
-  do {
-    size_t chunk_size = (size < max_chunk_size ? size : max_chunk_size);
-    get_raw_xattr_name(name, i, raw_name, sizeof(raw_name));
-    size -= chunk_size;
-
-    int r = sys_setxattr(fn, raw_name, (char *)val + pos, chunk_size);
-    if (r < 0) {
-      ret = r;
-      break;
-    }
-    pos  += chunk_size;
-    ret = pos;
-    i++;
-  } while (size);
-
-  if (ret >= 0 && !onechunk) {
-    int r;
-    do {
-      get_raw_xattr_name(name, i, raw_name, sizeof(raw_name));
-      r = sys_removexattr(fn, raw_name);
-      if (r < 0 && r != -ENODATA)
-	ret = r;
-      i++;
-    } while (r != -ENODATA);
-  }
-
-  return ret;
-}
-
-int chain_fsetxattr(int fd, const char *name, const void *val, size_t size, bool onechunk)
-{
-  int i = 0, pos = 0;
-  char raw_name[CHAIN_XATTR_MAX_NAME_LEN * 2 + 16];
-  int ret = 0;
-  size_t max_chunk_size = get_xattr_block_size(size);
-
-  do {
-    size_t chunk_size = (size < max_chunk_size ? size : max_chunk_size);
-    get_raw_xattr_name(name, i, raw_name, sizeof(raw_name));
-    size -= chunk_size;
-
-    int r = sys_fsetxattr(fd, raw_name, (char *)val + pos, chunk_size);
-    if (r < 0) {
-      ret = r;
-      break;
-    }
-    pos  += chunk_size;
-    ret = pos;
-    i++;
-  } while (size);
-
-  if (ret >= 0 && !onechunk) {
-    int r;
-    do {
-      get_raw_xattr_name(name, i, raw_name, sizeof(raw_name));
-      r = sys_fremovexattr(fd, raw_name);
-      if (r < 0 && r != -ENODATA)
-	ret = r;
-      i++;
-    } while (r != -ENODATA);
-  }
-
-  return ret;
-}
-
 
 // removexattr
 

--- a/src/os/filestore/chain_xattr.cc
+++ b/src/os/filestore/chain_xattr.cc
@@ -173,6 +173,35 @@ int chain_getxattr(const char *fn, const char *name, void *val, size_t size)
   return ret;
 }
 
+int chain_getxattr_buf(const char *fn, const char *name, bufferptr *bp)
+{
+  size_t size = 1024; // Initial
+  while (1) {
+    bufferptr buf(size);
+    int r = chain_getxattr(
+      fn,
+      name,
+      buf.c_str(),
+      size);
+    if (r > 0) {
+      buf.set_length(r);
+      if (bp)
+	bp->swap(buf);
+      return r;
+    } else if (r == 0) {
+      return 0;
+    } else {
+      if (r == -ERANGE) {
+	size *= 2;
+      } else {
+	return r;
+      }
+    }
+  }
+  assert(0 == "unreachable");
+  return 0;
+}
+
 static int chain_fgetxattr_len(int fd, const char *name)
 {
   int i = 0, total = 0;

--- a/src/os/filestore/chain_xattr.h
+++ b/src/os/filestore/chain_xattr.h
@@ -6,6 +6,7 @@
 
 #include "common/xattr.h"
 #include "include/assert.h"
+#include "include/buffer.h"
 #include <string.h>
 #include <stdio.h>
 
@@ -80,6 +81,7 @@ static inline int sys_fremovexattr(int fd, const char *name)
 // wrappers to chain large values across multiple xattrs
 
 int chain_getxattr(const char *fn, const char *name, void *val, size_t size);
+int chain_getxattr_buf(const char *fn, const char *name, bufferptr *bp);
 int chain_fgetxattr(int fd, const char *name, void *val, size_t size);
 
 int get_xattr_block_size(size_t size);

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -411,8 +411,9 @@ public:
 
   int fsck();
 
-  unsigned get_max_object_name_length() {
-    return 4096;
+
+  int validate_hobject_key(const hobject_t &obj) const override {
+    return 0;
   }
   unsigned get_max_attr_name_length() {
     return 256;  // arbitrary; there is no real limit internally

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -365,8 +365,8 @@ public:
   int mount();
   int umount();
 
-  unsigned get_max_object_name_length() {
-    return 4096;
+  int validate_hobject_key(const hobject_t &obj) const override {
+    return 0;
   }
   unsigned get_max_attr_name_length() {
     return 256;  // arbitrary; there is no real limit internally

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -95,6 +95,88 @@ TEST_F(LibRadosMiscPP, LongNamePP) {
   ASSERT_EQ(-ENAMETOOLONG, ioctx.write(string(maxlen*2, 'a').c_str(), bl, bl.length(), 0));
 }
 
+TEST_F(LibRadosMiscPP, LongLocatorPP) {
+  bufferlist bl;
+  bl.append("content");
+  int maxlen = g_conf->osd_max_object_name_len;
+  ioctx.locator_set_key(
+    string((maxlen/2), 'a'));
+  ASSERT_EQ(
+    0,
+    ioctx.write(
+      string("a").c_str(),
+      bl, bl.length(), 0));
+  ioctx.locator_set_key(
+    string(maxlen - 1, 'a'));
+  ASSERT_EQ(
+    0,
+    ioctx.write(
+      string("a").c_str(),
+      bl, bl.length(), 0));
+  ioctx.locator_set_key(
+    string(maxlen, 'a'));
+  ASSERT_EQ(
+    0,
+    ioctx.write(
+      string("a").c_str(),
+      bl, bl.length(), 0));
+  ioctx.locator_set_key(
+    string(maxlen+1, 'a'));
+  ASSERT_EQ(
+    -ENAMETOOLONG,
+    ioctx.write(
+      string("a").c_str(),
+      bl, bl.length(), 0));
+  ioctx.locator_set_key(
+    string((maxlen*2), 'a'));
+  ASSERT_EQ(
+    -ENAMETOOLONG,
+    ioctx.write(
+      string("a").c_str(),
+      bl, bl.length(), 0));
+}
+
+TEST_F(LibRadosMiscPP, LongNSpacePP) {
+  bufferlist bl;
+  bl.append("content");
+  int maxlen = g_conf->osd_max_object_namespace_len;
+  ioctx.set_namespace(
+    string((maxlen/2), 'a'));
+  ASSERT_EQ(
+    0,
+    ioctx.write(
+      string("a").c_str(),
+      bl, bl.length(), 0));
+  ioctx.set_namespace(
+    string(maxlen - 1, 'a'));
+  ASSERT_EQ(
+    0,
+    ioctx.write(
+      string("a").c_str(),
+      bl, bl.length(), 0));
+  ioctx.set_namespace(
+    string(maxlen, 'a'));
+  ASSERT_EQ(
+    0,
+    ioctx.write(
+      string("a").c_str(),
+      bl, bl.length(), 0));
+  ioctx.set_namespace(
+    string(maxlen+1, 'a'));
+  ASSERT_EQ(
+    -ENAMETOOLONG,
+    ioctx.write(
+      string("a").c_str(),
+      bl, bl.length(), 0));
+  ioctx.set_namespace(
+    string((maxlen*2), 'a'));
+  ASSERT_EQ(
+    -ENAMETOOLONG,
+    ioctx.write(
+      string("a").c_str(),
+      bl, bl.length(), 0));
+}
+
 TEST_F(LibRadosMiscPP, LongAttrNamePP) {
   bufferlist bl;
   bl.append("content");


### PR DESCRIPTION
Tested: samuelj-2016-04-06_16:46:34-rados-wip-sam-testing-distro-basic-smithi -- failures appear to be unrelated

ceph-qa-suite branch to follow