### PR TITLE
ceph: Fix rados bench seq/rand tests to work when -b op-size != -o ob…

### DIFF
--- a/doc/dev/perf.rst
+++ b/doc/dev/perf.rst
@@ -1,0 +1,39 @@
+Using perf
+==========
+
+Top::
+
+  sudo perf top -p `pidof ceph-osd`
+
+To capture some data with call graphs::
+
+  sudo perf record -p `pidof ceph-osd` -F 99 --call-graph dwarf -- sleep 60
+
+To view by caller (where you can see what each top function calls)::
+
+  sudo perf report --call-graph caller
+
+To view by callee (where you can see who calls each each top function)::  
+
+  sudo perf report --call-graph callee
+
+:note: If the the caller/callee views look the same you may be
+       suffering from a kernel bug; upgrade to 4.8 or later.
+
+Flamegraphs
+-----------
+
+First, get things set up::
+
+  cd ~/src
+  git clone https://github.com/brendangregg/FlameGraph
+
+Run ceph, then record some perf data::
+
+  sudo perf record -p `pidof ceph-osd` -F 99 --call-graph dwarf -- sleep 60
+
+Then generate the flamegraph::
+
+  sudo perf script | ~/src/FlameGraph/stackcollapse-perf.pl > /tmp/folded
+  ~/src/FlameGraph/flamegraph.pl /tmp/folded > /tmp/perf.svg
+  firefox /tmp/perf.svg

--- a/doc/install/install-ceph-gateway.rst
+++ b/doc/install/install-ceph-gateway.rst
@@ -241,7 +241,7 @@ configuration file, restart your gateway. On Red Hat Enteprise Linux execute::
 
 On Ubuntu execute::
 
- sudo service radosgw restart id=rgw.<short-hostname>sudo service radosgw restart id=rgw.<short-hostname>
+ sudo service radosgw restart id=rgw.<short-hostname>
 
 For federated configurations, each zone may have a different ``index_pool``
 setting for failover. To make the value consistent for a region's zones, you

--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -237,6 +237,17 @@ scrubbing operations.
 :Type: Integer in the range of 0 to 24
 :Default: ``24``
 
+
+``osd scrub during recovery``
+
+:Description: Allow scrub during recovery. Setting this to ``false`` will disable
+              scheduling new scrub (and deep--scrub) while there is active recovery.
+              Already running scrubs will be continued. This might be useful to reduce
+              load on busy clusters.
+:Type: Boolean
+:Default: ``true``
+
+
 ``osd scrub thread timeout`` 
 
 :Description: The maximum time in seconds before timing out a scrub thread.
@@ -279,6 +290,32 @@ scrubbing operations.
 
 :Type: Float
 :Default: Once per week. ``7*60*60*24``
