### PR TITLE
doc: fix dependencies

### DIFF
--- a/doc_deps.deb.txt
+++ b/doc_deps.deb.txt
@@ -6,3 +6,6 @@ ditaa
 libxml2-dev
 libxslt-dev
 graphviz
+ant
+zlib1g-dev
+cython


### PR DESCRIPTION
Tested on two different new instances.
Debian 7 : ant and cython were missing (zlib1g-dev was installed by default on the image )
Debian 8 : ant, cython and zlib1g-dev were missing
Signed-off-by: Etienne Menguy <etienne.menguy@corp.ovh.com>