### PR TITLE
osd: remove dispatch queue check since we don't queue hb message to this

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4137,11 +4137,6 @@ void OSD::heartbeat_check()
 {
   assert(heartbeat_lock.is_locked());
   utime_t now = ceph_clock_now(cct);
-  double age = hbclient_messenger->get_dispatch_queue_max_age(now);
-  if (age > ((double)cct->_conf->osd_heartbeat_grace / 2.0)) {
-    derr << "skipping heartbeat_check, hbqueue max age: " << age << dendl;
-    return; // hb dispatch is too backed up for our hb status to be meaningful
-  }
 
   // check for incoming heartbeats (move me elsewhere?)
   utime_t cutoff = now;


### PR DESCRIPTION
We already make simple/async all OSDPing use fast dispatch, xio doesn't
implment this.

Otherwise if osd_lock is held by other threads which stuck into waiting
FileStore throttler, it may cause heartbeat failure message delay a lot.

We also consider to remove Messenger::get_dispatch_queue_max_age since
it doesn't have users now. But it's fine to wait some periods to see.

Signed-off-by: Haomai Wang <haomai@xsky.com>