### PR TITLE
test: fix ut test failure caused by lfn change

### DIFF
--- a/src/test/os/TestLFNIndex.cc
+++ b/src/test/os/TestLFNIndex.cc
@@ -49,7 +49,7 @@ public:
     const std::string mangled_name = lfn_generate_object_name(hoid);
     EXPECT_EQ(mangled_expected, mangled_name);
     ghobject_t hoid_parsed;
-    EXPECT_TRUE(lfn_parse_object_name(mangled_name, &hoid_parsed));
+    EXPECT_EQ(0, lfn_parse_object_name(mangled_name, &hoid_parsed));
     EXPECT_EQ(hoid, hoid_parsed);
   }
 


### PR DESCRIPTION
https://github.com/ceph/ceph/pull/8496/commits/755c685f2d09c36b53bc39589a77fa73faba5149
change the lfn_parse_object_name() return type from bool to int but does not
change the relevant test correspondingly.

Fixes: http://tracker.ceph.com/issues/15464
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>