### PR TITLE
[DNM] Performance changes to reduce false sharing - for discussion.

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -278,6 +278,11 @@ void OpTracker::mark_event(TrackedOp *op, const string &dest, utime_t time)
 {
   if (!tracking_enabled)
     return;
+ 
+  //
+  // POC hack to demonstrate 12% speedup from skipping the _mark_event method
+  return;
+  
   return _mark_event(op, dest, time);
 }
 

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -414,7 +414,8 @@ CephContext::CephContext(uint32_t module_type_)
   ceph_spin_init(&_associated_objs_lock);
   ceph_spin_init(&_feature_lock);
 
-  _log = new ceph::log::Log(&_conf->subsys);
+  void *p = aligned_alloc (64,sizeof (ceph::log::Log));
+  _log = new (p) ceph::log::Log(&_conf->subsys);
   _log->start();
 
   _log_obs = new LogObs(_log);

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -15,22 +15,26 @@
 namespace ceph {
 namespace log {
 
-class Log : private Thread
+//
+// Place the class and the hot pthread members
+// on cacheline aligned boundaries.
+//
+class __attribute  ((aligned(64))) Log : private Thread
 {
   Log **m_indirect_this;
-
   SubsystemMap *m_subs;
-  
-  pthread_mutex_t m_queue_mutex;
-  pthread_mutex_t m_flush_mutex;
-  pthread_cond_t m_cond_loggers;
-  pthread_cond_t m_cond_flusher;
 
-  pthread_t m_queue_mutex_holder;
-  pthread_t m_flush_mutex_holder;
+  pthread_mutex_t m_queue_mutex __attribute__((aligned (64)));
+  pthread_t m_queue_mutex_holder __attribute__((aligned (64)));
 
-  EntryQueue m_new;    ///< new entries
-  EntryQueue m_recent; ///< recent (less new) entries we've already written at low detail
+  pthread_mutex_t m_flush_mutex __attribute__((aligned (64)));
+  pthread_t m_flush_mutex_holder __attribute__((aligned (64)));
+
+  pthread_cond_t m_cond_loggers __attribute__((aligned (64)));
+  pthread_cond_t m_cond_flusher __attribute__((aligned (64)));
+
+  EntryQueue m_new    __attribute__((aligned (64)));   ///< new entries
+  EntryQueue m_recent __attribute__((aligned (64))); ///< recent (less new) entries we've already written at low detail
 
   std::string m_log_file;
   int m_fd;

--- a/src/msg/simple/Pipe.h
+++ b/src/msg/simple/Pipe.h
@@ -186,8 +186,9 @@ class DispatchQueue;
     entity_addr_t peer_addr;
     Messenger::Policy policy;
     
-    Mutex pipe_lock;
-    int state;
+    // put pipe_lock in own cacheline, by itself to avoid false sharing.
+    Mutex pipe_lock __attribute__((aligned (64)));
+    int state __attribute__((aligned (64)));
     atomic_t state_closed; // non-zero iff state = STATE_CLOSED
 
     // session_security handles any signatures or encryptions required for this pipe's msgs. PLR

--- a/src/msg/simple/SimpleMessenger.cc
+++ b/src/msg/simple/SimpleMessenger.cc
@@ -334,7 +334,8 @@ int SimpleMessenger::start()
 Pipe *SimpleMessenger::add_accept_pipe(int sd)
 {
   lock.Lock();
-  Pipe *p = new Pipe(this, Pipe::STATE_ACCEPTING, NULL);
+  void *p_al = aligned_alloc (64, sizeof(Pipe));
+  Pipe *p = new (p_al) Pipe(this, Pipe::STATE_ACCEPTING, NULL);
   p->sd = sd;
   p->pipe_lock.Lock();
   p->start_reader();
@@ -359,7 +360,8 @@ Pipe *SimpleMessenger::connect_rank(const entity_addr_t& addr,
   ldout(cct,10) << "connect_rank to " << addr << ", creating pipe and registering" << dendl;
   
   // create pipe
-  Pipe *pipe = new Pipe(this, Pipe::STATE_CONNECTING,
+  void *p_al = aligned_alloc (64, sizeof(Pipe));
+  Pipe *pipe = new (p_al) Pipe(this, Pipe::STATE_CONNECTING,
 			static_cast<PipeConnection*>(con));
   pipe->pipe_lock.Lock();
   pipe->set_peer_type(type);


### PR DESCRIPTION
This commit demonstrates the benefit of reducing cacheline contention, in two ways:
1) Align classes and contended hot data members.
2) Demonstrate how expensive OpTracker::_mark_event can be.

This commit is not to be checked in as-is.
Although I am not a Ceph developer, I have been able to realize worthwhile performance gains from these changes.   Ben England and I would like to share these findings at a upcoming weekly Ceph performance meeting.  
