### PR TITLE
sysvinit: fix ceph init script

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -38,7 +38,7 @@ else
     ASSUME_DEV=0
 fi
 
-if [ -n $CEPH_BIN ] && [ -n $CEPH_ROOT ] && [ -n $CEPH_BUILD_DIR ]; then
+if [ -n "$CEPH_BIN" ] && [ -n "$CEPH_ROOT" ] && [ -n "$CEPH_BUILD_DIR" ]; then
   BINDIR=$CEPH_BIN
   SBINDIR=$CEPH_ROOT/src
   ETCDIR=$CEPH_BIN


### PR DESCRIPTION
commit 65963739cd6815b8008282c8f64cd64365662e60 have introduce a bug

test variables need to be quoted, or -n always return true, even if variables don't exist