### PR TITLE
osd: fix problematic got_full_map() logic

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4954,23 +4954,18 @@ void OSD::got_full_map(epoch_t e)
 	     << ", ignoring" << dendl;
     return;
   }
-  if (e > requested_full_first) {
+  if (e >= requested_full_last) {
     dout(10) << __func__ << " " << e << ", requested " << requested_full_first
 	     << ".." << requested_full_last << ", resetting" << dendl;
     requested_full_first = requested_full_last = 0;
     return;
   }
-  if (requested_full_first == requested_full_last) {
-    dout(10) << __func__ << " " << e << ", requested " << requested_full_first
-	     << ".." << requested_full_last
-	     << ", now done" << dendl;
-    requested_full_first = requested_full_last = 0;
-  } else {
-    dout(10) << __func__ << " " << e << ", requested " << requested_full_first
-	     << ".." << requested_full_last
-	     << ", still need more" << dendl;
-    ++requested_full_first;
-  }
+  
+  requested_full_first = e + 1;
+
+  dout(10) << __func__ << " " << e << ", requested " << requested_full_first
+           << ".." << requested_full_last
+           << ", still need more" << dendl;
 }
 
 void OSD::requeue_failures()


### PR DESCRIPTION
We shall only clear out requested_full_first/last either we got all
we want or we received a map that was newer than requested_full_last.

Also we shall increase requested_full_first properly to reflect exactly
we have got instead of advancing requested_full_first blindly.

NB: if requested_full_first is equal to requested_full_last, we still
have one epoch to request.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>