### PR TITLE
osd/OSD.cc: change shared_ptr to unique_ptr

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1455,7 +1455,7 @@ int OSD::mkfs(CephContext *cct, ObjectStore *store, const string &dev,
 {
   int ret;
 
-  ceph::shared_ptr<ObjectStore::Sequencer> osr(
+  std::unique_ptr<ObjectStore::Sequencer> osr(
     new ObjectStore::Sequencer("mkfs"));
   OSDSuperblock sb;
   bufferlist sbbl;


### PR DESCRIPTION
There is no need for osr to be a shared_ptr.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>