### PR TITLE
replcatedBackend: delete one of the repeated op->mark_started in ReplicatedBackend::sub_op_modify_impl

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1193,8 +1193,6 @@ void ReplicatedBackend::sub_op_modify_impl(OpRequestRef op)
 
   rm->bytes_written = rm->opt.get_encoded_bytes();
 
-  op->mark_started();
-
   rm->localt.append(rm->opt);
   rm->localt.register_on_commit(
     parent->bless_context(


### PR DESCRIPTION
http://tracker.ceph.com/issues/16572

…o in ReplicatedBackend::sub_op_modify_impl

delete one mark_start event as there are two same op->mark_started  in ReplicatedBackend::sub_op_modify_impl

Signed-off-by: shun-s <song.shun3@zte.com.cn>