### PR TITLE
mon: snaps state clean on tier change

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -274,7 +274,7 @@ function test_tiering_agent()
   done
   $evicted # assert
   ceph osd tier remove-overlay $slow
-  ceph osd tier remove $slow $fast
+  ceph osd tier remove $slow $fast --force-nonempty
   ceph osd pool delete $fast $fast --yes-i-really-really-mean-it
   ceph osd pool delete $slow $slow --yes-i-really-really-mean-it
 }
@@ -352,7 +352,8 @@ function test_tiering()
   done
   expect_false ceph osd tier add slow cache2
   ceph osd tier add slow cache2 --force-nonempty
-  ceph osd tier remove slow cache2
+  expect_false ceph osd tier remove slow cache2
+  ceph osd tier remove slow cache2 --force-nonempty
 
   ceph osd pool ls | grep cache2
   ceph osd pool ls -f json-pretty | grep cache2

--- a/qa/workunits/rados/test_cache_pool.sh
+++ b/qa/workunits/rados/test_cache_pool.sh
@@ -79,9 +79,9 @@ expect_false diff -q tmp.txt empty.txt
 
 # cleanup
 ceph osd tier remove-overlay base_pool
-ceph osd tier remove base_pool wrong_cache
-ceph osd tier remove base_pool partial_wrong
-ceph osd tier remove base_pool empty_cache
+ceph osd tier remove base_pool wrong_cache --force-nonempty
+ceph osd tier remove base_pool partial_wrong  --force-nonempty
+ceph osd tier remove base_pool empty_cache  --force-nonempty
 ceph osd pool delete base_pool base_pool --yes-i-really-really-mean-it
 ceph osd pool delete empty_cache empty_cache --yes-i-really-really-mean-it
 ceph osd pool delete wrong_cache wrong_cache --yes-i-really-really-mean-it
@@ -129,7 +129,7 @@ rados -p cache ls - | wc -l | grep 0
 
 # cleanup
 ceph osd tier remove-overlay base
-ceph osd tier remove base cache
+ceph osd tier remove base cache --force-nonempty
 
 ceph osd pool delete cache cache --yes-i-really-really-mean-it
 ceph osd pool delete base base --yes-i-really-really-mean-it

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -790,12 +790,14 @@ COMMAND("osd tier add " \
 	"osd", "rw", "cli,rest")
 COMMAND("osd tier remove " \
 	"name=pool,type=CephPoolname " \
-	"name=tierpool,type=CephPoolname",
+	"name=tierpool,type=CephPoolname " \
+	"name=force_nonempty,type=CephChoices,strings=--force-nonempty,req=false",
 	"remove the tier <tierpool> (the second one) from base pool <pool> (the first one)", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd tier rm " \
 	"name=pool,type=CephPoolname " \
-	"name=tierpool,type=CephPoolname",
+	"name=tierpool,type=CephPoolname " \
+	"name=force_nonempty,type=CephChoices,strings=--force-nonempty,req=false",
 	"remove the tier <tierpool> (the second one) from base pool <pool> (the first one)", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd tier cache-mode " \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7180,6 +7180,20 @@ done:
       err = -EBUSY;
       goto reply;
     }
