### PR TITLE
rgw_admin: improve period update errors

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1482,7 +1482,8 @@ static int update_period(const string& realm_id, const string& realm_name,
   period.fork();
   ret = period.update();
   if(ret < 0) {
-    cerr << "failed to update period: " << cpp_strerror(-ret) << std::endl;
+    // Dropping the error message here, as both the ret codes were handled in
+    // period.update()
     return ret;
   }
   ret = period.store_info(false);
@@ -2537,7 +2538,6 @@ int main(int argc, char **argv)
                                 commit, remote, url, access_key, secret_key,
                                 formatter);
 	if (ret < 0) {
-          cerr << "period update failed: " << cpp_strerror(-ret) << std::endl;
 	  return ret;
 	}
       }
@@ -3799,8 +3799,7 @@ int main(int argc, char **argv)
                               commit, remote, url, access_key, secret_key,
                               formatter);
       if (ret < 0) {
-        cerr << "period update failed: " << cpp_strerror(-ret) << std::endl;
-        return ret;
+	return ret;
       }
     }
     return 0;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1147,7 +1147,7 @@ int RGWPeriod::add_zonegroup(const RGWZoneGroup& zonegroup)
   if (zonegroup.realm_id != realm_id) {
     return 0;
   }
-  int ret = period_map.update(zonegroup);
+  int ret = period_map.update(zonegroup, cct);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: updating period map: " << cpp_strerror(-ret) << dendl;
     return ret;
@@ -1184,9 +1184,8 @@ int RGWPeriod::update()
       master_zone = zg.master_zone;
     }
 
-    int ret = period_map.update(zg);
+    int ret = period_map.update(zg, cct);
     if (ret < 0) {
-      ldout(cct, 0) << "ERROR: updating period map: " << cpp_strerror(-ret) << dendl;
       return ret;
     }
   }
@@ -1623,9 +1622,11 @@ void RGWPeriodMap::decode(bufferlist::iterator& bl) {
   }
 }
 
-int RGWPeriodMap::update(const RGWZoneGroup& zonegroup)
+int RGWPeriodMap::update(const RGWZoneGroup& zonegroup, CephContext *cct)
 {
   if (zonegroup.is_master && (!master_zonegroup.empty() && zonegroup.get_id() != master_zonegroup)) {
+    ldout(cct,0) << "Error updating periodmap, multiple master zonegroups configured "<< dendl;
+    ldout(cct,0) << "master zonegroup: " << master_zonegroup << " and  " << zonegroup.get_id() <<dendl;
     return -EINVAL;
   }
   map<string, RGWZoneGroup>::iterator iter = zonegroups.find(zonegroup.get_id());

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1181,7 +1181,7 @@ struct RGWPeriodMap
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& bl);
 
-  int update(const RGWZoneGroup& zonegroup);
+  int update(const RGWZoneGroup& zonegroup, CephContext *cct);
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);


### PR DESCRIPTION
Basically if we do a period update on a realm with multiple masters, we
fail stating invalid argument, improving this to suggest that we have
actually errored out because of multiple master zg in a realm

Fixes: http://tracker.ceph.com/issues/15251
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>