### PR TITLE
mds: evict MMDSResolve from delayed_resolve map if it is going to be …

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -3083,6 +3083,7 @@ void MDCache::handle_resolve(MMDSResolve *m)
 
   if (mds->get_state() < MDSMap::STATE_RESOLVE) {
     if (mds->get_want_state() == CEPH_MDS_STATE_RESOLVE) {
+      discard_delayed_resolve(from);
       mds->wait_for_resolve(new C_MDS_RetryMessage(mds, m));
       return;
     }


### PR DESCRIPTION
…re-disptached

So we don't process the same message twice.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>