### PR TITLE
rgw_rest_admin: return -EINVAL for improper user info requests

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -238,7 +238,7 @@ Request Parameters
 :Description: The user for which the information is requested.
 :Type: String
 :Example: ``foo_user``
-:Required: No
+:Required: Yes
 
 
 Response Entities

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -34,6 +34,15 @@ void RGWOp_User_Info::execute()
   bool fetch_stats;
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+
+  // if uid was not supplied in rest argument, error out now, otherwise we'll
+  // end up initializing anonymous user, for which keys.init will eventually
+  // return -EACESS
+  if (uid_str.empty()){
+    http_ret=-EINVAL;
+    return;
+  }
+
   rgw_user uid(uid_str);
 
   RESTArgs::get_bool(s, "stats", false, &fetch_stats);


### PR DESCRIPTION
for /admin/user GET requests, if a uid is not given, we ultimately
return an AccessDenied error, as we initialize an anon user by default
where operations like key initialization will throw an -EACCESS. Since
the actual failure here is that uid was not specified, return an
-EINVAL, HTTP 400 error instead which is more clearer.

Fixes: http://tracker.ceph.com/issues/15455
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>