### PR TITLE
cmake: Remove redundant call to get_processors

### DIFF
--- a/run-cmake-check.sh
+++ b/run-cmake-check.sh
@@ -51,7 +51,7 @@ function run() {
     $DRY_RUN mkdir build
     $DRY_RUN cd build
     $DRY_RUN cmake ../    
-    $DRY_RUN make $BUILD_MAKEOPTS -j$(get_processors) || return 1
+    $DRY_RUN make $BUILD_MAKEOPTS || return 1
 }
 
 function main() {


### PR DESCRIPTION
The redundant code causes the following undesirable behaviour.

$ DRY_RUN=echo ./run-cmake-check.sh 2>/dev/null|grep "\-j"
make -j4 -j4

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>