### PR TITLE
doc: remove btrfs contradiction

### DIFF
--- a/doc/rados/configuration/filesystem-recommendations.rst
+++ b/doc/rados/configuration/filesystem-recommendations.rst
@@ -92,8 +92,7 @@ capability means that ``btrfs`` can support snapshots that are writable.
 ``btrfs`` also incorporates multi-device management into the file system,
 which enables you to support heterogeneous disk storage infrastructure,
 data allocation policies. The community also aims to provide ``fsck``, 
-deduplication, and data encryption support in the future. This compelling 
-list of features makes ``btrfs`` the ideal choice for Ceph clusters.
+deduplication, and data encryption support in the future.
 
 .. _copy-on-write: http://en.wikipedia.org/wiki/Copy-on-write
 .. _compared: http://en.wikipedia.org/wiki/Comparison_of_file_systems


### PR DESCRIPTION
btrfs is not "the ideal choice for Ceph clusters" because it isn't mature and
the promised features (like deduplication) have not materialized.
    
The "Filesystems -> Recommended" section of this very same document (several
paragraphs) above the paragraph being modified by this commit, has been
modified to say "We used to recommend btrfs for testing, development, and any
non-critical deployments. . . . However . . . ."
    
This PR removes this contradiction.

Signed-off-by: Nathan Cutler <ncutler@suse.com>