### PR TITLE
test/mon/misc: fix pool set test given new default ec k

### DIFF
--- a/src/test/mon/misc.sh
+++ b/src/test/mon/misc.sh
@@ -89,7 +89,8 @@ function TEST_osd_pool_get_set() {
     ceph osd pool create $ecpool 12 12 erasure default || return 1
     #erasue pool size=k+m, min_size=k
     local size=$(ceph osd pool get $ecpool size|awk '{print $2}')
-    local k=$(ceph osd pool get $ecpool min_size|awk '{print $2}')
+    local min_size=$(ceph osd pool get $ecpool min_size|awk '{print $2}')
+    local k=$(expr $min_size - 1)  # default min_size=k+1
     #erasure pool size can't change
     ! ceph osd pool set $ecpool size  $(expr $size + 1) || return 1
     #erasure pool min_size must be between in k and size


### PR DESCRIPTION
k is no longer min_size by default; adjust test accordingly.

Signed-off-by: Sage Weil <sage@redhat.com>