### PR TITLE
[DNM] rgw: add global RGWHTTPManager to RGWRados

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1689,6 +1689,7 @@ struct RGWObjectCtx {
 
 class Finisher;
 class RGWAsyncRadosProcessor;
+class RGWHTTPManager;
 
 template <class T>
 class RGWChainedCacheImpl;
@@ -1756,6 +1757,7 @@ class RGWRados
   bool run_sync_thread;
 
   RGWAsyncRadosProcessor* async_rados;
+  RGWHTTPManager *http_manager;
 
   RGWMetaNotifier *meta_notifier;
   RGWDataNotifier *data_notifier;
@@ -1833,7 +1835,7 @@ protected:
 public:
   RGWRados() : max_req_id(0), lock("rados_timer_lock"), watchers_lock("watchers_lock"), timer(NULL),
                gc(NULL), obj_expirer(NULL), use_gc_thread(false), quota_threads(false),
-               run_sync_thread(false), async_rados(nullptr), meta_notifier(NULL),
+               run_sync_thread(false), async_rados(nullptr), http_manager(nullptr), meta_notifier(NULL),
                data_notifier(NULL), meta_sync_processor_thread(NULL),
                meta_sync_thread_lock("meta_sync_thread_lock"), data_sync_thread_lock("data_sync_thread_lock"),
                num_watchers(0), watchers(NULL),

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -604,14 +604,14 @@ int RGWRESTStreamWriteRequest::complete(string& etag, real_time *mtime)
   return status;
 }
 
-int RGWRESTStreamRWRequest::get_obj(RGWAccessKey& key, map<string, string>& extra_headers, rgw_obj& obj)
+int RGWRESTStreamRWRequest::get_obj(RGWAccessKey& key, map<string, string>& extra_headers, rgw_obj& obj, RGWHTTPManager *mgr)
 {
   string urlsafe_bucket, urlsafe_object;
   url_encode(obj.bucket.name, urlsafe_bucket);
   url_encode(obj.get_orig_obj(), urlsafe_object);
   string resource = urlsafe_bucket + "/" + urlsafe_object;
 
-  return get_resource(key, extra_headers, resource);
+  return get_resource(key, extra_headers, resource, mgr);
 }
 
 int RGWRESTStreamRWRequest::get_resource(RGWAccessKey& key, map<string, string>& extra_headers, const string& resource, RGWHTTPManager *mgr)

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -107,7 +107,7 @@ public:
                 chunk_ofs(0), ofs(0), http_manager(_cct), method(_method), write_ofs(0) {
   }
   virtual ~RGWRESTStreamRWRequest() {}
-  int get_obj(RGWAccessKey& key, map<string, string>& extra_headers, rgw_obj& obj);
+  int get_obj(RGWAccessKey& key, map<string, string>& extra_headers, rgw_obj& obj, RGWHTTPManager *mgr = NULL);
   int get_resource(RGWAccessKey& key, map<string, string>& extra_headers, const string& resource, RGWHTTPManager *mgr = NULL);
   int complete(string& etag, real_time *mtime, map<string, string>& attrs);
 

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -118,7 +118,7 @@ static void set_header(T val, map<string, string>& headers, const string& header
 int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, rgw_obj& obj,
                          const real_time *mod_ptr, const real_time *unmod_ptr,
                          uint32_t mod_zone_id, uint64_t mod_pg_ver,
-                         bool prepend_metadata, RGWGetDataCB *cb, RGWRESTStreamReadRequest **req)
+                         bool prepend_metadata, RGWGetDataCB *cb, RGWRESTStreamReadRequest **req, RGWHTTPManager *mgr)
 {
   string url;
   int ret = get_url(url);
@@ -163,7 +163,7 @@ int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, rgw
     set_header(mod_pg_ver, extra_headers, "HTTP_DEST_PG_VER");
   }
 
-  return (*req)->get_obj(key, extra_headers, obj);
+  return (*req)->get_obj(key, extra_headers, obj, mgr);
 }
 
 int RGWRESTConn::complete_request(RGWRESTStreamReadRequest *req, string& etag, real_time *mtime, map<string, string>& attrs)

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -93,7 +93,7 @@ public:
   int get_obj(const rgw_user& uid, req_info *info /* optional */, rgw_obj& obj,
               const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
               uint32_t mod_zone_id, uint64_t mod_pg_ver,
-              bool prepend_metadata, RGWGetDataCB *cb, RGWRESTStreamReadRequest **req);
+              bool prepend_metadata, RGWGetDataCB *cb, RGWRESTStreamReadRequest **req, RGWHTTPManager *mgr = NULL);
   int complete_request(RGWRESTStreamReadRequest *req, string& etag, ceph::real_time *mtime, map<string, string>& attrs);
 
   int get_resource(const string& resource,


### PR DESCRIPTION
RGWRados::fetch_remote_obj() uses the same RGWHTTPManager for all calls,
so that they can be stopped on shutdown

Signed-off-by: Yehuda Sadeh \<yehuda@redhat.com\>
Signed-off-by: Casey Bodley \<cbodley@redhat.com\>