### PR TITLE
pybind, FileStore: silence gcc warnings

### DIFF
--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -174,16 +174,22 @@
 #cmakedefine HAVE_SYS_VFS_H 1
 
 /* Define to 1 if you have <sys/wait.h> that is POSIX.1 compatible. */
+#ifndef HAVE_SYS_WAIT_H
 #cmakedefine HAVE_SYS_WAIT_H
+#endif
 
 /* Define to 1 if you have the <sys/xattr.h> header file. */
 #cmakedefine HAVE_SYS_XATTR_H
 
+#ifndef HAVE_UNISTD_H
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD_H
+#endif
 
+#ifndef HAVE_UTIME_H
 /* Define to 1 if you have the <utime.h> header file. */
 #cmakedefine HAVE_UTIME_H
+#endif
 
 /* Define if you have the <execinfo.h> header file. */
 #cmakedefine HAVE_EXECINFO_H

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -152,7 +152,6 @@ void FileStore::FSPerfTracker::update_from_perfcounters(
 
 ostream& operator<<(ostream& out, const FileStore::OpSequencer& s)
 {
-  assert(&out);
   return out << *s.parent;
 }
 

--- a/src/pybind/cephfs/CMakeLists.txt
+++ b/src/pybind/cephfs/CMakeLists.txt
@@ -4,6 +4,7 @@ add_custom_target(cython_cephfs
   CC=${PY_CC}
   CXX=${PY_CXX}
   LDSHARED=${PY_LDSHARED}
+  OPT=\"-DNDEBUG -g -fwrapv -O2 -Wall\"
   LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
   CYTHON_BUILD_DIR=${CMAKE_BINARY_DIR}/src/pybind/cephfs
   CFLAGS=\"-iquote ${CMAKE_SOURCE_DIR}/src/include\"

--- a/src/pybind/rados/CMakeLists.txt
+++ b/src/pybind/rados/CMakeLists.txt
@@ -4,6 +4,7 @@ add_custom_target(cython_rados
   CC=${PY_CC}
   CXX=${PY_CXX}
   LDSHARED=${PY_LDSHARED}
+  OPT=\"-DNDEBUG -g -fwrapv -O2 -Wall\"
   LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
   CYTHON_BUILD_DIR=${CMAKE_BINARY_DIR}/src/pybind/rados
   CFLAGS=\"-iquote ${CMAKE_SOURCE_DIR}/src/include\"

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -1013,7 +1013,7 @@ Rados object in state %s." % self.state)
                 with nogil:
                     ret = rados_inconsistent_pg_list(self.cluster, pool,
                                                      pgs, size)
-                if ret > size:
+                if ret > <int>size:
                     size *= 2
                 elif ret >= 0:
                     break
@@ -1039,7 +1039,7 @@ Rados object in state %s." % self.state)
                 c_names = <char *>realloc_chk(c_names, size)
                 with nogil:
                     ret = rados_pool_list(self.cluster, c_names, size)
-                if ret > size:
+                if ret > <int>size:
                     size *= 2
                 elif ret >= 0:
                     break
@@ -1068,7 +1068,7 @@ Rados object in state %s." % self.state)
                 ret = rados_cluster_fsid(self.cluster, ret_buf, buf_len)
             if ret < 0:
                 raise make_ex(ret, "error getting cluster fsid")
-            if ret != buf_len:
+            if ret != <int>buf_len:
                 _PyBytes_Resize(&ret_s, ret)
             return <object>ret_s
         finally:

--- a/src/pybind/rbd/CMakeLists.txt
+++ b/src/pybind/rbd/CMakeLists.txt
@@ -4,6 +4,7 @@ add_custom_target(cython_rbd
   CC=${PY_CC}
   CXX=${PY_CXX}
   LDSHARED=${PY_LDSHARED}
+  OPT=\"-DNDEBUG -g -fwrapv -O2 -Wall\"
   LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
   CYTHON_BUILD_DIR=${CMAKE_BINARY_DIR}/src/pybind/rbd
   CFLAGS=\"-iquote ${CMAKE_SOURCE_DIR}/src/include\"


### PR DESCRIPTION
- pybind/rados: silence "-Wstrict-prototypes" warnings
- pybind: silence gcc warnings about '-Wstrict-prototypes'
- os/FileStore::OpSequencer: operator<<: silence gcc warning