### PR TITLE
common/rados: Release memory have been reused

### DIFF
--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -113,7 +113,6 @@ void env_to_vec(std::vector<const char*>& args, const char *name)
   std::vector<const char*> env_arguments;
   static vector<string> str_vec;
   std::vector<const char*> env;
-  str_vec.clear();
   get_str_vec(p, " ", str_vec);
   for (vector<string>::iterator i = str_vec.begin();
        i != str_vec.end();


### PR DESCRIPTION
Release memory have been reused,because in get_str_vec(p, " ", str_vec) is alse user clear() to release memory

Signed-off-by: zhang.zezhu zhang.zezhu@zte.com.cn
