### PR TITLE
os/bluestore: get rid off blob's ref_map for non-shared objects

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6021,7 +6021,7 @@ int BlueStore::_do_alloc_write(
 	final_length = newlen;
 	csum_length = newlen;
 	csum_order = ctz(newlen);
-	b->blob.set_compressed(rawlen);
+	b->blob.set_compressed(wi.blob_length, rawlen);
 	compressed = true;
       } else {
 	dout(20) << __func__ << hex << "  compressed 0x" << l->length()

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2837,21 +2837,20 @@ int BlueStore::_fsck_verify_blob_map(
       ++errors;
       continue;
     }
-    if (pv->second != b.blob.ref_map) {
+    if (b.blob.has_refmap() && pv->second != b.blob.ref_map) {
       derr << " " << what << " blob " << b.id
 	   << " ref_map " << b.blob.ref_map
 	   << " != expected " << pv->second << dendl;
       ++errors;
     }
-    v.erase(pv);
-    interval_set<uint64_t> span;
     bool compressed = b.blob.is_compressed();
     if (compressed) {
       expected_statfs.compressed += b.blob.compressed_length;
-      for (auto& r : b.blob.ref_map.ref_map) {
-        expected_statfs.compressed_original += r.second.refs * r.second.length;
+      for (auto& r : b.blob.has_refmap() ? b.blob.ref_map.ref_map : v[b.id].ref_map) {
+	expected_statfs.compressed_original += r.second.refs * r.second.length;
       }
     }
+    v.erase(pv);
     for (auto& p : b.blob.extents) {
       if (!p.is_valid()) {
         continue;
@@ -5813,12 +5812,10 @@ void BlueStore::_do_write_small(
 			  &txc->ioc, wctx->buffered);
 	});
       b->blob.calc_csum(b_off, padded);
-      o->onode.punch_hole(offset, length, &wctx->lex_old);
       dout(20) << __func__ << "  lexold 0x" << std::hex << offset << std::dec
 	       << ": " << ep->second << dendl;
-      bluestore_lextent_t& lex = o->onode.extent_map[offset] =
-	bluestore_lextent_t(blob, b_off + head_pad, length);
-      b->blob.ref_map.get(lex.offset, lex.length);
+      bluestore_lextent_t lex(blob, b_off + head_pad, length);
+      o->onode.set_lextent(offset, lex, &b->blob, &wctx->lex_old);
       b->blob.mark_used(lex.offset, lex.length, min_alloc_size);
       txc->statfs_delta.stored() += lex.length;
       dout(20) << __func__ << "  lex 0x" << std::hex << offset << std::dec
@@ -5888,10 +5885,8 @@ void BlueStore::_do_write_small(
       dout(20) << __func__ << "  wal write 0x" << std::hex << b_off << "~"
 	       << b_len << std::dec << " of mutable " << blob << ": " << *b
 	       << " at " << op->extents << dendl;
-      o->onode.punch_hole(offset, length, &wctx->lex_old);
-      bluestore_lextent_t& lex = o->onode.extent_map[offset] =
-	bluestore_lextent_t(blob, offset - bstart, length);
-      b->blob.ref_map.get(lex.offset, lex.length);
+      bluestore_lextent_t lex(blob, offset - bstart, length);
+      o->onode.set_lextent(offset, lex, &b->blob, &wctx->lex_old);
       b->blob.mark_used(lex.offset, lex.length, min_alloc_size);
       txc->statfs_delta.stored() += lex.length;
       dout(20) << __func__ << "  lex 0x" << std::hex << offset
@@ -5909,10 +5904,8 @@ void BlueStore::_do_write_small(
   uint64_t b_off = P2PHASE(offset, alloc_len);
   b->bc.write(txc->seq, b_off, bl, wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
   _pad_zeros(&bl, &b_off, block_size);
-  o->onode.punch_hole(offset, length, &wctx->lex_old);
-  bluestore_lextent_t& lex = o->onode.extent_map[offset] =
-    bluestore_lextent_t(b->id, P2PHASE(offset, alloc_len), length);
-  b->blob.ref_map.get(lex.offset, lex.length);
+  bluestore_lextent_t lex(b->id, P2PHASE(offset, alloc_len), length);
+  o->onode.set_lextent(offset, lex, &b->blob, &wctx->lex_old);
   txc->statfs_delta.stored() += lex.length;
   dout(20) << __func__ << "  lex 0x" << std::hex << offset << std::dec
 	   << ": " << lex << dendl;
@@ -5944,9 +5937,8 @@ void BlueStore::_do_write_big(
     blp.copy(l, t);
     b->bc.write(txc->seq, 0, t, wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
     wctx->write(b, l, 0, t, false);
-    o->onode.punch_hole(offset, l, &wctx->lex_old);
-    o->onode.extent_map[offset] = bluestore_lextent_t(b->id, 0, l);
-    b->blob.ref_map.get(0, l);
+    bluestore_lextent_t lex(b->id, 0, l);
+    o->onode.set_lextent(offset, lex, &b->blob, &wctx->lex_old);
     txc->statfs_delta.stored() += l;
     dout(20) << __func__ << "  lex 0x" << std::hex << offset << std::dec << ": "
 	     << o->onode.extent_map[offset] << dendl;
@@ -6097,12 +6089,15 @@ void BlueStore::_wctx_finish(
   WriteContext *wctx)
 {
   dout(10) << __func__ << " lex_old " << wctx->lex_old << dendl;
+  set<pair<bool, Blob*> > blobs2remove;
   for (auto &lo : wctx->lex_old) {
     bluestore_lextent_t& l = lo.second;
     Blob *b = c->get_blob(o, l.blob);
     vector<bluestore_pextent_t> r;
     bool compressed = b->blob.is_compressed();
-    b->blob.put_ref(l.offset, l.length, min_alloc_size, &r);
+    if (o->onode.deref_lextent(lo.first, l, &b->blob, min_alloc_size, &r)) {
+      blobs2remove.insert(std::make_pair(l.blob >= 0, b));
+    }
     // we can't invalidate our logical extents as we drop them because
     // other lextents (either in our onode or others) may still
     // reference them.  but we can throw out anything that is no
@@ -6122,19 +6117,18 @@ void BlueStore::_wctx_finish(
         txc->statfs_delta.compressed_allocated() -= e.length;
       }
     }
-    if (b->blob.ref_map.empty()) {
-      dout(20) << __func__ << " rm blob " << *b << dendl;
-      txc->statfs_delta.compressed() -= b->blob.get_compressed_payload_length();
-      if (l.blob >= 0) {
-	o->blob_map.erase(b);
-      } else {
-	o->bnode->blob_map.erase(b);
-      }
-    } else {
-      dout(20) << __func__ << " keep blob " << *b << dendl;
-    }
     if (l.blob < 0) {
       txc->write_bnode(o->bnode);
+    }
+  }
+  for (auto br : blobs2remove) {
+    Blob* b = br.second;
+    dout(20) << __func__ << " rm blob " << *b << dendl;
+    txc->statfs_delta.compressed() -= b->blob.get_compressed_payload_length();
+    if (br.first) {
+      o->blob_map.erase(b);
+    } else {
+      o->bnode->blob_map.erase(b);
     }
   }
 
@@ -6679,15 +6673,22 @@ int BlueStore::_clone(TransContext *txc,
       // move blobs
       map<int64_t,int64_t> moved_blobs;
       for (auto& p : oldo->onode.extent_map) {
-	if (!p.second.is_shared() && moved_blobs.count(p.second.blob) == 0) {
-	  Blob *b = oldo->blob_map.get(p.second.blob);
-	  oldo->blob_map.erase(b);
-	  newo->bnode->blob_map.claim(b);
-	  moved_blobs[p.second.blob] = b->id;
-	  dout(30) << __func__ << "  moving old onode blob " << p.second.blob
-		   << " to bnode blob " << b->id << dendl;
-	  b->blob.clear_flag(bluestore_blob_t::FLAG_MUTABLE);
-	}
+        if (!p.second.is_shared()) {
+          Blob *b;
+          if (moved_blobs.count(p.second.blob) == 0) {
+            b = oldo->blob_map.get(p.second.blob);
+            oldo->blob_map.erase(b);
+            newo->bnode->blob_map.claim(b);
+            moved_blobs[p.second.blob] = b->id;
+            dout(30) << __func__ << "  moving old onode blob " << p.second.blob
+                    << " to bnode blob " << b->id << dendl;
+            b->blob.clear_flag(bluestore_blob_t::FLAG_MUTABLE);
+            b->blob.set_flag(bluestore_blob_t::FLAG_HAS_REFMAP);
+          } else {
+            b = newo->bnode->blob_map.get(moved_blobs[p.second.blob]);
+          }
+          b->blob.get_ref(p.second.offset, p.second.length);
+        }
       }
       // update lextents
       for (auto& p : oldo->onode.extent_map) {
@@ -6696,9 +6697,7 @@ int BlueStore::_clone(TransContext *txc,
 	}
 	newo->onode.extent_map[p.first] = p.second;
         assert(p.second.blob < 0);
-	newo->bnode->blob_map.get(-p.second.blob)->blob.ref_map.get(
-	  p.second.offset,
-	  p.second.length);
+	newo->bnode->blob_map.get(-p.second.blob)->blob.get_ref(p.second.offset, p.second.length);
 	txc->statfs_delta.stored() += p.second.length;
       }
       _dump_onode(newo);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6097,7 +6097,8 @@ void BlueStore::_wctx_finish(
   WriteContext *wctx)
 {
   dout(10) << __func__ << " lex_old " << wctx->lex_old << dendl;
-  for (auto &l : wctx->lex_old) {
+  for (auto &lo : wctx->lex_old) {
+    bluestore_lextent_t& l = lo.second;
     Blob *b = c->get_blob(o, l.blob);
     vector<bluestore_pextent_t> r;
     bool compressed = b->blob.is_compressed();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1498,7 +1498,7 @@ private:
     uint64_t comp_blob_size = 0; ///< target compressed blob size
     unsigned csum_order = 0;     ///< target checksum chunk order
 
-    vector<bluestore_lextent_t> lex_old;       ///< must deref blobs
+    vector<std::pair<uint64_t, bluestore_lextent_t> > lex_old; ///< must deref blobs
 
     struct write_item {
       Blob *b;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -630,13 +630,13 @@ struct bluestore_onode_t {
 
   /// punch a logical hole.  add lextents to deref to target list.
   void punch_hole(uint64_t offset, uint64_t length,
-		  vector<bluestore_lextent_t> *deref);
+		  vector<std::pair<uint64_t, bluestore_lextent_t> >*deref);
 
   /// put new lextent into lextent_map overwriting existing ones if any and update references accordingly
   void set_lextent(uint64_t offset,
 		   const bluestore_lextent_t& lext,
 		   bluestore_blob_t* b,
-		   vector<bluestore_lextent_t> *deref);
+		   vector<std::pair<uint64_t, bluestore_lextent_t> >*deref);
 
   /// post process removed lextent to take care of blob references
   /// returns true is underlying blob has to be released

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -120,6 +120,14 @@ struct bluestore_extent_ref_map_t {
     return ref_map.empty();
   }
 
+  //raw reference insertion that assumes no conflicts/interference with the existing references
+  void fill(uint32_t offset, uint32_t len, int refs = 1) {
+    auto p = ref_map.insert(
+        map<uint32_t,record_t>::value_type(offset,
+                                           record_t(len, refs))).first;
+    _maybe_merge_left(p);
+  }
+
   void get(uint32_t offset, uint32_t len);
   void put(uint32_t offset, uint32_t len, vector<bluestore_pextent_t> *release);
 

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -245,9 +245,7 @@ struct bluestore_blob_t {
   typedef std::bitset<sizeof(unused_uint_t) * 8> unused_t;
   unused_t unused;                    ///< portion that has never been written to
 
-  bluestore_blob_t(uint32_t f = 0) : flags(f) {
-    set_flag(FLAG_HAS_REFMAP);
-  }
+  bluestore_blob_t(uint32_t f = 0) : flags(f) {}
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& p);

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -632,6 +632,20 @@ struct bluestore_onode_t {
   void punch_hole(uint64_t offset, uint64_t length,
 		  vector<bluestore_lextent_t> *deref);
 
+  /// put new lextent into lextent_map overwriting existing ones if any and update references accordingly
+  void set_lextent(uint64_t offset,
+		   const bluestore_lextent_t& lext,
+		   bluestore_blob_t* b,
+		   vector<bluestore_lextent_t> *deref);
+
+  /// post process removed lextent to take care of blob references
+  /// returns true is underlying blob has to be released
+  bool deref_lextent(uint64_t offset,
+               bluestore_lextent_t& lext,
+               bluestore_blob_t* b,
+               uint64_t min_alloc_size,
+               vector<bluestore_pextent_t>* r);
+
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& p);
   void dump(Formatter *f) const;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -223,6 +223,7 @@ struct bluestore_blob_t {
   }
 
   vector<bluestore_pextent_t> extents;///< raw data position on device
+  uint32_t compressed_length_orig = 0;///< original length of compressed blob if any
   uint32_t compressed_length = 0;     ///< compressed length if any
   uint32_t flags = 0;                 ///< FLAG_*
 
@@ -258,8 +259,9 @@ struct bluestore_blob_t {
     return get_flags_string(flags);
   }
 
-  void set_compressed(uint64_t clen) {
+  void set_compressed(uint64_t clen_orig, uint64_t clen) {
     set_flag(FLAG_COMPRESSED);
+    compressed_length_orig = clen_orig;
     compressed_length = clen;
   }
   bool is_mutable() const {
@@ -287,6 +289,9 @@ struct bluestore_blob_t {
   }
   uint32_t get_compressed_payload_length() const {
     return is_compressed() ? compressed_length : 0;
+  }
+  uint32_t get_compressed_payload_original_length() const {
+    return is_compressed() ? compressed_length_orig : 0;
   }
   uint64_t calc_offset(uint64_t x_off, uint64_t *plen) const {
     auto p = extents.begin();

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -389,8 +389,12 @@ struct bluestore_blob_t {
   /// get logical references
   void get_ref(uint64_t offset, uint64_t length);
   /// put logical references, and get back any released extents
-  void put_ref(uint64_t offset, uint64_t length, uint64_t min_alloc_size,
-	       vector<bluestore_pextent_t> *r);
+  bool put_ref(uint64_t offset, uint64_t length,  uint64_t min_alloc_size,
+              vector<bluestore_pextent_t> *r);
+  /// put logical references using external ref_map, and get back any released extents
+  bool put_ref_external( bluestore_extent_ref_map_t& ref_map,
+               uint64_t offset, uint64_t length,  uint64_t min_alloc_size,
+               vector<bluestore_pextent_t> *r);
 
   void map(uint64_t x_off, uint64_t x_len,
 	   std::function<void(uint64_t,uint64_t)> f) const {

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -767,16 +767,16 @@ TEST(bluestore_onode_t, compress_extent_map)
 TEST(bluestore_onode_t, punch_hole)
 {
   bluestore_onode_t on;
-  vector<bluestore_lextent_t> r;
+  vector<std::pair<uint64_t, bluestore_lextent_t> > r;
   on.extent_map[0] = bluestore_lextent_t(1, 0, 100);
   on.extent_map[100] = bluestore_lextent_t(2, 0, 100);
 
   on.punch_hole(0, 100, &r);
   ASSERT_EQ(1u, on.extent_map.size());
   ASSERT_EQ(1u, r.size());
-  ASSERT_EQ(1, r[0].blob);
-  ASSERT_EQ(0u, r[0].offset);
-  ASSERT_EQ(100u, r[0].length);
+  ASSERT_EQ(1, r[0].second.blob);
+  ASSERT_EQ(0u, r[0].second.offset);
+  ASSERT_EQ(100u, r[0].second.length);
   r.clear();
 
   on.punch_hole(150, 10, &r);
@@ -788,9 +788,9 @@ TEST(bluestore_onode_t, punch_hole)
   ASSERT_EQ(60u, on.extent_map.rbegin()->second.offset);
   ASSERT_EQ(40u, on.extent_map.rbegin()->second.length);
   ASSERT_EQ(1u, r.size());
-  ASSERT_EQ(2, r[0].blob);
-  ASSERT_EQ(50u, r[0].offset);
-  ASSERT_EQ(10u, r[0].length);
+  ASSERT_EQ(2, r[0].second.blob);
+  ASSERT_EQ(50u, r[0].second.offset);
+  ASSERT_EQ(10u, r[0].second.length);
   r.clear();
 
   on.punch_hole(140, 20, &r);
@@ -802,9 +802,9 @@ TEST(bluestore_onode_t, punch_hole)
   ASSERT_EQ(60u, on.extent_map.rbegin()->second.offset);
   ASSERT_EQ(40u, on.extent_map.rbegin()->second.length);
   ASSERT_EQ(1u, r.size());
-  ASSERT_EQ(2, r[0].blob);
-  ASSERT_EQ(40u, r[0].offset);
-  ASSERT_EQ(10u, r[0].length);
+  ASSERT_EQ(2, r[0].second.blob);
+  ASSERT_EQ(40u, r[0].second.offset);
+  ASSERT_EQ(10u, r[0].second.length);
   r.clear();
 
   on.punch_hole(130, 40, &r);
@@ -816,12 +816,12 @@ TEST(bluestore_onode_t, punch_hole)
   ASSERT_EQ(70u, on.extent_map.rbegin()->second.offset);
   ASSERT_EQ(30u, on.extent_map.rbegin()->second.length);
   ASSERT_EQ(2u, r.size());
-  ASSERT_EQ(2, r[0].blob);
-  ASSERT_EQ(30u, r[0].offset);
-  ASSERT_EQ(10u, r[0].length);
-  ASSERT_EQ(2, r[1].blob);
-  ASSERT_EQ(60u, r[1].offset);
-  ASSERT_EQ(10u, r[1].length);
+  ASSERT_EQ(2, r[0].second.blob);
+  ASSERT_EQ(30u, r[0].second.offset);
+  ASSERT_EQ(10u, r[0].second.length);
+  ASSERT_EQ(2, r[1].second.blob);
+  ASSERT_EQ(60u, r[1].second.offset);
+  ASSERT_EQ(10u, r[1].second.length);
   r.clear();
 
   on.punch_hole(110, 10, &r);
@@ -835,30 +835,30 @@ TEST(bluestore_onode_t, punch_hole)
   ASSERT_EQ(70u, on.extent_map.rbegin()->second.offset);
   ASSERT_EQ(30u, on.extent_map.rbegin()->second.length);
   ASSERT_EQ(1u, r.size());
-  ASSERT_EQ(2, r[0].blob);
-  ASSERT_EQ(10u, r[0].offset);
-  ASSERT_EQ(10u, r[0].length);
+  ASSERT_EQ(2, r[0].second.blob);
+  ASSERT_EQ(10u, r[0].second.offset);
+  ASSERT_EQ(10u, r[0].second.length);
   r.clear();
 
   on.punch_hole(0, 1000, &r);
   ASSERT_EQ(0u, on.extent_map.size());
   ASSERT_EQ(3u, r.size());
-  ASSERT_EQ(2, r[0].blob);
-  ASSERT_EQ(0u, r[0].offset);
-  ASSERT_EQ(10u, r[0].length);
-  ASSERT_EQ(2, r[1].blob);
-  ASSERT_EQ(20u, r[1].offset);
-  ASSERT_EQ(10u, r[1].length);
-  ASSERT_EQ(2, r[2].blob);
-  ASSERT_EQ(70u, r[2].offset);
-  ASSERT_EQ(30u, r[2].length);
+  ASSERT_EQ(2, r[0].second.blob);
+  ASSERT_EQ(0u, r[0].second.offset);
+  ASSERT_EQ(10u, r[0].second.length);
+  ASSERT_EQ(2, r[1].second.blob);
+  ASSERT_EQ(20u, r[1].second.offset);
+  ASSERT_EQ(10u, r[1].second.length);
+  ASSERT_EQ(2, r[2].second.blob);
+  ASSERT_EQ(70u, r[2].second.offset);
+  ASSERT_EQ(30u, r[2].second.length);
   r.clear();
 }
 
 TEST(bluestore_onode_t, insert_remove_lextent)
 {
   bluestore_onode_t on;
-  vector<bluestore_lextent_t> r;
+  vector<std::pair<uint64_t, bluestore_lextent_t> > r;
   vector<bluestore_pextent_t> rp;
 
   bluestore_pextent_t pext1(1, 0x10000);
@@ -903,15 +903,15 @@ TEST(bluestore_onode_t, insert_remove_lextent)
 
   ASSERT_EQ(2u, on.extent_map.size());
   ASSERT_EQ(1u, r.size());
-  ASSERT_EQ(2, r[0].blob);
-  ASSERT_EQ(1u, r[0].offset);
-  ASSERT_EQ(99u, r[0].length);
+  ASSERT_EQ(2, r[0].second.blob);
+  ASSERT_EQ(1u, r[0].second.offset);
+  ASSERT_EQ(99u, r[0].second.length);
   ASSERT_TRUE(blob.ref_map.contains(0,100));
   ASSERT_TRUE(blob2.ref_map.empty());
   ASSERT_TRUE(blob3.ref_map.empty());
 
   //deref overwritten lextent
-  empty = on.deref_lextent(100, r[0], &blob2, 0x10000, &rp);
+  empty = on.deref_lextent(100, r[0].second, &blob2, 0x10000, &rp);
   ASSERT_TRUE(empty);
   ASSERT_EQ(1u, rp.size());
   ASSERT_TRUE(pext2.offset == rp[0].offset);
@@ -930,15 +930,15 @@ TEST(bluestore_onode_t, insert_remove_lextent)
 
   ASSERT_EQ(2u, on.extent_map.size());
   ASSERT_EQ(1u, r.size());
-  ASSERT_EQ(1, r[0].blob);
-  ASSERT_EQ(0u, r[0].offset);
-  ASSERT_EQ(100u, r[0].length);
+  ASSERT_EQ(1, r[0].second.blob);
+  ASSERT_EQ(0u, r[0].second.offset);
+  ASSERT_EQ(100u, r[0].second.length);
   ASSERT_TRUE(blob.ref_map.contains(0,100));
   ASSERT_TRUE(blob2.ref_map.empty());
   ASSERT_TRUE(blob3.ref_map.empty());
 
   //deref overwritten lextent
-  empty = on.deref_lextent(0, r[0], &blob, 0x10000, &rp);
+  empty = on.deref_lextent(0, r[0].second, &blob, 0x10000, &rp);
   ASSERT_TRUE(empty);
   ASSERT_EQ(1u, rp.size());
   ASSERT_TRUE(pext1.offset == rp[0].offset);
@@ -961,11 +961,11 @@ TEST(bluestore_onode_t, insert_remove_lextent)
   //deref lextent with underlying blob having multiple references (no ref_map case)
   on.punch_hole(100, 100, &r);
   ASSERT_EQ(1u, r.size());
-  ASSERT_EQ(3, r[0].blob);
-  ASSERT_EQ(1u, r[0].offset);
-  ASSERT_EQ(99u, r[0].length);
+  ASSERT_EQ(3, r[0].second.blob);
+  ASSERT_EQ(1u, r[0].second.offset);
+  ASSERT_EQ(99u, r[0].second.length);
 
-  empty = on.deref_lextent(100, r[0], &blob3, 0x10000, &rp);
+  empty = on.deref_lextent(100, r[0].second, &blob3, 0x10000, &rp);
   ASSERT_FALSE(empty);
   ASSERT_EQ(0u, rp.size());
 
@@ -975,11 +975,11 @@ TEST(bluestore_onode_t, insert_remove_lextent)
   //deref lextent with underlying blob having single reference (no ref_map case)
   on.punch_hole(300, 100, &r);
   ASSERT_EQ(1u, r.size());
-  ASSERT_EQ(3, r[0].blob);
-  ASSERT_EQ(200u, r[0].offset);
-  ASSERT_EQ(50u, r[0].length);
+  ASSERT_EQ(3, r[0].second.blob);
+  ASSERT_EQ(200u, r[0].second.offset);
+  ASSERT_EQ(50u, r[0].second.length);
 
-  empty = on.deref_lextent(300, r[0], &blob3, 0x10000, &rp);
+  empty = on.deref_lextent(300, r[0].second, &blob3, 0x10000, &rp);
   ASSERT_TRUE(empty);
   ASSERT_EQ(1u, rp.size());
   ASSERT_TRUE(pext3.offset == rp[0].offset);
@@ -991,11 +991,11 @@ TEST(bluestore_onode_t, insert_remove_lextent)
 
   //deref lextent partially (no ref_map case)
   on.punch_hole(20, 10, &r);
-  ASSERT_EQ(2, r[0].blob);
-  ASSERT_EQ(20u, r[0].offset);
-  ASSERT_EQ(10u, r[0].length);
+  ASSERT_EQ(2, r[0].second.blob);
+  ASSERT_EQ(20u, r[0].second.offset);
+  ASSERT_EQ(10u, r[0].second.length);
 
-  empty = on.deref_lextent(20, r[0], &blob2, 0x10000, &rp);
+  empty = on.deref_lextent(20, r[0].second, &blob2, 0x10000, &rp);
   ASSERT_FALSE(empty);
   ASSERT_EQ(0u, rp.size());
 
@@ -1005,11 +1005,11 @@ TEST(bluestore_onode_t, insert_remove_lextent)
   //deref lextent partially once again(no ref_map case)
   on.punch_hole(70, 10, &r);
   ASSERT_EQ(1u, r.size());
-  ASSERT_EQ(2, r[0].blob);
-  ASSERT_EQ(70u, r[0].offset);
-  ASSERT_EQ(10u, r[0].length);
+  ASSERT_EQ(2, r[0].second.blob);
+  ASSERT_EQ(70u, r[0].second.offset);
+  ASSERT_EQ(10u, r[0].second.length);
 
-  empty = on.deref_lextent(70, r[0], &blob2, 0x10000, &rp);
+  empty = on.deref_lextent(70, r[0].second, &blob2, 0x10000, &rp);
   ASSERT_FALSE(empty);
   ASSERT_EQ(0u, rp.size());
 
@@ -1019,29 +1019,29 @@ TEST(bluestore_onode_t, insert_remove_lextent)
   //deref fragmented lextent totally (no ref_map case)
   on.punch_hole(0, 100, &r);
   ASSERT_EQ(3u, r.size());
-  ASSERT_EQ(2, r[0].blob);
-  ASSERT_EQ(0u, r[0].offset);
-  ASSERT_EQ(20u, r[0].length);
-  ASSERT_EQ(2, r[1].blob);
-  ASSERT_EQ(30u, r[1].offset);
-  ASSERT_EQ(40u, r[1].length);
-  ASSERT_EQ(2, r[2].blob);
-  ASSERT_EQ(80u, r[2].offset);
-  ASSERT_EQ(20u, r[2].length);
+  ASSERT_EQ(2, r[0].second.blob);
+  ASSERT_EQ(0u, r[0].second.offset);
+  ASSERT_EQ(20u, r[0].second.length);
+  ASSERT_EQ(2, r[1].second.blob);
+  ASSERT_EQ(30u, r[1].second.offset);
+  ASSERT_EQ(40u, r[1].second.length);
+  ASSERT_EQ(2, r[2].second.blob);
+  ASSERT_EQ(80u, r[2].second.offset);
+  ASSERT_EQ(20u, r[2].second.length);
 
-  empty = on.deref_lextent(0, r[0], &blob2, 0x10000, &rp);
+  empty = on.deref_lextent(0, r[0].second, &blob2, 0x10000, &rp);
   ASSERT_TRUE(empty);
   ASSERT_EQ(1u, rp.size());
   ASSERT_TRUE(pext2.offset == rp[0].offset);
   ASSERT_TRUE(pext2.length == rp[0].length);
   rp.clear();
 
-  empty = on.deref_lextent(30, r[1], &blob2, 0x10000, &rp);
+  empty = on.deref_lextent(30, r[1].second, &blob2, 0x10000, &rp);
   ASSERT_TRUE(empty);
   ASSERT_EQ(0u, rp.size()); //no more pextents for the blob, already deallocated above
   rp.clear();
 
-  empty = on.deref_lextent(80, r[2], &blob2, 0x10000, &rp);
+  empty = on.deref_lextent(80, r[2].second, &blob2, 0x10000, &rp);
   ASSERT_TRUE(empty);
   ASSERT_EQ(0u, rp.size()); //no more pextents for the blob, already deallocated above
 

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -195,10 +195,10 @@ TEST(bluestore_blob_t, put_ref)
   unsigned mrs = 8192;
 
   {
-    bluestore_blob_t b;
+    bluestore_blob_t b(bluestore_blob_t::FLAG_HAS_REFMAP);
     vector<bluestore_pextent_t> r;
     b.extents.push_back(bluestore_pextent_t(0, mas*2));
-    b.ref_map.get(0, mas*2);
+    b.get_ref(0, mas*2);
     ASSERT_TRUE(b.is_allocated(0, mas*2));
     b.put_ref(0, mas*2, mrs, &r);
     cout << "r " << r << " " << b << std::endl;
@@ -212,10 +212,10 @@ TEST(bluestore_blob_t, put_ref)
     ASSERT_EQ(mas*2, b.extents[0].length);
   }
   {
-    bluestore_blob_t b;
+    bluestore_blob_t b(bluestore_blob_t::FLAG_HAS_REFMAP);
     vector<bluestore_pextent_t> r;
     b.extents.push_back(bluestore_pextent_t(123, mas*2));
-    b.ref_map.get(0, mas*2);
+    b.get_ref(0, mas*2);
     b.put_ref(0, mas, mrs, &r);
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
@@ -230,13 +230,13 @@ TEST(bluestore_blob_t, put_ref)
     ASSERT_EQ(mas*2, b.extents[0].length);
   }
   {
-    bluestore_blob_t b;
+    bluestore_blob_t b(bluestore_blob_t::FLAG_HAS_REFMAP);
     vector<bluestore_pextent_t> r;
     b.extents.push_back(bluestore_pextent_t(1, mas));
     b.extents.push_back(bluestore_pextent_t(2, mas));
     b.extents.push_back(bluestore_pextent_t(3, mas));
     b.extents.push_back(bluestore_pextent_t(4, mas));
-    b.ref_map.get(0, mas*4);
+    b.get_ref(0, mas*4);
     b.put_ref(mas, mas, mrs, &r);
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
@@ -262,7 +262,7 @@ TEST(bluestore_blob_t, put_ref)
     ASSERT_EQ(3u, b.extents.size());
   }
   {
-    bluestore_blob_t b;
+    bluestore_blob_t b(bluestore_blob_t::FLAG_HAS_REFMAP);
     vector<bluestore_pextent_t> r;
     b.extents.push_back(bluestore_pextent_t(1, mas));
     b.extents.push_back(bluestore_pextent_t(2, mas));
@@ -270,7 +270,7 @@ TEST(bluestore_blob_t, put_ref)
     b.extents.push_back(bluestore_pextent_t(4, mas));
     b.extents.push_back(bluestore_pextent_t(5, mas));
     b.extents.push_back(bluestore_pextent_t(6, mas));
-    b.ref_map.get(0, mas*6);
+    b.get_ref(0, mas*6);
     b.put_ref(mas, mas, mrs, &r);
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
@@ -297,10 +297,10 @@ TEST(bluestore_blob_t, put_ref)
     ASSERT_TRUE(b.extents[4].is_valid());
   }
   {
-    bluestore_blob_t b;
+    bluestore_blob_t b(bluestore_blob_t::FLAG_HAS_REFMAP);
     vector<bluestore_pextent_t> r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 6));
-    b.ref_map.get(0, mas*6);
+    b.get_ref(0, mas*6);
     b.put_ref(mas, mas, mrs, &r);
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
@@ -323,12 +323,12 @@ TEST(bluestore_blob_t, put_ref)
     ASSERT_TRUE(b.extents[2].is_valid());
   }
   {
-    bluestore_blob_t b;
+    bluestore_blob_t b(bluestore_blob_t::FLAG_HAS_REFMAP);
     vector<bluestore_pextent_t> r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 4));
     b.extents.push_back(bluestore_pextent_t(2, mas * 4));
     b.extents.push_back(bluestore_pextent_t(3, mas * 4));
-    b.ref_map.get(0, mas*12);
+    b.get_ref(0, mas*12);
     b.put_ref(mas, mas, mrs, &r);
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
@@ -355,12 +355,12 @@ TEST(bluestore_blob_t, put_ref)
     ASSERT_TRUE(b.extents[2].is_valid());
   }
   {
-    bluestore_blob_t b;
+    bluestore_blob_t b(bluestore_blob_t::FLAG_HAS_REFMAP);
     vector<bluestore_pextent_t> r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 4));
     b.extents.push_back(bluestore_pextent_t(2, mas * 4));
     b.extents.push_back(bluestore_pextent_t(3, mas * 4));
-    b.ref_map.get(0, mas*12);
+    b.get_ref(0, mas*12);
     b.put_ref(mas, mas, mrs, &r);
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
@@ -402,12 +402,12 @@ TEST(bluestore_blob_t, put_ref)
     ASSERT_FALSE(b.extents[0].is_valid());
   }
   {
-    bluestore_blob_t b;
+    bluestore_blob_t b(bluestore_blob_t::FLAG_HAS_REFMAP);
     vector<bluestore_pextent_t> r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 4));
     b.extents.push_back(bluestore_pextent_t(2, mas * 4));
     b.extents.push_back(bluestore_pextent_t(3, mas * 4));
-    b.ref_map.get(0, mas*12);
+    b.get_ref(0, mas*12);
     b.put_ref(mas, mas, mrs, &r);
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
@@ -449,10 +449,10 @@ TEST(bluestore_blob_t, put_ref)
     ASSERT_FALSE(b.extents[0].is_valid());
   }
   {
-    bluestore_blob_t b;
+    bluestore_blob_t b(bluestore_blob_t::FLAG_HAS_REFMAP);
     vector<bluestore_pextent_t> r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 8));
-    b.ref_map.get(0, mas*8);
+    b.get_ref(0, mas*8);
     b.put_ref(0, mas, mrs, &r);
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
@@ -484,11 +484,11 @@ TEST(bluestore_blob_t, put_ref)
   }
   // verify csum chunk size if factored in properly
   {
-    bluestore_blob_t b;
+    bluestore_blob_t b(bluestore_blob_t::FLAG_HAS_REFMAP);
     vector<bluestore_pextent_t> r;
     b.extents.push_back(bluestore_pextent_t(0, mas*4));
     b.init_csum(bluestore_blob_t::CSUM_CRC32C, 14, mas * 4);
-    b.ref_map.get(0, mas*4);
+    b.get_ref(0, mas*4);
     ASSERT_TRUE(b.is_allocated(0, mas*4));
     b.put_ref(0, mas*3, mrs, &r);
     cout << "r " << r << " " << b << std::endl;


### PR DESCRIPTION
Ref_map is built on the fly for onodes that are not shared. Hence provides saving for both serialized and in-memory onode representation.

Signed-off-by: Igor Fedotov ifedotov@mirantis.com