### PR TITLE
os/fs/FS: optimize aio::pwritev which make caller provide length.

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -381,7 +381,7 @@ int KernelDevice::aio_write(
   bl.hexdump(*_dout);
   *_dout << dendl;
 
-  _aio_log_start(ioc, off, bl.length());
+  _aio_log_start(ioc, off, len);
 
 #ifdef HAVE_LIBAIO
   if (aio && dio && !buffered) {
@@ -403,7 +403,7 @@ int KernelDevice::aio_write(
 		 << " " << aio.iov[i].iov_len << dendl;
       }
       aio.bl.claim_append(bl);
-      aio.pwritev(off);
+      aio.pwritev(off, len);
     }
     dout(5) << __func__ << " " << off << "~" << len << " aio " << &aio << dendl;
   } else
@@ -421,7 +421,7 @@ int KernelDevice::aio_write(
     bl.prepare_iov(&iov);
     int r = ::pwritev(buffered ? fd_buffered : fd_direct,
 		      &iov[0], iov.size(), off);
-    _aio_log_finish(ioc, off, bl.length());
+    _aio_log_finish(ioc, off, len);
 
     if (r < 0) {
       r = -errno;

--- a/src/os/fs/FS.h
+++ b/src/os/fs/FS.h
@@ -65,12 +65,10 @@ public:
       memset(&iocb, 0, sizeof(iocb));
     }
 
-    void pwritev(uint64_t _offset) {
+    void pwritev(uint64_t _offset, uint64_t len) {
       offset = _offset;
+      length = len;
       io_prep_pwritev(&iocb, fd, &iov[0], iov.size(), offset);
-      length = 0;
-      for (unsigned u=0; u<iov.size(); ++u)
-	length += iov[u].iov_len;
     }
     void pread(uint64_t _offset, uint64_t len) {
       offset = _offset;


### PR DESCRIPTION
Signed-off-by: Jianpeng Ma jianpeng.ma@intel.com
