### PR TITLE
RFC: change default monitor port

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,0 +1,16 @@
+v11.0.0
+-------
+
+* The default monitor port has changed from 6789 to 3300, which has
+  been assigned to us by IANA.  Existing monitor will continue to use
+  the ports they were created with, while new clusters will default to the
+  new port.
+
+  Clients will try first the new port and then the old port if it is
+  not explicitly specified, except in one case.  If the monitor
+  addresses are specified in the ``ceph.conf`` file by the ``mon
+  addr`` option, we will default to the new port and will not try the
+  old port as well.  Note that this method specifying monitors is
+  deprecated.  Please use ``mon hosts`` in the ``[global]`` section
+  instead, or modify the options to explicitly specify the old port
+  6789 if needed.

--- a/doc/cephfs/fstab.rst
+++ b/doc/cephfs/fstab.rst
@@ -15,7 +15,7 @@ following to ``/etc/fstab``::
 
 For example:: 
 
-	10.10.10.10:6789:/     /mnt/ceph    ceph    name=admin,secretfile=/etc/ceph/secret.key,noatime    0       2
+	10.10.10.10:3300:/     /mnt/ceph    ceph    name=admin,secretfile=/etc/ceph/secret.key,noatime    0       2
 	
 .. important:: The ``name`` and ``secret`` or ``secretfile`` options are 
    mandatory when you have Ceph authentication running. 

--- a/doc/cephfs/fuse.rst
+++ b/doc/cephfs/fuse.rst
@@ -28,7 +28,7 @@ To mount the Ceph file system as a FUSE, you may use the ``ceph-fuse`` command.
 For example::
 
 	sudo mkdir /home/usernname/cephfs
-	sudo ceph-fuse -m 192.168.0.1:6789 /home/username/cephfs
+	sudo ceph-fuse -m 192.168.0.1:3300 /home/username/cephfs
 
 See `ceph-fuse`_ for additional details.
 

--- a/doc/cephfs/kernel.rst
+++ b/doc/cephfs/kernel.rst
@@ -7,17 +7,17 @@ monitor host IP address(es), or use the ``mount.ceph`` utility to resolve the
 monitor host name(s) into IP address(es) for you. For example:: 
 
 	sudo mkdir /mnt/mycephfs
-	sudo mount -t ceph 192.168.0.1:6789:/ /mnt/mycephfs
+	sudo mount -t ceph 192.168.0.1:3300:/ /mnt/mycephfs
 
 To mount the Ceph file system with ``cephx`` authentication enabled, you must
 specify a user name and a secret. ::
 
-	sudo mount -t ceph 192.168.0.1:6789:/ /mnt/mycephfs -o name=admin,secret=AQATSKdNGBnwLhAAnNDKnH65FmVKpXZJVasUeQ==
+	sudo mount -t ceph 192.168.0.1:3300:/ /mnt/mycephfs -o name=admin,secret=AQATSKdNGBnwLhAAnNDKnH65FmVKpXZJVasUeQ==
 
 The foregoing usage leaves the secret in the Bash history. A more secure
 approach reads the secret from a file. For example::
 
-	sudo mount -t ceph 192.168.0.1:6789:/ /mnt/mycephfs -o name=admin,secretfile=/etc/ceph/admin.secret
+	sudo mount -t ceph 192.168.0.1:3300:/ /mnt/mycephfs -o name=admin,secretfile=/etc/ceph/admin.secret
 	
 See `Authentication`_ for details on cephx.
 

--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -281,7 +281,7 @@ The procedure is as follows:
 
 	cluster a7f64266-0894-4f1e-a635-d0aeaca0e993
 	  health HEALTH_ERR 192 pgs stuck inactive; 192 pgs stuck unclean; no osds
-	  monmap e1: 1 mons at {node1=192.168.0.1:6789/0}, election epoch 1, quorum 0 node1
+	  monmap e1: 1 mons at {node1=192.168.0.1:3300/0}, election epoch 1, quorum 0 node1
 	  osdmap e1: 0 osds: 0 up, 0 in
 	  pgmap v2: 192 pgs, 3 pools, 0 bytes data, 0 objects
 	     0 kB used, 0 kB / 0 kB avail

--- a/doc/man/8/monmaptool.rst
+++ b/doc/man/8/monmaptool.rst
@@ -26,7 +26,8 @@ When creating a map with --create, a new monitor map with a new,
 random UUID will be created. It should be followed by one or more
 monitor addresses.
 
-The default Ceph monitor port is 6789.
+The default Ceph monitor port is 3300, as assigned by the IANA.  Prior to
+the kraken 11.2.z release the default was 6789.
 
 
 Options
@@ -80,8 +81,8 @@ Example
 
 To create a new map with three monitors (for a fresh Ceph file system)::
 
