### PR TITLE
os/bluestore: enable RocksDB row cache

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -843,7 +843,8 @@ OPTION(rocksdb_separate_wal_dir, OPT_BOOL, false) // use $path.wal for wal
 OPTION(rocksdb_db_paths, OPT_STR, "")   // path,size( path,size)*
 OPTION(rocksdb_log_to_ceph_log, OPT_BOOL, true)  // log to ceph log
 OPTION(rocksdb_block_cache_size, OPT_INT, 128*1024*1024)  // default rocksdb block cache size
-OPTION(rocksdb_cache_shard_bits, OPT_INT, 4)  // rocksdb block cache shard bits, 4 bit -> 16 shards
+OPTION(rocksdb_row_cache_size, OPT_INT, 128*1024*1024)    // default rocksdb row cache size
+OPTION(rocksdb_cache_shard_bits, OPT_INT, 4)  // rocksdb block&row cache shard bits, 4 bit -> 16 shards
 OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR, "")

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -842,7 +842,8 @@ OPTION(kinetic_use_ssl, OPT_BOOL, false) // whether to secure kinetic traffic wi
 OPTION(rocksdb_separate_wal_dir, OPT_BOOL, false) // use $path.wal for wal
 OPTION(rocksdb_db_paths, OPT_STR, "")   // path,size( path,size)*
 OPTION(rocksdb_log_to_ceph_log, OPT_BOOL, true)  // log to ceph log
-OPTION(rocksdb_cache_size, OPT_INT, 128*1024*1024)  // default leveldb cache size
+OPTION(rocksdb_cache_size, OPT_INT, 128*1024*1024)  // default rocksdb cache size
+OPTION(rocksdb_cache_shard_bits, OPT_INT, 4)  // rocksdb block cache shard bits, 4 bit -> 16 shards
 OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR, "")

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -842,7 +842,7 @@ OPTION(kinetic_use_ssl, OPT_BOOL, false) // whether to secure kinetic traffic wi
 OPTION(rocksdb_separate_wal_dir, OPT_BOOL, false) // use $path.wal for wal
 OPTION(rocksdb_db_paths, OPT_STR, "")   // path,size( path,size)*
 OPTION(rocksdb_log_to_ceph_log, OPT_BOOL, true)  // log to ceph log
