### PR TITLE
fuse_ll: fix incorrect error settings of fuse_ll_mkdir()

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -340,11 +340,11 @@ static void fuse_ll_mkdir(fuse_req_t req, fuse_ino_t parent, const char *name,
     int err = 0;
     int fd = ::open(cfuse->mountpoint, O_RDONLY | O_DIRECTORY);
     if (fd < 0) {
-      err = -errno;
+      err = errno;
     } else {
       int r = ::syncfs(fd);
       if (r < 0)
-	err = -errno;
+	err = errno;
       ::close(fd);
     }
     if (err) {


### PR DESCRIPTION
As fuse_reply_err() actually requires a positive error number.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>