### PR TITLE
msg/async: set socket priority for heartbeat socket

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1008,6 +1008,7 @@ ssize_t AsyncConnection::_process_connection()
         }
 
         center->delete_file_event(sd, EVENT_WRITABLE);
+        net.set_priority(sd, async_msgr->get_socket_priority());
         ldout(async_msgr->cct, 10) << __func__ << " connect successfully, ready to send banner" << dendl;
 
         bufferlist bl;
@@ -1306,6 +1307,7 @@ ssize_t AsyncConnection::_process_connection()
           goto fail;
 
         net.set_socket_options(sd);
+        net.set_priority(sd, async_msgr->get_socket_priority());
 
         bl.append(CEPH_BANNER, strlen(CEPH_BANNER));
 

--- a/src/msg/async/net_handler.h
+++ b/src/msg/async/net_handler.h
@@ -40,6 +40,7 @@ namespace ceph {
      */
     int reconnect(const entity_addr_t &addr, int sd);
     int nonblock_connect(const entity_addr_t &addr);
+    void set_priority(int sd, int priority);
   };
 }
 


### PR DESCRIPTION
To prioritize the heartbeat packets in the the diffserv-aware device.

Learn/copy from https://github.com/ceph/ceph/pull/3353

Signed-off-by: Haomai Wang <haomai@xsky.com>