### PR TITLE
crushtool: do not allow to compile crushmap with repeat ruleset.

### DIFF
--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -608,6 +608,10 @@ int CrushCompiler::parse_rule(iter_t const& i)
   }
 
   int ruleset = int_node(i->children[start]);
+  if (ruleset_name.count(ruleset)) {
+    err << "ruleset '" << ruleset << "' already defined in rule '" << ruleset_name[ruleset] <<"'\n"<< std::endl;
+    return -1;
+  }
 
   string tname = string_node(i->children[start+2]);
   int type;
@@ -724,6 +728,7 @@ int CrushCompiler::parse_rule(iter_t const& i)
     }
   }
   assert(step == steps);
+  ruleset_name[ruleset] = rname;
   return 0;
 }
 

--- a/src/crush/CrushCompiler.h
+++ b/src/crush/CrushCompiler.h
@@ -39,7 +39,7 @@ class CrushCompiler {
   map<int, unsigned> item_weight;
   map<string, int> type_id;
   map<string, int> rule_id;
-
+  map<int, string> ruleset_name;
   string string_node(node_t &node);
   int int_node(node_t &node); 
   float float_node(node_t &node);


### PR DESCRIPTION
crushtool: do not allow to compile crushmap with repeat ruleset.

Signed-off-by: song baisen <song.baisen@zte.com.cn>