### PR TITLE
rgw: file unix

### DIFF
--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -290,6 +290,8 @@ namespace cohort {
 	Partition* p;
 	LK* lock;
 	insert_commit_data commit_data;
+
+	Latch() : p(nullptr), lock(nullptr) {}
       };
 
       Partition& partition_of_scalar(uint64_t x) {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -96,7 +96,8 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_OLH_PENDING_PREFIX RGW_ATTR_OLH_PREFIX "pending."
 
 /* RGW File Attributes */
-#define RGW_ATTR_UNIX1     RGW_ATTR_PREFIX "unix1"
+#define RGW_ATTR_UNIX_KEY1      RGW_ATTR_PREFIX "unix-key1"
+#define RGW_ATTR_UNIX1          RGW_ATTR_PREFIX "unix1"
 
 #define RGW_BUCKETS_OBJ_SUFFIX ".buckets"
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -95,6 +95,9 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_OLH_ID_TAG     RGW_ATTR_OLH_PREFIX "idtag"
 #define RGW_ATTR_OLH_PENDING_PREFIX RGW_ATTR_OLH_PREFIX "pending."
 
+/* RGW File Attributes */
+#define RGW_ATTR_UNIX1     RGW_ATTR_PREFIX "unix1"
+
 #define RGW_BUCKETS_OBJ_SUFFIX ".buckets"
 
 #define RGW_MAX_PENDING_CHUNKS  16

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -411,7 +411,6 @@ namespace rgw {
 	rc = rc2;
     }
 
-  out:
     rgw_fh->mtx.unlock(); /* !LOCKED */
     get<1>(mkr) = rc;
 

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -338,6 +338,84 @@ namespace rgw {
     return mkr;
   } /* RGWLibFS::mkdir */
 
+  MkObjResult RGWLibFS::mkdir2(RGWFileHandle* parent, const char *name,
+			       struct stat *st, uint32_t mask, uint32_t flags)
+  {
+    MkObjResult mkr{nullptr, -EINVAL};
+    int rc, rc2;
+
+    LookupFHResult fhr;
+    RGWFileHandle* rgw_fh = nullptr;
+
+    fhr = lookup_fh(parent, name,
+		    RGWFileHandle::FLAG_CREATE|
+		    RGWFileHandle::FLAG_DIRECTORY|
+		    RGWFileHandle::FLAG_LOCK);
+    rgw_fh = get<0>(fhr);
+    if (rgw_fh) {
+      /* XXX unify timestamps */
+      rgw_fh->create_stat(st, mask);
+      rgw_fh->set_times(real_clock::now());
+      rgw_fh->stat(st);
+      get<0>(mkr) = rgw_fh;
+    } else {
+      get<1>(mkr) = -EIO;
+      return mkr;
+    }
+
+    if (parent->is_root()) {
+      /* bucket */
+      string bname{name};
+      /* enforce S3 name restrictions */
+      rc = valid_s3_bucket_name(bname, false /* relaxed */);
+      if (rc != 0) {
+	rgw_fh->flags |= RGWFileHandle::FLAG_DELETED;
+	rgw_fh->mtx.unlock();
+	unref(rgw_fh);
+	get<0>(mkr) = nullptr;
+	return mkr;
+      }
+
+      string uri = "/" + bname; /* XXX get rid of URI some day soon */
+      RGWCreateBucketRequest req(get_context(), get_user(), uri);
+      rc = rgwlib.get_fe()->execute_req(&req);
+      rc2 = req.get_ret();
+    } else {
+      /* create an object representing the directory */
+      buffer::list bl;
+      string dir_name = /* XXX get rid of this some day soon, too */
+	parent->relative_object_name();
+      /* creating objects w/leading '/' makes a mess */
+      if ((dir_name.size() > 0) &&
+	  (dir_name.back() != '/'))
+	dir_name += "/";
+      dir_name += name;
+      dir_name += "/";
+      RGWPutObjRequest req(get_context(), get_user(), parent->bucket_name(),
+			  dir_name, bl);
+      rc = rgwlib.get_fe()->execute_req(&req);
+      rc2 = req.get_ret();
+    }
+
+    if (! ((rc == 0) &&
+	   (rc2 == 0))) {
+      /* op failed */
+      rgw_fh->flags |= RGWFileHandle::FLAG_DELETED;
+      rgw_fh->mtx.unlock();
+      unref(rgw_fh);
+      get<0>(mkr) = nullptr;
+      /* fixup rc */
+      if (!rc)
+	rc = rc2;
+    }
+
+  out:
+    rgw_fh->mtx.unlock(); /* !LOCKED */
+    get<1>(mkr) = rc;
+
+    return mkr;
+  } /* RGWLibFS::mkdir2 */
+
   MkObjResult RGWLibFS::create(RGWFileHandle* parent, const char *name,
 			      struct stat *st, uint32_t mask, uint32_t flags)
   {
@@ -908,7 +986,7 @@ int rgw_mkdir(struct rgw_fs *rgw_fs,
     return -EINVAL;
   }
 
-  MkObjResult fhr = fs->mkdir(parent, name, st, mask, flags);
+  MkObjResult fhr = fs->mkdir2(parent, name, st, mask, flags);
   RGWFileHandle *nfh = get<0>(fhr); // nullptr if !success
 
   if (nfh)

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -380,6 +380,7 @@ namespace rgw {
 
       string uri = "/" + bname; /* XXX get rid of URI some day soon */
       RGWCreateBucketRequest req(get_context(), get_user(), uri);
+      req.emplace_attr(RGW_ATTR_UNIX1, std::move(ux_attrs));
       rc = rgwlib.get_fe()->execute_req(&req);
       rc2 = req.get_ret();
     } else {
@@ -395,6 +396,7 @@ namespace rgw {
       dir_name += "/";
       RGWPutObjRequest req(get_context(), get_user(), parent->bucket_name(),
 			  dir_name, bl);
+      req.emplace_attr(RGW_ATTR_UNIX1, std::move(ux_attrs));
       rc = rgwlib.get_fe()->execute_req(&req);
       rc2 = req.get_ret();
     }

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -346,6 +346,7 @@ namespace rgw {
 
     LookupFHResult fhr;
     RGWFileHandle* rgw_fh = nullptr;
+    buffer::list ux_attrs;
 
     fhr = lookup_fh(parent, name,
 		    RGWFileHandle::FLAG_CREATE|
@@ -353,9 +354,10 @@ namespace rgw {
 		    RGWFileHandle::FLAG_LOCK);
     rgw_fh = get<0>(fhr);
     if (rgw_fh) {
-      /* XXX unify timestamps */
       rgw_fh->create_stat(st, mask);
       rgw_fh->set_times(real_clock::now());
+      /* save attrs */
+      rgw_fh->encode_attrs(ux_attrs);
       rgw_fh->stat(st);
       get<0>(mkr) = rgw_fh;
     } else {

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -794,7 +794,6 @@ namespace rgw {
 	return fhr;
 
       RGWFileHandle::FHCache::Latch lat;
-      memset(&lat, 0, sizeof(lat)); // XXXX testing
 
       std::string obj_name{name};
       std::string key_name{parent->make_key_name(name)};

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -857,6 +857,9 @@ namespace rgw {
     LookupFHResult stat_leaf(RGWFileHandle* parent, const char *path,
 			     uint32_t flags);
 
+    int read(RGWFileHandle* rgw_fh, uint64_t offset, size_t length,
+	     size_t* bytes_read, void* buffer, uint32_t flags);
+
     int rename(RGWFileHandle* old_fh, RGWFileHandle* new_fh,
 	       const char *old_name, const char *new_name);
 

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -830,10 +830,12 @@ namespace rgw {
 			cohort::lru::Edge::MRU,
 			cohort::lru::FLAG_INITIAL));
 	if (fh) {
-	  fh_cache.insert_latched(fh, lat, RGWFileHandle::FHCache::FLAG_UNLOCK);
-	  get<1>(fhr) |= RGWFileHandle::FLAG_CREATE;
+	  /* lock fh (LATCHED) */
 	  if (fh->flags & RGWFileHandle::FLAG_LOCK)
 	    fh->mtx.lock();
+	  /* inserts, releasing latch */
+	  fh_cache.insert_latched(fh, lat, RGWFileHandle::FHCache::FLAG_UNLOCK);
+	  get<1>(fhr) |= RGWFileHandle::FLAG_CREATE;
 	  goto out; /* !LATCHED */
 	} else {
 	  lat.lock->unlock();
@@ -873,6 +875,8 @@ namespace rgw {
 		      uint32_t mask, uint32_t flags);
 
     MkObjResult mkdir(RGWFileHandle* parent, const char *name, struct stat *st,
+		      uint32_t mask, uint32_t flags);
+    MkObjResult mkdir2(RGWFileHandle* parent, const char *name, struct stat *st,
 		      uint32_t mask, uint32_t flags);
 
     int unlink(RGWFileHandle* parent, const char *name);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2517,8 +2517,7 @@ void RGWPutObj::execute()
   }
 
   policy.encode(aclbl);
-
-  attrs[RGW_ATTR_ACL] = aclbl;
+  emplace_attr(RGW_ATTR_ACL, std::move(aclbl));
 
   if (dlo_manifest) {
     op_ret = encode_dlo_manifest_attr(dlo_manifest, attrs);
@@ -2533,7 +2532,7 @@ void RGWPutObj::execute()
   if (slo_info) {
     bufferlist manifest_bl;
     ::encode(*slo_info, manifest_bl);
-    attrs[RGW_ATTR_SLO_MANIFEST] = manifest_bl;
+    emplace_attr(RGW_ATTR_SLO_MANIFEST, std::move(manifest_bl));
 
     hash.Update((byte *)slo_info->raw_data, slo_info->raw_data_len);
     complete_etag(hash, &etag);
@@ -2545,7 +2544,7 @@ void RGWPutObj::execute()
     goto done;
   }
   bl.append(etag.c_str(), etag.size() + 1);
-  attrs[RGW_ATTR_ETAG] = bl;
+  emplace_attr(RGW_ATTR_ETAG, std::move(bl));
 
   for (iter = s->generic_attrs.begin(); iter != s->generic_attrs.end();
        ++iter) {
@@ -2563,11 +2562,11 @@ void RGWPutObj::execute()
   if (slo_info) {
     bufferlist slo_userindicator_bl;
     ::encode("True", slo_userindicator_bl);
-    attrs[RGW_ATTR_SLO_UINDICATOR] = slo_userindicator_bl;
+    emplace_attr(RGW_ATTR_SLO_UINDICATOR, std::move(slo_userindicator_bl));
   }
 
-  op_ret = processor->complete(etag, &mtime, real_time(), attrs, delete_at, if_match,
-			       if_nomatch);
+  op_ret = processor->complete(etag, &mtime, real_time(), attrs, delete_at,
+			      if_match, if_nomatch);
 
 done:
   dispose_processor(processor);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2332,13 +2332,11 @@ void RGWPutObj::execute()
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
   MD5 hash;
   bufferlist bl, aclbl;
-  map<string, bufferlist> attrs;
   int len;
   map<string, string>::iterator iter;
   bool multipart;
 
   bool need_calc_md5 = (dlo_manifest == NULL) && (slo_info == NULL);
-
 
   perfcounter->inc(l_rgw_put);
   op_ret = -EINVAL;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -717,6 +717,10 @@ public:
 		 supplied_md5_b64(NULL), supplied_etag(NULL),
 		 data_pending(false) {}
 
+  void emplace_attr(std::string&& key, buffer::list&& bl) {
+    attrs.emplace(key, bl); /* key and bl are r-value refs */
+  }
+
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *h) {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
@@ -766,6 +770,7 @@ public:
 
 class RGWPutMetadataBucket : public RGWOp {
 protected:
+  map<string, buffer::list> attrs;
   set<string> rmattr_names;
   bool has_policy, has_cors;
   RGWAccessControlPolicy policy;
@@ -778,10 +783,15 @@ public:
     : has_policy(false), has_cors(false)
   {}
 
+  void emplace_attr(std::string&& key, buffer::list&& bl) {
+    attrs.emplace(key, bl); /* key and bl are r-value refs */
+  }
+
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *h) {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
+
   int verify_permission();
   void pre_exec();
   void execute();

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -547,7 +547,7 @@ public:
   RGWCreateBucket() : has_cors(false) {}
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {
-    attrs.emplace(key, bl); /* key and bl are r-value refs */
+    attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
   int verify_permission();
@@ -680,7 +680,7 @@ public:
   }
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {
-    attrs.emplace(key, bl); /* key and bl are r-value refs */
+    attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
   virtual RGWPutObjProcessor *select_processor(RGWObjectCtx& obj_ctx, bool *is_multipart);
@@ -723,7 +723,7 @@ public:
 		 data_pending(false) {}
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {
-    attrs.emplace(key, bl); /* key and bl are r-value refs */
+    attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *h) {
@@ -789,7 +789,7 @@ public:
   {}
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {
-    attrs.emplace(key, bl); /* key and bl are r-value refs */
+    attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *h) {
@@ -929,7 +929,7 @@ public:
                                   rgw_obj_key& object);
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {
-    attrs.emplace(key, bl); /* key and bl are r-value refs */
+    attrs.emplace(std::move(key), std::move(bl));
   }
 
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *h) {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -647,7 +647,7 @@ protected:
   RGWAccessControlPolicy policy;
   const char *dlo_manifest;
   RGWSLOInfo *slo_info;
-
+  map<string, bufferlist> attrs;
   ceph::real_time mtime;
   uint64_t olh_epoch;
   string version_id;
@@ -672,6 +672,10 @@ public:
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *h) {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
+  }
+
+  void emplace_attr(std::string&& key, buffer::list&& bl) {
+    attrs.emplace(key, bl); /* key and bl are r-value refs */
   }
 
   virtual RGWPutObjProcessor *select_processor(RGWObjectCtx& obj_ctx, bool *is_multipart);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -536,6 +536,7 @@ protected:
   bool has_cors;
   RGWCORSConfiguration cors_config;
   string swift_ver_location;
+  map<string, buffer::list> attrs;
   set<string> rmattr_names;
 
   bufferlist in_data;
@@ -544,6 +545,10 @@ protected:
 
 public:
   RGWCreateBucket() : has_cors(false) {}
+
+  void emplace_attr(std::string&& key, buffer::list&& bl) {
+    attrs.emplace(key, bl); /* key and bl are r-value refs */
+  }
 
   int verify_permission();
   void pre_exec();
@@ -875,7 +880,7 @@ protected:
   ceph::real_time unmod_time;
   ceph::real_time *mod_ptr;
   ceph::real_time *unmod_ptr;
-  map<string, bufferlist> attrs;
+  map<string, buffer::list> attrs;
   string src_tenant_name, src_bucket_name;
   rgw_bucket src_bucket;
   rgw_obj_key src_object;
@@ -922,6 +927,10 @@ public:
   static bool parse_copy_location(const string& src,
                                   string& bucket_name,
                                   rgw_obj_key& object);
+
+  void emplace_attr(std::string&& key, buffer::list&& bl) {
+    attrs.emplace(key, bl); /* key and bl are r-value refs */
+  }
 
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *h) {
     RGWOp::init(store, s, h);

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -262,6 +262,9 @@ TEST(LibRGW, SETUP_DIRS1) {
 	rc = rgw_mkdir(fs, dirs1_b.parent_fh, dirs1_b.name.c_str(), &st,
 		      create_mask, &dirs1_b.fh, RGW_MKDIR_FLAG_NONE);
 	ASSERT_EQ(rc, 0);
+      } else {
+	/* no top-level dir and can't create it--skip remaining tests */
+	return;
       }
     }
     dirs1_b.sync();
@@ -487,6 +490,12 @@ TEST(LibRGW, RGW_CROSSBUCKET_RENAME1) {
 TEST(LibRGW, BAD_DELETES_DIRS1) {
   if (do_dirs1) {
     int rc;
+
+    if (dirs_vec.size() == 0) {
+      /* skip */
+      return;
+    }
+
     if (do_delete) {
       /* try to unlink a non-empty directory (bucket) */
       rc = rgw_unlink(fs, dirs1_b.parent_fh, dirs1_b.name.c_str(),
@@ -494,7 +503,8 @@ TEST(LibRGW, BAD_DELETES_DIRS1) {
       ASSERT_NE(rc, 0);
     }
     /* try to unlink a non-empty directory (non-bucket) */
-    obj_rec& sdir_0 = get<1>(dirs_vec[0])[0];    ASSERT_EQ(sdir_0.name, "sdir_0");
+    obj_rec& sdir_0 = get<1>(dirs_vec[0])[0];
+    ASSERT_EQ(sdir_0.name, "sdir_0");
     ASSERT_TRUE(sdir_0.rgw_fh->is_dir());
     /* XXX we can't enforce this currently */
 #if 0


### PR DESCRIPTION

Above Unix attrs support, this change does use std::map::emplace to assign attributes in several RGWOps.

Not sure if that can go on Jewel, but it has to pass s3-tests anyway--this branch passes my simple S3 object tests as well as the RGW NFS tests.