### PR TITLE
ceph-disk: add option to not lock prepare

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1840,6 +1840,11 @@ class Prepare(object):
             default='{statedir}/bootstrap-osd/{cluster}.keyring',
             dest='prepare_key_template',
         )
+        parser.add_argument(
+            '--no-locking',
+            action='store_true', default=None,
+            help='let many prepare\'s run in parallel',
+        )
         return parser
 
     @staticmethod
@@ -1899,9 +1904,12 @@ class Prepare(object):
         )
         return parser
 
-    def prepare(self):
-        with prepare_lock:
+    def prepare(self, args):
+        if args.no_locking:
             self.prepare_locked()
+        else:
+            with prepare_lock:
+                self.prepare_locked()
 
     @staticmethod
     def factory(args):
@@ -1912,7 +1920,7 @@ class Prepare(object):
 
     @staticmethod
     def main(args):
-        Prepare.factory(args).prepare()
+        Prepare.factory(args).prepare(args)
 
 
 class PrepareFilestore(Prepare):

--- a/src/ceph-disk/tests/test_prepare.py
+++ b/src/ceph-disk/tests/test_prepare.py
@@ -66,7 +66,7 @@ class TestPrepare(Base):
         assert prepare.data.is_file()
         assert isinstance(prepare.journal, main.PrepareJournal)
         assert prepare.journal.is_none()
-        prepare.prepare()
+        prepare.prepare(args)
         assert os.path.exists(os.path.join(data, 'fsid'))
         shutil.rmtree(data)
 


### PR DESCRIPTION
We have hosts with 48 OSDs, and it's painful how long it takes to prepare these 48 disks.
Since we have no shared journal devs, we _should_ be able to prepare in parallel.
I tested this on our machines, works fine.

Opinions?
