### PR TITLE
fix install-deps.sh on openSUSE Tumbleweed.

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -60,7 +60,7 @@ if test -f /etc/redhat-release ; then
     $SUDO yum install -y redhat-lsb-core
 fi
 
-if type apt-get > /dev/null 2>&1 ; then
+if type apt-get > /dev/null 2>&1 && [ ! type zypper > /dev/null 2>&1 ]; then
     $SUDO apt-get install -y lsb-release devscripts equivs
 fi
 


### PR DESCRIPTION
Test for apt-get (install-deps.sh:60) suceeds on Tumbleweed and tries to
install nonexistent equivs package. This patch fixes this by checking
for (apt-get and NOT zypper).
Fixes http://tracker.ceph.com/issues/16522

Signed-off-by: Jan Fajerski <jfajerski@suse.com>