### PR TITLE
bluestore: fix is_allocated() method of bluestore_blob_t

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2629,7 +2629,7 @@ int BlueStore::fsck()
       ghobject_t oid;
       if (is_bnode_key(it->key())) {
 	if (expecting_objects) {
-	  dout(30) << __func__ << "  had bnode but no objects for "
+	  dout(30) << __func__ << "  had bnode but no objects for 0x"
 		   << std::hex << expecting_hash << std::dec << dendl;
 	  ++errors;
 	}
@@ -2646,7 +2646,7 @@ int BlueStore::fsck()
       }
       if (expecting_objects) {
 	if (oid.hobj.get_bitwise_key_u32() != expecting_hash) {
-	  dout(30) << __func__ << "  had bnode but no objects for "
+	  dout(30) << __func__ << "  had bnode but no objects for 0x"
 		   << std::hex << expecting_hash << std::dec << dendl;
 	  ++errors;
 	}
@@ -2672,7 +2672,7 @@ int BlueStore::fsck()
       }
     }
     if (expecting_objects) {
-      dout(30) << __func__ << "  had bnode but no objects for "
+      dout(30) << __func__ << "  had bnode but no objects for 0x"
 	       << std::hex << expecting_hash << std::dec << dendl;
       ++errors;
       expecting_objects = false;

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -104,9 +104,7 @@ string bluestore_extent_t::get_flags_string(unsigned flags)
 {
   string s;
   if (flags & FLAG_SHARED) {
-    if (s.length())
-      s += '+';
-    s += "shared";
+    s = "shared";
   }
   return s;
 }
@@ -438,9 +436,7 @@ string bluestore_blob_t::get_flags_string(unsigned flags)
 {
   string s;
   if (flags & FLAG_MUTABLE) {
-    if (s.length())
-      s += '+';
-    s += "mutable";
+    s = "mutable";
   }
   if (flags & FLAG_COMPRESSED) {
     if (s.length())

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -687,7 +687,7 @@ int bluestore_blob_t::verify_csum(uint64_t b_off, const bufferlist& bl) const
     return Checksummer::verify<Checksummer::crc32c>(
       get_csum_block_size(), b_off, bl.length(), bl, csum_data);
   default:
-    return -EOPNOTSUPP;
+    return EOPNOTSUPP;
   }
 }
 

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -337,6 +337,7 @@ struct bluestore_blob_t {
 	return true;
       }
       b_len -= p->length;
+      ++p;
     }
     assert(0 == "we should not get here");
   }


### PR DESCRIPTION
Seems we forget to increase the iterator properly.