### PR TITLE
Jewel client: fix bugs accidentally disabling readahead

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8080,8 +8080,9 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl)
     len = in->size - off;    
   }
 
-  ldout(cct, 10) << " max_bytes=" << conf->client_readahead_max_bytes
-		 << " max_periods=" << conf->client_readahead_max_periods << dendl;
+  ldout(cct, 10) << " min_bytes=" << f->readahead.get_min_readahead_size()
+                 << " max_bytes=" << f->readahead.get_max_readahead_size()
+                 << " max_periods=" << conf->client_readahead_max_periods << dendl;
 
   // read (and possibly block)
   int r, rvalue = 0;
@@ -8106,7 +8107,7 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl)
     delete onfinish;
   }
 
-  if(conf->client_readahead_max_bytes > 0) {
+  if(f->readahead.get_min_readahead_size() > 0) {
     pair<uint64_t, uint64_t> readahead_extent = f->readahead.update(off, len, in->size);
     if (readahead_extent.second > 0) {
       ldout(cct, 20) << "readahead " << readahead_extent.first << "~" << readahead_extent.second

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7635,7 +7635,6 @@ Fh *Client::_create_fh(Inode *in, int flags, int cmode)
   }
 
   const md_config_t *conf = cct->_conf;
-  loff_t p = in->layout.stripe_count * in->layout.object_size;
   f->readahead.set_trigger_requests(1);
   f->readahead.set_min_readahead_size(conf->client_readahead_min);
   uint64_t max_readahead = Readahead::NO_LIMIT;
@@ -7643,11 +7642,11 @@ Fh *Client::_create_fh(Inode *in, int flags, int cmode)
     max_readahead = MIN(max_readahead, (uint64_t)conf->client_readahead_max_bytes);
   }
   if (conf->client_readahead_max_periods) {
-    max_readahead = MIN(max_readahead, ((uint64_t)conf->client_readahead_max_periods) * p);
+    max_readahead = MIN(max_readahead, in->layout.get_period()*(uint64_t)conf->client_readahead_max_periods);
   }
   f->readahead.set_max_readahead_size(max_readahead);
   vector<uint64_t> alignments;
-  alignments.push_back(p);
+  alignments.push_back(in->layout.get_period());
   alignments.push_back(in->layout.stripe_unit);
   f->readahead.set_alignments(alignments);
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -713,6 +713,7 @@ private:
     Client *client;
     Fh *f;
     C_Readahead(Client *c, Fh *f);
+    ~C_Readahead();
     void finish(int r);
   };
 

--- a/src/common/Readahead.cc
+++ b/src/common/Readahead.cc
@@ -168,6 +168,16 @@ void Readahead::set_trigger_requests(int trigger_requests) {
   m_lock.Unlock();
 }
 
+uint64_t Readahead::get_min_readahead_size(void) {
+  Mutex::Locker lock(m_lock);
+  return m_readahead_min_bytes;
+}
+
+uint64_t Readahead::get_max_readahead_size(void) {
+  Mutex::Locker lock(m_lock);
+  return m_readahead_max_bytes;
+}
+
 void Readahead::set_min_readahead_size(uint64_t min_readahead_size) {
   m_lock.Lock();
   m_readahead_min_bytes = min_readahead_size;

--- a/src/common/Readahead.h
+++ b/src/common/Readahead.h
@@ -79,6 +79,16 @@ public:
   void set_trigger_requests(int trigger_requests);
 
   /**
+     Gets the minimum size of a readahead request, in bytes.
+   */
+  uint64_t get_min_readahead_size(void);
+
+  /**
+     Gets the maximum size of a readahead request, in bytes.
+   */
+  uint64_t get_max_readahead_size(void);
+
+  /**
      Sets the minimum size of a readahead request, in bytes.
    */
   void set_min_readahead_size(uint64_t min_readahead_size);

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -371,7 +371,7 @@ OPTION(client_mount_timeout, OPT_DOUBLE, 300.0)
 OPTION(client_tick_interval, OPT_DOUBLE, 1.0)
 OPTION(client_trace, OPT_STR, "")
 OPTION(client_readahead_min, OPT_LONGLONG, 128*1024)  // readahead at _least_ this much.
-OPTION(client_readahead_max_bytes, OPT_LONGLONG, 0)  //8 * 1024*1024
+OPTION(client_readahead_max_bytes, OPT_LONGLONG, 0)  // default unlimited
 OPTION(client_readahead_max_periods, OPT_LONGLONG, 4)  // as multiple of file layout period (object size * num stripes)
 OPTION(client_snapdir, OPT_STR, ".snap")
 OPTION(client_mountpoint, OPT_STR, "/")

--- a/src/osdc/Striper.cc
+++ b/src/osdc/Striper.cc
@@ -241,10 +241,9 @@ uint64_t Striper::object_truncate_size(CephContext *cct,
 uint64_t Striper::get_num_objects(const file_layout_t& layout,
 				  uint64_t size)
 {
-  __u32 object_size = layout.object_size;
   __u32 stripe_unit = layout.stripe_unit;
   __u32 stripe_count = layout.stripe_count;
-  uint64_t period = (uint64_t)stripe_count * object_size;
+  uint64_t period = layout.get_period();
   uint64_t num_periods = (size + period - 1) / period;
   uint64_t remainder_bytes = size % period;
   uint64_t remainder_objs = 0;


### PR DESCRIPTION
http://tracker.ceph.com/issues/16252

A change to the readahead algorithms erroneously disabled it entirely, and leaked a reference. This PR fixes both.