### PR TITLE
doc: add breathe_domain_by_extension to conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -59,6 +59,7 @@ breathe_projects_source = {
     "Ceph": (os.path.join(top_level, "src/include/rados"),
              ["rados_types.h", "librados.h"])
 }
+breathe_domain_by_extension = {'py': 'py', 'c': 'c', 'h': 'c', 'cc': 'cxx', 'hpp': 'cxx'}
 pybind = os.path.join(top_level, 'src/pybind')
 if pybind not in sys.path:
     sys.path.insert(0, pybind)


### PR DESCRIPTION
so it can render the doxygen generated objects with the proper domain by
checking the extension of rendered source file.

Signed-off-by: Kefu Chai <kchai@redhat.com>

@badone it should work if https://github.com/michaeljones/breathe/pull/263 gets merged.