### PR TITLE
doc: add rgw_enable_usage_log option in Rados Gateway admin guide

### DIFF
--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -433,6 +433,8 @@ Usage
 The Ceph Object Gateway logs usage for each user. You can track
 user usage within date ranges too.
 
+- Add ``rgw enable usage log = true`` in [client.rgw] section of ceph.conf and restart the radosgw service. 
+
 Options include: 
 
 - **Start Date:** The ``--start-date`` option allows you to filter usage


### PR DESCRIPTION
doc: add rgw_enable_usage_log option in Rados Gateway admin guide

Fixes: http://tracker.ceph.com/issues/16604

Signed-off-by: Mike Hackett <mhackett@redhat.com>