### PR TITLE
os/filestore: Make sure str-pointer is not 0x0 when referenced

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4929,7 +4929,7 @@ int FileStore::omap_get_values(const coll_t& _c, const ghobject_t &hoid,
   const coll_t& c = !_need_temp_object_collection(_c, hoid) ? _c : _c.get_temp();
   dout(15) << __func__ << " " << c << "/" << hoid << dendl;
   Index index;
-  const char *where = 0;
+  const char *where = "()";
   int r = get_index(c, &index);
   if (r < 0) {
     where = " (get_index)";

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4947,6 +4947,7 @@ int FileStore::omap_get_values(const coll_t& _c, const ghobject_t &hoid,
   r = object_map->get_values(hoid, keys, out);
   if (r < 0 && r != -ENOENT) {
     assert(!m_filestore_fail_eio || r != -EIO);
+    where = " (get_values)";
     goto out;
   }
   r = 0;


### PR DESCRIPTION
ceph-osd crashes on reference to where if it is not get_index or lfn_find.
So init with an "empty" indicator "()

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>