### PR TITLE
vstart: replace ifconfig usage with ip addr

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -387,8 +387,13 @@ if [ -n "$ip" ]; then
     IP="$ip"
 else
     echo hostname $HOSTNAME
+    if [ -x "$(which ip 2>/dev/null)" ]; then
+	IP_CMD="ip addr"
+    else
+	IP_CMD="ifconfig"
+    fi
     # filter out IPv6 and localhost addresses
-    IP="$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -n1)"
+    IP="$($IP_CMD | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -n1)"
     # if nothing left, try using localhost address, it might work
     if [ -z "$IP" ]; then IP="127.0.0.1"; fi
 fi


### PR DESCRIPTION
Ifconfig is obsolete with Linux 2.0+, and may not be in a user's PATH.
Use ip addr instead.

Signed-off-by: David Disseldorp <ddiss@suse.de>