+
+    //make sure no objects leaves on tier(except hit_set_archives)
+    string force_nonempty;
+    cmd_getval(g_ceph_context, cmdmap, "force_nonempty", force_nonempty);
+    const pool_stat_t& tier_stats =
+      mon->pgmon()->pg_map.get_pg_pool_sum_stat(tierpool_id);
+    if ((tier_stats.stats.sum.num_objects -
+         tier_stats.stats.sum.num_objects_hit_set_archive) != 0 &&
+        force_nonempty != "--force-nonempty") {
+      ss << "tier pool '" << tierpoolstr << "' is not empty; --force-nonempty to force";
+      err = -ENOTEMPTY;
+      goto reply;
+    }
+
     // go
     pg_pool_t *np = pending_inc.get_new_pool(pool_id, p);
     pg_pool_t *ntp = pending_inc.get_new_pool(tierpool_id, tp);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -166,6 +166,9 @@ void PGPool::update(OSDMapRef map)
   if ((map->get_epoch() == cached_epoch + 1) &&
       (pi->get_snap_epoch() == map->get_epoch())) {
     updated = true;
+    if (pi->get_last_tier_change() == map->get_epoch()) {
+      cached_removed_snaps.clear();
+    }
     pi->build_removed_snaps(newly_removed_snaps);
     interval_set<snapid_t> intersection;
     intersection.intersection_of(newly_removed_snaps, cached_removed_snaps);
@@ -5533,6 +5536,9 @@ void PG::handle_advance_map(
 	   << dendl;
   update_osdmap_ref(osdmap);
   pool.update(osdmap);
+  if (pool.info.get_last_tier_change() == osdmap->get_epoch()) {
+    info.purged_snaps.clear();
+  }
   AdvMap evt(
     osdmap, lastmap, newup, up_primary,
     newacting, acting_primary);

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1148,6 +1148,7 @@ void pg_pool_t::dump(Formatter *f) const
   f->dump_int("tier_of", tier_of);
   f->dump_int("read_tier", read_tier);
   f->dump_int("write_tier", write_tier);
+  f->dump_int("last_tier_change", last_tier_change);
   f->dump_string("cache_mode", get_cache_mode_name());
   f->dump_unsigned("target_max_bytes", target_max_bytes);
   f->dump_unsigned("target_max_objects", target_max_objects);
@@ -1489,7 +1490,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     return;
   }
 
-  ENCODE_START(24, 5, bl);
+  ENCODE_START(25, 5, bl);
   ::encode(type, bl);
   ::encode(size, bl);
   ::encode(crush_ruleset, bl);
@@ -1538,6 +1539,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
   ::encode(hit_set_grade_decay_rate, bl);
   ::encode(hit_set_search_last_n, bl);
   ::encode(opts, bl);
+  ::encode(last_tier_change, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -1685,6 +1687,11 @@ void pg_pool_t::decode(bufferlist::iterator& bl)
   if (struct_v >= 24) {
     ::decode(opts, bl);
   }
+  if (struct_v >= 25) {
+    ::decode(last_tier_change, bl);
+  } else {
+    last_tier_change = 0;
+  }
   DECODE_FINISH(bl);
   calc_pg_masks();
   calc_grade_table();
@@ -1747,6 +1754,7 @@ void pg_pool_t::generate_test_instances(list<pg_pool_t*>& o)
   a.erasure_code_profile = "profile in osdmap";
   a.expected_num_objects = 123456;
   a.fast_read = false;
+  a.last_tier_change = 10;
   o.push_back(new pg_pool_t(a));
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1221,6 +1221,7 @@ public:
   int64_t read_tier;       ///< pool/tier for objecter to direct reads to
   int64_t write_tier;      ///< pool/tier for objecter to direct writes to
   cache_mode_t cache_mode;  ///< cache pool mode
+  epoch_t last_tier_change;	    ///< osdmap epoch of last being or removing a tier
 
   bool is_tier() const { return tier_of >= 0; }
   bool has_tiers() const { return !tiers.empty(); }
@@ -1312,6 +1313,7 @@ public:
       pg_num_mask(0), pgp_num_mask(0),
       tier_of(-1), read_tier(-1), write_tier(-1),
       cache_mode(CACHEMODE_NONE),
+      last_tier_change(0),
       target_max_bytes(0), target_max_objects(0),
       cache_target_dirty_ratio_micro(0),
       cache_target_dirty_high_ratio_micro(0),
@@ -1363,6 +1365,7 @@ public:
   epoch_t get_last_change() const { return last_change; }
   epoch_t get_last_force_op_resend() const { return last_force_op_resend; }
   epoch_t get_snap_epoch() const { return snap_epoch; }
+  epoch_t get_last_tier_change() const { return last_tier_change; }
   snapid_t get_snap_seq() const { return snap_seq; }
   uint64_t get_auid() const { return auid; }
   unsigned get_crash_replay_interval() const { return crash_replay_interval; }

--- a/src/test/librados/TestCase.cc
+++ b/src/test/librados/TestCase.cc
@@ -118,7 +118,7 @@ void RadosTestParamPPNS::TearDownTestCase()
       inbl, NULL, NULL));
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-      "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+      "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
       inbl, NULL, NULL));
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd pool delete\", \"pool\": \"" + cache_pool_name +
@@ -373,7 +373,7 @@ void RadosTestParamPP::TearDownTestCase()
       inbl, NULL, NULL));
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-      "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+      "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
       inbl, NULL, NULL));
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd pool delete\", \"pool\": \"" + cache_pool_name +

