### PR TITLE
os/bluestore: get rid off blob's ref_map for non-shared objects

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1241,6 +1241,16 @@ private:
   void _txc_state_proc(TransContext *txc);
   void _txc_aio_submit(TransContext *txc);
   void _txc_finalize_kv(TransContext *txc, KeyValueDB::Transaction t);
+
+  //helpers to handle blob references depending on the blob nature: shared or private
+  void get_ref(bluestore_lextent_t& lext, Blob* b);
+  bool put_ref(OnodeRef o,
+               uint64_t offset,
+               bluestore_lextent_t& lext,
+               Blob* b,
+               uint64_t min_alloc_size,
+               vector<bluestore_pextent_t>* r);
+
 public:
   void _txc_aio_finish(void *p) {
     _txc_state_proc(static_cast<TransContext*>(p));
@@ -1500,7 +1510,7 @@ private:
     uint64_t comp_blob_size = 0; ///< target compressed blob size
     unsigned csum_order = 0;     ///< target checksum chunk order
 
-    vector<bluestore_lextent_t> lex_old;       ///< must deref blobs
+    vector<std::pair<uint64_t, bluestore_lextent_t> > lex_old;       ///< must deref blobs
 
     struct write_item {
       Blob *b;

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -423,6 +423,11 @@ string bluestore_blob_t::get_flags_string(unsigned flags)
       s += '+';
     s += "has_unused";
   }
+  if (flags & FLAG_HAS_REFMAP) {
+    if (s.length())
+      s += '+';
+    s += "has_refmap";
+  }
   return s;
 }
 
@@ -432,6 +437,7 @@ void bluestore_blob_t::encode(bufferlist& bl) const
   small_encode(extents, bl);
   small_encode_varint(flags, bl);
   if (is_compressed()) {
+    small_encode_varint_lowz(compressed_length_orig, bl);
     small_encode_varint_lowz(compressed_length, bl);
   }
   if (has_csum()) {
@@ -439,7 +445,9 @@ void bluestore_blob_t::encode(bufferlist& bl) const
     small_encode_varint(csum_chunk_order, bl);
     small_encode_buf_lowz(csum_data, bl);
   }
-  ::encode(ref_map, bl);
+  if (has_refmap()) {
+    ::encode(ref_map, bl);
+  }
   if (has_unused()) {
     ::encode( unused_uint_t(unused.to_ullong()), bl);
   }
@@ -452,9 +460,10 @@ void bluestore_blob_t::decode(bufferlist::iterator& p)
   small_decode(extents, p);
   small_decode_varint(flags, p);
   if (is_compressed()) {
+    small_decode_varint_lowz(compressed_length_orig, p);
     small_decode_varint_lowz(compressed_length, p);
   } else {
-    compressed_length = 0;
+    compressed_length_orig = compressed_length = 0;
   }
   if (has_csum()) {
     small_decode_varint(csum_type, p);
@@ -464,7 +473,9 @@ void bluestore_blob_t::decode(bufferlist::iterator& p)
     csum_type = CSUM_NONE;
     csum_chunk_order = 0;
   }
-  ::decode(ref_map, p);
+  if (has_refmap()) {
+    ::decode(ref_map, p);
+  }
   if (has_unused()) {
     unused_uint_t val;
     ::decode(val, p);
@@ -480,6 +491,7 @@ void bluestore_blob_t::dump(Formatter *f) const
     f->dump_object("extent", p);
   }
   f->close_section();
+  f->dump_unsigned("compressed_length_original", compressed_length_orig);
   f->dump_unsigned("compressed_length", compressed_length);
   f->dump_unsigned("flags", flags);
   f->dump_unsigned("csum_type", csum_type);
@@ -515,7 +527,11 @@ void bluestore_blob_t::generate_test_instances(list<bluestore_blob_t*>& ls)
 ostream& operator<<(ostream& out, const bluestore_blob_t& o)
 {
   out << "blob(" << o.extents
-      << " clen 0x" << std::hex << o.compressed_length << std::dec;
+      << " clen 0x" << std::hex
+      << o.compressed_length_orig
+      << " -> " << std::hex
+      << o.compressed_length
+      << std::dec;
   if (o.flags) {
     out << " " << o.get_flags_string();
   }
@@ -532,7 +548,22 @@ ostream& operator<<(ostream& out, const bluestore_blob_t& o)
   return out;
 }
 
