### PR TITLE
[DNM] s/boost::regex/std::regex/

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -732,10 +732,6 @@ if test "x$enable_xio" = x"yes"; then
    AC_CHECK_HEADER([libxio.h], [], AC_MSG_ERROR([Cannot find header 'libxio.h'.]))
    AC_CHECK_LIB([xio], [xio_init], [], AC_MSG_FAILURE([Accelio libxio not found]))
 
-   # Also require boost-regex, used in address_helper
-   AC_CHECK_LIB(boost_regex, main, [],
-      AC_MSG_FAILURE(["Boost regex library not found."]))
-
    AC_DEFINE([HAVE_XIO], [1], [Accelio conditional compilation])
 
    XIO_LIBS="-lxio"

--- a/configure.ac
+++ b/configure.ac
@@ -937,8 +937,6 @@ AC_CHECK_HEADER([boost/asio/coroutine.hpp],
 	[])
 AC_CHECK_HEADER([boost/statechart/state.hpp], [],
     AC_MSG_FAILURE(["Can't find boost statechart headers; need 1.34 or later"]))
-AC_CHECK_HEADER([boost/regex.hpp], [],
-    AC_MSG_FAILURE(["Can't find boost regex headers"]))
 AC_CHECK_HEADER([boost/program_options/option.hpp], [],
     AC_MSG_FAILURE(["Can't find boost program_options headers"]))
 
