### PR TITLE
global: negative error return code for pidfh::write()

### DIFF
--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -185,7 +185,7 @@ int pidfh::write()
     int err = errno;
     derr << __func__ << ": failed to ftruncate the pid file '"
 	 << pf_path << "': " << cpp_strerror(err) << dendl;
-    return err;
+    return -err;
   }
   ssize_t res = safe_write(pf_fd, buf, len);
   if (res < 0) {


### PR DESCRIPTION
Global callers such as global_init_prefork() won't catch postive
error codes:
```c++
    if (pidfile_write(conf) < 0)
      exit(1);
```
Fixes: http://tracker.ceph.com/issues/16159
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>