### PR TITLE
OSD:memory leak in ReplicatedPG.cc

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3241,14 +3241,6 @@ ReplicatedPG::RepGather *ReplicatedPG::trim_object(const hobject_t &coid)
     return NULL;
   }
 
-  RepGather *repop = simple_repop_create(obc);
-  OpContext *ctx = repop->ctx;
-  ctx->snapset_obc = snapset_obc;
-  ctx->lock_to_release = OpContext::W_LOCK;
-  ctx->release_snapset_obc = true;
-  ctx->at_version = get_next_version();
-
-  PGBackend::PGTransaction *t = ctx->op_t;
   set<snapid_t> new_snaps;
   for (set<snapid_t>::iterator i = old_snaps.begin();
        i != old_snaps.end();
@@ -3272,6 +3264,15 @@ ReplicatedPG::RepGather *ReplicatedPG::trim_object(const hobject_t &coid)
       osd->clog->error() << __func__ << " Snap " << coid.snap << " not in clones" << "\n";
       return NULL;
     }
+
+    RepGather *repop = simple_repop_create(obc);
+    OpContext *ctx = repop->ctx;
+    ctx->snapset_obc = snapset_obc;
+    ctx->lock_to_release = OpContext::W_LOCK;
+    ctx->release_snapset_obc = true;
+    ctx->at_version = get_next_version();
+
+    PGBackend::PGTransaction *t = ctx->op_t;
 
     ctx->delta_stats.num_bytes -= snapset.get_clone_bytes(last);
 


### PR DESCRIPTION
"return NULL" in "if (p == snapset.clones.end())" can not free the memory of "*repop"

Signed-off-by: Yongqiang He <he.yongqiang@h3c.com>