### PR TITLE
msg/async/net_handler.cc: make it more compatible with BSDs

### DIFF
--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -14,6 +14,7 @@
  *
  */
 
+#include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>


### PR DESCRIPTION
According the Linux manual page:
POSIX.1-2001 does not require the inclusion of <sys/types.h>, and this header file is not required on Linux.  However, some historical (BSD) implementations required this header file, and portable applications are probably wise to include it.

Submitted-by: Willem Jan Withagen <wjw@digiware.nl>