### PR TITLE
ceph.spec.in: use %autosetup macro

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -619,7 +619,7 @@ python-cephfs instead.
 # common
 #################################################################################
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 %if 0%{with cephfs_java}


### PR DESCRIPTION
New in rpm 4.11,
http://www.rpm.org/wiki/PackagerDocs/Autosetup

This makes it a bit easier to incorporate patches downstream.