### PR TITLE
debian: package compressor plugins and silence dpkg-shlibdeps warnings  

### DIFF
--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -16,6 +16,7 @@ usr/bin/rbdmap
 usr/bin/rbd-replay*
 usr/bin/ceph-post-file
 usr/bin/ceph-brag
+usr/lib/ceph/compressor/*
 usr/share/man/man8/ceph-authtool.8
 usr/share/man/man8/ceph-conf.8
 usr/share/man/man8/ceph-dencoder.8

--- a/debian/rules
+++ b/debian/rules
@@ -203,7 +203,7 @@ binary-arch: build install
 	dh_makeshlibs -a
 	dh_python2 -a
 	dh_installdeb -a
-	dh_shlibdeps -a
+	dh_shlibdeps -a --exclude=erasure-code --exclude=rados-classes --exclude=compressor
 	dh_gencontrol -a
 	dh_md5sums -a
 	dh_builddeb -a


### PR DESCRIPTION
- package compressor plugins: these plugins are not used yet, but this change tries to sync debian/rules with ceph.spec.in
- silence dpkg-shlibdeps warnings: the plugins do have unresolved symbols. this is expected.