### PR TITLE
common/Finisher: Using queue(list<context*>) instead queue(context*).

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6556,12 +6556,10 @@ void BlueStore::_txc_finish_kv(TransContext *txc)
     finishers[n]->queue(txc->onreadable);
     txc->onreadable = NULL;
   }
-  while (!txc->oncommits.empty()) {
-    auto f = txc->oncommits.front();
-    finishers[n]->queue(f);
-    txc->oncommits.pop_front();
-  }
 
+  if (!txc->oncommits.empty()) {
+    finishers[n]->queue(txc->oncommits);
+  }
   op_queue_release_throttle(txc);
 }
 

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1988,9 +1988,8 @@ void KStore::_txc_finish_kv(TransContext *txc)
     finisher.queue(txc->oncommit);
     txc->oncommit = NULL;
   }
-  while (!txc->oncommits.empty()) {
-    finisher.queue(txc->oncommits.front());
-    txc->oncommits.pop_front();
+  if (!txc->oncommits.empty()) {
+    finisher.queue(txc->oncommits);
   }
 
   throttle_ops.put(txc->ops);


### PR DESCRIPTION
Avoid call many time queue(context*).

Signed-off-by: Jianpeng Ma jianpeng.ma@intel.com
