### PR TITLE
ceph.spec.in: fix rpm package building error

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1152,6 +1152,7 @@ fi
 %{_sbindir}/ceph-disk
 %{_sbindir}/ceph-disk-udev
 %{_libexecdir}/ceph/ceph-osd-prestart.sh
+%{_udevrulesdir}/60-ceph-by-parttypeuuid.rules
 %{_udevrulesdir}/95-ceph-osd.rules
 %{_mandir}/man8/ceph-clsinfo.8*
 %{_mandir}/man8/ceph-disk.8*


### PR DESCRIPTION
the rpm package building error is as follows:
```
 error: Installed (but unpackaged) file(s) found:
 /usr/lib/udev/rules.d/60-ceph-by-parttypeuuid.rules
```
which was introduced by #9885 

Signed-off-by: runsisi <runsisi@zte.com.cn>