### PR TITLE
osd/OSD.h: remove redundant find in map

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -438,7 +438,7 @@ public:
     Mutex::Locker l(pg_epoch_lock);
     map<spg_t,epoch_t>::iterator t = pg_epoch.find(pgid);
     assert(t != pg_epoch.end());
-    pg_epochs.erase(pg_epochs.find(t->second));
+    pg_epochs.erase(t->second);
     t->second = epoch;
     pg_epochs.insert(epoch);
   }
@@ -446,7 +446,7 @@ public:
     Mutex::Locker l(pg_epoch_lock);
     map<spg_t,epoch_t>::iterator t = pg_epoch.find(pgid);
     if (t != pg_epoch.end()) {
-      pg_epochs.erase(pg_epochs.find(t->second));
+      pg_epochs.erase(t->second);
       pg_epoch.erase(t);
     }
   }


### PR DESCRIPTION
We don't need to use find to get iterator that is then passed to
erase. We can just erase element directly.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>