### PR TITLE
Wip multi object write transaction support

### DIFF
--- a/doc/dev/osd_internals/multi_object_write_transaction.rst
+++ b/doc/dev/osd_internals/multi_object_write_transaction.rst
@@ -1,0 +1,113 @@
+==============================
+Multi-Object Write Transaction
+==============================
+
+Multi-object write transaction enables a group of write operations
+on multi-objects complete atomically.
+
+Description of the Process
+--------------------------
+
+The high level process is,
+
+  1. Define the following class,
+
+     class *CEPH_RADOS_API MultiObjectWriteOperation*
+
+     {
+
+       std::map<std::string, ObjectWriteOperation*> slaves;
+
+       ObjectWriteOperation master;
+
+     };
+
+     based on this, client could send a group of ops on multi-objects
+     through *MOSDOp* to the primary osd in charge of the *master* object
+     which is explicitly specified by client, call this osd *MASTER*
+
+  #. *MASTER* recieves the multi-object write operation request, writes a
+     *LOCK* entry into *PGLOG*, creates a meta object, and records the *slaves*
+     information in it;
+
+  #. *MASTER* extracts operations by objects from *slaves*, enclose them in
+     *LOCK* requests, each request includes a group of operations on a single
+     slave object. *MASTER* sends *LOCK* requests to corresponding primary osds
+     individually, call those osds "SLAVE*;
+
+  #. *SLAVE* recieves *LOCK* request, confirms the validity of the operation,
+     then writes a *LOCK* entry into *PGLOG*, creates a meta object, and
+     records the transaction information in it, then sends ack to *MASTER*;
+
+  #. *MASTER* collects response, then does the operations on the *master*
+     object, besides, writes a *COMMIT* entry into *PGLOG*. *MASTER* sends
+     *COMMIT* request to *SLAVE*, then sends ack to client;
+
+  #. *SLAVE* receives *COMMIT*, performs the operations on the slave object,
+     besides, writes a *COMMIT* entry into *PGLOG*. *SLAVE* sends ack to
+     *MASTER*, deletes the meta object and writes a *UNLOCK* entry into
+     *PGLOG*;
+
+  #. *MASTER* collects ack, deletes the meta object and writes a *UNLOCK*
+     entry into *PGLOG*
+
+Fault Tolerance
+---------------
+When restarting, the osd re-creates the transaction in memory according to
+the *PGLOG* entry and meta object
+
+- *MASTER* restart
+
+ - If the transaction is in *LOCK* state
+
+ (1) *MASTER* sends *UNLOCK* to *SLAVE*;
+
+ (2) *SLAVE* receives *UNLOCK*, if the transaction does not exist or in
+ *UNLOCK* state, goto 3; If the transaction is in *LOCK* state, *SLAVE*
+ rolls back;
+
+ (3) *SLAVE* sends ack to *MASTER*;
+
+ (4) *MASTER* collects ack, and rolls back itself.
+
+ - If the transaction is in *COMMIT* state
+
+ (1) *MASTER* sends *COMMIT* to *SLAVE*;
+
+ (2) *SLAVE* receives *COMMIT*, if the transaction is not in *LOCK* state,
+ goto 3; Otherwise, proceed as normal;
+
+ (3) *SLAVE* sends ack to *MASTER*;
+
+
+ (4) *MASTER* collects ack, proceed as normal
+
+- SLAVE restart
+
+ - If the transaction is in *LOCK* state
+
+ *Slave* waits *MASTER* to re/send *LOCK/UNLOCK/COMMIT*
+
+ - If the transaction is in *COMMIT* state
+
+ *SLAVE* does the *UNLOCK* process; if *MASTER* resends *COMMIT*, it directy
+ sends ack to *MASTER*
+
+Dead Lock Avoidance
+-------------------
+
+When a osd receives a new multi-object write operation request, if there is
+pending multi-object write operation operating on the same object,
+return *EDEADLK*, except these two cases:
+
+  1. The osd plays *MASTER* for the new operation;
+
+  2. The osd plays *SLAVE* for the new operation, and the pending operation
+  has entered *COMMIT* step;
+
+In these two cases, the new request could be delayed until the pending one
+finishes
+
+When a new single object write operation request comes, if there is pending
+multi-object write operation operating on the same object, the new request must
+be delayed until the pending one finish

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -814,6 +814,16 @@ OPTION(osd_debug_skip_full_check_in_backfill_reservation, OPT_BOOL, false)
 OPTION(osd_debug_reject_backfill_probability, OPT_DOUBLE, 0)
 OPTION(osd_debug_inject_copyfrom_error, OPT_BOOL, false)  // inject failure during copyfrom completion
 OPTION(osd_debug_randomize_hobject_sort_order, OPT_BOOL, false)
+OPTION(osd_debug_multi_object_write_operation_master_lock_self_crash, OPT_BOOL, false)
+OPTION(osd_debug_multi_object_write_operation_master_lock_slave_crash, OPT_BOOL, false)
+OPTION(osd_debug_multi_object_write_operation_master_commit_self_crash, OPT_BOOL, false)
+OPTION(osd_debug_multi_object_write_operation_master_commit_slave_crash, OPT_BOOL, false)
+OPTION(osd_debug_multi_object_write_operation_master_unlock_self_crash, OPT_BOOL, false)
+OPTION(osd_debug_multi_object_write_operation_master_unlock_slave_crash, OPT_BOOL, false)
+OPTION(osd_debug_multi_object_write_operation_slave_lock_crash, OPT_BOOL, false)
+OPTION(osd_debug_multi_object_write_operation_slave_commit_crash, OPT_BOOL, false)
+OPTION(osd_debug_multi_object_write_operation_slave_unlock_crash, OPT_BOOL, false)
+OPTION(osd_multi_object_operation_namespace, OPT_STR, ".ceph-mooc") // rados namespace for multi operation
 OPTION(osd_enable_op_tracker, OPT_BOOL, true) // enable/disable OSD op tracking
 OPTION(osd_num_op_tracker_shard, OPT_U32, 32) // The number of shards for holding the ops
 OPTION(osd_op_history_size, OPT_U32, 20)    // Max number of completed ops to track

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -173,6 +173,7 @@ extern const char *ceph_osd_state_name(int s);
 #define CEPH_OSD_OP_TYPE_EXEC  0x0400
 #define CEPH_OSD_OP_TYPE_PG    0x0500
 #define CEPH_OSD_OP_TYPE_MULTI 0x0600 /* multiobject */
