### PR TITLE
include/small_encoding: fix lba encoding with many low zeros

### DIFF
--- a/src/include/small_encoding.h
+++ b/src/include/small_encoding.h
@@ -183,6 +183,7 @@ inline void small_encode_lba(uint64_t v, bufferlist& bl) {
     pos = t + 1;
     word = (1 << t) - 1;
   } else {
+    v >>= 20;
     pos = 3;
     word = 0x3;
   }

--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -320,6 +320,7 @@ TEST(small_encoding, varint_lowz) {
     {0x7f0000, 2, 2, 2},
     {0xffff0000, 4, 4, 4},
     {0xffffffff, 5, 5, 5},
+    {0x41000000, 3, 4, 4},
     {0, 0, 0, 0}
   };
   for (unsigned i=0; v[i][1]; ++i) {
@@ -382,6 +383,7 @@ TEST(small_encoding, lba) {
     {0x3fffffff0000, 5},
     {0xfffffff00000, 4},
     {0x1fffffff00000, 5},
+    {0x41000000, 4},
     {0, 0}
   };
   for (unsigned i=0; v[i][1]; ++i) {


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>