### PR TITLE
os/filestore: add sanity check for stat() syscall

### DIFF
--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -786,6 +786,12 @@ int LFNIndex::lfn_get_name(const vector<string> &path,
       if (hardlink) {
 	struct stat st;
 	r = ::stat(candidate_path.c_str(), &st);
+        if (r < 0) {
+          if (errno == ENOENT)
+            *hardlink = 0;
+          else
+            return -errno;
+        }
 	*hardlink = st.st_nlink;
       }
       return 0;


### PR DESCRIPTION
The syscall stat() may fail here, the hardlink output shall
be assigned a rubbish value as a result and mislead caller.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>