### PR TITLE
os/bluestore: fix ut failure due to incorrect test instance

### DIFF
--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -506,7 +506,6 @@ void bluestore_blob_t::generate_test_instances(list<bluestore_blob_t*>& ls)
   ls.back()->ref_map.get(3, 5);
   ls.back()->add_unused(0, 3, 4096);
   ls.back()->add_unused(8, 8, 4096);
-  ls.back()->add_unused(80, 8192-1, 4096);
   ls.back()->extents.emplace_back(bluestore_pextent_t(0x40100000, 0x10000));
   ls.back()->extents.emplace_back(
     bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x1000));


### PR DESCRIPTION
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>