### PR TITLE
rgw: cleanup RGW_MIN_MULTIPART_SIZE

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -102,7 +102,6 @@ using ceph::crypto::MD5;
 #define RGW_BUCKETS_OBJ_SUFFIX ".buckets"
 
 #define RGW_MAX_PENDING_CHUNKS  16
-#define RGW_MIN_MULTIPART_SIZE (5ULL*1024*1024)
 
 #define RGW_FORMAT_PLAIN        0
 #define RGW_FORMAT_XML          1


### PR DESCRIPTION
rgw: cleanup RGW_MIN_MULTIPART_SIZE

As the commit 11cf9bbb298768b5307616db5977cc4985072a6e
make rgw_multipart_min_part_size as a config option,
we did not use RGW_MIN_MULTIPART_SIZE anymore.

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>