### PR TITLE
librbd: put the validation of image snap context earlier

### DIFF
--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -245,6 +245,12 @@ Context *RefreshRequest<I>::handle_v2_get_mutable_metadata(int *result) {
     return m_on_finish;
   }
 
+  if (!m_snapc.is_valid()) {
+    lderr(cct) << "image snap context is invalid!" << dendl;
+    *result = -EIO;
+    return m_on_finish;
+  }
+
   send_v2_get_flags();
   return nullptr;
 }
@@ -349,12 +355,6 @@ Context *RefreshRequest<I>::handle_v2_get_snapshots(int *result) {
   } else if (*result < 0) {
     lderr(cct) << "failed to retrieve snapshots: " << cpp_strerror(*result)
                << dendl;
-    return m_on_finish;
-  }
-
-  if (!m_snapc.is_valid()) {
-    lderr(cct) << "image snap context is invalid!" << dendl;
-    *result = -EIO;
     return m_on_finish;
   }
 


### PR DESCRIPTION
we'd better validate the snap context right after we got the mutable
metadata before we could go any further

Signed-off-by: runsisi <runsisi@zte.com.cn>