### PR TITLE
qa/workunits/rbd: before removing image make sure it is not bootstrapped

### DIFF
--- a/qa/workunits/rbd/rbd_mirror.sh
+++ b/qa/workunits/rbd/rbd_mirror.sh
@@ -170,6 +170,8 @@ unprotect_snapshot ${CLUSTER2} ${POOL} ${image5} 'snap2'
 for i in ${image3} ${image5}; do
   remove_snapshot ${CLUSTER2} ${POOL} ${i} 'snap1'
   remove_snapshot ${CLUSTER2} ${POOL} ${i} 'snap2'
+  # workaround #16555: before removing make sure it is not still bootstrapped
+  wait_for_image_replay_started ${CLUSTER1} ${POOL} ${i}
   remove_image ${CLUSTER2} ${POOL} ${i}
 done
 


### PR DESCRIPTION
If an image is being bootstrapped, it implies that the rbd-mirror
daemon currently has the image open. The removal API will prevent the
removal of any image that is opened by another client.

Works-around: http://tracker.ceph.com/issues/16555
Signed-off-by: Mykola Golub <mgolub@mirantis.com>