### PR TITLE
osd: clear osd_weight correctly for a destroyed osd

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1350,7 +1350,7 @@ int OSDMap::apply_incremental(const Incremental &inc)
       (*osd_uuid)[i->first] = uuid_d();
       osd_info[i->first] = osd_info_t();
       osd_xinfo[i->first] = osd_xinfo_t();
-      osd_weight[i->first] = CEPH_OSD_IN;
+      osd_weight[i->first] = CEPH_OSD_OUT;
       set_primary_affinity(i->first, CEPH_OSD_DEFAULT_PRIMARY_AFFINITY);
       osd_addrs->client_addr[i->first].reset(new entity_addr_t());
       osd_addrs->cluster_addr[i->first].reset(new entity_addr_t());


### PR DESCRIPTION
Shall reset a destroyed osd's osd_weight to CEPH_OSD_OUT
instead of CEPH_OSD_IN, I think.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>