### PR TITLE
mds: fix SnapRealm::have_past_parents_open()

### DIFF
--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -189,8 +189,8 @@ bool SnapRealm::have_past_parents_open(snapid_t first, snapid_t last)
       return false;
     }
     SnapRealm *parent_realm = open_past_parents[p->second.ino].first;
-    if (parent_realm->have_past_parents_open(MAX(first, p->second.first),
-					     MIN(last, p->first)))
+    if (!parent_realm->have_past_parents_open(MAX(first, p->second.first),
+					      MIN(last, p->first)))
       return false;
   }
 


### PR DESCRIPTION
the '!' got delete accidentally in commit f7fb2cb52c (mds: fix open
snap parents tracking)

Signed-off-by: Yan, Zheng <zyan@redhat.com>