### PR TITLE
common: fix value of CINIT_FLAG_DEFER_DROP_PRIVILEGES

### DIFF
--- a/src/common/common_init.h
+++ b/src/common/common_init.h
@@ -39,7 +39,7 @@ enum common_init_flags_t {
   CINIT_FLAG_NO_DAEMON_ACTIONS = 0x8,
 
   // don't drop privileges
-  CINIT_FLAG_DEFER_DROP_PRIVILEGES = 0x16,
+  CINIT_FLAG_DEFER_DROP_PRIVILEGES = 0x10,
 };
 
 /*


### PR DESCRIPTION
This was causing hangs in test/rgw/test_multi.py, because radosgw is being started via the python subprocess module, which waits for radosgw to terminate or close its stderr. Even though we don't pass `CINIT_FLAG_NO_CLOSE_STDERR` to `global_init()`, it still wasn't being closed.

It turns out that `CINIT_FLAG_DEFER_DROP_PRIVILEGES` has a hex value that overlaps both `CINIT_FLAG_NO_DEFAULT_CONFIG_FILE` and `CINIT_FLAG_NO_CLOSE_STDERR`, causing them to be silently enabled when using civetweb.