### PR TITLE
osd/ReplicatedPG: fix implementation of register_on_success()

### DIFF
--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -567,7 +567,7 @@ public:
     }
     template <typename F>
     void register_on_success(F &&f) {
-      on_finish.emplace_back(std::move(f));
+      on_success.emplace_back(std::move(f));
     }
     template <typename F>
     void register_on_applied(F &&f) {


### PR DESCRIPTION
We shall push the callbacks into on_success instead, I think.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>