### PR TITLE
rgw: handle errors properly during GET on Swift's DLO.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1225,6 +1225,7 @@ void RGWGetObj::execute()
     if (op_ret < 0) {
       ldout(s->cct, 0) << "ERROR: failed to handle user manifest ret="
 		       << op_ret << dendl;
+      goto done_err;
     }
     return;
   }


### PR DESCRIPTION
Backport: Jewel, Hammer
Fixes: http://tracker.ceph.com/issues/15812
Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>