### PR TITLE
mon: MonClient may hang on pinging an unresponsive monitor

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -427,6 +427,7 @@ void MonClient::shutdown()
   monc_lock.Unlock();
 
   if (initialized) {
+    finisher.wait_for_empty();
     finisher.stop();
   }
   monc_lock.Lock();

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -72,7 +72,7 @@ struct MonClientPinger : public Dispatcher {
     int ret = 0;
     while (!done) {
       ret = ping_recvd_cond.WaitUntil(lock, until);
-      if (ret == -ETIMEDOUT)
+      if (ret == ETIMEDOUT)
         break;
     }
     return ret;

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -143,8 +143,10 @@ class TestRados(object):
         cmd = {'prefix': 'mon dump', 'format':'json'}
         ret, buf, out = self.rados.mon_command(json.dumps(cmd), b'')
         for mon in json.loads(buf.decode('utf8'))['mons']:
-            buf = json.loads(self.rados.ping_monitor(mon['name']))
-            assert buf.get('health')
+            while True:
+                buf = json.loads(self.rados.ping_monitor(mon['name']))
+                if buf.get('health'):
+                    break
 
     def test_create(self):
         self.rados.create_pool('foo')


### PR DESCRIPTION
On timedout, WaitUntil() method return a positive ETIMEDOUT error number.
It never returns -ETIMEDOUT.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>