### PR TITLE
server: fix potential access violation

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1426,14 +1426,16 @@ void Server::handle_client_request(MClientRequest *req)
 
   // register + dispatch
   MDRequestRef mdr = mdcache->request_start(req);
-  if (mdr.get()) {
-    if (session) {
-      mdr->session = session;
-      session->requests.push_back(&mdr->item_session_request);
-    }
-    if (has_completed)
-      mdr->has_completed = true;
+  if (!mdr.get())
+    return;
+
+  if (session) {
+    mdr->session = session;
+    session->requests.push_back(&mdr->item_session_request);
   }
+
+  if (has_completed)
+    mdr->has_completed = true;
 
   // process embedded cap releases?
   //  (only if NOT replay!)
@@ -1446,8 +1448,7 @@ void Server::handle_client_request(MClientRequest *req)
     req->releases.clear();
   }
 
-  if (mdr.get())
-    dispatch_client_request(mdr);
+  dispatch_client_request(mdr);
   return;
 }
 


### PR DESCRIPTION
The mdcache->request_start() method may lose the forward race
against a slave and thus may either drop the last reference of the
passed in message or push the message into the waiting_for_finish
list for a later retry.

In either case we shall stall and exit, otherwise we'll access
violation especifally for the former case(as we drop the last
reference of "req" and it shall be destructed by now).

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>