### PR TITLE
init-ceph: make it behave when run from a cmake build dir

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -21,9 +21,8 @@ fi
 SYSTEMD_RUN=$(which systemd-run 2>/dev/null)
 grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
 
-# if we start up as ./init-ceph, assume everything else is in the
-# current directory too.
 if [ `dirname $0` = "." ] && [ $PWD != "/etc/init.d" ]; then
+    # looks like an autotools src dir build
     BINDIR=.
     SBINDIR=.
     LIBEXECDIR=.
@@ -31,11 +30,22 @@ if [ `dirname $0` = "." ] && [ $PWD != "/etc/init.d" ]; then
     SYSTEMD_RUN=""
     ASSUME_DEV=1
 else
-    BINDIR=@bindir@
-    SBINDIR=@prefix@/sbin
-    LIBEXECDIR=@libexecdir@/ceph
-    ETCDIR=@sysconfdir@/ceph
-    ASSUME_DEV=0
+    if [ -e CMakeCache.txt ] && [ -e bin/init-ceph ]; then
+	# looks like a cmake build directory
+	CEPH_ROOT=`grep ceph_SOURCE_DIR CMakeCache.txt | cut -d "=" -f 2`
+	BINDIR=bin
+	SBINDIR=bin
+	LIBEXECDIR=$CEPH_ROOT/src
+	ETCDIR=.
+	SYSTEMD_RUN=""
+	ASSUME_DEV=1
+    else
+	BINDIR=@bindir@
+	SBINDIR=@prefix@/sbin
+	LIBEXECDIR=@libexecdir@/ceph
+	ETCDIR=@sysconfdir@/ceph
+	ASSUME_DEV=0
+    fi
 fi
 
 if [ -n "$CEPH_BIN" ] && [ -n "$CEPH_ROOT" ] && [ -n "$CEPH_BUILD_DIR" ]; then


### PR DESCRIPTION
Note that we assume ../src is the path to source, since the libexec
scripts (ceph_common.sh) aren't built/installed into the build dir.

Signed-off-by: Sage Weil <sage@redhat.com>