### PR TITLE
client: fix access violation

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1706,10 +1706,11 @@ int Client::make_request(MetaRequest *request,
   if (!request->reply) {
     assert(request->aborted());
     assert(!request->got_unsafe);
+    r = request->get_abort_code();
     request->item.remove_myself();
     unregister_request(request);
     put_request(request); // ours
-    return request->get_abort_code();
+    return r;
   }
 
   // got it!

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1614,7 +1614,7 @@ int Client::make_request(MetaRequest *request,
 
   // make note
   mds_requests[tid] = request->get();
-  if (oldest_tid == 0 && request->get_op() != CEPH_MDS_OP_SETFILELOCK)\
+  if (oldest_tid == 0 && request->get_op() != CEPH_MDS_OP_SETFILELOCK)
     oldest_tid = tid;
 
   if (uid < 0)


### PR DESCRIPTION
The MetaRequest is a refcounted object. On construction, it will default ref to 1.
The general process to make an MDS request will be:

```
  MetaRequest *req = new MetaRequest(op);
  // fill in something
  int r = make_request(req, uid, gid, target);
  return r;
```

As mentioned, make_request() will put the passed request before returning(and thereby 
delete the request automatically).

To be more specific here, the make_request() will call "mds_requests[tid] = request->get();"
to keep the request well local tracked on entry(which raises the ref of request to 2). 
And on error exit(especially for the following no reply is received case), by calling both
 
```
    unregister_request(request);
    put_request(request); // ours 
```
	
, it will decrease the reference of the corresponding request to zero and thereby delete request. 
Therefore the call to request thereafter is at risk of "access violation". 
    
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>