### PR TITLE
cmake: pass RULE_LAUNCHER_* to cython

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ if(WITH_CCACHE)
   if(CCACHE_FOUND)
     message(STATUS "Building with ccache: ${CCACHE_FOUND}, CCACHE_DIR=$ENV{CCACHE_DIR}")
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    # ccache does not accelerate link (ld), but let it handle it. by passing it
+    # along with cc to python's distutils, we are able to workaround
+    # https://bugs.python.org/issue8027.
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
   else(CCACHE_FOUND)
     message(FATAL_ERROR "Can't find ccache. Is it installed?")

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -1,4 +1,9 @@
 set(CYTHON_MODULE_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules)
+get_property(compiler_launcher GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
+get_property(link_launcher GLOBAL PROPERTY RULE_LAUNCH_LINK)
+set(PY_CC \"${compiler_launcher} ${CMAKE_C_COMPILER}\")
+set(PY_CXX \"${compiler_launcher} ${CMAKE_CXX_COMPILER}\")
+set(PY_LDSHARED \"${link_launcher} ${CMAKE_C_COMPILER} -shared\")
 
 add_subdirectory(rados)
 add_subdirectory(rbd)

--- a/src/pybind/Makefile.am
+++ b/src/pybind/Makefile.am
@@ -6,6 +6,9 @@ CYTHON_BUILD_DIR="$(shell readlink -f $(builddir))/build"
 
 PY_DISTUTILS = \
 	mkdir -p $(CYTHON_BUILD_DIR); \
+	CC="${CC}" \
+	CXX="${CXX}" \
+	LDSHARED="${CC} -shared" \
 	CPPFLAGS="-iquote \${abs_srcdir}/include ${AM_CPPFLAGS} ${CPPFLAGS}" \
 	CFLAGS="-iquote \${abs_srcdir}/include ${AM_CFLAGS} ${PYTHON_CFLAGS}" \
 	LDFLAGS="-L\${abs_builddir}/.libs $(subst -pie,,${AM_LDFLAGS}) ${PYTHON_LDFLAGS}" \

--- a/src/pybind/cephfs/CMakeLists.txt
+++ b/src/pybind/cephfs/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_custom_target(cython_cephfs
   COMMAND
+  env
+  CC=${PY_CC}
+  CXX=${PY_CXX}
+  LDSHARED=${PY_LDSHARED}
   LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
   CYTHON_BUILD_DIR=${CMAKE_BINARY_DIR}/src/pybind/cephfs
   CFLAGS=\"-I${CMAKE_SOURCE_DIR}/src -I${CMAKE_BINARY_DIR}/include -I${CMAKE_SOURCE_DIR}/src/include -std=c++11\"

--- a/src/pybind/rados/CMakeLists.txt
+++ b/src/pybind/rados/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_custom_target(cython_rados
   COMMAND
+  env
+  CC=${PY_CC}
+  CXX=${PY_CXX}
+  LDSHARED=${PY_LDSHARED}
   LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
   CYTHON_BUILD_DIR=${CMAKE_BINARY_DIR}/src/pybind/rados
   CFLAGS=\"-I${CMAKE_SOURCE_DIR}/src/include -std=c++11\"

--- a/src/pybind/rbd/CMakeLists.txt
+++ b/src/pybind/rbd/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_custom_target(cython_rbd
   COMMAND
+  env
+  CC=${PY_CC}
+  CXX=${PY_CXX}
+  LDSHARED=${PY_LDSHARED}
   LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
   CYTHON_BUILD_DIR=${CMAKE_BINARY_DIR}/src/pybind/rbd
   CFLAGS=\"-I${CMAKE_SOURCE_DIR}/src/include -std=c++11\"


### PR DESCRIPTION
* pass the environment variables using `env` to pass environment
  varibles with space(s) in them to the COMMAND in add_custom_target.
  otherwise, cmake will try to quote the space with "\". this breaks the
  generated command line.
* add a comment for ccache to note that we do not expect ccache to speed
  up linking. we use it as the linker's launcher to workaround
  https://bugs.python.org/issue8027. to be specific,
  distutils.UnixCCompiler.link overwrites the first linker CLI's arg
  using the the first C++ compiler's CLI arg, if "env" is not used to
  launch the linker. this breaks the cythonization of our pybind APIs.

Signed-off-by: Kefu Chai <kchai@redhat.com>