### PR TITLE
osd: fix omap digest compare when scrub

### DIFF
--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -664,7 +664,7 @@ void PGBackend::be_compare_scrubmaps(
       }
 
       if (auth_object.digest_present && auth_object.omap_digest_present &&
-	  (!auth_oi.is_data_digest() || !auth_oi.is_omap_digest())) {
+	  (!auth_oi.is_data_digest() || (!auth_oi.is_omap_digest() && auth_oi.is_omap()))) {
 	dout(20) << __func__ << " missing digest on " << *k << dendl;
 	update = MAYBE;
       }


### PR DESCRIPTION
Introduce by https://github.com/ceph/ceph/commit/fe1c28dea4e5607a0c72eab1f046074616cd55a7.

The if logic would always return ture when deep-scrub non-omap object. And would trigger update the digest every deep-scrub.

Signed-off-by: Xinze Chi <xinze@xsky.com>