-        monmaptool  --create  --add  mon.a 192.168.0.10:6789 --add mon.b 192.168.0.11:6789 \
-          --add mon.c 192.168.0.12:6789 --clobber monmap
+        monmaptool  --create  --add  mon.a 192.168.0.10:3300 --add mon.b 192.168.0.11:3300 \
+          --add mon.c 192.168.0.12:3300 --clobber monmap
 
 To display the contents of the map::
 
@@ -89,7 +90,7 @@ To display the contents of the map::
 
 To replace one monitor::
 
-        monmaptool --rm mon.a --add mon.a 192.168.0.9:6789 --clobber monmap
+        monmaptool --rm mon.a --add mon.a 192.168.0.9:3300 --clobber monmap
 
 
 Availability

--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -26,7 +26,7 @@ specifying monitor address(es) by IP::
         mount -t ceph 1.2.3.4:/ mountpoint
 
 Each monitor address monaddr takes the form host[:port]. If the port
-is not specified, the Ceph default of 6789 is assumed.
+is not specified, the Ceph default of 3300 is assumed.
 
 Multiple monitor addresses can be separated by commas. Only one
 responsible monitor is needed to successfully mount; the client will

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -92,7 +92,7 @@ configuration as follows:
               the Ceph Storage Cluster, and override the same setting in 
               ``[global]``.
 
-:Example: ``mon addr = 10.0.0.101:6789``
+:Example: ``mon addr = 10.0.0.101:3300``
 
 
 ``[mds]``
@@ -283,13 +283,13 @@ Monitors in the quorum.
 .. note:: You may deploy Ceph with a single monitor, but if the instance fails,
 	       the lack of other monitors may interrupt data service availability.
 
-Ceph Monitors typically listen on port ``6789``. For example:
+Ceph Monitors typically listen on port ``3300``. For example:
 
 .. code-block:: ini 
 
 	[mon.a]
 	host = hostName
-	mon addr = 150.140.130.120:6789
+	mon addr = 150.140.130.120:3300
 
 By default, Ceph expects that you will store a monitor's data under the
 following path::
@@ -510,8 +510,8 @@ name at the appropriate places in the path. For example::
 	sudo mkdir /var/lib/ceph/mon/openstack-a
 	
 .. important:: When running monitors on the same host, you should use 
-   different ports. By default, monitors use port 6789. If you already 
-   have monitors using port 6789, use a different port for your other cluster(s). 
+   different ports. By default, monitors use port 3300. If you already 
+   have monitors using port 3300, use a different port for your other cluster(s). 
 
 To invoke a cluster other than the default ``ceph`` cluster, use the 
 ``-c {filename}.conf`` option with the ``ceph`` command. For example:: 

--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -209,14 +209,14 @@ these under ``[mon]`` or under the entry for a specific monitor.
 
 	[mon]
 		mon host = hostname1,hostname2,hostname3
-		mon addr = 10.0.0.10:6789,10.0.0.11:6789,10.0.0.12:6789
+		mon addr = 10.0.0.10:3300,10.0.0.11:3300,10.0.0.12:3300
 
 
 .. code-block:: ini
 
 	[mon.a]
 		host = hostname1
-		mon addr = 10.0.0.10:6789
+		mon addr = 10.0.0.10:3300
 
 See the `Network Configuration Reference`_ for details.
 

--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -90,13 +90,13 @@ harden the ports on your Ceph Nodes.
 Monitor IP Tables
 -----------------
 
-Ceph Monitors listen on port ``6789`` by default. Additionally, Ceph Monitors
+Ceph Monitors listen on port ``3300`` by default. Additionally, Ceph Monitors
 always operate on the public network. When you add the rule using the example
 below, make sure you replace ``{iface}`` with the public network interface
 (e.g., ``eth0``, ``eth1``, etc.), ``{ip-address}`` with  the IP address of the
 public network and ``{netmask}`` with the netmask for the public network. ::
 
-   sudo iptables -A INPUT -i {iface} -p tcp -s {ip-address}/{netmask} --dport 6789 -j ACCEPT
+   sudo iptables -A INPUT -i {iface} -p tcp -s {ip-address}/{netmask} --dport 3300 -j ACCEPT
 
 
 MDS IP Tables
@@ -242,7 +242,7 @@ port.
 	[mon.a]
 	
 		host = {hostname}
-		mon addr = {ip-address}:6789
+		mon addr = {ip-address}:3300
 
 	[osd.0]
 		host = {hostname}

--- a/doc/rados/operations/add-or-rm-mons.rst
+++ b/doc/rados/operations/add-or-rm-mons.rst
@@ -265,13 +265,13 @@ For example, lets assume there are three monitors in place, such as ::
 
 	[mon.a]
 		host = host01
