### PR TITLE
[DNM] hammer: build/ops: include rocksdb sources in make dist

### DIFF
--- a/src/Makefile-rocksdb.am
+++ b/src/Makefile-rocksdb.am
@@ -1,3 +1,6 @@
+
+## include rocksdb sources no matter what current build options are
+DIST_SUBDIRS += rocksdb
 if WITH_SLIBROCKSDB
   SUBDIRS += rocksdb
 else


### PR DESCRIPTION
make dist does not recurse into SUBDIRS if DIST_SUBDIRS are defined.
As a result rocksdb source was missing in the tarball if the source
has been configured --with-librocksdb-static. Unconditionally add
rocksdb to DIST_SUBDIRS to avoid the problem. As a side effect files
rocksdb's configure script, Makefile.in, and various autoconf/libtool
bits are also included in the dist tarball.

Signed-off-by: Alexey Sheplyakov asheplyakov@mirantis.com
