### PR TITLE
lockdep: fix assertion expression if ran out of lock ids

### DIFF
--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -144,7 +144,7 @@ int lockdep_register(const char *name)
       for (auto& p : lock_names) {
 	lockdep_dout(0) << "  lock " << p.first << " " << p.second << dendl;
       }
-      assert(free_ids.empty());
+      assert(!free_ids.empty());
     }
     id = free_ids.front();
     free_ids.pop_front();


### PR DESCRIPTION
we should assert that the `free_ids` is not empty

Signed-off-by: runsisi <runsisi@zte.com.cn>