### PR TITLE
doc: fix the librados c api can not compile problem

### DIFF
--- a/doc/rados/api/librados-intro.rst
+++ b/doc/rados/api/librados-intro.rst
@@ -579,8 +579,9 @@ C Example
 	#include <stdio.h>
 	#include <string.h>
 	#include <rados/librados.h>
+       #include <stdlib.h>
 
-	int main (int argc, const char argv**) 
+	int main (int argc, const char **argv) 
 	{
 		/* 
 		 * Continued from previous C example, where cluster handle and


### PR DESCRIPTION
doc: fix the librados c api can not compile problem
like below::
 client.c:6:30: error: expected 鈥?[01m;鈥? 鈥?[01m,鈥?or 鈥?[01m)鈥?before 鈥?[01m_鈥?token
 int main (int argc, char argv_*)

client.c:21:22: error: 鈥?[01mEXIT_FAILURE鈥?undeclared (first use in this function)
                 exit(EXIT_FAILURE);

Signed-off-by:song baisen song.baisen@zte.com.cn
