### PR TITLE
Unittesting: freebsd changes, part 3

### DIFF
--- a/README.FreeBSD
+++ b/README.FreeBSD
@@ -16,10 +16,21 @@ The following setup will get things running for FreeBSD:
 	sudo pkg install bash
 	sudo ln -s /usr/local/bin/bash /bin/bash
 
-Building Ceph
-=============
+Building and Testing Ceph
+=========================
+
  - Go and start building
 	./do_freebsd.sh
+ - This is going to terminate some where in testing due to not all
+   commit to correct testing under FreeBSD are commited.
+ - Rerunning the TESTS can be done with:
+	cd src
+	gmake check
+   Or
+	cd src
+	gmake recheck
+  Where the last one actually only tests the previously failed tests.
+  To run tests in parallel use a '-j<nr>'.
 
 Parts not (yet) included:
 =========================
@@ -57,3 +68,17 @@ Things to investigate:
 
  - ceph-{osd,mon} need 2 signals before they actually terminate.
 
+Tests that fail at the moment:
+==============================
+ - test/cephtool-test-mon.sh
+	The test builds a cluster runs some tests on it, that works.
+	Then osd.0 is set down, and then up, but it actually does not come back up
+	at all.
+	Test terminates because of timeout waiting for osd.0 up
+ -  test/cephtool-test-rados.sh
+     0> 2016-03-16 00:04:01.041452 8056a0d00 -1 common/HeartbeatMap.cc: 
+	In function 'bool ceph::HeartbeatMap::_check(const ceph::heartbeat_handle_d *, const char *, time_t)' 
+	thread 8056a0d00 time 2016-03-16 00:04:00.999146 
+     common/HeartbeatMap.cc: 86: FAILED assert(0 == "hit suicide timeout")
+
+ 

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -743,7 +743,11 @@ def is_mounted(dev):
     Check if the given device is mounted.
     """
     dev = os.path.realpath(dev)
-    with file('/proc/mounts', 'rb') as proc_mounts:
+    proc_prefix = ''
+    if platform.system() == "FreeBSD":
+        # Use the Linux compatibility tree
+        proc_prefix = '/compat/linux'
+    with file(proc_prefix + '/proc/mounts', 'rb') as proc_mounts:
         for line in proc_mounts:
             fields = line.split()
             if len(fields) < 3:

--- a/src/ceph-disk/tests/test_main.py
+++ b/src/ceph-disk/tests/test_main.py
@@ -14,6 +14,7 @@
 #
 from mock import patch, DEFAULT
 import os
+import platform
 import io
 import shutil
 import subprocess
@@ -310,6 +311,10 @@ class TestCephDisk(object):
             assert expect == main.list_devices()
 
     def test_list_dmcrypt_data(self):
+        if platform.system() == "FreeBSD":
+            # FreeBSD does not have blkid, and the semantics that go with it
+            print "SKIPPED: no blkid"
+            return
         partition_type2type = {
             main.PTYPE['plain']['osd']['ready']: 'plain',
             main.PTYPE['luks']['osd']['ready']: 'LUKS',
@@ -376,6 +381,10 @@ class TestCephDisk(object):
                 assert expect == main.list_devices()
 
     def test_list_multipath(self):
+        if platform.system() == "FreeBSD":
+            # FreeBSD does not have blkid, and the semantics that go with it
+            print "SKIPPED: no blkid"
+            return
         #
         # multipath data partition
         #
@@ -581,6 +590,10 @@ class TestCephDisk(object):
             assert expect == main.list_devices()
 
     def test_list_other(self):
+        if platform.system() == "FreeBSD":
+            # FreeBSD does not have the same type of devices
+            print "SKIPPED: FreeBSD devices have different properties"
+            return
         #
         # not swap, unknown fs type, not mounted, with uuid
         #

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -12,6 +12,7 @@
  * 
  */
 
+#include "include/compat.h"
 #include <iostream>
 #include <sstream>
 using namespace std;

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1049,18 +1049,35 @@ OPTION(filestore_omap_header_cache_size, OPT_INT, 1024)
 OPTION(filestore_max_inline_xattr_size, OPT_U32, 0)	//Override
 OPTION(filestore_max_inline_xattr_size_xfs, OPT_U32, 65536)
 OPTION(filestore_max_inline_xattr_size_btrfs, OPT_U32, 2048)
+OPTION(filestore_max_inline_xattr_size_zfs, OPT_U32, 2048)
+#if defined(__FreeBSD__)
+// Assuming ZFS without using ZFS-FileStore
+OPTION(filestore_max_inline_xattr_size_other, OPT_U32, 2048)
+#else
 OPTION(filestore_max_inline_xattr_size_other, OPT_U32, 512)
+#endif
 
 // for more than filestore_max_inline_xattrs attrs
 OPTION(filestore_max_inline_xattrs, OPT_U32, 0)	//Override
 OPTION(filestore_max_inline_xattrs_xfs, OPT_U32, 10)
 OPTION(filestore_max_inline_xattrs_btrfs, OPT_U32, 10)
+OPTION(filestore_max_inline_xattrs_zfs, OPT_U32, 10)
+#if defined(__FreeBSD__)
+// Assuming running on ZFS without using ZFS-FileStore
+OPTION(filestore_max_inline_xattrs_other, OPT_U32, 10)
+#else
 OPTION(filestore_max_inline_xattrs_other, OPT_U32, 2)
+#endif
 
 // max xattr value size
 OPTION(filestore_max_xattr_value_size, OPT_U32, 0)	//Override
 OPTION(filestore_max_xattr_value_size_xfs, OPT_U32, 64<<10)
 OPTION(filestore_max_xattr_value_size_btrfs, OPT_U32, 64<<10)
+OPTION(filestore_max_xattr_value_size_zfs, OPT_U32, 64<<10)
+#if defined(__FreeBSD__)
+// Assuming ZFS without using ZFS-FileStore
+OPTION(filestore_max_xattr_value_size_other, OPT_U32, 64<<10)
+#else
 // ext4 allows 4k xattrs total including some smallish extra fields and the
 // keys.  We're allowing 2 512 inline attrs in addition some some filestore
 // replay attrs.  After accounting for those, we still need to fit up to
@@ -1068,6 +1085,7 @@ OPTION(filestore_max_xattr_value_size_btrfs, OPT_U32, 64<<10)
 // to be safe.  This is hacky, but it's not worth complicating the code
 // to work around ext4's total xattr limit.
 OPTION(filestore_max_xattr_value_size_other, OPT_U32, 1<<10)
+#endif
 
 OPTION(filestore_sloppy_crc, OPT_BOOL, false)         // track sloppy crcs
 OPTION(filestore_sloppy_crc_block_size, OPT_INT, 65536)
@@ -1078,7 +1096,11 @@ OPTION(filestore_max_sync_interval, OPT_DOUBLE, 5)    // seconds
 OPTION(filestore_min_sync_interval, OPT_DOUBLE, .01)  // seconds
 OPTION(filestore_btrfs_snap, OPT_BOOL, true)
 OPTION(filestore_btrfs_clone_range, OPT_BOOL, true)
+#if defined(__linux__)
 OPTION(filestore_zfs_snap, OPT_BOOL, false) // zfsonlinux is still unstable
+#else
+OPTION(filestore_zfs_snap, OPT_BOOL, true) 
+#endif
 OPTION(filestore_fsync_flushes_journal_data, OPT_BOOL, false)
 OPTION(filestore_fiemap, OPT_BOOL, false)     // (try to) use fiemap
 OPTION(filestore_punch_hole, OPT_BOOL, false)

--- a/src/common/dns_resolve.cc
+++ b/src/common/dns_resolve.cc
@@ -11,7 +11,6 @@
  * Foundation.  See file COPYING.
  *
  */
-#include "dns_resolve.h"
 
 #include <sys/types.h>
 #include <netinet/in.h>
@@ -22,7 +21,7 @@
 #include "acconfig.h"
 #include "common/debug.h"
 #include "msg/msg_types.h"
-
+#include "dns_resolve.h"
 
 #define dout_subsys ceph_subsys_
 

--- a/src/common/xattr.c
+++ b/src/common/xattr.c
@@ -10,6 +10,7 @@
  */
 
 #include "acconfig.h"
+#include "include/compat.h"
 #if defined(__FreeBSD__)
 #include <errno.h>
 #include <stdint.h>
@@ -17,6 +18,7 @@
 #include <strings.h>
 #include <sys/types.h>
 #include <sys/extattr.h>
+#include <assert.h>
 #elif defined(__linux__)
 #include <sys/types.h>
 #include <sys/xattr.h>

--- a/src/common/xattr.h
+++ b/src/common/xattr.h
@@ -19,11 +19,19 @@
 extern "C" {
 #endif
 
+#if defined(__linux__)
 // Almost everyone defines ENOATTR, except for Linux,
 // which does #define ENOATTR ENODATA.  It seems that occasionally that
 // isn't defined, though, so let's make sure.
 #ifndef ENOATTR
 # define ENOATTR ENODATA
+#endif
+#else
+// ! LINUX
+#if !defined(ENOATTR) && !defined(ENODATA)
+#warning ENOATTR and ENODATA should already be defined.
+#warning perhaps you need to include "include/compat.h" to fix this.
+#endif
 #endif
 
 int ceph_os_setxattr(const char *path, const char *name,

--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -162,7 +162,12 @@ int pidfh::open(const md_config_t *conf)
   pf_dev = st.st_dev;
   pf_ino = st.st_ino;
 
-  struct flock l = { F_WRLCK, SEEK_SET, 0, 0, 0 };
+  struct flock l = {
+    .l_type = F_WRLCK,
+    .l_whence = SEEK_SET,
+    .l_start = 0,
+    .l_len = 0,
+  }; 
   int r = ::fcntl(pf_fd, F_SETLK, &l);
   if (r < 0) {
     derr << __func__ << ": failed to lock pidfile "

--- a/src/os/filestore/chain_xattr.h
+++ b/src/os/filestore/chain_xattr.h
@@ -4,6 +4,7 @@
 #ifndef __CEPH_OSD_CHAIN_XATTR_H
 #define __CEPH_OSD_CHAIN_XATTR_H
 
+#include "include/compat.h"
 #include "common/xattr.h"
 #include "include/assert.h"
 #include "include/buffer.h"
@@ -18,6 +19,10 @@
 #elif defined(__APPLE__)
 #include <sys/xattr.h>
 #define CHAIN_XATTR_MAX_NAME_LEN ((XATTR_MAXNAMELEN + 1) / 2)
+#elif defined(__FreeBSD__)
+#include <sys/syslimits.h>
+#include <sys/extattr.h>
+#define CHAIN_XATTR_MAX_NAME_LEN ((NAME_MAX + 1) / 2)
 #else
 #define CHAIN_XATTR_MAX_NAME_LEN  128
 #endif
@@ -30,6 +35,13 @@
  */
 #define CHAIN_XATTR_SHORT_BLOCK_LEN 250
 #define CHAIN_XATTR_SHORT_LEN_THRESHOLD 1000
+
+#if defined(__FreeBSD__)
+  // After all the includes are done
+  // Make sure compatability has worked
+  static_assert( ENODATA != 9919, "ENODATA used from /usr/include/c++/v1/cerrno");
+  static_assert( ENODATA == 87, "ENODATA does not equal ENOATTR" );
+#endif
 
 // wrappers to hide annoying errno handling.
 

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "include/compat.h"
 #include "include/rados/rgw_file.h"
 
 #include <sys/types.h>

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "include/compat.h"
 #include <boost/utility/string_ref.hpp>
 
 #include <curl/curl.h>

--- a/src/test/Makefile-server.am
+++ b/src/test/Makefile-server.am
@@ -45,12 +45,12 @@ ceph_perf_msgr_client_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 ceph_perf_msgr_client_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_perf_msgr_client
 
-if LINUX
 ceph_test_objectstore_SOURCES = test/objectstore/store_test.cc
 ceph_test_objectstore_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 ceph_test_objectstore_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_objectstore
 
+if LINUX
 ceph_test_keyvaluedb_SOURCES = test/objectstore/test_kv.cc
 ceph_test_keyvaluedb_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 ceph_test_keyvaluedb_CXXFLAGS = $(UNITTEST_CXXFLAGS)

--- a/src/test/cli/ceph-authtool/cap-bin.t
+++ b/src/test/cli/ceph-authtool/cap-bin.t
@@ -2,5 +2,5 @@
   creating kring
 
   $ ceph-authtool --cap osd 'allow rx pool=swimming' kring
-  $ ceph-authtool kring --list|grep -P '^\tcaps '
+  $ ceph-authtool kring --list|grep -E '^\Wcaps '
   \tcaps osd = "allow rx pool=swimming" (esc)

--- a/src/test/cli/ceph-authtool/cap-invalid.t
+++ b/src/test/cli/ceph-authtool/cap-invalid.t
@@ -3,10 +3,10 @@
 
 # TODO is this nice?
   $ ceph-authtool --cap osd 'broken' kring
-  $ ceph-authtool kring --list|grep -P '^\tcaps '
+  $ ceph-authtool kring --list|grep -E '^\Wcaps '
   \tcaps osd = "broken" (esc)
 
 # TODO is this nice?
   $ ceph-authtool --cap xyzzy 'broken' kring
-  $ ceph-authtool kring --list|grep -P '^\tcaps '
+  $ ceph-authtool kring --list|grep -E '^\Wcaps '
   \tcaps xyzzy = "broken" (esc)

--- a/src/test/cli/ceph-authtool/cap-overwrite.t
+++ b/src/test/cli/ceph-authtool/cap-overwrite.t
@@ -2,10 +2,10 @@
   creating kring
 
   $ ceph-authtool --cap osd 'allow rx pool=swimming' kring
-  $ ceph-authtool kring --list|grep -P '^\tcaps '
+  $ ceph-authtool kring --list|grep -E '^\Wcaps '
   \tcaps osd = "allow rx pool=swimming" (esc)
 
 # TODO it seems --cap overwrites all previous caps; is this wanted?
   $ ceph-authtool --cap mds 'allow' kring
-  $ ceph-authtool kring --list|grep -P '^\tcaps '
+  $ ceph-authtool kring --list|grep -E '^\Wcaps '
   \tcaps mds = "allow" (esc)

--- a/src/test/cli/ceph-authtool/cap.t
+++ b/src/test/cli/ceph-authtool/cap.t
@@ -2,7 +2,7 @@
   creating kring
 
   $ ceph-authtool --cap osd 'allow rx pool=swimming' kring
-  $ ceph-authtool kring --list|grep -P '^\tcaps '
+  $ ceph-authtool kring --list|grep -E '^\Wcaps '
   \tcaps osd = "allow rx pool=swimming" (esc)
 
   $ cat kring

--- a/src/test/cli/osdmaptool/test-map-pgs.t
+++ b/src/test/cli/osdmaptool/test-map-pgs.t
@@ -22,7 +22,7 @@
   $ grep "pg_num $PG_NUM" "$OUT" || cat $OUT
   pool 0 pg_num 8000
   $ TOTAL=$((POOL_COUNT * $PG_NUM))
-  $ grep -P "size $SIZE\t$TOTAL" $OUT || cat $OUT
+  $ grep -E "size $SIZE\W$TOTAL" $OUT || cat $OUT
   size 3\t8000 (esc)
   $ STATS_CRUSH=$(grep '^ avg ' "$OUT")
 # 
@@ -34,7 +34,7 @@
   $ grep "pg_num $PG_NUM" "$OUT" || cat $OUT
   pool 0 pg_num 8000
   $ TOTAL=$((POOL_COUNT * $PG_NUM))
-  $ grep -P "size $SIZE\t$TOTAL" $OUT || cat $OUT
+  $ grep -E "size $SIZE\W$TOTAL" $OUT || cat $OUT
   size 3\t8000 (esc)
   $ STATS_RANDOM=$(grep '^ avg ' "$OUT")
 # it is almost impossible to get the same stats with random and crush

--- a/src/test/common/dns_resolve.cc
+++ b/src/test/common/dns_resolve.cc
@@ -11,6 +11,13 @@
  * Foundation.  See file COPYING.
  *
  */
+
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <arpa/nameser.h>
+#include <arpa/inet.h>
+#include <resolv.h>
+
 #include "common/dns_resolve.h"
 #include "test/common/dns_messages.h"
 

--- a/src/test/common/test_util.cc
+++ b/src/test/common/test_util.cc
@@ -32,6 +32,7 @@ TEST(util, unit_to_bytesize)
   ASSERT_EQ(65536ll, unit_to_bytesize(" 64K", &cerr));
 }
 
+#if !defined(__FreeBSD__)
 TEST(util, collect_sys_info)
 {
   map<string, string> sys_info;
@@ -45,3 +46,4 @@ TEST(util, collect_sys_info)
 
   cct->put();
 }
+#endif

--- a/src/test/on_exit.cc
+++ b/src/test/on_exit.cc
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 
   // shared mem for exit tests
   shared_val = (int*)mmap(NULL, sizeof(int),
-      PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, 0, 0);
+      PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
   assert(shared_val != MAP_FAILED);
 
   // test normal exit returning from main

--- a/src/test/system/cross_process_sem.cc
+++ b/src/test/system/cross_process_sem.cc
@@ -36,7 +36,7 @@ create(int initial_val, CrossProcessSem** res)
 {
   struct cross_process_sem_data_t *data = static_cast < cross_process_sem_data_t*> (
     mmap(NULL, sizeof(struct cross_process_sem_data_t),
-       PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, 0, 0));
+       PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0));
   if (data == MAP_FAILED) {
     int err = errno;
     return err;

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -92,7 +92,11 @@ start_rgw=0
 ip=""
 nodaemon=0
 smallmds=0
-short=0
+if [ `uname` = FreeBSD ] ; then
+  short=1
+else
+  short=0
+fi
 ec=0
 hitset=""
 overwrite_conf=1
@@ -629,7 +633,9 @@ EOF
 	    fi
 
 	    rm -rf $CEPH_DEV_DIR/osd$osd || true
-	    for f in $CEPH_DEV_DIR/osd$osd/*; do btrfs sub delete $f &> /dev/null || true; done
+	    if [ -f /usr/bin/btrfs ]; then 
+	        for f in $CEPH_DEV_DIR/osd$osd/*; do btrfs sub delete $f &> /dev/null || true; done
+	    fi
 	    mkdir -p $CEPH_DEV_DIR/osd$osd
 
 	    uuid=`uuidgen`


### PR DESCRIPTION
This requires Clang to be at least 3.7
It compiles all ceph code (expect the ones excluded in autogen_freebsd.sh)
It compiles all tests

Tests will run, but not all complete successfully,
  Currently the only one failing is osd-markup.sh

Other tests have been execluded from testing, see README.FreeBSD for that

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>