### PR TITLE
os/bluestore/NVMEDevice: performance improvements

### DIFF
--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -28,7 +28,7 @@
 
 #include "include/atomic.h"
 #include "include/interval_set.h"
-#include "include/utime.h"
+#include "common/ceph_time.h"
 #include "common/Mutex.h"
 #include "BlockDevice.h"
 
@@ -43,13 +43,18 @@ class NVMEDevice;
 
 struct Task {
   NVMEDevice *device;
-  IOContext *ctx;
+  IOContext *ctx = nullptr;
   IOCommand command;
-  uint64_t offset, len;
-  void *buf;
-  Task *next;
+  uint64_t offset;
+  uint64_t len;
+  void *buf = nullptr;
+  Task *next = nullptr;
   int64_t return_code;
   utime_t start;
+  Task(NVMEDevice *dev, IOCommand c, uint64_t off, uint64_t l, int64_t rc = 0)
+    : device(dev), command(c), offset(off), len(l),
+      return_code(rc),
+      start(ceph_clock_now(g_ceph_context)) {}
 };
 
 class PerfCounters;

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -39,24 +39,7 @@ enum class IOCommand {
   FLUSH_COMMAND
 };
 
-class NVMEDevice;
-
-struct Task {
-  NVMEDevice *device;
-  IOContext *ctx = nullptr;
-  IOCommand command;
-  uint64_t offset;
-  uint64_t len;
-  void *buf = nullptr;
-  Task *next = nullptr;
-  int64_t return_code;
-  utime_t start;
-  Task(NVMEDevice *dev, IOCommand c, uint64_t off, uint64_t l, int64_t rc = 0)
-    : device(dev), command(c), offset(off), len(l),
-      return_code(rc),
-      start(ceph_clock_now(g_ceph_context)) {}
-};
-
+class Task;
 class PerfCounters;
 class SharedDriverData;
 
@@ -219,13 +202,6 @@ class NVMEDevice : public BlockDevice {
 
   static void init();
  public:
-  void queue_buffer_task(Task *t) {
-    Mutex::Locker l(buffer_lock);
-    assert(t->next == nullptr);
-    t->next = buffered_task_head;
-    buffered_task_head = t;
-  }
-
   SharedDriverData *get_driver() { return driver; }
 
  public:


### PR DESCRIPTION
1. previously we use rte_malloc to alloc Task structure, rte_malloc is a strict memory allocator and will consume lots of time to seek for aligned-size memory in local numa node. Now we make task structure alloc with default allocator
2. same for Task structure, we need to pass physical address aware memory to spdk. So we need to copy data to rte memory range. Now we preallocate memory and use sgl-api to pass preallocated buffer  instead of alloc inflight to spdk
3. reimpl flush and make it reasonable

passed test_objectstore