### PR TITLE
check-generated.sh: can't source bash from sh

### DIFF
--- a/src/test/encoding/check-generated.sh
+++ b/src/test/encoding/check-generated.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 source ../qa/workunits/ceph-helpers.sh
 


### PR DESCRIPTION
'source' is not sh command and executing bash commands in sh won't
work. We could try to replace it with:
'. ../qa/workunits/ceph-helpers.sh'
but the above file uses bash.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>