### PR TITLE
DNM os/bluestore: New data structures and read/write/zero/truncate handler implementations embedded into Bluestore

### DIFF
--- a/src/os/Makefile.am
+++ b/src/os/Makefile.am
@@ -44,6 +44,7 @@ libos_a_SOURCES += \
 	os/bluestore/BlueStore.cc \
 	os/bluestore/FreelistManager.cc \
 	os/bluestore/KernelDevice.cc \
+	os/bluestore/ExtentManager.cc \
 	os/bluestore/StupidAllocator.cc
 endif
 
@@ -112,6 +113,7 @@ noinst_HEADERS += \
 	os/bluestore/BlueStore.h \
 	os/bluestore/KernelDevice.h \
 	os/bluestore/FreelistManager.h \
+	os/bluestore/ExtentManager.h \
 	os/bluestore/StupidAllocator.h
 endif
 

--- a/src/os/bluestore/ExtentManager.cc
+++ b/src/os/bluestore/ExtentManager.cc
@@ -62,13 +62,10 @@ int ExtentManager::read(uint64_t offset, uint32_t length, void* opaque, bufferli
     assert(bptr != nullptr);
     unsigned l2read;
     if(o >= lext->first && o < lext->first + lext->second.length) {
-      blobs2read_t::iterator it = blobs2read.find(bptr);
       unsigned r_off = o - lext->first;
       l2read = MIN(l, lext->second.length - r_off);
-      if (it != blobs2read.end())
-        it->second.push_back(region_t(o, r_off + lext->second.x_offset, 0, l2read));
-      else
-        blobs2read[bptr].push_back(region_t(o, r_off + lext->second.x_offset, 0, l2read));
+      regions2read_t& regions = blobs2read[bptr];
+      regions.push_back(region_t(o, r_off + lext->second.x_offset, 0, l2read));
       ++lext;
     } else if(o >= lext->first + lext->second.length){
       //handling the case when the first lookup get into the previous block due to the hole
@@ -253,11 +250,8 @@ int ExtentManager::blob2read_to_extents2read(const bluestore_blob_t* blob, Exten
       if (r_len > 0) {
 	r_len = MIN(r_len, l);
 	const bluestore_extent_t* eptr = &(*ext_it);
-	extents2read_t::iterator res_it = result->find(eptr);
-	if (res_it != result->end())
-	  res_it->second.push_back(region_t(l_offs, ext_pos, r_offs, r_len));
-	else
-	  (*result)[eptr].push_back(region_t(l_offs, ext_pos, r_offs, r_len));
+	regions2read_t& regions = (*result)[eptr];
+	regions.push_back(region_t(l_offs, ext_pos, r_offs, r_len));
 	l -= r_len;
 	l_offs += r_len;
       }

--- a/src/os/bluestore/ExtentManager.cc
+++ b/src/os/bluestore/ExtentManager.cc
@@ -1,0 +1,311 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+* Ceph - scalable distributed file system
+*
+* Copyright (C) 2016 Mirantis, Inc
+*
+* Author: Igor Fedotov <ifedotov@mirantis.com>
+*
+* This is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License version 2.1, as published by the Free Software
+* Foundation.  See file COPYING.
+*
+*/
+
+#include "ExtentManager.h"
+#include "common/debug.h"
+
+#define dout_subsys ceph_subsys_bluestore
+#undef dout_prefix
+#define dout_prefix *_dout << "ext_mgr:"
+
+
+bluestore_blob_t* ExtentManager::get_blob(BlobRef blob)
+{
+  bluestore_blob_t* res = nullptr;
+  bluestore_blob_map_t::iterator it = m_blobs.find(blob);
+  if (it != m_blobs.end())
+    res = &it->second;
+  return res;
+}
+
+uint64_t ExtentManager::get_read_block_size(const bluestore_blob_t* blob) const
+{
+  uint64_t block_size = m_device.get_block_size();
+  if(blob->csum_type != bluestore_blob_t::CSUM_NONE)
+    block_size = MAX(blob->get_csum_block_size(), block_size);
+  return block_size;
+}
+
+int ExtentManager::read(uint64_t offset, uint32_t length, void* opaque, bufferlist* result)
+{
+  result->clear();
+
+  bluestore_lextent_map_t::iterator lext = m_lextents.upper_bound(offset);
+  uint32_t l = length;
+  uint64_t o = offset;
+  if (lext == m_lextents.begin() && offset+length <= lext->first){
+    result->append_zero(length);
+    return 0;
+  } else if(lext == m_lextents.begin()) {
+    o = lext->first;
+    l -= lext->first - offset;
+  } else
+    --lext;
+
+  //build blob list to read
+  blobs2read_t blobs2read;
+  while (l > 0 && lext != m_lextents.end()) {
+    bluestore_blob_t* bptr = get_blob(lext->second.blob);
+    assert(bptr != nullptr);
+    unsigned l2read;
+    if(o >= lext->first && o < lext->first + lext->second.length) {
+      blobs2read_t::iterator it = blobs2read.find(bptr);
+      unsigned r_off = o - lext->first;
+      l2read = MIN(l, lext->second.length - r_off);
+      if (it != blobs2read.end())
+        it->second.push_back(region_t(o, r_off + lext->second.x_offset, 0, l2read));
+      else
+        blobs2read[bptr].push_back(region_t(o, r_off + lext->second.x_offset, 0, l2read));
+      ++lext;
+    } else if(o >= lext->first + lext->second.length){
+      //handling the case when the first lookup get into the previous block due to the hole
+      l2read = 0;
+      ++lext;
+    } else {
+      //hole found
+      l2read = MIN(l, lext->first -o);
+    }
+    o += l2read;
+    l -= l2read;
+  }
+
+  ready_regions_t ready_regions;
+
+  //enumerate and read/decompress desired blobs
+  blobs2read_t::iterator b2r_it = blobs2read.begin();
+  while (b2r_it != blobs2read.end()) {
+    const bluestore_blob_t* bptr = b2r_it->first;
+    regions2read_t r2r = b2r_it->second;
+    regions2read_t::const_iterator r2r_it = r2r.cbegin();
+    if (bptr->has_flag(bluestore_blob_t::BLOB_COMPRESSED)) {
+      bufferlist compressed_bl, raw_bl;
+
+      int r = read_whole_blob(bptr, opaque, &compressed_bl);
+      if (r < 0)
+	return r;
+      if(bptr->csum_type != bluestore_blob_t::CSUM_NONE){
+        r = verify_csum(bptr, 0, compressed_bl, opaque);
+        if (r < 0) {
+          dout(20) << __func__ << "  blob reading " << r2r_it->logical_offset << "~" << bptr->length <<" csum verification failed."<< dendl;
+          return r;
+        }
+      }
+
+      r = m_compressor.decompress(compressed_bl, opaque, &raw_bl);
+      if (r < 0)
+	return r;
+
+      while (r2r_it != r2r.end()) {
+	ready_regions[r2r_it->logical_offset].substr_of(raw_bl, r2r_it->blob_xoffset, r2r_it->length);
+	++r2r_it;
+      }
+
+    } else {
+      extents2read_t e2r;
+      int r = blob2read_to_extents2read(bptr, r2r_it, r2r.cend(), &e2r);
+      if (r < 0)
+	return r;
+
+      extents2read_t::const_iterator it = e2r.cbegin();
+      while (it != e2r.cend()) {
+	int r = read_extent_sparse(bptr, it->first, it->second.cbegin(), it->second.cend(), opaque, &ready_regions);
+	if (r < 0)
+	  return r;
+	++it;
+      }
+    }
+    ++b2r_it;
+  }
+
+  //generate a resulting buffer
+  ready_regions_t::iterator rr_it = ready_regions.begin();
+  o = offset;
+
+  while (rr_it != ready_regions.end()) {
+    if (o < rr_it->first)
+      result->append_zero(rr_it->first - o);
+    o = rr_it->first + rr_it->second.length();
+    assert(o <= offset + length);
+    result->claim_append(rr_it->second);
+    ++rr_it;
+  }
+  result->append_zero(offset + length - o);
+
+  return 0;
+}
+
+
+int ExtentManager::read_whole_blob(const bluestore_blob_t* blob, void* opaque, bufferlist* result)
+{
+  result->clear();
+
+  uint64_t block_size = m_device.get_block_size();
+
+  uint32_t l = blob->length;
+  uint64_t ext_pos = 0;
+  auto it = blob->extents.cbegin();
+  while (it != blob->extents.cend() && l > 0){
+    uint32_t r_len = MIN(l, it->length);
+    //uint32_t r_len = it->length;
+    uint32_t x_len = ROUND_UP_TO(r_len, block_size);
+
+    bufferlist bl;
+    //  dout(30) << __func__ << "  reading " << it->offset << "~" << x_len << dendl;
+    int r = m_device.read_block(it->offset, x_len, opaque, &bl);
+    if (r < 0) {
+      return r;
+    }
+
+    if (x_len == r_len){
+      result->claim_append(bl);
+    } else {
+      bufferlist u;
+      u.substr_of(bl, 0, r_len);
+      result->claim_append(u);
+    }
+    l -= r_len;
+    ext_pos += it->length;
+    ++it;
+  }
+
+  return 0;
+}
+
+int ExtentManager::read_extent_sparse(const bluestore_blob_t* blob, const bluestore_extent_t* extent, ExtentManager::regions2read_t::const_iterator cur, ExtentManager::regions2read_t::const_iterator end, void* opaque, ExtentManager::ready_regions_t* result)
+{
+  //FIXME: this is a trivial implementation that reads each region independently - can be improved to read neighboring and/or close enough regions together.
+
+  uint64_t block_size = get_read_block_size(blob);
+
+  assert((extent->length % block_size) == 0);   // all physical extents has to be aligned with read block size
+
+  while (cur != end) {
+
+    assert(cur->ext_xoffset + cur->length <= extent->length);
+
+
+    uint64_t r_off = cur->ext_xoffset;
+    uint64_t front_extra = r_off % block_size;
+    r_off -= front_extra;
+
+    uint64_t x_len = cur->length;
+    uint64_t r_len = ROUND_UP_TO(x_len + front_extra, block_size);
+
+//    dout(30) << __func__ << "  reading " << r_off << "~" << r_len << dendl;
+    bufferlist bl;
+    int r = m_device.read_block(r_off + extent->offset, r_len, opaque, &bl);
+    if (r < 0) {
+      return r;
+    }
+    r = verify_csum(blob, cur->blob_xoffset, bl, opaque);
+    if (r < 0) {
+      return r;
+    }
+
+    bufferlist u;
+    u.substr_of(bl, front_extra, x_len);
+    (*result)[cur->logical_offset].claim_append(u);
+
+    ++cur;
+  }
+  return 0;
+}
+
+int ExtentManager::blob2read_to_extents2read(const bluestore_blob_t* blob, ExtentManager::regions2read_t::const_iterator cur, ExtentManager::regions2read_t::const_iterator end, ExtentManager::extents2read_t* result)
+{
+  result->clear();
+
+  vector<bluestore_extent_t>::const_iterator ext_it = blob->extents.cbegin();
+  vector<bluestore_extent_t>::const_iterator ext_end = blob->extents.cend();
+
+  uint64_t ext_pos = 0;
+  uint64_t l = 0;
+  while (cur != end && ext_it != ext_end) {
+
+  assert(cur->ext_xoffset == 0);
+
+    //bypass preceeding extents
+    while (cur->blob_xoffset  >= ext_pos + ext_it->length && ext_it != ext_end) {
+      ext_pos += ext_it->length;
+      ++ext_it;
+    }
+    l = cur->length;
+    uint64_t r_offs = cur->blob_xoffset - ext_pos;
+    uint64_t l_offs = cur->logical_offset;
+    while (l > 0 && ext_it != ext_end) {
+
+      assert(blob->length >= ext_pos + r_offs);
+
+      uint64_t r_len = MIN(blob->length - ext_pos - r_offs, ext_it->length - r_offs);
+      if (r_len > 0) {
+	r_len = MIN(r_len, l);
+	const bluestore_extent_t* eptr = &(*ext_it);
+	extents2read_t::iterator res_it = result->find(eptr);
+	if (res_it != result->end())
+	  res_it->second.push_back(region_t(l_offs, ext_pos, r_offs, r_len));
+	else
+	  (*result)[eptr].push_back(region_t(l_offs, ext_pos, r_offs, r_len));
+	l -= r_len;
+	l_offs += r_len;
+      }
+
+      //leave extent pointer as-is if current region's been fully processed - lookup will start from it for the next region
+      if (l != 0) {
+	ext_pos += ext_it->length;
+	r_offs = 0;
+	++ext_it;
+      }
+    }
+
+    ++cur;
+    assert(cur == end || l_offs <= cur->logical_offset); //region offsets to be ordered ascending and with no overlaps. Overwise ext_it(ext_pos) to be enumerated from the beginning on each region
+  }
+
+  if (cur != end || l > 0) {
+    assert(l == 0);
+    assert(cur == end);
+    return -EFAULT;
+  }
+
+  return 0;
+}
+
+int ExtentManager::verify_csum(const bluestore_blob_t* blob, uint64_t blob_xoffset, const bufferlist& bl, void* opaque) const
+{
+  uint64_t block_size = blob->get_csum_block_size();
+  size_t csum_len = blob->get_csum_value_size();
+
+  assert((blob_xoffset % block_size) == 0);
+  assert((bl.length() % block_size) == 0);
+
+  uint64_t block0 = blob_xoffset / block_size;
+  uint64_t blocks = bl.length() / block_size;
+
+  assert(blob->csum_data.size() >= (block0 + blocks) * csum_len);
+
+  vector<char> csum_data;
+  csum_data.resize(blob->get_csum_value_size() * blocks);
+
+  vector<char>::const_iterator start = blob->csum_data.cbegin();
+  vector<char>::const_iterator end = blob->csum_data.cbegin();
+  start += block0 * csum_len;
+  end += (block0+blocks) * csum_len;
+
+  std::copy(start, end, csum_data.begin());
+
+  int r = m_csum_verifier.verify((bluestore_blob_t::CSumType)blob->csum_type, blob->get_csum_block_size(), csum_data, bl, opaque);
+  return r;
+}

--- a/src/os/bluestore/ExtentManager.h
+++ b/src/os/bluestore/ExtentManager.h
@@ -15,7 +15,7 @@
  */
 
 #ifndef CEPH_OSD_EXTENT_MANAGER_H
-#define CEPH_OSD_EXTENT_ANAGER_H
+#define CEPH_OSD_EXTENT_MANAGER_H
 
 #include <list>
 #include <map>
@@ -26,38 +26,66 @@
 class ExtentManager{
 
 public:
+  struct CheckSumInfo{
+    uint8_t csum_type;               //  enum bluestore_blob_t::CSumType
+    uint8_t csum_block_order;
+    CheckSumInfo() : csum_type(bluestore_blob_t::CSUM_NONE), csum_block_order(12) {}
+    CheckSumInfo(uint8_t _type, uint8_t _csum_block_order) : csum_type(_type), csum_block_order(_csum_block_order) {}
+  };
 
-  struct DeviceInterface
+  struct CompressInfo{
+    uint8_t compress_type;
+    CompressInfo() : compress_type(0xff) {}
+  };
+
+  struct BlockOpInterface
   {
-    virtual ~DeviceInterface() {}
+    virtual ~BlockOpInterface() {}
     virtual uint64_t get_block_size() = 0;
 
     virtual int read_block(uint64_t offset, uint32_t length, void* opaque, bufferlist* result) = 0;
+    virtual int write_block(uint64_t offset, const bufferlist& data, void* opaque) = 0;
+    virtual int zero_block(uint64_t offset, uint32_t length, void* opaque) = 0;
+
+    //method to allocate pextents, depending on the store state can return single or multiple pextents if there is no contiguous extent available
+    virtual int allocate_blocks(uint32_t length, void* opaque, bluestore_extent_vector_t* result) = 0;
+
+    virtual int release_block(uint64_t offset, uint32_t length, void* opaque) = 0;
 
   };
+
   struct CompressorInterface
   {
     virtual ~CompressorInterface() {}
+    virtual int compress(const CompressInfo& cinfo, uint32_t source_offs, uint32_t length, const bufferlist& source, void* opaque, bufferlist* result) = 0;
     virtual int decompress(const bufferlist& source, void* opaque, bufferlist* result) = 0;
   };
   struct CheckSumVerifyInterface
   {
     virtual ~CheckSumVerifyInterface() {}
-    virtual int verify(bluestore_blob_t::CSumType, uint32_t csum_block_size, const vector<char>& csum_data, const bufferlist& source, void* opaque) = 0;
+
+    virtual int calculate(bluestore_blob_t::CSumType, uint32_t csum_value_size, uint32_t csum_block_size, uint32_t source_offs, uint32_t source_len, const bufferlist& source, void* opaque, vector<char>* csum_data) = 0;
+    virtual int verify(bluestore_blob_t::CSumType, uint32_t csum_value_size, uint32_t csum_block_size, const bufferlist& source, void* opaque, const vector<char>& csum_data ) = 0;
   };
 
-  ExtentManager(DeviceInterface& device, CompressorInterface& compressor, CheckSumVerifyInterface& csum_verifier)
-    : m_device(device), m_compressor(compressor), m_csum_verifier(csum_verifier) {
+
+  ExtentManager(BlockOpInterface& blockop_inf, CompressorInterface& compressor, CheckSumVerifyInterface& csum_verifier)
+    : m_blockop_inf(blockop_inf), m_compressor(compressor), m_csum_verifier(csum_verifier) {
   }
 
-  int write(uint64_t offset, uint32_t length, void* opaque, const bufferlist& bl);
+  int write(uint64_t offset, const bufferlist& bl, void* opaque, const CheckSumInfo& check_info, const CompressInfo* compress_info);
+  int zero(uint64_t offset, uint64_t length, void* opaque);
+  int truncate(uint64_t offset, void* opaque);
   int read(uint64_t offset, uint32_t length, void* opaque, bufferlist* result);
+
+  uint64_t get_max_blob_size() const;
+  uint64_t get_min_alloc_size() const;
 
 protected:
 
   bluestore_blob_map_t m_blobs;
   bluestore_lextent_map_t m_lextents;
-  DeviceInterface& m_device;
+  BlockOpInterface& m_blockop_inf;
   CompressorInterface& m_compressor;
   CheckSumVerifyInterface& m_csum_verifier;
 
@@ -80,15 +108,79 @@ protected:
   typedef map<const bluestore_extent_t*, regions2read_t> extents2read_t;
   typedef map<uint64_t, bufferlist> ready_regions_t;
 
+  //Temporary struct to represent lextent along with corresponding pointer to a blob.
+  //Valid during single write request handling call.
+  //Intended to reduce blobs lookup.
+  struct live_lextent_t : public bluestore_lextent_t
+  {
+    bluestore_blob_map_t::iterator blob_iterator;
 
-  bluestore_blob_t* get_blob(BlobRef pextent);
+    live_lextent_t(const live_lextent_t& from)
+      : bluestore_lextent_t(from),
+      blob_iterator(from.blob_iterator)
+    {}
+    live_lextent_t(bluestore_blob_map_t::iterator blob_it)
+      : bluestore_lextent_t(),
+      blob_iterator(blob_it)
+    {}
+    live_lextent_t(bluestore_blob_map_t::iterator blob_it, BlobRef blob_ref, uint32_t o, uint32_t l, uint32_t f)
+      : bluestore_lextent_t(blob_ref, o, l, f),
+      blob_iterator(blob_it)
+    {}
+  };
+  typedef map<uint64_t, live_lextent_t> live_lextent_map_t;
+
+  bluestore_blob_t* get_blob(BlobRef blob_ref);
+  bluestore_blob_map_t::iterator get_blob_iterator(BlobRef blob_ref);
+
+  void ref_blob(BlobRef blob_ref);
+  void ref_blob(bluestore_blob_map_t::iterator blob_it);
+  void deref_blob(bluestore_blob_map_t::iterator blob_it, bool zero, void* opaque);
+
   uint64_t get_read_block_size(const bluestore_blob_t*) const;
+
+  void preprocess_changes(uint64_t offset, uint64_t length, bluestore_lextent_map_t* updated_lextents, live_lextent_map_t* removed_lextents, list<BlobRef>* blob2ref);
 
   int read_whole_blob(const bluestore_blob_t*, void* opaque, bufferlist* result);
   int read_extent_sparse(const bluestore_blob_t*, const bluestore_extent_t* extent, regions2read_t::const_iterator begin, regions2read_t::const_iterator end, void* opaque, ready_regions_t* result);
   int blob2read_to_extents2read(const bluestore_blob_t* blob, regions2read_t::const_iterator begin, regions2read_t::const_iterator end, extents2read_t* result);
 
   int verify_csum(const bluestore_blob_t* blob, uint64_t x_offset, const bufferlist& bl, void* opaque) const;
+
+  int allocate_raw_blob(uint32_t length, void* opaque, const CheckSumInfo& check_info, BlobRef* blob, bluestore_blob_map_t::iterator* res_blob_it);
+  int compress_and_allocate_blob(
+    uint64_t input_offs,
+    const bufferlist& raw_buffer,
+    void* opaque,
+    const CheckSumInfo& check_info,
+    const CompressInfo& compress_info,
+    BlobRef* blob,
+    bluestore_blob_map_t::iterator* res_blob_it,
+    bufferlist* compressed_buffer);
+
+  int write_blob(bluestore_blob_t& blob, uint64_t input_offs, const bufferlist& bl, void* opaque);
+
+  int write_uncompressed(uint64_t offset,
+    const bufferlist& bl,
+    void* opaque,
+    const CheckSumInfo& check_info,
+    live_lextent_map_t* new_lextents);
+  int write_compressed(uint64_t offset,
+    const bufferlist& bl,
+    void* opaque,
+    const CheckSumInfo& check_info,
+    const CompressInfo& compress_info,
+    live_lextent_map_t* new_lextents);
+  int apply_lextents(
+    live_lextent_map_t& new_lextents,
+    const bufferlist& raw_buffer,
+    std::vector<bufferlist>* compressed_buffers,
+    void* opaque);
+
+  void add_lextents(live_lextent_map_t::iterator cur, live_lextent_map_t::iterator end);
+  void update_lextents(bluestore_lextent_map_t::iterator start, bluestore_lextent_map_t::iterator end);
+  void release_lextents(live_lextent_map_t::iterator start, live_lextent_map_t::iterator end, bool zero, bool remove_from_primary_map, void* opaque);
+
 };
 
 #endif

--- a/src/os/bluestore/ExtentManager.h
+++ b/src/os/bluestore/ExtentManager.h
@@ -1,0 +1,94 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 Mirantis, Inc
+ *
+ * Author: Igor Fedotov <ifedotov@mirantis.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_OSD_EXTENT_MANAGER_H
+#define CEPH_OSD_EXTENT_ANAGER_H
+
+#include <list>
+#include <map>
+
+#include "include/buffer.h"
+#include "bluestore_types.h"
+
+class ExtentManager{
+
+public:
+
+  struct DeviceInterface
+  {
+    virtual ~DeviceInterface() {}
+    virtual uint64_t get_block_size() = 0;
+
+    virtual int read_block(uint64_t offset, uint32_t length, void* opaque, bufferlist* result) = 0;
+
+  };
+  struct CompressorInterface
+  {
+    virtual ~CompressorInterface() {}
+    virtual int decompress(const bufferlist& source, void* opaque, bufferlist* result) = 0;
+  };
+  struct CheckSumVerifyInterface
+  {
+    virtual ~CheckSumVerifyInterface() {}
+    virtual int verify(bluestore_blob_t::CSumType, uint32_t csum_block_size, const vector<char>& csum_data, const bufferlist& source, void* opaque) = 0;
+  };
+
+  ExtentManager(DeviceInterface& device, CompressorInterface& compressor, CheckSumVerifyInterface& csum_verifier)
+    : m_device(device), m_compressor(compressor), m_csum_verifier(csum_verifier) {
+  }
+
+  int write(uint64_t offset, uint32_t length, void* opaque, const bufferlist& bl);
+  int read(uint64_t offset, uint32_t length, void* opaque, bufferlist* result);
+
+protected:
+
+  bluestore_blob_map_t m_blobs;
+  bluestore_lextent_map_t m_lextents;
+  DeviceInterface& m_device;
+  CompressorInterface& m_compressor;
+  CheckSumVerifyInterface& m_csum_verifier;
+
+  //intermediate data structures used while reading
+  struct region_t {
+    uint64_t logical_offset;
+    uint64_t blob_xoffset,   //region offset within the blob
+             ext_xoffset,    //region offset within the pextent
+             length;
+
+    region_t(uint64_t offset, uint64_t b_offs, uint64_t x_offs, uint32_t len)
+      : logical_offset(offset), blob_xoffset(b_offs), ext_xoffset(x_offs), length(len) {
+    }
+    region_t(const region_t& from)
+      : logical_offset(from.logical_offset), blob_xoffset(from.blob_xoffset), ext_xoffset(from.ext_xoffset), length(from.length) {
+    }
+  };
+  typedef list<region_t> regions2read_t;
+  typedef map<const bluestore_blob_t*, regions2read_t> blobs2read_t;
+  typedef map<const bluestore_extent_t*, regions2read_t> extents2read_t;
+  typedef map<uint64_t, bufferlist> ready_regions_t;
+
+
+  bluestore_blob_t* get_blob(BlobRef pextent);
+  uint64_t get_read_block_size(const bluestore_blob_t*) const;
+
+  int read_whole_blob(const bluestore_blob_t*, void* opaque, bufferlist* result);
+  int read_extent_sparse(const bluestore_blob_t*, const bluestore_extent_t* extent, regions2read_t::const_iterator begin, regions2read_t::const_iterator end, void* opaque, ready_regions_t* result);
+  int blob2read_to_extents2read(const bluestore_blob_t* blob, regions2read_t::const_iterator begin, regions2read_t::const_iterator end, extents2read_t* result);
+
+  int verify_csum(const bluestore_blob_t* blob, uint64_t x_offset, const bufferlist& bl, void* opaque) const;
+};
+
+#endif

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -409,6 +409,8 @@ void bluestore_onode_t::encode(bufferlist& bl) const
   ::encode(omap_head, bl);
   ::encode(expected_object_size, bl);
   ::encode(expected_write_size, bl);
+  //FIXME: raise ver
+  ::encode(lextents, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -425,6 +427,8 @@ void bluestore_onode_t::decode(bufferlist::iterator& p)
   ::decode(omap_head, p);
   ::decode(expected_object_size, p);
   ::decode(expected_write_size, p);
+  //FIXME: raise ver
+  ::decode(lextents, p);
   DECODE_FINISH(p);
 }
 
@@ -601,11 +605,53 @@ void bluestore_wal_transaction_t::generate_test_instances(list<bluestore_wal_tra
 }
 
 // bluestore_blob_t
+void bluestore_blob_t::encode(bufferlist& bl) const
+{
+  ENCODE_START(1, 1, bl);
+  ::encode(extents, bl);
+  ::encode(length, bl);
+  ::encode(flags, bl);
+  ::encode(csum_type, bl);
+  ::encode(csum_block_order, bl);
+  ::encode(num_refs, bl);
+  ::encode(csum_data, bl);
+  ENCODE_FINISH(bl);
+}
+void bluestore_blob_t::decode(bufferlist::iterator& p)
+{
+  DECODE_START(1, p);
+  ::decode(extents, p);
+  ::decode(length, p);
+  ::decode(flags, p);
+  ::decode(csum_type, p);
+  ::decode(csum_block_order, p);
+  ::decode(num_refs, p);
+  ::decode(csum_data, p);
+  DECODE_FINISH(p);
+}
+
 void bluestore_blob_t::dump(Formatter *f) const
 {
   f->dump_unsigned("length", length);
   f->dump_unsigned("flags", flags);
-  //FIXME: more fields to dump
+  f->dump_unsigned("csum_type", csum_type);
+  f->dump_unsigned("csum_block_order", csum_block_order);
+  f->dump_unsigned("num_refs", num_refs);
+  f->dump_unsigned("flags", flags);
+  f->open_array_section("extents");
+  for (auto i = extents.begin();
+    i != extents.end();
+    ++i) {
+    f->open_object_section("extent");
+    i->dump(f);
+    f->close_section();
+  }
+  f->close_section();
+  //FIXME: dump csum_data
+}
+
+void bluestore_blob_t::generate_test_instances(list<bluestore_blob_t*>& o)
+{
 }
 
 // bluestore_lextent_t

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -599,3 +599,38 @@ void bluestore_wal_transaction_t::generate_test_instances(list<bluestore_wal_tra
   o.back()->ops.back().data.append("foodata");
   o.back()->ops.back().nid = 4;
 }
+
+// bluestore_blob_t
+void bluestore_blob_t::dump(Formatter *f) const
+{
+  f->dump_unsigned("length", length);
+  f->dump_unsigned("flags", flags);
+  //FIXME: more fields to dump
+}
+
+// bluestore_lextent_t
+string bluestore_lextent_t::get_flags_string(unsigned flags)
+{
+  string s;
+  return s;
+}
+
+void bluestore_lextent_t::dump(Formatter *f) const
+{
+  f->dump_unsigned("blob", blob);
+  f->dump_unsigned("x_offset", x_offset);
+  f->dump_unsigned("length", length);
+  f->dump_unsigned("flags", flags);
+}
+
+void bluestore_lextent_t::generate_test_instances(list<bluestore_lextent_t*>& o)
+{
+}
+
+ostream& operator<<(ostream& out, const bluestore_lextent_t& lb)
+{
+  out  << lb.x_offset << "~" << lb.length << "->" << lb.blob;
+  if (lb.flags)
+    out << ":" << bluestore_lextent_t::get_flags_string(lb.flags);
+  return out;
+}

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -148,7 +148,7 @@ ostream& operator<<(ostream& out, const bluestore_extent_t& e)
 }
 
 // bluestore_extent_ref_map_t
-
+/*
 void bluestore_extent_ref_map_t::add(uint64_t offset, uint32_t len, unsigned ref)
 {
   map<uint64_t,record_t>::iterator p = ref_map.insert(
@@ -353,7 +353,7 @@ ostream& operator<<(ostream& out, const bluestore_extent_ref_map_t& m)
   out << ")";
   return out;
 }
-
+*/
 // bluestore_overlay_t
 
 void bluestore_overlay_t::encode(bufferlist& bl) const
@@ -402,14 +402,9 @@ void bluestore_onode_t::encode(bufferlist& bl) const
   ::encode(nid, bl);
   ::encode(size, bl);
   ::encode(attrs, bl);
-  ::encode(block_map, bl);
-  ::encode(overlay_map, bl);
-  ::encode(overlay_refs, bl);
-  ::encode(last_overlay_key, bl);
   ::encode(omap_head, bl);
   ::encode(expected_object_size, bl);
   ::encode(expected_write_size, bl);
-  //FIXME: raise ver
   ::encode(lextents, bl);
   ENCODE_FINISH(bl);
 }
@@ -420,14 +415,9 @@ void bluestore_onode_t::decode(bufferlist::iterator& p)
   ::decode(nid, p);
   ::decode(size, p);
   ::decode(attrs, p);
-  ::decode(block_map, p);
-  ::decode(overlay_map, p);
-  ::decode(overlay_refs, p);
-  ::decode(last_overlay_key, p);
   ::decode(omap_head, p);
   ::decode(expected_object_size, p);
   ::decode(expected_write_size, p);
-  //FIXME: raise ver
   ::decode(lextents, p);
   DECODE_FINISH(p);
 }
@@ -445,37 +435,18 @@ void bluestore_onode_t::dump(Formatter *f) const
     f->close_section();
   }
   f->close_section();
