### PR TITLE
doc: Fixes Different font of the title

### DIFF
--- a/doc/rados/operations/add-or-rm-osds.rst
+++ b/doc/rados/operations/add-or-rm-osds.rst
@@ -221,7 +221,7 @@ that your cluster is not at its ``near full`` ratio.
    or exceed its ``full ratio``.
    
 
-Take the OSD ``out`` of the Cluster
+Take the OSD out of the Cluster
 -----------------------------------
 
 Before you remove an OSD, it is usually ``up`` and ``in``.  You need to take it


### PR DESCRIPTION
Which makes the title "Take the OSD out of the Cluster" of http://docs.ceph.com/docs/master/rados/operations/add-or-rm-osds/#take-the-osd-out-of-the-cluster looks ugly.

Signed-off-by: luo kexue luo.kexue@zte.com.cn