### PR TITLE
hammer: configure: Add -D_LARGEFILE64_SOURCE to Linux build.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ darwin*)
 	;;
 linux*)
 	linux="yes"
+	CFLAGS="-D_LARGEFILE64_SOURCE ${CFLAGS}"
 	;;
 freebsd*)
 	freebsd="yes"


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16612
