### PR TITLE
jewel: mds: wrongly treat symlink inode as normal file/dir when symlink inode is stale on kcephfs

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2908,7 +2908,7 @@ void Server::handle_client_open(MDRequestRef& mdr)
     respond_to_request(mdr, -ENXIO);                 // FIXME what error do we want?
     return;
     }*/
-  if ((flags & O_DIRECTORY) && !cur->inode.is_dir()) {
+  if ((flags & O_DIRECTORY) && !cur->inode.is_dir() && !cur->inode.is_symlink()) {
     dout(7) << "specified O_DIRECTORY on non-directory " << *cur << dendl;
     respond_to_request(mdr, -EINVAL);
     return;


### PR DESCRIPTION
http://tracker.ceph.com/issues/16083