### PR TITLE
test/test_crush_bucket.sh: source detect-build-env-vars.sh for settin…

### DIFF
--- a/src/test/test_crush_bucket.sh
+++ b/src/test/test_crush_bucket.sh
@@ -5,6 +5,7 @@
 #
 
 # Includes
+source $(dirname $0)/detect-build-env-vars.sh
 source ../qa/workunits/ceph-helpers.sh
 function run() {
     local dir=$1


### PR DESCRIPTION
…gs paths

this fixes errors like

../qa/workunits/ceph-helpers.sh:354: run_mon:  ceph-mon --id a
--mon-osd-full-ratio=.99 --mon-data-avail-crit=1
--paxos-propose-interval=0.1 --osd-crush-chooseleaf-type=0
--erasure-code-dir= --plugin-dir= --debug-mon 20 --debug-ms 20
--debug-paxos 20 --chdir= --mon-data=testdir/testcrushbucket/a
'--log-file=testdir/testcrushbucket/$name.log'
'--admin-socket=testdir/testcrushbucket/$cluster-$name.asok'
--mon-cluster-log-file=testdir/testcrushbucket/log
--run-dir=testdir/testcrushbucket
'--pid-file=testdir/testcrushbucket/$name.pid'
2016-06-28 11:24:24.105884 2b1bbd3d0380 -1 load
dlopen(/libec_jerasure.so): /libec_jerasure.so: cannot open shared
object file: No such file or directory
../qa/workunits/ceph-helpers.sh:371: run_mon:  return 1

Signed-off-by: Kefu Chai <kchai@redhat.com>