### PR TITLE
multi-dump.sh: fix usage function

### DIFF
--- a/src/multi-dump.sh
+++ b/src/multi-dump.sh
@@ -8,7 +8,7 @@
 
 ### Functions
 usage() {
-        echo <<EOF
+        cat <<EOF
 multi-dump.sh: dumps out ceph maps
 
 -D                         Enable diff-mode


### PR DESCRIPTION
The usage() function was not producing any output.

Signed-off-by: Nathan Cutler <ncutler@suse.com>