+#define CEPH_OSD_OP_TYPE_MOC   0x0700 /* multi object operation control */
 
 #define __CEPH_OSD_OP1(mode, nr) \
 	(CEPH_OSD_OP_MODE_##mode | (nr))
@@ -260,6 +261,11 @@ extern const char *ceph_osd_state_name(int s);
 	/* ESX/SCSI */							    \
 	f(WRITESAME,	__CEPH_OSD_OP(WR, DATA, 38),	"write-same")	    \
 									    \
+	/* multi object slave op*/				            \
+        f(MOC_LOCK,   __CEPH_OSD_OP(WR, MOC, 1),   "moc-lock")              \
+        f(MOC_COMMIT, __CEPH_OSD_OP(WR, MOC, 2),   "moc-commit")            \
+        f(MOC_UNLOCK, __CEPH_OSD_OP(WR, MOC, 3),   "moc-unlock")            \
+                                                                            \
 	/** multi **/							    \
 	f(CLONERANGE,	__CEPH_OSD_OP(WR, MULTI, 1),	"clonerange")	    \
 	f(ASSERT_SRC_VERSION, __CEPH_OSD_OP(RD, MULTI, 2), "assert-src-version") \
@@ -326,6 +332,10 @@ static inline int ceph_osd_op_type_pg(int op)
 static inline int ceph_osd_op_type_multi(int op)
 {
 	return (op & CEPH_OSD_OP_TYPE) == CEPH_OSD_OP_TYPE_MULTI;
+}
+static inline int ceph_osd_op_type_moc(int op)
+{
+	return (op & CEPH_OSD_OP_TYPE) == CEPH_OSD_OP_TYPE_MOC;
 }
 
 static inline int ceph_osd_op_mode_subop(int op)

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -27,6 +27,7 @@ namespace librados
   class IoCtx;
   struct IoCtxImpl;
   class ObjectOperationImpl;
+  class MultiObjectWriteOperation;
   struct ObjListCtx;
   struct PoolAsyncCompletionImpl;
   class RadosClient;
@@ -361,6 +362,7 @@ namespace librados
     ObjectOperation& operator=(const ObjectOperation& rhs);
     friend class IoCtx;
     friend class Rados;
+    friend class MultiObjectWriteOperation;
   };
 
   /*
@@ -482,6 +484,18 @@ namespace librados
     void cache_unpin();
 
     friend class IoCtx;
+  };
+
+  class CEPH_RADOS_API MultiObjectWriteOperation
+  {
+  protected:
+    std::map<std::string, ObjectWriteOperation*> slaves;
+    void prepare_operate();
+    friend class IoCtx;
+  public:
+    ObjectWriteOperation master;
+    ObjectWriteOperation& slave(const std::string &oid);
+    virtual ~MultiObjectWriteOperation();
   };
 
   /*
@@ -983,8 +997,10 @@ namespace librados
 	         bufferlist& inbl, bufferlist *outbl);
 
     // compound object operations
+    int operate(const std::string& oid, MultiObjectWriteOperation *op);
     int operate(const std::string& oid, ObjectWriteOperation *op);
     int operate(const std::string& oid, ObjectReadOperation *op, bufferlist *pbl);
+    int aio_operate(const std::string& oid, AioCompletion *c, MultiObjectWriteOperation *op);
     int aio_operate(const std::string& oid, AioCompletion *c, ObjectWriteOperation *op);
     int aio_operate(const std::string& oid, AioCompletion *c, ObjectWriteOperation *op, int flags);
     /**

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -766,6 +766,14 @@ int librados::IoCtxImpl::aio_operate(const object_t& oid,
   if (snap_seq != CEPH_NOSNAP)
     return -EROFS;
 
+  if (o->sub_ops.size()) {
+    bool kraken = objecter->with_osdmap([](const OSDMap& osdmap) {
+      return osdmap.test_flag(CEPH_OSDMAP_REQUIRE_KRAKEN);
+    });
+    if (!kraken)
+      return -EOPNOTSUPP;
+  }
+
   Context *onack = c->wants_ack() ? new C_aio_Ack(c) : NULL;
   Context *oncommit = new C_aio_Safe(c);
 

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -10,6 +10,7 @@ set(osd_srcs
   PG.cc
   PGLog.cc
   ReplicatedPG.cc
+  MultiObjectOperation.cc
   ReplicatedBackend.cc
   ECBackend.cc
   ECTransaction.cc

--- a/src/osd/MultiObjectOperation.cc
+++ b/src/osd/MultiObjectOperation.cc
@@ -1,0 +1,95 @@
+#include "boost/tuple/tuple.hpp"
+#include "boost/bind.hpp"
+#include "PG.h"
+#include "ReplicatedPG.h"
+#include "OSD.h"
+#include "OpRequest.h"
+
+#include "common/config.h"
+#include "include/compat.h"
+
+#include "osdc/Objecter.h"
+
+#include "include/assert.h"
+#include "include/rados/rados_types.hpp"
+
+#ifdef WITH_LTTNG
+#include "tracing/osd.h"
+#else
+#define tracepoint(...)
+#endif
+
+#define dout_subsys ceph_subsys_osd
+#define DOUT_PREFIX_ARGS this, osd->whoami, get_osdmap()
+#undef dout_prefix
+#define dout_prefix _prefix(_dout, this)
+template <typename T>
+static ostream& _prefix(std::ostream *_dout, T *pg) {
+  return *_dout << pg->gen_prefix();
+}
+
+
+#include <sstream>
+#include <utility>
+
+#include <errno.h>
+
+void ReplicatedPG::MultiObjectWriteOpContext::encode(bufferlist &bl)
+{
+  ENCODE_START(1, 1, bl);
+
+  __u8 m = is_master ? 1 : 0;
+  ::encode(m, bl);
+
+  ::encode(master, bl);
+  ::encode(locator, bl);
+  ::encode(snapc, bl);
+  utime_t t;
+  t = ceph::real_clock::to_ceph_timespec(mtime);
+  ::encode(t, bl);
+  ::encode(master_reqid, bl);
+
+  if (is_master) {
+    int obj_nums = sub_objects.size();
+    ::encode(obj_nums, bl);
+    for (auto &p : sub_objects)
+      ::encode(p.first, bl);
+  } else {
+    ::encode(slave_data_bl, bl);
+  }
+
+  ENCODE_FINISH(bl);
+}
+
+void ReplicatedPG::MultiObjectWriteOpContext::decode(bufferlist::iterator &bl)
+{
+  DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
+
+  __u8 m;
+  ::decode(m, bl);
+  if (m)
+    is_master = true;
+
+  ::decode(master, bl);
+  ::decode(locator, bl);
+  ::decode(snapc, bl);
+  utime_t t;
+  ::decode(t, bl);
+  mtime = ceph::real_clock::from_ceph_timespec(t);
+  ::decode(master_reqid, bl);
+
+  if (is_master) {
+    int obj_nums;
+    ::decode(obj_nums, bl);
+    assert(obj_nums > 0);
+    for (int i = 0; i < obj_nums; ++i) {
+      object_t obj;
+      ::decode(obj, bl);
+      sub_objects.insert(make_pair(obj, make_pair(0, 0)));
+    }
+  } else {
+    ::decode(slave_data_bl, bl);
+  }
+
+  DECODE_FINISH(bl);
+}

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9220,6 +9220,9 @@ int OSD::init_op_flags(OpRequestRef& op)
   // client flags have no bearing on whether an op is a read, write, etc.
   op->rmw_flags = 0;
 
+  if (m->sub_ops.size())
+    op->set_multi_object_write_operation();
+
   // set bits based on op codes, called methods.
   for (iter = m->ops.begin(); iter != m->ops.end(); ++iter) {
     if (ceph_osd_op_mode_modify(iter->op.op))
@@ -9237,6 +9240,9 @@ int OSD::init_op_flags(OpRequestRef& op)
 
     if (ceph_osd_op_mode_cache(iter->op.op))
       op->set_cache();
+
+    if (ceph_osd_op_type_moc(iter->op.op))
+      op->set_multi_object_write_operation();
 
     // check for ec base pool
     int64_t poolid = m->get_pg().pool();

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -112,6 +112,9 @@ bool OpRequest::need_skip_handle_cache() {
 bool OpRequest::need_skip_promote() {
   return check_rmw(CEPH_OSD_RMW_FLAG_SKIP_PROMOTE);
 }
+bool OpRequest::is_multi_object_write_operation() {
+  return check_rmw(CEPH_OSD_RMW_FLAG_MULTI_OBJECT_WRITE_OPERATION);
+}
 
 void OpRequest::set_rmw_flags(int flags) {
 #ifdef WITH_LTTNG
@@ -132,6 +135,7 @@ void OpRequest::set_cache() { set_rmw_flags(CEPH_OSD_RMW_FLAG_CACHE); }
 void OpRequest::set_promote() { set_rmw_flags(CEPH_OSD_RMW_FLAG_FORCE_PROMOTE); }
 void OpRequest::set_skip_handle_cache() { set_rmw_flags(CEPH_OSD_RMW_FLAG_SKIP_HANDLE_CACHE); }
 void OpRequest::set_skip_promote() { set_rmw_flags(CEPH_OSD_RMW_FLAG_SKIP_PROMOTE); }
+void OpRequest::set_multi_object_write_operation() { set_rmw_flags(CEPH_OSD_RMW_FLAG_MULTI_OBJECT_WRITE_OPERATION); }
 
 void OpRequest::mark_flag_point(uint8_t flag, const string& s) {
 #ifdef WITH_LTTNG

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -71,6 +71,7 @@ struct OpRequest : public TrackedOp {
   bool need_promote();
   bool need_skip_handle_cache();
   bool need_skip_promote();
+  bool is_multi_object_write_operation();
   void set_read();
   void set_write();
   void set_cache();
@@ -80,6 +81,7 @@ struct OpRequest : public TrackedOp {
   void set_promote();
   void set_skip_handle_cache();
   void set_skip_promote();
+  void set_multi_object_write_operation();
 
   struct ClassInfo {
     ClassInfo(const std::string& name, bool read, bool write,

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -226,6 +226,7 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   state(0),
   send_notify(false),
   pg_whoami(osd->whoami, p.shard),
+  pg_trim_to_locker(false),
   need_up_thru(false),
   last_peering_reset(0),
   heartbeat_peer_lock("PG::heartbeat_peer_lock"),
@@ -944,6 +945,7 @@ void PG::clear_primary_state()
   peer_activated.clear();
   min_last_complete_ondisk = eversion_t();
   pg_trim_to = eversion_t();
+  pg_trim_to_locker = false;
   might_have_unfound.clear();
 
   last_update_ondisk = eversion_t();

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -550,6 +550,7 @@ public:
   map<pg_shard_t,eversion_t> peer_last_complete_ondisk;
   eversion_t  min_last_complete_ondisk;  // up: min over last_complete_ondisk, peer_last_complete_ondisk
   eversion_t  pg_trim_to;
+  bool pg_trim_to_locker;
 
   set<int> blocked_by; ///< osds we are blocked by (for pg stats)
 

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -474,6 +474,11 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      virtual bool empty() const = 0;
      virtual uint64_t get_bytes_written() const = 0;
      virtual ~PGTransaction() {}
+
+     virtual void encode(bufferlist &bl)
+     { assert(0); }
+     virtual void decode(bufferlist::iterator &bl)
+     { assert(0); }
    };
    using PGTransactionUPtr = std::unique_ptr<PGTransaction>;
 

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -560,6 +560,28 @@ public:
     return written;
   }
   ~RPGTransaction() { }
+
+  void encode(bufferlist &bl)
+  {
+    ENCODE_START(1, 1, bl);
+    ::encode(coll, bl);
+    ::encode(temp_added, bl);
+    ::encode(temp_cleared, bl);
+    ::encode(written, bl);
+    t.encode(bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::iterator &bl)
+  {
+    DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
+    ::decode(coll, bl);
+    ::decode(temp_added, bl);
+    ::decode(temp_cleared, bl);
+    ::decode(written, bl);
+    t.decode(bl);
+    DECODE_FINISH(bl);
+  }
 };
 
 PGBackend::PGTransaction *ReplicatedBackend::get_transaction()

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -10399,6 +10399,7 @@ void ReplicatedPG::on_activate()
 
   hit_set_setup();
   agent_setup();
+  multi_object_write_ops_setup();
 }
 
 void ReplicatedPG::_on_new_interval()

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -10335,6 +10335,7 @@ void ReplicatedPG::on_shutdown()
   cancel_copy_ops(false);
   cancel_flush_ops(false);
   cancel_proxy_ops(false);
+  cancel_multi_object_write_ops(false);
   apply_and_flush_repops(false);
   cancel_log_updates();
 
@@ -10436,6 +10437,7 @@ void ReplicatedPG::on_change(ObjectStore::Transaction *t)
   cancel_copy_ops(is_primary());
   cancel_flush_ops(is_primary());
   cancel_proxy_ops(is_primary());
+  cancel_multi_object_write_ops(is_primary());
 
   // requeue object waiters
   if (is_primary()) {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -12464,6 +12464,10 @@ bool ReplicatedPG::agent_maybe_evict(ObjectContextRef& obc, bool after_flush)
     dout(20) << __func__ << " skip (cache_pinned) " << obc->obs.oi << dendl;
     return false;
   }
+  if (multi_object_write_op_find(soid)) {
+    dout(20) << __func__ << " skip (multi operation) " << obc->obs.oi << dendl;
+    return false;
+  }
 
   if (soid.snap == CEPH_NOSNAP) {
     int result = _verify_no_head_clones(soid, obc->ssc->snapset);

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -16,6 +16,7 @@
  */
 
 #include "boost/tuple/tuple.hpp"
