### PR TITLE
hammer: Pool quota alarm is not in effect

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3638,8 +3638,8 @@ void OSDMonitor::get_pools_health(
 	detail->push_back(make_pair(HEALTH_WARN, ss.str()));
     }
 
-    float warn_threshold = g_conf->mon_pool_quota_warn_threshold/100;
-    float crit_threshold = g_conf->mon_pool_quota_crit_threshold/100;
+    float warn_threshold = (float)g_conf->mon_pool_quota_warn_threshold/100;
+    float crit_threshold = (float)g_conf->mon_pool_quota_crit_threshold/100;
 
     if (pool.quota_max_objects > 0) {
       stringstream ss;


### PR DESCRIPTION
http://tracker.ceph.com/issues/15478

Fix for:

CID 1297885 (#1 of 2): Result is not floating-point (UNINTENDED_INTEGER_DIVISION)
 integer_division: Dividing integer expressions g_conf->mon_pool_quota_warn_threshold
 and 100, and then converting the integer quotient to type float. Any remainder,
 or fractional part of the quotient, is ignored.

CID 1297885 (#2 of 2): Result is not floating-point (UNINTENDED_INTEGER_DIVISION)
 integer_division: Dividing integer expressions g_conf->mon_pool_quota_crit_threshold
 and 100, and then converting the integer quotient to type float. Any remainder,
  or fractional part of the quotient, is ignored.

Signed-off-by: Danny Al-Gaaf <danny.al-gaaf@bisect.de>