### PR TITLE
ceph.spec.in: fix for use of make-dist built tarballs

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -613,7 +613,7 @@ python-cephfs instead.
 # common
 #################################################################################
 %prep
-%autosetup -p1
+%setup -q -n %{name}-%{version}-%{release}
 
 %build
 %if 0%{with cephfs_java}


### PR DESCRIPTION
As the tarballs generation is moved to make-dist from autotools setup
in recent commit it breaks the rpmbuild as the prefix in the tarball
is different now. This spec file change unbreaks the rpmbuild with
the make-dist generated tarball.

Signed-off-by: Nitin A Kamble <Nitin.Kamble@Teradata.com>