### PR TITLE
os/bluestore: replace interval_set with a bitset for used_block conta…

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -27,6 +27,7 @@
 #include <boost/intrusive/unordered_set.hpp>
 #include <boost/intrusive/set.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/dynamic_bitset.hpp>
 
 #include "include/assert.h"
 #include "include/unordered_map.h"
@@ -1272,7 +1273,7 @@ private:
     string what,
     const BlobMap& blob_map,
     map<int64_t,bluestore_extent_ref_map_t>& v,
-    interval_set<uint64_t> &used_blocks,
+    boost::dynamic_bitset<> &used_blocks,
     store_statfs_t& expected_statfs);
 
 public:


### PR DESCRIPTION
…iner in fsck

The reasons for the change are memory footprint reduction/limitation and lookup/insert/remote performance improvement. The latter operations have constant complexity for bitset container comparing to increasing one for interval_set. The same  applies to memory footprint (permanent vs growing) too.

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>