### PR TITLE
os/bluestore: Fix for bit_alloc unit test case stack size and handle device that has less than block size at end.

### DIFF
--- a/src/os/bluestore/BitAllocator.cc
+++ b/src/os/bluestore/BitAllocator.cc
@@ -842,7 +842,7 @@ bool BitMapAreaIN::is_allocated(int64_t start_block, int64_t num_blocks)
     area = (BitMapArea *) m_child_list->get_nth_item(
                     start_block / m_child_size_blocks);
 
-    area_block_offset = start_block % area->size();
+    area_block_offset = start_block % m_child_size_blocks;
     falling_in_area = MIN(m_child_size_blocks - area_block_offset,
               num_blocks);
     if (!area->is_allocated(area_block_offset, falling_in_area)) {
@@ -1214,15 +1214,13 @@ BitAllocator::BitAllocator(int64_t total_blocks, int64_t zone_size_block, bmap_a
 }
 
 BitAllocator::BitAllocator(int64_t total_blocks, int64_t zone_size_block,
-         bmap_alloc_mode_t mode, bool def):
-  BitMapAreaIN(total_blocks, zone_size_block, def)
+         bmap_alloc_mode_t mode, bool def)
 {
   init_check(total_blocks, zone_size_block, mode, def, false);
 }
 
 BitAllocator::BitAllocator(int64_t total_blocks, int64_t zone_size_block,
-         bmap_alloc_mode_t mode, bool def, bool stats_on):
-  BitMapAreaIN(total_blocks, zone_size_block, def)
+         bmap_alloc_mode_t mode, bool def, bool stats_on)
 {
   init_check(total_blocks, zone_size_block, mode, def, stats_on);
 }

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -158,9 +158,18 @@ void BitMapAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   dout(10) << __func__ <<" instance "<< (uint64_t) this <<
     " offset " << offset << " length " << length << dendl;
+  uint64_t size = m_bit_alloc->size() * m_block_size;
 
-  insert_free(ROUND_UP_TO(offset, m_block_size),
-      (length / m_block_size) * m_block_size);
+  uint64_t offset_adj = ROUND_UP_TO(offset, m_block_size);
+  uint64_t length_adj = ((length - (offset_adj - offset)) /
+                         m_block_size) * m_block_size;
+
+  if ((offset_adj + length_adj) > size) {
+    assert(((offset_adj + length_adj) - m_block_size) < size);
+    length_adj = size - offset_adj;
+  }
+
+  insert_free(offset_adj, length_adj);
 }
 
 void BitMapAllocator::init_rm_free(uint64_t offset, uint64_t length)

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -13,7 +13,7 @@
 
 #define bmap_test_assert(x) EXPECT_EQ(true, (x))
 #define NUM_THREADS 16
-#define MAX_BLOCKS (1024 * 1024 * 16)
+#define MAX_BLOCKS (1024 * 1024 * 1)
 
 TEST(BitAllocator, test_bmap_iter)
 {
@@ -481,7 +481,6 @@ verify_blocks(int64_t num_blocks, int64_t *blocks)
 }
 
 __thread int my_tid;
-__thread int64_t allocated_blocks[MAX_BLOCKS];
 
 void
 do_work(BitAllocator *alloc)
@@ -491,6 +490,7 @@ do_work(BitAllocator *alloc)
   int64_t start_block = -1;
   int64_t num_blocks = alloc->size() / NUM_THREADS;
   int total_alloced = 0;
+  int64_t *allocated_blocks = (int64_t *) new int64_t [MAX_BLOCKS];
 
   while (num_iters--) {
     printf("Allocating in tid %d.\n", my_tid);


### PR DESCRIPTION
Hi,
The two changes involves
1. Reduce stack size of the bit_alloc_unit test that was causing segfault in some environments.
2. Handle case when total device size is not multiple of block size used by bluefs (1MB or 64KB). 

Tests:
1. make check
2. cheph_test_objectstore
3. unit test cases for environment that had disk with odd size, 