### PR TITLE
rgw: fix manager selection when APIs customized

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1550,9 +1550,6 @@ RGWRESTMgr *RGWRESTMgr::get_resource_mgr(struct req_state *s, const string& uri,
 {
   *out_uri = uri;
 
-  if (resources_by_size.empty())
-    return this;
-
   multimap<size_t, string>::reverse_iterator iter;
 
   for (iter = resources_by_size.rbegin(); iter != resources_by_size.rend(); ++iter) {


### PR DESCRIPTION
When modifying rgw_enable_apis per RGW instance, such as for staticsites, you
can end up with RESTManager instance being null in some cases, which returns a
HTTP 405 MethodNotAllowed to all requests.

Example configuration to trigger the bug:
rgw_enable_apis = s3website

Backport: jewel
X-Note: Patch from Yehuda in private IRC discussion, 2016/05/20.
Fixes: http://tracker.ceph.com/issues/15973
Fixes: http://tracker.ceph.com/issues/15974
Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>