### PR TITLE
jewel: rgw: data sync stops after getting error in all data log sync shards

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1182,6 +1182,7 @@ public:
   void stop_spawned_services() {
     lease_cr->go_down();
     if (error_repo) {
+      error_repo->finish();
       error_repo->put();
       error_repo = NULL;
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/16565