### PR TITLE
ceph-disk: remove the useless function

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -4593,9 +4593,6 @@ def main_catch(func, args):
         )
 
 
-def run():
-    main(sys.argv[1:])
-
 if __name__ == '__main__':
     main(sys.argv[1:])
     warned_about = {}


### PR DESCRIPTION
The function 'run' in ceph-disk/main.py is no use.
The function 'main' would handle the process.

Signed-off-by: DesmondS <desmond.s@inwinstack.com>