### PR TITLE
os/bluestore: change algorithm of compression header from string to int

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3689,7 +3689,8 @@ int BlueStore::_decompress(bufferlist& source, bufferlist* result)
   bufferlist::iterator i = source.begin();
   bluestore_compression_header_t chdr;
   ::decode(chdr, i);
-  CompressorRef compressor = Compressor::create(cct, chdr.type);
+  string name = bluestore_blob_t::get_comp_alg_name(chdr.type);
+  CompressorRef compressor = Compressor::create(cct, name);
   if (!compressor.get()) {
     // if compressor isn't available - error, because cannot return
     // decompressed data?
@@ -5952,7 +5953,7 @@ int BlueStore::_do_alloc_write(
       assert(b_off == 0);
       assert(wi.blob_length == l->length());
       bluestore_compression_header_t chdr;
-      chdr.type = c->get_type();
+      chdr.type = bluestore_blob_t::get_comp_alg_type(c->get_type());
       // FIXME: memory alignment here is bad
       bufferlist t;
       c->compress(*l, t);

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -1054,7 +1054,7 @@ void bluestore_compression_header_t::decode(bufferlist::iterator& p)
 
 void bluestore_compression_header_t::dump(Formatter *f) const
 {
-  f->dump_string("type", type);
+  f->dump_unsigned("type", type);
   f->dump_unsigned("length", length);
 }
 
@@ -1062,6 +1062,6 @@ void bluestore_compression_header_t::generate_test_instances(
   list<bluestore_compression_header_t*>& o)
 {
   o.push_back(new bluestore_compression_header_t);
-  o.push_back(new bluestore_compression_header_t("some_header"));
+  o.push_back(new bluestore_compression_header_t(1));
   o.back()->length = 1234;
 }

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -194,6 +194,33 @@ struct bluestore_blob_t {
     return -EINVAL;
   }
 
+  enum CompressionAlgorithm {
+    COMP_ALG_NONE = 0,
+    COMP_ALG_SNAPPY = 1,
+    COMP_ALG_ZLIB = 2,
+  };
+
+  static const char * get_comp_alg_name(int a) {
+    switch (a) {
+    case COMP_ALG_NONE: return "none";
+    case COMP_ALG_SNAPPY: return "snappy";
+    case COMP_ALG_ZLIB: return "zlib";
+    default: return "???";
+    }
+  }
+
+  static int get_comp_alg_type(const std::string &s) {
+    if (s == "none")
+      return COMP_ALG_NONE;
+    if (s == "snappy")
+      return COMP_ALG_SNAPPY;
+    if (s == "zlib")
+      return COMP_ALG_ZLIB;
+
+    assert(0 == "invalid compression algorithm");
+    return COMP_ALG_NONE;
+  }
+
   vector<bluestore_pextent_t> extents;///< raw data position on device
   uint32_t compressed_length = 0;     ///< compressed length if any
   uint32_t flags = 0;                 ///< FLAG_*
@@ -621,11 +648,11 @@ struct bluestore_wal_transaction_t {
 WRITE_CLASS_ENCODER(bluestore_wal_transaction_t)
 
 struct bluestore_compression_header_t {
-  std::string type;
+  uint8_t type = bluestore_blob_t::COMP_ALG_NONE;
   uint32_t length = 0;
 
   bluestore_compression_header_t() {}
-  bluestore_compression_header_t(const std::string& _type)
+  bluestore_compression_header_t(uint8_t _type)
     : type(_type) {}
 
   void encode(bufferlist& bl) const;


### PR DESCRIPTION
The literal description of compression algorithm can vary from
various compression types and thus increases the complexity of
en/decoding, which as a result can cause chaos. Also it can be
more efficient by translating it into a fixed-length type.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>