### PR TITLE
make-debs.sh: avoid creating recursive conf dir

### DIFF
--- a/make-debs.sh
+++ b/make-debs.sh
@@ -93,7 +93,9 @@ Suite: stable
 Components: main
 Architectures: i386 amd64 source
 EOF
-ln -s $codename/conf conf
+if [ ! -e conf ]; then
+    ln -s $codename/conf conf
+fi
 reprepro --basedir $(pwd) include $codename WORKDIR/*.changes
 #
 # teuthology needs the version in the version file


### PR DESCRIPTION
Before this commit when running make-debs.sh second time ln will create
the conf symlink inside already exisiting conf dir that was created
on the first tune.

Signed-off-by: Roi Dayan <roid@mellanox.com>