### PR TITLE
client: fuse_file_info.fh type should be uint64_t

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -271,7 +271,7 @@ static void fuse_ll_opendir(fuse_req_t req, fuse_ino_t ino,
   int r = cfuse->client->ll_opendir(in, fi->flags, (dir_result_t **)&dirp,
 				    ctx->uid, ctx->gid);
   if (r >= 0) {
-    fi->fh = (long)dirp;
+    fi->fh = (uint64_t)dirp;
     fuse_reply_open(req, fi);
   } else {
     fuse_reply_err(req, -r);
@@ -469,7 +469,7 @@ static void fuse_ll_open(fuse_req_t req, fuse_ino_t ino,
 
   int r = cfuse->client->ll_open(in, fi->flags, &fh, ctx->uid, ctx->gid);
   if (r == 0) {
-    fi->fh = (long)fh;
+    fi->fh = (uint64_t)fh;
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(2, 8)
     if (cfuse->client->cct->_conf->fuse_use_invalidate_cb)
       fi->keep_cache = 1;
@@ -671,7 +671,7 @@ static void fuse_ll_create(fuse_req_t req, fuse_ino_t parent, const char *name,
   int r = cfuse->client->ll_create(i1, name, mode, fi->flags, &fe.attr, &i2,
 				   &fh, ctx->uid, ctx->gid);
   if (r == 0) {
-    fi->fh = (long)fh;
+    fi->fh = (uint64_t)fh;
     fe.ino = cfuse->make_fake_ino(fe.attr.st_ino, fe.attr.st_dev);
     fuse_reply_create(req, &fe, fi);
   } else


### PR DESCRIPTION
fuse_file_info.fh type should be uint64_t 
reference fuse_file_info define:
struct fuse_file_info {
	/** Open flags.	 Available in open() and release() */
	int flags;
        ......
        /** File handle.  May be filled in by filesystem in open().
	    Available in all other file operations */
	uint64_t fh;
        ......
}

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>