### PR TITLE
Allows developers to turn on diagnostic colors for compiler output when stderr is not a terminal

### DIFF
--- a/README.cmake.md
+++ b/README.cmake.md
@@ -49,10 +49,21 @@ external dependencies:
       -DCMAKE_INSTALL_PREFIX=/opt/accelio -DCMAKE_C_FLAGS="-O0 -g3 -gdwarf-4" \
       ..
 
-More options will be implemented in the future.
+If you often pipe `make`to `less` and would like to maintain the
+diagnostic colors for errors and warnings, you can invoke `cmake`
+with:
+
+    $ cmake -DDIAG_COLOR_ALWAYS=yes [...]
+
+Then you'll get the diagnostic colors when you execute:
+
+    $ make | less -R
+
+**More options will be implemented in the future.**
+
 
 Targets Built
-==============
+=============
 
 * ceph-mon 
 * ceph-osd 

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -50,14 +50,18 @@ external dependencies:
       ..
 
 If you often pipe `make`to `less` and would like to maintain the
-diagnostic colors for errors and warnings, you can invoke `cmake`
-with:
+diagnostic colors for errors and warnings (and if your compiler
+supports it), you can invoke `cmake` with:
 
-    $ cmake -DDIAG_COLOR_ALWAYS=yes [...]
+    $ cmake -DDIAGNOSTICS_COLOR=always [...]
 
 Then you'll get the diagnostic colors when you execute:
 
     $ make | less -R
+
+Other available values for DIAGNOSTICS_COLOR are 'auto' (default) and
+'never'.
+
 
 **More options will be implemented in the future.**
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,20 @@ else()
   message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support.")
 endif()
 
+
+# if compiler allows it and if -DDIAG_COLOR_ALWAYS=yes is provided to
+# cmake, turn on diagnostic colors, even when compiler output does not
+# go to terminal (e.g., when piped to less)
+
+CHECK_C_COMPILER_FLAG("-fdiagnostics-color=always"
+  COMPILER_SUPPORTS_DIAG_COLOR_ALWAYS)
+
+if(COMPILER_SUPPORTS_DIAG_COLOR_ALWAYS AND DIAG_COLOR_ALWAYS)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=always")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+endif()
+
+
 ## detect sse support
 
 # create a tmp file with an empty main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,22 +91,17 @@ else()
 endif()
 
 
-# if compiler allows it and if -DDIAG_COLOR_ALWAYS=yes is provided to
-# cmake, turn on diagnostic colors, even when compiler output does not
-# go to terminal (e.g., when piped to less)
+## Handle diagnostics color if compiler supports them.
 
 CHECK_C_COMPILER_FLAG("-fdiagnostics-color=always"
-  COMPILER_SUPPORTS_DIAG_COLOR_ALWAYS)
+  COMPILER_SUPPORTS_DIAGNOSTICS_COLOR)
 
-if(DIAG_COLOR_ALWAYS)
-  if(COMPILER_SUPPORTS_DIAG_COLOR_ALWAYS)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=always")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
-    message(STATUS "C and C++ compilers will always show diagnostic colors")
-  else()
-    message(WARNING
-      "Unable to turn on DIAG_COLOR_ALWAYS, because this compiler does not support -fdiagnostics-color=always flag.")
-  endif()
+set(DIAGNOSTICS_COLOR "auto"
+  CACHE STRING "Used if the C/C++ compiler supports the -fdiagnostics-color option. May have one of three values -- 'auto' (default), 'always', or 'never'. If set to 'always' and the compiler supports the option, 'make [...] | less -R' will make visible diagnostics colorization of compiler output.")
+
+if(COMPILER_SUPPORTS_DIAGNOSTICS_COLOR)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=${DIAGNOSTICS_COLOR}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=${DIAGNOSTICS_COLOR}")
 endif()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,9 +98,15 @@ endif()
 CHECK_C_COMPILER_FLAG("-fdiagnostics-color=always"
   COMPILER_SUPPORTS_DIAG_COLOR_ALWAYS)
 
-if(COMPILER_SUPPORTS_DIAG_COLOR_ALWAYS AND DIAG_COLOR_ALWAYS)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=always")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+if(DIAG_COLOR_ALWAYS)
+  if(COMPILER_SUPPORTS_DIAG_COLOR_ALWAYS)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=always")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+    message(STATUS "C and C++ compilers will always show diagnostic colors")
+  else()
+    message(WARNING
+      "Unable to turn on DIAG_COLOR_ALWAYS, because this compiler does not support -fdiagnostics-color=always flag.")
+  endif()
 endif()
 
 


### PR DESCRIPTION
Useful for those who'd like to do:

    make | less -R

Checks if the C compiler supports the -fdiagnostics-color=always option, and then if cmake will use the value of DIAGNOSTICS_COLOR to set the option. Valid values are "auto" (default), "always" (nice for "make | less -R") and "never".

For example, during cmake invocation one could use:

    cmake -DDIAGNOSTICS_COLOR=always [...]

to make sure the above combination of make and less works.
