### PR TITLE
os/filestore: fix return type mismatch for lfn parse

### DIFF
--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -1041,13 +1041,13 @@ static int parse_object(const char *s, ghobject_t& o)
 
 int LFNIndex::lfn_parse_object_name_keyless(const string &long_name, ghobject_t *out)
 {
-  bool r = parse_object(long_name.c_str(), *out);
+  int r = parse_object(long_name.c_str(), *out);
   int64_t pool = -1;
   spg_t pg;
   if (coll().is_pg_prefix(&pg))
     pool = (int64_t)pg.pgid.pool();
   out->hobj.pool = pool;
-  if (!r) return r;
+  if (!r) return -EINVAL;
   string temp = lfn_generate_object_name(*out);
   return r ? 0 : -EINVAL;
 }


### PR DESCRIPTION
According to https://github.com/ceph/ceph/pull/8496/commits/755c685f2d09c36b53bc39589a77fa73faba5149,
we shall return a int value instead of bool now.
So if we fail to parse an object, we shall reset "false" into "-EINVAL" instead,
as "false" is always translated into 0, which is supposed to indicate a success.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>