### PR TITLE
mon: delete redundant code and add assertions to print

### DIFF
--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -298,7 +298,7 @@ bool AuthMonitor::preprocess_query(MonOpRequestRef op)
     return false;
 
   default:
-    assert(0);
+    assert(0 == "unknown type!");
     return true;
   }
 }
@@ -315,7 +315,7 @@ bool AuthMonitor::prepare_update(MonOpRequestRef op)
   case CEPH_MSG_AUTH:
     return prep_auth(op, true);
   default:
-    assert(0);
+    assert(0 == "unknown type!");
     return false;
   }
 }

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -290,7 +290,7 @@ bool LogMonitor::preprocess_query(MonOpRequestRef op)
     return preprocess_log(op);
 
   default:
-    assert(0);
+    assert(0 == "unknown type!");
     return true;
   }
 }
@@ -306,7 +306,7 @@ bool LogMonitor::prepare_update(MonOpRequestRef op)
   case MSG_LOG:
     return prepare_log(op);
   default:
-    assert(0);
+    assert(0 == "unknown type!");
     return false;
   }
 }

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -136,7 +136,7 @@ bool MonmapMonitor::preprocess_query(MonOpRequestRef op)
   case MSG_MON_JOIN:
     return preprocess_join(op);
   default:
-    assert(0);
+    assert(0 == "unknown type!");
     return true;
   }
 }
@@ -264,7 +264,7 @@ bool MonmapMonitor::prepare_update(MonOpRequestRef op)
   case MSG_MON_JOIN:
     return prepare_join(op);
   default:
-    assert(0);
+    assert(0 == "unknown type!");
   }
 
   return false;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1367,7 +1367,7 @@ bool OSDMonitor::preprocess_query(MonOpRequestRef op)
     return preprocess_remove_snaps(op);
 
   default:
-    assert(0);
+    assert(0 == "unknown type!");
     return true;
   }
 }
@@ -1401,7 +1401,7 @@ bool OSDMonitor::prepare_update(MonOpRequestRef op)
     return prepare_remove_snaps(op);
 
   default:
-    assert(0);
+    assert(0 == "unknown type!");
   }
 
   return false;
@@ -7698,8 +7698,7 @@ bool OSDMonitor::preprocess_pool_op(MonOpRequestRef op)
   case POOL_OP_AUID_CHANGE:
     return false;
   default:
-    assert(0);
-    break;
+    assert(0 == "unknown type!");
   }
 
   return false;
@@ -7856,8 +7855,7 @@ bool OSDMonitor::prepare_pool_op(MonOpRequestRef op)
     break;
 
   default:
-    assert(0);
-    break;
+    assert(0 == "unknown type!");
   }
 
   if (changed) {

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -589,7 +589,7 @@ bool PGMonitor::preprocess_query(MonOpRequestRef op)
 
 
   default:
-    assert(0);
+    assert(0 == "unknown type!");
     return true;
   }
 }
@@ -607,7 +607,7 @@ bool PGMonitor::prepare_update(MonOpRequestRef op)
     return prepare_command(op);
 
   default:
-    assert(0);
+    assert(0 == "unknown type!");
     return false;
   }
 }
@@ -2048,7 +2048,7 @@ static void note_stuck_detail(int what,
       whatname = "stale";
       break;
     default:
-      assert(0);
+      assert(0 == "unknown type!");
     }
     ss << "pg " << p->first << " is stuck " << whatname;
     if (since == utime_t()) {


### PR DESCRIPTION
delete the code that will not be executed before assert;
add error exception information in assert.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>