### PR TITLE
CMake: LINK_PRIVATE compatibility 

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -70,7 +70,8 @@ add_library(librbd ${CEPH_SHARED}
   $<TARGET_OBJECTS:krbd_objs>
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
   librbd.cc)
-target_link_libraries(librbd PRIVATE 
+# LINK_PRIVATE instead of PRIVATE is used to backward compatibility with cmake 2.8.11
+target_link_libraries(librbd LINK_PRIVATE
   rbd_internal
   rbd_types
   journal


### PR DESCRIPTION
Use LINK_PRIVATE keyword instead of PRIVATE in librbd, for backward compatibility with cmake 2.8.11.

Signed-off-by: heroanxiaobo <heroanxiaobo@gmail.com>