### PR TITLE
ceph_volume_client: store authentication metadata

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -199,6 +199,15 @@ class CephFSVolumeClientError(Exception):
     pass
 
 
+CEPHFSVOLUMECLIENT_VERSION_HISTORY = """
+
+    CephFSVolumeClient Version History:
+
+    * 1 - Initial version
+
+"""
+
+
 class CephFSVolumeClient(object):
     """
     Combine libcephfs and librados interfaces to implement a
@@ -217,6 +226,11 @@ class CephFSVolumeClient(object):
     In general, functions in this class are allowed raise rados.Error
     or cephfs.Error exceptions in unexpected situations.
     """
+
+    # Current version
+    version = 1
+    # Earliest compatible version
+    compat_version = 1
 
     # Where shall we create our volumes?
     POOL_PREFIX = "fsvolume_"

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -233,7 +233,6 @@ class CephFSVolumeClient(object):
         # ".meta" filenames
         # TODO: remove .meta files on volume deletion
         # TODO: remove .meta files on last rule for an auth ID deletion
-        # TODO: implement fsync in bindings so that we don't have to syncfs
         # TODO: version the on-disk structures
 
     def recover(self):
@@ -726,7 +725,7 @@ class CephFSVolumeClient(object):
         fd = self.fs.open(path, "w")
         try:
             self.fs.write(fd, serialized, 0)
-            self.fs.sync_fs()
+            self.fs.fsync(fd, 0)
         finally:
             self.fs.close(fd)
 

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -582,8 +582,8 @@ class CephFSVolumeClient(object):
         :param data_isolated: If true, create a separate OSD pool for this volume
         :return:
         """
-        log.info("create_volume: {0}".format(volume_path))
         path = self._get_path(volume_path)
+        log.info("create_volume: {0}".format(path))
 
         self._mkdir_p(path)
 
@@ -627,7 +627,8 @@ class CephFSVolumeClient(object):
         :return:
         """
 
-        log.info("delete_volume: {0}".format(volume_path))
+        path = self._get_path(volume_path)
+        log.info("delete_volume: {0}".format(path))
 
         # Create the trash folder if it doesn't already exist
         trash = os.path.join(self.volume_prefix, "_deleting")
@@ -637,7 +638,6 @@ class CephFSVolumeClient(object):
         trashed_volume = os.path.join(trash, volume_path.volume_id)
 
         # Move the volume's data to the trash folder
-        path = self._get_path(volume_path)
         try:
             self.fs.stat(path)
         except cephfs.ObjectNotFound:

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -108,6 +108,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_conf_set(ceph_mount_info *cmount, const char *option, const char *value)
 
     int ceph_mount(ceph_mount_info *cmount, const char *root)
+    int ceph_fstat(ceph_mount_info *cmount, int fd, stat *stbuf)
     int ceph_stat(ceph_mount_info *cmount, const char *path, stat *stbuf)
     int ceph_statfs(ceph_mount_info *cmount, const char *path, statvfs *stbuf)
 
@@ -790,6 +791,29 @@ cdef class LibCephFS(object):
             ret = ceph_stat(self.cluster, _path, &statbuf)
         if ret < 0:
             raise make_ex(ret, "error in stat: %s" % path)
+        return StatResult(st_dev=statbuf.st_dev, st_ino=statbuf.st_ino,
+                          st_mode=statbuf.st_mode, st_nlink=statbuf.st_nlink,
+                          st_uid=statbuf.st_uid, st_gid=statbuf.st_gid,
+                          st_rdev=statbuf.st_rdev, st_size=statbuf.st_size,
+                          st_blksize=statbuf.st_blksize,
+                          st_blocks=statbuf.st_blocks,
+                          st_atime=datetime.fromtimestamp(statbuf.st_atime),
+                          st_mtime=datetime.fromtimestamp(statbuf.st_mtime),
+                          st_ctime=datetime.fromtimestamp(statbuf.st_ctime))
+
+    def fstat(self, fd):
+        self.require_state("mounted")
+        if not isinstance(fd, int):
+            raise TypeError('fd must be an int')
+
+        cdef:
+            int _fd = fd
+            stat statbuf
+
+        with nogil:
+            ret = ceph_fstat(self.cluster, _fd, &statbuf)
+        if ret < 0:
+            raise make_ex(ret, "error in fsat")
         return StatResult(st_dev=statbuf.st_dev, st_ino=statbuf.st_ino,
                           st_mode=statbuf.st_mode, st_nlink=statbuf.st_nlink,
                           st_uid=statbuf.st_uid, st_gid=statbuf.st_gid,

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -2,6 +2,7 @@
 from nose.tools import assert_raises, assert_equal, with_setup
 import cephfs as libcephfs
 import fcntl
+import os
 
 cephfs = None
 
@@ -131,6 +132,10 @@ def test_open():
     assert_equal(cephfs.read(fd, 0, 4), "")
     cephfs.write(fd, "zxcv", 4)
     assert_equal(cephfs.read(fd, 4, 8), "zxcv")
+    cephfs.close(fd)
+    fd = cephfs.open('file-1', os.O_RDWR, 0755)
+    cephfs.write(fd, "asdf", 0)
+    assert_equal(cephfs.read(fd, 0, 4), "asdf")
     cephfs.close(fd)
     assert_raises(libcephfs.OperationNotSupported, cephfs.open, 'file-1', 'a')
     cephfs.unlink('file-1')

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -41,6 +41,13 @@ def test_version():
     cephfs.version()
 
 @with_setup(setup_test)
+def test_fstat():
+    fd = cephfs.open('file-1', 'w', 0755)
+    stat = cephfs.fstat(fd)
+    assert(len(stat) == 13)
+    cephfs.close(fd)
+
+@with_setup(setup_test)
 def test_statfs():
     stat = cephfs.statfs('/')
     assert(len(stat) == 11)


### PR DESCRIPTION
ceph_volume_client: store authentication metadata

Store a two-way mapping between auth IDs and volumes.

Enables us to record some metadata on auth ids (which
openstack tenant created it) so that we can avoid exposing
keys to other tenants who try to use the same ceph
auth id.

Enables us to expose the list of which auth ids have access
to a volume, so that Manila's update_access() can be
implemented efficiently.

Fixes: http://tracker.ceph.com/issues/15615
Fixes: http://tracker.ceph.com/issues/15406
