### PR TITLE
osd: refuse to start if object name limits are not possible

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -556,6 +556,9 @@ OPTION(mds_max_scrub_ops_in_progress, OPT_INT, 5) // the number of simultaneous 
 // Maximum number of damaged frags/dentries before whole MDS rank goes damaged
 OPTION(mds_damage_table_max_entries, OPT_INT, 10000)
 
+// verify backend can support configured max object name length
+OPTION(osd_check_max_object_name_len_on_sthartup, OPT_BOOL, true)
+
 // If true, compact leveldb store on mount
 OPTION(osd_compact_leveldb_on_mount, OPT_BOOL, false)
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2037,7 +2037,13 @@ int OSD::init()
       derr << "   osd max object namespace len = "
 	   << g_conf->osd_max_object_namespace_len << dendl;
       derr << cpp_strerror(r) << dendl;
-      goto out;
+      if (g_conf->osd_check_max_object_name_len_on_startup) {
+	goto out;
+      }
+      derr << "osd_check_max_object_name_len_on_startup = false, starting anyway"
+	   << dendl;
+    } else {
+      dout(20) << "configured osd_max_object_name[space]_len looks ok" << dendl;
     }
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2022,6 +2022,25 @@ int OSD::init()
   int rotating_auth_attempts = 0;
   const int max_rotating_auth_attempts = 10;
 
+  // sanity check long object name handling
+  {
+    hobject_t l;
+    l.oid.name = string(g_conf->osd_max_object_name_len, 'n');
+    l.set_key(string(g_conf->osd_max_object_name_len, 'k'));
+    l.nspace = string(g_conf->osd_max_object_namespace_len, 's');
+    r = store->validate_hobject_key(l);
+    if (r < 0) {
+      derr << "backend (" << store->get_type() << ") is unable to support max "
+	   << "object name[space] len" << dendl;
+      derr << "   osd max object name len = "
+	   << g_conf->osd_max_object_name_len << dendl;
+      derr << "   osd max object namespace len = "
+	   << g_conf->osd_max_object_namespace_len << dendl;
+      derr << cpp_strerror(r) << dendl;
+      goto out;
+    }
+  }
+
   // read superblock
   r = read_superblock();
   if (r < 0) {

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -91,6 +91,7 @@ start_rgw=0
 ip=""
 nodaemon=0
 smallmds=0
+short=0
 ec=0
 hitset=""
 overwrite_conf=1
@@ -131,6 +132,7 @@ usage=$usage"\t--rgw_port specify ceph rgw http listen port\n"
 usage=$usage"\t--bluestore use bluestore as the osd objectstore backend\n"
 usage=$usage"\t--memstore use memstore as the osd objectstore backend\n"
 usage=$usage"\t--cache <pool>: enable cache tiering on pool\n"
+usage=$usage"\t--short: short object names only; necessary for ext4 dev\n"
 
 usage_exit() {
 	printf "$usage"
@@ -161,6 +163,9 @@ case $1 in
 	    ;;
     --new | -n )
 	    new=1
+	    ;;
+    --short )
+	    short=1
 	    ;;
     --valgrind )
 	    [ -z "$2" ] && usage_exit
@@ -465,6 +470,10 @@ cat <<EOF >> $conf_fn
 	auth client required = none
 EOF
 fi
+if [ "$short" -eq 1 ]; then
+    COSDSHORT="        osd max object name len = 460
+        osd max object namespace len = 64"
+fi
 			cat <<EOF >> $conf_fn
 
 [client]
@@ -505,6 +514,7 @@ $DAEMONOPTS
 	bluestore block wal create = true
 $COSDDEBUG
 $COSDMEMSTORE
+$COSDSHORT
 $extra_conf
 [mon]
         mon pg warn min per osd = 3


### PR DESCRIPTION
Unfortunately we don't mount() until after the fork.  It goes in the  log, though, and systemd should still capture it since derr echos to stderr too.

This does change the workflow for devs on ext4 because they have to pass --short.  This seems better than having librados and rgw tests unexpectedly fail.