### PR TITLE
rgw: forward delete bucket to master before deleting them in a zone

### DIFF
--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -153,6 +153,8 @@ static inline int rgw_http_error_to_errno(int http_err)
         return -EACCES;
     case 404:
         return -ENOENT;
+    case 409:
+        return -ENOTEMPTY;
     default:
         return -EIO;
   }


### PR DESCRIPTION
- `rgw_http_errors.h`- add an entry for -ENOTEMTPY, we currently return a 500 if forward_request returns a 409 as we dont have an entry for it 
- forward delete bucket requests to master before deleting them locally
 
Fixes: http://tracker.ceph.com/issues/15540

