### PR TITLE
CMakeList.txt: Fix libraries for ceph_objectstore_tool

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -34,7 +34,10 @@ install(PROGRAMS
 add_executable(ceph-objectstore-tool
   ceph_objectstore_tool.cc
   RadosDump.cc)
-target_link_libraries(ceph-objectstore-tool osd os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${CMAKE_DL_LIBS} fuse)
+target_link_libraries(ceph-objectstore-tool osd os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${CMAKE_DL_LIBS})
+if(WITH_FUSE)
+  target_link_libraries(ceph-objectstore-tool fuse)
+endif(WITH_FUSE)
 install(TARGETS ceph-objectstore-tool DESTINATION bin)
 
 add_executable(ceph-client-debug ceph-client-debug.cc)


### PR DESCRIPTION
 - Does not require fuse
 - is CMAKE_DL_LIBS instead of dl

Submitted-by: Willem Jan Withagen <wjw@digiware.nl>