### PR TITLE
cmake: use LINK_PRIVATE instead of PRIVATE for CMake version == 2.8.11

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -70,7 +70,7 @@ add_library(librbd ${CEPH_SHARED}
   $<TARGET_OBJECTS:krbd_objs>
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
   librbd.cc)
-target_link_libraries(librbd PRIVATE 
+target_link_libraries(librbd LINK_PRIVATE 
   rbd_internal
   rbd_types
   journal


### PR DESCRIPTION
with version 2.8.11, i.e., the minimum version required by the building
system, we will hit a compile error as follows:
```
  /usr/bin/ld: cannot find -lPRIVATE
  collect2: error: ld returned 1 exit status
  make[2]: *** [lib/librbd.so.1.0.0] Error 1
  make[1]: *** [src/librbd/CMakeFiles/librbd.dir/all] Error 2
```

Signed-off-by: runsisi <runsisi@zte.com.cn>