@@ -973,17 +971,6 @@ AC_CHECK_LIB(boost_random-mt, main, [],
 BOOST_RANDOM_LIBS="${LIBS}"
 LIBS="${saved_LIBS}"
 AC_SUBST(BOOST_RANDOM_LIBS)
-
-# boost-regex
-BOOST_REGEX_LIBS=""
-saved_LIBS="${LIBS}"
-LIBS=""
-AC_CHECK_LIB(boost_regex-mt, main, [],
-    [AC_CHECK_LIB(boost_regex, main, [],
-        AC_MSG_FAILURE(["Boost regex library not found."]))])
-BOOST_REGEX_LIBS="${LIBS}"
-LIBS="${saved_LIBS}"
-AC_SUBST(BOOST_REGEX_LIBS)
 
 #
 # Check for boost_program_options library (defines BOOST_PROGRAM_OPTIONS_LIBS).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1215,8 +1215,7 @@ if(${WITH_RBD})
 
   add_executable(rbd-nbd tools/rbd_nbd/rbd-nbd.cc
     $<TARGET_OBJECTS:parse_secret_objs>)
-  target_link_libraries(rbd-nbd librbd librados global keyutils
-    ${Boost_REGEX_LIBRARY})
+  target_link_libraries(rbd-nbd librbd librados global keyutils)
 
   set(rbd_mirror_internal
     tools/rbd_mirror/ClusterWatcher.cc
@@ -1312,7 +1311,7 @@ if(${WITH_RBD})
     $<TARGET_OBJECTS:krbd_objs>)
   set_target_properties(rbd PROPERTIES OUTPUT_NAME rbd)
   target_link_libraries(rbd librbd librados global common keyutils udev
-    ${Boost_REGEX_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
   install(TARGETS rbd rbd-nbd rbd-mirror DESTINATION bin)
   install(PROGRAMS ${CMAKE_SOURCE_DIR}/src/ceph-rbdnamer DESTINATION bin)

--- a/src/common/address_helper.cc
+++ b/src/common/address_helper.cc
@@ -8,25 +8,20 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <arpa/inet.h>
 
 #include <iostream>
 #include <string>
-
-using namespace std;
+#include <regex>
 
 #include "common/config.h"
-#include "boost/regex.hpp"
-
 #include "common/address_helper.h"
 
-#include <arpa/inet.h>
+using namespace std;
 
 // decode strings like "tcp://<host>:<port>"
 int entity_addr_from_url(entity_addr_t *addr /* out */, const char *url)
 {
-	using namespace boost;
-	using std::endl;
-
 	regex expr("(tcp|rdma)://([^:]*):([\\d]+)");
 	cmatch m;
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -180,7 +180,6 @@ if(${WITH_RADOSGW})
     cls_rgw_client
     cls_user_client
     cls_lock_client
-    ${Boost_REGEX_LIBRARY}
     ${BLKID_LIBRARIES}
     ${CMAKE_DL_LIBS} ${UNITTEST_LIBS} ${CRYPTO_LIBS})
   set_target_properties(ceph_test_cls_rgw_meta PROPERTIES
@@ -210,7 +209,6 @@ if(${WITH_RADOSGW})
     cls_rgw_client
     cls_user_client
     cls_lock_client
-    ${Boost_REGEX_LIBRARY}
     ${BLKID_LIBRARIES}
     ${CMAKE_DL_LIBS}
     ${UNITTEST_LIBS}

--- a/src/test/messenger/CMakeLists.txt
+++ b/src/test/messenger/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(simple_server
   simple_dispatcher.cc
   )
 target_link_libraries(simple_server
-  os global common ${Boost_REGEX_LIBRARY}
+  os global common
   ${EXTRALIBS}
   ${CMAKE_DL_LIBS}
   )
@@ -13,7 +13,7 @@ add_executable(simple_client
   simple_dispatcher.cc
   )
 target_link_libraries(simple_client
-  os global common ${Boost_REGEX_LIBRARY}
+  os global common
   ${EXTRALIBS}
   ${CMAKE_DL_LIBS}
   )
@@ -24,7 +24,7 @@ if(HAVE_XIO)
     xio_dispatcher.cc
     )
   target_link_libraries(xio_server
-    os global common ${Boost_REGEX_LIBRARY}
+    os global common
     ${XIO_LIBRARY} pthread rt
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
@@ -35,7 +35,7 @@ if(HAVE_XIO)
     xio_dispatcher.cc
     )
   target_link_libraries(xio_client
-    os global common ${Boost_REGEX_LIBRARY}
+    os global common
     ${XIO_LIBRARY} pthread rt
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -74,7 +74,7 @@ rbd_LDADD = \
 	libjournal.la libcls_journal_client.la \
 	libcls_rbd_client.la libcls_lock_client.la \
 	$(LIBRBD) $(LIBRBD_TYPES) $(LIBRADOS) $(CEPH_GLOBAL) \
-	$(BOOST_REGEX_LIBS) $(BOOST_PROGRAM_OPTIONS_LIBS)
+	$(BOOST_PROGRAM_OPTIONS_LIBS)
 if LINUX
 rbd_LDADD += $(LIBKRBD)
 endif # LINUX
@@ -83,7 +83,7 @@ bin_PROGRAMS += rbd
 if LINUX
 rbd_nbd_SOURCES = tools/rbd_nbd/rbd-nbd.cc
 rbd_nbd_CXXFLAGS = $(AM_CXXFLAGS)
-rbd_nbd_LDADD = $(LIBRBD) $(LIBRADOS) $(CEPH_GLOBAL) $(BOOST_REGEX_LIBS)
+rbd_nbd_LDADD = $(LIBRBD) $(LIBRADOS) $(CEPH_GLOBAL)
 bin_PROGRAMS += rbd-nbd
 
 endif # LINUX

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -13,7 +13,7 @@
 #include "common/safe_io.h"
 #include "global/global_context.h"
 #include <iostream>
-#include <boost/regex.hpp>
+#include <regex>
 
 namespace rbd {
 namespace utils {
@@ -86,7 +86,7 @@ int extract_spec(const std::string &spec, std::string *pool_name,
     spec_validation = SPEC_VALIDATION_NONE;
   }
 
-  boost::regex pattern;
+  std::regex pattern;
   switch (spec_validation) {
   case SPEC_VALIDATION_FULL:
     // disallow "/" and "@" in image and snap name
@@ -106,8 +106,8 @@ int extract_spec(const std::string &spec, std::string *pool_name,
     break;
   }
 
-  boost::smatch match;
-  if (!boost::regex_match(spec, match, pattern)) {
+  std::smatch match;
+  if (!std::regex_match(spec, match, pattern)) {
     std::cerr << "rbd: invalid spec '" << spec << "'" << std::endl;
     return -EINVAL;
   }
@@ -127,11 +127,11 @@ int extract_spec(const std::string &spec, std::string *pool_name,
 int extract_group_spec(const std::string &spec,
 		       std::string *pool_name,
 		       std::string *group_name) {
-  boost::regex pattern;
+  std::regex pattern;
   pattern = "^(?:([^/]+)/)?(.+)?$";
 
-  boost::smatch match;
-  if (!boost::regex_match(spec, match, pattern)) {
+  std::smatch match;
+  if (!std::regex_match(spec, match, pattern)) {
     std::cerr << "rbd: invalid spec '" << spec << "'" << std::endl;
     return -EINVAL;
   }

--- a/src/tools/rbd/action/MirrorImage.cc
+++ b/src/tools/rbd/action/MirrorImage.cc
@@ -22,7 +22,6 @@
 #include "global/global_context.h"
 #include <iostream>
 #include <boost/program_options.hpp>
-#include <boost/regex.hpp>
 
 namespace rbd {
 namespace action {

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -11,8 +11,8 @@
 #include "common/TextTable.h"
 #include "global/global_context.h"
 #include <iostream>
+#include <regex>
 #include <boost/program_options.hpp>
-#include <boost/regex.hpp>
 
 namespace rbd {
 namespace action {
@@ -24,10 +24,10 @@ namespace po = boost::program_options;
 namespace {
 
 int validate_uuid(const std::string &uuid) {
-  boost::regex pattern("^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$",
-                       boost::regex::icase);
-  boost::smatch match;
-  if (!boost::regex_match(uuid, match, pattern)) {
+  std::regex pattern("^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$",
+                       std::regex::icase);
+  std::smatch match;
+  if (!std::regex_match(uuid, match, pattern)) {
     std::cerr << "rbd: invalid uuid '" << uuid << "'" << std::endl;
     return -EINVAL;
   }
@@ -61,9 +61,9 @@ int get_remote_cluster_spec(const po::variables_map &vm,
   }
 
   if (!spec.empty()) {
-    boost::regex pattern("^(?:(client\\.[^@]+)@)?([^/@]+)$");
-    boost::smatch match;
-    if (!boost::regex_match(spec, match, pattern)) {
+    std::regex pattern("^(?:(client\\.[^@]+)@)?([^/@]+)$");
+    std::smatch match;
+    if (!std::regex_match(spec, match, pattern)) {
       std::cerr << "rbd: invalid spec '" << spec << "'" << std::endl;
       return -EINVAL;
     }

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -34,7 +34,7 @@
 #include <sys/socket.h>
 
 #include <iostream>
-#include <boost/regex.hpp>
+#include <regex>
 
 #include "mon/MonClient.h"
 #include "common/config.h"
@@ -685,9 +685,9 @@ static int do_unmap()
 
 static int parse_imgpath(const std::string &imgpath)
 {
-  boost::regex pattern("^(?:([^/@]+)/)?([^/@]+)(?:@([^/@]+))?$");
-  boost::smatch match;
-  if (!boost::regex_match(imgpath, match, pattern)) {
+  std::regex pattern("^(?:([^/@]+)/)?([^/@]+)(?:@([^/@]+))?$");
+  std::smatch match;
+  if (!std::regex_match(imgpath, match, pattern)) {
     std::cerr << "rbd-nbd: invalid spec '" << imgpath << "'" << std::endl;
     return -EINVAL;
   }


### PR DESCRIPTION
to use the `std::regex` instead of the one from boost. always good to have less dependency if everything else is the same.