### PR TITLE
test/ec: build the libs only when 'make check'

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -734,20 +734,6 @@ make %{?_smp_mflags} check-local
 
 %install
 make DESTDIR=$RPM_BUILD_ROOT install
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_example.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_fail_to_initialize.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_fail_to_register.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_hangs.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_missing_entry_point.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_missing_version.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_test_jerasure_generic.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_test_jerasure_neon.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_test_jerasure_sse3.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_test_jerasure_sse4.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_test_shec_generic.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_test_shec_neon.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_test_shec_sse3.so
-rm -f $RPM_BUILD_ROOT%{_libdir}/ceph/erasure-code/libec_test_shec_sse4.so
 find $RPM_BUILD_ROOT -type f -name "*.la" -exec rm -f {} ';'
 find $RPM_BUILD_ROOT -type f -name "*.a" -exec rm -f {} ';'
 install -D src/etc-rbdmap $RPM_BUILD_ROOT%{_sysconfdir}/ceph/rbdmap

--- a/src/erasure-code/Makefile.am
+++ b/src/erasure-code/Makefile.am
@@ -3,6 +3,8 @@
 erasure_codelibdir = $(pkglibdir)/erasure-code
 erasure_codelib_LTLIBRARIES =  
 
+check_LTLIBRARIES =  
+
 include erasure-code/jerasure/Makefile.am
 include erasure-code/lrc/Makefile.am
 include erasure-code/shec/Makefile.am

--- a/src/test/erasure-code/Makefile.am
+++ b/src/test/erasure-code/Makefile.am
@@ -42,109 +42,109 @@ test/erasure-code/ErasureCodePluginExample.cc: ./ceph_ver.h
 libec_example_la_CFLAGS = ${AM_CFLAGS}
 libec_example_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_example_la_LIBADD = $(LIBCRUSH) $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_example_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_example_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_example_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_example.la
+check_LTLIBRARIES += libec_example.la
 
 libec_missing_entry_point_la_SOURCES = test/erasure-code/ErasureCodePluginMissingEntryPoint.cc
 test/erasure-code/ErasureCodePluginMissingEntryPoint.cc: ./ceph_ver.h
 libec_missing_entry_point_la_CFLAGS = ${AM_CFLAGS}
 libec_missing_entry_point_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_missing_entry_point_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_missing_entry_point_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_missing_entry_point_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_missing_entry_point_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_missing_entry_point.la
+check_LTLIBRARIES += libec_missing_entry_point.la
 
 libec_missing_version_la_SOURCES = test/erasure-code/ErasureCodePluginMissingVersion.cc
 libec_missing_version_la_CFLAGS = ${AM_CFLAGS}
 libec_missing_version_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_missing_version_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_missing_version_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_missing_version_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_missing_version_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_missing_version.la
+check_LTLIBRARIES += libec_missing_version.la
 
 libec_hangs_la_SOURCES = test/erasure-code/ErasureCodePluginHangs.cc
 test/erasure-code/ErasureCodePluginHangs.cc: ./ceph_ver.h
 libec_hangs_la_CFLAGS = ${AM_CFLAGS}
 libec_hangs_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_hangs_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_hangs_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_hangs_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_hangs_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_hangs.la
+check_LTLIBRARIES += libec_hangs.la
 
 libec_fail_to_initialize_la_SOURCES = test/erasure-code/ErasureCodePluginFailToInitialize.cc
 test/erasure-code/ErasureCodePluginFailToInitialize.cc: ./ceph_ver.h
 libec_fail_to_initialize_la_CFLAGS = ${AM_CFLAGS}
 libec_fail_to_initialize_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_fail_to_initialize_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_fail_to_initialize_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_fail_to_initialize_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_fail_to_initialize_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_fail_to_initialize.la
+check_LTLIBRARIES += libec_fail_to_initialize.la
 
 libec_fail_to_register_la_SOURCES = test/erasure-code/ErasureCodePluginFailToRegister.cc
 test/erasure-code/ErasureCodePluginFailToRegister.cc: ./ceph_ver.h
 libec_fail_to_register_la_CFLAGS = ${AM_CFLAGS}
 libec_fail_to_register_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_fail_to_register_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_fail_to_register_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_fail_to_register_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_fail_to_register_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_fail_to_register.la
+check_LTLIBRARIES += libec_fail_to_register.la
 
 libec_test_jerasure_neon_la_SOURCES = test/erasure-code/TestJerasurePluginNEON.cc
 test/erasure-code/TestJerasurePluginNEON.cc: ./ceph_ver.h
 libec_test_jerasure_neon_la_CFLAGS = ${AM_CFLAGS}
 libec_test_jerasure_neon_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_jerasure_neon_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_jerasure_neon_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_test_jerasure_neon_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_test_jerasure_neon_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_jerasure_neon.la
