### PR TITLE
os/bluestore: no 'head_read' when check ondisk length.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5564,7 +5564,7 @@ void BlueStore::_do_write_small(
     uint64_t tail_read =
       ROUND_UP_TO(b_off + b_len, chunk_size) - (b_off + b_len);
     if ((head_read || tail_read) &&
-	b->get_ondisk_length() >= b_off + b_len + head_read + tail_read) {
+	(b->get_ondisk_length() >= b_off + b_len + tail_read)) {
       dout(20) << __func__ << "  reading head 0x" << std::hex << head_read
 	       << " and tail 0x" << tail_read << std::dec << dendl;
       if (head_read) {


### PR DESCRIPTION
If we add 'b_off', we should not add 'head_read' again.

Signed-off-by: Haodong Tang <haodong.tang@intel.com>