### PR TITLE
librbd: initial hooks for client-side, image-extent cache in IO path

### DIFF
--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -197,7 +197,11 @@ void AioImageRequest<I>::send() {
                  << "completion=" << aio_comp <<  dendl;
 
   aio_comp->get();
-  send_request();
+  if (m_bypass_image_cache || true) { // TODO
+    send_request();
+  } else {
+    send_image_cache_request();
+  }
 }
 
 template <typename I>
@@ -287,6 +291,11 @@ void AioImageRead<I>::send_request() {
 
   image_ctx.perfcounter->inc(l_librbd_rd);
   image_ctx.perfcounter->inc(l_librbd_rd_bytes, buffer_ofs);
+}
+
+template <typename I>
+void AioImageRead<I>::send_image_cache_request() {
+  // TODO
 }
 
 template <typename I>
@@ -426,6 +435,11 @@ uint64_t AioImageWrite<I>::append_journal_event(
 }
 
 template <typename I>
+void AioImageWrite<I>::send_image_cache_request() {
+  // TODO
+}
+
+template <typename I>
 void AioImageWrite<I>::send_cache_requests(const ObjectExtents &object_extents,
                                         uint64_t journal_tid) {
   I &image_ctx = this->m_image_ctx;
@@ -526,6 +540,11 @@ uint32_t AioImageDiscard<I>::get_cache_request_count(bool journaling) const {
 }
 
 template <typename I>
+void AioImageDiscard<I>::send_image_cache_request() {
+  // TODO
+}
+
+template <typename I>
 void AioImageDiscard<I>::send_cache_requests(const ObjectExtents &object_extents,
                                           uint64_t journal_tid) {
   I &image_ctx = this->m_image_ctx;
@@ -614,6 +633,11 @@ void AioImageFlush<I>::send_request() {
   aio_comp->put();
 
   image_ctx.perfcounter->inc(l_librbd_aio_flush);
+}
+
+template <typename I>
+void AioImageFlush<I>::send_image_cache_request() {
+  // TODO
 }
 
 } // namespace librbd

--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -189,7 +189,6 @@ void AioImageRequest<I>::aio_flush(I *ictx, AioCompletion *c) {
 template <typename I>
 void AioImageRequest<I>::send() {
   I &image_ctx = this->m_image_ctx;
-  assert(image_ctx.owner_lock.is_locked());
   assert(m_aio_comp->is_initialized(get_aio_type()));
   assert(m_aio_comp->is_started() ^ (get_aio_type() == AIO_TYPE_FLUSH));
 

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -33,6 +33,8 @@ public:
                        size_t len, char *buf, bufferlist *pbl, int op_flags);
   static void aio_write(ImageCtxT *ictx, AioCompletion *c, uint64_t off,
                         size_t len, const char *buf, int op_flags);
+  static void aio_write(ImageCtxT *ictx, AioCompletion *c, uint64_t off,
+                        bufferlist &&bl, int op_flags);
   static void aio_discard(ImageCtxT *ictx, AioCompletion *c, uint64_t off,
                           uint64_t len);
   static void aio_flush(ImageCtxT *ictx, AioCompletion *c);
@@ -153,7 +155,13 @@ public:
   AioImageWrite(ImageCtxT &image_ctx, AioCompletion *aio_comp, uint64_t off,
                 size_t len, const char *buf, int op_flags)
     : AbstractAioImageWrite<ImageCtxT>(image_ctx, aio_comp, off, len),
-      m_buf(buf), m_op_flags(op_flags) {
+      m_op_flags(op_flags) {
+    m_bl.append(buf, len);
+  }
+  AioImageWrite(ImageCtxT &image_ctx, AioCompletion *aio_comp, uint64_t off,
+                bufferlist &&bl, int op_flags)
+    : AbstractAioImageWrite<ImageCtxT>(image_ctx, aio_comp, off, bl.length()),
+      m_bl(std::move(bl)), m_op_flags(op_flags) {
   }
 
 protected:
@@ -183,7 +191,7 @@ protected:
                                         bool synchronous);
   virtual void update_stats(size_t length);
 private:
-  const char *m_buf;
+  bufferlist m_bl;
   int m_op_flags;
 };
 

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -129,11 +129,11 @@ protected:
 
   virtual void prune_object_extents(ObjectExtents &object_extents) {
   }
-  virtual uint32_t get_cache_request_count(bool journaling) const {
+  virtual uint32_t get_object_cache_request_count(bool journaling) const {
     return 0;
   }
-  virtual void send_cache_requests(const ObjectExtents &object_extents,
-                                   uint64_t journal_tid) = 0;
+  virtual void send_object_cache_requests(const ObjectExtents &object_extents,
+                                          uint64_t journal_tid) = 0;
 
   virtual void send_object_requests(const ObjectExtents &object_extents,
                                     const ::SnapContext &snapc,
@@ -183,8 +183,8 @@ protected:
 
   virtual void send_image_cache_request() override;
 
-  virtual void send_cache_requests(const ObjectExtents &object_extents,
-                                   uint64_t journal_tid);
+  virtual void send_object_cache_requests(const ObjectExtents &object_extents,
+                                          uint64_t journal_tid);
 
   virtual void send_object_requests(const ObjectExtents &object_extents,
                                     const ::SnapContext &snapc,
@@ -224,9 +224,9 @@ protected:
 
   virtual void send_image_cache_request() override;
 
-  virtual uint32_t get_cache_request_count(bool journaling) const override;
-  virtual void send_cache_requests(const ObjectExtents &object_extents,
-                                   uint64_t journal_tid);
+  virtual uint32_t get_object_cache_request_count(bool journaling) const override;
+  virtual void send_object_cache_requests(const ObjectExtents &object_extents,
+                                          uint64_t journal_tid);
 
   virtual AioObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -48,12 +48,17 @@ public:
   void send();
   void fail(int r);
 
+  void set_bypass_image_cache() {
+    m_bypass_image_cache = true;
+  }
+
 protected:
   typedef std::list<AioObjectRequestHandle *> AioObjectRequests;
 
   ImageCtxT &m_image_ctx;
   AioCompletion *m_aio_comp;
   Extents m_image_extents;
+  bool m_bypass_image_cache = false;
 
   AioImageRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                   Extents &&image_extents)
@@ -62,6 +67,8 @@ protected:
   }
 
   virtual void send_request() = 0;
+  virtual void send_image_cache_request() = 0;
+
   virtual aio_type_t get_aio_type() const = 0;
   virtual const char *get_request_type() const = 0;
 };
@@ -79,7 +86,9 @@ public:
   }
 
 protected:
