### PR TITLE
rgw: support size suffixes for --max-size in radosgw-admin command

### DIFF
--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -310,7 +310,7 @@ storage size in megabytes.
   the maximum number of objects. A negative value disables this setting.
   
 - **Maximum Size:** The ``--max-size`` option allows you to specify a quota
-  for the maximum number of bytes. A negative value disables this setting.
+  size in B/K/M/G/T. A negative value disables this setting.
   
 - **Quota Scope:** The ``--quota-scope`` option sets the scope for the quota.
   The options are ``bucket`` and ``user``. Bucket quotas apply to buckets a 
@@ -327,7 +327,7 @@ For example::
 
 For example:: 
 
-	radosgw-admin quota set --quota-scope=user --uid=johndoe --max-objects=1024 --max-size=1024
+	radosgw-admin quota set --quota-scope=user --uid=johndoe --max-objects=1024 --max-size=1024B
 
 
 A negative value for num objects and / or max size means that the

--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -187,6 +187,7 @@ T strict_si_cast(const char *str, std::string *err)
 
 template int strict_si_cast<int>(const char *str, std::string *err);
 template long long strict_si_cast<long long>(const char *str, std::string *err);
+template int64_t strict_si_cast<int64_t>(const char *str, std::string *err);
 template uint64_t strict_si_cast<uint64_t>(const char *str, std::string *err);
 template uint32_t strict_si_cast<uint32_t>(const char *str, std::string *err);
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -233,7 +233,7 @@ void _usage()
   cout << "\nQuota options:\n";
   cout << "   --bucket                  specified bucket for quota command\n";
   cout << "   --max-objects             specify max objects (negative value to disable)\n";
-  cout << "   --max-size                specify max size (in bytes, negative value to disable)\n";
+  cout << "   --max-size                specify max size (in B/K/M/G/T, negative value to disable)\n";
   cout << "   --quota-scope             scope of quota (bucket, user)\n";
   cout << "\nOrphans search options:\n";
   cout << "   --pool                    data pool to scan for leaked rados objects in\n";
@@ -1027,7 +1027,11 @@ void set_quota_info(RGWQuotaInfo& quota, int opt_cmd, int64_t max_size, int64_t 
 
     case OPT_QUOTA_SET:
       if (have_max_objects) {
-        quota.max_objects = max_objects;
+        if (max_objects < 0) {
+          quota.max_objects = -1;
+        } else {
+          quota.max_objects = max_objects;
+        }
       }
       if (have_max_size) {
         if (max_size < 0) {
@@ -2148,7 +2152,7 @@ int main(int argc, char **argv)
         return EINVAL;
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--max-size", (char*)NULL)) {
-      max_size = (int64_t)strict_strtoll(val.c_str(), 10, &err);
+      max_size = strict_si_cast<int64_t>(val.c_str(), &err);
       if (!err.empty()) {
         cerr << "ERROR: failed to parse max size: " << err << std::endl;
         return EINVAL;

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -186,7 +186,7 @@
   Quota options:
      --bucket                  specified bucket for quota command
      --max-objects             specify max objects (negative value to disable)
-     --max-size                specify max size (in bytes, negative value to disable)
+     --max-size                specify max size (in B/K/M/G/T, negative value to disable)
      --quota-scope             scope of quota (bucket, user)
   
   Orphans search options:

--- a/src/test/strtol.cc
+++ b/src/test/strtol.cc
@@ -234,6 +234,21 @@ TEST(StrictSICast, Error) {
     (void)strict_si_cast<int>("1T", &err);
     ASSERT_NE(err, "");
   }
+  {
+    std::string err;
+    (void)strict_si_cast<int64_t>("2E", &err);
+    ASSERT_EQ(err, "");
+  }
+  {
+    std::string err;
+    (void)strict_si_cast<int64_t>("-2E", &err);
+    ASSERT_EQ(err, "");
+  }
+  {
+    std::string err;
+    (void)strict_si_cast<int64_t>("1T", &err);
+    ASSERT_EQ(err, "");
+  }
 }
 
 /*


### PR DESCRIPTION
rgw: support size suffixes for --max-size in radosgw-admin command

Fixes: http://tracker.ceph.com/issues/16004

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>