### PR TITLE
rgw-rest: remove redundant virtual functions

### DIFF
--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -391,14 +391,6 @@ public:
 
   virtual RGWOp* get_op(RGWRados* store);
   virtual void put_op(RGWOp* op);
-
-  virtual int retarget(RGWOp* op, RGWOp** new_op) {
-    *new_op = op;
-    return 0;
-  }
-
-  virtual int authorize() = 0;
-  // virtual int postauth_init(struct req_init_state *t) = 0;
 };
 
 class RGWHandler_REST_SWIFT;

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -468,10 +468,6 @@ public:
     return RGW_Auth_S3::authorize(store, s);
   }
   int postauth_init();
-  virtual int retarget(RGWOp *op, RGWOp **new_op) {
-    *new_op = op;
-    return 0;
-  }
 };
 
 class RGWHandler_REST_Service_S3 : public RGWHandler_REST_S3 {


### PR DESCRIPTION
'virtual int retarget()' is already declared and defined in the
RGWHandler base class. RGWHandler_REST and RGWHandler_REST_S3 inherit
accordingly also the purely virtual functions 'virtual int authorize()'
and 'virtual int postauth_init()'.

Signed-off-by: Karol Mroz <kmroz@suse.com>