### PR TITLE
objclass: honour do_osd_ops() results before going any further

### DIFF
--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -119,6 +119,8 @@ int cls_call(cls_method_context_t hctx, const char *cls, const char *method,
   op.indata.append(method, op.op.cls.method_len);
   op.indata.append(indata, datalen);
   r = (*pctx)->pg->do_osd_ops(*pctx, nops);
+  if (r < 0)
+    return r;
 
   *outdata = (char *)malloc(op.outdata.length());
   if (!*outdata)
@@ -142,6 +144,8 @@ int cls_getxattr(cls_method_context_t hctx, const char *name,
   op.indata.append(name);
   op.op.xattr.name_len = strlen(name);
   r = (*pctx)->pg->do_osd_ops(*pctx, nops);
+  if (r < 0)
+    return r;
 
   *outdata = (char *)malloc(op.outdata.length());
   if (!*outdata)
@@ -180,15 +184,14 @@ int cls_read(cls_method_context_t hctx, int ofs, int len,
   ops[0].op.extent.offset = ofs;
   ops[0].op.extent.length = len;
   int r = (*pctx)->pg->do_osd_ops(*pctx, ops);
+  if (r < 0)
+    return r;
 
   *outdata = (char *)malloc(ops[0].outdata.length());
   if (!*outdata)
     return -ENOMEM;
   memcpy(*outdata, ops[0].outdata.c_str(), ops[0].outdata.length());
   *outdatalen = ops[0].outdata.length();
-
-  if (r < 0)
-    return r;
 
   return *outdatalen;
 }


### PR DESCRIPTION
This is because:
 1. all the other methods are doing the same.
 2. the origin results of do_osd_ops() may get overwritten by -ENOMEM,
    which is misleading.
 3. if the class methods return negative results, normally it's not
    the responsibility for the caller being in charge of freeing out
    buffers. Therefore this change saves our some efforts and avoids
    potential memory leaks(Though I doubt this shall happen).

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>