### PR TITLE
os/bluestore: If using sync_wal_apply, no need start wal_tp thread.

### DIFF
--- a/src/common/WorkQueue.cc
+++ b/src/common/WorkQueue.cc
@@ -78,7 +78,7 @@ void ThreadPool::handle_conf_change(const struct md_config_t *conf,
     assert(r >= 0);
     int v = atoi(buf);
     free(buf);
-    if (v > 0) {
+    if (v >= 0) {
       _lock.Lock();
       _num_threads = v;
       start_threads();

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -650,13 +650,14 @@ void md_config_t::_apply_changes(std::ostream *oss)
     }
   }
 
+  changed.clear();
+
   // Make any pending observer callbacks
   for (rev_obs_map_t::const_iterator r = robs.begin(); r != robs.end(); ++r) {
     md_config_obs_t *obs = r->first;
     obs->handle_conf_change(this, r->second);
   }
 
-  changed.clear();
 }
 
 void md_config_t::call_all_observers()

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -936,7 +936,8 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
     kv_stop(false),
     logger(NULL),
     csum_type(bluestore_blob_t::CSUM_CRC32C),
-    min_alloc_size(0)
+    min_alloc_size(0),
+    sync_wal_apply(cct->_conf->bluestore_sync_wal_apply)
 {
   _init_logger();
   g_ceph_context->_conf->add_observer(this);
@@ -4229,7 +4230,7 @@ void BlueStore::_txc_state_proc(TransContext *txc)
       txc->log_state_latency(logger, l_bluestore_state_kv_done_lat);
       if (txc->wal_txn) {
 	txc->state = TransContext::STATE_WAL_QUEUED;
-	if (g_conf->bluestore_sync_wal_apply) {
+	if (sync_wal_apply) {
 	  _wal_apply(txc);
 	} else {
 	  wal_wq.queue(txc);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -925,7 +925,7 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
     wal_tp(cct,
 	   "BlueStore::wal_tp",
            "tp_wal",
-	   cct->_conf->bluestore_wal_threads,
+	   cct->_conf->bluestore_sync_wal_apply ? 0 : cct->_conf->bluestore_wal_threads,
 	   "bluestore_wal_threads"),
     wal_wq(this,
 	     cct->_conf->bluestore_wal_thread_timeout,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -822,6 +822,8 @@ private:
 
   uint64_t min_alloc_size; ///< minimum allocation unit (power of 2)
 
+  bool sync_wal_apply;	  ///< see config option bluestore_sync_wal_apply
+
   // compression options
   enum CompressionMode {
     COMP_NONE,                  ///< compress never

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -749,11 +749,6 @@ public:
     }
 
     void flush() {
-      lock();
-      while (!wal_queue.empty()) {
-	_wait();
-      }
-      unlock();
       drain();
     }
   };


### PR DESCRIPTION
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>