### PR TITLE
msg/AsyncMessenger: remove unneeded friend decl

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -302,7 +302,6 @@ class WorkerPool {
       delete this;
     }
   };
-  friend class C_barrier;
   public:
   explicit WorkerPool(CephContext *c);
   WorkerPool(const WorkerPool &) = delete;


### PR DESCRIPTION
Removed unneeded friend declaration. Nested class already has access
to all the names(private, protected) to which enclosing class has
access(as of C++11).

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>