### PR TITLE
mds/MDSMap output None instead of 0 when no fs present.

### DIFF
--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -225,7 +225,7 @@ public:
       session_autoclose(0),
       max_file_size(0),
       cas_pool(-1),
-      metadata_pool(0),
+      metadata_pool(-1),
       max_mds(0),
       ever_allowed_features(0),
       explicitly_allowed_features(0),


### PR DESCRIPTION
When no fs present, the mdsmap::dump will output metadata_pool: 0,
which is misleading.

Change the initial value of metadata_pool from 0 to -1 , and output None
when seeing -1.

Fixes: http://tracker.ceph.com/issues/16588

Signed-off-by: Xiaoxi Chen <xiaoxchen@ebay.com>