### PR TITLE
doc: Fixes three hyphen errors and a syntax error.

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -983,7 +983,7 @@ Keystone Settings
 :Default: ``15 * 60``
 
 
-``rgw keystone verify ssl`
+``rgw keystone verify ssl``
 
 :Description: Verify SSL certificates while making token requests to keystone.
 :Type: Boolean

--- a/doc/start/quick-ceph-deploy.rst
+++ b/doc/start/quick-ceph-deploy.rst
@@ -195,7 +195,7 @@ quorum of Ceph Monitors.
 
 .. ditaa::
            /------------------\         /----------------\
-           |    ceph–deploy   |         |     node1      |
+           |    ceph-deploy   |         |     node1      |
            |    Admin Node    |         | cCCC           |
            |                  +-------->+   mon.node1    |
            |                  |         |     osd.2      |

--- a/doc/start/quick-rbd.rst
+++ b/doc/start/quick-rbd.rst
@@ -13,9 +13,9 @@ Device`.
 
 .. ditaa:: 
            /------------------\         /----------------\
-           |    Admin Node    |         |   ceph–client  |
+           |    Admin Node    |         |   ceph-client  |
            |                  +-------->+ cCCC           |
-           |    ceph–deploy   |         |      ceph      |
+           |    ceph-deploy   |         |      ceph      |
            \------------------/         \----------------/
 
 


### PR DESCRIPTION
These errors cause some problems on web page of ceph documentation, such as http://docs.ceph.com/docs/master/start/quick-ceph-deploy/#expanding-your-cluster 