### PR TITLE
msg/simple: wait dispatch_queue until all pipes closed

### DIFF
--- a/src/msg/simple/SimpleMessenger.h
+++ b/src/msg/simple/SimpleMessenger.h
@@ -305,6 +305,9 @@ private:
   /// internal cluster protocol version, if any, for talking to entities of the same type.
   int cluster_protocol;
 
+  Cond  stop_cond;
+  bool stopped = true;
+
   bool reaper_started, reaper_stop;
   Cond reaper_cond;
 


### PR DESCRIPTION
    Now we use dispatch_queue.wait to wait for SimpleMessenger shutdown,
    but we need to ensure DispatchQueue can process event after Accepter down,
    Otherwise accepter may continue to accept new connection which may queue
    new item. so we can't rely on DispatchQueue now.

    Introduce stop_cond and stop flag to indicate this function like
    AsyncMessenger did

Signed-off-by: Haomai Wang <haomai@xsky.com>