### PR TITLE
osdc/ObjectCacher.h: move classes to cc file

### DIFF
--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -592,38 +592,8 @@ class ObjectCacher {
     }
   };
 
-  class C_WriteCommit : public Context {
-    ObjectCacher *oc;
-    int64_t poolid;
-    sobject_t oid;
-    vector<pair<loff_t, uint64_t> > ranges;
-  public:
-    ceph_tid_t tid;
-    C_WriteCommit(ObjectCacher *c, int64_t _poolid, sobject_t o, loff_t s,
-		  uint64_t l) :
-      oc(c), poolid(_poolid), oid(o), tid(0) {
-	ranges.push_back(make_pair(s, l));
-      }
-    C_WriteCommit(ObjectCacher *c, int64_t _poolid, sobject_t o,
-		  vector<pair<loff_t, uint64_t> >& _ranges) :
-      oc(c), poolid(_poolid), oid(o), tid(0) {
-	ranges.swap(_ranges);
-      }
-    void finish(int r) {
-      oc->bh_write_commit(poolid, oid, ranges, tid, r);
-    }
- };
-
-  class C_WaitForWrite : public Context {
-  public:
-    C_WaitForWrite(ObjectCacher *oc, uint64_t len, Context *onfinish) :
-      m_oc(oc), m_len(len), m_onfinish(onfinish) {}
-    void finish(int r);
-  private:
-    ObjectCacher *m_oc;
-    uint64_t m_len;
-    Context *m_onfinish;
-  };
+  class C_WriteCommit;
+  class C_WaitForWrite;
 
   void perf_start();
   void perf_stop();


### PR DESCRIPTION
Move C_WriteCommit and C_WaitForWrite to cc file.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>