### PR TITLE
cmake: fix rbd-nbd linkage

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1005,8 +1005,10 @@ add_library(krbd_objs OBJECT krbd.cc)
 if(${WITH_RBD})
   add_subdirectory(librbd)
   
-  add_executable(rbd-nbd tools/rbd_nbd/rbd-nbd.cc)
-  target_link_libraries(rbd-nbd rbd librados global ${Boost_REGEX_LIBRARY})
+  add_executable(rbd-nbd tools/rbd_nbd/rbd-nbd.cc
+    $<TARGET_OBJECTS:parse_secret_objs>)
+  target_link_libraries(rbd-nbd librbd librados global keyutils
+    ${Boost_REGEX_LIBRARY})
 
   set(rbd_mirror_internal
     tools/rbd_mirror/ClusterWatcher.cc 


### PR DESCRIPTION
Use correct name for librbd, add parse_secret_objs and its
keyutils libdep.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>