### PR TITLE
rgw: handle Swift auth errors in a way compatible with new Tempests.

### DIFF
--- a/src/rgw/rgw_auth_decoimpl.h
+++ b/src/rgw/rgw_auth_decoimpl.h
@@ -153,7 +153,11 @@ void RGWThirdPartyAccountAuthApplier<T>::load_acct_info(RGWUserInfo& user_info) 
     if (ret < 0) {
       /* We aren't trying to recover from ENOENT here. It's supposed that creating
        * someone else's account isn't a thing we want to support in this filter. */
-      throw ret;
+      if (ret == -ENOENT) {
+        throw -EACCES;
+      } else {
+        throw ret;
+      }
     }
 
   }

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -71,7 +71,7 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
 };
 
 const static struct rgw_http_errors RGW_HTTP_SWIFT_ERRORS[] = {
-    { EACCES, 401, "AccessDenied" },
+    { EACCES, 403, "AccessDenied" },
     { EPERM, 401, "AccessDenied" },
     { ERR_USER_SUSPENDED, 401, "UserSuspended" },
     { ERR_INVALID_UTF8, 412, "Invalid UTF8" },

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3051,7 +3051,7 @@ int RGWPutMetadataAccount::verify_permission()
    * override in rgw_process.cc. This is the way to specify a given RGWOp
    * expect extra privileges.  */
   if (new_quota_extracted) {
-    return -EPERM;
+    return -EACCES;
   }
 
   return 0;

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -678,6 +678,20 @@ static int get_delete_at_param(req_state *s, real_time *delete_at)
   return 0;
 }
 
+int RGWPutObj_ObjStore_SWIFT::verify_permission()
+{
+  op_ret = RGWPutObj_ObjStore::verify_permission();
+
+  /* We have to differentiate error codes depending on whether user is
+   * anonymous (401 Unauthorized) or he doesn't have necessary permissions
+   * (403 Forbidden). */
+  if (s->auth_identity->is_anonymous() && op_ret == -EACCES) {
+    return -EPERM;
+  } else {
+    return op_ret;
+  }
+}
+
 int RGWPutObj_ObjStore_SWIFT::get_params()
 {
   if (s->has_bad_meta) {
@@ -966,6 +980,20 @@ static void bulkdelete_respond(const unsigned num_deleted,
   formatter.close_section();
 
   formatter.close_section();
+}
+
+int RGWDeleteObj_ObjStore_SWIFT::verify_permission()
+{
+  op_ret = RGWDeleteObj_ObjStore::verify_permission();
+
+  /* We have to differentiate error codes depending on whether user is
+   * anonymous (401 Unauthorized) or he doesn't have necessary permissions
+   * (403 Forbidden). */
+  if (s->auth_identity->is_anonymous() && op_ret == -EACCES) {
+    return -EPERM;
+  } else {
+    return op_ret;
+  }
 }
 
 int RGWDeleteObj_ObjStore_SWIFT::get_params()

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -95,6 +95,7 @@ public:
   RGWPutObj_ObjStore_SWIFT() {}
   ~RGWPutObj_ObjStore_SWIFT() {}
 
+  int verify_permission() override;
   int get_params();
   void send_response();
 };
@@ -132,6 +133,7 @@ public:
   RGWDeleteObj_ObjStore_SWIFT() {}
   ~RGWDeleteObj_ObjStore_SWIFT() {}
 
+  int verify_permission() override;
   int get_params();
   bool need_object_expiration() { return true; }
   void send_response();


### PR DESCRIPTION
We have to differentiate the error codes depending on whether user is
anonymous (401 Unauthorized) or he doesn't have necessary permissions
(403 Forbidden). The reason behind that is the change in Tempest. See
commit ID: 6b1cd29b763dbc556137c89c5fed54c624da7f69.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>

-- 

CC: @yehudasa, @cbodley.