### PR TITLE
doc: remove references to old EOL releases

### DIFF
--- a/doc/dev/development-workflow.rst
+++ b/doc/dev/development-workflow.rst
@@ -56,12 +56,10 @@ Release Cycle
 
 Four times a year, the development roadmap is discussed online during
 the `Ceph Developer Summit <http://wiki.ceph.com/Planning/CDS/>`_. A
-new stable release (argonaut, cuttlefish, dumpling, emperor, firefly,
-giant, hammer, infernalis ...) is published at the same frequency. 
-Every other release (dumpling, firefly, hammer, ...) is a `Long Term Stable (LTS) <../../releases>`_.
-See `Understanding the release cycle
-<../../releases#understanding-the-release-cycle>`_ for more
-information.
+new stable release (hammer, infernalis, jewel ...) is published at the same
+frequency.  Every other release (firefly, hammer, jewel...) is a `Long Term
+Stable (LTS) <../../releases>`_.  See `Understanding the release cycle
+<../../releases#understanding-the-release-cycle>`_ for more information.
 
 Merging bug fixes or features
 =============================

--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -59,10 +59,10 @@ Add Keys
 ========
 
 Add a key to your system's list of trusted keys to avoid a security warning. For
-major releases (e.g., ``dumpling``, ``emperor``, ``firefly``) and development
-releases (``release-name-rc1``, ``release-name-rc2``), use the ``release.asc``
-key. For development testing packages, use the ``autobuild.asc`` key (developers
-and QA).
+major releases (e.g., ``hammer``, ``jewel``) and development releases
+(``release-name-rc1``, ``release-name-rc2``), use the ``release.asc`` key. For
+development testing packages, use the ``autobuild.asc`` key (developers and
+QA).
 
 
 APT
@@ -141,11 +141,11 @@ Add a Ceph package repository to your system's list of APT sources. For newer
 versions of Debian/Ubuntu, call ``lsb_release -sc`` on the command line to
 get the short codename, and replace ``{codename}`` in the following command. ::
 
-	sudo apt-add-repository 'deb http://download.ceph.com/debian-firefly/ {codename} main'
+	sudo apt-add-repository 'deb http://download.ceph.com/debian-jewel/ {codename} main'
 
 For early Linux distributions, you may execute the following command::
 
-	echo deb http://download.ceph.com/debian-firefly/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
+	echo deb http://download.ceph.com/debian-jewel/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
 For earlier Ceph releases, replace ``{release-name}`` with the name  with the
 name of the Ceph release. You may call ``lsb_release -sc`` on the command  line
@@ -179,11 +179,11 @@ RPM Packages
 
 For major releases, you may add a Ceph entry to the ``/etc/yum.repos.d``
 directory. Create a ``ceph.repo`` file. In the example below, replace
-``{ceph-release}`` with  a major release of Ceph (e.g., ``dumpling``,
-``emperor``, etc.) and ``{distro}`` with your Linux distribution (e.g., ``el6``,
-``rhel6``, etc.).  You may view http://download.ceph.com/rpm-{ceph-release}/ directory to
-see which  distributions Ceph supports. Some Ceph packages (e.g., EPEL) must
-take priority over standard packages, so you must ensure that you set
+``{ceph-release}`` with  a major release of Ceph (e.g., ``hammer``, ``jewel``,
+etc.) and ``{distro}`` with your Linux distribution (e.g., ``el7``, etc.).  You
+may view http://download.ceph.com/rpm-{ceph-release}/ directory to see which
+distributions Ceph supports. Some Ceph packages (e.g., EPEL) must take priority
+over standard packages, so you must ensure that you set
 ``priority=2``. ::
 
 	[ceph]
@@ -255,7 +255,7 @@ The repository package installs the repository details on your local system for
 use with ``yum``. Replace ``{distro}`` with your Linux distribution, and
 ``{release}`` with the specific release of Ceph::
 
-    su -c 'rpm -Uvh http://download.ceph.com/rpms/{distro}/x86_64/ceph-{release}.el6.noarch.rpm'
+    su -c 'rpm -Uvh http://download.ceph.com/rpms/{distro}/x86_64/ceph-{release}.el7.noarch.rpm'
 
 You can download the RPMs directly from::
 
@@ -292,9 +292,8 @@ RPM Packages
 
 For current development branches, you may add a Ceph entry to the
 ``/etc/yum.repos.d`` directory. Create a ``ceph.repo`` file. In the example
-below, replace ``{distro}`` with your Linux distribution (e.g., ``centos6``,
-``rhel6``, etc.), and ``{branch}`` with the name of the branch you want to
-install. ::
+below, replace ``{distro}`` with your Linux distribution (e.g., ``el7``), and
+``{branch}`` with the name of the branch you want to install. ::
 
 
 	[ceph-source]
