### PR TITLE
rbd: cleanup - Proxied operations shouldn't result in error messages if replayed

### DIFF
--- a/src/librbd/operation/RenameRequest.cc
+++ b/src/librbd/operation/RenameRequest.cc
@@ -66,7 +66,11 @@ bool RenameRequest<I>::should_complete(int r) {
                 << "r=" << r << dendl;
   r = filter_state_return_code(r);
   if (r < 0) {
-    lderr(cct) << "encountered error: " << cpp_strerror(r) << dendl;
+    if (r == -EEXIST) {
+      ldout(cct, 1) << "image already exists" << dendl;
+    } else {
+      lderr(cct) << "encountered error: " << cpp_strerror(r) << dendl;
+    }
     return true;
   }
 

--- a/src/librbd/operation/SnapshotProtectRequest.cc
+++ b/src/librbd/operation/SnapshotProtectRequest.cc
@@ -47,7 +47,11 @@ bool SnapshotProtectRequest<I>::should_complete(int r) {
   ldout(cct, 5) << this << " " << __func__ << ": state=" << m_state << ", "
                 << "r=" << r << dendl;
   if (r < 0) {
-    lderr(cct) << "encountered error: " << cpp_strerror(r) << dendl;
+    if (r == -EBUSY) {
+      ldout(cct, 1) << "snapshot is already protected" << dendl;
+    } else {
+      lderr(cct) << "encountered error: " << cpp_strerror(r) << dendl;
+    }
   }
   return true;
 }

--- a/src/librbd/operation/SnapshotRemoveRequest.cc
+++ b/src/librbd/operation/SnapshotRemoveRequest.cc
@@ -135,7 +135,11 @@ void SnapshotRemoveRequest<I>::send_remove_child() {
     parent_spec our_pspec;
     int r = image_ctx.get_parent_spec(m_snap_id, &our_pspec);
     if (r < 0) {
-      lderr(cct) << "failed to retrieve parent spec" << dendl;
+      if (r == -ENOENT) {
+        ldout(cct, 1) << "No such snapshot" << dendl;
+      } else {
+        lderr(cct) << "failed to retrieve parent spec" << dendl;
+      }
       m_state = STATE_ERROR;
 
       this->async_complete(r);

--- a/src/librbd/operation/SnapshotRenameRequest.cc
+++ b/src/librbd/operation/SnapshotRenameRequest.cc
@@ -49,7 +49,11 @@ bool SnapshotRenameRequest<I>::should_complete(int r) {
   ldout(cct, 5) << this << " " << __func__ << ": state=" << m_state << ", "
                 << "r=" << r << dendl;
   if (r < 0) {
-    lderr(cct) << "encountered error: " << cpp_strerror(r) << dendl;
+    if (r == -EEXIST) {
+      ldout(cct, 1) << "snapshot already exists" << dendl;
+    } else {
+      lderr(cct) << "encountered error: " << cpp_strerror(r) << dendl;
+    }
   }
   return true;
 }

--- a/src/librbd/operation/SnapshotUnprotectRequest.cc
+++ b/src/librbd/operation/SnapshotUnprotectRequest.cc
@@ -169,7 +169,11 @@ bool SnapshotUnprotectRequest<I>::should_complete(int r) {
   ldout(cct, 5) << this << " " << __func__ << ": state=" << m_state << ", "
                 << "r=" << r << dendl;
   if (r < 0) {
-    lderr(cct) << "encountered error: " << cpp_strerror(r) << dendl;
+    if (r == -EINVAL) {
+      ldout(cct, 1) << "snapshot is already unprotected" << dendl;
+    } else {
+      lderr(cct) << "encountered error: " << cpp_strerror(r) << dendl;
+    }
     if (m_ret_val == 0) {
       m_ret_val = r;
     }


### PR DESCRIPTION
rbd: cleanup - Proxied operations shouldn't result
in error messages if replayed

Fixes: http://tracker.ceph.com/issues/16130

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>