### PR TITLE
test/encoding/check-generated.sh: remove bashism

### DIFF
--- a/src/test/encoding/check-generated.sh
+++ b/src/test/encoding/check-generated.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-source ../qa/workunits/ceph-helpers.sh
+. ../qa/workunits/ceph-helpers.sh
 
 dir=$1
 


### PR DESCRIPTION
the `source` builtin is a bashism. just use `.` instead. was introduced
in d5ec33f.

this fixes the broken test in http://gitbuilder.sepia.ceph.com/gitbuilder-ceph-tarball-trusty-amd64-basic/log.cgi?log=b4746520706495314c24992b663ea4955607fdbe

```
FAIL: test/encoding/check-generated.sh
======================================
./test/encoding/check-generated.sh: 3: ./test/encoding/check-generated.sh: source: not found
```