### PR TITLE
rgw: RGWPeriod::reflect() sets master zonegroup as default

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1204,6 +1204,14 @@ int RGWPeriod::reflect()
       ldout(cct, 0) << "ERROR: failed to store zonegroup info for zonegroup=" << iter.first << ": " << cpp_strerror(-r) << dendl;
       return r;
     }
+    if (zg.is_master_zonegroup()) {
+      // set master as default if no default exists
+      r = zg.set_as_default(true);
+      if (r == 0) {
+        ldout(cct, 1) << "Set the period's master zonegroup " << zg.get_id()
+            << " as the default" << dendl;
+      }
+    }
   }
   return 0;
 }


### PR DESCRIPTION
This patch improves the configuration of a secondary cluster by establishing a default zonegroup after the initial 'realm pull'.

Previously, the initial output of 'zonegroup list' was:
```
read_default_id : -2
{
    "default_info": "",
    "zonegroups": [
        "us",
        "default"
    ]
}
```
With these patches, the output is as expected:
```
read_default_id : 0
{
    "default_info": "792474ac-d2f1-4a29-9c48-ce2dd1f116cf",
    "zonegroups": [
        "us"
    ]
}
```