### PR TITLE
msg/async/AsyncConnection: create writable event for in progress connection

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1046,9 +1046,12 @@ ssize_t AsyncConnection::_process_connection()
           ldout(async_msgr->cct, 1) << __func__ << " reconnect failed " << dendl;
           goto fail;
         } else if (r > 0) {
+          ldout(async_msgr->cct, 10) << __func__ << " nonblock connect inprogress" << dendl;
+          center->create_file_event(sd, EVENT_WRITABLE, read_handler);
           break;
         }
 
+        center->delete_file_event(sd, EVENT_WRITABLE);
         state = STATE_CONNECTING_WAIT_BANNER;
         break;
       }


### PR DESCRIPTION
Previously we use a tricky with ceph msgr protocol, if initiator side got
in progress connection state, it will wait until read event. Because if
tcp session built successfully server side will send the banner firstly
and initiator side will get read event. Otherwise, if connection failed,
read event also be called.

But actually man(2)[http://man7.org/linux/man-pages/man2/connect.2.html]
specify if we want to get notification whether connection built, we need
to listen writable event. It means when connection built, send buffer
is ready to be written.

This patch follow the strict nonblock connect process. Not fully sure fix
http://tracker.ceph.com/issues/15849

Signed-off-by: Haomai Wang <haomai@xsky.com>