### PR TITLE
mon/mds: add err info when load_metadata is abnormal

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2641,8 +2641,10 @@ int MDSMonitor::load_metadata(map<mds_gid_t, Metadata>& m)
 {
   bufferlist bl;
   int r = mon->store->get(MDS_METADATA_PREFIX, "last_metadata", bl);
-  if (r)
+  if (r) {
+    dout(1) << "Unable to load 'last_metadata'" << dendl;
     return r;
+  }
 
   bufferlist::iterator it = bl.begin();
   ::decode(m, it);


### PR DESCRIPTION
add a print of the most important reason is that:
when the MDSMonitor::init  call MDSMonitor::load_metadata, no processing error code,
so printing can discover problems

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>