### PR TITLE
common/buffer: add noexcept to ensure move ctor is used

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -776,7 +776,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
       bdout << "ptr " << this << " get " << _raw << bendl;
     }
   }
-  buffer::ptr::ptr(ptr&& p) : _raw(p._raw), _off(p._off), _len(p._len)
+  buffer::ptr::ptr(ptr&& p) noexcept : _raw(p._raw), _off(p._off), _len(p._len)
   {
     p._raw = nullptr;
     p._off = p._len = 0;
@@ -806,7 +806,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     }
     return *this;
   }
-  buffer::ptr& buffer::ptr::operator= (ptr&& p)
+  buffer::ptr& buffer::ptr::operator= (ptr&& p) noexcept
   {
     release();
     buffer::raw *raw = p._raw;

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -173,10 +173,10 @@ namespace buffer CEPH_BUFFER_API {
     ptr(unsigned l);
     ptr(const char *d, unsigned l);
     ptr(const ptr& p);
-    ptr(ptr&& p);
+    ptr(ptr&& p) noexcept;
     ptr(const ptr& p, unsigned o, unsigned l);
     ptr& operator= (const ptr& p);
-    ptr& operator= (ptr&& p);
+    ptr& operator= (ptr&& p) noexcept;
     ~ptr() {
       release();
     }


### PR DESCRIPTION
otherwise vector::push_back() will use the copy ctor if it resizes,
to enforce its strong exception guarantee.

Signed-off-by: Kefu Chai <kchai@redhat.com>