### PR TITLE
test: test_{compression_plugin,async_compressor}: do not copy plugins

### DIFF
--- a/src/test/common/test_async_compressor.cc
+++ b/src/test/common/test_async_compressor.cc
@@ -212,17 +212,6 @@ int main(int argc, char **argv) {
 
   const char* env = getenv("CEPH_LIB");
   string directory(env ? env : ".libs");
-
-  // copy libceph_snappy.so into $plugin_dir/compressor for PluginRegistry
-  // TODO: just build the compressor plugins in this subdir
-  string mkdir_compressor = "mkdir -p " + directory + "/compressor";
-  int r = system(mkdir_compressor.c_str());
-  (void)r;
-
-  string cp_libceph_snappy = "cp " + directory + "/libceph_snappy.so* " + directory + "/compressor/";
-  r = system(cp_libceph_snappy.c_str());
-  (void)r;
-
   g_conf->set_val("plugin_dir", directory, false, false);
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/test/compressor/test_compression_plugin.cc
+++ b/src/test/compressor/test_compression_plugin.cc
@@ -56,14 +56,6 @@ int main(int argc, char **argv) {
 
   const char* env = getenv("CEPH_LIB");
   string directory(env ? env : ".libs");
-  string mkdir_compressor = "mkdir -p " + directory + "/compressor";
-  int r = system(mkdir_compressor.c_str());
-  (void)r;
-
-  string cp_libceph_example = "cp " + directory + "/libceph_example.so* " + directory + "/compressor/";
-  r = system(cp_libceph_example.c_str());
-  (void)r;
-
   g_conf->set_val("plugin_dir", directory, false, false);
 
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
do not copy plugins in unittest_{compression_plugin,async_compressor}
anymore.
42c640e searches in conf->plugin_dir also, if conf->plugin_dir/$type
does not have the requested plugin.

Signed-off-by: Kefu Chai <kchai@redhat.com>