### PR TITLE
rgw: fix error handling in RGWBulkDelete::execute.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8,6 +8,8 @@
 #include <sstream>
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/optional.hpp>
+#include <boost/utility/in_place_factory.hpp>
 
 #include "common/Clock.h"
 #include "common/armor.h"
@@ -3322,12 +3324,7 @@ int RGWDeleteObj::handle_slo_manifest(bufferlist& bl)
     return -EIO;
   }
 
-  try {
-    deleter = std::unique_ptr<RGWBulkDelete::Deleter>(\
-          new RGWBulkDelete::Deleter(store, s));
-  } catch (std::bad_alloc) {
-    return -ENOMEM;
-  }
+  deleter = boost::in_place(RGWBulkDelete::Deleter(store, s));
 
   list<RGWBulkDelete::acct_path_t> items;
   for (const auto& iter : slo_info.entries) {
@@ -5125,7 +5122,7 @@ void RGWBulkDelete::pre_exec()
 
 void RGWBulkDelete::execute()
 {
-  deleter = std::unique_ptr<Deleter>(new RGWBulkDelete::Deleter(store, s));
+  deleter = boost::in_place(RGWBulkDelete::Deleter(store, s));
 
   bool is_truncated = false;
   do {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3358,10 +3358,8 @@ int RGWDeleteObj::handle_slo_manifest(bufferlist& bl)
   path.obj_key = s->object;
   items.push_back(path);
 
-  int ret = deleter->delete_chunk(items);
-  if (ret < 0) {
-    return ret;
-  }
+  /* Errors are stored internally for the dedicated response printer. */
+  deleter->delete_chunk(items);
 
   return 0;
 }
@@ -5127,18 +5125,19 @@ void RGWBulkDelete::pre_exec()
 
 void RGWBulkDelete::execute()
 {
-  deleter = std::unique_ptr<Deleter>(new Deleter(store, s));
+  deleter = std::unique_ptr<Deleter>(new RGWBulkDelete::Deleter(store, s));
 
   bool is_truncated = false;
   do {
     list<RGWBulkDelete::acct_path_t> items;
 
-    int ret = get_data(items, &is_truncated);
-    if (ret < 0) {
+    op_ret = get_data(items, &is_truncated);
+    if (op_ret < 0) {
       return;
     }
 
-    ret = deleter->delete_chunk(items);
+    /* Errors are stored internally for the dedicated response printer. */
+    deleter->delete_chunk(items);
   } while (!op_ret && is_truncated);
 
   return;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -249,12 +249,10 @@ public:
   static const size_t MAX_CHUNK_ENTRIES = 1024;
 
 protected:
-  std::unique_ptr<Deleter> deleter;
+  boost::optional<Deleter> deleter;
 
 public:
-  RGWBulkDelete()
-    : deleter(nullptr) {
-  }
+  RGWBulkDelete() = default;
 
   int verify_permission();
   void pre_exec();
@@ -859,14 +857,13 @@ protected:
   string version_id;
   ceph::real_time unmod_since; /* if unmodified since */
   bool no_precondition_error;
-  std::unique_ptr<RGWBulkDelete::Deleter> deleter;
+  boost::optional<RGWBulkDelete::Deleter> deleter;
 
 public:
   RGWDeleteObj()
     : delete_marker(false),
       multipart_delete(false),
-      no_precondition_error(false),
-      deleter(nullptr) {
+      no_precondition_error(false) {
   }
 
   int verify_permission();


### PR DESCRIPTION
This is continuation of PR #8092.
