### PR TITLE
rbd-mirror: Throttle in-flight image syncs to only a N concurrent

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1223,6 +1223,7 @@ if(${WITH_RBD})
     tools/rbd_mirror/ImageReplayer.cc
     tools/rbd_mirror/ImageDeleter.cc
     tools/rbd_mirror/ImageSync.cc
+    tools/rbd_mirror/ImageSyncThrottler.cc
     tools/rbd_mirror/Mirror.cc
     tools/rbd_mirror/PoolWatcher.cc
     tools/rbd_mirror/Replayer.cc

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1238,6 +1238,7 @@ OPTION(rbd_journal_pool, OPT_STR, "") // pool for journal objects
  * RBD Mirror options
  */
 OPTION(rbd_mirror_sync_point_update_age, OPT_DOUBLE, 30) // number of seconds between each update of the image sync point object number
+OPTION(rbd_mirror_concurrent_image_syncs, OPT_U32, 5) // maximum number of image syncs in parallel
 
 OPTION(nss_db_path, OPT_STR, "") // path to nss db
 

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -485,6 +485,7 @@ unittest_rbd_mirror_SOURCES = \
 	test/rbd_mirror/test_mock_fixture.cc \
 	test/rbd_mirror/test_mock_ImageReplayer.cc \
 	test/rbd_mirror/test_mock_ImageSync.cc \
