### PR TITLE
Wip rgw : bucket create - avoid listing all entries

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -275,7 +275,12 @@ static int cls_user_remove_bucket(cls_method_context_t hctx, bufferlist *in, buf
   }
 
 
-  entry.bucket_count = 1;
+  if (entry.user_stats_sync){
+    //we set user_stats_sync to true when we create a bucket
+    // as far as nobody overrides the stats are handled correctly
+    // if anyone else overrides this then the bucket header stats are no longer valid
+    dec_header_stats(&header.stats, entry, true);
+  }
 
   CLS_LOG(20, "removing entry at %s", key.c_str());
 
@@ -283,11 +288,7 @@ static int cls_user_remove_bucket(cls_method_context_t hctx, bufferlist *in, buf
   if (ret < 0)
     return ret;
 
-  // TODO: find better ways to handle this user_stats_sync isn't set in all
-  // buckets but we need to always decrement the header count anyway since we
-  // use that instead of all the entries
-  dec_header_stats(&header.stats, entry, true);
-
+  // write the header stats to disk
   CLS_LOG(20, "header: total bytes=%lld entries=%lld buckets=%lld",
 	  (long long)header.stats.total_bytes, (long long)header.stats.total_entries,
 	  (long long)header.stats.total_buckets);

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -168,7 +168,8 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     if (ret < 0) {
       CLS_LOG(0, "ERROR: get_existing_bucket_entry() key=%s returned %d", key.c_str(), ret);
       return ret;
-    } else if (ret >= 0 && entry.user_stats_sync) {      // only delete if we are actually doing an op.add which means that this is a rewrite
+    } else if (ret >= 0 && entry.user_stats_sync) {
+      // only delete if we are actually doing an op.add which means that this is a rewrite
       dec_header_stats(&header.stats, entry, op.add);
     }
 

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -172,8 +172,9 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
       dec_header_stats(&header.stats, entry, op.add);
     }
 
-    CLS_LOG(20, "storing entry for key=%s size=%lld count=%lld",
-            key.c_str(), (long long)update_entry.size, (long long)update_entry.count);
+    CLS_LOG(20, "storing entry for key=%s size=%lld count=%lld bucket_count=%lld",
+            key.c_str(), (long long)update_entry.size, (long long)update_entry.count,
+	    (long long)update_entry.bucket_count);
 
     apply_entry_stats(update_entry, &entry);
     entry.user_stats_sync = true;
@@ -189,7 +190,9 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
 
   bufferlist bl;
 
-  CLS_LOG(20, "header: total bytes=%lld entries=%lld", (long long)header.stats.total_bytes, (long long)header.stats.total_entries);
+  CLS_LOG(20, "header: total bytes=%lld entries=%lld buckets=%lld",
+	  (long long)header.stats.total_bytes, (long long)header.stats.total_entries,
+	  (long long)header.stats.total_buckets);
 
   if (header.last_stats_update < op.time)
     header.last_stats_update = op.time;

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -168,8 +168,8 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     if (ret < 0) {
       CLS_LOG(0, "ERROR: get_existing_bucket_entry() key=%s returned %d", key.c_str(), ret);
       return ret;
-    } else if (ret >= 0 && entry.user_stats_sync) {
-      dec_header_stats(&header.stats, entry);
+    } else if (ret >= 0 && entry.user_stats_sync) {      // only delete if we are actually doing an op.add which means that this is a rewrite
+      dec_header_stats(&header.stats, entry, op.add);
     }
 
     CLS_LOG(20, "storing entry for key=%s size=%lld count=%lld",
@@ -182,8 +182,7 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     if (ret < 0)
       return ret;
 
-    if (op.add)
-      add_header_stats(&header.stats, entry);
+    add_header_stats(&header.stats, entry, op.add);
 
   }
 

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -105,6 +105,7 @@ static void add_header_stats(cls_user_stats *stats, cls_user_bucket_entry& entry
   stats->total_entries += entry.count;
   stats->total_bytes += entry.size;
   stats->total_bytes_rounded += entry.size_rounded;
+  stats->total_buckets += entry.bucket_count;
 }
 
 static void dec_header_stats(cls_user_stats *stats, cls_user_bucket_entry& entry)
