### PR TITLE
osd/ReplicatedBackend: fix potential memory leak

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -285,7 +285,7 @@ void ReplicatedBackend::objects_read_async(
   for (list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
 		 pair<bufferlist*, Context*> > >::const_iterator i =
 	   to_read.begin();
-       i != to_read.end() && r >= 0;
+       i != to_read.end();
        ++i) {
     int _r = store->read(ch, ghobject_t(hoid), i->first.get<0>(),
 			 i->first.get<1>(), *(i->second.first),
@@ -295,7 +295,7 @@ void ReplicatedBackend::objects_read_async(
 	get_parent()->bless_gencontext(
 	  new AsyncReadCallback(_r, i->second.second)));
     }
-    if (_r < 0)
+    if (_r < 0 && r == 0)
       r = _r;
   }
   get_parent()->schedule_recovery_work(


### PR DESCRIPTION
During ```ReplicatedBackend::objects_read_async()```, we may gather multiple
asynchronous read requests in one single run, and may encounter some error on the
intermediate read. We can't just quit as we may leave the callbacks of the
residual read requests hanging, which turns out to cause memory leaks.

This pr solves the above problem by ignoring any reading error if it is
still tolerable, otherwise we simply crash. Therefore in neither way we will
cause memory leaks.

P.S currently we always fill in an extent of asynchronous read with a callback,
see below(```ReplicatedPG::do_osd_ops()```):
```
 ctx->pending_async_reads.push_back(
   make_pair(
   boost::make_tuple(op.extent.offset, op.extent.length, op.flags),
   make_pair(&osd_op.outdata,
   new FillInVerifyExtent(&op.extent.length, &osd_op.rval,
   &osd_op.outdata, maybe_crc, oi.size, osd,
   soid, op.flags))));
```
or
```
  ctx->pending_async_reads.push_back(
    make_pair(
    boost::make_tuple(op.extent.offset, op.extent.length, op.flags),
    make_pair(&osd_op.outdata, new ToSparseReadResult(osd_op.outdata,
    op.extent.length))));
```
That's why we need this change.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>