### PR TITLE
cephfs: add link function in python

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -115,6 +115,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
                          const char *inbuf, size_t inbuflen, char **outbuf, size_t *outbuflen,
                          char **outs, size_t *outslen)
     int ceph_rename(ceph_mount_info *cmount, const char *from_, const char *to)
+    int ceph_link(ceph_mount_info *cmount, const char *existing, const char *newname)
     int ceph_unlink(ceph_mount_info *cmount, const char *path)
     int ceph_symlink(ceph_mount_info *cmount, const char *existing, const char *newname)
     int ceph_setxattr(ceph_mount_info *cmount, const char *path, const char *name,
@@ -798,6 +799,19 @@ cdef class LibCephFS(object):
             ret = ceph_symlink(self.cluster, _existing, _newname)
         if ret < 0:
             raise make_ex(ret, "error in symlink")
+    
+    def link(self, existing, newname):
+        self.require_state("mounted")
+        existing = cstr(existing, 'existing')
+        newname = cstr(newname, 'newname')
+        cdef:
+            char* _existing = existing
+            char* _newname = newname
+        
+        with nogil:
+            ret = ceph_link(self.cluster, _existing, _newname)
+        if ret < 0:
+            raise make_ex(ret, "error in link")    
 
     def unlink(self, path):
         self.require_state("mounted")

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -125,6 +125,23 @@ def test_open():
     cephfs.unlink('file-1')
 
 @with_setup(setup_test)
+def test_link():
+    fd = cephfs.open('file-1', 'w', 0755)
+    cephfs.write(fd, "1111", 0)
+    cephfs.close(fd)
+    cephfs.link('file-1', 'file-2')
+    fd = cephfs.open('file-2', 'r', 0755)
+    assert_equal(cephfs.read(fd, 0, 4), "1111")
+    cephfs.close(fd)
+    fd = cephfs.open('file-2', 'r+', 0755)
+    cephfs.write(fd, "2222", 4)
+    cephfs.close(fd)
+    fd = cephfs.open('file-1', 'r', 0755)
+    assert_equal(cephfs.read(fd, 0, 8), "11112222")
+    cephfs.close(fd)
+    cephfs.unlink('file-2')
+
+@with_setup(setup_test)
 def test_symlink():
     fd = cephfs.open('file-1', 'w', 0755)
     cephfs.write(fd, "1111", 0)


### PR DESCRIPTION
During the practical using
in addition to support symlink, but also need to support link

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>