### PR TITLE
librados: fix to make external functions visible in librados.so

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -174,8 +174,10 @@ LIBCOMMON_DEPS += -lrt -lblkid
 endif # LINUX
 
 libcommon_la_SOURCES = common/buffer.cc
-libcommon_la_LIBADD = $(LIBCOMMON_DEPS)
-noinst_LTLIBRARIES += libcommon.la
+libcommon_la_LIBADD = $(LIBCOMMON_DEPS) $(CRYPTO_LIBS)
+libcommon_la_CXXFLAGS = ${AM_CXXFLAGS}
+libcommon_la_LDFLAGS = ${AM_LDFLAGS} -version-info 1:0:0
+lib_LTLIBRARIES += libcommon.la
 
 noinst_HEADERS += \
 	common/BackTrace.h \

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -270,7 +270,7 @@ namespace buffer CEPH_BUFFER_API {
 
   private:
     template <bool is_const>
-    class CEPH_BUFFER_DETAILS iterator_impl
+    class CEPH_BUFFER_API iterator_impl
       : public std::iterator<std::forward_iterator_tag, char> {
     protected:
       typedef typename std::conditional<is_const,

--- a/src/librados/Makefile.am
+++ b/src/librados/Makefile.am
@@ -22,7 +22,7 @@ librados_la_CXXFLAGS = ${AM_CXXFLAGS}
 
 LIBRADOS_DEPS += \
 	librados_internal.la libcls_lock_client.la \
-	$(LIBOSDC) $(LIBCOMMON_DEPS)
+	$(LIBOSDC) $(LIBCOMMON)
 
 librados_la_LIBADD = $(LIBRADOS_DEPS) $(PTHREAD_LIBS) $(CRYPTO_LIBS) $(EXTRALIBS)
 librados_la_LDFLAGS = ${AM_LDFLAGS} -version-info 2:0:0


### PR DESCRIPTION
This PR is motivated by the problems reported in PRs #8476 #8203.

The specific problem with lockdep static global variables occurs because the exported lockdep functions are not externally visible in librados.so. Therefore, when a program is statically linked with common/lockdep.cc and dynmically linked with librados.so, it will create two versions of the lockdep's static global variables.

The reason why lockdep's functions are not externally visible in librados.so is due to the linker option:
`-Xcompiler -Xlinker -Xcompiler '--exclude-libs=ALL'`

I don't see a significant increase in size of the the shared library file when this option is removed. So is this option critical to some other issue?

Signed-off-by: Ricardo Dias <rdias@suse.com>