### PR TITLE
rgw_rados: remove unused ioctx for domain root in create_bucket

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5004,14 +5004,6 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     uint32_t nop = 0;
     ::encode(nop, bl);
 
-    const string& pool = get_zone_params().domain_root.name;
-    const char *pool_str = pool.c_str();
-    librados::IoCtx id_io_ctx;
-    librados::Rados *rad = get_rados_handle();
-    int r = rad->ioctx_create(pool_str, id_io_ctx);
-    if (r < 0)
-      return r;
-
     if (!pmaster_bucket) {
       uint64_t iid = instance_id();
       uint64_t bid = next_bucket_id();
@@ -5024,7 +5016,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
       bucket.bucket_id = pmaster_bucket->bucket_id;
     }
 
-    r = init_bucket_index(bucket, bucket_index_max_shards);
+    int r = init_bucket_index(bucket, bucket_index_max_shards);
     if (r < 0)
       return r;
 


### PR DESCRIPTION
In `create_bucket`, we open an ioctx for domain root pool and never use
it later, removing this.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>