### PR TITLE
cmake: ceph_test_rbd_mirror does not require librados_test_stub

### DIFF
--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -60,7 +60,6 @@ set_target_properties(ceph_test_rbd_mirror PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_test_rbd_mirror
   rbd_mirror
-  rados_test_stub
   rbd_mirror_internal
   rbd_internal
   rbd_api


### PR DESCRIPTION
Linking both librados_test_stub and librados results in failed
test cases.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>