### PR TITLE
DNM: log: use coarse time

### DIFF
--- a/src/common/Graylog.cc
+++ b/src/common/Graylog.cc
@@ -84,7 +84,8 @@ void Graylog::log_entry(Entry const * const e)
     m_formatter->dump_string("host", m_hostname);
     m_formatter->dump_string("short_message", s);
     m_formatter->dump_string("_app", "ceph");
-    m_formatter->dump_float("timestamp", e->m_stamp.sec() + (e->m_stamp.usec() / 1000000.0));
+    auto ts = ceph::coarse_real_clock::to_timespec(e->m_stamp);
+    m_formatter->dump_float("timestamp", ts.tv_sec + (ts.tv_nsec / 1000000000.0));
     m_formatter->dump_int("_thread", e->m_thread);
     m_formatter->dump_int("_level", e->m_prio);
     if (m_subs != NULL)

--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -118,4 +118,33 @@ namespace ceph {
   operator<< <coarse_mono_clock>(std::ostream& m, const coarse_mono_time& t);
   template std::ostream&
   operator<< <coarse_real_clock>(std::ostream& m, const coarse_real_time& t);
-}
+
+  int snprintf_time(char *out, size_t outlen, const real_time& t)
+  {
+    struct tm bdt;
+    time_t tt = ceph::real_clock::to_time_t(t);
+    localtime_r(&tt, &bdt);
+    auto usec = duration_cast<microseconds>(
+      t.time_since_epoch() % seconds(1));
+    return ::snprintf(
+      out, outlen,
+      "%04d-%02d-%02d %02d:%02d:%02d.%06ld",
+      bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
+      bdt.tm_hour, bdt.tm_min, bdt.tm_sec, usec.count());
+  }
+
+  int snprintf_time(char *out, size_t outlen, const coarse_real_time& t)
+  {
+    struct tm bdt;
+    time_t tt = ceph::coarse_real_clock::to_time_t(t);
+    localtime_r(&tt, &bdt);
+    auto usec = duration_cast<microseconds>(
+      t.time_since_epoch() % seconds(1));
+    return ::snprintf(
+      out, outlen,
+      "%04d-%02d-%02d %02d:%02d:%02d.%03ld",
+      bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
+      bdt.tm_hour, bdt.tm_min, bdt.tm_sec, usec.count() / 1000);
+  }
+};
+

--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -412,6 +412,9 @@ namespace ceph {
   std::ostream& operator<<(std::ostream& m,
 			   const std::chrono::time_point<Clock>& t);
 
+  int snprintf_time(char *out, size_t outlen, const real_time& t);
+  int snprintf_time(char *out, size_t outlen, const coarse_real_time& t);
+
   // The way std::chrono handles the return type of subtraction is not
   // wonderful. The difference of two unsigned types SHOULD be signed.
 

--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -4,9 +4,10 @@
 #ifndef __CEPH_LOG_ENTRY_H
 #define __CEPH_LOG_ENTRY_H
 
-#include "include/utime.h"
+#include "common/ceph_time.h"
 #include "common/PrebufferedStreambuf.h"
 #include <pthread.h>
+#include <iostream>
 #include <string>
 
 
@@ -14,7 +15,7 @@ namespace ceph {
 namespace log {
 
 struct Entry {
-  utime_t m_stamp;
+  coarse_real_clock::time_point m_stamp;
   pthread_t m_thread;
   short m_prio, m_subsys;
   Entry *m_next;
@@ -31,8 +32,12 @@ struct Entry {
       m_buf_len(sizeof(m_static_buf)),
       m_exp_len(NULL)
   {}
-  Entry(utime_t s, pthread_t t, short pr, short sub,
-  const char *msg = NULL)
+  Entry(
+    ceph::coarse_real_clock::time_point s,
+    pthread_t t,
+    short pr,
+    short sub,
+    const char *msg = NULL)
       : m_stamp(s), m_thread(t), m_prio(pr), m_subsys(sub),
         m_next(NULL),
         m_streambuf(m_static_buf, sizeof(m_static_buf)),
@@ -40,12 +45,19 @@ struct Entry {
         m_exp_len(NULL)
     {
       if (msg) {
-        ostream os(&m_streambuf);
+        std::ostream os(&m_streambuf);
         os << msg;
       }
     }
-  Entry(utime_t s, pthread_t t, short pr, short sub, char* buf, size_t buf_len, size_t* exp_len,
-	const char *msg = NULL)
+  Entry(
+    ceph::coarse_real_clock::time_point s,
+    pthread_t t,
+    short pr,
+    short sub,
+    char* buf,
+    size_t buf_len,
+    size_t* exp_len,
+    const char *msg = NULL)
     : m_stamp(s), m_thread(t), m_prio(pr), m_subsys(sub),
       m_next(NULL),
       m_streambuf(buf, buf_len),
@@ -53,7 +65,7 @@ struct Entry {
       m_exp_len(exp_len)
   {
     if (msg) {
-      ostream os(&m_streambuf);
+      std::ostream os(&m_streambuf);
       os << msg;
     }
   }
@@ -74,7 +86,7 @@ struct Entry {
   }
 
   void set_str(const std::string &s) {
-    ostream os(&m_streambuf);
+    std::ostream os(&m_streambuf);
     os << s;
   }
 

--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -28,7 +28,7 @@ TEST(Log, Simple)
     int sys = i % 4;
     int l = 5 + (i%4);
     if (subs.should_gather(sys, l)) {
-      Entry *e = new Entry(ceph_clock_now(NULL),
+      Entry *e = new Entry(ceph::coarse_real_clock::now(NULL),
 			   pthread_self(),
 			   l,
 			   sys,
@@ -57,7 +57,8 @@ TEST(Log, ManyNoGather)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l))
-      log.submit_entry(new Entry(ceph_clock_now(NULL), pthread_self(), l, 1));
+      log.submit_entry(new Entry(ceph::coarse_real_clock::now(NULL),
+				 pthread_self(), l, 1));
   }
   log.flush();
   log.stop();
@@ -75,7 +76,8 @@ TEST(Log, ManyGatherLog)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l))
-      log.submit_entry(new Entry(ceph_clock_now(NULL), pthread_self(), l, 1,
+      log.submit_entry(new Entry(ceph::coarse_real_clock::now(NULL),
+				 pthread_self(), l, 1,
 				 "this is a long string asdf asdf asdf asdf asdf asdf asd fasd fasdf "));
   }
   log.flush();
@@ -93,7 +95,8 @@ TEST(Log, ManyGatherLogStringAssign)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l)) {
-      Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), l, 1);
+      Entry *e = new Entry(ceph::coarse_real_clock::now(NULL),
+			   pthread_self(), l, 1);
       ostringstream oss;
       oss << "this i a long stream asdf asdf asdf asdf asdf asdf asdf asdf asdf as fd";
       e->set_str(oss.str());
@@ -114,7 +117,8 @@ TEST(Log, ManyGatherLogStringAssignWithReserve)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l)) {
-      Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), l, 1);
+      Entry *e = new Entry(ceph::coarse_real_clock::now(NULL),
+			   pthread_self(), l, 1);
       ostringstream oss;
       oss.str().reserve(80);
       oss << "this i a long stream asdf asdf asdf asdf asdf asdf asdf asdf asdf as fd";
