### PR TITLE
packaging: move parted requirement to -osd subpkg

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -205,7 +205,6 @@ Requires:      python-setuptools
 Requires:      grep
 Requires:      xfsprogs
 Requires:      logrotate
-Requires:      parted
 Requires:      util-linux
 Requires:      hdparm
 Requires:      cryptsetup
@@ -344,6 +343,7 @@ Requires:	gdisk
 %if 0%{?suse_version}
 Requires:	gptfdisk
 %endif
+Requires:       parted
 %description osd
 ceph-osd is the object storage daemon for the Ceph distributed file
 system.  It is responsible for storing objects on a local file system

--- a/debian/control
+++ b/debian/control
@@ -91,7 +91,6 @@ Depends: binutils,
          grep,
          logrotate,
          lsb-release,
-         parted,
          python,
          python-argparse | libpython2.7-stdlib,
          python-pkg-resources,
@@ -180,7 +179,10 @@ Description: debugging symbols for ceph-mon
 
 Package: ceph-osd
 Architecture: linux-any
-Depends: ceph-base (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}
+Depends: ceph-base (= ${binary:Version}),
+         parted,
+         ${misc:Depends},
+         ${shlibs:Depends}
 Recommends: ceph-common (= ${binary:Version})
 Replaces: ceph (<< 10)
 Breaks: ceph (<< 10)


### PR DESCRIPTION
Prior to this change, ceph-base required the "parted" package, which meant that any installation of ceph-osd, ceph-mon, or ceph-mds would pull in the parted package.

Move the parted dependency to ceph-osd, since ceph-disk is the only thing that uses parted.

The advantage of this change is that Mon and MDS systems will not need to install the parted package.

Fixes: http://tracker.ceph.com/issues/16095

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>