### PR TITLE
src/common/buffer.cc fix judgment for lseek

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -2293,9 +2293,9 @@ int buffer::list::write_fd_zero_copy(int fd) const
    */
   int64_t offset = ::lseek(fd, 0, SEEK_CUR);
   int64_t *off_p = &offset;
-  if (offset < 0 && offset != ESPIPE)
-    return (int) offset;
-  if (offset == ESPIPE)
+  if (offset < 0 && errno != ESPIPE)
+    return -errno;
+  if (errno == ESPIPE)
     off_p = NULL;
   for (std::list<ptr>::const_iterator it = _buffers.begin();
        it != _buffers.end(); ++it) {


### PR DESCRIPTION
lseek()  returns  the resulting offset location as measured in bytes from the beginning of the file.  On error, the value (off_t) -1 is returned and errno is set to indicate the error. And this errno returned ESPIPE.

Signed-off-by: zhang.zezhu <zhang.zezhu@zte.com.cn>