### PR TITLE
ceph-disk: modify the disk partition sequence of ceph-disk list

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3974,7 +3974,7 @@ def list_format_plain(devices):
     for device in devices:
         if device.get('partitions'):
             lines.append('%s :' % device['path'])
-            for p in sorted(device['partitions']):
+            for p in sorted(device['partitions'], key=lambda x: x['path']):
                 lines.append(list_format_dev_plain(dev=p,
                                                    prefix=' '))
         else:


### PR DESCRIPTION
    before the change, when you execute ceph-disk list, it will show in this order:
    /dev/sda :
     /dev/sda2 ceph journal, for /dev/sda1
     /dev/sda1 ceph data, active, cluster ceph, osd.0, journal /dev/sda2

    after the change, it will show in this order:
    /dev/sda :
     /dev/sda1 ceph data, active, cluster ceph, osd.0, journal /dev/sda2
     /dev/sda2 ceph journal, for /dev/sda1

    Before the change,  the entries are disordered. After the change, the entries will always show in the same order. It makes it look good and easier to visually spot the differences between two runs.
 
Signed-off-by: houlinfei <hou.linfei@h3c.com>