### PR TITLE
jewel: rbd-mirror: do not propagate deletions when pool unavailable

### DIFF
--- a/src/tools/rbd_mirror/PoolWatcher.h
+++ b/src/tools/rbd_mirror/PoolWatcher.h
@@ -64,7 +64,7 @@ private:
 
   ImageIds m_images;
 
-  void refresh(ImageIds *image_ids);
+  int refresh(ImageIds *image_ids);
 };
 
 } // namespace mirror


### PR DESCRIPTION
http://tracker.ceph.com/issues/16233