### PR TITLE
 mon: remove the redundant min_last_epoch_clean judge in PGMap

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -206,20 +206,7 @@ void PGMap::apply_incremental(CephContext *cct, const Incremental& inc)
     if (t == pg_stat.end()) {
       ceph::unordered_map<pg_t,pg_stat_t>::value_type v(update_pg, update_stat);
       pg_stat.insert(v);
-      // did we affect the min?
-      if (min_last_epoch_clean &&
-          update_stat.get_effective_last_epoch_clean() < min_last_epoch_clean)
-	min_last_epoch_clean = 0;
     } else {
-      // did we (or might we) affect the min?
-      epoch_t lec = update_stat.get_effective_last_epoch_clean();
-      if (min_last_epoch_clean &&
-          (lec < min_last_epoch_clean ||  // we did
-           (lec > min_last_epoch_clean && // we might
-            t->second.get_effective_last_epoch_clean() == min_last_epoch_clean)
-          ))
-	min_last_epoch_clean = 0;
-
       stat_pg_sub(update_pg, t->second);
       t->second = update_stat;
     }
@@ -244,14 +231,6 @@ void PGMap::apply_incremental(CephContext *cct, const Incremental& inc)
     ceph::unordered_map<int32_t,epoch_t>::iterator i = osd_epochs.find(osd);
     map<int32_t,epoch_t>::const_iterator j = inc.get_osd_epochs().find(osd);
     assert(j != inc.get_osd_epochs().end());
-
-    // will we potentially affect the min?
-    if (min_last_epoch_clean &&
-        (i == osd_epochs.end() ||
-         j->second < min_last_epoch_clean ||
-         (j->second > min_last_epoch_clean &&
-          i->second == min_last_epoch_clean)))
-      min_last_epoch_clean = 0;
 
     if (i == osd_epochs.end())
       osd_epochs.insert(*j);


### PR DESCRIPTION
 mon: remove the redundant min_last_epoch_clean judge in PGMap

 In the end of the apply_incremental function, no matter what
 happens the min_last_epoch_clean must be 0.

 Signed-off-by:song baisen <song.baisen@zte.com.cn>