### PR TITLE
log: fix the WARNING in death test from gtest

### DIFF
--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -209,6 +209,8 @@ void do_segv()
 
 TEST(Log, InternalSegv)
 {
+  // To bypass the warning "Death tests use fork()"
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH(do_segv(), ".*");
 }
 


### PR DESCRIPTION
The death test case in unittest_log results in some warning info
from gtest:

[WARNING] ./src/gtest-death-test.cc:825:: Death tests use fork(),
which is unsafe particularly in a threaded context. For this test,
Google Test couldn't detect the number of threads.

Jenkins will mark this as some "failure", which is a bit missleading.

This patch adds one option for gtest to ignore this issue:
::testing::FLAGS_gtest_death_test_style = "threadsafe"

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>