### PR TITLE
osd/OSD.h: remove unneeded line

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1029,7 +1029,6 @@ public:
   void add_pgid(spg_t pgid, PG *pg) {
     Mutex::Locker l(pgid_lock);
     if (!pgid_tracker.count(pgid)) {
-      pgid_tracker[pgid] = 0;
       live_pgs[pgid] = pg;
     }
     pgid_tracker[pgid]++;


### PR DESCRIPTION
We don't need to create a key with value 0 here.
It is created in statement:
pgid_tracker[pgid]++
if it doesnt exist.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>