### PR TITLE
xio: clean xcon on connection teardown

### DIFF
--- a/src/msg/xio/XioMessenger.h
+++ b/src/msg/xio/XioMessenger.h
@@ -130,6 +130,7 @@ public:
 
   virtual ConnectionRef get_loopback_connection();
 
+  void unregister_xcon(XioConnection *xcon);
   virtual void mark_down(const entity_addr_t& a);
   virtual void mark_down(Connection *con);
   virtual void mark_down_all();


### PR DESCRIPTION
Accelio could raise connection teardown event without
a disconnected/closed/refused/error event before it which will
leave the xcon reference in XioMessenger entity map and conn list
which will also cause an assertion from boost.

Signed-off-by: Roi Dayan <roid@mellanox.com>