### PR TITLE
common: obj_bencher.cc add missing ":"

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -813,7 +813,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
        << "Read size:            " << data.op_size << std::endl
        << "Object size:          " << data.object_size << std::endl
        << "Bandwidth (MB/sec):   " << setprecision(6) << bandwidth << std::endl
-       << "Average IOPS          " << (int)(data.finished/runtime) << std::endl
+       << "Average IOPS:         " << (int)(data.finished/runtime) << std::endl
        << "Stddev IOPS:          " << vec_stddev(data.history.iops) << std::endl
        << "Max IOPS:             " << data.idata.max_iops << std::endl
        << "Min IOPS:             " << data.idata.min_iops << std::endl


### PR DESCRIPTION
"Average IOPS" field in obj_bencher.cc is the only field missing a ":".
Make it consistent with other output fields

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>