### PR TITLE
xio: add MNop.h to dist tarball

### DIFF
--- a/src/messages/Makefile.am
+++ b/src/messages/Makefile.am
@@ -123,5 +123,6 @@ noinst_HEADERS += \
 	messages/MStatfsReply.h \
 	messages/MTimeCheck.h \
 	messages/MWatchNotify.h \
-	messages/PaxosServiceMessage.h
+	messages/PaxosServiceMessage.h \
+	messages/MNop.h
 


### PR DESCRIPTION
This file is needed when we want to build a package with xio messenger
but was not added to dist tarball.

Signed-off-by: Roi Dayan <roid@mellanox.com>