### PR TITLE
OSD: set peers need update before reset peers

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6954,6 +6954,8 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 
 	hbclient_messenger->mark_down_all();
 
+	heartbeat_set_peers_need_update();
+	last_heartbeat_resample = ceph_clock_now(cct);
 	reset_heartbeat_peers();
       }
     }


### PR DESCRIPTION
otherwise the following call of maybe_update_heartbeat_peers() may not update peers immediately...

Signed-off-by: Zengran Zhang <zhangzengran@h3c.com>