### PR TITLE
rgw: test_multi.py avoid creating mds

### DIFF
--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -79,7 +79,7 @@ def mstart(cluster_id, is_new):
     cmd = mpath('mstart.sh', cluster_id)
     if is_new:
         cmd += ' -n'
-
+        cmd += ' --mds_num 0'
     bash(cmd)
 
 def mstop(cluster_id, entity = None):

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -491,7 +491,7 @@ class RGWMulti:
         realm = RGWRealm('earth', realm_credentials, self.clusters)
 
         if bootstrap:
-            log(1, 'bootstapping clusters')
+            log(1, 'bootstrapping clusters')
             self.clusters[0].start()
             realm.init_zone(self.clusters[0], 'us', 'us-1', self.base_port)
 


### PR DESCRIPTION
Avoid creating mds' while bootstrapping new clusters from test_multi.py
as we only require an rgw+ceph cluster for the tests

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>