### PR TITLE
mds: Add path filtering for dump cache

### DIFF
--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1111,11 +1111,14 @@ public:
   void notify_osdmap_changed();
 
 protected:
-  void dump_cache(const char *fn, Formatter *f);
+  void dump_cache(const char *fn, Formatter *f,
+		  const std::string& dump_root = "",
+		  int depth = -1);
 public:
   void dump_cache() {dump_cache(NULL, NULL);}
   void dump_cache(const std::string &filename);
   void dump_cache(Formatter *f);
+  void dump_cache(const std::string& dump_root, int depth, Formatter *f);
 
   void dump_resolve_status(Formatter *f) const;
   void dump_rejoin_status(Formatter *f) const;

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -273,6 +273,13 @@ void MDSDaemon::set_up_admin_socket()
                                      asok_hook,
                                      "dump metadata cache (optionally to a file)");
   assert(r == 0);
+  r = admin_socket->register_command("dump tree",
+				     "dump tree "
+				     "name=root,type=CephString,req=true "
+				     "name=depth,type=CephInt,req=false ",
+				     asok_hook,
+				     "dump metadata cache for subtree");
+  assert(r == 0);
   r = admin_socket->register_command("session evict",
 				     "session evict name=client_id,type=CephString",
 				     asok_hook,
@@ -339,6 +346,7 @@ void MDSDaemon::clean_up_admin_socket()
   admin_socket->unregister_command("flush_path");
   admin_socket->unregister_command("export dir");
   admin_socket->unregister_command("dump cache");
+  admin_socket->unregister_command("dump tree");
   admin_socket->unregister_command("session evict");
   admin_socket->unregister_command("osdmap barrier");
   admin_socket->unregister_command("session ls");

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1758,6 +1758,16 @@ bool MDSRankDispatcher::handle_asok_command(
     } else {
       mdcache->dump_cache(path);
     }
+  } else if (command == "dump tree") {
+    string root;
+    int64_t depth;
+    cmd_getval(g_ceph_context, cmdmap, "root", root);
+    if (!cmd_getval(g_ceph_context, cmdmap, "depth", depth))
+      depth = -1;
+    {
+      Mutex::Locker l(mds_lock);
+      mdcache->dump_cache(root, depth, f);
+    }
   } else if (command == "force_readonly") {
     mds_lock.Lock();
     mdcache->force_readonly();


### PR DESCRIPTION
Add a new admin socket command, dump below, to filter
cache dumps by path. An optional integer depth parameter
limits the depth below the specified path.

Fixes: http://tracker.ceph.com/issues/11171
Signed-off-by: Douglas Fuller <dfuller@redhat.com>