### PR TITLE
kv: explicitly set DISABLE_JEMALLOC for rocksdb in Makefile.am.

### DIFF
--- a/src/kv/Makefile.am
+++ b/src/kv/Makefile.am
@@ -25,8 +25,15 @@ else
 NPROC = nproc
 endif
 
+# explicitly disable jemalloc unless we are using it.
+if WITH_JEMALLOC
+DISABLE_JEMALLOC = 0
+else
+DISABLE_JEMALLOC = 1
+endif
+
 rocksdb/librocksdb.a:
-	cd rocksdb && CC="${CC}" CXX="${CXX}" EXTRA_CXXFLAGS="${ROCKSDBCXX_FLAGS}" PORTABLE=1 ${MAKE} -j$(shell ${NPROC}) static_lib
+	cd rocksdb && CC="${CC}" CXX="${CXX}" EXTRA_CXXFLAGS="${ROCKSDBCXX_FLAGS}" PORTABLE=1 DISABLE_JEMALLOC="${DISABLE_JEMALLOC}" ${MAKE} -j$(shell ${NPROC}) static_lib
 libkv_a_CXXFLAGS += -I rocksdb/include -fPIC
 libkv_a_SOURCES += kv/RocksDBStore.cc
 libkv_a_LIBADD += rocksdb/librocksdb.a


### PR DESCRIPTION
Upstream RocksDB changed the way they detect jemalloc which breaks our build:

https://github.com/ceph/rocksdb/commit/0850bc514737a64dc8ca13de8510fcad4756616a

We can explicitly set DISABLE_JEMALLOC depending on whether we are using jemalloc via the existing AM_CONDITIONAL value in configure.ac.  I was able to successfully build master with PR #9466 using tcmalloc or jemalloc on my test cluster after this change.

Signed-off-by: Mark Nelson <mnelson@redhat.com>