### PR TITLE
os: fix typo in LFNIndex.h

### DIFF
--- a/src/os/filestore/LFNIndex.h
+++ b/src/os/filestore/LFNIndex.h
@@ -31,7 +31,7 @@
 
 /**
  * LFNIndex also encapsulates logic for manipulating
- * subdirectories of of a collection as well as the long filename
+ * subdirectories of a collection as well as the long filename
  * logic.
  *
  * The protected methods provide machinery for derived classes to


### PR DESCRIPTION
remove the duplicated "of" in "subdirectories of".

Signed-off-by: Qinghua Jin <qhjin_dev@163.com>