### PR TITLE
mon: avoid start election twice when quorum enter

### DIFF
--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -488,6 +488,5 @@ void Elector::start_participating()
 {
   if (!participating) {
     participating = true;
-    call_election();
   }
 }

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -425,6 +425,7 @@ class Elector {
    * @post  @p participating is true
    */
   void start_participating();
+
   /**
    * @}
    */


### PR DESCRIPTION
mon: avoid start election twice when quorum enter

when quorum enter it is no meaning to start election twice

Signed-off-by: song baisen song.baisen@zte.com.cn