+#include "boost/bind.hpp"
 #include "PG.h"
 #include "ReplicatedPG.h"
 #include "OSD.h"
@@ -1188,6 +1189,10 @@ void ReplicatedPG::do_pg_op(OpRequestRef op)
 
 	  // skip internal namespace
 	  if (candidate.get_namespace() == cct->_conf->osd_hit_set_namespace)
+	    continue;
+
+	  // skip multi operation meta obj
+	  if (candidate.get_namespace() == cct->_conf->osd_multi_object_operation_namespace)
 	    continue;
 
 	  // skip wrong namespace

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -12156,6 +12156,11 @@ bool ReplicatedPG::agent_work(int start_max, int agent_flush_quota)
       osd->logger->inc(l_osd_agent_skip);
       continue;
     }
+    if (p->nspace == cct->_conf->osd_multi_object_operation_namespace) {
+      dout(20) << __func__ << " skip (multi operation) " << *p << dendl;
+      osd->logger->inc(l_osd_agent_skip);
+      continue;
+    }
     if (is_degraded_or_backfilling_object(*p)) {
       dout(20) << __func__ << " skip (degraded) " << *p << dendl;
       osd->logger->inc(l_osd_agent_skip);

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -4432,6 +4432,9 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
     case CEPH_OSD_OP_COPY_FROM:  // we handle user_version update explicitly
     case CEPH_OSD_OP_CACHE_PIN:
     case CEPH_OSD_OP_CACHE_UNPIN:
+    case CEPH_OSD_OP_MOC_LOCK:
+    case CEPH_OSD_OP_MOC_COMMIT:
+    case CEPH_OSD_OP_MOC_UNLOCK:
       break;
     default:
       if (op.op & CEPH_OSD_OP_MODE_WR)
@@ -6252,6 +6255,19 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	}
       }
       break;