-void bluestore_blob_t::put_ref(
+bool bluestore_blob_t::put_ref(
+  uint64_t offset,
+  uint64_t length,
+  uint64_t min_release_size,
+  vector<bluestore_pextent_t> *r)
+{
+  return put_ref_external(
+    ref_map,
+    offset,
+    length,
+    min_release_size,
+    r);
+}
+
+bool bluestore_blob_t::put_ref_external(
+  bluestore_extent_ref_map_t& ref_map,
   uint64_t offset,
   uint64_t length,
   uint64_t min_release_size,
@@ -555,12 +586,12 @@ void bluestore_blob_t::put_ref(
     extents.resize(1);
     extents[0].offset = bluestore_pextent_t::INVALID_OFFSET;
     extents[0].length = pos;
-    return;
+    return true;
   }
 
   // we cannot do partial deallocation on compressed blobs
   if (has_flag(FLAG_COMPRESSED)) {
-    return;
+    return false;
   }
 
   // we cannot release something smaller than our csum chunk size
@@ -650,6 +681,7 @@ void bluestore_blob_t::put_ref(
     vb.flush();
     extents.swap(vb.v);
   }
+  return false;
 }
 
 void bluestore_blob_t::calc_csum(uint64_t b_off, const bufferlist& bl)
@@ -841,7 +873,7 @@ int bluestore_onode_t::compress_extent_map()
 void bluestore_onode_t::punch_hole(
   uint64_t offset,
   uint64_t length,
-  vector<bluestore_lextent_t> *deref)
+  vector<std::pair<uint64_t, bluestore_lextent_t> >*deref)
 {
   auto p = seek_lextent(offset);
   uint64_t end = offset + length;
@@ -854,10 +886,12 @@ void bluestore_onode_t::punch_hole(
 	// split and deref middle
 	uint64_t front = offset - p->first;
 	deref->emplace_back(
-	  bluestore_lextent_t(
-	    p->second.blob,
-	    p->second.offset + front,
-	    length));
+	  std::make_pair(
+	    offset,
+	    bluestore_lextent_t(
+	      p->second.blob,
+	      p->second.offset + front,
+	      length)));
 	extent_map[end] = bluestore_lextent_t(
 	  p->second.blob,
 	  p->second.offset + front + length,
@@ -866,13 +900,15 @@ void bluestore_onode_t::punch_hole(
 	break;
       } else {
 	// deref tail
-	assert(p->first + p->second.length > offset); // else bug in find_lextent
+	assert(p->first + p->second.length > offset); // else bug in seek_lextent
 	uint64_t keep = offset - p->first;
 	deref->emplace_back(
-	  bluestore_lextent_t(
-	    p->second.blob,
-	    p->second.offset + keep,
-	    p->second.length - keep));
+	  std::make_pair(
+	    offset,
+	    bluestore_lextent_t(
+	      p->second.blob,
+	      p->second.offset + keep,
+	      p->second.length - keep)));
 	p->second.length = keep;
 	++p;
 	continue;
@@ -880,17 +916,19 @@ void bluestore_onode_t::punch_hole(
     }
     if (p->first + p->second.length <= end) {
       // deref whole lextent
-      deref->push_back(p->second);
+      deref->push_back(std::make_pair(p->first, p->second));
       extent_map.erase(p++);
       continue;
     }
     // deref head
     uint64_t keep = (p->first + p->second.length) - end;
     deref->emplace_back(
-      bluestore_lextent_t(
-	p->second.blob,
-	p->second.offset,
-	p->second.length - keep));
+      std::make_pair(
+	p->first,
+	bluestore_lextent_t(
+	  p->second.blob,
+	  p->second.offset,
+	  p->second.length - keep)));
     extent_map[end] = bluestore_lextent_t(
       p->second.blob,
       p->second.offset + p->second.length - keep,

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -423,7 +423,6 @@ string bluestore_blob_t::get_flags_string(unsigned flags)
       s += '+';
     s += "has_unused";
   }
-
   return s;
 }
 

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -120,6 +120,15 @@ struct bluestore_extent_ref_map_t {
     return ref_map.empty();
   }
 
+  //raw reference insertion that assumes no conflicts/interference with the existing references
+  void fill(uint32_t offset, uint32_t len, int refs = 1) {
+    assert(!intersects(offset,len));
+    auto p = ref_map.insert(
+        map<uint32_t,record_t>::value_type(offset,
+                                           record_t(len, refs))).first;
+    _maybe_merge_left(p);
+  }
+
   void get(uint32_t offset, uint32_t len);
   void put(uint32_t offset, uint32_t len, vector<bluestore_pextent_t> *release);
 
@@ -155,6 +164,7 @@ struct bluestore_blob_t {
     FLAG_COMPRESSED = 2,      ///< blob is compressed
     FLAG_CSUM = 4,            ///< blob has checksums
     FLAG_HAS_UNUSED = 8,      ///< blob has unused map
+    FLAG_HAS_REFMAP  = 16,    ///< blob has non-empty reference map
   };
   static string get_flags_string(unsigned flags);
 
@@ -194,9 +204,10 @@ struct bluestore_blob_t {
     return -EINVAL;
   }
 
