### PR TITLE
client: fix potential access violation

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8273,6 +8273,9 @@ int Client::_preadv_pwritev(int fd, const struct iovec *iov, unsigned iovcnt, in
         bufferlist bl;
         int r = _read(fh, offset, totallen, &bl);
         ldout(cct, 3) << "preadv(" << fd << ", " <<  offset << ") = " << r << dendl;
+        if (r <= 0)
+          return r;
+
         int bufoff = 0;
         for (unsigned j = 0, resid = r; j < iovcnt && resid > 0; j++) {
                /*


### PR DESCRIPTION
The _read() call may fail and return a negative result,
and thus when it is passed to "resid", which is of type of
"unsigned", overflow happens due to a forced cast that is
implicitly performed.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>