### PR TITLE
cmake: Really add FCGI_INCLUDE_DIR to include_directories for rgw

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1429,6 +1429,7 @@ if(${WITH_RADOSGW})
   endif(HAVE_SSL)
 
   add_library(rgw_a STATIC ${rgw_a_srcs})
+  target_include_directories(rgw_a PUBLIC ${FCGI_INCLUDE_DIR})
   target_link_libraries(rgw_a librados cls_rgw_client cls_refcount_client
     cls_log_client cls_statelog_client cls_timeindex_client cls_version_client
     cls_replica_log_client cls_user_client curl global expat ${OPENLDAP_LIBS})

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${FCGI_INCLUDE_DIR})
-
 add_executable(ceph_rgw_jsonparser
   rgw_jsonparser.cc
   rgw_common.cc

--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -4,7 +4,6 @@
 #include "rgw_fcgi.h"
 
 #include "acconfig.h"
-#include <fcgiapp.h>
 
 int RGWFCGX::write_data(const char *buf, int len)
 {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -254,6 +254,7 @@ add_executable(ceph_test_librgw_file
   )
 set_target_properties(ceph_test_librgw_file PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
+target_include_directories(ceph_test_librgw_file PRIVATE ${FCGI_INCLUDE_DIR})
 target_link_libraries(ceph_test_librgw_file
   rgw
   librados
@@ -293,6 +294,7 @@ add_executable(ceph_test_librgw_file_nfsns
   )
 set_target_properties(ceph_test_librgw_file_nfsns PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
+target_include_directories(ceph_test_librgw_file_nfsns PRIVATE ${FCGI_INCLUDE_DIR})
 target_link_libraries(ceph_test_librgw_file_nfsns
   rgw
   librados


### PR DESCRIPTION
Commit 3cf6c53 was incorrect.  FCGI_INCLUDE_DIR doesn't need to be
set in src/rgw/CMakeLists.txt, but it does need to be set for the
rgw_a target in src/CMakeLists.txt, as well as for the
ceph_test_librgw_file and ceph_test_librgw_file_nfsns targets in
src/test/CMakeLists.txt.  I can only assume that I must not have
done a completely clean rebuild at some point when testing a
reworked version of the earlier commit :-/

This is only a problem for distros that keep the FCGI headers in
/usr/include/fastcgi/ (e.g.: SUSE).

This commit also removes a redundant include of <fcgiapp.h>

Signed-off-by: Tim Serong <tserong@suse.com>