### PR TITLE
unittest_workqueue: fix wq test for 0 threads

### DIFF
--- a/src/test/test_workqueue.cc
+++ b/src/test/test_workqueue.cc
@@ -38,12 +38,12 @@ TEST(WorkQueue, Resize)
   sleep(1);
   ASSERT_EQ(3, tp.get_num_threads());
 
-  g_conf->set_val("osd op threads", "15");
+  g_conf->set_val("osd op threads", "0");
   g_conf->apply_changes(&cout);
   sleep(1);
-  ASSERT_EQ(15, tp.get_num_threads());
+  ASSERT_EQ(0, tp.get_num_threads());
 
-  g_conf->set_val("osd op threads", "0");
+  g_conf->set_val("osd op threads", "15");
   g_conf->apply_changes(&cout);
   sleep(1);
   ASSERT_EQ(15, tp.get_num_threads());


### PR DESCRIPTION
In 81517aea0696e4e62c2eb0830d7b0bd378c57230 we added
support for a wq with 0 worker threads.  Fix unit test
accordingly.

Signed-off-by: Sage Weil <sage@redhat.com>