### PR TITLE
osd: fast dispatch heartbeat message

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1594,6 +1594,20 @@ public:
   struct HeartbeatDispatcher : public Dispatcher {
     OSD *osd;
     explicit HeartbeatDispatcher(OSD *o) : Dispatcher(o->cct), osd(o) {}
+
+    bool ms_can_fast_dispatch_any() const { return true; }
+    bool ms_can_fast_dispatch(Message *m) const {
+      switch (m->get_type()) {
+	case CEPH_MSG_PING:
+	case MSG_OSD_PING:
+          return true;
+	default:
+          return false;
+	}
+    }
+    void ms_fast_dispatch(Message *m) {
+      osd->heartbeat_dispatch(m);
+    }
     bool ms_dispatch(Message *m) {
       return osd->heartbeat_dispatch(m);
     }


### PR DESCRIPTION
As for simple messenger implementation, in a large-scaled ceph cluster, hundreds of threads are used to do heartbeat. Also, the total thread number of one node is approximately linear to qemu VMs (a.k.a librbd client) in extreme case.

Recently, we tested an extreme case: 80 ceph nodes, each has 9 OSDs. 
We ran fio instance in each VM. We observed that when more than 1000 VMs, there were about 30000 thread in our environment.

We observed that  dispatch thread may delay due to system schedule. 
Also, even if heartbeat uses independent messenger, many heartbeat reader threads and the dispatch thread will compete with the disptach queue lock, which might also delay dispatch thread if it fails to get the lock. 






Signed-off-by: Wei Jin <wjin.cn@gmail.com>