### PR TITLE
msg/AsyncMessenger: remove unused method

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -568,12 +568,6 @@ void AsyncMessenger::set_addr_unknowns(const entity_addr_t &addr)
   }
 }
 
-int AsyncMessenger::send_keepalive(Connection *con)
-{
-  con->send_keepalive();
-  return 0;
-}
-
 void AsyncMessenger::shutdown_connections(bool queue_reset)
 {
   ldout(cct,1) << __func__ << " " << dendl;

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -148,7 +148,6 @@ public:
    */
   ConnectionRef get_connection(const entity_inst_t& dest) override;
   ConnectionRef get_loopback_connection() override;
-  int send_keepalive(Connection *con);
   virtual void mark_down(const entity_addr_t& addr) override;
   virtual void mark_down_all() override {
     shutdown_connections(true);


### PR DESCRIPTION
Change the return type of function send_keepalive to void. It
doesn't make sense to return constant value(zero).

Signed-off-by: Michal Jarzabek stiopa@gmail.com
