### PR TITLE
xio: provide keepalive(s) and their ack(s)

### DIFF
--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -636,7 +636,7 @@ int XioConnection::flush_out_queues(uint32_t flags) {
   return 0;
 }
 
-int XioConnection::discard_input_queue(uint32_t flags)
+int XioConnection::discard_out_queues(uint32_t flags)
 {
   Message::Queue disc_q;
   XioSubmit::Queue deferred_q;
@@ -748,7 +748,7 @@ int XioConnection::_mark_down(uint32_t flags)
 
   /* XXX this will almost certainly be called again from
    * on_disconnect_event() */
-  discard_input_queue(flags|CState::OP_FLAG_LOCKED);
+  discard_out_queues(flags|CState::OP_FLAG_LOCKED);
 
   if (! (flags & CState::OP_FLAG_LOCKED))
     pthread_spin_unlock(&sp);
@@ -820,7 +820,7 @@ int XioConnection::CState::state_fail(Message* m, uint32_t flags)
   session_state.set(DISCONNECTED);
   startup_state.set(FAIL);
 
-  xcon->discard_input_queue(flags|OP_FLAG_LOCKED);
+  xcon->discard_out_queues(flags|OP_FLAG_LOCKED);
   xcon->adjust_clru(flags|OP_FLAG_LOCKED|OP_FLAG_LRU);
 
   xcon->disconnect();

--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -488,7 +488,7 @@ int XioConnection::on_ow_msg_send_complete(struct xio_session *session,
 void XioConnection::msg_send_fail(XioMsg *xmsg, int code)
 {
   ldout(msgr->cct,2) << "xio_send_msg FAILED xcon: " << this <<
-    " xmsg: " << &xmsg->req_0.msg << " code=" << code <<
+    " xmsg: " << xmsg->get_xio_msg() << " code=" << code <<
     " (" << xio_strerror(code) << ")" << dendl;
   /* return refs taken for each xio_msg */
   xmsg->put_msg_refs();
@@ -562,7 +562,7 @@ int XioConnection::discard_input_queue(uint32_t flags)
 	xmsg = static_cast<XioMsg*>(xs);
 	deferred_q.erase(q_iter);
 	// release once for each chained xio_msg
-	xmsg->put(xmsg->hdr.msg_cnt);
+	xmsg->put(xmsg->get_msg_count());
 	break;
       case XioSubmit::INCOMING_MSG_RELEASE:
 	deferred_q.erase(q_iter);

--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -311,6 +311,8 @@ public:
 
   int passive_setup(); /* XXX */
 
+  int handle_data_msg(struct xio_session *session, struct xio_msg *msg,
+		 int more_in_batch, void *cb_user_context);
   int on_msg(struct xio_session *session, struct xio_msg *msg,
 		 int more_in_batch, void *cb_user_context);
   int on_ow_msg_send_complete(struct xio_session *session, struct xio_msg *msg,

--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -327,11 +327,11 @@ public:
 		   struct xio_msg  *msg, void *conn_user_context);
   void msg_send_fail(XioSend *xsend, int code);
   void msg_release_fail(struct xio_msg *msg, int code);
+private:
+  void send_keepalive_or_ack_internal(bool ack = false, const utime_t *tp = nullptr);
   int flush_out_queues(uint32_t flags);
   int discard_out_queues(uint32_t flags);
   int adjust_clru(uint32_t flags);
-private:
-  void send_keepalive_or_ack_internal(bool ack = false, const utime_t *tp = nullptr);
 };
 
 typedef boost::intrusive_ptr<XioConnection> XioConnectionRef;

--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -241,7 +241,7 @@ private:
   int on_disconnect_event() {
     connected.set(false);
     pthread_spin_lock(&sp);
-    discard_input_queue(CState::OP_FLAG_LOCKED);
+    discard_out_queues(CState::OP_FLAG_LOCKED);
     pthread_spin_unlock(&sp);
     return 0;
   }
@@ -328,7 +328,7 @@ public:
   void msg_send_fail(XioSend *xsend, int code);
   void msg_release_fail(struct xio_msg *msg, int code);
   int flush_out_queues(uint32_t flags);
-  int discard_input_queue(uint32_t flags);
+  int discard_out_queues(uint32_t flags);
   int adjust_clru(uint32_t flags);
 private:
   void send_keepalive_or_ack_internal(bool ack = false, const utime_t *tp = nullptr);

--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -37,7 +37,7 @@ namespace bi = boost::intrusive;
 
 class XioPortal;
 class XioMessenger;
-class XioMsg;
+class XioSend;
 
 class XioConnection : public Connection
 {
@@ -231,7 +231,7 @@ private:
   friend class XioMessenger;
   friend class XioDispatchHook;
   friend class XioMarkDownHook;
-  friend class XioMsg;
+  friend class XioSend;
 
   int on_disconnect_event() {
     connected.set(false);
@@ -319,7 +319,7 @@ public:
 			      void *conn_user_context);
   int on_msg_error(struct xio_session *session, enum xio_status error,
 		   struct xio_msg  *msg, void *conn_user_context);
-  void msg_send_fail(XioMsg *xmsg, int code);
+  void msg_send_fail(XioSend *xsend, int code);
   void msg_release_fail(struct xio_msg *msg, int code);
   int flush_out_queues(uint32_t flags);
   int discard_input_queue(uint32_t flags);

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -293,7 +293,9 @@ void XioInit::package_init(CephContext *cct) {
        xopt = max(cct->_conf->xio_max_send_inline, 512);
        xio_set_opt(NULL, XIO_OPTLEVEL_ACCELIO, XIO_OPTNAME_MAX_INLINE_XIO_DATA,
                   &xopt, sizeof(xopt));
-       xopt = 216;
+
+       xopt = XioMsgHdr::get_max_encoded_length();
+       ldout(cct,2) << "setting accelio max header size " << xopt << dendl;
        xio_set_opt(NULL, XIO_OPTLEVEL_ACCELIO, XIO_OPTNAME_MAX_INLINE_XIO_HEADER,
                   &xopt, sizeof(xopt));
 

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -860,6 +860,7 @@ int XioMessenger::_send_message_impl(Message* m, XioConnection* xcon)
   }
 
   ldout(cct,4) << __func__ << " " << m << " new XioMsg " << xmsg
+       << " tag " << (int)xmsg->hdr.tag
        << " req_0 " << &xmsg->req_0.msg << " msg type " << m->get_type()
        << " features: " << xcon->get_features()
        << " conn " << xcon->conn << " sess " << xcon->session << dendl;

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -790,6 +790,18 @@ static inline XioMsg* pool_alloc_xio_msg(Message *m, XioConnection *xcon,
   return xmsg;
 }
 
+XioCommand* pool_alloc_xio_command(XioConnection *xcon)
+{
+  struct xio_reg_mem mp_mem;
+  int e = xpool_alloc(xio_msgr_noreg_mpool, sizeof(XioCommand), &mp_mem);
+  if (!!e)
+    return NULL;
+  XioCommand *xcmd = reinterpret_cast<XioCommand*>(mp_mem.addr);
+  assert(!!xcmd);
+  new (xcmd) XioCommand(xcon, mp_mem);
+  return xcmd;
+}
+
 int XioMessenger::_send_message(Message *m, Connection *con)
 {
   if (con == loop_con.get() /* intrusive_ptr get() */) {

--- a/src/msg/xio/XioMessenger.h
+++ b/src/msg/xio/XioMessenger.h
@@ -130,12 +130,6 @@ public:
 
   virtual ConnectionRef get_loopback_connection();
 
-  virtual int send_keepalive(const entity_inst_t& dest)
-    { return EINVAL; }
-
-  virtual int send_keepalive(Connection *con)
-    { return EINVAL; }
-
   virtual void mark_down(const entity_addr_t& a);
   virtual void mark_down(Connection *con);
   virtual void mark_down_all();
@@ -164,5 +158,8 @@ protected:
 public:
   uint64_t local_features;
 };
+
+XioCommand* pool_alloc_xio_command(XioConnection *xcon);
+
 
 #endif /* XIO_MESSENGER_H */

--- a/src/msg/xio/XioMsg.cc
+++ b/src/msg/xio/XioMsg.cc
@@ -34,3 +34,12 @@ int XioDispatchHook::release_msgs()
   assert(r);
   return r;
 }
+
+/*static*/ size_t XioMsgHdr::get_max_encoded_length() {
+  ceph_msg_header _ceph_msg_header;
+  ceph_msg_footer _ceph_msg_footer;
+  XioMsgHdr hdr (_ceph_msg_header, _ceph_msg_footer);
+  const std::list<buffer::ptr>& hdr_buffers = hdr.get_bl().buffers();
+  assert(hdr_buffers.size() == 1); /* accelio header is small without scatter gather */
+  return hdr_buffers.begin()->length();
+}

--- a/src/msg/xio/XioMsg.cc
+++ b/src/msg/xio/XioMsg.cc
@@ -43,3 +43,8 @@ int XioDispatchHook::release_msgs()
   assert(hdr_buffers.size() == 1); /* accelio header is small without scatter gather */
   return hdr_buffers.begin()->length();
 }
+
+void XioMsg::print_debug(CephContext *cct, const char *tag) const {
+  print_xio_msg_hdr(cct, tag, hdr, get_xio_msg());
+  print_ceph_msg(cct, tag, m);
+}

--- a/src/msg/xio/XioMsg.h
+++ b/src/msg/xio/XioMsg.h
@@ -45,6 +45,7 @@ public:
 class XioMsgHdr
 {
 public:
+  char tag;
   __le32 msg_cnt;
   __le32 peer_type;
   entity_addr_t addr; /* XXX hack! */
@@ -53,7 +54,7 @@ public:
   buffer::list bl;
 public:
   XioMsgHdr(ceph_msg_header& _hdr, ceph_msg_footer& _ftr)
-    : msg_cnt(0), hdr(&_hdr), ftr(&_ftr)
+    : tag(CEPH_MSGR_TAG_MSG), msg_cnt(0), hdr(&_hdr), ftr(&_ftr)
     { }
 
   XioMsgHdr(ceph_msg_header& _hdr, ceph_msg_footer &_ftr, buffer::ptr p)
@@ -69,6 +70,7 @@ public:
   const buffer::list& get_bl() { encode(bl); return bl; };
 
   inline void encode_hdr(buffer::list& bl) const {
+    ::encode(tag, bl);
     ::encode(msg_cnt, bl);
     ::encode(peer_type, bl);
     ::encode(addr, bl);
@@ -101,6 +103,7 @@ public:
   }
 
   inline void decode_hdr(buffer::list::iterator& bl) {
+    ::decode(tag, bl);
     ::decode(msg_cnt, bl);
     ::decode(peer_type, bl);
     ::decode(addr, bl);

--- a/src/msg/xio/XioMsg.h
+++ b/src/msg/xio/XioMsg.h
@@ -215,6 +215,11 @@ public:
       xcon->get();
     }
 
+  void print_debug(CephContext *cct, const char *tag) const;
+  const struct xio_msg * get_xio_msg() const {return &req_0.msg;}
+  struct xio_msg * get_xio_msg() {return &req_0.msg;}
+  size_t get_msg_count() const {return hdr.msg_cnt;}
+
   XioMsg* get() { nrefs.inc(); return this; };
 
   void put(int n) {
@@ -231,7 +236,7 @@ public:
   }
 
   void put_msg_refs() {
-    put(hdr.msg_cnt);
+    put(get_msg_count());
   }
 
   void alloc_trailers(int cnt) {
@@ -247,7 +252,7 @@ public:
   ~XioMsg()
     {
       if (unlikely(!!req_arr)) {
-	for (unsigned int ix = 0; ix < hdr.msg_cnt-1; ++ix) {
+	for (unsigned int ix = 0; ix < get_msg_count()-1; ++ix) {
 	  xio_msg_ex* xreq = &(req_arr[ix]);
 	  xreq->~xio_msg_ex();
 	}

--- a/src/msg/xio/XioMsg.h
+++ b/src/msg/xio/XioMsg.h
@@ -64,6 +64,8 @@ public:
       decode(bl_iter);
     }
 
+  static size_t get_max_encoded_length();
+
   const buffer::list& get_bl() { encode(bl); return bl; };
 
   inline void encode_hdr(buffer::list& bl) const {

--- a/src/msg/xio/XioMsg.h
+++ b/src/msg/xio/XioMsg.h
@@ -189,7 +189,7 @@ public:
   struct xio_msg * get_xio_msg() {return &req_0.msg;}
   virtual size_t get_msg_count() const {return 1;}
 
-  XioSend(XioConnection *_xcon, struct xio_reg_mem& _mp, int _ex_cnt) :
+  XioSend(XioConnection *_xcon, struct xio_reg_mem& _mp, int _ex_cnt=0) :
     XioSubmit(XioSubmit::OUTGOING_MSG, _xcon),
     req_0(this), mp_this(_mp), nrefs(_ex_cnt+1)
   {
@@ -225,6 +225,18 @@ private:
   xio_msg_ex req_0;
   struct xio_reg_mem mp_this;
   atomic_t nrefs;
+};
+
+class XioCommand : public XioSend
+{
+public:
+  XioCommand(XioConnection *_xcon, struct xio_reg_mem& _mp):XioSend(_xcon, _mp) {
+  }
+
+  buffer::list& get_bl_ref() { return bl; };
+
+private:
+  buffer::list bl;
 };
 
 struct XioMsg : public XioSend

--- a/src/msg/xio/XioPortal.h
+++ b/src/msg/xio/XioPortal.h
@@ -46,7 +46,7 @@ private:
     struct Lane
     {
       uint32_t size;
-      XioMsg::Queue q;
+      XioSubmit::Queue q;
       pthread_spinlock_t sp;
       CACHE_PAD(0);
     };

--- a/src/msg/xio/XioPortal.h
+++ b/src/msg/xio/XioPortal.h
@@ -209,7 +209,6 @@ public:
     // and push them in FIFO order to front of the input queue,
     // and mark the connection as flow-controlled
     XioSubmit::Queue requeue_q;
-    XioMsg *xmsg;
 
     while (q_iter != send_q.end()) {
       XioSubmit *xs = &(*q_iter);
@@ -218,9 +217,8 @@ public:
 	q_iter++;
 	continue;
       }
-      xmsg = static_cast<XioMsg*>(xs);
       q_iter = send_q.erase(q_iter);
-      requeue_q.push_back(*xmsg);
+      requeue_q.push_back(*xs);
     }
     pthread_spin_lock(&xcon->sp);
     XioSubmit::Queue::const_iterator i1 = xcon->outgoing.requeue.begin();

--- a/src/msg/xio/XioSubmit.h
+++ b/src/msg/xio/XioSubmit.h
@@ -50,6 +50,8 @@ public:
 				     bi::list_member_hook<>,
 				     &XioSubmit::submit_list >
 		    > Queue;
+  virtual ~XioSubmit(){
+  }
 };
 
 #endif /* XIO_SUBMIT_H */


### PR DESCRIPTION
Till now XIO in Ceph could only send Ceph messages, but not notifications like keepalive/ack.  Hence, Ceph with XIO was not robust enough.

From now on, the first byte in the accelio header of any outgoing accelio message will carry the 'tag' of that notification (either data message, keepalive, ack, and so on).
For command notifications (i.e., keepalive/ack) - we'll put all the payload in accelio header since accelio header can easily contain even 200 bytes (which is more than enough for us).

Implementation :
0. add tag to the header of each outgoing accelio message (and switch according to it upon msg receival)
1. splits XioMsg into 2 classes: base XioSend and derived XioMsg.
2. Derive a new class from XioSend - XioCmd for the new notifications (keepalive,ack,...)