### PR TITLE
mon/PGMonitor: use TextTable for pg relevant dump commands.

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -927,18 +927,42 @@ void PGMap::dump_pool_stats(ostream& ss, bool header) const
 
 void PGMap::dump_pg_sum_stats(ostream& ss, bool header) const
 {
-  if (header)
-    ss << "pg_stat\tobjects\tmip\tdegr\tmisp\tunf\tbytes\tlog\tdisklog" << std::endl;
-  ss << " sum\t" << pg_sum.stats.sum.num_objects
-  //<< "\t" << pg_sum.num_object_copies
-     << "\t" << pg_sum.stats.sum.num_objects_missing_on_primary
-     << "\t" << pg_sum.stats.sum.num_objects_degraded
-     << "\t" << pg_sum.stats.sum.num_objects_misplaced
-     << "\t" << pg_sum.stats.sum.num_objects_unfound
-     << "\t" << pg_sum.stats.sum.num_bytes
-     << "\t" << pg_sum.log_size
-     << "\t" << pg_sum.ondisk_log_size
-     << std::endl;
+  TextTable tab;
+
+  if (header) {
+    tab.define_column("PG_STAT", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("MISSING_ON_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("DEGRADED", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("MISPLACED", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("UNFOUND", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("BYTES", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("LOG", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("DISK_LOG", TextTable::LEFT, TextTable::RIGHT);
+  } else {
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+  };
+
+  tab << "sum"
+      << pg_sum.stats.sum.num_objects
+      << pg_sum.stats.sum.num_objects_missing_on_primary
+      << pg_sum.stats.sum.num_objects_degraded
+      << pg_sum.stats.sum.num_objects_misplaced
+      << pg_sum.stats.sum.num_objects_unfound
+      << pg_sum.stats.sum.num_bytes
+      << pg_sum.log_size
+      << pg_sum.ondisk_log_size
+      << TextTable::endrow;
+
+  ss << tab;
 }
 
 void PGMap::dump_osd_stats(ostream& ss) const

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -780,46 +780,81 @@ void PGMap::dump_pg_stats_plain(ostream& ss,
                                 const ceph::unordered_map<pg_t, pg_stat_t>& pg_stats,
                                 bool brief) const
 {
-  if (brief)
-    ss << "pg_stat\tstate\tup\tup_primary\tacting\tacting_primary" << std::endl;
-  else
-    ss << "pg_stat\tobjects\tmip\tdegr\tmisp\tunf\tbytes\tlog\tdisklog\tstate\t"
-          "state_stamp\tv\treported\tup\tup_primary\tacting\tacting_primary\t"
-          "last_scrub\tscrub_stamp\tlast_deep_scrub\tdeep_scrub_stamp" << std::endl;
+  TextTable tab;
+
+  if (brief){
+    tab.define_column("PG_STAT", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("STATE", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("UP", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("UP_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("ACTING", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("ACTING_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
+  }
+  else {
+    tab.define_column("PG_STAT", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("MISSING_ON_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("DEGRADED", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("MISPLACED", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("UNFOUND", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("BYTES", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("LOG", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("DISK_LOG", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("STATE", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("STATE_STAMP", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("VERSION", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("REPORTED", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("UP", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("UP_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("ACTING", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("ACTING_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("LAST_SCRUB", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("SCRUB_STAMP", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("LAST_DEEP_SCRUB", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("DEEP_SCRUB_STAMP", TextTable::LEFT, TextTable::RIGHT);
+  }
+
   for (ceph::unordered_map<pg_t, pg_stat_t>::const_iterator i = pg_stats.begin();
        i != pg_stats.end(); ++i) {
     const pg_stat_t &st(i->second);
     if (brief) {
-      ss << i->first
-         << "\t" << pg_state_string(st.state)
-         << "\t" << st.up
-         << "\t" << st.up_primary
-         << "\t" << st.acting
-         << "\t" << st.acting_primary
-         << std::endl;
+      tab << i->first
+          << pg_state_string(st.state)
+          << st.up
+          << st.up_primary
+          << st.acting
+          << st.acting_primary
+          << TextTable::endrow;
     } else {
-      ss << i->first
-         << "\t" << st.stats.sum.num_objects
-         << "\t" << st.stats.sum.num_objects_missing_on_primary
-         << "\t" << st.stats.sum.num_objects_degraded
-         << "\t" << st.stats.sum.num_objects_misplaced
-         << "\t" << st.stats.sum.num_objects_unfound
-         << "\t" << st.stats.sum.num_bytes
-         << "\t" << st.log_size
-         << "\t" << st.ondisk_log_size
-         << "\t" << pg_state_string(st.state)
-         << "\t" << st.last_change
-         << "\t" << st.version
-         << "\t" << st.reported_epoch << ":" << st.reported_seq
-         << "\t" << pg_vector_string(st.up)
-         << "\t" << st.up_primary
-         << "\t" << pg_vector_string(st.acting)
-         << "\t" << st.acting_primary
-         << "\t" << st.last_scrub << "\t" << st.last_scrub_stamp
-         << "\t" << st.last_deep_scrub << "\t" << st.last_deep_scrub_stamp
-         << std::endl;
+      ostringstream reported;
+      reported << st.reported_epoch << ":" << st.reported_seq;
+
+      tab << i->first
+          << st.stats.sum.num_objects
+          << st.stats.sum.num_objects_missing_on_primary
+          << st.stats.sum.num_objects_degraded
+          << st.stats.sum.num_objects_misplaced
+          << st.stats.sum.num_objects_unfound
+          << st.stats.sum.num_bytes
+          << st.log_size
+          << st.ondisk_log_size
+          << pg_state_string(st.state)
+          << st.last_change
+          << st.version
+          << reported.str()
+          << pg_vector_string(st.up)
+          << st.up_primary
+          << pg_vector_string(st.acting)
+          << st.acting_primary
+          << st.last_scrub
+          << st.last_scrub_stamp
+          << st.last_deep_scrub
+          << st.last_deep_scrub_stamp
+          << TextTable::endrow;
     }
   }
+
+  ss << tab;
 }
 
 void PGMap::dump(ostream& ss) const

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -967,23 +967,34 @@ void PGMap::dump_pg_sum_stats(ostream& ss, bool header) const
 
 void PGMap::dump_osd_stats(ostream& ss) const
 {
-  ss << "osdstat\tused\tavail\ttotal\thb in\thb out\tpg sum" << std::endl;
+  TextTable tab;
+
+  tab.define_column("OSD_STAT", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("USED", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("AVAIL", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("TOTAL", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("HB_IN", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("PG_SUM", TextTable::LEFT, TextTable::RIGHT);
+
   for (ceph::unordered_map<int32_t,osd_stat_t>::const_iterator p = osd_stat.begin();
        p != osd_stat.end();
        ++p) {
-    ss << p->first
-       << "\t" << prettybyte_t(p->second.kb_used)
-       << "\t" << prettybyte_t(p->second.kb_avail)
-       << "\t" << prettybyte_t(p->second.kb)
-       << "\t" << p->second.hb_in
-       << "\t" << p->second.hb_out
-       << "\t" << get_num_pg_by_osd(p->first)
-       << std::endl;
+    tab << p->first
+        << prettybyte_t(p->second.kb_used)
+        << prettybyte_t(p->second.kb_avail)
+        << prettybyte_t(p->second.kb)
+        << p->second.hb_in
+        << get_num_pg_by_osd(p->first)
+        << TextTable::endrow;
   }
-  ss << " sum\t" << prettybyte_t(osd_sum.kb_used)
-     << "\t" << prettybyte_t(osd_sum.kb_avail)
-     << "\t" << prettybyte_t(osd_sum.kb)
-     << std::endl;
+
+  tab << "sum"
+      << prettybyte_t(osd_sum.kb_used)
+      << prettybyte_t(osd_sum.kb_avail)
+      << prettybyte_t(osd_sum.kb)
+      << TextTable::endrow;
+
+  ss << tab;
 }
 
 void PGMap::dump_osd_sum_stats(ostream& ss) const

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -999,11 +999,20 @@ void PGMap::dump_osd_stats(ostream& ss) const
 
 void PGMap::dump_osd_sum_stats(ostream& ss) const
 {
-  ss << "osdstat\tused\tavail\ttotal" << std::endl;
-  ss << " sum\t" << prettybyte_t(osd_sum.kb_used)
-     << "\t" << prettybyte_t(osd_sum.kb_avail)
-     << "\t" << prettybyte_t(osd_sum.kb)
-     << std::endl;
+  TextTable tab;
+
+  tab.define_column("OSD_STAT", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("USED", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("AVAIL", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("TOTAL", TextTable::LEFT, TextTable::RIGHT);
+
+  tab << "sum"
+      << prettybyte_t(osd_sum.kb_used)
+      << prettybyte_t(osd_sum.kb_avail)
+      << prettybyte_t(osd_sum.kb)
+      << TextTable::endrow;
+
+  ss << tab;
 }
 
 void PGMap::get_stuck_stats(int types, const utime_t cutoff,

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1791,32 +1791,63 @@ void PGMap::dump_filtered_pg_stats(Formatter *f, set<pg_t>& pgs)
   }
   f->close_section();
 }
+
 void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs)
 {
-  ss << "pg_stat\tobjects\tmip\tdegr\tmisp\tunf\tbytes\tlog\tdisklog\tstate\t"
-        "state_stamp\tv\treported\tup\tup_primary\tacting\tacting_primary\t"
-        "last_scrub\tscrub_stamp\tlast_deep_scrub\tdeep_scrub_stamp" << std::endl;
+  TextTable tab;
+
+  tab.define_column("PG_STAT", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("MISSING_ON_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("DEGRADED", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("MISPLACED", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("UNFOUND", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("BYTES", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("LOG", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("DISK_LOG", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("STATE", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("STATE_STAMP", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("VERSION", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("REPORTED", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("UP", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("UP_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("ACTING", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("ACTING_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("LAST_SCRUB", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("SCRUB_STAMP", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("LAST_DEEP_SCRUB", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("DEEP_SCRUB_STAMP", TextTable::LEFT, TextTable::RIGHT);
+
   for (set<pg_t>::iterator i = pgs.begin(); i != pgs.end(); ++i) {
     pg_stat_t& st = pg_stat[*i];
-    ss << *i
-       << "\t" << st.stats.sum.num_objects
-       << "\t" << st.stats.sum.num_objects_missing_on_primary
-       << "\t" << st.stats.sum.num_objects_degraded
-       << "\t" << st.stats.sum.num_objects_misplaced
-       << "\t" << st.stats.sum.num_objects_unfound
-       << "\t" << st.stats.sum.num_bytes
-       << "\t" << st.log_size
-       << "\t" << st.ondisk_log_size
-       << "\t" << pg_state_string(st.state)
-       << "\t" << st.last_change
-       << "\t" << st.version
-       << "\t" << st.reported_epoch << ":" << st.reported_seq
-       << "\t" << st.up
-       << "\t" << st.up_primary
-       << "\t" << st.acting
-       << "\t" << st.acting_primary
-       << "\t" << st.last_scrub << "\t" << st.last_scrub_stamp
-       << "\t" << st.last_deep_scrub << "\t" << st.last_deep_scrub_stamp
-       << std::endl;
+
+    ostringstream reported;
+    reported << st.reported_epoch << ":" << st.reported_seq;
+
+    tab << *i
+        << st.stats.sum.num_objects
+        << st.stats.sum.num_objects_missing_on_primary
+        << st.stats.sum.num_objects_degraded
+        << st.stats.sum.num_objects_misplaced
+        << st.stats.sum.num_objects_unfound
+        << st.stats.sum.num_bytes
+        << st.log_size
+        << st.ondisk_log_size
+        << pg_state_string(st.state)
+        << st.last_change
+        << st.version
+        << reported.str()
+        << st.up
+        << st.up_primary
+        << st.acting
+        << st.acting_primary
+        << st.last_scrub
+        << st.last_scrub_stamp
+        << st.last_deep_scrub
+        << st.last_deep_scrub_stamp
+        << TextTable::endrow;
   }
+
+  ss << tab;
 }
+

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -883,23 +883,46 @@ void PGMap::dump_pg_stats(ostream& ss, bool brief) const
 
 void PGMap::dump_pool_stats(ostream& ss, bool header) const
 {
-  if (header)
-    ss << "pg_stat\tobjects\tmip\tdegr\tmisp\tunf\tbytes\tlog\tdisklog" << std::endl;
+  TextTable tab;
+
+  if (header) {
+    tab.define_column("POOLID", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("MISSING_ON_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("DEGRADED", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("MISPLACED", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("UNFOUND", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("BYTES", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("LOG", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("DISK_LOG", TextTable::LEFT, TextTable::RIGHT);
+  } else {
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+  }
+
   for (ceph::unordered_map<int,pool_stat_t>::const_iterator p = pg_pool_sum.begin();
        p != pg_pool_sum.end();
        ++p) {
-    ss << "pool " << p->first
-       << "\t" << p->second.stats.sum.num_objects
-    //<< "\t" << p->second.num_object_copies
-       << "\t" << p->second.stats.sum.num_objects_missing_on_primary
-       << "\t" << p->second.stats.sum.num_objects_degraded
-       << "\t" << p->second.stats.sum.num_objects_misplaced
-       << "\t" << p->second.stats.sum.num_objects_unfound
-       << "\t" << p->second.stats.sum.num_bytes
-       << "\t" << p->second.log_size
-       << "\t" << p->second.ondisk_log_size
-       << std::endl;
+    tab << p->first
+        << p->second.stats.sum.num_objects
+        << p->second.stats.sum.num_objects_missing_on_primary
+        << p->second.stats.sum.num_objects_degraded
+        << p->second.stats.sum.num_objects_misplaced
+        << p->second.stats.sum.num_objects_unfound
+        << p->second.stats.sum.num_bytes
+        << p->second.log_size
+        << p->second.ondisk_log_size
+        << TextTable::endrow;
   }
+
+  ss << tab;
 }
 
 void PGMap::dump_pg_sum_stats(ostream& ss, bool header) const


### PR DESCRIPTION
To make the output better aligned and more human-readable.

E.g:
```
[root@c7 /]# ceph --cluster clove pg dump osds                                       
dumped osds in format plain
OSD_STAT USED     AVAIL  TOTAL  HB_IN PG_SUM 
       1 72070 kB 124 MB 195 MB   [0]    360 
       0 72070 kB 124 MB 195 MB   [1]    360 
     sum   140 MB 249 MB 390 MB              
[root@c7 /]#
```

```
[root@c7 /]# ceph --cluster clove pg dump summary
dumped summary in format plain
version 453832
stamp 2016-05-11 18:29:34.282001
last_osdmap_epoch 212
last_pg_scan 212
full_ratio 0.95
nearfull_ratio 0.85
PG_STAT OBJECTS MISSING_ON_PRIMARY DEGRADED MISPLACED UNFOUND BYTES    LOG   DISK_LOG 
    sum    1753                  0        0         0       0 42241382 98774    98774 
OSD_STAT USED   AVAIL  TOTAL  
     sum 140 MB 249 MB 390 MB 
``` 

```
[root@c7 /]# ceph --cluster clove pg dump pools
dumped pools in format plain
POOLID OBJECTS MISSING_ON_PRIMARY DEGRADED MISPLACED UNFOUND BYTES    LOG   DISK_LOG 
     9      33                  0        0         0       0     7583   346      346 
     8     591                  0        0         0       0     9573 24492    24492 
     7      32                  0        0         0       0        0 23435    23435 
     6     191                  0        0         0       0    58682   233      233 
     5       8                  0        0         0       0        0   832      832 
     4      34                  0        0         0       0    16299   211      211 
    37       1                  0        0         0       0     1558     1        1 
    36      10                  0        0         0       0        0    12       12 
    19     129                  0        0         0       0        0 24366    24366 
    18      32                  0        0         0       0        0 23028    23028 
    17       2                  0        0         0       0      628     2        2 
    16       8                  0        0         0       0        0   540      540 
    15       0                  0        0         0       0        0     0        0 
    14       0                  0        0         0       0        0     5        5 
    13      25                  0        0         0       0 42069502   108      108 
    12     356                  0        0         0       0        0   471      471 
    35      10                  0        0         0       0     1097    84       84 
    11     233                  0        0         0       0    73333   408      408 
    10      22                  0        0         0       0      230    45       45 
    20       2                  0        0         0       0      363     8        8 
    21       1                  0        0         0       0       14     3        3 
    22      14                  0        0         0       0     2405    95       95 
    23       1                  0        0         0       0        0     2        2 
    25       8                  0        0         0       0        0    24       24 
    26       0                  0        0         0       0        0     0        0 
    27       0                  0        0         0       0        0     0        0 
    28       0                  0        0         0       0        0     0        0 
    29       7                  0        0         0       0       79    20       20 
    30       0                  0        0         0       0        0     0        0 
    31       3                  0        0         0       0       36     3        3 
```