### PR TITLE
osd,librados: cmpext support

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -258,6 +258,7 @@ extern const char *ceph_osd_state_name(int s);
 									    \
 	/* ESX/SCSI */							    \
 	f(WRITESAME,	__CEPH_OSD_OP(WR, DATA, 38),	"write-same")	    \
+	f(CMPEXT,	__CEPH_OSD_OP(RD, DATA, 31),	"cmpext")	    \
 									    \
 	/** multi **/							    \
 	f(CLONERANGE,	__CEPH_OSD_OP(WR, MULTI, 1),	"clonerange")	    \
@@ -358,6 +359,7 @@ static inline int ceph_osd_op_uses_extent(int op)
 	case CEPH_OSD_OP_ZERO:
 	case CEPH_OSD_OP_APPEND:
 	case CEPH_OSD_OP_TRIMTRUNC:
+	case CEPH_OSD_OP_CMPEXT:
 		return true;
 	default:
 		return false;

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -296,6 +296,8 @@ namespace librados
     //flag mean ObjectOperationFlags
     void set_op_flags2(int flags);
 
+    void cmpext(uint64_t off, bufferlist& cmp_bl,
+                bufferlist *mismatch_bl, uint64_t *mismatch_off, int *prval);
     void cmpxattr(const char *name, uint8_t op, const bufferlist& val);
     void cmpxattr(const char *name, uint8_t op, uint64_t v);
     void src_cmpxattr(const std::string& src_oid,
@@ -695,6 +697,8 @@ namespace librados
     int remove(const std::string& oid, int flags);
     int trunc(const std::string& oid, uint64_t size);
     int mapext(const std::string& o, uint64_t off, size_t len, std::map<uint64_t,uint64_t>& m);
+    int cmpext(const std::string& o, uint64_t off, bufferlist& cmp_bl,
+	       bufferlist *mismatch_bl, uint64_t *mismatch_off);
     int sparse_read(const std::string& o, std::map<uint64_t,uint64_t>& m, bufferlist& bl, size_t len, uint64_t off);
     int getxattr(const std::string& oid, const char *name, bufferlist& bl);
     int getxattrs(const std::string& oid, std::map<std::string, bufferlist>& attrset);
@@ -907,6 +911,26 @@ namespace librados
     int aio_sparse_read(const std::string& oid, AioCompletion *c,
 			std::map<uint64_t,uint64_t> *m, bufferlist *data_bl,
 			size_t len, uint64_t off, uint64_t snapid);
+    /**
+     * Asynchronously compare an on-disk object range with a buffer
+     *
+     * On mismatch, -EILSEQ will be returned with @mismatch_bl and
+     * @mismatch_off filled accordingly.
+     *
+     * @param oid the name of the object to read from
+     * @param c what to do when the read is complete
+     * @param mismatch_bl buffer filled with object data on mismatch
+     * @param mismatch_off offset into buffer where the mismatch was detected
+     * @param off object byte offset at which to start the comparison
+     * @param cmp_bl buffer containing bytes to be compared with object contents
+     * @returns 0 on success, negative error code on failure
+     */
+    int aio_cmpext(const std::string& oid,
+		   librados::AioCompletion *c,
+		   bufferlist *mismatch_bl,
+		   uint64_t *mismatch_off,
+		   uint64_t off,
+		   bufferlist& cmp_bl);
     int aio_write(const std::string& oid, AioCompletion *c, const bufferlist& bl,
 		  size_t len, uint64_t off);
     int aio_append(const std::string& oid, AioCompletion *c, const bufferlist& bl,

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -141,6 +141,8 @@ struct librados::IoCtxImpl {
   int stat(const object_t& oid, uint64_t *psize, time_t *pmtime);
   int stat2(const object_t& oid, uint64_t *psize, struct timespec *pts);
   int trunc(const object_t& oid, uint64_t size);
+  int cmpext(const object_t& oid, uint64_t off, bufferlist& cmp_bl,
+             bufferlist *mismatch_bl, uint64_t *mismatch_off);
 
   int tmap_update(const object_t& oid, bufferlist& cmdbl);
   int tmap_put(const object_t& oid, bufferlist& bl);
@@ -197,6 +199,13 @@ struct librados::IoCtxImpl {
   int aio_sparse_read(const object_t oid, AioCompletionImpl *c,
 		      std::map<uint64_t,uint64_t> *m, bufferlist *data_bl,
 		      size_t len, uint64_t off, uint64_t snapid);
+  int aio_cmpext(const object_t& oid, AioCompletionImpl *c, uint64_t off,
+		 bufferlist& cmp_bl, bufferlist *mismatch_bl,
+		 uint64_t *mismatch_off);
+  int aio_cmpext(const object_t& oid, AioCompletionImpl *c,
+		 const char *cmp_buf, size_t cmp_len, uint64_t off,
+		 char *mismatch_buf, size_t *mismatch_len,
+		 uint64_t *mismatch_off);
   int aio_write(const object_t &oid, AioCompletionImpl *c,
 		const bufferlist& bl, size_t len, uint64_t off);
   int aio_append(const object_t &oid, AioCompletionImpl *c,

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3700,6 +3700,39 @@ int ReplicatedPG::do_xattr_cmp_str(int op, string& v1s, bufferlist& xattr)
   }
 }
 
+int ReplicatedPG::do_extent_cmp(OpContext *ctx, OSDOp& osd_op)
+{
+  ceph_osd_op& op = osd_op.op;
+  vector<OSDOp> read_ops(1);
+  OSDOp& read_op = read_ops[0];
+  int result = 0;
+
+  read_op.op.op = CEPH_OSD_OP_SYNC_READ;
+  read_op.op.extent.offset = op.extent.offset;
+  read_op.op.extent.length = op.extent.length;
+  read_op.op.extent.truncate_seq = op.extent.truncate_seq;
+  read_op.op.extent.truncate_size = op.extent.truncate_size;
+
+  result = do_osd_ops(ctx, read_ops);
+  if (result < 0) {
+    derr << "do_extent_cmp do_osd_ops failed " << result << dendl;
+    return result;
+  }
+
+  if (read_op.outdata.length() != osd_op.indata.length())
+    return -EINVAL;
+
+  for (uint64_t p = 0; p < osd_op.indata.length(); p++) {
+    if (read_op.outdata[p] != osd_op.indata[p]) {
+      ::encode(p, osd_op.outdata);
+      osd_op.outdata.claim_append(read_op.outdata);
+      return -EILSEQ;
+    }
+  }
+
+  return 0;
+}
+
 int ReplicatedPG::do_writesame(OpContext *ctx, OSDOp& osd_op)
 {
   ceph_osd_op& op = osd_op.op;
@@ -4205,6 +4238,12 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
     switch (op.op) {
       
       // --- READS ---
+
+    case CEPH_OSD_OP_CMPEXT:
+      ++ctx->num_read;
+      tracepoint(osd, do_osd_op_pre_extent_cmp, soid.oid.name.c_str(), soid.snap.val, oi.size, oi.truncate_seq, op.extent.offset, op.extent.length, op.extent.truncate_size, op.extent.truncate_seq);
+      result = do_extent_cmp(ctx, osd_op);
+      break;
 
     case CEPH_OSD_OP_SYNC_READ:
       if (pool.info.require_rollback()) {

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1412,6 +1412,7 @@ protected:
   int do_xattr_cmp_u64(int op, __u64 v1, bufferlist& xattr);
   int do_xattr_cmp_str(int op, string& v1s, bufferlist& xattr);
 
+  int do_extent_cmp(OpContext *ctx, OSDOp& osd_op);
   int do_writesame(OpContext *ctx, OSDOp& osd_op);
 
   bool pgls_filter(PGLSFilter *filter, hobject_t& sobj, bufferlist& outdata);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2194,6 +2194,10 @@ public:
     o->priority = op.priority;
     o->mtime = mtime;
     o->snapc = snapc;
+    if (op.size() == 1 && op.out_bl[0]->length())
+	o->outbl = op.out_bl[0];
+    o->out_bl.swap(op.out_bl);
+    o->out_handler.swap(op.out_handler);
     o->out_rval.swap(op.out_rval);
     o->reqid = reqid;
     return o;

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -3389,3 +3389,243 @@ TEST(LibRadosAioEC, MultiWritePP) {
   delete my_completion2;
   delete my_completion3;
 }
+
+TEST(LibRadosAio, RoundTripCmpExt) {
+  char full[128];
+  char buf2[128];
+  char mismatch_buf[128];
+  size_t mismatch_len;
+  uint64_t mismatch_off;
+  AioTestData test_data;
+  rados_completion_t my_completion, my_completion2, my_completion3;
+  ASSERT_EQ("", test_data.init());
+  ASSERT_EQ(0, rados_aio_create_completion((void*)&test_data,
+	      set_completion_complete, set_completion_safe, &my_completion));
+  memset(full, 0xcc, sizeof(full));
+  ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
+			       my_completion, full, sizeof(full), 0));
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, rados_aio_wait_for_complete(my_completion));
+  }
+  ASSERT_EQ(0, rados_aio_get_return_value(my_completion));
+  /* compare with match */
+  memset(mismatch_buf, 0, sizeof(mismatch_buf));
+  mismatch_len = 0;
+  mismatch_off = 0;
+  ASSERT_EQ(0, rados_aio_create_completion((void*)&test_data,
+	      set_completion_complete, set_completion_safe, &my_completion2));
+  ASSERT_EQ(0, rados_aio_cmpext(test_data.m_ioctx, "foo",
+				my_completion2, full, sizeof(full), 0,
+				mismatch_buf, &mismatch_len, &mismatch_off));
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, rados_aio_wait_for_complete(my_completion2));
+  }
+  ASSERT_EQ(0, rados_aio_get_return_value(my_completion2));
+  ASSERT_EQ(0, mismatch_len);
+  ASSERT_EQ(0, mismatch_off);
+
+
+  /* compare with mismatch */
+  memset(buf2, 0xdd, sizeof(buf2));
+  memset(mismatch_buf, 0, sizeof(mismatch_buf));
+  mismatch_len = 0;
+  mismatch_off = 0;
+  ASSERT_EQ(0, rados_aio_create_completion((void*)&test_data,
+	      set_completion_complete, set_completion_safe, &my_completion3));
+  ASSERT_EQ(0, rados_aio_cmpext(test_data.m_ioctx, "foo",
+				my_completion3, buf2, sizeof(buf2), 0,
+				mismatch_buf, &mismatch_len, &mismatch_off));
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, rados_aio_wait_for_complete(my_completion3));
+  }
+  ASSERT_EQ(-EILSEQ, rados_aio_get_return_value(my_completion3));
+  ASSERT_EQ(sizeof(mismatch_buf), mismatch_len);
+  ASSERT_EQ(0, mismatch_off);
+  ASSERT_EQ(sizeof(full), sizeof(mismatch_buf));
+  ASSERT_EQ(0, memcmp(mismatch_buf, full, sizeof(full)));
+
+  rados_aio_release(my_completion);
+  rados_aio_release(my_completion2);
+  rados_aio_release(my_completion3);
+}
+
+TEST(LibRadosAio, RoundTripCmpExtPP) {
+  AioTestDataPP test_data;
+  ASSERT_EQ("", test_data.init());
+  AioCompletion *my_completion = test_data.m_cluster.aio_create_completion(
+	  (void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion_null = NULL;
+  ASSERT_NE(my_completion, my_completion_null);
+  char mismatch_buf[128];
+  uint64_t mismatch_off;
+  char full[128];
+  memset(full, 0xcc, sizeof(full));
+  bufferlist bl1;
+  bl1.append(full, sizeof(full));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion,
+					   bl1, sizeof(full), 0));
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, my_completion->wait_for_complete());
+  }
+  ASSERT_EQ(0, my_completion->get_return_value());
+
+  /* compare with match */
+  bufferlist mbl;
+  bufferlist cbl;
+  cbl.append(full, sizeof(full));
+  mismatch_off = 0;
+  AioCompletion *my_completion2 = test_data.m_cluster.aio_create_completion(
+	  (void*)&test_data, set_completion_complete, set_completion_safe);
+  ASSERT_EQ(0, test_data.m_ioctx.aio_cmpext("foo", my_completion2, &mbl,
+					    &mismatch_off, 0, cbl));
+
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, my_completion2->wait_for_complete());
+  }
+  ASSERT_EQ(0, my_completion2->get_return_value());
+  ASSERT_EQ(0, mbl.length());
+  ASSERT_EQ(0, mismatch_off);
+
+  /* compare with mismatch */
+  memset(mismatch_buf, 0xdd, sizeof(mismatch_buf));
+  cbl.clear();
+  cbl.append(mismatch_buf, sizeof(mismatch_buf));
+  mbl.clear();
+  mismatch_off = 0;
+  AioCompletion *my_completion3 = test_data.m_cluster.aio_create_completion(
+	  (void*)&test_data, set_completion_complete, set_completion_safe);
+  ASSERT_EQ(0, test_data.m_ioctx.aio_cmpext("foo", my_completion3, &mbl,
+					    &mismatch_off, 0, cbl));
+
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, my_completion3->wait_for_complete());
+  }
+  ASSERT_EQ(-EILSEQ, my_completion3->get_return_value());
+  ASSERT_EQ(0, mismatch_off);
+  ASSERT_EQ(sizeof(full), mbl.length());
+  ASSERT_EQ(0, memcmp(mbl.c_str(), full, sizeof(full)));
+
+  delete my_completion;
+  delete my_completion2;
+  delete my_completion3;
+}
+
+TEST(LibRadosAio, RoundTripCmpExtPP2)
+{
+  int ret;
+  char buf[128];
+  char miscmp_buf[128];
+  bufferlist cbl;
+  bufferlist mbl;
+  uint64_t mismatch_off;
+  Rados cluster;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
+  IoCtx ioctx;
+  cluster.ioctx_create(pool_name.c_str(), ioctx);
+
+  boost::scoped_ptr<AioCompletion>
+			wr_cmpl(cluster.aio_create_completion(0, 0, 0));
+  ObjectWriteOperation wr_op;
+  memset(buf, 0xcc, sizeof(buf));
+  memset(miscmp_buf, 0xdd, sizeof(miscmp_buf));
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+
+  wr_op.write_full(bl);
+  wr_op.set_op_flags2(LIBRADOS_OP_FLAG_FADVISE_DONTNEED);
+  ioctx.aio_operate("test_obj", wr_cmpl.get(), &wr_op);
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, wr_cmpl->wait_for_complete());
+  }
+  EXPECT_EQ(0, wr_cmpl->get_return_value());
+
+  /* cmpext as write op. first match then mismatch */
+  boost::scoped_ptr<AioCompletion>
+			wr_cmpext_cmpl(cluster.aio_create_completion(0, 0, 0));
+  cbl.append(buf, sizeof(buf));
+  mbl.clear();
+  mismatch_off = 0;
+  ret = 0;
+
+  wr_op.cmpext(0, cbl, &mbl, &mismatch_off, &ret);
+  wr_op.set_op_flags2(LIBRADOS_OP_FLAG_FADVISE_DONTNEED);
+  ioctx.aio_operate("test_obj", wr_cmpext_cmpl.get(), &wr_op);
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, wr_cmpext_cmpl->wait_for_complete());
+  }
+  EXPECT_EQ(0, wr_cmpext_cmpl->get_return_value());
+  EXPECT_EQ(0, ret);
+  EXPECT_EQ(0, mismatch_off);
+
+  boost::scoped_ptr<AioCompletion>
+			wr_cmpext_cmpl2(cluster.aio_create_completion(0, 0, 0));
+  cbl.clear();
+  cbl.append(miscmp_buf, sizeof(miscmp_buf));
+  mbl.clear();
+  mismatch_off = 0;
+  ret = 0;
+
+  wr_op.cmpext(0, cbl, &mbl, &mismatch_off, &ret);
+  wr_op.set_op_flags2(LIBRADOS_OP_FLAG_FADVISE_DONTNEED);
+  ioctx.aio_operate("test_obj", wr_cmpext_cmpl2.get(), &wr_op);
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, wr_cmpext_cmpl2->wait_for_complete());
+  }
+  EXPECT_EQ(-EILSEQ, wr_cmpext_cmpl2->get_return_value());
+  EXPECT_EQ(-EILSEQ, ret);
+  EXPECT_EQ(0, mismatch_off);
+  EXPECT_EQ(true, mbl.contents_equal(bl));
+
+  /* cmpext as read op */
+  boost::scoped_ptr<AioCompletion>
+			rd_cmpext_cmpl(cluster.aio_create_completion(0, 0, 0));
+  ObjectReadOperation rd_op;
+  cbl.clear();
+  cbl.append(buf, sizeof(buf));
+  mbl.clear();
+  mismatch_off = 0;
+  ret = 0;
+  rd_op.cmpext(0, cbl, &mbl, &mismatch_off, &ret);
+  rd_op.set_op_flags2(LIBRADOS_OP_FLAG_FADVISE_DONTNEED);
+  ioctx.aio_operate("test_obj", rd_cmpext_cmpl.get(), &rd_op, 0);
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, rd_cmpext_cmpl->wait_for_complete());
+  }
+  EXPECT_EQ(0, rd_cmpext_cmpl->get_return_value());
+  EXPECT_EQ(0, ret);
+  EXPECT_EQ(0, mismatch_off);
+
+  boost::scoped_ptr<AioCompletion>
+			rd_cmpext_cmpl2(cluster.aio_create_completion(0, 0, 0));
+  cbl.clear();
+  cbl.append(miscmp_buf, sizeof(miscmp_buf));
+  mbl.clear();
+  mismatch_off = 0;
+  ret = 0;
+
+  rd_op.cmpext(0, cbl, &mbl, &mismatch_off, &ret);
+  rd_op.set_op_flags2(LIBRADOS_OP_FLAG_FADVISE_DONTNEED);
+  ioctx.aio_operate("test_obj", rd_cmpext_cmpl2.get(), &rd_op, 0);
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, rd_cmpext_cmpl2->wait_for_complete());
+  }
+  EXPECT_EQ(-EILSEQ, rd_cmpext_cmpl2->get_return_value());
+  EXPECT_EQ(-EILSEQ, ret);
+  EXPECT_EQ(0, mismatch_off);
+  EXPECT_EQ(true, mbl.contents_equal(bl));
+
+  ioctx.remove("test_obj");
+  destroy_one_pool_pp(pool_name, cluster);
+}

