### PR TITLE
os/bluestore: Add an option to choose bluefs direct or buffered io mode

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -934,6 +934,7 @@ OPTION(bluestore_bluefs_min_ratio, OPT_FLOAT, .02)  // min fs free / total free
 OPTION(bluestore_bluefs_max_ratio, OPT_FLOAT, .90)  // max fs free / total free
 OPTION(bluestore_bluefs_gift_ratio, OPT_FLOAT, .02) // how much to add at a time
 OPTION(bluestore_bluefs_reclaim_ratio, OPT_FLOAT, .20) // how much to reclaim at a time
+OPTION(bluestore_bluefs_buffered_io, OPT_BOOL, true)
 // If you want to use spdk driver, you need to specify NVMe serial number here
 // with "spdk:" prefix.
 // Users can use 'lspci -vvv -d 8086:0953 | grep "Device Serial Number"' to

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -740,7 +740,8 @@ int BlueFS::_read_random(
     }
     dout(20) << __func__ << " read buffered " << x_off << "~" << l << " of "
 	       << *p << dendl;
-    int r = bdev[p->bdev]->read_random(p->offset + x_off, l, out, false);
+    int r = bdev[p->bdev]->read_random(p->offset + x_off, l, out,
+				       g_conf->bluestore_bluefs_buffered_io);
     assert(r == 0);
     off += l;
     len -= l;
@@ -799,7 +800,7 @@ int BlueFS::_read(
       dout(20) << __func__ << " fetching " << x_off << "~" << l << " of "
 	       << *p << dendl;
       int r = bdev[p->bdev]->read(p->offset + x_off, l, &buf->bl, ioc[p->bdev],
-				  false);
+				  g_conf->bluestore_bluefs_buffered_io);
       assert(r == 0);
     }
     left = buf->get_buf_remaining(off);
@@ -1123,7 +1124,8 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
       h->tail_block.substr_of(bl, bl.length() - tail, tail);
       t.append_zero(super.block_size - tail);
     }
-    bdev[p->bdev]->aio_write(p->offset + x_off, t, h->iocv[p->bdev], false);
+    bdev[p->bdev]->aio_write(p->offset + x_off, t, h->iocv[p->bdev],
+			     g_conf->bluestore_bluefs_buffered_io);
     bloff += x_len;
     length -= x_len;
     ++p;


### PR DESCRIPTION
For now, set default to buffered io; after rocksdb block cache
has ability to cache writes, we will set default to direct io.

For more info, see
https://github.com/ceph/ceph/pull/9533