### PR TITLE
os: simplify store_statfs_t

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -40,7 +40,6 @@ OPTION(restapi_log_level, OPT_STR, "") 	// default set by Python code
 OPTION(restapi_base_url, OPT_STR, "")	// "
 OPTION(fatal_signal_handlers, OPT_BOOL, true)
 OPTION(erasure_code_dir, OPT_STR, CEPH_PKGLIBDIR"/erasure-code") // default location for erasure-code plugins
-OPTION(compression_dir, OPT_STR, CEPH_PKGLIBDIR"/compressor") // default location for compression plugins
 
 OPTION(log_file, OPT_STR, "/var/log/ceph/$cluster-$name.log") // default changed by common_preinit()
 OPTION(log_max_new, OPT_INT, 1000) // default changed by common_preinit()

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -982,9 +982,9 @@ static int os_statfs(const char *path, struct statvfs *stbuf)
   int r = fs->store->statfs(&s);
   if (r < 0)
     return r;
-  stbuf->f_bsize = s.bsize;
-  stbuf->f_blocks = s.blocks;
-  stbuf->f_bavail = stbuf->f_bfree = s.available / s.bsize;
+  stbuf->f_bsize = 4096;   // LIES!
+  stbuf->f_blocks = s.total / 4096;
+  stbuf->f_bavail = s.available / 4096;
 
   return 0;
 }

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -711,8 +711,7 @@ int FileStore::statfs(struct store_statfs_t *buf0)
     assert(r != -ENOENT);
     return r;
   }
-  buf0->blocks = buf.f_blocks;
-  buf0->bsize = buf.f_bsize;
+  buf0->total = buf.f_blocks * buf.f_bsize;
   buf0->available = buf.f_bavail * buf.f_bsize;
   return 0;
 }

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -224,14 +224,10 @@ int MemStore::statfs(struct store_statfs_t *st)
 {
    dout(10) << __func__ << dendl;
   st->reset();
-  st->bsize = 4096;
-
-   // Device size is a configured constant
-  st->blocks = g_conf->memstore_device_bytes / st->bsize;
-
-  dout(10) << __func__ << ": used_bytes: " << used_bytes << "/" << g_conf->memstore_device_bytes << dendl;
-  st->available = MAX((int64_t(st->blocks * st->bsize) - int64_t(used_bytes)), 0);
-
+  st->total = g_conf->memstore_device_bytes;
+  st->available = MAX(int64_t(st->total) - int64_t(used_bytes), 0ll);
+  dout(10) << __func__ << ": used_bytes: " << used_bytes
+	   << "/" << g_conf->memstore_device_bytes << dendl;
   return 0;
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -774,7 +774,7 @@ void OSDService::update_osd_stat(vector<int>& hb_peers)
     return;
   }
 
-  uint64_t bytes = stbuf.blocks * stbuf.bsize;
+  uint64_t bytes = stbuf.total;
   uint64_t used = bytes - stbuf.available;
   uint64_t avail = stbuf.available;
 
