### PR TITLE
osd/ReplicatedBackend: reuse the already computed cost

### DIFF
--- a/src/messages/MOSDPGPush.h
+++ b/src/messages/MOSDPGPush.h
@@ -28,8 +28,11 @@ public:
   spg_t pgid;
   epoch_t map_epoch;
   vector<PushOp> pushes;
+
+private:
   uint64_t cost;
 
+public:
   void compute_cost(CephContext *cct) {
     cost = 0;
     for (vector<PushOp>::iterator i = pushes.begin();
@@ -41,6 +44,10 @@ public:
 
   int get_cost() const {
     return cost;
+  }
+
+  void set_cost(uint64_t c) {
+    cost = c;
   }
 
   MOSDPGPush() :

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1911,7 +1911,7 @@ void ReplicatedBackend::send_pushes(int prio, map<pg_shard_t, vector<PushOp> > &
 	pushes += 1;
 	msg->pushes.push_back(*j);
       }
-      msg->compute_cost(cct);
+      msg->set_cost(cost);
       get_parent()->send_message_osd_cluster(msg, con);
     }
   }


### PR DESCRIPTION
no need to compute the cost a second time

Signed-off-by: runsisi <runsisi@zte.com.cn>