### PR TITLE
build: freebsd changes, part 2

### DIFF
--- a/src/common/Graylog.cc
+++ b/src/common/Graylog.cc
@@ -85,7 +85,7 @@ void Graylog::log_entry(Entry const * const e)
     m_formatter->dump_string("short_message", s);
     m_formatter->dump_string("_app", "ceph");
     m_formatter->dump_float("timestamp", e->m_stamp.sec() + (e->m_stamp.usec() / 1000000.0));
-    m_formatter->dump_int("_thread", e->m_thread);
+    m_formatter->dump_unsigned("_thread", (uint64_t)e->m_thread);
     m_formatter->dump_int("_level", e->m_prio);
     if (m_subs != NULL)
     m_formatter->dump_string("_subsys_name", m_subs->get_name(e->m_subsys));

--- a/src/common/HeartbeatMap.cc
+++ b/src/common/HeartbeatMap.cc
@@ -17,6 +17,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <pthread.h>
+#include <signal.h>
 
 #include "HeartbeatMap.h"
 #include "ceph_context.h"

--- a/src/common/RWLock.h
+++ b/src/common/RWLock.h
@@ -41,6 +41,7 @@ public:
   RWLock(const std::string &n, bool track_lock=true, bool ld=true, bool prioritize_write=false)
     : name(n), id(-1), nrlock(0), nwlock(0), track(track_lock),
       lockdep(ld) {
+#if defined(PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)
     if (prioritize_write) {
       pthread_rwlockattr_t attr;
       pthread_rwlockattr_init(&attr);
@@ -50,7 +51,10 @@ public:
       pthread_rwlockattr_setkind_np(&attr,
           PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
       pthread_rwlock_init(&L, &attr);
-    } else {
+    } else 
+#endif 
+    // Next block is in {} to possibly connect to the above if when code is used.
+    {
       pthread_rwlock_init(&L, NULL);
     }
     ANNOTATE_BENIGN_RACE_SIZED(&id, sizeof(id), "RWLock lockdep id");

--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include "include/compat.h"
 #include "common/Thread.h"
 #include "common/code_environment.h"
 #include "common/debug.h"
@@ -22,6 +23,7 @@
 #include <errno.h>
 #include <iostream>
 #include <pthread.h>
+
 #include <signal.h>
 #include <sstream>
 #include <stdlib.h>

--- a/src/common/WorkQueue.cc
+++ b/src/common/WorkQueue.cc
@@ -95,7 +95,9 @@ void ThreadPool::worker(WorkThread *wt)
   
   std::stringstream ss;
   char name[16] = {0};
+#if !defined(__FreeBSD__)
   pthread_getname_np(pthread_self(), name, sizeof(name));
+#endif
   ss << name << " thread " << name;
   heartbeat_handle_d *hb = cct->get_heartbeat_map()->add_worker(ss.str(), pthread_self());
 
@@ -300,7 +302,9 @@ void ShardedThreadPool::shardedthreadpool_worker(uint32_t thread_index)
 
   std::stringstream ss;
   char name[16] = {0};
+#if !defined(__FreeBSD__)
   pthread_getname_np(pthread_self(), name, sizeof(name));
+#endif
   ss << name << " thread " << name;
   heartbeat_handle_d *hb = cct->get_heartbeat_map()->add_worker(ss.str(), pthread_self());
 

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -15,6 +15,7 @@
  * try and bench on a pool you don't have permission to access
  * it will just loop forever.
  */
+#include "include/compat.h"
 #include "common/Cond.h"
 #include "obj_bencher.h"
 

--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "include/compat.h"
 #include "CrushLocation.h"
 #include "CrushWrapper.h"
 #include "common/config.h"

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -92,8 +92,10 @@ static void handle_fatal_signal(int signum)
   // presumably dump core-- will handle it.
   char buf[1024];
   char pthread_name[16] = {0}; //limited by 16B include terminating null byte.
+#if !defined(__FreeBSD__)
   int r = pthread_getname_np(pthread_self(), pthread_name, sizeof(pthread_name));
   (void)r;
+#endif
 #if defined(__sun)
   char message[SIG2STR_MAX];
   sig2str(signum,message);

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -15,7 +15,9 @@
 #ifndef CEPH_LIB_H
 #define CEPH_LIB_H
 
+#if defined(__linux__)
 #include <features.h>
+#endif
 #include <utime.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -13,8 +13,56 @@
 #define CEPH_COMPAT_H
 
 #if defined(__FreeBSD__)
+
+/* Make sure that ENODATA is defined in the correct way */
+#ifndef ENODATA
 #define	ENODATA	ENOATTR
+#else
+#if (ENODATA == 9919)
+// #warning ENODATA already defined to be 9919, redefining to fix
+// Silencing this warning because it fires at all files where compat.h
+// is included after boost files.
+//
+// This value stems from the definition in the boost library
+// And when this case occurs it is due to the fact that boost files
+// are included before this file. Redefinition might not help in this
+// case since already parsed code has evaluated to the wrong value.
+// This would warrrant for d definition that would actually be evaluated
+// at the location of usage and report a possible confict.
+// This is left up to a future improvement
+#elif (ENODATA != 87)
+#warning ENODATA already defined to a value different from 87 (ENOATRR), refining to fix
+#endif
+#undef ENODATA
+#define ENODATA ENOATTR
+#endif
+
+#ifndef MSG_MORE
 #define	MSG_MORE 0
+#endif
+
+#ifndef O_DSYNC
+#define O_DSYNC O_SYNC
+#endif
+
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX 64
+#endif
+
+// Fix clock accuracy
+#if !defined(CLOCK_MONOTONIC_COARSE)
+#if defined(CLOCK_MONOTONIC_FAST)
+#define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST
+#else
+#define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
+#endif
+#endif
+
+/* Fix a small name diff */
+#define pthread_setname_np pthread_set_name_np
+/* And include the extra required include file */
+#include <pthread_np.h>
+
 #endif /* !__FreeBSD__ */
 
 #if defined(__APPLE__)

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+#include "../compat.h"
 #include <netinet/in.h>
 #if defined(__linux__)
 #include <linux/types.h>

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -12,6 +12,7 @@
  * Foundation.  See file COPYING.
  *
  */
+#include "include/compat.h"
 #include "include/int_types.h"
 
 #include <unistd.h>
@@ -31,7 +32,6 @@
 #include <iostream>
 #include <map>
 
-#include "include/compat.h"
 #include "include/linux_fiemap.h"
 
 #include "common/xattr.h"

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -802,7 +802,10 @@ namespace rgw {
 			     const uint32_t flags = RGWFileHandle::FLAG_NONE) {
       using std::get;
 
-      LookupFHResult fhr { nullptr, RGWFileHandle::FLAG_NONE };
+      // cast int32_t(RGWFileHandle::FLAG_NONE) due to strictness of Clang 
+      // the cast transfers a lvalue into a rvalue  in the ctor
+      // check the commit message for the full details
+      LookupFHResult fhr { nullptr, uint32_t(RGWFileHandle::FLAG_NONE) };
 
       /* mount is stale? */
       if (state.flags & FLAG_CLOSED)

--- a/src/test/common/test_time.cc
+++ b/src/test/common/test_time.cc
@@ -75,7 +75,7 @@ static void system_clock_sanity() {
 
 template<typename Clock>
 static void system_clock_conversions() {
-  static constexpr typename Clock::time_point brt(seconds(bs) +
+  static typename Clock::time_point brt(seconds(bs) +
 						  nanoseconds(bns));
 
   ASSERT_EQ(Clock::to_time_t(brt), btt);

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -114,6 +114,7 @@ TYPE(ObjectStore::Transaction)
 #include "os/filestore/SequencerPosition.h"
 TYPE(SequencerPosition)
 
+#if !defined(__FreeBSD__)
 #include "os/bluestore/bluestore_types.h"
 TYPE(bluestore_cnode_t)
 TYPE(bluestore_extent_t)
@@ -122,6 +123,7 @@ TYPE(bluestore_overlay_t)
 TYPE(bluestore_onode_t)
 TYPE(bluestore_wal_op_t)
 TYPE(bluestore_wal_transaction_t)
+#endif
 
 #include "common/hobject.h"
 TYPE(hobject_t)

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -293,7 +293,7 @@ TEST_F(IsaErasureCodeTest, chunk_size)
     profile["k"] = "2";
     profile["m"] = "1";
     Isa.init(profile, &cerr);
-    int k = 2;
+    const int k = 2;
 
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT, Isa.get_chunk_size(1));
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT, Isa.get_chunk_size(EC_ISA_ADDRESS_ALIGNMENT * k - 1));
@@ -305,7 +305,7 @@ TEST_F(IsaErasureCodeTest, chunk_size)
     profile["k"] = "3";
     profile["m"] = "1";
     Isa.init(profile, &cerr);
-    int k = 3;
+    const int k = 3;
 
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT, Isa.get_chunk_size(1));
     ASSERT_EQ(EC_ISA_ADDRESS_ALIGNMENT, Isa.get_chunk_size(EC_ISA_ADDRESS_ALIGNMENT * k - 1));
@@ -536,8 +536,8 @@ TEST_F(IsaErasureCodeTest, isa_cauchy_exhaustive)
 
   Isa.init(profile, &cerr);
 
-  int k = 12;
-  int m = 4;
+  const int k = 12;
+  const int m = 4;
 
 #define LARGE_ENOUGH 2048
   bufferptr in_ptr(buffer::create_page_aligned(LARGE_ENOUGH));
@@ -663,8 +663,8 @@ TEST_F(IsaErasureCodeTest, isa_cauchy_cache_trash)
 
   Isa.init(profile, &cerr);
 
-  int k = 16;
-  int m = 4;
+  const int k = 16;
+  const int m = 4;
 
 #define LARGE_ENOUGH 2048
   bufferptr in_ptr(buffer::create_page_aligned(LARGE_ENOUGH));
@@ -789,8 +789,8 @@ TEST_F(IsaErasureCodeTest, isa_xor_codec)
   profile["m"] = "1";
   Isa.init(profile, &cerr);
 
-  int k = 4;
-  int m = 1;
+  const int k = 4;
+  const int m = 1;
 
 #define LARGE_ENOUGH 2048
   bufferptr in_ptr(buffer::create_page_aligned(LARGE_ENOUGH));

--- a/src/test/system/systest_runnable.cc
+++ b/src/test/system/systest_runnable.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include "include/compat.h"
 #include "common/errno.h"
 #include "include/atomic.h"
 #include "systest_runnable.h"
@@ -30,10 +31,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
-
-#if defined(__FreeBSD__)
-#include <pthread_np.h>
-#endif
 
 using std::ostringstream;
 using std::string;

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -1,6 +1,10 @@
 #include "include/ipaddr.h"
 #include "gtest/gtest.h"
 
+#if defined(__FreeBSD__)
+#include <sys/types.h>
+#include <sys/socket.h>
+#endif
 #include <arpa/inet.h>
 
 static void ipv4(struct sockaddr_in *addr, const char *s) {


### PR DESCRIPTION
This requires Clang to be at least 3.7
It compiles all ceph code (expect the ones excluded in autogen_freebsd.sh)
It compiles all tests

Tests will run, but not all complete successfully, 
and make check will stall at unittest_chain_xattr.

Also note that there are a lot of warnings (I'm preparing a separate pull for that)
 - struct <-> class
 - unused or uninitialized 
 - some more Clang pickyness

