### PR TITLE
etc/default/ceph: set 128MB tcmalloc cache size

### DIFF
--- a/etc/default/ceph
+++ b/etc/default/ceph
@@ -3,6 +3,10 @@
 # Environment file for ceph daemon systemd unit files.
 #
 
+# Increase tcmalloc cache size
+TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=128MB
+
+
 ## use jemalloc instead of tcmalloc
 #
 # jemalloc is generally faster for small IO workloads and when

--- a/etc/default/ceph
+++ b/etc/default/ceph
@@ -4,8 +4,7 @@
 #
 
 # Increase tcmalloc cache size
-TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=128MB
-
+TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728
 
 ## use jemalloc instead of tcmalloc
 #


### PR DESCRIPTION
Signed-off-by: Alexandre Derumier <aderumier@odiso.com>

commit https://github.com/ceph/ceph/commit/9565a50c58194bf2ffd52f6c3cc797a28047ddbe

have increased tcmalloc cache size to 128M in rpm sysconfig.

We need to do the same for deb /etc/default/ceph

This fix : http://tracker.ceph.com/issues/15588