### PR TITLE
jewel: librbd: does not crash if image header is too short

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -523,7 +523,8 @@ remove_mirroring_image:
       off += r;
     } while (r == READ_SIZE);
 
-    if (memcmp(RBD_HEADER_TEXT, header.c_str(), sizeof(RBD_HEADER_TEXT))) {
+    if (header.length() < sizeof(RBD_HEADER_TEXT) ||
+	memcmp(RBD_HEADER_TEXT, header.c_str(), sizeof(RBD_HEADER_TEXT))) {
       CephContext *cct = (CephContext *)io_ctx.cct();
       lderr(cct) << "unrecognized header format" << dendl;
       return -ENXIO;


### PR DESCRIPTION
if something goes wrong with the object, and returns a chunk shorter
than expected, don't panic

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 7b52183addda83f98c8b1f37d3de20ca0fc4687b)