### PR TITLE
rgw, doc: improve documentation of Keystone v3 config options

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -982,7 +982,13 @@ Keystone Settings
 
 ``rgw keystone admin token``
 
-:Description: The Keystone admin token (shared secret).
+:Description: The Keystone admin token (shared secret). In Ceph RadosGW
+              authentication with the admin token has priority over
+              authentication with the admin credentials
+              (``rgw keystone admin user``, ``rgw keystone admin password``,
+              ``rgw keystone admin tenant``, ``rgw keystone admin project``,
+              ``rgw keystone admin domain``). Admin token feature is considered
+              as deprecated.
 :Type: String
 :Default: None
 

--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -955,6 +955,31 @@ Keystone Settings
 :Default: None
 
 
+``rgw keystone api version``
+
+:Description: The version (2 or 3) of OpenStack Identity API that should be
+              used for communication with the Keystone server.
+:Type: Integer
+:Default: ``2``
+
+
+``rgw keystone admin domain``
+
+:Description: The name of OpenStack domain with admin privilege when using
+              OpenStack Identity API v3.
+:Type: String
+:Default: None
+
+
+``rgw keystone admin project``
+
+:Description: The name of OpenStack project with admin privilege when using
+              OpenStack Identity API v3. If left unspecified, value of
+              ``rgw keystone admin tenant`` will be used instead.
+:Type: String
+:Default: None
+
+
 ``rgw keystone admin token``
 
 :Description: The Keystone admin token (shared secret).


### PR DESCRIPTION
The PR #7193 documents rest of the options for the credentials-based Keystone authentication.

CC: @yehudasa, @mattbenjamin.