### PR TITLE
mrgw: search for cmake build dir.

### DIFF
--- a/src/mrgw.sh
+++ b/src/mrgw.sh
@@ -3,6 +3,14 @@
 set -e
 
 script_root=`dirname $0`
+script_root=`(cd $script_root;pwd)`
+if [ -e CMakeCache.txt ]; then
+    script_root=$PWD
+elif [ -e $root_path/../build/CMakeCache.txt ]; then
+    cd $root_path/../build
+    script_root=$PWD
+fi
+vstart_path=`dirname $0`
 
 [ "$#" -lt 2 ] && echo "usage: $0 <name> <port> [params...]" && exit 1
 
@@ -16,6 +24,6 @@ pidfile=$run_root/out/radosgw.${port}.pid
 asokfile=$run_root/out/radosgw.${port}.asok
 logfile=$run_root/out/radosgw.${port}.log
 
-$script_root/mstop.sh $name radosgw $port
+$vstart_path/mstop.sh $name radosgw $port
 
-$script_root/mrun $name radosgw --rgw-frontends="civetweb port=$port" --pid-file=$pidfile --admin-socket=$asokfile "$@" --log-file=$logfile
+$vstart_path/mrun $name radosgw --rgw-frontends="civetweb port=$port" --pid-file=$pidfile --admin-socket=$asokfile "$@" --log-file=$logfile


### PR DESCRIPTION
Similar to mstart and mstop, mrgw also needs to find the correct build
dir as we pass in the pidfile and asokfile which otherwise falls back to
src/run dir.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>