### PR TITLE
vstart: set osd_check_max_object_name_len_on_startup

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -513,6 +513,7 @@ $CMDSDEBUG
 $extra_conf
 [osd]
 $DAEMONOPTS
+        osd_check_max_object_name_len_on_startup = false
         osd data = $CEPH_DEV_DIR/osd\$id
         osd journal = $CEPH_DEV_DIR/osd\$id/journal
         osd journal size = 100


### PR DESCRIPTION
For the benefit of those running vstart clusters on local dev machines with a filesystem that trips the object name len check.