### PR TITLE
mds: fix shutting down mds timed-out due to deadlock

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -238,7 +238,11 @@ void MDSRankDispatcher::shutdown()
   progress_thread.shutdown();
 
   // shut down messenger
+  // release mds_lock first because messenger thread might call 
+  // MDSDaemon::ms_handle_reset which will try to hold mds_lock
+  mds_lock.Unlock();
   messenger->shutdown();
+  mds_lock.Lock();
 
   // Workaround unclean shutdown: HeartbeatMap will assert if
   // worker is not removed (as we do in ~MDS), but ~MDS is not

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -262,15 +262,15 @@ void EventCenter::delete_time_event(uint64_t id)
 
 void EventCenter::wakeup()
 {
-  if (already_wakeup.compare_and_swap(0, 1)) {
     ldout(cct, 1) << __func__ << dendl;
+    already_wakeup.compare_and_swap(0, 1);
+
     char buf[1];
     buf[0] = 'c';
     // wake up "event_wait"
     int n = write(notify_send_fd, buf, 1);
     // FIXME ?
     assert(n == 1);
-  }
 }
 
 int EventCenter::process_time_events()


### PR DESCRIPTION
Fixes: #16396

This PR contains 2 fixes:

* Fix shutting down mds timed-out due to deadlock

The root cause is ms_handle_reset may be called within mds_lock via 'MDSDaemon::handle_signal' -> 'MDSDaemon::suicide' -> 'MDSRankDispatcher::shutdown' -> 'AsyncMessenger::shutdown' -> 'AsyncMessenger::mark_down_all' -> ... -> 'AsyncConnection::stop' -> dispatch 'C_handle_reset' event -> 'Messenger::ms_deliver_handle_reset' in 2 different threads.

* Remove the unnecessary checking to wakup event_wait, discussed with @yuyuyu101 in https://github.com/ceph/ceph/pull/9841

Signed-off-by: Zhi Zhang zhangz.david@outlook.com