### PR TITLE
rgw-admin: sync zones as part of realm pull

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1496,7 +1496,7 @@ int RGWZoneParams::create(bool exclusive)
   }
 
   r = RGWSystemMetaObj::create(exclusive);
-  if (r < 0) {
+  if (r < 0 && r != -EEXIST) {
     ldout(cct, 0) << "RGWZoneParams::create(): error creating default zone params: " << cpp_strerror(-r) << dendl;
     return r;
   }


### PR DESCRIPTION
Up until now, a realm pull from a master to a peer, would sync realm and period information. Within the period, one would find the period map containing zone groups. Zone groups would also be synced to the peer. Syncing zones attached to each zone group, however, would make life a bit easier for the administrator. This PR tries to address this.

@oritwas - Orit, as we discussed on IRC. Please have a look when you have a moment. Thanks!