### PR TITLE
mds,libcephfs: add ceph_statx support and expose birthtime via it

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -835,6 +835,7 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
 
     // immutable bits
     in->ino = st->vino.ino;
+    in->btime = st->btime;
     in->snapid = st->vino.snapid;
     in->mode = st->mode & S_IFMT;
     was_new = true;
@@ -9461,6 +9462,7 @@ Inode *Client::open_snapdir(Inode *diri)
     in->gid = diri->gid;
     in->mtime = diri->mtime;
     in->ctime = diri->ctime;
+    in->btime = diri->btime;
     in->size = diri->size;
 
     in->dirfragtree.clear();

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9644,15 +9644,26 @@ Inode *Client::ll_get_inode(vinodeno_t vino)
   return in;
 }
 
-int Client::ll_getattr(Inode *in, struct stat *attr, int uid, int gid)
+int Client::_ll_getattr(Inode *in, int uid, int gid)
 {
-  Mutex::Locker lock(client_lock);
-
   vinodeno_t vino = _get_vino(in);
 
   ldout(cct, 3) << "ll_getattr " << vino << dendl;
   tout(cct) << "ll_getattr" << std::endl;
   tout(cct) << vino.ino.val << std::endl;
+
+  if (vino.snapid < CEPH_NOSNAP)
+    return 0;
+  else
+    return _getattr(in, CEPH_STAT_CAP_INODE_ALL, uid, gid);
+}
+
+int Client::ll_getattr(Inode *in, struct stat *attr, int uid, int gid)
+{
+  Mutex::Locker lock(client_lock);
+
+  int res = _ll_getattr(in, uid, gid);
+  vinodeno_t vino = _get_vino(in);
 
   /* special case for dotdot (..) */
   if (vino.ino.val == CEPH_INO_DOTDOT) {
@@ -9661,11 +9672,6 @@ int Client::ll_getattr(Inode *in, struct stat *attr, int uid, int gid)
     return 0;
   }
 
-  int res;
-  if (vino.snapid < CEPH_NOSNAP)
-    res = 0;
-  else
-    res = _getattr(in, CEPH_STAT_CAP_INODE_ALL, uid, gid);
   if (res == 0)
     fill_stat(in, attr);
   ldout(cct, 3) << "ll_getattr " << vino << " = " << res << dendl;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -702,7 +702,7 @@ void Client::update_inode_file_bits(Inode *in,
 				    uint64_t truncate_seq, uint64_t truncate_size,
 				    uint64_t size,
 				    uint64_t time_warp_seq, utime_t ctime,
-				    utime_t mtime,
+				    utime_t btime, utime_t mtime,
 				    utime_t atime,
 				    version_t inline_version,
 				    bufferlist& inline_data,
@@ -885,8 +885,8 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
     }
 
     update_inode_file_bits(in, st->truncate_seq, st->truncate_size, st->size,
-			   st->time_warp_seq, st->ctime, st->mtime, st->atime,
-			   st->inline_version, st->inline_data,
+			   st->time_warp_seq, st->ctime, st->btime, st->mtime,
+			   st->atime, st->inline_version, st->inline_data,
 			   issued);
   } else if (st->inline_version > in->inline_version) {
     in->inline_data = st->inline_data;
@@ -4649,7 +4649,7 @@ void Client::handle_cap_trunc(MetaSession *session, Inode *in, MClientCaps *m)
   issued |= implemented;
   update_inode_file_bits(in, m->get_truncate_seq(), m->get_truncate_size(),
                          m->get_size(), m->get_time_warp_seq(), m->get_ctime(),
-                         m->get_mtime(), m->get_atime(),
+                         m->get_btime(), m->get_mtime(), m->get_atime(),
                          m->inline_version, m->inline_data,
                          issued);
   m->put();
@@ -4853,8 +4853,8 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, MClient
     in->xattr_version = m->head.xattr_version;
   }
   update_inode_file_bits(in, m->get_truncate_seq(), m->get_truncate_size(), m->get_size(),
-			 m->get_time_warp_seq(), m->get_ctime(), m->get_mtime(), m->get_atime(),
-			 m->inline_version, m->inline_data, issued);
+			 m->get_time_warp_seq(), m->get_ctime(), m->get_btime(), m->get_mtime(),
+			 m->get_atime(), m->inline_version, m->inline_data, issued);
 
   // max_size
   if (cap == in->auth_cap &&

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -908,6 +908,8 @@ private:
 
   mds_rank_t _get_random_up_mds() const;
 
+  int _ll_getattr(Inode *in, int uid, int gid);
+
 public:
   int mount(const std::string &mount_root, bool require_mds=false);
   void unmount();

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -524,6 +524,12 @@ protected:
   int fill_stat(InodeRef& in, struct stat *st, frag_info_t *dirstat=0, nest_info_t *rstat=0) {
     return fill_stat(in.get(), st, dirstat, rstat);
   }
+
+  int fill_statx(Inode *in, struct statx *stx, frag_info_t *dirstat=0);
+  int fill_statx(InodeRef& in, struct statx *stx, frag_info_t *dirstat=0) {
+    return fill_statx(in.get(), stx, dirstat);
+  }
+
   void touch_dn(Dentry *dn);
 
   // trim cache.
@@ -980,6 +986,7 @@ public:
 
   // inode stuff
   int stat(const char *path, struct stat *stbuf, frag_info_t *dirstat=0, int mask=CEPH_STAT_CAP_INODE_ALL);
+  int statx(const char *path, unsigned int flags, struct statx *stx, frag_info_t *dirstat=0, int mask=CEPH_STAT_CAP_INODE_ALL);
   int lstat(const char *path, struct stat *stbuf, frag_info_t *dirstat=0, int mask=CEPH_STAT_CAP_INODE_ALL);
   int lstatlite(const char *path, struct statlite *buf);
 
@@ -1079,6 +1086,7 @@ public:
   bool ll_forget(Inode *in, int count);
   bool ll_put(Inode *in);
   int ll_getattr(Inode *in, struct stat *st, int uid = -1, int gid = -1);
+  int ll_getattrx(Inode *in, unsigned int flags, struct statx *st, int uid = -1, int gid = -1);
   int ll_setattr(Inode *in, struct stat *st, int mask, int uid = -1,
 		 int gid = -1);
   int ll_getxattr(Inode *in, const char *name, void *value, size_t size,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -695,8 +695,8 @@ protected:
   Inode* insert_trace(MetaRequest *request, MetaSession *session);
   void update_inode_file_bits(Inode *in,
 			      uint64_t truncate_seq, uint64_t truncate_size, uint64_t size,
-			      uint64_t time_warp_seq, utime_t ctime, utime_t mtime, utime_t atime,
-			      version_t inline_version, bufferlist& inline_data,
+			      uint64_t time_warp_seq, utime_t ctime, utime_t btime, utime_t mtime,
+			      utime_t atime, version_t inline_version, bufferlist& inline_data,
 			      int issued);
   Inode *add_update_inode(InodeStat *st, utime_t ttl, MetaSession *session);
   Dentry *insert_dentry_inode(Dir *dir, const string& dname, LeaseStat *dlease, 

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -324,6 +324,7 @@ void Inode::dump(Formatter *f) const
   if (rdev)
     f->dump_unsigned("rdev", rdev);
   f->dump_stream("ctime") << ctime;
+  f->dump_stream("btime") << btime;
   f->dump_stream("mode") << '0' << std::oct << mode << std::dec;
   f->dump_unsigned("uid", uid);
   f->dump_unsigned("gid", gid);
@@ -482,6 +483,7 @@ void CapSnap::dump(Formatter *f) const
   f->dump_stream("dirty") << ccap_string(dirty);
   f->dump_unsigned("size", size);
   f->dump_stream("ctime") << ctime;
+  f->dump_stream("btime") << btime;
   f->dump_stream("mtime") << mtime;
   f->dump_stream("atime") << atime;
   f->dump_int("time_warp_seq", time_warp_seq);

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -51,7 +51,7 @@ struct CapSnap {
   int issued, dirty;
 
   uint64_t size;
-  utime_t ctime, mtime, atime;
+  utime_t ctime, btime, mtime, atime;
   version_t time_warp_seq;
   uint32_t   mode;
   uid_t      uid;

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -93,6 +93,7 @@ struct Inode {
 
   // affected by any inode change...
   utime_t    ctime;   // inode change time
+  utime_t    btime;   // birth time
 
   // perm (namespace permissions)
   uint32_t   mode;

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -84,6 +84,7 @@
 // duplicated since it was introduced at the same time as CEPH_FEATURE_CRUSH_TUNABLES5
 #define CEPH_FEATURE_NEW_OSDOPREPLY_ENCODING (1ULL<<58) /* New, v7 encoding */
 #define CEPH_FEATURE_FS_FILE_LAYOUT_V2       (1ULL<<58) /* file_layout_t */
+#define CEPH_FEATURE_FS_BTIME                (1ULL<<59) /* btime */
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */
@@ -179,6 +180,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_CRUSH_TUNABLES5 |	    \
 	 CEPH_FEATURE_SERVER_JEWEL |  \
 	 CEPH_FEATURE_FS_FILE_LAYOUT_V2 |		 \
+	 CEPH_FEATURE_FS_BTIME |			 \
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -624,7 +624,7 @@ int ceph_stat(struct ceph_mount_info *cmount, const char *path, struct stat *stb
  *
  * @param cmount the ceph mount handle to use for performing the stat.
  * @param path the file or directory to get the statistics of.
- * @param flags bitfield that can be used to set AT_* modifier flags
+ * @param flags bitfield that can be used to set AT_* modifier flags (only AT_NO_ATTR_SYNC)
  * @param stx the statx struct that will be filled in with the file's statistics.
  * @returns 0 on success or negative error code on failure.
  */

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -26,6 +26,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "statx.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -616,6 +618,17 @@ int ceph_rename(struct ceph_mount_info *cmount, const char *from, const char *to
  * @returns 0 on success or negative error code on failure.
  */
 int ceph_stat(struct ceph_mount_info *cmount, const char *path, struct stat *stbuf);
+
+/**
+ * Get a file's extended statistics and attributes.
+ *
+ * @param cmount the ceph mount handle to use for performing the stat.
+ * @param path the file or directory to get the statistics of.
+ * @param flags bitfield that can be used to set AT_* modifier flags
+ * @param stx the statx struct that will be filled in with the file's statistics.
+ * @returns 0 on success or negative error code on failure.
+ */
+int ceph_statx(struct ceph_mount_info *cmount, const char *path, unsigned int flags, struct statx *stx);
 
 /**
  * Get a file's statistics and attributes, without following symlinks.
@@ -1392,6 +1405,8 @@ int ceph_ll_walk(struct ceph_mount_info *cmount, const char *name,
 		 struct stat *attr);
 int ceph_ll_getattr(struct ceph_mount_info *cmount, struct Inode *in,
 		    struct stat *attr, int uid, int gid);
+int ceph_ll_getattrx(struct ceph_mount_info *cmount, struct Inode *in,
+		    unsigned int mask, struct statx *stx, int uid, int gid);
 int ceph_ll_setattr(struct ceph_mount_info *cmount, struct Inode *in,
 		    struct stat *st, int mask, int uid, int gid);
 int ceph_ll_open(struct ceph_mount_info *cmount, struct Inode *in, int flags,

--- a/src/include/cephfs/statx.h
+++ b/src/include/cephfs/statx.h
@@ -73,6 +73,11 @@ struct statx {
 #define STATX_GEN		0x00002000U     /* Want/got st_gen */
 #define STATX_ALL_STATS		0x00003fffU     /* All supported stats */
 
+/* statx request flags. Callers can set these in the "flags" field */
+#ifndef AT_NO_ATTR_SYNC
+#define AT_NO_ATTR_SYNC		0x4000 /* Don't sync attributes with the server */
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/cephfs/statx.h
+++ b/src/include/cephfs/statx.h
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * scalable distributed file system
+ *
+ * Copyright (C) Jeff Layton <jlayton@redhat.com>
+ *
+ * Heavily borrowed from David Howells' draft statx patchset.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef STATX_H
+#define STATX_H
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Since the xstat patches are still a work in progress, we borrow its data
+ * structures and #defines to implement ceph_getattrx. Once the xstat stuff
+ * has been merged we should drop this and switch over to using that instead.
+ */
+struct statx {
+	uint32_t	stx_mask;
+	uint32_t	stx_information;
+	uint32_t	stx_blksize;
+	uint32_t	stx_nlink;
+	uint32_t	stx_gen;
+	uint32_t	stx_uid;
+	uint32_t	stx_gid;
+	uint16_t	stx_mode;
+	uint16_t	__spare0[1];
+	uint64_t	stx_ino;
+	uint64_t	stx_size;
+	uint64_t	stx_blocks;
+	uint64_t	stx_version;
+	int64_t		stx_atime;
+	int64_t		stx_btime;
+	int64_t		stx_ctime;
+	int64_t		stx_mtime;
+	int32_t		stx_atime_ns;
+	int32_t		stx_btime_ns;
+	int32_t		stx_ctime_ns;
+	int32_t		stx_mtime_ns;
+	uint32_t	stx_rdev_major;
+	uint32_t	stx_rdev_minor;
+	uint32_t	stx_dev_major;
+	uint32_t	stx_dev_minor;
+	uint64_t	__spare1[16];
+};
+
+#define STATX_MODE		0x00000001U     /* Want/got st_mode */
+#define STATX_NLINK		0x00000002U     /* Want/got st_nlink */
+#define STATX_UID		0x00000004U     /* Want/got st_uid */
+#define STATX_GID		0x00000008U     /* Want/got st_gid */
+#define STATX_RDEV		0x00000010U     /* Want/got st_rdev */
+#define STATX_ATIME		0x00000020U     /* Want/got st_atime */
+#define STATX_MTIME		0x00000040U     /* Want/got st_mtime */
+#define STATX_CTIME		0x00000080U     /* Want/got st_ctime */
+#define STATX_INO		0x00000100U     /* Want/got st_ino */
+#define STATX_SIZE		0x00000200U     /* Want/got st_size */
+#define STATX_BLOCKS		0x00000400U     /* Want/got st_blocks */
+#define STATX_BASIC_STATS	0x000007ffU     /* The stuff in the normal stat struct */
+#define STATX_BTIME		0x00000800U     /* Want/got st_btime */
+#define STATX_VERSION		0x00001000U     /* Want/got st_version */
+#define STATX_GEN		0x00002000U     /* Want/got st_gen */
+#define STATX_ALL_STATS		0x00003fffU     /* All supported stats */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STATX_H */
+

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -610,6 +610,14 @@ extern "C" int ceph_stat(struct ceph_mount_info *cmount, const char *path,
   return cmount->get_client()->stat(path, stbuf);
 }
 
+extern "C" int ceph_statx(struct ceph_mount_info *cmount, const char *path,
+			 unsigned int flags, struct statx *stx)
+{
+  if (!cmount->is_mounted())
+    return -ENOTCONN;
+  return cmount->get_client()->statx(path, flags, stx);
+}
+
 extern "C" int ceph_lstat(struct ceph_mount_info *cmount, const char *path,
 			  struct stat *stbuf)
 {
@@ -1404,6 +1412,13 @@ extern "C" int ceph_ll_getattr(class ceph_mount_info *cmount,
 			       int uid, int gid)
 {
   return (cmount->get_client()->ll_getattr(in, attr, uid, gid));
+}
+
+extern "C" int ceph_ll_getattrx(class ceph_mount_info *cmount,
+			        Inode *in, unsigned int flags,
+			        struct statx *stx, int uid, int gid)
+{
+  return (cmount->get_client()->ll_getattrx(in, flags, stx, uid, gid));
 }
 
 extern "C" int ceph_ll_setattr(class ceph_mount_info *cmount,

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3352,7 +3352,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
   if (session->connection->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)) {
     ::encode(layout.pool_ns, bl);
   }
-  if (session->connection->has_featuer(CEPH_FEATURE_FS_BTIME)) {
+  if (session->connection->has_feature(CEPH_FEATURE_FS_BTIME)) {
     ::encode(any_i->btime, bl);
   }
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3352,6 +3352,9 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
   if (session->connection->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)) {
     ::encode(layout.pool_ns, bl);
   }
+  if (session->connection->has_featuer(CEPH_FEATURE_FS_BTIME)) {
+    ::encode(any_i->btime, bl);
+  }
 
   return valid;
 }

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -355,7 +355,8 @@ void MDCache::create_unlinked_system_inode(CInode *in, inodeno_t ino,
   in->inode.mode = 0500 | mode;
   in->inode.size = 0;
   in->inode.ctime = 
-    in->inode.mtime = ceph_clock_now(g_ceph_context);
+    in->inode.mtime =
+    in->inode.btime = ceph_clock_now(g_ceph_context);
   in->inode.nlink = 1;
   in->inode.truncate_size = -1ull;
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2352,7 +2352,8 @@ CInode* Server::prepare_new_inode(MDRequestRef& mdr, CDir *dir, inodeno_t useino
 
   in->inode.uid = mdr->client_request->get_caller_uid();
 
-  in->inode.ctime = in->inode.mtime = in->inode.atime = mdr->get_op_stamp();
+  in->inode.btime = in->inode.ctime = in->inode.mtime = in->inode.atime =
+    mdr->get_op_stamp();
 
   MClientRequest *req = mdr->client_request;
   if (req->get_data().length()) {

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -470,6 +470,7 @@ struct inode_t {
 
   // affected by any inode change...
   utime_t    ctime;   // inode change time
+  utime_t    btime;   // birth time
 
   // perm (namespace permissions)
   uint32_t   mode;

--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -28,7 +28,7 @@ class MClientCaps : public Message {
 
   uint64_t size, max_size, truncate_size;
   uint32_t truncate_seq;
-  utime_t mtime, atime, ctime;
+  utime_t mtime, atime, ctime, btime;
   file_layout_t layout;
   uint32_t time_warp_seq;
 
@@ -62,6 +62,7 @@ class MClientCaps : public Message {
   __u32 get_truncate_seq() { return truncate_seq; }
   uint64_t get_truncate_size() { return truncate_size; }
   utime_t get_ctime() { return ctime; }
+  utime_t get_btime() { return btime; }
   utime_t get_mtime() { return mtime; }
   utime_t get_atime() { return atime; }
   __u32 get_time_warp_seq() { return time_warp_seq; }

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -102,7 +102,7 @@ struct InodeStat {
   version_t xattr_version;
   ceph_mds_reply_cap cap;
   file_layout_t layout;
-  utime_t ctime, mtime, atime;
+  utime_t ctime, btime, mtime, atime;
   uint32_t time_warp_seq;
   uint64_t size, max_size;
   uint64_t truncate_size;

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -185,6 +185,10 @@ struct InodeStat {
 
     if ((features & CEPH_FEATURE_FS_FILE_LAYOUT_V2))
       ::decode(layout.pool_ns, p);
+    if ((features & CEPH_FEATURE_FS_BTIME))
+      ::decode(btime, p);
+    else
+      btime = utime_t();
   }
   
   // see CInode::encode_inodestat for encoder.

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -1374,3 +1374,37 @@ TEST(LibCephFS, OpenNoClose) {
   // shutdown should force close opened file/dir
   ceph_shutdown(cmount);
 }
+
+TEST(LibCephFS, TestStatx) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  char filename[32];
+  sprintf(filename, "/getattrx%x", getpid());
+
+  ceph_unlink(cmount, filename);
+  int fd = ceph_open(cmount, filename, O_RDWR|O_CREAT|O_EXCL, 0666);
+  ASSERT_LT(0, fd);
+
+  struct statx	stx;
+  ASSERT_EQ(ceph_statx(cmount, filename, STATX_BASIC_STATS | STATX_BTIME, &stx), 0);
+  ASSERT_TRUE(stx.stx_mask & (STATX_MTIME|STATX_BTIME));
+  ASSERT_EQ(stx.stx_btime, stx.stx_ctime);
+  ASSERT_EQ(stx.stx_btime_ns, stx.stx_ctime_ns);
+
+  int64_t old_btime = stx.stx_btime;
+  int32_t old_btime_ns = stx.stx_btime_ns;
+
+  /* Now sleep, do a chmod and verify that the ctime changed, but btime didn't */
+  sleep(1);
+  ASSERT_EQ(ceph_chmod(cmount, filename, 0644), 0);
+  ASSERT_EQ(ceph_statx(cmount, filename, 0, &stx), 0);
+  ASSERT_EQ(stx.stx_btime, old_btime);
+  ASSERT_EQ(stx.stx_btime_ns, old_btime_ns);
+  ASSERT_FALSE(old_btime == stx.stx_ctime && old_btime_ns == stx.stx_ctime_ns);
+
+  ceph_shutdown(cmount);
+}

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -1408,3 +1408,43 @@ TEST(LibCephFS, TestStatx) {
 
   ceph_shutdown(cmount);
 }
+
+TEST(LibCephFS, TestStatxLazy) {
+  struct ceph_mount_info *cmount1, *cmount2;
+  ASSERT_EQ(ceph_create(&cmount1, NULL), 0);
+  ASSERT_EQ(ceph_create(&cmount2, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount1, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount2, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount1, NULL));
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount2, NULL));
+  ASSERT_EQ(ceph_mount(cmount1, "/"), 0);
+  ASSERT_EQ(ceph_mount(cmount2, "/"), 0);
+
+  char filename[32];
+  sprintf(filename, "/statxlazy%x", getpid());
+
+  ceph_unlink(cmount1, filename);
+  int fd = ceph_open(cmount1, filename, O_RDWR|O_CREAT|O_EXCL, 0666);
+  ASSERT_LT(0, fd);
+
+  struct statx	stx;
+  ASSERT_EQ(ceph_statx(cmount2, filename, 0, &stx), 0);
+
+  int64_t old_ctime = stx.stx_btime;
+  int32_t old_ctime_ns = stx.stx_btime_ns;
+
+  /*
+   * Now sleep, do a chmod on the first client and the see whether we get a
+   * different ctime with a statx that uses AT_NO_ATTR_SYNC
+   */
+  sleep(1);
+  ASSERT_EQ(ceph_chmod(cmount1, filename, 0644), 0);
+  ASSERT_EQ(ceph_statx(cmount1, filename, 0, &stx), 0);
+  ASSERT_FALSE(old_ctime == stx.stx_ctime && old_ctime_ns == stx.stx_ctime_ns);
+  ASSERT_EQ(ceph_statx(cmount2, filename, AT_NO_ATTR_SYNC, &stx), 0);
+  ASSERT_EQ(stx.stx_ctime, old_ctime);
+  ASSERT_EQ(stx.stx_ctime_ns, old_ctime_ns);
+
+  ceph_shutdown(cmount1);
+  ceph_shutdown(cmount2);
+}


### PR DESCRIPTION
The birthtime for an inode is the time when it was first created. It's not updated on any other event, aside from being explicitly set.

This PR builds on the work that Sage started a couple of weeks ago to track the btime in the inode. It also adds a new statx() like interface to libcephfs to allow applications to get at it.

Note that the testcase is not actually tested yet (waiting for the build to finish), but I *think* it'll DTRT.

Also, we may need some cmake changes to ensure that the statx file is installed at install time, and I'm not 100% sure that that is how to want to statx definitions...