### PR TITLE
mds: fix auth caps with hyphen in path (#15465)

### DIFF
--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -56,7 +56,7 @@ struct MDSCapParser : qi::grammar<Iterator, MDSAuthCaps()>
     quoted_path %=
       lexeme[lit("\"") >> *(char_ - '"') >> '"'] | 
       lexeme[lit("'") >> *(char_ - '\'') >> '\''];
-    unquoted_path %= +char_("a-zA-Z0-9_.-/");
+    unquoted_path %= +char_("a-zA-Z0-9_./-");
 
     // match := [path=<path>] [uid=<uid> [gids=<gid>[,<gid>...]]
     path %= (spaces >> lit("path") >> lit('=') >> (quoted_path | unquoted_path));

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -184,6 +184,27 @@ TEST(MDSAuthCaps, AllowPath) {
   ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, MAY_READ | MAY_WRITE, 0, 0));
 }
 
+TEST(MDSAuthCaps, AllowPathChars) {
+  MDSAuthCaps unquo_cap;
+  ASSERT_TRUE(unquo_cap.parse(g_ceph_context, "allow * path=/sandbox-._foo", NULL));
+  ASSERT_FALSE(unquo_cap.allow_all());
+  ASSERT_TRUE(unquo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_FALSE(unquo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_FALSE(unquo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_FALSE(unquo_cap.is_capable("foo", 0, 0, 0777, 0, 0, MAY_READ | MAY_WRITE, 0, 0));
+}
+
+
+TEST(MDSAuthCaps, AllowPathCharsQuoted) {
+  MDSAuthCaps quo_cap;
+  ASSERT_TRUE(quo_cap.parse(g_ceph_context, "allow * path=\"/sandbox-._foo\"", NULL));
+  ASSERT_FALSE(quo_cap.allow_all());
+  ASSERT_TRUE(quo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_FALSE(quo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_FALSE(quo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_FALSE(quo_cap.is_capable("foo", 0, 0, 0777, 0, 0, MAY_READ | MAY_WRITE, 0, 0));
+}
+
 TEST(MDSAuthCaps, OutputParsed) {
   struct CapsTest {
     const char *input;

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -29,6 +29,7 @@ const char *parse_good[] = {
   "allow rw uid=1 gids=1",
   "allow * path=\"/foo\"",
   "allow * path=/foo",
+  "allow * path=/foo-bar_baz",
   "allow * path=\"/foo bar/baz\"",
   "allow * uid=1",
   "allow * path=\"/foo\" uid=1",


### PR DESCRIPTION
Quirk of the boost spirit char() fn, hyphens
are treated as range delimiters unless they're
the last character in the set.

Fixes: #15465
Signed-off-by: John Spray <john.spray@redhat.com>