### PR TITLE
osd/PG: update info.stats.* mappings on split

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2337,6 +2337,12 @@ void PG::split_into(pg_t child_pgid, PG *child, unsigned split_bits)
   if (get_primary() != child->get_primary())
     child->info.history.same_primary_since = get_osdmap()->get_epoch();
 
+  child->info.stats.up = up;
+  child->info.stats.up_primary = up_primary;
+  child->info.stats.acting = acting;
+  child->info.stats.acting_primary = primary;
+  child->info.stats.mapping_epoch = get_osdmap()->get_epoch();
+
   // History
   child->past_intervals = past_intervals;
 


### PR DESCRIPTION
These are updated in the init and start_peering_interval paths, but not
on split.

Fixes: http://tracker.ceph.com/issues/15523
Signed-off-by: Sage Weil <sage@redhat.com>