### PR TITLE
[DNM] test: disable parallel test and enable only cephtool-test-osd.sh

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -1167,7 +1167,7 @@ function pg_scrub() {
     wait_for_scrub $pgid "$last_scrub"
 }
 
-function DISABLED_test_pg_scrub() {
+function test_pg_scrub() {
     local dir=$1
 
     setup $dir || return 1

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -68,7 +68,7 @@ function run() {
     if test -x ./do_cmake.sh ; then
         $DRY_RUN ./do_cmake.sh || return 1
         cd build
-        export CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=$(get_processors)
+        export CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=1
         $DRY_RUN make $BUILD_MAKEOPTS check || return 1
     else
         $DRY_RUN ./autogen.sh || return 1

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -369,7 +369,7 @@ enum {
 
 extern const char *ceph_mds_op_name(int op);
 
-
+#ifndef CEPH_SETATTR_MODE
 #define CEPH_SETATTR_MODE	(1 << 0)
 #define CEPH_SETATTR_UID	(1 << 1)
 #define CEPH_SETATTR_GID	(1 << 2)
@@ -377,6 +377,7 @@ extern const char *ceph_mds_op_name(int op);
 #define CEPH_SETATTR_ATIME	(1 << 4)
 #define CEPH_SETATTR_SIZE	(1 << 5)
 #define CEPH_SETATTR_CTIME	(1 << 6)
+#endif
 #define CEPH_SETATTR_MTIME_NOW	(1 << 7)
 #define CEPH_SETATTR_ATIME_NOW	(1 << 8)
 


### PR DESCRIPTION
for debugging the jenkins "make check" failures.