### PR TITLE
cmake: use object library instead recompiling popular .cc files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -552,7 +552,7 @@ add_subdirectory(ceph-detect-init)
 set(dencoder_srcs
   test/encoding/ceph_dencoder.cc
   $<TARGET_OBJECTS:krbd_objs>
-  common/secret.c
+  $<TARGET_OBJECTS:parse_secret_objs>
   common/TextTable.cc
   )
 if(${WITH_RADOSGW})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -222,6 +222,9 @@ if(HAVE_GOOD_YASM_ELF64)
     common/crc32c_intel_fast_zero_asm.S)
 endif(HAVE_GOOD_YASM_ELF64)
 
+add_library(common_texttable_obj OBJECT
+  common/TextTable.cc)
+
 set(libcommon_files
   ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h
   ceph_ver.c
@@ -268,7 +271,7 @@ set(libcommon_files
   common/TrackedOp.cc
   common/SloppyCRCMap.cc
   common/types.cc
-  common/TextTable.cc
+  $<TARGET_OBJECTS:common_texttable_obj>
   log/Log.cc
   log/SubsystemMap.cc
   mon/MonCap.cc
@@ -553,7 +556,7 @@ set(dencoder_srcs
   test/encoding/ceph_dencoder.cc
   $<TARGET_OBJECTS:krbd_objs>
   $<TARGET_OBJECTS:parse_secret_objs>
-  common/TextTable.cc
+  $<TARGET_OBJECTS:common_texttable_obj>
   )
 if(${WITH_RADOSGW})
   list(APPEND dencoder_srcs
@@ -637,9 +640,9 @@ add_library(mon STATIC ${lib_mon_srcs} $<TARGET_OBJECTS:mon_common_objs>
 target_link_libraries(mon ${ALLOC_LIBS})
 
 set(ceph_mon_srcs
-  ceph_mon.cc
-  common/TextTable.cc)
-add_executable(ceph-mon ${ceph_mon_srcs})
+  ceph_mon.cc)
+add_executable(ceph-mon ${ceph_mon_srcs}
+  $<TARGET_OBJECTS:common_texttable_obj>)
 add_dependencies(ceph-mon erasure_code_plugins)
       target_link_libraries(ceph-mon mon common os global ${EXTRALIBS}
   ${CMAKE_DL_LIBS})
@@ -1100,10 +1103,11 @@ if(${WITH_RBD})
     tools/rbd/action/Resize.cc
     tools/rbd/action/Snap.cc
     tools/rbd/action/Status.cc
-    tools/rbd/action/Watch.cc
-    common/TextTable.cc)
-  add_executable(rbd ${rbd_srcs} $<TARGET_OBJECTS:common_util_obj>
-    $<TARGET_OBJECTS:parse_secret_objs>)
+    tools/rbd/action/Watch.cc)
+  add_executable(rbd ${rbd_srcs}
+    $<TARGET_OBJECTS:common_util_obj>
+    $<TARGET_OBJECTS:parse_secret_objs>
+    $<TARGET_OBJECTS:common_texttable_obj>)
   set_target_properties(rbd PROPERTIES OUTPUT_NAME rbd)
   target_link_libraries(rbd librbd librados global common keyutils udev
     ${Boost_REGEX_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -761,7 +761,7 @@ target_link_libraries(unittest_ipaddr mon global)
 # unittest_texttable
 add_executable(unittest_texttable EXCLUDE_FROM_ALL
   test_texttable.cc
-  ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
+  $<TARGET_OBJECTS:common_texttable_obj>
   )
 add_ceph_unittest(unittest_texttable ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_texttable)
 target_link_libraries(unittest_texttable mon global)

--- a/src/test/bench/CMakeLists.txt
+++ b/src/test/bench/CMakeLists.txt
@@ -19,10 +19,10 @@ if (${WITH_RBD})
     detailed_stat_collector.cc
     bencher.cc
     ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
-    ${CMAKE_SOURCE_DIR}/src/common/secret.c
   )
   add_executable(ceph_smalliobenchrbd
     ${smalliobenchrbd_srcs}
+    $<TARGET_OBJECTS:parse_secret_objs>
     )
   target_link_libraries(ceph_smalliobenchrbd
     librbd

--- a/src/test/bench/CMakeLists.txt
+++ b/src/test/bench/CMakeLists.txt
@@ -18,10 +18,10 @@ if (${WITH_RBD})
     rbd_backend.cc
     detailed_stat_collector.cc
     bencher.cc
-    ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
   )
   add_executable(ceph_smalliobenchrbd
     ${smalliobenchrbd_srcs}
+    $<TARGET_OBJECTS:common_texttable_obj>
     $<TARGET_OBJECTS:parse_secret_objs>
     )
   target_link_libraries(ceph_smalliobenchrbd

--- a/src/test/cls_rbd/CMakeLists.txt
+++ b/src/test/cls_rbd/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_executable(ceph_test_cls_rbd
   test_cls_rbd.cc
   ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
-  ${CMAKE_SOURCE_DIR}/src/common/secret.c
+  $<TARGET_OBJECTS:parse_secret_objs>
   )
 set_target_properties(ceph_test_cls_rbd PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})

--- a/src/test/cls_rbd/CMakeLists.txt
+++ b/src/test/cls_rbd/CMakeLists.txt
@@ -1,7 +1,7 @@
 # cls_test_cls_rbd
 add_executable(ceph_test_cls_rbd
   test_cls_rbd.cc
-  ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
+  $<TARGET_OBJECTS:common_texttable_obj>
   $<TARGET_OBJECTS:parse_secret_objs>
   )
 set_target_properties(ceph_test_cls_rbd PROPERTIES COMPILE_FLAGS

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -1,7 +1,7 @@
 # get_command_descriptions
 add_executable(get_command_descriptions
   get_command_descriptions.cc
-  ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
+  $<TARGET_OBJECTS:common_texttable_obj>
   )
 target_link_libraries(get_command_descriptions
   mon

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -44,8 +44,8 @@ set(unittest_librbd_srcs
   )
 add_executable(unittest_librbd EXCLUDE_FROM_ALL
   ${unittest_librbd_srcs}
-  ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
+  $<TARGET_OBJECTS:common_texttable_obj>
   $<TARGET_OBJECTS:parse_secret_objs>
   )
 target_compile_definitions(unittest_librbd PUBLIC "-DTEST_LIBRBD_INTERNALS")
@@ -76,8 +76,8 @@ target_link_libraries(unittest_librbd
 
 add_executable(ceph_test_librbd
   test_main.cc
-  ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
+  $<TARGET_OBJECTS:common_texttable_obj>
   $<TARGET_OBJECTS:parse_secret_objs>
   )
 target_link_libraries(ceph_test_librbd
@@ -104,7 +104,7 @@ add_executable(ceph_test_librbd_api
   test_support.cc
   test_librbd.cc
   test_main.cc
-  ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
+  $<TARGET_OBJECTS:common_texttable_obj>
   $<TARGET_OBJECTS:parse_secret_objs>
   )
 target_link_libraries(ceph_test_librbd_api
@@ -121,7 +121,7 @@ set_target_properties(ceph_test_librbd_api PROPERTIES COMPILE_FLAGS
 add_executable(ceph_test_librbd_fsx
   fsx.cc
   $<TARGET_OBJECTS:krbd_objs>
-  ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
+  $<TARGET_OBJECTS:common_texttable_obj>
   $<TARGET_OBJECTS:parse_secret_objs>
   )
 target_link_libraries(ceph_test_librbd_fsx

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -122,7 +122,7 @@ add_executable(ceph_test_librbd_fsx
   fsx.cc
   $<TARGET_OBJECTS:krbd_objs>
   ${CMAKE_SOURCE_DIR}/src/common/TextTable.cc
-  ${CMAKE_SOURCE_DIR}/src/common/secret.c
+  $<TARGET_OBJECTS:parse_secret_objs>
   )
 target_link_libraries(ceph_test_librbd_fsx
   librbd


### PR DESCRIPTION
* common/TextTable.cc
* common/secret.c