### PR TITLE
tool/cephfs: make EventOutput::binary() idempotent

### DIFF
--- a/src/tools/cephfs/EventOutput.cc
+++ b/src/tools/cephfs/EventOutput.cc
@@ -29,8 +29,11 @@ int EventOutput::binary() const
   // Binary output, files
   int r = ::mkdir(path.c_str(), 0755);
   if (r != 0) {
-    std::cerr << "Error creating output directory: " << cpp_strerror(r) << std::endl;
-    return r;
+    r = -errno;
+    if (r != -EEXIST) {
+      std::cerr << "Error creating output directory: " << cpp_strerror(r) << std::endl;
+      return r;
+    }
   }
 
   for (JournalScanner::EventMap::const_iterator i = scan.events.begin(); i != scan.events.end(); ++i) {


### PR DESCRIPTION
We may passed a path in which has already been created. So we shall
tolerate the EEXIST error, which shall also make this funciton
idempotent.

Besides, we shall reset return code to errno on mkdir() system call
error for better tracing.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>