### PR TITLE
rgw: should clear 'short_zone_ids' when update period

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1189,6 +1189,7 @@ struct RGWPeriodMap
   void reset() {
     zonegroups.clear();
     zonegroups_by_api.clear();
+    short_zone_ids.clear();
   }
 
   uint32_t get_zone_short_id(const string& zone_id) const;


### PR DESCRIPTION
when delete a zone from zonegroup, update the period and commit the changes,
the zone remove from current periodmap, but the short_zone_ids of zone still in
'short_zone_ids' map of the periodmap, so we should remove it.

Signed-off-by: weiqiaomiao <wei.qiaomiao@zte.com.cn>