### PR TITLE
osd/ReplicatedPG: make handle_watch_timeout no-op if !active

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -8783,6 +8783,10 @@ void ReplicatedPG::handle_watch_timeout(WatchRef watch)
   ObjectContextRef obc = watch->get_obc(); // handle_watch_timeout owns this ref
   dout(10) << "handle_watch_timeout obc " << obc << dendl;
 
+  if (!is_active()) {
+    dout(10) << "handle_watch_timeout not active, no-op" << dendl;
+    return;
+  }
   if (is_degraded_or_backfilling_object(obc->obs.oi.soid)) {
     callbacks_for_degraded_object[obc->obs.oi.soid].push_back(
       watch->get_delayed_cb()


### PR DESCRIPTION
During on_change, we clean up old events on the obcs.  This can
include a queued watch timeout:

 3: (ReplicatedPG::handle_watch_timeout(std::shared_ptr<Watch>)+0x125) [0x7f1fc21fe375]
 4: (HandleDelayedWatchTimeout::finish(int)+0xd3) [0x7f1fc213e2e3]
 5: (Context::complete(int)+0x9) [0x7f1fc20ead29]
 6: (ReplicatedPG::finish_degraded_object(hobject_t const&)+0x354) [0x7f1fc22429e4]
 7: (ReplicatedPG::on_change(ObjectStore::Transaction*)+0x2ba) [0x7f1fc224353a]
 8: (PG::start_peering_interval(std::shared_ptr<OSDMap const>, std::vector<int, std::allocator<int> > const&, int, std::vector<int, std::allocator<int> > const&, int, ObjectStore::Transaction*)+0x7bd) [0x7f1fc219a0bd]

In this case, handle_watch_timeout should not assume that we are
active and primary.

Fixes: http://tracker.ceph.com/issues/15391
Signed-off-by: Sage Weil <sage@redhat.com>