### PR TITLE
rgw: add support for account and container quotas of Swift API

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -811,8 +811,10 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
     RGWStorageStats& s = iter->second;
     const char *cat_name = rgw_obj_category_name(iter->first);
     formatter->open_object_section(cat_name);
-    formatter->dump_int("size_kb", s.num_kb);
-    formatter->dump_int("size_kb_actual", s.num_kb_rounded);
+    formatter->dump_int("size", s.size);
+    formatter->dump_int("size_actual", s.size_rounded);
+    formatter->dump_int("size_kb", rgw_rounded_kb(s.size));
+    formatter->dump_int("size_kb_actual", rgw_rounded_kb(s.size_rounded));
     formatter->dump_int("num_objects", s.num_objects);
     formatter->close_section();
     formatter->flush(cout);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1033,9 +1033,9 @@ void set_quota_info(RGWQuotaInfo& quota, int opt_cmd, int64_t max_size, int64_t 
       }
       if (have_max_size) {
         if (max_size < 0) {
-          quota.max_size_kb = -1;
+          quota.max_size = -1;
         } else {
-          quota.max_size_kb = rgw_rounded_kb(max_size);
+          quota.max_size = rgw_rounded_kb(max_size) * 1024;
         }
       }
       break;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -736,8 +736,10 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
     RGWStorageStats& s = iter->second;
     const char *cat_name = rgw_obj_category_name(iter->first);
     formatter->open_object_section(cat_name);
-    formatter->dump_int("size_kb", s.num_kb);
-    formatter->dump_int("size_kb_actual", s.num_kb_rounded);
+    formatter->dump_int("size", s.size);
+    formatter->dump_int("size_actual", s.size_rounded);
+    formatter->dump_int("size_kb", rgw_rounded_kb(s.size));
+    formatter->dump_int("size_kb_actual", rgw_rounded_kb(s.size_rounded));
     formatter->dump_int("num_objects", s.num_objects);
     formatter->close_section();
   }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -88,6 +88,10 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_TEMPURL_KEY1   RGW_ATTR_META_PREFIX "temp-url-key"
 #define RGW_ATTR_TEMPURL_KEY2   RGW_ATTR_META_PREFIX "temp-url-key-2"
 
+/* Container quota of the Swift API. */
+#define RGW_ATTR_CQUOTA_NOBJS   RGW_ATTR_META_PREFIX "quota-count"
+#define RGW_ATTR_CQUOTA_MSIZE   RGW_ATTR_META_PREFIX "quota-bytes"
+
 #define RGW_ATTR_OLH_PREFIX     RGW_ATTR_PREFIX "olh."
 
 #define RGW_ATTR_OLH_INFO       RGW_ATTR_OLH_PREFIX "info"

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -88,9 +88,9 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_TEMPURL_KEY1   RGW_ATTR_META_PREFIX "temp-url-key"
 #define RGW_ATTR_TEMPURL_KEY2   RGW_ATTR_META_PREFIX "temp-url-key-2"
 
-/* Container quota of the Swift API. */
-#define RGW_ATTR_CQUOTA_NOBJS   RGW_ATTR_META_PREFIX "quota-count"
-#define RGW_ATTR_CQUOTA_MSIZE   RGW_ATTR_META_PREFIX "quota-bytes"
+/* Account/container quota of the Swift API. */
+#define RGW_ATTR_QUOTA_NOBJS    RGW_ATTR_META_PREFIX "quota-count"
+#define RGW_ATTR_QUOTA_MSIZE    RGW_ATTR_META_PREFIX "quota-bytes"
 
 #define RGW_ATTR_OLH_PREFIX     RGW_ATTR_PREFIX "olh."
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1061,11 +1061,15 @@ WRITE_CLASS_ENCODER(RGWBucketEntryPoint)
 struct RGWStorageStats
 {
   RGWObjCategory category;
-  uint64_t num_kb;
-  uint64_t num_kb_rounded;
+  uint64_t size;
+  uint64_t size_rounded;
   uint64_t num_objects;
 
-  RGWStorageStats() : category(RGW_OBJ_CATEGORY_NONE), num_kb(0), num_kb_rounded(0), num_objects(0) {}
+  RGWStorageStats()
+    : category(RGW_OBJ_CATEGORY_NONE),
+      size(0),
+      size_rounded(0),
+      num_objects(0) {}
 
   void dump(Formatter *f) const;
 };
@@ -1820,6 +1824,11 @@ static inline const char *rgw_obj_category_name(RGWObjCategory category)
 static inline uint64_t rgw_rounded_kb(uint64_t bytes)
 {
   return (bytes + 1023) / 1024;
+}
+
+static inline uint64_t rgw_rounded_objsize(uint64_t bytes)
+{
+  return ((bytes + 4095) & ~4095);
 }
 
 static inline uint64_t rgw_rounded_objsize_kb(uint64_t bytes)

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -76,7 +76,8 @@ const static struct rgw_http_errors RGW_HTTP_SWIFT_ERRORS[] = {
     { ERR_USER_SUSPENDED, 401, "UserSuspended" },
     { ERR_INVALID_UTF8, 412, "Invalid UTF8" },
     { ERR_BAD_URL, 412, "Bad URL" },
-    { ERR_NOT_SLO_MANIFEST, 400, "Not an SLO manifest" }
+    { ERR_NOT_SLO_MANIFEST, 400, "Not an SLO manifest" },
+    { ERR_QUOTA_EXCEEDED, 413, "QuotaExceeded" }
 };
 
 struct rgw_http_status_code {

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -488,13 +488,20 @@ void RGWUserInfo::decode_json(JSONObj *obj)
 void RGWQuotaInfo::dump(Formatter *f) const
 {
   f->dump_bool("enabled", enabled);
-  f->dump_int("max_size_kb", max_size_kb);
+  f->dump_int("max_size", max_size);
+  f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
   f->dump_int("max_objects", max_objects);
 }
 
 void RGWQuotaInfo::decode_json(JSONObj *obj)
 {
-  JSONDecoder::decode_json("max_size_kb", max_size_kb, obj);
+  if (false == JSONDecoder::decode_json("max_size", max_size, obj)) {
+    /* We're parsing an older version of the struct. */
+    int64_t max_size_kb = 0;
+
+    JSONDecoder::decode_json("max_size_kb", max_size_kb, obj);
+    max_size = max_size_kb * 1024;
+  }
   JSONDecoder::decode_json("max_objects", max_objects, obj);
   JSONDecoder::decode_json("enabled", enabled, obj);
 }

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -488,6 +488,8 @@ void RGWUserInfo::decode_json(JSONObj *obj)
 void RGWQuotaInfo::dump(Formatter *f) const
 {
   f->dump_bool("enabled", enabled);
+  f->dump_bool("check_on_raw", check_on_raw);
+
   f->dump_int("max_size", max_size);
   f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
   f->dump_int("max_objects", max_objects);
@@ -503,6 +505,8 @@ void RGWQuotaInfo::decode_json(JSONObj *obj)
     max_size = max_size_kb * 1024;
   }
   JSONDecoder::decode_json("max_objects", max_objects, obj);
+
+  JSONDecoder::decode_json("check_on_raw", check_on_raw, obj);
   JSONDecoder::decode_json("enabled", enabled, obj);
 }
 

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -545,8 +545,10 @@ void RGWBucketEntryPoint::decode_json(JSONObj *obj) {
 
 void RGWStorageStats::dump(Formatter *f) const
 {
-  encode_json("num_kb", num_kb, f);
-  encode_json("num_kb_rounded", num_kb_rounded, f);
+  encode_json("size", size, f);
+  encode_json("size_rounded", size_rounded, f);
+  encode_json("num_kb", rgw_rounded_kb(size), f);
+  encode_json("num_kb_rounded", rgw_rounded_kb(size_rounded), f);
   encode_json("num_objects", num_objects, f);
 }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2797,34 +2797,6 @@ done:
   dispose_processor(processor);
 }
 
