### PR TITLE
rgw: cleanup: use boost::algorithm::starts_with to replace our own implementations

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <errno.h>
+#include <boost/algorithm/string.hpp>
 
 #include "json_spirit/json_spirit.h"
 #include "common/ceph_json.h"
@@ -97,18 +98,6 @@ is_err() const
   return !(http_ret >= 200 && http_ret <= 399);
 }
 
-static bool starts_with(const string& s, const string& prefix) {
-  if (s.size() < prefix.size()) {
-    return false;
-  }
-  for (unsigned int i = 0; i < prefix.size(); ++i) {
-    if (prefix[i] != s[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
 // The requestURI transferred from the frontend can be abs_path or absoluteURI
 // If it is absoluteURI, we should adjust it to abs_path for the following 
 // S3 authorization and some other processes depending on the requestURI
@@ -117,7 +106,7 @@ static string get_abs_path(const string& request_uri) {
   const static string ABS_PREFIXS[] = {"http://", "https://", "ws://", "wss://"};
   bool isAbs = false;
   for (int i = 0; i < 4; ++i) {
-    if (starts_with(request_uri, ABS_PREFIXS[i])) {
+    if (boost::algorithm::starts_with(request_uri, ABS_PREFIXS[i])) {
       isAbs = true;
       break;
     } 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1738,11 +1738,6 @@ inline ostream& operator<<(ostream& out, const rgw_obj &o) {
   return out << o.bucket.name << ":" << o.get_object();
 }
 
-static inline bool str_startswith(const string& str, const string& prefix)
-{
-  return (str.compare(0, prefix.size(), prefix) == 0);
-}
-
 static inline void buf_to_hex(const unsigned char *buf, int len, char *str)
 {
   int i;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#include <boost/algorithm/string.hpp>
 
 #include "common/ceph_json.h"
 #include "common/utf8.h"
@@ -9838,7 +9839,7 @@ static void filter_attrset(map<string, bufferlist>& unfiltered_attrset, const st
   map<string, bufferlist>::iterator iter;
   for (iter = unfiltered_attrset.lower_bound(check_prefix);
        iter != unfiltered_attrset.end(); ++iter) {
-    if (!str_startswith(iter->first, check_prefix))
+    if (!boost::algorithm::starts_with(iter->first, check_prefix))
       break;
     (*attrset)[iter->first] = iter->second;
   }


### PR DESCRIPTION
Don't reinvent the wheel.

Signed-off-by: Li Peng <lip@dtdream.com>