### PR TITLE
test/osd/osd-markdown: make test more reliable

### DIFF
--- a/src/test/osd/osd-markdown.sh
+++ b/src/test/osd/osd-markdown.sh
@@ -59,10 +59,10 @@ function TEST_markdown_exceed_maxdown_count() {
     run_osd $dir 0 || return 1
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
-    # 3+1 times within 120s, osd should stay dead on the 4th time
+    # 3+1 times within 300s, osd should stay dead on the 4th time
     local count=3
     local sleeptime=10
-    local period=120
+    local period=300
     ceph tell osd.0 injectargs '--osd_max_markdown_count '$count'' || return 1
     ceph tell osd.0 injectargs '--osd_max_markdown_period '$period'' || return 1
 
@@ -88,6 +88,7 @@ function TEST_markdown_boot() {
 
     markdown_N_impl $count $period $sleeptime
     #down N times, osd.0 should be up
+    sleep 15  # give osd plenty of time to notice and come back up
     ceph osd tree | grep up | grep osd.0 || return 1
 }
 
@@ -108,6 +109,7 @@ function TEST_markdown_boot_exceed_time() {
     ceph tell osd.0 injectargs '--osd_max_markdown_period '$period'' || return 1
 
     markdown_N_impl $(($count+1)) $period $sleeptime
+    sleep 15  # give osd plenty of time to notice and come back up
     ceph osd tree | grep up | grep osd.0 || return 1
 }
 


### PR DESCRIPTION
This can fail if the osd hasn't gotten the map for the
last time it was marked down and come back up.  This
should make this test much more reliable (fewer false
positives).

Signed-off-by: Sage Weil <sage@redhat.com>