### PR TITLE
test/cli: fix crush related ut failure

### DIFF
--- a/src/test/cli/crushtool/check-overlapped-rules.t
+++ b/src/test/cli/crushtool/check-overlapped-rules.t
@@ -1,6 +1,13 @@
   $ crushtool -c "$TESTDIR/check-overlapped-rules.crushmap.txt" -o "$TESTDIR/check-overlapped-rules.crushmap"
+  ruleset '0' already defined in rule 'rule-r0'
+  
+  ruleset '0' already defined in rule 'rule-r0'
+  
+  ruleset '0' already defined in rule 'rule-r0'
+  
+  ruleset '0' already defined in rule 'rule-r0'
+  
+  ruleset '0' already defined in rule 'rule-r0'
+  
   $ crushtool -i "$TESTDIR/check-overlapped-rules.crushmap" --check
-  overlapped rules in ruleset 0: rule-r0, rule-r1, rule-r2
-  overlapped rules in ruleset 0: rule-r0, rule-r2, rule-r3
-  overlapped rules in ruleset 0: rule-r0, rule-r3
   $ rm -f "$TESTDIR/check-overlapped-rules.crushmap"


### PR DESCRIPTION
There is a ut failure introduced by https://github.com/ceph/ceph/pull/8502
and can by found at https://jenkins.ceph.com/job/ceph-pull-requests/4668/console,
for example.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>