### PR TITLE
librados/TestCase: skip tests if SetUpTestCase() fails

### DIFF
--- a/src/test/librados/TestCase.h
+++ b/src/test/librados/TestCase.h
@@ -45,6 +45,7 @@ protected:
   static void TearDownTestCase();
   static void cleanup_all_objects(librados::IoCtx ioctx);
   static librados::Rados s_cluster;
+  static bool is_connected;
   static std::string pool_name;
 
   virtual void SetUp();
@@ -62,6 +63,7 @@ public:
 protected:
   static void cleanup_all_objects(librados::IoCtx ioctx);
   static librados::Rados s_cluster;
+  static bool is_connected;
   static std::string pool_name;
   static std::string cache_pool_name;
 
@@ -96,6 +98,7 @@ protected:
   static void SetUpTestCase();
   static void TearDownTestCase();
   static librados::Rados s_cluster;
+  static bool is_connected;
   static std::string pool_name;
 
   virtual void SetUp();
@@ -142,6 +145,7 @@ protected:
   static void cleanup_default_namespace(librados::IoCtx ioctx);
   static void cleanup_namespace(librados::IoCtx ioctx, std::string ns);
   static librados::Rados s_cluster;
+  static bool is_connected;
   static std::string pool_name;
 
   virtual void SetUp();
@@ -161,6 +165,7 @@ protected:
   static void cleanup_default_namespace(librados::IoCtx ioctx);
   static void cleanup_namespace(librados::IoCtx ioctx, std::string ns);
   static librados::Rados s_cluster;
+  static bool is_connected;
   static std::string pool_name;
   static std::string cache_pool_name;
 
@@ -197,6 +202,7 @@ protected:
   static void SetUpTestCase();
   static void TearDownTestCase();
   static librados::Rados s_cluster;
+  static bool is_connected;
   static std::string pool_name;
 
   virtual void SetUp();


### PR DESCRIPTION
see https://github.com/google/googletest/issues/247, gtest does not fail
its tests even if SetUpTestCase() fails. after shutdown(), the behaviour
of RadosClient is undefined. so we'd better avoid using it anymore in
that case.

Signed-off-by: Kefu Chai <kchai@redhat.com>