### PR TITLE
librbd: fix potential assertion for object map invalidation

### DIFF
--- a/src/librbd/object_map/InvalidateRequest.cc
+++ b/src/librbd/object_map/InvalidateRequest.cc
@@ -47,6 +47,7 @@ void InvalidateRequest<I>::send() {
   r = image_ctx.update_flags(m_snap_id, flags, true);
   if (r < 0) {
     this->async_complete(r);
+    return;
   }
 
   // do not update on-disk flags if not image owner


### PR DESCRIPTION
if update_flags fails we should not go any further, or the async request
will be removed from m_image_ctx.async_requests twice

Signed-off-by: runsisi <runsisi@zte.com.cn>