### PR TITLE
common: fix lockdep vs recursive mutexes

### DIFF
--- a/src/common/Mutex.cc
+++ b/src/common/Mutex.cc
@@ -92,7 +92,7 @@ Mutex::~Mutex() {
 void Mutex::Lock(bool no_lockdep) {
   int r;
 
-  if (lockdep && g_lockdep && !no_lockdep) _will_lock();
+  if (lockdep && g_lockdep && !no_lockdep && !recursive) _will_lock();
 
   if (logger && cct && cct->_conf->mutex_perf_counter) {
     utime_t start;

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -202,6 +202,13 @@ add_executable(unittest_mutex_debug
 add_ceph_unittest(unittest_mutex_debug ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mutex_debug)
 target_link_libraries(unittest_mutex_debug global ${BLKID_LIBRARIES} ${EXTRALIBS})
 
+# unittest_mutex
+add_executable(unittest_mutex
+  test_mutex.cc
+  )
+add_ceph_unittest(unittest_mutex ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mutex)
+target_link_libraries(unittest_mutex global ${BLKID_LIBRARIES} ${EXTRALIBS})
+
 # unittest_shunique_lock
 add_executable(unittest_shunique_lock
   test_shunique_lock.cc

--- a/src/test/common/test_mutex.cc
+++ b/src/test/common/test_mutex.cc
@@ -1,0 +1,66 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 &smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ */
+
+#include <common/Mutex.h>
+#include "gtest/gtest.h"
+#include "common/ceph_context.h"
+#include "common/config.h"
+
+/*
+ * Override normal ceph assert.
+ * It is needed to prevent hang when we assert() and THEN still wait on lock().
+ */
+namespace ceph
+{
+  void __ceph_assert_fail(const char *assertion, const char *file, int line,
+        const char *func)
+  {
+    throw 0;
+  }
+}
+
+void do_init() {
+  static CephContext* cct = nullptr;
+  if (cct == nullptr) {
+    cct = new CephContext(0);
+    lockdep_register_ceph_context(cct);
+  }
+}
+
+TEST(MutexDebug, NormalAsserts) {
+  Mutex* m = new Mutex("Normal",false);
+  m->Lock();
+  EXPECT_THROW(m->Lock(), int);
+}
+
+TEST(MutexDebug, RecursiveWithLockdep) {
+  do_init();
+  g_lockdep = 1;
+  Mutex* m = new Mutex("Recursive1",true);
+  m->Lock();
+  m->Lock();
+  m->Unlock();
+  m->Unlock();
+  delete m;
+}
+
+TEST(MutexDebug, RecursiveWithoutLockdep) {
+  do_init();
+  g_lockdep = 0;
+  Mutex* m = new Mutex("Recursive2",true);
+  m->Lock();
+  m->Lock();
+  m->Unlock();
+  m->Unlock();
+  delete m;
+}
+
+TEST(MutexDebug, DeleteLocked) {
+  Mutex* m = new Mutex("Recursive3",false);
+  m->Lock();
+  EXPECT_DEATH(delete m,".*");
+}

--- a/src/test/common/test_mutex.cc
+++ b/src/test/common/test_mutex.cc
@@ -31,13 +31,13 @@ void do_init() {
   }
 }
 
-TEST(MutexDebug, NormalAsserts) {
+TEST(Mutex, NormalAsserts) {
   Mutex* m = new Mutex("Normal",false);
   m->Lock();
   EXPECT_THROW(m->Lock(), int);
 }
 
-TEST(MutexDebug, RecursiveWithLockdep) {
+TEST(Mutex, RecursiveWithLockdep) {
   do_init();
   g_lockdep = 1;
   Mutex* m = new Mutex("Recursive1",true);
@@ -48,7 +48,7 @@ TEST(MutexDebug, RecursiveWithLockdep) {
   delete m;
 }
 
-TEST(MutexDebug, RecursiveWithoutLockdep) {
+TEST(Mutex, RecursiveWithoutLockdep) {
   do_init();
   g_lockdep = 0;
   Mutex* m = new Mutex("Recursive2",true);
@@ -59,7 +59,7 @@ TEST(MutexDebug, RecursiveWithoutLockdep) {
   delete m;
 }
 
-TEST(MutexDebug, DeleteLocked) {
+TEST(Mutex, DeleteLocked) {
   Mutex* m = new Mutex("Recursive3",false);
   m->Lock();
   EXPECT_DEATH(delete m,".*");


### PR DESCRIPTION
The problem is that:
Mutex lock("RGWKeystoneTokenCache", true /\* recursive */);
Mutex::Locker l(lock);
lock.Lock();
fails...
Signed-off-by: Adam Kupczyk akupczyk@mirantis.com
