### PR TITLE
Jewel mds: order directories by hash and fix simultaneous readdir races

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1118,10 +1118,7 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session, 
     if (fg != dst.frag) {
       ldout(cct, 10) << "insert_trace got new frag " << fg << " -> " << dst.frag << dendl;
       fg = dst.frag;
-      if (fg.is_leftmost())
-	readdir_offset = 2;
-      else
-	readdir_offset = 0;
+      readdir_offset = 2;
       readdir_start.clear();
     }
 
@@ -6851,8 +6848,6 @@ void Client::seekdir(dir_result_t *dirp, loff_t offset)
     d->release_count--;   // bump if we do a forward seek
 
   d->offset = offset;
-  if (!d->frag().is_leftmost() && d->next_offset == 2)
-    d->next_offset = 0;  // not 2 on non-leftmost frags!
 }
 
 
@@ -6968,10 +6963,7 @@ int Client::_readdir_get_frag(dir_result_t *dirp)
 
     if (fg != req->readdir_reply_frag) {
       fg = req->readdir_reply_frag;
-      if (fg.is_leftmost())
-	dirp->next_offset = 2;
-      else
-	dirp->next_offset = 0;
+      dirp->next_offset = 2;
       dirp->offset = dir_result_t::make_fpos(fg, dirp->next_offset);
     }
     dirp->buffer_frag = fg;
@@ -6982,10 +6974,7 @@ int Client::_readdir_get_frag(dir_result_t *dirp)
 
     if (req->readdir_end) {
       dirp->last_name.clear();
-      if (fg.is_rightmost())
-	dirp->next_offset = 2;
-      else
-	dirp->next_offset = 0;
+      dirp->next_offset = 2;
     } else {
       dirp->last_name = req->readdir_last_name;
       dirp->next_offset += req->readdir_num;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1107,10 +1107,11 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session, 
     // dirstat
     DirStat dst(p);
     __u32 numdn;
-    __u8 complete, end;
+    __u16 flags;
     ::decode(numdn, p);
-    ::decode(end, p);
-    ::decode(complete, p);
+    ::decode(flags, p);
+
+    bool end = ((unsigned)flags & CEPH_READDIR_FRAG_END);
 
     frag_t fg = (unsigned)request->head.args.readdir.frag;
     uint64_t readdir_offset = dirp->next_offset;
@@ -1124,7 +1125,7 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session, 
       dirp->offset = dir_result_t::make_fpos(fg, readdir_offset);
     }
 
-    ldout(cct, 10) << __func__ << " " << numdn << " readdir items, end=" << (int)end
+    ldout(cct, 10) << __func__ << " " << numdn << " readdir items, end=" << end
 		   << ", offset " << readdir_offset
 		   << ", readdir_start " << readdir_start << dendl;
 
@@ -6943,6 +6944,7 @@ int Client::_readdir_get_frag(dir_result_t *dirp)
   req->set_filepath(path); 
   req->set_inode(diri.get());
   req->head.args.readdir.frag = fg;
+  req->head.args.readdir.flags = CEPH_READDIR_REPLY_BITFLAGS;
   if (dirp->last_name.length()) {
     req->path2.set_path(dirp->last_name.c_str());
   }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6991,8 +6991,12 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p)
     if (it == dir->dentries.end())
       return -EAGAIN;
     Dentry *dn = it->second;
+    assert(dir_result_t::fpos_cmp(dn->offset, dirp->offset) < 0);
     pd = xlist<Dentry*>::iterator(&dn->item_dentry_list);
     ++pd;
+    while (!pd.end() &&
+	   dir_result_t::fpos_cmp((*pd)->offset, dirp->offset) < 0)
+      ++pd;
   }
 
   string dn_name;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -189,7 +189,7 @@ struct dir_result_t {
   int start_shared_gen;  // dir shared_gen at start of readdir
 
   frag_t buffer_frag;
-  vector<pair<string,InodeRef> > *buffer;
+  vector<pair<string,InodeRef> > buffer;
 
   string at_cache_name;  // last entry we successfully returned
 
@@ -218,8 +218,7 @@ struct dir_result_t {
     next_offset = 2;
     this_offset = 0;
     offset = 0;
-    delete buffer;
-    buffer = 0;
+    buffer.clear();
   }
 };
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -205,6 +205,7 @@ struct dir_result_t {
 
   uint64_t release_count;
   uint64_t ordered_count;
+  unsigned cache_index;
   int start_shared_gen;  // dir shared_gen at start of readdir
 
   frag_t buffer_frag;
@@ -223,8 +224,6 @@ struct dir_result_t {
     }
   };
   vector<dentry> buffer;
