### PR TITLE
common/config: fix return type of string::find and use string::npos

### DIFF
--- a/src/common/entity_name.cc
+++ b/src/common/entity_name.cc
@@ -57,9 +57,9 @@ to_cstr() const
 bool EntityName::
 from_str(const string& s)
 {
-  int pos = s.find('.');
+  size_t pos = s.find('.');
 
-  if (pos < 0)
+  if (pos == string::npos)
     return false;
  
   string type_ = s.substr(0, pos);


### PR DESCRIPTION
Signed-off-by: Yan Jun yan.jun8@zte.com.cn
