### PR TITLE
global-init: fixup chown of the run directory along with log and asok files

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -290,7 +290,7 @@ void* AdminSocket::entry()
 void AdminSocket::chown(uid_t uid, gid_t gid)
 {
   if (m_sock_fd >= 0) {
-    int r = ::fchown(m_sock_fd, uid, gid);
+    int r = ::chown(m_path.c_str(), uid, gid);
     if (r < 0) {
       r = -errno;
       lderr(m_cct) << "AdminSocket: failed to chown socket: "

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -641,6 +641,11 @@ uint32_t CephContext::get_module_type() const
   return _module_type;
 }
 
+void CephContext::set_init_flags(int flags)
+{
+  _init_flags = flags;
+}
+
 int CephContext::get_init_flags() const
 {
   return _init_flags;

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -84,6 +84,7 @@ public:
   /* Get the module type (client, mon, osd, mds, etc.) */
   uint32_t get_module_type() const;
 
+  void set_init_flags(int flags);
   int get_init_flags() const;
 
   /* Get the PerfCountersCollection of this CephContext */

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include "common/admin_socket.h"
 #include "common/ceph_argparse.h"
 #include "common/ceph_context.h"
 #include "common/ceph_crypto.h"
@@ -123,6 +124,16 @@ void common_init_finish(CephContext *cct)
 {
   cct->init_crypto();
 
-  if (!(cct->get_init_flags() & CINIT_FLAG_NO_DAEMON_ACTIONS))
+  int flags = cct->get_init_flags();
+  if (!(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))
     cct->start_service_thread();
+
+  if ((flags & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&
+      (cct->get_set_uid() || cct->get_set_gid())) {
+    // FIXME: Changing ownership of a socket file via the fd does not work as
+    //        expected. The socket file is listed as owned by the same
+    //        'user:group' which the daemon that created the socket had during
+    //        open().
+    cct->get_admin_socket()->chown(cct->get_set_uid(), cct->get_set_gid());
+  }
 }

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -130,10 +130,6 @@ void common_init_finish(CephContext *cct)
 
   if ((flags & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&
       (cct->get_set_uid() || cct->get_set_gid())) {
-    // FIXME: Changing ownership of a socket file via the fd does not work as
-    //        expected. The socket file is listed as owned by the same
-    //        'user:group' which the daemon that created the socket had during
-    //        open().
     cct->get_admin_socket()->chown(cct->get_set_uid(), cct->get_set_gid());
   }
 }

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -60,6 +60,26 @@ static const char* c_str_or_null(const std::string &str)
   return str.c_str();
 }
 
+static int chown_path(const std::string &pathname, const uid_t owner, const gid_t group,
+		      const std::string &uid_str, const std::string &gid_str)
+{
+  const char *pathname_cstr = c_str_or_null(pathname);
+
+  if (!pathname_cstr) {
+    return 0;
+  }
+
+  int r = ::chown(pathname_cstr, owner, group);
+
+  if (r < 0) {
+    r = -errno;
+    cerr << "warning: unable to chown() " << pathname << " as "
+	 << uid_str << ":" << gid_str << ": " << cpp_strerror(r) << std::endl;
+  }
+
+  return r;
+}
+
 void global_pre_init(std::vector < const char * > *alt_def_args,
 		     std::vector < const char* >& args,
 		     uint32_t module_type, code_environment_t code_env,

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -297,9 +297,6 @@ void global_init(std::vector < const char * > *alt_def_args,
       g_ceph_context->_log->chown_log_file(
 	g_ceph_context->get_set_uid(),
 	g_ceph_context->get_set_gid());
-      g_ceph_context->get_admin_socket()->chown(
-	g_ceph_context->get_set_uid(),
-	g_ceph_context->get_set_gid());
     }
   }
 

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -148,6 +148,12 @@ void global_init(std::vector < const char * > *alt_def_args,
   }
   first_run = false;
 
+  // Verify flags have not changed if global_pre_init() has been called
+  // manually. If they have, update them.
+  if (g_ceph_context->get_init_flags() != flags) {
+    g_ceph_context->set_init_flags(flags);
+  }
+
   // signal stuff
   int siglist[] = { SIGPIPE, 0 };
   block_signals(siglist, NULL);

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -339,6 +339,12 @@ int global_init_prefork(CephContext *cct)
     if (pidfile_write(g_conf) < 0)
       exit(1);
 
+    if ((cct->get_init_flags() & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&
+	(cct->get_set_uid() || cct->get_set_gid())) {
+      chown_path(conf->pid_file, cct->get_set_uid(), cct->get_set_gid(),
+		 cct->get_set_uid_string(), cct->get_set_gid_string());
+    }
+
     return -1;
   }
 
@@ -399,6 +405,12 @@ void global_init_postfork_start(CephContext *cct)
 
   if (pidfile_write(g_conf) < 0)
     exit(1);
+
+  if ((cct->get_init_flags() & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&
+      (cct->get_set_uid() || cct->get_set_gid())) {
+    chown_path(conf->pid_file, cct->get_set_uid(), cct->get_set_gid(),
+	       cct->get_set_uid_string(), cct->get_set_gid_string());
+  }
 }
 
 void global_init_postfork_finish(CephContext *cct)

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -336,7 +336,7 @@ int global_init_prefork(CephContext *cct)
   const md_config_t *conf = cct->_conf;
   if (!conf->daemonize) {
 
-    if (pidfile_write(g_conf) < 0)
+    if (pidfile_write(conf) < 0)
       exit(1);
 
     if ((cct->get_init_flags() & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&
@@ -349,8 +349,8 @@ int global_init_prefork(CephContext *cct)
   }
 
   // stop log thread
-  g_ceph_context->_log->flush();
-  g_ceph_context->_log->stop();
+  cct->_log->flush();
+  cct->_log->stop();
   return 0;
 }
 
@@ -378,7 +378,7 @@ void global_init_daemonize(CephContext *cct)
 void global_init_postfork_start(CephContext *cct)
 {
   // restart log thread
-  g_ceph_context->_log->start();
+  cct->_log->start();
 
   /* This is the old trick where we make file descriptors 0, 1, and possibly 2
    * point to /dev/null.
@@ -403,7 +403,8 @@ void global_init_postfork_start(CephContext *cct)
     exit(1);
   }
 
-  if (pidfile_write(g_conf) < 0)
+  const md_config_t *conf = cct->_conf;
+  if (pidfile_write(conf) < 0)
     exit(1);
 
   if ((cct->get_init_flags() & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&


### PR DESCRIPTION
As part of deferred setuid/setgid, we also need to chown the run_dir if specified in the config. This ensures that asok files created in a custom run_dir are ultimately owned by the correct user:group.

@liewegas - Please have a look? It adds make your 'bit of a hack' into a bigger one. Further, pid files are not handled either. Adding to a pidfile chown to this code block does not work as the pid files appear to be created later (not sure where). I think a followup PR for this will be needed also.

Hit this while debugging: http://tracker.ceph.com/issues/15553