### PR TITLE
cmake: install ceph_test_cls_rgw

### DIFF
--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -1,4 +1,5 @@
 etc/bash_completion.d/ceph
+etc/init.d/ceph
 usr/sbin/ceph-create-keys
 usr/bin/ceph-detect-init
 usr/bin/ceph-debugpack

--- a/src/test/cls_rgw/CMakeLists.txt
+++ b/src/test/cls_rgw/CMakeLists.txt
@@ -13,5 +13,8 @@ if(${WITH_RADOSGW})
     ${BLKID_LIBRARIES}
     ${CMAKE_DL_LIBS}
     radostest)
+  install(TARGETS
+    ceph_test_cls_rgw
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif(${WITH_RADOSGW})
 


### PR DESCRIPTION
it is used by cls/test_cls_rgw.sh

Signed-off-by: Kefu Chai <kchai@redhat.com>