### PR TITLE
rgw: fix error_repo segfault in data sync

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -865,7 +865,7 @@ class RGWDataSyncSingleEntryCR : public RGWCoroutine {
 
   RGWDataSyncShardMarkerTrack *marker_tracker;
 
-  RGWOmapAppend *error_repo;
+  boost::intrusive_ptr<RGWOmapAppend> error_repo;
   bool remove_from_repo;
 
   set<string> keys;
@@ -906,10 +906,10 @@ public:
         if (retcode < 0) {
           ldout(sync_env->store->ctx(), 0) << "ERROR: failed to log sync failure: retcode=" << retcode << dendl;
         }
-        if (!error_repo->append(raw_key)) {
+        if (error_repo && !error_repo->append(raw_key)) {
           ldout(sync_env->store->ctx(), 0) << "ERROR: failed to log sync failure in error repo: retcode=" << retcode << dendl;
         }
-      } else if (remove_from_repo) {
+      } else if (error_repo && remove_from_repo) {
         keys = {raw_key};
         yield call(new RGWRadosRemoveOmapKeysCR(sync_env->store, error_repo->get_pool(), error_repo->get_oid(), keys));
         if (retcode < 0) {


### PR DESCRIPTION
RGWDataSyncShardCR will only allocate an error_repo if it's doing
incremental sync, so RGWDataSyncSingleEntryCR needs to guard against a
null error_repo

also, RGWDataSyncShardCR::stop_spawned_services() was dropping the last
reference to the error_repo before calling drain_all(), which meant that
RGWDataSyncSingleEntryCR could still be holding a pointer

Fixes: http://tracker.ceph.com/issues/16603

Signed-off-by: Casey Bodley <cbodley@redhat.com>