@@ -137,7 +141,8 @@ TEST(Log, ManyGatherLogPrebuf)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l)) {
-      Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), l, 1);
+      Entry *e = new Entry(ceph::coarse_real_clock::now(NULL),
+			   pthread_self(), l, 1);
       PrebufferedStreambuf psb(e->m_static_buf, sizeof(e->m_static_buf));
       ostream oss(&psb);
       oss << "this i a long stream asdf asdf asdf asdf asdf asdf asdf asdf asdf as fd";
@@ -160,7 +165,7 @@ TEST(Log, ManyGatherLogPrebufOverflow)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l)) {
-      Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), l, 1);
+      Entry *e = new Entry(ceph::coarse_real_clock::now(NULL), pthread_self(), l, 1);
       PrebufferedStreambuf psb(e->m_static_buf, sizeof(e->m_static_buf));
       ostream oss(&psb);
       oss << "this i a long stream asdf asdf asdf asdf asdf asdf asdf asdf asdf as fd"
@@ -184,7 +189,7 @@ TEST(Log, ManyGather)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l))
-      log.submit_entry(new Entry(ceph_clock_now(NULL), pthread_self(), l, 1));
+      log.submit_entry(new Entry(ceph::coarse_real_clock::now(NULL), pthread_self(), l, 1));
   }
   log.flush();
   log.stop();
@@ -200,7 +205,7 @@ void do_segv()
   log.reopen_log_file();
 
   log.inject_segv();
-  Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), 10, 1);
+  Entry *e = new Entry(ceph::coarse_real_clock::now(NULL), pthread_self(), 10, 1);
   log.submit_entry(e);  // this should segv
 
   log.flush();
@@ -221,7 +226,7 @@ TEST(Log, LargeLog)
   log.set_log_file("/tmp/big");
   log.reopen_log_file();
   int l = 10;
-  Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), l, 1);
+  Entry *e = new Entry(ceph::coarse_real_clock::now(NULL), pthread_self(), l, 1);
 
   std::string msg(10000000, 0);
   e->set_str(msg);


### PR DESCRIPTION
```
- coarse time is way faster than gettimeofday.
- log events are ordered, so the exact timestamps mostly only matter when
  comparing events across hosts.  and host clocks drift anyway, so there
  is little value for debugging purposes.
- if you *do* need accurate time for events, modify the code to log it
  explicitly.
```
