### PR TITLE
cls_rbd: fix loop condition when listing image metadata

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -2563,10 +2563,13 @@ int metadata_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     for (; it != raw_data.end(); ++it)
       data[metadata_name_from_key(it->first)].swap(it->second);
 
+    if (r < max_read)
+      break;
+
     last_read = raw_data.rbegin()->first;
     if (max_return)
       max_read = MIN(RBD_MAX_KEYS_READ, max_return-data.size());
-  } while (max_return && max_read);
+  } while (max_read);
 
   ::encode(data, *out);
   return 0;

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -2525,7 +2525,7 @@ static const string metadata_name_from_key(const string &key)
  * Input:
  * @param start_after which name to begin listing after
  *        (use the empty string to start at the beginning)
- * @param max_return the maximum number of names to lis(if 0 means no limit)
+ * @param max_return the maximum number of names to list(if 0 means no limit)
 
  * Output:
  * @param value
@@ -2568,7 +2568,7 @@ int metadata_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 
     last_read = raw_data.rbegin()->first;
     if (max_return)
-      max_read = MIN(RBD_MAX_KEYS_READ, max_return-data.size());
+      max_read = MIN(RBD_MAX_KEYS_READ, max_return - data.size());
   } while (max_read);
 
   ::encode(data, *out);


### PR DESCRIPTION
if `max_return` is 0 (i.e., the rbd client wants to list all metadata of the
image), then we should not use `max_return` as a part of the loop
condition
and there is also a small typo fix

Signed-off-by: runsisi <runsisi@zte.com.cn>