### PR TITLE
 mds: dispatch assert cleanup

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -98,7 +98,8 @@ void Locker::dispatch(Message *m)
     break;
     
   default:
-    assert(0);
+    derr << "locker unknown message " << m->get_type() << dendl;
+    assert(0 == "locker unknown message");
   }
 }
 

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -58,10 +58,8 @@ int MDBalancer::proc_message(Message *m)
     break;
 
   default:
-    dout(1) << " balancer unknown message " << m->get_type() << dendl;
-    assert(0);
-    m->put();
-    break;
+    derr << " balancer unknown message " << m->get_type() << dendl;
+    assert(0 == "balancer unknown message");
   }
 
   return 0;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7624,10 +7624,8 @@ void MDCache::dispatch(Message *m)
     break;
     
   default:
-    dout(7) << "cache unknown message " << m->get_type() << dendl;
-    assert(0);
-    m->put();
-    break;
+    derr << "cache unknown message " << m->get_type() << dendl;
+    assert(0 == "cache unknown message");
   }
 }
 

--- a/src/mds/MDSTableClient.cc
+++ b/src/mds/MDSTableClient.cc
@@ -127,7 +127,7 @@ void MDSTableClient::handle_request(class MMDSTableRequest *m)
     break;
 
   default:
-    assert(0);
+    assert(0 == "unrecognized mds_table_client request op");
   }
 
   m->put();

--- a/src/mds/MDSTableServer.cc
+++ b/src/mds/MDSTableServer.cc
@@ -33,7 +33,7 @@ void MDSTableServer::handle_request(MMDSTableRequest *req)
   case TABLESERVER_OP_PREPARE: return handle_prepare(req);
   case TABLESERVER_OP_COMMIT: return handle_commit(req);
   case TABLESERVER_OP_ROLLBACK: return handle_rollback(req);
-  default: assert(0);
+  default: assert(0 == "unrecognized mds_table_server request op");
   }
 }
 

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -145,7 +145,8 @@ void Migrator::dispatch(Message *m)
     break;
 
   default:
-    assert(0);
+    derr << "migrator unknown message " << m->get_type() << dendl;
+    assert(0 == "migrator unknown message");
   }
 }
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -194,10 +194,10 @@ void Server::dispatch(Message *m)
   case MSG_MDS_SLAVE_REQUEST:
     handle_slave_request(static_cast<MMDSSlaveRequest*>(m));
     return;
+  default:
+    derr << "server unknown message " << m->get_type() << dendl;
+    assert(0 == "server unknown message");  
   }
-
-  dout(1) << "server unknown message " << m->get_type() << dendl;
-  assert(0);
 }
 
 


### PR DESCRIPTION
fixed dispatch in the default branch.
    include:
    mdcache->dispatch(m);
    mdcache->migrator->dispatch(m);
    server->dispatch(m);
    balancer->proc_message(m);
    locker->dispatch(m);
    client->handle_request(req);
    server->handle_request(req);

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>