### PR TITLE
mon: Monitor: validate prefix on handle_command()

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2631,7 +2631,19 @@ void Monitor::handle_command(MonOpRequestRef op)
     return;
   }
 
-  cmd_getval(g_ceph_context, cmdmap, "prefix", prefix);
+  // check return value. If no prefix parameter provided,
+  // return value will be false, then return error info.
+  if(!cmd_getval(g_ceph_context, cmdmap, "prefix", prefix)) {
+    reply_command(op, -EINVAL, "command prefix not found", 0);
+    return;
+  }
+
+  // check prefix is empty
+  if (prefix.empty()) {
+    reply_command(op, -EINVAL, "command prefix must not be empty", 0);
+    return;
+  }
+
   if (prefix == "get_command_descriptions") {
     bufferlist rdata;
     Formatter *f = Formatter::create("json");
@@ -2652,6 +2664,15 @@ void Monitor::handle_command(MonOpRequestRef op)
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   get_str_vec(prefix, fullcmd);
+
+  // make sure fullcmd is not empty.
+  // invalid prefix will cause empty vector fullcmd.
+  // such as, prefix=";,,;"
+  if (fullcmd.empty()) {
+    reply_command(op, -EINVAL, "command requires a prefix to be valid", 0);
+    return;
+  }
+
   module = fullcmd[0];
 
   // validate command is in leader map

--- a/src/test/librados/cmd.cc
+++ b/src/test/librados/cmd.cc
@@ -48,6 +48,41 @@ TEST(LibRadosCmd, MonDescribe) {
   rados_buffer_free(buf);
   rados_buffer_free(st);
 
+  cmd[0] = (char *)"";
+  ASSERT_EQ(-EINVAL, rados_mon_command(cluster, (const char **)cmd, 1, "{}", 2, &buf, &buflen, &st, &stlen));
+  rados_buffer_free(buf);
+  rados_buffer_free(st);
+
+  cmd[0] = (char *)"{}";
+  ASSERT_EQ(-EINVAL, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, &buf, &buflen, &st, &stlen));
+  rados_buffer_free(buf);
+  rados_buffer_free(st);
+
+  cmd[0] = (char *)"{\"abc\":\"something\"}";
+  ASSERT_EQ(-EINVAL, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, &buf, &buflen, &st, &stlen));
+  rados_buffer_free(buf);
+  rados_buffer_free(st);
+
+  cmd[0] = (char *)"{\"prefix\":\"\"}";
+  ASSERT_EQ(-EINVAL, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, &buf, &buflen, &st, &stlen));
+  rados_buffer_free(buf);
+  rados_buffer_free(st);
+
+  cmd[0] = (char *)"{\"prefix\":\"    \"}";
+  ASSERT_EQ(-EINVAL, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, &buf, &buflen, &st, &stlen));
+  rados_buffer_free(buf);
+  rados_buffer_free(st);
+
+  cmd[0] = (char *)"{\"prefix\":\";;;,,,;;,,\"}";
+  ASSERT_EQ(-EINVAL, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, &buf, &buflen, &st, &stlen));
+  rados_buffer_free(buf);
+  rados_buffer_free(st);
+
+  cmd[0] = (char *)"{\"prefix\":\"extra command\"}";
+  ASSERT_EQ(-EINVAL, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, &buf, &buflen, &st, &stlen));
+  rados_buffer_free(buf);
+  rados_buffer_free(st);
+
   cmd[0] = (char *)"{\"prefix\":\"mon_status\"}";
   ASSERT_EQ(0, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, &buf, &buflen, &st, &stlen));
   ASSERT_LT(0u, buflen);


### PR DESCRIPTION
This patch mainly fix issue:

http://tracker.ceph.com/issues/16297

Ceph monitors will crash when `mon_command` receive empty prefix sent by rados.py. Such as: use below script to query pool stats info, will cause ceph monitors crash.

```
"""Utilities and helper functions."""

import json
import subprocess
import logging
import rados


LOG = logging.getLogger(__name__)


class CephConfig(dict):
    """
    Validate ceph cluster connection configs
    """

    def __init__(self, cluster_name):
        dict.__init__(self)

        config = {"ceph_config": "/etc/ceph/%s.conf" % cluster_name,
                  "client_name": "client.admin",
                  "keyring": "/etc/ceph/%s.client.admin.keyring" % cluster_name}
        self['conffile'] = config['ceph_config']
        self['conf'] = dict()

        if 'keyring' in config:
            self['conf']['keyring'] = config['keyring']

        if 'client_name' in config:
            self['name'] = config['client_name']


def ceph_status(cluster_name, timeout):
    """Use rados client to fetch the information."""
    def _run(cluster, timeout, **kwargs):
        ret, buf, err = cluster.mon_command(json.dumps(kwargs), '',
                                            timeout=timeout)
        if ret != 0:
            LOG.error('Run ceph with cluster.mon_command meets error %s' % err)
            return None, None, None

        return json.loads(buf)

    config = CephConfig(cluster_name)
    with rados.Rados(**config) as cluster:
        status = _run(cluster, timeout,
                      abc="osd pool stats",  # <<-- you may type anything here (not prefix="xxx") will cause monitor crush.
                      format="json")
        return status
    LOG.error('Cat error when use rados.Rados to fetch info.')
    return None

# set cluster name as ceph
status = ceph_status('ceph', 60)
print json.dumps(status, indent=2)
```

If `mon_command` does not contain `prefix=xxx` parameter, ceph monitor will get empty prefix, then monitor will crash.


Signed-off-by: You Ji <youji@ebay.com>