### PR TITLE
include/rados: fix scrub-map definition

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -284,7 +284,8 @@ extern const char *ceph_osd_state_name(int s);
 	f(SCRUB,	__CEPH_OSD_OP1(SUB, 5),		"scrub")	    \
 	f(SCRUB_RESERVE, __CEPH_OSD_OP1(SUB, 6),	"scrub-reserve")    \
 	f(SCRUB_UNRESERVE, __CEPH_OSD_OP1(SUB, 7),	"scrub-unreserve")  \
-	f(SCRUB_MAP,	__CEPH_OSD_OP1(SUB, 8),		"scrub-map")	    \
+	/* 8 used to be scrub-stop */					\
+	f(SCRUB_MAP,	__CEPH_OSD_OP1(SUB, 9),		"scrub-map")	    \
 									    \
 	/** exec **/							    \
 	/* note: the RD bit here is wrong; see special-case below in helper */ \


### PR DESCRIPTION
In commit 40add6a63defd09b47c594171c0f72906d218cc6 we
changed the scrub-map op code, breaking compatibility.

Signed-off-by: Sage Weil <sage@redhat.com>