### PR TITLE
jewel: cmake: add missing source file to rbd_mirror/image_replayer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1010,6 +1010,7 @@ if(${WITH_RBD})
     tools/rbd_mirror/image_replayer/BootstrapRequest.cc
     tools/rbd_mirror/image_replayer/CloseImageRequest.cc
     tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
+    tools/rbd_mirror/image_replayer/ReplayStatusFormatter.cc
     tools/rbd_mirror/image_sync/ImageCopyRequest.cc
     tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
     tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc


### PR DESCRIPTION
fixes an undefined reference when linking librbd_mirror_internal.a

Signed-off-by: Casey Bodley <cbodley@redhat.com>
(cherry picked from commit 2f3f56170ab47fc10d4232101ae2e85398a4c299)