### PR TITLE
os/FileStore::sync_entry check for stop in after wait

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3693,6 +3693,9 @@ void FileStore::sync_entry()
     if (force_sync) {
       dout(20) << "sync_entry force_sync set" << dendl;
       force_sync = false;
+    } else if (stop) {
+      dout(20) << __func__ << " stop set" << dendl;
+      break;
     } else {
       // wait for at least the min interval
       utime_t woke = ceph_clock_now(g_ceph_context);


### PR DESCRIPTION
there is chance that the sync_entry() gets signaled in the
WaitInterval(max_interval) call because of sync_cond.Signal() call after
"stop = true" in umount(), so without this change, sync_entry() will
continue wait until min_interval is reached. this forces umount() to
wait even it has called d_force_sync(), and hence slows down the
progress of umount(). so we need to check for `stop` if we are not
signalled because of `force_sync`.

Fixes: http://tracker.ceph.com/issues/15695
Reported-by: Haomai Wang <haomaiwang@gmail.com>
Signed-off-by: Kefu Chai <kchai@redhat.com>