### PR TITLE
rgw: add user default-placement cmd

### DIFF
--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2246,6 +2246,11 @@ int RGWUser::execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg)
   if (op_state.mfa_ids_specified) {
     user_info.mfa_ids = op_state.mfa_ids;
   }
+  
+  if (op_state.has_default_placement_op()) {
+    user_info.default_placement = op_state.get_default_placement();
+  }
+  
   op_state.set_user_info(user_info);
 
   // if we're supposed to modify keys, do so

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -170,6 +170,7 @@ struct RGWUserAdminOpState {
   RGWObjVersionTracker objv;
   uint32_t op_mask;
   map<int, string> temp_url_keys;
+  std::string default_placement;
 
   // subuser attributes
   std::string subuser;
@@ -222,6 +223,8 @@ struct RGWUserAdminOpState {
 
   bool bucket_quota_specified;
   bool user_quota_specified;
+
+  bool default_placement_specified;
 
   RGWQuotaInfo bucket_quota;
   RGWQuotaInfo user_quota;
@@ -396,6 +399,11 @@ struct RGWUserAdminOpState {
     mfa_ids = ids;
     mfa_ids_specified = true;
   }
+ 
+ void set_default_placement(const string &placement) {
+    default_placement = placement;
+    default_placement_specified = true;
+  }
 
   bool is_populated() { return populated; }
   bool is_initialized() { return initialized; }
@@ -407,6 +415,7 @@ struct RGWUserAdminOpState {
   bool has_key_op() { return key_op; }
   bool has_caps_op() { return caps_specified; }
   bool has_suspension_op() { return suspension_op; }
+  bool has_default_placement_op() { return default_placement_specified; }
   bool has_subuser_perm() { return perm_specified; }
   bool has_op_mask() { return op_mask_specified; }
   bool will_gen_access() { return gen_access; }
@@ -442,6 +451,7 @@ struct RGWUserAdminOpState {
   std::string get_caps() { return caps; }
   std::string get_user_email() { return user_email; }
   std::string get_display_name() { return display_name; }
+  std::string get_default_placement() { return default_placement; }
   map<int, std::string>& get_temp_url_keys() { return temp_url_keys; }
 
   RGWUserInfo&  get_user_info() { return info; }
@@ -534,6 +544,7 @@ struct RGWUserAdminOpState {
     found_by_email = false;
     found_by_key = false;
     mfa_ids_specified = false;
+    default_placement_specified = false;
   }
 };
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -10,6 +10,7 @@
     user check                 check user info
     user stats                 show user stats as accounted by quota subsystem
     user list                  list users
+    user default-placement     set user default-placement
     caps add                   add user capabilities
     caps rm                    remove user capabilities
     subuser create             create a new subuser
@@ -167,6 +168,8 @@
                                of read, write, readwrite, full
      --display-name=<name>     user's display name
      --max-buckets             max number of buckets for a user
+     --default-placement=<placement-rule>
+                               specify placement-rule for user default-placement
      --admin                   set the admin flag on the user
      --system                  set the system flag on the user
      --bucket=<bucket>         Specify the bucket name. Also used by the quota command.


### PR DESCRIPTION
Add user default-placement cmd to set  or clear default placement rule for a user. The format of this cmd is:

```
radosgw-admin user default-placement --uid=<uid> --default-placement=<placement-rule>
```

e.x.  
set placement-rule named "ssd-placement" to a user named "testuser":

```
radosgw-admin user default-placement --uid=testuser --default-placement="ssd-placement" 
```

and clear it with an empty string specified to "--default-placement" option

```
radosgw-admin user default-placement --uid=testuser --default-placement="" 
```

Signed-off-by: Wei Qiaomiao wei.qiaomiao@zte.com.cn