--- a/src/test/librados/c_read_operations.cc
+++ b/src/test/librados/c_read_operations.cc
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "include/rados/librados.h"
+#include "include/byteorder.h"
 #include "test/librados/test.h"
 #include "test/librados/TestCase.h"
 
@@ -593,6 +594,58 @@ TEST_F(CReadOpsTest, GetXattrs) {
   EXPECT_EQ(0, rval);
   rados_release_read_op(op);
   compare_xattrs(keys, vals, lens, 4, it);
+
+  remove_object();
+}
+
+TEST_F(CReadOpsTest, CmpExt) {
+  char mismatch_buf[len];
+  char buf[len];
+  uint64_t mismatch_off = 0;
+  size_t mismatch_len = 0;
+  size_t bytes_read = 0;
+  int cmpext_val = 0;
+  int read_val = 0;
+
+  write_object();
+
+  // cmpext with match should ensure that the following read is successful
+  rados_read_op_t op = rados_create_read_op();
+  ASSERT_TRUE(op);
+  // @obj, @data and @len correspond to object initialised by write_object()
+  rados_read_op_cmpext(op, data, len, 0, mismatch_buf, &mismatch_len,
+		       &mismatch_off, &cmpext_val);
+  rados_read_op_read(op, 0, len, buf, &bytes_read, &read_val);
+  ASSERT_EQ(0, rados_read_op_operate(op, ioctx, obj, 0));
+  ASSERT_EQ(len, bytes_read);
+  ASSERT_EQ(0, memcmp(data, buf, len));
+  ASSERT_EQ(mismatch_len, 0);
+  ASSERT_EQ(mismatch_off, 0);
+  ASSERT_EQ(cmpext_val, 0);
+  rados_release_read_op(op);
+
+  // cmpext with mismatch should fail and fill mismatch_buf accordingly
+  memset(mismatch_buf, 0, sizeof(mismatch_buf));
+  memset(buf, 0, sizeof(buf));
+  mismatch_len = 0;
+  mismatch_off = 0;
+  bytes_read = 0;
+  cmpext_val = 0;
+  read_val = 0;
+  op = rados_create_read_op();
+  ASSERT_TRUE(op);
+  ASSERT_TRUE(strlen("mismatch") <= sizeof(mismatch_buf));
+  // @obj, @data and @len correspond to object initialised by write_object()
+  rados_read_op_cmpext(op, "mismatch", strlen("mismatch"), 0, mismatch_buf,
+		       &mismatch_len, &mismatch_off, &cmpext_val);
+  rados_read_op_read(op, 0, len, buf, &bytes_read, &read_val);
+  ASSERT_EQ(-EILSEQ, rados_read_op_operate(op, ioctx, obj, 0));
+  rados_release_read_op(op);
+
+  ASSERT_EQ(mismatch_len, len);
+  ASSERT_EQ(mismatch_off, 0);
+  ASSERT_EQ(0, memcmp(mismatch_buf, data, len));
+  ASSERT_EQ(-EILSEQ, cmpext_val);
 
   remove_object();
 }

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -1445,6 +1445,35 @@ TRACEPOINT_EVENT(librados, rados_ioctx_snap_get_stamp_exit,
     )
 )
 
