### PR TITLE
[DNM, proposal] rgw: fix the handling of rgw_swift_url_prefix.

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -796,6 +796,9 @@ Swift Settings
               on the same host. For compatibility, setting this configuration
               variable to empty causes the default "/swift" to be used.
               Use explicit prefix "/" to start StorageURL at the root.
+              WARNING: setting this option to "/" will NOT work if S3 API is
+              enabled. From the other side disabling S3 will make impossible
+              to deploy RadosGW in the multi-site configuration!
 :Default: ``swift``
 :Example: "/swift-testing"
 


### PR DESCRIPTION
This patch fixes to the support for placing the Swift API in the root of URL hierarchy. Unfortunately, the whole concept exhibits a severe side effect: inability to deploy RadosGW in multi-site configuration.

The sole reason behind this fix is the fact we claimed in documentation that the feature is available.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>

-- 

This PR is a proposal of quick but very limited fix for the issue we faced in PR #9582. I don't believe it's ready for merge. I sent this patch rather to ignite a discussion.

CC: @cbodley, @pritha-srivastava.