### PR TITLE
mon/log: clean unused function and comments

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -435,7 +435,7 @@ int LogMonitor::sub_name_to_id(const string& n)
     return CLOG_WARN;
   if (n == "log-error")
     return CLOG_ERROR;
-  return -1;
+  return CLOG_UNKNOWN;
 }
 
 void LogMonitor::check_subs()

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -48,24 +48,6 @@ static ostream& _prefix(std::ostream *_dout, Monitor *mon, version_t v) {
 
 ostream& operator<<(ostream& out, LogMonitor& pm)
 {
-  /*
-  std::stringstream ss;
-  for (ceph::unordered_map<int,int>::iterator p = pm.pg_map.num_pg_by_state.begin();
-       p != pm.pg_map.num_pg_by_state.end();
-       ++p) {
-    if (p != pm.pg_map.num_pg_by_state.begin())
-      ss << ", ";
-    ss << p->second << " " << pg_state_string(p->first);
-  }
-  string states = ss.str();
-  return out << "v" << pm.pg_map.version << ": "
-	     << pm.pg_map.pg_stat.size() << " pgs: "
-	     << states << "; "
-	     << kb_t(pm.pg_map.total_pg_kb()) << " data, " 
-	     << kb_t(pm.pg_map.total_used_kb()) << " used, "
-	     << kb_t(pm.pg_map.total_avail_kb()) << " / "
-	     << kb_t(pm.pg_map.total_kb()) << " free";
-  */
   return out << "log";
 }
 
@@ -221,17 +203,6 @@ void LogMonitor::update_from_paxos(bool *need_bootstrap)
   }
 
   check_subs();
-}
-
-void LogMonitor::store_do_append(MonitorDBStore::TransactionRef t,
-    const string& key, bufferlist& bl)
-{
-  bufferlist existing_bl;
-  int err = get_value(key, existing_bl);
-  assert(err == 0);
-
-  existing_bl.append(bl);
-  put_value(t, key, existing_bl);
 }
 
 void LogMonitor::create_pending()

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -169,9 +169,6 @@ private:
   bool _create_sub_summary(MLog *mlog, int level);
   void _create_sub_incremental(MLog *mlog, int level, version_t sv);
 
-  void store_do_append(MonitorDBStore::TransactionRef t,
-		       const string& key, bufferlist& bl);
-
  public:
   LogMonitor(Monitor *mn, Paxos *p, const string& service_name) 
     : PaxosService(mn, p, service_name) { }


### PR DESCRIPTION
clean unused function and comments
and using standard macros instead of -1 in the sub_name_to_id()

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>