### PR TITLE
osd: fix sched_time not actually randomized

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6429,7 +6429,7 @@ OSDService::ScrubJob::ScrubJob(const spg_t& pg, const utime_t& timestamp,
       pool_scrub_max_interval : g_conf->osd_scrub_max_interval;
 
     sched_time += scrub_min_interval;
-    double r = rand() / RAND_MAX;
+    double r = rand() / (double)RAND_MAX;
     sched_time +=
       scrub_min_interval * g_conf->osd_scrub_interval_randomize_ratio * r;
     deadline += scrub_max_interval;


### PR DESCRIPTION
The test program:
```c++
main()
{
  for (int i = 0; i < 1000; i++) {
    double before = rand() / RAND_MAX;
    double after = rand() / (double)RAND_MAX;
    cout << "before: " << before << " after: " << after << endl;
  }
}
```
And the output(partial and with "-std=c++11" option):
```
before: 0 after: 0.394383
before: 0 after: 0.79844
before: 0 after: 0.197551
before: 0 after: 0.76823
before: 0 after: 0.55397
before: 0 after: 0.628871
before: 0 after: 0.513401
before: 0 after: 0.916195
before: 0 after: 0.717297
before: 0 after: 0.606969
before: 0 after: 0.242887
before: 0 after: 0.804177
before: 0 after: 0.400944
before: 0 after: 0.108809
before: 0 after: 0.218257
before: 0 after: 0.839112
before: 0 after: 0.296032
before: 0 after: 0.524287
```
Fixes: http://tracker.ceph.com/issues/15890
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>