### PR TITLE
test/osd/TestRados.cc: silence a compiler warning

### DIFF
--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -237,6 +237,7 @@ private:
     default:
       cerr << m_op << ": Invalid op type " << type << std::endl;
       assert(0);
+      return nullptr;
     }
   }
 


### PR DESCRIPTION
fix following warning by returning `nullptr` after an assert(0).
```
ceph/src/test/osd/TestRados.cc: In member function ‘TestOp*
WeightedTestGenerator::gen_op(RadosTestContext&, TestOpType)’:
ceph/src/test/osd/TestRados.cc:241:3: warning: control reaches
end of non-void function [-Wreturn-type]
   }
```

Signed-off-by: Kefu Chai <kchai@redhat.com>