### PR TITLE
librbd: fix potential double free of SetSnapRequest instance

### DIFF
--- a/src/librbd/image/SetSnapRequest.cc
+++ b/src/librbd/image/SetSnapRequest.cc
@@ -60,8 +60,8 @@ void SetSnapRequest<I>::send_init_exclusive_lock() {
     int r = 0;
     if (send_refresh_parent(&r) != nullptr) {
       send_complete();
-      return;
     }
+    return;
   }
 
   CephContext *cct = m_image_ctx.cct;


### PR DESCRIPTION
if image feature `EXCLUSIVE_LOCK` is not enabled we should not try to
initialize the exclusive lock, or we may end with two async Contexts
to finish the same `SetSnapRequest` instance

Signed-off-by: runsisi <runsisi@zte.com.cn>