### PR TITLE
os/bluestore: make verify_csum catch unsupported csum type error

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3398,12 +3398,19 @@ int BlueStore::_blob2read_to_extents2read(
 
 int BlueStore::_verify_csum(const bluestore_blob_t* blob, uint64_t blob_xoffset, const bufferlist& bl) const
 {
-  int bad = blob->verify_csum(blob_xoffset, bl);
-  if (bad >= 0) {
-    dout(20) << __func__ << " at blob offset 0x" << std::hex << bad << dendl;
-    return -1;
+  int bad;
+  int r = blob->verify_csum(blob_xoffset, bl, &bad);
+  if (r < 0) {
+    if (r == -1) {
+      dout(20) << __func__ << "bad checksum at blob offset 0x"
+               << std::hex << bad << dendl;
+    } else {
+      derr << __func__ << "failed with exit code: " << cpp_strerror(r) << dendl;
+    }
+    return r;
+  } else {
+    return 0;
   }
-  return 0;
 }
 
 int BlueStore::_decompress(bufferlist& source, bufferlist* result)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3403,7 +3403,7 @@ int BlueStore::_verify_csum(const bluestore_blob_t* blob, uint64_t blob_xoffset,
   if (r < 0) {
     if (r == -1) {
       dout(20) << __func__ << "bad checksum at blob offset 0x"
-               << std::hex << bad << dendl;
+               << std::hex << bad << std::dec << dendl;
     } else {
       derr << __func__ << "failed with exit code: " << cpp_strerror(r) << dendl;
     }

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -481,8 +481,10 @@ struct bluestore_blob_t {
   /// calculate csum for the buffer at the given b_off
   void calc_csum(uint64_t b_off, const bufferlist& bl);
 
-  /// verify csum: return offset of error, or -1 for no error.
-  int verify_csum(uint64_t b_off, const bufferlist& bl) const;
+  /// verify csum: return -EOPNOTSUPP for unsupported checksum type;
+  /// return -1 and valid(nonnegative) b_bad_off for checksum error;
+  /// return 0 if all is well.
+  int verify_csum(uint64_t b_off, const bufferlist& bl, int* b_bad_off) const;
 
 };
 WRITE_CLASS_ENCODER(bluestore_blob_t)

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -515,31 +515,48 @@ TEST(bluestore_blob_t, calc_csum)
 	 << std::endl;
 
     bluestore_blob_t b;
-    ASSERT_EQ(-1, b.verify_csum(0, bl));
+    int bad_off;
+    ASSERT_EQ(0, b.verify_csum(0, bl, &bad_off));
+    ASSERT_EQ(-1, bad_off);
 
     b.init_csum(csum_type, 3, 24);
     cout << "  value size " << b.get_csum_value_size() << std::endl;
     b.calc_csum(0, bl);
-    ASSERT_EQ(-1, b.verify_csum(0, bl));
-    ASSERT_EQ(0, b.verify_csum(0, bl2));
+    ASSERT_EQ(0, b.verify_csum(0, bl, &bad_off));
+    ASSERT_EQ(-1, bad_off);
+    ASSERT_EQ(-1, b.verify_csum(0, bl2, &bad_off));
+    ASSERT_EQ(0, bad_off);
 
-    ASSERT_EQ(-1, b.verify_csum(0, f));
-    ASSERT_EQ(8, b.verify_csum(8, f));
-    ASSERT_EQ(16, b.verify_csum(16, f));
+    ASSERT_EQ(0, b.verify_csum(0, f, &bad_off));
+    ASSERT_EQ(-1, bad_off);
+    ASSERT_EQ(-1, b.verify_csum(8, f, &bad_off));
+    ASSERT_EQ(8, bad_off);
+    ASSERT_EQ(-1, b.verify_csum(16, f, &bad_off));
+    ASSERT_EQ(16, bad_off);
 
-    ASSERT_EQ(0, b.verify_csum(0, m));
-    ASSERT_EQ(-1, b.verify_csum(8, m));
-    ASSERT_EQ(16, b.verify_csum(16, m));
+    ASSERT_EQ(-1, b.verify_csum(0, m, &bad_off));
+    ASSERT_EQ(0, bad_off);
+    ASSERT_EQ(0, b.verify_csum(8, m, &bad_off));
+    ASSERT_EQ(-1, bad_off);
+    ASSERT_EQ(-1, b.verify_csum(16, m, &bad_off));
+    ASSERT_EQ(16, bad_off);
 
-    ASSERT_EQ(0, b.verify_csum(0, e));
-    ASSERT_EQ(8, b.verify_csum(8, e));
-    ASSERT_EQ(-1, b.verify_csum(16, e));
+    ASSERT_EQ(-1, b.verify_csum(0, e, &bad_off));
+    ASSERT_EQ(0, bad_off);
+    ASSERT_EQ(-1, b.verify_csum(8, e, &bad_off));
+    ASSERT_EQ(8, bad_off);
+    ASSERT_EQ(0, b.verify_csum(16, e, &bad_off));
+    ASSERT_EQ(-1, bad_off);
 
     b.calc_csum(8, n);
-    ASSERT_EQ(-1, b.verify_csum(0, f));
-    ASSERT_EQ(-1, b.verify_csum(8, n));
-    ASSERT_EQ(-1, b.verify_csum(16, e));
-    ASSERT_EQ(8, b.verify_csum(0, bl));
+    ASSERT_EQ(0, b.verify_csum(0, f, &bad_off));
+    ASSERT_EQ(-1, bad_off);
+    ASSERT_EQ(0, b.verify_csum(8, n, &bad_off));
+    ASSERT_EQ(-1, bad_off);
+    ASSERT_EQ(0, b.verify_csum(16, e, &bad_off));
+    ASSERT_EQ(-1, bad_off);
+    ASSERT_EQ(-1, b.verify_csum(0, bl, &bad_off));
+    ASSERT_EQ(8, bad_off);
   }
 }
 


### PR DESCRIPTION
And update related unit-testing cases.