-		addr = 10.0.0.1:6789
+		addr = 10.0.0.1:3300
 	[mon.b]
 		host = host02
-		addr = 10.0.0.2:6789
+		addr = 10.0.0.2:3300
 	[mon.c]
 		host = host03
-		addr = 10.0.0.3:6789
+		addr = 10.0.0.3:3300
 
 To change ``mon.c`` to ``host04`` with the IP address  ``10.0.0.4``, follow the
 steps in `Adding a Monitor (Manual)`_ by adding a  new monitor ``mon.d``. Ensure
@@ -314,9 +314,9 @@ networks  are unable to communicate.  Use the following procedure:
 	fsid 224e376d-c5fe-4504-96bb-ea6332a19e61
 	last_changed 2012-12-17 02:46:41.591248
 	created 2012-12-17 02:46:41.591248
-	0: 10.0.0.1:6789/0 mon.a
-	1: 10.0.0.2:6789/0 mon.b
-	2: 10.0.0.3:6789/0 mon.c
+	0: 10.0.0.1:3300/0 mon.a
+	1: 10.0.0.2:3300/0 mon.b
+	2: 10.0.0.3:3300/0 mon.c
 
 #. Remove the existing monitors. ::
 
@@ -330,7 +330,7 @@ networks  are unable to communicate.  Use the following procedure:
 
 #. Add the new monitor locations. ::
 
-	$ monmaptool --add a 10.1.0.1:6789 --add b 10.1.0.2:6789 --add c 10.1.0.3:6789 {tmp}/{filename}
+	$ monmaptool --add a 10.1.0.1:3300 --add b 10.1.0.2:3300 --add c 10.1.0.3:3300 {tmp}/{filename}
 	
 	monmaptool: monmap file {tmp}/{filename}
 	monmaptool: writing epoch 1 to {tmp}/{filename} (3 monitors)
@@ -344,9 +344,9 @@ networks  are unable to communicate.  Use the following procedure:
 	fsid 224e376d-c5fe-4504-96bb-ea6332a19e61
 	last_changed 2012-12-17 02:46:41.591248
 	created 2012-12-17 02:46:41.591248
-	0: 10.1.0.1:6789/0 mon.a
-	1: 10.1.0.2:6789/0 mon.b
-	2: 10.1.0.3:6789/0 mon.c
+	0: 10.1.0.1:3300/0 mon.a
+	1: 10.1.0.2:3300/0 mon.b
+	2: 10.1.0.3:3300/0 mon.c
 
 At this point, we assume the monitors (and stores) are installed at the new
 location. The next step is to propagate the modified monmap to the new 

--- a/doc/rados/operations/control.rst
+++ b/doc/rados/operations/control.rst
@@ -319,7 +319,7 @@ Show monitor stats::
 	ceph mon stat
 	
 	2011-12-14 10:40:59.044395 mon {- [mon,stat]
-	2011-12-14 10:40:59.057111 mon.1 -} 'e3: 5 mons at {a=10.1.2.3:6789/0,b=10.1.2.4:6789/0,c=10.1.2.5:6789/0,d=10.1.2.6:6789/0,e=10.1.2.7:6789/0}, election epoch 16, quorum 0,1,2,3' (0)
+	2011-12-14 10:40:59.057111 mon.1 -} 'e3: 5 mons at {a=10.1.2.3:3300/0,b=10.1.2.4:3300/0,c=10.1.2.5:3300/0,d=10.1.2.6:3300/0,e=10.1.2.7:3300/0}, election epoch 16, quorum 0,1,2,3' (0)
 
 The ``quorum`` list at the end lists monitor nodes that are part of the current quorum.
 
@@ -344,7 +344,7 @@ This is also available more directly::
 	      "mons": [
 	            { "rank": 0,
 	              "name": "a",
-	              "addr": "127.0.0.1:6789\/0"},
+	              "addr": "127.0.0.1:3300\/0"},
 	            { "rank": 1,
 	              "name": "b",
 	              "addr": "127.0.0.1:6790\/0"},
@@ -381,7 +381,7 @@ to select)::
 	      "mons": [
 	            { "rank": 0,
 	              "name": "a",
-	              "addr": "127.0.0.1:6789\/0"},
+	              "addr": "127.0.0.1:3300\/0"},
 	            { "rank": 1,
 	              "name": "b",
 	              "addr": "127.0.0.1:6790\/0"},
@@ -399,7 +399,7 @@ A dump of the monitor state::
 	fsid 444b489c-4f16-4b75-83f0-cb8097468898
 	last_changed 2011-12-12 13:28:27.505520
 	created 2011-12-12 13:28:27.505520
