### PR TITLE
Wrong spell

### DIFF
--- a/doc/cephfs/journaler.rst
+++ b/doc/cephfs/journaler.rst
@@ -28,7 +28,7 @@
 
 ``journal prezero periods``
 
-:Description: How mnay stripe periods to zero ahead of write position
+:Description: How many stripe periods to zero ahead of write position
 :Type: Integer
 :Required: No
 :Default: ``10``

--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -14,7 +14,7 @@
 
 
 #include <mutex>
-
+#include <algorithm>
 #include "Filer.h"
 #include "osd/OSDMap.h"
 #include "Striper.h"
@@ -208,13 +208,7 @@ bool Filer::_probed(Probe *probe, const object_t& oid, uint64_t size,
   uint64_t end = 0;
 
   if (!probe->fwd) {
-    // reverse
-    vector<ObjectExtent> r;
-    for (vector<ObjectExtent>::reverse_iterator p = probe->probing.rbegin();
-	 p != probe->probing.rend();
-	 ++p)
-      r.push_back(*p);
-    probe->probing.swap(r);
+    std::reverse(probe->probing.begin(), probe->probing.end());
   }
 
   for (vector<ObjectExtent>::iterator p = probe->probing.begin();


### PR DESCRIPTION
doc: correct wrong spell 'mnay' to 'many'