-  f->open_object_section("block_map");
-  for (map<uint64_t, bluestore_extent_t>::const_iterator p = block_map.begin();
-       p != block_map.end(); ++p) {
-    f->open_object_section("extent");
-    f->dump_unsigned("extent_offset", p->first);
-    p->second.dump(f);
-    f->close_section();
-  }
-  f->close_section();
-  f->open_object_section("overlays");
-  for (map<uint64_t, bluestore_overlay_t>::const_iterator p = overlay_map.begin();
-       p != overlay_map.end(); ++p) {
-    f->open_object_section("overlay");
-    f->dump_unsigned("offset", p->first);
-    p->second.dump(f);
-    f->close_section();
-  }
-  f->close_section();
-  f->open_array_section("overlay_refs");
-  for (map<uint64_t,uint16_t>::const_iterator p = overlay_refs.begin();
-       p != overlay_refs.end(); ++p) {
-    f->open_object_section("overlay");
-    f->dump_unsigned("offset", p->first);
-    f->dump_unsigned("refs", p->second);
-    f->close_section();
-  }
-  f->close_section();
-  f->dump_unsigned("last_overlay_key", last_overlay_key);
   f->dump_unsigned("omap_head", omap_head);
   f->dump_unsigned("expected_object_size", expected_object_size);
   f->dump_unsigned("expected_write_size", expected_write_size);
+  f->open_array_section("lextents");
+  for (auto p = lextents.cbegin();
+       p != lextents.cend(); ++p) {
+    f->open_object_section("lextent");
+    f->dump_unsigned("offset", p->first);
+    p->second.dump(f);
+    f->close_section();
+  }
+  f->close_section();
 }
 
 void bluestore_onode_t::generate_test_instances(list<bluestore_onode_t*>& o)

--- a/src/test/Makefile-server.am
+++ b/src/test/Makefile-server.am
@@ -71,6 +71,11 @@ unittest_bluestore_types_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_bluestore_types_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_TESTPROGRAMS += unittest_bluestore_types
 
+unittest_bluestore_extent_manager_SOURCES = test/objectstore/test_bluestore_extent_manager.cc
+unittest_bluestore_extent_manager_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
+unittest_bluestore_extent_manager_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+check_TESTPROGRAMS += unittest_bluestore_extent_manager
+
 endif
 
 ceph_test_objectstore_workloadgen_SOURCES = \

--- a/src/test/objectstore/test_bluestore_extent_manager.cc
+++ b/src/test/objectstore/test_bluestore_extent_manager.cc
@@ -23,8 +23,27 @@
 #include "global/global_context.h"
 #include "os/bluestore/ExtentManager.h"
 
-typedef pair<uint64_t, uint32_t> ReadTuple;
-typedef vector<ReadTuple> ReadList;
+typedef pair<uint64_t, uint32_t> OffsLenTuple;
+typedef vector<OffsLenTuple> OffsLenList;
+
+struct WriteTuple
+{
+  uint64_t offs;
+  uint32_t len;
+  uint32_t csum;
+  WriteTuple()
+    : offs(0), len(0), csum(0) {}
+  WriteTuple(uint64_t _offs, uint32_t _len, uint32_t _csum)
+    : offs(_offs), len(_len), csum(_csum) {}
+  WriteTuple(const WriteTuple& from)
+    : offs(from.offs), len(from.len), csum(from.csum) {}
+
+  bool operator==(const WriteTuple& from) const {
+    return offs == from.offs && len == from.len && csum == from.csum;
+  }
+};
+
+typedef vector<WriteTuple> WriteList;
 
 struct CheckTuple {
   bluestore_blob_t::CSumType type;
@@ -38,29 +57,85 @@ struct CheckTuple {
 };
 typedef vector<CheckTuple> CheckList;
 
+enum {
+  PEXTENT_BASE = 0x12345, //just to have pextent offsets different from lextent ones
+};
+
 class TestExtentManager
-    : public ExtentManager::DeviceInterface,
+    : public ExtentManager::BlockOpInterface,
       public ExtentManager::CompressorInterface,
       public ExtentManager::CheckSumVerifyInterface,
       public ExtentManager {
 
-  enum {
-    PEXTENT_BASE = 0x12345, //just to have pextent offsets different from lextent ones
-    PEXTENT_ALLOC_UNIT = 0x10000
-  };
-
 public:
   TestExtentManager() 
-    : ExtentManager::DeviceInterface(),
+    : ExtentManager::BlockOpInterface(),
       ExtentManager::CompressorInterface(),
       ExtentManager::CheckSumVerifyInterface(),
-      ExtentManager(*this, *this, *this) {
+      ExtentManager(*this, *this, *this),
+      m_allocNextOffset(0),
+      m_fail_compress(false),
+      m_cratio(2) {
   }
-  ReadList m_reads;
+  OffsLenList m_reads, m_zeros, m_releases, m_compresses;
+  WriteList m_writes;
   CheckList m_checks;
+  uint64_t m_allocNextOffset;
+  bool m_fail_compress;
+  int m_cratio;
 
-  bool checkRead(const ReadTuple& r) {
+  //Intended to create EM backup thus performs incomplete copy that covers EM state only. Op history and test wrapper state aren't copied.
+  void operator= (const TestExtentManager& from) {
+    ExtentManager::m_lextents = from.m_lextents;
+    ExtentManager::m_blobs = from.m_blobs;
+  }
+  const bluestore_lextent_map_t& lextents() const { return m_lextents; }
+  const bluestore_blob_map_t& blobs() const { return m_blobs; }
+
+  bool checkRead(const OffsLenTuple& r) {
     return std::find(m_reads.begin(), m_reads.end(), r) != m_reads.end();
+  }
+  bool checkReleases(const OffsLenTuple& r) {
+    return std::find(m_releases.begin(), m_releases.end(), r) != m_releases.end();
+  }
+  bool checkZero(const OffsLenTuple& r) {
+    return std::find(m_zeros.begin(), m_zeros.end(), r) != m_zeros.end();
+  }
+  bool checkWrite(uint64_t offs, uint32_t len, const bufferlist& bl0, uint32_t input_offset = 0, uint32_t input_len = 0) {
+    assert(bl0.length() > input_offset);
+    input_len = input_len ? input_len : bl0.length() - input_offset;
+    bufferlist bl;
+    bl.substr_of(bl0, input_offset, input_len);
+    bl.append_zero( ROUND_UP_TO(input_len, get_block_size()) - input_len);
+    uint32_t crc = bl.crc32c(0);
+    WriteTuple w(offs, len, crc);
+    return std::find(m_writes.begin(), m_writes.end(), w) != m_writes.end();
+  }
+
+  void _calc_crc32(uint32_t csum_value_size, uint32_t csum_block_size, uint32_t source_offs, uint32_t source_len, const bufferlist& source, vector<char>* csum_data) {
+    while (source_len > 0) {
+      bufferlist bl;
+      uint32_t l = MIN(source_len, csum_block_size);
+      bl.substr_of(source, source_offs, l);
+
+      source_offs += l;
+      source_len -= l;
+      auto crc = bl.crc32c(0);
+      for (size_t i = 0; i < csum_value_size; i++)
+	csum_data->push_back(((char*)&crc)[i]);
+    }
+  }
+
+  bool checkCSum(uint32_t csum_val_size, uint32_t csum_block_size, const vector<char> csum_data, const bufferlist& bl0) {
+    vector<char> my_csum_data;
+    auto source_len = bl0.length();
+    uint32_t source_offs = 0;
+    _calc_crc32(csum_val_size, csum_block_size, source_offs, source_len, bl0, &my_csum_data);
+    return my_csum_data == csum_data;
+  }
+
+  bool checkCompress(const OffsLenTuple& r) {
+    return std::find(m_compresses.begin(), m_compresses.end(), r) != m_compresses.end();
   }
 
   void setup_csum() {
@@ -80,30 +155,30 @@ public:
 
     unsigned f = compress ? bluestore_blob_t::BLOB_COMPRESSED : 0;
 
-    m_lextents[0] = bluestore_lextent_t(0, 0, 0x8000);
-    m_blobs[0] = bluestore_blob_t(0x8000, bluestore_extent_t(PEXTENT_BASE + 0x00000, 1 * PEXTENT_ALLOC_UNIT), f);
+    m_lextents[0] = bluestore_lextent_t(10, 0, 0x8000, 0);
+    m_blobs[10] = bluestore_blob_t(0x8000, bluestore_extent_t(PEXTENT_BASE + 0x00000, 1 * get_min_alloc_size()), f);
 
-    m_lextents[0x8000] = bluestore_lextent_t(1, 0, 0x2000);
-    m_blobs[1] = bluestore_blob_t(0x4000, bluestore_extent_t(PEXTENT_BASE + 0x10000, 1 * PEXTENT_ALLOC_UNIT), f);
+    m_lextents[0x8000] = bluestore_lextent_t(1, 0, 0x2000, 0);
+    m_blobs[1] = bluestore_blob_t(0x4000, bluestore_extent_t(PEXTENT_BASE + 0x10000, 1 * get_min_alloc_size()), f);
 
     //hole at 0x0a000~0xc000
 
-    m_lextents[0x16000] = bluestore_lextent_t(2, 0, 0x3000);
-    m_blobs[2] = bluestore_blob_t(0x3000, bluestore_extent_t(PEXTENT_BASE + 0x20000, 1 * PEXTENT_ALLOC_UNIT), f);
+    m_lextents[0x16000] = bluestore_lextent_t(2, 0, 0x3000, 0);
+    m_blobs[2] = bluestore_blob_t(0x3000, bluestore_extent_t(PEXTENT_BASE + 0x20000, 1 * get_min_alloc_size()), f);
 
-    m_lextents[0x19000] = bluestore_lextent_t(3, 0, 0x17610);
-    m_blobs[3] = bluestore_blob_t(0x18000, bluestore_extent_t(PEXTENT_BASE + 0x40000, 2 * PEXTENT_ALLOC_UNIT), f);
+    m_lextents[0x19000] = bluestore_lextent_t(3, 0, 0x17610, 0);
+    m_blobs[3] = bluestore_blob_t(0x18000, bluestore_extent_t(PEXTENT_BASE + 0x40000, 2 * get_min_alloc_size()), f);
 
     //hole at 0x30610~0x29f0
 
-    m_lextents[0x33000] = bluestore_lextent_t(4, 0x0, 0x1900);
-    m_blobs[4] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x80000, 1 * PEXTENT_ALLOC_UNIT), f);
+    m_lextents[0x33000] = bluestore_lextent_t(4, 0x0, 0x1900, 0);
+    m_blobs[4] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x80000, 1 * get_min_alloc_size()), f);
 
-    m_lextents[0x34900] = bluestore_lextent_t(5, 0x400, 0x1515);
-    m_blobs[5] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x90000, 3 * PEXTENT_ALLOC_UNIT), f);
+    m_lextents[0x34900] = bluestore_lextent_t(5, 0x400, 0x1515, 0);
+    m_blobs[5] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x90000, 3 * get_min_alloc_size()), f);
 
