### PR TITLE
hammer: build/ops: remove SYSTEMD_RUN from initscript

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -17,10 +17,6 @@ if [ -x /sbin/start-stop-daemon ]; then
 else
     . /etc/rc.d/init.d/functions
     DEBIAN=0
-
-    # detect systemd, also check whether the systemd-run binary exists
-    SYSTEMD_RUN=$(which systemd-run 2>/dev/null)
-    grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
 fi
 
 daemon_is_running() {
@@ -99,10 +95,8 @@ case "$1" in
             fi
 
             echo "Starting $name..."
-	    if [ $DEBIAN -eq 1 ]; then
-		start-stop-daemon --start -u $user -x $RADOSGW -p /var/run/ceph/client-$name.pid -- -n $name
-	    elif [ -n "$SYSTEMD_RUN" ]; then
-                $SYSTEMD_RUN -r su "$user" -c "ulimit -n 32768; $RADOSGW -n $name"
+            if [ $DEBIAN -eq 1 ]; then
+                start-stop-daemon --start -u $user -x $RADOSGW -p /var/run/ceph/client-$name.pid -- -n $name
             else
 		ulimit -n 32768
                 daemon --user="$user" "$RADOSGW -n $name"


### PR DESCRIPTION
Closes: http://tracker.ceph.com/issues/16442

`systemd-run` logic in initscripts was introduced because of ticket http://tracker.ceph.com/issues/7627.
If we have systemd-based distro, we should use systemd unit files from systemd directory to start/stop ceph daemons.
Otherwise, `daemon()` from `/etc/init.d/functions` on systemd distro starts service in `system.slice` and everything works well in case, for example, when we use hammer on RH7. With this code it will start daemon with `daemon()` function from `init.d/functions`.
`systemd-run` can not be run on non-systemd distros, so it's not needed on SysV systems.
I've performed successful testing with hammer on RH6, RH7 systems with ceph-osd, ceph-mon, ceph-radosgw services.

Backport of: #9871

Signed-off-by: Vladislav Odintsov odivlad@gmail.com
