### PR TITLE
common: Improve linux dcache hash algorithm

### DIFF
--- a/src/common/ceph_hash.cc
+++ b/src/common/ceph_hash.cc
@@ -82,7 +82,7 @@ unsigned ceph_str_hash_rjenkins(const char *str, unsigned length)
  */
 unsigned ceph_str_hash_linux(const char *str, unsigned length)
 {
-	unsigned long hash = 0;
+	unsigned hash = 0;
 
 	while (length--) {
 		unsigned char c = *str++;


### PR DESCRIPTION
Test code for profiling: [hash-profile2.tar.gz](https://github.com/ceph/ceph/files/325058/hash-profile2.tar.gz)

In ceph_str_hash_linux(), hash value is defined as unsigned **long**,
which is 8 bytes on 64-bit platforms when compiled with gcc. But
the return value is truncated to 4 bytes, and there's no need to
preserve 8 bytes intermediate value in the algorithm. The compiler
doesn't figure out this fact and produces redundant code.

```c
unsigned ceph_str_hash_linux(const char *str, unsigned length)
{
        /* "long" introduces performance penalty, should be deleted. */
        unsigned long hash = 0;

        while (length--) {
                unsigned char c = *str++; 
                hash = (hash + (c << 4) + (c >> 4)) * 11;
        }
        return hash;
}
```

After removing the "long" definition, this route runs much faster.
Following result are tested on x86_64 and aarch64 platforms, built
by gcc 5.3.1 with optimization level -O2. Same output is observed
with gcc 4.8.4 and -O3 optimization.

*ARM Cortex-A57*

String Length | Time w/ long | Time w/o long | Improvement 
------------- | ------------ | ------------- | -----------
 32            | 0.088 us     | 0.067 us      | 24%         
 4096          | 10.26 us     | 8.20 us       | 20%         
 65536         | 164 us       | 131 us        | 20%         
 1048576       | 2624 us      | 2099 us       | 20%         

*Intel i7-4790*

String Length | Time w/ long | Time w/o long | Improvement
--------------- | -------------- | --------------- | -------------
 32            | 0.033 us     | 0.028 us      | 16.3%       
 4096          | 3.87 us      | 3.64 us       | 6.2%        
 65536         | 61.3 us      | 57.8 us       | 5.7%        
 1048576       | 973 us       | 917 us        | 5.8%        

Signed-off-by: Yibo Cai <yibo.cai@linaro.org>