### PR TITLE
cephx: Fix multiple segfaults due to attempts to encrypt or decrypt

### DIFF
--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -107,10 +107,12 @@ public:
   int create(CephContext *cct, int type);
   int encrypt(CephContext *cct, const bufferlist& in, bufferlist& out,
 	       std::string *error) const {
+    assert(ckh); // Bad key?
     return ckh->encrypt(in, out, error);
   }
   int decrypt(CephContext *cct, const bufferlist& in, bufferlist& out,
 	       std::string *error) const {
+    assert(ckh); // Bad key?
     return ckh->decrypt(in, out, error);
   }
 

--- a/src/auth/cephx/CephxClientHandler.cc
+++ b/src/auth/cephx/CephxClientHandler.cc
@@ -46,6 +46,12 @@ int CephxClientHandler::build_request(bufferlist& bl) const
       return -ENOENT;
     }
 
+    // is the key OK?
+    if (!secret.get_secret().length()) {
+      ldout(cct, 20) << "secret for entity " << cct->_conf->name << " is invalid" << dendl;
+      return -EINVAL;
+    }
+
     CephXAuthenticate req;
     get_random_bytes((char *)&req.client_challenge, sizeof(req.client_challenge));
     std::string error;

--- a/src/auth/cephx/CephxProtocol.cc
+++ b/src/auth/cephx/CephxProtocol.cc
@@ -60,7 +60,10 @@ bool cephx_build_service_ticket_blob(CephContext *cct, CephXSessionAuthInfo& inf
 	   << " ticket_info.ticket.name=" << ticket_info.ticket.name.to_str() << dendl;
   blob.secret_id = info.secret_id;
   std::string error;
-  encode_encrypt_enc_bl(cct, ticket_info, info.service_secret, blob.blob, error);
+  if (!info.service_secret.get_secret().length())
+    error = "invalid key";  // Bad key?
+  else
+    encode_encrypt_enc_bl(cct, ticket_info, info.service_secret, blob.blob, error);
   if (!error.empty()) {
     ldout(cct, -1) << "cephx_build_service_ticket_blob failed with error "
 	  << error << dendl;
@@ -428,7 +431,10 @@ bool cephx_verify_authorizer(CephContext *cct, KeyStore *keys,
     }
   }
   std::string error;
-  decode_decrypt_enc_bl(cct, ticket_info, service_secret, ticket.blob, error);
+  if (!service_secret.get_secret().length())
+    error = "invalid key";  // Bad key?
+  else
+    decode_decrypt_enc_bl(cct, ticket_info, service_secret, ticket.blob, error);
   if (!error.empty()) {
     ldout(cct, 0) << "verify_authorizer could not decrypt ticket info: error: "
       << error << dendl;


### PR DESCRIPTION
an empty secret and a null CryptoKeyHandler

http://tracker.ceph.com/issues/16266

Fixes: #16266
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>