### PR TITLE
pybind: expose fsync in cephfs binding.

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -135,6 +135,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_rmdir(ceph_mount_info *cmount, const char *path)
     const char* ceph_getcwd(ceph_mount_info *cmount)
     int ceph_sync_fs(ceph_mount_info *cmount)
+    int ceph_fsync(ceph_mount_info *cmount, int fd, int syncdataonly)
     int ceph_conf_parse_argv(ceph_mount_info *cmount, int argc, const char **argv)
     void ceph_buffer_free(char *buf)
 
@@ -505,6 +506,13 @@ cdef class LibCephFS(object):
             ret = ceph_sync_fs(self.cluster)
         if ret < 0:
             raise make_ex(ret, "sync_fs failed")
+
+    def fsync(self, int fd, int syncdataonly):
+        self.require_state("mounted")
+        with nogil:
+            ret = ceph_fsync(self.cluster, fd, syncdataonly)
+        if ret < 0:
+            raise make_ex(ret, "fsync failed")
 
     def getcwd(self):
         self.require_state("mounted")

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -49,6 +49,17 @@ def test_syncfs():
     stat = cephfs.sync_fs()
 
 @with_setup(setup_test)
+def test_fsync():
+    fd = cephfs.open('file-1', 'w', 0755)
+    cephfs.write(fd, "asdf", 0)
+    stat = cephfs.fsync(fd, 0)
+    cephfs.write(fd, "qwer", 0)
+    stat = cephfs.fsync(fd, 1)
+    cephfs.close(fd)
+    #sync on non-existing fd (assume fd 12345 is not exists)
+    assert_raises(libcephfs.Error, cephfs.fsync, 12345, 0)
+
+@with_setup(setup_test)
 def test_directory():
     cephfs.mkdir("/temp-directory", 0755)
     cephfs.mkdirs("/temp-directory/foo/bar", 0755)


### PR DESCRIPTION
So we don't necessary to syncfs when want to persistent
some file.

Signed-off-by: Xiaoxi Chen <xiaoxchen@ebay.com>