### PR TITLE
librbd: discard should return error if length too large

### DIFF
--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1160,6 +1160,10 @@ namespace librbd {
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, discard_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, ofs, len);
+    if (len > std::numeric_limits<int32_t>::max()) {
+        tracepoint(librbd, discard_exit, -EINVAL);
+        return -EINVAL;
+    }
     int r = ictx->aio_work_queue->discard(ofs, len);
     tracepoint(librbd, discard_exit, r);
     return r;


### PR DESCRIPTION
rbd discard use 'int' to return the discarded length, but the 'len'
user passed is 'uint64', in some case, the return value will be
truncated and return a negative value which means discard failed.
use ssize_t to avoid.

Signed-off-by: Huan Zhang <zhanghuan@chinac.com>