### PR TITLE
configure: Add -D_LARGEFILE64_SOURCE to Linux build.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ darwin*)
 	;;
 linux*)
 	linux="yes"
+	CFLAGS="-D_LARGEFILE64_SOURCE ${CFLAGS}"
 	;;
 freebsd*)
 	freebsd="yes"


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16612

Without -D_LARGEFILE64_SOURCE we can't build against libxfs,
because off64_t must be defined.

Signed-off-by: Ira Cooper <ira@redhat.com>
(cherry picked from commit 602425a)