### PR TITLE
packaging: drop python-flask dependency from radosgw

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -313,12 +313,6 @@ Requires:	librados2 = %{epoch}:%{version}-%{release}
 Requires:	librgw2 = %{epoch}:%{version}-%{release}
 %if 0%{?rhel} || 0%{?fedora}
 Requires:	mailcap
-# python-flask for powerdns
-Requires:	python-flask
-%endif
-%if 0%{?suse_version}
-# python-Flask for powerdns
-Requires:      python-Flask
 %endif
 %description radosgw
 RADOS is a distributed object store used by the Ceph distributed

--- a/debian/control
+++ b/debian/control
@@ -599,7 +599,6 @@ Package: radosgw
 Architecture: linux-any
 Depends: ceph-common (= ${binary:Version}),
          mime-support,
-         python-flask,
          librgw2 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
The PowerDNS integration code itself is not packaged at this point, so remove the python-flask dependency from the radosgw package.

Maybe the PowerDNS integration bits could live in a separate sub-package, eventually.

Fixes: http://tracker.ceph.com/issues/16032