### PR TITLE
mailmap: Abhishek Lekshmanan affiliation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,8 +7,8 @@
 #
 #
 Aaron Bassett <abassett@gmail.com>
-Abhishek Lekshmanan <abhishek.lekshmanan@ril.com> <abhishek.lekshmanan@gmail.com>
 Abhishek Lekshmanan <abhishek@suse.com> <alekshmanan@suse.com>
+Abhishek Lekshmanan <abhishek@suse.com> <abhishek.lekshmanan@gmail.com>
 Adam C. Emerson <aemerson@redhat.com>
 Adam Twardowski <adam.twardowski@gmail.com>
 Ahoussi Armand <ahoussi.say@telecom-bretagne.eu> <delco225>


### PR DESCRIPTION
Adding an entry to normalize the personal email id and work email id (As reviews/and commits assoc'ed with gmail still got normalized to previous email)
