### PR TITLE
msgr,xio: flexible Messenger::create options

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -138,7 +138,7 @@ int main(int argc, const char **argv)
 
   Messenger *msgr = Messenger::create(g_ceph_context, g_conf->ms_type,
 				      entity_name_t::MDS(-1), "mds",
-				      getpid());
+				      getpid(), 0, Messenger::HAS_MANY_CONNECTIONS);
   if (!msgr)
     exit(1);
   msgr->set_cluster_protocol(CEPH_MDS_PROTOCOL);

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -663,9 +663,8 @@ int main(int argc, const char **argv)
   // bind
   int rank = monmap.get_rank(g_conf->name.get_id());
   Messenger *msgr = Messenger::create(g_ceph_context, g_conf->ms_type,
-				      entity_name_t::MON(rank),
-				      "mon",
-				      0);
+				      entity_name_t::MON(rank), "mon",
+				      0, 0, Messenger::HAS_MANY_CONNECTIONS);
   if (!msgr)
     exit(1);
   msgr->set_cluster_protocol(CEPH_MON_PROTOCOL);

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -447,19 +447,23 @@ int main(int argc, const char **argv)
 
   Messenger *ms_public = Messenger::create(g_ceph_context, g_conf->ms_type,
 					   entity_name_t::OSD(whoami), "client",
-					   getpid());
+					   getpid(), 0,
+					   Messenger::HAS_HEAVY_TRAFFIC |
+					   Messenger::HAS_MANY_CONNECTIONS);
   Messenger *ms_cluster = Messenger::create(g_ceph_context, g_conf->ms_type,
 					    entity_name_t::OSD(whoami), "cluster",
-					    getpid(), CEPH_FEATURES_ALL);
+					    getpid(), CEPH_FEATURES_ALL,
+					    Messenger::HAS_HEAVY_TRAFFIC |
+					    Messenger::HAS_MANY_CONNECTIONS);
   Messenger *ms_hbclient = Messenger::create(g_ceph_context, g_conf->ms_type,
 					     entity_name_t::OSD(whoami), "hbclient",
-					     getpid());
+					     getpid(), 0, Messenger::HEARTBEAT);
   Messenger *ms_hb_back_server = Messenger::create(g_ceph_context, g_conf->ms_type,
 						   entity_name_t::OSD(whoami), "hb_back_server",
-						   getpid());
+						   getpid(), 0, Messenger::HEARTBEAT);
   Messenger *ms_hb_front_server = Messenger::create(g_ceph_context, g_conf->ms_type,
 						    entity_name_t::OSD(whoami), "hb_front_server",
-						    getpid());
+						    getpid(), 0, Messenger::HEARTBEAT);
   Messenger *ms_objecter = Messenger::create(g_ceph_context, g_conf->ms_type,
 					     entity_name_t::OSD(whoami), "ms_objecter",
 					     getpid());

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -21,7 +21,7 @@ Messenger *Messenger::create_client_messenger(CephContext *cct, string lname)
 
 Messenger *Messenger::create(CephContext *cct, const string &type,
 			     entity_name_t name, string lname,
-			     uint64_t nonce, uint64_t features)
+			     uint64_t nonce, uint64_t features, uint64_t cflags)
 {
   int r = -1;
   if (type == "random") {
@@ -36,7 +36,7 @@ Messenger *Messenger::create(CephContext *cct, const string &type,
 #ifdef HAVE_XIO
   else if ((type == "xio") &&
 	   cct->check_experimental_feature_enabled("ms-type-xio"))
-    return new XioMessenger(cct, name, lname, nonce, features);
+    return new XioMessenger(cct, name, lname, nonce, features, cflags);
 #endif
   lderr(cct) << "unrecognized ms_type '" << type << "'" << dendl;
   return nullptr;

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -53,6 +53,14 @@ protected:
 
 public:
   /**
+   * Various Messenger conditional config/type flags to allow
+   * different "transport" Messengers to tune themselves
+   */
+  static const int HAS_HEAVY_TRAFFIC    = 0x0001;
+  static const int HAS_MANY_CONNECTIONS = 0x0002;
+  static const int HEARTBEAT            = 0x0004;
+
+  /**
    *  The CephContext this Messenger uses. Many other components initialize themselves
    *  from this value.
    */
@@ -151,13 +159,15 @@ public:
    * @param lname logical name of the messenger in this process (e.g., "client")
    * @param nonce nonce value to uniquely identify this instance on the current host
    * @param features bits for the local connection
+   * @param cflags general set of flags to configure transport resources
    */
   static Messenger *create(CephContext *cct,
                            const string &type,
                            entity_name_t name,
 			   string lname,
                            uint64_t nonce,
-			   uint64_t features = 0);
+			   uint64_t features = 0,
+			   uint64_t cflags = 0);
 
   /**
    * create a new messenger

--- a/src/msg/xio/XioMessenger.h
+++ b/src/msg/xio/XioMessenger.h
@@ -64,6 +64,7 @@ private:
 public:
   XioMessenger(CephContext *cct, entity_name_t name,
 	       string mname, uint64_t nonce, uint64_t features,
+	       uint64_t cflags = 0,
 	       DispatchStrategy* ds = new QueueStrategy(1));
 
   virtual ~XioMessenger();
@@ -149,8 +150,8 @@ public:
   void learned_addr(const entity_addr_t& peer_addr_for_me);
 
 private:
-  int get_nconns_per_portal();
-  int get_nportals();
+  int get_nconns_per_portal(uint64_t cflags);
+  int get_nportals(uint64_t cflags);
 
 protected:
   virtual void ready()

--- a/src/test/messenger/xio_client.cc
+++ b/src/test/messenger/xio_client.cc
@@ -117,7 +117,7 @@ int main(int argc, const char **argv)
 	messenger = new XioMessenger(g_ceph_context,
 				     entity_name_t::MON(-1),
 				     "xio_client",
-				     0 /* nonce */, XIO_ALL_FEATURES,
+				     0 /* nonce */, XIO_ALL_FEATURES, 0 /* cflags */,
 				     dstrategy);
 
 	// enable timing prints

--- a/src/test/messenger/xio_server.cc
+++ b/src/test/messenger/xio_server.cc
@@ -88,7 +88,7 @@ int main(int argc, const char **argv)
 	messenger = new XioMessenger(g_ceph_context,
 				     entity_name_t::MON(-1),
 				     "xio_server",
-				     0 /* nonce */, XIO_ALL_FEATURES,
+				     0 /* nonce */, XIO_ALL_FEATURES, 0 /* cflags */,
 				     dstrategy);
 
 	static_cast<XioMessenger*>(messenger)->set_magic(


### PR DESCRIPTION
Widen Messenger::create and XioMessenger constructor to support
per-Messenger instance creation parameters.

This introduces a minimalist Proplist mechanism, based on <map>
and <boost::variant>, to pass in general parameters to
Messenger::create() without changing policy or involving names

Used the new Proplist to apply xio_portal_threads and
xio_max_conns_per_portal to XioMessenger. Tested with
xio_client/xio_server and cluster bringup with and without
Proplist.

We will extend the usage of Proplist to ceph-osd's
"workhorse" and "light" Messenger instances, and other
ceph clients Messenger in next patch

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
Signed-off-by: Vu Pham <vu@mellanox.com>