### PR TITLE
rgw: for the create_bucket api, if the input creation_time is zero, we should set it to 'now"

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5158,7 +5158,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     info.bucket_index_shard_hash_type = RGWBucketInfo::MOD;
     info.requester_pays = false;
     if (real_clock::is_zero(creation_time)) {
-      creation_time = ceph::real_clock::now(cct);
+      info.creation_time = ceph::real_clock::now(cct);
     } else {
       info.creation_time = creation_time;
     }


### PR DESCRIPTION
For the create_bucket api, if the input creation_time is zero, we should set it to 'now"

Fixes: http://tracker.ceph.com/issues/16597

Signed-off-by: weiqiaomiao <wei.qiaomiao@zte.com.cn>