### PR TITLE
os/bluestore: make rocksdb not to use page cache

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -842,7 +842,8 @@ OPTION(kinetic_use_ssl, OPT_BOOL, false) // whether to secure kinetic traffic wi
 OPTION(rocksdb_separate_wal_dir, OPT_BOOL, false) // use $path.wal for wal
 OPTION(rocksdb_db_paths, OPT_STR, "")   // path,size( path,size)*
 OPTION(rocksdb_log_to_ceph_log, OPT_BOOL, true)  // log to ceph log
-OPTION(rocksdb_cache_size, OPT_INT, 128*1024*1024)  // default leveldb cache size
+OPTION(rocksdb_cache_size, OPT_INT, 128*1024*1024)  // default rocksdb cache size
+OPTION(rocksdb_cache_shard_bits, OPT_INT, 4)  // rocksdb block cache shard bits, 4 bit -> 16 shards
 OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR, "")

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -279,13 +279,14 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
     opt.env = static_cast<rocksdb::Env*>(priv);
   }
 
-  auto cache = rocksdb::NewLRUCache(g_conf->rocksdb_cache_size);
+  auto cache = rocksdb::NewLRUCache(g_conf->rocksdb_cache_size, g_conf->rocksdb_cache_shard_bits);
   rocksdb::BlockBasedTableOptions bbt_opts;
   bbt_opts.block_size = g_conf->rocksdb_block_size;
   bbt_opts.block_cache = cache;
   opt.table_factory.reset(rocksdb::NewBlockBasedTableFactory(bbt_opts));
   dout(10) << __func__ << " set block size to " << g_conf->rocksdb_block_size
-           << " cache size to " << g_conf->rocksdb_cache_size << dendl;
+           << " cache size to " << g_conf->rocksdb_cache_size
+           << " num of cache shards to " << (1 << g_conf->rocksdb_cache_shard_bits) << dendl;
 
   opt.merge_operator.reset(new MergeOperatorRouter(*this));
   status = rocksdb::DB::Open(opt, path, &db);

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -93,7 +93,8 @@ public:
 
   virtual int read(uint64_t off, uint64_t len, bufferlist *pbl,
 	   IOContext *ioc, bool buffered) = 0;
-  virtual int read_buffered(uint64_t off, uint64_t len, char *buf) = 0;
+  virtual int read_random(uint64_t off, uint64_t len, char *buf,
+           bool buffered) = 0;
 
   virtual int aio_write(uint64_t off, bufferlist& bl,
 		IOContext *ioc, bool buffered) = 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -738,7 +738,7 @@ int BlueFS::_read_random(
     }
     dout(20) << __func__ << " read buffered " << x_off << "~" << l << " of "
 	       << *p << dendl;
-    int r = bdev[p->bdev]->read_random(p->offset + x_off, l, out, true);
+    int r = bdev[p->bdev]->read_random(p->offset + x_off, l, out, false);
     assert(r == 0);
     off += l;
     len -= l;
@@ -797,7 +797,7 @@ int BlueFS::_read(
       dout(20) << __func__ << " fetching " << x_off << "~" << l << " of "
 	       << *p << dendl;
       int r = bdev[p->bdev]->read(p->offset + x_off, l, &buf->bl, ioc[p->bdev],
-				  true);
+				  false);
       assert(r == 0);
     }
     left = buf->get_buf_remaining(off);
@@ -1121,7 +1121,7 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
       h->tail_block.substr_of(bl, bl.length() - tail, tail);
       t.append_zero(super.block_size - tail);
     }
-    bdev[p->bdev]->aio_write(p->offset + x_off, t, h->iocv[p->bdev], true);
+    bdev[p->bdev]->aio_write(p->offset + x_off, t, h->iocv[p->bdev], false);
     bloff += x_len;
     length -= x_len;
     ++p;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -738,7 +738,7 @@ int BlueFS::_read_random(
     }
     dout(20) << __func__ << " read buffered " << x_off << "~" << l << " of "
 	       << *p << dendl;
-    int r = bdev[p->bdev]->read_buffered(p->offset + x_off, l, out);
+    int r = bdev[p->bdev]->read_random(p->offset + x_off, l, out, true);
     assert(r == 0);
     off += l;
     len -= l;

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -62,6 +62,8 @@ class KernelDevice : public BlockDevice {
 
   int _lock();
 
+  int direct_read_unaligned(uint64_t off, uint64_t len, char *buf);
+
 public:
   KernelDevice(aio_callback_t cb, void *cbpriv);
 
@@ -77,7 +79,7 @@ public:
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
 	   IOContext *ioc,
 	   bool buffered) override;
-  int read_buffered(uint64_t off, uint64_t len, char *buf) override;
+  int read_random(uint64_t off, uint64_t len, char *buf, bool buffered) override;
 
   int aio_write(uint64_t off, bufferlist& bl,
 		IOContext *ioc,

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -938,7 +938,7 @@ int NVMEDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   return r;
 }
 
-int NVMEDevice::read_buffered(uint64_t off, uint64_t len, char *buf)
+int NVMEDevice::read_random(uint64_t off, uint64_t len, char *buf, bool buffered)
 {
   assert(len > 0);
   assert(off < size);

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -228,7 +228,7 @@ class NVMEDevice : public BlockDevice {
                 IOContext *ioc,
                 bool buffered) override;
   int flush() override;
-  int read_buffered(uint64_t off, uint64_t len, char *buf) override;
+  int read_random(uint64_t off, uint64_t len, char *buf, bool buffered) override;
 
   // for managing buffered readers/writers
   int invalidate_cache(uint64_t off, uint64_t len) override;


### PR DESCRIPTION
This is second try. Previous PR crashed, because rocksdb does random unaligned read.
I rewrote read_buffered function to read_random, which uses an internal aligned buffer to perform direct read when needed.
Will use a worse case scenario(bluestore_block_buffered_read = false) to test if rocksdb with block cache can perform as with page cache.