### PR TITLE
Wip Xio heavy messengers and resources

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -93,6 +93,7 @@ OPTION(xio_mp_max_1k, OPT_INT, 8192) // max 1K chunks
 OPTION(xio_mp_max_page, OPT_INT, 4096) // max 1K chunks
 OPTION(xio_mp_max_hint, OPT_INT, 4096) // max size-hint chunks
 OPTION(xio_portal_threads, OPT_INT, 2) // xio portal threads per messenger
+OPTION(xio_max_conns_per_portal, OPT_INT, 32) // max xio_connections per portal/ctx
 OPTION(xio_transport_type, OPT_STR, "rdma") // xio transport type: {rdma or tcp}
 OPTION(xio_max_send_inline, OPT_INT, 512) // xio maximum threshold to send inline
 

--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -81,7 +81,7 @@ XioConnection::XioConnection(XioMessenger *m, XioConnection::type _type,
 			     const entity_inst_t& _peer) :
   Connection(m->cct, m),
   xio_conn_type(_type),
-  portal(m->default_portal()),
+  portal(m->get_portal()),
   connected(false),
   peer(_peer),
   session(NULL),

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -541,9 +541,9 @@ int XioMessenger::session_event(struct xio_session *session,
   case XIO_SESSION_CONNECTION_CLOSED_EVENT: /* orderly discon */
   case XIO_SESSION_CONNECTION_DISCONNECTED_EVENT: /* unexpected discon */
   case XIO_SESSION_CONNECTION_REFUSED_EVENT:
-    ldout(cct,2) << xio_session_event_types[event_data->event]
-      << " user_context " << event_data->conn_user_context << dendl;
     xcon = static_cast<XioConnection*>(event_data->conn_user_context);
+    ldout(cct,2) << xio_session_event_types[event_data->event]
+      << " xcon " << xcon << " session " << session  << dendl;
     if (likely(!!xcon)) {
       Spinlock::Locker lckr(conns_sp);
       XioConnection::EntitySet::iterator conn_iter =
@@ -565,9 +565,9 @@ int XioMessenger::session_event(struct xio_session *session,
     }
     break;
   case XIO_SESSION_CONNECTION_TEARDOWN_EVENT:
-    ldout(cct,2) << xio_session_event_types[event_data->event]
-      << " user_context " << event_data->conn_user_context << dendl;
     xcon = static_cast<XioConnection*>(event_data->conn_user_context);
+    ldout(cct,2) << xio_session_event_types[event_data->event]
+      << " xcon " << xcon << " session " << session << dendl;
     xcon->on_teardown_event();
     break;
   case XIO_SESSION_TEARDOWN_EVENT:
@@ -1004,7 +1004,7 @@ ConnectionRef XioMessenger::get_connection(const entity_inst_t& dest)
      * we can always set it explicitly */
     struct xio_connection_params xcp = {};
     xcp.session           = xcon->session;
-    xcp.ctx               = this->portals.get_portal0()->ctx;
+    xcp.ctx               = xcon->portal->ctx;
     xcp.conn_user_context = xcon;
 
     xcon->conn = xio_connect(&xcp);

--- a/src/msg/xio/XioMessenger.h
+++ b/src/msg/xio/XioMessenger.h
@@ -153,6 +153,9 @@ public:
    */
   void learned_addr(const entity_addr_t& peer_addr_for_me);
 
+private:
+  int get_nconns_per_portal();
+  int get_nportals();
 
 protected:
   virtual void ready()

--- a/src/msg/xio/XioMessenger.h
+++ b/src/msg/xio/XioMessenger.h
@@ -68,7 +68,7 @@ public:
 
   virtual ~XioMessenger();
 
-  XioPortal* default_portal() { return portals.get_portal0(); }
+  XioPortal* get_portal() { return portals.get_next_portal(); }
 
   virtual void set_myaddr(const entity_addr_t& a) {
     Messenger::set_myaddr(a);

--- a/src/msg/xio/XioPortal.cc
+++ b/src/msg/xio/XioPortal.cc
@@ -62,9 +62,6 @@ int XioPortals::bind(struct xio_session_ops *ops, const string& base_uri,
 
   /* bind the portals */
   for (size_t i = 0; i < portals.size(); i++) {
-    if (!portals[i])
-      portals[i] = new XioPortal(msgr, max_conns_per_ctx);
-
     uint16_t result_port;
     if (port != 0) {
       // bind directly to the given port

--- a/src/msg/xio/XioPortal.cc
+++ b/src/msg/xio/XioPortal.cc
@@ -63,7 +63,7 @@ int XioPortals::bind(struct xio_session_ops *ops, const string& base_uri,
   /* bind the portals */
   for (size_t i = 0; i < portals.size(); i++) {
     if (!portals[i])
-      portals[i] = new XioPortal(msgr);
+      portals[i] = new XioPortal(msgr, max_conns_per_ctx);
 
     uint16_t result_port;
     if (port != 0) {

--- a/src/msg/xio/XioPortal.h
+++ b/src/msg/xio/XioPortal.h
@@ -131,28 +131,28 @@ private:
   friend class XioMessenger;
 
 public:
-  explicit XioPortal(Messenger *_msgr) :
-  msgr(_msgr), ctx(NULL), server(NULL), submit_q(), xio_uri(""),
-  portal_id(NULL), _shutdown(false), drained(false),
-  magic(0),
-  special_handling(0)
-    {
-      pthread_spin_init(&sp, PTHREAD_PROCESS_PRIVATE);
-      pthread_mutex_init(&mtx, NULL);
+  explicit XioPortal(Messenger *_msgr, int max_conns) :
+    msgr(_msgr), ctx(NULL), server(NULL), submit_q(), xio_uri(""),
+    portal_id(NULL), _shutdown(false), drained(false),
+    magic(0),
+    special_handling(0)
+  {
+    pthread_spin_init(&sp, PTHREAD_PROCESS_PRIVATE);
+    pthread_mutex_init(&mtx, NULL);
 
-      /* a portal is an xio_context and event loop */
-      ctx = xio_context_create(NULL, 0 /* poll timeout */, -1 /* cpu hint */);
+    struct xio_context_params ctx_params;
+    memset(&ctx_params, 0, sizeof(ctx_params));
+    ctx_params.user_context = this;
+    /*
+     * hint to Accelio the total number of connections that will share
+     * this context's resources: internal primary task pool...
+     */
+    ctx_params.max_conns_per_ctx = max_conns;
 
-      /* associate this XioPortal object with the xio_context handle */
-      struct xio_context_attr xca;
-      xca.user_context = this;
-      xio_modify_context(ctx, &xca, XIO_CONTEXT_ATTR_USER_CTX);
-
-      if (magic & (MSG_MAGIC_XIO)) {
-	printf("XioPortal %p created ev_loop %p ctx %p\n",
-	       this, ev_loop, ctx);
-      }
-    }
+    /* a portal is an xio_context and event loop */
+    ctx = xio_context_create(&ctx_params, 0 /* poll timeout */, -1 /* cpu hint */);
+    assert(ctx && "Whoops, failed to create portal/ctx");
+  }
 
   int bind(struct xio_session_ops *ops, const string &base_uri,
 	   uint16_t port, uint16_t *assigned_port);
@@ -355,20 +355,16 @@ private:
   vector<XioPortal*> portals;
   char **p_vec;
   int n;
-  int last_use;
+  int last_unused;
+  int max_conns_per_ctx;
 
 public:
-  XioPortals(Messenger *msgr, int _n) : p_vec(NULL)
+  XioPortals(Messenger *msgr, int _n, int nconns) : p_vec(NULL), last_unused(0)
   {
+    max_conns_per_ctx = nconns;
+    n = max(_n, 1);
     /* portal0 */
-    portals.push_back(new XioPortal(msgr));
-    last_use = 0;
-
-    /* enforce at least two portals if bind */
-    if (_n < 2)
-      _n = 2;
-    n = _n;
-
+    portals.push_back(new XioPortal(msgr, nconns));
     /* additional portals allocated on bind() */
   }
 
@@ -384,11 +380,11 @@ public:
     return n;
   }
 
-  int get_last_use()
+  int get_last_unused()
   {
-    int pix = last_use;
-    if (++last_use >= get_portals_len() - 1)
-      last_use = 0;
+    int pix = last_unused;
+    if (++last_unused >= get_portals_len())
+      last_unused = 0;
     return pix;
   }
 
@@ -405,11 +401,15 @@ public:
 	     void *cb_user_context)
   {
     const char **portals_vec = get_vec();
-    int pix = get_last_use();
+    int pix = get_last_unused();
 
-    return xio_accept(session,
-		      (const char **)&(portals_vec[pix]),
-		      1, NULL, 0);
+    if (pix == 0) {
+      return xio_accept(session, NULL, 0, NULL, 0);
+    } else {
+      return xio_accept(session,
+			(const char **)&(portals_vec[pix]),
+			1, NULL, 0);
+    }
   }
 
   void start()
@@ -417,14 +417,11 @@ public:
     XioPortal *portal;
     int p_ix, nportals = portals.size();
 
-    /* portal_0 is the new-session handler, portal_1+ terminate
-     * active sessions */
-
-    p_vec = new char*[(nportals-1)];
-    for (p_ix = 1; p_ix < nportals; ++p_ix) {
+    p_vec = new char*[nportals];
+    for (p_ix = 0; p_ix < nportals; ++p_ix) {
       portal = portals[p_ix];
       /* shift left */
-      p_vec[(p_ix-1)] = (char*) /* portal->xio_uri.c_str() */
+      p_vec[p_ix] = (char*) /* portal->xio_uri.c_str() */
 			portal->portal_id;
     }
 


### PR DESCRIPTION
Patch set to identify and allocate properly resources (number of portals/contexts, max number of connections per portal/context), then use all portals/contexts for both passive and active connections