### PR TITLE
client: renew caps for read/write if mds session got killed.

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -748,6 +748,7 @@ private:
   int _removexattr(Inode *in, const char *nm, int uid=-1, int gid=-1);
   int _removexattr(InodeRef &in, const char *nm);
   int _open(Inode *in, int flags, mode_t mode, Fh **fhp, int uid, int gid);
+  int _renew_caps(Inode *in);
   int _create(Inode *in, const char *name, int flags, mode_t mode, InodeRef *inp, Fh **fhp,
               int stripe_unit, int stripe_count, int object_size, const char *data_pool,
 	      bool *created, int uid, int gid);

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -253,6 +253,14 @@ int Inode::caps_wanted()
   return want;
 }
 
+int Inode::caps_mds_wanted()
+{
+  int want = 0;
+  for (auto it = caps.begin(); it != caps.end(); ++it)
+    want |= it->second->wanted;
+  return want;
+}
+
 int Inode::caps_dirty()
 {
   return dirty_caps | flushing_caps;

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -151,8 +151,9 @@ public:
 };
 
 // inode flags
-#define I_COMPLETE 1
-#define I_DIR_ORDERED 2
+#define I_COMPLETE	1
+#define I_DIR_ORDERED	2
+#define I_CAP_DROPPED	4
 
 struct Inode {
   Client *client;
@@ -348,6 +349,7 @@ struct Inode {
   int caps_used();
   int caps_file_wanted();
   int caps_wanted();
+  int caps_mds_wanted();
   int caps_dirty();
 
   bool have_valid_size();


### PR DESCRIPTION
When mds session got killed, read/write operation may hang (it also
can return -ESTALE). Client waits for Frw caps, but mds does not know
what caps client wants. To recover this, client sends an open request
to mds. The request will tell mds what caps client wants.

Signed-off-by: Yan, Zheng <zyan@redhat.com>