### PR TITLE
rgw/user: remove needless bufferlist encoding

### DIFF
--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -95,8 +95,6 @@ int rgw_store_user_info(RGWRados *store,
                         bool exclusive,
                         map<string, bufferlist> *pattrs)
 {
-  bufferlist bl;
-  info.encode(bl);
   int ret;
   RGWObjVersionTracker ot;
 


### PR DESCRIPTION
`bl` encoded but never be used.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>