### PR TITLE
Modify a hyphen error

### DIFF
--- a/doc/start/quick-ceph-deploy.rst
+++ b/doc/start/quick-ceph-deploy.rst
@@ -195,7 +195,7 @@ quorum of Ceph Monitors.
 
 .. ditaa::
            /------------------\         /----------------\
-           |    ceph–deploy   |         |     node1      |
+           |    ceph-deploy   |         |     node1      |
            |    Admin Node    |         | cCCC           |
            |                  +-------->+   mon.node1    |
            |                  |         |     osd.2      |


### PR DESCRIPTION
File: doc/start/quick-ceph-deploy.rst
Locate: The ditaa of "Expanding Your Cluster" section
Description: The hyphen of "ceph-deploy" is error so that there is a problem in web page of ceph documentation (http://docs.ceph.com/docs/master/start/quick-ceph-deploy/#expanding-your-cluster) .