### PR TITLE
rgw: misc fix for test_multi.py

### DIFF
--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -507,8 +507,6 @@ class RGWMulti:
         user = RGWUser('tester', '"Test User"', gen_access_key(), gen_secret())
         realm.create_user(user)
 
-        realm.meta_checkpoint()
-
 def check_all_buckets_exist(zone, buckets):
     conn = zone.get_connection(user)
 


### PR DESCRIPTION
 rgw: misc fix for test_multi.p

remove redundent meta_checkpoint, cause realm.create_user(user) will
call meta_checkpoint by default(via wait_meta = True).
