### PR TITLE
mds/mdbalancer: fixup assignment type in the hit_dir

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -1010,9 +1010,9 @@ void MDBalancer::hit_dir(utime_t now, CDir *dir, int type, int who, double amoun
   double rd_adj = 0;
   if (type == META_POP_IRD &&
       dir->last_popularity_sample < last_sample) {
-    float dir_pop = dir->pop_auth_subtree.get(type).get(now, mds->mdcache->decayrate);    // hmm??
+    double dir_pop = dir->pop_auth_subtree.get(type).get(now, mds->mdcache->decayrate);    // hmm??
     dir->last_popularity_sample = last_sample;
-    float pop_sp = dir->pop_spread.get(now, mds->mdcache->decayrate);
+    double pop_sp = dir->pop_spread.get(now, mds->mdcache->decayrate);
     dir_pop += pop_sp * 10;
 
     //if (dir->ino() == inodeno_t(0x10000000002))
@@ -1029,7 +1029,7 @@ void MDBalancer::hit_dir(utime_t now, CDir *dir, int type, int who, double amoun
       if (!dir->is_rep() &&
 	  dir_pop >= g_conf->mds_bal_replicate_threshold) {
 	// replicate
-	float rdp = dir->pop_me.get(META_POP_IRD).get(now, mds->mdcache->decayrate);
+	double rdp = dir->pop_me.get(META_POP_IRD).get(now, mds->mdcache->decayrate);
 	rd_adj = rdp / mds->get_mds_map()->get_num_in_mds() - rdp;
 	rd_adj /= 2.0;  // temper somewhat
 


### PR DESCRIPTION
The DecayCounter of val is double type,
so dir_pop&pop_sp&rdp should be double type,
otherwise it will affect the accuracy of calculation.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>