### PR TITLE
client: fix sanity check of preadv/pwritev

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7903,7 +7903,7 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
 int Client::preadv(int fd, const struct iovec *iov, int iovcnt, loff_t offset)
 {
   if (iovcnt < 0)
-    return EINVAL;
+    return -EINVAL;
   return _preadv_pwritev(fd, iov, iovcnt, offset, false);
 }
 
@@ -8244,7 +8244,7 @@ int Client::write(int fd, const char *buf, loff_t size, loff_t offset)
 int Client::pwritev(int fd, const struct iovec *iov, int iovcnt, int64_t offset)
 {
   if (iovcnt < 0)
-    return EINVAL;
+    return -EINVAL;
   return _preadv_pwritev(fd, iov, iovcnt, offset, true);
 }
 


### PR DESCRIPTION
The preadv/pwritev call is only supposed to return a postive
number indicating how many bytes we succeed in reading from
or writing into disk, which is obviously not what we want
under the following cases.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>