### PR TITLE
Include Python 3 bindings into the cmake build and make packages for them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,6 @@ if(${WITH_EXPAT})
 find_package(EXPAT REQUIRED)
 endif(${WITH_EXPAT})
 
-find_package(Cython REQUIRED)
 find_package(fcgi REQUIRED)
 
 find_package(atomic_ops REQUIRED)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -45,6 +45,7 @@
 
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}
 %{!?tmpfiles_create: %global tmpfiles_create systemd-tmpfiles --create}
+%{!?python3_pkgversion: %global python3_pkgversion 3}
 
 # unify libexec for all targets
 %global _libexecdir %{_exec_prefix}/lib
@@ -153,6 +154,16 @@ BuildRequires:  openldap-devel
 BuildRequires:  openssl-devel
 BuildRequires:  redhat-lsb-core
 BuildRequires:	Cython
+%endif
+# python34-... for RHEL, python3-... for all other supported distros
+%if 0%{?rhel}
+BuildRequires:	python34-devel
+BuildRequires:	python34-setuptools
+BuildRequires:	python34-Cython
+%else
+BuildRequires:	python3-devel
+BuildRequires:	python3-setuptools
+BuildRequires:	python3-Cython
 %endif
 # lttng and babeltrace for rbd-replay-prep
 %if %{with lttng}
@@ -399,13 +410,23 @@ This package contains libraries and headers needed to develop programs
 that use RADOS gateway client library.
 
 %package -n python-rados
-Summary:	Python libraries for the RADOS object store
+Summary:	Python 2 libraries for the RADOS object store
 Group:		System Environment/Libraries
 License:	LGPL-2.0
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 Obsoletes:	python-ceph < %{epoch}:%{version}-%{release}
 %description -n python-rados
-This package contains Python libraries for interacting with Cephs RADOS
+This package contains Python 2 libraries for interacting with Cephs RADOS
+object store.
+
+%package -n python%{python3_pkgversion}-rados
+Summary:	Python 3 libraries for the RADOS object store
+Group:		System Environment/Libraries
+License:	LGPL-2.0
+Requires:	python%{python3_pkgversion}
+Requires:	librados2 = %{epoch}:%{version}-%{release}
+%description -n python%{python3_pkgversion}-rados
+This package contains Python 3 libraries for interacting with Cephs RADOS
 object store.
 
 %package -n libradosstriper1
@@ -459,14 +480,24 @@ This package contains libraries and headers needed to develop programs
 that use RADOS block device.
 
 %package -n python-rbd
-Summary:	Python libraries for the RADOS block device
+Summary:	Python 2 libraries for the RADOS block device
 Group:		System Environment/Libraries
 License:	LGPL-2.0
 Requires:	librbd1 = %{epoch}:%{version}-%{release}
 Requires:	python-rados = %{epoch}:%{version}-%{release}
 Obsoletes:	python-ceph < %{epoch}:%{version}-%{release}
 %description -n python-rbd
-This package contains Python libraries for interacting with Cephs RADOS
+This package contains Python 2 libraries for interacting with Cephs RADOS
+block device.
+
+%package -n python%{python3_pkgversion}-rbd
+Summary:	Python 3 libraries for the RADOS block device
+Group:		System Environment/Libraries
+License:	LGPL-2.0
+Requires:	librbd1 = %{epoch}:%{version}-%{release}
+Requires:	python%{python3_pkgversion}-rados = %{epoch}:%{version}-%{release}
+%description -n python%{python3_pkgversion}-rbd
+This package contains Python 3 libraries for interacting with Cephs RADOS
 block device.
 
 %package -n libcephfs1
@@ -497,15 +528,35 @@ This package contains libraries and headers needed to develop programs
 that use Cephs distributed file system.
 
 %package -n python-cephfs
-Summary:	Python libraries for Ceph distributed file system
+Summary:	Python 2 libraries for Ceph distributed file system
 Group:		System Environment/Libraries
 License:	LGPL-2.0
 Requires:	libcephfs1 = %{epoch}:%{version}-%{release}
 Requires:	python-rados = %{epoch}:%{version}-%{release}
 Obsoletes:	python-ceph < %{epoch}:%{version}-%{release}
 %description -n python-cephfs
-This package contains Python libraries for interacting with Cephs distributed
+This package contains Python 2 libraries for interacting with Cephs distributed
 file system.
+
+%package -n python%{python3_pkgversion}-cephfs
+Summary:	Python 3 libraries for Ceph distributed file system
+Group:		System Environment/Libraries
+License:	LGPL-2.0
+Requires:	libcephfs1 = %{epoch}:%{version}-%{release}
+Requires:	python%{python3_pkgversion}-rados = %{epoch}:%{version}-%{release}
+%description -n python%{python3_pkgversion}-cephfs
+This package contains Python 3 libraries for interacting with Cephs distributed
+file system.
+
+%package -n python%{python3_pkgversion}-ceph-argparse
+Summary:	Python 3 utility libraries for Ceph CLI
+Group:		System Environment/Libraries
+License:	LGPL-2.0
+%description -n python%{python3_pkgversion}-ceph-argparse
+This package contains types and routines for Python 3 used by the Ceph CLI as
+well as the RESTful interface. These have to do with querying the daemons for
+command-description information, validating user command input against those
+descriptions, and submitting the command to the appropriate daemon.
 
 %package -n ceph-test
 Summary:	Ceph benchmarks and test tools
@@ -1266,6 +1317,12 @@ fi
 %{python_sitearch}/rados-*.egg-info
 
 #################################################################################
+%files -n python%{python3_pkgversion}-rados
+%defattr(-,root,root,-)
+%{python3_sitearch}/rados.cpython*.so
+%{python3_sitearch}/rados-*.egg-info
+
+#################################################################################
 %files -n libradosstriper1
 %defattr(-,root,root,-)
 %{_libdir}/libradosstriper.so.*
@@ -1338,6 +1395,12 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{python_sitearch}/rbd-*.egg-info
 
 #################################################################################
+%files -n python%{python3_pkgversion}-rbd
+%defattr(-,root,root,-)
+%{python3_sitearch}/rbd.cpython*.so
+%{python3_sitearch}/rbd-*.egg-info
+
+#################################################################################
 %files -n libcephfs1
 %defattr(-,root,root,-)
 %{_libdir}/libcephfs.so.*
@@ -1361,6 +1424,22 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{python_sitearch}/cephfs.so
 %{python_sitearch}/cephfs-*.egg-info
 %{python_sitelib}/ceph_volume_client.py*
+
+#################################################################################
+%files -n python%{python3_pkgversion}-cephfs
+%defattr(-,root,root,-)
+%{python3_sitearch}/cephfs.cpython*.so
+%{python3_sitearch}/cephfs-*.egg-info
+%{python3_sitelib}/ceph_volume_client.py
+%{python3_sitelib}/__pycache__/ceph_volume_client.cpython*.py*
+
+#################################################################################
+%files -n python%{python3_pkgversion}-ceph-argparse
+%defattr(-,root,root,-)
+%{python3_sitelib}/ceph_argparse.py
+%{python3_sitelib}/__pycache__/ceph_argparse.cpython*.py*
+%{python3_sitelib}/ceph_daemon.py
+%{python3_sitelib}/__pycache__/ceph_daemon.cpython*.py*
 
 #################################################################################
 %files -n ceph-test

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -13,7 +13,7 @@ function(add_ceph_test test_name test_path)
     CEPH_BUILD_DIR=${CMAKE_BINARY_DIR}
     LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib
     PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}:${CMAKE_SOURCE_DIR}/src:$ENV{PATH}
