### PR TITLE
osd: dump full map bl at 20 when crc doesn't match

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6303,6 +6303,9 @@ void OSD::handle_osd_map(MOSDMap *m)
 		<< " but failed to encode full with correct crc; requesting"
 		<< dendl;
 	clog->warn() << "failed to encode map e" << e << " with expected crc\n";
+	dout(20) << "my encoded map was:\n";
+	fbl.hexdump(*_dout);
+	*_dout << dendl;
 	delete o;
 	MMonGetOSDMap *req = new MMonGetOSDMap;
 	req->request_full(e, last);


### PR DESCRIPTION
This will help us debug cases where the encoding doesn't match due
to a bug.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit bfe359af0b80f44ca04847f74d5a2d81097ce4e6)