### PR TITLE
xio: Rename XioRsp to XioCompletion

### DIFF
--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -540,7 +540,7 @@ int XioConnection::discard_input_queue(uint32_t flags)
 	break;
       case XioSubmit::INCOMING_MSG_RELEASE:
 	deferred_q.erase(q_iter);
-	portal->release_xio_msg(static_cast<XioRsp*>(xs));
+	portal->release_xio_msg(static_cast<XioCompletion*>(xs));
 	break;
       default:
 	ldout(msgr->cct,0) << __func__ << ": Unknown Msg type " << xs->type << dendl;

--- a/src/msg/xio/XioMsg.cc
+++ b/src/msg/xio/XioMsg.cc
@@ -20,16 +20,16 @@
 
 int XioDispatchHook::release_msgs()
 {
-  XioRsp *xrsp;
+  XioCompletion *xcmp;
   int r = msg_seq.size();
   cl_flag = true;
 
   /* queue for release */
-  xrsp = static_cast<XioRsp *>(rsp_pool.alloc(sizeof(XioRsp)));
-  new (xrsp) XioRsp(xcon, this);
+  xcmp = static_cast<XioCompletion *>(rsp_pool.alloc(sizeof(XioCompletion)));
+  new (xcmp) XioCompletion(xcon, this);
 
   /* merge with portal traffic */
-  xcon->portal->enqueue_for_send(xcon, xrsp);
+  xcon->portal->enqueue_for_send(xcon, xcmp);
 
   assert(r);
   return r;

--- a/src/msg/xio/XioMsg.h
+++ b/src/msg/xio/XioMsg.h
@@ -373,11 +373,11 @@ public:
   }
 };
 
-struct XioRsp : public XioSubmit
+struct XioCompletion : public XioSubmit
 {
   XioDispatchHook *xhook;
 public:
-  XioRsp(XioConnection *_xcon, XioDispatchHook *_xhook)
+  XioCompletion(XioConnection *_xcon, XioDispatchHook *_xhook)
     : XioSubmit(XioSubmit::INCOMING_MSG_RELEASE, _xcon /* not xcon! */),
       xhook(_xhook->get()) {
       // submit queue ref

--- a/src/msg/xio/XioPortal.h
+++ b/src/msg/xio/XioPortal.h
@@ -157,22 +157,22 @@ public:
   int bind(struct xio_session_ops *ops, const string &base_uri,
 	   uint16_t port, uint16_t *assigned_port);
 
-  inline void release_xio_msg(XioRsp* xrsp) {
-    struct xio_msg *msg = xrsp->dequeue();
+  inline void release_xio_msg(XioCompletion* xcmp) {
+    struct xio_msg *msg = xcmp->dequeue();
     struct xio_msg *next_msg = NULL;
     int code;
-    if (unlikely(!xrsp->xcon->conn)) {
+    if (unlikely(!xcmp->xcon->conn)) {
       // NOTE: msg is not safe to dereference if the connection was torn down
-      xrsp->xcon->msg_release_fail(msg, ENOTCONN);
+      xcmp->xcon->msg_release_fail(msg, ENOTCONN);
     }
     else while (msg) {
       next_msg = static_cast<struct xio_msg *>(msg->user_context);
       code = xio_release_msg(msg);
       if (unlikely(code)) /* very unlikely, so log it */
-	xrsp->xcon->msg_release_fail(msg, code);
+	xcmp->xcon->msg_release_fail(msg, code);
       msg = next_msg;
     }
-    xrsp->finalize(); /* unconditional finalize */
+    xcmp->finalize(); /* unconditional finalize */
   }
 
   void enqueue_for_send(XioConnection *xcon, XioSubmit *xs)
@@ -193,7 +193,7 @@ public:
 	break;
       default:
 	/* INCOMING_MSG_RELEASE */
-	release_xio_msg(static_cast<XioRsp*>(xs));
+	release_xio_msg(static_cast<XioCompletion*>(xs));
       break;
       };
     }
@@ -321,7 +321,7 @@ public:
 	    default:
 	      /* INCOMING_MSG_RELEASE */
 	      q_iter = send_q.erase(q_iter);
-	      release_xio_msg(static_cast<XioRsp*>(xs));
+	      release_xio_msg(static_cast<XioCompletion*>(xs));
 	      continue;
 	    } /* switch (xs->type) */
 	    q_iter = send_q.erase(q_iter);


### PR DESCRIPTION
since this element is not causing real response message on
the wire it was decided to change the name to XioCompletion to
explain that the transaction is completed and the memory
associated to it can be released by accelio.

Signed-off-by: Adir Lev <adirl@mellanox.com>