### PR TITLE
osd: clear requeue_scrub_on_unblock flag after requeue scrub

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -9288,8 +9288,10 @@ void ReplicatedPG::kick_object_context_blocked(ObjectContextRef obc)
     objects_blocked_on_snap_promotion.erase(i);
   }
 
-  if (obc->requeue_scrub_on_unblock)
+  if (obc->requeue_scrub_on_unblock) {
+    obc->requeue_scrub_on_unblock = false;
     requeue_scrub();
+  }
 }
 
 SnapSetContext *ReplicatedPG::create_snapset_context(const hobject_t& oid)


### PR DESCRIPTION
We'd better clear requeue_scrub_on_unblock flag after successfully
requeuing scrub, this is for:
  1. if a newly initiated scrub is blocked by objectcontext again,
     reset requeue_scrub_on_unblock to true will be satisfied enough
     to meet such a appeal.
  2. so we don't push pg to the scrub queue when we don't want to
     by accident.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>