### PR TITLE
os/bluestore: make zone/span size of bitmap-allocator configurable

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -972,6 +972,8 @@ OPTION(bluestore_kvbackend, OPT_STR, "rocksdb")
 OPTION(bluestore_allocator, OPT_STR, "bitmap")     // stupid | bitmap
 OPTION(bluestore_freelist_type, OPT_STR, "bitmap") // extent | bitmap
 OPTION(bluestore_freelist_blocks_per_key, OPT_INT, 128)
+OPTION(bluestore_bitmapallocator_blocks_per_zone, OPT_INT, 1024) // must be power of 2 aligned, e.g., 512, 1024, 2048...
+OPTION(bluestore_bitmapallocator_span_size, OPT_INT, 1024) // must be power of 2 aligned, e.g., 512, 1024, 2048...
 OPTION(bluestore_rocksdb_options, OPT_STR, "compression=kNoCompression,max_write_buffer_number=16,min_write_buffer_number_to_merge=3,recycle_log_file_num=16")
 OPTION(bluestore_fsck_on_mount, OPT_BOOL, false)
 OPTION(bluestore_fsck_on_umount, OPT_BOOL, false)

--- a/src/os/bluestore/BitAllocator.cc
+++ b/src/os/bluestore/BitAllocator.cc
@@ -419,11 +419,7 @@ BitMapZone::~BitMapZone()
 bool BitMapZone::is_exhausted()
 {
   debug_assert(check_locked());
-  if (get_used_blocks() == size()) {
-    return true;
-  } else {
-    return false;
-  }
+  return get_used_blocks() == size();
 }
 
 bool BitMapZone::is_allocated(int64_t start_block, int64_t num_blocks)
@@ -523,10 +519,7 @@ void BitMapZone::lock_excl()
 
 bool BitMapZone::lock_excl_try()
 {
-  if (m_lock.try_lock()) {
-    return true;
-  }
-  return false;
+  return m_lock.try_lock();
 }
 
 void BitMapZone::unlock()
@@ -793,10 +786,7 @@ void BitMapAreaIN::child_unlock(BitMapArea *child)
 
 bool BitMapAreaIN::is_exhausted()
 {
-  if (get_used_blocks() == size()) {
-    return true;
-  }
-  return false;
+  return get_used_blocks() == size();
 }
 
 int64_t BitMapAreaIN::add_used_blocks(int64_t blks)

--- a/src/os/bluestore/BitAllocator.cc
+++ b/src/os/bluestore/BitAllocator.cc
@@ -946,7 +946,7 @@ int64_t BitMapAreaIN::alloc_blocks_dis_int(bool wait, int64_t num_blocks,
     }
 
     blk_off = child->get_index() * m_child_size_blocks + area_blk_off;
