### PR TITLE
doc/dev: Fix missing code section due to no lexer for "none"

### DIFF
--- a/doc/dev/osd_internals/last_epoch_started.rst
+++ b/doc/dev/osd_internals/last_epoch_started.rst
@@ -42,7 +42,7 @@ how far back divergent log entries can be found.
 
 However, in a case like
 
-.. code:: none
+.. code::
 
   calc_acting osd.0 1.4e( v 473'302 (292'200,473'302] local-les=473 n=4 ec=5 les/c 473/473 556/556/556
   calc_acting osd.1 1.4e( v 473'302 (293'202,473'302] lb 0//0//-1 local-les=477 n=0 ec=5 les/c 473/473 556/556/556


### PR DESCRIPTION
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>

This is currently affecting http://docs.ceph.com/docs/master/dev/osd_internals/last_epoch_started/