### PR TITLE
common: unknown hash type of judgment modification

### DIFF
--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -212,6 +212,7 @@ struct Inode {
     int which = dir_layout.dl_dir_hash;
     if (!which)
       which = CEPH_STR_HASH_LINUX;
+    assert(ceph_str_hash_valid(which));
     return ceph_str_hash(which, dn.data(), dn.length());
   }
 

--- a/src/common/ceph_hash.cc
+++ b/src/common/ceph_hash.cc
@@ -115,3 +115,14 @@ const char *ceph_str_hash_name(int type)
 		return "unknown";
 	}
 }
+
+bool ceph_str_hash_valid(int type)
+{
+        switch (type) {
+        case CEPH_STR_HASH_LINUX:
+        case CEPH_STR_HASH_RJENKINS:
+                return true;
+        default:
+                return false;
+        }
+}

--- a/src/include/ceph_hash.h
+++ b/src/include/ceph_hash.h
@@ -9,5 +9,6 @@ extern unsigned ceph_str_hash_rjenkins(const char *s, unsigned len);
 
 extern unsigned ceph_str_hash(int type, const char *s, unsigned len);
 extern const char *ceph_str_hash_name(int type);
+extern bool ceph_str_hash_valid(int type);
 
 #endif

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -493,6 +493,7 @@ __u32 InodeStoreBase::hash_dentry_name(const string &dn)
   int which = inode.dir_layout.dl_dir_hash;
   if (!which)
     which = CEPH_STR_HASH_LINUX;
+  assert(ceph_str_hash_valid(which));
   return ceph_str_hash(which, dn.data(), dn.length());
 }
 


### PR DESCRIPTION
ceph_str_hash() return -1 if set unknown hash type
but (unsiged)-1 = unsiged 4294967295 
So we can't judge whether the 4294967295 is the normal value of hash, or the return value of the unknown hash type
use assert replace

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>