### PR TITLE
rgw: add deadlock detection to RGWCoroutinesManager::run()

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -570,6 +570,7 @@ int RGWCoroutinesManager::run(list<RGWCoroutinesStack *>& stacks)
   }
 
   lock.get_write();
+  assert(context_stacks.empty() || going_down.read()); // assert on deadlock
   for (auto stack : context_stacks) {
     ldout(cct, 20) << "clearing stack on run() exit: stack=" << (void *)stack << " nref=" << stack->get_nref() << dendl;
     stack->put();


### PR DESCRIPTION
assert instead of returning if all coroutines are blocked