### PR TITLE
rocksdb: remove experimental flag

### DIFF
--- a/src/kv/KeyValueDB.cc
+++ b/src/kv/KeyValueDB.cc
@@ -24,8 +24,7 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
   }
 #endif
 #ifdef HAVE_LIBROCKSDB
-  if (type == "rocksdb" &&
-      cct->check_experimental_feature_enabled("rocksdb")) {
+  if (type == "rocksdb") {
     return new RocksDBStore(cct, dir, p);
   }
 #endif


### PR DESCRIPTION
All of our rocks patches are upstream.  QA is happy with it for the mons (modulo the valgrind warnings, which I *think* are all suppressed now).