### PR TITLE
rgw/test: use variable type 'size_t' instead of 'int' 

### DIFF
--- a/src/test/rgw/test_http_manager.cc
+++ b/src/test/rgw/test_http_manager.cc
@@ -37,7 +37,7 @@ TEST(HTTPManager, SignalThread)
   // send one extra request to test that we don't deadlock
   constexpr size_t num_requests = max_requests + 1;
 
-  for (int i = 0; i < (int)num_requests; i++) {
+  for (size_t i = 0; i < num_requests; i++) {
     RGWHTTPClient client{cct};
     http.add_request(&client, "PUT", "http://127.0.0.1:80");
   }


### PR DESCRIPTION
use variable type `size_t` instead of `int` seems to be more reasonable

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>