### PR TITLE
librados:  For C-API, expose LIBRADOS_OPERATION_FULL_FORCE flag

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -124,6 +124,10 @@ enum {
      full; ops will either succeed (e.g., delete) or return EDQUOT or
      ENOSPC. */
   LIBRADOS_OPERATION_FULL_TRY           = 64,
+  /*
+   * Mainly for delete op
+   */
+  LIBRADOS_OPERATION_FULL_FORCE		= 128,
 };
 /** @} */
 

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -278,6 +278,8 @@ namespace librados
     // marked full; ops will either succeed (e.g., delete) or return
     // EDQUOT or ENOSPC
     OPERATION_FULL_TRY           = LIBRADOS_OPERATION_FULL_TRY,
+    //mainly for delete
+    OPERATION_FULL_FORCE	 = LIBRADOS_OPERATION_FULL_FORCE,
   };
 
   /*

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -1423,6 +1423,8 @@ static int translate_flags(int flags)
     op_flags |= CEPH_OSD_FLAG_IGNORE_OVERLAY;
   if (flags & librados::OPERATION_FULL_TRY)
     op_flags |= CEPH_OSD_FLAG_FULL_TRY;
+  if (flags & librados::OPERATION_FULL_FORCE)
+    op_flags |= CEPH_OSD_FLAG_FULL_FORCE;
 
   return op_flags;
 }


### PR DESCRIPTION
Make librados c-api can use LIBRADOS_OPERATION_FULL_FORCE. This maily
for delete op.

Signed-off-by: Jianpeng Ma jianpeng.ma@intel.com
