### PR TITLE
rgw/basic_type: use the standard usage of string::npos

### DIFF
--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -52,8 +52,8 @@ struct rgw_user {
   }
 
   void from_str(const std::string& str) {
-    ssize_t pos = str.find('$');
-    if (pos >= 0) {
+    size_t pos = str.find('$');
+    if (pos != std::string::npos) {
       tenant = str.substr(0, pos);
       id = str.substr(pos + 1);
     } else {


### PR DESCRIPTION
string::find() returns a value of size_t type, we'd better
use the std::string::npos when it find nothing.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>