### PR TITLE
os/bluestore: Remove bit alloc Woverloaded-virtual warnings

### DIFF
--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -345,6 +345,17 @@ public:
   ~BitMapZone();
   void shutdown();
 
+  virtual int64_t alloc_blocks(bool wait, int64_t num_blocks, int64_t *start_block) {
+    debug_assert(0);
+    return 0;
+  }
+
+  virtual int64_t alloc_blocks_dis(bool wait, int64_t num_blocks,
+             int64_t blk_off, int64_t *block_list) {
+    debug_assert(0);
+    return 0;
+  }
+
   int64_t alloc_blocks(int64_t num_blocks, int64_t *start_block);
   int64_t alloc_blocks_dis(int64_t num_blocks, int64_t blk_off, int64_t *block_list);
   void set_blocks_used(int64_t start_block, int64_t num_blocks);
@@ -368,6 +379,12 @@ protected:
   bool is_allocated(int64_t start_block, int64_t num_blocks);
   virtual bool is_allocated(int64_t *blocks, int64_t num_blocks, int64_t blk_off);
   virtual bool is_exhausted();
+  
+  bool child_check_n_lock(BitMapArea *child, int64_t required, bool lock) {
+    debug_assert(0);
+    return false;
+  }
+
   virtual bool child_check_n_lock(BitMapArea *child, int64_t required);
   virtual void child_unlock(BitMapArea *child);
 
@@ -403,6 +420,8 @@ public:
 
   virtual int64_t alloc_blocks_int(bool wait, bool wrap,
                      int64_t num_blocks, int64_t *start_block);
+  using BitMapArea::alloc_blocks; //non-wait version
+  using BitMapArea::alloc_blocks_dis; //non-wait version
   virtual int64_t alloc_blocks(bool wait, int64_t num_blocks, int64_t *start_block);
   virtual int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks,
                int64_t blk_off, int64_t *block_list);
@@ -427,6 +446,12 @@ public:
   BitMapAreaLeaf() { }
   BitMapAreaLeaf(int64_t zone_num, int64_t total_blocks);
   BitMapAreaLeaf(int64_t zone_num, int64_t total_blocks, bool def);
+
+  bool child_check_n_lock(BitMapArea *child, int64_t required) {
+    debug_assert(0);
+    return false;
+  }
+
   bool child_check_n_lock(BitMapArea *child, int64_t required, bool lock);
   void child_unlock(BitMapArea *child);
 
@@ -459,6 +484,7 @@ private:
     return m_is_stats_on;
   }
 
+  using BitMapArea::child_check_n_lock;
   bool child_check_n_lock(BitMapArea *child, int64_t required);
   virtual void child_unlock(BitMapArea *child);
 
@@ -481,6 +507,9 @@ public:
                bmap_alloc_mode_t mode, bool def, bool stats_on);
   ~BitAllocator();
   void shutdown();
+  using BitMapAreaIN::alloc_blocks; //Wait version
+  using BitMapAreaIN::alloc_blocks_dis; //Wait version
+
   int64_t alloc_blocks(int64_t num_blocks, int64_t *start_block);
   int64_t alloc_blocks_res(int64_t num_blocks, int64_t *start_block);
   void free_blocks(int64_t start_block, int64_t num_blocks);


### PR DESCRIPTION
os/bluestore: removed warning from bitallo code that came after cmake changes.
Signed-off-by: Ramesh Chander <Ramesh.Chander@sandisk.com>