### PR TITLE
rgw: add pg_ver to tombstone_cache

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7757,9 +7757,9 @@ int RGWRados::Object::Delete::delete_obj()
   int64_t poolid = ref.ioctx.get_id();
   if (r >= 0) {
     tombstone_cache_t *obj_tombstone_cache = store->get_tombstone_cache();
-    pair<ceph::real_time, uint32_t> tombstone_entry = make_pair<>(state->mtime, state->zone_short_id);
     if (obj_tombstone_cache) {
-      obj_tombstone_cache->add(obj, tombstone_entry);
+      tombstone_entry entry{*state};
+      obj_tombstone_cache->add(obj, entry);
     }
     r = index_op.complete_del(poolid, ref.ioctx.get_last_version(), state->mtime, params.remove_objs);
   } else {
@@ -7981,11 +7981,13 @@ int RGWRados::get_obj_state_impl(RGWObjectCtx *rctx, rgw_obj& obj, RGWObjState *
   if (r == -ENOENT) {
     s->exists = false;
     s->has_attrs = true;
-    pair<ceph::real_time, uint32_t> tombstone_entry;
-    if (obj_tombstone_cache && obj_tombstone_cache->find(obj, tombstone_entry)) {
-      s->mtime = tombstone_entry.first;
-      s->zone_short_id = tombstone_entry.second;
-      ldout(cct, 20) << __func__ << "(): found obj in tombstone cache: obj=" << obj << " mtime=" << s->mtime << dendl;
+    tombstone_entry entry;
+    if (obj_tombstone_cache && obj_tombstone_cache->find(obj, entry)) {
+      s->mtime = entry.mtime;
+      s->zone_short_id = entry.zone_short_id;
+      s->pg_ver = entry.pg_ver;
+      ldout(cct, 20) << __func__ << "(): found obj in tombstone cache: obj=" << obj
+          << " mtime=" << s->mtime << " pgv=" << s->pg_ver << dendl;
     } else {
       s->mtime = real_time();
     }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1702,6 +1702,17 @@ struct bucket_info_entry {
   map<string, bufferlist> attrs;
 };
 
+struct tombstone_entry {
+  ceph::real_time mtime;
+  uint32_t zone_short_id;
+  uint64_t pg_ver;
+
+  tombstone_entry() = default;
+  tombstone_entry(const RGWObjState& state)
+    : mtime(state.mtime), zone_short_id(state.zone_short_id),
+      pg_ver(state.pg_ver) {}
+};
+
 class RGWRados
 {
   friend class RGWGC;
@@ -1811,7 +1822,7 @@ protected:
   using RGWChainedCacheImpl_bucket_info_entry = RGWChainedCacheImpl<bucket_info_entry>;
   RGWChainedCacheImpl_bucket_info_entry *binfo_cache;
 
-  using tombstone_cache_t = lru_map<rgw_obj, pair<ceph::real_time, uint32_t> >;
+  using tombstone_cache_t = lru_map<rgw_obj, tombstone_entry>;
   tombstone_cache_t *obj_tombstone_cache;
 
   librados::IoCtx gc_pool_ctx;        // .rgw.gc


### PR DESCRIPTION
a tombstone cache was added to remember the mtime of deleted objects for
use with the HTTP_IF_MODIFIED_SINCE header, but the comparison was still
failing because of a missing pg_ver. added pg_ver to the tombstone cache
so it can be passed with HTTP_DEST_PG_VER