### PR TITLE
doc: reinstate accidentally removed section header

### DIFF
--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -263,6 +263,8 @@ You can download the RPMs directly from::
 
 .. tip:: For international users: There might be a mirror close to you where download Ceph from. For more information see: `Ceph Mirrors`_.
 
+
+Add Ceph Development
 ====================
 
 Development repositories use the ``autobuild.asc`` key to verify packages.


### PR DESCRIPTION
Accidentally removed in 63be401a411ffc7c2f78e450a29c69eee1af02d3

Signed-off-by: Josh Durgin <jdurgin@redhat.com>