### PR TITLE
doc: update canonical tarballs URL

### DIFF
--- a/doc/install/get-tarballs.rst
+++ b/doc/install/get-tarballs.rst
@@ -10,5 +10,5 @@ source code. You may download source code tarballs for Ceph releases here:
 .. tip:: For international users: There might be a mirror close to you where download Ceph from. For more information see: `Ceph Mirrors`_.
 
 
-.. _Ceph Release Tarballs: http://ceph.com/download/
+.. _Ceph Release Tarballs: https://download.ceph.com/tarballs/
 .. _Ceph Mirrors: ../mirrors


### PR DESCRIPTION
tarballs are now hosted on download.ceph.com

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>