### PR TITLE
mds: fix mdsmap->get_metadata_pool() return to int64_t

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8077,7 +8077,7 @@ void MDCache::open_remote_dentry(CDentry *dn, bool projected, MDSInternalContext
   dout(10) << "open_remote_dentry " << *dn << dendl;
   CDentry::linkage_t *dnl = projected ? dn->get_projected_linkage() : dn->get_linkage();
   inodeno_t ino = dnl->get_remote_ino();
-  uint64_t pool = dnl->get_remote_d_type() == DT_DIR ? mds->mdsmap->get_metadata_pool() : -1;
+  int64_t pool = dnl->get_remote_d_type() == DT_DIR ? mds->mdsmap->get_metadata_pool() : -1;
   open_ino(ino, pool,
       new C_MDC_OpenRemoteDentry(this, dn, ino, fin, want_xlocked), true, want_xlocked); // backtrace
 }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -270,7 +270,7 @@ class C_MDS_VoidFn : public MDSInternalContext
   }
 };
 
-uint64_t MDSRank::get_metadata_pool()
+int64_t MDSRank::get_metadata_pool()
 {
     return mdsmap->get_metadata_pool();
 }

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -125,7 +125,7 @@ class MDSRank {
 
   public:
     mds_rank_t get_nodeid() const { return whoami; }
-    uint64_t get_metadata_pool();
+    int64_t get_metadata_pool();
 
     // Reference to global MDS::mds_lock, so that users of MDSRank don't
     // carry around references to the outer MDS, and we can substitute

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -278,7 +278,7 @@ int DataScan::main(const std::vector<const char*> &args)
       std::cerr << "Filesystem id " << fscid << " does not exist" << std::endl;
       return -ENOENT;
     }
-    int const metadata_pool_id = fs->mds_map.get_metadata_pool();
+    int64_t const metadata_pool_id = fs->mds_map.get_metadata_pool();
 
     dout(4) << "resolving metadata pool " << metadata_pool_id << dendl;
     std::string metadata_pool_name;
@@ -1576,7 +1576,7 @@ int MetadataDriver::init(
 {
   auto fs =  fsmap->get_filesystem(fscid);
   assert(fs != nullptr);
-  int const metadata_pool_id = fs->mds_map.get_metadata_pool();
+  int64_t const metadata_pool_id = fs->mds_map.get_metadata_pool();
 
   dout(4) << "resolving metadata pool " << metadata_pool_id << dendl;
   std::string metadata_pool_name;

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -116,7 +116,7 @@ int JournalTool::main(std::vector<const char*> &argv)
  
   auto fs = fsmap->get_filesystem(role_selector.get_ns());
   assert(fs != nullptr);
-  int const pool_id = fs->mds_map.get_metadata_pool();
+  int64_t const pool_id = fs->mds_map.get_metadata_pool();
   dout(4) << "JournalTool: resolving pool " << pool_id << dendl;
   std::string pool_name;
   r = rados.pool_reverse_lookup(pool_id, &pool_name);

--- a/src/tools/cephfs/Resetter.cc
+++ b/src/tools/cephfs/Resetter.cc
@@ -34,7 +34,7 @@ int Resetter::reset(mds_role_t role)
 
   auto fs =  fsmap->get_filesystem(role.fscid);
   assert(fs != nullptr);
-  int const pool_id = fs->mds_map.get_metadata_pool();
+  int64_t const pool_id = fs->mds_map.get_metadata_pool();
 
   JournalPointer jp(role.rank, pool_id);
   int jp_load_result = jp.load(objecter);
@@ -117,7 +117,7 @@ int Resetter::reset_hard(mds_role_t role)
 {
   auto fs =  fsmap->get_filesystem(role.fscid);
   assert(fs != nullptr);
-  int const pool_id = fs->mds_map.get_metadata_pool();
+  int64_t const pool_id = fs->mds_map.get_metadata_pool();
 
   JournalPointer jp(role.rank, pool_id);
   jp.front = role.rank + MDS_INO_LOG_OFFSET;

--- a/src/tools/cephfs/TableTool.cc
+++ b/src/tools/cephfs/TableTool.cc
@@ -332,7 +332,7 @@ int TableTool::main(std::vector<const char*> &argv)
 
   auto fs =  fsmap->get_filesystem(role_selector.get_ns());
   assert(fs != nullptr);
-  int const pool_id = fs->mds_map.get_metadata_pool();
+  int64_t const pool_id = fs->mds_map.get_metadata_pool();
   dout(4) << "resolving pool " << pool_id << dendl;
   std::string pool_name;
   r = rados.pool_reverse_lookup(pool_id, &pool_name);


### PR DESCRIPTION
if dnl->get_remote_d_type() == DT_DIR not establish, then pool = -1
so the type of pool should be int64_t not uint64_t

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>