### PR TITLE
OSDMonitor: avoid underflow in reweight-by-utilization if max_change=1

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -615,7 +615,8 @@ int OSDMonitor::reweight_by_utilization(int oload,
       // to represent e.g. differing storage capacities
       unsigned weight = osdmap.get_weight(p->first);
       unsigned new_weight = (unsigned)((average_util / util) * (float)weight);
-      new_weight = MAX(new_weight, weight - max_change);
+      if (weight > max_change)
+	new_weight = MAX(new_weight, weight - max_change);
       newinc.new_weight[p->first] = new_weight;
       if (!dry_run) {
 	pending_inc.new_weight[p->first] = new_weight;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/15655
Signed-off-by: Samuel Just <sjust@redhat.com>
(cherry picked from commit c121bc51a5a877a49094cfbd3bd16af1f3ae5090)