### PR TITLE
mds: fixup dump Formatter' type error; add path_ino and is_primary in the CDentry::dump()

### DIFF
--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -559,16 +559,16 @@ void CDentry::dump(Formatter *f) const
   make_path(path);
 
   f->dump_string("path", path.get_path());
-  f->dump_int("snap_first", first);
-  f->dump_int("snap_last", last);
-
+  f->dump_unsigned("snap_first", first);
+  f->dump_unsigned("snap_last", last);
+  
   f->dump_bool("is_null", get_linkage()->is_null());
   f->dump_bool("is_remote", get_linkage()->is_remote());
   f->dump_bool("is_new", is_new());
   if (get_linkage()->get_inode()) {
-    f->dump_int("inode", get_linkage()->get_inode()->ino());
+    f->dump_unsigned("inode", get_linkage()->get_inode()->ino());
   } else {
-    f->dump_int("inode", 0);
+    f->dump_unsigned("inode", 0);
   }
 
   if (linkage.is_remote()) {
@@ -577,8 +577,8 @@ void CDentry::dump(Formatter *f) const
     f->dump_string("remote_type", "");
   }
 
-  f->dump_int("version", get_version());
-  f->dump_int("projected_version", get_projected_version());
+  f->dump_unsigned("version", get_version());
+  f->dump_unsigned("projected_version", get_projected_version());
 
   f->dump_int("auth_pins", auth_pins);
   f->dump_int("nested_auth_pins", nested_auth_pins);

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -559,11 +559,13 @@ void CDentry::dump(Formatter *f) const
   make_path(path);
 
   f->dump_string("path", path.get_path());
+  f->dump_unsigned("path_ino", path.get_ino().val);
   f->dump_unsigned("snap_first", first);
   f->dump_unsigned("snap_last", last);
   
-  f->dump_bool("is_null", get_linkage()->is_null());
+  f->dump_bool("is_primary", get_linkage()->is_primary());
   f->dump_bool("is_remote", get_linkage()->is_remote());
+  f->dump_bool("is_null", get_linkage()->is_null());
   f->dump_bool("is_new", is_new());
   if (get_linkage()->get_inode()) {
     f->dump_unsigned("inode", get_linkage()->get_inode()->ino());

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -1066,7 +1066,7 @@ void MDSCacheObject::dump(Formatter *f) const
     f->dump_int("first", authority().first);
     f->dump_int("second", authority().second);
     f->close_section();
-    f->dump_int("replica_nonce", get_replica_nonce());
+    f->dump_unsigned("replica_nonce", get_replica_nonce());
   }
   f->close_section();  // replica_state
 


### PR DESCRIPTION
1.fixup dump Formatter' type error
2.mds/CDentry: add path_ino and is_primary in the dump()


Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>