### PR TITLE
osd/ReplicatedPG: allow CMPXATTR ops to trigger side effects too

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2987,7 +2987,7 @@ void ReplicatedPG::execute_ctx(OpContext *ctx)
   // read or error?
   if (ctx->op_t->empty() || result < 0) {
     // finish side-effects
-    if (result == 0)
+    if (result >= 0)
       do_osd_op_effects(ctx, m->get_connection());
 
     if (ctx->pending_async_reads.empty()) {


### PR DESCRIPTION
This is for:
1. during the do_osd_ops() process, it may return 1 when processing
a CEPH_OSD_OP_CMPXATTR/CEPH_OSD_OP_SRC_CMPXATTR message to indicate
that the comparison result is positive. Therefore, the do_osd_ops()
method may also be able to return a value which is bigger than 0.
2. the ReplicatedPG::execute_ctx() method will try to catch any non-modify
operations and trigger do_osd_op_effects() on success, as below:
```
    // read or error?
    if (ctx->op_t->empty() || result < 0)
    {
        // finish side-effects
        if (result == 0)
            do_osd_op_effects(ctx, m->get_connection());
```
Thus we may don't call do_osd_op_effects() as expected if result is bigger
than 0 and op is not write.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>