### PR TITLE
librbd: ignore missing object map during snap remove

### DIFF
--- a/src/librbd/object_map/SnapshotRemoveRequest.cc
+++ b/src/librbd/object_map/SnapshotRemoveRequest.cc
@@ -72,6 +72,11 @@ bool SnapshotRemoveRequest::should_complete(int r) {
   bool finished = false;
   switch (m_state) {
   case STATE_LOAD_MAP:
+    if (r == -ENOENT) {
+      finished = true;
+      break;
+    }
+
     if (r == 0) {
       bufferlist::iterator it = m_out_bl.begin();
       r = cls_client::object_map_load_finish(&it, &m_snap_object_map);

--- a/src/librbd/object_map/SnapshotRemoveRequest.h
+++ b/src/librbd/object_map/SnapshotRemoveRequest.h
@@ -58,7 +58,8 @@ protected:
   virtual bool should_complete(int r);
 
   virtual int filter_return_code(int r) const {
-    if (m_state == STATE_REMOVE_MAP && r == -ENOENT) {
+    if ((m_state == STATE_LOAD_MAP || m_state == STATE_REMOVE_MAP) &&
+        r == -ENOENT) {
       return 0;
     }
     return r;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16350
Signed-off-by: Jason Dillaman <dillaman@redhat.com>