### PR TITLE
doc: Small styling fix to mirror documentation

### DIFF
--- a/doc/install/mirrors.rst
+++ b/doc/install/mirrors.rst
@@ -27,15 +27,15 @@ These mirrors are available on the following locations:
 
 You can replace all download.ceph.com URLs with any of the mirrors, for example:
 
-  http://download.ceph.com/tarballs/
-  http://download.ceph.com/debian-hammer/
-  http://download.ceph.com/rpm-hammer/
+- http://download.ceph.com/tarballs/
+- http://download.ceph.com/debian-hammer/
+- http://download.ceph.com/rpm-hammer/
 
 Change this to:
 
-  http://eu.ceph.com/tarballs/
-  http://eu.ceph.com/debian-hammer/
-  http://eu.ceph.com/rpm-hammer/
+- http://eu.ceph.com/tarballs/
+- http://eu.ceph.com/debian-hammer/
+- http://eu.ceph.com/rpm-hammer/
 
 
 Mirroring


### PR DESCRIPTION
Small fix to the mirroring documentation.

URLs should now be displayed on separate lines.

Signed-off-by: Wido den Hollander wido@42on.com