-  virtual void send_request();
+  virtual void send_request() override;
+  virtual void send_image_cache_request() override;
+
   virtual aio_type_t get_aio_type() const {
     return AIO_TYPE_READ;
   }
@@ -171,6 +180,8 @@ protected:
 
   void assemble_extent(const ObjectExtent &object_extent, bufferlist *bl);
 
+  virtual void send_image_cache_request() override;
+
   virtual void send_cache_requests(const ObjectExtents &object_extents,
                                    uint64_t journal_tid);
 
@@ -209,6 +220,9 @@ protected:
   }
 
   virtual void prune_object_extents(ObjectExtents &object_extents) override;
+
+  virtual void send_image_cache_request() override;
+
   virtual uint32_t get_cache_request_count(bool journaling) const override;
   virtual void send_cache_requests(const ObjectExtents &object_extents,
                                    uint64_t journal_tid);
@@ -237,6 +251,8 @@ protected:
   using typename AioImageRequest<ImageCtxT>::AioObjectRequests;
 
   virtual void send_request();
+  virtual void send_image_cache_request() override;
+
   virtual aio_type_t get_aio_type() const {
     return AIO_TYPE_FLUSH;
   }

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -66,6 +66,7 @@ protected:
       m_image_extents(image_extents) {
   }
 
+  virtual int clip_request();
   virtual void send_request() = 0;
   virtual void send_image_cache_request() = 0;
 
@@ -250,6 +251,9 @@ public:
 protected:
   using typename AioImageRequest<ImageCtxT>::AioObjectRequests;
 
+  virtual int clip_request() {
+    return 0;
+  }
   virtual void send_request();
   virtual void send_image_cache_request() override;
 

--- a/src/librbd/AioImageRequestWQ.cc
+++ b/src/librbd/AioImageRequestWQ.cc
@@ -120,10 +120,11 @@ void AioImageRequestWQ::aio_read(AioCompletion *c, uint64_t off, uint64_t len,
 
   if (m_image_ctx.non_blocking_aio || writes_blocked() || !writes_empty() ||
       lock_required) {
-    queue(new AioImageRead<>(m_image_ctx, c, off, len, buf, pbl, op_flags));
+    queue(new AioImageRead<>(m_image_ctx, c, {{off, len}}, buf, pbl, op_flags));
   } else {
     c->start_op();
-    AioImageRequest<>::aio_read(&m_image_ctx, c, off, len, buf, pbl, op_flags);
+    AioImageRequest<>::aio_read(&m_image_ctx, c, {{off, len}}, buf, pbl,
+                                op_flags);
     finish_in_flight_op();
   }
 }

