### PR TITLE
hammer: rbd snap rollback: restore the link to parent

### DIFF
--- a/src/librbd/parent_types.h
+++ b/src/librbd/parent_types.h
@@ -14,12 +14,12 @@ namespace librbd {
     parent_spec() : pool_id(-1), snap_id(CEPH_NOSNAP) {}
     parent_spec(uint64_t pool_id, string image_id, snapid_t snap_id) :
       pool_id(pool_id), image_id(image_id), snap_id(snap_id) {}
-    bool operator==(const parent_spec &other) {
+    bool operator==(const parent_spec &other) const {
       return ((this->pool_id == other.pool_id) &&
 	      (this->image_id == other.image_id) &&
 	      (this->snap_id == other.snap_id));
     }
-    bool operator!=(const parent_spec &other) {
+    bool operator!=(const parent_spec &other) const {
       return !(*this == other);
     }
   };
@@ -28,6 +28,12 @@ namespace librbd {
     parent_spec spec;
     uint64_t overlap;
     parent_info() : overlap(0) {}
+    bool operator==(const parent_info &other) const {
+        return (spec == other.spec) && (overlap == other.overlap);
+    }
+    bool operator!=(const parent_info &other) const {
+      return (spec != other.spec) || (overlap != other.overlap);
+    }
   };
 }
 

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -1048,3 +1048,96 @@ class TestExclusiveLock(object):
             for offset in [0, IMG_SIZE / 2]:
                 read = image2.read(offset, 256)
                 eq(data, read)
+
+
+class TestCloneRollback(object):
+
+    @require_features([RBD_FEATURE_LAYERING])
+    def setUp(self):
+        self.rbd = RBD()
+        create_image()
+        self.clone_name = image_name + '_cloned'
+        with Image(ioctx, image_name) as image1:
+            image1.write('FOOBAR', 0)
+            image1.create_snap('FOOBAR')
+            image1.protect_snap('FOOBAR')
+        RBD().clone(ioctx, image_name, 'FOOBAR',
+                    ioctx, self.clone_name,
+                    features=RBD_FEATURE_LAYERING)
+        with Image(ioctx, self.clone_name) as clone:
+            clone.write('OOPS', IMG_SIZE / 2)
+            clone.create_snap('OOPS')
+
+    def tearDown(self):
+        global ioctx
+        with Image(ioctx, self.clone_name) as clone:
+            clone.remove_snap('OOPS')
+            try:
+                clone.remove_snap('FLATTENED')
+            except:
+                pass
+        RBD().remove(ioctx, self.clone_name)
+        with Image(ioctx, image_name) as image1:
+            image1.unprotect_snap('FOOBAR')
+            image1.remove_snap('FOOBAR')
+        remove_image()
+
+    def test_rollback_flattened_to_parented(self):
+        # target snapshot has a parent, and head does not
+        expected_head, expected_tail = 'FOOBAR', 'OOPS'
+        with Image(ioctx, self.clone_name) as clone:
+            clone.write('HEHE', IMG_SIZE / 2)
+            clone.flatten()
+            clone.rollback_to_snap('OOPS')
+            head = clone.read(0, len(expected_head))
+            tail = clone.read(IMG_SIZE / 2, len(expected_tail))
+            eq(head, expected_head)
+            eq(tail, expected_tail)
+            _, image, snap = clone.parent_info()
+            eq(image, image_name)
+            eq(snap, 'FOOBAR')
+
+    def test_rollback_parented_to_flattened(self):
+        expected_head, expected_tail = 'FOOBAR', 'HEHE'
+        with Image(ioctx, self.clone_name) as clone:
+            clone.write(expected_tail, IMG_SIZE / 2)
+            clone.flatten()
+            clone.create_snap('FLATTENED')
+            clone.rollback_to_snap('OOPS')
+            # head has a parent, and the target snapshot does not
+            _, image, snap = clone.parent_info()
+            eq(image, image_name)
+            eq(snap, 'FOOBAR')
+            clone.rollback_to_snap('FLATTENED')
+            head = clone.read(0, len(expected_head))
+            tail = clone.read(IMG_SIZE / 2, len(expected_tail))
+            assert_raises(ImageNotFound, clone.parent_info)
+            eq(head, expected_head)
+            eq(tail, expected_tail)
+
+    def test_rollback_same_parent(self):
+        expected_head, expected_tail = 'FOOBAR', 'OOPS'
+        with Image(ioctx, self.clone_name) as clone:
+            clone.write('HEHE', IMG_SIZE / 2)
+            clone.rollback_to_snap('OOPS')
+            head = clone.read(0, len(expected_head))
+            tail = clone.read(IMG_SIZE / 2, len(expected_tail))
+            _, image, snap = clone.parent_info()
+            eq(head, expected_head)
+            eq(tail, expected_tail)
+            eq(image, image_name)
+            eq(snap, 'FOOBAR')
+
+    def test_rollback_same_parent_shrinked(self):
+        expected_head, expected_tail = 'FOOBAR', 'OOPS'
+        with Image(ioctx, self.clone_name) as clone:
+            clone.resize(IMG_SIZE / 2)
+            clone.write('HEHE', 0)
+            clone.rollback_to_snap('OOPS')
+            _, image, snap = clone.parent_info()
+            head = clone.read(0, len(expected_head))
+            tail = clone.read(IMG_SIZE / 2, len(expected_tail))
+            eq(image, image_name)
+            eq(snap, 'FOOBAR')
+            eq(head, expected_head)
+            eq(tail, expected_tail)


### PR DESCRIPTION
So snapshot, flatten, rollback of a cloned image does not loose any data

Fixes: #14512
Signed-off-by: Alexey Sheplyakov <asheplyakov@mirantis.com>