### PR TITLE
rgw/rados: remove confused error printout

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -10805,7 +10805,8 @@ int RGWRados::list_raw_objects(rgw_bucket& pool, const string& prefix_filter,
   vector<RGWObjEnt> objs;
   int r = pool_iterate(ctx.iter_ctx, max, objs, is_truncated, &filter);
   if (r < 0) {
-    ldout(cct, 10) << "failed to list objects pool_iterate returned r=" << r << dendl;
+    if(r != -ENOENT)
+      ldout(cct, 10) << "failed to list objects pool_iterate returned r=" << r << dendl;
     return r;
   }
 


### PR DESCRIPTION
Maybe we should not print or log this failed message when 
the `pool_iterate` returns `-ENOENT` which means no objects but failed.

this message will be print on the screen in the `hammer` version.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>