### PR TITLE
DNM: bluefs: drop lock during log compaction

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1217,6 +1217,7 @@ void BlueFS::_pad_bl(bufferlist& bl)
 
 void BlueFS::flush_log()
 {
+  std::lock_guard<std::mutex> l(lock);
   _flush_log();
 }
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -275,6 +275,7 @@ public:
   int mkfs(uuid_d osd_uuid);
   int mount();
   void umount();
+  void dump_logfile(ostream &out);
 
   int fsck();
 
@@ -320,6 +321,8 @@ public:
 
   /// sync any uncommitted state to disk
   int sync();
+  void flush_log();
+  void compact_log();
 
   void sync_metadata();
 


### PR DESCRIPTION
1. Reorg the compaction process to allow frontend threads to work concurrently with log compaction. Log file is still protected by a global lock.
2. Added utility function to dump the log file contents.
3. Added some test cases to test compaction and read/write files.

Passed make check and unittest_bluefs with new test cases.
Signed-off-by: Varada Kari <varada.kari@sandisk.com>