### PR TITLE
rbd: help message distinction between commands and aliases

### DIFF
--- a/src/tools/rbd/Shell.h
+++ b/src/tools/rbd/Shell.h
@@ -57,12 +57,12 @@ private:
   void get_command_spec(const std::vector<std::string> &arguments,
                         std::vector<std::string> *command_spec);
   Action *find_action(const CommandSpec &command_spec,
-                      CommandSpec **matching_spec);
+                      CommandSpec **matching_spec, bool *is_alias);
 
   void get_global_options(boost::program_options::options_description *opts);
 
   void print_help();
-  void print_action_help(Action *action);
+  void print_action_help(Action *action, bool is_alias);
   void print_unknown_action(const CommandSpec &command_spec);
 
   void print_bash_completion(const CommandSpec &command_spec);


### PR DESCRIPTION
Fixes BUG #15521:Seeing rollback and revert option for snapshot, which seems to be same and can be confusing for users

Signed-off-by: Yongqiang He <he.yongqiang@h3c.com>