### PR TITLE
install-deps.sh: use 'pip install --upgrade' to prepare virtualenv

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -110,7 +110,7 @@ function activate_virtualenv() {
     if ! test -d $env_dir ; then
         virtualenv --python $interpreter $env_dir
         . $env_dir/bin/activate
-        if ! populate_wheelhouse install ; then
+        if ! populate_wheelhouse "install --upgrade" ; then
             rm -rf $env_dir
             return 1
         fi


### PR DESCRIPTION
or the command ```pip install  'setuptools >= 0.8' 'pip >= 7.0' 'wheel >= 0.24'```
will always ignore the local configured pypi mirror and try to get updated pip
from https://bitbucket.org/ which results:

Downloading/unpacking pip>=7.0
  Could not fetch URL https://bitbucket.org/pypa/setuptools/downloads/ctypes-1.0.2.win32-py2.4.exe#md5=9092a0ad5a3d79fa2d980f1ddc5e9dbc: There was a problem confirming the ssl certificate: <urlopen error EOF occurred in violation of protocol (_ssl.c:765)>
  Will skip URL https://bitbucket.org/pypa/setuptools/downloads/ctypes-1.0.2.win32-py2.4.exe#md5=9092a0ad5a3d79fa2d980f1ddc5e9dbc when looking for download links for pip>=7.0

Signed-off-by: runsisi <runsisi@zte.com.cn>