### PR TITLE
rgw_swift: newer versions of boost/utility no longer include in_place

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <boost/optional.hpp>
+#include <boost/utility/in_place_factory.hpp>
 
 #include "include/assert.h"
 


### PR DESCRIPTION
boost > 1.58 no longer includes in_place in boost/utility, we need to
include in_place_factory explicitly. This causes build failures in
distros that ship with a higher version of boost. Since the only call is for
swift_ver_location, another possibility is to use emplace()
instead (though this requires boost ~ 1.56)

Fixes: http://tracker.ceph.com/issues/16391
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>