### PR TITLE
jewel: mon: Display full flag in ceph status if full flag is set

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2888,7 +2888,8 @@ void OSDMonitor::get_health(list<pair<health_status_t,string> >& summary,
     }
 
     // warn about flags
-    if (osdmap.test_flag(CEPH_OSDMAP_PAUSERD |
+    if (osdmap.test_flag(CEPH_OSDMAP_FULL |
+			 CEPH_OSDMAP_PAUSERD |
 			 CEPH_OSDMAP_PAUSEWR |
 			 CEPH_OSDMAP_NOUP |
 			 CEPH_OSDMAP_NODOWN |


### PR DESCRIPTION
mon : Display full flag in ceph status if full flag is set

Fixes: http://tracker.ceph.com/issues/16069

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>
(cherry picked from commit 6b1c894b2b083bf6cead21e9f96d304b2eb7887d)