@@ -333,8 +332,8 @@ RPM Packages
 
 You may add a Ceph entry to the ``/etc/yum.repos.d`` directory. Create a
 ``ceph-apache.repo`` file. In the example below, replace ``{distro}`` with your
-Linux distribution (e.g., ``el6``, ``rhel6``, etc.).  You may view
-http://gitbuilder.ceph.com directory to see which distributions Ceph supports.
+Linux distribution (e.g., ``el7``).  You may view http://gitbuilder.ceph.com
+directory to see which distributions Ceph supports.
 ::
 
 
@@ -435,20 +434,19 @@ Ceph requires the following packages:
 - gperftools-libs
 
 
-Packages are currently built for the RHEL/CentOS6 (``el6``), Fedora 18 and 19
-(``f18`` and ``f19``), OpenSUSE 12.2 (``opensuse12.2``), and SLES (``sles11``)
-platforms. The repository package installs the repository details on your local
-system for use with ``yum``. Replace ``{distro}`` with your distribution. ::
+Packages are currently built for the RHEL/CentOS7 (``el7``) platforms.  The
+repository package installs the repository details on your local system for use
+with ``yum``. Replace ``{distro}`` with your distribution. ::
 
-    su -c 'rpm -Uvh http://download.ceph.com/rpm-firefly/{distro}/noarch/ceph-{version}.{distro}.noarch.rpm'
+    su -c 'rpm -Uvh http://download.ceph.com/rpm-jewel/{distro}/noarch/ceph-{version}.{distro}.noarch.rpm'
 
-For example, for CentOS 6  (``el6``)::
+For example, for CentOS 7  (``el7``)::
 
-    su -c 'rpm -Uvh http://download.ceph.com/rpm-firefly/el6/noarch/ceph-release-1-0.el6.noarch.rpm'
+    su -c 'rpm -Uvh http://download.ceph.com/rpm-jewel/el7/noarch/ceph-release-1-0.el7.noarch.rpm'
 
 You can download the RPMs directly from::
 
-	http://download.ceph.com/rpm-firefly
+	http://download.ceph.com/rpm-jewel
 
 
 For earlier Ceph releases, replace ``{release-name}`` with the name

--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -34,8 +34,7 @@ For Debian and Ubuntu distributions, perform the following steps:
 	wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
 
 #. Add the Ceph packages to your repository. Replace ``{ceph-stable-release}``
-   with a stable Ceph release (e.g., ``cuttlefish``, ``dumpling``,
-   ``emperor``, ``firefly``, etc.).
+   with a stable Ceph release (e.g., ``hammer``, ``jewel``, etc.)
    For example::
 
 	echo deb http://download.ceph.com/debian-{ceph-stable-release}/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
@@ -51,14 +50,14 @@ For Debian and Ubuntu distributions, perform the following steps:
 Red Hat Package Manager (RPM)
 -----------------------------
 
-For Red Hat(rhel6, rhel7), CentOS (el6, el7), and Fedora 19-20 (f19-f20) perform the
-following steps:
+For CentOS 7, perform the following steps:
 
 #. On Red Hat Enterprise Linux 7, register the target machine with ``subscription-manager``, verify your subscriptions, and enable the "Extras" repoistory for package dependencies. For example::
 
         sudo subscription-manager repos --enable=rhel-7-server-extras-rpms
 
-#. On Red Hat Enterprise Linux 6, install and enable the Extra Packages for Enterprise Linux (EPEL) repository. Please see the `EPEL wiki`_ page for more information.
+#. Install and enable the Extra Packages for Enterprise Linux (EPEL)
+   repository. Please see the `EPEL wiki`_ page for more information.
 
 #. On CentOS, you can execute the following command chain::
 
@@ -71,11 +70,9 @@ following steps:
 	sudo vim /etc/yum.repos.d/ceph.repo
 
    Paste the following example code. Replace ``{ceph-release}`` with
-   the recent major release of Ceph (e.g., ``firefly``). Replace ``{distro}``
-   with your Linux distribution (e.g., ``el6`` for CentOS 6,
-   ``el7`` for CentOS 7, ``rhel6`` for
-   Red Hat 6.5, ``rhel7`` for Red Hat 7, and ``fc19`` or ``fc20`` for Fedora 19
-   or Fedora 20. Finally, save the contents to the
+   the recent major release of Ceph (e.g., ``jewel``). Replace ``{distro}``
+   with your Linux distribution (e.g., ``el7`` for CentOS 7). Finally, save the
+   contents to the
    ``/etc/yum.repos.d/ceph.repo`` file. ::
 
 	[ceph-noarch]


### PR DESCRIPTION
There were several references to old releases like "dumpling", "emperor", and "firefly", throughout the docs. Remove these and update the examples to use jewel instead.

Remove references to CentOS 6 and RHEL 6, since we only support CentOS 7 now.

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>