### PR TITLE
common: drop a redundant warning about experimental features

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -250,9 +250,6 @@ public:
     get_str_set(conf->enable_experimental_unrecoverable_data_corrupting_features,
 		cct->_experimental_features);
     ceph_spin_unlock(&cct->_feature_lock);
-    if (!cct->_experimental_features.empty())
-      lderr(cct) << "WARNING: the following dangerous and experimental features are enabled: "
-		 << cct->_experimental_features << dendl;
   }
 };
 


### PR DESCRIPTION
At first I thought perhaps to filter out blanket enablement with "*", or change the level of the warning. But what I found is a surprising redundancy, which makes this warning worthless to begin with! Thus this commit simply removes the silly thing. The commit has a longer explanation.

If anyone sees something I'm missing here, please comment.
