### PR TITLE
osd/OSD.h: move shared_ptr instead of copying it

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -505,7 +505,7 @@ public:
   Cond pre_publish_cond;
   void pre_publish_map(OSDMapRef map) {
     Mutex::Locker l(pre_publish_lock);
-    next_osdmap = map;
+    next_osdmap = std::move(map);
   }
 
   void activate_map();


### PR DESCRIPTION
By copying map to next_osdmap we are increasing the shared_ptr's
reference count, which is then decreased again when map variable goes
out of scope. This can be avoided by using std move.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>