### PR TITLE
rbd: add explicit shrink check while resizing images

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -272,6 +272,8 @@ CEPH_RBD_API int rbd_aio_open_read_only(rados_ioctx_t io, const char *name,
 CEPH_RBD_API int rbd_close(rbd_image_t image);
 CEPH_RBD_API int rbd_aio_close(rbd_image_t image, rbd_completion_t c);
 CEPH_RBD_API int rbd_resize(rbd_image_t image, uint64_t size);
+CEPH_RBD_API int rbd_resize2(rbd_image_t image, uint64_t size, bool allow_shrink,
+			     librbd_progress_fn_t cb, void *cbdata);
 CEPH_RBD_API int rbd_resize_with_progress(rbd_image_t image, uint64_t size,
 			     librbd_progress_fn_t cb, void *cbdata);
 CEPH_RBD_API int rbd_stat(rbd_image_t image, rbd_image_info_t *info,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -191,6 +191,7 @@ public:
   int aio_close(RBD::AioCompletion *c);
 
   int resize(uint64_t size);
+  int resize2(uint64_t size, bool allow_shrink, ProgressContext& pctx);
   int resize_with_progress(uint64_t size, ProgressContext& pctx);
   int stat(image_info_t &info, size_t infosize);
   int parent_info(std::string *parent_poolname, std::string *parent_name,

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -213,7 +213,7 @@ void ImageWatcher::notify_flatten(uint64_t request_id,
 }
 
 void ImageWatcher::notify_resize(uint64_t request_id, uint64_t size,
-				 ProgressContext &prog_ctx,
+				 bool allow_shrink, ProgressContext &prog_ctx,
                                  Context *on_finish) {
   assert(m_image_ctx.owner_lock.is_locked());
   assert(m_image_ctx.exclusive_lock &&
@@ -222,7 +222,7 @@ void ImageWatcher::notify_resize(uint64_t request_id, uint64_t size,
   AsyncRequestId async_request_id(get_client_id(), request_id);
 
   bufferlist bl;
-  ::encode(NotifyMessage(ResizePayload(size, async_request_id)), bl);
+  ::encode(NotifyMessage(ResizePayload(size, allow_shrink, async_request_id)), bl);
   notify_async_request(async_request_id, std::move(bl), prog_ctx, on_finish);
 }
 
@@ -711,8 +711,9 @@ bool ImageWatcher::handle_payload(const ResizePayload &payload,
       if (new_request) {
         ldout(m_image_ctx.cct, 10) << this << " remote resize request: "
 				   << payload.async_request_id << " "
-				   << payload.size << dendl;
-        m_image_ctx.operations->execute_resize(payload.size, *prog_ctx, ctx, 0);
+				   << payload.size << " "
+				   << payload.allow_shrink << dendl;
+        m_image_ctx.operations->execute_resize(payload.size, payload.allow_shrink, *prog_ctx, ctx, 0);
       }
 
       ::encode(ResponseMessage(r), ack_ctx->out);

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -33,7 +33,7 @@ public:
 
   void notify_flatten(uint64_t request_id, ProgressContext &prog_ctx,
                       Context *on_finish);
-  void notify_resize(uint64_t request_id, uint64_t size,
+  void notify_resize(uint64_t request_id, uint64_t size, bool allow_shrink,
                      ProgressContext &prog_ctx, Context *on_finish);
   void notify_snap_create(const std::string &snap_name, Context *on_finish);
   void notify_snap_rename(const snapid_t &src_snap_id,

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -39,8 +39,8 @@ public:
   int rename(const char *dstname);
   void execute_rename(const char *dstname, Context *on_finish);
 
-  int resize(uint64_t size, ProgressContext& prog_ctx);
-  void execute_resize(uint64_t size, ProgressContext &prog_ctx,
+  int resize(uint64_t size, bool allow_shrink, ProgressContext& prog_ctx);
+  void execute_resize(uint64_t size, bool allow_shrink, ProgressContext &prog_ctx,
                       Context *on_finish, uint64_t journal_op_tid);
 
   int snap_create(const char *snap_name);

--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -207,17 +207,23 @@ void AsyncCompletePayload::dump(Formatter *f) const {
 }
 
 void ResizePayload::encode(bufferlist &bl) const {
-  ::encode(size, bl);
   AsyncRequestPayloadBase::encode(bl);
+  ::encode(size, bl);
+  ::encode(allow_shrink, bl);
 }
 
 void ResizePayload::decode(__u8 version, bufferlist::iterator &iter) {
-  ::decode(size, iter);
   AsyncRequestPayloadBase::decode(version, iter);
+  ::decode(size, iter);
+
+  if (version >= 4) {
+    ::decode(allow_shrink, iter);
+  }
 }
 
 void ResizePayload::dump(Formatter *f) const {
   f->dump_unsigned("size", size);
+  f->dump_bool("allow_shrink", allow_shrink);
   AsyncRequestPayloadBase::dump(f);
 }
 
@@ -275,7 +281,7 @@ bool NotifyMessage::check_for_refresh() const {
 }
 
 void NotifyMessage::encode(bufferlist& bl) const {
-  ENCODE_START(3, 1, bl);
+  ENCODE_START(4, 1, bl);
   boost::apply_visitor(EncodePayloadVisitor(bl), payload);
   ENCODE_FINISH(bl);
 }
@@ -354,7 +360,7 @@ void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
   o.push_back(new NotifyMessage(AsyncProgressPayload(AsyncRequestId(ClientId(0, 1), 2), 3, 4)));
   o.push_back(new NotifyMessage(AsyncCompletePayload(AsyncRequestId(ClientId(0, 1), 2), 3)));
   o.push_back(new NotifyMessage(FlattenPayload(AsyncRequestId(ClientId(0, 1), 2))));
-  o.push_back(new NotifyMessage(ResizePayload(123, AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(new NotifyMessage(ResizePayload(123, true, AsyncRequestId(ClientId(0, 1), 2))));
   o.push_back(new NotifyMessage(SnapCreatePayload("foo")));
   o.push_back(new NotifyMessage(SnapRemovePayload("foo")));
   o.push_back(new NotifyMessage(SnapProtectPayload("foo")));

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -200,11 +200,12 @@ struct ResizePayload : public AsyncRequestPayloadBase {
   static const NotifyOp NOTIFY_OP = NOTIFY_OP_RESIZE;
   static const bool CHECK_FOR_REFRESH = true;
 
-  ResizePayload() : size(0) {}
-  ResizePayload(uint64_t size_, const AsyncRequestId &id)
-    : AsyncRequestPayloadBase(id), size(size_) {}
+  ResizePayload() : size(0), allow_shrink(true) {}
+  ResizePayload(uint64_t size_, bool allow_shrink_, const AsyncRequestId &id)
+    : AsyncRequestPayloadBase(id), size(size_), allow_shrink(allow_shrink_) {}
 
   uint64_t size;
+  bool allow_shrink;
 
   void encode(bufferlist &bl) const;
   void decode(__u8 version, bufferlist::iterator &iter);

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -76,7 +76,7 @@ struct ExecuteOp : public Context {
   }
 
   void execute(const journal::ResizeEvent &_) {
-    image_ctx.operations->execute_resize(event.size, no_op_progress_callback,
+    image_ctx.operations->execute_resize(event.size, true, no_op_progress_callback,
                                          on_op_complete, event.op_tid);
   }
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -615,7 +615,16 @@ namespace librbd {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, resize_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, size);
     librbd::NoOpProgressContext prog_ctx;
-    int r = ictx->operations->resize(size, prog_ctx);
+    int r = ictx->operations->resize(size, true, prog_ctx);
+    tracepoint(librbd, resize_exit, r);
+    return r;
+  }
+
+  int Image::resize2(uint64_t size, bool allow_shrink, librbd::ProgressContext& pctx)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    tracepoint(librbd, resize_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, size);
+    int r = ictx->operations->resize(size, allow_shrink, pctx);
     tracepoint(librbd, resize_exit, r);
     return r;
   }
@@ -624,7 +633,7 @@ namespace librbd {
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, resize_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, size);
-    int r = ictx->operations->resize(size, pctx);
+    int r = ictx->operations->resize(size, true, pctx);
     tracepoint(librbd, resize_exit, r);
     return r;
   }
@@ -1969,7 +1978,18 @@ extern "C" int rbd_resize(rbd_image_t image, uint64_t size)
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   tracepoint(librbd, resize_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, size);
   librbd::NoOpProgressContext prog_ctx;
-  int r = ictx->operations->resize(size, prog_ctx);
+  int r = ictx->operations->resize(size, true, prog_ctx);
+  tracepoint(librbd, resize_exit, r);
+  return r;
+}
+
+extern "C" int rbd_resize2(rbd_image_t image, uint64_t size, bool allow_shrink,
+					librbd_progress_fn_t cb, void *cbdata)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  tracepoint(librbd, resize_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, size);
+  librbd::CProgressContext prog_ctx(cb, cbdata);
+  int r = ictx->operations->resize(size, allow_shrink, prog_ctx);
   tracepoint(librbd, resize_exit, r);
   return r;
 }
@@ -1980,7 +2000,7 @@ extern "C" int rbd_resize_with_progress(rbd_image_t image, uint64_t size,
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   tracepoint(librbd, resize_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, size);
   librbd::CProgressContext prog_ctx(cb, cbdata);
-  int r = ictx->operations->resize(size, prog_ctx);
+  int r = ictx->operations->resize(size, true, prog_ctx);
   tracepoint(librbd, resize_exit, r);
   return r;
 }

--- a/src/librbd/operation/ResizeRequest.h
+++ b/src/librbd/operation/ResizeRequest.h
@@ -18,14 +18,15 @@ template <typename ImageCtxT = ImageCtx>
 class ResizeRequest : public Request<ImageCtxT> {
 public:
   static ResizeRequest *create(ImageCtxT &image_ctx, Context *on_finish,
-                               uint64_t new_size, ProgressContext &prog_ctx,
-                               uint64_t journal_op_tid, bool disable_journal) {
-    return new ResizeRequest(image_ctx, on_finish, new_size, prog_ctx,
+                               uint64_t new_size, bool allow_shrink,
+                               ProgressContext &prog_ctx, uint64_t journal_op_tid,
+                               bool disable_journal) {
+    return new ResizeRequest(image_ctx, on_finish, new_size, allow_shrink, prog_ctx,
                              journal_op_tid, disable_journal);
   }
 
   ResizeRequest(ImageCtxT &image_ctx, Context *on_finish, uint64_t new_size,
-                ProgressContext &prog_ctx, uint64_t journal_op_tid,
+                bool allow_shrink, ProgressContext &prog_ctx, uint64_t journal_op_tid,
                 bool disable_journal);
   virtual ~ResizeRequest();
 
@@ -106,6 +107,7 @@ private:
 
   uint64_t m_original_size;
   uint64_t m_new_size;
+  bool m_allow_shrink = true;
   ProgressContext &m_prog_ctx;
   uint64_t m_new_parent_overlap;
   bool m_shrink_size_visible = false;

--- a/src/librbd/operation/SnapshotRollbackRequest.cc
+++ b/src/librbd/operation/SnapshotRollbackRequest.cc
@@ -137,7 +137,7 @@ void SnapshotRollbackRequest<I>::send_resize_image() {
     SnapshotRollbackRequest<I>,
     &SnapshotRollbackRequest<I>::handle_resize_image>(this);
   ResizeRequest<I> *req = ResizeRequest<I>::create(image_ctx, ctx, m_snap_size,
-                                                   m_no_op_prog_ctx, 0, true);
+                                                   true, m_no_op_prog_ctx, 0, true);
   req->send();
 }
 

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -617,7 +617,7 @@ TEST_F(TestJournalReplay, Resize) {
 
   // verify lock ordering constraints
   librbd::NoOpProgressContext no_op_progress;
-  ASSERT_EQ(0, ictx->operations->resize(0, no_op_progress));
+  ASSERT_EQ(0, ictx->operations->resize(0, true, no_op_progress));
 }
 
 TEST_F(TestJournalReplay, Flatten) {

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -138,8 +138,8 @@ public:
 
   void expect_resize(MockReplayImageCtx &mock_image_ctx, Context **on_finish,
                      uint64_t size, uint64_t op_tid) {
-    EXPECT_CALL(*mock_image_ctx.operations, execute_resize(size, _, _, op_tid))
-                  .WillOnce(DoAll(SaveArg<2>(on_finish),
+    EXPECT_CALL(*mock_image_ctx.operations, execute_resize(size, _, _, _, op_tid))
+                  .WillOnce(DoAll(SaveArg<3>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }
 

--- a/src/test/librbd/mock/MockOperations.h
+++ b/src/test/librbd/mock/MockOperations.h
@@ -18,8 +18,8 @@ struct MockOperations {
   MOCK_METHOD2(execute_rebuild_object_map, void(ProgressContext &prog_ctx,
                                                 Context *on_finish));
   MOCK_METHOD2(execute_rename, void(const char *dstname, Context *on_finish));
-  MOCK_METHOD4(execute_resize, void(uint64_t size, ProgressContext &prog_ctx,
-                                    Context *on_finish,
+  MOCK_METHOD5(execute_resize, void(uint64_t size, bool allow_shrink,
+                                    ProgressContext &prog_ctx, Context *on_finish,
                                     uint64_t journal_op_tid));
   MOCK_METHOD2(snap_create, void(const char *snap_name, Context *on_finish));
   MOCK_METHOD4(execute_snap_create, void(const char *snap_name,

--- a/src/test/librbd/operation/test_mock_SnapshotRollbackRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotRollbackRequest.cc
@@ -32,8 +32,9 @@ struct ResizeRequest<MockOperationImageCtx> {
   Context *on_finish = nullptr;
 
   static ResizeRequest* create(MockOperationImageCtx &image_ctx, Context *on_finish,
-                               uint64_t new_size, ProgressContext &prog_ctx,
-                               uint64_t journal_op_tid, bool disable_journal) {
+                               uint64_t new_size, bool allow_shrink,
+                               ProgressContext &prog_ctx, uint64_t journal_op_tid,
+                               bool disable_journal) {
     assert(s_instance != nullptr);
     assert(journal_op_tid == 0);
     assert(disable_journal);

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -274,7 +274,7 @@ struct ResizeTask {
   void operator()() {
     RWLock::RLocker l(ictx->owner_lock);
     C_SaferCond ctx;
-    ictx->image_watcher->notify_resize(0, 0, *progress_context, &ctx);
+    ictx->image_watcher->notify_resize(0, 0, true, *progress_context, &ctx);
     result = ctx.wait();
   }
 };

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -113,7 +113,7 @@ TEST_F(TestInternal, ResizeLocksImage) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   librbd::NoOpProgressContext no_op;
-  ASSERT_EQ(0, ictx->operations->resize(m_image_size >> 1, no_op));
+  ASSERT_EQ(0, ictx->operations->resize(m_image_size >> 1, true, no_op));
 
   bool is_owner;
   ASSERT_EQ(0, librbd::is_exclusive_lock_owner(ictx, &is_owner));
@@ -128,7 +128,7 @@ TEST_F(TestInternal, ResizeFailsToLockImage) {
   ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE, "manually locked"));
 
   librbd::NoOpProgressContext no_op;
-  ASSERT_EQ(-EROFS, ictx->operations->resize(m_image_size >> 1, no_op));
+  ASSERT_EQ(-EROFS, ictx->operations->resize(m_image_size >> 1, true, no_op));
 }
 
 TEST_F(TestInternal, SnapCreateLocksImage) {
@@ -336,7 +336,7 @@ TEST_F(TestInternal, CancelAsyncResize) {
     size -= MIN(size, 1<<18);
     {
       RWLock::RLocker l(ictx->owner_lock);
-      ictx->operations->execute_resize(size, prog_ctx, &ctx, 0);
+      ictx->operations->execute_resize(size, true, prog_ctx, &ctx, 0);
     }
 
     // try to interrupt the in-progress resize
@@ -384,7 +384,7 @@ TEST_F(TestInternal, MultipleResize) {
 
     RWLock::RLocker l(ictx->owner_lock);
     contexts.push_back(new C_SaferCond());
-    ictx->operations->execute_resize(new_size, prog_ctx, contexts.back(), 0);
+    ictx->operations->execute_resize(new_size, true, prog_ctx, contexts.back(), 0);
   }
 
   for (uint32_t i = 0; i < contexts.size(); ++i) {
@@ -610,9 +610,9 @@ TEST_F(TestInternal, ResizeCopyup)
   // verify full / partial object removal properly copyup
   librbd::NoOpProgressContext no_op;
   ASSERT_EQ(0, ictx2->operations->resize(m_image_size - (1 << order) - 32,
-                                         no_op));
+                                         true, no_op));
   ASSERT_EQ(0, ictx2->operations->resize(m_image_size - (2 << order) - 32,
-                                         no_op));
+                                         true, no_op));
   ASSERT_EQ(0, librbd::snap_set(ictx2, "snap1"));
 
   {
@@ -699,7 +699,7 @@ TEST_F(TestInternal, ShrinkFlushesCache) {
   ictx->aio_work_queue->aio_write(c, 0, buffer.size(), buffer.c_str(), 0);
 
   librbd::NoOpProgressContext no_op;
-  ASSERT_EQ(0, ictx->operations->resize(m_image_size >> 1, no_op));
+  ASSERT_EQ(0, ictx->operations->resize(m_image_size >> 1, true, no_op));
 
   ASSERT_TRUE(c->is_complete());
   ASSERT_EQ(0, c->wait_for_complete());
@@ -781,7 +781,7 @@ TEST_F(TestInternal, WriteFullCopyup) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   librbd::NoOpProgressContext no_op;
-  ASSERT_EQ(0, ictx->operations->resize(1 << ictx->order, no_op));
+  ASSERT_EQ(0, ictx->operations->resize(1 << ictx->order, true, no_op));
 
   bufferlist bl;
   bl.append(std::string(1 << ictx->order, '1'));

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -420,6 +420,16 @@ TEST_F(TestLibRBD, ResizeAndStat)
   ASSERT_EQ(0, rbd_stat(image, &info, sizeof(info)));
   ASSERT_EQ(info.size, size / 2);
 
+  // downsizing without allowing shrink should fail
+  // and image size should not change
+  ASSERT_EQ(-EINVAL, rbd_resize2(image, size / 4, false, NULL, NULL));
+  ASSERT_EQ(0, rbd_stat(image, &info, sizeof(info)));
+  ASSERT_EQ(info.size, size / 2);
+
+  ASSERT_EQ(0, rbd_resize2(image, size / 4, true, NULL, NULL));
+  ASSERT_EQ(0, rbd_stat(image, &info, sizeof(info)));
+  ASSERT_EQ(info.size, size / 4);
+
   ASSERT_PASSED(validate_object_map, image);
   ASSERT_EQ(0, rbd_close(image));
 

--- a/src/test/rbd_mirror/test_ImageSync.cc
+++ b/src/test/rbd_mirror/test_ImageSync.cc
@@ -144,7 +144,7 @@ TEST_F(TestImageSync, SnapshotStress) {
 
     librbd::NoOpProgressContext no_op_progress_ctx;
     uint64_t size = 1 + rand() % m_image_size;
-    ASSERT_EQ(0, m_remote_image_ctx->operations->resize(size,
+    ASSERT_EQ(0, m_remote_image_ctx->operations->resize(size, true,
                                                         no_op_progress_ctx));
     ASSERT_EQ(0, m_remote_image_ctx->state->refresh());
 


### PR DESCRIPTION
Currently, if multiple clients issue resizes without coordination it is possible that the image undergoes downsizing due to a race. This might have undesired consequences depending on how strong or weak the client-level coordination works. As Ceph already provides atomic guarantees within its `ResizeRequest` state machine, we leverage that to guard against the unintended shrinking of image by exposing the `rbd_resize2()` API call.

/cc @dillaman 

Signed-off-by: Vaibhav Bhembre vaibhav@digitalocean.com