### PR TITLE
osd: optimize header file dependency to decreace compile time when modify any file

### DIFF
--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -2,10 +2,9 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "include/types.h"
-#include "msg/Message.h"
-#include "osd/OSD.h"
 #include "ClassHandler.h"
 #include "common/errno.h"
+#include "common/ceph_context.h"
 
 #include <dlfcn.h>
 
@@ -16,6 +15,7 @@
 #endif
 
 #include "common/config.h"
+#include "common/debug.h"
 
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix

--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -2,13 +2,11 @@
 #define CEPH_CLASSHANDLER_H
 
 #include "include/types.h"
-
 #include "objclass/objclass.h"
-
-#include "common/Cond.h"
 #include "common/Mutex.h"
-#include "common/ceph_context.h"
 
+//forward declaration
+class CephContext;
 
 class ClassHandler
 {

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -12,18 +12,19 @@
  *
  */
 
-#include <boost/variant.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <iostream>
 #include <sstream>
 
-#include "ECUtil.h"
 #include "ECBackend.h"
 #include "messages/MOSDPGPush.h"
 #include "messages/MOSDPGPushReply.h"
-#include "ReplicatedPG.h"
+#include "messages/MOSDECSubOpWrite.h"
+#include "messages/MOSDECSubOpWriteReply.h"
+#include "messages/MOSDECSubOpRead.h"
+#include "messages/MOSDECSubOpReadReply.h"
+#include "ECMsgTypes.h"
 
-class ReplicatedPG;
+#include "ReplicatedPG.h"
 
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -18,13 +18,15 @@
 #include "OSD.h"
 #include "PGBackend.h"
 #include "erasure-code/ErasureCodeInterface.h"
-#include "ECTransaction.h"
-#include "ECMsgTypes.h"
 #include "ECUtil.h"
-#include "messages/MOSDECSubOpWrite.h"
-#include "messages/MOSDECSubOpWriteReply.h"
-#include "messages/MOSDECSubOpRead.h"
-#include "messages/MOSDECSubOpReadReply.h"
+#include "ECTransaction.h"
+
+//forward declaration
+struct ECSubWrite;
+struct ECSubWriteReply;
+struct ECSubRead;
+struct ECSubReadReply;
+class ECTransaction;
 
 struct RecoveryMessages;
 class ECBackend : public PGBackend {

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -12,13 +12,11 @@
  *
  */
 
-#include <boost/variant.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <iostream>
 #include <vector>
 #include <sstream>
 
-#include "ECBackend.h"
+#include "ECTransaction.h"
 #include "ECUtil.h"
 #include "os/ObjectStore.h"
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -113,8 +113,10 @@
 #include "common/perf_counters.h"
 #include "common/Timer.h"
 #include "common/LogClient.h"
+#include "common/AsyncReserver.h"
 #include "common/HeartbeatMap.h"
 #include "common/admin_socket.h"
+#include "common/ceph_context.h"
 
 #include "global/signal_handler.h"
 #include "global/pidfile.h"
@@ -123,11 +125,9 @@
 #include "perfglue/cpu_profiler.h"
 #include "perfglue/heap_profiler.h"
 
-#include "osd/ClassHandler.h"
 #include "osd/OpRequest.h"
 
 #include "auth/AuthAuthorizeHandler.h"
-
 #include "common/errno.h"
 
 #include "objclass/objclass.h"

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -15,8 +15,6 @@
 #ifndef CEPH_OSD_H
 #define CEPH_OSD_H
 
-#include "boost/tuple/tuple.hpp"
-
 #include "PG.h"
 
 #include "msg/Dispatcher.h"
@@ -25,19 +23,15 @@
 #include "common/RWLock.h"
 #include "common/Timer.h"
 #include "common/WorkQueue.h"
-#include "common/LogClient.h"
 #include "common/AsyncReserver.h"
-#include "common/ceph_context.h"
-
 #include "os/ObjectStore.h"
-#include "OSDCap.h"
-
+#include "OSDCap.h" 
+ 
+#include "auth/KeyRing.h"
 #include "osd/ClassHandler.h"
 
 #include "include/CompatSet.h"
 
-#include "auth/KeyRing.h"
-#include "messages/MOSDRepScrub.h"
 #include "OpRequest.h"
 
 #include <atomic>
@@ -48,13 +42,11 @@ using namespace std;
 
 #include "include/unordered_map.h"
 
-#include "Watch.h"
 #include "common/shared_cache.hpp"
 #include "common/simple_cache.hpp"
 #include "common/sharedptr_registry.hpp"
 #include "common/WeightedPriorityQueue.h"
 #include "common/PrioritizedQueue.h"
-#include "common/OpQueue.h"
 #include "messages/MOSDOp.h"
 #include "include/Spinlock.h"
 
@@ -222,8 +214,10 @@ class OpsFlightSocketHook;
 class HistoricOpsSocketHook;
 class TestOpsSocketHook;
 struct C_CompleteSplits;
-
+class LogChannel;
+class CephContext;
 typedef ceph::shared_ptr<ObjectStore::Sequencer> SequencerRef;
+class MOSDOp;
 
 class DeletingState {
   Mutex lock;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -22,12 +22,12 @@
 #include "common/TextTable.h"
 #include "include/ceph_features.h"
 #include "include/str_map.h"
-#include "include/stringify.h"
 
 #include "common/code_environment.h"
 
 #include "crush/CrushTreeDumper.h"
-
+#include "common/Clock.h"
+ 
 #define dout_subsys ceph_subsys_osd
 
 // ----------------------------------

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -24,16 +24,11 @@
  *   disks, disk groups, total # osds,
  *
  */
-#include "common/config.h"
 #include "include/types.h"
 #include "osd_types.h"
 
-#include "include/ceph_features.h"
-
+//#include "include/ceph_features.h"
 #include "crush/CrushWrapper.h"
-
-#include "include/interval_set.h"
-
 #include <vector>
 #include <list>
 #include <set>
@@ -41,7 +36,9 @@
 #include "include/memory.h"
 using namespace std;
 
-
+//forward declaration
+class CephContext;
+class CrushWrapper;
 /*
  * we track up to two intervals during which the osd was alive and
  * healthy.  the most recent is [up_from,up_thru), where up_thru is

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -13,6 +13,11 @@
  */
 
 #include "PG.h"
+// #include "msg/Messenger.h"
+#include "messages/MOSDRepScrub.h"
+// #include "common/cmdparse.h"
+// #include "common/ceph_context.h"
+
 #include "common/errno.h"
 #include "common/config.h"
 #include "OSD.h"
@@ -23,7 +28,7 @@
 
 #include "messages/MOSDOp.h"
 #include "messages/MOSDPGNotify.h"
-#include "messages/MOSDPGLog.h"
+// #include "messages/MOSDPGLog.h"
 #include "messages/MOSDPGRemove.h"
 #include "messages/MOSDPGInfo.h"
 #include "messages/MOSDPGTrim.h"

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -31,22 +31,13 @@
 #include "include/types.h"
 #include "include/stringify.h"
 #include "osd_types.h"
-#include "include/buffer_fwd.h"
 #include "include/xlist.h"
 #include "include/atomic.h"
 #include "SnapMapper.h"
 
 #include "PGLog.h"
-#include "OpRequest.h"
 #include "OSDMap.h"
-#include "os/ObjectStore.h"
-#include "msg/Messenger.h"
-#include "messages/MOSDRepScrub.h"
 #include "messages/MOSDPGLog.h"
-#include "common/cmdparse.h"
-#include "common/tracked_int_ptr.hpp"
-#include "common/WorkQueue.h"
-#include "common/ceph_context.h"
 #include "include/str_list.h"
 #include "PGBackend.h"
 
@@ -55,8 +46,8 @@
 #include <string>
 using namespace std;
 
-#include "include/unordered_map.h"
-#include "include/unordered_set.h"
+// #include "include/unordered_map.h"
+// #include "include/unordered_set.h"
 
 
 //#define DEBUG_RECOVERY_OIDS   // track set of recovering oids explicitly, to find counting bugs
@@ -71,6 +62,10 @@ class MOSDPGBackfill;
 class MOSDPGInfo;
 
 class PG;
+struct OpRequest;
+typedef OpRequest::Ref OpRequestRef;
+class MOSDPGLog;
+class CephContext;
 
 namespace Scrub {
   class Store;
@@ -80,6 +75,7 @@ void intrusive_ptr_add_ref(PG *pg);
 void intrusive_ptr_release(PG *pg);
 
 #ifdef PG_DEBUG_REFS
+#include "common/tracked_int_ptr.hpp"
   uint64_t get_with_id(PG *pg);
   void put_with_id(PG *pg, uint64_t id);
   typedef TrackedIntPtr<PG> PGRef;

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -24,6 +24,9 @@
 #include "PGBackend.h"
 #include "OSD.h"
 #include "erasure-code/ErasureCodePlugin.h"
+#include "OSDMap.h"
+#include "PGLog.h"
+#include "common/LogClient.h"
 
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -18,8 +18,6 @@
 #ifndef PGBACKEND_H
 #define PGBACKEND_H
 
-#include "OSDMap.h"
-#include "PGLog.h"
 #include "osd_types.h"
 #include "common/WorkQueue.h"
 #include "include/Context.h"
@@ -31,6 +29,11 @@ namespace Scrub {
   class Store;
 }
 struct shard_info_wrapper;
+
+//forward declaration
+class OSDMap;
+class PGLog;
+typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
 
  /**
   * PGBackend

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -16,9 +16,8 @@
  */
 
 #include "PGLog.h"
-#include "PG.h"
-#include "SnapMapper.h"
-#include "../include/unordered_map.h"
+#include "include/unordered_map.h"
+#include "common/ceph_context.h"
 
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -21,7 +21,6 @@
 #include "include/assert.h" 
 #include "osd_types.h"
 #include "os/ObjectStore.h"
-#include "common/ceph_context.h"
 #include <list>
 using namespace std;
 
@@ -29,6 +28,8 @@ using namespace std;
 #define PGLOG_INDEXED_CALLER_OPS       (1 << 1)
 #define PGLOG_INDEXED_EXTRA_CALLER_OPS (1 << 2)
 #define PGLOG_INDEXED_ALL              (PGLOG_INDEXED_OBJECTS | PGLOG_INDEXED_CALLER_OPS | PGLOG_INDEXED_EXTRA_CALLER_OPS)
+
+class CephContext;
 
 struct PGLog : DoutPrefixProvider {
   DoutPrefixProvider *prefix_provider;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -28,40 +28,21 @@
 #include "common/perf_counters.h"
 
 #include "messages/MOSDOp.h"
-#include "messages/MOSDOpReply.h"
 #include "messages/MOSDSubOp.h"
 #include "messages/MOSDSubOpReply.h"
-#include "messages/MOSDRepOp.h"
-#include "messages/MOSDRepOpReply.h"
-
-#include "messages/MOSDPGNotify.h"
-#include "messages/MOSDPGInfo.h"
-#include "messages/MOSDPGRemove.h"
 #include "messages/MOSDPGTrim.h"
 #include "messages/MOSDPGScan.h"
+#include "messages/MOSDRepScrub.h"
 #include "messages/MOSDPGBackfill.h"
-
-#include "messages/MOSDPing.h"
-#include "messages/MWatchNotify.h"
-
-#include "messages/MOSDPGPush.h"
-#include "messages/MOSDPGPull.h"
-#include "messages/MOSDPGPushReply.h"
 #include "messages/MOSDPGUpdateLogMissing.h"
 #include "messages/MOSDPGUpdateLogMissingReply.h"
 #include "messages/MCommandReply.h"
-
-#include "Watch.h"
-
 #include "mds/inode_backtrace.h" // Ugh
 
 #include "common/config.h"
 #include "include/compat.h"
-#include "common/cmdparse.h"
-
 #include "mon/MonClient.h"
 #include "osdc/Objecter.h"
-
 #include "json_spirit/json_spirit_value.h"
 #include "json_spirit/json_spirit_reader.h"
 #include "include/assert.h"  // json_spirit clobbers it

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -17,29 +17,14 @@
 #ifndef CEPH_REPLICATEDPG_H
 #define CEPH_REPLICATEDPG_H
 
-#include <boost/optional/optional_io.hpp>
 #include <boost/tuple/tuple.hpp>
-
 #include "include/assert.h" 
-#include "include/unordered_map.h"
-#include "common/cmdparse.h"
-
-#include "HitSet.h"
-#include "OSD.h"
 #include "PG.h"
 #include "Watch.h"
-#include "OpRequest.h"
 #include "TierAgentState.h"
-
-#include "messages/MOSDOp.h"
 #include "messages/MOSDOpReply.h"
-#include "messages/MOSDSubOp.h"
-
 #include "common/sharedptr_registry.hpp"
-
-#include "PGBackend.h"
 #include "ReplicatedBackend.h"
-#include "ECBackend.h"
 
 class MOSDSubOpReply;
 
@@ -48,6 +33,13 @@ class PromoteCallback;
 
 class ReplicatedPG;
 class PGLSFilter;
+class HitSet;
+struct TierAgentState;
+class MOSDOp;
+class MOSDOpReply;
+class MOSDSubOp;
+class OSDService;
+
 void intrusive_ptr_add_ref(ReplicatedPG *pg);
 void intrusive_ptr_release(ReplicatedPG *pg);
 uint64_t get_with_id(ReplicatedPG *pg);

--- a/src/osd/Watch.h
+++ b/src/osd/Watch.h
@@ -14,13 +14,11 @@
 #ifndef CEPH_WATCH_H
 #define CEPH_WATCH_H
 
-#include <boost/intrusive_ptr.hpp>
 #include "include/memory.h"
 #include <set>
 
 #include "msg/Messenger.h"
 #include "include/Context.h"
-#include "common/Mutex.h"
 
 enum WatcherState {
   WATCHER_PENDING,


### PR DESCRIPTION
1、hmm, everytime modify any file, then compile, then wait&wait&wait, so trying to optimize
    this part, wish to decrease header dependency, try to improve compile speed.
optimization include OSD, PG, PGBackend layer.

2、 I am wandering whether OSD and OSDService can be separated into two single file,
    so other file don't need to ref osd.h, osd.h changed will not affect too much.