### PR TITLE
mon: cancel timer events when peon receives paxos update

### DIFF
--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -698,6 +698,7 @@ void Paxos::handle_begin(MonOpRequestRef op)
   // set state.
   state = STATE_UPDATING;
   lease_expire = utime_t();  // cancel lease
+  cancel_events(); // cancel lease timeout event
 
   // yes.
   version_t v = last_committed+1;


### PR DESCRIPTION
In a multi-mon cluster, when a paxos update happens right before the
lease renew, all the events in the mon timer are cancelled, including
the lease renew event, until the paxos update completes. The leader
won't send lease renew to the peons during this period. If for some
reasons a peon is laggy, it is possible that the other peons might
see lease timeout, and initiate a election. From a leader's perspective,
this may not be what it wants. Canceling the lease timeout event on
the peon when it receives the paxos update could solve this issue.

Signed-off-by: Zhiqiang Wang zhiqiang@xsky.com
