### PR TITLE
mds: fix MDLog recovery rare case

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -924,6 +924,10 @@ void MDLog::_recovery_thread(MDSInternalContextBase *completion)
     if (mds->is_standby_replay()) {
       dout(1) << "Journal " << jp.front << " is being rewritten, "
         << "cannot replay in standby until an active MDS completes rewrite" << dendl;
+      Mutex::Locker l(mds->mds_lock);
+      if (mds->is_daemon_stopping()) {
+        return;
+      }
       completion->complete(-EAGAIN);
       return;
     }


### PR DESCRIPTION
This handled the case where one daemon
saw a log that was partially rewritten
by another.  It was calling the context
incorrectly (without mds_lock held)

Fixes: http://tracker.ceph.com/issues/16298
Signed-off-by: John Spray <john.spray@redhat.com>