### PR TITLE
osdc: send error to recovery waiters on shutdown

### DIFF
--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -1492,7 +1492,7 @@ void Journaler::shutdown()
     f->complete(-EAGAIN);
   }
 
-  finish_contexts(cct, waitfor_recover, 0);
+  finish_contexts(cct, waitfor_recover, -ESHUTDOWN);
 
   std::map<uint64_t, std::list<Context*> >::iterator i;
   for (i = waitfor_safe.begin(); i != waitfor_safe.end(); ++i) {


### PR DESCRIPTION
...instead of sending them '0', which gets things
confused.

Fixes: http://tracker.ceph.com/issues/15689
Signed-off-by: John Spray <john.spray@redhat.com>