### PR TITLE
mon: remove the redundant is_active judge in Paxos finish_round function

### DIFF
--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -1042,7 +1042,7 @@ void Paxos::finish_round()
     trim();
   }
 
-  if (is_active() && pending_proposal) {
+  if (pending_proposal) {
     propose_pending();
   }
 }


### PR DESCRIPTION
mon: remove the redundant is_active judge in Paxos finish_round function

If the leader have finished the collected and go to the lease state.So he must be
in active state.So the jugement here is redundant

Signed-off-by:song baisen song.baisen@zte.com.cn
