### PR TITLE
jewel: No Last-Modified, Content-Size and X-Object-Manifest headers if no segments in DLO manifest

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1225,6 +1225,7 @@ void RGWGetObj::execute()
     if (op_ret < 0) {
       ldout(s->cct, 0) << "ERROR: failed to handle user manifest ret="
 		       << op_ret << dendl;
+      goto done_err;
     }
     return;
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/15965