### PR TITLE
rgw: update user stat before get it for Get User Info api

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -50,6 +50,14 @@ void RGWOp_User_Info::execute()
   op_state.set_user_id(uid);
   op_state.set_fetch_stats(fetch_stats);
 
+  if(fetch_stats) {
+    http_ret = rgw_user_sync_all_stats(store, uid);
+    if (http_ret < 0) {
+      ldout(store->ctx(), 0) << "ERROR: failed to sync user stats: " << dendl;
+      return ;
+    }
+  }
+
   http_ret = RGWUserAdminOp_User::info(store, op_state, flusher);
 }
 


### PR DESCRIPTION
update user stat before  we get it  to retrieve the latest quota stats for Get User Info api
Signed-off-by: weiqiaomiao <wei.qiaomiao@zte.com.cn>