### PR TITLE
librbd: ignore snap unprotect -EBUSY errors during journal replay

### DIFF
--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -112,24 +112,29 @@ struct C_RefreshIfRequired : public Context {
   C_RefreshIfRequired(I &image_ctx, Context *on_finish)
     : image_ctx(image_ctx), on_finish(on_finish) {
   }
+  virtual ~C_RefreshIfRequired() {
+    delete on_finish;
+  }
 
   virtual void finish(int r) override {
     CephContext *cct = image_ctx.cct;
+    Context *ctx = on_finish;
+    on_finish = nullptr;
 
     if (r < 0) {
       lderr(cct) << "C_RefreshIfRequired: " << __func__ << ": r=" << r << dendl;
-      image_ctx.op_work_queue->queue(on_finish, r);
+      image_ctx.op_work_queue->queue(ctx, r);
       return;
     }
 
     if (image_ctx.state->is_refresh_required()) {
       ldout(cct, 20) << "C_RefreshIfRequired: " << __func__ << ": "
                      << "refresh required" << dendl;
-      image_ctx.state->refresh(on_finish);
+      image_ctx.state->refresh(ctx);
       return;
     }
 
-    image_ctx.op_work_queue->queue(on_finish, 0);
+    image_ctx.op_work_queue->queue(ctx, 0);
   }
 };
 

--- a/src/librbd/journal/Replay.h
+++ b/src/librbd/journal/Replay.h
@@ -52,6 +52,7 @@ private:
     Context *on_finish_ready = nullptr;
     Context *on_finish_safe = nullptr;
     Context *on_op_complete = nullptr;
+    ReturnValues op_finish_error_codes;
     ReturnValues ignore_error_codes;
   };
 

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -972,6 +972,34 @@ TEST_F(TestMockJournalReplay, SnapUnprotectEvent) {
   ASSERT_EQ(0, on_finish_safe.wait());
 }
 
+TEST_F(TestMockJournalReplay, SnapUnprotectOpFinishBusy) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockReplayImageCtx mock_image_ctx(*ictx);
+  MockJournalReplay mock_journal_replay(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  C_SaferCond on_start_ready;
+  C_SaferCond on_start_safe;
+  when_process(mock_journal_replay, EventEntry{SnapUnprotectEvent(123, "snap")},
+               &on_start_ready, &on_start_safe);
+  ASSERT_EQ(0, on_start_ready.wait());
+
+  // aborts the snap unprotect op if image had children
+  C_SaferCond on_finish_ready;
+  C_SaferCond on_finish_safe;
+  when_process(mock_journal_replay, EventEntry{OpFinishEvent(123, -EBUSY)},
+               &on_finish_ready, &on_finish_safe);
+
+  ASSERT_EQ(0, on_start_safe.wait());
+  ASSERT_EQ(0, on_finish_safe.wait());
+  ASSERT_EQ(0, on_finish_ready.wait());
+}
+
 TEST_F(TestMockJournalReplay, SnapUnprotectEventInvalid) {
   REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16445
Signed-off-by: Jason Dillaman <dillaman@redhat.com>