### PR TITLE
os/bluestore/BlueFS: wait for aios on shutdown

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -27,14 +27,16 @@ BlueFS::BlueFS()
 
 BlueFS::~BlueFS()
 {
+  for (auto p : ioc) {
+    if (p)
+      p->aio_wait();
+    delete p;
+  }
   for (auto p : bdev) {
     if (p) {
       p->close();
       delete p;
     }
-  }
-  for (auto p : ioc) {
-    delete p;
   }
 }
 


### PR DESCRIPTION
This fixes segv from unittest_bluefs.

Signed-off-by: Sage Weil <sage@redhat.com>