-    m_lextents[0x35e15] = bluestore_lextent_t(6, 0x0, 0xa1eb);
-    m_blobs[6] = bluestore_blob_t(0xb000, bluestore_extent_t(PEXTENT_BASE + 0xc0000, 1 * PEXTENT_ALLOC_UNIT), f);
+    m_lextents[0x35e15] = bluestore_lextent_t(6, 0x0, 0xa1eb, 0);
+    m_blobs[6] = bluestore_blob_t(0xb000, bluestore_extent_t(PEXTENT_BASE + 0xc0000, 1 * get_min_alloc_size()), f);
 
     //hole at 0x40000~
 
@@ -117,18 +192,18 @@ public:
     unsigned f = compress ? bluestore_blob_t::BLOB_COMPRESSED : 0;
 
     //hole at 0~100
-    m_lextents[0x100] = bluestore_lextent_t(0, 0, 0x8000);
-    m_blobs[0] = bluestore_blob_t(0xa000, bluestore_extent_t(PEXTENT_BASE + 0xa0000, 1 * PEXTENT_ALLOC_UNIT), f);
+    m_lextents[0x100] = bluestore_lextent_t(100, 0, 0x8000, 0);
+    m_blobs[100] = bluestore_blob_t(0xa000, bluestore_extent_t(PEXTENT_BASE + 0xa0000, 1 * get_min_alloc_size()), f);
 
-    m_lextents[0x8100] = bluestore_lextent_t(1, 0, 0x200);
-    m_blobs[1] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x10000, 1 * PEXTENT_ALLOC_UNIT), f);
+    m_lextents[0x8100] = bluestore_lextent_t(1, 0, 0x200, 0);
+    m_blobs[1] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x10000, 1 * get_min_alloc_size()), f);
 
-    m_lextents[0x8300] = bluestore_lextent_t(2, 0, 0x1100);
-    m_blobs[2] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x20000, 2 * PEXTENT_ALLOC_UNIT), f);
+    m_lextents[0x8300] = bluestore_lextent_t(2, 0, 0x1100, 0);
+    m_blobs[2] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x20000, 2 * get_min_alloc_size()), f);
 
     //hole at 0x9400~0x100
 
-    m_lextents[0x9500] = bluestore_lextent_t(0, 0x9400, 0x200);
+    m_lextents[0x9500] = bluestore_lextent_t(100, 0x9400, 0x200, 0);
 
     //hole at 0x9700~
 
@@ -142,28 +217,28 @@ public:
     unsigned f = compress ? bluestore_blob_t::BLOB_COMPRESSED : 0;
 
     //hole at 0~100
-    m_lextents[0x100] = bluestore_lextent_t(0, 0, 0x8000);
-    m_blobs[0] = bluestore_blob_t(0xa000, f);
-    m_blobs[0].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0xa0000, 0x6000));
-    m_blobs[0].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0xb0000, 0x6000));
+    m_lextents[0x100] = bluestore_lextent_t(100, 0, 0x8000, 0);
+    m_blobs[100] = bluestore_blob_t(0xa000, f);
+    m_blobs[100].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0xa0000, 0x6000));
+    m_blobs[100].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0xb0000, 0x6000));
 
-    m_lextents[0x8100] = bluestore_lextent_t(1, 0, 0x200);
+    m_lextents[0x8100] = bluestore_lextent_t(1, 0, 0x200, 0);
     m_blobs[1] = bluestore_blob_t(0x2000, f);
-    m_blobs[1].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x10000, 1 * PEXTENT_ALLOC_UNIT / 2));
-    m_blobs[1].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x18000, 1 * PEXTENT_ALLOC_UNIT / 2));
+    m_blobs[1].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x10000, 1 * get_min_alloc_size() / 2));
+    m_blobs[1].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x18000, 1 * get_min_alloc_size() / 2));
 
-    m_lextents[0x8300] = bluestore_lextent_t(2, 0, 0x1100);
+    m_lextents[0x8300] = bluestore_lextent_t(2, 0, 0x1100, 0);
     m_blobs[2] = bluestore_blob_t(0x2000, f);
-    m_blobs[2].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x20000, 1 * PEXTENT_ALLOC_UNIT));
+    m_blobs[2].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x20000, 1 * get_min_alloc_size()));
 
     //hole at 0x9400~0x100
 
-    m_lextents[0x9500] = bluestore_lextent_t(0, 0x9400, 0x200);
+    m_lextents[0x9500] = bluestore_lextent_t(100, 0x9400, 0x200, 0);
 
     //hole at 0x9700~0x6600
     //hole at 0x10000~0x100
 
-    m_lextents[0x10100] = bluestore_lextent_t(3, 0x100, 0xcf00);
+    m_lextents[0x10100] = bluestore_lextent_t(3, 0x100, 0xcf00, 0);
     m_blobs[3] = bluestore_blob_t(0x26b00, f);
     m_blobs[3].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x30000, 0x8000));
     m_blobs[3].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x40000, 0x6000));
@@ -171,10 +246,10 @@ public:
     m_blobs[3].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x60000, 0x12000));
 
     //hole at 0x1d000~0x300
-    m_lextents[0x1d300] = bluestore_lextent_t(3, 0xd300, 0x1100);
+    m_lextents[0x1d300] = bluestore_lextent_t(3, 0xd300, 0x1100, 0);
     //hole at 0x1e400~0x5700
-    m_lextents[0x23b00] = bluestore_lextent_t(3, 0x13b00, 0x10000);
-    m_lextents[0x33b00] = bluestore_lextent_t(3, 0x23b00, 0x3000);
+    m_lextents[0x23b00] = bluestore_lextent_t(3, 0x13b00, 0x10000, 0);
+    m_lextents[0x33b00] = bluestore_lextent_t(3, 0x23b00, 0x3000, 0);
     //hole at 36ff1~
 
     if(csum_enable){
@@ -187,16 +262,38 @@ public:
     if (total){
       m_lextents.clear();
       m_blobs.clear();
+      m_allocNextOffset = 0;
+      m_fail_compress = false;
+      m_cratio = 2;
     }
     m_reads.clear();
+    m_writes.clear();
+    m_zeros.clear();
+    m_releases.clear();
     m_checks.clear();
+    m_compresses.clear();
+  }
+
+  void prepareWriteData(uint64_t offset0, uint32_t length, bufferlist* res_bl)
+  {
+    res_bl->clear();
+    auto offset = offset0;
+
+    unsigned shift = 17; //arbitrary selected value to have non-zero value at offset 0
+    bufferptr buf(length);
+    for (unsigned o = 0; o < length; o++){
+      buf[o] = (o + offset + shift) & 0xff;  //fill resulting buffer with some checksum pattern
+      ++offset;
+    }
+    res_bl->append(buf);
   }
 
 
-protected:
-  ////////////////DeviceInterface implementation////////////
+  ////////////////BlockOpInterface implementation////////////
   virtual uint64_t get_block_size() { return 4096; }
 
+protected:
+  ////////////////BlockOpInterface implementation////////////
   virtual int read_block(uint64_t offset0, uint32_t length, void* opaque, bufferlist* result)
   {
     uint64_t block_size = get_block_size();
@@ -214,27 +311,71 @@ protected:
       ++offset;
     }
     result->append(buf);
-    m_reads.push_back(ReadList::value_type(offset0, length));
+    m_reads.push_back(OffsLenList::value_type(offset0, length));
+    return 0;
+  }
+
+  virtual int write_block(uint64_t offset, const bufferlist& data, void* opaque)
+  {
+    assert(data.length() > 0);
+    assert(0u == (data.length() % get_block_size()));
+    m_writes.push_back(WriteList::value_type(offset - PEXTENT_BASE, data.length(), data.crc32c(0)));
+    return data.length();
+  }
+  virtual int zero_block(uint64_t offset, uint32_t length, void* opaque)
+  {
+    assert(0u == (length % get_block_size()));
+    m_zeros.push_back(OffsLenList::value_type(offset - PEXTENT_BASE, length));
+    return 0;
+  }
+
+
+  //method to allocate pextents, depending on the store state can return single or multiple pextents if there is no contiguous extent available
+  virtual int allocate_blocks(uint32_t length, void* opaque, bluestore_extent_vector_t* result)
+  {
+    assert(length != 0);
+    assert(0u == (length % get_min_alloc_size()));
+    result->push_back(bluestore_extent_vector_t::value_type(m_allocNextOffset + PEXTENT_BASE, length));
+    m_allocNextOffset += length;
+    return 0;
+  }
+
+  virtual int release_block(uint64_t offset, uint32_t length, void* opaque)
+  {
+    assert(0u == (offset - PEXTENT_BASE) % get_min_alloc_size());
+    assert(length != 0);
+    assert(0u == (length % get_min_alloc_size()));
+    m_releases.push_back(OffsLenTuple(offset - PEXTENT_BASE, length));
+
     return 0;
   }
 
   ////////////////CompressorInterface implementation////////
+  virtual int compress(const ExtentManager::CompressInfo& cinfo, uint32_t source_offs, uint32_t length, const bufferlist& source, void* opaque, bufferlist* result)
+  {
+    m_compresses.push_back(OffsLenTuple(source_offs, length));
+    if (!m_fail_compress) {
+      result->substr_of(source, source_offs, length / m_cratio);
+      return 0;
+    }
+    return -1;
+  }
+
   virtual int decompress(const bufferlist& source, void* opaque, bufferlist* result) {
     result->append(source);
     return 0;
   }
   ////////////////CheckSumVerifyInterface implementation////////
-  virtual int calculate(bluestore_blob_t::CSumType, uint32_t csum_block_size, uint32_t source_offs, const bufferlist& source, void* opaque, vector<char>* csum_data)
+  virtual int calculate(bluestore_blob_t::CSumType type, uint32_t csum_value_size, uint32_t csum_block_size, uint32_t source_offs, uint32_t source_len, const bufferlist& source, void* opaque, vector<char>* csum_data)
   {
-    //FIXME: to implement
+    _calc_crc32(csum_value_size, csum_block_size, source_offs, source_len, source, csum_data);
     return 0;
   }
-  virtual int verify(bluestore_blob_t::CSumType type, uint32_t csum_block_size, const vector<char>& csum_data, const bufferlist& source, void* opaque)
+  virtual int verify(bluestore_blob_t::CSumType type, uint32_t csum_value_size, uint32_t csum_block_size, const bufferlist& source, void* opaque, const vector<char>& csum_data)
   {
     m_checks.push_back(CheckList::value_type(type, csum_block_size, csum_data, source));
     return 0;
   }
-
 };
 
 TEST(bluestore_extent_manager, read)
@@ -247,7 +388,7 @@ TEST(bluestore_extent_manager, read)
   mgr.read(0, 128, NULL, &res);
   ASSERT_EQ(128u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0, 4096)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0, 4096)));
   ASSERT_EQ(0u, unsigned(res[0]));
   ASSERT_EQ(1u, unsigned(res[1]));
   ASSERT_EQ(127u, unsigned(res[127]));
@@ -259,8 +400,8 @@ TEST(bluestore_extent_manager, read)
   mgr.read(0x7000, 0x4000, NULL, &res);
   ASSERT_EQ(0x4000u, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x7000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x7000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x2000)));
 
   ASSERT_EQ(unsigned((0x7000 >> 12) & 0xff), unsigned(res[0]));
   ASSERT_EQ(unsigned(((0x7001 >> 12) + 1) & 0xff), unsigned(res[1]));
@@ -284,8 +425,8 @@ TEST(bluestore_extent_manager, read)
   mgr.read(0x7800, 0x0a00, NULL, &res);
   ASSERT_EQ(0x0a00u, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x7000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x7000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x1000)));
 
   ASSERT_EQ(unsigned((0x7800 >> 12) & 0xff), unsigned(res[0]));
   ASSERT_EQ(unsigned(((0x7801 >> 12) + 1) & 0xff), unsigned(res[1]));
@@ -302,8 +443,8 @@ TEST(bluestore_extent_manager, read)
   mgr.read(0x77f8, 0x080a, NULL, &res);
   ASSERT_EQ(0x080au, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x7000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x7000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x1000)));
 
   ASSERT_EQ(unsigned(((0x77f8 >> 12) + 0x07f8) & 0xff), (unsigned char)res[0]);
   ASSERT_EQ(unsigned(((0x77f9 >> 12) + 0x07f9) & 0xff), (unsigned char)res[1]);
@@ -331,8 +472,8 @@ TEST(bluestore_extent_manager, read)
   mgr.read(0x15ffe, 0x1a614, NULL, &res);
   ASSERT_EQ(0x1a614u, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x3000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x18000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x3000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x40000, 0x18000)));
 
   ASSERT_EQ(0u, unsigned(res[0x0000]));
   ASSERT_EQ(0u, unsigned(res[0x0001]));
@@ -351,9 +492,9 @@ TEST(bluestore_extent_manager, read)
   mgr.read(0x15ffe, 0x1e003, NULL, &res);
   ASSERT_EQ(0x1e003u, res.length());
   ASSERT_EQ(3u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x3000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x18000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x80000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x3000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x40000, 0x18000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x80000, 0x2000)));
 
   ASSERT_EQ(0u, unsigned(res[0x0000]));
   ASSERT_EQ(0u, unsigned(res[0x0001]));
@@ -375,7 +516,7 @@ TEST(bluestore_extent_manager, read)
   mgr.read(0x34902u, 0x2, NULL, &res);
   ASSERT_EQ(0x2u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x90000, 0x1000)));
 
   ASSERT_EQ(unsigned(((0x90402 >> 12) + 2)& 0xff), (unsigned char)res[0x0]);
   ASSERT_EQ(unsigned(((0x90403 >> 12) + 3)& 0xff), (unsigned char)res[0x1]);
@@ -387,7 +528,7 @@ TEST(bluestore_extent_manager, read)
   mgr.read(0x34902u, 0x1001, NULL, &res);
   ASSERT_EQ(0x1001u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x90000, 0x2000)));
 
   ASSERT_EQ(unsigned(((0x90402 >> 12) + 2) & 0xff), (unsigned char)res[0x0]);
   ASSERT_EQ(unsigned(((0x90402 >> 12) + 3) & 0xff), (unsigned char)res[0x1]);
@@ -401,9 +542,9 @@ TEST(bluestore_extent_manager, read)
   mgr.read(0x348fe, 0x1601, NULL, &res);
   ASSERT_EQ(0x1601u, res.length());
   ASSERT_EQ(3u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x81000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xc0000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x81000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x90000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xc0000, 0x1000)));
 
   ASSERT_EQ(unsigned(((0x818fe >> 12) + 0x18fe) & 0xff), (unsigned char)res[0x0]);
   ASSERT_EQ(unsigned(((0x818ff >> 12) + 0x18ff) & 0xff), (unsigned char)res[0x1]);
@@ -421,7 +562,7 @@ TEST(bluestore_extent_manager, read)
   mgr.read(0x3fff0, 0x12010, NULL, &res);
   ASSERT_EQ(0x12010u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xca000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xca000, 0x1000)));
 
   ASSERT_EQ(unsigned(((0xca000 >> 12) + 0xa1db) & 0xff), (unsigned char)res[0x0]);
   ASSERT_EQ(unsigned(((0xca00f >> 12) + 0xa1ea) & 0xff), (unsigned char)res[0xf]);
@@ -455,7 +596,7 @@ TEST(bluestore_extent_manager, read_checksum)
   mgr.read(0, 128, NULL, &res);
   ASSERT_EQ(128u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0, 0x2000)));
   ASSERT_EQ(1u, mgr.m_checks.size());
 
   ASSERT_EQ(0u, unsigned(res[0]));
@@ -469,8 +610,8 @@ TEST(bluestore_extent_manager, read_checksum)
   mgr.read(0x7000, 0x4000, NULL, &res);
   ASSERT_EQ(0x4000u, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x6000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x6000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x2000)));
 
   ASSERT_EQ(2u, mgr.m_checks.size());
 
@@ -496,8 +637,8 @@ TEST(bluestore_extent_manager, read_checksum)
   mgr.read(0x7800, 0x0a00, NULL, &res);
   ASSERT_EQ(0x0a00u, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x6000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x6000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x2000)));
 
   ASSERT_EQ(2u, mgr.m_checks.size());
 
@@ -516,8 +657,8 @@ TEST(bluestore_extent_manager, read_checksum)
   mgr.read(0x77f8, 0x080a, NULL, &res);
   ASSERT_EQ(0x080au, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x6000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x6000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x2000)));
 
   ASSERT_EQ(2u, mgr.m_checks.size());
 
@@ -547,8 +688,8 @@ TEST(bluestore_extent_manager, read_checksum)
   mgr.read(0x15ffe, 0x1a614, NULL, &res);
   ASSERT_EQ(0x1a614u, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x4000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x18000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x4000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x40000, 0x18000)));
 
   ASSERT_EQ(2u, mgr.m_checks.size());
 
@@ -569,9 +710,9 @@ TEST(bluestore_extent_manager, read_checksum)
   mgr.read(0x15ffe, 0x1e003, NULL, &res);
   ASSERT_EQ(0x1e003u, res.length());
   ASSERT_EQ(3u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x4000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x18000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x80000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x4000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x40000, 0x18000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x80000, 0x2000)));
 
   ASSERT_EQ(3u, mgr.m_checks.size());
 
@@ -595,7 +736,7 @@ TEST(bluestore_extent_manager, read_checksum)
   mgr.read(0x34902u, 0x2, NULL, &res);
   ASSERT_EQ(0x2u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x90000, 0x2000)));
   ASSERT_EQ(1u, mgr.m_checks.size());
 
 
@@ -609,7 +750,7 @@ TEST(bluestore_extent_manager, read_checksum)
   mgr.read(0x34902u, 0x1001, NULL, &res);
   ASSERT_EQ(0x1001u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x90000, 0x2000)));
   ASSERT_EQ(1u, mgr.m_checks.size());
 
   ASSERT_EQ(unsigned(((0x90402 >> 12) + 2) & 0xff), (unsigned char)res[0x0]);
@@ -624,9 +765,9 @@ TEST(bluestore_extent_manager, read_checksum)
   mgr.read(0x348fe, 0x1601, NULL, &res);
   ASSERT_EQ(0x1601u, res.length());
   ASSERT_EQ(3u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x80000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xc0000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x80000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x90000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xc0000, 0x2000)));
 
   ASSERT_EQ(3u, mgr.m_checks.size());
 
@@ -646,7 +787,7 @@ TEST(bluestore_extent_manager, read_checksum)
   mgr.read(0x3fff0, 0x12010, NULL, &res);
   ASSERT_EQ(0x12010u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xca000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xca000, 0x2000)));
 
   ASSERT_EQ(1u, mgr.m_checks.size());
 
@@ -685,7 +826,7 @@ TEST(bluestore_extent_manager, read_splitted_blob)
   mgr.read(0x50, 0x12b0, NULL, &res);
   ASSERT_EQ(0x12b0u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x2000)));
 
   ASSERT_EQ(0u, unsigned(res[0]));
   ASSERT_EQ(0u, unsigned(res[1]));
@@ -700,10 +841,10 @@ TEST(bluestore_extent_manager, read_splitted_blob)
   mgr.read(0x100, 0x9500, NULL, &res);
   ASSERT_EQ(0x9500u, res.length());
   ASSERT_EQ(4u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x8000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa9000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa9000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x2000)));
 
   ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x0]);
   ASSERT_EQ(unsigned(((0xa7fff >> 12) + 0x7fff) & 0xff), (unsigned char)res[0x7fff]);
@@ -724,10 +865,10 @@ TEST(bluestore_extent_manager, read_splitted_blob)
   mgr.read(0xff, 0x9602, NULL, &res);
   ASSERT_EQ(0x9602u, res.length());
   ASSERT_EQ(4u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x8000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa9000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa9000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x2000)));
 
   ASSERT_EQ(0u, unsigned(res[0]));
   ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x1]);
@@ -758,7 +899,7 @@ TEST(bluestore_extent_manager, read_splitted_checksum_blob)
   mgr.read(0x50, 0x12b0, NULL, &res);
   ASSERT_EQ(0x12b0u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x2000)));
 
   ASSERT_EQ(1u, mgr.m_checks.size());
 
@@ -775,10 +916,10 @@ TEST(bluestore_extent_manager, read_splitted_checksum_blob)
   mgr.read(0x100, 0x9500, NULL, &res);
   ASSERT_EQ(0x9500u, res.length());
   ASSERT_EQ(4u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x8000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa8000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa8000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x2000)));
 
   ASSERT_EQ(4u, mgr.m_checks.size());
 
@@ -801,10 +942,10 @@ TEST(bluestore_extent_manager, read_splitted_checksum_blob)
   mgr.read(0xff, 0x9602, NULL, &res);
   ASSERT_EQ(0x9602u, res.length());
   ASSERT_EQ(4u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x8000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa8000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa8000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x2000)));
 
   ASSERT_EQ(4u, mgr.m_checks.size());
 
@@ -837,7 +978,7 @@ TEST(bluestore_extent_manager, read_splitted_checksum_blob_compressed)
   mgr.read(0x50, 0x12b0, NULL, &res);
   ASSERT_EQ(0x12b0u, res.length());
   ASSERT_EQ(1u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0xa000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0xa000)));
 
   ASSERT_EQ(1u, mgr.m_checks.size());
 
@@ -854,9 +995,9 @@ TEST(bluestore_extent_manager, read_splitted_checksum_blob_compressed)
   mgr.read(0x100, 0x9500, NULL, &res);
   ASSERT_EQ(0x9500u, res.length());
   ASSERT_EQ(3u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0xa000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0xa000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x2000)));
 
   ASSERT_EQ(3u, mgr.m_checks.size());
 
