### PR TITLE
osd: instrument map cache hits and misses

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -125,6 +125,11 @@ enum {
 
   l_osd_waiting_for_map,
 
+  l_osd_map_cache_hit,
+  l_osd_map_cache_miss,
+  l_osd_map_cache_miss_low,
+  l_osd_map_cache_miss_low_avg,
+
   l_osd_stat_bytes,
   l_osd_stat_bytes_used,
   l_osd_stat_bytes_avail,


### PR DESCRIPTION
In particular, note misses that are below the map cache lower
bound, and the average distance below that lb.

Signed-off-by: Sage Weil <sage@redhat.com>