### PR TITLE
rgw: fix potential memory leaks and remove unnecessary assignment

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3803,9 +3803,7 @@ int RGWRados::initialize()
   if (ret < 0)
     return ret;
 
-  ret = init_complete();
-
-  return ret;
+  return init_complete();
 }
 
 void RGWRados::finalize_watch()

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2311,7 +2311,8 @@ int RGWPutCORS_ObjStore_S3::get_params()
   if (s->aws4_auth_needs_complete) {
     int ret_auth = do_aws4_auth_completion();
     if (ret_auth < 0) {
-      return ret_auth;
+      r = ret_auth;
+      goto done_err;
     }
   }
 


### PR DESCRIPTION
We should free `data` before return or jump to `done_err` label to do so.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>