### PR TITLE
msg: don't truncate message sequence to 32-bits

### DIFF
--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -422,8 +422,8 @@ public:
   uint64_t get_tid() const { return header.tid; }
   void set_tid(uint64_t t) { header.tid = t; }
 
-  unsigned get_seq() const { return header.seq; }
-  void set_seq(unsigned s) { header.seq = s; }
+  uint64_t get_seq() const { return header.seq; }
+  void set_seq(uint64_t s) { header.seq = s; }
 
   unsigned get_priority() const { return header.priority; }
   void set_priority(__s16 p) { header.priority = p; }

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -278,8 +278,8 @@ class AsyncConnection : public Connection {
   PerfCounters *logger;
   int global_seq;
   __u32 connect_seq, peer_global_seq;
-  atomic_t out_seq;
-  atomic_t ack_left, in_seq;
+  atomic64_t out_seq;
+  atomic64_t ack_left, in_seq;
   int state;
   int state_after_send;
   int sd;

--- a/src/msg/simple/Pipe.h
+++ b/src/msg/simple/Pipe.h
@@ -275,7 +275,7 @@ static const int SM_IOV_MAX = (IOV_MAX >= 1024 ? IOV_MAX / 4 : IOV_MAX);
     static const Pipe& Server(int s);
     static const Pipe& Client(const entity_addr_t& pi);
 
-    __u32 get_out_seq() { return out_seq; }
+    uint64_t get_out_seq() { return out_seq; }
 
     bool is_queued() { return !out_q.empty() || send_keepalive || send_keepalive_ack; }
 

--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -93,18 +93,18 @@ private:
     /* XXX */
     uint32_t reconnects;
     uint32_t connect_seq, peer_global_seq;
-    uint32_t in_seq, out_seq_acked; // atomic<uint64_t>, got receipt
-    atomic_t out_seq; // atomic<uint32_t>
+    uint64_t in_seq, out_seq_acked; // atomic<uint64_t>, got receipt
+    atomic64_t out_seq; // atomic<uint32_t>
 
     lifecycle() : state(lifecycle::INIT), reconnects(0), connect_seq(0),
 		  peer_global_seq(0), in_seq(0), out_seq_acked(0), 
 		  out_seq(0) {}
 
-    void set_in_seq(uint32_t seq) {
+    void set_in_seq(uint64_t seq) {
       in_seq = seq;
     }
 
-    uint32_t next_out_seq() {
+    uint64_t next_out_seq() {
       return out_seq.inc();
     }
 
@@ -139,8 +139,8 @@ private:
 
     uint32_t reconnects;
     uint32_t connect_seq, global_seq, peer_global_seq;
-    uint32_t in_seq, out_seq_acked; // atomic<uint64_t>, got receipt
-    atomic_t out_seq; // atomic<uint32_t>
+    uint64_t in_seq, out_seq_acked; // atomic<uint64_t>, got receipt
+    atomic64_t out_seq; // atomic<uint64_t>
 
     uint32_t flags;
 
@@ -168,11 +168,11 @@ private:
       return startup_state.read();
     }
 
-    void set_in_seq(uint32_t seq) {
+    void set_in_seq(uint64_t seq) {
       in_seq = seq;
     }
 
-    uint32_t next_out_seq() {
+    uint64_t next_out_seq() {
       return out_seq.inc();
     };
 
@@ -339,7 +339,7 @@ typedef boost::intrusive_ptr<XioConnection> XioConnectionRef;
 class XioLoopbackConnection : public Connection
 {
 private:
-  atomic_t seq;
+  atomic64_t seq;
 public:
   explicit XioLoopbackConnection(Messenger *m) : Connection(m->cct, m), seq(0)
     {
@@ -360,11 +360,11 @@ public:
   void mark_down() override {}
   void mark_disposable() override {}
 
-  uint32_t get_seq() {
+  uint64_t get_seq() {
     return seq.read();
   }
 
-  uint32_t next_seq() {
+  uint64_t next_seq() {
     return seq.inc();
   }
 };


### PR DESCRIPTION
Message sequence is 64-bits number, but the upper 32-bits get lost
when setting/getting message sequence. This causes messenger to
malfunction after receiving 1^32 messages

Fixes: http://tracker.ceph.com/issues/16122
Signed-off-by: Yan, Zheng <zyan@redhat.com>