### PR TITLE
cephfs: should give a value before use cpp_strerror

### DIFF
--- a/src/cephfs.cc
+++ b/src/cephfs.cc
@@ -194,6 +194,7 @@ int init_options(int argc, char **argv, int *fd, char **path, int *cmd,
 
   *fd = open(argv[1], O_RDONLY);
   if (*fd < 0) {
+    *fd = -errno;
     cerr << "error opening path: " << cpp_strerror(*fd) << endl;
     return 1;
   }


### PR DESCRIPTION
cephfs: should give a value before use cpp_strerror

Signed-off-by:song baisen <song.baisen@zte.com.cn>