### PR TITLE
authtool: Enhance argument combinations validation

### DIFF
--- a/src/test/cli/ceph-authtool/add-key.t
+++ b/src/test/cli/ceph-authtool/add-key.t
@@ -12,3 +12,9 @@
   $ cat kring
   [client.admin]
   \tkey = AQAK7yxNeF+nHBAA0SgSdbs8IkJrxroDeJ6SwQ== (esc)
+
+Test --add-key with empty argument
+
+  $ ceph-authtool kring -C --name=mon.* --add-key= --cap mon 'allow *'
+  Option --add-key requires an argument
+  [1]


### PR DESCRIPTION
Under certain circumstances ceph-authtool can create invalid key entries in
the specified keyring and behave less than intuitively. What's worse these
keys can currently cause ceph daemons to crash. This patch attempts to tighten
the behaviour and eliminate the possibility an invalid key can be created.

http://tracker.ceph.com/issues/2904

Fixes: #2904
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>