### PR TITLE
rgw: fix printing wrong X-Storage-Url in Swift's TempAuth.

### DIFF
--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -215,7 +215,7 @@ void RGW_SWIFT_Auth_Get::execute()
     tenant_path.append(g_conf->rgw_swift_tenant_name);
   } else if (g_conf->rgw_swift_account_in_url) {
     tenant_path = "/AUTH_";
-    tenant_path.append(user_str);
+    tenant_path.append(info.user_id.to_str());
   }
 
   STREAM_IO(s)->print("X-Storage-Url: %s/%s/v1%s\r\n", swift_url.c_str(),


### PR DESCRIPTION
If the option "rgw_swift_account_in_url" is being set to true,
both user and subuser IDs will be present in the X-Storage-Url
header generated by the implementation of Swift API's TempAuth.
This patch rectifies this behavior and makes that only the user
identifier will be placed there.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>