### PR TITLE
osd/OSD: make 'ceph tell osd.x get_command_descriptions' work.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5586,6 +5586,9 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       }
     }
 
+    if (osize && bsize > osize)
+      bsize = osize;
+
     dout(1) << " bench count " << count
             << " bsize " << prettybyte_t(bsize) << dendl;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5329,6 +5329,7 @@ COMMAND("list_missing " \
 
 // tell <osd.n> commands.  Validation of osd.n must be special-cased in client
 COMMAND("version", "report version of OSD", "osd", "r", "cli,rest")
+COMMAND("get_command_descriptions", "list commands descriptions", "osd", "r", "cli,rest")
 COMMAND("injectargs " \
 	"name=injected_args,type=CephString,n=N",
 	"inject configuration arguments into running OSD",

--- a/src/test/osd/osd-bench.sh
+++ b/src/test/osd/osd-bench.sh
@@ -77,6 +77,16 @@ function TEST_bench() {
     # default values should work
     #
     ceph tell osd.0 bench || return 1
+
+    #
+    # test object_size < block_size
+    ceph tell osd.0 bench 10 14456 4444 3
+    #
+
+    #
+    # test object_size < block_size & object_size = 0(default value)
+    #
+    ceph tell osd.0 bench 1 14456
 }
 
 main osd-bench "$@"


### PR DESCRIPTION
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>