### PR TITLE
msg/AsyncMessenger:delete cpy constr and assign op

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -281,8 +281,6 @@ void Worker::stop()
 }
 
 class WorkerPool {
-  WorkerPool(const WorkerPool &);
-  WorkerPool& operator=(const WorkerPool &);
   CephContext *cct;
   vector<Worker*> workers;
   vector<int> coreids;
@@ -307,6 +305,8 @@ class WorkerPool {
   friend class C_barrier;
   public:
   explicit WorkerPool(CephContext *c);
+  WorkerPool(const WorkerPool &) = delete;
+  WorkerPool& operator=(const WorkerPool &) = delete;
   virtual ~WorkerPool();
   void start();
   Worker *get_worker();


### PR DESCRIPTION
Delete copy constructor and assignment operator, so the checking can
be moved from linking to compile time - as it was when the above
where only declared, but not defined.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>