+
+    case CEPH_OSD_OP_MOC_LOCK:
+      {
+        result = multi_object_write_op_slave_lock(ctx);
+      }
+      break;
+    case CEPH_OSD_OP_MOC_COMMIT:
+      {
+        result = multi_object_write_op_slave_commit(ctx);
+      }
+      break;
+    case CEPH_OSD_OP_MOC_UNLOCK:
+      assert(0 == "unexpected case");
 
     default:
       tracepoint(osd, do_osd_op_pre_unknown, soid.oid.name.c_str(), soid.snap.val, op.op, ceph_osd_op_name(op.op));

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -6933,8 +6933,9 @@ int ReplicatedPG::prepare_transaction(OpContext *ctx)
        get_osdmap()->test_flag(CEPH_OSDMAP_FULL))) {
     MOSDOp *m = static_cast<MOSDOp*>(ctx->op->get_req());
     if (ctx->reqid.name.is_mds() ||   // FIXME: ignore MDS for now
+        ctx->is_slave_commit() ||
 	m->has_flag(CEPH_OSD_FLAG_FULL_FORCE)) {
-      dout(20) << __func__ << " full, but proceeding due to FULL_FORCE or MDS"
+      dout(20) << __func__ << " full, but proceeding due to FULL_FORCE or MDS or SLAVE_COMMIT"
 	       << dendl;
     } else if (m->has_flag(CEPH_OSD_FLAG_FULL_TRY)) {
       // they tried, they failed.
@@ -9306,6 +9307,7 @@ ObjectContextRef ReplicatedPG::get_object_context(const hobject_t& soid,
     dout(10) << __func__ << ": obc NOT found in cache: " << soid << dendl;
     // check disk
     bufferlist bv;
+    bufferlist mw_bl;
     if (attrs) {
       assert(attrs->count(OI_ATTR));
       bv = attrs->find(OI_ATTR)->second;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4649,6 +4649,19 @@ struct OSDOp {
    * @param in  [in] combined data buffer
    */
   static void split_osd_op_vector_in_data(vector<OSDOp>& ops, bufferlist& in);
+  static void split_osd_op_vector_in_data(vector<OSDOp>& ops,
+                                          bufferlist::iterator& p);
+
+  /**
+   * split a bufferlist into constituent indata nembers of a vector of OSDOps
+   *
+   * @param ops [out] vector of OSDOps
+   * @param sub_ops [out] map of vector of OSDOps
+   * @param in  [in] combined data buffer
+   */
+  static void split_osd_op_vector_in_data(vector<OSDOp>& ops,
+                                          map<object_t, vector<OSDOp> >& sub_ops,
+                                          bufferlist& in);
 
   /**
    * merge indata nembers of a vector of OSDOp into a single bufferlist
@@ -4660,6 +4673,20 @@ struct OSDOp {
    * @param out [out] combined data buffer
    */
   static void merge_osd_op_vector_in_data(vector<OSDOp>& ops, bufferlist& out);
+
+  /**
+   * merge indata nembers of a vector of OSDOp into a single bufferlist
+   *
+   * Notably this also encodes certain other OSDOp data into the data
+   * buffer, including the sobject_t soid.
+   *
+   * @param ops [in] vector of OSDOps
+   * @param sub_ops [in] map of vector of OSDOps
+   * @param out [out] combined data buffer
+   */
+  static void merge_osd_op_vector_in_data(vector<OSDOp>& ops,
+                                          map<object_t, vector<OSDOp> >& sub_ops,
+                                          bufferlist& out);
 
   /**
    * split a bufferlist into constituent outdata members of a vector of OSDOps

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -60,6 +60,15 @@ set_target_properties(ceph_test_rados_api_list PROPERTIES COMPILE_FLAGS
 target_link_libraries(ceph_test_rados_api_list
   rados_a global ${UNITTEST_LIBS} radostest)
 
+# ceph_test_rados_api_multiobjectoperation
+add_executable(ceph_test_rados_api_multiobjectoperation
+  multiobjectoperation.cc
+  )
+set_target_properties(ceph_test_rados_api_multiobjectoperation PROPERTIES COMPILE_FLAGS
+  ${UNITTEST_CXX_FLAGS})
+target_link_libraries(ceph_test_rados_api_multiobjectoperation
+  librados ${UNITTEST_LIBS} radostest)
+
 # ceph_test_rados_api_nlist
 add_executable(ceph_test_rados_api_nlist
   nlist.cc
@@ -151,6 +160,7 @@ install(TARGETS
   ceph_test_rados_api_list
   ceph_test_rados_api_lock
   ceph_test_rados_api_misc
+  ceph_test_rados_api_multiobjectoperation
   ceph_test_rados_api_pool
   ceph_test_rados_api_snapshots
   ceph_test_rados_api_stat

--- a/src/test/librados/multiobjectoperation.cc
+++ b/src/test/librados/multiobjectoperation.cc
@@ -1,0 +1,726 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*
+// vim: ts=8 sw=2 smarttab
+
+#include <climits>
+#include <vector>
+
+#include "include/rados/librados.h"
+#include "include/rados/librados.hpp"
+#include "test/librados/test.h"
+#include "test/librados/TestCase.h"
+
+#include "common/ceph_argparse.h"
+
+#include <errno.h>
+#include "gtest/gtest.h"
+
+using namespace librados;
+using std::string;
+using std::vector;
+
+typedef RadosTestPP LibRadosMultiObjectOperationPP;
+
+TEST_F(LibRadosMultiObjectOperationPP, SimplePP) {
+  string b1("abcd"), b2("pqrs");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  MultiObjectWriteOperation writes;
+  writes.master.write(0, bl1);
+  writes.slave("bar").write(0, bl2);
+  ASSERT_EQ(0, ioctx.operate("foo", &writes));
+
+  ObjectReadOperation read1;
+  read1.read(0, b1.size(), NULL, NULL);
+  ASSERT_EQ(0, ioctx.operate("foo", &read1, &bl1));
+  ASSERT_EQ(0, b1.compare(0, b1.size(), bl1.c_str(), bl1.length()));
+
+  ObjectReadOperation read2;
+  read2.read(0, b2.size(), NULL, NULL);
+  ASSERT_EQ(0, ioctx.operate("bar", &read2, &bl2));
+  ASSERT_EQ(0, b2.compare(0, b2.size(), bl2.c_str(), bl2.length()));
+}
+
+struct ObjectsWriter
+{
+  struct obj {
+    string oid;
+    string value;
+    bufferlist bl;
+  };
+  vector<obj> list;
+  obj &master;
+
+  ObjectsWriter(int count, int _master, const char *value)
+    : list(count)
+    , master(list[_master])
+  {
+    for (int i = 0; i < count; ++i) {
+      char buf[1024];
+      obj &c = list[i];
+
+      snprintf(buf, sizeof(buf), "oid%doid", i);
+      c.oid = buf;
+      snprintf(buf, sizeof(buf), "%s%d%s", value, i, value);
+      c.value = buf;
+    }
+  }
+
+  void fill(MultiObjectWriteOperation &w)
+  {
+    master.bl.clear();
+    master.bl.append(master.value);
+    w.master.write(0, master.bl);
+    for (vector<obj>::iterator p = list.begin();
+         p != list.end(); ++p) {
+      if (p->oid == master.oid)
+        continue;
+      p->bl.clear();
+      p->bl.append(p->value);
+      w.slave(p->oid).write(0, p->bl);
+    }
+  }
+};
+
+TEST_F(LibRadosMultiObjectOperationPP, WriteObjects64PP) {
+  ObjectsWriter writer(64, 0, "value");
+
+  {
+    MultiObjectWriteOperation w;
+    writer.fill(w);
+    ASSERT_EQ(0, ioctx.operate(writer.master.oid, &w));
+  }
+
+  for (vector<ObjectsWriter::obj>::iterator p = writer.list.begin();
+       p != writer.list.end(); ++p) {
+    ObjectReadOperation r;
+    r.read(0, p->value.size(), NULL, NULL);
+    std::cout << "Read " << p->oid;
+    ASSERT_EQ(0, ioctx.operate(p->oid, &r, &p->bl));
+    ASSERT_EQ(0, p->value.compare(0, p->value.size(), p->bl.c_str(), p->bl.length()));
+    std::cout << " OK" << std::endl;
+  }
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, AtomicPP) {
+  ObjectsWriter ow1(8, 0, "xxx");
+  ObjectsWriter ow2(8, 4, "yyy");
+
+  int r1, r2;
+  MultiObjectWriteOperation w1, w2;
+  ow1.fill(w1);
+  ow2.fill(w2);
+  AioCompletion *c1 = cluster.aio_create_completion();
+  AioCompletion *c2 = cluster.aio_create_completion();
+  ASSERT_EQ(0, ioctx.aio_operate(ow1.master.oid, c1, &w1));
+  ASSERT_EQ(0, ioctx.aio_operate(ow2.master.oid, c2, &w2));
+  c1->wait_for_safe();
+  c2->wait_for_safe();
+  r1 = c1->get_return_value();
+  r2 = c2->get_return_value();
+  c1->release();
+  c2->release();
+
+  ASSERT_EQ(true, ((r1 == 0) || (r1 == -EDEADLK)));
+  ASSERT_EQ(true, ((r2 == 0) || (r2 == -EDEADLK)));
+
+  std::cout << "op1 r: " << r1 << std::endl;
+  std::cout << "op2 r: " << r2 << std::endl;
+
+  if (r1 == 0 || r2 == 0) {
+    string match;
+    for (vector<ObjectsWriter::obj>::iterator p = ow1.list.begin();
+         p != ow1.list.end(); ++p) {
+      ObjectReadOperation r;
+      r.read(0, 3, NULL, NULL);
+      ASSERT_EQ(0, ioctx.operate(p->oid, &r, &p->bl));
+      if (match.empty())
+        match = p->bl.c_str();
+      else
+        ASSERT_EQ(0, match.compare(0, 3, p->bl.c_str(), p->bl.length()));
+    }
+  } else {
+    for (vector<ObjectsWriter::obj>::iterator p = ow1.list.begin();
+         p != ow1.list.end(); ++p) {
+      ObjectReadOperation r;
+      r.stat(NULL, NULL, NULL);
+      ASSERT_EQ(-ENOENT, ioctx.operate(p->oid, &r, &p->bl));
+    }
+  }
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, AtomicSameMasterPP) {
+  ObjectsWriter ow1(8, 0, "xxx");
+  ObjectsWriter ow2(8, 0, "yyy");
+
+  int r1, r2;
+  MultiObjectWriteOperation w1, w2;
+  ow1.fill(w1);
+  ow2.fill(w2);
+  AioCompletion *c1 = cluster.aio_create_completion();
+  AioCompletion *c2 = cluster.aio_create_completion();
+  ASSERT_EQ(0, ioctx.aio_operate(ow1.master.oid, c1, &w1));
+  ASSERT_EQ(0, ioctx.aio_operate(ow2.master.oid, c2, &w2));
+  c1->wait_for_safe();
+  c2->wait_for_safe();
+  r1 = c1->get_return_value();
+  r2 = c2->get_return_value();
+  c1->release();
+  c2->release();
+
+  ASSERT_EQ(true, ((r1 == 0) || (r1 == -EDEADLK)));
+  ASSERT_EQ(true, ((r2 == 0) || (r2 == -EDEADLK)));
+
+  std::cout << "op1 r: " << r1 << std::endl;
+  std::cout << "op2 r: " << r2 << std::endl;
+
+  if (r1 == 0 || r2 == 0) {
+    string match;
+    for (vector<ObjectsWriter::obj>::iterator p = ow1.list.begin();
+         p != ow1.list.end(); ++p) {
+      ObjectReadOperation r;
+      r.read(0, 3, NULL, NULL);
+      ASSERT_EQ(0, ioctx.operate(p->oid, &r, &p->bl));
+      if (match.empty())
+        match = p->bl.c_str();
+      else
+        ASSERT_EQ(0, match.compare(0, 3, p->bl.c_str(), p->bl.length()));
+    }
+  } else {
+    for (vector<ObjectsWriter::obj>::iterator p = ow1.list.begin();
+         p != ow1.list.end(); ++p) {
+      ObjectReadOperation r;
+      r.stat(NULL, NULL, NULL);
+      ASSERT_EQ(-ENOENT, ioctx.operate(p->oid, &r, &p->bl));
+    }
+  }
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, SlaveFailureOperationPP) {
+  string b1("abcd"), b2("pqrs");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  ASSERT_EQ(0, ioctx.create("bar", true));
+
+  MultiObjectWriteOperation writes;
+  writes.master.write(0, bl1);
+  writes.slave("bar").create(true);
+  writes.slave("bar").write(0, bl2);
+  ASSERT_EQ(-EEXIST, ioctx.operate("foo", &writes));
+
+  ASSERT_EQ(-ENOENT, ioctx.stat("foo", NULL, NULL));
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, MasterFailureOperationPP) {
+  string b1("abcd"), b2("pqrs");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  ASSERT_EQ(0, ioctx.create("foo", true));
+
+  MultiObjectWriteOperation writes;
+  writes.master.create(true);
+  writes.master.write(0, bl1);
+  writes.slave("bar").write(0, bl2);
+  ASSERT_EQ(-EEXIST, ioctx.operate("foo", &writes));
+
+  ASSERT_EQ(-ENOENT, ioctx.stat("bar", NULL, NULL));
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, SlaveOperationCombinationDataPP) {
+  string b1("mmmm"), b2("abcdef");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("create", w));
+  }
+
+  {
+    MultiObjectWriteOperation writes;
+    writes.master.create(false);
+    writes.master.write(0, bl1);
+    writes.slave("write").write(8, bl2);
+    writes.slave("writefull").write_full(bl2);
+    writes.slave("truncate").write_full(bl2);
+    writes.slave("truncate").truncate(4);
+    writes.slave("zero").write_full(bl2);
+    writes.slave("zero").zero(2, 3);
+    writes.slave("delete").create(false);
+    writes.slave("delete").remove();
+    writes.slave("append").write_full(bl2);
+    writes.slave("append").append(bl1);
+    writes.slave("create").remove();
+    writes.slave("create").create(true);
+    writes.slave("create").write_full(bl2);
+    ASSERT_EQ(0, ioctx.operate("foo", &writes));
+  }
+
+  {
+    bufferlist r;
+    bufferlist m;
+    m.append(bl1);
+    ASSERT_EQ(m.length(), ioctx.read("foo", r, 1024, 0));
+    ASSERT_EQ(true, r.contents_equal(m));
+  }
+  {
+    bufferlist r;
+    bufferlist m;
+    m.append_zero(8);
+    m.append(bl2);
+    ASSERT_EQ(m.length(), ioctx.read("write", r, 1024, 0));
+    ASSERT_EQ(true, r.contents_equal(m));
+  }
+  {
+    bufferlist r;
+    bufferlist m;
+    m.append(bl2);
+    ASSERT_EQ(m.length(), ioctx.read("writefull", r, 1024, 0));
+    ASSERT_EQ(true, r.contents_equal(m));
+  }
+  {
+    bufferlist r;
+    bufferlist m;
+    m.substr_of(bl2, 0, 4);
+    ASSERT_EQ(m.length(), ioctx.read("truncate", r, 1024, 0));
+    ASSERT_EQ(true, r.contents_equal(m));
+  }
+  {
+    bufferlist r;
+    bufferlist m;
+    m.append(bl2);
+    m.rebuild();
+    m.zero(2, 3);
+    ASSERT_EQ(m.length(), ioctx.read("zero", r, 1024, 0));
+    ASSERT_EQ(true, r.contents_equal(m));
+  }
+  {
+    ASSERT_EQ(-ENOENT, ioctx.stat("delete", NULL, NULL));
+  }
+  {
+    bufferlist r;
+    bufferlist m;
+    m.append(bl2);
+    m.append(bl1);
+    ASSERT_EQ(m.length(), ioctx.read("append", r, 1024, 0));
+    ASSERT_EQ(true, r.contents_equal(m));
+  }
+  {
+    bufferlist r;
+    bufferlist m;
+    m.append(bl2);
+    ASSERT_EQ(m.length(), ioctx.read("create", r, 1024, 0));
+    ASSERT_EQ(true, r.contents_equal(m));
+  }
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, SlaveOperationCombinationXattrPP) {
+  string b1("mmmm"), b2("abcdef");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.setxattr("foo", "init", w));
+    ASSERT_EQ(0, ioctx.setxattr("foo", "do", w));
+  }
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.setxattr("remove", "init", w));
+    ASSERT_EQ(0, ioctx.setxattr("remove", "do", w));
+  }
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.setxattr("modify", "init", w));
+    ASSERT_EQ(0, ioctx.setxattr("modify", "do", w));
+  }
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.setxattr("create", "init", w));
+  }
+
+  {
+    MultiObjectWriteOperation writes;
+    writes.master.cmpxattr("init", CEPH_OSD_CMPXATTR_OP_EQ, bl1);
+    writes.master.rmxattr("do");
+    writes.master.setxattr("do2", bl2);
+    writes.slave("remove").cmpxattr("init", CEPH_OSD_CMPXATTR_OP_EQ, bl1);
+    writes.slave("remove").rmxattr("do");
+    writes.slave("modify").cmpxattr("init", CEPH_OSD_CMPXATTR_OP_EQ, bl1);
+    writes.slave("modify").setxattr("do", bl2);
+    writes.slave("create").cmpxattr("init", CEPH_OSD_CMPXATTR_OP_EQ, bl1);
+    writes.slave("create").setxattr("do", bl2);
+    ASSERT_EQ(0, ioctx.operate("foo", &writes));
+  }
+
+  {
+    bufferlist r;
+    ASSERT_EQ(-ENODATA, ioctx.getxattr("foo", "do", r));
+    ASSERT_EQ(bl2.length(), ioctx.getxattr("foo", "do2", r));
+    ASSERT_EQ(true, r.contents_equal(bl2));
+  }
+  {
+    bufferlist r;
+    ASSERT_EQ(-ENODATA, ioctx.getxattr("remove", "do", r));
+  }
+  {
+    bufferlist r;
+    ASSERT_EQ(bl2.length(), ioctx.getxattr("modify", "do", r));
+    ASSERT_EQ(true, r.contents_equal(bl2));
+  }
+  {
+    bufferlist r;
+    ASSERT_EQ(bl2.length(), ioctx.getxattr("create", "do", r));
+    ASSERT_EQ(true, r.contents_equal(bl2));
+  }
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, SlaveOperationCombinationOmapPP) {
+  string b1("mmmm"), b2("abcdef");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  {
+    map<string, bufferlist> m;
+    m.insert(make_pair("init", bl1));
+    ASSERT_EQ(0, ioctx.omap_set("create", m));
+    m.insert(make_pair("do", bl1));
+    ASSERT_EQ(0, ioctx.omap_set("foo", m));
+    ASSERT_EQ(0, ioctx.omap_set("remove", m));
+    ASSERT_EQ(0, ioctx.omap_set("modify", m));
+    ASSERT_EQ(0, ioctx.omap_set("clear", m));
+  }
+
+  {
+    std::map<std::string, std::pair<bufferlist, int> > assertions;
+    assertions.insert(make_pair("init", make_pair(bl1, CEPH_OSD_CMPXATTR_OP_EQ)));
+
+    std::set<std::string> rm_do;
+    rm_do.insert("do");
+    std::map<std::string, bufferlist> set_do;
+    set_do.insert(make_pair("do", bl2));
+    std::map<std::string, bufferlist> set_do2;
+    set_do2.insert(make_pair("do2", bl2));
+
+    MultiObjectWriteOperation writes;
+    writes.master.omap_cmp(assertions, NULL);
+    writes.master.omap_rm_keys(rm_do);
+    writes.master.omap_set(set_do2);
+    writes.master.omap_set_header(bl2);
+    writes.slave("remove").omap_cmp(assertions, NULL);
+    writes.slave("remove").omap_rm_keys(rm_do);
+    writes.slave("modify").omap_cmp(assertions, NULL);
+    writes.slave("modify").omap_set(set_do);
+    writes.slave("create").omap_cmp(assertions, NULL);
+    writes.slave("create").omap_set(set_do);
+    writes.slave("clear").omap_cmp(assertions, NULL);
+    writes.slave("clear").omap_clear();
+    ASSERT_EQ(0, ioctx.operate("foo", &writes));
+  }
+
+  {
+    map<std::string, bufferlist> vals;
+    ASSERT_EQ(0, ioctx.omap_get_vals("foo", "", 10, &vals));
+    ASSERT_EQ(2, vals.size());
+    ASSERT_EQ(true, vals.count("do") == 0);
+    ASSERT_EQ(true, vals.count("do2") > 0);
+    ASSERT_EQ(true, bl2.contents_equal(vals["do2"]));
+    bufferlist r;
+    ASSERT_EQ(0, ioctx.omap_get_header("foo", &r));
+    ASSERT_EQ(true, r.contents_equal(bl2));
+  }
+  {
+    map<std::string, bufferlist> vals;
+    ASSERT_EQ(0, ioctx.omap_get_vals("remove", "", 10, &vals));
+    ASSERT_EQ(1, vals.size());
+    ASSERT_EQ(true, vals.count("do") == 0);
+  }
+  {
+    map<std::string, bufferlist> vals;
+    ASSERT_EQ(0, ioctx.omap_get_vals("modify", "", 10, &vals));
+    ASSERT_EQ(2, vals.size());
+    ASSERT_EQ(true, vals.count("do") > 0);
+    ASSERT_EQ(true, bl2.contents_equal(vals["do"]));
+  }
+  {
+    map<std::string, bufferlist> vals;
+    ASSERT_EQ(0, ioctx.omap_get_vals("create", "", 10, &vals));
+    ASSERT_EQ(2, vals.size());
+    ASSERT_EQ(true, vals.count("do") > 0);
+    ASSERT_EQ(true, bl2.contents_equal(vals["do"]));
+  }
+  {
+    map<std::string, bufferlist> vals;
+    ASSERT_EQ(0, ioctx.omap_get_vals("clear", "", 10, &vals));
+    ASSERT_EQ(0, vals.size());
+  }
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, MasterFailureAssertVersionPP) {
+  string b1("mmmm"), b2("abcdef");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  uint64_t v1, v2;
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("v1", w));
+    ASSERT_EQ(bl1.length(), ioctx.read("v1", w, 1024, 0));
+    ASSERT_EQ(true, bl1.contents_equal(w));
+    v1 = ioctx.get_last_version();
+  }
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("v2", w));
+    ASSERT_EQ(bl1.length(), ioctx.read("v2", w, 1024, 0));
+    ASSERT_EQ(true, bl1.contents_equal(w));
+    v2 = ioctx.get_last_version();
+  }
+
+  {
+    MultiObjectWriteOperation writes;
+    writes.master.create(true);
+    writes.master.write_full(bl2);
+    writes.slave("v2").write_full(bl2);
+    ASSERT_EQ(-EEXIST, ioctx.operate("v1", &writes));
+  }
+
+  {
+    bufferlist r;
+    ObjectReadOperation o;
+    o.assert_version(v1);
+    o.read(0, 1024, NULL, NULL);
+    ASSERT_EQ(0, ioctx.operate("v1", &o, &r));
+    ASSERT_EQ(true, bl1.contents_equal(r));
+  }
+  {
+    bufferlist r;
+    ObjectReadOperation o;
+    o.assert_version(v2);
+    o.read(0, 1024, NULL, NULL);
+    ASSERT_EQ(0, ioctx.operate("v2", &o, &r));
+    ASSERT_EQ(true, bl1.contents_equal(r));
+  }
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, SlaveFailureAssertVersionPP) {
+  string b1("mmmm"), b2("abcdef");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  uint64_t v1, v2, v3;
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("v1", w));
+    ASSERT_EQ(bl1.length(), ioctx.read("v1", w, 1024, 0));
+    ASSERT_EQ(true, bl1.contents_equal(w));
+    v1 = ioctx.get_last_version();
+  }
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("v2", w));
+    ASSERT_EQ(bl1.length(), ioctx.read("v2", w, 1024, 0));
+    ASSERT_EQ(true, bl1.contents_equal(w));
+    v2 = ioctx.get_last_version();
+  }
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("v3", w));
+    ASSERT_EQ(bl1.length(), ioctx.read("v3", w, 1024, 0));
+    ASSERT_EQ(true, bl1.contents_equal(w));
+    v3 = ioctx.get_last_version();
+  }
+
+  {
+    MultiObjectWriteOperation writes;
+    writes.master.write_full(bl2);
+    writes.slave("v2").create(true);
+    writes.slave("v2").write_full(bl2);
+    writes.slave("v3").write_full(bl2);
+    ASSERT_EQ(-EEXIST, ioctx.operate("v1", &writes));
+  }
+
+  {
+    bufferlist r;
+    ObjectReadOperation o;
+    o.assert_version(v1);
+    o.read(0, 1024, NULL, NULL);
+    ASSERT_EQ(0, ioctx.operate("v1", &o, &r));
+    ASSERT_EQ(true, bl1.contents_equal(r));
+  }
+  {
+    bufferlist r;
+    ObjectReadOperation o;
+    o.assert_version(v2);
+    o.read(0, 1024, NULL, NULL);
+    ASSERT_EQ(0, ioctx.operate("v2", &o, &r));
+    ASSERT_EQ(true, bl1.contents_equal(r));
+  }
+  {
+    bufferlist r;
+    ObjectReadOperation o;
+    o.assert_version(v3);
+    o.read(0, 1024, NULL, NULL);
+    ASSERT_EQ(0, ioctx.operate("v3", &o, &r));
+    ASSERT_EQ(true, bl1.contents_equal(r));
+  }
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, SuccessAssertVersionPP) {
+  string b1("mmmm"), b2("abcdef");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  uint64_t v1_old, v1, v2, v3;
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("v1", w));
+    ASSERT_EQ(bl1.length(), ioctx.read("v1", w, 1024, 0));
+    ASSERT_EQ(true, bl1.contents_equal(w));
+    v1_old = ioctx.get_last_version();
+  }
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("v2", w));
+    ASSERT_EQ(bl1.length(), ioctx.read("v2", w, 1024, 0));
+    ASSERT_EQ(true, bl1.contents_equal(w));
+    v2 = ioctx.get_last_version();
+  }
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("v3", w));
+    ASSERT_EQ(bl1.length(), ioctx.read("v3", w, 1024, 0));
+    ASSERT_EQ(true, bl1.contents_equal(w));
+    v3 = ioctx.get_last_version();
+  }
+  {
+    MultiObjectWriteOperation writes;
+    writes.master.assert_version(v1_old);
+    writes.master.write_full(bl2);
+    writes.slave("v2").write_full(bl2);
+    writes.slave("v3").assert_exists();
+    ASSERT_EQ(0, ioctx.operate("v1", &writes));
+    v1 = ioctx.get_last_version();
+    ASSERT_EQ(true, v1 > v1_old);
+  }
+  {
+    bufferlist r;
+    ObjectReadOperation o;
+    o.assert_version(v1);
+    o.read(0, 1024, NULL, NULL);
+    ASSERT_EQ(0, ioctx.operate("v1", &o, &r));
+    ASSERT_EQ(true, bl2.contents_equal(r));
+  }
+  {
+    bufferlist r;
+    ObjectReadOperation o;
+    o.assert_version(v2);
+    o.read(0, 1024, NULL, NULL);
+    ASSERT_EQ(-ERANGE, ioctx.operate("v2", &o, &r));
+  }
+  {
+    bufferlist r;
+    ObjectReadOperation o;
+    o.assert_version(v3);
+    o.read(0, 1024, NULL, NULL);
+    ASSERT_EQ(0, ioctx.operate("v3", &o, &r));
+    ASSERT_EQ(true, bl1.contents_equal(r));
+  }
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, SuccessOperationWithSnapshotPP) {
+  string b1("abcd"), b2("pqrs");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("bar", w));
+  }
+  ASSERT_EQ(0, ioctx.snap_create("test"));
+  ASSERT_EQ(0, ioctx.remove("bar"));
+  ASSERT_EQ(-ENOENT, ioctx.stat("bar", NULL, NULL));
+  snap_t snap;
+  ASSERT_EQ(0, ioctx.snap_lookup("test", &snap));
+  ioctx.snap_set_read(snap);
+  ASSERT_EQ(0, ioctx.stat("bar", NULL, NULL));
+  ioctx.snap_set_read(0);
+
+  MultiObjectWriteOperation writes;
+  writes.master.create(true);
+  writes.slave("bar").write(0, bl2);
+  ASSERT_EQ(0, ioctx.operate("foo", &writes));
+
+  ASSERT_EQ(0, ioctx.stat("foo", NULL, NULL));
+  {
+    bufferlist r;
+    ASSERT_EQ(bl2.length(), ioctx.read("bar", r, 1024, 0));
+    ASSERT_EQ(true, bl2.contents_equal(r));
+  }
+
+  ASSERT_EQ(0, ioctx.snap_remove("test"));
+}
+
+TEST_F(LibRadosMultiObjectOperationPP, FailureOperationWithSnapshotPP) {
+  string b1("abcd"), b2("pqrs");
+  bufferlist bl1, bl2;
+  bl1.append(b1.c_str(), b1.size());
+  bl2.append(b2.c_str(), b2.size());
+
+  {
+    bufferlist w;
+    w.append(bl1);
+    ASSERT_EQ(0, ioctx.write_full("bar", w));
+  }
+  ASSERT_EQ(0, ioctx.snap_create("test"));
+  ASSERT_EQ(0, ioctx.remove("bar"));
+  ASSERT_EQ(-ENOENT, ioctx.stat("bar", NULL, NULL));
+  snap_t snap;
+  ASSERT_EQ(0, ioctx.snap_lookup("test", &snap));
+  ioctx.snap_set_read(snap);
+  ASSERT_EQ(0, ioctx.stat("bar", NULL, NULL));
+  ioctx.snap_set_read(0);
+
+  ASSERT_EQ(0, ioctx.create("foo", true));
+
+  MultiObjectWriteOperation writes;
+  writes.master.create(true);
+  writes.slave("bar").write(0, bl2);
+  ASSERT_EQ(-EEXIST, ioctx.operate("foo", &writes));
+
+  ASSERT_EQ(-ENOENT, ioctx.stat("bar", NULL, NULL));
+  {
+    ioctx.snap_set_read(snap);
+    bufferlist r;
+    ASSERT_EQ(bl1.length(), ioctx.read("bar", r, 1024, 0));
+    ASSERT_EQ(true, bl1.contents_equal(r));
+  }
+
+  ASSERT_EQ(0, ioctx.snap_remove("test"));
+}


### PR DESCRIPTION
This patch implements multi-object write transaction. It is originally proposed by Sage at CDS for 
Infernalis (http://tracker.ceph.com/projects/ceph/wiki/Osd_-_Transactions), with more discussion at  CDS for Jewel (http://tracker.ceph.com/projects/ceph/wiki/Rados_-_multi-object_transaction_support). The support for multi-object write transaction at RADOS could potentially greatly simplify the client design, such as CephFS, which can expect many file system calls finish atomically, eliminating the need of journals. Similar idea is presented at  https://www.usenix.org/conference/fast16/technical-sessions/presentation/shin. 

It is theoretically fully on top of the current RADOS mechanism, and in terms of implementation, it keeps the minimal intrusion to the ReplicatedPG code.

src/test/librados/multiobjectwriteoperation.cc gives the usage example, and ceph_test_rados_api_multiobjectwriteoperation runs the test.
