### PR TITLE
librbd: Check image_watcher before sending update

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -1020,14 +1020,18 @@ struct C_InvalidateCache : public Context {
   void ImageCtx::notify_update() {
     state->handle_update_notification();
 
-    C_SaferCond ctx;
-    image_watcher->notify_header_update(&ctx);
-    ctx.wait();
+    if (image_watcher != NULL) {
+      C_SaferCond ctx;
+      image_watcher->notify_header_update(&ctx);
+      ctx.wait();
+    }
   }
 
   void ImageCtx::notify_update(Context *on_finish) {
     state->handle_update_notification();
-    image_watcher->notify_header_update(on_finish);
+    if (image_watcher != NULL) {
+      image_watcher->notify_header_update(on_finish);
+    }
   }
 
   exclusive_lock::Policy *ImageCtx::get_exclusive_lock_policy() const {


### PR DESCRIPTION
This fixes https://github.com/ceph/go-ceph/issues/20  
  rbd_open didn't initialize image_wathcer which will be used later for notification.
  It will cause go-ceph client crash.

Signed-off-by: Ren Li <sqallowlee@gmail.com>