### PR TITLE
pybind/ceph_argparse: handle non ascii unicode args

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -540,14 +540,16 @@ class CephPrefix(CephArgtype):
         self.prefix = prefix
 
     def valid(self, s, partial=False):
-        s = str(s)
-        if isinstance(s, bytes):
-            try:
+        try:
+            s = str(s)
+            if isinstance(s, bytes):
                 # `prefix` can always be converted into unicode when being compared,
                 # but `s` could be anything passed by user.
                 s = s.decode('ascii')
-            except UnicodeDecodeError:
-                raise ArgumentPrefix("no match for {0}".format(s))
+        except UnicodeEncodeError:
+            raise ArgumentPrefix(u"no match for {0}".format(s))
+        except UnicodeDecodeError:
+            raise ArgumentPrefix("no match for {0}".format(s))
 
         if partial:
             if self.prefix.startswith(s):

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -92,10 +92,16 @@ class TestArgparse:
 class TestBasic:
 
     def test_non_ascii_in_non_options(self):
-        # unicode() is not able to convert this str parameter into unicode
-        # using the default encoding 'ascii'. and validate_command() should
-        # not choke on it.
+        # ArgumentPrefix("no match for {0}".format(s)) is not able to convert
+        # unicode str parameter into str. and validate_command() should not
+        # choke on it.
+        assert_is_none(validate_command(sigdict, [u'章鱼和鱿鱼']))
+        assert_is_none(validate_command(sigdict, [u'–w']))
+        # actually we always pass unicode strings to validate_command() in "ceph"
+        # CLI, but we also use bytestrings in our tests, so make sure it does not
+        # break.
         assert_is_none(validate_command(sigdict, ['章鱼和鱿鱼']))
+        assert_is_none(validate_command(sigdict, ['–w']))
 
 
 class TestPG(TestArgparse):


### PR DESCRIPTION
we raise UnicodeDecodeError at seeing non-ascii args if we fail to match
it with any command signatures. instead, we should use a unicode string
for representing the error in that case. please note, the exception is not
printed at all in real-world. =)

Fixes: http://tracker.ceph.com/issues/12287
Signed-off-by: Kefu Chai <tchaikov@gmail.com>