### PR TITLE
cmake: rbd_mirror not linking rbd_test_mock

### DIFF
--- a/src/test/journal/CMakeLists.txt
+++ b/src/test/journal/CMakeLists.txt
@@ -1,8 +1,5 @@
-set(journal_test
-  mock/MockJournaler.cc
-  )
-add_library(journal_test STATIC ${journal_test})
-set_target_properties(journal_test PROPERTIES COMPILE_FLAGS
+add_library(journal_test_mock STATIC mock/MockJournaler.cc)
+set_target_properties(journal_test_mock PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 
 # unittest_journal

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -12,6 +12,13 @@ set(librbd_test
 add_library(rbd_test STATIC ${librbd_test})
 set_target_properties(rbd_test PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 
+set(librbd_test_mock_srcs
+  mock/MockImageCtx.cc
+  mock/MockJournal.cc)
+add_library(rbd_test_mock STATIC ${librbd_test_mock_srcs})
+set_target_properties(rbd_test_mock PROPERTIES COMPILE_FLAGS
+  ${UNITTEST_CXX_FLAGS})
+
 # unittest_librbd
 # doesn't use add_ceph_test because it is called by run-rbd-unit-tests.sh
 set(unittest_librbd_srcs
@@ -39,8 +46,6 @@ set(unittest_librbd_srcs
   operation/test_mock_SnapshotRemoveRequest.cc 
   operation/test_mock_SnapshotRollbackRequest.cc 
   operation/test_mock_SnapshotUnprotectRequest.cc
-  mock/MockImageCtx.cc
-  mock/MockJournal.cc
   )
 add_executable(unittest_librbd EXCLUDE_FROM_ALL
   ${unittest_librbd_srcs}
@@ -57,13 +62,14 @@ target_link_libraries(unittest_librbd
   cls_lock
   cls_lock_client
   journal
-  journal_test
+  journal_test_mock
   cls_journal
   cls_journal_client
   rados_test_stub
   librados
   librados_api
   rbd_test
+  rbd_test_mock
   rbd_api
   rbd_internal
   rbd_types

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -33,8 +33,9 @@ target_link_libraries(unittest_rbd_mirror
   rbd_mirror_internal
   rbd_internal
   rbd_api
+  rbd_test_mock
   journal
-  journal_test
+  journal_test_mock
   cls_rbd_client
   cls_lock_client
   cls_journal_client


### PR DESCRIPTION
Added rbd_test_mock lib, also changed name of
journal_test to journal_test_mock to mimic
automake naming.

Signed-off-by: Ali Maredia <amaredia@redhat.com>