-  vector<bluestore_pextent_t> extents;///< raw data position on device
-  uint32_t compressed_length = 0;     ///< compressed length if any
-  uint32_t flags = 0;                 ///< FLAG_*
+  vector<bluestore_pextent_t> extents; ///< raw data position on device
+  uint32_t compressed_length_orig = 0; ///< original length of compressed blob if any
+  uint32_t compressed_length = 0;      ///< compressed length if any
+  uint32_t flags = 0;                  ///< FLAG_*
 
   uint8_t csum_type = CSUM_NONE;      ///< CSUM_*
   uint8_t csum_chunk_order = 0;       ///< csum block size is 1<<block_order bytes
@@ -208,6 +219,7 @@ struct bluestore_blob_t {
   typedef std::bitset<sizeof(unused_uint_t) * 8> unused_t;
   unused_t unused;                    ///< portion that has never been written to
 
+public:
   bluestore_blob_t(uint32_t f = 0) : flags(f) {}
 
   void encode(bufferlist& bl) const;
@@ -228,8 +240,9 @@ struct bluestore_blob_t {
     return get_flags_string(flags);
   }
 
-  void set_compressed(uint64_t clen) {
+  void set_compressed(uint64_t clen_orig, uint64_t clen) {
     set_flag(FLAG_COMPRESSED);
+    compressed_length_orig = clen_orig;
     compressed_length = clen;
   }
   bool is_mutable() const {
@@ -244,6 +257,9 @@ struct bluestore_blob_t {
   bool has_unused() const {
     return has_flag(FLAG_HAS_UNUSED);
   }
+  bool has_refmap() const {
+    return has_flag(FLAG_HAS_REFMAP);
+  }
 
   /// return chunk (i.e. min readable block) size for the blob
   uint64_t get_chunk_size(uint64_t dev_block_size) {
@@ -254,6 +270,9 @@ struct bluestore_blob_t {
   }
   uint32_t get_compressed_payload_length() const {
     return is_compressed() ? compressed_length : 0;
+  }
+  uint32_t get_compressed_payload_original_length() const {
+    return is_compressed() ? compressed_length_orig : 0;
   }
   uint64_t calc_offset(uint64_t x_off, uint64_t *plen) const {
     auto p = extents.begin();
@@ -295,14 +314,6 @@ struct bluestore_blob_t {
     assert(0 == "we should not get here");
   }
 
-  uint32_t get_csum_chunk_size() const {
-    return 1 << csum_chunk_order;
-  }
-
-  /// return chunk (i.e. min readable block) size for the blob
-  uint64_t get_chunk_size(uint64_t dev_block_size) {
-    return has_csum() ? MAX(dev_block_size, get_csum_chunk_size()) : dev_block_size;
-  }
   /// return true if the logical range has never been used
   bool is_unused(uint64_t offset, uint64_t length, uint64_t min_alloc_size) const {
     if (!has_unused()) {
@@ -356,7 +367,11 @@ struct bluestore_blob_t {
   }
 
   /// put logical references, and get back any released extents
-  void put_ref(uint64_t offset, uint64_t length,  uint64_t min_alloc_size,
+  bool put_ref(uint64_t offset, uint64_t length,  uint64_t min_alloc_size,
+	       vector<bluestore_pextent_t> *r);
+  /// put logical references using external ref_map, and get back any released extents
+  bool put_ref_external( bluestore_extent_ref_map_t& ref_map,
+	       uint64_t offset, uint64_t length,  uint64_t min_alloc_size,
 	       vector<bluestore_pextent_t> *r);
 
   void map(uint64_t x_off, uint64_t x_len,
@@ -589,7 +604,7 @@ struct bluestore_onode_t {
 
   /// punch a logical hole.  add lextents to deref to target list.
   void punch_hole(uint64_t offset, uint64_t length,
-		  vector<bluestore_lextent_t> *deref);
+		  vector<std::pair<uint64_t, bluestore_lextent_t> > *deref);
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& p);

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -295,6 +295,14 @@ struct bluestore_blob_t {
     assert(0 == "we should not get here");
   }
 
+  uint32_t get_csum_chunk_size() const {
+    return 1 << csum_chunk_order;
+  }
+
+  /// return chunk (i.e. min readable block) size for the blob
+  uint64_t get_chunk_size(uint64_t dev_block_size) {
+    return has_csum() ? MAX(dev_block_size, get_csum_chunk_size()) : dev_block_size;
+  }
   /// return true if the logical range has never been used
   bool is_unused(uint64_t offset, uint64_t length, uint64_t min_alloc_size) const {
     if (!has_unused()) {
@@ -398,7 +406,6 @@ struct bluestore_blob_t {
     }
     return len;
   }
-
 
   size_t get_csum_value_size() const {
     switch (csum_type) {


### PR DESCRIPTION
Ref_map is built on the fly for onodes that are not shared. Hence provides saving for both serialized and in-memory onode representation.
PR is based on PR#9866

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>