### PR TITLE
osd/ReplicatedPG: move classes to cc file

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -159,6 +159,52 @@ public:
   }
 };
 
+struct ReplicatedPG::C_OSD_OndiskWriteUnlock : public Context {
+  ObjectContextRef obc, obc2, obc3;
+  C_OSD_OndiskWriteUnlock(
+    ObjectContextRef o,
+    ObjectContextRef o2 = ObjectContextRef(),
+    ObjectContextRef o3 = ObjectContextRef()) : obc(o), obc2(o2), obc3(o3) {}
+  void finish(int r) {
+    obc->ondisk_write_unlock();
+    if (obc2)
+      obc2->ondisk_write_unlock();
+    if (obc3)
+      obc3->ondisk_write_unlock();
+  }
+};
+
+struct ReplicatedPG::C_OSD_AppliedRecoveredObject : public Context {
+  ReplicatedPGRef pg;
+  ObjectContextRef obc;
+  C_OSD_AppliedRecoveredObject(ReplicatedPG *p, ObjectContextRef o) :
+    pg(p), obc(o) {}
+  void finish(int r) {
+    pg->_applied_recovered_object(obc);
+  }
+};
+
+struct ReplicatedPG::C_OSD_CommittedPushedObject : public Context {
+  ReplicatedPGRef pg;
+  epoch_t epoch;
+  eversion_t last_complete;
+  C_OSD_CommittedPushedObject(
+    ReplicatedPG *p, epoch_t epoch, eversion_t lc) :
+    pg(p), epoch(epoch), last_complete(lc) {
+  }
+  void finish(int r) {
+    pg->_committed_pushed_object(epoch, last_complete);
+  }
+};
+
+struct ReplicatedPG::C_OSD_AppliedRecoveredObjectReplica : public Context {
+  ReplicatedPGRef pg;
+  explicit C_OSD_AppliedRecoveredObjectReplica(ReplicatedPG *p) :
+    pg(p) {}
+  void finish(int r) {
+    pg->_applied_recovered_object_replica();
+  }
+};
 // ======================
 // PGBackend::Listener
 

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1271,50 +1271,10 @@ protected:
     PGBackend::RecoveryHandle *h);
   void send_remove_op(const hobject_t& oid, eversion_t v, pg_shard_t peer);
 
-
-  struct C_OSD_OndiskWriteUnlock : public Context {
-    ObjectContextRef obc, obc2, obc3;
-    C_OSD_OndiskWriteUnlock(
-      ObjectContextRef o,
-      ObjectContextRef o2 = ObjectContextRef(),
-      ObjectContextRef o3 = ObjectContextRef()) : obc(o), obc2(o2), obc3(o3) {}
-    void finish(int r) {
-      obc->ondisk_write_unlock();
-      if (obc2)
-	obc2->ondisk_write_unlock();
-      if (obc3)
-	obc3->ondisk_write_unlock();
-    }
-  };
-  struct C_OSD_AppliedRecoveredObject : public Context {
-    ReplicatedPGRef pg;
-    ObjectContextRef obc;
-    C_OSD_AppliedRecoveredObject(ReplicatedPG *p, ObjectContextRef o) :
-      pg(p), obc(o) {}
-    void finish(int r) {
-      pg->_applied_recovered_object(obc);
-    }
-  };
-  struct C_OSD_CommittedPushedObject : public Context {
-    ReplicatedPGRef pg;
-    epoch_t epoch;
-    eversion_t last_complete;
-    C_OSD_CommittedPushedObject(
-      ReplicatedPG *p, epoch_t epoch, eversion_t lc) :
-      pg(p), epoch(epoch), last_complete(lc) {
-    }
-    void finish(int r) {
-      pg->_committed_pushed_object(epoch, last_complete);
-    }
-  };
-  struct C_OSD_AppliedRecoveredObjectReplica : public Context {
-    ReplicatedPGRef pg;
-    explicit C_OSD_AppliedRecoveredObjectReplica(ReplicatedPG *p) :
-      pg(p) {}
-    void finish(int r) {
-      pg->_applied_recovered_object_replica();
-    }
-  };
+  struct C_OSD_OndiskWriteUnlock;
+  struct C_OSD_AppliedRecoveredObject;
+  struct C_OSD_CommittedPushedObject;
+  struct C_OSD_AppliedRecoveredObjectReplica;
 
   void sub_op_remove(OpRequestRef op);
 


### PR DESCRIPTION
Move
C_OSD_OndiskWriteUnlock
C_OSD_AppliedRecoveredObject
C_OSD_CommittedPushedObject
C_OSD_AppliedRecoveredObjectReplica
to cc file.

Signed-off-by: Michal Jarzabek stiopa@gmail.com
