### PR TITLE
doc: fix broken link to monitor quorum

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -93,7 +93,7 @@ and `Monitoring OSDs and PGs`_ for additional details.
 Monitor Quorum
 --------------
 
-Our Getting Started section provides a trivial `Ceph configuration file`_ that
+Our Configuring ceph section provides a trivial `Ceph configuration file`_ that
 provides for one monitor in the test cluster. A cluster will run fine with a
 single monitor; however, **a single monitor is a single-point-of-failure**. To
 ensure high availability in a production Ceph Storage Cluster, you should run
@@ -866,7 +866,7 @@ Miscellaneous
 
 .. _Paxos: http://en.wikipedia.org/wiki/Paxos_(computer_science)
 .. _Monitor Keyrings: ../../operations/authentication#monitor-keyrings
-.. _Ceph configuration file: ../../../start/quick-start/#add-a-configuration-file
+.. _Ceph configuration file: ../ceph-conf/#monitors
 .. _Network Configuration Reference: ../network-config-ref
 .. _ACID: http://en.wikipedia.org/wiki/ACID
 .. _Adding/Removing a Monitor: ../../operations/add-or-rm-mons


### PR DESCRIPTION
Link pointing in Monitor Quorum section to
ceph configuration file was broken.
Fixing it to point to configuration section.

Signed-off-by: Yatin Kumbhare yatinkumbhare@gmail.com