@@ -879,9 +1020,9 @@ TEST(bluestore_extent_manager, read_splitted_checksum_blob_compressed)
   mgr.read(0xff, 0x9602, NULL, &res);
   ASSERT_EQ(0x9602u, res.length());
   ASSERT_EQ(3u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0xa000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0xa000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x2000)));
 
   ASSERT_EQ(3u, mgr.m_checks.size());
 
@@ -914,8 +1055,8 @@ TEST(bluestore_extent_manager, read_splitted_blob_multi_extent)
   mgr.read(0x50, 0x75b0, NULL, &res);
   ASSERT_EQ(0x75b0u, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xb0000, 0x2000)));
 
   ASSERT_EQ(0u, unsigned(res[0]));
   ASSERT_EQ(0u, unsigned(res[1]));
@@ -934,11 +1075,11 @@ TEST(bluestore_extent_manager, read_splitted_blob_multi_extent)
   mgr.read(0x100, 0x9500, NULL, &res);
   ASSERT_EQ(0x9500u, res.length());
   ASSERT_EQ(5u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb3000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xb0000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xb3000, 0x1000)));
 
   ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x0]);
   ASSERT_EQ(unsigned(((0xa5fff >> 12) + 0xa5fff) & 0xff), (unsigned char)res[0x5fff]);
@@ -976,13 +1117,13 @@ TEST(bluestore_extent_manager, read_splitted_blob_multi_extent)
   ASSERT_EQ(0, mgr.read(0x10000, 0x2c100, NULL, &res));
   ASSERT_EQ(0x2c100u, res.length());
   ASSERT_EQ(7u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x30000, 0x8000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x5000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x45000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x50000, 0x1000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x55000, 0x7000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x60000, 0xa000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x69000, 0x4000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x30000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x40000, 0x5000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x45000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x50000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x55000, 0x7000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x60000, 0xa000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x69000, 0x4000)));
 
   ASSERT_EQ(0u, unsigned(res[0x0]));
   ASSERT_EQ(0u, unsigned(res[0x1]));
@@ -1032,8 +1173,8 @@ TEST(bluestore_extent_manager, read_splitted_blob_multi_extent_checksum)
   mgr.read(0x50, 0x75b0, NULL, &res);
   ASSERT_EQ(0x75b0u, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xb0000, 0x2000)));
 
   ASSERT_EQ(2u, mgr.m_checks.size());
 
@@ -1063,11 +1204,11 @@ TEST(bluestore_extent_manager, read_splitted_blob_multi_extent_checksum)
   mgr.read(0x100, 0x9500, NULL, &res);
   ASSERT_EQ(0x9500u, res.length());
   ASSERT_EQ(5u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb2000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xb0000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xb2000, 0x2000)));
 
   ASSERT_EQ(5u, mgr.m_checks.size());
 
@@ -1107,13 +1248,13 @@ TEST(bluestore_extent_manager, read_splitted_blob_multi_extent_checksum)
   ASSERT_EQ(0, mgr.read(0x10000, 0x2c100, NULL, &res));
   ASSERT_EQ(0x2c100u, res.length());
   ASSERT_EQ(7u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x30000, 0x8000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x6000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x44000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x50000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x54000, 0x8000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x60000, 0xa000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x68000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x30000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x40000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x44000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x50000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x54000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x60000, 0xa000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x68000, 0x6000)));
 
   ASSERT_EQ(7u, mgr.m_checks.size());
 
@@ -1165,8 +1306,8 @@ TEST(bluestore_extent_manager, read_splitted_blob_multi_extent_compressed)
   mgr.read(0x50, 0x75b0, NULL, &res);
   ASSERT_EQ(0x75b0u, res.length());
   ASSERT_EQ(2u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x4000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xb0000, 0x4000)));
 
   ASSERT_EQ(0u, unsigned(res[0]));
   ASSERT_EQ(0u, unsigned(res[1]));
@@ -1196,10 +1337,10 @@ TEST(bluestore_extent_manager, read_splitted_blob_multi_extent_compressed)
   mgr.read(0x100, 0x9500, NULL, &res);
   ASSERT_EQ(0x9500u, res.length());
   ASSERT_EQ(4u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x4000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0xb0000, 0x4000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x20000, 0x2000)));
 
   ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x0]);
   ASSERT_EQ(unsigned(((0xa5fff >> 12) + 0xa5fff) & 0xff), (unsigned char)res[0x5fff]);
@@ -1237,10 +1378,10 @@ TEST(bluestore_extent_manager, read_splitted_blob_multi_extent_compressed)
   ASSERT_EQ(0, mgr.read(0x10000, 0x2c100, NULL, &res));
   ASSERT_EQ(0x2c100u, res.length());
   ASSERT_EQ(4u, mgr.m_reads.size());
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x30000, 0x8000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x6000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x50000, 0xc000)));
-  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x60000, 0xd000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x30000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x40000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x50000, 0xc000)));
+  ASSERT_TRUE(mgr.checkRead(OffsLenTuple(0x60000, 0xd000)));
 
   ASSERT_EQ(0u, unsigned(res[0x0]));
   ASSERT_EQ(0u, unsigned(res[0x1]));
@@ -1274,6 +1415,1243 @@ TEST(bluestore_extent_manager, read_splitted_blob_multi_extent_compressed)
   mgr.reset(false);
   res.clear();
 
