### PR TITLE
osd: reset session->osdmap if waiting_for_pg is empty

### DIFF
--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -446,10 +446,10 @@ public:
     return get_source_inst();
   }
   entity_name_t get_orig_source() const {
-    return get_orig_source_inst().name;
+    return get_source();
   }
   entity_addr_t get_orig_source_addr() const {
-    return get_orig_source_inst().addr;
+    return get_source_addr();
   }
 
   // virtual bits

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5886,6 +5886,7 @@ void OSD::dispatch_session_waiting(Session *session, OSDMapRef osdmap)
   } else {
     register_session_waiting_on_map(session);
   }
+  session->maybe_reset_osdmap();
 }
 
 
@@ -5964,6 +5965,7 @@ void OSD::session_notify_pg_cleared(
   assert(session->session_dispatch_lock.is_locked());
   update_waiting_for_pg(session, osdmap);
   session->waiting_for_pg.erase(pgid);
+  session->maybe_reset_osdmap();
   clear_session_waiting_on_pg(session, pgid);
 }
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1342,8 +1342,11 @@ public:
       session_dispatch_lock("Session::session_dispatch_lock"), 
       last_sent_epoch(0), received_map_epoch(0)
     {}
-
-
+    void maybe_reset_osdmap() {
+      if (waiting_for_pg.empty()) {
+	osdmap.reset();
+      }
+    }
   };
   void update_waiting_for_pg(Session *session, OSDMapRef osdmap);
   void session_notify_pg_create(Session *session, OSDMapRef osdmap, spg_t pgid);
@@ -1442,6 +1445,7 @@ public:
      */
     session->waiting_on_map.clear();
     session->waiting_for_pg.clear();
+    session->osdmap.reset();
   }
   void register_session_waiting_on_pg(Session *session, spg_t pgid) {
     Mutex::Locker l(session_waiting_lock);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1348,6 +1348,8 @@ public:
       }
     }
   };
+
+private:
   void update_waiting_for_pg(Session *session, OSDMapRef osdmap);
   void session_notify_pg_create(Session *session, OSDMapRef osdmap, spg_t pgid);
   void session_notify_pg_cleared(Session *session, OSDMapRef osdmap, spg_t pgid);

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -82,6 +82,7 @@ void OpRequest::_unregistered() {
   request->clear_data();
   request->clear_payload();
   request->release_message_throttle();
+  request->set_connection(nullptr);
 }
 
 bool OpRequest::check_rmw(int flag) {


### PR DESCRIPTION
we should release the osdmap reference once we are done with it,
otherwise we might need to wait very long to update that reference with
a newer osdmap ref. this appears to be an OSDMap leak: it is held by an
quiet OSD::Session forever.

Fixes: http://tracker.ceph.com/issues/15879
Signed-off-by: Kefu Chai <kchai@redhat.com>