### PR TITLE
os/bluestore: Added libzbc library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,6 @@
 [submodule "src/xxHash"]
 	path = src/xxHash
 	url = https://github.com/ceph/xxHash.git
+[submodule "src/libzbc"]
+	path = src/libzbc
+	url = git@github.com:shehbazj/libzbc.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,6 +202,11 @@ if(WITH_OCF)
   add_subdirectory(ocf)
 endif()
 
+option(WITH_LIBZBC "build libzbc - library to support SMR commands" OFF)
+if(WITH_LIBZBC)
+	add_subdirectory(libzbc)
+endif()
+
 option(WITH_CEPHFS_JAVA "build libcephfs Java bindings" OFF)
 if(WITH_CEPHFS_JAVA)
   add_subdirectory(java)


### PR DESCRIPTION
libzbc library provides API that can be used to query SMR drives.

Fixes: http://tracker.ceph.com/issues/16174
Signed-off-by: Shehbaz Jaffer <shehbaz.jaffer@mail.utoronto.ca>