### PR TITLE
msg/AsyncMessenger: move C_processor_accept class

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -96,6 +96,24 @@ class Worker : public Thread {
  * Processor
  */
 
+class Processor::C_processor_accept : public EventCallback {
+  Processor *pro;
+
+ public:
+  explicit C_processor_accept(Processor *p): pro(p) {}
+  void do_request(int id) {
+    pro->accept();
+  }
+};
+
+Processor::Processor(AsyncMessenger *r, CephContext *c, uint64_t n)
+  : msgr(r),
+  net(c),
+  worker(NULL),
+  listen_sd(-1),
+  nonce(n),
+  listen_handler(new C_processor_accept(this)) {}
+
 int Processor::bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports)
 {
   const md_config_t *conf = msgr->cct->_conf;

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -70,19 +70,10 @@ class Processor {
   uint64_t nonce;
   EventCallbackRef listen_handler;
 
-  class C_processor_accept : public EventCallback {
-    Processor *pro;
-
-   public:
-    explicit C_processor_accept(Processor *p): pro(p) {}
-    void do_request(int id) {
-      pro->accept();
-    }
-  };
+  class C_processor_accept;
 
  public:
-  Processor(AsyncMessenger *r, CephContext *c, uint64_t n)
-          : msgr(r), net(c), worker(NULL), listen_sd(-1), nonce(n), listen_handler(new C_processor_accept(this)) {}
+  Processor(AsyncMessenger *r, CephContext *c, uint64_t n);
   ~Processor() { delete listen_handler; };
 
   void stop();


### PR DESCRIPTION
Move C_processor_accept class to cc file.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>