### PR TITLE
osdc/ObjectCacher.h: delete copy constr and assign

### DIFF
--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -250,8 +250,8 @@ class ObjectCacher {
     map< ceph_tid_t, list<Context*> > waitfor_commit;
     xlist<C_ReadFinish*> reads;
 
-    Object(const Object& other);
-    const Object& operator=(const Object& other);
+    Object(const Object&) = delete;
+    Object& operator=(const Object&) = delete;
 
     Object(ObjectCacher *_oc, sobject_t o, uint64_t ono, ObjectSet *os,
 	   object_locator_t& l, uint64_t ts, uint64_t tq) :


### PR DESCRIPTION
Delete copy constructor and assignment operator, so the checking can
be moved from linking to compile time - as it was when the above
where only declared, but not defined.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>