### PR TITLE
vstart_wrapper.sh: allow a lot of the test scripts to run standalone

### DIFF
--- a/src/test/vstart_wrapper.sh
+++ b/src/test/vstart_wrapper.sh
@@ -16,6 +16,18 @@
 # GNU Library Public License for more details.
 #
 
+if [ -z "$CEPH_ROOT" ] ; then
+    CEPH_ROOT=`readlink -f $(dirname $0)/../..`
+    if [ -d $CEPH_ROOT/build ] ; then
+       # asume we are in Cmake build environment
+        CEPH_BIN=$CEPH_ROOT/build/bin
+        CEPH_LIB=$CEPH_ROOT/build/lib
+    else
+        CEPH_BIN=$CEPH_ROOT/src
+        CEPH_LIB=$CEPH_ROOT/.libs/src
+    fi
+fi
+
 source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
 
 export CEPH_VSTART_WRAPPER=1


### PR DESCRIPTION
Fixing fallout of a previous Cmake commit that introduced CEPH_.... variables
but failed to keep backwards compatability

Signed-off-by: Willem Jan Withagen wjw@digiware.nl