-    PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.${PYTHON_VERSION_MAJOR}:${CMAKE_SOURCE_DIR}/src/pybind
+    PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.${PYTHON${PYTHON_VERSION}_VERSION_MAJOR}:${CMAKE_SOURCE_DIR}/src/pybind
     CEPH_BUILD_VIRTUALENV=${CEPH_BUILD_VIRTUALENV})
   # none of the tests should take more than 1 hour to complete
   set_property(TEST

--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -24,7 +24,7 @@ function(distutils_install_module name)
       endif()
     endif()
     execute_process(
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND ${PYTHON${PYTHON_VERSION}_EXECUTABLE}
         setup.py install \${options}
     WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
 endfunction(distutils_install_module)
@@ -46,8 +46,9 @@ function(distutils_add_cython_module name src)
     CYTHON_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
     CEPH_LIBDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     CFLAGS=\"-iquote${CMAKE_SOURCE_DIR}/src/include\"
-    ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
-    build --build-base ${CYTHON_MODULE_DIR} --build-platlib ${CYTHON_MODULE_DIR}/lib.${PYTHON_VERSION_MAJOR} --verbose
+    ${PYTHON${PYTHON_VERSION}_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
+    build --verbose --build-base ${CYTHON_MODULE_DIR}
+    --build-platlib ${CYTHON_MODULE_DIR}/lib.${PYTHON${PYTHON_VERSION}_VERSION_MAJOR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${src})
 endfunction(distutils_add_cython_module)
@@ -70,8 +71,9 @@ function(distutils_install_cython_module name)
            CC=${CMAKE_C_COMPILER}
            CPPFLAGS=\"-iquote${CMAKE_SOURCE_DIR}/src/include\"
            LDFLAGS=\"-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}\"
-           ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
-           build --build-base ${CYTHON_MODULE_DIR} --build-platlib ${CYTHON_MODULE_DIR}/lib.${PYTHON_VERSION_MAJOR} --verbose
+           ${PYTHON${PYTHON_VERSION}_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
+           build --verbose --build-base ${CYTHON_MODULE_DIR}
+           --build-platlib ${CYTHON_MODULE_DIR}/lib.${PYTHON${PYTHON_VERSION}_VERSION_MAJOR}
            build_ext --cython-c-in-temp --build-temp ${CMAKE_CURRENT_BINARY_DIR} --cython-include-dirs ${PROJECT_SOURCE_DIR}/src/pybind/rados
            install \${options} --single-version-externally-managed --record /dev/null
            egg_info --egg-base ${CMAKE_CURRENT_BINARY_DIR}

--- a/cmake/modules/FindCython.cmake
+++ b/cmake/modules/FindCython.cmake
@@ -2,81 +2,25 @@
 # Cython
 #
 
-# This finds the "cython" executable in your PATH, and then in some standard
-# paths:
-FIND_FILE(CYTHON_BIN cython /usr/bin /usr/local/bin)
-SET(CYTHON_FLAGS --cplus --fast-fail)
-
-SET(Cython_FOUND FALSE)
-IF (CYTHON_BIN)
-    # Try to run Cython, to make sure it works:
-    execute_process(
-        COMMAND ${CYTHON_BIN} ${CYTHON_FLAGS} ${CMAKE_MODULE_PATH}/cython_test.pyx
-        RESULT_VARIABLE CYTHON_RESULT
-        OUTPUT_QUIET
-        ERROR_QUIET
-        )
-    if (CYTHON_RESULT EQUAL 0)
-        # Only if cython exits with the return code 0, we know that all is ok:
-        SET(Cython_FOUND TRUE)
-        SET(Cython_Compilation_Failed FALSE)
-    else (CYTHON_RESULT EQUAL 0)
-        SET(Cython_Compilation_Failed TRUE)
-    endif (CYTHON_RESULT EQUAL 0)
-ENDIF (CYTHON_BIN)
+SET(Cython${PYTHON_VERSION}_FOUND FALSE)
+# Try to run Cython, to make sure it works:
+execute_process(
+    COMMAND ${PYTHON${PYTHON_VERSION}_EXECUTABLE} -m cython --version
+    RESULT_VARIABLE CYTHON_RESULT
+    OUTPUT_QUIET
+    ERROR_QUIET
+    )
+if (CYTHON_RESULT EQUAL 0)
+    SET(Cython${PYTHON_VERSION}_FOUND TRUE)
+endif (CYTHON_RESULT EQUAL 0)
 
 
-IF (Cython_FOUND)
-        IF (NOT Cython_FIND_QUIETLY)
-                MESSAGE(STATUS "Found CYTHON: ${CYTHON_BIN}")
-        ENDIF (NOT Cython_FIND_QUIETLY)
-ELSE (Cython_FOUND)
-        IF (Cython_FIND_REQUIRED)
-        if(Cython_Compilation_Failed)
-            MESSAGE(STATUS "Found CYTHON: ${CYTHON_BIN}")
-        else(Cython_Compilation_Failed)
-            MESSAGE(FATAL_ERROR "Could not find Cython. Please install Cython.")
-        endif(Cython_Compilation_Failed)
-        ENDIF (Cython_FIND_REQUIRED)
-ENDIF (Cython_FOUND)
-
-
-# This allows to link Cython files
-# Examples:
-# 1) to compile assembly.pyx to assembly.so:
-#   CYTHON_ADD_MODULE(assembly)
-# 2) to compile assembly.pyx and something.cpp to assembly.so:
-#   CYTHON_ADD_MODULE(assembly something.cpp)
-
-# Cythonizes the .pyx files into .cpp file (but doesn't compile it)
-macro(CYTHON_ADD_MODULE_PYX name)
-  set(depends ${name}.pyx)
-  if(CYTHON_INCLUDE_DIRECTORIES)
-    foreach(dir ${CYTHON_INCLUDE_DIRECTORIES})
-      file(GLOB pxd_srcs ${CYTHON_INCLUDE_DIRECTORIES}/*.pxd)
-      list(APPEND depends ${pxd_srcs})
-    endforeach()
-  elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${name}.pxd)
-    list(APPEND depends ${CMAKE_CURRENT_SOURCE_DIR}/${name}.pxd)
-    set(CYTHON_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
-  endif()
-  # Allow the user to specify dependencies as optional arguments
-  list(APPEND depends ${ARGN})
-  add_custom_command(
-    OUTPUT ${name}.cpp
-    COMMAND ${CYTHON_BIN}
-    ARGS ${CYTHON_FLAGS} -I ${CYTHON_INCLUDE_DIRECTORIES} -o ${name}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${name}.pyx
-    DEPENDS ${depends}
-    COMMENT "Cythonizing ${name}.pyx")
-endmacro(CYTHON_ADD_MODULE_PYX)
-
-# Cythonizes and compiles a .pyx file
-macro(CYTHON_ADD_MODULE name pyx)
-  CYTHON_ADD_MODULE_PYX(${pyx})
-  add_library(${name} MODULE ${pyx}.cpp)
-  target_include_directories(${name} PRIVATE ${PYTHON_INCLUDE_PATH})
-  target_link_libraries(${name} ${PYTHON_LIBRARIES})
-  set_target_properties(${name} PROPERTIES
-    PREFIX "${PYTHON_MODULE_PREFIX}"
-    OUTPUT_NAME ${pyx})
-endmacro(CYTHON_ADD_MODULE)
+IF (Cython${PYTHON_VERSION}_FOUND)
+    IF (NOT Cython_FIND_QUIETLY)
+        MESSAGE(STATUS "Found cython${PYTHON_VERSION}")
+    ENDIF (NOT Cython_FIND_QUIETLY)
+ELSE (Cython${PYTHON_VERSION}_FOUND)
+    IF (Cython_FIND_REQUIRED)
+        MESSAGE(FATAL_ERROR "Could not find cython${PYTHON_VERSION}. Please install Cython.")
+    ENDIF (Cython_FIND_REQUIRED)
+ENDIF (Cython${PYTHON_VERSION}_FOUND)

--- a/cmake/modules/FindPython3Interp.cmake
+++ b/cmake/modules/FindPython3Interp.cmake
@@ -1,0 +1,148 @@
+#.rst:
+# FindPython3Interp
+# ----------------
+#
+# Find python interpreter
+#
+# This module finds if Python interpreter is installed and determines
+# where the executables are.  This code sets the following variables:
+#
+# ::
+#
+#   PYTHON3INTERP_FOUND         - Was the Python executable found
+#   PYTHON3_EXECUTABLE          - path to the Python interpreter
+#
+#
+#
+# ::
+#
+#   PYTHON3_VERSION_STRING      - Python version found e.g. 2.5.2
+#   PYTHON3_VERSION_MAJOR       - Python major version found e.g. 2
+#   PYTHON3_VERSION_MINOR       - Python minor version found e.g. 5
+#   PYTHON3_VERSION_PATCH       - Python patch version found e.g. 2
+#
+#
+#
+# The Python3_ADDITIONAL_VERSIONS variable can be used to specify a list
+# of version numbers that should be taken into account when searching
+# for Python.  You need to set this variable before calling
+# find_package(Python3Interp).
+#
+# If calling both ``find_package(Python3Interp)`` and
+# ``find_package(Python3Libs)``, call ``find_package(Python3Interp)`` first to
+# get the currently active Python version by default with a consistent version
+# of PYTHON3_LIBRARIES.
+
+#=============================================================================
+# Copyright 2005-2010 Kitware, Inc.
+# Copyright 2011 Bjoern Ricks <bjoern.ricks@gmail.com>
+# Copyright 2012 Rolf Eike Beer <eike@sf-mail.de>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+#   nor the names of their contributors may be used to endorse or promote
+#   products derived from this software without specific prior written
+#   permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#=============================================================================
+
+unset(_Python3_NAMES)
+
+set(_PYTHON3_VERSIONS 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
+
+if(Python3Interp_FIND_VERSION)
+    if(Python3Interp_FIND_VERSION_COUNT GREATER 1)
+        set(_PYTHON3_FIND_MAJ_MIN "${Python3Interp_FIND_VERSION_MAJOR}.${Python3Interp_FIND_VERSION_MINOR}")
+        list(APPEND _Python3_NAMES
+             python${_PYTHON3_FIND_MAJ_MIN}
+             python${Python3Interp_FIND_VERSION_MAJOR})
+        unset(_PYTHON3_FIND_OTHER_VERSIONS)
+        if(NOT Python3Interp_FIND_VERSION_EXACT)
+            foreach(_PYTHON3_V ${_PYTHON${Python3Interp_FIND_VERSION_MAJOR}_VERSIONS})
+                if(NOT _PYTHON3_V VERSION_LESS _PYTHON3_FIND_MAJ_MIN)
+                    list(APPEND _PYTHON3_FIND_OTHER_VERSIONS ${_PYTHON3_V})
+                endif()
+             endforeach()
+        endif()
+        unset(_PYTHON3_FIND_MAJ_MIN)
+    else()
+        list(APPEND _Python3_NAMES python${Python3Interp_FIND_VERSION_MAJOR})
+        set(_PYTHON3_FIND_OTHER_VERSIONS ${_PYTHON${Python3Interp_FIND_VERSION_MAJOR}_VERSIONS})
+    endif()
+else()
+    set(_PYTHON3_FIND_OTHER_VERSIONS ${_PYTHON3_VERSIONS})
+endif()
+find_program(PYTHON3_EXECUTABLE NAMES ${_Python3_NAMES})
+
+# Set up the versions we know about, in the order we will search. Always add
+# the user supplied additional versions to the front.
+set(_Python3_VERSIONS ${Python3_ADDITIONAL_VERSIONS})
+# If FindPython3Interp has already found the major and minor version,
+# insert that version next to get consistent versions of the interpreter and
+# library.
+if(DEFINED PYTHON3LIBS_VERSION_STRING)
+  string(REPLACE "." ";" _PYTHON3LIBS_VERSION "${PYTHON3LIBS_VERSION_STRING}")
+  list(GET _PYTHON3LIBS_VERSION 0 _PYTHON3LIBS_VERSION_MAJOR)
+  list(GET _PYTHON3LIBS_VERSION 1 _PYTHON3LIBS_VERSION_MINOR)
+  list(APPEND _Python3_VERSIONS ${_PYTHON3LIBS_VERSION_MAJOR}.${_PYTHON3LIBS_VERSION_MINOR})
+endif()
+# Search for the current active python version first
+list(APPEND _Python3_VERSIONS ";")
+list(APPEND _Python3_VERSIONS ${_PYTHON3_FIND_OTHER_VERSIONS})
+
+unset(_PYTHON3_FIND_OTHER_VERSIONS)
+unset(_PYTHON3_VERSIONS)
+
+# Search for newest python version if python executable isn't found
+if(NOT PYTHON3_EXECUTABLE)
+    foreach(_CURRENT_VERSION IN LISTS _Python3_VERSIONS)
+      set(_Python3_NAMES python${_CURRENT_VERSION})
+      if(WIN32)
+        list(APPEND _Python3_NAMES python)
+      endif()
+      find_program(PYTHON3_EXECUTABLE
+        NAMES ${_Python3_NAMES}
+        PATHS [HKEY_LOCAL_MACHINE\\SOFTWARE\\Python\\PythonCore\\${_CURRENT_VERSION}\\InstallPath]
+        )
+    endforeach()
+endif()
+
+# determine python version string
+if(PYTHON3_EXECUTABLE)
+    execute_process(COMMAND "${PYTHON3_EXECUTABLE}" -c
+                            "import sys; sys.stdout.write(';'.join([str(x) for x in sys.version_info[:3]]))"
+                    OUTPUT_VARIABLE _VERSION)
+    string(REPLACE ";" "." PYTHON3_VERSION_STRING "${_VERSION}")
+    list(GET _VERSION 0 PYTHON3_VERSION_MAJOR)
+    list(GET _VERSION 1 PYTHON3_VERSION_MINOR)
+    list(GET _VERSION 2 PYTHON3_VERSION_PATCH)
+    unset(_VERSION)
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set PYTHON3INTERP_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Python3Interp REQUIRED_VARS PYTHON3_EXECUTABLE VERSION_VAR PYTHON3_VERSION_STRING)
+
+mark_as_advanced(PYTHON3_EXECUTABLE)

--- a/cmake/modules/FindPython3Libs.cmake
+++ b/cmake/modules/FindPython3Libs.cmake
@@ -1,0 +1,369 @@
+#.rst:
+# FindPython3Libs
+# --------------
+#
+# Find python libraries
+#
+# This module finds if Python is installed and determines where the
+# include files and libraries are.  It also determines what the name of
+# the library is.  This code sets the following variables:
+#
+# ::
+#
+#   PYTHON3LIBS_FOUND           - have the Python libs been found
+#   PYTHON3_LIBRARIES           - path to the python library
+#   PYTHON3_INCLUDE_PATH        - path to where Python.h is found (deprecated)
+#   PYTHON3_INCLUDE_DIRS        - path to where Python.h is found
+#   PYTHON3_DEBUG_LIBRARIES     - path to the debug library (deprecated)
+#   PYTHON3LIBS_VERSION_STRING  - version of the Python libs found (since CMake 2.8.8)
+#
+#
+#
+# The Python3_ADDITIONAL_VERSIONS variable can be used to specify a list
+# of version numbers that should be taken into account when searching
+# for Python.  You need to set this variable before calling
+# find_package(Python3Libs).
+#
+# If you'd like to specify the installation of Python to use, you should
+# modify the following cache variables:
+#
+# ::
+#
+#   PYTHON3_LIBRARY             - path to the python library
+#   PYTHON3_INCLUDE_DIR         - path to where Python.h is found
+#
+# If calling both ``find_package(PythonInterp)`` and
+# ``find_package(Python3Libs)``, call ``find_package(PythonInterp)`` first to
+# get the currently active Python version by default with a consistent version
+# of PYTHON3_LIBRARIES.
+
+#=============================================================================
+# Copyright 2001-2009 Kitware, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+#   nor the names of their contributors may be used to endorse or promote
+#   products derived from this software without specific prior written
+#   permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#=============================================================================
+
+# Use the executable's path as a hint
+set(_Python3_LIBRARY_PATH_HINT)
+if(PYTHON3_EXECUTABLE)
+  if(WIN32)
+    get_filename_component(_Python3_PREFIX ${PYTHON3_EXECUTABLE} PATH)
+    if(_Python3_PREFIX)
+      set(_Python3_LIBRARY_PATH_HINT ${_Python3_PREFIX}/libs)
+    endif()
+    unset(_Python3_PREFIX)
+  else()
+    get_filename_component(_Python3_PREFIX ${PYTHON3_EXECUTABLE} PATH)
+    get_filename_component(_Python3_PREFIX ${_Python3_PREFIX} PATH)
+    if(_Python3_PREFIX)
+      set(_Python3_LIBRARY_PATH_HINT ${_Python3_PREFIX}/lib)
+    endif()
+    unset(_Python3_PREFIX)
+  endif()
+endif()
+
+include(CMakeFindFrameworks)
+# Search for the python framework on Apple.
+CMAKE_FIND_FRAMEWORKS(Python)
+
+# Save CMAKE_FIND_FRAMEWORK
+if(DEFINED CMAKE_FIND_FRAMEWORK)
+  set(_Python3Libs_CMAKE_FIND_FRAMEWORK ${CMAKE_FIND_FRAMEWORK})
+else()
+  unset(_Python3Libs_CMAKE_FIND_FRAMEWORK)
+endif()
+# To avoid picking up the system Python.h pre-maturely.
+set(CMAKE_FIND_FRAMEWORK LAST)
+
+set(_PYTHON3_VERSIONS 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
+
+if(Python3Libs_FIND_VERSION)
+    if(Python3Libs_FIND_VERSION_COUNT GREATER 1)
+        set(_PYTHON3_FIND_MAJ_MIN "${Python3Libs_FIND_VERSION_MAJOR}.${Python3Libs_FIND_VERSION_MINOR}")
+        unset(_PYTHON3_FIND_OTHER_VERSIONS)
+        if(Python3Libs_FIND_VERSION_EXACT)
+            if(_PYTHON3_FIND_MAJ_MIN STREQUAL Python3Libs_FIND_VERSION)
+                set(_PYTHON3_FIND_OTHER_VERSIONS "${Python3Libs_FIND_VERSION}")
+            else()
+                set(_PYTHON3_FIND_OTHER_VERSIONS "${Python3Libs_FIND_VERSION}" "${_PYTHON3_FIND_MAJ_MIN}")
+            endif()
+        else()
+            foreach(_PYTHON3_V ${_PYTHON${Python3Libs_FIND_VERSION_MAJOR}_VERSIONS})
+                if(NOT _PYTHON3_V VERSION_LESS _PYTHON3_FIND_MAJ_MIN)
+                    list(APPEND _PYTHON3_FIND_OTHER_VERSIONS ${_PYTHON3_V})
+                endif()
+             endforeach()
+        endif()
+        unset(_PYTHON3_FIND_MAJ_MIN)
+    else()
+        set(_PYTHON3_FIND_OTHER_VERSIONS ${_PYTHON${Python3Libs_FIND_VERSION_MAJOR}_VERSIONS})
+    endif()
+else()
+    set(_PYTHON3_FIND_OTHER_VERSIONS ${_PYTHON3_VERSIONS})
+endif()
+
+# Set up the versions we know about, in the order we will search. Always add
+# the user supplied additional versions to the front.
+# If FindPythonInterp has already found the major and minor version,
+# insert that version between the user supplied versions and the stock
+# version list.
+set(_Python3_VERSIONS ${Python3_ADDITIONAL_VERSIONS})
+if(DEFINED PYTHON3_VERSION_MAJOR AND DEFINED PYTHON3_VERSION_MINOR)
+  list(APPEND _Python3_VERSIONS ${PYTHON3_VERSION_MAJOR}.${PYTHON3_VERSION_MINOR})
+endif()
+list(APPEND _Python3_VERSIONS ${_PYTHON3_FIND_OTHER_VERSIONS})
+
+unset(_PYTHON3_FIND_OTHER_VERSIONS)
+unset(_PYTHON3_VERSIONS)
+
+foreach(_CURRENT_VERSION ${_Python3_VERSIONS})
+  string(REPLACE "." "" _CURRENT_VERSION_NO_DOTS ${_CURRENT_VERSION})
+  if(WIN32)
+    find_library(PYTHON3_DEBUG_LIBRARY
+      NAMES python${_CURRENT_VERSION_NO_DOTS}_d python
+      HINTS ${_Python3_LIBRARY_PATH_HINT}
+      PATHS
+      [HKEY_LOCAL_MACHINE\\SOFTWARE\\Python\\PythonCore\\${_CURRENT_VERSION}\\InstallPath]/libs/Debug
+      [HKEY_CURRENT_USER\\SOFTWARE\\Python\\PythonCore\\${_CURRENT_VERSION}\\InstallPath]/libs/Debug
+      [HKEY_LOCAL_MACHINE\\SOFTWARE\\Python\\PythonCore\\${_CURRENT_VERSION}\\InstallPath]/libs
+      [HKEY_CURRENT_USER\\SOFTWARE\\Python\\PythonCore\\${_CURRENT_VERSION}\\InstallPath]/libs
+      )
+  endif()
+
+  set(PYTHON3_FRAMEWORK_LIBRARIES)
+  if(Python3_FRAMEWORKS AND NOT PYTHON3_LIBRARY)
+    foreach(dir ${Python3_FRAMEWORKS})
+      list(APPEND PYTHON3_FRAMEWORK_LIBRARIES
+           ${dir}/Versions/${_CURRENT_VERSION}/lib)
+    endforeach()
+  endif()
+  find_library(PYTHON3_LIBRARY
+    NAMES
+      python${_CURRENT_VERSION_NO_DOTS}
+      python${_CURRENT_VERSION}mu
+      python${_CURRENT_VERSION}m
+      python${_CURRENT_VERSION}u
+      python${_CURRENT_VERSION}
+    HINTS
+      ${_Python3_LIBRARY_PATH_HINT}
+    PATHS
+      ${PYTHON3_FRAMEWORK_LIBRARIES}
+      [HKEY_LOCAL_MACHINE\\SOFTWARE\\Python\\PythonCore\\${_CURRENT_VERSION}\\InstallPath]/libs
+      [HKEY_CURRENT_USER\\SOFTWARE\\Python\\PythonCore\\${_CURRENT_VERSION}\\InstallPath]/libs
+    # Avoid finding the .dll in the PATH.  We want the .lib.
+    NO_SYSTEM_ENVIRONMENT_PATH
+  )
+  # Look for the static library in the Python config directory
+  find_library(PYTHON3_LIBRARY
+    NAMES python${_CURRENT_VERSION_NO_DOTS} python${_CURRENT_VERSION}
+    # Avoid finding the .dll in the PATH.  We want the .lib.
+    NO_SYSTEM_ENVIRONMENT_PATH
+    # This is where the static library is usually located
+    PATH_SUFFIXES python${_CURRENT_VERSION}/config
+  )
+
+  # Don't search for include dir until library location is known
+  if(PYTHON3_LIBRARY)
+
+    # Use the library's install prefix as a hint
+    set(_Python3_INCLUDE_PATH_HINT)
+    get_filename_component(_Python3_PREFIX ${PYTHON3_LIBRARY} PATH)
+    get_filename_component(_Python3_PREFIX ${_Python3_PREFIX} PATH)
+    if(_Python3_PREFIX)
+      set(_Python3_INCLUDE_PATH_HINT ${_Python3_PREFIX}/include)
+    endif()
+    unset(_Python3_PREFIX)
+
+    # Add framework directories to the search paths
+    set(PYTHON3_FRAMEWORK_INCLUDES)
+    if(Python3_FRAMEWORKS AND NOT PYTHON3_INCLUDE_DIR)
+      foreach(dir ${Python3_FRAMEWORKS})
+        list(APPEND PYTHON3_FRAMEWORK_INCLUDES
+          ${dir}/Versions/${_CURRENT_VERSION}/include)
+      endforeach()
+    endif()
+
+    find_path(PYTHON3_INCLUDE_DIR
+      NAMES Python.h
+      HINTS
+        ${_Python3_INCLUDE_PATH_HINT}
+      PATHS
+        ${PYTHON3_FRAMEWORK_INCLUDES}
+        [HKEY_LOCAL_MACHINE\\SOFTWARE\\Python\\PythonCore\\${_CURRENT_VERSION}\\InstallPath]/include
+        [HKEY_CURRENT_USER\\SOFTWARE\\Python\\PythonCore\\${_CURRENT_VERSION}\\InstallPath]/include
+      PATH_SUFFIXES
+        python${_CURRENT_VERSION}mu
+        python${_CURRENT_VERSION}m
+        python${_CURRENT_VERSION}u
+        python${_CURRENT_VERSION}
+    )
+  endif()
+
+  # For backward compatibility, set PYTHON3_INCLUDE_PATH.
+  set(PYTHON3_INCLUDE_PATH "${PYTHON3_INCLUDE_DIR}")
+
+  if(PYTHON3_INCLUDE_DIR AND EXISTS "${PYTHON3_INCLUDE_DIR}/patchlevel.h")
+    file(STRINGS "${PYTHON3_INCLUDE_DIR}/patchlevel.h" python3_version_str
+         REGEX "^#define[ \t]+PY_VERSION[ \t]+\"[^\"]+\"")
+    string(REGEX REPLACE "^#define[ \t]+PY_VERSION[ \t]+\"([^\"]+)\".*" "\\1"
+                         PYTHON3LIBS_VERSION_STRING "${python3_version_str}")
+    unset(python3_version_str)
+  endif()
+
+  if(PYTHON3_LIBRARY AND PYTHON3_INCLUDE_DIR)
+    break()
+  endif()
+endforeach()
+
+unset(_Python3_INCLUDE_PATH_HINT)
+unset(_Python3_LIBRARY_PATH_HINT)
+
+mark_as_advanced(
+  PYTHON3_DEBUG_LIBRARY
+  PYTHON3_LIBRARY
+  PYTHON3_INCLUDE_DIR
+)
+
+# We use PYTHON3_INCLUDE_DIR, PYTHON3_LIBRARY and PYTHON3_DEBUG_LIBRARY for the
+# cache entries because they are meant to specify the location of a single
+# library. We now set the variables listed by the documentation for this
+# module.
+set(PYTHON3_INCLUDE_DIRS "${PYTHON3_INCLUDE_DIR}")
+set(PYTHON3_DEBUG_LIBRARIES "${PYTHON3_DEBUG_LIBRARY}")
+
+# These variables have been historically named in this module different from
+# what SELECT_LIBRARY_CONFIGURATIONS() expects.
+set(PYTHON3_LIBRARY_DEBUG "${PYTHON3_DEBUG_LIBRARY}")
+set(PYTHON3_LIBRARY_RELEASE "${PYTHON3_LIBRARY}")
+include(SelectLibraryConfigurations)
+SELECT_LIBRARY_CONFIGURATIONS(PYTHON3)
+# SELECT_LIBRARY_CONFIGURATIONS() sets ${PREFIX}_FOUND if it has a library.
+# Unset this, this prefix doesn't match the module prefix, they are different
+# for historical reasons.
+unset(PYTHON3_FOUND)
+
+# Restore CMAKE_FIND_FRAMEWORK
+if(DEFINED _Python3Libs_CMAKE_FIND_FRAMEWORK)
+  set(CMAKE_FIND_FRAMEWORK ${_Python3Libs_CMAKE_FIND_FRAMEWORK})
+  unset(_Python3Libs_CMAKE_FIND_FRAMEWORK)
+else()
+  unset(CMAKE_FIND_FRAMEWORK)
+endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Python3Libs
+                                  REQUIRED_VARS PYTHON3_LIBRARIES PYTHON3_INCLUDE_DIRS
+                                  VERSION_VAR PYTHON3LIBS_VERSION_STRING)
+
+# PYTHON3_ADD_MODULE(<name> src1 src2 ... srcN) is used to build modules for python.
+# PYTHON3_WRITE_MODULES_HEADER(<filename>) writes a header file you can include
+# in your sources to initialize the static python modules
+function(PYTHON3_ADD_MODULE _NAME )
+  get_property(_TARGET_SUPPORTS_SHARED_LIBS
+    GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
+  option(PYTHON3_ENABLE_MODULE_${_NAME} "Add module ${_NAME}" TRUE)
+  option(PYTHON3_MODULE_${_NAME}_BUILD_SHARED
+    "Add module ${_NAME} shared" ${_TARGET_SUPPORTS_SHARED_LIBS})
+
+  # Mark these options as advanced
+  mark_as_advanced(PYTHON3_ENABLE_MODULE_${_NAME}
+    PYTHON3_MODULE_${_NAME}_BUILD_SHARED)
+
+  if(PYTHON3_ENABLE_MODULE_${_NAME})
+    if(PYTHON3_MODULE_${_NAME}_BUILD_SHARED)
+      set(PY_MODULE_TYPE MODULE)
+    else()
+      set(PY_MODULE_TYPE STATIC)
+      set_property(GLOBAL  APPEND  PROPERTY  PY_STATIC_MODULES_LIST ${_NAME})
+    endif()
+
+    set_property(GLOBAL  APPEND  PROPERTY  PY_MODULES_LIST ${_NAME})
+    add_library(${_NAME} ${PY_MODULE_TYPE} ${ARGN})
+#    target_link_libraries(${_NAME} ${PYTHON3_LIBRARIES})
+
+    if(PYTHON3_MODULE_${_NAME}_BUILD_SHARED)
+      set_target_properties(${_NAME} PROPERTIES PREFIX "${PYTHON3_MODULE_PREFIX}")
+      if(WIN32 AND NOT CYGWIN)
+        set_target_properties(${_NAME} PROPERTIES SUFFIX ".pyd")
+      endif()
+    endif()
+
+  endif()
+endfunction()
+
+function(PYTHON3_WRITE_MODULES_HEADER _filename)
+
+  get_property(PY_STATIC_MODULES_LIST  GLOBAL  PROPERTY PY_STATIC_MODULES_LIST)
+
+  get_filename_component(_name "${_filename}" NAME)
+  string(REPLACE "." "_" _name "${_name}")
+  string(TOUPPER ${_name} _nameUpper)
+  set(_filename ${CMAKE_CURRENT_BINARY_DIR}/${_filename})
+
+  set(_filenameTmp "${_filename}.in")
+  file(WRITE ${_filenameTmp} "/*Created by cmake, do not edit, changes will be lost*/\n")
+  file(APPEND ${_filenameTmp}
+"#ifndef ${_nameUpper}
+#define ${_nameUpper}
+
+#include <Python.h>
+
+#ifdef __cplusplus
+extern \"C\" {
+#endif /* __cplusplus */
+
+")
+
+  foreach(_currentModule ${PY_STATIC_MODULES_LIST})
+    file(APPEND ${_filenameTmp} "extern void init${PYTHON3_MODULE_PREFIX}${_currentModule}(void);\n\n")
+  endforeach()
+
+  file(APPEND ${_filenameTmp}
+"#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+")
+
+
+  foreach(_currentModule ${PY_STATIC_MODULES_LIST})
+    file(APPEND ${_filenameTmp} "int ${_name}_${_currentModule}(void) \n{\n  static char name[]=\"${PYTHON3_MODULE_PREFIX}${_currentModule}\"; return PyImport_AppendInittab(name, init${PYTHON3_MODULE_PREFIX}${_currentModule});\n}\n\n")
+  endforeach()
+
+  file(APPEND ${_filenameTmp} "void ${_name}_LoadAllPythonModules(void)\n{\n")
+  foreach(_currentModule ${PY_STATIC_MODULES_LIST})
+    file(APPEND ${_filenameTmp} "  ${_name}_${_currentModule}();\n")
+  endforeach()
+  file(APPEND ${_filenameTmp} "}\n\n")
+  file(APPEND ${_filenameTmp} "#ifndef EXCLUDE_LOAD_ALL_FUNCTION\nvoid CMakeLoadAllPythonModules(void)\n{\n  ${_name}_LoadAllPythonModules();\n}\n#endif\n\n#endif\n")
+
+# with configure_file() cmake complains that you may not use a file created using file(WRITE) as input file for configure_file()
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${_filenameTmp}" "${_filename}" OUTPUT_QUIET ERROR_QUIET)
+
+endfunction()

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Build-Depends: btrfs-tools,
                cpio,
 	       cryptsetup-bin | cryptsetup,
                cython,
+               cython3,
                debhelper (>= 9),
                dh-python,
 	       dh-systemd,
@@ -57,6 +58,8 @@ Build-Depends: btrfs-tools,
                python-nose,
 	       python-setuptools,
                python-sphinx,
+               python3-all-dev,
+               python3-setuptools,
                virtualenv | python-virtualenv,
                sdparm | hdparm,
                uuid-runtime,
@@ -624,7 +627,7 @@ Description: Meta-package for python libraries for the Ceph libraries
  storage system that runs on commodity hardware and delivers object,
  block and file system storage.
  .
- This package is a metapackage for all python bindings.
+ This package is a metapackage for all Python 2 bindings.
 
 Package: python-rados
 Architecture: linux-any
@@ -632,12 +635,24 @@ Section: python
 Depends: librados2 (= ${binary:Version}), ${misc:Depends}, ${python:Depends}
 Replaces: python-ceph (<< 0.92-1223)
 Breaks: python-ceph (<< 0.92-1223)
-Description: Python libraries for the Ceph librados library
+Description: Python 2 libraries for the Ceph librados library
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,
  block and file system storage.
  .
- This package contains Python libraries for interacting with Ceph's
+ This package contains Python 2 libraries for interacting with Ceph's
+ RADOS object storage.
+
+Package: python3-rados
+Architecture: linux-any
+Section: python
+Depends: librados2 (= ${binary:Version}), ${misc:Depends}, ${python3:Depends}
+Description: Python 3 libraries for the Ceph librados library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 3 libraries for interacting with Ceph's
  RADOS object storage.
 
 Package: python-rbd
@@ -646,12 +661,24 @@ Section: python
 Depends: librbd1 (>= ${binary:Version}), ${misc:Depends}, ${python:Depends}
 Replaces: python-ceph (<< 0.92-1223)
 Breaks: python-ceph (<< 0.92-1223)
-Description: Python libraries for the Ceph librbd library
+Description: Python 2 libraries for the Ceph librbd library
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,
  block and file system storage.
  .
- This package contains Python libraries for interacting with Ceph's
+ This package contains Python 2 libraries for interacting with Ceph's
+ RBD block device library.
+
+Package: python3-rbd
+Architecture: linux-any
+Section: python
+Depends: librbd1 (>= ${binary:Version}), ${misc:Depends}, ${python3:Depends}
+Description: Python 3 libraries for the Ceph librbd library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 3 libraries for interacting with Ceph's
  RBD block device library.
 
 Package: python-cephfs
@@ -660,13 +687,37 @@ Section: python
 Depends: libcephfs1 (= ${binary:Version}), ${misc:Depends}, ${python:Depends}
 Replaces: python-ceph (<< 0.92-1223)
 Breaks: python-ceph (<< 0.92-1223)
-Description: Python libraries for the Ceph libcephfs library
+Description: Python 2 libraries for the Ceph libcephfs library
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,
  block and file system storage.
  .
- This package contains Python libraries for interacting with Ceph's
+ This package contains Python 2 libraries for interacting with Ceph's
  CephFS file system client library.
+
+Package: python3-cephfs
+Architecture: linux-any
+Section: python
+Depends: libcephfs1 (= ${binary:Version}), ${misc:Depends}, ${python3:Depends}
+Description: Python 3 libraries for the Ceph libcephfs library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 3 libraries for interacting with Ceph's
+ CephFS file system client library.
+
+Package: python3-ceph-argparse
+Architecture: linux-any
+Section: python
+Depends: ${misc:Depends}, ${python3:Depends}
+Description: Python 3 utility libraries for Ceph CLI
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains types and routines for Python 3 used by the
+ Ceph CLI as well as the RESTful interface.
 
 Package: libcephfs-java
 Section: java

--- a/debian/python-cephfs.install
+++ b/debian/python-cephfs.install
@@ -1,3 +1,3 @@
-usr/lib/python*/dist-packages/ceph_volume_client.py*
-usr/lib/python*/dist-packages/cephfs.so
-usr/lib/python*/dist-packages/cephfs-*.egg-info
+usr/lib/python2*/dist-packages/ceph_volume_client.py*
+usr/lib/python2*/dist-packages/cephfs.so
+usr/lib/python2*/dist-packages/cephfs-*.egg-info

--- a/debian/python-rados.install
+++ b/debian/python-rados.install
@@ -1,2 +1,2 @@
-usr/lib/python*/dist-packages/rados.so
-usr/lib/python*/dist-packages/rados-*.egg-info
+usr/lib/python2*/dist-packages/rados.so
+usr/lib/python2*/dist-packages/rados-*.egg-info

--- a/debian/python-rbd.install
+++ b/debian/python-rbd.install
@@ -1,2 +1,2 @@
-usr/lib/python*/dist-packages/rbd.so
-usr/lib/python*/dist-packages/rbd-*.egg-info
+usr/lib/python2*/dist-packages/rbd.so
+usr/lib/python2*/dist-packages/rbd-*.egg-info

--- a/debian/python3-ceph-argparse.install
+++ b/debian/python3-ceph-argparse.install
@@ -1,0 +1,2 @@
+usr/lib/python3*/dist-packages/ceph_argparse.py
+usr/lib/python3*/dist-packages/ceph_daemon.py

--- a/debian/python3-cephfs.install
+++ b/debian/python3-cephfs.install
@@ -1,0 +1,3 @@
+usr/lib/python3*/dist-packages/ceph_volume_client.py
+usr/lib/python3*/dist-packages/cephfs.cpython*.so
+usr/lib/python3*/dist-packages/cephfs-*.egg-info

--- a/debian/python3-rados.install
+++ b/debian/python3-rados.install
@@ -1,0 +1,2 @@
+usr/lib/python3*/dist-packages/rados.cpython*.so
+usr/lib/python3*/dist-packages/rados-*.egg-info

--- a/debian/python3-rbd.install
+++ b/debian/python3-rbd.install
@@ -1,0 +1,2 @@
+usr/lib/python3*/dist-packages/rbd.cpython*.so
+usr/lib/python3*/dist-packages/rbd-*.egg-info

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -277,13 +277,6 @@ if(WITH_CEPHFS_JAVA)
   add_subdirectory(java)
 endif()
 
-# Python stuff
-find_package(PythonInterp 2 QUIET)
-if(NOT PYTHONINTERP_FOUND)
-  message(FATAL_ERROR "Python 2 interpreter not found.")
-endif(NOT PYTHONINTERP_FOUND)
-find_package(PythonLibs REQUIRED)
-
 if(HAVE_XIO)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${XIO_INCLUDE_DIR}")
   list(APPEND EXTRALIBS ${XIO_LIBRARY} pthread rt)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -277,6 +277,12 @@ if(WITH_CEPHFS_JAVA)
   add_subdirectory(java)
 endif()
 
+# Python stuff
+find_package(PythonInterp 2 REQUIRED)
+find_package(PythonLibs 2 REQUIRED)
+find_package(Python3Interp 3 REQUIRED)
+find_package(Python3Libs 3 REQUIRED)
+
 if(HAVE_XIO)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${XIO_INCLUDE_DIR}")
   list(APPEND EXTRALIBS ${XIO_LIBRARY} pthread rt)

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -9,9 +9,6 @@ foreach(python_version 3 2)  # Keep the default version last
     set(PYTHON_VERSION ${python_version})
   endif(${python_version} EQUAL 2)
 
-  find_package(Python${PYTHON_VERSION}Interp ${python_version} REQUIRED)
-  find_package(Python${PYTHON_VERSION}Libs ${python_version} REQUIRED)
-
   find_package(Cython REQUIRED)
 
   add_subdirectory(rados rados${PYTHON_VERSION})

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -1,33 +1,48 @@
-find_package(Cython REQUIRED)
 include(Distutils)
 
 set(CYTHON_MODULE_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules)
 
-add_subdirectory(rados)
-add_subdirectory(rbd)
-add_subdirectory(cephfs)
+foreach(python_version 3 2)  # Keep the default version last
+  if(${python_version} EQUAL 2)
+    set(PYTHON_VERSION "")
+  else(${python_version} EQUAL 2)
+    set(PYTHON_VERSION ${python_version})
+  endif(${python_version} EQUAL 2)
 
-add_custom_target(cython_modules ALL
-  DEPENDS cython_rados cython_cephfs cython_rbd)
+  find_package(Python${PYTHON_VERSION}Interp ${python_version} REQUIRED)
+  find_package(Python${PYTHON_VERSION}Libs ${python_version} REQUIRED)
 
-# if CMAKE_INSTALL_PREFIX is an empty string, must replace
-# it with "/" to make PYTHON_INSTALL_TEMPLATE an absolute path to be
-# consistent with all other installation paths.
-if(CMAKE_INSTALL_PREFIX)
-  set(PYTHON_INSTALL_TEMPLATE "${CMAKE_INSTALL_PREFIX}")
-else(CMAKE_INSTALL_PREFIX)
-  set(PYTHON_INSTALL_TEMPLATE "/")
-endif(CMAKE_INSTALL_PREFIX)
+  find_package(Cython REQUIRED)
 
-execute_process(
-  COMMAND
-  ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print sysconfig.get_python_lib(prefix='${PYTHON_INSTALL_TEMPLATE}')"
-  OUTPUT_VARIABLE PYTHON_INSTDIR
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  add_subdirectory(rados rados${PYTHON_VERSION})
+  add_subdirectory(rbd rbd${PYTHON_VERSION})
+  add_subdirectory(cephfs cephfs${PYTHON_VERSION})
+
+  add_custom_target(cython${PYTHON_VERSION}_modules ALL
+    DEPENDS cython${PYTHON_VERSION}_rados cython${PYTHON_VERSION}_cephfs cython${PYTHON_VERSION}_rbd)
+
+  # if CMAKE_INSTALL_PREFIX is an empty string, must replace
+  # it with "/" to make PYTHON_INSTALL_TEMPLATE an absolute path to be
+  # consistent with all other installation paths.
+  if(CMAKE_INSTALL_PREFIX)
+    set(PYTHON_INSTALL_TEMPLATE "${CMAKE_INSTALL_PREFIX}")
+  else(CMAKE_INSTALL_PREFIX)
+    set(PYTHON_INSTALL_TEMPLATE "/")
+  endif(CMAKE_INSTALL_PREFIX)
+
+  execute_process(
+    COMMAND
+    ${PYTHON${PYTHON_VERSION}_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix='${PYTHON_INSTALL_TEMPLATE}'))"
+    OUTPUT_VARIABLE "PYTHON${PYTHON_VERSION}_INSTDIR"
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/ceph_argparse.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/ceph_daemon.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/ceph_volume_client.py
+    DESTINATION ${PYTHON${PYTHON_VERSION}_INSTDIR})
+endforeach()
 
 install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/ceph_argparse.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/ceph_daemon.py
   ${CMAKE_CURRENT_SOURCE_DIR}/ceph_rest_api.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/ceph_volume_client.py
   DESTINATION ${PYTHON_INSTDIR})

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -181,7 +181,7 @@ class RankEvicter(threading.Thread):
     def run(self):
         try:
             self._evict()
-        except Exception, e:
+        except Exception as e:
             self.success = False
             self.exception = e
         else:
@@ -597,7 +597,7 @@ class CephFSVolumeClient(object):
             try:
                 self.fs.stat(subpath)
             except cephfs.ObjectNotFound:
-                self.fs.mkdir(subpath, 0755)
+                self.fs.mkdir(subpath, 0o755)
 
     def create_volume(self, volume_path, size=None, data_isolated=False):
         """
@@ -639,7 +639,7 @@ class CephFSVolumeClient(object):
         # Create a volume meta file, if it does not already exist, to store
         # data about auth ids having access to the volume
         fd = self.fs.open(self._volume_metadata_path(volume_path),
-                          os.O_CREAT, 0755)
+                          os.O_CREAT, 0o755)
         self.fs.close(fd)
 
         return {
@@ -789,7 +789,7 @@ class CephFSVolumeClient(object):
         @contextmanager
         def fn():
             while(1):
-                fd = self.fs.open(path, os.O_CREAT, 0755)
+                fd = self.fs.open(path, os.O_CREAT, 0o755)
                 self.fs.flock(fd, fcntl.LOCK_EX, self._id)
 
                 # The locked file will be cleaned up sometime. It could be
@@ -1300,7 +1300,7 @@ class CephFSVolumeClient(object):
 
     def _snapshot_create(self, dir_path, snapshot_name):
         # TODO: raise intelligible exception for clusters where snaps are disabled
-        self.fs.mkdir(self._snapshot_path(dir_path, snapshot_name), 0755)
+        self.fs.mkdir(self._snapshot_path(dir_path, snapshot_name), 0o755)
 
     def _snapshot_destroy(self, dir_path, snapshot_name):
         """

--- a/src/pybind/cephfs/CMakeLists.txt
+++ b/src/pybind/cephfs/CMakeLists.txt
@@ -1,3 +1,3 @@
-distutils_add_cython_module(cython_cephfs ${CMAKE_CURRENT_SOURCE_DIR}/cephfs.pyx)
-add_dependencies(cython_cephfs cephfs)
-distutils_install_cython_module(cython_cephfs)
+distutils_add_cython_module(cython${PYTHON_VERSION}_cephfs ${CMAKE_CURRENT_SOURCE_DIR}/cephfs.pyx)
+add_dependencies(cython${PYTHON_VERSION}_cephfs cephfs)
+distutils_install_cython_module(cython${PYTHON_VERSION}_cephfs)

--- a/src/pybind/rados/CMakeLists.txt
+++ b/src/pybind/rados/CMakeLists.txt
@@ -1,3 +1,3 @@
-distutils_add_cython_module(cython_rados ${CMAKE_CURRENT_SOURCE_DIR}/rados.pyx)
-add_dependencies(cython_rados rados)
-distutils_install_cython_module(cython_rados)
+distutils_add_cython_module(cython${PYTHON_VERSION}_rados ${CMAKE_CURRENT_SOURCE_DIR}/rados.pyx)
+add_dependencies(cython${PYTHON_VERSION}_rados rados)
+distutils_install_cython_module(cython${PYTHON_VERSION}_rados)

--- a/src/pybind/rbd/CMakeLists.txt
+++ b/src/pybind/rbd/CMakeLists.txt
@@ -1,3 +1,3 @@
-distutils_add_cython_module(cython_rbd ${CMAKE_CURRENT_SOURCE_DIR}/rbd.pyx)
-add_dependencies(cython_rbd rbd)
-distutils_install_cython_module(cython_rbd)
+distutils_add_cython_module(cython${PYTHON_VERSION}_rbd ${CMAKE_CURRENT_SOURCE_DIR}/rbd.pyx)
+add_dependencies(cython${PYTHON_VERSION}_rbd rbd)
+distutils_install_cython_module(cython${PYTHON_VERSION}_rbd)


### PR DESCRIPTION
## cmake

#### FindPython3Interp and FindPython3Libs modules have been added
Multiple alternatives have been considered on how to include multiple versions of Python into the build process.

- The first thing that comes to mind is to reuse the standard module *FindPythonInterp* twice with different inputs, however CMake makes this very difficult because this module saves globally cached state and still gives its initial outputs even when ran with different arguments. An effort was made to clear specific cache variables in the middle of the build process to be able to reuse the module, and it seemed to mostly work, even if it was a mess, but in the end it was discovered that Ubuntu 14.04 ships an old version of CMake where *FindPythonLibs* simply does not acknowledge Python 3 yet, even by itself.

The two other alternatives that were dismissed, for hopefully obvious reasons:
- Drop *FindPythonXXX* modules and run hardcoded Python binaries
- Run the whole configure+build process twice with a different flag for the Python version

So, the final decision was to copy the latest versions of the official CMake modules *FindPythonInterp*, *FindPythonLibs* and replace every variable name inside them from `Python`, `PYTHON_` etc. to `Python3`, `PYTHON3_` etc. So even though these modules have global state, the state is now separate for Python 2 and 3.

#### Python bindings are built for Python 2 and 3
This is achieved by looping over two values of a global variable `${PYTHON_VERSION}` &ndash; `""` and `"3"`. *src/pybind/CMakeLists.txt* introduces this variable, calls `find_package(Python${PYTHON_VERSION}Interp ...` and includes the subdirectories, which use the *Distutils* module, which is now aware of this `PYTHON_VERSION` variable.

#### FindCython module has been dropped
The only effect this module did was to fail when a `cython` executable was not found. However, running Cython itself was done through `python setup.py` in a different module, which is a bit of an inconsistency and these two things succeeding are not necessarily correlated. The situation is made worse by the fact that now we need Cython specifically for Python 2 and separately for Python 3.

I acknowledge that there needs to be a way to fail if Cython is not present &ndash; during the configuration phase rather than during the build. Looking for feedback on alternatives. The simple way to do the check would be to run `${PYTHON_EXECUTABLE} -m cython`

#### Summary

This change makes the CMake-based build additionally produce files like *build/lib/cython_modules/lib.linux-x86_64-3.4/`{`rados,cephfs,rbd`}`.cpython-34m.so*

The weakest point of this change is about *FindCython* (discussed above). Other than that, it has been tested on Debian and produces working libraries for both Python versions.


## debian

This is quite straightforward, three new packages have been created: *python3-`{`rados,cephfs,rbd`}`* (based on existing ones). Because Python libraries are installed into a path like */usr/lib/python3.4/dist-packages/*, these *install* files utilize this like so: `usr/lib/python3*/dist-packages/rados.so`. Additionally, the file lists for Python 2 needed to be changed to include a *2* so they don't pick up files for both versions of Python.
The newly added packages get a line [`Depends: ${python3:Depends}`](https://wiki.debian.org/Python/LibraryStyleGuide#Python_versions)

Some build dependencies were added: [*python3-dev*](https://packages.debian.org/search?keywords=python3-dev), [*python3-setuptools*](https://packages.debian.org/search?keywords=python3-setuptools), [*cython3*](https://packages.debian.org/search?keywords=cython3).

This change has **not** been confirmed working, but to the best of my knowledge there should be no problems.


## rpm

Three new packages have been created: *python34-`{`rados,cephfs,rbd`}`* (based on existing ones). Well, the version *34* is not specified anywhere, but my understanding is that the `%{python3_pkgversion}` macro expands to *34* on CentOS and to *3* on Fedora. `%{python3_sitearch}` and `%{python3_sitelib}` were utilized. [*python3-numpy.spec*](http://pkgs.fedoraproject.org/cgit/rpms/python3-numpy.git/tree/python3-numpy.spec?h=epel7) served as an example of these techniques.

Added dependencies:

- RHEL/CentOS:
[*python34*](https://dl.fedoraproject.org/pub/epel/7/x86_64/p/python34-3.4.3-4.el7.x86_64.rpm)
    - build:
[*python34-devel*](https://dl.fedoraproject.org/pub/epel/7/x86_64/p/python34-devel-3.4.3-4.el7.x86_64.rpm), [*python34-setuptools*](https://dl.fedoraproject.org/pub/epel/7/x86_64/p/python34-setuptools-19.2-3.el7.noarch.rpm), [*python34-Cython*](https://dl.fedoraproject.org/pub/epel/7/x86_64/p/python34-Cython-0.23.5-1.el7.x86_64.rpm)
- Fedora:
[*python3*](https://admin.fedoraproject.org/pkgdb/package/rpms/python3/)
    - build:
[*python3-devel*](https://apps.fedoraproject.org/packages/python3-devel), [*python3-setuptools*](https://apps.fedoraproject.org/packages/python3-setuptools), [*python3-Cython*](https://apps.fedoraproject.org/packages/python3-Cython)
- OpenSUSE:
[*python3*](http://download.opensuse.org/tumbleweed/repo/oss/suse/x86_64/python3-3.5.1-3.4.x86_64.rpm)
    - build:
[*python3-devel*](http://download.opensuse.org/tumbleweed/repo/oss/suse/x86_64/python3-devel-3.5.1-3.3.x86_64.rpm), [*python3-setuptools*](http://download.opensuse.org/tumbleweed/repo/oss/suse/noarch/python3-setuptools-23.1.0-1.1.noarch.rpm), [*python3-cython*](http://download.opensuse.org/tumbleweed/repo/oss/suse/x86_64/python3-Cython-0.24-2.2.x86_64.rpm)

This change has **not** been tested at all.

The big problem with it is that on CentOS all mentioned Python3-related packages come from EPEL (not readily available to install by default). And they are mandatory for the build, so it may become generally more difficult to build packages.