### PR TITLE
msg/async: fix trying to wake up worker event which is already waked up when shuting down msgr

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -428,6 +428,12 @@ void WorkerPool::barrier()
   pthread_t cur = pthread_self();
   for (vector<Worker*>::iterator it = workers.begin(); it != workers.end(); ++it) {
     assert(cur != (*it)->center.get_owner());
+    if ((*it)->center.already_wakeup.read()) {
+      ldout(cct, 10) << __func__ << " worker Event=" << &((*it)->center) 
+        << " already_wakeup" << dendl;
+      continue;
+    }
+
     barrier_count.inc();
     (*it)->center.dispatch_event_external(EventCallbackRef(new C_barrier(this)));
   }


### PR DESCRIPTION
Fixes: #16396

This issue was found in jewel when restarting/stopping mds. It took long time for mds to completely stop until mds thread timed out. This is caused by when shutting down async msgr, it will try to dispatch external barrier event to a worker and wake it up, but this worker has been processed clean_handler event before, so its event status is already waked up. Hence this barrier event can't be processed further and msgr thread will be stuck at waiting for barrier count.

In shutting down msgr, we can check if this worker's event status is already waked up. If yes, I think there is no need to barrier this worker.

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>