### PR TITLE
osd/OSD.h: remove unneeded include file

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -47,7 +47,6 @@
 using namespace std;
 
 #include "include/unordered_map.h"
-#include "include/unordered_set.h"
 
 #include "Watch.h"
 #include "common/shared_cache.hpp"


### PR DESCRIPTION
Signed-off-by: Michal Jarzabek <stiopa@gmail.com>