### PR TITLE
cmake: do not exclude tests from 'make all'

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -413,7 +413,7 @@ add_executable(ceph_test_keys
 target_link_libraries(ceph_test_keys mon global ${CMAKE_DL_LIBS})
 
 # ceph_test_snap_mapper
-add_executable(ceph_test_snap_mapper EXCLUDE_FROM_ALL
+add_executable(ceph_test_snap_mapper
   test_snap_mapper.cc
   )
 target_link_libraries(ceph_test_snap_mapper osd global ${BLKID_LIBRARIES} ${UNITTEST_LIBS})
@@ -542,196 +542,196 @@ set_property(TEST
   )
 
 # unittest_admin_socket
-add_executable(unittest_admin_socket EXCLUDE_FROM_ALL
+add_executable(unittest_admin_socket
   admin_socket.cc
   )
 add_ceph_unittest(unittest_admin_socket ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_admin_socket)
 target_link_libraries(unittest_admin_socket global) 
 
 # unittest_encoding
-add_executable(unittest_encoding EXCLUDE_FROM_ALL
+add_executable(unittest_encoding
   encoding.cc
   )
 add_ceph_unittest(unittest_encoding ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_encoding)
 target_link_libraries(unittest_encoding librados pthread rt m ${BLKID_LIBRARIES})
 
 # unittest_addrs
-add_executable(unittest_addrs EXCLUDE_FROM_ALL
+add_executable(unittest_addrs
   test_addrs.cc
   )
 add_ceph_unittest(unittest_addrs ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_addrs)
 target_link_libraries(unittest_addrs librados pthread rt m ${BLKID_LIBRARIES}) 
 
 # unittest_workqueue
-add_executable(unittest_workqueue EXCLUDE_FROM_ALL
+add_executable(unittest_workqueue
   test_workqueue.cc
   )
 add_ceph_unittest(unittest_workqueue ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_workqueue)
 target_link_libraries(unittest_workqueue global ${BLKID_LIBRARIES})
 
 # unittest_striper
-add_executable(unittest_striper EXCLUDE_FROM_ALL
+add_executable(unittest_striper
   test_striper.cc
   )
 add_ceph_unittest(unittest_striper ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_striper)
 target_link_libraries(unittest_striper global ${BLKID_LIBRARIES})
 
 # unittest_prebufferedstreambuf
-add_executable(unittest_prebufferedstreambuf EXCLUDE_FROM_ALL
+add_executable(unittest_prebufferedstreambuf
   test_prebufferedstreambuf.cc
   )
 add_ceph_unittest(unittest_prebufferedstreambuf ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_prebufferedstreambuf)
 target_link_libraries(unittest_prebufferedstreambuf global ${BLKID_LIBRARIES})
 
 # unittest_str_list
-add_executable(unittest_str_list EXCLUDE_FROM_ALL
+add_executable(unittest_str_list
   test_str_list.cc
   )
 add_ceph_unittest(unittest_str_list ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_str_list)
 target_link_libraries(unittest_str_list global ${BLKID_LIBRARIES})
 
 # unittest_log
-add_executable(unittest_log EXCLUDE_FROM_ALL
+add_executable(unittest_log
   ${CMAKE_SOURCE_DIR}/src/log/test.cc
   )
 add_ceph_unittest(unittest_log ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_log)
 target_link_libraries(unittest_log global)
 
 # unittest_base64
-add_executable(unittest_base64 EXCLUDE_FROM_ALL
+add_executable(unittest_base64
   base64.cc
   )
 add_ceph_unittest(unittest_base64 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_base64)
 target_link_libraries(unittest_base64 global) 
 
 # unittest_ceph_argparse
-add_executable(unittest_ceph_argparse EXCLUDE_FROM_ALL
+add_executable(unittest_ceph_argparse
   ceph_argparse.cc
   )
 add_ceph_unittest(unittest_ceph_argparse ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_ceph_argparse)
 target_link_libraries(unittest_ceph_argparse global)
 
 # unittest_ceph_compatset
-add_executable(unittest_ceph_compatset EXCLUDE_FROM_ALL
+add_executable(unittest_ceph_compatset
   ceph_compatset.cc
   )
 add_ceph_unittest(unittest_ceph_compatset ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_ceph_compatset)
 target_link_libraries(unittest_ceph_compatset global)
 
 # unittest_gather
-add_executable(unittest_gather EXCLUDE_FROM_ALL
+add_executable(unittest_gather
   gather.cc
   )
 add_ceph_unittest(unittest_gather ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_gather)
 target_link_libraries(unittest_gather global)
 
 # unittest_run_cmd
-add_executable(unittest_run_cmd EXCLUDE_FROM_ALL
+add_executable(unittest_run_cmd
   run_cmd.cc
   )
 add_ceph_unittest(unittest_run_cmd ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_run_cmd)
 target_link_libraries(unittest_run_cmd global)
 
 # signals
-add_executable(unittest_signals EXCLUDE_FROM_ALL
+add_executable(unittest_signals
   signals.cc
   )
 add_ceph_unittest(unittest_signals ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_signals)
 target_link_libraries(unittest_signals global)
 
 # unittest_simple_spin
-add_executable(unittest_simple_spin EXCLUDE_FROM_ALL
+add_executable(unittest_simple_spin
   simple_spin.cc
   )
 add_ceph_unittest(unittest_simple_spin ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_simple_spin)
 target_link_libraries(unittest_simple_spin global)
 
 # unittest_bufferlist
-add_executable(unittest_bufferlist EXCLUDE_FROM_ALL
+add_executable(unittest_bufferlist
   bufferlist.cc
   )
 add_ceph_unittest(unittest_bufferlist ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bufferlist)
 target_link_libraries(unittest_bufferlist global)
 
 # unittest_xlist
-add_executable(unittest_xlist EXCLUDE_FROM_ALL
+add_executable(unittest_xlist
   test_xlist.cc
   )
 add_ceph_unittest(unittest_xlist ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_xlist)
 target_link_libraries(unittest_xlist common)
 
 # unittest_arch
-add_executable(unittest_arch EXCLUDE_FROM_ALL
+add_executable(unittest_arch
   test_arch.cc
   )
 add_ceph_unittest(unittest_arch ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_arch)
 target_link_libraries(unittest_arch global)
 
 # unittest_crypto
-add_executable(unittest_crypto EXCLUDE_FROM_ALL
+add_executable(unittest_crypto
   crypto.cc
   )
 add_ceph_unittest(unittest_crypto ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_crypto)
 target_link_libraries(unittest_crypto global)
 
 # unittest_crypto_init
-add_executable(unittest_crypto_init EXCLUDE_FROM_ALL
+add_executable(unittest_crypto_init
   crypto_init.cc
   )
 add_ceph_unittest(unittest_crypto_init ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_crypto_init)
 target_link_libraries(unittest_crypto_init global)
 
 # unittest_perf_counters
-add_executable(unittest_perf_counters EXCLUDE_FROM_ALL
+add_executable(unittest_perf_counters
   perf_counters.cc
   )
 add_ceph_unittest(unittest_perf_counters ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_perf_counters)
 target_link_libraries(unittest_perf_counters global)
 
 # unittest_ceph_crypto
-add_executable(unittest_ceph_crypto EXCLUDE_FROM_ALL
+add_executable(unittest_ceph_crypto
   ceph_crypto.cc
   )
 add_ceph_unittest(unittest_ceph_crypto ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_ceph_crypto)
 target_link_libraries(unittest_ceph_crypto global)
 
 # unittest_utf8
-add_executable(unittest_utf8 EXCLUDE_FROM_ALL
+add_executable(unittest_utf8
   utf8.cc
   )
 add_ceph_unittest(unittest_utf8 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_utf8)
 target_link_libraries(unittest_utf8 global)
 
 # unittest_mime
-add_executable(unittest_mime EXCLUDE_FROM_ALL
+add_executable(unittest_mime
   mime.cc
   )
 add_ceph_unittest(unittest_mime ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mime)
 target_link_libraries(unittest_mime global)
 
 # unittest_escape
-add_executable(unittest_escape EXCLUDE_FROM_ALL
+add_executable(unittest_escape
   escape.cc
   )
 add_ceph_unittest(unittest_escape ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_escape)
 target_link_libraries(unittest_escape global)
 
 # unittest_strtol
-add_executable(unittest_strtol EXCLUDE_FROM_ALL
+add_executable(unittest_strtol
   strtol.cc
   )
 add_ceph_unittest(unittest_strtol ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_strtol)
 target_link_libraries(unittest_strtol global)
 
 # unittest_confutils
-add_executable(unittest_confutils EXCLUDE_FROM_ALL
+add_executable(unittest_confutils
   confutils.cc
   )
 add_ceph_unittest(unittest_confutils ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_confutils)
 target_link_libraries(unittest_confutils global)
 
 # unittest_heartbeatmap
-add_executable(unittest_heartbeatmap EXCLUDE_FROM_ALL
+add_executable(unittest_heartbeatmap
   heartbeat_map.cc
   )
 add_ceph_unittest(unittest_heartbeatmap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_heartbeatmap)
@@ -740,7 +740,7 @@ target_link_libraries(unittest_heartbeatmap global)
 if(${WITH_RADOSGW})
   # unittest_formatter
   # why does this include rgw/rgw_formats.cc...?
-  add_executable(unittest_formatter EXCLUDE_FROM_ALL
+  add_executable(unittest_formatter
     formatter.cc
     ${CMAKE_SOURCE_DIR}/src/rgw/rgw_formats.cc
   )
@@ -749,7 +749,7 @@ if(${WITH_RADOSGW})
 endif(${WITH_RADOSGW})
 
 # unittest_daemon_config
-add_executable(unittest_daemon_config EXCLUDE_FROM_ALL
+add_executable(unittest_daemon_config
   daemon_config.cc
   )
 add_ceph_unittest(unittest_daemon_config ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_daemon_config)
@@ -761,14 +761,14 @@ target_link_libraries(unittest_daemon_config
   )
 
 # unittest_libcephfs_config
-add_executable(unittest_libcephfs_config EXCLUDE_FROM_ALL
+add_executable(unittest_libcephfs_config
   libcephfs_config.cc
   )
 add_ceph_unittest(unittest_libcephfs_config ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_libcephfs_config)
 target_link_libraries(unittest_libcephfs_config cephfs)
 
 # unittest_rbd_replay
-add_executable(unittest_rbd_replay EXCLUDE_FROM_ALL
+add_executable(unittest_rbd_replay
   test_rbd_replay.cc
   $<TARGET_OBJECTS:parse_secret_objs>
 )
@@ -784,13 +784,13 @@ target_link_libraries(unittest_rbd_replay
   )
 
 # unittest_ipaddr
-add_executable(unittest_ipaddr EXCLUDE_FROM_ALL
+add_executable(unittest_ipaddr
   test_ipaddr.cc)  
 add_ceph_unittest(unittest_ipaddr ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_ipaddr)
 target_link_libraries(unittest_ipaddr mon global)
 
 # unittest_texttable
-add_executable(unittest_texttable EXCLUDE_FROM_ALL
+add_executable(unittest_texttable
   test_texttable.cc
   $<TARGET_OBJECTS:common_texttable_obj>
   )
@@ -798,21 +798,21 @@ add_ceph_unittest(unittest_texttable ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_
 target_link_libraries(unittest_texttable mon global)
 
 # unittest_on_exit
-add_executable(unittest_on_exit EXCLUDE_FROM_ALL
+add_executable(unittest_on_exit
   on_exit.cc
   )
 add_ceph_unittest(unittest_on_exit ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_on_exit)
 target_link_libraries(unittest_on_exit global)
 
 # unittest_subprocess
-add_executable(unittest_subprocess EXCLUDE_FROM_ALL
+add_executable(unittest_subprocess
   test_subprocess.cc
   )
 add_ceph_unittest(unittest_subprocess ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_subprocess)
 target_link_libraries(unittest_subprocess global)
 
 # unittest_pageset
-add_executable(unittest_pageset EXCLUDE_FROM_ALL test_pageset.cc)
+add_executable(unittest_pageset test_pageset.cc)
 add_ceph_unittest(unittest_pageset ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_pageset)
 
 #make check ends here

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -13,63 +13,63 @@ target_link_libraries(get_command_descriptions
   )
 
 # unittest_blkdev
-add_executable(unittest_blkdev EXCLUDE_FROM_ALL
+add_executable(unittest_blkdev
   test_blkdev.cc
   )
 add_ceph_unittest(unittest_blkdev ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_blkdev)
 target_link_libraries(unittest_blkdev global ${BLKID_LIBRARIES})
 
 # unittest_bloom_filter
-add_executable(unittest_bloom_filter EXCLUDE_FROM_ALL
+add_executable(unittest_bloom_filter
   test_bloom_filter.cc
   )
 add_ceph_unittest(unittest_bloom_filter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bloom_filter)
 target_link_libraries(unittest_bloom_filter global ${BLKID_LIBRARIES}) 
 
 # unittest_histogram
-add_executable(unittest_histogram EXCLUDE_FROM_ALL
+add_executable(unittest_histogram
   histogram.cc
   )
 add_ceph_unittest(unittest_histogram ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_histogram)
 target_link_libraries(unittest_histogram global ${BLKID_LIBRARIES})
 
 # unittest_prioritized_queue
-add_executable(unittest_prioritized_queue EXCLUDE_FROM_ALL
+add_executable(unittest_prioritized_queue
   test_prioritized_queue.cc
   )
 add_ceph_unittest(unittest_prioritized_queue ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_prioritized_queue)
 target_link_libraries(unittest_prioritized_queue global ${BLKID_LIBRARIES})
 
 # unittest_str_map
-add_executable(unittest_str_map EXCLUDE_FROM_ALL
+add_executable(unittest_str_map
   test_str_map.cc
   )
 add_ceph_unittest(unittest_str_map ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_str_map)
 target_link_libraries(unittest_str_map common global ${BLKID_LIBRARIES})
 
 # unittest_sharedptr_registry
-add_executable(unittest_sharedptr_registry EXCLUDE_FROM_ALL
+add_executable(unittest_sharedptr_registry
   test_sharedptr_registry.cc
   )
 add_ceph_unittest(unittest_sharedptr_registry ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_sharedptr_registry)
 target_link_libraries(unittest_sharedptr_registry global ${BLKID_LIBRARIES})
 
 # unittest_shared_cache
-add_executable(unittest_shared_cache EXCLUDE_FROM_ALL
+add_executable(unittest_shared_cache
   test_shared_cache.cc
   )
 add_ceph_unittest(unittest_shared_cache ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_shared_cache)
 target_link_libraries(unittest_shared_cache global ${BLKID_LIBRARIES})
 
 # unittest_sloppy_crc_map
-add_executable(unittest_sloppy_crc_map EXCLUDE_FROM_ALL
+add_executable(unittest_sloppy_crc_map
   test_sloppy_crc_map.cc
   )
 add_ceph_unittest(unittest_sloppy_crc_map ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_sloppy_crc_map)
 target_link_libraries(unittest_sloppy_crc_map global ${BLKID_LIBRARIES})
 
 # unittest_time
-add_executable(unittest_time EXCLUDE_FROM_ALL
+add_executable(unittest_time
   test_time.cc
   ${CMAKE_SOURCE_DIR}/src/common/ceph_time.cc
   )
@@ -77,7 +77,7 @@ add_ceph_unittest(unittest_time ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_time)
 target_link_libraries(unittest_time global ${BLKID_LIBRARIES})
 
 # unittest_util
-add_executable(unittest_util EXCLUDE_FROM_ALL
+add_executable(unittest_util
   test_util.cc
   ${CMAKE_SOURCE_DIR}/src/common/util.cc
   )
@@ -85,77 +85,77 @@ add_ceph_unittest(unittest_util ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_util)
 target_link_libraries(unittest_util global ${BLKID_LIBRARIES})
 
 # unittest_throttle
-add_executable(unittest_throttle EXCLUDE_FROM_ALL
+add_executable(unittest_throttle
   Throttle.cc
   )
 add_ceph_unittest(unittest_throttle ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_throttle)
 target_link_libraries(unittest_throttle global) 
 
 # unittest_lru
-add_executable(unittest_lru EXCLUDE_FROM_ALL
+add_executable(unittest_lru
   test_lru.cc
   )
 add_ceph_unittest(unittest_lru ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_lru)
 target_link_libraries(unittest_lru global)
 
 # unittest_io_priority
-add_executable(unittest_io_priority EXCLUDE_FROM_ALL
+add_executable(unittest_io_priority
   test_io_priority.cc
   )
 add_ceph_unittest(unittest_io_priority ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_io_priority)
 target_link_libraries(unittest_io_priority global)
 
 # unittest_crc32c
-add_executable(unittest_crc32c EXCLUDE_FROM_ALL
+add_executable(unittest_crc32c
   test_crc32c.cc
   )
 add_ceph_unittest(unittest_crc32c ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_crc32c)
 target_link_libraries(unittest_crc32c global)
 
 # unittest_config
-add_executable(unittest_config EXCLUDE_FROM_ALL
+add_executable(unittest_config
   test_config.cc
   )
 add_ceph_unittest(unittest_config ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_config)
 target_link_libraries(unittest_config global)
 
 # unittest_context
-add_executable(unittest_context EXCLUDE_FROM_ALL
+add_executable(unittest_context
   test_context.cc
   )
 add_ceph_unittest(unittest_context ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_context)
 target_link_libraries(unittest_context global)
 
 # unittest_safe_io
-add_executable(unittest_safe_io EXCLUDE_FROM_ALL
+add_executable(unittest_safe_io
   test_safe_io.cc
   )
 add_ceph_unittest(unittest_safe_io ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_safe_io)
 target_link_libraries(unittest_safe_io global)
 
 # unittest_readahead
-add_executable(unittest_readahead EXCLUDE_FROM_ALL
+add_executable(unittest_readahead
   Readahead.cc
   )
 add_ceph_unittest(unittest_readahead ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_readahead)
 target_link_libraries(unittest_readahead global)
 
 # unittest_tableformatter
-add_executable(unittest_tableformatter EXCLUDE_FROM_ALL
+add_executable(unittest_tableformatter
   test_tableformatter.cc
   )
 add_ceph_unittest(unittest_tableformatter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_tableformatter)
 target_link_libraries(unittest_tableformatter global)
 
 # unittest_bit_vector
-add_executable(unittest_bit_vector EXCLUDE_FROM_ALL
+add_executable(unittest_bit_vector
   test_bit_vector.cc
   )
 add_ceph_unittest(unittest_bit_vector ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bit_vector)
 target_link_libraries(unittest_bit_vector global)
 
 # unittest_async_compressor
-add_executable(unittest_async_compressor EXCLUDE_FROM_ALL
+add_executable(unittest_async_compressor
   test_async_compressor.cc
 )
 add_ceph_unittest(unittest_async_compressor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_async_compressor)
@@ -163,28 +163,28 @@ target_link_libraries(unittest_async_compressor global)
 add_dependencies(unittest_async_compressor ceph_snappy)
 
 # unittest_interval_set
-add_executable(unittest_interval_set EXCLUDE_FROM_ALL
+add_executable(unittest_interval_set
   test_interval_set.cc
 )
 add_ceph_unittest(unittest_interval_set ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_interval_set)
 target_link_libraries(unittest_interval_set global)
 
 # unittest_weighted_priority_queue
-add_executable(unittest_weighted_priority_queue EXCLUDE_FROM_ALL
+add_executable(unittest_weighted_priority_queue
   test_weighted_priority_queue.cc
   )
 add_ceph_unittest(unittest_weighted_priority_queue ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_weighted_priority_queue)
 target_link_libraries(unittest_weighted_priority_queue global ${BLKID_LIBRARIES}) 
 
 # unittest_mutex_debug
-add_executable(unittest_mutex_debug EXCLUDE_FROM_ALL
+add_executable(unittest_mutex_debug
   test_mutex_debug.cc
   )
 add_ceph_unittest(unittest_mutex_debug ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mutex_debug)
 target_link_libraries(unittest_mutex_debug global ${BLKID_LIBRARIES} ${EXTRALIBS})
 
 # unittest_shunique_lock
-add_executable(unittest_shunique_lock EXCLUDE_FROM_ALL
+add_executable(unittest_shunique_lock
   test_shunique_lock.cc
   )
 add_ceph_unittest(unittest_shunique_lock ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_shunique_lock)

--- a/src/test/compressor/CMakeLists.txt
+++ b/src/test/compressor/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(ceph_example SHARED compressor_plugin_example.cc)
 
 # unittest_compression_plugin
-add_executable(unittest_compression_plugin EXCLUDE_FROM_ALL
+add_executable(unittest_compression_plugin
   test_compression_plugin.cc
   )
 add_ceph_unittest(unittest_compression_plugin ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression_plugin)
@@ -9,14 +9,14 @@ target_link_libraries(unittest_compression_plugin global)
 add_dependencies(unittest_compression_plugin ceph_example)
 
 # unittest_compression_snappy
-add_executable(unittest_compression_snappy EXCLUDE_FROM_ALL
+add_executable(unittest_compression_snappy
   test_compression_snappy.cc
   )
 add_ceph_unittest(unittest_compression_snappy ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression_snappy)
 target_link_libraries(unittest_compression_snappy global ceph_snappy)
 
 # unittest_compression_plugin_snappy
-add_executable(unittest_compression_plugin_snappy EXCLUDE_FROM_ALL
+add_executable(unittest_compression_plugin_snappy
   test_compression_plugin_snappy.cc
   )
 add_ceph_unittest(unittest_compression_plugin_snappy ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression_plugin_snappy)
@@ -24,14 +24,14 @@ target_link_libraries(unittest_compression_plugin_snappy global)
 add_dependencies(unittest_compression_plugin_snappy ceph_snappy)
 
 # unittest_compression_zlib
-add_executable(unittest_compression_zlib EXCLUDE_FROM_ALL
+add_executable(unittest_compression_zlib
   test_compression_zlib.cc
   )
 add_ceph_unittest(unittest_compression_zlib ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression_zlib)
 target_link_libraries(unittest_compression_zlib global ceph_zlib)
 
 # unittest_compression_plugin_zlib
-add_executable(unittest_compression_plugin_zlib EXCLUDE_FROM_ALL
+add_executable(unittest_compression_plugin_zlib
   test_compression_plugin_zlib.cc
   )
 add_ceph_unittest(unittest_compression_plugin_zlib ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression_plugin_zlib)

--- a/src/test/crush/CMakeLists.txt
+++ b/src/test/crush/CMakeLists.txt
@@ -1,12 +1,12 @@
 # unittest_crush_wrapper
-add_executable(unittest_crush_wrapper EXCLUDE_FROM_ALL
+add_executable(unittest_crush_wrapper
   CrushWrapper.cc
   )
 add_ceph_unittest(unittest_crush_wrapper ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_crush_wrapper)
 target_link_libraries(unittest_crush_wrapper global crush ${BLKID_LIBRARIES})
 
 # unittest_crush
-add_executable(unittest_crush EXCLUDE_FROM_ALL
+add_executable(unittest_crush
   crush.cc
   )
 add_ceph_unittest(unittest_crush ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_crush)

--- a/src/test/erasure-code/CMakeLists.txt
+++ b/src/test/erasure-code/CMakeLists.txt
@@ -41,7 +41,7 @@ add_dependencies(ec_fail_to_register ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ec_fail_to_register pthread ${EXTRA_LIBS})
 
 # unittest_erasure_code_plugin
-add_executable(unittest_erasure_code_plugin EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_plugin
   ${CMAKE_SOURCE_DIR}/src/erasure-code/ErasureCode.cc
   TestErasureCodePlugin.cc
   )
@@ -62,7 +62,7 @@ add_dependencies(unittest_erasure_code_plugin
   ec_fail_to_register)
 
 # unittest_erasure_code
-add_executable(unittest_erasure_code EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code
   ${CMAKE_SOURCE_DIR}/src/erasure-code/ErasureCode.cc
   TestErasureCode.cc
   )
@@ -90,7 +90,7 @@ add_dependencies(ec_test_jerasure_generic ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ec_test_jerasure_generic pthread ${EXTRA_LIBS})
 
 # unittest_erasure_code_plugin_jerasure
-add_executable(unittest_erasure_code_plugin_jerasure EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_plugin_jerasure
   TestErasureCodePluginJerasure.cc
   )
 add_ceph_unittest(unittest_erasure_code_plugin_jerasure ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_jerasure)
@@ -111,7 +111,7 @@ add_dependencies(unittest_erasure_code_plugin_jerasure
 if(HAVE_BETTER_YASM_ELF64)
 
 #unittest_erasure_code_isa
-add_executable(unittest_erasure_code_isa EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_isa
   ${CMAKE_SOURCE_DIR}/src/erasure-code/ErasureCode.cc
   TestErasureCodeIsa.cc
   )
@@ -125,7 +125,7 @@ target_link_libraries(unittest_erasure_code_isa
   )
 
 #unittest_erasure_code_plugin_isa
-add_executable(unittest_erasure_code_plugin_isa EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_plugin_isa
   ${CMAKE_SOURCE_DIR}/src/erasure-code/ErasureCode.cc
   TestErasureCodePluginIsa.cc
   )
@@ -142,7 +142,7 @@ target_link_libraries(unittest_erasure_code_plugin_isa
 endif(HAVE_BETTER_YASM_ELF64)
 
 # unittest_erasure_code_lrc
-add_executable(unittest_erasure_code_lrc EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_lrc
   TestErasureCodeLrc.cc
   ${lrc_srcs}
   )
@@ -156,7 +156,7 @@ target_link_libraries(unittest_erasure_code_lrc
   )
 
 # unittest_erasure_code_plugin_lrc
-add_executable(unittest_erasure_code_plugin_lrc EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_plugin_lrc
   TestErasureCodePluginLrc.cc
   )
 add_ceph_unittest(unittest_erasure_code_plugin_lrc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_lrc)
@@ -191,7 +191,7 @@ add_dependencies(ec_test_shec_generic ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ec_test_shec_generic pthread ${EXTRA_LIBS})
 
 # unittest_erasure_code_plugin_shec
-add_executable(unittest_erasure_code_plugin_shec EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_plugin_shec
   TestErasureCodePluginShec.cc
   )
 add_ceph_unittest(unittest_erasure_code_plugin_shec ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_shec)
@@ -212,7 +212,7 @@ add_dependencies(unittest_erasure_code_plugin_shec
   ec_test_shec_generic)
 
 # unittest_erasure_code_example
-add_executable(unittest_erasure_code_example EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_example
   ${CMAKE_SOURCE_DIR}/src/erasure-code/ErasureCode.cc
   TestErasureCodeExample.cc
 )
@@ -231,7 +231,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src/erasure-code/jerasure/jerasure/inclu
 include_directories(${CMAKE_SOURCE_DIR}/src/erasure-code//jerasure/gf-complete/include)
 
 # unittest_erasure_code_jerasure
-add_executable(unittest_erasure_code_jerasure EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_jerasure
   TestErasureCodeJerasure.cc
   )
 add_ceph_unittest(unittest_erasure_code_jerasure ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_jerasure)
@@ -246,7 +246,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src/erasure-code/jerasure)
 include_directories(${CMAKE_SOURCE_DIR}/src/erasure-code/shec)
 
 # unittest_erasure_code_shec
-add_executable(unittest_erasure_code_shec EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_shec
   TestErasureCodeShec.cc
   )
 add_ceph_unittest(unittest_erasure_code_shec ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_shec)
@@ -259,7 +259,7 @@ target_link_libraries(unittest_erasure_code_shec
   )
 
 # unittest_erasure_code_shec_all
-add_executable(unittest_erasure_code_shec_all EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_shec_all
   TestErasureCodeShec_all.cc
   )
 add_ceph_unittest(unittest_erasure_code_shec_all ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_shec_all)
@@ -272,7 +272,7 @@ target_link_libraries(unittest_erasure_code_shec_all
   )
 
 # unittest_erasure_code_shec_thread
-add_executable(unittest_erasure_code_shec_thread EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_shec_thread
   TestErasureCodeShec_thread.cc
   )
 add_ceph_unittest(unittest_erasure_code_shec_thread ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_shec_thread)
@@ -286,7 +286,7 @@ target_link_libraries(unittest_erasure_code_shec_thread
 
 
 # unittest_erasure_code_shec_arguments
-add_executable(unittest_erasure_code_shec_arguments EXCLUDE_FROM_ALL
+add_executable(unittest_erasure_code_shec_arguments
   TestErasureCodeShec_arguments.cc
   )
 add_ceph_unittest(unittest_erasure_code_shec_arguments ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_shec_arguments)

--- a/src/test/fs/CMakeLists.txt
+++ b/src/test/fs/CMakeLists.txt
@@ -1,5 +1,5 @@
 # unittest_mds_types
-add_executable(unittest_mds_types EXCLUDE_FROM_ALL
+add_executable(unittest_mds_types
   mds_types.cc
   )
 add_ceph_unittest(unittest_mds_types ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mds_types)

--- a/src/test/journal/CMakeLists.txt
+++ b/src/test/journal/CMakeLists.txt
@@ -17,7 +17,7 @@ set(unittest_journal_srcs
   RadosTestFixture.cc
   )
 
-add_executable(unittest_journal EXCLUDE_FROM_ALL
+add_executable(unittest_journal
   ${unittest_journal_srcs} 
   )
 add_ceph_unittest(unittest_journal ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_journal)

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -153,14 +153,14 @@ target_link_libraries(ceph_test_rados_api_tmap_migrate
   librados mds osdc global cls_cephfs_client ${UNITTEST_LIBS} radostest)
 
 # unittest_librados
-add_executable(unittest_librados EXCLUDE_FROM_ALL
+add_executable(unittest_librados
   librados.cc
   )
 add_ceph_unittest(unittest_librados ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_librados)
 target_link_libraries(unittest_librados librados global ${BLKID_LIBRARIES})
 
 # unittest_librados_config
-add_executable(unittest_librados_config EXCLUDE_FROM_ALL
+add_executable(unittest_librados_config
   librados_config.cc
   )
 add_ceph_unittest(unittest_librados_config ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_librados_config)

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -48,7 +48,7 @@ set(unittest_librbd_srcs
   operation/test_mock_SnapshotRollbackRequest.cc 
   operation/test_mock_SnapshotUnprotectRequest.cc
   )
-add_executable(unittest_librbd EXCLUDE_FROM_ALL
+add_executable(unittest_librbd
   ${unittest_librbd_srcs}
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
   $<TARGET_OBJECTS:common_texttable_obj>

--- a/src/test/mds/CMakeLists.txt
+++ b/src/test/mds/CMakeLists.txt
@@ -1,12 +1,12 @@
 # unittest_mds_authcap
-add_executable(unittest_mds_authcap EXCLUDE_FROM_ALL
+add_executable(unittest_mds_authcap
   TestMDSAuthCaps.cc
   )
 add_ceph_unittest(unittest_mds_authcap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mds_authcap)
 target_link_libraries(unittest_mds_authcap mds global ${BLKID_LIBRARIES})
 
 # unittest_mds_sessionfilter
-add_executable(unittest_mds_sessionfilter EXCLUDE_FROM_ALL
+add_executable(unittest_mds_sessionfilter
   TestSessionFilter.cc
   $<TARGET_OBJECTS:common_util_obj>
   )

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -33,14 +33,14 @@ add_ceph_test(osd-pool-create.sh ${CMAKE_CURRENT_SOURCE_DIR}/osd-pool-create.sh)
 add_ceph_test(test_pool_quota.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_pool_quota.sh)
 
 # unittest_mon_moncap
-add_executable(unittest_mon_moncap EXCLUDE_FROM_ALL
+add_executable(unittest_mon_moncap
   moncap.cc
   )
 add_ceph_unittest(unittest_mon_moncap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mon_moncap)
 target_link_libraries(unittest_mon_moncap mon global)
 
 # unittest_mon_pgmap
-add_executable(unittest_mon_pgmap EXCLUDE_FROM_ALL
+add_executable(unittest_mon_pgmap
   PGMap.cc
   )
 add_ceph_unittest(unittest_mon_pgmap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mon_pgmap)

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -85,42 +85,42 @@ target_link_libraries(ceph_test_filestore_idempotent_sequence
   )
 
 # unittest_chain_xattr
-add_executable(unittest_chain_xattr EXCLUDE_FROM_ALL
+add_executable(unittest_chain_xattr
   chain_xattr.cc
   )
 add_ceph_unittest(unittest_chain_xattr ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_chain_xattr)
 target_link_libraries(unittest_chain_xattr os global)
 
 # unittest_rocksdb_option
-add_executable(unittest_rocksdb_option EXCLUDE_FROM_ALL
+add_executable(unittest_rocksdb_option
   TestRocksdbOptionParse.cc
   )
 add_ceph_unittest(unittest_rocksdb_option ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rocksdb_option)
 target_link_libraries(unittest_rocksdb_option global os ${BLKID_LIBRARIES})
 
 # unittest_bit_alloc
-add_executable(unittest_bit_alloc EXCLUDE_FROM_ALL
+add_executable(unittest_bit_alloc
   BitAllocator_test.cc
   )
 add_ceph_unittest(unittest_bit_alloc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bit_alloc)
 target_link_libraries(unittest_bit_alloc os global)
 
 # unittest_bluefs
-add_executable(unittest_bluefs EXCLUDE_FROM_ALL 
+add_executable(unittest_bluefs
   test_bluefs.cc
   )
 add_ceph_unittest(unittest_bluefs ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bluefs)
 target_link_libraries(unittest_bluefs os global)
 
 # unittest_bluestore_types
-add_executable(unittest_bluestore_types EXCLUDE_FROM_ALL 
+add_executable(unittest_bluestore_types
   test_bluestore_types.cc
   )
 add_ceph_unittest(unittest_bluestore_types ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bluestore_types)
 target_link_libraries(unittest_bluestore_types os global)
   
 # unittest_transaction
-add_executable(unittest_transaction EXCLUDE_FROM_ALL 
+add_executable(unittest_transaction
   test_transaction.cc)
 add_ceph_unittest(unittest_transaction ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_transaction)
 target_link_libraries(unittest_transaction os common)

--- a/src/test/os/CMakeLists.txt
+++ b/src/test/os/CMakeLists.txt
@@ -1,5 +1,5 @@
 # unittest_lfnindex
-add_executable(unittest_lfnindex EXCLUDE_FROM_ALL
+add_executable(unittest_lfnindex
   TestLFNIndex.cc
   )
 add_ceph_unittest(unittest_lfnindex ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_lfnindex)

--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -41,49 +41,49 @@ set_property(TEST
   PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.linux-x86_64-2.7:${CMAKE_SOURCE_DIR}/src/pybind)
 
 # unittest_osdmap
-add_executable(unittest_osdmap EXCLUDE_FROM_ALL
+add_executable(unittest_osdmap
   TestOSDMap.cc
   )
 add_ceph_unittest(unittest_osdmap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_osdmap)
 target_link_libraries(unittest_osdmap global ${BLKID_LIBRARIES})
 
 # unittest_osd_types
-add_executable(unittest_osd_types EXCLUDE_FROM_ALL
+add_executable(unittest_osd_types
   types.cc
   )
 add_ceph_unittest(unittest_osd_types ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_osd_types)
 target_link_libraries(unittest_osd_types global)
 
 # unittest_ecbackend
-add_executable(unittest_ecbackend EXCLUDE_FROM_ALL
+add_executable(unittest_ecbackend
   TestECBackend.cc
   )
 add_ceph_unittest(unittest_ecbackend ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_ecbackend)
 target_link_libraries(unittest_ecbackend osd global)
 
 # unittest_osdscrub
-add_executable(unittest_osdscrub EXCLUDE_FROM_ALL
+add_executable(unittest_osdscrub
   TestOSDScrub.cc
   )
 add_ceph_unittest(unittest_osdscrub ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_osdscrub)
 target_link_libraries(unittest_osdscrub osd global dl os mon ${BLKID_LIBRARIES})
 
 # unittest_pglog
-add_executable(unittest_pglog EXCLUDE_FROM_ALL
+add_executable(unittest_pglog
   TestPGLog.cc
   )
 add_ceph_unittest(unittest_pglog ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_pglog)
 target_link_libraries(unittest_pglog osd global dl ${BLKID_LIBRARIES})
 
 # unittest_hitset
-add_executable(unittest_hitset EXCLUDE_FROM_ALL
+add_executable(unittest_hitset
   hitset.cc
   )
 add_ceph_unittest(unittest_hitset ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_hitset)
 target_link_libraries(unittest_hitset osd global ${BLKID_LIBRARIES})
 
 # unittest_osd_osdcap
-add_executable(unittest_osd_osdcap EXCLUDE_FROM_ALL
+add_executable(unittest_osd_osdcap
   osdcap.cc
 )
 add_ceph_unittest(unittest_osd_osdcap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_osd_osdcap)

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(rbd_mirror STATIC ${rbd_mirror_test_srcs})
 set_target_properties(rbd_mirror PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 
-add_executable(unittest_rbd_mirror EXCLUDE_FROM_ALL
+add_executable(unittest_rbd_mirror
   test_main.cc
   test_mock_fixture.cc
   test_mock_ImageReplayer.cc

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -1,10 +1,10 @@
 #unitttest_rgw_period_history
-add_executable(unittest_rgw_period_history EXCLUDE_FROM_ALL test_rgw_period_history.cc)
+add_executable(unittest_rgw_period_history test_rgw_period_history.cc)
 add_ceph_unittest(unittest_rgw_period_history ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rgw_period_history)
 target_link_libraries(unittest_rgw_period_history rgw_a)
 
 # unitttest_http_manager
-add_executable(unittest_http_manager EXCLUDE_FROM_ALL test_http_manager.cc)
+add_executable(unittest_http_manager test_http_manager.cc)
 add_ceph_unittest(unittest_http_manager ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_http_manager)
 target_link_libraries(unittest_http_manager rgw_a)
 


### PR DESCRIPTION
This prevent us from doing 'make' and then 'ctest ...'.
It is also super annoying in general to not verify the
tests compile with a simple 'make'.

This does a full build for me locally, yay!