### PR TITLE
bufferlist.cc fix typo in output

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -763,7 +763,7 @@ TEST(BufferPtr, copy_out_bench) {
     }
     utime_t end = ceph_clock_now(NULL);
     cout << count << " fills of buffer len " << buflen
-	 << " with " << s << " byte copy_in in "
+	 << " with " << s << " byte copy_out in"
 	 << (end - start) << std::endl;
   }
 }


### PR DESCRIPTION
copy_out_bench needs to say that is has used copy_out

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>