### PR TITLE
cmake FreeBSD changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,24 @@ endif (POLICY CMP0023)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 
+# find out which platform we are building on
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  message(STATUS "Building for Linux.")
+  set(LINUX ON)
+  set(UNIX ON)
+  FIND_PACKAGE(Threads)
+elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+  message(STATUS "Building for FreeBSD.")
+  set(FREEBSD ON)
+  set(UNIX ON)
+  FIND_PACKAGE(Threads)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  message(STATUS "Building for Darwin.")
+  set(OperatingSystem "Mac OS X")
+else()
+  message(STATUS "No systemtype selected for building")
+endif(CMAKE_SYSTEM_NAME MATCHES "Linux")
+
 option(WITH_CCACHE "Build with ccache.")
 if(WITH_CCACHE)
   find_program(CCACHE_FOUND ccache)
@@ -54,6 +72,12 @@ link_directories(
   ${OFED_PREFIX}/lib
   ${LEVELDB_PREFIX}/lib
 )
+if(FREEBSD)
+  include_directories(/usr/local/include)
+  link_directories(/usr/local/lib)
+  list(APPEND CMAKE_REQUIRED_INCLUDES /usr/local/include)
+endif(FREEBSD)
+
 
 #put all the libs and binaries in one place
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -103,7 +127,12 @@ CHECK_INCLUDE_FILES("sys/types.h" HAVE_SYS_TYPES_H)
 CHECK_INCLUDE_FILES("sys/vfs.h" HAVE_SYS_VFS_H)
 CHECK_INCLUDE_FILES("sys/prctl.h" HAVE_SYS_PRCTL_H)
 CHECK_INCLUDE_FILES("execinfo.h" HAVE_EXECINFO_H)
+if(LINUX)
 CHECK_INCLUDE_FILES("sched.h" HAVE_SCHED)
+endif(LINUX)
+if(FREEBSD)
+CHECK_INCLUDE_FILES("sched.h" HAVE_SCHED_FREEBSD)
+endif(FREEBSD)
 CHECK_INCLUDE_FILES("valgrind/helgrind.h" HAVE_VALGRIND_HELGRIND_H)
 
 include(CheckTypeSize)
@@ -154,15 +183,24 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ${ENABLE_SHARED})
 
 find_package(execinfo)
 
-find_package(udev REQUIRED)
-set(HAVE_UDEV ${UDEV_FOUND})
+if(LINUX)
+  find_package(udev REQUIRED)
+  set(HAVE_UDEV ${UDEV_FOUND})
 
-option(WITH_AIO "AIO is here ON" ON)
-if(${WITH_AIO})
-find_package(aio REQUIRED)
-set(HAVE_LIBAIO ${AIO_FOUND})
-message(STATUS "${AIO_LIBS}")
-endif(${WITH_AIO})
+  find_package(aio REQUIRED)
+  set(HAVE_LIBAIO ${AIO_FOUND})
+  message(STATUS "${AIO_LIBS}")
+
+  find_package(blkid REQUIRED)
+  set(HAVE_BLKID ${BLKID_FOUND})
+else()
+  set(HAVE_UDEV OFF)
+  message(STATUS "Not using udev")
+  set(HAVE_LIBAIO OFF)
+  message(STATUS "Not using AIO")
+  set(HAVE_BLKID OFF)
+  message(STATUS "Not using BLKID")
+endif(LINUX)
 
 option(WITH_OPENLDAP "OPENLDAP is here" ON)
 if(${WITH_OPENLDAP})
@@ -189,8 +227,6 @@ if(WITH_SPDK)
   find_package(dpdk REQUIRED)
   set(HAVE_SPDK TRUE)
 endif(WITH_SPDK)
-
-find_package(blkid REQUIRED)
 
 # needs mds and? XXX
 option(WITH_LIBCEPHFS "libcephfs client library" ON)
@@ -260,7 +296,10 @@ else(ALLOCATOR)
   endif(Tcmalloc_FOUND)
 endif(ALLOCATOR)
 
-find_package(keyutils REQUIRED)
+if(NOT FREEBSD)
+  # XXX keyutils is available, but not yet recognised
+  find_package(keyutils REQUIRED)
+endif(NOT FREEBSD)
 
 find_package(libuuid REQUIRED)
 
@@ -344,7 +383,9 @@ option(HAVE_LIBZFS "LibZFS is enabled" OFF)
 option(ENABLE_COVERAGE "Coverage is enabled" OFF)
 option(PG_DEBUG_REFS "PG Ref debugging is enabled" OFF)
 
-add_definitions(-D__linux__)
+if(LINUX)
+  add_definitions(-D__linux__)
+endif(LINUX)
 
 if(ENABLE_SHARED)
   set(Boost_USE_STATIC_LIBS   OFF)
@@ -368,18 +409,6 @@ if(WITH_SELINUX)
   endif()
   add_subdirectory(selinux)
 endif(WITH_SELINUX)
