### PR TITLE
rbd-mirror: gracefully fail if object map is unavailable

### DIFF
--- a/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
@@ -235,6 +235,13 @@ void ObjectCopyRequest<I>::send_update_object_map() {
     m_local_image_ctx->snap_lock.put_read();
     finish(0);
     return;
+  } else if (m_local_image_ctx->object_map == nullptr) {
+    // possible that exclusive lock was lost in background
+    derr << ": object map is not initialized" << dendl;
+
+    m_local_image_ctx->snap_lock.put_read();
+    finish(-EINVAL);
+    return;
   }
 
   assert(m_local_image_ctx->object_map != nullptr);


### PR DESCRIPTION
If the exclusive lock was lost due to a watch failure from an
overloaded cluster, gracefully abort the image sync.

Fixes: http://tracker.ceph.com/issues/16558
Signed-off-by: Jason Dillaman <dillaman@redhat.com>