### PR TITLE
mon: Forbidden copy and assignment function in monoprequest

### DIFF
--- a/src/mon/MonOpRequest.h
+++ b/src/mon/MonOpRequest.h
@@ -74,6 +74,9 @@ struct MonOpRequest : public TrackedOp {
     OP_TYPE_COMMAND,          ///< is a command
   };
 
+  MonOpRequest(const MonOpRequest &other) = delete;
+  MonOpRequest & operator = (const MonOpRequest &other) = delete;
+
 private:
   Message *request;
   utime_t dequeued_time;


### PR DESCRIPTION
mon: Forbidden copy and assignment function in monoprequest


Signed-off-by:song baisen song.baisen@zte.com.cn
