### PR TITLE
ceph.in: fix exception when pool name has non-ascii characters

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -892,7 +892,7 @@ def main():
 
         if ret < 0:
             ret = -ret
-            print('Error {0}: {1}'.format(errno.errorcode.get(ret, 'Unknown'), outs), file=sys.stderr)
+            print(u'Error {0}: {1}'.format(errno.errorcode.get(ret, 'Unknown'), outs), file=sys.stderr)
             if len(targets) > 1:
                 final_ret = ret
             else:


### PR DESCRIPTION
When deleting a pool without the --i-really-really-mean-it option, if the pool name has non-ascii characters, the format of the command message raises a UnicodeEncodeError exception.

Fixes: http://tracker.ceph.com/issues/15913

Signed-off-by: Ricardo Dias <rdias@suse.com>