### PR TITLE
DNM rgw-admin: remove misleading error message

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3265,11 +3265,7 @@ int main(int argc, char **argv)
             cerr << "WARNING: failed to initialize zonegroup " << zonegroup_name << std::endl;
             continue;
           }
-          ret = zonegroup.remove_zone(zone);
-          if (ret < 0 && ret != -ENOENT) {
-            cerr << "failed to remove zone " << zone_name << " from zonegroup " << zonegroup.get_name() << ": "
-              << cpp_strerror(-ret) << std::endl;
-          }
+          zonegroup.remove_zone(zone);
         }
 
 	ret = zone.delete_obj();


### PR DESCRIPTION
In RGWZoneGroup::remove_zone(), we already log a message when trying to
remove a non-existent zone from a zonegroup. No need to treat this as an
error condition.

Signed-off-by: Karol Mroz <kmroz@suse.com>