### PR TITLE
mon:quickly return on on_active function

### DIFF
--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -114,6 +114,7 @@ void MonmapMonitor::on_active()
     t->put(Monitor::MONITOR_NAME, "joined", 1);
     mon->store->apply_transaction(t);
     mon->has_ever_joined = true;
+    return;
   }
 
   if (mon->is_leader())


### PR DESCRIPTION
mon:quickly return on on_active function

If we are not quorum must be not leader too.
So here quickly return.

Signed-off-by:song baisen <song.baisen@zte.com.cn>