### PR TITLE
jewel: possible double-free of object map invalidation request upon error

### DIFF
--- a/src/librbd/object_map/InvalidateRequest.cc
+++ b/src/librbd/object_map/InvalidateRequest.cc
@@ -47,6 +47,7 @@ void InvalidateRequest<I>::send() {
   r = image_ctx.update_flags(m_snap_id, flags, true);
   if (r < 0) {
     this->async_complete(r);
+    return;
   }
 
   // do not update on-disk flags if not image owner


### PR DESCRIPTION
http://tracker.ceph.com/issues/15649