### PR TITLE
Do not link lttng into libglobal

### DIFF
--- a/src/global/Makefile.am
+++ b/src/global/Makefile.am
@@ -6,9 +6,7 @@ libglobal_la_SOURCES = \
 	common/TrackedOp.cc
 
 libglobal_la_LIBADD = $(LIBCOMMON)
-if WITH_LTTNG
-libglobal_la_LIBADD += -ldl -llttng-ust
-endif
+
 noinst_LTLIBRARIES += libglobal.la
 
 noinst_HEADERS += \


### PR DESCRIPTION
Without this patch, radosgw binary is linked against lttng. This causes SELinux and probably even AppArmor denials, we should backport it to jewel.