### PR TITLE
rgw: cls_user don't clobber existing bucket stats when creating bucket

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -170,7 +170,13 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     CLS_LOG(20, "storing entry for key=%s size=%lld count=%lld",
             key.c_str(), (long long)update_entry.size, (long long)update_entry.count);
 
-    apply_entry_stats(update_entry, &entry);
+    // sync entry stats when not an op.add, as when the case is op.add if its a
+    // new entry we already have copied update_entry earlier, OTOH, for an existing entry
+    // we end up clobbering the existing stats for the bucket
+    if (!op.add){
+      apply_entry_stats(update_entry, &entry);
+    }
+
     entry.user_stats_sync = true;
 
     ret = write_entry(hctx, key, entry);


### PR DESCRIPTION
when cls_user_set_buckets_info is called by create bucket, we sync the
entry stats from the given info and thus end up setting the existing
stats on a bucket to 0, this is later corrected during a bucket sync,
however there is no need to update the entry and override the existing
bucket count and stats (as these aren't set during the call) and if it
is a new bucket call we already copy over the values earlier.

Fixes: http://tracker.ceph.com/issues/16357

Reported-by: pengju jiao pj.jiao@139.com
Signed-off-by: Abhishek Lekshmanan abhishek@suse.com
