### PR TITLE
cmake: add missing source file to rbd_mirror/image_replayer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1017,6 +1017,7 @@ if(${WITH_RBD})
     tools/rbd_mirror/image_replayer/BootstrapRequest.cc
     tools/rbd_mirror/image_replayer/CloseImageRequest.cc
     tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
+    tools/rbd_mirror/image_replayer/ReplayStatusFormatter.cc
     tools/rbd_mirror/image_sync/ImageCopyRequest.cc
     tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
     tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc


### PR DESCRIPTION
fixes an undefined reference when linking librbd_mirror_internal.a

Signed-off-by: Casey Bodley \<cbodley@redhat.com\>