### PR TITLE
tools: remove installation for distribute. It is no longer maintained

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -66,7 +66,7 @@ CentOS|Fedora|RedHatEnterpriseServer)
                     $SUDO yum install subscription-manager
                     $SUDO subscription-manager repos --enable=rhel-$MAJOR_VERSION-server-optional-rpms
                 fi
-                $SUDO yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/$MAJOR_VERSION/x86_64/ 
+                $SUDO yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/$MAJOR_VERSION/x86_64/
                 $SUDO yum install --nogpgcheck -y epel-release
                 $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
@@ -92,8 +92,6 @@ function populate_wheelhouse() {
     local install=$1
     shift
 
-    # Ubuntu-12.04 and Python 2.7.3 require this line
-    pip --timeout 300 $install 'distribute >= 0.7.3' || return 1
     # although pip comes with virtualenv, having a recent version
     # of pip matters when it comes to using wheel packages
     pip --timeout 300 $install 'setuptools >= 0.8' 'pip >= 7.0' 'wheel >= 0.24' || return 1

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -26,7 +26,7 @@ pip --log $DIR/log.txt install --upgrade 'pip >= 6.1'
 if test -d wheelhouse ; then
     export NO_INDEX=--no-index
 fi
-pip --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse --upgrade distribute
+
 pip --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9'
 if test -f requirements.txt ; then
     pip --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse -r requirements.txt


### PR DESCRIPTION
It is also breaking Jenkins:

https://jenkins.ceph.com/job/ceph-build/ARCH=arm64,DIST=xenial,MACHINE_SIZE=huge/92/consoleFull

    Building wheels for collected packages: distribute
      Running setup.py bdist_wheel for distribute: started
      Running setup.py bdist_wheel for distribute: finished with status 'error'
      Complete output from command /tmp/ceph-detect-init-virtualenv/bin/python2.7 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-PENKkf/distribute/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /tmp/tmpPTw4_wpip-wheel- --python-tag cp27:
      Traceback (most recent call last):
        File "<string>", line 1, in <module>
        File "/tmp/pip-build-PENKkf/distribute/setup.py", line 58, in <module>
          setuptools.setup(**setup_params)
        File "/usr/lib/python2.7/distutils/core.py", line 137, in setup
          ok = dist.parse_command_line()
        File "setuptools/dist.py", line 276, in parse_command_line
          result = _Distribution.parse_command_line(self)
        File "/usr/lib/python2.7/distutils/dist.py", line 467, in parse_command_line
          args = self._parse_command_opts(parser, args)
        File "setuptools/dist.py", line 602, in _parse_command_opts
          nargs = _Distribution._parse_command_opts(self, parser, args)
        File "/usr/lib/python2.7/distutils/dist.py", line 523, in _parse_command_opts
          cmd_class = self.get_command_class(command)
        File "setuptools/dist.py", line 406, in get_command_class
          ep.require(installer=self.fetch_build_egg)
        File "pkg_resources.py", line 2254, in require
          working_set.resolve(self.dist.requires(self.extras),env,installer)))
        File "pkg_resources.py", line 2471, in requires
          dm = self._dep_map
        File "pkg_resources.py", line 2682, in _dep_map
          self.__dep_map = self._compute_dependencies()
        File "pkg_resources.py", line 2699, in _compute_dependencies
          from _markerlib import compile as compile_marker
      ImportError: No module named _markerlib
      
      ----------------------------------------
      Failed building wheel for distribute
      Running setup.py clean for distribute

distribute was a fork of setuptools and it is no longer maintained and it is currently deprecated in favor of setuptools: https://pythonhosted.org/distribute/

There is no reason why code would need to ensure that the "latest" distribute is installed with:

    pip --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse --upgrade distribute

distribute's last upload was in 2013. That upload was to provide "... a simple compatibility layer that installs Setuptools 0.7+."

https://pypi.python.org/pypi/distribute/0.7.3