### PR TITLE
osd: allow eviction on non-legacy watched object

### DIFF
--- a/src/osd/Watch.h
+++ b/src/osd/Watch.h
@@ -227,6 +227,7 @@ public:
   entity_name_t get_entity() const { return entity; }
   entity_addr_t get_peer_addr() const { return addr; }
   uint32_t get_timeout() const { return timeout; }
+  bool is_legacy_watch() const { return !will_ping; }
 
   /// Generates context for use if watch timeout is delayed by scrub or recovery
   Context *get_delayed_cb();


### PR DESCRIPTION
For v2 watch, the watchers are disconnected while doing eviction.
Clients can reconnect to the object in the base. This is to support
removing a cache tier on active RBD pools where the RBD image header
is watched by active clients.

Fixes: http://tracker.ceph.com/issues/14865
Signed-off-by: Zhiqiang Wang zhiqiang@xsky.com
