### PR TITLE
cmake: unittest_librbd missing a source file

### DIFF
--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -22,6 +22,7 @@ set_target_properties(rbd_test_mock PROPERTIES COMPILE_FLAGS
 # unittest_librbd
 # doesn't use add_ceph_test because it is called by run-rbd-unit-tests.sh
 set(unittest_librbd_srcs
+  test_ConsistencyGroups.cc 
   test_main.cc
   test_mock_fixture.cc 
   test_mock_ExclusiveLock.cc 


### PR DESCRIPTION
src/test/librbd/test_ConsistencyGroups.cc missing
from ${unittest_librbd_srcs}.

Signed-off-by: Ali Maredia <amaredia@redhat.com>