### PR TITLE
rgw: return 503 for requests when master zone is down

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -180,6 +180,7 @@ using ceph::crypto::MD5;
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
 #define ERR_NOT_IMPLEMENTED      2201
+#define ERR_SERVICE_UNAVAILABLE  2202
 
 #ifndef UINT32_MAX
 #define UINT32_MAX (0xffffffffu)

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -121,7 +121,7 @@ int RGWHTTPClient::process(const char *method, const char *url)
 
   CURLcode status = curl_easy_perform(curl_handle);
   if (status) {
-    dout(0) << "curl_easy_perform returned error: " << error_buf << dendl;
+    dout(0) << "curl_easy_perform returned status " << status << " error: " << error_buf << dendl;
     ret = -EINVAL;
   }
   curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_status);

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -67,6 +67,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ERR_LOCKED, 423, "Locked" },
     { ERR_INTERNAL_ERROR, 500, "InternalError" },
     { ERR_NOT_IMPLEMENTED, 501, "NotImplemented" },
+    { ERR_SERVICE_UNAVAILABLE, 503, "ServiceUnavailable"}
 };
 
 const static struct rgw_http_errors RGW_HTTP_SWIFT_ERRORS[] = {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1928,8 +1928,9 @@ void RGWCreateBucket::execute()
   if (!store->is_meta_master()) {
     JSONParser jp;
     op_ret = forward_request_to_master(s, NULL, store, in_data, &jp);
-    if (op_ret < 0)
+    if (op_ret < 0) {
       return;
+    }
 
     JSONDecoder::decode_json("entry_point_object_ver", ep_objv, &jp);
     JSONDecoder::decode_json("object_ver", objv, &jp);

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -292,8 +292,13 @@ int RGWRESTSimpleRequest::forward_request(RGWAccessKey& key, req_info& info, siz
   }
 
   int r = process(new_info.method, new_url.c_str());
-  if (r < 0)
+  if (r < 0){
+    if (r == -EINVAL){
+      // curl_easy has errored, generally means the service is not available
+      r = -ERR_SERVICE_UNAVAILABLE;
+    }
     return r;
+  }
 
   response.append((char)0); /* NULL terminate response */
 


### PR DESCRIPTION
This patch basically tries to return 503 Service Unavailable when `forward_request_to_master` fails during bucket create, we currently return 400 Invalid Argument which is wrong, as this is more of a server side error than a client side improper request. Following are the changes

1.Adding a HTTP Error Code for 503
2.Printing the curl_easy_perform error code too along with status 
3. Bailing out when forward request to master fails and returning a service unavailable

Posting this for review, I'm still confused on 3 on whether  we return 503s for general failures of forward_request_to_master itself or should we make the rest_client handle when process request fails with an -EINVAL and return 503 there

Fixes: http://tracker.ceph.com/issues/15501

