### PR TITLE
PG: rename state WaitActingChange

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7459,7 +7459,7 @@ void PG::RecoveryState::GetLog::exit()
 /*------WaitActingChange--------*/
 PG::RecoveryState::WaitActingChange::WaitActingChange(my_context ctx)
   : my_base(ctx),
-    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Peering/WaitActingChange")
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/WaitActingChange")
 {
   context< RecoveryMachine >().log_enter(state_name);
 }


### PR DESCRIPTION
State 'WaitActingChange' does not belong to state 'Peering', so it may
be better to rename it to 'Started/Primary/WaitActingChange' to make it
less confusing.

Signed-off-by: wuxingyi <wuxingyi@letv.com>