### PR TITLE
cmake: add ocf support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,11 @@ else(${ENABLE_GIT_VERSION})
   set(CEPH_GIT_NICE_VER "Development")
 endif(${ENABLE_GIT_VERSION})
 
+option(WITH_OCF "build OCF-compliant cluster resource agent" OFF)
+if(WITH_OCF)
+  add_subdirectory(ocf)
+endif()
+
 # Python stuff
 find_package(PythonInterp 2 QUIET)
 if(NOT PYTHONINTERP_FOUND)

--- a/src/ocf/CMakeLists.txt
+++ b/src/ocf/CMakeLists.txt
@@ -1,0 +1,22 @@
+# The root of the OCF resource agent hierarchy
+# Per the OCF standard, it's always "lib",
+# not "lib64" (even on 64-bit platforms).
+set(ocf_dir ${CMAKE_INSTALL_PREFIX}/lib/ocf)
+
+string(TOLOWER ${PROJECT_NAME} lower_project_name)
+# The ceph provider directory
+set(ra_dir ${ocf_dir}/resource.d/${lower_project_name})
+
+foreach(agent ceph rbd)
+  configure_file(${agent}.in
+    ${agent} @ONLY)
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${agent}
+    DESTINATION ${ra_dir})
+endforeach()
+
+foreach(agent osd mds mon)
+  install(CODE
+    "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ceph ${agent}
+       WORKING_DIRECTORY \"${ra_dir}\")")
+endforeach()


### PR DESCRIPTION
a new option is added: WITH_OCF. it is OFF by default.

Signed-off-by: Kefu Chai <kchai@redhat.com>