### PR TITLE
rgw: finish error_repo cr in stop_spawned_services()

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1267,6 +1267,7 @@ public:
   void stop_spawned_services() {
     lease_cr->go_down();
     if (error_repo) {
+      error_repo->finish();
       error_repo->put();
       error_repo = NULL;
     }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16530

Need to call finish, otherwise drain_all() wouldn't be able to
drain it.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>