### PR TITLE
mds: move Finisher to unlocked shutdown

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -223,8 +223,6 @@ void MDSRankDispatcher::shutdown()
   // threads block on IOs that require finisher to complete.
   mdlog->shutdown();
 
-  finisher->stop(); // no flushing
-
   // shut down cache
   mdcache->shutdown();
 
@@ -237,11 +235,15 @@ void MDSRankDispatcher::shutdown()
 
   progress_thread.shutdown();
 
-  // shut down messenger
-  // release mds_lock first because messenger thread might call 
-  // MDSDaemon::ms_handle_reset which will try to hold mds_lock
+  // release mds_lock for finisher/messenger threads (e.g.
+  // MDSDaemon::ms_handle_reset called from Messenger).
   mds_lock.Unlock();
+
+  finisher->stop(); // no flushing
+
+  // shut down messenger
   messenger->shutdown();
+
   mds_lock.Lock();
 
   // Workaround unclean shutdown: HeartbeatMap will assert if


### PR DESCRIPTION
This commit resolves a deadlock reported in i16042 where the thread calling
MDSRankDispatcher::shutdown would hold the mds_lock while asynchronous
callbacks in the Finisher would attempt to lock mds_lock.

For simplicity, I merged the finisher stop with the messenger shutdown as both
need the mds_lock dropped.

Fixes: http://tracker.ceph.com/issues/16042

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>