### PR TITLE
doc: fix typo for rbd-mirroring

### DIFF
--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -251,7 +251,7 @@ To request the mirror pool summary status with ``rbd``, specify the
 
 For example::
 
-        rbd mirror image status image-pool
+        rbd mirror pool status image-pool
 
 .. note:: Adding ``--verbose`` option to the ``mirror pool status`` command will
    additionally output status details for every mirroring image in the pool.


### PR DESCRIPTION
the example for command `rbd mirror pool status` should be `rbd mirror pool status image-pool` instead of `rbd mirror image status image-pool`

Signed-off-by: runsisi <runsisi@zte.com.cn>