### PR TITLE
[RFC] osd/ReplicatedPG: bypass op w/ FULL_FORCE when osd is full.

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1683,7 +1683,7 @@ void ReplicatedPG::do_op(OpRequestRef& op)
 	     << *m << dendl;
     return;
   }
-  if (!m->get_source().is_mds() && osd->check_failsafe_full()) {
+  if (!(m->get_source().is_mds() || m->has_flag(CEPH_OSD_FLAG_FULL_FORCE)) && osd->check_failsafe_full()) {
     dout(10) << __func__ << " fail-safe full check failed, dropping request"
 	     << dendl;
     return;


### PR DESCRIPTION
If usage of osd reached failsafe_full_ratio, it discard all ops expect
mds. For delete w/ FULL_FORCE it still discard. This make no way to free
space.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>