+	test/rbd_mirror/test_mock_ImageSyncThrottler.cc \
 	test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc \
 	test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc \
 	test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc \

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(unittest_rbd_mirror
   test_mock_fixture.cc
   test_mock_ImageReplayer.cc
   test_mock_ImageSync.cc
+  test_mock_ImageSyncThrottler.cc
   image_replayer/test_mock_BootstrapRequest.cc
   image_replayer/test_mock_CreateImageRequest.cc
   image_sync/test_mock_ImageCopyRequest.cc

--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -6,6 +6,7 @@
 #include "tools/rbd_mirror/ImageReplayer.h"
 #include "tools/rbd_mirror/image_replayer/BootstrapRequest.h"
 #include "tools/rbd_mirror/image_replayer/CloseImageRequest.h"
+#include "tools/rbd_mirror/ImageSyncThrottler.h"
 #include "test/journal/mock/MockJournaler.h"
 #include "test/librbd/mock/MockImageCtx.h"
 #include "test/librbd/mock/MockJournal.h"
@@ -59,19 +60,20 @@ struct BootstrapRequest<librbd::MockTestImageCtx> {
   Context *on_finish = nullptr;
 
   static BootstrapRequest* create(librados::IoCtx &local_io_ctx,
-                                  librados::IoCtx &remote_io_ctx,
-                                  librbd::MockTestImageCtx **local_image_ctx,
-                                  const std::string &local_image_name,
-                                  const std::string &remote_image_id,
-                                  const std::string &global_image_id,
-                                  ContextWQ *work_queue, SafeTimer *timer,
-                                  Mutex *timer_lock,
-                                  const std::string &local_mirror_uuid,
-                                  const std::string &remote_mirror_uuid,
-                                  ::journal::MockJournalerProxy *journaler,
-                                  librbd::journal::MirrorPeerClientMeta *client_meta,
-                                  Context *on_finish,
-                                  rbd::mirror::ProgressContext *progress_ctx = nullptr) {
+        librados::IoCtx &remote_io_ctx,
+        rbd::mirror::ImageSyncThrottlerRef<librbd::MockTestImageCtx> image_sync_throttler,
+        librbd::MockTestImageCtx **local_image_ctx,
+        const std::string &local_image_name,
+        const std::string &remote_image_id,
+        const std::string &global_image_id,
+        ContextWQ *work_queue, SafeTimer *timer,
+        Mutex *timer_lock,
+        const std::string &local_mirror_uuid,
+        const std::string &remote_mirror_uuid,
+        ::journal::MockJournalerProxy *journaler,
+        librbd::journal::MirrorPeerClientMeta *client_meta,
+        Context *on_finish,
+        rbd::mirror::ProgressContext *progress_ctx = nullptr) {
     assert(s_instance != nullptr);
     s_instance->on_finish = on_finish;
     return s_instance;

--- a/src/test/rbd_mirror/test_mock_ImageSyncThrottler.cc
+++ b/src/test/rbd_mirror/test_mock_ImageSyncThrottler.cc
@@ -1,0 +1,398 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "librbd/journal/TypeTraits.h"
+#include "test/journal/mock/MockJournaler.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "librbd/ImageState.h"
+#include "tools/rbd_mirror/Threads.h"
+#include "tools/rbd_mirror/ImageSync.h"
+
+namespace librbd {
+namespace journal {
+
+template <>
+struct TypeTraits<librbd::MockImageCtx> {
+  typedef ::journal::MockJournaler Journaler;
+};
+
+} // namespace journal
+} // namespace librbd
+
+namespace rbd {
+namespace mirror {
+
+using ::testing::Invoke;
+
+typedef ImageSync<librbd::MockImageCtx> MockImageSync;
+
+template<>
+class ImageSync<librbd::MockImageCtx> {
+public:
+  static std::vector<MockImageSync *> instances;
+
+  Context *on_finish;
+  bool syncing = false;
+
+  static ImageSync* create(librbd::MockImageCtx *local_image_ctx,
+                           librbd::MockImageCtx *remote_image_ctx,
+                           SafeTimer *timer, Mutex *timer_lock,
+                           const std::string &mirror_uuid,
+                           journal::MockJournaler *journaler,
+                           librbd::journal::MirrorPeerClientMeta *client_meta,
+                           ContextWQ *work_queue, Context *on_finish,
+                           ProgressContext *progress_ctx = nullptr) {
+    ImageSync *sync = new ImageSync();
+    sync->on_finish = on_finish;
+
+    EXPECT_CALL(*sync, send())
+      .WillRepeatedly(Invoke([sync]() {
+            sync->syncing = true;
+          }));
+
+    return sync;
+  }
+
+  void finish(int r) {
+    on_finish->complete(r);
+    put();
+  }
+
+  void get() {
+    instances.push_back(this);
+  }
+
+  void put() { delete this; }
+
+  MOCK_METHOD0(cancel, void());
+  MOCK_METHOD0(send, void());
+
+};
+
+
+std::vector<MockImageSync *> MockImageSync::instances;
+
+} // namespace mirror
+} // namespace rbd
+
+
+// template definitions
+#include "tools/rbd_mirror/ImageSyncThrottler.cc"
+template class rbd::mirror::ImageSyncThrottler<librbd::MockImageCtx>;
+
+namespace rbd {
+namespace mirror {
+
+class TestMockImageSyncThrottler : public TestMockFixture {
+public:
+  typedef ImageSyncThrottler<librbd::MockImageCtx> MockImageSyncThrottler;
+
+  virtual void SetUp() {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+
+    ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+
+    mock_sync_throttler = new MockImageSyncThrottler();
+
+    m_mock_local_image_ctx = new librbd::MockImageCtx(*m_local_image_ctx);
+    m_mock_remote_image_ctx = new librbd::MockImageCtx(*m_remote_image_ctx);
+    m_mock_journaler = new journal::MockJournaler();
+  }
+
+  virtual void TearDown() {
+    MockImageSync::instances.clear();
+    delete mock_sync_throttler;
+    delete m_mock_local_image_ctx;
+    delete m_mock_remote_image_ctx;
+    delete m_mock_journaler;
+    TestMockFixture::TearDown();
+  }
+
+  void start_sync(const std::string& image_id, Context *ctx) {
+    m_mock_local_image_ctx->id = image_id;
+    mock_sync_throttler->start_sync(m_mock_local_image_ctx,
+                                    m_mock_remote_image_ctx,
+                                    m_threads->timer,
+                                    &m_threads->timer_lock,
+                                    "mirror_uuid",
+                                    m_mock_journaler,
+                                    &m_client_meta,
+                                    m_threads->work_queue,
+                                    ctx);
+  }
+
+  void cancel(const std::string& mirror_uuid, MockImageSync *sync,
+              bool running=true) {
+    if (running) {
+      EXPECT_CALL(*sync, cancel())
+        .WillOnce(Invoke([sync]() {
+              sync->finish(-ECANCELED);
+            }));
+    } else {
+      EXPECT_CALL(*sync, cancel()).Times(0);
+    }
+    mock_sync_throttler->cancel_sync(mirror_uuid);
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::ImageCtx *m_local_image_ctx;
+  librbd::MockImageCtx *m_mock_local_image_ctx;
+  librbd::MockImageCtx *m_mock_remote_image_ctx;
+  journal::MockJournaler *m_mock_journaler;
+  librbd::journal::MirrorPeerClientMeta m_client_meta;
+  MockImageSyncThrottler *mock_sync_throttler;
+};
+
+TEST_F(TestMockImageSyncThrottler, Single_Sync) {
+  C_SaferCond ctx;
+  start_sync("image_id", &ctx);
+
+  ASSERT_EQ(1u, MockImageSync::instances.size());
+  MockImageSync *sync = MockImageSync::instances[0];
+  ASSERT_EQ(true, sync->syncing);
+  sync->finish(0);
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Multiple_Syncs) {
+  mock_sync_throttler->set_max_concurrent_syncs(2);
+
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+  C_SaferCond ctx3;
+  start_sync("image_id_3", &ctx3);
+  C_SaferCond ctx4;
+  start_sync("image_id_4", &ctx4);
+
+  ASSERT_EQ(4u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_TRUE(sync2->syncing);
+
+  MockImageSync *sync3 = MockImageSync::instances[2];
+  ASSERT_FALSE(sync3->syncing);
+
+  MockImageSync *sync4 = MockImageSync::instances[3];
+  ASSERT_FALSE(sync4->syncing);
+
+  sync1->finish(0);
+  ASSERT_EQ(0, ctx1.wait());
+
+  ASSERT_TRUE(sync3->syncing);
+  sync3->finish(-EINVAL);
+  ASSERT_EQ(-EINVAL, ctx3.wait());
+
+  ASSERT_TRUE(sync4->syncing);
+
+  sync2->finish(0);
+  ASSERT_EQ(0, ctx2.wait());
+
+  sync4->finish(0);
+  ASSERT_EQ(0, ctx4.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Cancel_Running_Sync) {
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+
+  ASSERT_EQ(2u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_TRUE(sync2->syncing);
+
+  cancel("image_id_2", sync2);
+  ASSERT_EQ(-ECANCELED, ctx2.wait());
+
+  sync1->finish(0);
+  ASSERT_EQ(0, ctx1.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Cancel_Waiting_Sync) {
+  mock_sync_throttler->set_max_concurrent_syncs(1);
+
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+
+  ASSERT_EQ(2u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_FALSE(sync2->syncing);
+
+  cancel("image_id_2", sync2, false);
+  ASSERT_EQ(-ECANCELED, ctx2.wait());
+
+  sync1->finish(0);
+  ASSERT_EQ(0, ctx1.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Cancel_Running_Sync_Start_Waiting) {
+  mock_sync_throttler->set_max_concurrent_syncs(1);
+
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+
+  ASSERT_EQ(2u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_FALSE(sync2->syncing);
+
+  cancel("image_id_1", sync1);
+  ASSERT_EQ(-ECANCELED, ctx1.wait());
+
+  ASSERT_TRUE(sync2->syncing);
+  sync2->finish(0);
+  ASSERT_EQ(0, ctx2.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Increase_Max_Concurrent_Syncs) {
+  mock_sync_throttler->set_max_concurrent_syncs(2);
+
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+  C_SaferCond ctx3;
+  start_sync("image_id_3", &ctx3);
+  C_SaferCond ctx4;
+  start_sync("image_id_4", &ctx4);
+  C_SaferCond ctx5;
+  start_sync("image_id_5", &ctx5);
+
+  ASSERT_EQ(5u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_TRUE(sync2->syncing);
+
+  MockImageSync *sync3 = MockImageSync::instances[2];
+  ASSERT_FALSE(sync3->syncing);
+
+  MockImageSync *sync4 = MockImageSync::instances[3];
+  ASSERT_FALSE(sync4->syncing);
+
+  MockImageSync *sync5 = MockImageSync::instances[4];
+  ASSERT_FALSE(sync5->syncing);
+
+  mock_sync_throttler->set_max_concurrent_syncs(4);
+
+  ASSERT_TRUE(sync3->syncing);
+  ASSERT_TRUE(sync4->syncing);
+  ASSERT_FALSE(sync5->syncing);
+
+  sync1->finish(0);
+  ASSERT_EQ(0, ctx1.wait());
+
+  ASSERT_TRUE(sync5->syncing);
+  sync5->finish(-EINVAL);
+  ASSERT_EQ(-EINVAL, ctx5.wait());
+
+  sync2->finish(0);
+  ASSERT_EQ(0, ctx2.wait());
+
+  sync3->finish(0);
+  ASSERT_EQ(0, ctx3.wait());
+
+  sync4->finish(0);
+  ASSERT_EQ(0, ctx4.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Decrease_Max_Concurrent_Syncs) {
+  mock_sync_throttler->set_max_concurrent_syncs(4);
+
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+  C_SaferCond ctx3;
+  start_sync("image_id_3", &ctx3);
+  C_SaferCond ctx4;
+  start_sync("image_id_4", &ctx4);
+  C_SaferCond ctx5;
+  start_sync("image_id_5", &ctx5);
+
+  ASSERT_EQ(5u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_TRUE(sync2->syncing);
+
+  MockImageSync *sync3 = MockImageSync::instances[2];
+  ASSERT_TRUE(sync3->syncing);
+
+  MockImageSync *sync4 = MockImageSync::instances[3];
+  ASSERT_TRUE(sync4->syncing);
+
+  MockImageSync *sync5 = MockImageSync::instances[4];
+  ASSERT_FALSE(sync5->syncing);
+
+  mock_sync_throttler->set_max_concurrent_syncs(2);
+
+  ASSERT_FALSE(sync5->syncing);
+
+  sync1->finish(0);
+  ASSERT_EQ(0, ctx1.wait());
+
+  ASSERT_FALSE(sync5->syncing);
+
+  sync2->finish(0);
+  ASSERT_EQ(0, ctx2.wait());
+
+  ASSERT_FALSE(sync5->syncing);
+
+  sync3->finish(0);
+  ASSERT_EQ(0, ctx3.wait());
+
+  ASSERT_TRUE(sync5->syncing);
+
+  sync4->finish(0);
+  ASSERT_EQ(0, ctx4.wait());
+
+  sync5->finish(0);
+  ASSERT_EQ(0, ctx5.wait());
+}
+
+
+} // namespace mirror
+} // namespace rbd
+

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -93,6 +93,7 @@ librbd_mirror_internal_la_SOURCES = \
 	tools/rbd_mirror/ClusterWatcher.cc \
 	tools/rbd_mirror/ImageReplayer.cc \
 	tools/rbd_mirror/ImageSync.cc \
+        tools/rbd_mirror/ImageSyncThrottler.cc \
 	tools/rbd_mirror/Mirror.cc \
 	tools/rbd_mirror/PoolWatcher.cc \
 	tools/rbd_mirror/Replayer.cc \
@@ -117,6 +118,7 @@ noinst_HEADERS += \
 	tools/rbd_mirror/ClusterWatcher.h \
 	tools/rbd_mirror/ImageReplayer.h \
 	tools/rbd_mirror/ImageSync.h \
+	tools/rbd_mirror/ImageSyncThrottler.h \
 	tools/rbd_mirror/Mirror.h \
 	tools/rbd_mirror/PoolWatcher.h \
 	tools/rbd_mirror/ProgressContext.h \

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -77,6 +77,7 @@ public:
   };
 
   ImageReplayer(Threads *threads, std::shared_ptr<ImageDeleter> image_deleter,
+                ImageSyncThrottlerRef<ImageCtxT> image_sync_throttler,
                 RadosRef local, RadosRef remote,
                 const std::string &local_mirror_uuid,
                 const std::string &remote_mirror_uuid, int64_t local_pool_id,
@@ -223,6 +224,7 @@ private:
 
   Threads *m_threads;
   std::shared_ptr<ImageDeleter> m_image_deleter;
+  ImageSyncThrottlerRef<ImageCtxT> m_image_sync_throttler;
   RadosRef m_local, m_remote;
   std::string m_local_mirror_uuid;
   std::string m_remote_mirror_uuid;

--- a/src/tools/rbd_mirror/ImageSyncThrottler.cc
+++ b/src/tools/rbd_mirror/ImageSyncThrottler.cc
@@ -1,0 +1,243 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "ImageSyncThrottler.h"
+#include "ImageSync.h"
+#include "common/ceph_context.h"
+
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::ImageSyncThrottler:: " << this \
+                           << " " << __func__ << ": "
+using std::unique_ptr;
+using std::string;
+using std::set;
+
+namespace rbd {
+namespace mirror {
+
+template <typename I>
+ImageSyncThrottler<I>::ImageSyncThrottler()
+  : m_max_concurrent_syncs(g_ceph_context->_conf->rbd_mirror_concurrent_image_syncs),
+    m_lock("rbd::mirror::ImageSyncThrottler")
+{
+  dout(20) << "Initialized max_concurrent_syncs=" << m_max_concurrent_syncs
+           << dendl;
+  g_ceph_context->_conf->add_observer(this);
+}
+
+template <typename I>
+ImageSyncThrottler<I>::~ImageSyncThrottler() {
+  {
+    Mutex::Locker l(m_lock);
+    assert(m_sync_queue.empty());
+    assert(m_inflight_syncs.empty());
+  }
+
+  g_ceph_context->_conf->remove_observer(this);
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::start_sync(
+                            I *local_image_ctx, I *remote_image_ctx,
+                            SafeTimer *timer, Mutex *timer_lock,
+                            const std::string &mirror_uuid,
+                            Journaler *journaler,
+                            MirrorPeerClientMeta *client_meta,
+                            ContextWQ *work_queue, Context *on_finish,
+                            ProgressContext *progress_ctx) {
+  dout(20) << dendl;
+
+  C_SyncHolder *sync_holder_ctx = new C_SyncHolder(this, local_image_ctx->id,
+                                                   on_finish);
+  sync_holder_ctx->m_sync = ImageSync<I>::create(local_image_ctx,
+                                         remote_image_ctx, timer,
+                                         timer_lock, mirror_uuid,
+                                         journaler, client_meta,
+                                         work_queue, sync_holder_ctx,
+	                                 progress_ctx);
+  sync_holder_ctx->m_sync->get();
+
+  bool start = false;
+  {
+    Mutex::Locker l(m_lock);
+
+    if (m_inflight_syncs.size() < m_max_concurrent_syncs) {
+      m_inflight_syncs.insert(std::make_pair(local_image_ctx->id,
+                                             sync_holder_ctx));
+      start = true;
+      dout(10) << "ready to start image sync for local_image_id "
+               << local_image_ctx->id << " [" << m_inflight_syncs.size() << "/"
+               << m_max_concurrent_syncs << "]" << dendl;
+    } else {
+      m_sync_queue.push_front(sync_holder_ctx);
+      dout(10) << "image sync for local_image_id " << local_image_ctx->id
+               << " has been queued" << dendl;
+    }
+  }
+
+  if (start) {
+      sync_holder_ctx->m_sync->send();
+  }
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::cancel_sync(const std::string& local_image_id) {
+  dout(20) << dendl;
+
+  C_SyncHolder *sync_holder = nullptr;
+  bool running_sync = true;
+
+  {
+    Mutex::Locker l(m_lock);
+
+    if (m_inflight_syncs.empty()) {
+      // no image sync currently running and neither waiting
+      return;
+    }
+
+    auto it = m_inflight_syncs.find(local_image_id);
+    if (it != m_inflight_syncs.end()) {
+      sync_holder = it->second;
+    }
+
+    if (!sync_holder) {
+      for (auto it=m_sync_queue.begin(); it != m_sync_queue.end(); ++it) {
+        if ((*it)->m_local_image_id == local_image_id) {
+          sync_holder = (*it);
+          m_sync_queue.erase(it);
+          running_sync = false;
+          break;
+        }
+      }
+    }
+  }
+
+  if (sync_holder) {
+    if (running_sync) {
+      dout(10) << "canceled running image sync for local_image_id "
+               << sync_holder->m_local_image_id << dendl;
+      sync_holder->m_sync->cancel();
+    } else {
+      dout(10) << "canceled waiting image sync for local_image_id "
+               << sync_holder->m_local_image_id << dendl;
+      sync_holder->m_on_finish->complete(-ECANCELED);
+      sync_holder->m_sync->put();
+      delete sync_holder;
+    }
+  }
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::handle_sync_finished(C_SyncHolder *sync_holder) {
+  dout(20) << dendl;
+
+  C_SyncHolder *next_sync_holder = nullptr;
+
+  {
+    Mutex::Locker l(m_lock);
+
+    m_inflight_syncs.erase(sync_holder->m_local_image_id);
+
+    if (m_inflight_syncs.size() < m_max_concurrent_syncs
+        && !m_sync_queue.empty()) {
+      next_sync_holder = m_sync_queue.back();
+      m_sync_queue.pop_back();
+      m_inflight_syncs.insert(std::make_pair(next_sync_holder->m_local_image_id,
+                                             next_sync_holder));
+      dout(10) << "ready to start image sync for local_image_id "
+               << next_sync_holder->m_local_image_id
+               << " [" << m_inflight_syncs.size() << "/"
+               << m_max_concurrent_syncs << "]" << dendl;
+    }
+
+    dout(10) << "currently running image syncs [" << m_inflight_syncs.size()
+             << "/" << m_max_concurrent_syncs << "]" << dendl;
+  }
+
+  if (next_sync_holder) {
+    next_sync_holder->m_sync->send();
+  }
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::set_max_concurrent_syncs(uint32_t max) {
+  dout(20) << " max=" << max << dendl;
+
+  assert(max > 0);
+
+  std::list<C_SyncHolder *> next_sync_holders;
+  {
+    Mutex::Locker l(m_lock);
+    this->m_max_concurrent_syncs = max;
+
+    // Start waiting syncs in the case of available free slots
+    while(m_inflight_syncs.size() < m_max_concurrent_syncs
+          && !m_sync_queue.empty()) {
+        C_SyncHolder *next_sync_holder = m_sync_queue.back();
+        next_sync_holders.push_back(next_sync_holder);
+        m_sync_queue.pop_back();
+        m_inflight_syncs.insert(std::make_pair(next_sync_holder->m_local_image_id,
+                                               next_sync_holder));
+        dout(10) << "ready to start image sync for local_image_id "
+                 << next_sync_holder->m_local_image_id
+                 << " [" << m_inflight_syncs.size() << "/"
+                 << m_max_concurrent_syncs << "]" << dendl;
+    }
+  }
+
+  for (const auto& sync_holder : next_sync_holders) {
+    sync_holder->m_sync->send();
+  }
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::print_status(Formatter *f, stringstream *ss) {
+  Mutex::Locker l(m_lock);
+
+  if (f) {
+    f->dump_int("max_parallel_syncs", m_max_concurrent_syncs);
+    f->dump_int("running_syncs", m_inflight_syncs.size());
+    f->dump_int("waiting_syncs", m_sync_queue.size());
+    f->flush(*ss);
+  } else {
+    *ss << "[ ";
+    *ss << "max_parallel_syncs=" << m_max_concurrent_syncs << ", ";
+    *ss << "running_syncs=" << m_inflight_syncs.size() << ", ";
+    *ss << "waiting_syncs=" << m_sync_queue.size() << " ]";
+  }
+}
+
+template <typename I>
+const char** ImageSyncThrottler<I>::get_tracked_conf_keys() const {
+  static const char* KEYS[] = {
+    "rbd_mirror_concurrent_image_syncs",
+    NULL
+  };
+  return KEYS;
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::handle_conf_change(
+                                              const struct md_config_t *conf,
+                                              const set<string> &changed) {
+  if (changed.count("rbd_mirror_concurrent_image_syncs")) {
+    set_max_concurrent_syncs(conf->rbd_mirror_concurrent_image_syncs);
+  }
+}
+
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::ImageSyncThrottler<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/ImageSyncThrottler.h
+++ b/src/tools/rbd_mirror/ImageSyncThrottler.h
@@ -1,0 +1,103 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_RBD_MIRROR_IMAGE_SYNC_THROTTLER_H
+#define CEPH_RBD_MIRROR_IMAGE_SYNC_THROTTLER_H
+
+#include <list>
+#include <map>
+#include "common/Mutex.h"
+#include "librbd/ImageCtx.h"
+#include "include/Context.h"
+#include "librbd/journal/TypeTraits.h"
+
+class CephContext;
+class Context;
+class ContextWQ;
+class SafeTimer;
+namespace journal { class Journaler; }
+namespace librbd { namespace journal { struct MirrorPeerClientMeta; } }
+
+namespace rbd {
+namespace mirror {
+
+template <typename> class ImageSync;
+
+class ProgressContext;
+
+/**
+ * Manage concurrent image-syncs
+ */
+template <typename ImageCtxT = librbd::ImageCtx>
+class ImageSyncThrottler : public md_config_obs_t {
+public:
+
+  typedef librbd::journal::TypeTraits<ImageCtxT> TypeTraits;
+  typedef typename TypeTraits::Journaler Journaler;
+  typedef librbd::journal::MirrorPeerClientMeta MirrorPeerClientMeta;
+
+  ImageSyncThrottler();
+  ~ImageSyncThrottler();
+  ImageSyncThrottler(const ImageSyncThrottler&) = delete;
+  ImageSyncThrottler& operator=(const ImageSyncThrottler&) = delete;
+
+  void start_sync(ImageCtxT *local_image_ctx,
+                  ImageCtxT *remote_image_ctx, SafeTimer *timer,
+                  Mutex *timer_lock, const std::string &mirror_uuid,
+                  Journaler *journaler, MirrorPeerClientMeta *client_meta,
+                  ContextWQ *work_queue, Context *on_finish,
+                  ProgressContext *progress_ctx = nullptr);
+
+  void cancel_sync(const std::string& mirror_uuid);
+
+  void set_max_concurrent_syncs(uint32_t max);
+
+  void print_status(Formatter *f, std::stringstream *ss);
+
+private:
+
+  struct C_SyncHolder : public Context {
+    ImageSyncThrottler<ImageCtxT> *m_sync_throttler;
+    std::string m_local_image_id;
+    ImageSync<ImageCtxT> *m_sync;
+    Context *m_on_finish;
+
+    C_SyncHolder(ImageSyncThrottler<ImageCtxT> *sync_throttler,
+                 const std::string& local_image_id, Context *on_finish)
+      : m_sync_throttler(sync_throttler), m_local_image_id(local_image_id),
+        m_sync(nullptr), m_on_finish(on_finish) {}
+
+    virtual void finish(int r) {
+      m_sync_throttler->handle_sync_finished(this);
+      m_on_finish->complete(r);
+    }
+  };
+
+  void handle_sync_finished(C_SyncHolder *sync_holder);
+
+  const char **get_tracked_conf_keys() const;
+  void handle_conf_change(const struct md_config_t *conf,
+                          const std::set<std::string> &changed);
+
+  uint32_t m_max_concurrent_syncs;
+  Mutex m_lock;
+  std::list<C_SyncHolder *> m_sync_queue;
+  std::map<std::string, C_SyncHolder *> m_inflight_syncs;
+
+};
+
+} // namespace mirror
+} // namespace rbd
+
+#endif // CEPH_RBD_MIRROR_IMAGE_SYNC_THROTTLER_H

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -9,6 +9,7 @@
 #include "common/errno.h"
 #include "Mirror.h"
 #include "Threads.h"
+#include "ImageSync.h"
 
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
@@ -220,6 +221,8 @@ int Mirror::init()
   m_image_deleter.reset(new ImageDeleter(m_local, m_threads->timer,
                                          &m_threads->timer_lock));
 
+  m_image_sync_throttler.reset(new ImageSyncThrottler<>());
+
   return r;
 }
 
@@ -264,6 +267,13 @@ void Mirror::print_status(Formatter *f, stringstream *ss)
   }
 
   m_image_deleter->print_status(f, ss);
+
+  if (f) {
+    f->close_section();
+    f->open_object_section("sync_throttler");
+  }
+
+  m_image_sync_throttler->print_status(f, ss);
 
   if (f) {
     f->close_section();
@@ -363,6 +373,7 @@ void Mirror::update_replayers(const PoolPeers &pool_peers)
       if (m_replayers.find(pool_peer) == m_replayers.end()) {
         dout(20) << "starting replayer for " << peer << dendl;
         unique_ptr<Replayer> replayer(new Replayer(m_threads, m_image_deleter,
+                                                   m_image_sync_throttler,
                                                    m_local, kv.first, peer,
                                                    m_args));
         // TODO: make async, and retry connecting within replayer

--- a/src/tools/rbd_mirror/Mirror.h
+++ b/src/tools/rbd_mirror/Mirror.h
@@ -62,6 +62,7 @@ private:
   // monitor local cluster for config changes in peers
   std::unique_ptr<ClusterWatcher> m_local_cluster_watcher;
   std::shared_ptr<ImageDeleter> m_image_deleter;
+  ImageSyncThrottlerRef<> m_image_sync_throttler;
   std::map<PoolPeer, std::unique_ptr<Replayer> > m_replayers;
   atomic_t m_stopping;
   bool m_manual_stop = false;

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -229,10 +229,12 @@ private:
 };
 
 Replayer::Replayer(Threads *threads, std::shared_ptr<ImageDeleter> image_deleter,
+                   ImageSyncThrottlerRef<> image_sync_throttler,
                    RadosRef local_cluster, int64_t local_pool_id,
                    const peer_t &peer, const std::vector<const char*> &args) :
   m_threads(threads),
   m_image_deleter(image_deleter),
+  m_image_sync_throttler(image_sync_throttler),
   m_lock(stringify("rbd::mirror::Replayer ") + stringify(peer)),
   m_peer(peer),
   m_args(args),
@@ -611,9 +613,9 @@ void Replayer::set_sources(const ImageIds &image_ids)
     auto it = m_image_replayers.find(image_id.id);
     if (it == m_image_replayers.end()) {
       unique_ptr<ImageReplayer<> > image_replayer(new ImageReplayer<>(
-        m_threads, m_image_deleter, m_local, m_remote, local_mirror_uuid,
-        remote_mirror_uuid, m_local_pool_id, m_remote_pool_id, image_id.id,
-        image_id.global_id));
+        m_threads, m_image_deleter, m_image_sync_throttler, m_local, m_remote,
+        local_mirror_uuid, remote_mirror_uuid, m_local_pool_id,
+        m_remote_pool_id, image_id.id, image_id.global_id));
       it = m_image_replayers.insert(
         std::make_pair(image_id.id, std::move(image_replayer))).first;
     }

--- a/src/tools/rbd_mirror/Replayer.h
+++ b/src/tools/rbd_mirror/Replayer.h
@@ -34,6 +34,7 @@ class MirrorStatusWatchCtx;
 class Replayer {
 public:
   Replayer(Threads *threads, std::shared_ptr<ImageDeleter> image_deleter,
+           ImageSyncThrottlerRef<> image_sync_throttler,
            RadosRef local_cluster, int64_t local_pool_id, const peer_t &peer,
            const std::vector<const char*> &args);
   ~Replayer();
@@ -65,6 +66,7 @@ private:
 
   Threads *m_threads;
   std::shared_ptr<ImageDeleter> m_image_deleter;
+  ImageSyncThrottlerRef<> m_image_sync_throttler;
   Mutex m_lock;
   Cond m_cond;
   atomic_t m_stopping;

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -20,6 +20,7 @@
 #include "librbd/journal/Types.h"
 #include "tools/rbd_mirror/ImageSync.h"
 #include "tools/rbd_mirror/ProgressContext.h"
+#include "tools/rbd_mirror/ImageSyncThrottler.h"
 
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
@@ -35,23 +36,26 @@ using librbd::util::create_rados_ack_callback;
 using librbd::util::unique_lock_name;
 
 template <typename I>
-BootstrapRequest<I>::BootstrapRequest(librados::IoCtx &local_io_ctx,
-                                      librados::IoCtx &remote_io_ctx,
-                                      I **local_image_ctx,
-                                      const std::string &local_image_name,
-                                      const std::string &remote_image_id,
-                                      const std::string &global_image_id,
-                                      ContextWQ *work_queue, SafeTimer *timer,
-                                      Mutex *timer_lock,
-                                      const std::string &local_mirror_uuid,
-                                      const std::string &remote_mirror_uuid,
-                                      Journaler *journaler,
-                                      MirrorPeerClientMeta *client_meta,
-                                      Context *on_finish,
-				      rbd::mirror::ProgressContext *progress_ctx)
+BootstrapRequest<I>::BootstrapRequest(
+        librados::IoCtx &local_io_ctx,
+        librados::IoCtx &remote_io_ctx,
+        std::shared_ptr<ImageSyncThrottler<I>> image_sync_throttler,
+        I **local_image_ctx,
+        const std::string &local_image_name,
+        const std::string &remote_image_id,
+        const std::string &global_image_id,
+        ContextWQ *work_queue, SafeTimer *timer,
+        Mutex *timer_lock,
+        const std::string &local_mirror_uuid,
+        const std::string &remote_mirror_uuid,
+        Journaler *journaler,
+        MirrorPeerClientMeta *client_meta,
+        Context *on_finish,
+        rbd::mirror::ProgressContext *progress_ctx)
   : BaseRequest("rbd::mirror::image_replayer::BootstrapRequest",
 		reinterpret_cast<CephContext*>(local_io_ctx.cct()), on_finish),
     m_local_io_ctx(local_io_ctx), m_remote_io_ctx(remote_io_ctx),
+    m_image_sync_throttler(image_sync_throttler),
     m_local_image_ctx(local_image_ctx), m_local_image_name(local_image_name),
     m_remote_image_id(remote_image_id), m_global_image_id(global_image_id),
     m_work_queue(work_queue), m_timer(timer), m_timer_lock(timer_lock),
@@ -63,7 +67,6 @@ BootstrapRequest<I>::BootstrapRequest(librados::IoCtx &local_io_ctx,
 
 template <typename I>
 BootstrapRequest<I>::~BootstrapRequest() {
-  assert(m_image_sync_request == nullptr);
   assert(m_remote_image_ctx == nullptr);
 }
 
@@ -79,9 +82,7 @@ void BootstrapRequest<I>::cancel() {
   Mutex::Locker locker(m_lock);
   m_canceled = true;
 
-  if (m_image_sync_request) {
-    m_image_sync_request->cancel();
-  }
+  m_image_sync_throttler->cancel_sync(m_local_image_id);
 }
 
 template <typename I>
@@ -547,30 +548,18 @@ void BootstrapRequest<I>::image_sync() {
   Context *ctx = create_context_callback<
     BootstrapRequest<I>, &BootstrapRequest<I>::handle_image_sync>(
       this);
-  ImageSync<I> *request = ImageSync<I>::create(*m_local_image_ctx,
-                                               m_remote_image_ctx, m_timer,
-                                               m_timer_lock,
-                                               m_local_mirror_uuid, m_journaler,
-                                               m_client_meta, m_work_queue, ctx,
-					       m_progress_ctx);
-  {
-    Mutex::Locker locker(m_lock);
-    request->get();
-    m_image_sync_request = request;
-  }
 
-  request->send();
+  m_image_sync_throttler->start_sync(*m_local_image_ctx,
+                                     m_remote_image_ctx, m_timer,
+                                     m_timer_lock,
+                                     m_local_mirror_uuid, m_journaler,
+                                     m_client_meta, m_work_queue, ctx,
+                                     m_progress_ctx);
 }
 
 template <typename I>
 void BootstrapRequest<I>::handle_image_sync(int r) {
   dout(20) << ": r=" << r << dendl;
-
-  {
-    Mutex::Locker locker(m_lock);
-    m_image_sync_request->put();
-    m_image_sync_request = nullptr;
-  }
 
   if (m_canceled) {
     dout(10) << ": request canceled" << dendl;

--- a/src/tools/rbd_mirror/types.h
+++ b/src/tools/rbd_mirror/types.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "include/rbd/librbd.hpp"
+#include "ImageSyncThrottler.h"
 
 namespace rbd {
 namespace mirror {
@@ -17,6 +18,9 @@ namespace mirror {
 typedef shared_ptr<librados::Rados> RadosRef;
 typedef shared_ptr<librados::IoCtx> IoCtxRef;
 typedef shared_ptr<librbd::Image> ImageRef;
+
+template <typename I = librbd::ImageCtx>
+using ImageSyncThrottlerRef = std::shared_ptr<ImageSyncThrottler<I>>;
 
 struct peer_t {
   peer_t() = default;


### PR DESCRIPTION

Fixes: http://tracker.ceph.com/issues/15239