### PR TITLE
[DNM] rbd: Create fewer empty objects

### DIFF
--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -313,7 +313,7 @@ namespace librbd {
 
   bool AbstractAioObjectWrite::should_complete(int r)
   {
-    ldout(m_ictx->cct, 20) << get_write_type() << " " << this << " " << m_oid
+    ldout(m_ictx->cct, 20) << get_op_type() << " " << this << " " << m_oid
                            << " " << m_object_off << "~" << m_object_len
 			   << " should_complete: r = " << r << dendl;
 
@@ -363,6 +363,16 @@ namespace librbd {
       }
       break;
 
+    case LIBRBD_AIO_WRITE_OBJECT_MAP:
+      ldout(m_ictx->cct, 20) << "OBJECT_MAP" << dendl;
+      finished = false;
+      if (r < 0) {
+	m_state = LIBRBD_AIO_WRITE_ERROR;
+	complete(r);
+      }
+      send_write_op();
+      break;
+
     case LIBRBD_AIO_WRITE_FLAT:
       ldout(m_ictx->cct, 20) << "WRITE_FLAT" << dendl;
 
@@ -385,21 +395,52 @@ namespace librbd {
 
   void AbstractAioObjectWrite::send() {
     assert(m_ictx->owner_lock.is_locked());
-    ldout(m_ictx->cct, 20) << "send " << get_write_type() << " " << this <<" "
+    ldout(m_ictx->cct, 20) << "send " << get_op_type() << " " << this <<" "
                            << m_oid << " " << m_object_off << "~"
                            << m_object_len << dendl;
     send_pre();
   }
 
+  void AbstractAioObjectWrite::send_object_map_update() {
+    ldout(m_ictx->cct, 20) << "update object map" << dendl;
+
+    if (!m_ictx->object_map) {
+      send_write_op();
+      return;
+    }
+
+    ldout(m_ictx->cct, 20) << "update required" << dendl;
+
+    m_state = LIBRBD_AIO_WRITE_OBJECT_MAP;
+
+    uint8_t new_state;
+    boost::optional<uint8_t> current_state;
+
+    assert(m_ictx->owner_lock.is_locked());
+    {
+      RWLock::RLocker snap_lock(m_ictx->snap_lock);
+
+      pre_object_map_update(&new_state);
+      RWLock::WLocker object_map_locker(m_ictx->object_map_lock);
+      if ((*m_ictx->object_map)[m_object_no] != new_state) {
+	Context *ctx = util::create_context_callback<AioObjectRequest>(this);
+	bool updated = m_ictx->object_map->aio_update(m_object_no, new_state,
+						      current_state, ctx);
+	assert(updated);
+	return;
+      }
+    }
+
+    send_write_op();
+  }
+
   void AbstractAioObjectWrite::send_pre() {
     assert(m_ictx->owner_lock.is_locked());
 
-    bool write = false;
     {
       RWLock::RLocker snap_lock(m_ictx->snap_lock);
       if (m_ictx->object_map == nullptr) {
         m_object_exist = true;
-        write = true;
       } else {
         // should have been flushed prior to releasing lock
         assert(m_ictx->exclusive_lock->is_lock_owner());
@@ -410,27 +451,10 @@ namespace librbd {
           		       << m_object_off << "~" << m_object_len << dendl;
         m_state = LIBRBD_AIO_WRITE_PRE;
 
-        uint8_t new_state;
-        boost::optional<uint8_t> current_state;
-        pre_object_map_update(&new_state);
-
-        RWLock::WLocker object_map_locker(m_ictx->object_map_lock);
-        if ((*m_ictx->object_map)[m_object_no] != new_state) {
-          Context *ctx = util::create_context_callback<AioObjectRequest>(this);
-          bool updated = m_ictx->object_map->aio_update(m_object_no, new_state,
-                                                        current_state, ctx);
-          assert(updated);
-        } else {
-          write = true;
-        }
       }
     }
 
-    // avoid possible recursive lock attempts
-    if (write) {
-      // no object map update required
-      send_write();
-    }
+    send_write();
   }
 
   bool AbstractAioObjectWrite::send_post() {
@@ -471,7 +495,8 @@ namespace librbd {
       m_state = LIBRBD_AIO_WRITE_GUARD;
       handle_write_guard();
     } else {
-      send_write_op(true);
+      m_guard = true;
+      send_object_map_update();
     }
   }
 
@@ -500,10 +525,10 @@ namespace librbd {
       m_ictx->copyup_list_lock.Unlock();
     }
   }
-  void AbstractAioObjectWrite::send_write_op(bool write_guard)
+  void AbstractAioObjectWrite::send_write_op()
   {
     m_state = LIBRBD_AIO_WRITE_FLAT;
-    if (write_guard)
+    if (m_guard)
       guard_write();
     add_write_ops(&m_write);
     assert(m_write.size() != 0);
@@ -557,7 +582,8 @@ namespace librbd {
                            << " object exist " << m_object_exist
 			   << " write_full " << write_full << dendl;
     if (write_full && !has_parent()) {
-      send_write_op(false);
+      m_guard = false;
+      send_object_map_update();
     } else {
       AbstractAioObjectWrite::send_write();
     }
@@ -573,7 +599,8 @@ namespace librbd {
   void AioObjectRemove::send_write() {
     ldout(m_ictx->cct, 20) << "send_write " << this << " " << m_oid << " "
 			   << m_object_off << "~" << m_object_len << dendl;
-    send_write_op(true);
+    m_guard = true;
+    send_object_map_update();
   }
   void AioObjectTruncate::send_write() {
     ldout(m_ictx->cct, 20) << "send_write " << this << " " << m_oid

--- a/src/librbd/CopyupRequest.h
+++ b/src/librbd/CopyupRequest.h
@@ -56,7 +56,8 @@ namespace librbd {
      */
     enum State {
       STATE_READ_FROM_PARENT,
-      STATE_OBJECT_MAP,
+      STATE_OBJECT_MAP_HEAD,
+      STATE_OBJECT_MAP_SNAP,
       STATE_COPYUP
     };
 
@@ -79,8 +80,10 @@ namespace librbd {
 
     void remove_from_list();
 
-    bool send_object_map();
+    bool send_object_map_head();
+    bool send_object_map_snap();
     bool send_copyup();
+    bool is_nop();
   };
 }
 

--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -854,11 +854,11 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </snapshots>
   $ rbd disk-usage --pool rbd_other
   NAME                    PROVISIONED  USED 
-  child@snap                     512M  512M 
-  child                          512M  512M 
-  deep-flatten-child@snap        512M  512M 
-  deep-flatten-child             512M  512M 
-  <TOTAL>                       1024M 2048M 
+  child@snap                     512M     0 
+  child                          512M 4096k 
+  deep-flatten-child@snap        512M     0 
+  deep-flatten-child             512M     0 
+  <TOTAL>                       1024M 4096k 
   $ rbd disk-usage --pool rbd_other --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "images": [
@@ -866,27 +866,27 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
               "name": "child", 
               "provisioned_size": 536870912, 
               "snapshot": "snap", 
-              "used_size": 536870912
+              "used_size": 0
           }, 
           {
               "name": "child", 
               "provisioned_size": 536870912, 
-              "used_size": 536870912
+              "used_size": 4194304
           }, 
           {
               "name": "deep-flatten-child", 
               "provisioned_size": 536870912, 
               "snapshot": "snap", 
-              "used_size": 536870912
+              "used_size": 0
           }, 
           {
               "name": "deep-flatten-child", 
               "provisioned_size": 536870912, 
-              "used_size": 536870912
+              "used_size": 0
           }
       ], 
       "total_provisioned_size": 1073741824, 
-      "total_used_size": 2147483648
+      "total_used_size": 4194304
   }
   $ rbd disk-usage --pool rbd_other --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
   <stats>
@@ -895,27 +895,27 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
         <name>child</name>
         <snapshot>snap</snapshot>
         <provisioned_size>536870912</provisioned_size>
-        <used_size>536870912</used_size>
+        <used_size>0</used_size>
       </image>
       <image>
         <name>child</name>
         <provisioned_size>536870912</provisioned_size>
-        <used_size>536870912</used_size>
+        <used_size>4194304</used_size>
       </image>
       <image>
         <name>deep-flatten-child</name>
         <snapshot>snap</snapshot>
         <provisioned_size>536870912</provisioned_size>
-        <used_size>536870912</used_size>
+        <used_size>0</used_size>
       </image>
       <image>
         <name>deep-flatten-child</name>
         <provisioned_size>536870912</provisioned_size>
-        <used_size>536870912</used_size>
+        <used_size>0</used_size>
       </image>
     </images>
     <total_provisioned_size>1073741824</total_provisioned_size>
-    <total_used_size>2147483648</total_used_size>
+    <total_used_size>4194304</total_used_size>
   </stats>
 
 # cleanup

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2331,8 +2331,11 @@ void scribble(librbd::Image& image, int n, int max,
 
     } else {
       bufferlist bl;
+      char *buf = new char[len];
       bl.append(buffer::create(len));
-      bl.zero();
+      memset(buf, 1, len);
+      bl.copy_in(0, len, buf);
+      delete buf;
       ASSERT_EQ((int)len, image.write(off, len, bl));
       interval_set<uint64_t> w;
       w.insert(off, len);


### PR DESCRIPTION
In many cases, we unconditionally create empty objects (of size 0) when
performing layered writes. While functionally correct, this causes tools
like rbd du to space is allocated (since they conservatively assume all
objects are full). Detect empty writes and bail out early. This is
particularly helpful for operations like flatten, which create all
objects that might exist in an image.       

Fixes: http://tracker.ceph.com/issues/15028
Signed-off-by: Douglas Fuller dfuller@redhat.com  