-
-# find out which platform we are building on
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  set(LINUX ON)
-  set(UNIX ON)
-  FIND_PACKAGE(Threads)
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-
-# find out which platform we are building on
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-set(OperatingSystem "Mac OS X")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 # enables testing and creates Make check command
 add_custom_target(tests

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -1,5 +1,22 @@
 #AddCephTest is a module for adding tests to the "make check" target which runs CTest
 
+execute_process(
+    COMMAND uname -m
+    OUTPUT_VARIABLE ARCHSTR
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(LINUX)
+  set(OSSTR linux)
+  set(PYVER 2.7)
+elseif(FREEBSD)
+  execute_process(
+    COMMAND uname -r
+    OUTPUT_VARIABLE OSVER
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(OSSTR freebsd-${OSVER})
+  set(PYVER 2.7)
+endif(LINUX)
+
 #adds makes target/script into a test, test to check target, sets necessary environment variables
 function(add_ceph_test test_name test_path)
   add_test(NAME ${test_name} COMMAND ${test_path})
@@ -13,7 +30,7 @@ function(add_ceph_test test_name test_path)
     CEPH_BUILD_DIR=${CMAKE_BINARY_DIR}
     LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib
     PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}:${CMAKE_SOURCE_DIR}/src:$ENV{PATH}
-    PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.linux-x86_64-2.7:${CMAKE_SOURCE_DIR}/src/pybind
+    PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.${OSSTR}-${ARCHSTR}-${PYVER}:${CMAKE_SOURCE_DIR}/src/pybind
     CEPH_BUILD_VIRTUALENV=${CEPH_BUILD_VIRTUALENV})
   # none of the tests should take more than 1 hour to complete
   set_property(TEST

--- a/cmake/modules/FindNSS.cmake
+++ b/cmake/modules/FindNSS.cmake
@@ -32,6 +32,7 @@ else (NSS_LIBRARIES AND NSS_INCLUDE_DIRS)
       /usr/local/include
       /opt/local/include
       /sw/include
+      /usr/local/include/nss
     PATH_SUFFIXES
       nss3
       nss

--- a/do_freebsd-cmake.sh
+++ b/do_freebsd-cmake.sh
@@ -1,0 +1,36 @@
+#!/bin/sh -xve
+NPROC=`sysctl -n hw.ncpu`
+
+if [ x"$1"x = x"--deps"x ]; then
+    # we need bash first otherwise almost nothing will work
+    sudo pkg install bash
+    if [ ! -L /bin/bash ]; then
+        echo linking /bin/bash to /usr/local/bin/bash
+        ln -s /usr/local/bin/bash /bin/bash
+    fi
+    sudo ./install-deps.sh
+fi
+rm -rf build && ./do_cmake.sh "$*" \
+	-D CMAKE_BUILD_TYPE=Debug \
+	-D ENABLE_GIT_VERSION=OFF \
+	-D WITH_BLKID=OFF \
+	-D WITH_FUSE=OFF \
+	-D WITH_RBD=OFF \
+	-D WITH_XFS=OFF \
+	-D WITH_KVS=OFF \
+	-D WITH_MANPAGE=OFF \
+	-D WITH_LIBCEPHFS=OFF \
+	-D WITH_CEPHFS=OFF \
+	-D WITH_RADOSGW=OFF \
+	2>&1 | tee cmake.log 
+
+cd src/gmock/gtest 
+if patch -sN < /usr/ports/devel/googletest/files/patch-bsd-defines ; then  
+  patch < /usr/ports/devel/googletest/files/patch-bsd-defines 
+fi
+cd ../../..
+
+cd build 
+gmake -j$NPROC V=1 VERBOSE=1 | tee build.log 2>&1
+gmake -j$NPROC check CEPH_BUFFER_NO_BENCH=yes | tee check.log 2>&1
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,7 +298,7 @@ elseif(ALLOCATOR STREQUAL "jemalloc")
   set(TCMALLOC_srcs perfglue/disabled_heap_profiler.cc)
 elseif(ALLOCATOR STREQUAL "libc")
   set(TCMALLOC_srcs perfglue/disabled_heap_profiler.cc)
-endif()
+endif(ALLOCATOR STREQUAL "tcmalloc")
 
 # tcmalloc heap profiler
 set(heap_profiler_files ${TCMALLOC_srcs})
@@ -492,7 +492,7 @@ set(libcommon_files
   common/dns_resolve.cc
   common/armor.c
   common/safe_io.c
-  common/addr_parsing.c)
+  common/addr_parsing.c
   ${arch_files}
   ${auth_files}
   $<TARGET_OBJECTS:compressor_objs>
@@ -923,9 +923,14 @@ endif(WITH_SPDK)
 if(NOT ALLOCATOR STREQUAL "jemalloc")
   set(disable_jemalloc "DISABLE_JEMALLOC=1")
 endif()
+set(EXTRA_CXXFLAGS -fPIC -Wno-unused-variable)
+if(FREEBSD)
+  set(EXTRA_CXXFLAGS ${EXTRA_CXXFLAGS} -Irocksdb/include -I/usr/local/include)
+  set(MAKEFLAGS ${MAKEFLAGS})
+endif(FREEBSD)
 add_custom_target(build_rocksdb
     COMMAND
-    PORTABLE=1 ${disable_jemalloc} $(MAKE) static_lib EXTRA_CXXFLAGS='-fPIC -Wno-unused-variable'
+    PORTABLE=1 ${disable_jemalloc} $(MAKE) ${MAKEFLAGS} static_lib EXTRA_CXXFLAGS="${EXTRA_CXXFLAGS}"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/rocksdb
     COMMENT "rocksdb building")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ else(no_yasm)
     COMMAND uname -m
     OUTPUT_VARIABLE arch
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if(arch STREQUAL "x86_64")
+  if(arch MATCHES "x86_64|amd64")
     message(STATUS " we are x84_64")
     set(save_quiet ${CMAKE_REQUIRED_QUIET})
     set(CMAKE_REQUIRED_QUIET true)
@@ -110,9 +110,9 @@ else(no_yasm)
     else(not_arch_x32)
       message(STATUS " we are x32; no yasm for you")
     endif(not_arch_x32)
-  else(arch STREQUAL "x86_64")
+  else(arch MATCHES "x86_64|amd64")
     message(STATUS " we are not x86_64 && !x32")
-  endif(arch STREQUAL "x86_64")
+  endif(arch MATCHES "x86_64|amd64")
 endif(no_yasm)
 
 
@@ -169,12 +169,15 @@ try_compile(INTEL_SSE4_1 ${CMAKE_BINARY_DIR} ${sse_srcs}
   COMPILE_DEFINITIONS "-msse4.1")
 try_compile(INTEL_SSE4_2 ${CMAKE_BINARY_DIR} ${sse_srcs}
   COMPILE_DEFINITIONS "-msse4.2")
-try_compile(ARM_NEON ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-mfpu=neon")
-try_compile(ARM_NEON2 ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-march=armv8-a+simd")
-try_compile(ARM_CRC ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-march=armv8-a+crc")
+
+if(NOT arch MATCHES "x84_64|amd64")
+  try_compile(ARM_NEON ${CMAKE_BINARY_DIR} ${sse_srcs}
+    COMPILE_DEFINITIONS "-mfpu=neon")
+  try_compile(ARM_NEON2 ${CMAKE_BINARY_DIR} ${sse_srcs}
+    COMPILE_DEFINITIONS "-march=armv8-a+simd")
+  try_compile(ARM_CRC ${CMAKE_BINARY_DIR} ${sse_srcs}
+    COMPILE_DEFINITIONS "-march=armv8-a+crc")
+if(NOT arch MATCHES "x84_64|amd64")
 
 # clean up tmp file
 file(REMOVE ${sse_srcs})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,17 +17,32 @@ set(prefix ${CMAKE_INSTALL_PREFIX})
 
 add_definitions("-DCEPH_LIBDIR=\"${CMAKE_INSTALL_FULL_LIBDIR}\"")
 add_definitions("-DCEPH_PKGLIBDIR=\"${CMAKE_INSTALL_FULL_PKGLIBDIR}\"")
-add_definitions("-DHAVE_CONFIG_H -D__CEPH__ -D_FILE_OFFSET_BITS=64 -D_REENTRANT -D_THREAD_SAFE -D__STDC_FORMAT_MACROS -D_GNU_SOURCE")
+add_definitions("-DHAVE_CONFIG_H -D__CEPH__ -D_REENTRANT -D_THREAD_SAFE -D__STDC_FORMAT_MACROS")
 
-set(CMAKE_ASM_COMPILER  ${PROJECT_SOURCE_DIR}/src/yasm-wrapper)
-set(CMAKE_ASM_FLAGS "-f elf64")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -rdynamic -Wall -Wtype-limits -Wignored-qualifiers -Winit-self -Wpointer-arith -Werror=format-security -fno-strict-aliasing -fsigned-char")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wtype-limits -Wignored-qualifiers -Winit-self") 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Werror=format-security -fno-strict-aliasing -fsigned-char")
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  add_definitions("-D_GNU_SOURCE -D_FILE_OFFSET_BITS=64")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -rdynamic")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_EXE_LINKER_FLAGS "-Wl,-export-dynamic")
+  set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -rdynamic -Wl,-export-dynamic -export-dynamic")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-inconsistent-missing-override")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-mismatched-tags -Wno-unused-function")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-local-typedef -Wno-inconsistent-missing-override")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-private-field -Wno-varargs")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-gnu-designator -Wno-mismatched-tags")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-braces -Wno-parentheses -Wno-deprecated-register")
+endif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Default BUILD_TYPE is RelWithDebInfo, other options are: Debug, Release, and MinSizeRel." FORCE) 
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" 
+	CACHE STRING "Default BUILD_TYPE is RelWithDebInfo, other options are: Debug, Release, and MinSizeRel." 
+	FORCE) 
 endif()
 
