### PR TITLE
hammer: No Last-Modified, Content-Size and X-Object-Manifest headers if no segments in DLO manifest

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -942,6 +942,7 @@ void RGWGetObj::execute()
     ret = handle_user_manifest(attr_iter->second.c_str());
     if (ret < 0) {
       ldout(s->cct, 0) << "ERROR: failed to handle user manifest ret=" << ret << dendl;
+      goto done_err;
     }
     return;
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/15966