### PR TITLE
client/filer: cleanup the redundant judgments of _write&&_fallocate

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8585,13 +8585,10 @@ int Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
     unsafe_sync_write++;
     get_cap_ref(in, CEPH_CAP_FILE_BUFFER);  // released by onsafe callback
 
-    r = filer->write_trunc(in->ino, &in->layout, in->snaprealm->get_snap_context(),
+    filer->write_trunc(in->ino, &in->layout, in->snaprealm->get_snap_context(),
 			   offset, size, bl, ceph::real_clock::now(cct), 0,
 			   in->truncate_size, in->truncate_seq,
 			   onfinish, new C_OnFinisher(onsafe, &objecter_finisher));
-    if (r < 0)
-      goto done;
-
     client_lock.Unlock();
     flock.Lock();
 
@@ -11665,14 +11662,12 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
       get_cap_ref(in, CEPH_CAP_FILE_BUFFER);
 
       _invalidate_inode_cache(in, offset, length);
-      r = filer->zero(in->ino, &in->layout,
+      filer->zero(in->ino, &in->layout,
 		      in->snaprealm->get_snap_context(),
 		      offset, length,
 		      ceph::real_clock::now(cct),
 		      0, true, onfinish,
 		      new C_OnFinisher(onsafe, &objecter_finisher));
-      assert(r == 0);
-
       in->mtime = ceph_clock_now(cct);
       mark_caps_dirty(in, CEPH_CAP_FILE_WR);
 

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -117,7 +117,7 @@ class Filer {
 
   /*** async file interface.  scatter/gather as needed. ***/
 
-  int read(inodeno_t ino,
+  void read(inodeno_t ino,
 	   file_layout_t *layout,
 	   snapid_t snap,
 	   uint64_t offset,
@@ -130,10 +130,9 @@ class Filer {
     vector<ObjectExtent> extents;
     Striper::file_to_extents(cct, ino, layout, offset, len, 0, extents);
     objecter->sg_read(extents, snap, bl, flags, onfinish, op_flags);
-    return 0;
   }
 
-  int read_trunc(inodeno_t ino,
+  void read_trunc(inodeno_t ino,
 		 file_layout_t *layout,
 		 snapid_t snap,
 		 uint64_t offset,
@@ -150,10 +149,9 @@ class Filer {
 			     extents);
     objecter->sg_read_trunc(extents, snap, bl, flags,
 			    truncate_size, truncate_seq, onfinish, op_flags);
-    return 0;
   }
 
-  int write(inodeno_t ino,
+  void write(inodeno_t ino,
 	    file_layout_t *layout,
 	    const SnapContext& snapc,
 	    uint64_t offset,
@@ -168,10 +166,9 @@ class Filer {
     Striper::file_to_extents(cct, ino, layout, offset, len, 0, extents);
     objecter->sg_write(extents, snapc, bl, mtime, flags, onack, oncommit,
 		       op_flags);
-    return 0;
   }
 
-  int write_trunc(inodeno_t ino,
+  void write_trunc(inodeno_t ino,
 		  file_layout_t *layout,
 		  const SnapContext& snapc,
 		  uint64_t offset,
@@ -189,10 +186,9 @@ class Filer {
 			     extents);
     objecter->sg_write_trunc(extents, snapc, bl, mtime, flags,
 		       truncate_size, truncate_seq, onack, oncommit, op_flags);
-    return 0;
   }
 
-  int truncate(inodeno_t ino,
+  void truncate(inodeno_t ino,
 	       file_layout_t *layout,
 	       const SnapContext& snapc,
 	       uint64_t offset,
@@ -228,10 +224,9 @@ class Filer {
       gack.activate();
       gcom.activate();
     }
-    return 0;
   }
 
-  int zero(inodeno_t ino,
+  void zero(inodeno_t ino,
 	   file_layout_t *layout,
 	   const SnapContext& snapc,
 	   uint64_t offset,
@@ -273,10 +268,9 @@ class Filer {
       gack.activate();
       gcom.activate();
     }
-    return 0;
   }
 
-  int zero(inodeno_t ino,
+  void zero(inodeno_t ino,
 	   file_layout_t *layout,
 	   const SnapContext& snapc,
 	   uint64_t offset,
@@ -285,12 +279,11 @@ class Filer {
 	   int flags,
 	   Context *onack,
 	   Context *oncommit) {
-
-    return zero(ino, layout,
-		snapc, offset,
-		len, mtime,
-		flags, false,
-		onack, oncommit);
+    zero(ino, layout,
+         snapc, offset,
+         len, mtime,
+         flags, false,
+         onack, oncommit);
   }
   // purge range of ino.### objects
   int purge_range(inodeno_t ino,


### PR DESCRIPTION
The running time of redundant judgments influence function,especially _write(),
at the same time,Filer::read/read_trunc/write/write_trunc/truncate/zero type should be void, fix it

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>