### PR TITLE
bluestore: make verify_csum can catch unsupported csum type error

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3398,12 +3398,16 @@ int BlueStore::_blob2read_to_extents2read(
 
 int BlueStore::_verify_csum(const bluestore_blob_t* blob, uint64_t blob_xoffset, const bufferlist& bl) const
 {
-  int bad = blob->verify_csum(blob_xoffset, bl);
-  if (bad >= 0) {
-    dout(20) << __func__ << " at blob offset 0x" << std::hex << bad << dendl;
+  int bad;
+  int r = blob->verify_csum(blob_xoffset, bl, bad);
+  if (r < 0) {
+    return r;
+  } else if (bad >= 0) {
+    dout(20) << __func__ << "bad checksum at blob offset 0x" << std::hex << bad << dendl;
     return -1;
+  } else {
+    return 0;
   }
-  return 0;
 }
 
 int BlueStore::_decompress(bufferlist& source, bufferlist* result)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3403,7 +3403,8 @@ int BlueStore::_verify_csum(const bluestore_blob_t* blob, uint64_t blob_xoffset,
   if (r < 0) {
     return r;
   } else if (bad >= 0) {
-    dout(20) << __func__ << "bad checksum at blob offset 0x" << std::hex << bad << dendl;
+    dout(20) << __func__ << "bad checksum at blob offset 0x"
+             << std::hex << bad << std::dec << dendl;
     return -1;
   } else {
     return 0;

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -668,20 +668,25 @@ void bluestore_blob_t::calc_csum(uint64_t b_off, const bufferlist& bl)
   }
 }
 
-int bluestore_blob_t::verify_csum(uint64_t b_off, const bufferlist& bl) const
+int bluestore_blob_t::verify_csum(uint64_t b_off, const bufferlist& bl,
+  int &b_bad_off) const
 {
+  b_bad_off = -1;
   switch (csum_type) {
   case CSUM_NONE:
-    return -1;
+    return 0;
   case CSUM_XXHASH32:
-    return Checksummer::verify<Checksummer::xxhash32>(
+    b_bad_off = Checksummer::verify<Checksummer::xxhash32>(
       get_csum_block_size(), b_off, bl.length(), bl, csum_data);
+    return 0;
   case CSUM_XXHASH64:
-    return Checksummer::verify<Checksummer::xxhash64>(
+    b_bad_off = Checksummer::verify<Checksummer::xxhash64>(
       get_csum_block_size(), b_off, bl.length(), bl, csum_data);
+    return 0;
   case CSUM_CRC32C:
-    return Checksummer::verify<Checksummer::crc32c>(
+    b_bad_off = Checksummer::verify<Checksummer::crc32c>(
       get_csum_block_size(), b_off, bl.length(), bl, csum_data);
+    return 0;
   default:
     return -EOPNOTSUPP;
   }

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -481,8 +481,9 @@ struct bluestore_blob_t {
   /// calculate csum for the buffer at the given b_off
   void calc_csum(uint64_t b_off, const bufferlist& bl);
 
-  /// verify csum: return offset of error, or -1 for no error.
-  int verify_csum(uint64_t b_off, const bufferlist& bl) const;
+  /// verify csum: return -EOPNOTSUPP for unsupported checksum type;
+  /// return 0 and valid(nonnegative) b_bad_off for checksum error.
+  int verify_csum(uint64_t b_off, const bufferlist& bl, int &b_bad_off) const;
 
 };
 WRITE_CLASS_ENCODER(bluestore_blob_t)


### PR DESCRIPTION
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>