### PR TITLE
mds/SessionMap: transfer session to the correct list while state chan…

### DIFF
--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -439,6 +439,7 @@ void SessionMap::decode_legacy(bufferlist::iterator &p)
 uint64_t SessionMap::set_state(Session *session, int s) {
   if (session->state != s) {
     session->set_state(s);
+    session->item_session_list.remove_myself();
     if (by_state.count(s) == 0)
       by_state[s] = new xlist<Session*>;
     by_state[s]->push_back(&session->item_session_list);


### PR DESCRIPTION
…ging

This is because:
  1 The state field is exclusive. Combination of multiple states is
    not supported. So we shall remove session from the current state xlist
    before we transfer to the destionation state xlist.

  2 If the same session is allowed to in multiple states xlist, caller such as
    `Server::find_idle_sessions() `can be problematic, as it relies on
    the truth that the related session shall transfer to the "stale" xlist
    and be no more in the "open" xlist to end the infinite `while` loop
    correctly.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>