### PR TITLE
rgw: fix deadlock in RGWHTTPManager when HAVE_CURL_MULTI_WAIT=0

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -465,8 +465,11 @@ static int do_curl_wait(CephContext *cct, CURLM *handle, int signal_fd)
     return -EIO;
   }
 
-  if (signal_fd >= maxfd) {
-    maxfd = signal_fd + 1;
+  if (signal_fd > 0) {
+    FD_SET(signal_fd, &fdread);
+    if (signal_fd >= maxfd) {
+      maxfd = signal_fd + 1;
+    }
   }
 
   /* forcing a strict timeout, as the returned fdsets might not reference all fds we wait on */

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -718,6 +718,13 @@ ceph_test_rgw_period_history_LDADD = \
 ceph_test_rgw_period_history_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 bin_DEBUGPROGRAMS += ceph_test_rgw_period_history
 
+ceph_test_http_manager_SOURCES = test/rgw/test_http_manager.cc
+ceph_test_http_manager_LDADD = \
+	$(LIBRADOS) $(LIBRGW) $(LIBRGW_DEPS) $(CEPH_GLOBAL) \
+	$(UNITTEST_LDADD) $(CRYPTO_LIBS) -lcurl -lexpat
+ceph_test_http_manager_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+bin_DEBUGPROGRAMS += ceph_test_http_manager
+
 ceph_test_rgw_obj_SOURCES = test/rgw/test_rgw_obj.cc
 ceph_test_rgw_obj_LDADD = \
 	$(LIBRADOS) $(LIBRGW) $(LIBRGW_DEPS) $(CEPH_GLOBAL) \

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -3,6 +3,11 @@ add_executable(unittest_rgw_period_history EXCLUDE_FROM_ALL test_rgw_period_hist
 add_ceph_unittest(unittest_rgw_period_history ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rgw_period_history)
 target_link_libraries(unittest_rgw_period_history rgw_a)
 
+# unitttest_http_manager
+add_executable(unittest_http_manager EXCLUDE_FROM_ALL test_http_manager.cc)
+add_ceph_unittest(unittest_http_manager ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_http_manager)
+target_link_libraries(unittest_http_manager rgw_a)
+
 # ceph_test_rgw_manifest
 set(test_rgw_manifest_srcs test_rgw_manifest.cc)
 add_executable(ceph_test_rgw_manifest

--- a/src/test/rgw/test_http_manager.cc
+++ b/src/test/rgw/test_http_manager.cc
@@ -1,0 +1,59 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+#include "rgw/rgw_rados.h"
+#include "rgw/rgw_http_client.h"
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
+#include <curl/curl.h>
+#include <gtest/gtest.h>
+
+TEST(HTTPManager, SignalThread)
+{
+  auto cct = g_ceph_context;
+  RGWHTTPManager http(cct);
+
+  ASSERT_EQ(0, http.set_threaded());
+
+  // default pipe buffer size according to man pipe
+  constexpr size_t max_pipe_buffer_size = 65536;
+  // each signal writes 4 bytes to the pipe
+  constexpr size_t max_pipe_signals = max_pipe_buffer_size / sizeof(uint32_t);
+  // add_request and unregister_request
+  constexpr size_t pipe_signals_per_request = 2;
+  // number of http requests to fill the pipe buffer
+  constexpr size_t max_requests = max_pipe_signals / pipe_signals_per_request;
+
+  // send one extra request to test that we don't deadlock
+  constexpr size_t num_requests = max_requests + 1;
+
+  for (int i = 0; i < num_requests; i++) {
+    RGWHTTPClient client{cct};
+    http.add_request(&client, "PUT", "http://127.0.0.1:80");
+  }
+}
+
+int main(int argc, char** argv)
+{
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+
+  curl_global_init(CURL_GLOBAL_ALL);
+  ::testing::InitGoogleTest(&argc, argv);
+  int r = RUN_ALL_TESTS();
+  curl_global_cleanup();
+  return r;
+}


### PR DESCRIPTION
when HAVE_CURL_MULTI_WAIT is 0, the pipe fd is never added to the
readfds for select(), so FD_ISSET() is always false. this prevents us
from ever trying to read from the fd, and the pipe's buffer eventually
fills up and deadlocks callers of RGWHTTPManager::signal_thread() when
they try to write to the pipe

Fixes: http://tracker.ceph.com/issues/16368

a unit test is included which reproduces this deadlock when HAVE_CURL_MULTI_WAIT=0