### PR TITLE
Event: do not increase EventCenter::file_events so aggresively

### DIFF
--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -149,9 +149,9 @@ int EventCenter::create_file_event(int fd, int mask, EventCallbackRef ctxt)
   int r = 0;
   Mutex::Locker l(file_lock);
   if (fd >= nevent) {
-    int new_size = nevent << 2;
+    int new_size = nevent << 1;
     while (fd > new_size)
-      new_size <<= 2;
+      new_size <<= 1;
     ldout(cct, 10) << __func__ << " event count exceed " << nevent << ", expand to " << new_size << dendl;
     r = driver->resize_events(new_size);
     if (r < 0) {


### PR DESCRIPTION
resize EventCenter::file_events array with x2 instead of x4

Signed-off-by: runsisi <runsisi@zte.com.cn>