### PR TITLE
common: instantiate strict_si_cast<long> not strict_si_cast<int64_t>

### DIFF
--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -186,8 +186,8 @@ T strict_si_cast(const char *str, std::string *err)
 }
 
 template int strict_si_cast<int>(const char *str, std::string *err);
+template long strict_si_cast<long>(const char *str, std::string *err);
 template long long strict_si_cast<long long>(const char *str, std::string *err);
-template int64_t strict_si_cast<int64_t>(const char *str, std::string *err);
 template uint64_t strict_si_cast<uint64_t>(const char *str, std::string *err);
 template uint32_t strict_si_cast<uint32_t>(const char *str, std::string *err);
 


### PR DESCRIPTION
this fixes the build on armf.

on 32bit platforms, cstdint is very likely to

 typedef long long int int64_t;

this results in compilation error like

 `common/strtol.cc:190:75: error: duplicate explicit instantiation of 'T
 strict_si_cast(const char, std::string) [with T = long long int;
 std::string = std::basic_string]'

 [-fpermissive]
 template int64_t strict_si_cast(const char *str, std::string *err);
 ^`

we can address this by instantiate the primitive type of `long long`
instead of `in64_t`.

Fixes: http://tracker.ceph.com/issues/16398
Signed-off-by: Kefu Chai <kchai@redhat.com>