### PR TITLE
xio: add log prefix for log prints outside the XioMessenger class

### DIFF
--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -26,6 +26,8 @@
 #include "messages/MNop.h"
 
 #define dout_subsys ceph_subsys_xio
+#undef dout_prefix
+#define dout_prefix *_dout << "xio."
 
 Mutex mtx("XioMessenger Package Lock");
 atomic_t initialized;


### PR DESCRIPTION
Signed-off-by: Roi Dayan <roid@mellanox.com>