### PR TITLE
rbd-mirror: don't unregister asok commands if image replayer start failed

### DIFF
--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -562,9 +562,6 @@ void ImageReplayer<I>::on_start_fail_finish(int r)
   m_local_ioctx.close();
   m_remote_ioctx.close();
 
-  delete m_asok_hook;
-  m_asok_hook = nullptr;
-
   if (on_start_finish != nullptr) {
     dout(20) << "on start finish complete, r=" << r << dendl;
     on_start_finish->complete(r);


### PR DESCRIPTION

Signed-off-by: Mykola Golub <mgolub@mirantis.com>