### PR TITLE
rgw-admin: don't print on ENOENT for orphans find

### DIFF
--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -177,8 +177,8 @@ int RGWOrphanStore::read_entries(const string& oid, const string& marker, map<st
 {
 #define MAX_OMAP_GET 100
   int ret = ioctx.omap_get_vals(oid, marker, MAX_OMAP_GET, entries);
-  if (ret < 0) {
-    cerr << "ERROR: " << __func__ << "(" << oid << ") returned ret=" << ret << std::endl;
+  if (ret < 0 && ret != -ENOENT) {
+    cerr << "ERROR: " << __func__ << "(" << oid << ") returned ret=" << cpp_strerror(-ret) << std::endl;
   }
 
   *truncated = (entries->size() == MAX_OMAP_GET);


### PR DESCRIPTION
Currently orphans-find on a pool always has entries printed on stdout
like:
`ERROR: read_entries(orphan.scan.job10.buckets.63) returned ret=-2`

Since this doesn't mean that the job has failed (only the read_entry on
the particular object has, as it wasn't found) we don't print the error
message

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>