### PR TITLE
rgw/common: fix error return value of hex_to_buf.

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1774,7 +1774,7 @@ static inline int hex_to_buf(const char *hex, char *buf, int len)
       return -EINVAL;
     d = hexdigit(*p);
     if (d < 0)
-      return -d;
+      return d;
     buf[i] += d;
     i++;
     p++;

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -141,7 +141,6 @@ int rgw_swift_verify_signed_token(CephContext *cct, RGWRados *store,
 void RGW_SWIFT_Auth_Get::execute()
 {
   int ret = -EPERM;
-  const char *token_tag = "rgwtk";
 
   const char *key = s->info.env->get("HTTP_X_AUTH_KEY");
   const char *user = s->info.env->get("HTTP_X_AUTH_USER");


### PR DESCRIPTION
We should return negative value if error happens, otherwise
the caller may run into exceptions. eg, `rgw_swift_verify_signed_token`
will not return as follow:
```c++
  int ret = hex_to_buf(token, p.c_str(), len);
  if (ret < 0)
    return ret;
```