### PR TITLE
test: set a default $CEPH_ROOT env variable

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
+source $(dirname $0)/../ceph-helpers.sh
 
 set -e
 set -o functrace

--- a/src/test/cephtool-test-mds.sh
+++ b/src/test/cephtool-test-mds.sh
@@ -15,6 +15,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Library Public License for more details.
 #
+CEPH_ROOT=${CEPH_ROOT:-..}
+
 CEPH_CLI_TEST_DUP_COMMAND=1 \
 MDS=1 MON=1 OSD=3 CEPH_START='mon osd mds' CEPH_PORT=7200 $CEPH_ROOT/src/test/vstart_wrapper.sh \
     $CEPH_ROOT/qa/workunits/cephtool/test.sh \

--- a/src/test/cephtool-test-mon.sh
+++ b/src/test/cephtool-test-mon.sh
@@ -15,6 +15,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Library Public License for more details.
 #
+CEPH_ROOT=${CEPH_ROOT:-..}
+
 CEPH_CLI_TEST_DUP_COMMAND=1 \
 # uses CEPH_PORT going from 7202 7203 and 7204 because
 # it starts at 7202 and runs 3 mons (see vstart.sh)

--- a/src/test/cephtool-test-osd.sh
+++ b/src/test/cephtool-test-osd.sh
@@ -15,6 +15,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Library Public License for more details.
 #
+CEPH_ROOT=${CEPH_ROOT:-..}
+
 CEPH_CLI_TEST_DUP_COMMAND=1 \
 MON=1 OSD=3 CEPH_START='mon osd' CEPH_PORT=7201 $CEPH_ROOT/src/test/vstart_wrapper.sh \
     $CEPH_ROOT/qa/workunits/cephtool/test.sh \


### PR DESCRIPTION
in cf24535, we use $CEPH_ROOT to specify the $top_srcdir to unify
cmake and autotools, but this breaks ceph-qa-suite/tasks/workunit.py,
as it only clones the necessary qa/workunits directory, and does not
pass $CEPH_ROOT to the test scripts. so we need to set a default
$CEPH_ROOT if it is not set.

Signed-off-by: Kefu Chai <kchai@redhat.com>