### PR TITLE
OSD.cc: remove unneeded return

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -327,7 +327,7 @@ void OSDService::mark_split_in_progress(spg_t parent, const set<spg_t> &children
 void OSDService::cancel_pending_splits_for_parent(spg_t parent)
 {
   Mutex::Locker l(in_progress_split_lock);
-  return _cancel_pending_splits_for_parent(parent);
+  _cancel_pending_splits_for_parent(parent);
 }
 
 void OSDService::_cancel_pending_splits_for_parent(spg_t parent)


### PR DESCRIPTION
There is no need for a return in function returning void.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>