### PR TITLE
osd: small cleanups

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2457,6 +2457,7 @@ private:
   static int write_meta(ObjectStore *store,
 			uuid_d& cluster_fsid, uuid_d& osd_fsid, int whoami);
 
+  void handle_pg_scrub(struct MOSDScrub *m, PG* pg);
   void handle_scrub(struct MOSDScrub *m);
   void handle_osd_ping(class MOSDPing *m);
   void handle_op(OpRequestRef& op, OSDMapRef& osdmap);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2437,7 +2437,6 @@ protected:
   ~OSD();
 
   // static bits
-  static int find_osd_dev(char *result, int whoami);
   static int mkfs(CephContext *cct, ObjectStore *store,
 		  const string& dev,
 		  uuid_d fsid, int whoami);


### PR DESCRIPTION
OSD: remove the useless find_osd_dev()
OSD: split out handle_pg_scrub() from handle_scrub()