+TRACEPOINT_EVENT(librados, rados_cmpext_enter,
+    TP_ARGS(
+	rados_ioctx_t, ioctx,
+	const char*, oid,
+	const char*, cmp_buf,
+	size_t, cmp_len,
+	uint64_t, off,
+	char*, mismatch_buf,
+	size_t*, mismatch_len,
+	uint64_t*, mismatch_off),
+    TP_FIELDS(
+	ctf_integer_hex(rados_ioctx_t, ioctx, ioctx)
+	ctf_string(oid, oid)
+	ceph_ctf_sequence(unsigned char, cmp_buf, cmp_buf, size_t, cmp_len)
+	ctf_integer(uint64_t, off, off)
+	ctf_integer_hex(void*, mismatch_buf, mismatch_buf)
+	ctf_integer_hex(void*, mismatch_len, mismatch_len)
+	ctf_integer_hex(void*, mismatch_off, mismatch_off)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_cmpext_exit,
+    TP_ARGS(
+	int, retval),
+    TP_FIELDS(
+	ctf_integer(int, retval, retval)
+    )
+)
+
 TRACEPOINT_EVENT(librados, rados_getxattr_enter,
     TP_ARGS(
         rados_ioctx_t, ioctx,
@@ -2275,6 +2304,37 @@ TRACEPOINT_EVENT(librados, rados_aio_stat_exit,
     )
 )
 
+TRACEPOINT_EVENT(librados, rados_aio_cmpext_enter,
+    TP_ARGS(
+        rados_ioctx_t, ioctx,
+        const char*, oid,
+        rados_completion_t, completion,
+	const char*, cmp_buf,
+	size_t, cmp_len,
+	uint64_t, off,
+	char*, mismatch_buf,
+	size_t*, mismatch_len,
+	uint64_t*, mismatch_off),
+    TP_FIELDS(
+        ctf_integer_hex(rados_ioctx_t, ioctx, ioctx)
+        ctf_string(oid, oid)
+        ctf_integer_hex(rados_completion_t, completion, completion)
+	ceph_ctf_sequence(unsigned char, cmp_buf, cmp_buf, size_t, cmp_len)
+	ctf_integer(uint64_t, off, off)
+	ctf_integer_hex(void*, mismatch_buf, mismatch_buf)
+	ctf_integer_hex(void*, mismatch_len, mismatch_len)
+	ctf_integer_hex(void*, mismatch_off, mismatch_off)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_aio_cmpext_exit,
+    TP_ARGS(
+	int, retval),
+    TP_FIELDS(
+	ctf_integer(int, retval, retval)
+    )
+)
+
 TRACEPOINT_EVENT(librados, rados_watch_enter,
     TP_ARGS(
         rados_ioctx_t, ioctx,
@@ -2808,6 +2868,33 @@ TRACEPOINT_EVENT(librados, rados_write_op_assert_exists_exit,
     TP_FIELDS()
 )
 
+TRACEPOINT_EVENT(librados, rados_write_op_cmpext_enter,
+    TP_ARGS(
+	rados_write_op_t, op,
+	const char*, cmp_buffer,
+	size_t, cmp_len,
+	uint64_t, offset,
+	char*, mismatch_buf,
+	size_t*, mismatch_len,
+	uint64_t*, mismatch_off,
+	int*, prval),
+    TP_FIELDS(
+	ctf_integer_hex(rados_write_op_t, op, op)
+	ceph_ctf_sequence(unsigned char, cmp_buffer, cmp_buffer, size_t, cmp_len)
+	ctf_integer(size_t, cmp_len, cmp_len)
+	ctf_integer(uint64_t, offset, offset)
+	ctf_integer_hex(void*, mismatch_buf, mismatch_buf)
+	ctf_integer_hex(void*, mismatch_len, mismatch_len)
+	ctf_integer_hex(void*, mismatch_off, mismatch_off)
+	ctf_integer_hex(void*, prval, prval)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_write_op_cmpext_exit,
+    TP_ARGS(),
+    TP_FIELDS()
+)
+
 TRACEPOINT_EVENT(librados, rados_write_op_cmpxattr_enter,
     TP_ARGS(
         rados_write_op_t, op,
@@ -3245,6 +3332,33 @@ TRACEPOINT_EVENT(librados, rados_read_op_assert_exists_enter,
 )
 
 TRACEPOINT_EVENT(librados, rados_read_op_assert_exists_exit,
+    TP_ARGS(),
+    TP_FIELDS()
+)
+
+TRACEPOINT_EVENT(librados, rados_read_op_cmpext_enter,
+    TP_ARGS(
+	rados_read_op_t, op,
+	const char*, cmp_buffer,
+	size_t, cmp_len,
+	uint64_t, offset,
+	char*, mismatch_buf,
+	size_t*, mismatch_len,
+	uint64_t*, mismatch_off,
+	int*, prval),
+    TP_FIELDS(
+	ctf_integer_hex(rados_read_op_t, op, op)
+	ceph_ctf_sequence(unsigned char, cmp_buffer, cmp_buffer, size_t, cmp_len)
+	ctf_integer(size_t, cmp_len, cmp_len)
+	ctf_integer(uint64_t, offset, offset)
+	ctf_integer_hex(void*, mismatch_buf, mismatch_buf)
+	ctf_integer_hex(void*, mismatch_len, mismatch_len)
+	ctf_integer_hex(void*, mismatch_off, mismatch_off)
+	ctf_integer_hex(void*, prval, prval)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_read_op_cmpext_exit,
     TP_ARGS(),
     TP_FIELDS()
 )

--- a/src/tracing/osd.tp
+++ b/src/tracing/osd.tp
@@ -91,6 +91,28 @@ TRACEPOINT_EVENT(osd, do_osd_op_pre,
     )
 )
 
+TRACEPOINT_EVENT(osd, do_osd_op_pre_extent_cmp,
+    TP_ARGS(
+        const char*, oid,
+        uint64_t, snap,
+        uint64_t, osize,
+        uint32_t, oseq,
+        uint64_t, offset,
+        uint64_t, length,
+        uint64_t, truncate_size,
+        uint32_t, truncate_seq),
+    TP_FIELDS(
+        ctf_string(oid, oid)
+        ctf_integer(uint64_t, snap, snap)
+        ctf_integer(uint64_t, osize, osize)
+        ctf_integer(uint32_t, oseq, oseq)
+        ctf_integer(uint64_t, offset, offset)
+        ctf_integer(uint64_t, length, length)
+        ctf_integer(uint64_t, truncate_size, truncate_size)
+        ctf_integer(uint32_t, truncate_seq, truncate_seq)
+    )
+)
+
 TRACEPOINT_EVENT(osd, do_osd_op_pre_read,
     TP_ARGS(
         const char*, oid,


### PR DESCRIPTION
This is a follow up to #8175 and #8568. The patch-set carries @mikechristie 's implementation of OSD cmpext support.
The librados API, based on @mikechristie 's initial C++ work, has been extended to handle transparent miscompare response unmarshalling. AIO support and a C API has also been added, along with corresponding unit tests.
Some aspects of the patchset that could potentially be improved:
- The C API invokes an unnecessary memcpy() on miscompare
  - this was discussed upstream via http://www.spinics.net/lists/ceph-devel/msg29969.html
- The IoCtxImpl::aio_cmpext() helpers used by the AIO cmpext APIs are a little convoluted
  - prepare_cmpext_op is used for C++. m_ops.cmpext() + prepare_read_op() for C
