### PR TITLE
client: fix setting empty default ACL

### DIFF
--- a/qa/workunits/fs/misc/acl.sh
+++ b/qa/workunits/fs/misc/acl.sh
@@ -11,6 +11,13 @@ if test $? != 0; then
 	exit 0
 fi
 
+expect_failure() {
+	if [ `"$@"` -e 0 ]; then
+		return 1
+	fi
+	return 0
+}
+
 set -e
 c=0
 while [ $c -lt 100  ]
@@ -29,6 +36,18 @@ do
 	fi
 done
 
+mkdir d1
+
+# The ACL xattr only contains ACL header. ACL should be removed
+# in this case.
+setfattr -n system.posix_acl_access -v 0x02000000 d1
+setfattr -n system.posix_acl_default -v 0x02000000 .
+
+expect_failure getfattr -n system.posix_acl_access d1
+expect_failure getfattr -n system.posix_acl_default .
+
+
+rmdir d1
 cd ..
 rmdir testdir
 echo OK

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9887,8 +9887,13 @@ int Client::_setxattr(Inode *in, const char *name, const void *value,
       if (value) {
 	if (!S_ISDIR(in->mode))
 	  return -EACCES;
-	if (!posix_acl_check(value, size))
+	int ret = posix_acl_check(value, size);
+	if (ret < 0)
 	  return -EINVAL;
+	if (ret == 0) {
+	  value = NULL;
+	  size = 0;
+	}
       }
     } else {
       return -EOPNOTSUPP;


### PR DESCRIPTION
'cp -a ...' may call setxattr(..., "system.posix_acl_default",
"\2\0\0", 4, 0). The ACL xattr only include ACL header. Client
should remove ACL in this case.

Signed-off-by: Yan, Zheng <zyan@redhat.com>