### PR TITLE
osd: increment stats on recovery pull also

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1832,7 +1832,11 @@ bool ReplicatedBackend::handle_pull_response(
 		   pop.omap_entries,
 		   t);
 
+  pi.stat.num_keys_recovered += pop.omap_entries.size();
+  pi.stat.num_bytes_recovered += data.length();
+
   if (complete) {
+    pi.stat.num_objects_recovered++;
     to_continue->push_back(hoid);
     get_parent()->on_local_recover(
       hoid, pi.recovery_info, pi.obc, t);


### PR DESCRIPTION
PGMap::recovery_rate_summary() summaries the recovery progress from
a pool's
pool_stat_t.stats.sum.num_{objects_recovered,bytes_recovered,keys_recovered},
now we only increment stats on completion of recovery push, but there
are chances that a PG recovers by pulling data from replicas to primary.
in that case, teuthology will erroneously consider recovery hung: a zero
recovering_keys_per_sec or recovering_bytes_per_sec or
recovering_objects_per_sec. so we should increment stats on pull as
well.

Fixes: http://tracker.ceph.com/issues/16277
Signed-off-by: Kefu Chai <kchai@redhat.com>