### PR TITLE
jewel: librbd: validate image metadata configuration overrides

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2733,6 +2733,15 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
   int metadata_set(ImageCtx *ictx, const string &key, const string &value)
   {
     CephContext *cct = ictx->cct;
+    string start = ictx->METADATA_CONF_PREFIX;
+    size_t conf_prefix_len = start.size();
+
+    if(key.size() > conf_prefix_len && !key.compare(0,conf_prefix_len,start)) {
+      string subkey = key.substr(conf_prefix_len, key.size()-conf_prefix_len);
+      int r = cct->_conf->set_val(subkey.c_str(), value);
+      if (r < 0)
+        return r;
+    }
     ldout(cct, 20) << "metadata_set " << ictx << " key=" << key << " value=" << value << dendl;
 
     int r = ictx->state->refresh_if_required();


### PR DESCRIPTION
http://tracker.ceph.com/issues/16084