### PR TITLE
Python 3 compatibility of Ceph CLI

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -81,13 +81,13 @@ if MYDIR.endswith('src') and \
 
     python_libpath = os.path.join(MYDIR, 'build', get_pythonlib_dir())
     respawn_in_path(os.path.join(MYDIR, '.libs'), 'pybind', python_libpath)
-    if os.environ.has_key('PATH') and MYDIR not in os.environ['PATH']:
+    if 'PATH' in os.environ and MYDIR not in os.environ['PATH']:
         os.environ['PATH'] += ':' + MYDIR
 
 elif os.path.exists(os.path.join(os.getcwd(), "CMakeCache.txt")) \
      and os.path.exists(os.path.join(os.getcwd(), "bin/init-ceph")):
     src_path = None
-    for l in open("./CMakeCache.txt").readlines():
+    for l in open("./CMakeCache.txt"):
         if l.startswith("ceph_SOURCE_DIR:STATIC="):
             src_path = l.split("=")[1].strip()
 
@@ -109,7 +109,7 @@ elif os.path.exists(os.path.join(os.getcwd(), "CMakeCache.txt")) \
 
         respawn_in_path(lib_path, pybind_path, pythonlib_path)
 
-        if os.environ.has_key('PATH') and bin_path not in os.environ['PATH']:
+        if 'PATH' in os.environ and bin_path not in os.environ['PATH']:
             os.environ['PATH'] += ':' + bin_path
 
 import argparse
@@ -122,7 +122,7 @@ import string
 import subprocess
 
 from ceph_argparse import \
-    concise_sig, descsort, parse_json_funcsigs, \
+    concise_sig, descsort_key, parse_json_funcsigs, \
     matchnum, validate_command, find_cmd_target, \
     send_command, json_command, run_in_thread
 
@@ -134,10 +134,18 @@ verbose = False
 cluster_handle = None
 
 # Always use Unicode (UTF-8) for stdout
-raw_stdout = sys.__stdout__
-raw_stderr = sys.__stderr__
-sys.stdout = codecs.getwriter('utf-8')(raw_stdout)
-sys.stderr = codecs.getwriter('utf-8')(raw_stderr)
+if sys.version_info[0] >= 3:
+    raw_stdout = sys.stdout.buffer
+    raw_stderr = sys.stderr.buffer
+else:
+    raw_stdout = sys.__stdout__
+    raw_stderr = sys.__stderr__
+    sys.stdout = codecs.getwriter('utf-8')(raw_stdout)
+    sys.stderr = codecs.getwriter('utf-8')(raw_stderr)
+
+def raw_write(buf):
+    sys.stdout.flush()
+    raw_stdout.write(buf)
 
 ############################################################################
 
@@ -282,7 +290,7 @@ def do_extended_help(parser, args):
         help_for_target(target=('mon', ''), partial=partial)
     return 0
 
-DONTSPLIT = string.letters + '{[<>]}'
+DONTSPLIT = string.ascii_letters + '{[<>]}'
 
 def wrap(s, width, indent):
     """
@@ -342,7 +350,7 @@ def format_help(cmddict, partial=None):
     """
 
     fullusage = ''
-    for cmd in sorted(cmddict.itervalues(), cmp=descsort):
+    for cmd in sorted(cmddict.values(), key=descsort_key):
 
         if not cmd['help']:
             continue
@@ -371,7 +379,7 @@ def ceph_conf(parsed_args, field, name):
         args.extend(['--name', name])
 
     # add any args in GLOBAL_ARGS
-    for key, val in GLOBAL_ARGS.iteritems():
+    for key, val in GLOBAL_ARGS.items():
         # ignore name in favor of argument name, if any
         if name and key == 'client_name':
             continue
@@ -499,7 +507,7 @@ def complete(sigdict, args, target):
 
     match_count = 0
     comps = []
-    for cmdtag, cmd in sigdict.iteritems():
+    for cmdtag, cmd in sigdict.items():
         sig = cmd['sig']
         j = 0
         # iterate over all arguments, except last one

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -156,7 +156,7 @@ def osdids():
         ret, outbuf, outs = send_command(cluster_handle, cmd=['osd', 'ls'])
     if ret:
         raise RuntimeError('Can\'t contact mon for osd list')
