### PR TITLE
jewel: rbd-mirror: FAILED assert(!m_status_watcher)

### DIFF
--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -599,7 +599,7 @@ void Replayer::set_sources(const ImageIds &image_ids)
     return;
   }
 
-  if (m_image_replayers.empty()) {
+  if (m_image_replayers.empty() && !existing_image_replayers) {
     // create entry for pool if it doesn't exist
     r = mirror_image_status_init();
     if (r < 0) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/16290