+}
+
+TEST(bluestore_extent_manager, write)
+{
+  TestExtentManager mgr, backup_mgr;
+  bufferlist bl, tmpbl;
+  mgr.reset(true);
+
+  ExtentManager::CheckSumInfo check_info;
+  int r;
+  uint64_t offset = 0u;
+  uint64_t prev_alloc_offset = 0;
+  uint64_t some_alloc_offset0 = 0, some_alloc_offset = 0, some_alloc_offset2 = 0;
+
+  //Append get_block_size()-6 bytes  at offset 6
+  offset = 6u;
+  mgr.prepareWriteData(offset, mgr.get_block_size()-6, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(0u, ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ( ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset);
+
+  ASSERT_EQ(1u, mgr.lextents().size());
+  ASSERT_EQ(1u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, bl.length(), 0) == mgr.lextents().at(6));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE( bluestore_extent_t( 0 + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Append 64K+8K data
+  mgr.prepareWriteData(offset, mgr.get_min_alloc_size() + mgr.get_block_size()*2, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(mgr.get_min_alloc_size(), bl.length(), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(2u, mgr.lextents().size());
+  ASSERT_EQ(2u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, mgr.get_block_size() - 6, 0) == mgr.lextents().at(6u));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, bl.length(), 0) == mgr.lextents().at(0x1000));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 1);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(mgr.get_min_alloc_size() + PEXTENT_BASE, 2 * mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Append 1 byte
+  mgr.prepareWriteData(offset, 1, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(3 * mgr.get_min_alloc_size(), ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(3u, mgr.lextents().size());
+  ASSERT_EQ(3u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, mgr.get_block_size() - 6, 0) == mgr.lextents().at(6));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, bl.length(), 0) == mgr.lextents().at(0x1000 + 0x12000));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 2);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(3 * mgr.get_min_alloc_size() + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Append 128K + 2 bytes
+  mgr.prepareWriteData(offset, mgr.get_min_alloc_size()*2 + 2, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(4 * mgr.get_min_alloc_size(), ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(4u, mgr.lextents().size());
+  ASSERT_EQ(4u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, mgr.get_block_size() - 6, 0) == mgr.lextents().at(6));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, bl.length(), 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 3);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(4 * mgr.get_min_alloc_size() + PEXTENT_BASE, 3 * mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Overwrite 1 block(4K) data at offset 0
+  offset = 0u;
+  mgr.prepareWriteData(offset, mgr.get_block_size(), &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(1u, mgr.m_zeros.size());
+  ASSERT_EQ(1u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, bl.length(), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(0u, mgr.get_block_size())));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(0u, mgr.get_min_alloc_size())));
+
+  ASSERT_EQ(4u, mgr.lextents().size());
+  ASSERT_EQ(4u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 4, 0u, mgr.get_block_size(), 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, 2 * mgr.get_min_alloc_size() + 2, 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 4);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE( bluestore_extent_t( prev_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Overwrite 0.5 block(2K) data at offset 0
+  offset = 0u;
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF + 4).extents.at(0).offset;
+  mgr.prepareWriteData(offset, mgr.get_block_size() / 2, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, bl.length() * 2, bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(5u, mgr.lextents().size());
+  ASSERT_EQ(5u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 5, 0u, mgr.get_block_size() / 2, 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 4, mgr.get_block_size() / 2, mgr.get_block_size() / 2, 0) == mgr.lextents().at(mgr.get_block_size() / 2));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, 2 * mgr.get_min_alloc_size() + 2, 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 5);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(prev_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 4);
+    ASSERT_EQ(mgr.get_block_size(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(some_alloc_offset, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Overwrite 1 block(4K) data at offset 0 - thus releasing lextents at both offset=0 & offset=block_size/2
+  offset = 0u;
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF + 4).extents.at(0).offset - PEXTENT_BASE;
+  some_alloc_offset2 = mgr.blobs().at(FIRST_BLOB_REF + 5).extents.at(0).offset - PEXTENT_BASE;
+
+  mgr.prepareWriteData(offset, mgr.get_block_size(), &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(2u, mgr.m_zeros.size());
+  ASSERT_EQ(2u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, bl.length(), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset, mgr.get_block_size())));
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset2, mgr.get_block_size())));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset, mgr.get_min_alloc_size())));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset2, mgr.get_min_alloc_size())));
+
+  ASSERT_EQ(4u, mgr.lextents().size());
+  ASSERT_EQ(4u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 6, 0u, mgr.get_block_size(), 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, 2 * mgr.get_min_alloc_size() + 2, 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 6);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(prev_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Overwrite 0.5 block(2K) data at offset 0x400 - thus making a hole in the first lextent
+  offset = 0x400u;
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF + 6).extents.at(0).offset - PEXTENT_BASE;
+
+  mgr.prepareWriteData(offset, mgr.get_block_size() / 2, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(6u, mgr.lextents().size());
+  ASSERT_EQ(5u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 6, 0u, 0x400, 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 7, 0u, bl.length(), 0) == mgr.lextents().at(0x400));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 6, 0xc00, 0x400, 0) == mgr.lextents().at(0xc00));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, 2 * mgr.get_min_alloc_size() + 2, 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 7);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(prev_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 6);
+    ASSERT_EQ(mgr.get_block_size(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(2u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(some_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Overwrite 0.25 block(1K) data at offset 0x800 - thus making a hole in the second lextent
+  offset = 0x600u;
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF + 7).extents.at(0).offset - PEXTENT_BASE;
+
+  mgr.prepareWriteData(offset, mgr.get_block_size() / 4, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(8u, mgr.lextents().size());
+  ASSERT_EQ(6u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 6, 0u, 0x400, 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 7, 0u, 0x200, 0) == mgr.lextents().at(0x400));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 8, 0u, 0x400, 0) == mgr.lextents().at(0x600));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 7, 0x600u, 0x200, 0) == mgr.lextents().at(0xa00));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 6, 0xc00, 0x400, 0) == mgr.lextents().at(0xc00));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, 2 * mgr.get_min_alloc_size() + 2, 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 8);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(prev_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 7);
+    ASSERT_EQ(mgr.get_block_size() / 2, blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(2u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(some_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //create extent manager state backup to test different cases for the same state
+  backup_mgr = mgr;
+
+  //Overwrite 4095 bytes data at offset 0x1 - thus releasing all lextents/blobs within the starting 4K block but the first one
+  offset = 1;
+  some_alloc_offset0 = mgr.blobs().at(FIRST_BLOB_REF + 6).extents.at(0).offset - PEXTENT_BASE;
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF + 7).extents.at(0).offset - PEXTENT_BASE;
+  some_alloc_offset2= mgr.blobs().at(FIRST_BLOB_REF + 8).extents.at(0).offset - PEXTENT_BASE;
+
+  mgr.prepareWriteData(offset, mgr.get_block_size() - 1, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(2u, mgr.m_zeros.size());
+  ASSERT_EQ(2u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset, mgr.get_block_size())));
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset2, mgr.get_block_size())));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset, mgr.get_min_alloc_size())));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset2, mgr.get_min_alloc_size())));
+
+  ASSERT_EQ(5u, mgr.lextents().size());
+  ASSERT_EQ(5u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 6, 0u, 1u, 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 9, 0u, 4095, 0) == mgr.lextents().at(1));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, 2 * mgr.get_min_alloc_size() + 2, 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 9);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(prev_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 6);
+    ASSERT_EQ(mgr.get_block_size(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(some_alloc_offset0 + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //rollback to the previous EM state
+  mgr = backup_mgr;
+
+  //Overwrite 4095 bytes data at offset 0x0 - thus releasing all lextents/blobs within the starting 4K block but the last one
+  offset = 0;
+  some_alloc_offset0 = mgr.blobs().at(FIRST_BLOB_REF + 6).extents.at(0).offset - PEXTENT_BASE;
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF + 7).extents.at(0).offset - PEXTENT_BASE;
+  some_alloc_offset2= mgr.blobs().at(FIRST_BLOB_REF + 8).extents.at(0).offset - PEXTENT_BASE;
+
+  mgr.prepareWriteData(offset, mgr.get_block_size() - 1, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(2u, mgr.m_zeros.size());
+  ASSERT_EQ(2u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset, mgr.get_block_size())));
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset2, mgr.get_block_size())));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset, mgr.get_min_alloc_size())));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset2, mgr.get_min_alloc_size())));
+
+  ASSERT_EQ(5u, mgr.lextents().size());
+  ASSERT_EQ(5u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 9, 0u, 4095u, 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 6, 4095u, 1u, 0) == mgr.lextents().at(4095));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, 2 * mgr.get_min_alloc_size() + 2, 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 9);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(prev_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 6);
+    ASSERT_EQ(mgr.get_block_size(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(some_alloc_offset0 + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //rollback to the previous EM state
+  mgr = backup_mgr;
+
+  //Overwrite the content totally + append some data (0x80000 - 100 bytes total) - thus releasing all lextents/blobs
+  offset = 0;
+
+  mgr.prepareWriteData(offset, 0x80000 - 100, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(2u, mgr.m_writes.size()); //two lextents has been created due to max_blob_size limit
+
+  ASSERT_EQ(6u, mgr.m_zeros.size());
+  ASSERT_EQ(6u, mgr.m_releases.size());
+  tmpbl.substr_of(bl, 0, mgr.get_max_blob_size());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, mgr.get_max_blob_size(), tmpbl));
+  tmpbl.substr_of(bl, mgr.get_max_blob_size(), bl.length() - mgr.get_max_blob_size());
+  ASSERT_TRUE(mgr.checkWrite(
+    prev_alloc_offset + mgr.get_max_blob_size(),
+    ROUND_UP_TO(bl.length() - mgr.get_max_blob_size(), mgr.get_block_size()),
+    tmpbl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(2u, mgr.lextents().size());
+  ASSERT_EQ(2u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 9, 0u, mgr.get_max_blob_size(), 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 10, 0u, bl.length() - mgr.get_max_blob_size(), 0) == mgr.lextents().at(mgr.get_max_blob_size()));
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Append some data after the end pos
+  offset = 0x80100;
+  mgr.prepareWriteData(offset, 0x12345, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, NULL);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(3u, mgr.lextents().size());
+  ASSERT_EQ(3u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 9, 0u, mgr.get_max_blob_size(), 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 10, 0u, 0x80000 - 100 - mgr.get_max_blob_size(), 0) == mgr.lextents().at(mgr.get_max_blob_size()));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 11, 0u, bl.length(), 0) == mgr.lextents().at(0x80100));
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+}
+
+TEST(bluestore_extent_manager, write_compressed)
+{
+  TestExtentManager mgr, backup_mgr;
+  bufferlist bl, tmpbl;
+  mgr.reset(true);
+
+  ExtentManager::CheckSumInfo check_info;
+  ExtentManager::CompressInfo zip_info; zip_info.compress_type = 1;
+  int r;
+  uint64_t offset = 0u;
+  uint64_t prev_alloc_offset = 0;
+  uint64_t some_alloc_offset = 0, some_alloc_offset2 = 0;
+  uint64_t some_len = 0, some_len2 = 0;;
+
+  //Append get_block_size()-6 bytes  at offset 6
+  offset = 6u;
+  mgr.prepareWriteData(offset, mgr.get_block_size() - 6, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(0u, mgr.m_compresses.size());
+  ASSERT_TRUE(mgr.checkWrite(0u, ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset);
+
+  ASSERT_EQ(1u, mgr.lextents().size());
+  ASSERT_EQ(1u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, bl.length(), 0) == mgr.lextents().at(6));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Append 64K+8K data
+  mgr.prepareWriteData(offset, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(1u, mgr.m_compresses.size());
+  ASSERT_TRUE(mgr.checkWrite(mgr.get_min_alloc_size(), bl.length() / mgr.m_cratio, bl, 0, bl.length() / mgr.m_cratio));
+  ASSERT_TRUE(mgr.checkCompress(OffsLenTuple(0u, bl.length())));
+  ASSERT_EQ(ROUND_UP_TO(bl.length() / mgr.m_cratio, mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(2u, mgr.lextents().size());
+  ASSERT_EQ(2u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, mgr.get_block_size() - 6, 0) == mgr.lextents().at(6u));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, bl.length(), 0) == mgr.lextents().at(0x1000));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 1);
+    ASSERT_EQ(bl.length() / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(mgr.get_min_alloc_size() + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Append 1 byte
+  mgr.prepareWriteData(offset, 1, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(0u, mgr.m_compresses.size());
+  ASSERT_TRUE(mgr.checkWrite(2 * mgr.get_min_alloc_size(), ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(3u, mgr.lextents().size());
+  ASSERT_EQ(3u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, mgr.get_block_size() - 6, 0) == mgr.lextents().at(6));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, bl.length(), 0) == mgr.lextents().at(0x1000 + 0x12000));
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Append 128K + 2 bytes
+  mgr.prepareWriteData(offset, mgr.get_min_alloc_size() * 2 + 2, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(1u, mgr.m_compresses.size());
+  tmpbl.substr_of(bl, 0, bl.length() / mgr.m_cratio);
+  tmpbl.append_zero( ROUND_UP_TO(bl.length() / mgr.m_cratio, mgr.get_block_size()) - bl.length() / mgr.m_cratio);
+  ASSERT_TRUE(mgr.checkWrite(3 * mgr.get_min_alloc_size(), tmpbl.length(), tmpbl));
+  ASSERT_TRUE(mgr.checkCompress(OffsLenTuple(0u, bl.length())));
+  ASSERT_EQ(ROUND_UP_TO(bl.length() / mgr.m_cratio, mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(4u, mgr.lextents().size());
+  ASSERT_EQ(4u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, mgr.get_block_size() - 6, 0) == mgr.lextents().at(6));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, bl.length(), 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 3);
+    ASSERT_EQ(bl.length() / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(3 * mgr.get_min_alloc_size() + PEXTENT_BASE, 2 * mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Overwrite 1 block(4K) data at offset 0
+  offset = 0u;
+  mgr.prepareWriteData(offset, mgr.get_block_size(), &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(1u, mgr.m_zeros.size());
+  ASSERT_EQ(1u, mgr.m_releases.size());
+  ASSERT_EQ(0u, mgr.m_compresses.size());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, bl.length(), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(0u, mgr.get_block_size())));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(0u, mgr.get_min_alloc_size())));
+
+  ASSERT_EQ(4u, mgr.lextents().size());
+  ASSERT_EQ(4u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 4, 0u, mgr.get_block_size(), 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, 2 * mgr.get_min_alloc_size() + 2, 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 4);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(prev_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Totally overwrite second extent ( 64K + 8K)with a different cratio.
+  offset = mgr.get_block_size();
+  mgr.m_cratio = 3;
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF + 1).extents.at(0).offset - PEXTENT_BASE;
+  some_len = mgr.blobs().at(FIRST_BLOB_REF + 1).length;
+  mgr.prepareWriteData(offset, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+
+  ASSERT_EQ(1u, mgr.m_zeros.size());
+  ASSERT_EQ(1u, mgr.m_releases.size());
+  tmpbl.substr_of(bl, 0, bl.length() / mgr.m_cratio);
+  tmpbl.append_zero( ROUND_UP_TO(bl.length() / mgr.m_cratio, mgr.get_block_size()) - bl.length() / mgr.m_cratio);
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, tmpbl.length(), tmpbl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length() / mgr.m_cratio, mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset, ROUND_UP_TO( some_len, mgr.get_block_size()))));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset, mgr.get_min_alloc_size())));
+
+  ASSERT_EQ(4u, mgr.lextents().size());
+  ASSERT_EQ(4u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 4, 0u, mgr.get_block_size(), 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 5, 0u, bl.length(), 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, 2 * mgr.get_min_alloc_size() + 2, 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 5);
+    ASSERT_EQ(bl.length() / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(prev_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Totally overwrite the forth extent ( 128K + 1 ) with a different cratio.
+
+  offset = 0x1000 + 0x12000 + 1;
+  mgr.m_cratio = 3;
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF + 3).extents.at(0).offset - PEXTENT_BASE;
+  some_len = mgr.blobs().at(FIRST_BLOB_REF + 3).length;
+  mgr.prepareWriteData(offset, mgr.get_min_alloc_size() * 2 + 2, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+
+  ASSERT_EQ(1u, mgr.m_zeros.size());
+  ASSERT_EQ(1u, mgr.m_releases.size());
+  tmpbl.substr_of(bl, 0, bl.length() / mgr.m_cratio);
+  tmpbl.append_zero( ROUND_UP_TO(bl.length() / mgr.m_cratio, mgr.get_block_size()) - bl.length() / mgr.m_cratio);
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, tmpbl.length(), tmpbl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length() / mgr.m_cratio, mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset, ROUND_UP_TO( some_len, mgr.get_block_size()))));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset, 2 * mgr.get_min_alloc_size())));
+
+  ASSERT_EQ(4u, mgr.lextents().size());
+  ASSERT_EQ(4u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 4, 0u, 0x1000, 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 5, 0u, 0x12000, 0) == mgr.lextents().at(0x1000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, 1, 0) == mgr.lextents().at(0x1000 + 0x12000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 6, 0u, bl.length(), 0) == mgr.lextents().at(0x1000 + 0x12000 + 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 6);
+    ASSERT_EQ(bl.length() / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_TRUE(bluestore_extent_t(prev_alloc_offset + PEXTENT_BASE, mgr.get_min_alloc_size()) == blob.extents.at(0));
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Overwrite the content totally + append some data (0x80000 - 100 bytes total) - thus releasing all lextents/blobs
+  offset = 0;
+  mgr.m_cratio = 2;
+  mgr.prepareWriteData(offset, 0x80000 - 100, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(2u, mgr.m_writes.size()); //two lextents has been created due to max_blob_size limit
+
+  ASSERT_EQ(4u, mgr.m_zeros.size());
+  ASSERT_EQ(4u, mgr.m_releases.size());
+  ASSERT_EQ(2u, mgr.m_compresses.size());
+  tmpbl.substr_of(bl, 0, mgr.get_max_blob_size() / mgr.m_cratio);
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, tmpbl.length(), tmpbl));
+  tmpbl.substr_of(bl, mgr.get_max_blob_size(), (bl.length() - mgr.get_max_blob_size()) / 2);
+  tmpbl.append_zero( ROUND_UP_TO(tmpbl.length(), mgr.get_block_size()) - tmpbl.length());
+  ASSERT_TRUE(mgr.checkWrite(
+    prev_alloc_offset + mgr.get_max_blob_size() / mgr.m_cratio,
+    tmpbl.length(),
+    tmpbl));
+
+  ASSERT_EQ(2u, mgr.lextents().size());
+  ASSERT_EQ(2u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 7, 0u, mgr.get_max_blob_size(), 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 8, 0u, bl.length() - mgr.get_max_blob_size(), 0) == mgr.lextents().at(mgr.get_max_blob_size()));
+
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 7);
+    ASSERT_EQ(mgr.get_max_blob_size() / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+  }
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 8);
+    ASSERT_EQ((bl.length() - mgr.get_max_blob_size()) / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Append some data after the end pos
+  offset = 0x80100;
+  mgr.prepareWriteData(offset, 0x12345, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(1u, mgr.m_compresses.size());
+  tmpbl.substr_of(bl, 0, bl.length() / mgr.m_cratio);;
+  tmpbl.append_zero( ROUND_UP_TO(tmpbl.length(), mgr.get_block_size()) - tmpbl.length());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, tmpbl.length(), tmpbl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length() / mgr.m_cratio, mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(3u, mgr.lextents().size());
+  ASSERT_EQ(3u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 7, 0u, mgr.get_max_blob_size(), 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 8, 0u, 0x80000 - 100 - mgr.get_max_blob_size(), 0) == mgr.lextents().at(mgr.get_max_blob_size()));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 9, 0u, bl.length(), 0) == mgr.lextents().at(0x80100));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 9);
+    ASSERT_EQ(bl.length() / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Partially overwrite ( with 0x10001 bytes of data, uncompressed ) last two extents
+  offset = 0x7A000;
+  mgr.m_fail_compress = true;
+  mgr.prepareWriteData(offset, 0x10001, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(1u, mgr.m_compresses.size());
+  tmpbl = bl;
+  tmpbl.append_zero( ROUND_UP_TO(tmpbl.length(), mgr.get_block_size()) - tmpbl.length());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, tmpbl.length(), tmpbl));
+  ASSERT_EQ(ROUND_UP_TO(tmpbl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(4u, mgr.lextents().size());
+  ASSERT_EQ(4u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 7, 0u, mgr.get_max_blob_size(), 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 8, 0u, 0x3a000, 0) == mgr.lextents().at(mgr.get_max_blob_size()));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 10, 0u, bl.length(), 0) == mgr.lextents().at(0x7A000));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 9, 0x9f01, 0x12345 - 0x9f01, 0) == mgr.lextents().at(0x8a001));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 10);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+  }
+
+  mgr.m_fail_compress = false;
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Overwrite with append ( with 0x30001 bytes of data). Last two extents to be removed, the preceeding one to be altered
+  offset = 0x79fff;
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF + 10).extents.at(0).offset - PEXTENT_BASE;
+  some_alloc_offset2 = mgr.blobs().at(FIRST_BLOB_REF + 9).extents.at(0).offset - PEXTENT_BASE;
+  some_len = mgr.blobs().at(FIRST_BLOB_REF + 10).length;
+  some_len2 = mgr.blobs().at(FIRST_BLOB_REF + 9).length;
+
+  mgr.prepareWriteData(offset, 0x30001, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(2u, mgr.m_zeros.size());
+  ASSERT_EQ(2u, mgr.m_releases.size());
+  ASSERT_EQ(1u, mgr.m_compresses.size());
+  tmpbl.substr_of(bl, 0, bl.length() / mgr.m_cratio);
+  tmpbl.append_zero(ROUND_UP_TO(tmpbl.length(), mgr.get_block_size()) - tmpbl.length());
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, tmpbl.length(), tmpbl));
+  ASSERT_EQ(ROUND_UP_TO(tmpbl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset, ROUND_UP_TO(some_len, mgr.get_block_size()))));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset, ROUND_UP_TO(some_len, mgr.get_min_alloc_size()))));
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset2, ROUND_UP_TO(some_len2, mgr.get_block_size()))));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset2, ROUND_UP_TO(some_len2, mgr.get_min_alloc_size()))));
+
+  ASSERT_EQ(3u, mgr.lextents().size());
+  ASSERT_EQ(3u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 7, 0u, mgr.get_max_blob_size(), 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 8, 0u, 0x39fff, 0) == mgr.lextents().at(mgr.get_max_blob_size()));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 11, 0u, bl.length(), 0) == mgr.lextents().at(0x79fff));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 11);
+    ASSERT_EQ(bl.length() / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(bluestore_blob_t::CSUM_NONE, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+}
+
+TEST(bluestore_extent_manager, zero_truncate)
+{
+  TestExtentManager mgr, backup_mgr;
+  bufferlist bl, tmpbl;
+  mgr.reset(true);
+
+  ExtentManager::CheckSumInfo check_info;
+  ExtentManager::CompressInfo zip_info; zip_info.compress_type = 1;
+  int r;
+  uint64_t offset = 0u;
+  uint64_t some_alloc_offset = 0;
+  uint64_t some_len = 0, some_len2 = 0;
+
+  //truncate on empty object
+  r = mgr.truncate(0, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  mgr.reset(false);
+
+  r = mgr.truncate(0x12345, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  mgr.reset(false);
+
+  //zero on empty object
+  r = mgr.zero(0, 0, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  mgr.reset(false);
+
+  r = mgr.zero(0, 0x1234, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  mgr.reset(false);
+
+  r = mgr.zero(0x1234, 0, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  mgr.reset(false);
+
+  r = mgr.zero(0x1234, 0x1234, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  mgr.reset(false);
+
+  //Append get_block_size() * 2 bytes  at offset 0
+  offset = 0u;
+  mgr.prepareWriteData(offset, mgr.get_block_size() * 2, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(0u, mgr.m_compresses.size());
+  ASSERT_TRUE(mgr.checkWrite(0u, ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset);
+
+  ASSERT_EQ(1u, mgr.lextents().size());
+  ASSERT_EQ(1u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, bl.length(), 0) == mgr.lextents().at(0));
+
+  offset += bl.length();
+  mgr.reset(false);
+
+  //Make a backup
+  backup_mgr = mgr;
+
+  //Truncate to 1 block
+  r = mgr.truncate(mgr.get_block_size(), NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(1u, mgr.lextents().size());
+  ASSERT_EQ(1u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, mgr.get_block_size(), 0) == mgr.lextents().at(0));
+
+  mgr.reset(false);
+
+  //Truncate to zero
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF).extents.at(0).offset  - PEXTENT_BASE;
+  some_len = mgr.blobs().at(FIRST_BLOB_REF).length;
+  some_len2 = mgr.blobs().at(FIRST_BLOB_REF).extents.at(0).length;
+  r = mgr.truncate(0, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(1u, mgr.m_zeros.size());
+  ASSERT_EQ(1u, mgr.m_releases.size());
+  ASSERT_EQ(0u, mgr.lextents().size());
+  ASSERT_EQ(0u, mgr.blobs().size());
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset, ROUND_UP_TO(some_len, mgr.get_block_size()))));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset, ROUND_UP_TO(some_len2, mgr.get_min_alloc_size()))));
+
+  mgr.reset(false);
+
+  //Restore from backup
+  mgr = backup_mgr;
+
+  //Zero (255 bytes) in the mid of the first extent
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF).extents.at(0).offset;
+  some_len = mgr.blobs().at(FIRST_BLOB_REF).extents.at(0).length;
+  some_len2 = mgr.blobs().at(FIRST_BLOB_REF).length;
+  r = mgr.zero(mgr.get_block_size() / 2, 255, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(2u, mgr.lextents().size());
+  ASSERT_EQ(1u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, mgr.get_block_size() / 2, 0) == mgr.lextents().at(0));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, mgr.get_block_size() / 2 + 255, some_len2 - mgr.get_block_size() / 2 - 255, 0) == mgr.lextents().at(mgr.get_block_size() / 2 + 255));
+
+  //Zero the first lextent and partially the subsequent hole (2048 + 250 bytes)
+  some_len2 = mgr.blobs().at(FIRST_BLOB_REF).length;
+  r = mgr.zero(0, mgr.get_block_size() / 2 + 250, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(1u, mgr.lextents().size());
+  ASSERT_EQ(1u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, mgr.get_block_size() / 2 + 255, some_len2 - mgr.get_block_size() / 2 - 255, 0) == mgr.lextents().at(mgr.get_block_size() / 2 + 255));
+
+  //Restore from backup
+  mgr = backup_mgr;
+
+  //Zero the first lextent, partially the last lextent and intermediate hole (2048 + 260 bytes)
+  some_len2 = mgr.blobs().at(FIRST_BLOB_REF).length;
+  r = mgr.zero(0, mgr.get_block_size() / 2 + 260, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(1u, mgr.lextents().size());
+  ASSERT_EQ(1u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, mgr.get_block_size() / 2 + 260, some_len2 - mgr.get_block_size() / 2 - 260, 0) == mgr.lextents().at(mgr.get_block_size() / 2 + 260));
+
+  //Restore from backup
+  mgr = backup_mgr;
+
+  //Full zero
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF).extents.at(0).offset  - PEXTENT_BASE;
+  some_len = mgr.blobs().at(FIRST_BLOB_REF).length;
+  some_len2 = mgr.blobs().at(FIRST_BLOB_REF).extents.at(0).length;
+  r = mgr.zero(0, some_len, NULL);
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(0u, mgr.m_writes.size());
+  ASSERT_EQ(1u, mgr.m_zeros.size());
+  ASSERT_EQ(1u, mgr.m_releases.size());
+  ASSERT_EQ(0u, mgr.lextents().size());
+  ASSERT_EQ(0u, mgr.blobs().size());
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset, ROUND_UP_TO(some_len, mgr.get_block_size()))));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset, ROUND_UP_TO(some_len2, mgr.get_min_alloc_size()))));
+
+}
+
+TEST(bluestore_extent_manager, write_csum_compressed)
+{
+  TestExtentManager mgr, backup_mgr;
+  bufferlist bl, tmpbl;
+  mgr.reset(true);
+
+  ExtentManager::CheckSumInfo check_info;
+  check_info.csum_type = bluestore_blob_t::CSUM_CRC32C;
+  check_info.csum_block_order = 10; //1024 bytes
+
+  ExtentManager::CompressInfo zip_info; zip_info.compress_type = 1;
+  int r;
+  uint64_t offset = 0u;
+  uint64_t prev_alloc_offset = 0;
+  uint64_t some_alloc_offset = 0;
+  uint64_t some_len = 0;
+
+  //Append get_block_size()-10 bytes  at offset 6
+  offset = 6u;
+  mgr.prepareWriteData(offset, mgr.get_block_size() - 10, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(0u, mgr.m_compresses.size());
+  ASSERT_TRUE(mgr.checkWrite(0u, ROUND_UP_TO(bl.length(), mgr.get_block_size()), bl));
+  ASSERT_EQ(ROUND_UP_TO(bl.length(), mgr.get_min_alloc_size()), mgr.m_allocNextOffset);
+
+  ASSERT_EQ(1u, mgr.lextents().size());
+  ASSERT_EQ(1u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, bl.length(), 0) == mgr.lextents().at(6));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF);
+    ASSERT_EQ(bl.length(), blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(check_info.csum_type, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_EQ(check_info.csum_block_order, blob.csum_block_order);
+    ASSERT_EQ(4 * blob.get_csum_value_size(), blob.csum_data.size());
+    ASSERT_TRUE(mgr.checkCSum(
+      blob.get_csum_value_size(),
+      blob.get_csum_block_size(),
+      blob.csum_data,
+      bl));
+  }
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Append 64K+8K data at 0x1000
+  offset = mgr.get_block_size();
+  mgr.prepareWriteData(offset, mgr.get_min_alloc_size() + mgr.get_block_size() * 2, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(1u, mgr.m_writes.size());
+  ASSERT_EQ(0u, mgr.m_zeros.size());
+  ASSERT_EQ(0u, mgr.m_releases.size());
+  ASSERT_EQ(1u, mgr.m_compresses.size());
+  ASSERT_TRUE(mgr.checkWrite(mgr.get_min_alloc_size(), bl.length() / mgr.m_cratio, bl, 0, bl.length() / mgr.m_cratio));
+  ASSERT_TRUE(mgr.checkCompress(OffsLenTuple(0u, bl.length())));
+  ASSERT_EQ(ROUND_UP_TO(bl.length() / mgr.m_cratio, mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(2u, mgr.lextents().size());
+  ASSERT_EQ(2u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, mgr.get_block_size() - 10, 0) == mgr.lextents().at(6u));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 1, 0u, bl.length(), 0) == mgr.lextents().at(0x1000));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 1);
+    ASSERT_EQ(bl.length() / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(check_info.csum_type, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_EQ(check_info.csum_block_order, blob.csum_block_order);
+    tmpbl.substr_of(bl, 0, blob.length);
+    auto bs = blob.get_csum_block_size();
+    ASSERT_EQ(
+      ROUND_UP_TO(tmpbl.length(), bs) / bs * blob.get_csum_value_size(),
+      blob.csum_data.size());
+    ASSERT_TRUE(mgr.checkCSum(
+      blob.get_csum_value_size(),
+      blob.get_csum_block_size(),
+      blob.csum_data,
+      tmpbl));
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
+
+  //Overwrite + append 512K+100 data at 0x1000 - 1
+  some_alloc_offset = mgr.blobs().at(FIRST_BLOB_REF + 1).extents.at(0).offset - PEXTENT_BASE;
+  some_len = mgr.blobs().at(FIRST_BLOB_REF + 1).length
+;
+  offset = mgr.get_block_size() - 1;
+  mgr.prepareWriteData(offset, 0x80000 + 100, &bl);
+  r = mgr.write(offset, bl, NULL, check_info, &zip_info);
+  ASSERT_EQ((int)bl.length(), r);
+  ASSERT_EQ(3u, mgr.m_writes.size());
+  ASSERT_EQ(1u, mgr.m_zeros.size());
+  ASSERT_EQ(1u, mgr.m_releases.size());
+  ASSERT_EQ(2u, mgr.m_compresses.size());
+
+  ASSERT_TRUE(mgr.checkWrite(prev_alloc_offset, mgr.get_max_blob_size() / mgr.m_cratio, bl, 0, mgr.get_max_blob_size() / mgr.m_cratio));
+  ASSERT_TRUE(mgr.checkWrite(
+    prev_alloc_offset + mgr.get_max_blob_size() / mgr.m_cratio,
+    mgr.get_max_blob_size() / mgr.m_cratio,
+    bl,
+    mgr.get_max_blob_size() / mgr.m_cratio,
+    mgr.get_max_blob_size() / mgr.m_cratio));
+  tmpbl.substr_of(bl, mgr.get_max_blob_size() * 2, 100);
+  tmpbl.append_zero(mgr.get_block_size() - tmpbl.length());
+  ASSERT_TRUE(mgr.checkWrite(
+    prev_alloc_offset + 2 * mgr.get_max_blob_size() / mgr.m_cratio,
+    ROUND_UP_TO(100, mgr.get_block_size()),
+    tmpbl));
+
+  ASSERT_TRUE(mgr.checkZero(OffsLenTuple(some_alloc_offset, ROUND_UP_TO(some_len, mgr.get_block_size()))));
+  ASSERT_TRUE(mgr.checkReleases(OffsLenTuple(some_alloc_offset, ROUND_UP_TO(some_len, mgr.get_min_alloc_size()))));
+
+  ASSERT_TRUE(mgr.checkCompress(OffsLenTuple(0u, mgr.get_max_blob_size())));
+  ASSERT_TRUE(mgr.checkCompress(OffsLenTuple(mgr.get_max_blob_size(), mgr.get_max_blob_size())));
+
+  ASSERT_EQ(ROUND_UP_TO(bl.length() / mgr.m_cratio, mgr.get_min_alloc_size()), mgr.m_allocNextOffset - prev_alloc_offset);
+
+  ASSERT_EQ(4u, mgr.lextents().size());
+  ASSERT_EQ(4u, mgr.blobs().size());
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF, 0u, mgr.get_block_size() - 10, 0) == mgr.lextents().at(6u));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 2, 0u, mgr.get_max_blob_size(), 0) == mgr.lextents().at(0x1000 - 1));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 3, 0u, mgr.get_max_blob_size(), 0) == mgr.lextents().at(mgr.get_max_blob_size() + 0x1000 - 1));
+  ASSERT_TRUE(bluestore_lextent_t(FIRST_BLOB_REF + 4, 0u, 100, 0) == mgr.lextents().at(mgr.get_max_blob_size() * 2 + 0x1000 - 1));
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 2);
+    ASSERT_EQ(mgr.get_max_blob_size() / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(check_info.csum_type, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_EQ(check_info.csum_block_order, blob.csum_block_order);
+    tmpbl.substr_of(bl, 0, blob.length);
+    auto bs = blob.get_csum_block_size();
+    ASSERT_EQ(
+      ROUND_UP_TO(tmpbl.length(), bs) / bs * blob.get_csum_value_size(),
+      blob.csum_data.size());
+    ASSERT_TRUE(mgr.checkCSum(
+      blob.get_csum_value_size(),
+      blob.get_csum_block_size(),
+      blob.csum_data,
+      tmpbl));
+  }
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 3);
+    ASSERT_EQ(mgr.get_max_blob_size() / mgr.m_cratio, blob.length);
+    ASSERT_EQ(bluestore_blob_t::BLOB_COMPRESSED, blob.flags);
+    ASSERT_EQ(check_info.csum_type, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_EQ(check_info.csum_block_order, blob.csum_block_order);
+    tmpbl.substr_of(bl, mgr.get_max_blob_size(), blob.length);
+    auto bs = blob.get_csum_block_size();
+    ASSERT_EQ(
+      ROUND_UP_TO(tmpbl.length(), bs) / bs * blob.get_csum_value_size(),
+      blob.csum_data.size());
+    ASSERT_TRUE(mgr.checkCSum(
+      blob.get_csum_value_size(),
+      blob.get_csum_block_size(),
+      blob.csum_data,
+      tmpbl));
+  }
+  {
+    const bluestore_blob_t& blob = mgr.blobs().at(FIRST_BLOB_REF + 4);
+    ASSERT_EQ(100u, blob.length);
+    ASSERT_EQ(0u, blob.flags);
+    ASSERT_EQ(check_info.csum_type, blob.csum_type);
+    ASSERT_EQ(1u, blob.num_refs);
+    ASSERT_EQ(1u, blob.extents.size());
+    ASSERT_EQ(check_info.csum_block_order, blob.csum_block_order);
+    tmpbl.substr_of(bl, mgr.get_max_blob_size() * 2, blob.length);
+    auto bs = blob.get_csum_block_size();
+    ASSERT_EQ(
+      ROUND_UP_TO(tmpbl.length(), bs) / bs * blob.get_csum_value_size(),
+      blob.csum_data.size());
+    ASSERT_TRUE(mgr.checkCSum(
+      blob.get_csum_value_size(),
+      blob.get_csum_block_size(),
+      blob.csum_data,
+      tmpbl));
+  }
+
+  offset += bl.length();
+  prev_alloc_offset = mgr.m_allocNextOffset;
+  mgr.reset(false);
 }
 
 int main(int argc, char **argv) {

--- a/src/test/objectstore/test_bluestore_extent_manager.cc
+++ b/src/test/objectstore/test_bluestore_extent_manager.cc
@@ -1,0 +1,1293 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+* Ceph - scalable distributed file system
+*
+* Copyright (C) 2016 Mirantis, Inc
+*
+* Author: Igor Fedotov <ifedotov@mirantis.com>
+*
+* This is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License version 2.1, as published by the Free Software
+* Foundation.  See file COPYING.
+*
+*/
+
+#include <sstream>
+#include <vector>
+#include "gtest/gtest.h"
+#include "common/config.h"
+#include "common/ceph_argparse.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "os/bluestore/ExtentManager.h"
+
+typedef pair<uint64_t, uint32_t> ReadTuple;
+typedef vector<ReadTuple> ReadList;
+
+struct CheckTuple {
+  bluestore_blob_t::CSumType type;
+  uint32_t csum_block_size;
+  vector<char> csum_data;
+  bufferlist source;
+
+  CheckTuple(bluestore_blob_t::CSumType _type, uint32_t _csum_block_size, const vector<char>& _csum_data, const bufferlist& _source)
+    : type(_type), csum_block_size(_csum_block_size), csum_data(_csum_data), source(_source) {
+  }
+};
+typedef vector<CheckTuple> CheckList;
+
+class TestExtentManager
+    : public ExtentManager::DeviceInterface,
+      public ExtentManager::CompressorInterface,
+      public ExtentManager::CheckSumVerifyInterface,
+      public ExtentManager {
+
+  enum {
+    PEXTENT_BASE = 0x12345, //just to have pextent offsets different from lextent ones
+    PEXTENT_ALLOC_UNIT = 0x10000
+  };
+
+public:
+  TestExtentManager() 
+    : ExtentManager::DeviceInterface(),
+      ExtentManager::CompressorInterface(),
+      ExtentManager::CheckSumVerifyInterface(),
+      ExtentManager(*this, *this, *this) {
+  }
+  ReadList m_reads;
+  CheckList m_checks;
+
+  bool checkRead(const ReadTuple& r) {
+    return std::find(m_reads.begin(), m_reads.end(), r) != m_reads.end();
+  }
+
+  void setup_csum() {
+    for(auto it = m_blobs.begin(); it != m_blobs.end(); it++) {
+      it->second.csum_type = bluestore_blob_t::CSUM_CRC32C;
+      it->second.csum_block_order = 13; //read block size = 8192
+      uint64_t size = ROUND_UP_TO(it->second.length, it->second.get_csum_block_size());
+      size_t blocks = size / it->second.get_csum_block_size();
+      it->second.csum_data.resize(it->second.get_csum_value_size() * blocks);
+
+      //fill corresponding csum with block number to be able to verify that proper csum value is passed
+      for(size_t i = 0; i < it->second.csum_data.size(); i += it->second.get_csum_value_size())
+	it->second.csum_data[i] = i / it->second.get_csum_value_size();
+    }
+  }
+  void prepareTestSet4SimpleRead(bool compress, bool csum_enable = false) {
+
+    unsigned f = compress ? bluestore_blob_t::BLOB_COMPRESSED : 0;
+
+    m_lextents[0] = bluestore_lextent_t(0, 0, 0x8000);
+    m_blobs[0] = bluestore_blob_t(0x8000, bluestore_extent_t(PEXTENT_BASE + 0x00000, 1 * PEXTENT_ALLOC_UNIT), f);
+
+    m_lextents[0x8000] = bluestore_lextent_t(1, 0, 0x2000);
+    m_blobs[1] = bluestore_blob_t(0x4000, bluestore_extent_t(PEXTENT_BASE + 0x10000, 1 * PEXTENT_ALLOC_UNIT), f);
+
+    //hole at 0x0a000~0xc000
+
+    m_lextents[0x16000] = bluestore_lextent_t(2, 0, 0x3000);
+    m_blobs[2] = bluestore_blob_t(0x3000, bluestore_extent_t(PEXTENT_BASE + 0x20000, 1 * PEXTENT_ALLOC_UNIT), f);
+
+    m_lextents[0x19000] = bluestore_lextent_t(3, 0, 0x17610);
+    m_blobs[3] = bluestore_blob_t(0x18000, bluestore_extent_t(PEXTENT_BASE + 0x40000, 2 * PEXTENT_ALLOC_UNIT), f);
+
+    //hole at 0x30610~0x29f0
+
+    m_lextents[0x33000] = bluestore_lextent_t(4, 0x0, 0x1900);
+    m_blobs[4] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x80000, 1 * PEXTENT_ALLOC_UNIT), f);
+
+    m_lextents[0x34900] = bluestore_lextent_t(5, 0x400, 0x1515);
+    m_blobs[5] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x90000, 3 * PEXTENT_ALLOC_UNIT), f);
+
+    m_lextents[0x35e15] = bluestore_lextent_t(6, 0x0, 0xa1eb);
+    m_blobs[6] = bluestore_blob_t(0xb000, bluestore_extent_t(PEXTENT_BASE + 0xc0000, 1 * PEXTENT_ALLOC_UNIT), f);
+
+    //hole at 0x40000~
+
+    if(csum_enable){
+      setup_csum();
+    }
+  }
+
+  void prepareTestSet4SplitBlobRead(bool compress, bool csum_enable = false) {
+
+    unsigned f = compress ? bluestore_blob_t::BLOB_COMPRESSED : 0;
+
+    //hole at 0~100
+    m_lextents[0x100] = bluestore_lextent_t(0, 0, 0x8000);
+    m_blobs[0] = bluestore_blob_t(0xa000, bluestore_extent_t(PEXTENT_BASE + 0xa0000, 1 * PEXTENT_ALLOC_UNIT), f);
+
+    m_lextents[0x8100] = bluestore_lextent_t(1, 0, 0x200);
+    m_blobs[1] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x10000, 1 * PEXTENT_ALLOC_UNIT), f);
+
+    m_lextents[0x8300] = bluestore_lextent_t(2, 0, 0x1100);
+    m_blobs[2] = bluestore_blob_t(0x2000, bluestore_extent_t(PEXTENT_BASE + 0x20000, 2 * PEXTENT_ALLOC_UNIT), f);
+
+    //hole at 0x9400~0x100
+
+    m_lextents[0x9500] = bluestore_lextent_t(0, 0x9400, 0x200);
+
+    //hole at 0x9700~
+
+    if(csum_enable){
+      setup_csum();
+    }
+  }
+
+  void prepareTestSet4SplitBlobMultiExtentRead(bool compress, bool csum_enable = false) {
+
+    unsigned f = compress ? bluestore_blob_t::BLOB_COMPRESSED : 0;
+
+    //hole at 0~100
+    m_lextents[0x100] = bluestore_lextent_t(0, 0, 0x8000);
+    m_blobs[0] = bluestore_blob_t(0xa000, f);
+    m_blobs[0].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0xa0000, 0x6000));
+    m_blobs[0].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0xb0000, 0x6000));
+
+    m_lextents[0x8100] = bluestore_lextent_t(1, 0, 0x200);
+    m_blobs[1] = bluestore_blob_t(0x2000, f);
+    m_blobs[1].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x10000, 1 * PEXTENT_ALLOC_UNIT / 2));
+    m_blobs[1].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x18000, 1 * PEXTENT_ALLOC_UNIT / 2));
+
+    m_lextents[0x8300] = bluestore_lextent_t(2, 0, 0x1100);
+    m_blobs[2] = bluestore_blob_t(0x2000, f);
+    m_blobs[2].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x20000, 1 * PEXTENT_ALLOC_UNIT));
+
+    //hole at 0x9400~0x100
+
+    m_lextents[0x9500] = bluestore_lextent_t(0, 0x9400, 0x200);
+
+    //hole at 0x9700~0x6600
+    //hole at 0x10000~0x100
+
+    m_lextents[0x10100] = bluestore_lextent_t(3, 0x100, 0xcf00);
+    m_blobs[3] = bluestore_blob_t(0x26b00, f);
+    m_blobs[3].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x30000, 0x8000));
+    m_blobs[3].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x40000, 0x6000));
+    m_blobs[3].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x50000, 0xc000));
+    m_blobs[3].extents.push_back(bluestore_extent_t(PEXTENT_BASE + 0x60000, 0x12000));
+
+    //hole at 0x1d000~0x300
+    m_lextents[0x1d300] = bluestore_lextent_t(3, 0xd300, 0x1100);
+    //hole at 0x1e400~0x5700
+    m_lextents[0x23b00] = bluestore_lextent_t(3, 0x13b00, 0x10000);
+    m_lextents[0x33b00] = bluestore_lextent_t(3, 0x23b00, 0x3000);
+    //hole at 36ff1~
+
+    if(csum_enable){
+      setup_csum();
+    }
+  }
+
+
+  void reset(bool total) {
+    if (total){
+      m_lextents.clear();
+      m_blobs.clear();
+    }
+    m_reads.clear();
+    m_checks.clear();
+  }
+
+
+protected:
+  ////////////////DeviceInterface implementation////////////
+  virtual uint64_t get_block_size() { return 4096; }
+
+  virtual int read_block(uint64_t offset0, uint32_t length, void* opaque, bufferlist* result)
+  {
+    uint64_t block_size = get_block_size();
+    offset0 -= PEXTENT_BASE;
+    assert(length > 0);
+    assert((length % block_size) == 0);
+    assert((offset0 % block_size) == 0);
+
+    auto offset = offset0;
+
+    bufferptr buf(length);
+    for (unsigned o = 0; o < length; o++){
+      auto o0 = (offset >> 12); //pblock no
+      buf[o] = (o + o0) & 0xff;  //fill resulting buffer with some checksum pattern
+      ++offset;
+    }
+    result->append(buf);
+    m_reads.push_back(ReadList::value_type(offset0, length));
+    return 0;
+  }
+
+  ////////////////CompressorInterface implementation////////
+  virtual int decompress(const bufferlist& source, void* opaque, bufferlist* result) {
+    result->append(source);
+    return 0;
+  }
+  ////////////////CheckSumVerifyInterface implementation////////
+  virtual int calculate(bluestore_blob_t::CSumType, uint32_t csum_block_size, uint32_t source_offs, const bufferlist& source, void* opaque, vector<char>* csum_data)
+  {
+    //FIXME: to implement
+    return 0;
+  }
+  virtual int verify(bluestore_blob_t::CSumType type, uint32_t csum_block_size, const vector<char>& csum_data, const bufferlist& source, void* opaque)
+  {
+    m_checks.push_back(CheckList::value_type(type, csum_block_size, csum_data, source));
+    return 0;
+  }
+
+};
+
+TEST(bluestore_extent_manager, read)
+{
+  TestExtentManager mgr;
+  bufferlist res;
+  mgr.reset(true);
+  mgr.prepareTestSet4SimpleRead(false);
+
+  mgr.read(0, 128, NULL, &res);
+  ASSERT_EQ(128u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0, 4096)));
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(1u, unsigned(res[1]));
+  ASSERT_EQ(127u, unsigned(res[127]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x7000~0x1000, 0x8000~0x2000, 0xa00~0x1000(unallocated)
+  mgr.read(0x7000, 0x4000, NULL, &res);
+  ASSERT_EQ(0x4000u, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x7000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+
+  ASSERT_EQ(unsigned((0x7000 >> 12) & 0xff), unsigned(res[0]));
+  ASSERT_EQ(unsigned(((0x7001 >> 12) + 1) & 0xff), unsigned(res[1]));
+  ASSERT_EQ(unsigned(((0x7fff >> 12) + 0xfff) & 0xff), unsigned(res[0x0fff]));
+
+  ASSERT_EQ(unsigned((0x10000>>12) & 0xff), unsigned(res[0x1000]));
+  ASSERT_EQ(unsigned(((0x10001 >> 12)+1) & 0xff), unsigned(res[0x1001]));
+  ASSERT_EQ(unsigned(((0x10fff >> 12)+0x0fff) & 0xff), unsigned(res[0x1fff]));
+  ASSERT_EQ(unsigned(((0x11000 >> 12)+0x1000) & 0xff), unsigned(res[0x2000]));
+  ASSERT_EQ(unsigned(((0x11001 >> 12)+0x1001) & 0xff), unsigned(res[0x2001]));
+  ASSERT_EQ(unsigned(((0x11fff >> 12) + 0x1fff) & 0xff), unsigned(res[0x2fff]));
+
+  ASSERT_EQ(0u, unsigned(res[0x3000]));
+  ASSERT_EQ(0u, unsigned(res[0x3001]));
+  ASSERT_EQ(0u, unsigned(res[0x3fff]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x7800~0x0800, 0x8000~0x0200
+  mgr.read(0x7800, 0x0a00, NULL, &res);
+  ASSERT_EQ(0x0a00u, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x7000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x1000)));
+
+  ASSERT_EQ(unsigned((0x7800 >> 12) & 0xff), unsigned(res[0]));
+  ASSERT_EQ(unsigned(((0x7801 >> 12) + 1) & 0xff), unsigned(res[1]));
+  ASSERT_EQ(unsigned(((0x7fff >> 12) + 0x7ff) & 0xff), unsigned(res[0x07ff]));
+
+  ASSERT_EQ(unsigned((0x10000 >> 12) & 0xff), unsigned(res[0x0800]));
+  ASSERT_EQ(unsigned(((0x10801 >> 12) + 1) & 0xff), unsigned(res[0x0801]));
+  ASSERT_EQ(unsigned(((0x109ff >> 12) + 0x01ff) & 0xff), unsigned(res[0x09ff]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x77f8~0x0808, 0x8000~0x0002
+  mgr.read(0x77f8, 0x080a, NULL, &res);
+  ASSERT_EQ(0x080au, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x7000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x1000)));
+
+  ASSERT_EQ(unsigned(((0x77f8 >> 12) + 0x07f8) & 0xff), (unsigned char)res[0]);
+  ASSERT_EQ(unsigned(((0x77f9 >> 12) + 0x07f9) & 0xff), (unsigned char)res[1]);
+  ASSERT_EQ(unsigned(((0x7fff >> 12) + 0x0fff) & 0xff), (unsigned char)res[0x0807]);
+
+  ASSERT_EQ(unsigned((0x10000 >> 12) & 0xff), unsigned(res[0x0808]));
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 1) & 0xff), unsigned(res[0x0809]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x108f8~0x1808 (unallocated)
+  mgr.read(0x108f8, 0x1808, NULL, &res);
+  ASSERT_EQ(0x1808u, res.length());
+  ASSERT_EQ(0u, mgr.m_reads.size());
+
+  ASSERT_EQ(0u, unsigned(res[0x0000]));
+  ASSERT_EQ(0u, unsigned(res[0x0001]));
+  ASSERT_EQ(0u, unsigned(res[0x1807]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x15ffe~2, 0x16000~0x3000, 0x19000~0x17610, 0x30610~2
+  mgr.read(0x15ffe, 0x1a614, NULL, &res);
+  ASSERT_EQ(0x1a614u, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x3000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x18000)));
+
+  ASSERT_EQ(0u, unsigned(res[0x0000]));
+  ASSERT_EQ(0u, unsigned(res[0x0001]));
+  ASSERT_EQ(unsigned((0x20000 >> 12) & 0xff), unsigned(res[0x0002]));
+  ASSERT_EQ(unsigned(((0x22fff >> 12) + 0x2fff) & 0xff), unsigned(res[0x3001]));
+  ASSERT_EQ(unsigned((0x40000 >> 12) & 0xff), unsigned(res[0x3002]));
+  ASSERT_EQ(unsigned(((0x5760f >> 12) + 0x1760f) & 0xff), unsigned(res[0x1a611]));
+  ASSERT_EQ(0u, unsigned(res[0x1a612]));
+  ASSERT_EQ(0u, unsigned(res[0x1a613]));
+
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x15ffe~2, 0x16000~0x3000, 0x19000~0x17610, 0x30610~29f0, 0x33000~0x1001
+  mgr.read(0x15ffe, 0x1e003, NULL, &res);
+  ASSERT_EQ(0x1e003u, res.length());
+  ASSERT_EQ(3u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x3000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x18000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x80000, 0x2000)));
+
+  ASSERT_EQ(0u, unsigned(res[0x0000]));
+  ASSERT_EQ(0u, unsigned(res[0x0001]));
+  ASSERT_EQ(unsigned((0x20000 >> 12) & 0xff), unsigned(res[0x0002]));
+  ASSERT_EQ(unsigned(((0x22fff >> 12) + 0x2fff) & 0xff), unsigned(res[0x3001]));
+  ASSERT_EQ(unsigned((0x40000 >> 12) & 0xff), unsigned(res[0x3002]));
+  ASSERT_EQ(unsigned(((0x5760f >> 12) + 0x1760f) & 0xff), unsigned(res[0x1a611]));
+  ASSERT_EQ(0u, unsigned(res[0x1a612]));
+  ASSERT_EQ(0u, unsigned(res[0x1a613]));
+  ASSERT_EQ(0u, unsigned(res[0x1d001]));
+  ASSERT_EQ(unsigned(((0x80000 >> 12) + 0) & 0xff), (unsigned char)res[0x1d002]);
+  ASSERT_EQ(unsigned(((0x80001 >> 12) + 1) & 0xff), (unsigned char)res[0x1d003]);
+  ASSERT_EQ(unsigned(((0x81000 >> 12) + 0x1000) & 0xff), (unsigned char)res[0x1e002]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x34902~2
+  mgr.read(0x34902u, 0x2, NULL, &res);
+  ASSERT_EQ(0x2u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x1000)));
+
+  ASSERT_EQ(unsigned(((0x90402 >> 12) + 2)& 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0x90403 >> 12) + 3)& 0xff), (unsigned char)res[0x1]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x34902~0x1001
+  mgr.read(0x34902u, 0x1001, NULL, &res);
+  ASSERT_EQ(0x1001u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x2000)));
+
+  ASSERT_EQ(unsigned(((0x90402 >> 12) + 2) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0x90402 >> 12) + 3) & 0xff), (unsigned char)res[0x1]);
+  ASSERT_EQ(unsigned(((0x91401 >> 12) + 0x1001) & 0xff), (unsigned char)res[0xfff]);
+  ASSERT_EQ(unsigned(((0x91402 >> 12) + 0x1002) & 0xff), (unsigned char)res[0x1000]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x348fe~2, 0x34900~0x1515, 35e15~0x00ea
+  mgr.read(0x348fe, 0x1601, NULL, &res);
+  ASSERT_EQ(0x1601u, res.length());
+  ASSERT_EQ(3u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x81000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xc0000, 0x1000)));
+
+  ASSERT_EQ(unsigned(((0x818fe >> 12) + 0x18fe) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0x818ff >> 12) + 0x18ff) & 0xff), (unsigned char)res[0x1]);
+  ASSERT_EQ(unsigned(((0x90400 >> 12) + 0x0) & 0xff), (unsigned char)res[0x2]);
+  ASSERT_EQ(unsigned(((0x91914 >> 12) + 0x1514) & 0xff), (unsigned char)res[0x1516]);
+
+  ASSERT_EQ(unsigned(((0xc0000 >> 12) + 0) & 0xff), (unsigned char)res[0x1517]);
+  ASSERT_EQ(unsigned(((0xc0001 >> 12) + 1) & 0xff), (unsigned char)res[0x1518]);
+  ASSERT_EQ(unsigned(((0xc00e9 >> 12) + 0xe9) & 0xff), (unsigned char)res[0x1600]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x3fff0~0x10, 0x40000~0x12000 (unallocated)
+  mgr.read(0x3fff0, 0x12010, NULL, &res);
+  ASSERT_EQ(0x12010u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xca000, 0x1000)));
+
+  ASSERT_EQ(unsigned(((0xca000 >> 12) + 0xa1db) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0xca00f >> 12) + 0xa1ea) & 0xff), (unsigned char)res[0xf]);
+  ASSERT_EQ(0u, unsigned(res[0x10]));
+  ASSERT_EQ(0u, unsigned(res[0x11]));
+  ASSERT_EQ(0u, unsigned(res[0x1200f]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x40700~0x0a02 (unallocated)
+  mgr.read(0x40700, 0xa02, NULL, &res);
+  ASSERT_EQ(0xa02u, res.length());
+  ASSERT_EQ(0u, mgr.m_reads.size());
+
+  ASSERT_EQ(0u, unsigned(res[0x0]));
+  ASSERT_EQ(0u, unsigned(res[0x1]));
+  ASSERT_EQ(0u, unsigned(res[0xa01]));
+
+  mgr.reset(false);
+  res.clear();
+}
+
+TEST(bluestore_extent_manager, read_checksum)
+{
+  TestExtentManager mgr;
+  bufferlist res;
+  mgr.reset(true);
+  mgr.prepareTestSet4SimpleRead(false, true);
+
+  mgr.read(0, 128, NULL, &res);
+  ASSERT_EQ(128u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0, 0x2000)));
+  ASSERT_EQ(1u, mgr.m_checks.size());
+
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(1u, unsigned(res[1]));
+  ASSERT_EQ(127u, unsigned(res[127]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x7000~0x1000, 0x8000~0x2000, 0xa00~0x1000(unallocated)
+  mgr.read(0x7000, 0x4000, NULL, &res);
+  ASSERT_EQ(0x4000u, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x6000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+
+  ASSERT_EQ(2u, mgr.m_checks.size());
+
+  ASSERT_EQ(unsigned((0x7000 >> 12) & 0xff), unsigned(res[0]));
+  ASSERT_EQ(unsigned(((0x7001 >> 12) + 1) & 0xff), unsigned(res[1]));
+  ASSERT_EQ(unsigned(((0x7fff >> 12) + 0xfff) & 0xff), unsigned(res[0x0fff]));
+
+  ASSERT_EQ(unsigned((0x10000>>12) & 0xff), unsigned(res[0x1000]));
+  ASSERT_EQ(unsigned(((0x10001 >> 12)+1) & 0xff), unsigned(res[0x1001]));
+  ASSERT_EQ(unsigned(((0x10fff >> 12)+0x0fff) & 0xff), unsigned(res[0x1fff]));
+  ASSERT_EQ(unsigned(((0x11000 >> 12)+0x1000) & 0xff), unsigned(res[0x2000]));
+  ASSERT_EQ(unsigned(((0x11001 >> 12)+0x1001) & 0xff), unsigned(res[0x2001]));
+  ASSERT_EQ(unsigned(((0x11fff >> 12) + 0x1fff) & 0xff), unsigned(res[0x2fff]));
+
+  ASSERT_EQ(0u, unsigned(res[0x3000]));
+  ASSERT_EQ(0u, unsigned(res[0x3001]));
+  ASSERT_EQ(0u, unsigned(res[0x3fff]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x7800~0x0800, 0x8000~0x0200
+  mgr.read(0x7800, 0x0a00, NULL, &res);
+  ASSERT_EQ(0x0a00u, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x6000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+
+  ASSERT_EQ(2u, mgr.m_checks.size());
+
+  ASSERT_EQ(unsigned((0x7800 >> 12) & 0xff), unsigned(res[0]));
+  ASSERT_EQ(unsigned(((0x7801 >> 12) + 1) & 0xff), unsigned(res[1]));
+  ASSERT_EQ(unsigned(((0x7fff >> 12) + 0x7ff) & 0xff), unsigned(res[0x07ff]));
+
+  ASSERT_EQ(unsigned((0x10000 >> 12) & 0xff), unsigned(res[0x0800]));
+  ASSERT_EQ(unsigned(((0x10801 >> 12) + 1) & 0xff), unsigned(res[0x0801]));
+  ASSERT_EQ(unsigned(((0x109ff >> 12) + 0x01ff) & 0xff), unsigned(res[0x09ff]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x77f8~0x0808, 0x8000~0x0002
+  mgr.read(0x77f8, 0x080a, NULL, &res);
+  ASSERT_EQ(0x080au, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x6000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+
+  ASSERT_EQ(2u, mgr.m_checks.size());
+
+  ASSERT_EQ(unsigned(((0x77f8 >> 12) + 0x07f8) & 0xff), (unsigned char)res[0]);
+  ASSERT_EQ(unsigned(((0x77f9 >> 12) + 0x07f9) & 0xff), (unsigned char)res[1]);
+  ASSERT_EQ(unsigned(((0x7fff >> 12) + 0x0fff) & 0xff), (unsigned char)res[0x0807]);
+
+  ASSERT_EQ(unsigned((0x10000 >> 12) & 0xff), unsigned(res[0x0808]));
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 1) & 0xff), unsigned(res[0x0809]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x108f8~0x1808 (unallocated)
+  mgr.read(0x108f8, 0x1808, NULL, &res);
+  ASSERT_EQ(0x1808u, res.length());
+  ASSERT_EQ(0u, mgr.m_reads.size());
+
+  ASSERT_EQ(0u, unsigned(res[0x0000]));
+  ASSERT_EQ(0u, unsigned(res[0x0001]));
+  ASSERT_EQ(0u, unsigned(res[0x1807]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x15ffe~2, 0x16000~0x3000, 0x19000~0x17610, 0x30610~2
+  mgr.read(0x15ffe, 0x1a614, NULL, &res);
+  ASSERT_EQ(0x1a614u, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x4000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x18000)));
+
+  ASSERT_EQ(2u, mgr.m_checks.size());
+
+  ASSERT_EQ(0u, unsigned(res[0x0000]));
+  ASSERT_EQ(0u, unsigned(res[0x0001]));
+  ASSERT_EQ(unsigned((0x20000 >> 12) & 0xff), unsigned(res[0x0002]));
+  ASSERT_EQ(unsigned(((0x22fff >> 12) + 0x2fff) & 0xff), unsigned(res[0x3001]));
+  ASSERT_EQ(unsigned((0x40000 >> 12) & 0xff), unsigned(res[0x3002]));
+  ASSERT_EQ(unsigned(((0x5760f >> 12) + 0x1760f) & 0xff), unsigned(res[0x1a611]));
+  ASSERT_EQ(0u, unsigned(res[0x1a612]));
+  ASSERT_EQ(0u, unsigned(res[0x1a613]));
+
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x15ffe~2, 0x16000~0x3000, 0x19000~0x17610, 0x30610~29f0, 0x33000~0x1001
+  mgr.read(0x15ffe, 0x1e003, NULL, &res);
+  ASSERT_EQ(0x1e003u, res.length());
+  ASSERT_EQ(3u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x4000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x18000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x80000, 0x2000)));
+
+  ASSERT_EQ(3u, mgr.m_checks.size());
+
+  ASSERT_EQ(0u, unsigned(res[0x0000]));
+  ASSERT_EQ(0u, unsigned(res[0x0001]));
+  ASSERT_EQ(unsigned((0x20000 >> 12) & 0xff), unsigned(res[0x0002]));
+  ASSERT_EQ(unsigned(((0x22fff >> 12) + 0x2fff) & 0xff), unsigned(res[0x3001]));
+  ASSERT_EQ(unsigned((0x40000 >> 12) & 0xff), unsigned(res[0x3002]));
+  ASSERT_EQ(unsigned(((0x5760f >> 12) + 0x1760f) & 0xff), unsigned(res[0x1a611]));
+  ASSERT_EQ(0u, unsigned(res[0x1a612]));
+  ASSERT_EQ(0u, unsigned(res[0x1a613]));
+  ASSERT_EQ(0u, unsigned(res[0x1d001]));
+  ASSERT_EQ(unsigned(((0x80000 >> 12) + 0) & 0xff), (unsigned char)res[0x1d002]);
+  ASSERT_EQ(unsigned(((0x80001 >> 12) + 1) & 0xff), (unsigned char)res[0x1d003]);
+  ASSERT_EQ(unsigned(((0x81000 >> 12) + 0x1000) & 0xff), (unsigned char)res[0x1e002]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x34902~2
+  mgr.read(0x34902u, 0x2, NULL, &res);
+  ASSERT_EQ(0x2u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x2000)));
+  ASSERT_EQ(1u, mgr.m_checks.size());
+
+
+  ASSERT_EQ(unsigned(((0x90402 >> 12) + 2)& 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0x90403 >> 12) + 3)& 0xff), (unsigned char)res[0x1]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x34902~0x1001
+  mgr.read(0x34902u, 0x1001, NULL, &res);
+  ASSERT_EQ(0x1001u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x2000)));
+  ASSERT_EQ(1u, mgr.m_checks.size());
+
+  ASSERT_EQ(unsigned(((0x90402 >> 12) + 2) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0x90402 >> 12) + 3) & 0xff), (unsigned char)res[0x1]);
+  ASSERT_EQ(unsigned(((0x91401 >> 12) + 0x1001) & 0xff), (unsigned char)res[0xfff]);
+  ASSERT_EQ(unsigned(((0x91402 >> 12) + 0x1002) & 0xff), (unsigned char)res[0x1000]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x348fe~2, 0x34900~0x1515, 35e15~0x00ea
+  mgr.read(0x348fe, 0x1601, NULL, &res);
+  ASSERT_EQ(0x1601u, res.length());
+  ASSERT_EQ(3u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x80000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x90000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xc0000, 0x2000)));
+
+  ASSERT_EQ(3u, mgr.m_checks.size());
+
+  ASSERT_EQ(unsigned(((0x818fe >> 12) + 0x18fe) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0x818ff >> 12) + 0x18ff) & 0xff), (unsigned char)res[0x1]);
+  ASSERT_EQ(unsigned(((0x90400 >> 12) + 0x0) & 0xff), (unsigned char)res[0x2]);
+  ASSERT_EQ(unsigned(((0x91914 >> 12) + 0x1514) & 0xff), (unsigned char)res[0x1516]);
+
+  ASSERT_EQ(unsigned(((0xc0000 >> 12) + 0) & 0xff), (unsigned char)res[0x1517]);
+  ASSERT_EQ(unsigned(((0xc0001 >> 12) + 1) & 0xff), (unsigned char)res[0x1518]);
+  ASSERT_EQ(unsigned(((0xc00e9 >> 12) + 0xe9) & 0xff), (unsigned char)res[0x1600]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x3fff0~0x10, 0x40000~0x12000 (unallocated)
+  mgr.read(0x3fff0, 0x12010, NULL, &res);
+  ASSERT_EQ(0x12010u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xca000, 0x2000)));
+
+  ASSERT_EQ(1u, mgr.m_checks.size());
+
+  ASSERT_EQ(unsigned(((0xca000 >> 12) + 0xa1db) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0xca00f >> 12) + 0xa1ea) & 0xff), (unsigned char)res[0xf]);
+  ASSERT_EQ(0u, unsigned(res[0x10]));
+  ASSERT_EQ(0u, unsigned(res[0x11]));
+  ASSERT_EQ(0u, unsigned(res[0x1200f]));
+
+  mgr.reset(false);
+  res.clear();
+
+  //read 0x40700~0x0a02 (unallocated)
+  mgr.read(0x40700, 0xa02, NULL, &res);
+  ASSERT_EQ(0xa02u, res.length());
+  ASSERT_EQ(0u, mgr.m_reads.size());
+
+  ASSERT_EQ(0u, mgr.m_checks.size());
+
+  ASSERT_EQ(0u, unsigned(res[0x0]));
+  ASSERT_EQ(0u, unsigned(res[0x1]));
+  ASSERT_EQ(0u, unsigned(res[0xa01]));
+
+  mgr.reset(false);
+  res.clear();
+}
+
+TEST(bluestore_extent_manager, read_splitted_blob)
+{
+  TestExtentManager mgr;
+  bufferlist res;
+  mgr.reset(true);
+  mgr.prepareTestSet4SplitBlobRead(false);
+
+  //0x50~0xb0 (unalloc), 0x100~0x1200
+  mgr.read(0x50, 0x12b0, NULL, &res);
+  ASSERT_EQ(0x12b0u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x2000)));
+
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(0u, unsigned(res[1]));
+  ASSERT_EQ(0u, unsigned(res[0xaf]));
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0xb0]);
+
+  mgr.reset(false);
+  res.clear();
+
+  // 0x100~0x8000, 0x8100~0x200, 0x8300~0x1100, 0x9400~100 (unalloc), 0x9500~0x100
+  mgr.read(0x100, 0x9500, NULL, &res);
+  ASSERT_EQ(0x9500u, res.length());
+  ASSERT_EQ(4u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa9000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0xa7fff >> 12) + 0x7fff) & 0xff), (unsigned char)res[0x7fff]);
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 0) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x101ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x81ff]);
+  ASSERT_EQ(unsigned(((0x20000 >> 12) + 0) & 0xff), (unsigned char)res[0x8200]);
+  ASSERT_EQ(unsigned(((0x210ff >> 12) + 0x10ff) & 0xff), (unsigned char)res[0x92ff]);
+  ASSERT_EQ(0u, unsigned(res[0x9300]));
+  ASSERT_EQ(0u, unsigned(res[0x9301]));
+  ASSERT_EQ(0u, unsigned(res[0x93ff]));
+  ASSERT_EQ(unsigned(((0xa9000 >> 12) + 0) & 0xff), (unsigned char)res[0x9400]);
+  ASSERT_EQ(unsigned(((0xa90ff >> 12) + 0xff) & 0xff), (unsigned char)res[0x94ff]);
+
+  mgr.reset(false);
+  res.clear();
+
+  // 0xff~1, 0x100~0x8000, 0x8100~0x200, 0x8300~0x1100, 0x9400~100 (unalloc), 0x9500~0x200, 0x9700~1
+  mgr.read(0xff, 0x9602, NULL, &res);
+  ASSERT_EQ(0x9602u, res.length());
+  ASSERT_EQ(4u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa9000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x1]);
+  ASSERT_EQ(unsigned(((0xa7fff >> 12) + 0x7fff) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 0) & 0xff), (unsigned char)res[0x8001]);
+  ASSERT_EQ(unsigned(((0x101ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x8200]);
+  ASSERT_EQ(unsigned(((0x20000 >> 12) + 0) & 0xff), (unsigned char)res[0x8201]);
+  ASSERT_EQ(unsigned(((0x210ff >> 12) + 0x10ff) & 0xff), (unsigned char)res[0x9300]);
+  ASSERT_EQ(0u, unsigned(res[0x9301]));
+  ASSERT_EQ(0u, unsigned(res[0x9302]));
+  ASSERT_EQ(0u, unsigned(res[0x9400]));
+  ASSERT_EQ(unsigned(((0xa9000 >> 12) + 0) & 0xff), (unsigned char)res[0x9401]);
+  ASSERT_EQ(unsigned(((0xa91ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x9600]);
+  ASSERT_EQ(0u, unsigned(res[0x9601]));
+
+  mgr.reset(false);
+  res.clear();
+}
+
+TEST(bluestore_extent_manager, read_splitted_checksum_blob)
+{
+  TestExtentManager mgr;
+  bufferlist res;
+  mgr.reset(true);
+  mgr.prepareTestSet4SplitBlobRead(false, true);
+
+  //0x50~0xb0 (unalloc), 0x100~0x1200
+  mgr.read(0x50, 0x12b0, NULL, &res);
+  ASSERT_EQ(0x12b0u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x2000)));
+
+  ASSERT_EQ(1u, mgr.m_checks.size());
+
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(0u, unsigned(res[1]));
+  ASSERT_EQ(0u, unsigned(res[0xaf]));
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0xb0]);
+
+  mgr.reset(false);
+  res.clear();
+
+  // 0x100~0x8000, 0x8100~0x200, 0x8300~0x1100, 0x9400~100 (unalloc), 0x9500~0x100
+  mgr.read(0x100, 0x9500, NULL, &res);
+  ASSERT_EQ(0x9500u, res.length());
+  ASSERT_EQ(4u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa8000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+
+  ASSERT_EQ(4u, mgr.m_checks.size());
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0xa7fff >> 12) + 0x7fff) & 0xff), (unsigned char)res[0x7fff]);
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 0) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x101ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x81ff]);
+  ASSERT_EQ(unsigned(((0x20000 >> 12) + 0) & 0xff), (unsigned char)res[0x8200]);
+  ASSERT_EQ(unsigned(((0x210ff >> 12) + 0x10ff) & 0xff), (unsigned char)res[0x92ff]);
+  ASSERT_EQ(0u, unsigned(res[0x9300]));
+  ASSERT_EQ(0u, unsigned(res[0x9301]));
+  ASSERT_EQ(0u, unsigned(res[0x93ff]));
+  ASSERT_EQ(unsigned(((0xa9000 >> 12) + 0) & 0xff), (unsigned char)res[0x9400]);
+  ASSERT_EQ(unsigned(((0xa90ff >> 12) + 0xff) & 0xff), (unsigned char)res[0x94ff]);
+
+  mgr.reset(false);
+  res.clear();
+
+  // 0xff~1, 0x100~0x8000, 0x8100~0x200, 0x8300~0x1100, 0x9400~100 (unalloc), 0x9500~0x200, 0x9700~1
+  mgr.read(0xff, 0x9602, NULL, &res);
+  ASSERT_EQ(0x9602u, res.length());
+  ASSERT_EQ(4u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa8000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+
+  ASSERT_EQ(4u, mgr.m_checks.size());
+
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x1]);
+  ASSERT_EQ(unsigned(((0xa7fff >> 12) + 0x7fff) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 0) & 0xff), (unsigned char)res[0x8001]);
+  ASSERT_EQ(unsigned(((0x101ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x8200]);
+  ASSERT_EQ(unsigned(((0x20000 >> 12) + 0) & 0xff), (unsigned char)res[0x8201]);
+  ASSERT_EQ(unsigned(((0x210ff >> 12) + 0x10ff) & 0xff), (unsigned char)res[0x9300]);
+  ASSERT_EQ(0u, unsigned(res[0x9301]));
+  ASSERT_EQ(0u, unsigned(res[0x9302]));
+  ASSERT_EQ(0u, unsigned(res[0x9400]));
+  ASSERT_EQ(unsigned(((0xa9000 >> 12) + 0) & 0xff), (unsigned char)res[0x9401]);
+  ASSERT_EQ(unsigned(((0xa91ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x9600]);
+  ASSERT_EQ(0u, unsigned(res[0x9601]));
+
+  mgr.reset(false);
+  res.clear();
+}
+
+TEST(bluestore_extent_manager, read_splitted_checksum_blob_compressed)
+{
+  TestExtentManager mgr;
+  bufferlist res;
+  mgr.reset(true);
+  mgr.prepareTestSet4SplitBlobRead(true, true);
+
+  //0x50~0xb0 (unalloc), 0x100~0x1200
+  mgr.read(0x50, 0x12b0, NULL, &res);
+  ASSERT_EQ(0x12b0u, res.length());
+  ASSERT_EQ(1u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0xa000)));
+
+  ASSERT_EQ(1u, mgr.m_checks.size());
+
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(0u, unsigned(res[1]));
+  ASSERT_EQ(0u, unsigned(res[0xaf]));
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0xb0]);
+
+  mgr.reset(false);
+  res.clear();
+
+  // 0x100~0x8000, 0x8100~0x200, 0x8300~0x1100, 0x9400~100 (unalloc), 0x9500~0x100
+  mgr.read(0x100, 0x9500, NULL, &res);
+  ASSERT_EQ(0x9500u, res.length());
+  ASSERT_EQ(3u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0xa000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+
+  ASSERT_EQ(3u, mgr.m_checks.size());
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0xa7fff >> 12) + 0x7fff) & 0xff), (unsigned char)res[0x7fff]);
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 0) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x101ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x81ff]);
+  ASSERT_EQ(unsigned(((0x20000 >> 12) + 0) & 0xff), (unsigned char)res[0x8200]);
+  ASSERT_EQ(unsigned(((0x210ff >> 12) + 0x10ff) & 0xff), (unsigned char)res[0x92ff]);
+  ASSERT_EQ(0u, unsigned(res[0x9300]));
+  ASSERT_EQ(0u, unsigned(res[0x9301]));
+  ASSERT_EQ(0u, unsigned(res[0x93ff]));
+  ASSERT_EQ(unsigned(((0xa9000 >> 12) + 0) & 0xff), (unsigned char)res[0x9400]);
+  ASSERT_EQ(unsigned(((0xa90ff >> 12) + 0xff) & 0xff), (unsigned char)res[0x94ff]);
+
+  mgr.reset(false);
+  res.clear();
+
+  // 0xff~1, 0x100~0x8000, 0x8100~0x200, 0x8300~0x1100, 0x9400~100 (unalloc), 0x9500~0x200, 0x9700~1
+  mgr.read(0xff, 0x9602, NULL, &res);
+  ASSERT_EQ(0x9602u, res.length());
+  ASSERT_EQ(3u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0xa000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+
+  ASSERT_EQ(3u, mgr.m_checks.size());
+
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x1]);
+  ASSERT_EQ(unsigned(((0xa7fff >> 12) + 0x7fff) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 0) & 0xff), (unsigned char)res[0x8001]);
+  ASSERT_EQ(unsigned(((0x101ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x8200]);
+  ASSERT_EQ(unsigned(((0x20000 >> 12) + 0) & 0xff), (unsigned char)res[0x8201]);
+  ASSERT_EQ(unsigned(((0x210ff >> 12) + 0x10ff) & 0xff), (unsigned char)res[0x9300]);
+  ASSERT_EQ(0u, unsigned(res[0x9301]));
+  ASSERT_EQ(0u, unsigned(res[0x9302]));
+  ASSERT_EQ(0u, unsigned(res[0x9400]));
+  ASSERT_EQ(unsigned(((0xa9000 >> 12) + 0) & 0xff), (unsigned char)res[0x9401]);
+  ASSERT_EQ(unsigned(((0xa91ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x9600]);
+  ASSERT_EQ(0u, unsigned(res[0x9601]));
+
+  mgr.reset(false);
+  res.clear();
+}
+
+TEST(bluestore_extent_manager, read_splitted_blob_multi_extent)
+{
+  TestExtentManager mgr;
+  bufferlist res;
+  mgr.reset(true);
+  mgr.prepareTestSet4SplitBlobMultiExtentRead(false);
+
+  //0x50~0xb0 (unalloc), 0x100~0x7500
+  mgr.read(0x50, 0x75b0, NULL, &res);
+  ASSERT_EQ(0x75b0u, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x2000)));
+
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(0u, unsigned(res[1]));
+  ASSERT_EQ(0u, unsigned(res[0xaf]));
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0xb0]);
+  ASSERT_EQ(unsigned(((0xa5fff >> 12) + 0x5fff) & 0xff), (unsigned char)res[0x60af]);
+  ASSERT_EQ(unsigned(((0xb0000 >> 12) + 0) & 0xff), (unsigned char)res[0x60b0]);
+  ASSERT_EQ(unsigned(((0xb14ff >> 12) + 0x14ff) & 0xff), (unsigned char)res[0x75af]);
+
+  mgr.reset(false);
+  res.clear();
+
+
+  // 0x100~0x8000, 0x8100~0x200, 0x8300~0x1100, 0x9400~100 (unalloc), 0x9500~0x100
+  mgr.read(0x100, 0x9500, NULL, &res);
+  ASSERT_EQ(0x9500u, res.length());
+  ASSERT_EQ(5u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb3000, 0x1000)));
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0xa5fff >> 12) + 0xa5fff) & 0xff), (unsigned char)res[0x5fff]);
+  ASSERT_EQ(unsigned(((0xb0000 >> 12) + 0) & 0xff), (unsigned char)res[0x6000]);
+  ASSERT_EQ(unsigned(((0xb1fff >> 12) + 0x1fff) & 0xff), (unsigned char)res[0x7fff]);
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 0) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x101ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x81ff]);
+  ASSERT_EQ(unsigned(((0x20000 >> 12) + 0) & 0xff), (unsigned char)res[0x8200]);
+  ASSERT_EQ(unsigned(((0x210ff >> 12) + 0x10ff) & 0xff), (unsigned char)res[0x92ff]);
+  ASSERT_EQ(0u, unsigned(res[0x9300]));
+  ASSERT_EQ(0u, unsigned(res[0x9301]));
+  ASSERT_EQ(0u, unsigned(res[0x93ff]));
+  ASSERT_EQ(unsigned(((0xb3000 >> 12) + 0) & 0xff), (unsigned char)res[0x9400]);
+  ASSERT_EQ(unsigned(((0xb35ff >> 12) + 0x5ff) & 0xff), (unsigned char)res[0x94ff]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //0x10000~0x100 (unalloc),
+  //0x10100~0xcf00
+  //               -> 0x30100~0x7f00 -> 0x30000~0x8000,
+  //               -> 0x40000~0x5000 -> 0x40000~0x5000
+  //0x1d000~0x300 (unalloc)
+  //0x1d300~0x1100
+  //               -> 0x45300~0xd00 -> 0x45000~0x1000
+  //               -> 0x50000~0x400 -> 0x50000~0x1000
+  //0x1e400~0x5700 (unalloc)
+  //0x23b00~0x10000
+  //               -> 0x55b00~0x6500 -> 0x55000~0x7000
+  //               -> 0x60000~0x9b00 -> 0x60000~0xa000
+  //0x33b00~0x3000
+  //               -> 0x69b00~0x3000 -> 0x69000~0x4000
+  //0x36b00~0x5600 (unalloc)
+
+  ASSERT_EQ(0, mgr.read(0x10000, 0x2c100, NULL, &res));
+  ASSERT_EQ(0x2c100u, res.length());
+  ASSERT_EQ(7u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x30000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x5000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x45000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x50000, 0x1000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x55000, 0x7000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x60000, 0xa000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x69000, 0x4000)));
+
+  ASSERT_EQ(0u, unsigned(res[0x0]));
+  ASSERT_EQ(0u, unsigned(res[0x1]));
+  ASSERT_EQ(0u, unsigned(res[0xff]));
+
+  ASSERT_EQ(unsigned(((0x30100 >> 12) + 0x100) & 0xff), (unsigned char)res[0x100]);
+  ASSERT_EQ(unsigned(((0x37fff >> 12) + 0x7fff) & 0xff), (unsigned char)res[0x7fff]);
+  ASSERT_EQ(unsigned(((0x40000 >> 12) + 0) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x44fff >> 12) + 0x4fff) & 0xff), (unsigned char)res[0xcfff]);
+  ASSERT_EQ(0u, unsigned(res[0xd000]));
+  ASSERT_EQ(0u, unsigned(res[0xd001]));
+  ASSERT_EQ(0u, unsigned(res[0xd2ff]));
+
+  ASSERT_EQ(unsigned(((0x45300 >> 12) + 0x300) & 0xff), (unsigned char)res[0xd300]);
+  ASSERT_EQ(unsigned(((0x45fff >> 12) + 0xfff) & 0xff), (unsigned char)res[0xdfff]);
+  ASSERT_EQ(unsigned(((0x50000 >> 12) + 0) & 0xff), (unsigned char)res[0xe000]);
+  ASSERT_EQ(unsigned(((0x503ff >> 12) + 0x3ff) & 0xff), (unsigned char)res[0xe3ff]);
+  ASSERT_EQ(0u, unsigned(res[0xe400]));
+  ASSERT_EQ(0u, unsigned(res[0xe401]));
+  ASSERT_EQ(0u, unsigned(res[0x13aff]));
+  ASSERT_EQ(unsigned(((0x55b00 >> 12) + 0x5b00) & 0xff), (unsigned char)res[0x13b00]);
+  ASSERT_EQ(unsigned(((0x5bfff >> 12) + 0xbfff) & 0xff), (unsigned char)res[0x19fff]);
+  ASSERT_EQ(unsigned(((0x60000 >> 12) + 0x5b00) & 0xff), (unsigned char)res[0x1a000]);
+  ASSERT_EQ(unsigned(((0x69aff >> 12) + 0x9aff) & 0xff), (unsigned char)res[0x23aff]);
+  ASSERT_EQ(unsigned(((0x69b00 >> 12) + 0x9b00) & 0xff), (unsigned char)res[0x23b00]);
+  ASSERT_EQ(unsigned(((0x6caff >> 12) + 0x2fff) & 0xff), (unsigned char)res[0x26aff]);
+  ASSERT_EQ(0u, unsigned(res[0x26b00]));
+  ASSERT_EQ(0u, unsigned(res[0x26b01]));
+  ASSERT_EQ(0u, unsigned(res[0x2c0ff]));
+
+  mgr.reset(false);
+  res.clear();
+
+}
+
+TEST(bluestore_extent_manager, read_splitted_blob_multi_extent_checksum)
+{
+  TestExtentManager mgr;
+  bufferlist res;
+  mgr.reset(true);
+  mgr.prepareTestSet4SplitBlobMultiExtentRead(false, true);
+
+  //0x50~0xb0 (unalloc),
+  //0x100~0x7500
+  //               -> 0xa0000~0x6000,
+  //               -> 0xb0000~0x2000,
+  mgr.read(0x50, 0x75b0, NULL, &res);
+  ASSERT_EQ(0x75b0u, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x2000)));
+
+  ASSERT_EQ(2u, mgr.m_checks.size());
+
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(0u, unsigned(res[1]));
+  ASSERT_EQ(0u, unsigned(res[0xaf]));
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0xb0]);
+  ASSERT_EQ(unsigned(((0xa5fff >> 12) + 0x5fff) & 0xff), (unsigned char)res[0x60af]);
+  ASSERT_EQ(unsigned(((0xb0000 >> 12) + 0) & 0xff), (unsigned char)res[0x60b0]);
+  ASSERT_EQ(unsigned(((0xb14ff >> 12) + 0x14ff) & 0xff), (unsigned char)res[0x75af]);
+
+  mgr.reset(false);
+  res.clear();
+
+
+  //0x100~0x8100
+  //               -> 0xa0000~0x6000,
+  //               -> 0xb0000~0x2000,
+  //0x8100~0x200
+  //               -> 0x10000~0x8000,
+  //0x8300~0x1100
+  //               -> 0x20000~0x10000,
+  //0x9400~0x100   unalloc
+  //0x9500~0x100
+  //              -> 0xb0000~0x6000 (bypassed as read before)
+  mgr.read(0x100, 0x9500, NULL, &res);
+  ASSERT_EQ(0x9500u, res.length());
+  ASSERT_EQ(5u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb2000, 0x2000)));
+
+  ASSERT_EQ(5u, mgr.m_checks.size());
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0xa5fff >> 12) + 0xa5fff) & 0xff), (unsigned char)res[0x5fff]);
+  ASSERT_EQ(unsigned(((0xb0000 >> 12) + 0) & 0xff), (unsigned char)res[0x6000]);
+  ASSERT_EQ(unsigned(((0xb1fff >> 12) + 0x1fff) & 0xff), (unsigned char)res[0x7fff]);
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 0) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x101ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x81ff]);
+  ASSERT_EQ(unsigned(((0x20000 >> 12) + 0) & 0xff), (unsigned char)res[0x8200]);
+  ASSERT_EQ(unsigned(((0x210ff >> 12) + 0x10ff) & 0xff), (unsigned char)res[0x92ff]);
+  ASSERT_EQ(0u, unsigned(res[0x9300]));
+  ASSERT_EQ(0u, unsigned(res[0x9301]));
+  ASSERT_EQ(0u, unsigned(res[0x93ff]));
+  ASSERT_EQ(unsigned(((0xb3000 >> 12) + 0) & 0xff), (unsigned char)res[0x9400]);
+  ASSERT_EQ(unsigned(((0xb35ff >> 12) + 0x5ff) & 0xff), (unsigned char)res[0x94ff]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //0x10000~0x100 (unalloc),
+  //0x10100~0xcf00
+  //               -> 0x30100~0x7f00 -> 0x30000~0x8000,
+  //               -> 0x40000~0x5000 -> 0x40000~0x6000
+  //0x1d000~0x300 (unalloc)
+  //0x1d300~0x1100
+  //               -> 0x45300~0xd00 -> 0x44000~0x2000
+  //               -> 0x50000~0x400 -> 0x50000~0x2000
+  //0x1e400~0x5700 (unalloc)
+  //0x23b00~0x10000
+  //               -> 0x55b00~0x6500 -> 0x54000~0x8000
+  //               -> 0x60000~0x9b00 -> 0x60000~0xa000
+  //0x33b00~0x3000
+  //               -> 0x69b00~0x3000 -> 0x68000~0x6000
+  //0x36b00~0x5600 (unalloc)
+
+  ASSERT_EQ(0, mgr.read(0x10000, 0x2c100, NULL, &res));
+  ASSERT_EQ(0x2c100u, res.length());
+  ASSERT_EQ(7u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x30000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x44000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x50000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x54000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x60000, 0xa000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x68000, 0x6000)));
+
+  ASSERT_EQ(7u, mgr.m_checks.size());
+
+  ASSERT_EQ(0u, unsigned(res[0x0]));
+  ASSERT_EQ(0u, unsigned(res[0x1]));
+  ASSERT_EQ(0u, unsigned(res[0xff]));
+
+  ASSERT_EQ(unsigned(((0x30100 >> 12) + 0x100) & 0xff), (unsigned char)res[0x100]);
+  ASSERT_EQ(unsigned(((0x37fff >> 12) + 0x7fff) & 0xff), (unsigned char)res[0x7fff]);
+  ASSERT_EQ(unsigned(((0x40000 >> 12) + 0) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x44fff >> 12) + 0x4fff) & 0xff), (unsigned char)res[0xcfff]);
+  ASSERT_EQ(0u, unsigned(res[0xd000]));
+  ASSERT_EQ(0u, unsigned(res[0xd001]));
+  ASSERT_EQ(0u, unsigned(res[0xd2ff]));
+
+  ASSERT_EQ(unsigned(((0x45300 >> 12) + 0x300) & 0xff), (unsigned char)res[0xd300]);
+  ASSERT_EQ(unsigned(((0x45fff >> 12) + 0xfff) & 0xff), (unsigned char)res[0xdfff]);
+  ASSERT_EQ(unsigned(((0x50000 >> 12) + 0) & 0xff), (unsigned char)res[0xe000]);
+  ASSERT_EQ(unsigned(((0x503ff >> 12) + 0x3ff) & 0xff), (unsigned char)res[0xe3ff]);
+  ASSERT_EQ(0u, unsigned(res[0xe400]));
+  ASSERT_EQ(0u, unsigned(res[0xe401]));
+  ASSERT_EQ(0u, unsigned(res[0x13aff]));
+  ASSERT_EQ(unsigned(((0x55b00 >> 12) + 0x5b00) & 0xff), (unsigned char)res[0x13b00]);
+  ASSERT_EQ(unsigned(((0x5bfff >> 12) + 0xbfff) & 0xff), (unsigned char)res[0x19fff]);
+  ASSERT_EQ(unsigned(((0x60000 >> 12) + 0x5b00) & 0xff), (unsigned char)res[0x1a000]);
+  ASSERT_EQ(unsigned(((0x69aff >> 12) + 0x9aff) & 0xff), (unsigned char)res[0x23aff]);
+  ASSERT_EQ(unsigned(((0x69b00 >> 12) + 0x9b00) & 0xff), (unsigned char)res[0x23b00]);
+  ASSERT_EQ(unsigned(((0x6caff >> 12) + 0x2fff) & 0xff), (unsigned char)res[0x26aff]);
+  ASSERT_EQ(0u, unsigned(res[0x26b00]));
+  ASSERT_EQ(0u, unsigned(res[0x26b01]));
+  ASSERT_EQ(0u, unsigned(res[0x2c0ff]));
+
+  mgr.reset(false);
+  res.clear();
+
+}
+
+TEST(bluestore_extent_manager, read_splitted_blob_multi_extent_compressed)
+{
+  TestExtentManager mgr;
+  bufferlist res;
+  mgr.reset(true);
+  mgr.prepareTestSet4SplitBlobMultiExtentRead(true);
+
+  //0x50~0xb0 (unalloc),
+  //0x100~0x7500
+  //               -> 0xa0000~0x6000,
+  //               -> 0xb0000~0x4000,
+  mgr.read(0x50, 0x75b0, NULL, &res);
+  ASSERT_EQ(0x75b0u, res.length());
+  ASSERT_EQ(2u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x4000)));
+
+  ASSERT_EQ(0u, unsigned(res[0]));
+  ASSERT_EQ(0u, unsigned(res[1]));
+  ASSERT_EQ(0u, unsigned(res[0xaf]));
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0xb0]);
+  ASSERT_EQ(unsigned(((0xa5fff >> 12) + 0x5fff) & 0xff), (unsigned char)res[0x60af]);
+  ASSERT_EQ(unsigned(((0xb0000 >> 12) + 0) & 0xff), (unsigned char)res[0x60b0]);
+  ASSERT_EQ(unsigned(((0xb14ff >> 12) + 0x14ff) & 0xff), (unsigned char)res[0x75af]);
+
+  mgr.reset(false);
+  res.clear();
+
+
+  //0x100~0x8100
+  //               -> 0xa0000~0x6000,
+  //               -> 0xb0000~0x4000,
+  //0x8100~0x200
+  //               -> 0x10000~0x8000,
+  //0x8300~0x1100
+  //               -> 0x20000~0x10000,
+  //0x9400~0x100   unalloc
+  //0x9500~0x100
+  //              -> 0xb0000~0x6000 (bypassed as read before)
+
+  // 0x100~0x8000, 0x8100~0x200, 0x8300~0x1100, 0x9400~100 (unalloc), 0x9500~0x100
+  mgr.read(0x100, 0x9500, NULL, &res);
+  ASSERT_EQ(0x9500u, res.length());
+  ASSERT_EQ(4u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xa0000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0xb0000, 0x4000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x10000, 0x2000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x20000, 0x2000)));
+
+  ASSERT_EQ(unsigned(((0xa0000 >> 12) + 0) & 0xff), (unsigned char)res[0x0]);
+  ASSERT_EQ(unsigned(((0xa5fff >> 12) + 0xa5fff) & 0xff), (unsigned char)res[0x5fff]);
+  ASSERT_EQ(unsigned(((0xb0000 >> 12) + 0) & 0xff), (unsigned char)res[0x6000]);
+  ASSERT_EQ(unsigned(((0xb1fff >> 12) + 0x1fff) & 0xff), (unsigned char)res[0x7fff]);
+  ASSERT_EQ(unsigned(((0x10000 >> 12) + 0) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x101ff >> 12) + 0x1ff) & 0xff), (unsigned char)res[0x81ff]);
+  ASSERT_EQ(unsigned(((0x20000 >> 12) + 0) & 0xff), (unsigned char)res[0x8200]);
+  ASSERT_EQ(unsigned(((0x210ff >> 12) + 0x10ff) & 0xff), (unsigned char)res[0x92ff]);
+  ASSERT_EQ(0u, unsigned(res[0x9300]));
+  ASSERT_EQ(0u, unsigned(res[0x9301]));
+  ASSERT_EQ(0u, unsigned(res[0x93ff]));
+  ASSERT_EQ(unsigned(((0xb3400 >> 12) + 0x3400) & 0xff), (unsigned char)res[0x9400]);
+  ASSERT_EQ(unsigned(((0xb34ff >> 12) + 0x34ff) & 0xff), (unsigned char)res[0x94ff]);
+
+  mgr.reset(false);
+  res.clear();
+
+  //0x10000~0x100 (unalloc),
+  //0x10100~0xcf00
+  //               -> 0x30100~0x7f00 -> 0x30000~0x8000,
+  //               -> 0x40000~0x5000 -> 0x40000~0x6000
+  //0x1d000~0x300 (unalloc)
+  //0x1d300~0x1100
+  //               -> 0x45300~0xd00 -> 0x40000~0x6000 (duplicate)
+  //               -> 0x50000~0x400 -> 0x50000~0xc000
+  //0x1e400~0x5700 (unalloc)
+  //0x23b00~0x10000
+  //               -> 0x55b00~0x6500 -> 0x50000~0xc000 (duplicate)
+  //               -> 0x60000~0x9b00 -> 0x60000~0xd000
+  //0x33b00~0x3000
+  //               -> 0x69b00~0x3000 -> 0x60000~0xd000 (duplicate)
+  //0x36b00~0x5600 (unalloc)
+
+  ASSERT_EQ(0, mgr.read(0x10000, 0x2c100, NULL, &res));
+  ASSERT_EQ(0x2c100u, res.length());
+  ASSERT_EQ(4u, mgr.m_reads.size());
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x30000, 0x8000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x40000, 0x6000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x50000, 0xc000)));
+  ASSERT_TRUE(mgr.checkRead(ReadTuple(0x60000, 0xd000)));
+
+  ASSERT_EQ(0u, unsigned(res[0x0]));
+  ASSERT_EQ(0u, unsigned(res[0x1]));
+  ASSERT_EQ(0u, unsigned(res[0xff]));
+
+  ASSERT_EQ(unsigned(((0x30100 >> 12) + 0x100) & 0xff), (unsigned char)res[0x100]);
+  ASSERT_EQ(unsigned(((0x37fff >> 12) + 0x7fff) & 0xff), (unsigned char)res[0x7fff]);
+  ASSERT_EQ(unsigned(((0x40000 >> 12) + 0) & 0xff), (unsigned char)res[0x8000]);
+  ASSERT_EQ(unsigned(((0x44fff >> 12) + 0x4fff) & 0xff), (unsigned char)res[0xcfff]);
+  ASSERT_EQ(0u, unsigned(res[0xd000]));
+  ASSERT_EQ(0u, unsigned(res[0xd001]));
+  ASSERT_EQ(0u, unsigned(res[0xd2ff]));
+
+  ASSERT_EQ(unsigned(((0x45300 >> 12) + 0x300) & 0xff), (unsigned char)res[0xd300]);
+  ASSERT_EQ(unsigned(((0x45fff >> 12) + 0xfff) & 0xff), (unsigned char)res[0xdfff]);
+  ASSERT_EQ(unsigned(((0x50000 >> 12) + 0) & 0xff), (unsigned char)res[0xe000]);
+  ASSERT_EQ(unsigned(((0x503ff >> 12) + 0x3ff) & 0xff), (unsigned char)res[0xe3ff]);
+  ASSERT_EQ(0u, unsigned(res[0xe400]));
+  ASSERT_EQ(0u, unsigned(res[0xe401]));
+  ASSERT_EQ(0u, unsigned(res[0x13aff]));
+  ASSERT_EQ(unsigned(((0x55b00 >> 12) + 0x5b00) & 0xff), (unsigned char)res[0x13b00]);
+  ASSERT_EQ(unsigned(((0x5bfff >> 12) + 0xbfff) & 0xff), (unsigned char)res[0x19fff]);
+  ASSERT_EQ(unsigned(((0x60000 >> 12) + 0x5b00) & 0xff), (unsigned char)res[0x1a000]);
+  ASSERT_EQ(unsigned(((0x69aff >> 12) + 0x9aff) & 0xff), (unsigned char)res[0x23aff]);
+  ASSERT_EQ(unsigned(((0x69b00 >> 12) + 0x9b00) & 0xff), (unsigned char)res[0x23b00]);
+  ASSERT_EQ(unsigned(((0x6caff >> 12) + 0x2fff) & 0xff), (unsigned char)res[0x26aff]);
+  ASSERT_EQ(0u, unsigned(res[0x26b00]));
+  ASSERT_EQ(0u, unsigned(res[0x26b01]));
+  ASSERT_EQ(0u, unsigned(res[0x2c0ff]));
+
+  mgr.reset(false);
+  res.clear();
+
+}
+
+int main(int argc, char **argv) {
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+  env_to_vec(args);
+
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+  g_ceph_context->_conf->set_val(
+    "enable_experimental_unrecoverable_data_corrupting_features",
+    "*");
+  g_ceph_context->_conf->apply_changes(NULL);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is a prototype code implementing lextent/blob/pextent structure triple at bluestore to support compression/checksum verification. This patch introduces data structure modifications and read/write/zero/fiemap/clone op implementations along with corresponding UT coverage.
Code integrates into Bluestore and replaces old data structures for all object operations.
ceph_test_objectstore test case PASSED.

Open tasks:
- Remove legacy WAL structures and related code, most of other legacy stuff has been already removed.
- Add deferred processing to implement merge procedures that require R/M/W sequence
- Add calls and settings for compressor/checksum verification

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>
