### PR TITLE
librbd: fix get/list mirror image status API

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -124,6 +124,8 @@ typedef enum {
 } rbd_mirror_image_status_state_t;
 
 typedef struct {
+  char *name;
+  rbd_mirror_image_info_t info;
   rbd_mirror_image_status_state_t state;
   char *description;
   time_t last_update;
@@ -228,9 +230,12 @@ CEPH_RBD_API int rbd_mirror_peer_set_cluster(rados_ioctx_t io_ctx,
                                              const char *uuid,
                                              const char *cluster_name);
 CEPH_RBD_API int rbd_mirror_image_status_list(rados_ioctx_t io_ctx,
-    const char *start, size_t max, char **image_names,
-    rbd_mirror_image_info_t *images, rbd_mirror_image_status_t *image_statuses,
-    size_t *len);
+					      const char *start_id, size_t max,
+					      char **image_ids,
+					      rbd_mirror_image_status_t *images,
+					      size_t *len);
+CEPH_RBD_API void rbd_mirror_image_status_list_cleanup(char **image_ids,
+    rbd_mirror_image_status_t *images, size_t len);
 CEPH_RBD_API int rbd_mirror_image_status_summary(rados_ioctx_t io_ctx,
     rbd_mirror_image_status_state_t *states, int *counts, size_t *maxlen);
 
@@ -633,7 +638,8 @@ CEPH_RBD_API int rbd_mirror_image_get_info(rbd_image_t image,
                                            rbd_mirror_image_info_t *mirror_image_info,
                                            size_t info_size);
 CEPH_RBD_API int rbd_mirror_image_get_status(rbd_image_t image,
-    rbd_mirror_image_status_t *mirror_image_status, size_t info_size);
+                                             rbd_mirror_image_status_t *mirror_image_status,
+                                             size_t status_size);
 
 #ifdef __cplusplus
 }

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -63,6 +63,8 @@ namespace librbd {
   typedef rbd_mirror_image_status_state_t mirror_image_status_state_t;
 
   typedef struct {
+    std::string name;
+    mirror_image_info_t info;
     mirror_image_status_state_t state;
     std::string description;
     time_t last_update;
@@ -141,9 +143,8 @@ public:
                              const std::string &client_name);
   int mirror_peer_set_cluster(IoCtx& io_ctx, const std::string &uuid,
                               const std::string &cluster_name);
-  int mirror_image_status_list(IoCtx& io_ctx, const std::string &start,
-      size_t max, std::map<std::string, mirror_image_info_t> *images,
-      std::map<std::string, mirror_image_status_t> *statuses);
+  int mirror_image_status_list(IoCtx& io_ctx, const std::string &start_id,
+      size_t max, std::map<std::string, mirror_image_status_t> *images);
   int mirror_image_status_summary(IoCtx& io_ctx,
       std::map<mirror_image_status_state_t, int> *states);
 

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -191,9 +191,8 @@ namespace librbd {
                              const std::string &client_name);
   int mirror_peer_set_cluster(IoCtx& io_ctx, const std::string &uuid,
                               const std::string &cluster_name);
-  int mirror_image_status_list(IoCtx& io_ctx, const std::string &start,
-      size_t max, std::map<std::string, mirror_image_info_t> *images,
-      std::map<std::string, mirror_image_status_t> *statuses);
+  int mirror_image_status_list(IoCtx& io_ctx, const std::string &start_id,
+      size_t max, std::map<std::string, mirror_image_status_t> *images);
   int mirror_image_status_summary(IoCtx& io_ctx,
       std::map<mirror_image_status_state_t, int> *states);
 

--- a/src/tools/rbd/action/MirrorImage.cc
+++ b/src/tools/rbd/action/MirrorImage.cc
@@ -220,20 +220,6 @@ int execute_status(const po::variables_map &vm) {
     return r;
   }
 
-  librbd::mirror_image_info_t mirror_image;
-  r = image.mirror_image_get_info(&mirror_image, sizeof(mirror_image));
-  if (r < 0) {
-    std::cerr << "rbd: failed to get global image id for image " << image_name
-	      << ": " << cpp_strerror(r) << std::endl;
-    return r;
-  }
-
-  if (mirror_image.global_id.empty()) {
-    std::cerr << "rbd: failed to get global image id for image " << image_name
-	      << std::endl;
-    return -EINVAL;
-  }
-
   librbd::mirror_image_status_t status;
   r = image.mirror_image_get_status(&status, sizeof(status));
   if (r < 0) {
@@ -248,7 +234,7 @@ int execute_status(const po::variables_map &vm) {
   if (formatter != nullptr) {
     formatter->open_object_section("image");
     formatter->dump_string("name", image_name);
-    formatter->dump_string("global_id", mirror_image.global_id);
+    formatter->dump_string("global_id", status.info.global_id);
     formatter->dump_string("state", state);
     formatter->dump_string("description", status.description);
     formatter->dump_string("last_update", last_update);
@@ -256,7 +242,7 @@ int execute_status(const po::variables_map &vm) {
     formatter->flush(std::cout);
   } else {
     std::cout << image_name << ":\n"
-	      << "  global_id:   " << mirror_image.global_id << "\n"
+	      << "  global_id:   " << status.info.global_id << "\n"
 	      << "  state:       " << state << "\n"
 	      << "  description: " << status.description << "\n"
 	      << "  last_update: " << last_update << std::endl;

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -466,19 +466,18 @@ int execute_status(const po::variables_map &vm) {
     std::string last_read = "";
     int max_read = 1024;
     do {
-      map<std::string, librbd::mirror_image_info_t> mirror_images;
-      map<std::string, librbd::mirror_image_status_t> statuses;
+      map<std::string, librbd::mirror_image_status_t> mirror_images;
       r = rbd.mirror_image_status_list(io_ctx, last_read, max_read,
-				       &mirror_images, &statuses);
+				       &mirror_images);
       if (r < 0) {
 	std::cerr << "rbd: failed to list mirrored image directory: "
 		  << cpp_strerror(r) << std::endl;
 	return r;
       }
       for (auto it = mirror_images.begin(); it != mirror_images.end(); ++it) {
-	const std::string &image_name = it->first;
-	std::string &global_image_id = it->second.global_id;
-	librbd::mirror_image_status_t &status = statuses[image_name];
+	librbd::mirror_image_status_t &status = it->second;
+	const std::string &image_name = status.name;
+	std::string &global_image_id = status.info.global_id;
 	std::string state = utils::mirror_image_status_state(status);
 	std::string last_update = utils::timestr(status.last_update);
 


### PR DESCRIPTION
- embed name and rbd_mirror_image_info_t into rbd_mirror_image_status_t;
- index image status list by image id to make 'start' work correctly;
- provide rbd_mirror_image_status_list_cleanup function.

Fixes: #15771
Signed-off-by: Mykola Golub <mgolub@mirantis.com>