--- a/src/librbd/AioImageRequestWQ.cc
+++ b/src/librbd/AioImageRequestWQ.cc
@@ -351,10 +351,7 @@ void AioImageRequestWQ::process(AioImageRequest<> *req) {
   ldout(cct, 20) << __func__ << ": ictx=" << &m_image_ctx << ", "
                  << "req=" << req << dendl;
 
-  {
-    RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-    req->send();
-  }
+  req->send();
 
   finish_queued_op(req);
   if (req->is_write_op()) {
@@ -388,7 +385,6 @@ void AioImageRequestWQ::finish_in_progress_write() {
   }
 
   if (writes_blocked) {
-    RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
     m_image_ctx.flush(new C_BlockedWrites(this));
   }
 }
@@ -409,19 +405,20 @@ int AioImageRequestWQ::start_in_flight_op(AioCompletion *c) {
 }
 
 void AioImageRequestWQ::finish_in_flight_op() {
+  Context *on_shutdown;
   {
     RWLock::RLocker locker(m_lock);
     if (m_in_flight_ops.dec() > 0 || !m_shutdown) {
       return;
     }
+    on_shutdown = m_on_shutdown;
   }
 
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 5) << __func__ << ": completing shut down" << dendl;
 
-  RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-  assert(m_on_shutdown != nullptr);
-  m_image_ctx.flush(m_on_shutdown);
+  assert(on_shutdown != nullptr);
+  m_image_ctx.flush(on_shutdown);
 }
 
 bool AioImageRequestWQ::is_lock_required() const {

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -168,7 +168,7 @@ private:
 
   void send_copyup();
 
-  void read_from_parent(const Extents& image_extents);
+  void read_from_parent(Extents&& image_extents);
 };
 
 class AbstractAioObjectWrite : public AioObjectRequest<> {

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -140,7 +140,6 @@ private:
   bool m_sparse;
   int m_op_flags;
   ceph::bufferlist m_read_data;
-  AioCompletion *m_parent_completion;
   ExtentMap m_ext_map;
 
   /**

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -26,6 +26,8 @@ set(librbd_internal_srcs
   ObjectWatcher.cc 
   Operations.cc
   Utils.cc
+  cache/ImageWriteback.cc
+  cache/PassthroughImageCache.cc
   exclusive_lock/AcquireRequest.cc
   exclusive_lock/ReacquireRequest.cc
   exclusive_lock/ReleaseRequest.cc

--- a/src/librbd/CopyupRequest.cc
+++ b/src/librbd/CopyupRequest.cc
@@ -78,8 +78,7 @@ private:
 
 
 CopyupRequest::CopyupRequest(ImageCtx *ictx, const std::string &oid,
-                             uint64_t objectno,
-      		       vector<pair<uint64_t,uint64_t> >& image_extents)
+                             uint64_t objectno, Extents &&image_extents)
   : m_ictx(ictx), m_oid(oid), m_object_no(objectno),
     m_image_extents(image_extents), m_state(STATE_READ_FROM_PARENT)
 {
@@ -188,8 +187,8 @@ void CopyupRequest::send()
                          << ", oid " << m_oid
                          << ", extents " << m_image_extents
                          << dendl;
-  AioImageRequest<>::aio_read(m_ictx->parent, comp, m_image_extents, NULL,
-                              &m_copyup_data, 0);
+  AioImageRequest<>::aio_read(m_ictx->parent, comp, std::move(m_image_extents),
+                              nullptr, &m_copyup_data, 0);
 }
 
 void CopyupRequest::complete(int r)
@@ -205,7 +204,6 @@ bool CopyupRequest::should_complete(int r)
   CephContext *cct = m_ictx->cct;
   ldout(cct, 20) << __func__ << " " << this
                  << ": oid " << m_oid
-                 << ", extents " << m_image_extents
                  << ", r " << r << dendl;
 
   uint64_t pending_copyups;

--- a/src/librbd/CopyupRequest.cc
+++ b/src/librbd/CopyupRequest.cc
@@ -39,7 +39,6 @@ public:
   }
 
   virtual int send() {
-    assert(m_image_ctx.owner_lock.is_locked());
     uint64_t snap_id = m_snap_ids[m_snap_id_idx];
     if (snap_id == CEPH_NOSNAP) {
       RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
@@ -189,7 +188,6 @@ void CopyupRequest::send()
                          << ", oid " << m_oid
                          << ", extents " << m_image_extents
                          << dendl;
-  RWLock::RLocker owner_locker(m_ictx->parent->owner_lock);
   AioImageRequest<>::aio_read(m_ictx->parent, comp, m_image_extents, NULL,
                               &m_copyup_data, 0);
 }
@@ -260,7 +258,6 @@ void CopyupRequest::remove_from_list()
 
 bool CopyupRequest::send_object_map() {
   {
-    RWLock::RLocker owner_locker(m_ictx->owner_lock);
     RWLock::RLocker snap_locker(m_ictx->snap_lock);
     if (m_ictx->object_map != nullptr) {
       bool copy_on_read = m_pending_requests.empty();

--- a/src/librbd/CopyupRequest.h
+++ b/src/librbd/CopyupRequest.h
@@ -16,8 +16,10 @@ struct ImageCtx;
 
 class CopyupRequest {
 public:
+  typedef std::vector<std::pair<uint64_t, uint64_t> > Extents;
+
   CopyupRequest(ImageCtx *ictx, const std::string &oid, uint64_t objectno,
-                vector<pair<uint64_t,uint64_t> >& image_extents);
+                Extents &&image_extents);
   ~CopyupRequest();
 
   void append_request(AioObjectRequest<ImageCtx> *req);
@@ -63,7 +65,7 @@ private:
   ImageCtx *m_ictx;
   std::string m_oid;
   uint64_t m_object_no;
-  vector<pair<uint64_t,uint64_t> > m_image_extents;
+  Extents m_image_extents;
   State m_state;
   ceph::bufferlist m_copyup_data;
   vector<AioObjectRequest<ImageCtx> *> m_pending_requests;

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -51,6 +51,7 @@ namespace librbd {
   template <typename> class Operations;
   class LibrbdWriteback;
 
+  namespace cache { struct ImageCache; }
   namespace exclusive_lock { struct Policy; }
   namespace journal { struct Policy; }
 
@@ -127,6 +128,7 @@ namespace librbd {
 
     file_layout_t layout;
 
+    cache::ImageCache *image_cache = nullptr;
     ObjectCacher *object_cacher;
     LibrbdWriteback *writeback_handler;
     ObjectCacher::ObjectSet *object_set;

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -789,8 +789,6 @@ uint64_t Journal<I>::append_write_event(uint64_t offset, size_t length,
                                         const bufferlist &bl,
                                         const AioObjectRequests &requests,
                                         bool flush_entry) {
-  assert(m_image_ctx.owner_lock.is_locked());
-
   assert(m_max_append_size > journal::AioWriteEvent::get_fixed_size());
   uint64_t max_write_data_size =
     m_max_append_size - journal::AioWriteEvent::get_fixed_size();
@@ -824,8 +822,6 @@ uint64_t Journal<I>::append_io_event(journal::EventEntry &&event_entry,
                                      const AioObjectRequests &requests,
                                      uint64_t offset, size_t length,
                                      bool flush_entry) {
-  assert(m_image_ctx.owner_lock.is_locked());
-
   bufferlist bl;
   ::encode(event_entry, bl);
   return append_io_events(event_entry.get_event_type(), {bl}, requests, offset,
@@ -838,7 +834,6 @@ uint64_t Journal<I>::append_io_events(journal::EventType event_type,
                                       const AioObjectRequests &requests,
                                       uint64_t offset, size_t length,
                                       bool flush_entry) {
-  assert(m_image_ctx.owner_lock.is_locked());
   assert(!bufferlists.empty());
 
   Futures futures;
@@ -1587,7 +1582,6 @@ void Journal<I>::handle_io_event_safe(int r, uint64_t tid) {
       (*it)->complete(r);
     } else {
       // send any waiting aio requests now that journal entry is safe
-      RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
       (*it)->send();
     }
   }

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -50,15 +50,12 @@ namespace librbd {
    */
   class C_ReadRequest : public Context {
   public:
-    C_ReadRequest(CephContext *cct, Context *c, RWLock *owner_lock,
-                  Mutex *cache_lock)
-      : m_cct(cct), m_ctx(c), m_owner_lock(owner_lock),
-        m_cache_lock(cache_lock) {
+    C_ReadRequest(CephContext *cct, Context *c, Mutex *cache_lock)
+      : m_cct(cct), m_ctx(c), m_cache_lock(cache_lock) {
     }
     virtual void finish(int r) {
       ldout(m_cct, 20) << "aio_cb completing " << dendl;
       {
-        RWLock::RLocker owner_locker(*m_owner_lock);
         Mutex::Locker cache_locker(*m_cache_lock);
 	m_ctx->complete(r);
       }
@@ -67,7 +64,6 @@ namespace librbd {
   private:
     CephContext *m_cct;
     Context *m_ctx;
-    RWLock *m_owner_lock;
     Mutex *m_cache_lock;
   };
 
@@ -157,7 +153,6 @@ namespace librbd {
       ldout(cct, 20) << this << " C_WriteJournalCommit: "
                      << "journal committed: sending write request" << dendl;
 
-      RWLock::RLocker owner_locker(image_ctx->owner_lock);
       assert(image_ctx->exclusive_lock->is_lock_owner());
 
       request_sent = true;
@@ -199,8 +194,7 @@ namespace librbd {
 			     __u32 trunc_seq, int op_flags, Context *onfinish)
   {
     // on completion, take the mutex and then call onfinish.
-    Context *req = new C_ReadRequest(m_ictx->cct, onfinish, &m_ictx->owner_lock,
-                                     &m_lock);
+    Context *req = new C_ReadRequest(m_ictx->cct, onfinish, &m_lock);
 
     {
       RWLock::RLocker snap_locker(m_ictx->snap_lock);
@@ -257,7 +251,6 @@ namespace librbd {
 				    __u32 trunc_seq, ceph_tid_t journal_tid,
 				    Context *oncommit)
   {
-    assert(m_ictx->owner_lock.is_locked());
     uint64_t object_no = oid_to_object_no(oid.name, m_ictx->object_prefix);
 
     write_result_d *result = new write_result_d(oid.name, oncommit);
@@ -292,7 +285,6 @@ namespace librbd {
                            << "journal_tid=" << original_journal_tid << ", "
                            << "new_journal_tid=" << new_journal_tid << dendl;
 
-    assert(m_ictx->owner_lock.is_locked());
     uint64_t object_no = oid_to_object_no(oid.name, m_ictx->object_prefix);
 
     // all IO operations are flushed prior to closing the journal
@@ -315,14 +307,6 @@ namespace librbd {
 					        it->second, 0);
       }
     }
-  }
-
-  void LibrbdWriteback::get_client_lock() {
-    m_ictx->owner_lock.get_read();
-  }
-
-  void LibrbdWriteback::put_client_lock() {
-    m_ictx->owner_lock.put_read();
   }
 
   void LibrbdWriteback::complete_writes(const std::string& oid)

--- a/src/librbd/LibrbdWriteback.h
+++ b/src/librbd/LibrbdWriteback.h
@@ -44,9 +44,6 @@ namespace librbd {
 				  uint64_t len, ceph_tid_t original_journal_tid,
                                   ceph_tid_t new_journal_tid);
 
-    virtual void get_client_lock();
-    virtual void put_client_lock();
-
     struct write_result_d {
       bool done;
       int ret;

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -31,6 +31,8 @@ librbd_internal_la_SOURCES = \
 	librbd/ObjectWatcher.cc \
 	librbd/Operations.cc \
 	librbd/Utils.cc \
+	librbd/cache/ImageWriteback.cc \
+	librbd/cache/PassthroughImageCache.cc \
 	librbd/exclusive_lock/AcquireRequest.cc \
 	librbd/exclusive_lock/ReacquireRequest.cc \
 	librbd/exclusive_lock/ReleaseRequest.cc \
@@ -123,6 +125,9 @@ noinst_HEADERS += \
 	librbd/TaskFinisher.h \
 	librbd/Utils.h \
 	librbd/WatchNotifyTypes.h \
+	librbd/cache/ImageCache.h \
+	librbd/cache/ImageWriteback.h \
+	librbd/cache/PassthroughImageCache.h \
 	librbd/exclusive_lock/AcquireRequest.h \
 	librbd/exclusive_lock/Policy.h \
 	librbd/exclusive_lock/ReacquireRequest.h \

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -202,7 +202,6 @@ bool ObjectMap::aio_update(uint64_t start_object_no, uint64_t end_object_no,
 {
   assert(m_image_ctx.snap_lock.is_locked());
   assert((m_image_ctx.features & RBD_FEATURE_OBJECT_MAP) != 0);
-  assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.image_watcher != NULL);
   assert(m_image_ctx.exclusive_lock == nullptr ||
          m_image_ctx.exclusive_lock->is_lock_owner());

--- a/src/librbd/cache/ImageCache.h
+++ b/src/librbd/cache/ImageCache.h
@@ -1,0 +1,46 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CACHE_IMAGE_CACHE
+#define CEPH_LIBRBD_CACHE_IMAGE_CACHE
+
+#include "include/buffer_fwd.h"
+#include "include/int_types.h"
+#include <vector>
+
+class Context;
+
+namespace librbd {
+namespace cache {
+
+/**
+ * client-side, image extent cache interface
+ */
+struct ImageCache {
+  typedef std::vector<std::pair<uint64_t,uint64_t> > Extents;
+
+  virtual ~ImageCache() {
+  }
+
+  /// client AIO methods
+  virtual void aio_read(Extents&& image_extents, ceph::bufferlist* bl,
+                        int fadvise_flags, Context *on_finish) = 0;
+  virtual void aio_write(Extents&& image_extents, ceph::bufferlist&& bl,
+                         int fadvise_flags, Context *on_finish) = 0;
+  virtual void aio_discard(uint64_t offset, uint64_t length,
+                           Context *on_finish) = 0;
+  virtual void aio_flush(Context *on_finish) = 0;
+
+  /// internal state methods
+  virtual void init(Context *on_finish) = 0;
+  virtual void shut_down(Context *on_finish) = 0;
+
+  virtual void invalidate(Context *on_finish) = 0;
+  virtual void flush(Context *on_finish) = 0;
+
+};
+
+} // namespace cache
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_CACHE_IMAGE_CACHE

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -4,6 +4,7 @@
 #include "ImageWriteback.h"
 #include "include/buffer.h"
 #include "common/dout.h"
+#include "librbd/AioCompletion.h"
 #include "librbd/AioImageRequest.h"
 #include "librbd/ImageCtx.h"
 
@@ -25,7 +26,13 @@ void ImageWriteback<I>::aio_read(Extents &&image_extents, bufferlist *bl,
   ldout(cct, 20) << "image_extents=" << image_extents << ", "
                  << "on_finish=" << on_finish << dendl;
 
-  // TODO
+  AioCompletion *aio_comp = AioCompletion::create_and_start(on_finish,
+                                                            &m_image_ctx,
+                                                            AIO_TYPE_READ);
+  AioImageRead<I> req(m_image_ctx, aio_comp, std::move(image_extents), nullptr,
+                      bl, fadvise_flags);
+  req.set_bypass_image_cache();
+  req.send();
 }
 
 template <typename I>
@@ -36,7 +43,13 @@ void ImageWriteback<I>::aio_write(Extents &&image_extents,
   ldout(cct, 20) << "image_extents=" << image_extents << ", "
                  << "on_finish=" << on_finish << dendl;
 
-  // TODO
+  AioCompletion *aio_comp = AioCompletion::create_and_start(on_finish,
+                                                            &m_image_ctx,
+                                                            AIO_TYPE_WRITE);
+  AioImageWrite<I> req(m_image_ctx, aio_comp, std::move(image_extents),
+                       std::move(bl), fadvise_flags);
+  req.set_bypass_image_cache();
+  req.send();
 }
 
 template <typename I>
@@ -47,7 +60,12 @@ void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
                  << "length=" << length << ", "
                 << "on_finish=" << on_finish << dendl;
 
-  // TODO
+  AioCompletion *aio_comp = AioCompletion::create_and_start(on_finish,
+                                                            &m_image_ctx,
+                                                            AIO_TYPE_DISCARD);
+  AioImageDiscard<I> req(m_image_ctx, aio_comp, offset, length);
+  req.set_bypass_image_cache();
+  req.send();
 }
 
 template <typename I>
@@ -55,7 +73,12 @@ void ImageWriteback<I>::aio_flush(Context *on_finish) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "on_finish=" << on_finish << dendl;
 
-  // TODO
+  AioCompletion *aio_comp = AioCompletion::create_and_start(on_finish,
+                                                            &m_image_ctx,
+                                                            AIO_TYPE_FLUSH);
+  AioImageFlush<I> req(m_image_ctx, aio_comp);
+  req.set_bypass_image_cache();
+  req.send();
 }
 
 } // namespace cache

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -1,0 +1,65 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "ImageWriteback.h"
+#include "include/buffer.h"
+#include "common/dout.h"
+#include "librbd/AioImageRequest.h"
+#include "librbd/ImageCtx.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::ImageWriteback: " << __func__ << ": "
+
+namespace librbd {
+namespace cache {
+
+template <typename I>
+ImageWriteback<I>::ImageWriteback(I &image_ctx) : m_image_ctx(image_ctx) {
+}
+
+template <typename I>
+void ImageWriteback<I>::aio_read(Extents &&image_extents, bufferlist *bl,
+                                 int fadvise_flags, Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "image_extents=" << image_extents << ", "
+                 << "on_finish=" << on_finish << dendl;
+
+  // TODO
+}
+
+template <typename I>
+void ImageWriteback<I>::aio_write(Extents &&image_extents,
+                                  ceph::bufferlist&& bl,
+                                  int fadvise_flags, Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "image_extents=" << image_extents << ", "
+                 << "on_finish=" << on_finish << dendl;
+
+  // TODO
+}
+
+template <typename I>
+void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
+                                    Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "offset=" << offset << ", "
+                 << "length=" << length << ", "
+                << "on_finish=" << on_finish << dendl;
+
+  // TODO
+}
+
+template <typename I>
+void ImageWriteback<I>::aio_flush(Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "on_finish=" << on_finish << dendl;
+
+  // TODO
+}
+
+} // namespace cache
+} // namespace librbd
+
+template class librbd::cache::ImageWriteback<librbd::ImageCtx>;
+

--- a/src/librbd/cache/ImageWriteback.h
+++ b/src/librbd/cache/ImageWriteback.h
@@ -1,0 +1,46 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CACHE_IMAGE_WRITEBACK
+#define CEPH_LIBRBD_CACHE_IMAGE_WRITEBACK
+
+#include "include/buffer_fwd.h"
+#include "include/int_types.h"
+#include <vector>
+
+class Context;
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace cache {
+
+/**
+ * client-side, image extent cache writeback handler
+ */
+template <typename ImageCtxT = librbd::ImageCtx>
+class ImageWriteback {
+public:
+  typedef std::vector<std::pair<uint64_t,uint64_t> > Extents;
+
+  ImageWriteback(ImageCtxT &image_ctx);
+
+  void aio_read(Extents &&image_extents, ceph::bufferlist *bl,
+                int fadvise_flags, Context *on_finish);
+  void aio_write(Extents &&image_extents, ceph::bufferlist&& bl,
+                 int fadvise_flags, Context *on_finish);
+  void aio_discard(uint64_t offset, uint64_t length, Context *on_finish);
+  void aio_flush(Context *on_finish);
+
+private:
+  ImageCtxT &m_image_ctx;
+
+};
+
+} // namespace cache
+} // namespace librbd
+
+extern template class librbd::cache::ImageWriteback<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_CACHE_IMAGE_WRITEBACK

--- a/src/librbd/cache/PassthroughImageCache.cc
+++ b/src/librbd/cache/PassthroughImageCache.cc
@@ -1,0 +1,103 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "PassthroughImageCache.h"
+#include "include/buffer.h"
+#include "common/dout.h"
+#include "librbd/ImageCtx.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::PassthroughImageCache: " << this << " " \
+                           <<  __func__ << ": "
+
+namespace librbd {
+namespace cache {
+
+template <typename I>
+PassthroughImageCache<I>::PassthroughImageCache(ImageCtx &image_ctx)
+  : m_image_ctx(image_ctx), m_image_writeback(image_ctx) {
+}
+
+template <typename I>
+void PassthroughImageCache<I>::aio_read(Extents &&image_extents, bufferlist *bl,
+                                        int fadvise_flags, Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "image_extents=" << image_extents << ", "
+                 << "on_finish=" << on_finish << dendl;
+
+  m_image_writeback.aio_read(std::move(image_extents), bl, fadvise_flags,
+                             on_finish);
+}
+
+template <typename I>
+void PassthroughImageCache<I>::aio_write(Extents &&image_extents,
+                                         bufferlist&& bl,
+                                         int fadvise_flags,
+                                         Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "image_extents=" << image_extents << ", "
+                 << "on_finish=" << on_finish << dendl;
+
+  m_image_writeback.aio_write(std::move(image_extents), std::move(bl),
+                              fadvise_flags, on_finish);
+}
+
+template <typename I>
+void PassthroughImageCache<I>::aio_discard(uint64_t offset, uint64_t length,
+                                           Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "offset=" << offset << ", "
+                 << "length=" << length << ", "
+                 << "on_finish=" << on_finish << dendl;
+
+  m_image_writeback.aio_discard(offset, length, on_finish);
+}
+
+template <typename I>
+void PassthroughImageCache<I>::aio_flush(Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "on_finish=" << on_finish << dendl;
+
+  m_image_writeback.aio_flush(on_finish);
+}
+
+template <typename I>
+void PassthroughImageCache<I>::init(Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << dendl;
+
+  on_finish->complete(0);
+}
+
+template <typename I>
+void PassthroughImageCache<I>::shut_down(Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << dendl;
+
+  on_finish->complete(0);
+}
+
+template <typename I>
+void PassthroughImageCache<I>::invalidate(Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << dendl;
+
+  // dump cache contents (don't have anything)
+  on_finish->complete(0);
+}
+
+template <typename I>
+void PassthroughImageCache<I>::flush(Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << dendl;
+
+  // internal flush -- nothing to writeback but make sure
+  // in-flight IO is flushed
+  aio_flush(on_finish);
+}
+
+} // namespace cache
+} // namespace librbd
+
+template class librbd::cache::PassthroughImageCache<librbd::ImageCtx>;

--- a/src/librbd/cache/PassthroughImageCache.h
+++ b/src/librbd/cache/PassthroughImageCache.h
@@ -1,0 +1,51 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CACHE_PASSTHROUGH_IMAGE_CACHE
+#define CEPH_LIBRBD_CACHE_PASSTHROUGH_IMAGE_CACHE
+
+#include "ImageCache.h"
+#include "ImageWriteback.h"
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace cache {
+
+/**
+ * Example passthrough client-side, image extent cache
+ */
+template <typename ImageCtxT = librbd::ImageCtx>
+class PassthroughImageCache : public ImageCache {
+public:
+  PassthroughImageCache(ImageCtx &image_ctx);
+
+  /// client AIO methods
+  virtual void aio_read(Extents&& image_extents, ceph::bufferlist *bl,
+                        int fadvise_flags, Context *on_finish);
+  virtual void aio_write(Extents&& image_extents, ceph::bufferlist&& bl,
+                         int fadvise_flags, Context *on_finish);
+  virtual void aio_discard(uint64_t offset, uint64_t length,
+                           Context *on_finish);
+  virtual void aio_flush(Context *on_finish);
+
+  /// internal state methods
+  virtual void init(Context *on_finish);
+  virtual void shut_down(Context *on_finish);
+
+  virtual void invalidate(Context *on_finish);
+  virtual void flush(Context *on_finish);
+
+private:
+  ImageCtxT &m_image_ctx;
+  ImageWriteback<ImageCtxT> m_image_writeback;
+
+};
+
+} // namespace cache
+} // namespace librbd
+
+extern template class librbd::cache::PassthroughImageCache<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_CACHE_PASSTHROUGH_IMAGE_CACHE

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2465,7 +2465,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
       Context *ctx = new C_CopyRead(&throttle, dest, offset, bl);
       AioCompletion *comp = AioCompletion::create_and_start(ctx, src,
                                                             AIO_TYPE_READ);
-      AioImageRequest<>::aio_read(src, comp, offset, len, NULL, bl,
+      AioImageRequest<>::aio_read(src, comp, {{offset, len}}, nullptr, bl,
                                   fadvise_flags);
       prog_ctx.update_progress(offset, src_size);
     }
@@ -2691,7 +2691,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
       C_SaferCond ctx;
       AioCompletion *c = AioCompletion::create_and_start(&ctx, ictx,
                                                          AIO_TYPE_READ);
-      AioImageRequest<>::aio_read(ictx, c, off, read_len, NULL, &bl, 0);
+      AioImageRequest<>::aio_read(ictx, c, {{off, read_len}}, nullptr, &bl, 0);
 
       int ret = ctx.wait();
       if (ret < 0) {

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1749,7 +1749,6 @@ int ObjectCacher::_wait_for_write(OSDWrite *wr, uint64_t len, ObjectSet *oset,
 void ObjectCacher::flusher_entry()
 {
   ldout(cct, 10) << "flusher start" << dendl;
-  writeback_handler.get_client_lock();
   lock.Lock();
   while (!flusher_stop) {
     loff_t all = get_stat_tx() + get_stat_rx() + get_stat_clean() +
@@ -1791,8 +1790,6 @@ void ObjectCacher::flusher_entry()
       if (!max) {
 	// back off the lock to avoid starving other threads
 	lock.Unlock();
-	writeback_handler.put_client_lock();
-	writeback_handler.get_client_lock();
 	lock.Lock();
 	continue;
       }
@@ -1800,12 +1797,7 @@ void ObjectCacher::flusher_entry()
     if (flusher_stop)
       break;
 
-    writeback_handler.put_client_lock();
     flusher_cond.WaitInterval(cct, lock, seconds(1));
-    lock.Unlock();
-
-    writeback_handler.get_client_lock();
-    lock.Lock();
   }
 
   /* Wait for reads to finish. This is only possible if handling
@@ -1821,7 +1813,6 @@ void ObjectCacher::flusher_entry()
   }
 
   lock.Unlock();
-  writeback_handler.put_client_lock();
   ldout(cct, 10) << "flusher finish" << dendl;
 }
 

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -48,9 +48,6 @@ class WritebackHandler {
 			   Context *oncommit) {
     return 0;
   }
-
-  virtual void get_client_lock() {}
-  virtual void put_client_lock() {}
 };
 
 #endif

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -22,6 +22,7 @@
 
 namespace librbd {
 
+namespace cache { class MockImageCache; }
 namespace operation {
 template <typename> class ResizeRequest;
 }
@@ -231,9 +232,10 @@ struct MockImageCtx {
   xlist<AsyncRequest<MockImageCtx>*> async_requests;
   std::list<Context*> async_requests_waiters;
 
-
   MockAioImageRequestWQ *aio_work_queue;
   MockContextWQ *op_work_queue;
+
+  cache::MockImageCache *image_cache = nullptr;
 
   MockReadahead readahead;
   uint64_t readahead_max_bytes;

--- a/src/test/librbd/mock/cache/MockImageCache.h
+++ b/src/test/librbd/mock/cache/MockImageCache.h
@@ -1,0 +1,38 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_LIBRBD_CACHE_MOCK_IMAGE_CACHE_H
+#define CEPH_TEST_LIBRBD_CACHE_MOCK_IMAGE_CACHE_H
+
+#include "gmock/gmock.h"
+#include <vector>
+
+namespace librbd {
+namespace cache {
+
+struct MockImageCache {
+  typedef std::vector<std::pair<uint64_t,uint64_t> > Extents;
+
+  MOCK_METHOD4(aio_read_mock, void(const Extents &, ceph::bufferlist*, int,
+                                   Context *));
+  void aio_read(Extents&& image_extents, ceph::bufferlist* bl,
+                int fadvise_flags, Context *on_finish) {
+    aio_read_mock(image_extents, bl, fadvise_flags, on_finish);
+  }
+
+
+  MOCK_METHOD4(aio_write_mock, void(const Extents &, const ceph::bufferlist &,
+                                    int, Context *));
+  void aio_write(Extents&& image_extents, ceph::bufferlist&& bl,
+                 int fadvise_flags, Context *on_finish) {
+    aio_write_mock(image_extents, bl, fadvise_flags, on_finish);
+  }
+
+  MOCK_METHOD3(aio_discard, void(uint64_t, uint64_t, Context *));
+  MOCK_METHOD1(aio_flush, void(Context *));
+};
+
+} // namespace cache
+} // namespace librbd
+
+#endif // CEPH_TEST_LIBRBD_CACHE_MOCK_IMAGE_CACHE_H

--- a/src/test/librbd/test_mock_AioImageRequest.cc
+++ b/src/test/librbd/test_mock_AioImageRequest.cc
@@ -5,6 +5,7 @@
 #include "test/librbd/test_support.h"
 #include "test/librbd/mock/MockImageCtx.h"
 #include "test/librbd/mock/MockJournal.h"
+#include "test/librbd/mock/cache/MockImageCache.h"
 #include "librbd/AioImageRequest.h"
 #include "librbd/AioObjectRequest.h"
 


### PR DESCRIPTION
Foundational changes to support a persistent, client-side cache for librbd