### PR TITLE
osd: replace ceph:atomic_t with std::atomic in osd module.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -239,7 +239,6 @@ OSDService::OSDService(OSD *osd) :
   agent_stop_flag(false),
   agent_timer_lock("OSDService::agent_timer_lock"),
   agent_timer(osd->client_messenger->cct, agent_timer_lock),
-  promote_probability_millis(1000),
   last_recalibrate(ceph_clock_now(NULL)),
   promote_max_objects(0),
   promote_max_bytes(0),
@@ -250,7 +249,6 @@ OSDService::OSDService(OSD *osd) :
   next_notif_id(0),
   backfill_request_lock("OSDService::backfill_request_lock"),
   backfill_request_timer(cct, backfill_request_lock, false),
-  last_tid(0),
   reserver_finisher(cct),
   local_reserver(&reserver_finisher, cct->_conf->osd_max_backfills,
 		 cct->_conf->osd_min_recovery_priority),
@@ -273,8 +271,7 @@ OSDService::OSDService(OSD *osd) :
   cur_ratio(0),
   epoch_lock("OSDService::epoch_lock"),
   boot_epoch(0), up_epoch(0), bind_epoch(0),
-  is_stopping_lock("OSDService::is_stopping_lock"),
-  state(NOT_STOPPING)
+  is_stopping_lock("OSDService::is_stopping_lock")
 #ifdef PG_DEBUG_REFS
   , pgid_lock("OSDService::pgid_lock")
 #endif
@@ -617,7 +614,7 @@ void OSDService::promote_throttle_recalibrate()
   utime_t now = ceph_clock_now(NULL);
   double dur = now - last_recalibrate;
   last_recalibrate = now;
-  unsigned prob = promote_probability_millis.read();
+  unsigned prob = promote_probability_millis;
 
   uint64_t target_obj_sec = g_conf->osd_tier_promote_max_objects_sec;
   uint64_t target_bytes_sec = g_conf->osd_tier_promote_max_bytes_sec;
@@ -674,9 +671,9 @@ void OSDService::promote_throttle_recalibrate()
   dout(10) << __func__ << "  actual " << actual
 	   << ", actual/prob ratio " << ratio
 	   << ", adjusted new_prob " << new_prob
-	   << ", prob " << promote_probability_millis.read() << " -> " << prob
+	   << ", prob " << promote_probability_millis << " -> " << prob
 	   << dendl;
-  promote_probability_millis.set(prob);
+  promote_probability_millis = prob;
 
   // set hard limits for this interval to mitigate stampedes
   promote_max_objects = target_obj_sec * OSD::OSD_TICK_INTERVAL * 2;
@@ -1656,7 +1653,6 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
   dev_path(dev), journal_path(jdev),
   asok_hook(NULL),
   osd_compat(get_osd_compat_set()),
-  state(STATE_INITIALIZING),
   osd_tp(cct, "OSD::osd_tp", "tp_osd", cct->_conf->osd_op_threads, "osd_op_threads"),
   osd_op_tp(cct, "OSD::osd_op_tp", "tp_osd_tp",
     cct->_conf->osd_op_num_threads_per_shard * cct->_conf->osd_op_num_shards),
@@ -2742,9 +2738,9 @@ int OSD::shutdown()
         ++p) {
       dout(20) << " kicking pg " << p->first << dendl;
       p->second->lock();
-      if (p->second->ref.read() != 1) {
+      if (p->second->ref != 1) {
         derr << "pgid " << p->first << " has ref count of "
-            << p->second->ref.read() << dendl;
+            << p->second->ref << dendl;
 #ifdef PG_DEBUG_REFS
 	p->second->dump_live_ids();
 #endif

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -817,7 +817,7 @@ public:
 
 private:
   /// throttle promotion attempts
-  atomic_t promote_probability_millis; ///< probability thousands. one word.
+  std::atomic_uint promote_probability_millis{1000}; ///< probability thousands. one word.
   PromoteCounter promote_counter;
   utime_t last_recalibrate;
   unsigned long promote_max_objects, promote_max_bytes;
@@ -826,13 +826,13 @@ public:
   bool promote_throttle() {
     // NOTE: lockless!  we rely on the probability being a single word.
     promote_counter.attempt();
-    if ((unsigned)rand() % 1000 > promote_probability_millis.read())
+    if ((unsigned)rand() % 1000 > promote_probability_millis)
       return true;  // yes throttle (no promote)
     if (promote_max_objects &&
-	promote_counter.objects.read() > promote_max_objects)
+	promote_counter.objects > promote_max_objects)
       return true;  // yes throttle
     if (promote_max_bytes &&
-	promote_counter.bytes.read() > promote_max_bytes)
+	promote_counter.bytes > promote_max_bytes)
       return true;  // yes throttle
     return false;   //  no throttle (promote)
   }
@@ -861,9 +861,9 @@ public:
 
   // -- tids --
   // for ops i issue
-  atomic_t last_tid;
+  std::atomic_uint last_tid{0};
   ceph_tid_t get_tid() {
-    return (ceph_tid_t)last_tid.inc();
+    return (ceph_tid_t)last_tid++;
   }
 
   // -- backfill_reservation --
@@ -1124,18 +1124,18 @@ public:
     NOT_STOPPING,
     PREPARING_TO_STOP,
     STOPPING };
