### PR TITLE
mon: fix typo of 'ceph auth rm'

### DIFF
--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -984,7 +984,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
 					      get_last_committed() + 1));
     return true;
-  } else if ((prefix == "auth del" || prefix == "auto rm") &&
+  } else if ((prefix == "auth del" || prefix == "auth rm") &&
              !entity_name.empty()) {
     KeyServerData::Incremental auth_inc;
     auth_inc.name = entity;


### PR DESCRIPTION
Signed-off-by: Na Xie <xie.na@h3c.com>