### PR TITLE
test: sudo to rm btrfs subvol

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -125,15 +125,10 @@ function teardown() {
 
 function __teardown_btrfs() {
     local btrfs_base_dir=$1
-
-    btrfs_dirs=`ls -l $btrfs_base_dir | egrep '^d' | awk '{print $9}'`
-    current_path=`pwd`
-    # extracting the current existing subvolumes
-    for subvolume in $(cd $btrfs_base_dir; btrfs subvolume list . -t |egrep '^[0-9]' | awk '{print $4}' |grep "$btrfs_base_dir/$btrfs_dir"); do
-       # Compute the relative path by removing the local path
-       # Like "erwan/chroot/ceph/src/testdir/test-7202/dev/osd1/snap_439" while we want "testdir/test-7202/dev/osd1/snap_439"
-       local_subvolume=$(echo $subvolume | sed -e "s|.*$current_path/||"g)
-       btrfs subvolume delete $local_subvolume
+    local btrfs_root=$(df -P . | tail -1 | awk '{print $NF}')
+    local btrfs_dirs=$(cd $btrfs_base_dir; sudo btrfs subvolume list . -t | awk '/^[0-9]/ {print $4}' | grep "$btrfs_base_dir/$btrfs_dir")
+    for subvolume in $btrfs_dirs; do
+       sudo btrfs subvolume delete $btrfs_root/$subvolume
     done
 }
 

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -1874,14 +1874,14 @@ def remove_btrfs_subvolumes(path):
     result = subprocess.Popen("stat -f -c '%%T' %s" % path, shell=True, stdout=subprocess.PIPE)
     filesystem = result.stdout.readlines()[0]
     if filesystem.rstrip('\n') == "btrfs":
-        result = subprocess.Popen("btrfs subvolume list %s" % path, shell=True, stdout=subprocess.PIPE)
+        result = subprocess.Popen("sudo btrfs subvolume list %s" % path, shell=True, stdout=subprocess.PIPE)
         for line in result.stdout.readlines():
             subvolume=line.split()[8]
             # extracting the relative volume name
             m = re.search(".*(%s.*)" % path, subvolume)
             if m:
                 found = m.group(1)
-                call("btrfs subvolume delete %s" % found, shell=True)
+                call("sudo btrfs subvolume delete %s" % found, shell=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
"btrfs subvolume {list,delete}" needs root privilege even if the current
user owns this subvol. one can only list/delete he/she is the root, or
if the btrfs volume was mounted with "-o user_subvol_rm_allowed".

Signed-off-by: Kefu Chai <kchai@redhat.com>