### PR TITLE
client: correct the client_lock order when cleanup

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -490,9 +490,9 @@ int Client::init()
   int r = monclient->init();
   if (r < 0) {
     // need to do cleanup because we're in an intermediate init state
-    objecter->shutdown();
     timer.shutdown();
     client_lock.Unlock();
+    objecter->shutdown();
     objectcacher->stop();
     monclient->shutdown();
     return r;


### PR DESCRIPTION

As 448bea4, we need to handle a dependency
between client lock and admin socket lock.

Signed-off-by: Vicente Cheng <freeze.bilsted@gmail.com>