### PR TITLE
ceph-helpers.sh: only use mon*pid files when killing MONs

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -213,7 +213,8 @@ function test_kill_daemon() {
 
     ceph osd dump | grep "osd.0 down" || return 1
 
-    for pidfile in $(find $dir -name "*.pid" 2>/dev/null) ; do
+    name_prefix=mon
+    for pidfile in $(find $dir 2>/dev/null | grep $name_prefix'[^/]*\.pid') ; do
         #
         # kill the mon and verify it cannot be reached
         #


### PR DESCRIPTION

FreeBSD once in a while forgets to remove *pid files (this is probably a bug).
But taking care of it this way is probably much in line of what is actually needs to be done

Signed-off-by: Willem Jan Withagen wjw@digiware.nl