### PR TITLE
cmake: fixes for pypi change

### DIFF
--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -66,11 +66,13 @@ function(distutils_install_cython_module name)
        COMMAND env
            CYTHON_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
            CEPH_LIBDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+           CC=${CMAKE_C_COMPILER}
            CFLAGS=\"-iquote ${CMAKE_SOURCE_DIR}/src/include\"
            ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
            build --build-base ${CYTHON_MODULE_DIR} --verbose
-           install \${options} --verbose
-           --single-version-externally-managed --record /dev/null
+           install \${options} --single-version-externally-managed --record /dev/null
+           egg_info --egg-base ${CMAKE_CURRENT_BINARY_DIR}
+           --verbose
        WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\"
        RESULT_VARIABLE install_res)
     if(NOT \"\${install_res}\" STREQUAL 0)

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -109,7 +109,7 @@ def check_sanity():
 
     try:
         compiler.link_executable(
-            compiler.compile([tmp_file]),
+            compiler.compile([tmp_file], tmp_dir),
             os.path.join(tmp_dir, 'rados_dummy'),
             libraries=['rados'],
             output_dir=tmp_dir,


### PR DESCRIPTION
this fixes the failure like
```
+ echo 'error: Added files:'
error: Added files:
+ cat .git/added-files
src/pybind/rados/rados.egg-info/PKG-INFO
...
```

see http://gitbuilder.sepia.ceph.com/gitbuilder-ceph-tarball-trusty-amd64-cmake/log.cgi?log=07387eb9af16b4916c64259d8aa98267b34b3a6c