### PR TITLE
osd/OSD.h: remove closing brace } from comment

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1582,9 +1582,9 @@ private:
 
 private:
   /**
-   *  @defgroup monc helpers
-   *
-   *  Right now we only have the one
+   * @defgroup monc helpers
+   * @{
+   * Right now we only have the one
    */
 
   /**


### PR DESCRIPTION
This is confusing vim when moving to matching brace of OSD class.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>