### PR TITLE
cls_rbd: encode entity_addr_t with features

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -3219,7 +3219,7 @@ int image_status_set(cls_method_context_t hctx, const string &global_image_id,
   assert(r == 0);
 
   bufferlist bl;
-  encode(ondisk_status, bl);
+  encode(ondisk_status, bl, cls_get_features(hctx));
 
   r = cls_cxx_map_set_val(hctx, status_global_key(global_image_id), &bl);
   if (r < 0) {


### PR DESCRIPTION
mirror_image_status_get method call currently fails with EIO

Signed-off-by: Jason Dillaman <dillaman@redhat.com>