### PR TITLE
librados: restore ability to compile against librados

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -19,7 +19,6 @@
 extern "C" {
 #endif
 
-#include "../compat.h"
 #include <netinet/in.h>
 #if defined(__linux__)
 #include <linux/types.h>


### PR DESCRIPTION
Partial revert of 62be9268de5e9c9a08bdb977a7dab1ab9c55b2be which
added a new header dependency which was is not part of the librados
API.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>