### PR TITLE
doc: Jason Dillaman is now RBD lead

### DIFF
--- a/doc/dev/development-workflow.rst
+++ b/doc/dev/development-workflow.rst
@@ -104,7 +104,7 @@ Each ``team`` is responsible for a project:
 * rgw lead is Yehuda Sadeh
 * CephFS lead is Gregory Farnum
 * rados lead is Samuel Just
-* rbd lead is Josh Durgin
+* rbd lead is Jason Dillaman
 
 The ``developer`` assigned to an issue is responsible for it. The
 status of an open issue can be:

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -55,7 +55,7 @@ Scope     Lead            GitHub nick
 Ceph      Sage Weil       liewegas
 RADOS     Samuel Just     athanatos
 RGW       Yehuda Sadeh    yehudasa
-RBD       Josh Durgin     jdurgin
+RBD       Jason Dillaman  dillaman
 CephFS    Gregory Farnum  gregsfortytwo
 Build/Ops Ken Dreyer      ktdreyer
 ========= =============== =============


### PR DESCRIPTION
Signed-off-by: Ken Dreyer <kdreyer@redhat.com>