### PR TITLE
rbd: helpful error message on map failure

### DIFF
--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -153,6 +153,45 @@ static int do_kernel_showmapped(Formatter *f)
   return r;
 }
 
+/*
+ * hint user to check syslog for krbd related messages and provide suggestions
+ * based on errno return by krbd_map(). also note that even if some librbd calls
+ * fail, we atleast dump the "try dmesg..." message to aid debugging.
+ */
+static void print_error_description(const char *poolname, const char *imgname,
+				    const char *snapname, int maperrno)
+{
+  int r;
+  uint8_t oldformat;
+  librados::Rados rados;
+  librados::IoCtx ioctx;
+  librbd::Image image;
+
+  if (maperrno == -ENOENT)
+    goto done;
+
+  r = utils::init_and_open_image(poolname, imgname, snapname,
+				 true, &rados, &ioctx, &image);
+  if (r < 0)
+    goto done;
+
+  r = image.old_format(&oldformat);
+  if (r < 0)
+    goto done;
+
+  /*
+   * kernel returns -ENXIO when mapping a V2 image due to unsupported feature
+   * set - so, hint about that too...
+   */
+  if (!oldformat && (maperrno == -ENXIO)) {
+    std::cout << "RBD image feature set mismatch. You can disable features unsupported by the "
+	      << "kernel with \"rbd feature disable\"." << std::endl;
+  }
+
+ done:
+  std::cout << "In some cases useful info is found in syslog - try \"dmesg | tail\" or so." << std::endl;
+}
+
 static int do_kernel_map(const char *poolname, const char *imgname,
                          const char *snapname)
 {
@@ -181,8 +220,10 @@ static int do_kernel_map(const char *poolname, const char *imgname,
   }
 
   r = krbd_map(krbd, poolname, imgname, snapname, oss.str().c_str(), &devnode);
-  if (r < 0)
+  if (r < 0) {
+    print_error_description(poolname, imgname, snapname, r);
     goto out;
+  }
 
   std::cout << devnode << std::endl;
 


### PR DESCRIPTION
Failure to map an rbd image provides pretty much nothing to
debug (or rectify) the nature of failure. This change tries
to improve the same by providing helpful error messages (by
pointing to dmesg, etc..).

Fixes: http://tracker.ceph.com/issues/15721
Signed-off-by: Venky Shankar <vshankar@redhat.com>