### PR TITLE
osd/PG: PG is only likely to go active when min_size turns smaller.

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7531,8 +7531,8 @@ boost::statechart::result PG::RecoveryState::Incomplete::react(const AdvMap &adv
   PG *pg = context< RecoveryMachine >().pg;
   int64_t poolnum = pg->info.pgid.pool();
 
-  // Reset if min_size changed, pg might now be able to go active
-  if (advmap.lastmap->get_pools().find(poolnum)->second.min_size !=
+  // Reset if min_size turn smaller than previous value, pg might now be able to go active
+  if (advmap.lastmap->get_pools().find(poolnum)->second.min_size >
       advmap.osdmap->get_pools().find(poolnum)->second.min_size) {
     post_event(advmap);
     return transit< Reset >();


### PR DESCRIPTION
PG: PG is only likely to go active when min_size turns smaller.
Signed-off-by: wuxingyi <wuxingyi@letv.com>