-int RGWPutMetadataAccount::handle_temp_url_update(
-  const map<int, string>& temp_url_keys) {
-  RGWUserAdminOpState user_op;
-  user_op.set_user_id(s->user->user_id);
-
-  map<int, string>::const_iterator iter;
-  for (iter = temp_url_keys.begin(); iter != temp_url_keys.end(); ++iter) {
-    user_op.set_temp_url_key(iter->second, iter->first);
-  }
-
-  RGWUser user;
-  op_ret = user.init(store, user_op);
-  if (op_ret < 0) {
-    ldout(store->ctx(), 0) << "ERROR: could not init user ret=" << op_ret
-			   << dendl;
-    return op_ret;
-  }
-
-  string err_msg;
-  op_ret = user.modify(user_op, &err_msg);
-  if (op_ret < 0) {
-    ldout(store->ctx(), 10) << "user.modify() returned " << op_ret << ": "
-			    << err_msg << dendl;
-    return op_ret;
-  }
-  return 0;
-}
-
 int RGWPutMetadataAccount::verify_permission()
 {
   if (!rgw_user_is_authenticated(*(s->user))) {
@@ -2887,36 +2859,31 @@ void RGWPutMetadataAccount::execute()
   prepare_add_del_attrs(orig_attrs, rmattr_names, attrs);
   populate_with_generic_attrs(s, attrs);
 
-  RGWUserInfo orig_uinfo;
-  op_ret = rgw_get_user_info_by_uid(store, s->user->user_id, orig_uinfo,
+  RGWUserInfo new_uinfo;
+  op_ret = rgw_get_user_info_by_uid(store, s->user->user_id, new_uinfo,
                                     &acct_op_tracker);
   if (op_ret < 0) {
     return;
   }
 
   /* Handle the TempURL-related stuff. */
-  map<int, string> temp_url_keys;
+  std::map<int, std::string> temp_url_keys;
   filter_out_temp_url(attrs, rmattr_names, temp_url_keys);
   if (!temp_url_keys.empty()) {
     if (s->perm_mask != RGW_PERM_FULL_CONTROL) {
       op_ret = -EPERM;
       return;
     }
-  }
 
-  /* XXX tenant needed? */
-  op_ret = rgw_store_user_info(store, *(s->user), &orig_uinfo,
-                               &acct_op_tracker, real_time(), false, &attrs);
-  if (op_ret < 0) {
-    return;
-  }
-
-  if (!temp_url_keys.empty()) {
-    op_ret = handle_temp_url_update(temp_url_keys);
-    if (op_ret < 0) {
-      return;
+    for (auto& pair : temp_url_keys) {
+      new_uinfo.temp_url_keys[pair.first] = std::move(pair.second);
     }
   }
+
+  /* We are passing here the current (old) user info to allow the function
+   * optimize-out some operations. */
+  op_ret = rgw_store_user_info(store, new_uinfo, s->user,
+                               &acct_op_tracker, real_time(), false, &attrs);
 }
 
 int RGWPutMetadataBucket::verify_permission()

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1912,12 +1912,12 @@ static void populate_with_generic_attrs(const req_state * const s,
 }
 
 
-static int filter_out_bucket_quota(std::map<std::string, bufferlist>& add_attrs,
-                                   const std::set<std::string>& rmattr_names,
-                                   RGWQuotaInfo& quota)
+static int filter_out_quota_info(std::map<std::string, bufferlist>& add_attrs,
+                                 const std::set<std::string>& rmattr_names,
+                                 RGWQuotaInfo& quota)
 {
   /* Put new limit on max objects. */
-  auto iter = add_attrs.find(RGW_ATTR_CQUOTA_NOBJS);
+  auto iter = add_attrs.find(RGW_ATTR_QUOTA_NOBJS);
   std::string err;
   if (std::end(add_attrs) != iter) {
     quota.max_objects =
@@ -1929,7 +1929,7 @@ static int filter_out_bucket_quota(std::map<std::string, bufferlist>& add_attrs,
   }
 
   /* Put new limit on bucket (container) size. */
-  iter = add_attrs.find(RGW_ATTR_CQUOTA_MSIZE);
+  iter = add_attrs.find(RGW_ATTR_QUOTA_MSIZE);
   if (iter != add_attrs.end()) {
     quota.max_size =
       static_cast<int64_t>(strict_strtoll(iter->second.c_str(), 10, &err));
@@ -1941,12 +1941,12 @@ static int filter_out_bucket_quota(std::map<std::string, bufferlist>& add_attrs,
 
   for (const auto& name : rmattr_names) {
     /* Remove limit on max objects. */
-    if (name.compare(RGW_ATTR_CQUOTA_NOBJS) == 0) {
+    if (name.compare(RGW_ATTR_QUOTA_NOBJS) == 0) {
       quota.max_objects = -1;
     }
 
     /* Remove limit on max bucket size. */
-    if (name.compare(RGW_ATTR_CQUOTA_MSIZE) == 0) {
+    if (name.compare(RGW_ATTR_QUOTA_MSIZE) == 0) {
       quota.max_size = -1;
     }
   }
@@ -2069,7 +2069,7 @@ void RGWCreateBucket::execute()
     prepare_add_del_attrs(s->bucket_attrs, rmattr_names, attrs);
     populate_with_generic_attrs(s, attrs);
 
-    op_ret = filter_out_bucket_quota(attrs, rmattr_names, quota_info);
+    op_ret = filter_out_quota_info(attrs, rmattr_names, quota_info);
     if (op_ret < 0) {
       return;
     }
@@ -2150,7 +2150,7 @@ void RGWCreateBucket::execute()
       rgw_get_request_metadata(s->cct, s->info, attrs, false);
       prepare_add_del_attrs(s->bucket_attrs, rmattr_names, attrs);
       populate_with_generic_attrs(s, attrs);
-      op_ret = filter_out_bucket_quota(attrs, rmattr_names, s->bucket_info.quota);
+      op_ret = filter_out_quota_info(attrs, rmattr_names, s->bucket_info.quota);
       if (op_ret < 0) {
         return;
       }
@@ -2972,7 +2972,7 @@ void RGWPutMetadataBucket::execute()
    * implementation: anyone with write permissions is able to set the bucket
    * quota. This stays in contrast to account quotas that can be set only by
    * clients holding reseller admin privileges. */
-  op_ret = filter_out_bucket_quota(attrs, rmattr_names, s->bucket_info.quota);
+  op_ret = filter_out_quota_info(attrs, rmattr_names, s->bucket_info.quota);
   if (op_ret < 0) {
     return;
   }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1951,6 +1951,8 @@ static int filter_out_bucket_quota(std::map<std::string, bufferlist>& add_attrs,
     }
   }
 
+  /* Swift requries checking on raw usage instead of the 4 KiB rounded one. */
+  quota.check_on_raw = true;
   quota.enabled = quota.max_size > 0 || quota.max_objects > 0;
   return 0;
 }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2797,16 +2797,6 @@ done:
   dispose_processor(processor);
 }
 
-int RGWPutMetadataAccount::verify_permission()
-{
-  if (!rgw_user_is_authenticated(*(s->user))) {
-    return -EACCES;
-  }
-  // if ((s->perm_mask & RGW_PERM_WRITE) == 0) {
-  //   return -EACCES;
-  // }
-  return 0;
-}
 
 void RGWPutMetadataAccount::filter_out_temp_url(map<string, bufferlist>& add_attrs,
                                                 const set<string>& rmattr_names,
@@ -2826,10 +2816,7 @@ void RGWPutMetadataAccount::filter_out_temp_url(map<string, bufferlist>& add_att
     add_attrs.erase(iter);
   }
 
-  set<string>::const_iterator riter;
-  for(riter = rmattr_names.begin(); riter != rmattr_names.end(); ++riter) {
-    const string& name = *riter;
-
+  for (const string& name : rmattr_names) {
     if (name.compare(RGW_ATTR_TEMPURL_KEY1) == 0) {
       temp_url_keys[0] = string();
     }
@@ -2839,26 +2826,60 @@ void RGWPutMetadataAccount::filter_out_temp_url(map<string, bufferlist>& add_att
   }
 }
 
-void RGWPutMetadataAccount::execute()
+int RGWPutMetadataAccount::init_processing()
 {
-  map<string, bufferlist> attrs, orig_attrs, rmattrs;
-  RGWObjVersionTracker acct_op_tracker;
+  /* First, go to the base class. At the time of writing the method was
+   * responsible only for initializing the quota. This isn't necessary
+   * here as we are touching metadata only. I'm putting this call only
+   * for the future. */
+  op_ret = RGWOp::init_processing();
+  if (op_ret < 0) {
+    return op_ret;
+  }
 
   op_ret = get_params();
   if (op_ret < 0) {
-    return;
+    return op_ret;
   }
 
   op_ret = rgw_get_user_attrs_by_uid(store, s->user->user_id, orig_attrs,
                                      &acct_op_tracker);
   if (op_ret < 0) {
-    return;
+    return op_ret;
   }
 
   rgw_get_request_metadata(s->cct, s->info, attrs, false);
   prepare_add_del_attrs(orig_attrs, rmattr_names, attrs);
   populate_with_generic_attrs(s, attrs);
 
+  /* Try extract the TempURL-related stuff now to allow verify_permission
+   * evaluate whether we need FULL_CONTROL or not. */
+  filter_out_temp_url(attrs, rmattr_names, temp_url_keys);
+
+  return 0;
+}
+
+int RGWPutMetadataAccount::verify_permission()
+{
+  if (!rgw_user_is_authenticated(*(s->user))) {
+    return -EACCES;
+  }
+
+  // if ((s->perm_mask & RGW_PERM_WRITE) == 0) {
+  //   return -EACCES;
+  // }
+
+  /* Altering TempURL keys requires FULL_CONTROL. */
+  if (!temp_url_keys.empty() && s->perm_mask != RGW_PERM_FULL_CONTROL) {
+    return -EPERM;
+  }
+
+  return 0;
+}
+
+void RGWPutMetadataAccount::execute()
+{
+  /* Params have been extracted earlier. See init_processing(). */
   RGWUserInfo new_uinfo;
   op_ret = rgw_get_user_info_by_uid(store, s->user->user_id, new_uinfo,
                                     &acct_op_tracker);
@@ -2867,14 +2888,7 @@ void RGWPutMetadataAccount::execute()
   }
 
   /* Handle the TempURL-related stuff. */
-  std::map<int, std::string> temp_url_keys;
-  filter_out_temp_url(attrs, rmattr_names, temp_url_keys);
   if (!temp_url_keys.empty()) {
-    if (s->perm_mask != RGW_PERM_FULL_CONTROL) {
-      op_ret = -EPERM;
-      return;
-    }
-
     for (auto& pair : temp_url_keys) {
       new_uinfo.temp_url_keys[pair.first] = std::move(pair.second);
     }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1912,6 +1912,50 @@ static void populate_with_generic_attrs(const req_state * const s,
 }
 
 
+static int filter_out_bucket_quota(std::map<std::string, bufferlist>& add_attrs,
+                                   const std::set<std::string>& rmattr_names,
+                                   RGWQuotaInfo& quota)
+{
+  /* Put new limit on max objects. */
+  auto iter = add_attrs.find(RGW_ATTR_CQUOTA_NOBJS);
+  std::string err;
+  if (std::end(add_attrs) != iter) {
+    quota.max_objects =
+      static_cast<int64_t>(strict_strtoll(iter->second.c_str(), 10, &err));
+    if (!err.empty()) {
+      return -EINVAL;
+    }
+    add_attrs.erase(iter);
+  }
+
+  /* Put new limit on bucket (container) size. */
+  iter = add_attrs.find(RGW_ATTR_CQUOTA_MSIZE);
+  if (iter != add_attrs.end()) {
+    quota.max_size =
+      static_cast<int64_t>(strict_strtoll(iter->second.c_str(), 10, &err));
+    if (!err.empty()) {
+      return -EINVAL;
+    }
+    add_attrs.erase(iter);
+  }
+
+  for (const auto& name : rmattr_names) {
+    /* Remove limit on max objects. */
+    if (name.compare(RGW_ATTR_CQUOTA_NOBJS) == 0) {
+      quota.max_objects = -1;
+    }
+
+    /* Remove limit on max bucket size. */
+    if (name.compare(RGW_ATTR_CQUOTA_MSIZE) == 0) {
+      quota.max_size = -1;
+    }
+  }
+
+  quota.enabled = quota.max_size > 0 || quota.max_objects > 0;
+  return 0;
+}
+
+
 void RGWCreateBucket::execute()
 {
   RGWAccessControlPolicy old_policy(s->cct);
@@ -2907,9 +2951,20 @@ void RGWPutMetadataBucket::execute()
   prepare_add_del_attrs(s->bucket_attrs, rmattr_names, attrs);
   populate_with_generic_attrs(s, attrs);
 
+  /* According  to the Swift's behaviour and its container_quota WSGI middleware
+   * implementation: anyone with write permissions is able to set the bucket
+   * quota. This stays in contrast to account quotas that can be set only by
+   * clients holding reseller admin privileges. */
+  op_ret = filter_out_bucket_quota(attrs, rmattr_names, s->bucket_info.quota);
+  if (op_ret < 0) {
+    return;
+  }
+
   s->bucket_info.swift_ver_location = swift_ver_location;
   s->bucket_info.swift_versioning = (!swift_ver_location.empty());
 
+  /* Setting attributes also stores the provided bucket info. Due to this
+   * fact, the new quota settings can be serialized with the same call. */
   op_ret = rgw_bucket_set_attrs(store, s->bucket_info, attrs,
 				&s->bucket_info.objv_tracker);
 }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2060,18 +2060,28 @@ void RGWCreateBucket::execute()
     emplace_attr(RGW_ATTR_CORS, std::move(corsbl));
   }
 
+  RGWQuotaInfo quota_info;
+  const RGWQuotaInfo * pquota_info = nullptr;
   if (need_metadata_upload()) {
     /* It's supposed that following functions WILL NOT change any special
      * attributes (like RGW_ATTR_ACL) if they are already present in attrs. */
     rgw_get_request_metadata(s->cct, s->info, attrs, false);
     prepare_add_del_attrs(s->bucket_attrs, rmattr_names, attrs);
     populate_with_generic_attrs(s, attrs);
+
+    op_ret = filter_out_bucket_quota(attrs, rmattr_names, quota_info);
+    if (op_ret < 0) {
+      return;
+    }
+
+    pquota_info = &quota_info;
   }
 
   s->bucket.tenant = s->bucket_tenant; /* ignored if bucket exists */
   s->bucket.name = s->bucket_name;
   op_ret = store->create_bucket(*(s->user), s->bucket, zonegroup_id,
-				placement_rule, swift_ver_location, attrs,
+				placement_rule, swift_ver_location,
+				pquota_info, attrs,
 				info, pobjv, &ep_objv, creation_time,
 				pmaster_bucket, true);
   /* continue if EEXIST and create_bucket will fail below.  this way we can
@@ -2140,7 +2150,12 @@ void RGWCreateBucket::execute()
       rgw_get_request_metadata(s->cct, s->info, attrs, false);
       prepare_add_del_attrs(s->bucket_attrs, rmattr_names, attrs);
       populate_with_generic_attrs(s, attrs);
+      op_ret = filter_out_bucket_quota(attrs, rmattr_names, s->bucket_info.quota);
+      if (op_ret < 0) {
+        return;
+      }
 
+      /* This will also set the quota on the bucket. */
       op_ret = rgw_bucket_set_attrs(store, s->bucket_info, attrs,
                                     &s->bucket_info.objv_tracker);
     } while (op_ret == -ECANCELED && tries++ < 20);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1914,8 +1914,11 @@ static void populate_with_generic_attrs(const req_state * const s,
 
 static int filter_out_quota_info(std::map<std::string, bufferlist>& add_attrs,
                                  const std::set<std::string>& rmattr_names,
-                                 RGWQuotaInfo& quota)
+                                 RGWQuotaInfo& quota,
+                                 bool * quota_extracted = nullptr)
 {
+  bool extracted = false;
+
   /* Put new limit on max objects. */
   auto iter = add_attrs.find(RGW_ATTR_QUOTA_NOBJS);
   std::string err;
@@ -1926,6 +1929,7 @@ static int filter_out_quota_info(std::map<std::string, bufferlist>& add_attrs,
       return -EINVAL;
     }
     add_attrs.erase(iter);
+    extracted = true;
   }
 
   /* Put new limit on bucket (container) size. */
@@ -1937,23 +1941,31 @@ static int filter_out_quota_info(std::map<std::string, bufferlist>& add_attrs,
       return -EINVAL;
     }
     add_attrs.erase(iter);
+    extracted = true;
   }
 
   for (const auto& name : rmattr_names) {
     /* Remove limit on max objects. */
     if (name.compare(RGW_ATTR_QUOTA_NOBJS) == 0) {
       quota.max_objects = -1;
+      extracted = true;
     }
 
     /* Remove limit on max bucket size. */
     if (name.compare(RGW_ATTR_QUOTA_MSIZE) == 0) {
       quota.max_size = -1;
+      extracted = true;
     }
   }
 
   /* Swift requries checking on raw usage instead of the 4 KiB rounded one. */
   quota.check_on_raw = true;
   quota.enabled = quota.max_size > 0 || quota.max_objects > 0;
+
+  if (quota_extracted) {
+    *quota_extracted = extracted;
+  }
+
   return 0;
 }
 
@@ -2856,6 +2868,13 @@ int RGWPutMetadataAccount::init_processing()
    * evaluate whether we need FULL_CONTROL or not. */
   filter_out_temp_url(attrs, rmattr_names, temp_url_keys);
 
+  /* The same with quota except a client needs to be reseller admin. */
+  op_ret = filter_out_quota_info(attrs, rmattr_names, new_quota,
+                                 &new_quota_extracted);
+  if (op_ret < 0) {
+    return op_ret;
+  }
+
   return 0;
 }
 
@@ -2871,6 +2890,13 @@ int RGWPutMetadataAccount::verify_permission()
 
   /* Altering TempURL keys requires FULL_CONTROL. */
   if (!temp_url_keys.empty() && s->perm_mask != RGW_PERM_FULL_CONTROL) {
+    return -EPERM;
+  }
+
+  /* We are failing this intensionally to allow system user/reseller admin
+   * override in rgw_process.cc. This is the way to specify a given RGWOp
+   * expect extra privileges.  */
+  if (new_quota_extracted) {
     return -EPERM;
   }
 
@@ -2892,6 +2918,11 @@ void RGWPutMetadataAccount::execute()
     for (auto& pair : temp_url_keys) {
       new_uinfo.temp_url_keys[pair.first] = std::move(pair.second);
     }
+  }
+
+  /* Handle the quota extracted at the verify_permission step. */
+  if (new_quota_extracted) {
+    new_uinfo.user_quota = std::move(new_quota);
   }
 
   /* We are passing here the current (old) user info to allow the function

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -748,13 +748,17 @@ protected:
   std::set<std::string> rmattr_names;
   std::map<std::string, bufferlist> attrs, orig_attrs;
   std::map<int, std::string> temp_url_keys;
+  RGWQuotaInfo new_quota;
+  bool new_quota_extracted;
 
   RGWObjVersionTracker acct_op_tracker;
 
   RGWAccessControlPolicy policy;
 
 public:
-  RGWPutMetadataAccount() {}
+  RGWPutMetadataAccount()
+    : new_quota_extracted(false) {
+  }
 
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *h) {
     RGWOp::init(store, s, h);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -745,7 +745,12 @@ public:
 
 class RGWPutMetadataAccount : public RGWOp {
 protected:
-  set<string> rmattr_names;
+  std::set<std::string> rmattr_names;
+  std::map<std::string, bufferlist> attrs, orig_attrs;
+  std::map<int, std::string> temp_url_keys;
+
+  RGWObjVersionTracker acct_op_tracker;
+
   RGWAccessControlPolicy policy;
 
 public:
@@ -755,6 +760,7 @@ public:
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
+  int init_processing();
   int verify_permission();
   void pre_exec() { }
   void execute();

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -764,7 +764,6 @@ public:
   virtual void filter_out_temp_url(map<string, bufferlist>& add_attrs,
                                    const set<string>& rmattr_names,
                                    map<int, string>& temp_url_keys);
-  virtual int handle_temp_url_update(const map<int, string>& temp_url_keys);
   virtual const string name() { return "put_account_metadata"; }
   virtual RGWOpType get_type() { return RGW_OP_PUT_METADATA_ACCOUNT; }
   virtual uint32_t op_mask() { return RGW_OP_TYPE_WRITE; }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -106,9 +106,10 @@ bool RGWQuotaCache<T>::can_use_cached_stats(RGWQuotaInfo& quota, RGWStorageStats
       quota.max_size_soft_threshold = quota.max_size_kb * store->ctx()->_conf->rgw_bucket_quota_soft_threshold;
     }
 
-    if (cached_stats.num_kb_rounded >= (uint64_t)quota.max_size_soft_threshold) {
+    const auto cached_stats_num_kb_rounded = rgw_rounded_kb(cached_stats.size_rounded);
+    if (cached_stats_num_kb_rounded >= (uint64_t)quota.max_size_soft_threshold) {
       ldout(store->ctx(), 20) << "quota: can't use cached stats, exceeded soft threshold (size): "
-        << cached_stats.num_kb_rounded << " >= " << quota.max_size_soft_threshold << dendl;
+        << cached_stats_num_kb_rounded << " >= " << quota.max_size_soft_threshold << dendl;
       return false;
     }
   }
@@ -211,18 +212,24 @@ int RGWQuotaCache<T>::get_stats(const rgw_user& user, rgw_bucket& bucket, RGWSto
 
 template<class T>
 class RGWQuotaStatsUpdate : public lru_map<T, RGWQuotaCacheStats>::UpdateContext {
-  int objs_delta;
-  uint64_t added_bytes;
-  uint64_t removed_bytes;
+  const int objs_delta;
+  const uint64_t added_bytes;
+  const uint64_t removed_bytes;
 public:
-  RGWQuotaStatsUpdate(int _objs_delta, uint64_t _added_bytes, uint64_t _removed_bytes) : 
-                    objs_delta(_objs_delta), added_bytes(_added_bytes), removed_bytes(_removed_bytes) {}
-  bool update(RGWQuotaCacheStats *entry) {
-    uint64_t rounded_kb_added = rgw_rounded_objsize_kb(added_bytes);
-    uint64_t rounded_kb_removed = rgw_rounded_objsize_kb(removed_bytes);
+  RGWQuotaStatsUpdate(const int objs_delta,
+                      const uint64_t added_bytes,
+                      const uint64_t removed_bytes)
+    : objs_delta(objs_delta),
+      added_bytes(added_bytes),
+      removed_bytes(removed_bytes) {
+  }
 
-    entry->stats.num_kb_rounded += (rounded_kb_added - rounded_kb_removed);
-    entry->stats.num_kb += (added_bytes - removed_bytes) / 1024;
+  bool update(RGWQuotaCacheStats * const entry) override {
+    const uint64_t rounded_added = rgw_rounded_objsize(added_bytes);
+    const uint64_t rounded_removed = rgw_rounded_objsize(removed_bytes);
+
+    entry->stats.size += added_bytes - removed_bytes;
+    entry->stats.size_rounded += rounded_added - rounded_removed;
     entry->stats.num_objects += objs_delta;
 
     return true;
@@ -269,7 +276,7 @@ int BucketAsyncRefreshHandler::init_fetch()
   return 0;
 }
 
-void BucketAsyncRefreshHandler::handle_response(int r)
+void BucketAsyncRefreshHandler::handle_response(const int r)
 {
   if (r < 0) {
     ldout(store->ctx(), 20) << "AsyncRefreshHandler::handle_response() r=" << r << dendl;
@@ -278,11 +285,11 @@ void BucketAsyncRefreshHandler::handle_response(int r)
 
   RGWStorageStats bs;
 
-  map<RGWObjCategory, RGWStorageStats>::iterator iter;
-  for (iter = stats->begin(); iter != stats->end(); ++iter) {
-    RGWStorageStats& s = iter->second;
-    bs.num_kb += s.num_kb;
-    bs.num_kb_rounded += s.num_kb_rounded;
+  for (const auto& pair : *stats) {
+    const RGWStorageStats& s = pair.second;
+
+    bs.size += s.size;
+    bs.size_rounded += s.size_rounded;
     bs.num_objects += s.num_objects;
   }
 
@@ -322,19 +329,21 @@ int RGWBucketStatsCache::fetch_stats_from_storage(const rgw_user& user, rgw_buck
   string master_ver;
 
   map<RGWObjCategory, RGWStorageStats> bucket_stats;
-  int r = store->get_bucket_stats(bucket, RGW_NO_SHARD, &bucket_ver, &master_ver, bucket_stats, NULL);
+  int r = store->get_bucket_stats(bucket, RGW_NO_SHARD, &bucket_ver,
+                                  &master_ver, bucket_stats, nullptr);
   if (r < 0) {
-    ldout(store->ctx(), 0) << "could not get bucket info for bucket=" << bucket.name << dendl;
+    ldout(store->ctx(), 0) << "could not get bucket info for bucket="
+                           << bucket.name << dendl;
     return r;
   }
 
   stats = RGWStorageStats();
 
-  map<RGWObjCategory, RGWStorageStats>::iterator iter;
-  for (iter = bucket_stats.begin(); iter != bucket_stats.end(); ++iter) {
-    RGWStorageStats& s = iter->second;
-    stats.num_kb += s.num_kb;
-    stats.num_kb_rounded += s.num_kb_rounded;
+  for (const auto& pair : bucket_stats) {
+    const RGWStorageStats& s = pair.second;
+
+    stats.size += s.size;
+    stats.size_rounded += s.size_rounded;
     stats.num_objects += s.num_objects;
   }
 
@@ -669,26 +678,44 @@ class RGWQuotaHandlerImpl : public RGWQuotaHandler {
   RGWQuotaInfo def_bucket_quota;
   RGWQuotaInfo def_user_quota;
 
-  int check_quota(const char *entity, RGWQuotaInfo& quota, RGWStorageStats& stats,
-                  uint64_t num_objs, uint64_t size_kb) {
-    if (!quota.enabled)
+  int check_quota(const char * const entity,
+                  const RGWQuotaInfo& quota,
+                  const RGWStorageStats& stats,
+                  const uint64_t num_objs,
+                  const uint64_t size) {
+    if (!quota.enabled) {
       return 0;
+    }
 
-    ldout(store->ctx(), 20) << entity << " quota: max_objects=" << quota.max_objects
+    ldout(store->ctx(), 20) << entity
+                            << " quota: max_objects=" << quota.max_objects
                             << " max_size_kb=" << quota.max_size_kb << dendl;
 
     if (quota.max_objects >= 0 &&
         stats.num_objects + num_objs > (uint64_t)quota.max_objects) {
-      ldout(store->ctx(), 10) << "quota exceeded: stats.num_objects=" << stats.num_objects
-                              << " " << entity << "_quota.max_objects=" << quota.max_objects << dendl;
+      ldout(store->ctx(), 10) << "quota exceeded: stats.num_objects="
+                              << stats.num_objects
+                              << " " << entity << "_quota.max_objects="
+                              << quota.max_objects << dendl;
 
       return -ERR_QUOTA_EXCEEDED;
     }
-    if (quota.max_size_kb >= 0 &&
-               stats.num_kb_rounded + size_kb > (uint64_t)quota.max_size_kb) {
-      ldout(store->ctx(), 10) << "quota exceeded: stats.num_kb_rounded=" << stats.num_kb_rounded << " size_kb=" << size_kb
-                              << " " << entity << "_quota.max_size_kb=" << quota.max_size_kb << dendl;
-      return -ERR_QUOTA_EXCEEDED;
+
+    /* Handling quota in KiBs due to backward compatibility. */
+    if (quota.max_size_kb >= 0) {
+      const uint64_t size_kb = rgw_rounded_objsize_kb(size);
+      /* XXX: just div 1024 should be enough. */
+      const uint64_t stats_num_kb_rounded = rgw_rounded_kb(stats.size_rounded);
+
+      if (stats_num_kb_rounded + size_kb > (uint64_t)quota.max_size_kb) {
+        ldout(store->ctx(), 10) << "quota exceeded: stats_num_kb_rounded="
+                                << stats_num_kb_rounded
+                                << " size_kb=" << size_kb << " " << entity
+                                << "_quota.max_size_kb="
+                                << quota.max_size_kb << dendl;
+
+        return -ERR_QUOTA_EXCEEDED;
+      }
     }
 
     return 0;
@@ -712,54 +739,66 @@ public:
       def_user_quota.enabled = true;
     }
   }
-  virtual int check_quota(const rgw_user& user, rgw_bucket& bucket,
-                          RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota,
-			  uint64_t num_objs, uint64_t size) {
+
+  virtual int check_quota(const rgw_user& user,
+                          rgw_bucket& bucket,
+                          RGWQuotaInfo& user_quota,
+                          RGWQuotaInfo& bucket_quota,
+                          uint64_t num_objs,
+                          uint64_t size) override {
 
     if (!bucket_quota.enabled && !user_quota.enabled && !def_bucket_quota.enabled && !def_user_quota.enabled)
       return 0;
 
-    uint64_t size_kb = rgw_rounded_objsize_kb(size);
-
     RGWStorageStats bucket_stats;
 
     /*
-     * we need to fetch bucket stats if the user quota is enabled, because the whole system relies
-     * on us periodically updating the user's bucket stats in the user's header, this happens in
-     * get_stats() if we actually fetch that info and not rely on cached data
+     * we need to fetch bucket stats if the user quota is enabled, because
+     * the whole system relies on us periodically updating the user's bucket
+     * stats in the user's header, this happens in get_stats() if we actually
+     * fetch that info and not rely on cached data
      */
 
-    int ret = bucket_stats_cache.get_stats(user, bucket, bucket_stats, bucket_quota);
-    if (ret < 0)
+    int ret = bucket_stats_cache.get_stats(user, bucket, bucket_stats,
+                                           bucket_quota);
+    if (ret < 0) {
       return ret;
+    }
 
     if (bucket_quota.enabled) {
-      ret = check_quota("bucket", bucket_quota, bucket_stats, num_objs, size_kb);
-      if (ret < 0)
+      ret = check_quota("bucket", bucket_quota, bucket_stats, num_objs, size);
+      if (ret < 0) {
         return ret;
+      }
     }
 
     if (def_bucket_quota.enabled) {
-      ret = check_quota("def_bucket", def_bucket_quota, bucket_stats, num_objs, size_kb);
-      if (ret < 0)
+      ret = check_quota("def_bucket", def_bucket_quota, bucket_stats,
+                        num_objs, size);
+      if (ret < 0) {
         return ret;
+      }
     }
 
     if (user_quota.enabled || def_user_quota.enabled) {
       RGWStorageStats user_stats;
 
       ret = user_stats_cache.get_stats(user, bucket, user_stats, user_quota);
-      if (ret < 0)
+      if (ret < 0) {
         return ret;
+      }
 
       if (user_quota.enabled) {
-	ret = check_quota("user", user_quota, user_stats, num_objs, size_kb);
-	if (ret < 0)
+	ret = check_quota("user", user_quota, user_stats, num_objs, size);
+	if (ret < 0) {
 	  return ret;
+        }
       } else if (def_user_quota.enabled) {
-        ret = check_quota("def_user", def_user_quota, user_stats, num_objs, size_kb);
-        if (ret < 0)
+        ret = check_quota("def_user", def_user_quota, user_stats,
+                          num_objs, size);
+        if (ret < 0) {
           return ret;
+        }
       }
     }
 

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -101,9 +101,9 @@ public:
 template<class T>
 bool RGWQuotaCache<T>::can_use_cached_stats(RGWQuotaInfo& quota, RGWStorageStats& cached_stats)
 {
-  if (quota.max_size_kb >= 0) {
+  if (quota.max_size >= 0) {
     if (quota.max_size_soft_threshold < 0) {
-      quota.max_size_soft_threshold = quota.max_size_kb * store->ctx()->_conf->rgw_bucket_quota_soft_threshold;
+      quota.max_size_soft_threshold = quota.max_size * store->ctx()->_conf->rgw_bucket_quota_soft_threshold;
     }
 
     const auto cached_stats_num_kb_rounded = rgw_rounded_kb(cached_stats.size_rounded);
@@ -712,21 +712,17 @@ bool RGWQuotaInfoDefApplier::is_size_exceeded(const char * const entity,
                                               const RGWStorageStats& stats,
                                               const uint64_t size) const
 {
-  if (qinfo.max_size_kb < 0) {
+  if (qinfo.max_size < 0) {
     /* The limit is not enabled. */
     return false;
   }
 
-  /* Handling quota in KiBs due to backward compatibility. */
-  const uint64_t add_size_kb = rgw_rounded_objsize_kb(size);
-  /* XXX: just div 1024 should be enough. */
-  const uint64_t cur_size_kb = rgw_rounded_kb(stats.size_rounded);
-  const uint64_t stats_num_kb_rounded = rgw_rounded_kb(stats.size_rounded);
+  const uint64_t cur_size = stats.size_rounded;
 
-  if (cur_size_kb + add_size_kb > static_cast<uint64_t>(qinfo.max_size_kb)) {
-    dout(10) << "quota exceeded: stats_num_kb_rounded=" << stats_num_kb_rounded
-             << " size_kb=" << add_size_kb << " "
-             << entity << "_quota.max_size_kb=" << qinfo.max_size_kb << dendl;
+  if (cur_size + size > static_cast<uint64_t>(qinfo.max_size)) {
+    dout(10) << "quota exceeded: stats.size_rounded=" << stats.size_rounded
+             << " size=" << size << " "
+             << entity << "_quota.max_size=" << qinfo.max_size << dendl;
     return true;
   }
 
@@ -782,7 +778,7 @@ class RGWQuotaHandlerImpl : public RGWQuotaHandler {
 
     ldout(store->ctx(), 20) << entity
                             << " quota: max_objects=" << quota.max_objects
-                            << " max_size_kb=" << quota.max_size_kb << dendl;
+                            << " max_size=" << quota.max_size << dendl;
 
 
     if (quota_applier.is_num_objs_exceeded(entity, quota, stats, num_objs)) {
@@ -805,7 +801,7 @@ public:
       def_bucket_quota.enabled = true;
     }
     if (store->ctx()->_conf->rgw_bucket_default_quota_max_size >= 0) {
-      def_bucket_quota.max_size_kb = store->ctx()->_conf->rgw_bucket_default_quota_max_size;
+      def_bucket_quota.max_size = store->ctx()->_conf->rgw_bucket_default_quota_max_size * 1024;
       def_bucket_quota.enabled = true;
     }
     if (store->ctx()->_conf->rgw_user_default_quota_max_objects >= 0) {
@@ -813,7 +809,7 @@ public:
       def_user_quota.enabled = true;
     }
     if (store->ctx()->_conf->rgw_user_default_quota_max_size >= 0) {
-      def_user_quota.max_size_kb = store->ctx()->_conf->rgw_user_default_quota_max_size;
+      def_user_quota.max_size = store->ctx()->_conf->rgw_user_default_quota_max_size * 1024;
       def_user_quota.enabled = true;
     }
   }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -731,10 +731,11 @@ bool RGWQuotaInfoDefApplier::is_size_exceeded(const char * const entity,
   }
 
   const uint64_t cur_size = stats.size_rounded;
+  const uint64_t new_size = rgw_rounded_objsize(size);
 
-  if (cur_size + size > static_cast<uint64_t>(qinfo.max_size)) {
+  if (cur_size + new_size > static_cast<uint64_t>(qinfo.max_size)) {
     dout(10) << "quota exceeded: stats.size_rounded=" << stats.size_rounded
-             << " size=" << size << " "
+             << " size=" << new_size << " "
              << entity << "_quota.max_size=" << qinfo.max_size << dendl;
     return true;
   }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -671,6 +671,97 @@ void RGWUserStatsCache::data_modified(const rgw_user& user, rgw_bucket& bucket)
 }
 
 
+class RGWQuotaInfoApplier {
+  /* NOTE: no non-static field allowed as instances are supposed to live in
+   * the static memory only. */
+protected:
+  RGWQuotaInfoApplier() = default;
+
+public:
+  virtual ~RGWQuotaInfoApplier() {}
+
+  virtual bool is_size_exceeded(const char * const entity,
+                                const RGWQuotaInfo& qinfo,
+                                const RGWStorageStats& stats,
+                                const uint64_t size) const = 0;
+
+  virtual bool is_num_objs_exceeded(const char * const entity,
+                                    const RGWQuotaInfo& qinfo,
+                                    const RGWStorageStats& stats,
+                                    const uint64_t num_objs) const = 0;
+
+  static const RGWQuotaInfoApplier& get_instance(const RGWQuotaInfo& qinfo);
+};
+
+class RGWQuotaInfoDefApplier : public RGWQuotaInfoApplier {
+public:
+  virtual bool is_size_exceeded(const char * const entity,
+                                const RGWQuotaInfo& qinfo,
+                                const RGWStorageStats& stats,
+                                const uint64_t size) const;
+
+  virtual bool is_num_objs_exceeded(const char * const entity,
+                                    const RGWQuotaInfo& qinfo,
+                                    const RGWStorageStats& stats,
+                                    const uint64_t num_objs) const;
+};
+
+
+bool RGWQuotaInfoDefApplier::is_size_exceeded(const char * const entity,
+                                              const RGWQuotaInfo& qinfo,
+                                              const RGWStorageStats& stats,
+                                              const uint64_t size) const
+{
+  if (qinfo.max_size_kb < 0) {
+    /* The limit is not enabled. */
+    return false;
+  }
+
+  /* Handling quota in KiBs due to backward compatibility. */
+  const uint64_t add_size_kb = rgw_rounded_objsize_kb(size);
+  /* XXX: just div 1024 should be enough. */
+  const uint64_t cur_size_kb = rgw_rounded_kb(stats.size_rounded);
+  const uint64_t stats_num_kb_rounded = rgw_rounded_kb(stats.size_rounded);
+
+  if (cur_size_kb + add_size_kb > static_cast<uint64_t>(qinfo.max_size_kb)) {
+    dout(10) << "quota exceeded: stats_num_kb_rounded=" << stats_num_kb_rounded
+             << " size_kb=" << add_size_kb << " "
+             << entity << "_quota.max_size_kb=" << qinfo.max_size_kb << dendl;
+    return true;
+  }
+
+  return false;
+}
+
+bool RGWQuotaInfoDefApplier::is_num_objs_exceeded(const char * const entity,
+                                                  const RGWQuotaInfo& qinfo,
+                                                  const RGWStorageStats& stats,
+                                                  const uint64_t num_objs) const
+{
+  if (qinfo.max_objects < 0) {
+    /* The limit is not enabled. */
+    return false;
+  }
+
+  if (stats.num_objects + num_objs > static_cast<uint64_t>(qinfo.max_objects)) {
+    dout(10) << "quota exceeded: stats.num_objects=" << stats.num_objects
+             << " " << entity << "_quota.max_objects=" << qinfo.max_objects
+             << dendl;
+    return true;
+  }
+
+  return false;
+}
+
+const RGWQuotaInfoApplier& RGWQuotaInfoApplier::get_instance(
+  const RGWQuotaInfo& qinfo)
+{
+  static RGWQuotaInfoDefApplier default_qapplier;
+
+  return default_qapplier;
+}
+
+
 class RGWQuotaHandlerImpl : public RGWQuotaHandler {
   RGWRados *store;
   RGWBucketStatsCache bucket_stats_cache;
@@ -687,37 +778,24 @@ class RGWQuotaHandlerImpl : public RGWQuotaHandler {
       return 0;
     }
 
+    const auto& quota_applier = RGWQuotaInfoApplier::get_instance(quota);
+
     ldout(store->ctx(), 20) << entity
                             << " quota: max_objects=" << quota.max_objects
                             << " max_size_kb=" << quota.max_size_kb << dendl;
 
-    if (quota.max_objects >= 0 &&
-        stats.num_objects + num_objs > (uint64_t)quota.max_objects) {
-      ldout(store->ctx(), 10) << "quota exceeded: stats.num_objects="
-                              << stats.num_objects
-                              << " " << entity << "_quota.max_objects="
-                              << quota.max_objects << dendl;
 
+    if (quota_applier.is_num_objs_exceeded(entity, quota, stats, num_objs)) {
       return -ERR_QUOTA_EXCEEDED;
     }
 
-    /* Handling quota in KiBs due to backward compatibility. */
-    if (quota.max_size_kb >= 0) {
-      const uint64_t size_kb = rgw_rounded_objsize_kb(size);
-      /* XXX: just div 1024 should be enough. */
-      const uint64_t stats_num_kb_rounded = rgw_rounded_kb(stats.size_rounded);
-
-      if (stats_num_kb_rounded + size_kb > (uint64_t)quota.max_size_kb) {
-        ldout(store->ctx(), 10) << "quota exceeded: stats_num_kb_rounded="
-                                << stats_num_kb_rounded
-                                << " size_kb=" << size_kb << " " << entity
-                                << "_quota.max_size_kb="
-                                << quota.max_size_kb << dendl;
-
-        return -ERR_QUOTA_EXCEEDED;
-      }
+    if (quota_applier.is_size_exceeded(entity, quota, stats, size)) {
+      return -ERR_QUOTA_EXCEEDED;
     }
 
+    ldout(store->ctx(), 20) << entity << " quota OK:"
+                            << " stats.num_objects=" << stats.num_objects
+                            << " stats.size=" << stats.size << dendl;
     return 0;
   }
 public:

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -42,17 +42,21 @@ public:
   int64_t max_size;
   int64_t max_objects;
   bool enabled;
+  /* Do we want to compare with raw, not rounded RGWStorageStats::size (true)
+   * or maybe rounded-to-4KiB RGWStorageStats::size_rounded (false)? */
+  bool check_on_raw;
 
   RGWQuotaInfo()
     : max_size_soft_threshold(-1),
       max_objs_soft_threshold(-1),
       max_size(-1),
       max_objects(-1),
-      enabled(false) {
+      enabled(false),
+      check_on_raw(false) {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     if (max_size < 0) {
       ::encode(-rgw_rounded_kb(abs(max_size)), bl);
     } else {
@@ -61,10 +65,11 @@ public:
     ::encode(max_objects, bl);
     ::encode(enabled, bl);
     ::encode(max_size, bl);
+    ::encode(check_on_raw, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(2, 1, 1, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(3, 1, 1, bl);
     int64_t max_size_kb;
     ::decode(max_size_kb, bl);
     ::decode(max_objects, bl);
@@ -73,6 +78,9 @@ public:
       max_size = max_size_kb * 1024;
     } else {
       ::decode(max_size, bl);
+    }
+    if (struct_v >= 3) {
+      ::decode(check_on_raw, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -24,14 +24,27 @@ class RGWRados;
 class JSONObj;
 
 struct RGWQuotaInfo {
-  int64_t max_size_kb;
-  int64_t max_objects;
-  bool enabled;
+  template<class T> friend class RGWQuotaCache;
+protected:
+  /* The quota thresholds after which comparing against cached storage stats
+   * is disallowed. Those fields may be accessed only by the RGWQuotaCache.
+   * They are not intended as tunables but rather as a mean to store results
+   * of repeating calculations in the quota cache subsystem. */
   int64_t max_size_soft_threshold;
   int64_t max_objs_soft_threshold;
 
-  RGWQuotaInfo() : max_size_kb(-1), max_objects(-1), enabled(false),
-                   max_size_soft_threshold(-1), max_objs_soft_threshold(-1) {}
+public:
+  int64_t max_size_kb;
+  int64_t max_objects;
+  bool enabled;
+
+  RGWQuotaInfo()
+    : max_size_soft_threshold(-1),
+      max_objs_soft_threshold(-1),
+      max_size_kb(-1),
+      max_objects(-1),
+      enabled(false) {
+  }
 
   void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7336,16 +7336,18 @@ int RGWRados::open_bucket_index_shard(rgw_bucket& bucket, librados::IoCtx& index
   return 0;
 }
 
-static void accumulate_raw_stats(rgw_bucket_dir_header& header, map<RGWObjCategory, RGWStorageStats>& stats)
+static void accumulate_raw_stats(const rgw_bucket_dir_header& header,
+                                 map<RGWObjCategory, RGWStorageStats>& stats)
 {
-  map<uint8_t, struct rgw_bucket_category_stats>::iterator iter = header.stats.begin();
-  for (; iter != header.stats.end(); ++iter) {
-    RGWObjCategory category = (RGWObjCategory)iter->first;
+  for (const auto& pair : header.stats) {
+    const RGWObjCategory category = static_cast<RGWObjCategory>(pair.first);
+    const rgw_bucket_category_stats& header_stats = pair.second;
+
     RGWStorageStats& s = stats[category];
-    struct rgw_bucket_category_stats& header_stats = iter->second;
-    s.category = (RGWObjCategory)iter->first;
-    s.num_kb += ((header_stats.total_size + 1023) / 1024);
-    s.num_kb_rounded += ((header_stats.total_size_rounded + 1023) / 1024);
+
+    s.category = category;
+    s.size += header_stats.total_size;
+    s.size_rounded += header_stats.total_size_rounded;
     s.num_objects += header_stats.num_entries;
   }
 }
@@ -10250,14 +10252,16 @@ class RGWGetUserStatsContext : public RGWGetUserHeader_CB {
   RGWGetUserStats_CB *cb;
 
 public:
-  explicit RGWGetUserStatsContext(RGWGetUserStats_CB *_cb) : cb(_cb) {}
+  explicit RGWGetUserStatsContext(RGWGetUserStats_CB * const cb)
+    : cb(cb) {}
+
   void handle_response(int r, cls_user_header& header) {
-    cls_user_stats& hs = header.stats;
+    const cls_user_stats& hs = header.stats;
     if (r >= 0) {
       RGWStorageStats stats;
 
-      stats.num_kb = (hs.total_bytes + 1023) / 1024;
-      stats.num_kb_rounded = (hs.total_bytes_rounded + 1023) / 1024;
+      stats.size = hs.total_bytes;
+      stats.size_rounded = hs.total_bytes_rounded;
       stats.num_objects = hs.total_entries;
 
       cb->set_response(stats);
@@ -10278,10 +10282,10 @@ int RGWRados::get_user_stats(const rgw_user& user, RGWStorageStats& stats)
   if (r < 0)
     return r;
 
-  cls_user_stats& hs = header.stats;
+  const cls_user_stats& hs = header.stats;
 
-  stats.num_kb = (hs.total_bytes + 1023) / 1024;
-  stats.num_kb_rounded = (hs.total_bytes_rounded + 1023) / 1024;
+  stats.size = hs.total_bytes;
+  stats.size_rounded = hs.total_bytes_rounded;
   stats.num_objects = hs.total_entries;
 
   return 0;
@@ -11589,8 +11593,8 @@ int RGWRados::update_user_bucket_stats(const string& user_id, rgw_bucket& bucket
 {
   cls_user_bucket_entry entry;
 
-  entry.size = stats.num_kb * 1024;
-  entry.size_rounded = stats.num_kb_rounded * 1024;
+  entry.size = stats.size;
+  entry.size_rounded = stats.size_rounded;
   entry.count += stats.num_objects;
 
   list<cls_user_bucket_entry> entries;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5032,6 +5032,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
                             const string& zonegroup_id,
                             const string& placement_rule,
                             const string& swift_ver_location,
+                            const RGWQuotaInfo * pquota_info,
 			    map<std::string, bufferlist>& attrs,
                             RGWBucketInfo& info,
                             obj_version *pobjv,
@@ -5089,10 +5090,14 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     info.num_shards = bucket_index_max_shards;
     info.bucket_index_shard_hash_type = RGWBucketInfo::MOD;
     info.requester_pays = false;
-    if (real_clock::is_zero(creation_time))
+    if (real_clock::is_zero(creation_time)) {
       creation_time = ceph::real_clock::now(cct);
-    else
+    } else {
       info.creation_time = creation_time;
+    }
+    if (pquota_info) {
+      info.quota = *pquota_info;
+    }
     ret = put_linked_bucket_info(info, exclusive, ceph::real_time(), pep_objv, &attrs, true);
     if (ret == -EEXIST) {
        /* we need to reread the info and return it, caller will have a use for it */

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2051,6 +2051,7 @@ public:
                             const string& zonegroup_id,
                             const string& placement_rule,
                             const string& swift_ver_location,
+                            const RGWQuotaInfo * pquota_info,
                             map<std::string,bufferlist>& attrs,
                             RGWBucketInfo& bucket_info,
                             obj_version *pobjv,

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -55,11 +55,12 @@ int RGWListBuckets_ObjStore_SWIFT::get_params()
 }
 
 static void dump_account_metadata(struct req_state * const s,
-				  const uint32_t buckets_count,
-				  const uint64_t buckets_object_count,
-				  const uint64_t buckets_size,
-				  const uint64_t buckets_size_rounded,
-				  map<string, bufferlist>& attrs)
+                                  const uint32_t buckets_count,
+                                  const uint64_t buckets_object_count,
+                                  const uint64_t buckets_size,
+                                  const uint64_t buckets_size_rounded,
+                                  /* const */map<string, bufferlist>& attrs,
+                                  const RGWQuotaInfo& quota)
 {
   char buf[32];
   utime_t now = ceph_clock_now(g_ceph_context);
@@ -77,17 +78,31 @@ static void dump_account_metadata(struct req_state * const s,
 
   /* Dump TempURL-related stuff */
   if (s->perm_mask == RGW_PERM_FULL_CONTROL) {
-    map<int, string>::iterator iter;
-    iter = s->user->temp_url_keys.find(0);
-    if (iter != s->user->temp_url_keys.end() && !iter->second.empty()) {
+    auto iter = s->user->temp_url_keys.find(0);
+    if (iter != std::end(s->user->temp_url_keys) && !iter->second.empty()) {
       STREAM_IO(s)->print("X-Account-Meta-Temp-Url-Key: %s\r\n",
 			  iter->second.c_str());
     }
 
     iter = s->user->temp_url_keys.find(1);
-    if (iter != s->user->temp_url_keys.end() && !iter->second.empty()) {
+    if (iter != std::end(s->user->temp_url_keys) && !iter->second.empty()) {
       STREAM_IO(s)->print("X-Account-Meta-Temp-Url-Key-2: %s\r\n",
 			  iter->second.c_str());
+    }
+  }
+
+  /* Dump quota headers. */
+  if (quota.enabled) {
+    if (quota.max_size >= 0) {
+      STREAM_IO(s)->print("X-Account-Meta-Quota-Bytes: %lld\r\n",
+			  (long long)quota.max_size);
+    }
+
+    /* Limit on the number of objects in a given account is a RadosGW's
+     * extension. Swift's account quota WSGI filter doesn't support it. */
+    if (quota.max_objects >= 0) {
+      STREAM_IO(s)->print("X-Account-Meta-Quota-Count: %lld\r\n",
+			  (long long)quota.max_objects);
     }
   }
 
@@ -125,7 +140,8 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
             buckets_objcount,
             buckets_size,
             buckets_size_rounded,
-            attrs);
+            attrs,
+            user_quota);
     dump_errno(s);
     end_header(s, NULL, NULL, NO_CONTENT_LENGTH, true);
   }
@@ -175,7 +191,8 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_end()
             buckets_objcount,
             buckets_size,
             buckets_size_rounded,
-            attrs);
+            attrs,
+            user_quota);
     dump_errno(s);
     end_header(s, NULL, NULL, s->formatter->get_len(), true);
   }
@@ -225,7 +242,9 @@ int RGWListBucket_ObjStore_SWIFT::get_params()
   return 0;
 }
 
-static void dump_container_metadata(struct req_state *, RGWBucketEnt&);
+static void dump_container_metadata(struct req_state *,
+                                    const RGWBucketEnt&,
+                                    const RGWQuotaInfo&);
 
 void RGWListBucket_ObjStore_SWIFT::send_response()
 {
@@ -233,7 +252,7 @@ void RGWListBucket_ObjStore_SWIFT::send_response()
   map<string, bool>::iterator pref_iter = common_prefixes.begin();
 
   dump_start(s);
-  dump_container_metadata(s, bucket);
+  dump_container_metadata(s, bucket, bucket_quota);
 
   s->formatter->open_array_section_with_attrs("container", FormatterAttrs("name", s->bucket.name.c_str(), NULL));
 
@@ -323,7 +342,9 @@ next:
   rgw_flush_formatter_and_reset(s, s->formatter);
 }
 
-static void dump_container_metadata(struct req_state *s, RGWBucketEnt& bucket)
+static void dump_container_metadata(struct req_state *s,
+                                    const RGWBucketEnt& bucket,
+                                    const RGWQuotaInfo& quota)
 {
   char buf[32];
   /* Adding X-Timestamp to keep align with Swift API */
@@ -381,6 +402,18 @@ static void dump_container_metadata(struct req_state *s, RGWBucketEnt& bucket)
     STREAM_IO(s)->print("X-Versions-Location: %s\r\n", encoded_loc.c_str());
   }
 
+  /* Dump quota headers. */
+  if (quota.enabled) {
+    if (quota.max_size >= 0) {
+      STREAM_IO(s)->print("X-Container-Meta-Quota-Bytes: %lld\r\n",
+			  (long long)quota.max_size);
+    }
+
+    if (quota.max_objects >= 0) {
+      STREAM_IO(s)->print("X-Container-Meta-Quota-Count: %lld\r\n",
+			  (long long)quota.max_objects);
+    }
+  }
 }
 
 void RGWStatAccount_ObjStore_SWIFT::execute()
@@ -394,7 +427,7 @@ void RGWStatAccount_ObjStore_SWIFT::send_response()
   if (op_ret >= 0) {
     op_ret = STATUS_NO_CONTENT;
     dump_account_metadata(s, buckets_count, buckets_objcount, buckets_size,
-			  buckets_size_rounded, attrs);
+			  buckets_size_rounded, attrs, user_quota);
   }
 
   set_req_state_err(s, op_ret);
@@ -409,7 +442,7 @@ void RGWStatBucket_ObjStore_SWIFT::send_response()
 {
   if (op_ret >= 0) {
     op_ret = STATUS_NO_CONTENT;
-    dump_container_metadata(s, bucket);
+    dump_container_metadata(s, bucket, bucket_quota);
   }
 
   set_req_state_err(s, op_ret);

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -891,8 +891,11 @@ void RGWOp_Quota_Set::execute()
         old_quota = &info.bucket_quota;
       }
 
+      int64_t old_max_size_kb = rgw_rounded_kb(old_quota->max_size);
+      int64_t max_size_kb;
       RESTArgs::get_int64(s, "max-objects", old_quota->max_objects, &quota.max_objects);
-      RESTArgs::get_int64(s, "max-size-kb", old_quota->max_size_kb, &quota.max_size_kb);
+      RESTArgs::get_int64(s, "max-size-kb", old_max_size_kb, &max_size_kb);
+      quota.max_size = max_size_kb * 1024;
       RESTArgs::get_bool(s, "enabled", old_quota->enabled, &quota.enabled);
     }
 


### PR DESCRIPTION
This pull request brings support for account as well as container quota of Swift API. The first one isn't currently operational because RadosGW doesn't have the *reseller admin* concept yet. It's essential because only administrators should be able to modify account quotas - there is no business in having that kind of quota if we allow account owner to change it. This is stays in contrast to bucket quota that may be altered by anyone with write access to a given bucket.

Derogates: #8947.

Depends on: *reseller admin* feature of #8657.

Includes commits from: #9002.

CC: @yehudasa, @mattbenjamin.