### PR TITLE
jewel: Missing export for rados_aio_get_version in src/include/rados/librados.h

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1819,6 +1819,22 @@ CEPH_RADOS_API int rados_aio_is_safe_and_cb(rados_completion_t c);
 CEPH_RADOS_API int rados_aio_get_return_value(rados_completion_t c);
 
 /**
+ * Get the internal object version of the target of an asychronous operation
+ *
+ * The return value is set when the operation is complete or safe,
+ * whichever comes first.
+ *
+ * @pre The operation is safe or complete
+ *
+ * @note BUG: complete callback may never be called when the safe
+ * message is received before the complete message
+ *
+ * @param c async operation to inspect
+ * @returns version number of the asychronous operation's target
+ */
+CEPH_RADOS_API uint64_t rados_aio_get_version(rados_completion_t c);
+
+/**
  * Release a completion
  *
  * Call this when you no longer need the completion. It may not be


### PR DESCRIPTION
http://tracker.ceph.com/issues/16153