### PR TITLE
rpm: unconditionally set ceph user's primary group to ceph (SUSE) 

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -978,8 +978,13 @@ fi
 if ! getent passwd ceph >/dev/null ; then
     CEPH_USER_ID_OPTION=""
     getent passwd $CEPH_USER_ID >/dev/null || CEPH_USER_ID_OPTION="-u $CEPH_USER_ID"
-    useradd ceph $CEPH_USER_ID_OPTION -r -g ceph -s /sbin/nologin -c "Ceph daemons" -d %{_localstatedir}/lib/ceph 2>/dev/null || :
+    useradd ceph $CEPH_USER_ID_OPTION -r -g ceph -s /sbin/nologin 2>/dev/null || :
 fi
+usermod -c "Ceph storage service" \
+        -d %{_localstatedir}/lib/ceph \   
+        -g ceph \
+        -s /sbin/nologin \
+        ceph
 %endif
 exit 0
 


### PR DESCRIPTION
This commit brings the user/group creation into greater semantic alignment
with the Debian packaging, but only for SUSE.

Fixes: http://tracker.ceph.com/issues/15869
Signed-off-by: Nathan Cutler <ncutler@suse.com>