### PR TITLE
os/bluestore/BlueFS: don't inc l_bluefs_files_written_wal if overwrite.

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1530,7 +1530,7 @@ int BlueFS::open_for_write(
 
   if (0 == filename.compare(filename.length() - 4, 4, ".log")) {
     (*h)->writer_type = BlueFS::WRITER_WAL;
-    if (logger) {
+    if (logger && !overwrite) {
       logger->inc(l_bluefs_files_written_wal);
     }
   } else if (0 == filename.compare(filename.length() - 4, 4, ".sst")) {


### PR DESCRIPTION
Because rocksdb now use journal recycling. So we can use this
perfcounter to judge whether this feature work.
We hope after some time, rocksdb don't create new wal log instead of
using old log.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>