### PR TITLE
cmake: remove unnecessary linked libs from libcephfs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1157,10 +1157,8 @@ if(WITH_LIBCEPHFS)
   target_link_libraries(client osdc mds)
   set(libcephfs_srcs libcephfs.cc)
   add_library(cephfs ${CEPH_SHARED} ${libcephfs_srcs}
-    $<TARGET_OBJECTS:cls_references_objs>
     $<TARGET_OBJECTS:common_util_obj>)
-  target_link_libraries(cephfs LINK_PRIVATE client osdc osd os global common
-    ${BLKID_LIBRARIES}
+  target_link_libraries(cephfs LINK_PRIVATE client
     ${CRYPTO_LIBS} ${EXTRALIBS})
   if(ENABLE_SHARED)
     set_target_properties(cephfs PROPERTIES


### PR DESCRIPTION
* some of the libs shares the same .cc which has static C++ variables. if
  we link against the different libs sharing the same static C++
  variables, and the dtor of the C++ variables has side-effects, among
  other things, deallocates a memory chunk. then, we are in the trouble of
  double free.
* some of the libs are referenced by the linked lib, so no need to link
  against them again. for example, BLKID_LIBRARIES are linked by
  libcommon, so we can remove it from the linked libs list.

Fixes: http://tracker.ceph.com/issues/16556
Signed-off-by: Kefu Chai <kchai@redhat.com>