### PR TITLE
jewel: rgw: fix multi-delete query param parsing.

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1473,7 +1473,7 @@ int RGWHandler_REST::read_permissions(RGWOp* op_obj)
   case OP_POST:
   case OP_COPY:
     /* is it a 'multi-object delete' request? */
-    if (s->info.request_params == "delete") {
+    if (s->info.args.exists("delete")) {
       only_bucket = true;
       break;
     }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2690,7 +2690,7 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_delete()
 
 RGWOp *RGWHandler_REST_Bucket_S3::op_post()
 {
-  if ( s->info.request_params == "delete" ) {
+  if (s->info.args.exists("delete")) {
     return new RGWDeleteMultiObj_ObjStore_S3;
   }
 


### PR DESCRIPTION
Backport: http://tracker.ceph.com/issues/16699

Multi-delete is triggered by a query parameter on POST, but there are
multiple valid ways of representing it, and Ceph should accept ANY way
that has the query parameter set, regardless of what value or absence of
value.

This caused the RubyGem aws-sdk-v1 to break, and has been present since
multi-delete was first added in commit 0a1f4a97da, for the bobtail
release.

Fixes: http://tracker.ceph.com/issues/16618
Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>
(cherry picked from commit a7016e1b67e82641f0702fda4eae799e953063e6)