### PR TITLE
osd: make health check more accurate for heartbeat mechanism

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4054,44 +4054,76 @@ void OSD::handle_osd_ping(MOSDPing *m)
     {
       map<int,HeartbeatInfo>::iterator i = heartbeat_peers.find(from);
       if (i != heartbeat_peers.end()) {
-	if (m->get_connection() == i->second.con_back) {
-	  dout(25) << "handle_osd_ping got reply from osd." << from
-		   << " first_tx " << i->second.first_tx
-		   << " last_tx " << i->second.last_tx
-		   << " last_rx_back " << i->second.last_rx_back << " -> " << m->stamp
-		   << " last_rx_front " << i->second.last_rx_front
-		   << dendl;
-	  i->second.last_rx_back = m->stamp;
-	  // if there is no front con, set both stamps.
-	  if (i->second.con_front == NULL)
-	    i->second.last_rx_front = m->stamp;
-	} else if (m->get_connection() == i->second.con_front) {
-	  dout(25) << "handle_osd_ping got reply from osd." << from
-		   << " first_tx " << i->second.first_tx
-		   << " last_tx " << i->second.last_tx
-		   << " last_rx_back " << i->second.last_rx_back
-		   << " last_rx_front " << i->second.last_rx_front << " -> " << m->stamp
-		   << dendl;
-	  i->second.last_rx_front = m->stamp;
-	}
-
-        utime_t cutoff = ceph_clock_now(cct);
-        cutoff -= cct->_conf->osd_heartbeat_grace;
-        if (i->second.is_healthy(cutoff)) {
-          // Cancel false reports
-          if (failure_queue.count(from)) {
-            dout(10) << "handle_osd_ping canceling queued "
-                     << "failure report for osd." << from << dendl;
-            failure_queue.erase(from);
+        auto acked = i->second.pending_pings.find(m->stamp);
+        if (acked != i->second.pending_pings.end()) {
+          utime_t now = ceph_clock_now(cct);
+          int &rx_refs_remaining = acked->second.second;
+          if (m->get_connection() == i->second.con_back) {
+            dout(25) << "handle_osd_ping got reply from osd." << from
+                     << " first_tx " << i->second.first_tx
+                     << " last_tx " << i->second.last_tx
+                     << " last_rx_back " << i->second.last_rx_back << " -> " << now
+                     << " last_rx_front " << i->second.last_rx_front
+                     << dendl;
+            i->second.last_rx_back = now;
+            assert(rx_refs_remaining > 0);
+            --rx_refs_remaining;
+            // if there is no front con, set both stamps.
+            if (i->second.con_front == NULL) {
+              i->second.last_rx_front = now;
+              assert(rx_refs_remaining > 0);
+              --rx_refs_remaining;
+            }
+          } else if (m->get_connection() == i->second.con_front) {
+            dout(25) << "handle_osd_ping got reply from osd." << from
+                     << " first_tx " << i->second.first_tx
+                     << " last_tx " << i->second.last_tx
+                     << " last_rx_back " << i->second.last_rx_back
+                     << " last_rx_front " << i->second.last_rx_front << " -> " << now
+                     << dendl;
+            i->second.last_rx_front = now;
+            assert(rx_refs_remaining > 0);
+            --rx_refs_remaining;
           }
 
-          if (failure_pending.count(from)) {
-            dout(10) << "handle_osd_ping canceling in-flight "
-                     << "failure report for osd." << from << dendl;
-            send_still_alive(curmap->get_epoch(),
-              failure_pending[from].second);
-            failure_pending.erase(from);
+          if (rx_refs_remaining == 0) {
+            // succeeded in getting all replies
+            dout(25) << "handle_osd_ping got all replies from osd." << from
+                     << " , erase pending ping(sent at " << m->stamp << ")"
+                     << " and older pending ping(s)"
+                     << dendl;
+
+            map<utime_t, pair<utime_t, int> > still_pending;
+            ++acked;
+
+            if (acked != i->second.pending_pings.end())
+              still_pending.insert(acked, i->second.pending_pings.end());
+
+            i->second.pending_pings.swap(still_pending);
           }
+
+          if (i->second.is_healthy(now)) {
+            // Cancel false reports
+            if (failure_queue.count(from)) {
+              dout(10) << "handle_osd_ping canceling queued "
+                       << "failure report for osd." << from << dendl;
+              failure_queue.erase(from);
+            }
+
+            if (failure_pending.count(from)) {
+              dout(10) << "handle_osd_ping canceling in-flight "
+                       << "failure report for osd." << from << dendl;
+              send_still_alive(curmap->get_epoch(),
+                failure_pending[from].second);
+              failure_pending.erase(from);
+            }
+          }
+        } else {
+          // old replies, deprecated by newly sent pings.
+          dout(10) << "handle_osd_ping no pending ping(sent at " << m->stamp
+                   << ") is found, treat as covered by newly sent pings "
+                   << "and ignore"
+                   << dendl;
         }
       }
 
@@ -4149,17 +4181,9 @@ void OSD::heartbeat_check()
   }
 
   // check for incoming heartbeats (move me elsewhere?)
-  utime_t cutoff = now;
-  cutoff -= cct->_conf->osd_heartbeat_grace;
   for (map<int,HeartbeatInfo>::iterator p = heartbeat_peers.begin();
        p != heartbeat_peers.end();
        ++p) {
-
-    if (p->second.first_tx == utime_t()) {
-      dout(25) << "heartbeat_check we haven't sent ping to osd." << p->first
-               << "yet, skipping" << dendl;
-      continue;
-    }
 
     dout(25) << "heartbeat_check osd." << p->first
 	     << " first_tx " << p->second.first_tx
@@ -4167,19 +4191,21 @@ void OSD::heartbeat_check()
 	     << " last_rx_back " << p->second.last_rx_back
 	     << " last_rx_front " << p->second.last_rx_front
 	     << dendl;
-    if (p->second.is_unhealthy(cutoff)) {
+    if (p->second.is_unhealthy(now)) {
+      utime_t oldest_deadline = p->second.pending_pings.begin()->second.first;
       if (p->second.last_rx_back == utime_t() ||
 	  p->second.last_rx_front == utime_t()) {
-	derr << "heartbeat_check: no reply from " << p->second.con_front->get_peer_addr().get_sockaddr()
-	     << " osd." << p->first << " ever on either front or back, first ping sent "
-	     << p->second.first_tx << " (cutoff " << cutoff << ")" << dendl;
+        derr << "heartbeat_check: no reply from " << p->second.con_front->get_peer_addr().get_sockaddr()
+             << " osd." << p->first
+             << " ever on either front or back, first ping sent " << p->second.first_tx
+             << " (oldest deadline " << oldest_deadline << ")" << dendl;
 	// fail
 	failure_queue[p->first] = p->second.last_tx;
       } else {
 	derr << "heartbeat_check: no reply from " << p->second.con_front->get_peer_addr().get_sockaddr()
 	     << " osd." << p->first << " since back " << p->second.last_rx_back
 	     << " front " << p->second.last_rx_front
-	     << " (cutoff " << cutoff << ")" << dendl;
+	     << " (oldest deadline " << oldest_deadline << ")" << dendl;
 	// fail
 	failure_queue[p->first] = MIN(p->second.last_rx_back, p->second.last_rx_front);
       }
@@ -4213,6 +4239,8 @@ void OSD::heartbeat()
   dout(5) << "heartbeat: " << service.get_osd_stat() << dendl;
 
   utime_t now = ceph_clock_now(cct);
+  utime_t deadline = now;
+  deadline += cct->_conf->osd_heartbeat_grace;
 
   // send heartbeats
   for (map<int,HeartbeatInfo>::iterator i = heartbeat_peers.begin();
@@ -4222,6 +4250,8 @@ void OSD::heartbeat()
     i->second.last_tx = now;
     if (i->second.first_tx == utime_t())
       i->second.first_tx = now;
+    i->second.pending_pings[now] = make_pair(deadline,
+      HeartbeatInfo::HEARTBEAT_MAX_CONN);
     dout(30) << "heartbeat sending ping to osd." << peer << dendl;
     i->second.con_back->send_message(new MOSDPing(monc->get_fsid(),
 					  service.get_osdmap()->get_epoch(),
@@ -4883,13 +4913,12 @@ bool OSD::_is_healthy()
 
   if (is_waiting_for_healthy()) {
     Mutex::Locker l(heartbeat_lock);
-    utime_t cutoff = ceph_clock_now(cct);
-    cutoff -= cct->_conf->osd_heartbeat_grace;
+    utime_t now = ceph_clock_now(cct);
     int num = 0, up = 0;
     for (map<int,HeartbeatInfo>::iterator p = heartbeat_peers.begin();
 	 p != heartbeat_peers.end();
 	 ++p) {
-      if (p->second.is_healthy(cutoff))
+      if (p->second.is_healthy(now))
 	++up;
       ++num;
     }


### PR DESCRIPTION
The original logic will reuse the timestamp which we send a PING to
the specific heartbeat peer to update the last_rx_front[back] field
on receiving the corresponding REPLIES, which later shall be honoured
as the exact timestamps we succeed in getting the corresponding
REPLIES and used to calculate the heartbeat latency and determine
whether the relevant peer is dead.

However this is not accurate enough as there may be a delay between
we receive a PINGREPLY and call `heartbeat_check()`, which is
periodcially scheduled by the `tick()` thread and heartbeat_thread,
to calculate the real heartbeat latency:

1. the `tick()` thread will wake up and call `OSD::heartbeat_check()` at 1s interval,
 but can be blocked and delayed by the big osd_lock significantly.
2. the heartbeat_thread will wake up and call `OSD::heartbeat_check()` at a
 random-choosen interval, which can vary from 0.5s ~6.5S, and 
is blockless, since it requires the heartbeat_lock only.
3. the heartbeat_thread will also be responsible for sending PINGs each time
 it wakes up.

With the prior knowledge above, the following example might be a
little more comprehensible now:
```
1. we send ping at 2016/5/13 14:59:10
2. we get both replies at 2016/5/13 14:59:11 and mark last_rx_* as
   2016/5/13 14:59:10(NB: we always update last_rx_* fields to the
   timestamp we sending pings, instead of receiving replies)
3. heartbeat_thread wakes up at 2016/5/13 14:59:15 and calls
   OSD::heartbeat_check() for the heartbeat latency.
   However, it will figure out that the latency is

     now(2016/5/13 14:59:15) - last_rx_*(2016/5/13 14:59:10) = 5s

   instead of

     2016/5/13 14:59:11 - 2016/5/13 14:59:10 =  1s

   which is obviously wrong.
4. further, heartbeat_thread resends a new ping at 2016/5/13 14:59:15
   meanwhile and the peer is now unable to respond such a call.
5. the tick() thread keeps ticking and the heartbeat latency now may
   appear to be the following series:
     now(2016/5/13 14:59:16) - last_rx_*(2016/5/13 14:59:10) = 6s
     now(2016/5/13 14:59:17) - last_rx_*(2016/5/13 14:59:10) = 7s
     now(2016/5/13 14:59:18) - last_rx_*(2016/5/13 14:59:10) = 8s
     ...
   this is also **not** accurate as we know we send new ping at 2016/5/13 14:59:15
   and shall count down from then.
6. However the last_rx_* fields shall still be consider as the 
   lower bound we can't hear a reply from the front/back side.
```
As both heartbeat interval(osd_heartbeat_interval, default to 6)
and grace(osd_heartbeat_grace, default to 20) are configurable
options, the above case may become fatal if we set a longer
osd_heartbeat_interval or a shorter osd_heartbeat_grace and thus
shall be resolved.
    
Because we keep sending new pings periodically, the old pings
could be deprecated by the newly sent pings, thus we introduces a map
to keep tracking of the ping-history here, which consists of
three elements:
    
    1. "tx_time", worked as map key, indicates the exact timestamp we send
       a ping.
    2. "deadline", indicates we shall receive all replies until then,
       otherwise we consider this peer as "dead".
    3. "rx_refs_remaining", indicates how many replies for the corresponding
       ping are still in-flight. The initial value is 2(the front side and the
       back side).
    
We insert an item into the map above every time we send a ping, and
drop the "rx_refs_remaining" by 1 each time we get a reply for the
tracked ping. If "rx_refs_remaining" drops to 0, we know all the replies
have been successfully collected and we can safely erase the relevant
item from the map as well as older ones if there is any.
    
By comparing the current timestamp with the oldest deadline, we can now
make a much accurate decision about whether the corresponding peer is
healthy or not. And by setting last_rx_* to the timestamp we receiving
the reply, the lower bound that we can't hear a reply from the corresponding
connection is also much clear now.

Other notable changes including:

 **move heartbeat_check() from tick() to tick_without_osd_lock()**--
    The heartbeat_check() logic requires heartbeat_lock only, so it shall
    work without osd_lock in hand. By doing this, we avoid the latency to
    acquire the big osd_lock and detect peer failure much quickly.

 **send heartbeat more randomly**--
    The original scale of randomized interval we sending PINGs is
    too rough, and may raise the ability of PING messages burst for
    large clusters.
