### PR TITLE
os/bluestore: Unaligned device length and Correct alloc size fix for BitMap allocator

### DIFF
--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -8,12 +8,13 @@
 
 #define dout_subsys ceph_subsys_bluestore
 
-Allocator *Allocator::create(string type, int64_t size)
+Allocator *Allocator::create(string type,
+                             int64_t size, int64_t block_size)
 {
   if (type == "stupid") {
     return new StupidAllocator;
   } else if (type == "bitmap") {
-    return new BitMapAllocator(size);
+    return new BitMapAllocator(size, block_size);
   }
   derr << "Allocator::" << __func__ << " unknown alloc type " << type << dendl;
   return NULL;

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -43,7 +43,7 @@ public:
   virtual uint64_t get_free() = 0;
 
   virtual void shutdown() = 0;
-  static Allocator *create(string type, int64_t size);
+  static Allocator *create(string type, int64_t size, int64_t block_size);
 };
 
 #endif

--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <atomic>
 #include <vector>
+#include "include/intarith.h"
 
 class BitAllocatorStats {
 public:

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -19,11 +19,10 @@
 #define dout_prefix *_dout << "bitmapalloc:"
 
 
-BitMapAllocator::BitMapAllocator(int64_t device_size)
+BitMapAllocator::BitMapAllocator(int64_t device_size, int64_t block_size)
   : m_num_uncommitted(0),
     m_num_committing(0)
 {
-  int64_t block_size = g_conf->bdev_block_size;
   int64_t zone_size_blks = 1024; // Change it later
 
   m_block_size = block_size;

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -18,7 +18,6 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "bitmapalloc:"
 
-#define NEXT_MULTIPLE(x, m) (!(x) ? 0: (((((x) - 1) / (m)) + 1)  * (m)))
 
 BitMapAllocator::BitMapAllocator(int64_t device_size)
   : m_num_uncommitted(0),
@@ -161,16 +160,8 @@ void BitMapAllocator::init_add_free(uint64_t offset, uint64_t length)
   dout(10) << __func__ <<" instance "<< (uint64_t) this <<
     " offset " << offset << " length " << length << dendl;
 
-  offset = NEXT_MULTIPLE(offset, m_block_size);
-
-  // bitallocator::init may decrease the size of blkdev.
-  uint64_t total_size = m_bit_alloc->size() * m_block_size;
-  if (offset + length > total_size) {
-    assert(offset + length < total_size + m_bit_alloc->get_truncated_blocks() * m_block_size);
-    length -= (offset + length) - total_size;
-  }
-
-  insert_free(offset, (length / m_block_size) * m_block_size);
+  insert_free(ROUND_UP_TO(offset, m_block_size),
+      (length / m_block_size) * m_block_size);
 }
 
 void BitMapAllocator::init_rm_free(uint64_t offset, uint64_t length)

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -26,7 +26,7 @@ class BitMapAllocator : public Allocator {
 
 public:
   BitMapAllocator();
-  BitMapAllocator(int64_t device_size);
+  BitMapAllocator(int64_t device_size, int64_t block_size);
   ~BitMapAllocator();
 
   int reserve(uint64_t need);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -286,7 +286,9 @@ void BlueFS::_init_alloc()
       continue;
     }
     assert(bdev[id]->get_size());
-    alloc[id] = Allocator::create(g_conf->bluestore_allocator, bdev[id]->get_size());
+    alloc[id] = Allocator::create(g_conf->bluestore_allocator,
+                                  bdev[id]->get_size(),
+                                  g_conf->bluefs_alloc_size);
     interval_set<uint64_t>& p = block_all[id];
     for (interval_set<uint64_t>::iterator q = p.begin(); q != p.end(); ++q) {
       alloc[id]->init_add_free(q.get_start(), q.get_len());

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1416,7 +1416,9 @@ int BlueStore::_open_alloc()
 {
   assert(alloc == NULL);
   assert(bdev->get_size());
-  alloc = Allocator::create(g_conf->bluestore_allocator, bdev->get_size());
+  alloc = Allocator::create(g_conf->bluestore_allocator,
+                            bdev->get_size(),
+                            min_alloc_size);
   uint64_t num = 0, bytes = 0;
   fm->enumerate_reset();
   uint64_t offset, length;

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -408,6 +408,22 @@ TEST(BitAllocator, test_bmap_alloc)
   alloc->free_blocks(0, alloc->size());
   delete alloc;
 
+  // unaligned zones
+  total_blocks = 1024 * 2 + 11;
+  alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT);
+
+  for (int64_t iter = 0; iter < 4; iter++) {
+    for (int64_t i = 0; i < total_blocks; i++) {
+      allocated = alloc->alloc_blocks(1, &start_block);
+      bmap_test_assert(allocated == 1);
+      bmap_test_assert(start_block == i);
+    }
+
+    for (int64_t i = 0; i < total_blocks; i++) {
+      alloc->free_blocks(i, 1);
+    }
+  }
+
   // Make three > 3 levels tree and check allocations and dealloc
   // in a loop
   int64_t alloc_size = 16;


### PR DESCRIPTION
These two changes are:
1. Take care of situation when total blocks are not aligned to zone boundary.
    a. Pad extra blocks and mark them used.
    b. add unit test cases for the same.
2. Set correct min alloc size as a unit for BitMapAllocator allocation unit.  That is 1M for BlueFS and 4k or 64k for ssd and hdd.

It passes unit + ceph_test_objectstore