### PR TITLE
Doc: ceph-deploy mon add doesn't take multiple nodes

### DIFF
--- a/doc/start/quick-ceph-deploy.rst
+++ b/doc/start/quick-ceph-deploy.rst
@@ -324,7 +324,8 @@ Add two Ceph Monitors to your cluster. ::
 
 For example::
 
-	ceph-deploy mon add node2 node3
+	ceph-deploy mon add node2
+	ceph-deploy mon add node3
 
 Once you have added your new Ceph Monitors, Ceph will begin synchronizing
 the monitors and form a quorum. You can check the quorum status by executing


### PR DESCRIPTION
As ceph-deploy 1.5.34, ceph-deploy mon add doesn't take multiple nodes as
argument but only take one.

Signed-off-by: Chengwei Yang <yangchengwei@qiyi.com>