### PR TITLE
doc: more details for pool deletion

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -179,9 +179,22 @@ To delete a pool, execute::
 
 	
 If you created your own rulesets and rules for a pool you created,  you should
-consider removing them when you no longer need your pool.  If you created users
-with permissions strictly for a pool that no longer exists, you should consider
-deleting those users too.
+consider removing them when you no longer need your pool::
+
+	ceph osd pool get {pool-name} crush_ruleset
+
+If the ruleset was "123", for example, you can check the other pools like so::
+
+	ceph osd dump | grep "^pool" | grep "crush_ruleset 123"
+
+If no other pools use that custom ruleset, then it's safe to delete that
+ruleset from the cluster.
+
+If you created users with permissions strictly for a pool that no longer
+exists, you should consider deleting those users too::
+
+	ceph auth list | grep -C 5 {pool-name}
+	ceph auth del {user}
 
 
 Rename a Pool


### PR DESCRIPTION
Prior to this change, the documention instructed administrators to delete rulesets and users, but did not go into details regarding how to do that.

Add example commands that admins may use to search for rulesets and users that might reference the to-be-deleted pool.