### PR TITLE
common: CompatSet.h: Remove unneeded constuctor

### DIFF
--- a/src/include/CompatSet.h
+++ b/src/include/CompatSet.h
@@ -25,7 +25,6 @@ struct CompatSet {
     uint64_t id;
     string name;
 
-    Feature(uint64_t _id, const char *_name) : id(_id), name(_name) {}
     Feature(uint64_t _id, const string& _name) : id(_id), name(_name) {}
   };
 


### PR DESCRIPTION
We have a constuctor taking a std::string so there is no need for
the constuctor taking char*.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>