### PR TITLE
mon : Display full flag in ceph status if full flag is set

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2853,7 +2853,8 @@ void OSDMonitor::get_health(list<pair<health_status_t,string> >& summary,
     }
 
     // warn about flags
-    if (osdmap.test_flag(CEPH_OSDMAP_PAUSERD |
+    if (osdmap.test_flag(CEPH_OSDMAP_FULL |
+			 CEPH_OSDMAP_PAUSERD |
 			 CEPH_OSDMAP_PAUSEWR |
 			 CEPH_OSDMAP_NOUP |
 			 CEPH_OSDMAP_NODOWN |


### PR DESCRIPTION
mon : Display full flag in ceph status if full flag is set

Fixes: http://tracker.ceph.com/issues/15809

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>