### PR TITLE
librbd: unlock image if journal error encountered during lock

### DIFF
--- a/src/librbd/exclusive_lock/AcquireRequest.h
+++ b/src/librbd/exclusive_lock/AcquireRequest.h
@@ -49,20 +49,25 @@ private:
    *          .   |                         |                             |
    *    . . . .   |                         |                             |
    *    .         v                         v                             |
-   *    .     OPEN_OBJECT_MAP             GET_WATCHERS . . .              |
-   *    .         |                         |              .              |
+   *    .     OPEN_OBJECT_MAP (skip if    GET_WATCHERS . . .              |
+   *    .         |            disabled)    |              .              |
    *    .         v                         v              .              |
-   *    . . > OPEN_JOURNAL * * * * * *    BLACKLIST        . (blacklist   |
-   *    .         |                  *      |              .  disabled)   |
-   *    .         v                  *      v              .              |
-   *    .     ALLOCATE_JOURNAL_TAG   *    BREAK_LOCK < . . .              |
-   *    .         |            *     *      |                             |
-   *    .         |            *     *      \-----------------------------/
-   *    .         |            v     v
+   *    . . > OPEN_JOURNAL (skip if       BLACKLIST        . (blacklist   |
+   *    .         |   *     disabled)       |              .  disabled)   |
+   *    .         |   *                     v              .              |
+   *    .         |   * * * * * * * *     BREAK_LOCK < . . .              |
+   *    .         v                 *       |                             |
+   *    .     ALLOCATE_JOURNAL_TAG  *       \-----------------------------/
+   *    .         |            *    *
+   *    .         |            *    *
+   *    .         |            v    v
    *    .         |         CLOSE_JOURNAL
    *    .         |               |
    *    .         |               v
    *    .         |         CLOSE_OBJECT_MAP
+   *    .         |               |
+   *    .         |               v
+   *    .         |         UNLOCK_IMAGE
    *    .         |               |
    *    .         v               |
    *    . . > <finish> <----------/
@@ -105,14 +110,17 @@ private:
   void send_allocate_journal_tag();
   Context *handle_allocate_journal_tag(int *ret_val);
 
-  void send_close_journal();
-  Context *handle_close_journal(int *ret_val);
-
   Context *send_open_object_map();
   Context *handle_open_object_map(int *ret_val);
 
-  Context *send_close_object_map(int *ret_val);
+  void send_close_journal();
+  Context *handle_close_journal(int *ret_val);
+
+  void send_close_object_map();
   Context *handle_close_object_map(int *ret_val);
+
+  void send_unlock();
+  Context *handle_unlock(int *ret_val);
 
   void send_get_lockers();
   Context *handle_get_lockers(int *ret_val);

--- a/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_AcquireRequest.cc
@@ -52,6 +52,12 @@ public:
                   .WillOnce(Return(r));
   }
 
+  void expect_unlock(MockImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(mock_image_ctx.header_oid, _, StrEq("lock"), StrEq("unlock"), _, _, _))
+                  .WillOnce(Return(r));
+  }
+
   void expect_create_object_map(MockImageCtx &mock_image_ctx,
                                 MockObjectMap *mock_object_map) {
     EXPECT_CALL(mock_image_ctx, create_object_map(_))
@@ -293,6 +299,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, JournalError) {
   expect_open_journal(mock_image_ctx, *mock_journal, -EINVAL);
   expect_close_journal(mock_image_ctx, *mock_journal);
   expect_close_object_map(mock_image_ctx, *mock_object_map);
+  expect_unlock(mock_image_ctx, 0);
 
   C_SaferCond acquire_ctx;
   C_SaferCond ctx;
@@ -330,6 +337,7 @@ TEST_F(TestMockExclusiveLockAcquireRequest, AllocateJournalTagError) {
   expect_allocate_journal_tag(mock_image_ctx, mock_journal_policy, -EPERM);
   expect_close_journal(mock_image_ctx, *mock_journal);
   expect_close_object_map(mock_image_ctx, *mock_object_map);
+  expect_unlock(mock_image_ctx, 0);
 
   C_SaferCond acquire_ctx;
   C_SaferCond ctx;


### PR DESCRIPTION
Explicitly unlock to prevent a client from accidentally blacklisting
itself when retrying the lock.

Fixes: http://tracker.ceph.com/issues/15709
Signed-off-by: Jason Dillaman <dillaman@redhat.com>