### PR TITLE
test/libcephfs: fix gcc sys/fcntl.h warnings

### DIFF
--- a/src/test/libcephfs/access.cc
+++ b/src/test/libcephfs/access.cc
@@ -19,7 +19,7 @@
 #include "include/cephfs/libcephfs.h"
 #include "include/rados/librados.h"
 #include <errno.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/test/libcephfs/acl.cc
+++ b/src/test/libcephfs/acl.cc
@@ -17,7 +17,7 @@
 #include "include/ceph_fs.h"
 #include "client/posix_acl.h"
 #include <errno.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/test/libcephfs/caps.cc
+++ b/src/test/libcephfs/caps.cc
@@ -17,7 +17,7 @@
 #include "include/ceph_fs.h"
 #include "include/cephfs/libcephfs.h"
 #include <errno.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/test/libcephfs/flock.cc
+++ b/src/test/libcephfs/flock.cc
@@ -20,7 +20,7 @@
 
 #include "include/cephfs/libcephfs.h"
 #include <errno.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/file.h>
 #include <sys/types.h>

--- a/src/test/libcephfs/multiclient.cc
+++ b/src/test/libcephfs/multiclient.cc
@@ -15,7 +15,7 @@
 #include "gtest/gtest.h"
 #include "include/cephfs/libcephfs.h"
 #include <errno.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/test/libcephfs/readdir_r_cb.cc
+++ b/src/test/libcephfs/readdir_r_cb.cc
@@ -15,7 +15,7 @@
 #include "gtest/gtest.h"
 #include "include/cephfs/libcephfs.h"
 #include <errno.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 
 TEST(LibCephFS, ReaddirRCB) {
   struct ceph_mount_info *cmount;

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -15,7 +15,7 @@
 #include "gtest/gtest.h"
 #include "include/cephfs/libcephfs.h"
 #include <errno.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
/usr/include/sys/fcntl.h:1:2: warning: #warning redirecting incorrect #include \<sys/fcntl.h> to \<fcntl.h> [-Wcpp]
#warning redirecting incorrect #include \<sys/fcntl.h> to \<fcntl.h>