### PR TITLE
test/encoding/readable.sh: use bash instead of sh

### DIFF
--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 [ -z "$CEPH_ROOT" ] && CEPH_ROOT=..
 


### PR DESCRIPTION
aside from the `source` statement, the readable.sh is POSIX shell
script. we can just "." the referenced helper script. but to be
consistent with other encoding/*.sh scripts, let's just change the
shebang line to "#!/bin/bash".

Signed-off-by: Kefu Chai <tchaikov@gmail.com>