### PR TITLE
buffer: don't invalidate crc cache of new ptr before zeroing it

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1754,7 +1754,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
   void buffer::list::append_zero(unsigned len)
   {
     ptr bp(len);
-    bp.zero();
+    bp.zero(false);
     append(std::move(bp));
   }
 


### PR DESCRIPTION
When doing append_zero, we create new bufferptr and then zero it.
Don't invalidate internal crc cache, because at this point it's
empty anyway.

Signed-off-by: Piotr Dałek <git@predictor.org.pl>