-    return [i for i in outbuf.split('\n') if i != '']
+    return [line.decode('utf-8') for line in outbuf.split(b'\n') if line]
 
 def monids():
     ret, outbuf, outs = json_command(cluster_handle, prefix='mon dump',
@@ -167,7 +167,7 @@ def monids():
                                          cmd=['mon', 'dump', '--format=json'])
     if ret:
         raise RuntimeError('Can\'t contact mon for mon list')
-    d = json.loads(outbuf)
+    d = json.loads(outbuf.decode('utf-8'))
     return [m['name'] for m in d['mons']]
 
 def mdsids():
@@ -179,7 +179,7 @@ def mdsids():
                                          cmd=['mds', 'dump', '--format=json'])
     if ret:
         raise RuntimeError('Can\'t contact mon for mds list')
-    d = json.loads(outbuf)
+    d = json.loads(outbuf.decode('utf-8'))
     l = []
     infodict = d['info']
     for mdsdict in infodict.values():
@@ -283,7 +283,7 @@ def do_extended_help(parser, args):
             print("couldn't get command descriptions for {0}: {1}".\
                 format(target, outs), file=sys.stderr)
         else:
-            help_for_sigs(outbuf, partial)
+            help_for_sigs(outbuf.decode('utf-8'), partial)
 
     partial = ' '.join(args)
     if (cluster_handle.state == "connected"):
@@ -647,7 +647,7 @@ def main():
         return 0
     elif sockpath:
         try:
-            print(admin_socket(sockpath, childargs, format))
+            raw_write(admin_socket(sockpath, childargs, format))
         except Exception as e:
             print('admin_socket: {0}'.format(e))
             print('admin_socket: {0}'.format(e), file=sys.stderr)
@@ -790,10 +790,10 @@ def main():
             return 0
 
     # read input file, if any
-    inbuf = ''
+    inbuf = b''
     if parsed_args.input_file:
         try:
-            with open(parsed_args.input_file, 'r') as f:
+            with open(parsed_args.input_file, 'rb') as f:
                 inbuf = f.read()
         except Exception as e:
             print('Can\'t open input file {0}: {1}'.format(parsed_args.input_file, e), file=sys.stderr)
@@ -802,7 +802,7 @@ def main():
     # prepare output file, if any
     if parsed_args.output_file:
         try:
-            outf = open(parsed_args.output_file, 'w')
+            outf = open(parsed_args.output_file, 'wb')
         except Exception as e:
             print('Can\'t open output file {0}: {1}'.format(parsed_args.output_file, e), file=sys.stderr)
             return 1
@@ -880,7 +880,7 @@ def main():
                 if ret < 0:
                     outs = 'problem getting command descriptions from {0}.{1}'.format(*target)
             else:
-                sigdict = parse_json_funcsigs(outbuf, 'cli')
+                sigdict = parse_json_funcsigs(outbuf.decode('utf-8'), 'cli')
 
                 if parsed_args.completion:
                     return complete(sigdict, childargs, target)
@@ -927,17 +927,17 @@ def main():
             if parsed_args.output_format and \
                parsed_args.output_format.startswith('json') and \
                not compat:
-                raw_stdout.write('\n')
+                print()
 
             # if we are prettifying things, normalize newlines.  sigh.
-            if suffix != '':
+            if suffix:
                 outbuf = outbuf.rstrip()
-            if outbuf != '':
+            if outbuf:
                 try:
+                    print(prefix, end='')
                     # Write directly to binary stdout
-                    raw_stdout.write(prefix)
-                    raw_stdout.write(outbuf)
-                    raw_stdout.write(suffix)
+                    raw_write(outbuf)
+                    print(suffix, end='')
                 except IOError as e:
                     if e.errno != errno.EPIPE:
                         raise e

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1120,14 +1120,14 @@ class RadosThread(threading.Thread):
         self.args = args
         self.kwargs = kwargs
         self.target = target
