### PR TITLE
librbd: remove invalid object map flag when object map is disabled

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1782,7 +1782,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
             return -EINVAL;
           }
 
-          disable_flags = RBD_FLAG_OBJECT_MAP_INVALID;
+          disable_flags |= RBD_FLAG_OBJECT_MAP_INVALID;
           r = remove_object_map(ictx);
           if (r < 0) {
             lderr(cct) << "failed to remove object map" << dendl;
@@ -1790,7 +1790,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
           }
         }
         if ((features & RBD_FEATURE_FAST_DIFF) != 0) {
-          disable_flags = RBD_FLAG_FAST_DIFF_INVALID;
+          disable_flags |= RBD_FLAG_FAST_DIFF_INVALID;
         }
         if ((features & RBD_FEATURE_JOURNALING) != 0) {
           rbd_mirror_mode_t mirror_mode;


### PR DESCRIPTION
Fixes: #16706
Signed-off-by: xinxin shu <shuxinxin@chinac.com>