### PR TITLE
ceph-helpers.sh: only use mon*pid files when killing MONs

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -293,7 +293,7 @@ function test_kill_daemons() {
     #
     # kill the mon and verify it cannot be reached
     #
-    kill_daemons $dir TERM || return 1
+    kill_daemons $dir TERM mon || return 1
     ! ceph --connect-timeout 60 status || return 1
     teardown $dir || return 1
 }


### PR DESCRIPTION
FreeBSD once in a while forgets to remove *pid files (this is probably a bug).
But taking care of it this way is probably much in line of what is actually needs to be done

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>