### PR TITLE
doc: adding pg_num to pools documentation

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -266,12 +266,21 @@ You may set values for the following keys:
               
 :Type: Integer
 
+.. _pg_num:
+
+``pg_num``
+
+:Description: The effective number of placement groups to use when calculating 
+              data placement.
+:Type: Integer
+:Valid Range: Superior to ``pg_num`` current value.
+
 .. _pgp_num:
 
 ``pgp_num``
 
-:Description: The effective number of placement groups to use when calculating 
-              data placement.
+:Description: The effective number of placement groups for placement to use 
+              when calculating data placement.
 
 :Type: Integer
 :Valid Range: Equal to or less than ``pg_num``.
@@ -550,6 +559,12 @@ You may get values for the following keys:
 
 :Description: see crash_replay_interval_
               
+:Type: Integer
+
+``pg_num``
+
+:Description: see pg_num_
+
 :Type: Integer
 
 


### PR DESCRIPTION
Current documentation only makes reference to pgp_num to get or set value.
http://docs.ceph.com/docs/hammer/rados/operations/pools/

pg_num documentation already exists here http://docs.ceph.com/docs/master/rados/operations/placement-groups/#set-the-number-of-placement-groups

Had to change pgp_num description to distinguish them.

Signed-off-by: Etienne Menguy <etienne.menguy@corp.ovh.com>