### PR TITLE
rgw: better error message when user has no bucket created yet

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4817,7 +4817,11 @@ next:
     string user_str = user_id.to_str();
     int ret = store->cls_user_get_header(user_str, &header);
     if (ret < 0) {
-      cerr << "ERROR: can't read user header: " << cpp_strerror(-ret) << std::endl;
+      if (ret == -ENOENT) { /* in case of ENOENT */
+        cerr << "User has not been initialized or user does not exist" << std::endl;
+      } else {
+        cerr << "ERROR: can't read user: " << cpp_strerror(ret) << std::endl;
+      }
       return -ret;
     }
 


### PR DESCRIPTION
Currently when there is no bucket in the cluster and user execute
 "$radosgw-admin user  stats --uid=testid" command then rgw admin
not throwing meaningful error message.

With this fix it will show proper meaningful error message.

Fixes: http://tracker.ceph.com/issues/16444

Reported-by: Abhishek Lekshmanan <abhishek@suse.com>
Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>