### PR TITLE
hammer: is_split crash in handle_pg_create

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2188,10 +2188,12 @@ void PG::split_into(pg_t child_pgid, PG *child, unsigned split_bits)
 
   // Info
   child->info.history = info.history;
+  child->info.history.epoch_created = get_osdmap()->get_epoch();
   child->info.purged_snaps = info.purged_snaps;
   child->info.last_backfill = info.last_backfill;
 
   child->info.stats = info.stats;
+  child->info.stats.parent_split_bits = split_bits;
   info.stats.stats_invalid = true;
   child->info.stats.stats_invalid = true;
   child->info.last_epoch_started = info.last_epoch_started;


### PR DESCRIPTION
http://tracker.ceph.com/issues/15482