### PR TITLE
rbd: check value of rbd_cache when setting image-meta

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2627,6 +2627,14 @@ remove_mirroring_image:
   int metadata_set(ImageCtx *ictx, const string &key, const string &value)
   {
     CephContext *cct = ictx->cct;
+    string start = ictx->METADATA_CONF_PREFIX;
+    size_t conf_prefix_len = start.size();
+
+    if(key.size() > conf_prefix_len && !key.compare(0,conf_prefix_len,start)) {
+      string subkey = key.substr(conf_prefix_len,key.size()-conf_prefix_len);
+      return cct->_conf->set_val(subkey.c_str(),value);
+    }
+
     ldout(cct, 20) << "metadata_set " << ictx << " key=" << key << " value=" << value << dendl;
 
     int r = ictx->state->refresh_if_required();

--- a/src/tools/rbd/action/ImageMeta.cc
+++ b/src/tools/rbd/action/ImageMeta.cc
@@ -233,6 +233,13 @@ int execute_set(const po::variables_map &vm) {
     return -EINVAL;
   }
 
+  if ((key.compare("rbd_cache") == 0) || (key.compare("rbd_cache_writethrough_until_flush") == 0)) {
+    if ((value.compare("true") != 0) && (key.compare("false") != 0)) {
+      std::cerr << "rbd: rbd_cache or rbd_cache_writethrough_until_flush must be true or false" << std::endl;
+      return -EINVAL;
+    }
+  }
+
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;

--- a/src/tools/rbd/action/ImageMeta.cc
+++ b/src/tools/rbd/action/ImageMeta.cc
@@ -233,13 +233,6 @@ int execute_set(const po::variables_map &vm) {
     return -EINVAL;
   }
 
-  if ((key.compare("rbd_cache") == 0) || (key.compare("rbd_cache_writethrough_until_flush") == 0)) {
-    if ((value.compare("true") != 0) && (key.compare("false") != 0)) {
-      std::cerr << "rbd: rbd_cache or rbd_cache_writethrough_until_flush must be true or false" << std::endl;
-      return -EINVAL;
-    }
-  }
-
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/15522

eg.
rbd image-meta set zzq/rbd1 rbd_cache_writethrough_until_flush 512
rbd image-meta set zzq/rbd1 rbd_cache 1024
rbd_cache_writethrough_until_flush and rbd_cache should accept only true and false

Signed-off-by: zeqiang zhuang <zhuang.zeqiang@h3c.com>