### PR TITLE
cephtool/test.sh: Adding iterations numbers in output log

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -14,9 +14,10 @@ function check_no_osd_down()
 
 function wait_no_osd_down()
 {
-  for i in $(seq 1 300) ; do
+  max_run=300
+  for i in $(seq 1 $max_run) ; do
     if ! check_no_osd_down ; then
-      echo "waiting for osd(s) to come back up"
+      echo "waiting for osd(s) to come back up ($i/$max_run)"
       sleep 1
     else
       break
@@ -666,9 +667,10 @@ function check_mds_active()
 function wait_mds_active()
 {
   fs_name=$1
-  for i in $(seq 1 300) ; do
+  max_run=300
+  for i in $(seq 1 $max_run) ; do
       if ! check_mds_active $fs_name ; then
-          echo "waiting for an active MDS daemon"
+          echo "waiting for an active MDS daemon ($i/$max_run)"
           sleep 5
       else
           break
@@ -1097,9 +1099,10 @@ function test_mon_osd()
   ceph osd down 0
   ceph osd dump | grep 'osd.0 down'
   ceph osd unset noup
-  for ((i=0; i < 1000; i++)); do
+  max_run=1000
+  for ((i=0; i < $max_run; i++)); do
     if ! ceph osd dump | grep 'osd.0 up'; then
-      echo "waiting for osd.0 to come back up"
+      echo "waiting for osd.0 to come back up ($i/$max_run)"
       sleep 1
     else
       break


### PR DESCRIPTION
When this test is failing and reach the limits, reading the log doesn't make
obvious that we reach them.

This simple patch adds the iterations numbers inside the output log.

Signed-off-by: Erwan Velu <erwan@redhat.com>