### PR TITLE
 rgw: log name instead of id for SystemMetaObj on failure

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3450,7 +3450,7 @@ int RGWRados::init_zg_from_period(bool *initialized)
     return 0;
   }
   if (ret < 0) {
-    ldout(cct, 0) << "failed reading zonegroup info: " << " " << cpp_strerror(-ret) << dendl;
+    ldout(cct, 0) << "failed reading zonegroup info: " << cpp_strerror(-ret) << dendl;
     return ret;
   }
   ldout(cct, 20) << "period zonegroup name " << zonegroup.get_name() << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -383,8 +383,8 @@ int RGWSystemMetaObj::init(CephContext *_cct, RGWRados *_store, bool setup_obj, 
     } else if (!old_format) {
       r = read_id(name, id);
       if (r < 0) {
-	ldout(cct, 0) << "error in read_id for id " << id << " : " << cpp_strerror(-r) << dendl;
-	return r;
+        ldout(cct, 0) << "error in read_id for object name: " << name << " : " << cpp_strerror(-r) << dendl;
+        return r;
       }
     }
   }


### PR DESCRIPTION
Currently if we fail to read a SystemMetaObj we try to log the
MetaObject id, however this will not be set as read_id has
failed, so we end up logging an empty id, changing this to log
the object name instead

Also one more smaller fix to drop an unneeded space when 
we're printing the zg init log message
Fixes: http://tracker.ceph.com/issues/15776
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>