### PR TITLE
client:calculation pg use the correct method 

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11061,7 +11061,7 @@ int Client::ll_get_stripe_osd(Inode *in, uint64_t blockno,
       pg_t pg = (pg_t)olayout.ol_pgid;
       vector<int> osds;
       int primary;
-      o.pg_to_osds(pg, &osds, &primary);
+      o.pg_to_raw_up(pg, &osds, &primary);
       return osds[0];
     });
 }


### PR DESCRIPTION
client:calculation pg use the correct method 

If we want to know the real up primary pg for the osds .We should use the 

pg_to_raw_up method.If not I do not know why here use the  pg_to_osds method.

Thank you!

Signed-off-by:song baisen <song.baisen@zte.com.cn>