### PR TITLE
cmake: unittest_rbd_mirror: split this test into two

### DIFF
--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -10,42 +10,53 @@ add_library(rbd_mirror STATIC ${rbd_mirror_test_srcs})
 set_target_properties(rbd_mirror PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 
-add_executable(unittest_rbd_mirror
+add_library(unittest_rbd_mirror_objs OBJECT
   test_main.cc
   test_mock_fixture.cc
+  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc)
+set_target_properties(unittest_rbd_mirror_objs PROPERTIES COMPILE_FLAGS
+  ${UNITTEST_CXX_FLAGS})
+
+# some tests fully specialize a mock class, but some other test explicitly
+# instantiate the same mock class using the original template. this violates
+# ODR, and causes segfault. so we split the test cases into two groups
+# which do not interfere with each other.
+add_executable(unittest_rbd_mirror_1
   test_mock_ImageReplayer.cc
   test_mock_ImageSync.cc
   image_replayer/test_mock_BootstrapRequest.cc
   image_replayer/test_mock_CreateImageRequest.cc
-  image_sync/test_mock_ImageCopyRequest.cc
   image_sync/test_mock_ObjectCopyRequest.cc
-  image_sync/test_mock_SnapshotCopyRequest.cc
   image_sync/test_mock_SnapshotCreateRequest.cc
+  $<TARGET_OBJECTS:unittest_rbd_mirror_objs>)
+add_executable(unittest_rbd_mirror_2
+  image_sync/test_mock_ImageCopyRequest.cc
+  image_sync/test_mock_SnapshotCopyRequest.cc
   image_sync/test_mock_SyncPointCreateRequest.cc
   image_sync/test_mock_SyncPointPruneRequest.cc
-  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
-  )
-add_ceph_unittest(unittest_rbd_mirror ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rbd_mirror)
-set_target_properties(unittest_rbd_mirror PROPERTIES COMPILE_FLAGS
-  ${UNITTEST_CXX_FLAGS})
-target_link_libraries(unittest_rbd_mirror
-  rbd_mirror
-  rados_test_stub
-  rbd_mirror_internal
-  rbd_internal
-  rbd_api
-  rbd_test_mock
-  journal
-  journal_test_mock
-  cls_rbd_client
-  cls_lock_client
-  cls_journal_client
-  rbd_types
-  librados
-  osdc
-  global
-  radostest
-  )
+  $<TARGET_OBJECTS:unittest_rbd_mirror_objs>)
+foreach(unittest unittest_rbd_mirror_1 unittest_rbd_mirror_2)
+  add_ceph_unittest(${unittest} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rbd_mirror)
+  set_target_properties("${unittest}" PROPERTIES COMPILE_FLAGS
+    ${UNITTEST_CXX_FLAGS})
+  target_link_libraries(${unittest}
+    rbd_mirror
+    rados_test_stub
+    rbd_mirror_internal
+    rbd_internal
+    rbd_api
+    rbd_test_mock
+    journal
+    journal_test_mock
+    cls_rbd_client
+    cls_lock_client
+    cls_journal_client
+    rbd_types
+    librados
+    osdc
+    global
+    radostest)
+endforeach()
 
 add_executable(ceph_test_rbd_mirror
   test_main.cc


### PR DESCRIPTION
this fixes the segfault with cmake build.

Signed-off-by: Kefu Chai <kchai@redhat.com>