### PR TITLE
osd/ReplicatedPG.h: remove incorrect use of move

### DIFF
--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -563,19 +563,19 @@ public:
     list<std::function<void()>> on_success;
     template <typename F>
     void register_on_finish(F &&f) {
-      on_finish.emplace_back(std::move(f));
+      on_finish.emplace_back(std::forward<F>(f));
     }
     template <typename F>
     void register_on_success(F &&f) {
-      on_success.emplace_back(std::move(f));
+      on_success.emplace_back(std::forward<F>(f));
     }
     template <typename F>
     void register_on_applied(F &&f) {
-      on_applied.emplace_back(std::move(f));
+      on_applied.emplace_back(std::forward<F>(f));
     }
     template <typename F>
     void register_on_commit(F &&f) {
-      on_committed.emplace_back(std::move(f));
+      on_committed.emplace_back(std::forward<F>(f));
     }
 
     bool sent_ack;


### PR DESCRIPTION
The modified functions  take universal references, so they can bind to
either rvalues and lvalues. When they bind to lvalues the use of
std::move is incorrect.
We should use std::forward, so we only move from rvalues.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>