### PR TITLE
osd: hobject_t::get_max() vs is_max() discrepancy

### DIFF
--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -142,6 +142,12 @@ void hobject_t::decode(bufferlist::iterator& bl)
       pool = INT64_MIN;
       assert(is_min());
     }
+
+    // for compatibility with some earlier verisons which might encoded
+    // a non-canonical max object
+    if (max) {
+      *this = hobject_t::get_max();
+    }
   }
   DECODE_FINISH(bl);
   build_hash_cache();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3018,7 +3018,7 @@ int BlueStore::collection_list(
     pnext = &static_next;
 
   if (start == ghobject_t::get_max() ||
-      start.hobj == hobject_t::get_max()) {
+      start.hobj.is_max()) {
     goto out;
   }
   get_coll_key_range(c->cid, c->cnode.bits, &temp_start_key, &temp_end_key,

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -532,7 +532,7 @@ bool PG::MissingLoc::add_source_info(
 	       << dendl;
       continue;
     }
-    if (oinfo.last_backfill != hobject_t::get_max() &&
+    if (!oinfo.last_backfill.is_max() &&
 	oinfo.last_backfill_bitwise != sort_bitwise) {
       dout(10) << "search_for_missing " << soid << " " << need
 	       << " also missing on osd." << fromosd
@@ -1798,7 +1798,7 @@ void PG::activate(ObjectStore::Transaction& t,
       } else {
 	assert(peer_missing.count(*i));
 	missing_loc.add_active_missing(peer_missing[*i]);
-        if (!peer_missing[*i].have_missing() && peer_info[*i].last_backfill == hobject_t::get_max())
+        if (!peer_missing[*i].have_missing() && peer_info[*i].last_backfill.is_max())
           complete_shards.insert(*i);
       }
     }
@@ -4281,7 +4281,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  break;
 	}
 
-	if (cmp(scrubber.end, hobject_t::get_max(), get_sort_bitwise()) < 0) {
+	if (!(scrubber.end.is_max())) {
           scrubber.state = PG::Scrubber::NEW_CHUNK;
 	  requeue_scrub();
           done = true;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3899,8 +3899,10 @@ void PG::replica_scrub(
   // compensate for hobject_t's with wrong pool from sloppy hammer OSDs
   hobject_t start = msg->start;
   hobject_t end = msg->end;
-  start.pool = info.pgid.pool();
-  end.pool = info.pgid.pool();
+  if (!start.is_max())
+    start.pool = info.pgid.pool();
+  if (!end.is_max())
+    end.pool = info.pgid.pool();
 
   build_scrub_map_chunk(
     map, start, end, msg->deep, msg->seed,

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -457,7 +457,7 @@ public:
       needs_recovery_map[hoid] = *item;
       auto mliter =
 	missing_loc.insert(make_pair(hoid, set<pg_shard_t>())).first;
-      assert(info.last_backfill == hobject_t::get_max());
+      assert(info.last_backfill.is_max());
       assert(info.last_update >= item->need);
       if (!missing.is_missing(hoid))
 	mliter->second.insert(self);

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -953,7 +953,7 @@ void ReplicatedPG::do_pg_op(OpRequestRef op)
         dout(10) << " pgnls lower_bound " << lower_bound
 		 << " pg_end " << pg_end << dendl;
 	if (get_sort_bitwise() &&
-	    ((lower_bound != hobject_t::get_max() &&
+	    ((!lower_bound.is_max() &&
 	      cmp_bitwise(lower_bound, pg_end) >= 0) ||
 	     (lower_bound != hobject_t() &&
 	      cmp_bitwise(lower_bound, pg_start) < 0))) {

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2761,7 +2761,7 @@ void pg_info_t::encode(bufferlist &bl) const
   ::encode(last_update, bl);
   ::encode(last_complete, bl);
   ::encode(log_tail, bl);
-  if (last_backfill_bitwise && last_backfill != last_backfill.get_max()) {
+  if (last_backfill_bitwise && !last_backfill.is_max()) {
     ::encode(hobject_t(), bl);
   } else {
     ::encode(last_backfill, bl);


### PR DESCRIPTION
sjust@teuthology:/a/samuelj-2016-06-08_14:58:37-rados-wip-16113-jewel-distro-basic-smithi
sjust@teuthology:/a/samuelj-2016-06-05_21:24:33-rados-wip-16113-jewel-distro-basic-smithi

Tested above, each had some environmental noise, but nothing attributable to these patches.  The latter includes 16113.yaml passing.  samuelj-2016-06-09_09:28:24-rados-jewel-distro-basic-smithi shows it failing on jewel.

Merge with: https://github.com/ceph/ceph-qa-suite/pull/1047