### PR TITLE
os/filestore: Place KeyValueDB::test_init at the front

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -870,6 +870,12 @@ int FileStore::mkfs()
   }
 
   // superblock
+  ret = KeyValueDB::test_init(g_conf->filestore_omap_backend, omap_dir);
+  if (ret < 0) {
+    derr << "mkfs failed to create " << g_conf->filestore_omap_backend << dendl;
+    goto close_fsid_fd;
+  }
+
   superblock.omap_backend = g_conf->filestore_omap_backend;
   ret = write_superblock();
   if (ret < 0) {
@@ -930,11 +936,6 @@ int FileStore::mkfs()
       }
     }
     VOID_TEMP_FAILURE_RETRY(::close(fd));
-  }
-  ret = KeyValueDB::test_init(superblock.omap_backend, omap_dir);
-  if (ret < 0) {
-    derr << "mkfs failed to create " << g_conf->filestore_omap_backend << dendl;
-    goto close_fsid_fd;
   }
   // create fsid under omap
   // open+lock fsid


### PR DESCRIPTION
To determine whether the filestore'omap storage is valid before the assignment superblock

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>