@@ -112,6 +113,7 @@ static void dec_header_stats(cls_user_stats *stats, cls_user_bucket_entry& entry
   stats->total_bytes -= entry.size;
   stats->total_bytes_rounded -= entry.size_rounded;
   stats->total_entries -= entry.count;
+  stats->total_buckets -= entry.bucket_count;
 }
 
 static void apply_entry_stats(const cls_user_bucket_entry& src_entry, cls_user_bucket_entry *target_entry)
@@ -119,6 +121,7 @@ static void apply_entry_stats(const cls_user_bucket_entry& src_entry, cls_user_b
   target_entry->size = src_entry.size;
   target_entry->size_rounded = src_entry.size_rounded;
   target_entry->count = src_entry.count;
+  target_entry->bucket_count = src_entry.bucket_count;
 }
 
 static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, bufferlist *out)

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -100,20 +100,22 @@ static int read_header(cls_method_context_t hctx, cls_user_header *header)
   return 0;
 }
 
-static void add_header_stats(cls_user_stats *stats, cls_user_bucket_entry& entry)
+static void add_header_stats(cls_user_stats *stats, cls_user_bucket_entry& entry, bool need_bucket_add=false)
 {
   stats->total_entries += entry.count;
   stats->total_bytes += entry.size;
   stats->total_bytes_rounded += entry.size_rounded;
-  stats->total_buckets += entry.bucket_count;
+  if (need_bucket_add)
+    stats->total_buckets += entry.bucket_count;
 }
 
-static void dec_header_stats(cls_user_stats *stats, cls_user_bucket_entry& entry)
+static void dec_header_stats(cls_user_stats *stats, cls_user_bucket_entry& entry, bool need_delete=false)
 {
   stats->total_bytes -= entry.size;
   stats->total_bytes_rounded -= entry.size_rounded;
   stats->total_entries -= entry.count;
-  stats->total_buckets -= entry.bucket_count;
+  if (need_delete)
+    stats->total_buckets -= entry.bucket_count;
 }
 
 static void apply_entry_stats(const cls_user_bucket_entry& src_entry, cls_user_bucket_entry *target_entry)

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -177,8 +177,11 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     if (ret < 0)
       return ret;
 
-    add_header_stats(&header.stats, entry);
+    if (op.add)
+      add_header_stats(&header.stats, entry);
+
   }
+
 
   bufferlist bl;
 
@@ -262,16 +265,20 @@ static int cls_user_remove_bucket(cls_method_context_t hctx, bufferlist *in, buf
     return ret;
   }
 
-  if (entry.user_stats_sync) {
-    dec_header_stats(&header.stats, entry);
-  }
+
+  /* if (entry.user_stats_sync) { */
+  /*   dec_header_stats(&header.stats, entry); */
+  /* } */
 
   CLS_LOG(20, "removing entry at %s", key.c_str());
 
   ret = remove_entry(hctx, key);
   if (ret < 0)
     return ret;
-  
+
+  // decrease stats after removal actually succeeds
+  dec_header_stats(&header.stats, entry);
+
   return 0;
 }
 

--- a/src/cls/user/cls_user_types.cc
+++ b/src/cls/user/cls_user_types.cc
@@ -43,6 +43,7 @@ void cls_user_bucket_entry::dump(Formatter *f) const
   encode_json("creation_time", utime_t(creation_time), f);
   encode_json("count", count, f);
   encode_json("user_stats_sync", user_stats_sync, f);
+  encode_json("bucket_count", bucket_count, f);
 }
 
 void cls_user_gen_test_bucket_entry(cls_user_bucket_entry *entry, int i)
@@ -53,6 +54,7 @@ void cls_user_gen_test_bucket_entry(cls_user_bucket_entry *entry, int i)
   entry->creation_time = real_clock::from_time_t(i + 3);
   entry->count = i + 4;
   entry->user_stats_sync = true;
+  entry->bucket_count = i;
 }
 
 void cls_user_bucket_entry::generate_test_instances(list<cls_user_bucket_entry*>& ls)
@@ -68,6 +70,7 @@ void cls_user_gen_test_stats(cls_user_stats *s)
   s->total_entries = 1;
   s->total_bytes = 2;
   s->total_bytes_rounded = 3;
+  s->total_buckets = 1;
 }
 
 void cls_user_stats::dump(Formatter *f) const
@@ -75,6 +78,7 @@ void cls_user_stats::dump(Formatter *f) const
   f->dump_int("total_entries", total_entries);
   f->dump_int("total_bytes", total_bytes);
   f->dump_int("total_bytes_rounded", total_bytes_rounded);
