### PR TITLE
log/LogClient: fill seq & who for syslog and graylog

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -238,11 +238,10 @@ void LogChannel::do_log(clog_type prio, const std::string& s)
   int lvl = (prio == CLOG_ERROR ? -1 : 0);
   ldout(cct,lvl) << "log " << prio << " : " << s << dendl;
   LogEntry e;
-  // who will be set when we queue the entry on LogClient
-  //e.who = messenger->get_myinst();
   e.stamp = ceph_clock_now(cct);
-  // seq will be set when we queue the entry on LogClient
-  // e.seq = ++last_log;
+  // seq and who should be set for syslog/graylog/log_to_mon
+  e.who = parent->get_myinst();
+  e.seq = parent->get_next_seq();
   e.prio = prio;
   e.msg = s;
   e.channel = get_log_channel();
@@ -342,8 +341,6 @@ void LogClient::_send_to_mon()
 version_t LogClient::queue(LogEntry &entry)
 {
   Mutex::Locker l(log_lock);
-  entry.seq = ++last_log;
-  entry.who = messenger->get_myinst();
   log_queue.push_back(entry);
 
   if (is_mon) {
@@ -351,6 +348,16 @@ version_t LogClient::queue(LogEntry &entry)
   }
 
   return entry.seq;
+}
+
+uint64_t LogClient::get_next_seq()
+{
+  return ++last_log;
+}
+
+const entity_inst_t& LogClient::get_myinst()
+{
+  return messenger->get_myinst();
 }
 
 bool LogClient::handle_log_ack(MLogAck *m)

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -20,6 +20,7 @@
 
 #include <iosfwd>
 #include <sstream>
+#include <atomic>
 
 class LogClient;
 class MLog;
@@ -233,6 +234,8 @@ public:
     channels.clear();
   }
 
+  uint64_t get_next_seq();
+  const entity_inst_t& get_myinst();
   version_t queue(LogEntry &entry);
 
 private:
@@ -245,7 +248,7 @@ private:
   bool is_mon;
   Mutex log_lock;
   version_t last_log_sent;
-  version_t last_log;
+  std::atomic<uint64_t> last_log;
   std::deque<LogEntry> log_queue;
 
   std::map<std::string, LogChannelRef> channels;


### PR DESCRIPTION
Previous code fill "seq" and "who" in LogClient::queue(), but
syslog and graylog doesn't go through this path. Which will result
the message without unidentifier.

Fixes http://tracker.ceph.com/issues/16609

Signed-off-by: Xiaoxi Chen xiaoxchen@ebay.com
