### PR TITLE
jewel backport: mds: fix mdsmap print_summary with standby replays

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -151,7 +151,8 @@ void FSMap::print_summary(Formatter *f, ostream *out)
 
     const fs_cluster_id_t fscid = mds_roles.at(info.global_id);
 
-    if (info.rank != MDS_RANK_NONE) {
+    if (info.rank != MDS_RANK_NONE &&
+        info.state != MDSMap::STATE_STANDBY_REPLAY) {
       if (f) {
         f->open_object_section("mds");
         f->dump_unsigned("filesystem_id", fscid);

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -263,7 +263,7 @@ void MDSMap::print_summary(Formatter *f, ostream *out) const
     if (p.second.laggy())
       s += "(laggy or crashed)";
 
-    if (p.second.rank >= 0) {
+    if (p.second.rank >= 0 && p.second.state != MDSMap::STATE_STANDBY_REPLAY) {
       if (f) {
 	f->open_object_section("mds");
 	f->dump_unsigned("rank", p.second.rank);


### PR DESCRIPTION
http://tracker.ceph.com/issues/15968