### PR TITLE
osd: handle boot racing with NOUP set

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6794,9 +6794,9 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
       }
     }
 
-    if (osdmap->test_flag(CEPH_OSDMAP_NOUP) &&
-	!newmap->test_flag(CEPH_OSDMAP_NOUP)) {
-      dout(10) << __func__ << " NOUP flag cleared in " << newmap->get_epoch()
+    if (osdmap->test_flag(CEPH_OSDMAP_NOUP) !=
+	newmap->test_flag(CEPH_OSDMAP_NOUP)) {
+      dout(10) << __func__ << " NOUP flag changed in " << newmap->get_epoch()
 	       << dendl;
       if (is_booting()) {
 	// this captures the case where we sent the boot message while


### PR DESCRIPTION
This is a follow-on to 7139a232d26beef441ffbc13bc087baab3505ea8,
which handled the NOUP set + clear case when the OSD found out
about the flag being cleared.  However, it's possible that the
flag will get cleared but the OSD won't get a map update (because
it hasn't subscribed and is not doing any work).

This means that it is *more* likely than before that we will
restart the boot process even though the OSD did successfully
mark us up.  However, as before, it is unavoidable because there
is no notification of whether our boot request succeeds or not.

And it is still mostly harmless (an extra mark down + up cycle).

Signed-off-by: Sage Weil <sage@redhat.com>