### PR TITLE
PG: set epoch_created and parent_split_bits for child pg

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2298,6 +2298,7 @@ void PG::split_into(pg_t child_pgid, PG *child, unsigned split_bits)
 
   // Info
   child->info.history = info.history;
+  child->info.history.epoch_created = get_osdmap()->get_epoch();
   child->info.purged_snaps = info.purged_snaps;
 
   if (info.last_backfill.is_max()) {
@@ -2313,6 +2314,7 @@ void PG::split_into(pg_t child_pgid, PG *child, unsigned split_bits)
   }
 
   child->info.stats = info.stats;
+  child->info.stats.parent_split_bits = split_bits;
   info.stats.stats_invalid = true;
   child->info.stats.stats_invalid = true;
   child->info.last_epoch_started = info.last_epoch_started;


### PR DESCRIPTION
if we have a wrong "created", OSD receiving a osd_pg_create message
could fail to project its history and crash. a bad split_bits could miss
lead the monitor and osd, and hence cause problems.
* set child.info.history.epoch_created to osdmap.get_epoch() instead of
  using the parent's epoch_created
* set child.info.stats.parent_split_bits to the calculated split_bits
  instead using the parent's split_bits

Fixes: http://tracker.ceph.com/issues/15426
Signed-off-by: Kefu Chai <kchai@redhat.com>