### PR TITLE
mon/PGMap: pretty output for "pg dump osds" command

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -885,31 +885,31 @@ void PGMap::dump_pg_sum_stats(ostream& ss, bool header) const
 
 void PGMap::dump_osd_stats(ostream& ss) const
 {
-  ss << "osdstat\tkbused\tkbavail\tkb\thb in\thb out\tpg sum" << std::endl;
+  ss << "osdstat\tused\tavail\ttotal\thb in\thb out\tpg sum" << std::endl;
   for (ceph::unordered_map<int32_t,osd_stat_t>::const_iterator p = osd_stat.begin();
        p != osd_stat.end();
        ++p) {
     ss << p->first
-       << "\t" << p->second.kb_used
-       << "\t" << p->second.kb_avail
-       << "\t" << p->second.kb
+       << "\t" << prettybyte_t(p->second.kb_used)
+       << "\t" << prettybyte_t(p->second.kb_avail)
+       << "\t" << prettybyte_t(p->second.kb)
        << "\t" << p->second.hb_in
        << "\t" << p->second.hb_out
        << "\t" << get_num_pg_by_osd(p->first)
        << std::endl;
   }
-  ss << " sum\t" << osd_sum.kb_used
-     << "\t" << osd_sum.kb_avail
-     << "\t" << osd_sum.kb
+  ss << " sum\t" << prettybyte_t(osd_sum.kb_used)
+     << "\t" << prettybyte_t(osd_sum.kb_avail)
+     << "\t" << prettybyte_t(osd_sum.kb)
      << std::endl;
 }
 
 void PGMap::dump_osd_sum_stats(ostream& ss) const
 {
-  ss << "osdstat\tkbused\tkbavail\tkb" << std::endl;
-  ss << " sum\t" << osd_sum.kb_used
-     << "\t" << osd_sum.kb_avail
-     << "\t" << osd_sum.kb
+  ss << "osdstat\tused\tavail\ttotal" << std::endl;
+  ss << " sum\t" << prettybyte_t(osd_sum.kb_used)
+     << "\t" << prettybyte_t(osd_sum.kb_avail)
+     << "\t" << prettybyte_t(osd_sum.kb)
      << std::endl;
 }
 


### PR DESCRIPTION
**before:**
```
[root@c7 yum.repos.d]# ceph pg dump osds
dumped osds in format plain
osdstat kbused  kbavail kb      hb in   hb out
1       12914796        88268416        101183212       [0]     []
0       12914796        88268416        101183212       [1]     []
 sum    25829592        176536832       202366424
```
**after(come from a upgraded cluster applied this patch):**
```
[root@c7 yum.repos.d]# ceph --cluster clove pg dump osds
dumped osds in format plain
osdstat used    avail   total   hb in   hb out
1       71883 kB        125 MB  195 MB  [0]     []
0       71883 kB        125 MB  195 MB  [1]     []
 sum    140 MB  250 MB  390 MB
```
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>