### PR TITLE
mds: mds-daemon init fixup

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1049,6 +1049,10 @@ void MDSDaemon::handle_signal(int signum)
 void MDSDaemon::suicide()
 {
   assert(mds_lock.is_locked());
+  
+  // make sure we don't suicide twice
+  assert(stopping == false);
+  stopping = true;
 
   dout(1) << "suicide.  wanted state "
           << ceph_mds_state_name(beacon.get_want_state()) << dendl;

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -539,6 +539,9 @@ int MDSDaemon::init()
   mds_lock.Lock();
   if (beacon.get_want_state() == MDSMap::STATE_DNE) {
     suicide();  // we could do something more graceful here
+    dout(4) << __func__ << ": terminated already, dropping out" << dendl;
+    mds_lock.Unlock();
+    return 0; 
   }
 
   timer.init();

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -662,7 +662,10 @@ void MDSRank::_advance_queues()
       old->put();
     } else {
       dout(7) << " processing laggy deferred " << *old << dendl;
-      handle_deferrable_message(old);
+      if (!handle_deferrable_message(old)) {
+        dout(0) << "unrecognized message " << *old << dendl;
+        old->put();
+      }
     }
 
     heartbeat_reset();


### PR DESCRIPTION
1. set stopping to true during suicide()
2. make a quick exit if suicide()
3. drop reference if message in laggy queue is unrecognized

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>