### PR TITLE
xio: provide dout_prefix for XioConnection

### DIFF
--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -272,6 +272,7 @@ public:
     if (conn)
       xio_connection_destroy(conn);
   }
+  ostream& conn_prefix(std::ostream *_dout);
 
   bool is_connected() override { return connected.read(); }
 


### PR DESCRIPTION
provide dout_prefix for XioConnection with: from>>to, peer-type, and conn/sess
1. this prefix will be added for any log message from XioConnection
   (2. hence, remove info that is now redundeant in few existing log messages)

Signed-off-by: Avner BenHanoch avnerb@mellanox.com
