### PR TITLE
Solve osd flapping and message is discarded issue

### DIFF
--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -717,6 +717,13 @@ public:
   /**
    * @} // Dispatcher Interfacing
    */
+
+  bool is_iface_connected() {
+    if ((!my_inst.addr.is_ip()) ||
+          (my_inst.addr.is_blank_ip()))
+      return true;
+    return my_inst.addr.is_iface_connected();
+  }
 };
 
 

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -357,7 +357,8 @@ struct entity_addr_t {
       return false;
     }
   }
-
+  std::string get_iface_name();
+  bool is_iface_connected();
   bool parse(const char *s, const char **end = 0);
 
   // Right now, these only deal with sockaddr_storage that have only family and content.

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7052,13 +7052,14 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 	avoid_ports.insert(hb_front_server_messenger->get_myaddr().get_port());
 
 	int r = cluster_messenger->rebind(avoid_ports);
-	if (r != 0) {
+	if (r != 0 || (!cluster_messenger->is_iface_connected())) {
 	  do_shutdown = true;  // FIXME: do_restart?
           network_error = true;
+          cluster_messenger->mark_down_all();
         }
 
 	r = hb_back_server_messenger->rebind(avoid_ports);
-	if (r != 0) {
+	if (r != 0 || (!hb_back_server_messenger->is_iface_connected())) {
 	  do_shutdown = true;  // FIXME: do_restart?
           network_error = true;
         }


### PR DESCRIPTION
Cluster network disconnection cause osd appears flapping and message is
discarded. When the cluster network is restored,the peering in the
process,there will be message is discarded,resulting in peering in a
suspended state,ops becomes zero.If you use openvswitch as a cluster
network,to reproduce the problem 100%

Signed -off-by: Jie Chen <chen.jie@h3c.com>