-    allocated += child->alloc_blocks_dis(wait, num_blocks,
+    allocated += child->alloc_blocks_dis(wait, num_blocks - allocated,
                             blk_off, &block_list[allocated]);
     child_unlock(child);
     if (allocated == num_blocks) {
@@ -1174,7 +1174,8 @@ int64_t BitMapAreaLeaf::alloc_blocks_dis_int(bool wait, int64_t num_blocks,
     }
 
     blk_off = child->get_index() * m_child_size_blocks + area_blk_off;
-    allocated += child->alloc_blocks_dis(num_blocks, blk_off, &block_list[allocated]);
+    allocated += child->alloc_blocks_dis(num_blocks - allocated,
+      blk_off, &block_list[allocated]);
     child_unlock(child);
     if (allocated == num_blocks) {
       break;
@@ -1563,7 +1564,8 @@ int64_t BitAllocator::alloc_blocks_dis(int64_t num_blocks, int64_t *block_list)
   }
 
   while (scans && allocated < num_blocks) {
-    allocated += alloc_blocks_dis_int(false, num_blocks, blk_off, &block_list[allocated]);
+    allocated += alloc_blocks_dis_int(false, num_blocks - allocated,
+      blk_off, &block_list[allocated]);
     scans--;
   }
 
@@ -1577,7 +1579,8 @@ int64_t BitAllocator::alloc_blocks_dis(int64_t num_blocks, int64_t *block_list)
     unlock();
     lock_excl();
     serial_lock();
-    allocated += alloc_blocks_dis_int(false, num_blocks, blk_off, &block_list[allocated]);
+    allocated += alloc_blocks_dis_int(false, num_blocks - allocated,
+      blk_off, &block_list[allocated]);
     if (is_stats_on()) {
       m_stats->add_serial_scans(1);
     }

--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -9,7 +9,6 @@
 #define CEPH_OS_BLUESTORE_BITALLOCATOR_H
 
 #define debug_assert assert
-#define BITMAP_SPAN_SIZE (1024)
 
 #include <assert.h>
 #include <stdint.h>
@@ -187,9 +186,11 @@ protected:
   bmap_area_type_t m_type;
 
 public:
+  static int64_t get_zone_size();
   static int64_t get_span_size();
   bmap_area_type_t level_to_type(int level);
   static int get_level(int64_t total_blocks);
+  static int64_t get_level_factor(int level);
   virtual bool is_allocated(int64_t start_block, int64_t num_blocks) = 0;
   virtual bool is_exhausted() = 0;
   virtual bool child_check_n_lock(BitMapArea *child, int64_t required) {

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -105,6 +105,8 @@ int BitMapAllocator::allocate(
   uint64_t want_size, uint64_t alloc_unit, int64_t hint,
   uint64_t *offset, uint32_t *length)
 {
+  if (want_size == 0)
+    return 0;
 
   assert(!(alloc_unit % m_block_size));
   int64_t nblks = (want_size + m_block_size - 1) / m_block_size;

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -23,7 +23,23 @@ BitMapAllocator::BitMapAllocator(int64_t device_size, int64_t block_size)
   : m_num_uncommitted(0),
     m_num_committing(0)
 {
-  int64_t zone_size_blks = 1024; // Change it later
+  int64_t zone_size_blks = g_conf->bluestore_bitmapallocator_blocks_per_zone;
+  assert((zone_size_blks & (zone_size_blks - 1)) == 0);
+  if (zone_size_blks & (zone_size_blks - 1)) {
+    derr << __func__ << " zone_size " << zone_size_blks
+         << " not power of 2 aligned!"
+         << dendl;
+    return;
+  }
+
+  int64_t span_size = g_conf->bluestore_bitmapallocator_span_size;
+  assert((span_size & (span_size - 1)) == 0);
+  if (span_size & (span_size - 1)) {
+    derr << __func__ << " span_size " << span_size
+         << " not power of 2 aligned!"
+         << dendl;
+    return;
+  }
 
   m_block_size = block_size;
   m_bit_alloc = new BitAllocator(device_size / block_size,

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -152,6 +152,7 @@ int BitMapAllocator::release(
 
 uint64_t BitMapAllocator::get_free()
 {
+  assert(m_bit_alloc->size() >= m_bit_alloc->get_used_blocks());
   return ((
     m_bit_alloc->size() - m_bit_alloc->get_used_blocks()) *
     m_block_size);

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -5,10 +5,14 @@
  * Author: Ramesh Chander, Ramesh.Chander@sandisk.com
  */
 
+#include "include/Context.h"
+#include "common/ceph_argparse.h"
+#include "global/global_init.h"
 #include "os/bluestore/BitAllocator.h"
 #include <stdio.h>
 #include <assert.h>
 #include <math.h>
+#include <sstream>
 #include <gtest/gtest.h>
 
 #define bmap_test_assert(x) EXPECT_EQ(true, (x))
@@ -341,138 +345,161 @@ TEST(BitAllocator, test_zone_alloc)
 
 TEST(BitAllocator, test_bmap_alloc)
 {
-  int64_t total_blocks = 1024 * 4;
-  int64_t zone_size = 1024;
-  int64_t allocated = 0;
-  int64_t start_block = 0;
+  const int max_iter = 2;
 
-  BitAllocator *alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT);
+  for (int round = 0; round < 3; round++) {
+    // Test zone of different sizes: 512, 1024, 2048
+    int64_t zone_size = 512ull << round;
+    ostringstream val;
+    val << zone_size;
+    g_conf->set_val("bluestore_bitmapallocator_blocks_per_zone", val.str());
 
-  for (int64_t iter = 0; iter < 4; iter++) {
-    for (int64_t i = 0; i < total_blocks; i++) {
-      allocated = alloc->alloc_blocks(1, &start_block);
-      bmap_test_assert(allocated == 1);
-      bmap_test_assert(start_block == i);
+    // choose randomized span_size
+    int64_t span_size = 512ull << (rand() % 4);
+    val.str("");
+    val << span_size;
+    g_conf->set_val("bluestore_bitmapallocator_span_size", val.str());
+    g_ceph_context->_conf->apply_changes(NULL);
+
+    int64_t total_blocks = zone_size * 4;
+    int64_t allocated = 0;
+    int64_t start_block = 0;
+
+    BitAllocator *alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT);
+
+    for (int64_t iter = 0; iter < max_iter; iter++) {
+      for (int64_t i = 0; i < total_blocks; i++) {
+        allocated = alloc->alloc_blocks(1, &start_block);
+        bmap_test_assert(allocated == 1);
+        bmap_test_assert(start_block == i);
+      }
+
+      for (int64_t i = 0; i < total_blocks; i++) {
+        alloc->free_blocks(i, 1);
+      }
     }
 
-    for (int64_t i = 0; i < total_blocks; i++) {
-      alloc->free_blocks(i, 1);
+    for (int64_t iter = 0; iter < max_iter; iter++) {
+      for (int64_t i = 0; i < total_blocks / zone_size; i++) {
+        allocated = alloc->alloc_blocks(zone_size, &start_block);
+        bmap_test_assert(allocated == zone_size);
+        bmap_test_assert(start_block == i * zone_size);
+      }
+
+      for (int64_t i = 0; i < total_blocks / zone_size; i++) {
+        alloc->free_blocks(i * zone_size, zone_size);
+      }
     }
-  }
 
-  for (int64_t iter = 0; iter < 4; iter++) {
-    for (int64_t i = 0; i < total_blocks / zone_size; i++) {
-      allocated = alloc->alloc_blocks(zone_size, &start_block);
-      bmap_test_assert(allocated == zone_size);
-      bmap_test_assert(start_block == i * zone_size);
-    }
-
-    for (int64_t i = 0; i < total_blocks / zone_size; i++) {
-      alloc->free_blocks(i * zone_size, zone_size);
-    }
-  }
-
-  allocated = alloc->alloc_blocks(1, &start_block);
-  bmap_test_assert(allocated == 1);
-
-  allocated = alloc->alloc_blocks(zone_size - 1, &start_block);
-  bmap_test_assert(allocated == zone_size - 1);
-  bmap_test_assert(start_block == 1);
-
-  allocated = alloc->alloc_blocks(1, &start_block);
-  bmap_test_assert(allocated == 1);
-
-  allocated = alloc->alloc_blocks(zone_size, &start_block);
-  bmap_test_assert(allocated == zone_size);
-  bmap_test_assert(start_block == zone_size * 2);
-
-  // Dis contiguous blocks allocations
-  delete alloc;
-  alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT);
-
-  for (int64_t i = 0; i < alloc->size(); i++) {
     allocated = alloc->alloc_blocks(1, &start_block);
     bmap_test_assert(allocated == 1);
-  }
-  for (int i = 0; i < alloc->size(); i += 2) {
-    alloc->free_blocks(i, 1);
-  }
 
-  int64_t blocks[alloc->size() / 2];
-  memset(blocks, 0, sizeof(blocks));
-  allocated = alloc->alloc_blocks_dis(alloc->size()/2, blocks);
-  bmap_test_assert(allocated == alloc->size() / 2);
+    allocated = alloc->alloc_blocks(zone_size - 1, &start_block);
+    bmap_test_assert(allocated == zone_size - 1);
+    bmap_test_assert(start_block == 1);
 
-  allocated = alloc->alloc_blocks_dis(1, blocks);
-  bmap_test_assert(allocated == 0);
+    allocated = alloc->alloc_blocks(1, &start_block);
+    bmap_test_assert(allocated == 1);
 
-  alloc->free_blocks(alloc->size()/2, 1);
-  allocated = alloc->alloc_blocks_dis(1, blocks);
+    allocated = alloc->alloc_blocks(zone_size, &start_block);
+    bmap_test_assert(allocated == zone_size);
+    bmap_test_assert(start_block == zone_size * 2);
 
-  bmap_test_assert(allocated == 1);
-  bmap_test_assert(blocks[0] == alloc->size()/2);
+    // Dis contiguous blocks allocations
+    delete alloc;
+    alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT);
 
-  alloc->free_blocks(0, alloc->size());
-  delete alloc;
-
-  // unaligned zones
-  total_blocks = 1024 * 2 + 11;
-  alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT);
-
-  for (int64_t iter = 0; iter < 4; iter++) {
-    for (int64_t i = 0; i < total_blocks; i++) {
+    for (int64_t i = 0; i < alloc->size(); i++) {
       allocated = alloc->alloc_blocks(1, &start_block);
       bmap_test_assert(allocated == 1);
-      bmap_test_assert(start_block == i);
     }
-
-    for (int64_t i = 0; i < total_blocks; i++) {
+    for (int i = 0; i < alloc->size(); i += 2) {
       alloc->free_blocks(i, 1);
     }
+
+    int64_t blocks[alloc->size() / 2];
+    memset(blocks, 0, sizeof(blocks));
+    allocated = alloc->alloc_blocks_dis(alloc->size()/2, blocks);
+    bmap_test_assert(allocated == alloc->size() / 2);
+
+    allocated = alloc->alloc_blocks_dis(1, blocks);
+    bmap_test_assert(allocated == 0);
+
+    alloc->free_blocks(alloc->size()/2, 1);
+    allocated = alloc->alloc_blocks_dis(1, blocks);
+
+    bmap_test_assert(allocated == 1);
+    bmap_test_assert(blocks[0] == alloc->size()/2);
+
+    alloc->free_blocks(0, alloc->size());
+    delete alloc;
+
+    // unaligned zones
+    total_blocks = zone_size * 2 + 11;
+    alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT);
+
+    for (int64_t iter = 0; iter < max_iter; iter++) {
+      for (int64_t i = 0; i < total_blocks; i++) {
+        allocated = alloc->alloc_blocks(1, &start_block);
+        bmap_test_assert(allocated == 1);
+        bmap_test_assert(start_block == i);
+      }
+
+      for (int64_t i = 0; i < total_blocks; i++) {
+        alloc->free_blocks(i, 1);
+      }
+    }
+    delete alloc;
+
+    // Make three > 3 levels tree and check allocations and dealloc
+    // in a loop
+    int64_t alloc_size = 64ull << round;
+    total_blocks = BitMapArea::get_level_factor(2) * 4;
+    alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT, false);
+    for (int64_t iter = 0; iter < max_iter; iter++) {
+      for (int64_t i = 0; i < total_blocks / alloc_size; i++) {
+        allocated = alloc->alloc_blocks(alloc_size, &start_block);
+        bmap_test_assert(allocated == alloc_size);
+        bmap_test_assert(start_block == i * alloc_size);
+      }
+
+      for (int64_t i = 0; i < total_blocks / alloc_size; i++) {
+        alloc->free_blocks(i * alloc_size, alloc_size);
+      }
+    }
+
+    delete alloc;
+    alloc = new BitAllocator(1024, zone_size, CONCURRENT, true);
+
+    alloc->free_blocks(1, 1023);
+    allocated = alloc->alloc_blocks(16, &start_block);
+    bmap_test_assert(allocated == 16);
+    bmap_test_assert(start_block == 1);
+    delete alloc;
+
+    total_blocks = BitMapArea::get_level_factor(2) * 4;
+    alloc_size = 64ull << round;
+    alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT, false);
+    for (int64_t iter = 0; iter < max_iter; iter++) {
+      for (int64_t i = 0; i < total_blocks / alloc_size; i++) {
+        bmap_test_assert(alloc->reserve_blocks(alloc_size));
+        allocated = alloc->alloc_blocks_res(alloc_size, &start_block);
+        bmap_test_assert(allocated == alloc_size);
+        bmap_test_assert(start_block == i * alloc_size);
+      }
+
+      for (int64_t i = 0; i < total_blocks / alloc_size; i++) {
+        alloc->free_blocks(i * alloc_size, alloc_size);
+      }
+    }
+
+    delete alloc;
   }
-  delete alloc;
 
-  // Make three > 3 levels tree and check allocations and dealloc
-  // in a loop
-  int64_t alloc_size = 16;
-  total_blocks = pow(BITMAP_SPAN_SIZE, 2) * 4;
-  alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT, false);
-  for (int64_t iter = 0; iter < 3; iter++) {
-    for (int64_t i = 0; i < total_blocks / alloc_size; i++) {
-      allocated = alloc->alloc_blocks(alloc_size, &start_block);
-      bmap_test_assert(allocated == alloc_size);
-      bmap_test_assert(start_block == i * alloc_size);
-    }
-
-    for (int64_t i = 0; i < total_blocks / alloc_size; i++) {
-      alloc->free_blocks(i * alloc_size, alloc_size);
-    }
-  }
-
-  delete alloc;
-  alloc = new BitAllocator(1024, zone_size, CONCURRENT, true);
-
-  alloc->free_blocks(1, 1023);
-  alloc->alloc_blocks(16, &start_block);
-  delete alloc;
-
-  total_blocks = pow(BITMAP_SPAN_SIZE, 2) * 4;
-  alloc_size = 16;
-  alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT, false);
-  for (int64_t iter = 0; iter < 3; iter++) {
-    for (int64_t i = 0; i < total_blocks / alloc_size; i++) {
-      bmap_test_assert(alloc->reserve_blocks(alloc_size));
-      allocated = alloc->alloc_blocks_res(alloc_size, &start_block);
-      bmap_test_assert(allocated == alloc_size);
-      bmap_test_assert(start_block == i * alloc_size);
-    }
-
-    for (int64_t i = 0; i < total_blocks / alloc_size; i++) {
-      alloc->free_blocks(i * alloc_size, alloc_size);
-    }
-  }
-
-  delete alloc;
+  // restore to typical value
+  g_conf->set_val("bluestore_bitmapallocator_blocks_per_zone", "1024");
+  g_conf->set_val("bluestore_bitmapallocator_span_size", "1024");
+  g_ceph_context->_conf->apply_changes(NULL);
 }
 
 void
@@ -560,6 +587,15 @@ TEST(BitAllocator, test_bmap_alloc_concurrent)
 
 int main(int argc, char **argv)
 {
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+  env_to_vec(args);
+
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int r = RUN_ALL_TESTS();
+  g_ceph_context->put();
+  return r;
 }


### PR DESCRIPTION
Perviously as zone_size_block and span_size are identical, so we could use
span_size only to simplify the calculation.

Now that the zone_size_block and span_size are both configurable, so
it is necessary to treat them respectively.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>