### PR TITLE
librbd: object_may_exist always return true when you write an empty o…

### DIFF
--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -538,7 +538,7 @@ namespace librbd {
     RWLock::RLocker snap_locker(m_ictx->snap_lock);
     if (m_ictx->enable_alloc_hint &&
         (m_ictx->object_map == nullptr ||
-         !m_ictx->object_map->object_may_exist(m_object_no))) {
+         !m_object_exist)) {
       wr->set_alloc_hint(m_ictx->get_object_size(), m_ictx->get_object_size());
     }
 


### PR DESCRIPTION
…bject

if you write an empty object, object map is updated firstly

Signed-off-by: xinxin shu <shuxinxin@chinac.com>