### PR TITLE
client: kill compiling warning

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11700,8 +11700,6 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
     }
   }
 
-done:
-
   if (onuninline) {
     client_lock.Unlock();
     uninline_flock.Lock();


### PR DESCRIPTION
The 'done' lable is not appliable any more.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>