### PR TITLE
radosgw-admin: fix 'period push' handling of --url

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3754,7 +3754,8 @@ int main(int argc, char **argv)
       jf.flush(bl);
 
       JSONParser p;
-      ret = send_to_remote_gateway(url, info, bl, p);
+      ret = send_to_remote_or_url(remote, url, access_key, secret_key,
+                                  info, bl, p);
       if (ret < 0) {
         cerr << "request failed: " << cpp_strerror(-ret) << std::endl;
         return ret;


### PR DESCRIPTION
was calling send_to_remote_gateway(), but passing 'url' instead of
'remote'. now uses send_to_remote_or_url() to accept either

Fixes: http://tracker.ceph.com/issues/15926

Signed-off-by: Casey Bodley <cbodley@redhat.com>