-	0: 127.0.0.1:6789/0 mon.a
+	0: 127.0.0.1:3300/0 mon.a
 	1: 127.0.0.1:6790/0 mon.b
 	2: 127.0.0.1:6791/0 mon.c
 

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -50,7 +50,7 @@ one monitor, and two OSDs may print the following::
 
     cluster b370a29d-9287-4ca3-ab57-3d824f65e339
      health HEALTH_OK
-     monmap e1: 1 mons at {ceph1=10.0.0.8:6789/0}, election epoch 2, quorum 0 ceph1
+     monmap e1: 1 mons at {ceph1=10.0.0.8:3300/0}, election epoch 2, quorum 0 ceph1
      osdmap e63: 2 osds: 2 up, 2 in
       pgmap v41338: 952 pgs, 20 pools, 17130 MB data, 2199 objects
             115 GB used, 167 GB / 297 GB avail
@@ -151,7 +151,7 @@ of one monitor, and two OSDs may print the following::
 
     cluster b370a29d-9287-4ca3-ab57-3d824f65e339
      health HEALTH_OK
-     monmap e1: 1 mons at {ceph1=10.0.0.8:6789/0}, election epoch 2, quorum 0 ceph1
+     monmap e1: 1 mons at {ceph1=10.0.0.8:3300/0}, election epoch 2, quorum 0 ceph1
      osdmap e63: 2 osds: 2 up, 2 in
       pgmap v41332: 952 pgs, 20 pools, 17130 MB data, 2199 objects
             115 GB used, 167 GB / 297 GB avail
@@ -224,7 +224,7 @@ three monitors may return the following:
 	      "mons": [
 	            { "rank": 0,
 	              "name": "a",
-	              "addr": "127.0.0.1:6789\/0"},
+	              "addr": "127.0.0.1:3300\/0"},
 	            { "rank": 1,
 	              "name": "b",
 	              "addr": "127.0.0.1:6790\/0"},

--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -123,7 +123,7 @@ Take the following example of ``mon_status``::
         "mons": [
               { "rank": 0,
                 "name": "a",
-                "addr": "127.0.0.1:6789\/0"},
+                "addr": "127.0.0.1:3300\/0"},
               { "rank": 1,
                 "name": "b",
                 "addr": "127.0.0.1:6790\/0"},
@@ -150,7 +150,7 @@ By the way, how are ranks established?
 
   Ranks are (re)calculated whenever you add or remove monitors and follow a
   simple rule: the **greater** the ``IP:PORT`` combination, the **lower** the
-  rank is. In this case, considering that ``127.0.0.1:6789`` is lower than all
+  rank is. In this case, considering that ``127.0.0.1:3300`` is lower than all
   the remaining ``IP:PORT`` combinations, ``mon.a`` has rank 0.
 
 Most Common Monitor Issues
@@ -164,7 +164,7 @@ you should be seeing something similar to::
 
       $ ceph health detail
       [snip]
-      mon.a (rank 0) addr 127.0.0.1:6789/0 is down (out of quorum)
+      mon.a (rank 0) addr 127.0.0.1:3300/0 is down (out of quorum)
 
 How to troubleshoot this?
 
@@ -262,7 +262,7 @@ monitors::
       fsid 5c4e9d53-e2e1-478a-8061-f543f8be4cf8
       last_changed 2013-10-30 04:12:01.945629
       created 2013-10-29 14:14:41.914786
-      0: 127.0.0.1:6789/0 mon.a
+      0: 127.0.0.1:3300/0 mon.a
       1: 127.0.0.1:6790/0 mon.b
       2: 127.0.0.1:6795/0 mon.c
       
@@ -349,7 +349,7 @@ How do I know there's a clock skew?
   The monitors will warn you in the form of a ``HEALTH_WARN``. ``ceph health
   detail`` should show something in the form of::
 
-      mon.c addr 10.10.0.1:6789/0 clock skew 0.08235s > max 0.05s (latency 0.0045s)
+      mon.c addr 10.10.0.1:3300/0 clock skew 0.08235s > max 0.05s (latency 0.0045s)
 
   That means that ``mon.c`` has been flagged as suffering from a clock skew.
 
@@ -378,10 +378,10 @@ like this appropriately::
 
 You may also need to add rules to IP tables on your Ceph hosts to ensure
 that clients can access the ports associated with your Ceph monitors (i.e., port
-6789 by default) and Ceph OSDs (i.e., 6800 through 7300 by default). For
+3300 by default) and Ceph OSDs (i.e., 6800 through 7300 by default). For
 example::
 
-	iptables -A INPUT -m multiport -p tcp -s {ip-address}/{netmask} --dports 6789,6800:7300 -j ACCEPT
+	iptables -A INPUT -m multiport -p tcp -s {ip-address}/{netmask} --dports 3300,6800:7300 -j ACCEPT
 
 
 Everything Failed! Now What?

