### PR TITLE
monstoretool: make it more clearly to user why it can not be used

### DIFF
--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -701,6 +701,83 @@ int rebuild_monstore(const char* progname,
   return 0;
 }
 
+void get_name_by_pid(pid_t pid, char *task_name)
+{
+  char proc_pid_path[PATH_MAX] = {0};
+  snprintf(proc_pid_path, PATH_MAX, "/proc/%d/cmdline", pid);
+  int fd = open(proc_pid_path, O_RDONLY);
+
+  if (fd < 0) {
+    fd = -errno;
+    std::cerr << "Fail to open '" << proc_pid_path
+              << "' error = " << cpp_strerror(fd)
+              << std::endl;
+    return;
+  }
+
+  int ret = read(fd, task_name, PATH_MAX-1);
+  if (ret < 0) {
+    ret = -errno;
+    std::cerr << "Fail to read '" << proc_pid_path
+              << "' error = " << cpp_strerror(ret)
+              << std::endl;
+  }
+
+  close(fd);
+}
+
+
+int check_lock(const string &path) {
+ 
+  string::const_reverse_iterator rit;
+  int pos = 0;
+  for (rit = path.rbegin(); rit != path.rend(); ++rit, ++pos) {
+    if (*rit != '/')
+      break;
+  }
+  ostringstream os;
+  os << path.substr(0, path.size() - pos) << "/store.db/LOCK";
+  string lock_path = os.str();
+
+  //The lock file is not existed.
+  if (access(lock_path.c_str(), F_OK)) {
+     return 0;
+  }
+
+  int fd = open(lock_path.c_str(), O_RDONLY);
+  if (fd < 0) {
+    fd = -errno;
+    std::cerr << "Fail to open '" << lock_path
+              << "' error = " << cpp_strerror(fd)
+              << std::endl;
+    return -1;
+  }
+
+  struct flock f;
+  memset(&f, 0, sizeof(f));
+  f.l_type = F_WRLCK;
+  f.l_whence = SEEK_SET;
+
+  if (-1 == fcntl(fd, F_GETLK, &f)) {
+    std::cerr << " Fail to get the lock " << cpp_strerror(errno) << std::endl;
+    return -1;
+  }
+
+  if (f.l_type != F_UNLCK) {
+    if (f.l_type == F_WRLCK) {
+      char task_name[PATH_MAX] = "unknown";
+      //get the locked thread name
+      get_name_by_pid(f.l_pid, task_name);
+      cout << "The database have already locked by PID: '"
+           << f.l_pid << "' task name: '" << task_name
+           << "' please close it first!" << std::endl;
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
 int main(int argc, char **argv) {
   int err = 0;
   po::options_description desc("Allowed options");
@@ -794,6 +871,8 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf->apply_changes(NULL);
   g_conf = g_ceph_context->_conf;
 
+  if (check_lock(store_path))
+    return 1;
   // this is where we'll write *whatever*, on a per-command basis.
   // not all commands require some place to write their things.
   MonitorDBStore st(store_path);


### PR DESCRIPTION
monstoretool: make it more clearly to user why it can not be used

like below:
    The database have already locked by PID: '420170' task name: '/usr/bin/ceph-mon' please close it first!

Signed-off-by:song baisen song.baisen@zte.com.cn
