### PR TITLE
jewel: python: clone operation will fail if config overridden with "rbd default format = 1"

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -138,6 +138,8 @@ CEPH_RBD_API int rbd_image_options_get_string(rbd_image_options_t opts,
 					      size_t maxlen);
 CEPH_RBD_API int rbd_image_options_get_uint64(rbd_image_options_t opts,
 					      int optname, uint64_t* optval);
+CEPH_RBD_API int rbd_image_options_is_set(rbd_image_options_t opts,
+                                          int optname, bool* is_set);
 CEPH_RBD_API int rbd_image_options_unset(rbd_image_options_t opts, int optname);
 CEPH_RBD_API void rbd_image_options_clear(rbd_image_options_t opts);
 CEPH_RBD_API int rbd_image_options_is_empty(rbd_image_options_t opts);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -149,6 +149,7 @@ public:
   int set(int optname, uint64_t optval);
   int get(int optname, std::string* optval) const;
   int get(int optname, uint64_t* optval) const;
+  int is_set(int optname, bool* is_set);
   int unset(int optname);
   void clear();
   bool empty() const;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1233,6 +1233,8 @@ remove_mirroring_image:
 	     ImageOptions& opts)
   {
     CephContext *cct = (CephContext *)io_ctx.cct();
+    ldout(cct, 10) << __func__ << " name=" << imgname << ", "
+                   << "size=" << size << ", opts=" << opts << dendl;
 
     uint64_t format = cct->_conf->rbd_default_format;
     opts.get(RBD_IMAGE_OPTION_FORMAT, &format);
@@ -1343,7 +1345,6 @@ remove_mirroring_image:
     uint64_t order = *c_order;
 
     ImageOptions opts;
-    opts.set(RBD_IMAGE_OPTION_FORMAT, static_cast<uint64_t>(2));
     opts.set(RBD_IMAGE_OPTION_FEATURES, features);
     opts.set(RBD_IMAGE_OPTION_ORDER, order);
     opts.set(RBD_IMAGE_OPTION_STRIPE_UNIT, stripe_unit);
@@ -1360,10 +1361,16 @@ remove_mirroring_image:
   {
     CephContext *cct = (CephContext *)p_ioctx.cct();
     ldout(cct, 20) << "clone " << &p_ioctx << " name " << p_name << " snap "
-		   << p_snap_name << "to child " << &c_ioctx << " name "
+		   << p_snap_name << " to child " << &c_ioctx << " name "
 		   << c_name << " opts = " << c_opts << dendl;
 
-    uint64_t format = cct->_conf->rbd_default_format;
+    bool default_format_set;
+    c_opts.is_set(RBD_IMAGE_OPTION_FORMAT, &default_format_set);
+    if (!default_format_set) {
+      c_opts.set(RBD_IMAGE_OPTION_FORMAT, static_cast<uint64_t>(2));
+    }
+
+    uint64_t format = 0;
     c_opts.get(RBD_IMAGE_OPTION_FORMAT, &format);
     if (format < 2) {
       lderr(cct) << "format 2 or later required for clone" << dendl;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -749,6 +749,19 @@ remove_mirroring_image:
     return 0;
   }
 
+  int image_options_is_set(rbd_image_options_t opts, int optname,
+                           bool* is_set)
+  {
+    if (IMAGE_OPTIONS_TYPE_MAPPING.find(optname) ==
+          IMAGE_OPTIONS_TYPE_MAPPING.end()) {
+      return -EINVAL;
+    }
+
+    image_options_ref* opts_ = static_cast<image_options_ref*>(opts);
+    *is_set = ((*opts_)->find(optname) != (*opts_)->end());
+    return 0;
+  }
+
   int image_options_unset(rbd_image_options_t opts, int optname)
   {
     image_options_ref* opts_ = static_cast<image_options_ref*>(opts);

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -81,6 +81,8 @@ namespace librbd {
 			std::string* optval);
   int image_options_get(rbd_image_options_t opts, int optname,
 			uint64_t* optval);
+  int image_options_is_set(rbd_image_options_t opts, int optname,
+                           bool* is_set);
   int image_options_unset(rbd_image_options_t opts, int optname);
   void image_options_clear(rbd_image_options_t opts);
   bool image_options_is_empty(rbd_image_options_t opts);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -487,6 +487,11 @@ namespace librbd {
     return librbd::image_options_get(opts, optname, optval);
   }
 
+  int ImageOptions::is_set(int optname, bool* is_set)
+  {
+    return librbd::image_options_is_set(opts, optname, is_set);
+  }
+
   int ImageOptions::unset(int optname)
   {
     return librbd::image_options_unset(opts, optname);
@@ -1316,6 +1321,12 @@ extern "C" int rbd_image_options_get_uint64(rbd_image_options_t opts, int optnam
 				 uint64_t* optval)
 {
   return librbd::image_options_get(opts, optname, optval);
+}
+
+extern "C" int rbd_image_options_is_set(rbd_image_options_t opts, int optname,
+                                        bool* is_set)
+{
+  return librbd::image_options_is_set(opts, optname, is_set);
 }
 
 extern "C" int rbd_image_options_unset(rbd_image_options_t opts, int optname)

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -3935,6 +3935,13 @@ TEST_F(TestLibRBD, TestImageOptions)
   uint64_t stripe_count = 16;
   rbd_image_options_t opts;
   rbd_image_options_create(&opts);
+
+  bool is_set;
+  ASSERT_EQ(-EINVAL, rbd_image_options_is_set(opts, 12345, &is_set));
+  ASSERT_EQ(0, rbd_image_options_is_set(opts, RBD_IMAGE_OPTION_FORMAT,
+                                        &is_set));
+  ASSERT_FALSE(is_set);
+
   ASSERT_EQ(0, rbd_image_options_set_uint64(opts, RBD_IMAGE_OPTION_FORMAT,
 	  2));
   ASSERT_EQ(0, rbd_image_options_set_uint64(opts, RBD_IMAGE_OPTION_FEATURES,
@@ -3945,6 +3952,10 @@ TEST_F(TestLibRBD, TestImageOptions)
 	  stripe_unit));
   ASSERT_EQ(0, rbd_image_options_set_uint64(opts, RBD_IMAGE_OPTION_STRIPE_COUNT,
 	  stripe_count));
+
+  ASSERT_EQ(0, rbd_image_options_is_set(opts, RBD_IMAGE_OPTION_FORMAT,
+                                        &is_set));
+  ASSERT_TRUE(is_set);
 
   std::string parent_name = get_temp_image_name();
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/15697