-
-  string at_cache_name;  // last entry we successfully returned
 
   explicit dir_result_t(Inode *in);
 
@@ -249,9 +248,10 @@ struct dir_result_t {
 
   void reset() {
     last_name.clear();
-    at_cache_name.clear();
     next_offset = 2;
     offset = 0;
+    ordered_count = 0;
+    cache_index = 0;
     buffer.clear();
   }
 };
@@ -696,6 +696,7 @@ protected:
   // metadata cache
   void update_dir_dist(Inode *in, DirStat *st);
 
+  void clear_dir_complete_and_ordered(Inode *diri, bool complete);
   void insert_readdir_results(MetaRequest *request, MetaSession *session, Inode *diri);
   Inode* insert_trace(MetaRequest *request, MetaSession *session);
   void update_inode_file_bits(Inode *in,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -172,6 +172,14 @@ struct dir_result_t {
   static unsigned fpos_off(uint64_t p) {
     return p & MASK;
   }
+  static int fpos_cmp(uint64_t l, uint64_t r) {
+    int c = ceph_frag_compare(fpos_high(l), fpos_high(r));
+    if (c)
+      return c;
+    if (fpos_low(l) == fpos_low(r))
+      return 0;
+    return fpos_low(l) < fpos_low(r) ? -1 : 1;
+  }
 
 
   InodeRef inode;

--- a/src/client/Dentry.h
+++ b/src/client/Dentry.h
@@ -17,7 +17,7 @@ class Dentry : public LRUObject {
   Dir	   *dir;
   InodeRef inode;
   int	   ref;                       // 1 if there's a dir beneath me.
-  uint64_t offset;
+  int64_t offset;
   mds_rank_t lease_mds;
   utime_t lease_ttl;
   uint64_t lease_gen;

--- a/src/client/Dentry.h
+++ b/src/client/Dentry.h
@@ -24,8 +24,6 @@ class Dentry : public LRUObject {
   ceph_seq_t lease_seq;
   int cap_shared_gen;
 
-  xlist<Dentry*>::item item_dentry_list;
-
   /*
    * ref==1 -> cached, unused
    * ref >1 -> pinned in lru
@@ -49,8 +47,8 @@ class Dentry : public LRUObject {
 
   Dentry() :
     dir(0), ref(1), offset(0),
-    lease_mds(-1), lease_gen(0), lease_seq(0), cap_shared_gen(0),
-    item_dentry_list(this)  { }
+    lease_mds(-1), lease_gen(0), lease_seq(0), cap_shared_gen(0)
+  { }
 private:
   ~Dentry() {
     assert(ref == 0);

--- a/src/client/Dir.h
+++ b/src/client/Dir.h
@@ -7,7 +7,7 @@ class Dir {
  public:
   Inode    *parent_inode;  // my inode
   ceph::unordered_map<string, Dentry*> dentries;
-  xlist<Dentry*> dentry_list;
+  vector<Dentry*> readdir_cache;
 
   explicit Dir(Inode* in) { parent_inode = in; }
 

--- a/src/client/Dir.h
+++ b/src/client/Dir.h
@@ -8,10 +8,8 @@ class Dir {
   Inode    *parent_inode;  // my inode
   ceph::unordered_map<string, Dentry*> dentries;
   xlist<Dentry*> dentry_list;
-  uint64_t release_count;
-  uint64_t ordered_count;
 
-  explicit Dir(Inode* in) : release_count(0), ordered_count(0) { parent_inode = in; }
+  explicit Dir(Inode* in) { parent_inode = in; }
 
   bool is_empty() {  return dentries.empty(); }
 };

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -302,7 +302,7 @@ struct Inode {
       size(0), truncate_seq(1), truncate_size(-1),
       time_warp_seq(0), max_size(0), version(0), xattr_version(0),
       inline_version(0), flags(0), qtree(NULL),
-      dir(0), dir_release_count(0), dir_ordered_count(0),
+      dir(0), dir_release_count(1), dir_ordered_count(1),
       dir_hashed(false), dir_replicated(false), auth_cap(NULL),
       cap_dirtier_uid(-1), cap_dirtier_gid(-1),
       dirty_caps(0), flushing_caps(0), shared_gen(0), cache_gen(0),

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -226,8 +226,11 @@ struct Inode {
   }
 
   // about the dir (if this is one!)
+  Dir       *dir;     // if i'm a dir.
+  fragtree_t dirfragtree;
   set<int>  dir_contacts;
-  bool      dir_hashed, dir_replicated;
+  uint64_t dir_release_count, dir_ordered_count;
+  bool dir_hashed, dir_replicated;
 
   // per-mds caps
   map<mds_rank_t, Cap*> caps;            // mds -> Cap
@@ -256,10 +259,8 @@ struct Inode {
 
   int       _ref;      // ref count. 1 for each dentry, fh that links to me.
   int       ll_ref;   // separate ref count for ll client
-  Dir       *dir;     // if i'm a dir.
   set<Dentry*> dn_set;      // if i'm linked to a dentry.
   string    symlink;  // symlink content, if it's a symlink
-  fragtree_t dirfragtree;
   map<string,bufferptr> xattrs;
   map<frag_t,int> fragmap;  // known frag -> mds mappings
 
@@ -300,9 +301,8 @@ struct Inode {
       rdev(0), mode(0), uid(0), gid(0), nlink(0),
       size(0), truncate_seq(1), truncate_size(-1),
       time_warp_seq(0), max_size(0), version(0), xattr_version(0),
-      inline_version(0),
-      flags(0),
-      qtree(NULL),
+      inline_version(0), flags(0), qtree(NULL),
+      dir(0), dir_release_count(0), dir_ordered_count(0),
       dir_hashed(false), dir_replicated(false), auth_cap(NULL),
       cap_dirtier_uid(-1), cap_dirtier_gid(-1),
       dirty_caps(0), flushing_caps(0), shared_gen(0), cache_gen(0),
@@ -311,7 +311,7 @@ struct Inode {
       snaprealm(0), snaprealm_item(this),
       oset((void *)this, newlayout->pool_id, ino),
       reported_size(0), wanted_max_size(0), requested_max_size(0),
-      _ref(0), ll_ref(0), dir(0), dn_set(),
+      _ref(0), ll_ref(0), dn_set(),
       fcntl_locks(NULL), flock_locks(NULL),
       async_err(0)
   {

--- a/src/client/MetaRequest.cc
+++ b/src/client/MetaRequest.cc
@@ -37,13 +37,6 @@ void MetaRequest::dump(Formatter *f) const
 
   f->dump_int("got_unsafe", got_unsafe);
 
-  if (head.op == CEPH_MDS_OP_READDIR ||
-      head.op == CEPH_MDS_OP_LSSNAP) {
-    f->dump_stream("readdir_frag") << readdir_frag;
-    f->dump_string("readdir_start", readdir_start);
-    f->dump_unsigned("readdir_offset", readdir_offset);
-  }
-
   f->dump_unsigned("uid", head.caller_uid);
   f->dump_unsigned("gid", head.caller_gid);
 

--- a/src/client/MetaRequest.h
+++ b/src/client/MetaRequest.h
@@ -19,6 +19,7 @@
 
 class MClientReply;
 class Dentry;
+class dir_result_t;
 
 struct MetaRequest {
 private:
@@ -56,15 +57,7 @@ public:
   bool success;
   
   // readdir result
-  frag_t readdir_frag;
-  string readdir_start;  // starting _after_ this name
-  uint64_t readdir_offset;
-
-  frag_t readdir_reply_frag;
-  vector<pair<string,InodeRef> > readdir_result;
-  bool readdir_end;
-  int readdir_num;
-  string readdir_last_name;
+  dir_result_t *dirp;
 
   //possible responses
   bool got_unsafe;
@@ -93,7 +86,6 @@ public:
     num_fwd(0), retry_attempt(0),
     ref(1), reply(0), 
     kick(false), success(false),
-    readdir_offset(0), readdir_end(false), readdir_num(0),
     got_unsafe(false), item(this), unsafe_item(this),
     unsafe_dir_item(this), unsafe_target_item(this),
     caller_cond(0), dispatch_cond(0) {

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -387,6 +387,17 @@ extern const char *ceph_mds_op_name(int op);
 #define CEPH_XATTR_REPLACE (1 << 1)
 #define CEPH_XATTR_REMOVE  (1 << 31)
 
+/*
+ * readdir request flags;
+ */
+#define CEPH_READDIR_REPLY_BITFLAGS	(1<<0)
+
+/*
+ * readdir reply flags.
+ */
+#define CEPH_READDIR_FRAG_END		(1<<0)
+#define CEPH_READDIR_FRAG_COMPLETE	(1<<8)
+
 union ceph_mds_request_args {
 	struct {
 		__le32 mask;                 /* CEPH_CAP_* */
@@ -404,6 +415,7 @@ union ceph_mds_request_args {
 		__le32 frag;                 /* which dir fragment */
 		__le32 max_entries;          /* how many dentries to grab */
 		__le32 max_bytes;
+		__le16 flags;
 	} __attribute__ ((packed)) readdir;
 	struct {
 		__le32 mode;

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -397,6 +397,7 @@ extern const char *ceph_mds_op_name(int op);
  */
 #define CEPH_READDIR_FRAG_END		(1<<0)
 #define CEPH_READDIR_FRAG_COMPLETE	(1<<8)
+#define CEPH_READDIR_HASH_ORDER		(1<<9)
 
 union ceph_mds_request_args {
 	struct {

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -110,7 +110,7 @@ public:
   snapid_t first, last;
 
   dentry_key_t key() { 
-    return dentry_key_t(last, name.c_str()); 
+    return dentry_key_t(last, name.c_str(), hash);
   }
 
 public:

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -295,10 +295,11 @@ bool CDir::check_rstats(bool scrub)
   return good;
 }
 
-CDentry *CDir::lookup(const char *name, snapid_t snap)
+CDentry *CDir::lookup(const string& name, snapid_t snap)
 { 
   dout(20) << "lookup (" << snap << ", '" << name << "')" << dendl;
-  map_t::iterator iter = items.lower_bound(dentry_key_t(snap, name));
+  map_t::iterator iter = items.lower_bound(dentry_key_t(snap, name.c_str(),
+							inode->hash_dentry_name(name)));
   if (iter == items.end())
     return 0;
   if (iter->second->name == name &&
@@ -310,9 +311,13 @@ CDentry *CDir::lookup(const char *name, snapid_t snap)
   return 0;
 }
 
-
-
-
+CDentry *CDir::lookup_exact_snap(const string& name, snapid_t last) {
+  map_t::iterator p = items.find(dentry_key_t(last, name.c_str(),
+					      inode->hash_dentry_name(name)));
+  if (p == items.end())
+    return NULL;
+  return p->second;
+}
 
 /***
  * linking fun

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -448,16 +448,11 @@ protected:
 
   // -- dentries and inodes --
  public:
-  CDentry* lookup_exact_snap(const std::string& dname, snapid_t last) {
-    map_t::iterator p = items.find(dentry_key_t(last, dname.c_str()));
-    if (p == items.end())
-      return NULL;
-    return p->second;
+  CDentry* lookup_exact_snap(const std::string& dname, snapid_t last);
+  CDentry* lookup(const std::string& n, snapid_t snap=CEPH_NOSNAP);
+  CDentry* lookup(const char *n, snapid_t snap=CEPH_NOSNAP) {
+    return lookup(std::string(n), snap);
   }
-  CDentry* lookup(const std::string& n, snapid_t snap=CEPH_NOSNAP) {
-    return lookup(n.c_str(), snap);
-  }
-  CDentry* lookup(const char *n, snapid_t snap=CEPH_NOSNAP);
 
   CDentry* add_null_dentry(const std::string& dname, 
 			   snapid_t first=2, snapid_t last=CEPH_NOSNAP);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -4558,6 +4558,7 @@ CDir *MDCache::rejoin_invent_dirfrag(dirfrag_t df)
   if (!in->is_dir()) {
     assert(in->state_test(CInode::STATE_REJOINUNDEF));
     in->inode.mode = S_IFDIR;
+    in->inode.dir_layout.dl_dir_hash = g_conf->mds_default_dir_hash;
   }
   CDir *dir = in->get_or_open_dirfrag(this, df.frag);
   dir->state_set(CDir::STATE_REJOINUNDEF);
@@ -5753,6 +5754,8 @@ void MDCache::opened_undef_inode(CInode *in) {
   dout(10) << "opened_undef_inode " << *in << dendl;
   rejoin_undef_inodes.erase(in);
   if (in->is_dir()) {
+    // FIXME: re-hash dentries if necessary
+    assert(in->inode.dir_layout.dl_dir_hash == g_conf->mds_default_dir_hash);
     if (in->has_dirfrags() && !in->dirfragtree.is_leaf(frag_t())) {
       CDir *dir = in->get_dirfrag(frag_t());
       assert(dir);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3446,6 +3446,7 @@ void Server::handle_client_readdir(MDRequestRef& mdr)
   }
   // client only understand END and COMPLETE flags ?
   if (req_flags & CEPH_READDIR_REPLY_BITFLAGS) {
+    flags |= CEPH_READDIR_HASH_ORDER;
   }
   
   // finish final blob


### PR DESCRIPTION
http://tracker.ceph.com/issues/16251

Ordering directories by hash makes readdir stable across directory fragmentation, and allows
an easier fix for racing readdirs on the client side.