### PR TITLE
mon: remove the redundant judge on dispatch_op function

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3682,8 +3682,7 @@ void Monitor::dispatch_op(MonOpRequestRef op)
       {
         op->set_type_paxos();
         MMonPaxos *pm = static_cast<MMonPaxos*>(op->get_req());
-        if (!op->is_src_mon() ||
-            !op->get_session()->is_capable("mon", MON_CAP_X)) {
+        if (!op->get_session()->is_capable("mon", MON_CAP_X)) {
           //can't send these!
           break;
         }


### PR DESCRIPTION
mon: remove the redundant judge on dispatch_op function

It have judged above,here no need to judge again.

Signed-off-by: songbaisen <song.baisen@zte.com.cn>