### PR TITLE
mds: FSmap decode fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_PREREQ(2.59)
 # VERSION define is not used by the code.  It gets a version string
 # from 'git describe'; see src/ceph_ver.[ch]
 
-AC_INIT([ceph], [10.1.1], [ceph-devel@vger.kernel.org])
+AC_INIT([ceph], [10.1.2], [ceph-devel@vger.kernel.org])
 
 AX_CXX_COMPILE_STDCXX_11(, mandatory)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ceph (10.1.2-1) stable; urgency=medium
+
+  * New upstream release
+
+ -- Alfredo Deza <adeza@redhat.com>  Tue, 12 Apr 2016 17:42:55 +0000
+
 ceph (10.1.1-1) stable; urgency=medium
 
   * New upstream release

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -440,7 +440,9 @@ void FSMap::decode(bufferlist::iterator& p)
     ::decode(mds_roles, p);
     ::decode(standby_daemons, p);
     ::decode(standby_epochs, p);
-    ::decode(ever_enabled_multiple, p);
+    if (struct_v >= 7) {
+      ::decode(ever_enabled_multiple, p);
+    }
   }
 
   DECODE_FINISH(p);


### PR DESCRIPTION
I left out a struct_v guard when decoding the ever_enabled_multiple boolean in FSMap. Add it!