### PR TITLE
os/bluestore/NVMEDevice: Remove the duplicated code.

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -26,16 +26,8 @@
 #include <xmmintrin.h>
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <spdk/pci.h>
 #include <spdk/nvme.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #include <rte_config.h>
 #include <rte_cycles.h>


### PR DESCRIPTION
In spdk/pci.h spdk/nvme.h, it alread contain those code:
extern "C" {
 So remove the duplicated code.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>