### PR TITLE
rgw: fix the missing return value of init_watch

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3974,7 +3974,6 @@ int RGWRados::init_watch()
 
   librados::Rados *rad = &rados[0];
   int r = rad->ioctx_create(control_pool, control_pool_ctx);
-
   if (r == -ENOENT) {
     r = rad->pool_create(control_pool);
     if (r == -EEXIST)
@@ -3985,6 +3984,8 @@ int RGWRados::init_watch()
     r = rad->ioctx_create(control_pool, control_pool_ctx);
     if (r < 0)
       return r;
+  } else if (r < 0) {
+    return r;
   }
 
   num_watchers = cct->_conf->rgw_num_control_oids;


### PR DESCRIPTION
we should return the negative error number if `ioctx_create` creates `control_pool_ctx` failed. otherwise, it will run into exception:
```
    r = control_pool_ctx.create(notify_oid, false);
    if (r < 0 && r != -EEXIST)
      return r;
```
Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>