-	self.exception = None
+        self.exception = None
         threading.Thread.__init__(self)
 
     def run(self):
         try:
-		self.retval = self.target(*self.args, **self.kwargs)
-	except Exception as e:
-		self.exception = e
+            self.retval = self.target(*self.args, **self.kwargs)
+        except Exception as e:
+            self.exception = e
 
 
 # time in seconds between each call to t.join() for child thread

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1189,7 +1189,7 @@ def run_in_thread(target, *args, **kwargs):
     return t.retval
 
 
-def send_command(cluster, target=('mon', ''), cmd=None, inbuf='', timeout=0,
+def send_command(cluster, target=('mon', ''), cmd=None, inbuf=b'', timeout=0,
                  verbose=False):
     """
     Send a command to a daemon using librados's
@@ -1271,7 +1271,7 @@ def send_command(cluster, target=('mon', ''), cmd=None, inbuf='', timeout=0,
 
 
 def json_command(cluster, target=('mon', ''), prefix=None, argdict=None,
-                 inbuf='', timeout=0, verbose=False):
+                 inbuf=b'', timeout=0, verbose=False):
     """
     Format up a JSON command and send it with send_command() above.
     Prefix may be supplied separately or in argdict.  Any bulk input

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -20,8 +20,13 @@ import socket
 import stat
 import sys
 import threading
-import types
 import uuid
+
+
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 class ArgumentError(Exception):
@@ -135,11 +140,11 @@ class CephInt(CephArgtype):
             self.range = list()
         else:
             self.range = list(range.split('|'))
-            self.range = map(long, self.range)
+            self.range = [int(x) for x in self.range]
 
     def valid(self, s, partial=False):
         try:
-            val = long(s)
+            val = int(s)
         except ValueError:
             raise ArgumentValid("{0} doesn't represent an int".format(s))
         if len(self.range) == 2:
@@ -170,7 +175,7 @@ class CephFloat(CephArgtype):
             self.range = list()
         else:
             self.range = list(range.split('|'))
-            self.range = map(float, self.range)
+            self.range = [float(x) for x in self.range]
 
     def valid(self, s, partial=False):
         try:
@@ -288,7 +293,7 @@ class CephIPAddr(CephArgtype):
                 socket.inet_pton(socket.AF_INET6, a)
             except:
                 raise ArgumentValid('{0} not valid IPv6 address'.format(s))
-        if p is not None and long(p) > 65535:
+        if p is not None and int(p) > 65535:
             raise ArgumentValid("{0} not a valid port number".format(p))
         self.val = s
         self.addr = a
@@ -310,12 +315,12 @@ class CephEntityAddr(CephIPAddr):
             ip = s
         super(self.__class__, self).valid(ip)
         if nonce:
-            nonce_long = None
+            nonce_int = None
             try:
-                nonce_long = long(nonce)
+                nonce_int = int(nonce)
             except ValueError:
                 pass
-            if nonce_long is None or nonce_long < 0:
+            if nonce_int is None or nonce_int < 0:
                 raise ArgumentValid(
                     '{0}: invalid entity, nonce {1} not integer > 0'.
                     format(s, nonce)
@@ -499,11 +504,11 @@ class CephFragment(CephArgtype):
         if not val.startswith('0x'):
             raise ArgumentFormat("{0} not a hex integer".format(val))
         try:
-            long(val)
+            int(val)
         except:
             raise ArgumentFormat('can\'t convert {0} to integer'.format(val))
         try:
-            long(bits)
+            int(bits)
         except:
             raise ArgumentFormat('can\'t convert {0} to integer'.format(bits))
         self.val = s
@@ -535,12 +540,14 @@ class CephPrefix(CephArgtype):
         self.prefix = prefix
 
     def valid(self, s, partial=False):
-        try:
-            # `prefix` can always be converted into unicode when being compared,
-            # but `s` could be anything passed by user.
-            s = unicode(s)
-        except UnicodeDecodeError:
-            raise ArgumentPrefix("no match for {0}".format(s))
+        s = str(s)
+        if isinstance(s, bytes):
+            try:
+                # `prefix` can always be converted into unicode when being compared,
+                # but `s` could be anything passed by user.
+                s = s.decode('ascii')
+            except UnicodeDecodeError:
+                raise ArgumentPrefix("no match for {0}".format(s))
 
         if partial:
             if self.prefix.startswith(s):
@@ -584,7 +591,7 @@ class argdesc(object):
     and will store the validated value in self.instance.val for extraction.
     """
     def __init__(self, t, name=None, n=1, req=True, **kwargs):
-        if isinstance(t, types.StringTypes):
+        if isinstance(t, basestring):
             self.t = CephPrefix
             self.typeargs = {'prefix': t}
             self.req = True
@@ -604,7 +611,7 @@ class argdesc(object):
     def __repr__(self):
         r = 'argdesc(' + str(self.t) + ', '
         internals = ['N', 'typeargs', 'instance', 't']
-        for (k, v) in self.__dict__.iteritems():
+        for (k, v) in self.__dict__.items():
             if k.startswith('__') or k in internals:
                 pass
             else:
@@ -612,7 +619,7 @@ class argdesc(object):
                 if k == 'n' and self.N:
                     v = 'N'
                 r += '{0}={1}, '.format(k, v)
-        for (k, v) in self.typeargs.iteritems():
+        for (k, v) in self.typeargs.items():
             r += '{0}={1}, '.format(k, v)
         return r[:-2] + ')'
 
@@ -672,7 +679,7 @@ def parse_funcsig(sig):
     argnum = 0
     for desc in sig:
         argnum += 1
-        if isinstance(desc, types.StringTypes):
+        if isinstance(desc, basestring):
             t = CephPrefix
             desc = {'type': t, 'name': 'prefix', 'prefix': desc}
         else:
@@ -681,11 +688,11 @@ def parse_funcsig(sig):
                 s = 'JSON descriptor {0} has no type'.format(sig)
                 raise JsonFormat(s)
             # look up type string in our globals() dict; if it's an
-            # object of type types.TypeType, it must be a
+            # object of type `type`, it must be a
             # locally-defined class. otherwise, we haven't a clue.
             if desc['type'] in globals():
                 t = globals()[desc['type']]
-                if not isinstance(t, types.TypeType):
+                if not isinstance(t, type):
                     s = 'unknown type {0}'.format(desc['type'])
                     raise JsonFormat(s)
             else:
@@ -741,7 +748,7 @@ def parse_json_funcsigs(s, consumer):
         print("Couldn't parse JSON {0}: {1}".format(s, e), file=sys.stderr)
         raise e
     sigdict = {}
-    for cmdtag, cmd in overall.iteritems():
+    for cmdtag, cmd in overall.items():
         if 'sig' not in cmd:
             s = "JSON descriptor {0} has no 'sig'".format(cmdtag)
             raise JsonFormat(s)
@@ -967,7 +974,8 @@ def validate(args, signature, partial=False):
 def cmdsiglen(sig):
     sigdict = sig.values()
     assert len(sigdict) == 1
-    return len(sig.values()[0]['sig'])
+    some_value = next(iter(sig.values()))
+    return len(some_value['sig'])
 
 
 def validate_command(sigdict, args, verbose=False):
@@ -984,7 +992,7 @@ def validate_command(sigdict, args, verbose=False):
         # (so we can maybe give a more-useful error message)
         best_match_cnt = 0
         bestcmds = []
-        for cmdtag, cmd in sigdict.iteritems():
+        for cmdtag, cmd in sigdict.items():
             sig = cmd['sig']
             matched = matchnum(args, sig, partial=True)
             if matched > best_match_cnt:
@@ -1003,8 +1011,7 @@ def validate_command(sigdict, args, verbose=False):
 
         # Sort bestcmds by number of args so we can try shortest first
         # (relies on a cmdsig being key,val where val is a list of len 1)
-        bestcmds_sorted = sorted(bestcmds,
-                                 cmp=lambda x, y: cmp(cmdsiglen(x), cmdsiglen(y)))
+        bestcmds_sorted = sorted(bestcmds, key=cmdsiglen)
 
         if verbose:
             print("bestcmds_sorted: ", file=sys.stderr)
@@ -1012,7 +1019,7 @@ def validate_command(sigdict, args, verbose=False):
 
         # for everything in bestcmds, look for a true match
         for cmdsig in bestcmds_sorted:
-            for cmd in cmdsig.itervalues():
+            for cmd in cmdsig.values():
                 sig = cmd['sig']
                 try:
                     valid_dict = validate(args, sig)

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -662,12 +662,19 @@ def concise_sig(sig):
     return ' '.join([d.helpstr() for d in sig])
 
 
-def descsort(sh1, sh2):
+def descsort_key(sh):
     """
     sort descriptors by prefixes, defined as the concatenation of all simple
     strings in the descriptor; this works out to just the leading strings.
     """
-    return cmp(concise_sig(sh1['sig']), concise_sig(sh2['sig']))
+    return concise_sig(sh['sig'])
+
+
+def descsort(sh1, sh2):
+    """
+    Deprecated; use (key=descsort_key) instead of (cmp=descsort)
+    """
+    return cmp(descsort_key(sh1), descsort_key(sh2))
 
 
 def parse_funcsig(sig):

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -350,6 +350,10 @@ class CephPgid(CephArgtype):
         if s.find('.') == -1:
             raise ArgumentFormat('pgid has no .')
         poolid, pgnum = s.split('.', 1)
+        try:
+            poolid = int(poolid)
+        except ValueError:
+            raise ArgumentFormat('pool {0} not integer'.format(poolid))
         if poolid < 0:
             raise ArgumentFormat('pool {0} < 0'.format(poolid))
         try:

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -36,12 +36,12 @@ def admin_socket(asok_path, cmd, format=''):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.connect(path)
         try:
-            sock.sendall(cmd_bytes + '\0')
+            sock.sendall(cmd_bytes + b'\0')
             len_str = sock.recv(4)
             if len(len_str) < 4:
                 raise RuntimeError("no data returned from admin socket")
             l, = struct.unpack(">I", len_str)
-            sock_ret = ''
+            sock_ret = b''
 
             got = 0
             while got < l:
@@ -55,14 +55,14 @@ def admin_socket(asok_path, cmd, format=''):
 
     try:
         cmd_json = do_sockio(asok_path,
-                             json.dumps({"prefix": "get_command_descriptions"}))
+                             b'{"prefix": "get_command_descriptions"}')
     except Exception as e:
         raise RuntimeError('exception getting command descriptions: ' + str(e))
 
     if cmd == 'get_command_descriptions':
         return cmd_json
 
-    sigdict = parse_json_funcsigs(cmd_json, 'cli')
+    sigdict = parse_json_funcsigs(cmd_json.decode('utf-8'), 'cli')
     valid_dict = validate_command(sigdict, cmd)
     if not valid_dict:
         raise RuntimeError('invalid command')
@@ -71,7 +71,7 @@ def admin_socket(asok_path, cmd, format=''):
         valid_dict['format'] = format
 
     try:
-        ret = do_sockio(asok_path, json.dumps(valid_dict))
+        ret = do_sockio(asok_path, json.dumps(valid_dict).encode('utf-8'))
     except Exception as e:
         raise RuntimeError('exception: ' + str(e))
 
@@ -234,7 +234,7 @@ class DaemonWatcher(object):
         Populate our instance-local copy of the daemon's performance counter
         schema, and work out which stats we will display.
         """
-        self._schema = json.loads(admin_socket(self.asok_path, ["perf", "schema"]))
+        self._schema = json.loads(admin_socket(self.asok_path, ["perf", "schema"]).decode('utf-8'))
 
         # Build list of which stats we will display, based on which
         # stats have a nickname
@@ -256,13 +256,13 @@ class DaemonWatcher(object):
 
         self._print_headers(ostr)
 
-        last_dump = json.loads(admin_socket(self.asok_path, ["perf", "dump"]))
+        last_dump = json.loads(admin_socket(self.asok_path, ["perf", "dump"]).decode('utf-8'))
         rows_since_header = 0
         term_height = 25
 
         try:
             while True:
-                dump = json.loads(admin_socket(self.asok_path, ["perf", "dump"]))
+                dump = json.loads(admin_socket(self.asok_path, ["perf", "dump"]).decode('utf-8'))
                 if rows_since_header > term_height - 2:
                     self._print_headers(ostr)
                     rows_since_header = 0

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -140,7 +140,7 @@ class DaemonWatcher(object):
         """
         units = [' ', 'k', 'M', 'G', 'T', 'P']
         unit = 0
-        while len("%s" % (int(n) / (1000**unit))) > width - 1:
+        while len("%s" % (int(n) // (1000**unit))) > width - 1:
             unit += 1
 
         if unit > 0:
@@ -177,7 +177,7 @@ class DaemonWatcher(object):
         for section_name, names in self._stats.items():
             section_width = sum([self.col_width(x)+1 for x in names.values()]) - 1
             pad = max(section_width - len(section_name), 0)
-            pad_prefix = pad / 2
+            pad_prefix = pad // 2
             header += (pad_prefix * '-')
             header += (section_name[0:section_width])
             header += ((pad - pad_prefix) * '-')

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -91,11 +91,11 @@ class TestArgparse:
 
 class TestBasic:
 
-	def test_non_ascii_in_non_options(self):
-		# unicode() is not able to convert this str parameter into unicode
-		# using the default encoding 'ascii'. and validate_command() should
-		# not choke on it.
-		assert_is_none(validate_command(sigdict, ['章鱼和鱿鱼']))
+    def test_non_ascii_in_non_options(self):
+        # unicode() is not able to convert this str parameter into unicode
+        # using the default encoding 'ascii'. and validate_command() should
+        # not choke on it.
+        assert_is_none(validate_command(sigdict, ['章鱼和鱿鱼']))
 
 
 class TestPG(TestArgparse):
@@ -640,7 +640,7 @@ class TestOSD(TestArgparse):
                                                     'rename-bucket']))
         assert_equal({}, validate_command(sigdict, ['osd', 'crush',
                                                     'rename-bucket',
-													'srcname']))
+                                                    'srcname']))
         assert_equal({}, validate_command(sigdict, ['osd', 'crush',
                                                     'rename-bucket', 'srcname',
                                                     'dstname',
@@ -746,7 +746,7 @@ class TestOSD(TestArgparse):
 
     def test_crush_tunables(self):
         for tunable in ('legacy', 'argonaut', 'bobtail', 'firefly',
-						'optimal', 'default'):
+                        'optimal', 'default'):
             self.assert_valid_command(['osd', 'crush', 'tunables',
                                        tunable])
         assert_equal({}, validate_command(sigdict, ['osd', 'crush',
@@ -998,13 +998,13 @@ class TestOSD(TestArgparse):
                                                     'poolname',
                                                     '128', '128',
                                                     'erasure', '^^^',
-													'ruleset']))
+                                                    'ruleset']))
         assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
                                                     'poolname',
                                                     '128', '128',
                                                     'erasure', 'profile',
                                                     'ruleset',
-												    'toomany']))
+                                                    'toomany']))
         assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
                                                     'poolname',
                                                     '128', '128',
@@ -1104,7 +1104,7 @@ class TestOSD(TestArgparse):
     def test_reweight_by_utilization(self):
         self.assert_valid_command(['osd', 'reweight-by-utilization'])
         self.assert_valid_command(['osd', 'reweight-by-utilization', '100'])
-		self.assert_valid_command(['osd', 'reweight-by-utilization', '100', '.1'])
+        self.assert_valid_command(['osd', 'reweight-by-utilization', '100', '.1'])
         self.assert_valid_command(['osd', 'reweight-by-utilization', '--no-increasing'])
         assert_equal({}, validate_command(sigdict, ['osd',
                                                     'reweight-by-utilization',


### PR DESCRIPTION
This replaces tabs with whitespace, fixes syntax and builtins (most controversial change would be `.iteritems()` -> `.items()` but should be fine).

There was also one bug with the validity check that was undetected on Python 2.

Compatibility down to Python 2.6 remains.