--- a/doc/rbd/disk.conf
+++ b/doc/rbd/disk.conf
@@ -1,6 +1,6 @@
 <disk type='network' device='disk'>
 	<source protocol='rbd' name='poolname/imagename'>
-		<host name='{fqdn}' port='6789'/>
+		<host name='{fqdn}' port='3300'/>
 		<host name='{fqdn}' port='6790'/>
 		<host name='{fqdn}' port='6791'/>
 	</source>

--- a/doc/rbd/libvirt.rst
+++ b/doc/rbd/libvirt.rst
@@ -189,7 +189,7 @@ commands, refer to `Virsh Command Reference`_.
 
 	<disk type='network' device='disk'>
 		<source protocol='rbd' name='libvirt-pool/new-libvirt-image'>
-			<host name='{monitor-host}' port='6789'/>
+			<host name='{monitor-host}' port='3300'/>
 		</source>
 		<target dev='vda' bus='virtio'/>
 	</disk>

--- a/doc/start/ceph.conf
+++ b/doc/start/ceph.conf
@@ -29,7 +29,7 @@
 [mon.a]
 
 	host = {hostname}
-	mon addr = {ip-address}:6789
+	mon addr = {ip-address}:3300
 
 [osd.0]
 	host = {hostname}

--- a/doc/start/quick-cephfs.rst
+++ b/doc/start/quick-cephfs.rst
@@ -78,13 +78,13 @@ Kernel Driver
 Mount Ceph FS as a kernel driver. :: 
 
 	sudo mkdir /mnt/mycephfs
-	sudo mount -t ceph {ip-address-of-monitor}:6789:/ /mnt/mycephfs
+	sudo mount -t ceph {ip-address-of-monitor}:3300:/ /mnt/mycephfs
 
 The Ceph Storage Cluster uses authentication by default. Specify a user ``name``
 and the ``secretfile`` you created  in the `Create a Secret File`_ section. For
 example::
 
-	sudo mount -t ceph 192.168.0.1:6789:/ /mnt/mycephfs -o name=admin,secretfile=admin.secret
+	sudo mount -t ceph 192.168.0.1:3300:/ /mnt/mycephfs -o name=admin,secretfile=admin.secret
 
 
 .. note:: Mount the Ceph FS filesystem on the admin node,
@@ -97,12 +97,12 @@ Filesystem in User Space (FUSE)
 Mount Ceph FS as a Filesystem in User Space (FUSE). ::
 
 	sudo mkdir ~/mycephfs
-	sudo ceph-fuse -m {ip-address-of-monitor}:6789 ~/mycephfs
+	sudo ceph-fuse -m {ip-address-of-monitor}:3300 ~/mycephfs
 
 The Ceph Storage Cluster uses authentication by default. Specify a keyring if it
 is not in the default location (i.e., ``/etc/ceph``)::
 
-	sudo ceph-fuse -k ./ceph.client.admin.keyring -m 192.168.0.1:6789 ~/mycephfs
+	sudo ceph-fuse -k ./ceph.client.admin.keyring -m 192.168.0.1:3300 ~/mycephfs
 
 
 Additional Information

--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -253,7 +253,7 @@ Address hostname resolution issues as necessary.
 Open Required Ports
 -------------------
 
-Ceph Monitors communicate using port ``6789`` by default. Ceph OSDs communicate
+Ceph Monitors communicate using port ``3300`` by default. Ceph OSDs communicate
 in a port range of ``6800:7300`` by default. See the `Network Configuration
 Reference`_ for details. Ceph OSDs can use multiple network connections to
 communicate with clients, monitors, other OSDs for replication, and other OSDs
@@ -263,16 +263,16 @@ On some distributions (e.g., RHEL), the default firewall configuration is fairly
 strict. You may need to adjust your firewall settings allow inbound requests so
 that clients in your network can communicate with daemons on your Ceph nodes.
 
-For ``firewalld`` on RHEL 7, add port ``6789`` for Ceph Monitor nodes and ports
+For ``firewalld`` on RHEL 7, add port ``3300`` for Ceph Monitor nodes and ports
 ``6800:7300`` for Ceph OSDs to the public zone and ensure that you make the
 setting permanent so that it is enabled on reboot. For example::
 
-	sudo firewall-cmd --zone=public --add-port=6789/tcp --permanent
+	sudo firewall-cmd --zone=public --add-port=3300/tcp --permanent
 
-For ``iptables``, add port ``6789`` for Ceph Monitors and ports ``6800:7300``
+For ``iptables``, add port ``3300`` for Ceph Monitors and ports ``6800:7300``
 for Ceph OSDs. For example::
 
