### PR TITLE
test/encoding/readable: use [ for "test" not ((

### DIFF
--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -149,7 +149,7 @@ waitall() { # PID...
          errors=$(($errors + 1))
        fi
      done
-     (("$#" > 0)) || break
+     [ $# -eq 0 ] && break
      sleep ${WAITALL_DELAY:-1}
     done
    [ $errors -eq 0 ]


### PR DESCRIPTION
this also fixes following error in the ubuntu gitbuilder

error: Added files:
+ cat .git/added-files
src/0

where sh points to dash.

Signed-off-by: Kefu Chai <kchai@redhat.com>