### PR TITLE
global: don't link lttng into libglobal

### DIFF
--- a/src/global/Makefile.am
+++ b/src/global/Makefile.am
@@ -6,9 +6,7 @@ libglobal_la_SOURCES = \
 	common/TrackedOp.cc
 
 libglobal_la_LIBADD = $(LIBCOMMON)
-if WITH_LTTNG
-libglobal_la_LIBADD += -ldl -llttng-ust
-endif
+
 noinst_LTLIBRARIES += libglobal.la
 
 noinst_HEADERS += \


### PR DESCRIPTION
Rely on dynamic initialization instead. Linking lttng in this way had
the unfortunate side effect of causing radosgw to segfault (when
daemonized) during sigterm processing (ie. during lttng_ust_exit()).

This was originally removed in 638738f, but accidentally re-added via
5f61d36.

Signed-off-by: Karol Mroz <kmroz@suse.com>