@@ -2799,7 +2799,7 @@ int OSD::update_crush_location()
     }
     snprintf(weight, sizeof(weight), "%.4lf",
 	     MAX((double).00001,
-		 (double)(st.blocks * st.bsize) /
+		 (double)(st.total) /
 		 (double)(1ull << 40 /* TB */)));
   }
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5571,8 +5571,7 @@ void OSDOp::merge_osd_op_vector_out_data(vector<OSDOp>& ops, bufferlist& out)
 
 bool store_statfs_t::operator==(const store_statfs_t& other) const
 {
-  return blocks == other.blocks
-    && bsize == other.bsize
+  return total == other.total
     && available == other.available
     && allocated == other.allocated
     && stored == other.stored
@@ -5583,11 +5582,8 @@ bool store_statfs_t::operator==(const store_statfs_t& other) const
 
 void store_statfs_t::dump(Formatter *f) const
 {
+  f->dump_int("total", total);
   f->dump_int("available", available);
-
-  f->dump_int("blocks", blocks);
-  f->dump_int("bsize", bsize);
-
   f->dump_int("allocated", allocated);
   f->dump_int("stored", stored);
   f->dump_int("compressed", compressed);
@@ -5598,9 +5594,8 @@ void store_statfs_t::dump(Formatter *f) const
 ostream& operator<<(ostream& out, const store_statfs_t &s)
 {
   out << std::hex
-      << " store_statfs(0x" << s.blocks
-      << "*0x"  << s.bsize
-      << "/0x"  << s.available
+      << " store_statfs(0x" << s.available
+      << "/0x"  << s.total
       << ", stored 0x" << s.stored
       << "/0x"  << s.allocated
       << ", compress 0x" << s.compressed

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4314,9 +4314,7 @@ struct PromoteCounter {
 +*/
 struct store_statfs_t
 {
-
-  uint64_t blocks = 0;                 // Total data blocks
-  uint32_t bsize = 0;                  // Optimal transfer block size
+  uint64_t total = 0;                  // Total bytes
   uint64_t available = 0;              // Free bytes available
 
   int64_t allocated = 0;               // Bytes allocated by the store

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1138,8 +1138,7 @@ TEST_P(StoreTest, BluestoreStatFSTest) {
     ASSERT_EQ(r, 0);
     ASSERT_EQ( 0u, statfs.allocated);
     ASSERT_EQ( 0u, statfs.stored);
-    ASSERT_EQ(0x1000u, statfs.bsize);
-    ASSERT_EQ(g_conf->bluestore_block_size / 0x1000, statfs.blocks);
+    ASSERT_EQ(g_conf->bluestore_block_size, statfs.total);
     ASSERT_TRUE(statfs.available > 0u && statfs.available < g_conf->bluestore_block_size);
     //force fsck
     EXPECT_EQ(store->umount(), 0);
@@ -1356,10 +1355,9 @@ TEST_P(StoreTest, BluestoreFragmentedBlobTest) {
     struct store_statfs_t statfs;
     int r = store->statfs(&statfs);
     ASSERT_EQ(r, 0);
-    ASSERT_EQ( 0u, statfs.allocated);
-    ASSERT_EQ( 0u, statfs.stored);
-    ASSERT_EQ(0x1000u, statfs.bsize);
-    ASSERT_EQ(g_conf->bluestore_block_size / 0x1000, statfs.blocks);
+    ASSERT_EQ(g_conf->bluestore_block_size, statfs.total);
+    ASSERT_EQ(0u, statfs.allocated);
+    ASSERT_EQ(0u, statfs.stored);
     ASSERT_TRUE(statfs.available > 0u && statfs.available < g_conf->bluestore_block_size);
   }
   std::string data;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -4755,38 +4755,6 @@ int main(int argc, char **argv) {
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 
-  const char* env = getenv("CEPH_LIB");
-  std::string directory(env ? env : ".libs");
-  if (plugin_exists(directory)) {
-    string mkdir_compressor = "mkdir -p " + directory + "/compressor";
-    int r = system(mkdir_compressor.c_str());
-    (void)r;
-
-    string cp_libceph_snappy = "cp " + directory + "/libceph_snappy.so* " + directory + "/compressor/";
-    r = system(cp_libceph_snappy.c_str());
-    (void)r;
-
-    string cp_libceph_zlib = "cp " + directory + "/libceph_zlib.so* " + directory + "/compressor/";
-    r = system(cp_libceph_zlib.c_str());
-    (void)r;
-    g_ceph_context->_conf->set_val("plugin_dir", directory, false, false);
-  } else {
-    char plugin_dir[PATH_MAX];
-    char *val = plugin_dir;
-    int r = g_ceph_context->_conf->get_val("plugin_dir", &val,
-					   sizeof(plugin_dir));
-    if (r)
-      return r;
-    string compressor_dir(val);
-    compressor_dir += "/compressor";
-    if (!plugin_exists(compressor_dir)) {
-      std::cerr << "compressor plugins not found in '"
-		<< directory << "' or '" << compressor_dir << "'"
-		<< std::endl;
-      return EINVAL;
-    }
-  }
-
   g_ceph_context->_conf->set_val("osd_journal_size", "400");
   g_ceph_context->_conf->set_val("filestore_index_retry_probability", "0.5");
   g_ceph_context->_conf->set_val("filestore_op_thread_timeout", "1000");

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -33,7 +33,6 @@ if [ -n "$CEPH_BUILD_ROOT" ]; then
         [ -z "$CEPH_BIN" ] && CEPH_BIN=$CEPH_BUILD_ROOT/bin
         [ -z "$CEPH_LIB" ] && CEPH_LIB=$CEPH_BUILD_ROOT/lib
         [ -z "$EC_PATH" ] && EC_PATH=$CEPH_LIB/erasure-code
-        [ -z "$CS_PATH" ] && CS_PATH=$CEPH_LIB/compressor
         [ -z "$OBJCLASS_PATH" ] && OBJCLASS_PATH=$CEPH_LIB/rados-classes
 elif [ -n "$CEPH_ROOT" ]; then
         [ -z "$PYBIND" ] && PYBIND=$CEPH_ROOT/src/pybind
@@ -43,12 +42,10 @@ elif [ -n "$CEPH_ROOT" ]; then
         [ -z "$CEPH_LIB" ] && CEPH_LIB=$CEPH_BUILD_DIR/lib
         [ -z "$OBJCLASS_PATH" ] && OBJCLASS_PATH=$CEPH_LIB
         [ -z "$EC_PATH" ] && EC_PATH=$CEPH_LIB
-        [ -z "$CS_PATH" ] && CS_PATH=$CEPH_LIB
 else
         [ -z "$CEPH_BIN" ] && CEPH_BIN=.
         [ -z "$CEPH_LIB" ] && CEPH_LIB=.libs
         [ -z "$EC_PATH" ] && EC_PATH=$CEPH_LIB
-        [ -z "$CS_PATH" ] && CS_PATH=$CEPH_LIB
         [ -z "$OBJCLASS_PATH" ] && OBJCLASS_PATH=$CEPH_LIB
 fi
 
@@ -469,7 +466,7 @@ if [ "$start_mon" -eq 1 ]; then
         mon data avail warn = 10
         mon data avail crit = 1
         erasure code dir = $EC_PATH
-        plugin dir = $CS_PATH
+        plugin dir = $CEPH_LIB
         osd pool default erasure code profile = plugin=jerasure technique=reed_sol_van k=2 m=1 ruleset-failure-domain=osd
         rgw frontends = fastcgi, civetweb port=$CEPH_RGW_PORT
         rgw dns name = localhost


### PR DESCRIPTION
This PR also fixes ceph_test_objectstore not to muck around with plugins (copying them around! yeesh). 

I'm not sure about the cmake vstart case.  And I'm not sure who you're "supposed" to run vstart and tests with cmake.

Can someone please update README.md with this information?  I'll document the automake way (short-lived though it is).