### PR TITLE
rgw_ldap: make ldap.h inclusion conditional

### DIFF
--- a/src/rgw/rgw_ldap.h
+++ b/src/rgw/rgw_ldap.h
@@ -4,8 +4,10 @@
 #ifndef RGW_LDAP_H
 #define RGW_LDAP_H
 
+#if defined(HAVE_OPENLDAP)
 #define LDAP_DEPRECATED 1
 #include "ldap.h"
+#endif
 
 #include <stdint.h>
 #include <tuple>


### PR DESCRIPTION
The feature implementation is conditional, embarassingly, the
header inclusion is not.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>