### PR TITLE
rgw: remove some useless codes 

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7367,9 +7367,7 @@ int RGWRados::Object::complete_atomic_modification()
   store->update_gc_chain(obj, state->manifest, &chain);
 
   string tag = state->obj_tag.to_str();
-  int ret = store->gc->send_chain(chain, tag, false);  // do it async
-
-  return ret;
+  return store->gc->send_chain(chain, tag, false);  // do it async
 }
 
 void RGWRados::update_gc_chain(rgw_obj& head_obj, RGWObjManifest& manifest, cls_rgw_obj_chain *chain)


### PR DESCRIPTION
We have no need to genarate an `oid_rand` and pass it into the `prepare`
function, which will do nothing with `oid_rand` as following:

```
  virtual int prepare(RGWRados *_store, string *oid_rand) {
    store = _store;
    return 0;
  }
```
On the other hand, the `RGWObjManifest::generator::create_begin` will
genarate a different rand `oid` suffix as well as we need.