### PR TITLE
ceph-disk: unmount the osd data when destroy

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3609,6 +3609,11 @@ def main_destroy_locked(args):
     # Deallocate OSD ID
     _deallocate_osd_id(args.cluster, osd_id)
 
+    # Unmount the osd data
+    path = (STATEDIR + '/osd/{cluster}-{osd_id}').format(
+        cluster=args.cluster, osd_id=osd_id)
+    unmount(path)
+
     # we remove the crypt map and device mapper (if dmcrypt is True)
     if dmcrypt:
         for name in Space.NAMES:

--- a/src/ceph-disk/tests/test_main.py
+++ b/src/ceph-disk/tests/test_main.py
@@ -1237,6 +1237,7 @@ class TestCephDiskDeactivateAndDestroy(unittest.TestCase):
                 _remove_from_crush_map=lambda cluster, osd_id: True,
                 _delete_osd_auth_key=lambda cluster, osd_id: True,
                 _deallocate_osd_id=lambda cluster, osd_id: True,
+                unmount=lambda path: True,
                 zap=lambda dev: True
         ):
             main.main_destroy(args)


### PR DESCRIPTION
when destroy one OSD by the command of ceph-disk destroy --destroy-by-id ##, the osd dir and dev are not unmount.
This fixes unmount the osd dir when destroy.

Signed-off-by: w11979 <wang.wenfeng@h3c.com>