### PR TITLE
cmake: fix linking of compressor and plugins

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,6 +327,7 @@ set(libcommon_files
   common/fs_types.cc
   ${arch_files}
   ${auth_files}
+  $<TARGET_OBJECTS:compressor_objs>
   ${mds_files})
 set(mon_common_files
   auth/AuthSessionHandler.cc

--- a/src/compressor/CMakeLists.txt
+++ b/src/compressor/CMakeLists.txt
@@ -2,8 +2,7 @@
 set(compressor_srcs 
   Compressor.cc
   AsyncCompressor.cc)
-add_library(compressor STATIC ${compressor_srcs})
-target_link_libraries(compressor common snappy ${CMAKE_DL_LIBS})
+add_library(compressor_objs OBJECT ${compressor_srcs})
 
 ## compressor plugins
 
@@ -11,8 +10,6 @@ set(compressorlibdir ${LIBRARY_OUTPUT_PATH}/compressor)
 
 add_subdirectory(snappy)
 add_subdirectory(zlib)
-
-add_library(compressor_objs OBJECT Compressor.cc)
 
 add_custom_target(compressor_plugins DEPENDS
     ceph_snappy

--- a/src/compressor/snappy/CMakeLists.txt
+++ b/src/compressor/snappy/CMakeLists.txt
@@ -1,14 +1,11 @@
 # snappy
 
-# absolute path because $snappy_sources used outside of this directory
 set(snappy_sources
-  ${CMAKE_SOURCE_DIR}/src/compressor/snappy/CompressionPluginSnappy.cc
-  $<TARGET_OBJECTS:compressor_objs>
+  CompressionPluginSnappy.cc
 )
 
 add_library(ceph_snappy SHARED ${snappy_sources})
 add_dependencies(ceph_snappy ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ceph_snappy ${EXTRALIBS})
-set_target_properties(ceph_snappy PROPERTIES VERSION 2.14.0 SOVERSION 2)
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lsnappy")
+target_link_libraries(ceph_snappy snappy)
+set_target_properties(ceph_snappy PROPERTIES VERSION 2.0.0 SOVERSION 2)
 install(TARGETS ceph_snappy DESTINATION lib/compressor)

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -3,12 +3,10 @@
 set(zlib_sources
   CompressionPluginZlib.cc
   CompressionZlib.cc
-  $<TARGET_OBJECTS:compressor_objs>
 )
 
 add_library(ceph_zlib SHARED ${zlib_sources})
 add_dependencies(ceph_zlib ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ceph_zlib ${EXTRALIBS})
-set_target_properties(ceph_zlib PROPERTIES VERSION 2.14.0 SOVERSION 2)
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lz")
+target_link_libraries(ceph_zlib z)
+set_target_properties(ceph_zlib PROPERTIES VERSION 2.0.0 SOVERSION 2)
 install(TARGETS ceph_zlib DESTINATION lib/compressor)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -160,6 +160,7 @@ add_executable(unittest_async_compressor EXCLUDE_FROM_ALL
 )
 add_ceph_unittest(unittest_async_compressor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_async_compressor)
 target_link_libraries(unittest_async_compressor global)
+add_dependencies(unittest_async_compressor ceph_snappy)
 
 # unittest_interval_set
 add_executable(unittest_interval_set EXCLUDE_FROM_ALL

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -159,7 +159,7 @@ add_executable(unittest_async_compressor EXCLUDE_FROM_ALL
   test_async_compressor.cc
 )
 add_ceph_unittest(unittest_async_compressor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_async_compressor)
-target_link_libraries(unittest_async_compressor global compressor)
+target_link_libraries(unittest_async_compressor global)
 
 # unittest_interval_set
 add_executable(unittest_interval_set EXCLUDE_FROM_ALL

--- a/src/test/common/test_async_compressor.cc
+++ b/src/test/common/test_async_compressor.cc
@@ -212,6 +212,17 @@ int main(int argc, char **argv) {
 
   const char* env = getenv("CEPH_LIB");
   string directory(env ? env : "lib");
+
+  // copy libceph_snappy.so into $plugin_dir/compressor for PluginRegistry
+  // TODO: just build the compressor plugins in this subdir
+  string mkdir_compressor = "mkdir -p " + directory + "/compressor";
+  int r = system(mkdir_compressor.c_str());
+  (void)r;
+
+  string cp_libceph_snappy = "cp " + directory + "/libceph_snappy.so* " + directory + "/compressor/";
+  r = system(cp_libceph_snappy.c_str());
+  (void)r;
+
   g_conf->set_val("plugin_dir", directory, false, false);
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/test/compressor/CMakeLists.txt
+++ b/src/test/compressor/CMakeLists.txt
@@ -1,76 +1,39 @@
-add_library(ceph_example SHARED
-  compressor_plugin_example.cc
-  ${CMAKE_SOURCE_DIR}/src/compressor/Compressor.cc
-  )
-target_link_libraries(ceph_example crush pthread ${EXTRA_LIBS})
+add_library(ceph_example SHARED compressor_plugin_example.cc)
 
 # unittest_compression_plugin
 add_executable(unittest_compression_plugin EXCLUDE_FROM_ALL
   test_compression_plugin.cc
-  ${CMAKE_SOURCE_DIR}/src/compressor/Compressor.cc
   )
 add_ceph_unittest(unittest_compression_plugin ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression_plugin)
-target_link_libraries(unittest_compression_plugin 
-  osd
-  common 
-  global 
-  dl 
-  )
+target_link_libraries(unittest_compression_plugin global)
+add_dependencies(unittest_compression_plugin ceph_example)
 
 # unittest_compression_snappy
 add_executable(unittest_compression_snappy EXCLUDE_FROM_ALL
   test_compression_snappy.cc
-  ${snappy_sources}
   )
 add_ceph_unittest(unittest_compression_snappy ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression_snappy)
-target_link_libraries(unittest_compression_snappy 
-  osd
-  common 
-  global 
-  dl 
-  snappy
-  )
+target_link_libraries(unittest_compression_snappy global ceph_snappy)
 
 # unittest_compression_plugin_snappy
 add_executable(unittest_compression_plugin_snappy EXCLUDE_FROM_ALL
   test_compression_plugin_snappy.cc
-  ${snappy_sources}
   )
 add_ceph_unittest(unittest_compression_plugin_snappy ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression_plugin_snappy)
-target_link_libraries(unittest_compression_plugin_snappy 
-  osd
-  common 
-  global 
-  compressor
-  dl 
-  snappy
-  )
+target_link_libraries(unittest_compression_plugin_snappy global)
+add_dependencies(unittest_compression_plugin_snappy ceph_snappy)
 
 # unittest_compression_zlib
 add_executable(unittest_compression_zlib EXCLUDE_FROM_ALL
   test_compression_zlib.cc
-  ${CMAKE_SOURCE_DIR}/src/compressor/zlib/CompressionZlib.cc
   )
 add_ceph_unittest(unittest_compression_zlib ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression_zlib)
-target_link_libraries(unittest_compression_zlib 
-  z
-  osd
-  common 
-  global 
-  )
+target_link_libraries(unittest_compression_zlib global ceph_zlib)
 
 # unittest_compression_plugin_zlib
 add_executable(unittest_compression_plugin_zlib EXCLUDE_FROM_ALL
   test_compression_plugin_zlib.cc
-  ${zlib_sources}
   )
 add_ceph_unittest(unittest_compression_plugin_zlib ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression_plugin_zlib)
-target_link_libraries(unittest_compression_plugin_zlib 
-  osd
-  common 
-  global 
-  compressor
-  dl 
-  z
-  )
-
+target_link_libraries(unittest_compression_plugin_zlib global)
+add_dependencies(unittest_compression_plugin_zlib ceph_zlib)


### PR DESCRIPTION
libcommon now includes the compressor objects necessary to load compressor plugins

also removed extra dependencies on the plugins and their unit tests

Signed-off-by: Casey Bodley \<cbodley@redhat.com\>