### PR TITLE
mds: stopping member of mds-daemon never correctly set

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1104,6 +1104,10 @@ void MDSDaemon::suicide()
 {
   assert(mds_lock.is_locked());
 
+  // make sure we don't suicide twice
+  assert(stopping == false);
+  stopping = true;
+
   dout(1) << "suicide.  wanted state "
           << ceph_mds_state_name(beacon.get_want_state()) << dendl;
 

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -541,6 +541,9 @@ int MDSDaemon::init(MDSMap::DaemonState wanted_state)
   mds_lock.Lock();
   if (beacon.get_want_state() == MDSMap::STATE_DNE) {
     suicide();  // we could do something more graceful here
+    dout(4) << __func__ << ": terminated already, dropping out" << dendl;
+    mds_lock.Unlock();
+    return 0;
   }
 
   timer.init();
@@ -560,6 +563,8 @@ int MDSDaemon::init(MDSMap::DaemonState wanted_state)
       // uh-oh, must specify one or the other!
       dout(0) << "Specified oneshot replay mode but not an MDS!" << dendl;
       suicide();
+      mds_lock.Unlock();
+      return -EINVAL;
     }
     standby_type = wanted_state;
     wanted_state = MDSMap::STATE_BOOT;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -662,7 +662,10 @@ void MDSRank::_advance_queues()
       old->put();
     } else {
       dout(7) << " processing laggy deferred " << *old << dendl;
-      handle_deferrable_message(old);
+      if(!handle_deferrable_message(old)) {
+        dout(0) << "unrecognized message " << *old << dendl;
+        old->put();
+      }
     }
 
     heartbeat_reset();


### PR DESCRIPTION
Also 
1. make a quick exit if we decide to suicide()
2. fix a potential message residual