### PR TITLE
Server: avoid duplicated call to acquire_locks()

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2990,8 +2990,6 @@ void Server::handle_client_open(MDRequestRef& mdr)
   //  and that data itself is flushed so that we can read the snapped data off disk.
   if (mdr->snapid != CEPH_NOSNAP && !cur->is_dir()) {
     rdlocks.insert(&cur->filelock);
-    if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))
-      return;
   }
 
   if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))


### PR DESCRIPTION
For snapped case we may call acquire_locks() twice,
which is not necessary.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>