### PR TITLE
rados: remove cppool command

### DIFF
--- a/qa/workunits/mon/rbd_snaps_ops.sh
+++ b/qa/workunits/mon/rbd_snaps_ops.sh
@@ -36,18 +36,4 @@ expect 'ceph osd pool mksnap test snapshot' 22
 
 expect 'ceph osd pool delete test test --yes-i-really-really-mean-it' 0
 
-# reproduce 7210 and expect it to be fixed
-# basically create such a scenario where we end up deleting what used to
-# be an unmanaged snapshot from a not-unmanaged pool
-
-expect 'rados mkpool test-foo' 0
-expect 'rbd --pool test-foo create --size 1024 image' 0
-expect 'rbd --pool test-foo snap create image@snapshot' 0
-expect 'rados mkpool test-bar' 0
-expect 'rados cppool test-foo test-bar' 0
-expect 'rbd --pool test-bar snap rm image@snapshot' 95
-expect 'ceph osd pool delete test-foo test-foo --yes-i-really-really-mean-it' 0
-expect 'ceph osd pool delete test-bar test-bar --yes-i-really-really-mean-it' 0
-
-
 echo OK

--- a/qa/workunits/rados/test_rados_tool.sh
+++ b/qa/workunits/rados/test_rados_tool.sh
@@ -171,26 +171,6 @@ for i in `seq 1 5`; do
   run_expect_succ --tee "$fname.omap.vals" "$RADOS_TOOL" -p "$POOL" listomapvals $objname
 done
 
-run_expect_succ "$RADOS_TOOL" cppool "$POOL" "$POOL_CP_TARGET"
-
-mkdir -p "$TDIR/dir_cp_dst"
-for i in `seq 1 5`; do
-  fname="$TDIR/dir_cp_dst/f.$i"
-  objname="f.$i"
-  run_expect_succ "$RADOS_TOOL" -p "$POOL_CP_TARGET" get $objname "$fname"
-
-# a few random attrs
-  for j in `seq 1 4`; do
-    run_expect_succ --tee "$fname.attr.$j" "$RADOS_TOOL" -p "$POOL_CP_TARGET" getxattr $objname attr.$j
-  done
-
-  run_expect_succ --tee "$fname.omap.header" "$RADOS_TOOL" -p "$POOL_CP_TARGET" getomapheader $objname
-  run_expect_succ --tee "$fname.omap.vals" "$RADOS_TOOL" -p "$POOL_CP_TARGET" listomapvals $objname
-done
-
-diff -q -r "$TDIR/dir_cp_src" "$TDIR/dir_cp_dst" \
-    || die "copy pool validation failed!"
-
 for opt in \
     block-size \
     concurrent-ios \


### PR DESCRIPTION
The cppool command is flawed in that it does not preserve
snapshots in the copy.  The fact that it is present makes it very
easy to a user to misused and break rbd images.  If they do want
to migrate images, they should use rbd export | import.

Signed-off-by: Sage Weil <sage@redhat.com>