### PR TITLE
cls_journal: remove duplicated key generation

### DIFF
--- a/src/cls/journal/cls_journal.cc
+++ b/src/cls/journal/cls_journal.cc
@@ -566,7 +566,6 @@ int journal_client_register(cls_method_context_t hctx, bufferlist *in,
   }
 
   cls::journal::Client client(id, data);
-  key = key_from_client_id(id);
   r = write_key(hctx, key, client);
   if (r < 0) {
     return r;


### PR DESCRIPTION
`key` has been generated previously, i.e., on line https://github.com/ceph/ceph/compare/master...runsisi:wip-fix-dup-keygen#diff-edb59546752ac6be072e7131f240c8b3L558, so no need to generate it again

Signed-off-by: runsisi <runsisi@zte.com.cn>