### PR TITLE
librados: copy out data to users' buffer for xio

### DIFF
--- a/src/librados/AioCompletionImpl.h
+++ b/src/librados/AioCompletionImpl.h
@@ -42,6 +42,7 @@ struct librados::AioCompletionImpl {
   bool is_read;
   bufferlist bl;
   bufferlist *blp;
+  char *out_buf;
 
   IoCtxImpl *io;
   ceph_tid_t aio_write_seq;
@@ -55,7 +56,7 @@ struct librados::AioCompletionImpl {
 			callback_safe(0),
 			callback_complete_arg(0),
 			callback_safe_arg(0),
-			is_read(false), blp(NULL),
+			is_read(false), blp(nullptr), out_buf(nullptr),
 			io(NULL), aio_write_seq(0), aio_write_list_item(this) { }
 
   int set_complete_callback(void *cb_arg, rados_callback_t cb) {

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -808,6 +808,7 @@ int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
   c->bl.clear();
   c->bl.push_back(buffer::create_static(len, buf));
   c->blp = &c->bl;
+  c->out_buf = buf;
 
   Objecter::Op *o = objecter->prepare_read_op(
     oid, oloc,
@@ -1630,6 +1631,8 @@ void librados::IoCtxImpl::C_aio_Ack::finish(int r)
   c->cond.Signal();
 
   if (r == 0 && c->blp && c->blp->length() > 0) {
+    if (c->out_buf && !c->blp->is_provided_buffer(c->out_buf))
+      c->blp->copy(0, c->blp->length(), c->out_buf);
     c->rval = c->blp->length();
   }
 


### PR DESCRIPTION
rados_aio_read(buf) call objecter->read(). Upon receiving
reply from osd, message->claim_data() is called which
enforces *deep* copy (both bufferlist and data buffers)
because Accelio's registered buffers is NON_SHAREABLE.
Received data is on new bufferlist and buffers but not
in original buffer provided by rados_aio_read() caller.
Another copy to users' buffer is needed

Signed-off-by: Vu Pham <vu@mellanox.com>