### PR TITLE
mds: fix Session::check_access()

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -807,9 +807,14 @@ bool CInode::is_projected_ancestor_of(CInode *other)
   return false;
 }
 
-void CInode::make_path_string(string& s, bool force, CDentry *use_parent) const
+/*
+ * If use_parent is NULL (it should be one of inode's projected parents),
+ * we use it to make path string. Otherwise, we use inode's parent dentry
+ * to make path string
+ */
+void CInode::make_path_string(string& s, CDentry *use_parent) const
 {
-  if (!force)
+  if (!use_parent)
     use_parent = parent;
 
   if (use_parent) {
@@ -844,7 +849,7 @@ void CInode::make_path_string_projected(string& s) const
 	 p != projected_parent.end();
 	 ++p) {
       string q;
-      make_path_string(q, true, *p);
+      make_path_string(q, *p);
       s += " ";
       s += q;
     }

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -738,7 +738,7 @@ public:
 
   // -- misc -- 
   bool is_projected_ancestor_of(CInode *other);
-  void make_path_string(std::string& s, bool force=false, CDentry *use_parent=NULL) const;
+  void make_path_string(std::string& s, CDentry *use_parent=NULL) const;
   void make_path_string_projected(std::string& s) const;
   void make_path(filepath& s) const;
   void name_stray_dentry(std::string& dname);

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -854,7 +854,7 @@ int Session::check_access(CInode *in, unsigned mask,
     path = in->get_projected_inode()->stray_prior_path;
     dout(20) << __func__ << " stray_prior_path " << path << dendl;
   } else {
-    in->make_path_string(path, false, in->get_projected_parent_dn());
+    in->make_path_string(path, in->get_projected_parent_dn());
     dout(20) << __func__ << " path " << path << dendl;
   }
   if (path.length())


### PR DESCRIPTION
It calls CInode::make_path_string(...) with the second argument is
false. The second argument makes the third argument useless. For
newly created inode, the path string is something like #1xxxxxxxxx.
This can cause the access check to fail.

Fixes: http://tracker.ceph.com/issues/16358
Signed-off-by: Yan, Zheng <zyan@redhat.com>