+
+
+``osd scrub chunk min``
+
+:Description: The minimal number of object store chunks to scrub during single operation.
+              Ceph blocks writes to single chunk during scrub.
+
+:Type: 32-bit Integer
+:Default: 5
+
+
+``osd scrub chunk max``
+
+:Description: The maximum number of object store chunks to scrub during single operation.
+
+:Type: 32-bit Integer
+:Default: 25
+
+
+``osd scrub sleep``
+
+:Description: Time to sleep before scrubbing next group of chunks. Increasing this value will slow
+              down whole scrub operation while client operations will be less impacted.
+
+:Type: Float
+:Default: 0
 
 
 ``osd deep scrub interval``

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -227,6 +227,7 @@ int ObjBencher::aio_bench(
     return -EINVAL;
 
   int num_objects = 0;
+  int num_writes = 0;
   int r = 0;
   int prevPid = 0;
   utime_t runtime;
@@ -238,7 +239,7 @@ int ObjBencher::aio_bench(
   if (operation != OP_WRITE) {
     uint64_t prev_op_size, prev_object_size;
     r = fetch_bench_metadata(run_name_meta, &prev_op_size, &prev_object_size,
-			     &num_objects, &prevPid);
+			     &num_objects, &num_writes, &prevPid);
     if (r < 0) {
       if (r == -ENOENT)
         cerr << "Must write data before running a read benchmark!" << std::endl;
@@ -273,17 +274,17 @@ int ObjBencher::aio_bench(
     if (r != 0) goto out;
   }
   else if (OP_SEQ_READ == operation) {
-    r = seq_read_bench(secondsToRun, num_objects, concurrentios, prevPid, no_verify);
+    r = seq_read_bench(secondsToRun, num_objects, num_writes, concurrentios, prevPid, no_verify);
     if (r != 0) goto out;
   }
   else if (OP_RAND_READ == operation) {
-    r = rand_read_bench(secondsToRun, num_objects, concurrentios, prevPid, no_verify);
+    r = rand_read_bench(secondsToRun, num_objects, num_writes, concurrentios, prevPid, no_verify);
     if (r != 0) goto out;
   }
 
   if (OP_WRITE == operation && cleanup) {
     r = fetch_bench_metadata(run_name_meta, &op_size, &object_size,
-			     &num_objects, &prevPid);
+			     &num_objects, &num_writes, &prevPid);
     if (r < 0) {
       if (r == -ENOENT)
         cerr << "Should never happen: bench metadata missing for current run!" << std::endl;
@@ -354,12 +355,13 @@ static T vec_stddev(vector<T>& v)
 
 int ObjBencher::fetch_bench_metadata(const std::string& metadata_file,
 				     uint64_t *op_size, uint64_t* object_size,
-				     int* num_objects, int* prevPid) {
+				     int* num_objects, int* num_writes,
+				     int* prevPid) {
   int r = 0;
   bufferlist object_data;
 
   r = sync_read(metadata_file, object_data,
-		sizeof(int) * 2 + sizeof(size_t) * 2);
+		sizeof(int) * 3 + sizeof(size_t) * 2);
   if (r <= 0) {
     // treat an empty file as a file that does not exist
     if (r == 0) {
@@ -375,6 +377,11 @@ int ObjBencher::fetch_bench_metadata(const std::string& metadata_file,
     ::decode(*op_size, p);
   } else {
     *op_size = *object_size;
+  }
+  if (!p.end()) {
+    ::decode(*num_writes, p);
+  } else {
+    *num_writes = *num_objects;
   }
 
   return 0;
@@ -609,6 +616,7 @@ int ObjBencher::write_bench(int secondsToRun,
   ::encode(num_objects, b_write);
   ::encode(getpid(), b_write);
   ::encode(data.op_size, b_write);
+  ::encode(data.started, b_write);
 
   // persist meta-data for further cleanup or read
   sync_write(run_name_meta, b_write, sizeof(int)*3);
@@ -631,7 +639,7 @@ int ObjBencher::write_bench(int secondsToRun,
   return r;
 }
 
-int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurrentios, int pid, bool no_verify) {
+int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int num_writes, int concurrentios, int pid, bool no_verify) {
   lock_cond lc(&lock);
 
   if (concurrentios <= 0) 
@@ -699,7 +707,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
 
   slot = 0;
   while ((!seconds_to_run || ceph_clock_now(cct) < finish_time) &&
-	 num_objects > data.started) {
+	 num_writes > data.started) {
     lock.Lock();
     int old_slot = slot;
     bool found = false;
@@ -857,7 +865,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
   return r;
 }
 
-int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurrentios, int pid, bool no_verify)
+int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int num_writes, int concurrentios, int pid, bool no_verify)
 {
   lock_cond lc(&lock);
 
@@ -875,6 +883,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   time_to_run.set_from_double(seconds_to_run);
   double total_latency = 0;
   int r = 0;
+  int rand_id;
   utime_t runtime;
   sanitize_object_contents(&data, data.op_size); //clean it up once; subsequent
   //changes will be safe because string length should remain the same
@@ -891,7 +900,6 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
 
   //set up initial reads
   for (int i = 0; i < concurrentios; ++i) {
-    name[i] = generate_object_name(i / writes_per_object, pid);
     contents[i] = new bufferlist();
   }
 
@@ -907,11 +915,13 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   utime_t finish_time = data.start_time + time_to_run;
   //start initial reads
   for (int i = 0; i < concurrentios; ++i) {
-    index[i] = i;
+    rand_id = rand() % num_writes;
+    name[i] = generate_object_name(rand_id / writes_per_object, pid);
+    index[i] = rand_id;
     start_times[i] = ceph_clock_now(g_ceph_context);
     create_completion(i, _aio_cb, (void *)&lc);
     r = aio_read(name[i], i, contents[i], data.op_size,
-		 data.op_size * (i % writes_per_object));
+		 data.op_size * (rand_id % writes_per_object));
     if (r < 0) { //naughty, doesn't clean up heap -- oh, or handle the print thread!
       cerr << "r = " << r << std::endl;
       goto ERR;
@@ -925,7 +935,6 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   //keep on adding new reads as old ones complete
   int slot;
   bufferlist *cur_contents;
-  int rand_id;
 
   slot = 0;
   while ((!seconds_to_run || ceph_clock_now(g_ceph_context) < finish_time)) {
@@ -982,7 +991,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
       }
     } 
 
-    rand_id = rand() % num_objects;
+    rand_id = rand() % num_writes;
     newName = generate_object_name(rand_id / writes_per_object, pid);
     index[slot] = rand_id;
     release_completion(slot);
@@ -1093,6 +1102,7 @@ int ObjBencher::clean_up(const std::string& orig_prefix, int concurrentios, cons
   int r = 0;
   uint64_t op_size, object_size;
   int num_objects;
+  int num_writes;
   int prevPid;
 
   // default meta object if user does not specify one
@@ -1139,7 +1149,7 @@ int ObjBencher::clean_up(const std::string& orig_prefix, int concurrentios, cons
       continue;
     }
 
-    r = fetch_bench_metadata(run_name_meta, &op_size, &object_size, &num_objects, &prevPid);
+    r = fetch_bench_metadata(run_name_meta, &op_size, &object_size, &num_objects, &num_writes, &prevPid);
     if (r < 0) {
       return r;
     }

--- a/src/common/obj_bencher.h
+++ b/src/common/obj_bencher.h
@@ -73,11 +73,12 @@ protected:
   struct bench_data data;
 
   int fetch_bench_metadata(const std::string& metadata_file, uint64_t* op_size,
-			   uint64_t* object_size, int* num_objects, int* prevPid);
+			   uint64_t* object_size, int* num_objects,
+			   int* num_writes, int* prevPid);
 
   int write_bench(int secondsToRun, int concurrentios, const string& run_name_meta, unsigned max_objects);
-  int seq_read_bench(int secondsToRun, int num_objects, int concurrentios, int writePid, bool no_verify=false);
-  int rand_read_bench(int secondsToRun, int num_objects, int concurrentios, int writePid, bool no_verify=false);
+  int seq_read_bench(int secondsToRun, int num_objects, int num_writes, int concurrentios, int writePid, bool no_verify=false);
+  int rand_read_bench(int secondsToRun, int num_objects, int num_writes, int concurrentios, int writePid, bool no_verify=false);
 
   int clean_up(int num_objects, int prevPid, int concurrentios);
   bool more_objects_matching_prefix(const std::string& prefix, std::list<Object>* name);

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -893,7 +893,8 @@ void Pipe::set_socket_options()
     int r = ::setsockopt(sd, IPPROTO_TCP, TCP_NODELAY, (char*)&flag, sizeof(flag));
     if (r < 0) {
       r = -errno;
-      ldout(msgr->cct,0) << "couldn't set TCP_NODELAY: " << cpp_strerror(r) << dendl;
+      ldout(msgr->cct,0) << "couldn't set TCP_NODELAY: "
+                         << cpp_strerror(r) << dendl;
     }
   }
   if (msgr->cct->_conf->ms_tcp_rcvbuf) {
@@ -901,7 +902,8 @@ void Pipe::set_socket_options()
     int r = ::setsockopt(sd, SOL_SOCKET, SO_RCVBUF, (void*)&size, sizeof(size));
     if (r < 0)  {
       r = -errno;
-      ldout(msgr->cct,0) << "couldn't set SO_RCVBUF to " << size << ": " << cpp_strerror(r) << dendl;
+      ldout(msgr->cct,0) << "couldn't set SO_RCVBUF to " << size
+                         << ": " << cpp_strerror(r) << dendl;
     }
   }
 
@@ -911,7 +913,8 @@ void Pipe::set_socket_options()
   int r = ::setsockopt(sd, SOL_SOCKET, SO_NOSIGPIPE, (void*)&val, sizeof(val));
   if (r) {
     r = -errno;
-    ldout(msgr->cct,0) << "couldn't set SO_NOSIGPIPE: " << cpp_strerror(r) << dendl;
+    ldout(msgr->cct,0) << "couldn't set SO_NOSIGPIPE: "
+                       << cpp_strerror(r) << dendl;
   }
 #endif
 
@@ -922,8 +925,9 @@ void Pipe::set_socket_options()
     int iptos = IPTOS_CLASS_CS6;
     r = ::setsockopt(sd, IPPROTO_IP, IP_TOS, &iptos, sizeof(iptos));
     if (r < 0) {
+      r = -errno;
       ldout(msgr->cct,0) << "couldn't set IP_TOS to " << iptos
-                         << ": " << cpp_strerror(errno) << dendl;
+                         << ": " << cpp_strerror(r) << dendl;
     }
 #endif
 #if defined(SO_PRIORITY) 
@@ -934,8 +938,9 @@ void Pipe::set_socket_options()
     r = ::setsockopt(sd, SOL_SOCKET, SO_PRIORITY, &prio, sizeof(prio));
 #endif
     if (r < 0) {
+      r = -errno;
       ldout(msgr->cct,0) << "couldn't set SO_PRIORITY to " << prio
-                         << ": " << cpp_strerror(errno) << dendl;
+                         << ": " << cpp_strerror(r) << dendl;
     }
 #endif
   }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -228,7 +228,7 @@ protected:
   void update_osdmap_ref(OSDMapRef newmap) {
     assert(_lock.is_locked_by_me());
     Mutex::Locker l(map_lock);
-    osdmap_ref = newmap;
+    osdmap_ref = std::move(newmap);
   }
 
   OSDMapRef get_osdmap_with_maplock() const {

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -916,7 +916,7 @@ protected:
 
   int aio_read(const std::string& oid, int slot, bufferlist *pbl, size_t len,
 	       size_t offset) {
-    return io_ctx.aio_read(oid, completions[slot], pbl, len, 0);
+    return io_ctx.aio_read(oid, completions[slot], pbl, len, offset);
   }
 
   int aio_write(const std::string& oid, int slot, bufferlist& bl, size_t len,


### PR DESCRIPTION
…ject-size

rados bench write correctly creates objects whose object_size is a multiple of
op_size, but radios bench seq and rand cannot read them, failing with:
    benchmark_data_alpha1-p200_7856_object0 is not correct!

There are a number of issues concerning this bug, discovered one at a time.
Routine aio_read() in rados.cc is hard-coded to read an object at offset zero,
no matter what offset it is passed.

Routine seq_read_bench() in obj_bencher.cc stops reading after "num_objects"
I/Os, when it should issue "num_objects \* writes_per_object" reads (but see
below), so the test run times are unexpectedly short.

In routine rand_read_bench(), the first "concurrentios" I/Os are actually
sequential reads of the first few objects, not random. Also, the routine
only generates random offsets modulo "num_objects", not
"num_objects \* writes_per_object", so the I/O distribution ignores most of
the higher-numbered objects (but see next).

If a rados bench write test finishes based on time, not number of objects,
then the last object written is usually shorter than the rest. Fixing the
above issues causes the seq and rand tests to issue I/Os beyond the end of
that final shorter object.

The solution is to record the number of writes issued by rados bench write
as an additional parameter in the "bench_metadata" file (num_writes). The
seq test then issues "num_writes" reads and doesn't run off the end of the
last object. The rand test generates a random number modulo "num_writes",
then converts that to an object and offset pair, also avoiding any reads
beyond the end of the last object, and the I/O distribution across the
entire set of objects and across offsets within objects is balanced.

The code in this fix is unencumbered by any other license.
Fixes: #16385
Signed-off-by: krehm
