### PR TITLE
client: move Inode specific cleanup to destructor

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2831,9 +2831,6 @@ void Client::put_inode(Inode *in, int n)
     if (use_faked_inos())
       _release_faked_ino(in);
 
-    in->cap_item.remove_myself();
-    in->snaprealm_item.remove_myself();
-    in->snapdir_parent.reset();
     if (in == root) {
       root = 0;
       root_ancestor = 0;
@@ -2841,14 +2838,6 @@ void Client::put_inode(Inode *in, int n)
         root_parents.erase(root_parents.begin());
     }
 
-    if (!in->oset.objects.empty()) {
-      ldout(cct, 0) << __func__ << ": leftover objects on inode 0x"
-        << std::hex << in->ino << std::dec << dendl;
-      assert(in->oset.objects.empty());
-    }
-
-    delete in->fcntl_locks;
-    delete in->flock_locks;
     delete in;
   }
 }

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -9,6 +9,24 @@
 #include "ClientSnapRealm.h"
 #include "UserGroups.h"
 
+#include "mds/flock.h"
+
+Inode::~Inode()
+{
+  cap_item.remove_myself();
+  snaprealm_item.remove_myself();
+  snapdir_parent.reset();
+
+  if (!oset.objects.empty()) {
+    lsubdout(client->cct, client, 0) << __func__ << ": leftover objects on inode 0x"
+      << std::hex << ino << std::dec << dendl;
+    assert(oset.objects.empty());
+  }
+
+  delete fcntl_locks;
+  delete flock_locks;
+}
+
 ostream& operator<<(ostream &out, const Inode &in)
 {
   out << in.vino() << "("

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -244,7 +244,7 @@ struct Inode {
     memset(&dir_layout, 0, sizeof(dir_layout));
     memset(&quota, 0, sizeof(quota));
   }
-  ~Inode() { }
+  ~Inode();
 
   vinodeno_t vino() const { return vinodeno_t(ino, snapid); }
 


### PR DESCRIPTION
This better internalizes Inode management.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>