### PR TITLE
librbd: write-after-write might result in an inconsistent replicated image 

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_stress.sh
+++ b/qa/workunits/rbd/rbd_mirror_stress.sh
@@ -325,7 +325,8 @@ write_image()
     local duration=$(($RANDOM % 35 + 15))
 
     timeout ${duration}s rbd --cluster ${cluster} -p ${POOL} bench-write \
-	${image} --io-size 4096 --io-threads 8 --io-total 10G --io-pattern rand || true
+	${image} --io-size 4096 --io-threads 8 --io-total 10G --io-pattern rand \
+        --debug-rbd=20 --debug-journaler=20 2> ${TEMPDIR}/rbd-bench-write.log || true
 }
 
 create_snap()
@@ -334,7 +335,8 @@ create_snap()
     local image=$2
     local snap_name=$3
 
-    rbd --cluster ${cluster} -p ${POOL} snap create ${image}@${snap_name}
+    rbd --cluster ${cluster} -p ${POOL} snap create ${image}@${snap_name} \
+	--debug-rbd=20 --debug-journaler=20 2> ${TEMPDIR}/rbd-snap-create.log
 }
 
 wait_for_snap()

--- a/src/journal/JournalPlayer.cc
+++ b/src/journal/JournalPlayer.cc
@@ -351,13 +351,13 @@ int JournalPlayer::process_playback(uint64_t object_number) {
   ldout(m_cct, 10) << __func__ << ": object_num=" << object_number << dendl;
   assert(m_lock.is_locked());
 
-  ObjectPlayerPtr object_player = get_object_player();
   if (verify_playback_ready()) {
     notify_entries_available();
   } else if (is_object_set_ready()) {
     if (m_watch_enabled) {
       schedule_watch();
     } else {
+      ObjectPlayerPtr object_player = get_object_player();
       uint8_t splay_width = m_journal_metadata->get_splay_width();
       uint64_t active_set = m_journal_metadata->get_active_set();
       uint64_t object_set = object_player->get_object_number() / splay_width;

--- a/src/librbd/LibrbdWriteback.h
+++ b/src/librbd/LibrbdWriteback.h
@@ -42,7 +42,8 @@ namespace librbd {
     using WritebackHandler::write;
 
     virtual void overwrite_extent(const object_t& oid, uint64_t off,
-				  uint64_t len, ceph_tid_t journal_tid);
+				  uint64_t len, ceph_tid_t original_journal_tid,
+                                  ceph_tid_t new_journal_tid);
 
     virtual void get_client_lock();
     virtual void put_client_lock();

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -462,7 +462,7 @@ void ObjectCacher::Object::replace_journal_tid(BufferHead *bh,
   if (bh_tid != 0 && bh_tid != tid) {
     // inform journal that it should not expect a writeback from this extent
     oc->writeback_handler.overwrite_extent(get_oid(), bh->start(),
-					   bh->length(), bh_tid);
+					   bh->length(), bh_tid, tid);
   }
   bh->set_journal_tid(tid);
 }

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -37,7 +37,8 @@ class WritebackHandler {
                            ceph_tid_t journal_tid, Context *oncommit) = 0;
 
   virtual void overwrite_extent(const object_t& oid, uint64_t off, uint64_t len,
-                                ceph_tid_t journal_tid) {}
+                                ceph_tid_t original_journal_tid,
+                                ceph_tid_t new_journal_tid) {}
 
   virtual bool can_scattered_write() { return false; }
   virtual ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,


### PR DESCRIPTION
With the librbd cache enabled, there is a possible race condition with write-after-write IO to the same image extent if followed by a client crash.  In such a case, it might result in an inconsistent primary / non-primary image.