--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -100,7 +100,7 @@ protected:
       inbl, NULL, NULL));
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-      "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+      "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
     // wait for maps to settle before next test
@@ -1835,7 +1835,7 @@ TEST_F(LibRadosTierPP, FlushWriteRaces) {
     inbl, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
   // wait for maps to settle before next test
@@ -2501,7 +2501,7 @@ TEST_F(LibRadosTwoPoolsPP, PromoteOn2ndRead) {
     inbl, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
   // wait for maps to settle before next test
@@ -2559,7 +2559,7 @@ TEST_F(LibRadosTwoPoolsPP, ProxyRead) {
     inbl, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
   // wait for maps to settle before next test
@@ -2710,7 +2710,7 @@ TEST_F(LibRadosTwoPoolsPP, CachePin) {
     inbl, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
   // wait for maps to settle before next test
@@ -2751,7 +2751,7 @@ protected:
       inbl, NULL, NULL));
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-      "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+      "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
     // wait for maps to settle before next test
@@ -4429,7 +4429,7 @@ TEST_F(LibRadosTierECPP, FlushWriteRaces) {
     inbl, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
   // wait for maps to settle before next test
@@ -4773,7 +4773,7 @@ TEST_F(LibRadosTierECPP, CallForcesPromote) {
     inbl, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
   // wait for maps to settle before next test
@@ -5132,7 +5132,7 @@ TEST_F(LibRadosTwoPoolsECPP, PromoteOn2ndRead) {
     inbl, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
   // wait for maps to settle before next test
@@ -5190,7 +5190,7 @@ TEST_F(LibRadosTwoPoolsECPP, ProxyRead) {
     inbl, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
   // wait for maps to settle before next test
@@ -5341,7 +5341,7 @@ TEST_F(LibRadosTwoPoolsECPP, CachePin) {
     inbl, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
-    "\", \"tierpool\": \"" + cache_pool_name + "\"}",
+    "\", \"tierpool\": \"" + cache_pool_name + "\", \"force_nonempty\": \"--force-nonempty\"}",
     inbl, NULL, NULL));
 
   // wait for maps to settle before next test

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2116,7 +2116,7 @@ TEST_F(TestLibRBD, ListChildrenTiered)
   cmd[0] = (char *)cmdstr.c_str();
   ASSERT_EQ(0, rados_mon_command(_cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0));
   cmdstr = "{\"prefix\": \"osd tier remove\", \"pool\": \"" +
-     pool_name1 + "\", \"tierpool\":\"" + pool_name3 + "\"}";
+     pool_name1 + "\", \"tierpool\":\"" + pool_name3 + "\", \"force_nonempty\": \"--force-nonempty\"}";
   cmd[0] = (char *)cmdstr.c_str();
   ASSERT_EQ(0, rados_mon_command(_cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0));
 }

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -228,7 +228,7 @@ class TestRados(object):
                     eq(pool_id, self.rados.get_pool_base_tier(pool_id))
                     eq(pool_id, self.rados.get_pool_base_tier(tier_pool_id))
                 finally:
-                    cmd = {"prefix":"osd tier remove", "pool":"foo", "tierpool":"foo-cache"}
+                    cmd = {"prefix":"osd tier remove", "pool":"foo", "tierpool":"foo-cache", "force_nonempty":"--force-nonempty"}
                     ret, buf, errs = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
                     eq(ret, 0)
             finally:

--- a/src/test/rbd_mirror/test_ClusterWatcher.cc
+++ b/src/test/rbd_mirror/test_ClusterWatcher.cc
@@ -112,7 +112,7 @@ public:
       inbl, NULL, NULL));
     ASSERT_EQ(0, m_cluster->mon_command(
       "{\"prefix\": \"osd tier remove\", \"pool\": \"" + base_pool +
-      "\", \"tierpool\": \"" + cache_pool + "\"}",
+      "\", \"tierpool\": \"" + cache_pool + "\", \"force_nonempty\": \"--force-nonempty\"}",
       inbl, NULL, NULL));
     m_cluster->wait_for_latest_osdmap();
     m_cluster->pool_delete(cache_pool.c_str());


### PR DESCRIPTION
OSDMonitor: clean snaps state of cache tier when setting or removing. 
will make sure there is no object in pool firstly.

Signed-off-by: Mingxin Liu mingxin@xsky.com
