### PR TITLE
log: Log.cc: Assign LOG_INFO priority to syslog calls

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -331,7 +331,7 @@ void Log::_flush(EntryQueue *t, EntryQueue *requeue, bool crash)
       }
 
       if (do_syslog) {
-        syslog(LOG_USER|LOG_DEBUG, "%s", buf);
+        syslog(LOG_USER|LOG_INFO, "%s", buf);
       }
 
       if (do_stderr) {
@@ -369,7 +369,7 @@ void Log::_log_message(const char *s, bool crash)
       cerr << "problem writing to " << m_log_file << ": " << cpp_strerror(r) << std::endl;
   }
   if ((crash ? m_syslog_crash : m_syslog_log) >= 0) {
-    syslog(LOG_USER|LOG_DEBUG, "%s", s);
+    syslog(LOG_USER|LOG_INFO, "%s", s);
   }
 
   if ((crash ? m_stderr_crash : m_stderr_log) >= 0) {


### PR DESCRIPTION
LOG_DEBUG prio messages are not logged by a default syslog
configuration so log at LOG_INFO instead.

http://tracker.ceph.com/issues/15808

Fixes: #15808
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>