### PR TITLE
cmake: put virtualenv directories under /tmp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -524,6 +524,12 @@ install(TARGETS rados librados-config DESTINATION bin)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/
   DESTINATION ${PYTHON_INSTDIR})
 
+# virtualenv base directory for ceph-disk and ceph-detect-init
+set(CEPH_BUILD_VIRTUALENV $ENV{TMPDIR})
+if(NOT CEPH_BUILD_VIRTUALENV)
+  set(CEPH_BUILD_VIRTUALENV /tmp)
+endif()
+
 add_subdirectory(pybind)
 add_subdirectory(ceph-disk)
 add_subdirectory(ceph-detect-init)

--- a/src/ceph-detect-init/CMakeLists.txt
+++ b/src/ceph-detect-init/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CEPH_DETECT_INIT_VIRTUALENV ${CMAKE_BINARY_DIR}/ceph-detect-init-virtualenv)
+set(CEPH_DETECT_INIT_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-virtualenv)
 
 add_custom_target(ceph-detect-init
   COMMAND

--- a/src/ceph-disk/CMakeLists.txt
+++ b/src/ceph-disk/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CEPH_DISK_VIRTUALENV ${CMAKE_BINARY_DIR}/ceph-disk-virtualenv)
+set(CEPH_DISK_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv)
 
 add_custom_target(ceph-disk
   COMMAND


### PR DESCRIPTION
this was required for cmake-check to find ceph-disk and ceph-detect-init in the PATH (because that's where automake puts them)