### PR TITLE
rbd-mirror: explicitly disable status updates on stopping replay

### DIFF
--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -325,6 +325,7 @@ void ImageReplayer<I>::start(Context *on_finish,
       m_state_desc.clear();
       m_on_start_finish = on_finish;
       m_manual_stop = false;
+      m_update_status_enabled = true;
     }
   }
 
@@ -1061,9 +1062,16 @@ void ImageReplayer<I>::update_mirror_image_status(bool final,
   {
     Mutex::Locker locker(m_lock);
 
+    if (!m_update_status_enabled) {
+      dout(10) << "update status disabled" << dendl;
+      return;
+    }
+
     assert(!final || !is_running_());
 
-    if (!final) {
+    if (final) {
+      m_update_status_enabled = false;
+    } else {
       if (expected_state != STATE_UNKNOWN && expected_state != m_state) {
 	dout(20) << "state changed" << dendl;
 	return;

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -227,6 +227,7 @@ private:
   int m_update_status_interval = 0;
   librados::AioCompletion *m_update_status_comp = nullptr;
   bool m_update_status_pending = false;
+  bool m_update_status_enabled = false;
   bool m_stop_requested = false;
   bool m_manual_stop = false;
 


### PR DESCRIPTION
Otherwise, there is still a chance of delayed update being fired by a
working thread after m_local_ioctx is destroyed.

Fixes: http://tracker.ceph.com/issues/15917
Signed-off-by: Mykola Golub <mgolub@mirantis.com>