### PR TITLE
cmake: add library cls_journal for target unittest_librbd

### DIFF
--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(unittest_librbd
   cls_lock
   cls_lock_client
   journal
+  cls_journal
   cls_journal_client
   rados_test_stub
   librados


### PR DESCRIPTION
otherwise if we want to generate target unittest_librbd we need to
(re)generate cls_journal manually

Signed-off-by: runsisi <runsisi@zte.com.cn>