### PR TITLE
doc: John Spray is now CephFS lead

### DIFF
--- a/doc/dev/development-workflow.rst
+++ b/doc/dev/development-workflow.rst
@@ -100,7 +100,7 @@ follows:
 Each ``team`` is responsible for a project:
 
 * rgw lead is Yehuda Sadeh
-* CephFS lead is Gregory Farnum
+* CephFS lead is John Spray
 * rados lead is Samuel Just
 * rbd lead is Jason Dillaman
 

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -56,7 +56,7 @@ Ceph      Sage Weil       liewegas
 RADOS     Samuel Just     athanatos
 RGW       Yehuda Sadeh    yehudasa
 RBD       Jason Dillaman  dillaman
-CephFS    Gregory Farnum  gregsfortytwo
+CephFS    John Spray      jcsp
 Build/Ops Ken Dreyer      ktdreyer
 ========= =============== =============
 


### PR DESCRIPTION
Signed-off-by: Ken Dreyer <kdreyer@redhat.com>