### PR TITLE
jewel: client: crash in unmount when fuse_use_invalidate_cb is enabled

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -668,7 +668,7 @@ protected:
   void _schedule_invalidate_callback(Inode *in, int64_t off, int64_t len);
   void _invalidate_inode_cache(Inode *in);
   void _invalidate_inode_cache(Inode *in, int64_t off, int64_t len);
-  void _async_invalidate(InodeRef& in, int64_t off, int64_t len);
+  void _async_invalidate(vinodeno_t ino, int64_t off, int64_t len);
   bool _release(Inode *in);
   
   /**


### PR DESCRIPTION
http://tracker.ceph.com/issues/16215