### PR TITLE
kv: add column family support to KeyValueDB and RocksDBStore

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -13,6 +13,7 @@
 #include "include/encoding.h"
 
 using std::string;
+using std::vector;
 /**
  * Defines virtual interface to be implemented by key value store
  *
@@ -20,11 +21,23 @@ using std::string;
  */
 class KeyValueDB {
 public:
+  /*
+   *  See RocksDB's definition of a column family(CF) and how to use it.
+   *  The interfaces of KeyValueDB is extended, when a column family is created.
+   *  Prefix will be the name of column family to use.
+   */
+  struct ColumnFamily {
+    string name;      //< name of this individual column family
+    string option;    //< configure option string for this CF
+    ColumnFamily(const string &name, const string &option)
+      : name(name), option(option) {}
+  };
+
   class TransactionImpl {
   public:
     /// Set Keys
     void set(
-      const std::string &prefix,                 ///< [in] Prefix for keys
+      const std::string &prefix,                      ///< [in] Prefix for keys, or CF name
       const std::map<std::string, bufferlist> &to_set ///< [in] keys/values to set
     ) {
       std::map<std::string, bufferlist>::const_iterator it;
@@ -34,8 +47,8 @@ public:
 
     /// Set Keys (via encoded bufferlist)
     void set(
-      const std::string &prefix,      ///< [in] prefix
-      bufferlist& to_set_bl     ///< [in] encoded key/values to set
+      const std::string &prefix,      ///< [in] prefix, or CF name
+      bufferlist& to_set_bl           ///< [in] encoded key/values to set
       ) {
       bufferlist::iterator p = to_set_bl.begin();
       uint32_t num;
@@ -51,16 +64,16 @@ public:
 
     /// Set Key
     virtual void set(
-      const std::string &prefix,   ///< [in] Prefix for the key
+      const std::string &prefix,      ///< [in] Prefix or CF for the key
       const std::string &k,	      ///< [in] Key to set
-      const bufferlist &bl    ///< [in] Value to set
+      const bufferlist &bl            ///< [in] Value to set
       ) = 0;
 
 
     /// Removes Keys (via encoded bufferlist)
     void rmkeys(
-      const std::string &prefix,   ///< [in] Prefix to search for
-      bufferlist &keys_bl ///< [in] Keys to remove
+      const std::string &prefix,     ///< [in] Prefix or CF to search for
+      bufferlist &keys_bl            ///< [in] Keys to remove
     ) {
       bufferlist::iterator p = keys_bl.begin();
       uint32_t num;
@@ -74,7 +87,7 @@ public:
 
     /// Removes Keys
     void rmkeys(
-      const std::string &prefix,   ///< [in] Prefix to search for
+      const std::string &prefix,        ///< [in] Prefix/CF to search for
       const std::set<std::string> &keys ///< [in] Keys to remove
     ) {
       std::set<std::string>::const_iterator it;
@@ -84,8 +97,8 @@ public:
 
     /// Remove Key
     virtual void rmkey(
-      const std::string &prefix,   ///< [in] Prefix to search for
-      const std::string &k	      ///< [in] Key to remove
+      const std::string &prefix,       ///< [in] Prefix/CF to search for
+      const std::string &k	       ///< [in] Key to remove
       ) = 0;
 
     /// Remove Single Key which exists and was not overwritten.
@@ -94,18 +107,18 @@ public:
     /// If a key is overwritten (by calling set multiple times), then the result
     /// of calling rm_single_key on this key is undefined.
     virtual void rm_single_key(
-      const std::string &prefix,   ///< [in] Prefix to search for
+      const std::string &prefix,      ///< [in] Prefix/CF to search for
       const std::string &k	      ///< [in] Key to remove
       ) { return rmkey(prefix, k);}
 
     /// Removes keys beginning with prefix
     virtual void rmkeys_by_prefix(
-      const std::string &prefix ///< [in] Prefix by which to remove keys
+      const std::string &prefix       ///< [in] Prefix/CF by which to remove keys
       ) = 0;
 
     /// Merge value into key
     virtual void merge(
-      const std::string &prefix,   ///< [in] Prefix ==> MUST match some established merge operator
+      const std::string &prefix,   ///< [in] Prefix/CF ==> MUST match some established merge operator
       const std::string &key,      ///< [in] Key to be merged
       const bufferlist  &value     ///< [in] value to be merged into key
     ) { assert(0 == "Not implemented"); }
@@ -123,8 +136,16 @@ public:
   static int test_init(const std::string& type, const std::string& dir);
   virtual int init(string option_str="") = 0;
   virtual int open(std::ostream &out) = 0;
+  virtual int open(std::ostream &out, const vector<ColumnFamily>& cfs) {
+    assert(0 == "Not implemented"); }
   virtual int create_and_open(std::ostream &out) = 0;
   virtual void close() { }
+  // vector cfs contains column families to be created when db is created.
+  virtual int create_and_open(std::ostream &out, const vector<ColumnFamily>& cfs) {
+    assert(0 == "Not implemented"); }
+  virtual int drop_column_family(
+    const string &cf_name         ///< [in] name of CF to delete
+  ) { assert(0 == "Not implemented"); }
 
   virtual Transaction get_transaction() = 0;
   virtual int submit_transaction(Transaction) = 0;
@@ -134,13 +155,13 @@ public:
 
   /// Retrieve Keys
   virtual int get(
-    const std::string &prefix,        ///< [in] Prefix for key
-    const std::set<std::string> &key,      ///< [in] Key to retrieve
-    std::map<std::string, bufferlist> *out ///< [out] Key value retrieved
+    const std::string &prefix,               ///< [in] Prefix/CF for key
+    const std::set<std::string> &key,        ///< [in] Key to retrieve
+    std::map<std::string, bufferlist> *out   ///< [out] Key value retrieved
     ) = 0;
-  virtual int get(const std::string &prefix, ///< [in] prefix
+  virtual int get(const std::string &prefix, ///< [in] prefix or CF name
 		  const std::string &key,    ///< [in] key
-		  bufferlist *value) {  ///< [out] value
+		  bufferlist *value) {       ///< [out] value
     std::set<std::string> ks;
     ks.insert(key);
     std::map<std::string,bufferlist> om;
@@ -167,6 +188,8 @@ public:
     virtual ~GenericIteratorImpl() {}
   };
 
+  /// When Column Family is used, WholeSpaceIterator is limited to the default column family,
+  /// and user can still use multiple prefixes within the default CF.
   class WholeSpaceIteratorImpl {
   public:
     virtual int seek_to_first() = 0;
@@ -195,85 +218,152 @@ public:
   };
   typedef ceph::shared_ptr< WholeSpaceIteratorImpl > WholeSpaceIterator;
 
+  /// Iterator for column family which is created explicitly and not the default one.
+  class ColumnFamilyIteratorImpl {
+  public:
+    virtual int seek_to_first() = 0;
+    virtual int seek_to_last() = 0;
+    virtual int upper_bound(const std::string &after) = 0;
+    virtual int lower_bound(const std::string &to) = 0;
+    virtual bool valid() = 0;
+    virtual int next() = 0;
+    virtual int prev() = 0;
+    virtual std::string key() = 0;
+    virtual bufferlist value() = 0;
+    virtual bufferptr value_as_ptr() {
+      bufferlist bl = value();
+      if (bl.length()) {
+        return *bl.buffers().begin();
+      } else {
+        return bufferptr();
+      }
+    }
+    virtual int status() = 0;
+    virtual ~ColumnFamilyIteratorImpl() { }
+  };
+  typedef ceph::shared_ptr< ColumnFamilyIteratorImpl > ColumnFamilyIterator;
+
   class IteratorImpl : public GenericIteratorImpl {
-    const std::string prefix;
+    const std::string prefix;         //prefix or CF name
     WholeSpaceIterator generic_iter;
+    ColumnFamilyIterator cf_iter;
+    bool is_cf;                       //is it for a explicit column family
   public:
     IteratorImpl(const std::string &prefix, WholeSpaceIterator iter) :
-      prefix(prefix), generic_iter(iter) { }
+      prefix(prefix), generic_iter(iter), is_cf(false) { }
+    IteratorImpl(const std::string &cf_name, ColumnFamilyIterator iter) :
+      prefix(cf_name), cf_iter(iter), is_cf(true) { }
     virtual ~IteratorImpl() { }
 
     int seek_to_first() {
-      return generic_iter->seek_to_first(prefix);
+      return is_cf ? cf_iter->seek_to_first() :
+                     generic_iter->seek_to_first(prefix);
     }
     int seek_to_last() {
-      return generic_iter->seek_to_last(prefix);
+      return is_cf ? cf_iter->seek_to_last() :
+                     generic_iter->seek_to_last(prefix);
     }
     int upper_bound(const std::string &after) {
-      return generic_iter->upper_bound(prefix, after);
+      return is_cf ? cf_iter->upper_bound(after) :
+                     generic_iter->upper_bound(prefix, after);
     }
     int lower_bound(const std::string &to) {
-      return generic_iter->lower_bound(prefix, to);
+      return is_cf ? cf_iter->lower_bound(to) :
+                     generic_iter->lower_bound(prefix, to);
     }
     bool valid() {
-      if (!generic_iter->valid())
-	return false;
-      return generic_iter->raw_key_is_prefixed(prefix);
+      if (is_cf) {
+        return cf_iter->valid();
+      } else {
+        if (!generic_iter->valid())
+	  return false;
+        return generic_iter->raw_key_is_prefixed(prefix);
+      }
     }
     // Note that next() and prev() shouldn't validate iters,
     // it's responsibility of caller to ensure they're valid.
     int next(bool validate=true) {
       if (validate) {
         if (valid())
-          return generic_iter->next();
+          return is_cf ? cf_iter->next() : generic_iter->next();
         return status();
       } else {
-        return generic_iter->next();  
+        return is_cf ? cf_iter->next() : generic_iter->next();  
       }      
     }
     
     int prev(bool validate=true) {
       if (validate) {
         if (valid())
-          return generic_iter->prev();
+          return is_cf ? cf_iter->prev() : generic_iter->prev();
         return status();
       } else {
-        return generic_iter->prev();  
+        return is_cf ? cf_iter->prev() : generic_iter->prev();
       }      
     }
     std::string key() {
-      return generic_iter->key();
+      return is_cf ? cf_iter->key() : generic_iter->key();
     }
+    // For column family, keys actually don't contain prefix;
+    // to make interface compatible, prefix is added.
     std::pair<std::string, std::string> raw_key() {
-      return generic_iter->raw_key();
+      return is_cf ? make_pair(prefix, cf_iter->key()) : generic_iter->raw_key();
     }
     bufferlist value() {
-      return generic_iter->value();
+      return is_cf ? cf_iter->value() : generic_iter->value();
     }
     bufferptr value_as_ptr() {
-      return generic_iter->value_as_ptr();
+      return is_cf ? cf_iter->value_as_ptr() : generic_iter->value_as_ptr();
     }
     int status() {
-      return generic_iter->status();
+      return is_cf ? cf_iter->status() : generic_iter->status();
     }
   };
-
   typedef ceph::shared_ptr< IteratorImpl > Iterator;
 
   WholeSpaceIterator get_iterator() {
     return _get_iterator();
   }
 
-  Iterator get_iterator(const std::string &prefix) {
-    return std::make_shared<IteratorImpl>(prefix, get_iterator());
+  ColumnFamilyIterator get_cf_iterator(const std::string& cf_name) {
+    return _get_cf_iterator(cf_name);
   }
 
   WholeSpaceIterator get_snapshot_iterator() {
     return _get_snapshot_iterator();
   }
 
+  ColumnFamilyIterator get_cf_snapshot_iterator(const std::string& cf_name) {
+    return _get_cf_snapshot_iterator(cf_name);
+  }
+
+  void add_column_family(const std::string& cf_name, void *handle) {
+    cf_handles.insert(std::make_pair(cf_name, handle));
+  }
+
+  void *get_cf_handle(const std::string& cf_name) {
+    std::unordered_map<std::string, void*>::const_iterator iter;
+    iter = cf_handles.find(cf_name);
+    if (iter == cf_handles.end())
+      return nullptr;
+    else
+      return iter->second;
+  }
+
+  bool is_column_family(const std::string& prefix) {
+    return cf_handles.count(prefix); 
+  }
+
+  Iterator get_iterator(const std::string &prefix) {
+    return is_column_family(prefix) ?
+             std::make_shared<IteratorImpl>(prefix, get_cf_iterator(prefix)) :
+             std::make_shared<IteratorImpl>(prefix, get_iterator());
+  }
+
   Iterator get_snapshot_iterator(const std::string &prefix) {
-    return std::make_shared<IteratorImpl>(prefix, get_snapshot_iterator());
+    return is_column_family(prefix) ?
+             std::make_shared<IteratorImpl>(prefix, get_cf_snapshot_iterator(prefix)) :
+             std::make_shared<IteratorImpl>(prefix, get_snapshot_iterator());
   }
 
   virtual uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) = 0;
@@ -321,12 +411,19 @@ public:
   }
 
 protected:
-  /// List of matching prefixes and merge operators
+  /// List of matching prefixes/ColumnFamilies and merge operators
   std::vector<std::pair<std::string,
 			std::shared_ptr<MergeOperator> > > merge_ops;
 
+  /// column families in use, name->handle
+  std::unordered_map<std::string, void *> cf_handles;
+
   virtual WholeSpaceIterator _get_iterator() = 0;
   virtual WholeSpaceIterator _get_snapshot_iterator() = 0;
+  virtual ColumnFamilyIterator _get_cf_iterator(const std::string& cf_name) {
+    assert(0 == "Not implemented"); }
+  virtual ColumnFamilyIterator _get_cf_snapshot_iterator(const std::string& cf_name) {
+    assert(0 == "Not implemented"); }
 };
 
 #endif

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -67,6 +67,7 @@ class RocksDBStore : public KeyValueDB {
   rocksdb::Env *env;
   string options_str;
   int create_db_dir();
+  int install_cf_mergeop(const string &cf_name, rocksdb::ColumnFamilyOptions *cf_opt);
   int do_open(ostream &out, bool create_if_missing,
 	      const vector<ColumnFamily>* cfs = nullptr);
 

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -35,6 +35,11 @@ public:
 
   KVTest() : db(0) {}
 
+  string _bl_to_str(bufferlist val) {
+    string str(val.c_str(), val.length());
+    return str;
+  }
+
   void rm_r(string path) {
     string cmd = string("rm -r ") + path;
     cout << "==> " << cmd << std::endl;
@@ -199,7 +204,6 @@ struct AppendMOP : public KeyValueDB::MergeOperator {
     const char *ldata, size_t llen,
     const char *rdata, size_t rlen,
     std::string *new_value) {
-
     *new_value = std::string(ldata, llen) + std::string(rdata, rlen);
   }
   // We use each operator name and each prefix to construct the
@@ -255,6 +259,110 @@ TEST_P(KVTest, Merge) {
   fini();
 }
 
+TEST_P(KVTest, RocksDBColumnFamilyTest) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  cfs.push_back(KeyValueDB::ColumnFamily("cf2", ""));
+  ASSERT_EQ(0, db->init(g_conf->bluestore_rocksdb_options));
+  cout << "creating two column families and opening them" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist value;
+    value.append("value");
+    cout << "write a transaction includes three keys in different CFs" << std::endl;
+    t->set("prefix", "key", value);
+    t->set("cf1", "key", value);
+    t->set("cf2", "key2", value);
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  fini();
+
+  init();
+  ASSERT_EQ(0, db->open(cout, cfs));
+  {
+    bufferlist v1, v2, v3;
+    cout << "reopen db and read those keys" << std::endl;
+    ASSERT_EQ(0, db->get("prefix", "key", &v1));
+    ASSERT_EQ(0, _bl_to_str(v1) != "value");
+    ASSERT_EQ(0, db->get("cf1", "key", &v2));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+    ASSERT_EQ(0, db->get("cf2", "key2", &v3));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+  }
+  {
+    cout << "delete two keys in CFs" << std::endl;
+    KeyValueDB::Transaction t = db->get_transaction();
+    t->rmkey("prefix", "key");
+    t->rmkey("cf2", "key2");
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  fini();
+
+  init();
+  ASSERT_EQ(0, db->open(cout, cfs));
+  {
+    cout << "reopen db and read keys again." << std::endl;
+    bufferlist v1, v2, v3;
+    ASSERT_EQ(-ENOENT, db->get("prefix", "key", &v1));
+    ASSERT_EQ(0, db->get("cf1", "key", &v2));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+    ASSERT_EQ(-ENOENT, db->get("cf2", "key2", &v3));
+  }
+  fini();
+}
+
+TEST_P(KVTest, RocksDBIteratorTest) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  ASSERT_EQ(0, db->init(g_conf->bluestore_rocksdb_options));
+  cout << "creating one column family and opening it" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist bl1;
+    bl1.append("hello");
+    bufferlist bl2;
+    bl2.append("world");
+    cout << "write some kv pairs into default and new CFs" << std::endl;
+    t->set("prefix", "key1", bl1);
+    t->set("prefix", "key2", bl2);
+    t->set("cf1", "key1", bl1);
+    t->set("cf1", "key2", bl2);
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  {
+    cout << "iterating the default CF" << std::endl;
+    KeyValueDB::Iterator iter = db->get_iterator("prefix");
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  {
+    cout << "iterating the new CF" << std::endl;
+    KeyValueDB::Iterator iter = db->get_iterator("cf1");
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  fini();
+}
 
 INSTANTIATE_TEST_CASE_P(
   KeyValueDB,


### PR DESCRIPTION
Column family is a very useful feature which RocksDB provides, basically user can create a dedicated column family for one kind of prefixed keys, and RocksDB will create dedicated LSM tree for it, still a transaction includes multiple kv updates into different CFs can be atomic.

This PR adds CF support into KeyValueDB interface and RocksDBStore implementation. The basic model is, the default column family can still have multiple prefixes, while each explicitly created column family can only have on prefix which is the name of the CF. All old APIs are kept backward compatible, user will have to call new API to create column families for some prefixes, then use old get/set APIs to access prefixed keys. RocksDBStore internally will remember all opened column families, if prefix matches name of created column family, it will go to that column family. By doing this, current modules who are using RocksDB only need small changes during init to enable this feature.
