### PR TITLE
test: generate temp pool name in a safer way

### DIFF
--- a/src/test/librados/test.cc
+++ b/src/test/librados/test.cc
@@ -23,12 +23,12 @@ using namespace librados;
 std::string get_temp_pool_name(const std::string &prefix)
 {
   char hostname[80];
-  char out[80];
+  char out[160];
   memset(hostname, 0, sizeof(hostname));
   memset(out, 0, sizeof(out));
   gethostname(hostname, sizeof(hostname)-1);
   static int num = 1;
-  sprintf(out, "%s-%d-%d", hostname, getpid(), num);
+  snprintf(out, sizeof(out), "%s-%d-%d", hostname, getpid(), num);
   num++;
   return prefix + out;
 }


### PR DESCRIPTION
The original purpose of this PR is to solve http://tracker.ceph.com/issues/15492,
but I can not guarantee that at all at this moment since I can't
reproduce http://tracker.ceph.com/issues/15492 in my local testbed.

However, this fix may indeed be one of solution to the above problem.
This is because according to void RadosTestPP::SetUp(), the result of
get_temp_pool_name() may serve as the default namespace of the subset of tests.
On the other hand, the get_temp_pool_name() may return a string with an uncertainty length
once the hostname is over a specific length, which as a result can cause the namespace
of ioctx hit the limitation of osd_max_object_namespace_len, 256 by default.

FWIW, since the current get_temp_pool_name() method may potentiallly encouter
"access violation" error and cause other unconscious failure, it deserves to
be fixed.