### PR TITLE
rgw: remove possible duplicate setting

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1955,7 +1955,7 @@ int RGWObjManifest::generator::create_next(uint64_t ofs)
 
   uint64_t max_head_size = manifest->get_max_head_size();
 
-  if (ofs <= max_head_size) {
+  if (ofs < max_head_size) {
     manifest->set_head_size(ofs);
   }
 


### PR DESCRIPTION
if `ofs == max_head_size`,  then `manifest->set_head_size` will run twice

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>