### PR TITLE
rgw: check for status >= 0

### DIFF
--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -692,7 +692,7 @@ int RGWRESTStreamRWRequest::get_resource(RGWAccessKey& key, map<string, string>&
 int RGWRESTStreamRWRequest::complete(string& etag, real_time *mtime, map<string, string>& attrs)
 {
   set_str_from_headers(out_headers, "ETAG", etag);
-  if (status > 0 && mtime) {
+  if (status >= 0 && mtime) {
     string mtime_str;
     set_str_from_headers(out_headers, "RGWX_MTIME", mtime_str);
     if (!mtime_str.empty()) {


### PR DESCRIPTION
Fixes: #15565

check only verified that status was > 0, so we ended not updating mtime for
the target object. This resulted in a continuous sync of objects.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>