### PR TITLE
qa: rbd/map-snapshot-io.sh: don't chown sysfs files

### DIFF
--- a/qa/workunits/rbd/map-snapshot-io.sh
+++ b/qa/workunits/rbd/map-snapshot-io.sh
@@ -1,29 +1,17 @@
 #!/bin/sh
-set -e
 
 # http://tracker.ceph.com/issues/3964
 
-[ -d /sys/bus/rbd ] || sudo modprobe rbd
-sudo chown ubuntu /sys/bus/rbd/add
-sudo chown ubuntu /sys/bus/rbd/remove
+set -ex
 
 rbd create image -s 100
-rbd map image
-udevadm settle  # note: newer versions of rbd do this for you.
-dd if=/dev/zero of=/dev/rbd/rbd/image oflag=direct count=10
+DEV=$(sudo rbd map image)
+dd if=/dev/zero of=$DEV oflag=direct count=10
 rbd snap create image@s1
-dd if=/dev/zero of=/dev/rbd/rbd/image oflag=direct count=10   # used to fail
+dd if=/dev/zero of=$DEV oflag=direct count=10   # used to fail
 rbd snap rm image@s1
-dd if=/dev/zero of=/dev/rbd/rbd/image oflag=direct count=10
-
-udevadm settle  # udev is does blkid on device close; yeesh!  see #4183
-
-rbd unmap /dev/rbd/rbd/image
+dd if=/dev/zero of=$DEV oflag=direct count=10
+sudo rbd unmap $DEV
 rbd rm image
 
-# wait a few seconds for the async kernel bits to clean themselves up
-sleep 4
-rbd rm image || :
-
 echo OK
-


### PR DESCRIPTION
/sys/bus/rbd/add_single_major is used if present, so chown'ing
/sys/bus/rbd/add doesn't help.  Use sudo on rbd map instead.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>