### PR TITLE
rgw: Set Access-Control-Allow-Origin to a Asterisk if allowed in a rule

### DIFF
--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -116,6 +116,13 @@ static bool is_string_in_set(set<string>& s, string h) {
   return false;
 }
 
+bool RGWCORSRule::has_wildcard_origin() {
+  if (allowed_origins.find("*") != allowed_origins.end())
+    return true;
+
+  return false;
+}
+
 bool RGWCORSRule::is_origin_present(const char *o) {
   string origin = o;
   return is_string_in_set(allowed_origins, origin);

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -81,6 +81,7 @@ public:
     ::decode(exposable_hdrs, bl);
     DECODE_FINISH(bl);
   }
+  bool has_wildcard_origin();
   bool is_origin_present(const char *o);
   void format_exp_headers(std::string& s);
   void erase_origin_if_present(std::string& origin, bool *rule_empty);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -634,6 +634,18 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
   if (!rule)
     return false;
 
+  /*
+   * Set the Allowed-Origin header to a asterisk if this is allowed in the rule
+   * and no Authorization was send by the client
+   *
+   * The origin parameter specifies a URI that may access the resource.  The browser must enforce this.
+   * For requests without credentials, the server may specify "*" as a wildcard,
+   * thereby allowing any origin to access the resource.
+   */
+  const char *authorization = s->info.env->get("HTTP_AUTHORIZATION");
+  if (!authorization && rule->has_wildcard_origin())
+    origin = "*";
+
   /* CORS 6.2.3. */
   const char *req_meth = s->info.env->get("HTTP_ACCESS_CONTROL_REQUEST_METHOD");
   if (!req_meth) {

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -459,6 +459,15 @@ void dump_access_control(struct req_state *s, const char *origin, const char *me
                          const char *hdr, const char *exp_hdr, uint32_t max_age) {
   if (origin && (origin[0] != '\0')) {
     s->cio->print("Access-Control-Allow-Origin: %s\r\n", origin);
+
+    /* If the server specifies an origin host rather than "*",
+     * then it must also include Origin in the Vary response header
+     * to indicate to clients that server responses will differ
+     * based on the value of the Origin request header.
+     */
+    if (strcmp(origin, "*") != 0)
+      s->cio->print("Vary: Origin\r\n");
+
     if (meth && (meth[0] != '\0'))
       s->cio->print("Access-Control-Allow-Methods: %s\r\n", meth);
     if (hdr && (hdr[0] != '\0'))


### PR DESCRIPTION
http://tracker.ceph.com/issues/15839

Before this patch the RGW would respond with the Origin send by the client in the request
if a wildcard/asterisk was specified as a valid Origin.

This patch makes sure we respond with a header like this:

  Access-Control-Allow-Origin: *

This way a resource can be used on different Origins by the same browser and that browser
will use the content as the asterisk.

We also keep in mind that when Authorization is send by the client different rules apply.
In the case of Authorization we may not respond with an Asterisk, but we do have to
add the Vary header with 'Origin' as a value to let the browser know that for different
Origins it has to perform a new request.

More information: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS

Fixes: #15348

Signed-off-by: Wido den Hollander <wido@42on.com>

Conflicts:
	src/rgw/rgw_rest.cc

This is the backport fix for #8441