### PR TITLE
librbd: fix missing return statement if failed to get mirror image state

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1839,6 +1839,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
             if (r < 0 && r != -ENOENT) {
               lderr(cct) << "error retrieving mirroring state: "
                 << cpp_strerror(r) << dendl;
+              return r;
             }
 
             if (mirror_image.state == cls::rbd::MIRROR_IMAGE_STATE_ENABLED) {


### PR DESCRIPTION
if fatal error occurred in `cls_client::mirror_image_get`, we should return the error and exit

Signed-off-by: runsisi <runsisi@zte.com.cn>