### PR TITLE
rgw: remove EEXIST error msg for ZoneCreate

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1496,7 +1496,6 @@ int RGWZoneParams::create(bool exclusive)
 
   r = RGWSystemMetaObj::create(exclusive);
   if (r < 0) {
-    ldout(cct, 0) << "RGWZoneParams::create(): error creating default zone params: " << cpp_strerror(-r) << dendl;
     return r;
   }
 


### PR DESCRIPTION
currently for any admin operations like user create etc. you would
always see:

`RGWZoneParams::create(): error creating default zone params: (17) File Exists`

in stdout as the debug level is set to 0, which doesn't make much sense
for an end user, so increase the debug level when we see an EEXIST, for
other failures we print the error at debug level 0 itself

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>