### PR TITLE
mds/server: fix rare race when waitting for osdmap

### DIFF
--- a/src/common/ceph_fs.cc
+++ b/src/common/ceph_fs.cc
@@ -11,30 +11,6 @@
  */
 #include "include/types.h"
 
-/*
- * return true if @layout appears to be valid
- */
-int ceph_file_layout_is_valid(const struct ceph_file_layout *layout)
-{
-	__u32 su = le32_to_cpu(layout->fl_stripe_unit);
-	__u32 sc = le32_to_cpu(layout->fl_stripe_count);
-	__u32 os = le32_to_cpu(layout->fl_object_size);
-
-	/* stripe unit, object size must be non-zero, 64k increment */
-	if (!su || (su & (CEPH_MIN_STRIPE_UNIT-1)))
-		return 0;
-	if (!os || (os & (CEPH_MIN_STRIPE_UNIT-1)))
-		return 0;
-	/* object size must be a multiple of stripe unit */
-	if (os < su || os % su)
-		return 0;
-	/* stripe count must be non-zero */
-	if (!sc)
-		return 0;
-	return 1;
-}
-
-
 int ceph_flags_to_mode(int flags)
 {
 	/* because CEPH_FILE_MODE_PIN is zero, so mode = -1 is error */

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -56,8 +56,6 @@ struct ceph_file_layout {
 
 #define CEPH_MIN_STRIPE_UNIT 65536
 
-int ceph_file_layout_is_valid(const struct ceph_file_layout *layout);
-
 struct ceph_dir_layout {
 	__u8   dl_dir_hash;   /* see ceph_hash.h for ids */
 	__u8   dl_unused1;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3038,8 +3038,7 @@ void Server::handle_client_open(MDRequestRef& mdr)
   }
   
   // hit pop
-  if (cmode == CEPH_FILE_MODE_RDWR ||
-      cmode == CEPH_FILE_MODE_WR) 
+  if (cmode & CEPH_FILE_MODE_WR)
     mds->balancer->hit_inode(mdr->get_mds_stamp(), cur, META_POP_IWR);
   else
     mds->balancer->hit_inode(mdr->get_mds_stamp(), cur, META_POP_IRD,

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -175,6 +175,10 @@ public:
   int parse_layout_vxattr(string name, string value, const OSDMap& osdmap,
 			  file_layout_t *layout, bool validate=true);
   int parse_quota_vxattr(string name, string value, quota_info_t *quota);
+  int check_layout_vxattr(MDRequestRef& mdr,
+                          string name,
+                          string value,
+                          file_layout_t *layout);
   void handle_set_vxattr(MDRequestRef& mdr, CInode *cur,
 			 file_layout_t *dir_layout,
 			 set<SimpleLock*> rdlocks,


### PR DESCRIPTION
If wait_for_map() returns true, we have got the requested osdmap
at the specified epoch, so we shall try again to do further
verification whether we have the specific pool or not.
    
The above case can happen because we drop the objecter internal
rwlock during the switch between the objecter->with_osdmap()
and objecter->wait_for_map() methods.
    
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>