### PR TITLE
cmake: Fix FCGI include directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -516,7 +516,7 @@ AS_IF([test "x$with_radosgw" != xno],
               [AC_CHECK_LIB([curl], [curl_easy_init],
                [RADOSGW=1
 	        AC_CHECK_HEADER([fastcgi/fcgiapp.h],
-		 [AC_DEFINE([FASTCGI_INCLUDE_DIR], [1], [FastCGI headers are in /usr/include/fastcgi])])
+		 [RGW_CXXFLAGS="-I/usr/include/fastcgi"])
 	       ],
 	       [if test "x$with_radosgw" != "xcheck"; then
 		    AC_MSG_FAILURE([--with-radosgw was given but libcurl (libcurl-dev on debian) not found])
@@ -529,6 +529,7 @@ AS_IF([test "x$with_radosgw" != xno],
 	     [if test "x$with_radosgw" != "xcheck"; then
 		AC_MSG_FAILURE([--with-radosgw was given but libfcgi (libfcgi-dev on debian) not found])
 	     fi])])
+AC_SUBST(RGW_CXXFLAGS)
 AM_CONDITIONAL(WITH_RADOSGW, test "$RADOSGW" = "1")
 
 AS_IF([test "$RADOSGW" = "1"], [AC_DEFINE([WITH_RADOSGW], [1], [define if radosgw enabled])])

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -1,3 +1,5 @@
+include_directories(${FCGI_INCLUDE_DIR})
+
 add_executable(ceph_rgw_jsonparser
   rgw_jsonparser.cc
   rgw_common.cc

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -158,6 +158,7 @@ radosgw_SOURCES = \
 	rgw/rgw_main.cc
 
 radosgw_CFLAGS = -I$(srcdir)/civetweb/include -fPIC -I$(srcdir)/xxHash
+radosgw_CXXFLAGS = ${RGW_CXXFLAGS} ${AM_CXXFLAGS}
 radosgw_LDADD = $(LIBRGW) $(LIBCIVETWEB) $(LIBCIVETWEB_DEPS) $(LIBRGW_DEPS) $(RESOLV_LIBS) \
 	$(CEPH_GLOBAL)
 bin_PROGRAMS += radosgw

--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -4,12 +4,7 @@
 #include "rgw_fcgi.h"
 
 #include "acconfig.h"
-#ifdef FASTCGI_INCLUDE_DIR
-# include "fastcgi/fcgiapp.h"
-#else
-# include <fcgiapp.h>
-#endif
-
+#include <fcgiapp.h>
 
 int RGWFCGX::write_data(const char *buf, int len)
 {

--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -7,7 +7,7 @@
 #ifdef FASTCGI_INCLUDE_DIR
 # include "fastcgi/fcgiapp.h"
 #else
-# include "fcgiapp.h"
+# include <fcgiapp.h>
 #endif
 
 

--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -8,7 +8,7 @@
 #ifdef FASTCGI_INCLUDE_DIR
 # include "fastcgi/fcgiapp.h"
 #else
-# include "fcgiapp.h"
+# include <fcgiapp.h>
 #endif
 
 #include "rgw_client_io.h"

--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -5,11 +5,7 @@
 #define CEPH_RGW_FCGI_H
 
 #include "acconfig.h"
-#ifdef FASTCGI_INCLUDE_DIR
-# include "fastcgi/fcgiapp.h"
-#else
-# include <fcgiapp.h>
-#endif
+#include <fcgiapp.h>
 
 #include "rgw_client_io.h"
 

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -802,7 +802,7 @@ librgw_file_aw_LDADD = $(UNITTEST_LDADD) \
 noinst_PROGRAMS += librgw_file_aw
 
 librgw_file_nfsns_SOURCES = test/librgw_file_nfsns.cc
-librgw_file_nfsns_CXXFLAGS = -I$(srcdir)/xxHash $(UNITTEST_CXXFLAGS)
+librgw_file_nfsns_CXXFLAGS = -I$(srcdir)/xxHash $(UNITTEST_CXXFLAGS) ${RGW_CXXFLAGS}
 librgw_file_nfsns_LDADD = $(UNITTEST_LDADD) \
 	$(LIBRGW) $(LIBRGW_DEPS) librados.la $(PTHREAD_LIBS) $(CEPH_GLOBAL) $(EXTRALIBS)
 noinst_PROGRAMS += librgw_file_nfsns


### PR DESCRIPTION
config-h.in.cmake and rgw_fcgi.{cc,h} all expect FASTCGI_INCLUDE_DIR to
be set when FastCGI headers are in /usr/include/fastcgi.  Unfortunately,
Findfcgi.cmake sets FCGI_INCLUDE_DIR, i.e. the name doesn't match.  This
breaks the cmake build on SUSE distros (and presumably any other distro
which has the FastCGI headers in /usr/include/fastcgi).

Signed-off-by: Tim Serong <tserong@suse.com>