### PR TITLE
cmake: add radosgw to 'make vstart' target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1518,12 +1518,14 @@ add_subdirectory(brag)
 add_custom_target(vstart DEPENDS
     ceph-osd
     ceph-mon
-    ceph-mds
     ceph-authtool
     ceph-conf
     monmaptool
     crushtool
     cython_rados)
+if(WITH_MDS)
+  add_dependencies(vstart ceph-mds)
+endif(WITH_MDS)
 if(WITH_RADOSGW)
   add_dependencies(vstart radosgw radosgw-admin)
 endif(WITH_RADOSGW)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1524,6 +1524,9 @@ add_custom_target(vstart DEPENDS
     monmaptool
     crushtool
     cython_rados)
+if(WITH_RADOSGW)
+  add_dependencies(vstart radosgw radosgw-admin)
+endif(WITH_RADOSGW)
 
 # Everything you need to run CephFS tests
 add_custom_target(cephfs_testing DEPENDS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1472,6 +1472,10 @@ if(${WITH_RADOSGW})
     cls_version_client cls_replica_log_client cls_user_client
     curl expat global fcgi resolv ${OPENSSL_LIBRARIES} ${BLKID_LIBRARIES} ${OPENLDAP_LIBS}
     ${ALLOC_LIBS})
+  # radosgw depends on cls libraries at runtime, but not as link dependencies
+  add_dependencies(radosgw cls_rgw cls_lock cls_refcount
+    cls_log cls_statelog cls_timeindex
+    cls_version cls_replica_log cls_user)
   install(TARGETS radosgw DESTINATION bin)
 
   add_executable(radosgw-admin ${radosgw_admin_srcs})


### PR DESCRIPTION
Now that all unit tests build by default in cmake (see 824931368fdd99ae20fe30094f8abce4045303f4), developers may want to use 'make vstart' to build the minimal set of targets needed to start a cluster with vstart.sh. This adds the radosgw and radosgw-admin targets to support this workflow for rgw testing.