### PR TITLE
mds/CInode: fix potential fin hanging

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -995,6 +995,7 @@ void CInode::_stored(int r, version_t v, Context *fin)
     mdcache->mds->clog->error() << "failed to store ino " << ino() << " object,"
 				<< " errno " << r << "\n";
     mdcache->mds->handle_write_error(r);
+    fin->complete(r);
     return;
   }
 
@@ -1211,6 +1212,8 @@ void CInode::_stored_backtrace(int r, version_t v, Context *fin)
                                 << ", pool " << get_backtrace_pool()
                                 << ", errno " << r << "\n";
     mdcache->mds->handle_write_error(r);
+    if (fin)
+      fin->complete(r);
     return;
   }
 


### PR DESCRIPTION
The behaviour of handle_write_error() process is configurable
and therefore is  non-deterministic. Thus we'd better to finish
the context here anyway.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>