### PR TITLE
rgw: call rgw_log_usage_finalize() on reconfiguration

### DIFF
--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -80,6 +80,10 @@ void RGWRealmReloader::reload()
   frontends->pause();
 
   ldout(cct, 1) << "Frontends paused" << dendl;
+
+  // TODO: make RGWRados responsible for rgw_log_usage lifetime
+  rgw_log_usage_finalize();
+
   // destroy the existing store
   RGWStoreManager::close_storage(store);
   store = nullptr;


### PR DESCRIPTION
RGWRealmReloader was calling rgw_log_usage_init() with the new RGWRados instance, but never cleaned up the previous one with rgw_log_usage_finalize()

Fixes a crash caused by the previous UsageLogger using the RGWRados instance after it was freed by RGWRealmReloader.