### PR TITLE
script/make_rocksdb_makefile.sh: do not include rocksdb/tools/rdb/*

### DIFF
--- a/src/script/make_rocksdb_makefile.sh
+++ b/src/script/make_rocksdb_makefile.sh
@@ -4,7 +4,7 @@ cd rocksdb
 git clean -dffx
 cd ..
 echo "EXTRA_DIST += \\" > /tmp/$$
-for f in `find rocksdb -type f | grep -v /.git$ | sort`; do
+for f in `find rocksdb -type f | grep -v -e /.git$ -e ^rocksdb/tools/rdb | sort`; do
 		echo "  $f \\" >> /tmp/$$
 done
 echo "  rocksdb/AUTHORS" >> /tmp/$$


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/13554
Signed-off-by: Kefu Chai <kchai@redhat.com>