### PR TITLE
msg/AsyncMessenger: remove unneeded include

### DIFF
--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -20,7 +20,6 @@
 #include "include/types.h"
 #include "include/xlist.h"
 
-#include <list>
 #include <map>
 using namespace std;
 #include "include/unordered_map.h"


### PR DESCRIPTION
Signed-off-by: Michal Jarzabek stiopa@gmail.com
