### PR TITLE
[RFC] shutdown PGs before osd aborting

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -94,6 +94,7 @@ const int SKIP_MOUNT_OMAP = 1 << 1;
 class ObjectStore {
 protected:
   string path;
+  Context* on_abort = NULL;
 
 public:
   /**
@@ -111,6 +112,10 @@ public:
 			     const string& data,
 			     const string& journal,
 			     osflagbits_t flags = 0);
+
+  void set_on_abort(Context* c) {
+    on_abort = c;
+  }
 
   /**
    * probe a block device to learn the uuid of the owning OSD

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2974,6 +2974,7 @@ void FileStore::_do_transaction(
 	  dump_open_fds(g_ceph_context);
 	}
 
+	on_abort->complete(r);
 	assert(0 == "unexpected error");
       }
     }

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -1026,6 +1026,7 @@ int FileStore::mkjournal()
 
   new_journal();
   if (journal) {
+    journal->set_on_abort(on_abort);
     ret = journal->check();
     if (ret < 0) {
       ret = journal->create();

--- a/src/os/filestore/Journal.h
+++ b/src/os/filestore/Journal.h
@@ -35,6 +35,7 @@ public:
 protected:
   Cond *do_sync_cond;
   bool wait_on_full;
+  Context *on_abort;
 
 public:
   Journal(uuid_d f, Finisher *fin, Cond *c=0) :
@@ -42,6 +43,10 @@ public:
     do_sync_cond(c),
     wait_on_full(false) { }
   virtual ~Journal() { }
+
+  void set_on_abort(Context *c) {
+    on_abort = c;
+  }
 
   virtual int check() = 0;   ///< check if journal appears valid
   virtual int create() = 0;  ///< create a fresh journal

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -1002,6 +1002,8 @@ void MemStore::_do_transaction(Transaction& t)
 	f.close_section();
 	f.flush(*_dout);
 	*_dout << dendl;
+
+	on_abort->complete(r);
 	assert(0 == "unexpected error");
       }
     }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1716,6 +1716,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
                                          cct->_conf->osd_op_log_threshold);
   op_tracker.set_history_size_and_duration(cct->_conf->osd_op_history_size,
                                            cct->_conf->osd_op_history_duration);
+  store->set_on_abort(new C_OSD_OnAbort(this));
 }
 
 OSD::~OSD()

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2611,6 +2611,19 @@ void OSD::kick_pgs(bool flush)
   clear_pg_stat_queue();
 }
 
+void OSD::on_abort()
+{
+  if (!service.prepare_to_stop())
+    return; // already shutting down
+  osd_lock.Lock();
+  if (is_stopping()) {
+    osd_lock.Unlock();
+    return;
+  }
+  // Shutdown PGs
+  kick_pgs(true);
+}
+
 int OSD::shutdown()
 {
   if (!service.prepare_to_stop())

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2494,6 +2494,7 @@ public:
 
   int enable_disable_fuse(bool stop);
 
+  void kick_pgs(bool flush);
   int shutdown();
 
   void handle_signal(int signum);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2494,6 +2494,15 @@ public:
 
   int enable_disable_fuse(bool stop);
 
+  class C_OSD_OnAbort : public Context {
+    OSD *osd;
+  public:
+    C_OSD_OnAbort(OSD *o) : osd(o) {}
+    void finish(int r) {
+      osd->on_abort();
+    }
+  };
+
   void kick_pgs(bool flush);
   void on_abort();
   int shutdown();

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2495,6 +2495,7 @@ public:
   int enable_disable_fuse(bool stop);
 
   void kick_pgs(bool flush);
+  void on_abort();
   int shutdown();
 
   void handle_signal(int signum);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2494,7 +2494,6 @@ public:
 
   int enable_disable_fuse(bool stop);
 
-  void suicide(int exitcode);
   int shutdown();
 
   void handle_signal(int signum);


### PR DESCRIPTION
When we meet an IO error in objectstore, we will assert(0) to abort our osd. But there is a problem in this case, that there have to be a time window to let heartbeat to detect this osd is down. In this window, the writings from user are blocked. Like below:
```
bench-write  io_size 4096 io_threads 16 bytes 1073741824 pattern sequential
  SEC       OPS   OPS/SEC   BYTES/SEC
    1      2898   2919.88  11959848.38
    2      6144   3082.58  12626249.21
    4      7016   1695.09  6943094.20
    5      7031   1226.59  5024098.20
    6      7046   1158.64  4745802.87
    7      9113   1034.27  4236364.20
    8     11897    958.92  3927740.74
    9     13234   1217.30  4986075.15
   10     14281   1687.51  6912041.28
   11     15326   1688.41  6915719.55
   12     17399   1573.81  6446337.95
   13     18587   1338.00  5480467.11
2016-05-25 03:18:53.431546 7f76907f8700  0 -- 192.168.1.119:0/3735375193 >> 192.168.1.119:6800/17940 pipe(0x7f76800053d0 sd=12 :0 s=1 pgs=0 cs=0 l=1 c=0x7f7680003070).fault
   37     19476    223.10  913799.40
   38     21556    259.58  1063256.69
   39     23537    293.26  1201204.65

```
Okey, that would be reduced by setting the config of osd_heartbeat_interval and osd_heartbeat_grace. But that time window will not disappear. The minimum number is about 5s in my testing.

That would cause the service to be paused, that's not acceptable in some cases. This patch will mark osd to be DOWN and shutdown related PGs before aborting. Then the pause problem is solved.