### PR TITLE
rgw/put: fix the 'ret' value of RGWPutObj

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2478,7 +2478,7 @@ void RGWPutObj::execute()
   } while (len > 0);
 
   if (!chunked_upload && ofs != s->content_length) {
-    op_ret = -ERR_REQUEST_TIMEOUT;
+    op_ret = -ERR_LENGTH_REQUIRED;
     goto done;
   }
   s->obj_size = ofs;


### PR DESCRIPTION
May be we should set `ret` value to `-ERR_LENGTH_REQUIRED`
if that `ofs != s->content_length` happens.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>