### PR TITLE
osdc/Objecter: fix race condition for sortbitwise flag detection

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3408,19 +3408,19 @@ void Objecter::list_nobjects(NListContext *list_context, Context *onfinish)
     return;
   }
   int pg_num = pool->get_pg_num();
+  bool sort_bitwise = osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE);
   rl.unlock();
 
   if (list_context->starting_pg_num == 0) {     // there can't be zero pgs!
     list_context->starting_pg_num = pg_num;
-    list_context->sort_bitwise = osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE);
+    list_context->sort_bitwise = sort_bitwise;
     ldout(cct, 20) << pg_num << " placement groups" << dendl;
   }
-  if (list_context->sort_bitwise !=
-      osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE)) {
+  if (list_context->sort_bitwise != sort_bitwise) {
     ldout(cct, 10) << " hobject sort order changed, restarting this pg"
 		   << dendl;
     list_context->cookie = collection_list_handle_t();
-    list_context->sort_bitwise = osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE);
+    list_context->sort_bitwise = sort_bitwise;
   }
   if (list_context->starting_pg_num != pg_num) {
     // start reading from the beginning; the pgs have changed
@@ -3564,19 +3564,19 @@ void Objecter::list_objects(ListContext *list_context, Context *onfinish)
     return;
   }
   int pg_num = pool->get_pg_num();
+  bool sort_bitwise = osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE);
   rl.unlock();
 
   if (list_context->starting_pg_num == 0) {     // there can't be zero pgs!
     list_context->starting_pg_num = pg_num;
-    list_context->sort_bitwise = osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE);
+    list_context->sort_bitwise = sort_bitwise;
     ldout(cct, 20) << pg_num << " placement groups" << dendl;
   }
-  if (list_context->sort_bitwise !=
-      osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE)) {
+  if (list_context->sort_bitwise != sort_bitwise) {
     ldout(cct, 10) << " hobject sort order changed, restarting this pg"
 		   << dendl;
     list_context->cookie = collection_list_handle_t();
-    list_context->sort_bitwise = osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE);
+    list_context->sort_bitwise = sort_bitwise;
   }
   if (list_context->starting_pg_num != pg_num) {
     // start reading from the beginning; the pgs have changed


### PR DESCRIPTION
During list_objects/list_nobjects(), we are checking osdmap's
sortbitwise flag setting without holding rwlock in hand, which
is a potential race condition.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>