### PR TITLE
mon: enable different backends (e.g., rocksdb)

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,0 +1,12 @@
+11.0.0
+------
+
+* If you have manually specified the monitor user rocksdb via the
+  ``mon keyvaluedb = rocksdb`` option, you will need to manually add a file
+  to the mon data directory to preserve this option::
+
+     echo rocksdb > /var/lib/ceph/mon/ceph-`hostname`/kv_backend
+
+  New monitors will now use rocksdb by default, but if that file is
+  not present, existing monitors will use leveldb.  The ``mon keyvaluedb`` option
+  now only affects the backend chosen when a monitor is created.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -843,7 +843,7 @@ OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR, "")
 // rocksdb options that will be used in monstore
-OPTION(mon_rocksdb_options, OPT_STR, "cache_size=536870912,write_buffer_size=33554432,block_size=65536,compression=kNoCompression")
+OPTION(mon_rocksdb_options, OPT_STR, "write_buffer_size=33554432,compression=kNoCompression")
 
 /**
  * osd_*_priority adjust the relative priority of client io, recovery io,

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -654,7 +654,7 @@ class MonitorDBStore
         dump_fd_binary = ::open(
           g_conf->mon_debug_dump_location.c_str(),
           O_CREAT|O_APPEND|O_WRONLY, 0644);
-        if (!dump_fd_binary) {
+        if (dump_fd_binary < 0) {
           dump_fd_binary = -errno;
           derr << "Could not open log file, got "
                << cpp_strerror(dump_fd_binary) << dendl;

--- a/src/test/mon/mkfs.sh
+++ b/src/test/mon/mkfs.sh
@@ -132,6 +132,7 @@ function auth_cephx_key() {
         return 1
     else
         rm -fr $MON_DIR/store.db
+        rm -fr $MON_DIR/kv_backend
     fi
 
     mon_mkfs --key=$key


### PR DESCRIPTION
- persist the backend type
- fix rocksdb options

https://github.com/ceph/ceph-qa-suite/pull/979