### PR TITLE
debian: fix /etc/default/ceph location

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -138,8 +138,8 @@ binary-arch: build install
 	# install the systemd stuff manually since we have funny service names
 	install -d -m0755 debian/ceph-common/lib/systemd/system
 	install -m0644 systemd/ceph.target debian/ceph-common/lib/systemd/system
-	install -d -m0755 debian/ceph-common/etc/default/ceph
-	install -m0644 etc/default/ceph debian/ceph-common/etc/default/ceph
+	install -d -m0755 debian/ceph-common/etc/default
+	install -m0644 etc/default/ceph debian/ceph-common/etc/default/
 	install -d -m0755 debian/ceph-common/usr/lib/tmpfiles.d
 	install -m 0644 -D systemd/ceph.tmpfiles.d debian/ceph-common/usr/lib/tmpfiles.d/ceph.conf
 


### PR DESCRIPTION
commit 7384a14f243519547a61534d22e21e6069aae016 have introduce
the /etc/default/ceph file at a wrong location : /etc/default/ceph/ceph

fix http://tracker.ceph.com/issues/15587

