### PR TITLE
librados: use caller provided snapid for aio_sparse_read()

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -863,7 +863,7 @@ int librados::IoCtxImpl::aio_sparse_read(const object_t oid,
 
   Objecter::Op *o = objecter->prepare_read_op(
     oid, oloc,
-    onack->m_ops, snap_seq, NULL, 0,
+    onack->m_ops, snapid, NULL, 0,
     onack, &c->objver);
   objecter->op_submit(o, &c->tid);
   return 0;


### PR DESCRIPTION
...instead of the value set via set_snap_read(). This makes
aio_sparse_read() consistent with aio_read(), which also accepts a
snapid parameter.

Signed-off-by: David Disseldorp <ddiss@suse.de>