### PR TITLE
server: set terminating_sessions flag correctly

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -453,7 +453,7 @@ void Server::_session_logged(Session *session, uint64_t state_seq, bool open, ve
       // ms_handle_remote_reset() and realize they had in fact closed.
       // do this *before* sending the message to avoid a possible
       // race.
-      if (session->connection != NULL) {;
+      if (session->connection != NULL) {
         // Conditional because terminate_sessions will indiscrimately
         // put sessions in CLOSING whether they ever had a conn or not.
         session->connection->mark_disposable();

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3495,7 +3495,7 @@ void Server::handle_client_readdir(MDRequestRef& mdr)
 	   << " complete=" << (int)complete << dendl;
 
   // bump popularity.  NOTE: this doesn't quite capture it.
-  mds->balancer->hit_dir(ceph_clock_now(g_ceph_context), dir, META_POP_IRD, -1, numfiles);
+  mds->balancer->hit_dir(now, dir, META_POP_IRD, -1, numfiles);
   
   // reply
   mdr->tracei = diri;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -571,6 +571,8 @@ void Server::terminate_sessions()
 {
   dout(2) << "terminate_sessions" << dendl;
 
+  terminating_sessions = true;
+
   // kill them off.  clients will retry etc.
   set<Session*> sessions;
   mds->sessionmap.get_client_session_set(sessions);

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -433,6 +433,12 @@ public:
                        loaded_legacy(false)
   { }
 
+  ~SessionMap()
+  {
+    for (auto p : by_state)
+      delete p.second;
+  }
+
   void set_version(const version_t v)
   {
     version = projected = v;

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -186,7 +186,7 @@ public:
     ++importing_count;
   }
   void dec_importing() {
-    assert(importing_count);
+    assert(importing_count > 0);
     --importing_count;
   }
   bool is_importing() { return importing_count > 0; }


### PR DESCRIPTION
So caller won't call terminate_sessions() multiple times.
    
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>
