### PR TITLE
cmake,make: speed up man page generation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -10,7 +10,9 @@ RECURSIVE = YES
 EXCLUDE = src/gmock \
 	src/test/virtualenv \
 	src/out \
-        src/tracing
+	src/tracing \
+	src/civetweb
+
 VERBATIM_HEADERS = NO
 GENERATE_HTML = NO
 GENERATE_LATEX = NO

--- a/admin/build-doc
+++ b/admin/build-doc
@@ -7,20 +7,7 @@ TOPDIR=`pwd`
 install -d -m0755 build-doc
 
 if command -v dpkg >/dev/null; then
-    packages='
-      git
-      gcc
-      python-dev
-      python-pip
-      python-virtualenv
-      libxml2-dev
-      libxslt1-dev
-      doxygen
-      ditaa
-      graphviz
-      ant
-      cython
-      zlib1g-dev'
+    packages=`cat ${TOPDIR}/doc_deps.deb.txt`
     for package in $packages; do
     if [ "$(dpkg --status -- $package 2>&1 | sed -n 's/^Status: //p')" != "install ok installed" ]; then
         # add a space after old values

--- a/admin/build-doc
+++ b/admin/build-doc
@@ -20,7 +20,6 @@ if command -v dpkg >/dev/null; then
       graphviz
       ant
       cython
-      librbd-dev
       zlib1g-dev'
     for package in $packages; do
     if [ "$(dpkg --status -- $package 2>&1 | sed -n 's/^Status: //p')" != "install ok installed" ]; then
@@ -127,7 +126,7 @@ rm -f $TOPDIR/src/pybind/rbd/rados.pxd $TOPDIR/src/pybind/cephfs/rados.pxd
 
 
 $vdir/bin/sphinx-build -a -n -b dirhtml -d doctrees $TOPDIR/doc $TOPDIR/build-doc/output/html
-$vdir/bin/sphinx-build -a -b man -d doctrees $TOPDIR/doc $TOPDIR/build-doc/output/man
+$vdir/bin/sphinx-build -a -b man -t man -d doctrees $TOPDIR/doc $TOPDIR/build-doc/output/man
 
 #
 # Build and install JavaDocs

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,6 +10,18 @@ templates_path = ['_templates']
 source_suffix = '.rst'
 master_doc = 'index'
 exclude_patterns = ['**/.#*', '**/*~', 'start/quick-common.rst']
+if tags.has('man'):
+    exclude_patterns += ['architecture.rst', 'glossary.rst', 'release*.rst',
+                         'api/*',
+                         'cephfs/*',
+                         'dev/*',
+                         'install/*',
+                         'mon/*',
+                         'rados/*',
+                         'radosgw/*',
+                         'rbd/*',
+                         'start/*']
+
 pygments_style = 'sphinx'
 
 html_theme = 'ceph'

--- a/doc/man/CMakeLists.txt
+++ b/doc/man/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(8)
 
 add_custom_command(
   OUTPUT ${sphinx_output}
-  COMMAND ${SPHINX_BUILD} -b man -d ${CMAKE_BINARY_DIR}/doc/doctrees -c ${CMAKE_SOURCE_DIR}/man ${CMAKE_CURRENT_SOURCE_DIR} ${sphinx_output_dir}
+  COMMAND ${SPHINX_BUILD} -b man -t man -d ${CMAKE_BINARY_DIR}/doc/doctrees -c ${CMAKE_SOURCE_DIR}/man ${CMAKE_CURRENT_SOURCE_DIR} ${sphinx_output_dir}
   DEPENDS ${sphinx_input})
 
 add_custom_target(

--- a/doc_deps.deb.txt
+++ b/doc_deps.deb.txt
@@ -1,10 +1,12 @@
+git
+gcc
 python-dev
 python-pip
 python-virtualenv
 doxygen
 ditaa
 libxml2-dev
-libxslt-dev
+libxslt1-dev
 graphviz
 ant
 zlib1g-dev

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -21,7 +21,7 @@ $(dist_man_MANS): sphinx-build.stamp
 # in a tree populated from dist tarball, the $(top_srcdir)/doc is not included
 sphinx-build.stamp:
 	if [ -d $(top_srcdir)/doc/man ] ; then \
-		${SPHINX_BUILD} -b man -d doctrees -c $(top_srcdir)/man $(top_srcdir)/doc/man $(top_builddir)/man; \
+		${SPHINX_BUILD} -b man -t man -d doctrees -c $(top_srcdir)/man $(top_srcdir)/doc/man $(top_builddir)/man; \
 	fi
 
 clean-local::


### PR DESCRIPTION
and this also address the failure of
```
Exception occurred:
  File "/usr/lib/python2.7/dist-packages/sphinx/writers/manpage.py", line 422, in unknown_visit
    raise NotImplementedError('Unknown node: ' + node.__class__.__name__)
NotImplementedError: Unknown node: ditaa
The full traceback has been saved in /tmp/user/1000/sphinx-err-r65gwE.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```


seems the ditaa plugin is not enabled when rendering manpages.