### PR TITLE
install-deps: Adding gcc for debian based systems

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -33,7 +33,7 @@ fi
 
 case $(lsb_release -si) in
 Ubuntu|Debian|Devuan)
-        $SUDO apt-get install -y dpkg-dev
+        $SUDO apt-get install -y dpkg-dev gcc
         if ! test -r debian/control ; then
             echo debian/control is not a readable file
             exit 1


### PR DESCRIPTION
When running install-deps on a minimalistic system, we reach that situation :

dpkg-checkbuilddeps --admindir=/tmp/install-deps.5526 debian/control
    sh: 1: gcc: not found
    dpkg-checkbuilddeps: warning: Couldn't determine gcc system type, falling back to default (native compilation)
    dpkg-checkbuilddeps: error: cannot open /tmp/install-deps.5526/status: No such file or directory

This means that we shall install gcc before calling dpkg-checkbuilddeps.

Signed-off-by: Erwan Velu <erwan@redhat.com>