+check_LTLIBRARIES += libec_test_jerasure_neon.la
 
 libec_test_jerasure_sse4_la_SOURCES = test/erasure-code/TestJerasurePluginSSE4.cc
 test/erasure-code/TestJerasurePluginSSE4.cc: ./ceph_ver.h
 libec_test_jerasure_sse4_la_CFLAGS = ${AM_CFLAGS}
 libec_test_jerasure_sse4_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_jerasure_sse4_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_jerasure_sse4_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_test_jerasure_sse4_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_test_jerasure_sse4_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_jerasure_sse4.la
+check_LTLIBRARIES += libec_test_jerasure_sse4.la
 
 libec_test_jerasure_sse3_la_SOURCES = test/erasure-code/TestJerasurePluginSSE3.cc
 test/erasure-code/TestJerasurePluginSSE3.cc: ./ceph_ver.h
 libec_test_jerasure_sse3_la_CFLAGS = ${AM_CFLAGS}
 libec_test_jerasure_sse3_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_jerasure_sse3_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_jerasure_sse3_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_test_jerasure_sse3_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_test_jerasure_sse3_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_jerasure_sse3.la
+check_LTLIBRARIES += libec_test_jerasure_sse3.la
 
 libec_test_jerasure_generic_la_SOURCES = test/erasure-code/TestJerasurePluginGeneric.cc
 test/erasure-code/TestJerasurePluginGeneric.cc: ./ceph_ver.h
 libec_test_jerasure_generic_la_CFLAGS = ${AM_CFLAGS}
 libec_test_jerasure_generic_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_jerasure_generic_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_jerasure_generic_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_test_jerasure_generic_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_test_jerasure_generic_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_jerasure_generic.la
+check_LTLIBRARIES += libec_test_jerasure_generic.la
 
 unittest_erasure_code_plugin_SOURCES = \
 	erasure-code/ErasureCode.cc \
@@ -318,44 +318,44 @@ test/erasure-code/TestShecPluginNEON.cc: ./ceph_ver.h
 libec_test_shec_neon_la_CFLAGS = ${AM_CFLAGS}
 libec_test_shec_neon_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_shec_neon_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_shec_neon_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_test_shec_neon_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_test_shec_neon_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_shec_neon.la
+check_LTLIBRARIES += libec_test_shec_neon.la
 
 libec_test_shec_sse4_la_SOURCES = test/erasure-code/TestShecPluginSSE4.cc
 test/erasure-code/TestShecPluginSSE4.cc: ./ceph_ver.h
 libec_test_shec_sse4_la_CFLAGS = ${AM_CFLAGS}
 libec_test_shec_sse4_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_shec_sse4_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_shec_sse4_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_test_shec_sse4_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_test_shec_sse4_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_shec_sse4.la
+check_LTLIBRARIES += libec_test_shec_sse4.la
 
 libec_test_shec_sse3_la_SOURCES = test/erasure-code/TestShecPluginSSE3.cc
 test/erasure-code/TestShecPluginSSE3.cc: ./ceph_ver.h
 libec_test_shec_sse3_la_CFLAGS = ${AM_CFLAGS}
 libec_test_shec_sse3_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_shec_sse3_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_shec_sse3_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_test_shec_sse3_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_test_shec_sse3_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_shec_sse3.la
+check_LTLIBRARIES += libec_test_shec_sse3.la
 
 libec_test_shec_generic_la_SOURCES = test/erasure-code/TestShecPluginGeneric.cc
 test/erasure-code/TestShecPluginGeneric.cc: ./ceph_ver.h
 libec_test_shec_generic_la_CFLAGS = ${AM_CFLAGS}
 libec_test_shec_generic_la_CXXFLAGS= ${AM_CXXFLAGS}
 libec_test_shec_generic_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
-libec_test_shec_generic_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared
+libec_test_shec_generic_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -rpath /nowhere
 if LINUX
 libec_test_shec_generic_la_LDFLAGS += -export-symbols-regex '.*__erasure_code_.*'
 endif
-erasure_codelib_LTLIBRARIES += libec_test_shec_generic.la
+check_LTLIBRARIES += libec_test_shec_generic.la
 
 unittest_erasure_code_example_SOURCES = \
 	erasure-code/ErasureCode.cc \


### PR DESCRIPTION
Currently, we are always building the erasure code libraries while we
need them only when 'make check' is run. Moving the test libraries to
check_LTLIBRARIES should fix this for us.

We no longer need to remove the libec libs manually, remove the lines
that do that.

Signed-off-by: Boris Ranto <branto@redhat.com>