### PR TITLE
os/bluestore: add an option to limit max allocation size

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -957,6 +957,7 @@ OPTION(bluestore_max_csum_block, OPT_U32, 64*1024)
 OPTION(bluestore_min_alloc_size, OPT_U32, 0)
 OPTION(bluestore_min_alloc_size_hdd, OPT_U32, 64*1024)
 OPTION(bluestore_min_alloc_size_ssd, OPT_U32, 4*1024)
+OPTION(bluestore_max_alloc_size, OPT_U32, 0)
 OPTION(bluestore_compression, OPT_STR, "none")  // force|aggressive|passive|none
 OPTION(bluestore_compression_algorithm, OPT_STR, "snappy")
 OPTION(bluestore_compression_min_blob_size, OPT_U32, 256*1024)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1008,6 +1008,7 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
     logger(NULL),
     csum_type(bluestore_blob_t::CSUM_CRC32C),
     min_alloc_size(0),
+    max_alloc_size(0),
     sync_wal_apply(cct->_conf->bluestore_sync_wal_apply)
 {
   _init_logger();
@@ -1273,8 +1274,9 @@ int BlueStore::_check_or_set_bdev_label(
   return 0;
 }
 
-void BlueStore::_set_min_alloc(void)
+void BlueStore::_set_alloc_sizes(void)
 {
+  max_alloc_size = g_conf->bluestore_max_alloc_size;
   /*
    * Set device block size according to its media
    */
@@ -1290,6 +1292,7 @@ void BlueStore::_set_min_alloc(void)
   }
 
   dout(10) << __func__ << " min_alloc_size 0x" << std::hex << min_alloc_size
+	   << " max_alloc_size 0x" << max_alloc_size
 	   << std::dec << dendl;
 }
 
@@ -1317,7 +1320,8 @@ int BlueStore::_open_bdev(bool create)
     ++block_size_order;
   }
 
-  _set_min_alloc();
+  _set_alloc_sizes();
+  max_alloc_size = g_conf->bluestore_max_alloc_size;
   return 0;
 
  fail_close:
@@ -5927,7 +5931,8 @@ int BlueStore::_do_alloc_write(
     while (final_length > 0) {
       bluestore_pextent_t e;
       uint32_t l;
-      int r = alloc->allocate(final_length, min_alloc_size, hint,
+      uint64_t want = max_alloc_size ? MIN(final_length, max_alloc_size) : final_length;
+      int r = alloc->allocate(want, min_alloc_size, hint,
 			      &e.offset, &l);
       assert(r == 0);
       need -= l;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -908,6 +908,8 @@ private:
 
   uint64_t min_alloc_size; ///< minimum allocation unit (power of 2)
 
+  uint64_t max_alloc_size; ///< maximum allocation unit (power of 2)
+
   bool sync_wal_apply;	  ///< see config option bluestore_sync_wal_apply
 
   // compression options
@@ -944,7 +946,7 @@ private:
   int _read_fsid(uuid_d *f);
   int _write_fsid();
   void _close_fsid();
-  void _set_min_alloc();
+  void _set_alloc_sizes();
   int _open_bdev(bool create);
   void _close_bdev();
   int _open_db(bool create);


### PR DESCRIPTION
…marily for testing. Extends ceph_test_objectstore  with cases for fragmented blob testing.

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>