-	sudo iptables -A INPUT -i {iface} -p tcp -s {ip-address}/{netmask} --dport 6789 -j ACCEPT
+	sudo iptables -A INPUT -i {iface} -p tcp -s {ip-address}/{netmask} --dport 3300 -j ACCEPT
 
 Once you have finished configuring ``iptables``, ensure that you make the
 changes persistent on each node so that they will be in effect when your nodes

--- a/src/ceph.conf.twoosds
+++ b/src/ceph.conf.twoosds
@@ -27,17 +27,17 @@
 
 [mon0]
 	host = cosd0
-	mon addr = 10.3.14.95:6789
+	mon addr = 10.3.14.95:3300
 	log dir = /data/cosd0
 
 [mon1]
 	host = cosd1
-	mon addr = 10.3.14.96:6789
+	mon addr = 10.3.14.96:3300
 	log dir = /data/cosd1
 
 [mon2]
 	host = cosd2
-	mon addr = 10.3.14.97:6789
+	mon addr = 10.3.14.97:3300
 	log dir = /data/cosd2
 
 

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -362,7 +362,7 @@ int main(int argc, const char **argv)
 	exit(1);
       }      
     } else {
-      int err = monmap.build_initial(g_ceph_context, cerr);
+      int err = monmap.build_initial(g_ceph_context, cerr, false);
       if (err < 0) {
 	cerr << argv[0] << ": warning: no initial monitors; must use admin socket to feed hints" << std::endl;
       }
@@ -643,7 +643,7 @@ int main(int argc, const char **argv)
 	      << ipaddr << dendl;
     } else {
       MonMap tmpmap;
-      int err = tmpmap.build_initial(g_ceph_context, cerr);
+      int err = tmpmap.build_initial(g_ceph_context, cerr, false);
       if (err < 0) {
 	derr << argv[0] << ": error generating initial monmap: "
              << cpp_strerror(err) << dendl;

--- a/src/include/msgr.h
+++ b/src/include/msgr.h
@@ -9,14 +9,8 @@
  * Data types for message passing layer used by Ceph.
  */
 
-#define CEPH_MON_PORT    6789  /* default monitor port */
-
-/*
- * client-side processes will try to bind to ports in this
- * range, simply for the benefit of tools like nmap or wireshark
- * that would like to identify the protocol.
- */
-#define CEPH_PORT_FIRST  6789
+#define CEPH_MON_PORT         3300  /* (ce4h) IANA assigned monitor port */
+#define CEPH_MON_PORT_LEGACY  6789  /* old default monitor port */
 
 /*
  * tcp connection banner.  include a protocol version. and adjust

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -471,9 +471,9 @@ CEPH_RADOS_API int rados_conf_read_file(rados_t cluster, const char *path);
  * argv can contain any common Ceph command line option, including any
  * configuration parameter prefixed by '--' and replacing spaces with
  * dashes or underscores. For example, the following options are equivalent:
- * - --mon-host 10.0.0.1:6789
- * - --mon_host 10.0.0.1:6789
- * - -m 10.0.0.1:6789
+ * - --mon-host 10.0.0.1:3300
+ * - --mon_host 10.0.0.1:3300
+ * - -m 10.0.0.1:3300
  *
  * @pre rados_connect() has not been called on the cluster handle
  *

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -114,7 +114,7 @@ static int build_map_buf(CephContext *cct, const char *pool, const char *image,
   int r;
 
   MonMap monmap;
-  r = monmap.build_initial(cct, cerr);
+  r = monmap.build_initial(cct, cerr, true);
   if (r < 0)
     return r;
 

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -89,7 +89,7 @@ MonClient::~MonClient()
 int MonClient::build_initial_monmap()
 {
   ldout(cct, 10) << "build_initial_monmap" << dendl;
-  return monmap.build_initial(cct, cerr);
+  return monmap.build_initial(cct, cerr, true);
 }
 
 int MonClient::get_monmap()

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -149,7 +149,8 @@ void MonMap::dump(Formatter *f) const
 }
 
 
-int MonMap::build_from_host_list(std::string hostlist, std::string prefix)
+int MonMap::build_from_host_list(std::string hostlist, std::string prefix,
+				 bool include_legacy)
 {
   vector<entity_addr_t> addrs;
   if (parse_ip_port_vec(hostlist.c_str(), addrs)) {
@@ -157,8 +158,13 @@ int MonMap::build_from_host_list(std::string hostlist, std::string prefix)
       char n[2];
       n[0] = 'a' + i;
       n[1] = 0;
-      if (addrs[i].get_port() == 0)
+      if (addrs[i].get_port() == 0) {
 	addrs[i].set_port(CEPH_MON_PORT);
+	if (include_legacy) {
+	  addrs.push_back(addrs[i]);
+	  addrs.back().set_port(CEPH_MON_PORT_LEGACY);
+	}
+      }
       string name = prefix;
       name += n;
       if (!contains(addrs[i]))
@@ -186,8 +192,13 @@ int MonMap::build_from_host_list(std::string hostlist, std::string prefix)
     char n[2];
     n[0] = 'a' + i;
     n[1] = 0;
-    if (addrs[i].get_port() == 0)
+    if (addrs[i].get_port() == 0) {
       addrs[i].set_port(CEPH_MON_PORT);
+      if (include_legacy) {
+	addrs.push_back(addrs[i]);
+	addrs.back().set_port(CEPH_MON_PORT_LEGACY);
+      }
+    }
     string name = prefix;
     name += n;
     if (!contains(addrs[i]) &&
@@ -242,7 +253,8 @@ void MonMap::set_initial_members(CephContext *cct,
 }
 
 
-int MonMap::build_initial(CephContext *cct, ostream& errout)
+int MonMap::build_initial(CephContext *cct, ostream& errout,
+			  bool include_legacy)
 {
   const md_config_t *conf = cct->_conf;
   // file?
@@ -268,7 +280,8 @@ int MonMap::build_initial(CephContext *cct, ostream& errout)
 
   // -m foo?
   if (!conf->mon_host.empty()) {
-    int r = build_from_host_list(conf->mon_host, "noname-");
+    int r = build_from_host_list(conf->mon_host, "noname-",
+				 include_legacy);
     if (r < 0) {
       errout << "unable to parse addrs in '" << conf->mon_host << "'"
              << std::endl;

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -200,8 +200,9 @@ class MonMap {
    *
    * @param cct context (and associated config)
    * @param errout ostream to send error messages too
+   * @param include_legacy  include legacy mon port (if not specified)
    */
-  int build_initial(CephContext *cct, ostream& errout);
+  int build_initial(CephContext *cct, ostream& errout, bool include_legacy);
 
   /**
    * build a monmap from a list of hosts or ips
@@ -210,9 +211,11 @@ class MonMap {
    *
    * @param hosts  list of hosts, space or comma separated
    * @param prefix prefix to prepend to generated mon names
+   * @param include_legacy  include legacy mon port (if not specified)
    * @return 0 for success, -errno on error
    */
-  int build_from_host_list(std::string hosts, std::string prefix);
+  int build_from_host_list(std::string hosts, std::string prefix,
+			   bool include_legacy);
 
   /**
    * filter monmap given a set of initial members.

--- a/src/sample.ceph.conf
+++ b/src/sample.ceph.conf
@@ -228,15 +228,15 @@
 
 ;[mon.alpha]
 ;    host                       = alpha
-;    mon addr                   = 192.168.0.10:6789
+;    mon addr                   = 192.168.0.10:3300
 
 ;[mon.beta]
 ;    host                       = beta
-;    mon addr                   = 192.168.0.11:6789
+;    mon addr                   = 192.168.0.11:3300
 
 ;[mon.gamma]
 ;    host                       = gamma
-;    mon addr                   = 192.168.0.12:6789
+;    mon addr                   = 192.168.0.12:3300
 
 
 ##################

--- a/src/test/cli/monmaptool/add-exists.t
+++ b/src/test/cli/monmaptool/add-exists.t
@@ -5,7 +5,7 @@
 
   $ ORIG_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
 
-  $ monmaptool --add foo 2.3.4.5:6789 mymonmap
+  $ monmaptool --add foo 2.3.4.5:3300 mymonmap
   monmaptool: monmap file mymonmap
   monmaptool: writing epoch 0 to mymonmap (1 monitors)
   $ monmaptool --add foo 3.4.5.6:7890 mymonmap
@@ -20,7 +20,7 @@
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
-  0: 2.3.4.5:6789/0 mon.foo
+  0: 2.3.4.5:3300/0 mon.foo
 
   $ NEW_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
   $ [ "$ORIG_FSID" = "$NEW_FSID" ]

--- a/src/test/cli/monmaptool/add-many.t
+++ b/src/test/cli/monmaptool/add-many.t
@@ -5,7 +5,7 @@
 
   $ ORIG_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
 
-  $ monmaptool --add foo 2.3.4.5:6789 mymonmap
+  $ monmaptool --add foo 2.3.4.5:3300 mymonmap
   monmaptool: monmap file mymonmap
   monmaptool: writing epoch 0 to mymonmap (1 monitors)
   $ monmaptool --add bar 3.4.5.6:7890 mymonmap
@@ -21,7 +21,7 @@
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
-  0: 2.3.4.5:6789/0 mon.foo
+  0: 2.3.4.5:3300/0 mon.foo
   1: 3.4.5.6:7890/0 mon.bar
   2: 4.5.6.7:8901/0 mon.baz
 

--- a/src/test/cli/monmaptool/clobber.t
+++ b/src/test/cli/monmaptool/clobber.t
@@ -1,4 +1,4 @@
-  $ monmaptool --create --add foo 2.3.4.5:6789 mymonmap
+  $ monmaptool --create --add foo 2.3.4.5:3300 mymonmap
   monmaptool: monmap file mymonmap
   monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   monmaptool: writing epoch 0 to mymonmap (1 monitors)
@@ -17,7 +17,7 @@
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
-  0: 2.3.4.5:6789/0 mon.foo
+  0: 2.3.4.5:3300/0 mon.foo
 
   $ NEW_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
   $ [ "$ORIG_FSID" = "$NEW_FSID" ]

--- a/src/test/cli/monmaptool/create-with-add.t
+++ b/src/test/cli/monmaptool/create-with-add.t
@@ -1,4 +1,4 @@
-  $ monmaptool --create --add foo 2.3.4.5:6789 mymonmap
+  $ monmaptool --create --add foo 2.3.4.5:3300 mymonmap
   monmaptool: monmap file mymonmap
   monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   monmaptool: writing epoch 0 to mymonmap (1 monitors)
@@ -9,4 +9,4 @@
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
-  0: 2.3.4.5:6789/0 mon.foo
+  0: 2.3.4.5:3300/0 mon.foo

--- a/src/test/cli/monmaptool/rm-nonexistent.t
+++ b/src/test/cli/monmaptool/rm-nonexistent.t
@@ -1,4 +1,4 @@
-  $ monmaptool --create --add foo 2.3.4.5:6789 mymonmap
+  $ monmaptool --create --add foo 2.3.4.5:3300 mymonmap
   monmaptool: monmap file mymonmap
   monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   monmaptool: writing epoch 0 to mymonmap (1 monitors)
@@ -18,7 +18,7 @@
   fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   last_changed \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
-  0: 2.3.4.5:6789/0 mon.foo
+  0: 2.3.4.5:3300/0 mon.foo
 
   $ NEW_FSID="$(monmaptool --print mymonmap|grep ^fsid)"
   $ [ "$ORIG_FSID" = "$NEW_FSID" ]

--- a/src/test/cli/monmaptool/rm.t
+++ b/src/test/cli/monmaptool/rm.t
@@ -1,4 +1,4 @@
-  $ monmaptool --create --add foo 2.3.4.5:6789 mymonmap
+  $ monmaptool --create --add foo 2.3.4.5:3300 mymonmap
   monmaptool: monmap file mymonmap
   monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
   monmaptool: writing epoch 0 to mymonmap (1 monitors)

--- a/src/test/cli/osdmaptool/ceph.conf.withracks
+++ b/src/test/cli/osdmaptool/ceph.conf.withracks
@@ -15,15 +15,15 @@
 
 [mon.alpha]
   host = peon5752
-  mon addr = [2607:f298:4:2243::5752]:6789
+  mon addr = [2607:f298:4:2243::5752]:3300
 
 [mon.beta]
   host = peon5753
-  mon addr = [2607:f298:4:2243::5753]:6789
+  mon addr = [2607:f298:4:2243::5753]:3300
 
 [mon.charlie]
   host = peon5754
-  mon addr = [2607:f298:4:2243::5754]:6789
+  mon addr = [2607:f298:4:2243::5754]:3300
 
 [client]
   rgw socket path = /var/run/ceph/radosgw.$name

--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -132,7 +132,7 @@ int main(int argc, const char **argv)
   }
 
   if (generate) {
-    int r = monmap.build_initial(g_ceph_context, cerr);
+    int r = monmap.build_initial(g_ceph_context, cerr, false);
     if (r < 0)
       return r;
   }

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -354,7 +354,7 @@ fi
 # export CEPH_ARGS="--lockdep 1"
 
 if [ -z "$CEPH_PORT" ]; then
-    CEPH_PORT=6789
+    CEPH_PORT=3300
     [ -e ".ceph_port" ] && CEPH_PORT=`cat .ceph_port`
 fi
 


### PR DESCRIPTION
We now have an IANA assigned port that we should use for monitors.

This PR makes (new) clients try the new then old ports when it is not
specified (in mon host, -m option, etc.).

New clusters use the new port.  Old clusters keep their old port.

The big question for me is whether it is okay that a new cluster will start
using the new port immediately, but old (jewel) clients will not try the
new port yet.  That means a new kraken cluster won't get reachable from a
jewel client that specifies only the mon host/ip (without the port).  I don't
think this is very common, and all they need to do to "fix" it is specify the
port in the mon host config option.
