### PR TITLE
rbd: disk usage now includes all snapshots by default

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -282,6 +282,7 @@
   rbd help disk-usage
   usage: rbd disk-usage [--pool <pool>] [--image <image>] [--snap <snap>] 
                         [--format <format>] [--pretty-format] 
+                        [--from-snap <from-snap>] 
                         <image-or-snap-spec> 
   
   Show disk usage stats for pool, image or snapshot
@@ -296,6 +297,7 @@
     --snap arg            snapshot name
     --format arg          output format [plain, json, or xml]
     --pretty-format       pretty formatting (json and xml)
+    --from-snap arg       snapshot starting point
   
   rbd help export
   usage: rbd export [--pool <pool>] [--image <image>] [--snap <snap>] 


### PR DESCRIPTION
Added a new "--from-snap" optional to restrict the calculation to
specific subsets of snapshots and the HEAD revision.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>