### PR TITLE
systemd: add osd id to service description

### DIFF
--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Ceph object storage daemon
+Description=Ceph object storage daemon osd.%i
 After=network-online.target local-fs.target time-sync.target
 Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-osd.target


### PR DESCRIPTION
So, instead of logging this:

Jul 01 13:51:04 localhost systemd[1]: Failed to start Ceph object storage daemon.
Jul 01 13:51:04 localhost systemd[1]: Failed to start Ceph object storage daemon.
Jul 01 13:51:04 localhost systemd[1]: Failed to start Ceph object storage daemon.
Jul 01 13:51:04 localhost systemd[1]: Failed to start Ceph object storage daemon.
Jul 01 13:51:04 localhost systemd[1]: Failed to start Ceph object storage daemon.
Jul 01 13:51:04 localhost systemd[1]: Failed to start Ceph object storage daemon.
Jul 01 13:51:04 localhost systemd[1]: Failed to start Ceph object storage daemon.
Jul 01 13:51:04 localhost systemd[1]: Failed to start Ceph object storage daemon.
Jul 01 13:51:04 localhost systemd[1]: Failed to start Ceph object storage daemon.
Jul 01 13:51:04 localhost systemd[1]: Failed to start Ceph object storage daemon.

We see this, which is a lot more useful:

Jul 01 13:59:32 localhost systemd[1]: Failed to start Ceph object storage daemon osd.27.
Jul 01 13:59:32 localhost systemd[1]: Failed to start Ceph object storage daemon osd.32.
Jul 01 13:59:32 localhost systemd[1]: Failed to start Ceph object storage daemon osd.29.
Jul 01 13:59:32 localhost systemd[1]: Failed to start Ceph object storage daemon osd.31.
Jul 01 13:59:32 localhost systemd[1]: Failed to start Ceph object storage daemon osd.23.
Jul 01 13:59:32 localhost systemd[1]: Failed to start Ceph object storage daemon osd.24.
Jul 01 13:59:32 localhost systemd[1]: Failed to start Ceph object storage daemon osd.25.
Jul 01 13:59:32 localhost systemd[1]: Failed to start Ceph object storage daemon osd.30.
Jul 01 13:59:32 localhost systemd[1]: Failed to start Ceph object storage daemon osd.28.
Jul 01 13:59:32 localhost systemd[1]: Failed to start Ceph object storage daemon osd.22.