### PR TITLE
msgr: set close on exec flag

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -104,7 +104,7 @@ int Processor::bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports)
     listen_sd = -1;
     return r;
   }
-
+  net.set_close_on_exec(listen_sd);
   net.set_socket_options(listen_sd);
 
   // use whatever user specified (if anything)
@@ -258,6 +258,7 @@ void Processor::accept()
     socklen_t slen = sizeof(ss);
     int sd = ::accept(listen_sd, (sockaddr*)&ss, &slen);
     if (sd >= 0) {
+      net.set_close_on_exec(sd);
       ldout(msgr->cct, 10) << __func__ << " accepted incoming on sd " << sd << dendl;
 
       msgr->add_accept(sd);

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -73,6 +73,22 @@ int NetHandler::set_nonblock(int sd)
   return 0;
 }
 
+void NetHandler::set_close_on_exec(int sd)
+{
+  int flags = fcntl(sd, F_GETFD, 0);
+  if (flags < 0) {
+    int r = errno;
+    lderr(cct) << __func__ << " fcntl(F_GETFD): "
+	       << cpp_strerror(r) << dendl;
+    return;
+  }
+  if (fcntl(sd, F_SETFD, flags | FD_CLOEXEC)) {
+    int r = errno;
+    lderr(cct) << __func__ << " fcntl(F_SETFD): "
+	       << cpp_strerror(r) << dendl;
+  }
+}
+
 void NetHandler::set_socket_options(int sd)
 {
   // disable Nagle algorithm?

--- a/src/msg/async/net_handler.h
+++ b/src/msg/async/net_handler.h
@@ -28,6 +28,7 @@ namespace ceph {
    public:
     explicit NetHandler(CephContext *c): cct(c) {}
     int set_nonblock(int sd);
+    void set_close_on_exec(int sd);
     void set_socket_options(int sd);
     int connect(const entity_addr_t &addr);
     

--- a/src/msg/simple/Accepter.cc
+++ b/src/msg/simple/Accepter.cc
@@ -37,6 +37,18 @@
  * Accepter
  */
 
+static int set_close_on_exec(int fd)
+{
+  int flags = fcntl(fd, F_GETFD, 0);
+  if (flags < 0) {
+    return errno;
+  }
+  if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC)) {
+    return errno;
+  }
+  return 0;
+}
+
 int Accepter::bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports)
 {
   const md_config_t *conf = msgr->cct->_conf;
@@ -61,6 +73,11 @@ int Accepter::bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports)
     lderr(msgr->cct) << "accepter.bind unable to create socket: "
 		     << cpp_strerror(errno) << dendl;
     return -errno;
+  }
+
+  if (set_close_on_exec(listen_sd)) {
+    lderr(msgr->cct) << "accepter.bind unable to set_close_exec(): "
+		     << cpp_strerror(errno) << dendl;
   }
 
   // use whatever user specified (if anything)
@@ -244,6 +261,11 @@ void *Accepter::entry()
     socklen_t slen = sizeof(ss);
     int sd = ::accept(listen_sd, (sockaddr*)&ss, &slen);
     if (sd >= 0) {
+      int r = set_close_on_exec(sd);
+      if (r) {
+	ldout(msgr->cct,0) << "accepter set_close_on_exec() failed "
+	      << cpp_strerror(r) << dendl;
+      }
       errors = 0;
       ldout(msgr->cct,10) << "accepted incoming on sd " << sd << dendl;
       


### PR DESCRIPTION
mds execv() when handling the "respawn" command, to avoid fd leakage,
and enormous CLOSE_WAIT connections after respawning, we need to set
FD_CLOEXEC flag for the socket fds.

Signed-off-by: Kefu Chai <kchai@redhat.com>