+  f->dump_int("total_buckets", total_buckets);
 }
 
 void cls_user_stats::generate_test_instances(list<cls_user_stats*>& ls)

--- a/src/cls/user/cls_user_types.h
+++ b/src/cls/user/cls_user_types.h
@@ -76,11 +76,12 @@ struct cls_user_bucket_entry {
   real_time creation_time;
   uint64_t count;
   bool user_stats_sync;
+  uint64_t bucket_count;
 
-  cls_user_bucket_entry() : size(0), size_rounded(0), count(1), user_stats_sync(false) {}
+  cls_user_bucket_entry() : size(0), size_rounded(0), count(0), user_stats_sync(false), bucket_count(0) {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(7, 5, bl);
+    ENCODE_START(8, 5, bl);
     uint64_t s = size;
     __u32 mt = ceph::real_clock::to_time_t(creation_time);
     string empty_str;  // originally had the bucket name here, but we encode bucket later
@@ -93,10 +94,11 @@ struct cls_user_bucket_entry {
     ::encode(s, bl);
     ::encode(user_stats_sync, bl);
     ::encode(creation_time, bl);
+    ::encode(bucket_count, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(6, 5, 5, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(7, 5, 5, bl);
     __u32 mt;
     uint64_t s;
     string empty_str;  // backward compatibility
@@ -118,6 +120,8 @@ struct cls_user_bucket_entry {
       ::decode(user_stats_sync, bl);
     if (struct_v >= 7)
       ::decode(creation_time, bl);
+    if (struct_v >= 8)
+      ::decode(bucket_count, bl);
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
@@ -129,24 +133,29 @@ struct cls_user_stats {
   uint64_t total_entries;
   uint64_t total_bytes;
   uint64_t total_bytes_rounded;
+  uint64_t total_buckets;
 
   cls_user_stats()
     : total_entries(0),
       total_bytes(0),
-      total_bytes_rounded(0) {}
+      total_bytes_rounded(0),
+      total_buckets(0){}
 
   void encode(bufferlist& bl) const {
-     ENCODE_START(1, 1, bl);
+     ENCODE_START(2, 1, bl);
     ::encode(total_entries, bl);
     ::encode(total_bytes, bl);
     ::encode(total_bytes_rounded, bl);
+    ::encode(total_buckets, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(2, 1, 1, bl);
     ::decode(total_entries, bl);
     ::decode(total_bytes, bl);
     ::decode(total_bytes_rounded, bl);
+    if (struct_v >=2)
+      ::decode(total_buckets, bl);
     DECODE_FINISH(bl);
   }
 

--- a/src/cls/user/cls_user_types.h
+++ b/src/cls/user/cls_user_types.h
@@ -77,7 +77,7 @@ struct cls_user_bucket_entry {
   uint64_t count;
   bool user_stats_sync;
 
-  cls_user_bucket_entry() : size(0), size_rounded(0), count(0), user_stats_sync(false) {}
+  cls_user_bucket_entry() : size(0), size_rounded(0), count(1), user_stats_sync(false) {}
 
   void encode(bufferlist& bl) const {
     ENCODE_START(7, 5, bl);

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -192,6 +192,11 @@ int rgw_link_bucket(RGWRados *store, const rgw_user& user_id, rgw_bucket& bucket
 
   bucket.convert(&new_bucket.bucket);
   new_bucket.size = 0;
+
+  // we set the bucket_count here, this is the only method that shall
+  // update  the count
+  new_bucket.bucket_count = 1;
+
   if (real_clock::is_zero(creation_time))
     new_bucket.creation_time = real_clock::now();
   else

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1926,7 +1926,7 @@ int RGWCreateBucket::verify_permission()
       }
       return op_ret;
     }
-    if ((int)header.stats.total_entries >= s->user->max_buckets){
+    if ((int)header.stats.total_buckets >= s->user->max_buckets){
       return -ERR_TOO_MANY_BUCKETS;
     }
   }


### PR DESCRIPTION
Avoid counting the buckets/omap entries during bucket create, update the stats in the bucket header object instead. Now we do have an additional call for omap header update too when we do deletion; on the other hand we avoid getting the full list of keys during bucket create. We can probably improvise here by deferring this check until we actually link the bucket maybe.. (modify one of the user to hold the max_buckets also maybe?) 