-if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   # we use assert(3) for testing, so scrub the -DNDEBUG defined by default
   string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type_upper)
   foreach(flags
@@ -35,20 +50,26 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
       CMAKE_C_FLAGS_${build_type_upper})
     string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " " "${flags}" "${${flags}}")
   endforeach()
-endif()
+elseif(CMAKE_BUILD_TYPE STREQUAL Debug)
+  set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
+endif(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
 
 include(CheckCCompilerFlag)
-CHECK_C_COMPILER_FLAG("-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2" HAS_FORTIFY_SOURCE)
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-if(HAS_FORTIFY_SOURCE)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2")
-endif()
-endif()
-CHECK_C_COMPILER_FLAG(-fstack-protector-strong HAS_STACK_PROTECT)
-if (HAS_STACK_PROTECT)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-strong")
-endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  CHECK_C_COMPILER_FLAG("-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2" HAS_FORTIFY_SOURCE)
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if(HAS_FORTIFY_SOURCE)
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2")
+    endif()
+  endif()
+  CHECK_C_COMPILER_FLAG(-fstack-protector-strong HAS_STACK_PROTECT)
+  if (HAS_STACK_PROTECT)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-strong")
+  endif()
+endif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
+set(CMAKE_ASM_COMPILER  ${PROJECT_SOURCE_DIR}/src/yasm-wrapper)
+set(CMAKE_ASM_FLAGS "-f elf64")
 execute_process(
   COMMAND yasm -f elf64 ${CMAKE_SOURCE_DIR}/src/common/crc32c_intel_fast_asm.S -o /dev/null
   RESULT_VARIABLE no_yasm
@@ -95,7 +116,11 @@ else(no_yasm)
 endif(no_yasm)
 
 
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -ftemplate-depth-1024 -Wno-invalid-offsetof -Wnon-virtual-dtor -Wno-invalid-offsetof -Wstrict-null-sentinel -Woverloaded-virtual")
+set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -ftemplate-depth-1024 -Wno-invalid-offsetof")
+set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wnon-virtual-dtor -Wno-invalid-offsetof -Woverloaded-virtual")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wstrict-null-sentinel")
+endif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
 # require c++11
 if(CMAKE_VERSION VERSION_LESS "3.1")
@@ -462,6 +487,15 @@ set(libcommon_files
   ${auth_files}
   $<TARGET_OBJECTS:compressor_objs>
   ${mds_files})
+
+if(LINUX)
+  list(APPEND libcommon_files msg/async/EventEpoll.cc)
+  message(STATUS " Using EventEpoll for events.")
+elseif(FREEBSD)
+  list(APPEND libcommon_files msg/async/EventKqueue.cc)
+  message(STATUS " Using EventKqueue for events.")
+endif(LINUX)
+
 set(mon_common_files
   auth/AuthSessionHandler.cc
   auth/cephx/CephxSessionHandler.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -869,7 +869,7 @@ set(libos_srcs
   os/kstore/kstore_types.cc
   os/fs/FS.cc
   ${libos_xfs_srcs})
-if(${WITH_AIO})
+if(HAVE_LIBAIO)
   list(APPEND libos_srcs
     os/bluestore/kv.cc
     os/bluestore/Allocator.cc
@@ -891,7 +891,7 @@ else()
   list(APPEND libos_srcs
     os/kstore/kv.cc
   )
-endif(${WITH_AIO})
+endif(HAVE_LIBAIO)
 if(${HAVE_LIBFUSE})
   list(APPEND libos_srcs
     os/FuseStore.cc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ if(NOT CMAKE_BUILD_TYPE)
 	FORCE) 
 endif()
 
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
   # we use assert(3) for testing, so scrub the -DNDEBUG defined by default
   string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type_upper)
   foreach(flags
@@ -50,9 +50,10 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
       CMAKE_C_FLAGS_${build_type_upper})
     string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " " "${flags}" "${${flags}}")
   endforeach()
-elseif(CMAKE_BUILD_TYPE STREQUAL Debug)
+elseif(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
-endif(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
+  message(STATUS "Compiling with debugging ON")
+endif(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
 
 include(CheckCCompilerFlag)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
@@ -177,7 +178,7 @@ if(NOT arch MATCHES "x84_64|amd64")
     COMPILE_DEFINITIONS "-march=armv8-a+simd")
   try_compile(ARM_CRC ${CMAKE_BINARY_DIR} ${sse_srcs}
     COMPILE_DEFINITIONS "-march=armv8-a+crc")
-if(NOT arch MATCHES "x84_64|amd64")
+endif(NOT arch MATCHES "x84_64|amd64")
 
 # clean up tmp file
 file(REMOVE ${sse_srcs})
@@ -224,8 +225,12 @@ else(INTEL_SSE4_1)
   message(STATUS "Skipping target ec_jerasure_sse4 & ec_shec_sse4: -msse4.1 not supported")
 endif(INTEL_SSE4_1)
 
-
-set(EXTRALIBS uuid rt ${CMAKE_DL_LIBS} ${ATOMIC_OPS_LIBRARIES})
+set(EXTRALIBS rt ${ATOMIC_OPS_LIBRARIES})
+if(LINUX)
+  set(LIB_RESOLV resolv)
+  set(LIB_UUID uuid)
+  list(APPEND EXTRALIBS ${LIB_RESOLV} ${CMAKE_DL_LIBS} ${LIB_UUID})
+endif(LINUX)
 
 if(${WITH_PROFILER})
   list(APPEND EXTRALIBS profiler)
@@ -434,7 +439,6 @@ set(libcommon_files
   msg/async/AsyncConnection.cc
   msg/async/AsyncMessenger.cc
   msg/async/Event.cc
-  msg/async/EventEpoll.cc
   msg/async/EventSelect.cc
   msg/async/net_handler.cc
   ${xio_common_srcs}
@@ -486,6 +490,9 @@ set(libcommon_files
   common/Graylog.cc
   common/fs_types.cc
   common/dns_resolve.cc
+  common/armor.c
+  common/safe_io.c
+  common/addr_parsing.c)
   ${arch_files}
   ${auth_files}
   $<TARGET_OBJECTS:compressor_objs>
@@ -504,13 +511,15 @@ set(mon_common_files
   auth/cephx/CephxSessionHandler.cc
   erasure-code/ErasureCodePlugin.cc)
 add_library(mon_common_objs OBJECT ${mon_common_files})
-set(common_mountcephfs_files
-  common/armor.c
-  common/safe_io.c
-  common/module.c
-  common/addr_parsing.c)
-add_library(common_mountcephfs_objs OBJECT
-  ${common_mountcephfs_files})
+
+if(LINUX)
+  list(APPEND libcommon_files
+    common/module.c )
+  set(common_mountcephfs_files
+    common/module.c )
+  add_library(common_mountcephfs_objs OBJECT
+    ${common_mountcephfs_files})
+endif(LINUX)
 
 if(${HAVE_GPERFTOOLS})
   list(APPEND libcommon_files
@@ -526,9 +535,12 @@ if(ENABLE_SHARED)
 endif(ENABLE_SHARED)
 
 add_library(common STATIC ${libcommon_files}
-  $<TARGET_OBJECTS:mon_common_objs>
-  $<TARGET_OBJECTS:common_mountcephfs_objs>)
-target_link_libraries(common ${CRYPTO_LIBS} ${CMAKE_DL_LIBS})
+  $<TARGET_OBJECTS:mon_common_objs>)
+if(WITH_LIBCEPHFS)
+  list(APPEND common STATIC ${libcommon_files}
+    $<TARGET_OBJECTS:common_mountcephfs_objs>)
+endif(WITH_LIBCEPHFS)
+target_link_libraries(common ${CMAKE_DL_LIBS})
 
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ceph_ver.c
   ${CMAKE_SOURCE_DIR}/src/common/version.cc
@@ -547,7 +559,7 @@ endif(${HAVE_ARMV8_CRC})
 
 add_library(common_utf8 STATIC common/utf8.c)
 
-target_link_libraries(common json_spirit common_utf8 erasure_code rt uuid resolv ${CRYPTO_LIBS} ${Boost_LIBRARIES} ${BLKID_LIBRARIES} ${EXECINFO_LIBRARIES})
+target_link_libraries(common json_spirit common_utf8 erasure_code ${EXTRALIBS} ${LIB_RESOLV} ${CRYPTO_LIBS} ${Boost_LIBRARIES} ${BLKID_LIBRARIES} ${EXECINFO_LIBRARIES})
 
 if(${WITH_LTTNG})
   add_subdirectory(tracing)
@@ -651,9 +663,11 @@ add_executable(ceph-objectstore-tool
   tools/ceph_objectstore_tool.cc
   tools/RadosDump.cc
   $<TARGET_OBJECTS:common_util_obj>)
-target_link_libraries(ceph-objectstore-tool osd os global ${Boost_PROGRAM_OPTIONS_LIBRARY} fuse ${CMAKE_DL_LIBS})
+target_link_libraries(ceph-objectstore-tool osd os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${CMAKE_DL_LIBS})
+if(WITH_FUSE)
+  target_link_libraries(ceph-objectstore-tool fuse)
+endif(WITH_FUSE)
 install(TARGETS ceph-objectstore-tool DESTINATION bin)
-
 
 set(rados_srcs
   tools/rados/rados.cc
@@ -732,8 +746,6 @@ endif()
 
 set(dencoder_srcs
   test/encoding/ceph_dencoder.cc
-  $<TARGET_OBJECTS:krbd_objs>
-  $<TARGET_OBJECTS:parse_secret_objs>
   $<TARGET_OBJECTS:common_texttable_obj>
   )
 if(${WITH_RADOSGW})
@@ -754,15 +766,19 @@ if(${WITH_RADOSGW})
   )
 endif(${WITH_RADOSGW})
 if(${WITH_RBD})
-  set(DENCODER_EXTRALIBS
-      ${DENCODER_EXTRALIBS}
-      rbd_replay_types)
+  list(APPEND DENCODER_EXTRALIBS
+      rbd_replay_types udev)
+  list(APPEND dencoder_srcs
+      $<TARGET_OBJECTS:krbd_objs>)
 endif(${WITH_RBD})
+if(${WITH_KVS})
+  list(APPEND dencoder_srcs
+      $<TARGET_OBJECTS:parse_secret_objs>)
+endif(${WITH_KVS})
 
 add_executable(ceph-dencoder ${dencoder_srcs})
 target_link_libraries(ceph-dencoder
   librados
-  librbd
   global
   os
   osd
@@ -780,13 +796,13 @@ target_link_libraries(ceph-dencoder
   cls_user_client
   cls_journal_client
   cls_timeindex_client
-  blkid
-  udev
-  keyutils
-  rbd_replay
   ${EXTRALIBS}
   ${CMAKE_DL_LIBS}
   )
+if(${WITH_KVS})
+  target_link_libraries(ceph-dencoder
+      keyutils)
+endif(${WITH_KVS})
 install(TARGETS ceph-dencoder DESTINATION bin)
 
 # Monitor
@@ -851,23 +867,31 @@ set(libos_srcs
   os/memstore/MemStore.cc
   os/kstore/KStore.cc
   os/kstore/kstore_types.cc
-  os/bluestore/kv.cc
-  os/bluestore/Allocator.cc
-  os/bluestore/BitmapFreelistManager.cc
-  os/bluestore/BlockDevice.cc
-  os/bluestore/BlueFS.cc
-  os/bluestore/bluefs_types.cc
-  os/bluestore/BlueRocksEnv.cc
-  os/bluestore/BlueStore.cc
-  os/bluestore/bluestore_types.cc
-  os/bluestore/ExtentFreelistManager.cc
-  os/bluestore/FreelistManager.cc
-  os/bluestore/KernelDevice.cc
-  os/bluestore/StupidAllocator.cc
-  os/bluestore/BitMapAllocator.cc
-  os/bluestore/BitAllocator.cc
   os/fs/FS.cc
   ${libos_xfs_srcs})
+if(${WITH_AIO})
+  list(APPEND libos_srcs
+    os/bluestore/kv.cc
+    os/bluestore/Allocator.cc
+    os/bluestore/BitmapFreelistManager.cc
+    os/bluestore/BlockDevice.cc
+    os/bluestore/BlueFS.cc
+    os/bluestore/bluefs_types.cc
+    os/bluestore/BlueRocksEnv.cc
+    os/bluestore/BlueStore.cc
+    os/bluestore/bluestore_types.cc
+    os/bluestore/ExtentFreelistManager.cc
+    os/bluestore/FreelistManager.cc
+    os/bluestore/KernelDevice.cc
+    os/bluestore/StupidAllocator.cc
+    os/bluestore/BitMapAllocator.cc
+    os/bluestore/BitAllocator.cc
+  )
+else()
+  list(APPEND libos_srcs
+    os/kstore/kv.cc
+  )
+endif(${WITH_AIO})
 if(${HAVE_LIBFUSE})
   list(APPEND libos_srcs
     os/FuseStore.cc)
@@ -1120,9 +1144,11 @@ install(PROGRAMS
 
 add_subdirectory(bash_completion)
 
-set(parse_secret_files
-  common/secret.c)
-add_library(parse_secret_objs OBJECT ${parse_secret_files})
+if(WITH_KVS)
+  set(parse_secret_files
+    common/secret.c)
+  add_library(parse_secret_objs OBJECT ${parse_secret_files})
+endif(WITH_KVS)
 
 if(WITH_LIBCEPHFS)
   set(libclient_srcs
@@ -1194,15 +1220,51 @@ set(journal_srcs
   journal/Utils.cc)
 add_library(journal STATIC ${journal_srcs})
 
-add_library(krbd_objs OBJECT krbd.cc)
+if(WITH_RBD)
+  add_library(krbd_objs OBJECT krbd.cc)
 
-if(${WITH_RBD})
   add_subdirectory(librbd)
   install(FILES
     include/rbd/features.h
     include/rbd/librbd.h
     include/rbd/librbd.hpp
     DESTINATION include/rbd)
+
+  add_executable(rbd-nbd tools/rbd_nbd/rbd-nbd.cc)
+  target_link_libraries(rbd-nbd librbd librados global
+    ${Boost_REGEX_LIBRARY})
+if(WITH_KVS)
+  add_dependencies(rbd-nbd
+    $<TARGET_OBJECTS:parse_secret_objs>)
+  target_link_libraries(rbd-nbd keyutils)
+endif(WITH_KVS)
+
+
+  set(rbd_mirror_internal
+    tools/rbd_mirror/ClusterWatcher.cc
+    tools/rbd_mirror/ImageReplayer.cc
+    tools/rbd_mirror/ImageDeleter.cc
+    tools/rbd_mirror/ImageSync.cc
+    tools/rbd_mirror/ImageSyncThrottler.cc
+    tools/rbd_mirror/Mirror.cc
+    tools/rbd_mirror/PoolWatcher.cc
+    tools/rbd_mirror/Replayer.cc
+    tools/rbd_mirror/Threads.cc
+    tools/rbd_mirror/types.cc
+    tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+    tools/rbd_mirror/image_replayer/CloseImageRequest.cc
+    tools/rbd_mirror/image_replayer/CreateImageRequest.cc
+    tools/rbd_mirror/image_replayer/OpenImageRequest.cc
+    tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
+    tools/rbd_mirror/image_replayer/ReplayStatusFormatter.cc
+    tools/rbd_mirror/image_sync/ImageCopyRequest.cc
+    tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
+    tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc
+    tools/rbd_mirror/image_sync/SnapshotCreateRequest.cc
+    tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc
+    tools/rbd_mirror/image_sync/SyncPointPruneRequest.cc)
+  add_library(rbd_mirror_internal STATIC
+    ${rbd_mirror_internal})
 
   if(WITH_FUSE)
     add_executable(rbd-fuse
@@ -1212,22 +1274,93 @@ if(${WITH_RBD})
     install(TARGETS rbd-fuse DESTINATION bin)
   endif()
 
+  add_executable(rbd-mirror
+    tools/rbd_mirror/main.cc
+    common/ContextCompletion.cc)
+  target_link_libraries(rbd-mirror
+    rbd_mirror_internal
+    rbd_internal
+    rbd_api
+    rbd_types
+    journal
+    librados
+    osdc
+    cls_rbd_client
+    cls_lock_client
+    cls_journal_client
+    global)
+
+  set(rbd_srcs
+    tools/rbd/rbd.cc
+    tools/rbd/ArgumentTypes.cc
+    tools/rbd/IndentStream.cc
+    tools/rbd/OptionPrinter.cc
+    tools/rbd/Shell.cc
+    tools/rbd/Utils.cc
+    tools/rbd/action/Bench.cc
+    tools/rbd/action/Children.cc
+    tools/rbd/action/Clone.cc
+    tools/rbd/action/Copy.cc
+    tools/rbd/action/Create.cc
+    tools/rbd/action/Diff.cc
+    tools/rbd/action/DiskUsage.cc
+    tools/rbd/action/Export.cc
+    tools/rbd/action/ExportDiff.cc
+    tools/rbd/action/Feature.cc
+    tools/rbd/action/Flatten.cc
+    tools/rbd/action/Group.cc
+    tools/rbd/action/ImageMeta.cc
+    tools/rbd/action/Import.cc
+    tools/rbd/action/ImportDiff.cc
+    tools/rbd/action/Info.cc
+    tools/rbd/action/Journal.cc
+    tools/rbd/action/Kernel.cc
+    tools/rbd/action/List.cc
+    tools/rbd/action/Lock.cc
+    tools/rbd/action/MergeDiff.cc
+    tools/rbd/action/MirrorPool.cc
+    tools/rbd/action/MirrorImage.cc
+    tools/rbd/action/Nbd.cc
+    tools/rbd/action/ObjectMap.cc
+    tools/rbd/action/Remove.cc
+    tools/rbd/action/Rename.cc
+    tools/rbd/action/Resize.cc
+    tools/rbd/action/Snap.cc
+    tools/rbd/action/Status.cc
+    tools/rbd/action/Watch.cc)
+  add_executable(rbd ${rbd_srcs}
+    $<TARGET_OBJECTS:common_util_obj>
+    $<TARGET_OBJECTS:common_texttable_obj>
+    $<TARGET_OBJECTS:krbd_objs>)
+  set_target_properties(rbd PROPERTIES OUTPUT_NAME rbd)
+  target_link_libraries(rbd librbd librados global common
+    ${Boost_REGEX_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+if(HAVE_UDEV)
+  target_link_libraries(rbd udev)
+endif(HAVE_UDEV)
+if(HAVE_KVS)
+  target_link_libraries(rbd keyutils)
+  add_executable(rbd ${rbd_srcs}
+    $<TARGET_OBJECTS:parse_secret_objs>)
+endif(HAVE_KVS)
+  install(TARGETS rbd rbd-nbd rbd-mirror DESTINATION bin)
   install(PROGRAMS
     ${CMAKE_SOURCE_DIR}/src/ceph-rbdnamer
     ${CMAKE_SOURCE_DIR}/src/rbd-replay-many
     ${CMAKE_SOURCE_DIR}/src/rbdmap
     DESTINATION ${CMAKE_INSTALL_BINDIR})
   add_subdirectory(rbd_replay)
-endif(${WITH_RBD})
+endif(WITH_RBD)
 
 # RadosGW
-if(${WITH_KVS})
+if(WITH_KVS)
   set(kvs_srcs
     key_value_store/cls_kvs.cc)
   add_library(cls_kvs SHARED ${kvs_srcs})
   set_target_properties(cls_kvs PROPERTIES VERSION "1.0.0" SOVERSION "1")
   install(TARGETS cls_kvs DESTINATION ${CMAKE_INSTALL_LIBDIR}/rados-classes)
-endif(${WITH_KVS})
+endif(WITH_KVS)
 
 if(${WITH_RADOSGW})
 
@@ -1357,7 +1490,7 @@ if(${WITH_RADOSGW})
     cls_replica_log_client
     cls_user_client
     curl expat global
-    resolv)
+    ${LIB_RESOLV})
   set_target_properties(rgw PROPERTIES OUTPUT_NAME rgw VERSION 2.0.0
     SOVERSION 1)
 
@@ -1372,7 +1505,7 @@ if(${WITH_RADOSGW})
     cls_rgw_client cls_lock_client cls_refcount_client
     cls_log_client cls_statelog_client cls_timeindex_client
     cls_version_client cls_replica_log_client cls_user_client
-    curl expat global fcgi resolv ${SSL_LIBRARIES} ${BLKID_LIBRARIES}
+    curl expat global fcgi ${LIB_RESOLV} ${SSL_LIBRARIES} ${BLKID_LIBRARIES}
     ${ALLOC_LIBS})
   # radosgw depends on cls libraries at runtime, but not as link dependencies
   add_dependencies(radosgw cls_rgw cls_lock cls_refcount
@@ -1385,7 +1518,7 @@ if(${WITH_RADOSGW})
     cls_rgw_client cls_lock_client cls_refcount_client
     cls_log_client cls_statelog_client cls_timeindex_client
     cls_version_client cls_replica_log_client cls_user_client
-    curl expat global fcgi resolv ${SSL_LIBRARIES} ${BLKID_LIBRARIES})
+    curl expat global fcgi ${LIB_RESOLV} ${SSL_LIBRARIES} ${BLKID_LIBRARIES})
 
   install(TARGETS radosgw-admin DESTINATION bin)
 
@@ -1399,7 +1532,7 @@ if(${WITH_RADOSGW})
     cls_rgw_client cls_lock_client cls_refcount_client
     cls_log_client cls_statelog_client cls_timeindex_client
     cls_version_client cls_replica_log_client cls_user_client
-    curl expat global fcgi resolv)
+    curl expat global fcgi ${LIB_RESOLV})
   install(TARGETS radosgw-object-expirer DESTINATION bin)
   add_subdirectory(rgw)
 endif(${WITH_RADOSGW})

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -71,13 +71,22 @@ if(WITH_LTTNG)
   add_dependencies(rbd_internal rbd-tp)
 endif()
 
-add_library(librbd ${CEPH_SHARED}
-  $<TARGET_OBJECTS:osdc_rbd_objs>
-  $<TARGET_OBJECTS:common_util_obj>
-  $<TARGET_OBJECTS:krbd_objs>
-  $<TARGET_OBJECTS:parse_secret_objs>  
-  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
-  librbd.cc)
+if(WITH_KVS)
+  add_library(librbd ${CEPH_SHARED}
+    $<TARGET_OBJECTS:osdc_rbd_objs>
+    $<TARGET_OBJECTS:common_util_obj>
+    $<TARGET_OBJECTS:krbd_objs>
+    $<TARGET_OBJECTS:parse_secret_objs>  
+    ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
+    librbd.cc)
+else()
+  add_library(librbd ${CEPH_SHARED}
+    $<TARGET_OBJECTS:osdc_rbd_objs>
+    $<TARGET_OBJECTS:common_util_obj>
+    $<TARGET_OBJECTS:krbd_objs>
+    ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
+    librbd.cc)
+endif(WITH_KVS)
 target_link_libraries(librbd LINK_PRIVATE 
   rbd_internal
   rbd_types

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -4,11 +4,21 @@ include(Distutils)
 set(CYTHON_MODULE_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules)
 
 add_subdirectory(rados)
-add_subdirectory(rbd)
-add_subdirectory(cephfs)
+if(WITH_RBD)
+  add_subdirectory(rbd)
+endif(WITH_RBD)
+if(WITH_CEPHFS)
+  add_subdirectory(cephfs)
+endif(WITH_CEPHFS)
 
 add_custom_target(cython_modules ALL
-  DEPENDS cython_rados cython_cephfs cython_rbd)
+  DEPENDS cython_rados)
+if(WITH_RBD)
+  add_dependencies(cython_modules cython_rbd)
+endif(WITH_RBD)
+if(WITH_CEPHFS)
+  add_dependencies(cython_modules cython_cephfs)
+endif(WITH_CEPHFS)
 
 # if CMAKE_INSTALL_PREFIX is an empty string, must replace
 # it with "/" to make PYTHON_INSTALL_TEMPLATE an absolute path to be

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -84,9 +84,11 @@ add_executable(test_build_librgw buildtest_skeleton.cc)
 target_link_libraries(test_build_librgw rgw_a global pthread ${CRYPTO_LIBS} ${EXTRALIBS})
 endif(${WITH_RADOSGW})
 
-# From src/test/Makefile-client.am: I dont get this one... testing the osdc build but link in libcephfs?
-add_executable(test_build_libcephfs buildtest_skeleton.cc)
-target_link_libraries(test_build_libcephfs cephfs expat pthread ${CRYPTO_LIBS} ${EXTRALIBS})
+if(WITH_LIBCEPHFS)
+  # From src/test/Makefile-client.am: I dont get this one... testing the osdc build but link in libcephfs?
+  add_executable(test_build_libcephfs buildtest_skeleton.cc)
+  target_link_libraries(test_build_libcephfs cephfs expat pthread ${CRYPTO_LIBS} ${EXTRALIBS})
+endif(WITH_LIBCEPHFS)
 
 add_executable(test_build_librados buildtest_skeleton.cc)
 target_link_libraries(test_build_librados librados pthread ${CRYPTO_LIBS} ${EXTRALIBS} osdc osd os common cls_lock_client ${BLKID_LIBRARIES})
@@ -131,6 +133,7 @@ target_link_libraries(ceph_omapbench
   ${CMAKE_DL_LIBS}
   )
 
+if(WITH_KVS)
 # ceph_kvstorebench
 set(kvstorebench_srcs
   kv_store_bench.cc
@@ -140,6 +143,10 @@ add_executable(ceph_kvstorebench
   ${kvstorebench_srcs}
   )
 target_link_libraries(ceph_kvstorebench librados global ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+install(TARGETS
+  ceph_kvstorebench
+  DESTINATION bin)
+endif(WITH_KVS)
 
 # ceph_objectstore_bench
 add_executable(ceph_objectstore_bench objectstore_bench.cc)
@@ -380,7 +387,6 @@ target_link_libraries(ceph_xattr_bench
 
 install(TARGETS
   ceph_bench_log
-  ceph_kvstorebench
   ceph_multi_stress_watch
   ceph_objectstore_bench
   ceph_omapbench
@@ -513,11 +519,15 @@ set_property(TEST test-ceph-helpers.sh ceph_objectstore_tool.py
 
 add_ceph_test(erasure-decode-non-regression.sh ${CMAKE_SOURCE_DIR}/qa/workunits/erasure-code/encode-decode-non-regression.sh)
 
-add_ceph_test(cephtool-test-mds.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-mds.sh)
+if(WITH_LIBCEPHFS)
+  add_ceph_test(cephtool-test-mds.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-mds.sh)
+endif(WITH_LIBCEPHFS)
 add_ceph_test(cephtool-test-mon.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-mon.sh)
 add_ceph_test(cephtool-test-osd.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-osd.sh)
 add_ceph_test(cephtool-test-rados.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-rados.sh)
-add_ceph_test(run-rbd-unit-tests.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh)
+if(WITH_RBD)
+  add_ceph_test(run-rbd-unit-tests.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh)
+endif(WITH_RBD)
 add_ceph_test(run-cli-tests ${CMAKE_CURRENT_SOURCE_DIR}/run-cli-tests)
 add_ceph_test(test_objectstore_memstore.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_objectstore_memstore.sh)
 add_ceph_test(test_pidfile.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_pidfile.sh)
@@ -764,13 +774,16 @@ target_link_libraries(unittest_daemon_config
   ${EXTRALIBS}
   )
 
+if(WITH_LIBCEPHFS)
 # unittest_libcephfs_config
 add_executable(unittest_libcephfs_config
   libcephfs_config.cc
   )
 add_ceph_unittest(unittest_libcephfs_config ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_libcephfs_config)
 target_link_libraries(unittest_libcephfs_config cephfs)
+endif(WITH_LIBCEPHFS)
 
+if(WITH_RBD)
 # unittest_rbd_replay
 add_executable(unittest_rbd_replay
   test_rbd_replay.cc
@@ -786,6 +799,7 @@ target_link_libraries(unittest_rbd_replay
   keyutils
   ${BLKID_LIBRARIES}
   )
+endif(WITH_RBD)
 
 # unittest_ipaddr
 add_executable(unittest_ipaddr

--- a/src/test/bench/CMakeLists.txt
+++ b/src/test/bench/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(ceph_smalliobench librados ${Boost_PROGRAM_OPTIONS_LIBRARY
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS}) 
 
 # ceph_smalliobenchrbd
-if (${WITH_RBD})
+if (WITH_RBD)
   set(smalliobenchrbd_srcs
     small_io_bench_rbd.cc
     rbd_backend.cc
@@ -35,7 +35,10 @@ if (${WITH_RBD})
     ${CMAKE_DL_LIBS}
     keyutils
     )
-endif (${WITH_RBD})
+install(TARGETS
+  ceph_smalliobenchrbd
+    DESTINATION bin)
+endif(WITH_RBD)
 
 # ceph_smalliobenchfs
 set(ceph_smalliobenchfs_srcs
@@ -75,7 +78,6 @@ target_link_libraries(ceph_tpbench librados ${Boost_PROGRAM_OPTIONS_LIBRARY} glo
 
 install(TARGETS
   ceph_smalliobench
-  ceph_smalliobenchrbd
   ceph_smalliobenchfs
   ceph_smalliobenchdumb
   ceph_tpbench

--- a/src/test/cls_rbd/CMakeLists.txt
+++ b/src/test/cls_rbd/CMakeLists.txt
@@ -1,4 +1,5 @@
 # cls_test_cls_rbd
+if(WITH_RBD)
 add_executable(ceph_test_cls_rbd
   test_cls_rbd.cc
   $<TARGET_OBJECTS:common_texttable_obj>
@@ -24,3 +25,4 @@ target_link_libraries(ceph_test_cls_rbd
 install(TARGETS
   ceph_test_cls_rbd
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif(WITH_RBD)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -12,12 +12,14 @@ target_link_libraries(get_command_descriptions
   ${CMAKE_DL_LIBS}
   )
 
+if(WITH_BLKID)
 # unittest_blkdev
 add_executable(unittest_blkdev
   test_blkdev.cc
   )
 add_ceph_unittest(unittest_blkdev ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_blkdev)
 target_link_libraries(unittest_blkdev global ${BLKID_LIBRARIES})
+endif(WITH_BLKID)
 
 # unittest_bloom_filter
 add_executable(unittest_bloom_filter

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -1,3 +1,4 @@
+if(WITH_RBD)
 set(librbd_test
   test_fixture.cc
   test_support.cc
@@ -148,3 +149,4 @@ install(TARGETS
   ceph_test_librbd_api
   ceph_test_librbd_fsx
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif(WITH_RBD)

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -102,6 +102,7 @@ add_executable(unittest_rocksdb_option
 add_ceph_unittest(unittest_rocksdb_option ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rocksdb_option)
 target_link_libraries(unittest_rocksdb_option global os ${BLKID_LIBRARIES})
 
+if(HAVE_LIBAIO)
 # unittest_bit_alloc
 add_executable(unittest_bit_alloc
   BitAllocator_test.cc
@@ -122,6 +123,7 @@ add_executable(unittest_bluestore_types
   )
 add_ceph_unittest(unittest_bluestore_types ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bluestore_types)
 target_link_libraries(unittest_bluestore_types os global)
+endif(HAVE_LIBAIO)
   
 # unittest_transaction
 add_executable(unittest_transaction

--- a/src/test/pybind/CMakeLists.txt
+++ b/src/test/pybind/CMakeLists.txt
@@ -1,2 +1,4 @@
+if(NOT FREEBSD)
 add_ceph_test(test_ceph_daemon.py ${CMAKE_CURRENT_SOURCE_DIR}/test_ceph_daemon.py)
 add_ceph_test(test_ceph_argparse.py ${CMAKE_CURRENT_SOURCE_DIR}/test_ceph_argparse.py)
+endif(NOT FREEBSD)

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -1,3 +1,4 @@
+if(WITH_RBD)
 set(rbd_mirror_test_srcs
   test_ClusterWatcher.cc
   test_PoolWatcher.cc
@@ -88,3 +89,4 @@ install(TARGETS
   ceph_test_rbd_mirror
   ceph_test_rbd_mirror_random_write
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif(WITH_RBD)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,6 +1,8 @@
-add_executable(ceph-client-debug ceph-client-debug.cc)
-target_link_libraries(ceph-client-debug cephfs librados global common)
-install(TARGETS ceph-client-debug DESTINATION bin)
+if(WITH_LIBCEPHFS)
+  add_executable(ceph-client-debug tools/ceph-client-debug.cc)
+  target_link_libraries(ceph-client-debug cephfs librados global common)
+  install(TARGETS ceph-client-debug DESTINATION bin)
+endif(WITH_LIBCEPHFS)
 
 add_executable(ceph-kvstore-tool ceph_kvstore_tool.cc)
 target_link_libraries(ceph-kvstore-tool os global ${UNITTEST_CXX_FLAGS})


### PR DESCRIPTION
 - Clang has different warning requirements
 - add /usr/local for include and libs
 - UDEV is not the same on FreeBSD
 - No blkid, keyutils
 - Several libs (dl, uuid, resolv) are in clib, so no need to link explicit
 - uname returns amd64
 - use EventKqueue.* in msg/async


Items excluded because porting is not done.
 - Bluestore, due to incompatible AIO
 - CephFS due to keystore dependancy??
 - RBD excluded because of incomplete porting
