### PR TITLE
osdc/Objecter: upper bound watch_check result

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -706,7 +706,9 @@ int Objecter::linger_check(LingerOp *info)
 		 << " age " << age << dendl;
   if (info->last_error)
     return info->last_error;
-  return std::chrono::duration_cast<std::chrono::milliseconds>(age).count();
+  // return a safe upper bound (we are truncating to ms)
+  return
+    1 + std::chrono::duration_cast<std::chrono::milliseconds>(age).count();
 }
 
 void Objecter::linger_cancel(LingerOp *info)


### PR DESCRIPTION
This way we always return a safe upper bound on the amount of time
since we did a check.  Among other things, this prevents us from
returning a value of 0, which is confusing.

Fixes: http://tracker.ceph.com/issues/15760
Signed-off-by: Sage Weil <sage@redhat.com>