### PR TITLE
jewel: ceph: cli: exception when pool name has non-ascii characters

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -892,7 +892,7 @@ def main():
 
         if ret < 0:
             ret = -ret
-            print('Error {0}: {1}'.format(errno.errorcode.get(ret, 'Unknown'), outs), file=sys.stderr)
+            print(u'Error {0}: {1}'.format(errno.errorcode.get(ret, 'Unknown'), outs), file=sys.stderr)
             if len(targets) > 1:
                 final_ret = ret
             else:


### PR DESCRIPTION
http://tracker.ceph.com/issues/16017