### PR TITLE
ceph-disk: get partition uuid and type from sgdisk

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3839,11 +3839,29 @@ def split_dev_base_partnum(dev):
 
 
 def get_partition_type(part):
-    return get_blkid_partition_info(part, 'ID_PART_ENTRY_TYPE')
+    return get_raw_partition_info(part, 'Partition GUID code')
 
 
 def get_partition_uuid(part):
-    return get_blkid_partition_info(part, 'ID_PART_ENTRY_UUID')
+    return get_raw_partition_info(part, 'Partition unique GUID')
+
+
+def get_raw_partition_info(part, what=None):
+    (base, partnum) = split_dev_base_partnum(part)
+    out, _, _ = command(
+        [
+            'sgdisk',
+            '-i',
+            str(partnum),
+            base,
+        ]
+    )
+    for line in out.splitlines():
+        line_list = line.split(": ")
+        if what in line_list:
+            v = line_list[1].split(" ")[0]
+            return v.rstrip().lower()
+    return None
 
 
 def get_blkid_partition_info(dev, what=None):


### PR DESCRIPTION
Some test cases in ceph-disk-test.py will fail when checking osd status for journal as follows. The reason is that journal is a raw partition without filesystem, ceph-disk can't get partition uuid and type from blkid on journal. So uuid_map in ceph-disk when listing devices didn't include journal uuid and there is no "journal_dev" as key in the final output. 

I think we could use sgdisk to get partition uuid and type. Tests have passed then. 

```
================================================================================= FAILURES =================================================================================
_______________________________________________________________ TestCephDisk.test_deactivate_reactivate_osd ________________________________________________________________

self = <ceph-disk-test.TestCephDisk object at 0x1f5d8d0>

    def test_deactivate_reactivate_osd(self):
        c = CephDisk()
        disk = c.unused_disks()[0]
        osd_uuid = str(uuid.uuid1())
        c.sh("ceph-disk --verbose zap " + disk)
        c.sh("ceph-disk --verbose prepare --osd-uuid " + osd_uuid +
             " " + disk)
        c.wait_for_osd_up(osd_uuid)
        device = json.loads(c.sh("ceph-disk list --format json " + disk))[0]
        assert len(device['partitions']) == 2
>       c.check_osd_status(osd_uuid, 'journal')

ceph-disk-test.py:259: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ceph-disk-test.CephDisk instance at 0x1f63050>, uuid = '5eecfede-44be-11e6-a315-e8bdd1f96413', space_name = 'journal'

    def check_osd_status(self, uuid, space_name=None):
        data_partition = self.get_osd_partition(uuid)
        assert data_partition['type'] == 'data'
        assert data_partition['state'] == 'active'
        if space_name is not None:
>           space_partition = self.get_space_partition(space_name, uuid)
ceph-disk-test.py:217: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ceph-disk-test.CephDisk instance at 0x1f63050>, name = 'journal', uuid = '5eecfede-44be-11e6-a315-e8bdd1f96413'

    def get_space_partition(self, name, uuid):
        data_partition = self.get_osd_partition(uuid)
>       space_dev = data_partition[name + '_dev']
E       KeyError: 'journal_dev'
```

```
[xxx]$ sudo sgdisk -p /dev/sdb
...
Number  Start (sector)    End (sector)  Size       Code  Name
   1        20482048      3907029134   1.8 TiB     FFFF  ceph data
   2            2048        20482047   9.8 GiB     FFFF  ceph journal

[xxx]$ sudo blkid -o udev -p /dev/sdb2
[xxx]$ 
[xxx]$sudo sgdisk -i 2 /dev/sdb
Partition GUID code: 45B0969E-9B03-4F30-B4C6-B4B80CEFF106 (Unknown)
Partition unique GUID: EB88026D-F9FD-4E58-AE10-CF6DEEDE236D
First sector: 2048 (at 1024.0 KiB)
Last sector: 20482047 (at 9.8 GiB)
Partition size: 20480000 sectors (9.8 GiB)
Attribute flags: 0000000000000000
Partition name: 'ceph journal'
```

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>