### PR TITLE
common/config: cast OPT_U32 options using uint32_t

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -998,7 +998,7 @@ int md_config_t::set_val_raw(const char *val, const config_option *opt)
       return 0;
     case OPT_U32: {
       std::string err;
-      int f = strict_si_cast<int>(val, &err);
+      int f = strict_si_cast<uint32_t>(val, &err);
       if (!err.empty())
 	return -EINVAL;
       *(uint32_t*)opt->conf_ptr(this) = f;

--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -186,10 +186,9 @@ T strict_si_cast(const char *str, std::string *err)
 }
 
 template int strict_si_cast<int>(const char *str, std::string *err);
-
 template long long strict_si_cast<long long>(const char *str, std::string *err);
-
 template uint64_t strict_si_cast<uint64_t>(const char *str, std::string *err);
+template uint32_t strict_si_cast<uint32_t>(const char *str, std::string *err);
 
 uint64_t strict_sistrtoll(const char *str, std::string *err)
 {

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -769,7 +769,7 @@ int MDSDaemon::_handle_command(
     string args = argsvec.front();
     for (vector<string>::iterator a = ++argsvec.begin(); a != argsvec.end(); ++a)
       args += " " + *a;
-    cct->_conf->injectargs(args, &ss);
+    r = cct->_conf->injectargs(args, &ss);
   } else if (prefix == "exit") {
     // We will send response before executing
     ss << "Exiting...";

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5462,7 +5462,7 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
     for (vector<string>::iterator a = ++argsvec.begin(); a != argsvec.end(); ++a)
       args += " " + *a;
     osd_lock.Unlock();
-    cct->_conf->injectargs(args, &ss);
+    r = cct->_conf->injectargs(args, &ss);
     osd_lock.Lock();
   }
   else if (prefix == "cluster_log") {


### PR DESCRIPTION
the OPT_U32 options was translated using strict_si_cast<int>(), and then
cast the converted result to uint32_t. this could cause integer
underflow. we could have lifted the burden of checking invalid input
from the user of this option to the strict_si_cast<>() function. so in
this change, we use strict_si_cast<uint32_t>() instead, before casting
the converted value into `uint32_t`.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>