### PR TITLE
msg/AsyncMessenger.cc: remove unneeded cast

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -730,7 +730,7 @@ void AsyncMessenger::submit_message(Message *m, AsyncConnectionRef con,
   // local?
   if (my_inst.addr == dest_addr) {
     // local
-    static_cast<AsyncConnection*>(local_connection.get())->send_message(m);
+    local_connection->send_message(m);
     return ;
   }
 


### PR DESCRIPTION
send_message is a virtual function, so there is no need to be casting
the pointer to AsyncConnection.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>