### PR TITLE
osd/OpRequest: reset connection upon unregister

### DIFF
--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -82,6 +82,10 @@ void OpRequest::_unregistered() {
   request->clear_data();
   request->clear_payload();
   request->release_message_throttle();
+  auto conn = request->get_connection();
+  if (conn) {
+    conn->set_priv(nullptr);
+  }
 }
 
 bool OpRequest::check_rmw(int flag) {


### PR DESCRIPTION
this helps to free the resources referenced by the connection, among
other things, in the case of MOSDOp, the OSD::Session and OSDMap. this
helps to free the resource earlier and trim the osdmaps in time.

Fixes: http://tracker.ceph.com/issues/13990
Signed-off-by: Kefu Chai <kchai@redhat.com>