### PR TITLE
cls_rbd: mirror image status summary should read full directory

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -3383,10 +3383,7 @@ int image_status_get_summary(cls_method_context_t hctx,
       }
 
       cls::rbd::MirrorImageStatus status;
-      r = image_status_get(hctx, mirror_image.global_image_id, &status);
-      if (r < 0) {
-	// Ignore.
-      }
+      image_status_get(hctx, mirror_image.global_image_id, &status);
 
       cls::rbd::MirrorImageStatusState state = status.up ? status.state :
 	cls::rbd::MIRROR_IMAGE_STATUS_STATE_UNKNOWN;


### PR DESCRIPTION
Previously only retrieved the status for the first 64 images in
the rbd_mirroring directory.

Fixes: http://tracker.ceph.com/issues/16178
Signed-off-by: Jason Dillaman <dillaman@redhat.com>