### PR TITLE
hammer: osd: acting_primary not updated on split

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2214,6 +2214,12 @@ void PG::split_into(pg_t child_pgid, PG *child, unsigned split_bits)
   if (get_primary() != child->get_primary())
     child->info.history.same_primary_since = get_osdmap()->get_epoch();
 
+  child->info.stats.up = up;
+  child->info.stats.up_primary = up_primary;
+  child->info.stats.acting = acting;
+  child->info.stats.acting_primary = primary;
+  child->info.stats.mapping_epoch = get_osdmap()->get_epoch();
+
   // History
   child->past_intervals = past_intervals;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/15730