### PR TITLE
cmake: removed rdmacm & ibverbs parallel to PR#8637

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,7 +124,7 @@ execute_process(
 
 if(HAVE_XIO)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${Xio_INCLUDE_DIR}")
-  list(APPEND EXTRALIBS ${Xio_LIBRARY} ibverbs rdmacm pthread rt)
+  list(APPEND EXTRALIBS ${Xio_LIBRARY} pthread rt)
 endif(HAVE_XIO)
 
 # sort out which allocator to use

--- a/src/test/messenger/CMakeLists.txt
+++ b/src/test/messenger/CMakeLists.txt
@@ -25,7 +25,7 @@ if(HAVE_XIO)
     )
   target_link_libraries(xio_server
     os global common ${Boost_REGEX_LIBRARY}
-    ${Xio_LIBRARY} ibverbs rdmacm pthread rt
+    ${Xio_LIBRARY} pthread rt
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
@@ -36,7 +36,7 @@ if(HAVE_XIO)
     )
   target_link_libraries(xio_client
     os global common ${Boost_REGEX_LIBRARY}
-    ${Xio_LIBRARY} ibverbs rdmacm pthread rt
+    ${Xio_LIBRARY} pthread rt
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )


### PR DESCRIPTION
Signed-off-by: Ali Maredia <amaredia@redhat.com>