### PR TITLE
ceph.spec.in: disable lttng and babeltrace explicitly

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -12,6 +12,11 @@
 %bcond_with selinux
 %endif
 
+# LTTng-UST enabled on Fedora, RHEL/CentOS 6+, and SLES 12
+# (rhel is true for CentOS)
+%if 0%{?fedora} || 0%{?rhel} >= 6 || 0%{?suse_version} == 1315
+%bcond_without lttng
+%endif
 
 %if (0%{?el5} || (0%{?rhel_version} >= 500 && 0%{?rhel_version} <= 600))
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
@@ -43,11 +48,6 @@ restorecon -R /var/log/ceph > /dev/null 2>&1;
 # /var/run/ceph.
 %if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1210
 %global _with_systemd 1
-%endif
-
-# LTTng-UST enabled on Fedora, RHEL 6, and SLES 12
-%if 0%{?fedora} || 0%{?rhel} == 6 || 0%{?suse_version} == 1315
-%global _with_lttng 1
 %endif
 
 #################################################################################
@@ -180,7 +180,7 @@ BuildRequires:  boost-random
 BuildRequires:	python-argparse
 %endif
 # lttng and babeltrace for rbd-replay-prep
-%if 0%{?_with_lttng}
+%if %{with lttng}
 %if 0%{?fedora} || 0%{?rhel}
 BuildRequires:	lttng-ust-devel
 BuildRequires:	libbabeltrace-devel
@@ -585,6 +585,10 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--with-rgw-group=www \
 %endif
 		--with-radosgw \
+%if %{without lttng}
+		--without-lttng \
+		--without-babeltrace \
+%endif
 		$CEPH_EXTRA_CONFIGURE_ARGS \
 		%{?_with_ocf} \
 		%{?_with_tcmalloc} \
@@ -813,7 +817,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/rados-classes/libcls_version.so*
 %dir %{_libdir}/ceph/erasure-code
 %{_libdir}/ceph/erasure-code/libec_*.so*
-%if 0%{?_with_lttng}
+%if %{with lttng}
 %{_libdir}/libos_tp.so*
 %{_libdir}/libosd_tp.so*
 %endif
@@ -874,7 +878,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/rbd-replay
 %{_bindir}/rbd-replay-many
 %{_bindir}/rbdmap
-%if 0%{?_with_lttng}
+%if %{with lttng}
 %{_bindir}/rbd-replay-prep
 %endif
 %{_bindir}/ceph-post-file
@@ -1034,7 +1038,7 @@ fi
 %files -n librados2
 %defattr(-,root,root,-)
 %{_libdir}/librados.so.*
-%if 0%{?_with_lttng}
+%if %{with lttng}
 %{_libdir}/librados_tp.so.*
 %endif
 
@@ -1057,7 +1061,7 @@ fi
 %{_includedir}/rados/rados_types.hpp
 %{_includedir}/rados/memory.h
 %{_libdir}/librados.so
-%if 0%{?_with_lttng}
+%if %{with lttng}
 %{_libdir}/librados_tp.so
 %endif
 
@@ -1089,7 +1093,7 @@ fi
 %files -n librbd1
 %defattr(-,root,root,-)
 %{_libdir}/librbd.so.*
-%if 0%{?_with_lttng}
+%if %{with lttng}
 %{_libdir}/librbd_tp.so.*
 %endif
 
@@ -1109,7 +1113,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_includedir}/rbd/librbd.hpp
 %{_includedir}/rbd/features.h
 %{_libdir}/librbd.so
-%if 0%{?_with_lttng}
+%if %{with lttng}
 %{_libdir}/librbd_tp.so
 %endif
 


### PR DESCRIPTION
before this change, we do not pacakge tracepoint probe shared libraries
on rhel7. but "configure" script enables them if lttng is detected. and
rpm complains at seeing installed but not pacakged files. as EPEL-7 now
includes lttng-ust-devel and libbabeltrace-devel, we'd better
BuildRequire them, and build with them unless disabled otherwise. so in
this change
* make "lttng" an rpm build option enabled by default
* BuildRequire lttng-ust-devel and libbabeltrace-devel if the "lttng"
 "lttng" option is enabled
* --without-lttng --without-babeltrace if the "lttng" option is disabled

Fixes: #14844
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit f1a44907a2f83cb8080cd8ab5980a30306a33fbd)

Conflicts:
	ceph.spec.in