### PR TITLE
doc/rgw/config: remove single quotes of ‘{swift_secret_key}’

### DIFF
--- a/doc/radosgw/config-fcgi.rst
+++ b/doc/radosgw/config-fcgi.rst
@@ -572,7 +572,7 @@ To install ``swift`` client, execute the following:
 
 To test swift access, execute the following::
 
-	swift -A http://{IP ADDRESS}/auth/1.0 -U testuser:swift -K ‘{swift_secret_key}’ list
+	swift -A http://{IP ADDRESS}/auth/1.0 -U testuser:swift -K {swift_secret_key} list
 
 Replace ``{IP ADDRESS}`` with the public IP address of the gateway server and
 ``{swift_secret_key}`` with its value from the output of
@@ -580,7 +580,7 @@ Replace ``{IP ADDRESS}`` with the public IP address of the gateway server and
 
 For example::
 
-	swift -A http://10.19.143.116/auth/1.0 -U testuser:swift -K ‘244+fz2gSqoHwR3lYtSbIyomyPHf3i7rgSJrF/IA’ list
+	swift -A http://10.19.143.116/auth/1.0 -U testuser:swift -K 244+fz2gSqoHwR3lYtSbIyomyPHf3i7rgSJrF/IA list
 
 The output should be::
 


### PR DESCRIPTION
when test swift access, the segment ‘{swift_secret_key}’ should not include the single quotes,

Signed-off-by: weiqiaomiao wei.qiaomiao@zte.com.cn
