### PR TITLE
librbd: flag image as updated after proxying maintenance op

### DIFF
--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -235,6 +235,8 @@ struct C_InvokeAsyncRequest : public Context {
     ldout(cct, 20) << __func__ << ": r=" << r << dendl;
 
     if (r != -ETIMEDOUT && r != -ERESTART) {
+      image_ctx.state->handle_update_notification();
+
       complete(r);
       return;
     }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16404
Signed-off-by: Jason Dillaman <dillaman@redhat.com>