### PR TITLE
radosgw-admin: add missing --zonegroup-id to usage

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -195,7 +195,8 @@ void _usage()
   cout << "   --realm-id=<realm id>     realm id\n";
   cout << "   --realm-new-name=<realm new name> realm new name\n";
   cout << "   --rgw-zonegroup=<zonegroup>   zonegroup name\n";
-  cout << "   --rgw-zone=<zone>         zone in which radosgw is running\n";
+  cout << "   --zonegroup-id=<zonegroup id> zonegroup id\n";
+  cout << "   --rgw-zone=<zone>         name of zone in which radosgw is running\n";
   cout << "   --zone-id=<zone id>       zone id\n";
   cout << "   --zone-new-name=<zone>    zone new name\n";
   cout << "   --source-zone             specify the source zone (for data sync)\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -147,7 +147,8 @@
      --realm-id=<realm id>     realm id
      --realm-new-name=<realm new name> realm new name
      --rgw-zonegroup=<zonegroup>   zonegroup name
-     --rgw-zone=<zone>         zone in which radosgw is running
+     --zonegroup-id=<zonegroup id> zonegroup id
+     --rgw-zone=<zone>         name of zone in which radosgw is running
      --zone-id=<zone id>       zone id
      --zone-new-name=<zone>    zone new name
      --source-zone             specify the source zone (for data sync)


### PR DESCRIPTION
also clarified that --rgw-zone takes the zone by name

Signed-off-by: Casey Bodley \<cbodley@redhat.com\>
Reported-by: John Wilkins \<jowilkin@redhat.com\>