### PR TITLE
jewel: rbd-mirror should disable the rbd cache for local images

### DIFF
--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -74,6 +74,7 @@ public:
   TestImageReplayer() : m_watch_handle(0)
   {
     EXPECT_EQ("", connect_cluster_pp(m_local_cluster));
+    EXPECT_EQ(0, m_local_cluster.conf_set("rbd_cache", "false"));
 
     m_local_pool_name = get_temp_pool_name();
     EXPECT_EQ(0, m_local_cluster.pool_create(m_local_pool_name.c_str()));
@@ -81,6 +82,7 @@ public:
 					      m_local_ioctx));
 
     EXPECT_EQ("", connect_cluster_pp(m_remote_cluster));
+    EXPECT_EQ(0, m_remote_cluster.conf_set("rbd_cache", "false"));
 
     m_remote_pool_name = get_temp_pool_name();
     EXPECT_EQ(0, m_remote_cluster.pool_create(m_remote_pool_name.c_str()));

--- a/src/test/rbd_mirror/test_fixture.cc
+++ b/src/test/rbd_mirror/test_fixture.cc
@@ -23,6 +23,7 @@ TestFixture::TestFixture() {
 
 void TestFixture::SetUpTestCase() {
   ASSERT_EQ("", connect_cluster_pp(_rados));
+  ASSERT_EQ(0, _rados.conf_set("rbd_cache", "false"));
 
   _local_pool_name = get_temp_pool_name("test-rbd-mirror-");
   ASSERT_EQ(0, _rados.pool_create(_local_pool_name.c_str()));

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -304,6 +304,8 @@ int Replayer::init()
     }
   }
 
+  // disable unnecessary librbd cache
+  cct->_conf->set_val_or_die("rbd_cache", "false");
   cct->_conf->apply_changes(nullptr);
   cct->_conf->complain_about_parse_errors(cct);
 

--- a/src/tools/rbd_mirror/main.cc
+++ b/src/tools/rbd_mirror/main.cc
@@ -61,6 +61,9 @@ int main(int argc, const char **argv)
   std::vector<const char*> cmd_args;
   argv_to_vec(argc, argv, cmd_args);
 
+  // disable unnecessary librbd cache
+  g_ceph_context->_conf->set_val_or_die("rbd_cache", "false");
+
   mirror = new rbd::mirror::Mirror(g_ceph_context, cmd_args);
   int r = mirror->init();
   if (r < 0) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/15956