### PR TITLE
mds: fix race between StrayManager::{eval_stray,reintegrate_stray}

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5569,8 +5569,9 @@ void Server::_unlink_local_finish(MDRequestRef& mdr,
   // removing a new dn?
   dn->get_dir()->try_remove_unlinked_dn(dn);
 
-  // clean up?
-  if (straydn) {
+  // clean up ?
+  // respond_to_request() drops locks. So stray reintegration can race with us.
+  if (straydn && !straydn->get_projected_linkage()->is_null()) {
     // Tip off the MDCache that this dentry is a stray that
     // might be elegible for purge.
     mdcache->notify_stray(straydn);
@@ -6417,7 +6418,8 @@ void Server::_rename_finish(MDRequestRef& mdr, CDentry *srcdn, CDentry *destdn, 
     mds->locker->eval(in, CEPH_CAP_LOCKS, true);
 
   // clean up?
-  if (straydn) {
+  // respond_to_request() drops locks. So stray reintegration can race with us.
+  if (straydn && !straydn->get_projected_linkage()->is_null()) {
     mdcache->notify_stray(straydn);
   }
 }


### PR DESCRIPTION
StrayManager::eval_stray() is called after Server::respond_to_request()
drops locks. So it can race with StrayManager::reintegrate_stray()

Fixes: http://tracker.ceph.com/issues/15920
Signed-off-by: Yan, Zheng <zyan@redhat.com>