### PR TITLE
mon: fix 'mon metadata' for lone monitors, and enable listing all metadata at once

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -649,6 +649,7 @@ function test_mon_misc()
   ceph_watch_wait "$mymsg"
 
   ceph mon metadata a
+  ceph mon metadata
   ceph node ls
 }
 

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -795,6 +795,8 @@ function test_mon_mds()
   for mds_gid in $(get_mds_gids $FS_NAME) ; do
       ceph mds metadata $mds_id
   done
+  ceph mds metadata
+
   # XXX mds fail, but how do you undo it?
   mdsmapfile=$TMPDIR/mdsmap.$$
   current_epoch=$(ceph mds getmap -o $mdsmapfile --no-log-to-stderr 2>&1 | grep epoch | sed 's/.*epoch //')

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1024,6 +1024,7 @@ bool MDSMonitor::preprocess_command(MonOpRequestRef op)
     bool all = !cmd_getval(g_ceph_context, cmdmap, "who", who);
     dout(1) << "all = " << all << dendl;
     if (all) {
+      r = 0;
       // Dump all MDSs' metadata
       const auto all_info = fsmap.get_mds_info();
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -312,7 +312,7 @@ COMMAND("fs dump "
 COMMAND("mds getmap " \
 	"name=epoch,type=CephInt,req=false,range=0", \
 	"get MDS map, optionally from epoch", "mds", "r", "cli,rest")
-COMMAND("mds metadata name=who,type=CephString",
+COMMAND("mds metadata name=who,type=CephString,req=false",
 	"fetch metadata for mds <who>",
 	"mds", "r", "cli,rest")
 COMMAND("mds tell " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -292,7 +292,7 @@ COMMAND_WITH_FLAG("mon sync force " \
     "force sync of and clear monitor store", \
     "mon", "rw", "cli,rest", \
     FLAG(NOFORWARD))
-COMMAND("mon metadata name=id,type=CephString",
+COMMAND("mon metadata name=id,type=CephString,req=false",
 	"fetch metadata for mon <id>",
 	"mon", "r", "cli,rest")
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2972,6 +2972,7 @@ void Monitor::handle_command(MonOpRequestRef op)
       f->close_section();
     } else {
       // Dump all mons' metadata
+      r = 0;
       f->open_array_section("mon_metadata");
       for (unsigned int rank = 0; rank < monmap->size(); ++rank) {
         std::ostringstream get_err;

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -919,7 +919,7 @@ public:
   int write_default_keyring(bufferlist& bl);
   void extract_save_mon_key(KeyRing& keyring);
 
-  void update_mon_metadata(int from, const Metadata& m);
+  void update_mon_metadata(int from, Metadata&& m);
   int load_metadata(map<int, Metadata>& m);
 
   // features

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -717,7 +717,9 @@ public:
   void handle_mon_metadata(MonOpRequestRef op);
   int get_mon_metadata(int mon, Formatter *f, ostream& err);
   int print_nodes(Formatter *f, ostream& err);
-  map<int, Metadata> metadata;
+
+  // Accumulate metadata across calls to update_mon_metadata
+  map<int, Metadata> pending_metadata;
 
   /**
    *

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3238,6 +3238,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
         goto reply;
       f->close_section();
     } else {
+      r = 0;
       f->open_array_section("osd_metadata");
       for (int i=0; i<osdmap.get_max_osd(); ++i) {
         if (osdmap.exists(i)) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3245,8 +3245,15 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
           f->open_object_section("osd");
           f->dump_unsigned("id", i);
           r = dump_osd_metadata(i, f.get(), NULL);
-          if (r < 0)
+          if (r == -EINVAL || r == -ENOENT) {
+            // Drop error, continue to get other daemons' metadata
+            dout(4) << "No metadata for osd." << i << dendl;
+            r = 0;
+            continue;
+          } else if (r < 0) {
+            // Unexpected error
             goto reply;
+          }
           f->close_section();
         }
       }


### PR DESCRIPTION
Previously, writing to the store was only
triggered when MMonMetadata was received
from peers, so if you had a single mon then
you would always get ENOENT from "mon metadata"

Fixes: http://tracker.ceph.com/issues/15866
Signed-off-by: John Spray <john.spray@redhat.com>