### PR TITLE
rpm: Drop SELinux priority setting

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1416,7 +1416,7 @@ FILE_CONTEXT=/etc/selinux/${SELINUXTYPE}/contexts/files/file_contexts
 cp ${FILE_CONTEXT} ${FILE_CONTEXT}.pre
 
 # Install the policy
-/usr/sbin/semodule -X 100 -i %{_datadir}/selinux/packages/ceph.pp
+/usr/sbin/semodule -i %{_datadir}/selinux/packages/ceph.pp
 
 # Load the policy if SELinux is enabled
 if ! /usr/sbin/selinuxenabled; then


### PR DESCRIPTION
Older versions of semodule binary that are in Centos/RHEL do not
support priority setting, dropping it.

Fixes: #15822
Signed-off-by: Boris Ranto <branto@redhat.com>