### PR TITLE
os/bluestore: benchmark Host Aware SMR Drives for linear writes

### DIFF
--- a/src/script/smr_benchmark/linearCopy.sh
+++ b/src/script/smr_benchmark/linearCopy.sh
@@ -1,0 +1,91 @@
+#! /bin/bash
+
+# copy a linear file from srcFile to destination disk in a loop until writeSize MBs is written
+# destinationDisk is a SMR Host Aware Disk eg. /dev/sdb
+
+if [ "$#" -lt 3 ]; then
+	echo "Usage ./linearCopy.sh srcFile destinationDisk writeSize(MB)"
+	exit
+fi
+
+if [ "$(id -u)" != "0" ]; then
+	echo "Please run as sudo user"
+	exit
+fi
+
+srcFile=$1
+destDisk=$2
+writeSize=$3
+verbose=true
+
+if [ -f time ]; then
+	rm -rf time
+fi
+
+#chunkSize=4096 # in bytes
+chunkSize=1048576 # in bytes
+fileSize=`stat --printf="%s" $srcFile`
+
+numChunksInFile=`echo "$fileSize * (1048576 / $chunkSize)" | bc`
+chunksLeft=$(( $(($writeSize * 1048576)) / $chunkSize))
+
+
+echo "fileSize = $fileSize"
+
+if [ "$(($fileSize % 512))" -ne 0 ]; then
+	echo "$srcFile not 512 byte aligned"
+	exit
+fi
+
+if [ "$(($chunkSize % 512))" -ne 0 ]; then
+	echo "$chunkSize not 512 byte aligned"
+	exit
+fi
+
+if [ "$fileSize" -lt "$chunkSize" ]; then
+	echo "filesize $fileSize should be greater than chunkSize $chunkSize"
+	exit
+fi
+
+
+numFileChunks=$(($fileSize / $chunkSize))
+if [ $verbose == true ]; then
+	echo "numFileChunks = $numFileChunks"
+fi
+
+smrLBAStart=33554432 # TODO query from SMR Drive
+#smrLBAStart=37224448
+
+offset=$(( $smrLBAStart / $(( $chunkSize / 512)) ))
+
+if [ $verbose == true ]; then
+	echo "chunksLeft = $chunksLeft, offset = $offset"
+fi
+
+chunkNum=0
+
+while [ "$chunksLeft" -gt 0 ]; do
+	chunkNum=$(($chunkNum + 1))
+	if [ $verbose == true ]; then
+		echo "CHUNK $chunkNum `date +%H:%M:%S`" >> time
+	fi
+	dd if=$srcFile of=$destDisk seek=$offset bs=$chunkSize 2> tmp 
+	cat tmp | grep MB >> time # > /dev/null 2>&1
+	if [ $verbose == true ]; then
+		echo "chunksLeft = $chunksLeft, offset = $offset"
+	fi
+	chunksLeft=$(($chunksLeft - $numFileChunks))
+	offset=$(($offset + $numFileChunks))
+done
+
+if [ -f tmp ]; then
+	rm tmp
+fi
+
+if [ $verbose == false ]; then
+	rm time
+else
+	echo "Time Stamp for Chunk Writes"
+	cat time
+	rm time
+fi

--- a/src/script/smr_benchmark/linearSMRCopy.sh
+++ b/src/script/smr_benchmark/linearSMRCopy.sh
@@ -1,0 +1,69 @@
+#! /bin/bash
+
+# copy a linear file from srcFile to destination SMRDisk in a loop until writeSize MBs is written
+# SMRDisk is the SMR Host Aware / Host Managed Disk eg. /dev/sdb
+
+usage(){
+	echo "linearSMRCopy.sh <srcFile> <SMRDisk> <writeSize (MB)>"
+}
+
+if [ "$#" -lt 3 ]; then
+	usage
+	exit
+fi
+
+if [ "$(id -u)" != "0" ]; then
+	echo "Please run as sudo user"
+	exit
+fi
+
+if which zbc_open_zone > /dev/null 2>&1 && which zbc_read_zone > /dev/null 2>&1 && which zbc_write_zone > /dev/null 2>&1 ; then
+	echo "libzbc commands present... refreshing zones"
+	# reset all write pointers before starting to write
+	sudo zbc_reset_write_ptr /dev/sdb -1
+else
+	echo "libzbc commands not detected. Please install libzbc"
+	exit
+fi
+
+srcFile=$1
+SMRDisk=$2
+writeSize=$3
+iosize=10240
+
+numberOfSectors=$(($writeSize * 2048))
+
+smrZoneStart=33554432 # TODO query this from SMR drive
+
+#dd if=$srcFile of=$destDisk seek=$smrZoneStart bs=512
+
+fileSize=`stat --printf="%s" $srcFile`
+
+if [ "$(($fileSize % 512))" -ne 0 ]; then
+	echo "$srcFile not 512 byte aligned"
+	exit
+fi
+
+sectorsLeftToWrite=$(($fileSize / 512))
+
+znum=64 # TODO query this from SMR Drive
+
+zoneLength=524288 # number of sectors in each zone TODO query from SMR drive
+
+writeOffset=$smrZoneStart
+
+sectorsLeftToWrite=$numberOfSectors
+
+echo "write begin sectors Left = $sectorsLeftToWrite, writeOffset = $writeOffset zone Num = $znum"
+
+while [ "$sectorsLeftToWrite" -gt 0 ]; 
+do
+	sudo zbc_open_zone $SMRDisk $znum 
+        sudo time zbc_write_zone -f $srcFile -loop $SMRDisk $znum $iosize
+	sudo zbc_close_zone /dev/sdb $znum
+	writeOffset=$(($writeOffset+$zoneLength))
+	znum=$(($znum+1))
+	sectorsLeftToWrite=$(($sectorsLeftToWrite - $zoneLength))
+done
+
+echo "write end sectors Left = $sectorsLeftToWrite, writeOffset = $writeOffset zone Num = $znum"


### PR DESCRIPTION
* add script to write files linearly using dd command
* add script to write files linearly using SMR zone aware commands

Script needs libzbc support. Check is provided so that script does
not run if libzbc commands are not installed.

Fixes: http://tracker.ceph.com/issues/16174
Signed-off-by: Shehbaz Jaffer <shehbazjaffer007@gmail.com>