### PR TITLE
tools/rados: fix "Floating point exception" if  objectsize smaller than  blocksize when do write-bench.

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2758,6 +2758,8 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     }
     if (!object_size)
       object_size = op_size;
+    else if (object_size < op_size)
+      op_size = object_size;
     ret = bencher.aio_bench(operation, seconds,
 			    concurrent_ios, op_size, object_size,
 			    max_objects, cleanup, run_name, no_verify);


### PR DESCRIPTION
…an blocksize when do write-bench.

When do write-bench, if objectsize is smaller than blocksize. It will
casue "Floating point exception".
This because in bjBencher::write_bench:
>>if (data.op_size)
>>    writes_per_object = data.object_size / data.op_size;
  It make writes_per_object = 0;
......
>> name[i] = generate_object_name(i / writes_per_object);
  i/0 cause Floating point exception.

If objectsize is smaller than blocksize, make blocksize is eqaul
objectsize.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>