### PR TITLE
image_watcher/Notifier: remove header file

### DIFF
--- a/src/librbd/image_watcher/Notifier.h
+++ b/src/librbd/image_watcher/Notifier.h
@@ -5,7 +5,7 @@
 #define CEPH_LIBRBD_IMAGE_WATCHER_NOTIFIER_H
 
 #include "include/int_types.h"
-#include "include/buffer.h"
+#include "include/buffer_fwd.h"
 #include "include/Context.h"
 #include "common/Mutex.h"
 #include <list>


### PR DESCRIPTION
Remove inclusion of buffer.h and instead just include forward
declaration header - buffer_fwd.h

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>