### PR TITLE
ceph.spec.in: terminate if statement in %pre scriptlet

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1040,6 +1040,7 @@ if ! getent passwd ceph >/dev/null ; then
     CEPH_USER_ID_OPTION=""
     getent passwd $CEPH_USER_ID >/dev/null || CEPH_USER_ID_OPTION="-u $CEPH_USER_ID"
     useradd ceph $CEPH_USER_ID_OPTION -r -g ceph -s /sbin/nologin -c "Ceph daemons" -d %{_localstatedir}/lib/ceph 2>/dev/null || :
+fi
 %endif
 exit 0
 


### PR DESCRIPTION
One of the if statements in the ceph-common %pre scriptlet was not properly
terminated.

Signed-off-by: Nathan Cutler <ncutler@suse.com>