### PR TITLE
rgw: kill compiling warning

### DIFF
--- a/src/test/rgw/test_http_manager.cc
+++ b/src/test/rgw/test_http_manager.cc
@@ -37,7 +37,7 @@ TEST(HTTPManager, SignalThread)
   // send one extra request to test that we don't deadlock
   constexpr size_t num_requests = max_requests + 1;
 
-  for (int i = 0; i < num_requests; i++) {
+  for (int i = 0; i < (int)num_requests; i++) {
     RGWHTTPClient client{cct};
     http.add_request(&client, "PUT", "http://127.0.0.1:80");
   }


### PR DESCRIPTION
```
test/rgw/test_http_manager.cc: In member function ‘virtual void HTTPManager_SignalThread_Test::TestBody()’:
test/rgw/test_http_manager.cc:40:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < num_requests; i++) {
                       ^
```
Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>