### PR TITLE
cmake: detection scripts use lowercase project name

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -88,7 +88,7 @@ elif os.path.exists(os.path.join(os.getcwd(), "CMakeCache.txt")) \
      and os.path.exists(os.path.join(os.getcwd(), "bin/init-ceph")):
     src_path = None
     for l in open("./CMakeCache.txt").readlines():
-        if l.startswith("Ceph_SOURCE_DIR:STATIC="):
+        if l.startswith("ceph_SOURCE_DIR:STATIC="):
             src_path = l.split("=")[1].strip()
 
 

--- a/src/test/detect-build-env-vars.sh
+++ b/src/test/detect-build-env-vars.sh
@@ -5,7 +5,7 @@ if [ -n "$CEPH_BUILD_DIR" ] && [ -n "$CEPH_ROOT" ] && [ -n "$CEPH_BIN" ] && [ -n
 elif [ -e CMakeCache.txt ]; then
   echo "Environment Variables Not All Set, Detected Build System CMake"
   echo "Setting Environment Variables"
-  export CEPH_ROOT=`grep Ceph_SOURCE_DIR CMakeCache.txt | cut -d "=" -f 2`
+  export CEPH_ROOT=`grep ceph_SOURCE_DIR CMakeCache.txt | cut -d "=" -f 2`
   export CEPH_BUILD_DIR=`pwd`
   export CEPH_BIN=$CEPH_BUILD_DIR/bin
   export CEPH_LIB=$CEPH_BUILD_DIR/lib

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -24,7 +24,7 @@ fi
 # for running out of the CMake build directory
 if [ -e CMakeCache.txt ]; then
   # Out of tree build, learn source location from CMakeCache.txt
-  CEPH_ROOT=`grep Ceph_SOURCE_DIR CMakeCache.txt | cut -d "=" -f 2`
+  CEPH_ROOT=`grep ceph_SOURCE_DIR CMakeCache.txt | cut -d "=" -f 2`
   CEPH_BUILD_DIR=`pwd`
 fi
 


### PR DESCRIPTION
Changing the detection scripts to use the new project name, changed in commit c1a37101ea87a973068f2dc9858487f83ae57f88 (cmake: project name should be "ceph")

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>