### PR TITLE
osd reweight-by-*: sort osds by diff from mean

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -599,9 +599,9 @@ int OSDMonitor::reweight_by_utilization(int oload,
     util_by_osd.push_back(osd_util);
   }
 
-  // sort and iterate from most to least utilized
-  std::sort(util_by_osd.begin(), util_by_osd.end(), [](std::pair<int, float> l, std::pair<int, float> r) {
-    return l.second > r.second;
+  // sort and iterate from most to least absolute difference to the mean utilization
+  std::sort(util_by_osd.begin(), util_by_osd.end(), [&](std::pair<int, float> l, std::pair<int, float> r) {
+    return std::abs(l.second - average_util) > std::abs(r.second - average_util);
   });
 
   OSDMap::Incremental newinc;


### PR DESCRIPTION
Sort the OSDs by their absolute difference from average_util, instead of
their utilization. Without this, the underloaded OSDs are reweighted last,
which means never unless the admins reweights all OSDs (not recommended).

Backport: jewel
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>