-OPTION(rocksdb_cache_size, OPT_INT, 128*1024*1024)  // default rocksdb cache size
+OPTION(rocksdb_block_cache_size, OPT_INT, 128*1024*1024)  // default rocksdb block cache size
 OPTION(rocksdb_cache_shard_bits, OPT_INT, 4)  // rocksdb block cache shard bits, 4 bit -> 16 shards
 OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -265,18 +265,18 @@ int LevelDBStore::get(
 
 int LevelDBStore::get(const string &prefix, 
 		  const string &key,
-		  bufferlist *value)
+		  bufferlist *out)
 {
-  assert(value && (value->length() == 0));
+  assert(out && (out->length() == 0));
   utime_t start = ceph_clock_now(g_ceph_context);
   int r = 0;
-  leveldb::ReadOptions options;
-  std::string value;
-  std::string bound = combine_strings(prefix, key);
-  auto status = db->Get(options, bound, &value);
-  if (status.ok()) {
-    value->append(value);
-  } else if (!status.IsNotFound()) {
+  string value, k;
+  leveldb::Status s;
+  k = combine_strings(prefix, key);
+  s = db->Get(leveldb::ReadOptions(), leveldb::Slice(k), &value);
+  if (s.ok()) {
+    out->append(value);
+  } else {
     r = -ENOENT;
   }
   utime_t lat = ceph_clock_now(g_ceph_context) - start;

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -270,11 +270,13 @@ int LevelDBStore::get(const string &prefix,
   assert(value && (value->length() == 0));
   utime_t start = ceph_clock_now(g_ceph_context);
   int r = 0;
-  KeyValueDB::Iterator it = get_iterator(prefix);
-  it->lower_bound(key);
-  if (it->valid() && it->key() == key) {
-    value->append(it->value_as_ptr());
-  } else {
+  leveldb::ReadOptions options;
+  std::string value;
+  std::string bound = combine_strings(prefix, key);
+  auto status = db->Get(options, bound, &value);
+  if (status.ok()) {
+    value->append(value);
+  } else if (!status.IsNotFound()) {
     r = -ENOENT;
   }
   utime_t lat = ceph_clock_now(g_ceph_context) - start;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -279,13 +279,14 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
     opt.env = static_cast<rocksdb::Env*>(priv);
   }
 
-  auto cache = rocksdb::NewLRUCache(g_conf->rocksdb_cache_size);
+  auto cache = rocksdb::NewLRUCache(g_conf->rocksdb_cache_size, g_conf->rocksdb_cache_shard_bits);
   rocksdb::BlockBasedTableOptions bbt_opts;
   bbt_opts.block_size = g_conf->rocksdb_block_size;
   bbt_opts.block_cache = cache;
   opt.table_factory.reset(rocksdb::NewBlockBasedTableFactory(bbt_opts));
   dout(10) << __func__ << " set block size to " << g_conf->rocksdb_block_size
-           << " cache size to " << g_conf->rocksdb_cache_size << dendl;
+           << " cache size to " << g_conf->rocksdb_cache_size
+           << " num of cache shards to " << (1 << g_conf->rocksdb_cache_shard_bits) << dendl;
 
   opt.merge_operator.reset(new MergeOperatorRouter(*this));
   status = rocksdb::DB::Open(opt, path, &db);

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -293,8 +293,21 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
     bbt_opts.block_cache = NULL;
   }
   opt.table_factory.reset(rocksdb::NewBlockBasedTableFactory(bbt_opts));
+
+  if (g_conf->rocksdb_row_cache_size) {
+    if (g_conf->rocksdb_cache_shard_bits >= 1) {
+      opt.row_cache = rocksdb::NewLRUCache(g_conf->rocksdb_row_cache_size,
+                                           g_conf->rocksdb_cache_shard_bits);
+    } else {
+      opt.row_cache = rocksdb::NewLRUCache(g_conf->rocksdb_row_cache_size);
+    }
+  } else {
+    opt.row_cache = NULL;
+  }
+
   dout(10) << __func__ << " set block size to " << g_conf->rocksdb_block_size
-           << " cache size to " << g_conf->rocksdb_block_cache_size
+           << " block cache size to " << g_conf->rocksdb_block_cache_size
+           << " row cache size to " << g_conf->rocksdb_row_cache_size
            << " num of cache shards to " << (1 << g_conf->rocksdb_cache_shard_bits) << dendl;
 
   opt.merge_operator.reset(new MergeOperatorRouter(*this));

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -496,6 +496,7 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
   }
 }
 
+//gets will bypass RocksDB row cache, since it uses iterator
 int RocksDBStore::get(
     const string &prefix,
     const std::set<string> &keys,
@@ -526,10 +527,12 @@ int RocksDBStore::get(
   assert(out && (out->length() == 0));
   utime_t start = ceph_clock_now(g_ceph_context);
   int r = 0;
-  KeyValueDB::Iterator it = get_iterator(prefix);
-  it->lower_bound(key);
-  if (it->valid() && it->key() == key) {
-    out->append(it->value_as_ptr());
+  string value, k;
+  rocksdb::Status s;
+  k = combine_strings(prefix, key);
+  s = db->Get(rocksdb::ReadOptions(), rocksdb::Slice(k), &value);
+  if (s.ok()) {
+    out->append(value);
   } else {
     r = -ENOENT;
   }


### PR DESCRIPTION
This PR will enable both RocksDB row cache for bluestore.
Row cache will cache kv pairs after db get(), so next time when db get same kv pair, it won't need to go through sst files to do lookup again.