### PR TITLE
tools: use TextTable for "rados df" plain output

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -781,7 +781,7 @@ void PGMap::dump_pg_stats_plain(ostream& ss,
   TextTable tab;
 
   if (brief){
-    tab.define_column("PG_STAT", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("PG_STAT", TextTable::LEFT, TextTable::LEFT);
     tab.define_column("STATE", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("UP", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("UP_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
@@ -789,7 +789,7 @@ void PGMap::dump_pg_stats_plain(ostream& ss,
     tab.define_column("ACTING_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
   }
   else {
-    tab.define_column("PG_STAT", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("PG_STAT", TextTable::LEFT, TextTable::LEFT);
     tab.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("MISSING_ON_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("DEGRADED", TextTable::LEFT, TextTable::RIGHT);
@@ -884,7 +884,7 @@ void PGMap::dump_pool_stats(ostream& ss, bool header) const
   TextTable tab;
 
   if (header) {
-    tab.define_column("POOLID", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("POOLID", TextTable::LEFT, TextTable::LEFT);
     tab.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("MISSING_ON_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("DEGRADED", TextTable::LEFT, TextTable::RIGHT);
@@ -894,7 +894,7 @@ void PGMap::dump_pool_stats(ostream& ss, bool header) const
     tab.define_column("LOG", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("DISK_LOG", TextTable::LEFT, TextTable::RIGHT);
   } else {
-    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::LEFT);
     tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
@@ -928,7 +928,7 @@ void PGMap::dump_pg_sum_stats(ostream& ss, bool header) const
   TextTable tab;
 
   if (header) {
-    tab.define_column("PG_STAT", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("PG_STAT", TextTable::LEFT, TextTable::LEFT);
     tab.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("MISSING_ON_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("DEGRADED", TextTable::LEFT, TextTable::RIGHT);
@@ -938,7 +938,7 @@ void PGMap::dump_pg_sum_stats(ostream& ss, bool header) const
     tab.define_column("LOG", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("DISK_LOG", TextTable::LEFT, TextTable::RIGHT);
   } else {
-    tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("", TextTable::LEFT, TextTable::LEFT);
     tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("", TextTable::LEFT, TextTable::RIGHT);
@@ -967,7 +967,7 @@ void PGMap::dump_osd_stats(ostream& ss) const
 {
   TextTable tab;
 
-  tab.define_column("OSD_STAT", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("OSD_STAT", TextTable::LEFT, TextTable::LEFT);
   tab.define_column("USED", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("AVAIL", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("TOTAL", TextTable::LEFT, TextTable::RIGHT);
@@ -999,7 +999,7 @@ void PGMap::dump_osd_sum_stats(ostream& ss) const
 {
   TextTable tab;
 
-  tab.define_column("OSD_STAT", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("OSD_STAT", TextTable::LEFT, TextTable::LEFT);
   tab.define_column("USED", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("AVAIL", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("TOTAL", TextTable::LEFT, TextTable::RIGHT);
@@ -1794,7 +1794,7 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs)
 {
   TextTable tab;
 
-  tab.define_column("PG_STAT", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("PG_STAT", TextTable::LEFT, TextTable::LEFT);
   tab.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("MISSING_ON_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("DEGRADED", TextTable::LEFT, TextTable::RIGHT);

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -978,18 +978,18 @@ void PGMap::dump_osd_stats(ostream& ss) const
        p != osd_stat.end();
        ++p) {
     tab << p->first
-        << prettybyte_t(p->second.kb_used << 10)
-        << prettybyte_t(p->second.kb_avail << 10)
-        << prettybyte_t(p->second.kb << 10)
+        << si_t(p->second.kb_used << 10)
+        << si_t(p->second.kb_avail << 10)
+        << si_t(p->second.kb << 10)
         << p->second.hb_in
         << get_num_pg_by_osd(p->first)
         << TextTable::endrow;
   }
 
   tab << "sum"
-      << prettybyte_t(osd_sum.kb_used << 10)
-      << prettybyte_t(osd_sum.kb_avail << 10)
-      << prettybyte_t(osd_sum.kb << 10)
+      << si_t(osd_sum.kb_used << 10)
+      << si_t(osd_sum.kb_avail << 10)
+      << si_t(osd_sum.kb << 10)
       << TextTable::endrow;
 
   ss << tab;
@@ -1005,9 +1005,9 @@ void PGMap::dump_osd_sum_stats(ostream& ss) const
   tab.define_column("TOTAL", TextTable::LEFT, TextTable::RIGHT);
 
   tab << "sum"
-      << prettybyte_t(osd_sum.kb_used << 10)
-      << prettybyte_t(osd_sum.kb_avail << 10)
-      << prettybyte_t(osd_sum.kb << 10)
+      << si_t(osd_sum.kb_used << 10)
+      << si_t(osd_sum.kb_avail << 10)
+      << si_t(osd_sum.kb << 10)
       << TextTable::endrow;
 
   ss << tab;

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -978,18 +978,18 @@ void PGMap::dump_osd_stats(ostream& ss) const
        p != osd_stat.end();
        ++p) {
     tab << p->first
-        << prettybyte_t(p->second.kb_used)
-        << prettybyte_t(p->second.kb_avail)
-        << prettybyte_t(p->second.kb)
+        << prettybyte_t(p->second.kb_used << 10)
+        << prettybyte_t(p->second.kb_avail << 10)
+        << prettybyte_t(p->second.kb << 10)
         << p->second.hb_in
         << get_num_pg_by_osd(p->first)
         << TextTable::endrow;
   }
 
   tab << "sum"
-      << prettybyte_t(osd_sum.kb_used)
-      << prettybyte_t(osd_sum.kb_avail)
-      << prettybyte_t(osd_sum.kb)
+      << prettybyte_t(osd_sum.kb_used << 10)
+      << prettybyte_t(osd_sum.kb_avail << 10)
+      << prettybyte_t(osd_sum.kb << 10)
       << TextTable::endrow;
 
   ss << tab;
@@ -1005,9 +1005,9 @@ void PGMap::dump_osd_sum_stats(ostream& ss) const
   tab.define_column("TOTAL", TextTable::LEFT, TextTable::RIGHT);
 
   tab << "sum"
-      << prettybyte_t(osd_sum.kb_used)
-      << prettybyte_t(osd_sum.kb_avail)
-      << prettybyte_t(osd_sum.kb)
+      << prettybyte_t(osd_sum.kb_used << 10)
+      << prettybyte_t(osd_sum.kb_avail << 10)
+      << prettybyte_t(osd_sum.kb << 10)
       << TextTable::endrow;
 
   ss << tab;


### PR DESCRIPTION
E.g.:
```
[root@c7 x86_64]# rados df
POOL_NAME                     USED  OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRAED RD     RD_OPS  WR     WR_OPS  
.rgw.root                     13514 23      0      46     0                  0       0       54575k 72692   95232  133     
p1                            535G  621     0      1863   0                  0       1128    6525k  6561    643M   145331  
p2                            318   8       0      16     0                  0       0       2418k  2446    6144   660     
us-east.rgw.buckets.data      1993M 4706    0      9412   0                  0       0       1924M  146254  5865M  218791  
us-east.rgw.buckets.index     0     665     0      1330   0                  0       0       418M   261239  0      114593  
us-east.rgw.buckets.non-ec    0     1       0      2      0                  0       0       18432  16      0      97      
us-east.rgw.control           0     8       0      16     0                  0       0       0      0       0      0       
us-east.rgw.data.root         91992 292     0      584    0                  0       37      21620k 27003   462k   1511    
us-east.rgw.gc                0     32      0      64     0                  0       0       265M   268427  0      217712  
us-east.rgw.log               3201k 1090    0      2180   0                  0       0       5679M  5953080 11509k 3789703 
us-east.rgw.meta              628k  1958    0      3916   0                  0       0       0      0       2011k  4343    
us-east.rgw.usage             0     13      0      26     0                  0       0       5402k  2814    0      892     
us-east.rgw.users.email       144   14      0      28     0                  0       0       0      0       30720  46      
us-east.rgw.users.keys        330   33      0      66     0                  0       6       158k   243     1289k  2545    
us-east.rgw.users.swift       36    3       0      6      0                  0       0       0      0       3072   3       
us-east.rgw.users.uid         10686 45      0      90     0                  0       0       30743k 30776   1496k  9822    
us-east.ssd.rgw.buckets.data  171k  4       0      8      0                  0       0       0      0       173k   38      
us-east.ssd.rgw.buckets.index 0     19      0      38     0                  0       1       864k   864     0      71      

==============================================================
Total Cluster Usage
==============================================================
total_objects    9535
total_used       35530M
total_avail      158G
total_space      192G
==============================================================
```
