### PR TITLE
mds/cdir: limit max snap id in lookup()

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -302,7 +302,8 @@ CDentry *CDir::lookup(const char *name, snapid_t snap)
   if (iter == items.end())
     return 0;
   if (iter->second->name == name &&
-      iter->second->first <= snap) {
+      iter->second->first <= snap &&
+      iter->second->last >= snap) {
     dout(20) << "  hit -> " << iter->first << dendl;
     return iter->second;
   }


### PR DESCRIPTION
If you give more than Snapid of dentry.last, then you can get dentry
It's not reasonable, I fix it

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>