### PR TITLE
rgw: Fix incorrect content length and range for zero sized objects during range requests

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1341,6 +1341,13 @@ void RGWGetObj::execute()
   if (op_ret < 0)
     goto done_err;
 
+  // for range requests with obj size 0
+  if (range_str && !(s->obj_size)) {
+    total_len = 0;
+    op_ret = -ERANGE;
+    goto done_err;
+  }
+
   /* start gettorrent */
   if (torrent.get_flag())
   {

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -655,9 +655,7 @@ void end_header(struct req_state* s, RGWOp* op, const char *content_type,
       s->formatter->close_section();
     }
     s->formatter->output_footer();
-    if (s->obj_size) {
-      dump_content_length(s, s->formatter->get_len());
-    }
+    dump_content_length(s, s->formatter->get_len());
   } else {
     if (proposed_content_length != NO_CONTENT_LENGTH) {
       dump_content_length(s, proposed_content_length);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1206,13 +1206,14 @@ int RGWGetObj_ObjStore_SWIFT::send_response_data(bufferlist& bl,
   set_req_state_err(s, (partial_content && !op_ret) ? STATUS_PARTIAL_CONTENT
 		    : op_ret);
   dump_errno(s);
-  if (s->err.is_err()) {
-    end_header(s, NULL);
-    return 0;
-  }
 
   if (range_str) {
     dump_range(s, ofs, end, s->obj_size);
+  }
+
+  if (s->err.is_err()) {
+    end_header(s, NULL);
+    return 0;
   }
 
   dump_content_length(s, total_len);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16388

Signed-off-by: Pavan Rallabhandi <PRallabhandi@walmartlabs.com>