### PR TITLE
rgw: use vector for librados handles

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3199,8 +3199,7 @@ void RGWRados::finalize()
 int RGWRados::init_rados()
 {
   int ret = 0;
-  auto count = cct->_conf->rgw_num_rados_handles;
-  auto handles = std::vector<librados::Rados>{count};
+  auto handles = std::vector<librados::Rados>{cct->_conf->rgw_num_rados_handles};
 
   for (auto& r : handles) {
     ret = r.init_with_context(cct);
@@ -3223,7 +3222,6 @@ int RGWRados::init_rados()
   meta_mgr = new RGWMetadataManager(cct, this);
   data_log = new RGWDataChangesLog(cct, this);
 
-  num_rados_handles = count;
   std::swap(handles, rados);
   return ret;
 }
@@ -12083,7 +12081,7 @@ void RGWStoreManager::close_storage(RGWRados *store)
 
 librados::Rados* RGWRados::get_rados_handle()
 {
-  if (num_rados_handles == 1) {
+  if (rados.size() == 1) {
     return &rados[0];
   } else {
     handle_lock.get_read();
@@ -12097,7 +12095,7 @@ librados::Rados* RGWRados::get_rados_handle()
       handle_lock.put_read();
       handle_lock.get_write();
       uint32_t handle = next_rados_handle.read();
-      if (handle == num_rados_handles) {
+      if (handle == rados.size()) {
         next_rados_handle.set(0);
         handle = 0;
       }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3213,14 +3213,16 @@ int RGWRados::init_rados()
     }
   }
 
-  cr_registry = new RGWCoroutinesManagerRegistry(cct);
-  ret =  cr_registry->hook_to_admin_command("cr dump");
+  auto crs = std::unique_ptr<RGWCoroutinesManagerRegistry>{
+    new RGWCoroutinesManagerRegistry(cct)};
+  ret = crs->hook_to_admin_command("cr dump");
   if (ret < 0) {
     return ret;
   }
 
   meta_mgr = new RGWMetadataManager(cct, this);
   data_log = new RGWDataChangesLog(cct, this);
+  cr_registry = crs.release();
 
   std::swap(handles, rados);
   return ret;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -12094,13 +12094,11 @@ librados::Rados* RGWRados::get_rados_handle()
     } else {
       handle_lock.put_read();
       handle_lock.get_write();
-      uint32_t handle = next_rados_handle.read();
-      if (handle == rados.size()) {
-        next_rados_handle.set(0);
-        handle = 0;
-      }
+      const uint32_t handle = next_rados_handle;
       rados_map[id] = handle;
-      next_rados_handle.inc();
+      if (++next_rados_handle == rados.size()) {
+        next_rados_handle = 0;
+      }
       handle_lock.put_write();
       return &rados[handle];
     }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2549,7 +2549,7 @@ int RGWRados::unwatch(uint64_t watch_handle)
     ldout(cct, 0) << "ERROR: rados->unwatch2() returned r=" << r << dendl;
     return r;
   }
-  r = rados[0]->watch_flush();
+  r = rados[0].watch_flush();
   if (r < 0) {
     ldout(cct, 0) << "ERROR: rados->watch_flush() returned r=" << r << dendl;
     return r;
@@ -3199,58 +3199,32 @@ void RGWRados::finalize()
 int RGWRados::init_rados()
 {
   int ret = 0;
+  auto count = cct->_conf->rgw_num_rados_handles;
+  auto handles = std::vector<librados::Rados>{count};
 
-  num_rados_handles = cct->_conf->rgw_num_rados_handles;
-
-  rados = new librados::Rados *[num_rados_handles];
-  if (!rados) {
-    ret = -ENOMEM;
-    return ret;
-  }
-
-  for (uint32_t i=0; i < num_rados_handles; i++) {
-
-    rados[i] = new Rados();
-    if (!rados[i]) {
-      ret = -ENOMEM;
-      goto fail;
+  for (auto& r : handles) {
+    ret = r.init_with_context(cct);
+    if (ret < 0) {
+      return ret;
     }
 
-    ret = rados[i]->init_with_context(cct);
+    ret = r.connect();
     if (ret < 0) {
-      goto fail;
-    }
-
-    ret = rados[i]->connect();
-    if (ret < 0) {
-      goto fail;
+      return ret;
     }
   }
 
   cr_registry = new RGWCoroutinesManagerRegistry(cct);
   ret =  cr_registry->hook_to_admin_command("cr dump");
   if (ret < 0) {
-    goto fail;
+    return ret;
   }
 
   meta_mgr = new RGWMetadataManager(cct, this);
   data_log = new RGWDataChangesLog(cct, this);
 
-  return ret;
-
-fail:
-  for (uint32_t i=0; i < num_rados_handles; i++) {
-    if (rados[i]) {
-      delete rados[i];
-      rados[i] = NULL;
-    }
-  }
-  num_rados_handles = 0;
-  if (rados) {
-    delete[] rados;
-    rados = NULL;
-  }
-
+  num_rados_handles = count;
+  std::swap(handles, rados);
   return ret;
 }
 
@@ -3993,7 +3967,7 @@ int RGWRados::init_watch()
 {
   const char *control_pool = get_zone_params().control_pool.name.c_str();
 
-  librados::Rados *rad = rados[0];
+  librados::Rados *rad = &rados[0];
   int r = rad->ioctx_create(control_pool, control_pool_ctx);
 
   if (r == -ENOENT) {
@@ -12110,7 +12084,7 @@ void RGWStoreManager::close_storage(RGWRados *store)
 librados::Rados* RGWRados::get_rados_handle()
 {
   if (num_rados_handles == 1) {
-    return rados[0];
+    return &rados[0];
   } else {
     handle_lock.get_read();
     pthread_t id = pthread_self();
@@ -12118,7 +12092,7 @@ librados::Rados* RGWRados::get_rados_handle()
 
     if (it != rados_map.end()) {
       handle_lock.put_read();
-      return rados[it->second];
+      return &rados[it->second];
     } else {
       handle_lock.put_read();
       handle_lock.get_write();
@@ -12130,7 +12104,7 @@ librados::Rados* RGWRados::get_rados_handle()
       rados_map[id] = handle;
       next_rados_handle.inc();
       handle_lock.put_write();
-      return rados[handle];
+      return &rados[handle];
     }
   }
 }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1801,7 +1801,7 @@ protected:
   CephContext *cct;
 
   std::vector<librados::Rados> rados;
-  atomic_t next_rados_handle;
+  uint32_t next_rados_handle;
   RWLock handle_lock;
   std::map<pthread_t, int> rados_map;
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1802,7 +1802,6 @@ protected:
 
   std::vector<librados::Rados> rados;
   atomic_t next_rados_handle;
-  uint32_t num_rados_handles;
   RWLock handle_lock;
   std::map<pthread_t, int> rados_map;
 
@@ -1842,7 +1841,7 @@ public:
                bucket_index_max_shards(0),
                max_bucket_id(0), cct(NULL),
                next_rados_handle(0),
-               num_rados_handles(0), handle_lock("rados_handle_lock"),
+               handle_lock("rados_handle_lock"),
                binfo_cache(NULL),
                pools_initialized(false),
                quota_handler(NULL),

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1800,7 +1800,7 @@ class RGWRados
 protected:
   CephContext *cct;
 
-  librados::Rados **rados;
+  std::vector<librados::Rados> rados;
   atomic_t next_rados_handle;
   uint32_t num_rados_handles;
   RWLock handle_lock;
@@ -1841,7 +1841,7 @@ public:
                bucket_id_lock("rados_bucket_id"),
                bucket_index_max_shards(0),
                max_bucket_id(0), cct(NULL),
-               rados(NULL), next_rados_handle(0),
+               next_rados_handle(0),
                num_rados_handles(0), handle_lock("rados_handle_lock"),
                binfo_cache(NULL),
                pools_initialized(false),
@@ -1956,17 +1956,7 @@ public:
 
   RGWDataChangesLog *data_log;
 
-  virtual ~RGWRados() {
-    for (uint32_t i=0; i < num_rados_handles; i++) {
-      if (rados[i]) {
-        rados[i]->shutdown();
-        delete rados[i];
-      }
-    }
-    if (rados) {
-      delete[] rados;
-    }
-  }
+  virtual ~RGWRados() = default;
 
   int get_required_alignment(rgw_bucket& bucket, uint64_t *alignment);
   int get_max_chunk_size(rgw_bucket& bucket, uint64_t *max_chunk_size);


### PR DESCRIPTION
using a vector instead of an array of pointers cleans up our initialization/shutdown logic