-  atomic_t state;
+  std::atomic_int state{NOT_STOPPING};
   int get_state() {
-    return state.read();
+    return state;
   }
   void set_state(int s) {
-    state.set(s);
+    state = s;
   }
   bool is_stopping() {
-    return get_state() == STOPPING;
+    return state == STOPPING;
   }
   bool is_preparing_to_stop() {
-    return get_state() == PREPARING_TO_STOP;
+    return state == PREPARING_TO_STOP;
   }
   bool prepare_to_stop();
   void got_stop_ack();
@@ -1338,32 +1338,32 @@ public:
   }
 
 private:
-  atomic_t state;
+  std::atomic_int state{STATE_INITIALIZING};
 
 public:
   int get_state() {
-    return state.read();
+    return state;
   }
   void set_state(int s) {
-    state.set(s);
+    state = s;
   }
   bool is_initializing() {
-    return get_state() == STATE_INITIALIZING;
+    return state == STATE_INITIALIZING;
   }
   bool is_preboot() {
-    return get_state() == STATE_PREBOOT;
+    return state == STATE_PREBOOT;
   }
   bool is_booting() {
-    return get_state() == STATE_BOOTING;
+    return state == STATE_BOOTING;
   }
   bool is_active() {
-    return get_state() == STATE_ACTIVE;
+    return state == STATE_ACTIVE;
   }
   bool is_stopping() {
-    return get_state() == STATE_STOPPING;
+    return state == STATE_STOPPING;
   }
   bool is_waiting_for_healthy() {
-    return get_state() == STATE_WAITING_FOR_HEALTHY;
+    return state == STATE_WAITING_FOR_HEALTHY;
   }
 
 private:

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -84,7 +84,7 @@ static ostream& _prefix(std::ostream *_dout, T *t)
 
 void PG::get(const char* tag)
 {
-  ref.inc();
+  ref++;
 #ifdef PG_DEBUG_REFS
   Mutex::Locker l(_ref_id_lock);
   if (!_tag_counts.count(tag)) {
@@ -106,14 +106,14 @@ void PG::put(const char* tag)
     }
   }
 #endif
-  if (ref.dec() == 0)
+  if (--ref== 0)
     delete this;
 }
 
 #ifdef PG_DEBUG_REFS
 uint64_t PG::get_with_id()
 {
-  ref.inc();
+  ref++;
   Mutex::Locker l(_ref_id_lock);
   uint64_t id = ++_ref_id;
   BackTrace bt(0);
@@ -133,7 +133,7 @@ void PG::put_with_id(uint64_t id)
     assert(_live_ids.count(id));
     _live_ids.erase(id);
   }
-  if (ref.dec() == 0)
+  if (--ref == 0)
     delete this;
 }
 
@@ -208,7 +208,6 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   map_lock("PG::map_lock"),
   osdmap_ref(curmap), last_persisted_osdmap_ref(curmap), pool(_pool),
   _lock("PG::_lock"),
-  ref(0),
   #ifdef PG_DEBUG_REFS
   _ref_id_lock("PG::_ref_id_lock"), _ref_id(0),
   #endif

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -32,7 +32,6 @@
 #include "include/stringify.h"
 #include "osd_types.h"
 #include "include/xlist.h"
-#include "include/atomic.h"
 #include "SnapMapper.h"
 
 #include "PGLog.h"
@@ -41,6 +40,7 @@
 #include "include/str_list.h"
 #include "PGBackend.h"
 
+#include <atomic>
 #include <list>
 #include <memory>
 #include <string>
@@ -251,7 +251,7 @@ protected:
    * put_unlock() when done with the current pointer (_most common_).
    */  
   mutable Mutex _lock;
-  atomic_t ref;
+  std::atomic_uint ref{0};
 
 #ifdef PG_DEBUG_REFS
   Mutex _ref_id_lock;


### PR DESCRIPTION
trying to use std more, and atomic_t easier to use and no need
t implement more interfaces, like operator++,++ etc.

Signed-off-by: Xiaowei Chen <chen.xiaowei@h3c.com>