### PR TITLE
doc: update required packages list to build doc

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -7,16 +7,31 @@ TOPDIR=`pwd`
 install -d -m0755 build-doc
 
 if command -v dpkg >/dev/null; then
-    for package in python-dev python-pip python-virtualenv doxygen ditaa ant libxml2-dev libxslt1-dev zlib1g-dev cython graphviz; do
-	if [ "$(dpkg --status -- $package|sed -n 's/^Status: //p')" != "install ok installed" ]; then
-            # add a space after old values
-	    missing="${missing:+$missing }$package"
-	fi
+    packages='
+      git
+      gcc
+      python-dev
+      python-pip
+      python-virtualenv
+      libxml2-dev
+      libxslt1-dev
+      doxygen
+      ditaa
+      graphviz
+      ant
+      cython
+      librbd-dev
+      zlib1g-dev'
+    for package in $packages; do
+    if [ "$(dpkg --status -- $package 2>&1 | sed -n 's/^Status: //p')" != "install ok installed" ]; then
+        # add a space after old values
+        missing="${missing:+$missing }$package"
+    fi
     done
     if [ -n "$missing" ]; then
-	echo "$0: missing required packages, please install them:" 1>&2
-	echo "sudo apt-get install $missing"
-	exit 1
+        echo "$0: missing required packages, please install them:" 1>&2
+        echo "sudo apt-get install -o APT::Install-Recommends=true $missing" 1>&2
+        exit 1
     fi
 elif command -v yum >/dev/null; then
     for package in python-devel python-pip python-virtualenv doxygen ditaa ant libxml-devel libxslt-devel Cython graphviz; do

--- a/doc/dev/generatedocs.rst
+++ b/doc/dev/generatedocs.rst
@@ -28,32 +28,22 @@ You should have a full copy of the Ceph repository.
 Install the Required Tools
 --------------------------
 
-To build the Ceph documentation, the following packages are required on
-Ubuntu 14.04:
+To build the Ceph documentation, some dependencies are required.
+To know what packages are needed, you can launch this command::
 
-- ``python-dev``
-- ``python-pip``
-- ``python-virtualenv``
-- ``libxml2-dev``
-- ``libxslt-dev``
-- ``doxygen``
-- ``ditaa``
-- ``graphviz``
-- ``ant``
-- ``cython``
-- ``librbd-dev``
+    cd ceph
+    admin/build-doc
 
-Execute ``apt-get install`` for each dependency that isn't installed
-on your host.::
-
-	sudo apt-get install python-dev python-pip python-virtualenv libxml2-dev libxslt-dev doxygen ditaa graphviz ant cython librbd-dev
-
+If dependencies are missing, the command above will fail
+with a message that suggests you a command to install all
+missing dependencies.
 
 
 Build the Documents
 -------------------
 
-Once you have installed all the dependencies, execute the build::
+Once you have installed all the dependencies, execute the build (the
+same command as above)::
 
 	cd ceph
 	admin/build-doc


### PR DESCRIPTION
* The package "zlib1g-dev" is needed and was not mentioned.
* "gcc" and "virtualenv" packages are added explicitly, because
  these packages can be not installed if APT::Install-Recommends
  is set to "false" (personally it's my case in all my Debian
  distributions).
* Debian Jessie and Ubuntu Xenial cases are added.

Signed-off-by: François Lafont <francois.lafont@ac-versailles.fr>