### PR TITLE
ceph-disk: parted < 3.2.16 misbehaves with multiple disks

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -205,7 +205,7 @@ Requires:      python-setuptools
 Requires:      grep
 Requires:      xfsprogs
 Requires:      logrotate
-Requires:      parted
+Requires:      parted >= 3.2.16
 Requires:      util-linux
 Requires:      hdparm
 Requires:      cryptsetup


### PR DESCRIPTION
When running multiple ceph-disk prepare /dev/sd? /dev/sde at the same
time, partprobe sometime fails with

  ceph-disk: Error: partprobe /dev/vd? failed :
    Error informing the kernel about modifications to partition /dev/vd?1

This misbehavior has been verified with parted 3.1.23. The exact cause
is unclear and the tracker issue should be updated with findings.

Fixes http://tracker.ceph.com/issues/15918

Signed-off-by: Loic Dachary <loic@dachary.org>